### PR TITLE
Make enough space for padding and 4 characters

### DIFF
--- a/common/views/components/NumberInput/NumberInput.js
+++ b/common/views/components/NumberInput/NumberInput.js
@@ -10,6 +10,7 @@ const StyledInput: ComponentType<SpaceComponentProps> = styled(Space).attrs({
   border: 1px solid ${props => props.theme.color('pumice')};
   padding: 12px;
   border-radius: 3px;
+  appearance: none;
 
   /* removes up and down arrows webkit adds to number inputs on desktop */
   &::-webkit-inner-spin-button,

--- a/common/views/components/SearchFilters/SearchFiltersMobile.js
+++ b/common/views/components/SearchFilters/SearchFiltersMobile.js
@@ -105,7 +105,11 @@ const ActiveFilters = styled(Space).attrs({
 
 const FiltersBody = styled(Space).attrs({
   h: { size: 'xl', properties: ['padding-left', 'padding-right'] },
-})``;
+})`
+  input[type='number'] {
+    min-width: calc(24px + 4ch);
+  }
+`;
 
 const FilterSection = styled(Space).attrs({
   v: { size: 'xl', properties: ['padding-top', 'padding-bottom'] },


### PR DESCRIPTION
Fixes #5465

Also removes the inset box-shadow from the top of the input (added by iOS `-webkit-appearance`).

![image](https://user-images.githubusercontent.com/1394592/90417814-2b14c680-e0ac-11ea-915b-856d6b07c9ab.png)
