### PR TITLE
Remove unwanted no-margin class from page header

### DIFF
--- a/content/webapp/pages/homepage.js
+++ b/content/webapp/pages/homepage.js
@@ -43,7 +43,6 @@ const PageHeading = styled(Space).attrs({
     properties: ['margin-top', 'margin-bottom'],
   },
   className: classNames({
-    'no-margin': true,
     [font('wb', 1)]: true,
   }),
 })``;


### PR DESCRIPTION
We had a `no-margin` class on the header that was previously being overridden by some margin space classes that we put on the top and bottom. Now the `no-margin` class does what we'd expect as a result of #6566 it makes it apparent that the class doesn't belong on this element at all.

__Before__

![image](https://user-images.githubusercontent.com/1394592/120615829-9455a280-c450-11eb-8ea4-e9359e00d9bb.png)


__After__

![image](https://user-images.githubusercontent.com/1394592/120615762-843dc300-c450-11eb-8b04-4f222e28a444.png)
