### PR TITLE
Archive tree padding

### DIFF
--- a/catalogue/webapp/pages/image.tsx
+++ b/catalogue/webapp/pages/image.tsx
@@ -172,7 +172,7 @@ export const getServerSideProps: GetServerSideProps<
   } else if (work.type === 'Redirect') {
     return {
       redirect: {
-        destination: `/works/${work.redirectToId}/images`,
+        destination: `/works/${work.redirectToId}`,
         permanent: work.status === 301,
       },
     };

--- a/common/views/components/ArchiveTree/ArchiveTree.tsx
+++ b/common/views/components/ArchiveTree/ArchiveTree.tsx
@@ -922,7 +922,9 @@ const ArchiveTree: FunctionComponent<{ work: Work }> = ({
         </>
       ) : (
         <TreeContainer>
-          <Space v={{ size: 'l', properties: ['padding-top'] }}>
+          <Space
+            v={{ size: 'l', properties: ['padding-top', 'padding-bottom'] }}
+          >
             <h2
               className={classNames({
                 [font('wb', 4)]: true,


### PR DESCRIPTION
Waiting on #6392 to avoid having to do git magic to revert the change out.

**Before**

<img width="534" alt="Screenshot 2021-04-19 at 10 23 01" src="https://user-images.githubusercontent.com/31692/115213749-bcd04a00-a0f9-11eb-9020-793ce7be4140.png">

**After**
<img width="483" alt="Screenshot 2021-04-19 at 10 23 09" src="https://user-images.githubusercontent.com/31692/115213753-bd68e080-a0f9-11eb-97b5-c1150b5a772a.png">
