### PR TITLE
Identity app path prefix

### DIFF
--- a/identity/webapp/.env.dist
+++ b/identity/webapp/.env.dist
@@ -14,3 +14,8 @@ AUTH_METHOD=local
 
 # API_BASE_URL=
 # API_KEY=
+
+# Is set to a path prefix in deployed environments
+# e.g. /account
+# but can be undefined in local dev
+# CONTEXT_PATH=

--- a/identity/webapp/docker-compose.yaml
+++ b/identity/webapp/docker-compose.yaml
@@ -1,6 +1,5 @@
-version: "3"
+version: '3'
 services:
-
   service:
     build:
       context: .
@@ -21,5 +20,6 @@ services:
       - SERVER_PORT=${SERVER_PORT:-3000}
       - API_BASE_URL=${API_BASE_URL}
       - API_KEY=${API_KEY}
+      - CONTEXT_PATH=${CONTEXT_PATH}
     ports:
-      - "${SERVER_PORT:-3000}:${SERVER_PORT:-3000}"
+      - '${SERVER_PORT:-3000}:${SERVER_PORT:-3000}'

--- a/identity/webapp/package.json
+++ b/identity/webapp/package.json
@@ -73,6 +73,7 @@
     "babel-plugin-transform-typescript-metadata": "^0.3.1",
     "babel-preset-react": "^6.24.1",
     "css-loader": "5.0.1",
+    "dotenv-webpack": "^6.0.0",
     "eslint": "^7.15.0",
     "eslint-config-prettier": "^7.0.0",
     "eslint-plugin-babel": "^5.3.1",

--- a/identity/webapp/src/frontend/index.tsx
+++ b/identity/webapp/src/frontend/index.tsx
@@ -14,8 +14,6 @@ import { prefix } from '../utility/prefix';
 
 const root = typeof document !== 'undefined' ? document.getElementById('root') : undefined;
 
