### PR TITLE
Totally Type-safe Toggling

### DIFF
--- a/cardigan/Dockerfile
+++ b/cardigan/Dockerfile
@@ -14,6 +14,7 @@ ADD ./flow-typed ./flow-typed
 
 ADD ./catalogue/webapp ./catalogue/webapp
 ADD ./content/webapp ./content/webapp
+ADD ./toggles/webapp ./toggles/webapp
 
 RUN yarn setupCommon
 

--- a/catalogue/Dockerfile
+++ b/catalogue/Dockerfile
@@ -14,6 +14,7 @@ ADD ./flow-typed ./flow-typed
 
 ADD ./catalogue/webapp ./catalogue/webapp
 ADD ./content/webapp ./content/webapp
+ADD ./toggles/webapp ./toggles/webapp
 
 RUN yarn setupCommon
 

--- a/catalogue/webapp/package.json
+++ b/catalogue/webapp/package.json
@@ -21,6 +21,7 @@
     "@types/jest": "^26.0.17",
     "@types/react": "^16.9.35",
     "@weco/common": "1.0.0",
+    "@weco/toggles": "1.0.0",
     "autoprefixer": "^9.5.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^24.5.0",

--- a/catalogue/webapp/pages/works.tsx
+++ b/catalogue/webapp/pages/works.tsx
@@ -7,7 +7,7 @@ import {
   Work,
   Image,
 } from '@weco/common/model/catalogue';
