### PR TITLE
Check structure has canvases

### DIFF
--- a/common/utils/iiif.ts
+++ b/common/utils/iiif.ts
@@ -186,7 +186,7 @@ export function groupStructures(
         acc.groupedArray[acc.groupedArray.length - 1].canvases.push(
           lastCanvasInRange
         );
-      } else {
+      } else if (structure.canvases.length > 0) {
         acc.groupedArray.push(structure);
       }
       acc.previousLabel = structure.label;


### PR DESCRIPTION
Fixes #6374 

It's not guaranteed that a structure will have anything in its `canvases` array, and we were (reasonably, I think) assuming that they would. 
![image](https://user-images.githubusercontent.com/1394592/114693101-2ecb1c80-9d11-11eb-845c-86aaa65b1035.png)
