### PR TITLE
* Remove filters from /works/{id} pages in search prototype #5739

### DIFF
--- a/catalogue/webapp/components/Work/Work.tsx
+++ b/catalogue/webapp/components/Work/Work.tsx
@@ -164,6 +164,7 @@ const Work: FunctionComponent<Props> = ({
                   }}
                   workTypeAggregations={[]}
                   shouldShowDescription={false}
+                  shouldShowFilters={false} // not display filters on the work detail page
                   activeTabIndex={0}
                 />
               </>

--- a/catalogue/webapp/pages/images.tsx
+++ b/catalogue/webapp/pages/images.tsx
@@ -174,6 +174,7 @@ const Images: NextPage<Props> = ({
                       workTypeAggregations={[]}
                       shouldShowDescription={query === ''}
                       activeTabIndex={1}
+                      shouldShowFilters={true}
                     />
                   </>
                 ) : (

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -199,6 +199,7 @@ const Works = ({ works, images, worksRouteProps, apiProps }: Props) => {
                         : []
                     }
                     shouldShowDescription={query === ''}
+                    shouldShowFilters={true}
                     aggregations={
                       works && works.aggregations
                         ? works.aggregations

--- a/common/views/components/PrototypeSearchForm/PrototypeSearchForm.tsx
+++ b/common/views/components/PrototypeSearchForm/PrototypeSearchForm.tsx
@@ -39,6 +39,7 @@ type Props = {
   aggregations: CatalogueAggregations | null;
   isImageSearch: boolean;
   isActive: boolean;
+  shouldShowFilters: boolean;
 };
 
 const SearchInputWrapper = styled.div`
@@ -82,6 +83,7 @@ const PrototypeSearchForm: FunctionComponent<Props> = ({
   aggregations,
   isImageSearch,
   isActive,
+  shouldShowFilters,
 }: Props): ReactElement<Props> => {
   const [, setSearchParamsState] = useSavedSearchState(routeProps);
   const { query } = routeProps;
@@ -94,7 +96,6 @@ const PrototypeSearchForm: FunctionComponent<Props> = ({
   const searchInput = useRef<HTMLInputElement>(null);
   const [portalSortOrder, setPortalSortOrder] = useState(routeProps.sortOrder);
   const [isInitialLoad, setIsInitialLoad] = useState(true);
-  const isWorksDetailPage = /works\/[a-zA-Z0-9]+/g.test(Router.asPath);
   function submit() {
     searchForm.current &&
       searchForm.current.dispatchEvent(
@@ -259,7 +260,7 @@ const PrototypeSearchForm: FunctionComponent<Props> = ({
           )}
         </SearchInputWrapper>
       </Space>
-      {query && !isWorksDetailPage && (
+      {query && shouldShowFilters && (
         <SearchFilters
           searchForm={searchForm}
           worksRouteProps={routeProps}

--- a/common/views/components/PrototypeSearchForm/PrototypeSearchForm.tsx
+++ b/common/views/components/PrototypeSearchForm/PrototypeSearchForm.tsx
@@ -6,7 +6,7 @@ import {
   FunctionComponent,
   ReactElement,
 } from 'react';
-import Router from 'next/router';
+import { useRouter } from 'next/router';
 import styled from 'styled-components';
 import TextInput from '@weco/common/views/components/TextInput/TextInput';
 import Icon from '@weco/common/views/components/Icon/Icon';
@@ -86,7 +86,7 @@ const PrototypeSearchForm: FunctionComponent<Props> = ({
   const [, setSearchParamsState] = useSavedSearchState(routeProps);
   const { query } = routeProps;
   const { isEnhanced } = useContext(AppContext);
-
+  const Router = useRouter();
   const searchForm = useRef<HTMLFormElement>(null);
   // This is the query used by the input, that is then eventually passed to the
   // Router
@@ -94,7 +94,7 @@ const PrototypeSearchForm: FunctionComponent<Props> = ({
   const searchInput = useRef<HTMLInputElement>(null);
   const [portalSortOrder, setPortalSortOrder] = useState(routeProps.sortOrder);
   const [isInitialLoad, setIsInitialLoad] = useState(true);
-
+  const isWorksDetailPage = /works\/[a-zA-Z0-9]+/g.test(Router.asPath);
   function submit() {
     searchForm.current &&
       searchForm.current.dispatchEvent(
@@ -259,8 +259,7 @@ const PrototypeSearchForm: FunctionComponent<Props> = ({
           )}
         </SearchInputWrapper>
       </Space>
-
-      {query && (
+      {query && !isWorksDetailPage && (
         <SearchFilters
           searchForm={searchForm}
           worksRouteProps={routeProps}
@@ -277,7 +276,7 @@ const PrototypeSearchForm: FunctionComponent<Props> = ({
           <Select
             name="portalSortOrder"
             label="Sort by"
-            value={portalSortOrder}
+            value={portalSortOrder || ''}
             options={[
               {
                 value: '',

--- a/common/views/components/PrototypeSearchForm/PrototypeSearchForm.tsx
+++ b/common/views/components/PrototypeSearchForm/PrototypeSearchForm.tsx
@@ -6,7 +6,7 @@ import {
   FunctionComponent,
   ReactElement,
 } from 'react';
-import { useRouter } from 'next/router';
+import Router from 'next/router';
 import styled from 'styled-components';
 import TextInput from '@weco/common/views/components/TextInput/TextInput';
 import Icon from '@weco/common/views/components/Icon/Icon';
@@ -88,7 +88,6 @@ const PrototypeSearchForm: FunctionComponent<Props> = ({
   const [, setSearchParamsState] = useSavedSearchState(routeProps);
   const { query } = routeProps;
   const { isEnhanced } = useContext(AppContext);
-  const Router = useRouter();
   const searchForm = useRef<HTMLFormElement>(null);
   // This is the query used by the input, that is then eventually passed to the
   // Router

--- a/common/views/components/SearchTabs/SearchTabs.tsx
+++ b/common/views/components/SearchTabs/SearchTabs.tsx
@@ -71,6 +71,7 @@ type Props = {
   shouldShowDescription: boolean;
   activeTabIndex?: number;
   aggregations?: CatalogueAggregations;
+  shouldShowFilters: boolean;
 };
 
 const SearchTabs: FunctionComponent<Props> = ({
@@ -80,6 +81,7 @@ const SearchTabs: FunctionComponent<Props> = ({
   aggregations,
   shouldShowDescription,
   activeTabIndex,
+  shouldShowFilters,
 }: Props): ReactElement<Props> => {
   const { isKeyboard, isEnhanced } = useContext(AppContext);
   const [activeTab, setActiveTab] = useState(
@@ -121,6 +123,7 @@ const SearchTabs: FunctionComponent<Props> = ({
             workTypeAggregations={workTypeAggregations}
             isImageSearch={false}
             aggregations={aggregations}
+            shouldShowFilters={shouldShowFilters}
           />
         </TabPanel>
       ),
@@ -159,6 +162,7 @@ const SearchTabs: FunctionComponent<Props> = ({
             routeProps={imagesRouteProps}
             workTypeAggregations={workTypeAggregations}
             isImageSearch={true}
+            shouldShowFilters={shouldShowFilters}
             aggregations={aggregations}
           />
         </TabPanel>


### PR DESCRIPTION
Be good to see if you guys think this solution is okay to go with. 
There are a couple of alternative solutions. 

* Checking the routing of the pages earlier on and passing it to searchForm
* basic black list utils to allow what should be shown and not shown on components. 

- fix warning issue on console
- remove filters on works details page

closes #5739

## Who is this for?


## What is it doing for them?
