### PR TITLE
Add resize-observer-types

### DIFF
--- a/common/views/components/IIIFViewerPrototype/IIIFViewerPrototype.tsx
+++ b/common/views/components/IIIFViewerPrototype/IIIFViewerPrototype.tsx
@@ -271,15 +271,10 @@ const IIIFViewerPrototype: FunctionComponent<IIIFViewerProps> = ({
     setIsDesktopSidebarActive(!showZoomed);
   }, [showZoomed]);
 
-  // TODO: check for intersectionObservers (previous version of isEnhanced)
-  // TODO: add testing and possibly fallbacks
   useEffect(() => {
     let timer;
     let previousActiveIndex;
 
-    // TODO: either polyfill ts-ignore
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
     const mainAreaObserver = new ResizeObserver(([mainArea]) => {
       clearTimeout(timer);
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/wellcomecollection/wellcomecollection.org#readme",
   "devDependencies": {
+    "@types/resize-observer-browser": "^0.1.5",
     "@types/styled-components": "^5.1.2",
     "@typescript-eslint/eslint-plugin": "^4.15.1",
     "@typescript-eslint/parser": "^4.15.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5553,6 +5553,11 @@
   dependencies:
     "@types/react" "*"
 
+"@types/resize-observer-browser@^0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@types/resize-observer-browser/-/resize-observer-browser-0.1.5.tgz#36d897708172ac2380cd486da7a3daf1161c1e23"
+  integrity sha512-8k/67Z95Goa6Lznuykxkfhq9YU3l1Qe6LNZmwde1u7802a3x8v44oq0j91DICclxatTr0rNnhXx7+VTIetSrSQ==
+
 "@types/responselike@*", "@types/responselike@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/responselike/-/responselike-1.0.0.tgz#251f4fe7d154d2bad125abe1b429b23afd262e29"


### PR DESCRIPTION
`ResizeObserver` isn't an experimental browser feature anymore, but it hasn't made it into TypeScript core yet. After reading[ this issue](https://github.com/Microsoft/TypeScript/issues/28502) it isn't clear to me why it hasn't. It's presumably round the corner, but while we're waiting for that, this adds the types from DefinitelyTyped.
