### PR TITLE
resize all prismic images, so we aren't loading huge images when we don't need to

### DIFF
--- a/common/utils/convert-image-uri.js
+++ b/common/utils/convert-image-uri.js
@@ -1,7 +1,7 @@
 // @flow
 import urlTemplate from 'url-template';
 
-const prismicBaseUri = 'https://images.prismic.io/wellcomecollection/';
+const prismicBaseUri = 'https://images.prismic.io/wellcomecollection';
 const iiifBaseUri = 'https://iiif.wellcomecollection.org/image/';
 
 function determineSrc(url: string): string {


### PR DESCRIPTION
The code we use to determine the image src, so we can then provide various sized images in the src-set, wasn't always working for images from prismic.

Sometimes  we were receiving urls with the backslash encoded, which meant we didn't resize the images.
