### PR TITLE
add base identity app

### DIFF
--- a/cardigan/.storybook/main.js
+++ b/cardigan/.storybook/main.js
@@ -1,6 +1,7 @@
 const path = require('path');
 module.exports = {
   stories: [
+    '../stories/components/**/*.tsx',
     '../stories/components/*.js',
     '../stories/global/**/*.js',
     '../stories/docs/*.js',

--- a/cardigan/stories/components/oath/Login.tsx
+++ b/cardigan/stories/components/oath/Login.tsx
@@ -1,0 +1,9 @@
+import { storiesOf } from '@storybook/react';
+import Login from '../../../../common/views/components/oauth/Login';
+
+const LoginExample = () => {
+  return <Login text={'Identity'} />;
+};
+
+const stories = storiesOf('Components/Oath', module);
+stories.add('Oauth login', LoginExample);

--- a/cardigan/stories/opening-times.js
+++ b/cardigan/stories/opening-times.js
@@ -1,604 +1,604 @@
 export const groupedVenues = {
-  'galleriesLibrary': {
-    'title': 'Venue',
-    'hours': [
+  galleriesLibrary: {
+    title: 'Venue',
+    hours: [
       {
-        'id': 'Wsttgx8AAJeSNmJ4',
-        'name': 'Galleries',
-        'order': 1,
-        'openingHours': {
-          'regular': [
+        id: 'Wsttgx8AAJeSNmJ4',
+        name: 'Galleries',
+        order: 1,
+        openingHours: {
+          regular: [
             {
-              'dayOfWeek': 'Monday',
-              'opens': null,
-              'closes': null
+              dayOfWeek: 'Monday',
+              opens: null,
+              closes: null,
             },
             {
-              'dayOfWeek': 'Tuesday',
-              'opens': '10:00',
-              'closes': '18:00'
+              dayOfWeek: 'Tuesday',
+              opens: '10:00',
+              closes: '18:00',
             },
             {
-              'dayOfWeek': 'Wednesday',
-              'opens': '10:00',
-              'closes': '18:00'
+              dayOfWeek: 'Wednesday',
+              opens: '10:00',
+              closes: '18:00',
             },
             {
-              'dayOfWeek': 'Thursday',
-              'opens': '10:00',
-              'closes': '22:00'
+              dayOfWeek: 'Thursday',
+              opens: '10:00',
+              closes: '22:00',
             },
             {
-              'dayOfWeek': 'Friday',
-              'opens': '10:00',
-              'closes': '18:00'
+              dayOfWeek: 'Friday',
+              opens: '10:00',
+              closes: '18:00',
             },
             {
-              'dayOfWeek': 'Saturday',
-              'opens': '10:00',
-              'closes': '18:00'
+              dayOfWeek: 'Saturday',
+              opens: '10:00',
+              closes: '18:00',
             },
             {
-              'dayOfWeek': 'Sunday',
-              'opens': '11:00',
-              'closes': '18:00'
-            }
+              dayOfWeek: 'Sunday',
+              opens: '11:00',
+              closes: '18:00',
+            },
           ],
-          'exceptional': [
+          exceptional: [
             {
-              'overrideDate': '2018-04-01T23:00:00.000Z',
-              'overrideType': 'Easter',
-              'opens': '10:00',
-              'closes': '18:00'
+              overrideDate: '2018-04-01T23:00:00.000Z',
+              overrideType: 'Easter',
+              opens: '10:00',
+              closes: '18:00',
             },
             {
-              'overrideDate': '2018-05-06T23:00:00.000Z',
-              'overrideType': 'Bank holiday',
-              'opens': '10:00',
-              'closes': '18:00'
+              overrideDate: '2018-05-06T23:00:00.000Z',
+              overrideType: 'Bank holiday',
+              opens: '10:00',
+              closes: '18:00',
             },
             {
-              'overrideDate': '2018-05-27T23:00:00.000Z',
-              'overrideType': 'Bank holiday',
-              'opens': '10:00',
-              'closes': '18:00'
+              overrideDate: '2018-05-27T23:00:00.000Z',
+              overrideType: 'Bank holiday',
+              opens: '10:00',
+              closes: '18:00',
             },
             {
-              'overrideDate': '2018-08-27T09:00:00.000Z',
-              'overrideType': 'Bank holiday',
-              'opens': '10:00',
-              'closes': '18:00'
+              overrideDate: '2018-08-27T09:00:00.000Z',
+              overrideType: 'Bank holiday',
+              opens: '10:00',
+              closes: '18:00',
             },
             {
-              'overrideDate': '2018-12-25T00:00:00.000Z',
-              'overrideType': 'Christmas and New Year',
-              'opens': null,
-              'closes': null
+              overrideDate: '2018-12-25T00:00:00.000Z',
+              overrideType: 'Christmas and New Year',
+              opens: null,
+              closes: null,
             },
             {
-              'overrideDate': '2018-12-26T00:00:00.000Z',
-              'overrideType': 'Christmas and New Year',
-              'opens': null,
-              'closes': null
+              overrideDate: '2018-12-26T00:00:00.000Z',
+              overrideType: 'Christmas and New Year',
+              opens: null,
+              closes: null,
             },
             {
-              'overrideDate': '2018-12-27T00:00:00.000Z',
-              'overrideType': 'Christmas and New Year',
-              'opens': '10:00',
-              'closes': '18:00'
+              overrideDate: '2018-12-27T00:00:00.000Z',
+              overrideType: 'Christmas and New Year',
+              opens: '10:00',
+              closes: '18:00',
             },
             {
-              'overrideDate': '2019-01-01T00:00:00.000Z',
-              'overrideType': 'Christmas and New Year',
-              'opens': null,
-              'closes': null
-            }
-          ]
-        }
+              overrideDate: '2019-01-01T00:00:00.000Z',
+              overrideType: 'Christmas and New Year',
+              opens: null,
+              closes: null,
+            },
+          ],
+        },
       },
       {
-        'id': 'WsuS_R8AACS1Nwlx',
-        'name': 'Library',
-        'order': 2,
-        'openingHours': {
-          'regular': [
+        id: 'WsuS_R8AACS1Nwlx',
+        name: 'Library',
+        order: 2,
+        openingHours: {
+          regular: [
             {
-              'dayOfWeek': 'Monday',
-              'opens': '10:00',
-              'closes': '18:00'
+              dayOfWeek: 'Monday',
+              opens: '10:00',
+              closes: '18:00',
             },
             {
-              'dayOfWeek': 'Tuesday',
-              'opens': '10:00',
-              'closes': '18:00'
+              dayOfWeek: 'Tuesday',
+              opens: '10:00',
+              closes: '18:00',
             },
             {
-              'dayOfWeek': 'Wednesday',
-              'opens': '10:00',
-              'closes': '18:00'
+              dayOfWeek: 'Wednesday',
+              opens: '10:00',
+              closes: '18:00',
             },
             {
-              'dayOfWeek': 'Thursday',
-              'opens': '10:00',
-              'closes': '20:00'
+              dayOfWeek: 'Thursday',
+              opens: '10:00',
+              closes: '20:00',
             },
             {
-              'dayOfWeek': 'Friday',
-              'opens': '10:00',
-              'closes': '18:00'
+              dayOfWeek: 'Friday',
+              opens: '10:00',
+              closes: '18:00',
             },
             {
-              'dayOfWeek': 'Saturday',
-              'opens': '10:00',
-              'closes': '16:00'
+              dayOfWeek: 'Saturday',
+              opens: '10:00',
+              closes: '16:00',
             },
             {
-              'dayOfWeek': 'Sunday',
-              'opens': null,
-              'closes': null
-            }
+              dayOfWeek: 'Sunday',
+              opens: null,
+              closes: null,
+            },
           ],
-          'exceptional': [
+          exceptional: [
             {
-              'overrideDate': '2018-03-29T23:00:00.000Z',
-              'overrideType': 'Easter',
-              'opens': null,
-              'closes': null
+              overrideDate: '2018-03-29T23:00:00.000Z',
+              overrideType: 'Easter',
+              opens: null,
+              closes: null,
             },
             {
-              'overrideDate': '2018-03-30T23:00:00.000Z',
-              'overrideType': 'Easter',
-              'opens': null,
-              'closes': null
+              overrideDate: '2018-03-30T23:00:00.000Z',
+              overrideType: 'Easter',
+              opens: null,
+              closes: null,
             },
             {
-              'overrideDate': '2018-04-01T23:00:00.000Z',
-              'overrideType': 'Easter',
-              'opens': null,
-              'closes': null
+              overrideDate: '2018-04-01T23:00:00.000Z',
+              overrideType: 'Easter',
+              opens: null,
+              closes: null,
             },
             {
-              'overrideDate': '2018-05-04T23:00:00.000Z',
-              'overrideType': 'Bank holiday',
-              'opens': null,
-              'closes': null
+              overrideDate: '2018-05-04T23:00:00.000Z',
+              overrideType: 'Bank holiday',
+              opens: null,
+              closes: null,
             },
             {
-              'overrideDate': '2018-05-05T23:00:00.000Z',
-              'overrideType': 'Bank holiday',
-              'opens': null,
-              'closes': null
+              overrideDate: '2018-05-05T23:00:00.000Z',
+              overrideType: 'Bank holiday',
+              opens: null,
+              closes: null,
             },
             {
-              'overrideDate': '2018-05-06T23:00:00.000Z',
-              'overrideType': 'Bank holiday',
-              'opens': null,
-              'closes': null
+              overrideDate: '2018-05-06T23:00:00.000Z',
+              overrideType: 'Bank holiday',
+              opens: null,
+              closes: null,
             },
             {
-              'overrideDate': '2018-05-25T23:00:00.000Z',
-              'overrideType': 'Bank holiday',
-              'opens': null,
-              'closes': null
+              overrideDate: '2018-05-25T23:00:00.000Z',
+              overrideType: 'Bank holiday',
+              opens: null,
+              closes: null,
             },
             {
-              'overrideDate': '2018-05-26T23:00:00.000Z',
-              'overrideType': 'Bank holiday',
-              'opens': null,
-              'closes': null
+              overrideDate: '2018-05-26T23:00:00.000Z',
+              overrideType: 'Bank holiday',
+              opens: null,
+              closes: null,
             },
             {
-              'overrideDate': '2018-05-27T23:00:00.000Z',
-              'overrideType': 'Bank holiday',
-              'opens': null,
-              'closes': null
+              overrideDate: '2018-05-27T23:00:00.000Z',
+              overrideType: 'Bank holiday',
+              opens: null,
+              closes: null,
             },
             {
-              'overrideDate': '2018-08-24T23:00:00.000Z',
-              'overrideType': 'Bank holiday',
-              'opens': null,
-              'closes': null
+              overrideDate: '2018-08-24T23:00:00.000Z',
+              overrideType: 'Bank holiday',
+              opens: null,
+              closes: null,
             },
             {
-              'overrideDate': '2018-08-25T23:00:00.000Z',
-              'overrideType': 'Bank holiday',
-              'opens': null,
-              'closes': null
+              overrideDate: '2018-08-25T23:00:00.000Z',
+              overrideType: 'Bank holiday',
+              opens: null,
+              closes: null,
             },
             {
-              'overrideDate': '2018-08-26T23:00:00.000Z',
-              'overrideType': 'Bank holiday',
-              'opens': null,
-              'closes': null
+              overrideDate: '2018-08-26T23:00:00.000Z',
+              overrideType: 'Bank holiday',
+              opens: null,
+              closes: null,
             },
             {
-              'overrideDate': '2018-12-24T00:00:00.000Z',
-              'overrideType': 'Christmas and New Year',
-              'opens': null,
-              'closes': null
+              overrideDate: '2018-12-24T00:00:00.000Z',
+              overrideType: 'Christmas and New Year',
+              opens: null,
+              closes: null,
             },
             {
-              'overrideDate': '2018-12-25T00:00:00.000Z',
-              'overrideType': 'Christmas and New Year',
-              'opens': null,
-              'closes': null
+              overrideDate: '2018-12-25T00:00:00.000Z',
+              overrideType: 'Christmas and New Year',
+              opens: null,
+              closes: null,
             },
             {
-              'overrideDate': '2018-12-26T00:00:00.000Z',
-              'overrideType': 'Christmas and New Year',
-              'opens': null,
-              'closes': null
+              overrideDate: '2018-12-26T00:00:00.000Z',
+              overrideType: 'Christmas and New Year',
+              opens: null,
+              closes: null,
             },
             {
-              'overrideDate': '2018-12-27T00:00:00.000Z',
-              'overrideType': 'Christmas and New Year',
-              'opens': null,
-              'closes': null
+              overrideDate: '2018-12-27T00:00:00.000Z',
+              overrideType: 'Christmas and New Year',
+              opens: null,
+              closes: null,
             },
             {
-              'overrideDate': '2018-12-28T00:00:00.000Z',
-              'overrideType': 'Christmas and New Year',
-              'opens': null,
-              'closes': null
+              overrideDate: '2018-12-28T00:00:00.000Z',
+              overrideType: 'Christmas and New Year',
+              opens: null,
+              closes: null,
             },
             {
-              'overrideDate': '2018-12-29T00:00:00.000Z',
-              'overrideType': 'Christmas and New Year',
-              'opens': null,
-              'closes': null
+              overrideDate: '2018-12-29T00:00:00.000Z',
+              overrideType: 'Christmas and New Year',
+              opens: null,
+              closes: null,
             },
             {
-              'overrideDate': '2018-12-31T00:00:00.000Z',
-              'overrideType': 'Christmas and New Year',
-              'opens': null,
-              'closes': null
+              overrideDate: '2018-12-31T00:00:00.000Z',
+              overrideType: 'Christmas and New Year',
+              opens: null,
+              closes: null,
             },
             {
-              'overrideDate': '2019-01-01T00:00:00.000Z',
-              'overrideType': 'Christmas and New Year',
-              'opens': null,
-              'closes': null
-            }
-          ]
-        }
-      }
-    ]
+              overrideDate: '2019-01-01T00:00:00.000Z',
+              overrideType: 'Christmas and New Year',
+              opens: null,
+              closes: null,
+            },
+          ],
+        },
+      },
+    ],
   },
-  'restaurantCafeShop': {
-    'title': 'Eat & Shop',
-    'hours': [
+  restaurantCafeShop: {
+    title: 'Eat & Shop',
+    hours: [
       {
-        'id': 'WsuYER8AAOG_NyBA',
-        'name': 'Restaurant',
-        'order': 3,
-        'openingHours': {
-          'regular': [
+        id: 'WsuYER8AAOG_NyBA',
+        name: 'Restaurant',
+        order: 3,
+        openingHours: {
+          regular: [
             {
-              'dayOfWeek': 'Monday',
-              'opens': null,
-              'closes': null
+              dayOfWeek: 'Monday',
+              opens: null,
+              closes: null,
             },
             {
-              'dayOfWeek': 'Tuesday',
-              'opens': '11:00',
-              'closes': '18:00'
+              dayOfWeek: 'Tuesday',
+              opens: '11:00',
+              closes: '18:00',
             },
             {
-              'dayOfWeek': 'Wednesday',
-              'opens': '11:00',
-              'closes': '18:00'
+              dayOfWeek: 'Wednesday',
+              opens: '11:00',
+              closes: '18:00',
             },
             {
-              'dayOfWeek': 'Thursday',
-              'opens': '11:00',
-              'closes': '22:00'
+              dayOfWeek: 'Thursday',
+              opens: '11:00',
+              closes: '22:00',
             },
             {
-              'dayOfWeek': 'Friday',
-              'opens': '11:00',
-              'closes': '18:00'
+              dayOfWeek: 'Friday',
+              opens: '11:00',
+              closes: '18:00',
             },
             {
-              'dayOfWeek': 'Saturday',
-              'opens': '11:00',
-              'closes': '18:00'
+              dayOfWeek: 'Saturday',
+              opens: '11:00',
+              closes: '18:00',
             },
             {
-              'dayOfWeek': 'Sunday',
-              'opens': '11:00',
-              'closes': '18:00'
-            }
+              dayOfWeek: 'Sunday',
+              opens: '11:00',
+              closes: '18:00',
+            },
           ],
-          'exceptional': [
+          exceptional: [
             {
-              'overrideDate': '2018-05-06T23:00:00.000Z',
-              'overrideType': 'Bank holiday',
-              'opens': null,
-              'closes': null
+              overrideDate: '2018-05-06T23:00:00.000Z',
+              overrideType: 'Bank holiday',
+              opens: null,
+              closes: null,
             },
             {
-              'overrideDate': '2018-05-27T23:00:00.000Z',
-              'overrideType': 'Bank holiday',
-              'opens': null,
-              'closes': null
+              overrideDate: '2018-05-27T23:00:00.000Z',
+              overrideType: 'Bank holiday',
+              opens: null,
+              closes: null,
             },
             {
-              'overrideDate': '2018-08-26T23:00:00.000Z',
-              'overrideType': 'Bank holiday',
-              'opens': null,
-              'closes': null
+              overrideDate: '2018-08-26T23:00:00.000Z',
+              overrideType: 'Bank holiday',
+              opens: null,
+              closes: null,
             },
             {
-              'overrideDate': '2018-12-25T00:00:00.000Z',
-              'overrideType': 'Christmas and New Year',
-              'opens': null,
-              'closes': null
+              overrideDate: '2018-12-25T00:00:00.000Z',
+              overrideType: 'Christmas and New Year',
+              opens: null,
+              closes: null,
             },
             {
-              'overrideDate': '2018-12-26T00:00:00.000Z',
-              'overrideType': 'Christmas and New Year',
-              'opens': null,
-              'closes': null
+              overrideDate: '2018-12-26T00:00:00.000Z',
+              overrideType: 'Christmas and New Year',
+              opens: null,
+              closes: null,
             },
             {
-              'overrideDate': '2018-12-27T00:00:00.000Z',
-              'overrideType': 'Christmas and New Year',
-              'opens': '11:00',
-              'closes': '18:00'
+              overrideDate: '2018-12-27T00:00:00.000Z',
+              overrideType: 'Christmas and New Year',
+              opens: '11:00',
+              closes: '18:00',
             },
             {
-              'overrideDate': '2019-01-01T00:00:00.000Z',
-              'overrideType': 'Christmas and New Year',
-              'opens': null,
-              'closes': null
-            }
-          ]
-        }
+              overrideDate: '2019-01-01T00:00:00.000Z',
+              overrideType: 'Christmas and New Year',
+              opens: null,
+              closes: null,
+            },
+          ],
+        },
       },
       {
-        'id': 'WsuZKh8AAOG_NyUo',
-        'name': 'Café',
-        'order': 4,
-        'openingHours': {
-          'regular': [
+        id: 'WsuZKh8AAOG_NyUo',
+        name: 'Café',
+        order: 4,
+        openingHours: {
+          regular: [
             {
-              'dayOfWeek': 'Monday',
-              'opens': '08:30',
-              'closes': '18:00'
+              dayOfWeek: 'Monday',
+              opens: '08:30',
+              closes: '18:00',
             },
             {
-              'dayOfWeek': 'Tuesday',
-              'opens': '08:30',
-              'closes': '18:00'
+              dayOfWeek: 'Tuesday',
+              opens: '08:30',
+              closes: '18:00',
             },
             {
-              'dayOfWeek': 'Wednesday',
-              'opens': '08:30',
-              'closes': '18:00'
+              dayOfWeek: 'Wednesday',
+              opens: '08:30',
+              closes: '18:00',
             },
             {
-              'dayOfWeek': 'Thursday',
-              'opens': '08:30',
-              'closes': '22:00'
+              dayOfWeek: 'Thursday',
+              opens: '08:30',
+              closes: '22:00',
             },
             {
-              'dayOfWeek': 'Friday',
-              'opens': '08:30',
-              'closes': '18:00'
+              dayOfWeek: 'Friday',
+              opens: '08:30',
+              closes: '18:00',
             },
             {
-              'dayOfWeek': 'Saturday',
-              'opens': '09:30',
-              'closes': '18:00'
+              dayOfWeek: 'Saturday',
+              opens: '09:30',
+              closes: '18:00',
             },
             {
-              'dayOfWeek': 'Sunday',
-              'opens': '10:30',
-              'closes': '18:00'
-            }
+              dayOfWeek: 'Sunday',
+              opens: '10:30',
+              closes: '18:00',
+            },
           ],
-          'exceptional': [
+          exceptional: [
             {
-              'overrideDate': '2018-03-29T23:00:00.000Z',
-              'overrideType': 'Easter',
-              'opens': '09:30',
-              'closes': '18:00'
+              overrideDate: '2018-03-29T23:00:00.000Z',
+              overrideType: 'Easter',
+              opens: '09:30',
+              closes: '18:00',
             },
             {
-              'overrideDate': '2018-04-01T23:00:00.000Z',
-              'overrideType': 'Easter',
-              'opens': '09:30',
-              'closes': '18:00'
+              overrideDate: '2018-04-01T23:00:00.000Z',
+              overrideType: 'Easter',
+              opens: '09:30',
+              closes: '18:00',
             },
             {
-              'overrideDate': '2018-05-06T23:00:00.000Z',
-              'overrideType': 'Bank holiday',
-              'opens': '09:30',
-              'closes': '18:00'
+              overrideDate: '2018-05-06T23:00:00.000Z',
+              overrideType: 'Bank holiday',
+              opens: '09:30',
+              closes: '18:00',
             },
             {
-              'overrideDate': '2018-05-27T23:00:00.000Z',
-              'overrideType': 'Bank holiday',
-              'opens': '09:30',
-              'closes': '18:00'
+              overrideDate: '2018-05-27T23:00:00.000Z',
+              overrideType: 'Bank holiday',
+              opens: '09:30',
+              closes: '18:00',
             },
             {
-              'overrideDate': '2018-08-26T23:00:00.000Z',
-              'overrideType': 'Bank holiday',
-              'opens': '09:30',
-              'closes': '18:00'
+              overrideDate: '2018-08-26T23:00:00.000Z',
+              overrideType: 'Bank holiday',
+              opens: '09:30',
+              closes: '18:00',
             },
             {
-              'overrideDate': '2018-12-24T00:00:00.000Z',
-              'overrideType': 'Christmas and New Year',
-              'opens': null,
-              'closes': null
+              overrideDate: '2018-12-24T00:00:00.000Z',
+              overrideType: 'Christmas and New Year',
+              opens: null,
+              closes: null,
             },
             {
-              'overrideDate': '2018-12-25T00:00:00.000Z',
-              'overrideType': 'Christmas and New Year',
-              'opens': null,
-              'closes': null
+              overrideDate: '2018-12-25T00:00:00.000Z',
+              overrideType: 'Christmas and New Year',
+              opens: null,
+              closes: null,
             },
             {
-              'overrideDate': '2018-12-26T00:00:00.000Z',
-              'overrideType': 'Christmas and New Year',
-              'opens': null,
-              'closes': null
+              overrideDate: '2018-12-26T00:00:00.000Z',
+              overrideType: 'Christmas and New Year',
+              opens: null,
+              closes: null,
             },
             {
-              'overrideDate': '2018-12-27T00:00:00.000Z',
-              'overrideType': 'Christmas and New Year',
-              'opens': '09:30',
-              'closes': '18:00'
+              overrideDate: '2018-12-27T00:00:00.000Z',
+              overrideType: 'Christmas and New Year',
+              opens: '09:30',
+              closes: '18:00',
             },
             {
-              'overrideDate': '2018-12-28T00:00:00.000Z',
-              'overrideType': 'Christmas and New Year',
-              'opens': '09:30',
-              'closes': '18:00'
+              overrideDate: '2018-12-28T00:00:00.000Z',
+              overrideType: 'Christmas and New Year',
+              opens: '09:30',
+              closes: '18:00',
             },
             {
-              'overrideDate': '2018-12-31T00:00:00.000Z',
-              'overrideType': 'Christmas and New Year',
-              'opens': null,
-              'closes': null
+              overrideDate: '2018-12-31T00:00:00.000Z',
+              overrideType: 'Christmas and New Year',
+              opens: null,
+              closes: null,
             },
             {
-              'overrideDate': '2019-01-01T00:00:00.000Z',
-              'overrideType': 'Christmas and New Year',
-              'opens': null,
-              'closes': null
-            }
-          ]
-        }
+              overrideDate: '2019-01-01T00:00:00.000Z',
+              overrideType: 'Christmas and New Year',
+              opens: null,
+              closes: null,
+            },
+          ],
+        },
       },
       {
-        'id': 'WsuaIB8AAH-yNylo',
-        'name': 'Shop',
-        'order': 5,
-        'openingHours': {
-          'regular': [
+        id: 'WsuaIB8AAH-yNylo',
+        name: 'Shop',
+        order: 5,
+        openingHours: {
+          regular: [
             {
-              'dayOfWeek': 'Monday',
-              'opens': '09:00',
-              'closes': '18:00'
+              dayOfWeek: 'Monday',
+              opens: '09:00',
+              closes: '18:00',
             },
             {
-              'dayOfWeek': 'Tuesday',
-              'opens': '09:00',
-              'closes': '18:00'
+              dayOfWeek: 'Tuesday',
+              opens: '09:00',
+              closes: '18:00',
             },
             {
-              'dayOfWeek': 'Wednesday',
-              'opens': '09:00',
-              'closes': '18:00'
+              dayOfWeek: 'Wednesday',
+              opens: '09:00',
+              closes: '18:00',
             },
             {
-              'dayOfWeek': 'Thursday',
-              'opens': '09:00',
-              'closes': '22:00'
+              dayOfWeek: 'Thursday',
+              opens: '09:00',
+              closes: '22:00',
             },
             {
-              'dayOfWeek': 'Friday',
-              'opens': '09:00',
-              'closes': '18:00'
+              dayOfWeek: 'Friday',
+              opens: '09:00',
+              closes: '18:00',
             },
             {
-              'dayOfWeek': 'Saturday',
-              'opens': '10:00',
-              'closes': '18:00'
+              dayOfWeek: 'Saturday',
+              opens: '10:00',
+              closes: '18:00',
             },
             {
-              'dayOfWeek': 'Sunday',
-              'opens': '11:00',
-              'closes': '18:00'
-            }
+              dayOfWeek: 'Sunday',
+              opens: '11:00',
+              closes: '18:00',
+            },
           ],
-          'exceptional': [
+          exceptional: [
             {
-              'overrideDate': '2018-03-29T23:00:00.000Z',
-              'overrideType': 'Easter',
-              'opens': '10:00',
-              'closes': '18:00'
+              overrideDate: '2018-03-29T23:00:00.000Z',
+              overrideType: 'Easter',
+              opens: '10:00',
+              closes: '18:00',
             },
             {
-              'overrideDate': '2018-04-02T09:00:00.000Z',
-              'overrideType': 'Easter',
-              'opens': '10:00',
-              'closes': '18:00'
+              overrideDate: '2018-04-02T09:00:00.000Z',
+              overrideType: 'Easter',
+              opens: '10:00',
+              closes: '18:00',
             },
             {
-              'overrideDate': '2018-05-06T23:00:00.000Z',
-              'overrideType': 'Bank holiday',
-              'opens': '10:00',
-              'closes': '18:00'
+              overrideDate: '2018-05-06T23:00:00.000Z',
+              overrideType: 'Bank holiday',
+              opens: '10:00',
+              closes: '18:00',
             },
             {
-              'overrideDate': '2018-05-27T23:00:00.000Z',
-              'overrideType': 'Bank holiday',
-              'opens': '10:00',
-              'closes': '18:00'
+              overrideDate: '2018-05-27T23:00:00.000Z',
+              overrideType: 'Bank holiday',
+              opens: '10:00',
+              closes: '18:00',
             },
             {
-              'overrideDate': '2018-08-26T23:00:00.000Z',
-              'overrideType': 'Bank holiday',
-              'opens': '10:00',
-              'closes': '18:00'
+              overrideDate: '2018-08-26T23:00:00.000Z',
+              overrideType: 'Bank holiday',
+              opens: '10:00',
+              closes: '18:00',
             },
             {
-              'overrideDate': '2018-12-24T00:00:00.000Z',
-              'overrideType': 'Christmas and New Year',
-              'opens': null,
-              'closes': null
+              overrideDate: '2018-12-24T00:00:00.000Z',
+              overrideType: 'Christmas and New Year',
+              opens: null,
+              closes: null,
             },
             {
-              'overrideDate': '2018-12-25T00:00:00.000Z',
-              'overrideType': 'Christmas and New Year',
-              'opens': null,
-              'closes': null
+              overrideDate: '2018-12-25T00:00:00.000Z',
+              overrideType: 'Christmas and New Year',
+              opens: null,
+              closes: null,
             },
             {
-              'overrideDate': '2018-12-26T00:00:00.000Z',
-              'overrideType': 'Christmas and New Year',
-              'opens': null,
-              'closes': null
+              overrideDate: '2018-12-26T00:00:00.000Z',
+              overrideType: 'Christmas and New Year',
+              opens: null,
+              closes: null,
             },
             {
-              'overrideDate': '2018-12-27T00:00:00.000Z',
-              'overrideType': 'Christmas and New Year',
-              'opens': '09:30',
-              'closes': '18:00'
+              overrideDate: '2018-12-27T00:00:00.000Z',
+              overrideType: 'Christmas and New Year',
+              opens: '09:30',
+              closes: '18:00',
             },
             {
-              'overrideDate': '2018-12-28T00:00:00.000Z',
-              'overrideType': 'Christmas and New Year',
-              'opens': '09:30',
-              'closes': '18:00'
+              overrideDate: '2018-12-28T00:00:00.000Z',
+              overrideType: 'Christmas and New Year',
+              opens: '09:30',
+              closes: '18:00',
             },
             {
-              'overrideDate': '2018-12-31T00:00:00.000Z',
-              'overrideType': 'Christmas and New Year',
-              'opens': null,
-              'closes': null
+              overrideDate: '2018-12-31T00:00:00.000Z',
+              overrideType: 'Christmas and New Year',
+              opens: null,
+              closes: null,
             },
             {
-              'overrideDate': '2019-01-01T00:00:00.000Z',
-              'overrideType': 'Christmas and New Year',
-              'opens': null,
-              'closes': null
-            }
-          ]
-        }
-      }
-    ]
-  }
+              overrideDate: '2019-01-01T00:00:00.000Z',
+              overrideType: 'Christmas and New Year',
+              opens: null,
+              closes: null,
+            },
+          ],
+        },
+      },
+    ],
+  },
 };
 
 export const upcomingExceptionalOpeningPeriods = [
   {
-    'type': 'Christmas and New Year',
-    'dates': [
+    type: 'Christmas and New Year',
+    dates: [
       new Date('2018-12-24T00:00:00.000Z'),
       new Date('2018-12-25T00:00:00.000Z'),
       new Date('2018-12-26T00:00:00.000Z'),
@@ -607,7 +607,7 @@ export const upcomingExceptionalOpeningPeriods = [
       new Date('2018-12-29T00:00:00.000Z'),
       new Date('2018-12-30T00:00:00.000Z'),
       new Date('2018-12-31T00:00:00.000Z'),
-      new Date('2019-01-01T00:00:00.000Z')
-    ]
-  }
+      new Date('2019-01-01T00:00:00.000Z'),
+    ],
+  },
 ];

