### PR TITLE
puts the filter prototype behind its own toggle

### DIFF
--- a/common/views/components/ModalFilters/ModalFilters.tsx
+++ b/common/views/components/ModalFilters/ModalFilters.tsx
@@ -77,7 +77,7 @@ const FiltersInner = styled.div`
   `}
 `;
 
-const SearchFiltersArchivesPrototype = ({
+const ModalFilters = ({
   searchForm,
   worksRouteProps,
   workTypeAggregations,
@@ -269,4 +269,4 @@ const SearchFiltersArchivesPrototype = ({
   );
 };
 
-export default SearchFiltersArchivesPrototype;
+export default ModalFilters;

--- a/common/views/components/SearchFilters/SearchFilters.js
+++ b/common/views/components/SearchFilters/SearchFilters.js
@@ -52,7 +52,7 @@ const SearchFilters = ({
   const [isMobile, setIsMobile] = useState(false);
   const [inputDateFrom, setInputDateFrom] = useState(productionDatesFrom);
   const [inputDateTo, setInputDateTo] = useState(productionDatesTo);
-  const { unfilteredSearchResults, archivesPrototype } = useContext(
+  const { unfilteredSearchResults, filterPrototype } = useContext(
     TogglesContext
   );
 
@@ -121,7 +121,7 @@ const SearchFilters = ({
 
   return (
     <>
-      {archivesPrototype ? (
+      {filterPrototype ? (
         <SearchFiltersArchivesPrototype {...sharedProps} />
       ) : (
         <>

--- a/common/views/components/SearchFilters/SearchFilters.js
+++ b/common/views/components/SearchFilters/SearchFilters.js
@@ -9,7 +9,7 @@ import { defaultWorkTypes } from '@weco/common/services/catalogue/api';
 import SearchFiltersDesktop from '@weco/common/views/components/SearchFilters/SearchFiltersDesktop';
 import SearchFiltersMobile from '@weco/common/views/components/SearchFilters/SearchFiltersMobile';
 // $FlowFixMe (tsx)
-import SearchFiltersArchivesPrototype from '@weco/common/views/components/SearchFiltersArchivesPrototype/SearchFiltersArchivesPrototype';
+import ModalFilters from '@weco/common/views/components/ModalFilters/ModalFilters';
 import theme from '@weco/common/views/themes/default';
 import TogglesContext from '../TogglesContext/TogglesContext';
 
@@ -52,7 +52,7 @@ const SearchFilters = ({
   const [isMobile, setIsMobile] = useState(false);
   const [inputDateFrom, setInputDateFrom] = useState(productionDatesFrom);
   const [inputDateTo, setInputDateTo] = useState(productionDatesTo);
-  const { unfilteredSearchResults, filterPrototype } = useContext(
+  const { unfilteredSearchResults, modalFiltersPrototype } = useContext(
     TogglesContext
   );
 
@@ -121,8 +121,8 @@ const SearchFilters = ({
 
   return (
     <>
-      {filterPrototype ? (
-        <SearchFiltersArchivesPrototype {...sharedProps} />
+      {modalFiltersPrototype ? (
+        <ModalFilters {...sharedProps} />
       ) : (
         <>
           {isMobile ? (

--- a/toggles/webapp/toggles.js
+++ b/toggles/webapp/toggles.js
@@ -27,6 +27,12 @@ module.exports = {
       defaultValue: true,
     },
     {
+      id: 'filterPrototype',
+      title: 'Use filter prototype',
+      defaultValue: false,
+      description: 'Search filters will appear in a modal',
+    },
+    {
       id: 'enableColorFiltering',
       title: 'Enable filtering images by color',
       defaultValue: false,

--- a/toggles/webapp/toggles.js
+++ b/toggles/webapp/toggles.js
@@ -27,8 +27,8 @@ module.exports = {
       defaultValue: true,
     },
     {
-      id: 'filterPrototype',
-      title: 'Use filter prototype',
+      id: 'modalFiltersPrototype',
+      title: 'Use the modal filter prototype',
       defaultValue: false,
       description: 'Search filters will appear in a modal',
     },


### PR DESCRIPTION
Puts the filter prototype (i.e. using a modal behind a button on desktop too) behind its own toggle.

This is currently behind the archivesPrototype toggle but isn't in a state to be released with the rest of the archives work.
