### PR TITLE
remove memoizedPrismic from ctx.query once we’ve made use of it

### DIFF
--- a/common/views/pages/_app.js
+++ b/common/views/pages/_app.js
@@ -161,6 +161,8 @@ export default class WecoApp extends App {
       }
     }
 
+    delete ctx.query.memoizedPrismic; // We need to remove memoizedPrismic value here otherwise we hit circular object issues with JSON.stringify
+
     return {
       pageProps,
       toggles,

--- a/content/webapp/pages/article-series.js
+++ b/content/webapp/pages/article-series.js
@@ -23,7 +23,6 @@ type Props = {|
 export class ArticleSeriesPage extends Component<Props> {
   static getInitialProps = async (ctx: Context) => {
     const { id, memoizedPrismic } = ctx.query;
-    ctx.query.memoizedPrismic = undefined; // Once we've got memoizedPrismic, we need to remove it before making requests - otherwise we hit circular object issues with JSON.stringify
     const seriesAndArticles = await getArticleSeries(
       ctx.req,
       {

--- a/content/webapp/pages/article.js
+++ b/content/webapp/pages/article.js
@@ -47,7 +47,6 @@ export class ArticlePage extends Component<Props, State> {
     ctx: Context
   ): Promise<?Props | PrismicApiError> => {
     const { id, memoizedPrismic } = ctx.query;
-    ctx.query.memoizedPrismic = undefined; // Once we've got memoizedPrismic, we need to remove it before making requests - otherwise we hit circular object issues with JSON.stringify
     const article = await getArticle(ctx.req, id, memoizedPrismic);
     if (article) {
       return {

--- a/content/webapp/pages/articles.js
+++ b/content/webapp/pages/articles.js
@@ -62,7 +62,6 @@ ArticlesPage.getInitialProps = async (
   ctx: Context
 ): Promise<?Props | PrismicApiError> => {
   const { page = 1, memoizedPrismic } = ctx.query;
-  ctx.query.memoizedPrismic = undefined; // Once we've got memoizedPrismic, we need to remove it before making requests - otherwise we hit circular object issues with JSON.stringify
   const articles = await getArticles(ctx.req, { page }, memoizedPrismic);
 
   return {

--- a/content/webapp/pages/book.js
+++ b/content/webapp/pages/book.js
@@ -61,7 +61,6 @@ const BookMetadata = ({ book }: Props) => (
 export class ArticleSeriesPage extends Component<Props> {
   static getInitialProps = async (ctx: Context) => {
     const { id, memoizedPrismic } = ctx.query;
-    ctx.query.memoizedPrismic = undefined; // Once we've got memoizedPrismic, we need to remove it before making requests - otherwise we hit circular object issues with JSON.stringify
     const book = await getBook(ctx.req, id, memoizedPrismic);
 
     if (book) {

--- a/content/webapp/pages/books.js
+++ b/content/webapp/pages/books.js
@@ -18,7 +18,6 @@ const pageDescription =
 export class BooksPage extends Component<Props> {
   static getInitialProps = async (ctx: Context) => {
     const { page = 1, memoizedPrismic } = ctx.query;
-    ctx.query.memoizedPrismic = undefined; // Once we've got memoizedPrismic, we need to remove it before making requests - otherwise we hit circular object issues with JSON.stringify
     const books = await getBooks(ctx.req, { page }, memoizedPrismic);
     if (books) {
       return {

--- a/content/webapp/pages/event-series.js
+++ b/content/webapp/pages/event-series.js
@@ -25,7 +25,6 @@ type Props = {|
 export class EventSeriesPage extends Component<Props> {
   static getInitialProps = async (ctx: Context) => {
     const { id, memoizedPrismic } = ctx.query;
-    ctx.query.memoizedPrismic = undefined; // Once we've got memoizedPrismic, we need to remove it before making requests - otherwise we hit circular object issues with JSON.stringify
     const seriesAndEvents = await getEventSeries(
       ctx.req,
       {

--- a/content/webapp/pages/event.js
+++ b/content/webapp/pages/event.js
@@ -144,7 +144,6 @@ class EventPage extends Component<Props, State> {
 
   static getInitialProps = async (ctx: Context) => {
     const { id, memoizedPrismic } = ctx.query;
-    ctx.query.memoizedPrismic = undefined; // Once we've got memoizedPrismic, we need to remove it before making requests - otherwise we hit circular object issues with JSON.stringify
     const event = await getEvent(ctx.req, { id }, memoizedPrismic);
 
     if (event) {

--- a/content/webapp/pages/events.js
+++ b/content/webapp/pages/events.js
@@ -29,7 +29,6 @@ const pageDescription =
 export class ArticleSeriesPage extends Component<Props> {
   static getInitialProps = async (ctx: Context) => {
     const { page = 1, memoizedPrismic } = ctx.query;
-    ctx.query.memoizedPrismic = undefined; // Once we've got memoizedPrismic, we need to remove it before making requests - otherwise we hit circular object issues with JSON.stringify
     const { period = 'current-and-coming-up' } = ctx.query;
     const events = await getEvents(
       ctx.req,

--- a/content/webapp/pages/exhibition.js
+++ b/content/webapp/pages/exhibition.js
@@ -19,7 +19,6 @@ const ExhibitionPage = ({ exhibition }: Props) => {
 
 ExhibitionPage.getInitialProps = async (ctx: Context) => {
   const { id, memoizedPrismic } = ctx.query;
-  ctx.query.memoizedPrismic = undefined; // Once we've got memoizedPrismic, we need to remove it before making requests - otherwise we hit circular object issues with JSON.stringify
   const exhibition = await getExhibition(ctx.req, id, memoizedPrismic);
 
   if (exhibition) {

--- a/content/webapp/pages/exhibitions.js
+++ b/content/webapp/pages/exhibitions.js
@@ -22,7 +22,6 @@ const pageDescription =
 export class ExhibitionsPage extends Component<Props> {
   static getInitialProps = async (ctx: Context) => {
     const { page = 1, period, memoizedPrismic } = ctx.query;
-    ctx.query.memoizedPrismic = undefined; // Once we've got memoizedPrismic, we need to remove it before making requests - otherwise we hit circular object issues with JSON.stringify
     const exhibitions = await getExhibitions(
       ctx.req,
       { page, period },

--- a/content/webapp/pages/homepage.js
+++ b/content/webapp/pages/homepage.js
@@ -52,7 +52,6 @@ const pageImage =
 export class HomePage extends Component<Props> {
   static getInitialProps = async (ctx: Context) => {
     const { id, memoizedPrismic } = ctx.query;
-    ctx.query.memoizedPrismic = undefined; // Once we've got memoizedPrismic, we need to remove it before making requests - otherwise we hit circular object issues with JSON.stringify
     const articlesPromise = await getArticles(
       ctx.req,
       { pageSize: 4 },

--- a/content/webapp/pages/page.js
+++ b/content/webapp/pages/page.js
@@ -23,7 +23,6 @@ const backgroundTexture =
 export class Page extends Component<Props> {
   static getInitialProps = async (ctx: Context) => {
     const { id, memoizedPrismic } = ctx.query;
-    ctx.query.memoizedPrismic = undefined; // Once we've got memoizedPrismic, we need to remove it before making requests - otherwise we hit circular object issues with JSON.stringify
     const page = await getPage(ctx.req, id, memoizedPrismic);
 
     if (page) {

--- a/content/webapp/pages/place.js
+++ b/content/webapp/pages/place.js
@@ -18,7 +18,6 @@ type Props = {|
 export class PlacePage extends Component<Props> {
   static getInitialProps = async (ctx: Context) => {
     const { id, memoizedPrismic } = ctx.query;
-    ctx.query.memoizedPrismic = undefined; // Once we've got memoizedPrismic, we need to remove it before making requests - otherwise we hit circular object issues with JSON.stringify
     const place = await getPlace(ctx.req, id, memoizedPrismic);
 
     if (place) {

--- a/content/webapp/pages/stories.js
+++ b/content/webapp/pages/stories.js
@@ -69,7 +69,6 @@ const pageDescription =
 export class StoriesPage extends Component<Props> {
   static getInitialProps = async (ctx: Context) => {
     const { page = 1, memoizedPrismic } = ctx.query;
-    ctx.query.memoizedPrismic = undefined; // Once we've got memoizedPrismic, we need to remove it before making requests - otherwise we hit circular object issues with JSON.stringify
     const articlesPromise = getArticles(ctx.req, { page }, memoizedPrismic);
     const seriesPromise = getArticleSeries(
       ctx.req,

--- a/content/webapp/pages/visit-us.js
+++ b/content/webapp/pages/visit-us.js
@@ -237,7 +237,6 @@ const backgroundTexture =
 export class Page extends Component<Props> {
   static getInitialProps = async (ctx: Context) => {
     const { id, memoizedPrismic } = ctx.query;
-    ctx.query.memoizedPrismic = undefined; // Once we've got memoizedPrismic, we need to remove it before making requests - otherwise we hit circular object issues with JSON.stringify
     const page = await getPage(ctx.req, id, memoizedPrismic);
 
     if (page) {

--- a/content/webapp/pages/whats-on.js
+++ b/content/webapp/pages/whats-on.js
@@ -314,7 +314,6 @@ export class WhatsOnPage extends Component<Props> {
   static getInitialProps = async (ctx: Context) => {
     const period = ctx.query.period || 'current-and-coming-up';
     const { memoizedPrismic } = ctx.query;
-    ctx.query.memoizedPrismic = undefined; // Once we've got memoizedPrismic, we need to remove it before making requests - otherwise we hit circular object issues with JSON.stringify
     const exhibitionsPromise = getExhibitions(
       ctx.req,
       {


### PR DESCRIPTION
Fixes error we sometimes see on static pages