--- a/cardigan/yarn.lock
+++ b/cardigan/yarn.lock
@@ -110,7 +110,7 @@
     lodash "^4.17.13"
     source-map "^0.5.0"
 
-"@babel/helper-annotate-as-pure@^7.10.4":
+"@babel/helper-annotate-as-pure@^7.0.0", "@babel/helper-annotate-as-pure@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz#5bf0d495a3f757ac3bda48b5bf3b3ba309c72ba3"
   integrity sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==
@@ -608,6 +608,11 @@
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.5.tgz#b4af32ddd473c0bfa643bd7ff0728b8e71b81ea0"
   integrity sha512-FVM6RZQ0mn2KCf1VUED7KepYeUWoVShczewOCfm3nzoBybaih51h+sYVVGthW9M6lPByEPTQf+xm27PBdlpwmQ==
+
+"@babel/parser@^7.12.7":
+  version "7.12.7"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.7.tgz#fee7b39fe809d0e73e5b25eecaf5780ef3d73056"
+  integrity sha512-oWR02Ubp4xTLCAqPRiNIuMVgNO5Aif/xpXtabhzW2HWUD47XJsAB4Zd/Rg30+XeQA3juXigV7hlquOTmwqLiwg==
 
 "@babel/parser@^7.8.6", "@babel/parser@^7.9.0":
   version "7.9.4"
