### PR TITLE
Fix breadcrumb

### DIFF
--- a/common/utils/works.js
+++ b/common/utils/works.js
@@ -274,10 +274,10 @@ function makeArchiveAncestorArray(partOfArray, nextPart) {
   if (!nextPart) return partOfArray;
   return makeArchiveAncestorArray(
     [...partOfArray, parsePart(nextPart)],
-    nextPart.partOf && nextPart.partOf[0]
+    nextPart?.partOf?.[0]
   );
 }
 
 export function getArchiveAncestorArray(work: Work): NodeWork[] {
-  return makeArchiveAncestorArray([], work.partOf && work.partOf[0]).reverse();
+  return makeArchiveAncestorArray([], work?.partOf?.[0]).reverse();
 }

--- a/common/utils/works.js
+++ b/common/utils/works.js
@@ -274,10 +274,7 @@ function makeArchiveAncestorArray(partOfArray, nextPart) {
   if (!nextPart) return partOfArray;
   return makeArchiveAncestorArray(
     [...partOfArray, parsePart(nextPart)],
-    nextPart.partOf &&
-      nextPart.partOf.find(part => {
-        return nextPart.referenceNumber.includes(part.referenceNumber);
-      })
+    nextPart.partOf && nextPart.partOf[0]
   );
 }
 


### PR DESCRIPTION
Fixes #5675

We were deciding which partOf item to use as the parent work based on referenceNumber, but it looks like they don't always follow the same pattern.

At the moment there is only ever one item in the partOf array, so we can just get the first one.

If in the future partOf contains more than one item, we’ll need a way to discern which one is correct
