### PR TITLE
Don't let anything out of the modal

### DIFF
--- a/common/views/components/Modal/Modal.tsx
+++ b/common/views/components/Modal/Modal.tsx
@@ -165,7 +165,7 @@ const ModalWindowPaddingNoOverflow = styled(BaseModalWindow).attrs<
     'shadow bg-white font-black': true,
   }),
 })<BaseModalProps>`
-  overflow: visible;
+  overflow: hidden;
   padding-left: 0px;
   padding-right: 0px;
 `;

--- a/common/views/components/ModalMoreFilters/ModalMoreFilters.tsx
+++ b/common/views/components/ModalMoreFilters/ModalMoreFilters.tsx
@@ -29,7 +29,9 @@ type MoreFiltersProps = {
   changeHandler: () => void;
 };
 
-const ModalInner = styled.div`
+const ModalInner = styled(Space).attrs({
+  v: { size: 'l', properties: ['padding-bottom'] },
+})`
   display: flex;
   flex-direction: column;
   min-width: 320px;


### PR DESCRIPTION
Fixes #6457

## Who is this for?
People who like things in a modal window to stay contained within the modal window.

## What is it doing for them?
Preventing them from falling out of the bottom.

__Before__
<img width="466" alt="Screenshot 2021-06-23 at 12 23 25" src="https://user-images.githubusercontent.com/1394592/123089070-61cf1200-d41e-11eb-8675-a6e31de01d6c.png">

__After__
<img width="496" alt="Screenshot 2021-06-23 at 12 22 53" src="https://user-images.githubusercontent.com/1394592/123089032-57147d00-d41e-11eb-88ad-bddf76cd6dac.png">

