### PR TITLE
Add prompts for creating stage deployments

### DIFF
--- a/catalogue/terraform/main.tf
+++ b/catalogue/terraform/main.tf
@@ -16,3 +16,29 @@ module "catalogue-prod" {
 
   subdomain = "works.www"
 }
+
+// Uncomment to create a staging environment
+// You can replace var.container_tag & local.nginx_image
+// to test differing images.
+//
+// The service should be available at:
+// "works.www-stage.wellcomecollection.org/works"
+//
+//module "catalogue-stage" {
+//  source = "./stack"
+//
+//  container_image = "wellcome/catalogue_webapp:${var.container_tag}"
+//  nginx_image     = local.nginx_image
+//  env_suffix      = "stage"
+//
+//  cluster_arn  = local.stage_cluster_arn
+//  namespace_id = local.stage_namespace_id
+//
+//  alb_listener_http_arn  = local.stage_alb_listener_http_arn
+//  alb_listener_https_arn = local.stage_alb_listener_https_arn
+//
+//  interservice_security_group_id   = local.stage_interservice_security_group_id
+//  service_egress_security_group_id = local.stage_service_egress_security_group_id
+//
+//  subdomain = "works.www-stage"
+//}

--- a/content/terraform/main.tf
+++ b/content/terraform/main.tf
@@ -16,3 +16,29 @@ module "content-prod" {
 
   subdomain = "content.www"
 }
+
+// Uncomment to create a staging environment
+// You can replace var.container_tag & local.nginx_image
+// to test differing images.
+//
+// The service should be available at:
+// "content.www-stage.wellcomecollection.org/works"
+//
+//module "content-stage" {
+//  source = "./stack"
+//
+//  container_image = "wellcome/content_webapp:${var.container_tag}"
+//  nginx_image     = local.nginx_image
+//  env_suffix      = "stage"
+//
+//  cluster_arn  = local.stage_cluster_arn
+//  namespace_id = local.stage_namespace_id
+//
+//  alb_listener_http_arn  = local.stage_alb_listener_http_arn
+//  alb_listener_https_arn = local.stage_alb_listener_https_arn
+//
+//  interservice_security_group_id   = local.stage_interservice_security_group_id
+//  service_egress_security_group_id = local.stage_service_egress_security_group_id
+//
+//  subdomain = "content.www-stage"
+//}


### PR DESCRIPTION
## Who is this for?

Developers who want to use the staging environment.

## What is it doing for them?

Providing a clear template for creating staging apps for content and catalogue services.