### PR TITLE
Add series to seasons

### DIFF
--- a/common/model/article-series.js
+++ b/common/model/article-series.js
@@ -3,6 +3,7 @@ import type { GenericContentFields } from './generic-content-fields';
 import type { Article } from './articles';
 import type { ArticleScheduleItem } from './article-schedule-items';
 import type { ColorSelection } from './color-selections';
+import type { Season } from './seasons';
 
 type ItemType = Article | ArticleScheduleItem;
 
@@ -13,4 +14,5 @@ export type ArticleSeries = {|
   color: ColorSelection,
   items: $ReadOnlyArray<ItemType>,
   color?: ?ColorSelection,
+  seasons: Season[],
 |};

--- a/common/model/article-series.ts
+++ b/common/model/article-series.ts
@@ -2,6 +2,7 @@ import { GenericContentFields } from './generic-content-fields';
 import { Article } from './articles';
 import { ArticleScheduleItem } from './article-schedule-items';
 import { ColorSelection } from './color-selections';
+import { Season } from './seasons';
 
 type ItemType = Article | ArticleScheduleItem;
 
@@ -10,4 +11,5 @@ export type ArticleSeries = GenericContentFields & {
   schedule: ArticleScheduleItem[];
   items: readonly ItemType[];
   color?: ColorSelection;
+  seasons: Season[];
 };

--- a/common/model/card.js
+++ b/common/model/card.js
@@ -6,6 +6,7 @@ import type { Article } from '@weco/common/model/articles';
 import type { LandingPage } from '@weco/common/model/landing-pages';
 import type { Season } from '@weco/common/model/seasons';
 import type { Page } from '@weco/common/model/pages';
