### PR TITLE
Single image downloads

### DIFF
--- a/catalogue/webapp/components/Download/Download.js
+++ b/catalogue/webapp/components/Download/Download.js
@@ -160,9 +160,9 @@ const Download = ({
                   .filter(option => option.format !== 'text/plain') // We're taking out raw text for now
                   .map(option => {
                     const action =
-                      option.label === 'Download full size'
+                      option.label === 'This image (Full size)'
                         ? 'download large work image'
-                        : option.label === 'Download small (760px)'
+                        : option.label === 'This image (760 pixels)'
                         ? 'download small work image'
                         : option.label;
                     const format = getFormatString(option.format);
@@ -171,7 +171,11 @@ const Download = ({
                       <li key={option.label}>
                         <DownloadLink
                           href={option['@id']}
-                          linkText={option.label}
+                          linkText={
+                            option.label === 'Download as PDF'
+                              ? 'Whole item PDF'
+                              : option.label
+                          }
                           format={format}
                           trackingEvent={{
                             category: 'Button',

--- a/common/utils/works.js
+++ b/common/utils/works.js
@@ -17,12 +17,12 @@ export function getDownloadOptionsFromImageUrl(
     {
       '@id': convertImageUri(imageUrl, 'full'),
       format: 'image/jpeg',
-      label: 'Download full size',
+      label: 'This image (Full size)',
     },
     {
       '@id': convertImageUri(imageUrl, 760),
       format: 'image/jpeg',
-      label: 'Download small (760px)',
+      label: 'This image (760 pixels)',
     },
   ];
 }

--- a/common/views/components/IIIFViewer/IIIFViewer.js
+++ b/common/views/components/IIIFViewer/IIIFViewer.js
@@ -292,8 +292,27 @@ const IIIFViewerComponent = ({
     : null;
 
   // Download info from manifest
+  const urlTemplateMain = mainImageService['@id']
+    ? iiifImageTemplate(mainImageService['@id'])
+    : null;
+  const largeImage = urlTemplateMain && {
+    '@id': urlTemplateMain({ size: 'full' }),
+    format: 'JPG',
+    label: 'Download current full size image',
+  };
+  const smallImage = urlTemplateMain && {
+    '@id': urlTemplateMain({ size: '760,' }),
+    format: 'JPG',
+    label: 'Download current small size image',
+  };
   const iiifPresentationDownloadOptions =
-    (manifest && getDownloadOptionsFromManifest(manifest)) || [];
+    (manifest &&
+      [
+        ...getDownloadOptionsFromManifest(manifest),
+        largeImage,
+        smallImage,
+      ].filter(Boolean)) ||
+    [largeImage, smallImage].filter(Boolean);
 
   const parentManifestUrl = manifest && manifest.within;
 

--- a/common/views/components/IIIFViewer/IIIFViewer.js
+++ b/common/views/components/IIIFViewer/IIIFViewer.js
@@ -26,7 +26,10 @@ import MainViewer from './parts/MainViewer';
 import ThumbsViewer from './parts/ThumbsViewer';
 import GridViewer from './parts/GridViewer';
 import Control from '../Buttons/Control/Control';
+import Layout12 from '@weco/common/views/components/Layout12/Layout12';
+import Download from '@weco/catalogue/components/Download/Download';
 import dynamic from 'next/dynamic';
+
 const LoadingComponent = () => (
   <div
     style={{
@@ -562,6 +565,23 @@ const IIIFViewerComponent = ({
           </>
         )}
       </IIIFViewerBackground>
+      {!enhanced && (
+        <Layout12>
+          <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
+            <Download
+              ariaControlsId="itemDownloads"
+              title={title}
+              workId={workId}
+              license={licenseInfo}
+              iiifImageLocationCredit={iiifImageLocationCredit}
+              downloadOptions={
+                downloadOptions || iiifPresentationDownloadOptions
+              }
+              useDarkControl={true}
+            />
+          </Space>
+        </Layout12>
+      )}
     </div>
   );
 };

--- a/common/views/components/IIIFViewer/IIIFViewer.js
+++ b/common/views/components/IIIFViewer/IIIFViewer.js
@@ -297,12 +297,12 @@ const IIIFViewerComponent = ({
     : null;
   const largeImage = urlTemplateMain && {
     '@id': urlTemplateMain({ size: 'full' }),
-    format: 'JPG',
+    format: 'image/jpeg',
     label: 'This image (Full size)',
   };
   const smallImage = urlTemplateMain && {
     '@id': urlTemplateMain({ size: '760,' }),
-    format: 'JPG',
+    format: 'image/jpeg',
     label: 'This image (760 pixels)',
   };
   const iiifPresentationDownloadOptions =

--- a/common/views/components/IIIFViewer/IIIFViewer.js
+++ b/common/views/components/IIIFViewer/IIIFViewer.js
@@ -298,12 +298,12 @@ const IIIFViewerComponent = ({
   const largeImage = urlTemplateMain && {
     '@id': urlTemplateMain({ size: 'full' }),
     format: 'JPG',
-    label: 'Download current full size image',
+    label: 'This image (Full size)',
   };
   const smallImage = urlTemplateMain && {
     '@id': urlTemplateMain({ size: '760,' }),
     format: 'JPG',
-    label: 'Download current small size image',
+    label: 'This image (760 pixels)',
   };
   const iiifPresentationDownloadOptions =
     (manifest &&


### PR DESCRIPTION
References #4938

## Who is this for?
People who want to download single images from the viewer

## What is it doing for them?
Adds links to 2 sizes of the current image being displayed

<img width="483" alt="Screenshot 2020-03-25 at 16 15 15" src="https://user-images.githubusercontent.com/6051896/77562710-46dabe80-6eb8-11ea-98b0-a672f5e7df1e.png">
