### PR TITLE
Show more/less in the onlineResourcesPrototype

### DIFF
--- a/catalogue/webapp/components/WorkDetails/OnlineResources.tsx
+++ b/catalogue/webapp/components/WorkDetails/OnlineResources.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useState, useRef, FunctionComponent } from 'react';
+import { font, classNames } from '@weco/common/utils/classnames';
+import { getItemsByLocationType } from '@weco/common/utils/works';
+import WorkDetailsSection from '../WorkDetailsSection/WorkDetailsSection';
+import { DigitalLocation, Work, Item } from '@weco/common/model/catalogue';
+import styled from 'styled-components';
+
+const ShowHideButton = styled.button.attrs({
+  className: classNames({
+    'plain-button no-margin no-padding': true,
+    [font('hnl', 5)]: true,
+  }),
+})`
+  text-decoration: underline;
+
+  &:hover {
+    text-decoration: none;
+  }
+`;
+type Props = {
+  work: Work;
+};
+const OnlineResources: FunctionComponent<Props> = ({ work }: Props) => {
+  type ItemWithDigitalLocation = Omit<Item, 'locations'> & {
+    location: DigitalLocation;
+  };
+
+  const onlineResources = getItemsByLocationType(work, 'online-resource').map(
+    i => {
+      const [location] = i.locations;
+      return {
+        title: i.title,
+        location,
+      };
+    }
+  ) as ItemWithDigitalLocation[]; // FIXME: I think this casting might be cheating?
+
+  const firstThreeOnlineResources = onlineResources.slice(0, 3);
+  const remainingOnlineResources = onlineResources.slice(3);
+  const [
+    isShowingRemainingOnlineResources,
+    setIsShowingRemainingOnlineResources,
+  ] = useState(false);
+  const firstOfRemainingOnlineResourcesRef = useRef<HTMLAnchorElement>(null);
+  const showHideResourcesRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (isShowingRemainingOnlineResources) {
+      firstOfRemainingOnlineResourcesRef?.current?.focus();
+    } else {
+      showHideResourcesRef?.current?.focus();
+    }
+  }, [isShowingRemainingOnlineResources]);
+
+  return onlineResources.length > 0 ? (
+    <WorkDetailsSection headingText="Available online">
+      <ul
+        className={classNames({
+          'plain-list no-margin no-padding': true,
+        })}
+      >
+        {firstThreeOnlineResources.map(item => (
+          <li
+            className={classNames({
+              [font('hnl', 5)]: true,
+            })}
+            key={item.location.url}
+          >
+            <a href={item.location.url}>
+              {item.title
+                ? `${item.title}: View resource`
+                : item.location.linkText}
+            </a>
+          </li>
+        ))}
+        {isShowingRemainingOnlineResources && (
+          <>
+            {remainingOnlineResources.map((item, index) => (
+              <li
+                className={classNames({
+                  [font('hnl', 5)]: true,
+                })}
+                key={item.location.url}
+              >
+                <a
+                  href={item.location.url}
+                  ref={
+                    index === 0 ? firstOfRemainingOnlineResourcesRef : undefined
+                  }
+                >
+                  {item.title
+                    ? `${item.title}: View resource`
+                    : item.location.linkText}
+                </a>
+              </li>
+            ))}
+          </>
+        )}
+      </ul>
+      {remainingOnlineResources.length > 0 && (
+        <ShowHideButton
+          ref={showHideResourcesRef}
+          onClick={() =>
+            setIsShowingRemainingOnlineResources(
+              !isShowingRemainingOnlineResources
+            )
+          }
+        >
+          {isShowingRemainingOnlineResources
+            ? '- Show less'
+            : `+ ${remainingOnlineResources.length} more`}
+        </ShowHideButton>
+      )}
+    </WorkDetailsSection>
+  ) : null;
+};
+
+export default OnlineResources;

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -10,7 +10,6 @@ import { toLink as imagesLink } from '@weco/common/views/components/ImagesLink/I
 import {
   getDownloadOptionsFromImageUrl,
   getDigitalLocationOfType,
-  getItemsByLocationType,
   getAccessConditionForDigitalLocation,
   getWorkIdentifiersWith,
   getEncoreLink,
@@ -41,7 +40,7 @@ import Layout12 from '@weco/common/views/components/Layout12/Layout12';
 import { DigitalLocation, Work, Item } from '@weco/common/model/catalogue';
 import useIIIFManifestData from '@weco/common/hooks/useIIIFManifestData';
 import IIIFClickthrough from '@weco/common/views/components/IIIFClickthrough/IIIFClickthrough';
-
+import OnlineResources from './OnlineResources';
 type Props = {
   work: Work;
   itemUrl?: NextLinkType;
@@ -79,20 +78,6 @@ const WorkDetails: FunctionComponent<Props> = ({ work, itemUrl }: Props) => {
   );
   // Determine digital location
   const iiifImageLocation = getDigitalLocationOfType(work, 'iiif-image');
-
-  type ItemWithDigitalLocation = Omit<Item, 'locations'> & {
-    location: DigitalLocation;
-  };
-  const onlineResources = getItemsByLocationType(work, 'online-resource').map(
-    i => {
-      const [location] = i.locations;
-      return {
-        title: i.title,
-        location,
-      };
-    }
-  ) as ItemWithDigitalLocation[]; // FIXME: I think this casting might be cheating?
-
   const iiifPresentationLocation = getDigitalLocationOfType(
     work,
     'iiif-presentation'
@@ -251,32 +236,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work, itemUrl }: Props) => {
 
   const Content = () => (
     <>
-      {onlineResourcesPrototype && onlineResources.length > 0 && (
-        <WorkDetailsSection headingText="Available online">
-          <ul
-            className={classNames({
-              'plain-list no-margin no-padding': true,
-            })}
-          >
-            {onlineResources.map(item => (
-              <li
-                className={classNames({
-                  [font('hnl', 5)]: true,
-                })}
-                key={item.location.url}
-              >
-                {item.title ? (
-                  <>
-                    {item.title}: <a href={item.location.url}>View resource</a>
-                  </>
-                ) : (
-                  <a href={item.location.url}>{item.location.linkText}</a>
-                )}{' '}
-              </li>
-            ))}
-          </ul>
-        </WorkDetailsSection>
-      )}
+      {onlineResourcesPrototype && <OnlineResources work={work} />}
 
       {digitalLocation && itemLinkState !== 'useNoLink' && (
         <WorkDetailsSection
@@ -495,7 +455,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work, itemUrl }: Props) => {
       )}
 
       {!digitalLocation &&
-        !(onlineResourcesPrototype && onlineResources.length > 0) &&
+        !onlineResourcesPrototype &&
         (locationOfWork || encoreLink) && <WhereToFindIt />}
 
       {work.images && work.images.length > 0 && (


### PR DESCRIPTION
Relates to #6137 

This splits the `onlineResources` into two lists – 1. the first three items and 2. the remaining items – then hides the second 'remaining' ones behind a toggle button.

When the items aren't visible, clicking the button will reveal the remaining items and give keyboard focus to the first 'remaining' item.

When the items are visible, clicking the button will hide the 'remaining' items and keep focus on the clicked button.

![image](https://user-images.githubusercontent.com/1394592/111492277-72436280-8734-11eb-9edf-e17d9cda914e.png)
