### PR TITLE
Allow for SoundCloud embeds without secret tokens

### DIFF
--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -773,17 +773,19 @@ export function parseBody(fragment: PrismicFragment[]): BodyType {
           if (embed.provider_name === 'SoundCloud') {
             const apiUrl = embed.html.match(/url=([^&]*)&/);
             const secretToken = embed.html.match(/secret_token=([^"]*)"/);
+            const secretTokenString =
+              secretToken && secretToken[1]
+                ? `%3Fsecret_token%3D${secretToken[1]}`
+                : '';
 
-            return (
-              secretToken && {
-                type: 'soundcloudEmbed',
-                weight: getWeight(slice.slice_label),
-                value: {
-                  embedUrl: `https://w.soundcloud.com/player/?url=${apiUrl[1]}%3Fsecret_token%3D${secretToken[1]}&color=%23ff5500&inverse=false&auto_play=false&show_user=true`,
-                  caption: slice.primary.caption,
-                },
-              }
-            );
+            return {
+              type: 'soundcloudEmbed',
+              weight: getWeight(slice.slice_label),
+              value: {
+                embedUrl: `https://w.soundcloud.com/player/?url=${apiUrl[1]}${secretTokenString}&color=%23ff5500&inverse=false&auto_play=false&show_user=true`,
+                caption: slice.primary.caption,
+              },
+            };
           }
 
           if (embed.provider_name === 'YouTube') {


### PR DESCRIPTION
For #6461 

## Who is this for?
People who want SoundCloud embeds to work whether or not they are from a private playlist.

## What is it doing for them?
Making the player show up.

![image](https://user-images.githubusercontent.com/1394592/118502006-30796d00-b721-11eb-9a34-d98b14d2cf31.png)
