### PR TITLE
redirect webcomic to story ‘January diet’

### DIFF
--- a/cache/edge_lambdas/redirects.js
+++ b/cache/edge_lambdas/redirects.js
@@ -170,4 +170,5 @@ module.exports = {
   '/articles/X5rs7RIAAB4Avr_r': '/articles/X8ZZChIAACUAiFbC',
   '/articles/X7bJORMAACEAiRPo': '/articles/X8dU2BIAACMAjKT-',
   '/articles/X8Ay3hIAACMAbSL2': '/articles/X8dV8xIAACIAjKn6',
+  '/articles/X_dsXREAACMASftU': '/articles/X_g6ohEAACQATYJF',
 };


### PR DESCRIPTION
The latest comic was mistakenly published as the deprecated webcomic type, this redirects it to the story type version