### PR TITLE
Search Sort have to click twice instead of once to trigger the select option

### DIFF
--- a/common/views/components/PrototypePortal/PrototypePortal.tsx
+++ b/common/views/components/PrototypePortal/PrototypePortal.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, ReactElement, useEffect } from 'react';
+import { FunctionComponent, ReactElement, useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 type Props = {
@@ -11,14 +11,13 @@ const PrototypePortal: FunctionComponent<Props> = ({
   children,
 }: Props): ReactElement<Props> => {
   const mount = document.getElementById(id);
-  const el = document.createElement('div');
-
+  const [element] = useState(document.createElement('div'));
   useEffect(() => {
-    mount && mount.appendChild(el);
-    return () => mount && mount.removeChild(el);
-  }, [el, mount]);
+    mount && mount.appendChild(element);
+    return () => mount && mount.removeChild(element);
+  }, [element, mount]);
 
-  return createPortal(children, el);
+  return createPortal(children, element);
 };
 
 export default PrototypePortal;


### PR DESCRIPTION
* Fix issue with prototype search sorting by providing state to trigger the render and bind required nodes when using reactPortal 
* Using reactPortal this for providing it to pagination search sorting is a different discussion
 
closes #5777
