### PR TITLE
Prevent last word of stories header text apearing on its own line

### DIFF
--- a/content/webapp/pages/stories.js
+++ b/content/webapp/pages/stories.js
@@ -151,7 +151,7 @@ export class StoriesPage extends Component<Props> {
               <div className="grid">
                 <div
                   className={classNames({
-                    [grid({ s: 12, m: 12, l: 7, xl: 8 })]: true,
+                    [grid({ s: 12, m: 12, l: 7, xl: 7 })]: true,
                   })}
                 >
                   <SectionPageHeader sectionLevelPage={true}>


### PR DESCRIPTION
☝️ 

__Before__
![image](https://user-images.githubusercontent.com/1394592/123241828-6278ae80-d4d9-11eb-8343-00823b3bdf22.png)


__After__
![image](https://user-images.githubusercontent.com/1394592/123241586-31987980-d4d9-11eb-8c83-0fabe7548e06.png)
