### PR TITLE
Update TextInput on /newsletter page

### DIFF
--- a/common/hooks/useValidation.js
+++ b/common/hooks/useValidation.js
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-const useValidation = (initIsValid = true, initShowValidity = false) => {
+const useValidation = (initIsValid = false, initShowValidity = false) => {
   const [isValid, setIsValid] = useState(initIsValid);
   const [showValidity, setShowValidity] = useState(initShowValidity);
 

--- a/common/views/components/NewsletterSignup/NewsletterSignup.js
+++ b/common/views/components/NewsletterSignup/NewsletterSignup.js
@@ -4,6 +4,7 @@ import TextInput from '@weco/common/views/components/TextInput/TextInput';
 import CheckboxRadio from '@weco/common/views/components/CheckboxRadio/CheckboxRadio';
 import { font, classNames } from '../../../utils/classnames';
 import Space from '../styled/Space';
+import useValidation from '../../../hooks/useValidation';
 
 type Props = {|
   isSuccess?: boolean,
@@ -37,10 +38,11 @@ const addressBooks = [
 
 const NewsletterSignup = ({ isSuccess, isError, isConfirmed }: Props) => {
   const [checkedInputs, setCheckedInputs] = useState([]);
-  const [isEmailError, setIsEmailError] = useState(true);
   const [isCheckboxError, setIsCheckboxError] = useState(true);
   const [noValidate, setNoValidate] = useState(false);
   const [isSubmitAttempted, setIsSubmitAttempted] = useState(false);
+  const [emailValue, setEmailValue] = useState('');
+  const emailValidation = useValidation();
 
   function updateCheckedInputs(event: SyntheticEvent<HTMLInputElement>) {
     const isChecked = event.currentTarget.checked;
@@ -53,14 +55,16 @@ const NewsletterSignup = ({ isSuccess, isError, isConfirmed }: Props) => {
     setIsCheckboxError(newInputs.length === 0);
   }
 
-  function handleEmailInput(event: SyntheticEvent<HTMLInputElement>) {
-    setIsEmailError(!event.currentTarget.validity.valid);
-  }
-
   function handleSubmit(event: SyntheticEvent<HTMLFormElement>) {
     event.preventDefault();
+
     setIsSubmitAttempted(true);
-    if (!isCheckboxError && !isEmailError) {
+
+    emailValidation.setShowValidity(true);
+
+    if (!emailValidation.isValid) return;
+
+    if (!isCheckboxError) {
       event.currentTarget.submit();
     }
   }
@@ -166,8 +170,12 @@ const NewsletterSignup = ({ isSuccess, isError, isConfirmed }: Props) => {
               placeholder="Your email address"
               name="Email"
               type="email"
-              onChange={handleEmailInput}
-              required
+              required={true}
+              big={true}
+              value={emailValue}
+              setValue={setEmailValue}
+              errorMessage={`Enter a valid email address.`}
+              {...emailValidation}
             />
           </Space>
 
@@ -217,25 +225,6 @@ const NewsletterSignup = ({ isSuccess, isError, isConfirmed }: Props) => {
           <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
             <button className="btn btn--primary">Subscribe</button>
           </Space>
-
-          {isEmailError && isSubmitAttempted && (
-            <Space
-              as="p"
-              v={{
-                size: 's',
-                properties: [
-                  'padding-top',
-                  'padding-bottom',
-                  'margin-top',
-                  'margin-bottom',
-                ],
-              }}
-              h={{ size: 'm', properties: ['padding-left', 'padding-right'] }}
-              className={`border-width-1 border-color-red font-red`}
-            >
-              Please enter a valid email address.
-            </Space>
-          )}
 
           {isCheckboxError && isSubmitAttempted && (
             <Space


### PR DESCRIPTION
## Who is this for?
Anyone who wants consistent text inputs.

## What is it doing for them?
Using the same email validation `TextInput` on the `/newsletter` page as appears in the `NewsletterPromo`.

![image](https://user-images.githubusercontent.com/1394592/79773170-fcb6f280-8328-11ea-8557-3db8ccdc0e73.png)
