### PR TITLE
Fix mobile button alignment

### DIFF
--- a/common/views/components/IIIFViewer/ViewerTopBar.tsx
+++ b/common/views/components/IIIFViewer/ViewerTopBar.tsx
@@ -97,8 +97,12 @@ const Sidebar = styled(Space).attrs({
   grid-column-start: left-edge;
   grid-column-end: desktop-sidebar-end;
   display: flex;
-  justify-content: flex-end;
+  justify-content: flex-start;
   align-items: center;
+
+  ${props => props.theme.media.medium`
+    justify-content: flex-end;
+  `}
 
   ${props =>
     !props.isZooming &&


### PR DESCRIPTION
When changing the alignment of the show/hide sidebar chevrons to be right-aligned, I didn't account for the fact the mobile view uses the same button, but needs to be left-aligned.

__Before:__
![image](https://user-images.githubusercontent.com/1394592/118264529-bbebc780-b4af-11eb-8df4-37bf6b835f43.png)

__After:__
![image](https://user-images.githubusercontent.com/1394592/118264696-fa818200-b4af-11eb-89b9-8ee437b664c0.png)


## What is it doing for them?
