### PR TITLE
Remove iiif toggle

### DIFF
--- a/catalogue/webapp/pages/item.tsx
+++ b/catalogue/webapp/pages/item.tsx
@@ -13,7 +13,7 @@ import {
   isUiEnabled,
   getAuthService,
   getTokenService,
-  getToggleDeterminedIIIFManifest,
+  getIIIFManifest,
 } from '@weco/common/utils/iiif';
 import { getWork, getCanvasOcr } from '../services/catalogue/works';
 import CataloguePageLayout from '@weco/common/views/components/CataloguePageLayout/CataloguePageLayout';
@@ -411,11 +411,7 @@ export const getServerSideProps: GetServerSideProps<
   const iiifImageLocation = getDigitalLocationOfType(work, 'iiif-image');
 
   const manifestOrCollection =
-    iiifPresentationUrl &&
-    (await getToggleDeterminedIIIFManifest(
-      globalContextData.toggles.switchIIIFManifestSource,
-      iiifPresentationUrl
-    ));
+    iiifPresentationUrl && (await getIIIFManifest(iiifPresentationUrl));
 
   if (manifestOrCollection) {
     // This happens when the main manifest is actually a Collection (manifest of manifest).

--- a/common/hooks/useIIIFManifestData.ts
+++ b/common/hooks/useIIIFManifestData.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, useContext } from 'react';
+import { useEffect, useState } from 'react';
 import {
   getAudio,
   getCanvases,
@@ -8,12 +8,11 @@ import {
   getUiExtensions,
   getVideo,
   isUiEnabled,
-  getToggleDeterminedIIIFManifest,
+  getIIIFManifest,
 } from '../utils/iiif';
 import { Work } from '../model/catalogue';
 import { IIIFManifest, IIIFMediaElement, IIIFRendering } from '../model/iiif';
 import { getDigitalLocationOfType } from '../utils/works';
-import TogglesContext from '../views/components/TogglesContext/TogglesContext';
 
 type IIIFManifestData = {
   imageCount: number;
@@ -62,7 +61,6 @@ const useIIIFManifestData = (work: Work): IIIFManifestData => {
     imageCount: 0,
     childManifestsCount: 0,
   });
-  const toggles = useContext(TogglesContext);
 
   useEffect(() => {
     const fetchIIIFPresentationManifest = async (work: Work) => {
@@ -75,10 +73,7 @@ const useIIIFManifestData = (work: Work): IIIFManifestData => {
 
         const iiifManifest =
           iiifPresentationLocation &&
-          (await getToggleDeterminedIIIFManifest(
-            toggles.switchIIIFManifestSource,
-            iiifPresentationLocation.url
-          ));
+          (await getIIIFManifest(iiifPresentationLocation.url));
 
         if (iiifManifest) {
           const data = parseManifest(iiifManifest);

--- a/common/utils/iiif.ts
+++ b/common/utils/iiif.ts
@@ -306,33 +306,8 @@ export function getThumbnailService(
     return service;
   }
 }
-function convertPresentationUrlToStage(originalUrl: string): string {
-  const originalUrlObject = new URL(originalUrl);
-  if (originalUrlObject.hostname === 'wellcomelibrary.org') {
-    const stageUrlObject = new URL(
-      originalUrlObject.pathname,
-      `${originalUrlObject.protocol}//stage.wellcomelibrary.org`
-    );
-    return stageUrlObject.href;
-  } else {
-    return originalUrl;
-  }
-}
 
-// Allows us to test with iiif manifests served from iiif.wellcomecollection.org rather than wellcomelibrary.org
-// e.g. converts http://wellcomelibrary.org/iiif/b28047345/manifest
-// to http://stage.wellcomelibrary.org/iiif/b28047345/manifest
-// which gets redirected to https://iiif.wellcomecollection.org/presentation/v2/b28047345
-export async function getToggleDeterminedIIIFManifest(
-  toggle: boolean,
-  url: string
-): Promise<IIIFManifest> {
-  if (toggle) {
-    const iiifPresentationUrlOnStage = convertPresentationUrlToStage(url);
-    const manifest = await fetchJson(iiifPresentationUrlOnStage);
-    return manifest;
-  } else {
-    const manifest = await fetchJson(url);
-    return manifest;
-  }
+export async function getIIIFManifest(url: string): Promise<IIIFManifest> {
+  const manifest = await fetchJson(url);
+  return manifest;
 }

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -33,13 +33,6 @@ export default {
         'Displays body copy in Helvetica regular (where it is currently Helvetica light)',
     },
     {
-      id: 'switchIIIFManifestSource',
-      title: 'Switch IIIF manifest source',
-      defaultValue: false,
-      description:
-        'Switches the manifest sources from wellcomelibrary.org to iiif.wellcomecollection.org for testing.',
-    },
-    {
       id: 'newSiteSections',
       title: 'New site sections - Get Involved and About us',
       defaultValue: false,


### PR DESCRIPTION
## Who is this for?
Developers who don't want redundant code left lying around

## What is it doing for them?
Now that the redirects for iiif presentation manifests are live, we no longer need the toggle and associated code that was put in place for testing.
