### PR TITLE
Access conditions digital

### DIFF
--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -539,6 +539,20 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
               </Space>
             </>
           )}
+          {digitalLocation?.accessConditions[0]?.terms && (
+            <Space
+              v={{
+                size: 'l',
+                properties: ['margin-top'],
+              }}
+            >
+              <WorkDetailsText
+                title="Access conditions"
+                noSpacing={true}
+                text={[digitalLocation?.accessConditions[0]?.terms]}
+              />
+            </Space>
+          )}
         </WorkDetailsSection>
       )}
 

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -503,6 +503,20 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
                   text={[digitalLocationInfo.license.label]}
                 />
               </Space>
+              {digitalLocation?.accessConditions[0]?.terms && (
+                <Space
+                  v={{
+                    size: 'l',
+                    properties: ['margin-top'],
+                  }}
+                >
+                  <WorkDetailsText
+                    title="Access conditions"
+                    noSpacing={true}
+                    text={[digitalLocation?.accessConditions[0]?.terms]}
+                  />
+                </Space>
+              )}
               <Space
                 v={{
                   size: 'l',
@@ -538,20 +552,6 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
                 </ExplanatoryText>
               </Space>
             </>
-          )}
-          {digitalLocation?.accessConditions[0]?.terms && (
-            <Space
-              v={{
-                size: 'l',
-                properties: ['margin-top'],
-              }}
-            >
-              <WorkDetailsText
-                title="Access conditions"
-                noSpacing={true}
-                text={[digitalLocation?.accessConditions[0]?.terms]}
-              />
-            </Space>
           )}
         </WorkDetailsSection>
       )}


### PR DESCRIPTION
Fixes wellcomecollection/platform#5177

Displays access conditions for digital items below license info

<img width="822" alt="Screenshot 2021-05-20 at 17 24 35" src="https://user-images.githubusercontent.com/6051896/119015502-dc74bf80-b990-11eb-9957-31926ed3617d.png">

This does cause a strange spacing bug, which I've spent far too long trying to resolve, so thought I would [raise as a separate issue](https://github.com/wellcomecollection/wellcomecollection.org/issues/6516).
