### PR TITLE
Add a compact card for the user panel

### DIFF
--- a/common/views/components/ContentPage/ContentPage.js
+++ b/common/views/components/ContentPage/ContentPage.js
@@ -10,6 +10,9 @@ import type { Node, Element, ElementProps } from 'react';
 import Body from '../Body/Body';
 import SpacingSection from '../SpacingSection/SpacingSection';
 import SpacingComponent from '../SpacingComponent/SpacingComponent';
+import CompactCard from '../CompactCard/CompactCard';
+import Image from '../Image/Image';
+import Space from '../styled/Space';
 
 /*eslint-disable */
 export const PageBackgroundContext = createContext<'cream' | 'white'>('white');
@@ -27,6 +30,37 @@ type Props = {|
   Siblings?: Element<typeof SeriesNavigation>[],
   outroProps?: ?ElementProps<typeof Outro>,
 |};
+
+// FIXME: obviously we can't carry on like this!
+const ShameWhatWeDoHack = () => (
+  <Layout8>
+    <Space v={{ size: 'l', properties: ['margin-top'] }}>
+      <div className="border-bottom-width-1 border-color-smoke"></div>
+    </Space>
+    <CompactCard
+      url="/user-panel"
+      title="Join our user panel"
+      labels={{ labels: [] }}
+      description="Are you able to find the information you are looking for? Help improve our website, in-venue technology, and other services by answering questions like these as part of our user panel."
+      urlOverride={null}
+      partNumber={null}
+      color={null}
+      Image={
+        <Image
+          contentUrl={`https://images.prismic.io/wellcomecollection/996aff41-b1cf-44e4-86ce-181438358c21_user_panel_square.jpg?auto=compress,format`}
+          width={3200}
+          height={3200}
+          alt={''}
+          tasl={null}
+        />
+      }
+      DateInfo={null}
+      StatusIndicator={null}
+      ExtraInfo={null}
+      xOfY={{ x: 1, y: 1 }}
+    />
+  </Layout8>
+);
 
 const ContentPage = ({
   id,
@@ -62,6 +96,7 @@ const ContentPage = ({
             <SpacingSection>
               <div className="basic-page">
                 <Fragment>{Body}</Fragment>
+                {id === 'WwLGFCAAAPMiB_Ps' && <ShameWhatWeDoHack />}
               </div>
             </SpacingSection>
           )}

--- a/common/views/components/ContentPage/ContentPage.js
+++ b/common/views/components/ContentPage/ContentPage.js
@@ -41,7 +41,7 @@ const ShameWhatWeDoHack = () => (
       url="/user-panel"
       title="Join our user panel"
       labels={{ labels: [] }}
-      description="Are you able to find the information you are looking for? Help improve our website, in-venue technology, and other services by answering questions like these as part of our user panel."
+      description="Get involved in shaping better website and gallery experiences for everyone. We’re looking for people to take part in online and in-person interviews, usability tests, surveys and more."
       urlOverride={null}
       partNumber={null}
       color={null}

--- a/common/views/components/ContentPage/ContentPage.js
+++ b/common/views/components/ContentPage/ContentPage.js
@@ -35,7 +35,7 @@ type Props = {|
 const ShameWhatWeDoHack = () => (
   <Layout8>
     <Space v={{ size: 'l', properties: ['margin-top'] }}>
-      <div className="border-bottom-width-1 border-color-smoke"></div>
+      <div className="border-bottom-width-1 border-color-pumice"></div>
     </Space>
     <CompactCard
       url="/user-panel"

--- a/content/webapp/pages/user-panel.js
+++ b/content/webapp/pages/user-panel.js
@@ -32,7 +32,7 @@ const UserPanelPage = () => {
   return (
     <PageLayout
       title={'Join our user panel'}
-      description={'Sign up for news and information from Wellcome Collection'}
+      description={`Get involved in shaping better website and gallery experiences for everyone. We’re looking for people to take part in online and in-person interviews, usability tests, surveys and more`}
       hideNewsletterPromo={true}
       url={{ pathname: `/user-panel` }}
       jsonLd={{ '@type': 'WebPage' }}


### PR DESCRIPTION
## Who is this for?
People who want a way to get to the `/user-panel` page without typing it in the url bar or being sent there from social media

## What is it doing for them?
Adding a `CompactCard` linking to the page from the bottom of the `/what-we-do` page.

![Screenshot 2020-07-02 at 17 49 08](https://user-images.githubusercontent.com/1394592/86388520-da2c4880-bc8c-11ea-8205-e2962bd0bc01.png)

__TODO:__
- [x] Get proper copy (currently just taken the first paragraph from the page)