### PR TITLE
Provide enough space for DropdownButton content

### DIFF
--- a/common/views/components/ArchiveBreadcrumb/ArchiveBreadcrumb.js
+++ b/common/views/components/ArchiveBreadcrumb/ArchiveBreadcrumb.js
@@ -57,7 +57,6 @@ const ArchiveBreadcrumbNav = styled.nav`
 
     ul {
       display: block;
-      min-width: max-content;
       white-space: normal;
 
       li {

--- a/common/views/components/DropdownButton/DropdownButton.tsx
+++ b/common/views/components/DropdownButton/DropdownButton.tsx
@@ -28,6 +28,7 @@ const Dropdown = styled(Space).attrs(props => ({
   overflow: auto;
   white-space: nowrap;
   transition: opacity 350ms ease, transform 350ms ease;
+  min-width: max-content;
 
   &,
   &.fade-exit-done {

--- a/common/views/components/DropdownButton/DropdownButton.tsx
+++ b/common/views/components/DropdownButton/DropdownButton.tsx
@@ -28,7 +28,6 @@ const Dropdown = styled(Space).attrs(props => ({
   overflow: auto;
   white-space: nowrap;
   transition: opacity 350ms ease, transform 350ms ease;
-  min-width: max-content;
 
   &,
   &.fade-exit-done {
@@ -59,6 +58,7 @@ const Dropdown = styled(Space).attrs(props => ({
 `;
 
 const Popper = styled.div`
+  width: max-content;
   max-width: calc(100vw - 20px);
   z-index: ${props => props.isVisible ? 1 : -1};
 `;


### PR DESCRIPTION
List items inside the archive breadcrumb have `min-width: max-content` set. Chrome expands the wrapper for these items accordingly, but safari doesn't. Setting `min-width: max-content` on the container solves the problem.

__Before__
![image](https://user-images.githubusercontent.com/1394592/91555551-22808380-e929-11ea-8abb-b57cde8d6eec.png)

__After__
![image](https://user-images.githubusercontent.com/1394592/91555465-fbc24d00-e928-11ea-911b-2e3172019bd3.png)