@@ -1790,6 +1795,21 @@
     globals "^11.1.0"
     lodash "^4.17.19"
 
+"@babel/traverse@^7.4.5":
+  version "7.12.9"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.12.9.tgz#fad26c972eabbc11350e0b695978de6cc8e8596f"
+  integrity sha512-iX9ajqnLdoU1s1nHt36JDI9KG4k+vmI8WgjK5d+aDTwQbL2fUnzedNedssA645Ede3PM2ma1n8Q4h2ohwXgMXw==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/generator" "^7.12.5"
+    "@babel/helper-function-name" "^7.10.4"
+    "@babel/helper-split-export-declaration" "^7.11.0"
+    "@babel/parser" "^7.12.7"
+    "@babel/types" "^7.12.7"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.19"
+
 "@babel/traverse@^7.8.3", "@babel/traverse@^7.8.6", "@babel/traverse@^7.9.0":
   version "7.9.0"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.9.0.tgz#d3882c2830e513f4fe4cec9fe76ea1cc78747892"
@@ -1818,6 +1838,15 @@
   version "7.12.6"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.6.tgz#ae0e55ef1cce1fbc881cd26f8234eb3e657edc96"
   integrity sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.10.4"
+    lodash "^4.17.19"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.12.7":
+  version "7.12.7"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.7.tgz#6039ff1e242640a29452c9ae572162ec9a8f5d13"
+  integrity sha512-MNyI92qZq6jrQkXvtIiykvl4WtoRrVV9MPn+ZfsoEENjiWcBQ3ZSHrkxnJWgWtLX3XXqX5hrSQ+X69wkmesXuQ==
   dependencies:
     "@babel/helper-validator-identifier" "^7.10.4"
     lodash "^4.17.19"
