### PR TITLE
Style breadcrumbs

### DIFF
--- a/common/views/components/ArchiveBreadcrumb/ArchiveBreadcrumb.js
+++ b/common/views/components/ArchiveBreadcrumb/ArchiveBreadcrumb.js
@@ -27,16 +27,9 @@ const ArchiveBreadcrumbNav = styled.nav`
 
   li {
     .crumb-inner {
-      text-decoration: none;
       display: flex;
       align-items: baseline;
       padding: 3px 8px;
-      border-radius: 3px;
-    }
-
-    a:hover {
-      background: #333;
-      color: white;
     }
 
     .icon {
@@ -46,16 +39,15 @@ const ArchiveBreadcrumbNav = styled.nav`
     }
 
     position: relative;
-    margin-right: 20px;
+    margin-right: 15px;
 
     &:after {
+      content: '〉';
       position: absolute;
       right: -15px;
       top: 50%;
       transform: translateY(-50%);
-      font-family: monospace;
-      color: #ccc;
-      content: '>';
+      color: #888;
     }
 
     &:last-child {

--- a/common/views/components/ArchiveBreadcrumb/ArchiveBreadcrumb.js
+++ b/common/views/components/ArchiveBreadcrumb/ArchiveBreadcrumb.js
@@ -22,7 +22,7 @@ const ArchiveBreadcrumbNav = styled.nav`
     margin: 0 0 10px;
     padding: 0;
     display: inline-flex;
-    align-items: center;
+    align-items: flex-start;
   }
 
   li {
@@ -30,23 +30,22 @@ const ArchiveBreadcrumbNav = styled.nav`
       display: flex;
       align-items: baseline;
       padding: 3px 8px;
+      max-width: 35em;
     }
 
-    .icon {
-      margin-right: 5px;
+    > .icon {
       position: relative;
-      top: 2px;
+      top: 5px;
     }
 
     position: relative;
-    margin-right: 15px;
+    margin-right: 24px;
 
     &:after {
-      content: '〉';
+      content: '>';
       position: absolute;
+      top: 3px;
       right: -15px;
-      top: 50%;
-      transform: translateY(-50%);
       color: #888;
     }
 
@@ -58,6 +57,8 @@ const ArchiveBreadcrumbNav = styled.nav`
 
     ul {
       display: block;
+      min-width: max-content;
+      white-space: normal;
 
       li {
         margin-bottom: 1px;
@@ -120,7 +121,11 @@ const ArchiveBreadcrumb = ({ work }: Props) => {
     <ArchiveBreadcrumbNav>
       <ul>
         {breadcrumb.firstCrumb && (
-          <li>
+          <li className={'flex'}>
+            <Icon
+              extraClasses={`icon--match-text icon--currentColor`}
+              name={`archive`}
+            />
             <ConditionalWrapper
               condition={breadcrumb.firstCrumb.work.id !== work.id}
               wrapper={children => (
@@ -134,10 +139,6 @@ const ArchiveBreadcrumb = ({ work }: Props) => {
                   'crumb-inner': breadcrumb.firstCrumb.work.id === work.id,
                 })}
               >
-                <Icon
-                  extraClasses={`icon--match-text icon--currentColor`}
-                  name={`archive`}
-                />
                 {breadcrumb.firstCrumb.work.title}
               </span>
             </ConditionalWrapper>
@@ -145,44 +146,46 @@ const ArchiveBreadcrumb = ({ work }: Props) => {
         )}
         {breadcrumb.middleCrumbs.length > 1 && (
           <li>
-            <DropdownButton label="…">
-              <ul>
-                {breadcrumb.middleCrumbs.map(crumb => {
-                  return (
-                    <li key={crumb.work.id}>
-                      <NextLink {...workLink({ id: crumb.work.id })}>
-                        <a className="crumb-inner">
-                          <Icon
-                            extraClasses={`icon--match-text icon--currentColor`}
-                            name={
-                              crumb.path.level === 'Item'
-                                ? 'document'
-                                : 'folder'
-                            }
-                          />
-                          {crumb.work.title} {crumb.path.label}
-                        </a>
-                      </NextLink>
-                    </li>
-                  );
-                })}
-              </ul>
-            </DropdownButton>
+            <div style={{ position: 'relative', top: '-5px' }}>
+              <DropdownButton label="…">
+                <ul>
+                  {breadcrumb.middleCrumbs.map(crumb => {
+                    return (
+                      <li key={crumb.work.id} className={`flex`}>
+                        <Icon
+                          extraClasses={`icon--match-text icon--currentColor`}
+                          name={
+                            crumb.path.level === 'Item'
+                              ? 'digitalImage'
+                              : 'folder'
+                          }
+                        />
+                        <NextLink {...workLink({ id: crumb.work.id })}>
+                          <a className="crumb-inner">
+                            {crumb.work.title} {crumb.path.label}
+                          </a>
+                        </NextLink>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </DropdownButton>
+            </div>
           </li>
         )}
         {breadcrumb.middleCrumbs.length === 1 && (
           <>
             {breadcrumb.middleCrumbs.map(crumb => {
               return (
-                <li key={crumb.work.id}>
+                <li key={crumb.work.id} className={'flex'}>
+                  <Icon
+                    extraClasses={`icon--match-text icon--currentColor`}
+                    name={
+                      crumb.path.level === 'Item' ? 'digitalImage' : 'folder'
+                    }
+                  />
                   <NextLink {...workLink({ id: crumb.work.id })}>
                     <a className="crumb-inner">
-                      <Icon
-                        extraClasses={`icon--match-text icon--currentColor`}
-                        name={
-                          crumb.path.level === 'Item' ? 'document' : 'folder'
-                        }
-                      />
                       {crumb.work.title} {crumb.path.label}
                     </a>
                   </NextLink>
@@ -192,16 +195,16 @@ const ArchiveBreadcrumb = ({ work }: Props) => {
           </>
         )}
         {breadcrumb.lastCrumb && (
-          <li>
+          <li className={'flex'}>
+            <Icon
+              extraClasses={`icon--match-text icon--currentColor`}
+              name={
+                breadcrumb.lastCrumb.path.level === 'Item'
+                  ? 'digitalImage'
+                  : 'folder'
+              }
+            />
             <span className="crumb-inner">
-              <Icon
-                extraClasses={`icon--match-text icon--currentColor`}
-                name={
-                  breadcrumb.lastCrumb.path.level === 'Item'
-                    ? 'document'
-                    : 'folder'
-                }
-              />
               {breadcrumb.lastCrumb.work.title}{' '}
               {breadcrumb.lastCrumb.path.label}
             </span>

--- a/common/views/components/ArchiveBreadcrumb/ArchiveBreadcrumb.js
+++ b/common/views/components/ArchiveBreadcrumb/ArchiveBreadcrumb.js
@@ -34,6 +34,7 @@ const ArchiveBreadcrumbNav = styled.nav`
     }
 
     > .icon {
+      min-width: 1em;
       position: relative;
       top: 5px;
     }


### PR DESCRIPTION
## Who is this for?
People who like slightly nicer styles for their archive breadcrumbs (especially when archive section/item titles are very long)

![image](https://user-images.githubusercontent.com/1394592/83773320-4874ef80-a67c-11ea-9169-a2882a68a572.png)

## What is it doing for them?
Top-aligning multi-line titles, limiting title line-length and preventing icons from shrinking.
