### PR TITLE
Filter font size

### DIFF
--- a/catalogue/webapp/components/RequestLocation/RequestLocation.js
+++ b/catalogue/webapp/components/RequestLocation/RequestLocation.js
@@ -3,6 +3,7 @@ import { useState, useEffect, useRef } from 'react';
 import { type Work } from '@weco/common/model/work';
 import useAuth from '@weco/common/hooks/useAuth';
 import ResponsiveTable from '@weco/common/views/components/styled/ResponsiveTable';
+// $FlowFixMe (tsx)
 import CheckboxRadio from '@weco/common/views/components/CheckboxRadio/CheckboxRadio';
 import Modal from '@weco/common/views/components/Modal/Modal';
 import ItemRequestButton from '@weco/catalogue/components/ItemRequestButton/ItemRequestButton';

--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -7,7 +7,7 @@ import TextInput from '@weco/common/views/components/TextInput/TextInput';
 import Icon from '@weco/common/views/components/Icon/Icon';
 // $FlowFixMe (tsx)
 import ButtonSolid from '@weco/common/views/components/ButtonSolid/ButtonSolid';
-import { classNames } from '@weco/common/utils/classnames';
+import { classNames, font } from '@weco/common/utils/classnames';
 import { trackEvent } from '@weco/common/utils/ga';
 import { inputValue, nodeListValueToArray } from '@weco/common/utils/forms';
 import SearchFilters from '@weco/common/views/components/SearchFilters/SearchFilters';
