### PR TITLE
allow _queryType cookie through the cache

### DIFF
--- a/cache/cloudfront_dev.tf
+++ b/cache/cloudfront_dev.tf
@@ -46,8 +46,8 @@ resource "aws_cloudfront_distribution" "devcache_wellcomecollection_org" {
         forward = "whitelist"
 
         whitelisted_names = [
-          "toggles",          # feature toggles
-          "toggle_*",         # feature toggles
+          "toggles",  # feature toggles
+          "toggle_*", # feature toggles
           "WC_auth_redirect",
         ]
       }
@@ -95,6 +95,7 @@ resource "aws_cloudfront_distribution" "devcache_wellcomecollection_org" {
         whitelisted_names = [
           "toggles",  # feature toggles
           "toggle_*", # feature toggles
+          "_queryType"
         ]
       }
     }

--- a/cache/cloudfront_prod.tf
+++ b/cache/cloudfront_prod.tf
@@ -124,9 +124,10 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
         forward = "whitelist"
 
         whitelisted_names = [
-          "toggles",          # feature toggles
-          "toggle_*",         # feature toggles
+          "toggles",  # feature toggles
+          "toggle_*", # feature toggles
           "WC_auth_redirect",
+          "_queryType"
         ]
       }
     }


### PR DESCRIPTION
Allows the `_queryType` cookie that we are using for testing query types on the API.

It's not been a problem as we haven't allowed people to select this manually, but we want to do that, and this stops that as the set-cookie header gets cached and sent down the pipes