### PR TITLE
Break sort/pagination controls onto another line where necessary

### DIFF
--- a/catalogue/webapp/pages/images.tsx
+++ b/catalogue/webapp/pages/images.tsx
@@ -44,28 +44,30 @@ const ImagesPagination = ({
   imagesRouteProps,
   setSavedSearchState,
 }) => (
-  <Paginator
-    query={query}
-    currentPage={page || 1}
-    pageSize={results.pageSize}
-    totalResults={results.totalResults}
-    link={imagesLink(
-      {
-        ...imagesRouteProps,
-      },
-      'search/paginator'
-    )}
-    onPageChange={async (event, newPage) => {
-      event.preventDefault();
-      const state = {
-        ...imagesRouteProps,
-        page: newPage,
-      };
-      const link = imagesLink(state, 'search/paginator');
-      setSavedSearchState(state);
-      Router.push(link.href, link.as).then(() => window.scrollTo(0, 0));
-    }}
-  />
+  <div className="flex flex--h-space-between flex--v-center flex--wrap">
+    <Paginator
+      query={query}
+      currentPage={page || 1}
+      pageSize={results.pageSize}
+      totalResults={results.totalResults}
+      link={imagesLink(
+        {
+          ...imagesRouteProps,
+        },
+        'search/paginator'
+      )}
+      onPageChange={async (event, newPage) => {
+        event.preventDefault();
+        const state = {
+          ...imagesRouteProps,
+          page: newPage,
+        };
+        const link = imagesLink(state, 'search/paginator');
+        setSavedSearchState(state);
+        Router.push(link.href, link.as).then(() => window.scrollTo(0, 0));
+      }}
+    />
+  </div>
 );
 
 const Images = ({ results, imagesRouteProps, apiProps }: Props) => {
@@ -187,15 +189,13 @@ const Images = ({ results, imagesRouteProps, apiProps }: Props) => {
                       [grid({ s: 12, m: 12, l: 12, xl: 12 })]: true,
                     })}
                   >
-                    <div className="flex flex--h-space-between flex--v-center">
-                      <ImagesPagination
-                        query={query}
-                        page={page}
-                        results={results}
-                        imagesRouteProps={imagesRouteProps}
-                        setSavedSearchState={setSavedSearchState}
-                      />
-                    </div>
+                    <ImagesPagination
+                      query={query}
+                      page={page}
+                      results={results}
+                      imagesRouteProps={imagesRouteProps}
+                      setSavedSearchState={setSavedSearchState}
+                    />
                   </div>
                 </div>
               </div>
@@ -230,15 +230,13 @@ const Images = ({ results, imagesRouteProps, apiProps }: Props) => {
                         [grid({ s: 12, m: 12, l: 12, xl: 12 })]: true,
                       })}
                     >
-                      <div className="flex flex--h-space-between flex--v-center">
-                        <ImagesPagination
-                          query={query}
-                          page={page}
-                          results={results}
-                          imagesRouteProps={imagesRouteProps}
-                          setSavedSearchState={setSavedSearchState}
-                        />
-                      </div>
+                      <ImagesPagination
+                        query={query}
+                        page={page}
+                        results={results}
+                        imagesRouteProps={imagesRouteProps}
+                        setSavedSearchState={setSavedSearchState}
+                      />
                     </div>
                   </div>
                 </div>

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -234,7 +234,7 @@ const Works = ({ works, images, worksRouteProps, apiProps }: Props) => {
                       [grid({ s: 12, m: 12, l: 12, xl: 12 })]: true,
                     })}
                   >
-                    <div className="flex flex--h-space-between flex--v-center">
+                    <div className="flex flex--h-space-between flex--v-center flex--wrap">
                       <Fragment>
                         <Paginator
                           query={searchPrototype ? query : undefined}
@@ -309,7 +309,7 @@ const Works = ({ works, images, worksRouteProps, apiProps }: Props) => {
                         [grid({ s: 12, m: 12, l: 12, xl: 12 })]: true,
                       })}
                     >
-                      <div className="flex flex--h-space-between flex--v-center">
+                      <div className="flex flex--h-space-between flex--v-center flex--wrap">
                         <Fragment>
                           <Paginator
                             query={query}

--- a/common/views/components/Paginator/Paginator.js
+++ b/common/views/components/Paginator/Paginator.js
@@ -77,10 +77,13 @@ const Paginator = ({
 
   return (
     <Fragment>
-      <div className={`flex flex--v-center ${font('hnm', 3)}`}>
+      <Space
+        h={{ size: 'm', properties: ['margin-right'] }}
+        className={`flex flex--v-center ${font('hnm', 3)}`}
+      >
         {totalResults} result{totalResults !== 1 ? 's' : ''}
         {query && ` for “${query}”`}
-      </div>
+      </Space>
       <div
         className={classNames({
           pagination: true,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1394592/98019505-bbd08800-1df9-11eb-86ee-5b80332dfa9b.png)

This was the least required to make sure the controls don't look broken for the prototype on mobile, without changing the appearance in production.