### PR TITLE
Remove open shelves library link

### DIFF
--- a/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
+++ b/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
@@ -7,7 +7,12 @@ import {
   getLocationShelfmark,
 } from '@weco/common/utils/works';
 import ButtonOutlinedLink from '@weco/common/views/components/ButtonOutlinedLink/ButtonOutlinedLink';
+import WorkDetailsText from '../WorkDetailsText/WorkDetailsText';
 
+function getFirstPhysicalLocation(item) {
+  // In practice we only expect one physical location per item
+  return item.locations.find(location => location.type === 'PhysicalLocation');
+}
 type Props = { items: PhysicalItem[]; encoreLink?: string };
 const PhysicalItems: FunctionComponent<Props> = ({
   items,
@@ -15,32 +20,56 @@ const PhysicalItems: FunctionComponent<Props> = ({
 }: Props) => {
   const headerRow = [/* 'Status', */ 'Location/Shelfmark', 'Access', 'Title']; // TODO status requires item API
   const bodyRows = items.map(item => {
-    const physicalLocation = item.locations.find(
-      // in practice we only expect one physical location per item
-      location => location.type === 'PhysicalLocation'
-    );
+    const physicalLocation = getFirstPhysicalLocation(item);
     const locationText = physicalLocation?.locationType.label ?? '';
     const locationLabel =
       physicalLocation && getLocationLabel(physicalLocation);
     const locationShelfmark =
       physicalLocation && getLocationShelfmark(physicalLocation);
     const shelfmark = `${locationLabel ?? ''} ${locationShelfmark ?? ''}`;
+    const accessLabel =
+      physicalLocation?.accessConditions[0].status.label ?? '';
+
     // TODO clarify difference between locationLabel and locationText and which we should be using
     return [
       /* status, TODO status requires item API */
       shelfmark,
-      locationText !== 'Open shelves' && encoreLink ? (
+      locationText !== 'Open shelves' &&
+      accessLabel !== 'By appointment' && // TODO question: are there other circumstances where we don't want the encore link?
+      encoreLink ? (
         <ButtonOutlinedLink text="Request this item" link={encoreLink} />
       ) : (
-        locationText
+        accessLabel
       ),
       item.title || 'unknown',
     ];
   });
 
+  const accessCondtionsTerms = items
+    .map(item => {
+      // TODO question: we're displaying accessConditions below the table, as per design, but need to check how this will work if we have multiple items with access conditions - design only really works for one such item.
+
+      const physicalLocation = getFirstPhysicalLocation(item);
+      return physicalLocation?.accessConditions[0].terms ?? null; // TODO question: in practice we only expect one access condition per item, is this true?
+    })
+    .filter(Boolean);
+
   return (
     <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
       <Table hasRowHeaders={false} rows={[headerRow, ...bodyRows]} />
+      {accessCondtionsTerms[0] && (
+        <Space
+          v={{
+            size: 'l',
+            properties: ['margin-top'],
+          }}
+        >
+          <WorkDetailsText
+            title="Access conditions"
+            text={accessCondtionsTerms}
+          />
+        </Space>
+      )}
     </Space>
   );
 };

--- a/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
+++ b/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
@@ -57,6 +57,8 @@ const PhysicalItems: FunctionComponent<Props> = ({
           ),
           item.title || 'n/a',
         ];
+      } else {
+        return [];
       }
     })
     .filter(Boolean);

--- a/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
+++ b/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
@@ -6,27 +6,36 @@ import {
   getLocationLabel,
   getLocationShelfmark,
 } from '@weco/common/utils/works';
+import ButtonOutlinedLink from '@weco/common/views/components/ButtonOutlinedLink/ButtonOutlinedLink';
 
