### PR TITLE
Archive tree updates for testing

### DIFF
--- a/catalogue/webapp/components/Work/Work.tsx
+++ b/catalogue/webapp/components/Work/Work.tsx
@@ -206,13 +206,15 @@ const Work = ({ work }: Props) => {
                   })]: true,
                 })}
               >
-                <WorkDetails
-                  work={work}
-                  itemUrl={itemUrlObject}
-                  iiifPresentationManifest={iiifPresentationManifest}
-                  childManifestsCount={childManifestsCount}
-                  imageCount={imageTotal}
-                />
+                <Space v={{size: 'xl', properties: ['margin-top'], negative: true}}>
+                  <WorkDetails
+                    work={work}
+                    itemUrl={itemUrlObject}
+                    iiifPresentationManifest={iiifPresentationManifest}
+                    childManifestsCount={childManifestsCount}
+                    imageCount={imageTotal}
+                  />
+                </Space>
               </div>
             </div>
           </div>

--- a/catalogue/webapp/components/Work/Work.tsx
+++ b/catalogue/webapp/components/Work/Work.tsx
@@ -16,6 +16,7 @@ import CataloguePageLayout from '@weco/common/views/components/CataloguePageLayo
 import { workLd } from '@weco/common/utils/json-ld';
 import BackToResults from '@weco/common/views/components/BackToResults/BackToResults';
 import WorkHeader from '@weco/common/views/components/WorkHeader/WorkHeader';
+import WorkHeaderPrototype from '@weco/common/views/components/WorkHeaderPrototype/WorkHeaderPrototype';
 import ArchiveBreadcrumb from '@weco/common/views/components/ArchiveBreadcrumb/ArchiveBreadcrumb';
 import Space from '@weco/common/views/components/styled/Space';
 import useSavedSearchState from '@weco/common/hooks/useSavedSearchState';
