### PR TITLE
add block step and prod deployment to ci

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -58,7 +58,7 @@
 - wait
 
 - label: "deploy catalogue (ecr image)"
-  branches: "master feat/ci_prod_deploy"
+  branches: "master"
   plugins:
     - wellcomecollection/aws-assume-role#v0.2.2:
         role: "arn:aws:iam::130871440101:role/experience-ci"
@@ -85,7 +85,7 @@
           - AWS_SESSION_TOKEN
 
 - label: "deploy content (ecr image)"
-  branches: "master feat/ci_prod_deploy"
+  branches: "master"
   plugins:
     - wellcomecollection/aws-assume-role#v0.2.2:
         role: "arn:aws:iam::130871440101:role/experience-ci"
@@ -264,14 +264,14 @@
 - wait
 
 - block: ":rocket: Release to prod"
-  branches: "master feat/ci_prod_deploy"
+  branches: "master"
   prompt: "Have you checked staging?"
   depends_on: 
     - step: "e2e_test_desktop_stage"
     - step: "e2e_test_mobile_stage"
 
 - label: "release to prod"
-  branches: "master feat/ci_prod_deploy"
+  branches: "master"
   plugins:
     - docker#v3.5.0:
         image: wellcome/weco-deploy:5.6.11
@@ -288,7 +288,7 @@
 - wait
 
 - label: "e2e test:desktop [prod]"
-  branches: "master feat/ci_prod_deploy"
+  branches: "master"
   plugins:
     - docker-compose#v3.5.0:
         run: e2e
@@ -297,7 +297,7 @@
         command: ["yarn", "test"]
 
 - label: "e2e test:mobile [prod]"
-  branches: "master feat/ci_prod_deploy"
+  branches: "master"
   plugins:
     - docker-compose#v3.5.0:
         run: e2e

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -222,7 +222,7 @@
   branches: "master"
   plugins:
     - docker#v3.5.0:
