### PR TITLE
Don't use a pointer on the item viewer images

### DIFF
--- a/common/views/components/ImageViewerPrototype/ImageViewerPrototype.tsx
+++ b/common/views/components/ImageViewerPrototype/ImageViewerPrototype.tsx
@@ -21,7 +21,6 @@ const ImageWrapper = styled.div`
   right: 0;
   padding: 0;
   img {
-    cursor: pointer;
     margin: auto;
     position: relative;
     top: 50%;


### PR DESCRIPTION
Relates to #6291

## Who is this for?
People using the item viewer.

## What is it doing for them?
Using the default cursor style on the images in the main pane.

We are currently using the `pointer` style, because the image is clickable (launching deep zoom), but this potentially adds more confusion around what affordance is present on the image.