### PR TITLE
add contributor field

### DIFF
--- a/prismic-model/js/parts/article-body.js
+++ b/prismic-model/js/parts/article-body.js
@@ -257,6 +257,7 @@ export default {
         },
         repeat: {
           contibutor: link('Contributor', 'document', ['people']),
+          contributor: link('Contributor', 'document', ['people']),
           text: structuredText('Text'),
         },
       }),

--- a/prismic-model/json/articles.json
+++ b/prismic-model/json/articles.json
@@ -459,6 +459,16 @@
                   ]
                 }
               },
+              "contributor": {
+                "type": "Link",
+                "config": {
+                  "label": "Contributor",
+                  "select": "document",
+                  "customtypes": [
+                    "people"
+                  ]
+                }
+              },
               "text": {
                 "type": "StructuredText",
                 "config": {


### PR DESCRIPTION
Adds a contributor field alongside the incorrectly spelt contibutor field.
Once this change is made in Prismic it will allow us to update the application code and then the old field can be removed.
