### PR TITLE
Don't rely on work being available

### DIFF
--- a/common/views/components/ArchiveBreadcrumb/ArchiveBreadcrumb.js
+++ b/common/views/components/ArchiveBreadcrumb/ArchiveBreadcrumb.js
@@ -128,7 +128,10 @@ const ArchiveBreadcrumb = ({ work }: Props) => {
               name={`archive`}
             />
             <ConditionalWrapper
-              condition={breadcrumb.firstCrumb.work.id !== work.id}
+              condition={
+                breadcrumb.firstCrumb.work &&
+                breadcrumb.firstCrumb.work.id !== work.id
+              }
               wrapper={children => (
                 <NextLink {...workLink({ id: breadcrumb.firstCrumb.work.id })}>
                   <a className="crumb-inner">{children}</a>
@@ -137,10 +140,14 @@ const ArchiveBreadcrumb = ({ work }: Props) => {
             >
               <span
                 className={classNames({
-                  'crumb-inner': breadcrumb.firstCrumb.work.id === work.id,
+                  'crumb-inner':
+                    breadcrumb.firstCrumb.work &&
+                    breadcrumb.firstCrumb.work.id === work.id,
                 })}
               >
-                {breadcrumb.firstCrumb.work.title}
+                {breadcrumb.firstCrumb.work
+                  ? breadcrumb.firstCrumb.work.title
+                  : 'Unknown (not available)'}
               </span>
             </ConditionalWrapper>
           </li>
@@ -212,7 +219,9 @@ const ArchiveBreadcrumb = ({ work }: Props) => {
               }
             />
             <span className="crumb-inner">
-              {breadcrumb.lastCrumb.work.title}{' '}
+              {breadcrumb.lastCrumb.work
+                ? breadcrumb.lastCrumb.work.title
+                : 'Unknown (not available)'}{' '}
               {breadcrumb.lastCrumb.path.label}
             </span>
           </li>

--- a/common/views/components/ArchiveTree/ArchiveTree.js
+++ b/common/views/components/ArchiveTree/ArchiveTree.js
@@ -175,7 +175,9 @@ const ArchiveTree = ({ collection = collectionTree, currentWork }: Props) => {
       .then(resp => resp.json())
       .then(resp =>
         setBelongsToCrickArchive(
-          resp.collection && resp.collection.work.id === 'hz43r7re'
+          resp.collection &&
+            resp.collection.work &&
+            resp.collection.work.id === 'hz43r7re'
         )
       );
   }, []);

--- a/common/views/components/RelatedArchiveWorks/RelatedArchiveWorks.js
+++ b/common/views/components/RelatedArchiveWorks/RelatedArchiveWorks.js
@@ -47,7 +47,7 @@ const WorksGrid = ({ title, works }: WorksGridProps) => {
         <div className="css-grid">
           {works.map(item => (
             <div
-              key={item.work.id}
+              key={item.path.path}
               className={classNames({
                 [cssGrid({
                   s: 12,
@@ -57,28 +57,36 @@ const WorksGrid = ({ title, works }: WorksGridProps) => {
                 })]: true,
               })}
             >
-              <NextLink
-                {...workLink({ id: item.work.id })}
-                scroll={true}
-                passHref
-              >
-                <WorkLink selected={false}>
-                  {item.path.level !== 'Item' && (
-                    <Space
-                      as="span"
-                      h={{ size: 'xs', properties: ['margin-right'] }}
-                    >
-                      <Icon
-                        extraClasses={`icon--match-text icon--currentColor`}
-                        name="folder"
-                      />
-                    </Space>
-                  )}
-                  {item.work.title}
+              {item.work ? (
+                <NextLink
+                  {...workLink({ id: item.work.id })}
+                  scroll={true}
+                  passHref
+                >
+                  <WorkLink selected={false}>
+                    {item.path.level !== 'Item' && (
+                      <Space
+                        as="span"
+                        h={{ size: 'xs', properties: ['margin-right'] }}
+                      >
+                        <Icon
+                          extraClasses={`icon--match-text icon--currentColor`}
+                          name="folder"
+                        />
+                      </Space>
+                    )}
+                    {item.work.title}
+                    <br />
+                    {item.path.path}
+                  </WorkLink>
+                </NextLink>
+              ) : (
+                <WorkLink>
+                  {`Unknown (not available)`}
                   <br />
                   {item.path.path}
                 </WorkLink>
-              </NextLink>
+              )}
             </div>
           ))}
         </div>
@@ -120,13 +128,21 @@ const RelatedArchiveWorks = ({ work }: Props) => {
         currentTree.children &&
         currentTree.children.length > 0 && (
           <WorksGrid
-            title={`${currentTree.work.title} ${currentTree.path.path} contains:`}
+            title={`${
+              currentTree.work
+                ? currentTree.work.title
+                : 'Unknown (not available)'
+            } ${currentTree.path.path} contains:`}
             works={currentTree.children}
           />
         )}
       {parentTree && parentTree.children && parentTree.children.length > 0 && (
         <WorksGrid
-          title={`Siblings of ${currentTree.work.title} ${currentTree.path.path}:`}
+          title={`Siblings of ${
+            currentTree.work
+              ? currentTree.work.title
+              : 'Unknown (not available)'
+          } ${currentTree.path.path}:`}
           works={parentTree.children}
         />
       )}


### PR DESCRIPTION
More of what's in #5315 to get prototype archive UI displaying (and stop the app from breaking if you have archive prototype toggles turned on).

Basically, we can't rely on `work` being in the archive api response, so have to check.
