### PR TITLE
don't redirect to deadend from images path

### DIFF
--- a/catalogue/webapp/pages/image.tsx
+++ b/catalogue/webapp/pages/image.tsx
@@ -172,7 +172,7 @@ export const getServerSideProps: GetServerSideProps<
   } else if (work.type === 'Redirect') {
     return {
       redirect: {
-        destination: `/works/${work.redirectToId}/images`,
+        destination: `/works/${work.redirectToId}`,
         permanent: work.status === 301,
       },
     };


### PR DESCRIPTION
There's a deeper underlaying issue around how images are merged that we need to solve, but we should definitely not be redirecting to dead-ends.