@@ -175,41 +176,47 @@ const Work = ({ work }: Props) => {
         )}
 
 {archivesPrototypeSidePanel && isInArchive ? (
-        <div className="container">
-          <div className="grid">
-            <div
-              className={classNames({
-                [grid({
-                  s: 12,
-                  m: 5,
-                  l: 4,
-                  xl: 3,
-                })]: true,
-              })}
-            >
-              <ArchiveTree work={work} withModal={false} />
-            </div>
-            <div
-              className={classNames({
-                [grid({
-                  s: 12,
-                  m: 7,
-                  l: 8,
-                  xl: 9,
-                })]: true,
-              })}
-            >
-              <WorkHeader work={work} childManifestsCount={childManifestsCount} />
-              <WorkDetails
-        work={work}
-        itemUrl={itemUrlObject}
-        iiifPresentationManifest={iiifPresentationManifest}
-        childManifestsCount={childManifestsCount}
-        imageCount={imageTotal}
-      />
+        <>
+          <div className="container">
+            <div className="grid">
+              <WorkHeaderPrototype work={work} childManifestsCount={childManifestsCount} />
             </div>
           </div>
-        </div>
+          <div className="container">
+            <div className="grid">
+              <div
+                className={classNames({
+                  [grid({
+                    s: 12,
+                    m: 5,
+                    l: 4,
+                    xl: 3,
+                  })]: true,
+                })}
+              >
+                <ArchiveTree work={work} withModal={false} />
+              </div>
+              <div
+                className={classNames({
+                  [grid({
+                    s: 12,
+                    m: 7,
+                    l: 8,
+                    xl: 9,
+                  })]: true,
+                })}
+              >
+                <WorkDetails
+                  work={work}
+                  itemUrl={itemUrlObject}
+                  iiifPresentationManifest={iiifPresentationManifest}
+                  childManifestsCount={childManifestsCount}
+                  imageCount={imageTotal}
+                />
+              </div>
+            </div>
+          </div>
+        </>
         ) : (
       <>
         <div className="container">

--- a/catalogue/webapp/components/Work/Work.tsx
+++ b/catalogue/webapp/components/Work/Work.tsx
@@ -181,9 +181,9 @@ const Work = ({ work }: Props) => {
               className={classNames({
                 [grid({
                   s: 12,
-                  m: 6,
-                  l: 5,
-                  xl: 5,
+                  m: 5,
+                  l: 4,
+                  xl: 3,
                 })]: true,
               })}
             >
@@ -193,9 +193,9 @@ const Work = ({ work }: Props) => {
               className={classNames({
                 [grid({
                   s: 12,
-                  m: 6,
-                  l: 7,
-                  xl: 7,
+                  m: 7,
+                  l: 8,
+                  xl: 9,
                 })]: true,
               })}
             >

--- a/common/views/components/ArchiveTree/ArchiveTree.js
+++ b/common/views/components/ArchiveTree/ArchiveTree.js
@@ -513,6 +513,18 @@ const ArchiveTree = ({ work }: { work: Work }) => {
     </Tree>
   );
 
+  const initialLoad = useRef(true);
+
+  useEffect(() => {
+    if (!initialLoad.current) {
+      const workInfo = document.getElementById('work-info');
+
+      workInfo.scrollIntoView({ behavior: 'smooth' });
+    }
+
+    initialLoad.current = false;
+  }, [work.id]);
+
   useEffect(() => {
     // Add siblings to each node, that leads to the current work
     const basicTree = createCollectionTree(work);

--- a/common/views/components/ArchiveTree/ArchiveTree.js
+++ b/common/views/components/ArchiveTree/ArchiveTree.js
@@ -11,8 +11,6 @@ import TogglesContext from '@weco/common/views/components/TogglesContext/Toggles
 import Space from '../styled/Space';
 // $FlowFixMe (tsx)
 import ButtonSolid from '@weco/common/views/components/ButtonSolid/ButtonSolid';
-// $FlowFixMe (tsx)
-import ButtonOutlined from '@weco/common/views/components/ButtonOutlined/ButtonOutlined';
 import Modal from '@weco/common/views/components/Modal/Modal';
 // $FlowFixMe (tsx)
 import WorkTitle from '@weco/common/views/components/WorkTitle/WorkTitle';
@@ -357,6 +355,53 @@ const ListItem = ({
         <TogglesContext.Consumer>
           {toggles => (
             <div style={{ whiteSpace: 'nowrap' }}>
+              {!isRootItem && (
+                <Space
+                  className="inline-block"
+                  h={{ size: 's', properties: ['margin-right'] }}
+                  style={{
+                    verticalAlign: 'top',
+                    display: showButton ? 'inline-block' : 'none',
+                  }}
+                >
+                  <button
+                    className={classNames({
+                      'plain-button': true,
+                    })}
+                    style={{
+                      fontSize: '10px',
+                      padding: '4px',
+                      background: '#ccc',
+                      position: 'relative',
+                      top: '-2px',
+                      cursor: 'pointer',
+                    }}
+                    onClick={() => {
+                      if (!item.children) {
+                        expandTree(
+                          item.work.id,
+                          toggles,
+                          setCollectionTree,
+                          fullTree
+                        );
+                      } else {
+                        setCollectionTree(
+                          updateDefaultOpenStatus(
+                            item.work.id,
+                            fullTree,
+                            !item.openStatus
+                          )
+                        );
+                      }
+                    }}
+                  >
+                    <Icon
+                      extraClasses="icon--match-text"
+                      name={item.openStatus ? 'minus' : 'plus'}
+                    />
+                  </button>
+                </Space>
+              )}
               <NextLink
                 {...workLink({ id: item.work.id })}
                 scroll={false}
@@ -385,41 +430,6 @@ const ListItem = ({
                   </div>
                 </StyledLink>
               </NextLink>
-              {!isRootItem && (
-                <Space
-                  className="inline-block"
-                  h={{ size: 'm', properties: ['margin-left'] }}
-                  style={{
-                    position: 'absolute',
-                    zoom: '0.7',
-                    display: showButton ? 'inline-block' : 'none',
-                  }}
-                >
-                  <ButtonOutlined
-                    icon={item.openStatus ? 'minus' : 'plus'}
-                    text={item.openStatus ? 'hide children' : 'show children'}
-                    isTextHidden={true}
-                    clickHandler={() => {
-                      if (!item.children) {
-                        expandTree(
-                          item.work.id,
-                          toggles,
-                          setCollectionTree,
-                          fullTree
-                        );
-                      } else {
-                        setCollectionTree(
-                          updateDefaultOpenStatus(
-                            item.work.id,
-                            fullTree,
-                            !item.openStatus
-                          )
-                        );
-                      }
-                    }}
-                  />
-                </Space>
-              )}
             </div>
           )}
         </TogglesContext.Consumer>

--- a/common/views/components/ArchiveTree/ArchiveTree.js
+++ b/common/views/components/ArchiveTree/ArchiveTree.js
@@ -558,9 +558,9 @@ const ArchiveTree = ({ work }: { work: Work }) => {
       <StickyContainer>
         <Space
           v={{ size: 'm', properties: ['padding-top', 'padding-bottom'] }}
-          h={{ size: 'l', properties: ['padding-left', 'padding-right'] }}
+          h={{ size: 'm', properties: ['padding-left', 'padding-right'] }}
           className={classNames({
-            'flex flex--v-center bg-pumice': true,
+            'flex flex--v-center bg-smoke': true,
           })}
         >
           <Space

--- a/common/views/components/ArchiveTree/ArchiveTree.js
+++ b/common/views/components/ArchiveTree/ArchiveTree.js
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useContext, useRef } from 'react';
 import styled from 'styled-components';
-import { classNames } from '@weco/common/utils/classnames';
+import { classNames, font } from '@weco/common/utils/classnames';
 import { getWork } from '@weco/catalogue/services/catalogue/works';
 import { workLink } from '@weco/common/services/catalogue/routes';
 // import { ArchiveNode } from '@weco/common/utils/works';
@@ -16,12 +16,30 @@ import ButtonOutlined from '@weco/common/views/components/ButtonOutlined/ButtonO
 import Modal from '@weco/common/views/components/Modal/Modal';
 // $FlowFixMe (tsx)
 import WorkTitle from '@weco/common/views/components/WorkTitle/WorkTitle';
+import Icon from '@weco/common/views/components/Icon/Icon';
 
 const Container = styled.div`
   overflow: scroll;
   height: ${props => (props.fixHeight ? '70vh' : 'auto')};
   border: 1px solid ${props => props.theme.color('pumice')};
   border-radius: 6px;
+`;
+
+const StickyContainer = styled.div`
+  border: 1px solid ${props => props.theme.color('pumice')};
+  border-bottom: 0;
+
+  ${props => props.theme.media.medium`
+    position: sticky;
+    top: 0px;
+  `}
+`;
+
+const StickyContainerInner = styled.div`
+  ${props => props.theme.media.medium`
+    overflow: scroll;
+    max-height: calc(100vh - 48px);
+  `}
 `;
 
 const StyledLink = styled.a`
@@ -65,7 +83,7 @@ const Tree = styled.div`
   }
 
   ul ul {
-    padding-left: 62px;
+    padding-left: 30px;
 
     li {
       a {
@@ -335,7 +353,7 @@ const ListItem = ({
   }, []);
   return (
     <li>
-      <div style={{ padding: '10px 10px 30px' }}>
+      <div style={{ padding: '10px 10px' }}>
         <TogglesContext.Consumer>
           {toggles => (
             <div style={{ whiteSpace: 'nowrap' }}>
@@ -345,6 +363,9 @@ const ListItem = ({
                 passHref
               >
                 <StyledLink
+                  className={classNames({
+                    [font('hnl', 6)]: true,
+                  })}
                   isCurrent={currentWorkId === item.work.id}
                   ref={currentWorkId === item.work.id ? selected : null}
                   onClick={() => {
@@ -522,9 +543,30 @@ const ArchiveTree = ({ work }: { work: Work }) => {
 
   return isInArchive ? (
     toggles.archivesPrototypeSidePanel ? (
-      <Container>
-        <TreeView />
-      </Container>
+      <StickyContainer>
+        <Space
+          v={{ size: 'm', properties: ['padding-top', 'padding-bottom'] }}
+          h={{ size: 'l', properties: ['padding-left', 'padding-right'] }}
+          className={classNames({
+            'flex flex--v-center bg-pumice': true,
+          })}
+        >
+          <Space
+            as="h2"
+            h={{ size: 'm', properties: ['margin-right'] }}
+            className={classNames({
+              [font('wb', 5)]: true,
+              'no-margin': true,
+            })}
+          >
+            Collection contents
+          </Space>
+          <Icon name="tree" />
+        </Space>
+        <StickyContainerInner>
+          <TreeView />
+        </StickyContainerInner>
+      </StickyContainer>
     ) : (
       <>
         <Space

--- a/common/views/components/ArchiveTree/ArchiveTree.js
+++ b/common/views/components/ArchiveTree/ArchiveTree.js
@@ -529,7 +529,9 @@ const ArchiveTree = ({ work }: { work: Work }) => {
     if (!initialLoad.current) {
       const workInfo = document.getElementById('work-info');
 
-      workInfo.scrollIntoView({ behavior: 'smooth' });
+      if (workInfo) {
+        workInfo.scrollIntoView({ behavior: 'smooth' });
+      }
     }
 
     initialLoad.current = false;

--- a/common/views/components/ArchiveTree/ArchiveTree.js
+++ b/common/views/components/ArchiveTree/ArchiveTree.js
@@ -351,7 +351,7 @@ const ListItem = ({
   }, []);
   return (
     <li>
-      <div style={{ padding: '10px 10px' }}>
+      <div style={{ padding: '10px 10px 10px 0' }}>
         <TogglesContext.Consumer>
           {toggles => (
             <div style={{ whiteSpace: 'nowrap' }}>
@@ -370,10 +370,13 @@ const ListItem = ({
                     })}
                     style={{
                       fontSize: '10px',
-                      padding: '4px',
+                      height: '18px',
+                      width: '18px',
+                      padding: '0',
                       background: '#ccc',
                       position: 'relative',
                       top: '-2px',
+                      textAlign: 'center',
                       cursor: 'pointer',
                     }}
                     onClick={() => {
@@ -530,7 +533,9 @@ const ArchiveTree = ({ work }: { work: Work }) => {
       const workInfo = document.getElementById('work-info');
 
       if (workInfo) {
-        workInfo.scrollIntoView({ behavior: 'smooth' });
+        window.requestAnimationFrame(() => {
+          workInfo.scrollIntoView({ behavior: 'smooth' });
+        });
       }
     }
 

--- a/common/views/components/WorkHeaderPrototype/WorkHeaderPrototype.tsx
+++ b/common/views/components/WorkHeaderPrototype/WorkHeaderPrototype.tsx
@@ -1,0 +1,153 @@
+// @flow
+import { Work } from '../../../model/work';
+import { font, classNames, grid } from '../../../utils/classnames';
+import { getProductionDates, getWorkTypeIcon } from '../../../utils/works';
+import Icon from '../Icon/Icon';
+import SpacingComponent from '../SpacingComponent/SpacingComponent';
+import LinkLabels from '../LinkLabels/LinkLabels';
+import Space from '../styled/Space';
+import Number from '@weco/common/views/components/Number/Number';
+import styled from 'styled-components';
+import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
+import ArchiveTree from '@weco/common/views/components/ArchiveTree/ArchiveTree';
+import WorkTitle from '@weco/common/views/components/WorkTitle/WorkTitle';
+
+const ArchiveTitle = styled.span.attrs({
+  className: classNames({
+    [font('hnm', 5)]: true,
+  })
+})`
+  display: block;
+`;
+
+const WorkHeaderContainer = styled.div.attrs(props => ({
+  className: classNames({
+    flex: true,
+  }),
+}))`
+  width: 100%;
+  align-content: flex-start;
+`;
+
+type Props = {
+  work: Work;
+  childManifestsCount?: number;
+};
+
+const WorkHeaderPrototype = ({ work, childManifestsCount = 0 }: Props) => {
+  const productionDates = getProductionDates(work);
+  const workTypeIcon = getWorkTypeIcon(work);
+  return (
+    <WorkHeaderContainer>
+      <Space
+        v={{
+          size: 'l',
+          properties: ['margin-bottom'],
+        }}
+        className={classNames([grid({ s: 12, m: 12, l: 10, xl: 10 })])}
+      >
+        <SpacingComponent>
+          <div
+            className={classNames({
+              flex: true,
+              'flex--v-center': true,
+              [font('hnl', 5)]: true,
+            })}
+          >
+            {workTypeIcon && (
+              <Space as="span" h={{ size: 's', properties: ['margin-right'] }}>
+                <Icon name={workTypeIcon} />
+              </Space>
+            )}
+            <div className="line-height-1">
+              <Space className={classNames({
+                'bg-purple font-white inline-block': work.workType.label.startsWith('Archive'),
+                [font('hnm', 5)]: work.workType.label.startsWith('Archive'),
+              })}
+                h={{size: work.workType.label.startsWith('Archive') ? 's' : null, properties: ['padding-left', 'padding-right']}}
+                v={{size: work.workType.label.startsWith('Archive') ? 's' : null, properties: ['padding-top', 'padding-bottom', 'margin-bottom', 'margin-top']}}
+              >
+                {work.workType.label}
+              </Space>
+            </div>
+          </div>
+
+          <TogglesContext.Consumer>
+            {({ archivesPrototype, archivesPrototypeSidePanel }) =>
+              archivesPrototype &&
+              !archivesPrototypeSidePanel && <ArchiveTree work={work} />
+            }
+          </TogglesContext.Consumer>
+
+            {work.partOf.length && (work.partOf[0].title !== work.title) ? (
+              <ArchiveTitle>{work.partOf.length && work.partOf[0].title}</ArchiveTitle>
+            ): null}
+
+          <h1
+            id="work-info"
+            className={classNames({
+              'no-margin': true,
+              [font('hnm', 2)]: true,
+              'inline-block': true,
+            })}
+            lang={work.language && work.language.id}
+          >
+            <WorkTitle title={work.title} />
+          </h1>
+
+          {(work.contributors.length > 0 || productionDates.length > 0) && (
+            <Space
+              v={{
+                size: 'l',
+                properties: ['margin-top'],
+              }}
+              className={classNames({
+                'flex flex--wrap flex--v-center': true,
+              })}
+            >
+              {work.contributors.length > 0 && (
+                <Space h={{ size: 'm', properties: ['margin-right'] }}>
+                  <LinkLabels
+                    items={[
+                      {
+                        text: work.contributors[0].agent.label,
+                        url: null,
+                      },
+                    ]}
+                  />
+                </Space>
+              )}
+
+              {productionDates.length > 0 && (
+                <LinkLabels
+                  heading={'Date'}
+                  items={[
+                    {
+                      text: productionDates[0],
+                      url: null,
+                    },
+                  ]}
+                />
+              )}
+            </Space>
+          )}
+
+          {childManifestsCount > 0 && (
+            <Space v={{ size: 'm', properties: ['margin-top'] }}>
+              <p
+                className={classNames({
+                  [font('hnm', 5)]: true,
+                  'no-margin': true,
+                })}
+              >
+                <Number color="yellow" number={childManifestsCount} /> volumes
+                online
+              </p>
+            </Space>
+          )}
+        </SpacingComponent>
+      </Space>
+    </WorkHeaderContainer>
+  );
+};
+export default WorkHeaderPrototype;


### PR DESCRIPTION
References #5281 

## Who is this for?
People testing the archive UI

## What is it doing for them?
- Sticky archive tree navigation with a max-height of 100% of the viewport. When an item has a lot of content (i.e. in the right-column) this ensures the navigation remains visible. It also alleviates the problem of being scrolled a long way down the archive tree navigation (i.e. in the left-column), clicking an item and not seeing the right-column content update.
- Moving the header section (title etc.) into its own row above the body of the content and including the archive collection title above the item.
- Clicking a link in the archive navigation will scroll the page to the title after the url has changed (this was actually slightly nicer when the title was aligned with the top of the nav because the nav would stay stuck but ¯\\_\_(ツ)_\_/¯
- Made the +/- buttons smaller and moved before the titles (not sure I was supposed to do this – easily undone – I think it _looks_ nicer, but could quite possibly be less clear)

![archive-update](https://user-images.githubusercontent.com/1394592/90908937-fa46d100-e3cc-11ea-9bd1-5b68c14b1943.gif)

- Tightened up the +/- buttons 
![image](https://user-images.githubusercontent.com/1394592/91032695-3f9c1600-e5fa-11ea-96a7-354e677bc75d.png)

