### PR TITLE
Card theme

### DIFF
--- a/common/views/components/Card/Card.js
+++ b/common/views/components/Card/Card.js
@@ -5,16 +5,49 @@ import { trackEvent } from '../../../utils/ga';
 import { UiImage } from '../Images/Images';
 import LabelsList from '../LabelsList/LabelsList';
 import Space from '../styled/Space';
+import styled from 'styled-components';
 
 type Props = {|
   item: CardType,
 |};
 
+export const CardOuter = styled.a.attrs(props => ({
+  className:
+    'plain-link promo-link rounded-corners overflow-hidden flex-ie-block flex--column',
+}))`
+  background: ${props => props.theme.colors.cream};
+
+  .bg-cream & {
+    background: ${props => props.theme.colors.white};
+  }
+
+  .bg-charcoal & {
+    background: ${props => props.theme.colors.transparent};
+    color: ${props => props.theme.colors.white};
+  }
+`;
+
+export const CardBody = styled(Space).attrs(props => ({
+  v: { size: 'm', properties: ['padding-top', 'padding-bottom'] },
+  className: 'flex flex--column flex-1 flex--h-space-between',
+}))`
+  ${props =>
+    props.theme.makeSpacePropertyValues(
+      'm',
+      ['padding-left', 'padding-right'],
+      false
+    )}
+
+  .bg-charcoal & {
+    padding-left: 0;
+    padding-right: 0;
+  }
+`;
+
 const Card = ({ item }: Props) => {
   return (
-    <a
+    <CardOuter
       href={item.link}
-      className="plain-link promo-link bg-cream rounded-corners overflow-hidden flex-ie-block flex--column"
       onClick={() => {
         trackEvent({
           category: 'Card',
@@ -38,16 +71,7 @@ const Card = ({ item }: Props) => {
         )}
       </div>
 
-      <Space
-        v={{
-          size: 'm',
-          properties: ['padding-top', 'padding-bottom'],
-        }}
-        h={{ size: 'm', properties: ['padding-left', 'padding-right'] }}
-        className={classNames({
-          'flex flex--column flex-1 flex--h-space-between': true,
-        })}
-      >
+      <CardBody>
         <div>
           {item.title && (
             <Space
@@ -71,8 +95,8 @@ const Card = ({ item }: Props) => {
             </p>
           )}
         </div>
-      </Space>
-    </a>
+      </CardBody>
+    </CardOuter>
   );
 };
 

--- a/common/views/components/Card/Card.js
+++ b/common/views/components/Card/Card.js
@@ -17,20 +17,25 @@ export const CardOuter = styled.a.attrs(props => ({
 }))`
   background: ${props => props.theme.colors.cream};
 
-  .bg-cream & {
+  .card-theme.card-theme--white & {
     background: ${props => props.theme.colors.white};
   }
 
-  .bg-charcoal & {
+  .card-theme.card-theme--transparent & {
     background: ${props => props.theme.colors.transparent};
+  }
+
+  .card-theme.bg-charcoal & {
     color: ${props => props.theme.colors.white};
   }
 `;
 
 export const CardBody = styled(Space).attrs(props => ({
   v: { size: 'm', properties: ['padding-top', 'padding-bottom'] },
-  className: 'flex flex--column flex-1 flex--h-space-between',
+  className: 'flex flex--column flex-1',
 }))`
+  justify-content: space-between;
+
   ${props =>
     props.theme.makeSpacePropertyValues(
       'm',
@@ -38,9 +43,10 @@ export const CardBody = styled(Space).attrs(props => ({
       false
     )}
 
-  .bg-charcoal & {
+  .card-theme.card-theme--transparent & {
     padding-left: 0;
     padding-right: 0;
+    justify-content: unset;
   }
 `;
 

--- a/common/views/components/CardGrid/CardGrid.js
+++ b/common/views/components/CardGrid/CardGrid.js
@@ -51,6 +51,7 @@ const CardGrid = ({
                   l: gridColumns,
                   xl: gridColumns,
                 })]: true,
+                'card-theme card-theme--transparent': itemsHaveTransparentBackground,
               })}
             >
               {item.id === 'tours' && <DailyTourPromo />}