-type Props = { items: PhysicalItem[] };
-const PhysicalItems: FunctionComponent<Props> = ({ items }: Props) => {
-  const headerRow = ['Title', 'Location', 'Shelfmark'];
+type Props = { items: PhysicalItem[]; encoreLink?: string };
+const PhysicalItems: FunctionComponent<Props> = ({
+  items,
+  encoreLink,
+}: Props) => {
+  const headerRow = ['Title', 'Location', 'Shelfmark', 'Access'];
   const bodyRows = items.map(item => {
-    const physicalLocations = item.locations.filter(
+    const physicalLocation = item.locations.find(
+      // in practice we only expect one physical location per item
       location => location.type === 'PhysicalLocation'
     );
-    const locationText = physicalLocations
-      .map(location => {
-        return location.locationType.label ?? '';
-      })
-      .join(', ');
-    const shelfmark = physicalLocations
-      .map(location => {
-        const locationLabel = getLocationLabel(location);
-        const locationShelfmark = getLocationShelfmark(location);
-        return `${locationLabel ?? ''} ${locationShelfmark ?? ''}`;
-      })
-      .join(', ');
-    return [item.title || 'unknown', locationText, shelfmark];
+    const locationText = physicalLocation?.locationType.label ?? '';
+    const locationLabel =
+      physicalLocation && getLocationLabel(physicalLocation);
+    const locationShelfmark =
+      physicalLocation && getLocationShelfmark(physicalLocation);
+    const shelfmark = `${locationLabel ?? ''} ${locationShelfmark ?? ''}`;
+
+    return [
+      item.title || 'unknown',
+      locationText,
+      shelfmark,
+      locationText !== 'Open shelves' && encoreLink ? (
+        <ButtonOutlinedLink text="Request this item" link={encoreLink} />
+      ) : (
+        'Open shelves'
+      ),
+    ];
   });
 
   return (

--- a/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
+++ b/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
@@ -50,7 +50,7 @@ const PhysicalItems: FunctionComponent<Props> = ({
           encoreLink ? (
             <ButtonOutlinedLink text="Request item" link={encoreLink} />
           ) : (
-            accessLabel
+            accessLabel || physicalLocation?.locationType.label
           ),
           item.title || 'n/a',
         ];

--- a/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
+++ b/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
@@ -84,7 +84,7 @@ const PhysicalItems: FunctionComponent<Props> = ({
 
   return (
     <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
-      {bodyRows[0] && (
+      {bodyRows[0][0] && (
         <Table hasRowHeaders={false} rows={[headerRow, ...bodyRows]} />
       )}
       {accessCondtionsTerms[0] && (

--- a/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
+++ b/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
@@ -13,7 +13,7 @@ const PhysicalItems: FunctionComponent<Props> = ({
   items,
   encoreLink,
 }: Props) => {
-  const headerRow = ['Title', 'Location', 'Shelfmark', 'Access'];
+  const headerRow = [/* 'Status', */ 'Location/Shelfmark', 'Access', 'Title']; // TODO status requires item API
   const bodyRows = items.map(item => {
     const physicalLocation = item.locations.find(
       // in practice we only expect one physical location per item
@@ -25,16 +25,16 @@ const PhysicalItems: FunctionComponent<Props> = ({
     const locationShelfmark =
       physicalLocation && getLocationShelfmark(physicalLocation);
     const shelfmark = `${locationLabel ?? ''} ${locationShelfmark ?? ''}`;
-
+    // TODO clarify difference between locationLabel and locationText and which we should be using
     return [
-      item.title || 'unknown',
-      locationText,
+      /* status, TODO status requires item API */
       shelfmark,
       locationText !== 'Open shelves' && encoreLink ? (
         <ButtonOutlinedLink text="Request this item" link={encoreLink} />
       ) : (
         locationText
       ),
+      item.title || 'unknown',
     ];
   });
 

--- a/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
+++ b/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
@@ -33,7 +33,7 @@ const PhysicalItems: FunctionComponent<Props> = ({
       locationText !== 'Open shelves' && encoreLink ? (
         <ButtonOutlinedLink text="Request this item" link={encoreLink} />
       ) : (
-        'Open shelves'
+        locationText
       ),
     ];
   });

--- a/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
+++ b/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
@@ -9,7 +9,6 @@ import {
 import ButtonOutlinedLink from '@weco/common/views/components/ButtonOutlinedLink/ButtonOutlinedLink';
 import WorkDetailsText from '../WorkDetailsText/WorkDetailsText';
 
-// TODO question: are there other circumstances where something isn't requestable? // isRequestableByAccessCondition? yedqmmxp
 function isRequestableByLocation(id: string): boolean {
   return Boolean(id !== 'on-exhibition' && id !== 'open-shelves');
 }
@@ -41,19 +40,17 @@ const PhysicalItems: FunctionComponent<Props> = ({
       const accessLabel =
         physicalLocation?.accessConditions[0]?.status?.label ?? '';
 
-      // TODO clarify difference between locationLabel and locationText and which we should be using
       if (locationId !== 'on-order') {
         return [
-          // We don't want to display on order items in a table, we just show the label
+          // We don't want to display items that are on order in a table, we just show the location label
           /* status, TODO status requires item API */
           shelfmark,
-          // TODO use ids not labels
           isRequestableByLocation(locationId) &&
           isRequestableByAccessCondition(accessId) &&
           encoreLink ? (
             <ButtonOutlinedLink text="Request item" link={encoreLink} />
           ) : (
-            accessLabel // TODO or something else?
+            accessLabel
           ),
           item.title || 'n/a',
         ];
@@ -65,10 +62,8 @@ const PhysicalItems: FunctionComponent<Props> = ({
 
   const accessCondtionsTerms = items
     .map(item => {
-      // TODO question: we're displaying accessConditions below the table, as per design, but need to check how this will work if we have multiple items with access conditions - design only really works for one such item.
-
       const physicalLocation = getFirstPhysicalLocation(item);
-      return physicalLocation?.accessConditions[0]?.terms ?? null; // TODO question: in practice we only expect one access condition per item, is this true?
+      return physicalLocation?.accessConditions[0]?.terms ?? null;
     })
     .filter(Boolean);
 

--- a/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
+++ b/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
@@ -9,6 +9,15 @@ import {
 import ButtonOutlinedLink from '@weco/common/views/components/ButtonOutlinedLink/ButtonOutlinedLink';
 import WorkDetailsText from '../WorkDetailsText/WorkDetailsText';
 
+// TODO question: are there other circumstances where something isn't requestable? // isRequestableByAccessCondition? yedqmmxp
+function isRequestableByLocation(id: string): boolean {
+  return Boolean(id !== 'on-exhibition' && id !== 'open-shelves');
+}
+
+function isRequestableByAccessCondition(id: string): boolean {
+  return Boolean(id !== 'by-appointment' && id !== 'restricted');
+}
+
 function getFirstPhysicalLocation(item) {
   // In practice we only expect one physical location per item
   return item.locations.find(location => location.type === 'PhysicalLocation');
@@ -22,15 +31,15 @@ const PhysicalItems: FunctionComponent<Props> = ({
   const bodyRows = items
     .map(item => {
       const physicalLocation = getFirstPhysicalLocation(item);
-      const locationText = physicalLocation?.locationType.label ?? '';
       const locationId = physicalLocation?.locationType.id;
       const locationLabel =
         physicalLocation && getLocationLabel(physicalLocation);
       const locationShelfmark =
         physicalLocation && getLocationShelfmark(physicalLocation);
       const shelfmark = `${locationLabel ?? ''} ${locationShelfmark ?? ''}`;
+      const accessId = physicalLocation?.accessConditions[0]?.status?.id ?? '';
       const accessLabel =
-        physicalLocation?.accessConditions[0]?.status.label ?? '';
+        physicalLocation?.accessConditions[0]?.status?.label ?? '';
 
       // TODO clarify difference between locationLabel and locationText and which we should be using
       if (locationId !== 'on-order') {
@@ -39,12 +48,12 @@ const PhysicalItems: FunctionComponent<Props> = ({
           /* status, TODO status requires item API */
           shelfmark,
           // TODO use ids not labels
-          locationText !== 'Open shelves' &&
-          accessLabel !== 'By appointment' && // TODO question: are there other circumstances where we don't want the encore link?
+          isRequestableByLocation(locationId) &&
+          isRequestableByAccessCondition(accessId) &&
           encoreLink ? (
             <ButtonOutlinedLink text="Request item" link={encoreLink} />
           ) : (
-            accessLabel
+            accessLabel // TODO or something else?
           ),
           item.title || 'n/a',
         ];

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -155,7 +155,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
     identifierId: 'sierra-system-number',
   });
 
-  const sierraWorkId = sierraWorkIds.length >= 1 ? sierraWorkIds[0] : null;
+  const sierraWorkId = sierraWorkIds[0];
 
   const encoreLink = sierraWorkId && getEncoreLink(sierraWorkId);
 
@@ -215,7 +215,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
           text={locationOfWork.contents}
         />
       )}
-      {showEncoreLink && (
+      {showEncoreLink && !showPhysicalItems && (
         <Space
           v={{
             size: 'l',
@@ -230,7 +230,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
         </Space>
       )}
       {showPhysicalItems && physicalItems && (
-        <PhysicalItems items={physicalItems} />
+        <PhysicalItems items={physicalItems} encoreLink={encoreLink} />
       )}
     </WorkDetailsSection>
   );


### PR DESCRIPTION
References #6470

- removes the library link for items on the open shelves (as well as items that are restricted, by-appointment or on-exhibition)
- makes  other changes to match the latest Zeplin designs:
  - [Access-conditions-longest-example](https://app.zeplin.io/project/5aab926b4b6efde01259e959/screen/6098f2aa205ca4143eec0ab5)
  - [Closed stores](https://app.zeplin.io/project/5aab926b4b6efde01259e959/screen/6098edbb10d91d112fa91a7d)
  - [On Order item_6May](https://app.zeplin.io/project/5aab926b4b6efde01259e959/screen/6098e92c50c3c0111a306b3a)
  - [open shelves + shelfmark](https://app.zeplin.io/project/5aab926b4b6efde01259e959/screen/6098e78b47fd4610d32247e6)
  - [digital and physical item](https://app.zeplin.io/project/5aab926b4b6efde01259e959/screen/6098e1a684a9503b87c392a8)
  - [open shelves + holdings](https://app.zeplin.io/project/5aab926b4b6efde01259e959/screen/60940d49e4772b3753a8eebf)
  - [holdings + closed stores](https://app.zeplin.io/project/5aab926b4b6efde01259e959/screen/6093fa496cbb4c0b83c64e94)
  - [On exhibition](https://app.zeplin.io/project/5aab926b4b6efde01259e959/screen/6093a72905f5e03497bf7983)