### PR TITLE
use image API error in response

### DIFF
--- a/catalogue/webapp/pages/image.tsx
+++ b/catalogue/webapp/pages/image.tsx
@@ -148,7 +148,7 @@ export const getServerSideProps: GetServerSideProps<
     if (image.httpStatus === 404) {
       return { notFound: true };
     }
-    return appError(context, image.httpStatus, 'Images API error');
+    return appError(context, image.httpStatus, image.description);
   }
 
   // This is to avoid exposing a URL that has a valid `imageId` in it


### PR DESCRIPTION
To help people know why they might be getting an error / a work isn't available.