### PR TITLE
move jank on search form to mobile version

### DIFF
--- a/common/hooks/useWindowSize.ts
+++ b/common/hooks/useWindowSize.ts
@@ -1,8 +1,7 @@
 import { useState, useEffect } from 'react';
-import theme from '../views/themes/default';
+import theme, { Size } from '../views/themes/default';
 
-type ScreenSize = 'small' | 'medium' | 'large' | 'xlarge';
-export function getScreenSize(): ScreenSize {
+export function getScreenSize(): Size {
   switch (true) {
     case window.innerWidth < theme.sizes.medium:
       return 'small';
@@ -14,8 +13,10 @@ export function getScreenSize(): ScreenSize {
       return 'xlarge';
   }
 }
-export default function useWindowSize(): string {
-  const [size, setSize] = useState('small');
+export default function useWindowSize(
+  initialSize: Size | undefined = 'small'
+): string {
+  const [size, setSize] = useState<Size>(initialSize);
   useEffect(() => {
     function updateSize() {
       setSize(getScreenSize());

--- a/common/views/components/SearchFilters/SearchFilters.tsx
+++ b/common/views/components/SearchFilters/SearchFilters.tsx
@@ -4,7 +4,7 @@ import SearchFiltersDesktop from '../SearchFiltersDesktop/SearchFiltersDesktop';
 import SearchFiltersMobile from '../SearchFiltersMobile/SearchFiltersMobile';
 import { LinkProps } from '../../../model/link-props';
 import { Filter } from '../../../services/catalogue/filters';
-import { cls } from '../../../views/themes/default';
+import useWindowSize from '../../../hooks/useWindowSize';
 
 type Props = {
   query: string;
@@ -23,6 +23,10 @@ const SearchFilters: FunctionComponent<Props> = ({
   filters,
   linkResolver,
 }: Props): ReactElement<Props> => {
+  // We set this as xlarge as the jank is more noticable on desktop,
+  // so we're living with the jank on mobile for now.
+  const size = useWindowSize('xlarge');
+
   const activeFiltersCount = filters
     .map(f => {
       if (f.type === 'checkbox') {
@@ -52,12 +56,11 @@ const SearchFilters: FunctionComponent<Props> = ({
 
   return (
     <>
-      <div className={cls.medium.displayNone}>
+      {size === 'small' ? (
         <SearchFiltersMobile {...sharedProps} />
-      </div>
-      <div className={`${cls.displayNone} ${cls.medium.displayBlock}`}>
+      ) : (
         <SearchFiltersDesktop {...sharedProps} />
-      </div>
+      )}
     </>
   );
 };

--- a/common/views/themes/default.ts
+++ b/common/views/themes/default.ts
@@ -165,7 +165,7 @@ function makeSpacePropertyValues(
 // https://github.com/styled-components/styled-components/blob/master/docs/tips-and-tricks.md#media-templates
 // using min-width because of
 // https://zellwk.com/blog/how-to-write-mobile-first-css/
-type Size = keyof typeof themeValues.sizes;
+export type Size = keyof typeof themeValues.sizes;
 type MediaMethodArgs = [
   TemplateStringsArray | CSSObject,
   SimpleInterpolation[]


### PR DESCRIPTION
Ref: #6268

Moves the jank to the mobile version as when we use CSS there are as twice as many form elements in the DOM, which causes loads of issues.