### PR TITLE
Display results/filters even when there is no query

### DIFF
--- a/common/views/components/SearchForm/SearchForm.tsx
+++ b/common/views/components/SearchForm/SearchForm.tsx
@@ -202,7 +202,7 @@ const SearchForm: FunctionComponent<Props> = ({
           )}
         </SearchInputWrapper>
       </Space>
-      {query && shouldShowFilters && (
+      {shouldShowFilters && (
         <SearchFilters
           query={query}
           linkResolver={linkResolver}


### PR DESCRIPTION
Resolves https://github.com/wellcomecollection/wellcomecollection.org/issues/6170

Think this is all that's required? Means that `/works` now looks like this:

![image](https://user-images.githubusercontent.com/4429247/123124737-d5cde200-d43f-11eb-9c8d-24866f640791.png)
