### PR TITLE
Use read-only roles to access remote Terraform state

### DIFF
--- a/cache/terraform.tf
+++ b/cache/terraform.tf
@@ -26,7 +26,7 @@ data "terraform_remote_state" "router" {
     bucket   = "wellcomecollection-infra"
     key      = "build-state/router.tfstate"
     region   = "eu-west-1"
-    role_arn = "arn:aws:iam::130871440101:role/experience-developer"
+    role_arn = "arn:aws:iam::130871440101:role/experience-read_only"
   }
 }
 
@@ -34,7 +34,7 @@ data "terraform_remote_state" "experience" {
   backend = "s3"
 
   config = {
-    role_arn = "arn:aws:iam::130871440101:role/experience-developer"
+    role_arn = "arn:aws:iam::130871440101:role/experience-read_only"
     bucket   = "wellcomecollection-experience-infra"
     key      = "terraform/experience.tfstate"
     region   = "eu-west-1"
@@ -48,7 +48,7 @@ data "terraform_remote_state" "assets" {
     bucket   = "wellcomecollection-infra"
     key      = "build-state/router.tfstate"
     region   = "eu-west-1"
-    role_arn = "arn:aws:iam::130871440101:role/experience-developer"
+    role_arn = "arn:aws:iam::130871440101:role/experience-read_only"
   }
 }
 

--- a/catalogue/terraform/data.tf
+++ b/catalogue/terraform/data.tf
@@ -2,7 +2,7 @@ data "terraform_remote_state" "experience_shared" {
   backend = "s3"
 
   config = {
-    role_arn = "arn:aws:iam::130871440101:role/experience-developer"
+    role_arn = "arn:aws:iam::130871440101:role/experience-read_only"
 
     bucket = "wellcomecollection-experience-infra"
     key    = "terraform/experience.tfstate"

--- a/catalogue/terraform/stack/data.tf
+++ b/catalogue/terraform/stack/data.tf
@@ -4,7 +4,7 @@ data "terraform_remote_state" "infra_shared" {
   config = {
     bucket   = "wellcomecollection-platform-infra"
     key      = "terraform/platform-infrastructure/accounts/experience.tfstate"
-    role_arn = "arn:aws:iam::760097843905:role/platform-developer"
+    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
     region   = "eu-west-1"
   }
 }

--- a/content/terraform/data.tf
+++ b/content/terraform/data.tf
@@ -2,7 +2,7 @@ data "terraform_remote_state" "experience_shared" {
   backend = "s3"
 
   config = {
-    role_arn = "arn:aws:iam::130871440101:role/experience-developer"
+    role_arn = "arn:aws:iam::130871440101:role/experience-read_only"
 
     bucket = "wellcomecollection-experience-infra"
     key    = "terraform/experience.tfstate"

--- a/content/terraform/stack/data.tf
+++ b/content/terraform/stack/data.tf
@@ -4,7 +4,7 @@ data "terraform_remote_state" "infra_shared" {
   config = {
     bucket   = "wellcomecollection-platform-infra"
     key      = "terraform/platform-infrastructure/accounts/experience.tfstate"
-    role_arn = "arn:aws:iam::760097843905:role/platform-developer"
+    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
     region   = "eu-west-1"
   }
 }

--- a/identity-admin/terraform/data.tf
+++ b/identity-admin/terraform/data.tf
@@ -2,7 +2,7 @@ data "terraform_remote_state" "identity-experience_shared" {
   backend = "s3"
 
   config = {
-   role_arn = "arn:aws:iam::770700576653:role/identity-developer"
+   role_arn = "arn:aws:iam::770700576653:role/identity-read_only"
     bucket  = "wellcomecollection-identity-experience-infra"
     key     = "terraform/identity-experience.tfstate"
     region  = "eu-west-1"
@@ -15,7 +15,7 @@ data "terraform_remote_state" "infra_shared" {
   config = {
     bucket   = "wellcomecollection-platform-infra"
     key      = "terraform/platform-infrastructure/accounts/identity.tfstate"
-    role_arn = "arn:aws:iam::760097843905:role/platform-developer"
+    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
     region   = "eu-west-1"
   }
 }

--- a/identity/terraform/data.tf
+++ b/identity/terraform/data.tf
@@ -2,7 +2,7 @@ data "terraform_remote_state" "experience_shared" {
   backend = "s3"
 
   config = {
-    role_arn = "arn:aws:iam::130871440101:role/experience-developer"
+    role_arn = "arn:aws:iam::130871440101:role/experience-read_only"
 
     bucket = "wellcomecollection-experience-infra"
     key    = "terraform/experience.tfstate"

--- a/identity/terraform/stack/data.tf
+++ b/identity/terraform/stack/data.tf
@@ -4,7 +4,7 @@ data "terraform_remote_state" "infra_shared" {
   config = {
     bucket   = "wellcomecollection-platform-infra"
     key      = "terraform/platform-infrastructure/accounts/experience.tfstate"
-    role_arn = "arn:aws:iam::760097843905:role/platform-developer"
+    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
     region   = "eu-west-1"
   }
 }

--- a/preview/terraform/data.tf
+++ b/preview/terraform/data.tf
@@ -2,7 +2,7 @@ data "terraform_remote_state" "experience" {
   backend = "s3"
 
   config = {
-    role_arn       = "arn:aws:iam::130871440101:role/experience-developer"
+    role_arn       = "arn:aws:iam::130871440101:role/experience-read_only"
     bucket         = "wellcomecollection-experience-infra"
     key            = "terraform/experience.tfstate"
     region         = "eu-west-1"
@@ -16,6 +16,6 @@ data "terraform_remote_state" "cache" {
     key            = "build-state/cache.tfstate"
     region         = "eu-west-1"
     bucket         = "wellcomecollection-infra"
-    role_arn       = "arn:aws:iam::130871440101:role/experience-developer"
+    role_arn       = "arn:aws:iam::130871440101:role/experience-read_only"
   }
 }


### PR DESCRIPTION
## Who is this for?
This isn’t “for” anyone; it’s just a general good practice we’ve adopted elsewhere in the platform. Fetching remote state doesn’t require anything more than read-only permissions, so that’s what we use.

I have some Python bits I can cobble together to find them:

```python
import os
from pprint import pprint

import hcl

def get_file_paths_under(root):
    """Generates the paths to every file under ``root``."""
    if not os.path.isdir(root):
        raise ValueError(f"Cannot find files under non-existent directory: {root!r}")

    for dirpath, _, filenames in os.walk(root):
        for f in filenames:
            if os.path.isfile(os.path.join(dirpath, f)):
                yield os.path.join(dirpath, f)

for f in get_file_paths_under("."):
    if not f.endswith(".tf"):
        continue
    
    if ".terraform" in f:
        continue
    
    if "node_modules" in f:
        continue
    
    try:
        tf = hcl.load(open(f))
    except ValueError:
        print("!!!", f)
    
    for remote_state_id, remote_state_config in tf.get('data', {}).get('terraform_remote_state', {}).items():
        role_arn = remote_state_config['config']['role_arn']
        if role_arn.endswith('-developer'):
            print(f, remote_state_id)
```

## What is it doing for them?
Following the principle of least privilege.
