### PR TITLE
Physical item locations

### DIFF
--- a/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
+++ b/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
@@ -1,0 +1,48 @@
+import { FunctionComponent } from 'react';
+import { PhysicalItem } from '@weco/common/model/catalogue';
+import Table from '@weco/common/views/components/Table/Table';
+import Space from '@weco/common/views/components/styled/Space';
+
+type Props = { items: PhysicalItem[] };
+const PhysicalItems: FunctionComponent<Props> = ({ items }: Props) => {
+  const headerRow = ['Title', 'Location/Shelfmark'];
+  const bodyRows = items.map(item => {
+    return [
+      item.title || 'unknown',
+      (function() {
+        const physicalLocation = item.locations.find(
+          location => location.type === 'PhysicalLocation'
+        );
+        return physicalLocation ? physicalLocation.label : '';
+      })(),
+    ];
+  });
+
+  return (
+    <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
+      <Table hasRowHeaders={false} rows={[headerRow, ...bodyRows]} />
+      <pre
+        style={{
+          maxWidth: '600px',
+          margin: '0 auto 24px',
+          fontSize: '14px',
+        }}
+      >
+        <code
+          style={{
+            display: 'block',
+            padding: '24px',
+            backgroundColor: '#EFE1AA',
+            color: '#000',
+            border: '4px solid #000',
+            borderRadius: '6px',
+          }}
+        >
+          {JSON.stringify(items, null, 1)}
+        </code>
+      </pre>
+    </Space>
+  );
+};
+
+export default PhysicalItems;

--- a/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
+++ b/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
@@ -2,45 +2,36 @@ import { FunctionComponent } from 'react';
 import { PhysicalItem } from '@weco/common/model/catalogue';
 import Table from '@weco/common/views/components/Table/Table';
 import Space from '@weco/common/views/components/styled/Space';
+import {
+  getLocationLabel,
+  getLocationShelfmark,
+} from '@weco/common/utils/works';
 
 type Props = { items: PhysicalItem[] };
 const PhysicalItems: FunctionComponent<Props> = ({ items }: Props) => {
-  const headerRow = ['Title', 'Location/Shelfmark'];
+  const headerRow = ['Title', 'Location', 'Shelfmark'];
   const bodyRows = items.map(item => {
-    return [
-      item.title || 'unknown',
-      (function() {
-        const physicalLocation = item.locations.find(
-          location => location.type === 'PhysicalLocation'
-        );
-        return physicalLocation ? physicalLocation.label : '';
-      })(),
-    ];
+    const physicalLocations = item.locations.filter(
+      location => location.type === 'PhysicalLocation'
+    );
+    const locationText = physicalLocations
+      .map(location => {
+        return `${location.locationType.label ?? ''}`;
+      })
+      .join(', ');
+    const shelfmark = physicalLocations
+      .map(location => {
+        const locationLabel = getLocationLabel(location);
+        const locationShelfmark = getLocationShelfmark(location);
+        return `${locationLabel ?? ''} ${locationShelfmark ?? ''}`;
+      })
+      .join(', ');
+    return [item.title || 'unknown', locationText, shelfmark];
   });
 
   return (
     <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
       <Table hasRowHeaders={false} rows={[headerRow, ...bodyRows]} />
-      <pre
-        style={{
-          maxWidth: '600px',
-          margin: '0 auto 24px',
-          fontSize: '14px',
-        }}
-      >
-        <code
-          style={{
-            display: 'block',
-            padding: '24px',
-            backgroundColor: '#EFE1AA',
-            color: '#000',
-            border: '4px solid #000',
-            borderRadius: '6px',
-          }}
-        >
-          {JSON.stringify(items, null, 1)}
-        </code>
-      </pre>
     </Space>
   );
 };

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -39,7 +39,7 @@ import ButtonOutlinedLink from '@weco/common/views/components/ButtonOutlinedLink
 import ExplanatoryText from '@weco/common/views/components/ExplanatoryText/ExplanatoryText';
 import { toLink as itemLink } from '@weco/common/views/components/ItemLink/ItemLink';
 import { trackEvent } from '@weco/common/utils/ga';
-import ItemLocation from '../RequestLocation/RequestLocation';
+import PhysicalItems from '../PhysicalItems/PhysicalItems';
 import Layout12 from '@weco/common/views/components/Layout12/Layout12';
 import { DigitalLocation, Work } from '@weco/common/model/catalogue';
 import useIIIFManifestData from '@weco/common/hooks/useIIIFManifestData';
