### PR TITLE
Non javascript: currently noscript images on search are not displaying correctly on live

### DIFF
--- a/catalogue/webapp/components/ImageCard/ImageCard.js
+++ b/catalogue/webapp/components/ImageCard/ImageCard.js
@@ -40,6 +40,7 @@ const ImageWrap = styled(Space).attrs({
     height: 100%;
     width: auto;
   }
+  noscript { display: inline; }
 `;
 
 const ImageCard = ({ id, image, onClick, workId }: Props) => {


### PR DESCRIPTION
Non javascript: search on images visual issues with images overlapping each other

**Current**:

![Screenshot 2020-11-25 at 15 03 26](https://user-images.githubusercontent.com/9095365/100244930-63d7fd80-2f2f-11eb-9ae1-7bf2917ef32d.png)

**Fix** : 
![Screenshot 2020-11-25 at 15 04 48](https://user-images.githubusercontent.com/9095365/100245304-cdf0a280-2f2f-11eb-9bd9-7b80bce62aea.png)



## Who is this for?

non javascript users and seo

## What is it doing for them?
