### PR TITLE
Revert part of 83bfc2 to show first paragraph of stories

### DIFF
--- a/common/views/components/ContentPage/ContentPage.tsx
+++ b/common/views/components/ContentPage/ContentPage.tsx
@@ -102,9 +102,9 @@ const ContentPage = ({
         {sectionLevelPages.includes(id) ? (
           Header
         ) : (
-          <Space v={{ size: 'l', properties: ['padding-bottom'] }}>
+          <SpacingSection>
             {Header}
-          </Space>
+          </SpacingSection>
         )}
         <div
           className={classNames({


### PR DESCRIPTION
## Who is this for?
People who want to read the whole of the first paragraph of a story.

## What is it doing for them?
Letting them do that.

__Before__
![image](https://user-images.githubusercontent.com/1394592/122906836-79d56180-d34a-11eb-9f19-562c200cc43f.png)


__After__
![image](https://user-images.githubusercontent.com/1394592/122906786-6fb36300-d34a-11eb-9a83-02ba54b11ace.png)
