### PR TITLE
Viewer bug

### DIFF
--- a/common/hooks/useOnScreen.js
+++ b/common/hooks/useOnScreen.js
@@ -7,11 +7,25 @@ export default function useOnScreen({
   threshold = 0,
 }) {
   const [isIntersecting, setIsIntersecting] = useState(false);
-
   useEffect(() => {
     const observer = new window.IntersectionObserver(
       ([entry]) => {
-        setIsIntersecting(entry.isIntersecting);
+        if (entry.isIntersecting) {
+          const midPointOfRoot =
+            entry.rootBounds.top + entry.rootBounds.height / 2;
+          const targetTop = entry.boundingClientRect.top;
+          const targetBottom = entry.boundingClientRect.bottom;
+          const topPassedMidPoint = targetTop < midPointOfRoot;
+          const bottomPassedMidPoint = targetBottom < midPointOfRoot;
+          if (topPassedMidPoint && !bottomPassedMidPoint) {
+            setIsIntersecting(true);
+          }
+          if (topPassedMidPoint && bottomPassedMidPoint) {
+            setIsIntersecting(false);
+          }
+        } else {
+          setIsIntersecting(false);
+        }
       },
       {
         root,

--- a/common/views/components/IIIFViewer/parts/GridViewer.js
+++ b/common/views/components/IIIFViewer/parts/GridViewer.js
@@ -1,7 +1,7 @@
 // @flow
 import styled from 'styled-components';
 import { useState, memo, useEffect, useRef } from 'react';
-import { FixedSizeGrid, areEqual } from 'react-window';
+import { FixedSizeGrid, FixedSizeList, areEqual } from 'react-window';
 import useScrollVelocity from '@weco/common/hooks/useScrollVelocity';
 import LL from '@weco/common/views/components/styled/LL';
 import IIIFCanvasThumbnail from './IIIFCanvasThumbnail';
@@ -84,7 +84,7 @@ type Props = {|
   gridWidth: number,
   gridVisible: boolean,
   gridViewerRef: { current: HTMLElement | null },
-  mainViewerRef: { current: HTMLElement | null },
+  mainViewerRef: { current: FixedSizeList | null },
   setGridVisible: boolean => void,
   activeIndex: number,
   setActiveIndex: number => void,

--- a/common/views/components/IIIFViewer/parts/MainViewer.js
+++ b/common/views/components/IIIFViewer/parts/MainViewer.js
@@ -128,7 +128,7 @@ const ItemRenderer = memo(({ style, index, data }) => {
 
 type Props = {|
   listHeight: number,
-  mainViewerRef: any,
+  mainViewerRef: { current: HTMLElement | null },
   setActiveIndex: number => void,
   pageWidth: number,
   canvases: [],
@@ -216,6 +216,7 @@ const MainViewer = ({
         setActiveIndex,
         setIsLoading,
         ocrText,
+        mainViewerRef,
       }}
       itemSize={itemHeight}
       onItemsRendered={debounceHandleOnItemsRendered.current}

--- a/common/views/components/IIIFViewer/parts/MainViewer.js
+++ b/common/views/components/IIIFViewer/parts/MainViewer.js
@@ -128,7 +128,7 @@ const ItemRenderer = memo(({ style, index, data }) => {
 
 type Props = {|
   listHeight: number,
-  mainViewerRef: any,
+  mainViewerRef: { current: FixedSizeList | null },
   setActiveIndex: number => void,
   pageWidth: number,
   canvases: [],

--- a/common/views/components/IIIFViewer/parts/MainViewer.js
+++ b/common/views/components/IIIFViewer/parts/MainViewer.js
@@ -128,7 +128,7 @@ const ItemRenderer = memo(({ style, index, data }) => {
 
 type Props = {|
   listHeight: number,
-  mainViewerRef: { current: HTMLElement | null },
+  mainViewerRef: any,
   setActiveIndex: number => void,
   pageWidth: number,
   canvases: [],

--- a/common/views/components/IIIFViewer/parts/ThumbsViewer.js
+++ b/common/views/components/IIIFViewer/parts/ThumbsViewer.js
@@ -59,7 +59,7 @@ const ItemRenderer = memo(({ style, index, data }) => {
 
 type Props = {|
   listHeight: number,
-  mainViewerRef: { current: HTMLElement | null },
+  mainViewerRef: { current: FixedSizeList | null },
   activeIndex: number,
   setActiveIndex: number => void,
   canvases: any,

--- a/common/views/components/ImageViewer/ImageViewer.js
+++ b/common/views/components/ImageViewer/ImageViewer.js
@@ -13,8 +13,6 @@ const ImageWrapper = styled.div`
   bottom: 0;
   right: 0;
   padding: 0;
-  transition: opacity 1000ms ease;
-  opacity: ${props => (props.imageLoading ? 0 : 1)};
   img {
     cursor: pointer;
     margin: auto;
@@ -43,7 +41,7 @@ type ImageViewerProps = {|
   setActiveIndex?: number => void,
   rotation: number,
   loadHandler?: Function,
-  mainViewerRef?: ?HTMLElement,
+  mainViewerRef?: any,
   index?: number,
 |};
 
@@ -65,9 +63,9 @@ const ImageViewer = ({
 }: ImageViewerProps) => {
   const imageViewer = useRef();
   const isOnScreen = useOnScreen({
-    root: mainViewerRef,
+    root: mainViewerRef && mainViewerRef._outerRef,
     ref: imageViewer,
-    threshold: 0.1,
+    threshold: [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9],
   });
   const [imageSrc, setImageSrc] = useState(urlTemplate({ size: '640,' }));
   const [imageSrcSet, setImageSrcSet] = useState(

--- a/common/views/components/ImageViewer/ImageViewer.js
+++ b/common/views/components/ImageViewer/ImageViewer.js
@@ -1,6 +1,7 @@
 // @flow
 import { useState, useEffect, useRef } from 'react';
 import styled from 'styled-components';
+import { FixedSizeList } from 'react-window';
 import { type IIIFUriProps } from '@weco/common/utils/convert-image-uri';
 import { imageSizes } from '../../../utils/image-sizes';
 import IIIFResponsiveImage from '../IIIFResponsiveImage/IIIFResponsiveImage';
@@ -41,7 +42,7 @@ type ImageViewerProps = {|
   setActiveIndex?: number => void,
   rotation: number,
   loadHandler?: Function,
-  mainViewerRef?: any,
+  mainViewerRef?: FixedSizeList,
   index?: number,
 |};
 

--- a/common/views/components/ImageViewer/ImageViewer.js
+++ b/common/views/components/ImageViewer/ImageViewer.js
@@ -61,7 +61,7 @@ const ImageViewer = ({
   rotation,
   loadHandler,
   mainViewerRef,
-  index,
+  index = 0,
 }: ImageViewerProps) => {
   const imageViewer = useRef();
   const isOnScreen = useOnScreen({
@@ -82,8 +82,8 @@ const ImageViewer = ({
       .join(',')
   );
   useEffect(() => {
-    if (setActiveIndex && index && isOnScreen) {
-      setActiveIndex && setActiveIndex(index);
+    if (setActiveIndex && isOnScreen) {
+      setActiveIndex(index);
       setZoomInfoUrl && setZoomInfoUrl(infoUrl);
     }
   }, [isOnScreen]);


### PR DESCRIPTION
Fixes #5269

Uses the top and bottom positions of the target element, relative to the mid point of the root element, in combination with the isIntersecting value to determine which image should be considered to be 'current'. Previously it was only using isIntersecting, with a 10% threshold. 