### PR TITLE
fix spacing for inline heading

### DIFF
--- a/catalogue/webapp/components/WorkDetailsProperty/WorkDetailsProperty.tsx
+++ b/catalogue/webapp/components/WorkDetailsProperty/WorkDetailsProperty.tsx
@@ -1,4 +1,4 @@
-import { font } from '@weco/common/utils/classnames';
+import { font, classNames } from '@weco/common/utils/classnames';
 import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
 import Space from '@weco/common/views/components/styled/Space';
 import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper/ConditionalWrapper';
@@ -37,7 +37,11 @@ const WorkDetailsProperty: FunctionComponent<Props> = ({
                   }
                 : { size: 's', properties: [] }
             }
-            className={`${font('hnm', 5, { small: 3, medium: 3 })} no-margin`}
+            className={classNames({
+              [font('hnm', 5, { small: 3, medium: 3 })]: true,
+              'no-margin': !inlineHeading,
+            })}
+            style={{ marginBottom: 0 }}
           >
             {title}
           </Space>


### PR DESCRIPTION
[This change](https://github.com/wellcomecollection/wellcomecollection.org/pull/6566) resulted in spacing issues for the inline headings, which this PR fixes

Before:
<img width="282" alt="Screenshot 2021-06-02 at 11 17 39" src="https://user-images.githubusercontent.com/6051896/120464216-99551c00-c394-11eb-92ff-5a9871759858.png">

After:
<img width="252" alt="Screenshot 2021-06-02 at 11 17 55" src="https://user-images.githubusercontent.com/6051896/120464252-a2de8400-c394-11eb-8451-2881cd01bee0.png">
