### PR TITLE
Add projects to seasons

### DIFF
--- a/common/model/projects.ts
+++ b/common/model/projects.ts
@@ -1,5 +1,6 @@
 import { GenericContentFields } from './generic-content-fields';
-
+import { Season } from './seasons';
 export type Project = {
   type: 'projects';
+  seasons: Season[];
 } & GenericContentFields;

--- a/common/model/seasons.ts
+++ b/common/model/seasons.ts
@@ -4,6 +4,7 @@ import { Book } from './books';
 import { Event } from './events';
 import { Exhibition } from './exhibitions';
 import { Page } from './pages';
+import { Project } from './projects';
 import { ArticleSeries } from './article-series';
 
 export type Season = GenericContentFields & {
@@ -20,4 +21,5 @@ export type SeasonWithContent = {
   exhibitions: Exhibition[];
   pages: Page[];
   articleSeries: ArticleSeries[];
+  projects: Project[];
 };

--- a/common/model/seasons.ts
+++ b/common/model/seasons.ts
@@ -4,7 +4,6 @@ import { Book } from './books';
 import { Event } from './events';
 import { Exhibition } from './exhibitions';
 import { Page } from './pages';
-import { Project } from './projects';
 import { ArticleSeries } from './article-series';
 
 export type Season = GenericContentFields & {
@@ -21,5 +20,5 @@ export type SeasonWithContent = {
   exhibitions: Exhibition[];
   pages: Page[];
   articleSeries: ArticleSeries[];
-  projects: Project[];
+  projects: Page[];
 };

--- a/common/services/prismic/pages.js
+++ b/common/services/prismic/pages.js
@@ -1,7 +1,12 @@
 // @flow
 import Prismic from 'prismic-javascript';
 import { getDocument, getDocuments } from './api';
-import { parseTimestamp, parseGenericFields, parseOnThisPage, parseSingleLevelGroup } from './parsers';
+import {
+  parseTimestamp,
+  parseGenericFields,
+  parseOnThisPage,
+  parseSingleLevelGroup,
+} from './parsers';
 // $FlowFixMe (tsx)
 import { parseSeason } from './seasons';
 import type { Page } from '../../model/pages';
@@ -104,27 +109,19 @@ type GetPagesProps = {|
 
 export async function getPages(
   req: ?Request,
-  {
-    predicates = [],
-    order = 'desc',
-    page = 1,
-  }: GetPagesProps = {},
+  { predicates = [], order = 'desc', page = 1 }: GetPagesProps = {},
   memoizedPrismic: ?Object
 ): Promise<PaginatedResults<Page>> {
   const paginatedResults = await getDocuments(
     req,
-    [Prismic.Predicates.any('document.type', ['pages'])].concat(
-      predicates,
-    ),
+    [Prismic.Predicates.any('document.type', ['pages'])].concat(predicates),
     {
       page,
     },
     memoizedPrismic
   );
 
-  const pages: Page[] = paginatedResults.results.map(
-    parsePage
-  );
+  const pages: Page[] = paginatedResults.results.map(parsePage);
 
   return {
     currentPage: paginatedResults.currentPage,

--- a/common/services/prismic/projects.ts
+++ b/common/services/prismic/projects.ts
@@ -1,0 +1,36 @@
+// @flow
+import Prismic from 'prismic-javascript';
+import { getDocuments } from './api';
+import { parsePage } from './pages';
+import { Page } from '../../model/pages';
+import { PaginatedResults } from './types';
+import { IncomingMessage } from 'http';
+
+type GetProjectsProps = {
+  predicates?: string[];
+  page?: number;
+};
+
+export async function getProjects(
+  req: IncomingMessage | undefined,
+  { predicates = [], page = 1 }: GetProjectsProps = {},
+  memoizedPrismic: Record<string, unknown>
+): Promise<PaginatedResults<Page>> {
+  const paginatedResults = await getDocuments(
+    req,
+    [Prismic.Predicates.any('document.type', ['projects'])].concat(predicates),
+    {
+      page,
+    },
+    memoizedPrismic
+  );
+  const pages: Page[] = paginatedResults.results.map(parsePage);
+
+  return {
+    currentPage: paginatedResults.currentPage,
+    pageSize: paginatedResults.pageSize,
+    totalResults: paginatedResults.totalResults,
+    totalPages: paginatedResults.totalPages,
+    results: pages,
+  };
+}

--- a/common/services/prismic/seasons.ts
+++ b/common/services/prismic/seasons.ts
@@ -6,6 +6,7 @@ import { getBooks } from './books';
 import { getEvents } from './events';
 import { getExhibitions } from './exhibitions';
 import { getPages } from './pages';
+import { getProjects } from './projects';
 import { getMultipleArticleSeries } from './article-series';
 import { Season, SeasonWithContent } from '../../model/seasons';
 import {
@@ -119,6 +120,14 @@ export async function getSeasonWithContent({
     memoizedPrismic
   );
 
+  const projectsPromise = await getProjects(
+    request,
+    {
+      predicates: [Prismic.Predicates.at('my.projects.seasons.season', id)],
+    },
+    memoizedPrismic
+  );
+
   const [
     season,
     articles,
@@ -127,6 +136,7 @@ export async function getSeasonWithContent({
     exhibitions,
     pages,
     articleSeries,
+    projects,
   ] = await Promise.all([
     seasonPromise,
     articlesPromise,
@@ -135,6 +145,7 @@ export async function getSeasonWithContent({
     exhibitionsPromise,
     pagesPromise,
     articleSeriesPromise,
+    projectsPromise,
   ]);
 
   if (season) {
@@ -146,6 +157,7 @@ export async function getSeasonWithContent({
       exhibitions: exhibitions?.results || [],
       pages: pages?.results || [],
       articleSeries: articleSeries?.results || [],
+      projects: projects?.results || [],
     };
   }
 }

--- a/common/views/components/CardGrid/CardGrid.js
+++ b/common/views/components/CardGrid/CardGrid.js
@@ -23,7 +23,13 @@ import Card from '../Card/Card';
 import { convertItemToCardProps } from '@weco/common/model/card';
 
 // TODO: This should be MultiContent
-type ContentTypes = UiEvent | UiExhibition | Book | Article | Page | ArticleSeries;
+type ContentTypes =
+  | UiEvent
+  | UiExhibition
+  | Book
+  | Article
+  | Page
+  | ArticleSeries;
 
 type Props = {|
   items: $ReadOnlyArray<ContentTypes>,

--- a/content/webapp/pages/season.tsx
+++ b/content/webapp/pages/season.tsx
@@ -22,6 +22,7 @@ const SeasonPage = ({
   exhibitions,
   pages,
   articleSeries,
+  projects,
 }: SeasonWithContent): ReactElement<SeasonWithContent> => {
   const Header = (
     <SeasonsHeader
@@ -49,6 +50,7 @@ const SeasonPage = ({
     ...books,
     ...pages,
     ...articleSeries,
+    ...projects,
   ];
 
   return (

--- a/prismic-model/js/projects.js
+++ b/prismic-model/js/projects.js
@@ -4,6 +4,8 @@ import body from './parts/body';
 import promo from './parts/promo';
 import structuredText from './parts/structured-text';
 import contributorsWithTitle from './parts/contributorsWithTitle';
+import link from './parts/link';
+import list from './parts/list';
 
 const Project = {
   Project: {
@@ -13,6 +15,11 @@ const Project = {
   Contributors: contributorsWithTitle(),
   Promo: {
     promo,
+  },
+  'Content relationships': {
+    seasons: list('Seasons', {
+      season: link('Season', 'document', ['seasons'], 'Select a Season'),
+    }),
   },
   Metadata: {
     metadataDescription: structuredText('Metadata description', 'single'),

--- a/prismic-model/json/projects.json
+++ b/prismic-model/json/projects.json
@@ -594,6 +594,27 @@
       }
     }
   },
+  "Content relationships": {
+    "seasons": {
+      "type": "Group",
+      "fieldset": "Seasons",
+      "config": {
+        "fields": {
+          "season": {
+            "type": "Link",
+            "config": {
+              "label": "Season",
+              "select": "document",
+              "customtypes": [
+                "seasons"
+              ],
+              "placeholder": "Select a Season"
+            }
+          }
+        }
+      }
+    }
+  },
   "Metadata": {
     "metadataDescription": {
       "type": "StructuredText",


### PR DESCRIPTION
Makes it possible to add Series to a Season and displays the relevant promos on each page.

N.B using page parsing functions etc. until we see how projects evolve.
![Screenshot 2021-01-07 at 14 06 18](https://user-images.githubusercontent.com/6051896/103908781-ce698500-50fa-11eb-922d-b05945f480cd.png)
![Screenshot 2021-01-07 at 14 06 31](https://user-images.githubusercontent.com/6051896/103908787-cf9ab200-50fa-11eb-99f1-47e07564714e.png)


