### PR TITLE
Remove chevron labels

### DIFF
--- a/cache/edge_lambdas/src/toggler.ts
+++ b/cache/edge_lambdas/src/toggler.ts
@@ -19,14 +19,7 @@ type Test = {
 };
 
 // This is mutable for testing
-export let tests: Test[] = [
-  {
-    id: 'showSidebarToggleLabel',
-    title: 'Sidebar show/hide toggle label visibility',
-    range: [0, 100],
-    when: request => Boolean(request.uri.match(/^\/works\/.*\/items/)),
-  },
-];
+export let tests: Test[] = [];
 export const setTests = function(newTests: Test[]): void {
   tests = newTests;
 };

--- a/common/views/components/IIIFViewer/ViewerTopBar.tsx
+++ b/common/views/components/IIIFViewer/ViewerTopBar.tsx
@@ -6,10 +6,8 @@ import Icon from '@weco/common/views/components/Icon/Icon';
 import Space from '@weco/common/views/components/styled/Space';
 import { FunctionComponent, useContext, RefObject } from 'react';
 import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
-import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
 import ItemViewerContext from '@weco/common/views/components/ItemViewerContext/ItemViewerContext';
 import useIsFullscreenEnabled from '@weco/common/hooks/useIsFullscreenEnabled';
-import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper/ConditionalWrapper';
 import ToolbarSegmentedControl from '../ToolbarSegmentedControl/ToolbarSegmentedControl';
 
 // TODO: update this with a more considered button from our system
@@ -99,7 +97,7 @@ const Sidebar = styled(Space).attrs({
   grid-column-start: left-edge;
   grid-column-end: desktop-sidebar-end;
   display: flex;
-  justify-content: flex-start;
+  justify-content: flex-end;
   align-items: center;
 
   ${props =>
@@ -152,7 +150,6 @@ type Props = {
 
 const ViewerTopBar: FunctionComponent<Props> = ({ viewerRef }: Props) => {
   const { isEnhanced } = useContext(AppContext);
-  const { showSidebarToggleLabel } = useContext(TogglesContext);
   const isFullscreenEnabled = useIsFullscreenEnabled();
   const {
     canvases,
@@ -200,15 +197,9 @@ const ViewerTopBar: FunctionComponent<Props> = ({ viewerRef }: Props) => {
                     'icon--180': !isDesktopSidebarActive,
                   })}
                 />
-                <ConditionalWrapper
-                  condition={!showSidebarToggleLabel}
-                  wrapper={children => (
-                    <span className={`visually-hidden`}>{children}</span>
-                  )}
-                >
-                  {isDesktopSidebarActive ? 'Hide' : 'Show'}
-                  {' info'}
-                </ConditionalWrapper>
+                <span className={`visually-hidden`}>
+                  {isDesktopSidebarActive ? 'Hide info' : 'Show info'}
+                </span>
               </ShameButton>
               <ShameButton
                 className={`viewer-mobile`}

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -39,14 +39,5 @@ export default {
       description: 'A toolbar to help us navigate the secret depths of the API',
     },
   ] as const,
-  tests: [
-    {
-      id: 'showSidebarToggleLabel',
-      title: 'Sidebar show/hide toggle label visibility',
-      range: [0, 100],
-      defaultValue: true,
-      description:
-        'Testing whether the presence of a label alongside the chevrons to show/hide the sidebar will impact on button usage',
-    },
-  ] as const,
+  tests: [] as const,
 };

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -1,3 +1,10 @@
+type ABTest = {
+  id: string;
+  title: string;
+  range: [number, number];
+  description: string;
+  defaultValue: boolean;
+};
 export default {
   toggles: [
     {
@@ -39,5 +46,5 @@ export default {
       description: 'A toolbar to help us navigate the secret depths of the API',
     },
   ] as const,
-  tests: [] as const,
+  tests: [] as ABTest[],
 };


### PR DESCRIPTION
A/B test results showed marginally more usage of the show/hide sidebar toggle button when it didn't have a label associated with it. That coupled with the design decision that it would look better without means that we can remove the (visible) labels.

I've also aligned the chevrons to the right of the sidebar area, which was the original design intention that I missed, but we didn't want to change while the a/b test was running (I didn't think this warranted a separate test). [See this thread in Slack for more context](https://wellcome.slack.com/archives/C294K7D5M/p1619695001071600).

![image](https://user-images.githubusercontent.com/1394592/118111461-a016f180-b3db-11eb-89dc-20e9318b5f3a.png)
