### PR TITLE
Input update

### DIFF
--- a/cardigan/stories/components/TextInput.js
+++ b/cardigan/stories/components/TextInput.js
@@ -16,7 +16,7 @@ const TextInputExample = () => {
       label={'Your email address'}
       errorMessage={'Enter a valid email address.'}
       value={value}
-      handleChange={event => setValue(event.currentTarget.value)}
+      setValue={setValue}
       {...useValidation()}
     />
   );

--- a/cardigan/stories/components/TextInput.js
+++ b/cardigan/stories/components/TextInput.js
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+import { storiesOf } from '@storybook/react';
+import TextInput from '../../../common/views/components/TextInput/TextInput';
+import Readme from '../../../common/views/components/TextInput/README.md';
+
+const TextInputExample = () => {
+  const [value, setValue] = useState('');
+  const [isValid, setIsValid] = useState(true);
+  const [showValidity, setShowValidity] = useState(false);
+
+  return (
+    <TextInput
+      required={true}
+      id={'test-id'}
+      type={'email'}
+      name={'email'}
+      label={'Your email address'}
+      errorMessage={'Enter a valid email address.'}
+      value={value}
+      handleInput={event => setValue(event.currentTarget.value)}
+      isValid={isValid}
+      setIsValid={setIsValid}
+      showValidity={showValidity}
+      setShowValidity={setShowValidity}
+    />
+  );
+};
+
+const stories = storiesOf('Components', module);
+stories.add('TextInput', TextInputExample, { readme: { sidebar: Readme } });

