### PR TITLE
Make http listener optional in listener module

### DIFF
--- a/identity-admin/terraform/stack/main.tf
+++ b/identity-admin/terraform/stack/main.tf
@@ -37,7 +37,7 @@ module "path_listener" {
   source = "../../../infrastructure/modules/alb_listener_rule"
 
   alb_listener_https_arn = var.alb_listener_https_arn
-  alb_listener_http_arn  = var.alb_listener_http_arn
+  #alb_listener_http_arn  = var.alb_listener_http_arn
   target_group_arn       = local.target_group_arn
 
   path_patterns = ["*"]

--- a/identity-admin/terraform/stack/main.tf
+++ b/identity-admin/terraform/stack/main.tf
@@ -37,7 +37,6 @@ module "path_listener" {
   source = "../../../infrastructure/modules/alb_listener_rule"
 
   alb_listener_https_arn = var.alb_listener_https_arn
-  #alb_listener_http_arn  = var.alb_listener_http_arn
   target_group_arn       = local.target_group_arn
 
   path_patterns = ["*"]

--- a/infrastructure/modules/alb_listener_rule/main.tf
+++ b/infrastructure/modules/alb_listener_rule/main.tf
@@ -25,6 +25,8 @@ resource "aws_alb_listener_rule" "https" {
 }
 
 resource "aws_alb_listener_rule" "http" {
+  count = var.alb_listener_http_arn == "" ? 0 : 1
+
   listener_arn = var.alb_listener_http_arn
   priority     = var.priority
 

--- a/infrastructure/modules/alb_listener_rule/variables.tf
+++ b/infrastructure/modules/alb_listener_rule/variables.tf
@@ -1,5 +1,8 @@
 variable "alb_listener_https_arn" {}
-variable "alb_listener_http_arn" {}
+variable "alb_listener_http_arn" {
+  type = string
+  default = ""
+}
 variable "target_group_arn" {}
 variable "priority" {}
 


### PR DESCRIPTION
## Who is this for?

Folk who want to be able to redirect HTTP -> HTTPS (and specifically for the identity-admin app do that).

## What is it doing for them?

Allowing services creating http listeners using a tf module to optionally pass in one for HTTP - if you don't the HTTP -> HTTPS redirect takes precedence.

The identity-admin app is being served out of the identity AWS account and does not have CloudFront to perform the HTTP -> HTTP redirect as the other services here do (the DNS account-admin.wellcomecollection.org record points direct at the ALB). Hence the need to make this change.

Note: This PR is deployed