### PR TITLE
Fix table alignment when there's only one item

### DIFF
--- a/catalogue/webapp/components/WorkDetails/WorkDetails.js
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.js
@@ -248,7 +248,7 @@ const WorkDetails = ({
               >
                 <thead>
                   <tr className={classNames({ [font('hnm', 5)]: true })}>
-                    {hasRequestableItems && <th></th>}
+                    {hasRequestableItems && !singleItem && <th></th>}
                     <th>Title</th>
                     <th>Location/Shelfmark</th>
                     <th>Status</th>
@@ -262,7 +262,12 @@ const WorkDetails = ({
                       className={classNames({ [font('hnm', 5)]: true })}
                     >
                       {hasRequestableItems && (
-                        <td style={{ padding: '0' }}>
+                        <td
+                          className={classNames({
+                            'is-hidden': singleItem,
+                            'no-padding': true,
+                          })}
+                        >
                           <span hidden={singleItem}>
                             {item.requestable && (
                               <>


### PR DESCRIPTION
We don't need the space for the cell that holds the checkbox if we're only displaying one item in the table (because it is checked by default), but we need to remove the extra space that's created.

__Before__
![image](https://user-images.githubusercontent.com/1394592/77682865-78728900-6f8f-11ea-940b-b47ee709c83e.png)

__After__
![Screenshot 2020-03-26 at 18 24 31](https://user-images.githubusercontent.com/1394592/77682784-61cc3200-6f8f-11ea-8769-fc77b84a8a82.png)
