### PR TITLE
Season dates

### DIFF
--- a/cardigan/stories/components/BannerCard.js
+++ b/cardigan/stories/components/BannerCard.js
@@ -1,9 +1,12 @@
 import { storiesOf } from '@storybook/react';
 import BannerCard from '../../../common/views/components/BannerCard/BannerCard';
 import Readme from '../../../common/views/components/BannerCard/README.md';
+import { boolean } from '@storybook/addon-knobs/react';
 
 const item = {
   title: 'What does it mean to be human, now?',
+  start: '2021-01-05T00:00:00.000Z',
+  end: '2021-01-26T00:00:00.000Z',
   type: 'seasons',
   promo: {
     caption:
@@ -159,6 +162,13 @@ const item = {
   },
 };
 
-const BannerCardExample = () => <BannerCard item={item} />;
+const BannerCardExample = () => {
+  const hasDateRange = boolean('hasDateRange', true);
+  return (
+    <BannerCard
+      item={hasDateRange ? item : { ...item, start: undefined, end: undefined }}
+    />
+  );
+};
 const stories = storiesOf('Components', module);
 stories.add('BannerCard', BannerCardExample, { readme: { sidebar: Readme } });

--- a/cardigan/stories/components/SeasonsHeader.js
+++ b/cardigan/stories/components/SeasonsHeader.js
@@ -2,6 +2,7 @@ import { storiesOf } from '@storybook/react';
 import { UiImage } from '@weco/common/views/components/Images/Images';
 import SeasonsHeader from '../../../common/views/components/SeasonsHeader/SeasonsHeader';
 import Readme from '../../../common/views/components/SeasonsHeader/README.md';
+import { boolean } from '@storybook/addon-knobs/react';
 
 const image = {
   contentUrl:
@@ -24,6 +25,8 @@ const image = {
 const headerProps = {
   labels: { labels: [{ url: null, text: 'Article' }] },
   title: 'What does it mean to be human, now?',
+  start: '2021-01-05T00:00:00.000Z',
+  end: '2021-01-26T00:00:00.000Z',
   FeaturedMedia: <UiImage {...image} />,
   standfirst: [
     {
@@ -35,14 +38,19 @@ const headerProps = {
   ],
 };
 
-const SeasonsHeaderExample = () => (
-  <SeasonsHeader
-    labels={headerProps.labels}
-    title={headerProps.title}
-    standfirst={headerProps.standfirst}
-    FeaturedMedia={headerProps.FeaturedMedia}
-  />
-);
+const SeasonsHeaderExample = () => {
+  const hasDateRange = boolean('hasDateRange', true);
+  return (
+    <SeasonsHeader
+      labels={headerProps.labels}
+      title={headerProps.title}
+      start={hasDateRange && headerProps.start}
+      end={hasDateRange && headerProps.end}
+      standfirst={headerProps.standfirst}
+      FeaturedMedia={headerProps.FeaturedMedia}
+    />
+  );
+};
 const stories = storiesOf('Components', module);
 stories.add('SeasonsHeader', SeasonsHeaderExample, {
   readme: { sidebar: Readme },

--- a/common/model/seasons.ts
+++ b/common/model/seasons.ts
@@ -8,6 +8,8 @@ import { ArticleSeries } from './article-series';
 
 export type Season = GenericContentFields & {
   type: 'seasons';
+  start: Date | undefined;
+  end: Date | undefined;
 };
 
 export type SeasonWithContent = {
@@ -16,6 +18,6 @@ export type SeasonWithContent = {
   books: Book[];
   events: Event[];
   exhibitions: Exhibition[];
-  pages: Page[],
-  articleSeries: ArticleSeries[]
+  pages: Page[];
+  articleSeries: ArticleSeries[];
 };

--- a/common/services/prismic/fetch-links.js
+++ b/common/services/prismic/fetch-links.js
@@ -94,7 +94,12 @@ export const eventsFields = [
   'events.series',
   'events.times',
 ];
-export const seasonsFields = ['seasons.title', 'seasons.promo'];
+export const seasonsFields = [
+  'seasons.title',
+  'seasons.start',
+  'seasons.end',
+  'seasons.promo',
+];
 export const cardsFields = [
   'card.title',
   'card.format',

--- a/common/views/components/BannerCard/BannerCard.tsx
+++ b/common/views/components/BannerCard/BannerCard.tsx
@@ -8,6 +8,7 @@ import styled from 'styled-components';
 import Space from '../styled/Space';
 import { convertImageUri } from '../../../utils/convert-image-uri';
 import ButtonOutlined from '../ButtonOutlined/ButtonOutlined';
+import DateRange from '../DateRange/DateRange';
 
 type CardOuterProps = {
   background: 'charcoal' | 'cream';
@@ -75,9 +76,11 @@ const BannerCard: FunctionComponent<Props> = ({
   background = 'charcoal',
   highlightColor = 'orange',
 }: Props) => {
-  const { type, title, description, image, link } = {
+  const { type, title, start, end, description, image, link } = {
     type: getTypeLabel(item.type),
     title: item.title,
+    start: item.start,
+    end: item.end,
     description: item.promo && item.promo.caption,
     image: item.promo &&
       item.promo.image && {
@@ -130,7 +133,7 @@ const BannerCard: FunctionComponent<Props> = ({
         )}
         <Space
           v={{
-            size: 's',
+            size: 'm',
             properties: ['margin-top', 'margin-bottom'],
           }}
           as="h2"
@@ -141,6 +144,17 @@ const BannerCard: FunctionComponent<Props> = ({
         >
           {title}
         </Space>
+        {start && end && (
+          <Space
+            v={{
+              size: 's',
+              properties: ['margin-top', 'margin-bottom'],
+            }}
+            className={`${font('hnl', 5)} font-marble`}
+          >
+            <DateRange start={new Date(start)} end={new Date(end)} />
+          </Space>
+        )}
         <p
           className={classNames({
             [font('hnl', 5)]: true,

--- a/common/views/components/SeasonsHeader/SeasonsHeader.tsx
+++ b/common/views/components/SeasonsHeader/SeasonsHeader.tsx
@@ -9,6 +9,7 @@ import Space from '../styled/Space';
 import PageHeaderStandfirst from '../PageHeaderStandfirst/PageHeaderStandfirst';
 import styled from 'styled-components';
 import { HTMLString } from '../../../services/prismic/types';
+import DateRange from '../DateRange/DateRange';
 
 const HeaderWrapper = styled.div`
   background: ${props => props.theme.color('charcoal')};
@@ -23,7 +24,8 @@ type Props = {
   title: string;
   FeaturedMedia: ReactElement<typeof UiImage> | null;
   standfirst: HTMLString | null;
-  // TODO dates
+  start: Date | undefined;
+  end: Date | undefined;
 };
 
 const SeasonsHeader: FunctionComponent<Props> = ({
@@ -31,6 +33,8 @@ const SeasonsHeader: FunctionComponent<Props> = ({
   title,
   FeaturedMedia,
   standfirst,
+  start,
+  end,
 }: Props) => {
   return (
     <Layout12>
@@ -50,9 +54,19 @@ const SeasonsHeader: FunctionComponent<Props> = ({
                     <LabelsList {...labels} labelColor="orange" />
                   )}
                   <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
-                    <h1 className={`inline-block no-margin ${font('wb', 1)}`}>
-                      {title}
-                    </h1>
+                    <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
+                      <h1 className={`inline-block no-margin ${font('wb', 1)}`}>
+                        {title}
+                      </h1>
+                    </Space>
+                    {start && end && (
+                      <div className={font('hnl', 5)}>
+                        <DateRange
+                          start={new Date(start)}
+                          end={new Date(end)}
+                        />
+                      </div>
+                    )}
                     <PageHeaderStandfirst html={standfirst} />
                   </Space>
                 </Space>

--- a/content/webapp/pages/page.js
+++ b/content/webapp/pages/page.js
@@ -126,9 +126,9 @@ export class Page extends Component<Props> {
               pageId={page.id}
               onThisPage={page.onThisPage}
               showOnThisPage={page.showOnThisPage}
-              />
-            }
-            seasons={page.seasons}
+            />
+          }
+          seasons={page.seasons}
         />
       </PageLayout>
     );

--- a/content/webapp/pages/season.tsx
+++ b/content/webapp/pages/season.tsx
@@ -12,7 +12,6 @@ import { getSeasonWithContent } from '@weco/common/services/prismic/seasons';
 import CardGrid from '@weco/common/views/components/CardGrid/CardGrid';
 import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
 import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
-import SectionHeader from '@weco/common/views/components/SectionHeader/SectionHeader';
 import { convertJsonToDates } from './event';
 
 const SeasonPage = ({
@@ -30,6 +29,8 @@ const SeasonPage = ({
       title={season.title}
       FeaturedMedia={<UiImage {...season.widescreenImage} sizesQueries="" />}
       standfirst={season?.standfirst}
+      start={season.start}
+      end={season.end}
     />
   );
   const parsedEvents = events.map(convertJsonToDates);
@@ -41,7 +42,14 @@ const SeasonPage = ({
     };
   });
 
-  const allItems = [...parsedExhibitions, ...parsedEvents, ...articles, ...books, ...pages, ...articleSeries];
+  const allItems = [
+    ...parsedExhibitions,
+    ...parsedEvents,
+    ...articles,
+    ...books,
+    ...pages,
+    ...articleSeries,
+  ];
 
   return (
     <PageLayout

--- a/prismic-model/js/seasons.js
+++ b/prismic-model/js/seasons.js
@@ -2,10 +2,13 @@
 import title from './parts/title';
 import promo from './parts/promo';
 import body from './parts/body';
+import timestamp from './parts/timestamp';
 
 const SeasonPage = {
   Season: {
     title: title,
+    start: timestamp('Start date'),
+    end: timestamp('End date'),
     body,
   },
   Promo: {

--- a/prismic-model/json/seasons.json
+++ b/prismic-model/json/seasons.json
@@ -8,6 +8,18 @@
         "useAsTitle": true
       }
     },
+    "start": {
+      "type": "Timestamp",
+      "config": {
+        "label": "Start date"
+      }
+    },
+    "end": {
+      "type": "Timestamp",
+      "config": {
+        "label": "End date"
+      }
+    },
     "body": {
       "fieldset": "Body content",
       "type": "Slices",
@@ -419,7 +431,8 @@
                     "articles",
                     "exhibitions",
                     "card",
-                    "landing-pages"
+                    "landing-pages",
+                    "seasons"
                   ]
                 }
               }


### PR DESCRIPTION
Fixes #5865

Adds start and end dates to the seasons custom type in prismic and displays them on the BannerCard and SeasonsHeader.

![Screenshot 2021-01-05 at 16 39 24](https://user-images.githubusercontent.com/6051896/103710893-0d3df480-4fae-11eb-87a2-2d02b7e28f3c.png)
![Screenshot 2021-01-05 at 17 53 44](https://user-images.githubusercontent.com/6051896/103710897-0e6f2180-4fae-11eb-85a1-68fe397acf9b.png)
