### PR TITLE
Don't convert items if they're already of type 'card'

### DIFF
--- a/common/views/components/LandingBody/LandingBody.js
+++ b/common/views/components/LandingBody/LandingBody.js
@@ -117,7 +117,8 @@ const Body = ({ body, isDropCapped, pageId }: Props) => {
           ) : null;
 
         const cards = cardItems.map((item, i) => {
-          const cardProps = convertItemToCardProps(item);
+          const cardProps =
+            item.type === 'card' ? item : convertItemToCardProps(item);
           return <Card key={i} item={cardProps} />;
         });
         return (


### PR DESCRIPTION
If `LandingBody` items are already Prismic `Card` types, we don't want to convert them.

__Before__
![Screenshot 2020-07-31 at 12 02 45](https://user-images.githubusercontent.com/1394592/89029924-4ef3b080-d327-11ea-919c-bb67a910f90b.png)

__After__
![Screenshot 2020-07-31 at 12 11 20](https://user-images.githubusercontent.com/1394592/89029930-53b86480-d327-11ea-82e7-1d781548beec.png)
