### PR TITLE
update qs to toggle to stop conflicting issue with toggles on _app.js…

### DIFF
--- a/cache/cloudfront_prod.tf
+++ b/cache/cloudfront_prod.tf
@@ -73,7 +73,7 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
         "page",
         "result",
         "uri",
-        "toggles",
+        "toggle",
       ]
 
       cookies {
@@ -127,7 +127,7 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
         "query",
         "sierraId",
         "workType",
-        "toggles",
+        "toggle",
       ]
 
       cookies {

--- a/cache/cloudfront_stage.tf
+++ b/cache/cloudfront_stage.tf
@@ -43,7 +43,7 @@ resource "aws_cloudfront_distribution" "stage_wc_org" {
         "page",
         "result",
         "uri",
-        "toggles",
+        "toggle",
       ]
 
       cookies {
@@ -97,7 +97,7 @@ resource "aws_cloudfront_distribution" "stage_wc_org" {
         "query",
         "sierraId",
         "workType",
-        "toggles",
+        "toggle",
       ]
 
       cookies {

--- a/common/koa-middleware/tests/withToggles.test.js
+++ b/common/koa-middleware/tests/withToggles.test.js
@@ -73,7 +73,7 @@ describe('withToggles', () => {
       const ctx = {
         ...defaultCtx,
         query: {
-          toggles: 'modalFiltersPrototype',
+          toggle: 'modalFiltersPrototype',
         },
       };
 
@@ -89,7 +89,7 @@ describe('withToggles', () => {
       const ctx = {
         ...defaultCtx,
         query: {
-          toggles: '!modalFiltersPrototype',
+          toggle: '!modalFiltersPrototype',
         },
       };
 
@@ -103,7 +103,7 @@ describe('withToggles', () => {
       const ctxMockFeatureToggleOff = {
         ...defaultCtx,
         query: {
-          toggles: '!dummyNameFeatureToggle',
+          toggle: '!dummyNameFeatureToggle',
         },
       };
 
@@ -113,7 +113,7 @@ describe('withToggles', () => {
       const ctxMockFeatureToggleOn = {
         ...defaultCtx,
         query: {
-          toggles: 'dummyFeatureToggle',
+          toggle: 'dummyFeatureToggle',
         },
       };
 

--- a/common/koa-middleware/withToggles.js
+++ b/common/koa-middleware/withToggles.js
@@ -58,8 +58,8 @@ function withToggles(ctx, next) {
 
 function enableDisableToggle(ctx) {
   if (ctx && ctx.toggles) {
-    if (ctx.query.toggles) {
-      const reqFeatureToggle = ctx.query.toggles;
+    if (ctx.query.toggle) {
+      const reqFeatureToggle = ctx.query.toggle;
       const validFeatureToggle = validToggle(ctx.toggles, reqFeatureToggle);
       const stateFeatureToggle = !reqFeatureToggle.startsWith('!');
       const cookieName = stateFeatureToggle


### PR DESCRIPTION
_app.js uses query string toggles which allows to override context. 
Ive just changing the toggles to toggle query string and also the functionality of the feature for now only allows you to set one. 

## Who is this for?


## What is it doing for them?
