### PR TITLE
use qualified_arn for edge cache lambdas

### DIFF
--- a/cache/cloudfront_prod.tf
+++ b/cache/cloudfront_prod.tf
@@ -82,12 +82,12 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
 
     lambda_function_association {
       event_type = "origin-request"
-      lambda_arn = data.aws_lambda_function.versioned_edge_lambda_request.arn
+      lambda_arn = data.aws_lambda_function.versioned_edge_lambda_request.qualified_arn
     }
 
     lambda_function_association {
       event_type = "origin-response"
-      lambda_arn = data.aws_lambda_function.versioned_edge_lambda_response.arn
+      lambda_arn = data.aws_lambda_function.versioned_edge_lambda_response.qualified_arn
     }
   }
 
@@ -131,12 +131,12 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
 
     lambda_function_association {
       event_type = "origin-request"
-      lambda_arn = data.aws_lambda_function.versioned_edge_lambda_request.arn
+      lambda_arn = data.aws_lambda_function.versioned_edge_lambda_request.qualified_arn
     }
 
     lambda_function_association {
       event_type = "origin-response"
-      lambda_arn = data.aws_lambda_function.versioned_edge_lambda_response.arn
+      lambda_arn = data.aws_lambda_function.versioned_edge_lambda_response.qualified_arn
     }
   }
 


### PR DESCRIPTION
## Who is this for?
People trying to deploy the cache

## What is it doing for them?
Uses the `qualified_arn`s for the lambdas. [The docs specify here that the arn is unqualified](https://www.terraform.io/docs/providers/aws/d/lambda_function.html#arn).

I am trying to figure out if this changed on moving to 0.12, but can't find evidence of that.

🤷‍♂ 🦐 
