### PR TITLE
Link reset

### DIFF
--- a/common/styles/components/_body_text.scss
+++ b/common/styles/components/_body_text.scss
@@ -36,14 +36,13 @@
     }
   }
 
-  a:link,
-  a:visited {
+  a:link:not(.link-reset),
+  a:visited:not(.link-reset) {
     text-decoration: none;
     border-bottom: 2px solid color('green');
     transition: color $transition-properties, border-bottom $transition-properties;
 
-    &:hover,
-    &:focus {
+    &:hover {
       color: color('green');
       border-bottom-color: color('transparent');
     }

--- a/common/views/components/ButtonOutlined/ButtonOutlined.tsx
+++ b/common/views/components/ButtonOutlined/ButtonOutlined.tsx
@@ -10,8 +10,15 @@ import {
   ButtonIconWrapper,
 } from '../ButtonSolid/ButtonSolid';
 
-export const OutlinedButton = styled(BaseButton).attrs(props => ({
-  className: '',
+
+type MaybeAnchor = {
+  href?: string,
+}
+
+export const OutlinedButton = styled(BaseButton).attrs<MaybeAnchor>(props => ({
+  className: classNames({
+    'link-reset': !!props.href,
+  }),
 }))`
   border: 2px solid ${props => props.theme.colors.green};
   background: ${props => props.theme.colors.transparent};


### PR DESCRIPTION
If a component comprised of an anchor tag is inside a `.body-text` block, the css currently applies any border bottom to be transparent on hover. This is undesirable if the component has its own border, e.g.

![image](https://user-images.githubusercontent.com/1394592/86820701-4f2ec200-c081-11ea-9287-e70def0a960a.png)

This adds a `:not(.link-reset)` declaration to the `.body-text` css, and anywhere we want to remove the hover behaviour within an anchor component, we can add the `link-reset` class.

This is branched off #5319 so there should only be a couple of files changes if/when that gets merged ([this commit](https://github.com/wellcomecollection/wellcomecollection.org/pull/5355/commits/0189b36e3ae78edfa0d282533fb70cd8506321a4)).
