### PR TITLE
Seasons content

### DIFF
--- a/content/webapp/pages/season.tsx
+++ b/content/webapp/pages/season.tsx
@@ -40,8 +40,8 @@ const SeasonPage = ({
       end: exhibition.end && new Date(exhibition.end),
     };
   });
-  const exhibitionsAndEvents = [...parsedExhibitions, ...parsedEvents];
-  const exploreMore = [...articles, ...books, ...pages, ...articleSeries];
+
+  const allItems = [...parsedExhibitions, ...parsedEvents, ...articles, ...books, ...pages, ...articleSeries];
 
   return (
     <PageLayout
@@ -60,30 +60,13 @@ const SeasonPage = ({
         Body={<Body body={season.body} pageId={season.id} />}
       />
 
-      {exhibitionsAndEvents.length > 0 && (
+      {allItems.length > 0 && (
         <SpacingSection>
           <SpacingComponent>
-            <SectionHeader title="Exhibitions and Events" />
-          </SpacingComponent>
-          <SpacingComponent>
-            <CardGrid items={exhibitionsAndEvents} itemsPerRow={3} />
+            <CardGrid items={allItems} itemsPerRow={3} />
           </SpacingComponent>
         </SpacingSection>
       )}
-
-      {exploreMore.length > 0 && (
-          <SpacingSection>
-            <SpacingComponent>
-              <SectionHeader title="Explore more" />
-            </SpacingComponent>
-            <SpacingComponent>
-              <CardGrid
-                items={exploreMore}
-                itemsPerRow={3}
-              />
-            </SpacingComponent>
-          </SpacingSection>
-        )}
     </PageLayout>
   );
 };


### PR DESCRIPTION
Takes the season content out of separate sections and displays it as a single list with no heading:

![single-list](https://user-images.githubusercontent.com/6051896/102378508-cddb4400-3fbd-11eb-846c-20f455de1499.jpg)

