### PR TITLE
Update green hex value to be accessible on white and cream

### DIFF
--- a/catalogue/webapp/test/components/__snapshots__/WorkDetails.test.js.snap
+++ b/catalogue/webapp/test/components/__snapshots__/WorkDetails.test.js.snap
@@ -39,7 +39,7 @@ exports[`Feature: 2. As a library member I want to request an item
               "componentStyle": ComponentStyle {
                 "componentId": "ButtonSolid__SolidButton-xui0q4-3",
                 "isStatic": false,
-                "lastClassName": "dhdqcB",
+                "lastClassName": "hkulVE",
                 "rules": Array [
                   "display:inline-flex;line-height:1;border-radius:",
                   [Function],
@@ -86,7 +86,7 @@ exports[`Feature: 2. As a library member I want to request an item
           onClick={[Function]}
         >
           <a
-            className="ButtonSolid__BaseButton-xui0q4-0 ButtonSolid__SolidButton-xui0q4-3 dhdqcB flex-inline flex--v-center"
+            className="ButtonSolid__BaseButton-xui0q4-0 ButtonSolid__SolidButton-xui0q4-3 hkulVE flex-inline flex--v-center"
             href="/loginUrl"
             onClick={[Function]}
           >
@@ -166,7 +166,7 @@ exports[`Feature: 2. As a library member I want to request an item Scenario: I'm
             "componentStyle": ComponentStyle {
               "componentId": "ButtonSolid__SolidButton-xui0q4-3",
               "isStatic": false,
-              "lastClassName": "dhdqcB",
+              "lastClassName": "hkulVE",
               "rules": Array [
                 "display:inline-flex;line-height:1;border-radius:",
                 [Function],
@@ -212,7 +212,7 @@ exports[`Feature: 2. As a library member I want to request an item Scenario: I'm
         onClick={[Function]}
       >
         <button
-          className="ButtonSolid__BaseButton-xui0q4-0 ButtonSolid__SolidButton-xui0q4-3 dhdqcB flex-inline flex--v-center"
+          className="ButtonSolid__BaseButton-xui0q4-0 ButtonSolid__SolidButton-xui0q4-3 hkulVE flex-inline flex--v-center"
           onClick={[Function]}
         >
           <ButtonSolid__BaseButtonInner>

--- a/common/views/themes/default.js
+++ b/common/views/themes/default.js
@@ -44,7 +44,7 @@ const theme = {
     yellow: { base: '#ffce3c', dark: '', light: '' },
     brown: { base: '#815e48', dark: '', light: '' },
     cream: { base: '#f0ede3', dark: '', light: '' },
-    green: { base: '#178474', dark: '#146a5c', light: '' },
+    green: { base: '#00786c', dark: '#146a5c', light: '' },
     charcoal: { base: '#323232', dark: '', light: '' },
     pewter: { base: '#6b6b6b', dark: '', light: '' },
     silver: { base: '#8f8f8f', dark: '', light: '' },


### PR DESCRIPTION
☝️ 

There is still a question of green on black being inaccessible, but that only happens on hover in the footer currently, so is less critical (and the footer is subject to change).