--- a/cardigan/stories/components/TextInput.js
+++ b/cardigan/stories/components/TextInput.js
@@ -17,7 +17,7 @@ const TextInputExample = () => {
       label={'Your email address'}
       errorMessage={'Enter a valid email address.'}
       value={value}
-      handleInput={event => setValue(event.currentTarget.value)}
+      handleChange={event => setValue(event.currentTarget.value)}
       isValid={isValid}
       setIsValid={setIsValid}
       showValidity={showValidity}

--- a/cardigan/stories/components/TextInput.js
+++ b/cardigan/stories/components/TextInput.js
@@ -2,11 +2,10 @@ import { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import TextInput from '../../../common/views/components/TextInput/TextInput';
 import Readme from '../../../common/views/components/TextInput/README.md';
+import useValidation from '../../../common/hooks/useValidation';
 
 const TextInputExample = () => {
   const [value, setValue] = useState('');
-  const [isValid, setIsValid] = useState(true);
-  const [showValidity, setShowValidity] = useState(false);
 
   return (
     <TextInput
@@ -18,10 +17,7 @@ const TextInputExample = () => {
       errorMessage={'Enter a valid email address.'}
       value={value}
       handleChange={event => setValue(event.currentTarget.value)}
-      isValid={isValid}
-      setIsValid={setIsValid}
-      showValidity={showValidity}
-      setShowValidity={setShowValidity}
+      {...useValidation()}
     />
   );
 };

--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -155,6 +155,7 @@ const SearchForm = ({
     >
       <SearchInputWrapper className="relative">
         <TextInput
+          id={'works-search-input'}
           label={'Search the catalogue'}
           name="query"
           value={inputQuery}

--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -161,12 +161,8 @@ const SearchForm = ({
           autoFocus={inputQuery === ''}
           handleInput={event => setInputQuery(event.currentTarget.value)}
           ref={searchInput}
-          required
-          shouldValidate={false}
-          className={classNames({
-            [font('hnm', 3)]: true,
-            'search-query': true,
-          })}
+          required={true}
+          big={true}
         />
 
         {inputQuery && (

--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -28,6 +28,7 @@ type Props = {|
 |};
 
 const SearchInputWrapper = styled.div`
+  font-size: 20px;
   background: ${props => props.theme.colors.white};
   margin-right: ${props => 12 * props.theme.spacingUnit}px;
 
@@ -41,7 +42,7 @@ const SearchInputWrapper = styled.div`
 `;
 
 const SearchButtonWrapper = styled.div`
-  height: ${props => 10 * props.theme.spacingUnit}px;
+  height: 60px;
   top: 0;
   right: 0;
   width: ${props => 10 * props.theme.spacingUnit}px;
@@ -155,13 +156,13 @@ const SearchForm = ({
       <SearchInputWrapper className="relative">
         <TextInput
           label={'Search the catalogue'}
-          placeholder={placeholder || 'Search for books and pictures'}
           name="query"
           value={inputQuery}
           autoFocus={inputQuery === ''}
-          onChange={event => setInputQuery(event.currentTarget.value)}
+          handleInput={event => setInputQuery(event.currentTarget.value)}
           ref={searchInput}
           required
+          shouldValidate={false}
           className={classNames({
             [font('hnm', 3)]: true,
             'search-query': true,

--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -159,8 +159,8 @@ const SearchForm = ({
           label={'Search the catalogue'}
           name="query"
           value={inputQuery}
+          setValue={setInputQuery}
           autoFocus={inputQuery === ''}
-          handleInput={event => setInputQuery(event.currentTarget.value)}
           ref={searchInput}
           required={true}
           big={true}
@@ -177,7 +177,6 @@ const SearchForm = ({
               });
 
               setInputQuery('');
-              // $FlowFixMe
               searchInput.current && searchInput.current.focus();
             }}
             type="button"

--- a/common/hooks/useValidation.js
+++ b/common/hooks/useValidation.js
@@ -1,0 +1,10 @@
+import { useState } from 'react';
+
+const useValidation = (initIsValid = true, initShowValidity = false) => {
+  const [isValid, setIsValid] = useState(initIsValid);
+  const [showValidity, setShowValidity] = useState(initShowValidity);
+
+  return { isValid, setIsValid, showValidity, setShowValidity };
+};
+
+export default useValidation;

--- a/common/test/components/TextInput.test.js
+++ b/common/test/components/TextInput.test.js
@@ -10,10 +10,9 @@ const ExampleTextInput = () => {
     <TextInput
       type="email"
       value={value}
-      handleChange={event => setValue(event.currentTarget.value)}
+      setValue={setValue}
       required={true}
       errorMessage={`test error message`}
-      handle
       {...useValidation()}
     />
   );

--- a/common/test/components/TextInput.test.js
+++ b/common/test/components/TextInput.test.js
@@ -53,7 +53,7 @@ describe('TextInput', () => {
       wrapper.find("[data-test-id='TextInputErrorMessage']")
     ).toMatchSnapshot();
   });
-  test(`A valid input will hide its valid state at the point new input is added`, () => {
+  test(`A valid input will hide its valid state at the point valid input is added`, () => {
     const wrapper = mountWithTheme(<ExampleTextInput />);
     const input = wrapper.find('input');
 
@@ -72,6 +72,24 @@ describe('TextInput', () => {
 
     expect(
       wrapper.find("[data-test-id='TextInputCheckmark']")
+    ).toMatchSnapshot();
+  });
+
+  test(`A valid input will hide its valid state at the point invalid input is added`, () => {
+    const wrapper = mountWithTheme(<ExampleTextInput />);
+    const input = wrapper.find('input');
+
+    input.simulate('focus');
+    input.instance().value = 'valid@email.com';
+    input.simulate('change');
+    input.simulate('blur');
+
+    input.simulate('focus');
+    input.instance().value = 'invalidemail@';
+    input.simulate('change');
+
+    expect(
+      wrapper.find("[data-test-id='TextInputErrorMessage']")
     ).toMatchSnapshot();
   });
 });

--- a/common/test/components/TextInput.test.js
+++ b/common/test/components/TextInput.test.js
@@ -1,0 +1,78 @@
+import { useState } from 'react';
+import TextInput from '../../views/components/TextInput/TextInput';
+import { mountWithTheme } from '../fixtures/enzyme-helpers';
+import useValidation from '../../hooks/useValidation';
+
+const ExampleTextInput = () => {
+  const [value, setValue] = useState('');
+
+  return (
+    <TextInput
+      type="email"
+      value={value}
+      handleChange={event => setValue(event.currentTarget.value)}
+      required={true}
+      errorMessage={`test error message`}
+      handle
+      {...useValidation()}
+    />
+  );
+};
+
+describe('TextInput', () => {
+  test(`The input will validate when blurred`, () => {
+    const wrapper = mountWithTheme(<ExampleTextInput />);
+    const input = wrapper.find('input');
+
+    input.simulate('focus');
+    input.instance().value = 'invalidemail@';
+    input.simulate('change');
+    input.simulate('blur');
+
+    expect(
+      wrapper.find("[data-test-id='TextInputErrorMessage']")
+    ).toMatchSnapshot();
+  });
+  test(`The input will hide errors at the point it becomes valid`, () => {
+    const wrapper = mountWithTheme(<ExampleTextInput />);
+    const input = wrapper.find('input');
+
+    input.simulate('focus');
+    input.instance().value = 'invalidemail@';
+    input.simulate('change');
+    input.simulate('blur');
+
+    expect(
+      wrapper.find("[data-test-id='TextInputErrorMessage']")
+    ).toMatchSnapshot();
+
+    input.simulate('focus');
+    input.instance().value = 'valid@email.com';
+    input.simulate('change');
+
+    expect(
+      wrapper.find("[data-test-id='TextInputErrorMessage']")
+    ).toMatchSnapshot();
+  });
+  test(`A valid input will hide its valid state at the point new input is added`, () => {
+    const wrapper = mountWithTheme(<ExampleTextInput />);
+    const input = wrapper.find('input');
+
+    input.simulate('focus');
+    input.instance().value = 'valid@email.com';
+    input.simulate('change');
+    input.simulate('blur');
+
+    expect(
+      wrapper.find("[data-test-id='TextInputCheckmark']")
+    ).toMatchSnapshot();
+
+    input.simulate('focus');
+    input.instance().value = 'valid@email.co';
+    input.simulate('change');
+
+    expect(
+      wrapper.find("[data-test-id='TextInputCheckmark']")
+    ).toMatchSnapshot();
+  });
+});

--- a/common/test/components/__snapshots__/TextInput.test.js.snap
+++ b/common/test/components/__snapshots__/TextInput.test.js.snap
@@ -1,0 +1,54 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TextInput A valid input will hide its valid state at the point new input is added 1`] = `
+<span
+  className="TextInput__TextInputCheckmark-sc-1860hhu-3 bEVYrx absolute"
+  data-test-id="TextInputCheckmark"
+>
+  <Icon
+    extraClasses="icon--green"
+    name="check"
+  >
+    <div
+      className="icon icon--green"
+    >
+      <svg
+        aria-hidden={true}
+        className="icon__svg"
+      >
+        <svg
+          viewBox="0 0 24 24"
+        >
+          <path
+            className="icon__shape"
+            d="M21.13 6.64a1 1 0 0 0-1.41 0L10 16.34l-5-5a1 1 0 0 0-1.41 1.41l5.67 5.67a1 1 0 0 0 1.41 0l10.4-10.4a1 1 0 0 0 .06-1.38z"
+            fillRule="nonzero"
+          />
+        </svg>
+      </svg>
+    </div>
+  </Icon>
+</span>
+`;
+
+exports[`TextInput A valid input will hide its valid state at the point new input is added 2`] = `null`;
+
+exports[`TextInput The input will hide errors at the point it becomes valid 1`] = `
+<span
+  className="TextInput__TextInputErrorMessage-sc-1860hhu-4 IKSWN font-hnm"
+  data-test-id="TextInputErrorMessage"
+>
+  test error message
+</span>
+`;
+
+exports[`TextInput The input will hide errors at the point it becomes valid 2`] = `null`;
+
+exports[`TextInput The input will validate when blurred 1`] = `
+<span
+  className="TextInput__TextInputErrorMessage-sc-1860hhu-4 IKSWN font-hnm"
+  data-test-id="TextInputErrorMessage"
+>
+  test error message
+</span>
+`;

--- a/common/test/components/__snapshots__/TextInput.test.js.snap
+++ b/common/test/components/__snapshots__/TextInput.test.js.snap
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TextInput A valid input will hide its valid state at the point new input is added 1`] = `
+exports[`TextInput A valid input will hide its valid state at the point invalid input is added 1`] = `null`;
+
+exports[`TextInput A valid input will hide its valid state at the point valid input is added 1`] = `
 <span
   className="TextInput__TextInputCheckmark-sc-1860hhu-3 bEVYrx absolute"
   data-test-id="TextInputCheckmark"
@@ -31,7 +33,7 @@ exports[`TextInput A valid input will hide its valid state at the point new inpu
 </span>
 `;
 
-exports[`TextInput A valid input will hide its valid state at the point new input is added 2`] = `null`;
+exports[`TextInput A valid input will hide its valid state at the point valid input is added 2`] = `null`;
 
 exports[`TextInput The input will hide errors at the point it becomes valid 1`] = `
 <span

--- a/common/views/components/NewsletterPromo/NewsletterPromo.js
+++ b/common/views/components/NewsletterPromo/NewsletterPromo.js
@@ -8,6 +8,7 @@ import fetch from 'isomorphic-unfetch';
 import Raven from 'raven-js';
 import TextInput from '../TextInput/TextInput';
 import { trackEvent } from '../../../utils/ga';
+import useValidation from '../../../hooks/useValidation';
 
 const FormElementWrapper = styled.div`
   width: 100%;
@@ -98,9 +99,8 @@ const NewsletterPromo = () => {
   const [isSuccess, setIsSuccess] = useState(false);
   const [isSubmitError, setIsSubmitError] = useState(false);
   const [value, setValue] = useState('');
-  const [isEmailValid, setIsEmailValid] = useState(true);
-  const [showEmailValidity, setShowEmailValidity] = useState(false);
   const { isEnhanced } = useContext(AppContext);
+  const emailValidation = useValidation();
 
   const headingText = 'Stay in the know';
   const bodyText =
@@ -109,9 +109,9 @@ const NewsletterPromo = () => {
   async function handleSubmit(event) {
     event.preventDefault();
 
-    setShowEmailValidity(true);
+    emailValidation.setShowValidity(true);
 
-    if (!isEmailValid) {
+    if (!emailValidation.isValid) {
       setIsSubmitError(false);
 
       return;
@@ -150,7 +150,7 @@ const NewsletterPromo = () => {
         break;
       default:
         setIsSubmitError(true);
-        setIsEmailValid(false);
+        emailValidation.setIsValid(false);
 
         if (status) {
           Raven.captureException(
@@ -250,13 +250,10 @@ const NewsletterPromo = () => {
                               : 'Enter a valid email address.'
                           }
                           value={value}
-                          handleInput={event =>
+                          handleChange={event =>
                             setValue(event.currentTarget.value)
                           }
-                          isValid={isEmailValid}
-                          setIsValid={setIsEmailValid}
-                          showValidity={showEmailValidity}
-                          setShowValidity={setShowEmailValidity}
+                          {...emailValidation}
                         />
                         <NewsletterButton disabled={isSubmitting}>
                           {isSubmitting ? 'Sending…' : 'Subscribe'}

--- a/common/views/components/NewsletterPromo/NewsletterPromo.js
+++ b/common/views/components/NewsletterPromo/NewsletterPromo.js
@@ -250,9 +250,7 @@ const NewsletterPromo = () => {
                               : 'Enter a valid email address.'
                           }
                           value={value}
-                          handleChange={event =>
-                            setValue(event.currentTarget.value)
-                          }
+                          setValue={setValue}
                           {...emailValidation}
                         />
                         <NewsletterButton disabled={isSubmitting}>

--- a/common/views/components/NewsletterPromo/NewsletterPromo.js
+++ b/common/views/components/NewsletterPromo/NewsletterPromo.js
@@ -25,17 +25,9 @@ const FormElementWrapper = styled.div`
   ${props => props.theme.media.medium`
     display: flex;
     flex: 1;
+    align-items: flex-start;
   `}
 `;
-
-const NewsletterInput = styled(TextInput).attrs({
-  required: true,
-  id: 'newsletter-input',
-  type: 'email',
-  name: 'email',
-  label: 'Your email address',
-  placeholder: 'Your email address',
-})``;
 
 const NewsletterButton = styled.button.attrs({
   className: classNames({
@@ -45,6 +37,7 @@ const NewsletterButton = styled.button.attrs({
 })`
   width: 100%;
   margin-top: 10px;
+  height: 60px;
 
   ${props => props.theme.media.medium`
     width: auto;
@@ -115,6 +108,7 @@ const NewsletterPromo = () => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSuccess, setIsSuccess] = useState(false);
   const [isError, setIsError] = useState(false);
+  const [value, setValue] = useState('');
 
   const headingText = 'Stay in the know';
   const bodyText =
@@ -244,7 +238,19 @@ const NewsletterPromo = () => {
                       />
                       <input type="hidden" name="addressbookid" value="40131" />
                       <FormElementWrapper>
-                        <NewsletterInput />
+                        <TextInput
+                          required={true}
+                          id={'newsletter-input'}
+                          type={'email'}
+                          name={'email'}
+                          label={'Your email address'}
+                          errorMessage={'Enter a valid email address'}
+                          value={value}
+                          handleInput={event =>
+                            setValue(event.currentTarget.value)
+                          }
+                          shouldValidate={true}
+                        />
                         <NewsletterButton disabled={isSubmitting}>
                           {isSubmitting ? 'Sending…' : 'Subscribe'}
                         </NewsletterButton>

--- a/common/views/components/NewsletterPromo/NewsletterPromo.js
+++ b/common/views/components/NewsletterPromo/NewsletterPromo.js
@@ -1,11 +1,13 @@
 // @flow
-import { useState, useRef } from 'react';
+import { useState, useRef, useContext } from 'react';
+import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
 import { font, classNames } from '../../../utils/classnames';
 import Space from '../styled/Space';
 import styled from 'styled-components';
 import fetch from 'isomorphic-unfetch';
 import Raven from 'raven-js';
 import TextInput from '../TextInput/TextInput';
+
 import { trackEvent } from '../../../utils/ga';
 
 const ErrorMessage = styled(Space).attrs({
@@ -111,6 +113,7 @@ const NewsletterPromo = () => {
   const [value, setValue] = useState('');
   const [isEmailValid, setIsEmailValid] = useState(true);
   const emailInputRef = useRef(null);
+  const { isEnhanced } = useContext(AppContext);
 
   const headingText = 'Stay in the know';
   const bodyText =
@@ -118,6 +121,7 @@ const NewsletterPromo = () => {
 
   async function handleSubmit(event) {
     event.preventDefault();
+
     setIsSubmitting(true);
     setIsError(false);
 
@@ -221,7 +225,10 @@ const NewsletterPromo = () => {
                 </CopyWrap>
                 {!isSuccess && (
                   <>
-                    <NewsletterForm onSubmit={handleSubmit}>
+                    <NewsletterForm
+                      onSubmit={handleSubmit}
+                      noValidate={isEnhanced}
+                    >
                       {isError && (
                         <ErrorMessage>
                           There was a problem. Please try again.

--- a/common/views/components/NewsletterPromo/NewsletterPromo.js
+++ b/common/views/components/NewsletterPromo/NewsletterPromo.js
@@ -1,5 +1,5 @@
 // @flow
-import { useState, useRef, useContext } from 'react';
+import { useState, useContext } from 'react';
 import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
 import { font, classNames } from '../../../utils/classnames';
 import Space from '../styled/Space';
@@ -100,8 +100,6 @@ const NewsletterPromo = () => {
   const [value, setValue] = useState('');
   const [isEmailValid, setIsEmailValid] = useState(true);
   const [showEmailValidity, setShowEmailValidity] = useState(false);
-
-  const emailInputRef = useRef(null);
   const { isEnhanced } = useContext(AppContext);
 
   const headingText = 'Stay in the know';
@@ -111,9 +109,10 @@ const NewsletterPromo = () => {
   async function handleSubmit(event) {
     event.preventDefault();
 
+    setShowEmailValidity(true);
+
     if (!isEmailValid) {
       setIsSubmitError(false);
-      setShowEmailValidity(true);
 
       return;
     }
@@ -240,7 +239,6 @@ const NewsletterPromo = () => {
                       <input type="hidden" name="addressbookid" value="40131" />
                       <FormElementWrapper>
                         <TextInput
-                          ref={emailInputRef}
                           required={true}
                           id={'newsletter-input'}
                           type={'email'}

--- a/common/views/components/NewsletterPromo/NewsletterPromo.js
+++ b/common/views/components/NewsletterPromo/NewsletterPromo.js
@@ -1,5 +1,5 @@
 // @flow
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { font, classNames } from '../../../utils/classnames';
 import Space from '../styled/Space';
 import styled from 'styled-components';
@@ -109,6 +109,8 @@ const NewsletterPromo = () => {
   const [isSuccess, setIsSuccess] = useState(false);
   const [isError, setIsError] = useState(false);
   const [value, setValue] = useState('');
+  const [isEmailValid, setIsEmailValid] = useState(true);
+  const emailInputRef = useRef(null);
 
   const headingText = 'Stay in the know';
   const bodyText =
@@ -239,6 +241,7 @@ const NewsletterPromo = () => {
                       <input type="hidden" name="addressbookid" value="40131" />
                       <FormElementWrapper>
                         <TextInput
+                          ref={emailInputRef}
                           required={true}
                           id={'newsletter-input'}
                           type={'email'}
@@ -249,7 +252,8 @@ const NewsletterPromo = () => {
                           handleInput={event =>
                             setValue(event.currentTarget.value)
                           }
-                          shouldValidate={true}
+                          isValid={isEmailValid}
+                          setIsValid={setIsEmailValid}
                         />
                         <NewsletterButton disabled={isSubmitting}>
                           {isSubmitting ? 'Sending…' : 'Subscribe'}

--- a/common/views/components/NewsletterPromo/NewsletterPromo.js
+++ b/common/views/components/NewsletterPromo/NewsletterPromo.js
@@ -26,7 +26,7 @@ const NewsletterButton = styled.button.attrs({
 })`
   width: 100%;
   margin-top: 10px;
-  height: 60px;
+  height: 55px;
 
   ${props => props.theme.media.medium`
     width: auto;

--- a/common/views/components/TextInput/README.md
+++ b/common/views/components/TextInput/README.md
@@ -1,0 +1,14 @@
+## Purpose
+To display a text input and any relevant validation UI/messaging to the user.
+
+### Notes
+- The label minifies if input has focus
+- The label remains minified when input is blurred as long as some value is entered
+- The label is always minified if user doesn't have JS
+- The input will validate when it is blurred or the form it lives in is submitted (either shows error state or 'valid' checkmark)
+- The input will hide any error at the point when it becomes valid and won't re-check for errors until it is blurred
+- The input will hide valid checkmark if it receives new input and won't revalidate until it is blurred
+
+[Edit this on GitHub](https://github.com/wellcomecollection/wellcomecollection.org/edit/master/common/views/components/TextInput/README.md)
+
+[View this on Zeplin](https://zpl.io/VQDJKEn)

--- a/common/views/components/TextInput/TextInput.js
+++ b/common/views/components/TextInput/TextInput.js
@@ -1,66 +1,151 @@
 // @flow
-import { forwardRef, type ComponentType } from 'react';
+import { forwardRef, useContext, useState } from 'react';
 import styled from 'styled-components';
-import Space, { type SpaceComponentProps } from '../styled/Space';
+import Icon from '../Icon/Icon';
+import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
+// import Space, { type SpaceComponentProps } from '../styled/Space';
 import { classNames } from '../../../utils/classnames';
 
-const VisuallyHidden = styled.div`
-  border: 0;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  width: 1px;
-  white-space: nowrap;
+const TextInputContainer = styled.div``;
+
+const TextInputWrap = styled.div.attrs({
+  className: classNames({
+    'flex relative': true,
+  }),
+})`
+  &:focus-within {
+    label {
+      font-size: 14px;
+      transform: translateY(0%);
+      top: 7px;
+    }
+  }
 `;
 
-const StyledInput: ComponentType<SpaceComponentProps> = styled(Space).attrs({
-  className: classNames({}),
+const TextInputLabel = styled.label.attrs({
+  className: classNames({
+    absolute: true,
+  }),
 })`
-  border-radius: ${props => `${props.theme.borderRadiusUnit}px`};
+  top: 50%;
+  left: 15px;
+  transform: translateY(-50%);
+  font-size: 16px;
+  transition: top 125ms ease-in, font-size 125ms ease-in,
+    transform 125ms ease-in;
+  pointer-events: none;
+  color: ${props => props.theme.colors.pumice};
+
+  ${props =>
+    (!props.isEnhanced || props.hasValue) &&
+    `
+      top: 7px;
+      transform: translateY(0);
+      font-size: 14px;
+  `}
+`;
+
+const TextInputInput = styled.input.attrs(props => ({
+  type: props.type || 'text',
+}))`
+  padding: 25px 10px 10px 15px;
+  appearance: none;
+  border: 0;
+  height: 100%;
+  border: 1px solid ${props => props.theme.colors.pumice};
+  border-radius: 6px;
+  font-size: inherit;
   width: 100%;
-  padding-right: 40px;
-  border: 2px solid ${props => props.theme.colors.pumice};
 
   &:focus {
     outline: 0;
-    border: 2px solid ${props => props.theme.colors.black};
   }
 
-  &::-ms-clear {
-    display: none;
-  }
+  ${props =>
+    !props.isValid &&
+    `
+  border-color: ${props.theme.colors.red};
+  box-shadow: 0 0 0 1px ${props.theme.colors.red};
+  `}
+`;
+
+const TextInputCheckmark = styled.span.attrs({
+  className: classNames({
+    absolute: true,
+  }),
+})`
+  top: 50%;
+  transform: translateY(-50%);
+  right: 10px;
+`;
+
+const TextInputErrorMessage = styled.span`
+  font-size: 14px;
+  font-weight: bold;
+  margin-top: 10px;
+  padding-left: 15px;
+  color: ${props => props.theme.colors.red};
 `;
 
 type Props = {
   label: string,
+  type: ?string,
+  errorMessage: ?string,
   // We can also pass inputProps here
 };
 
 // $FlowFixMe (forwardRef)
-const TextInput = forwardRef((
-  { label, ...inputProps }: Props,
-  ref // eslint-disable-line
-) => (
-  <label className="flex flex--v-center">
-    <StyledInput
-      v={{
-        size: 'm',
-        properties: ['padding-top', 'padding-bottom'],
-      }}
-      h={{ size: 'm', properties: ['padding-left'] }}
-      as="input"
-      ref={ref}
-      type="text"
-      {...inputProps}
-    />
-    <VisuallyHidden>
-      <label>{label}</label>
-    </VisuallyHidden>
-  </label>
-));
+const TextInput = forwardRef(
+  (
+    { label, type, errorMessage, ...inputProps }: Props,
+    ref // eslint-disable-line
+  ) => {
+    const { isEnhanced } = useContext(AppContext);
+    const [value, setValue] = useState('');
+    const [isValid, setIsValid] = useState(true);
+    const [showValid, setShowValid] = useState(false);
+
+    function handleInput(event) {
+      const isValid = event.currentTarget.validity.valid;
+
+      setShowValid(false);
+      setValue(event.currentTarget.value);
+
+      if (isValid) {
+        setIsValid(isValid);
+      }
+    }
+
+    function handleBlur(event) {
+      setIsValid(event.currentTarget.validity.valid);
+      setShowValid(value && true);
+    }
+
+    return (
+      <TextInputContainer>
+        <TextInputWrap value={value}>
+          <TextInputLabel isEnhanced={isEnhanced} hasValue={!!value}>
+            {label}
+          </TextInputLabel>
+          <TextInputInput
+            onInput={handleInput}
+            onBlur={handleBlur}
+            isValid={isValid}
+            type={type}
+          />
+          {isValid && showValid && (
+            <TextInputCheckmark>
+              <Icon name={`check`} extraClasses={`icon--green`} />
+            </TextInputCheckmark>
+          )}
+        </TextInputWrap>
+        {errorMessage && !isValid && (
+          <TextInputErrorMessage>{errorMessage}</TextInputErrorMessage>
+        )}
+      </TextInputContainer>
+    );
+  }
+);
 
 TextInput.displayName = 'TextInput';
 

--- a/common/views/components/TextInput/TextInput.js
+++ b/common/views/components/TextInput/TextInput.js
@@ -1,5 +1,5 @@
 // @flow
-import { forwardRef, useContext, useState } from 'react';
+import { forwardRef, useContext } from 'react';
 import styled from 'styled-components';
 import Icon from '../Icon/Icon';
 import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
@@ -108,9 +108,11 @@ type Props = {
   placeholder: ?string,
   errorMessage: ?string,
   value: string,
-  handleInput: event => void,
+  handleInput: (event: Event) => void,
   isValid: boolean,
   setIsValid: (value: boolean) => void,
+  showValidity: boolean,
+  setShowValidity: (value: boolean) => void,
   // We can also pass inputProps here
 };
 
@@ -128,12 +130,13 @@ const TextInput = forwardRef(
       handleInput,
       isValid,
       setIsValid,
+      showValidity,
+      setShowValidity,
       ...inputProps
     }: Props,
     ref // eslint-disable-line
   ) => {
     const { isEnhanced } = useContext(AppContext);
-    const [showValidity, setShowValidity] = useState(false);
 
     function onInput(event) {
       handleInput(event);
@@ -143,7 +146,7 @@ const TextInput = forwardRef(
 
     function onBlur(event) {
       setIsValid(event.currentTarget.validity.valid);
-      setShowValidity(value && true);
+      setShowValidity(!!value && true);
     }
 
     return (

--- a/common/views/components/TextInput/TextInput.js
+++ b/common/views/components/TextInput/TextInput.js
@@ -71,8 +71,7 @@ const TextInputInput = styled.input.attrs(props => ({
   }
 
   ${props =>
-    !props.isValid &&
-    props.shouldValidate &&
+    props.hasErrorBorder &&
     `
   border-color: ${props.theme.colors.red};
   `}
@@ -103,13 +102,15 @@ const TextInputErrorMessage = styled.span.attrs({
 type Props = {
   label: string,
   pattern: ?string,
+  name: ?string,
   required: ?boolean,
   type: ?string,
   placeholder: ?string,
   errorMessage: ?string,
   value: string,
-  shouldValidate: boolean,
   handleInput: event => void,
+  isValid: boolean,
+  setIsValid: (value: boolean) => void,
   // We can also pass inputProps here
 };
 
@@ -120,62 +121,55 @@ const TextInput = forwardRef(
       label,
       type,
       value,
+      name,
       pattern,
       required,
       errorMessage,
-      shouldValidate,
       handleInput,
+      isValid,
+      setIsValid,
       ...inputProps
     }: Props,
     ref // eslint-disable-line
   ) => {
     const { isEnhanced } = useContext(AppContext);
-    const [isValid, setIsValid] = useState(true);
-    const [showValid, setShowValid] = useState(false);
+    const [showValidity, setShowValidity] = useState(false);
 
     function onInput(event) {
       handleInput(event);
-      const isValid = event.currentTarget.validity.valid;
-
-      setShowValid(false);
-
-      if (isValid) {
-        setIsValid(isValid);
-      }
+      setIsValid(event.currentTarget.validity.valid);
+      setShowValidity(false);
     }
 
     function onBlur(event) {
       setIsValid(event.currentTarget.validity.valid);
-      setShowValid(value && true);
+      setShowValidity(value && true);
     }
 
     return (
       <TextInputContainer>
-        <TextInputWrap
-          value={value}
-          hasErrorBorder={shouldValidate && !isValid}
-        >
+        <TextInputWrap value={value} hasErrorBorder={!isValid && showValidity}>
           <TextInputLabel isEnhanced={isEnhanced} hasValue={!!value}>
             {label}
           </TextInputLabel>
           <TextInputInput
             ref={ref}
+            name={name}
             required={required}
             value={value}
             pattern={pattern}
             onInput={onInput}
             onBlur={onBlur}
-            isValid={isValid}
-            shouldValidate={shouldValidate}
+            hasErrorBorder={!isValid && showValidity}
             type={type}
           />
-          {isValid && showValid && shouldValidate && (
+          {isValid && showValidity && (
             <TextInputCheckmark>
               <Icon name={`check`} extraClasses={`icon--green`} />
             </TextInputCheckmark>
           )}
         </TextInputWrap>
-        {errorMessage && !isValid && shouldValidate && (
+        {errorMessage && !isValid && showValidity && (
           <TextInputErrorMessage>{errorMessage}</TextInputErrorMessage>
         )}
       </TextInputContainer>

--- a/common/views/components/TextInput/TextInput.js
+++ b/common/views/components/TextInput/TextInput.js
@@ -170,6 +170,11 @@ const TextInput = forwardRef(
       const isValueValid = event.currentTarget.validity.valid;
 
       setValue(event.currentTarget.value);
+
+      if (isValid && setShowValidity) {
+        setShowValidity(false);
+      }
+
       setIsValid && setIsValid(isValueValid);
 
       if (isValueValid && setShowValidity) {

--- a/common/views/components/TextInput/TextInput.js
+++ b/common/views/components/TextInput/TextInput.js
@@ -118,7 +118,7 @@ const TextInputErrorMessage = styled.span.attrs({
 type Props = {
   label: string,
   value: string,
-  handleInput: (event: Event) => void,
+  handleChange: (event: Event) => void,
   id: string,
   name: ?string,
   type: ?string,
@@ -146,7 +146,7 @@ const TextInput = forwardRef(
       pattern,
       required,
       errorMessage,
-      handleInput,
+      handleChange,
       isValid,
       setIsValid,
       showValidity,
@@ -158,10 +158,15 @@ const TextInput = forwardRef(
   ) => {
     const { isEnhanced } = useContext(AppContext);
 
-    function onInput(event) {
-      handleInput(event);
-      setIsValid && setIsValid(event.currentTarget.validity.valid);
-      setShowValidity && setShowValidity(false);
+    function onChange(event) {
+      const isValueValid = event.currentTarget.validity.valid;
+
+      handleChange(event);
+      setIsValid && setIsValid(isValueValid);
+
+      if (isValueValid && setShowValidity) {
+        setShowValidity(false);
+      }
     }
 
     function onBlur(event) {
@@ -176,7 +181,11 @@ const TextInput = forwardRef(
           hasErrorBorder={!isValid && showValidity}
           big={big}
         >
-          <TextInputLabel isEnhanced={isEnhanced} hasValue={!!value} for={id}>
+          <TextInputLabel
+            isEnhanced={isEnhanced}
+            hasValue={!!value}
+            htmlFor={id}
+          >
             {label}
           </TextInputLabel>
           <TextInputInput
@@ -186,7 +195,7 @@ const TextInput = forwardRef(
             required={required}
             value={value}
             pattern={pattern}
-            onInput={onInput}
+            onChange={onChange}
             onBlur={onBlur}
             hasErrorBorder={!isValid && showValidity}
             type={type}

--- a/common/views/components/TextInput/TextInput.js
+++ b/common/views/components/TextInput/TextInput.js
@@ -13,7 +13,7 @@ const TextInputWrap = styled.div.attrs({
   font-size: ${props => (props.big ? '20px' : '16px')};
 
   &:focus-within {
-    box-shadow: 0 0 0 3px rgba(92, 184, 191, 0.7); // turquoise @ 0.7 opacity
+    box-shadow: ${props => props.theme.focusBoxShadow};
 
     label {
       font-size: 14px;

--- a/common/views/components/TextInput/TextInput.js
+++ b/common/views/components/TextInput/TextInput.js
@@ -119,6 +119,7 @@ type Props = {
   label: string,
   value: string,
   handleInput: (event: Event) => void,
+  id: string,
   name: ?string,
   type: ?string,
   pattern: ?string,
@@ -140,6 +141,7 @@ const TextInput = forwardRef(
       label,
       type,
       value,
+      id,
       name,
       pattern,
       required,
@@ -174,11 +176,12 @@ const TextInput = forwardRef(
           hasErrorBorder={!isValid && showValidity}
           big={big}
         >
-          <TextInputLabel isEnhanced={isEnhanced} hasValue={!!value}>
+          <TextInputLabel isEnhanced={isEnhanced} hasValue={!!value} for={id}>
             {label}
           </TextInputLabel>
           <TextInputInput
             ref={ref}
+            id={id}
             name={name}
             required={required}
             value={value}

--- a/common/views/components/TextInput/TextInput.js
+++ b/common/views/components/TextInput/TextInput.js
@@ -94,6 +94,7 @@ const TextInputInput = styled.input.attrs(props => ({
 `;
 
 const TextInputCheckmark = styled.span.attrs({
+  'data-test-id': 'TextInputCheckmark',
   className: classNames({
     absolute: true,
   }),
@@ -105,6 +106,7 @@ const TextInputCheckmark = styled.span.attrs({
 `;
 
 const TextInputErrorMessage = styled.span.attrs({
+  'data-test-id': 'TextInputErrorMessage',
   className: classNames({
     'font-hnm': true,
   }),

--- a/common/views/components/TextInput/TextInput.js
+++ b/common/views/components/TextInput/TextInput.js
@@ -39,7 +39,7 @@ const TextInputLabel = styled.label.attrs({
   top: 50%;
   left: 15px;
   transform: translateY(-50%);
-  font-size: 16px;
+  font-size: inherit;
   transition: top 125ms ease-in, font-size 125ms ease-in,
     transform 125ms ease-in;
   pointer-events: none;
@@ -159,6 +159,7 @@ const TextInput = forwardRef(
             {label}
           </TextInputLabel>
           <TextInputInput
+            ref={ref}
             required={required}
             value={value}
             pattern={pattern}

--- a/common/views/components/TextInput/TextInput.js
+++ b/common/views/components/TextInput/TextInput.js
@@ -120,7 +120,7 @@ const TextInputErrorMessage = styled.span.attrs({
 type Props = {
   label: string,
   value: string,
-  handleChange: (event: Event) => void,
+  setValue: (value: string) => void,
   id: string,
   name: ?string,
   type: ?string,
@@ -143,12 +143,12 @@ const TextInput = forwardRef(
       label,
       type,
       value,
+      setValue,
       id,
       name,
       pattern,
       required,
       errorMessage,
-      handleChange,
       isValid,
       setIsValid,
       showValidity,
@@ -163,7 +163,7 @@ const TextInput = forwardRef(
     function onChange(event) {
       const isValueValid = event.currentTarget.validity.valid;
 
-      handleChange(event);
+      setValue(event.currentTarget.value);
       setIsValid && setIsValid(isValueValid);
 
       if (isValueValid && setShowValidity) {

--- a/common/views/components/TextInput/TextInput.js
+++ b/common/views/components/TextInput/TextInput.js
@@ -13,6 +13,8 @@ const TextInputWrap = styled.div.attrs({
   font-size: ${props => (props.big ? '20px' : '16px')};
 
   &:focus-within {
+    box-shadow: 0 0 0 3px rgba(92, 184, 191, 0.7); // turquoise @ 0.7 opacity
+
     label {
       font-size: 14px;
       transform: translateY(0%);
@@ -80,6 +82,7 @@ const TextInputInput = styled.input.attrs(props => ({
 
   &:focus {
     outline: 0;
+    border-color: ${props => props.theme.colors.turquoise};
   }
 
   &:-ms-clear {
@@ -89,7 +92,10 @@ const TextInputInput = styled.input.attrs(props => ({
   ${props =>
     props.hasErrorBorder &&
     `
-      border-color: ${props.theme.colors.red};
+      &,
+      &:focus {
+        border-color: ${props.theme.colors.red};
+      }
     `}
 `;
 

--- a/common/views/components/TextInput/TextInput.js
+++ b/common/views/components/TextInput/TextInput.js
@@ -3,21 +3,20 @@ import { forwardRef, useContext } from 'react';
 import styled from 'styled-components';
 import Icon from '../Icon/Icon';
 import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
-// import Space, { type SpaceComponentProps } from '../styled/Space';
 import { classNames } from '../../../utils/classnames';
-
-const TextInputContainer = styled.div``;
 
 const TextInputWrap = styled.div.attrs({
   className: classNames({
     'flex relative': true,
   }),
 })`
+  font-size: ${props => (props.big ? '20px' : '16px')};
+
   &:focus-within {
     label {
       font-size: 14px;
       transform: translateY(0%);
-      top: 7px;
+      top: 4px;
     }
   }
   overflow: hidden;
@@ -35,11 +34,22 @@ const TextInputLabel = styled.label.attrs({
     absolute: true,
   }),
 })`
+  /* Styles for browsers that don't support :focus-within (<=IE11) */
+  font-size: 14px;
+  transform: translateY(0%);
+  top: 4px;
+
+  /* IE doesn't support :focus-within, but you can't test for :focus-within
+  using @supports. Fortunately, IE doesn't support @supports, so this only
+  targets browsers that support @suports (> IE11) */
+  @supports (display: block) {
+    font-size: inherit;
+    transform: translateY(-50%);
+    top: 50%;
+  }
+
   white-space: nowrap;
-  top: 50%;
   left: 15px;
-  transform: translateY(-50%);
-  font-size: inherit;
   transition: top 125ms ease-in, font-size 125ms ease-in,
     transform 125ms ease-in;
   pointer-events: none;
@@ -48,16 +58,18 @@ const TextInputLabel = styled.label.attrs({
   ${props =>
     (!props.isEnhanced || props.hasValue) &&
     `
-      top: 7px;
+    @supports (display: block) {
+      top: 4px;
       transform: translateY(0);
       font-size: 14px;
+    }
   `}
 `;
 
 const TextInputInput = styled.input.attrs(props => ({
   type: props.type || 'text',
 }))`
-  padding: 25px 10px 10px 15px;
+  padding: 27px 40px 8px 15px;
   appearance: none;
   border: 0;
   height: 100%;
@@ -70,11 +82,15 @@ const TextInputInput = styled.input.attrs(props => ({
     outline: 0;
   }
 
+  &:-ms-clear {
+    display: none;
+  }
+
   ${props =>
     props.hasErrorBorder &&
     `
-  border-color: ${props.theme.colors.red};
-  `}
+      border-color: ${props.theme.colors.red};
+    `}
 `;
 
 const TextInputCheckmark = styled.span.attrs({
@@ -101,19 +117,20 @@ const TextInputErrorMessage = styled.span.attrs({
 
 type Props = {
   label: string,
-  pattern: ?string,
-  name: ?string,
-  required: ?boolean,
-  type: ?string,
-  placeholder: ?string,
-  errorMessage: ?string,
   value: string,
   handleInput: (event: Event) => void,
-  isValid: boolean,
-  setIsValid: (value: boolean) => void,
-  showValidity: boolean,
-  setShowValidity: (value: boolean) => void,
-  // We can also pass inputProps here
+  name: ?string,
+  type: ?string,
+  pattern: ?string,
+  required: ?boolean,
+  placeholder: ?string,
+  errorMessage: ?string,
+  isValid: ?boolean,
+  setIsValid: ?(value: boolean) => void,
+  showValidity: ?boolean,
+  setShowValidity: ?(value: boolean) => void,
+  autoFocus: ?boolean,
+  big: ?boolean,
 };
 
 // $FlowFixMe (forwardRef)
@@ -132,7 +149,8 @@ const TextInput = forwardRef(
       setIsValid,
       showValidity,
       setShowValidity,
-      ...inputProps
+      autoFocus,
+      big,
     }: Props,
     ref // eslint-disable-line
   ) => {
@@ -140,18 +158,22 @@ const TextInput = forwardRef(
 
     function onInput(event) {
       handleInput(event);
-      setIsValid(event.currentTarget.validity.valid);
-      setShowValidity(false);
+      setIsValid && setIsValid(event.currentTarget.validity.valid);
+      setShowValidity && setShowValidity(false);
     }
 
     function onBlur(event) {
-      setIsValid(event.currentTarget.validity.valid);
-      setShowValidity(!!value && true);
+      setIsValid && setIsValid(event.currentTarget.validity.valid);
+      setShowValidity && setShowValidity(!!value && true);
     }
 
     return (
-      <TextInputContainer>
-        <TextInputWrap value={value} hasErrorBorder={!isValid && showValidity}>
+      <div>
+        <TextInputWrap
+          value={value}
+          hasErrorBorder={!isValid && showValidity}
+          big={big}
+        >
           <TextInputLabel isEnhanced={isEnhanced} hasValue={!!value}>
             {label}
           </TextInputLabel>
@@ -165,6 +187,7 @@ const TextInput = forwardRef(
             onBlur={onBlur}
             hasErrorBorder={!isValid && showValidity}
             type={type}
+            autoFocus={autoFocus}
           />
           {isValid && showValidity && (
             <TextInputCheckmark>
@@ -175,7 +198,7 @@ const TextInput = forwardRef(
         {errorMessage && !isValid && showValidity && (
           <TextInputErrorMessage>{errorMessage}</TextInputErrorMessage>
         )}
-      </TextInputContainer>
+      </div>
     );
   }
 );

--- a/common/views/themes/default.js
+++ b/common/views/themes/default.js
@@ -59,6 +59,8 @@ const theme = {
     inherit: 'inherit',
     currentColor: 'currentColor',
   },
+  // Keyboard focus uses a hard box shadow of 0.7 opacity 'turquoise'
+  focusBoxShadow: '0 0 0 3px rgba(92, 184, 191, 0.7)',
   keyframes: {
     hoverBounce: keyframes`
       0% {


### PR DESCRIPTION
![textinput](https://user-images.githubusercontent.com/1394592/78804865-95a84e00-79b8-11ea-9bb6-c822263ea4fc.gif)

## Who is this for?
Site users

## What is it doing for them?
Giving them a better input element

__TODO__
- [x] Green checkmark doesn't match the one in Zeplin (it's not yet in our palette). Spoke with @GarethOrmerod and opted to use `green` until we re-assess/update use of greenish colours in the palette.
- [x] I'm wondering whether some of the validation logic can be moved to a hook, but it's not quite clear to me how yet
- [x] Tests
- [x] Focus state
- [ ] The font-size and padding values are set to be the same across all breakpoints – this means that buttons running inline have to be set to the input height. Responsive consideration needed.

__Focus__
![image](https://user-images.githubusercontent.com/1394592/79548624-9f534500-808d-11ea-8010-ede41cc59ea0.png)
