### PR TITLE
Vertically-align contents of BaseButton

### DIFF
--- a/catalogue/webapp/test/components/__snapshots__/WorkDetails.test.js.snap
+++ b/catalogue/webapp/test/components/__snapshots__/WorkDetails.test.js.snap
@@ -40,9 +40,9 @@ exports[`Feature: 2. As a library member I want to request an item
               "componentStyle": ComponentStyle {
                 "componentId": "ButtonSolid__SolidButton-is2j2c-3",
                 "isStatic": false,
-                "lastClassName": "bADJUb",
+                "lastClassName": "kcAXZg",
                 "rules": Array [
-                  "display:inline-flex;line-height:1;border-radius:",
+                  "align-items:center;display:inline-flex;line-height:1;border-radius:",
                   [Function],
                   ";text-decoration:none;text-align:center;transition:background ",
                   [Function],
@@ -93,7 +93,7 @@ exports[`Feature: 2. As a library member I want to request an item
           onClick={[Function]}
         >
           <a
-            className="ButtonSolid__BaseButton-is2j2c-0 ButtonSolid__SolidButton-is2j2c-3 bADJUb link-reset"
+            className="ButtonSolid__BaseButton-is2j2c-0 ButtonSolid__SolidButton-is2j2c-3 kcAXZg link-reset"
             href="/loginUrl"
             onClick={[Function]}
           >
@@ -172,9 +172,9 @@ exports[`Feature: 2. As a library member I want to request an item Scenario: I'm
             "componentStyle": ComponentStyle {
               "componentId": "ButtonSolid__SolidButton-is2j2c-3",
               "isStatic": false,
-              "lastClassName": "bADJUb",
+              "lastClassName": "kcAXZg",
               "rules": Array [
-                "display:inline-flex;line-height:1;border-radius:",
+                "align-items:center;display:inline-flex;line-height:1;border-radius:",
                 [Function],
                 ";text-decoration:none;text-align:center;transition:background ",
                 [Function],
@@ -224,7 +224,7 @@ exports[`Feature: 2. As a library member I want to request an item Scenario: I'm
         onClick={[Function]}
       >
         <button
-          className="ButtonSolid__BaseButton-is2j2c-0 ButtonSolid__SolidButton-is2j2c-3 bADJUb"
+          className="ButtonSolid__BaseButton-is2j2c-0 ButtonSolid__SolidButton-is2j2c-3 kcAXZg"
           onClick={[Function]}
         >
           <ButtonSolid__BaseButtonInner>

--- a/common/views/components/ButtonSolid/ButtonSolid.tsx
+++ b/common/views/components/ButtonSolid/ButtonSolid.tsx
@@ -7,20 +7,19 @@ import Space from '@weco/common/views/components/styled/Space';
 
 type BaseButtonProps = {
   href?: string;
-}
+};
 
 export const BaseButton = styled.button.attrs<BaseButtonProps>(props => ({
   as: props.href ? 'a' : 'button',
-  className: classNames({
-    'flex-inline flex--v-center': true,
-  }),
 }))`
+  align-items: center;
   display: inline-flex;
   line-height: 1;
   border-radius: ${props => `${props.theme.borderRadiusUnit}px`};
   text-decoration: none;
   text-align: center;
-  transition: background ${props => props.theme.transitionProperties}, border-color ${props => props.theme.transitionProperties};
+  transition: background ${props => props.theme.transitionProperties},
+    border-color ${props => props.theme.transitionProperties};
   border: 0;
   white-space: nowrap;
   padding: 13px 20px;
@@ -63,14 +62,16 @@ export const BaseButton = styled.button.attrs<BaseButtonProps>(props => ({
 
 type BaseButtonInnerProps = {
   isInline?: boolean;
-}
+};
 
-export const BaseButtonInner = styled.span.attrs<BaseButtonInnerProps>(props => ({
-  className: classNames({
-    [font(props.isInline ? 'hnl' : 'hnm', 5)]: true,
-    'flex flex--v-center': true,
-  }),
-}))`
+export const BaseButtonInner = styled.span.attrs<BaseButtonInnerProps>(
+  props => ({
+    className: classNames({
+      [font(props.isInline ? 'hnl' : 'hnm', 5)]: true,
+      'flex flex--v-center': true,
+    }),
+  })
+)`
   height: 1em;
 `;
 
@@ -91,7 +92,6 @@ export enum ButtonTypes {
   submit = 'submit',
 }
 
-
 export type ButtonSolidBaseProps = {
   text: string;
   icon?: string;
@@ -106,19 +106,21 @@ export type ButtonSolidBaseProps = {
 
 type ButtonSolidProps = ButtonSolidBaseProps & {
   disabled?: boolean;
-  clickHandler?: (event: SyntheticEvent<HTMLButtonElement>) => void,
+  clickHandler?: (event: SyntheticEvent<HTMLButtonElement>) => void;
 };
 
 type SolidButtonProps = {
   href?: string;
   isBig?: boolean;
-}
+};
 
-export const SolidButton = styled(BaseButton).attrs<SolidButtonProps>(props => ({
-  className: classNames({
-    'link-reset': !!props.href,
-  }),
-}))<SolidButtonProps>`
+export const SolidButton = styled(BaseButton).attrs<SolidButtonProps>(
+  props => ({
+    className: classNames({
+      'link-reset': !!props.href,
+    }),
+  })
+)<SolidButtonProps>`
   background: ${props => props.theme.color('green')};
   color: ${props => props.theme.color('white')};
   border: 2px solid ${props => props.theme.color('green')};
@@ -136,8 +138,6 @@ export const SolidButton = styled(BaseButton).attrs<SolidButtonProps>(props => (
 `;
 
 // TODO move styles here - styled component
-
-
 
 // $FlowFixMe (forwardRef)
 const ButtonSolid = forwardRef(


### PR DESCRIPTION
`styled-components` don't merge `attrs`, so if one styled component styles another one and they both have `className` in their `attrs`, only the outer component's `className`s will exist.

Here, `BaseButton` had vertical alignment classes from `root-scope-classes`, but they were being overridden by the `SolidButton`'s classes.

Adding the properties directly to the components instead of using `root-scope-classes` solves this.

Most of the changes in this PR are the result of Prettier not previously having been run on this file.

See https://github.com/styled-components/styled-components/issues/2270 for more context.