### PR TITLE
Slack deploy message / split pipelines

### DIFF
--- a/.buildkite/pipeline.deploy-prod.yml
+++ b/.buildkite/pipeline.deploy-prod.yml
@@ -10,5 +10,7 @@ steps:
     command: echo "testing prod"
 
 notify:
-  - slack: "#wc-experience"
-    message: "Deploying [bloop] to staging..."
+  - slack:
+      channels:
+        - "#wc-experience"
+      message: "Deploying [bloop] to staging..."

--- a/.buildkite/pipeline.deploy-prod.yml
+++ b/.buildkite/pipeline.deploy-prod.yml
@@ -1,16 +1,41 @@
 steps:
-  - label: "release to prod"
-    command: echo "$BUILDKITE_COMMIT $BUILDKITE_BUILD_URL"
+  - label: "deploy to prod"
     concurrency: 1
-    concurrency_group: "experience-deploy"
+    concurrency_group: "experience-deploy"  
+    plugins:
+      - docker#v3.5.0:
+          image: wellcome/weco-deploy:5.6.16
+          workdir: /repo
+          mount-ssh-agent: true
+          command: [
+              "--confirm",
+              "release-deploy",
+              "--from-label", "ref.$BUILDKITE_COMMIT",
+              "--environment-id", "prod",
+              "--description", $BUILDKITE_BUILD_URL,
+              "--confirmation-wait-for", 3540] # Session times out at 3600s / 1 hour
     
   - wait
 
   - label: "e2e test:desktop [prod]"
-    command: echo "testing prod"
+    plugins:
+      - docker-compose#v3.5.0:
+          run: e2e
+          env:
+            - PLAYWRIGHT_BASE_URL=https://wellcomecollection.org
+          command: ["yarn", "test"]
+
+  - label: "e2e test:mobile [prod]"
+    plugins:
+      - docker-compose#v3.5.0:
+          run: e2e
+          env:
+            - PLAYWRIGHT_BASE_URL=https://wellcomecollection.org
+          command: ["yarn", "test:mobile"]
+
 
 notify:
   - slack:
       channels:
         - "#wc-experience"
-      message: "Deploying [bloop] to staging..."
+      message: "Deployed to prod https://wellcomecollection.org"

--- a/.buildkite/pipeline.deploy-prod.yml
+++ b/.buildkite/pipeline.deploy-prod.yml
@@ -1,0 +1,14 @@
+steps:
+  - label: "release to prod"
+    command: echo "$BUILDKITE_COMMIT $BUILDKITE_BUILD_URL"
+    concurrency: 1
+    concurrency_group: "experience-deploy"
+    
+  - wait
+
+  - label: "e2e test:desktop [prod]"
+    command: echo "testing prod"
+
+notify:
+  - slack: "#wc-experience"
+    message: "Deploying [bloop] to staging..."

--- a/.buildkite/pipeline.deploy-prod.yml
+++ b/.buildkite/pipeline.deploy-prod.yml
@@ -33,7 +33,6 @@ steps:
             - PLAYWRIGHT_BASE_URL=https://wellcomecollection.org
           command: ["yarn", "test:mobile"]
 
-
 notify:
   - slack:
       channels:

--- a/.buildkite/pipeline.deploy-stage.yml
+++ b/.buildkite/pipeline.deploy-stage.yml
@@ -12,7 +12,6 @@ steps:
   - wait
 
   - block: ":rocket: Release to prod"
-    branches: "master"
     prompt: "Have you checked staging?"
     blocked_state: "running"
 

--- a/.buildkite/pipeline.deploy-stage.yml
+++ b/.buildkite/pipeline.deploy-stage.yml
@@ -1,21 +1,44 @@
 steps:
-  - label: "release to stage"
-    command: echo "$BUILDKITE_COMMIT $BUILDKITE_BUILD_URL"
+  - label: "deploy to stage"
     concurrency: 1
     concurrency_group: "experience-deploy"
-  
+    plugins:
+      - docker#v3.5.0:
+          image: wellcome/weco-deploy:5.6.16
+          workdir: /repo
+          mount-ssh-agent: true
+          command: [
+              "--confirm",
+              "release-deploy",
+              "--from-label", "ref.$BUILDKITE_COMMIT",
+              "--environment-id", "stage",
+              "--description", $BUILDKITE_BUILD_URL,
+              "--confirmation-wait-for", 3540] # Session times out at 3600s / 1 hour
+
   - wait
 
   - label: "e2e test:desktop [stage]"
-    command: echo "testing stage"
+    plugins:
+      - docker-compose#v3.5.0:
+          run: e2e
+          env:
+            - PLAYWRIGHT_BASE_URL=https://www-stage.wellcomecollection.org
+          command: ["yarn", "test"]
+
+  - label: "e2e test:mobile [stage]"
+    plugins:
+      - docker-compose#v3.5.0:
+          run: e2e
+          env:
+            - PLAYWRIGHT_BASE_URL=https://www-stage.wellcomecollection.org
+          command: ["yarn", "test:mobile"]
 
   - wait
 
