### PR TITLE
Fix icon colour classes

### DIFF
--- a/common/views/themes/base/icons.ts
+++ b/common/views/themes/base/icons.ts
@@ -30,15 +30,16 @@ export const icons = `
 
 ${Object.entries(themeValues.colors)
   .map(([key, value]) => {
-    return `icon--${key} {
-    .icon__shape {
-      fill: ${value};
-    }
+    return `
+    .icon--${key} {
+      .icon__shape {
+        fill: ${value.base};
+      }
 
-    .icon__stroke {
-      stroke: ${value};
-    }
-  }`;
+      .icon__stroke {
+        stroke: ${value.base};
+      }
+    }`;
   })
   .join(' ')}
 


### PR DESCRIPTION
☝️ 

These were broken in the port from Sass to TypeScript.

__Before__
![image](https://user-images.githubusercontent.com/1394592/119666555-61e2ee80-be2d-11eb-884a-29c57811770c.png)

__After__
![image](https://user-images.githubusercontent.com/1394592/119666427-44ae2000-be2d-11eb-9ee5-b448caf2c46e.png)
