### PR TITLE
Visit us whats on card

### DIFF
--- a/common/model/card.js
+++ b/common/model/card.js
@@ -4,6 +4,7 @@ import { type Format } from '@weco/common/model/format';
 import type { UiEvent } from '@weco/common/model/events';
 import type { Article } from '@weco/common/model/articles';
 import type { LandingPage } from '@weco/common/model/landing-pages';
+import linkResolver from '@weco/common/services/prismic/link-resolver';
 
 export type Card = {|
   type: 'card',
@@ -43,6 +44,8 @@ export function convertItemToCardProps(
           },
         },
       },
-    link: (item.promo && item.promo.link) || `/pages/${item.id}`,
+    link:
+      (item.promo && item.promo.link) ||
+      linkResolver({ id: item.id, type: item.type }),
   };
 }

--- a/common/model/card.js
+++ b/common/model/card.js
@@ -43,6 +43,6 @@ export function convertItemToCardProps(
           },
         },
       },
-    link: item.promo && item.promo.link,
+    link: (item.promo && item.promo.link) || `/pages/${item.id}`,
   };
 }

--- a/common/views/components/FeaturedCard/FeaturedCard.js
+++ b/common/views/components/FeaturedCard/FeaturedCard.js
@@ -35,7 +35,12 @@ type Props = {|
 export function convertCardToFeaturedCardProps(item: Card) {
   return {
     id: item.title || 'card',
-    image: { ...item.image, extraClasses: '', sizesQueries: '' },
+    image: {
+      ...item.image,
+      extraClasses: '',
+      sizesQueries: '',
+      showTasl: false,
+    },
     labels: [],
     link: { url: item.link || '', text: item.title || '' },
   };

--- a/common/views/components/FeaturedCard/FeaturedCard.js
+++ b/common/views/components/FeaturedCard/FeaturedCard.js
@@ -22,18 +22,24 @@ import {
 import { trackEvent } from '../../../utils/ga';
 import linkResolver from '../../../../common/services/prismic/link-resolver';
 
-type Props = {|
+type PartialFeaturedCard = {|
   id: string,
   image: ?UiImageProps,
   labels: Label[],
-  children: Node,
   link: Link,
+|};
+
+type Props = {|
+  ...PartialFeaturedCard,
+  children: Node,
   background: string,
   color: string,
   isReversed?: boolean,
 |};
 
-export function convertCardToFeaturedCardProps(item: Card) {
+export function convertCardToFeaturedCardProps(
+  item: Card
+): PartialFeaturedCard {
   return {
     id: item.title || 'card',
     image: {

--- a/common/views/components/FeaturedCard/FeaturedCard.js
+++ b/common/views/components/FeaturedCard/FeaturedCard.js
@@ -20,6 +20,7 @@ import {
   getArticleColor,
 } from '../../../../common/model/articles';
 import { trackEvent } from '../../../utils/ga';
+import linkResolver from '../../../../common/services/prismic/link-resolver';
 
 type Props = {|
   id: string,
@@ -63,7 +64,10 @@ export function convertItemToFeaturedCardProps(
       crops: {},
     },
     labels: item.labels,
-    link: { url: `/${item.type}/${item.id}`, text: item.title },
+    link: {
+      url: linkResolver({ id: item.id, type: item.type }),
+      text: item.title,
+    },
   };
 }
 

--- a/common/views/components/FeaturedCard/FeaturedCard.js
+++ b/common/views/components/FeaturedCard/FeaturedCard.js
@@ -4,6 +4,7 @@ import { type UiImageProps, UiImage } from '../../components/Images/Images';
 import type { UiExhibition } from '../../../../common/model/exhibitions';
 import type { UiEvent } from '../../../../common/model/events';
 import type { Article } from '../../../../common/model/articles';
+import type { Card } from '../../../../common/model/card';
 import type { LandingPage } from '../../../../common/model/landing-pages';
 import { type Label } from '../../../../common/model/labels';
 import { type Link } from '../../../../common/model/link';
@@ -31,6 +32,15 @@ type Props = {|
   isReversed?: boolean,
 |};
 
+export function convertCardToFeaturedCardProps(item: Card) {
+  return {
+    id: item.title || 'card',
+    image: { ...item.image, extraClasses: '', sizesQueries: '' },
+    labels: [],
+    link: { url: item.link || '', text: item.title || '' },
+  };
+}
+
 export function convertItemToFeaturedCardProps(
   item: Article | UiEvent | UiExhibition | LandingPage
 ) {
@@ -48,7 +58,7 @@ export function convertItemToFeaturedCardProps(
       crops: {},
     },
     labels: item.labels,
-    link: { url: `${item.type}/${item.id}`, text: item.title },
+    link: { url: `/${item.type}/${item.id}`, text: item.title },
   };
 }
 

--- a/common/views/components/LandingBody/LandingBody.js
+++ b/common/views/components/LandingBody/LandingBody.js
@@ -13,6 +13,7 @@ import SectionHeader from '../SectionHeader/SectionHeader';
 import Card from '../Card/Card';
 import FeaturedCard, {
   convertItemToFeaturedCardProps,
+  convertCardToFeaturedCardProps,
 } from '../FeaturedCard/FeaturedCard';
 import { convertItemToCardProps } from '@weco/common/model/card';
 import VisitUsStaticContent from './VisitUsStaticContent';
@@ -86,7 +87,12 @@ const Body = ({ body, isDropCapped, pageId }: Props) => {
           Boolean(section.value.hasFeatured) ||
           section.value.items.length === 1;
         const firstItem = section.value.items[0];
-        const firstItemProps = convertItemToFeaturedCardProps(firstItem);
+        const isCardType = firstItem.type === 'card';
+
+        const firstItemProps = isCardType
+          ? convertCardToFeaturedCardProps(firstItem)
+          : convertItemToFeaturedCardProps(firstItem);
+
         const cardItems = hasFeatured
           ? section.value.items.slice(1)
           : section.value.items;
@@ -99,6 +105,9 @@ const Body = ({ body, isDropCapped, pageId }: Props) => {
               isReversed={false}
             >
               <h2 className="font-wb font-size-2">{firstItem.title}</h2>
+              {isCardType && firstItem.description && (
+                <p className="font-hnl font-size-5">{firstItem.description}</p>
+              )}
               {firstItem.promo && (
                 <p className="font-hnl font-size-5">
                   {firstItem.promo.caption}
@@ -106,6 +115,7 @@ const Body = ({ body, isDropCapped, pageId }: Props) => {
               )}
             </FeaturedCard>
           ) : null;
+
         const cards = cardItems.map((item, i) => {
           const cardProps = convertItemToCardProps(item);
           return <Card key={i} item={cardProps} />;


### PR DESCRIPTION
Relates to #5317

This allows items with a `Card` content type to be rendered as a FeaturedCard in the `LandingBody`. This means that we can display a featured 'What's On' card (because 'What's On isn't a page in Prismic).

![Screenshot 2020-07-29 at 15 14 19](https://user-images.githubusercontent.com/1394592/88811447-796e2e00-d1ae-11ea-999b-2fc381f3ab05.png)

