### PR TITLE
add reference to WorkHeader

### DIFF
--- a/common/views/components/WorkHeader/WorkHeader.tsx
+++ b/common/views/components/WorkHeader/WorkHeader.tsx
@@ -115,6 +115,13 @@ const WorkHeader: FunctionComponent<Props> = ({
             </Space>
           )}
 
+          {work.referenceNumber && (
+            <LinkLabels
+              heading="Reference"
+              items={[{ text: work.referenceNumber }]}
+            />
+          )}
+
           {childManifestsCount > 0 && (
             <Space v={{ size: 'm', properties: ['margin-top'] }}>
               <p


### PR DESCRIPTION
references #5944

Adds reference number to the WorkHeader - we'll probably want to consolidate WorkHeader and ArchiveHeader into a single component at some point soon (The ArchiveHeader is really a remnant of prototyping).