### PR TITLE
Filter repetitive structures

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -40,6 +40,7 @@
     "jest": "^24.9.0",
     "koa-compose": "^4.1.0",
     "lazysizes": "^5.2.1",
+    "lodash.clonedeep": "^4.5.0",
     "lodash.debounce": "^4.0.8",
     "lodash.flattendeep": "^4.4.0",
     "lodash.groupby": "^4.6.0",

--- a/common/test/utils/iiif.test.ts
+++ b/common/test/utils/iiif.test.ts
@@ -1,0 +1,85 @@
+import { getCanvases, groupStructures } from '../../utils/iiif';
+import manifest from '../../../common/__mocks__/iiif-manifest';
+
+const canvases = getCanvases(manifest);
+const structures = [
+  {
+    '@id': 'https://wellcomelibrary.org/iiif/b21538906/range/r-0',
+    '@type': 'sc:Range',
+    label: 'First',
+    canvases: [
+      'https://wellcomelibrary.org/iiif/b21538906/canvas/c0',
+      'https://wellcomelibrary.org/iiif/b21538906/canvas/c1',
+    ],
+  },
+  {
+    '@id': 'https://wellcomelibrary.org/iiif/b21538906/range/r-1',
+    '@type': 'sc:Range',
+    label: 'First',
+    canvases: ['https://wellcomelibrary.org/iiif/b21538906/canvas/c2'],
+  },
+  {
+    '@id': 'https://wellcomelibrary.org/iiif/b21538906/range/r-2',
+    '@type': 'sc:Range',
+    label: 'First',
+    canvases: ['https://wellcomelibrary.org/iiif/b21538906/canvas/c5'],
+  },
+  {
+    '@id': 'https://wellcomelibrary.org/iiif/b21538906/range/r-3',
+    '@type': 'sc:Range',
+    label: 'Second',
+    canvases: ['https://wellcomelibrary.org/iiif/b21538906/canvas/c6'],
+  },
+  {
+    '@id': 'https://wellcomelibrary.org/iiif/b21538906/range/r-4',
+    '@type': 'sc:Range',
+    label: 'Third',
+    canvases: ['https://wellcomelibrary.org/iiif/b21538906/canvas/c8'],
+  },
+  {
+    '@id': 'https://wellcomelibrary.org/iiif/b21538906/range/r-5',
+    '@type': 'sc:Range',
+    label: 'Third',
+    canvases: ['https://wellcomelibrary.org/iiif/b21538906/canvas/c9'],
+  },
+];
+
+const correctResult = [
+  {
+    '@id': 'https://wellcomelibrary.org/iiif/b21538906/range/r-0',
+    '@type': 'sc:Range',
+    label: 'First',
+    canvases: [
+      'https://wellcomelibrary.org/iiif/b21538906/canvas/c0',
+      'https://wellcomelibrary.org/iiif/b21538906/canvas/c1',
+      'https://wellcomelibrary.org/iiif/b21538906/canvas/c2',
+    ],
+  },
+  {
+    '@id': 'https://wellcomelibrary.org/iiif/b21538906/range/r-2',
+    '@type': 'sc:Range',
+    label: 'First',
+    canvases: ['https://wellcomelibrary.org/iiif/b21538906/canvas/c5'],
+  },
+  {
+    '@id': 'https://wellcomelibrary.org/iiif/b21538906/range/r-3',
+    '@type': 'sc:Range',
+    label: 'Second',
+    canvases: ['https://wellcomelibrary.org/iiif/b21538906/canvas/c6'],
+  },
+  {
+    '@id': 'https://wellcomelibrary.org/iiif/b21538906/range/r-4',
+    '@type': 'sc:Range',
+    label: 'Third',
+    canvases: [
+      'https://wellcomelibrary.org/iiif/b21538906/canvas/c8',
+      'https://wellcomelibrary.org/iiif/b21538906/canvas/c9',
+    ],
+  },
+];
+describe('Group repetitive iiif structures', () => {
+  it('groups iiifStructures with consecutive canvases and the same label', () => {
+    const groupedStructures = groupStructures(canvases, structures);
+    expect(groupedStructures).toEqual(correctResult);
+  });
+});

--- a/common/utils/iiif.ts
+++ b/common/utils/iiif.ts
@@ -9,6 +9,7 @@ import {
   AuthService,
   IIIFAnnotationResource,
 } from '../model/iiif';
