### PR TITLE
Filter access status

### DIFF
--- a/common/services/catalogue/api.js
+++ b/common/services/catalogue/api.js
@@ -75,6 +75,7 @@ export const defaultAccessConditions = [
   '!open-with-advisory',
   '!restricted',
   '!closed',
+  '!licensed-resources',
 ];
 export function worksRouteToApiUrlWithDefaults(
   worksRouteProps: WorksRouteProps,

--- a/common/services/catalogue/api.js
+++ b/common/services/catalogue/api.js
@@ -17,6 +17,22 @@ export type CatalogueWorksApiProps = {|
   page: ?number,
   workType: ?(string[]),
   'items.locations.locationType': ?(string[]),
+  'items.locations.accessConditions.status': ?((
+    | 'open'
+    | 'open-with-advisory'
+    | 'restricted'
+    | 'closed'
+    | 'licensed-resources'
+    | 'unavailable'
+    | 'permission-required'
+    | '!open'
+    | '!open-with-advisory'
+    | '!restricted'
+    | '!closed'
+    | '!licensed-resources'
+    | '!unavailable'
+    | '!permission-required'
+  )[]),
   sort: ?string,
   sortOrder: ?string,
   'production.dates.from': ?string,
@@ -55,6 +71,11 @@ export const defaultItemsLocationsLocationType = [
   'iiif-image',
   'iiif-presentation',
 ];
+export const defaultAccessConditions = [
+  '!open-with-advisory',
+  '!restricted',
+  '!closed',
+];
 export function worksRouteToApiUrlWithDefaults(
   worksRouteProps: WorksRouteProps,
   overrides: $Shape<CatalogueWorksApiProps>
@@ -70,6 +91,7 @@ export function worksRouteToApiUrlWithDefaults(
       worksRouteProps.itemsLocationsLocationType.length > 0
         ? worksRouteProps.itemsLocationsLocationType
         : defaultItemsLocationsLocationType,
+    'items.locations.accessConditions.status': defaultAccessConditions,
     sort: worksRouteProps.sort,
     sortOrder: worksRouteProps.sortOrder,
     'production.dates.from': toIsoDateString(

--- a/common/services/catalogue/api.js
+++ b/common/services/catalogue/api.js
@@ -75,7 +75,6 @@ export const defaultAccessConditions = [
   '!open-with-advisory',
   '!restricted',
   '!closed',
-  '!licensed-resources',
 ];
 export function worksRouteToApiUrlWithDefaults(
   worksRouteProps: WorksRouteProps,


### PR DESCRIPTION
## Who is this for?
People who don't want to find works on the website that they can't do anything with

## What is it doing for them?
Removing works with access conditions from search results until we can handle them on the front end

Fixes #5314, references #4529

- filters out 'open with advisory', 'restricted' and 'closed' 