### PR TITLE
WS-185 Make Cancel action a button not a link

### DIFF
--- a/identity/webapp/src/frontend/Registration/Registration.style.ts
+++ b/identity/webapp/src/frontend/Registration/Registration.style.ts
@@ -1,6 +1,5 @@
 import CheckboxRadio from '@weco/common/views/components/CheckboxRadio/CheckboxRadio';
 import styled, { css } from 'styled-components';
-import { Link } from 'react-router-dom';
 
 export const ExternalLink = styled.a`
   white-space: nowrap;
@@ -56,6 +55,16 @@ export const InProgress = styled.div.attrs({ role: 'progressbar' })`
   user-select: none;
 `;
 
-export const Cancel = styled(Link).attrs({ children: 'Cancel', to: '#cancel' })`
+export const Cancel = styled.button.attrs({ type: 'button', children: 'Cancel' })`
   ${FullWidthElementBase}
+  width: fit-content;
+  margin: 0 auto;
+  background: none;
+  border: none;
+  text-decoration: underline;
+
+  &:hover {
+    text-decoration: none;
+    cursor: pointer;
+  }
 `;

--- a/identity/webapp/src/frontend/Registration/Registration.test.tsx
+++ b/identity/webapp/src/frontend/Registration/Registration.test.tsx
@@ -306,7 +306,7 @@ describe('Registration', () => {
   it('takes user back when Cancel link is clicked', () => {
     history.goBack = jest.fn();
     renderComponent();
-    userEvent.click(screen.getByRole('link', { name: /cancel/i }));
+    userEvent.click(screen.getByRole('button', { name: /cancel/i }));
     expect(history.goBack).toBeCalled();
   });
 });

--- a/identity/webapp/src/frontend/Registration/Registration.tsx
+++ b/identity/webapp/src/frontend/Registration/Registration.tsx
@@ -31,7 +31,7 @@ export function Registration(): JSX.Element {
     defaultValues: { password: '' },
   });
   const { registerUser, isLoading, isSuccess, error: registrationError } = useRegisterUser();
-  const { goBack } = useHistory();
+  const history = useHistory();
 
   usePageTitle('Register for a library account');
 
@@ -214,7 +214,7 @@ export function Registration(): JSX.Element {
             />
             <SpacingComponent />
             {isLoading ? <InProgress>Creating account…</InProgress> : <Button type="submit">Create account</Button>}
-            <Cancel onClick={goBack} />
+            <Cancel onClick={history.goBack} />
           </form>
         </Wrapper>
       </Container>


### PR DESCRIPTION
Unlike Chrome, Firefox and Safari prioritise a link's href over its onclick action

