### PR TITLE
Auto-retry e2e tests

### DIFF
--- a/.buildkite/pipeline.e2e-prod.yml
+++ b/.buildkite/pipeline.e2e-prod.yml
@@ -6,6 +6,8 @@ steps:
           env:
             - PLAYWRIGHT_BASE_URL=https://wellcomecollection.org
           command: ["yarn", "test"]
+    retry:
+      automatic: true
 
   - label: "e2e test:mobile [prod]"
     plugins:
@@ -14,3 +16,5 @@ steps:
           env:
             - PLAYWRIGHT_BASE_URL=https://wellcomecollection.org
           command: ["yarn", "test:mobile"]
+    retry:
+      automatic: true

--- a/.buildkite/pipeline.e2e-stage.yml
+++ b/.buildkite/pipeline.e2e-stage.yml
@@ -6,6 +6,8 @@ steps:
           env:
             - PLAYWRIGHT_BASE_URL=https://www-stage.wellcomecollection.org
           command: ["yarn", "test"]
+    retry:
+      automatic: true
 
   - label: "e2e test:mobile [stage]"
     plugins:
@@ -14,3 +16,5 @@ steps:
           env:
             - PLAYWRIGHT_BASE_URL=https://www-stage.wellcomecollection.org
           command: ["yarn", "test:mobile"]
+    retry:
+      automatic: true

--- a/.buildkite/pipeline.e2e.yml
+++ b/.buildkite/pipeline.e2e.yml
@@ -7,6 +7,8 @@ steps:
             - PLAYWRIGHT_BASE_URL=$PLAYWRIGHT_BASE_URL
             - USE_STAGE_APIS=$USE_STAGE_APIS
           command: ["yarn", "test"]
+    retry:
+      automatic: true
 
   - label: "e2e test:mobile"
     plugins:
@@ -16,3 +18,5 @@ steps:
             - PLAYWRIGHT_BASE_URL=$PLAYWRIGHT_BASE_URL
             - USE_STAGE_APIS=$USE_STAGE_APIS
           command: ["yarn", "test:mobile"]
+    retry:
+      automatic: true


### PR DESCRIPTION
## Who is this for?

Developers who want e2e tests to be less flaky.

## What is it doing for them?

This change enables auto-retrying failed e2e tests in CI (https://buildkite.com/docs/pipelines/command-step#retry-attributes). The nature of these tests is that they are quite heavyweight (running a headless browser),  which can mean that sometimes they fail waiting to complete. This tests is a partial mitigation in that it will hide flakiness beneath a certain level - we may want to look at the tests themselves to resolve flakiness also.

This fix mitigates the problem of test flakiness but does not resolve it.