### PR TITLE
Fix tsc:lint command

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Products and services relating to wellcomecollection.org.",
   "scripts": {
     "lint": "eslint ./.eslintrc.js catalogue/ common/ content/ toggles/ dash/ --fix",
-    "lint:tsc": "tsc --project content/webapp/tsconfig.json & tsc --project catalogue/webapp/tsconfig.json & tsc --project common/tsconfig.json",
+    "lint:tsc": "tsc --build common content/webapp catalogue/webapp",
     "setupCommon": "yarn install --production && yarn flow",
     "cardigan": "pushd cardigan && yarn dev",
     "catalogue": "pushd catalogue/webapp && yarn dev",


### PR DESCRIPTION
The usage of single ampersands runs commands in parallel but doesn't wait for them all to return / doesn't collect exit codes, so this was passing even if there were errors(!). I imagine this is how the extra stuff got into https://github.com/wellcomecollection/wellcomecollection.org/pull/5907/files

The fix uses [this](https://www.typescriptlang.org/docs/handbook/project-references.html) feature of tsc rather than trying to do the multiple projects with shell commands