### PR TITLE
Feat/identity infra

### DIFF
--- a/.buildkite/pipeline.identity.yml
+++ b/.buildkite/pipeline.identity.yml
@@ -24,3 +24,22 @@
           - identity:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/identity_webapp:ref.${BUILDKITE_COMMIT}
           - identity:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/identity_webapp:latest
 
+- wait
+
+- label: "deploy to stage"
+  concurrency: 1
+  concurrency_group: "experience-deploy"
+  plugins:
+    - docker#v3.5.0:
+        image: 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/weco-deploy:5.6.16
+        workdir: /repo
+        mount-ssh-agent: true
+        command: [
+            "--confirm",
+            "release-deploy",
+            "--from-label", "ref.$BUILDKITE_COMMIT",
+            "--environment-id", "stage",
+            "--description", $BUILDKITE_BUILD_URL,
+            "--confirmation-wait-for", 3540] # Session times out at 3600s / 1 hour
+
+

--- a/.buildkite/pipeline.identity.yml
+++ b/.buildkite/pipeline.identity.yml
@@ -36,6 +36,7 @@
         mount-ssh-agent: true
         command: [
             "--confirm",
+            "--project-id", "identity",
             "release-deploy",
             "--from-label", "ref.$BUILDKITE_COMMIT",
             "--environment-id", "stage",

--- a/.buildkite/pipeline.identity.yml
+++ b/.buildkite/pipeline.identity.yml
@@ -13,7 +13,7 @@
 - wait
 
 - label: "deploy identity (ecr image)"
-  branches: "master feat/identity_ecfr_container_build"
+  branches: "master feat/identity_infra"
   plugins:
     - wellcomecollection/aws-assume-role#v0.2.2:
         role: "arn:aws:iam::130871440101:role/experience-ci"

--- a/.wellcome_project
+++ b/.wellcome_project
@@ -14,3 +14,18 @@ experience:
         - id: catalogue_webapp
   name: Front End (wellcomecollection.org)
   role_arn: arn:aws:iam::130871440101:role/experience-ci
+
+# We have identity as a separate project as we need to support Digirati's rapid development
+# and not be tied to the rest of the projects deployment.
+identity:
+  environments:
+    - id: stage
+      name: Staging
+    - id: prod
+      name: Production
+  image_repositories:
+    - id: identity_webapp
+      services:
+        - id: identity_webapp
+  name: Experience identity
+  role_arn: arn:aws:iam::130871440101:role/experience-ci

--- a/cache/cloudfront_stage.tf
+++ b/cache/cloudfront_stage.tf
@@ -23,6 +23,7 @@ resource "aws_cloudfront_distribution" "stage_wc_org" {
     "www-stage.wellcomecollection.org",
     "content.www-stage.wellcomecollection.org",
     "works.www-stage.wellcomecollection.org",
+    "identity.www-stage.wellcomecollection.org",
   ]
 
   default_cache_behavior {

--- a/identity/terraform/data.tf
+++ b/identity/terraform/data.tf
@@ -1,0 +1,11 @@
+data "terraform_remote_state" "experience_shared" {
+  backend = "s3"
+
+  config = {
+    role_arn = "arn:aws:iam::130871440101:role/experience-developer"
+
+    bucket = "wellcomecollection-experience-infra"
+    key    = "terraform/experience.tfstate"
+    region = "eu-west-1"
+  }
+}

--- a/identity/terraform/locals.tf
+++ b/identity/terraform/locals.tf
@@ -1,0 +1,24 @@
+locals {
+  prod_cluster_arn  = data.terraform_remote_state.experience_shared.outputs.prod_cluster_arn
+  prod_namespace_id = data.terraform_remote_state.experience_shared.outputs.prod_namespace_id
+
+  prod_alb_listener_http_arn  = data.terraform_remote_state.experience_shared.outputs.prod_alb_listener_http_arn
+  prod_alb_listener_https_arn = data.terraform_remote_state.experience_shared.outputs.prod_alb_listener_https_arn
+
+  prod_interservice_security_group_id   = data.terraform_remote_state.experience_shared.outputs.prod_interservice_security_group_id
+  prod_service_egress_security_group_id = data.terraform_remote_state.experience_shared.outputs.prod_service_egress_security_group_id
+
+  stage_cluster_arn  = data.terraform_remote_state.experience_shared.outputs.stage_cluster_arn
+  stage_namespace_id = data.terraform_remote_state.experience_shared.outputs.stage_namespace_id
+
+  stage_alb_listener_http_arn  = data.terraform_remote_state.experience_shared.outputs.stage_alb_listener_http_arn
+  stage_alb_listener_https_arn = data.terraform_remote_state.experience_shared.outputs.stage_alb_listener_https_arn
+
+  stage_interservice_security_group_id   = data.terraform_remote_state.experience_shared.outputs.stage_interservice_security_group_id
+  stage_service_egress_security_group_id = data.terraform_remote_state.experience_shared.outputs.stage_service_egress_security_group_id
+
+  stage_app_image = "${data.terraform_remote_state.experience_shared.outputs.identity_webapp_ecr_uri}:env.stage"
+  prod_app_image  = "${data.terraform_remote_state.experience_shared.outputs.identity_webapp_ecr_uri}:env.prod"
+
+  nginx_image = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx_experience:78090f62ee23a39a1b4e929f25417bfa128c2aa8"
+}

--- a/identity/terraform/main.tf
+++ b/identity/terraform/main.tf
@@ -1,0 +1,41 @@
+// The service should be available at: "identity.www.wellcomecollection.org/_identity"
+
+module "identity-prod" {
+  source = "./stack"
+
+  container_image = local.prod_app_image
+  nginx_image     = local.nginx_image
+  env_suffix      = "prod"
+
+  cluster_arn  = local.prod_cluster_arn
+  namespace_id = local.prod_namespace_id
+
+  alb_listener_http_arn  = local.prod_alb_listener_http_arn
+  alb_listener_https_arn = local.prod_alb_listener_https_arn
+
+  interservice_security_group_id   = local.prod_interservice_security_group_id
+  service_egress_security_group_id = local.prod_service_egress_security_group_id
+
+  subdomain = "identity.www"
+}
+
+// The service should be available at: "identity.www-stage.wellcomecollection.org/_identity"
+
+module "identity-stage" {
+  source = "./stack"
+
+  container_image = local.stage_app_image
+  nginx_image     = local.nginx_image
+  env_suffix      = "stage"
+
+  cluster_arn  = local.stage_cluster_arn
+  namespace_id = local.stage_namespace_id
+
+  alb_listener_http_arn  = local.stage_alb_listener_http_arn
+  alb_listener_https_arn = local.stage_alb_listener_https_arn
+
+  interservice_security_group_id   = local.stage_interservice_security_group_id
+  service_egress_security_group_id = local.stage_service_egress_security_group_id
+
+  subdomain = "identity.www-stage"
+}

--- a/identity/terraform/main.tf
+++ b/identity/terraform/main.tf
@@ -1,4 +1,4 @@
-// The service should be available at: "identity.www.wellcomecollection.org/_identity"
+// The service should be available at: "https://identity.www.wellcomecollection.org"
 
 module "identity-prod" {
   source = "./stack"
@@ -19,7 +19,7 @@ module "identity-prod" {
   subdomain = "identity.www"
 }
 
-// The service should be available at: "identity.www-stage.wellcomecollection.org/_identity"
+// The service should be available at: "https://identity.www-stage.wellcomecollection.org"
 
 module "identity-stage" {
   source = "./stack"

--- a/identity/terraform/provider.tf
+++ b/identity/terraform/provider.tf
@@ -1,0 +1,24 @@
+provider "aws" {
+  assume_role {
+    role_arn = "arn:aws:iam::130871440101:role/experience-developer"
+  }
+
+  region  = var.aws_region
+  version = "~> 2.47.0"
+}
+
+provider "template" {
+  version = "~> 2.1"
+}
+
+provider "aws" {
+  alias = "platform"
+
+  region  = var.aws_region
+  version = "~> 2.47.0"
+
+  assume_role {
+    role_arn = "arn:aws:iam::760097843905:role/platform-developer"
+  }
+}
+

--- a/identity/terraform/stack/data.tf
+++ b/identity/terraform/stack/data.tf
@@ -1,0 +1,10 @@
+data "terraform_remote_state" "infra_shared" {
+  backend = "s3"
+
+  config = {
+    bucket   = "wellcomecollection-platform-infra"
+    key      = "terraform/platform-infrastructure/accounts/experience.tfstate"
+    role_arn = "arn:aws:iam::760097843905:role/platform-developer"
+    region   = "eu-west-1"
+  }
+}

--- a/identity/terraform/stack/locals.tf
+++ b/identity/terraform/stack/locals.tf
@@ -1,0 +1,6 @@
+locals {
+  vpc_id = data.terraform_remote_state.infra_shared.outputs.experience_vpc_id
+
+  private_subnets = data.terraform_remote_state.infra_shared.outputs.experience_vpc_private_subnets
+  public_subnets = data.terraform_remote_state.infra_shared.outputs.experience_vpc_public_subnets
+}

--- a/identity/terraform/stack/main.tf
+++ b/identity/terraform/stack/main.tf
@@ -31,16 +31,6 @@ locals {
   target_group_arn = module.identity-service-18012021.target_group_arn
 }
 
-module "path_listener" {
-  source = "../../../infrastructure/terraform/modules/alb_listener_rule"
-
-  alb_listener_https_arn = var.alb_listener_https_arn
-  alb_listener_http_arn  = var.alb_listener_http_arn
-  target_group_arn       = local.target_group_arn
-
-  path_patterns = ["/_identity*"]
-  priority      = "48997"
-}
 
 # This is used for the static assets served from _next with multiple next apps
 # See: https://github.com/zeit/next.js#multi-zones

--- a/identity/terraform/stack/main.tf
+++ b/identity/terraform/stack/main.tf
@@ -1,0 +1,93 @@
+module "identity-service-18012021" {
+  source = "../../../infrastructure/terraform/modules/service"
+
+  namespace = "identity-18012021-${var.env_suffix}"
+
+  namespace_id = var.namespace_id
+  cluster_arn  = var.cluster_arn
+
+  healthcheck_path = "/management/healthcheck"
+
+  container_image = var.container_image
+  container_port  = 3000
+
+  security_group_ids = [
+    var.interservice_security_group_id,
+    var.service_egress_security_group_id
+  ]
+
+  env_vars = {
+    PROD_SUBDOMAIN = var.subdomain
+  }
+
+  vpc_id  = local.vpc_id
+  subnets = local.private_subnets
+
+  deployment_service_name = "identity_webapp"
+  deployment_service_env  = var.env_suffix
+}
+
+locals {
+  target_group_arn = module.identity-service-18012021.target_group_arn
+}
+
+module "path_listener" {
+  source = "../../../infrastructure/terraform/modules/alb_listener_rule"
+
+  alb_listener_https_arn = var.alb_listener_https_arn
+  alb_listener_http_arn  = var.alb_listener_http_arn
+  target_group_arn       = local.target_group_arn
+
+  path_patterns = ["/_identity*"]
+  priority      = "48997"
+}
+
+# This is used for the static assets served from _next with multiple next apps
+# See: https://github.com/zeit/next.js#multi-zones
+module "subdomain_listener" {
+  source = "../../../infrastructure/terraform/modules/alb_listener_rule"
+
+  alb_listener_https_arn = var.alb_listener_https_arn
+  alb_listener_http_arn  = var.alb_listener_http_arn
+  target_group_arn       = local.target_group_arn
+
+  priority     = "301"
+  host_headers = ["${var.subdomain}.wellcomecollection.org"]
+}
+
+# We do this as our server side props for next.js are served over
+# /_next/data/{hash}/{page}.json
+# e.g. https://wellcomecollection.org/_next/data/dl7PfaUnoIXaQk0ol_5M8/identity.json
+# These routes will mimic the `/identity/webapp/pages/*` directory
+# see: https://github.com/vercel/next.js/issues/16090
+
+locals {
+  # Listener rules are limited to 5 different condition values so we
+  # must create several to cover all of the path patterns we need
+
+  identity_data_paths = [
+    "/_next/data/*/identity/*.json",
+  ]
+  max_conditions_per_rule = 5
+
+  identity_data_path_chunks = chunklist(local.identity_data_paths, local.max_conditions_per_rule)
+  identity_data_path_sets = zipmap(
+    range(length(local.identity_data_path_chunks)),
+    local.identity_data_path_chunks
+  )
+
+  max_priority = 48996
+  min_priority = local.max_priority - length(local.identity_data_path_chunks) + 1
+}
+
+module "identity_data_listener" {
+  source   = "../../../infrastructure/terraform/modules/alb_listener_rule"
+  for_each = local.identity_data_path_sets
+
+  alb_listener_https_arn = var.alb_listener_https_arn
+  alb_listener_http_arn  = var.alb_listener_http_arn
+  target_group_arn       = local.target_group_arn
+
+  path_patterns = each.value
+  priority      = local.min_priority + each.key
+}

--- a/identity/terraform/stack/variables.tf
+++ b/identity/terraform/stack/variables.tf
@@ -1,0 +1,17 @@
+variable "env_suffix" {}
+variable "namespace_id" {}
+variable "cluster_arn" {}
+
+variable "interservice_security_group_id" {}
+variable "service_egress_security_group_id" {}
+variable "alb_listener_https_arn" {}
+variable "alb_listener_http_arn" {}
+
+variable "subdomain" {}
+
+variable "container_image" {}
+variable "nginx_image" {}
+
+variable "aws_region" {
+  default = "eu-west-1"
+}

--- a/identity/terraform/terraform.tf
+++ b/identity/terraform/terraform.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_version = ">= 0.9"
+
+  backend "s3" {
+    key            = "build-state/identity.tfstate"
+    dynamodb_table = "terraform-locktable"
+    region         = "eu-west-1"
+    bucket         = "wellcomecollection-infra"
+
+    role_arn = "arn:aws:iam::130871440101:role/experience-developer"
+  }
+}

--- a/identity/terraform/variables.tf
+++ b/identity/terraform/variables.tf
@@ -1,0 +1,3 @@
+variable "aws_region" {
+  default = "eu-west-1"
+}


### PR DESCRIPTION
Adds the base infra for identity app, and adds identity as another project to allow us to deploy it completely separately so as not to slow Digirati down.

ref https://github.com/wellcomecollection/catalogue/issues/1276