### PR TITLE
Move Where to find it

### DIFF
--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -558,12 +558,6 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
 
       <OnlineResources work={work} />
 
-      {!digitalLocation && (locationOfWork || showEncoreLink) && (
-        <WhereToFindIt />
-      )}
-
-      {!digitalLocation && <Holdings />}
-
       {work.images && work.images.length > 0 && (
         <WorkDetailsSection
           headingText="Selected images from this work"
@@ -701,10 +695,9 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
         </WorkDetailsSection>
       )}
 
-      {digitalLocation && (locationOfWork || showEncoreLink) && (
-        <WhereToFindIt />
-      )}
-      {digitalLocation && <Holdings />}
+      <Holdings />
+
+      {(locationOfWork || showEncoreLink) && <WhereToFindIt />}
 
       <WorkDetailsSection
         headingText="Permanent link"


### PR DESCRIPTION
## Who is this for?
People who want consistent UI across works.

## What is it doing for them?
Moving the 'Where to find it' section to the penultimate slice on the page, and ensuring Holdings appear above Where to find it if they're present.

![image](https://user-images.githubusercontent.com/1394592/122757832-fe16de80-d28f-11eb-9282-93a293ccdbda.png)
