### PR TITLE
Use the new location of the VPC terraform state

### DIFF
--- a/infrastructure/terraform/locals.tf
+++ b/infrastructure/terraform/locals.tf
@@ -1,7 +1,7 @@
 locals {
-  vpc_id = data.terraform_remote_state.infra_shared.outputs.experience_vpc_id
+  vpc_id = local.experience_vpcs["experience_vpc_id"]
 
-  private_subnets = data.terraform_remote_state.infra_shared.outputs.experience_vpc_private_subnets
-  public_subnets  = data.terraform_remote_state.infra_shared.outputs.experience_vpc_public_subnets
+  private_subnets = local.experience_vpcs["experience_vpc_private_subnets"]
+  public_subnets  = local.experience_vpcs["experience_vpc_public_subnets"]
   wc_org_cert_arn = "arn:aws:acm:eu-west-1:130871440101:certificate/6876e191-3f7a-47b7-9c67-40f45bb51b72"
 }

--- a/infrastructure/terraform/terraform.tf
+++ b/infrastructure/terraform/terraform.tf
@@ -13,13 +13,17 @@ terraform {
   }
 }
 
-data "terraform_remote_state" "infra_shared" {
+data "terraform_remote_state" "accounts_experience" {
   backend = "s3"
 
   config = {
     role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
     bucket   = "wellcomecollection-platform-infra"
-    key      = "terraform/platform-infrastructure/shared.tfstate"
+    key      = "terraform/platform-infrastructure/accounts/experience.tfstate"
     region   = "eu-west-1"
   }
+}
+
+locals {
+  experience_vpcs = data.terraform_remote_state.accounts_experience.outputs
 }


### PR DESCRIPTION
Part of https://github.com/wellcomecollection/platform/issues/4802

We've rearranged some of our Terraform configs to reduce the amount of cross-account coupling. Changing the storage VPC shouldn't affect the Experience VPC, etc.

I've already checked this is a no-op.