### PR TITLE
Re add hotjar

### DIFF
--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -34,6 +34,7 @@ import { getWorks } from '../services/catalogue/works';
 import { trackSearch } from '@weco/common/views/components/Tracker/Tracker';
 import cookies from 'next-cookies';
 import useSavedSearchState from '@weco/common/hooks/useSavedSearchState';
+import useHotjar from '@weco/common/hooks/useHotjar';
 import WorkSearchResults from '../components/WorkSearchResults/WorkSearchResults';
 import ImageSearchResults from '../components/ImageSearchResults/ImageSearchResults';
 import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
@@ -97,6 +98,8 @@ const Works = ({
       Router.events.off('routeChangeComplete', routeChangeComplete);
     };
   }, []);
+
+  useHotjar();
 
   const isImageSearch = worksRouteProps.search === 'images';
   const { newImageSearch } = useContext(TogglesContext);

--- a/common/hooks/useHotjar.js
+++ b/common/hooks/useHotjar.js
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+
+const useHotjar = () => {
+  useEffect(() => {
+    (function(h, o, t, j, a, r) {
+      h.hj =
+        h.hj ||
+        function() {
+          (h.hj.q = h.hj.q || []).push(arguments);
+        };
+      h._hjSettings = { hjid: 3858, hjsv: 6 };
+      a = o.getElementsByTagName('head')[0];
+      r = o.createElement('script');
+      r.async = true;
+      r.src = t + h._hjSettings.hjid + j + h._hjSettings.hjsv;
+      a.appendChild(r);
+    })(window, document, '//static.hotjar.com/c/hotjar-', '.js?sv=');
+  }, []);
+};
+
+export default useHotjar;

--- a/common/hooks/useHotjar.js
+++ b/common/hooks/useHotjar.js
@@ -1,20 +1,24 @@
-import { useEffect } from 'react';
+import { useEffect, useContext } from 'react';
+import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
 
 const useHotjar = () => {
+  const { isHotjarActive } = useContext(TogglesContext);
+
   useEffect(() => {
-    (function(h, o, t, j, a, r) {
-      h.hj =
-        h.hj ||
-        function() {
-          (h.hj.q = h.hj.q || []).push(arguments);
-        };
-      h._hjSettings = { hjid: 3858, hjsv: 6 };
-      a = o.getElementsByTagName('head')[0];
-      r = o.createElement('script');
-      r.async = true;
-      r.src = t + h._hjSettings.hjid + j + h._hjSettings.hjsv;
-      a.appendChild(r);
-    })(window, document, '//static.hotjar.com/c/hotjar-', '.js?sv=');
+    isHotjarActive &&
+      (function(h, o, t, j, a, r) {
+        h.hj =
+          h.hj ||
+          function() {
+            (h.hj.q = h.hj.q || []).push(arguments);
+          };
+        h._hjSettings = { hjid: 3858, hjsv: 6 };
+        a = o.getElementsByTagName('head')[0];
+        r = o.createElement('script');
+        r.async = true;
+        r.src = t + h._hjSettings.hjid + j + h._hjSettings.hjsv;
+        a.appendChild(r);
+      })(window, document, '//static.hotjar.com/c/hotjar-', '.js?sv=');
   }, []);
 };
 

--- a/common/views/pages/_app.js
+++ b/common/views/pages/_app.js
@@ -267,6 +267,21 @@ export default class WecoApp extends App {
       })
       .catch(console.log);
 
+    // Hotjar
+    (function(h, o, t, j, a, r) {
+      h.hj =
+        h.hj ||
+        function() {
+          (h.hj.q = h.hj.q || []).push(arguments);
+        };
+      h._hjSettings = { hjid: 3858, hjsv: 6 };
+      a = o.getElementsByTagName('head')[0];
+      r = o.createElement('script');
+      r.async = true;
+      r.src = t + h._hjSettings.hjid + j + h._hjSettings.hjsv;
+      a.appendChild(r);
+    })(window, document, '//static.hotjar.com/c/hotjar-', '.js?sv=');
+
     // Prismic preview and validation warnings
     if (document.cookie.match('isPreview=true')) {
       window.prismic = {

--- a/common/views/pages/_app.js
+++ b/common/views/pages/_app.js
@@ -267,21 +267,6 @@ export default class WecoApp extends App {
       })
       .catch(console.log);
 
-    // Hotjar
-    (function(h, o, t, j, a, r) {
-      h.hj =
-        h.hj ||
-        function() {
-          (h.hj.q = h.hj.q || []).push(arguments);
-        };
-      h._hjSettings = { hjid: 3858, hjsv: 6 };
-      a = o.getElementsByTagName('head')[0];
-      r = o.createElement('script');
-      r.async = true;
-      r.src = t + h._hjSettings.hjid + j + h._hjSettings.hjsv;
-      a.appendChild(r);
-    })(window, document, '//static.hotjar.com/c/hotjar-', '.js?sv=');
-
     // Prismic preview and validation warnings
     if (document.cookie.match('isPreview=true')) {
       window.prismic = {

--- a/toggles/webapp/toggles.js
+++ b/toggles/webapp/toggles.js
@@ -55,5 +55,11 @@ module.exports = {
       description:
         'Displays body copy in Helvetica regular (where it is currently Helvetica light)',
     },
+    {
+      id: 'isHotjarActive',
+      title: 'Hotjar',
+      defaultValue: true,
+      description: 'Embeds the Hotjar script for user research',
+    },
   ],
 };


### PR DESCRIPTION
## Who is this for?
User researchers.

## What is it doing for them?
Letting them collect hotjar data.

Added the hotjar script as a hook so that it can be added/removed from individual pages relatively easily as needed. Currently only required on (so only added to) the works search pages.