### PR TITLE
convert pagination to tsx

### DIFF
--- a/common/model/link-props.ts
+++ b/common/model/link-props.ts
@@ -1,0 +1,14 @@
+import { UrlObject } from 'url';
+import { LinkProps as NextLinkProps } from 'next/link';
+import { ParsedUrlQueryInput } from 'querystring';
+
+// We simplify the types of LinkProps from next/link to avoid having type checks
+// throughout the code base.
+type Url = Omit<UrlObject, 'query'> & {
+  query?: ParsedUrlQueryInput;
+};
+
+export type LinkProps = Omit<NextLinkProps, 'href' | 'as'> & {
+  href: Url;
+  as?: Url;
+};

--- a/common/services/catalogue/ts_routes.ts
+++ b/common/services/catalogue/ts_routes.ts
@@ -1,4 +1,4 @@
-import { LinkProps } from 'next/link';
+import { LinkProps } from '../../model/link-props';
 import { ParsedUrlQuery } from 'querystring';
 
 type Params = Record<string, unknown>;

--- a/common/views/components/Buttons/Control/Control.tsx
+++ b/common/views/components/Buttons/Control/Control.tsx
@@ -1,5 +1,6 @@
 import { forwardRef } from 'react';
-import NextLink, { LinkProps } from 'next/link';
+import NextLink from 'next/link';
+import { LinkProps } from '../../../../model/link-props';
 import Icon from '../../Icon/Icon';
 import { GaEvent, trackEvent } from '../../../../utils/ga';
 

--- a/common/views/components/LayoutPaginatedResults/LayoutPaginatedResults.js
+++ b/common/views/components/LayoutPaginatedResults/LayoutPaginatedResults.js
@@ -3,6 +3,7 @@ import CardGrid from '../CardGrid/CardGrid';
 import Layout12 from '../Layout12/Layout12';
 // $FlowFixMe (tsx)
 import Divider from '../Divider/Divider';
+// $FlowFixMe (tsx)
 import Pagination from '../Pagination/Pagination';
 import PrismicHtmlBlock from '../PrismicHtmlBlock/PrismicHtmlBlock';
 import { classNames, font } from '../../../utils/classnames';

--- a/common/views/components/Pagination/Pagination.tsx
+++ b/common/views/components/Pagination/Pagination.tsx
@@ -1,24 +1,23 @@
-// @flow
+import { FunctionComponent } from 'react';
 import { font } from '../../../utils/classnames';
-// $FlowFixMe (tsx)
 import Control from '../Buttons/Control/Control';
 import Space from '../styled/Space';
 
-export type Props = {|
-  total: number,
-  prevPage?: ?number,
-  currentPage: number,
-  pageCount: number,
-  nextPage?: ?number,
-  nextQueryString?: string,
-  prevQueryString?: string,
-  range?: {|
-    beginning: number,
-    end: number,
-  |},
-|};
+export type Props = {
+  total: number;
+  prevPage?: number;
+  currentPage: number;
+  pageCount: number;
+  nextPage?: number;
+  nextQueryString?: string;
+  prevQueryString?: string;
+  range?: {
+    beginning: number;
+    end: number;
+  };
+};
 
-const Pagination = ({
+const Pagination: FunctionComponent<Props> = ({
   prevPage,
   currentPage,
   pageCount,
@@ -72,16 +71,16 @@ export class PaginationFactory {
   static fromList(
     l: [],
     total: number,
-    currentPage: number = 1,
-    pageSize: number = 32,
-    getParams: {} = {}
-  ) {
+    currentPage = 1,
+    pageSize = 32,
+    getParams = {}
+  ): Props {
     const size = l.length;
     const pageCount = Math.ceil(total / pageSize);
     const prevPage =
-      pageCount > 1 && currentPage !== 1 ? currentPage - 1 : null;
+      pageCount > 1 && currentPage !== 1 ? currentPage - 1 : undefined;
     const nextPage =
-      pageCount > 1 && currentPage !== pageCount ? currentPage + 1 : null;
+      pageCount > 1 && currentPage !== pageCount ? currentPage + 1 : undefined;
     const beginning = pageSize * currentPage - pageSize + 1;
     const range = {
       beginning: beginning,
@@ -103,7 +102,10 @@ export class PaginationFactory {
   }
 }
 
-function buildQueryString(page: number | null, getParams: {} = {}): string {
+function buildQueryString(
+  page: number | undefined,
+  getParams: Record<string, string> = {}
+): string {
   const paramsArray = Object.keys(getParams)
     .map(key => {
       if (key !== 'page') {

--- a/common/views/components/Paginator/Paginator.tsx
+++ b/common/views/components/Paginator/Paginator.tsx
@@ -1,48 +1,47 @@
-// @flow
-import { Fragment } from 'react';
+import { Fragment, FunctionComponent } from 'react';
+import { LinkProps } from '../../../model/link-props';
 import { classNames, font } from '../../../utils/classnames';
-// $FlowFixMe (tsx)
 import Control from '../Buttons/Control/Control';
 import Space from '../styled/Space';
 import styled from 'styled-components';
-type Link = {|
-  +pathname: string,
-  +query: Object,
-|};
-
-type LinkProps = {|
-  href: Link,
-  as: Link,
-|};
 
 type PageChangeFunction = (event: Event, page: number) => Promise<void>;
 
-type Props = {|
-  query?: string,
-  showPortal?: boolean,
-  currentPage: number,
-  pageSize: number,
-  totalResults: number,
-  link: LinkProps,
-  onPageChange: PageChangeFunction,
-  hideMobilePagination?: boolean,
-  hideMobileTotalResults?: boolean,
-|};
+type Props = {
+  query?: string;
+  showPortal?: boolean;
+  currentPage: number;
+  pageSize: number;
+  totalResults: number;
+  link: LinkProps;
+  onPageChange: PageChangeFunction;
+  hideMobilePagination?: boolean;
+  hideMobileTotalResults?: boolean;
+};
 
-const PaginatorWrapper = styled.div.attrs(props => ({
+type PaginatorWrapperProps = {
+  hideMobilePagination: boolean | undefined;
+};
+const PaginatorWrapper = styled.div.attrs<PaginatorWrapperProps>(props => ({
   className: classNames({
     'is-hidden-s': Boolean(props.hideMobilePagination),
     flex: true,
     'flex--v-center': true,
   }),
-}))``;
+}))<PaginatorWrapperProps>``;
 
-const TotalResultsWrapper = styled.div.attrs(props => ({
-  className: classNames({
-    'is-hidden-s': Boolean(props.hideMobileTotalResults),
-  }),
-}))``;
-const Paginator = ({
+type TotalResultsWrapperProps = {
+  hideMobileTotalResults: boolean | undefined;
+};
+const TotalResultsWrapper = styled.div.attrs<TotalResultsWrapperProps>(
+  props => ({
+    className: classNames({
+      'is-hidden-s': Boolean(props.hideMobileTotalResults),
+    }),
+  })
+)<TotalResultsWrapperProps>``;
+
+const Paginator: FunctionComponent<Props> = ({
   query,
   showPortal,
   currentPage,


### PR DESCRIPTION
* Converts pagination components to tsx
* Creates a new `LinkProps` type which is a subset of the `next/link` `LinkProps` so we don't need to typecheck everywhere.