### PR TITLE
add single text field for discussion transcript

### DIFF
--- a/prismic-model/js/parts/article-body.js
+++ b/prismic-model/js/parts/article-body.js
@@ -258,6 +258,7 @@ export default {
       discussion: slice('Discussion', {
         nonRepeat: {
           title: heading('Title', 2),
+          text: structuredText('Text'),
         },
         repeat: {
           contributor: link('Contributor', 'document', ['people']),

--- a/prismic-model/json/articles.json
+++ b/prismic-model/json/articles.json
@@ -450,6 +450,13 @@
                   "label": "Title",
                   "single": "heading2"
                 }
+              },
+              "text": {
+                "type": "StructuredText",
+                "config": {
+                  "multi": "paragraph,hyperlink,strong,em",
+                  "label": "Text"
+                }
               }
             },
             "repeat": {


### PR DESCRIPTION
- Makes the initial prismic changes required for this #6191
- Aim is to replace the repeatable text fields with a single text field
- This adds the single text field
- Once this change is made and the application code is changed, we'll be able to remove the repeatable fields