### PR TITLE
Fix online resources label/position

### DIFF
--- a/catalogue/webapp/components/WorkDetails/OnlineResources.tsx
+++ b/catalogue/webapp/components/WorkDetails/OnlineResources.tsx
@@ -53,7 +53,7 @@ const OnlineResources: FunctionComponent<Props> = ({ work }: Props) => {
   }, [isShowingRemainingOnlineResources]);
 
   return onlineResources.length > 0 ? (
-    <WorkDetailsSection headingText="Available online">
+    <WorkDetailsSection headingText="Online resources">
       <ul
         className={classNames({
           'plain-list no-margin no-padding': true,

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -238,8 +238,6 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
 
   const Content = () => (
     <>
-      {onlineResourcesPrototype && <OnlineResources work={work} />}
-
       {digitalLocation && itemLinkState !== 'useNoLink' && (
         <WorkDetailsSection
           headingText="Available online"
@@ -455,6 +453,8 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
           )}
         </WorkDetailsSection>
       )}
+
+      {onlineResourcesPrototype && <OnlineResources work={work} />}
 
       {!digitalLocation && (locationOfWork || encoreLink) && <WhereToFindIt />}
 


### PR DESCRIPTION
> In this instance, we have two types of digital location: an Online resource and a IIIF Presentation manifest. We currently assume both types are "Available online" - which in a sense they are. However, there's no guarantee that the resource link is a link to a digital surrogate (equivalent to the IIIF Presentation manifest). In this case, the online resource is supplementary information about the item, rather than a digital copy of the item itself.

This pr keeps the IIIF manifest information as 'Available online', and relables any `onlineResources` links as 'Online resources'.

![image](https://user-images.githubusercontent.com/1394592/112822289-ad705a80-907f-11eb-8159-0785138f7ba4.png)
