### PR TITLE
Split e2e tests out

### DIFF
--- a/.buildkite/pipeline.deploy-prod.yml
+++ b/.buildkite/pipeline.deploy-prod.yml
@@ -1,7 +1,7 @@
 steps:
   - label: "deploy to prod"
     concurrency: 1
-    concurrency_group: "experience-deploy"  
+    concurrency_group: "experience-deploy"
     plugins:
       - docker#v3.5.0:
           image: 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/weco-deploy:5.6.16
@@ -15,21 +15,17 @@ steps:
               "--environment-id", "prod",
               "--description", $BUILDKITE_BUILD_URL,
               "--confirmation-wait-for", 3540] # Session times out at 3600s / 1 hour
-    
+
   - wait
 
-  - label: "e2e test:desktop [prod]"
-    plugins:
-      - docker-compose#v3.5.0:
-          run: e2e
-          env:
-            - PLAYWRIGHT_BASE_URL=https://wellcomecollection.org
-          command: ["yarn", "test"]
-
-  - label: "e2e test:mobile [prod]"
-    plugins:
-      - docker-compose#v3.5.0:
-          run: e2e
-          env:
-            - PLAYWRIGHT_BASE_URL=https://wellcomecollection.org
-          command: ["yarn", "test:mobile"]
+  - label: "e2e test"
+    trigger: "experience-e2e-prod"
+    branches: "master"
+    build:
+      message: "${BUILDKITE_MESSAGE}"
+      commit: "${BUILDKITE_COMMIT}"
+      branch: "${BUILDKITE_BRANCH}"
+      env:
+        BUILDKITE_PULL_REQUEST: "${BUILDKITE_PULL_REQUEST}"
+        BUILDKITE_PULL_REQUEST_BASE_BRANCH: "${BUILDKITE_PULL_REQUEST_BASE_BRANCH}"
+        BUILDKITE_PULL_REQUEST_REPO: "${BUILDKITE_PULL_REQUEST_REPO}"

--- a/.buildkite/pipeline.deploy-stage.yml
+++ b/.buildkite/pipeline.deploy-stage.yml
@@ -18,21 +18,17 @@ steps:
 
   - wait
 
-  - label: "e2e test:desktop [stage]"
-    plugins:
-      - docker-compose#v3.5.0:
-          run: e2e
-          env:
-            - PLAYWRIGHT_BASE_URL=https://www-stage.wellcomecollection.org
-          command: ["yarn", "test"]
-
-  - label: "e2e test:mobile [stage]"
-    plugins:
-      - docker-compose#v3.5.0:
-          run: e2e
-          env:
-            - PLAYWRIGHT_BASE_URL=https://www-stage.wellcomecollection.org
-          command: ["yarn", "test:mobile"]
+  - label: "e2e test"
+    trigger: "experience-e2e-stage"
+    branches: "master"
+    build:
+      message: "${BUILDKITE_MESSAGE}"
+      commit: "${BUILDKITE_COMMIT}"
+      branch: "${BUILDKITE_BRANCH}"
+      env:
+        BUILDKITE_PULL_REQUEST: "${BUILDKITE_PULL_REQUEST}"
+        BUILDKITE_PULL_REQUEST_BASE_BRANCH: "${BUILDKITE_PULL_REQUEST_BASE_BRANCH}"
+        BUILDKITE_PULL_REQUEST_REPO: "${BUILDKITE_PULL_REQUEST_REPO}"
 
   - wait
 

--- a/.buildkite/pipeline.e2e-prod.yml
+++ b/.buildkite/pipeline.e2e-prod.yml
@@ -1,0 +1,16 @@
+steps:
+  - label: "e2e test:desktop [prod]"
+    plugins:
+      - docker-compose#v3.5.0:
+          run: e2e
+          env:
+            - PLAYWRIGHT_BASE_URL=https://wellcomecollection.org
+          command: ["yarn", "test"]
+
+  - label: "e2e test:mobile [prod]"
+    plugins:
+      - docker-compose#v3.5.0:
+          run: e2e
+          env:
+            - PLAYWRIGHT_BASE_URL=https://wellcomecollection.org
+          command: ["yarn", "test:mobile"]

--- a/.buildkite/pipeline.e2e-stage.yml
+++ b/.buildkite/pipeline.e2e-stage.yml
@@ -1,0 +1,16 @@
+steps:
+  - label: "e2e test:desktop [stage]"
+    plugins:
+      - docker-compose#v3.5.0:
+          run: e2e
+          env:
+            - PLAYWRIGHT_BASE_URL=https://www-stage.wellcomecollection.org
+          command: ["yarn", "test"]
+
+  - label: "e2e test:mobile [stage]"
+    plugins:
+      - docker-compose#v3.5.0:
+          run: e2e
+          env:
+            - PLAYWRIGHT_BASE_URL=https://www-stage.wellcomecollection.org
+          command: ["yarn", "test:mobile"]


### PR DESCRIPTION
## Who is this for?

Folk who want to trigger e2e tests outside this repo.

## What is it doing for them?

By splitting the e2e test step we can replace the front-end facing integration tests here: https://github.com/wellcomecollection/integration