### PR TITLE
Hide SearchTabs until JS fires

### DIFF
--- a/common/views/components/BaseTabs/BaseTabs.tsx
+++ b/common/views/components/BaseTabs/BaseTabs.tsx
@@ -7,7 +7,6 @@ import {
   useEffect,
 } from 'react';
 import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
-import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
 import styled from 'styled-components';
 import { classNames } from '@weco/common/utils/classnames';
 
@@ -70,7 +69,6 @@ const Tabs = ({
   const [activeId, setActiveId] = useState(tabs[activeTabIndex || 0].id);
   const [focusedId, setFocusedId] = useState(null);
   const { isEnhanced } = useContext(AppContext);
-  const { searchPrototype } = useContext(TogglesContext);
   const tabListRef = useRef(null);
   const handleTabClick = useCallback(
     (tabId: string) => {
@@ -162,7 +160,7 @@ const Tabs = ({
           key={id}
           id={id}
           isActive={id === activeId}
-          isEnhanced={isEnhanced || searchPrototype}
+          isEnhanced={isEnhanced}
         >
           {!isEnhanced && tab(id === activeId, id === focusedId)}
           {tabPanel}

--- a/common/views/components/SearchTabs/SearchTabs.tsx
+++ b/common/views/components/SearchTabs/SearchTabs.tsx
@@ -16,7 +16,11 @@ import {
 } from '@weco/common/model/catalogue';
 import { trackEvent } from '@weco/common/utils/ga';
 
-const BaseTabsWrapper = styled.div`
+const BaseTabsWrapper = styled.div.attrs<{ isEnhanced: boolean }>(props => ({
+  className: classNames({
+    'is-hidden': !props.isEnhanced,
+  }),
+}))<{ isEnhanced: boolean }>`
   // FIXME: For testing, make the checkboxes/buttons have a white background because they're on grey
   [class*='ButtonInline__InlineButton'],
   [class^='CheckboxRadio__CheckboxRadioBox'] {
@@ -78,7 +82,7 @@ const SearchTabs = ({
   shouldShowDescription,
   activeTabIndex,
 }: Props) => {
-  const { isKeyboard } = useContext(AppContext);
+  const { isKeyboard, isEnhanced } = useContext(AppContext);
   const [activeTab, setActiveTab] = useState(
     activeTabIndex === 0 ? 'tab-library-catalogue' : 'tab-images'
   );
@@ -168,7 +172,7 @@ const SearchTabs = ({
   }
 
   return (
-    <BaseTabsWrapper>
+    <BaseTabsWrapper isEnhanced={isEnhanced}>
       <BaseTabs
         tabs={tabs}
         label={'Tabs for search'}


### PR DESCRIPTION
Taking logic for preventing a flash out of the `BaseTabs` component and into a place where we're already expecting prototype code.
