### PR TITLE
Show/hide correct bits of ui for single images

### DIFF
--- a/common/views/components/IIIFViewerPrototype/ViewerTopBarPrototype.tsx
+++ b/common/views/components/IIIFViewerPrototype/ViewerTopBarPrototype.tsx
@@ -179,7 +179,7 @@ const ViewerTopBar: FunctionComponent<Props> = ({
       isZooming={showZoomed}
       isDesktopSidebarActive={isDesktopSidebarActive}
     >
-      {isEnhanced && canvases && canvases.length > 1 && (
+      {isEnhanced && (
         <Sidebar isZooming={showZoomed}>
           {!showZoomed && (
             <>
@@ -227,7 +227,7 @@ const ViewerTopBar: FunctionComponent<Props> = ({
       )}
       <Main>
         <LeftZone>
-          {!showZoomed && (
+          {!showZoomed && canvases && canvases.length > 1 && (
             <ShameButton
               className={`viewer-desktop`}
               isDark


### PR DESCRIPTION
Fixes #6420 

- Always show the show/hide sidebar toggle
- Only show the detail/grid toggle for items with more than one canvas

![image](https://user-images.githubusercontent.com/1394592/115752217-cecc1a00-a391-11eb-9692-ecccdf84f47b.png)