@@ -1873,7 +1902,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
   integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
 
-"@emotion/is-prop-valid@0.8.8":
+"@emotion/is-prop-valid@0.8.8", "@emotion/is-prop-valid@^0.8.8":
   version "0.8.8"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
   integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
@@ -1919,12 +1948,12 @@
     "@emotion/styled-base" "^10.0.27"
     babel-plugin-emotion "^10.0.27"
 
-"@emotion/stylis@0.8.5":
+"@emotion/stylis@0.8.5", "@emotion/stylis@^0.8.4":
   version "0.8.5"
   resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.5.tgz#deacb389bd6ee77d1e7fcaccce9e16c5c7e78e04"
   integrity sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==
 
-"@emotion/unitless@0.7.5":
+"@emotion/unitless@0.7.5", "@emotion/unitless@^0.7.4":
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
   integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
@@ -3381,6 +3410,16 @@ babel-plugin-react-require@^3.1.1:
   resolved "https://registry.yarnpkg.com/babel-plugin-react-require/-/babel-plugin-react-require-3.1.3.tgz#ba3d7305b044a90c35c32c5a9ab943fd68e1638d"
   integrity sha512-kDXhW2iPTL81x4Ye2aUMdEXQ56JP0sBJmRQRXJPH5FsNB7fOc/YCsHTqHv8IovPyw9Rk07gdd7MVUz8tUmRBCA==
 
