### PR TITLE
add routing rules and caching behaviours for nextjs data fetching

### DIFF
--- a/cache/cloudfront_prod.tf
+++ b/cache/cloudfront_prod.tf
@@ -129,6 +129,7 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
         "sierraId",
         "workType",
         "toggle",
+        "source",
       ]
 
       cookies {
@@ -175,6 +176,7 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
         "page",
         "query",
         "toggle",
+        "source",
       ]
 
       cookies {

--- a/cache/cloudfront_prod.tf
+++ b/cache/cloudfront_prod.tf
@@ -118,6 +118,8 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
       headers      = ["Host"]
       query_string = true
 
+      # The number of keys here is higher than the default limit of 10 -
+      # AWS have increased this to 50 for us - worth noting if we move accounts etc.
       query_string_cache_keys = [
         "_queryType",
         "canvas",

--- a/cache/cloudfront_stage.tf
+++ b/cache/cloudfront_stage.tf
@@ -99,6 +99,7 @@ resource "aws_cloudfront_distribution" "stage_wc_org" {
         "sierraId",
         "workType",
         "toggle",
+        "source",
       ]
 
       cookies {
@@ -145,6 +146,7 @@ resource "aws_cloudfront_distribution" "stage_wc_org" {
         "page",
         "query",
         "toggle",
+        "source",
       ]
 
       cookies {
@@ -167,6 +169,33 @@ resource "aws_cloudfront_distribution" "stage_wc_org" {
     lambda_function_association {
       event_type = "origin-response"
       lambda_arn = aws_lambda_function.edge_lambda_response.qualified_arn
+    }
+  }
+
+  # This is for the data fetching routes used in NextJs's getServerSideProps 
+  # see: https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering
+  ordered_cache_behavior {
+    target_origin_id       = local.default_origin_id
+    path_pattern           = "/_next/data/*"
+    allowed_methods        = ["HEAD", "GET"]
+    cached_methods         = ["HEAD", "GET"]
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 31536000
+
+    forwarded_values {
+      headers      = ["Host"]
+      query_string = true
+
+      cookies {
+        forward = "whitelist"
+
+        whitelisted_names = [
+          "toggles",  # feature toggles
+          "toggle_*", # feature toggles
+        ]
+      }
     }
   }
 

--- a/cache/cloudfront_stage.tf
+++ b/cache/cloudfront_stage.tf
@@ -88,6 +88,8 @@ resource "aws_cloudfront_distribution" "stage_wc_org" {
       headers      = ["Host"]
       query_string = true
 
+      # The number of keys here is higher than the default limit of 10 -
+      # AWS have increased this to 50 for us here.
       query_string_cache_keys = [
         "_queryType",
         "canvas",
@@ -172,7 +174,7 @@ resource "aws_cloudfront_distribution" "stage_wc_org" {
     }
   }
 
-  # This is for the data fetching routes used in NextJs's getServerSideProps 
+  # This is for the data fetching routes used in NextJs's getServerSideProps
   # see: https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering
   ordered_cache_behavior {
     target_origin_id       = local.default_origin_id

--- a/catalogue/terraform/data.tf
+++ b/catalogue/terraform/data.tf
@@ -9,8 +9,3 @@ data "terraform_remote_state" "experience_shared" {
     region = "eu-west-1"
   }
 }
-
-data "aws_ssm_parameter" "nginx_image_uri" {
-  name     = "/platform/images/latest/nginx_experience"
-  provider = aws.platform
-}

--- a/catalogue/terraform/locals.tf
+++ b/catalogue/terraform/locals.tf
@@ -18,8 +18,7 @@ locals {
   stage_service_egress_security_group_id = data.terraform_remote_state.experience_shared.outputs.stage_service_egress_security_group_id
 
   stage_app_image = "${data.terraform_remote_state.experience_shared.outputs.catalogue_webapp_ecr_uri}:env.stage"
-  prod_app_image = "${data.terraform_remote_state.experience_shared.outputs.catalogue_webapp_ecr_uri}:env.prod"
+  prod_app_image  = "${data.terraform_remote_state.experience_shared.outputs.catalogue_webapp_ecr_uri}:env.prod"
 
-  // Latest is available at data.aws_ssm_parameter.nginx_image_uri.value - test in staging before deployment
   nginx_image = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx_experience:78090f62ee23a39a1b4e929f25417bfa128c2aa8"
 }

--- a/catalogue/terraform/stack/main.tf
+++ b/catalogue/terraform/stack/main.tf
@@ -1,7 +1,7 @@
 module "catalogue-service-17092020" {
   source = "../../../infrastructure/terraform/modules/service"
 
-  namespace    = "catalogue-17092020-${var.env_suffix}"
+  namespace = "catalogue-17092020-${var.env_suffix}"
 
   namespace_id = var.namespace_id
   cluster_arn  = var.cluster_arn
@@ -24,7 +24,7 @@ module "catalogue-service-17092020" {
   subnets = local.private_subnets
 
   deployment_service_name = "catalogue_webapp"
-  deployment_service_env = var.env_suffix
+  deployment_service_env  = var.env_suffix
 }
 
 locals {
@@ -38,9 +38,9 @@ module "path_listener" {
   alb_listener_http_arn  = var.alb_listener_http_arn
   target_group_arn       = local.target_group_arn
 
-  field                  = "path-pattern"
-  values                 = ["/works*"]
-  priority               = "49997"
+  field    = "path-pattern"
+  values   = ["/works*"]
+  priority = "49997"
 }
 
 # This is used for the static assets served from _next with multiple next apps
@@ -52,9 +52,9 @@ module "subdomain_listener" {
   alb_listener_http_arn  = var.alb_listener_http_arn
   target_group_arn       = local.target_group_arn
 
-  priority               = "201"
-  values                 = ["${var.subdomain}.wellcomecollection.org"]
-  field                  = "host-header"
+  priority = "201"
+  values   = ["${var.subdomain}.wellcomecollection.org"]
+  field    = "host-header"
 }
 
 module "embed_path_rule" {
@@ -64,9 +64,9 @@ module "embed_path_rule" {
   alb_listener_http_arn  = var.alb_listener_http_arn
   target_group_arn       = local.target_group_arn
 
-  priority               = "202"
-  field                  = "path-pattern"
-  values                 = ["/oembed*"]
+  priority = "202"
+  field    = "path-pattern"
+  values   = ["/oembed*"]
 }
 
 module "images_search_rule" {
@@ -76,7 +76,34 @@ module "images_search_rule" {
   alb_listener_http_arn  = var.alb_listener_http_arn
   target_group_arn       = local.target_group_arn
 
-  priority               = "203"
-  field                  = "path-pattern"
-  values                 = ["/images*"]
+  priority = "203"
+  field    = "path-pattern"
+  values   = ["/images*"]
+}
+
+# We do this as our server side props for next.js are served over
+# /_next/data/{hash}/{page}.json
+# e.g. https://wellcomecollection.org/_next/data/dl7PfaUnoIXaQk0ol_5M8/works.json?query=things&source=search_form%2Fworks
+# These routes will mimic the `/catalogue/webapp/pages/*` directory
+# see: https://github.com/vercel/next.js/issues/16090
+
+module "works_data_listener" {
+  source = "../../../infrastructure/terraform/modules/alb_listener_rule"
+
+  alb_listener_https_arn = var.alb_listener_https_arn
+  alb_listener_http_arn  = var.alb_listener_http_arn
+  target_group_arn       = local.target_group_arn
+
+  field = "path-pattern"
+  values = [
+    "/_next/data/*/download.json",
+    "/_next/data/*/embed.json",
+    "/_next/data/*/image.json",
+    "/_next/data/*/images.json",
+    "/_next/data/*/item.json",
+    "/_next/data/*/progress.json",
+    "/_next/data/*/work.json",
+    "/_next/data/*/works.json",
+  ]
+  priority = "49997"
 }

--- a/catalogue/terraform/stack/main.tf
+++ b/catalogue/terraform/stack/main.tf
@@ -105,5 +105,5 @@ module "works_data_listener" {
     "/_next/data/*/work.json",
     "/_next/data/*/works.json",
   ]
-  priority = "49997"
+  priority = "49996"
 }

--- a/catalogue/terraform/stack/main.tf
+++ b/catalogue/terraform/stack/main.tf
@@ -38,9 +38,8 @@ module "path_listener" {
   alb_listener_http_arn  = var.alb_listener_http_arn
   target_group_arn       = local.target_group_arn
 
-  field    = "path-pattern"
-  values   = ["/works*"]
-  priority = "49997"
+  path_patterns = ["/works*"]
+  priority      = "49997"
 }
 
 # This is used for the static assets served from _next with multiple next apps
@@ -52,9 +51,8 @@ module "subdomain_listener" {
   alb_listener_http_arn  = var.alb_listener_http_arn
   target_group_arn       = local.target_group_arn
 
-  priority = "201"
-  values   = ["${var.subdomain}.wellcomecollection.org"]
-  field    = "host-header"
+  priority     = "201"
+  host_headers = ["${var.subdomain}.wellcomecollection.org"]
 }
 
 module "embed_path_rule" {
@@ -64,9 +62,8 @@ module "embed_path_rule" {
   alb_listener_http_arn  = var.alb_listener_http_arn
   target_group_arn       = local.target_group_arn
 
-  priority = "202"
-  field    = "path-pattern"
-  values   = ["/oembed*"]
+  priority      = "202"
+  path_patterns = ["/oembed*"]
 }
 
 module "images_search_rule" {
@@ -76,9 +73,8 @@ module "images_search_rule" {
   alb_listener_http_arn  = var.alb_listener_http_arn
   target_group_arn       = local.target_group_arn
 
-  priority = "203"
-  field    = "path-pattern"
-  values   = ["/images*"]
+  priority      = "203"
+  path_patterns = ["/images*"]
 }
 
 # We do this as our server side props for next.js are served over
@@ -94,8 +90,7 @@ module "works_data_listener" {
   alb_listener_http_arn  = var.alb_listener_http_arn
   target_group_arn       = local.target_group_arn
 
-  field = "path-pattern"
-  values = [
+  path_patterns = [
     "/_next/data/*/download.json",
     "/_next/data/*/embed.json",
     "/_next/data/*/image.json",

--- a/content/terraform/stack/main.tf
+++ b/content/terraform/stack/main.tf
@@ -1,7 +1,7 @@
 module "content-service-17092020" {
   source = "../../../infrastructure/terraform/modules/service"
 
-  namespace    = "content-17092020-${var.env_suffix}"
+  namespace = "content-17092020-${var.env_suffix}"
 
   namespace_id = var.namespace_id
   cluster_arn  = var.cluster_arn
@@ -29,7 +29,7 @@ module "content-service-17092020" {
   subnets = local.private_subnets
 
   deployment_service_name = "content_webapp"
-  deployment_service_env = var.env_suffix
+  deployment_service_env  = var.env_suffix
 }
 
 locals {
@@ -43,9 +43,8 @@ module "path_listener" {
   alb_listener_http_arn  = var.alb_listener_http_arn
   target_group_arn       = local.target_group_arn
 
-  field                  = "path-pattern"
-  values                 = ["/*"]
-  priority               = "49998"
+  path_patterns = ["/*"]
+  priority      = "49998"
 }
 
 # This is used for the static assets served from _next with multiple next apps
@@ -57,7 +56,6 @@ module "subdomain_listener" {
   alb_listener_http_arn  = var.alb_listener_http_arn
   target_group_arn       = local.target_group_arn
 
-  field                  = "host-header"
-  values                 = ["${var.subdomain}.wellcomecollection.org"]
-  priority               = "49999"
+  host_headers = ["${var.subdomain}.wellcomecollection.org"]
+  priority     = "49999"
 }

--- a/infrastructure/terraform/modules/alb_listener_rule/main.tf
+++ b/infrastructure/terraform/modules/alb_listener_rule/main.tf
@@ -1,29 +1,51 @@
 resource "aws_alb_listener_rule" "https" {
   listener_arn = var.alb_listener_https_arn
-  priority = var.priority
+  priority     = var.priority
 
   action {
-    type = "forward"
+    type             = "forward"
     target_group_arn = var.target_group_arn
   }
 
   condition {
-    field = var.field
-    values = var.values
+    dynamic "path_pattern" {
+      for_each = length(var.path_patterns) > 0 ? [""] : []
+      content {
+        values = var.path_patterns
+      }
+    }
+
+    dynamic "host_header" {
+      for_each = length(var.host_headers) > 0 ? [""] : []
+      content {
+        values = var.host_headers
+      }
+    }
   }
 }
 
 resource "aws_alb_listener_rule" "http" {
   listener_arn = var.alb_listener_http_arn
-  priority = var.priority
+  priority     = var.priority
 
   action {
-    type = "forward"
+    type             = "forward"
     target_group_arn = var.target_group_arn
   }
 
   condition {
-    field = var.field
-    values = var.values
+    dynamic "path_pattern" {
+      for_each = length(var.path_patterns) > 0 ? [""] : []
+      content {
+        values = var.path_patterns
+      }
+    }
+
+    dynamic "host_header" {
+      for_each = length(var.host_headers) > 0 ? [""] : []
+      content {
+        values = var.host_headers
+      }
+    }
   }
 }

--- a/infrastructure/terraform/modules/alb_listener_rule/variables.tf
+++ b/infrastructure/terraform/modules/alb_listener_rule/variables.tf
@@ -3,8 +3,12 @@ variable "alb_listener_http_arn" {}
 variable "target_group_arn" {}
 variable "priority" {}
 
-variable "values" {
-  type = list(string)
+variable "path_patterns" {
+  type    = list(string)
+  default = []
 }
 
-variable "field" {}
+variable "host_headers" {
+  type    = list(string)
+  default = []
+}


### PR DESCRIPTION
Turns out we need to route the data fetching endpoints to the same domain as [they don't respect the `assetPrefix`](https://nextjs.org/docs/api-reference/next.config.js/cdn-support-with-asset-prefix) (scroll down to see it's intended behaviour).

This takes any `catalogue/pages` data endpoints (`_next/data/{hash}/{page}.json`) and adds them to the ALB. It also creates a generic cache endpoint which we can optimise later.

We should probably make more use of [dynamic routing](https://nextjs.org/docs/routing/dynamic-routes) (it wasn't available when we wrote this) and can probably. The recommended way to do this is by [using `basePath`](https://nextjs.org/docs/api-reference/next.config.js/basepath) - but we haven't separated our domains so neatly, so it doesn't really work.

(this has not been applied as I can't without a phone with MFA on AWS stuff).