### PR TITLE
update node versions to 12.18.3 on webapps

### DIFF
--- a/catalogue/webapp/Dockerfile
+++ b/catalogue/webapp/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.15.1-alpine
+FROM node:12.18.3-alpine
 
 ENV NODE_ENV=production
 
@@ -9,9 +9,9 @@ ADD ./common ./common
 ADD ./catalogue/webapp ./catalogue/webapp
 # This is needed for node-sass
 RUN apk add --no-cache --virtual .gyp \
-        python \
-        make \
-        g++ \
+    python \
+    make \
+    g++ \
     && yarn install \
     && apk del .gyp
 

--- a/content/webapp/Dockerfile
+++ b/content/webapp/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.15.1-alpine
+FROM node:12.18.3-alpine
 
 ENV NODE_ENV=production
 
@@ -9,9 +9,9 @@ ADD ./common ./common
 ADD ./content/webapp ./content/webapp
 # This is needed for node-sass
 RUN apk add --no-cache --virtual .gyp \
-        python \
-        make \
-        g++ \
+    python \
+    make \
+    g++ \
     && yarn install \
     && apk del .gyp
 


### PR DESCRIPTION
We're falling out of line with the LTS and `apt` is playing up in places. Instead of running `apt update` which makes the build more inconsistent over time, and can run into every growing build times due to downloading more and more as we become out of date, let's just keep up to date.