### PR TITLE
Remove unwanted no-margin class

### DIFF
--- a/common/views/components/FindUs/FindUs.tsx
+++ b/common/views/components/FindUs/FindUs.tsx
@@ -73,7 +73,7 @@ const FindUs: FunctionComponent = () => (
       <p
         style={{ marginLeft: '38px' }}
         className={classNames({
-          'block': true,
+          block: true,
         })}
       >
         <abbr title="telephone number">T</abbr>:{' '}

--- a/common/views/components/FindUs/FindUs.tsx
+++ b/common/views/components/FindUs/FindUs.tsx
@@ -73,7 +73,7 @@ const FindUs: FunctionComponent = () => (
       <p
         style={{ marginLeft: '38px' }}
         className={classNames({
-          'block no-margin': true,
+          'block': true,
         })}
       >
         <abbr title="telephone number">T</abbr>:{' '}


### PR DESCRIPTION
## Who is this for?
People who want the FindUs section in the Footer and on the /visit-us page to be aligned with the content above.

## What is it doing for them?
Doing that.