### PR TITLE
convert image page to tsx and add error pages

### DIFF
--- a/catalogue/Dockerfile
+++ b/catalogue/Dockerfile
@@ -1,4 +1,4 @@
-# This image should be built with the parent directory as context
+  # This image should be built with the parent directory as context
 FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/node:12.18.3
 
 WORKDIR /usr/src/app/webapp

--- a/catalogue/Dockerfile
+++ b/catalogue/Dockerfile
@@ -1,4 +1,4 @@
-  # This image should be built with the parent directory as context
+# This image should be built with the parent directory as context
 FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/node:12.18.3
 
 WORKDIR /usr/src/app/webapp

--- a/catalogue/webapp/pages/404.tsx
+++ b/catalogue/webapp/pages/404.tsx
@@ -1,0 +1,8 @@
+import { NextPage } from 'next';
+import ErrorPage from '@weco/common/views/components/ErrorPage/ErrorPage';
+
+const Page: NextPage = () => {
+  return <ErrorPage statusCode={404} globalContextData={{}} />;
+};
+
+export default Page;

--- a/catalogue/webapp/pages/_error.tsx
+++ b/catalogue/webapp/pages/_error.tsx
@@ -1,0 +1,41 @@
+import { GetServerSideProps, NextPage } from 'next';
+import {
+  getGlobalContextData,
+  GlobalContextData,
+} from '@weco/common/views/components/GlobalContextProvider/GlobalContextProvider';
+import ErrorPage from '@weco/common/views/components/ErrorPage/ErrorPage';
+
+type Props = {
+  statusCode: number;
+  message: string;
+  globalContextData: GlobalContextData;
+};
+
+const Page: NextPage<Props> = ({
+  message,
+  statusCode,
+  globalContextData,
+}: Props) => {
+  return (
+    <ErrorPage
+      title={message}
+      statusCode={statusCode}
+      globalContextData={globalContextData}
+    />
+  );
+};
+
+export const getServerSideProps: GetServerSideProps<Props> = async context => {
+  const globalContextData = getGlobalContextData(context);
+
+  return {
+    props: {
+      message:
+        'Something unexpected happened. Our team will be looking into it.',
+      statusCode: context.res.statusCode,
+      globalContextData,
+    },
+  };
+};
+
+export default Page;

--- a/catalogue/webapp/pages/work.tsx
+++ b/catalogue/webapp/pages/work.tsx
@@ -11,6 +11,7 @@ import {
   WithGlobalContextData,
 } from '@weco/common/views/components/GlobalContextProvider/GlobalContextProvider';
 import { removeUndefinedProps } from '@weco/common/utils/json';
