### PR TITLE
Allow non js search prototype to display and update on tabs as links 

### DIFF
--- a/catalogue/webapp/components/SearchTitle/SearchTitle.tsx
+++ b/catalogue/webapp/components/SearchTitle/SearchTitle.tsx
@@ -1,0 +1,31 @@
+import { FunctionComponent, ReactElement } from 'react';
+import { grid, classNames } from '@weco/common/utils/classnames';
+import Space from '@weco/common/views/components/styled/Space';
+
+const SearchTitle: FunctionComponent = (): ReactElement => {
+  return (
+    <div className="grid">
+      <div className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>
+        <Space
+          v={{
+            size: 'm',
+            properties: ['margin-bottom'],
+          }}
+          className={classNames([
+            'flex flex--h-space-between flex--v-center flex--wrap',
+          ])}
+        >
+          <Space
+            as="h1"
+            v={{ size: 'm', properties: ['margin-bottom'] }}
+            className="h1"
+          >
+            Search the collections
+          </Space>
+        </Space>
+      </div>
+    </div>
+  );
+};
+
+export default SearchTitle;

--- a/catalogue/webapp/pages/images.tsx
+++ b/catalogue/webapp/pages/images.tsx
@@ -34,6 +34,7 @@ import {
   WithGlobalContextData,
 } from '@weco/common/views/components/GlobalContextProvider/GlobalContextProvider';
 import { removeUndefinedProps } from '@weco/common/utils/json';
