### PR TITLE
Upgrade ECS to 1.4 (to be compatible with weco-deploy)

### DIFF
--- a/catalogue/terraform/main.tf
+++ b/catalogue/terraform/main.tf
@@ -1,3 +1,5 @@
+// The service should be available at: "works.www.wellcomecollection.org/works"
+
 module "catalogue-prod" {
   source = "./stack"
 
@@ -17,28 +19,23 @@ module "catalogue-prod" {
   subdomain = "works.www"
 }
 
-// Uncomment to create a staging environment
-// You can replace var.container_tag & local.nginx_image
-// to test differing images.
-//
-// The service should be available at:
-// "works.www-stage.wellcomecollection.org/works"
-//
-//module "catalogue-stage" {
-//  source = "./stack"
-//
-//  container_image = "wellcome/catalogue_webapp:${var.container_tag}"
-//  nginx_image     = local.nginx_image
-//  env_suffix      = "stage"
-//
-//  cluster_arn  = local.stage_cluster_arn
-//  namespace_id = local.stage_namespace_id
-//
-//  alb_listener_http_arn  = local.stage_alb_listener_http_arn
-//  alb_listener_https_arn = local.stage_alb_listener_https_arn
-//
-//  interservice_security_group_id   = local.stage_interservice_security_group_id
-//  service_egress_security_group_id = local.stage_service_egress_security_group_id
-//
-//  subdomain = "works.www-stage"
-//}
+// The service should be available at: "works.www-stage.wellcomecollection.org/works"
+
+module "catalogue-stage" {
+  source = "./stack"
+
+  container_image = "wellcome/catalogue_webapp:${var.container_tag}"
+  nginx_image     = local.nginx_image
+  env_suffix      = "stage"
+
+  cluster_arn  = local.stage_cluster_arn
+  namespace_id = local.stage_namespace_id
+
+  alb_listener_http_arn  = local.stage_alb_listener_http_arn
+  alb_listener_https_arn = local.stage_alb_listener_https_arn
+
+  interservice_security_group_id   = local.stage_interservice_security_group_id
+  service_egress_security_group_id = local.stage_service_egress_security_group_id
+
+  subdomain = "works.www-stage"
+}

--- a/catalogue/terraform/stack/main.tf
+++ b/catalogue/terraform/stack/main.tf
@@ -1,33 +1,7 @@
-module "catalogue-service-23062020" {
-  source = "../../../infrastructure/terraform/modules/service_23062020"
-
-  namespace    = "catalogue-23062020-${var.env_suffix}"
-
-  namespace_id = var.namespace_id
-  cluster_arn  = var.cluster_arn
-
-  healthcheck_path = "/management/healthcheck"
-
-  container_image = var.container_image
-  container_port  = 3000
-
-  security_group_ids = [
-    var.interservice_security_group_id,
-    var.service_egress_security_group_id
-  ]
-
-  env_vars = {
-    PROD_SUBDOMAIN = var.subdomain
-  }
-
-  vpc_id  = local.vpc_id
-  subnets = local.private_subnets
-}
-
-module "catalogue-service" {
+module "catalogue-service-17092020" {
   source = "../../../infrastructure/terraform/modules/service"
 
-  namespace    = "catalogue-23062020-${var.env_suffix}"
+  namespace    = "catalogue-17092020-${var.env_suffix}"
 
   namespace_id = var.namespace_id
   cluster_arn  = var.cluster_arn
@@ -48,10 +22,13 @@ module "catalogue-service" {
 
   vpc_id  = local.vpc_id
   subnets = local.private_subnets
+
+  deployment_service_name = "catalogue_webapp"
+  deployment_service_env = var.env_suffix
 }
 
 locals {
-  target_group_arn = module.catalogue-service-23062020.target_group_arn
+  target_group_arn = module.catalogue-service-17092020.target_group_arn
 }
 
 module "path_listener" {

--- a/catalogue/terraform/stack/main.tf
+++ b/catalogue/terraform/stack/main.tf
@@ -24,6 +24,32 @@ module "catalogue-service-23062020" {
   subnets = local.private_subnets
 }
 
+module "catalogue-service" {
+  source = "../../../infrastructure/terraform/modules/service"
+
+  namespace    = "catalogue-23062020-${var.env_suffix}"
+
+  namespace_id = var.namespace_id
+  cluster_arn  = var.cluster_arn
+
+  healthcheck_path = "/management/healthcheck"
+
+  container_image = var.container_image
+  container_port  = 3000
+
+  security_group_ids = [
+    var.interservice_security_group_id,
+    var.service_egress_security_group_id
+  ]
+
+  env_vars = {
+    PROD_SUBDOMAIN = var.subdomain
+  }
+
+  vpc_id  = local.vpc_id
+  subnets = local.private_subnets
+}
+
 locals {
   target_group_arn = module.catalogue-service-23062020.target_group_arn
 }

--- a/content/terraform/main.tf
+++ b/content/terraform/main.tf
@@ -1,3 +1,5 @@
+// The service should be available at: "content.www.wellcomecollection.org"
+
 module "content-prod" {
   source = "./stack"
 
@@ -17,28 +19,23 @@ module "content-prod" {
   subdomain = "content.www"
 }
 
-// Uncomment to create a staging environment
-// You can replace var.container_tag & local.nginx_image
-// to test differing images.
-//
-// The service should be available at:
-// "content.www-stage.wellcomecollection.org"
-//
-//module "content-stage" {
-//  source = "./stack"
-//
-//  container_image = "wellcome/content_webapp:${var.container_tag}"
-//  nginx_image     = local.nginx_image
-//  env_suffix      = "stage"
-//
-//  cluster_arn  = local.stage_cluster_arn
-//  namespace_id = local.stage_namespace_id
-//
-//  alb_listener_http_arn  = local.stage_alb_listener_http_arn
-//  alb_listener_https_arn = local.stage_alb_listener_https_arn
-//
-//  interservice_security_group_id   = local.stage_interservice_security_group_id
-//  service_egress_security_group_id = local.stage_service_egress_security_group_id
-//
-//  subdomain = "content.www-stage"
-//}
+// The service should be available at: "content.www-stage.wellcomecollection.org"
+
+module "content-stage" {
+  source = "./stack"
+
+  container_image = "wellcome/content_webapp:${var.container_tag}"
+  nginx_image     = local.nginx_image
+  env_suffix      = "stage"
+
+  cluster_arn  = local.stage_cluster_arn
+  namespace_id = local.stage_namespace_id
+
+  alb_listener_http_arn  = local.stage_alb_listener_http_arn
+  alb_listener_https_arn = local.stage_alb_listener_https_arn
+
+  interservice_security_group_id   = local.stage_interservice_security_group_id
+  service_egress_security_group_id = local.stage_service_egress_security_group_id
+
+  subdomain = "content.www-stage"
+}

--- a/content/terraform/stack/main.tf
+++ b/content/terraform/stack/main.tf
@@ -1,7 +1,7 @@
-module "content-service-23062020" {
-  source = "../../../infrastructure/terraform/modules/service_23062020"
+module "content-service-17092020" {
+  source = "../../../infrastructure/terraform/modules/service"
 
-  namespace    = "content-23062020-${var.env_suffix}"
+  namespace    = "content-17092020-${var.env_suffix}"
 
   namespace_id = var.namespace_id
   cluster_arn  = var.cluster_arn
@@ -27,10 +27,13 @@ module "content-service-23062020" {
 
   vpc_id  = local.vpc_id
   subnets = local.private_subnets
+
+  deployment_service_name = "content_webapp"
+  deployment_service_env = var.env_suffix
 }
 
 locals {
-  target_group_arn = module.content-service-23062020.target_group_arn
+  target_group_arn = module.content-service-17092020.target_group_arn
 }
 
 module "path_listener" {
@@ -45,7 +48,7 @@ module "path_listener" {
   priority               = "49998"
 }
 
-# This is used for the static assets served from _next with multiple next apps
+# This is used for the static assets served from _next with multiple next apps
 # See: https://github.com/zeit/next.js#multi-zones
 module "subdomain_listener" {
   source = "../../../infrastructure/terraform/modules/alb_listener_rule"

--- a/infrastructure/terraform/modules/service/main.tf
+++ b/infrastructure/terraform/modules/service/main.tf
@@ -1,6 +1,6 @@
 resource "aws_lb_target_group" "http" {
   name                 = var.namespace
-  port                 = var.nginx_container_port
+  port                 = module.nginx_container.container_port
   protocol             = "HTTP"
   vpc_id               = var.vpc_id
   deregistration_delay = 10
@@ -9,7 +9,7 @@ resource "aws_lb_target_group" "http" {
   health_check {
     interval            = 10
     path                = var.healthcheck_path
-    port                = var.nginx_container_port
+    port                = module.nginx_container.container_port
     protocol            = "HTTP"
     timeout             = 5
     healthy_threshold   = 3
@@ -22,52 +22,82 @@ resource "aws_lb_target_group" "http" {
   }
 }
 
-module "service" {
-  source = "github.com/wellcomecollection/terraform-aws-ecs-service.git//service?ref=v1.1.1"
-
-  service_name = var.namespace
-  cluster_arn  = var.cluster_arn
-
-  desired_task_count = var.desired_task_count
-
-  task_definition_arn = module.task.arn
-
-  subnets = var.subnets
-
-  namespace_id = var.namespace_id
-
-  security_group_ids = var.security_group_ids
-
-  target_group_arn = aws_lb_target_group.http.arn
-  container_name   = "nginx"
-  container_port   = var.nginx_container_port
+module "log_router_container" {
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v2.6.2"
+  namespace = var.namespace
 }
 
-module "task" {
-  source = "github.com/wellcomecollection/terraform-aws-ecs-service.git//task_definition/container_with_sidecar?ref=v1.1.1"
+module "log_router_container_secrets_permissions" {
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v2.6.2"
+  secrets   = module.log_router_container.shared_secrets_logging
+  role_name = module.task_definition.task_execution_role_name
+}
 
-  task_name = var.namespace
+module "nginx_container" {
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/nginx/frontend?ref=v2.6.2"
+
+  forward_port      = var.container_port
+  log_configuration = module.log_router_container.container_log_configuration
+}
+
+module "app_container" {
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v2.6.2"
+  name   = "app"
+
+  image = var.container_image
+
+  environment = var.env_vars
+  secrets     = var.secret_env_vars
+
+  log_configuration = module.log_router_container.container_log_configuration
+}
+
+module "app_container_secrets_permissions" {
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v2.6.2"
+  secrets   = var.secret_env_vars
+  role_name = module.task_definition.task_execution_role_name
+}
+
+module "task_definition" {
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v2.6.2"
 
   cpu    = var.app_cpu + var.nginx_cpu
   memory = var.app_memory + var.nginx_memory
 
-  app_container_image = var.container_image
-  app_container_port  = var.container_port
-  app_cpu             = var.app_cpu
-  app_memory          = var.app_memory
+  container_definitions = [
+    module.log_router_container.container_definition,
+    module.nginx_container.container_definition,
+    module.app_container.container_definition
+  ]
 
-  app_env_vars        = var.env_vars
-  secret_app_env_vars = var.secret_env_vars
+  task_name = var.namespace
+}
 
-  sidecar_container_image = var.nginx_container_image
-  sidecar_container_port  = var.nginx_container_port
-  sidecar_cpu             = var.nginx_cpu
-  sidecar_memory          = var.nginx_memory
+module "service" {
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/service?ref=v3.1.0"
 
-  sidecar_env_vars = {
-    APP_HOST = "localhost"
-    APP_PORT = "3000"
+  cluster_arn  = var.cluster_arn
+  service_name = var.namespace
+
+  service_discovery_namespace_id = var.namespace_id
+
+  task_definition_arn = module.task_definition.arn
+
+  subnets            = var.subnets
+  security_group_ids = var.security_group_ids
+
+  desired_task_count = var.desired_task_count
+  use_fargate_spot   = var.use_fargate_spot
+
+  target_group_arn = aws_lb_target_group.http.arn
+
+  container_name = "nginx"
+  container_port = module.nginx_container.container_port
+
+  propagate_tags = "SERVICE"
+
+  tags = {
+    "deployment:service" = var.deployment_service_name
+    "deployment:env"     = var.deployment_service_env
   }
-
-  aws_region = var.aws_region
 }

--- a/infrastructure/terraform/modules/service/outputs.tf
+++ b/infrastructure/terraform/modules/service/outputs.tf
@@ -7,5 +7,9 @@ output "name" {
 }
 
 output "task_role_name" {
-  value = module.task.task_role_name
+  value = module.task_definition.task_role_name
+}
+
+output "nginx_container_port" {
+  value = module.nginx_container.container_port
 }

--- a/infrastructure/terraform/modules/service/variables.tf
+++ b/infrastructure/terraform/modules/service/variables.tf
@@ -14,11 +14,6 @@ variable "container_port" {
   type = number
 }
 
-variable "nginx_container_image" {}
-variable "nginx_container_port" {
-  type = number
-}
-
 variable "security_group_ids" {
   type = list(string)
 }
@@ -66,3 +61,19 @@ variable "desired_task_count" {
 }
 
 variable "healthcheck_path" {}
+
+variable "use_fargate_spot" {
+  default = false
+}
+
+variable "deployment_service_name" {
+  type        = string
+  description = "Used by weco-deploy to determine which services to deploy, if unset the value used will be var.name"
+  default     = ""
+}
+
+variable "deployment_service_env" {
+  type        = string
+  description = "Used by weco-deploy to determine which services to deploy in conjunction with deployment_service_name"
+  default     = "prod"
+}


### PR DESCRIPTION
## Who is this for?

Developers who want deployments (quite possibly automated deployments from CI).

## What is it doing for them?

To use the new weco-deploy tool we need to upgrade some ECS infrastructure - this does that and allows tagging of ECS services/tasks that is required for weco-deploy to work.

*Note:* This enables the staging services as an upcoming step will be automatically deploying to stage from CI.