### PR TITLE
Allow expanded of collections without selecting works

### DIFF
--- a/common/views/components/Collection/Collection.js
+++ b/common/views/components/Collection/Collection.js
@@ -9,7 +9,7 @@ import Layout12 from '@weco/common/views/components/Layout12/Layout12';
 import { classNames } from '@weco/common/utils/classnames';
 import { workLink } from '@weco/common/services/catalogue/routes';
 
-type childProps = {|
+type ChildProps = {|
   child: any,
   currentWorkPath: string,
   expandedPaths: string[],

--- a/common/views/components/Collection/Collection.js
+++ b/common/views/components/Collection/Collection.js
@@ -20,7 +20,7 @@ const Child = ({
   currentWorkPath,
   expandedPaths,
   setExpandedPaths,
-}: childProps) => {
+}: ChildProps) => {
   const isExpanded = child.children || expandedPaths.includes(child.path.path);
   const canToggleExpanded = !currentWorkPath.startsWith(child.path.path);
   return (


### PR DESCRIPTION
Just a small update to @jamesgorrie `Collection` component. Doubt this will make it through to the final user interface but wanted to display more of the functionality the current API offers (letting the user explore more of the archive without actually changing what work is selected).

![2020-04-30-123557_2444x1708_scrot](https://user-images.githubusercontent.com/921101/80705882-2e754980-8adf-11ea-8482-444a842b5cde.png)
