### PR TITLE
Mobile view toolbar segmented control

### DIFF
--- a/common/views/components/IIIFViewer/IIIFViewer.tsx
+++ b/common/views/components/IIIFViewer/IIIFViewer.tsx
@@ -463,6 +463,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
     >
       <Grid ref={viewerRef}>
         <Sidebar
+          data-test-id="viewer-sidebar"
           isActiveMobile={isMobileSidebarActive}
           isActiveDesktop={isDesktopSidebarActive}
         >

--- a/common/views/components/IIIFViewer/ViewerBottomBar.tsx
+++ b/common/views/components/IIIFViewer/ViewerBottomBar.tsx
@@ -8,6 +8,8 @@ import { FunctionComponent, useContext, RefObject } from 'react';
 import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
 import ItemViewerContext from '@weco/common/views/components/ItemViewerContext/ItemViewerContext';
 import useIsFullscreenEnabled from '@weco/common/hooks/useIsFullscreenEnabled';
+import ToolbarSegmentedControl from '../ToolbarSegmentedControl/ToolbarSegmentedControl';
+
 // TODO: update this with a more considered button from our system
 export const ShameButton = styled.button.attrs(() => ({
   className: classNames({
@@ -65,6 +67,7 @@ const BottomBar = styled.div`
 
 const LeftZone = styled(Space).attrs({
   v: { size: 's', properties: ['padding-top', 'padding-bottom'] },
+  h: { size: 'm', properties: ['padding-left'] },
 })`
   display: flex;
   justify-content: flex-start;
@@ -84,10 +87,7 @@ type Props = {
   viewerRef: RefObject<HTMLDivElement>;
 };
 
-const ViewerBottomBar: FunctionComponent<Props> = ({
-  viewToggleRef,
-  viewerRef,
-}: Props) => {
+const ViewerBottomBar: FunctionComponent<Props> = ({ viewerRef }: Props) => {
   const { isEnhanced } = useContext(AppContext);
   const isFullscreenEnabled = useIsFullscreenEnabled();
 
@@ -97,41 +97,49 @@ const ViewerBottomBar: FunctionComponent<Props> = ({
     setGridVisible,
     work,
     showZoomed,
+    isMobileSidebarActive,
   } = useContext(ItemViewerContext);
   return (
     <BottomBar className="flex">
-      {isEnhanced && canvases && canvases.length > 1 && (
-        <LeftZone>
-          {!showZoomed && (
-            <Space
-              h={{ size: 's', properties: ['margin-left'] }}
-              className={classNames({
-                'flex flex--v-center flex--h-center': true,
-              })}
-            >
-              <ShameButton
-                isDark
-                ref={viewToggleRef}
-                onClick={() => {
-                  setGridVisible(!gridVisible);
-                  trackEvent({
-                    category: 'Control',
-                    action: `clicked work viewer ${
-                      gridVisible ? '"Detail view"' : '"View all"'
-                    } button`,
-                    label: `${work.id}`,
-                  });
-                }}
-              >
-                <Icon name={gridVisible ? 'detailView' : 'gridView'} />
-                <span className={`btn__text`}>
-                  {gridVisible ? 'Detail view' : 'View all'}
-                </span>
-              </ShameButton>
-            </Space>
+      <LeftZone>
+        {!showZoomed &&
+          canvases &&
+          canvases.length > 1 &&
+          !isMobileSidebarActive && (
+            <ToolbarSegmentedControl
+              hideLabels={true}
+              items={[
+                {
+                  id: 'pageView',
+                  label: 'Page',
+                  icon: 'singlePage',
+                  clickHandler() {
+                    setGridVisible(false);
+                    trackEvent({
+                      category: 'Control',
+                      action: `clicked work viewer Detail view button`,
+                      label: `${work.id}`,
+                    });
+                  },
+                },
+                {
+                  id: 'gridView',
+                  label: 'Grid',
+                  icon: 'gridView',
+                  clickHandler() {
+                    setGridVisible(true);
+                    trackEvent({
+                      category: 'Control',
+                      action: `clicked work viewer Grid view button`,
+                      label: `${work.id}`,
+                    });
+                  },
+                },
+              ]}
+              activeId={gridVisible ? 'gridView' : 'pageView'}
+            />
           )}
-        </LeftZone>
-      )}
+      </LeftZone>
 
       <RightZone>
         {isEnhanced && isFullscreenEnabled && (

--- a/common/views/components/IIIFViewer/ViewerBottomBar.tsx
+++ b/common/views/components/IIIFViewer/ViewerBottomBar.tsx
@@ -101,7 +101,7 @@ const ViewerBottomBar: FunctionComponent<Props> = ({ viewerRef }: Props) => {
   } = useContext(ItemViewerContext);
   return (
     <BottomBar className="flex">
-      <LeftZone>
+      <LeftZone data-test-id="page-grid-buttons">
         {!showZoomed &&
           canvases &&
           canvases.length > 1 &&

--- a/common/views/components/IIIFViewer/ViewerTopBar.tsx
+++ b/common/views/components/IIIFViewer/ViewerTopBar.tsx
@@ -183,6 +183,7 @@ const ViewerTopBar: FunctionComponent<Props> = ({ viewerRef }: Props) => {
           {!showZoomed && (
             <>
               <ShameButton
+                data-test-id="toggle-info-desktop"
                 className={`viewer-desktop`}
                 isDark
                 onClick={() => {
@@ -206,6 +207,7 @@ const ViewerTopBar: FunctionComponent<Props> = ({ viewerRef }: Props) => {
                 </span>
               </ShameButton>
               <ShameButton
+                data-test-id="toggle-info-mobile"
                 className={`viewer-mobile`}
                 isDark
                 onClick={() => {

--- a/playwright/test/selectors/item.ts
+++ b/playwright/test/selectors/item.ts
@@ -11,3 +11,7 @@ export const fullscreenButton = 'css=button >> text="Full screen"';
 export const searchWithinResultsHeader = `[data-test-id="results-header"]`;
 export const mainViewer = `[data-test-id=main-viewer] > div`;
 export const activeIndex = `[data-test-id=active-index]`;
+export const viewerSidebar = `[data-test-id="viewer-sidebar"]`;
+export const toggleInfoDesktop = `[data-test-id="toggle-info-desktop"]`;
+export const toggleInfoMobile = `[data-test-id="toggle-info-mobile"]`;
+export const mobilePageGridButtons = `[data-test-id="page-grid-buttons"] button`;

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -14,6 +14,10 @@ import {
   workDates,
   searchWithinResultsHeader,
   mainViewer,
+  viewerSidebar,
+  mobilePageGridButtons,
+  toggleInfoDesktop,
+  toggleInfoMobile,
 } from './selectors/item';
 import { baseUrl } from './helpers/urls';
 import { makeDefaultToggleAndTestCookies } from './helpers/utils';
@@ -48,6 +52,40 @@ describe('Scenario 1: A user wants a large-scale view of an item', () => {
     // make sure we can actually see deep zoom
     const isVisible = await page.isVisible(openseadragonCanvas);
     expect(isVisible).toBeTruthy();
+  });
+
+  test.only('the info panel visibility can be toggled', async () => {
+    await multiVolumeItem();
+    if (!isMobile()) {
+      const isVisibleBefore = await page.isVisible(viewerSidebar);
+      expect(isVisibleBefore).toBeTruthy();
+      await page.click(toggleInfoDesktop);
+      const isVisibleAfter = await page.isVisible(viewerSidebar);
+      expect(isVisibleAfter).toBeFalsy();
+    }
+
+    // Info is hidden by default on mobile. It covers the viewing
+    // area on mobile, so we want to ensure things that control
+    // the viewing area are also hidden when it is visible
+    if (isMobile()) {
+      // await page.waitForSelector(viewerSidebar);
+      const isSidebarVisibleBefore = await page.isVisible(viewerSidebar);
+      const isMobilePageGridButtonVisibleBefore = await page.isVisible(
+        mobilePageGridButtons
+      );
+
+      expect(isSidebarVisibleBefore).toBeFalsy();
+      expect(isMobilePageGridButtonVisibleBefore).toBeTruthy();
+
+      await page.click(toggleInfoMobile);
+      const isSidebarVisibleAfter = await page.isVisible(viewerSidebar);
+      const isMobilePageGridButtonVisibleAfter = await page.isVisible(
+        mobilePageGridButtons
+      );
+
+      expect(isSidebarVisibleAfter).toBeTruthy();
+      expect(isMobilePageGridButtonVisibleAfter).toBeFalsy();
+    }
   });
 });
 

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -68,7 +68,6 @@ describe('Scenario 1: A user wants a large-scale view of an item', () => {
     // area on mobile, so we want to ensure things that control
     // the viewing area are also hidden when it is visible
     if (isMobile()) {
-      // await page.waitForSelector(viewerSidebar);
       const isSidebarVisibleBefore = await page.isVisible(viewerSidebar);
       const isMobilePageGridButtonVisibleBefore = await page.isVisible(
         mobilePageGridButtons


### PR DESCRIPTION
Fixes #6506 

- Using the `ToolbarSegmentedControl` component for the page/grid toggle
- Hiding this component when the item info is visible (where it could be confusing, since you can't see the result until you close the info)

![image](https://user-images.githubusercontent.com/1394592/118267370-dfb10c80-b4b3-11eb-8bfb-d53b55970b65.png)
