### PR TITLE
* Work detail page to display search ui fix 

### DIFF
--- a/catalogue/webapp/components/Work/Work.tsx
+++ b/catalogue/webapp/components/Work/Work.tsx
@@ -124,7 +124,7 @@ const Work: FunctionComponent<Props> = ({
       null,
     // We only send a langCode if it's unambiguous -- better to send no language
     // than the wrong one.
-    langCode: work.languages.length === 1 && work.languages[0]?.id,
+    langCode: work?.languages?.length === 1 && work?.languages[0]?.id,
     canvas: 1,
     page: 1,
   });

--- a/catalogue/webapp/components/Work/Work.tsx
+++ b/catalogue/webapp/components/Work/Work.tsx
@@ -1,11 +1,5 @@
 import { Work as WorkType } from '@weco/common/model/catalogue';
-import {
-  useEffect,
-  useState,
-  useContext,
-  FunctionComponent,
-  ReactElement,
-} from 'react';
+import { useEffect, useState, FunctionComponent, ReactElement } from 'react';
 import fetch from 'isomorphic-unfetch';
 import { grid, classNames, font } from '@weco/common/utils/classnames';
 import {
@@ -35,7 +29,6 @@ import ArchiveTree from '@weco/common/views/components/ArchiveTree/ArchiveTree';
 import SearchTabs from '@weco/common/views/components/SearchTabs/SearchTabs';
 import Divider from '@weco/common/views/components/Divider/Divider';
 import styled from 'styled-components';
-import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
 import { WithGlobalContextData } from '@weco/common/views/components/GlobalContextProvider/GlobalContextProvider';
 
 const ArchiveDetailsContainer = styled.div`
@@ -59,7 +52,7 @@ const Work: FunctionComponent<Props> = ({
   work,
   globalContextData,
 }: Props): ReactElement<Props> => {
-  const { searchPrototype } = useContext(TogglesContext);
+  const { searchPrototype } = globalContextData.toggles;
   const [savedSearchFormState] = useSavedSearchState({
     query: '',
     page: 1,
@@ -129,9 +122,9 @@ const Work: FunctionComponent<Props> = ({
       (iiifPresentationLocation &&
         sierraIdFromPresentationManifestUrl(iiifPresentationLocation.url)) ||
       null,
-      // We only send a langCode if it's unambiguous -- better to send no language
-      // than the wrong one.
-      langCode: work.languages.length === 1 && work.languages[0].id,
+    // We only send a langCode if it's unambiguous -- better to send no language
+    // than the wrong one.
+    langCode: work.languages.length === 1 && work.languages[0].id,
     canvas: 1,
     page: 1,
   });

--- a/catalogue/webapp/components/Work/Work.tsx
+++ b/catalogue/webapp/components/Work/Work.tsx
@@ -124,7 +124,7 @@ const Work: FunctionComponent<Props> = ({
       null,
     // We only send a langCode if it's unambiguous -- better to send no language
     // than the wrong one.
-    langCode: work.languages.length === 1 && work.languages[0].id,
+    langCode: work.languages.length === 1 && work.languages[0]?.id,
     canvas: 1,
     page: 1,
   });

--- a/catalogue/webapp/pages/images.tsx
+++ b/catalogue/webapp/pages/images.tsx
@@ -28,7 +28,6 @@ import SearchForm from '@weco/common/views/components/SearchForm/SearchForm';
 import { getImages } from '../services/catalogue/images';
 import useSavedSearchState from '@weco/common/hooks/useSavedSearchState';
 import useHotjar from '@weco/common/hooks/useHotjar';
-import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
 import SearchTabs from '@weco/common/views/components/SearchTabs/SearchTabs';
 import SearchNoResults from '../components/SearchNoResults/SearchNoResults';
 import {

--- a/common/views/components/WorkHeaderPrototype/WorkHeaderPrototype.tsx
+++ b/common/views/components/WorkHeaderPrototype/WorkHeaderPrototype.tsx
@@ -105,7 +105,7 @@ const WorkHeaderPrototype: FunctionComponent<Props> = ({
             // We only send a lang if it's unambiguous -- better to send
             // no language than the wrong one.
             lang={
-              work.languages.length === 1 ? work.languages[0].id : undefined
+              work.languages.length === 1 ? work.languages[0]?.id : undefined
             }
           >
             <WorkTitle title={work.title} />

--- a/common/views/components/WorkHeaderPrototype/WorkHeaderPrototype.tsx
+++ b/common/views/components/WorkHeaderPrototype/WorkHeaderPrototype.tsx
@@ -104,7 +104,9 @@ const WorkHeaderPrototype: FunctionComponent<Props> = ({
             })}
             // We only send a lang if it's unambiguous -- better to send
             // no language than the wrong one.
-            lang={work.languages.length === 1 && work.languages[0].id}
+            lang={
+              work.languages.length === 1 ? work.languages[0].id : undefined
+            }
           >
             <WorkTitle title={work.title} />
           </h1>

--- a/common/views/components/WorkHeaderPrototype/WorkHeaderPrototype.tsx
+++ b/common/views/components/WorkHeaderPrototype/WorkHeaderPrototype.tsx
@@ -105,7 +105,7 @@ const WorkHeaderPrototype: FunctionComponent<Props> = ({
             // We only send a lang if it's unambiguous -- better to send
             // no language than the wrong one.
             lang={
-              work.languages.length === 1 ? work.languages[0]?.id : undefined
+              work?.languages?.length === 1 ? work?.languages[0]?.id : undefined
             }
           >
             <WorkTitle title={work.title} />


### PR DESCRIPTION
Work detail page to display search ui fix - not use ToggleContext but use GlobalContext from serverProps

* WorkHeadPrototype console error .. returning false when item is not expecting boolean with lang 
* clean up remove toggleContext which is not used in images.tsx
