### PR TITLE
Add tests for top-level landing pages response

### DIFF
--- a/playwright/test/helpers/urls.ts
+++ b/playwright/test/helpers/urls.ts
@@ -6,3 +6,12 @@ export const useStageApis = process.env.USE_STAGE_APIS
   : false;
 export const worksUrl = `${baseUrl}/works`;
 export const imagesUrl = `${baseUrl}/images`;
+
+// Top-level pages
+export const homepageUrl = `${baseUrl}`;
+export const visitUsUrl = `${baseUrl}/visit-us`;
+export const whatsOnUrl = `${baseUrl}/whats-on`;
+export const storiesUrl = `${baseUrl}/stories`;
+export const collectionsUrl = `${baseUrl}/collections`;
+export const getInvolvedUrl = `${baseUrl}/get-involved`;
+export const aboutUsUrl = `${baseUrl}/about-us`;

--- a/playwright/test/landing-pages.test.ts
+++ b/playwright/test/landing-pages.test.ts
@@ -1,0 +1,46 @@
+import {
+  homepageUrl,
+  visitUsUrl,
+  whatsOnUrl,
+  storiesUrl,
+  collectionsUrl,
+  aboutUsUrl,
+} from './helpers/urls';
+
+describe('Top-level landing pages', () => {
+  test('the homepage renders with a status code of 200', async () => {
+    await page.goto(homepageUrl);
+    const response = await page.waitForEvent('response');
+    expect(response.ok()).toBe(true);
+  });
+
+  test('the visit us page renders with a status code of 200', async () => {
+    await page.goto(visitUsUrl);
+    const response = await page.waitForEvent('response');
+    expect(response.ok()).toBe(true);
+  });
+
+  test(`the what's on page renders with a status code of 200`, async () => {
+    await page.goto(whatsOnUrl);
+    const response = await page.waitForEvent('response');
+    expect(response.ok()).toBe(true);
+  });
+
+  test(`the stories page renders with a status code of 200`, async () => {
+    await page.goto(storiesUrl);
+    const response = await page.waitForEvent('response');
+    expect(response.ok()).toBe(true);
+  });
+
+  test('the collections page renders with a status code of 200', async () => {
+    await page.goto(collectionsUrl);
+    const response = await page.waitForEvent('response');
+    expect(response.ok()).toBe(true);
+  });
+
+  test('the about us page renders with a status code of 200', async () => {
+    await page.goto(aboutUsUrl);
+    const response = await page.waitForEvent('response');
+    expect(response.ok()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Who is this for?
Devs who want confidence that the top-level pages are going to render.

## What is it doing for them?
Adding a test for the response status code of each page.