### PR TITLE
Fix edge_lambdas deploy step

### DIFF
--- a/cache/edge_lambdas/Dockerfile
+++ b/cache/edge_lambdas/Dockerfile
@@ -12,4 +12,4 @@ RUN yarn
 
 RUN zip -r edge_lambda_origin.zip toggler.js origin.js redirector.js redirects.js
 
-CMD ["cp", "/usr/src/app/webapp/edge_lambda_origin.zip", "/dist/.dist/edge_lambda_origin.zip"]
+CMD ["true"]

--- a/cache/edge_lambdas/deploy.js
+++ b/cache/edge_lambdas/deploy.js
@@ -4,7 +4,7 @@ const s3 = new AWS.S3({apiVersion: '2006-03-01'});
 const fs = require('fs');
 
 try {
-  const data = fs.readFileSync('edge_lambda_origin.zip', 'utf8');
+  const data = fs.readFileSync('edge_lambda_origin.zip');
 
   const params = {
     Body: data,


### PR DESCRIPTION
This change fixes the deploy step for the edge_lambdas project. The problem was caused by incorrect encoding used when the ZIP file was uploaded. 

This PR also includes documentation for replicating CI steps locally to make future debugging easier.