### PR TITLE
Volumes bug

### DIFF
--- a/catalogue/webapp/components/Work/Work.tsx
+++ b/catalogue/webapp/components/Work/Work.tsx
@@ -15,7 +15,6 @@ import SearchTabs from '@weco/common/views/components/SearchTabs/SearchTabs';
 import Divider from '@weco/common/views/components/Divider/Divider';
 import styled from 'styled-components';
 import { WithGlobalContextData } from '@weco/common/views/components/GlobalContextProvider/GlobalContextProvider';
-import useIIIFManifestData from '@weco/common/hooks/useIIIFManifestData';
 import SearchContext from '@weco/common/views/components/SearchContext/SearchContext';
 
 const ArchiveDetailsContainer = styled.div`
@@ -42,7 +41,6 @@ const Work: FunctionComponent<Props> = ({
   const { link: searchLink } = useContext(SearchContext);
 
   const isInArchive = work.parts.length > 0 || work.partOf.length > 0;
-  const { childManifestsCount } = useIIIFManifestData(work);
 
   const workData = {
     workType: (work.workType ? work.workType.label : '').toLocaleLowerCase(),
@@ -129,13 +127,9 @@ const Work: FunctionComponent<Props> = ({
               </Space>
             </div>
           </div>
-
           <div className="container">
             <div className="grid">
-              <WorkHeader
-                work={work}
-                childManifestsCount={childManifestsCount}
-              />
+              <WorkHeader work={work} />
             </div>
           </div>
 
@@ -153,10 +147,7 @@ const Work: FunctionComponent<Props> = ({
         <>
           <div className="container">
             <div className="grid">
-              <WorkHeader
-                work={work}
-                childManifestsCount={childManifestsCount}
-              />
+              <WorkHeader work={work} />
             </div>
           </div>
           <WorkDetails work={work} />

--- a/common/views/components/ManifestContext/ManifestContext.js
+++ b/common/views/components/ManifestContext/ManifestContext.js
@@ -1,5 +1,0 @@
-// @flow
-import { createContext } from 'react';
-// $FlowFixMe
-const ManifestContext = createContext(null);
-export default ManifestContext;

--- a/common/views/components/WorkHeader/WorkHeader.tsx
+++ b/common/views/components/WorkHeader/WorkHeader.tsx
@@ -10,6 +10,7 @@ import styled from 'styled-components';
 import WorkTitle from '@weco/common/views/components/WorkTitle/WorkTitle';
 import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
 import { getArchiveLabels, getCardLabels } from '@weco/common/utils/works';
+import useIIIFManifestData from '@weco/common/hooks/useIIIFManifestData';
 
 const WorkHeaderContainer = styled.div.attrs({
   className: classNames({
@@ -22,16 +23,15 @@ const WorkHeaderContainer = styled.div.attrs({
 
 type Props = {
   work: Work;
-  childManifestsCount?: number;
 };
 
 const WorkHeader: FunctionComponent<Props> = ({
   work,
-  childManifestsCount = 0,
 }: Props): ReactElement<Props> => {
   const productionDates = getProductionDates(work);
   const archiveLabels = getArchiveLabels(work);
   const cardLabels = getCardLabels(work);
+  const { childManifestsCount } = useIIIFManifestData(work);
 
   return (
     <WorkHeaderContainer>


### PR DESCRIPTION
Fixes bug reported by Natalie:

"I'm seeing something odd with volumes, looking at https://wellcomecollection.org/works/ysmqsfhg
When I first go to that work there's no "6 volumes online" beneath the 'Books' and 'Online' labels.
I view the online work then go back to works page, and the "6 volumes online" has appeared.
Why isn't that information about the volumes showing when I first go to the works page? How can we make it show there on the first view? Thanks."

![Screenshot 2021-05-25 at 15 30 55](https://user-images.githubusercontent.com/6051896/119515998-449b1b00-bd6e-11eb-9459-bd7d03447994.png)

- We use a hook to get this data when a component mounts. 
- We were tracking the id of works we'd already made requests for, to prevent duplicate requests.
- However, in cases where the request was pending we didn't wait for it to finish before returning the data from the hook.

This fixes that.




