### PR TITLE
Add variable to playwright tests to use stage apis

### DIFF
--- a/.buildkite/pipeline.e2e.yml
+++ b/.buildkite/pipeline.e2e.yml
@@ -1,0 +1,18 @@
+steps:
+  - label: "e2e test:desktop"
+    plugins:
+      - docker-compose#v3.5.0:
+          run: e2e
+          env:
+            - PLAYWRIGHT_BASE_URL
+            - USE_STAGE_APIS
+          command: ["yarn", "test"]
+
+  - label: "e2e test:mobile"
+    plugins:
+      - docker-compose#v3.5.0:
+          run: e2e
+          env:
+            - PLAYWRIGHT_BASE_URL
+            - USE_STAGE_APIS
+          command: ["yarn", "test:mobile"]

--- a/playwright/test/contexts.ts
+++ b/playwright/test/contexts.ts
@@ -1,38 +1,50 @@
-import { baseUrl } from './helpers/urls';
+import { baseUrl, useStageApis } from './helpers/urls';
+
+const createCookie = (name: string) => {
+  return {
+    name: name,
+    value: 'true',
+    path: '/',
+    domain: new URL(baseUrl).host,
+  };
+};
+
+const acceptCookieCookie = createCookie('WC_cookiesAccepted');
+const stageApiToggleCookie = createCookie('toggle_stagingApi');
+
+// TODO: context.addCookies should run for the first test of a suite (even on beforeAll/beforeEach)
+
+const requiredCookies = useStageApis
+  ? [acceptCookieCookie, stageApiToggleCookie]
+  : [acceptCookieCookie];
 
 const multiVolumeItem = async (): Promise<void> => {
+  context.addCookies(requiredCookies);
   await page.goto(`${baseUrl}/works/mg56yqa4/items`);
 };
 
 const itemWithSearchAndStructures = async (): Promise<void> => {
+  context.addCookies(requiredCookies);
   await page.goto(`${baseUrl}/works/re9cyhkt/items`);
 };
 
 const workWithPhysicalAndDigitalLocation = async (): Promise<void> => {
+  context.addCookies(requiredCookies);
   await page.goto(`${baseUrl}/works/a235xn8e`);
 };
 
 const workWithPhysicalLocationOnly = async (): Promise<void> => {
+  context.addCookies(requiredCookies);
   await page.goto(`${baseUrl}/works/ffd3zeq3`);
 };
 
 const workWithDigitalLocationOnly = async (): Promise<void> => {
+  context.addCookies(requiredCookies);
   await page.goto(`${baseUrl}/works/m54uwqgm`);
 };
 
 const worksSearch = async (): Promise<void> => {
-  // This is because the cookie notice actually hides interface.
-  // It should also not live here, but I was battling on getting it to
-  // run for the first test of a suite (even on beforeAll/beforeEach)
-  context.addCookies([
-    {
-      name: 'WC_cookiesAccepted',
-      value: 'true',
-      path: '/',
-      domain: new URL(baseUrl).host,
-    },
-  ]);
-
+  context.addCookies(requiredCookies);
   await page.goto(`${baseUrl}/works`);
 };
 

--- a/playwright/test/helpers/urls.ts
+++ b/playwright/test/helpers/urls.ts
@@ -1,6 +1,8 @@
 export const baseUrl = process.env.PLAYWRIGHT_BASE_URL
   ? process.env.PLAYWRIGHT_BASE_URL
   : 'http://localhost:3000';
+export const useStageApis = process.env.USE_STAGE_APIS
+  ? process.env.USE_STAGE_APIS && process.env.USE_STAGE_APIS === 'true'
+  : false;
 export const worksUrl = `${baseUrl}/works`;
 export const imagesUrl = `${baseUrl}/images`;
-export const useStageApis = 'USE_STAGE_APIS' in process.env;

--- a/playwright/test/helpers/urls.ts
+++ b/playwright/test/helpers/urls.ts
@@ -3,3 +3,4 @@ export const baseUrl = process.env.PLAYWRIGHT_BASE_URL
   : 'http://localhost:3000';
 export const worksUrl = `${baseUrl}/works`;
 export const imagesUrl = `${baseUrl}/images`;
+export const useStageApis = 'USE_STAGE_APIS' in process.env;


### PR DESCRIPTION
## Who is this for?

Folk who want to run the playwright tests with stage APIs

## What is it doing for them?

Allowing the catalogue-api smoke tests to ensure the current prod deploy of the wellcomecollection.org site will work with what's in stage - thereby indicating it is safe to deploy catalogue-api stage to prod.