### PR TITLE
Disable miro merging test

### DIFF
--- a/catalogue/webapp/services/catalogue/common.js
+++ b/catalogue/webapp/services/catalogue/common.js
@@ -14,9 +14,7 @@ type GlobalApiOptions = {|
 
 export const globalApiOptions = (toggles: Toggles): GlobalApiOptions => ({
   env: toggles.stagingApi ? 'stage' : 'prod',
-  indexOverrideSuffix: toggles.newImageSearch
-    ? 'miro-merging-test' // This is an index alias, not an actual index name
-    : null,
+  indexOverrideSuffix: null,
 });
 
 export const queryString = (params: { [key: string]: any }): string => {

--- a/toggles/webapp/toggles.js
+++ b/toggles/webapp/toggles.js
@@ -16,11 +16,10 @@ module.exports = {
     },
     {
       id: 'newImageSearch',
-      title:
-        'Use the images endpoint + the Miro merging test index for image searches',
+      title: 'Use the images endpoint',
       defaultValue: false,
       description:
-        'Use the new images endpoint rather than filtering for works with iiif-image in images search, and use an index where many more Miro works have been merged into Sierra',
+        'Use the new images endpoint rather than filtering for works with iiif-image in images search',
     },
     {
       id: 'searchToolbar',


### PR DESCRIPTION
It's hard to keep the miro merging test pipeline and the production pipeline mappings in sync with each other, so disabling the use of separate indices in the image search for now.