### PR TITLE
Non JS search: Make search tab align together instead of a row

### DIFF
--- a/common/views/components/BaseTabs/BaseTabs.tsx
+++ b/common/views/components/BaseTabs/BaseTabs.tsx
@@ -43,7 +43,7 @@ type TabPanelProps = {
 const TabPanel = styled.div.attrs((props: TabPanelProps) => ({
   id: props.id,
   role: 'tabpanel',
-  hidden: props.isEnhanced && !props.isActive,
+  hidden: !props.isActive,
   'aria-expanded': props.isActive,
 }))<TabPanelProps>``;
 
@@ -139,32 +139,29 @@ const Tabs: FunctionComponent<Props> = ({
 
   return (
     <>
-      {isEnhanced && (
-        <TabList ref={tabListRef} aria-label={label}>
-          {tabs.map(({ id, tab }) => (
-            <Tab
-              key={id}
-              id={id}
-              tabPanelId={id}
-              isActive={id === activeId}
-              onClick={() => handleTabClick(id)}
-              onBlur={() => setFocusedId(null)}
-              onFocus={() => setFocusedId(id)}
-              onKeyDown={handleKeyDown}
-            >
-              {tab(id === activeId, id === focusedId)}
-            </Tab>
-          ))}
-        </TabList>
-      )}
-      {tabs.map(({ id, tabPanel, tab }) => (
+      <TabList ref={tabListRef} aria-label={label}>
+        {tabs.map(({ id, tab }) => (
+          <Tab
+            key={id}
+            id={id}
+            tabPanelId={id}
+            isActive={id === activeId}
+            onClick={() => handleTabClick(id)}
+            onBlur={() => setFocusedId(null)}
+            onFocus={() => setFocusedId(id)}
+            onKeyDown={handleKeyDown}
+          >
+            {tab(id === activeId, id === focusedId)}
+          </Tab>
+        ))}
+      </TabList>
+      {tabs.map(({ id, tabPanel }) => (
         <TabPanel
           key={id}
           id={id}
           isActive={id === activeId}
           isEnhanced={isEnhanced}
         >
-          {!isEnhanced && tab(id === activeId, id === focusedId)}
           {tabPanel}
         </TabPanel>
       ))}


### PR DESCRIPTION
The tab panels are now href links so for the non js version we can display it like the javascript version. 

Effected pages 

- images search results 
- library search results 
- collections search page

<img width="1275" alt="Screenshot 2020-11-24 at 11 23 31" src="https://user-images.githubusercontent.com/9095365/100099032-c3aea580-2e56-11eb-99ca-3c70cb797e8b.png">

closes #5810 

## Who is this for?


## What is it doing for them?
