### PR TITLE
Account navigation

### DIFF
--- a/identity/webapp/src/frontend/components/PageWrapper.tsx
+++ b/identity/webapp/src/frontend/components/PageWrapper.tsx
@@ -1,30 +1,10 @@
 import React from 'react';
-import styled from 'styled-components';
-import { Logo } from './Logo';
-
-const Header = styled.header`
-  position: relative;
-  top: 0;
-  left: 0;
-  right: 0;
-  background-color: white;
-  border-bottom: 1px solid #ddd;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 85px;
-
-  & > img {
-    width: unset;
-  }
-`;
+import Header from '@weco/common/views/components/Header/Header';
 
 export const PageWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   return (
     <>
-      <Header>
-        <Logo />
-      </Header>
+      <Header siteSection="collections" />
       <div>{children}</div>
     </>
   );

--- a/identity/webapp/src/routes/assets/index.html.ts
+++ b/identity/webapp/src/routes/assets/index.html.ts
@@ -142,6 +142,37 @@ export default function buildHtml(bundle: string, prefix = ''): string {
     <title>Account management</title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="https://i.wellcomecollection.org/assets/icons/apple-touch-icon.png"
+    />
+    <link
+      rel="shortcut icon"
+      href="https://i.wellcomecollection.org/assets/icons/favicon.ico"
+      type="image/ico"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      href="https://i.wellcomecollection.org/assets/icons/favicon-32x32.png"
+      sizes="32x32"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      href="https://i.wellcomecollection.org/assets/icons/favicon-16x16.png"
+      sizes="16x16"
+    />
+    <link
+      rel="manifest"
+      href="https://i.wellcomecollection.org/assets/icons/manifest.json"
+    />
+    <link
+      rel="mask-icon"
+      href="https://i.wellcomecollection.org/assets/icons/safari-pinned-tab.svg"
+      color="#000000"
+    />
     <script crossorigin src="https://unpkg.com/react@16/umd/react.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"></script>
   </head>


### PR DESCRIPTION
Adds the main navigation to the identity app pages so users can navigate to the rest of the site

Before: 
![before](https://user-images.githubusercontent.com/6051896/121917636-39179000-cd2d-11eb-8fd0-b544d9d9bf73.gif)

After:
![after](https://user-images.githubusercontent.com/6051896/121917671-416fcb00-cd2d-11eb-9fad-8ba6137ed3cc.gif)

Also adds favicons:
<img width="221" alt="Screenshot 2021-06-14 at 16 19 29" src="https://user-images.githubusercontent.com/6051896/121917684-46cd1580-cd2d-11eb-96d1-8aa0cc704f4a.png">






