### PR TITLE
Update weco-deploy to latest version

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -231,7 +231,7 @@
             "--from-label", "ref.$BUILDKITE_COMMIT",
             "--environment-id", "stage",
             "--description", $BUILDKITE_BUILD_URL,
-            "--confirmation-wait-for", 3600]
+            "--confirmation-wait-for", 3540] # Session times out at 3600s / 1 hour
 
 - wait
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -222,7 +222,7 @@
   if: build.branch == "master"
   plugins:
     - docker#v3.5.0:
-        image: wellcome/weco-deploy:5.5.3
+        image: wellcome/weco-deploy:5.6.11
         workdir: /repo
         mount-ssh-agent: true
         command: [


### PR DESCRIPTION
Waiting for deployment sometimes never succeeds - eg https://buildkite.com/wellcomecollection/front-end-wellcomecollection-dot-org/builds/1180#51445ae1-7726-4c5a-950e-a86d1d4221f4 and https://buildkite.com/wellcomecollection/front-end-wellcomecollection-dot-org/builds/1207#b278b54d-57ad-4da8-a1be-5a05f0bd282b.

I'm not totally sure of the reason(s) for this but there were a variety of fixes/changes to this behaviour since 5.5.3 so updating is the first and hopefully only step to resolving it.