### PR TITLE
Supply logout redirect URL to identity from terraform

### DIFF
--- a/identity/terraform/locals.tf
+++ b/identity/terraform/locals.tf
@@ -26,11 +26,12 @@ locals {
 
   service_env = {for env_name in local.service_env_names : env_name => {
     env_vars = {
-      AUTH0_DOMAIN       = data.aws_ssm_parameter.auth0_domain[env_name].value
-      AUTH0_CLIENT_ID    = data.aws_ssm_parameter.auth0_client_id[env_name].value
-      AUTH0_CALLBACK_URL = data.aws_ssm_parameter.auth0_callback_url[env_name].value
-      API_BASE_URL       = data.aws_ssm_parameter.api_base_url[env_name].value
-      CONTEXT_PATH       = data.aws_ssm_parameter.context_path[env_name].value
+      AUTH0_DOMAIN        = data.aws_ssm_parameter.auth0_domain[env_name].value
+      AUTH0_CLIENT_ID     = data.aws_ssm_parameter.auth0_client_id[env_name].value
+      AUTH0_CALLBACK_URL  = data.aws_ssm_parameter.auth0_callback_url[env_name].value
+      API_BASE_URL        = data.aws_ssm_parameter.api_base_url[env_name].value
+      CONTEXT_PATH        = data.aws_ssm_parameter.context_path[env_name].value
+      LOGOUT_REDIRECT_URL = data.aws_ssm_parameter.logout_redirect_url[env_name].value
     }
 
     secret_env_vars = {
@@ -91,4 +92,10 @@ data "aws_ssm_parameter" "api_base_url"{
   for_each = toset(local.service_env_names)
 
   name = "/identity/${each.key}/account_management_system/api_base_url"
+}
+
+data "aws_ssm_parameter" "logout_redirect_url"{
+  for_each = toset(local.service_env_names)
+
+  name = "/identity/${each.key}/account_management_system/logout_redirect_url"
 }

--- a/identity/webapp/src/config.ts
+++ b/identity/webapp/src/config.ts
@@ -40,6 +40,10 @@ export const config = {
     // Session / cookie options.
   } as Partial<SessionOpts>,
 
+  logout : {
+    redirectUrl: process.env.LOGOUT_REDIRECT_URL
+  },
+
   testUser: isProduction
     ? undefined
     : {

--- a/identity/webapp/src/routes/auth.ts
+++ b/identity/webapp/src/routes/auth.ts
@@ -3,7 +3,6 @@ import koaPassport from 'koa-passport';
 import { withPrefix } from '../utility/prefix';
 import { config } from '../config';
 import * as querystring from 'querystring';
-import { router } from '../router';
 import { URL } from 'url';
 
 export const loginAction: RouteMiddleware = koaPassport.authenticate('auth0', {
@@ -20,7 +19,7 @@ export const logoutAction: RouteMiddleware = (context) => {
   context.logout();
 
   const logoutUri = new URL(`https://${config.auth0.domain}/v2/logout`);
-  const returnTo = context.request.origin + router.url('login');
+  const returnTo = config.logout.redirectUrl;
 
   logoutUri.search = querystring.stringify({
     client_id: config.auth0.clientID,


### PR DESCRIPTION
## Who is this for?

Users logging out.

## What is it doing for them?

Making the URL they are redirected to upon logout configurable on a per-deployment basis.