### PR TITLE
Catalogue stage tests

### DIFF
--- a/catalogue/terraform/stack/main.tf
+++ b/catalogue/terraform/stack/main.tf
@@ -21,7 +21,8 @@ module "catalogue-service-17092020" {
   }
 
    secret_env_vars = {
-    items_api_key = "catalogue_api/items/prod/api_key"
+    items_api_key_prod = "catalogue_api/items/prod/api_key"
+    items_api_key_stage = "catalogue_api/items/stage/api_key"
   }
 
   vpc_id  = local.vpc_id

--- a/catalogue/webapp/pages/api/works/items.ts
+++ b/catalogue/webapp/pages/api/works/items.ts
@@ -1,8 +1,15 @@
 import fetch from 'isomorphic-unfetch';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { ItemsWork, CatalogueApiError } from '@weco/common/model/catalogue';
-import { catalogueApiError } from '../../../services/catalogue/common';
+import {
+  catalogueApiError,
+  rootUris,
+  globalApiOptions,
+} from '../../../services/catalogue/common';
 import hasOwnProperty from '@weco/common/utils/has-own-property';
+import { Toggles } from '@weco/toggles';
+
+const toggleCookiePrefix = 'toggle_';
 
 export function isCatalogueApiError(
   response: ItemsWork | CatalogueApiError
@@ -10,19 +17,45 @@ export function isCatalogueApiError(
   return Boolean(hasOwnProperty(response, 'type') && response.type === 'Error');
 }
 
-async function fetchWorkItems(
-  id: string
-): Promise<ItemsWork | CatalogueApiError> {
+function getApiUrl(apiOptions, workId: string): string {
+  return `${rootUris[apiOptions.env]}/v2/works/${workId}/items`;
+}
+
+function getApiKey(apiOptions): string | undefined {
+  if (apiOptions.env === 'stage') {
+    return process.env.items_api_key_stage;
+  } else {
+    return process.env.items_api_key_prod;
+  }
+}
+
+function cookiesToToggles(cookies): Toggles {
+  const toggles = { ...cookies };
+  Object.keys(toggles).forEach(key => {
+    if (key.startsWith(toggleCookiePrefix)) {
+      toggles[key.replace(toggleCookiePrefix, '')] = toggles[key] === 'true';
+    }
+    delete toggles[key];
+  });
+  return toggles;
+}
+
+async function fetchWorkItems({
+  workId,
+  toggles,
+}: {
+  workId: string;
+  toggles: Toggles;
+}): Promise<ItemsWork | CatalogueApiError> {
+  const apiOptions = globalApiOptions(toggles);
+  const apiUrl = getApiUrl(apiOptions, workId);
   try {
-    const items = await fetch(
-      `https://api.wellcomecollection.org/catalogue/v2/works/${id}/items`,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          'x-api-key': process.env.items_api_key || '',
-        },
-      }
-    ).then(resp => resp.json());
+    const items = await fetch(apiUrl, {
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': getApiKey(apiOptions) || '',
+      },
+    }).then(resp => resp.json());
     return items;
   } catch (error) {
     return catalogueApiError();
@@ -34,8 +67,13 @@ const ItemsApi = async (
   res: NextApiResponse
 ): Promise<void> => {
   const { workId } = req.query;
+  const cookies = req.cookies ?? {};
+  const toggles = cookiesToToggles(cookies);
   const id = Array.isArray(workId) ? workId[0] : workId;
-  const response = await fetchWorkItems(id);
+  const response = await fetchWorkItems({
+    toggles,
+    workId: id,
+  });
   res.setHeader('Content-Type', 'application/json');
   res.setHeader('Access-Control-Allow-Origin', '*');
   if (isCatalogueApiError(response)) {

--- a/catalogue/webapp/pages/api/works/items.ts
+++ b/catalogue/webapp/pages/api/works/items.ts
@@ -5,6 +5,7 @@ import {
   catalogueApiError,
   rootUris,
   globalApiOptions,
+  GlobalApiOptions,
 } from '../../../services/catalogue/common';
 import hasOwnProperty from '@weco/common/utils/has-own-property';
 import { Toggles } from '@weco/toggles';
@@ -18,11 +19,11 @@ export function isCatalogueApiError(
   return Boolean(hasOwnProperty(response, 'type') && response.type === 'Error');
 }
 
-function getApiUrl(apiOptions, workId: string): string {
+function getApiUrl(apiOptions: GlobalApiOptions, workId: string): string {
   return `${rootUris[apiOptions.env]}/v2/works/${workId}/items`;
 }
 
-function getApiKey(apiOptions): string | undefined {
+function getApiKey(apiOptions: GlobalApiOptions): string {
   if (apiOptions.env === 'stage') {
     return process.env.items_api_key_stage;
   } else {

--- a/catalogue/webapp/pages/api/works/items.ts
+++ b/catalogue/webapp/pages/api/works/items.ts
@@ -1,5 +1,5 @@
 import fetch from 'isomorphic-unfetch';
-import { NextApiRequest, NextApiResponse } from 'next';
+import { NextApiResponse } from 'next';
 import { ItemsWork, CatalogueApiError } from '@weco/common/model/catalogue';
 import {
   catalogueApiError,
@@ -8,7 +8,9 @@ import {
 } from '../../../services/catalogue/common';
 import hasOwnProperty from '@weco/common/utils/has-own-property';
 import { Toggles } from '@weco/toggles';
-import withToggles from '@weco/common/api-routes-middleware/withToggles';
+import withToggles, {
+  NextApiRequestWithToggles,
+} from '@weco/common/api-routes-middleware/withToggles';
 
 export function isCatalogueApiError(
   response: ItemsWork | CatalogueApiError
@@ -49,10 +51,6 @@ async function fetchWorkItems({
     return catalogueApiError();
   }
 }
-
-type NextApiRequestWithToggles = NextApiRequest & {
-  toggles: Toggles;
-};
 
 const ItemsApi = async (
   req: NextApiRequestWithToggles,

--- a/catalogue/webapp/services/catalogue/common.ts
+++ b/catalogue/webapp/services/catalogue/common.ts
@@ -7,7 +7,7 @@ export const rootUris = {
   stage: 'https://api-stage.wellcomecollection.org/catalogue',
 };
 
-type GlobalApiOptions = {
+export type GlobalApiOptions = {
   env: 'prod' | 'stage';
   indexOverrideSuffix?: string;
 };

--- a/catalogue/webapp/types/environment.d.ts
+++ b/catalogue/webapp/types/environment.d.ts
@@ -1,0 +1,11 @@
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv {
+      /* eslint camelcase: "off" */
+      items_api_key_stage: string;
+      items_api_key_prod: string;
+    }
+  }
+}
+
+export {};

--- a/common/api-routes-middleware/withToggles.ts
+++ b/common/api-routes-middleware/withToggles.ts
@@ -1,0 +1,47 @@
+const cookiePrefix = 'toggle_';
+let defaultToggleValues = {};
+
+const parseCookies = function(req) {
+  if (!req.headers.cookie) {
+    return [];
+  }
+
+  return req.headers.cookie.split(';').map(cookieString => {
+    const keyVal = cookieString.split('=');
+    const key = keyVal[0] && keyVal[0].trim();
+    const value = keyVal[1] && keyVal[1].trim();
+
+    return { key, value };
+  });
+};
+
+async function getDefaultToggleValues() {
+  try {
+    const togglesResp = await fetch(
+      'https://toggles.wellcomecollection.org/toggles.json'
+    ).then(response => response.json());
+    defaultToggleValues = togglesResp.toggles.reduce(
+      (acc, toggle) => ({ ...acc, [toggle.id]: toggle.defaultValue }),
+      {}
+    );
+  } catch (e) {}
+}
+getDefaultToggleValues();
+setInterval(getDefaultToggleValues, 2 * 60 * 1000);
+const withToggles = handler => {
+  return async (req, res) => {
+    const cookies = parseCookies(req);
+    const togglesCookies = cookies.filter(cookie =>
+      cookie.key.startsWith(cookiePrefix)
+    );
+    const toggles = togglesCookies.reduce((acc, cookie) => {
+      return Object.assign({}, acc, {
+        [cookie.key.replace(cookiePrefix, '')]: cookie.value === 'true',
+      });
+    }, {});
+    req.toggles = { ...defaultToggleValues, ...toggles };
+    return handler(req, res);
+  };
+};
+
+export default withToggles;

--- a/common/api-routes-middleware/withToggles.ts
+++ b/common/api-routes-middleware/withToggles.ts
@@ -1,3 +1,9 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { Toggles } from '@weco/toggles';
+
+export type NextApiRequestWithToggles = NextApiRequest & {
+  toggles: Toggles;
+};
 const cookiePrefix = 'toggle_';
 let defaultToggleValues = {};
 
@@ -29,7 +35,10 @@ async function getDefaultToggleValues() {
 getDefaultToggleValues();
 setInterval(getDefaultToggleValues, 2 * 60 * 1000);
 const withToggles = handler => {
-  return async (req, res) => {
+  return async (
+    req: NextApiRequestWithToggles,
+    res: NextApiResponse
+  ): Promise<void> => {
     const cookies = parseCookies(req);
     const togglesCookies = cookies.filter(cookie =>
       cookie.key.startsWith(cookiePrefix)


### PR DESCRIPTION
- Adds middleware to make Toggles available to the API routes
- uses the stagingApi toggle to switch between  using the catalogue api staging and prod versions
