### PR TITLE
Stacks requesting events

### DIFF
--- a/catalogue/webapp/components/ItemRequestButton/ItemRequestButton.js
+++ b/catalogue/webapp/components/ItemRequestButton/ItemRequestButton.js
@@ -70,6 +70,13 @@ const ItemRequestButton = ({
         event.preventDefault();
         makeRequests(itemsWithPhysicalLocations);
       }}
+      trackingEvent={{
+        category: 'Button',
+        action: 'confirm Stacks request',
+        label: `item id(s): ${itemsWithPhysicalLocations
+          .map(i => i.id)
+          .join()}`,
+      }}
     />
   ) : null;
 };

--- a/catalogue/webapp/components/LogInButton/LogInButton.js
+++ b/catalogue/webapp/components/LogInButton/LogInButton.js
@@ -19,6 +19,11 @@ const LogInButton = ({ workId, loginUrl }: Props) => {
         clickHandler={event => {
           setRedirectCookie(workId);
         }}
+        trackingEvent={{
+          category: 'Button',
+          action: 'follow Cognito login link',
+          label: workId,
+        }}
       />
     </div>
   );

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.js
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.js
@@ -379,6 +379,11 @@ const WorkDetails = ({
                               window.alert('please make a selection');
                             }
                           }}
+                          trackingEvent={{
+                            category: 'Button',
+                            action: 'open stacks request modal window',
+                            label: work.id,
+                          }}
                         />
 
                         <Modal

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.js
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.js
@@ -381,7 +381,7 @@ const WorkDetails = ({
                           }}
                           trackingEvent={{
                             category: 'Button',
-                            action: 'open stacks request modal window',
+                            action: 'open Stacks request modal window',
                             label: work.id,
                           }}
                         />

--- a/catalogue/webapp/test/components/__snapshots__/WorkDetails.test.js.snap
+++ b/catalogue/webapp/test/components/__snapshots__/WorkDetails.test.js.snap
@@ -13,6 +13,13 @@ exports[`Feature: 2. As a library member I want to request an item
     clickHandler={[Function]}
     externalLink="/loginUrl"
     text="Log in to request"
+    trackingEvent={
+      Object {
+        "action": "follow Cognito login link",
+        "category": "Button",
+        "label": "{workId}",
+      }
+    }
     type="primary"
   >
     <a
@@ -50,6 +57,13 @@ exports[`Feature: 2. As a library member I want to request an item Scenario: I'm
   <Button
     clickHandler={[Function]}
     text="Request"
+    trackingEvent={
+      Object {
+        "action": "open Stacks request modal window",
+        "category": "Button",
+        "label": "{workId}",
+      }
+    }
     type="primary"
   >
     <button


### PR DESCRIPTION
Closes #5191 

Adds tracking events for:

1. Visiting the Cognito auth login
2. Launching the modal window to request items
3. Confirming item requests
