### PR TITLE
bump nginx container version to include Host headers

### DIFF
--- a/catalogue/terraform/locals.tf
+++ b/catalogue/terraform/locals.tf
@@ -18,5 +18,5 @@ locals {
   stage_service_egress_security_group_id = data.terraform_remote_state.experience_shared.outputs.stage_service_egress_security_group_id
 
   // Latest is available at data.aws_ssm_parameter.nginx_image_uri.value - test in staging before deployment
-  nginx_image = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx_experience:d0d9a9c7ab728e9c4fc6222ce0127208e1ff4c96"
+  nginx_image = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx_experience:78090f62ee23a39a1b4e929f25417bfa128c2aa8"
 }

--- a/content/terraform/locals.tf
+++ b/content/terraform/locals.tf
@@ -18,5 +18,5 @@ locals {
   stage_service_egress_security_group_id = data.terraform_remote_state.experience_shared.outputs.stage_service_egress_security_group_id
 
   // Latest is available at data.aws_ssm_parameter.nginx_image_uri.value - test in staging before deployment
-  nginx_image = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx_experience:d0d9a9c7ab728e9c4fc6222ce0127208e1ff4c96"
+  nginx_image = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx_experience:78090f62ee23a39a1b4e929f25417bfa128c2aa8"
 }


### PR DESCRIPTION
Bumps the [new nginx container](https://github.com/wellcomecollection/platform/pull/4383) that passes the host header across for preview to work.