### PR TITLE
Only show filters if there's a query

### DIFF
--- a/common/views/components/PrototypeSearchForm/PrototypeSearchForm.tsx
+++ b/common/views/components/PrototypeSearchForm/PrototypeSearchForm.tsx
@@ -232,16 +232,18 @@ const PrototypeSearchForm = ({
         </SearchInputWrapper>
       </Space>
 
-      <SearchFilters
-        searchForm={searchForm}
-        worksRouteProps={routeProps}
-        workTypeAggregations={workTypeAggregations}
-        changeHandler={submit}
-        aggregations={aggregations}
-        filtersToShow={
-          isImageSearch ? ['colors'] : ['dates', 'formats', 'locations']
-        }
-      />
+      {query && (
+        <SearchFilters
+          searchForm={searchForm}
+          worksRouteProps={routeProps}
+          workTypeAggregations={workTypeAggregations}
+          changeHandler={submit}
+          aggregations={aggregations}
+          filtersToShow={
+            isImageSearch ? ['colors'] : ['dates', 'formats', 'locations']
+          }
+        />
+      )}
       {!isImageSearch && (
         <PrototypePortal id="sort-select-portal">
           <Select


### PR DESCRIPTION
We only want filters to display once a search has been run.
