### PR TITLE
Use not selector to prevent * + * spacing

### DIFF
--- a/common/services/prismic/html-serializers.js
+++ b/common/services/prismic/html-serializers.js
@@ -157,13 +157,13 @@ export const defaultSerializer: HtmlSerializer = (
           <a
             key={i}
             target={target}
-            className="no-margin plain-link font-green font-HNM3-s flex-inline flex--h-baseline"
+            className="no-owl plain-link font-green font-HNM3-s flex-inline flex--h-baseline"
             href={linkUrl}
           >
             <span className="icon" style={{ top: '8px' }}>
               <canvas className="icon__canvas" height="20" width="20"></canvas>
               <svg
-                className="icon__svg no-margin"
+                className="icon__svg no-owl"
                 role="img"
                 aria-labelledby={`icon-download-title-${nameWithoutSpaces}`}
                 style={{ width: '20px', height: '20px' }}
@@ -179,13 +179,13 @@ export const defaultSerializer: HtmlSerializer = (
                 </svg>
               </svg>
             </span>
-            <span className="no-margin">
-              <span className="no-margin underline-on-hover">{children}</span>{' '}
+            <span className="no-owl">
+              <span className="no-owl underline-on-hover">{children}</span>{' '}
               <span style={{ whiteSpace: 'nowrap' }}>
-                <span className="no-margin font-pewter font-HNM4-s">
+                <span className="no-owl font-pewter font-HNM4-s">
                   {documentType}
                 </span>{' '}
-                <span className="no-margin font-pewter font-HNL4-s">
+                <span className="no-owl font-pewter font-HNL4-s">
                   {documentSize}kb
                 </span>
               </span>

--- a/common/services/prismic/html-serializers.js
+++ b/common/services/prismic/html-serializers.js
@@ -157,13 +157,13 @@ export const defaultSerializer: HtmlSerializer = (
           <a
             key={i}
             target={target}
-            className="no-owl plain-link font-green font-HNM3-s flex-inline flex--h-baseline"
+            className="no-margin plain-link font-green font-HNM3-s flex-inline flex--h-baseline"
             href={linkUrl}
           >
             <span className="icon" style={{ top: '8px' }}>
               <canvas className="icon__canvas" height="20" width="20"></canvas>
               <svg
-                className="icon__svg no-owl"
+                className="icon__svg no-margin"
                 role="img"
                 aria-labelledby={`icon-download-title-${nameWithoutSpaces}`}
                 style={{ width: '20px', height: '20px' }}

--- a/common/services/prismic/html-serializers.js
+++ b/common/services/prismic/html-serializers.js
@@ -179,13 +179,13 @@ export const defaultSerializer: HtmlSerializer = (
                 </svg>
               </svg>
             </span>
-            <span className="no-owl">
-              <span className="no-owl underline-on-hover">{children}</span>{' '}
+            <span className="no-margin">
+              <span className="no-margin underline-on-hover">{children}</span>{' '}
               <span style={{ whiteSpace: 'nowrap' }}>
-                <span className="no-owl font-pewter font-HNM4-s">
+                <span className="no-margin font-pewter font-HNM4-s">
                   {documentType}
                 </span>{' '}
-                <span className="no-owl font-pewter font-HNL4-s">
+                <span className="no-margin font-pewter font-HNL4-s">
                   {documentSize}kb
                 </span>
               </span>

--- a/common/views/themes/typography.ts
+++ b/common/views/themes/typography.ts
@@ -210,7 +210,7 @@ export const typography = `
       margin-bottom: 0;
     }
 
-    * + *:not(.no-owl) {
+    * + *:not(.no-margin) {
       margin-top: 1.55em;
     }
 

--- a/common/views/themes/typography.ts
+++ b/common/views/themes/typography.ts
@@ -210,7 +210,7 @@ export const typography = `
       margin-bottom: 0;
     }
 
-    * + * {
+    * + *:not(.no-owl) {
       margin-top: 1.55em;
     }
 


### PR DESCRIPTION
CSS specificity used to favour our `.no-margin` selector over the `.spaced-text * + *` selector because of the source order. But that has changed now we're using `styled-components` to do typography (in the `GlobalStyle` component).

Updating the `spaced-text` selector to not apply to `no-margin` solves the issue.