@@ -73,9 +73,7 @@ function getItemLinkState({
 }
 
 const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
-  const { stacksRequestService, showHoldingsOnWork } = useContext(
-    TogglesContext
-  );
+  const { showHoldingsOnWork } = useContext(TogglesContext);
 
   const itemUrl = itemLink({ workId: work.id }, 'work');
 
@@ -161,8 +159,8 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
 
   const encoreLink = sierraWorkId && getEncoreLink(sierraWorkId);
 
-  const physicalLocations = getItemsWithPhysicalLocation(work);
-  const showEncoreLink = encoreLink && physicalLocations.length > 0;
+  const physicalItems = getItemsWithPhysicalLocation(work);
+  const showEncoreLink = encoreLink && physicalItems.length > 0;
 
   const locationOfWork = work.notes.find(
     note => note.noteType.id === 'location-of-original'
@@ -217,8 +215,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
           text={locationOfWork.contents}
         />
       )}
-
-      {!stacksRequestService && showEncoreLink && (
+      {showEncoreLink && (
         <Space
           v={{
             size: 'l',
@@ -232,8 +229,8 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
           />
         </Space>
       )}
-
-      {stacksRequestService && <ItemLocation work={work} />}
+      {/* TODO wrap in toggle */}
+      {physicalItems && <PhysicalItems items={physicalItems} />}
     </WorkDetailsSection>
   );
 

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -73,7 +73,7 @@ function getItemLinkState({
 }
 
 const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
-  const { showHoldingsOnWork } = useContext(TogglesContext);
+  const { showPhysicalItems, showHoldingsOnWork } = useContext(TogglesContext);
 
   const itemUrl = itemLink({ workId: work.id }, 'work');
 
@@ -229,8 +229,9 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
           />
         </Space>
       )}
-      {/* TODO wrap in toggle */}
-      {physicalItems && <PhysicalItems items={physicalItems} />}
+      {showPhysicalItems && physicalItems && (
+        <PhysicalItems items={physicalItems} />
+      )}
     </WorkDetailsSection>
   );
 

--- a/common/model/catalogue.ts
+++ b/common/model/catalogue.ts
@@ -181,6 +181,10 @@ export type Item = {
   type: 'Item';
 };
 
+export type PhysicalItem = Omit<Item, 'locations'> & {
+  locations: PhysicalLocation[];
+};
+
 type Date = {
   label: string;
   type: 'Period';

--- a/common/utils/works.ts
+++ b/common/utils/works.ts
@@ -5,6 +5,7 @@ import {
   RelatedWork,
   Work,
   Holding,
+  PhysicalItem,
 } from '../model/catalogue';
 import { IIIFRendering } from '../model/iiif';
 import { convertImageUri } from '../utils/convert-image-uri';
@@ -121,20 +122,16 @@ export function getHoldings(work: Work): Holding[] {
   return work?.holdings || [];
 }
 
-export function getItemsWithPhysicalLocation(
-  work: Work
-): PhysicalItemAugmented[] {
+export function getItemsWithPhysicalLocation(work: Work): PhysicalItem[] {
   return (work.items ?? [])
     .map(item => {
       if (
         item.locations.find(location => location.type === 'PhysicalLocation')
       ) {
-        return item as PhysicalItemAugmented;
+        return item as PhysicalItem;
       }
     })
-    .filter((item?: PhysicalItemAugmented): item is PhysicalItemAugmented =>
-      Boolean(item)
-    );
+    .filter((item?: PhysicalItem): item is PhysicalItem => Boolean(item));
 }
 
 export function getItemsByLocationType(

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -20,10 +20,10 @@ export default {
       description: 'Use the staging catalogue API',
     },
     {
-      id: 'stacksRequestService',
-      title: 'Items status and requesting',
+      id: 'showPhysicalItems',
+      title: 'Show physical items on the work page',
       defaultValue: false,
-      description: 'Get the status of items and request them from the stacks',
+      description: 'Shows physical items and their locations on the work page',
     },
     {
       id: 'helveticaRegular',


### PR DESCRIPTION
References #6410

Separates the display of the physical items from the old stacks prototype work and puts it behind its own toggle.

![Screenshot 2021-04-30 at 16 02 28](https://user-images.githubusercontent.com/6051896/116714695-ed539600-a9cd-11eb-9fa2-d13862bc5fda.png)


Will need tweaking once I have designs from @DominiqueMarshall, especially with regards to single items with multiple physical locations.
