### PR TITLE
Enforce button types

### DIFF
--- a/cardigan/package.json
+++ b/cardigan/package.json
@@ -4,7 +4,7 @@
   "description": "Wellcome Collection's design system",
   "main": "index.js",
   "scripts": {
-    "dev": "fractal start",
+    "dev": "fractal start --sync --watch",
     "build": "node ./build-cardigan.js"
   },
   "keywords": [],

--- a/catalogue/webapp/pages/catalogue/work.js
+++ b/catalogue/webapp/pages/catalogue/work.js
@@ -250,7 +250,7 @@ const WorkPage = ({work}: Props) => {
 
               <div className={spacing({s: 2}, {margin: ['bottom']})}>
                 <Button
-                  extraClasses='btn--tertiary'
+                  type='tertiary'
                   url={convertImageUri(work.items[0].locations[0].url, 'full')}
                   target='_blank'
                   download={`${work.id}.jpg`}
@@ -266,7 +266,7 @@ const WorkPage = ({work}: Props) => {
 
               <div className={spacing({s: 3}, {margin: ['bottom']})}>
                 <Button
-                  extraClasses='btn--tertiary'
+                  type='tertiary'
                   url={convertImageUri(work.items[0].locations[0].url, 760)}
                   target='_blank'
                   download={`${work.id}.jpg`}

--- a/common/views/components/Buttons/Button/Button.config.js
+++ b/common/views/components/Buttons/Button/Button.config.js
@@ -6,7 +6,7 @@ export const variants = [
     name: 'default',
     label: 'primary (button)',
     context: {
-      extraClasses: 'btn--primary',
+      type: 'primary',
       icon: 'email',
       text: 'Email to book'
     }
@@ -15,7 +15,7 @@ export const variants = [
     name: 'secondary',
     label: 'secondary (button)',
     context: {
-      extraClasses: 'btn--secondary',
+      type: 'secondary',
       text: 'Cancel'
     }
   },
@@ -24,7 +24,7 @@ export const variants = [
     label: 'tertiary (button)',
     context: {
       icon: 'download',
-      extraClasses: 'btn--tertiary',
+      type: 'tertiary',
       text: 'Download full size'
     }
   },
@@ -33,7 +33,7 @@ export const variants = [
     label: 'primary (link)',
     context: {
       url: '#',
-      extraClasses: 'btn--primary',
+      type: 'primary',
       icon: 'email',
       text: 'Email to book'
     }
@@ -43,7 +43,7 @@ export const variants = [
     label: 'secondary (link)',
     context: {
       url: '#',
-      extraClasses: 'btn--secondary',
+      type: 'secondary',
       text: 'Cancel'
     }
   },
@@ -53,7 +53,7 @@ export const variants = [
     context: {
       url: '#',
       icon: 'download',
-      extraClasses: 'btn--tertiary',
+      type: 'tertiary',
       text: 'Download full size'
     }
   },
@@ -61,7 +61,7 @@ export const variants = [
     name: 'disabled',
     label: 'disabled',
     context: {
-      extraClasses: 'btn--primary',
+      type: 'primary',
       disabled: true,
       icon: 'download',
       text: 'Email to book'

--- a/common/views/components/Buttons/Button/Button.js
+++ b/common/views/components/Buttons/Button/Button.js
@@ -5,6 +5,7 @@ import Icon from '../../Icon/Icon';
 
 type Props = {|
   url?: string,
+  type: 'primary' | 'secondary' | 'tertiary',
   extraClasses?: string,
   icon?: string,
   text: string,
@@ -19,6 +20,7 @@ type Props = {|
 
 const Button = ({
   url,
+  type,
   id,
   extraClasses,
   icon,
@@ -41,7 +43,7 @@ const Button = ({
       download={download}
       rel={rel}
       id={id}
-      className={`btn ${extraClasses || ''} ${font(fontClasses)} flex-inline flex--v-center`}
+      className={`btn btn--${type} ${extraClasses || ''} ${font(fontClasses)} flex-inline flex--v-center`}
       data-track-event={eventTracking}
       onClick={clickHandler}
       disabled={disabled}>

--- a/common/views/components/Buttons/Control/Control.config.js
+++ b/common/views/components/Buttons/Control/Control.config.js
@@ -7,7 +7,7 @@ export const variants = [
     label: 'light (button)',
     context: {
       icon: 'download',
-      extraClasses: 'control--light',
+      type: 'light',
       text: 'download'
     }
   },
@@ -16,7 +16,7 @@ export const variants = [
     label: 'dark (button)',
     context: {
       icon: 'download',
-      extraClasses: 'control--dark',
+      type: 'dark',
       text: 'download'
     }
   },
@@ -26,7 +26,7 @@ export const variants = [
     context: {
       url: '#',
       icon: 'download',
-      extraClasses: 'control--light',
+      type: 'light',
       text: 'download'
     }
   },
@@ -36,7 +36,7 @@ export const variants = [
     context: {
       url: '#',
       icon: 'download',
-      extraClasses: 'control--dark',
+      type: 'dark',
       text: 'download'
     }
   }

--- a/common/views/components/Buttons/Control/Control.js
+++ b/common/views/components/Buttons/Control/Control.js
@@ -5,6 +5,7 @@ import Icon from '../../Icon/Icon';
 type Props = {|
   url?: string,
   id?: string,
+  type: 'light' | 'dark',
   extraClasses?: string,
   icon: string,
   text: string,
@@ -16,6 +17,7 @@ type Props = {|
 const Control = ({
   url,
   id,
+  type,
   extraClasses,
   icon,
   text,
@@ -28,7 +30,7 @@ const Control = ({
     <HtmlTag
       id={id}
       href={url}
-      className={`control ${extraClasses || ''}`}
+      className={`control control--${type} ${extraClasses || ''}`}
       data-track-event={eventTracking}
       disabled={disabled}
       onClick={clickHandler}>

--- a/common/views/components/EventBookingButton/EventBookingButton.js
+++ b/common/views/components/EventBookingButton/EventBookingButton.js
@@ -15,7 +15,7 @@ function getButtonMarkup(event) {
   if (event.isCompletelySoldOut) {
     return (
       <Button
-        extraClasses='btn--primary'
+        type='primary'
         text='Fully booked'
         icon='ticketAvailable' />
     );
@@ -23,7 +23,7 @@ function getButtonMarkup(event) {
     return (
       <div className='js-eventbrite-ticket-button' data-eventbrite-ticket-id={event.eventbriteId}>
         <Button
-          extraClasses='btn--primary'
+          type='primary'
           url={`https://www.eventbrite.com/e/${event.eventbriteId || ''}/`}
           icon='ticketAvailable'
           text='Book free tickets' />
@@ -39,7 +39,7 @@ function getBookingEnquiryMarkup(event) {
     return (
       <Fragment>
         <Button
-          extraClasses='btn--primary'
+          type='primary'
           disabled={true}
           text='Fully booked' />
       </Fragment>
@@ -47,7 +47,7 @@ function getBookingEnquiryMarkup(event) {
   } else {
     return (
       <Button
-        extraClasses='btn--primary'
+        type='primary'
         url={`mailto:${event.bookingEnquiryTeam.email}?subject=${event.title}`}
         icon='email'
         text='Email to book' />

--- a/common/views/components/ImageViewer/ImageViewer.js
+++ b/common/views/components/ImageViewer/ImageViewer.js
@@ -17,9 +17,10 @@ type Props = {|
 const ImageViewer = ({id, trackTitle, imageUrl}: Props) => (
   <div className='js-image-viewer image-viewer'>
     <Control
+      type='dark'
       text='View larger image'
       icon='zoomIn'
-      extraClasses={`control--dark image-viewer__launch-button js-image-viewer__launch-button`}
+      extraClasses={`image-viewer__launch-button js-image-viewer__launch-button`}
       eventTracking={`{${commonBtnTracking(id, trackTitle)}, "action": "work-launch-image-viewer:btnClick"}`} />
 
     <div
@@ -29,21 +30,24 @@ const ImageViewer = ({id, trackTitle, imageUrl}: Props) => (
 
       <div className='image-viewer__controls flex flex-end flex--v-center'>
         <Control
+          type='light'
           text='Zoom in'
           id={`zoom-in-${id}`}
           icon='zoomIn'
-          extraClasses={`control--light ${spacing({s: 1}, {margin: ['right']})}`}
+          extraClasses={`${spacing({s: 1}, {margin: ['right']})}`}
           eventTracking={`{${commonBtnTracking(id, trackTitle)}, "action": "work-zoom-in-button:click"}`} />
         <Control
+          type='light'
           text='Zoom out'
           id={`zoom-out-${id}`}
           icon='zoomOut'
-          extraClasses={`control--light ${spacing({s: 8}, {margin: ['right']})}`}
+          extraClasses={`${spacing({s: 8}, {margin: ['right']})}`}
           eventTracking={`{${commonBtnTracking(id, trackTitle)}, "action": "work-zoom-out-button:click"}`} />
         <Control
+          type='light'
           text='Close image viewer'
           icon='cross'
-          extraClasses={`control--light js-image-viewer__exit-button ${spacing({s: 2}, {margin: ['right']})}`}
+          extraClasses={`js-image-viewer__exit-button ${spacing({s: 2}, {margin: ['right']})}`}
           eventTracking={`{${commonBtnTracking(id, trackTitle)}, "action": "work-exit-image-viewer:btnClick"}`} />
       </div>
 

--- a/common/views/components/ImageViewer/ImageViewer2.js
+++ b/common/views/components/ImageViewer/ImageViewer2.js
@@ -22,9 +22,10 @@ class LaunchViewerButton extends React.Component<LaunchViewerButtonProps> {
   render() {
     return (
       <Control
+        type='dark'
         text='View larger image'
         icon='zoomIn'
-        extraClasses={`control--dark image-viewer__launch-button ${this.props.classes}`}
+        extraClasses={`image-viewer__launch-button ${this.props.classes}`}
         clickHandler={this.props.clickHandler} />
     );
   }
@@ -82,23 +83,26 @@ class ViewerContent extends React.Component<ViewerContentProps> {
       <div className={`${this.props.classes} image-viewer__content image-viewer__content2`}>
         <div className='image-viewer__controls flex flex-end flex--v-center'>
           <Control
+            type='light'
             text='Zoom in'
             id={`zoom-in-${this.props.id}`}
             icon='zoomIn'
-            extraClasses={`control--light ${spacing({s: 1}, {margin: ['right']})}`}
+            extraClasses={`${spacing({s: 1}, {margin: ['right']})}`}
             clickHandler={this.handleZoomIn} />
 
           <Control
+            type='light'
             text='Zoom out'
             id={`zoom-out-${this.props.id}`}
             icon='zoomOut'
-            extraClasses={`control--light ${spacing({s: 8}, {margin: ['right']})}`}
+            extraClasses={`{spacing({s: 8}, {margin: ['right']})}`}
             clickHandler={this.handleZoomOut} />
 
           <Control
+            type='light'
             text='Close image viewer'
             icon='cross'
-            extraClasses={`control--light ${spacing({s: 2}, {margin: ['right']})}`}
+            extraClasses={`${spacing({s: 2}, {margin: ['right']})}`}
             clickHandler={this.props.handleViewerDisplay} />
         </div>
 

--- a/common/views/components/PageHeaders/Hero/Hero.js
+++ b/common/views/components/PageHeaders/Hero/Hero.js
@@ -28,7 +28,8 @@ const Hero = ({ images, whiteBox }: Props) => (
       </div>
       <div className={`relative ${spacing({s: 3}, { margin: ['bottom'] })}`} style={{ zIndex: 20 }}>
         <Control
-          extraClasses='scroll-to-info js-scroll-to-info js-work-media-control flush-container-right control--dark'
+          type='dark'
+          extraClasses='scroll-to-info js-scroll-to-info js-work-media-control flush-container-right'
           url='#exhibition-content'
           eventTracking='{"category": "component", "action": "scroll-to-info:click", "label": "scrolled-to-id:exhibition-content"}`}'
           icon='chevron'

--- a/common/views/components/Pagination/Pagination.js
+++ b/common/views/components/Pagination/Pagination.js
@@ -19,8 +19,9 @@ const Pagination = ({prevPage, currentPage, pageCount, nextPage, nextQueryString
     {prevPage && prevQueryString &&
       <NextLink href={prevQueryString}>
         <Control
+          type='light'
           url={prevQueryString}
-          extraClasses={`icon--180 control--light ${spacing({s: 2}, {margin: ['right']})}`}
+          extraClasses={`icon--180 ${spacing({s: 2}, {margin: ['right']})}`}
           icon='arrow'
           text={`Previous (page ${prevPage})`} />
       </NextLink>
@@ -31,8 +32,9 @@ const Pagination = ({prevPage, currentPage, pageCount, nextPage, nextQueryString
     {nextPage && nextQueryString &&
       <NextLink href={nextQueryString}>
         <Control
+          type='light'
           url={nextQueryString}
-          extraClasses={`control--light ${spacing({s: 2}, {margin: ['left']})}`}
+          extraClasses={`${spacing({s: 2}, {margin: ['left']})}`}
           icon='arrow'
           text={`Next (page ${nextPage})`} />
       </NextLink>

--- a/common/views/components/WorkMedia/WorkMedia.js
+++ b/common/views/components/WorkMedia/WorkMedia.js
@@ -53,7 +53,8 @@ const WorkMedia = ({
       }
       <div id={`work-media-${id}`} className='row bg-black work-media js-work-media'>
         <Control
-          extraClasses='scroll-to-info js-scroll-to-info js-work-media-control flush-container-right control--dark'
+          type='dark'
+          extraClasses='scroll-to-info js-scroll-to-info js-work-media-control flush-container-right'
           url='#work-info'
           eventTracking='{"category": "component", "action": "scroll-to-info:click", "label": "scrolled-to-id:work-info"}`}'
           icon='chevron'

--- a/common/views/components/WorkMedia/WorkMedia2.js
+++ b/common/views/components/WorkMedia/WorkMedia2.js
@@ -52,7 +52,8 @@ const WorkMedia = ({
       }
       <div id={`work-media-${id}`} className='row bg-black work-media js-work-media'>
         <Control
-          extraClasses='scroll-to-info js-scroll-to-info js-work-media-control flush-container-right control--dark'
+          type='dark'
+          extraClasses='scroll-to-info js-scroll-to-info js-work-media-control flush-container-right'
           url='#work-info'
           eventTracking='{"category": "component", "action": "scroll-to-info:click", "label": "scrolled-to-id:work-info"}`}'
           icon='chevron'

--- a/events/app/views/partials/event_without_schedule.njk
+++ b/events/app/views/partials/event_without_schedule.njk
@@ -108,11 +108,11 @@
           {% if event.eventbriteId %}
             <div class="border-top-width-1 border-color-pumice {{ {s: 2} | spacingClasses({padding: ['top', 'bottom']}) }}">
               {% if event.isCompletelySoldOut %}
-                {% componentJsx 'Button', {extraClasses: 'btn--primary', disabled: true, text: 'Fully booked'} %}
+                {% componentJsx 'Button', {type: 'primary', disabled: true, text: 'Fully booked'} %}
               {% else %}
                 <div class="js-eventbrite-ticket-button" data-eventbrite-ticket-id="{{ event.eventbriteId }}">
                   {% componentJsx 'Button', {
-                    extraClasses: 'btn--primary',
+                    type: 'primary',
                     url: 'https://www.eventbrite.com/e/' + event.eventbriteId + '/',
                     eventTracking: "{category: 'component', action: 'booking-tickets:click', label: 'event-page'}",
                     text: 'Book free tickets',
@@ -133,10 +133,10 @@
           {% if event.bookingEnquiryTeam %}
             <div class="border-top-width-1 border-color-pumice {{ {s: 2} | spacingClasses({padding: ['top', 'bottom']}) }}">
               {% if event.isCompletelySoldOut %}
-                {% componentJsx 'Button', {extraClasses: 'btn--primary', disabled: true, text: 'Fully booked'} %}
+                {% componentJsx 'Button', {type: 'primary', disabled: true, text: 'Fully booked'} %}
               {% else %}
                 {% componentJsx 'Button', {
-                    extraClasses: 'btn--primary',
+                    type: 'primary',
                     url: 'mailto:' + event.bookingEnquiryTeam.email + '?subject=' + event.title,
                     eventTracking: "{category: 'component', action: 'booking-tickets:click', label: 'event-page'}",
                     text: 'Email to book',

--- a/server/views/pages/search.njk
+++ b/server/views/pages/search.njk
@@ -205,8 +205,9 @@
       </div>
     </div>
     {% componentJsx 'Control', {
+      type: 'dark',
       url: '#top',
-      extraClasses: 'icon--180 control--dark js-back-to-top back-to-top',
+      extraClasses: 'icon--180 js-back-to-top back-to-top',
       icon: 'chevron',
       text: 'Back to top',
       eventTracking: '{"category": "component", "action": "back-to-top:click", "label": "url:' + pageConfig.canonicalUri + '"}'

--- a/server/views/pages/work.njk
+++ b/server/views/pages/work.njk
@@ -76,7 +76,7 @@
 
           <div class="{{ {s:1} | spacingClasses({margin: ['bottom']}) }}">
             {% componentJsx 'Button', {
-              extraClasses: 'btn--tertiary',
+              type: 'tertiary',
               url: work.imgLink | convertImageUri('full', false),
               download: work.id + '.jpg',
               rel: 'noopener noreferrer',
@@ -89,7 +89,7 @@
 
           <div class="{{ {s:4} | spacingClasses({margin: ['bottom']}) }}">
             {% componentJsx 'Button', {
-              extraClasses: 'btn--tertiary',
+              type: 'tertiary',
               url: work.imgLink | convertImageUri(760, false),
               download: work.id + '.jpg',
               rel: 'noopener noreferrer',
@@ -123,8 +123,9 @@
   </div>
 
   {% componentJsx 'Control', {
+    type: 'dark',
     url: '#top',
-    extraClasses: 'icon--180 control--dark js-back-to-top back-to-top',
+    extraClasses: 'icon--180 js-back-to-top back-to-top',
     icon: 'chevron',
     text: 'Back to top',
     eventTracking: '{"category": "component", "action": "back-to-top:click", "label": "url:' + pageConfig.canonicalUri + '"}'


### PR DESCRIPTION
Using an enum string prop, enforces the type of button ('primary' | 'secondary' | 'tertiary') or control ('light' | 'dark'), rather than relying on the `extraClasses` prop.