### PR TITLE
Stop filters modal button being triggered by the form submit action

### DIFF
--- a/common/views/components/SearchFilters/SearchFiltersMobile.js
+++ b/common/views/components/SearchFilters/SearchFiltersMobile.js
@@ -130,6 +130,7 @@ const SearchFiltersMobile = ({
     <Space v={{ size: 'l', properties: ['margin-top', 'margin-bottom'] }}>
       <ShameButtonWrap>
         <SolidButton
+          type="button"
           onClick={() => {
             setShowFiltersModal(true);
           }}


### PR DESCRIPTION
When `SearchFiltersMobile` was being rendered, a click event would fire on the open button when the form was submitted (most obviously from the mobile native keyboard submit action, but also reproducible when pressing return in a sufficiently small viewport). This stops that from happening. I can see why a lot of people stopped using the native `<form>` element 🙃 .