### PR TITLE
add source to item pagination

### DIFF
--- a/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
+++ b/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
@@ -294,6 +294,7 @@ const ExpandedImage: FunctionComponent<Props> = ({
       ? imageLink({
           workId,
           id: image.id,
+          resultPosition,
           source: trackingSource,
         })
       : detailedWork &&
@@ -305,6 +306,7 @@ const ExpandedImage: FunctionComponent<Props> = ({
             detailedWork?.languages.length === 1
               ? detailedWork?.languages[0].id
               : undefined,
+          resultPosition: resultPosition,
           source: trackingSource,
           ...(canvasDeeplink || {}),
         });

--- a/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
+++ b/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
@@ -42,6 +42,7 @@ type Props = {
   onWorkLinkClick: () => void;
   onImageLinkClick: () => void;
   id?: string;
+  resultPosition: number;
 };
 
 type CanvasLink = {
@@ -184,6 +185,7 @@ const ExpandedImage: FunctionComponent<Props> = ({
   onWorkLinkClick,
   onImageLinkClick,
   id,
+  resultPosition,
 }: Props) => {
   const { isKeyboard } = useContext(AppContext);
   const toggles = useContext(TogglesContext);
@@ -377,7 +379,11 @@ const ExpandedImage: FunctionComponent<Props> = ({
                   />
                 </Space>
               )}
-              <WorkLink id={workId} source={trackingSource}>
+              <WorkLink
+                id={workId}
+                source={trackingSource}
+                resultPosition={resultPosition}
+              >
                 <a
                   className={classNames({
                     'inline-block': true,

--- a/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
+++ b/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
@@ -26,7 +26,7 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
       className={'flex flex--wrap plain-list no-padding no-margin'}
       role="list"
     >
-      {images.results.map((result: Image, i) => (
+      {images.results.map((result: Image) => (
         <li key={result.id} role="listitem">
           <ImageCard
             id={result.id}
@@ -47,7 +47,7 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
       ))}
       {expandedImage && (
         <ExpandedImage
-          resultPosition={i}
+          resultPosition={expandedImagePosition}
           image={expandedImage}
           setExpandedImage={setExpandedImage}
           onWorkLinkClick={() => {

--- a/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
+++ b/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
@@ -26,7 +26,7 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
       className={'flex flex--wrap plain-list no-padding no-margin'}
       role="list"
     >
-      {images.results.map((result: Image) => (
+      {images.results.map((result: Image, i) => (
         <li key={result.id} role="listitem">
           <ImageCard
             id={result.id}
@@ -47,6 +47,7 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
       ))}
       {expandedImage && (
         <ExpandedImage
+          resultPosition={i}
           image={expandedImage}
           setExpandedImage={setExpandedImage}
           onWorkLinkClick={() => {

--- a/catalogue/webapp/components/WorksSearchResult/WorksSearchResult.tsx
+++ b/catalogue/webapp/components/WorksSearchResult/WorksSearchResult.tsx
@@ -21,6 +21,7 @@ import TogglesContext from '@weco/common/views/components/TogglesContext/Toggles
 
 type Props = {
   work: Work;
+  resultPosition: number;
 };
 
 const ShameAvailableOnlineTag = styled(Space).attrs({
@@ -75,7 +76,10 @@ function isPdfThumbnail(thumbnail): boolean {
   return Boolean(thumbnail.url.match('.pdf/full'));
 }
 
-const WorkCard: FunctionComponent<Props> = ({ work }: Props) => {
+const WorkSearchResult: FunctionComponent<Props> = ({
+  work,
+  resultPosition,
+}: Props) => {
   const productionDates = getProductionDates(work);
   const workTypeIcon = getWorkTypeIcon(work);
   const { archiveContextInSearch } = useContext(TogglesContext);
@@ -89,7 +93,12 @@ const WorkCard: FunctionComponent<Props> = ({ work }: Props) => {
         'border-top-width-1': true,
       })}
     >
-      <WorkLink id={work.id} source={`works_search_result`} passHref>
+      <WorkLink
+        id={work.id}
+        resultPosition={resultPosition}
+        source={`works_search_result`}
+        passHref
+      >
         <Space
           as="a"
           v={{
@@ -213,4 +222,4 @@ const WorkCard: FunctionComponent<Props> = ({ work }: Props) => {
     </div>
   );
 };
-export default WorkCard;
+export default WorkSearchResult;

--- a/catalogue/webapp/components/WorksSearchResults/WorksSearchResults.tsx
+++ b/catalogue/webapp/components/WorksSearchResults/WorksSearchResults.tsx
@@ -45,7 +45,7 @@ const WorkSearchResults: FunctionComponent<Props> = ({
               });
             }}
           >
-            <WorksSearchResult work={result} />
+            <WorksSearchResult work={result} resultPosition={i} />
           </div>
 
           {relevanceRating && (

--- a/common/views/components/IIIFViewer/IIIFViewer.tsx
+++ b/common/views/components/IIIFViewer/IIIFViewer.tsx
@@ -168,7 +168,7 @@ const ImageViewerControls = styled.div<{ showControls?: boolean }>`
     width: 1px;
     white-space: nowrap;
   }
-}`;
+`;
 
 type IIIFViewerProps = {
   title: string;
@@ -358,6 +358,7 @@ const IIIFViewerComponent: FunctionComponent<IIIFViewerProps> = ({
         query: {
           ...mainPaginatorProps.link.href.query,
           ...canvasParams,
+          source: 'viewer/paginator',
         },
       },
       {
@@ -365,6 +366,7 @@ const IIIFViewerComponent: FunctionComponent<IIIFViewerProps> = ({
         query: {
           ...mainPaginatorProps.link.as.query,
           ...canvasParams,
+          source: 'viewer/paginator',
         },
       }
     );

--- a/common/views/components/ImageLink/ImageLink.tsx
+++ b/common/views/components/ImageLink/ImageLink.tsx
@@ -7,6 +7,7 @@ export type ImageQueryParams = {
   id: string;
   workId: string;
   langCode?: string;
+  resultPosition?: number;
   source: ImageLinkSource;
 };
 
@@ -17,6 +18,7 @@ type Props = ImageQueryParams & Omit<LinkProps, 'as' | 'href'>;
 export function imageLink({
   workId,
   source,
+  resultPosition,
   ...params
 }: ImageQueryParams): LinkProps {
   return {
@@ -25,6 +27,7 @@ export function imageLink({
       query: {
         workId,
         source,
+        resultPosition,
         ...params,
       },
     },

--- a/common/views/components/ItemLink/ItemLink.tsx
+++ b/common/views/components/ItemLink/ItemLink.tsx
@@ -11,6 +11,7 @@ export type ItemQueryParams = {
   langCode?: string;
   sierraId?: string;
   isOverview?: boolean;
+  resultPosition?: number;
   source: ItemLinkSource;
 };
 
@@ -47,6 +48,7 @@ const ItemLink: FunctionComponent<PropsWithChildren<Props>> = ({
   isOverview,
   page = 1,
   pageSize = 4,
+  resultPosition,
   source,
   children,
   ...linkProps
@@ -62,6 +64,7 @@ const ItemLink: FunctionComponent<PropsWithChildren<Props>> = ({
         isOverview,
         page,
         pageSize,
+        resultPosition,
       })}
       {...linkProps}
     >

--- a/common/views/components/ItemLink/ItemLink.tsx
+++ b/common/views/components/ItemLink/ItemLink.tsx
@@ -1,7 +1,7 @@
 import NextLink, { LinkProps } from 'next/link';
 import { FunctionComponent, PropsWithChildren } from 'react';
 
-type ItemLinkSource = 'images_search_result';
+type ItemLinkSource = 'images_search_result' | 'viewer/paginator';
 
 export type ItemQueryParams = {
   workId: string;

--- a/common/views/components/WorkLink/WorkLink.tsx
+++ b/common/views/components/WorkLink/WorkLink.tsx
@@ -13,11 +13,13 @@ type WorkLinkSource =
 type Props = {
   id: string;
   source: WorkLinkSource;
+  resultPosition?: number;
 } & Omit<LinkProps, 'as' | 'href'>;
 
 const WorkLink: FunctionComponent<PropsWithChildren<Props>> = ({
   id,
   source,
+  resultPosition,
   children,
   ...linkProps
 }: PropsWithChildren<Props>) => {
@@ -28,6 +30,7 @@ const WorkLink: FunctionComponent<PropsWithChildren<Props>> = ({
         query: {
           id,
           source,
+          resultPosition,
         },
       }}
       as={{


### PR DESCRIPTION
## Who is this for?
ref #5939

* People wanting to know when the pagination has been used to navigate
* People wanting to know what position a work was clicked on from

## What is it doing for them?

* Labels the IIIFViewer pagination with `viewer/paginator`. 
* Adds the `resultPosition` to the works search result

Ping @taceybadgerbrook for reference.
