### PR TITLE
trigger identity pipelines with branch names or filepath

### DIFF
--- a/.buildkite/pipeline.identity.yml
+++ b/.buildkite/pipeline.identity.yml
@@ -29,7 +29,7 @@
 - label: "deploy to stage"
   branches: "master"
   concurrency: 1
-  concurrency_group: "experience-deploy"
+  concurrency_group: "experience-identity-deploy"
   plugins:
     - docker#v3.5.0:
         image: 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/weco-deploy:5.6.16

--- a/.buildkite/pipeline.triggers.yml
+++ b/.buildkite/pipeline.triggers.yml
@@ -1,0 +1,12 @@
+steps:
+  - label: "Triggering pipelines identity branch name"
+    branches: "identity/*"
+  - label: "Triggering pipelines via git diff"
+    plugins:
+      - chronotc/monorepo-diff#v1.3.0:
+          diff: "git diff --name-only HEAD~1"
+          watch:
+            - path: "identity/webapp/"
+              config:
+                label: "Trigger identity"
+                trigger: "experience-identity"

--- a/.buildkite/pipeline.triggers.yml
+++ b/.buildkite/pipeline.triggers.yml
@@ -3,6 +3,7 @@ steps:
     trigger: "experience-identity"
     branches: "identity/*"
   - label: "Triggering pipelines via git diff"
+    branches: "!identity/*"
     plugins:
       - chronotc/monorepo-diff#v1.3.0:
           diff: "git diff --name-only HEAD~1"

--- a/.buildkite/pipeline.triggers.yml
+++ b/.buildkite/pipeline.triggers.yml
@@ -1,5 +1,6 @@
 steps:
   - label: "Triggering pipelines identity branch name"
+    trigger: "experience-identity"
     branches: "identity/*"
   - label: "Triggering pipelines via git diff"
     plugins:


### PR DESCRIPTION
Triggers the [ID pipeline](https://buildkite.com/wellcomecollection/experience-identity/) when
* a change has been made to the identity folder
* You force it with a `identity/*` prefix to your branch name

This isn't an end game, as this should build when common changes, but to facilitate the rapid development of Digirati, this will stop the pipeline running whenever there is a change, creating a traffic jam on that pipeline.