### PR TITLE
Display holdings

### DIFF
--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -502,10 +502,10 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
                   controlText="Can I use this?"
                 >
                   <>
-                    {digitalLocationInfo?.license.humanReadableText.length >
+                    {digitalLocationInfo.license.humanReadableText.length >
                       0 && (
                       <WorkDetailsText
-                        text={digitalLocationInfo?.license.humanReadableText}
+                        text={digitalLocationInfo.license.humanReadableText}
                       />
                     )}
 
@@ -518,9 +518,9 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
                 : ` `
             }
           ${
-            digitalLocationInfo?.license.url
-              ? `<a href="${digitalLocationInfo?.license.url}">${digitalLocationInfo?.license.label}</a>`
-              : digitalLocationInfo?.license.label
+            digitalLocationInfo.license.url
+              ? `<a href="${digitalLocationInfo.license.url}">${digitalLocationInfo.license.label}</a>`
+              : digitalLocationInfo.license.label
           }`,
                       ]}
                     />

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -14,6 +14,7 @@ import {
   getEncoreLink,
   getItemsWithPhysicalLocation,
   sierraIdFromPresentationManifestUrl,
+  getHoldings,
 } from '@weco/common/utils/works';
 import {
   getVideoClickthroughService,
@@ -207,6 +208,9 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
   });
 
   const isInArchive = work.parts.length > 0 || work.partOf.length > 0;
+
+  const holdings = getHoldings(work);
+
   const WhereToFindIt = () => (
     <WorkDetailsSection
       headingText="Where to find it"
@@ -240,6 +244,14 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
 
   const Content = () => (
     <>
+      {holdings.length > 0 && (
+        <WorkDetailsSection headingText="Holdings" isInArchive={isInArchive}>
+          {holdings.map((holding, i) => (
+            <p key={i}>{holding.type}</p>
+          ))}
+        </WorkDetailsSection>
+      )}
+
       {digitalLocation && itemLinkState !== 'useNoLink' && (
         <WorkDetailsSection
           headingText="Available online"

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -73,7 +73,9 @@ function getItemLinkState({
 }
 
 const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
-  const { stacksRequestService } = useContext(TogglesContext);
+  const { stacksRequestService, showHoldingsOnWork } = useContext(
+    TogglesContext
+  );
 
   const itemUrl = itemLink({ workId: work.id }, 'work');
 
@@ -237,7 +239,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
 
   const Content = () => (
     <>
-      {holdings.length > 0 && (
+      {showHoldingsOnWork && holdings.length > 0 && (
         <WorkDetailsSection headingText="Holdings" isInArchive={isInArchive}>
           {holdings.map((holding, i) => (
             <div key={i}>

--- a/catalogue/webapp/services/catalogue/works.ts
+++ b/catalogue/webapp/services/catalogue/works.ts
@@ -50,6 +50,7 @@ const workIncludes = [
   'precededBy',
   'succeededBy',
   'languages',
+  'holdings',
 ];
 
 const redirect = (id: string, status = 302): CatalogueApiRedirect => ({
@@ -138,7 +139,7 @@ export async function getCanvasOcr(
   const textContent =
     canvas.otherContent &&
     canvas.otherContent.find(
-      (content) =>
+      content =>
         content['@type'] === 'sc:AnnotationList' &&
         content.label === 'Text of this page'
     );
@@ -150,10 +151,10 @@ export async function getCanvasOcr(
       const textJson = await fetch(textService);
       const text = await textJson.json();
       const textString = text.resources
-        .filter((resource) => {
+        .filter(resource => {
           return resource.resource['@type'] === 'cnt:ContentAsText';
         })
-        .map((resource) => resource.resource.chars)
+        .map(resource => resource.resource.chars)
         .join(' ');
       return textString.length > 0 ? textString : 'text unavailable';
     } catch (e) {

--- a/common/model/catalogue.ts
+++ b/common/model/catalogue.ts
@@ -134,6 +134,7 @@ export type DigitalLocation = {
 export type PhysicalLocation = {
   locationType: LocationType;
   label: string;
+  shelfmark?: string;
   accessConditions: AccessCondition[];
   type: 'PhysicalLocation';
 };

--- a/common/model/catalogue.ts
+++ b/common/model/catalogue.ts
@@ -32,6 +32,23 @@ export type Work = {
   availableOnline: boolean;
   availabilities: Availability[];
   '@context'?: string;
+  holdings?: Holding[];
+};
+
+export type Holding = {
+  // TODO
+  enumeration: ['Current copy on Quick Ref.  Superseded copy discarded.'];
+  location: {
+    locationType: {
+      id: 'open-shelves';
+      label: 'Open shelves';
+      type: 'LocationType';
+    };
+    label: 'Open shelves';
+    accessConditions: [];
+    type: 'PhysicalLocation';
+  };
+  type: 'Holdings';
 };
 
 type MinimalRelatedWorkFields =

--- a/common/model/catalogue.ts
+++ b/common/model/catalogue.ts
@@ -32,7 +32,7 @@ export type Work = {
   availableOnline: boolean;
   availabilities: Availability[];
   '@context'?: string;
-  holdings?: Holding[];
+  holdings: Holding[];
 };
 
 export type Holding = {

--- a/common/model/catalogue.ts
+++ b/common/model/catalogue.ts
@@ -36,18 +36,9 @@ export type Work = {
 };
 
 export type Holding = {
-  // TODO
-  enumeration: ['Current copy on Quick Ref.  Superseded copy discarded.'];
-  location: {
-    locationType: {
-      id: 'open-shelves';
-      label: 'Open shelves';
-      type: 'LocationType';
-    };
-    label: 'Open shelves';
-    accessConditions: [];
-    type: 'PhysicalLocation';
-  };
+  note?: string;
+  enumeration: string[];
+  location?: Location;
   type: 'Holdings';
 };
 

--- a/common/utils/works.ts
+++ b/common/utils/works.ts
@@ -4,6 +4,7 @@ import {
   PhysicalLocation,
   RelatedWork,
   Work,
+  Holding,
 } from '../model/catalogue';
 import { IIIFRendering } from '../model/iiif';
 import { convertImageUri } from '@weco/common/utils/convert-image-uri';
@@ -114,6 +115,10 @@ export type PhysicalItemAugmented = {
   requested?: boolean;
   requestSucceeded?: boolean;
 };
+
+export function getHoldings(work: Work): Holding[] {
+  return work?.holdings || [];
+}
 
 export function getItemsWithPhysicalLocation(
   work: Work

--- a/common/utils/works.ts
+++ b/common/utils/works.ts
@@ -7,8 +7,9 @@ import {
   Holding,
 } from '../model/catalogue';
 import { IIIFRendering } from '../model/iiif';
-import { convertImageUri } from '@weco/common/utils/convert-image-uri';
+import { convertImageUri } from '../utils/convert-image-uri';
 import { Label } from '../model/labels';
+import getAugmentedLicenseInfo, { LicenseData } from '../utils/licenses';
 
 export function getProductionDates(work: Work): string[] {
   return work.production
@@ -284,4 +285,20 @@ function makeArchiveAncestorArray(partOfArray, nextPart) {
 
 export function getArchiveAncestorArray(work: Work): RelatedWork[] {
   return makeArchiveAncestorArray([], work?.partOf?.[0]).reverse();
+}
+
+type DigitalLocationInfo = {
+  accessCondition: string | undefined;
+  license: LicenseData | undefined;
+};
+
+export function getDigitalLocationInfo(
+  digitalLocation: DigitalLocation
+): DigitalLocationInfo {
+  return {
+    accessCondition: getAccessConditionForDigitalLocation(digitalLocation),
+    license:
+      digitalLocation?.license &&
+      getAugmentedLicenseInfo(digitalLocation.license),
+  };
 }

--- a/common/views/components/IIIFViewer/parts/IIIFCanvasThumbnail.tsx
+++ b/common/views/components/IIIFViewer/parts/IIIFCanvasThumbnail.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, useState, useContext } from 'react';
+import { FunctionComponent, useState } from 'react';
 import { IIIFCanvas } from '@weco/common/model/iiif';
 import { classNames, font } from '@weco/common/utils/classnames';
 import styled from 'styled-components';
@@ -8,8 +8,6 @@ import IIIFResponsiveImage from '@weco/common/views/components/IIIFResponsiveIma
 import LL from '@weco/common/views/components/styled/LL';
 import { getImageAuthService } from '@weco/common/utils/iiif';
 import Padlock from '@weco/common/views/components/styled/Padlock';
-import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
-import Space from '@weco/common/views/components/styled/Space';
 
 type ViewerThumbProps = {
   isFocusable?: boolean;
@@ -108,7 +106,6 @@ const IIIFCanvasThumbnail: FunctionComponent<IIIFCanvasThumbnailProps> = ({
     thumbnailService.sizes
       .sort((a, b) => a.width - b.width)
       .find(dimensions => dimensions.width > 100);
-  const { showCanvasLabels } = useContext(TogglesContext);
   return (
     <IIIFViewerThumb
       onClick={clickHandler}
@@ -162,29 +159,10 @@ const IIIFCanvasThumbnail: FunctionComponent<IIIFCanvasThumbnailProps> = ({
           )}
         </ImageContainer>
         <div>
-          {showCanvasLabels ? (
-            <>
-              {canvas.label.trim() !== '-' && (
-                <Space v={{ size: 's', properties: ['margin-bottom'] }}>
-                  <IIIFViewerThumbNumber isActive={isActive}>
-                    {canvas.label}
-                  </IIIFViewerThumbNumber>
-                </Space>
-              )}
-              <div>
-                <IIIFViewerThumbNumber isActive={isActive}>
-                  <span
-                    style={{ fontSize: '11px' }}
-                  >{`image ${thumbNumber}`}</span>
-                </IIIFViewerThumbNumber>
-              </div>
-            </>
-          ) : (
-            <IIIFViewerThumbNumber isActive={isActive}>
-              <span className="visually-hidden">image </span>
-              {thumbNumber}
-            </IIIFViewerThumbNumber>
-          )}
+          <IIIFViewerThumbNumber isActive={isActive}>
+            <span className="visually-hidden">image </span>
+            {thumbNumber}
+          </IIIFViewerThumbNumber>
         </div>
       </IIIFViewerThumbInner>
     </IIIFViewerThumb>

--- a/common/views/components/ItemViewerContext/ItemViewerContext.tsx
+++ b/common/views/components/ItemViewerContext/ItemViewerContext.tsx
@@ -91,6 +91,7 @@ const ItemViewerContext = createContext<Props>({
     succeededBy: [],
     availabilities: [],
     availableOnline: false,
+    holdings: [],
   },
   manifest: undefined,
   manifestIndex: undefined,

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -9,7 +9,7 @@ export default {
     },
     {
       id: 'showHoldingsOnWork',
-      title: 'Shows holdings on the work page',
+      title: 'Show holdings on the work page',
       description: 'Shows the holding information for a work',
       defaultValue: false,
     },

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -8,10 +8,9 @@ export default {
       defaultValue: true,
     },
     {
-      id: 'showCanvasLabels',
-      title: 'Show canvas labels on viewer thumbnails',
-      description:
-        'Shows the canvas label on the viewer thumbnails above the image number',
+      id: 'showHoldingsOnWork',
+      title: 'Shows holdings on the work page',
+      description: 'Shows the holding information for a work',
       defaultValue: false,
     },
     {


### PR DESCRIPTION
Relates to #6247

First pass at getting holdings data onto the work page behind a toggle (no styling or UX):

![Screenshot 2021-04-16 at 16 48 14](https://user-images.githubusercontent.com/6051896/115050781-05a6b980-9ed4-11eb-8a78-5ccf9e86043d.png)

Also, removes redundant showCanvasLabels toggle and related code