-  - block: ":rocket: Release to prod"
+  - block: ":rocket: deploy to prod"
     prompt: "Have you checked staging?"
-    blocked_state: "running"
 
-  - label: "Deplyments steps"
+  - label: "deploy to prod"
     trigger: "experience-deploy-prod"
     build:
       message: "${BUILDKITE_MESSAGE}"
@@ -30,4 +53,4 @@ notify:
   - slack:
       channels:
         - "#wc-experience"
-      message: "Deploying [bloop] to staging..."
+      message: "Deployed to stage https://www-stage.wellcomecollection.org"

--- a/.buildkite/pipeline.deploy-stage.yml
+++ b/.buildkite/pipeline.deploy-stage.yml
@@ -18,6 +18,14 @@ steps:
 
   - label: "Deplyments steps"
     trigger: "experience-deploy-prod"
+    build:
+      message: "${BUILDKITE_MESSAGE}"
+      commit: "${BUILDKITE_COMMIT}"
+      branch: "${BUILDKITE_BRANCH}"
+      env:
+        BUILDKITE_PULL_REQUEST: "${BUILDKITE_PULL_REQUEST}"
+        BUILDKITE_PULL_REQUEST_BASE_BRANCH: "${BUILDKITE_PULL_REQUEST_BASE_BRANCH}"
+        BUILDKITE_PULL_REQUEST_REPO: "${BUILDKITE_PULL_REQUEST_REPO}"
 
 notify:
   - slack:

--- a/.buildkite/pipeline.deploy-stage.yml
+++ b/.buildkite/pipeline.deploy-stage.yml
@@ -20,5 +20,7 @@ steps:
     trigger: "experience-deploy-prod"
 
 notify:
-  - slack: "#wc-experience"
-    message: "Deploying [bloop] to staging..."
+  - slack:
+      channels:
+        - "#wc-experience"
+      message: "Deploying [bloop] to staging..."

--- a/.buildkite/pipeline.deploy-stage.yml
+++ b/.buildkite/pipeline.deploy-stage.yml
@@ -1,0 +1,24 @@
+steps:
+  - label: "release to stage"
+    command: echo "$BUILDKITE_COMMIT $BUILDKITE_BUILD_URL"
+    concurrency: 1
+    concurrency_group: "experience-deploy"
+  
+  - wait
+
+  - label: "e2e test:desktop [stage]"
+    command: echo "testing stage"
+
+  - wait
+
+  - block: ":rocket: Release to prod"
+    branches: "master"
+    prompt: "Have you checked staging?"
+    blocked_state: "running"
+
+  - label: "Deplyments steps"
+    trigger: "experience-deploy-prod"
+
+notify:
+  - slack: "#wc-experience"
+    message: "Deploying [bloop] to staging..."

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,13 @@
 - label: "Deplyments steps"
   trigger: "experience-deploy-stage"
+  build:
+    message: "${BUILDKITE_MESSAGE}"
+    commit: "${BUILDKITE_COMMIT}"
+    branch: "${BUILDKITE_BRANCH}"
+    env:
+      BUILDKITE_PULL_REQUEST: "${BUILDKITE_PULL_REQUEST}"
+      BUILDKITE_PULL_REQUEST_BASE_BRANCH: "${BUILDKITE_PULL_REQUEST_BASE_BRANCH}"
+      BUILDKITE_PULL_REQUEST_REPO: "${BUILDKITE_PULL_REQUEST_REPO}"
 
 - label: ":docker: Build"
   plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,6 +9,8 @@
       BUILDKITE_PULL_REQUEST_BASE_BRANCH: "${BUILDKITE_PULL_REQUEST_BASE_BRANCH}"
       BUILDKITE_PULL_REQUEST_REPO: "${BUILDKITE_PULL_REQUEST_REPO}"
 
+- wait
+
 - label: ":docker: Build"
   plugins:
     - wellcomecollection/aws-assume-role#v0.2.2:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -220,6 +220,7 @@
 
 - label: "deploy to stage"
   trigger: "experience-deploy-stage"
+  branches: "master"
   build:
     message: "${BUILDKITE_MESSAGE}"
     commit: "${BUILDKITE_COMMIT}"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,16 +1,3 @@
