### PR TITLE
Keep pa11y happy

### DIFF
--- a/common/views/components/Images/Images.js
+++ b/common/views/components/Images/Images.js
@@ -92,6 +92,7 @@ export class UiImage extends Component<UiImageProps, UiImageState> {
     return (
       <Fragment>
         <noscript
+          className={`bg-charcoal font-white flex-inline`}
           dangerouslySetInnerHTML={{
             __html: `
           <img width='${width}'


### PR DESCRIPTION
Adding the foreground/background colours on the `noscript` element instead of the `img` fixes the Pa11y error, but is in fact worse for the end user (`noscript` doesn't appear to honour the `background` property consistently). So keeping the colour classes on the inner `img` (which is what the user sees) _and_ putting them on the `noscript` (what pa11y sees) should keep everyone happy.
