### PR TITLE
change priority of api_path_listener

### DIFF
--- a/catalogue/terraform/stack/main.tf
+++ b/catalogue/terraform/stack/main.tf
@@ -55,7 +55,7 @@ module "api_path_listener" {
   target_group_arn       = local.target_group_arn
 
   path_patterns = ["/api/works*"]
-  priority      = "49996"
+  priority      = "49998"
 }
 
 # This is used for the static assets served from _next with multiple next apps
@@ -121,7 +121,7 @@ locals {
     local.works_data_path_chunks
   )
 
-  max_priority = 49995
+  max_priority = 49996
   min_priority = local.max_priority - length(local.works_data_path_chunks) + 1
 }
 


### PR DESCRIPTION
Trying to apply the new listener path causes errors, e.g. Error creating LB Listener Rule: PriorityInUse: Priority '49994' is currently in use

I _was_ trying to change the priorities of the works_data_listener rules at the same time so, I could use  49996 for the api rule

Instead, this uses a higher priority instead (49998), but since they max out at 49999 is there a better way to do this?

