### PR TITLE
ensure Safari preloads initial frame of video

### DIFF
--- a/common/views/components/GifVideo/GifVideo.js
+++ b/common/views/components/GifVideo/GifVideo.js
@@ -144,7 +144,7 @@ const GifVideo = ({
           controls={showControls}
           playsInline
         >
-          <source src={videoUrl} type="video/mp4" />
+          <source src={`${videoUrl}#t=0.1`} type="video/mp4" />
           <p>{"Your browser doesn't support video"}</p>
         </video>
         {canPlay && !showControls && (


### PR DESCRIPTION
Safari doesn't show the initial video frame. This wasn't a problem with auto playing videos, but now we have non autoplaying videos it is.

This uses the [Media Fragments](https://www.w3.org/TR/media-frags/) #t= in the src, which results in Safari downloading the first frame
