### PR TITLE
Add turquoise border to focused links

### DIFF
--- a/common/styles/base/_typography.scss
+++ b/common/styles/base/_typography.scss
@@ -163,9 +163,11 @@ a {
     text-decoration: none;
   }
 
-  &:focus {
-    outline: 0;
-    box-shadow: 0 0 0 3px rgba(92, 184, 191, 0.7);
+  .is-keyboard & {
+    &:focus {
+      outline: 0;
+      box-shadow: 0 0 0 3px rgba(92, 184, 191, 0.7);
+    }
   }
 }
 

--- a/common/styles/base/_typography.scss
+++ b/common/styles/base/_typography.scss
@@ -162,6 +162,11 @@ a {
   &:hover {
     text-decoration: none;
   }
+
+  &:focus {
+    outline: 0;
+    box-shadow: 0 0 0 3px rgba(92, 184, 191, 0.7);
+  }
 }
 
 p {

--- a/common/views/components/AppContext/AppContext.js
+++ b/common/views/components/AppContext/AppContext.js
@@ -33,10 +33,16 @@ export const AppContextProvider = ({ children }: AppContextProviderProps) => {
   }, []);
 
   function setIsKeyboardFalse() {
+    document &&
+      document.documentElement &&
+      document.documentElement.classList.remove('is-keyboard');
     setIsKeyboard(false);
   }
 
   function setIsKeyboardTrue() {
+    document &&
+      document.documentElement &&
+      document.documentElement.classList.add('is-keyboard');
     setIsKeyboard(true);
   }
 

--- a/common/views/pages/_document.js
+++ b/common/views/pages/_document.js
@@ -15,7 +15,7 @@ export default function WeDoc(css: string) {
 
     render() {
       return (
-        <html id="top" lang="en">
+        <html id="top" lang="en" className="is-keyboard">
           <Head>
             {/* Google Tag Manager */}
             <script


### PR DESCRIPTION
## Who is this for?
People who like consistent link focus styles

## What is it doing for them?
Adding a turquoise border to all links when focused

In draft [while we consider whether we want these styles to always apply, or only with keyboard focus](https://github.com/wellcomecollection/wellcomecollection.org/issues/4946#issuecomment-615308773)

[Decision made on focus styles](https://github.com/wellcomecollection/wellcomecollection.org/issues/4946#issuecomment-616573719) is to apply turquoise-border focus state to links and buttons only when accessed via the keyboard.