### PR TITLE
handle items that have a mix of authServices

### DIFF
--- a/common/utils/iiif.ts
+++ b/common/utils/iiif.ts
@@ -47,7 +47,7 @@ export function getAuthService(
           'https://iiif.wellcomecollection.org/auth/restrictedlogin'
       );
       // If there is a mixture of restricted images and non restricted images, we show the auth service of the non restricted ones, 'e.g. open with advisory', as these can still be viewd.
-      // Individual images that are restricted won't be displayed anhyway.
+      // Individual images that are restricted won't be displayed anyway.
       return nonRestrictedService || restrictedService;
     } else {
       return iiifManifest.service.authService;

--- a/common/utils/iiif.ts
+++ b/common/utils/iiif.ts
@@ -32,9 +32,26 @@ export function getAuthService(
   iiifManifest?: IIIFManifest
 ): AuthService | undefined {
   if (iiifManifest && iiifManifest.service) {
-    return Array.isArray(iiifManifest.service)
-      ? iiifManifest.service.find(service => !!service.authService)?.authService
-      : iiifManifest.service.authService;
+    if (Array.isArray(iiifManifest.service)) {
+      const authServices = iiifManifest.service
+        .filter(service => !!service.authService)
+        .map(service => service?.authService);
+      const restrictedService = authServices.find(
+        service =>
+          service?.['@id'] ===
+          'https://iiif.wellcomecollection.org/auth/restrictedlogin'
+      );
+      const nonRestrictedService = authServices.find(
+        service =>
+          service?.['@id'] !==
+          'https://iiif.wellcomecollection.org/auth/restrictedlogin'
+      );
+      // If there is a mixture of restricted images and non restricted images, we show the auth service of the non restricted ones, 'e.g. open with advisory', as these can still be viewd.
+      // Individual images that are restricted won't be displayed anhyway.
+      return nonRestrictedService || restrictedService;
+    } else {
+      return iiifManifest.service.authService;
+    }
   }
 }
 
@@ -84,8 +101,8 @@ export function getImageAuthService(canvas: IIIFCanvas): AuthService | null {
 export function isImageRestricted(canvas: IIIFCanvas): boolean {
   const imageAuthService = getImageAuthService(canvas);
   return Boolean(
-    imageAuthService &&
-      imageAuthService.profile === 'http://iiif.io/api/auth/0/login/restricted'
+    imageAuthService?.['@id'] ===
+      'https://iiif.wellcomecollection.org/auth/restrictedlogin'
   );
 }
 


### PR DESCRIPTION
We were only looking for the first authService in the iiifManifest, which assumed all images had the same conditions.

This meant when we had an item with a mixture of 'restricted' and 'open with advisory' images, the [whole item was being treated as restricted](https://wellcome.slack.com/archives/C8X9YKM5X/p1623244527029200), if that was the first authService we found.

We can only handle showing one authService message in the viewer, so this PR uses the first on that isn't the restricted one, if there is a mix.

This is ok as the restricted image won't show in the viewer. Instead the user sees the following:

On thumbnails:
<img width="491" alt="Screenshot 2021-06-09 at 15 06 58" src="https://user-images.githubusercontent.com/6051896/121372470-3801ef80-c936-11eb-97fc-09081af6fb6d.png">

For the main image:
<img width="842" alt="Screenshot 2021-06-09 at 15 07 12" src="https://user-images.githubusercontent.com/6051896/121372539-4819cf00-c936-11eb-8e59-7e41951f87fa.png">


 
