### PR TITLE
Handle redirects isomorphically

### DIFF
--- a/catalogue/webapp/pages/work.tsx
+++ b/catalogue/webapp/pages/work.tsx
@@ -48,6 +48,9 @@ WorkPage.getInitialProps = async (ctx: NextPageContext) => {
         const link = workLink({ id: workResponse.redirectToId });
         Router.push(link.href, link.as);
       }
+      return {
+        statusCode: workResponse.status,
+      };
     }
 
     if (workResponse.type === 'Work' || workResponse.type === 'Error') {

--- a/catalogue/webapp/pages/work.tsx
+++ b/catalogue/webapp/pages/work.tsx
@@ -3,8 +3,8 @@ import Router from 'next/router';
 import {
   Work as WorkType,
   CatalogueApiError,
-  CatalogueApiRedirect,
 } from '@weco/common/model/catalogue';
+import { workLink } from '@weco/common/services/catalogue/routes';
 import ErrorPage from '@weco/common/views/components/ErrorPage/ErrorPage';
 import Work from '../components/Work/Work';
 import { getWork } from '../services/catalogue/works';
@@ -45,7 +45,8 @@ WorkPage.getInitialProps = async (ctx: NextPageContext) => {
         });
         res.end();
       } else {
-        Router.push(workResponse.redirectToId);
+        const link = workLink({ id: workResponse.redirectToId });
+        Router.push(link.href, link.as);
       }
     }
 

--- a/catalogue/webapp/services/catalogue/common.js
+++ b/catalogue/webapp/services/catalogue/common.js
@@ -1,3 +1,4 @@
+import type { CatalogueApiError } from '@weco/common/model/catalogue';
 import { serialiseUrl } from '@weco/common/services/catalogue/routes';
 
 export const rootUris = {
@@ -24,3 +25,11 @@ export const queryString = (params: { [key: string]: any }): string => {
   });
   return strings.length > 0 ? `?${strings.join('&')}` : '';
 };
+
+export const catalogueApiError = (): CatalogueApiError => ({
+  description: '',
+  errorType: 'http',
+  httpStatus: 500,
+  label: 'Internal Server Error',
+  type: 'Error',
+});

--- a/catalogue/webapp/services/catalogue/images.js
+++ b/catalogue/webapp/services/catalogue/images.js
@@ -10,6 +10,7 @@ import {
   rootUris,
   globalApiOptions,
   queryString,
+  catalogueApiError,
 } from './common';
 
 type GetImagesProps = {|
@@ -47,13 +48,7 @@ export async function getImages({
 
     return (json: CatalogueResultsList<Image> | CatalogueApiError);
   } catch (error) {
-    return {
-      description: '',
-      errorType: 'http',
-      httpStatus: 500,
-      label: 'Internal Server Error',
-      type: 'Error',
-    };
+    return catalogueApiError();
   }
 }
 
@@ -71,7 +66,12 @@ export async function getImage({
   };
   const query = queryString(params);
   let url = `${rootUris[apiOptions.env]}/v2/images/${id}${query}`;
-  const res = await fetch(url);
-  const json = await res.json();
-  return json;
+
+  try {
+    const res = await fetch(url);
+    const json = await res.json();
+    return json;
+  } catch (e) {
+    return catalogueApiError();
+  }
 }

--- a/catalogue/webapp/services/catalogue/works.js
+++ b/catalogue/webapp/services/catalogue/works.js
@@ -1,19 +1,20 @@
 // @flow
-import fetch from 'isomorphic-unfetch';
 import {
-  type CatalogueResultsList,
   type CatalogueApiError,
-  type Work,
   type CatalogueApiRedirect,
+  type CatalogueResultsList,
+  type Work,
 } from '@weco/common/model/catalogue';
 import { type IIIFCanvas } from '@weco/common/model/iiif';
-import Raven from 'raven-js';
 import { type CatalogueWorksApiProps } from '@weco/common/services/catalogue/api';
+import fetch from 'isomorphic-unfetch';
+import Raven from 'raven-js';
 import {
-  type Toggles,
-  rootUris,
+  catalogueApiError,
   globalApiOptions,
   queryString,
+  rootUris,
+  type Toggles,
 } from './common';
 
 type GetWorkProps = {|
@@ -66,13 +67,7 @@ export async function getWorks({
 
     return (json: CatalogueResultsList<Work> | CatalogueApiError);
   } catch (error) {
-    return {
-      description: '',
-      errorType: 'http',
-      httpStatus: 500,
-      label: 'Internal Server Error',
-      type: 'Error',
-    };
+    return catalogueApiError();
   }
 }
 
@@ -104,9 +99,12 @@ export async function getWork({
     };
   }
 
-  const json = await res.json();
-
-  return json;
+  try {
+    const json = await res.json();
+    return json;
+  } catch (e) {
+    return catalogueApiError();
+  }
 }
 
 export async function getCanvasOcr(canvas: IIIFCanvas) {


### PR DESCRIPTION
Redirects were not being followed when clicking a link (ie they required a refresh / getInitialProps) - this should fix that.

Apologies for the weird steps to reproduce but this is how I found it and I can't work out a simpler way:

- Do an images search for 'rats'
- Click the 3rd result, which says 'Tord Boyaux'
- Click on 'More about this work' - get a 500
- Refresh the page - redirect.

_note: I know the link to the image is still broken, that's a pipeline issue that I'll take a look at next_

The fetch API is quite strange in this respect, and whatever next gives us on the server doesn't appear to follow the spec. See:

- https://github.com/whatwg/fetch/issues/763
- https://stackoverflow.com/questions/46004103/how-do-i-determine-the-status-code-of-a-fetch-request/46005718