### PR TITLE
propegate errors to UI from API

### DIFF
--- a/catalogue/webapp/pages/download.tsx
+++ b/catalogue/webapp/pages/download.tsx
@@ -182,7 +182,7 @@ export const getServerSideProps: GetServerSideProps<
     toggles: globalContextData.toggles,
   });
   if (work.type === 'Error') {
-    return appError(context, work.httpStatus, 'Works API error');
+    return appError(context, work.httpStatus, work.description);
   } else if (work.type === 'Redirect') {
     return {
       redirect: {

--- a/catalogue/webapp/pages/image.tsx
+++ b/catalogue/webapp/pages/image.tsx
@@ -145,7 +145,7 @@ export const getServerSideProps: GetServerSideProps<
     if (work.httpStatus === 404) {
       return { notFound: true };
     }
-    return appError(context, work.httpStatus, 'Works API error');
+    return appError(context, work.httpStatus, work.description);
   } else if (work.type === 'Redirect') {
     return {
       redirect: {

--- a/catalogue/webapp/pages/item.tsx
+++ b/catalogue/webapp/pages/item.tsx
@@ -388,7 +388,7 @@ export const getServerSideProps: GetServerSideProps<
   });
 
   if (work.type === 'Error') {
-    return appError(context, work.httpStatus, 'Works API error');
+    return appError(context, work.httpStatus, work.description);
   } else if (work.type === 'Redirect') {
     return {
       redirect: {

--- a/catalogue/webapp/pages/work.tsx
+++ b/catalogue/webapp/pages/work.tsx
@@ -55,7 +55,7 @@ export const getServerSideProps: GetServerSideProps<
     if (workResponse.httpStatus === 404) {
       return { notFound: true };
     }
-    return appError(context, workResponse.httpStatus, 'Works API error');
+    return appError(context, workResponse.httpStatus, workResponse.description);
   }
 
   return {

--- a/catalogue/webapp/pages/works.tsx
+++ b/catalogue/webapp/pages/works.tsx
@@ -334,7 +334,7 @@ export const getServerSideProps: GetServerSideProps<
     : undefined;
 
   if (works && works.type === 'Error') {
-    return appError(context, works.httpStatus, 'Works API error');
+    return appError(context, works.httpStatus, works.description);
   }
 
   // TODO: increase pageSize to 100 when `isImageSearch` (but only if `isEnhanced`)


### PR DESCRIPTION
## Who is this for?
People wanting to know what happened when the API errors

## What is it doing for them?
Removes the generic errors message and propagates the error down from the API.

<img width="746" alt="screen showing generic API errors" src="https://user-images.githubusercontent.com/31692/104700922-ce761000-570c-11eb-9c24-0a7565e25a30.png">

<img width="698" alt="screen showing API errors" src="https://user-images.githubusercontent.com/31692/104700918-cd44e300-570c-11eb-9530-985b40d01124.png">

Thanks @alexwlchan for reporting

