### PR TITLE
adds availableOnline to events

### DIFF
--- a/content/webapp/pages/events.js
+++ b/content/webapp/pages/events.js
@@ -34,6 +34,7 @@ export class EventsPage extends Component<Props> {
       memoizedPrismic,
       period = 'current-and-coming-up',
       isOnline,
+      availableOnline,
     } = ctx.query;
 
     const events = await getEvents(
@@ -42,7 +43,8 @@ export class EventsPage extends Component<Props> {
         page,
         period,
         pageSize: 100,
-        isOnline: Boolean(isOnline),
+        isOnline: isOnline === 'true',
+        availableOnline: availableOnline === 'true',
       },
       memoizedPrismic
     );

--- a/prismic-model/js/events.js
+++ b/prismic-model/js/events.js
@@ -18,7 +18,8 @@ const Events = {
     title,
     format: link('Format', 'document', ['event-formats']),
     place: place,
-    isOnline: boolean('Online?', false),
+    isOnline: boolean('Happens Online?', false),
+    availableOnline: boolean('Available Online?', false),
     times: list('Times', {
       startDateTime: timestamp('Start'),
       endDateTime: timestamp('End'),

--- a/prismic-model/json/events.json
+++ b/prismic-model/json/events.json
@@ -33,7 +33,14 @@
       "type": "Boolean",
       "config": {
         "default_value": false,
-        "label": "Online?"
+        "label": "Happens Online?"
+      }
+    },
+    "availableOnline": {
+      "type": "Boolean",
+      "config": {
+        "default_value": false,
+        "label": "Available Online?"
       }
     },
     "times": {


### PR DESCRIPTION
We can mark events as available online.

As far as I can tell - this is all we will need for any differentiating in interface and works a charm for filtering, initially implemented as `/events?availableOnline=true` mimicking the API.