-console.log({ prefix });
-
 if (root) {
   render(
     <ThemeProvider theme={theme}>

--- a/identity/webapp/src/frontend/index.tsx
+++ b/identity/webapp/src/frontend/index.tsx
@@ -18,7 +18,7 @@ if (root) {
     <ThemeProvider theme={theme}>
       <style id="styleguide-sass"></style>
       <AppContextProvider>
-        <BrowserRouter>
+        <BrowserRouter basename="/batman">
           <Switch>
             <Route exact path="/register" component={Registration} />
             <Route exact path="/validated" component={AccountValidated} />

--- a/identity/webapp/src/frontend/index.tsx
+++ b/identity/webapp/src/frontend/index.tsx
@@ -10,15 +10,18 @@ import { AppContextProvider } from '@weco/common/views/components/AppContext/App
 import { ThemeProvider } from 'styled-components';
 import theme from '@weco/common/views/themes/default';
 import '@weco/common/styles/styleguide.scss';
+import { prefix } from '../utility/prefix';
 
 const root = typeof document !== 'undefined' ? document.getElementById('root') : undefined;
+
+console.log({ prefix });
 
 if (root) {
   render(
     <ThemeProvider theme={theme}>
       <style id="styleguide-sass"></style>
       <AppContextProvider>
-        <BrowserRouter basename="/batman">
+        <BrowserRouter basename={prefix}>
           <Switch>
             <Route exact path="/register" component={Registration} />
             <Route exact path="/validated" component={AccountValidated} />

--- a/identity/webapp/src/router.ts
+++ b/identity/webapp/src/router.ts
@@ -55,6 +55,5 @@ export const router = new TypedRouter({
   ...loginRoutes,
 
   // Frontend fallback route.
-  frontend: [TypedRouter.GET, /(.*)/ as any, indexPage]
-
+  frontend: [TypedRouter.GET, '(.*)', indexPage],
 });

--- a/identity/webapp/src/utility/prefix.ts
+++ b/identity/webapp/src/utility/prefix.ts
@@ -1,0 +1,1 @@
+export const prefix = process.env.CONTEXT_PATH ? `/${process.env.CONTEXT_PATH}` : undefined;

--- a/identity/webapp/src/utility/typed-router.ts
+++ b/identity/webapp/src/utility/typed-router.ts
@@ -2,6 +2,7 @@ import Router from '@koa/router';
 import koaBody from 'koa-body';
 import { requestBody } from '../middleware/request-body';
 import { RouteMiddleware } from '../types/application';
+import { prefix } from './prefix';
 
 export type RouteWithParams<Props, Body = any> =
   | [string, string, RouteMiddleware<Props, Body>]
@@ -29,7 +30,7 @@ export class TypedRouter<
   static PUT = 'put';
   static DELETE = 'delete';
 
-  private router = new Router({ prefix: '/batman' });
+  private router = new Router({ prefix });
 
   constructor(routes: MappedRoutes) {
     const routeNames = Object.keys(routes) as Routes[];

--- a/identity/webapp/src/utility/typed-router.ts
+++ b/identity/webapp/src/utility/typed-router.ts
@@ -29,7 +29,7 @@ export class TypedRouter<
   static PUT = 'put';
   static DELETE = 'delete';
 
-  private router = new Router();
+  private router = new Router({ prefix: '/batman' });
 
   constructor(routes: MappedRoutes) {
     const routeNames = Object.keys(routes) as Routes[];

--- a/identity/webapp/webpack.frontend.js
+++ b/identity/webapp/webpack.frontend.js
@@ -1,4 +1,5 @@
 const createStyledComponentsTransformer = require('typescript-plugin-styled-components').default;
+const Dotenv = require('dotenv-webpack');
 const styledComponentsTransformer = createStyledComponentsTransformer({
   displayName: true,
 });
@@ -91,6 +92,8 @@ module.exports = {
       },
     ],
   },
+
+  plugins: [new Dotenv()],
 
   // Add problem packages to alias.
   resolve: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8992,6 +8992,13 @@ dotenv-defaults@^1.0.2:
   dependencies:
     dotenv "^6.2.0"
 
+dotenv-defaults@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/dotenv-defaults/-/dotenv-defaults-2.0.1.tgz#ea6f9632b3b5cc55e48b736760def5561f1cb7c0"
+  integrity sha512-ugFCyBF7ILuwpmznduHPQZBMucHHJ8T4OBManTEVjemxCm2+nqifSuW2lD2SNKdiKSH1E324kZSdJ8M04b4I/A==
+  dependencies:
+    dotenv "^8.2.0"
+
 dotenv-expand@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-5.1.0.tgz#3fbaf020bfd794884072ea26b1e9791d45a629f0"
@@ -9003,6 +9010,13 @@ dotenv-webpack@^1.7.0:
   integrity sha512-o8pq6NLBehtrqA8Jv8jFQNtG9nhRtVqmoD4yWbgUyoU3+9WBlPe+c2EAiaJok9RB28QvrWvdWLZGeTT5aATDMg==
   dependencies:
     dotenv-defaults "^1.0.2"
+
+dotenv-webpack@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv-webpack/-/dotenv-webpack-6.0.0.tgz#cd42454ee754fe8b7adb4fb70196f6e45f41876c"
+  integrity sha512-u/ycyUq7+x407HNTTqJDJelX64Pjmtm96IskgV4ZPPqTdE5d7+p8GzK7OW4sOoPxnwiLQ3iM6zjauYqFU8KdNg==
+  dependencies:
+    dotenv-defaults "^2.0.1"
 
 dotenv@^6.2.0:
   version "6.2.0"


### PR DESCRIPTION
This PR will allow the identity webapp to live at a path prefix when deployed. This is probably `account` so that the app is accessed at wellcome.org/account, but it can be any value, set by the environment variable `CONTEXT_PATH`, and this env var can be undefined in local development.

Duplicate of #6031 