### PR TITLE
Archive label tweaks

### DIFF
--- a/catalogue/webapp/components/WorksSearchResult/WorksSearchResult.tsx
+++ b/catalogue/webapp/components/WorksSearchResult/WorksSearchResult.tsx
@@ -79,7 +79,9 @@ const WorkCard: FunctionComponent<Props> = ({ work }: Props) => {
   const productionDates = getProductionDates(work);
   const workTypeIcon = getWorkTypeIcon(work);
   const { archiveContextInSearch } = useContext(TogglesContext);
-  const archiveLabels = archiveContextInSearch && getArchiveLabels(work);
+  const archiveLabels = archiveContextInSearch
+    ? getArchiveLabels(work)
+    : undefined;
   return (
     <div
       className={classNames({
@@ -180,17 +182,17 @@ const WorkCard: FunctionComponent<Props> = ({ work }: Props) => {
                   />
                 )}
               </div>
-              {archiveLabels && (
-                <>
-                  <LinkLabels
-                    heading="Reference"
-                    items={[{ text: archiveLabels.reference }]}
-                  />
-                  <LinkLabels
-                    heading="Part of"
-                    items={[{ text: archiveLabels.partOf }]}
-                  />
-                </>
+              {archiveLabels?.reference && (
+                <LinkLabels
+                  heading="Reference"
+                  items={[{ text: archiveLabels.reference }]}
+                />
+              )}
+              {archiveLabels?.partOf && (
+                <LinkLabels
+                  heading="Part of"
+                  items={[{ text: archiveLabels.partOf }]}
+                />
               )}
             </Details>
             {work.thumbnail && !isPdfThumbnail(work.thumbnail) && (

--- a/common/utils/works.ts
+++ b/common/utils/works.ts
@@ -228,18 +228,18 @@ export function getItemIdentifiersWith(
 
 type ArchiveLabels = {
   reference: string;
-  partOf: string;
+  partOf?: string;
 };
 
 const getArchiveRoot = (work: RelatedWork): RelatedWork =>
   work?.partOf?.[0] ? getArchiveRoot(work.partOf[0]) : work;
 
 export const getArchiveLabels = (work: Work): ArchiveLabels | undefined => {
-  if (work.referenceNumber && work.partOf?.[0]?.referenceNumber) {
+  if (work.referenceNumber) {
     const root = getArchiveRoot(work);
     return {
       reference: work.referenceNumber,
-      partOf: root.title,
+      partOf: root.id !== work.id ? root.title : undefined,
     };
   }
   return undefined;


### PR DESCRIPTION
I was accidentally not showing the reference for archive roots, and realised that we shouldn't be showing "part of" for them