### PR TITLE
Add toggle for the miro merging test index

### DIFF
--- a/catalogue/webapp/components/ExpandedImage/ExpandedImage.js
+++ b/catalogue/webapp/components/ExpandedImage/ExpandedImage.js
@@ -1,4 +1,5 @@
 // @flow
+import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
 import NextLink from 'next/link';
 import { workLink, itemLink } from '@weco/common/services/catalogue/routes';
 import { font, classNames } from '@weco/common/utils/classnames';
@@ -164,6 +165,7 @@ const ExpandedImage = ({
   onImageLinkClick,
 }: Props) => {
   const { isKeyboard } = useContext(AppContext);
+  const toggles = useContext(TogglesContext);
   const [detailedWork, setDetailedWork] = useState(null);
   const modalRef = useRef(null);
   const closeButtonRef = useRef(null);
@@ -198,7 +200,7 @@ const ExpandedImage = ({
   }, []);
   useEffect(() => {
     const fetchDetailedWork = async () => {
-      const res = await getWork({ id: workId });
+      const res = await getWork({ id: workId, toggles });
       if (res.type === 'Work') {
         setDetailedWork(res);
       }

--- a/catalogue/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.js
+++ b/catalogue/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.js
@@ -2,7 +2,8 @@
 import { font, classNames } from '@weco/common/utils/classnames';
 import Image from '@weco/common/views/components/Image/Image';
 import { type Image as ImageType } from '@weco/common/model/catalogue';
-import { useEffect, useState } from 'react';
+import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
+import { useContext, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { getImage } from '../../services/catalogue/images';
 import Space from '@weco/common/views/components/styled/Space';
@@ -29,9 +30,10 @@ const Wrapper = styled.div`
 
 const VisuallySimilarImagesFromApi = ({ originalId, onClickImage }: Props) => {
   const [similarImages, setSimilarImages] = useState<ImageType[]>([]);
+  const toggles = useContext(TogglesContext);
   useEffect(() => {
     const fetchVisuallySimilarImages = async () => {
-      const fullImage = await getImage({ id: originalId });
+      const fullImage = await getImage({ id: originalId, toggles });
       setSimilarImages(fullImage.visuallySimilar);
     };
     fetchVisuallySimilarImages();

--- a/catalogue/webapp/pages/download.js
+++ b/catalogue/webapp/pages/download.js
@@ -150,7 +150,7 @@ DownloadPage.getInitialProps = async (ctx: Context): Promise<Props> => {
     ? `https://wellcomelibrary.org/iiif/${sierraId}/manifest`
     : null;
   const manifest = manifestUrl ? await (await fetch(manifestUrl)).json() : null;
-  const work = await getWork({ id: workId });
+  const work = await getWork({ id: workId, toggles: ctx.query.toggles });
   return {
     workId,
     sierraId,

--- a/catalogue/webapp/pages/item.js
+++ b/catalogue/webapp/pages/item.js
@@ -234,10 +234,9 @@ ItemPage.getInitialProps = async (ctx: Context): Promise<Props> => {
   const manifest = manifestUrl ? await (await fetch(manifestUrl)).json() : null;
   const video = manifest && getVideo(manifest);
   const audio = manifest && getAudio(manifest);
-  const { stagingApi } = ctx.query.toggles;
   const work = await getWork({
     id: workId,
-    env: stagingApi ? 'stage' : 'prod',
+    toggles: ctx.query.toggles,
   });
   const canvases =
     manifest && manifest.sequences && manifest.sequences[0].canvases

--- a/catalogue/webapp/pages/work.tsx
+++ b/catalogue/webapp/pages/work.tsx
@@ -30,12 +30,10 @@ export const WorkPage: NextPage<Props> = ({ workResponse }) => {
 
 WorkPage.getInitialProps = async (ctx: NextPageContext) => {
   const { id } = ctx.query;
-  // @ts-ignore
-  const { stagingApi } = ctx.query.toggles;
 
   const workResponse = await getWork({
     id,
-    env: stagingApi ? 'stage' : 'prod',
+    toggles: ctx.query.toggles,
   });
 
   if (workResponse) {

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -389,11 +389,7 @@ const IMAGES_LOCATION_TYPE = 'iiif-image';
 
 Works.getInitialProps = async (ctx: Context): Promise<Props> => {
   const params = WorksRoute.fromQuery(ctx.query);
-  const {
-    unfilteredSearchResults,
-    imagesEndpoint,
-    stagingApi,
-  } = ctx.query.toggles;
+  const { unfilteredSearchResults, imagesEndpoint } = ctx.query.toggles;
   const _queryType = cookies(ctx)._queryType;
   const isImageSearch = params.search === 'images';
 
@@ -420,12 +416,11 @@ Works.getInitialProps = async (ctx: Context): Promise<Props> => {
 
   const shouldGetWorks = hasQuery && !isEndpointImageSearch;
   const shouldGetImages = hasQuery && isEndpointImageSearch;
-  const apiEnv = stagingApi ? 'stage' : 'prod';
 
   const worksOrError = shouldGetWorks
     ? await getWorks({
         params: apiProps,
-        env: apiEnv,
+        toggles: ctx.query.toggles,
       })
     : null;
 
@@ -433,7 +428,7 @@ Works.getInitialProps = async (ctx: Context): Promise<Props> => {
   const imagesOrError = shouldGetImages
     ? await getImages({
         params: worksPropsToImagesProps(apiProps),
-        env: apiEnv,
+        toggles: ctx.query.toggles,
       })
     : null;
 

--- a/catalogue/webapp/services/catalogue/common.js
+++ b/catalogue/webapp/services/catalogue/common.js
@@ -1,6 +1,3 @@
-import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
-import { useContext } from 'react';
-
 export const rootUris = {
   prod: 'https://api.wellcomecollection.org/catalogue',
   stage: 'https://api-stage.wellcomecollection.org/catalogue',
@@ -8,21 +5,9 @@ export const rootUris = {
 
 export type Toggles = { [key: string]: boolean };
 
-export const isomorphicGetApiOptions = maybeToggles => {
-  let toggles = maybeToggles;
-  try {
-    toggles = useContext(TogglesContext); // eslint-disable-line
-  } catch (e) {
-    if (!toggles) {
-      throw new Error(
-        'If using isomorphicGetApiOptions outside of a React component, a toggles object must be provided'
-      );
-    }
-  }
-  return {
-    env: toggles.stagingApi ? 'stage' : 'prod',
-    indexOverrideSuffix: toggles.miroMergingTest
-      ? 'miro-merging-test'
-      : undefined,
-  };
-};
+export const globalApiOptions = (toggles: Toggles) => ({
+  env: toggles.stagingApi ? 'stage' : 'prod',
+  indexOverrideSuffix: toggles.miroMergingTest
+    ? 'miro-merging-test' // This is an index alias, not an actual index name
+    : undefined,
+});

--- a/catalogue/webapp/services/catalogue/common.js
+++ b/catalogue/webapp/services/catalogue/common.js
@@ -1,3 +1,5 @@
+import { serialiseUrl } from '@weco/common/services/catalogue/routes';
+
 export const rootUris = {
   prod: 'https://api.wellcomecollection.org/catalogue',
   stage: 'https://api-stage.wellcomecollection.org/catalogue',
@@ -5,9 +7,22 @@ export const rootUris = {
 
 export type Toggles = { [key: string]: boolean };
 
-export const globalApiOptions = (toggles: Toggles) => ({
+type GlobalApiOptions = {|
+  env: 'prod' | 'stage',
+  indexOverrideSuffix: ?string,
+|};
+
+export const globalApiOptions = (toggles: Toggles): GlobalApiOptions => ({
   env: toggles.stagingApi ? 'stage' : 'prod',
   indexOverrideSuffix: toggles.miroMergingTest
     ? 'miro-merging-test' // This is an index alias, not an actual index name
-    : undefined,
+    : null,
 });
+
+export const queryString = (params: { [key: string]: any }): string => {
+  const strings = Object.keys(serialiseUrl(params)).map(key => {
+    const val = params[key];
+    return `${key}=${encodeURIComponent(val)}`;
+  });
+  return strings.length > 0 ? `?${strings.join('&')}` : '';
+};

--- a/catalogue/webapp/services/catalogue/common.js
+++ b/catalogue/webapp/services/catalogue/common.js
@@ -1,8 +1,28 @@
+import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
+import { useContext } from 'react';
+
 export const rootUris = {
   prod: 'https://api.wellcomecollection.org/catalogue',
   stage: 'https://api-stage.wellcomecollection.org/catalogue',
 };
 
-export type Environment = {|
-  env?: $Keys<typeof rootUris>,
-|};
+export type Toggles = { [key: string]: boolean };
+
+export const isomorphicGetApiOptions = maybeToggles => {
+  let toggles = maybeToggles;
+  try {
+    toggles = useContext(TogglesContext); // eslint-disable-line
+  } catch (e) {
+    if (!toggles) {
+      throw new Error(
+        'If using isomorphicGetApiOptions outside of a React component, a toggles object must be provided'
+      );
+    }
+  }
+  return {
+    env: toggles.stagingApi ? 'stage' : 'prod',
+    indexOverrideSuffix: toggles.miroMergingTest
+      ? 'miro-merging-test'
+      : undefined,
+  };
+};

--- a/catalogue/webapp/services/catalogue/images.js
+++ b/catalogue/webapp/services/catalogue/images.js
@@ -6,30 +6,34 @@ import type {
 } from '@weco/common/model/catalogue';
 import { type CatalogueImagesApiProps } from '@weco/common/services/catalogue/api';
 import { serialiseUrl } from '@weco/common/services/catalogue/routes';
-import { type Environment, rootUris } from './common';
+import { type Toggles, isomorphicGetApiOptions, rootUris } from './common';
 
 type GetImagesProps = {|
   params: CatalogueImagesApiProps,
   pageSize?: number,
-  ...Environment,
+  toggles?: Toggles,
 |};
 
 type GetImageProps = {|
   id: string,
-  ...Environment,
+  toggles?: Toggles,
 |};
 
 export async function getImages({
   params,
-  env = 'prod',
+  toggles,
   pageSize = 25,
 }: GetImagesProps): Promise<CatalogueResultsList<Image> | CatalogueApiError> {
+  const apiOptions = isomorphicGetApiOptions(toggles);
+  if (apiOptions.indexOverrideSuffix) {
+    params._index = `&_index=images-${apiOptions.indexOverrideSuffix}`;
+  }
   const filterQueryString = Object.keys(serialiseUrl(params)).map(key => {
     const val = params[key];
     return `${key}=${encodeURIComponent(val)}`;
   });
   const url =
-    `${rootUris[env]}/v2/images?pageSize=${pageSize}` +
+    `${rootUris[apiOptions.env]}/v2/images?pageSize=${pageSize}` +
     (filterQueryString.length > 0 ? `&${filterQueryString.join('&')}` : '');
   try {
     const res = await fetch(url);
@@ -51,11 +55,15 @@ const imageIncludes = ['visuallySimilar'];
 
 export async function getImage({
   id,
-  env = 'prod',
+  toggles,
 }: GetImageProps): Promise<Image | CatalogueApiError> {
-  const url = `${rootUris[env]}/v2/images/${id}?include=${imageIncludes.join(
-    ','
-  )}`;
+  const apiOptions = isomorphicGetApiOptions(toggles);
+  let url = `${
+    rootUris[apiOptions.env]
+  }/v2/images/${id}?include=${imageIncludes.join(',')}`;
+  if (apiOptions.indexOverrideSuffix) {
+    url += `&_index=images-${apiOptions.indexOverrideSuffix}`;
+  }
   const res = await fetch(url);
   const json = await res.json();
   return json;

--- a/catalogue/webapp/services/catalogue/images.js
+++ b/catalogue/webapp/services/catalogue/images.js
@@ -25,13 +25,18 @@ export async function getImages({
   pageSize = 25,
 }: GetImagesProps): Promise<CatalogueResultsList<Image> | CatalogueApiError> {
   const apiOptions = isomorphicGetApiOptions(toggles);
-  if (apiOptions.indexOverrideSuffix) {
-    params._index = `&_index=images-${apiOptions.indexOverrideSuffix}`;
-  }
-  const filterQueryString = Object.keys(serialiseUrl(params)).map(key => {
-    const val = params[key];
-    return `${key}=${encodeURIComponent(val)}`;
-  });
+  const extendedParams = {
+    ...params,
+    _index: apiOptions.indexOverrideSuffix
+      ? `images-${apiOptions.indexOverrideSuffix}`
+      : undefined,
+  };
+  const filterQueryString = Object.keys(serialiseUrl(extendedParams)).map(
+    key => {
+      const val = params[key];
+      return `${key}=${encodeURIComponent(val)}`;
+    }
+  );
   const url =
     `${rootUris[apiOptions.env]}/v2/images?pageSize=${pageSize}` +
     (filterQueryString.length > 0 ? `&${filterQueryString.join('&')}` : '');

--- a/catalogue/webapp/services/catalogue/images.js
+++ b/catalogue/webapp/services/catalogue/images.js
@@ -6,17 +6,17 @@ import type {
 } from '@weco/common/model/catalogue';
 import { type CatalogueImagesApiProps } from '@weco/common/services/catalogue/api';
 import { serialiseUrl } from '@weco/common/services/catalogue/routes';
-import { type Toggles, isomorphicGetApiOptions, rootUris } from './common';
+import { type Toggles, rootUris, globalApiOptions } from './common';
 
 type GetImagesProps = {|
   params: CatalogueImagesApiProps,
   pageSize?: number,
-  toggles?: Toggles,
+  toggles: Toggles,
 |};
 
 type GetImageProps = {|
   id: string,
-  toggles?: Toggles,
+  toggles: Toggles,
 |};
 
 export async function getImages({
@@ -24,7 +24,7 @@ export async function getImages({
   toggles,
   pageSize = 25,
 }: GetImagesProps): Promise<CatalogueResultsList<Image> | CatalogueApiError> {
-  const apiOptions = isomorphicGetApiOptions(toggles);
+  const apiOptions = globalApiOptions(toggles);
   const extendedParams = {
     ...params,
     _index: apiOptions.indexOverrideSuffix
@@ -33,7 +33,7 @@ export async function getImages({
   };
   const filterQueryString = Object.keys(serialiseUrl(extendedParams)).map(
     key => {
-      const val = params[key];
+      const val = extendedParams[key];
       return `${key}=${encodeURIComponent(val)}`;
     }
   );
@@ -62,7 +62,7 @@ export async function getImage({
   id,
   toggles,
 }: GetImageProps): Promise<Image | CatalogueApiError> {
-  const apiOptions = isomorphicGetApiOptions(toggles);
+  const apiOptions = globalApiOptions(toggles);
   let url = `${
     rootUris[apiOptions.env]
   }/v2/images/${id}?include=${imageIncludes.join(',')}`;

--- a/catalogue/webapp/services/catalogue/works.js
+++ b/catalogue/webapp/services/catalogue/works.js
@@ -41,13 +41,18 @@ export async function getWorks({
   pageSize = 25,
 }: GetWorksProps): Promise<CatalogueResultsList<Work> | CatalogueApiError> {
   const apiOptions = isomorphicGetApiOptions(toggles);
-  if (apiOptions.indexOverrideSuffix) {
-    params._index = `works-${apiOptions.indexOverrideSuffix}`;
-  }
-  const filterQueryString = Object.keys(serialiseUrl(params)).map(key => {
-    const val = params[key];
-    return `${key}=${encodeURIComponent(val)}`;
-  });
+  const extendedParams = {
+    ...params,
+    _index: apiOptions.indexOverrideSuffix
+      ? `works-${apiOptions.indexOverrideSuffix}`
+      : undefined,
+  };
+  const filterQueryString = Object.keys(serialiseUrl(extendedParams)).map(
+    key => {
+      const val = params[key];
+      return `${key}=${encodeURIComponent(val)}`;
+    }
+  );
   const url =
     `${rootUris[apiOptions.env]}/v2/works?include=${worksIncludes.join(',')}` +
     `&pageSize=${pageSize}` +

--- a/catalogue/webapp/services/catalogue/works.js
+++ b/catalogue/webapp/services/catalogue/works.js
@@ -10,7 +10,7 @@ import { type IIIFCanvas } from '@weco/common/model/iiif';
 import Raven from 'raven-js';
 import { serialiseUrl } from '@weco/common/services/catalogue/routes';
 import { type CatalogueWorksApiProps } from '@weco/common/services/catalogue/api';
-import { type Toggles, isomorphicGetApiOptions, rootUris } from './common';
+import { type Toggles, rootUris, globalApiOptions } from './common';
 
 type GetWorkProps = {|
   id: string,
@@ -40,7 +40,7 @@ export async function getWorks({
   toggles,
   pageSize = 25,
 }: GetWorksProps): Promise<CatalogueResultsList<Work> | CatalogueApiError> {
-  const apiOptions = isomorphicGetApiOptions(toggles);
+  const apiOptions = globalApiOptions(toggles);
   const extendedParams = {
     ...params,
     _index: apiOptions.indexOverrideSuffix
@@ -49,7 +49,7 @@ export async function getWorks({
   };
   const filterQueryString = Object.keys(serialiseUrl(extendedParams)).map(
     key => {
-      const val = params[key];
+      const val = extendedParams[key];
       return `${key}=${encodeURIComponent(val)}`;
     }
   );
@@ -77,7 +77,7 @@ export async function getWork({
   id,
   toggles,
 }: GetWorkProps): Promise<Work | CatalogueApiError | CatalogueApiRedirect> {
-  const apiOptions = isomorphicGetApiOptions(toggles);
+  const apiOptions = globalApiOptions(toggles);
   let url = `${
     rootUris[apiOptions.env]
   }/v2/works/${id}?include=${workIncludes.join(',')}`;

--- a/common/services/catalogue/api.js
+++ b/common/services/catalogue/api.js
@@ -39,12 +39,14 @@ export type CatalogueWorksApiProps = {|
   'production.dates.to': ?string,
   _queryType: ?string,
   aggregations: ?(string[]),
+  _index: ?string,
 |};
 
 export type CatalogueImagesApiProps = {|
   query: ?string,
   page: ?number,
   'locations.license': ?(string[]),
+  _index: ?string,
 |};
 
 export function worksRouteToApiUrl(

--- a/common/services/catalogue/api.js
+++ b/common/services/catalogue/api.js
@@ -39,14 +39,12 @@ export type CatalogueWorksApiProps = {|
   'production.dates.to': ?string,
   _queryType: ?string,
   aggregations: ?(string[]),
-  _index: ?string,
 |};
 
 export type CatalogueImagesApiProps = {|
   query: ?string,
   page: ?number,
   'locations.license': ?(string[]),
-  _index: ?string,
 |};
 
 export function worksRouteToApiUrl(

--- a/toggles/webapp/toggles.js
+++ b/toggles/webapp/toggles.js
@@ -28,6 +28,13 @@ module.exports = {
         'Rather than searching for works filtered by iiif-image, use the new (beta) images endpoint for image search',
     },
     {
+      id: 'miroMergingTest',
+      title: 'Use the Miro merging test index',
+      defaultValue: false,
+      description:
+        'The miro merging test merges as many miro works as possible (ie regardless of number or worktype)',
+    },
+    {
       id: 'searchToolbar',
       title: 'Search toolbar',
       defaultValue: false,


### PR DESCRIPTION
I realised I hadn't been using the `stagingApi` toggle where I should've been so I've moved the logic for that into the `get<Thing>` functions - hopefully will avoid the same mistake in future.