### PR TITLE
Use correct remote state in services

### DIFF
--- a/catalogue/terraform/stack/data.tf
+++ b/catalogue/terraform/stack/data.tf
@@ -2,9 +2,9 @@ data "terraform_remote_state" "infra_shared" {
   backend = "s3"
 
   config = {
-    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
     bucket   = "wellcomecollection-platform-infra"
-    key      = "terraform/platform-infrastructure/shared.tfstate"
+    key      = "terraform/platform-infrastructure/accounts/experience.tfstate"
+    role_arn = "arn:aws:iam::760097843905:role/platform-developer"
     region   = "eu-west-1"
   }
 }

--- a/content/terraform/stack/data.tf
+++ b/content/terraform/stack/data.tf
@@ -2,9 +2,9 @@ data "terraform_remote_state" "infra_shared" {
   backend = "s3"
 
   config = {
-    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
     bucket   = "wellcomecollection-platform-infra"
-    key      = "terraform/platform-infrastructure/shared.tfstate"
+    key      = "terraform/platform-infrastructure/accounts/experience.tfstate"
+    role_arn = "arn:aws:iam::760097843905:role/platform-developer"
     region   = "eu-west-1"
   }
 }


### PR DESCRIPTION
Fixes terraform operations not working because referencing moved state.