### PR TITLE
show collection search even when the main search has no results

### DIFF
--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -203,7 +203,19 @@ const Works = ({
         </Space>
 
         {!results && <StaticWorksContent />}
-
+        {collectionSearch && !isImageSearch && results && (
+          <div className="container">
+            <div className="grid">
+              <div
+                className={classNames({
+                  [grid({ s: 12, m: 12, l: 12, xl: 12 })]: true,
+                })}
+              >
+                <CollectionSearch query={query} />
+              </div>
+            </div>
+          </div>
+        )}
         {results && results.results.length > 0 && (
           <Fragment>
             <Space v={{ size: 'l', properties: ['padding-top'] }}>
@@ -254,9 +266,6 @@ const Works = ({
               style={{ opacity: loading ? 0 : 1 }}
             >
               <div className="container">
-                {collectionSearch && !isImageSearch && (
-                  <CollectionSearch query={query} />
-                )}
                 {(() => {
                   if (
                     works &&

--- a/common/views/components/CollectionSearch/CollectionSearch.js
+++ b/common/views/components/CollectionSearch/CollectionSearch.js
@@ -14,8 +14,10 @@ const Container = styled(Space).attrs({
   },
   v: { size: 's', properties: ['padding-bottom'] },
 })`
-  background: ${props => props.theme.colors.cream};
-  border-top: 5px solid ${props => props.theme.colors.cyan};
+  border-top: 1px solid ${props => props.theme.colors.cyan};
+  border-bottom: 1px solid ${props => props.theme.colors.cyan};
+  border-left: 1px solid ${props => props.theme.colors.cream};
+  border-right: 1px solid ${props => props.theme.colors.cream};
 `;
 
 type Props = {| query: string |};
@@ -36,8 +38,8 @@ const CollectionSearch = ({ query }: Props) => {
       <h2
         className="h2"
         style={{
-          marginTop: '5px',
-          marginBottom: '15px',
+          marginTop: '10px',
+          marginBottom: '10px',
         }}
       >
         Collections
@@ -49,13 +51,12 @@ const CollectionSearch = ({ query }: Props) => {
               <a
                 className="plain-link"
                 style={{
-                  borderTop: '1px solid #298187',
-                  padding: '5px',
+                  borderTop: '1px solid #e8e8e8',
+                  padding: '10px 0',
                   display: 'block',
                 }}
               >
                 {work.title}
-                <h3 className="font-hnm font-size-4 card-link__title"></h3>
               </a>
             </NextLink>
           );


### PR DESCRIPTION
## Who is this for?
People wanting to see collection results when there are no normal results

## What is it doing for them?
Doesn't hide the collection search if that search would actually yield results

![Screenshot 2020-06-16 at 17 03 03](https://user-images.githubusercontent.com/31692/84798914-6d118580-aff3-11ea-8100-2defa1de98f8.png)
