### PR TITLE
add user story tests

### DIFF
--- a/catalogue/webapp/components/WorksSearchResults/WorksSearchResults.tsx
+++ b/catalogue/webapp/components/WorksSearchResults/WorksSearchResults.tsx
@@ -23,13 +23,9 @@ const WorkSearchResults: FunctionComponent<Props> = ({
   const { relevanceRating } = useContext(TogglesContext);
 
   return (
-    <ul className={'grid plain-list no-padding no-margin'} role="list">
+    <ul className={'grid plain-list no-padding no-margin'}>
       {works.results.map((result, i) => (
-        <li
-          key={result.id}
-          className={grid({ s: 12, m: 12, l: 12, xl: 12 })}
-          role="listitem"
-        >
+        <li key={result.id} className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>
           <div
             onClick={() => {
               trackSearchResultSelected(apiProps, {

--- a/catalogue/webapp/pages/works.tsx
+++ b/catalogue/webapp/pages/works.tsx
@@ -128,6 +128,7 @@ const Works: NextPage<Props> = ({
         imageUrl={undefined}
         imageAltText={undefined}
         globalContextData={globalContextData}
+        excludeRoleMain={true}
       >
         <Space
           v={{
@@ -215,7 +216,7 @@ const Works: NextPage<Props> = ({
               }}
               style={{ opacity: loading ? 0 : 1 }}
             >
-              <div className="container">
+              <div className="container" role="main">
                 {works && (
                   <WorksSearchResults
                     works={works}

--- a/common/views/components/CheckboxRadio/CheckboxRadio.tsx
+++ b/common/views/components/CheckboxRadio/CheckboxRadio.tsx
@@ -85,7 +85,7 @@ const CheckboxRadio: FunctionComponent<CheckboxRadioProps> = ({
   ...inputProps
 }: CheckboxRadioProps): ReactElement<CheckboxRadioProps> => {
   return (
-    <CheckboxRadioLabel htmlFor={id} aria-label={ariaLabel}>
+    <CheckboxRadioLabel htmlFor={id}>
       <CheckBoxWrapper>
         <CheckboxRadioInput id={id} type={type} {...inputProps} />
         <CheckboxRadioBox type={type}>

--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -49,6 +49,7 @@ type ComponentProps = {
   children: ReactNode;
   hideNewsletterPromo?: boolean;
   hideFooter?: boolean;
+  excludeRoleMain?: boolean;
 };
 
 const PageLayoutComponent: FunctionComponent<ComponentProps> = ({
@@ -65,6 +66,7 @@ const PageLayoutComponent: FunctionComponent<ComponentProps> = ({
   children,
   hideNewsletterPromo = false,
   hideFooter = false,
+  excludeRoleMain = false,
 }: ComponentProps) => {
   const urlString = convertUrlToString(url);
   const fullTitle =
@@ -253,7 +255,11 @@ const PageLayoutComponent: FunctionComponent<ComponentProps> = ({
 
         {popupDialog && popupDialog.isShown && <PopupDialog {...popupDialog} />}
 
-        <div id="main" className="main" role="main">
+        <div
+          id="main"
+          className="main"
+          role={excludeRoleMain ? undefined : 'main'}
+        >
           {children}
         </div>
         {!hideNewsletterPromo && (

--- a/common/views/components/Paginator/Paginator.tsx
+++ b/common/views/components/Paginator/Paginator.tsx
@@ -22,7 +22,7 @@ type Props = {
 type PaginatorWrapperProps = {
   hideMobilePagination: boolean | undefined;
 };
-const PaginatorWrapper = styled.div.attrs<PaginatorWrapperProps>((props) => ({
+const PaginatorWrapper = styled.div.attrs<PaginatorWrapperProps>(props => ({
   className: classNames({
     'is-hidden-s': Boolean(props.hideMobilePagination),
     flex: true,
@@ -34,7 +34,7 @@ type TotalResultsWrapperProps = {
   hideMobileTotalResults: boolean | undefined;
 };
 const TotalResultsWrapper = styled.div.attrs<TotalResultsWrapperProps>(
-  (props) => ({
+  props => ({
     className: classNames({
       'is-hidden-s': Boolean(props.hideMobileTotalResults),
     }),
@@ -126,12 +126,16 @@ const Paginator: FunctionComponent<Props> = ({
         }}
       >
         {showPortal && <div id="sort-select-portal"></div>}
-        <PaginatorWrapper hideMobilePagination={hideMobilePagination}>
+        <PaginatorWrapper
+          hideMobilePagination={hideMobilePagination}
+          aria-label="Pagination navigation"
+          role="navigation"
+        >
           {prevLink && prev && (
             <Space as="span" h={{ size: 'm', properties: ['margin-right'] }}>
               <Control
                 link={prevLink}
-                clickHandler={(event) => {
+                clickHandler={event => {
                   onPageChange(event, prev);
                 }}
                 colorScheme="light"
@@ -150,7 +154,7 @@ const Paginator: FunctionComponent<Props> = ({
             <Space as="span" h={{ size: 'm', properties: ['margin-left'] }}>
               <Control
                 link={nextLink}
-                clickHandler={(event) => {
+                clickHandler={event => {
                   onPageChange(event, next);
                 }}
                 colorScheme="light"

--- a/common/views/components/SearchFiltersDesktop/SearchFiltersDesktop.tsx
+++ b/common/views/components/SearchFiltersDesktop/SearchFiltersDesktop.tsx
@@ -19,7 +19,6 @@ import {
 } from '../../../services/catalogue/filters';
 import ModalMoreFilters from '../ModalMoreFilters/ModalMoreFilters';
 import ButtonInline from '../ButtonInline/ButtonInline';
-import { searchFilterCheckBox } from '../../../text/arial-labels';
 import { ResetActiveFilters } from '../ResetActiveFilters/ResetActiveFilters';
 import { ButtonTypes } from '../ButtonSolid/ButtonSolid';
 
@@ -52,7 +51,6 @@ const CheckboxFilter = ({ f, changeHandler }: CheckboxFilterProps) => {
                   name={f.id}
                   checked={selected}
                   onChange={changeHandler}
-                  ariaLabel={searchFilterCheckBox(label)}
                 />
               </li>
             )

--- a/playwright/contexts.ts
+++ b/playwright/contexts.ts
@@ -1,7 +1,0 @@
-import { baseUrl } from './test/helpers/urls';
-
-const multiVolumeItem = async (): Promise<void> => {
-  await page.goto(`${baseUrl}/works/mg56yqa4/items`);
-};
-
-export { multiVolumeItem };

--- a/playwright/test/contexts.ts
+++ b/playwright/test/contexts.ts
@@ -1,0 +1,25 @@
+import { baseUrl } from './helpers/urls';
+
+const multiVolumeItem = async (): Promise<void> => {
+  await page.goto(`${baseUrl}/works/mg56yqa4/items`);
+};
+
+const worksSearch = async (): Promise<void> => {
+  // This is because the cookie notice actually hides interface.
+  // It should also not live here, but I was battling on getting it to
+  // run for the first test of a suite (even on beforeAll/beforeEach)
+  context.addCookies([
+    {
+      name: 'WC_cookiesAccepted',
+      value: 'true',
+      path: '/',
+      domain: new URL(baseUrl).host,
+    },
+  ]);
+
+  await page.goto(`${baseUrl}/works`);
+};
+
+export const isMobile = Boolean(deviceName);
+
+export { multiVolumeItem, worksSearch };

--- a/playwright/test/roles.ts
+++ b/playwright/test/roles.ts
@@ -1,3 +1,4 @@
 const researcher = {};
+const imageResearcher = {};
 
-export { researcher };
+export { researcher, imageResearcher };

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -1,4 +1,4 @@
-import { multiVolumeItem } from '../contexts';
+import { multiVolumeItem } from './contexts';
 import { isMobile } from './actions/common';
 import { volumesNavigationLabel } from './text/aria-labels';
 

--- a/playwright/test/works-search.test.ts
+++ b/playwright/test/works-search.test.ts
@@ -1,0 +1,128 @@
+import { isMobile, worksSearch } from './contexts';
+import { URLSearchParams } from 'url';
+
+// Not sure why this isn't working here, it's now in the contexts
+// beforeEach(async () => {
+//   context.addCookies([
+//     {
+//       name: 'WC_cookiesAccepted',
+//       value: 'true',
+//       path: '/',
+//       domain: new URL(baseUrl).host,
+//     },
+//   ]);
+// });
+
+async function searchFor(query: string) {
+  console.info('searchFor', query);
+  const searchInput = '[aria-label="Search the catalogue"]';
+  await page.fill(searchInput, query);
+  await page.press(searchInput, 'Enter');
+}
+
+function expectSearchParam(expectedKey: string, expectedVal: string) {
+  console.info('expectSearchParam', { expectedKey, expectedVal });
+  const params = new URLSearchParams(page.url());
+  expect(
+    Array.from(params).find(
+      ([key, val]) => key === expectedKey && val === expectedVal
+    )
+  ).toBeTruthy();
+}
+
+async function openDropdown(label: string) {
+  console.info('openDropdown', label);
+  if (isMobile) {
+  } else {
+    await page.click(`button :text("${label}")`);
+  }
+}
+
+async function selectCheckbox(label: string) {
+  if (isMobile) {
+    // TODO: Make this a user centric selector
+    // for some reason `"Filters"` isn't working.
+    await page.click(`[aria-controls="mobile-filters-modal"]`);
+  }
+
+  await page.click(`label :text("${label}")`);
+
+  if (isMobile) {
+    await page.click(`"Show results"`);
+  }
+  await page.waitForNavigation();
+}
+
+async function navigateToNextPage() {
+  // Not a massive fan of this selector, as it isn't very user-centric,
+  // but the selector `Next (page 2)` doesn't work as it's `visually-hidden`
+  // we also use nth-of-type as the bottom navigation is the one ued on mobile
+  // another hack
+  await page.click('[aria-label="Pagination navigation"]:nth-of-type(1) a');
+  await page.waitForNavigation();
+}
+
+async function navigateToResult(n = 1) {
+  const result = `[role="main"] ul li:nth-of-type(${n}) a`;
+  const searchResultTitle = await page.textContent(`${result} h2`);
+
+  await page.click(result);
+  await page.waitForNavigation();
+
+  const title = await page.textContent('h1');
+  expect(title).toBe(searchResultTitle);
+}
+
+describe('Scenario 1: The person is looking for an archive', () => {
+  test('the work should be browsable to from the search results', async () => {
+    await worksSearch();
+    await searchFor('Persian');
+    await openDropdown('Formats');
+    await selectCheckbox('Archives and manuscripts');
+    await navigateToNextPage();
+
+    expectSearchParam('workType', 'h');
+
+    await navigateToResult(3);
+  });
+});
+
+describe('Scenario 2: The person is searching for a work in the physical library', () => {
+  test('the work should be browsable to from the search results', async () => {
+    await worksSearch();
+    await searchFor('Miasma');
+    await selectCheckbox('In the library');
+    await navigateToNextPage();
+
+    expectSearchParam('availabilities', 'in-library');
+
+    await navigateToResult(6);
+  });
+});
+
+describe('Scenario 3: The person is searching for a work that is available online', () => {
+  test('the work should be browsable to from the search results', async () => {
+    await worksSearch();
+    await searchFor('skin');
+    await selectCheckbox('Online');
+    await navigateToNextPage();
+
+    expectSearchParam('availabilities', 'online');
+
+    await navigateToResult(8);
+  });
+});
+
+describe('Scenario 4: The person is searching for a work from Wellcome Images', () => {
+  test('the work should be browsable to from the search results', async () => {
+    await worksSearch();
+    await searchFor('skeleton');
+    await openDropdown('Formats');
+    await selectCheckbox('Digital images');
+    await navigateToNextPage();
+
+    expectSearchParam('workType', 'q');
+
+    await navigateToResult(1);
+  });
+});

--- a/playwright/user-stories/images-search.md
+++ b/playwright/user-stories/images-search.md
@@ -1,0 +1,11 @@
+## A image researcher can complete a works search
+
+> As a _image researcher_
+> I want to _find things I am interested in_
+> so I can _use them in my research_
+
+### Scenario 1: The person is looking for an archive
+Given we have the archive in our collection
+When the person searches for a term matching the archive
+    And filters the results for “Archive and manuscripts”
+Then the work should be browsable to from the search results

--- a/prismic-model/json/interpretation-types.json
+++ b/prismic-model/json/interpretation-types.json
@@ -4,7 +4,8 @@
       "type" : "StructuredText",
       "config" : {
         "single" : "heading1",
-        "label" : "Title"
+        "label" : "Title",
+        "useAsTitle": true
       }
     },
     "abbreviation" : {


### PR DESCRIPTION
## Who is this for?
All of us

## What is it doing for us?
Takes the user stories that were collectively written and starts to encode them in tests.

I plan to expand on the user stories and tests to work on how we deal with #6144 as @jamieparkinson and I have experienced, some issues there would really have benefited from some tests to record context that we think has been lost to  ⏳ .

The process is also helping massively with thinking about where the interface is not as intrinsic as it can be. One specific piece being writing selectors that are more user centric, and is something I would like to see continued when writing tests (See [playwright](https://playwright.dev/docs/selectors#prioritize-user-facing-attributes) and [testing library](https://testing-library.com/docs/) docs advocating for this). Where I haven't been able to do this to get the tests running, i've left notes, which means I should probably find a way to fix it in the code rather than test.

There's a few gotchas in the code but commented./