### PR TITLE
query the correct field

### DIFF
--- a/common/services/prismic/articles.js
+++ b/common/services/prismic/articles.js
@@ -150,7 +150,7 @@ const graphQuery = `{
           title
         }
         repeat {
-          contibutor {
+          contributor {
             ...on people {
               name
             }


### PR DESCRIPTION
Once the changes in #6176 have been applied in Prismic, we can query the correctly spelt field
