### PR TITLE
New search UI improvements

### DIFF
--- a/catalogue/webapp/pages/images.tsx
+++ b/catalogue/webapp/pages/images.tsx
@@ -104,6 +104,7 @@ const Images: NextPage<Props> = ({
   const [loading, setLoading] = useState(false);
   const [, setSavedSearchState] = useSavedSearchState(imagesRouteProps);
   const { query, page, color } = imagesRouteProps;
+  const { searchPrototype } = globalContextData.toggles;
   useEffect(() => {
     function routeChangeStart() {
       setLoading(true);
@@ -213,7 +214,7 @@ const Images: NextPage<Props> = ({
                       results={results}
                       imagesRouteProps={imagesRouteProps}
                       setSavedSearchState={setSavedSearchState}
-                      hideMobilePagination={true}
+                      hideMobilePagination={Boolean(searchPrototype)}
                     />
                   </div>
                 </div>
@@ -255,7 +256,7 @@ const Images: NextPage<Props> = ({
                         results={results}
                         imagesRouteProps={imagesRouteProps}
                         setSavedSearchState={setSavedSearchState}
-                        hideMobileTotalResults={true}
+                        hideMobileTotalResults={Boolean(searchPrototype)}
                       />
                     </div>
                   </div>

--- a/catalogue/webapp/pages/images.tsx
+++ b/catalogue/webapp/pages/images.tsx
@@ -54,6 +54,7 @@ type ImagesPaginationProps = {
   imagesRouteProps: ImagesRouteProps;
   setSavedSearchState: (state: ImagesRouteProps) => void;
   hideMobilePagination?: boolean;
+  hideMobileTotalResults?: boolean;
 };
 
 const ImagesPagination = ({
@@ -63,6 +64,7 @@ const ImagesPagination = ({
   imagesRouteProps,
   setSavedSearchState,
   hideMobilePagination,
+  hideMobileTotalResults,
 }: ImagesPaginationProps) => (
   <div className="flex flex--h-space-between flex--v-center flex--wrap">
     <Paginator
@@ -88,6 +90,7 @@ const ImagesPagination = ({
         Router.push(link.href, link.as).then(() => window.scrollTo(0, 0));
       }}
       hideMobilePagination={hideMobilePagination}
+      hideMobileTotalResults={hideMobileTotalResults}
     />
   </div>
 );
@@ -252,6 +255,7 @@ const Images: NextPage<Props> = ({
                         results={results}
                         imagesRouteProps={imagesRouteProps}
                         setSavedSearchState={setSavedSearchState}
+                        hideMobileTotalResults={true}
                       />
                     </div>
                   </div>

--- a/catalogue/webapp/pages/works.tsx
+++ b/catalogue/webapp/pages/works.tsx
@@ -242,7 +242,7 @@ const Works: NextPage<Props> = ({
                               window.scrollTo(0, 0)
                             );
                           }}
-                          hideMobilePagination={true}
+                          hideMobilePagination={Boolean(searchPrototype)}
                         />
                       </Fragment>
                     </div>
@@ -318,7 +318,7 @@ const Works: NextPage<Props> = ({
                                 window.scrollTo(0, 0)
                               );
                             }}
-                            hideMobileTotalResults={true}
+                            hideMobileTotalResults={Boolean(searchPrototype)}
                           />
                         </Fragment>
                       </div>

--- a/catalogue/webapp/pages/works.tsx
+++ b/catalogue/webapp/pages/works.tsx
@@ -318,6 +318,7 @@ const Works: NextPage<Props> = ({
                                 window.scrollTo(0, 0)
                               );
                             }}
+                            hideMobileTotalResults={true}
                           />
                         </Fragment>
                       </div>

--- a/common/views/components/Paginator/Paginator.js
+++ b/common/views/components/Paginator/Paginator.js
@@ -25,14 +25,22 @@ type Props = {|
   link: LinkProps,
   onPageChange: PageChangeFunction,
   hideMobilePagination?: boolean,
+  hideMobileTotalResults?: boolean,
 |};
 
 const PaginatorWrapper = styled.div.attrs(props => ({
   className: classNames({
     'is-hidden-s': Boolean(props.hideMobilePagination),
+    flex: true,
+    'flex--v-center': true,
   }),
 }))``;
 
+const TotalResultsWrapper = styled.div.attrs(props => ({
+  className: classNames({
+    'is-hidden-s': Boolean(props.hideMobileTotalResults),
+  }),
+}))``;
 const Paginator = ({
   query,
   showPortal,
@@ -42,6 +50,7 @@ const Paginator = ({
   link,
   onPageChange,
   hideMobilePagination,
+  hideMobileTotalResults,
 }: Props) => {
   const totalPages = Math.ceil(totalResults / pageSize);
   const next = currentPage < totalPages ? currentPage + 1 : null;
@@ -89,12 +98,18 @@ const Paginator = ({
     <Fragment>
       <Space
         h={{ size: 'm', properties: ['margin-right'] }}
-        className={`flex flex--v-center ${font('hnm', 3)}`}
+        className={classNames({
+          flex: true,
+          'flex--v-center': true,
+          [font('hnm', 3)]: true,
+        })}
       >
-        {totalResults} result{totalResults !== 1 ? 's' : ''}
-        {query && ` for “${query}”`}
+        <TotalResultsWrapper hideMobileTotalResults={hideMobileTotalResults}>
+          {totalResults} result{totalResults !== 1 ? 's' : ''}
+          {query && ` for “${query}”`}
+        </TotalResultsWrapper>
       </Space>
-      <div
+      <Space
         className={classNames({
           pagination: true,
           'float-r': true,
@@ -102,7 +117,13 @@ const Paginator = ({
           'flex--v-center': true,
           'font-pewter': true,
           [font('hnl', 5)]: true,
+          'flex-end': true,
         })}
+        v={{
+          size: 'm',
+          properties: ['padding-top', 'padding-bottom'],
+          overrides: { small: 5, medium: 5, large: 1 },
+        }}
       >
         {showPortal && <div id="sort-select-portal"></div>}
         <PaginatorWrapper hideMobilePagination={hideMobilePagination}>
@@ -139,7 +160,7 @@ const Paginator = ({
             </Space>
           )}
         </PaginatorWrapper>
-      </div>
+      </Space>
     </Fragment>
   );
 };

--- a/common/views/components/SearchTabs/SearchTabs.tsx
+++ b/common/views/components/SearchTabs/SearchTabs.tsx
@@ -95,6 +95,7 @@ const SearchTabs: FunctionComponent<Props> = ({
       tab: function TabWithDisplayName(isActive, isFocused) {
         return (
           <NextLink
+            scroll={false}
             href={{
               pathname: '/works',
               query: removeEmptyProps({
@@ -151,6 +152,7 @@ const SearchTabs: FunctionComponent<Props> = ({
       tab: function TabWithDisplayName(isActive, isFocused) {
         return (
           <NextLink
+            scroll={false}
             href={{
               pathname: '/images',
               query: removeEmptyProps({


### PR DESCRIPTION
* Fix issue with search tabs href not scrolling to the top but keep scroll state for all platforms
* Add padding around sort and pagination area for search for mobile
* Add feature for mobile pagination total results not allow to show pagination
* Hide total results of pagination of the bottom for mobile images and library
* always make the pagination align to the right side for all platforms
* vertically align pages numbers to pagination icon for all platforms
<img width="364" alt="Screenshot 2020-12-02 at 17 37 19" src="https://user-images.githubusercontent.com/9095365/100911699-7b7f2b00-34c7-11eb-933d-abc84475d679.png">
<img width="335" alt="Screenshot 2020-12-02 at 17 55 16" src="https://user-images.githubusercontent.com/9095365/100911775-905bbe80-34c7-11eb-8e9e-60def45ad2bf.png">
<img width="1011" alt="Screenshot 2020-12-02 at 17 55 40" src="https://user-images.githubusercontent.com/9095365/100911821-9e114400-34c7-11eb-8552-4ab4eb3680bc.png">



