### PR TITLE
Systematise spacing for uls after headings

### DIFF
--- a/common/styles/base/_typography.scss
+++ b/common/styles/base/_typography.scss
@@ -239,11 +239,13 @@ hr {
   }
 
   // …and paragraphs after headings have a specific margin-top too
-  h2 + p {
+  h2 + p,
+  h2 + ul {
     margin-top: 1.2em;
   }
 
-  h3 + p {
+  h3 + p,
+  h3 + ul {
     margin-top: 0.3em;
   }
 }

--- a/content/webapp/pages/covid-book-your-ticket.tsx
+++ b/content/webapp/pages/covid-book-your-ticket.tsx
@@ -14,7 +14,8 @@ const CovidSmallPrint = styled.div.attrs({
     [font('hnl', 5)]: true,
   }),
 })`
-  h4 + p {
+  h4 + p,
+  h4 + ul {
     margin-top: 0.2em;
   }
 `;
@@ -156,7 +157,7 @@ const CovidWeAreOpenPage = () => {
                     Need to know about your library visit
                   </h3>
                   <CovidH4>What to bring</CovidH4>
-                  <ul className="no-margin">
+                  <ul>
                     <li>Your ticket – on your phone is fine</li>
 
                     <li>Your library card</li>
@@ -186,7 +187,7 @@ const CovidWeAreOpenPage = () => {
                     you need it, as there is limited availability to allow for
                     social distancing.
                   </p>
-                  <ul className="no-margin">
+                  <ul>
                     <li>
                       All your online requests will be delivered to the Rare
                       Materials Room.{' '}
@@ -233,7 +234,7 @@ const CovidWeAreOpenPage = () => {
                   </p>
 
                   <CovidH4>Study rooms</CovidH4>
-                  <ul className="no-margin">
+                  <ul>
                     <li>
                       The accessible study room can be booked - email the
                       library before you book your ticket to make sure the room

--- a/content/webapp/pages/covid-welcome-back.tsx
+++ b/content/webapp/pages/covid-welcome-back.tsx
@@ -118,7 +118,7 @@ const CovidWelcomeBackPage = () => {
                 <h2 id="plan-your-visit">Plan your visit</h2>
 
                 <h3>What’s open?</h3>
-                <ul className="no-margin">
+                <ul>
                   <li>
                     ‘Being Human’ permanent gallery, the Reading Room, café, and
                     library are open from 7 October.
@@ -137,7 +137,7 @@ const CovidWelcomeBackPage = () => {
                 </p>
 
                 <h3>Facilities and access</h3>
-                <ul className="no-margin">
+                <ul>
                   <li>All our toilets are open as usual.</li>
                   <li>
                     There are accessible toilets on every floor and a Changing
@@ -166,7 +166,7 @@ const CovidWelcomeBackPage = () => {
                 </p>
 
                 <h3>Storing your belongings</h3>
-                <ul className="no-margin">
+                <ul>
                   <li>
                     You will be able to use the lockers on level 0 to store
                     belongings.
@@ -281,7 +281,7 @@ const CovidWelcomeBackPage = () => {
                 />
 
                 <h3>How we’re keeping you safe</h3>
-                <ul className="no-margin">
+                <ul>
                   <li>
                     Limiting the number of visitors each day with a free
                     ticketing system.{' '}


### PR DESCRIPTION
Until now we've only accounted for the spacing of `p`s after headings within `spaced-text` blocks, but recent copy indicates that we need to apply the same rules to `ul`s too. We _could_ make the selectors broader (e.g. `h2 + *`), but that feels a bit heavy handed to me.