### PR TITLE
fixes error where bodyRows was an empty array

### DIFF
--- a/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
+++ b/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent } from 'react';
+import { FunctionComponent, ReactElement } from 'react';
 import { PhysicalItem } from '@weco/common/model/catalogue';
 import Table from '@weco/common/views/components/Table/Table';
 import Space from '@weco/common/views/components/styled/Space';
@@ -21,44 +21,49 @@ function getFirstPhysicalLocation(item) {
   // In practice we only expect one physical location per item
   return item.locations.find(location => location.type === 'PhysicalLocation');
 }
+
+function createBodyRow(
+  item: PhysicalItem,
+  encoreLink: string | undefined
+): (string | ReactElement)[] | undefined {
+  const physicalLocation = getFirstPhysicalLocation(item);
+  const locationId = physicalLocation?.locationType.id;
+  const locationLabel = physicalLocation && getLocationLabel(physicalLocation);
+  const locationShelfmark =
+    physicalLocation && getLocationShelfmark(physicalLocation);
+  const shelfmark = `${locationLabel ?? ''} ${locationShelfmark ?? ''}`;
+  const accessId = physicalLocation?.accessConditions[0]?.status?.id ?? '';
+  const accessLabel =
+    physicalLocation?.accessConditions[0]?.status?.label ?? '';
+
+  if (locationId !== 'on-order') {
+    return [
+      // We don't want to display items that are on order in a table, we just show the location label
+      /* status, TODO status requires item API */
+      shelfmark,
+      isRequestableByLocation(locationId) &&
+      isRequestableByAccessCondition(accessId) &&
+      encoreLink ? (
+        <ButtonOutlinedLink text="Request item" link={encoreLink} />
+      ) : (
+        accessLabel || physicalLocation?.locationType.label
+      ),
+      item.title || 'n/a',
+    ];
+  }
+}
+
+function createBodyRows(items, encoreLink) {
+  return items.map(item => createBodyRow(item, encoreLink)).filter(Boolean);
+}
+
 type Props = { items: PhysicalItem[]; encoreLink?: string };
 const PhysicalItems: FunctionComponent<Props> = ({
   items,
   encoreLink,
 }: Props) => {
   const headerRow = [/* 'Status', */ 'Location/Shelfmark', 'Access', 'Title']; // TODO status requires item API
-  const bodyRows = items
-    .map(item => {
-      const physicalLocation = getFirstPhysicalLocation(item);
-      const locationId = physicalLocation?.locationType.id;
-      const locationLabel =
-        physicalLocation && getLocationLabel(physicalLocation);
-      const locationShelfmark =
-        physicalLocation && getLocationShelfmark(physicalLocation);
-      const shelfmark = `${locationLabel ?? ''} ${locationShelfmark ?? ''}`;
-      const accessId = physicalLocation?.accessConditions[0]?.status?.id ?? '';
-      const accessLabel =
-        physicalLocation?.accessConditions[0]?.status?.label ?? '';
-
-      if (locationId !== 'on-order') {
-        return [
-          // We don't want to display items that are on order in a table, we just show the location label
-          /* status, TODO status requires item API */
-          shelfmark,
-          isRequestableByLocation(locationId) &&
-          isRequestableByAccessCondition(accessId) &&
-          encoreLink ? (
-            <ButtonOutlinedLink text="Request item" link={encoreLink} />
-          ) : (
-            accessLabel || physicalLocation?.locationType.label
-          ),
-          item.title || 'n/a',
-        ];
-      } else {
-        return [];
-      }
-    })
-    .filter(Boolean);
+  const bodyRows = createBodyRows(items, encoreLink);
 
   const accessCondtionsTerms = items
     .map(item => {
@@ -78,15 +83,17 @@ const PhysicalItems: FunctionComponent<Props> = ({
     .filter(Boolean);
 
   return (
-    <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
-      {bodyRows[0][0] && (
-        <Table hasRowHeaders={false} rows={[headerRow, ...bodyRows]} />
+    <>
+      {Boolean(bodyRows.length) && (
+        <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
+          <Table hasRowHeaders={false} rows={[headerRow, ...bodyRows]} />
+        </Space>
       )}
       {accessCondtionsTerms[0] && (
         <Space
           v={{
             size: 'l',
-            properties: ['margin-top'],
+            properties: ['margin-bottom'],
           }}
         >
           <WorkDetailsText
@@ -99,13 +106,13 @@ const PhysicalItems: FunctionComponent<Props> = ({
         <Space
           v={{
             size: 'l',
-            properties: ['margin-top'],
+            properties: ['margin-bottom'],
           }}
         >
           <WorkDetailsText text={itemsOnOrder} />
         </Space>
       )}
-    </Space>
+    </>
   );
 };
 

--- a/common/utils/works.ts
+++ b/common/utils/works.ts
@@ -126,7 +126,7 @@ export function getItemsWithPhysicalLocation(work: Work): PhysicalItem[] {
   return (work.items ?? [])
     .map(item => {
       if (
-        item.locations.find(location => location.type === 'PhysicalLocation')
+        item.locations.some(location => location.type === 'PhysicalLocation')
       ) {
         return item as PhysicalItem;
       }


### PR DESCRIPTION
Some work pages (with 'Show physical items on the work page' toggle on ) are broken, because of a bit of a nasty check on the items of an array which is sometimes empty. This fixes that (and tidies up some layout spacing)
