### PR TITLE
Search form button

### DIFF
--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -5,7 +5,8 @@ import Router from 'next/router';
 import styled from 'styled-components';
 import TextInput from '@weco/common/views/components/TextInput/TextInput';
 import Icon from '@weco/common/views/components/Icon/Icon';
-import { classNames, font } from '@weco/common/utils/classnames';
+import ButtonSolid from '@weco/common/views/components/ButtonSolid/ButtonSolid';
+import { classNames } from '@weco/common/utils/classnames';
 import { trackEvent } from '@weco/common/utils/ga';
 import { inputValue, nodeListValueToArray } from '@weco/common/utils/forms';
 import SearchFilters from '@weco/common/views/components/SearchFilters/SearchFilters';
@@ -30,27 +31,20 @@ type Props = {|
 const SearchInputWrapper = styled.div`
   font-size: 20px;
   background: ${props => props.theme.colors.white};
-  margin-right: ${props => 12 * props.theme.spacingUnit}px;
-
-  ${props => props.theme.media.medium`
-    margin-right: ${props => 16 * props.theme.spacingUnit}px;
-  `}
+  margin-right: 80px;
 
   .search-query {
     height: ${props => 10 * props.theme.spacingUnit}px;
   }
 `;
 
-const SearchButtonWrapper = styled.div`
-  height: 60px;
+const SearchButtonWrapper = styled.div.attrs({
+  className: classNames({
+    absolute: true,
+  }),
+})`
   top: 0;
   right: 0;
-  width: ${props => 10 * props.theme.spacingUnit}px;
-  border: ${props => props.theme.borderRadiusUnit}px;
-
-  ${props => props.theme.media.medium`
-    width: ${props => 14 * props.theme.spacingUnit}px;
-  `}
 `;
 
 const ClearSearch = styled.button`
@@ -275,21 +269,13 @@ const SearchForm = ({
           </noscript>
         </>
       )}
-      <SearchButtonWrapper className="absolute bg-green rounded-corners">
-        <button
-          className={classNames({
-            'full-width': true,
-            'full-height': true,
-            'line-height-1': true,
-            'plain-button no-padding': true,
-            [font('hnl', 3)]: true,
-          })}
-        >
-          <span className="visually-hidden">Search</span>
-          <span className="flex flex--v-center flex--h-center">
-            <Icon name="search" title="Search" extraClasses="icon--white" />
-          </span>
-        </button>
+      <SearchButtonWrapper>
+        <ButtonSolid
+          icon="search"
+          text="search"
+          isTextHidden={true}
+          isBig={true}
+        />
       </SearchButtonWrapper>
     </form>
   );

