### PR TITLE
making archive tree scrollable

### DIFF
--- a/common/views/components/ArchiveTree/ArchiveTree.js
+++ b/common/views/components/ArchiveTree/ArchiveTree.js
@@ -36,6 +36,7 @@ const StickyContainer = styled.div`
 const StickyContainerInner = styled.div`
   ${props => props.theme.media.medium`
     overflow: scroll;
+    max-height: calc(100vh - 48px);
   `}
 `;
 


### PR DESCRIPTION
Had accidentally remove max-height on archive tree container, which means users can no longer scroll it independently of the rest of the page. This puts it back
