### PR TITLE
Add production CONTEXT_PATH to Next content app

### DIFF
--- a/catalogue/webapp/.env.production
+++ b/catalogue/webapp/.env.production
@@ -1,1 +1,5 @@
+# In development, the app is served at the root path.
+# In staging and production environments, the app is served from a sub-directory path.
+# This discrepancy is accounted for by a CONTEXT_PATH env var.
+# See the Identity README for a full account: https://github.com/wellcomecollection/wellcomecollection.org/blob/main/identity/webapp/README.md#context-path
 CONTEXT_PATH="account"

--- a/content/webapp/.env.production
+++ b/content/webapp/.env.production
@@ -1,1 +1,5 @@
+# In development, the app is served at the root path.
+# In staging and production environments, the app is served from a sub-directory path.
+# This discrepancy is accounted for by a CONTEXT_PATH env var.
+# See the Identity README for a full account: https://github.com/wellcomecollection/wellcomecollection.org/blob/main/identity/webapp/README.md#context-path
 CONTEXT_PATH="account"

--- a/content/webapp/.env.production
+++ b/content/webapp/.env.production
@@ -1,0 +1,1 @@
+CONTEXT_PATH="account"


### PR DESCRIPTION
## Who is this for?
People who want to be able to login from the `/collections` page, which is served from within the `content` app.

## What is it doing for them?
Making a request to the correct url (adding `account` as per [this equivalent commit in the catalogue app](https://github.com/wellcomecollection/wellcomecollection.org/commit/1266748bd2411f8588d9036eddc249ed75fa6515)).