### PR TITLE
layout changes for holdings

### DIFF
--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -248,40 +248,65 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
               const locationLink =
                 holding.location && getLocationLink(holding.location);
               return (
-                <Space key={i} v={{ size: 'l', properties: ['margin-bottom'] }}>
+                <Space
+                  key={i}
+                  v={
+                    i + 1 !== holdings.length
+                      ? { size: 'l', properties: ['margin-bottom'] }
+                      : { size: 'l', properties: [] }
+                  }
+                >
                   {holding.enumeration.length > 0 && (
-                    <ExpandableList listItems={holding.enumeration} />
+                    <Space
+                      key={i}
+                      v={{ size: 's', properties: ['margin-bottom'] }}
+                    >
+                      <ExpandableList listItems={holding.enumeration} />
+                    </Space>
                   )}
+                  <Space
+                    key={i}
+                    v={{ size: 's', properties: ['margin-bottom'] }}
+                  >
+                    {holding.location?.locationType.label && (
+                      <>
+                        <WorkDetailsText
+                          title="Location"
+                          inlineHeading={true}
+                          noSpacing={true}
+                          text={[holding.location.locationType.label]}
+                        />
+                        {locationLink && (
+                          <a
+                            className={classNames({
+                              [font('hnl', 5)]: true,
+                            })}
+                            href={locationLink.url}
+                          >
+                            {locationLink.linkText}
+                          </a>
+                        )}
+                      </>
+                    )}
 
-                  {holding.location?.locationType.label && (
-                    <>
+                    {locationShelfmark && (
                       <WorkDetailsText
-                        title="Location"
-                        text={[holding.location.locationType.label]}
+                        title="Shelfmark"
+                        inlineHeading={true}
+                        noSpacing={true}
+                        text={[`${locationLabel} ${locationShelfmark}`]}
                       />
-                      {locationLink && (
-                        <a
-                          className={classNames({
-                            [font('hnl', 5)]: true,
-                          })}
-                          href={locationLink.url}
-                        >
-                          {locationLink.linkText}
-                        </a>
-                      )}
-                    </>
-                  )}
+                    )}
 
-                  {locationShelfmark && (
-                    <WorkDetailsText
-                      title="Shelfmark"
-                      text={[`${locationLabel}${locationShelfmark}`]}
-                    />
-                  )}
-
-                  {holding.note && (
-                    <WorkDetailsText title="Note" text={[holding.note]} />
-                  )}
+                    {holding.note && (
+                      <WorkDetailsText
+                        title="Note"
+                        inlineHeading={true}
+                        noSpacing={true}
+                        text={[holding.note]}
+                      />
+                    )}
+                  </Space>
                 </Space>
               );
             })}

--- a/catalogue/webapp/components/WorkDetailsProperty/WorkDetailsProperty.tsx
+++ b/catalogue/webapp/components/WorkDetailsProperty/WorkDetailsProperty.tsx
@@ -1,26 +1,50 @@
 import { font } from '@weco/common/utils/classnames';
 import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
+import Space from '@weco/common/views/components/styled/Space';
+import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper/ConditionalWrapper';
 import { FunctionComponent, PropsWithChildren } from 'react';
 
-type Props = PropsWithChildren<{ title?: string }>;
+type Props = PropsWithChildren<{
+  title?: string;
+  inlineHeading?: boolean;
+  noSpacing?: boolean;
+}>;
 
 const WorkDetailsProperty: FunctionComponent<Props> = ({
   title,
+  inlineHeading,
+  noSpacing,
   children,
 }: Props) => {
   return (
-    <SpacingComponent>
-      <div className={`${font('hnl', 5, { small: 3, medium: 3 })}`}>
+    <ConditionalWrapper
+      condition={!noSpacing}
+      wrapper={children => <SpacingComponent>{children}</SpacingComponent>}
+    >
+      <div
+        className={`${font('hnl', 5, { small: 3, medium: 3 })}${
+          inlineHeading ? ' flex' : ''
+        }`}
+      >
         {title && (
-          <h3
+          <Space
+            as="h3"
+            h={
+              inlineHeading
+                ? {
+                    size: 's',
+                    properties: ['margin-right'],
+                  }
+                : { size: 's', properties: [] }
+            }
             className={`${font('hnm', 5, { small: 3, medium: 3 })} no-margin`}
           >
             {title}
-          </h3>
+          </Space>
         )}
         {children}
       </div>
-    </SpacingComponent>
+    </ConditionalWrapper>
   );
 };
 

--- a/catalogue/webapp/components/WorkDetailsText/WorkDetailsText.tsx
+++ b/catalogue/webapp/components/WorkDetailsText/WorkDetailsText.tsx
@@ -1,11 +1,25 @@
 import WorkDetailsProperty from '../WorkDetailsProperty/WorkDetailsProperty';
 import { FunctionComponent } from 'react';
 
-type Props = { title?: string; text: string[] };
+type Props = {
+  title?: string;
+  inlineHeading?: boolean;
+  noSpacing?: boolean;
+  text: string[];
+};
 
-const WorkDetailsText: FunctionComponent<Props> = ({ title, text }: Props) => {
+const WorkDetailsText: FunctionComponent<Props> = ({
+  title,
+  inlineHeading = false,
+  noSpacing = false,
+  text,
+}: Props) => {
   return (
-    <WorkDetailsProperty title={title}>
+    <WorkDetailsProperty
+      title={title}
+      inlineHeading={inlineHeading}
+      noSpacing={noSpacing}
+    >
       <div className="spaced-text">
         {text.map((para, i) => {
           return <div key={i} dangerouslySetInnerHTML={{ __html: para }} />;


### PR DESCRIPTION
References #6247

Improves the display of the holdings data based on [zeplin designs](https://app.zeplin.io/project/5aab926b4b6efde01259e959/dashboard?q=holdings)

@GarethOrmerod @DominiqueMarshall We [still need designs for links to digital resources](https://github.com/wellcomecollection/wellcomecollection.org/issues/6247#issuecomment-839934016)
