### PR TITLE
Use work links on Collections

### DIFF
--- a/common/views/components/Collection/Collection.js
+++ b/common/views/components/Collection/Collection.js
@@ -7,6 +7,7 @@ import styled from 'styled-components';
 import Space from '@weco/common/views/components/styled/Space';
 import Layout12 from '@weco/common/views/components/Layout12/Layout12';
 import { classNames } from '@weco/common/utils/classnames';
+import { workLink } from '@weco/common/services/catalogue/routes';
 
 type childProps = {| child: any, currentWorkId: string |};
 const Child = ({ child, currentWorkId }: childProps) => {
@@ -16,7 +17,7 @@ const Child = ({ child, currentWorkId }: childProps) => {
       id={child.work ? `collection-${child.work.id}` : ''}
     >
       {child.work && (
-        <NextLink href={`/works/${child.work.id}#collection-${child.work.id}`}>
+        <NextLink {...workLink({ id: child.work.id })} scroll={false}>
           <a
             className="plain-link"
             style={{
@@ -92,7 +93,7 @@ const Collection = ({ work }: Props) => {
     fetch(url)
       .then(resp => resp.json())
       .then(resp => setCollection(resp.collection));
-  }, []);
+  }, [work.id]);
 
   return collection ? (
     <CollectionContainer>

--- a/common/views/components/CollectionSearch/CollectionSearch.js
+++ b/common/views/components/CollectionSearch/CollectionSearch.js
@@ -4,6 +4,7 @@ import NextLink from 'next/link';
 import fetch from 'isomorphic-unfetch';
 import styled from 'styled-components';
 import Space from '../styled/Space';
+import { workLink } from '../../../services/catalogue/routes';
 
 const Container = styled(Space).attrs({
   h: {
@@ -40,7 +41,7 @@ const CollectionSearch = ({ query }: Props) => {
       {collections &&
         collections.results.map(work => {
           return (
-            <NextLink key={work.id} href={`/works/${work.id}`}>
+            <NextLink key={work.id} {...workLink({ id: work.id })}>
               <a
                 className="plain-link"
                 style={{


### PR DESCRIPTION
~I'm going to dig into why this fixes an issue when we hover over it as previously done, it tries to load `pages/works/[id].js`...~

☝️ is not true.

Just needed to use the `workLink`. Removed the scroll so you stay on the same part of the page.