### PR TITLE
add event-series.promo to fetch link

### DIFF
--- a/common/services/prismic/fetch-links.js
+++ b/common/services/prismic/fetch-links.js
@@ -40,6 +40,7 @@ export const eventSeriesFields = [
   'event-series.title',
   'event-series.description',
   'event-series.backgroundTexture',
+  'event-series.promo',
 ];
 export const exhibitionFields = [
   'exhibition-formats.title',


### PR DESCRIPTION
It was reported the promo wasn't coming through.
The fetch links field wasn't filled in.
Ah Prismic.