### PR TITLE
Add starter 'available online' label

### DIFF
--- a/catalogue/webapp/components/WorkCard/WorkCard.tsx
+++ b/catalogue/webapp/components/WorkCard/WorkCard.tsx
@@ -19,6 +19,18 @@ type Props = {
   work: Work;
 };
 
+const ShameAvailableOnlineTag = styled(Space).attrs({
+  h: {
+    size: 's',
+    properties: ['padding-left', 'padding-right'],
+  },
+  v: {
+    size: 's',
+    properties: ['padding-top', 'padding-bottom'],
+  },
+  className: `bg-smoke line-height-1`,
+})``;
+
 const Container = styled.div`
   ${props => props.theme.media.medium`
     display: flex;
@@ -111,6 +123,13 @@ const WorkCard: FunctionComponent<Props> = ({ work }: Props) => {
                   </Space>
                 )}
                 {work.workType.label}
+                {work.availableOnline && (
+                  <Space h={{ size: 'm', properties: ['margin-left'] }}>
+                    <ShameAvailableOnlineTag>
+                      Available online
+                    </ShameAvailableOnlineTag>
+                  </Space>
+                )}
               </Space>
               <h2
                 className={classNames({

--- a/common/model/catalogue.ts
+++ b/common/model/catalogue.ts
@@ -27,6 +27,7 @@ export type Work = {
   partOf: Work[];
   precededBy: Work[];
   succeededBy: Work[];
+  availableOnline?: boolean;
 };
 
 type WorkType = {

--- a/common/model/catalogue.ts
+++ b/common/model/catalogue.ts
@@ -27,7 +27,7 @@ export type Work = {
   partOf: Work[];
   precededBy: Work[];
   succeededBy: Work[];
-  availableOnline?: boolean;
+  availableOnline: boolean;
 };
 
 type WorkType = {


### PR DESCRIPTION
Closes #5741 

This hasn't been fully designed, but @GarethOrmerod feels this is good enough to release, ahead of further design iteration on the `WorkCard` component.

Draft until we know for sure that `availableOnline` will be the property in the api.

![image](https://user-images.githubusercontent.com/1394592/99546112-00d5ec00-29ae-11eb-983a-43f4fca4a5b0.png)
