### PR TITLE
Put some spacing back in

### DIFF
--- a/common/views/components/ContentPage/ContentPage.tsx
+++ b/common/views/components/ContentPage/ContentPage.tsx
@@ -114,10 +114,12 @@ const ContentPage = ({
           })}
         >
           {shouldRenderBody() && (
-            <div className="basic-page">
-              <Fragment>{Body}</Fragment>
-              {id === prismicPageIds.whatWeDo && <ShameWhatWeDoHack />}
-            </div>
+            <SpacingSection>
+              <div className="basic-page">
+                <Fragment>{Body}</Fragment>
+                {id === prismicPageIds.whatWeDo && <ShameWhatWeDoHack />}
+              </div>
+            </SpacingSection>
           )}
 
           {children && (


### PR DESCRIPTION
https://github.com/wellcomecollection/wellcomecollection.org/pull/6658 was a bit over-enthusiastic - while it (correctly) reduced the space between the bottom of the collections sections and the newsletter promo, it removed too much elsewhere:

![image](https://user-images.githubusercontent.com/4429247/123100647-330b6880-d42b-11eb-9e68-98873e2dce8b.png)

Whether the component underneath the sections has its own spacing is inconsistent, so the easiest fix for this was to live with the large-ish spacing of the newsletter promo (ie how it was before https://github.com/wellcomecollection/wellcomecollection.org/pull/6658)

![image](https://user-images.githubusercontent.com/4429247/123100801-57674500-d42b-11eb-95fa-3b83e448727c.png)
