### PR TITLE
unlock scroll when modal is unmounted

### DIFF
--- a/common/views/components/Modal/Modal.tsx
+++ b/common/views/components/Modal/Modal.tsx
@@ -230,6 +230,10 @@ const Modal: FunctionComponent<Props> = ({
         document.documentElement.classList.remove('is-scroll-locked');
       }
     }
+
+    return () => {
+      document.documentElement.classList.remove('is-scroll-locked');
+    };
   }, [isActive]);
 
   useFocusTrap(closeButtonRef, lastFocusableRef);


### PR DESCRIPTION
## Who is this for?
Scrollers

## What is it doing for them?
Allows them to scroll once they return to a page that had a modal open.

e.g. 
- visit https://wellcomecollection.org/works/z8e3hfkn
- use "View" button
- use "Take me back to the item page" link
- try scrolling 😞  
