### PR TITLE
Guides

### DIFF
--- a/common/model/card.js
+++ b/common/model/card.js
@@ -22,7 +22,7 @@ export function convertItemToCardProps(
 ): Card {
   return {
     type: 'card',
-    format: null,
+    format: item.format || null,
     title: item.title,
     description: item.promo && item.promo.caption,
     image: item.promo &&

--- a/common/model/content-format-id.js
+++ b/common/model/content-format-id.js
@@ -1,11 +1,22 @@
 // @flow
-
-export const ContentFormatIds = {
+export const ArticleFormatIds = {
   ImageGallery: 'W5uKaCQAACkA3C0T',
   Essay: 'W7TfJRAAAJ1D0eLK',
   Comic: 'W7d_ghAAALWY3Ujc',
   Podcast: 'XwRZ6hQAAG4K-bbt',
+};
+
+export const PageFormatIds = {
   Landing: 'YBwQWxMAACAAuno1',
 };
 
-export type ContentFormatId = $Values<typeof ContentFormatIds>;
+export const GuideFormatIds = {
+  HowTo: 'YC_GIhMAACAADdCN',
+  Topic: 'YC_GQRMAACIADdEh',
+  LearningResource: 'YC_GrhMAACMADdMc',
+  ExhibitionGuide: 'YC_GfxMAACEADdI9',
+};
+
+export type ArticleFormatId = $Values<typeof ArticleFormatIds>;
+export type PageFormatId = $Values<typeof PageFormatIds>;
+export type GuideFormatId = $Values<typeof GuideFormatIds>;

--- a/common/model/content-format-id.ts
+++ b/common/model/content-format-id.ts
@@ -1,8 +1,21 @@
-export const ContentFormatIds = {
+export const ArticleFormatIds = {
   ImageGallery: 'W5uKaCQAACkA3C0T',
   Essay: 'W7TfJRAAAJ1D0eLK',
   Comic: 'W7d_ghAAALWY3Ujc',
   Podcast: 'XwRZ6hQAAG4K-bbt',
 } as const;
 
-export type ContentFormatId = typeof ContentFormatIds[keyof typeof ContentFormatIds];
+export const PageFormatIds = {
+  Landing: 'YBwQWxMAACAAuno1',
+} as const;
+
+export const GuideFormatIds = {
+  HowTo: 'YC_GIhMAACAADdCN',
+  Topic: 'YC_GQRMAACIADdEh',
+  LearningResource: 'YC_GrhMAACMADdMc',
+  ExhibitionGuide: 'YC_GfxMAACEADdI9',
+} as const;
+
+export type ArticleFormatId = typeof ArticleFormatIds[keyof typeof ArticleFormatIds];
+export type PageFormatId = typeof PageFormatIds[keyof typeof PageFormatIds];
+export type GuideFormatId = typeof GuideFormatIds[keyof typeof GuideFormatIds];

--- a/common/model/label-field.js
+++ b/common/model/label-field.js
@@ -1,9 +1,9 @@
 // @flow
 import type { HTMLString } from '../services/prismic/types';
-import type { ContentFormatId } from './content-format-id';
+import type { ArticleFormatId } from './content-format-id';
 
 export type LabelField = {|
-  id: ?ContentFormatId,
+  id: ?ArticleFormatId,
   title: ?string,
   description: ?HTMLString,
 |};

--- a/common/model/label-field.ts
+++ b/common/model/label-field.ts
@@ -1,8 +1,8 @@
 import { HTMLString } from '../services/prismic/types';
-import { ContentFormatId } from './content-format-id';
+import { ArticleFormatId } from './content-format-id';
 
 export type LabelField = {
-  id?: ContentFormatId;
+  id?: ArticleFormatId;
   title?: string;
   description?: HTMLString;
 };

--- a/common/services/prismic/fetch-links.js
+++ b/common/services/prismic/fetch-links.js
@@ -111,5 +111,7 @@ export const cardsFields = [
 export const pagesFormatsFields = [
   'page-formats.title',
   'page-formats.description',
+  'guide-formats.title',
+  'guide-formats.description',
 ];
 export const labelsFields = ['labels.title', 'labels.description'];

--- a/common/services/prismic/formats.ts
+++ b/common/services/prismic/formats.ts
@@ -1,0 +1,19 @@
+import { Format } from '@weco/common/model/format';
+import { parseTitle, asHtml } from './parsers';
+
+type FormatDoc = {
+  id: string;
+  data: {
+    title: Record<string, unknown>;
+    description: Record<string, unknown>;
+  };
+};
+
+export function parseFormat(format: FormatDoc): Format {
+  const data = format.data;
+  return {
+    id: format.id,
+    title: parseTitle(data.title),
+    description: asHtml(data.description),
+  };
+}

--- a/common/services/prismic/guides.ts
+++ b/common/services/prismic/guides.ts
@@ -1,0 +1,45 @@
+import Prismic from 'prismic-javascript';
+import { getDocuments } from './api';
+import { getGuideFormatPredicates } from '@weco/common/services/prismic/utils';
+import { parsePage } from '@weco/common/services/prismic/pages';
+import { pagesFormatsFields } from './fetch-links';
+import { PrismicQueryOpts, PaginatedResults } from './types';
+import { Page } from '../../model/pages';
+import { IncomingMessage } from 'http';
+
+type GuidesQueryProps = {
+  predicates?: string[];
+  format: string | string[] | undefined;
+} & PrismicQueryOpts;
+export async function getGuides(
+  req: IncomingMessage | undefined,
+  { predicates = [], format, ...opts }: GuidesQueryProps,
+  memoizedPrismic: Record<string, unknown>
+): Promise<PaginatedResults<Page>> {
+  const filterPredicates = getGuideFormatPredicates(format);
+
+  const paginatedResults = await getDocuments(
+    req,
+    [Prismic.Predicates.at('document.type', 'guides')]
+      .concat(predicates, filterPredicates)
+      .filter(Boolean),
+    {
+      page: opts.page,
+      pageSize: opts.pageSize,
+      fetchLinks: pagesFormatsFields,
+    },
+    memoizedPrismic
+  );
+  console.dir(paginatedResults, { depth: null });
+  const guides = paginatedResults.results.map(doc => {
+    return parsePage(doc, null);
+  });
+
+  return {
+    currentPage: paginatedResults.currentPage,
+    pageSize: paginatedResults.pageSize,
+    totalResults: paginatedResults.totalResults,
+    totalPages: paginatedResults.totalPages,
+    results: guides,
+  };
+}

--- a/common/services/prismic/link-resolver.js
+++ b/common/services/prismic/link-resolver.js
@@ -31,6 +31,8 @@ function linkResolver(doc /* :Doc */) /* :string */ {
       return `/seasons/${doc.id}`;
     case 'projects':
       return `/projects/${doc.id}`;
+    case 'guides':
+      return `/guides/${doc.id}`;
     default:
       return '/';
   }

--- a/common/services/prismic/utils.js
+++ b/common/services/prismic/utils.js
@@ -4,6 +4,38 @@ import { Predicates } from 'prismic-javascript';
 import { london } from '../../utils/format-date';
 import { getNextWeekendDateRange } from '../../utils/dates';
 import type { Period } from '../../model/periods';
+import {
+  type GuideFormatId,
+  GuideFormatIds,
+} from '@weco/common/model/content-format-id';
+
+type guideTypes = 'HowTo' | 'Topic' | 'LearningResource' | 'ExhibitionGuide';
+function getKey(format: string): ?guideTypes {
+  switch (true) {
+    case format === 'how-to':
+      return 'HowTo';
+    case format === 'topic':
+      return 'Topic';
+    case format === 'learning-resource':
+      return 'LearningResource';
+    case format === 'exhibition-guide':
+      return 'ExhibitionGuide';
+  }
+}
+
+export function getGuideFormatId(formatQuery: string): ?GuideFormatId {
+  const key = getKey(formatQuery);
+  if (key) {
+    return GuideFormatIds[key];
+  }
+}
+
+export function getGuideFormatPredicates(formatQuery: string): Predicates[] {
+  const formatId = getGuideFormatId(formatQuery);
+  if (formatId) {
+    return [Predicates.at('my.guides.format', formatId)];
+  } else return [];
+}
 
 export function getPeriodPredicates(
   period: ?Period,

--- a/common/services/prismic/utils.js
+++ b/common/services/prismic/utils.js
@@ -4,38 +4,6 @@ import { Predicates } from 'prismic-javascript';
 import { london } from '../../utils/format-date';
 import { getNextWeekendDateRange } from '../../utils/dates';
 import type { Period } from '../../model/periods';
-import {
-  type GuideFormatId,
-  GuideFormatIds,
-} from '@weco/common/model/content-format-id';
-
-type guideTypes = 'HowTo' | 'Topic' | 'LearningResource' | 'ExhibitionGuide';
-function getKey(format: string): ?guideTypes {
-  switch (true) {
-    case format === 'how-to':
-      return 'HowTo';
-    case format === 'topic':
-      return 'Topic';
-    case format === 'learning-resource':
-      return 'LearningResource';
-    case format === 'exhibition-guide':
-      return 'ExhibitionGuide';
-  }
-}
-
-export function getGuideFormatId(formatQuery: string): ?GuideFormatId {
-  const key = getKey(formatQuery);
-  if (key) {
-    return GuideFormatIds[key];
-  }
-}
-
-export function getGuideFormatPredicates(formatQuery: string): Predicates[] {
-  const formatId = getGuideFormatId(formatQuery);
-  if (formatId) {
-    return [Predicates.at('my.guides.format', formatId)];
-  } else return [];
-}
 
 export function getPeriodPredicates(
   period: ?Period,

--- a/common/views/components/ArticleCard/ArticleCard.tsx
+++ b/common/views/components/ArticleCard/ArticleCard.tsx
@@ -2,7 +2,7 @@ import CompactCard from '../CompactCard/CompactCard';
 import Image from '../Image/Image';
 import { Article } from '../../../model/articles';
 import { FunctionComponent } from 'react';
-import { ContentFormatIds } from '@weco/common/model/content-format-id';
+import { ArticleFormatIds } from '@weco/common/model/content-format-id';
 import HTMLDate from '../HTMLDate/HTMLDate';
 import Space from '../styled/Space';
 import { WatchWrapper, WatchText } from '../styled/Watch';
@@ -32,7 +32,7 @@ const ArticleCard: FunctionComponent<Props> = ({
     : undefined;
 
   const isPodcast =
-    article.format && article.format.id === ContentFormatIds.Podcast;
+    article.format && article.format.id === ArticleFormatIds.Podcast;
 
   if (isPodcast) {
     return (

--- a/common/views/components/LayoutPaginatedResults/LayoutPaginatedResults.js
+++ b/common/views/components/LayoutPaginatedResults/LayoutPaginatedResults.js
@@ -1,4 +1,5 @@
 // @flow
+import { type Node } from 'react';
 // $FlowFixMe (tsx)
 import CardGrid from '../CardGrid/CardGrid';
 // $FlowFixMe (tsx)
@@ -38,6 +39,7 @@ type Props = {|
   paginatedResults: PaginatedResultsTypes,
   period?: Period,
   showFreeAdmissionMessage: boolean,
+  children?: Node,
 |};
 
 const LayoutPaginatedResults = ({
@@ -47,6 +49,7 @@ const LayoutPaginatedResults = ({
   paginationRoot,
   period,
   showFreeAdmissionMessage,
+  children,
 }: Props) => (
   <>
     <SpacingSection>
@@ -63,7 +66,7 @@ const LayoutPaginatedResults = ({
         isContentTypeInfoBeforeMedia={false}
       />
     </SpacingSection>
-
+    {children}
     {paginatedResults.totalPages > 1 && (
       <Layout12>
         <Space
@@ -106,7 +109,13 @@ const LayoutPaginatedResults = ({
     )}
 
     <Space v={{ size: 'l', properties: ['margin-top'] }}>
-      <CardGrid items={paginatedResults.results} itemsPerRow={3} />
+      {paginatedResults.results.length > 0 ? (
+        <CardGrid items={paginatedResults.results} itemsPerRow={3} />
+      ) : (
+        <Layout12>
+          <p>There are no results.</p>
+        </Layout12>
+      )}
     </Space>
 
     {paginatedResults.totalPages > 1 && (

--- a/content/webapp/app.js
+++ b/content/webapp/app.js
@@ -75,6 +75,9 @@ module.exports = app
       id: 'YBfeAhMAACEAqBTx',
     });
 
+    route('/guides', '/guides', router, app);
+    route('/guides/:id', '/page', router, app);
+
     pageVanityUrl(router, app, '/opening-times', 'WwQHTSAAANBfDYXU');
     pageVanityUrl(router, app, '/what-we-do', 'WwLGFCAAAPMiB_Ps');
     pageVanityUrl(router, app, '/press', 'WuxrKCIAAP9h3hmw');

--- a/content/webapp/pages/article.js
+++ b/content/webapp/pages/article.js
@@ -24,7 +24,7 @@ import PageHeader, {
 } from '@weco/common/views/components/PageHeader/PageHeader';
 import { convertImageUri } from '@weco/common/utils/convert-image-uri';
 import { articleLd } from '@weco/common/utils/json-ld';
-import { ContentFormatIds } from '@weco/common/model/content-format-id';
+import { ArticleFormatIds } from '@weco/common/model/content-format-id';
 // $FlowFixMe (tsx)
 import Space from '@weco/common/views/components/styled/Space';
 
@@ -100,7 +100,7 @@ export class ArticlePage extends Component<Props, State> {
     };
 
     const isPodcast =
-      article.format && article.format.id === ContentFormatIds.Podcast;
+      article.format && article.format.id === ArticleFormatIds.Podcast;
 
     // Check if the article is in a serial, and where
     const serial = article.series.find(series => series.schedule.length > 0);
@@ -204,8 +204,8 @@ export class ArticlePage extends Component<Props, State> {
       : null;
     const isImageGallery =
       article.format &&
-      (article.format.id === ContentFormatIds.ImageGallery ||
-        article.format.id === ContentFormatIds.Comic);
+      (article.format.id === ArticleFormatIds.ImageGallery ||
+        article.format.id === ArticleFormatIds.Comic);
 
     const Header = (
       <PageHeader

--- a/content/webapp/pages/guides.tsx
+++ b/content/webapp/pages/guides.tsx
@@ -1,0 +1,131 @@
+import { NextPageContext } from 'next';
+import { FunctionComponent, ReactElement } from 'react';
+import PageLayout from '@weco/common/views/components/PageLayoutDeprecated/PageLayoutDeprecated';
+import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
+import LayoutPaginatedResults from '@weco/common/views/components/LayoutPaginatedResults/LayoutPaginatedResults';
+import Layout12 from '@weco/common/views/components/Layout12/Layout12';
+import SegmentedControl from '@weco/common/views/components/SegmentedControl/SegmentedControl';
+import { getGuides } from '@weco/common/services/prismic/guides';
+import { getGuideFormatId } from '@weco/common/services/prismic/utils';
+import {
+  GuideFormatId,
+  GuideFormatIds,
+} from '@weco/common/model/content-format-id';
+import { Page } from '@weco/common/model/pages';
+import { PaginatedResults } from '@weco/common/services/prismic/types';
+
+const pageDescription = 'Guides intro text...';
+const displayTitle = 'Guides';
+
+type FiltersProps = {
+  currentId: GuideFormatId;
+};
+
+const Filters: FunctionComponent<FiltersProps> = ({ currentId }) => {
+  return (
+    <Layout12>
+      <SegmentedControl
+        id={'guidesFilter'}
+        activeId={currentId || 'all'}
+        items={[
+          {
+            id: 'all',
+            url: '/guides',
+            text: 'All',
+          },
+          {
+            id: GuideFormatIds.HowTo,
+            url: '/guides?format=how-to',
+            text: 'How-to',
+          },
+          {
+            id: GuideFormatIds.Topic,
+            url: '/guides?format=topic',
+            text: 'Topic',
+          },
+          {
+            id: GuideFormatIds.LearningResource,
+            url: '/guides?format=learning-resource',
+            text: 'Learning resource',
+          },
+          {
+            id: GuideFormatIds.ExhibitionGuide,
+            url: '/guides?format=exhibition-guide',
+            text: 'Exhibition guide',
+          },
+        ]}
+      />
+    </Layout12>
+  );
+};
+
+type Props = {
+  guides: PaginatedResults<Page>;
+  formatId: GuideFormatId;
+};
+
+const GuidePage = ({ guides, formatId }: Props): ReactElement<Props> => {
+  return (
+    <PageLayout
+      title={'Guides'}
+      description={pageDescription}
+      url={{ pathname: '/guides' }}
+      jsonLd={{}}
+      openGraphType={'website'}
+      siteSection={'whatwedo'}
+      imageUrl={null}
+      imageAltText={null}
+    >
+      <SpacingSection>
+        <LayoutPaginatedResults
+          showFreeAdmissionMessage={false}
+          title={displayTitle}
+          description={[
+            {
+              type: 'paragraph',
+              text: pageDescription,
+              spans: [],
+            },
+          ]}
+          paginatedResults={guides}
+          paginationRoot={''} // TODO
+        >
+          <Filters currentId={formatId} />
+        </LayoutPaginatedResults>
+      </SpacingSection>
+    </PageLayout>
+  );
+};
+
+GuidePage.getInitialProps = async (
+  ctx: NextPageContext
+): Promise<Props | { statusCode: number }> => {
+  const { format } = ctx.query;
+  const formatId = getGuideFormatId(format);
+  const { memoizedPrismic } = (ctx.query.memoizedPrismic as unknown) as Record<
+    string,
+    unknown
+  >;
+  const memo = Array.isArray(memoizedPrismic)
+    ? memoizedPrismic[0]
+    : memoizedPrismic;
+  const guides = await getGuides(
+    ctx.req,
+    {
+      pageSize: 10,
+      format,
+    },
+    memo
+  );
+
+  if (guides) {
+    return {
+      guides,
+      formatId,
+    };
+  } else {
+    return { statusCode: 404 };
+  }
+};
+
+export default GuidePage;

--- a/content/webapp/pages/page.js
+++ b/content/webapp/pages/page.js
@@ -33,7 +33,7 @@ import CardGrid from '@weco/common/views/components/CardGrid/CardGrid';
 import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
 import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
 import SectionHeader from '@weco/common/views/components/SectionHeader/SectionHeader';
-import { ContentFormatIds } from '@weco/common/model/content-format-id';
+import { PageFormatIds } from '@weco/common/model/content-format-id';
 
 type Props = {|
   page: PageType,
@@ -62,8 +62,7 @@ export class Page extends Component<Props> {
     const DateInfo = page.datePublished && (
       <HTMLDate date={new Date(page.datePublished)} />
     );
-    const isLanding =
-      page.format && page.format.id === ContentFormatIds.Landing;
+    const isLanding = page.format && page.format.id === PageFormatIds.Landing;
     const backgroundTexture = isLanding
       ? landingHeaderBackgroundLs
       : headerBackgroundLs;

--- a/prismic-model/js/guide-formats.js
+++ b/prismic-model/js/guide-formats.js
@@ -1,0 +1,5 @@
+// @flow
+import label from './types/label';
+
+const GuideFormat = label('Guide format');
+export default GuideFormat;

--- a/prismic-model/js/guides.js
+++ b/prismic-model/js/guides.js
@@ -1,0 +1,24 @@
+// @flow
+import title from './parts/title';
+import body from './parts/body';
+import promo from './parts/promo';
+import link from './parts/link';
+import timestamp from './parts/timestamp';
+import structuredText from './parts/structured-text';
+
+const Guide = {
+  Guide: {
+    title,
+    format: link('Format', 'document', ['guide-formats']),
+    datePublished: timestamp('Date published'),
+    body,
+  },
+  Promo: {
+    promo,
+  },
+  Metadata: {
+    metadataDescription: structuredText('Metadata description', 'single'),
+  },
+};
+
+export default Guide;

--- a/prismic-model/json/guide-formats.json
+++ b/prismic-model/json/guide-formats.json
@@ -1,0 +1,19 @@
+{
+  "Guide format": {
+    "title": {
+      "type": "StructuredText",
+      "config": {
+        "label": "Title",
+        "single": "heading1",
+        "useAsTitle": true
+      }
+    },
+    "description": {
+      "type": "StructuredText",
+      "config": {
+        "multi": "paragraph,hyperlink,strong,em",
+        "label": "Description"
+      }
+    }
+  }
+}

--- a/prismic-model/json/guides.json
+++ b/prismic-model/json/guides.json
@@ -1,0 +1,670 @@
+{
+  "Guide": {
+    "title": {
+      "type": "StructuredText",
+      "config": {
+        "label": "Title",
+        "single": "heading1",
+        "useAsTitle": true
+      }
+    },
+    "format": {
+      "type": "Link",
+      "config": {
+        "label": "Format",
+        "select": "document",
+        "customtypes": [
+          "guide-formats"
+        ]
+      }
+    },
+    "datePublished": {
+      "type": "Timestamp",
+      "config": {
+        "label": "Date published"
+      }
+    },
+    "body": {
+      "fieldset": "Body content",
+      "type": "Slices",
+      "config": {
+        "labels": {
+          "collectionVenue": [
+            {
+              "name": "featured",
+              "display": "Featured"
+            }
+          ],
+          "text": [
+            {
+              "name": "featured",
+              "display": "Featured"
+            }
+          ],
+          "editorialImage": [
+            {
+              "name": "supporting",
+              "display": "Supporting"
+            },
+            {
+              "name": "standalone",
+              "display": "Standalone"
+            }
+          ],
+          "quote": [
+            {
+              "name": "pull",
+              "display": "Pull"
+            },
+            {
+              "name": "review",
+              "display": "Review"
+            }
+          ]
+        },
+        "choices": {
+          "text": {
+            "type": "Slice",
+            "fieldset": "Text",
+            "non-repeat": {
+              "text": {
+                "type": "StructuredText",
+                "config": {
+                  "multi": "paragraph,hyperlink,strong,em,heading2,heading3,list-item",
+                  "label": "Text"
+                }
+              }
+            }
+          },
+          "editorialImage": {
+            "type": "Slice",
+            "fieldset": "Captioned image",
+            "non-repeat": {
+              "image": {
+                "type": "Image",
+                "config": {
+                  "label": "Image",
+                  "thumbnails": [
+                    {
+                      "name": "32:15",
+                      "width": 3200,
+                      "height": 1500
+                    },
+                    {
+                      "name": "16:9",
+                      "width": 3200,
+                      "height": 1800
+                    },
+                    {
+                      "name": "square",
+                      "width": 3200,
+                      "height": 3200
+                    }
+                  ]
+                }
+              },
+              "caption": {
+                "type": "StructuredText",
+                "config": {
+                  "single": "paragraph,hyperlink,strong,em",
+                  "label": "Caption"
+                }
+              }
+            }
+          },
+          "editorialImageGallery": {
+            "type": "Slice",
+            "fieldset": "Image gallery",
+            "non-repeat": {
+              "title": {
+                "type": "StructuredText",
+                "config": {
+                  "label": "Title",
+                  "single": "heading1",
+                  "useAsTitle": true
+                }
+              }
+            },
+            "repeat": {
+              "image": {
+                "type": "Image",
+                "config": {
+                  "label": "Image",
+                  "thumbnails": [
+                    {
+                      "name": "32:15",
+                      "width": 3200,
+                      "height": 1500
+                    },
+                    {
+                      "name": "16:9",
+                      "width": 3200,
+                      "height": 1800
+                    },
+                    {
+                      "name": "square",
+                      "width": 3200,
+                      "height": 3200
+                    }
+                  ]
+                }
+              },
+              "caption": {
+                "type": "StructuredText",
+                "config": {
+                  "single": "paragraph,hyperlink,strong,em",
+                  "label": "Caption"
+                }
+              }
+            }
+          },
+          "gifVideo": {
+            "type": "Slice",
+            "fieldset": "Gif video",
+            "non-repeat": {
+              "caption": {
+                "type": "StructuredText",
+                "config": {
+                  "single": "paragraph,hyperlink,strong,em",
+                  "label": "Caption"
+                }
+              },
+              "tasl": {
+                "type": "Text",
+                "config": {
+                  "label": "TASL",
+                  "placeholder": "title|author|sourceName|sourceLink|license|copyrightHolder|copyrightLink"
+                }
+              },
+              "video": {
+                "type": "Link",
+                "config": {
+                  "label": "Video",
+                  "select": "media",
+                  "customtypes": [],
+                  "placeholder": "Video"
+                }
+              },
+              "playbackRate": {
+                "type": "Select",
+                "config": {
+                  "label": "Playback rate",
+                  "options": [
+                    "0.1",
+                    "0.25",
+                    "0.5",
+                    "0.75",
+                    "1",
+                    "1.25",
+                    "1.5",
+                    "1.75",
+                    "2"
+                  ]
+                }
+              },
+              "autoPlay": {
+                "type": "Boolean",
+                "config": {
+                  "default_value": true,
+                  "label": "Auto play"
+                }
+              },
+              "loop": {
+                "type": "Boolean",
+                "config": {
+                  "default_value": true,
+                  "label": "Loop video"
+                }
+              },
+              "mute": {
+                "type": "Boolean",
+                "config": {
+                  "default_value": true,
+                  "label": "Mute video"
+                }
+              },
+              "showControls": {
+                "type": "Boolean",
+                "config": {
+                  "default_value": false,
+                  "label": "Show controls"
+                }
+              }
+            }
+          },
+          "iframe": {
+            "type": "Slice",
+            "fieldset": "Iframe",
+            "non-repeat": {
+              "iframeSrc": {
+                "type": "Text",
+                "config": {
+                  "label": "iframe src",
+                  "placeholder": "iframe src"
+                }
+              },
+              "previewImage": {
+                "type": "Image",
+                "config": {
+                  "label": "Preview image"
+                }
+              }
+            }
+          },
+          "quote": {
+            "type": "Slice",
+            "fieldset": "Quote",
+            "non-repeat": {
+              "text": {
+                "type": "StructuredText",
+                "config": {
+                  "multi": "paragraph,hyperlink,strong,em",
+                  "label": "Quote"
+                }
+              },
+              "citation": {
+                "type": "StructuredText",
+                "config": {
+                  "single": "paragraph,hyperlink,strong,em",
+                  "label": "Citation"
+                }
+              }
+            }
+          },
+          "standfirst": {
+            "type": "Slice",
+            "fieldset": "Standfirst",
+            "non-repeat": {
+              "text": {
+                "type": "StructuredText",
+                "config": {
+                  "single": "paragraph,hyperlink,strong,em",
+                  "label": "Standfirst"
+                }
+              }
+            }
+          },
+          "table": {
+            "type": "Slice",
+            "fieldset": "Table",
+            "non-repeat": {
+              "caption": {
+                "type": "Text",
+                "config": {
+                  "label": "Table caption (heading)"
+                }
+              },
+              "tableData": {
+                "type": "Text",
+                "config": {
+                  "label": "Pipe-delimeted csv"
+                }
+              },
+              "hasRowHeaders": {
+                "type": "Boolean",
+                "config": {
+                  "default_value": false,
+                  "label": "Make first column bold (instead of first row)"
+                }
+              }
+            }
+          },
+          "embed": {
+            "type": "Slice",
+            "fieldset": "Embed",
+            "non-repeat": {
+              "embed": {
+                "type": "Embed",
+                "config": {
+                  "label": "Embed (Youtube, Vimeo etc)"
+                }
+              },
+              "caption": {
+                "type": "StructuredText",
+                "config": {
+                  "single": "paragraph,hyperlink,strong,em",
+                  "label": "Caption"
+                }
+              }
+            }
+          },
+          "map": {
+            "type": "Slice",
+            "fieldset": "Map",
+            "non-repeat": {
+              "title": {
+                "type": "StructuredText",
+                "config": {
+                  "label": "Title",
+                  "single": "heading1",
+                  "useAsTitle": true
+                }
+              },
+              "geolocation": {
+                "type": "GeoPoint",
+                "config": {
+                  "label": "Geo point"
+                }
+              }
+            }
+          },
+          "collectionVenue": {
+            "type": "Slice",
+            "fieldset": "Collection venue",
+            "non-repeat": {
+              "content": {
+                "type": "Link",
+                "config": {
+                  "label": "Content item",
+                  "select": "document",
+                  "customtypes": [
+                    "collection-venue"
+                  ]
+                }
+              },
+              "showClosingTimes": {
+                "type": "Select",
+                "config": {
+                  "label": "Show closing times",
+                  "options": [
+                    "yes"
+                  ]
+                }
+              }
+            }
+          },
+          "contact": {
+            "type": "Slice",
+            "fieldset": "Contact",
+            "non-repeat": {
+              "content": {
+                "type": "Link",
+                "config": {
+                  "label": "Content item",
+                  "select": "document",
+                  "customtypes": [
+                    "teams"
+                  ]
+                }
+              }
+            }
+          },
+          "inPageAnchor": {
+            "type": "Slice",
+            "fieldset": "In page anchor",
+            "non-repeat": {
+              "id": {
+                "type": "Text",
+                "config": {
+                  "label": "id",
+                  "placeholder": "unique identifier without spaces"
+                }
+              }
+            }
+          },
+          "tagList": {
+            "type": "Slice",
+            "fieldset": "Tag List",
+            "non-repeat": {
+              "title": {
+                "type": "StructuredText",
+                "config": {
+                  "label": "Title",
+                  "single": "heading2"
+                }
+              }
+            },
+            "repeat": {
+              "link": {
+                "type": "Link",
+                "config": {
+                  "label": "Link",
+                  "select": "web",
+                  "customtypes": []
+                }
+              },
+              "linkText": {
+                "type": "Text",
+                "config": {
+                  "label": "Link text"
+                }
+              }
+            }
+          },
+          "infoBlock": {
+            "type": "Slice",
+            "fieldset": "Info block",
+            "non-repeat": {
+              "title": {
+                "type": "StructuredText",
+                "config": {
+                  "label": "Title",
+                  "single": "heading2"
+                }
+              },
+              "text": {
+                "type": "StructuredText",
+                "config": {
+                  "multi": "paragraph,hyperlink,strong,em,heading3,list-item",
+                  "label": "Text"
+                }
+              },
+              "link": {
+                "type": "Link",
+                "config": {
+                  "label": "Button link",
+                  "select": "web",
+                  "customtypes": []
+                }
+              },
+              "linkText": {
+                "type": "Text",
+                "config": {
+                  "label": "Button text"
+                }
+              }
+            }
+          },
+          "titledTextList": {
+            "type": "Slice",
+            "fieldset": "Titled text list",
+            "repeat": {
+              "title": {
+                "type": "StructuredText",
+                "config": {
+                  "label": "Title",
+                  "single": "heading3"
+                }
+              },
+              "text": {
+                "type": "StructuredText",
+                "config": {
+                  "multi": "paragraph,hyperlink,strong,em,heading4,list-item",
+                  "label": "Text"
+                }
+              },
+              "link": {
+                "type": "Link",
+                "config": {
+                  "label": "Link",
+                  "customtypes": []
+                }
+              },
+              "label": {
+                "type": "Link",
+                "config": {
+                  "label": "tag",
+                  "select": "document",
+                  "customtypes": [
+                    "labels"
+                  ]
+                }
+              }
+            }
+          },
+          "contentList": {
+            "type": "Slice",
+            "fieldset": "(β) Content list",
+            "non-repeat": {
+              "title": {
+                "type": "StructuredText",
+                "config": {
+                  "label": "Title",
+                  "single": "heading1",
+                  "useAsTitle": true
+                }
+              }
+            },
+            "repeat": {
+              "content": {
+                "type": "Link",
+                "config": {
+                  "label": "Content item",
+                  "select": "document",
+                  "customtypes": [
+                    "pages",
+                    "event-series",
+                    "books",
+                    "events",
+                    "articles",
+                    "exhibitions",
+                    "card",
+                    "seasons"
+                  ]
+                }
+              }
+            }
+          },
+          "searchResults": {
+            "type": "Slice",
+            "fieldset": "(β) Search results",
+            "non-repeat": {
+              "title": {
+                "type": "StructuredText",
+                "config": {
+                  "label": "Title",
+                  "single": "heading1",
+                  "useAsTitle": true
+                }
+              },
+              "query": {
+                "type": "Text",
+                "config": {
+                  "label": "Query"
+                }
+              }
+            }
+          },
+          "mediaObjectList": {
+            "type": "Slice",
+            "fieldset": "Media Object List",
+            "repeat": {
+              "title": {
+                "type": "StructuredText",
+                "config": {
+                  "label": "Title",
+                  "single": "heading1",
+                  "useAsTitle": true
+                }
+              },
+              "text": {
+                "type": "StructuredText",
+                "config": {
+                  "multi": "paragraph,hyperlink,strong,em",
+                  "label": "Text"
+                }
+              },
+              "image": {
+                "type": "Image",
+                "config": {
+                  "label": "Image",
+                  "thumbnails": [
+                    {
+                      "name": "32:15",
+                      "width": 3200,
+                      "height": 1500
+                    },
+                    {
+                      "name": "16:9",
+                      "width": 3200,
+                      "height": 1800
+                    },
+                    {
+                      "name": "square",
+                      "width": 3200,
+                      "height": 3200
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "Promo": {
+    "promo": {
+      "type": "Slices",
+      "config": {
+        "label": "Promo",
+        "choices": {
+          "editorialImage": {
+            "type": "Slice",
+            "fieldset": "Editorial image",
+            "config": {
+              "label": "Editorial image"
+            },
+            "non-repeat": {
+              "caption": {
+                "type": "StructuredText",
+                "config": {
+                  "label": "Promo text",
+                  "single": "paragraph"
+                }
+              },
+              "image": {
+                "type": "Image",
+                "config": {
+                  "label": "Promo image",
+                  "thumbnails": [
+                    {
+                      "name": "32:15",
+                      "width": 3200,
+                      "height": 1500
+                    },
+                    {
+                      "name": "16:9",
+                      "width": 3200,
+                      "height": 1800
+                    },
+                    {
+                      "name": "square",
+                      "width": 3200,
+                      "height": 3200
+                    }
+                  ]
+                }
+              },
+              "link": {
+                "type": "Text",
+                "config": {
+                  "label": "Link override"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "Metadata": {
+    "metadataDescription": {
+      "type": "StructuredText",
+      "config": {
+        "single": "paragraph,hyperlink,strong,em",
+        "label": "Metadata description"
+      }
+    }
+  }
+}


### PR DESCRIPTION
References #6036

- creates new guides and guide-formats content types in Prismic
- renders a guide @ /guide/:id (with page template)
- shows a list of guides @ /guides
- enables filtering of guides by format, making use of SegmentedControl component in the UI

![Screenshot 2021-02-22 at 23 46 08](https://user-images.githubusercontent.com/6051896/108982943-3dd50d00-7686-11eb-94dd-96fdb396042c.png)
Will need design/UX consideration but seems like a reasonable place to start