### PR TITLE
Center landscape

### DIFF
--- a/common/views/components/MainViewerPrototype/MainViewerPrototype.tsx
+++ b/common/views/components/MainViewerPrototype/MainViewerPrototype.tsx
@@ -341,7 +341,7 @@ const MainViewer: FunctionComponent<Props> = ({
 
       if (isLandscape) {
         const ratio = currentCanvas.height / currentCanvas.width;
-        const renderedHeight = mainAreaWidth * ratio * 0.8;
+        const renderedHeight = mainAreaWidth * ratio * 0.8; // TODO: 0.8 = 80% max-width image in container. Variable.
         const heightOfPreviousItems =
           canvasIndex * (viewer?.props.itemSize || 0);
         const distanceToScroll =

--- a/common/views/components/MainViewerPrototype/MainViewerPrototype.tsx
+++ b/common/views/components/MainViewerPrototype/MainViewerPrototype.tsx
@@ -330,25 +330,26 @@ const MainViewer: FunctionComponent<Props> = ({
     }, 500);
   }
 
-  // Vertically center the first canvas if it's landscape
-  useEffect(() => {
-    const currentCanvas = canvases[canvasIndex];
-
-    if (currentCanvas.width > currentCanvas.height) {
-      mainViewerRef?.current?.scrollToItem(canvasIndex, 'center');
-    }
-  }, []);
-
   function handleOnItemsRendered() {
     setIsProgrammaticScroll(false);
     let currentCanvas;
     if (firstRenderRef.current) {
       setActiveIndex(canvasIndex);
-      mainViewerRef &&
-        mainViewerRef.current &&
-        mainViewerRef.current.scrollToItem(canvasIndex, 'start');
-      setFirstRender(false);
       currentCanvas = canvases && canvases[canvasIndex];
+      const viewer = mainViewerRef?.current;
+      const isLandscape = currentCanvas.width > currentCanvas.height;
+
+      if (isLandscape && canvasIndex === 0) {
+        const ratio = currentCanvas.height / currentCanvas.width;
+        const renderedHeight = mainAreaWidth * ratio * 0.8;
+        const distanceToScroll =
+          ((viewer?.props.itemSize || 0) - renderedHeight) / 2;
+        viewer?.scrollTo(distanceToScroll);
+      } else {
+        viewer &&
+          viewer.scrollToItem(canvasIndex, isLandscape ? 'center' : 'start');
+      }
+      setFirstRender(false);
       const mainImageService = {
         '@id': currentCanvas
           ? currentCanvas.images[0].resource.service['@id']

--- a/common/views/components/MainViewerPrototype/MainViewerPrototype.tsx
+++ b/common/views/components/MainViewerPrototype/MainViewerPrototype.tsx
@@ -339,6 +339,12 @@ const MainViewer: FunctionComponent<Props> = ({
       const viewer = mainViewerRef?.current;
       const isLandscape = currentCanvas.width > currentCanvas.height;
 
+      // If an image is landscape, it will tend to appear too low in the viewport
+      // on account of the FixedSizedList necessarily being comprised of square items.
+      // To circumvent this, if the image is landscape
+      // 1. We calculate the rendered height of the image
+      // 2. We half the difference between that and the square item it sits inside
+      // 3. We scroll that distance, putting the top of the image at the top of the viewport
       if (isLandscape) {
         const ratio = currentCanvas.height / currentCanvas.width;
         const renderedHeight = mainAreaWidth * ratio * 0.8; // TODO: 0.8 = 80% max-width image in container. Variable.

--- a/common/views/components/MainViewerPrototype/MainViewerPrototype.tsx
+++ b/common/views/components/MainViewerPrototype/MainViewerPrototype.tsx
@@ -349,7 +349,7 @@ const MainViewer: FunctionComponent<Props> = ({
           ((viewer?.props.itemSize || 0) - renderedHeight) / 2;
         viewer?.scrollTo(distanceToScroll);
       } else {
-        viewer && viewer.scrollToItem(canvasIndex, 'start');
+        viewer?.scrollToItem(canvasIndex, 'start');
       }
       setFirstRender(false);
       const mainImageService = {

--- a/common/views/components/MainViewerPrototype/MainViewerPrototype.tsx
+++ b/common/views/components/MainViewerPrototype/MainViewerPrototype.tsx
@@ -339,15 +339,17 @@ const MainViewer: FunctionComponent<Props> = ({
       const viewer = mainViewerRef?.current;
       const isLandscape = currentCanvas.width > currentCanvas.height;
 
-      if (isLandscape && canvasIndex === 0) {
+      if (isLandscape) {
         const ratio = currentCanvas.height / currentCanvas.width;
         const renderedHeight = mainAreaWidth * ratio * 0.8;
+        const heightOfPreviousItems =
+          canvasIndex * (viewer?.props.itemSize || 0);
         const distanceToScroll =
+          heightOfPreviousItems +
           ((viewer?.props.itemSize || 0) - renderedHeight) / 2;
         viewer?.scrollTo(distanceToScroll);
       } else {
-        viewer &&
-          viewer.scrollToItem(canvasIndex, isLandscape ? 'center' : 'start');
+        viewer && viewer.scrollToItem(canvasIndex, 'start');
       }
       setFirstRender(false);
       const mainImageService = {

--- a/common/views/components/MainViewerPrototype/MainViewerPrototype.tsx
+++ b/common/views/components/MainViewerPrototype/MainViewerPrototype.tsx
@@ -330,6 +330,15 @@ const MainViewer: FunctionComponent<Props> = ({
     }, 500);
   }
 
+  // Vertically center the first canvas if it's landscape
+  useEffect(() => {
+    const currentCanvas = canvases[canvasIndex];
+
+    if (currentCanvas.width > currentCanvas.height) {
+      mainViewerRef?.current?.scrollToItem(canvasIndex, 'center');
+    }
+  }, []);
+
   function handleOnItemsRendered() {
     setIsProgrammaticScroll(false);
     let currentCanvas;


### PR DESCRIPTION
Addresses #5097 

I'm not sure this is a good idea – the maths and the slightly niche conditionals make me feel not that great. But it's a way to address the issue of landscape images appearing low in the viewport.

On first render, and only if the image is landscape:
1. We calculate the rendered height of the image
2. We half the difference between that and the square item it sits inside
3. We scroll that distance, putting the top of the image at the top of the viewport