### PR TITLE
Add links to third party item resources behind a toggle

### DIFF
--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -79,7 +79,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work, itemUrl }: Props) => {
   // Determine digital location
   const iiifImageLocation = getDigitalLocationOfType(work, 'iiif-image');
 
-  type ItemWithDigitalLocation = Omit<Item, 'location'> & {
+  type ItemWithDigitalLocation = Omit<Item, 'locations'> & {
     location: DigitalLocation;
   };
   const onlineResources = getItemsByLocationType(work, 'online-resource').map(

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -243,20 +243,29 @@ const WorkDetails: FunctionComponent<Props> = ({ work, itemUrl }: Props) => {
         </Space>
       )}
 
+      {stacksRequestService && <ItemLocation work={work} />}
+    </WorkDetailsSection>
+  );
+
+  const Content = () => (
+    <>
       {onlineResourcesPrototype && onlineResources.length > 0 && (
-        <details>
-          <summary>
-            <h3
-              className={classNames({
-                inline: true,
-                [font('hnm', 5)]: true,
-              })}
-            >
-              Online resources
-            </h3>
-          </summary>
+        <WorkDetailsSection headingText="Available online">
+          <h3
+            className={classNames({
+              'no-margin': true,
+              [font('hnm', 5)]: true,
+            })}
+          >
+            Online resources
+          </h3>
           {onlineResources.map(item => (
-            <span key={item.location.url}>
+            <span
+              className={classNames({
+                [font('hnl', 5)]: true,
+              })}
+              key={item.location.url}
+            >
               {item.title ? (
                 <>
                   {item.title}: <a href={item.location.url}>view resource</a>
@@ -266,15 +275,9 @@ const WorkDetails: FunctionComponent<Props> = ({ work, itemUrl }: Props) => {
               )}{' '}
             </span>
           ))}
-        </details>
+        </WorkDetailsSection>
       )}
 
-      {stacksRequestService && <ItemLocation work={work} />}
-    </WorkDetailsSection>
-  );
-
-  const Content = () => (
-    <>
       {digitalLocation && itemLinkState !== 'useNoLink' && (
         <WorkDetailsSection
           headingText="Available online"
@@ -473,7 +476,9 @@ const WorkDetails: FunctionComponent<Props> = ({ work, itemUrl }: Props) => {
         </WorkDetailsSection>
       )}
 
-      {!digitalLocation && (locationOfWork || encoreLink) && <WhereToFindIt />}
+      {!digitalLocation &&
+        !(onlineResourcesPrototype && onlineResources.length > 0) &&
+        (locationOfWork || encoreLink) && <WhereToFindIt />}
 
       {work.images && work.images.length > 0 && (
         <WorkDetailsSection

--- a/common/model/catalogue.ts
+++ b/common/model/catalogue.ts
@@ -113,6 +113,8 @@ type Concept = {
 };
 
 export type DigitalLocation = {
+  title?: string;
+  linkText?: string;
   locationType: LocationType;
   url: string;
   credit?: string;

--- a/common/utils/works.ts
+++ b/common/utils/works.ts
@@ -131,6 +131,15 @@ export function getItemsWithPhysicalLocation(
     );
 }
 
+export function getItemsByLocationType(
+  work: Work,
+  locationTypeId: string
+): Item[] {
+  return (work.items || []).filter(i =>
+    i?.locations.find(l => l.locationType.id === locationTypeId)
+  );
+}
+
 export function getDigitalLocationOfType(
   work: Work,
   locationType: string

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -8,6 +8,12 @@ export default {
       defaultValue: true,
     },
     {
+      id: 'onlineResourcesPrototype',
+      title: 'Online resources',
+      description: `Adds links to any third-party resources associated with items (inside 'Where to find it')`,
+      defaultValue: false,
+    },
+    {
       id: 'buildingReopening',
       title: 'Wellcome Collection reopening UI changes',
       description:

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -10,7 +10,7 @@ export default {
     {
       id: 'onlineResourcesPrototype',
       title: 'Online resources',
-      description: `Adds links to any third-party resources associated with items (inside 'Where to find it')`,
+      description: `Adds links to any third-party resources associated with items (inside 'Available online')`,
       defaultValue: false,
     },
     {


### PR DESCRIPTION
Related to #6137 

## Who is this for?
People who have access to third-party resources that we link to.

## What is it doing for them?
Adding an 'Online resources' section in the 'Where to find it' section of a work page. If an item location has a `title`, I've added that with a linked 'view resource' suffix. If (instead) it has `linkText`, I've linked directly to that (`linktText` tends e.g. to be something like 'View resource').

Getting this information on the page in some form so that we can get a feel for what it tends to look like. This should then help inform the direction the design moves in.

~I've put them as inline links in a `<details>` element initially because there can be quite a lot of them and they can be very similar (identical). Although perhaps it'd be more useful to see them always displayed so's to get a quicker idea of how variable the data is (@DominiqueMarshall)?~

Work with item `linkText` of 'View resource' [here](https://wellcomecollection.org/works/trpt9cmr)
![image](https://user-images.githubusercontent.com/1394592/110106033-11657300-7da1-11eb-9b88-590bfa5b8508.png)

Work with item `title` (and 'view resource' linked suffix) [here](https://wellcomecollection.org/works/hkmb2e6c)
![image](https://user-images.githubusercontent.com/1394592/110106199-470a5c00-7da1-11eb-8c66-80a180c5b071.png)

Work with _a lot_ of very similar 'view resource' `linkText` links [here](https://wellcomecollection.org/works/d5zws93r)

