### PR TITLE
don't hide info box on past events, and add extra info to interpretations

### DIFF
--- a/common/model/events.js
+++ b/common/model/events.js
@@ -42,6 +42,7 @@ type InterpretationType = {|
 export type Interpretation = {|
   interpretationType: InterpretationType,
   isPrimary: boolean,
+  extraInformation: ?PrismicHTMLString,
 |};
 
 export type Team = {|

--- a/common/services/prismic/api.js
+++ b/common/services/prismic/api.js
@@ -56,9 +56,9 @@ export async function getDocuments(
       ? memoizedPrismic
       : await getPrismicApi(req);
   const docs: PrismicApiSearchResponse = await prismicApi.query(
-    // predicates.concat([Prismic.Predicates.not('document.tags', ['delist'])]),
+    predicates.concat([Prismic.Predicates.not('document.tags', ['delist'])]),
     // uncomment this and comment out the line above to show delisted content
-    predicates,
+    // predicates,
     opts
   );
   const paginatedResults = {

--- a/common/services/prismic/api.js
+++ b/common/services/prismic/api.js
@@ -56,9 +56,9 @@ export async function getDocuments(
       ? memoizedPrismic
       : await getPrismicApi(req);
   const docs: PrismicApiSearchResponse = await prismicApi.query(
-    predicates.concat([Prismic.Predicates.not('document.tags', ['delist'])]),
+    // predicates.concat([Prismic.Predicates.not('document.tags', ['delist'])]),
     // uncomment this and comment out the line above to show delisted content
-    // predicates,
+    predicates,
     opts
   );
   const paginatedResults = {

--- a/common/services/prismic/events.js
+++ b/common/services/prismic/events.js
@@ -122,8 +122,11 @@ export function parseEventDoc(
               description: interpretation.interpretationType.data.description,
               primaryDescription:
                 interpretation.interpretationType.data.primaryDescription,
+              extraInformation:
+                interpretation.interpretationType.data.primaryDescription,
             },
             isPrimary: Boolean(interpretation.isPrimary),
+            extraInformation: interpretation.extraInformation,
           }
         : null
     )

--- a/common/services/prismic/events.js
+++ b/common/services/prismic/events.js
@@ -122,8 +122,6 @@ export function parseEventDoc(
               description: interpretation.interpretationType.data.description,
               primaryDescription:
                 interpretation.interpretationType.data.primaryDescription,
-              extraInformation:
-                interpretation.interpretationType.data.primaryDescription,
             },
             isPrimary: Boolean(interpretation.isPrimary),
             extraInformation: interpretation.extraInformation,

--- a/common/views/components/InfoBox/InfoBox.js
+++ b/common/views/components/InfoBox/InfoBox.js
@@ -52,7 +52,6 @@ const InfoBox = ({ title, items, children }: Props) => {
                   }}
                   className={classNames({
                     [font('hnl', 5)]: true,
-                    'first-para-no-margin': true,
                   })}
                 >
                   <PrismicHtmlBlock html={description} />

--- a/content/webapp/pages/event.js
+++ b/content/webapp/pages/event.js
@@ -476,55 +476,55 @@ class EventPage extends Component<Props, State> {
                 )}
             </Fragment>
           )}
-          {!event.isPast && (
-            <Fragment>
-              <InfoBox
-                title="Need to know"
-                items={[
-                  event.place && {
-                    id: null,
-                    title: 'Location',
-                    description: event.place.information,
-                  },
-                  event.bookingInformation && {
-                    id: null,
-                    title: 'Extra information',
-                    description: event.bookingInformation,
-                  },
-                ]
-                  .concat(event.policies.map(policy => ({ ...policy })))
-                  .concat(
-                    event.interpretations.map(
-                      ({ interpretationType, isPrimary }) => {
-                        const iconName = camelize(interpretationType.title);
-                        return {
-                          id: null,
-                          icon: [
-                            'britishSignLanguage',
-                            'speechToText',
-                            'hearingLoop',
-                            'audioDescribed',
-                          ].includes(iconName)
-                            ? iconName
-                            : null,
-                          title: interpretationType.title,
-                          description: isPrimary
-                            ? interpretationType.primaryDescription
-                            : interpretationType.description,
-                        };
-                      }
-                    )
-                  )
-                  .filter(Boolean)}
-              >
-                <p className={`no-margin ${font('hnl', 5)}`}>
-                  <a href="https://wellcomecollection.org/pages/Wuw19yIAAK1Z3Sng">
-                    Our event terms and conditions
-                  </a>
-                </p>
-              </InfoBox>
-            </Fragment>
-          )}
+
+          <InfoBox
+            title="Need to know"
+            items={[
+              event.place && {
+                id: null,
+                title: 'Location',
+                description: event.place.information,
+              },
+              event.bookingInformation && {
+                id: null,
+                title: 'Extra information',
+                description: event.bookingInformation,
+              },
+            ]
+              .concat(event.policies.map(policy => ({ ...policy })))
+              .concat(
+                event.interpretations.map(
+                  ({ interpretationType, isPrimary, extraInformation }) => {
+                    const iconName = camelize(interpretationType.title);
+                    return {
+                      id: null,
+                      icon: [
+                        'britishSignLanguage',
+                        'speechToText',
+                        'hearingLoop',
+                        'audioDescribed',
+                      ].includes(iconName)
+                        ? iconName
+                        : null,
+                      title: interpretationType.title,
+                      description: (
+                        (isPrimary
+                          ? interpretationType.primaryDescription
+                          : interpretationType.description) || []
+                      ).concat(extraInformation || []),
+                    };
+                  }
+                )
+              )
+              .filter(Boolean)}
+          >
+            <p className={`no-margin ${font('hnl', 5)}`}>
+              <a href="https://wellcomecollection.org/pages/Wuw19yIAAK1Z3Sng">
+                Our event terms and conditions
+              </a>
+            </p>
+          </InfoBox>
+
           {event.audiences.map(audience => {
             if (audience.description) {
               return (

--- a/prismic-model/js/events.js
+++ b/prismic-model/js/events.js
@@ -34,6 +34,7 @@ const Events = {
         'interpretation-types',
       ]),
       isPrimary: booleanDeprecated('Primary interprtation'),
+      extraInformation: structuredText('Extra information'),
     }),
     audiences: list('Audiences', {
       audience: link('Audience', 'document', ['audiences']),

--- a/prismic-model/json/events.json
+++ b/prismic-model/json/events.json
@@ -483,7 +483,8 @@
                     "articles",
                     "exhibitions",
                     "card",
-                    "landing-pages"
+                    "landing-pages",
+                    "seasons"
                   ]
                 }
               }
@@ -589,6 +590,13 @@
               "options": [
                 "yes"
               ]
+            }
+          },
+          "extraInformation": {
+            "type": "StructuredText",
+            "config": {
+              "multi": "paragraph,hyperlink,strong,em",
+              "label": "Extra information"
             }
           }
         }


### PR DESCRIPTION
Ref #5791

## Who is this for?
People wanting to know how to access an event

## What is it doing for them?
Adds any extra information onto an interpretation. An example from [this event](https://wellcomecollection.org/events/X2ipQhMAAExK8Kam) is

> Please note that the audio description won’t be an additional track; instead the host and speaker will describe themselves and any key visual elements they refer to. The event will be live captioned by StageText.

![extrainfo](https://user-images.githubusercontent.com/31692/101653693-8261ec80-3a37-11eb-953e-9835f3c689f2.png)
