### PR TITLE
Use new segmented control in viewer

### DIFF
--- a/common/icons/components/SinglePage.js
+++ b/common/icons/components/SinglePage.js
@@ -1,0 +1,13 @@
+const SvgSinglePage = props => (
+  <svg viewBox="0 0 24 24" {...props}>
+    <rect className="icon__shape" x={8.7} y={7.3} width={6.7} height={2} />
+    <rect className="icon__shape" x={8.7} y={10.7} width={6.7} height={2} />
+    <rect className="icon__shape" x={8.7} y={14} width={6.7} height={2} />
+    <path
+      className="icon__shape"
+      d="M15.7,3.3H8.3c-1.7,0-3,1.3-3,3v11.3c0,1.7,1.3,3,3,3h7.3c1.7,0,3-1.3,3-3V6.3C18.7,4.7,17.3,3.3,15.7,3.3z M16.7,17.7     c0,0.6-0.4,1-1,1H8.3c-0.6,0-1-0.4-1-1V6.3c0-0.6,0.4-1,1-1h7.3c0.6,0,1,0.4,1,1V17.7z"
+    />
+  </svg>
+);
+
+export default SvgSinglePage;

--- a/common/icons/index.js
+++ b/common/icons/index.js
@@ -85,6 +85,7 @@ import saveTo from './components/SaveTo';
 import scroll from './components/Scroll';
 import search from './components/Search';
 import share from './components/Share';
+import singlePage from './components/SinglePage';
 import smartphone from './components/Smartphone';
 import snowflake from './components/Snowflake';
 import sort from './components/Sort';