@@ -183,7 +183,12 @@ const SearchForm = ({
 
       {shouldShowFilters && (
         <>
-          <Space v={{ size: 'm', properties: ['margin-top'] }}>
+          <Space
+            v={{ size: 'm', properties: ['margin-top'] }}
+            className={classNames({
+              [font('hnl', 5)]: true,
+            })}
+          >
             <RadioGroup
               name="search"
               selected={worksRouteProps.search ? 'images' : ''}

--- a/common/views/components/CheckboxRadio/CheckboxRadio.js
+++ b/common/views/components/CheckboxRadio/CheckboxRadio.js
@@ -28,6 +28,8 @@ const CheckboxRadioBox = styled.span.attrs({
   .icon {
     position: absolute;
     opacity: 0;
+    width: 100%;
+    height: 100%;
   }
 `;
 
@@ -83,10 +85,7 @@ function CheckboxRadio({ id, text, type, ...inputProps }: CheckboxRadioProps) {
         hideFocus={!isKeyboard}
       />
       <CheckboxRadioBox type={type}>
-        <Icon
-          name={type === 'checkbox' ? 'check' : 'indicator'}
-          extraClasses={`icon--match-text`}
-        />
+        <Icon name={type === 'checkbox' ? 'check' : 'indicator'} />
       </CheckboxRadioBox>
       <Space as="span" h={{ size: 'xs', properties: ['margin-left'] }}>
         {text}

--- a/common/views/components/CheckboxRadio/CheckboxRadio.tsx
+++ b/common/views/components/CheckboxRadio/CheckboxRadio.tsx
@@ -1,6 +1,4 @@
-// @flow
-
-import { useContext } from 'react';
+import { useContext, SyntheticEvent } from 'react';
 import styled from 'styled-components';
 import { classNames } from '../../../utils/classnames';
 import Space from '../styled/Space';
@@ -63,15 +61,15 @@ const CheckboxRadioInput = styled.input.attrs(props => ({
   }
 `;
 
-type CheckboxRadioProps = {|
-  type: 'checkbox' | 'radio',
-  id: string,
-  text: string,
-  checked: boolean,
-  name: string,
-  onChange: (SyntheticEvent<HTMLInputElement>) => void,
-  value: string,
-|};
+type CheckboxRadioProps = {
+  type: 'checkbox' | 'radio';
+  id: string;
+  text: string;
+  checked: boolean;
+  name: string;
+  onChange: (event: SyntheticEvent<HTMLInputElement>) => void;
+  value: string;
+};
 
 function CheckboxRadio({ id, text, type, ...inputProps }: CheckboxRadioProps) {
   const { isKeyboard } = useContext(AppContext);

--- a/common/views/components/NewsletterSignup/NewsletterSignup.js
+++ b/common/views/components/NewsletterSignup/NewsletterSignup.js
@@ -1,6 +1,7 @@
 // @flow
 import { useState, useEffect } from 'react';
 import TextInput from '@weco/common/views/components/TextInput/TextInput';
+// $FlowFixMe (tsx)
 import CheckboxRadio from '@weco/common/views/components/CheckboxRadio/CheckboxRadio';
 import { font, classNames } from '../../../utils/classnames';
 import Space from '../styled/Space';

--- a/common/views/components/RadioGroup/RadioGroup.js
+++ b/common/views/components/RadioGroup/RadioGroup.js
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react';
+// $FlowFixMe (tsx)
 import CheckboxRadio from '../CheckboxRadio/CheckboxRadio';
 import Space from '../styled/Space';
 import { classNames } from '../../../utils/classnames';

--- a/common/views/components/SearchFilters/SearchFiltersDesktop.js
+++ b/common/views/components/SearchFilters/SearchFiltersDesktop.js
@@ -83,7 +83,12 @@ const SearchFiltersDesktop = ({
             Filter by
           </Space>
         </Space>
-        <Space h={{ size: 's', properties: ['margin-right'] }}>
+        <Space
+          h={{ size: 's', properties: ['margin-right'] }}
+          className={classNames({
+            [font('hnl', 5)]: true,
+          })}
+        >
           <DropdownButton label={'Dates'} isInline={true}>
             <>
               <Space as="span" h={{ size: 'm', properties: ['margin-right'] }}>
@@ -119,6 +124,7 @@ const SearchFiltersDesktop = ({
             <ul
               className={classNames({
                 'no-margin no-padding plain-list': true,
+                [font('hnl', 5)]: true,
               })}
             >
               {workTypeFilters.map(workType => {

--- a/common/views/components/SearchFilters/SearchFiltersDesktop.js
+++ b/common/views/components/SearchFilters/SearchFiltersDesktop.js
@@ -7,6 +7,7 @@ import Icon from '../Icon/Icon';
 // $FlowFixMe (tsx)
 import DropdownButton from '@weco/common/views/components/DropdownButton/DropdownButton';
 import NumberInput from '@weco/common/views/components/NumberInput/NumberInput';
+// $FlowFixMe (tsx)
 import CheckboxRadio from '@weco/common/views/components/CheckboxRadio/CheckboxRadio';
 import NextLink from 'next/link';
 import { type SearchFiltersSharedProps } from './SearchFilters';

--- a/common/views/components/SearchFilters/SearchFiltersMobile.js
+++ b/common/views/components/SearchFilters/SearchFiltersMobile.js
@@ -11,6 +11,7 @@ import { classNames } from '../../../utils/classnames';
 import Space from '../styled/Space';
 import Icon from '../Icon/Icon';
 import NumberInput from '@weco/common/views/components/NumberInput/NumberInput';
+// $FlowFixMe (tsx)
 import CheckboxRadio from '@weco/common/views/components/CheckboxRadio/CheckboxRadio';
 import { type SearchFiltersSharedProps } from './SearchFilters';
 import ButtonSolid, {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/wellcomecollection/wellcomecollection.org#readme",
   "devDependencies": {
+    "@types/styled-components": "^5.1.2",
     "babel-cli": "^6.26.0",
     "babel-eslint": "^10.0.1",
     "eslint": "^5.11.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1707,6 +1707,14 @@
   resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.3.3.tgz#85bc74ba782fb7aa3a514d11767832b0e3bc6803"
   integrity sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==
 
+"@types/hoist-non-react-statics@*":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"
@@ -1752,6 +1760,21 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.2.tgz#690a1475b84f2a884fd07cd797c00f5f31356ea8"
   integrity sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==
 
+"@types/react-native@*":
+  version "0.63.8"
+  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.63.8.tgz#73ec087122c64c309eeaf150b565b8d755f0fb1f"
+  integrity sha512-QRwGFRTyGafRVTUS+0GYyJrlpmS3boyBaFI0ULSc+mh/lQNxrzbdQvoL2k5X7+t9hxyqA4dTQAlP6l0ir/fNJQ==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*":
+  version "16.9.46"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.46.tgz#f0326cd7adceda74148baa9bff6e918632f5069e"
+  integrity sha512-dbHzO3aAq1lB3jRQuNpuZ/mnu+CdD3H0WVaaBQA8LTT3S33xhVBUj232T8M3tAhSWJs/D/UqORYUlJNl/8VQZg==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^3.0.2"
+
 "@types/react@^16.9.35":
   version "16.9.35"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.35.tgz#a0830d172e8aadd9bd41709ba2281a3124bbd368"
@@ -1764,6 +1787,16 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+
+"@types/styled-components@^5.1.2":
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/@types/styled-components/-/styled-components-5.1.2.tgz#652af475b4af917b355ea1c3068acae63d46455f"
+  integrity sha512-HNocYLfrsnNNm8NTS/W53OERSjRA8dx5Bn6wBd2rXXwt4Z3s+oqvY6/PbVt3e6sgtzI63GX//WiWiRhWur08qQ==
+  dependencies:
+    "@types/hoist-non-react-statics" "*"
+    "@types/react" "*"
+    "@types/react-native" "*"
+    csstype "^3.0.2"
 
 "@types/yargs-parser@*":
   version "15.0.0"
@@ -4048,6 +4081,11 @@ csstype@^2.2.0, csstype@^2.6.7:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.10.tgz#e63af50e66d7c266edb6b32909cfd0aabe03928b"
   integrity sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==
 
+csstype@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.2.tgz#ee5ff8f208c8cd613b389f7b222c9801ca62b3f7"
+  integrity sha512-ofovWglpqoqbfLNOTBNZLSbMuGrblAf1efvvArGKOZMBrIoJeu5UsAipQolkijtyQx5MtAzT/J9IHj/CEY1mJw==
+
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
@@ -5916,6 +5954,13 @@ hogan.js@^3.0.2:
   dependencies:
     mkdirp "0.3.0"
     nopt "1.0.10"
+
+hoist-non-react-statics@^3.3.0:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -10266,7 +10311,7 @@ react-ga@^2.5.6:
   resolved "https://registry.yarnpkg.com/react-ga/-/react-ga-2.7.0.tgz#24328f157f31e8cffbf4de74a3396536679d8d7c"
   integrity sha512-AjC7UOZMvygrWTc2hKxTDvlMXEtbmA0IgJjmkhgmQQ3RkXrWR11xEagLGFGaNyaPnmg24oaIiaNPnEoftUhfXA==
 
-react-is@16.13.1, react-is@^16.12.0, react-is@^16.6.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6, react-is@^16.9.0:
+react-is@16.13.1, react-is@^16.12.0, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6, react-is@^16.9.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==


### PR DESCRIPTION
The font size for the filters and the All collection/Images only radios is currently one size larger than it is in the designs. This PR reduces those font sizes.

![image](https://user-images.githubusercontent.com/1394592/90397902-77520d80-e090-11ea-9c6d-d9f9dd75f2ee.png)

Using percentages for the `CheckboxRadio` icon sizing _seems_ to solve the browser rounding errors that resulted in radios possibly looking like googly eyes.