### PR TITLE
s/viewerBlack/black

### DIFF
--- a/common/views/components/ArchiveTree/ArchiveTree.tsx
+++ b/common/views/components/ArchiveTree/ArchiveTree.tsx
@@ -166,7 +166,7 @@ const StyledLink = styled.a<StyledLinkProps>`
   display: inline-block;
   min-height: ${`${controlHeight}px`};
   line-height: 1;
-  color: ${props => props.theme.color('viewerBlack')};
+  color: ${props => props.theme.color('black')};
   background: ${props =>
     props.theme.color(props.isCurrent ? 'yellow' : 'transparent')};
   cursor: pointer;

--- a/common/views/components/IIIFViewer/GridViewer.tsx
+++ b/common/views/components/IIIFViewer/GridViewer.tsx
@@ -119,7 +119,7 @@ const GridViewerEl = styled.div<GridViewerElProps>`
   left: 0;
   bottom: 0;
   z-index: 1;
-  background: ${props => props.theme.color('viewerBlack')};
+  background: ${props => props.theme.color('black')};
   transition: top 500ms ease;
 `;
 

--- a/common/views/components/IIIFViewer/IIIFCanvasThumbnail.tsx
+++ b/common/views/components/IIIFViewer/IIIFCanvasThumbnail.tsx
@@ -33,8 +33,8 @@ const IIIFViewerThumb = styled.button.attrs<ViewerThumbProps>(props => ({
   border-radius: 8px;
   background: ${props =>
     props.isActive
-      ? lighten(0.14, props.theme.color('viewerBlack'))
-      : props.theme.color('viewerBlack')};
+      ? lighten(0.14, props.theme.color('black'))
+      : props.theme.color('black')};
   padding: 12px 16px;
   text-align: center;
   margin: auto;

--- a/common/views/components/IIIFViewer/IIIFViewer.tsx
+++ b/common/views/components/IIIFViewer/IIIFViewer.tsx
@@ -118,7 +118,7 @@ const Sidebar = styled.div<{
 
   ${props => props.theme.media.medium`
     grid-area: desktop-main-start / left-edge / bottom-edge / desktop-sidebar-end;
-    border-right: 1px solid ${props.theme.color('viewerBlack')};
+    border-right: 1px solid ${props.theme.color('black')};
   `}
 
   background: ${props => props.theme.color('charcoal', 'dark')};
@@ -143,7 +143,7 @@ const Main = styled.div<{
   isResizing: boolean;
   isDesktopSidebarActive: boolean;
 }>`
-  background: ${props => props.theme.color('viewerBlack')};
+  background: ${props => props.theme.color('black')};
   color: ${props => props.theme.color('white')};
   overflow: auto;
   position: relative;

