### PR TITLE
Check that token is defined before adding it to localStorage

### DIFF
--- a/common/hooks/useAuth.js
+++ b/common/hooks/useAuth.js
@@ -9,8 +9,8 @@ import base64url from 'base64url';
 const authDomain = 'https://id.wellcomecollection.org';
 const authParams = {
   response_type: 'code',
-  client_id: '5n4vt54rjsg6t691c5b5kiacdv', // l
-  // client_id: '4sl9v9v3i72fs66i0kpgqent8b', // p
+  // client_id: '5n4vt54rjsg6t691c5b5kiacdv', // localhost
+  client_id: '4sl9v9v3i72fs66i0kpgqent8b', // production
   scope: ['openid'].join(' '),
 };
 
@@ -158,8 +158,10 @@ const useAuth = () => {
       };
       Router.replace(link, link, { shallow: true });
     } else {
-      console.error('getToken returned undefined. Failed to authorise.');
-      // TODO: something else? Try again?
+      const { verifier, loginUrl } = createLoginUrlWithVerifier();
+      window.localStorage.setItem('auth.verifier', verifier);
+      setState(({ type: authStates.unauthorized, loginUrl }: Unauthorized));
+      // TODO: let the user know something failed?
     }
   }
 

--- a/common/hooks/useAuth.js
+++ b/common/hooks/useAuth.js
@@ -9,8 +9,8 @@ import base64url from 'base64url';
 const authDomain = 'https://id.wellcomecollection.org';
 const authParams = {
   response_type: 'code',
-  // client_id: '5n4vt54rjsg6t691c5b5kiacdv', // l
-  client_id: '4sl9v9v3i72fs66i0kpgqent8b', // p
+  client_id: '5n4vt54rjsg6t691c5b5kiacdv', // l
+  // client_id: '4sl9v9v3i72fs66i0kpgqent8b', // p
   scope: ['openid'].join(' '),
 };
 
@@ -145,17 +145,22 @@ const useAuth = () => {
     const verifier = window.localStorage.getItem('auth.verifier');
     const token = await getToken(code, verifier);
 
-    window.localStorage.setItem('auth.token', JSON.stringify(token));
-    setState({ type: authStates.authorized, token });
-    const link = {
-      pathname: Router.asPath.split('?')[0],
-      // TODO: This is very app specific, but it's an absolute pain to try and get this to work
-      // The side effect is that it removes the rest of the URL params if there are any
-      query: {
-        action: Router.query.action,
-      },
-    };
-    Router.replace(link, link, { shallow: true });
+    if (token) {
+      window.localStorage.setItem('auth.token', JSON.stringify(token));
+      setState({ type: authStates.authorized, token });
+      const link = {
+        pathname: Router.asPath.split('?')[0],
+        // TODO: This is very app specific, but it's an absolute pain to try and get this to work
+        // The side effect is that it removes the rest of the URL params if there are any
+        query: {
+          action: Router.query.action,
+        },
+      };
+      Router.replace(link, link, { shallow: true });
+    } else {
+      console.error('getToken returned undefined. Failed to authorise.');
+      // TODO: something else? Try again?
+    }
   }
 
   return state;

--- a/common/hooks/useAuth.js
+++ b/common/hooks/useAuth.js
@@ -161,7 +161,8 @@ const useAuth = () => {
       const { verifier, loginUrl } = createLoginUrlWithVerifier();
       window.localStorage.setItem('auth.verifier', verifier);
       setState(({ type: authStates.unauthorized, loginUrl }: Unauthorized));
-      // TODO: let the user know something failed?
+      // TODO: nicer solution than window.alert
+      window.alert('Authorisation failed. Please try to log in again.');
     }
   }
 


### PR DESCRIPTION
If the `fetch` in `getToken` fails for any reason, the function will return `undefined` as the value of `token`. Code block [here](https://github.com/wellcomecollection/wellcomecollection.org/blob/eed80e96064b20fe9034980207e44e6b81263f70/common/hooks/useAuth.js#L44-L55).

We `JSON.stringify` the `token` and keep it in `localStorage`, but without checking that it is properly defined, we currently can end up with the string 'undefined' stored as the value for `auth.token` in `localStorage`.

This PR adds a check for the token in the `authorise` function, so it won't add an undefined value to `localStorage`, or set the `authState` to `authorised`, or change the URL. But I'm not sure what we should do _then_ – retry the authorisation somehow? Display an error message? Do nothing? 