### PR TITLE
Adding options for automated tests for debug and mobile

### DIFF
--- a/catalogue/webapp/jest.e2e.config.js
+++ b/catalogue/webapp/jest.e2e.config.js
@@ -1,4 +1,34 @@
+const chromium = 'chromium';
+const allSupportedBrowsers = [chromium, 'firefox', 'webkit'];
+const defaultMobileDevices = ['iPhone 11'];
+const platform = process.env.platform ? process.env.platform : 'desktop';
+const debug = !!process.env.debug;
+const browsers =
+  process.env.browsers === 'all' ? allSupportedBrowsers : [chromium];
+
+function getLaunchOptions() {
+  const launchOptions = {
+    'jest-playwright': {
+      browsers: browsers,
+      launchOptions: {
+        headless: !debug,
+        devtools: !debug,
+      },
+    },
+  };
+  return platform === 'mobile'
+    ? {
+        ...launchOptions,
+        'jest-playwright': {
+          ...launchOptions['jest-playwright'],
+          devices: defaultMobileDevices,
+        },
+      }
+    : launchOptions;
+}
+
 module.exports = {
   preset: 'jest-playwright-preset',
   testMatch: ['**/e2e/**/*.test.ts'],
+  testEnvironmentOptions: getLaunchOptions(),
 };

--- a/catalogue/webapp/package.json
+++ b/catalogue/webapp/package.json
@@ -11,6 +11,8 @@
     "test:watch": "yarn test -- --watchAll",
     "test:updateSnapshots": "yarn test -- --updateSnapshot",
     "test:e2e": "NODE_ENV=test yarn test -c jest.e2e.config.js",
+    "test:e2e:mobile": "NODE_ENV=test platform=mobile yarn test -c jest.e2e.config.js",
+    "test:e2e:debug": "NODE_ENV=test debug=true yarn test -c jest.e2e.config.js",
     "test:e2e:watch": "NODE_ENV=test yarn test -- --watchAll -c jest.e2e.config.js "
   },
   "dependencies": {


### PR DESCRIPTION
* Allow to show debug mode when running automated tests locally
* Render tests in mobile or desktop by default 
* Ability to run all supported browsers if required headless or not headless 