-        image: wellcome/weco-deploy:5.6.12
+        image: wellcome/weco-deploy:5.6.11
         workdir: /repo
         mount-ssh-agent: true
         command: [
@@ -274,7 +274,7 @@
   branches: "master feat/ci_prod_deploy"
   plugins:
     - docker#v3.5.0:
-        image: wellcome/weco-deploy:5.6.12
+        image: wellcome/weco-deploy:5.6.11
         workdir: /repo
         mount-ssh-agent: true
         command: [

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -58,6 +58,7 @@
 - wait
 
 - label: "deploy catalogue (ecr image)"
+  key: "deploy_catalogue_ecr_image"
   branches: "master feat/ci_prod_deploy"
   plugins:
     - wellcomecollection/aws-assume-role#v0.2.2:
@@ -85,6 +86,7 @@
           - AWS_SESSION_TOKEN
 
 - label: "deploy content (ecr image)"
+  key: "deploy_content_ecr_image"
   branches: "master feat/ci_prod_deploy"
   plugins:
     - wellcomecollection/aws-assume-role#v0.2.2:
@@ -242,7 +244,7 @@
     - docker-compose#v3.5.0:
         run: e2e
         env:
-          - PLAYWRIGHT_BASE_URL=https://www-stage.wellcomecollection-dummy.org
+          - PLAYWRIGHT_BASE_URL=https://www-stage.wellcomecollection.org
         command: ["yarn", "test"]
 
 - label: "e2e test:mobile [stage]"
@@ -252,7 +254,7 @@
     - docker-compose#v3.5.0:
         run: e2e
         env:
-          - PLAYWRIGHT_BASE_URL=https://www-stage.wellcomecollection-dummy.org
+          - PLAYWRIGHT_BASE_URL=https://www-stage.wellcomecollection.org
         command: ["yarn", "test:mobile"]  
 
 - wait
@@ -266,7 +268,9 @@
 - block: ":rocket: Release to prod"
   branches: "master feat/ci_prod_deploy"
   prompt: "Have you checked staging?"
-  depends_on: 
+  depends_on:
+    - step: "deploy_catalogue_ecr_image"
+    - step: "deploy_content_ecr_image"
     - step: "e2e_test_desktop_stage"
     - step: "e2e_test_mobile_stage"
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -58,7 +58,7 @@
 - wait
 
 - label: "deploy catalogue (ecr image)"
-  branches: "master"
+  branches: "master feat/ci_prod_deploy"
   plugins:
     - wellcomecollection/aws-assume-role#v0.2.2:
         role: "arn:aws:iam::130871440101:role/experience-ci"
@@ -85,7 +85,7 @@
           - AWS_SESSION_TOKEN
 
 - label: "deploy content (ecr image)"
-  branches: "master"
+  branches: "master feat/ci_prod_deploy"
   plugins:
     - wellcomecollection/aws-assume-role#v0.2.2:
         role: "arn:aws:iam::130871440101:role/experience-ci"
@@ -236,23 +236,23 @@
 - wait
 
 - label: "e2e test:desktop [stage]"
-  branches: "master"
+  branches: "master feat/ci_prod_deploy"
   key: "e2e_test_desktop_stage"
   plugins:
     - docker-compose#v3.5.0:
         run: e2e
         env:
-          - PLAYWRIGHT_BASE_URL=https://www-stage.wellcomecollection.org
+          - PLAYWRIGHT_BASE_URL=https://www-stage.wellcomecollection-dummy.org
         command: ["yarn", "test"]
 
 - label: "e2e test:mobile [stage]"
-  branches: "master"
+  branches: "master feat/ci_prod_deploy"
   key: "e2e_test_mobile_stage"
   plugins:
     - docker-compose#v3.5.0:
         run: e2e
         env:
-          - PLAYWRIGHT_BASE_URL=https://www-stage.wellcomecollection.org
+          - PLAYWRIGHT_BASE_URL=https://www-stage.wellcomecollection-dummy.org
         command: ["yarn", "test:mobile"]  
 
 - wait
@@ -264,14 +264,14 @@
 - wait
 
 - block: ":rocket: Release to prod"
-  branches: "master"
+  branches: "master feat/ci_prod_deploy"
   prompt: "Have you checked staging?"
   depends_on: 
     - step: "e2e_test_desktop_stage"
     - step: "e2e_test_mobile_stage"
 
 - label: "release to prod"
-  branches: "master"
+  branches: "master feat/ci_prod_deploy"
   plugins:
     - docker#v3.5.0:
         image: wellcome/weco-deploy:5.6.11

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -262,11 +262,11 @@
 - wait
 
 - block:
-    if: build.branch == "feat/ci_prod_deploy"
-    prompt: ":rocket: Release to prod?"
+    branches: "master feat/ci_prod_deploy"
+    prompt: ":rocket: Release to prod, have you checked [staging]?"
 
 - label: "release to prod"
-  if: build.branch == "feat/ci_prod_deploy"
+  branches: "master feat/ci_prod_deploy"
   plugins:
     - docker#v3.5.0:
         image: wellcome/weco-deploy:5.6.11

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -218,7 +218,7 @@
 
 - wait
 
-- label: release to stage
+- label: "release to stage"
   if: build.branch == "master"
   plugins:
     - docker#v3.5.0:
@@ -258,3 +258,24 @@
 - label: "Integration pipeline"
   trigger: "integration"
   async: true
+
+- wait
+
+- block:
+    if: build.branch == "feat/ci_prod_deploy"
+    prompt: ":rocket: Release to prod?"
+
+- label: "release to prod"
+  if: build.branch == "feat/ci_prod_deploy"
+  plugins:
+    - docker#v3.5.0:
+        image: wellcome/weco-deploy:5.6.11
+        workdir: /repo
+        mount-ssh-agent: true
+        command: [
+            "--confirm",
+            "release-deploy",
+            "--from-label", "ref.$BUILDKITE_COMMIT",
+            "--environment-id", "stage",
+            "--description", $BUILDKITE_BUILD_URL,
+            "--confirmation-wait-for", 3540] # Session times out at 3600s / 1 hour

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -58,7 +58,6 @@
 - wait
 
 - label: "deploy catalogue (ecr image)"
-  key: "deploy_catalogue_ecr_image"
   branches: "master"
   plugins:
     - wellcomecollection/aws-assume-role#v0.2.2:
@@ -86,7 +85,6 @@
           - AWS_SESSION_TOKEN
 
 - label: "deploy content (ecr image)"
-  key: "deploy_content_ecr_image"
   branches: "master"
   plugins:
     - wellcomecollection/aws-assume-role#v0.2.2:
@@ -239,7 +237,6 @@
 
 - label: "e2e test:desktop [stage]"
   branches: "master"
-  key: "e2e_test_desktop_stage"
   plugins:
     - docker-compose#v3.5.0:
         run: e2e
@@ -249,7 +246,6 @@
 
 - label: "e2e test:mobile [stage]"
   branches: "master"
-  key: "e2e_test_mobile_stage"
   plugins:
     - docker-compose#v3.5.0:
         run: e2e

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -276,6 +276,6 @@
             "--confirm",
             "release-deploy",
             "--from-label", "ref.$BUILDKITE_COMMIT",
-            "--environment-id", "stage",
+            "--environment-id", "production",
             "--description", $BUILDKITE_BUILD_URL,
             "--confirmation-wait-for", 3540] # Session times out at 3600s / 1 hour

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -219,7 +219,7 @@
 - wait
 
 - label: "release to stage"
-  if: build.branch == "master"
+  branches: "master feat/ci_prod_deploy"
   plugins:
     - docker#v3.5.0:
         image: wellcome/weco-deploy:5.6.12

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -263,9 +263,9 @@
 
 - wait
 
-- block:
+- block: ":rocket: Release to prod"
     branches: "master feat/ci_prod_deploy"
-    prompt: "Release to prod, have you checked staging?"
+    prompt: "Have you checked staging?"
     depends_on: 
       - step: "e2e_test_desktop_stage"
       - step: "e2e_test_mobile_stage"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -58,7 +58,7 @@
 - wait
 
 - label: "deploy catalogue (ecr image)"
-  branches: "master"
+  branches: "master feat/ci_prod_deploy"
   plugins:
     - wellcomecollection/aws-assume-role#v0.2.2:
         role: "arn:aws:iam::130871440101:role/experience-ci"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -222,7 +222,7 @@
   if: build.branch == "master"
   plugins:
     - docker#v3.5.0:
-        image: wellcome/weco-deploy:5.6.11
+        image: wellcome/weco-deploy:5.6.12
         workdir: /repo
         mount-ssh-agent: true
         command: [
@@ -269,7 +269,7 @@
   if: build.branch == "master"
   plugins:
     - docker#v3.5.0:
-        image: wellcome/weco-deploy:5.6.11
+        image: wellcome/weco-deploy:5.6.12
         workdir: /repo
         mount-ssh-agent: true
         command: [

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -262,11 +262,11 @@
 - wait
 
 - block:
-    branches: "master feat/ci_prod_deploy"
-    prompt: ":rocket: Release to prod, have you checked [staging]?"
+    if: build.branch == "master"
+    prompt: "Release to prod, have you checked [staging]?"
 
 - label: "release to prod"
-  branches: "master feat/ci_prod_deploy"
+  if: build.branch == "master"
   plugins:
     - docker#v3.5.0:
         image: wellcome/weco-deploy:5.6.11

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -266,13 +266,8 @@
 - wait
 
 - block: ":rocket: Release to prod"
-  branches: "master feat/ci_prod_deploy"
+  branches: "master"
   prompt: "Have you checked staging?"
-  depends_on:
-    - step: "deploy_catalogue_ecr_image"
-    - step: "deploy_content_ecr_image"
-    - step: "e2e_test_desktop_stage"
-    - step: "e2e_test_mobile_stage"
 
 - label: "release to prod"
   branches: "master"
@@ -285,7 +280,7 @@
             "--confirm",
             "release-deploy",
             "--from-label", "ref.$BUILDKITE_COMMIT",
-            "--environment-id", "stage",
+            "--environment-id", "prod",
             "--description", $BUILDKITE_BUILD_URL,
             "--confirmation-wait-for", 3540] # Session times out at 3600s / 1 hour
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -85,7 +85,7 @@
           - AWS_SESSION_TOKEN
 
 - label: "deploy content (ecr image)"
-  branches: "master"
+  branches: "master feat/ci_prod_deploy"
   plugins:
     - wellcomecollection/aws-assume-role#v0.2.2:
         role: "arn:aws:iam::130871440101:role/experience-ci"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -259,12 +259,6 @@
 
 - wait
 
-- label: "Integration pipeline"
-  trigger: "integration"
-  async: true
-
-- wait
-
 - block: ":rocket: Release to prod"
   branches: "master"
   prompt: "Have you checked staging?"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -262,11 +262,11 @@
 - wait
 
 - block:
-    if: build.branch == "master"
+    branches: "master feat/ci_prod_deploy"
     prompt: "Release to prod, have you checked [staging]?"
 
 - label: "release to prod"
-  if: build.branch == "master"
+  branches: "master feat/ci_prod_deploy"
   plugins:
     - docker#v3.5.0:
         image: wellcome/weco-deploy:5.6.12
@@ -276,6 +276,6 @@
             "--confirm",
             "release-deploy",
             "--from-label", "ref.$BUILDKITE_COMMIT",
-            "--environment-id", "production",
+            "--environment-id", "stage",
             "--description", $BUILDKITE_BUILD_URL,
             "--confirmation-wait-for", 3540] # Session times out at 3600s / 1 hour

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -262,6 +262,7 @@
 - block: ":rocket: Release to prod"
   branches: "master"
   prompt: "Have you checked staging?"
+  blocked_state: "running"
 
 - label: "release to prod"
   branches: "master"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -235,9 +235,9 @@
 
 - wait
 
-- label: "e2e test: desktop"
+- label: "e2e test:desktop [stage]"
   branches: "master"
-  key: "e2e_test_desktop"
+  key: "e2e_test_desktop_stage"
   branches: "master"
   plugins:
     - docker-compose#v3.5.0:
@@ -246,9 +246,9 @@
           - PLAYWRIGHT_BASE_URL=https://www-stage.wellcomecollection.org
         command: ["yarn", "test"]
 
-- label: "e2e test: mobile"
+- label: "e2e test:mobile [stage]"
   branches: "master"
-  key: "e2e_test_mobile"
+  key: "e2e_test_mobile_stage"
   plugins:
     - docker-compose#v3.5.0:
         run: e2e
@@ -266,16 +266,13 @@
 
 - block:
     branches: "master feat/ci_prod_deploy"
-    prompt: "Release to prod, have you checked [staging]?"
+    prompt: "Release to prod, have you checked staging?"
     depends_on: 
-    - step: "e2e_test_desktop"
-    - step: "e2e_test_mobile"
+      - step: "e2e_test_desktop_stage"
+      - step: "e2e_test_mobile_stage"
 
 - label: "release to prod"
   branches: "master feat/ci_prod_deploy"
-  depends_on: 
-    - step: "e2e_test_desktop"
-    - step: "e2e_test_mobile"
   plugins:
     - docker#v3.5.0:
         image: wellcome/weco-deploy:5.6.12
@@ -291,20 +288,20 @@
 
 - wait
 
-- label: "e2e test desktop prod"
+- label: "e2e test:desktop [prod]"
   branches: "master feat/ci_prod_deploy"
   plugins:
     - docker-compose#v3.5.0:
         run: e2e
         env:
-          - PLAYWRIGHT_BASE_URL=https://www-stage.wellcomecollection.org
+          - PLAYWRIGHT_BASE_URL=https://wellcomecollection.org
         command: ["yarn", "test"]
 
-- label: "e2e test mobile prod"
+- label: "e2e test:mobile [prod]"
   branches: "master feat/ci_prod_deploy"
   plugins:
     - docker-compose#v3.5.0:
         run: e2e
         env:
-          - PLAYWRIGHT_BASE_URL=https://www-stage.wellcomecollection.org
+          - PLAYWRIGHT_BASE_URL=https://wellcomecollection.org
         command: ["yarn", "test:mobile"]  

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -222,7 +222,7 @@
   branches: "master"
   plugins:
     - docker#v3.5.0:
-        image: wellcome/weco-deploy:5.5.3
+        image: wellcome/weco-deploy:5.6.12
         workdir: /repo
         mount-ssh-agent: true
         command: [
@@ -274,7 +274,7 @@
   branches: "master feat/ci_prod_deploy"
   plugins:
     - docker#v3.5.0:
-        image: wellcome/weco-deploy:5.5.3
+        image: wellcome/weco-deploy:5.6.12
         workdir: /repo
         mount-ssh-agent: true
         command: [

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -264,11 +264,11 @@
 - wait
 
 - block: ":rocket: Release to prod"
-    branches: "master feat/ci_prod_deploy"
-    prompt: "Have you checked staging?"
-    depends_on: 
-      - step: "e2e_test_desktop_stage"
-      - step: "e2e_test_mobile_stage"
+  branches: "master feat/ci_prod_deploy"
+  prompt: "Have you checked staging?"
+  depends_on: 
+    - step: "e2e_test_desktop_stage"
+    - step: "e2e_test_mobile_stage"
 
 - label: "release to prod"
   branches: "master feat/ci_prod_deploy"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -293,4 +293,4 @@
         run: e2e
         env:
           - PLAYWRIGHT_BASE_URL=https://wellcomecollection.org
-        command: ["yarn", "test:mobile"]  
+        command: ["yarn", "test:mobile"]

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -58,7 +58,7 @@
 - wait
 
 - label: "deploy catalogue (ecr image)"
-  if: build.branch == "master"
+  branches: "master"
   plugins:
     - wellcomecollection/aws-assume-role#v0.2.2:
         role: "arn:aws:iam::130871440101:role/experience-ci"
@@ -70,7 +70,7 @@
           - catalogue:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/catalogue_webapp:latest
 
 - label: "deploy catalogue (bundle analysis)"
-  if: build.branch == "master"
+  branches: "master"
   plugins:
     - wellcomecollection/aws-assume-role#v0.2.2:
         role: "arn:aws:iam::130871440101:role/experience-ci"
@@ -85,7 +85,7 @@
           - AWS_SESSION_TOKEN
 
 - label: "deploy content (ecr image)"
-  if: build.branch == "master"
+  branches: "master"
   plugins:
     - wellcomecollection/aws-assume-role#v0.2.2:
         role: "arn:aws:iam::130871440101:role/experience-ci"
@@ -97,7 +97,7 @@
           - content:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/content_webapp:latest
 
 - label: "deploy content (bundle analysis)"
-  if: build.branch == "master"
+  branches: "master"
   plugins:
     - wellcomecollection/aws-assume-role#v0.2.2:
         role: "arn:aws:iam::130871440101:role/experience-ci"
@@ -112,7 +112,7 @@
           - AWS_SESSION_TOKEN
 
 - label: "deploy dash"
-  if: build.branch == "master"
+  branches: "master"
   plugins:
     - wellcomecollection/aws-assume-role#v0.2.2:
         role: "arn:aws:iam::130871440101:role/experience-ci"
@@ -127,7 +127,7 @@
           - AWS_SESSION_TOKEN
 
 - label: "deploy cardigan"
-  if: build.branch == "master"
+  branches: "master"
   plugins:
     - wellcomecollection/aws-assume-role#v0.2.2:
         role: "arn:aws:iam::130871440101:role/experience-ci"
@@ -142,7 +142,7 @@
           - AWS_SESSION_TOKEN
 
 - label: "deploy dash"
-  if: build.branch == "master"
+  branches: "master"
   plugins:
     - wellcomecollection/aws-assume-role#v0.2.2:
         role: "arn:aws:iam::130871440101:role/experience-ci"
@@ -157,7 +157,7 @@
           - AWS_SESSION_TOKEN
 
 - label: "deploy toggles"
-  if: build.branch == "master"
+  branches: "master"
   plugins:
     - wellcomecollection/aws-assume-role#v0.2.2:
         role: "arn:aws:iam::130871440101:role/experience-ci"
@@ -172,7 +172,7 @@
           - AWS_SESSION_TOKEN
 
 - label: "deploy pa11y"
-  if: build.branch == "master"
+  branches: "master"
   plugins:
     - wellcomecollection/aws-assume-role#v0.2.2:
         role: "arn:aws:iam::130871440101:role/experience-ci"
@@ -187,7 +187,7 @@
           - AWS_SESSION_TOKEN
 
 - label: "deploy edge_lambdas"
-  if: build.branch == "master"
+  branches: "master"
   plugins:
     - wellcomecollection/aws-assume-role#v0.2.2:
         role: "arn:aws:iam::130871440101:role/experience-ci"
@@ -202,7 +202,7 @@
           - AWS_SESSION_TOKEN
 
 - label: "deploy updown"
-  if: build.branch == "master"
+  branches: "master"
   plugins:
     - wellcomecollection/aws-assume-role#v0.2.2:
         role: "arn:aws:iam::130871440101:role/experience-ci"
@@ -219,7 +219,7 @@
 - wait
 
 - label: "release to stage"
-  branches: "master feat/ci_prod_deploy"
+  branches: "master"
   plugins:
     - docker#v3.5.0:
         image: wellcome/weco-deploy:5.6.12
@@ -236,7 +236,7 @@
 - wait
 
 - label: "e2e test: desktop"
-  if: build.branch == "master"
+  branches: "master"
   plugins:
     - docker-compose#v3.5.0:
         run: e2e
@@ -245,7 +245,7 @@
         command: ["yarn", "test"]
 
 - label: "e2e test: mobile"
-  if: build.branch == "master"
+  branches: "master"
   plugins:
     - docker-compose#v3.5.0:
         run: e2e

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -217,6 +217,7 @@
           - AWS_SESSION_TOKEN
 
 - wait
+  branches: "master"
 
 - label: "release to stage"
   branches: "master"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -59,7 +59,7 @@
 
 - label: "deploy catalogue (ecr image)"
   key: "deploy_catalogue_ecr_image"
-  branches: "master feat/ci_prod_deploy"
+  branches: "master"
   plugins:
     - wellcomecollection/aws-assume-role#v0.2.2:
         role: "arn:aws:iam::130871440101:role/experience-ci"
@@ -87,7 +87,7 @@
 
 - label: "deploy content (ecr image)"
   key: "deploy_content_ecr_image"
-  branches: "master feat/ci_prod_deploy"
+  branches: "master"
   plugins:
     - wellcomecollection/aws-assume-role#v0.2.2:
         role: "arn:aws:iam::130871440101:role/experience-ci"
@@ -238,7 +238,7 @@
 - wait
 
 - label: "e2e test:desktop [stage]"
-  branches: "master feat/ci_prod_deploy"
+  branches: "master"
   key: "e2e_test_desktop_stage"
   plugins:
     - docker-compose#v3.5.0:
@@ -248,7 +248,7 @@
         command: ["yarn", "test"]
 
 - label: "e2e test:mobile [stage]"
-  branches: "master feat/ci_prod_deploy"
+  branches: "master"
   key: "e2e_test_mobile_stage"
   plugins:
     - docker-compose#v3.5.0:
@@ -275,7 +275,7 @@
     - step: "e2e_test_mobile_stage"
 
 - label: "release to prod"
-  branches: "master feat/ci_prod_deploy"
+  branches: "master"
   plugins:
     - docker#v3.5.0:
         image: wellcome/weco-deploy:5.6.11

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -217,7 +217,6 @@
           - AWS_SESSION_TOKEN
 
 - wait
-  branches: "master"
 
 - label: "release to stage"
   branches: "master"
@@ -239,7 +238,6 @@
 - label: "e2e test:desktop [stage]"
   branches: "master"
   key: "e2e_test_desktop_stage"
-  branches: "master"
   plugins:
     - docker-compose#v3.5.0:
         run: e2e


### PR DESCRIPTION
## Who is this for?
Deployers

## What is it doing for them?
Deploys to prod after a [buildkite block step](https://buildkite.com/docs/pipelines/block-step).