-- label: "Deplyments steps"
-  trigger: "experience-deploy-stage"
-  build:
-    message: "${BUILDKITE_MESSAGE}"
-    commit: "${BUILDKITE_COMMIT}"
-    branch: "${BUILDKITE_BRANCH}"
-    env:
-      BUILDKITE_PULL_REQUEST: "${BUILDKITE_PULL_REQUEST}"
-      BUILDKITE_PULL_REQUEST_BASE_BRANCH: "${BUILDKITE_PULL_REQUEST_BASE_BRANCH}"
-      BUILDKITE_PULL_REQUEST_REPO: "${BUILDKITE_PULL_REQUEST_REPO}"
-
-- wait
-
 - label: ":docker: Build"
   plugins:
     - wellcomecollection/aws-assume-role#v0.2.2:
@@ -231,79 +218,13 @@
 
 - wait
 
-- label: "release to stage"
-  branches: "master"
-  plugins:
-    - docker#v3.5.0:
-        image: wellcome/weco-deploy:5.6.16
-        workdir: /repo
-        mount-ssh-agent: true
-        command: [
-            "--confirm",
-            "release-deploy",
-            "--from-label", "ref.$BUILDKITE_COMMIT",
-            "--environment-id", "stage",
-            "--description", $BUILDKITE_BUILD_URL,
-            "--confirmation-wait-for", 3540] # Session times out at 3600s / 1 hour
-
-- wait
-
-- label: "e2e test:desktop [stage]"
-  branches: "master"
-  plugins:
-    - docker-compose#v3.5.0:
-        run: e2e
-        env:
-          - PLAYWRIGHT_BASE_URL=https://www-stage.wellcomecollection.org
-        command: ["yarn", "test"]
-
-- label: "e2e test:mobile [stage]"
-  branches: "master"
-  plugins:
-    - docker-compose#v3.5.0:
-        run: e2e
-        env:
-          - PLAYWRIGHT_BASE_URL=https://www-stage.wellcomecollection.org
-        command: ["yarn", "test:mobile"]  
-
-- wait
-
-- block: ":rocket: Release to prod"
-  branches: "master"
-  prompt: "Have you checked staging?"
-  blocked_state: "running"
-
-- label: "release to prod"
-  branches: "master"
-  plugins:
-    - docker#v3.5.0:
-        image: wellcome/weco-deploy:5.6.16
-        workdir: /repo
-        mount-ssh-agent: true
-        command: [
-            "--confirm",
-            "release-deploy",
-            "--from-label", "ref.$BUILDKITE_COMMIT",
-            "--environment-id", "prod",
-            "--description", $BUILDKITE_BUILD_URL,
-            "--confirmation-wait-for", 3540] # Session times out at 3600s / 1 hour
-
-- wait
-
-- label: "e2e test:desktop [prod]"
-  branches: "master"
-  plugins:
-    - docker-compose#v3.5.0:
-        run: e2e
-        env:
-          - PLAYWRIGHT_BASE_URL=https://wellcomecollection.org
-        command: ["yarn", "test"]
-
-- label: "e2e test:mobile [prod]"
-  branches: "master"
-  plugins:
-    - docker-compose#v3.5.0:
-        run: e2e
-        env:
-          - PLAYWRIGHT_BASE_URL=https://wellcomecollection.org
-        command: ["yarn", "test:mobile"]
+- label: "deploy to stage"
+  trigger: "experience-deploy-stage"
+  build:
+    message: "${BUILDKITE_MESSAGE}"
+    commit: "${BUILDKITE_COMMIT}"
+    branch: "${BUILDKITE_BRANCH}"
+    env:
+      BUILDKITE_PULL_REQUEST: "${BUILDKITE_PULL_REQUEST}"
+      BUILDKITE_PULL_REQUEST_BASE_BRANCH: "${BUILDKITE_PULL_REQUEST_BASE_BRANCH}"
+      BUILDKITE_PULL_REQUEST_REPO: "${BUILDKITE_PULL_REQUEST_REPO}"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,3 +1,7 @@
+notify:
+  - slack: "#wc-experience"
+    message: "Deploying [bloop] to staging..."
+
 - label: ":docker: Build"
   plugins:
     - wellcomecollection/aws-assume-role#v0.2.2:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,5 @@
-notify:
-  - slack: "#wc-experience"
-    message: "Deploying [bloop] to staging..."
+- label: "Deplyments steps"
+  trigger: "experience-deploy-stage"
 
 - label: ":docker: Build"
   plugins:


### PR DESCRIPTION
## Who is this for?
People who want to see what's deploying where

## What is it doing for them?
Adds slack deployment messages to the buildkite pipeline. It might be better to have them in the deploy tool, but this can be a first step.

We split the deployment up into test / deploy / deploy stage as per the example here.

[You can see a set of pipelines running here](https://buildkite.com/wellcomecollection/front-end-wellcomecollection-dot-org/builds/1329), with the [code here](https://github.com/wellcomecollection/wellcomecollection.org/tree/e5633a0822c13ad19f4ced4800cd7aed78da08b8/.buildkite) - the PR has the actual code filled out.

After this I will work with the team to see what events we need to the channel.
