### PR TITLE
consolodate how we use the IIIF manifest of a work

### DIFF
--- a/catalogue/webapp/components/Work/Work.tsx
+++ b/catalogue/webapp/components/Work/Work.tsx
@@ -25,7 +25,7 @@ import Divider from '@weco/common/views/components/Divider/Divider';
 import styled from 'styled-components';
 import { WithGlobalContextData } from '@weco/common/views/components/GlobalContextProvider/GlobalContextProvider';
 import useHotjar from '@weco/common/hooks/useHotjar';
-import useIIIFManifest from '@weco/common/hooks/useIIIFManifest';
+import useIIIFManifestData from '@weco/common/hooks/useIIIFManifestData';
 
 const ArchiveDetailsContainer = styled.div`
   display: block;
@@ -63,9 +63,10 @@ const Work: FunctionComponent<Props> = ({
   const isInArchive = work.parts.length > 0 || work.partOf.length > 0;
   useHotjar(isInArchive);
 
-  const { childManifestsCount, firstChildManifestLocation } = useIIIFManifest(
-    work
-  );
+  const {
+    childManifestsCount,
+    firstChildManifestLocation,
+  } = useIIIFManifestData(work);
   const iiifPresentationLocation = getDigitalLocationOfType(
     work,
     'iiif-presentation'

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -34,7 +34,7 @@ import { trackEvent } from '@weco/common/utils/ga';
 import ItemLocation from '../RequestLocation/RequestLocation';
 import Layout12 from '@weco/common/views/components/Layout12/Layout12';
 import { DigitalLocation, Work } from '@weco/common/model/catalogue';
-import useIIIFManifest from '@weco/common/hooks/useIIIFManifest';
+import useIIIFManifestData from '@weco/common/hooks/useIIIFManifestData';
 
 type Props = {
   work: Work;
@@ -109,7 +109,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work, itemUrl }: Props) => {
     iiifCredit,
     iiifPresentationDownloadOptions = [],
     iiifDownloadEnabled,
-  } = useIIIFManifest(work);
+  } = useIIIFManifestData(work);
 
   // 'Available online' data
   const license =

--- a/catalogue/webapp/tsconfig.json
+++ b/catalogue/webapp/tsconfig.json
@@ -15,7 +15,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "downlevelIteration": true
   },
   "exclude": ["node_modules", "./test/**/*.ts"],
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"]

--- a/common/hooks/useIIIFManifest.ts
+++ b/common/hooks/useIIIFManifest.ts
@@ -1,0 +1,102 @@
+import { useEffect, useState } from 'react';
+import {
+  getAudio,
+  getCanvases,
+  getDownloadOptionsFromManifest,
+  getFirstChildManifestLocation,
+  getIIIFPresentationCredit,
+  getUiExtensions,
+  getVideo,
+  isUiEnabled,
+} from '../utils/iiif';
+import { Work } from '../model/catalogue';
+import { IIIFManifest, IIIFMediaElement, IIIFRendering } from '../model/iiif';
+import { getDigitalLocationOfType } from '../utils/works';
+
+type IIIFManifestData = {
+  imageCount: number;
+  childManifestsCount: number;
+  audio?: IIIFMediaElement;
+  video?: IIIFMediaElement;
+  iiifCredit?: string;
+  iiifPresentationDownloadOptions?: IIIFRendering[];
+  iiifDownloadEnabled?: boolean;
+  firstChildManifestLocation?: string;
+};
+
+function parseManifest(manifest: IIIFManifest): IIIFManifestData {
+  const imageCount = getCanvases(manifest).length;
+  const childManifestsCount = manifest.manifests
+    ? manifest.manifests.length
+    : 0;
+  const audio = getAudio(manifest);
+  const video = getVideo(manifest);
+  const iiifCredit = getIIIFPresentationCredit(manifest);
+  const iiifPresentationDownloadOptions = getDownloadOptionsFromManifest(
+    manifest
+  );
+  const iiifDownloadEnabled = isUiEnabled(
+    getUiExtensions(manifest),
+    'mediaDownload'
+  );
+  const firstChildManifestLocation = getFirstChildManifestLocation(manifest);
+
+  return {
+    imageCount,
+    childManifestsCount,
+    audio,
+    video,
+    iiifCredit,
+    iiifPresentationDownloadOptions,
+    iiifDownloadEnabled,
+    firstChildManifestLocation,
+  };
+}
+
+const startedFetchingIds = new Set();
+const cachedManifestData: Map<string, IIIFManifestData> = new Map();
+
+const useIIIFManifest = (work: Work): IIIFManifestData => {
+  const [manifestData, setManifestData] = useState<IIIFManifestData>({
+    imageCount: 0,
+    childManifestsCount: 0,
+  });
+
+  useEffect(() => {
+    const fetchIIIFPresentationManifest = async (work: Work) => {
+      startedFetchingIds.add(work.id);
+      try {
+        const iiifPresentationLocation = getDigitalLocationOfType(
+          work,
+          'iiif-presentation'
+        );
+
+        const iiifManifestResp =
+          iiifPresentationLocation &&
+          (await fetch(iiifPresentationLocation.url));
+
+        if (iiifManifestResp) {
+          const iiifManifest = await iiifManifestResp.json();
+          const data = parseManifest(iiifManifest);
+
+          cachedManifestData.set(work.id, data);
+          setManifestData(data);
+        }
+      } catch (e) {}
+    };
+
+    const cachedManifest = cachedManifestData.get(work.id);
+    if (cachedManifest) {
+      setManifestData(cachedManifest);
+    }
+
+    // If we've started fetching a work, we can just wait for that to resolve
+    if (!startedFetchingIds.has(work.id)) {
+      fetchIIIFPresentationManifest(work);
+    }
+  }, [work.id]);
+
+  return manifestData;
+};
+
+export default useIIIFManifest;

--- a/common/hooks/useIIIFManifestData.ts
+++ b/common/hooks/useIIIFManifestData.ts
@@ -56,7 +56,7 @@ function parseManifest(manifest: IIIFManifest): IIIFManifestData {
 const startedFetchingIds = new Set();
 const cachedManifestData: Map<string, IIIFManifestData> = new Map();
 
-const useIIIFManifest = (work: Work): IIIFManifestData => {
+const useIIIFManifestData = (work: Work): IIIFManifestData => {
   const [manifestData, setManifestData] = useState<IIIFManifestData>({
     imageCount: 0,
     childManifestsCount: 0,
@@ -99,4 +99,4 @@ const useIIIFManifest = (work: Work): IIIFManifestData => {
   return manifestData;
 };
 
-export default useIIIFManifest;
+export default useIIIFManifestData;

--- a/common/tsconfig.json
+++ b/common/tsconfig.json
@@ -15,7 +15,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "downlevelIteration": true
   },
   "exclude": ["node_modules"],
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"]

--- a/common/utils/iiif.ts
+++ b/common/utils/iiif.ts
@@ -169,11 +169,11 @@ export function getAnnotationFromMediaElement(
   );
 }
 
-export function getFirstChildManifestLocation(iiifManifest: IIIFManifest) {
+export function getFirstChildManifestLocation(
+  iiifManifest: IIIFManifest
+): string | undefined {
   if (iiifManifest.manifests) {
     return iiifManifest.manifests.find(manifest => manifest['@id'])['@id'];
-  } else {
-    return null;
   }
 }
 

--- a/content/webapp/tsconfig.json
+++ b/content/webapp/tsconfig.json
@@ -15,7 +15,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "downlevelIteration": true
   },
   "exclude": ["node_modules"],
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"]

--- a/identity/webapp/tsconfig.json
+++ b/identity/webapp/tsconfig.json
@@ -17,7 +17,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "downlevelIteration": true
   },
   "include": [
     "next-env.d.ts",

--- a/toggles/webapp/tsconfig.json
+++ b/toggles/webapp/tsconfig.json
@@ -12,7 +12,8 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "downlevelIteration": true
   },
   "exclude": ["node_modules", "./test/**/*.ts"],
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"]


### PR DESCRIPTION
## Who is this for?
Devs & perf-people

## What is it doing for them?
Consolidating how we use IIIF manifest.

Caching responses so we need not call out each time. Another way to do this would be to cache it on the server side JSON props response, but then we would couple the fetching of the manifest to our application (if wl fails, we fail), which is no good.

