### PR TITLE
Testing new iiif manifest source

### DIFF
--- a/catalogue/webapp/pages/item.tsx
+++ b/catalogue/webapp/pages/item.tsx
@@ -13,7 +13,7 @@ import {
   isUiEnabled,
   getAuthService,
   getTokenService,
-  convertPresentationUrlToStage,
+  getToggleDeterminedIIIFManifest,
 } from '@weco/common/utils/iiif';
 import { getWork, getCanvasOcr } from '../services/catalogue/works';
 import CataloguePageLayout from '@weco/common/views/components/CataloguePageLayout/CataloguePageLayout';
@@ -440,18 +440,12 @@ export const getServerSideProps: GetServerSideProps<
   )?.url;
   const iiifImageLocation = getDigitalLocationOfType(work, 'iiif-image');
 
-  let manifestOrCollection;
-  if (globalContextData.toggles.switchIIIFManifestSource) {
-    const iiifPresentationUrlOnStage =
-      iiifPresentationUrl && convertPresentationUrlToStage(iiifPresentationUrl);
-    manifestOrCollection = iiifPresentationUrlOnStage
-      ? await fetchJson(iiifPresentationUrlOnStage)
-      : undefined;
-  } else {
-    manifestOrCollection = iiifPresentationUrl
-      ? await fetchJson(iiifPresentationUrl)
-      : undefined;
-  }
+  const manifestOrCollection =
+    iiifPresentationUrl &&
+    (await getToggleDeterminedIIIFManifest(
+      globalContextData.toggles.switchIIIFManifestSource,
+      iiifPresentationUrl
+    ));
 
   if (manifestOrCollection) {
     // This happens when the main manifest is actually a Collection (manifest of manifest).

--- a/catalogue/webapp/pages/item.tsx
+++ b/catalogue/webapp/pages/item.tsx
@@ -13,6 +13,7 @@ import {
   isUiEnabled,
   getAuthService,
   getTokenService,
+  convertPresentationUrlToStage,
 } from '@weco/common/utils/iiif';
 import { getWork, getCanvasOcr } from '../services/catalogue/works';
 import CataloguePageLayout from '@weco/common/views/components/CataloguePageLayout/CataloguePageLayout';
@@ -439,9 +440,18 @@ export const getServerSideProps: GetServerSideProps<
   )?.url;
   const iiifImageLocation = getDigitalLocationOfType(work, 'iiif-image');
 
