### PR TITLE
Add an Updown check for redirects on wellcomeimages.org

### DIFF
--- a/updown/webapp/expected-checks.js
+++ b/updown/webapp/expected-checks.js
@@ -101,6 +101,12 @@ const expectedChecks = [
     alias: 'Front End Works Search (Cached)',
     period: 120,
   },
+  {
+    url: 'https://wellcomeimages.org/indexplus/image/L0030772.html',
+    alias: 'Wellcome Images Redirect',
+    period: 120,
+    note: 'This is from Wikimedia Commons linking to Wellcome Images: https://commons.wikimedia.org/wiki/File:S._Pinaeus,_De_integritatis_et_corruptionis_virginum..._Wellcome_L0030772.jpg'
+  },
 ];
 
 export default expectedChecks;

--- a/updown/webapp/package.json
+++ b/updown/webapp/package.json
@@ -7,5 +7,6 @@
   "dependencies": {
     "aws-sdk": "^2.777.0",
     "updown.io": "^3.0.0"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/platform/issues/4860

This means we should be alerted if/when wellcomeimages.org redirects break in future. This change is applied.