### PR TITLE
Add LinkList slice to article/story

### DIFF
--- a/prismic-model/js/parts/article-body.js
+++ b/prismic-model/js/parts/article-body.js
@@ -294,7 +294,7 @@ export default {
           },
         },
       },
-      linkList: slice('Link List', {
+      tagList: slice('Tag List', {
         nonRepeat: {
           title: heading('Title', 2),
         },

--- a/prismic-model/js/parts/article-body.js
+++ b/prismic-model/js/parts/article-body.js
@@ -1,5 +1,9 @@
 // @flow
-import body from './body';
+import body, { slice } from './body';
+import heading from './heading';
+import link from './link';
+import text from './text';
+
 export default {
   fieldset: 'Body content',
   type: 'Slices',
@@ -290,6 +294,15 @@ export default {
           },
         },
       },
+      linkList: slice('Link List', {
+        nonRepeat: {
+          title: heading('Title', 2),
+        },
+        repeat: {
+          link: link('Link', 'web'),
+          linkText: text('Link text'),
+        },
+      }),
       imageList: {
         type: 'Slice',
         fieldset:

--- a/prismic-model/json/articles.json
+++ b/prismic-model/json/articles.json
@@ -407,6 +407,35 @@
               }
             }
           },
+          "linkList": {
+            "type": "Slice",
+            "fieldset": "Link List",
+            "non-repeat": {
+              "title": {
+                "type": "StructuredText",
+                "config": {
+                  "label": "Title",
+                  "single": "heading2"
+                }
+              }
+            },
+            "repeat": {
+              "link": {
+                "type": "Link",
+                "config": {
+                  "label": "Link",
+                  "select": "web",
+                  "customtypes": []
+                }
+              },
+              "linkText": {
+                "type": "Text",
+                "config": {
+                  "label": "Link text"
+                }
+              }
+            }
+          },
           "imageList": {
             "type": "Slice",
             "fieldset": "[Deprecated] Image list (please use captioned image or image gallery)",

--- a/prismic-model/json/articles.json
+++ b/prismic-model/json/articles.json
@@ -407,9 +407,9 @@
               }
             }
           },
-          "linkList": {
+          "tagList": {
             "type": "Slice",
-            "fieldset": "Link List",
+            "fieldset": "Tag List",
             "non-repeat": {
               "title": {
                 "type": "StructuredText",


### PR DESCRIPTION
Adds a new slice to the articles/story custom type for creating a list of links

Will be used to create the following on the Podcast page

![Screenshot 2021-01-13 at 11 07 18](https://user-images.githubusercontent.com/6051896/104444444-b62cb680-558f-11eb-81ef-3585fe7cba66.png)

