### PR TITLE
add isPreview cookie in preview middleware

### DIFF
--- a/common/koa-middleware/withCachedValues.js
+++ b/common/koa-middleware/withCachedValues.js
@@ -14,7 +14,7 @@ const withCachedValues = compose([
 
 async function route(path, page, router, app, extraParams = {}) {
   router.get(path, async ctx => {
-    const { toggles, globalAlert, openingTimes, isPreview } = ctx;
+    const { toggles, globalAlert, openingTimes } = ctx;
     const params = ctx.params;
     const query = ctx.query;
 
@@ -22,7 +22,6 @@ async function route(path, page, router, app, extraParams = {}) {
       toggles,
       globalAlert,
       openingTimes,
-      isPreview,
       ...params,
       ...query,
       ...extraParams,
@@ -34,14 +33,13 @@ async function route(path, page, router, app, extraParams = {}) {
 function handleAllRoute(handle) {
   return async function(ctx, extraCtxParams = {}) {
     const parsedUrl = parse(ctx.request.url, true);
-    const { toggles, globalAlert, openingTimes, isPreview } = ctx;
+    const { toggles, globalAlert, openingTimes } = ctx;
     const query = {
       ...parsedUrl.query,
       ...extraCtxParams,
       toggles,
       globalAlert,
       openingTimes,
-      isPreview,
     };
     const url = {
       ...parsedUrl,

--- a/common/koa-middleware/withPrismicPreviewStatus.js
+++ b/common/koa-middleware/withPrismicPreviewStatus.js
@@ -2,7 +2,19 @@ function withPrismicPreviewStatus(ctx, next) {
   // for previews on localhost we use /preview to determine whether the 'isPreview' cookie should be set
   // this kinda works for live too, but not for shared preview links, as they never hit /preview
   // we therefore look for the subdomain .preview to determine if it's a preview
-  ctx.isPreview = Boolean(ctx.request.host.startsWith('preview.'));
+  const previewCookieName = 'isPreview';
+  const isPreviewDomain = Boolean(ctx.request.host.startsWith('preview.'));
+  const previewCookieMatch = ctx.headers.cookie
+    ? ctx.headers.cookie.match(`(^|;) ?${previewCookieName}=([^;]*)(;|$)`)
+    : null;
+
+  const previewCookie = previewCookieMatch ? previewCookieMatch[2] : null;
+
+  if (isPreviewDomain && !previewCookie) {
+    ctx.cookies.set('isPreview', 'true', {
+      httpOnly: false,
+    });
+  }
   return next();
 }
 

--- a/common/views/components/PageLayout/PageLayout.js
+++ b/common/views/components/PageLayout/PageLayout.js
@@ -55,7 +55,6 @@ const PageLayout = ({
       : 'Wellcome Collection | The free museum and library for the incurably curious';
 
   const absoluteUrl = `https://wellcomecollection.org${urlString}`;
-  const isPreview = false;
   return (
     <Fragment>
       <Head>
@@ -119,7 +118,7 @@ const PageLayout = ({
         )}
       </Head>
 
-      <div className={isPreview ? 'is-preview' : undefined}>
+      <div>
         <CookieNotice />
         <a className="skip-link" href="#main">
           Skip to main content

--- a/common/views/pages/_app.js
+++ b/common/views/pages/_app.js
@@ -33,7 +33,6 @@ const isClient = !isServer;
 let toggles;
 let openingTimes;
 let globalAlert;
-let isPreview;
 let engagement;
 let previouslyAccruedTimeOnSpaPage = 0;
 let accruedHiddenTimeOnPage = 0;
@@ -143,12 +142,10 @@ export default class WecoApp extends App {
     toggles = isServer ? router.query.toggles : toggles;
     openingTimes = isServer ? router.query.openingTimes : openingTimes;
     globalAlert = isServer ? router.query.globalAlert : globalAlert;
-    isPreview = isServer ? router.query.isPreview : isPreview;
 
     let pageProps = {};
     if (Component.getInitialProps) {
       ctx.query.toggles = toggles;
-      ctx.query.isPreview = isPreview;
 
       // If the getInitialProps fails, we should propegate this failure through to the repsonse.
       try {
@@ -170,7 +167,6 @@ export default class WecoApp extends App {
       toggles,
       openingTimes,
       globalAlert,
-      isPreview,
     };
   }
 
@@ -184,9 +180,6 @@ export default class WecoApp extends App {
     }
     if (isClient && !globalAlert) {
       globalAlert = props.globalAlert;
-    }
-    if (isClient && !isPreview) {
-      isPreview = props.isPreview;
     }
 
     super(props);
@@ -278,7 +271,7 @@ export default class WecoApp extends App {
       .catch(console.log);
 
     // Prismic preview and validation warnings
-    if (isPreview || document.cookie.match('isPreview=true')) {
+    if (document.cookie.match('isPreview=true')) {
       window.prismic = {
         endpoint: 'https://wellcomecollection.prismic.io/api/v2',
       };


### PR DESCRIPTION
We are using the hijack of the isPreview query parameter to read the value, but setting it directly on the ctx.

This just sets the isPreview cookie giving us 1 way to do this, just in multiple places.

Trying to think of a E2E test, but nothing comes immediately. 