### PR TITLE
Allow the query type selector to work in conjunction with the staging API

### DIFF
--- a/common/services/catalogue/swagger.js
+++ b/common/services/catalogue/swagger.js
@@ -1,7 +1,9 @@
 // @flow
 import fetch from 'isomorphic-unfetch';
 
-export default async () =>
+export default async (useStaging: boolean) =>
   fetch(
-    'https://api.wellcomecollection.org/catalogue/v2/swagger.json'
+    `https://api${
+      useStaging ? '-stage' : ''
+    }.wellcomecollection.org/catalogue/v2/swagger.json`
   ).then(resp => resp.json());


### PR DESCRIPTION
This is so we can test queries on the staging API first, before moving to prod.

We had to change the middleware as well as it would look at the swagger for the allowedValues, and these will be different on different stages.

I haven't cared much about the extra http request as it's only made by the app and cached.

Also added the entire catalogue switch onto the search toolbar.

![Screenshot 2020-07-27 at 17 41 00](https://user-images.githubusercontent.com/31692/88568378-cd530880-d030-11ea-91f6-cbe4c47ae8b6.png)
