### PR TITLE
Allow FeaturedCard to have image and copy in reversed locations

### DIFF
--- a/cardigan/stories/components/FeaturedCard.js
+++ b/cardigan/stories/components/FeaturedCard.js
@@ -2,12 +2,13 @@ import { storiesOf } from '@storybook/react';
 import FeaturedCard from '../../../common/views/components/FeaturedCard/FeaturedCard';
 import Readme from '../../../common/views/components/FeaturedCard/README.md';
 import { image } from '../content';
-import { select } from '@storybook/addon-knobs';
+import { select, boolean } from '@storybook/addon-knobs';
 
 const stories = storiesOf('Components', module);
 
 const FeaturedCardExample = () => {
   const imageWithoutTasl = { ...image(), showTasl: false };
+  const isReversed = boolean('is reversed', false);
   const color = select('text colour', ['white', 'black'], 'white');
   const background = select(
     'background colour',
@@ -23,6 +24,7 @@ const FeaturedCardExample = () => {
       link={{ url: '#', text: 'Remote diagnosis from wee to the web' }}
       background={background}
       color={color}
+      isReversed={isReversed}
     >
       <h2 className="font-wb font-size-2">
         Remote diagnosis from wee to the Web

--- a/common/views/components/FeaturedCard/FeaturedCard.js
+++ b/common/views/components/FeaturedCard/FeaturedCard.js
@@ -28,6 +28,7 @@ type Props = {|
   link: Link,
   background: string,
   color: string,
+  isReversed?: boolean,
 |};
 
 function convertItemToFeaturedCardProps(
@@ -182,6 +183,14 @@ const FeaturedCardWrap = styled.div`
   `}
 `;
 
+const FeaturedCardLink = styled.a.attrs(props => ({
+  className: classNames({
+    'grid flex-end promo-link plain-link': true,
+  }),
+}))`
+  flex-direction: ${props => (props.isReversed ? 'row-reverse' : 'row')};
+`;
+
 const FeaturedCardLeft = styled.div.attrs({
   className: classNames({
     [grid({ s: 12, m: 12, l: 7, xl: 7 })]: true,
@@ -193,7 +202,9 @@ const FeaturedCardRight = styled.div.attrs({
     'flex flex--column': true,
   }),
 })`
-  padding-left: ${props => props.theme.gutter.small}px;
+  padding-left: ${props => (props.isReversed ? 0 : props.theme.gutter.small)}px;
+  padding-right: ${props =>
+    props.isReversed ? props.theme.gutter.small : 0}px;
   transform: translateY(-60px);
   width: 100%;
   height: 100%;
@@ -201,10 +212,12 @@ const FeaturedCardRight = styled.div.attrs({
 
   ${props => props.theme.media.medium`
     padding-left: 0;
+    padding-right: 0;
   `}
 
   ${props => props.theme.media.large`
-    margin-left: -${props => props.theme.gutter.large}px;
+    margin-left: ${props =>
+      props.isReversed ? 0 : -props.theme.gutter.large + 'px'};
     transform: translateY(0);
   `}
 `;
@@ -221,6 +234,18 @@ const FeaturedCardCopy = styled(Space).attrs(props => ({
   `}
 `;
 
+const FeaturedCardShim = styled.div.attrs(props => ({
+  className: classNames({
+    [`bg-${props.background}`]: true,
+    'is-hidden-s is-hidden-m': true,
+    [grid({ s: 12, m: 11, l: 5, xl: 5 })]: true,
+  }),
+}))`
+  height: 20px;
+  margin-left: ${props =>
+    props.isReversed ? props.theme.gutter.large + 'px' : null};
+`;
+
 const FeaturedCard = ({
   id,
   image,
@@ -229,12 +254,14 @@ const FeaturedCard = ({
   link,
   color,
   background,
+  isReversed,
 }: Props) => {
   return (
     <div className="container">
       <FeaturedCardWrap>
-        <NextLink href={link.url}>
-          <a
+        <NextLink href={link.url} passHref>
+          <FeaturedCardLink
+            isReversed={isReversed}
             onClick={() => {
               trackEvent({
                 category: 'FeaturedCard',
@@ -242,7 +269,6 @@ const FeaturedCard = ({
                 label: `${id}`,
               });
             }}
-            className="grid flex-end promo-link plain-link"
           >
             <FeaturedCardLeft>
               {image && <UiImage {...image} />}
@@ -253,7 +279,7 @@ const FeaturedCard = ({
                 [grid({ s: 12, m: 11, l: 5, xl: 5 })]: true,
               })}
             >
-              <FeaturedCardRight>
+              <FeaturedCardRight isReversed={isReversed}>
                 {labels && labels.length > 0 && <LabelsList labels={labels} />}
                 <FeaturedCardCopy
                   className={classNames({
@@ -269,15 +295,8 @@ const FeaturedCard = ({
                 [grid({ s: 12, m: 12, l: 7, xl: 7 })]: true,
               })}
             ></div>
-            <div
-              style={{ height: '20px' }}
-              className={classNames({
-                [`bg-${background}`]: true,
-                'is-hidden-s is-hidden-m': true,
-                [grid({ s: 12, m: 11, l: 5, xl: 5 })]: true,
-              })}
-            ></div>
-          </a>
+            <FeaturedCardShim background={background} isReversed={isReversed} />
+          </FeaturedCardLink>
         </NextLink>
       </FeaturedCardWrap>
     </div>


### PR DESCRIPTION
Enabling the copy/image for the `FeaturedCard` to appear on opposite sides to allow for less homogenous appearance especially when e.g. multiple `FeaturedCards` appear on the same page.

![Jun-22-2020 16-08-58](https://user-images.githubusercontent.com/1394592/85303930-0c76c280-b4a3-11ea-9e10-5f78a59c8401.gif)
