### PR TITLE
Render React elements in Table if they're valid

### DIFF
--- a/common/views/components/Table/Table.tsx
+++ b/common/views/components/Table/Table.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { useRef, useEffect, useState, Fragment } from 'react';
+import { useRef, useEffect, useState, Fragment, isValidElement } from 'react';
 import { font, classNames } from '../../../utils/classnames';
 import Space from '../styled/Space';
 import Control from '../Buttons/Control/Control';
@@ -149,7 +149,13 @@ const TableRow = ({ items, hasHeader }: TableRow) => {
       {items.map((item, index) => (
         <Fragment key={index}>
           {hasHeader && index === 0 ? (
-            <TableTh scope="row" dangerouslySetInnerHTML={{ __html: item }} />
+            isValidElement(item) ? (
+              <TableTh scope="row">{item}</TableTh>
+            ) : (
+              <TableTh scope="row" dangerouslySetInnerHTML={{ __html: item }} />
+            )
+          ) : isValidElement(item) ? (
+            <TableTd>{item}</TableTd>
           ) : (
             <TableTd dangerouslySetInnerHTML={{ __html: item }} />
           )}
@@ -277,13 +283,19 @@ const Table = ({ rows, hasRowHeaders, caption }: Props) => {
             {headerRow && (
               <TableThead>
                 <TableTr>
-                  {headerRow.map((item, index) => (
-                    <TableTh
-                      key={index}
-                      scope="col"
-                      dangerouslySetInnerHTML={{ __html: item }}
-                    />
-                  ))}
+                  {headerRow.map((item, index) =>
+                    isValidElement ? (
+                      <TableTh key={index} scope="col">
+                        {item}
+                      </TableTh>
+                    ) : (
+                      <TableTh
+                        key={index}
+                        scope="col"
+                        dangerouslySetInnerHTML={{ __html: item }}
+                      />
+                    )
+                  )}
                 </TableTr>
               </TableThead>
             )}


### PR DESCRIPTION
The `Table` component can accept `string`s or `JSX.Element`s as cell data, but it currently runs all items through `dangerouslySetInnerHTML`. This checks if it's a React element and renders it as is if so.

__before__
![Screenshot 2020-09-30 at 13 44 37](https://user-images.githubusercontent.com/1394592/94687353-0f941100-0324-11eb-994e-7f544381538b.png)

__after__
![Screenshot 2020-09-30 at 13 43 42](https://user-images.githubusercontent.com/1394592/94687426-25a1d180-0324-11eb-8f4c-e885f0bc40f8.png)
