### PR TITLE
Move lint back to pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
   },
   "husky": {
     "hooks": {
-      "pre-push": "lint-staged & yarn tsc"
+      "pre-commit": "lint-staged",
+      "pre-push": "yarn tsc"
     }
   }
 }


### PR DESCRIPTION
We run `eslint` on any files staged for commit. But since we're now running it in the `pre-push` hook, they're not staged at this point – they've already been committed. So we're not linting anything.

I think the two options are:

1. lint the staged files in the `pre-commit` hook (as we did previously – fairly fast because you're only checking a small number of files, but happens on every commit), or
2. lint all files in the `pre-push` hook (would take a lot longer, but only happen the once)

I think my preference would be for 1., and keeping the TypeScript compilation check in the `pre-push` hook (as per this PR).

