### PR TITLE
Login v2

### DIFF
--- a/catalogue/webapp/.env.production
+++ b/catalogue/webapp/.env.production
@@ -1,0 +1,1 @@
+CONTEXT_PATH="account"

--- a/catalogue/webapp/components/SignIn/SignIn.tsx
+++ b/catalogue/webapp/components/SignIn/SignIn.tsx
@@ -1,5 +1,8 @@
 import { FunctionComponent } from 'react';
-import { useUserInfo } from '@weco/identity/src/frontend/MyAccount/UserInfoContext';
+import {
+  useUserInfo,
+  withUserInfo,
+} from '@weco/identity/src/frontend/MyAccount/UserInfoContext';
 import { classNames } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 
@@ -29,4 +32,4 @@ const SignIn: FunctionComponent = () => {
   );
 };
 
-export default SignIn;
+export default withUserInfo(SignIn);

--- a/common/views/components/CataloguePageLayout/CataloguePageLayout.tsx
+++ b/common/views/components/CataloguePageLayout/CataloguePageLayout.tsx
@@ -1,7 +1,6 @@
 import { FunctionComponent, useEffect, useState } from 'react';
 import PageLayout, { Props as PageLayoutProps } from '../PageLayout/PageLayout';
 import InfoBanner from '../InfoBanner/InfoBanner';
-import { UserInfoProvider } from '@weco/identity/src/frontend/MyAccount/UserInfoContext';
 import SignIn from '@weco/catalogue/components/SignIn/SignIn';
 import { prefix } from '@weco/identity/src/utility/prefix';
 
@@ -41,11 +40,7 @@ const CataloguePageLayout: FunctionComponent<Props> = ({
             )}
           </>
         )}
-        {showLogin && (
-          <UserInfoProvider>
-            <SignIn />
-          </UserInfoProvider>
-        )}
+        {showLogin && <SignIn />}
         {children}
       </PageLayout>
     </div>

--- a/common/views/components/CataloguePageLayout/CataloguePageLayout.tsx
+++ b/common/views/components/CataloguePageLayout/CataloguePageLayout.tsx
@@ -3,6 +3,7 @@ import PageLayout, { Props as PageLayoutProps } from '../PageLayout/PageLayout';
 import InfoBanner from '../InfoBanner/InfoBanner';
 import { UserInfoProvider } from '@weco/identity/src/frontend/MyAccount/UserInfoContext';
 import SignIn from '@weco/catalogue/components/SignIn/SignIn';
+import { prefix } from '@weco/identity/src/utility/prefix';
 
 type Props = {
   hideInfoBar?: boolean;
@@ -22,30 +23,32 @@ const CataloguePageLayout: FunctionComponent<Props> = ({
   }, []);
 
   return (
-    <PageLayout {...props}>
-      {hideInfoBar !== true && (
-        <>
-          {isRedirectBannerVisible && (
-            <InfoBanner
-              text={[
-                {
-                  type: 'paragraph',
-                  text: `Coming from Wellcome Images? All freely available images have now been moved to the Wellcome Collection website. Here we're working to improve data quality, search relevance and tools to help you use these images more easily`,
-                  spans: [],
-                },
-              ]}
-              cookieName="WC_wellcomeImagesRedirect"
-            />
-          )}
-        </>
-      )}
-      {showLogin && (
-        <UserInfoProvider>
-          <SignIn />
-        </UserInfoProvider>
-      )}
-      {children}
-    </PageLayout>
+    <div id="root" data-context-path={prefix}>
+      <PageLayout {...props}>
+        {hideInfoBar !== true && (
+          <>
+            {isRedirectBannerVisible && (
+              <InfoBanner
+                text={[
+                  {
+                    type: 'paragraph',
+                    text: `Coming from Wellcome Images? All freely available images have now been moved to the Wellcome Collection website. Here we're working to improve data quality, search relevance and tools to help you use these images more easily`,
+                    spans: [],
+                  },
+                ]}
+                cookieName="WC_wellcomeImagesRedirect"
+              />
+            )}
+          </>
+        )}
+        {showLogin && (
+          <UserInfoProvider>
+            <SignIn />
+          </UserInfoProvider>
+        )}
+        {children}
+      </PageLayout>
+    </div>
   );
 };
 


### PR DESCRIPTION
Gets the login functionality in the catalogue app working on stage and prod, and not just locally.

[Sets a CONTEXT_PATH environment variable, as outlined in the identity app readme](https://github.com/wellcomecollection/wellcomecollection.org/tree/main/identity/webapp#context-path) and adds the value as a data attribute to the page, in the same way the identity app does.

We may want to make use of [Nextjs's ability to expose environment variables to the browser](https://nextjs.org/docs/basic-features/environment-variables#exposing-environment-variables-to-the-browser), rather than using a data attribute, but this works for now and is consistent with the identity app, meaning we don't need to rewrite any methods.

But we'll probably want to get the value of the context path from AWS Parameter Store as the identity app does, which I don't think will allow us to expose the environment variable to the browser with Nextjs

