### PR TITLE
Remove space after slash in viewer x/y

### DIFF
--- a/common/views/components/IIIFViewer/ViewerTopBar.tsx
+++ b/common/views/components/IIIFViewer/ViewerTopBar.tsx
@@ -265,7 +265,7 @@ const ViewerTopBar: FunctionComponent<Props> = ({ viewerRef }: Props) => {
             <>
               <span data-test-id="active-index">{`${activeIndex + 1 ||
                 ''}`}</span>
-              {` / ${(canvases && canvases.length) || ''}`}{' '}
+              {`/${(canvases && canvases.length) || ''}`}{' '}
               {!(canvases[activeIndex].label.trim() === '-') &&
                 `(page ${canvases[activeIndex].label.trim()})`}
             </>


### PR DESCRIPTION
Trying and failing to figure out #6520, but not wanting to leave empty-handed, I picked up the associated nit in Slack about spacing around the `x/ y` (checked with @GarethOrmerod that no space was the way to go).

__Before__
![image](https://user-images.githubusercontent.com/1394592/123126231-1da13900-d441-11eb-9d15-b5c3a8d7c056.png)

__After__
<img width="84" alt="Screenshot 2021-06-23 at 16 34 46" src="https://user-images.githubusercontent.com/1394592/123126086-02cec480-d441-11eb-9043-c4a8f1510986.png">
