### PR TITLE
Fix issue Flickering screen when displaying the scroll bar on the works viewer

### DIFF
--- a/common/views/components/IIIFViewer/IIIFViewer.js
+++ b/common/views/components/IIIFViewer/IIIFViewer.js
@@ -556,6 +556,7 @@ const IIIFViewerComponent = ({
                   canvases={canvases}
                   gridViewerRef={gridViewerRef}
                   isFullscreen={isFullscreen}
+                  viewerRef={viewerRef}
                 />
                 {pageWidth >= 600 && (
                   <ThumbsViewer

--- a/common/views/components/InfoBanner/InfoBanner.tsx
+++ b/common/views/components/InfoBanner/InfoBanner.tsx
@@ -32,6 +32,7 @@ const InfoBanner: FunctionComponent<Props> = ({
     });
 
     setIsVisible(false);
+    onVisibilityChange(false);
   };
 
   useEffect(() => {


### PR DESCRIPTION
1. Fix issue Flickering screen when displaying the scroll bar on the works viewer #5726
2. Fix issue with info banner display getting cut off in gallery view #5728

closes #5728 
closes #5726 
