### PR TITLE
Display override status in installation page header

### DIFF
--- a/content/webapp/components/Installation/Installation.js
+++ b/content/webapp/components/Installation/Installation.js
@@ -4,6 +4,7 @@ import { exhibitionLd } from '@weco/common/utils/json-ld';
 import { convertImageUri } from '@weco/common/utils/convert-image-uri';
 import PageLayout from '@weco/common/views/components/PageLayoutDeprecated/PageLayoutDeprecated';
 import DateAndStatusIndicator from '@weco/common/views/components/DateAndStatusIndicator/DateAndStatusIndicator';
+import StatusIndicator from '@weco/common/views/components/StatusIndicator/StatusIndicator';
 import HeaderBackground from '@weco/common/views/components/HeaderBackground/HeaderBackground';
 import ContentPage from '@weco/common/views/components/ContentPage/ContentPage';
 // $FlowFixMe (tsx)
@@ -75,10 +76,21 @@ const Installation = ({ installation }: Props) => {
       FeaturedMedia={FeaturedMedia}
       Background={<HeaderBackground hasWobblyEdge={true} />}
       ContentTypeInfo={
-        <DateAndStatusIndicator
-          start={installation.start}
-          end={installation.end}
-        />
+        <>
+          {installation.start && !installation.statusOverride && (
+            <DateAndStatusIndicator
+            start={installation.start}
+            end={installation.end}
+            />
+          )}
+          {installation.statusOverride &&  (
+            <StatusIndicator
+            start={installation.start}
+            end={installation.end || new Date()}
+            statusOverride={installation.statusOverride}
+          />
+          )}
+        </>
       }
       HeroPicture={null}
       isContentTypeInfoBeforeMedia={true}


### PR DESCRIPTION
The current Installation page header doesn't display the override status and also attempts to display a date even when there isn't one. This fixes that.

Before:

![Screenshot 2020-12-16 at 11 10 03](https://user-images.githubusercontent.com/6051896/102341481-d0bf4000-3f8f-11eb-8ea5-2b3439796bd9.png)

After:

![Screenshot 2020-12-16 at 11 11 48](https://user-images.githubusercontent.com/6051896/102341494-d4eb5d80-3f8f-11eb-99ed-71503b246313.png)