+import { appError, AppErrorProps } from '@weco/common/views/pages/_app';
 
 type Props = {
   workResponse: WorkType | CatalogueApiError;
@@ -36,7 +37,9 @@ export const WorkPage: NextPage<Props> = ({
   );
 };
 
-export const getServerSideProps: GetServerSideProps<Props> = async context => {
+export const getServerSideProps: GetServerSideProps<
+  Props | AppErrorProps
+> = async context => {
   const globalContextData = getGlobalContextData(context);
   const { id } = context.query;
 
@@ -53,6 +56,13 @@ export const getServerSideProps: GetServerSideProps<Props> = async context => {
         permanent: workResponse.status === 301,
       },
     };
+  }
+
+  if (workResponse.type === 'Error') {
+    if (workResponse.httpStatus === 404) {
+      return { notFound: true };
+    }
+    return appError(context, workResponse.statusCode, 'Works API error');
   }
 
   return {

--- a/catalogue/webapp/services/catalogue/common.js
+++ b/catalogue/webapp/services/catalogue/common.js
@@ -26,10 +26,18 @@ export const queryString = (params: { [key: string]: any }): string => {
   return strings.length > 0 ? `?${strings.join('&')}` : '';
 };
 
-export const catalogueApiError = (): CatalogueApiError => ({
+export const notFound = (): CatalogueApiError => ({
+  errorType: 'http',
+  httpStatus: 404,
+  label: 'Not Found',
   description: '',
+  type: 'Error',
+});
+
+export const catalogueApiError = (): CatalogueApiError => ({
   errorType: 'http',
   httpStatus: 500,
   label: 'Internal Server Error',
+  description: '',
   type: 'Error',
 });

--- a/catalogue/webapp/services/catalogue/images.js
+++ b/catalogue/webapp/services/catalogue/images.js
@@ -11,6 +11,7 @@ import {
   globalApiOptions,
   queryString,
   catalogueApiError,
+  notFound,
 } from './common';
 
 type GetImagesProps = {|
@@ -70,6 +71,10 @@ export async function getImage({
   try {
     const res = await fetch(url);
     const json = await res.json();
+    if (res.status === 404) {
+      return notFound();
+    }
+
     return json;
   } catch (e) {
     return catalogueApiError();

--- a/catalogue/webapp/services/catalogue/works.js
+++ b/catalogue/webapp/services/catalogue/works.js
@@ -15,6 +15,7 @@ import {
   globalApiOptions,
   queryString,
   rootUris,
+  notFound,
   type Toggles,
 } from './common';
 
@@ -121,6 +122,9 @@ export async function getWork({
 
   try {
     const json = await res.json();
+    if (res.status === 404) {
+      return notFound();
+    }
     return json;
   } catch (e) {
     return catalogueApiError();

--- a/common/views/components/CataloguePageLayout/CataloguePageLayout.tsx
+++ b/common/views/components/CataloguePageLayout/CataloguePageLayout.tsx
@@ -1,4 +1,3 @@
-// @flow
 import { FunctionComponent, useContext, useEffect, useState } from 'react';
 import PageLayout, { Props as PageLayoutProps } from '../PageLayout/PageLayout';
 import InfoBanner from '../InfoBanner/InfoBanner';

--- a/common/views/components/ErrorPage/ErrorPage.js
+++ b/common/views/components/ErrorPage/ErrorPage.js
@@ -12,12 +12,12 @@ import { headerBackgroundLs } from '@weco/common/utils/backgrounds';
 import { type GlobalContextData } from '@weco/common/views/components/GlobalContextProvider/GlobalContextProvider';
 
 type Props = {|
-  statusCode: number,
-  title?: ?string,
+  statusCode?: number,
+  title?: string,
   globalContextData: GlobalContextData,
 |};
 
-const ErrorPage = ({ statusCode, title, globalContextData }: Props) => {
+const ErrorPage = ({ statusCode = 500, title, globalContextData }: Props) => {
   return (
     <PageLayout
       title={`${statusCode}`}

--- a/common/views/components/GlobalContextProvider/GlobalContextProvider.tsx
+++ b/common/views/components/GlobalContextProvider/GlobalContextProvider.tsx
@@ -34,14 +34,15 @@ const GlobalContextProvider: FunctionComponent<Props> = ({
   value,
   children,
 }: Props) => {
-  const parsedOpeningTimes = parseCollectionVenues(value.openingTimes);
+  const parsedOpeningTimes =
+    value.openingTimes && parseCollectionVenues(value.openingTimes);
   return (
     <Context.Provider value={value}>
       <OpeningTimesContext.Provider value={parsedOpeningTimes}>
         <GlobalAlertContext.Provider value={value.globalAlert}>
           <PopupDialogContext.Provider value={value.popupDialog}>
             <TogglesContext.Provider value={value.toggles}>
-              {value.toggles.helveticaRegular && (
+              {value.toggles && value.toggles.helveticaRegular && (
                 <style
                   type="text/css"
                   dangerouslySetInnerHTML={{

--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -75,14 +75,12 @@ const PageLayoutComponent: FunctionComponent<ComponentProps> = ({
   const globalAlert = useContext(GlobalAlertContext);
   const popupDialog = useContext(PopupDialogContext);
   const openingTimes = useContext(OpeningTimesContext);
-  const galleries = getParseCollectionVenueById(
-    openingTimes,
-    collectionVenueId.galleries.id
-  );
-  const library = getParseCollectionVenueById(
-    openingTimes,
-    collectionVenueId.libraries.id
-  );
+  const galleries =
+    openingTimes &&
+    getParseCollectionVenueById(openingTimes, collectionVenueId.galleries.id);
+  const library =
+    openingTimes &&
+    getParseCollectionVenueById(openingTimes, collectionVenueId.libraries.id);
   const galleriesOpeningHours = galleries && galleries.openingHours;
   const libraryOpeningHours = library && library.openingHours;
   const wellcomeCollectionGalleryWithHours = {
@@ -272,7 +270,7 @@ const PageLayoutComponent: FunctionComponent<ComponentProps> = ({
           hide={hideFooter}
           openingTimes={openingTimes}
           upcomingExceptionalOpeningPeriods={
-            openingTimes.upcomingExceptionalOpeningPeriods
+            openingTimes && openingTimes.upcomingExceptionalOpeningPeriods
           }
         />
       </div>

--- a/content/webapp/pages/404.tsx
+++ b/content/webapp/pages/404.tsx
@@ -1,0 +1,8 @@
+import { NextPage } from 'next';
+import ErrorPage from '@weco/common/views/components/ErrorPage/ErrorPage';
+
+const Page: NextPage = () => {
+  return <ErrorPage statusCode={404} globalContextData={{}} />;
+};
+
+export default Page;


### PR DESCRIPTION
Started converting the `image` page to tsx, and realised error pages were in a mess.

* Added the `_error` pages which will catch thrown errors from next and render the `ErrorPage`
* Allow `getServerSideProps` to pass `AppErrorProps` to `_app` which then render the `ErrorPage`
* Allow PageLayout to render without `GlobalContextData` values
* return `notFound` from images API
* handle errors from works API

The next thing to do would be to integrate sentry with the new pages, but I'd like to have more of a think of where the error boundaries are and what errors we alert no. So watch this space.