### PR TITLE
Ensure identity app does not require context path at buildtime

### DIFF
--- a/identity/webapp/src/frontend/index.tsx
+++ b/identity/webapp/src/frontend/index.tsx
@@ -10,11 +10,11 @@ import { AppContextProvider } from '@weco/common/views/components/AppContext/App
 import { ThemeProvider } from 'styled-components';
 import theme from '@weco/common/views/themes/default';
 import '@weco/common/styles/styleguide.scss';
-import { prefix } from '../utility/prefix';
 
 const root = typeof document !== 'undefined' ? document.getElementById('root') : undefined;
 
 if (root) {
+  let prefix = root.getAttribute("data-context-path");
   render(
     <ThemeProvider theme={theme}>
       <style id="styleguide-sass"></style>

--- a/identity/webapp/src/routes/index.ts
+++ b/identity/webapp/src/routes/index.ts
@@ -19,7 +19,7 @@ export const indexPage: RouteMiddleware = (context) => {
           <script crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"></script>
         </head>
         <body>
-          <div id="root"></div>
+          <div id="root" data-context-path="${prefix}"></div>
           <script type="application/javascript" src="${bundle}"></script>
         </body>
       </html>


### PR DESCRIPTION
Previously, pages in the identity app were not rendering at all on the staging environment due to the context path not being provided at build time. This change makes sure that the webpack bundle does not need the environment variable at build time, by providing it from the Koa server at runtime instead