### PR TITLE
Fixes bug where tree control for the initially loaded work is not shown

### DIFF
--- a/common/views/components/ArchiveTree/ArchiveTree.js
+++ b/common/views/components/ArchiveTree/ArchiveTree.js
@@ -299,7 +299,10 @@ function createSiblingsArray({
       children: undefined,
     })),
     createNodeFromWork({
-      work,
+      work: {
+        ...work,
+        totalParts: work.parts && work.parts.length,
+      },
       openStatus: !openStatusOverride,
     }),
     ...(work.succeededBy || []).map(item => ({


### PR DESCRIPTION
Before: 
![Before](https://user-images.githubusercontent.com/6051896/100449646-2d73bd00-30ac-11eb-8bec-57afd9d8e94c.png)

After:
![Screenshot 2020-11-27 at 12 30 36](https://user-images.githubusercontent.com/6051896/100449772-6875f080-30ac-11eb-85de-ea0985c33030.png)
