### PR TITLE
Use and update PageHeader for list pages

### DIFF
--- a/common/utils/backgrounds.js
+++ b/common/utils/backgrounds.js
@@ -6,3 +6,5 @@ export const repeatingLsBlack =
   'https://images.prismic.io/wellcomecollection%2Fe483a8f3-f7bb-4c3f-8081-8f5d8875230e_ls_svg_black.svg';
 export const leaningLMask =
   'https://images.prismic.io/wellcomecollection%2F696073c9-01ca-4f21-a633-c10bf1ff10e4_l-mask.svg';
+export const headerBackgroundLs =
+  'https://wellcomecollection.cdn.prismic.io/wellcomecollection%2F43a35689-4923-4451-85d9-1ab866b1826d_event_header_background.svg';

--- a/common/views/components/ErrorPage/ErrorPage.js
+++ b/common/views/components/ErrorPage/ErrorPage.js
@@ -6,6 +6,7 @@ import Body from '../Body/Body';
 // $FlowFixMe
 import MoreLink from '../MoreLink/MoreLink';
 import Space from '../styled/Space';
+import { headerBackgroundLs } from '@weco/common/utils/backgrounds';
 
 type Props = {|
   statusCode: number,
@@ -36,9 +37,7 @@ const ErrorPage = ({ statusCode, title }: Props) => {
             }
             ContentTypeInfo={null}
             Background={null}
-            backgroundTexture={
-              'https://wellcomecollection.cdn.prismic.io/wellcomecollection%2F9154df28-e179-47c0-8d41-db0b74969153_wc+brand+backgrounds+2_pattern+2+colour+1.svg'
-            }
+            backgroundTexture={headerBackgroundLs}
             FeaturedMedia={null}
             HeroPicture={null}
             highlightHeading={true}

--- a/common/views/components/HeaderBackground/HeaderBackground.js
+++ b/common/views/components/HeaderBackground/HeaderBackground.js
@@ -20,7 +20,7 @@ const HeaderBackground = ({
   const backgroundStyles = texture
     ? {
         backgroundImage: `url(${texture})`,
-        backgroundSize: '150%',
+        backgroundSize: 'cover',
       }
     : {};
 

--- a/common/views/components/LayoutPaginatedResults/LayoutPaginatedResults.js
+++ b/common/views/components/LayoutPaginatedResults/LayoutPaginatedResults.js
@@ -54,7 +54,7 @@ const LayoutPaginatedResults = ({
         FeaturedMedia={null}
         HeroPicture={null}
         highlightHeading={true}
-        isListPage={true}
+        isArticleExhibitionEvent={false}
       />
     </SpacingSection>
 

--- a/common/views/components/LayoutPaginatedResults/LayoutPaginatedResults.js
+++ b/common/views/components/LayoutPaginatedResults/LayoutPaginatedResults.js
@@ -54,7 +54,7 @@ const LayoutPaginatedResults = ({
         FeaturedMedia={null}
         HeroPicture={null}
         highlightHeading={true}
-        isArticleExhibitionEvent={false}
+        isContentTypeInfoBeforeMedia={false}
       />
     </SpacingSection>
 

--- a/common/views/components/LayoutPaginatedResults/LayoutPaginatedResults.js
+++ b/common/views/components/LayoutPaginatedResults/LayoutPaginatedResults.js
@@ -1,7 +1,6 @@
 // @flow
 import CardGrid from '../CardGrid/CardGrid';
 import Layout12 from '../Layout12/Layout12';
-import Layout from '../Layout/Layout';
 import Divider from '../Divider/Divider';
 import Pagination from '../Pagination/Pagination';
 import PrismicHtmlBlock from '../PrismicHtmlBlock/PrismicHtmlBlock';
@@ -18,7 +17,7 @@ import type {
 import SpacingSection from '../SpacingSection/SpacingSection';
 import Space from '../styled/Space';
 import PageHeader from '../PageHeader/PageHeader';
-import WobblyEdge from '../WobblyEdge/WobblyEdge';
+import { headerBackgroundLs } from '../../../../common/utils/backgrounds';
 
 type PaginatedResultsTypes =
   | PaginatedResults<UiExhibition>
@@ -49,27 +48,15 @@ const LayoutPaginatedResults = ({
         breadcrumbs={{ items: [] }}
         labels={null}
         title={title}
-        ContentTypeInfo={null}
+        ContentTypeInfo={description && <PrismicHtmlBlock html={description} />}
         Background={null}
-        backgroundTexture={`https://wellcomecollection.cdn.prismic.io/wellcomecollection%2F43a35689-4923-4451-85d9-1ab866b1826d_event_header_background.svg`}
+        backgroundTexture={headerBackgroundLs}
         FeaturedMedia={null}
         HeroPicture={null}
         highlightHeading={true}
+        isListPage={true}
       />
-      <WobblyEdge background={'white'} />
     </SpacingSection>
-
-    {description && (
-      <Layout gridSizes={{ s: 12, m: 10, l: 8, xl: 8 }}>
-        <div
-          className={classNames({
-            [font('hnm', 4)]: true,
-          })}
-        >
-          <PrismicHtmlBlock html={description} />
-        </div>
-      </Layout>
-    )}
 
     {paginatedResults.totalPages > 1 && (
       <Layout12>

--- a/common/views/components/LayoutPaginatedResults/LayoutPaginatedResults.js
+++ b/common/views/components/LayoutPaginatedResults/LayoutPaginatedResults.js
@@ -1,11 +1,11 @@
 // @flow
-import { Fragment } from 'react';
 import CardGrid from '../CardGrid/CardGrid';
 import Layout12 from '../Layout12/Layout12';
+import Layout from '../Layout/Layout';
 import Divider from '../Divider/Divider';
 import Pagination from '../Pagination/Pagination';
 import PrismicHtmlBlock from '../PrismicHtmlBlock/PrismicHtmlBlock';
-import { classNames, font, grid } from '../../../utils/classnames';
+import { classNames, font } from '../../../utils/classnames';
 import type { Period } from '../../../model/periods';
 import type { UiExhibition } from '../../../model/exhibitions';
 import type { UiEvent } from '../../../model/events';
@@ -17,6 +17,8 @@ import type {
 } from '../../../services/prismic/types';
 import SpacingSection from '../SpacingSection/SpacingSection';
 import Space from '../styled/Space';
+import PageHeader from '../PageHeader/PageHeader';
+import WobblyEdge from '../WobblyEdge/WobblyEdge';
 
 type PaginatedResultsTypes =
   | PaginatedResults<UiExhibition>
@@ -41,138 +43,117 @@ const LayoutPaginatedResults = ({
   period,
   showFreeAdmissionMessage,
 }: Props) => (
-  <Fragment>
+  <>
     <SpacingSection>
-      <Space
-        v={{
-          size: 'l',
-          properties: ['padding-top', 'padding-bottom'],
-        }}
-        className={classNames({
-          row: true,
-          'bg-cream': true,
-        })}
-      >
-        <div className="container">
-          <div className="grid">
-            <div
-              className={classNames({
-                [grid({ s: 12, m: 12, l: 8, xl: 8 })]: true,
-              })}
-            >
-              <h1
-                className={classNames({
-                  'no-margin': true,
-                  [font('wb', 2)]: true,
-                })}
-              >
-                {title}
-              </h1>
-
-              {description && (
-                <Space
-                  v={{
-                    size: 'm',
-                    properties: ['margin-top'],
-                  }}
-                  className={classNames({
-                    'first-para-no-margin body-text': true,
-                  })}
-                >
-                  <PrismicHtmlBlock html={description} />
-                </Space>
-              )}
-            </div>
-          </div>
-        </div>
-      </Space>
+      <PageHeader
+        breadcrumbs={{ items: [] }}
+        labels={null}
+        title={title}
+        ContentTypeInfo={null}
+        Background={null}
+        backgroundTexture={`https://wellcomecollection.cdn.prismic.io/wellcomecollection%2F43a35689-4923-4451-85d9-1ab866b1826d_event_header_background.svg`}
+        FeaturedMedia={null}
+        HeroPicture={null}
+        highlightHeading={true}
+      />
+      <WobblyEdge background={'white'} />
     </SpacingSection>
 
-    <>
-      {paginatedResults.totalPages > 1 && (
-        <Layout12>
-          <Space
-            v={{
-              size: 'l',
-              properties: ['padding-bottom'],
-            }}
+    {description && (
+      <Layout gridSizes={{ s: 12, m: 10, l: 8, xl: 8 }}>
+        <div
+          className={classNames({
+            [font('hnm', 4)]: true,
+          })}
+        >
+          <PrismicHtmlBlock html={description} />
+        </div>
+      </Layout>
+    )}
+
+    {paginatedResults.totalPages > 1 && (
+      <Layout12>
+        <Space
+          v={{
+            size: 'l',
+            properties: ['padding-bottom'],
+          }}
+          className={classNames({
+            flex: true,
+            'flex--v-center': true,
+            'font-pewter': true,
+            [font('lr', 6)]: true,
+          })}
+        >
+          {paginatedResults.pageSize * paginatedResults.currentPage -
+            (paginatedResults.pageSize - 1)}
+          -
+          {paginatedResults.currentPage < paginatedResults.totalPages
+            ? paginatedResults.pageSize * paginatedResults.currentPage
+            : null}
+          {paginatedResults.currentPage === paginatedResults.totalPages
+            ? paginatedResults.totalResults
+            : null}
+        </Space>
+        <Divider extraClasses={'divider--keyline divider--pumice'} />
+      </Layout12>
+    )}
+    {showFreeAdmissionMessage && (
+      <Layout12>
+        <div className="flex-inline flex--v-center">
+          <span
             className={classNames({
-              flex: true,
-              'flex--v-center': true,
-              'font-pewter': true,
-              [font('lr', 6)]: true,
+              [font('hnm', 4)]: true,
             })}
           >
-            {paginatedResults.pageSize * paginatedResults.currentPage -
-              (paginatedResults.pageSize - 1)}
-            -
-            {paginatedResults.currentPage < paginatedResults.totalPages
-              ? paginatedResults.pageSize * paginatedResults.currentPage
-              : null}
-            {paginatedResults.currentPage === paginatedResults.totalPages
-              ? paginatedResults.totalResults
-              : null}
-          </Space>
-          <Divider extraClasses={'divider--keyline divider--pumice'} />
-        </Layout12>
-      )}
-      {showFreeAdmissionMessage && (
+            Free admission
+          </span>
+        </div>
+      </Layout12>
+    )}
+
+    <Space v={{ size: 'l', properties: ['margin-top'] }}>
+      <CardGrid items={paginatedResults.results} itemsPerRow={3} />
+    </Space>
+
+    {paginatedResults.totalPages > 1 && (
+      <Space v={{ size: 'm', properties: ['padding-top', 'padding-bottom'] }}>
         <Layout12>
-          <div className="flex-inline flex--v-center">
-            <span
-              className={classNames({
-                [font('hnm', 4)]: true,
-              })}
-            >
-              Free admission
-            </span>
+          <div className="text-align-right">
+            <Pagination
+              total={paginatedResults.totalResults}
+              currentPage={paginatedResults.currentPage}
+              pageCount={paginatedResults.totalPages}
+              prevPage={
+                paginatedResults.currentPage > 1
+                  ? paginatedResults.currentPage - 1
+                  : null
+              }
+              nextPage={
+                paginatedResults.currentPage < paginatedResults.totalPages
+                  ? paginatedResults.currentPage + 1
+                  : null
+              }
+              prevQueryString={
+                `/${paginationRoot}` +
+                (period ? `/${period}` : '') +
+                (paginatedResults.currentPage > 1
+                  ? `?page=${paginatedResults.currentPage - 1}`
+                  : '')
+              }
+              nextQueryString={
+                `/${paginationRoot}` +
+                (period ? `/${period}` : '') +
+                (paginatedResults.currentPage < paginatedResults.totalPages
+                  ? `?page=${paginatedResults.currentPage + 1}`
+                  : '')
+              }
+            />
           </div>
         </Layout12>
-      )}
-
-      <Space v={{ size: 'l', properties: ['margin-top'] }}>
-        <CardGrid items={paginatedResults.results} itemsPerRow={3} />
       </Space>
-
-      {paginatedResults.totalPages > 1 && (
-        <Space v={{ size: 'm', properties: ['padding-top', 'padding-bottom'] }}>
-          <Layout12>
-            <div className="text-align-right">
-              <Pagination
-                total={paginatedResults.totalResults}
-                currentPage={paginatedResults.currentPage}
-                pageCount={paginatedResults.totalPages}
-                prevPage={
-                  paginatedResults.currentPage > 1
-                    ? paginatedResults.currentPage - 1
-                    : null
-                }
-                nextPage={
-                  paginatedResults.currentPage < paginatedResults.totalPages
-                    ? paginatedResults.currentPage + 1
-                    : null
-                }
-                prevQueryString={
-                  `/${paginationRoot}` +
-                  (period ? `/${period}` : '') +
-                  (paginatedResults.currentPage > 1
-                    ? `?page=${paginatedResults.currentPage - 1}`
-                    : '')
-                }
-                nextQueryString={
-                  `/${paginationRoot}` +
-                  (period ? `/${period}` : '') +
-                  (paginatedResults.currentPage < paginatedResults.totalPages
-                    ? `?page=${paginatedResults.currentPage + 1}`
-                    : '')
-                }
-              />
-            </div>
-          </Layout12>
-        </Space>
-      )}
-    </>
-  </Fragment>
+    )}
+  </>
 );
 
 export default LayoutPaginatedResults;

--- a/common/views/components/PageHeader/PageHeader.js
+++ b/common/views/components/PageHeader/PageHeader.js
@@ -117,7 +117,7 @@ type Props = {|
   backgroundTexture?: ?string,
   highlightHeading?: boolean,
   asyncBreadcrumbsRoute?: string,
-  isListPage?: boolean,
+  isArticleExhibitionEvent?: boolean,
 
   // TODO: Don't overload this, it's just for putting things in till
   // we find a pattern
@@ -133,7 +133,7 @@ const PageHeader = ({
   HeroPicture,
   FeaturedMedia,
   isFree = false,
-  isListPage = false,
+  isArticleExhibitionEvent = false,
   // Not a massive fan of this, but it feels overkill to make a new component
   // for it as it's only used on articles and exhibitions
   heroImageBgColor = 'white',
@@ -174,9 +174,10 @@ const PageHeader = ({
             v={{
               size: 'l',
               // properties:  ['margin-top', 'margin-bottom', 'padding-bottom'],
-              properties: hasMedia
-                ? ['margin-top', 'margin-bottom']
-                : ['margin-top', 'margin-bottom', 'padding-bottom'],
+              properties:
+                isArticleExhibitionEvent || hasMedia
+                  ? ['margin-top', 'margin-bottom']
+                  : ['margin-top', 'margin-bottom', 'padding-bottom'],
             }}
           >
             {breadcrumbs.items.length > 0 && (
@@ -200,7 +201,7 @@ const PageHeader = ({
               {Heading}
             </Space>
 
-            {!isListPage && (
+            {isArticleExhibitionEvent && ContentTypeInfo && (
               <Space
                 v={{ size: 'm', properties: ['margin-bottom'] }}
                 className={classNames({
@@ -241,9 +242,11 @@ const PageHeader = ({
         )}
       </div>
 
-      {!hasMedia && <WobblyEdge background={'white'} />}
+      {!hasMedia && !isArticleExhibitionEvent && (
+        <WobblyEdge background={'white'} />
+      )}
 
-      {isListPage && ContentTypeInfo && (
+      {!isArticleExhibitionEvent && ContentTypeInfo && (
         <Layout gridSizes={{ s: 12, m: 10, l: 8, xl: 8 }}>
           <Space
             v={{

--- a/common/views/components/PageHeader/PageHeader.js
+++ b/common/views/components/PageHeader/PageHeader.js
@@ -156,7 +156,7 @@ const PageHeader = ({
           backgroundImage: backgroundTexture
             ? `url(${backgroundTexture})`
             : null,
-          backgroundSize: backgroundTexture ? '150%' : null,
+          backgroundSize: backgroundTexture ? 'cover' : null,
         }}
       >
         {Background}

--- a/common/views/components/PageHeader/PageHeader.js
+++ b/common/views/components/PageHeader/PageHeader.js
@@ -176,26 +176,42 @@ const PageHeader = ({
               // properties:  ['margin-top', 'margin-bottom', 'padding-bottom'],
               properties:
                 isArticleExhibitionEvent || hasMedia
-                  ? ['margin-top', 'margin-bottom']
-                  : ['margin-top', 'margin-bottom', 'padding-bottom'],
+                  ? ['margin-bottom']
+                  : ['margin-bottom', 'padding-bottom'],
             }}
           >
-            {breadcrumbs.items.length > 0 && (
-              <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
-                {!asyncBreadcrumbsRoute && <Breadcrumb {...breadcrumbs} />}
-                {asyncBreadcrumbsRoute && (
-                  <div
-                    data-component="AsyncBreadcrumb"
-                    className="async-content breadcrumb-placeholder"
-                    data-endpoint={asyncBreadcrumbsRoute}
-                    data-prefix-endpoint="false"
-                    data-modifiers=""
-                  >
-                    <Breadcrumb {...breadcrumbs} />
-                  </div>
-                )}
-              </Space>
-            )}
+            <Space
+              v={{
+                size: 's',
+                properties: ['margin-top', 'margin-bottom'],
+              }}
+            >
+              {breadcrumbs.items.length > 0 ? (
+                <>
+                  {!asyncBreadcrumbsRoute && <Breadcrumb {...breadcrumbs} />}
+                  {asyncBreadcrumbsRoute && (
+                    <div
+                      data-component="AsyncBreadcrumb"
+                      className="async-content breadcrumb-placeholder"
+                      data-endpoint={asyncBreadcrumbsRoute}
+                      data-prefix-endpoint="false"
+                      data-modifiers=""
+                    >
+                      <Breadcrumb {...breadcrumbs} />
+                    </div>
+                  )}
+                </>
+              ) : (
+                <span
+                  className={classNames({
+                    [font('hnl', 5)]: true,
+                    flex: true,
+                  })}
+                >
+                  &nbsp;
+                </span>
+              )}
+            </Space>
             <Space v={{ size: 'xs', properties: ['margin-bottom'] }}>
               {TitleTopper}
               {Heading}

--- a/common/views/components/PageHeader/PageHeader.js
+++ b/common/views/components/PageHeader/PageHeader.js
@@ -148,6 +148,8 @@ const PageHeader = ({
     <h1 className="h1 inline-block no-margin">{title}</h1>
   );
 
+  const hasMedia = FeaturedMedia || HeroPicture;
+
   return (
     <>
       <div
@@ -160,20 +162,21 @@ const PageHeader = ({
         }}
       >
         {Background}
-        <Layout10>
-          {isFree && (
+        {isFree && (
+          <Layout10>
             <div className="relative">
               <FreeSticker />
             </div>
-          )}
-        </Layout10>
+          </Layout10>
+        )}
         <Layout gridSizes={{ s: 12, m: 10, l: 8, xl: 8 }}>
           <Space
             v={{
               size: 'l',
-              properties: isListPage
-                ? ['margin-top', 'margin-bottom', 'padding-bottom']
-                : ['margin-top', 'margin-bottom'],
+              // properties:  ['margin-top', 'margin-bottom', 'padding-bottom'],
+              properties: hasMedia
+                ? ['margin-top', 'margin-bottom']
+                : ['margin-top', 'margin-bottom', 'padding-bottom'],
             }}
           >
             {breadcrumbs.items.length > 0 && (
@@ -238,23 +241,22 @@ const PageHeader = ({
         )}
       </div>
 
-      {isListPage && (
-        <>
-          <WobblyEdge background={'white'} />
-          <Layout gridSizes={{ s: 12, m: 10, l: 8, xl: 8 }}>
-            <Space
-              v={{
-                size: 'l',
-                properties: ['margin-top'],
-              }}
-              className={classNames({
-                [font('hnm', 4)]: true,
-              })}
-            >
-              {ContentTypeInfo}
-            </Space>
-          </Layout>
-        </>
+      {!hasMedia && <WobblyEdge background={'white'} />}
+
+      {isListPage && ContentTypeInfo && (
+        <Layout gridSizes={{ s: 12, m: 10, l: 8, xl: 8 }}>
+          <Space
+            v={{
+              size: 'l',
+              properties: ['margin-top'],
+            }}
+            className={classNames({
+              [font('hnm', 4)]: true,
+            })}
+          >
+            {ContentTypeInfo}
+          </Space>
+        </Layout>
       )}
     </>
   );

--- a/common/views/components/PageHeader/PageHeader.js
+++ b/common/views/components/PageHeader/PageHeader.js
@@ -10,7 +10,6 @@ import HeaderBackground from '../HeaderBackground/HeaderBackground';
 import FreeSticker from '../FreeSticker/FreeSticker';
 import HighlightedHeading from '../HighlightedHeading/HighlightedHeading';
 import Layout10 from '../Layout10/Layout10';
-import Layout12 from '../Layout12/Layout12';
 import Layout from '../Layout/Layout';
 import WobblyEdge from '../WobblyEdge/WobblyEdge';
 import WobblyBottom from '../WobblyBottom/WobblyBottom';
@@ -161,13 +160,13 @@ const PageHeader = ({
         }}
       >
         {Background}
-        <Layout12>
+        <Layout10>
           {isFree && (
             <div className="relative">
               <FreeSticker />
             </div>
           )}
-        </Layout12>
+        </Layout10>
         <Layout gridSizes={{ s: 12, m: 10, l: 8, xl: 8 }}>
           <Space
             v={{

--- a/common/views/components/PageHeader/PageHeader.js
+++ b/common/views/components/PageHeader/PageHeader.js
@@ -117,7 +117,7 @@ type Props = {|
   backgroundTexture?: ?string,
   highlightHeading?: boolean,
   asyncBreadcrumbsRoute?: string,
-  isArticleExhibitionEvent?: boolean,
+  isContentTypeInfoBeforeMedia?: boolean,
 
   // TODO: Don't overload this, it's just for putting things in till
   // we find a pattern
@@ -133,7 +133,7 @@ const PageHeader = ({
   HeroPicture,
   FeaturedMedia,
   isFree = false,
-  isArticleExhibitionEvent = false,
+  isContentTypeInfoBeforeMedia = false,
   // Not a massive fan of this, but it feels overkill to make a new component
   // for it as it's only used on articles and exhibitions
   heroImageBgColor = 'white',
@@ -173,9 +173,8 @@ const PageHeader = ({
           <Space
             v={{
               size: 'l',
-              // properties:  ['margin-top', 'margin-bottom', 'padding-bottom'],
               properties:
-                isArticleExhibitionEvent || hasMedia
+                isContentTypeInfoBeforeMedia || hasMedia
                   ? ['margin-bottom']
                   : ['margin-bottom', 'padding-bottom'],
             }}
@@ -217,7 +216,7 @@ const PageHeader = ({
               {Heading}
             </Space>
 
-            {isArticleExhibitionEvent && ContentTypeInfo && (
+            {isContentTypeInfoBeforeMedia && ContentTypeInfo && (
               <Space
                 v={{ size: 'm', properties: ['margin-bottom'] }}
                 className={classNames({
@@ -258,11 +257,11 @@ const PageHeader = ({
         )}
       </div>
 
-      {!hasMedia && !isArticleExhibitionEvent && (
+      {!hasMedia && !isContentTypeInfoBeforeMedia && (
         <WobblyEdge background={'white'} />
       )}
 
-      {!isArticleExhibitionEvent && ContentTypeInfo && (
+      {!isContentTypeInfoBeforeMedia && ContentTypeInfo && (
         <Layout gridSizes={{ s: 12, m: 10, l: 8, xl: 8 }}>
           <Space
             v={{

--- a/common/views/components/PageHeader/PageHeader.js
+++ b/common/views/components/PageHeader/PageHeader.js
@@ -9,7 +9,7 @@ import Picture from '../Picture/Picture';
 import HeaderBackground from '../HeaderBackground/HeaderBackground';
 import FreeSticker from '../FreeSticker/FreeSticker';
 import HighlightedHeading from '../HighlightedHeading/HighlightedHeading';
-import Layout10 from '../Layout10/Layout10';
+import Layout12 from '../Layout12/Layout12';
 import WobblyBottom from '../WobblyBottom/WobblyBottom';
 import { breakpoints } from '../../../utils/breakpoints';
 import type { Node, Element, ElementProps } from 'react';
@@ -153,27 +153,34 @@ const PageHeader = ({
       }}
     >
       {Background}
-      <Layout10>
+      <Layout12>
         {isFree && (
           <div className="relative">
             <FreeSticker />
           </div>
         )}
-        <Space v={{ size: 'l', properties: ['margin-top', 'margin-bottom'] }}>
-          <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
-            {!asyncBreadcrumbsRoute && <Breadcrumb {...breadcrumbs} />}
-            {asyncBreadcrumbsRoute && (
-              <div
-                data-component="AsyncBreadcrumb"
-                className="async-content breadcrumb-placeholder"
-                data-endpoint={asyncBreadcrumbsRoute}
-                data-prefix-endpoint="false"
-                data-modifiers=""
-              >
-                <Breadcrumb {...breadcrumbs} />
-              </div>
-            )}
-          </Space>
+        <Space
+          v={{
+            size: 'l',
+            properties: ['margin-top', 'margin-bottom', 'padding-bottom'],
+          }}
+        >
+          {breadcrumbs.items.length > 0 && (
+            <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
+              {!asyncBreadcrumbsRoute && <Breadcrumb {...breadcrumbs} />}
+              {asyncBreadcrumbsRoute && (
+                <div
+                  data-component="AsyncBreadcrumb"
+                  className="async-content breadcrumb-placeholder"
+                  data-endpoint={asyncBreadcrumbsRoute}
+                  data-prefix-endpoint="false"
+                  data-modifiers=""
+                >
+                  <Breadcrumb {...breadcrumbs} />
+                </div>
+              )}
+            </Space>
+          )}
           <Space v={{ size: 'xs', properties: ['margin-bottom'] }}>
             {TitleTopper}
             {Heading}
@@ -196,7 +203,7 @@ const PageHeader = ({
           {labels && labels.labels.length > 0 && <LabelsList {...labels} />}
         </Space>
         <div className="relative">{FeaturedMedia}</div>
-      </Layout10>
+      </Layout12>
 
       {HeroPicture && (
         <div

--- a/common/views/components/PageHeader/PageHeader.js
+++ b/common/views/components/PageHeader/PageHeader.js
@@ -9,7 +9,10 @@ import Picture from '../Picture/Picture';
 import HeaderBackground from '../HeaderBackground/HeaderBackground';
 import FreeSticker from '../FreeSticker/FreeSticker';
 import HighlightedHeading from '../HighlightedHeading/HighlightedHeading';
+import Layout10 from '../Layout10/Layout10';
 import Layout12 from '../Layout12/Layout12';
+import Layout from '../Layout/Layout';
+import WobblyEdge from '../WobblyEdge/WobblyEdge';
 import WobblyBottom from '../WobblyBottom/WobblyBottom';
 import { breakpoints } from '../../../utils/breakpoints';
 import type { Node, Element, ElementProps } from 'react';
@@ -115,6 +118,7 @@ type Props = {|
   backgroundTexture?: ?string,
   highlightHeading?: boolean,
   asyncBreadcrumbsRoute?: string,
+  isListPage?: boolean,
 
   // TODO: Don't overload this, it's just for putting things in till
   // we find a pattern
@@ -130,6 +134,7 @@ const PageHeader = ({
   HeroPicture,
   FeaturedMedia,
   isFree = false,
+  isListPage = false,
   // Not a massive fan of this, but it feels overkill to make a new component
   // for it as it's only used on articles and exhibitions
   heroImageBgColor = 'white',
@@ -145,83 +150,114 @@ const PageHeader = ({
   );
 
   return (
-    <div
-      className={`row relative`}
-      style={{
-        backgroundImage: backgroundTexture ? `url(${backgroundTexture})` : null,
-        backgroundSize: backgroundTexture ? '150%' : null,
-      }}
-    >
-      {Background}
-      <Layout12>
-        {isFree && (
-          <div className="relative">
-            <FreeSticker />
+    <>
+      <div
+        className={`row relative`}
+        style={{
+          backgroundImage: backgroundTexture
+            ? `url(${backgroundTexture})`
+            : null,
+          backgroundSize: backgroundTexture ? '150%' : null,
+        }}
+      >
+        {Background}
+        <Layout12>
+          {isFree && (
+            <div className="relative">
+              <FreeSticker />
+            </div>
+          )}
+        </Layout12>
+        <Layout gridSizes={{ s: 12, m: 10, l: 8, xl: 8 }}>
+          <Space
+            v={{
+              size: 'l',
+              properties: isListPage
+                ? ['margin-top', 'margin-bottom', 'padding-bottom']
+                : ['margin-top', 'margin-bottom'],
+            }}
+          >
+            {breadcrumbs.items.length > 0 && (
+              <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
+                {!asyncBreadcrumbsRoute && <Breadcrumb {...breadcrumbs} />}
+                {asyncBreadcrumbsRoute && (
+                  <div
+                    data-component="AsyncBreadcrumb"
+                    className="async-content breadcrumb-placeholder"
+                    data-endpoint={asyncBreadcrumbsRoute}
+                    data-prefix-endpoint="false"
+                    data-modifiers=""
+                  >
+                    <Breadcrumb {...breadcrumbs} />
+                  </div>
+                )}
+              </Space>
+            )}
+            <Space v={{ size: 'xs', properties: ['margin-bottom'] }}>
+              {TitleTopper}
+              {Heading}
+            </Space>
+
+            {!isListPage && (
+              <Space
+                v={{ size: 'm', properties: ['margin-bottom'] }}
+                className={classNames({
+                  [font('hnl', 4)]: true,
+                })}
+              >
+                {ContentTypeInfo}
+              </Space>
+            )}
+
+            {labels && labels.labels.length > 0 && <LabelsList {...labels} />}
+          </Space>
+        </Layout>
+
+        {FeaturedMedia && (
+          <Layout10>
+            <div className="relative">{FeaturedMedia}</div>
+          </Layout10>
+        )}
+
+        {HeroPicture && (
+          <div
+            className={classNames({
+              relative: true,
+            })}
+            style={{ height: '100%' }}
+          >
+            <HeroPictureBackground
+              className={`bg-${heroImageBgColor} absolute`}
+            />
+
+            <HeroPictureContainer>
+              <WobblyBottom color={heroImageBgColor}>
+                {HeroPicture}
+              </WobblyBottom>
+            </HeroPictureContainer>
           </div>
         )}
-        <Space
-          v={{
-            size: 'l',
-            properties: ['margin-top', 'margin-bottom', 'padding-bottom'],
-          }}
-        >
-          {breadcrumbs.items.length > 0 && (
-            <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
-              {!asyncBreadcrumbsRoute && <Breadcrumb {...breadcrumbs} />}
-              {asyncBreadcrumbsRoute && (
-                <div
-                  data-component="AsyncBreadcrumb"
-                  className="async-content breadcrumb-placeholder"
-                  data-endpoint={asyncBreadcrumbsRoute}
-                  data-prefix-endpoint="false"
-                  data-modifiers=""
-                >
-                  <Breadcrumb {...breadcrumbs} />
-                </div>
-              )}
-            </Space>
-          )}
-          <Space v={{ size: 'xs', properties: ['margin-bottom'] }}>
-            {TitleTopper}
-            {Heading}
-          </Space>
+      </div>
 
-          {ContentTypeInfo && (
+      {isListPage && (
+        <>
+          <WobblyEdge background={'white'} />
+          <Layout gridSizes={{ s: 12, m: 10, l: 8, xl: 8 }}>
             <Space
               v={{
-                size: 'm',
-                properties: ['margin-bottom'],
+                size: 'l',
+                properties: ['margin-top'],
               }}
               className={classNames({
-                [font('hnl', 4)]: true,
+                [font('hnm', 4)]: true,
               })}
             >
               {ContentTypeInfo}
             </Space>
-          )}
-
-          {labels && labels.labels.length > 0 && <LabelsList {...labels} />}
-        </Space>
-        <div className="relative">{FeaturedMedia}</div>
-      </Layout12>
-
-      {HeroPicture && (
-        <div
-          className={classNames({
-            relative: true,
-          })}
-          style={{ height: '100%' }}
-        >
-          <HeroPictureBackground
-            className={`bg-${heroImageBgColor} absolute`}
-          />
-
-          <HeroPictureContainer>
-            <WobblyBottom color={heroImageBgColor}>{HeroPicture}</WobblyBottom>
-          </HeroPictureContainer>
-        </div>
+          </Layout>
+        </>
       )}
-    </div>
+    </>
   );
 };
 

--- a/content/webapp/components/Exhibition/Exhibition.js
+++ b/content/webapp/components/Exhibition/Exhibition.js
@@ -236,6 +236,7 @@ const Exhibition = ({ exhibition }: Props) => {
       FeaturedMedia={maybeFeaturedMedia}
       HeroPicture={maybeHeroPicture}
       isFree={true}
+      isArticleExhibitionEvent={true}
     />
   );
 

--- a/content/webapp/components/Exhibition/Exhibition.js
+++ b/content/webapp/components/Exhibition/Exhibition.js
@@ -236,7 +236,7 @@ const Exhibition = ({ exhibition }: Props) => {
       FeaturedMedia={maybeFeaturedMedia}
       HeroPicture={maybeHeroPicture}
       isFree={true}
-      isArticleExhibitionEvent={true}
+      isContentTypeInfoBeforeMedia={true}
     />
   );
 

--- a/content/webapp/components/Installation/Installation.js
+++ b/content/webapp/components/Installation/Installation.js
@@ -80,7 +80,7 @@ const Installation = ({ installation }: Props) => {
         />
       }
       HeroPicture={null}
-      isArticleExhibitionEvent={true}
+      isContentTypeInfoBeforeMedia={true}
     />
   );
   return (

--- a/content/webapp/components/Installation/Installation.js
+++ b/content/webapp/components/Installation/Installation.js
@@ -80,6 +80,7 @@ const Installation = ({ installation }: Props) => {
         />
       }
       HeroPicture={null}
+      isArticleExhibitionEvent={true}
     />
   );
   return (

--- a/content/webapp/pages/article.js
+++ b/content/webapp/pages/article.js
@@ -200,7 +200,7 @@ export class ArticlePage extends Component<Props, State> {
         HeroPicture={isImageGallery ? null : maybeHeroPicture}
         heroImageBgColor={isImageGallery ? 'white' : 'cream'}
         TitleTopper={TitleTopper}
-        isArticleExhibitionEvent={true}
+        isContentTypeInfoBeforeMedia={true}
       />
     );
 

--- a/content/webapp/pages/article.js
+++ b/content/webapp/pages/article.js
@@ -200,6 +200,7 @@ export class ArticlePage extends Component<Props, State> {
         HeroPicture={isImageGallery ? null : maybeHeroPicture}
         heroImageBgColor={isImageGallery ? 'white' : 'cream'}
         TitleTopper={TitleTopper}
+        isArticleExhibitionEvent={true}
       />
     );
 

--- a/content/webapp/pages/event.js
+++ b/content/webapp/pages/event.js
@@ -294,6 +294,7 @@ class EventPage extends Component<Props, State> {
         }
         HeroPicture={null}
         isFree={!event.cost}
+        isArticleExhibitionEvent={true}
       />
     );
 

--- a/content/webapp/pages/event.js
+++ b/content/webapp/pages/event.js
@@ -294,7 +294,7 @@ class EventPage extends Component<Props, State> {
         }
         HeroPicture={null}
         isFree={!event.cost}
-        isArticleExhibitionEvent={true}
+        isContentTypeInfoBeforeMedia={true}
       />
     );
 

--- a/content/webapp/pages/page.js
+++ b/content/webapp/pages/page.js
@@ -86,7 +86,7 @@ export class Page extends Component<Props> {
         HeroPicture={null}
         backgroundTexture={!FeaturedMedia ? backgroundTexture : null}
         highlightHeading={true}
-        isListPage={true}
+        isArticleExhibitionEvent={false}
       />
     );
     return (

--- a/content/webapp/pages/page.js
+++ b/content/webapp/pages/page.js
@@ -86,7 +86,7 @@ export class Page extends Component<Props> {
         HeroPicture={null}
         backgroundTexture={!FeaturedMedia ? backgroundTexture : null}
         highlightHeading={true}
-        isArticleExhibitionEvent={false}
+        isContentTypeInfoBeforeMedia={false}
       />
     );
     return (

--- a/content/webapp/pages/page.js
+++ b/content/webapp/pages/page.js
@@ -13,13 +13,13 @@ import { convertImageUri } from '@weco/common/utils/convert-image-uri';
 import { getPage } from '@weco/common/services/prismic/pages';
 import { contentLd } from '@weco/common/utils/json-ld';
 import type { Page as PageType } from '@weco/common/model/pages';
+import { headerBackgroundLs } from '@weco/common/utils/backgrounds';
 
 type Props = {|
   page: PageType,
 |};
 
-const backgroundTexture =
-  'https://wellcomecollection.cdn.prismic.io/wellcomecollection%2F9154df28-e179-47c0-8d41-db0b74969153_wc+brand+backgrounds+2_pattern+2+colour+1.svg';
+const backgroundTexture = headerBackgroundLs;
 export class Page extends Component<Props> {
   static getInitialProps = async (ctx: Context) => {
     const { id, memoizedPrismic } = ctx.query;
@@ -76,13 +76,17 @@ export class Page extends Component<Props> {
         FeaturedMedia={FeaturedMedia}
         Background={
           FeaturedMedia && (
-            <HeaderBackground backgroundTexture={backgroundTexture} />
+            <HeaderBackground
+              backgroundTexture={backgroundTexture}
+              hasWobblyEdge={true}
+            />
           )
         }
         ContentTypeInfo={DateInfo}
         HeroPicture={null}
         backgroundTexture={!FeaturedMedia ? backgroundTexture : null}
         highlightHeading={true}
+        isListPage={true}
       />
     );
     return (


### PR DESCRIPTION
Closes #5411
![Screenshot 2020-07-31 at 16 24 44](https://user-images.githubusercontent.com/1394592/89050619-ec141080-d34a-11ea-9a0f-47e6dc8baaa7.png)

Uses the `PageHeader` component.

I added an (optional) `isContentTypeInfoBeforeMedia` prop to the `PageHeader` in order to determine when to display the `ContentTypeInfo` below the textured background area, rather than within it. I'd started trying to do this based on other factors (e.g. the presence of `FeautredMedia` or a `HeroImage`, but the conditionals got quite long and esoteric to the extent that a new prop felt better).

All `PageHeader` content is now aligned to the left edge of the grid (i.e. in line with the Wellcome logo), whereas previously it was padded in. The place where this makes most of a difference is on the individual article and exhibition pages, as these also use a version of the `PageHeader`. Agreed with @DominiqueMarshall that keeping left-alignment consistent everywhere made sense, but if this needed to be changed per content type for whatever reason, we can update it later on.

__TODO__
- [x] Establish if the space for breadcrumbs should always be there, or if the heading should move down only if there are breadcrumb items. ~Something for @GarethOrmerod to decide probably. Don't think it should block this PR.~ Answer: the designs already answer this (the space should be consistent with/without breadcrumbs)
- [x] Work out if the `HeaderBackground` component is necessary, or if all `PageHeader`s can be dealt with by a `backgroundTexture` (having both feels confusing – presumably it was needed at some point). Answer: to have the featuredImage and the wobbly edge offset, it's probably still the most sensible way to do it
- [x] Make the `event_header_background.svg` the default (and rename it accordingly)
- [ ] Documentation in Cardigan