### PR TITLE
add reference number to header and rename component

### DIFF
--- a/catalogue/webapp/components/Work/Work.tsx
+++ b/catalogue/webapp/components/Work/Work.tsx
@@ -11,7 +11,7 @@ import CataloguePageLayout from '@weco/common/views/components/CataloguePageLayo
 import { workLd } from '@weco/common/utils/json-ld';
 import BackToResults from '@weco/common/views/components/BackToResults/BackToResults';
 import WorkHeader from '@weco/common/views/components/WorkHeader/WorkHeader';
-import WorkHeaderPrototype from '@weco/common/views/components/WorkHeaderPrototype/WorkHeaderPrototype';
+import ArchiveHeader from '@weco/common/views/components/ArchiveHeader/ArchiveHeader';
 import ArchiveBreadcrumb from '@weco/common/views/components/ArchiveBreadcrumb/ArchiveBreadcrumb';
 import Space from '@weco/common/views/components/styled/Space';
 import useSavedSearchState from '@weco/common/hooks/useSavedSearchState';
@@ -179,7 +179,7 @@ const Work: FunctionComponent<Props> = ({
 
           <div className="container">
             <div className="grid">
-              <WorkHeaderPrototype
+              <ArchiveHeader
                 work={work}
                 childManifestsCount={childManifestsCount}
               />

--- a/common/views/components/ArchiveHeader/ArchiveHeader.tsx
+++ b/common/views/components/ArchiveHeader/ArchiveHeader.tsx
@@ -33,7 +33,7 @@ type Props = {
   childManifestsCount?: number;
 };
 
-const WorkHeaderPrototype: FunctionComponent<Props> = ({
+const ArchiveHeader: FunctionComponent<Props> = ({
   work,
   childManifestsCount = 0,
 }: Props): ReactElement<Props> => {
@@ -147,6 +147,13 @@ const WorkHeaderPrototype: FunctionComponent<Props> = ({
             </Space>
           )}
 
+          {work.referenceNumber && (
+            <LinkLabels
+              heading="Reference"
+              items={[{ text: work.referenceNumber }]}
+            />
+          )}
+
           {childManifestsCount > 0 && (
             <Space v={{ size: 'm', properties: ['margin-top'] }}>
               <p
@@ -165,4 +172,4 @@ const WorkHeaderPrototype: FunctionComponent<Props> = ({
     </WorkHeaderContainer>
   );
 };
-export default WorkHeaderPrototype;
+export default ArchiveHeader;


### PR DESCRIPTION
references #5944

Adds reference number to the archive page header
![ref](https://user-images.githubusercontent.com/6051896/106887773-8af43d80-66dd-11eb-8840-192c18a2121d.png)
