### PR TITLE
don’t use library link for restricted items

### DIFF
--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -57,11 +57,7 @@ function getItemLinkState({
   audio,
   video,
 }): ItemLinkState | undefined {
-  if (
-    (accessCondition === 'restricted' ||
-      accessCondition === 'permission-required') &&
-    sierraIdFromManifestUrl
-  ) {
+  if (accessCondition === 'permission-required' && sierraIdFromManifestUrl) {
     return 'useLibraryLink';
   }
   if (accessCondition === 'closed') {


### PR DESCRIPTION
We were sending people to the library website for items with an accessCondition of restricted and they were getting redirected straight back. This stops that happening and this is what they'll see on the item page instead:

![Screenshot 2021-04-21 at 11 11 32](https://user-images.githubusercontent.com/6051896/115537992-4ff0b780-a293-11eb-8fb3-e4a686ac4599.png)

N.B. we are also sending people to the library website for items with an accessCondition of permission-required, we'll need to stop doing this too, but want to get an example to test.