### PR TITLE
add segment session

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -22,6 +22,7 @@
     "@types/jest": "^26.0.17",
     "@types/lodash": "^4.14.161",
     "@types/react-window": "^1.8.2",
+    "@types/uuid": "^8.3.0",
     "@weco/next-plugin-transpile-modules": "^2.0.1",
     "@weco/toggles": "1.0.0",
     "babel-core": "^7.0.0-bridge.0",

--- a/common/package.json
+++ b/common/package.json
@@ -67,6 +67,7 @@
     "search-query-parser": "^1.3.0",
     "styled-components": "^5.2.1",
     "superagent": "^4.1.0",
-    "url-template": "^2.0.8"
+    "url-template": "^2.0.8",
+    "uuid": "^8.3.2"
   }
 }

--- a/common/services/conversion/track.ts
+++ b/common/services/conversion/track.ts
@@ -34,7 +34,7 @@ type Session = {
 
 const sessionIdLocalStorageKey = 'sessionId';
 const lastTrackedLocalStorageKey = 'lastTracked';
-const sessionTimeout = 1000 * 60 * 0.1; // 30 minutes
+const sessionTimeout = 1000 * 60 * 30; // 30 minutes
 function getSessionId(): string {
   const lsSessionId = localStorage.getItem(sessionIdLocalStorageKey);
   const lsLastTracked = localStorage.getItem(lastTrackedLocalStorageKey);

--- a/common/services/conversion/track.ts
+++ b/common/services/conversion/track.ts
@@ -1,6 +1,7 @@
 import cookies from 'next-cookies';
 import Router from 'next/router';
 import { ParsedUrlQuery } from 'querystring';
+import { v4 as uuidv4 } from 'uuid';
 
 declare global {
   interface Window {
@@ -24,6 +25,40 @@ interface Conversion {
   properties: {
     [key: string]: unknown;
   };
+}
+
+type Session = {
+  id: string;
+  timeout: number;
+};
+
+const sessionIdLocalStorageKey = 'sessionId';
+const lastTrackedLocalStorageKey = 'lastTracked';
+const sessionTimeout = 1000 * 60 * 0.1; // 30 minutes
+function getSessionId(): string {
+  const lsSessionId = localStorage.getItem(sessionIdLocalStorageKey);
+  const lsLastTracked = localStorage.getItem(lastTrackedLocalStorageKey);
+
+  if (lsLastTracked) {
+    const now = Date.now();
+    const diff = now - parseInt(lsLastTracked, 10);
+
+    if (diff >= sessionTimeout) {
+      return resetSessionId();
+    }
+  }
+
+  if (lsSessionId) {
+    return lsSessionId;
+  }
+
+  return resetSessionId();
+}
+
+function resetSessionId(): string {
+  const sessionId = uuidv4();
+  localStorage.setItem(sessionIdLocalStorageKey, sessionId);
+  return sessionId;
 }
 
 function removeCacheValuesFromUrlQuery(query: ParsedUrlQuery) {
@@ -66,9 +101,20 @@ export function trackPageview(
 
 function track(conversion: Conversion) {
   const debug = Boolean(cookies({}).analytics_debug);
+  const sessionId = getSessionId();
+  const session: Session = {
+    id: sessionId,
+    timeout: sessionTimeout,
+  };
+
+  localStorage.setItem(lastTrackedLocalStorageKey, Date.now().toString());
+
   if (debug) {
-    console.info(conversion);
+    console.info(sessionId, conversion);
   }
 
-  window.analytics.track('conversion', conversion);
+  window.analytics.track('conversion', {
+    session,
+    ...conversion,
+  });
 }

--- a/common/services/conversion/track.ts
+++ b/common/services/conversion/track.ts
@@ -110,7 +110,10 @@ function track(conversion: Conversion) {
   localStorage.setItem(lastTrackedLocalStorageKey, Date.now().toString());
 
   if (debug) {
-    console.info(sessionId, conversion);
+    console.info({
+      session,
+      ...conversion,
+    });
   }
 
   window.analytics.track('conversion', {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16888,6 +16888,11 @@ uuid@^3.3.2, uuid@^3.3.3:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
 v8-compile-cache@^2.0.3:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz#9471efa3ef9128d2f7c6a7ca39c4dd6b5055b132"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2969,6 +2969,11 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
 
+"@types/uuid@^8.3.0":
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
+  integrity sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
+
 "@types/webpack-env@^1.15.0":
   version "1.16.0"
   resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.16.0.tgz#8c0a9435dfa7b3b1be76562f3070efb3f92637b4"


### PR DESCRIPTION
## Who is this for?
Analysts not wanting to have non-expiring session IDs.

## What is it doing for them?
Sends across a `sessionId` with the conversion event, that changes if there the previously recorded event was more than 30 minutes before the current.

ping @taceybadgerbrook 
