### PR TITLE
No caching of 404s

### DIFF
--- a/cache/cloudfront_prod.tf
+++ b/cache/cloudfront_prod.tf
@@ -96,6 +96,12 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
     }
   }
 
+  # Don't cache 404s
+  custom_error_response {
+    error_code            = 404
+    error_caching_min_ttl = 0
+  }
+
   # Works
   ordered_cache_behavior {
     allowed_methods        = ["HEAD", "GET", "OPTIONS"]

--- a/cache/cloudfront_stage.tf
+++ b/cache/cloudfront_stage.tf
@@ -66,6 +66,12 @@ resource "aws_cloudfront_distribution" "stage_wc_org" {
     }
   }
 
+  # Don't cache 404s
+  custom_error_response {
+    error_code            = 404
+    error_caching_min_ttl = 0
+  }
+
   # Works
   ordered_cache_behavior {
     allowed_methods        = ["HEAD", "GET", "OPTIONS"]


### PR DESCRIPTION
I'm not really convinced by this change, but I do remember having to do it before. It seems like it shouldn't be necessary because we shouldn't be getting a 404 to cache in the first place!

Anyway, maybe next time someone deploys I'll have a look and see if I have any more ideas. One other thought is - I wonder if the problem is that we're caching the old _page_ but not the old JS, so the assets that are 404ing might actually be the old ones? 🤷‍♂️ 