### PR TITLE
add clear filter for item location type

### DIFF
--- a/common/views/components/SearchFilters/SearchFiltersDesktop.js
+++ b/common/views/components/SearchFilters/SearchFiltersDesktop.js
@@ -237,7 +237,8 @@ const SearchFiltersDesktop = ({
         {(productionDatesFrom ||
           productionDatesTo ||
           (imagesColor && showColorFilter) ||
-          workTypeInUrlArray.length > 0) &&
+          workTypeInUrlArray.length > 0 ||
+          worksRouteProps.itemsLocationsType.length > 0) &&
           (workTypeFilters.length > 0 ||
             worksRouteProps.search === 'images') && (
             <div className={classNames({ [font('hnl', 5)]: true })}>
@@ -337,13 +338,42 @@ const SearchFiltersDesktop = ({
                   );
                 })}
 
-                {workTypeFilters.length > 0 && (
+                {aggregations &&
+                  aggregations.locationType.buckets
+                    .filter(locationType =>
+                      worksRouteProps.itemsLocationsType.includes(
+                        locationType.data.type
+                      )
+                    )
+                    .map(locationType => (
+                      <NextLink
+                        key={locationType.type}
+                        passHref
+                        {...worksLink(
+                          {
+                            ...worksRouteProps,
+                            itemsLocationsType: worksRouteProps.itemsLocationsType.filter(
+                              type => type !== locationType.data.type
+                            ),
+                            page: 1,
+                          },
+                          'cancel_filter/items_locations_type'
+                        )}
+                      >
+                        <a>
+                          <CancelFilter text={locationType.data.label} />
+                        </a>
+                      </NextLink>
+                    ))}
+
+                {worksRouteProps.itemsLocationsType.length > 0 && (
                   <NextLink
                     passHref
                     {...worksLink(
                       {
                         ...worksRouteProps,
                         itemsLocationsLocationType: [],
+                        itemsLocationsType: [],
                         workType: [],
                         page: 1,
                         productionDatesFrom: null,


### PR DESCRIPTION
## Who is this for?
People who love convenient clearing of filters

## What is it doing for them?
Makes clearing location type filters conveniently
<img width="590" alt="Screenshot 2020-09-29 at 09 35 35" src="https://user-images.githubusercontent.com/31692/94533667-5c4dee00-0237-11eb-871d-8b39dc50e847.png">

