### PR TITLE
stop archivesPrototype toggle from affecting search results

### DIFF
--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -375,32 +375,17 @@ Works.getInitialProps = async (ctx: Context): Promise<Props> => {
   if (shouldSeeArchives) {
     ctx.query.toggles.archivesPrototype = true;
   }
-  const {
-    unfilteredSearchResults,
-    archivesPrototype,
-    enableColorFiltering,
-  } = ctx.query.toggles;
+  const { unfilteredSearchResults, enableColorFiltering } = ctx.query.toggles;
   const _queryType = cookies(ctx)._queryType;
   const isImageSearch = params.search === 'images';
   const apiPropsFn = unfilteredSearchResults
     ? worksRouteToApiUrl
     : worksRouteToApiUrlWithDefaults;
   const aggregations = ['workType', 'locationType'];
-  const apiProps = archivesPrototype
-    ? apiPropsFn(
-        params,
-        {
-          _queryType,
-          aggregations,
-          'items.locations.locationType': null,
-          'items.locations.accessConditions.status': null,
-        },
-        true
-      )
-    : apiPropsFn(params, {
-        _queryType,
-        aggregations,
-      });
+  const apiProps = apiPropsFn(params, {
+    _queryType,
+    aggregations,
+  });
 
   const hasQuery = !!(params.query && params.query !== '');
 

--- a/common/services/catalogue/api.js
+++ b/common/services/catalogue/api.js
@@ -51,8 +51,7 @@ export type CatalogueImagesApiProps = {|
 
 export function worksRouteToApiUrl(
   worksRouteProps: WorksRouteProps,
-  overrides: $Shape<CatalogueWorksApiProps>,
-  useTestDefaultWorkTypes?: boolean
+  overrides: $Shape<CatalogueWorksApiProps>
 ): CatalogueWorksApiProps {
   return {
     query: worksRouteProps.query,
@@ -71,7 +70,6 @@ export function worksRouteToApiUrl(
 }
 
 export const defaultWorkTypes = ['a', 'b', 'g', 'i', 'k', 'l', 'q'];
-export const testDefaultWorkTypes = ['a', 'b', 'g', 'h', 'i', 'k', 'l', 'q'];
 
 export const defaultItemsLocationsLocationType = [
   'iiif-image',
@@ -84,8 +82,7 @@ export const defaultAccessConditions = [
 ];
 export function worksRouteToApiUrlWithDefaults(
   worksRouteProps: WorksRouteProps,
-  overrides: $Shape<CatalogueWorksApiProps>,
-  useTestDefaultWorkTypes?: boolean
+  overrides: $Shape<CatalogueWorksApiProps>
 ): CatalogueWorksApiProps {
   return {
     query: worksRouteProps.query,
@@ -93,8 +90,6 @@ export function worksRouteToApiUrlWithDefaults(
     workType:
       worksRouteProps.workType.length > 0
         ? worksRouteProps.workType
-        : useTestDefaultWorkTypes
-        ? testDefaultWorkTypes
         : defaultWorkTypes,
     'items.locations.locationType':
       worksRouteProps.itemsLocationsLocationType.length > 0

--- a/common/views/components/SearchFilters/SearchFilters.js
+++ b/common/views/components/SearchFilters/SearchFilters.js
@@ -5,10 +5,7 @@ import {
   type CatalogueAggregationBucket,
   type CatalogueAggregations,
 } from '@weco/common/model/catalogue';
-import {
-  defaultWorkTypes,
-  testDefaultWorkTypes,
-} from '@weco/common/services/catalogue/api';
+import { defaultWorkTypes } from '@weco/common/services/catalogue/api';
 import SearchFiltersDesktop from '@weco/common/views/components/SearchFilters/SearchFiltersDesktop';
 import SearchFiltersMobile from '@weco/common/views/components/SearchFilters/SearchFiltersMobile';
 // $FlowFixMe (tsx)
@@ -62,9 +59,7 @@ const SearchFilters = ({
   const workTypeFilters = unfilteredSearchResults
     ? workTypeAggregations
     : workTypeAggregations.filter(agg =>
-        archivesPrototype
-          ? testDefaultWorkTypes.includes(agg.data.id)
-          : defaultWorkTypes.includes(agg.data.id)
+        defaultWorkTypes.includes(agg.data.id)
       );
 
   useEffect(() => {

--- a/toggles/webapp/toggles.js
+++ b/toggles/webapp/toggles.js
@@ -2,11 +2,10 @@ module.exports = {
   toggles: [
     {
       id: 'archivesPrototype',
-      title:
-        'Include archives in search results and view additions to the work page relating to archives',
+      title: 'Show additions to the work page relating to archives',
       defaultValue: false,
       description:
-        'Include archives in search results and view prototypes of breadcrumbs and archive tree on work page.',
+        'Shows archive specific header, breadcrumbs and archive tree on the work page.',
     },
     {
       id: 'unfilteredSearchResults',


### PR DESCRIPTION
In order to make testing the archive prototypes as simple as possible for participants, the archivesPrototype toggle combined some changes to search functionality, i.e. to include archives in search results.

Now that the testing is over, and we are about to make unfiltered searches live anyway, it makes sense to remove this additional functionality from this toggle.
