### PR TITLE
don’t focus button on first render

### DIFF
--- a/catalogue/webapp/components/WorkDetails/OnlineResources.tsx
+++ b/catalogue/webapp/components/WorkDetails/OnlineResources.tsx
@@ -39,12 +39,16 @@ const OnlineResources: FunctionComponent<Props> = ({ work }: Props) => {
   ] = useState(false);
   const firstOfRemainingOnlineResourcesRef = useRef<HTMLAnchorElement>(null);
   const showHideResourcesRef = useRef<HTMLButtonElement>(null);
-
+  const firstRender = useRef(true);
   useEffect(() => {
     if (isShowingRemainingOnlineResources) {
       firstOfRemainingOnlineResourcesRef?.current?.focus();
     } else {
-      showHideResourcesRef?.current?.focus();
+      if (!firstRender.current) {
+        showHideResourcesRef?.current?.focus();
+      } else {
+        firstRender.current = false;
+      }
     }
   }, [isShowingRemainingOnlineResources]);
 

--- a/common/views/components/ExpandableList/ExpandableList.tsx
+++ b/common/views/components/ExpandableList/ExpandableList.tsx
@@ -26,12 +26,17 @@ const ExpandableList: FunctionComponent<Props> = ({ listItems }: Props) => {
   ] = useState(false);
   const firstOfRemainingListItemRef = useRef<HTMLAnchorElement>(null);
   const showHideItemsRef = useRef<HTMLButtonElement>(null);
+  const firstRender = useRef(true);
 
   useEffect(() => {
     if (isShowingRemainingListItems) {
       firstOfRemainingListItemRef?.current?.focus();
     } else {
-      showHideItemsRef?.current?.focus();
+      if (!firstRender.current) {
+        showHideItemsRef?.current?.focus();
+      } else {
+        firstRender.current = false;
+      }
     }
   }, [isShowingRemainingListItems]);
 


### PR DESCRIPTION
The ExpandableList and OnlineResource components focus their button when the page loads and they shouldn't. This fixes that.

![Screenshot 2021-06-02 at 16 09 03](https://user-images.githubusercontent.com/6051896/120506070-7c810e80-c3bd-11eb-9fb5-defe1f7ab91c.png)


N.B. Would be good to make it possible to use the ExpandableList component inside the OnlineResource component. It's not so straight forward because of having links inside the list for the latter and how focus is handled in that case.
