### PR TITLE
Audio transcript link

### DIFF
--- a/common/views/components/AudioPlayer/AudioPlayer.tsx
+++ b/common/views/components/AudioPlayer/AudioPlayer.tsx
@@ -3,6 +3,8 @@ import { trackEvent } from '../../../utils/ga';
 import { useEffect, useState, ReactElement, FunctionComponent } from 'react';
 import useInterval from '../../../../common/hooks/useInterval';
 import { IIIFMediaElement } from '../../../model/iiif';
+import MediaAnnotations from '../MediaAnnotations/MediaAnnotations';
+
 type Props = {
   audio: IIIFMediaElement;
 };
@@ -51,24 +53,27 @@ const AudioPlayer: FunctionComponent<Props> = ({
     isPlaying ? 1000 : null
   );
   return (
-    <audio
-      onPlay={() => {
-        setIsPlaying(true);
+    <>
+      <audio
+        onPlay={() => {
+          setIsPlaying(true);
 
-        trackEvent({
-          category: 'Audio',
-          action: 'play audio',
-          label: audio['@id'],
-        });
-      }}
-      onPause={() => {
-        setIsPlaying(false);
-      }}
-      controls
-      src={audio['@id']}
-    >
-      {`Sorry, your browser doesn't support embedded audio.`}
-    </audio>
+          trackEvent({
+            category: 'Audio',
+            action: 'play audio',
+            label: audio['@id'],
+          });
+        }}
+        onPause={() => {
+          setIsPlaying(false);
+        }}
+        controls
+        src={audio['@id']}
+      >
+        {`Sorry, your browser doesn't support embedded audio.`}
+      </audio>
+      <MediaAnnotations media={audio} />
+    </>
   );
 };
 

--- a/common/views/components/MediaAnnotations/MediaAnnotations.tsx
+++ b/common/views/components/MediaAnnotations/MediaAnnotations.tsx
@@ -1,0 +1,53 @@
+import { ReactElement, FunctionComponent } from 'react';
+import { IIIFMediaElement, IIIFAnnotationResource } from '../../../model/iiif';
+import { getAnnotationFromMediaElement } from '@weco/common/utils/iiif';
+import Space from '@weco/common/views/components/styled/Space';
+import DownloadLink from '@weco/catalogue/components/DownloadLink/DownloadLink';
+
+type Props = {
+  media: IIIFMediaElement;
+};
+
+function getMediaFormatString(format) {
+  switch (format) {
+    case 'audio/mp3':
+      return ' audio';
+    case 'video/mp4':
+      return ' video';
+    default:
+      return '';
+  }
+}
+
+const MediaAnnotations: FunctionComponent<Props> = ({
+  media,
+}: Props): ReactElement => {
+  const annotation:
+    | IIIFAnnotationResource
+    | undefined = getAnnotationFromMediaElement(media);
+  const typeString = getMediaFormatString(media.format);
+  return (
+    <>
+      {annotation &&
+        annotation.resource &&
+        annotation.resource.format === 'application/pdf' && (
+          <Space v={{ size: 's', properties: ['margin-top'] }}>
+            <DownloadLink
+              href={annotation.resource['@id']}
+              linkText={`Transcript of ${annotation.resource.label}${typeString}`}
+              format={'PDF'}
+              trackingEvent={{
+                category: 'Download link',
+                action: `follow${typeString} annotation link`,
+                label: media['@id'],
+              }}
+              mimeType={annotation.resource.format}
+              trackingTags={['annotation']}
+            />
+          </Space>
+        )}
+    </>
+  );
+};
+
+export default MediaAnnotations;

--- a/common/views/components/VideoPlayer/VideoPlayer.tsx
+++ b/common/views/components/VideoPlayer/VideoPlayer.tsx
@@ -3,9 +3,7 @@ import { trackEvent } from '@weco/common/utils/ga';
 import { FunctionComponent, useEffect, useState } from 'react';
 import useInterval from '@weco/common/hooks/useInterval';
 import { IIIFMediaElement } from '@weco/common/model/iiif';
-import { getAnnotationFromMediaElement } from '@weco/common/utils/iiif';
-import Space from '@weco/common/views/components/styled/Space';
-import DownloadLink from '@weco/catalogue/components/DownloadLink/DownloadLink';
+import MediaAnnotations from '../MediaAnnotations/MediaAnnotations';
 
 type Props = {
   video: IIIFMediaElement;
@@ -18,7 +16,6 @@ const VideoPlayer: FunctionComponent<Props> = ({
 }: Props) => {
   const [secondsPlayed, setSecondsPlayed] = useState(0);
   const [isPlaying, setIsPlaying] = useState(false);
-  const annotation: any = getAnnotationFromMediaElement(video);
 
   function trackViewingTime() {
     trackEvent({
@@ -86,24 +83,7 @@ const VideoPlayer: FunctionComponent<Props> = ({
         <source src={video['@id']} type={video.format} />
         {`Sorry, your browser doesn't support embedded video.`}
       </video>
-      {annotation &&
-        annotation.resource &&
-        annotation.resource.format === 'application/pdf' && (
-          <Space v={{ size: 's', properties: ['margin-top'] }}>
-            <DownloadLink
-              href={annotation.resource['@id']}
-              linkText={`Transcript of ${annotation.resource.label} video`}
-              format={'PDF'}
-              trackingEvent={{
-                category: 'Download link',
-                action: 'follow video annotation link',
-                label: video['@id'],
-              }}
-              mimeType={annotation.resource.format}
-              trackingTags={['annotation']}
-            />
-          </Space>
-        )}
+      <MediaAnnotations media={video} />
     </>
   );
 };


### PR DESCRIPTION
References: wellcomecollection/platform#5032

Specifically [this comment](https://github.com/wellcomecollection/platform/issues/5032#issuecomment-832476907) 

## Who is this for?
People of want to be able to read the transcript of an audio file

## What is it doing for them?
Adding a links to the transcript underneath the audio player

<img width="434" alt="Screenshot 2021-05-06 at 16 00 13" src="https://user-images.githubusercontent.com/6051896/117329056-28e9d680-ae8c-11eb-9e26-78f3aef4e378.png">

