### PR TITLE
add linkresolver to PrismicHtmlBlock

### DIFF
--- a/common/views/components/InfoBanner/InfoBanner.tsx
+++ b/common/views/components/InfoBanner/InfoBanner.tsx
@@ -16,7 +16,9 @@ type Props = {
 const InfoBanner: FunctionComponent<Props> = ({
   cookieName,
   text,
-  onVisibilityChange,
+  onVisibilityChange = () => {
+    // noop
+  },
 }: Props) => {
   const defaultValue = false;
   const [isVisible, setIsVisible] = useState<boolean>(defaultValue);
@@ -36,7 +38,7 @@ const InfoBanner: FunctionComponent<Props> = ({
   };
 
   useEffect(() => {
-    if (prevIsVisible !== isVisible && onVisibilityChange) {
+    if (prevIsVisible !== isVisible) {
       onVisibilityChange(isVisible);
     }
   }, [isVisible]);

--- a/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock.js
+++ b/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock.js
@@ -3,6 +3,7 @@
 import type { HtmlSerializer } from '../../../services/prismic/html-serializers';
 import type { HTMLString } from '../../../services/prismic/types';
 import { RichText } from 'prismic-reactjs';
+import linkResolver from '../../../services/prismic/link-resolver';
 
 type Props = {|
   html: HTMLString,
@@ -10,7 +11,11 @@ type Props = {|
 |};
 
 const PrismicHtmlBlock = ({ html, htmlSerializer }: Props) => (
-  <RichText render={html} htmlSerializer={htmlSerializer} />
+  <RichText
+    render={html}
+    htmlSerializer={htmlSerializer}
+    linkResolver={linkResolver}
+  />
 );
 
 export default PrismicHtmlBlock;


### PR DESCRIPTION
Adds the link resolver to the `PrismicHtmBlock`.

Not sure how we have got away with this for this long.