### PR TITLE
Shim space if there aren't any labels in the FeaturedCard

### DIFF
--- a/common/views/components/FeaturedCard/FeaturedCard.js
+++ b/common/views/components/FeaturedCard/FeaturedCard.js
@@ -277,7 +277,11 @@ const FeaturedCard = ({
             })}
           >
             <FeaturedCardRight isReversed={isReversed}>
-              {labels && labels.length > 0 && <LabelsList labels={labels} />}
+              {labels && labels.length > 0 ? (
+                <LabelsList labels={labels} />
+              ) : (
+                <Space v={{ size: 'l', properties: ['margin-bottom'] }} />
+              )}
               <FeaturedCardCopy
                 className={classNames({
                   [`bg-${background} font-${color}`]: true,


### PR DESCRIPTION
This ensures the top of the image and the copy sections in the `FeaturedCard` are vertically offset even when there aren't any labels

![image](https://user-images.githubusercontent.com/1394592/86242146-20ee4580-bb9c-11ea-9729-13761d9278f3.png)
