### PR TITLE
Go to start of page from clicking grid thumb

### DIFF
--- a/common/views/components/IIIFViewerPrototype/GridViewerPrototype.tsx
+++ b/common/views/components/IIIFViewerPrototype/GridViewerPrototype.tsx
@@ -86,7 +86,7 @@ const Cell = memo(({ columnIndex, rowIndex, style, data }: CellProps) => {
               clickHandler={() => {
                 mainViewerRef &&
                   mainViewerRef.current &&
-                  mainViewerRef.current.scrollToItem(itemIndex);
+                  mainViewerRef.current.scrollToItem(itemIndex, 'start');
                 setActiveIndex(itemIndex);
                 setGridVisible(false);
               }}


### PR DESCRIPTION
## Who is this for?
People who expect to arrive at the beginning of a page when selecting a thumbnail from the grid view.

## What is it doing for them?
That.