### PR TITLE
turn on showItemStatus toggle for test

### DIFF
--- a/playwright/test/workPrototype.test.ts
+++ b/playwright/test/workPrototype.test.ts
@@ -18,6 +18,10 @@ beforeAll(async () => {
       name: 'toggle_showPhysicalItems',
       value: 'true',
     },
+    {
+      name: 'toggle_showItemStatus',
+      value: 'true',
+    },
   ];
   const overriddenCookies = defaultToggleAndTestCookies.map(cookie => {
     const matchingOverrideCookie = toggleOverrides.find(


### PR DESCRIPTION
## Who is this for?
people who want the tests to pass

## What is it doing for them?
Turning on the showItemStatus toggle for the test, so that when we look for the status is is there
