### PR TITLE
Check landing pages for some simple content

### DIFF
--- a/playwright/test/landing-pages.test.ts
+++ b/playwright/test/landing-pages.test.ts
@@ -11,7 +11,7 @@ describe('Top-level landing pages', () => {
   test('the homepage renders with a status code of 200', async () => {
     const [, content] = await Promise.all([
       page.goto(homepageUrl),
-      page.waitForSelector('h1'),
+      page.textContent('h1'),
     ]);
 
     expect(content).toBe(
@@ -22,7 +22,7 @@ describe('Top-level landing pages', () => {
   test('the visit us page renders with a status code of 200', async () => {
     const [, content] = await Promise.all([
       page.goto(visitUsUrl),
-      page.waitForSelector('h1'),
+      page.textContent('h1'),
     ]);
 
     expect(content).toBe('Visit us');
@@ -31,7 +31,7 @@ describe('Top-level landing pages', () => {
   test(`the what's on page renders with a status code of 200`, async () => {
     const [, content] = await Promise.all([
       page.goto(whatsOnUrl),
-      page.waitForSelector('h1'),
+      page.textContent('h1'),
     ]);
 
     expect(content).toBe("What's on");
@@ -40,7 +40,7 @@ describe('Top-level landing pages', () => {
   test(`the stories page renders with a status code of 200`, async () => {
     const [, content] = await Promise.all([
       page.goto(storiesUrl),
-      page.waitForSelector('h1'),
+      page.textContent('h1'),
     ]);
 
     expect(content).toBe('Stories');
@@ -49,7 +49,7 @@ describe('Top-level landing pages', () => {
   test('the collections page renders with a status code of 200', async () => {
     const [, content] = await Promise.all([
       page.goto(collectionsUrl),
-      page.waitForSelector('h1'),
+      page.textContent('h1'),
     ]);
 
     expect(content).toBe('Collections');
@@ -58,7 +58,7 @@ describe('Top-level landing pages', () => {
   test('the about us page renders with a status code of 200', async () => {
     const [, content] = await Promise.all([
       page.goto(aboutUsUrl),
-      page.waitForSelector('h1'),
+      page.textContent('h1'),
     ]);
 
     expect(content).toBe('About us');

--- a/playwright/test/landing-pages.test.ts
+++ b/playwright/test/landing-pages.test.ts
@@ -9,56 +9,58 @@ import {
 
 describe('Top-level landing pages', () => {
   test('the homepage renders with a status code of 200', async () => {
-    const [, response] = await Promise.all([
+    const [, content] = await Promise.all([
       page.goto(homepageUrl),
-      page.waitForEvent('response'),
+      page.waitForSelector('h1'),
     ]);
 
-    expect(response.ok()).toBe(true);
+    expect(content).toBe(
+      'A free museum and library exploring health and human experience'
+    );
   });
 
   test('the visit us page renders with a status code of 200', async () => {
-    const [, response] = await Promise.all([
+    const [, content] = await Promise.all([
       page.goto(visitUsUrl),
-      page.waitForEvent('response'),
+      page.waitForSelector('h1'),
     ]);
 
-    expect(response.ok()).toBe(true);
+    expect(content).toBe('Visit us');
   });
 
   test(`the what's on page renders with a status code of 200`, async () => {
-    const [, response] = await Promise.all([
+    const [, content] = await Promise.all([
       page.goto(whatsOnUrl),
-      page.waitForEvent('response'),
+      page.waitForSelector('h1'),
     ]);
 
-    expect(response.ok()).toBe(true);
+    expect(content).toBe("What's on");
   });
 
   test(`the stories page renders with a status code of 200`, async () => {
-    const [, response] = await Promise.all([
+    const [, content] = await Promise.all([
       page.goto(storiesUrl),
-      page.waitForEvent('response'),
+      page.waitForSelector('h1'),
     ]);
 
-    expect(response.ok()).toBe(true);
+    expect(content).toBe('Stories');
   });
 
   test('the collections page renders with a status code of 200', async () => {
-    const [, response] = await Promise.all([
+    const [, content] = await Promise.all([
       page.goto(collectionsUrl),
-      page.waitForEvent('response'),
+      page.waitForSelector('h1'),
     ]);
 
-    expect(response.ok()).toBe(true);
+    expect(content).toBe('Collections');
   });
 
   test('the about us page renders with a status code of 200', async () => {
-    const [, response] = await Promise.all([
+    const [, content] = await Promise.all([
       page.goto(aboutUsUrl),
-      page.waitForEvent('response'),
+      page.waitForSelector('h1'),
     ]);
 
-    expect(response.ok()).toBe(true);
+    expect(content).toBe('About us');
   });
 });


### PR DESCRIPTION
## Who is this for?

Folk who want simple, reliable and accurate e2e tests

## What is it doing for them?

On each landing page check for some obvious content rather than a response code. This fixes a bug where the e2e tests could fail if they got a non 200 status code, but the page would load correctly.