### PR TITLE
check we have an interpretation icon before trying to render it

### DIFF
--- a/content/webapp/pages/event.js
+++ b/content/webapp/pages/event.js
@@ -43,6 +43,15 @@ type State = {|
   scheduledIn: ?UiEvent,
 |};
 
+function haveIcon(iconName) {
+  return [
+    'britishSignLanguage',
+    'speechToText',
+    'hearingLoop',
+    'audioDescribed',
+  ].includes(iconName);
+}
+
 // TODO: Probably use the StatusIndicator?
 function EventStatus(text, color) {
   return (
@@ -484,14 +493,18 @@ class EventPage extends Component<Props, State> {
                   .concat(event.policies.map(policy => ({ ...policy })))
                   .concat(
                     event.interpretations.map(
-                      ({ interpretationType, isPrimary }) => ({
-                        id: null,
-                        icon: camelize(interpretationType.title),
-                        title: interpretationType.title,
-                        description: isPrimary
-                          ? interpretationType.primaryDescription
-                          : interpretationType.description,
-                      })
+                      ({ interpretationType, isPrimary }) => {
+                        const iconName = camelize(interpretationType.title);
+                        const useIcon = haveIcon(iconName);
+                        return {
+                          id: null,
+                          icon: useIcon ? iconName : null,
+                          title: interpretationType.title,
+                          description: isPrimary
+                            ? interpretationType.primaryDescription
+                            : interpretationType.description,
+                        };
+                      }
                     )
                   )
                   .filter(Boolean)}

--- a/content/webapp/pages/event.js
+++ b/content/webapp/pages/event.js
@@ -43,15 +43,6 @@ type State = {|
   scheduledIn: ?UiEvent,
 |};
 
-function haveIcon(iconName) {
-  return [
-    'britishSignLanguage',
-    'speechToText',
-    'hearingLoop',
-    'audioDescribed',
-  ].includes(iconName);
-}
-
 // TODO: Probably use the StatusIndicator?
 function EventStatus(text, color) {
   return (
@@ -495,10 +486,16 @@ class EventPage extends Component<Props, State> {
                     event.interpretations.map(
                       ({ interpretationType, isPrimary }) => {
                         const iconName = camelize(interpretationType.title);
-                        const useIcon = haveIcon(iconName);
                         return {
                           id: null,
-                          icon: useIcon ? iconName : null,
+                          icon: [
+                            'britishSignLanguage',
+                            'speechToText',
+                            'hearingLoop',
+                            'audioDescribed',
+                          ].includes(iconName)
+                            ? iconName
+                            : null,
                           title: interpretationType.title,
                           description: isPrimary
                             ? interpretationType.primaryDescription


### PR DESCRIPTION
If an interpretation type is added to an event, and we don't have an icon for it, then the page breaks. This adds a check that the interpretation type is one of the ones we have an icon for before trying to render it.
