### PR TITLE
Fix padding of "Online" label in event cards

### DIFF
--- a/common/views/components/EventPromo/EventPromo.js
+++ b/common/views/components/EventPromo/EventPromo.js
@@ -84,9 +84,13 @@ const EventPromo = ({
           </Space>
 
           {event.isOnline && !event.availableOnline && (
-            <LabelsList
-              labels={[{ text: 'Online', labelColor: 'transparent' }]}
-            />
+            <Space v={{ size: 'xs', properties: ['margin-bottom'] }}>
+              {/* This extra space is to compensate for the negative margin that LabelsList is wrapped in. */}
+              {/* TODO: LabelsList should not provide its own margin: spacing responsibilities lie with the parent */}
+              <LabelsList
+                labels={[{ text: 'Online', labelColor: 'transparent' }]}
+              />
+            </Space>
           )}
 
           {event.availableOnline && (


### PR DESCRIPTION
Resolves https://github.com/wellcomecollection/wellcomecollection.org/issues/6529

![image](https://user-images.githubusercontent.com/4429247/122549654-a4fa4100-d02a-11eb-893c-da39836ca864.png)
