### PR TITLE
Add tsc script

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged && yarn tsc"
+      "pre-commit": "lint-staged & yarn tsc"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Products and services relating to wellcomecollection.org.",
   "scripts": {
     "lint": "eslint ./.eslintrc.js catalogue/ common/ content/ toggles/ dash/ --fix",
+    "tsc": "tsc --project content/webapp/tsconfig.json & tsc --project catalogue/webapp/tsconfig.json",
     "setupCommon": "yarn install --production && yarn flow",
     "cardigan": "pushd cardigan && yarn dev",
     "catalogue": "pushd catalogue/webapp && yarn dev",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-commit": "lint-staged && yarn tsc"
     }
   }
 }


### PR DESCRIPTION
Lets you `yarn tsc` to check TypeScript compilation for content and catalogue apps. Also runs this in the pre-commit hook to prevent us pushing broken TS.