### PR TITLE
don't lowercase generated HTML IDs

### DIFF
--- a/common/utils/string.ts
+++ b/common/utils/string.ts
@@ -1,3 +1,3 @@
 export function toHtmlId(s: string): string {
-  return s.replace(/\W/g, '-').toLocaleLowerCase();
+  return s.replace(/\W/g, '-');
 }


### PR DESCRIPTION
Examples we have where this creates issues is `Electronic books` and `Electronic Books` in genres.

Uppercase is completely valid, so we leave it.