### PR TITLE
move source from href => as on search tabs

### DIFF
--- a/common/views/components/SearchTabs/SearchTabs.tsx
+++ b/common/views/components/SearchTabs/SearchTabs.tsx
@@ -109,6 +109,12 @@ const SearchTabs: FunctionComponent<Props> = ({
                     query,
                   }),
                 }}
+                as={{
+                  pathname: '/works',
+                  query: removeEmptyProps({
+                    query,
+                  }),
+                }}
               >
                 <a
                   className={classNames({
@@ -170,6 +176,12 @@ const SearchTabs: FunctionComponent<Props> = ({
                   pathname: '/images',
                   query: removeEmptyProps({
                     source: 'search_tabs',
+                    query,
+                  }),
+                }}
+                as={{
+                  pathname: '/images',
+                  query: removeEmptyProps({
                     query,
                   }),
                 }}


### PR DESCRIPTION
Currently we're exposing the source in the URL. We shouldn't be.
