### PR TITLE
Fix cafe/shop links (again)

### DIFF
--- a/common/data/facility-promos.js
+++ b/common/data/facility-promos.js
@@ -26,7 +26,7 @@ export const cafePromo: Promo = {
   id: 'cafePromo',
   contentType: 'place',
   title: 'Café',
-  url: 'https://wellcomecollection.org/pages/WwgaIh8AAB8AGhC_',
+  url: 'https://wellcomecollection.org/pages/Wvl1wiAAADMJ3zNe',
   description:
     'Join us for a quick cup of coffee and a pastry, afternoon tea, or a light meal with a glass of wine.',
   image: {
@@ -81,7 +81,7 @@ export const shopPromo: Promo = {
   id: 'shopPromo',
   contentType: 'place',
   title: 'Shop',
-  url: 'https://wellcomecollection.org/pages/Wvl1wiAAADMJ3zNe',
+  url: 'https://wellcomecollection.org/pages/WwgaIh8AAB8AGhC_',
   description: 'Come and browse a selection of our quirky gifts and books.',
   image: {
     type: 'picture',

--- a/content/webapp/pages/whats-on.js
+++ b/content/webapp/pages/whats-on.js
@@ -345,7 +345,7 @@ export class WhatsOnPage extends Component<Props> {
         events,
         dateRange,
         tryTheseTooPromos: [readingRoomPromo],
-        eatShopPromos: [shopPromo, cafePromo, restaurantPromo],
+        eatShopPromos: [cafePromo, shopPromo, restaurantPromo],
         cafePromo,
         shopPromo,
         dailyTourPromo,


### PR DESCRIPTION
Reverting the links to what they were previously, but re-ordering the `eatShopPromos` array (which is where the problem was initially spotted).