### PR TITLE
Don't focus Modal button on initial render

### DIFF
--- a/catalogue/webapp/test/components/__snapshots__/WorkDetails.test.js.snap
+++ b/catalogue/webapp/test/components/__snapshots__/WorkDetails.test.js.snap
@@ -390,7 +390,7 @@ exports[`Feature: 2. As a library member I want to request an item Scenario: I'm
                 >
                   <button
                     class="Space-sc-4az8w3-0 Modal__CloseButton-sc-12234yr-1 fXXAZK"
-                    data-test-id="close-modal-button"
+                    role="button"
                   >
                     <span
                       class="visually-hidden"
@@ -540,13 +540,13 @@ exports[`Feature: 2. As a library member I want to request an item Scenario: I'm
                       "attrs": Array [
                         Object {
                           "as": "button",
-                          "data-test-id": "close-modal-button",
                           "h": Object {
                             "properties": Array [
                               "left",
                             ],
                             "size": "m",
                           },
+                          "role": "button",
                           "v": Object {
                             "properties": Array [
                               "top",
@@ -587,7 +587,7 @@ exports[`Feature: 2. As a library member I want to request an item Scenario: I'm
                     Object {
                       "current": <button
                         class="Space-sc-4az8w3-0 Modal__CloseButton-sc-12234yr-1 fXXAZK"
-                        data-test-id="close-modal-button"
+                        role="button"
                       >
                         <span
                           class="visually-hidden"
@@ -620,8 +620,8 @@ exports[`Feature: 2. As a library member I want to request an item Scenario: I'm
                 >
                   <button
                     className="Space-sc-4az8w3-0 Modal__CloseButton-sc-12234yr-1 fXXAZK"
-                    data-test-id="close-modal-button"
                     onClick={[Function]}
+                    role="button"
                   >
                     <span
                       className="visually-hidden"

--- a/catalogue/webapp/test/components/__snapshots__/WorkDetails.test.js.snap
+++ b/catalogue/webapp/test/components/__snapshots__/WorkDetails.test.js.snap
@@ -390,6 +390,7 @@ exports[`Feature: 2. As a library member I want to request an item Scenario: I'm
                 >
                   <button
                     class="Space-sc-4az8w3-0 Modal__CloseButton-sc-12234yr-1 fXXAZK"
+                    data-test-id="close-modal-button"
                   >
                     <span
                       class="visually-hidden"
@@ -539,6 +540,7 @@ exports[`Feature: 2. As a library member I want to request an item Scenario: I'm
                       "attrs": Array [
                         Object {
                           "as": "button",
+                          "data-test-id": "close-modal-button",
                           "h": Object {
                             "properties": Array [
                               "left",
@@ -585,6 +587,7 @@ exports[`Feature: 2. As a library member I want to request an item Scenario: I'm
                     Object {
                       "current": <button
                         class="Space-sc-4az8w3-0 Modal__CloseButton-sc-12234yr-1 fXXAZK"
+                        data-test-id="close-modal-button"
                       >
                         <span
                           class="visually-hidden"
@@ -617,6 +620,7 @@ exports[`Feature: 2. As a library member I want to request an item Scenario: I'm
                 >
                   <button
                     className="Space-sc-4az8w3-0 Modal__CloseButton-sc-12234yr-1 fXXAZK"
+                    data-test-id="close-modal-button"
                     onClick={[Function]}
                   >
                     <span

--- a/common/views/components/Modal/Modal.js
+++ b/common/views/components/Modal/Modal.js
@@ -35,6 +35,7 @@ const Overlay = styled.div`
 `;
 
 const CloseButton = styled(Space).attrs({
+  'data-test-id': 'close-modal-button',
   as: 'button',
   v: { size: 'm', properties: ['top'] },
   h: { size: 'm', properties: ['left'] },

--- a/common/views/components/Modal/Modal.js
+++ b/common/views/components/Modal/Modal.js
@@ -35,7 +35,7 @@ const Overlay = styled.div`
 `;
 
 const CloseButton = styled(Space).attrs({
-  'data-test-id': 'close-modal-button',
+  role: 'button',
   as: 'button',
   v: { size: 'm', properties: ['top'] },
   h: { size: 'm', properties: ['left'] },

--- a/common/views/components/Modal/Modal.js
+++ b/common/views/components/Modal/Modal.js
@@ -154,6 +154,11 @@ const Modal = ({
     lastFocusableRef.current = newRef;
   }
 
+  function closeModal() {
+    setIsActive(false);
+    openButtonRef && openButtonRef.current && openButtonRef.current.focus();
+  }
+
   useEffect(() => {
     const focusables = modalRef &&
       modalRef.current && [...getFocusableElements(modalRef.current)];
@@ -164,16 +169,13 @@ const Modal = ({
     if (isActive && closeButtonRef && closeButtonRef.current) {
       closeButtonRef.current.focus();
     }
-    if (!isActive && openButtonRef && openButtonRef.current) {
-      openButtonRef.current.focus();
-    }
   }, [isActive]);
 
   useEffect(() => {
     function closeOnEscape(event: KeyboardEvent) {
       if (event.key !== 'Escape') return;
 
-      setIsActive(false);
+      closeModal();
     }
 
     document.addEventListener('keydown', closeOnEscape);
@@ -195,12 +197,12 @@ const Modal = ({
 
   return (
     <>
-      {isActive && <Overlay onClick={() => setIsActive(false)} />}
+      {isActive && <Overlay onClick={closeModal} />}
       <CSSTransition in={isActive} classNames="fade" timeout={350}>
         <ModalWindow ref={modalRef} width={width} id={id} hidden={!isActive}>
           <CloseButton
             ref={closeButtonRef}
-            onClick={() => setIsActive(false)}
+            onClick={closeModal}
             hideFocus={!isKeyboard}
           >
             <span className="visually-hidden">Close modal window</span>

--- a/common/views/components/Modal/Modal.test.js
+++ b/common/views/components/Modal/Modal.test.js
@@ -1,0 +1,60 @@
+import Modal from '@weco/common/views/components/Modal/Modal';
+import { useState, useRef } from 'react';
+import { mountWithTheme } from '@weco/common/test/fixtures/enzyme-helpers';
+
+const openModalButtonSelector = '[data-test-id="open-modal-button"]';
+const closeModalButtonSelector = '[data-test-id="close-modal-button"]';
+
+const ModalExample = () => {
+  const [isActive, setIsActive] = useState(false);
+  const openModalRef = useRef(null);
+
+  return (
+    <div style={{ padding: '50px' }}>
+      <button
+        ref={openModalRef}
+        data-test-id="open-modal-button"
+        onClick={() => setIsActive(true)}
+      >
+        open
+      </button>
+      <Modal
+        isActive={isActive}
+        setIsActive={setIsActive}
+        openModalRef={openModalRef}
+      >
+        <p>This is a modal window.</p>
+      </Modal>
+    </div>
+  );
+};
+
+describe('Modal', () => {
+  it(`should have an unfocused button on initial render`, () => {
+    const component = mountWithTheme(<ModalExample />);
+    const openButton = component.find(openModalButtonSelector);
+
+    expect(openButton.is(':focus')).toBe(false);
+  });
+
+  it(`should focus the close button when opened`, () => {
+    const component = mountWithTheme(<ModalExample />);
+    const openButton = component.find(openModalButtonSelector);
+    const closeButton = component.find(closeModalButtonSelector);
+
+    openButton.simulate('click');
+
+    expect(closeButton.is(':focus')).toBe(true);
+  });
+
+  it(`should focus the open button when closed`, () => {
+    const component = mountWithTheme(<ModalExample />);
+    const openButton = component.find(openModalButtonSelector);
+    const closeButton = component.find(closeModalButtonSelector);
+
+    openButton.simulate('click');
+    closeButton.simulate('click');
+
+    expect(openButton.is(':focus')).toBe(true);
+  });
+});

--- a/common/views/components/Modal/Modal.test.js
+++ b/common/views/components/Modal/Modal.test.js
@@ -3,7 +3,7 @@ import { useState, useRef } from 'react';
 import { mountWithTheme } from '@weco/common/test/fixtures/enzyme-helpers';
 
 const openModalButtonSelector = '[data-test-id="open-modal-button"]';
-const closeModalButtonSelector = '[data-test-id="close-modal-button"]';
+const closeModalButtonSelector = '[role="button"]';
 
 const ModalExample = () => {
   const [isActive, setIsActive] = useState(false);

--- a/common/views/components/Modal/Modal.test.js
+++ b/common/views/components/Modal/Modal.test.js
@@ -7,12 +7,12 @@ const closeModalButtonSelector = '[data-test-id="close-modal-button"]';
 
 const ModalExample = () => {
   const [isActive, setIsActive] = useState(false);
-  const openModalRef = useRef(null);
+  const openButtonRef = useRef(null);
 
   return (
-    <div style={{ padding: '50px' }}>
+    <div>
       <button
-        ref={openModalRef}
+        ref={openButtonRef}
         data-test-id="open-modal-button"
         onClick={() => setIsActive(true)}
       >
@@ -21,7 +21,7 @@ const ModalExample = () => {
       <Modal
         isActive={isActive}
         setIsActive={setIsActive}
-        openModalRef={openModalRef}
+        openButtonRef={openButtonRef}
       >
         <p>This is a modal window.</p>
       </Modal>


### PR DESCRIPTION
Fixes #5671

The `useWindowSize` hook defaults to the value `'small'`, which means the mobile version of the filters is (momentarily) rendered before being updated to the desktop view (if you're browser's wide enough). The `Modal` component in the mobile filters has an 'open' button that should get focus whenever the modal is closed. But it is also currently getting focus on initial render, which moves the scroll position to the top of the page.

This PR ensures that launch `Modal` buttons only gain focus _after_ the modal has been closed.