### PR TITLE
Pixels for downloads

### DIFF
--- a/catalogue/webapp/components/Download/Download.js
+++ b/catalogue/webapp/components/Download/Download.js
@@ -159,11 +159,9 @@ const Download = ({
                 {downloadOptions
                   .filter(option => option.format !== 'text/plain') // We're taking out raw text for now
                   .map(option => {
-                    const action = option.label.startsWith(
-                      'This image (Full size'
-                    )
+                    const action = option['@id'].match(/\/full\/full\//)
                       ? 'download large work image'
-                      : option.label.startsWith('This image (760')
+                      : option['@id'].match(/\/full\/760/)
                       ? 'download small work image'
                       : option.label;
                     const format = getFormatString(option.format);

--- a/catalogue/webapp/components/Download/Download.js
+++ b/catalogue/webapp/components/Download/Download.js
@@ -174,7 +174,7 @@ const Download = ({
                           href={option['@id']}
                           linkText={
                             option.label === 'Download as PDF'
-                              ? 'Whole item PDF'
+                              ? 'Whole item'
                               : option.label
                           }
                           format={format}

--- a/catalogue/webapp/components/Download/Download.js
+++ b/catalogue/webapp/components/Download/Download.js
@@ -159,12 +159,13 @@ const Download = ({
                 {downloadOptions
                   .filter(option => option.format !== 'text/plain') // We're taking out raw text for now
                   .map(option => {
-                    const action =
-                      option.label === 'This image (Full size)'
-                        ? 'download large work image'
-                        : option.label === 'This image (760 pixels)'
-                        ? 'download small work image'
-                        : option.label;
+                    const action = option.label.startsWith(
+                      'This image (Full size'
+                    )
+                      ? 'download large work image'
+                      : option.label.startsWith('This image (760')
+                      ? 'download small work image'
+                      : option.label;
                     const format = getFormatString(option.format);
 
                     return (

--- a/catalogue/webapp/components/DownloadLink/DownloadLink.js
+++ b/catalogue/webapp/components/DownloadLink/DownloadLink.js
@@ -12,6 +12,7 @@ const DownloadLinkStyle = styled.a.attrs({
   }),
 })`
   display: inline-block;
+  white-space: nowrap;
   background: ${props => props.theme.colors.white};
   color: ${props => props.theme.colors.green};
   text-decoration: none;

--- a/common/views/components/IIIFViewer/IIIFViewer.js
+++ b/common/views/components/IIIFViewer/IIIFViewer.js
@@ -313,14 +313,12 @@ const IIIFViewerComponent = ({
   const largeImage = urlTemplateMain && {
     '@id': urlTemplateMain({ size: 'full' }),
     format: 'image/jpeg',
-    label: `This image (Full size ${imageDimensions.fullWidth} x
-      ${imageDimensions.fullHeight} pixels)`,
+    label: `This image (${imageDimensions.fullWidth}x${imageDimensions.fullHeight} pixels)`,
   };
   const smallImage = urlTemplateMain && {
     '@id': urlTemplateMain({ size: '760,' }),
     format: 'image/jpeg',
-    label: `This image (${imageDimensions.smallWidth} x
-    ${imageDimensions.smallHeight} pixels)`,
+    label: `This image (${imageDimensions.smallWidth}x${imageDimensions.smallHeight} pixels)`,
   };
   const iiifPresentationDownloadOptions =
     (manifest &&

--- a/common/views/components/IIIFViewer/IIIFViewer.js
+++ b/common/views/components/IIIFViewer/IIIFViewer.js
@@ -323,9 +323,9 @@ const IIIFViewerComponent = ({
   const iiifPresentationDownloadOptions =
     (manifest &&
       [
-        ...getDownloadOptionsFromManifest(manifest),
         largeImage,
         smallImage,
+        ...getDownloadOptionsFromManifest(manifest),
       ].filter(Boolean)) ||
     [largeImage, smallImage].filter(Boolean);
 

--- a/common/views/components/IIIFViewer/IIIFViewer.js
+++ b/common/views/components/IIIFViewer/IIIFViewer.js
@@ -295,18 +295,32 @@ const IIIFViewerComponent = ({
     : null;
 
   // Download info from manifest
+  const smallImageWidth = 760;
+  const imageDimensions = {
+    fullWidth: currentCanvas ? `${currentCanvas.width}` : '',
+    fullHeight: currentCanvas ? `${currentCanvas.height}` : '',
+    smallWidth: `${smallImageWidth}`,
+    smallHeight: currentCanvas
+      ? `${Math.round(
+          currentCanvas.height / (currentCanvas.width / smallImageWidth)
+        )}`
+      : '',
+  };
+
   const urlTemplateMain = mainImageService['@id']
     ? iiifImageTemplate(mainImageService['@id'])
     : null;
   const largeImage = urlTemplateMain && {
     '@id': urlTemplateMain({ size: 'full' }),
     format: 'image/jpeg',
-    label: 'This image (Full size)',
+    label: `This image (Full size ${imageDimensions.fullWidth} x
+      ${imageDimensions.fullHeight} pixels)`,
   };
   const smallImage = urlTemplateMain && {
     '@id': urlTemplateMain({ size: '760,' }),
     format: 'image/jpeg',
-    label: 'This image (760 pixels)',
+    label: `This image (${imageDimensions.smallWidth} x
+    ${imageDimensions.smallHeight} pixels)`,
   };
   const iiifPresentationDownloadOptions =
     (manifest &&


### PR DESCRIPTION
Fixes #5196

## Who is this for?
Researching using the digitised collections

## What is it doing for them?
Showing the size of downloadable images

<img width="476" alt="Screenshot 2020-03-25 at 17 19 25" src="https://user-images.githubusercontent.com/6051896/77566818-19910f00-6ebe-11ea-82ab-676c4f78bdc5.png">



