### PR TITLE
Allow alert banner to be targeted based on page-path

### DIFF
--- a/common/model/global-alert.js
+++ b/common/model/global-alert.js
@@ -2,4 +2,5 @@
 export type GlobalAlert = {|
   text: string,
   isShown: boolean,
+  routeRegex: ?string,
 |};

--- a/common/services/prismic/global-alert.js
+++ b/common/services/prismic/global-alert.js
@@ -9,5 +9,6 @@ export async function fetchGlobalAlert(): GlobalAlert {
   return {
     text: globalAlert.data.text && asHtml(globalAlert.data.text),
     isShown: globalAlert.data.isShown && globalAlert.data.isShown === 'show',
+    routeRegex: globalAlert.data.routeRegex,
   };
 }

--- a/common/views/components/PageLayout/PageLayout.js
+++ b/common/views/components/PageLayout/PageLayout.js
@@ -125,7 +125,9 @@ const PageLayout = ({
         <Header siteSection={siteSection} />
         <GlobalAlertContext.Consumer>
           {globalAlert =>
-            globalAlert.isShown === 'show' && (
+            globalAlert.isShown === 'show' &&
+            (!globalAlert.routeRegex ||
+              urlString.match(new RegExp(globalAlert.routeRegex))) && (
               <InfoBanner text={globalAlert.text} cookieName="WC_globalAlert" />
             )
           }


### PR DESCRIPTION
Closes #5157 

## Who is this for?
Content team

## What is it doing for them?
Allowing them to decide which pages the alert banner should display on.

Because `/visit-us` is a vanity URL, this method requires knowing that the _actual_ url is `/pages/WwLIBiAAAPMiB_zC`. Not sure if this is a problem we need to solve.
