### PR TITLE
sets the archivesPrototype value and adds cookie based on query param…

### DIFF
--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -45,6 +45,7 @@ type Props = {|
   unfilteredSearchResults: boolean,
   shouldGetWorks: boolean,
   apiProps: CatalogueWorksApiProps,
+  setArchivesPrototypeCookie: boolean,
 |};
 
 const Works = ({
@@ -54,6 +55,7 @@ const Works = ({
   unfilteredSearchResults,
   shouldGetWorks,
   apiProps,
+  setArchivesPrototypeCookie,
 }: Props) => {
   const [loading, setLoading] = useState(false);
   const [, setSavedSearchState] = useSavedSearchState(worksRouteProps);
@@ -66,6 +68,12 @@ const Works = ({
     productionDatesFrom,
     productionDatesTo,
   } = worksRouteProps;
+
+  useEffect(() => {
+    if (setArchivesPrototypeCookie) {
+      document.cookie = `toggle_archivesPrototype=true; Max-Age=${31536000}`;
+    }
+  }, []);
 
   useEffect(() => {
     trackSearch(apiProps, {
@@ -376,6 +384,10 @@ const IMAGES_LOCATION_TYPE = 'iiif-image';
 
 Works.getInitialProps = async (ctx: Context): Promise<Props> => {
   const params = WorksRoute.fromQuery(ctx.query);
+  const shouldSeeArchives = ctx.query.archivesPrototype;
+  if (shouldSeeArchives) {
+    ctx.query.toggles.archivesPrototype = true;
+  }
   const {
     unfilteredSearchResults,
     imagesEndpoint,
@@ -383,7 +395,6 @@ Works.getInitialProps = async (ctx: Context): Promise<Props> => {
   } = ctx.query.toggles;
   const _queryType = cookies(ctx)._queryType;
   const isImageSearch = params.search === 'images';
-
   const apiPropsFn = unfilteredSearchResults
     ? worksRouteToApiUrl
     : worksRouteToApiUrlWithDefaults;
@@ -447,6 +458,7 @@ Works.getInitialProps = async (ctx: Context): Promise<Props> => {
     unfilteredSearchResults,
     shouldGetWorks,
     apiProps,
+    setArchivesPrototypeCookie: shouldSeeArchives,
   };
 };
 


### PR DESCRIPTION
References #4321

## Who is this for?
People outside the team (internal and external users) who we want to test new toggled functionality with

## What is it doing for them?
Allows test participants to go to a url (in this case /works?archivesPrototype=true) in order to access prototype work, rather than have to navigate to the toggles dash first and follow instructions of which toggles to turn on