+import type { ArticleSeries } from '@weco/common/model/article-series';
 import linkResolver from '@weco/common/services/prismic/link-resolver';
 
 export type Card = {|
@@ -18,7 +19,7 @@ export type Card = {|
 |};
 
 export function convertItemToCardProps(
-  item: Article | UiEvent | LandingPage | Season | Page
+  item: Article | UiEvent | LandingPage | Season | Page | ArticleSeries
 ): Card {
   return {
     type: 'card',

--- a/common/model/seasons.js
+++ b/common/model/seasons.js
@@ -5,6 +5,7 @@ import type { Book } from './books';
 import type { Event } from './events';
 import type { Exhibition } from './exhibitions';
 import type { Page } from './pages';
+import type { ArticleSeries } from './article-series';
 
 export type Season = {
   ...GenericContentFields,
@@ -18,4 +19,5 @@ export type SeasonWithContent = {
   events: Event[],
   exhibitions: Exhibition[],
   pages: Page[],
+  articleSeries: ArticleSeries[],
 };

--- a/common/model/seasons.ts
+++ b/common/model/seasons.ts
@@ -4,6 +4,7 @@ import { Book } from './books';
 import { Event } from './events';
 import { Exhibition } from './exhibitions';
 import { Page } from './pages';
+import { ArticleSeries } from './article-series';
 
 export type Season = GenericContentFields & {
   type: 'seasons';
@@ -16,4 +17,5 @@ export type SeasonWithContent = {
   events: Event[];
   exhibitions: Exhibition[];
   pages: Page[],
+  articleSeries: ArticleSeries[]
 };

--- a/common/services/prismic/article-series.js
+++ b/common/services/prismic/article-series.js
@@ -7,6 +7,9 @@ import { parseGenericFields, isStructuredText, asText } from './parsers';
 import type { PrismicDocument, PrismicQueryOpts } from './types';
 import type { ArticleSeries } from '../../model/article-series';
 import type { Article } from '../../model/articles';
+import {
+  seasonsFields,
+} from './fetch-links';
 
 export function parseArticleSeries(document: PrismicDocument): ArticleSeries {
   const { data } = document;
@@ -117,7 +120,9 @@ export async function getArticleSeries(
   } else {
     // TODO: (perf) we shouldn't really be doing two calls here, but it's for
     // when a series has no events attached.
-    const document = await getDocument(req, id, {}, memoizedPrismic);
+    const document = await getDocument(req, id, {
+      fetchLinks:seasonsFields,
+    }, memoizedPrismic);
     return document && { series: parseArticleSeries(document), articles: [] };
   }
 }

--- a/common/services/prismic/seasons.ts
+++ b/common/services/prismic/seasons.ts
@@ -6,6 +6,7 @@ import { getBooks } from './books';
 import { getEvents } from './events';
 import { getExhibitions } from './exhibitions';
 import { getPages } from './pages';
+import { getMultipleArticleSeries } from './article-series';
 import { Season, SeasonWithContent } from '../../model/seasons';
 import { parseGenericFields, parseSingleLevelGroup } from './parsers';
 import {
@@ -99,15 +100,24 @@ export async function getSeasonWithContent({
       predicates: [Prismic.Predicates.at('my.pages.seasons.season', id)],
     },
     memoizedPrismic
-  );
+    );
 
-  const [season, articles, books, events, exhibitions, pages] = await Promise.all([
+    const articleSeriesPromise = await getMultipleArticleSeries(
+    request,
+    {
+      predicates: [Prismic.Predicates.at('my.series.seasons.season', id)],
+    },
+    memoizedPrismic
+  )
+
+  const [season, articles, books, events, exhibitions, pages, articleSeries] = await Promise.all([
     seasonPromise,
     articlesPromise,
     booksPromise,
     eventsPromise,
     exhibitionsPromise,
     pagesPromise,
+    articleSeriesPromise,
   ]);
 
   if (season) {
@@ -118,6 +128,7 @@ export async function getSeasonWithContent({
       events: events?.results || [],
       exhibitions: exhibitions?.results || [],
       pages: pages?.results || [],
+      articleSeries: articleSeries?.results || [],
     };
   }
 }

--- a/common/services/prismic/seasons.ts
+++ b/common/services/prismic/seasons.ts
@@ -7,7 +7,7 @@ import { getEvents } from './events';
 import { getExhibitions } from './exhibitions';
 import { getPages } from './pages';
 import { Season, SeasonWithContent } from '../../model/seasons';
-import { parseGenericFields } from './parsers';
+import { parseGenericFields, parseSingleLevelGroup } from './parsers';
 import {
   pagesFields,
   articlesFields,
@@ -20,10 +20,13 @@ import { IncomingMessage } from 'http';
 export function parseSeason(document: PrismicDocument): Season {
   const genericFields = parseGenericFields(document);
   const promo = genericFields.promo;
-
+  const seasons = parseSingleLevelGroup(document.data.seasons, 'season').map(season => {
+    return parseSeason(season);
+  });
   return {
     type: 'seasons',
     ...genericFields,
+    seasons,
     labels: [{ url: null, text: 'Season' }],
     promo: promo && promo.image && promo,
   };

--- a/common/views/components/CardGrid/CardGrid.js
+++ b/common/views/components/CardGrid/CardGrid.js
@@ -16,13 +16,14 @@ import { type UiEvent } from '../../../model/events';
 import { type Book } from '../../../model/books';
 import { type Article } from '../../../model/articles';
 import { type Page } from '../../../model/pages';
+import { type ArticleSeries } from '../../../model/article-series';
 import Space from '../styled/Space';
 import type Moment from 'moment';
 import Card from '../Card/Card';
 import { convertItemToCardProps } from '@weco/common/model/card';
 
 // TODO: This should be MultiContent
-type ContentTypes = UiEvent | UiExhibition | Book | Article | Page;
+type ContentTypes = UiEvent | UiExhibition | Book | Article | Page | ArticleSeries;
 
 type Props = {|
   items: $ReadOnlyArray<ContentTypes>,
@@ -99,7 +100,7 @@ const CardGrid = ({
                   image={item.cover}
                 />
               )}
-              {item.type === 'pages' && (
+              {(item.type === 'pages' || item.type === 'series') && (
                 <Card item={convertItemToCardProps(item)} />
               )}
             </div>

--- a/content/webapp/pages/article-series.js
+++ b/content/webapp/pages/article-series.js
@@ -116,6 +116,7 @@ export class ArticleSeriesPage extends Component<Props> {
           Header={Header}
           Body={<Body body={series.body} pageId={series.id} />}
           contributorProps={{ contributors: series.contributors }}
+          seasons={series.seasons}
         >
           {articles.length > 0 && (
             <SearchResults items={series.items} showPosition={true} />

--- a/content/webapp/pages/article-series.js
+++ b/content/webapp/pages/article-series.js
@@ -15,6 +15,9 @@ import PageHeader, {
 import { convertImageUri } from '@weco/common/utils/convert-image-uri';
 import type { ArticleSeries } from '@weco/common/model/article-series';
 import type { Article } from '@weco/common/model/articles';
+import {
+  seasonsFields,
+} from '@weco/common/services/prismic/fetch-links';
 
 type Props = {|
   series: ArticleSeries,
@@ -29,6 +32,7 @@ export class ArticleSeriesPage extends Component<Props> {
       {
         id,
         pageSize: 100,
+        fetchLinks: seasonsFields,
       },
       memoizedPrismic
     );

--- a/content/webapp/pages/season.tsx
+++ b/content/webapp/pages/season.tsx
@@ -22,6 +22,7 @@ const SeasonPage = ({
   events,
   exhibitions,
   pages,
+  articleSeries,
 }: SeasonWithContent): ReactElement<SeasonWithContent> => {
   const Header = (
     <SeasonsHeader
@@ -40,7 +41,7 @@ const SeasonPage = ({
     };
   });
   const exhibitionsAndEvents = [...parsedExhibitions, ...parsedEvents];
-  const exploreMore = [...articles, ...books, ...pages];
+  const exploreMore = [...articles, ...books, ...pages, ...articleSeries];
 
   return (
     <PageLayout

--- a/prismic-model/js/series.js
+++ b/prismic-model/js/series.js
@@ -33,6 +33,11 @@ const StorySeries = {
   Metadata: {
     metadataDescription: structuredText('Metadata description', 'single'),
   },
+  'Content relationships': {
+    seasons: list('Seasons', {
+      season: link('Season', 'document', ['seasons'], 'Select a Season'),
+    }),
+  },
   Deprecated: {
     description: structuredText(
       '[Deprecated] Description. Please use standfirst slice'

--- a/prismic-model/json/series.json
+++ b/prismic-model/json/series.json
@@ -649,6 +649,27 @@
       }
     }
   },
+  "Content relationships": {
+    "seasons": {
+      "type": "Group",
+      "fieldset": "Seasons",
+      "config": {
+        "fields": {
+          "season": {
+            "type": "Link",
+            "config": {
+              "label": "Season",
+              "select": "document",
+              "customtypes": [
+                "seasons"
+              ],
+              "placeholder": "Select a Season"
+            }
+          }
+        }
+      }
+    }
+  },
   "Deprecated": {
     "description": {
       "type": "StructuredText",


### PR DESCRIPTION
Fixes #5905

Makes it possible to add Series to a Season and displays the relevant promos on each page.

N.B. Using Generic Promo Card, as we don't have one for series

![Screenshot 2020-12-16 at 14 08 46](https://user-images.githubusercontent.com/6051896/102359954-58657880-3fa9-11eb-8bc5-d1315e630a3f.png)

![Screenshot 2020-12-16 at 14 07 58](https://user-images.githubusercontent.com/6051896/102359960-5a2f3c00-3fa9-11eb-8938-780e1e87a259.png)
