### PR TITLE
add id for anchor to element inside the body

### DIFF
--- a/common/views/pages/_document.tsx
+++ b/common/views/pages/_document.tsx
@@ -58,7 +58,7 @@ class WecoDoc extends Document {
 
   render(): ReactElement<DocumentInitialProps> {
     return (
-      <Html id="top" lang="en" className="is-keyboard">
+      <Html lang="en" className="is-keyboard">
         <Head>
           {/* GA v4 */}
           <script
@@ -80,7 +80,9 @@ class WecoDoc extends Document {
           />
         </Head>
         <body>
-          <Main />
+          <div id="top">
+            <Main />
+          </div>
           <NextScript />
         </body>
       </Html>


### PR DESCRIPTION
Fixes #6546

Having discussed this with Sarah Parry from the Digital Accessibility Centre, it seems that having the id for the back to top link on the html element is what is causing the issues with screen readers. She suggested moving the id to an element inside the body, so that's what this PR does.