### PR TITLE
Stop filters button from submitting form on mobile

### DIFF
--- a/common/views/components/SearchFiltersMobile/SearchFiltersMobile.tsx
+++ b/common/views/components/SearchFiltersMobile/SearchFiltersMobile.tsx
@@ -288,6 +288,7 @@ const SearchFiltersMobile: FunctionComponent<SearchFiltersSharedProps> = ({
     >
       <ShameButtonWrap>
         <SolidButton
+          type={ButtonTypes.button}
           ref={openFiltersButtonRef}
           onClick={handleOpenFiltersButtonClick}
           aria-controls="mobile-filters-modal"


### PR DESCRIPTION
Should we change the default `type` in our button component? It risks breaking other things but I think this bug is pretty common, and will keep happening otherwise (I know I never think to change it when I add a button).