### PR TITLE
Use color function everywhere

### DIFF
--- a/common/views/components/ArchiveTree/ArchiveTree.js
+++ b/common/views/components/ArchiveTree/ArchiveTree.js
@@ -43,7 +43,7 @@ const StyledLink = styled.a`
   background: ${props => (props.isCurrent ? 'yellow' : 'transparent')};
   font-weight: ${props => (props.isCurrent ? 'bold' : 'normal')};
   border-color: ${props =>
-    props.isCurrent ? props.theme.colors.green : 'transparent'};
+    props.theme.color(props.isCurrent ? 'green' : 'transparent')};
   border-radius: 6px;
   padding: 0 6px;
   cursor: pointer;

--- a/common/views/components/ButtonOutlined/ButtonOutlined.tsx
+++ b/common/views/components/ButtonOutlined/ButtonOutlined.tsx
@@ -20,9 +20,9 @@ export const OutlinedButton = styled(BaseButton).attrs<MaybeAnchor>(props => ({
     'link-reset': !!props.href,
   }),
 }))`
-  border: 2px solid ${props => props.theme.colors.green};
-  background: ${props => props.theme.colors.transparent};
-  color: ${props => props.theme.colors.green};
+  border: 2px solid ${props => props.theme.color('green')};
+  background: ${props => props.theme.color('transparent')};
+  color: ${props => props.theme.color('green')};
   padding: 15px 20px;
 
   &:hover {

--- a/common/views/components/Rating/Rating.js
+++ b/common/views/components/Rating/Rating.js
@@ -43,7 +43,7 @@ const Star = styled.span.attrs(props => ({
   padding: 0 0.3em;
   &::before {
     transition: color 400ms;
-    color: ${props => props.theme.colors[props.color]};
+    color: ${props => props.theme.color([props.color])};
     content: '★';
   }
 `;

--- a/common/views/components/RepeatingLs/RepeatingLs.js
+++ b/common/views/components/RepeatingLs/RepeatingLs.js
@@ -8,7 +8,7 @@ type Props = {|
 |};
 
 const RepeatingLsOuter = styled.div`
-  background: ${props => props.theme.colors[props.background]};
+  background: ${props => props.theme.color([props.background])};
   position: absolute;
   top: 0;
   right: 0;
@@ -24,7 +24,7 @@ const ReapeatingLsInner = styled.div`
   bottom: 0;
   left: 0;
   mask-size: ${props => props.size}px;
-  background: ${props => props.theme.colors[props.foreground]};
+  background: ${props => props.theme.color([props.foreground])};
   mask-image: url(${props => props.mask});
   mask-repeat: repeat;
 `;


### PR DESCRIPTION
Fixing a handful of stray instances not using the `color` function.

__before__

![Screenshot 2020-08-10 at 16 00 02](https://user-images.githubusercontent.com/1394592/89797320-b200f680-db22-11ea-863a-09d71dc62fad.png)

__after__

![Screenshot 2020-08-10 at 15 59 40](https://user-images.githubusercontent.com/1394592/89797329-b5947d80-db22-11ea-9eff-20398eaed807.png)

