### PR TITLE
Update checkbox and radio hover/focus states in line with designs

### DIFF
--- a/common/views/components/CheckboxRadio/CheckboxRadio.js
+++ b/common/views/components/CheckboxRadio/CheckboxRadio.js
@@ -11,7 +11,9 @@ const CheckboxRadioLabel = styled.label.attrs({
   className: classNames({
     'flex-inline flex--v-center': true,
   }),
-})``;
+})`
+  cursor: pointer;
+`;
 
 const CheckboxRadioBox = styled.span.attrs({
   className: classNames({
@@ -48,8 +50,16 @@ const CheckboxRadioInput = styled.input.attrs(props => ({
     }
   }
 
-  &:focus ~ ${CheckboxRadioBox} {
-    border-color: ${props => !props.hideFocus && props.theme.colors.black};
+  &:hover ~ ${CheckboxRadioBox} {
+    border-color: ${props => props.theme.colors.black};
+  }
+
+  .is-keyboard & {
+    &:focus ~ ${CheckboxRadioBox} {
+      outline: 0;
+      box-shadow: ${props => props.theme.focusBoxShadow};
+      border-color: ${props => props.theme.colors.black};
+    }
   }
 `;
 


### PR DESCRIPTION
☝️ 

Relates to #4946.


Question for @GarethOrmerod about whether or not the `border-color` and `box-shadow` should transition (which they are doing currently). If so, then should we update these properties for the other `:focus` states (links and buttons) to transition as well?

[Zeplin designs/rationale](https://app.zeplin.io/project/5aab926b4b6efde01259e959/screen/5ea1a9620e1d577b0a1e8dac)
