### PR TITLE
 Not allow, Footer collection venue opening times names dynamic.

### DIFF
--- a/cardigan/stories/components/Footer.js
+++ b/cardigan/stories/components/Footer.js
@@ -1,8 +1,7 @@
 import { storiesOf } from '@storybook/react';
 import Footer from '../../../common/views/components/Footer/Footer';
 import Readme from '../../../common/views/components/Footer/README.md';
-import { openingTimes } from '../content';
-
+import { openingTimes } from '../../../common/test/fixtures/components/opening-times';
 const FooterExample = () => {
   return <Footer openingTimes={openingTimes} />;
 };

--- a/cardigan/stories/content.js
+++ b/cardigan/stories/content.js
@@ -1,5 +1,5 @@
 import faker from 'faker';
-
+import { openingTimes as openingTimesFixture } from '@weco/common/test/fixtures/components/opening-times';
 export function randomNumber(min, max) {
   return Math.floor(Math.random() * max) + min;
 }
@@ -285,94 +285,4 @@ export function organisation() {
   };
 }
 
-export const openingTimes = {
-  collectionOpeningTimes: {
-    placesOpeningHours: [
-      {
-        id: 'Wsttgx8AAJeSNmJ4',
-        order: 1,
-        name: 'Galleries',
-        openingHours: {
-          regular: [
-            { dayOfWeek: 'Monday', opens: null, closes: null },
-            { dayOfWeek: 'Tuesday', opens: '10:00', closes: '18:00' },
-            { dayOfWeek: 'Wednesday', opens: '10:00', closes: '18:00' },
-            { dayOfWeek: 'Thursday', opens: '10:00', closes: '21:00' },
-            { dayOfWeek: 'Friday', opens: '10:00', closes: '18:00' },
-            { dayOfWeek: 'Saturday', opens: '10:00', closes: '18:00' },
-            { dayOfWeek: 'Sunday', opens: '10:00', closes: '18:00' },
-          ],
-          exceptional: [],
-        },
-      },
-      {
-        id: 'WsuS_R8AACS1Nwlx',
-        order: 2,
-        name: 'Library',
-        openingHours: {
-          regular: [
-            { dayOfWeek: 'Monday', opens: '10:00', closes: '18:00' },
-            { dayOfWeek: 'Tuesday', opens: '10:00', closes: '18:00' },
-            { dayOfWeek: 'Wednesday', opens: '10:00', closes: '18:00' },
-            { dayOfWeek: 'Thursday', opens: '10:00', closes: '20:00' },
-            { dayOfWeek: 'Friday', opens: '10:00', closes: '18:00' },
-            { dayOfWeek: 'Saturday', opens: '10:00', closes: '16:00' },
-            { dayOfWeek: 'Sunday', opens: null, closes: null },
-          ],
-          exceptional: [],
-        },
-      },
-      {
-        id: 'WsuYER8AAOG_NyBA',
-        order: 3,
-        name: 'Restaurant',
-        openingHours: {
-          regular: [
-            { dayOfWeek: 'Monday', opens: null, closes: null },
-            { dayOfWeek: 'Tuesday', opens: '11:00', closes: '18:00' },
-            { dayOfWeek: 'Wednesday', opens: '11:00', closes: '18:00' },
-            { dayOfWeek: 'Thursday', opens: '11:00', closes: '21:00' },
-            { dayOfWeek: 'Friday', opens: '11:00', closes: '18:00' },
-            { dayOfWeek: 'Saturday', opens: '11:00', closes: '18:00' },
-            { dayOfWeek: 'Sunday', opens: '11:00', closes: '18:00' },
-          ],
-          exceptional: [],
-        },
-      },
-      {
-        id: 'WsuZKh8AAOG_NyUo',
-        order: 4,
-        name: 'Café',
-        openingHours: {
-          regular: [
-            { dayOfWeek: 'Monday', opens: '08:30', closes: '18:00' },
-            { dayOfWeek: 'Tuesday', opens: '08:30', closes: '18:00' },
-            { dayOfWeek: 'Wednesday', opens: '08:30', closes: '18:00' },
-            { dayOfWeek: 'Thursday', opens: '08:30', closes: '21:00' },
-            { dayOfWeek: 'Friday', opens: '08:30', closes: '18:00' },
-            { dayOfWeek: 'Saturday', opens: '09:30', closes: '18:00' },
-            { dayOfWeek: 'Sunday', opens: '10:00', closes: '18:00' },
-          ],
-          exceptional: [],
-        },
-      },
-      {
-        id: 'WsuaIB8AAH-yNylo',
-        order: 5,
-        name: 'Shop',
-        openingHours: {
-          regular: [
-            { dayOfWeek: 'Monday', opens: '09:00', closes: '18:00' },
-            { dayOfWeek: 'Tuesday', opens: '09:00', closes: '18:00' },
-            { dayOfWeek: 'Wednesday', opens: '09:00', closes: '18:00' },
-            { dayOfWeek: 'Thursday', opens: '09:00', closes: '21:00' },
-            { dayOfWeek: 'Friday', opens: '09:00', closes: '18:00' },
-            { dayOfWeek: 'Saturday', opens: '10:00', closes: '18:00' },
-            { dayOfWeek: 'Sunday', opens: '10:00', closes: '18:00' },
-          ],
-          exceptional: [],
-        },
-      },
-    ],
-  },
-};
+export const openingTimes = openingTimesFixture;

