### PR TITLE
add catch up events to whats-on

### DIFF
--- a/common/services/prismic/events.js
+++ b/common/services/prismic/events.js
@@ -48,6 +48,82 @@ import { getNextWeekendDateRange, isPast } from '../../utils/dates';
 const startField = 'my.events.times.startDateTime';
 const endField = 'my.events.times.endDateTime';
 
+const graphQuery = `{
+  events {
+    ...eventsFields
+    format {
+      ...formatFields
+    }
+    place {
+      ...placeFields
+    }
+    series {
+      series {
+        ...seriesFields
+        contributors {
+          ...contributorsFields
+          role {
+            ...roleFields
+          }
+          contributor {
+            ... on people {
+              ...peopleFields
+            }
+            ... on organisations {
+              ...organisationsFields
+            }
+          }
+        }
+        promo {
+          ... on editorialImage {
+            non-repeat {
+              caption
+              image
+            }
+          }
+        }
+      }
+    }
+    interpretations {
+      interpretationType {
+        ...interpretationTypeFields
+      }
+    }
+    policies {
+      policy {
+        ...policyFields
+      }
+    }
+    audiences {
+      audience {
+        ...audienceFields
+      }
+    }
+    contributors {
+      ...contributorsFields
+      role {
+        ...roleFields
+      }
+      contributor {
+        ... on people {
+          ...peopleFields
+        }
+        ... on organisations {
+          ...organisationsFields
+        }
+      }
+    }
+    promo {
+      ... on editorialImage {
+        non-repeat {
+          caption
+          image
+        }
+      }
+    }
+  }
+}`;
+
 function parseEventBookingType(eventDoc: PrismicDocument): ?string {
   return !isEmptyObj(eventDoc.data.eventbriteEvent)
     ? 'Ticketed'
@@ -351,82 +427,6 @@ export async function getEvents(
   }: EventsQueryProps,
   memoizedPrismic: ?Object
 ): Promise<PaginatedResults<UiEvent>> {
-  const graphQuery = `{
-    events {
-      ...eventsFields
-      format {
-        ...formatFields
-      }
-      place {
-        ...placeFields
-      }
-      series {
-        series {
-          ...seriesFields
-          contributors {
-            ...contributorsFields
-            role {
-              ...roleFields
-            }
-            contributor {
-              ... on people {
-                ...peopleFields
-              }
-              ... on organisations {
-                ...organisationsFields
-              }
-            }
-          }
-          promo {
-            ... on editorialImage {
-              non-repeat {
-                caption
-                image
-              }
-            }
-          }
-        }
-      }
-      interpretations {
-        interpretationType {
-          ...interpretationTypeFields
-        }
-      }
-      policies {
-        policy {
-          ...policyFields
-        }
-      }
-      audiences {
-        audience {
-          ...audienceFields
-        }
-      }
-      contributors {
-        ...contributorsFields
-        role {
-          ...roleFields
-        }
-        contributor {
-          ... on people {
-            ...peopleFields
-          }
-          ... on organisations {
-            ...organisationsFields
-          }
-        }
-      }
-      promo {
-        ... on editorialImage {
-          non-repeat {
-            caption
-            image
-          }
-        }
-      }
-    }
-  }`;
-
   const order = period === 'past' ? 'desc' : 'asc';
   const orderings = `[my.events.times.startDateTime${
     order === 'desc' ? ' desc' : ''

--- a/toggles/webapp/toggles.js
+++ b/toggles/webapp/toggles.js
@@ -66,5 +66,11 @@ module.exports = {
       description:
         'Displays body copy in Helvetica regular (where it is currently Helvetica light)',
     },
+    {
+      id: 'catchUpOnWhatsOn',
+      title: "Catch up on what's on",
+      defaultValue: false,
+      description: "Shows catch up events on the what's on page",
+    },
   ],
 };


### PR DESCRIPTION
Ref #5767 

## Who is this for?
People wanting to catch up on what was on.

## What is it doing for them?
Adds a section to what's on with catch up events.

__All behind a toggle, so we can develop in the open__

![Screenshot 2020-12-09 at 14 03 54](https://user-images.githubusercontent.com/31692/101639601-66eee580-3a27-11eb-877b-606142b67c60.png)
