### PR TITLE
Don't include locationOfWork in remainingNotes

### DIFF
--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -183,7 +183,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work, itemUrl }: Props) => {
   ];
 
   const remainingNotes = work.notes.filter(note => {
-    return !orderedNotes.some(n => n === note);
+    return ![...orderedNotes, locationOfWork].some(n => n === note);
   });
 
   const showDownloadOptions =


### PR DESCRIPTION
…because it's being handled in the 'Where to find it' section

Fixes #5555 
