### PR TITLE
Shunt FeaturedCard shim up a pixel to prevent a white line appearing

### DIFF
--- a/common/views/components/FeaturedCard/FeaturedCard.js
+++ b/common/views/components/FeaturedCard/FeaturedCard.js
@@ -267,6 +267,7 @@ const FeaturedCardShim = styled.div.attrs(props => ({
   }),
 }))`
   height: 21px;
+  /* Prevent a white line appearing above the shim because of browser rounding errors */
   top: -1px;
   margin-left: ${props =>
     props.isReversed ? props.theme.gutter.large + 'px' : null};

--- a/common/views/components/FeaturedCard/FeaturedCard.js
+++ b/common/views/components/FeaturedCard/FeaturedCard.js
@@ -262,11 +262,12 @@ const FeaturedCardCopy = styled(Space).attrs(props => ({
 const FeaturedCardShim = styled.div.attrs(props => ({
   className: classNames({
     [`bg-${props.background}`]: true,
-    'is-hidden-s is-hidden-m': true,
+    'is-hidden-s is-hidden-m relative': true,
     [grid({ s: 12, m: 11, l: 5, xl: 5 })]: true,
   }),
 }))`
-  height: 20px;
+  height: 21px;
+  top: -1px;
   margin-left: ${props =>
     props.isReversed ? props.theme.gutter.large + 'px' : null};
 `;


### PR DESCRIPTION
This is hacky and obviously doesn't make me happy, but Firefox doesn't like maths.