--- a/common/model/opening-hours.ts
+++ b/common/model/opening-hours.ts
@@ -13,11 +13,11 @@ export type OverrideType =
 
 export type OverrideDate = {
   overrideDate: Moment,
-  overrideType: OverrideType,
+  overrideType: OverrideType | null,
 };
 
 export type ExceptionalPeriod = {
-  type: OverrideType,
+  type: OverrideType | null,
   dates: OverrideDate[],
 };
 
@@ -29,7 +29,7 @@ export type OpeningHoursDay = {
 
 export type ExceptionalOpeningHoursDay = {
   overrideDate: Moment,
-  overrideType: OverrideType,
+  overrideType: OverrideType | null,
   opens?: string,
   closes?: string,
 };
@@ -53,7 +53,7 @@ export type PlacesOpeningHours = Venue[];
 
 export type CollectionOpeningTimes = {
   placesOpeningHours: PlacesOpeningHours,
-  upcomingExceptionalOpeningPeriods?: { dates: Moment[]; type: OverrideType; }[],
+  upcomingExceptionalOpeningPeriods?: { dates: Moment[]; type: OverrideType | null; }[],
 };
 
 // http://schema.org/specialOpeningHoursSpecification

--- a/common/model/opening-hours.ts
+++ b/common/model/opening-hours.ts
@@ -23,20 +23,20 @@ export type ExceptionalPeriod = {
 
 export type OpeningHoursDay = {
   dayOfWeek: Day,
-  opens?: string,
-  closes?: string,
+  opens: string | null,
+  closes: string | null,
 };
 
 export type ExceptionalOpeningHoursDay = {
   overrideDate: Moment,
-  overrideType: OverrideType | null,
-  opens?: string,
-  closes?: string,
+  overrideType: OverrideType,
+  opens: string | null,
+  closes: string | null,
 };
 
 export type OpeningHours = {
   regular: OpeningHoursDay[],
-  exceptional: ExceptionalOpeningHoursDay[],
+  exceptional: ExceptionalOpeningHoursDay[] | null,
 };
 
 export type Venue = {
@@ -45,7 +45,7 @@ export type Venue = {
   order: number,
   openingHours: OpeningHours,
   url?: LinkType,
-  linkText?: string,
+  linkText?: string | null,
   image?: ImageType,
 };
 
@@ -53,7 +53,7 @@ export type PlacesOpeningHours = Venue[];
 
 export type CollectionOpeningTimes = {
   placesOpeningHours: PlacesOpeningHours,
-  upcomingExceptionalOpeningPeriods?: { dates: Moment[]; type: OverrideType | null; }[],
+  upcomingExceptionalOpeningPeriods: { dates: Moment[]; type: OverrideType; }[] | null,
 };
 
 // http://schema.org/specialOpeningHoursSpecification

--- a/common/model/opening-hours.ts
+++ b/common/model/opening-hours.ts
@@ -1,0 +1,65 @@
+import { Moment } from 'moment';
+import { ImageType } from './image';
+import { Link as LinkType } from './link';
+
+export type Day = string; // 'Monday' | 'Tuesday' | 'Wednesday' | 'Thursday' | 'Friday' | 'Saturday' | 'Sunday';
+
+export type OverrideType =
+  | 'Bank holiday'
+  | 'Easter'
+  | 'Christmas and New Year'
+  | 'Late Spectacluar'
+  | 'other';
+
+export type OverrideDate = {
+  overrideDate: Moment,
+  overrideType: OverrideType,
+};
+
+export type ExceptionalPeriod = {
+  type: OverrideType,
+  dates: OverrideDate[],
+};
+
+export type OpeningHoursDay = {
+  dayOfWeek: Day,
+  opens?: string,
+  closes?: string,
+};
+
+export type ExceptionalOpeningHoursDay = {
+  overrideDate: Moment,
+  overrideType: OverrideType,
+  opens?: string,
+  closes?: string,
+};
+
+export type OpeningHours = {
+  regular: OpeningHoursDay[],
+  exceptional: ExceptionalOpeningHoursDay[],
+};
+
+export type Venue = {
+  id: string,
+  name: string,
+  order: number,
+  openingHours: OpeningHours,
+  url?: LinkType,
+  linkText?: string,
+  image?: ImageType,
+};
+
+export type PlacesOpeningHours = Venue[];
+
+export type CollectionOpeningTimes = {
+  placesOpeningHours: PlacesOpeningHours,
+  upcomingExceptionalOpeningPeriods?: { dates: Moment[]; type: OverrideType; }[],
+};
+
+// http://schema.org/specialOpeningHoursSpecification
+export type SpecialOpeningHours = {
+  opens: string,
+  closes: string,
+  validFrom: Date,
+  validThrough: Date,
+};

--- a/common/services/prismic/hardcoded-id.js
+++ b/common/services/prismic/hardcoded-id.js
@@ -1,7 +1,36 @@
+// @flow
+
 // Place to store id's of prismic of dynamic content if required.
 // We can always reference all hardcoded prismic id where they are called and remove them later to maintain
 
 export const collectionVenueId = {
-  galleries: 'Wsttgx8AAJeSNmJ4',
-  libraries: 'WsuS_R8AACS1Nwlx',
+  galleries: {
+    id: 'Wsttgx8AAJeSNmJ4',
+    name: 'Galleries',
+  },
+  libraries: {
+    id: 'WsuS_R8AACS1Nwlx',
+    name: 'Library',
+  },
+  restaurant: {
+    id: 'WsuYER8AAOG_NyBA',
+    name: 'Restaurant',
+  },
+  shop: {
+    id: 'WsuaIB8AAH-yNylo',
+    name: 'Shop',
+  },
+  café: {
+    id: 'WsuZKh8AAOG_NyUo',
+    name: 'Café',
+  },
+};
+
+export const getNameFromCollectionVenue = (id: string) => {
+  // check the keys and returns back name based on id
+  for (const [key, value] of Object.entries(collectionVenueId)) {
+    if (value && value.id === id) {
+      return collectionVenueId[key].name;
+    }
+  }
 };

--- a/common/test/fixtures/components/opening-times.js
+++ b/common/test/fixtures/components/opening-times.js
@@ -1,0 +1,91 @@
+export const openingTimes = {
+  collectionOpeningTimes: {
+    placesOpeningHours: [
+      {
+        id: 'Wsttgx8AAJeSNmJ4',
+        order: 1,
+        name: 'Galleries',
+        openingHours: {
+          regular: [
+            { dayOfWeek: 'Monday', opens: null, closes: null },
+            { dayOfWeek: 'Tuesday', opens: '10:00', closes: '18:00' },
+            { dayOfWeek: 'Wednesday', opens: '10:00', closes: '18:00' },
+            { dayOfWeek: 'Thursday', opens: '10:00', closes: '21:00' },
+            { dayOfWeek: 'Friday', opens: '10:00', closes: '18:00' },
+            { dayOfWeek: 'Saturday', opens: '10:00', closes: '18:00' },
+            { dayOfWeek: 'Sunday', opens: '10:00', closes: '18:00' },
+          ],
+          exceptional: [],
+        },
+      },
+      {
+        id: 'WsuS_R8AACS1Nwlx',
+        order: 2,
+        name: 'Library',
+        openingHours: {
+          regular: [
+            { dayOfWeek: 'Monday', opens: '10:00', closes: '18:00' },
+            { dayOfWeek: 'Tuesday', opens: '10:00', closes: '18:00' },
+            { dayOfWeek: 'Wednesday', opens: '10:00', closes: '18:00' },
+            { dayOfWeek: 'Thursday', opens: '10:00', closes: '20:00' },
+            { dayOfWeek: 'Friday', opens: '10:00', closes: '18:00' },
+            { dayOfWeek: 'Saturday', opens: '10:00', closes: '16:00' },
+            { dayOfWeek: 'Sunday', opens: null, closes: null },
+          ],
+          exceptional: [],
+        },
+      },
+      {
+        id: 'WsuYER8AAOG_NyBA',
+        order: 3,
+        name: 'Restaurant',
+        openingHours: {
+          regular: [
+            { dayOfWeek: 'Monday', opens: null, closes: null },
+            { dayOfWeek: 'Tuesday', opens: '11:00', closes: '18:00' },
+            { dayOfWeek: 'Wednesday', opens: '11:00', closes: '18:00' },
+            { dayOfWeek: 'Thursday', opens: '11:00', closes: '21:00' },
+            { dayOfWeek: 'Friday', opens: '11:00', closes: '18:00' },
+            { dayOfWeek: 'Saturday', opens: '11:00', closes: '18:00' },
+            { dayOfWeek: 'Sunday', opens: '11:00', closes: '18:00' },
+          ],
+          exceptional: [],
+        },
+      },
+      {
+        id: 'WsuZKh8AAOG_NyUo',
+        order: 4,
+        name: 'Café',
+        openingHours: {
+          regular: [
+            { dayOfWeek: 'Monday', opens: '08:30', closes: '18:00' },
+            { dayOfWeek: 'Tuesday', opens: '08:30', closes: '18:00' },
+            { dayOfWeek: 'Wednesday', opens: '08:30', closes: '18:00' },
+            { dayOfWeek: 'Thursday', opens: '08:30', closes: '21:00' },
+            { dayOfWeek: 'Friday', opens: '08:30', closes: '18:00' },
+            { dayOfWeek: 'Saturday', opens: '09:30', closes: '18:00' },
+            { dayOfWeek: 'Sunday', opens: '10:00', closes: '18:00' },
+          ],
+          exceptional: [],
+        },
+      },
+      {
+        id: 'WsuaIB8AAH-yNylo',
+        order: 5,
+        name: 'Shop',
+        openingHours: {
+          regular: [
+            { dayOfWeek: 'Monday', opens: '09:00', closes: '18:00' },
+            { dayOfWeek: 'Tuesday', opens: '09:00', closes: '18:00' },
+            { dayOfWeek: 'Wednesday', opens: '09:00', closes: '18:00' },
+            { dayOfWeek: 'Thursday', opens: '09:00', closes: '21:00' },
+            { dayOfWeek: 'Friday', opens: '09:00', closes: '18:00' },
+            { dayOfWeek: 'Saturday', opens: '10:00', closes: '18:00' },
+            { dayOfWeek: 'Sunday', opens: '10:00', closes: '18:00' },
+          ],
+          exceptional: [],
+        },
+      },
+    ],
+  },
+};

--- a/common/views/components/Footer/Footer.js
+++ b/common/views/components/Footer/Footer.js
@@ -1,17 +1,17 @@
 // @flow
 import { useRef, useEffect } from 'react';
 import { font, grid, classNames } from '../../../utils/classnames';
-import { getTodaysVenueHours } from '@weco/common/services/prismic/opening-times';
 import FooterWellcomeLogo from '../FooterWellcomeLogo/FooterWellcomeLogo';
 import FooterNav from '../FooterNav/FooterNav';
 import FindUs from '../FindUs/FindUs';
-// TODO import OpeningHours from '../OpeningHours/OpeningHours';
 import FooterSocial from '../FooterSocial/FooterSocial';
 import Icon from '../Icon/Icon';
 import type { OverrideType } from '../../../model/opening-hours';
 import type Moment from 'moment';
 import styled from 'styled-components';
 import Space from '../styled/Space';
+// $FlowFixMe (tsx)
+import FooterOpeningTimes from '@weco/common/views/components/FooterOpeningTimes/FooterOpeningTimes';
 
 const TopBorderBox = styled.div`
   @media (min-width: ${props => props.theme.sizes.large}px) {
@@ -136,38 +136,13 @@ const Footer = ({
                       'no-margin': true,
                     })}
                   >{`Today's opening times`}</h4>
-                  <ul className="plain-list no-padding no-margin">
-                    {openingTimes.collectionOpeningTimes.placesOpeningHours.map(
-                      venue => {
-                        const todaysHours = getTodaysVenueHours(venue);
-                        return (
-                          todaysHours && (
-                            <Space
-                              v={{
-                                size: 's',
-                                properties: ['margin-top'],
-                              }}
-                              as="li"
-                              key={venue.name}
-                            >
-                              {venue.name.toLowerCase() === 'restaurant'
-                                ? 'Kitchen '
-                                : `${venue.name} `}
-                              {todaysHours.opens ? (
-                                <>
-                                  <time>{todaysHours.opens}</time>
-                                  {'—'}
-                                  <time>{todaysHours.closes}</time>
-                                </>
-                              ) : (
-                                'closed'
-                              )}
-                            </Space>
-                          )
-                        );
+                  {openingTimes && openingTimes?.collectionOpeningTimes && (
+                    <FooterOpeningTimes
+                      collectionOpeningTimes={
+                        openingTimes.collectionOpeningTimes
                       }
-                    )}
-                  </ul>
+                    />
+                  )}
                   <Space v={{ size: 's', properties: ['margin-top'] }} as="p">
                     <a href="/opening-times">Opening times</a>
                   </Space>

--- a/common/views/components/FooterOpeningTimes/FooterOpeningTimes.test.js
+++ b/common/views/components/FooterOpeningTimes/FooterOpeningTimes.test.js
@@ -1,0 +1,85 @@
+import FooterOpeningTimes from './FooterOpeningTimes';
+import {
+  shallowWithTheme,
+  mountWithTheme,
+} from '../../../test/fixtures/enzyme-helpers';
+import { openingTimes } from '../../../test/fixtures/components/opening-times';
+
+describe('FooterOpeningTimes', () => {
+  const component = shallowWithTheme(
+    <FooterOpeningTimes
+      collectionOpeningTimes={openingTimes.collectionOpeningTimes}
+    />
+  );
+
+  const componentHtml = component.html();
+  it('Should match snapshot of FooterOpeningTimes', () => {
+    expect(componentHtml).toMatchSnapshot();
+  });
+
+  it('Should display opening times name restaurant as Kitchen', () => {
+    expect(componentHtml.match('Kitchen '));
+  });
+
+  it('Should not display render any opening times if opening times are empty', () => {
+    const mockOpeningTimes = {
+      collectionOpeningTimes: {
+        placesOpeningHours: [
+          {
+            id: 'WsuaIB8AAH-yNylo',
+            order: 5,
+            name: 'Shop',
+            openingHours: {
+              regular: [],
+              exceptional: [],
+            },
+          },
+        ],
+      },
+    };
+
+    const component = mountWithTheme(
+      <FooterOpeningTimes
+        collectionOpeningTimes={mockOpeningTimes.collectionOpeningTimes}
+      />
+    );
+
+    const footerOpeningTimes = component.find('ul');
+    expect(footerOpeningTimes.length).toEqual(1);
+    expect(footerOpeningTimes.find('li').length).toEqual(0);
+  });
+
+  it('Should render venue opening times as closed', () => {
+    const mockOpeningTimes = {
+      collectionOpeningTimes: {
+        placesOpeningHours: [
+          {
+            id: 'WsuaIB8AAH-yNylo',
+            order: 5,
+            name: 'Shop',
+            openingHours: {
+              regular: [
+                { dayOfWeek: 'Monday', opens: null, closes: null },
+                { dayOfWeek: 'Tuesday', opens: null, closes: null },
+                { dayOfWeek: 'Wednesday', opens: null, closes: null },
+                { dayOfWeek: 'Thursday', opens: null, closes: null },
+                { dayOfWeek: 'Friday', opens: null, closes: null },
+                { dayOfWeek: 'Saturday', opens: null, closes: null },
+                { dayOfWeek: 'Sunday', opens: null, closes: null },
+              ],
+              exceptional: [],
+            },
+          },
+        ],
+      },
+    };
+
+    const component = shallowWithTheme(
+      <FooterOpeningTimes
+        collectionOpeningTimes={mockOpeningTimes.collectionOpeningTimes}
+      />
+    );
+
+    expect(component.html().match('Shop closed')).toBeTruthy();
+  });
+});

--- a/common/views/components/FooterOpeningTimes/FooterOpeningTimes.tsx
+++ b/common/views/components/FooterOpeningTimes/FooterOpeningTimes.tsx
@@ -1,0 +1,46 @@
+import { getTodaysVenueHours } from '@weco/common/services/prismic/opening-times';
+import Space from '../styled/Space';
+import { CollectionOpeningTimes } from '@weco/common/model/opening-hours';
+import { collectionVenueId, getNameFromCollectionVenue } from '@weco/common/services/prismic/hardcoded-id';
+
+type Props = {
+    collectionOpeningTimes: CollectionOpeningTimes
+};
+
+const FooterOpeningTimes = ({ collectionOpeningTimes } : Props) => {
+    return (
+        <ul className="plain-list no-padding no-margin">
+        {collectionOpeningTimes.placesOpeningHours.map(
+          venue => {
+            const todaysHours = getTodaysVenueHours(venue);
+            return (
+              todaysHours && (
+                <Space
+                  v={{
+                    size: 's',
+                    properties: ['margin-top'],
+                  }}
+                  as="li"
+                  key={venue.id}
+                >
+                  {venue.id === collectionVenueId.restaurant.id
+                    ? 'Kitchen '
+                    : `${getNameFromCollectionVenue(venue.id)} `}
+                  {todaysHours.opens ? (
+                    <>
+                      <time>{todaysHours.opens}</time>
+                      {'—'}
+                      <time>{todaysHours.closes}</time>
+                    </>
+                  ) : (
+                    'closed'
+                  )}
+                </Space>
+              )
+            );
+          }
+        )}
+      </ul>
+    );
+};
+export default FooterOpeningTimes;

--- a/common/views/components/FooterOpeningTimes/__snapshots__/FooterOpeningTimes.test.js.snap
+++ b/common/views/components/FooterOpeningTimes/__snapshots__/FooterOpeningTimes.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FooterOpeningTimes Should match snapshot of FooterOpeningTimes 1`] = `"<ul class=\\"plain-list no-padding no-margin\\"><li class=\\"Space-sc-4az8w3-0 iJQveI\\">Galleries <time>10:00</time>—<time>18:00</time></li><li class=\\"Space-sc-4az8w3-0 iJQveI\\">Library <time>10:00</time>—<time>18:00</time></li><li class=\\"Space-sc-4az8w3-0 iJQveI\\">Kitchen <time>11:00</time>—<time>18:00</time></li><li class=\\"Space-sc-4az8w3-0 iJQveI\\">Café <time>08:30</time>—<time>18:00</time></li><li class=\\"Space-sc-4az8w3-0 iJQveI\\">Shop <time>09:00</time>—<time>18:00</time></li></ul>"`;

--- a/common/views/components/LandingBody/VisitUsStaticContent.js
+++ b/common/views/components/LandingBody/VisitUsStaticContent.js
@@ -1,5 +1,4 @@
 import { classNames, font, grid } from '@weco/common/utils/classnames';
-import { getTodaysVenueHours } from '@weco/common/services/prismic/opening-times';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import OpeningTimesContext from '@weco/common/views/components/OpeningTimesContext/OpeningTimesContext';
 import FindUs from '@weco/common/views/components/FindUs/FindUs';
@@ -7,6 +6,7 @@ import SpacingSection from '../SpacingSection/SpacingSection';
 import SpacingComponent from '../SpacingComponent/SpacingComponent';
 import Space from '@weco/common/views/components/styled/Space';
 import Layout8 from '../Layout8/Layout8';
+import FooterOpeningTimes from '@weco/common/views/components/FooterOpeningTimes/FooterOpeningTimes';
 
 type ContainerProps = {|
   children: any,
@@ -61,38 +61,11 @@ const VisitUsStaticContent = () => (
                     'no-margin': true,
                   })}
                 >{`Today's opening times`}</h2>
-                <ul className="plain-list no-padding no-margin">
-                  {openingTimes.collectionOpeningTimes.placesOpeningHours.map(
-                    venue => {
-                      const todaysHours = getTodaysVenueHours(venue);
-                      return (
-                        todaysHours && (
-                          <Space
-                            v={{
-                              size: 's',
-                              properties: ['margin-top'],
-                            }}
-                            as="li"
-                            key={venue.name}
-                          >
-                            {venue.name.toLowerCase() === 'restaurant'
-                              ? 'Kitchen '
-                              : `${venue.name} `}
-                            {todaysHours.opens ? (
-                              <>
-                                <time>{todaysHours.opens}</time>
-                                {'—'}
-                                <time>{todaysHours.closes}</time>
-                              </>
-                            ) : (
-                              'closed'
-                            )}
-                          </Space>
-                        )
-                      );
-                    }
-                  )}
-                </ul>
+                {openingTimes && openingTimes?.collectionOpeningTimes && (
+                  <FooterOpeningTimes
+                    collectionOpeningTimes={openingTimes.collectionOpeningTimes}
+                  />
+                )}
                 <Space
                   v={{
                     size: 's',

--- a/common/views/components/VenueClosedPeriods/VenueClosedPeriods.js
+++ b/common/views/components/VenueClosedPeriods/VenueClosedPeriods.js
@@ -9,7 +9,10 @@ import {
 } from '../../../services/prismic/opening-times';
 import { formatDayDate } from '@weco/common/utils/format-date';
 import OpeningTimesContext from '@weco/common/views/components/OpeningTimesContext/OpeningTimesContext';
-
+import {
+  collectionVenueId,
+  getNameFromCollectionVenue,
+} from '@weco/common/services/prismic/hardcoded-id';
 type Props = {|
   venue: Venue,
 |};
@@ -27,12 +30,11 @@ const VenueClosedPeriods = ({ venue }: Props) => {
   const groupedConsectiveClosedDays = onlyClosedDays
     ? groupConsecutiveDays(onlyClosedDays)
     : [[]];
-
   return groupedConsectiveClosedDays[0] &&
     groupedConsectiveClosedDays[0].length > 0 ? (
     <div className="body-text">
-      <h2>{venue.name} closures</h2>
-      {venue.name.toLowerCase() === 'library' && (
+      <h2>{getNameFromCollectionVenue(venue.id)} closures</h2>
+      {venue.id === collectionVenueId.libraries.id && (
         <p className="no-margin">
           Planning a research visit? Our library is closed over bank holiday
           weekends and between Christmas Eve and New Year{`'`}s Day:

--- a/common/views/pages/_app.js
+++ b/common/views/pages/_app.js
@@ -366,11 +366,11 @@ export default class WecoApp extends App {
     // Interim solution : Getting openingHours by hardcoded id rather than name just in case contracts may break when editors make changes
     const galleries = getParseCollectionVenueById(
       parsedOpeningTimes,
-      collectionVenueId.galleries
+      collectionVenueId.galleries.id
     );
     const library = getParseCollectionVenueById(
       parsedOpeningTimes,
-      collectionVenueId.libraries
+      collectionVenueId.libraries.id
     );
     const galleriesOpeningHours = galleries && galleries.openingHours;
     const libraryOpeningHours = library && library.openingHours;

--- a/content/webapp/pages/whats-on.js
+++ b/content/webapp/pages/whats-on.js
@@ -54,12 +54,12 @@ type Props = {|
 function getListHeader(openingTimes: any) {
   const galleriesOpeningTimes = getParseCollectionVenueById(
     openingTimes,
-    collectionVenueId.galleries
+    collectionVenueId.galleries.id
   );
 
   return {
     todayOpeningHours: getTodaysGalleriesHours(
-      galleriesOpeningTimes.openingHours
+      galleriesOpeningTimes.openingHours.id
     ),
     name: "What's on",
     items: [

--- a/content/webapp/pages/whats-on.js
+++ b/content/webapp/pages/whats-on.js
@@ -39,6 +39,8 @@ import { exhibitionLd, eventLd } from '@weco/common/utils/json-ld';
 import { convertImageUri } from '@weco/common/utils/convert-image-uri';
 import Space from '@weco/common/views/components/styled/Space';
 import { FeaturedCardExhibition } from '@weco/common/views/components/FeaturedCard/FeaturedCard';
+import { getParseCollectionVenueById } from '@weco/common/services/prismic/opening-times';
+import { collectionVenueId } from '@weco/common/services/prismic/hardcoded-id';
 
 type Props = {|
   exhibitions: PaginatedResults<UiExhibition>,
@@ -49,14 +51,16 @@ type Props = {|
   eatShopPromos: any[],
 |};
 
-function getListHeader(collectionOpeningTimes: any = {}) {
-  const galleriesOpeningTimes =
-    collectionOpeningTimes.placesOpeningHours.length > 1 &&
-    collectionOpeningTimes.placesOpeningHours.find(
-      venue => venue.name === 'Galleries'
-    ).openingHours;
+function getListHeader(openingTimes: any) {
+  const galleriesOpeningTimes = getParseCollectionVenueById(
+    openingTimes,
+    collectionVenueId.galleries
+  );
+
   return {
-    todayOpeningHours: getTodaysGalleriesHours(galleriesOpeningTimes),
+    todayOpeningHours: getTodaysGalleriesHours(
+      galleriesOpeningTimes.openingHours
+    ),
     name: "What's on",
     items: [
       {
@@ -198,9 +202,7 @@ type HeaderProps = {|
   openingTimes: any, // TODO
 |};
 const Header = ({ activeId, openingTimes }: HeaderProps) => {
-  const collectionOpeningTimes =
-    openingTimes && openingTimes.collectionOpeningTimes;
-  const listHeader = getListHeader(collectionOpeningTimes);
+  const listHeader = getListHeader(openingTimes);
   const todayOpeningHours = listHeader.todayOpeningHours;
 
   return (


### PR DESCRIPTION
*  Not allow, Footer collection venue opening times names dynamic.
*  Replace name and using id to find openingTimes on whats-on.

@jamesgorrie @gestchild @davidpmccormick  - I have done some regression, seems to be all rendering fine. 
* visit-us 
* footer page
* opening-times page
Let me know if you think i would need to introduce any unit testing in any parts of the code I have implemented.

Effected pages: 

- VisitUsStaticContent
- Footer.js 
- whats-on.js 
- VenueClosedPeriods