### PR TITLE
Make 'black' the same as 'viewerBlack' behind a newBlack toggle

### DIFF
--- a/common/views/pages/_app-deprecated.js
+++ b/common/views/pages/_app-deprecated.js
@@ -475,7 +475,19 @@ export default class WecoApp extends App {
               <OpeningTimesContext.Provider value={parsedOpeningTimes}>
                 <GlobalAlertContext.Provider value={globalAlert}>
                   <PopupDialogContext.Provider value={popupDialog}>
-                    <ThemeProvider theme={theme}>
+                    <ThemeProvider
+                      theme={
+                        toggles.newBlack
+                          ? {
+                              ...theme,
+                              colors: {
+                                ...theme.colors,
+                                black: theme.colors.viewerBlack,
+                              },
+                            }
+                          : theme
+                      }
+                    >
                       <GlobalStyle toggles={toggles} />
                       <OutboundLinkTracker>
                         <Fragment>

--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -309,7 +309,19 @@ const WecoApp: FunctionComponent<AppProps> = ({
   return (
     <>
       <AppContextProvider>
-        <ThemeProvider theme={theme}>
+        <ThemeProvider
+          theme={
+            pageProps?.globalContextData?.toggles.newBlack
+              ? {
+                  ...theme,
+                  colors: {
+                    ...theme.colors,
+                    black: theme.colors.viewerBlack,
+                  },
+                }
+              : theme
+          }
+        >
           <GlobalStyle toggles={pageProps?.globalContextData?.toggles} />
           <OutboundLinkTracker>
             <LoadingIndicator />

--- a/common/views/themes/typography.ts
+++ b/common/views/themes/typography.ts
@@ -130,7 +130,10 @@ export const typography = css<GlobalStyleProps>`
     ${fontFamilyMixin('hnr', true)}
     ${fontSizeMixin(4)}
     line-height: 1.5;
-    color: ${themeValues.color('black')};
+    color: ${props =>
+      props.toggles?.newBlack
+        ? themeValues.color('viewerBlack')
+        : themeValues.color('black')};
     font-variant-ligatures: no-common-ligatures;
     -webkit-font-smoothing: antialiased;
     -moz-font-smoothing: antialiased;
@@ -305,7 +308,10 @@ export const typography = css<GlobalStyleProps>`
   .drop-cap {
     ${fontFamilyMixin('wb', true)}
     font-size: 3em;
-    color: ${themeValues.color('black')};
+    color: ${props =>
+      props.toggles?.newBlack
+        ? themeValues.color('viewerBlack')
+        : themeValues.color('black')};
     float: left;
     line-height: 1em;
     padding-right: 0.1em;

--- a/common/views/themes/utility-classes.ts
+++ b/common/views/themes/utility-classes.ts
@@ -1,6 +1,9 @@
 import { themeValues } from './config';
+import { css } from 'styled-components';
+import { GlobalStyleProps } from './default';
 import { respondTo, respondBetween, visuallyHidden, clearfix } from './mixins';
-export const utilityClasses = `
+
+export const utilityClasses = css<GlobalStyleProps>`
 
 ${[1, 2, 3, 4, 5]
   .map(width => {
@@ -438,18 +441,12 @@ ${Object.entries(themeValues.colors)
   background: ${themeValues.color('transparent-black')};
 }
 
-.bg-transparent-black--hover {
-  transition: background 0.7s ease;
-
-  &[href]:hover,
-  &[href]:focus {
-    background: ${themeValues.color('black')};
-  }
-}
-
 .promo-link {
   height: 100%;
-  color: ${themeValues.color('black')};
+  color: ${props =>
+    props.toggles?.newBlack
+      ? themeValues.color('viewerBlack')
+      : themeValues.color('black')};
 
   &:hover .promo-link__title,
   &:focus .promo-link__title {

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -14,6 +14,12 @@ export default {
       defaultValue: true,
     },
     {
+      id: 'newBlack',
+      title: 'New black',
+      description: '#121212 is the new black',
+      defaultValue: false,
+    },
+    {
       id: 'buildingReopening',
       title: 'Wellcome Collection reopening UI changes',
       description:


### PR DESCRIPTION
The recent Helvetica weight changes highlighted the fact that `black` in our code is currently `#010101`, whereas @GarethOrmerod has been designing with a black of `#121212`. This is a fairly subtle change, but potentially improves the reading experience for body copy.

Unfortunately it's not _quite_ enough to override the `black` value in `theme.colors`, because there are a couple of instances where it is used in `GlobalStyles`. I don't think it's too much to work it this way though.

What is currently called `viewerBlack` is what Gareth is proposing as the new black for use everywhere. If, after looking at these changes behind the toggle we're happy to go ahead with them, then we should rename `viewerBlack` to `black`.