### PR TITLE
Fix image card hrefs

### DIFF
--- a/catalogue/webapp/components/ImageCard/ImageCard.js
+++ b/catalogue/webapp/components/ImageCard/ImageCard.js
@@ -5,12 +5,13 @@ import { trackEvent } from '@weco/common/utils/ga';
 import type { Props as ImageProps } from '@weco/common/views/components/Image/Image';
 import Image from '@weco/common/views/components/Image/Image';
 import Space from '@weco/common/views/components/styled/Space';
-import { workLink } from '@weco/common/services/catalogue/routes';
+import { imageLink } from '@weco/common/services/catalogue/routes';
 import styled from 'styled-components';
 import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
 
 type Props = {|
   id: string,
+  workId: string,
   image: ImageProps,
   onClick: (event: SyntheticEvent<HTMLAnchorElement>) => void,
 |};
@@ -40,11 +41,11 @@ const ImageWrap = styled(Space).attrs({
   }
 `;
 
-const ImageCard = ({ id, image, onClick }: Props) => {
+const ImageCard = ({ id, image, onClick, workId }: Props) => {
   const { isEnhanced } = useContext(AppContext);
 
   return (
-    <NextLink {...workLink({ id })}>
+    <NextLink {...imageLink({ id, workId })}>
       <a
         onClick={event => {
           trackEvent({

--- a/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.js
+++ b/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.js
@@ -29,6 +29,7 @@ const ImageEndpointSearchResults = ({ images, apiProps }: Props) => {
         <div key={result.id}>
           <ImageCard
             id={result.id}
+            workId={result.source.id}
             image={{
               contentUrl: result.locations[0].url,
               width: 300,


### PR DESCRIPTION
We hadn't noticed this because the link is overridden by the JS to open the modal, but it does crop up if you try to open an image in a new tab