### PR TITLE
fixes Warning: Prop `dangerouslySetInnerHTML` did not match.

### DIFF
--- a/catalogue/webapp/components/WorkDetailsText/WorkDetailsText.js
+++ b/catalogue/webapp/components/WorkDetailsText/WorkDetailsText.js
@@ -9,7 +9,7 @@ const WorkDetailsText = ({ title, text }: Props) => {
     <WorkDetailsProperty title={title}>
       <div className="spaced-text">
         {text.map((para, i) => {
-          return <p key={i} dangerouslySetInnerHTML={{ __html: para }} />;
+          return <div key={i} dangerouslySetInnerHTML={{ __html: para }} />;
         })}
       </div>
     </WorkDetailsProperty>


### PR DESCRIPTION
and stops data disappearing from the page

We were trying to nest `<p>`'s in a `<p>`
