### PR TITLE
Use ECR base images in Dockerfiles

### DIFF
--- a/cache/edge_lambdas/Dockerfile
+++ b/cache/edge_lambdas/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.18.3
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/node:12.18.3
 
 VOLUME /dist
 

--- a/cardigan/Dockerfile
+++ b/cardigan/Dockerfile
@@ -1,5 +1,5 @@
 # This image should be built with the parent directory as context
-FROM node:12.18.3
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/node:12.18.3
 
 WORKDIR /usr/src/app/webapp
 

--- a/catalogue/Dockerfile
+++ b/catalogue/Dockerfile
@@ -1,5 +1,5 @@
 # This image should be built with the parent directory as context
-FROM node:12.18.3
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/node:12.18.3
 
 WORKDIR /usr/src/app/webapp
 

--- a/common/Dockerfile
+++ b/common/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.18.3
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/node:12.18.3
 
 WORKDIR /usr/src/app/webapp
 

--- a/content/Dockerfile
+++ b/content/Dockerfile
@@ -1,5 +1,5 @@
 # This image should be built with the parent directory as context
-FROM node:12.18.3
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/node:12.18.3
 
 WORKDIR /usr/src/app/webapp
 

--- a/pa11y/Dockerfile
+++ b/pa11y/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.18.3
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/node:12.18.3
 
 VOLUME /dist
 

--- a/toggles/Dockerfile
+++ b/toggles/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.18.3
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/node:12.18.3
 
 VOLUME /dist
 

--- a/updown/Dockerfile
+++ b/updown/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.14.0
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/node:14.14.0
 
 WORKDIR /usr/src/app/webapp
 


### PR DESCRIPTION
This should stop the pull rate limit errors in CI. Right now, you may need to login to ECR in order to build these locally (annoying!) - you do that with:
```
eval $(AWS_PROFILE=platform-dev aws ecr get-login --no-include-email)
```

AWS is apparently going to have a public container registry available "within weeks" so hopefully this won't be the case for long.