### PR TITLE
Don't have any breadcrumbs on landing pages

### DIFF
--- a/content/webapp/pages/landing-page.js
+++ b/content/webapp/pages/landing-page.js
@@ -58,20 +58,9 @@ export class Page extends Component<Props> {
       ) : null
     ) : null;
 
-    // TODO: This is not the way to do site sections
-    const breadcrumbs = {
-      items: page.siteSection
-        ? [
-            {
-              text: page.siteSection === 'visit-us' ? 'Visit us' : 'What we do',
-              url: `/${page.siteSection}`,
-            },
-          ]
-        : [],
-    };
     const Header = (
       <PageHeader
-        breadcrumbs={breadcrumbs}
+        breadcrumbs={{ items: [] }}
         labels={null}
         title={page.title}
         FeaturedMedia={FeaturedMedia}


### PR DESCRIPTION
Fixes #5478 with the addition of a 'visit-us' tag to the 'Visit us' page in Prismic.

![image](https://user-images.githubusercontent.com/1394592/91068362-14321f00-e62c-11ea-8e6a-888e65f3d2e4.png)

Presumably the reason the tag has been removed from the page in Prismic is because it creates a breadcrumb and looks bad

![image](https://user-images.githubusercontent.com/1394592/91068508-4cd1f880-e62c-11ea-9f8c-25ca28c89458.png)
