### PR TITLE
add sending webvitals to GA

### DIFF
--- a/catalogue/webapp/pages/_app.tsx
+++ b/catalogue/webapp/pages/_app.tsx
@@ -1,7 +1,14 @@
+import { NextWebVitalsMetric } from 'next/app';
 import App from '@weco/common/views/pages/_app';
 // this css should be included in the ColorPicker component
 // but is causing this error https://err.sh/next.js/css-npm
 import 'react-colorful/dist/index.css';
 import '@weco/common/views/components/ColorPicker/react-colorful-overrides.css';
+import { gtagReportWebVitals } from '@weco/common/utils/gtag';
 import '../styles.scss';
+
+export function reportWebVitals(metric: NextWebVitalsMetric): void {
+  gtagReportWebVitals(metric);
+}
+
 export default App;

--- a/common/utils/gtag.ts
+++ b/common/utils/gtag.ts
@@ -1,0 +1,16 @@
+import { NextWebVitalsMetric } from 'next/app';
+
+export function gtagReportWebVitals({
+  id,
+  name,
+  label,
+  value,
+}: NextWebVitalsMetric): void {
+  window.gtag('event', name, {
+    event_category:
+      label === 'web-vital' ? 'Web Vitals' : 'Next.js custom metric',
+    value: Math.round(name === 'CLS' ? value * 1000 : value), // values must be integers
+    event_label: id, // id unique to current page load
+    non_interaction: true, // avoids affecting bounce rate.
+  });
+}

--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -1,4 +1,4 @@
-import { AppProps } from 'next/app';
+import { AppProps, NextWebVitalsMetric } from 'next/app';
 import Router from 'next/router';
 import ReactGA from 'react-ga';
 import { useEffect } from 'react';

--- a/content/webapp/pages/_app.js
+++ b/content/webapp/pages/_app.js
@@ -1,3 +1,0 @@
-import App from '@weco/common/views/pages/_app-deprecated';
-import '../styles.scss';
-export default App;

--- a/content/webapp/pages/_app.tsx
+++ b/content/webapp/pages/_app.tsx
@@ -1,0 +1,8 @@
+import { NextWebVitalsMetric } from 'next/app';
+import App from '@weco/common/views/pages/_app-deprecated';
+import { gtagReportWebVitals } from '@weco/common/utils/gtag';
+import '../styles.scss';
+export function reportWebVitals(metric: NextWebVitalsMetric): void {
+  gtagReportWebVitals(metric);
+}
+export default App;


### PR DESCRIPTION
Adds web vitals to GA (our v4 property).
[Nabbed straight from here](https://github.com/GoogleChrome/web-vitals#send-the-results-to-google-analytics)