### PR TITLE
convert EventDatesLink to ts

### DIFF
--- a/common/views/components/EventDatesLink/EventDatesLink.tsx
+++ b/common/views/components/EventDatesLink/EventDatesLink.tsx
@@ -1,17 +1,14 @@
-// @flow
-
-import NextLink from 'next/link';
 import { font, classNames } from '../../../utils/classnames';
 import { trackEvent } from '../../../utils/ga';
 import Icon from '../Icon/Icon';
 
-type Props = {|
-  id: string,
-|};
+type Props = {
+  id: string;
+};
 
 const EventDatesLink = ({ id }: Props) => {
   return (
-    <NextLink href={`#dates`} as={`#dates`}>
+    <a href={`#dates`}>
       <a
         onClick={() => {
           trackEvent({
@@ -29,7 +26,7 @@ const EventDatesLink = ({ id }: Props) => {
         <Icon name={`arrowSmall`} extraClasses="icon--black icon--90" />
         <span>{`See all dates`}</span>
       </a>
-    </NextLink>
+    </a>
   );
 };
 

--- a/common/views/components/EventDatesLink/EventDatesLink.tsx
+++ b/common/views/components/EventDatesLink/EventDatesLink.tsx
@@ -8,24 +8,23 @@ type Props = {
 
 const EventDatesLink = ({ id }: Props) => {
   return (
-    <a href={`#dates`}>
-      <a
-        onClick={() => {
-          trackEvent({
-            category: 'EventDatesLink',
-            action: 'follow link',
-            label: id,
-          });
-        }}
-        className={classNames({
-          'flex-inline': true,
-          'flex-v-center': true,
-          [font('hnm', 5)]: true,
-        })}
-      >
-        <Icon name={`arrowSmall`} extraClasses="icon--black icon--90" />
-        <span>{`See all dates`}</span>
-      </a>
+    <a
+      href={`#dates`}
+      onClick={() => {
+        trackEvent({
+          category: 'EventDatesLink',
+          action: 'follow link',
+          label: id,
+        });
+      }}
+      className={classNames({
+        'flex-inline': true,
+        'flex-v-center': true,
+        [font('hnm', 5)]: true,
+      })}
+    >
+      <Icon name={`arrowSmall`} extraClasses="icon--black icon--90" />
+      <span>{`See all dates`}</span>
     </a>
   );
 };

--- a/content/webapp/pages/event.js
+++ b/content/webapp/pages/event.js
@@ -35,6 +35,7 @@ import { getEvent, getEvents } from '@weco/common/services/prismic/events';
 import { convertImageUri } from '@weco/common/utils/convert-image-uri';
 import { eventLd } from '@weco/common/utils/json-ld';
 import { isEventFullyBooked } from '@weco/common/model/events';
+// $FlowFixMe (tsx)
 import EventDatesLink from '@weco/common/views/components/EventDatesLink/EventDatesLink';
 import Space from '@weco/common/views/components/styled/Space';
 


### PR DESCRIPTION
## Who is this for?
People who like links to work

## What is it doing for them?
Making the event date link work

It stopped working with the next update, as the link functionality changed slightly.

This isn't actually a next link, so best we don't use it as such.

You can see it broken here:
https://www-stage.wellcomecollection.org/events/X5aeBhIAAB4Aq3nK
