### PR TITLE
Landing page page relationships

### DIFF
--- a/common/model/pages.js
+++ b/common/model/pages.js
@@ -7,6 +7,7 @@ export type Page = {|
   type: 'pages',
   ...GenericContentFields,
   seasons: Season[],
+  landingPages: Page[],
   onThisPage: Link[],
   datePublished: ?Date,
   // TODO (tagging): This is just for now, we will be implementing a proper site tagging

--- a/common/model/pages.ts
+++ b/common/model/pages.ts
@@ -5,6 +5,7 @@ import { Season } from './seasons';
 export type Page = GenericContentFields & {
   type: 'pages';
   seasons: Season[];
+  landingPages: Page[];
   onThisPage: Link[];
   datePublished?: Date;
   siteSection?: string;

--- a/common/model/siblings-group.js
+++ b/common/model/siblings-group.js
@@ -1,6 +1,7 @@
 import type { Page } from './pages';
 
 export type SiblingsGroup = {|
-  landingPageTitle: string,
+  id: string,
+  title: string,
   siblings: Page[],
 |};

--- a/common/model/siblings-group.js
+++ b/common/model/siblings-group.js
@@ -1,7 +1,0 @@
-import type { Page } from './pages';
-
-export type SiblingsGroup = {|
-  id: string,
-  title: string,
-  siblings: Page[],
-|};

--- a/common/model/siblings-group.js
+++ b/common/model/siblings-group.js
@@ -1,0 +1,6 @@
+import type { Page } from './pages';
+
+export type SiblingsGroup = {|
+  landingPageTitle: string,
+  siblings: Page[],
+|};

--- a/common/model/siblings-group.ts
+++ b/common/model/siblings-group.ts
@@ -1,6 +1,7 @@
 import { Page } from './pages';
 
 export type SiblingsGroup = {
-  landingPageTitle: string;
+  id: string;
+  title: string;
   siblings: Page[];
 };

--- a/common/model/siblings-group.ts
+++ b/common/model/siblings-group.ts
@@ -1,0 +1,6 @@
+import { Page } from './pages';
+
+export type SiblingsGroup = {
+  landingPageTitle: string;
+  siblings: Page[];
+};

--- a/common/services/prismic/fetch-links.js
+++ b/common/services/prismic/fetch-links.js
@@ -101,6 +101,7 @@ export const seasonsFields = [
   'seasons.end',
   'seasons.promo',
 ];
+export const landingPagesFields = ['landing-pages.title'];
 export const cardsFields = [
   'card.title',
   'card.format',

--- a/common/services/prismic/pages.js
+++ b/common/services/prismic/pages.js
@@ -10,6 +10,7 @@ import {
 // $FlowFixMe (tsx)
 import { parseSeason } from './seasons';
 import type { Page } from '../../model/pages';
+// $FlowFixMe (tsx)
 import type { SiblingsGroup } from '../../model/siblings-group';
 import type { PrismicDocument, PaginatedResults } from './types';
 import {

--- a/common/services/prismic/pages.js
+++ b/common/services/prismic/pages.js
@@ -191,7 +191,8 @@ export async function getPageSiblings(
   const relatedPages = await Promise.all(relatedPagePromises);
   const siblingsWithLandingTitle = relatedPages.map((results, i) => {
     return {
-      landingPageTitle: page.landingPages[i].title,
+      id: page.landingPages[i].id,
+      title: page.landingPages[i].title,
       siblings: results.results.filter(sibling => sibling.id !== page.id),
     };
   });

--- a/common/views/components/ContentPage/ContentPage.js
+++ b/common/views/components/ContentPage/ContentPage.js
@@ -24,6 +24,7 @@ import { WeAreGoodToGo } from '@weco/common/views/components/CovidIcons/CovidIco
 import { prismicPageIds } from '@weco/common/services/prismic/hardcoded-id';
 // $FlowFixMe (tsx)
 import BannerCard from '../BannerCard/BannerCard';
+import type { SiblingsGroup } from '@weco/common/model/siblings-group';
 /*eslint-disable */
 export const PageBackgroundContext = createContext<'cream' | 'white'>('white');
 
@@ -39,6 +40,7 @@ type Props = {|
   Siblings?: Element<typeof SeriesNavigation>[],
   outroProps?: ?ElementProps<typeof Outro>,
   seasons?: any, // TODO
+  pageSiblings?: SiblingsGroup[],
 |};
 
 // FIXME: obviously we can't carry on like this!
@@ -83,6 +85,7 @@ const ContentPage = ({
   Siblings = [],
   outroProps,
   seasons = [],
+  pageSiblings = [],
 }: Props) => {
   // We don't want to add a spacing unit if there's nothing to render
   // in the body (we don't render the 'standfirst' here anymore).

--- a/common/views/components/ContentPage/ContentPage.js
+++ b/common/views/components/ContentPage/ContentPage.js
@@ -35,7 +35,7 @@ type Props = {|
   // This is used for content type specific components e.g. InfoBox
   children?: ?Node,
   contributorProps?: ElementProps<typeof Contributors>,
-  Siblings?: Element,
+  Siblings?: Node[],
   outroProps?: ?ElementProps<typeof Outro>,
   seasons?: any, // TODO
 |};

--- a/common/views/components/ContentPage/ContentPage.js
+++ b/common/views/components/ContentPage/ContentPage.js
@@ -5,7 +5,6 @@ import Contributors from '../Contributors/Contributors';
 import Layout8 from '../Layout8/Layout8';
 // $FlowFixMe (tsx)
 import Layout12 from '../Layout12/Layout12';
-import SeriesNavigation from '../SeriesNavigation/SeriesNavigation';
 import PageHeader from '../PageHeader/PageHeader';
 import Outro from '../Outro/Outro';
 import { classNames } from '../../../utils/classnames';
@@ -36,7 +35,7 @@ type Props = {|
   // This is used for content type specific components e.g. InfoBox
   children?: ?Node,
   contributorProps?: ElementProps<typeof Contributors>,
-  Siblings?: Element<typeof SeriesNavigation>[], // TODO typeof CardGrid?
+  Siblings?: Element,
   outroProps?: ?ElementProps<typeof Outro>,
   seasons?: any, // TODO
 |};

--- a/common/views/components/ContentPage/ContentPage.js
+++ b/common/views/components/ContentPage/ContentPage.js
@@ -24,7 +24,6 @@ import { WeAreGoodToGo } from '@weco/common/views/components/CovidIcons/CovidIco
 import { prismicPageIds } from '@weco/common/services/prismic/hardcoded-id';
 // $FlowFixMe (tsx)
 import BannerCard from '../BannerCard/BannerCard';
-import type { SiblingsGroup } from '@weco/common/model/siblings-group';
 /*eslint-disable */
 export const PageBackgroundContext = createContext<'cream' | 'white'>('white');
 
@@ -37,10 +36,9 @@ type Props = {|
   // This is used for content type specific components e.g. InfoBox
   children?: ?Node,
   contributorProps?: ElementProps<typeof Contributors>,
-  Siblings?: Element<typeof SeriesNavigation>[],
+  Siblings?: Element<typeof SeriesNavigation>[], // TODO typeof CardGrid?
   outroProps?: ?ElementProps<typeof Outro>,
   seasons?: any, // TODO
-  pageSiblings?: SiblingsGroup[],
 |};
 
 // FIXME: obviously we can't carry on like this!
@@ -85,7 +83,6 @@ const ContentPage = ({
   Siblings = [],
   outroProps,
   seasons = [],
-  pageSiblings = [],
 }: Props) => {
   // We don't want to add a spacing unit if there's nothing to render
   // in the body (we don't render the 'standfirst' here anymore).
@@ -142,11 +139,7 @@ const ContentPage = ({
             <SpacingSection>
               {Children.map(Siblings, (child, i) => (
                 <Fragment>
-                  {child && (
-                    <SpacingComponent>
-                      <Layout8>{child}</Layout8>
-                    </SpacingComponent>
-                  )}
+                  {child}
                 </Fragment>
               ))}
             </SpacingSection>

--- a/common/views/components/SeriesNavigation/SeriesNavigation.js
+++ b/common/views/components/SeriesNavigation/SeriesNavigation.js
@@ -3,6 +3,7 @@ import SearchResults from '../SearchResults/SearchResults';
 // $FlowFixMe
 import MoreLink from '../MoreLink/MoreLink';
 import SpacingComponent from '../SpacingComponent/SpacingComponent';
+// $FlowFixMe
 import Layout8 from '../Layout8/Layout8';
 import type { EventSeries } from '../../../model/event-series';
 import type { ArticleSeries } from '../../../model/article-series';

--- a/common/views/components/SeriesNavigation/SeriesNavigation.js
+++ b/common/views/components/SeriesNavigation/SeriesNavigation.js
@@ -1,8 +1,9 @@
 // @flow
-import { Fragment } from 'react';
 import SearchResults from '../SearchResults/SearchResults';
 // $FlowFixMe
 import MoreLink from '../MoreLink/MoreLink';
+import SpacingComponent from '../SpacingComponent/SpacingComponent';
+import Layout8 from '../Layout8/Layout8';
 import type { EventSeries } from '../../../model/event-series';
 import type { ArticleSeries } from '../../../model/article-series';
 import type { Article } from '../../../model/articles';
@@ -19,21 +20,23 @@ type Props = {|
 const SeriesNavigation = ({ series, items }: Props) => {
   const showPosition = !!(series.schedule && series.schedule.length > 0);
   return (
-    <Fragment>
-      <SearchResults
-        key={series.id}
-        title={`Read more from ${series.title}`}
-        summary={series.promoText}
-        items={items}
-        showPosition={showPosition}
-      />
-      <Space v={{ size: 'm', properties: ['margin-top'] }}>
-        <MoreLink
-          name={`More from ${series.title}`}
-          url={`/${series.type}/${series.id}`}
+    <SpacingComponent>
+      <Layout8>
+        <SearchResults
+          key={series.id}
+          title={`Read more from ${series.title}`}
+          summary={series.promoText}
+          items={items}
+          showPosition={showPosition}
         />
-      </Space>
-    </Fragment>
+        <Space v={{ size: 'm', properties: ['margin-top'] }}>
+          <MoreLink
+            name={`More from ${series.title}`}
+            url={`/${series.type}/${series.id}`}
+          />
+        </Space>
+      </Layout8>
+    </SpacingComponent>
   );
 };
 export default SeriesNavigation;

--- a/content/webapp/pages/page.js
+++ b/content/webapp/pages/page.js
@@ -13,15 +13,16 @@ import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
 import VideoEmbed from '@weco/common/views/components/VideoEmbed/VideoEmbed';
 import { UiImage } from '@weco/common/views/components/Images/Images';
 import { convertImageUri } from '@weco/common/utils/convert-image-uri';
-import { getPage } from '@weco/common/services/prismic/pages';
+import { getPage, getPageSiblings } from '@weco/common/services/prismic/pages';
 import { contentLd } from '@weco/common/utils/json-ld';
 import type { Page as PageType } from '@weco/common/model/pages';
+import type { SiblingsGroup } from '@weco/common/model/siblings-group';
 // $FlowFixMe (ts)
 import { headerBackgroundLs } from '@weco/common/utils/backgrounds';
 import { prismicPageIds } from '@weco/common/services/prismic/hardcoded-id';
-
 type Props = {|
   page: PageType,
+  siblings: SiblingsGroup,
 |};
 
 const backgroundTexture = headerBackgroundLs;
@@ -30,8 +31,10 @@ export class Page extends Component<Props> {
     const { id, memoizedPrismic } = ctx.query;
     const page = await getPage(ctx.req, id, memoizedPrismic);
     if (page) {
+      const siblings = await getPageSiblings(page, ctx.req, memoizedPrismic);
       return {
         page,
+        siblings,
       };
     } else {
       return { statusCode: 404 };
@@ -39,7 +42,7 @@ export class Page extends Component<Props> {
   };
 
   render() {
-    const { page } = this.props;
+    const { page, siblings } = this.props;
     const DateInfo = page.datePublished && (
       <HTMLDate date={new Date(page.datePublished)} />
     );
@@ -133,6 +136,7 @@ export class Page extends Component<Props> {
           }
           contributorProps={{ contributors: page.contributors }}
           seasons={page.seasons}
+          pageSiblings={siblings}
         />
       </PageLayout>
     );

--- a/content/webapp/pages/page.js
+++ b/content/webapp/pages/page.js
@@ -16,6 +16,7 @@ import { convertImageUri } from '@weco/common/utils/convert-image-uri';
 import { getPage, getPageSiblings } from '@weco/common/services/prismic/pages';
 import { contentLd } from '@weco/common/utils/json-ld';
 import type { Page as PageType } from '@weco/common/model/pages';
+// $FlowFixMe (tsx)
 import type { SiblingsGroup } from '@weco/common/model/siblings-group';
 // $FlowFixMe (ts)
 import { headerBackgroundLs } from '@weco/common/utils/backgrounds';

--- a/content/webapp/pages/page.js
+++ b/content/webapp/pages/page.js
@@ -20,6 +20,11 @@ import type { SiblingsGroup } from '@weco/common/model/siblings-group';
 // $FlowFixMe (ts)
 import { headerBackgroundLs } from '@weco/common/utils/backgrounds';
 import { prismicPageIds } from '@weco/common/services/prismic/hardcoded-id';
+import CardGrid from '@weco/common/views/components/CardGrid/CardGrid';
+import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
+import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
+import SectionHeader from '@weco/common/views/components/SectionHeader/SectionHeader';
+
 type Props = {|
   page: PageType,
   siblings: SiblingsGroup,
@@ -77,16 +82,28 @@ export class Page extends Component<Props> {
         : 'What we do';
     }
     // TODO: This is not the way to do site sections
+    const sectionItem = page.siteSection
+      ? [
+          {
+            text: getBreadcrumbText(page.siteSection, page.id),
+            url: page.siteSection ? `/${page.siteSection}` : '',
+          },
+        ]
+      : [];
     const breadcrumbs = {
-      items: page.siteSection
-        ? [
-            {
-              text: getBreadcrumbText(page.siteSection, page.id),
-              url: page.siteSection ? `/${page.siteSection}` : '',
-            },
-          ]
-        : [],
+      items: [
+        ...sectionItem,
+        // Only using the first of the siblingsGroup in the list
+        // This should be fine as in reality there shouldn't be more than one
+        // Don't have capacity to implement a better solution
+        ...siblings.slice(0, 1).map(siblingGroup => ({
+          url: `/landing-pages/${siblingGroup.id}`,
+          text: siblingGroup.title || '',
+          prefix: `Part of`,
+        })),
+      ],
     };
+
     const Header = (
       <PageHeader
         breadcrumbs={breadcrumbs}
@@ -108,6 +125,20 @@ export class Page extends Component<Props> {
         isContentTypeInfoBeforeMedia={false}
       />
     );
+    const Siblings = siblings.map((siblingGroup, i) => {
+      if (siblingGroup.siblings.length > 0) {
+        return (
+          <SpacingSection key={i}>
+            <SpacingComponent>
+              <SectionHeader title={`More from ${siblingGroup.title}`} />
+            </SpacingComponent>
+            <SpacingComponent>
+              <CardGrid key={i} items={siblingGroup.siblings} itemsPerRow={3} />
+            </SpacingComponent>
+          </SpacingSection>
+        );
+      }
+    });
     return (
       <PageLayout
         title={page.title}
@@ -134,9 +165,9 @@ export class Page extends Component<Props> {
               showOnThisPage={page.showOnThisPage}
             />
           }
+          Siblings={Siblings}
           contributorProps={{ contributors: page.contributors }}
           seasons={page.seasons}
-          pageSiblings={siblings}
         />
       </PageLayout>
     );


### PR DESCRIPTION
references #6004

Displays related page cards and 'Part of ...' in header on pages

N.B. went down a rabbit hole with getServerSideProps, due to issues with serialisation so have left it out of this PR
![Screenshot 2021-02-02 at 16 57 14](https://user-images.githubusercontent.com/6051896/106745140-99c4ec80-6618-11eb-9681-7f98d8de006f.png)
