### PR TITLE
Fix: visually similar images do not refresh when changing image in modal

### DIFF
--- a/catalogue/webapp/components/ExpandedImage/ExpandedImage.js
+++ b/catalogue/webapp/components/ExpandedImage/ExpandedImage.js
@@ -308,7 +308,7 @@ const ExpandedImage = ({
             </Space>
             {image ? (
               <VisuallySimilarImagesFromApi
-                originalImage={image}
+                originalId={image.id}
                 onClickImage={setExpandedImage}
               />
             ) : (

--- a/catalogue/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.js
+++ b/catalogue/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.js
@@ -8,7 +8,7 @@ import { getImage } from '../../services/catalogue/images';
 import Space from '@weco/common/views/components/styled/Space';
 
 type Props = {|
-  originalImage: ImageType,
+  originalId: string,
   onClickImage: (image: ImageType) => void,
 |};
 
@@ -27,18 +27,15 @@ const Wrapper = styled.div`
   }
 `;
 
-const VisuallySimilarImagesFromApi = ({
-  originalImage,
-  onClickImage,
-}: Props) => {
+const VisuallySimilarImagesFromApi = ({ originalId, onClickImage }: Props) => {
   const [similarImages, setSimilarImages] = useState<ImageType[]>([]);
   useEffect(() => {
     const fetchVisuallySimilarImages = async () => {
-      const fullImage = await getImage({ id: originalImage.id });
+      const fullImage = await getImage({ id: originalId });
       setSimilarImages(fullImage.visuallySimilar);
     };
     fetchVisuallySimilarImages();
-  }, []);
+  }, [originalId]);
   return similarImages.length === 0 ? null : (
     <Space v={{ size: 'xl', properties: ['margin-bottom'] }}>
       <h3 className={font('wb', 5)}>Visually similar images</h3>


### PR DESCRIPTION
Got to admit this is where React hooks are really, really nice to use