### PR TITLE
use prefers-reduce-motion media query to stop wobbly line animation

### DIFF
--- a/common/styles/components/_wobbly_edge.scss
+++ b/common/styles/components/_wobbly_edge.scss
@@ -7,6 +7,7 @@
   transition: -webkit-clip-path 2000ms ease-in-out, clip-path 2000ms ease-in-out;
   display: none;
 
+
   @include respond-to('large') {
     max-height: 60px;
     margin-top: -60px;
@@ -15,6 +16,9 @@
   @supports ((clip-path: polygon(0 0)) or (-webkit-clip-path: polygon(0 0))) {
     .enhanced & {
       display: block;
+      @media screen and (prefers-reduced-motion: reduce) {
+        display: none;
+      }
     }
   }
 }


### PR DESCRIPTION
Prevents the wobbly line animation, if users have specified a preference for reduced motion in system settings, in accordance with [Success Criterion 2.3.3 Animation from Interactions (Level AAA)](https://www.w3.org/TR/WCAG21/#animation-from-interactions)
