### PR TITLE
standalone should always use Layout12

### DIFF
--- a/common/views/components/Body/Body.tsx
+++ b/common/views/components/Body/Body.tsx
@@ -148,9 +148,9 @@ const Body: FunctionComponent<Props> = ({
               </Layout10>
             )}
             {slice.type === 'picture' && slice.weight === 'standalone' && (
-              <LayoutWidth width={minWidth}>
+              <Layout12>
                 <CaptionedImage {...slice.value} sizesQueries={''} />
-              </LayoutWidth>
+              </Layout12>
             )}
             {slice.type === 'picture' && slice.weight === 'supporting' && (
               <LayoutWidth width={minWidth}>


### PR DESCRIPTION
Accidentally made standalone picture slices narrower than they should be here: #5977

This fixes that
