### PR TITLE
Fix crash when trying to serialize a non-existent drop cap

### DIFF
--- a/common/services/prismic/html-serializers.js
+++ b/common/services/prismic/html-serializers.js
@@ -19,7 +19,7 @@ export const dropCapSerializer: HtmlSerializer = (
   children,
   i
 ) => {
-  if (type === Elements.paragraph && i === 0) {
+  if (type === Elements.paragraph && i === 0 && children[0] !== null) {
     const firstChild = children[0];
     const firstCharacters =
       firstChild.props &&


### PR DESCRIPTION
If there isn't anything to drop-cap, as in the case of `/articles/W03jACYAACUAg5IR`, the serializer crashes. This stops it doing that.