### PR TITLE
add format to series

### DIFF
--- a/prismic-model/js/series.js
+++ b/prismic-model/js/series.js
@@ -9,13 +9,15 @@ import select from './parts/select';
 import text from './parts/text';
 import timestamp from './parts/timestamp';
 import structuredText from './parts/structured-text';
+import link from './parts/link';
 
 // This is called `ArticleSeries` and the filename `series`, as it was a
 // mistake we made way back when when all we were doing was articles
-const ArticleSeries = {
-  'Article series': {
+const StorySeries = {
+  'Story series': {
     title: title,
     color: select('Colour', ['teal', 'red', 'green', 'purple']),
+    format: link('Format', 'document', ['article-formats']),
     body,
   },
   Schedule: {
@@ -40,4 +42,4 @@ const ArticleSeries = {
   },
 };
 
-export default ArticleSeries;
+export default StorySeries;

--- a/prismic-model/json/series.json
+++ b/prismic-model/json/series.json
@@ -1,5 +1,5 @@
 {
-  "Article series": {
+  "Story series": {
     "title": {
       "type": "StructuredText",
       "config": {
@@ -17,6 +17,16 @@
           "red",
           "green",
           "purple"
+        ]
+      }
+    },
+    "format": {
+      "type": "Link",
+      "config": {
+        "label": "Format",
+        "select": "document",
+        "customtypes": [
+          "article-formats"
         ]
       }
     },
@@ -431,7 +441,8 @@
                     "articles",
                     "exhibitions",
                     "card",
-                    "landing-pages"
+                    "landing-pages",
+                    "seasons"
                   ]
                 }
               }
@@ -453,6 +464,50 @@
                 "type": "Text",
                 "config": {
                   "label": "Query"
+                }
+              }
+            }
+          },
+          "mediaObjectList": {
+            "type": "Slice",
+            "fieldset": "Media Object List",
+            "repeat": {
+              "title": {
+                "type": "StructuredText",
+                "config": {
+                  "label": "Title",
+                  "single": "heading1",
+                  "useAsTitle": true
+                }
+              },
+              "text": {
+                "type": "StructuredText",
+                "config": {
+                  "multi": "paragraph,hyperlink,strong,em",
+                  "label": "Text"
+                }
+              },
+              "image": {
+                "type": "Image",
+                "config": {
+                  "label": "Image",
+                  "thumbnails": [
+                    {
+                      "name": "32:15",
+                      "width": 3200,
+                      "height": 1500
+                    },
+                    {
+                      "name": "16:9",
+                      "width": 3200,
+                      "height": 1800
+                    },
+                    {
+                      "name": "square",
+                      "width": 3200,
+                      "height": 3200
+                    }
+                  ]
                 }
               }
             }


### PR DESCRIPTION
Adds format to a series.

We can then flag a series as a `podcast`, or anything else in the future, to live at `/series/{id}`, and have whatever visual treatment applied to it. 

