### PR TITLE
Use div for dangerouslySetInnerHTML

### DIFF
--- a/catalogue/webapp/pages/item.tsx
+++ b/catalogue/webapp/pages/item.tsx
@@ -292,14 +292,18 @@ const ItemPage: NextPage<Props> = ({
             <h2 className={font('hnm', 4)}>{authService?.label}</h2>
           )}
           {authService?.description && (
-            <p
+            <div
               dangerouslySetInnerHTML={{
                 __html: authService?.description,
               }}
             />
           )}
           {authService?.['@id'] && origin && (
-            <Space as="span" h={{ size: 'm', properties: ['margin-right'] }}>
+            <Space
+              className={'flex flex-inline'}
+              h={{ size: 'm', properties: ['margin-right'] }}
+              v={{ size: 'm', properties: ['margin-top'] }}
+            >
               <ButtonSolid
                 text="Show the content"
                 clickHandler={() => {


### PR DESCRIPTION
Fixes #6339

Having `dangerouslySetInnerHTML` within a `<p>` where the first part of the `authService.description` contained a `<p>` itself would result in invalid markup which the browser would fail to render. Putting it in a `<div>` instead means any nested elements should be valid.
