### PR TITLE
use site sections to get text for breadcrumb

### DIFF
--- a/content/webapp/pages/page.js
+++ b/content/webapp/pages/page.js
@@ -97,7 +97,8 @@ export class Page extends Component<Props> {
     function getBreadcrumbText(siteSection: string, pageId: string): string {
       return hiddenBreadcrumbPages.includes(page.id) || isLanding
         ? '\u200b'
-        : links.find(link => link.siteSection === siteSection)?.title;
+        : links.find(link => link.siteSection === siteSection)?.title ||
+            siteSection;
     }
 
     // TODO: This is not the way to do site sections

--- a/content/webapp/pages/page.js
+++ b/content/webapp/pages/page.js
@@ -37,6 +37,8 @@ import SpacingSection from '@weco/common/views/components/SpacingSection/Spacing
 import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
 import SectionHeader from '@weco/common/views/components/SectionHeader/SectionHeader';
 import { PageFormatIds } from '@weco/common/model/content-format-id';
+// $FlowFixMe (tsx)
+import { links } from '@weco/common/views/components/Header/Header';
 
 type Props = {|
   page: PageType,
@@ -95,10 +97,9 @@ export class Page extends Component<Props> {
     function getBreadcrumbText(siteSection: string, pageId: string): string {
       return hiddenBreadcrumbPages.includes(page.id) || isLanding
         ? '\u200b'
-        : siteSection === 'visit-us'
-        ? 'Visit us'
-        : 'What we do';
+        : links.find(link => link.siteSection === siteSection)?.title;
     }
+
     // TODO: This is not the way to do site sections
     const sectionItem = page.siteSection
       ? [
@@ -108,6 +109,7 @@ export class Page extends Component<Props> {
           },
         ]
       : [];
+
     const breadcrumbs = {
       items: [
         ...sectionItem,


### PR DESCRIPTION
There's definitely a better way to do this, but the template itself needs so much work so I was looking for the least moving parts solution.

![Screenshot 2021-03-15 at 16 53 03](https://user-images.githubusercontent.com/31692/111190458-01bf0900-85af-11eb-872c-d94af8c661cb.png)
