### PR TITLE
Show the right copy at the right time

### DIFF
--- a/common/views/components/NewsletterPromo/NewsletterPromo.js
+++ b/common/views/components/NewsletterPromo/NewsletterPromo.js
@@ -195,14 +195,16 @@ const NewsletterPromo = () => {
                   >
                     {isSuccess ? 'Thank you for signing up!' : headingText}
                   </h2>
-                  <p
-                    className={classNames({
-                      [font('hnl', 5)]: true,
-                      'no-margin': true,
-                    })}
-                  >
-                    {bodyText}
-                  </p>
+                  {!isSuccess && (
+                    <p
+                      className={classNames({
+                        [font('hnl', 5)]: true,
+                        'no-margin': true,
+                      })}
+                    >
+                      {bodyText}
+                    </p>
+                  )}
                   {isSuccess && (
                     <div
                       className={classNames({


### PR DESCRIPTION
![Screenshot 2020-04-08 at 12 22 54](https://user-images.githubusercontent.com/1394592/78779155-5b2cba00-7994-11ea-8df5-2a18a550c538.png)

Spotted that we're still displaying the initial body copy in the `NewsletterPromo` before the message you get when form submission was successful.