### PR TITLE
Remove excess space from last items

### DIFF
--- a/common/views/components/LandingBody/LandingBody.js
+++ b/common/views/components/LandingBody/LandingBody.js
@@ -17,6 +17,7 @@ import FeaturedCard, {
 } from '../FeaturedCard/FeaturedCard';
 import { convertItemToCardProps } from '@weco/common/model/card';
 import VisitUsStaticContent from './VisitUsStaticContent';
+import ConditionalWrapper from '../ConditionalWrapper/ConditionalWrapper';
 
 type BodySlice = {|
   type: string,
@@ -121,11 +122,22 @@ const Body = ({ body, isDropCapped, pageId }: Props) => {
             item.type === 'card' ? item : convertItemToCardProps(item);
           return <Card key={i} item={cardProps} />;
         });
+        const isLast = index === sections.length - 1;
+
         return (
-          <SpacingSection key={index}>
+          <ConditionalWrapper
+            key={index}
+            condition={!isLast}
+            wrapper={children => <SpacingSection>{children}</SpacingSection>}
+          >
             <WobblyEdge background={sectionTheme.rowBackground} isStatic />
             <Space
-              v={{ size: 'xl', properties: ['padding-top', 'padding-bottom'] }}
+              v={{
+                size: 'xl',
+                properties: isLast
+                  ? ['padding-top']
+                  : ['padding-top', 'padding-bottom'],
+              }}
               className={classNames({
                 'row card-theme': true,
                 [`bg-${sectionTheme.rowBackground}`]: true,
@@ -138,14 +150,22 @@ const Body = ({ body, isDropCapped, pageId }: Props) => {
                 </Space>
               )}
               {featuredItem && (
-                <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
+                <ConditionalWrapper
+                  condition={!isLast}
+                  wrapper={children => (
+                    <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
+                      {children}
+                    </Space>
+                  )}
+                >
                   <Layout12>{featuredItem}</Layout12>
-                </Space>
+                </ConditionalWrapper>
               )}
               {cards.length > 0 && <GridFactory items={cards} />}
             </Space>
-            <WobblyEdge background={'white'} isStatic />
-          </SpacingSection>
+
+            {!isLast && <WobblyEdge background={'white'} isStatic />}
+          </ConditionalWrapper>
         );
       })}
     </div>


### PR DESCRIPTION
Fixes #5425

Removes excess space/wobbly-edge below final component.

![Screenshot 2020-07-31 at 17 27 02](https://user-images.githubusercontent.com/1394592/89056249-a445b700-d353-11ea-9729-9891070a5ee5.png)
