### PR TITLE
use portal sortOrder in form submit

### DIFF
--- a/common/views/components/SearchForm/SearchForm.tsx
+++ b/common/views/components/SearchForm/SearchForm.tsx
@@ -139,7 +139,7 @@ const SearchForm: FunctionComponent<Props> = ({
     // We do this as the JS form uses a portal, due to the control being
     // outside of the for to obtain this value.
     const sort =
-      sortOrder === 'asc' || sortOrder === 'desc'
+      portalSortOrder === 'asc' || portalSortOrder === 'desc'
         ? 'production.dates'
         : undefined;
 


### PR DESCRIPTION
A misunderstanding on portals.
Tests to follow as I am writing the e2e tests which would capture this.