### PR TITLE
Remove FeaturedCard copy/image overlap

### DIFF
--- a/common/views/components/FeaturedCard/FeaturedCard.js
+++ b/common/views/components/FeaturedCard/FeaturedCard.js
@@ -205,7 +205,7 @@ const FeaturedCardRight = styled.div.attrs({
   padding-left: ${props => (props.isReversed ? 0 : props.theme.gutter.small)}px;
   padding-right: ${props =>
     props.isReversed ? props.theme.gutter.small : 0}px;
-  transform: translateY(-60px);
+  transform: translateY(-26px);
   width: 100%;
   height: 100%;
   min-height: 200px;


### PR DESCRIPTION
Closes #5392

Copy and image are now flush against each other at the small and medium breakpoints.

Screenshot from Cardigan:
![image](https://user-images.githubusercontent.com/1394592/88551572-e781ec00-d01a-11ea-9db3-9b46130b9dae.png)