@@ -81,7 +82,6 @@ const CardGrid = ({
                   item={item}
                   position={i}
                   hidePromoText={hidePromoText}
-                  hasTransparentBackground={itemsHaveTransparentBackground}
                 />
               )}
               {item.type === 'books' && (

--- a/common/views/components/EventPromo/EventPromo.js
+++ b/common/views/components/EventPromo/EventPromo.js
@@ -8,6 +8,7 @@ import EventDateRange from '../EventDateRange/EventDateRange';
 import { type UiEvent, isEventFullyBooked } from '../../../model/events';
 import Moment from 'moment';
 import Space from '../styled/Space';
+import { CardOuter, CardBody } from '../Card/Card';
 
 type Props = {|
   event: UiEvent,
@@ -27,11 +28,10 @@ const EventPromo = ({
   const fullyBooked = isEventFullyBooked(event);
   const isPast = event.isPast;
   return (
-    <a
+    <CardOuter
       data-component="EventPromo"
       data-component-state={JSON.stringify({ position: position })}
       href={(event.promo && event.promo.link) || `/events/${event.id}`}
-      className="plain-link promo-link bg-cream rounded-corners overflow-hidden flex-ie-block flex--column"
       onClick={() => {
         trackEvent({
           category: 'EventPromo',
@@ -58,16 +58,7 @@ const EventPromo = ({
         )}
       </div>
 
-      <Space
-        v={{
-          size: 'm',
-          properties: ['padding-top', 'padding-bottom'],
-        }}
-        h={{ size: 'm', properties: ['padding-left', 'padding-right'] }}
-        className={classNames({
-          'flex flex--column flex-1 flex--h-space-between': true,
-        })}
-      >
+      <CardBody>
         <div>
           <Space
             v={{
@@ -155,8 +146,8 @@ const EventPromo = ({
             ))}
           </Space>
         )}
-      </Space>
-    </a>
+      </CardBody>
+    </CardOuter>
   );
 };
 

--- a/common/views/components/ExhibitionPromo/ExhibitionPromo.js
+++ b/common/views/components/ExhibitionPromo/ExhibitionPromo.js
@@ -8,6 +8,7 @@ import LabelsList from '../LabelsList/LabelsList';
 import { type ExhibitionPromo as ExhibitionPromoProps } from '../../../model/exhibitions';
 import StatusIndicator from '../StatusIndicator/StatusIndicator';
 import Space from '../styled/Space';
+import { CardOuter, CardBody } from '../Card/Card';
 
 type Props = {|
   ...ExhibitionPromoProps,
@@ -27,12 +28,11 @@ const ExhibitionPromo = ({
   position = 0,
 }: Props) => {
   return (
-    <a
+    <CardOuter
       data-component="ExhibitionPromo"
       data-component-state={JSON.stringify({ position: position })}
       id={id}
       href={url}
-      className="plain-link promo-link bg-cream rounded-corners overflow-hidden flex--column flex-ie-block"
       onClick={() => {
         trackEvent({
           category: 'ExhibitionPromo',
@@ -74,16 +74,7 @@ const ExhibitionPromo = ({
         </div>
       </div>
 
-      <Space
-        v={{
-          size: 'm',
-          properties: ['padding-top', 'padding-bottom'],
-        }}
-        h={{ size: 'm', properties: ['padding-left', 'padding-right'] }}
-        className={`
-          flex flex--column flex-1 flex--h-space-between
-        `}
-      >
+      <CardBody>
         <div>
           <Space
             v={{
@@ -117,8 +108,8 @@ const ExhibitionPromo = ({
             statusOverride={statusOverride}
           />
         </div>
-      </Space>
-    </a>
+      </CardBody>
+    </CardOuter>
   );
 };
 

--- a/common/views/components/FacilityPromo/FacilityPromo.js
+++ b/common/views/components/FacilityPromo/FacilityPromo.js
@@ -5,6 +5,7 @@ import Icon from '../Icon/Icon';
 import { UiImage } from '../Images/Images';
 import type { ImageType } from '../../../model/image';
 import Space from '../styled/Space';
+import { CardOuter, CardBody } from '../Card/Card';
 
 type Props = {|
   id: string,
@@ -33,7 +34,7 @@ const FacilityPromo = ({
     sizesQueries,
   };
   return (
-    <a
+    <CardOuter
       data-component="FacilityPromo"
       onClick={() => {
         trackEvent({
@@ -44,47 +45,45 @@ const FacilityPromo = ({
       }}
       id={id}
       href={url}
-      className="plain-link promo-link"
     >
       <div>
         <div className="rounded-corners overflow-hidden">
           <UiImage {...uiImageProps} />
         </div>
 
-        <Space
-          v={{
-            size: 's',
-            properties: ['margin-top'],
-          }}
-          as="h2"
-          className={classNames({
-            'promo-link__title': true,
-            [font('wb', 4)]: true,
-          })}
-        >
-          {title}
-        </Space>
-        <p className={`${font('hnl', 5)} no-margin no-padding`}>
-          {description}
-        </p>
+        <CardBody>
+          <div>
+            <h2
+              className={classNames({
+                'promo-link__title': true,
+                [font('wb', 4)]: true,
+              })}
+            >
+              {title}
+            </h2>
+            <p className={`${font('hnl', 5)} no-margin no-padding`}>
+              {description}
+            </p>
 
-        {metaText && (
-          <Space v={{ size: 'm', properties: ['margin-top'] }}>
-            <div className={`${font('hnm', 6)} flex flex--v-center`}>
-              {metaIcon && (
-                <Space
-                  as="span"
-                  h={{ size: 's', properties: ['margin-right'] }}
-                >
-                  <Icon name={metaIcon} />
-                </Space>
-              )}
-              <span>{metaText}</span>
-            </div>
-          </Space>
-        )}
+            {metaText && (
+              <Space v={{ size: 'm', properties: ['margin-top'] }}>
+                <div className={`${font('hnm', 6)} flex flex--v-center`}>
+                  {metaIcon && (
+                    <Space
+                      as="span"
+                      h={{ size: 's', properties: ['margin-right'] }}
+                    >
+                      <Icon name={metaIcon} />
+                    </Space>
+                  )}
+                  <span>{metaText}</span>
+                </div>
+              </Space>
+            )}
+          </div>
+        </CardBody>
       </div>
-    </a>
+    </CardOuter>
   );
 };
 export default FacilityPromo;

--- a/common/views/components/StoryPromo/StoryPromo.js
+++ b/common/views/components/StoryPromo/StoryPromo.js
@@ -7,6 +7,7 @@ import { UiImage } from '../Images/Images';
 import LabelsList from '../LabelsList/LabelsList';
 import PartNumberIndicator from '../PartNumberIndicator/PartNumberIndicator';
 import Space from '../styled/Space';
+import { CardOuter, CardBody } from '../Card/Card';
 
 type Props = {|
   item: Article,
@@ -25,7 +26,7 @@ const StoryPromo = ({
 }: Props) => {
   const positionInSeries = getPositionInSeries(item);
   return (
-    <a
+    <CardOuter
       onClick={() => {
         trackEvent({
           category: 'StoryPromo',
@@ -35,17 +36,10 @@ const StoryPromo = ({
       }}
       href={(item.promo && item.promo.link) || `/articles/${item.id}`}
       className={classNames({
-        'story-promo': true,
-        'plain-link': true,
-        'promo-link': true,
         'bg-cream': !hasTransparentBackground,
-        'rounded-corners': true,
-        'overflow-hidden': true,
-        'flex-ie-block': true,
-        'flex--column': true,
       })}
     >
-      <div className="relative story-promo__image">
+      <div className="relative">
         {/* FIXME: Image type tidy */}
         {item.promoImage && (
           // $FlowFixMe
@@ -63,21 +57,7 @@ const StoryPromo = ({
         )}
       </div>
 
-      <Space
-        v={{
-          size: 'm',
-          properties: ['padding-top', 'padding-bottom'],
-        }}
-        h={
-          !hasTransparentBackground
-            ? { size: 'm', properties: ['padding-left', 'padding-right'] }
-            : undefined
-        }
-        className={classNames({
-          'story-promo__text flex flex--column flex-1': true,
-          'flex--h-space-between': !hasTransparentBackground,
-        })}
-      >
+      <CardBody>
         <div>
           {positionInSeries && (
             <PartNumberIndicator
@@ -119,8 +99,8 @@ const StoryPromo = ({
             ))}
           </Space>
         )}
-      </Space>
-    </a>
+      </CardBody>
+    </CardOuter>
   );
 };
 

--- a/content/webapp/pages/stories.js
+++ b/content/webapp/pages/stories.js
@@ -195,15 +195,11 @@ export class StoriesPage extends Component<Props> {
             </Space>
             <div className="row__wobbly-background" />
             <div className="container container--scroll container--scroll-cream touch-scroll">
-              <div className="grid grid--scroll grid--theme-4">
+              <div className="grid grid--scroll grid--theme-4 card-theme card-theme--transparent">
                 {articles.slice(1, 5).map((article, i) => {
                   return (
                     <div className="grid__cell" key={article.id}>
-                      <StoryPromo
-                        item={article}
-                        position={i}
-                        hasTransparentBackground={true}
-                      />
+                      <StoryPromo item={article} position={i} />
                     </div>
                   );
                 })}

--- a/content/webapp/pages/whats-on.js
+++ b/content/webapp/pages/whats-on.js
@@ -510,7 +510,7 @@ export class WhatsOnPage extends Component<Props> {
                           [cssGrid({ s: 12, m: 12, l: 12, xl: 12 })]: true,
                         })}
                       >
-                        <div className="css-grid grid--scroll">
+                        <div className="css-grid grid--scroll card-theme card-theme--transparent">
                           {tryTheseTooPromos
                             .concat(eatShopPromos)
                             .map(promo => (


### PR DESCRIPTION
Preparing the different cards (exhibition/event/story/facility) to display differently based on a parent `css-theme` class, ready for the work to create various card sections in #5317.

For example
- cards that appear on a cream background should have a white background, and vice versa
- cards that appear on a charcoal background should have a transparent background and white text
- cards that have a transparent background should have no horizontal padding applied to the text