### PR TITLE
Exhibition related pages

### DIFF
--- a/common/services/prismic/exhibitions.js
+++ b/common/services/prismic/exhibitions.js
@@ -57,6 +57,7 @@ import type {
   ExhibitionFormat,
 } from '../../model/exhibitions';
 import type { MultiContent } from '../../model/multi-content';
+import { getPages } from './pages';
 
 const startField = 'my.exhibitions.start';
 const endField = 'my.exhibitions.end';
@@ -393,6 +394,35 @@ export async function getExhibition(
     const exhibition = parseExhibitionDoc(document);
     return exhibition;
   }
+}
+
+export async function getExhibitionWithRelatedContent({
+  request,
+  id,
+  memoizedPrismic,
+}: {
+  request: ?Request,
+  memoizedPrismic: ?Object,
+  id: string,
+}) {
+  const exhibitionPromise = await getExhibition(request, id, memoizedPrismic);
+  const pagesPromise = await getPages(
+    request,
+    {
+      predicates: [Prismic.Predicates.at('my.pages.parents.parent', id)],
+    },
+    memoizedPrismic
+  );
+
+  const [exhibition, pages] = await Promise.all([
+    exhibitionPromise,
+    pagesPromise,
+  ]);
+
+  return {
+    exhibition,
+    pages,
+  };
 }
 
 type ExhibitionRelatedContent = {|

--- a/content/webapp/components/Exhibition/Exhibition.js
+++ b/content/webapp/components/Exhibition/Exhibition.js
@@ -273,6 +273,8 @@ const Exhibition = ({ exhibition, pages }: Props) => {
             contributors={exhibition.contributors}
           />
         )}
+        {/* TODO: This probably isn't going to be the final resting place for related `pages`, but it's
+        a reasonable starting place. Update this once the UX has shaken out. */}
         {(exhibitionOfs.length > 0 || pages.length > 0) && (
           <SearchResults
             items={[...exhibitionOfs, ...pages]}

--- a/content/webapp/components/Exhibition/Exhibition.js
+++ b/content/webapp/components/Exhibition/Exhibition.js
@@ -25,6 +25,8 @@ import BookPromo from '@weco/common/views/components/BookPromo/BookPromo';
 import { font, grid } from '@weco/common/utils/classnames';
 import { convertImageUri } from '@weco/common/utils/convert-image-uri';
 import type { UiExhibition } from '@weco/common/model/exhibitions';
+import { type Page } from '@weco/common/model/pages';
+
 // $FlowFixMe (tsx)
 import Space from '@weco/common/views/components/styled/Space';
 
@@ -157,9 +159,10 @@ export function getInfoItems(exhibition: UiExhibition) {
 
 type Props = {|
   exhibition: UiExhibition,
+  pages: Page[],
 |};
 
-const Exhibition = ({ exhibition }: Props) => {
+const Exhibition = ({ exhibition, pages }: Props) => {
   const [exhibitionOfs, setExhibitionOfs] = useState([]);
   const [exhibitionAbouts, setExhibitionAbouts] = useState([]);
 
@@ -270,9 +273,13 @@ const Exhibition = ({ exhibition }: Props) => {
             contributors={exhibition.contributors}
           />
         )}
-        {exhibitionOfs.length > 0 && (
-          <SearchResults items={exhibitionOfs} title={`In this exhibition`} />
+        {(exhibitionOfs.length > 0 || pages.length > 0) && (
+          <SearchResults
+            items={[...exhibitionOfs, ...pages]}
+            title={`In this exhibition`}
+          />
         )}
+
         {exhibition.end && !isPast(exhibition.end) && (
           <InfoBox title="Visit us" items={getInfoItems(exhibition)}>
             <p className={`no-margin ${font('hnl', 5)}`}>

--- a/content/webapp/pages/exhibition.js
+++ b/content/webapp/pages/exhibition.js
@@ -1,29 +1,36 @@
 // @flow
 import { type Context } from 'next';
 import { type UiExhibition } from '@weco/common/model/exhibitions';
-import { getExhibition } from '@weco/common/services/prismic/exhibitions';
+import { type Page } from '@weco/common/model/pages';
+import { getExhibitionWithRelatedContent } from '@weco/common/services/prismic/exhibitions';
 import Exhibition from '../components/Exhibition/Exhibition';
 import Installation from '../components/Installation/Installation';
 
 type Props = {|
   exhibition: UiExhibition,
+  pages: Page[],
 |};
 
-const ExhibitionPage = ({ exhibition }: Props) => {
+const ExhibitionPage = ({ exhibition, pages }: Props) => {
   if (exhibition.format && exhibition.format.title === 'Installation') {
     return <Installation installation={exhibition} />;
   } else {
-    return <Exhibition exhibition={exhibition} />;
+    return <Exhibition exhibition={exhibition} pages={pages} />;
   }
 };
 
 ExhibitionPage.getInitialProps = async (ctx: Context) => {
   const { id, memoizedPrismic } = ctx.query;
-  const exhibition = await getExhibition(ctx.req, id, memoizedPrismic);
+  const { exhibition, pages } = await getExhibitionWithRelatedContent({
+    request: ctx.req,
+    id,
+    memoizedPrismic,
+  });
 
   if (exhibition) {
     return {
       exhibition,
+      pages: pages?.results || [],
     };
   } else {
     return { statusCode: 404 };


### PR DESCRIPTION
Closes #6435 and closes #6461

A `page` in Prismic can now take an `exhibition` as a parent. An exhibition then queries for this related content at the point of getting the exhibition itself (in the same way we do for Seasons).

We now have two ways of doing related content in exhibitions: 1. attaching it to the exhibition itself (the old way), 2. attaching the exhibition to the child (this new way).

I think if we're happy with the new way, we should go back and update the way the old related content works for exhibitions, too, so that content editors only have to know one system for relating things to each other, and that we don't have a one-off way of doing it in the code.

<img width="941" alt="Screenshot 2021-05-10 at 12 10 11" src="https://user-images.githubusercontent.com/1394592/117819286-4f7b8900-b261-11eb-9b3c-d0979569d852.png">

