### PR TITLE
Don't render portal on /images route

### DIFF
--- a/catalogue/webapp/pages/images.tsx
+++ b/catalogue/webapp/pages/images.tsx
@@ -39,7 +39,6 @@ type Props = {
 
 const ImagesPagination = ({
   query,
-  showPortal,
   page,
   results,
   imagesRouteProps,
@@ -48,7 +47,7 @@ const ImagesPagination = ({
   <div className="flex flex--h-space-between flex--v-center flex--wrap">
     <Paginator
       query={query}
-      showPortal={showPortal}
+      showPortal={false}
       currentPage={page || 1}
       pageSize={results.pageSize}
       totalResults={results.totalResults}
@@ -193,7 +192,6 @@ const Images = ({ results, imagesRouteProps, apiProps }: Props) => {
                   >
                     <ImagesPagination
                       query={query}
-                      showPortal={true}
                       page={page}
                       results={results}
                       imagesRouteProps={imagesRouteProps}
@@ -235,7 +233,6 @@ const Images = ({ results, imagesRouteProps, apiProps }: Props) => {
                     >
                       <ImagesPagination
                         query={query}
-                        showPortal={false}
                         page={page}
                         results={results}
                         imagesRouteProps={imagesRouteProps}


### PR DESCRIPTION
We don't want the 'sort by' `Select` to render for image searches (because it doesn't work).
