### PR TITLE
Project format

### DIFF
--- a/common/services/prismic/fetch-links.js
+++ b/common/services/prismic/fetch-links.js
@@ -113,5 +113,7 @@ export const pagesFormatsFields = [
   'page-formats.description',
   'guide-formats.title',
   'guide-formats.description',
+  'project-formats.title',
+  'project-formats.description',
 ];
 export const labelsFields = ['labels.title', 'labels.description'];

--- a/common/views/components/LabelsList/LabelsList.js
+++ b/common/views/components/LabelsList/LabelsList.js
@@ -4,7 +4,7 @@ import Label from '../../components/Label/Label';
 // $FlowFixMe (tsx)
 import Space from '../styled/Space';
 
-type Props = {|
+export type Props = {|
   labels: {|
     ...LabelType,
     labelColor?: LabelColor,

--- a/content/webapp/pages/page.js
+++ b/content/webapp/pages/page.js
@@ -75,7 +75,8 @@ export class Page extends Component<Props> {
       <HTMLDate date={new Date(page.datePublished)} />
     );
     const isLanding = page.format && page.format.id === PageFormatIds.Landing;
-    const labels = isLanding ? null : makeLabels(page.format?.title);
+    const labels =
+      !isLanding && page.format?.title ? makeLabels(page.format?.title) : null;
 
     const backgroundTexture = isLanding
       ? landingHeaderBackgroundLs

--- a/content/webapp/pages/page.js
+++ b/content/webapp/pages/page.js
@@ -39,6 +39,7 @@ import SectionHeader from '@weco/common/views/components/SectionHeader/SectionHe
 import { PageFormatIds } from '@weco/common/model/content-format-id';
 // $FlowFixMe (tsx)
 import { links } from '@weco/common/views/components/Header/Header';
+import { type Props as LabelsListProps } from '@weco/common/views/components/LabelsList/LabelsList';
 
 type Props = {|
   page: PageType,
@@ -63,11 +64,19 @@ export class Page extends Component<Props> {
   };
 
   render() {
+    function makeLabels(title?: string): ?LabelsListProps {
+      if (!title) return null;
+
+      return { labels: [{ text: title }] };
+    }
+
     const { page, siblings, children } = this.props;
     const DateInfo = page.datePublished && (
       <HTMLDate date={new Date(page.datePublished)} />
     );
     const isLanding = page.format && page.format.id === PageFormatIds.Landing;
+    const labels = isLanding ? null : makeLabels(page.format?.title);
+
     const backgroundTexture = isLanding
       ? landingHeaderBackgroundLs
       : headerBackgroundLs;
@@ -133,7 +142,7 @@ export class Page extends Component<Props> {
     const Header = (
       <PageHeader
         breadcrumbs={breadcrumbs}
-        labels={null}
+        labels={labels}
         title={page.title}
         FeaturedMedia={FeaturedMedia}
         Background={displayBackground}


### PR DESCRIPTION
Rendering project formats in the page header for consistency with how we treat other formats.

![image](https://user-images.githubusercontent.com/1394592/114065816-f94aad00-9892-11eb-9cae-4744878f59af.png)


Fixes #6202 