+"babel-plugin-styled-components@>= 1":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.12.0.tgz#1dec1676512177de6b827211e9eda5a30db4f9b9"
+  integrity sha512-FEiD7l5ZABdJPpLssKXjBUJMYqzbcNzBowfXDCdJhOpbhWiewapUaY+LZGT8R4Jg2TwOjGjG4RKeyrO5p9sBkA==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/helper-module-imports" "^7.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    lodash "^4.17.11"
+
 babel-plugin-syntax-jsx@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
@@ -3889,6 +3928,11 @@ camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
+
+camelize@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.0.tgz#164a5483e630fa4321e5af07020e531831b2609b"
+  integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
 can-use-dom@^0.1.0:
   version "0.1.0"
@@ -4445,6 +4489,11 @@ crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
+css-color-keywords@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
+  integrity sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=
+
 css-color-names@0.0.4, css-color-names@^0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
@@ -4519,6 +4568,15 @@ css-select@^2.0.0:
     css-what "^3.2.1"
     domutils "^1.7.0"
     nth-check "^1.0.2"
+
+css-to-react-native@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-3.0.0.tgz#62dbe678072a824a689bcfee011fc96e02a7d756"
+  integrity sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==
+  dependencies:
+    camelize "^1.0.0"
+    css-color-keywords "^1.0.0"
+    postcss-value-parser "^4.0.2"
 
 css-tree@1.0.0-alpha.37:
   version "1.0.0-alpha.37"
