### PR TITLE
add OptionalToUndefined

### DIFF
--- a/common/utils/routes.ts
+++ b/common/utils/routes.ts
@@ -2,9 +2,12 @@ import { LinkProps } from 'next/link';
 import { ParsedUrlQuery } from 'querystring';
 import { PropsWithChildren } from 'react';
 import { isInTuple } from './type-guards';
+import { OptionalToUndefined } from './utility-types';
 
 export type QueryParam = ParsedUrlQuery[string];
-export type QueryTo<Props> = (query: ParsedUrlQuery) => Props;
+export type QueryTo<Props> = (
+  query: ParsedUrlQuery
+) => OptionalToUndefined<Props>;
 export type LinkFrom<Props> = PropsWithChildren<Props> &
   Omit<LinkProps, 'as' | 'href'>;
 

--- a/common/utils/utility-types.ts
+++ b/common/utils/utility-types.ts
@@ -1,0 +1,9 @@
+// This will convert optional parameters in a type to required, but undefineable
+// e.g. { required: string, optional?: string } => { required: string, optional: string | undefined }
+// This is useful for when you want to expose the type,
+// but have the implementation express all properties if if the = undefined
+// A nice read on why we need the `keyof never` to make it homomorphic
+// see: https://stackoverflow.com/questions/59790508/what-does-homomorphic-mapped-type-mean/59791889#59791889
+export type OptionalToUndefined<T> = {
+  [P in keyof T & keyof never]: T[P];
+};

--- a/common/views/components/ItemLink/ItemLink.tsx
+++ b/common/views/components/ItemLink/ItemLink.tsx
@@ -1,8 +1,6 @@
 import NextLink, { LinkProps } from 'next/link';
 import { FunctionComponent } from 'react';
-import { OptionalToUndefined } from 'utils/utility-types';
 import {
-  ConvertOptionalToUndefined,
   LinkFrom,
   QueryTo,
   toMaybeNumber,

--- a/common/views/components/ItemLink/ItemLink.tsx
+++ b/common/views/components/ItemLink/ItemLink.tsx
@@ -1,6 +1,8 @@
 import NextLink, { LinkProps } from 'next/link';
 import { FunctionComponent } from 'react';
+import { OptionalToUndefined } from 'utils/utility-types';
 import {
+  ConvertOptionalToUndefined,
   LinkFrom,
   QueryTo,
   toMaybeNumber,


### PR DESCRIPTION
When you create the return type of a function, because of [type compatibility](https://www.typescriptlang.org/docs/handbook/type-compatibility.html) - the returned object of the method only needs to be compatible.

That means the below works:
```TS
type Return = { required: string, optional?: string }
type Func = () => Return

const f: Func = () => ({ required: 'yes', saywat: 'wat' })

// because
console.info(f().required) // 'yes'
console.info(f().optional) // undefined
console.info(f().saywat) // Error
```

This utility method converts optional (`?`) parameters in the undefinable ones.

Let's go again
```ts
type ModifiedReturn = OptionalToUndefined<{ required: string, optional?: string }>
type Func = () => ModifiedReturn

const g: Func = () => ({ required: 'yes', saywat: 'wat' }) // Error, need optional key
const h: Func = () => ({ required: 'yes', optional: undefined }) // All good

// All good, you won't be able to use this property outside of this method. I couldn't find a way around this.
const h: Func = () => ({ required: 'yes', optional: 'string', saywat: 'blop' }) 

console.info(g().required) // 'yes'
console.info(g().optional) // undefined
console.info(h().optional) // 'string'
console.info(h().saywat) // Error
```

[Codesandbox](https://codesandbox.io/s/relaxed-solomon-eich3?file=/src/index.ts)

This allows us to have greater type security on things like parsing URLs.