### PR TITLE
Use the LabelsList component for the Online indicator on EventPromos

### DIFF
--- a/common/model/labels.js
+++ b/common/model/labels.js
@@ -1,7 +1,13 @@
 // @flow
-
+export type LabelColor =
+  | 'orange'
+  | 'yellow'
+  | 'black'
+  | 'cream'
+  | 'white'
+  | 'transparent';
 export type Label = {|
   url: ?string,
   text: string,
-  labelColor?: 'orange' | 'yellow' | 'black' | 'cream' | 'white',
+  labelColor?: LabelColor,
 |};

--- a/common/model/labels.ts
+++ b/common/model/labels.ts
@@ -1,5 +1,12 @@
+export type LabelColor =
+  | 'orange'
+  | 'yellow'
+  | 'black'
+  | 'cream'
+  | 'white'
+  | 'transparent';
 export type Label = {
   url: string | null;
   text: string;
-  labelColor?: 'orange' | 'yellow' | 'black' | 'cream' | 'white';
+  labelColor?: LabelColor;
 };

--- a/common/views/components/EventPromo/EventPromo.js
+++ b/common/views/components/EventPromo/EventPromo.js
@@ -83,7 +83,9 @@ const EventPromo = ({
 
           {event.isOnline && !event.availableOnline && (
             <LabelsList
-              labels={[{ text: 'Online', labelColor: 'white', url: null }]}
+              labels={[
+                { text: 'Online', labelColor: 'transparent', url: null },
+              ]}
             />
           )}
 

--- a/common/views/components/EventPromo/EventPromo.js
+++ b/common/views/components/EventPromo/EventPromo.js
@@ -14,22 +14,9 @@ import Space from '../styled/Space';
 import { CardOuter, CardBody } from '../Card/Card';
 /* $FlowFixMe (tsx) */
 import Divider from '../Divider/Divider';
-import styled from 'styled-components';
 /* $FlowFixMe (ts) */
 import WatchLabel from '../WatchLabel/WatchLabel';
 
-// TODO: make the online indicator a part of the Label component?
-const OnlineIndicator = styled(Space).attrs({
-  v: { size: 's', properties: ['padding-top', 'padding-bottom'] },
-  h: { size: 's', properties: ['padding-left', 'padding-right'] },
-  className: classNames({
-    [font('hnm', 6)]: true,
-  }),
-})`
-  display: inline-block;
-  border: 1px solid ${props => props.theme.color('silver')};
-  line-height: 1;
-`;
 type Props = {|
   event: UiEvent,
   position?: number,
@@ -95,7 +82,9 @@ const EventPromo = ({
           </Space>
 
           {event.isOnline && !event.availableOnline && (
-            <OnlineIndicator>Online</OnlineIndicator>
+            <LabelsList
+              labels={[{ text: 'Online', labelColor: 'white', url: null }]}
+            />
           )}
 
           {event.availableOnline && (

--- a/common/views/components/Label/Label.js
+++ b/common/views/components/Label/Label.js
@@ -1,5 +1,5 @@
 // @flow
-import type { Label as LabelType } from '../../../model/labels';
+import type { Label as LabelType, LabelColor } from '../../../model/labels';
 import { font, classNames } from '../../../utils/classnames';
 // $FlowFixMe (tsx)
 import Space from '../styled/Space';
@@ -22,6 +22,8 @@ const LabelContainer = styled(Space).attrs(props => ({
   ${props => {
     if (props.labelColor === 'white') {
       return `border: 1px solid ${props.theme.color('pumice')};`;
+    } else if (props.labelColor === 'transparent') {
+      return `border: 1px solid ${props.theme.color('silver')}`;
     } else {
       return `border: 1px solid ${props.theme.color(props.labelColor)};`;
     }
@@ -30,7 +32,7 @@ const LabelContainer = styled(Space).attrs(props => ({
 
 export type Props = {|
   label: LabelType,
-  labelColor?: 'orange' | 'yellow' | 'black' | 'cream' | 'white',
+  labelColor?: LabelColor,
 |};
 
 function getFontColor(bgColor) {

--- a/common/views/components/Label/Label.js
+++ b/common/views/components/Label/Label.js
@@ -20,10 +20,8 @@ const LabelContainer = styled(Space).attrs(props => ({
     }
   }}
   ${props => {
-    if (props.labelColor === 'white') {
-      return `border: 1px solid ${props.theme.color('pumice')};`;
-    } else if (props.labelColor === 'transparent') {
-      return `border: 1px solid ${props.theme.color('silver')}`;
+    if (props.labelColor === 'white' || props.labelColor === 'transparent') {
+      return `border: 1px solid ${props.theme.color('silver')};`;
     } else {
       return `border: 1px solid ${props.theme.color(props.labelColor)};`;
     }
@@ -36,14 +34,7 @@ export type Props = {|
 |};
 
 function getFontColor(bgColor) {
-  switch (true) {
-    case bgColor === 'black':
-      return 'yellow';
-    case bgColor === 'cream' || bgColor === 'white':
-      return 'charcoal';
-    default:
-      return 'black';
-  }
+  return bgColor === 'black' ? 'yellow' : 'black';
 }
 
 const Label = ({ label, labelColor = 'yellow' }: Props) => {

--- a/common/views/components/LabelsList/LabelsList.js
+++ b/common/views/components/LabelsList/LabelsList.js
@@ -1,5 +1,5 @@
 // @flow
-import type { Label as LabelType } from '../../../model/labels';
+import type { Label as LabelType, LabelColor } from '../../../model/labels';
 import Label from '../../components/Label/Label';
 // $FlowFixMe (tsx)
 import Space from '../styled/Space';
@@ -7,9 +7,9 @@ import Space from '../styled/Space';
 type Props = {|
   labels: {|
     ...LabelType,
-    labelColor?: 'orange' | 'yellow' | 'black' | 'cream' | 'white',
+    labelColor?: LabelColor,
   |}[],
-  defaultLabelColor?: 'orange' | 'yellow' | 'black' | 'cream' | 'white',
+  defaultLabelColor?: LabelColor,
 |};
 
 const LabelsList = ({ labels, defaultLabelColor = 'yellow' }: Props) => (


### PR DESCRIPTION
Making the 'Online' indicator that can be on Event cards into a `Label` component, instead of its own snowflake.

![image](https://user-images.githubusercontent.com/1394592/109004369-9addbc80-76a0-11eb-85ac-c6555e957185.png)