--- a/catalogue/webapp/test/components/__snapshots__/WorkDetails.test.js.snap
+++ b/catalogue/webapp/test/components/__snapshots__/WorkDetails.test.js.snap
@@ -39,15 +39,13 @@ exports[`Feature: 2. As a library member I want to request an item
               "componentStyle": ComponentStyle {
                 "componentId": "ButtonSolid__SolidButton-xui0q4-3",
                 "isStatic": false,
-                "lastClassName": "hVleSf",
+                "lastClassName": "bjmhOA",
                 "rules": Array [
                   "line-height:1;border-radius:",
                   [Function],
                   ";text-decoration:none;text-align:center;transition:all ",
                   [Function],
-                  ";border:0;white-space:nowrap;padding:",
-                  [Function],
-                  ";&:not([disabled]):hover,&:not([disabled]):focus{cursor:pointer;}&:focus{outline:0;.is-keyboard &{box-shadow:",
+                  ";border:0;white-space:nowrap;padding:15px 20px;&:not([disabled]):hover,&:not([disabled]):focus{cursor:pointer;}&:focus{outline:0;.is-keyboard &{box-shadow:",
                   [Function],
                   ";}}&[disabled],&.disabled{background:",
                   [Function],
@@ -64,9 +62,9 @@ exports[`Feature: 2. As a library member I want to request an item
                   [Function],
                   ";color:",
                   [Function],
-                  ";padding:",
+                  ";",
                   [Function],
-                  ";&:not([disabled]):hover,&:not([disabled]):focus{border-color:",
+                  " &:not([disabled]):hover,&:not([disabled]):focus{border-color:",
                   [Function],
                   ";background:",
                   [Function],
@@ -90,7 +88,7 @@ exports[`Feature: 2. As a library member I want to request an item
           onClick={[Function]}
         >
           <a
-            className="ButtonSolid__BaseButton-xui0q4-0 ButtonSolid__SolidButton-xui0q4-3 hVleSf flex-inline flex--v-center"
+            className="ButtonSolid__BaseButton-xui0q4-0 ButtonSolid__SolidButton-xui0q4-3 bjmhOA flex-inline flex--v-center"
             href="/loginUrl"
             onClick={[Function]}
           >
@@ -170,15 +168,13 @@ exports[`Feature: 2. As a library member I want to request an item Scenario: I'm
             "componentStyle": ComponentStyle {
               "componentId": "ButtonSolid__SolidButton-xui0q4-3",
               "isStatic": false,
-              "lastClassName": "hVleSf",
+              "lastClassName": "bjmhOA",
               "rules": Array [
                 "line-height:1;border-radius:",
                 [Function],
                 ";text-decoration:none;text-align:center;transition:all ",
                 [Function],
-                ";border:0;white-space:nowrap;padding:",
-                [Function],
-                ";&:not([disabled]):hover,&:not([disabled]):focus{cursor:pointer;}&:focus{outline:0;.is-keyboard &{box-shadow:",
+                ";border:0;white-space:nowrap;padding:15px 20px;&:not([disabled]):hover,&:not([disabled]):focus{cursor:pointer;}&:focus{outline:0;.is-keyboard &{box-shadow:",
                 [Function],
                 ";}}&[disabled],&.disabled{background:",
                 [Function],
@@ -195,9 +191,9 @@ exports[`Feature: 2. As a library member I want to request an item Scenario: I'm
                 [Function],
                 ";color:",
                 [Function],
-                ";padding:",
+                ";",
                 [Function],
-                ";&:not([disabled]):hover,&:not([disabled]):focus{border-color:",
+                " &:not([disabled]):hover,&:not([disabled]):focus{border-color:",
                 [Function],
                 ";background:",
                 [Function],
@@ -220,7 +216,7 @@ exports[`Feature: 2. As a library member I want to request an item Scenario: I'm
         onClick={[Function]}
       >
         <button
-          className="ButtonSolid__BaseButton-xui0q4-0 ButtonSolid__SolidButton-xui0q4-3 hVleSf flex-inline flex--v-center"
+          className="ButtonSolid__BaseButton-xui0q4-0 ButtonSolid__SolidButton-xui0q4-3 bjmhOA flex-inline flex--v-center"
           onClick={[Function]}
         >
           <ButtonSolid__SolidButtonInner>

--- a/common/views/components/ButtonSolid/ButtonSolid.js
+++ b/common/views/components/ButtonSolid/ButtonSolid.js
@@ -19,6 +19,7 @@ export const BaseButton = styled.button.attrs(props => ({
   transition: all ${props => props.theme.transitionProperties};
   border: 0;
   white-space: nowrap;
+  padding: 15px 20px;
 
   &:not([disabled]):hover,
   &:not([disabled]):focus {
@@ -76,7 +77,12 @@ export const SolidButton = styled(BaseButton)`
   border: 2px solid ${props => props.theme.colors.green};
   background: ${props => props.theme.colors.green};
   color: ${props => props.theme.colors.white};
-  padding: ${props => (props.isBig ? '21px 20px 20px' : '15px 20px')};
+
+  ${props =>
+    props.isBig &&
+    `
+    padding: 21px 20px 20px;
+  `}
 
   &:not([disabled]):hover,
   &:not([disabled]):focus {

--- a/common/views/components/ButtonSolid/ButtonSolid.js
+++ b/common/views/components/ButtonSolid/ButtonSolid.js
@@ -19,8 +19,6 @@ export const BaseButton = styled.button.attrs(props => ({
   transition: all ${props => props.theme.transitionProperties};
   border: 0;
   white-space: nowrap;
-  padding: ${props =>
-    `${props.theme.spacingUnit} ${2 * props.theme.spacingUnit}`};
 
   &:not([disabled]):hover,
   &:not([disabled]):focus {
@@ -78,7 +76,7 @@ export const SolidButton = styled(BaseButton)`
   border: 2px solid ${props => props.theme.colors.green};
   background: ${props => props.theme.colors.green};
   color: ${props => props.theme.colors.white};
-  padding: ${props => (props.isBig ? '21px 20px' : '15px 20px')};
+  padding: ${props => (props.isBig ? '21px 20px 20px' : '15px 20px')};
 
   &:not([disabled]):hover,
   &:not([disabled]):focus {


### PR DESCRIPTION
Replacing the final primary-esque button with a `ButtonSolid`. This one slipped through the net because it had no mention of `btn--primary` _or_ `import Button` (a good illustration of why we needed to rationalise our button styles in the first place).

<img width="571" alt="Screenshot 2020-06-23 at 10 38 15" src="https://user-images.githubusercontent.com/1394592/85388271-cd497f80-b53d-11ea-9a70-af29295ee6f2.png">
