### PR TITLE
double install in setupCommon unnecessary

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -23,7 +23,6 @@
     - docker-compose#v3.5.0:
         run: common
         command: ["yarn", "test"]
-        workdir: /usr/src/app/webapp/common
 
 - label: "test catalogue"
   plugins:

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Products and services relating to wellcomecollection.org.",
   "scripts": {
-    "setupCommon": "yarn install --production && yarn flow && cd common && yarn && yarn install",
+    "setupCommon": "yarn install --production && yarn flow",
     "cardigan": "pushd cardigan && yarn dev",
     "catalogue": "pushd catalogue/webapp && yarn dev",
     "content": "pushd content/webapp && yarn dev",


### PR DESCRIPTION
## Who is this for?

Developers who want faster builds.

## What is it doing for them?

Making builds faster.