### PR TITLE
trigger identity build with build info

### DIFF
--- a/.buildkite/pipeline.triggers.yml
+++ b/.buildkite/pipeline.triggers.yml
@@ -2,6 +2,14 @@ steps:
   - label: "Triggering pipelines identity branch name"
     trigger: "experience-identity"
     branches: "identity/*"
+    build:
+      message: "${BUILDKITE_MESSAGE}"
+      commit: "${BUILDKITE_COMMIT}"
+      branch: "${BUILDKITE_BRANCH}"
+      env:
+        BUILDKITE_PULL_REQUEST: "${BUILDKITE_PULL_REQUEST}"
+        BUILDKITE_PULL_REQUEST_BASE_BRANCH: "${BUILDKITE_PULL_REQUEST_BASE_BRANCH}"
+        BUILDKITE_PULL_REQUEST_REPO: "${BUILDKITE_PULL_REQUEST_REPO}"
   - label: "Triggering pipelines via git diff"
     env:
       DEBUG: true

--- a/.buildkite/pipeline.triggers.yml
+++ b/.buildkite/pipeline.triggers.yml
@@ -12,3 +12,11 @@ steps:
               config:
                 label: "Trigger identity"
                 trigger: "experience-identity"
+                build:
+                  message: "${BUILDKITE_MESSAGE}"
+                  commit: "${BUILDKITE_COMMIT}"
+                  branch: "${BUILDKITE_BRANCH}"
+                  env:
+                    BUILDKITE_PULL_REQUEST: "${BUILDKITE_PULL_REQUEST}"
+                    BUILDKITE_PULL_REQUEST_BASE_BRANCH: "${BUILDKITE_PULL_REQUEST_BASE_BRANCH}"
+                    BUILDKITE_PULL_REQUEST_REPO: "${BUILDKITE_PULL_REQUEST_REPO}"

--- a/.buildkite/pipeline.triggers.yml
+++ b/.buildkite/pipeline.triggers.yml
@@ -11,8 +11,6 @@ steps:
         BUILDKITE_PULL_REQUEST_BASE_BRANCH: "${BUILDKITE_PULL_REQUEST_BASE_BRANCH}"
         BUILDKITE_PULL_REQUEST_REPO: "${BUILDKITE_PULL_REQUEST_REPO}"
   - label: "Triggering pipelines via git diff"
-    env:
-      DEBUG: true
     branches: "!identity/*"
     plugins:
       - chronotc/monorepo-diff#v1.3.0:

--- a/.buildkite/pipeline.triggers.yml
+++ b/.buildkite/pipeline.triggers.yml
@@ -3,6 +3,8 @@ steps:
     trigger: "experience-identity"
     branches: "identity/*"
   - label: "Triggering pipelines via git diff"
+    env:
+      DEBUG: true
     branches: "!identity/*"
     plugins:
       - chronotc/monorepo-diff#v1.3.0:


### PR DESCRIPTION
Seems the builds are running on previous commits. master is running [here](https://github.com/wellcomecollection/wellcomecollection.org/commits/abe5f75c190d3824c8e363aca528a880) - [which you can infer from this](https://buildkite.com/wellcomecollection/experience-identity/builds/42#a8d59441-933a-4211-ba7d-816a4c436a52/121).

Main thing was that the concurrency group running the ID deploy is `experience-deploy`, which it shouldn't be.

This is a bit verbose, but it is the [recommended way of doing this](https://identity.www-stage.wellcomecollection.org/identity). I might have looked into [dynamic pipelines](https://buildkite.com/docs/pipelines/defining-steps#dynamic-pipelines), but I think most of this will become redundant, so it feels Ok.