### PR TITLE
Redirect http listener to https

### DIFF
--- a/infrastructure/modules/alb/main.tf
+++ b/infrastructure/modules/alb/main.tf
@@ -27,8 +27,13 @@ resource "aws_alb_listener" "http" {
   protocol = "HTTP"
 
   default_action {
-    target_group_arn = aws_alb_target_group.ecs_service_default.arn
-    type = "forward"
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
   }
 }
 


### PR DESCRIPTION
## Who is this for?

Folk who never want a nice secure connection always

## What is it doing for them?

Redirecting any http requests that come into our load balancers to https.