### PR TITLE
Add explicit template provider version for catalogue terraform stack

### DIFF
--- a/catalogue/terraform/provider.tf
+++ b/catalogue/terraform/provider.tf
@@ -7,6 +7,10 @@ provider "aws" {
   version = "~> 2.47.0"
 }
 
+provider "template" {
+  version = "~> 2.1"
+}
+
 provider "aws" {
   alias = "platform"
 


### PR DESCRIPTION
This provider existed in other stacks but not in the catalogue one, and without it Terraform was fetching a later version and getting upset