### PR TITLE
Season page changes

### DIFF
--- a/cardigan/stories/components/SeasonsHeader.js
+++ b/cardigan/stories/components/SeasonsHeader.js
@@ -1,0 +1,49 @@
+import { storiesOf } from '@storybook/react';
+import { UiImage } from '@weco/common/views/components/Images/Images';
+import SeasonsHeader from '../../../common/views/components/SeasonsHeader/SeasonsHeader';
+import Readme from '../../../common/views/components/SeasonsHeader/README.md';
+
+const image = {
+  contentUrl:
+    'https://images.prismic.io/wellcomecollection/7b0bfd6f-6a12-432f-9040-2c9724cb7605_ep_000832_016.jpg?auto=compress,format&rect=0,0,4000,2250&w=3200&h=1800',
+  width: 3200,
+  height: 1800,
+  alt: null,
+  tasl: {
+    title: 'Refugee Astronaut by Yinka Shonibare CBE',
+    author: null,
+    sourceName: 'Wellcome Collection',
+    sourceLink: null,
+    license: null,
+    copyrightHolder: null,
+    copyrightLink: null,
+  },
+  crops: {},
+};
+
+const headerProps = {
+  labels: { labels: [{ url: null, text: 'Article' }] },
+  title: 'What does it mean to be human, now?',
+  FeaturedMedia: <UiImage {...image} />,
+  standfirst: [
+    {
+      type: 'paragraph',
+      text:
+        'Throughout history, pandemics have been powerful engines of change, exposing structural inequalities in the distribution of health and wealth.',
+      spans: [],
+    },
+  ],
+};
+
+const SeasonsHeaderExample = () => (
+  <SeasonsHeader
+    labels={headerProps.labels}
+    title={headerProps.title}
+    standfirst={headerProps.standfirst}
+    FeaturedMedia={headerProps.FeaturedMedia}
+  />
+);
+const stories = storiesOf('Components', module);
+stories.add('SeasonsHeader', SeasonsHeaderExample, {
+  readme: { sidebar: Readme },
+});

--- a/common/services/prismic/seasons.ts
+++ b/common/services/prismic/seasons.ts
@@ -23,6 +23,7 @@ export function parseSeason(document: PrismicDocument): Season {
   return {
     type: 'seasons',
     ...genericFields,
+    labels: [{ url: null, text: 'Season' }],
     promo: promo && promo.image && promo,
   };
 }

