### PR TITLE
Select styles

### DIFF
--- a/common/views/components/SelectContainer/SelectContainer.js
+++ b/common/views/components/SelectContainer/SelectContainer.js
@@ -8,7 +8,7 @@ import { classNames, font } from '../../../utils/classnames';
 
 const StyledSelect = styled.div.attrs(props => ({
   className: classNames({
-    [font('hnm', 5)]: true,
+    [font('hnl', 5)]: true,
   }),
 }))`
   position: relative;

--- a/common/views/components/SelectContainer/SelectContainer.js
+++ b/common/views/components/SelectContainer/SelectContainer.js
@@ -25,7 +25,7 @@ const StyledSelect = styled.div.attrs(props => ({
     font-family: inherit;
     font-weight: inherit;
     appearance: none;
-    padding: 7px 12px 9px;
+    padding: 7px 36px 9px 12px;
     border: 2px solid ${props => props.theme.color('pumice')};
     border-radius: ${props => props.theme.borderRadiusUnit}px;
     background-color: ${props => props.theme.color('white')};

--- a/common/views/components/SelectContainer/SelectContainer.js
+++ b/common/views/components/SelectContainer/SelectContainer.js
@@ -61,7 +61,13 @@ const SelectContainer = ({ label, children }: Props) => {
   return (
     <StyledSelect isKeyboard={isKeyboard}>
       <label>
-        <Space as="span" h={{ size: 'm', properties: ['margin-right'] }}>
+        <Space
+          as="span"
+          h={{ size: 'm', properties: ['margin-right'] }}
+          className={classNames({
+            [font('hnm', 5)]: true,
+          })}
+        >
           {label}
         </Space>
         {children}

--- a/common/views/components/SelectContainer/SelectContainer.js
+++ b/common/views/components/SelectContainer/SelectContainer.js
@@ -1,48 +1,51 @@
 // @flow
-import { type Element } from 'react';
+import { useContext, type Element } from 'react';
+import { AppContext } from '../AppContext/AppContext';
 import styled from 'styled-components';
 import Space from '../styled/Space';
+import Icon from '../Icon/Icon';
 import { classNames, font } from '../../../utils/classnames';
 
 const StyledSelect = styled.div.attrs(props => ({
   className: classNames({
-    [font('hnl', 5)]: true,
+    [font('hnm', 5)]: true,
   }),
 }))`
   position: relative;
 
-  &:after {
-    position: absolute;
-    margin-left: -22px;
-    top: 17px;
-    content: '';
-    width: 0;
-    height: 0;
-    border-left: 5px solid transparent;
-    border-right: 5px solid transparent;
-    border-top: 5px solid ${props => props.theme.color('silver')};
+  .icon {
     pointer-events: none;
+    top: 6px;
+    right: 36px;
   }
+
   select {
     -moz-appearance: none;
     -webkit-appearance: none;
+    font-family: inherit;
+    font-weight: inherit;
     appearance: none;
-    padding: 10px 26px 10px 12px;
-    border: 1px solid ${props => props.theme.color('pumice')};
-    border-radius: ${props => props.borderRadiusUnit}px;
+    padding: 7px 12px 9px;
+    border: 2px solid ${props => props.theme.color('pumice')};
+    border-radius: ${props => props.theme.borderRadiusUnit}px;
     background-color: ${props => props.theme.color('white')};
 
     &::-ms-expand {
       display: none;
     }
+
     &:hover {
-      border-color: ${props => props.theme.color('yellow')};
+      box-shadow: ${props => props.theme.focusBoxShadow};
     }
+
     &:focus {
-      padding: 9px 25px 9px 11px;
-      border-width: 2px;
-      border-color: ${props => props.theme.color('yellow')};
-      outline: none;
+      outline: 0;
+
+      ${props =>
+        props.isKeyboard &&
+        `
+        box-shadow: ${props.theme.focusBoxShadow};
+      `}
     }
   }
 `;
@@ -53,14 +56,17 @@ type Props = {
 };
 
 const SelectContainer = ({ label, children }: Props) => {
+  const { isKeyboard } = useContext(AppContext);
+
   return (
-    <StyledSelect>
+    <StyledSelect isKeyboard={isKeyboard}>
       <label>
-        <Space as="span" h={{ size: 's', properties: ['margin-right'] }}>
+        <Space as="span" h={{ size: 'm', properties: ['margin-right'] }}>
           {label}
         </Space>
         {children}
       </label>
+      <Icon name="chevron" />
     </StyledSelect>
   );
 };


### PR DESCRIPTION
Aligning our styled `select` element with the `DropdownButton` (inline variant) styles.

![image](https://user-images.githubusercontent.com/1394592/90132340-8588ec80-dd65-11ea-8cfe-d8395f62c945.png)

I think hover styles have to be distinct, because you can't afaik have e.g. text-decoration on an `option` element (and I don't _think_ we want to start hacking the `select`. I certainly don't). I've used the focus style for hover currently, but will check with @GarethOrmerod if there's something he'd prefer.