### PR TITLE
Test viewer scenarios 6 7 8 9

### DIFF
--- a/common/views/components/IIIFSearchWithin/IIIFSearchWithin.tsx
+++ b/common/views/components/IIIFSearchWithin/IIIFSearchWithin.tsx
@@ -150,7 +150,7 @@ const IIIFSearchWithin: FunctionComponent<Props> = ({
       <div aria-live="polite">
         {isLoading && <Loading />}
         {searchResults.within.total !== null && (
-          <ResultsHeader>
+          <ResultsHeader data-test-id="results-header">
             {searchResults.within.total}{' '}
             {searchResults.within.total === 1 ? 'result' : 'results'}
           </ResultsHeader>

--- a/common/views/components/IIIFViewerPrototype/ViewerSidebarPrototype.tsx
+++ b/common/views/components/IIIFViewerPrototype/ViewerSidebarPrototype.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, useState, useContext } from 'react';
+import { FunctionComponent, useState, useContext, ReactNode } from 'react';
 import WorkLink from '../WorkLink/WorkLink';
 import Icon from '../Icon/Icon';
 import styled from 'styled-components';
@@ -82,10 +82,18 @@ const Item = styled.div`
   }
 `;
 
-const AccordionItem = ({ title, children }) => {
+const AccordionItem = ({
+  title,
+  children,
+  testId,
+}: {
+  title: string;
+  children: ReactNode;
+  testId?: string;
+}) => {
   const [isActive, setIsActive] = useState(false);
   return (
-    <Item>
+    <Item data-test-id={testId}>
       <AccordionInner
         onClick={() => setIsActive(!isActive)}
         className={classNames({
@@ -177,6 +185,7 @@ const ViewerSidebarPrototype: FunctionComponent<Props> = ({
         )}
         {currentManifestLabel && (
           <span
+            data-test-id="current-manifest"
             className={classNames({
               [font('hnl', 5)]: true,
             })}
@@ -249,17 +258,18 @@ const ViewerSidebarPrototype: FunctionComponent<Props> = ({
           </div>
         </AccordionItem>
         {manifest && manifest.structures && manifest.structures.length > 0 && (
-          <AccordionItem title={'Contents'}>
+          <AccordionItem title={'Contents'} testId="accordion-item-contents">
             <ViewerStructuresPrototype mainViewerRef={mainViewerRef} />
           </AccordionItem>
         )}
         {parentManifest && parentManifest.manifests && (
-          <AccordionItem title={'Volumes'}>
+          <AccordionItem title={'Volumes'} testId="accordion-item-volumes">
             <MultipleManifestListPrototype />
           </AccordionItem>
         )}
       </div>
-      {searchService && itemViewerPrototypeWithSearch && (
+      {/* {searchService && itemViewerPrototypeWithSearch && ( */}
+      {true && (
         <Inner>
           <IIIFSearchWithin mainViewerRef={mainViewerRef} />
         </Inner>

--- a/common/views/components/IIIFViewerPrototype/ViewerSidebarPrototype.tsx
+++ b/common/views/components/IIIFViewerPrototype/ViewerSidebarPrototype.tsx
@@ -268,8 +268,7 @@ const ViewerSidebarPrototype: FunctionComponent<Props> = ({
           </AccordionItem>
         )}
       </div>
-      {/* {searchService && itemViewerPrototypeWithSearch && ( */}
-      {true && (
+      {searchService && itemViewerPrototypeWithSearch && (
         <Inner>
           <IIIFSearchWithin mainViewerRef={mainViewerRef} />
         </Inner>

--- a/common/views/components/IIIFViewerPrototype/ViewerTopBarPrototype.tsx
+++ b/common/views/components/IIIFViewerPrototype/ViewerTopBarPrototype.tsx
@@ -166,8 +166,9 @@ const ViewerTopBar: FunctionComponent<Props> = ({
       <MiddleZone>
         {canvases && canvases.length > 1 && !showZoomed && (
           <>
-            {`${activeIndex + 1 || ''} / ${(canvases && canvases.length) ||
-              ''}`}{' '}
+            <span data-test-id="active-index">{`${activeIndex + 1 ||
+              ''}`}</span>
+            {` / ${(canvases && canvases.length) || ''}`}{' '}
             {!(canvases[activeIndex].label.trim() === '-') &&
               `(page ${canvases[activeIndex].label.trim()})`}
           </>

--- a/common/views/components/MainViewerPrototype/MainViewerPrototype.tsx
+++ b/common/views/components/MainViewerPrototype/MainViewerPrototype.tsx
@@ -358,31 +358,33 @@ const MainViewer: FunctionComponent<Props> = ({
   }, [canvasIndex]);
 
   return (
-    <FixedSizeList
-      width={mainAreaWidth}
-      style={{ width: `${mainAreaWidth}px`, margin: '0 auto' }}
-      height={mainAreaHeight}
-      itemCount={canvases.length}
-      itemData={{
-        scrollVelocity,
-        isProgrammaticScroll,
-        canvases,
-        setShowZoomed,
-        setZoomInfoUrl,
-        rotatedImages,
-        setActiveIndex,
-        setIsLoading,
-        ocrText,
-        mainAreaRef,
-        errorHandler,
-      }}
-      itemSize={mainAreaWidth}
-      onItemsRendered={debounceHandleOnItemsRendered.current}
-      onScroll={handleOnScroll}
-      ref={mainViewerRef}
-    >
-      {ItemRenderer}
-    </FixedSizeList>
+    <div data-test-id="main-viewer">
+      <FixedSizeList
+        width={mainAreaWidth}
+        style={{ width: `${mainAreaWidth}px`, margin: '0 auto' }}
+        height={mainAreaHeight}
+        itemCount={canvases.length}
+        itemData={{
+          scrollVelocity,
+          isProgrammaticScroll,
+          canvases,
+          setShowZoomed,
+          setZoomInfoUrl,
+          rotatedImages,
+          setActiveIndex,
+          setIsLoading,
+          ocrText,
+          mainAreaRef,
+          errorHandler,
+        }}
+        itemSize={mainAreaWidth}
+        onItemsRendered={debounceHandleOnItemsRendered.current}
+        onScroll={handleOnScroll}
+        ref={mainViewerRef}
+      >
+        {ItemRenderer}
+      </FixedSizeList>
+    </div>
   );
 };
 

--- a/common/views/components/MultipleManifestListPrototype/MultipleManifestListPrototype.tsx
+++ b/common/views/components/MultipleManifestListPrototype/MultipleManifestListPrototype.tsx
@@ -3,13 +3,18 @@ import NextLink from 'next/link';
 import { itemLink } from '@weco/common/services/catalogue/routes';
 import ItemViewerContext from '../ItemViewerContext/ItemViewerContext';
 import { classNames } from '@weco/common/utils/classnames';
+import { volumesNavigationLabel } from '@weco/common/text/arial-labels';
 
 const MultipleManifestListPrototype: FunctionComponent = () => {
   const { parentManifest, work, lang, manifestIndex } = useContext(
     ItemViewerContext
   );
   return (
-    <ul className="no-margin no-padding plain-list">
+    <ul
+      className="no-margin no-padding plain-list"
+      role="navigation"
+      aria-label={volumesNavigationLabel}
+    >
       {parentManifest?.manifests.map((manifest, i) => (
         <li key={manifest['@id']}>
           <NextLink

--- a/playwright/test/contexts.ts
+++ b/playwright/test/contexts.ts
@@ -4,6 +4,10 @@ const multiVolumeItem = async (): Promise<void> => {
   await page.goto(`${baseUrl}/works/mg56yqa4/items`);
 };
 
+const itemWithSearchAndStructures = async (): Promise<void> => {
+  await page.goto(`${baseUrl}/works/re9cyhkt/items`);
+};
+
 const worksSearch = async (): Promise<void> => {
   // This is because the cookie notice actually hides interface.
   // It should also not live here, but I was battling on getting it to
@@ -22,4 +26,4 @@ const worksSearch = async (): Promise<void> => {
 
 export const isMobile = Boolean(deviceName);
 
-export { multiVolumeItem, worksSearch };
+export { multiVolumeItem, worksSearch, itemWithSearchAndStructures };

--- a/playwright/test/selectors/item.ts
+++ b/playwright/test/selectors/item.ts
@@ -1,3 +1,8 @@
 export const zoomInButton = `[data-test-id="zoom-in-button"] button`;
 export const openseadragonCanvas = `.openseadragon-canvas`;
 export const fullscreenButton = `[data-test-id="fullscreen-button"] button`;
+export const searchWithinResultsHeader = `[data-test-id="results-header"]`;
+export const mainViewer = `[data-test-id=main-viewer] > div`;
+export const activeIndex = `[data-test-id=active-index]`;
+export const accordionItemVolumes = `[data-test-id=accordion-item-volumes]`;
+export const accordionItemContents = `[data-test-id=accordion-item-contents]`;

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -45,7 +45,7 @@ describe('Scenario 1: A user wants a large-scale view of an item', () => {
   });
 });
 
-describe.only('Scenario 6: Item has multiple volumes', () => {
+describe('Scenario 6: Item has multiple volumes', () => {
   test('the volumes should be browsable', async () => {
     if (!isMobile()) {
       await multiVolumeItem();


### PR DESCRIPTION
- updates test for scenario 6 to work with new ui
- adds test for scenarios 7, 8 and 9

Can someone think of a better way of testing the active canvas changed to the correct thing, other than `await page.waitForSelector(`css=[data-test-id=active-index] >> text="68"`)` - with a hard coded value?