### PR TITLE
Add bottom padding to ArchiveTree styled link

### DIFF
--- a/common/views/components/ArchiveTree/ArchiveTree.tsx
+++ b/common/views/components/ArchiveTree/ArchiveTree.tsx
@@ -173,6 +173,7 @@ const StyledLink = styled.a<StyledLinkProps>`
   margin-left: ${props =>
     props.hasControl ? `-${controlWidth / 2}px` : `${controlWidth / 2}px`};
   padding-top: ${props => `${props.theme.spacingUnit}px`};
+  padding-bottom: ${props => `${props.theme.spacingUnit}px`};
   padding-left: ${props =>
     props.hasControl
       ? `${circleWidth / 2 + props.theme.spacingUnit}px`


### PR DESCRIPTION
__Before__
![image](https://user-images.githubusercontent.com/1394592/122903801-a76cdb80-d347-11eb-9746-b809d0d599c5.png)

__After__
![Screenshot 2021-06-22 at 10 37 45](https://user-images.githubusercontent.com/1394592/122903573-7096c580-d347-11eb-8e21-5b694c9788cd.png)

