### PR TITLE
Remove unused aliases

### DIFF
--- a/cache/cloudfront_prod.tf
+++ b/cache/cloudfront_prod.tf
@@ -42,11 +42,9 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
   is_ipv6_enabled = true
 
   aliases = [
+    "wellcomecollection.org",
     "blog.wellcomecollection.org",
     "content.wellcomecollection.org",
-    "next.wellcomecollection.org",
-    "wellcomecollection.org",
-    "whats-on.wellcomecollection.org",
     "works.wellcomecollection.org",
   ]
 


### PR DESCRIPTION
## Who is this for?

Developers who want a clear CloudFront config

## What is it doing for them?

Removing unused aliases (`next.` and `whats-on.` are no longer referred to by the apps or on the internet).