+import SearchTitle from '../components/SearchTitle/SearchTitle';
 
 type Props = {
   results?: CatalogueResultsList<Image> | CatalogueApiError;
@@ -168,6 +169,8 @@ const Images: NextPage<Props> = ({
           className={classNames(['row'])}
         >
           <div className="container">
+            {!results && <SearchTitle />}
+
             <div className="grid">
               <div className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>
                 <SearchTabs

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -46,7 +46,8 @@ import SearchTabs from '@weco/common/views/components/SearchTabs/SearchTabs';
 import SearchNoResults from '../components/SearchNoResults/SearchNoResults';
 // $FlowFixMe (tsx)
 import { removeUndefinedProps } from '@weco/common/utils/json';
-
+// $FlowFixMe (tsx)
+import SearchTitle from '../components/SearchTitle/SearchTitle';
 type Props = {|
   works: ?CatalogueResultsList<Work> | CatalogueApiError,
   images: ?CatalogueResultsList<Image> | CatalogueApiError,
@@ -160,29 +161,7 @@ const Works = ({
           className={classNames(['row'])}
         >
           <div className="container">
-            {!results && (
-              <div className="grid">
-                <div className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>
-                  <Space
-                    v={{
-                      size: 'm',
-                      properties: ['margin-bottom'],
-                    }}
-                    className={classNames([
-                      'flex flex--h-space-between flex--v-center flex--wrap',
-                    ])}
-                  >
-                    <Space
-                      as="h1"
-                      v={{ size: 'm', properties: ['margin-bottom'] }}
-                      className="h1"
-                    >
-                      Search the collections
-                    </Space>
-                  </Space>
-                </div>
-              </div>
-            )}
+            {!results && <SearchTitle />}
 
             <div className="grid">
               <div className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>

--- a/common/views/components/PrototypeSearchForm/PrototypeSearchForm.tsx
+++ b/common/views/components/PrototypeSearchForm/PrototypeSearchForm.tsx
@@ -38,7 +38,6 @@ type Props = {
   workTypeAggregations: CatalogueAggregationBucket[];
   aggregations: CatalogueAggregations | null;
   isImageSearch: boolean;
-  isActive: boolean;
   shouldShowFilters: boolean;
 };
 
@@ -82,7 +81,6 @@ const PrototypeSearchForm: FunctionComponent<Props> = ({
   workTypeAggregations,
   aggregations,
   isImageSearch,
-  isActive,
   shouldShowFilters,
 }: Props): ReactElement<Props> => {
   const [, setSearchParamsState] = useSavedSearchState(routeProps);
@@ -94,7 +92,6 @@ const PrototypeSearchForm: FunctionComponent<Props> = ({
   const [inputQuery, setInputQuery] = useState(query);
   const searchInput = useRef<HTMLInputElement>(null);
   const [portalSortOrder, setPortalSortOrder] = useState(routeProps.sortOrder);
-  const [isInitialLoad, setIsInitialLoad] = useState(true);
   function submit() {
     searchForm.current &&
       searchForm.current.dispatchEvent(
@@ -111,16 +108,6 @@ const PrototypeSearchForm: FunctionComponent<Props> = ({
       setInputQuery(query);
     }
   }, [query]);
-
-  useEffect(() => {
-    if (query && isActive && !isInitialLoad) {
-      submit();
-    }
-  }, [isActive]);
-
-  useEffect(() => {
-    setIsInitialLoad(false);
-  }, []);
 
   useEffect(() => {
     if (portalSortOrder !== routeProps.sortOrder) {

--- a/common/views/components/SearchTabs/SearchTabs.tsx
+++ b/common/views/components/SearchTabs/SearchTabs.tsx
@@ -2,7 +2,7 @@ import BaseTabs, { TabType } from '../BaseTabs/BaseTabs';
 import { classNames, font } from '@weco/common/utils/classnames';
 import styled from 'styled-components';
 import Space from '../styled/Space';
-import { useContext, useState, FunctionComponent, ReactElement } from 'react';
+import { useContext, FunctionComponent, ReactElement } from 'react';
 import { AppContext } from '../AppContext/AppContext';
 import PrototypeSearchForm from '@weco/common/views/components/PrototypeSearchForm/PrototypeSearchForm';
 import {
@@ -14,12 +14,11 @@ import {
   CatalogueAggregations,
 } from '@weco/common/model/catalogue';
 import { trackEvent } from '@weco/common/utils/ga';
+import NextLink from 'next/link';
+import { removeEmptyProps } from '../../../utils/json';
+import { useRouter } from 'next/router';
 
-const BaseTabsWrapper = styled.div.attrs<{ isEnhanced: boolean }>(props => ({
-  className: classNames({
-    'is-hidden': !props.isEnhanced,
-  }),
-}))<{ isEnhanced: boolean }>`
+const BaseTabsWrapper = styled.div`
   // FIXME: For testing, make the checkboxes/buttons have a white background because they're on grey
   [class*='ButtonInline__InlineButton'],
   [class^='CheckboxRadio__CheckboxRadioBox'] {
@@ -84,22 +83,37 @@ const SearchTabs: FunctionComponent<Props> = ({
   activeTabIndex,
   shouldShowFilters,
 }: Props): ReactElement<Props> => {
-  const { isKeyboard, isEnhanced } = useContext(AppContext);
-  const [activeTab, setActiveTab] = useState(
-    activeTabIndex === 0 ? 'tab-library-catalogue' : 'tab-images'
-  );
+  const router = useRouter();
+  const { query } = router.query;
+
+  const { isKeyboard } = useContext(AppContext);
   const tabs: TabType[] = [
     {
       id: 'tab-library-catalogue',
       tab: function TabWithDisplayName(isActive, isFocused) {
         return (
-          <Tab
-            isActive={isActive}
-            isFocused={isFocused}
-            isKeyboard={isKeyboard}
+          <NextLink
+            href={{
+              pathname: '/works',
+              query: removeEmptyProps({
+                query,
+              }),
+            }}
           >
-            Library catalogue
-          </Tab>
+            <a
+              className={classNames({
+                'plain-link': true,
+              })}
+            >
+              <Tab
+                isActive={isActive}
+                isFocused={isFocused}
+                isKeyboard={isKeyboard}
+              >
+                Library catalogue
+              </Tab>
+            </a>
+          </NextLink>
         );
       },
       tabPanel: (
@@ -118,7 +132,6 @@ const SearchTabs: FunctionComponent<Props> = ({
             access.
           </Space>
           <PrototypeSearchForm
-            isActive={activeTab === 'tab-library-catalogue'}
             ariaDescribedBy={'library-catalogue-form-description'}
             routeProps={worksRouteProps}
             workTypeAggregations={workTypeAggregations}
@@ -133,14 +146,29 @@ const SearchTabs: FunctionComponent<Props> = ({
       id: 'tab-images',
       tab: function TabWithDisplayName(isActive, isFocused) {
         return (
-          <Tab
-            isActive={isActive}
-            isFocused={isFocused}
-            isKeyboard={isKeyboard}
-            isLast={true}
+          <NextLink
+            href={{
+              pathname: '/images',
+              query: removeEmptyProps({
+                query,
+              }),
+            }}
           >
-            Images
-          </Tab>
+            <a
+              className={classNames({
+                'plain-link': true,
+              })}
+            >
+              <Tab
+                isActive={isActive}
+                isFocused={isFocused}
+                isKeyboard={isKeyboard}
+                isLast={true}
+              >
+                Images
+              </Tab>
+            </a>
+          </NextLink>
         );
       },
       tabPanel: (
@@ -158,7 +186,6 @@ const SearchTabs: FunctionComponent<Props> = ({
             museum collections, including objects at the Science Museum.
           </Space>
           <PrototypeSearchForm
-            isActive={activeTab === 'tab-images'}
             ariaDescribedBy="images-form-description"
             routeProps={imagesRouteProps}
             workTypeAggregations={workTypeAggregations}
@@ -179,18 +206,13 @@ const SearchTabs: FunctionComponent<Props> = ({
     });
   }
 
-  function onTabChanged(id: string) {
-    setActiveTab(id);
-  }
-
   return (
-    <BaseTabsWrapper isEnhanced={isEnhanced}>
+    <BaseTabsWrapper>
       <BaseTabs
         tabs={tabs}
         label={'Tabs for search'}
         activeTabIndex={activeTabIndex}
         onTabClick={onTabClick}
-        onTabChanged={onTabChanged}
       />
     </BaseTabsWrapper>
   );


### PR DESCRIPTION
* Make tabs work via links to stop janking on render on non js view. #5795 
* Create search title component to be used on works and images.tsx
* update the search tabs to allow to display for non js to display current state.

relating to 
#5740

