### PR TITLE
Switch to helvetica roman/bold combination for everyone

### DIFF
--- a/cardigan/stories/components/Cards/Cards.stories.tsx
+++ b/cardigan/stories/components/Cards/Cards.stories.tsx
@@ -59,7 +59,7 @@ const FeaturedCardTemplate = args => {
       <h2 className="font-wb font-size-2">
         Remote diagnosis from wee to the Web
       </h2>
-      <p className="font-hnl font-size-5">
+      <p className="font-hnr font-size-5">
         Medical practice might have moved on from when patients posted flasks of
         their urine for doctors to taste, but telehealth today keeps up the
         tradition of remote diagnosis – to our possible detriment.

--- a/cardigan/stories/components/PageHeader/PageHeader.stories.tsx
+++ b/cardigan/stories/components/PageHeader/PageHeader.stories.tsx
@@ -37,21 +37,21 @@ const ContentTypeInfo = (
       <Space
         h={{ size: 's', properties: ['margin-right', 'margin-top'] }}
         className={classNames({
-          [font('hnl', 6)]: true,
+          [font('hnr', 6)]: true,
         })}
       >
         <p className="no-margin">
           <span>By </span>
           <span
             className={classNames({
-              [font('hnm', 6)]: true,
+              [font('hnb', 6)]: true,
             })}
           >
             Naomi Paxton
           </span>{' '}
           <span
             className={classNames({
-              [font('hnl', 6)]: true,
+              [font('hnr', 6)]: true,
               'font-pewter': true,
             })}
           >
@@ -156,7 +156,7 @@ const EventContentTypeInfo = () => (
       Saturday 8 February 2020, 13:00—16:00
     </Space>
     <div className="flex">
-      <div className={`${font('hnm', 5)} flex flex--v-center`}>
+      <div className={`${font('hnb', 5)} flex flex--v-center`}>
         <Space
           as="span"
           h={{ size: 'xs', properties: ['margin-right'] }}
@@ -172,7 +172,7 @@ const EventContentTypeInfo = () => (
 
 const ExhibitionContentTypeInfo = () => (
   <div className="flex">
-    <div className={`${font('hnm', 5)} flex flex--v-center`}>
+    <div className={`${font('hnb', 5)} flex flex--v-center`}>
       <Space
         as="span"
         h={{ size: 'xs', properties: ['margin-right'] }}
@@ -189,7 +189,7 @@ const BookContentTypeInfo = () => (
   <p
     className={classNames({
       'no-margin': true,
-      [font('hnm', 3)]: true,
+      [font('hnb', 3)]: true,
     })}
   >
     Loneliness, Health & What Happens When We Find Connection

--- a/cardigan/stories/global/typography/typography.stories.tsx
+++ b/cardigan/stories/global/typography/typography.stories.tsx
@@ -11,7 +11,7 @@ const Font = styled.div`
 
 const FontName = styled.h2.attrs({
   className: classNames({
-    [font('hnm', 6)]: true,
+    [font('hnb', 6)]: true,
   }),
 })`
   color: ${props => props.theme.color('red')};
@@ -55,7 +55,7 @@ const TypographyScale = ({ fontFamily }) => {
 };
 
 const sizes = [0, 1, 2, 3, 4, 5, 6];
-const fontFamilies = ['wb', 'hnm', 'hnl', 'lr'];
+const fontFamilies = ['wb', 'hnb', 'hnr', 'lr'];
 
 const Typography = ({ text }) => {
   return (
@@ -120,7 +120,7 @@ const MiscTemplate = () => (
     <div>
       <h2>Plain text link</h2>
       <div>
-        <p className="no-margin font-hnl4-s">
+        <p className="no-margin font-hnr4-s">
           Here is <a href="#">a link</a> in a block of non body text.
         </p>
       </div>

--- a/catalogue/webapp/components/Download/Download.tsx
+++ b/catalogue/webapp/components/Download/Download.tsx
@@ -14,7 +14,7 @@ import { DownloadFormat } from '../DownloadLink/DownloadLink';
 
 export const DownloadOptions = styled.div.attrs(() => ({
   className: classNames({
-    [font('hnm', 4)]: true,
+    [font('hnb', 4)]: true,
   }),
 }))`
   white-space: normal;
@@ -69,7 +69,7 @@ const Download: NextPage<Props> = ({
   return (
     <div
       className={classNames({
-        [font('hnl', 5)]: true,
+        [font('hnr', 5)]: true,
         'inline-block': isEnhanced,
         relative: true,
       })}
@@ -85,7 +85,7 @@ const Download: NextPage<Props> = ({
           >
             <DownloadOptions
               className={classNames({
-                [font('hnm', 5)]: true,
+                [font('hnb', 5)]: true,
               })}
             >
               <SpacingComponent>

--- a/catalogue/webapp/components/DownloadLink/DownloadLink.tsx
+++ b/catalogue/webapp/components/DownloadLink/DownloadLink.tsx
@@ -8,7 +8,7 @@ import { trackEvent } from '@weco/common/services/conversion/track';
 
 const DownloadLinkStyle = styled.a.attrs({
   className: classNames({
-    [font('hnm', 5)]: true,
+    [font('hnb', 5)]: true,
   }),
 })`
   display: inline-block;
@@ -63,7 +63,7 @@ const DownloadLink: FunctionComponent<Props> = ({
           as="span"
           h={{ size: 'm', properties: ['margin-left'] }}
           className={classNames({
-            [font('hnm', 5)]: true,
+            [font('hnb', 5)]: true,
             'font-pewter': true,
           })}
         >

--- a/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
+++ b/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
@@ -343,7 +343,7 @@ const ExpandedImage: FunctionComponent<Props> = ({
             <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
               <h2
                 className={classNames({
-                  [font('hnm', 3)]: true,
+                  [font('hnb', 3)]: true,
                   'no-margin': true,
                 })}
               >
@@ -353,7 +353,7 @@ const ExpandedImage: FunctionComponent<Props> = ({
                 <Space
                   as="h3"
                   v={{ size: 's', properties: ['margin-top'] }}
-                  className={classNames({ [font('hnm', 5)]: true })}
+                  className={classNames({ [font('hnb', 5)]: true })}
                 >
                   {displayContributor}
                 </Space>
@@ -361,7 +361,7 @@ const ExpandedImage: FunctionComponent<Props> = ({
             </Space>
             {license && (
               <Space
-                className={font('hnl', 5)}
+                className={font('hnr', 5)}
                 v={{ size: 'l', properties: ['margin-bottom'] }}
               >
                 <License license={license} />
@@ -391,7 +391,7 @@ const ExpandedImage: FunctionComponent<Props> = ({
                 <a
                   className={classNames({
                     'inline-block': true,
-                    [font('hnl', 5)]: true,
+                    [font('hnr', 5)]: true,
                   })}
                   onClick={onWorkLinkClick}
                 >

--- a/catalogue/webapp/components/MultipleManifestList/MultipleManifestList.tsx
+++ b/catalogue/webapp/components/MultipleManifestList/MultipleManifestList.tsx
@@ -11,7 +11,7 @@ import { volumesNavigationLabel } from '@weco/common/text/aria-labels';
 
 const HiddenContent = styled.div.attrs(() => ({
   className: classNames({
-    [font('hnm', 5)]: true,
+    [font('hnb', 5)]: true,
   }),
 }))`
   min-width: 200px;

--- a/catalogue/webapp/components/RequestLocation/RequestLocation.js
+++ b/catalogue/webapp/components/RequestLocation/RequestLocation.js
@@ -198,21 +198,21 @@ const RequestLocation = ({ work }: Props) => {
                 >
                   <h2
                     className={classNames({
-                      [font('hnm', 5)]: true,
+                      [font('hnb', 5)]: true,
                     })}
                   >
                     Request items
                   </h2>
                   <p
                     className={classNames({
-                      [font('hnl', 5)]: true,
+                      [font('hnr', 5)]: true,
                     })}
                   >
                     You are about to request the following items:
                   </p>
                   <p
                     className={classNames({
-                      [font('hnm', 6)]: true,
+                      [font('hnb', 6)]: true,
                     })}
                   >
                     {work.title}
@@ -224,13 +224,13 @@ const RequestLocation = ({ work }: Props) => {
                           <li
                             key={item.id}
                             className={classNames({
-                              [font('hnm', 5)]: true,
+                              [font('hnb', 5)]: true,
                             })}
                           >
                             <Space
                               as="span"
                               className={classNames({
-                                [font('hnl', 5)]: true,
+                                [font('hnr', 5)]: true,
                               })}
                               h={{
                                 size: 's',
@@ -269,7 +269,7 @@ const RequestLocation = ({ work }: Props) => {
                             <Space
                               as="span"
                               className={classNames({
-                                [font('hnl', 5)]: true,
+                                [font('hnr', 5)]: true,
                               })}
                               h={{
                                 size: 'l',
@@ -308,7 +308,7 @@ const RequestLocation = ({ work }: Props) => {
                       <Space
                         as="span"
                         className={classNames({
-                          [font('hnl', 6)]: true,
+                          [font('hnr', 6)]: true,
                         })}
                         h={{ size: 'l', properties: ['margin-left'] }}
                       >
@@ -328,7 +328,7 @@ const RequestLocation = ({ work }: Props) => {
                   >
                     <h2
                       className={classNames({
-                        [font('hnm', 5)]: true,
+                        [font('hnb', 5)]: true,
                       })}
                     >
                       {itemsWithPhysicalLocations.filter(item => item.requested)
@@ -346,7 +346,7 @@ const RequestLocation = ({ work }: Props) => {
                           <li key={item.id}>
                             <span
                               className={classNames({
-                                [font('hnm', 5)]: true,
+                                [font('hnb', 5)]: true,
                               })}
                             >
                               {item.title}
@@ -355,7 +355,7 @@ const RequestLocation = ({ work }: Props) => {
                             <Space
                               as="span"
                               className={classNames({
-                                [font('hnl', 5)]: true,
+                                [font('hnr', 5)]: true,
                               })}
                               h={{
                                 size: 'l',

--- a/catalogue/webapp/components/SearchNoResults/SearchNoResults.tsx
+++ b/catalogue/webapp/components/SearchNoResults/SearchNoResults.tsx
@@ -10,7 +10,7 @@ type Props = {
 
 const QuerySpan = styled.span.attrs({
   className: classNames({
-    [font('hnm', 2)]: true,
+    [font('hnb', 2)]: true,
   }),
 })``;
 
@@ -23,7 +23,7 @@ const SearchNoResults: FunctionComponent<Props> = ({
       <div className="container">
         <div className="grid">
           <div className={grid({ s: 12, m: 10, l: 8, xl: 8 })}>
-            <p className={font('hnl', 2)}>
+            <p className={font('hnr', 2)}>
               We couldn{`'`}t find anything that matched{' '}
               <QuerySpan>{query}</QuerySpan>
               {hasFilters && (

--- a/catalogue/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.tsx
+++ b/catalogue/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.tsx
@@ -64,7 +64,7 @@ const VisuallySimilarImagesFromApi: FunctionComponent<Props> = ({
       </Wrapper>
       <p
         className={classNames({
-          [font('hnl', 6)]: true,
+          [font('hnr', 6)]: true,
           'no-margin': true,
         })}
       >

--- a/catalogue/webapp/components/WorkDetails/OnlineResources.tsx
+++ b/catalogue/webapp/components/WorkDetails/OnlineResources.tsx
@@ -8,7 +8,7 @@ import styled from 'styled-components';
 const ShowHideButton = styled.button.attrs({
   className: classNames({
     'plain-button no-margin no-padding': true,
-    [font('hnl', 5)]: true,
+    [font('hnr', 5)]: true,
   }),
 })`
   text-decoration: underline;
@@ -62,7 +62,7 @@ const OnlineResources: FunctionComponent<Props> = ({ work }: Props) => {
         {firstThreeOnlineResources.map(item => (
           <li
             className={classNames({
-              [font('hnl', 5)]: true,
+              [font('hnr', 5)]: true,
             })}
             key={item.location.url}
           >
@@ -78,7 +78,7 @@ const OnlineResources: FunctionComponent<Props> = ({ work }: Props) => {
             {remainingOnlineResources.map((item, index) => (
               <li
                 className={classNames({
-                  [font('hnl', 5)]: true,
+                  [font('hnr', 5)]: true,
                 })}
                 key={item.location.url}
               >

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -283,7 +283,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
                         {locationLink && (
                           <a
                             className={classNames({
-                              [font('hnl', 5)]: true,
+                              [font('hnr', 5)]: true,
                             })}
                             href={locationLink.url}
                           >
@@ -710,7 +710,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
         headingText="Permanent link"
         isInArchive={isInArchive}
       >
-        <div className={`${font('hnl', 5)}`}>
+        <div className={`${font('hnr', 5)}`}>
           <CopyUrl
             id={work.id}
             url={`https://wellcomecollection.org/works/${work.id}`}

--- a/catalogue/webapp/components/WorkDetailsProperty/WorkDetailsProperty.tsx
+++ b/catalogue/webapp/components/WorkDetailsProperty/WorkDetailsProperty.tsx
@@ -22,7 +22,7 @@ const WorkDetailsProperty: FunctionComponent<Props> = ({
       wrapper={children => <SpacingComponent>{children}</SpacingComponent>}
     >
       <div
-        className={`${font('hnl', 5, { small: 3, medium: 3 })}${
+        className={`${font('hnr', 5, { small: 3, medium: 3 })}${
           inlineHeading ? ' flex' : ''
         }`}
       >
@@ -38,7 +38,7 @@ const WorkDetailsProperty: FunctionComponent<Props> = ({
                 : { size: 's', properties: [] }
             }
             className={classNames({
-              [font('hnm', 5, { small: 3, medium: 3 })]: true,
+              [font('hnb', 5, { small: 3, medium: 3 })]: true,
               'no-margin': !inlineHeading,
             })}
             style={{ marginBottom: 0 }}

--- a/catalogue/webapp/components/WorksSearchResult/WorksSearchResult.tsx
+++ b/catalogue/webapp/components/WorksSearchResult/WorksSearchResult.tsx
@@ -112,7 +112,7 @@ const WorkSearchResult: FunctionComponent<Props> = ({
             <Details>
               <h2
                 className={classNames({
-                  [font('hnm', 4)]: true,
+                  [font('hnb', 4)]: true,
                   'card-link__title': true,
                 })}
               >

--- a/catalogue/webapp/pages/download.tsx
+++ b/catalogue/webapp/pages/download.tsx
@@ -109,7 +109,7 @@ const DownloadPage: NextPage<Props> = ({
               as="h1"
               id="work-info"
               className={classNames({
-                [font('hnm', 1)]: true,
+                [font('hnb', 1)]: true,
               })}
             >
               {title}

--- a/catalogue/webapp/pages/item.tsx
+++ b/catalogue/webapp/pages/item.tsx
@@ -282,9 +282,9 @@ const ItemPage: NextPage<Props> = ({
         removeCloseButton={true}
         openButtonRef={{ current: null }}
       >
-        <div className={font('hnl', 5)}>
+        <div className={font('hnr', 5)}>
           {authService?.label && (
-            <h2 className={font('hnm', 4)}>{authService?.label}</h2>
+            <h2 className={font('hnb', 4)}>{authService?.label}</h2>
           )}
           {authService?.description && (
             <div

--- a/common/services/prismic/html-serializers.js
+++ b/common/services/prismic/html-serializers.js
@@ -157,7 +157,7 @@ export const defaultSerializer: HtmlSerializer = (
           <a
             key={i}
             target={target}
-            className="no-margin plain-link font-green font-HNM3-s flex-inline flex--h-baseline"
+            className="no-margin plain-link font-green flex-inline flex--h-baseline"
             href={linkUrl}
           >
             <span className="icon" style={{ top: '8px' }}>
@@ -182,12 +182,8 @@ export const defaultSerializer: HtmlSerializer = (
             <span className="no-margin">
               <span className="no-margin underline-on-hover">{children}</span>{' '}
               <span style={{ whiteSpace: 'nowrap' }}>
-                <span className="no-margin font-pewter font-HNM4-s">
-                  {documentType}
-                </span>{' '}
-                <span className="no-margin font-pewter font-HNL4-s">
-                  {documentSize}kb
-                </span>
+                <span className="no-margin font-pewter">{documentType}</span>{' '}
+                <span className="no-margin font-pewter">{documentSize}kb</span>
               </span>
             </span>
           </a>

--- a/common/utils/classnames.js
+++ b/common/utils/classnames.js
@@ -32,7 +32,7 @@ export function cssGrid(sizes: SizeMap): string {
   return [base].concat(modifierClasses).join(' ');
 }
 
-type FontFamily = 'hnl' | 'hnm' | 'wb' | 'lr';
+type FontFamily = 'hnr' | 'hnb' | 'wb' | 'lr';
 type FontSize = 1 | 2 | 3 | 4 | 5 | 6;
 type FontSizeAll = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
 type FontSizeOverrides = {|

--- a/common/views/components/ArchiveTree/ArchiveTree.tsx
+++ b/common/views/components/ArchiveTree/ArchiveTree.tsx
@@ -192,7 +192,7 @@ const StyledLink = styled.a<StyledLinkProps>`
 
 const RefNumber = styled.span.attrs({
   className: classNames({
-    [font('hnl', 6)]: true,
+    [font('hnr', 6)]: true,
   }),
 })`
   line-height: 1;
@@ -691,8 +691,8 @@ const ListItem: FunctionComponent<ListItemProps> = ({
         >
           <StyledLink
             className={classNames({
-              [font('hnm', 6)]: level === 1,
-              [font('hnl', 6)]: level > 1,
+              [font('hnb', 6)]: level === 1,
+              [font('hnr', 6)]: level > 1,
             })}
             hideFocus={!isKeyboard}
             tabIndex={isEnhanced ? (isSelected ? 0 : -1) : 0}

--- a/common/views/components/BackToResults/BackToResults.tsx
+++ b/common/views/components/BackToResults/BackToResults.tsx
@@ -20,7 +20,7 @@ const BackToResults: FunctionComponent = () => {
           });
         }}
         className={classNames({
-          [font('hnl', 5)]: true,
+          [font('hnr', 5)]: true,
         })}
       >
         <span>{`Back to search${query ? ' results' : ''}`}</span>

--- a/common/views/components/BannerCard/BannerCard.tsx
+++ b/common/views/components/BannerCard/BannerCard.tsx
@@ -147,14 +147,14 @@ const BannerCard: FunctionComponent<Props> = ({
               size: 's',
               properties: ['margin-top', 'margin-bottom'],
             }}
-            className={`${font('hnl', 5)} font-marble`}
+            className={`${font('hnr', 5)} font-marble`}
           >
             <DateRange start={new Date(start)} end={new Date(end)} />
           </Space>
         )}
         <p
           className={classNames({
-            [font('hnl', 5)]: true,
+            [font('hnr', 5)]: true,
           })}
         >
           {description}

--- a/common/views/components/BetaMessage/BetaMessage.tsx
+++ b/common/views/components/BetaMessage/BetaMessage.tsx
@@ -6,7 +6,7 @@ import Icon from '@weco/common/views/components/Icon/Icon';
 
 const StyledBetaMessage = styled.div.attrs(() => ({
   className: classNames({
-    [font('hnl', 5)]: true,
+    [font('hnr', 5)]: true,
     'flex flex--v-center': true,
   }),
 }))`

--- a/common/views/components/Body/Body.tsx
+++ b/common/views/components/Body/Body.tsx
@@ -200,12 +200,12 @@ const Body: FunctionComponent<Props> = ({
                   >
                     <h2 className="font-wb font-size-2">{firstItem.title}</h2>
                     {isCardType && firstItem.description && (
-                      <p className="font-hnl font-size-5">
+                      <p className="font-hnr font-size-5">
                         {firstItem.description}
                       </p>
                     )}
                     {firstItem.promo && (
-                      <p className="font-hnl font-size-5">
+                      <p className="font-hnr font-size-5">
                         {firstItem.promo.caption}
                       </p>
                     )}

--- a/common/views/components/Body/VisitUsStaticContent.tsx
+++ b/common/views/components/Body/VisitUsStaticContent.tsx
@@ -33,7 +33,7 @@ const VisitUsStaticContent: FunctionComponent = () => {
         <div
           className={classNames({
             [grid({ s: 12, l: 5, xl: 5 })]: true,
-            [font('hnl', 4)]: true,
+            [font('hnr', 4)]: true,
           })}
         >
           <FindUs />
@@ -41,7 +41,7 @@ const VisitUsStaticContent: FunctionComponent = () => {
         <div
           className={classNames({
             [grid({ s: 12, l: 5, xl: 5 })]: true,
-            [font('hnl', 4)]: true,
+            [font('hnr', 4)]: true,
           })}
         >
           <div className="flex">
@@ -50,13 +50,13 @@ const VisitUsStaticContent: FunctionComponent = () => {
             </Space>
             <div
               className={classNames({
-                [font('hnl', 5)]: true,
+                [font('hnr', 5)]: true,
                 'float-l': true,
               })}
             >
               <h2
                 className={classNames({
-                  [font('hnm', 5)]: true,
+                  [font('hnb', 5)]: true,
                   'no-margin': true,
                 })}
               >{`Today's opening times`}</h2>

--- a/common/views/components/BookPromo/BookPromo.tsx
+++ b/common/views/components/BookPromo/BookPromo.tsx
@@ -123,7 +123,7 @@ const BookPromo: FunctionComponent<Props> = ({
               v={{ size: 's', properties: ['margin-top'] }}
               className={classNames({
                 'no-margin': true,
-                [font('hnm', 5)]: true,
+                [font('hnb', 5)]: true,
               })}
             >
               {subtitle}
@@ -134,7 +134,7 @@ const BookPromo: FunctionComponent<Props> = ({
             <Space v={{ size: 's', properties: ['margin-top'] }}>
               <p
                 className={classNames({
-                  [font('hnl', 5)]: true,
+                  [font('hnr', 5)]: true,
                   'no-margin': true,
                 })}
               >

--- a/common/views/components/Breadcrumb/Breadcrumb.tsx
+++ b/common/views/components/Breadcrumb/Breadcrumb.tsx
@@ -38,14 +38,14 @@ const Breadcrumb: FunctionComponent<Props> = ({
             }}
             key={text}
             className={classNames({
-              [font('hnl', 5)]: true,
+              [font('hnr', 5)]: true,
               'border-left-width-1 border-color-black': i !== 0,
             })}
           >
             {prefix}{' '}
             <LinkOrSpanTag
               className={classNames({
-                [font('hnm', 5)]: Boolean(prefix),
+                [font('hnb', 5)]: Boolean(prefix),
               })}
               href={url}
             >
@@ -58,7 +58,7 @@ const Breadcrumb: FunctionComponent<Props> = ({
     {items.length === 0 && (
       <span
         className={classNames({
-          [font('hnl', 5)]: true,
+          [font('hnr', 5)]: true,
           'empty-filler': true,
         })}
         style={{ lineHeight: 1 }}

--- a/common/views/components/ButtonSolid/ButtonSolid.tsx
+++ b/common/views/components/ButtonSolid/ButtonSolid.tsx
@@ -70,7 +70,7 @@ export const BaseButtonInner = styled(BaseButtonInnerSpan).attrs<
   BaseButtonInnerProps
 >(props => ({
   className: classNames({
-    [font(props.isInline ? 'hnl' : 'hnm', 5)]: true,
+    [font(props.isInline ? 'hnr' : 'hnb', 5)]: true,
     'flex flex--v-center': true,
   }),
 }))`

--- a/common/views/components/Card/Card.tsx
+++ b/common/views/components/Card/Card.tsx
@@ -99,7 +99,7 @@ const Card: FunctionComponent<Props> = ({ item }: Props) => {
             </Space>
           )}
           {item.description && (
-            <p className={`${font('hnl', 5)} no-padding no-margin`}>
+            <p className={`${font('hnr', 5)} no-padding no-margin`}>
               {item.description}
             </p>
           )}

--- a/common/views/components/Contact/Contact.tsx
+++ b/common/views/components/Contact/Contact.tsx
@@ -29,7 +29,7 @@ const Contact: FunctionComponent<Props> = ({
       >
         <span
           className={classNames({
-            [font('hnm', 4)]: true,
+            [font('hnb', 4)]: true,
           })}
         >
           {title}
@@ -39,7 +39,7 @@ const Contact: FunctionComponent<Props> = ({
             as="span"
             h={{ size: 's', properties: ['margin-left'] }}
             className={classNames({
-              [font('hnl', 4)]: true,
+              [font('hnr', 4)]: true,
             })}
           >
             {subtitle}
@@ -49,7 +49,7 @@ const Contact: FunctionComponent<Props> = ({
       {phone && (
         <span
           className={classNames({
-            [font('hnl', 4)]: true,
+            [font('hnr', 4)]: true,
             block: true,
           })}
         >
@@ -60,7 +60,7 @@ const Contact: FunctionComponent<Props> = ({
         <div>
           <a
             className={classNames({
-              [font('hnl', 4)]: true,
+              [font('hnr', 4)]: true,
             })}
             href={`mailto:${email}`}
           >

--- a/common/views/components/Contributor/Contributor.js
+++ b/common/views/components/Contributor/Contributor.js
@@ -46,7 +46,7 @@ const Contributor = ({ contributor, role, description }: ContributorType) => {
           {contributor.type === 'organisations' && contributor.url && (
             <h3
               className={classNames({
-                [font('hnm', 4)]: true,
+                [font('hnb', 4)]: true,
                 'no-margin': true,
               })}
             >
@@ -58,7 +58,7 @@ const Contributor = ({ contributor, role, description }: ContributorType) => {
           {!contributor.url && (
             <h3
               className={classNames({
-                [font('hnm', 4)]: true,
+                [font('hnb', 4)]: true,
                 'no-margin': true,
               })}
             >
@@ -66,7 +66,7 @@ const Contributor = ({ contributor, role, description }: ContributorType) => {
             </h3>
           )}
           {role && role.title && (
-            <div className={'font-pewter ' + font('hnm', 5)}>{role.title}</div>
+            <div className={'font-pewter ' + font('hnb', 5)}>{role.title}</div>
           )}
 
           {contributor.sameAs.length > 0 && (
@@ -85,7 +85,7 @@ const Contributor = ({ contributor, role, description }: ContributorType) => {
                 properties: ['margin-top'],
               }}
               className={classNames({
-                [font('hnl', 5)]: true,
+                [font('hnr', 5)]: true,
                 'spaced-text': true,
               })}
             >

--- a/common/views/components/CookieNotice/CookieNotice.tsx
+++ b/common/views/components/CookieNotice/CookieNotice.tsx
@@ -9,7 +9,7 @@ import Layout12 from '@weco/common/views/components/Layout12/Layout12';
 
 const CookieNoticeStyle = styled.div.attrs({
   className: classNames({
-    [font('hnm', 4)]: true,
+    [font('hnb', 4)]: true,
   }),
 })`
   position: fixed;

--- a/common/views/components/EventBookingButton/EventBookingButton.js
+++ b/common/views/components/EventBookingButton/EventBookingButton.js
@@ -63,7 +63,7 @@ const EventBookingButton = ({ event }: Props) => {
             size: 's',
             properties: ['margin-top'],
           }}
-          className={`block font-charcoal ${font('hnl', 4)}`}
+          className={`block font-charcoal ${font('hnr', 4)}`}
           href={`mailto:${team.email}?subject=${event.title}`}
         >
           {team.email}

--- a/common/views/components/EventCard/EventCard.js
+++ b/common/views/components/EventCard/EventCard.js
@@ -46,7 +46,7 @@ const EventCard = ({ event, xOfY }: Props) => {
         event.times.length > 1 && (
           <p
             className={classNames({
-              [font('hnm', 4)]: true,
+              [font('hnb', 4)]: true,
               'no-margin': true,
             })}
           >

--- a/common/views/components/EventDatesLink/EventDatesLink.tsx
+++ b/common/views/components/EventDatesLink/EventDatesLink.tsx
@@ -21,7 +21,7 @@ const EventDatesLink: FunctionComponent<Props> = ({ id }: Props) => {
       className={classNames({
         'flex-inline': true,
         'flex-v-center': true,
-        [font('hnm', 5)]: true,
+        [font('hnb', 5)]: true,
       })}
     >
       <Icon name={`arrowSmall`} extraClasses="icon--black icon--90" />

--- a/common/views/components/EventPromo/EventPromo.js
+++ b/common/views/components/EventPromo/EventPromo.js
@@ -96,7 +96,7 @@ const EventPromo = ({
           )}
 
           {!isPast && (
-            <p className={`${font('hnl', 5)} no-padding no-margin`}>
+            <p className={`${font('hnr', 5)} no-padding no-margin`}>
               <EventDateRange
                 event={event}
                 splitTime={true}
@@ -106,13 +106,13 @@ const EventPromo = ({
           )}
 
           {!isPast && dateString && (
-            <p className={`${font('hnl', 5)} no-padding no-margin`}>
+            <p className={`${font('hnr', 5)} no-padding no-margin`}>
               {dateString}
             </p>
           )}
 
           {!isPast && timeString && (
-            <p className={`${font('hnl', 5)} no-padding no-margin`}>
+            <p className={`${font('hnr', 5)} no-padding no-margin`}>
               {timeString}
             </p>
           )}
@@ -120,7 +120,7 @@ const EventPromo = ({
           {!isPast && fullyBooked && (
             <Space
               v={{ size: 'm', properties: ['margin-top'] }}
-              className={`${font('hnl', 5)} flex flex--v-center`}
+              className={`${font('hnr', 5)} flex flex--v-center`}
             >
               <Space
                 as="span"
@@ -133,7 +133,7 @@ const EventPromo = ({
             </Space>
           )}
           {!isPast && event.scheduleLength > 0 && (
-            <p className={`${font('hnm', 5)} no-padding no-margin`}>
+            <p className={`${font('hnb', 5)} no-padding no-margin`}>
               {`${event.scheduleLength} ${
                 event.scheduleLength > 1 ? 'events' : 'event'
               }`}
@@ -141,11 +141,11 @@ const EventPromo = ({
           )}
 
           {!isPast && event.times.length > 1 && (
-            <p className={`${font('hnm', 6)}`}>See all dates/times</p>
+            <p className={`${font('hnb', 6)}`}>See all dates/times</p>
           )}
 
           {isPast && !event.availableOnline && (
-            <div className={`${font('hnl', 5)} flex flex--v-center`}>
+            <div className={`${font('hnr', 5)} flex flex--v-center`}>
               <Space
                 as="span"
                 h={{ size: 'xs', properties: ['margin-right'] }}
@@ -161,8 +161,8 @@ const EventPromo = ({
         {event.series.length > 0 && (
           <Space v={{ size: 'm', properties: ['margin-top'] }}>
             {event.series.map(series => (
-              <p key={series.title} className={`${font('hnm', 6)} no-margin`}>
-                <span className={font('hnl', 6)}>Part of</span> {series.title}
+              <p key={series.title} className={`${font('hnb', 6)} no-margin`}>
+                <span className={font('hnr', 6)}>Part of</span> {series.title}
               </p>
             ))}
           </Space>

--- a/common/views/components/EventScheduleItem/EventScheduleItem.js
+++ b/common/views/components/EventScheduleItem/EventScheduleItem.js
@@ -52,7 +52,7 @@ const EventScheduleItem = ({ event, isNotLinked }: Props) => {
               return (
                 <p
                   key={`${event.title} ${startTimeString}`}
-                  className={`${font('hnm', 5)} no-margin`}
+                  className={`${font('hnb', 5)} no-margin`}
                 >
                   <time dateTime={startTimeString}>
                     {formatTime(t.range.startDateTime)}
@@ -84,7 +84,7 @@ const EventScheduleItem = ({ event, isNotLinked }: Props) => {
                 v={{ size: 's', properties: ['margin-bottom'] }}
                 as="p"
                 className={classNames({
-                  [font('hnl', 5)]: true,
+                  [font('hnr', 5)]: true,
                 })}
               >
                 {event.place.title}
@@ -93,7 +93,7 @@ const EventScheduleItem = ({ event, isNotLinked }: Props) => {
 
             <Space
               v={{ size: 'm', properties: ['margin-bottom'] }}
-              className={font('hnl', 5)}
+              className={font('hnr', 5)}
               dangerouslySetInnerHTML={{ __html: event.promoText }}
             />
 
@@ -104,7 +104,7 @@ const EventScheduleItem = ({ event, isNotLinked }: Props) => {
                   properties: ['margin-top', 'margin-bottom'],
                 }}
               >
-                <p className={`${font('hnl', 5)} no-margin`}>
+                <p className={`${font('hnr', 5)} no-margin`}>
                   <a href={`/events/${event.id}`}>
                     Full event details
                     <span className={`visually-hidden`}>
@@ -134,7 +134,7 @@ const EventScheduleItem = ({ event, isNotLinked }: Props) => {
                   }}
                   className={classNames({
                     'bg-yellow inline-block': true,
-                    [font('hnm', 5)]: true,
+                    [font('hnb', 5)]: true,
                   })}
                 >
                   {/* TODO: work out why the second method below will fail Flow without a null check */}

--- a/common/views/components/EventbriteButton/EventbriteButton.js
+++ b/common/views/components/EventbriteButton/EventbriteButton.js
@@ -37,7 +37,7 @@ const EventbriteButton = ({ event }: Props) => {
           <p
             className={classNames({
               'font-charcoal no-margin': true,
-              [font('hnl', 5)]: true,
+              [font('hnr', 5)]: true,
             })}
           >
             Tickets via Eventbrite

--- a/common/views/components/Excerpt/Excerpt.js
+++ b/common/views/components/Excerpt/Excerpt.js
@@ -36,7 +36,7 @@ const Excerpt = ({ title, content, source, audio }: Props) => (
     {audio && <audio controls src={audio} style={{ width: '100%' }} />}
     {source && (
       <p>
-        <a href={`/books/${source.id}`} className={`${font('hnl', 4)}`}>
+        <a href={`/books/${source.id}`} className={`${font('hnr', 4)}`}>
           {source.title}
         </a>
       </p>

--- a/common/views/components/ExhibitionPromo/ExhibitionPromo.js
+++ b/common/views/components/ExhibitionPromo/ExhibitionPromo.js
@@ -96,7 +96,7 @@ const ExhibitionPromo = ({
             <Space
               as="p"
               v={{ size: 'm', properties: ['margin-bottom'] }}
-              className={`${font('hnl', 5)} no-padding`}
+              className={`${font('hnr', 5)} no-padding`}
             >
               <Fragment>
                 <time dateTime={formatDate(start)}>{formatDate(start)}</time>—

--- a/common/views/components/ExpandableList/ExpandableList.tsx
+++ b/common/views/components/ExpandableList/ExpandableList.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 const ShowHideButton = styled.button.attrs({
   className: classNames({
     'plain-button no-margin no-padding': true,
-    [font('hnl', 5)]: true,
+    [font('hnr', 5)]: true,
   }),
 })`
   text-decoration: underline;
@@ -53,7 +53,7 @@ const ExpandableList: FunctionComponent<Props> = ({ listItems }: Props) => {
         ) => (
           <li
             className={classNames({
-              [font('hnl', 5)]: true,
+              [font('hnr', 5)]: true,
             })}
             key={index}
           >
@@ -65,7 +65,7 @@ const ExpandableList: FunctionComponent<Props> = ({ listItems }: Props) => {
             {remainingListItems.map((item, index) => (
               <li
                 className={classNames({
-                  [font('hnl', 5)]: true,
+                  [font('hnr', 5)]: true,
                 })}
                 key={index}
               >

--- a/common/views/components/ExplanatoryText/ExplanatoryText.js
+++ b/common/views/components/ExplanatoryText/ExplanatoryText.js
@@ -24,7 +24,7 @@ const Control = styled.button.attrs(props => ({
     'plain-button': true,
     flex: true,
     'flex--v-center': true,
-    [font('hnm', 5)]: true,
+    [font('hnb', 5)]: true,
   }),
 }))`
   cursor: pointer;

--- a/common/views/components/FacilityPromo/FacilityPromo.js
+++ b/common/views/components/FacilityPromo/FacilityPromo.js
@@ -64,13 +64,13 @@ const FacilityPromo = ({
             >
               {title}
             </h2>
-            <p className={`${font('hnl', 5)} no-margin no-padding`}>
+            <p className={`${font('hnr', 5)} no-margin no-padding`}>
               {description}
             </p>
 
             {metaText && (
               <Space v={{ size: 'm', properties: ['margin-top'] }}>
-                <div className={`${font('hnm', 6)} flex flex--v-center`}>
+                <div className={`${font('hnb', 6)} flex flex--v-center`}>
                   {metaIcon && (
                     <Space
                       as="span"

--- a/common/views/components/FeaturedCard/FeaturedCard.js
+++ b/common/views/components/FeaturedCard/FeaturedCard.js
@@ -123,7 +123,7 @@ const FeaturedCardArticleBody = ({ article }: FeaturedCardArticleBodyProps) => {
       {article.promoText && (
         <p
           className={classNames({
-            [font('hnl', 5)]: true,
+            [font('hnr', 5)]: true,
           })}
         >
           {article.promoText}
@@ -132,8 +132,8 @@ const FeaturedCardArticleBody = ({ article }: FeaturedCardArticleBodyProps) => {
       {article.series.length > 0 && (
         <Space v={{ size: 'l', properties: ['margin-top'] }}>
           {article.series.map(series => (
-            <p key={series.title} className={`${font('hnm', 6)} no-margin`}>
-              <span className={font('hnl', 6)}>Part of</span> {series.title}
+            <p key={series.title} className={`${font('hnb', 6)} no-margin`}>
+              <span className={font('hnr', 6)}>Part of</span> {series.title}
             </p>
           ))}
         </Space>
@@ -181,7 +181,7 @@ const FeaturedCardExhibitionBody = ({
         <Space
           as="p"
           v={{ size: 'm', properties: ['margin-bottom'] }}
-          className={`${font('hnl', 4)} no-margin no-padding`}
+          className={`${font('hnr', 4)} no-margin no-padding`}
         >
           <>
             <time dateTime={exhibition.start}>

--- a/common/views/components/FeaturedText/FeaturedText.js
+++ b/common/views/components/FeaturedText/FeaturedText.js
@@ -14,7 +14,7 @@ const FeaturedText = ({ html, htmlSerializer }: Props) => (
   <div
     className={classNames({
       'body-text': true,
-      [font('hnl', 4)]: true,
+      [font('hnr', 4)]: true,
     })}
   >
     <PrismicHtmlBlock html={html} htmlSerializer={htmlSerializer} />

--- a/common/views/components/FindUs/FindUs.tsx
+++ b/common/views/components/FindUs/FindUs.tsx
@@ -10,7 +10,7 @@ import { FunctionComponent } from 'react';
 
 const StyledFindUs = styled.div.attrs({
   className: classNames({
-    [font('hnl', 5)]: true,
+    [font('hnr', 5)]: true,
   }),
 })`
   &:hover,

--- a/common/views/components/Footer/Footer.js
+++ b/common/views/components/Footer/Footer.js
@@ -61,7 +61,7 @@ const Footer = ({
                 properties: ['margin-bottom'],
               }}
               as="h3"
-              className={`footer__heading relative ${font('hnl', 4)}`}
+              className={`footer__heading relative ${font('hnr', 4)}`}
             >
               <span className="hidden">Wellcome collection</span>
               <a href="#" className="footer-nav__brand absolute">
@@ -86,7 +86,7 @@ const Footer = ({
               }}
               as="h3"
               className={`footer__heading hidden is-hidden-s is-hidden-m ${font(
-                'hnl',
+                'hnr',
                 5
               )}`}
             >
@@ -101,7 +101,7 @@ const Footer = ({
           <div
             className={classNames({
               [grid({ s: 12, m: 6, l: 4, xl: 4 })]: true,
-              [font('hnl', 5)]: true,
+              [font('hnr', 5)]: true,
             })}
           >
             <Space
@@ -111,7 +111,7 @@ const Footer = ({
               }}
               as="h3"
               className={`footer__heading hidden is-hidden-s is-hidden-m ${font(
-                'hnl',
+                'hnr',
                 5
               )}`}
             >
@@ -130,13 +130,13 @@ const Footer = ({
                 </Space>
                 <div
                   className={classNames({
-                    [font('hnl', 5)]: true,
+                    [font('hnr', 5)]: true,
                     'float-l': true,
                   })}
                 >
                   <h4
                     className={classNames({
-                      [font('hnm', 5)]: true,
+                      [font('hnb', 5)]: true,
                       'no-margin': true,
                     })}
                   >{`Today's opening times`}</h4>
@@ -164,7 +164,7 @@ const Footer = ({
                 properties: ['margin-top', 'padding-bottom', 'margin-bottom'],
               }}
               className={classNames({
-                [font('hnm', 6)]: true,
+                [font('hnb', 6)]: true,
                 footer__strap: true,
               })}
             >
@@ -181,7 +181,7 @@ const Footer = ({
                 properties: ['margin-top', 'padding-bottom', 'margin-bottom'],
               }}
               className={classNames({
-                [font('hnm', 6)]: true,
+                [font('hnb', 6)]: true,
                 footer__licensing: true,
               })}
             >
@@ -206,7 +206,7 @@ const Footer = ({
             <ul
               className={`plain-list footer__hygiene-list no-margin no-padding`}
             >
-              <li className={`footer__hygiene-item ${font('hnm', 6)}`}>
+              <li className={`footer__hygiene-item ${font('hnb', 6)}`}>
                 <a
                   href="https://wellcome.ac.uk/jobs"
                   className="footer__hygiene-link"
@@ -214,7 +214,7 @@ const Footer = ({
                   Jobs
                 </a>
               </li>
-              <li className={`footer__hygiene-item ${font('hnm', 6)}`}>
+              <li className={`footer__hygiene-item ${font('hnb', 6)}`}>
                 <a
                   href="https://wellcome.ac.uk/about-us/terms-use"
                   className="footer__hygiene-link"
@@ -222,7 +222,7 @@ const Footer = ({
                   Privacy
                 </a>
               </li>
-              <li className={`footer__hygiene-item ${font('hnm', 6)}`}>
+              <li className={`footer__hygiene-item ${font('hnb', 6)}`}>
                 <a
                   href="https://wellcome.ac.uk/about-us/terms-use"
                   className="footer__hygiene-link"
@@ -230,7 +230,7 @@ const Footer = ({
                   Cookies
                 </a>
               </li>
-              <li className={`footer__hygiene-item ${font('hnm', 6)}`}>
+              <li className={`footer__hygiene-item ${font('hnb', 6)}`}>
                 <a
                   href="https://wellcomecollection.org/press"
                   className="footer__hygiene-link"
@@ -238,7 +238,7 @@ const Footer = ({
                   Media office
                 </a>
               </li>
-              <li className={`footer__hygiene-item ${font('hnm', 6)}`}>
+              <li className={`footer__hygiene-item ${font('hnb', 6)}`}>
                 <a
                   href="https://developers.wellcomecollection.org"
                   className="footer__hygiene-link"
@@ -246,7 +246,7 @@ const Footer = ({
                   Developers
                 </a>
               </li>
-              <li className={`footer__hygiene-item ${font('hnm', 6)}`}>
+              <li className={`footer__hygiene-item ${font('hnb', 6)}`}>
                 <a
                   href="#top"
                   className="footer__hygiene-link footer__hygiene-link--back-to-top"

--- a/common/views/components/FooterSocial/FooterSocial.js
+++ b/common/views/components/FooterSocial/FooterSocial.js
@@ -63,7 +63,7 @@ const FooterSocial = () => (
             properties: ['margin-bottom'],
           }}
           as="a"
-          className={`footer-social__link ${font('hnm', 6)}`}
+          className={`footer-social__link ${font('hnb', 6)}`}
           href={item.url}
         >
           <Space as="span" h={{ size: 's', properties: ['margin-right'] }}>

--- a/common/views/components/GlobalContextProvider/GlobalContextProvider.tsx
+++ b/common/views/components/GlobalContextProvider/GlobalContextProvider.tsx
@@ -49,30 +49,6 @@ const GlobalContextProvider: FunctionComponent<Props> = ({
         <GlobalAlertContext.Provider value={value.globalAlert}>
           <PopupDialogContext.Provider value={value.popupDialog}>
             <TogglesContext.Provider value={value.toggles}>
-              {value.toggles && value.toggles.helveticaRegular && (
-                <style
-                  type="text/css"
-                  dangerouslySetInnerHTML={{
-                    __html: `
-                      @font-face {
-                        font-family: 'Helvetica Neue Light Web';
-                        src: url('https://i.wellcomecollection.org/assets/fonts/helvetica-neue-roman.woff2') format('woff2'),
-                          url('https://i.wellcomecollection.org/assets/fonts/helvetica-neue-roman.woff') format('woff');
-                        font-weight: normal;
-                        font-style: normal;
-                      }
-
-                      @font-face {
-                        font-family: 'Helvetica Neue Medium Web';
-                        src: url('https://i.wellcomecollection.org/assets/fonts/helvetica-neue-bold.woff2') format('woff2'),
-                          url('https://i.wellcomecollection.org/assets/fonts/helvetica-neue-bold.woff') format('woff');
-                        font-weight: normal;
-                        font-style: normal;
-                      }
-                    `,
-                  }}
-                />
-              )}
               {children}
             </TogglesContext.Provider>
           </PopupDialogContext.Provider>

--- a/common/views/components/IIIFClickthrough/IIIFClickthrough.tsx
+++ b/common/views/components/IIIFClickthrough/IIIFClickthrough.tsx
@@ -49,9 +49,9 @@ const IIIFClickthrough: FunctionComponent<Props> = ({
         />
       )}
       {showClickthroughMessage ? (
-        <div className={font('hnl', 5)}>
+        <div className={font('hnr', 5)}>
           {authService?.label && (
-            <h2 className={font('hnm', 4)}>{authService?.label}</h2>
+            <h2 className={font('hnb', 4)}>{authService?.label}</h2>
           )}
           {authService?.description && (
             <p

--- a/common/views/components/IIIFSearchWithin/IIIFSearchWithin.tsx
+++ b/common/views/components/IIIFSearchWithin/IIIFSearchWithin.tsx
@@ -57,7 +57,7 @@ const ListItem = styled.li`
 
 const SearchResult = styled.button.attrs({
   className: classNames({
-    [font('hnl', 6)]: true,
+    [font('hnr', 6)]: true,
     'plain-button': true,
   }),
 })`
@@ -74,7 +74,7 @@ const SearchResult = styled.button.attrs({
 const HitData = styled(Space).attrs({
   as: 'span',
   className: classNames({
-    [font('hnm', 6)]: true,
+    [font('hnb', 6)]: true,
   }),
 })`
   display: block;

--- a/common/views/components/IIIFViewer/IIIFCanvasThumbnail.tsx
+++ b/common/views/components/IIIFViewer/IIIFCanvasThumbnail.tsx
@@ -73,7 +73,7 @@ const IIIFViewerThumbNumber = styled.span.attrs<ViewerThumbProps>(props => ({
     'font-white': !props.isActive,
     'font-black': props.isActive,
     'bg-yellow': props.isActive,
-    [font('hnm', 6)]: true,
+    [font('hnb', 6)]: true,
   }),
 }))<ViewerThumbProps>`
   padding: 3px 6px;

--- a/common/views/components/IIIFViewer/MainViewer.tsx
+++ b/common/views/components/IIIFViewer/MainViewer.tsx
@@ -225,11 +225,11 @@ const ItemRenderer = memo(({ style, index, data }: ItemRendererProps) => {
         </div>
       ) : isRestricted ? (
         <MessageContainer>
-          <h2 className={font('hnm', 4)}>
+          <h2 className={font('hnb', 4)}>
             {imageAuthService && imageAuthService.label}
           </h2>
           <p
-            className={font('hnl', 5)}
+            className={font('hnr', 5)}
             dangerouslySetInnerHTML={{
               __html: imageAuthService ? imageAuthService.description : '',
             }}

--- a/common/views/components/IIIFViewer/ViewerBottomBar.tsx
+++ b/common/views/components/IIIFViewer/ViewerBottomBar.tsx
@@ -14,7 +14,7 @@ import ToolbarSegmentedControl from '../ToolbarSegmentedControl/ToolbarSegmented
 export const ShameButton = styled.button.attrs(() => ({
   className: classNames({
     'btn relative flex flex--v-center': true,
-    [font('hnm', 5)]: true,
+    [font('hnb', 5)]: true,
   }),
 }))<{ isDark?: boolean }>`
   overflow: hidden;

--- a/common/views/components/IIIFViewer/ViewerSidebar.tsx
+++ b/common/views/components/IIIFViewer/ViewerSidebar.tsx
@@ -44,7 +44,7 @@ const Inner = styled(Space).attrs({
 const AccordionInner = styled(Space).attrs({
   v: { size: 's', properties: ['padding-top', 'padding-bottom'] },
   className: classNames({
-    [font('hnm', 5)]: true,
+    [font('hnb', 5)]: true,
   }),
 })`
   button {
@@ -100,7 +100,7 @@ const AccordionItem = ({
           <span>
             <h2
               className={classNames({
-                [font('hnm', 5)]: true,
+                [font('hnb', 5)]: true,
                 'no-margin': true,
               })}
             >
@@ -153,14 +153,14 @@ const ViewerSidebar: FunctionComponent<Props> = ({ mainViewerRef }: Props) => {
     <>
       <Inner
         className={classNames({
-          [font('hnm', 5)]: true,
+          [font('hnb', 5)]: true,
         })}
       >
         {currentManifestLabel && (
           <span
             data-test-id="current-manifest"
             className={classNames({
-              [font('hnl', 5)]: true,
+              [font('hnr', 5)]: true,
             })}
           >
             {currentManifestLabel}
@@ -203,7 +203,7 @@ const ViewerSidebar: FunctionComponent<Props> = ({ mainViewerRef }: Props) => {
           <WorkLink id={work.id} source="viewer_back_link">
             <a
               className={classNames({
-                [font('hnl', 5)]: true,
+                [font('hnr', 5)]: true,
                 'flex flex--v-center': true,
               })}
             >
@@ -226,7 +226,7 @@ const ViewerSidebar: FunctionComponent<Props> = ({ mainViewerRef }: Props) => {
           title={'Licence and credit'}
           testId={'license-and-credit'}
         >
-          <div className={font('hnl', 6)}>
+          <div className={font('hnr', 6)}>
             {license && license.label && (
               <p>
                 <strong>Licence:</strong>{' '}

--- a/common/views/components/IIIFViewer/ViewerStructures.tsx
+++ b/common/views/components/IIIFViewer/ViewerStructures.tsx
@@ -39,7 +39,7 @@ const ViewerStructuresPrototype: FunctionComponent<Props> = ({
     v: { size: 'xs', properties: ['padding-top', 'padding-bottom'] },
     h: { size: 'm', properties: ['padding-left', 'padding-right'] },
     className: classNames({
-      [font('hnl', 5)]: true,
+      [font('hnr', 5)]: true,
     }),
   })<{ isActive: boolean }>`
     position: relative;

--- a/common/views/components/IIIFViewer/ViewerTopBar.tsx
+++ b/common/views/components/IIIFViewer/ViewerTopBar.tsx
@@ -15,7 +15,7 @@ import AlignFont from '../styled/AlignFont';
 export const ShameButton = styled.button.attrs(() => ({
   className: classNames({
     'btn relative flex flex--v-center': true,
-    [font('hnm', 5)]: true,
+    [font('hnb', 5)]: true,
   }),
 }))<{ isDark?: boolean }>`
   overflow: hidden;
@@ -134,7 +134,7 @@ const LeftZone = styled.div`
 
 const MiddleZone = styled.div.attrs({
   className: classNames({
-    [font('hnm', 5)]: true,
+    [font('hnb', 5)]: true,
   }),
 })`
   display: flex;

--- a/common/views/components/ImageGallery/ImageGallery.js
+++ b/common/views/components/ImageGallery/ImageGallery.js
@@ -285,7 +285,7 @@ class ImageGallery extends Component<Props, State> {
                                 properties: ['margin-bottom'],
                               }}
                               className={classNames({
-                                [font('hnm', 5)]: true,
+                                [font('hnb', 5)]: true,
                               })}
                             >
                               {i + 1} of {items.length}

--- a/common/views/components/InfoBanner/InfoBanner.tsx
+++ b/common/views/components/InfoBanner/InfoBanner.tsx
@@ -62,7 +62,7 @@ const InfoBanner: FunctionComponent<Props> = ({
       <div className="container">
         <div className="grid">
           <div className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>
-            <div className={`flex flex--h-space-between ${font('hnl', 5)}`}>
+            <div className={`flex flex--h-space-between ${font('hnr', 5)}`}>
               <div>
                 <span className="flex">
                   <Space

--- a/common/views/components/InfoBox/InfoBox.js
+++ b/common/views/components/InfoBox/InfoBox.js
@@ -34,7 +34,7 @@ const InfoBox = ({ title, items, children }: Props) => {
       >
         {items.map(({ title, description, icon }, i) => (
           <Fragment key={i}>
-            <div className={font('hnm', 4)}>
+            <div className={font('hnb', 4)}>
               {icon && (title || description) && (
                 <Space
                   h={{ size: 's', properties: ['margin-right'] }}
@@ -44,7 +44,7 @@ const InfoBox = ({ title, items, children }: Props) => {
                 </Space>
               )}
               {title && (
-                <h3 className={classNames([font('hnm', 5)])}>{title}</h3>
+                <h3 className={classNames([font('hnb', 5)])}>{title}</h3>
               )}
               {description && (
                 <Space
@@ -53,7 +53,7 @@ const InfoBox = ({ title, items, children }: Props) => {
                     properties: ['margin-bottom'],
                   }}
                   className={classNames({
-                    [font('hnl', 5)]: true,
+                    [font('hnr', 5)]: true,
                   })}
                 >
                   <PrismicHtmlBlock html={description} />

--- a/common/views/components/Label/Label.tsx
+++ b/common/views/components/Label/Label.tsx
@@ -13,7 +13,7 @@ type LabelContainerProps = {
 const LabelContainer = styled(Space).attrs({
   className: classNames({
     'nowrap line-height-1': true,
-    [font('hnm', 6)]: true,
+    [font('hnb', 6)]: true,
   }),
 })<LabelContainerProps>`
   color: ${props => props.theme.color(props.fontColor)};

--- a/common/views/components/LayoutPaginatedResults/LayoutPaginatedResults.js
+++ b/common/views/components/LayoutPaginatedResults/LayoutPaginatedResults.js
@@ -99,7 +99,7 @@ const LayoutPaginatedResults = ({
         <div className="flex-inline flex--v-center">
           <span
             className={classNames({
-              [font('hnm', 4)]: true,
+              [font('hnb', 4)]: true,
             })}
           >
             Free admission

--- a/common/views/components/LinkLabels/LinkLabels.js
+++ b/common/views/components/LinkLabels/LinkLabels.js
@@ -22,7 +22,7 @@ const LinkLabels = ({ items, heading, icon }: Props) => (
       flex: true,
       'flex--wrap': true,
       'no-margin': true,
-      [font('hnm', 5)]: true,
+      [font('hnb', 5)]: true,
     })}
   >
     {heading && (
@@ -59,7 +59,7 @@ const LinkLabels = ({ items, heading, icon }: Props) => (
             }}
             as="a"
             className={classNames({
-              [`${font('hnl', 5)}`]: true,
+              [`${font('hnr', 5)}`]: true,
               'border-left-width-1 border-color-marble': i !== 0,
             })}
             href={url}
@@ -77,7 +77,7 @@ const LinkLabels = ({ items, heading, icon }: Props) => (
               ].filter(Boolean),
             }}
             className={classNames({
-              [`${font('hnl', 5)}`]: true,
+              [`${font('hnr', 5)}`]: true,
               'border-left-width-1 border-color-marble': i !== 0,
             })}
           >

--- a/common/views/components/MediaObjectBase/MediaObjectBase.tsx
+++ b/common/views/components/MediaObjectBase/MediaObjectBase.tsx
@@ -160,11 +160,11 @@ const MediaObjectBase: FunctionComponent<Props> = ({
           <div
             className={classNames({
               'spaced-text': true,
-              [font('hnl', 5)]: !descriptionIsString,
+              [font('hnr', 5)]: !descriptionIsString,
             })}
           >
             {descriptionIsString ? (
-              <p className={font('hnl', 5)}>{description}</p>
+              <p className={font('hnr', 5)}>{description}</p>
             ) : (
               description
             )}

--- a/common/views/components/Message/Message.js
+++ b/common/views/components/Message/Message.js
@@ -17,7 +17,7 @@ const Message = ({ text }: Props) => (
       'border-left-width-5': true,
       'border-color-yellow': true,
       'inline-block': true,
-      [font('hnm', 5)]: true,
+      [font('hnb', 5)]: true,
     })}
   >
     {text}

--- a/common/views/components/MessageBar/MessageBar.js
+++ b/common/views/components/MessageBar/MessageBar.js
@@ -14,7 +14,7 @@ const ColouredTag: ComponentType<SpaceComponentProps> = styled(Space).attrs(
       'inline-block': true,
       'bg-charcoal': true,
       'font-white': true,
-      [font('hnm', 6)]: true,
+      [font('hnb', 6)]: true,
     }),
   })
 )`
@@ -33,7 +33,7 @@ const MessageBar = ({ tagText, children }: Props) => (
       properties: ['padding-top', 'padding-bottom'],
     }}
     className={classNames({
-      [font('hnl', 6)]: true,
+      [font('hnr', 6)]: true,
     })}
   >
     {tagText && (

--- a/common/views/components/NewsletterPromo/NewsletterPromo.js
+++ b/common/views/components/NewsletterPromo/NewsletterPromo.js
@@ -196,7 +196,7 @@ const NewsletterPromo = () => {
                   {!isSuccess && (
                     <p
                       className={classNames({
-                        [font('hnl', 5)]: true,
+                        [font('hnr', 5)]: true,
                         'no-margin': true,
                       })}
                     >
@@ -206,7 +206,7 @@ const NewsletterPromo = () => {
                   {isSuccess && (
                     <div
                       className={classNames({
-                        [font('hnl', 5)]: true,
+                        [font('hnr', 5)]: true,
                         'spaced-text': true,
                       })}
                     >
@@ -271,7 +271,7 @@ const NewsletterPromo = () => {
               {!isSuccess && (
                 <p
                   className={classNames({
-                    [font('hnl', 6)]: true,
+                    [font('hnr', 6)]: true,
                     'no-margin': true,
                   })}
                 >
@@ -283,7 +283,7 @@ const NewsletterPromo = () => {
               v={{ size: 'l', properties: ['margin-top'] }}
               style={{ flexBasis: '100%' }}
             >
-              <p className={font('hnl', 6)} style={{ maxWidth: '800px' }}>
+              <p className={font('hnr', 6)} style={{ maxWidth: '800px' }}>
                 We use a third party provider,{' '}
                 <a href="https://dotdigital.com/terms/privacy-policy/">
                   dotdigital

--- a/common/views/components/NewsletterSignup/NewsletterSignup.js
+++ b/common/views/components/NewsletterSignup/NewsletterSignup.js
@@ -84,7 +84,7 @@ const NewsletterSignup = ({ isSuccess, isError, isConfirmed }: Props) => {
         <div className="body-text">
           <p
             className={classNames({
-              [font('hnm', 3)]: true,
+              [font('hnb', 3)]: true,
             })}
           >
             Thank you for confirming your email address
@@ -109,7 +109,7 @@ const NewsletterSignup = ({ isSuccess, isError, isConfirmed }: Props) => {
         <div className="body-text">
           <p
             className={classNames({
-              [font('hnm', 3)]: true,
+              [font('hnb', 3)]: true,
             })}
           >
             You’re signed up
@@ -126,7 +126,7 @@ const NewsletterSignup = ({ isSuccess, isError, isConfirmed }: Props) => {
         <div className="body-text">
           <p
             className={classNames({
-              [font('hnm', 3)]: true,
+              [font('hnb', 3)]: true,
             })}
           >
             Sorry, there’s been a problem
@@ -139,7 +139,7 @@ const NewsletterSignup = ({ isSuccess, isError, isConfirmed }: Props) => {
         <div className="body-text">
           <p
             className={classNames({
-              [font('hnm', 3)]: true,
+              [font('hnb', 3)]: true,
             })}
           >
             Want to hear more from us?
@@ -200,7 +200,7 @@ const NewsletterSignup = ({ isSuccess, isError, isConfirmed }: Props) => {
             <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
               <legend
                 className={classNames({
-                  [font('hnm', 4)]: true,
+                  [font('hnb', 4)]: true,
                 })}
               >
                 You might also be interested in receiving updates on:
@@ -250,7 +250,7 @@ const NewsletterSignup = ({ isSuccess, isError, isConfirmed }: Props) => {
             </Space>
           )}
 
-          <p className={`${font('hnl', 6)}`}>
+          <p className={`${font('hnr', 6)}`}>
             We use a third-party provider,{' '}
             <a href="https://dotdigital.com/terms/privacy-policy/">
               dotdigital

--- a/common/views/components/OnThisPageAnchors/OnThisPageAnchors.tsx
+++ b/common/views/components/OnThisPageAnchors/OnThisPageAnchors.tsx
@@ -6,7 +6,7 @@ import { FunctionComponent, ReactElement } from 'react';
 
 const Anchor = styled.a.attrs(() => ({
   className: classNames({
-    [font('hnm', 5)]: true,
+    [font('hnb', 5)]: true,
   }),
 }))`
   color: ${props => props.theme.color('green')};

--- a/common/views/components/PageHeader/PageHeader.js
+++ b/common/views/components/PageHeader/PageHeader.js
@@ -227,7 +227,7 @@ const PageHeader = ({
                 ) : (
                   <span
                     className={classNames({
-                      [font('hnl', 5)]: true,
+                      [font('hnr', 5)]: true,
                       flex: true,
                     })}
                   >
@@ -252,7 +252,7 @@ const PageHeader = ({
               <Space
                 v={{ size: 'm', properties: ['margin-bottom'] }}
                 className={classNames({
-                  [font('hnl', 4)]: true,
+                  [font('hnr', 4)]: true,
                 })}
               >
                 {ContentTypeInfo}
@@ -299,7 +299,7 @@ const PageHeader = ({
               properties: ['margin-top'],
             }}
             className={classNames({
-              [font('hnm', 4)]: true,
+              [font('hnb', 4)]: true,
             })}
           >
             {ContentTypeInfo}

--- a/common/views/components/Paginator/Paginator.tsx
+++ b/common/views/components/Paginator/Paginator.tsx
@@ -101,7 +101,7 @@ const Paginator: FunctionComponent<Props> = ({
         className={classNames({
           flex: true,
           'flex--v-center': true,
-          [font('hnm', 3)]: true,
+          [font('hnb', 3)]: true,
         })}
       >
         <TotalResultsWrapper hideMobileTotalResults={hideMobileTotalResults}>
@@ -116,7 +116,7 @@ const Paginator: FunctionComponent<Props> = ({
           'flex-inline': true,
           'flex--v-center': true,
           'font-pewter': true,
-          [font('hnl', 5)]: true,
+          [font('hnr', 5)]: true,
           'flex-end': true,
         })}
         v={{

--- a/common/views/components/PopupDialog/PopupDialog.tsx
+++ b/common/views/components/PopupDialog/PopupDialog.tsx
@@ -38,7 +38,7 @@ const PopupDialogOpen = styled(Space).attrs<PopupDialogOpenProps>(props => ({
     overrides: { small: 5, medium: 5, large: 5 },
   },
   className: classNames({
-    [font('hnm', 5)]: true,
+    [font('hnb', 5)]: true,
     'plain-button line-height-1 flex-inline flex--v-center bg-hover-purple font-purple font-hover-white': true,
   }),
 }))<PopupDialogOpenProps>`
@@ -136,7 +136,7 @@ const PopupDialogCTA = styled(Space).attrs({
     overrides: { small: 5, medium: 5, large: 5 },
   },
   className: classNames({
-    [font('hnm', 5, { small: 3, medium: 3 })]: true,
+    [font('hnb', 5, { small: 3, medium: 3 })]: true,
     'bg-purple font-white font-hover-purple bg-hover-white rounded-corners inline-block': true,
   }),
 })`
@@ -338,7 +338,7 @@ const PopupDialog: FunctionComponent<Props> = ({
           </h2>
           <div
             className={classNames({
-              [font('hnl', 5, { medium: 2, large: 2 })]: true,
+              [font('hnr', 5, { medium: 2, large: 2 })]: true,
             })}
           >
             <PrismicHtmlBlock html={text} />

--- a/common/views/components/Quote/Quote.js
+++ b/common/views/components/Quote/Quote.js
@@ -15,7 +15,7 @@ const Quote = ({ text, citation, isPullOrReview }: Props) => (
   <blockquote
     className={classNames({
       'quote--pull': isPullOrReview,
-      [font('hnl', 2)]: isPullOrReview,
+      [font('hnr', 2)]: isPullOrReview,
       'quote no-margin': true,
     })}
   >
@@ -28,7 +28,7 @@ const Quote = ({ text, citation, isPullOrReview }: Props) => (
       <footer className="quote__footer flex">
         <cite
           className={`quote__cite flex flex--v-end font-pewter ${font(
-            'hnl',
+            'hnr',
             5
           )}`}
         >

--- a/common/views/components/ResetActiveFilters/ResetActiveFilters.tsx
+++ b/common/views/components/ResetActiveFilters/ResetActiveFilters.tsx
@@ -102,7 +102,7 @@ export const ResetActiveFilters: FunctionComponent<ResetActiveFilters> = ({
       h={{ size: 'm', properties: ['padding-left', 'padding-right'] }}
       className="tokens bg-white"
     >
-      <div className={classNames({ [font('hnm', 5)]: true })}>
+      <div className={classNames({ [font('hnb', 5)]: true })}>
         <div>
           <h2 className="inline">
             <Space

--- a/common/views/components/SearchFiltersDesktop/SearchFiltersDesktop.tsx
+++ b/common/views/components/SearchFiltersDesktop/SearchFiltersDesktop.tsx
@@ -37,7 +37,7 @@ const CheckboxFilter = ({ f, changeHandler }: CheckboxFilterProps) => {
       <ul
         className={classNames({
           'no-margin no-padding plain-list': true,
-          [font('hnl', 5)]: true,
+          [font('hnr', 5)]: true,
         })}
       >
         {f.options.map(({ id, label, value, count, selected }) => {
@@ -72,7 +72,7 @@ const DateRangeFilter = ({ f, changeHandler }: DateRangeFilterProps) => {
   return (
     <Space
       className={classNames({
-        [font('hnl', 5)]: true,
+        [font('hnr', 5)]: true,
       })}
     >
       <DropdownButton label={f.label} isInline={true} id={f.id}>
@@ -182,7 +182,7 @@ const SearchFiltersDesktop: FunctionComponent<SearchFiltersSharedProps> = ({
               <Space
                 h={{ size: 's', properties: ['margin-left'] }}
                 className={classNames({
-                  [font('hnm', 5)]: true,
+                  [font('hnb', 5)]: true,
                 })}
               >
                 <AlignFont>Filter by</AlignFont>
@@ -217,7 +217,7 @@ const SearchFiltersDesktop: FunctionComponent<SearchFiltersSharedProps> = ({
             {modalFilters.length > 0 && (
               <Space
                 className={classNames({
-                  [font('hnl', 5)]: true,
+                  [font('hnr', 5)]: true,
                 })}
                 h={{ size: 's', properties: ['margin-left'] }}
               >
@@ -254,7 +254,7 @@ const SearchFiltersDesktop: FunctionComponent<SearchFiltersSharedProps> = ({
               <Space
                 h={{ size: 's', properties: ['margin-left'] }}
                 className={classNames({
-                  [font('hnm', 5)]: true,
+                  [font('hnb', 5)]: true,
                 })}
               >
                 <AlignFont>Show items available</AlignFont>
@@ -263,7 +263,7 @@ const SearchFiltersDesktop: FunctionComponent<SearchFiltersSharedProps> = ({
                 <ul
                   className={classNames({
                     'no-margin no-padding plain-list flex': true,
-                    [font('hnl', 5)]: true,
+                    [font('hnr', 5)]: true,
                   })}
                 >
                   {availabilitiesFilter.options

--- a/common/views/components/SearchTabs/SearchTabs.tsx
+++ b/common/views/components/SearchTabs/SearchTabs.tsx
@@ -44,7 +44,7 @@ const Tab = styled(Space).attrs({
   h: { size: 'm', properties: ['padding-left', 'padding-right'] },
   className: classNames({
     'flex-inline': true,
-    [font('hnm', 5)]: true,
+    [font('hnb', 5)]: true,
   }),
 })<TabProps>`
   background: ${props => props.theme.color('white')};
@@ -158,7 +158,7 @@ const SearchTabs: FunctionComponent<Props> = ({
             h={{ size: 'm', properties: ['padding-left', 'padding-right'] }}
             className={classNames({
               'visually-hidden': !shouldShowDescription,
-              [font('hnl', 5)]: true,
+              [font('hnr', 5)]: true,
             })}
             id="library-catalogue-form-description"
           >
@@ -248,7 +248,7 @@ const SearchTabs: FunctionComponent<Props> = ({
             h={{ size: 'm', properties: ['padding-left', 'padding-right'] }}
             className={classNames({
               'visually-hidden': !shouldShowDescription,
-              [font('hnl', 5)]: true,
+              [font('hnr', 5)]: true,
             })}
             id="images-form-description"
           >

--- a/common/views/components/SearchToolbar/SearchToolbar.js
+++ b/common/views/components/SearchToolbar/SearchToolbar.js
@@ -15,7 +15,7 @@ import TogglesContext from '../TogglesContext/TogglesContext';
 const Form = styled(Space).attrs({
   className: classNames({
     flex: true,
-    [font('hnl', 5)]: true,
+    [font('hnr', 5)]: true,
   }),
   h: {
     size: 's',
@@ -33,7 +33,7 @@ const Heading = styled(Space).attrs({
   as: 'h2',
   className: classNames({
     'no-margin': true,
-    [font('hnm', 4)]: true,
+    [font('hnb', 4)]: true,
   }),
   h: {
     size: 's',

--- a/common/views/components/SeasonsHeader/SeasonsHeader.tsx
+++ b/common/views/components/SeasonsHeader/SeasonsHeader.tsx
@@ -60,7 +60,7 @@ const SeasonsHeader: FunctionComponent<Props> = ({
                       </h1>
                     </Space>
                     {start && end && (
-                      <div className={font('hnl', 5)}>
+                      <div className={font('hnr', 5)}>
                         <DateRange
                           start={new Date(start)}
                           end={new Date(end)}

--- a/common/views/components/SelectContainer/SelectContainer.js
+++ b/common/views/components/SelectContainer/SelectContainer.js
@@ -11,7 +11,7 @@ import { classNames, font } from '../../../utils/classnames';
 
 const StyledSelect = styled.div.attrs(props => ({
   className: classNames({
-    [font('hnl', 5)]: true,
+    [font('hnr', 5)]: true,
   }),
 }))`
   position: relative;
@@ -68,7 +68,7 @@ const SelectContainer = ({ label, children }: Props) => {
           as="span"
           h={{ size: 'm', properties: ['margin-right'] }}
           className={classNames({
-            [font('hnm', 5)]: true,
+            [font('hnb', 5)]: true,
           })}
         >
           {label}

--- a/common/views/components/SimpleCardGrid/SimpleCardGrid.js
+++ b/common/views/components/SimpleCardGrid/SimpleCardGrid.js
@@ -40,7 +40,7 @@ const CardGridFeaturedCard = ({ item }: CardGridFeaturedCardProps) => (
     >
       {item.title && <h2 className="font-wb font-size-2">{item.title}</h2>}
       {item.description && (
-        <p className="font-hnl font-size-5">{item.description}</p>
+        <p className="font-hnr font-size-5">{item.description}</p>
       )}
     </FeaturedCard>
   </Layout12>

--- a/common/views/components/StatusIndicator/StatusIndicator.js
+++ b/common/views/components/StatusIndicator/StatusIndicator.js
@@ -17,7 +17,7 @@ const StatusIndicator = ({ start, end, statusOverride }: Props) => {
     ? { color: 'marble', text: statusOverride }
     : formatDateRangeWithMessage({ start, end });
   return (
-    <span className={`flex flex--v-center ${font('hnl', 5)}`}>
+    <span className={`flex flex--v-center ${font('hnr', 5)}`}>
       <Space
         as="span"
         h={{ size: 'xs', properties: ['margin-right'] }}

--- a/common/views/components/StoryPromo/StoryPromo.tsx
+++ b/common/views/components/StoryPromo/StoryPromo.tsx
@@ -86,7 +86,7 @@ const StoryPromo: FunctionComponent<Props> = ({
             <p
               className={classNames({
                 'inline-block no-margin': true,
-                [font('hnl', 5)]: true,
+                [font('hnr', 5)]: true,
               })}
             >
               {item.promoText}
@@ -97,8 +97,8 @@ const StoryPromo: FunctionComponent<Props> = ({
         {item.series.length > 0 && (
           <Space v={{ size: 'l', properties: ['margin-top'] }}>
             {item.series.map(series => (
-              <p key={series.title} className={`${font('hnm', 6)} no-margin`}>
-                <span className={font('hnl', 6)}>Part of</span> {series.title}
+              <p key={series.title} className={`${font('hnb', 6)} no-margin`}>
+                <span className={font('hnr', 6)}>Part of</span> {series.title}
               </p>
             ))}
           </Space>

--- a/common/views/components/TabNav/TabNav.js
+++ b/common/views/components/TabNav/TabNav.js
@@ -95,7 +95,7 @@ const TabNav = ({ items }: Props) => {
   return (
     <div
       className={classNames({
-        [font('hnm', 4)]: true,
+        [font('hnb', 4)]: true,
       })}
     >
       <ul

--- a/common/views/components/Table/Table.tsx
+++ b/common/views/components/Table/Table.tsx
@@ -91,7 +91,7 @@ const TableWrap = styled.div`
 
 const TableTable = styled.table.attrs({
   className: classNames({
-    [font('hnl', 5)]: true,
+    [font('hnr', 5)]: true,
   }),
 })`
   width: 100%;

--- a/common/views/components/Tags/Tags.tsx
+++ b/common/views/components/Tags/Tags.tsx
@@ -56,7 +56,7 @@ const Tags: FunctionComponent<Props> = ({
                       key={part}
                       className={classNames({
                         [font(
-                          i === 0 && isFirstPartBold ? 'hnm' : 'hnl',
+                          i === 0 && isFirstPartBold ? 'hnb' : 'hnr',
                           5
                         )]: true,
                         'inline-block': true,
@@ -74,7 +74,7 @@ const Tags: FunctionComponent<Props> = ({
                                 : undefined
                             }
                             className={classNames({
-                              [font('hnl', 5)]: true,
+                              [font('hnr', 5)]: true,
                               'inline-block': true,
                             })}
                           >

--- a/common/views/components/TextInput/TextInput.tsx
+++ b/common/views/components/TextInput/TextInput.tsx
@@ -128,7 +128,7 @@ const TextInputCheckmark = styled.span.attrs({
 const TextInputErrorMessage = styled.span.attrs({
   'data-test-id': 'TextInputErrorMessage',
   className: classNames({
-    'font-hnm': true,
+    'font-hnb': true,
   }),
 })`
   font-size: 14px;

--- a/common/views/components/TitledTextList/TitledTextList.tsx
+++ b/common/views/components/TitledTextList/TitledTextList.tsx
@@ -9,7 +9,7 @@ import { LabelField } from '../../../model/label-field';
 
 const HeadingLink = styled.a.attrs({
   className: classNames({
-    [font('hnm', 4)]: true,
+    [font('hnb', 4)]: true,
   }),
 })`
   cursor: pointer;

--- a/common/views/components/ToolbarSegmentedControl/ToolbarSegmentedControl.tsx
+++ b/common/views/components/ToolbarSegmentedControl/ToolbarSegmentedControl.tsx
@@ -41,7 +41,7 @@ const ButtonInner = styled(Space).attrs({
   },
   className: classNames({
     'flex flex--v-center flex--h-center': true,
-    [font('hnm', 5)]: true,
+    [font('hnb', 5)]: true,
   }),
 })<{ isActive: boolean }>`
   color: ${props => props.theme.color('white')};

--- a/common/views/components/VenueHours/VenueHours.js
+++ b/common/views/components/VenueHours/VenueHours.js
@@ -137,7 +137,7 @@ const VenueHours = ({ venue, weight }: Props) => {
         <ul
           className={classNames({
             'plain-list no-padding no-margin': true,
-            [font('hnl', 5)]: true,
+            [font('hnr', 5)]: true,
           })}
         >
           {venue.openingHours.regular.map(({ dayOfWeek, opens, closes }) => (
@@ -170,7 +170,7 @@ const VenueHours = ({ venue, weight }: Props) => {
             >
               <h3
                 className={classNames({
-                  [font('hnm', 5)]: true,
+                  [font('hnb', 5)]: true,
                 })}
               >
                 <div
@@ -190,7 +190,7 @@ const VenueHours = ({ venue, weight }: Props) => {
               <ul
                 className={classNames({
                   'plain-list no-padding no-margin': true,
-                  [font('hnl', 5)]: true,
+                  [font('hnr', 5)]: true,
                 })}
               >
                 {upcomingExceptionalPeriod.map(p => (

--- a/common/views/components/ViewerTopBar/ViewerTopBar.tsx
+++ b/common/views/components/ViewerTopBar/ViewerTopBar.tsx
@@ -20,7 +20,7 @@ import { FunctionComponent, RefObject } from 'react';
 export const ShameButton = styled.button.attrs(() => ({
   className: classNames({
     'btn relative flex flex--v-center': true,
-    [font('hnm', 5)]: true,
+    [font('hnb', 5)]: true,
   }),
 }))<{ isDark?: boolean }>`
   overflow: hidden;
@@ -105,7 +105,7 @@ const ViewAllContainer = styled.div.attrs(() => ({
 const TitleContainer = styled.div.attrs(() => ({
   className: classNames({
     'flex flex--v-center': true,
-    [font('hnl', 5)]: true,
+    [font('hnr', 5)]: true,
   }),
 }))<{ isEnhanced?: boolean }>`
   justify-content: space-between;
@@ -183,7 +183,7 @@ const ViewerTopBar: FunctionComponent<Props> = ({
           <WorkLink id={workId} source="viewer_back_link">
             <a
               className={classNames({
-                [font('hnm', 5)]: true,
+                [font('hnb', 5)]: true,
                 flex: true,
                 'flex-v-center': true,
                 'plain-link': true,

--- a/common/views/components/WatchLabel/WatchLabel.tsx
+++ b/common/views/components/WatchLabel/WatchLabel.tsx
@@ -21,7 +21,7 @@ const WatchIconWrapper = styled.div`
 const WatchText = styled(Space).attrs({
   v: { size: 's', properties: ['margin-left'] },
   className: classNames({
-    [font('hnl', 6)]: true,
+    [font('hnr', 6)]: true,
   }),
 })`
   color: ${props => props.theme.color('pewter')};
@@ -34,7 +34,7 @@ type Props = {
 const WatchLabel: FunctionComponent<Props> = ({ text }: Props) => (
   <div
     className={classNames({
-      [font('hnl', 4)]: true,
+      [font('hnr', 4)]: true,
       'flex flex--v-center': true,
     })}
   >

--- a/common/views/components/WorkHeader/WorkHeader.tsx
+++ b/common/views/components/WorkHeader/WorkHeader.tsx
@@ -48,7 +48,7 @@ const WorkHeader: FunctionComponent<Props> = ({
             id="work-info"
             className={classNames({
               'no-margin': true,
-              [font('hnm', 2)]: true,
+              [font('hnb', 2)]: true,
               'inline-block': true,
             })}
             // We only send a lang if it's unambiguous -- better to send
@@ -112,7 +112,7 @@ const WorkHeader: FunctionComponent<Props> = ({
             <Space v={{ size: 'm', properties: ['margin-top'] }}>
               <p
                 className={classNames({
-                  [font('hnm', 5)]: true,
+                  [font('hnb', 5)]: true,
                   'no-margin': true,
                 })}
               >

--- a/common/views/components/styled/AlignFont.tsx
+++ b/common/views/components/styled/AlignFont.tsx
@@ -1,30 +1,20 @@
-import { useContext, FunctionComponent, ReactNode } from 'react';
+import { FunctionComponent, ReactNode } from 'react';
 import styled from 'styled-components';
-import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
 
 type Props = {
   className?: string;
   children: ReactNode;
 };
 
-const Align = styled.span<{ isOn: boolean }>`
+const Align = styled.span`
   .fonts-loaded & {
-    ${props =>
-      props.isOn &&
-      `
-      transform: translateY(-${props.theme.fontVerticalOffset});
-      display: inline-block;
-    `}
+    transform: translateY(-${props => props.theme.fontVerticalOffset});
+    display: inline-block;
   }
 `;
 
 const AlignFont: FunctionComponent<Props> = ({ children, className }) => {
-  const { helveticaRegular } = useContext(TogglesContext);
-  return (
-    <Align isOn={helveticaRegular} className={className}>
-      {children}
-    </Align>
-  );
+  return <Align className={className}>{children}</Align>;
 };
 
 export default AlignFont;

--- a/common/views/components/styled/ProtoTag.js
+++ b/common/views/components/styled/ProtoTag.js
@@ -3,7 +3,7 @@ import { font, classNames } from '../../../utils/classnames';
 
 const ProtoTag = styled.div.attrs(props => ({
   className: classNames({
-    [font(props.isPrimary ? 'hnm' : 'hnl', props.small ? 6 : 5)]: true,
+    [font(props.isPrimary ? 'hnb' : 'hnr', props.small ? 6 : 5)]: true,
   }),
 }))`
   cursor: pointer;

--- a/common/views/pages/_app-deprecated.js
+++ b/common/views/pages/_app-deprecated.js
@@ -279,11 +279,11 @@ export default class WecoApp extends App {
     const FontFaceObserver = require('fontfaceobserver');
 
     const WB = new FontFaceObserver('Wellcome Bold Web', { weight: 'bold' });
-    const HNL = new FontFaceObserver('Helvetica Neue Light Web');
-    const HNM = new FontFaceObserver('Helvetica Neue Medium Web');
+    const HNR = new FontFaceObserver('Helvetica Neue Roman Web');
+    const HNB = new FontFaceObserver('Helvetica Neue Bold Web');
     const LR = new FontFaceObserver('Lettera Regular Web');
 
-    Promise.all([WB.load(), HNL.load(), HNM.load(), LR.load()])
+    Promise.all([WB.load(), HNR.load(), HNB.load(), LR.load()])
       .then(() => {
         if (document.documentElement) {
           document.documentElement.classList.add('fonts-loaded');
@@ -479,34 +479,6 @@ export default class WecoApp extends App {
                       <GlobalStyle toggles={toggles} />
                       <OutboundLinkTracker>
                         <Fragment>
-                          <TogglesContext.Consumer>
-                            {({ helveticaRegular }) =>
-                              helveticaRegular && (
-                                <style
-                                  type="text/css"
-                                  dangerouslySetInnerHTML={{
-                                    __html: `
-                                    @font-face {
-                                      font-family: 'Helvetica Neue Light Web';
-                                      src: url('https://i.wellcomecollection.org/assets/fonts/helvetica-neue-roman.woff2') format('woff2'),
-                                        url('https://i.wellcomecollection.org/assets/fonts/helvetica-neue-roman.woff') format('woff');
-                                      font-weight: normal;
-                                      font-style: normal;
-                                    }
-
-                                    @font-face {
-                                      font-family: 'Helvetica Neue Medium Web';
-                                      src: url('https://i.wellcomecollection.org/assets/fonts/helvetica-neue-bold.woff2') format('woff2'),
-                                        url('https://i.wellcomecollection.org/assets/fonts/helvetica-neue-bold.woff') format('woff');
-                                      font-weight: normal;
-                                      font-style: normal;
-                                    }
-                                  `,
-                                  }}
-                                />
-                              )
-                            }
-                          </TogglesContext.Consumer>
                           <LoadingIndicator />
                           {!pageProps.statusCode && (
                             <Component {...pageProps} />

--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -220,11 +220,11 @@ const WecoApp: FunctionComponent<AppProps> = ({
     /* eslint-enable @typescript-eslint/no-var-requires */
 
     const WB = new FontFaceObserver('Wellcome Bold Web', { weight: 'bold' });
-    const HNL = new FontFaceObserver('Helvetica Neue Light Web');
-    const HNM = new FontFaceObserver('Helvetica Neue Medium Web');
+    const HNR = new FontFaceObserver('Helvetica Neue Light Web');
+    const HNB = new FontFaceObserver('Helvetica Neue Medium Web');
     const LR = new FontFaceObserver('Lettera Regular Web');
 
-    Promise.all([WB.load(), HNL.load(), HNM.load(), LR.load()])
+    Promise.all([WB.load(), HNR.load(), HNB.load(), LR.load()])
       .then(() => {
         if (document.documentElement) {
           document.documentElement.classList.add('fonts-loaded');

--- a/common/views/themes/base/fonts.ts
+++ b/common/views/themes/base/fonts.ts
@@ -17,6 +17,7 @@ export const fonts = `
   font-family: 'Helvetica Neue Bold Web';
   src: url('https://i.wellcomecollection.org/assets/fonts/helvetica-neue-bold.woff2') format('woff2'),
     url('https://i.wellcomecollection.org/assets/fonts/helvetica-neue-bold.woff') format('woff');
+  font-weight: bold;
 }
 
 

--- a/common/views/themes/base/fonts.ts
+++ b/common/views/themes/base/fonts.ts
@@ -8,24 +8,17 @@ export const fonts = `
 }
 
 @font-face {
-  font-family: 'Helvetica Neue Light Web';
-  src: local('Helvetica Neue Light'),
-    local('HelveticaNeue-Light'),
-    url('https://i.wellcomecollection.org/assets/fonts/3f289cf9-c08b-4ffc-97cc-d1230c569129.woff2') format('woff2'),
-    url('https://i.wellcomecollection.org/assets/fonts/ee81d85a-174d-4def-9af8-9d1057a2737f.woff') format('woff');
-  font-weight: normal;
-  font-style: normal;
+  font-family: 'Helvetica Neue Roman Web';
+  src: url('https://i.wellcomecollection.org/assets/fonts/helvetica-neue-roman.woff2') format('woff2'),
+    url('https://i.wellcomecollection.org/assets/fonts/helvetica-neue-roman.woff') format('woff');
 }
 
 @font-face {
-  font-family: 'Helvetica Neue Medium Web';
-  src: local('Helvetica Neue Medium'),
-    local('HelveticaNeue-Medium'),
-    url('https://i.wellcomecollection.org/assets/fonts/5393f1cf-e069-4466-bb37-f26f99fb4cf7.woff2') format('woff2'),
-    url('https://i.wellcomecollection.org/assets/fonts/26b8484e-52e3-44ac-b958-865809934ebb.woff') format('woff');
-  font-weight: normal;
-  font-style: normal;
+  font-family: 'Helvetica Neue Bold Web';
+  src: url('https://i.wellcomecollection.org/assets/fonts/helvetica-neue-bold.woff2') format('woff2'),
+    url('https://i.wellcomecollection.org/assets/fonts/helvetica-neue-bold.woff') format('woff');
 }
+
 
 /*
  * Legal Disclaimer

--- a/common/views/themes/typography.ts
+++ b/common/views/themes/typography.ts
@@ -50,8 +50,8 @@ export const fontSizesAtBreakpoints = {
 
 const fontFamilies = {
   hnb: {
-    base: `'Helvetica Neue', 'Arial', sans-serif;`,
-    full: `'Helvetica Neue Bold Web', 'Helvetica Neue', 'Arial', sans-serif;`,
+    base: `'Helvetica Neue', Helvetica, Arial, sans-serif;`,
+    full: `'Helvetica Neue Bold Web', 'Helvetica Neue', Helvetica, Arial, sans-serif;`,
   },
   hnr: {
     base: `'Helvetica Neue', Helvetica, Arial, sans-serif;`,

--- a/common/views/themes/typography.ts
+++ b/common/views/themes/typography.ts
@@ -49,13 +49,13 @@ export const fontSizesAtBreakpoints = {
 };
 
 const fontFamilies = {
-  hnm: {
-    base: `'HelveticaNeue-Medium', 'Helvetica Neue Medium', 'Arial Black', sans-serif;`,
-    full: `'Helvetica Neue Medium Web', 'HelveticaNeue-Medium', 'Helvetica Neue Medium', 'Arial Black', sans-serif;`,
+  hnb: {
+    base: `'Helvetica Neue', 'Arial', sans-serif;`,
+    full: `'Helvetica Neue Bold Web', 'Helvetica Neue', 'Arial', sans-serif;`,
   },
-  hnl: {
-    base: `'HelveticaNeue-Light', 'Helvetica Neue Light', 'Helvetica Neue', Helvetica, Arial, sans-serif;`,
-    full: `'Helvetica Neue Light Web', 'HelveticaNeue-Light', 'Helvetica Neue Light', 'Helvetica Neue', Helvetica, Arial, sans-serif;`,
+  hnr: {
+    base: `'Helvetica Neue', Helvetica, Arial, sans-serif;`,
+    full: `'Helvetica Neue Roman Web', 'Helvetica Neue', Helvetica, Arial, sans-serif;`,
   },
   wb: {
     base: `'Wellcome Bold Web Subset', 'Arial Black', sans-serif;`,
@@ -82,24 +82,27 @@ const fontFamilyMixin = (family, isFull) => {
 };
 
 export const typography = css<GlobalStyleProps>`
-  .font-hnm,
-  .font-hnl {
+  .font-hnb {
+    font-weight: bold;
+  }
+
+  .font-hnr {
     font-weight: normal;
   }
 
-  .font-hnm {
-    ${fontFamilyMixin('hnm', false)};
+  .font-hnb {
+    ${fontFamilyMixin('hnb', false)};
 
     .fonts-loaded & {
-      ${fontFamilyMixin('hnm', true)};
+      ${fontFamilyMixin('hnb', true)};
     }
   }
 
-  .font-hnl {
-    ${fontFamilyMixin('hnl', false)};
+  .font-hnr {
+    ${fontFamilyMixin('hnr', false)};
 
     .fonts-loaded & {
-      ${fontFamilyMixin('hnl', true)}
+      ${fontFamilyMixin('hnr', true)}
     }
   }
 
@@ -124,7 +127,7 @@ export const typography = css<GlobalStyleProps>`
   }
 
   body {
-    ${fontFamilyMixin('hnl', true)}
+    ${fontFamilyMixin('hnr', true)}
     ${fontSizeMixin(4)}
     line-height: 1.5;
     color: ${themeValues.color('black')};
@@ -162,7 +165,6 @@ export const typography = css<GlobalStyleProps>`
   h6 {
     font-size: 1em;
     margin: 0 0 0.6em;
-    font-weight: normal;
   }
 
   a {
@@ -274,39 +276,21 @@ export const typography = css<GlobalStyleProps>`
 
     a:link:not(.link-reset),
     a:visited:not(.link-reset) {
-      text-decoration: none;
-      border-bottom: 2px solid ${themeValues.color('green')};
+      text-decoration: underline;
+      text-decoration-color: ${themeValues.color('green')};
+      text-underline-offset: 0.1em;
       transition: color ${themeValues.transitionProperties},
-        border-bottom ${themeValues.transitionProperties};
+        text-decoration-color ${themeValues.transitionProperties};
 
       &:hover {
         color: ${themeValues.color('green')};
-        border-bottom-color: ${themeValues.color('transparent')};
+        text-decoration-color: transparent;
       }
     }
 
-    ${props =>
-      props?.toggles?.helveticaRegular &&
-      `
-      a:link:not(.link-reset),
-      a:visited:not(.link-reset) {
-        text-decoration: underline;
-        text-decoration-color: ${themeValues.color('green')};
-        text-underline-offset: 0.1em;
-        border-bottom: none;
-        transition: color ${themeValues.transitionProperties},
-        text-decoration-color ${themeValues.transitionProperties};
-
-        &:hover {
-          color: ${themeValues.color('green')};
-          text-decoration-color: transparent;
-        }
-      }
-    `}
-
     strong,
     b {
-      ${fontFamilyMixin('hnm', true)}
+      ${fontFamilyMixin('hnb', true)}
       font-weight: normal;
     }
   }
@@ -314,7 +298,7 @@ export const typography = css<GlobalStyleProps>`
   // This is for when we receive content from a CMS,
   // making it easier to style the first node
   .first-para-bold p:first-of-type {
-    ${fontFamilyMixin('hnm', true)}
+    ${fontFamilyMixin('hnb', true)}
     ${fontSizeMixin(4)}
   }
 

--- a/content/webapp/components/Exhibition/Exhibition.js
+++ b/content/webapp/components/Exhibition/Exhibition.js
@@ -284,7 +284,7 @@ const Exhibition = ({ exhibition, pages }: Props) => {
 
         {exhibition.end && !isPast(exhibition.end) && (
           <InfoBox title="Visit us" items={getInfoItems(exhibition)}>
-            <p className={`no-margin ${font('hnl', 5)}`}>
+            <p className={`no-margin ${font('hnr', 5)}`}>
               <a href="/access">All our accessibility services</a>
             </p>
           </InfoBox>

--- a/content/webapp/components/Installation/Installation.js
+++ b/content/webapp/components/Installation/Installation.js
@@ -122,7 +122,7 @@ const Installation = ({ installation }: Props) => {
       >
         {installation.end && !isPast(installation.end) && (
           <InfoBox title="Visit us" items={getInfoItems(installation)}>
-            <p className={`no-margin ${font('hnl', 5)}`}>
+            <p className={`no-margin ${font('hnr', 5)}`}>
               <a href="/access">All our accessibility services</a>
             </p>
           </InfoBox>

--- a/content/webapp/components/OpeningTimesStatic/OpeningTimesStatic.js
+++ b/content/webapp/components/OpeningTimesStatic/OpeningTimesStatic.js
@@ -34,11 +34,8 @@ const OpeningTimesStatic = () => (
 
     <h3>Regular opening times</h3>
 
-    <table
-      className="font-HNL5-s margin-bottom-s6"
-      style={{ borderCollapse: 'collapse' }}
-    >
-      <thead className="font-HNM5-s">
+    <table className="margin-bottom-s6" style={{ borderCollapse: 'collapse' }}>
+      <thead>
         <tr>
           <th style={cellStyles} scope="col">
             <span className="visually-hidden">Day</span>
@@ -116,11 +113,8 @@ const OpeningTimesStatic = () => (
 
     <h3 id="revised">Revised hours for the festive holiday</h3>
 
-    <table
-      className="font-HNL5-s margin-bottom-s6"
-      style={{ borderCollapse: 'collapse' }}
-    >
-      <thead className="font-HNM5-s">
+    <table className="margin-bottom-s6" style={{ borderCollapse: 'collapse' }}>
+      <thead>
         <tr>
           <th style={cellStyles} scope="col">
             <span className="visually-hidden">Day</span>
@@ -180,11 +174,8 @@ const OpeningTimesStatic = () => (
 
     <h3>Regular opening times</h3>
 
-    <table
-      className="font-HNL5-s margin-bottom-s6"
-      style={{ borderCollapse: 'collapse' }}
-    >
-      <thead className="font-HNM5-s">
+    <table className="margin-bottom-s6" style={{ borderCollapse: 'collapse' }}>
+      <thead>
         <tr>
           <th style={cellStyles} scope="col">
             <span className="visually-hidden">Day</span>
@@ -262,11 +253,8 @@ const OpeningTimesStatic = () => (
 
     <h3>Revised hours for the festive holiday</h3>
 
-    <table
-      className="font-HNL5-s margin-bottom-s6"
-      style={{ borderCollapse: 'collapse' }}
-    >
-      <thead className="font-HNM5-s">
+    <table className="margin-bottom-s6" style={{ borderCollapse: 'collapse' }}>
+      <thead>
         <tr>
           <th style={cellStyles} scope="col">
             <span className="visually-hidden">Day</span>

--- a/content/webapp/pages/article.js
+++ b/content/webapp/pages/article.js
@@ -150,7 +150,7 @@ export class ArticlePage extends Component<Props, State> {
             <p
               className={classNames({
                 'no-margin': true,
-                [font('hnl', 6)]: true,
+                [font('hnr', 6)]: true,
               })}
             >
               {article.contributors.map(({ contributor, role }, i, arr) => (
@@ -165,7 +165,7 @@ export class ArticlePage extends Component<Props, State> {
                   )}
                   <span
                     className={classNames({
-                      [font('hnm', 6)]: true,
+                      [font('hnb', 6)]: true,
                     })}
                   >
                     {contributor.name}
@@ -187,7 +187,7 @@ export class ArticlePage extends Component<Props, State> {
               <span
                 className={classNames({
                   'block font-pewter': true,
-                  [font('hnl', 6)]: true,
+                  [font('hnr', 6)]: true,
                 })}
               >
                 <HTMLDate date={new Date(article.datePublished)} />

--- a/content/webapp/pages/book.tsx
+++ b/content/webapp/pages/book.tsx
@@ -103,7 +103,7 @@ export class BookPage extends Component<Props | { statusCode: number }> {
               <p
                 className={classNames({
                   'no-margin': true,
-                  [font('hnm', 3)]: true,
+                  [font('hnb', 3)]: true,
                 })}
               >
                 {book.subtitle}

--- a/content/webapp/pages/event.tsx
+++ b/content/webapp/pages/event.tsx
@@ -48,7 +48,7 @@ type EventStatusProps = {
 function EventStatus({ text, color }: EventStatusProps) {
   return (
     <div className="flex">
-      <div className={`${font('hnm', 5)} flex flex--v-center`}>
+      <div className={`${font('hnb', 5)} flex flex--v-center`}>
         <Space
           as="span"
           h={{ size: 'xs', properties: ['margin-right'] }}
@@ -359,7 +359,7 @@ const EventPage: NextPage<Props> = ({ jsonEvent }: Props) => {
                       <Space v={{ size: 's', properties: ['margin-top'] }}>
                         <p
                           className={`no-margin font-charcoal ${font(
-                            'hnl',
+                            'hnr',
                             5
                           )}`}
                         >
@@ -411,7 +411,7 @@ const EventPage: NextPage<Props> = ({ jsonEvent }: Props) => {
                     as="a"
                     className={classNames({
                       'block font-charcoal': true,
-                      [font('hnm', 5)]: true,
+                      [font('hnb', 5)]: true,
                     })}
                   >
                     <span>{event.bookingEnquiryTeam.email}</span>
@@ -484,7 +484,7 @@ const EventPage: NextPage<Props> = ({ jsonEvent }: Props) => {
               .filter(Boolean) as LabelField[]
           }
         >
-          <p className={`no-margin ${font('hnl', 5)}`}>
+          <p className={`no-margin ${font('hnr', 5)}`}>
             <a href="https://wellcomecollection.org/pages/Wuw19yIAAK1Z3Sng">
               Our event terms and conditions
             </a>

--- a/content/webapp/pages/whats-on.js
+++ b/content/webapp/pages/whats-on.js
@@ -164,7 +164,7 @@ const DateRange = ({
         }}
         as="p"
         className={classNames({
-          [font('hnl', 5)]: true,
+          [font('hnr', 5)]: true,
         })}
       >
         {period === 'today' && (
@@ -248,7 +248,7 @@ const Header = ({ activeId, openingTimes, featuredText }: HeaderProps) => {
                       as="span"
                       h={{ size: 'm', properties: ['margin-right'] }}
                       className={classNames({
-                        [font('hnm', 5)]: true,
+                        [font('hnb', 5)]: true,
                       })}
                     >
                       Galleries
@@ -267,7 +267,7 @@ const Header = ({ activeId, openingTimes, featuredText }: HeaderProps) => {
                           as="span"
                           h={{ size: 'm', properties: ['margin-right'] }}
                           className={classNames({
-                            [font('hnl', 5)]: true,
+                            [font('hnr', 5)]: true,
                           })}
                         >
                           <Fragment>
@@ -283,7 +283,7 @@ const Header = ({ activeId, openingTimes, featuredText }: HeaderProps) => {
                 <NextLink href={`/opening-times`} as={`/opening-times`}>
                   <a
                     className={classNames({
-                      [font('hnm', 5)]: true,
+                      [font('hnb', 5)]: true,
                     })}
                   >{`Full opening times`}</a>
                 </NextLink>
@@ -478,7 +478,7 @@ export class WhatsOnPage extends Component<Props> {
                         <Layout12>
                           <div className="flex flex--v-center flex--h-space-between">
                             <h2 className="h1">Exhibitions</h2>
-                            <span className={font('hnm', 5)}>
+                            <span className={font('hnb', 5)}>
                               Free admission
                             </span>
                           </div>
@@ -571,7 +571,7 @@ export class WhatsOnPage extends Component<Props> {
                       <Layout12>
                         <div className="flex flex--v-center flex--h-space-between">
                           <h2 className="h1">Exhibitions and Events</h2>
-                          <span className={font('hnm', 4)}>Free admission</span>
+                          <span className={font('hnb', 4)}>Free admission</span>
                         </div>
                       </Layout12>
                     </Space>

--- a/identity/webapp/src/frontend/MyAccount/DeleteRequested.tsx
+++ b/identity/webapp/src/frontend/MyAccount/DeleteRequested.tsx
@@ -9,13 +9,13 @@ export const DeleteRequested: React.FC = () => {
       <Container>
         <Wrapper>
           <h1 className="font-wb font-size-1">Delete request received</h1>
-          <p className="font-hnl font-size-4">Your request for account deletion has been received.</p>
+          <p className="font-hnr font-size-4">Your request for account deletion has been received.</p>
           <SpacingComponent />
-          <p className="font-hnl font-size-4">
+          <p className="font-hnr font-size-4">
             Our Library enquiries team will now progress your request. If there are any issues they will be in touch
             otherwise your account will be removed.
           </p>
-          <p className="font-hnl font-size-4">
+          <p className="font-hnr font-size-4">
             <a href="/">Return to homepage</a>
           </p>
         </Wrapper>

--- a/identity/webapp/src/frontend/MyAccount/MyAccount.style.ts
+++ b/identity/webapp/src/frontend/MyAccount/MyAccount.style.ts
@@ -23,7 +23,7 @@ export const DetailWrapper = styled.dl`
   text-overflow: ellipsis;
 `;
 
-export const DetailLabel = styled.dt.attrs({ className: 'font-hnl fonts-loaded font-size-4' })`
+export const DetailLabel = styled.dt.attrs({ className: 'font-hnr fonts-loaded font-size-4' })`
   display: block;
   font-weight: bold;
 `;
@@ -102,7 +102,7 @@ export const Section = styled.section.attrs({ className: 'border-top-width-1 bor
   }
 `;
 
-export const SectionHeading = styled.h2.attrs({ className: 'font-hnl fonts-loaded font-size-3' })`
+export const SectionHeading = styled.h2.attrs({ className: 'font-hnr fonts-loaded font-size-3' })`
   font-weight: bold;
   margin: 0;
 `;

--- a/identity/webapp/src/frontend/Registration/AccountCreated.tsx
+++ b/identity/webapp/src/frontend/Registration/AccountCreated.tsx
@@ -17,22 +17,22 @@ export const AccountCreated: React.FC = () => {
             address.
           </SuccessMessage>
           <SpacingComponent />
-          <p className="font-hnl">
+          <p className="font-hnr">
             We&apos;ve sent you an email with a link to verify your email address and activate your library account.
             Please do this within the next 24 hours, before the link expires.
           </p>
-          <p className="font-hnl">You won&apos;t be able to sign in until you have activated your account.</p>
-          <h2 className="font-hnl" style={{ fontWeight: 'bold' }}>
+          <p className="font-hnr">You won&apos;t be able to sign in until you have activated your account.</p>
+          <h2 className="font-hnr" style={{ fontWeight: 'bold' }}>
             Didn&apos;t receive an email?
           </h2>
-          <p className="font-hnl">
+          <p className="font-hnr">
             If you don&apos;t see an email from us within the next few minutes, please check the following:
           </p>
           <ul>
-            <li className="font-hnl">Is the email is in your spam/junk folder?</li>
-            <li className="font-hnl">Was the email address you entered correct?</li>
+            <li className="font-hnr">Is the email is in your spam/junk folder?</li>
+            <li className="font-hnr">Was the email address you entered correct?</li>
           </ul>
-          <p className="font-hnl" style={{ fontWeight: 'bold' }}>
+          <p className="font-hnr" style={{ fontWeight: 'bold' }}>
             If you still haven&apos;t received a verification email or need any other help with your account, please
             contact <a href="mailto:library@wellcomecollection.org">Library enquiries</a>.
           </p>

--- a/identity/webapp/src/frontend/Registration/Registration.style.ts
+++ b/identity/webapp/src/frontend/Registration/Registration.style.ts
@@ -5,7 +5,7 @@ export const ExternalLink = styled.a`
   white-space: nowrap;
 `;
 
-const AlertBox = styled.div.attrs({ role: 'alert', className: 'font-hnl' })`
+const AlertBox = styled.div.attrs({ role: 'alert', className: 'font-hnr' })`
   padding: 1em 2em;
   display: flex;
   flex-direction: column;

--- a/identity/webapp/src/frontend/components/ErrorPage/ErrorPage.tsx
+++ b/identity/webapp/src/frontend/components/ErrorPage/ErrorPage.tsx
@@ -20,7 +20,7 @@ export const ErrorPage = (): JSX.Element => {
           <h2 className="font-size-3">
             <pre>{error}</pre>
           </h2>
-          <p className="font-hnl font-size-4">{error_description}</p>
+          <p className="font-hnr font-size-4">{error_description}</p>
           <SpacingComponent />
           <OutlinedButton>
             <a

--- a/identity/webapp/src/frontend/components/Form.style.ts
+++ b/identity/webapp/src/frontend/components/Form.style.ts
@@ -6,7 +6,7 @@ export const FieldMargin = styled.div`
   margin-bottom: 1em;
 `;
 
-export const Label = styled.label.attrs({ className: 'font-hnl fonts-loaded font-size-4' })`
+export const Label = styled.label.attrs({ className: 'font-hnr fonts-loaded font-size-4' })`
   display: block;
   font-weight: bold;
 `;
@@ -20,7 +20,7 @@ export const TextInput = styled.input<{ invalid?: FieldError }>`
   border-radius: 6px;
 `;
 
-export const InvalidFieldAlert = styled.span.attrs({ role: 'alert', className: 'font-hnl font-size-6' })`
+export const InvalidFieldAlert = styled.span.attrs({ role: 'alert', className: 'font-hnr font-size-6' })`
   color: #d1192c;
   font-weight: bold;
   font-size: 14px;

--- a/identity/webapp/src/frontend/components/PasswordInput/PasswordRules.tsx
+++ b/identity/webapp/src/frontend/components/PasswordInput/PasswordRules.tsx
@@ -4,10 +4,10 @@ import { RulesList } from './PasswordInput.style';
 export const PasswordRules: React.FC = () => {
   return (
     <RulesList>
-      <li className="font-hnl font-size-6">One lowercase character</li>
-      <li className="font-hnl font-size-6">One uppercase character</li>
-      <li className="font-hnl font-size-6">One number</li>
-      <li className="font-hnl font-size-6">8 characters minimum</li>
+      <li className="font-hnr font-size-6">One lowercase character</li>
+      <li className="font-hnr font-size-6">One uppercase character</li>
+      <li className="font-hnr font-size-6">One number</li>
+      <li className="font-hnr font-size-6">8 characters minimum</li>
     </RulesList>
   );
 };

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -39,13 +39,6 @@ export default {
       description: 'Shows physical items and their locations on the work page',
     },
     {
-      id: 'helveticaRegular',
-      title: 'Helvetica regular',
-      defaultValue: false,
-      description:
-        'Displays body copy in Helvetica regular (where it is currently Helvetica light)',
-    },
-    {
       id: 'apiToolbar',
       title: 'API toolbar',
       defaultValue: false,


### PR DESCRIPTION
## Who is this for?
Everyone.

## What is it doing for them?
Making Helvetica Roman the standard body font and Helvetica Bold the emphasised font (replacing light and medium respectively).

I've changed the possible argument names to the `font` function to `hnr` and `hnb` (from `hnl` and `hnm`) with a repo-wide find and replace.

Also moved the [new link underlining](https://github.com/wellcomecollection/wellcomecollection.org/compare/helvetica-for-all?expand=1#diff-9a553c0fe102cdba16b56380ad97310f009cdc1bd575eac9180cca8ffe503831R277-R289) out from behind the toggle.