### PR TITLE
remove catch up events toggle for whats on

### DIFF
--- a/common/test/fixtures/pages/whats-on.js
+++ b/common/test/fixtures/pages/whats-on.js
@@ -1448,6 +1448,13 @@ export const whatsOn = hasExhibition => ({
     totalPages: 0,
     results: [],
   },
+  availableOnlineEvents: {
+    currentPage: 1,
+    pageSize: 100,
+    totalResults: 0,
+    totalPages: 0,
+    results: [],
+  },
   dateRange: ['2020-11-05T00:00:00.000Z', null],
   tryTheseTooPromos: [
     {

--- a/content/webapp/pages/whats-on.js
+++ b/content/webapp/pages/whats-on.js
@@ -45,7 +45,7 @@ import { collectionVenueId } from '@weco/common/services/prismic/hardcoded-id';
 type Props = {|
   exhibitions: PaginatedResults<UiExhibition>,
   events: PaginatedResults<UiEvent>,
-  availableOnlineEvents?: PaginatedResults<UiEvent>,
+  availableOnlineEvents: PaginatedResults<UiEvent>,
   period: string,
   dateRange: any[],
   tryTheseTooPromos: any[],
@@ -315,7 +315,7 @@ export class WhatsOnPage extends Component<Props> {
   static getInitialProps = async (ctx: Context) => {
     const period = ctx.query.period || 'current-and-coming-up';
     const { memoizedPrismic } = ctx.query;
-    const { catchUpOnWhatsOn } = ctx.query.toggles;
+
     const exhibitionsPromise = getExhibitions(
       ctx.req,
       {
@@ -333,17 +333,15 @@ export class WhatsOnPage extends Component<Props> {
       memoizedPrismic
     );
 
-    const availableOnlineEventsPromise = catchUpOnWhatsOn
-      ? getEvents(
-          ctx.req,
-          {
-            period: 'past',
-            pageSize: 6,
-            availableOnline: true,
-          },
-          memoizedPrismic
-        )
-      : Promise.resolve(undefined);
+    const availableOnlineEventsPromise = getEvents(
+      ctx.req,
+      {
+        period: 'past',
+        pageSize: 6,
+        availableOnline: true,
+      },
+      memoizedPrismic
+    );
 
     const [exhibitions, events, availableOnlineEvents] = await Promise.all([
       exhibitionsPromise,
@@ -373,9 +371,9 @@ export class WhatsOnPage extends Component<Props> {
     const { period, dateRange, tryTheseTooPromos, eatShopPromos } = this.props;
 
     const events = this.props.events.results.map(convertJsonToDates);
-    const availableOnlineEvents = this.props.availableOnlineEvents
-      ? this.props.availableOnlineEvents.results.map(convertJsonToDates)
-      : undefined;
+    const availableOnlineEvents = this.props.availableOnlineEvents.results.map(
+      convertJsonToDates
+    );
     const exhibitions = this.props.exhibitions.results.map(exhibition => {
       return {
         start: exhibition.start && new Date(exhibition.start),

--- a/content/webapp/pages/whats-on.js
+++ b/content/webapp/pages/whats-on.js
@@ -474,31 +474,29 @@ export class WhatsOnPage extends Component<Props> {
                         </SpacingComponent>
                       </SpacingSection>
 
-                      {availableOnlineEvents && (
-                        <SpacingSection>
-                          <SpacingComponent>
-                            <SectionHeader title="Catch up" />
-                          </SpacingComponent>
-                          <SpacingComponent>
-                            {availableOnlineEvents.length > 0 ? (
-                              <CardGrid
-                                items={availableOnlineEvents}
-                                itemsPerRow={3}
-                                links={[
-                                  {
-                                    text: 'View all catch up events',
-                                    url: '/events/past?availableOnline=true',
-                                  },
-                                ]}
-                              />
-                            ) : (
-                              <Layout12>
-                                <p>There are no upcoming catch up events</p>
-                              </Layout12>
-                            )}
-                          </SpacingComponent>
-                        </SpacingSection>
-                      )}
+                      <SpacingSection>
+                        <SpacingComponent>
+                          <SectionHeader title="Catch up" />
+                        </SpacingComponent>
+                        <SpacingComponent>
+                          {availableOnlineEvents.length > 0 ? (
+                            <CardGrid
+                              items={availableOnlineEvents}
+                              itemsPerRow={3}
+                              links={[
+                                {
+                                  text: 'View all catch up events',
+                                  url: '/events/past?availableOnline=true',
+                                },
+                              ]}
+                            />
+                          ) : (
+                            <Layout12>
+                              <p>There are no upcoming catch up events</p>
+                            </Layout12>
+                          )}
+                        </SpacingComponent>
+                      </SpacingSection>
                     </Space>
                   </Fragment>
                 )}

--- a/toggles/webapp/toggles.js
+++ b/toggles/webapp/toggles.js
@@ -59,11 +59,5 @@ module.exports = {
       description:
         'Displays body copy in Helvetica regular (where it is currently Helvetica light)',
     },
-    {
-      id: 'catchUpOnWhatsOn',
-      title: "Catch up on what's on",
-      defaultValue: false,
-      description: "Shows catch up events on the what's on page",
-    },
   ],
 };


### PR DESCRIPTION
Fixes #5767
Removes the toggle so live to all

<img width="999" alt="Screenshot 2020-12-15 at 10 25 33" src="https://user-images.githubusercontent.com/31692/102203017-f67d1400-3ebf-11eb-844d-5430e418f94b.png">
