### PR TITLE
only parse contact slice if there is an attached document

### DIFF
--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -748,10 +748,12 @@ export function parseBody(fragment: PrismicFragment[]): BodyType {
           };
 
         case 'contact':
-          return {
-            type: 'contact',
-            value: parseTeamToContact(slice.primary.content),
-          };
+          return slice.primary.content.isBroken === false
+            ? {
+                type: 'contact',
+                value: parseTeamToContact(slice.primary.content),
+              }
+            : undefined;
 
         case 'embed':
           const embed = slice.primary.embed;


### PR DESCRIPTION
There is so much work needed in this bit of the codebase, I didn't think coming up with a more robust check was worth it.

This checks to see if there is an attached doc, if not, move on.