### PR TITLE
Add background and color to noscript

### DIFF
--- a/common/styles/base/_layout.scss
+++ b/common/styles/base/_layout.scss
@@ -37,4 +37,11 @@ $tweakpoints: (
 // Without the width specified below it can cause issues with centering of the images, such as on the work page
 noscript {
   width: 100%;
+  background: color('white');
+  color: color('black');
+  display: inline-block;
+
+  .image {
+    display: block;
+  }
 }


### PR DESCRIPTION
Fixing an error on the [pa11y dashboard](https://dash.wellcomecollection.org/pa11y/) regarding color/background contrast on the `noscript` elements.
