### PR TITLE
Image modal fixes

### DIFF
--- a/catalogue/webapp/components/ExpandedImage/ExpandedImage.js
+++ b/catalogue/webapp/components/ExpandedImage/ExpandedImage.js
@@ -17,12 +17,13 @@ import Space from '@weco/common/views/components/styled/Space';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import getFocusableElements from '@weco/common/utils/get-focusable-elements';
 import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
+import VisuallySimilarImagesFromApi from '../VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi';
 
 type Props = {|
   title: string,
   workId: string,
   image?: ImageType,
-  setExpandedImageId: (id: string) => void,
+  setExpandedImage: (image: ?ImageType) => void,
   onWorkLinkClick: () => void,
   onImageLinkClick: (id: string) => void,
 |};
@@ -158,7 +159,7 @@ const ExpandedImage = ({
   title,
   workId,
   image,
-  setExpandedImageId,
+  setExpandedImage,
   onWorkLinkClick,
   onImageLinkClick,
 }: Props) => {
@@ -169,7 +170,6 @@ const ExpandedImage = ({
   const endRef = useRef(null);
 
   const displayTitle = title || (detailedWork && detailedWork.title) || '';
-  const imageId = image && image.id;
 
   useEffect(() => {
     const focusables = modalRef &&
@@ -189,7 +189,7 @@ const ExpandedImage = ({
     function closeOnEscape(event: KeyboardEvent) {
       if (event.key !== 'Escape') return;
 
-      setExpandedImageId('');
+      setExpandedImage(undefined);
     }
 
     document.addEventListener('keydown', closeOnEscape);
@@ -204,7 +204,7 @@ const ExpandedImage = ({
       }
     };
     fetchDetailedWork();
-  }, []);
+  }, [workId]);
 
   useEffect(() => {
     document &&
@@ -237,12 +237,12 @@ const ExpandedImage = ({
 
   return (
     <>
-      <Overlay onClick={() => setExpandedImageId('')} />
+      <Overlay onClick={() => setExpandedImage(undefined)} />
       <Modal ref={modalRef}>
         <CloseButton
           hideFocus={!isKeyboard}
           ref={closeButtonRef}
-          onClick={() => setExpandedImageId('')}
+          onClick={() => setExpandedImage(undefined)}
         >
           <span className="visually-hidden">Close modal window</span>
           <Icon name="cross" extraClasses={`icon--currentColor`} />
@@ -256,6 +256,7 @@ const ExpandedImage = ({
                   alt={displayTitle}
                   contentUrl={iiifImageLocation.url}
                   tasl={null}
+                  lazyload={false}
                 />
               </ImageWrapper>
             </NextLink>
@@ -305,10 +306,14 @@ const ExpandedImage = ({
                 </a>
               </NextLink>
             </Space>
-            <VisuallySimilarImages
-              originalId={imageId || workId}
-              sourceType={imageId ? 'image' : 'work'}
-            />
+            {image ? (
+              <VisuallySimilarImagesFromApi
+                originalImage={image}
+                onClickImage={setExpandedImage}
+              />
+            ) : (
+              <VisuallySimilarImages originalId={workId} />
+            )}
           </InfoWrapper>
         </ModalInner>
       </Modal>

--- a/catalogue/webapp/components/ExpandedImage/ExpandedImage.js
+++ b/catalogue/webapp/components/ExpandedImage/ExpandedImage.js
@@ -7,6 +7,7 @@ import getAugmentedLicenseInfo from '@weco/common/utils/licenses';
 import ButtonSolidLink from '@weco/common/views/components/ButtonSolidLink/ButtonSolidLink';
 import Image from '@weco/common/views/components/Image/Image';
 import License from '@weco/common/views/components/License/License';
+import { type Image as ImageType } from '@weco/common/model/catalogue';
 import { getWork } from '../../services/catalogue/works';
 import { useEffect, useState, useRef, useContext } from 'react';
 import useFocusTrap from '@weco/common/hooks/useFocusTrap';
@@ -20,7 +21,7 @@ import { AppContext } from '@weco/common/views/components/AppContext/AppContext'
 type Props = {|
   title: string,
   workId: string,
-  imageId?: string,
+  image?: ImageType,
   setExpandedImageId: (id: string) => void,
   onWorkLinkClick: () => void,
   onImageLinkClick: (id: string) => void,
@@ -156,7 +157,7 @@ const CloseButton = styled(Space).attrs({
 const ExpandedImage = ({
   title,
   workId,
-  imageId,
+  image,
   setExpandedImageId,
   onWorkLinkClick,
   onImageLinkClick,
@@ -168,6 +169,7 @@ const ExpandedImage = ({
   const endRef = useRef(null);
 
   const displayTitle = title || (detailedWork && detailedWork.title) || '';
+  const imageId = image && image.id;
 
   useEffect(() => {
     const focusables = modalRef &&
@@ -218,10 +220,13 @@ const ExpandedImage = ({
 
   useFocusTrap(closeButtonRef, endRef);
 
-  const iiifImageLocation =
-    detailedWork && getDigitalLocationOfType(detailedWork, 'iiif-image');
+  const iiifImageLocation = image
+    ? image.locations[0]
+    : detailedWork && getDigitalLocationOfType(detailedWork, 'iiif-image');
   const license =
-    iiifImageLocation && getAugmentedLicenseInfo(iiifImageLocation.license);
+    iiifImageLocation &&
+    iiifImageLocation.license &&
+    getAugmentedLicenseInfo(iiifImageLocation.license);
 
   const maybeItemLink =
     detailedWork &&

--- a/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.js
+++ b/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.js
@@ -39,7 +39,7 @@ const ImageEndpointSearchResults = ({ images, apiProps }: Props) => {
           {expandedImageId === result.id && (
             <ExpandedImage
               title=""
-              imageId={result.id}
+              image={result}
               workId={result.source.id}
               setExpandedImageId={setExpandedImageId}
               onWorkLinkClick={() => {

--- a/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.js
+++ b/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.js
@@ -16,7 +16,12 @@ type Props = {|
 |};
 
 const ImageEndpointSearchResults = ({ images, apiProps }: Props) => {
-  const [expandedImageId, setExpandedImageId] = useState('');
+  const [expandedImage, setExpandedImage] = useState();
+  // In the case that the modal changes the expanded image to
+  // be one that isn't on this results page, this index will be -1
+  const expandedImagePosition = images.results.findIndex(
+    img => expandedImage && img.id === expandedImage.id
+  );
 
   return (
     <div className={'flex flex--wrap'}>
@@ -33,41 +38,41 @@ const ImageEndpointSearchResults = ({ images, apiProps }: Props) => {
             }}
             onClick={event => {
               event.preventDefault();
-              setExpandedImageId(result.id);
+              setExpandedImage(result);
             }}
           />
-          {expandedImageId === result.id && (
-            <ExpandedImage
-              title=""
-              image={result}
-              workId={result.source.id}
-              setExpandedImageId={setExpandedImageId}
-              onWorkLinkClick={() => {
-                trackSearchResultSelected(apiProps, {
-                  id: result.source.id,
-                  position: i,
-                  resultIdentifiers: undefined,
-                  resultLanguage: undefined,
-                  resultSubjects: undefined,
-                  resultWorkType: '',
-                  source: 'image_endpoint_result/work_link',
-                });
-              }}
-              onImageLinkClick={() => {
-                trackSearchResultSelected(apiProps, {
-                  id: result.id,
-                  position: i,
-                  resultWorkType: '',
-                  resultLanguage: undefined,
-                  resultIdentifiers: undefined,
-                  resultSubjects: undefined,
-                  source: 'image_endpoint_result/image_link',
-                });
-              }}
-            />
-          )}
         </div>
       ))}
+      {expandedImage && (
+        <ExpandedImage
+          title=""
+          image={expandedImage}
+          workId={expandedImage.source.id}
+          setExpandedImage={setExpandedImage}
+          onWorkLinkClick={() => {
+            trackSearchResultSelected(apiProps, {
+              id: expandedImage.source.id,
+              position: expandedImagePosition,
+              resultIdentifiers: undefined,
+              resultLanguage: undefined,
+              resultSubjects: undefined,
+              resultWorkType: '',
+              source: 'image_endpoint_result/work_link',
+            });
+          }}
+          onImageLinkClick={() => {
+            trackSearchResultSelected(apiProps, {
+              id: expandedImage.id,
+              position: expandedImagePosition,
+              resultWorkType: '',
+              resultLanguage: undefined,
+              resultIdentifiers: undefined,
+              resultSubjects: undefined,
+              source: 'image_endpoint_result/image_link',
+            });
+          }}
+        />
+      )}
     </div>
   );
 };

--- a/catalogue/webapp/components/ImageSearchResults/ImageSearchResults.js
+++ b/catalogue/webapp/components/ImageSearchResults/ImageSearchResults.js
@@ -43,7 +43,7 @@ const ImageSearchResults = ({ works, apiProps }: Props) => {
             <ExpandedImage
               title={result.title}
               workId={result.id}
-              setExpandedImageId={setExpandedImageId}
+              setExpandedImage={img => setExpandedImageId(img && img.id)}
               onWorkLinkClick={() => {
                 trackSearchResultSelected(apiProps, {
                   id: result.id,

--- a/catalogue/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.js
+++ b/catalogue/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.js
@@ -1,14 +1,15 @@
 // @flow
 import { font, classNames } from '@weco/common/utils/classnames';
-import NextLink from 'next/link';
 import Image from '@weco/common/views/components/Image/Image';
+import { type Image as ImageType } from '@weco/common/model/catalogue';
 import { useEffect, useState } from 'react';
 import styled from 'styled-components';
-import { getSimilarImages } from '../../services/image-similarity';
+import { getImage } from '../../services/catalogue/images';
 import Space from '@weco/common/views/components/styled/Space';
 
 type Props = {|
-  originalId: string,
+  originalImage: ImageType,
+  onClickImage: (image: ImageType) => void,
 |};
 
 const Wrapper = styled.div`
@@ -26,34 +27,32 @@ const Wrapper = styled.div`
   }
 `;
 
-const VisuallySimilarImages = ({ originalId }: Props) => {
-  const [similarImages, setSimilarImages] = useState([]);
+const VisuallySimilarImagesFromApi = ({
+  originalImage,
+  onClickImage,
+}: Props) => {
+  const [similarImages, setSimilarImages] = useState<ImageType[]>([]);
   useEffect(() => {
-    const fetchRelatedImages = async () =>
-      setSimilarImages(
-        await getSimilarImages({
-          id: originalId,
-          n: 5,
-        })
-      );
-    fetchRelatedImages();
+    const fetchVisuallySimilarImages = async () => {
+      const fullImage = await getImage({ id: originalImage.id });
+      setSimilarImages(fullImage.visuallySimilar);
+    };
+    fetchVisuallySimilarImages();
   }, []);
   return similarImages.length === 0 ? null : (
     <Space v={{ size: 'xl', properties: ['margin-bottom'] }}>
       <h3 className={font('wb', 5)}>Visually similar images</h3>
       <Wrapper>
         {similarImages.map(related => (
-          <NextLink href={`/works/${related.workId}`} key={related.id}>
-            <a>
-              <Image
-                contentUrl={related.uri}
-                defaultSize={250}
-                width={250}
-                alt=""
-                tasl={null}
-              />
-            </a>
-          </NextLink>
+          <a href="#" onClick={() => onClickImage(related)} key={related.id}>
+            <Image
+              contentUrl={related.locations[0] && related.locations[0].url}
+              defaultSize={250}
+              width={250}
+              alt=""
+              tasl={null}
+            />
+          </a>
         ))}
       </Wrapper>
       <p
@@ -69,4 +68,4 @@ const VisuallySimilarImages = ({ originalId }: Props) => {
     </Space>
   );
 };
-export default VisuallySimilarImages;
+export default VisuallySimilarImagesFromApi;

--- a/common/model/catalogue.js
+++ b/common/model/catalogue.js
@@ -15,6 +15,7 @@ export type Image = {
     id: string,
     type: string,
   },
+  visuallySimilar?: Image[],
 };
 
 export type CatalogueApiError = {|


### PR DESCRIPTION
This fixes 2 of the biggest issues that the new image search had:

- The image in the modal is always shown (previously it tried to get the image off the work that the image was from 🙃 which failed sometimes)
- Clicking on the visually similar images will update the modal in-place. This fixes an issue where clicking them took you to a work where you couldn't see them (similar root to the first issue).

The view work / view image buttons still suffer from these cases but that requires some more thought and UX input to fix.