### PR TITLE
disable search form links on collections

### DIFF
--- a/common/views/components/Body/CollectionsStaticContent.tsx
+++ b/common/views/components/Body/CollectionsStaticContent.tsx
@@ -17,6 +17,7 @@ const CollectionsStaticContent: FunctionComponent = (): ReactElement => {
           shouldShowDescription={false}
           shouldShowFilters={false}
           showSortBy={false}
+          disableLink={true}
         />
       </Layout12>
     </>


### PR DESCRIPTION
https://user-images.githubusercontent.com/31692/110918688-59414880-8313-11eb-9327-8d21246d5f67.mov

Fixes links taking you through to the `works` / `images` pages when you're on `collections`.