### PR TITLE
don't run router on initial load of item page

### DIFF
--- a/catalogue/webapp/pages/item.tsx
+++ b/catalogue/webapp/pages/item.tsx
@@ -288,9 +288,7 @@ const ItemPage: NextPage<Props> = ({
       >
         <div className={font('hnl', 5)}>
           {authService?.label && (
-            <h2 className={font('hnm', 4)}>
-              {authService?.label}
-            </h2>
+            <h2 className={font('hnm', 4)}>{authService?.label}</h2>
           )}
           {authService?.description && (
             <p

--- a/common/hooks/useSkipInitialEffect.ts
+++ b/common/hooks/useSkipInitialEffect.ts
@@ -1,0 +1,18 @@
+import { DependencyList, EffectCallback, useEffect, useRef } from 'react';
+
+const useSkipInitialEffect = (
+  effect: EffectCallback,
+  deps?: DependencyList
+): void => {
+  const initialRender = useRef(true);
+
+  useEffect(() => {
+    if (initialRender.current) {
+      initialRender.current = false;
+    } else {
+      return effect();
+    }
+  }, deps);
+};
+
+export default useSkipInitialEffect;

--- a/common/views/components/IIIFViewer/IIIFViewer.tsx
+++ b/common/views/components/IIIFViewer/IIIFViewer.tsx
@@ -32,6 +32,7 @@ import Download from '@weco/catalogue/components/Download/Download';
 import dynamic from 'next/dynamic';
 import { DigitalLocation, Work } from '../../../model/catalogue';
 import { FixedSizeList } from 'react-window';
+import useSkipInitialEffect from '@weco/common/hooks/useSkipInitialEffect';
 
 const LoadingComponent = () => (
   <div
@@ -344,11 +345,13 @@ const IIIFViewerComponent: FunctionComponent<IIIFViewerProps> = ({
       setEnhanced(true);
     }
   }, []);
-  useEffect(() => {
+
+  useSkipInitialEffect(() => {
     const canvasParams =
       canvases.length > 0 || currentCanvas
         ? { canvas: `${activeIndex + 1}` }
         : {};
+
     Router.replace(
       {
         ...mainPaginatorProps.link.href,


### PR DESCRIPTION
**Who is this for?**
ref #5939 

People wanting more accurate analytics, and better perf on page

**What is it doing for them?**
Stops running `Router.replace` on the initial load of the page for page state that only changes once the page has loaded.