### PR TITLE
Helvetica regular toggle update

### DIFF
--- a/common/views/components/ButtonInline/ButtonInline.tsx
+++ b/common/views/components/ButtonInline/ButtonInline.tsx
@@ -9,6 +9,7 @@ import {
   ButtonIconWrapper,
   ButtonTypes,
 } from '../ButtonSolid/ButtonSolid';
+import AlignFont from '../styled/AlignFont';
 
 export type ButtonInlineBaseProps = {
   text: string;
@@ -72,13 +73,13 @@ const ButtonInline = forwardRef<HTMLButtonElement, ButtonInlineProps>(
       >
         <BaseButtonInner isInline={true}>
           <>
-            <span
+            <AlignFont
               className={classNames({
                 'visually-hidden': !!isTextHidden,
               })}
             >
               {text}
-            </span>
+            </AlignFont>
             {icon && (
               <ButtonIconWrapper iconAfter={true}>
                 <Icon name={icon} />

--- a/common/views/components/ButtonInlineLink/ButtonInlineLink.tsx
+++ b/common/views/components/ButtonInlineLink/ButtonInlineLink.tsx
@@ -10,6 +10,7 @@ import NextLink from 'next/link';
 import ConditionalWrapper from '../ConditionalWrapper/ConditionalWrapper';
 import convertUrlToString from '../../../utils/convert-url-to-string';
 import { LinkProps } from 'model/link-props';
+import AlignFont from '../styled/AlignFont';
 
 type ButtonInlineLinkProps = ButtonInlineBaseProps & {
   clickHandler?: (event: SyntheticEvent<HTMLAnchorElement>) => void;
@@ -57,7 +58,7 @@ const ButtonInlineLink: FunctionComponent<ButtonInlineLinkProps> = ({
         href={href}
       >
         <BaseButtonInner isInline={true}>
-          {text}
+          <AlignFont>{text}</AlignFont>
           {icon && (
             <ButtonIconWrapper iconAfter={true}>
               <Icon name={icon} />

--- a/common/views/components/ButtonOutlined/ButtonOutlined.tsx
+++ b/common/views/components/ButtonOutlined/ButtonOutlined.tsx
@@ -8,6 +8,7 @@ import {
   BaseButtonInner,
   ButtonIconWrapper,
 } from '../ButtonSolid/ButtonSolid';
+import AlignFont from '../styled/AlignFont';
 
 type OutlinedButtonProps = {
   href?: string;
@@ -85,13 +86,13 @@ const ButtonOutlined = forwardRef<HTMLButtonElement, ButtonOutlinedProps>(
       >
         <BaseButtonInner>
           <>
-            <span
+            <AlignFont
               className={classNames({
                 'visually-hidden': !!isTextHidden,
               })}
             >
               {text}
-            </span>
+            </AlignFont>
             {icon && (
               <ConditionalWrapper
                 condition={!isTextHidden}

--- a/common/views/components/ButtonOutlinedLink/ButtonOutlinedLink.tsx
+++ b/common/views/components/ButtonOutlinedLink/ButtonOutlinedLink.tsx
@@ -11,6 +11,7 @@ import NextLink from 'next/link';
 import ConditionalWrapper from '../ConditionalWrapper/ConditionalWrapper';
 import { getHref } from '../ButtonSolidLink/ButtonSolidLink';
 import { LinkProps } from '../../../model/link-props';
+import AlignFont from '../styled/AlignFont';
 
 type ButtonOutlinedLinkProps = ButtonOutlinedBaseProps & {
   clickHandler?: (event: SyntheticEvent<HTMLAnchorElement>) => void;
@@ -53,7 +54,7 @@ const ButtonOutlinedLink: FunctionComponent<ButtonOutlinedLinkProps> = ({
         href={getHref(link)}
       >
         <BaseButtonInner>
-          {text}
+          <AlignFont>{text}</AlignFont>
           {icon && (
             <ButtonIconWrapper iconAfter={true}>
               <Icon name={icon} />

--- a/common/views/components/ButtonSolid/ButtonSolid.tsx
+++ b/common/views/components/ButtonSolid/ButtonSolid.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { classNames, font } from '../../../utils/classnames';
 import { trackEvent, GaEvent } from '../../../utils/ga';
 import Icon from '../Icon/Icon';
+import AlignFont from '../styled/AlignFont';
 import Space from '../styled/Space';
 
 type BaseButtonProps = {
@@ -185,13 +186,13 @@ const ButtonSolid = forwardRef(
                 <Icon name={icon} />
               </ButtonIconWrapper>
             )}
-            <span
+            <AlignFont
               className={classNames({
                 'visually-hidden': !!isTextHidden,
               })}
             >
               {text}
-            </span>
+            </AlignFont>
           </>
         </BaseButtonInner>
       </SolidButton>

--- a/common/views/components/ButtonSolidLink/ButtonSolidLink.tsx
+++ b/common/views/components/ButtonSolidLink/ButtonSolidLink.tsx
@@ -9,6 +9,7 @@ import {
 import { trackEvent } from '@weco/common/utils/ga';
 import Icon from '../Icon/Icon';
 import ConditionalWrapper from '../ConditionalWrapper/ConditionalWrapper';
+import AlignFont from '../styled/AlignFont';
 
 type ButtonSolidLinkProps = ButtonSolidBaseProps & {
   clickHandler?: (event: SyntheticEvent<HTMLAnchorElement>) => void;
@@ -63,7 +64,7 @@ const ButtonSolidLink: FunctionComponent<ButtonSolidLinkProps> = ({
               <Icon name={icon} />
             </ButtonIconWrapper>
           )}
-          {text}
+          <AlignFont>{text}</AlignFont>
         </BaseButtonInner>
       </SolidButton>
     </ConditionalWrapper>

--- a/common/views/components/CheckboxRadio/CheckboxRadio.tsx
+++ b/common/views/components/CheckboxRadio/CheckboxRadio.tsx
@@ -3,10 +3,11 @@ import styled from 'styled-components';
 import { classNames } from '../../../utils/classnames';
 import Space from '../styled/Space';
 import Icon from '../Icon/Icon';
+import AlignFont from '../styled/AlignFont';
 
 const CheckboxRadioLabel = styled.label.attrs({
   className: classNames({
-    'flex-inline flex--v-start': true,
+    'flex-inline flex--v-center': true,
   }),
 })`
   cursor: pointer;
@@ -93,7 +94,7 @@ const CheckboxRadio: FunctionComponent<CheckboxRadioProps> = ({
         </CheckboxRadioBox>
       </CheckBoxWrapper>
       <Space as="span" h={{ size: 'xs', properties: ['margin-left'] }}>
-        {text}
+        <AlignFont>{text}</AlignFont>
       </Space>
     </CheckboxRadioLabel>
   );

--- a/common/views/components/GlobalContextProvider/GlobalContextProvider.tsx
+++ b/common/views/components/GlobalContextProvider/GlobalContextProvider.tsx
@@ -56,9 +56,7 @@ const GlobalContextProvider: FunctionComponent<Props> = ({
                     __html: `
                       @font-face {
                         font-family: 'Helvetica Neue Light Web';
-                        src: local('Helvetica Neue Regular'),
-                          local('HelveticaNeue-Regular'),
-                          url('https://i.wellcomecollection.org/assets/fonts/d460c8dd-ab48-422e-ac1c-d9b6392b605a.woff2') format('woff2'),
+                        src: url('https://i.wellcomecollection.org/assets/fonts/d460c8dd-ab48-422e-ac1c-d9b6392b605a.woff2') format('woff2'),
                           url('https://i.wellcomecollection.org/assets/fonts/955441c8-2039-4256-bf4a-c475c31d1c0d.woff') format('woff');
                         font-weight: normal;
                         font-style: normal;
@@ -66,9 +64,7 @@ const GlobalContextProvider: FunctionComponent<Props> = ({
 
                       @font-face {
                         font-family: 'Helvetica Neue Medium Web';
-                        src: local('Helvetica Neue Bold'),
-                          local('HelveticaNeue-Bold'),
-                          url('https://i.wellcomecollection.org/assets/fonts/455d1f57-1462-4536-aefa-c13f0a67bbbe.woff2') format('woff2'),
+                        src: url('https://i.wellcomecollection.org/assets/fonts/455d1f57-1462-4536-aefa-c13f0a67bbbe.woff2') format('woff2'),
                           url('https://i.wellcomecollection.org/assets/fonts/fd5c4818-7809-4a21-a48d-a0dc15aa47b8.woff') format('woff');
                         font-weight: normal;
                         font-style: normal;

--- a/common/views/components/GlobalContextProvider/GlobalContextProvider.tsx
+++ b/common/views/components/GlobalContextProvider/GlobalContextProvider.tsx
@@ -60,13 +60,12 @@ const GlobalContextProvider: FunctionComponent<Props> = ({
                           url('https://i.wellcomecollection.org/assets/fonts/helvetica-neue-roman.woff') format('woff');
                         font-weight: normal;
                         font-style: normal;
-                        ascent-override: 125%;
                       }
 
                       @font-face {
                         font-family: 'Helvetica Neue Medium Web';
-                        src: url('https://i.wellcomecollection.org/assets/fonts/455d1f57-1462-4536-aefa-c13f0a67bbbe.woff2') format('woff2'),
-                          url('https://i.wellcomecollection.org/assets/fonts/fd5c4818-7809-4a21-a48d-a0dc15aa47b8.woff') format('woff');
+                        src: url('https://i.wellcomecollection.org/assets/fonts/helvetica-neue-bold.woff2') format('woff2'),
+                          url('https://i.wellcomecollection.org/assets/fonts/helvetica-neue-bold.woff') format('woff');
                         font-weight: normal;
                         font-style: normal;
                       }

--- a/common/views/components/GlobalContextProvider/GlobalContextProvider.tsx
+++ b/common/views/components/GlobalContextProvider/GlobalContextProvider.tsx
@@ -56,10 +56,11 @@ const GlobalContextProvider: FunctionComponent<Props> = ({
                     __html: `
                       @font-face {
                         font-family: 'Helvetica Neue Light Web';
-                        src: url('https://i.wellcomecollection.org/assets/fonts/d460c8dd-ab48-422e-ac1c-d9b6392b605a.woff2') format('woff2'),
-                          url('https://i.wellcomecollection.org/assets/fonts/955441c8-2039-4256-bf4a-c475c31d1c0d.woff') format('woff');
+                        src: url('https://i.wellcomecollection.org/assets/fonts/helvetica-neue-roman.woff2') format('woff2'),
+                          url('https://i.wellcomecollection.org/assets/fonts/helvetica-neue-roman.woff') format('woff');
                         font-weight: normal;
                         font-style: normal;
+                        ascent-override: 125%;
                       }
 
                       @font-face {

--- a/common/views/components/IIIFViewer/ViewerSidebar.tsx
+++ b/common/views/components/IIIFViewer/ViewerSidebar.tsx
@@ -11,7 +11,7 @@ import { FixedSizeList } from 'react-window';
 import Icon from '../Icon/Icon';
 import styled from 'styled-components';
 import Space from '../styled/Space';
-
+import AlignFont from '../styled/AlignFont';
 import { classNames, font } from '@weco/common/utils/classnames';
 import LinkLabels from '../LinkLabels/LinkLabels';
 import {
@@ -104,7 +104,7 @@ const AccordionItem = ({
                 'no-margin': true,
               })}
             >
-              {title}
+              <AlignFont>{title}</AlignFont>
             </h2>
             <Icon
               name={'chevron'}
@@ -207,7 +207,7 @@ const ViewerSidebar: FunctionComponent<Props> = ({ mainViewerRef }: Props) => {
                 'flex flex--v-center': true,
               })}
             >
-              Catalogue details
+              <AlignFont>Catalogue details</AlignFont>
               <Space
                 h={{ size: 's', properties: ['margin-left'] }}
                 className="flex flex--v-center"

--- a/common/views/components/IIIFViewer/ViewerTopBar.tsx
+++ b/common/views/components/IIIFViewer/ViewerTopBar.tsx
@@ -9,6 +9,7 @@ import { AppContext } from '@weco/common/views/components/AppContext/AppContext'
 import ItemViewerContext from '@weco/common/views/components/ItemViewerContext/ItemViewerContext';
 import useIsFullscreenEnabled from '@weco/common/hooks/useIsFullscreenEnabled';
 import ToolbarSegmentedControl from '../ToolbarSegmentedControl/ToolbarSegmentedControl';
+import AlignFont from '../styled/AlignFont';
 
 // TODO: update this with a more considered button from our system
 export const ShameButton = styled.button.attrs(() => ({
@@ -214,7 +215,9 @@ const ViewerTopBar: FunctionComponent<Props> = ({ viewerRef }: Props) => {
                   setIsMobileSidebarActive(!isMobileSidebarActive);
                 }}
               >
-                {isMobileSidebarActive ? 'Hide info' : 'Show info'}
+                <AlignFont>
+                  {isMobileSidebarActive ? 'Hide info' : 'Show info'}
+                </AlignFont>
               </ShameButton>
             </>
           )}
@@ -317,12 +320,14 @@ const ViewerTopBar: FunctionComponent<Props> = ({ viewerRef }: Props) => {
                   document['webkitFullscreenElement'] ? (
                     <>
                       <Icon name={'collapse'} />
-                      <span className={`btn__text`}>Exit full screen</span>
+                      <AlignFont className={`btn__text`}>
+                        Exit full screen
+                      </AlignFont>
                     </>
                   ) : (
                     <>
                       <Icon name={'expand'} />
-                      <span className={`btn__text`}>Full screen</span>
+                      <AlignFont className={`btn__text`}>Full screen</AlignFont>
                     </>
                   )}
                 </ShameButton>

--- a/common/views/components/Label/Label.tsx
+++ b/common/views/components/Label/Label.tsx
@@ -3,6 +3,7 @@ import { Label as LabelType, LabelColor } from '../../../model/labels';
 import { font, classNames } from '../../../utils/classnames';
 import Space from '../styled/Space';
 import styled from 'styled-components';
+import AlignFont from '../styled/AlignFont';
 
 type LabelContainerProps = {
   fontColor: string;
@@ -51,7 +52,7 @@ const Label: FunctionComponent<Props> = ({
       fontColor={labelColor === 'black' ? 'yellow' : 'black'}
       labelColor={labelColor}
     >
-      {label.text}
+      <AlignFont>{label.text}</AlignFont>
     </LabelContainer>
   );
 };

--- a/common/views/components/MessageBar/MessageBar.js
+++ b/common/views/components/MessageBar/MessageBar.js
@@ -3,6 +3,8 @@ import { type Node, type ComponentType } from 'react';
 import styled from 'styled-components';
 import { classNames, font } from '../../../utils/classnames';
 // $FlowFixMe (tsx)
+import AlignFont from '../styled/AlignFont';
+// $FlowFixMe (tsx)
 import Space, { type SpaceComponentProps } from '../styled/Space';
 
 const ColouredTag: ComponentType<SpaceComponentProps> = styled(Space).attrs(
@@ -42,7 +44,7 @@ const MessageBar = ({ tagText, children }: Props) => (
           properties: ['margin-right'],
         }}
       >
-        {tagText}
+        <AlignFont>{tagText}</AlignFont>
       </ColouredTag>
     )}
     {children}

--- a/common/views/components/SearchFiltersDesktop/SearchFiltersDesktop.tsx
+++ b/common/views/components/SearchFiltersDesktop/SearchFiltersDesktop.tsx
@@ -21,6 +21,7 @@ import ModalMoreFilters from '../ModalMoreFilters/ModalMoreFilters';
 import ButtonInline from '../ButtonInline/ButtonInline';
 import { ResetActiveFilters } from '../ResetActiveFilters/ResetActiveFilters';
 import { ButtonTypes } from '../ButtonSolid/ButtonSolid';
+import AlignFont from '../styled/AlignFont';
 
 const PaletteColorPicker = dynamic(
   import('../PaletteColorPicker/PaletteColorPicker')
@@ -184,7 +185,7 @@ const SearchFiltersDesktop: FunctionComponent<SearchFiltersSharedProps> = ({
                   [font('hnm', 5)]: true,
                 })}
               >
-                Filter by
+                <AlignFont>Filter by</AlignFont>
               </Space>
             </Space>
 
@@ -256,7 +257,7 @@ const SearchFiltersDesktop: FunctionComponent<SearchFiltersSharedProps> = ({
                   [font('hnm', 5)]: true,
                 })}
               >
-                Show items available
+                <AlignFont>Show items available</AlignFont>
               </Space>
               <Space as="span" h={{ size: 's', properties: ['margin-left'] }}>
                 <ul

--- a/common/views/components/Tags/Tags.tsx
+++ b/common/views/components/Tags/Tags.tsx
@@ -1,10 +1,10 @@
 import { font, classNames } from '../../../utils/classnames';
 import NextLink from 'next/link';
 import Space from '../styled/Space';
+import AlignFont from '../styled/AlignFont';
 import { InlineButton } from '../ButtonInline/ButtonInline';
 import { FunctionComponent, ReactElement } from 'react';
 import { LinkProps } from '../../../model/link-props';
-
 export type TagType = {
   textParts: string[];
   linkAttributes: LinkProps;
@@ -62,25 +62,27 @@ const Tags: FunctionComponent<Props> = ({
                         'inline-block': true,
                       })}
                     >
-                      {part}
-                      {i !== arr.length - 1 && (
-                        <Space
-                          as="span"
-                          h={
-                            // If we are the first element, we always have a `|` separator
-                            i === 0 || separator !== ''
-                              ? { size: 's', properties: ['padding-left'] }
-                              : undefined
-                          }
-                          className={classNames({
-                            [font('hnl', 5)]: true,
-                            'inline-block': true,
-                          })}
-                        >
-                          {' '}
-                          {i === 0 ? '|' : separator}
-                        </Space>
-                      )}
+                      <AlignFont>
+                        {part}
+                        {i !== arr.length - 1 && (
+                          <Space
+                            as="span"
+                            h={
+                              // If we are the first element, we always have a `|` separator
+                              i === 0 || separator !== ''
+                                ? { size: 's', properties: ['padding-left'] }
+                                : undefined
+                            }
+                            className={classNames({
+                              [font('hnl', 5)]: true,
+                              'inline-block': true,
+                            })}
+                          >
+                            {' '}
+                            {i === 0 ? '|' : separator}
+                          </Space>
+                        )}
+                      </AlignFont>
                     </Space>
                   ))}
                 </InlineButton>

--- a/common/views/components/styled/AlignFont.tsx
+++ b/common/views/components/styled/AlignFont.tsx
@@ -1,10 +1,25 @@
+import { useContext, FunctionComponent, ReactNode } from 'react';
 import styled from 'styled-components';
+import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
 
-const AlignFont = styled.span`
+type Props = {
+  children: ReactNode;
+};
+
+const Align = styled.span<{ isOn: boolean }>`
   .fonts-loaded & {
-    transform: translateY(-${props => props.theme.fontVerticalOffset});
-    display: inline-flex;
+    ${props =>
+      props.isOn &&
+      `
+      transform: translateY(-${props.theme.fontVerticalOffset});
+      display: inline-flex;
+    `}
   }
 `;
+
+const AlignFont: FunctionComponent<Props> = ({ children }) => {
+  const { helveticaRegular } = useContext(TogglesContext);
+  return <Align isOn={helveticaRegular}>{children}</Align>;
+};
 
 export default AlignFont;

--- a/common/views/components/styled/AlignFont.tsx
+++ b/common/views/components/styled/AlignFont.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
 
 type Props = {
-  className: string;
+  className?: string;
   children: ReactNode;
 };
 

--- a/common/views/components/styled/AlignFont.tsx
+++ b/common/views/components/styled/AlignFont.tsx
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+const AlignFont = styled.span`
+  .fonts-loaded & {
+    transform: translateY(-${props => props.theme.fontVerticalOffset});
+    display: inline-flex;
+  }
+`;
+
+export default AlignFont;

--- a/common/views/components/styled/AlignFont.tsx
+++ b/common/views/components/styled/AlignFont.tsx
@@ -13,7 +13,7 @@ const Align = styled.span<{ isOn: boolean }>`
       props.isOn &&
       `
       transform: translateY(-${props.theme.fontVerticalOffset});
-      display: inline-flex;
+      display: inline-block;
     `}
   }
 `;

--- a/common/views/components/styled/AlignFont.tsx
+++ b/common/views/components/styled/AlignFont.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
 
 type Props = {
+  className: string;
   children: ReactNode;
 };
 
@@ -17,9 +18,13 @@ const Align = styled.span<{ isOn: boolean }>`
   }
 `;
 
-const AlignFont: FunctionComponent<Props> = ({ children }) => {
+const AlignFont: FunctionComponent<Props> = ({ children, className }) => {
   const { helveticaRegular } = useContext(TogglesContext);
-  return <Align isOn={helveticaRegular}>{children}</Align>;
+  return (
+    <Align isOn={helveticaRegular} className={className}>
+      {children}
+    </Align>
+  );
 };
 
 export default AlignFont;

--- a/common/views/pages/_app-deprecated.js
+++ b/common/views/pages/_app-deprecated.js
@@ -488,8 +488,8 @@ export default class WecoApp extends App {
                                     __html: `
                                     @font-face {
                                       font-family: 'Helvetica Neue Light Web';
-                                      src: url('https://i.wellcomecollection.org/assets/fonts/d460c8dd-ab48-422e-ac1c-d9b6392b605a.woff2') format('woff2'),
-                                        url('https://i.wellcomecollection.org/assets/fonts/955441c8-2039-4256-bf4a-c475c31d1c0d.woff') format('woff');
+                                      src: url('https://i.wellcomecollection.org/assets/fonts/helvetica-neue-roman.woff2') format('woff2'),
+                                        url('https://i.wellcomecollection.org/assets/fonts/helvetica-neue-roman.woff') format('woff');
                                       font-weight: normal;
                                       font-style: normal;
                                     }
@@ -500,6 +500,7 @@ export default class WecoApp extends App {
                                         url('https://i.wellcomecollection.org/assets/fonts/fd5c4818-7809-4a21-a48d-a0dc15aa47b8.woff') format('woff');
                                       font-weight: normal;
                                       font-style: normal;
+                                      ascent-override: 100%;
                                     }
                                   `,
                                   }}

--- a/common/views/pages/_app-deprecated.js
+++ b/common/views/pages/_app-deprecated.js
@@ -496,11 +496,10 @@ export default class WecoApp extends App {
 
                                     @font-face {
                                       font-family: 'Helvetica Neue Medium Web';
-                                      src: url('https://i.wellcomecollection.org/assets/fonts/455d1f57-1462-4536-aefa-c13f0a67bbbe.woff2') format('woff2'),
-                                        url('https://i.wellcomecollection.org/assets/fonts/fd5c4818-7809-4a21-a48d-a0dc15aa47b8.woff') format('woff');
+                                      src: url('https://i.wellcomecollection.org/assets/fonts/helvetica-neue-bold.woff2') format('woff2'),
+                                        url('https://i.wellcomecollection.org/assets/fonts/helvetica-neue-bold.woff') format('woff');
                                       font-weight: normal;
                                       font-style: normal;
-                                      ascent-override: 100%;
                                     }
                                   `,
                                   }}

--- a/common/views/pages/_app-deprecated.js
+++ b/common/views/pages/_app-deprecated.js
@@ -476,7 +476,7 @@ export default class WecoApp extends App {
                 <GlobalAlertContext.Provider value={globalAlert}>
                   <PopupDialogContext.Provider value={popupDialog}>
                     <ThemeProvider theme={theme}>
-                      <GlobalStyle />
+                      <GlobalStyle toggles={toggles} />
                       <OutboundLinkTracker>
                         <Fragment>
                           <TogglesContext.Consumer>
@@ -488,9 +488,7 @@ export default class WecoApp extends App {
                                     __html: `
                                     @font-face {
                                       font-family: 'Helvetica Neue Light Web';
-                                      src: local('Helvetica Neue Regular'),
-                                        local('HelveticaNeue-Regular'),
-                                        url('https://i.wellcomecollection.org/assets/fonts/d460c8dd-ab48-422e-ac1c-d9b6392b605a.woff2') format('woff2'),
+                                      src: url('https://i.wellcomecollection.org/assets/fonts/d460c8dd-ab48-422e-ac1c-d9b6392b605a.woff2') format('woff2'),
                                         url('https://i.wellcomecollection.org/assets/fonts/955441c8-2039-4256-bf4a-c475c31d1c0d.woff') format('woff');
                                       font-weight: normal;
                                       font-style: normal;
@@ -498,9 +496,7 @@ export default class WecoApp extends App {
 
                                     @font-face {
                                       font-family: 'Helvetica Neue Medium Web';
-                                      src: local('Helvetica Neue Bold'),
-                                        local('HelveticaNeue-Bold'),
-                                        url('https://i.wellcomecollection.org/assets/fonts/455d1f57-1462-4536-aefa-c13f0a67bbbe.woff2') format('woff2'),
+                                      src: url('https://i.wellcomecollection.org/assets/fonts/455d1f57-1462-4536-aefa-c13f0a67bbbe.woff2') format('woff2'),
                                         url('https://i.wellcomecollection.org/assets/fonts/fd5c4818-7809-4a21-a48d-a0dc15aa47b8.woff') format('woff');
                                       font-weight: normal;
                                       font-style: normal;

--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -310,7 +310,7 @@ const WecoApp: FunctionComponent<AppProps> = ({
     <>
       <AppContextProvider>
         <ThemeProvider theme={theme}>
-          <GlobalStyle />
+          <GlobalStyle toggles={pageProps.globalContextData.toggles} />
           <OutboundLinkTracker>
             <LoadingIndicator />
             {!pageProps.err && <Component {...pageProps} />}

--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -310,7 +310,7 @@ const WecoApp: FunctionComponent<AppProps> = ({
     <>
       <AppContextProvider>
         <ThemeProvider theme={theme}>
-          <GlobalStyle toggles={pageProps.globalContextData.toggles} />
+          <GlobalStyle toggles={pageProps?.globalContextData?.toggles} />
           <OutboundLinkTracker>
             <LoadingIndicator />
             {!pageProps.err && <Component {...pageProps} />}

--- a/common/views/themes/config.ts
+++ b/common/views/themes/config.ts
@@ -188,6 +188,7 @@ export const themeValues = {
       xl: spacingUnits['10'],
     },
   },
+  fontVerticalOffset: '0.15em',
   grid,
   color(name: string, variant: ColorVariant = 'base'): string {
     return this.colors[name][variant];

--- a/common/views/themes/default.ts
+++ b/common/views/themes/default.ts
@@ -115,7 +115,7 @@ const cls = ({
 } as any) as Classes & SizedClasses;
 
 export type GlobalStyleProps = {
-  toggles: { [key: string]: boolean };
+  toggles?: { [key: string]: boolean };
 };
 
 const GlobalStyle = createGlobalStyle<GlobalStyleProps>`

--- a/common/views/themes/default.ts
+++ b/common/views/themes/default.ts
@@ -114,7 +114,11 @@ const cls = ({
   ...sizesClasses,
 } as any) as Classes & SizedClasses;
 
-const GlobalStyle = createGlobalStyle`
+export type GlobalStyleProps = {
+  toggles: { [key: string]: boolean };
+};
+
+const GlobalStyle = createGlobalStyle<GlobalStyleProps>`
   ${css`
     .${cls.displayBlock} {
       display: block;

--- a/common/views/themes/typography.ts
+++ b/common/views/themes/typography.ts
@@ -1,4 +1,6 @@
 import { themeValues } from './config';
+import { css } from 'styled-components';
+import { GlobalStyleProps } from './default';
 
 const breakpointNames = ['small', 'medium', 'large'];
 
@@ -79,7 +81,7 @@ const fontFamilyMixin = (family, isFull) => {
   return `font-family: ${fontFamilies[family][isFull ? 'full' : 'base']}`;
 };
 
-export const typography = `
+export const typography = css<GlobalStyleProps>`
   .font-hnm,
   .font-hnl {
     font-weight: normal;
@@ -274,15 +276,33 @@ export const typography = `
     a:visited:not(.link-reset) {
       text-decoration: none;
       border-bottom: 2px solid ${themeValues.color('green')};
-      transition: color ${themeValues.transitionProperties}, border-bottom ${
-  themeValues.transitionProperties
-};
+      transition: color ${themeValues.transitionProperties},
+        border-bottom ${themeValues.transitionProperties};
 
       &:hover {
         color: ${themeValues.color('green')};
         border-bottom-color: ${themeValues.color('transparent')};
       }
     }
+
+    ${props =>
+      props?.toggles.helveticaRegular &&
+      `
+      a:link:not(.link-reset),
+      a:visited:not(.link-reset) {
+        text-decoration: underline;
+        text-decoration-color: ${themeValues.color('green')};
+        text-underline-offset: 0.1em;
+        border-bottom: none;
+        transition: color ${themeValues.transitionProperties},
+        text-decoration-color ${themeValues.transitionProperties};
+
+        &:hover {
+          color: ${themeValues.color('green')};
+          text-decoration-color: transparent;
+        }
+      }
+    `}
 
     strong,
     b {

--- a/common/views/themes/typography.ts
+++ b/common/views/themes/typography.ts
@@ -286,7 +286,7 @@ export const typography = css<GlobalStyleProps>`
     }
 
     ${props =>
-      props?.toggles.helveticaRegular &&
+      props?.toggles?.helveticaRegular &&
       `
       a:link:not(.link-reset),
       a:visited:not(.link-reset) {


### PR DESCRIPTION
## Who is this for?
People looking at using roman/bold weight of Helvetica Neue behind a toggle

## What is it doing for them?
Changing the way link styling works (using a combination of `text-decoration-underline`, `text-underline-offset` and `text-decoration-color`) to prevent larger gaps that appear as a result of using `border-bottom` on the webfont when Helvetica isn't available as a system font.

Also allowing the toggles to be accessible within the `<GlobalStyle />`

The webfont has some extra space above each character, causing text in buttons and alongside icons to appear too low down. I've added an `AlignFont` component to apply an eye-balled amount of negative `translateY` to compensate. I think the ideal solution would be to apply the required [ascent-override](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/ascent-override) at the `@font-face` level, but this isn't yet supported in Safari/mobile Safari. Keeping an eye on [this webkit bug](https://bugs.webkit.org/show_bug.cgi?id=219735) for implementation though.

__Example body anchor font weight/color__
![image](https://user-images.githubusercontent.com/1394592/121344950-31667e80-c91c-11eb-90b4-e55f015ba3f1.png)


__TODO__
Updating `letter-spacing` for the `roman` weight of Helvetica Neue to be fractionally more spaced out. Unfortunately this isn't possible on the `@font-face` declaration, so not possible without targeting classes.