### PR TITLE
Show the format label if there is one

### DIFF
--- a/common/views/components/FeaturedCard/FeaturedCard.js
+++ b/common/views/components/FeaturedCard/FeaturedCard.js
@@ -48,7 +48,7 @@ export function convertCardToFeaturedCardProps(
       sizesQueries: '',
       showTasl: false,
     },
-    labels: [],
+    labels: item.format ? [{ url: null, text: item.format.title }] : [],
     link: { url: item.link || '', text: item.title || '' },
   };
 }


### PR DESCRIPTION
The `Card` content type can have a format. If this has been added and we're rendering the content in a `FeaturedCard` component, we should display it.
