### PR TITLE
Prismic model parents

### DIFF
--- a/prismic-model/js/articles.js
+++ b/prismic-model/js/articles.js
@@ -38,6 +38,10 @@ const Article = {
     seasons: list('Seasons', {
       season: link('Season', 'document', ['seasons'], 'Select a Season'),
     }),
+    parents: list('Parents', {
+      order: number('Order'),
+      parent: link('Parent', 'document', ['exhibitions'], 'Select a parent'),
+    }),
   },
   Migration: {
     publishDate: {

--- a/prismic-model/js/books.js
+++ b/prismic-model/js/books.js
@@ -8,6 +8,7 @@ import list from './parts/list';
 import promo from './parts/promo';
 import timestamp from './parts/timestamp';
 import contributorsWithTitle from './parts/contributorsWithTitle';
+import number from './parts/number';
 
 const Books = {
   Book: {
@@ -35,6 +36,10 @@ const Books = {
   'Content relationships': {
     seasons: list('Seasons', {
       season: link('Season', 'document', ['seasons'], 'Select a Season'),
+    }),
+    parents: list('Parents', {
+      order: number('Order'),
+      parent: link('Parent', 'document', ['exhibitions'], 'Select a parent'),
     }),
   },
   Migration: {

--- a/prismic-model/js/events.js
+++ b/prismic-model/js/events.js
@@ -12,6 +12,7 @@ import text from './parts/text';
 import contributorsWithTitle from './parts/contributorsWithTitle';
 import body from './parts/body';
 import boolean from './parts/boolean';
+import number from './parts/number';
 
 const Events = {
   Event: {
@@ -77,6 +78,10 @@ const Events = {
     }),
     seasons: list('Seasons', {
       season: link('Season', 'document', ['seasons'], 'Select a Season'),
+    }),
+    parents: list('Parents', {
+      order: number('Order'),
+      parent: link('Parent', 'document', ['exhibitions'], 'Select a parent'),
     }),
   },
   Deprecated: {

--- a/prismic-model/js/exhibitions.js
+++ b/prismic-model/js/exhibitions.js
@@ -12,6 +12,7 @@ import contributorsWithTitle from './parts/contributorsWithTitle';
 import body from './parts/body';
 import booleanDeprecated from './parts/boolean-deprecated';
 import singleLineText from './parts/single-line-text';
+import number from './parts/number';
 
 const Exhibitions = {
   Exhibition: {
@@ -53,6 +54,10 @@ const Exhibitions = {
   'Content relationships': {
     seasons: list('Seasons', {
       season: link('Season', 'document', ['seasons'], 'Select a Season'),
+    }),
+    parents: list('Parents', {
+      order: number('Order'),
+      parent: link('Parent', 'document', ['exhibitions'], 'Select a parent'),
     }),
   },
   Migration: {

--- a/prismic-model/json/articles.json
+++ b/prismic-model/json/articles.json
@@ -747,6 +747,31 @@
           }
         }
       }
+    },
+    "parents": {
+      "type": "Group",
+      "fieldset": "Parents",
+      "config": {
+        "fields": {
+          "order": {
+            "type": "Number",
+            "config": {
+              "label": "Order"
+            }
+          },
+          "parent": {
+            "type": "Link",
+            "config": {
+              "label": "Parent",
+              "select": "document",
+              "customtypes": [
+                "exhibitions"
+              ],
+              "placeholder": "Select a parent"
+            }
+          }
+        }
+      }
     }
   },
   "Migration": {

--- a/prismic-model/json/books.json
+++ b/prismic-model/json/books.json
@@ -806,6 +806,31 @@
           }
         }
       }
+    },
+    "parents": {
+      "type": "Group",
+      "fieldset": "Parents",
+      "config": {
+        "fields": {
+          "order": {
+            "type": "Number",
+            "config": {
+              "label": "Order"
+            }
+          },
+          "parent": {
+            "type": "Link",
+            "config": {
+              "label": "Parent",
+              "select": "document",
+              "customtypes": [
+                "exhibitions"
+              ],
+              "placeholder": "Select a parent"
+            }
+          }
+        }
+      }
     }
   },
   "Migration": {

--- a/prismic-model/json/events.json
+++ b/prismic-model/json/events.json
@@ -1001,6 +1001,31 @@
           }
         }
       }
+    },
+    "parents": {
+      "type": "Group",
+      "fieldset": "Parents",
+      "config": {
+        "fields": {
+          "order": {
+            "type": "Number",
+            "config": {
+              "label": "Order"
+            }
+          },
+          "parent": {
+            "type": "Link",
+            "config": {
+              "label": "Parent",
+              "select": "document",
+              "customtypes": [
+                "exhibitions"
+              ],
+              "placeholder": "Select a parent"
+            }
+          }
+        }
+      }
     }
   },
   "Deprecated": {

--- a/prismic-model/json/exhibitions.json
+++ b/prismic-model/json/exhibitions.json
@@ -873,6 +873,31 @@
           }
         }
       }
+    },
+    "parents": {
+      "type": "Group",
+      "fieldset": "Parents",
+      "config": {
+        "fields": {
+          "order": {
+            "type": "Number",
+            "config": {
+              "label": "Order"
+            }
+          },
+          "parent": {
+            "type": "Link",
+            "config": {
+              "label": "Parent",
+              "select": "document",
+              "customtypes": [
+                "exhibitions"
+              ],
+              "placeholder": "Select a parent"
+            }
+          }
+        }
+      }
     }
   },
   "Migration": {


### PR DESCRIPTION
Part of #6633

## Who is this for?
People who want parity between the models stored in this repo and those in prismic.io

## What is it doing for them?
Adding the missing `parents` relationship to `articles`, `books`, `events` and `exhibitions`.