-  const manifestOrCollection = iiifPresentationUrl
-    ? await fetchJson(iiifPresentationUrl)
-    : undefined;
+  let manifestOrCollection;
+  if (globalContextData.toggles.switchIIIFManifestSource) {
+    const iiifPresentationUrlOnStage =
+      iiifPresentationUrl && convertPresentationUrlToStage(iiifPresentationUrl);
+    manifestOrCollection = iiifPresentationUrlOnStage
+      ? await fetchJson(iiifPresentationUrlOnStage)
+      : undefined;
+  } else {
+    manifestOrCollection = iiifPresentationUrl
+      ? await fetchJson(iiifPresentationUrl)
+      : undefined;
+  }
 
   if (manifestOrCollection) {
     // This happens when the main manifest is actually a Collection (manifest of manifest).

--- a/common/hooks/useIIIFManifestData.ts
+++ b/common/hooks/useIIIFManifestData.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useContext } from 'react';
 import {
   getAudio,
   getCanvases,
@@ -8,10 +8,12 @@ import {
   getUiExtensions,
   getVideo,
   isUiEnabled,
+  convertPresentationUrlToStage,
 } from '../utils/iiif';
 import { Work } from '../model/catalogue';
 import { IIIFManifest, IIIFMediaElement, IIIFRendering } from '../model/iiif';
 import { getDigitalLocationOfType } from '../utils/works';
+import TogglesContext from '../views/components/TogglesContext/TogglesContext';
 
 type IIIFManifestData = {
   imageCount: number;
@@ -40,7 +42,6 @@ function parseManifest(manifest: IIIFManifest): IIIFManifestData {
     'mediaDownload'
   );
   const firstChildManifestLocation = getFirstChildManifestLocation(manifest);
-
   return {
     imageCount,
     childManifestsCount,
@@ -61,6 +62,7 @@ const useIIIFManifestData = (work: Work): IIIFManifestData => {
     imageCount: 0,
     childManifestsCount: 0,
   });
+  const toggles = useContext(TogglesContext);
 
   useEffect(() => {
     const fetchIIIFPresentationManifest = async (work: Work) => {
@@ -71,14 +73,23 @@ const useIIIFManifestData = (work: Work): IIIFManifestData => {
           'iiif-presentation'
         );
 
-        const iiifManifestResp =
-          iiifPresentationLocation &&
-          (await fetch(iiifPresentationLocation.url));
+        let iiifManifestResp;
+        if (toggles.switchIIIFManifestSource) {
+          const iiifPresentationUrlOnStage =
+            iiifPresentationLocation &&
+            convertPresentationUrlToStage(iiifPresentationLocation.url);
+          iiifManifestResp = iiifPresentationUrlOnStage
+            ? await fetch(iiifPresentationUrlOnStage)
+            : undefined;
+        } else {
+          iiifManifestResp = iiifPresentationLocation
+            ? await fetch(iiifPresentationLocation.url)
+            : undefined;
+        }
 
         if (iiifManifestResp) {
           const iiifManifest = await iiifManifestResp.json();
           const data = parseManifest(iiifManifest);
-
           cachedManifestData.set(work.id, data);
           setManifestData(data);
         }

--- a/common/hooks/useIIIFManifestData.ts
+++ b/common/hooks/useIIIFManifestData.ts
@@ -8,7 +8,7 @@ import {
   getUiExtensions,
   getVideo,
   isUiEnabled,
-  convertPresentationUrlToStage,
+  getToggleDeterminedIIIFManifest,
 } from '../utils/iiif';
 import { Work } from '../model/catalogue';
 import { IIIFManifest, IIIFMediaElement, IIIFRendering } from '../model/iiif';
@@ -73,22 +73,14 @@ const useIIIFManifestData = (work: Work): IIIFManifestData => {
           'iiif-presentation'
         );
 
-        let iiifManifestResp;
-        if (toggles.switchIIIFManifestSource) {
-          const iiifPresentationUrlOnStage =
-            iiifPresentationLocation &&
-            convertPresentationUrlToStage(iiifPresentationLocation.url);
-          iiifManifestResp = iiifPresentationUrlOnStage
-            ? await fetch(iiifPresentationUrlOnStage)
-            : undefined;
-        } else {
-          iiifManifestResp = iiifPresentationLocation
-            ? await fetch(iiifPresentationLocation.url)
-            : undefined;
-        }
+        const iiifManifest =
+          iiifPresentationLocation &&
+          (await getToggleDeterminedIIIFManifest(
+            toggles.switchIIIFManifestSource,
+            iiifPresentationLocation.url
+          ));
 
-        if (iiifManifestResp) {
-          const iiifManifest = await iiifManifestResp.json();
+        if (iiifManifest) {
           const data = parseManifest(iiifManifest);
           cachedManifestData.set(work.id, data);
           setManifestData(data);

--- a/common/model/iiif.ts
+++ b/common/model/iiif.ts
@@ -14,7 +14,7 @@ export type IIIFThumbnailService = {
 
 export type IIIFThumbnail = {
   '@id': string;
-  service: IIIFThumbnailService;
+  service: IIIFThumbnailService | IIIFThumbnailService[];
 };
 
 export type IIIFResource = {

--- a/common/utils/iiif.ts
+++ b/common/utils/iiif.ts
@@ -276,3 +276,20 @@ export function getSearchService(manifest: IIIFManifest): Service | undefined {
     return manifest.service;
   }
 }
+
+// Allows us to test with the iiif manifests served from iiif.wellcomecollection.org
+// e.g. converts http://wellcomelibrary.org/iiif/b28047345/manifest
+// to http://stage.wellcomelibrary.org/iiif/b28047345/manifest
+// which gets redirected to https://iiif.wellcomecollection.org/presentation/v2/b28047345
+export function createIIIFPresentationStageUrl(originalUrl: string): string {
+  const originalUrlObject = new URL(originalUrl);
+  if (originalUrlObject.hostname === 'wellcomelibrary.org') {
+    const stageUrlObject = new URL(
+      originalUrlObject.pathname,
+      `${originalUrlObject.protocol}//stage.wellcomelibrary.org`
+    );
+    return stageUrlObject.href;
+  } else {
+    return originalUrl;
+  }
+}

--- a/common/utils/iiif.ts
+++ b/common/utils/iiif.ts
@@ -281,7 +281,7 @@ export function getSearchService(manifest: IIIFManifest): Service | undefined {
 // e.g. converts http://wellcomelibrary.org/iiif/b28047345/manifest
 // to http://stage.wellcomelibrary.org/iiif/b28047345/manifest
 // which gets redirected to https://iiif.wellcomecollection.org/presentation/v2/b28047345
-export function createIIIFPresentationStageUrl(originalUrl: string): string {
+export function convertPresentationUrlToStage(originalUrl: string): string {
   const originalUrlObject = new URL(originalUrl);
   if (originalUrlObject.hostname === 'wellcomelibrary.org') {
     const stageUrlObject = new URL(

--- a/common/utils/iiif.ts
+++ b/common/utils/iiif.ts
@@ -9,6 +9,7 @@ import {
   AuthService,
   AuthServiceService,
   IIIFAnnotationResource,
+  IIIFThumbnailService,
 } from '../model/iiif';
 import cloneDeep from 'lodash.clonedeep';
 
@@ -274,6 +275,17 @@ export function getSearchService(manifest: IIIFManifest): Service | undefined {
     'http://iiif.io/api/search/0/context.json'
   ) {
     return manifest.service;
+  }
+}
+
+export function getThumbnailService(
+  canvas: IIIFCanvas
+): IIIFThumbnailService | undefined {
+  const service = canvas?.thumbnail?.service;
+  if (Array.isArray(service)) {
+    return service[0];
+  } else {
+    return service;
   }
 }
 

--- a/common/utils/iiif.ts
+++ b/common/utils/iiif.ts
@@ -11,6 +11,7 @@ import {
   IIIFAnnotationResource,
   IIIFThumbnailService,
 } from '../model/iiif';
+import { fetchJson } from '../utils/http';
 import cloneDeep from 'lodash.clonedeep';
 
 export function getServiceId(canvas?: IIIFCanvas): string | undefined {
@@ -293,7 +294,7 @@ export function getThumbnailService(
 // e.g. converts http://wellcomelibrary.org/iiif/b28047345/manifest
 // to http://stage.wellcomelibrary.org/iiif/b28047345/manifest
 // which gets redirected to https://iiif.wellcomecollection.org/presentation/v2/b28047345
-export function convertPresentationUrlToStage(originalUrl: string): string {
+function convertPresentationUrlToStage(originalUrl: string): string {
   const originalUrlObject = new URL(originalUrl);
   if (originalUrlObject.hostname === 'wellcomelibrary.org') {
     const stageUrlObject = new URL(
@@ -303,5 +304,19 @@ export function convertPresentationUrlToStage(originalUrl: string): string {
     return stageUrlObject.href;
   } else {
     return originalUrl;
+  }
+}
+
+export async function getToggleDeterminedIIIFManifest(
+  toggle: boolean,
+  url: string
+): Promise<IIIFManifest> {
+  if (toggle) {
+    const iiifPresentationUrlOnStage = convertPresentationUrlToStage(url);
+    const manifest = await fetchJson(iiifPresentationUrlOnStage);
+    return manifest;
+  } else {
+    const manifest = await fetchJson(url);
+    return manifest;
   }
 }

--- a/common/utils/iiif.ts
+++ b/common/utils/iiif.ts
@@ -279,6 +279,10 @@ export function getSearchService(manifest: IIIFManifest): Service | undefined {
   }
 }
 
+// This is necessary while we are in the process of switching the source of the iiif presentation manifests
+// There is a slight (temporary) difference between the manifest served from wellcomelibrary.org
+// and the one served from iiif.wellcomecollection.org
+// In the former canvas.thumbnail.service is an object and in the latter it is an array.
 export function getThumbnailService(
   canvas: IIIFCanvas
 ): IIIFThumbnailService | undefined {
@@ -289,11 +293,6 @@ export function getThumbnailService(
     return service;
   }
 }
-
-// Allows us to test with the iiif manifests served from iiif.wellcomecollection.org
-// e.g. converts http://wellcomelibrary.org/iiif/b28047345/manifest
-// to http://stage.wellcomelibrary.org/iiif/b28047345/manifest
-// which gets redirected to https://iiif.wellcomecollection.org/presentation/v2/b28047345
 function convertPresentationUrlToStage(originalUrl: string): string {
   const originalUrlObject = new URL(originalUrl);
   if (originalUrlObject.hostname === 'wellcomelibrary.org') {
@@ -307,6 +306,10 @@ function convertPresentationUrlToStage(originalUrl: string): string {
   }
 }
 
+// Allows us to test with iiif manifests served from iiif.wellcomecollection.org rather than wellcomelibrary.org
+// e.g. converts http://wellcomelibrary.org/iiif/b28047345/manifest
+// to http://stage.wellcomelibrary.org/iiif/b28047345/manifest
+// which gets redirected to https://iiif.wellcomecollection.org/presentation/v2/b28047345
 export async function getToggleDeterminedIIIFManifest(
   toggle: boolean,
   url: string

--- a/common/views/components/IIIFViewer/parts/IIIFCanvasThumbnail.tsx
+++ b/common/views/components/IIIFViewer/parts/IIIFCanvasThumbnail.tsx
@@ -6,7 +6,10 @@ import { lighten } from 'polished';
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
 import IIIFResponsiveImage from '@weco/common/views/components/IIIFResponsiveImage/IIIFResponsiveImage';
 import LL from '@weco/common/views/components/styled/LL';
-import { getImageAuthService } from '@weco/common/utils/iiif';
+import {
+  getImageAuthService,
+  getThumbnailService,
+} from '@weco/common/utils/iiif';
 import Padlock from '@weco/common/views/components/styled/Padlock';
 import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
 import Space from '@weco/common/views/components/styled/Space';
@@ -96,7 +99,7 @@ const IIIFCanvasThumbnail: FunctionComponent<IIIFCanvasThumbnailProps> = ({
   isFocusable,
 }: IIIFCanvasThumbnailProps) => {
   const [thumbnailLoaded, setThumbnailLoaded] = useState(false);
-  const thumbnailService = canvas?.thumbnail?.service;
+  const thumbnailService = getThumbnailService(canvas);
   const urlTemplate =
     thumbnailService && iiifImageTemplate(thumbnailService['@id']);
   const imageAuthService = getImageAuthService(canvas);

--- a/common/views/components/IIIFViewer/parts/MainViewer.tsx
+++ b/common/views/components/IIIFViewer/parts/MainViewer.tsx
@@ -19,7 +19,11 @@ import {
 import ImageViewer from '@weco/common/views/components/ImageViewer/ImageViewer';
 import IIIFResponsiveImage from '@weco/common/views/components/IIIFResponsiveImage/IIIFResponsiveImage';
 import { getCanvasOcr } from '@weco/catalogue/services/catalogue/works';
-import { getServiceId, getImageAuthService } from '@weco/common/utils/iiif';
+import {
+  getServiceId,
+  getImageAuthService,
+  getThumbnailService,
+} from '@weco/common/utils/iiif';
 import { font } from '@weco/common/utils/classnames';
 import { IIIFCanvas } from '../../../../model/iiif';
 
@@ -91,7 +95,7 @@ const ItemRenderer = memo(({ style, index, data }: ItemRendererProps) => {
   const urlTemplateMain = mainImageService['@id']
     ? iiifImageTemplate(mainImageService['@id'])
     : null;
-  const thumbnailService = currentCanvas?.thumbnail?.service;
+  const thumbnailService = getThumbnailService(currentCanvas);
   const urlTemplateThumbnail =
     thumbnailService && iiifImageTemplate(thumbnailService['@id']);
   const smallestWidthImageDimensions =

--- a/common/views/components/IIIFViewerPrototype/IIIFCanvasThumbnailPrototype.tsx
+++ b/common/views/components/IIIFViewerPrototype/IIIFCanvasThumbnailPrototype.tsx
@@ -6,7 +6,10 @@ import { lighten } from 'polished';
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
 import IIIFResponsiveImage from '@weco/common/views/components/IIIFResponsiveImage/IIIFResponsiveImage';
 import LL from '@weco/common/views/components/styled/LL';
-import { getImageAuthService } from '@weco/common/utils/iiif';
+import {
+  getImageAuthService,
+  getThumbnailService,
+} from '@weco/common/utils/iiif';
 import Padlock from '@weco/common/views/components/styled/Padlock';
 import Space from '@weco/common/views/components/styled/Space';
 
@@ -97,7 +100,7 @@ const IIIFCanvasThumbnail: FunctionComponent<IIIFCanvasThumbnailProps> = ({
   filterId,
 }: IIIFCanvasThumbnailProps) => {
   const [thumbnailLoaded, setThumbnailLoaded] = useState(false);
-  const thumbnailService = canvas?.thumbnail?.service;
+  const thumbnailService = getThumbnailService(canvas);
   const urlTemplate =
     thumbnailService && iiifImageTemplate(thumbnailService['@id']);
   const imageAuthService = getImageAuthService(canvas);

--- a/common/views/components/MainViewerPrototype/MainViewerPrototype.tsx
+++ b/common/views/components/MainViewerPrototype/MainViewerPrototype.tsx
@@ -19,7 +19,11 @@ import {
 } from '@weco/common/utils/convert-image-uri';
 import IIIFResponsiveImage from '@weco/common/views/components/IIIFResponsiveImage/IIIFResponsiveImage';
 import { getCanvasOcr } from '@weco/catalogue/services/catalogue/works';
-import { getServiceId, getImageAuthService } from '@weco/common/utils/iiif';
+import {
+  getServiceId,
+  getImageAuthService,
+  getThumbnailService,
+} from '@weco/common/utils/iiif';
 import { font } from '@weco/common/utils/classnames';
 import { IIIFCanvas } from '../../../model/iiif';
 import ItemViewerContext from '../ItemViewerContext/ItemViewerContext';
@@ -128,6 +132,7 @@ function getPositionData( // TODO typing
     });
   return highlightsPositioningData;
 }
+
 const ItemRenderer = memo(({ style, index, data }: ItemRendererProps) => {
   const {
     scrollVelocity,
@@ -144,7 +149,7 @@ const ItemRenderer = memo(({ style, index, data }: ItemRendererProps) => {
   const urlTemplateMain = mainImageService['@id']
     ? iiifImageTemplate(mainImageService['@id'])
     : null;
-  const thumbnailService = currentCanvas?.thumbnail?.service;
+  const thumbnailService = getThumbnailService(currentCanvas);
   const urlTemplateThumbnail =
     thumbnailService && iiifImageTemplate(thumbnailService['@id']);
   const smallestWidthImageDimensions =

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -55,5 +55,12 @@ export default {
       description:
         'Displays body copy in Helvetica regular (where it is currently Helvetica light)',
     },
+    {
+      id: 'switchIIIFManifestSource',
+      title: 'Switch IIIF manifest source',
+      defaultValue: false,
+      description:
+        'Switches the manifest sources from wellcomelibrary.org to iiif.wellcomecollection.org for testing.',
+    },
   ] as const,
 };


### PR DESCRIPTION
As per [this conversation](https://wellcome.slack.com/archives/CBT40CMKQ/p1618218551345200)

We need to make sure the wc.org /work and /item pages function correctly when the iiif presentation manifests are served from https://iiif.wellcomecollection.org/presentation/v2/<id> rather than http://wellcomelibrary.org/iiif/<id>/manifest

This PR creates a toggle to request the manifests from
http://stage.wellcomelibrary.org/iiif which gets redirected to https://iiif.wellcomecollection.org/presentation/v2/

N.B. The manifests at /v2 are designed to reproduce the slightly off-spec implementation of the current wl.org ones so everything _should_ work. However, I did see a breaking change where manifest.sequences.canvases.thumbnail.service was previously an object and is now an array. This PR also takes account of this.