@@ -5989,7 +6047,7 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -10170,6 +10228,22 @@ style-loader@^1.0.0:
     loader-utils "^1.2.3"
     schema-utils "^2.6.4"
 
+styled-components@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.2.1.tgz#6ed7fad2dc233825f64c719ffbdedd84ad79101a"
+  integrity sha512-sBdgLWrCFTKtmZm/9x7jkIabjFNVzCUeKfoQsM6R3saImkUnjx0QYdLwJHBjY9ifEcmjDamJDVfknWm1yxZPxQ==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/traverse" "^7.4.5"
+    "@emotion/is-prop-valid" "^0.8.8"
+    "@emotion/stylis" "^0.8.4"
+    "@emotion/unitless" "^0.7.4"
+    babel-plugin-styled-components ">= 1"
+    css-to-react-native "^3.0.0"
+    hoist-non-react-statics "^3.0.0"
+    shallowequal "^1.1.0"
+    supports-color "^5.5.0"
+
 stylehacks@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/stylehacks/-/stylehacks-4.0.3.tgz#6718fcaf4d1e07d8a1318690881e8d96726a71d5"
@@ -10184,7 +10258,7 @@ supports-color@^2.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
   integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
 
-supports-color@^5.3.0, supports-color@^5.4.0:
+supports-color@^5.3.0, supports-color@^5.4.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
@@ -10643,6 +10717,11 @@ url-parse@^1.4.3:
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
+
+url-template@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/url-template/-/url-template-2.0.8.tgz#fc565a3cccbff7730c775f5641f9555791439f21"
+  integrity sha1-/FZaPMy/93MMd19WQflVV5FDnyE=
 
 url@^0.11.0:
   version "0.11.0"

