### PR TITLE
use hardcoded cert for static and assets domains

### DIFF
--- a/assets/terraform/terraform.tf
+++ b/assets/terraform/terraform.tf
@@ -29,15 +29,14 @@ provider "template" {
   version = "~> 2.1"
 }
 
-data "aws_acm_certificate" "wellcomecollection_ssl_cert" {
-  provider = aws.us-east-1
-  domain   = "wellcomecollection.org"
+locals {
+  wellcome_cdn_cert_arn = "arn:aws:acm:us-east-1:130871440101:certificate/bb840c52-56bb-4bf8-86f8-59e7deaf9c98"
 }
 
 module "static" {
   source              = "../../infrastructure/terraform/modules/s3_website"
   website_uri         = "i.wellcomecollection.org"
-  acm_certificate_arn = data.aws_acm_certificate.wellcomecollection_ssl_cert.arn
+  acm_certificate_arn = local.wellcome_cdn_cert_arn
   min_ttl             = 86400
   default_ttl         = 86400
   max_ttl             = 86400

--- a/static/terraform/terraform.tf
+++ b/static/terraform/terraform.tf
@@ -29,13 +29,12 @@ provider "aws" {
   }
 }
 
-data "aws_acm_certificate" "wellcomecollection_ssl_cert" {
-  provider = aws.us-east-1
-  domain   = "wellcomecollection.org"
+locals {
+  wellcome_cdn_cert_arn = "arn:aws:acm:us-east-1:130871440101:certificate/bb840c52-56bb-4bf8-86f8-59e7deaf9c98"
 }
 
 module "static" {
   source              = "../../infrastructure/terraform/modules/s3_website"
   website_uri         = "static.wellcomecollection.org"
-  acm_certificate_arn = data.aws_acm_certificate.wellcomecollection_ssl_cert.arn
+  acm_certificate_arn = local.wellcome_cdn_cert_arn
 }


### PR DESCRIPTION
## Who is this for?
People who like pretty fonts and favicons

## What is it doing for them?
Uses a valid vert for `i.wellcomecollection.org` and `static.wellcomecollection.org`.

This has been applied and has been seen working in the wild.