-import { font, grid, classNames } from '@weco/common/utils/classnames';
+import { grid, classNames } from '@weco/common/utils/classnames';
 import convertUrlToString from '@weco/common/utils/convert-url-to-string';
 import {
   GlobalContextData,
@@ -28,7 +28,6 @@ import {
 } from '@weco/common/services/catalogue/ts_api';
 import Space from '@weco/common/views/components/styled/Space';
 import ImageEndpointSearchResults from '../components/ImageEndpointSearchResults/ImageEndpointSearchResults';
-import SearchForm from '@weco/common/views/components/SearchForm/SearchForm';
 import { getImages } from '../services/catalogue/images';
 import { getWorks } from '../services/catalogue/works';
 import { trackSearch } from '@weco/common/views/components/Tracker/Tracker';

--- a/catalogue/webapp/services/catalogue/common.ts
+++ b/catalogue/webapp/services/catalogue/common.ts
@@ -1,12 +1,11 @@
 import { CatalogueApiError } from '@weco/common/model/catalogue';
 import { serialiseUrl } from '@weco/common/services/catalogue/routes';
+import { Toggles } from '@weco/toggles';
 
 export const rootUris = {
   prod: 'https://api.wellcomecollection.org/catalogue',
   stage: 'https://api-stage.wellcomecollection.org/catalogue',
 };
-
-export type Toggles = { [key: string]: boolean };
 
 type GlobalApiOptions = {
   env: 'prod' | 'stage';

--- a/catalogue/webapp/services/catalogue/images.ts
+++ b/catalogue/webapp/services/catalogue/images.ts
@@ -6,13 +6,13 @@ import {
 } from '@weco/common/model/catalogue';
 import { CatalogueImagesApiProps } from '@weco/common/services/catalogue/ts_api';
 import {
-  Toggles,
   rootUris,
   globalApiOptions,
   queryString,
   catalogueApiError,
   notFound,
 } from './common';
+import { Toggles } from '@weco/toggles';
 
 type GetImagesProps = {
   params: CatalogueImagesApiProps;

--- a/catalogue/webapp/services/catalogue/works.ts
+++ b/catalogue/webapp/services/catalogue/works.ts
@@ -14,8 +14,8 @@ import {
   queryString,
   rootUris,
   notFound,
-  Toggles,
 } from './common';
+import { Toggles } from '@weco/toggles';
 
 type GetWorkProps = {
   id: string;

--- a/common/Dockerfile
+++ b/common/Dockerfile
@@ -13,6 +13,7 @@ ADD ./flow-typed ./flow-typed
 
 ADD ./catalogue/webapp ./catalogue/webapp
 ADD ./content/webapp ./content/webapp
+ADD ./toggles/webapp ./toggles/webapp
 
 RUN yarn setupCommon
 

--- a/common/model/global-alert.js
+++ b/common/model/global-alert.js
@@ -1,6 +1,0 @@
-// @flow
-export type GlobalAlert = {|
-  text: string,
-  isShown: boolean,
-  routeRegex: ?string,
-|};

--- a/common/package.json
+++ b/common/package.json
@@ -23,6 +23,7 @@
     "@types/lodash": "^4.14.161",
     "@types/react-window": "^1.8.2",
     "@weco/next-plugin-transpile-modules": "^2.0.1",
+    "@weco/toggles": "1.0.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^24.5.0",
     "babel-plugin-styled-components": "^1.9.4",

--- a/common/views/components/ArchiveTree/ArchiveTree.tsx
+++ b/common/views/components/ArchiveTree/ArchiveTree.tsx
@@ -13,7 +13,6 @@ import { getWork } from '@weco/catalogue/services/catalogue/works';
 import WorkLink from '@weco/common/views/components/WorkLink/WorkLink';
 import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
 import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
-import { Toggles } from '@weco/catalogue/services/catalogue/common';
 import Space from '@weco/common/views/components/styled/Space';
 import WorkTitle from '@weco/common/views/components/WorkTitle/WorkTitle';
 import Icon from '@weco/common/views/components/Icon/Icon';
@@ -22,6 +21,7 @@ import { RelatedWork, Work } from '@weco/common/model/catalogue';
 import useWindowSize from '@weco/common/hooks/useWindowSize';
 import Modal, { ModalContext } from '@weco/common/views/components/Modal/Modal';
 import ButtonSolid from '@weco/common/views/components/ButtonSolid/ButtonSolid';
+import { Toggles } from '@weco/toggles';
 
 const TreeContainer = styled.div`
   border-right: 1px solid ${props => props.theme.color('pumice')};

--- a/common/views/components/GlobalAlertContext/GlobalAlertContext.tsx
+++ b/common/views/components/GlobalAlertContext/GlobalAlertContext.tsx
@@ -1,6 +1,6 @@
 import { createContext } from 'react';
-import { HTMLString } from '../../../../common/services/prismic/types';
-type GlobalAlert = {
+import { HTMLString } from '../../../services/prismic/types';
+export type GlobalAlert = {
   isShown: string | null;
   routeRegex: string | null;
   text: HTMLString;

--- a/common/views/components/GlobalContextProvider/GlobalContextProvider.tsx
+++ b/common/views/components/GlobalContextProvider/GlobalContextProvider.tsx
@@ -1,17 +1,24 @@
 import { GetServerSidePropsContext } from 'next';
 import { createContext, FunctionComponent, ReactNode } from 'react';
-import OpeningTimesContext from '../OpeningTimesContext/OpeningTimesContext';
-import GlobalAlertContext from '../GlobalAlertContext/GlobalAlertContext';
-import PopupDialogContext from '../PopupDialogContext/PopupDialogContext';
+import OpeningTimesContext, {
+  OpeningTimes,
+} from '../OpeningTimesContext/OpeningTimesContext';
+import GlobalAlertContext, {
+  GlobalAlert,
+} from '../GlobalAlertContext/GlobalAlertContext';
+import PopupDialogContext, {
+  PopupDialog,
+} from '../PopupDialogContext/PopupDialogContext';
 import TogglesContext from '../TogglesContext/TogglesContext';
 import { parseCollectionVenues } from '../../../services/prismic/opening-times';
+import { Toggles } from '@weco/toggles';
 
-export type GlobalContextData = {
-  toggles: any;
-  globalAlert: any;
-  popupDialog: any;
-  openingTimes: any;
-};
+export interface GlobalContextData {
+  toggles: Toggles;
+  globalAlert: GlobalAlert | null;
+  popupDialog: PopupDialog | null;
+  openingTimes: OpeningTimes | null;
+}
 
 type Props = {
   value: GlobalContextData;
@@ -19,7 +26,7 @@ type Props = {
 };
 
 const defaultValue = {
-  toggles: {},
+  toggles: {} as Toggles,
   globalAlert: null,
   popupDialog: null,
   openingTimes: null,
@@ -83,10 +90,11 @@ export function getGlobalContextData(
   context: GetServerSidePropsContext
 ): GlobalContextData {
   return {
-    toggles: context.query.toggles,
-    globalAlert: context.query.globalAlert,
-    popupDialog: context.query.popupDialog,
-    openingTimes: context.query.openingTimes,
+    // NextJS types do not yet allow a parametrised `query` :(
+    toggles: (context.query.toggles as unknown) as Toggles,
+    globalAlert: (context.query.globalAlert as unknown) as GlobalAlert,
+    popupDialog: (context.query.popupDialog as unknown) as PopupDialog,
+    openingTimes: (context.query.openingTimes as unknown) as OpeningTimes,
   };
 }
 

--- a/common/views/components/GlobalContextProvider/GlobalContextProvider.tsx
+++ b/common/views/components/GlobalContextProvider/GlobalContextProvider.tsx
@@ -13,12 +13,12 @@ import TogglesContext from '../TogglesContext/TogglesContext';
 import { parseCollectionVenues } from '../../../services/prismic/opening-times';
 import { Toggles } from '@weco/toggles';
 
-export interface GlobalContextData {
+export type GlobalContextData = {
   toggles: Toggles;
   globalAlert: GlobalAlert | null;
   popupDialog: PopupDialog | null;
   openingTimes: OpeningTimes | null;
-}
+};
 
 type Props = {
   value: GlobalContextData;

--- a/common/views/components/OpeningTimesContext/OpeningTimesContext.tsx
+++ b/common/views/components/OpeningTimesContext/OpeningTimesContext.tsx
@@ -1,3 +1,8 @@
 import { createContext } from 'react';
-const OpeningTimesContext = createContext<any>(null);
+import { CollectionOpeningTimes } from '../../../model/opening-hours';
+// This appears to be nested in various confusing ways hence the inheritance
+export interface OpeningTimes extends CollectionOpeningTimes {
+  collectionOpeningTimes: CollectionOpeningTimes;
+}
+const OpeningTimesContext = createContext<OpeningTimes | null>(null);
 export default OpeningTimesContext;

--- a/common/views/components/PopupDialogContext/PopupDialogContext.tsx
+++ b/common/views/components/PopupDialogContext/PopupDialogContext.tsx
@@ -1,7 +1,7 @@
 import { createContext } from 'react';
 import { HTMLString, PrismicLink } from '../../../services/prismic/types';
 
-type PopupDialog = {
+export type PopupDialog = {
   isShown: boolean;
   openButtonText: string;
   title: string;

--- a/common/views/components/PrototypeSearchFilters/PrototypeSearchFiltersMobile.tsx
+++ b/common/views/components/PrototypeSearchFilters/PrototypeSearchFiltersMobile.tsx
@@ -2,7 +2,6 @@ import {
   useState,
   useRef,
   useEffect,
-  useContext,
   FunctionComponent,
   ReactElement,
 } from 'react';
@@ -18,7 +17,6 @@ import Space from '../styled/Space';
 import Icon from '../Icon/Icon';
 import NumberInput from '@weco/common/views/components/NumberInput/NumberInput';
 import CheckboxRadio from '@weco/common/views/components/CheckboxRadio/CheckboxRadio';
-import TogglesContext from '../TogglesContext/TogglesContext';
 import { SearchFiltersSharedProps } from './PrototypeSearchFilters';
 import ButtonSolid, {
   ButtonTypes,
@@ -227,7 +225,6 @@ const SearchFiltersMobile: FunctionComponent<SearchFiltersSharedProps> = ({
       closeFiltersButtonRef.current.focus();
   }
 
-  const { locationsFilter } = useContext(TogglesContext);
   const showWorkTypeFilters =
     workTypeFilters.some(f => f.count > 0) || workTypeInUrlArray.length > 0;
   const activeFiltersCount =
@@ -343,7 +340,7 @@ const SearchFiltersMobile: FunctionComponent<SearchFiltersSharedProps> = ({
                     </ul>
                   </FilterSection>
                 )}
-              {locationsFilter && aggregations && aggregations.locationType && (
+              {aggregations && aggregations.locationType && (
                 <FilterSection>
                   <h3 className="h3">Locations</h3>
                   <ul

--- a/common/views/components/TogglesContext/TogglesContext.ts
+++ b/common/views/components/TogglesContext/TogglesContext.ts
@@ -1,5 +1,6 @@
 import { createContext } from 'react';
+import { Toggles } from '@weco/toggles';
 
-const TogglesContext = createContext<{ [key: string]: boolean }>({});
+const TogglesContext = createContext<Toggles>({} as Toggles);
 
 export default TogglesContext;

--- a/content/Dockerfile
+++ b/content/Dockerfile
@@ -14,6 +14,7 @@ ADD ./flow-typed ./flow-typed
 
 ADD ./catalogue/webapp ./catalogue/webapp
 ADD ./content/webapp ./content/webapp
+ADD ./toggles/webapp ./toggles/webapp
 
 RUN yarn setupCommon
 

--- a/identity/Dockerfile
+++ b/identity/Dockerfile
@@ -14,6 +14,7 @@ ADD ./flow-typed ./flow-typed
 
 ADD ./catalogue/webapp ./catalogue/webapp
 ADD ./content/webapp ./content/webapp
+ADD ./toggles/webapp ./toggles/webapp
 ADD ./identity/webapp ./identity/webapp
 
 RUN yarn setupCommon

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "cardigan",
     "catalogue/webapp",
     "content/webapp",
-    "identity/webapp"
+    "identity/webapp",
+    "toggles/webapp"
   ],
   "lint-staged": {
     "*.{js,ts,tsx}": [

--- a/toggles/webapp/build.ts
+++ b/toggles/webapp/build.ts
@@ -1,6 +1,8 @@
-#!/usr/bin/env node
-const fs = require('fs');
-const toggles = require('./toggles');
+#!/usr/bin/env ts-node-script
+
+import fs from 'fs';
+import toggles from './toggles';
+
 const json = JSON.stringify(toggles);
 
 fs.writeFile('toggles.json', json, err => {

--- a/toggles/webapp/deploy.ts
+++ b/toggles/webapp/deploy.ts
@@ -1,7 +1,9 @@
-const AWS = require('aws-sdk');
-const s3 = new AWS.S3({ apiVersion: '2006-03-01' });
+#!/usr/bin/env ts-node-script
 
-const fs = require('fs');
+import AWS from 'aws-sdk';
+import fs from 'fs';
+
+const s3 = new AWS.S3({ apiVersion: '2006-03-01' });
 
 try {
   const data = fs.readFileSync('toggles.json', 'utf8');
@@ -14,10 +16,10 @@ try {
     ContentType: 'application/json',
   };
 
-  s3.putObject(params, function(err, data) {
+  s3.putObject(params, function(err) {
     if (err) console.log(err, err.stack);
     else console.log('Finished uploading toggles.json');
   });
 } catch (e) {
-  console.log('Error:', e.stack);
+  console.error('Error:', e.stack);
 }

--- a/toggles/webapp/index.d.ts
+++ b/toggles/webapp/index.d.ts
@@ -1,0 +1,6 @@
+import toggleConfig from './toggles';
+
+const toggleIds = toggleConfig.toggles.map(toggle => toggle.id);
+type ToggleId = typeof toggleIds[number];
+
+export type Toggles = Record<ToggleId, boolean>;

--- a/toggles/webapp/index.ts
+++ b/toggles/webapp/index.ts
@@ -3,4 +3,6 @@ import toggleConfig from './toggles';
 const toggleIds = toggleConfig.toggles.map(toggle => toggle.id);
 type ToggleId = typeof toggleIds[number];
 
+// Don't be tempted to make the keys on this optional - keeping them
+// as required means we catch dead code left over from removed toggles
 export type Toggles = Record<ToggleId, boolean>;

--- a/toggles/webapp/package.json
+++ b/toggles/webapp/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@weco/toggles",
+  "version": "1.0.0",
   "description": "Feature toggles",
   "license": "MIT",
   "scripts": {
     "build": "ts-node ./build",
     "deploy": "ts-node ./deploy"
   },
-  "dependencies": {
+  "devDependencies": {
     "aws-sdk": "^2.813.0",
     "ts-node": "^9.1.1",
     "typescript": "^4.1.3"

--- a/toggles/webapp/package.json
+++ b/toggles/webapp/package.json
@@ -3,10 +3,12 @@
   "description": "Feature toggles",
   "license": "MIT",
   "scripts": {
-    "build": "node ./build",
-    "deploy": "node deploy.js"
+    "build": "ts-node ./build",
+    "deploy": "ts-node ./deploy"
   },
   "dependencies": {
-    "aws-sdk": "^2.751.0"
+    "aws-sdk": "^2.813.0",
+    "ts-node": "^9.1.1",
+    "typescript": "^4.1.3"
   }
 }

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -59,5 +59,5 @@ export default {
       description:
         'Displays body copy in Helvetica regular (where it is currently Helvetica light)',
     },
-  ],
+  ] as const,
 };

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   toggles: [
     {
       id: 'openWithAdvisoryPrototype',

--- a/toggles/webapp/tsconfig.json
+++ b/toggles/webapp/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "strictNullChecks": true
+  },
+  "exclude": ["node_modules", "./test/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"]
+}

--- a/toggles/webapp/yarn.lock
+++ b/toggles/webapp/yarn.lock
@@ -2,10 +2,15 @@
 # yarn lockfile v1
 
 
-aws-sdk@^2.751.0:
-  version "2.751.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.751.0.tgz#aeab21a5fc1b1f843180a988ff0fb650119dc6ff"
-  integrity sha512-0lo7YKTfjEwoP+2vK7F7WGNigvwFxqiM96PzBaseOpOelfhFHPKEJpk2Poa12JI89c8dGoc1PhTQ1TSTJK3ZqQ==
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
+
+aws-sdk@^2.813.0:
+  version "2.813.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.813.0.tgz#16104b91a286c1fc8ca6480ac32ccebb955f6148"
+  integrity sha512-uOeJ6DgsImQLv0eC0KHloFgDP788A1MEYTKdSV+1Bjv1iqQHH3bJcH5DPPX2NSyeaXJAjkVSVT2Fqe4s5Vf9TA==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"
@@ -22,6 +27,11 @@ base64-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
   integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
 
+buffer-from@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
+  integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+
 buffer@4.9.2:
   version "4.9.2"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
@@ -30,6 +40,16 @@ buffer@4.9.2:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
     isarray "^1.0.0"
+
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 events@1.1.1:
   version "1.1.1"
@@ -51,6 +71,11 @@ jmespath@0.15.0:
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
   integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
 
+make-error@^1.1.1:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
+
 punycode@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
@@ -70,6 +95,36 @@ sax@>=0.6.0:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+
+source-map-support@^0.5.17:
+  version "0.5.19"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
+  integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+ts-node@^9.1.1:
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.1.1.tgz#51a9a450a3e959401bda5f004a72d54b936d376d"
+  integrity sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==
+  dependencies:
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.17"
+    yn "3.1.1"
+
+typescript@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
+  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
 
 url@0.10.3:
   version "0.10.3"
@@ -96,3 +151,8 @@ xmlbuilder@~9.0.1:
   version "9.0.7"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
   integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3790,6 +3790,11 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
+
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
@@ -4050,6 +4055,21 @@ autoprefixer@^9.5.0, autoprefixer@^9.7.2:
     num2fraction "^1.2.2"
     postcss "^7.0.32"
     postcss-value-parser "^4.1.0"
+
+aws-sdk@^2.813.0:
+  version "2.813.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.813.0.tgz#16104b91a286c1fc8ca6480ac32ccebb955f6148"
+  integrity sha512-uOeJ6DgsImQLv0eC0KHloFgDP788A1MEYTKdSV+1Bjv1iqQHH3bJcH5DPPX2NSyeaXJAjkVSVT2Fqe4s5Vf9TA==
+  dependencies:
+    buffer "4.9.2"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
 
 aws-sign2@~0.7.0:
   version "0.7.0"
@@ -5065,15 +5085,7 @@ buffer-xor@^1.0.3:
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
   integrity sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=
 
-buffer@5.6.0:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.6.0.tgz#a31749dc7d81d84db08abf937b6b8c4033f62786"
-  integrity sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==
-  dependencies:
-    base64-js "^1.0.2"
-    ieee754 "^1.1.4"
-
-buffer@^4.3.0:
+buffer@4.9.2, buffer@^4.3.0:
   version "4.9.2"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
   integrity sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==
@@ -5081,6 +5093,14 @@ buffer@^4.3.0:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
     isarray "^1.0.0"
+
+buffer@5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.6.0.tgz#a31749dc7d81d84db08abf937b6b8c4033f62786"
+  integrity sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
 
 buffer@^5.5.0:
   version "5.7.1"
@@ -6136,6 +6156,11 @@ create-react-context@0.3.0, create-react-context@^0.3.0:
     gud "^1.0.0"
     warning "^4.0.3"
 
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
 cross-fetch@3.0.5:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.5.tgz#2739d2981892e7ab488a7ad03b92df2816e03f4c"
@@ -6827,6 +6852,11 @@ diff-sequences@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"
   integrity sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -7746,6 +7776,11 @@ eventemitter3@^4.0.0:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
+
+events@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+  integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
 
 events@^3.0.0:
   version "3.2.0"
@@ -9466,6 +9501,11 @@ icss-utils@^4.0.0, icss-utils@^4.1.0, icss-utils@^4.1.1:
   dependencies:
     postcss "^7.0.14"
 
+ieee754@1.1.13:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
+  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
+
 ieee754@^1.1.13, ieee754@^1.1.4:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
@@ -11142,6 +11182,11 @@ jest@^24.5.0, jest@^24.9.0:
     import-local "^2.0.0"
     jest-cli "^24.9.0"
 
+jmespath@0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
+  integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
+
 joi@^17.1.1:
   version "17.3.0"
   resolved "https://registry.yarnpkg.com/joi/-/joi-17.3.0.tgz#f1be4a6ce29bc1716665819ac361dfa139fff5d2"
@@ -12013,7 +12058,7 @@ make-dir@^3.0.0, make-dir@^3.0.2, make-dir@^3.1.0:
   dependencies:
     semver "^6.0.0"
 
-make-error@1.x:
+make-error@1.x, make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
@@ -15970,7 +16015,12 @@ sass-loader@^8.0.0:
     schema-utils "^2.6.1"
     semver "^6.3.0"
 
-sax@^1.2.4, sax@~1.2.4:
+sax@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+  integrity sha1-e45lYZCyKOgaZq6nSEgNgozS03o=
+
+sax@>=0.6.0, sax@^1.2.4, sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -16433,7 +16483,7 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
-source-map-support@^0.5.6, source-map-support@~0.5.12:
+source-map-support@^0.5.17, source-map-support@^0.5.6, source-map-support@~0.5.12:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
@@ -17508,6 +17558,18 @@ ts-jest@^26.4.4:
     semver "7.x"
     yargs-parser "20.x"
 
+ts-node@^9.1.1:
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.1.1.tgz#51a9a450a3e959401bda5f004a72d54b936d376d"
+  integrity sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==
+  dependencies:
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.17"
+    yn "3.1.1"
+
 ts-pnp@^1.1.2, ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
@@ -17650,6 +17712,11 @@ typescript@^4.0.2, typescript@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.5.tgz#ae9dddfd1069f1cb5beb3ef3b2170dd7c1332389"
   integrity sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==
+
+typescript@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
+  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
 
 uglify-js@3.4.x:
   version "3.4.10"
@@ -17960,6 +18027,14 @@ url-to-options@^1.0.1:
   resolved "https://registry.yarnpkg.com/url-to-options/-/url-to-options-1.0.1.tgz#1505a03a289a48cbd7a434efbaeec5055f5633a9"
   integrity sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=
 
+url@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
+  integrity sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
+
 url@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
@@ -18044,6 +18119,11 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
+
+uuid@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
 uuid@^3.3.2, uuid@^3.3.3:
   version "3.4.0"
@@ -18580,6 +18660,19 @@ xml-name-validator@^3.0.0:
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
 
+xml2js@0.4.19:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
+  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~9.0.1"
+
+xmlbuilder@~9.0.1:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
+  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
+
 xmlchars@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
@@ -18707,6 +18800,11 @@ ylru@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ylru/-/ylru-1.2.1.tgz#f576b63341547989c1de7ba288760923b27fe84f"
   integrity sha512-faQrqNMzcPCHGVC2aaOINk13K+aaBDUPjGWl0teOXywElLjyVAB6Oe2jj62jHYtwsU49jXhScYbvPENK+6zAvQ==
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 yup@^0.27.0:
   version "0.27.0"


### PR DESCRIPTION
I'd been wondering if this was possible and thought I'd have a go at it - this work slurps the IDs out of the toggles file and makes a union type out of them, so that across the app we can be completely type safe with our toggles. One big benefit of this is that we are prevented from leaving behind old toggles - in fact I found an old one while doing this work!

Whilst it does introduce a dependency on `@weco/toggles` for the other webapps, by using `devDependencies` in the toggles app we don't drag along any of the transitive dependencies (typescript, ts-node, and aws-sdk) and so it shouldn't affect bundle size at all, but it did require that the (very small) toggles directory was added to the Docker images that needed it as a dependency.