### PR TITLE
order dates before finding the last one

### DIFF
--- a/common/services/prismic/events.js
+++ b/common/services/prismic/events.js
@@ -9,6 +9,7 @@ import type {
 import type { Team } from '../../model/team';
 import Prismic from 'prismic-javascript';
 import sortBy from 'lodash.sortby';
+import moment from 'moment';
 import { getDocument, getTypeByIds, getDocuments } from './api';
 import {
   eventAccessOptionsFields,
@@ -163,9 +164,16 @@ export function parseEventDoc(
     [];
 
   const displayTime = determineDisplayTime(times);
-  const lastEndTime = times
-    .map(time => time.range.endDateTime)
-    .find((date, i) => i === times.length - 1);
+  const lastEndTime =
+    data.times &&
+    data.times
+      .sort(
+        (x, y) => moment(x.endDateTime).unix() - moment(y.endDateTime).unix()
+      )
+      .map(time => {
+        return parseTimestamp(time.endDateTime);
+      })
+      .find((date, i) => i === times.length - 1);
   const isRelaxedPerformance = parseBoolean(data.isRelaxedPerformance);
 
   const schedule = eventSchedule.map((event, i) => {

--- a/common/services/prismic/events.js
+++ b/common/services/prismic/events.js
@@ -168,12 +168,11 @@ export function parseEventDoc(
     data.times &&
     data.times
       .sort(
-        (x, y) => moment(x.endDateTime).unix() - moment(y.endDateTime).unix()
+        (x, y) => moment(y.endDateTime).unix() - moment(x.endDateTime).unix()
       )
       .map(time => {
         return parseTimestamp(time.endDateTime);
-      })
-      .find((date, i) => i === times.length - 1);
+      })[0];
   const isRelaxedPerformance = parseBoolean(data.isRelaxedPerformance);
 
   const schedule = eventSchedule.map((event, i) => {


### PR DESCRIPTION
Fixes #5276

- the order that event dates are entered into Prismic shouldn’t determine which one determines the latest date of the event