--- a/common/views/components/IIIFViewer/ViewerBottomBar.tsx
+++ b/common/views/components/IIIFViewer/ViewerBottomBar.tsx
@@ -59,7 +59,7 @@ export const ShameButton = styled.button.attrs(() => ({
 const BottomBar = styled.div`
   position: relative;
   z-index: 3;
-  background: ${props => lighten(0.14, props.theme.color('viewerBlack'))};
+  background: ${props => lighten(0.14, props.theme.color('black'))};
   color: ${props => props.theme.color('white')};
   display: flex;
   justify-content: space-between;

--- a/common/views/components/IIIFViewer/ViewerTopBar.tsx
+++ b/common/views/components/IIIFViewer/ViewerTopBar.tsx
@@ -108,7 +108,7 @@ const Sidebar = styled(Space).attrs({
   ${props =>
     !props.isZooming &&
     props.theme.media.medium`
-    border-right: 1px solid ${props => props.theme.color('viewerBlack')};
+    border-right: 1px solid ${props => props.theme.color('black')};
   `}
 `;
 

--- a/common/views/components/ViewerTopBar/ViewerTopBar.tsx
+++ b/common/views/components/ViewerTopBar/ViewerTopBar.tsx
@@ -68,7 +68,7 @@ export const ShameButton = styled.button.attrs(() => ({
 const TopBar = styled.div`
   position: relative;
   z-index: 3;
-  background: ${props => lighten(0.14, props.theme.color('viewerBlack'))};
+  background: ${props => lighten(0.14, props.theme.color('black'))};
   color: ${props => props.theme.color('white')};
   .title {
     max-width: 30%;
@@ -98,8 +98,7 @@ const ViewAllContainer = styled.div.attrs(() => ({
 }))`
   height: 64px;
   width: 20%;
-  border-right: 1px solid
-    ${props => lighten(0.1, props.theme.color('viewerBlack'))};
+  border-right: 10px solid red;
 `;
 
 const TitleContainer = styled.div.attrs(() => ({

--- a/common/views/components/ViewerTopBar/ViewerTopBar.tsx
+++ b/common/views/components/ViewerTopBar/ViewerTopBar.tsx
@@ -98,7 +98,7 @@ const ViewAllContainer = styled.div.attrs(() => ({
 }))`
   height: 64px;
   width: 20%;
-  border-right: 10px solid red;
+  border-right: 1px solid ${props => lighten(0.1, props.theme.color('black'))};
 `;
 
 const TitleContainer = styled.div.attrs(() => ({

--- a/common/views/pages/_app-deprecated.js
+++ b/common/views/pages/_app-deprecated.js
@@ -475,19 +475,7 @@ export default class WecoApp extends App {
               <OpeningTimesContext.Provider value={parsedOpeningTimes}>
                 <GlobalAlertContext.Provider value={globalAlert}>
                   <PopupDialogContext.Provider value={popupDialog}>
-                    <ThemeProvider
-                      theme={
-                        toggles.newBlack
-                          ? {
-                              ...theme,
-                              colors: {
-                                ...theme.colors,
-                                black: theme.colors.viewerBlack,
-                              },
-                            }
-                          : theme
-                      }
-                    >
+                    <ThemeProvider theme={theme}>
                       <GlobalStyle toggles={toggles} />
                       <OutboundLinkTracker>
                         <Fragment>

--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -309,19 +309,7 @@ const WecoApp: FunctionComponent<AppProps> = ({
   return (
     <>
       <AppContextProvider>
-        <ThemeProvider
-          theme={
-            pageProps?.globalContextData?.toggles.newBlack
-              ? {
-                  ...theme,
-                  colors: {
-                    ...theme.colors,
-                    black: theme.colors.viewerBlack,
-                  },
-                }
-              : theme
-          }
-        >
+        <ThemeProvider theme={theme}>
           <GlobalStyle toggles={pageProps?.globalContextData?.toggles} />
           <OutboundLinkTracker>
             <LoadingIndicator />

--- a/common/views/themes/config.ts
+++ b/common/views/themes/config.ts
@@ -109,8 +109,7 @@ export const themeValues = {
   },
   colors: {
     white: { base: '#ffffff', dark: '', light: '' },
-    black: { base: '#010101', dark: '', light: '' },
-    viewerBlack: { base: '#121212', dark: '', light: '' },
+    black: { base: '#121212', dark: '', light: '' },
     purple: { base: '#944aa0', dark: '', light: '' },
     teal: { base: '#006272', dark: '', light: '' },
     cyan: { base: '#298187', dark: '', light: '' },

--- a/common/views/themes/typography.ts
+++ b/common/views/themes/typography.ts
@@ -130,10 +130,7 @@ export const typography = css<GlobalStyleProps>`
     ${fontFamilyMixin('hnr', true)}
     ${fontSizeMixin(4)}
     line-height: 1.5;
-    color: ${props =>
-      props.toggles?.newBlack
-        ? themeValues.color('viewerBlack')
-        : themeValues.color('black')};
+    color: ${themeValues.color('black')};
     font-variant-ligatures: no-common-ligatures;
     -webkit-font-smoothing: antialiased;
     -moz-font-smoothing: antialiased;
@@ -308,10 +305,7 @@ export const typography = css<GlobalStyleProps>`
   .drop-cap {
     ${fontFamilyMixin('wb', true)}
     font-size: 3em;
-    color: ${props =>
-      props.toggles?.newBlack
-        ? themeValues.color('viewerBlack')
-        : themeValues.color('black')};
+    color: ${themeValues.color('black')};
     float: left;
     line-height: 1em;
     padding-right: 0.1em;

--- a/common/views/themes/utility-classes.ts
+++ b/common/views/themes/utility-classes.ts
@@ -443,10 +443,7 @@ ${Object.entries(themeValues.colors)
 
 .promo-link {
   height: 100%;
-  color: ${props =>
-    props.toggles?.newBlack
-      ? themeValues.color('viewerBlack')
-      : themeValues.color('black')};
+  color: ${themeValues.color('black')};
 
   &:hover .promo-link__title,
   &:focus .promo-link__title {


### PR DESCRIPTION
## Who is this for?
Everyone.

## What is it doing for them?
Making our palette `black` `#121212` and getting rid of `viewerBlack`.

I noticed that we're using `polished` to lighten the shade of black in a handful of instances. We now have the ability to add a `light` (and `dark`) variant of each colour in the palette, and this would suit this purpose perfectly, and allow us to get rid of the `polished` dependency. Will open another PR for this.