### PR TITLE
Fix static assets on 404 pages

### DIFF
--- a/catalogue/webapp/next.config.js
+++ b/catalogue/webapp/next.config.js
@@ -1,4 +1,4 @@
 const webpack = require('webpack');
 const config = require('@weco/common/next/next.config');
 
-module.exports = config(webpack, 'works');
+module.exports = config(webpack);

--- a/catalogue/webapp/pages/_app.tsx
+++ b/catalogue/webapp/pages/_app.tsx
@@ -1,17 +1,35 @@
-import { NextWebVitalsMetric, AppProps } from 'next/app';
-import App from '@weco/common/views/pages/_app';
+import NextApp, { NextWebVitalsMetric, AppContext } from 'next/app';
+import App, { WecoAppProps } from '@weco/common/views/pages/_app';
 import { SearchContextProvider } from '@weco/common/views/components/SearchContext/SearchContext';
 import { gtagReportWebVitals } from '@weco/common/utils/gtag';
 import '../styles.scss';
+import { getGlobalContextData } from '@weco/common/views/components/GlobalContextProvider/GlobalContextProvider';
 
 export function reportWebVitals(metric: NextWebVitalsMetric): void {
   gtagReportWebVitals(metric);
 }
 
-export default function CatalogueApp(props: AppProps) {
+export default function CatalogueApp(props: WecoAppProps) {
   return (
     <SearchContextProvider>
       <App {...props} />
     </SearchContextProvider>
   );
 }
+
+// This is here to disable Automatic Static Optimisation as per
+// https://nextjs.org/docs/basic-features/typescript#custom-app
+// https://nextjs.org/docs/advanced-features/automatic-static-optimization#caveats
+//
+// Explicit static generation will still be possible:
+// https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
+//
+// This is necessary because statically generated pages will have
+// fixed asset prefixes, which is not compatible with using the same
+// application images in staging and production environments (which
+// require different prefixes).
+CatalogueApp.getInitialProps = async (appContext: AppContext) => {
+  const globalContextData = getGlobalContextData(appContext.ctx);
+  const initialProps = await NextApp.getInitialProps(appContext);
+  return { ...initialProps, globalContextData };
+};

--- a/common/next/next.config.js
+++ b/common/next/next.config.js
@@ -7,9 +7,8 @@ const withMDX = require('@next/mdx')({
 const buildHash = process.env.BUILD_HASH || 'test';
 const isProd = process.env.NODE_ENV === 'production';
 
-module.exports = function(webpack, assetPrefix) {
-  const prodSubdomain = process.env.PROD_SUBDOMAIN || assetPrefix;
-
+module.exports = function(webpack) {
+  const prodSubdomain = process.env.PROD_SUBDOMAIN || '';
   const withBundleAnalyzerConfig = withBundleAnalyzer({
     analyzeServer: ['server', 'both'].includes(process.env.BUNDLE_ANALYZE),
     analyzeBrowser: ['browser', 'both'].includes(process.env.BUNDLE_ANALYZE),
@@ -91,9 +90,10 @@ module.exports = function(webpack, assetPrefix) {
 
   return withMDX(
     withTM({
-      assetPrefix: isProd
-        ? `https://${prodSubdomain}.wellcomecollection.org`
-        : '',
+      assetPrefix:
+        isProd && prodSubdomain
+          ? `https://${prodSubdomain}.wellcomecollection.org`
+          : '',
       ...withBundleAnalyzerConfig,
       async rewrites() {
         return rewrites;

--- a/common/views/components/GlobalContextProvider/GlobalContextProvider.tsx
+++ b/common/views/components/GlobalContextProvider/GlobalContextProvider.tsx
@@ -65,10 +65,10 @@ export function getGlobalContextData(
 ): GlobalContextData {
   return {
     // NextJS types do not yet allow a parametrised `query` :(
-    toggles: (context.query.toggles as unknown) as Toggles,
-    globalAlert: (context.query.globalAlert as unknown) as GlobalAlert,
-    popupDialog: (context.query.popupDialog as unknown) as PopupDialog,
-    openingTimes: (context.query.openingTimes as unknown) as OpeningTimes,
+    toggles: (context.query?.toggles as unknown) as Toggles,
+    globalAlert: (context.query?.globalAlert as unknown) as GlobalAlert,
+    popupDialog: (context.query?.popupDialog as unknown) as PopupDialog,
+    openingTimes: (context.query?.openingTimes as unknown) as OpeningTimes,
   };
 }
 

--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -12,6 +12,7 @@ import ErrorPage from '../components/ErrorPage/ErrorPage';
 import {
   getGlobalContextData,
   GlobalContextData,
+  WithGlobalContextData,
 } from '../components/GlobalContextProvider/GlobalContextProvider';
 import { GetServerSidePropsContext } from 'next';
 import { trackPageview } from '../../services/conversion/track';
@@ -118,10 +119,13 @@ function makeSurePageIsTallEnough() {
   });
 }
 
-const WecoApp: FunctionComponent<AppProps> = ({
+export type WecoAppProps = AppProps & WithGlobalContextData;
+
+const WecoApp: FunctionComponent<WecoAppProps> = ({
   Component,
   pageProps,
-}: AppProps) => {
+  globalContextData,
+}) => {
   // enhanced
   useEffect(() => {
     makeSurePageIsTallEnough();
@@ -148,7 +152,7 @@ const WecoApp: FunctionComponent<AppProps> = ({
       },
     ]);
     ReactGA.set({
-      dimension5: JSON.stringify(pageProps.globalContextData.toggles),
+      dimension5: JSON.stringify(globalContextData.toggles),
     });
     trackPageview();
     Router.events.on('routeChangeComplete', trackPageview);
@@ -310,7 +314,7 @@ const WecoApp: FunctionComponent<AppProps> = ({
     <>
       <AppContextProvider>
         <ThemeProvider theme={theme}>
-          <GlobalStyle toggles={pageProps?.globalContextData?.toggles} />
+          <GlobalStyle toggles={globalContextData.toggles} />
           <OutboundLinkTracker>
             <LoadingIndicator />
             {!pageProps.err && <Component {...pageProps} />}
@@ -318,7 +322,7 @@ const WecoApp: FunctionComponent<AppProps> = ({
               <ErrorPage
                 statusCode={pageProps.err.statusCode}
                 title={pageProps.err.message}
-                globalContextData={pageProps.globalContextData}
+                globalContextData={globalContextData}
               />
             )}
           </OutboundLinkTracker>

--- a/content/webapp/next.config.js
+++ b/content/webapp/next.config.js
@@ -1,4 +1,4 @@
 const webpack = require('webpack');
 const config = require('@weco/common/next/next.config');
 
-module.exports = config(webpack, 'content');
+module.exports = config(webpack);


### PR DESCRIPTION
Resolves https://github.com/wellcomecollection/wellcomecollection.org/issues/6171

This bug was caused by Automatic Static Optimization creating an HTML file for the 404 page at build time - this meant that the environment variable that dictates the asset subdomain (`PROD_SUBDOMAIN`) wasn't being used, as it wasn't present at build time.

So that we can use the same bundles in whatever environment we want, this PR disables Automatic Static Optimization by adding a `getInitialProps` to `_app.tsx`. Some changes around injecting `globalContextData` were necessary to keep everything working. I've also changed the common `next.config.js` so that bugs regarding the `assetPrefix` setting are not quite so opaque in future.