### PR TITLE
Start tests for pages (parsePage:parseOnThisPage)

### DIFF
--- a/common/services/prismic/pages.js
+++ b/common/services/prismic/pages.js
@@ -48,7 +48,7 @@ export function parsePage(document: PrismicDocument): Page {
   return {
     type: 'pages',
     ...genericFields,
-    onThisPage: parseOnThisPage(data.body),
+    onThisPage: data.body ? parseOnThisPage(data.body) : [],
     showOnThisPage: data.showOnThisPage || false,
     promo: promo && promo.image ? promo : drupalisedPromo,
     datePublished: data.datePublished && parseTimestamp(data.datePublished),

--- a/common/test/fixtures/pages/page.js
+++ b/common/test/fixtures/pages/page.js
@@ -1,0 +1,12 @@
+export const pageWithoutBody = {
+  tags: [],
+  data: {
+    title: [[Object]],
+    datePublished: null,
+    showOnThisPage: null,
+    metadataDescription: [],
+    drupalPromoImage: { link_type: 'Web' },
+    drupalNid: null,
+    drupalPath: null,
+  },
+};

--- a/common/test/services/prismic/pages.test.js
+++ b/common/test/services/prismic/pages.test.js
@@ -1,0 +1,14 @@
+import { parsePage } from '../../../services/prismic/pages';
+import { pageWithoutBody } from '../../fixtures/pages/page';
+
+describe('pages', () => {
+  describe('parsePage', () => {
+    describe('parseOnThisPage', () => {
+      it(`Object onThisPage should return [] if body does not exist`, () => {
+        const page = parsePage(pageWithoutBody);
+        expect(Array.isArray(page.onThisPage)).toBeTruthy();
+        expect(page.onThisPage.length).toBe(0);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Who is this for?
People who want pages to not break

## What is it doing for them?
Testing that the body exists before trying to parse it.

I feel like typing could/should probably help here too (`body` can be undefined, but this isn't expressed in our GenericFields). Will open a different ticket for that.