### PR TITLE
Wait for visibility

### DIFF
--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -48,7 +48,8 @@ describe('Scenario 1: A user wants a large-scale view of an item', () => {
     await page.click(zoomInButton);
     await page.waitForSelector(openseadragonCanvas);
     // make sure we can actually see deep zoom
-    expect(page.isVisible(openseadragonCanvas)).toBeTruthy();
+    const isVisible = await page.isVisible(openseadragonCanvas);
+    expect(isVisible).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
The test for deep zoom visibility is failing intermittently. I think I need to `await` visibility of the selector.