### PR TITLE
Only render one modal at a time

### DIFF
--- a/catalogue/webapp/components/WorkDetails/WorkDetails.js
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.js
@@ -500,76 +500,77 @@ const WorkDetails = ({
                           </div>
                         </Modal>
                       </div>
-
-                      <div data-test-id="resultsModalCTA">
-                        <Modal
-                          isActive={showResultsModal}
-                          setIsActive={setShowResultsModal}
-                        >
-                          <h2
-                            className={classNames({
-                              [font('hnm', 5)]: true,
-                            })}
+                      {!showRequestModal && (
+                        <div data-test-id="resultsModalCTA">
+                          <Modal
+                            isActive={showResultsModal}
+                            setIsActive={setShowResultsModal}
                           >
-                            {itemsWithPhysicalLocations.filter(
-                              item => item.requested
-                            ).length ===
-                            itemsWithPhysicalLocations.filter(
-                              item => item.requestSucceeded
-                            ).length
-                              ? 'Your items have been requested'
-                              : 'We were unable to request all of your items'}
-                          </h2>
-                          <ul className="plain-list no-padding">
-                            {itemsWithPhysicalLocations
-                              .filter(item => item.requested)
-                              .map(item => (
-                                <li key={item.id}>
-                                  <span
-                                    className={classNames({
-                                      [font('hnm', 5)]: true,
-                                    })}
-                                  >
-                                    {item.title}
-                                  </span>
+                            <h2
+                              className={classNames({
+                                [font('hnm', 5)]: true,
+                              })}
+                            >
+                              {itemsWithPhysicalLocations.filter(
+                                item => item.requested
+                              ).length ===
+                              itemsWithPhysicalLocations.filter(
+                                item => item.requestSucceeded
+                              ).length
+                                ? 'Your items have been requested'
+                                : 'We were unable to request all of your items'}
+                            </h2>
+                            <ul className="plain-list no-padding">
+                              {itemsWithPhysicalLocations
+                                .filter(item => item.requested)
+                                .map(item => (
+                                  <li key={item.id}>
+                                    <span
+                                      className={classNames({
+                                        [font('hnm', 5)]: true,
+                                      })}
+                                    >
+                                      {item.title}
+                                    </span>
 
-                                  <Space
-                                    as="span"
-                                    className={classNames({
-                                      [font('hnl', 5)]: true,
-                                    })}
-                                    h={{
-                                      size: 'l',
-                                      properties: ['margin-left'],
-                                    }}
-                                  >
-                                    {(function() {
-                                      const physicalLocation = item.locations.find(
-                                        location =>
-                                          location.type === 'PhysicalLocation'
-                                      );
-                                      return physicalLocation
-                                        ? physicalLocation.label
-                                        : null;
-                                    })()}
-                                    {` : ${
-                                      item.requestSucceeded
-                                        ? 'item has been requested'
-                                        : 'item request failed'
-                                    }`}
-                                  </Space>
-                                </li>
-                              ))}
-                          </ul>
-                          <Button
-                            type="primary"
-                            text="Continue"
-                            clickHandler={() => {
-                              setShowResultsModal(false);
-                            }}
-                          />
-                        </Modal>
-                      </div>
+                                    <Space
+                                      as="span"
+                                      className={classNames({
+                                        [font('hnl', 5)]: true,
+                                      })}
+                                      h={{
+                                        size: 'l',
+                                        properties: ['margin-left'],
+                                      }}
+                                    >
+                                      {(function() {
+                                        const physicalLocation = item.locations.find(
+                                          location =>
+                                            location.type === 'PhysicalLocation'
+                                        );
+                                        return physicalLocation
+                                          ? physicalLocation.label
+                                          : null;
+                                      })()}
+                                      {` : ${
+                                        item.requestSucceeded
+                                          ? 'item has been requested'
+                                          : 'item request failed'
+                                      }`}
+                                    </Space>
+                                  </li>
+                                ))}
+                            </ul>
+                            <Button
+                              type="primary"
+                              text="Continue"
+                              clickHandler={() => {
+                                setShowResultsModal(false);
+                              }}
+                            />
+                          </Modal>
+                        </div>
+                      )}
                     </>
                   )}
                 </>


### PR DESCRIPTION
This ensures that scroll lock behaviour works.

Previously, the second rendered (but inactive) modal removed the body classes that locked scroll when the first modal was active.