### PR TITLE
Items prototype tests

### DIFF
--- a/playwright/test/contexts.ts
+++ b/playwright/test/contexts.ts
@@ -9,7 +9,7 @@ const itemWithSearchAndStructures = async (): Promise<void> => {
 };
 
 const workWithPhysicalAndDigitalLocation = async (): Promise<void> => {
-  await page.goto(`${baseUrl}/works/a235xn8e`); /// works/r9kpkq8e
+  await page.goto(`${baseUrl}/works/a235xn8e`);
 };
 
 const workWithRequestablePhysicalItem = async (): Promise<void> => {

--- a/playwright/test/contexts.ts
+++ b/playwright/test/contexts.ts
@@ -9,7 +9,11 @@ const itemWithSearchAndStructures = async (): Promise<void> => {
 };
 
 const workWithPhysicalAndDigitalLocation = async (): Promise<void> => {
-  await page.goto(`${baseUrl}/works/a235xn8e`);
+  await page.goto(`${baseUrl}/works/a235xn8e`); /// works/r9kpkq8e
+};
+
+const workWithRequestablePhysicalItem = async (): Promise<void> => {
+  await page.goto(`${baseUrl}/works/r9kpkq8e`);
 };
 
 const workWithPhysicalLocationOnly = async (): Promise<void> => {
@@ -43,6 +47,7 @@ export {
   worksSearch,
   itemWithSearchAndStructures,
   workWithPhysicalAndDigitalLocation,
+  workWithRequestablePhysicalItem,
   workWithPhysicalLocationOnly,
   workWithDigitalLocationOnly,
 };

--- a/playwright/test/contexts.ts
+++ b/playwright/test/contexts.ts
@@ -8,20 +8,20 @@ const itemWithSearchAndStructures = async (): Promise<void> => {
   await page.goto(`${baseUrl}/works/re9cyhkt/items`);
 };
 
-const workWithPhysicalAndDigitalLocation = async (): Promise<void> => {
-  await page.goto(`${baseUrl}/works/a235xn8e`);
-};
-
-const workWithRequestablePhysicalItem = async (): Promise<void> => {
-  await page.goto(`${baseUrl}/works/r9kpkq8e`);
-};
-
 const workWithPhysicalLocationOnly = async (): Promise<void> => {
   await page.goto(`${baseUrl}/works/ffd3zeq3`);
 };
 
 const workWithDigitalLocationOnly = async (): Promise<void> => {
-  await page.goto(`${baseUrl}/works/m54uwqgm`);
+  await page.goto(`${baseUrl}/works/j9kukb78`);
+};
+
+const workWithDigitalLocationAndLocationNote = async (): Promise<void> => {
+  await page.goto(`${baseUrl}/works/a235xn8e`);
+};
+
+const workWithPhysicalAndDigitalLocation = async (): Promise<void> => {
+  await page.goto(`${baseUrl}/works/works/r9kpkq8e`);
 };
 
 const worksSearch = async (): Promise<void> => {
@@ -47,7 +47,7 @@ export {
   worksSearch,
   itemWithSearchAndStructures,
   workWithPhysicalAndDigitalLocation,
-  workWithRequestablePhysicalItem,
   workWithPhysicalLocationOnly,
   workWithDigitalLocationOnly,
+  workWithDigitalLocationAndLocationNote,
 };

--- a/playwright/test/work.test.ts
+++ b/playwright/test/work.test.ts
@@ -1,7 +1,7 @@
 import {
-  workWithPhysicalAndDigitalLocation,
   workWithPhysicalLocationOnly,
   workWithDigitalLocationOnly,
+  workWithDigitalLocationAndLocationNote,
 } from './contexts';
 
 async function getWhereToFindItAndEncoreLink() {
@@ -15,31 +15,41 @@ async function getWhereToFindItAndEncoreLink() {
     encoreLink,
   };
 }
+
+async function getAvailableOnline() {
+  const availableOnline = await page.$('h2:has-text("Available online")');
+  return availableOnline;
+}
+
 describe(`Scenario 1: a user wants to see relevant information about where a work's items are located`, () => {
-  test(`works with a physical location item only display a 'where to find it' section with a link`, async () => {
+  test(`works that have a physical item location display a 'Where to find it' section with a link`, async () => {
     await workWithPhysicalLocationOnly();
-
     const { whereToFindIt, encoreLink } = await getWhereToFindItAndEncoreLink();
-
     expect(whereToFindIt).toBeTruthy();
     expect(encoreLink).toBeTruthy();
   });
 
-  test(`works with a physical and digital location item display a 'where to find it' section without a link`, async () => {
-    await workWithPhysicalAndDigitalLocation();
-
-    const { whereToFindIt, encoreLink } = await getWhereToFindItAndEncoreLink();
-
-    expect(whereToFindIt).toBeTruthy();
-    expect(encoreLink).toBeNull();
+  test(`works with only a physical location don't display an 'Available online' section`, async () => {
+    await workWithPhysicalLocationOnly();
+    const availableOnline = await getAvailableOnline();
+    expect(availableOnline).toBeNull();
   });
 
-  test(`works with a digital location only don't display a 'where to find it' section`, async () => {
+  test(`works with a digital item display an 'Available online' section`, async () => {
+    await workWithDigitalLocationAndLocationNote();
+    const availableOnline = await getAvailableOnline();
+    expect(availableOnline).toBeTruthy();
+  });
+
+  test(`works with only a digital location don't display a 'Where to find it' section`, async () => {
     await workWithDigitalLocationOnly();
-
-    const { whereToFindIt, encoreLink } = await getWhereToFindItAndEncoreLink();
-
+    const { whereToFindIt } = await getWhereToFindItAndEncoreLink();
     expect(whereToFindIt).toBeNull();
-    expect(encoreLink).toBeNull();
+  });
+
+  test(`works that have a note with a noteType.id of 'location-of-original', display a 'Where to find it' section`, async () => {
+    await workWithDigitalLocationAndLocationNote();
+    const { whereToFindIt } = await getWhereToFindItAndEncoreLink();
+    expect(whereToFindIt).toBeTruthy();
   });
 });

--- a/playwright/test/workPrototype.test.ts
+++ b/playwright/test/workPrototype.test.ts
@@ -58,7 +58,7 @@ describe(`Scenario 1: a user wants to see relevant information about where a wor
     expect(encoreLink).toBeTruthy();
   });
 
-  test.only(`works with a physical location item available to request display an access status`, async () => {
+  test(`works with a physical location item available to request display an access status`, async () => {
     await workWithRequestablePhysicalItem();
     const status = await page.waitForSelector('th:has-text("Status")');
     expect(status).toBeTruthy();

--- a/playwright/test/workPrototype.test.ts
+++ b/playwright/test/workPrototype.test.ts
@@ -64,7 +64,6 @@ describe(`Scenario 1: a user wants to see relevant information about where a wor
     expect(status).toBeTruthy();
   });
 
-  // Not sure this is actually what we want
   test(`works with a physical and digital location item display a 'where to find it' section without a link`, async () => {
     await workWithPhysicalAndDigitalLocation();
     const { whereToFindIt, encoreLink } = await getWhereToFindItAndEncoreLink();

--- a/playwright/test/workPrototype.test.ts
+++ b/playwright/test/workPrototype.test.ts
@@ -1,5 +1,6 @@
 import {
   workWithPhysicalAndDigitalLocation,
+  workWithRequestablePhysicalItem,
   workWithPhysicalLocationOnly,
   workWithDigitalLocationOnly,
 } from './contexts';
@@ -49,7 +50,7 @@ async function getWhereToFindItAndEncoreLink() {
   };
 }
 
-describe.only(`Scenario 1: a user wants to see relevant information about where a work's items are located and the access status of those items`, () => {
+describe(`Scenario 1: a user wants to see relevant information about where a work's items are located and the access status of those items where applicable`, () => {
   test(`works with a physical location item only display a 'where to find it' section with a link`, async () => {
     await workWithPhysicalLocationOnly();
     const { whereToFindIt, encoreLink } = await getWhereToFindItAndEncoreLink();
@@ -57,6 +58,13 @@ describe.only(`Scenario 1: a user wants to see relevant information about where 
     expect(encoreLink).toBeTruthy();
   });
 
+  test.only(`works with a physical location item available to request display an access status`, async () => {
+    await workWithRequestablePhysicalItem();
+    const status = await page.waitForSelector('th:has-text("Status")');
+    expect(status).toBeTruthy();
+  });
+
+  // Not sure this is actually what we want
   test(`works with a physical and digital location item display a 'where to find it' section without a link`, async () => {
     await workWithPhysicalAndDigitalLocation();
     const { whereToFindIt, encoreLink } = await getWhereToFindItAndEncoreLink();

--- a/playwright/test/workPrototype.test.ts
+++ b/playwright/test/workPrototype.test.ts
@@ -1,0 +1,73 @@
+import {
+  workWithPhysicalAndDigitalLocation,
+  workWithPhysicalLocationOnly,
+  workWithDigitalLocationOnly,
+} from './contexts';
+import { makeDefaultToggleAndTestCookies } from './helpers/utils';
+import { baseUrl } from './helpers/urls';
+
+const domain = new URL(baseUrl).host;
+
+// Turn on the showPhysicalItems toggle
+beforeAll(async () => {
+  const defaultToggleAndTestCookies = await makeDefaultToggleAndTestCookies(
+    domain
+  );
+  const toggleOverrides = [
+    {
+      name: 'toggle_showPhysicalItems',
+      value: 'true',
+    },
+  ];
+  const overriddenCookies = defaultToggleAndTestCookies.map(cookie => {
+    const matchingOverrideCookie = toggleOverrides.find(
+      override => override.name === cookie.name
+    );
+    if (matchingOverrideCookie) {
+      return {
+        ...cookie,
+        value: matchingOverrideCookie.value,
+      };
+    } else {
+      return cookie;
+    }
+  });
+  await context.addCookies([
+    { name: 'WC_cookiesAccepted', value: 'true', domain: domain, path: '/' },
+    { name: 'WC_globalAlert', value: 'true', domain: domain, path: '/' },
+    ...overriddenCookies,
+  ]);
+});
+
+async function getWhereToFindItAndEncoreLink() {
+  const whereToFindIt = await page.$('h2:has-text("Where to find it")');
+  const encoreLink = await page.$('a:has-text("Request item")');
+
+  return {
+    whereToFindIt,
+    encoreLink,
+  };
+}
+
+describe.only(`Scenario 1: a user wants to see relevant information about where a work's items are located and the access status of those items`, () => {
+  test(`works with a physical location item only display a 'where to find it' section with a link`, async () => {
+    await workWithPhysicalLocationOnly();
+    const { whereToFindIt, encoreLink } = await getWhereToFindItAndEncoreLink();
+    expect(whereToFindIt).toBeTruthy();
+    expect(encoreLink).toBeTruthy();
+  });
+
+  test(`works with a physical and digital location item display a 'where to find it' section without a link`, async () => {
+    await workWithPhysicalAndDigitalLocation();
+    const { whereToFindIt, encoreLink } = await getWhereToFindItAndEncoreLink();
+    expect(whereToFindIt).toBeTruthy();
+    expect(encoreLink).toBeNull();
+  });
+
+  test(`works with a digital location only don't display a 'where to find it' section`, async () => {
+    await workWithDigitalLocationOnly();
+    const { whereToFindIt, encoreLink } = await getWhereToFindItAndEncoreLink();
+    expect(whereToFindIt).toBeNull();
+    expect(encoreLink).toBeNull();
+  });
+});

--- a/playwright/test/workPrototype.test.ts
+++ b/playwright/test/workPrototype.test.ts
@@ -1,8 +1,7 @@
 import {
-  workWithPhysicalAndDigitalLocation,
-  workWithRequestablePhysicalItem,
   workWithPhysicalLocationOnly,
   workWithDigitalLocationOnly,
+  workWithDigitalLocationAndLocationNote,
 } from './contexts';
 import { makeDefaultToggleAndTestCookies } from './helpers/utils';
 import { baseUrl } from './helpers/urls';
@@ -50,8 +49,17 @@ async function getWhereToFindItAndEncoreLink() {
   };
 }
 
+async function getAvailableOnline() {
+  const availableOnline = await page.$('h2:has-text("Available online")');
+  return availableOnline;
+}
+
+async function getStatus() {
+  const status = await page.waitForSelector('th:has-text("Status")');
+  return status;
+}
 describe(`Scenario 1: a user wants to see relevant information about where a work's items are located and the access status of those items where applicable`, () => {
-  test(`works with a physical location item only display a 'where to find it' section with a link`, async () => {
+  test(`works that have a physical item location display a 'Where to find it' section with a link`, async () => {
     await workWithPhysicalLocationOnly();
     const { whereToFindIt, encoreLink } = await getWhereToFindItAndEncoreLink();
     expect(whereToFindIt).toBeTruthy();
@@ -59,22 +67,32 @@ describe(`Scenario 1: a user wants to see relevant information about where a wor
   });
 
   test(`works with a physical location item available to request display an access status`, async () => {
-    await workWithRequestablePhysicalItem();
-    const status = await page.waitForSelector('th:has-text("Status")');
+    await workWithPhysicalLocationOnly();
+    const status = await getStatus();
     expect(status).toBeTruthy();
   });
 
-  test(`works with a physical and digital location item display a 'where to find it' section without a link`, async () => {
-    await workWithPhysicalAndDigitalLocation();
-    const { whereToFindIt, encoreLink } = await getWhereToFindItAndEncoreLink();
-    expect(whereToFindIt).toBeTruthy();
-    expect(encoreLink).toBeNull();
+  test(`works with only a physical location don't display an 'Available online' section`, async () => {
+    await workWithPhysicalLocationOnly();
+    const availableOnline = await getAvailableOnline();
+    expect(availableOnline).toBeNull();
   });
 
-  test(`works with a digital location only don't display a 'where to find it' section`, async () => {
+  test(`works with a digital item display an 'Available online' section`, async () => {
+    await workWithDigitalLocationAndLocationNote();
+    const availableOnline = await getAvailableOnline();
+    expect(availableOnline).toBeTruthy();
+  });
+
+  test(`works with only a digital location don't display a 'Where to find it' section`, async () => {
     await workWithDigitalLocationOnly();
-    const { whereToFindIt, encoreLink } = await getWhereToFindItAndEncoreLink();
+    const { whereToFindIt } = await getWhereToFindItAndEncoreLink();
     expect(whereToFindIt).toBeNull();
-    expect(encoreLink).toBeNull();
+  });
+
+  test(`works that have a note with a noteType.id of 'location-of-original', display a 'Where to find it' section`, async () => {
+    await workWithDigitalLocationAndLocationNote();
+    const { whereToFindIt } = await getWhereToFindItAndEncoreLink();
+    expect(whereToFindIt).toBeTruthy();
   });
 });


### PR DESCRIPTION
- Replicates the work tests with the showPhysicalItems toggle turned on (and the required changes to make them pass)
- adds a test for the presence of status