--- a/common/views/components/BannerCard/BannerCard.tsx
+++ b/common/views/components/BannerCard/BannerCard.tsx
@@ -41,7 +41,7 @@ const ImageWrapper = styled.div`
     flex-basis: 106%;
   `};
   ${props => props.theme.media.xlarge`
-    flex-basis: 48%;
+    flex-basis: 42%;
   `};
 `;
 

--- a/common/views/components/SeasonsHeader/README.md
+++ b/common/views/components/SeasonsHeader/README.md
@@ -1,0 +1,5 @@
+## Purpose
+
+Header for Seasons page.
+
+[Edit this on GitHub](https://github.com/wellcomecollection/wellcomecollection.org/edit/master/common/views/components/SeasonsHeader/README.md)

--- a/common/views/components/SeasonsHeader/SeasonsHeader.tsx
+++ b/common/views/components/SeasonsHeader/SeasonsHeader.tsx
@@ -1,0 +1,68 @@
+import { font } from '../../../utils/classnames';
+import LabelsList from '../LabelsList/LabelsList';
+import { UiImage } from '../Images/Images';
+import Layout8 from '../Layout10/Layout10';
+import Layout12 from '../Layout12/Layout12';
+import WobblyBottom from '../WobblyBottom/WobblyBottom';
+import { FunctionComponent, ComponentProps, ReactElement } from 'react';
+import Space from '../styled/Space';
+import PageHeaderStandfirst from '../PageHeaderStandfirst/PageHeaderStandfirst';
+import styled from 'styled-components';
+import { HTMLString } from '../../../services/prismic/types';
+
+const HeaderWrapper = styled.div`
+  background: ${props => props.theme.color('charcoal')};
+  color: ${props => props.theme.color('white')};
+`;
+const TextWrapper = styled.div`
+  border-left: 1px solid ${props => props.theme.color('orange')};
+`;
+
+type Props = {
+  labels: ComponentProps<typeof LabelsList>;
+  title: string;
+  FeaturedMedia: ReactElement<typeof UiImage> | null;
+  standfirst: HTMLString | null;
+  // TODO dates
+};
+
+const SeasonsHeader: FunctionComponent<Props> = ({
+  labels,
+  title,
+  FeaturedMedia,
+  standfirst,
+}: Props) => {
+  return (
+    <Layout12>
+      <HeaderWrapper>
+        <WobblyBottom color={'white'}>
+          {FeaturedMedia && <div className="relative">{FeaturedMedia}</div>}
+          <Space
+            v={{
+              size: 'l',
+              properties: ['padding-top', 'padding-bottom'],
+            }}
+          >
+            <Layout8>
+              <TextWrapper>
+                <Space h={{ size: 'm', properties: ['padding-left'] }}>
+                  {labels && labels.labels.length > 0 && (
+                    <LabelsList {...labels} labelColor="orange" />
+                  )}
+                  <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
+                    <h1 className={`inline-block no-margin ${font('wb', 1)}`}>
+                      {title}
+                    </h1>
+                    <PageHeaderStandfirst html={standfirst} />
+                  </Space>
+                </Space>
+              </TextWrapper>
+            </Layout8>
+          </Space>
+        </WobblyBottom>
+      </HeaderWrapper>
+    </Layout12>
+  );
+};
+
+export default SeasonsHeader;

--- a/content/webapp/pages/season.tsx
+++ b/content/webapp/pages/season.tsx
@@ -3,11 +3,8 @@ import { ReactElement } from 'react';
 import { SeasonWithContent } from '@weco/common/model/seasons';
 import PageLayout from '@weco/common/views/components/PageLayoutDeprecated/PageLayoutDeprecated';
 import ContentPage from '@weco/common/views/components/ContentPage/ContentPage';
-import HeaderBackground from '@weco/common/views/components/HeaderBackground/HeaderBackground';
-import PageHeaderStandfirst from '@weco/common/views/components/PageHeaderStandfirst/PageHeaderStandfirst';
-import PageHeader, {
-  getFeaturedMedia,
-} from '@weco/common/views/components/PageHeader/PageHeader';
+import SeasonsHeader from '@weco/common/views/components/SeasonsHeader/SeasonsHeader';
+import { UiImage } from '@weco/common/views/components/Images/Images';
 import { convertImageUri } from '@weco/common/utils/convert-image-uri';
 import { contentLd } from '@weco/common/utils/json-ld';
 import Body from '@weco/common/views/components/Body/Body';
@@ -16,6 +13,7 @@ import CardGrid from '@weco/common/views/components/CardGrid/CardGrid';
 import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
 import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
 import SectionHeader from '@weco/common/views/components/SectionHeader/SectionHeader';
+import { convertJsonToDates } from './event';
 
 const SeasonPage = ({
   season,
@@ -24,39 +22,14 @@ const SeasonPage = ({
   events,
   exhibitions,
 }: SeasonWithContent): ReactElement<SeasonWithContent> => {
-  const genericFields = {
-    id: season.id,
-    title: season.title,
-    contributors: season.contributors,
-    contributorsTitle: season.contributorsTitle,
-    promo: season.promo,
-    body: season.body,
-    standfirst: season.standfirst,
-    promoImage: season.promoImage,
-    promoText: season.promoText,
-    image: season.image,
-    squareImage: season.squareImage,
-    widescreenImage: season.widescreenImage,
-    labels: season.labels,
-    metadataDescription: season.metadataDescription,
-  };
-
-  const ContentTypeInfo = season.standfirst && (
-    <PageHeaderStandfirst html={season.standfirst} />
-  );
-  const FeaturedMedia = getFeaturedMedia(genericFields);
   const Header = (
-    <PageHeader
-      breadcrumbs={{ items: [] }}
+    <SeasonsHeader
       labels={{ labels: season.labels }}
       title={season.title}
-      ContentTypeInfo={ContentTypeInfo}
-      Background={<HeaderBackground hasWobblyEdge={true} />}
-      FeaturedMedia={FeaturedMedia}
-      HeroPicture={null}
+      FeaturedMedia={<UiImage {...season.widescreenImage} sizesQueries="" />}
+      standfirst={season?.standfirst}
     />
   );
-
   return (
     <PageLayout
       title={season.title}
@@ -66,7 +39,7 @@ const SeasonPage = ({
       siteSection={'whats-on'}
       openGraphType={'website'}
       imageUrl={season.image && convertImageUri(season.image.contentUrl, 800)}
-      imageAltText={season.image && season.image.alt}
+      imageAltText={season?.image?.alt}
     >
       <ContentPage
         id={season.id}
@@ -80,7 +53,7 @@ const SeasonPage = ({
             <SectionHeader title="Events" />
           </SpacingComponent>
           <SpacingComponent>
-            <CardGrid items={events} itemsPerRow={4} />
+            <CardGrid items={events.map(convertJsonToDates)} itemsPerRow={4} />
           </SpacingComponent>
         </SpacingSection>
       )}

--- a/content/webapp/pages/season.tsx
+++ b/content/webapp/pages/season.tsx
@@ -30,6 +30,14 @@ const SeasonPage = ({
       standfirst={season?.standfirst}
     />
   );
+  const parsedEvents = events.map(convertJsonToDates);
+  const parsedExhibitions = exhibitions.map(exhibition => {
+    return {
+      start: exhibition.start && new Date(exhibition.start),
+      end: exhibition.end && new Date(exhibition.end),
+      ...exhibition,
+    };
+  });
   return (
     <PageLayout
       title={season.title}
@@ -53,7 +61,7 @@ const SeasonPage = ({
             <SectionHeader title="Events" />
           </SpacingComponent>
           <SpacingComponent>
-            <CardGrid items={events.map(convertJsonToDates)} itemsPerRow={4} />
+            <CardGrid items={parsedEvents} itemsPerRow={4} />
           </SpacingComponent>
         </SpacingSection>
       )}
@@ -66,7 +74,7 @@ const SeasonPage = ({
             </SpacingComponent>
             <SpacingComponent>
               <CardGrid
-                items={[...exhibitions, ...articles, ...books]}
+                items={[...parsedExhibitions, ...articles, ...books]}
                 itemsPerRow={4}
               />
             </SpacingComponent>

--- a/content/webapp/pages/season.tsx
+++ b/content/webapp/pages/season.tsx
@@ -13,6 +13,9 @@ import { contentLd } from '@weco/common/utils/json-ld';
 import Body from '@weco/common/views/components/Body/Body';
 import { getSeasonWithContent } from '@weco/common/services/prismic/seasons';
 import CardGrid from '@weco/common/views/components/CardGrid/CardGrid';
+import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
+import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
+import SectionHeader from '@weco/common/views/components/SectionHeader/SectionHeader';
 
 const SeasonPage = ({
   season,
@@ -70,10 +73,32 @@ const SeasonPage = ({
         Header={Header}
         Body={<Body body={season.body} pageId={season.id} />}
       />
-      <CardGrid
-        items={[...articles, ...books, ...events, ...exhibitions]}
-        itemsPerRow={4}
-      />
+
+      {events.length > 0 && (
+        <SpacingSection>
+          <SpacingComponent>
+            <SectionHeader title="Events" />
+          </SpacingComponent>
+          <SpacingComponent>
+            <CardGrid items={events} itemsPerRow={4} />
+          </SpacingComponent>
+        </SpacingSection>
+      )}
+      {exhibitions.length > 0 ||
+        articles.length > 0 ||
+        (books.length > 0 && (
+          <SpacingSection>
+            <SpacingComponent>
+              <SectionHeader title="Explore more" />
+            </SpacingComponent>
+            <SpacingComponent>
+              <CardGrid
+                items={[...exhibitions, ...articles, ...books]}
+                itemsPerRow={4}
+              />
+            </SpacingComponent>
+          </SpacingSection>
+        ))}
     </PageLayout>
   );
 };


### PR DESCRIPTION
References #5755 

Creates new Season Header and groups events separately from the rest of the 'Explore more' content

![screencapture-localhost-3000-seasons-X84FvhIAACUAqiqp-2020-12-08-00_13_41](https://user-images.githubusercontent.com/6051896/101420589-7288c200-38ea-11eb-86c2-a2a217957b3d.jpg)

