### PR TITLE
Use !important instead of not selector

### DIFF
--- a/common/services/prismic/html-serializers.js
+++ b/common/services/prismic/html-serializers.js
@@ -3,7 +3,22 @@ import PrismicDOM from 'prismic-dom';
 import linkResolver from './link-resolver';
 import { Fragment, type Element } from 'react';
 import { dasherize } from '@weco/common/utils/grammar';
+import styled from 'styled-components';
+import { classNames, font } from '@weco/common/utils/classnames';
 const { Elements } = PrismicDOM.RichText;
+
+const Anchor = styled.a.attrs({
+  classname: classNames({
+    [font('hnm', 3)]: true,
+    'plain-link font-green flex-inline flex--h-baseline': true,
+  }),
+})`
+  &,
+  svg,
+  span {
+    margin: 0;
+  }
+`;
 
 export type HtmlSerializer = (
   type: string,
@@ -154,16 +169,11 @@ export const defaultSerializer: HtmlSerializer = (
 
       if (isDocument) {
         return (
-          <a
-            key={i}
-            target={target}
-            className="no-margin plain-link font-green font-HNM3-s flex-inline flex--h-baseline"
-            href={linkUrl}
-          >
+          <Anchor key={i} target={target} href={linkUrl}>
             <span className="icon" style={{ top: '8px' }}>
               <canvas className="icon__canvas" height="20" width="20"></canvas>
               <svg
-                className="icon__svg no-margin"
+                className="icon__svg"
                 role="img"
                 aria-labelledby={`icon-download-title-${nameWithoutSpaces}`}
                 style={{ width: '20px', height: '20px' }}
@@ -179,18 +189,16 @@ export const defaultSerializer: HtmlSerializer = (
                 </svg>
               </svg>
             </span>
-            <span className="no-margin">
-              <span className="no-margin underline-on-hover">{children}</span>{' '}
+            <span>
+              <span className="underline-on-hover">{children}</span>{' '}
               <span style={{ whiteSpace: 'nowrap' }}>
-                <span className="no-margin font-pewter font-HNM4-s">
-                  {documentType}
-                </span>{' '}
-                <span className="no-margin font-pewter font-HNL4-s">
+                <span className="font-pewter font-HNM4-s">{documentType}</span>{' '}
+                <span className="font-pewter font-HNL4-s">
                   {documentSize}kb
                 </span>
               </span>
             </span>
-          </a>
+          </Anchor>
         );
       } else {
         return (

--- a/common/services/prismic/html-serializers.js
+++ b/common/services/prismic/html-serializers.js
@@ -3,22 +3,7 @@ import PrismicDOM from 'prismic-dom';
 import linkResolver from './link-resolver';
 import { Fragment, type Element } from 'react';
 import { dasherize } from '@weco/common/utils/grammar';
-import styled from 'styled-components';
-import { classNames, font } from '@weco/common/utils/classnames';
 const { Elements } = PrismicDOM.RichText;
-
-const Anchor = styled.a.attrs({
-  classname: classNames({
-    [font('hnm', 3)]: true,
-    'plain-link font-green flex-inline flex--h-baseline': true,
-  }),
-})`
-  &,
-  svg,
-  span {
-    margin: 0;
-  }
-`;
 
 export type HtmlSerializer = (
   type: string,
@@ -169,11 +154,16 @@ export const defaultSerializer: HtmlSerializer = (
 
       if (isDocument) {
         return (
-          <Anchor key={i} target={target} href={linkUrl}>
+          <a
+            key={i}
+            target={target}
+            className="no-margin plain-link font-green font-HNM3-s flex-inline flex--h-baseline"
+            href={linkUrl}
+          >
             <span className="icon" style={{ top: '8px' }}>
               <canvas className="icon__canvas" height="20" width="20"></canvas>
               <svg
-                className="icon__svg"
+                className="icon__svg no-margin"
                 role="img"
                 aria-labelledby={`icon-download-title-${nameWithoutSpaces}`}
                 style={{ width: '20px', height: '20px' }}
@@ -189,16 +179,18 @@ export const defaultSerializer: HtmlSerializer = (
                 </svg>
               </svg>
             </span>
-            <span>
-              <span className="underline-on-hover">{children}</span>{' '}
+            <span className="no-margin">
+              <span className="no-margin underline-on-hover">{children}</span>{' '}
               <span style={{ whiteSpace: 'nowrap' }}>
-                <span className="font-pewter font-HNM4-s">{documentType}</span>{' '}
-                <span className="font-pewter font-HNL4-s">
+                <span className="no-margin font-pewter font-HNM4-s">
+                  {documentType}
+                </span>{' '}
+                <span className="no-margin font-pewter font-HNL4-s">
                   {documentSize}kb
                 </span>
               </span>
             </span>
-          </Anchor>
+          </a>
         );
       } else {
         return (

--- a/common/views/themes/typography.ts
+++ b/common/views/themes/typography.ts
@@ -210,7 +210,7 @@ export const typography = `
       margin-bottom: 0;
     }
 
-    * + *:not(.no-margin) {
+    * + * {
       margin-top: 1.55em;
     }
 

--- a/common/views/themes/utility-classes.ts
+++ b/common/views/themes/utility-classes.ts
@@ -357,7 +357,7 @@ ${Object.entries(themeValues.colors)
 
 
 .no-margin {
-  margin: 0;
+  margin: 0 !important;
 }
 
 .no-margin-s.no-margin-s {


### PR DESCRIPTION
Adding `:not(.no-margin)` [here](https://github.com/wellcomecollection/wellcomecollection.org/pull/6525) made the selector too specific, such that it won over the `li + li` selector (so e.g. the bulleted lists on [this page](https://wellcomecollection.org/pages/YDo-nxMAACkAMBKl) are now too spread out).

I could think of four options

1. make the `.no-margin` class `!important`
2. add the `:not(.no-margin)` to all other combinant selectors
3. use a `style` tag on the element where the original issue was spotted
4. use a styled-component for the tag where the original issue was spotted

I don't _hate_ the idea of `1.` because if you don't want no margin, then the class really shouldn't be on there. `2.` seems like it would get us into trouble and be harder to maintain. `3.` and `4.` are essentially the same, but `4.` is the approach we are using (or trying to use) everywhere else, so probably feels like the sensible route for now?

If we discover other instances where our `.no-margin` class isn't doing what we want, I'd not be averse to reverting to option `1.` though.
