### PR TITLE
Add static re-opening banner behind new buildingReopening toggle

### DIFF
--- a/common/views/components/ButtonOutlinedLink/ButtonOutlinedLink.tsx
+++ b/common/views/components/ButtonOutlinedLink/ButtonOutlinedLink.tsx
@@ -25,6 +25,7 @@ const ButtonOutlinedLink = ({
   clickHandler,
   ariaControls,
   ariaExpanded,
+  isOnDark
 }: ButtonOutlinedLinkProps) => {
   function handleClick(event) {
     clickHandler && clickHandler(event);
@@ -48,6 +49,7 @@ const ButtonOutlinedLink = ({
         aria-controls={ariaControls}
         aria-expanded={ariaExpanded}
         onClick={handleClick}
+        isOnDark={isOnDark}
         href={isNextLink ? undefined : link}
       >
         <BaseButtonInner>

--- a/common/views/components/ReopeningBanner/ReopeningBanner.tsx
+++ b/common/views/components/ReopeningBanner/ReopeningBanner.tsx
@@ -1,0 +1,23 @@
+import Space from '../styled/Space';
+import ButtonOutlinedLink from '../ButtonOutlinedLink/ButtonOutlinedLink';
+import { classNames } from '../../../utils/classnames';
+
+const ReopeningBanner = () => {
+  return (
+    <Space
+      v={{size: 'xl', properties: ['padding-top', 'padding-bottom']}}
+      h={{size: 'xl', properties: ['padding-left', 'padding-right']}}
+      className={classNames({
+        'bg-green font-white text-align-center': true
+      })}
+    >
+      <h2 className="h1">We are open!</h2>
+      <p>We can't wait to welcome you back to the Wellcome Collection. Find out everything you need to plan a safe visit.</p>
+      <Space v={{size: 'l', properties: ['margin-top']}}>
+        <ButtonOutlinedLink text="Plan your visit" link="#" icon="arrow" isOnDark={true} />
+      </Space>
+    </Space>
+  )
+};
+
+export default ReopeningBanner;

--- a/content/webapp/pages/homepage.js
+++ b/content/webapp/pages/homepage.js
@@ -18,6 +18,9 @@ import Space from '@weco/common/views/components/styled/Space';
 import Layout10 from '@weco/common/views/components/Layout10/Layout10';
 import SimpleCardGrid from '@weco/common/views/components/SimpleCardGrid/SimpleCardGrid';
 import PageHeaderStandfirst from '@weco/common/views/components/PageHeaderStandfirst/PageHeaderStandfirst';
+import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
+// $FlowFixMe (tsx)
+import ReopeningBanner from '@weco/common/views/components/ReopeningBanner/ReopeningBanner';
 
 const PageHeading = styled(Space).attrs({
   as: 'h1',
@@ -91,11 +94,28 @@ export class HomePage extends Component<Props> {
             <PageHeading>
               The free museum and library for the incurably curious
             </PageHeading>
-            {standFirst && (
-              <CreamBox>
-                <PageHeaderStandfirst html={standFirst.value} />
-              </CreamBox>
-            )}
+            <TogglesContext.Consumer>
+              {({ buildingReopening }) =>
+                buildingReopening ? (
+                  <Space
+                    v={{
+                      size: 'm',
+                      properties: ['padding-top', 'padding-bottom'],
+                    }}
+                  >
+                    <ReopeningBanner />
+                  </Space>
+                ) : (
+                  <>
+                    {standFirst && (
+                      <CreamBox>
+                        <PageHeaderStandfirst html={standFirst.value} />
+                      </CreamBox>
+                    )}
+                  </>
+                )
+              }
+            </TogglesContext.Consumer>
           </SpacingSection>
         </Layout10>
         {contentList && (

--- a/toggles/webapp/toggles.js
+++ b/toggles/webapp/toggles.js
@@ -1,6 +1,13 @@
 module.exports = {
   toggles: [
     {
+      id: 'buildingReopening',
+      title: 'Wellcome Collection reopening UI changes',
+      description:
+        'Show additions/amendments made in preparation for the reopening of the Wellcome Collection building',
+      defaultValue: false,
+    },
+    {
       id: 'archivesPrototype',
       title:
         'Include archives in search results and view additions to the work page relating to archives',


### PR DESCRIPTION
☝️ 

part of #5457 

![image](https://user-images.githubusercontent.com/1394592/92009202-0ec98880-ed40-11ea-9429-cfd33eaa19df.png)

Adding a `buildingReopening` toggle so that we can view this and any other new bits of UI for testing.