### PR TITLE
Reduce min_ttl for assets at /_next/

### DIFF
--- a/cache/cloudfront_prod.tf
+++ b/cache/cloudfront_prod.tf
@@ -151,16 +151,9 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
     allowed_methods        = ["HEAD", "GET"]
     cached_methods         = ["HEAD", "GET"]
     viewer_protocol_policy = "redirect-to-https"
-    min_ttl                = 86400
+    min_ttl                = 0
     default_ttl            = 86400
     max_ttl                = 31536000
-
-    custom_error_response = [
-      {
-        error_caching_min_ttl = "0"
-        error_code            = "404"
-      }
-    ]
 
     forwarded_values {
       headers      = ["Host"]

--- a/cache/cloudfront_prod.tf
+++ b/cache/cloudfront_prod.tf
@@ -151,7 +151,7 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
     allowed_methods        = ["HEAD", "GET"]
     cached_methods         = ["HEAD", "GET"]
     viewer_protocol_policy = "redirect-to-https"
-    min_ttl                = 86400
+    min_ttl                = 0
     default_ttl            = 86400
     max_ttl                = 31536000
 

--- a/cache/cloudfront_prod.tf
+++ b/cache/cloudfront_prod.tf
@@ -151,9 +151,16 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
     allowed_methods        = ["HEAD", "GET"]
     cached_methods         = ["HEAD", "GET"]
     viewer_protocol_policy = "redirect-to-https"
-    min_ttl                = 0
+    min_ttl                = 86400
     default_ttl            = 86400
     max_ttl                = 31536000
+
+    custom_error_response = [
+      {
+        error_caching_min_ttl = "0"
+        error_code            = "404"
+      }
+    ]
 
     forwarded_values {
       headers      = ["Host"]

--- a/cache/cloudfront_stage.tf
+++ b/cache/cloudfront_stage.tf
@@ -121,16 +121,9 @@ resource "aws_cloudfront_distribution" "stage_wc_org" {
     allowed_methods        = ["HEAD", "GET"]
     cached_methods         = ["HEAD", "GET"]
     viewer_protocol_policy = "redirect-to-https"
-    min_ttl                = 86400
+    min_ttl                = 0
     default_ttl            = 86400
     max_ttl                = 31536000
-
-    custom_error_response = [
-      {
-        error_caching_min_ttl = "0"
-        error_code            = "404"
-      }
-    ]
 
     forwarded_values {
       headers      = ["Host"]

--- a/cache/cloudfront_stage.tf
+++ b/cache/cloudfront_stage.tf
@@ -121,9 +121,16 @@ resource "aws_cloudfront_distribution" "stage_wc_org" {
     allowed_methods        = ["HEAD", "GET"]
     cached_methods         = ["HEAD", "GET"]
     viewer_protocol_policy = "redirect-to-https"
-    min_ttl                = 0
+    min_ttl                = 86400
     default_ttl            = 86400
     max_ttl                = 31536000
+
+    custom_error_response = [
+      {
+        error_caching_min_ttl = "0"
+        error_code            = "404"
+      }
+    ]
 
     forwarded_values {
       headers      = ["Host"]

--- a/cache/cloudfront_stage.tf
+++ b/cache/cloudfront_stage.tf
@@ -121,7 +121,7 @@ resource "aws_cloudfront_distribution" "stage_wc_org" {
     allowed_methods        = ["HEAD", "GET"]
     cached_methods         = ["HEAD", "GET"]
     viewer_protocol_policy = "redirect-to-https"
-    min_ttl                = 86400
+    min_ttl                = 0
     default_ttl            = 86400
     max_ttl                = 31536000
 


### PR DESCRIPTION
## Who is this for?
People who like the site's client-side JS to work immediately after it's been deployed.

## What is it doing for them?
Reducing the time with CloudFront caches errors ([docs](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/custom-error-pages-expiration.html)).
