### PR TITLE
add source to images/work links on image modal

### DIFF
--- a/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
+++ b/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
@@ -6,7 +6,6 @@ import {
 import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
 import fetch from 'isomorphic-unfetch';
 import NextLink from 'next/link';
-import { itemLink, imageLink } from '@weco/common/services/catalogue/routes';
 import { font, classNames } from '@weco/common/utils/classnames';
 import {
   getDigitalLocationOfType,
@@ -34,6 +33,8 @@ import getFocusableElements from '@weco/common/utils/get-focusable-elements';
 import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
 import VisuallySimilarImagesFromApi from '../VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi';
 import WorkLink from '@weco/common/views/components/WorkLink/WorkLink';
+import { itemLink } from '@weco/common/views/components/ItemLink/ItemLink';
+import { imageLink } from '@weco/common/views/components/ImageLink/ImageLink';
 
 type Props = {
   image: ImageType;
@@ -174,6 +175,8 @@ const CloseButton = styled(Space).attrs({
   `}
 `;
 
+const trackingSource = 'images_search_result';
+
 const ExpandedImage: FunctionComponent<Props> = ({
   image,
   setExpandedImage,
@@ -284,15 +287,21 @@ const ExpandedImage: FunctionComponent<Props> = ({
 
   const expandedImageLink =
     image && !canvasDeeplink
-      ? imageLink({ workId, id: image.id })
+      ? imageLink({
+          workId,
+          id: image.id,
+          source: trackingSource,
+        })
       : detailedWork &&
         itemLink({
           workId,
           // We only send a langCode if it's unambiguous -- better to send
           // no language than the wrong one.
           langCode:
-            detailedWork?.languages.length === 1 &&
-            detailedWork?.languages[0].id,
+            detailedWork?.languages.length === 1
+              ? detailedWork?.languages[0].id
+              : undefined,
+          source: trackingSource,
           ...(canvasDeeplink || {}),
         });
 
@@ -365,7 +374,7 @@ const ExpandedImage: FunctionComponent<Props> = ({
                   />
                 </Space>
               )}
-              <WorkLink id={workId} source={'expanded_image_more_link'}>
+              <WorkLink id={workId} source={trackingSource}>
                 <a
                   className={classNames({
                     'inline-block': true,

--- a/common/views/components/ImageLink/ImageLink.tsx
+++ b/common/views/components/ImageLink/ImageLink.tsx
@@ -1,0 +1,61 @@
+import NextLink, { LinkProps } from 'next/link';
+import { FunctionComponent, PropsWithChildren } from 'react';
+
+type ImageLinkSource = 'images_search_result';
+
+export type ImageQueryParams = {
+  id: string;
+  workId: string;
+  langCode?: string;
+  source: ImageLinkSource;
+};
+
+// We remove `href` and `as` because we contruct those ourselves
+// in the component.
+type Props = ImageQueryParams & Omit<LinkProps, 'as' | 'href'>;
+
+export function imageLink({
+  workId,
+  source,
+  ...params
+}: ImageQueryParams): LinkProps {
+  return {
+    href: {
+      pathname: `/item`,
+      query: {
+        workId,
+        source,
+        ...params,
+      },
+    },
+    as: {
+      pathname: `/works/${workId}/images`,
+      query: { ...params },
+    },
+  };
+}
+
+const ImageLink: FunctionComponent<PropsWithChildren<Props>> = ({
+  id,
+  workId,
+  langCode,
+  source,
+  children,
+  ...linkProps
+}: PropsWithChildren<Props>) => {
+  return (
+    <NextLink
+      {...imageLink({
+        id,
+        workId,
+        langCode,
+        source,
+      })}
+      {...linkProps}
+    >
+      {children}
+    </NextLink>
+  );
+};
+
+export default ImageLink;

--- a/common/views/components/ItemLink/ItemLink.tsx
+++ b/common/views/components/ItemLink/ItemLink.tsx
@@ -1,0 +1,73 @@
+import NextLink, { LinkProps } from 'next/link';
+import { FunctionComponent, PropsWithChildren } from 'react';
+
+type ItemLinkSource = 'images_search_result';
+
+export type ItemQueryParams = {
+  workId: string;
+  canvas?: number;
+  page?: number;
+  pageSize?: number;
+  langCode?: string;
+  sierraId?: string;
+  isOverview?: boolean;
+  source: ItemLinkSource;
+};
+
+// We remove `href` and `as` because we contruct those ourselves
+// in the component.
+type Props = ItemQueryParams & Omit<LinkProps, 'as' | 'href'>;
+
+export function itemLink({
+  workId,
+  source,
+  ...params
+}: ItemQueryParams): LinkProps {
+  return {
+    href: {
+      pathname: `/item`,
+      query: {
+        workId,
+        source,
+        ...params,
+      },
+    },
+    as: {
+      pathname: `/works/${workId}/items`,
+      query: { ...params },
+    },
+  };
+}
+
+const ItemLink: FunctionComponent<PropsWithChildren<Props>> = ({
+  workId,
+  sierraId,
+  langCode,
+  canvas = 1,
+  isOverview,
+  page = 1,
+  pageSize = 4,
+  source,
+  children,
+  ...linkProps
+}: PropsWithChildren<Props>) => {
+  return (
+    <NextLink
+      {...itemLink({
+        workId,
+        source,
+        langCode,
+        canvas,
+        sierraId,
+        isOverview,
+        page,
+        pageSize,
+      })}
+      {...linkProps}
+    >
+      {children}
+    </NextLink>
+  );
+};
+
+export default ItemLink;

--- a/common/views/components/WorkLink/WorkLink.tsx
+++ b/common/views/components/WorkLink/WorkLink.tsx
@@ -3,7 +3,7 @@ import { FunctionComponent, PropsWithChildren } from 'react';
 
 type WorkLinkSource =
   | 'works_search_result'
-  | 'expanded_image_more_link'
+  | 'images_search_result'
   | 'item_auth_modal_back_to_work_link'
   | 'archive_tree'
   | 'viewer_back_link';


### PR DESCRIPTION
## Who is this for?
People analysing the image search


## What is it doing for them?
Adds the `images_search_result` source to the link. 

Updated to use component links.
