### PR TITLE
Expose the license filter on image search

### DIFF
--- a/catalogue/webapp/pages/images.tsx
+++ b/catalogue/webapp/pages/images.tsx
@@ -267,7 +267,8 @@ export const getServerSideProps: GetServerSideProps<
 > = async context => {
   const globalContextData = getGlobalContextData(context);
   const params = fromQuery(context.query);
-  const apiProps = imagesRouteToApiUrl(params);
+  const aggregations = ['locations.license'];
+  const apiProps = imagesRouteToApiUrl(params, { aggregations });
   const hasQuery = !!(params.query && params.query !== '');
   const images = hasQuery
     ? await getImages({

--- a/common/model/catalogue.ts
+++ b/common/model/catalogue.ts
@@ -303,13 +303,17 @@ export type CatalogueAggregationNoId = {
   buckets: CatalogueAggregationBucketNoId[];
 };
 
-export type CatalogueAggregations = {
+export type WorkAggregations = {
   workType: CatalogueAggregation;
   availabilities: CatalogueAggregation;
   languages?: CatalogueAggregation;
   genres?: CatalogueAggregationNoId;
   subjects?: CatalogueAggregationNoId;
   contributors?: CatalogueAggregationContributor;
+};
+
+export type ImageAggregations = {
+  license?: CatalogueAggregation;
 };
 
 export type CatalogueResultsList<Result = Work> = {
@@ -319,5 +323,5 @@ export type CatalogueResultsList<Result = Work> = {
   pageSize: number;
   prevPage: string | null;
   nextPage: string | null;
-  aggregations?: CatalogueAggregations;
+  aggregations?: Result extends Work ? WorkAggregations : ImageAggregations;
 };

--- a/common/services/catalogue/filters.ts
+++ b/common/services/catalogue/filters.ts
@@ -22,6 +22,7 @@ export type CheckboxFilter = {
   type: 'checkbox';
   id: keyof WorksProps | keyof ImagesProps;
   label: string;
+  showEmptyBuckets?: boolean;
   options: {
     id: string;
     value: string;
@@ -181,6 +182,7 @@ const licenseFilter = ({
   type: 'checkbox',
   id: 'locations.license',
   label: 'License',
+  showEmptyBuckets: true,
   options:
     images.aggregations?.license?.buckets.map(bucket => ({
       id: bucket.data.id,

--- a/common/services/catalogue/filters.ts
+++ b/common/services/catalogue/filters.ts
@@ -18,9 +18,9 @@ export type DateRangeFilter = {
   };
 };
 
-export type CheckboxFilter<Props = WorksProps> = {
+export type CheckboxFilter = {
   type: 'checkbox';
-  id: keyof Props;
+  id: keyof WorksProps | keyof ImagesProps;
   label: string;
   options: {
     id: string;
@@ -38,11 +38,7 @@ export type ColorFilter = {
   color: string | undefined;
 };
 
-export type Filter =
-  | CheckboxFilter<WorksProps>
-  | CheckboxFilter<ImagesProps>
-  | DateRangeFilter
-  | ColorFilter;
+export type Filter = CheckboxFilter | DateRangeFilter | ColorFilter;
 
 type WorksFilterProps = {
   works: CatalogueResultsList<Work>;
@@ -181,7 +177,7 @@ const colorFilter = ({ props }: ImagesFilterProps): ColorFilter => ({
 const licenseFilter = ({
   images,
   props,
-}: ImagesFilterProps): CheckboxFilter<ImagesProps> => ({
+}: ImagesFilterProps): CheckboxFilter => ({
   type: 'checkbox',
   id: 'locations.license',
   label: 'License',

--- a/common/services/catalogue/filters.ts
+++ b/common/services/catalogue/filters.ts
@@ -18,9 +18,9 @@ export type DateRangeFilter = {
   };
 };
 
-export type CheckboxFilter = {
+export type CheckboxFilter<Props = WorksProps> = {
   type: 'checkbox';
-  id: keyof WorksProps;
+  id: keyof Props;
   label: string;
   options: {
     id: string;
@@ -38,7 +38,11 @@ export type ColorFilter = {
   color: string | undefined;
 };
 
-export type Filter = CheckboxFilter | DateRangeFilter | ColorFilter;
+export type Filter =
+  | CheckboxFilter<WorksProps>
+  | CheckboxFilter<ImagesProps>
+  | DateRangeFilter
+  | ColorFilter;
 
 type WorksFilterProps = {
   works: CatalogueResultsList<Work>;
@@ -155,7 +159,6 @@ const availabilitiesFilter = ({
   props,
 }: WorksFilterProps): CheckboxFilter => ({
   type: 'checkbox',
-
   id: 'availabilities',
   label: 'Locations',
   options:
@@ -175,8 +178,25 @@ const colorFilter = ({ props }: ImagesFilterProps): ColorFilter => ({
   color: props.color,
 });
 
+const licenseFilter = ({
+  images,
+  props,
+}: ImagesFilterProps): CheckboxFilter<ImagesProps> => ({
+  type: 'checkbox',
+  id: 'locations.license',
+  label: 'License',
+  options:
+    images.aggregations?.license?.buckets.map(bucket => ({
+      id: bucket.data.id,
+      value: bucket.data.id,
+      count: bucket.count,
+      label: bucket.data.label,
+      selected: props['locations.license'].includes(bucket.data.id),
+    })) || [],
+});
+
 const imagesFilters: (props: ImagesFilterProps) => Filter[] = props =>
-  [colorFilter].map(f => f(props));
+  [colorFilter, licenseFilter].map(f => f(props));
 
 const worksFilters: (props: WorksFilterProps) => Filter[] = props =>
   [

--- a/common/services/catalogue/ts_api.ts
+++ b/common/services/catalogue/ts_api.ts
@@ -3,10 +3,11 @@ import { ImagesProps } from '../../views/components/ImagesLink/ImagesLink';
 import { WorksProps } from '../../views/components/WorksLink/WorksLink';
 
 export type CatalogueImagesApiProps = {
-  query: string | undefined;
-  page: number | undefined;
-  'locations.license': string[] | undefined;
-  color: string | undefined;
+  query?: string;
+  page?: number;
+  'locations.license'?: string[];
+  color?: string;
+  aggregations?: string[];
 };
 
 function toIsoDateString(s: string): string {
@@ -81,13 +82,15 @@ export function worksRouteToApiUrl(
 }
 
 export function imagesRouteToApiUrl(
-  imagesRouteProps: ImagesProps
+  imagesRouteProps: ImagesProps,
+  overrides: Partial<CatalogueImagesApiProps>
 ): CatalogueImagesApiProps {
   return {
     query: imagesRouteProps.query,
     page: imagesRouteProps.page,
     color: imagesRouteProps.color,
     'locations.license': imagesRouteProps['locations.license'],
+    ...overrides,
   };
 }
 

--- a/common/views/components/SearchFiltersDesktop/SearchFiltersDesktop.tsx
+++ b/common/views/components/SearchFiltersDesktop/SearchFiltersDesktop.tsx
@@ -42,7 +42,7 @@ const CheckboxFilter = ({ f, changeHandler }: CheckboxFilterProps) => {
       >
         {f.options.map(({ id, label, value, count, selected }) => {
           return (
-            (count > 0 || selected) && (
+            (f.showEmptyBuckets || count > 0 || selected) && (
               <li key={`${f.id}-${id}`}>
                 <CheckboxRadio
                   id={id}


### PR DESCRIPTION
Nice and easy to add thanks to @jamesgorrie's work in https://github.com/wellcomecollection/wellcomecollection.org/pull/6101

![image](https://user-images.githubusercontent.com/4429247/110000262-0233e600-7d0b-11eb-9bec-bb2d03cc72fd.png)
