### PR TITLE
reduce space under WorkHeader

### DIFF
--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -625,19 +625,9 @@ const WorkDetails: FunctionComponent<Props> = ({ work, itemUrl }: Props) => {
       </div>
     </div>
   ) : (
-    <Space
-      v={{
-        size: 'xl',
-        properties: ['padding-top', 'padding-bottom'],
-      }}
-      className={classNames({
-        row: true,
-      })}
-    >
-      <Layout12>
-        <Content />
-      </Layout12>
-    </Space>
+    <Layout12>
+      <Content />
+    </Layout12>
   );
 };
 

--- a/common/views/components/WorkHeader/WorkHeader.tsx
+++ b/common/views/components/WorkHeader/WorkHeader.tsx
@@ -37,7 +37,7 @@ const WorkHeader: FunctionComponent<Props> = ({
     <WorkHeaderContainer>
       <Space
         v={{
-          size: 'xl',
+          size: 'm',
           properties: ['margin-bottom'],
         }}
         className={classNames([grid({ s: 12, m: 12, l: 10, xl: 10 })])}


### PR DESCRIPTION
Implements spacing change to works header (point 9 from [Zeplin file](https://app.zeplin.io/project/5aab926b4b6efde01259e959/screen/60255798189e8faf9f378f12) 

Before:
![Screenshot 2021-02-17 at 17 50 26](https://user-images.githubusercontent.com/6051896/108246247-214a4980-7149-11eb-93b4-562ffe4633e1.png)

After:
![Screenshot 2021-02-17 at 17 50 51](https://user-images.githubusercontent.com/6051896/108246262-23aca380-7149-11eb-918f-9cade13e1665.png)
