### PR TITLE
WIP: page tracking

### DIFF
--- a/catalogue/webapp/components/Work/Work.tsx
+++ b/catalogue/webapp/components/Work/Work.tsx
@@ -37,6 +37,7 @@ import Divider from '@weco/common/views/components/Divider/Divider';
 import styled from 'styled-components';
 import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
 import { WithGlobalContextData } from '@weco/common/views/components/GlobalContextProvider/GlobalContextProvider';
+import { PageviewProps } from 'pages/work';
 
 const ArchiveDetailsContainer = styled.div`
   display: block;
@@ -51,9 +52,15 @@ declare global {
   }
 }
 
+// this is here as it's in the common folder
+// it should live in pages/work.tsx
+export type PageviewProps = {
+  workType: string;
+};
+
 type Props = {
   work: WorkType;
-} & WithGlobalContextData;
+} & WithGlobalContextData<PageviewProps>;
 
 const Work: FunctionComponent<Props> = ({
   work,
@@ -129,9 +136,9 @@ const Work: FunctionComponent<Props> = ({
       (iiifPresentationLocation &&
         sierraIdFromPresentationManifestUrl(iiifPresentationLocation.url)) ||
       null,
-      // We only send a langCode if it's unambiguous -- better to send no language
-      // than the wrong one.
-      langCode: work.languages.length === 1 && work.languages[0].id,
+    // We only send a langCode if it's unambiguous -- better to send no language
+    // than the wrong one.
+    langCode: work.languages.length === 1 && work.languages[0].id,
     canvas: 1,
     page: 1,
   });

--- a/catalogue/webapp/pages/images.tsx
+++ b/catalogue/webapp/pages/images.tsx
@@ -170,6 +170,30 @@ const Images: NextPage<Props> = ({
           className={classNames(['row'])}
         >
           <div className="container">
+            {!results && (
+              <div className="grid">
+                <div className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>
+                  <Space
+                    v={{
+                      size: 'm',
+                      properties: ['margin-bottom'],
+                    }}
+                    className={classNames([
+                      'flex flex--h-space-between flex--v-center flex--wrap',
+                    ])}
+                  >
+                    <Space
+                      as="h1"
+                      v={{ size: 'm', properties: ['margin-bottom'] }}
+                      className="h1"
+                    >
+                      Search the collections
+                    </Space>
+                  </Space>
+                </div>
+              </div>
+            )}
+
             <div className="grid">
               <div className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>
                 {searchPrototype ? (

--- a/catalogue/webapp/pages/work.tsx
+++ b/catalogue/webapp/pages/work.tsx
@@ -4,7 +4,7 @@ import {
   CatalogueApiError,
 } from '@weco/common/model/catalogue';
 import ErrorPage from '@weco/common/views/components/ErrorPage/ErrorPage';
-import Work from '../components/Work/Work';
+import Work, { PageviewProps } from '../components/Work/Work';
 import { getWork } from '../services/catalogue/works';
 import {
   getGlobalContextData,
@@ -14,7 +14,7 @@ import { removeUndefinedProps } from '@weco/common/utils/json';
 
 type Props = {
   workResponse: WorkType | CatalogueApiError;
-} & WithGlobalContextData;
+} & WithGlobalContextData<PageviewProps>;
 
 export const WorkPage: NextPage<Props> = ({
   workResponse,
@@ -59,6 +59,14 @@ export const getServerSideProps: GetServerSideProps<Props> = async context => {
     props: removeUndefinedProps({
       workResponse,
       globalContextData,
+      pageview: {
+        name: 'Work',
+        url: '/url',
+        query: context.query,
+        data: {
+          workType: workResponse.data.workType,
+        },
+      },
     }),
   };
 };

--- a/common/views/components/GlobalContextProvider/GlobalContextProvider.tsx
+++ b/common/views/components/GlobalContextProvider/GlobalContextProvider.tsx
@@ -25,11 +25,20 @@ const defaultValue = {
   openingTimes: null,
 };
 
-export type WithGlobalContextData = {
+type Pageview<T> = {
+  name: string;
+  url: string;
+  query: string;
+  data: T;
+};
+
+export type WithGlobalContextData<T> = {
   globalContextData: GlobalContextData;
+  pageview: Pageview<T>;
 };
 
 const Context = createContext<GlobalContextData>(defaultValue);
+
 const GlobalContextProvider: FunctionComponent<Props> = ({
   value,
   children,

--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -1,4 +1,9 @@
-import React, { useContext, FunctionComponent, ReactNode } from 'react';
+import React, {
+  useContext,
+  FunctionComponent,
+  ReactNode,
+  useEffect,
+} from 'react';
 import { Url } from '../../../model/url';
 import { JsonLdObj } from '../JsonLd/JsonLd';
 import Head from 'next/head';
@@ -26,6 +31,7 @@ import GlobalContextProvider, {
 import GlobalInfoBarContext, {
   GlobalInfoBarContextProvider,
 } from '../GlobalInfoBarContext/GlobalInfoBarContext';
+import { useRouter } from 'next/router';
 
 type SiteSection =
   | 'collections'
@@ -105,6 +111,7 @@ const PageLayoutComponent: FunctionComponent<ComponentProps> = ({
   ];
 
   const globalInfoBar = useContext(GlobalInfoBarContext);
+
   return (
     <>
       <Head>

--- a/common/views/components/PrototypeSearchForm/PrototypeSearchForm.tsx
+++ b/common/views/components/PrototypeSearchForm/PrototypeSearchForm.tsx
@@ -38,7 +38,6 @@ type Props = {
   workTypeAggregations: CatalogueAggregationBucket[];
   aggregations: CatalogueAggregations | null;
   isImageSearch: boolean;
-  isActive: boolean;
   shouldShowFilters: boolean;
 };
 
@@ -82,7 +81,6 @@ const PrototypeSearchForm: FunctionComponent<Props> = ({
   workTypeAggregations,
   aggregations,
   isImageSearch,
-  isActive,
   shouldShowFilters,
 }: Props): ReactElement<Props> => {
   const [, setSearchParamsState] = useSavedSearchState(routeProps);
@@ -94,7 +92,6 @@ const PrototypeSearchForm: FunctionComponent<Props> = ({
   const [inputQuery, setInputQuery] = useState(query);
   const searchInput = useRef<HTMLInputElement>(null);
   const [portalSortOrder, setPortalSortOrder] = useState(routeProps.sortOrder);
-  const [isInitialLoad, setIsInitialLoad] = useState(true);
   function submit() {
     searchForm.current &&
       searchForm.current.dispatchEvent(
@@ -111,16 +108,6 @@ const PrototypeSearchForm: FunctionComponent<Props> = ({
       setInputQuery(query);
     }
   }, [query]);
-
-  useEffect(() => {
-    if (query && isActive && !isInitialLoad) {
-      submit();
-    }
-  }, [isActive]);
-
-  useEffect(() => {
-    setIsInitialLoad(false);
-  }, []);
 
   useEffect(() => {
     if (portalSortOrder !== routeProps.sortOrder) {
@@ -210,6 +197,7 @@ const PrototypeSearchForm: FunctionComponent<Props> = ({
           label: query,
         });
 
+        console.info('onSubmit');
         updateUrl(event.currentTarget);
         return false;
       }}

--- a/common/views/components/SearchTabs/SearchTabs.tsx
+++ b/common/views/components/SearchTabs/SearchTabs.tsx
@@ -2,18 +2,28 @@ import BaseTabs, { TabType } from '../BaseTabs/BaseTabs';
 import { classNames, font } from '@weco/common/utils/classnames';
 import styled from 'styled-components';
 import Space from '../styled/Space';
-import { useContext, useState, FunctionComponent, ReactElement } from 'react';
+import {
+  useContext,
+  useState,
+  FunctionComponent,
+  ReactElement,
+  useEffect,
+} from 'react';
+import NextLink from 'next/link';
 import { AppContext } from '../AppContext/AppContext';
 import PrototypeSearchForm from '@weco/common/views/components/PrototypeSearchForm/PrototypeSearchForm';
 import {
   WorksRouteProps,
   ImagesRouteProps,
+  imagesLink,
 } from '@weco/common/services/catalogue/ts_routes';
 import {
   CatalogueAggregationBucket,
   CatalogueAggregations,
 } from '@weco/common/model/catalogue';
 import { trackEvent } from '@weco/common/utils/ga';
+import { useRouter } from 'next/router';
+import { removeEmptyProps } from '../../../utils/json';
 
 const BaseTabsWrapper = styled.div.attrs<{ isEnhanced: boolean }>(props => ({
   className: classNames({
@@ -65,6 +75,7 @@ const Tab = styled(Space).attrs({
 const TabPanel = styled(Space)`
   background: ${props => props.theme.color('cream')};
 `;
+
 type Props = {
   worksRouteProps: WorksRouteProps;
   imagesRouteProps: ImagesRouteProps;
@@ -85,21 +96,36 @@ const SearchTabs: FunctionComponent<Props> = ({
   shouldShowFilters,
 }: Props): ReactElement<Props> => {
   const { isKeyboard, isEnhanced } = useContext(AppContext);
-  const [activeTab, setActiveTab] = useState(
-    activeTabIndex === 0 ? 'tab-library-catalogue' : 'tab-images'
-  );
+  const router = useRouter();
+  const { query } = router.query;
+
   const tabs: TabType[] = [
     {
       id: 'tab-library-catalogue',
       tab: function TabWithDisplayName(isActive, isFocused) {
         return (
-          <Tab
-            isActive={isActive}
-            isFocused={isFocused}
-            isKeyboard={isKeyboard}
+          <NextLink
+            href={{
+              pathname: '/works',
+              query: removeEmptyProps({
+                query,
+              }),
+            }}
           >
-            Library catalogue
-          </Tab>
+            <a
+              className={classNames({
+                'plain-link': true,
+              })}
+            >
+              <Tab
+                isActive={isActive}
+                isFocused={isFocused}
+                isKeyboard={isKeyboard}
+              >
+                Library catalogue
+              </Tab>
+            </a>
+          </NextLink>
         );
       },
       tabPanel: (
@@ -118,12 +144,11 @@ const SearchTabs: FunctionComponent<Props> = ({
             access.
           </Space>
           <PrototypeSearchForm
-            isActive={activeTab === 'tab-library-catalogue'}
             ariaDescribedBy={'library-catalogue-form-description'}
             routeProps={worksRouteProps}
             workTypeAggregations={workTypeAggregations}
             isImageSearch={false}
-            aggregations={aggregations}
+            aggregations={aggregations || null}
             shouldShowFilters={shouldShowFilters}
           />
         </TabPanel>
@@ -133,14 +158,29 @@ const SearchTabs: FunctionComponent<Props> = ({
       id: 'tab-images',
       tab: function TabWithDisplayName(isActive, isFocused) {
         return (
-          <Tab
-            isActive={isActive}
-            isFocused={isFocused}
-            isKeyboard={isKeyboard}
-            isLast={true}
+          <NextLink
+            href={{
+              pathname: '/images',
+              query: removeEmptyProps({
+                query,
+              }),
+            }}
           >
-            Images
-          </Tab>
+            <a
+              className={classNames({
+                'plain-link': true,
+              })}
+            >
+              <Tab
+                isActive={isActive}
+                isFocused={isFocused}
+                isKeyboard={isKeyboard}
+                isLast={true}
+              >
+                Images
+              </Tab>
+            </a>
+          </NextLink>
         );
       },
       tabPanel: (
@@ -158,13 +198,12 @@ const SearchTabs: FunctionComponent<Props> = ({
             museum collections, including objects at the Science Museum.
           </Space>
           <PrototypeSearchForm
-            isActive={activeTab === 'tab-images'}
             ariaDescribedBy="images-form-description"
             routeProps={imagesRouteProps}
             workTypeAggregations={workTypeAggregations}
             isImageSearch={true}
             shouldShowFilters={shouldShowFilters}
-            aggregations={aggregations}
+            aggregations={aggregations || null}
           />
         </TabPanel>
       ),
@@ -179,8 +218,8 @@ const SearchTabs: FunctionComponent<Props> = ({
     });
   }
 
-  function onTabChanged(id: string) {
-    setActiveTab(id);
+  function onTabChanged() {
+    // The tabs are links, so no need to do anything here
   }
 
   return (

--- a/common/views/pages/_document.tsx
+++ b/common/views/pages/_document.tsx
@@ -18,7 +18,7 @@ const {
 function renderSegmentSnippet() {
   const opts = {
     apiKey: ANALYTICS_WRITE_KEY,
-    page: true,
+    page: false,
   };
 
   if (NODE_ENV === 'development') {


### PR DESCRIPTION
Pushing through a pageview prop on the `getServerSideProps`, which will then be pushed through to segment.

This will allow us to track certain properties of where / what a pageview is.

There some typing name issues, but the gist of what I am trying to do is there.

---

## Issue with form resubmitting onload

I had to also convert the tabs to links as there was a funky bit of functionality that was resubmitting the form on pageload, essentially giving us two pageloads. This configuration should probably help with the no-JS version.

It also means that we have the current active search persist, whereas currently if I click from images => catalogue or visa versa and refresh, you go to the original active tab.

To reproduce ▶
* visit `/collections`
* search the catalogue for `hats`
* swap the tab to `images`
* refresh
* you're back on `/works?query=hats`

This does point in the direction of trying to use non-JS interactions as much as possible. Next does a great job of makoing them seem seamless.

I can split this out if we like it, otherwise we'll need another solution to not resubmitting the form.

---

- [ ] Find a way to add clientside props to the info e.g. position of result clicked
- [ ] Convert all pages to TSX to benefit from the type safety of this