@@ -199,6 +200,7 @@ export {
   scroll,
   search,
   share,
+  singlePage,
   smartphone,
   snowflake,
   sort,

--- a/common/icons/svgs/single_page.svg
+++ b/common/icons/svgs/single_page.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <rect class="icon__shape" x="8.7" y="7.3" width="6.7" height="2"/>
+  <rect class="icon__shape" x="8.7" y="10.7" width="6.7" height="2"/>
+  <rect class="icon__shape" x="8.7" y="14" width="6.7" height="2"/>
+  <path class="icon__shape" d="M15.7,3.3H8.3c-1.7,0-3,1.3-3,3v11.3c0,1.7,1.3,3,3,3h7.3c1.7,0,3-1.3,3-3V6.3C18.7,4.7,17.3,3.3,15.7,3.3z M16.7,17.7
+    c0,0.6-0.4,1-1,1H8.3c-0.6,0-1-0.4-1-1V6.3c0-0.6,0.4-1,1-1h7.3c0.6,0,1,0.4,1,1V17.7z"/>
+</svg>

--- a/common/views/components/IIIFViewerPrototype/ViewerTopBarPrototype.tsx
+++ b/common/views/components/IIIFViewerPrototype/ViewerTopBarPrototype.tsx
@@ -10,6 +10,7 @@ import TogglesContext from '@weco/common/views/components/TogglesContext/Toggles
 import ItemViewerContext from '@weco/common/views/components/ItemViewerContext/ItemViewerContext';
 import useIsFullscreenEnabled from '@weco/common/hooks/useIsFullscreenEnabled';
 import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper/ConditionalWrapper';
+import ToolbarSegmentedControl from '../ToolbarSegmentedControl/ToolbarSegmentedControl';
 
 // TODO: update this with a more considered button from our system
 export const ShameButton = styled.button.attrs(() => ({
@@ -149,10 +150,7 @@ type Props = {
   viewerRef: RefObject<HTMLDivElement>;
 };
 
-const ViewerTopBar: FunctionComponent<Props> = ({
-  viewToggleRef,
-  viewerRef,
-}: Props) => {
+const ViewerTopBar: FunctionComponent<Props> = ({ viewerRef }: Props) => {
   const { isEnhanced } = useContext(AppContext);
   const { showSidebarToggleLabel } = useContext(TogglesContext);
   const isFullscreenEnabled = useIsFullscreenEnabled();
@@ -228,26 +226,38 @@ const ViewerTopBar: FunctionComponent<Props> = ({
       <Main>
         <LeftZone>
           {!showZoomed && (
-            <ShameButton
-              className={`viewer-desktop`}
-              isDark
-              ref={viewToggleRef}
-              onClick={() => {
-                setGridVisible(!gridVisible);
-                trackEvent({
-                  category: 'Control',
-                  action: `clicked work viewer ${
-                    gridVisible ? '"Detail view"' : '"View all"'
-                  } button`,
-                  label: `${work.id}`,
-                });
-              }}
-            >
-              <Icon name={gridVisible ? 'detailView' : 'gridView'} />
-              <span className={`btn__text`}>
-                {gridVisible ? 'Detail view' : 'View all'}
-              </span>
-            </ShameButton>
+            <ToolbarSegmentedControl
+              hideLabels={true}
+              items={[
+                {
+                  id: '1',
+                  label: 'Page',
+                  icon: 'singlePage',
+                  clickHandler() {
+                    setGridVisible(false);
+                    trackEvent({
+                      category: 'Control',
+                      action: `clicked work viewer Detail view button`,
+                      label: `${work.id}`,
+                    });
+                  },
+                },
+                {
+                  id: '2',
+                  label: 'Grid',
+                  icon: 'gridView',
+                  clickHandler() {
+                    setGridVisible(true);
+                    trackEvent({
+                      category: 'Control',
+                      action: `clicked work viewer Grid view button`,
+                      label: `${work.id}`,
+                    });
+                  },
+                },
+              ]}
+              activeId={gridVisible ? '2' : '1'}
+            />
           )}
         </LeftZone>
         <MiddleZone>

--- a/common/views/components/IIIFViewerPrototype/ViewerTopBarPrototype.tsx
+++ b/common/views/components/IIIFViewerPrototype/ViewerTopBarPrototype.tsx
@@ -230,7 +230,7 @@ const ViewerTopBar: FunctionComponent<Props> = ({ viewerRef }: Props) => {
               hideLabels={true}
               items={[
                 {
-                  id: '1',
+                  id: 'pageView',
                   label: 'Page',
                   icon: 'singlePage',
                   clickHandler() {
@@ -243,7 +243,7 @@ const ViewerTopBar: FunctionComponent<Props> = ({ viewerRef }: Props) => {
                   },
                 },
                 {
-                  id: '2',
+                  id: 'gridView',
                   label: 'Grid',
                   icon: 'gridView',
                   clickHandler() {
@@ -256,7 +256,7 @@ const ViewerTopBar: FunctionComponent<Props> = ({ viewerRef }: Props) => {
                   },
                 },
               ]}
-              activeId={gridVisible ? '2' : '1'}
+              activeId={gridVisible ? 'gridView' : 'pageView'}
             />
           )}
         </LeftZone>

--- a/common/views/components/ToolbarSegmentedControl/ToolbarSegmentedControl.tsx
+++ b/common/views/components/ToolbarSegmentedControl/ToolbarSegmentedControl.tsx
@@ -10,11 +10,11 @@ const List = styled.ul.attrs({
     'flex-inline flex--v-center flex--h-center': true,
   }),
 })`
-  border: 2px solid ${props => props.theme.color('charcoal')};
+  border: 2px solid ${props => props.theme.color('pewter')};
   border-radius: 3px;
 
   button {
-    border-right: 2px solid ${props => props.theme.color('charcoal')};
+    border-right: 2px solid ${props => props.theme.color('pewter')};
   }
 `;
 
@@ -22,7 +22,7 @@ const Item = styled.li<{ isActive: boolean }>`
   ${props =>
     props.isActive &&
     `
-    background: ${props.theme.color('charcoal')};
+    background: ${props.theme.color('pewter')};
   `}
 
   &:last-child button {
@@ -39,13 +39,20 @@ const Button = styled.button.attrs({
 
 const ButtonInner = styled(Space).attrs({
   as: 'span',
-  h: { size: 's', properties: ['padding-right', 'padding-left'] },
+  h: {
+    size: 'xs',
+    properties: ['padding-right', 'padding-left'],
+  },
+  v: {
+    size: 'xs',
+    properties: ['padding-top', 'padding-bottom'],
+  },
   className: classNames({
     'flex flex--v-center flex--h-center': true,
     [font('hnm', 5)]: true,
   }),
 })<{ isActive: boolean }>`
-  color: ${props => props.theme.color(props.isActive ? 'yellow' : 'pewter')};
+  color: ${props => props.theme.color('white')};
 `;
 
 type Props = {
@@ -70,10 +77,25 @@ const ToolbarSegmentedControl: FunctionComponent<Props> = ({
         <Item isActive={activeId === item.id} key={item.id}>
           <Button onClick={item.clickHandler}>
             <ButtonInner isActive={activeId === item.id}>
-              <Icon name={item.icon} extraClasses={'icon--currentColor'} />
-              <span className={hideLabels ? 'visually-hidden' : undefined}>
+              <Icon
+                name={item.icon}
+                extraClasses={
+                  activeId === item.id ? 'icon--yellow' : 'icon--pewter'
+                }
+              />
+              <Space
+                h={
+                  hideLabels
+                    ? undefined
+                    : {
+                        size: 'xs',
+                        properties: ['padding-left', 'padding-right'],
+                      }
+                }
+                className={hideLabels ? 'visually-hidden' : undefined}
+              >
                 {item.label}
-              </span>
+              </Space>
             </ButtonInner>
           </Button>
         </Item>


### PR DESCRIPTION
Closes #6147 

## Who is this for?
Users of of the item viewer

## What is it doing for them?
Giving them a new control for toggling between detail/grid view that is more consistent with the rest of the ui.

![image](https://user-images.githubusercontent.com/1394592/115852102-9d9a2b00-a41f-11eb-9659-e574ed58e7c2.png)

The intention is to a/b test the presence/absence of labels alongside the icons in the control, but we decided to wait until the a/b test for label presence on the sidebar toggle was complete.
