### PR TITLE
add search role to search form

### DIFF
--- a/common/views/components/PrototypeSearchForm/PrototypeSearchForm.tsx
+++ b/common/views/components/PrototypeSearchForm/PrototypeSearchForm.tsx
@@ -202,6 +202,7 @@ const PrototypeSearchForm: FunctionComponent<Props> = ({
 
   return (
     <form
+      role="search"
       ref={searchForm}
       className="relative"
       action={isImageSearch ? '/images' : '/works'}


### PR DESCRIPTION
## Who is this for?
People wanting to find our search form (including testing).

## What is it doing for them?
Adds the [search role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Search_role) to the search form.

I haven't added any labels etc as I worry about duplication and would like to have a more thorough accessibility testing process setup to be changing too much.

As a point it is best practice to label the forms differently if there are more than one `search` landmarks, but the tabs hide the form from the accessibility tree. 