--- a/common/styles/works.scss
+++ b/common/styles/works.scss
@@ -17,7 +17,7 @@ $is-next: true;
 @import 'base/fonts';
 @import 'base/responsive-defaults';
 @import 'base/transitions';
-@import 'utilities/root-scope-classes.scss';
+@import 'utilities/root-scope-classes';
 
 // Grids
 @import 'grids/grid_base';

--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -32,7 +32,8 @@ type SiteSection =
   | 'what-we-do'
   | 'visit-us'
   | 'stories'
-  | 'whats-on';
+  | 'whats-on'
+  | 'identity';
 
 type ComponentProps = {
   title: string;

--- a/common/views/components/oauth/Login.tsx
+++ b/common/views/components/oauth/Login.tsx
@@ -1,0 +1,11 @@
+import { FunctionComponent } from 'react';
+
+type Props = {
+  text: string;
+};
+
+const Login: FunctionComponent<Props> = ({ text }: Props) => {
+  return <button type="button">{text}</button>;
+};
+
+export default Login;

--- a/identity/Dockerfile
+++ b/identity/Dockerfile
@@ -1,0 +1,36 @@
+# This image should be built with the parent directory as context
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/node:12.18.3
+
+WORKDIR /usr/src/app/webapp
+
+RUN apt-get update && apt-get install -y python python-pip rename
+RUN pip install awscli
+
+ADD ./.flowconfig ./.flowconfig
+ADD ./package.json ./package.json
+ADD ./yarn.lock ./yarn.lock
+ADD ./common ./common
+ADD ./flow-typed ./flow-typed
+
+ADD ./catalogue/webapp ./catalogue/webapp
+ADD ./content/webapp ./content/webapp
+ADD ./identity/webapp ./identity/webapp
+
+RUN yarn setupCommon
+
+WORKDIR /usr/src/app/webapp/identity/webapp
+
+ENV BUILD_HASH=latest
+ENV BUNDLE_ANALYZE=both
+
+RUN yarn
+RUN yarn build
+
+WORKDIR /usr/src/app/webapp/identity/webapp/.dist
+RUN rename 's/^/identity./' *
+
+WORKDIR /usr/src/app/webapp/identity/webapp
+
+EXPOSE 3000
+
+CMD ["yarn", "start"]

--- a/identity/webapp/.dockerignore
+++ b/identity/webapp/.dockerignore
@@ -1,0 +1,3 @@
+**
+common/**
+identity/webapp/**

--- a/identity/webapp/babel.config.js
+++ b/identity/webapp/babel.config.js
@@ -1,0 +1,9 @@
+module.exports = function(api) {
+  api.cache(true);
+
+  const presets = ['@weco/common/babel'];
+
+  return {
+    presets,
+  };
+};

--- a/identity/webapp/jest.config.js
+++ b/identity/webapp/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  transformIgnorePatterns: ['node_modules(?!/@weco(?!.*node_modules))'],
+  setupFilesAfterEnv: ['@weco/common/test/setupTests.js'],
+  snapshotSerializers: ['enzyme-to-json/serializer'],
+};

--- a/identity/webapp/next-env.d.ts
+++ b/identity/webapp/next-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />

--- a/identity/webapp/next.config.js
+++ b/identity/webapp/next.config.js
@@ -1,0 +1,4 @@
+const webpack = require('webpack');
+const config = require('@weco/common/next/next.config');
+
+module.exports = config(webpack, 'identity');

--- a/identity/webapp/package.json
+++ b/identity/webapp/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "scripts": {
-    "dev": "nodemon --watch server.js server.js",
+    "dev": "yarn next",
     "build": "next build",
     "deployBundleAnalysis": "aws s3 sync .dist s3://dash.wellcomecollection.org/bundles  --only-show-errors --acl public-read",
     "start": "NODE_ENV=production next",

--- a/identity/webapp/package.json
+++ b/identity/webapp/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@weco/identity",
+  "version": "1.0.0",
+  "license": "MIT",
+  "scripts": {
+    "dev": "nodemon --watch server.js server.js",
+    "build": "next build",
+    "deployBundleAnalysis": "aws s3 sync .dist s3://dash.wellcomecollection.org/bundles  --only-show-errors --acl public-read",
+    "start": "NODE_ENV=production next",
+    "test": "NODE_ENV=test jest --no-cache",
+    "test:watch": "yarn test -- --watchAll",
+    "test:updateSnapshots": "yarn test -- --updateSnapshot"
+  },
+  "dependencies": {
+    "@types/react": "^16.9.35",
+    "next": "^10.0.1",
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1"
+  },
+  "browserslist": [
+    "last 2 versions",
+    "iOS 8"
+  ]
+}

--- a/identity/webapp/pages/_app.tsx
+++ b/identity/webapp/pages/_app.tsx
@@ -1,0 +1,3 @@
+import App from '@weco/common/views/pages/_app';
+import '../styles.scss';
+export default App;

--- a/identity/webapp/pages/identity/index.tsx
+++ b/identity/webapp/pages/identity/index.tsx
@@ -1,0 +1,33 @@
+import { NextPage } from 'next';
+import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
+import Label from '@weco/common/views/components/Label/Label';
+import Login from '@weco/common/views/components/oauth/Login';
+
+const IndexPage: NextPage = () => {
+  return (
+    <PageLayout
+      title="Identity"
+      description="Wellcome Collection login"
+      url={{
+        pathname: '/',
+        query: {},
+      }}
+      jsonLd={{ '@type': 'WebPage' }}
+      openGraphType={'website'}
+      siteSection={'identity'}
+      imageUrl={undefined}
+      imageAltText={undefined}
+      globalContextData={{
+        toggles: {},
+        globalAlert: undefined,
+        popupDialog: undefined,
+        openingTimes: undefined,
+      }}
+    >
+      <Label label={{ text: 'identify' }} />
+      <Login text="Login" />
+    </PageLayout>
+  );
+};
+
+export default IndexPage;

--- a/identity/webapp/postcss.config.js
+++ b/identity/webapp/postcss.config.js
@@ -1,0 +1,16 @@
+module.exports = {
+  plugins: [
+    [
+      'postcss-easy-import',
+      {
+        prefix: '_',
+      },
+    ],
+    [
+      'autoprefixer',
+      {
+        grid: false,
+      },
+    ],
+  ],
+};

--- a/identity/webapp/styles.scss
+++ b/identity/webapp/styles.scss
@@ -1,0 +1,1 @@
+@import '@weco/common/styles/works';

--- a/identity/webapp/tsconfig.json
+++ b/identity/webapp/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   "workspaces": [
     "catalogue/webapp",
     "content/webapp",
+    "identity/webapp",
     "common"
   ],
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -53,10 +53,11 @@
   },
   "private": true,
   "workspaces": [
+    "common",
+    "cardigan",
     "catalogue/webapp",
     "content/webapp",
-    "identity/webapp",
-    "common"
+    "identity/webapp"
   ],
   "lint-staged": {
     "*.{js,ts,tsx}": [


### PR DESCRIPTION
This introduces a new app for the identity work.

It adds a few base things:
* new app in the standard format that we do it
* an index page using our page layout
* a component in the components directory under the `oath` folder

And simplifies some others:
* removes a whole load of deps
* uses next directly without using the app

It'd be good to see how Digirati are using cypress and how we might integrate things. 