+import cloneDeep from 'lodash.clonedeep';
 
 export function getServiceId(canvas?: IIIFCanvas): string | undefined {
   const serviceSrc = canvas?.images[0]?.resource?.service;
@@ -64,7 +65,10 @@ export function getUiExtensions(
   }
 }
 
-export function isUiEnabled(uiExtensions: Service | undefined, uiName: string) {
+export function isUiEnabled(
+  uiExtensions: Service | undefined,
+  uiName: string
+): boolean {
   const disableUI = uiExtensions && uiExtensions.disableUI;
   if (disableUI) {
     return !(
@@ -127,6 +131,46 @@ export function getCanvases(iiifManifest: IIIFManifest): IIIFCanvas[] {
 
 export function getStructures(iiifManifest: IIIFManifest): IIIFStructure[] {
   return iiifManifest?.structures || [];
+}
+
+// When lots of the works were digitised, structures with multiple pages such as table of contents
+// were created individually, rather than as a single structure with a range of pages.
+// This means we will often display repetitive links to the essentially the same thing.
+// Until we can improve the data at source, this function groups structures that have the same label attached to consecutive pages into a single structure.
+export function groupStructures(
+  canvases: IIIFCanvas[],
+  structures: IIIFStructure[]
+): IIIFStructure[] {
+  const clonedStructures = cloneDeep(structures);
+  return clonedStructures.reduce(
+    (acc, structure) => {
+      const [lastCanvasInRange] = structure.canvases.slice(-1);
+      const [firstCanvasInRange] = structure.canvases;
+      const firstCanvasIndex = canvases.findIndex(
+        canvas => canvas['@id'] === firstCanvasInRange
+      );
+      if (
+        acc.previousLabel === structure.label &&
+        firstCanvasIndex === acc.previousLastCanvasIndex + 1
+      ) {
+        acc.groupedArray[acc.groupedArray.length - 1].canvases.push(
+          lastCanvasInRange
+        );
+      } else {
+        acc.groupedArray.push(structure);
+      }
+      acc.previousLabel = structure.label;
+      acc.previousLastCanvasIndex = canvases.findIndex(
+        canvas => canvas['@id'] === lastCanvasInRange
+      );
+      return acc;
+    },
+    {
+      previousLastCanvasIndex: null,
+      previousLabel: null,
+      groupedArray: [],
+    }
+  ).groupedArray;
 }
 
 export function getVideo(

--- a/common/views/components/IIIFViewer/parts/StructuresViewer.tsx
+++ b/common/views/components/IIIFViewer/parts/StructuresViewer.tsx
@@ -1,5 +1,9 @@
 import { IIIFManifest } from '@weco/common/model/iiif';
-import { getStructures, getCanvases } from '@weco/common/utils/iiif';
+import {
+  getStructures,
+  groupStructures,
+  getCanvases,
+} from '@weco/common/utils/iiif';
 import { FunctionComponent, RefObject } from 'react';
 import { FixedSizeList } from 'react-window';
 
@@ -17,10 +21,11 @@ const StructuresViewer: FunctionComponent<Props> = ({
 }: Props) => {
   const structures = manifest ? getStructures(manifest) : [];
   const canvases = manifest ? getCanvases(manifest) : [];
+  const groupedStructures = groupStructures(canvases, structures);
 
-  return structures.length > 0 ? (
+  return groupedStructures.length > 0 ? (
     <ul>
-      {structures.map((structure, i) => {
+      {groupedStructures.map((structure, i) => {
         const firstCanvasInRange = structure.canvases[0];
         const canvasIndex = canvases.findIndex(
           canvas => canvas['@id'] === firstCanvasInRange

--- a/yarn.lock
+++ b/yarn.lock
@@ -15226,6 +15226,11 @@ lodash-es@^4.17.15:
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
   integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
 
+lodash.clonedeep@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
+
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"


### PR DESCRIPTION
When lots of the works were digitised, structures with multiple pages such as table of contents were created individually, rather than as a single structure with a range of pages.

This means we will often display repetitive links to the essentially the same thing.

Until we can improve the data at source, this function groups structures that have the same label attached to consecutive pages into a single structure.

Before:
![Screenshot 2021-03-08 at 15 54 35](https://user-images.githubusercontent.com/6051896/110449596-42ec8000-80ba-11eb-9fce-b0de9e791e1c.png)

After:
![Screenshot 2021-03-08 at 15 54 57](https://user-images.githubusercontent.com/6051896/110449635-4bdd5180-80ba-11eb-8b10-a02efe9e2bae.png)

