### PR TITLE
Conditional wrapper search tabs on Collections page

### DIFF
--- a/common/views/components/LandingBody/CollectionsStaticContent.tsx
+++ b/common/views/components/LandingBody/CollectionsStaticContent.tsx
@@ -39,6 +39,7 @@ const CollectionsStaticContent: FunctionComponent = (): ReactElement => {
             }}
             workTypeAggregations={[]}
             shouldShowDescription={true}
+            disableLink={true}
           />
         </Space>
       </Layout12>

--- a/common/views/components/SearchTabs/SearchTabs.tsx
+++ b/common/views/components/SearchTabs/SearchTabs.tsx
@@ -86,18 +86,19 @@ const SearchTabs: FunctionComponent<Props> = ({
   activeTabIndex,
   shouldShowFilters,
   showSortBy,
-  disableLink,
+  disableLink = false,
 }: Props): ReactElement<Props> => {
   const router = useRouter();
   const { query } = router.query;
   const { isKeyboard, isEnhanced } = useContext(AppContext);
+  const tabCondition = (!disableLink && isEnhanced) || !isEnhanced;
   const tabs: TabType[] = [
     {
       id: 'tab-library-catalogue',
       tab: function TabWithDisplayName(isActive, isFocused) {
         return (
           <ConditionalWrapper
-            condition={!disableLink && !isEnhanced}
+            condition={tabCondition}
             wrapper={children => (
               <NextLink
                 scroll={false}
@@ -161,7 +162,7 @@ const SearchTabs: FunctionComponent<Props> = ({
       tab: function TabWithDisplayName(isActive, isFocused) {
         return (
           <ConditionalWrapper
-            condition={!disableLink && !isEnhanced}
+            condition={tabCondition}
             wrapper={children => (
               <NextLink
                 scroll={false}

--- a/common/views/components/SearchTabs/SearchTabs.tsx
+++ b/common/views/components/SearchTabs/SearchTabs.tsx
@@ -17,6 +17,7 @@ import { trackEvent } from '@weco/common/utils/ga';
 import NextLink from 'next/link';
 import { removeEmptyProps } from '../../../utils/json';
 import { useRouter } from 'next/router';
+import ConditionalWrapper from '../ConditionalWrapper/ConditionalWrapper';
 
 const BaseTabsWrapper = styled.div`
   // FIXME: For testing, make the checkboxes/buttons have a white background because they're on grey
@@ -73,6 +74,7 @@ type Props = {
   aggregations?: CatalogueAggregations;
   shouldShowFilters: boolean;
   showSortBy: boolean;
+  disableLink: boolean;
 };
 
 const SearchTabs: FunctionComponent<Props> = ({
@@ -84,40 +86,47 @@ const SearchTabs: FunctionComponent<Props> = ({
   activeTabIndex,
   shouldShowFilters,
   showSortBy,
+  disableLink,
 }: Props): ReactElement<Props> => {
   const router = useRouter();
   const { query } = router.query;
-
   const { isKeyboard, isEnhanced } = useContext(AppContext);
   const tabs: TabType[] = [
     {
       id: 'tab-library-catalogue',
       tab: function TabWithDisplayName(isActive, isFocused) {
         return (
-          <NextLink
-            scroll={false}
-            href={{
-              pathname: '/works',
-              query: removeEmptyProps({
-                source: 'search_tabs',
-                query,
-              }),
-            }}
-          >
-            <a
-              className={classNames({
-                'plain-link': true,
-              })}
-            >
-              <Tab
-                isActive={isActive}
-                isFocused={isFocused}
-                isKeyboard={isKeyboard}
+          <ConditionalWrapper
+            condition={!disableLink && !isEnhanced}
+            wrapper={children => (
+              <NextLink
+                scroll={false}
+                href={{
+                  pathname: '/works',
+                  query: removeEmptyProps({
+                    source: 'search_tabs',
+                    query,
+                  }),
+                }}
               >
-                Library catalogue
-              </Tab>
-            </a>
-          </NextLink>
+                <a
+                  className={classNames({
+                    'plain-link': true,
+                  })}
+                >
+                  {children}
+                </a>
+              </NextLink>
+            )}
+          >
+            <Tab
+              isActive={isActive}
+              isFocused={isFocused}
+              isKeyboard={isKeyboard}
+            >
+              Library catalogue
+            </Tab>
+          </ConditionalWrapper>
         );
       },
       tabPanel: (
@@ -151,31 +160,38 @@ const SearchTabs: FunctionComponent<Props> = ({
       id: 'tab-images',
       tab: function TabWithDisplayName(isActive, isFocused) {
         return (
-          <NextLink
-            scroll={false}
-            href={{
-              pathname: '/images',
-              query: removeEmptyProps({
-                query,
-                source: 'search_tabs',
-              }),
-            }}
-          >
-            <a
-              className={classNames({
-                'plain-link': true,
-              })}
-            >
-              <Tab
-                isActive={isActive}
-                isFocused={isFocused}
-                isKeyboard={isKeyboard}
-                isLast={true}
+          <ConditionalWrapper
+            condition={!disableLink && !isEnhanced}
+            wrapper={children => (
+              <NextLink
+                scroll={false}
+                href={{
+                  pathname: '/images',
+                  query: removeEmptyProps({
+                    source: 'search_tabs',
+                    query,
+                  }),
+                }}
               >
-                Images
-              </Tab>
-            </a>
-          </NextLink>
+                <a
+                  className={classNames({
+                    'plain-link': true,
+                  })}
+                >
+                  {children}
+                </a>
+              </NextLink>
+            )}
+          >
+            <Tab
+              isActive={isActive}
+              isFocused={isFocused}
+              isKeyboard={isKeyboard}
+              isLast={true}
+            >
+              Images
+            </Tab>
+          </ConditionalWrapper>
         );
       },
       tabPanel: (

--- a/common/views/components/SearchTabs/SearchTabs.tsx
+++ b/common/views/components/SearchTabs/SearchTabs.tsx
@@ -74,7 +74,7 @@ type Props = {
   aggregations?: CatalogueAggregations;
   shouldShowFilters: boolean;
   showSortBy: boolean;
-  disableLink: boolean;
+  disableLink?: boolean;
 };
 
 const SearchTabs: FunctionComponent<Props> = ({


### PR DESCRIPTION
* ConditionalWrapper 
** if javascript users land on collection page they will be not links but render tabs only. 
** If non javascript users on any search pages - tabs will work as links

* Links will Render for Non javascript or non enhanced users on Collections pages, works and images 
