### PR TITLE
Show where to find it section if onlineResources toggle is on

### DIFF
--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -456,9 +456,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
         </WorkDetailsSection>
       )}
 
-      {!digitalLocation &&
-        !onlineResourcesPrototype &&
-        (locationOfWork || encoreLink) && <WhereToFindIt />}
+      {!digitalLocation && (locationOfWork || encoreLink) && <WhereToFindIt />}
 
       {work.images && work.images.length > 0 && (
         <WorkDetailsSection


### PR DESCRIPTION
The `onlineResources` toggle is incorrectly hiding the 'Where to find it section' if it's turned on.
