### PR TITLE
Amend spacing for WorkHeader

### DIFF
--- a/common/views/components/WorkHeaderPrototype/WorkHeaderPrototype.tsx
+++ b/common/views/components/WorkHeaderPrototype/WorkHeaderPrototype.tsx
@@ -41,7 +41,7 @@ const WorkHeaderPrototype = ({ work, childManifestsCount = 0 }: Props) => {
     <WorkHeaderContainer>
       <Space
         v={{
-          size: 'l',
+          size: 'xl',
           properties: ['margin-bottom'],
         }}
         className={classNames([grid({ s: 12, m: 12, l: 10, xl: 10 })])}
@@ -98,7 +98,7 @@ const WorkHeaderPrototype = ({ work, childManifestsCount = 0 }: Props) => {
           {(work.contributors.length > 0 || productionDates.length > 0) && (
             <Space
               v={{
-                size: 'l',
+                size: 's',
                 properties: ['margin-top'],
               }}
               className={classNames({


### PR DESCRIPTION
Improving spacing for groups of header and body content on archive pages.

![image](https://user-images.githubusercontent.com/1394592/91051468-14282400-e618-11ea-8c0d-2a7bc1ad5587.png)

