### PR TITLE
Images page

### DIFF
--- a/catalogue/webapp/app.js
+++ b/catalogue/webapp/app.js
@@ -53,6 +53,7 @@ module.exports = app
     route('/works/:id', '/work', router, app);
     route('/works', '/works', router, app);
     route('/works/:workId/items', '/item', router, app);
+    route('/works/:workId/images', '/image', router, app);
     route('/works/:workId/download', '/download', router, app);
 
     router.get('/works/management/healthcheck', async ctx => {

--- a/catalogue/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.js
+++ b/catalogue/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.js
@@ -33,7 +33,11 @@ const VisuallySimilarImagesFromApi = ({ originalId, onClickImage }: Props) => {
   const toggles = useContext(TogglesContext);
   useEffect(() => {
     const fetchVisuallySimilarImages = async () => {
-      const fullImage = await getImage({ id: originalId, toggles });
+      const fullImage = await getImage({
+        id: originalId,
+        toggles,
+        include: ['visuallySimilar'],
+      });
       setSimilarImages(fullImage.visuallySimilar);
     };
     fetchVisuallySimilarImages();

--- a/catalogue/webapp/pages/image.js
+++ b/catalogue/webapp/pages/image.js
@@ -1,0 +1,126 @@
+// @flow
+import { type Context } from 'next';
+import { type Work, type Image } from '@weco/common/model/catalogue';
+import { imageLink } from '@weco/common/services/catalogue/routes';
+import { getWork } from '../services/catalogue/works';
+import { getImage } from '../services/catalogue/images';
+import CataloguePageLayout from '@weco/common/views/components/CataloguePageLayout/CataloguePageLayout';
+import Layout12 from '@weco/common/views/components/Layout12/Layout12';
+import IIIFViewer from '@weco/common/views/components/IIIFViewer/IIIFViewer';
+import BetaMessage from '@weco/common/views/components/BetaMessage/BetaMessage';
+import Space from '@weco/common/views/components/styled/Space';
+
+type Props = {|
+  image: Image,
+  sourceWork: Work,
+  langCode: string,
+|};
+
+const ImagePage = ({ image, sourceWork, langCode }: Props) => {
+  const title = sourceWork.title || '';
+  const iiifImageLocation = image.locations[0];
+
+  const sharedPaginatorProps = {
+    totalResults: 1,
+    link: imageLink({
+      workId: sourceWork.id,
+      id: image.id,
+      langCode,
+    }),
+  };
+
+  const mainPaginatorProps = {
+    currentPage: 1,
+    pageSize: 1,
+    linkKey: 'canvas',
+    ...sharedPaginatorProps,
+  };
+
+  const thumbsPaginatorProps = {
+    currentPage: 1,
+    pageSize: 1,
+    linkKey: 'page',
+    ...sharedPaginatorProps,
+  };
+
+  return (
+    <CataloguePageLayout
+      title={title}
+      description={''}
+      url={{
+        pathname: `/works/${sourceWork.id}/images`,
+        query: { id: image.id },
+      }}
+      openGraphType={'website'}
+      jsonLd={{ '@type': 'WebPage' }}
+      siteSection={'works'}
+      imageUrl={'imageContentUrl'}
+      imageAltText={''}
+      hideNewsletterPromo={true}
+      hideFooter={true}
+      hideInfoBar={true}
+    >
+      {iiifImageLocation ? (
+        <IIIFViewer
+          title={title}
+          mainPaginatorProps={mainPaginatorProps}
+          thumbsPaginatorProps={thumbsPaginatorProps}
+          currentCanvas={null}
+          lang={langCode}
+          canvasOcr={null}
+          canvases={[]}
+          workId={sourceWork.id}
+          pageIndex={0}
+          sierraId=""
+          pageSize={1}
+          canvasIndex={0}
+          iiifImageLocation={iiifImageLocation}
+          work={sourceWork}
+          manifest={null}
+        />
+      ) : (
+        <Layout12>
+          <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
+            <div style={{ marginTop: '98px' }}>
+              <BetaMessage message="We are working to make this image available online." />
+            </div>
+          </Space>
+        </Layout12>
+      )}
+    </CataloguePageLayout>
+  );
+};
+
+ImagePage.getInitialProps = async (ctx: Context): Promise<Props> => {
+  const { id, workId, langCode } = ctx.query;
+  if (!id) {
+    // $FlowFixMe
+    return { statusCode: 404 };
+  }
+
+  const image = await getImage({
+    id,
+    toggles: ctx.query.toggles,
+  });
+  if (image.type === 'Error' || image.source.id !== workId) {
+    // $FlowFixMe
+    return { statusCode: 404 };
+  }
+
+  const work = await getWork({
+    id: workId,
+    toggles: ctx.query.toggles,
+  });
+  if (work.type === 'Error') {
+    // $FlowFixMe
+    return { statusCode: 404 };
+  }
+
+  return {
+    image,
+    langCode,
+    sourceWork: work,
+  };
+};
+
+export default ImagePage;

--- a/catalogue/webapp/pages/image.js
+++ b/catalogue/webapp/pages/image.js
@@ -93,7 +93,8 @@ const ImagePage = ({ image, sourceWork, langCode }: Props) => {
 
 ImagePage.getInitialProps = async (ctx: Context): Promise<Props> => {
   const { id, workId, langCode } = ctx.query;
-  if (!id) {
+  const { imagesEndpoint } = ctx.query.toggles;
+  if (!id || !imagesEndpoint) {
     // $FlowFixMe
     return { statusCode: 404 };
   }

--- a/catalogue/webapp/pages/item.js
+++ b/catalogue/webapp/pages/item.js
@@ -6,7 +6,6 @@ import {
   type CatalogueApiError,
 } from '@weco/common/model/catalogue';
 import fetch from 'isomorphic-unfetch';
-import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
 import { type IIIFManifest } from '@weco/common/model/iiif';
 import { itemLink } from '@weco/common/services/catalogue/routes';
 import { getDigitalLocationOfType } from '@weco/common/utils/works';
@@ -76,10 +75,6 @@ const ItemPage = ({
   const title = (manifest && manifest.label) || (work && work.title) || '';
   const iiifImageLocation =
     work && getDigitalLocationOfType(work, 'iiif-image');
-  const iiifImageLocationUrl = iiifImageLocation && iiifImageLocation.url;
-  const iiifImage =
-    iiifImageLocationUrl && iiifImageTemplate(iiifImageLocationUrl);
-  const imageUrl = iiifImage && iiifImage({ size: '800,' });
   const mainImageService =
     currentCanvas && currentCanvas.images[0].resource.service
       ? {
@@ -171,7 +166,7 @@ const ItemPage = ({
         !video &&
         !pdfRendering &&
         !mainImageService &&
-        !iiifImageLocationUrl && (
+        !iiifImageLocation && (
           <Layout12>
             <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
               <div style={{ marginTop: '98px' }}>
@@ -192,8 +187,7 @@ const ItemPage = ({
         />
       )}
 
-      {((mainImageService && currentCanvas) ||
-        (imageUrl && iiifImageLocationUrl)) && (
+      {((mainImageService && currentCanvas) || iiifImageLocation) && (
         <IIIFViewer
           title={title}
           mainPaginatorProps={mainPaginatorProps}
@@ -207,8 +201,7 @@ const ItemPage = ({
           sierraId={sierraId}
           pageSize={pageSize}
           canvasIndex={canvasIndex}
-          iiifImageLocationUrl={iiifImageLocationUrl}
-          imageUrl={imageUrl}
+          iiifImageLocation={iiifImageLocation}
           work={work}
           manifest={manifest}
         />

--- a/catalogue/webapp/services/catalogue/images.js
+++ b/catalogue/webapp/services/catalogue/images.js
@@ -18,9 +18,12 @@ type GetImagesProps = {|
   toggles: Toggles,
 |};
 
+type ImageInclude = 'visuallySimilar';
+
 type GetImageProps = {|
   id: string,
   toggles: Toggles,
+  include: ImageInclude[],
 |};
 
 export async function getImages({
@@ -54,15 +57,14 @@ export async function getImages({
   }
 }
 
-const imageIncludes = ['visuallySimilar'];
-
 export async function getImage({
   id,
   toggles,
+  include = [],
 }: GetImageProps): Promise<Image | CatalogueApiError> {
   const apiOptions = globalApiOptions(toggles);
   const params = {
-    include: imageIncludes,
+    include: include,
     _index: apiOptions.indexOverrideSuffix
       ? `images-${apiOptions.indexOverrideSuffix}`
       : null,

--- a/common/services/catalogue/routes.js
+++ b/common/services/catalogue/routes.js
@@ -212,7 +212,41 @@ export const ItemRoute: NextRoute<ItemRouteProps> = {
   },
 };
 
+export type ImageRouteProps = {|
+  id: string,
+  workId: string,
+  langCode: string,
+|};
+
+export const ImageRoute: NextRoute<ImageRouteProps> = {
+  fromQuery(q) {
+    const { workId, langCode = 'eng', id } = q;
+    return {
+      workId: defaultToEmptyString(workId),
+      langCode,
+      id: defaultToEmptyString(id),
+    };
+  },
+  toLink(params) {
+    const { workId, ...as } = params;
+    return {
+      href: {
+        pathname: '/image',
+        query: ImageRoute.toQuery(params),
+      },
+      as: {
+        pathname: `/works/${workId}/images`,
+        query: ImageRoute.toQuery(as),
+      },
+    };
+  },
+  toQuery(params) {
+    return serialiseUrl(params);
+  },
+};
+
 export const worksLink = (params: $Shape<WorksRouteProps>, source: string) =>
   WorksRoute.toLink({ ...params, source });
 export const workLink = WorkRoute.toLink;
 export const itemLink = ItemRoute.toLink;
+export const imageLink = ImageRoute.toLink;

--- a/common/views/components/IIIFViewer/IIIFViewer.js
+++ b/common/views/components/IIIFViewer/IIIFViewer.js
@@ -293,6 +293,7 @@ const IIIFViewerComponent = ({
   }, []);
   const urlTemplate =
     iiifImageLocation && iiifImageTemplate(iiifImageLocation.url);
+  const imageUrl = urlTemplate && urlTemplate({ size: '800,' });
   const iiifPresentationLocation =
     work && work.type !== 'Error'
       ? getDigitalLocationOfType(work, 'iiif-presentation')
@@ -442,10 +443,10 @@ const IIIFViewerComponent = ({
             isFullscreen={isFullscreen}
           />
         )}
-        {!enhanced && urlTemplate && (
+        {!enhanced && (
           <NoScriptViewer
             thumbnailsRequired={thumbnailsRequired || false}
-            imageUrl={urlTemplate({ size: '800,' })}
+            imageUrl={imageUrl}
             iiifImageLocation={iiifImageLocation}
             currentCanvas={currentCanvas}
             canvasOcr={canvasOcr}
@@ -508,11 +509,11 @@ const IIIFViewerComponent = ({
                 />
               </Space>
             </ImageViewerControls>
-            {urlTemplate && (
+            {urlTemplate && imageUrl && iiifImageLocation && (
               <IIIFViewerImageWrapper>
                 <ImageViewer
                   infoUrl={iiifImageLocation.url}
-                  id={urlTemplate({ size: '800,' })}
+                  id={imageUrl}
                   width={800}
                   alt={(work && work.description) || (work && work.title) || ''}
                   urlTemplate={urlTemplate}

--- a/common/views/components/IIIFViewer/parts/NoScriptViewer.js
+++ b/common/views/components/IIIFViewer/parts/NoScriptViewer.js
@@ -139,7 +139,6 @@ type NoScriptViewerProps = {|
   pageIndex: number,
   sierraId: string,
   pageSize: number,
-  iiifImageLocationUrl: ?string,
   imageUrl: ?string,
   thumbnailsRequired: boolean,
   iiifImageLocation: ?{ url: string },
@@ -149,7 +148,6 @@ type NoScriptViewerProps = {|
 
 const NoScriptViewer = ({
   thumbnailsRequired,
-  iiifImageLocationUrl,
   imageUrl,
   iiifImageLocation,
   currentCanvas,
@@ -195,7 +193,7 @@ const NoScriptViewer = ({
         fullWidth={!thumbnailsRequired}
       >
         <IIIFViewerImageWrapper>
-          {iiifImageLocationUrl && imageUrl && (
+          {iiifImageLocation && imageUrl && (
             <IIIFResponsiveImage
               width={800}
               src={imageUrl}


### PR DESCRIPTION
This is similar to the items page in that it wraps IIIFViewer, albeit without all the other possibilities that items can bring. I also tried to reduce some of the duplication involved in the `iiifImageLocation`/`iiifImageLocationUrl`/`imageUrl` etc values in and around the viewer.

You would access this page with a route like:
```
/works/t867gjws/images?id=as33wqfn
```