### PR TITLE
sort by alphabetical order for languages

### DIFF
--- a/common/utils/filters.ts
+++ b/common/utils/filters.ts
@@ -133,16 +133,12 @@ export const sortAggregationBucket = (
   filter: CatalogueAggregationBucket[],
   sortBy?: 'alphabetical' | 'count'
 ): CatalogueAggregationBucket[] => {
-  let sortedfilter;
   switch (sortBy) {
     case 'count':
-      sortedfilter = filter.sort(sortByCount);
-      break;
+      return filter.sort(sortByCount);
     case 'alphabetical':
-      sortedfilter = filter.sort(sortLabelByAlphabeticalOrder);
-      break;
+      return filter.sort(sortLabelByAlphabeticalOrder);
     default:
-      sortedfilter = filter;
+      return filter;
   }
-  return sortedfilter;
 };

--- a/common/utils/filters.ts
+++ b/common/utils/filters.ts
@@ -131,11 +131,9 @@ export const getSelectedFilterColor = (form: HTMLFormElement): string => {
 
 export const sortAggregationBucket = (
   filter: CatalogueAggregationBucket[],
-  sortBy?: 'alphabetical' | 'count'
+  sortBy?: 'alphabetical'
 ): CatalogueAggregationBucket[] => {
   switch (sortBy) {
-    case 'count':
-      return filter.sort(sortByCount);
     case 'alphabetical':
       return filter.sort(sortLabelByAlphabeticalOrder);
     default:

--- a/common/utils/filters.ts
+++ b/common/utils/filters.ts
@@ -129,7 +129,7 @@ export const getSelectedFilterColor = (form: HTMLFormElement): string => {
   return imagesColor;
 };
 
-export const sortAggregationBucketByOrder = (
+export const sortAggregationBucket = (
   filter: CatalogueAggregationBucket[],
   sortBy?: 'alphabetical' | 'count'
 ): CatalogueAggregationBucket[] => {

--- a/common/utils/filters.ts
+++ b/common/utils/filters.ts
@@ -48,6 +48,19 @@ export const sortByCount = (
   }
 };
 
+export const sortLabelByAlphabeticalOrder = (
+  a: CatalogueAggregationBucket,
+  b: CatalogueAggregationBucket
+): number => {
+  if (a.data.label.toLowerCase() < b.data.label.toLowerCase()) {
+    return -1;
+  }
+  if (a.data.label.toLowerCase() > b.data.label.toLowerCase()) {
+    return 1;
+  }
+  return 0;
+};
+
 export const getAggregationRadioGroup = (
   aggregation: CatalogueAggregationBucket[],
   prefixId: string
@@ -114,4 +127,22 @@ export const getSelectedFilterColor = (form: HTMLFormElement): string => {
       ? imagesColorValue.replace('#', '')
       : imagesColorValue;
   return imagesColor;
+};
+
+export const sortAggregationBucketByOrder = (
+  filter: CatalogueAggregationBucket[],
+  sortBy?: 'alphabetical' | 'count'
+): CatalogueAggregationBucket[] => {
+  let sortedfilter;
+  switch (sortBy) {
+    case 'count':
+      sortedfilter = filter.sort(sortByCount);
+      break;
+    case 'alphabetical':
+      sortedfilter = filter.sort(sortLabelByAlphabeticalOrder);
+      break;
+    default:
+      sortedfilter = filter;
+  }
+  return sortedfilter;
 };

--- a/common/views/components/ModalMoreFilters/ModalMoreFilters.tsx
+++ b/common/views/components/ModalMoreFilters/ModalMoreFilters.tsx
@@ -12,7 +12,7 @@ import { searchFilterCheckBox } from '../../../text/arial-labels';
 import {
   getAggregationFilterByName,
   getAggregationRadioGroup,
-  sortAggregationBucketByOrder,
+  sortAggregationBucket,
 } from '@weco/common/utils/filters';
 import RadioGroup from '@weco/common/views/components/RadioGroup/RadioGroup';
 import NextLink from 'next/link';
@@ -205,10 +205,10 @@ const ModalMoreFilters: FunctionComponent<ModalMoreFiltersProps> = ({
   worksRouteProps,
   isEnhanced,
 }: ModalMoreFiltersProps) => {
-  const languagesFilter: CatalogueAggregationBucket[] = sortAggregationBucketByOrder(getAggregationFilterByName(
-    aggregations,
-    'languages'
-  ), 'alphabetical');
+  const languagesFilter: CatalogueAggregationBucket[] = sortAggregationBucket(
+    getAggregationFilterByName(aggregations, 'languages'),
+    'alphabetical'
+  );
 
   const subjectsFilter: CatalogueAggregationBucket[] = getAggregationFilterByName(
     aggregations,

--- a/common/views/components/ModalMoreFilters/ModalMoreFilters.tsx
+++ b/common/views/components/ModalMoreFilters/ModalMoreFilters.tsx
@@ -12,6 +12,7 @@ import { searchFilterCheckBox } from '../../../text/arial-labels';
 import {
   getAggregationFilterByName,
   getAggregationRadioGroup,
+  sortAggregationBucketByOrder,
 } from '@weco/common/utils/filters';
 import RadioGroup from '@weco/common/views/components/RadioGroup/RadioGroup';
 import NextLink from 'next/link';
@@ -204,10 +205,11 @@ const ModalMoreFilters: FunctionComponent<ModalMoreFiltersProps> = ({
   worksRouteProps,
   isEnhanced,
 }: ModalMoreFiltersProps) => {
-  const languagesFilter: CatalogueAggregationBucket[] = getAggregationFilterByName(
+  const languagesFilter: CatalogueAggregationBucket[] = sortAggregationBucketByOrder(getAggregationFilterByName(
     aggregations,
     'languages'
-  );
+  ), 'alphabetical');
+
   const subjectsFilter: CatalogueAggregationBucket[] = getAggregationFilterByName(
     aggregations,
     'subjects'

--- a/common/views/components/SearchFiltersDesktop/SearchFiltersDesktop.tsx
+++ b/common/views/components/SearchFiltersDesktop/SearchFiltersDesktop.tsx
@@ -225,7 +225,7 @@ const SearchFiltersDesktop: FunctionComponent<SearchFiltersSharedProps> = ({
               >
                 <ButtonInline
                   type={ButtonTypes.button}
-                  text="more Filters"
+                  text="More filters"
                   clickHandler={event => {
                     event.preventDefault();
                     setMoreFiltersModal(true);


### PR DESCRIPTION
Ability to sort aggregation filter on the front end in alphabetical or count.

closes #6057 