### PR TITLE
Remove misspelled field

### DIFF
--- a/prismic-model/README.md
+++ b/prismic-model/README.md
@@ -7,3 +7,8 @@ We can create the models in JS to avoid copy / paste errors, and then run:
   yarn convert custom_type
   # e.g.
   yarn convert installations
+
+To eliminate the possibility of overwriting changes to the custom types in Prismic, any changes should be merged to master before starting work on a feature that users them and you should rerun convert on the master branch to make sure nothing has changed before applying it in Prismic.
+
+N.B. In order for model changes to take effect in prismic, a custom type of the one created/amended needs to be saved.
+

--- a/prismic-model/README.md
+++ b/prismic-model/README.md
@@ -8,7 +8,7 @@ We can create the models in JS to avoid copy / paste errors, and then run:
   # e.g.
   yarn convert installations
 
-To eliminate the possibility of overwriting changes to the custom types in Prismic, any changes should be merged to master before starting work on a feature that users them and you should rerun convert on the master branch to make sure nothing has changed before applying it in Prismic.
+To eliminate the possibility of overwriting changes to the custom types in Prismic, any changes should be merged to master before starting work on a feature that uses them and you should rerun convert on the master branch to make sure nothing has changed before applying it in Prismic.
 
 N.B. In order for model changes to take effect in prismic, a custom type of the one created/amended needs to be saved.
 

--- a/prismic-model/js/parts/article-body.js
+++ b/prismic-model/js/parts/article-body.js
@@ -260,7 +260,6 @@ export default {
           title: heading('Title', 2),
         },
         repeat: {
-          contibutor: link('Contributor', 'document', ['people']),
           contributor: link('Contributor', 'document', ['people']),
           text: structuredText('Text'),
         },

--- a/prismic-model/json/articles.json
+++ b/prismic-model/json/articles.json
@@ -453,16 +453,6 @@
               }
             },
             "repeat": {
-              "contibutor": {
-                "type": "Link",
-                "config": {
-                  "label": "Contributor",
-                  "select": "document",
-                  "customtypes": [
-                    "people"
-                  ]
-                }
-              },
               "contributor": {
                 "type": "Link",
                 "config": {


### PR DESCRIPTION
#6177 is now [deployed to master](https://buildkite.com/wellcomecollection/experience-deploy-stage/builds/154):

So it is safe to remove the contibutor field from Prismic

Also, have updated the readme for creating/updating custom-types

