### PR TITLE
Use access method when it's available

### DIFF
--- a/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
+++ b/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
@@ -40,7 +40,7 @@ function createBodyRow(
     physicalLocation && getLocationShelfmark(physicalLocation);
   const shelfmark = `${locationLabel ?? ''} ${locationShelfmark ?? ''}`;
   const accessLabel =
-    physicalLocation?.accessConditions[0]?.status?.label ?? '';
+    physicalLocation?.accessConditions?.[0]?.method?.label ?? '';
 
   if (locationId !== 'on-order') {
     return [


### PR DESCRIPTION
## Who is this for?
People who want more meaningful information about item access.

## What is it doing for them?
Using the access method from the api, instead of the status.