### PR TITLE
Add more  discrete data to physical item table

### DIFF
--- a/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
+++ b/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
@@ -34,13 +34,13 @@ function createBodyRow(
   const physicalLocation = getFirstPhysicalLocation(item);
   const isRequestableOnline =
     physicalLocation?.accessConditions?.[0]?.method?.id === 'online-request';
-  const accessMethod =
+  const accessMethodLabel =
     physicalLocation?.accessConditions?.[0]?.method?.label || ' ';
-  const accessMethodColumn =
+  const accessMethod =
     isRequestableOnline && encoreLink ? (
-      <ButtonInlineLink text={accessMethod} link={encoreLink} />
+      <ButtonInlineLink text={accessMethodLabel} link={encoreLink} />
     ) : (
-      <>{accessMethod}</>
+      <>{accessMethodLabel}</>
     );
   const accessStatus =
     physicalLocation?.accessConditions?.[0]?.status?.label || ' ';
@@ -56,7 +56,7 @@ function createBodyRow(
       // We don't want to display items that are on order in a table, we just show the location label
       item.title || ' ',
       shelfmark,
-      accessMethodColumn,
+      accessMethod,
       accessStatus,
       accessTerms,
     ].filter(Boolean);

--- a/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
+++ b/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
@@ -1,10 +1,4 @@
-import {
-  FunctionComponent,
-  ReactElement,
-  useState,
-  useEffect,
-  useContext,
-} from 'react';
+import { FunctionComponent, ReactElement, useState, useEffect } from 'react';
 import {
   PhysicalItem,
   ItemsWork,
@@ -19,7 +13,6 @@ import {
 import ButtonInlineLink from '@weco/common/views/components/ButtonInlineLink/ButtonInlineLink';
 import WorkDetailsText from '../WorkDetailsText/WorkDetailsText';
 import { isCatalogueApiError } from '../../pages/api/works/items/[workId]';
-import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
 
 async function fetchWorkItems(
   workId: string
@@ -36,39 +29,42 @@ function getFirstPhysicalLocation(item) {
 
 function createBodyRow(
   item: PhysicalItem,
-  encoreLink: string | undefined,
-  showItemStatus: boolean
+  encoreLink: string | undefined
 ): (string | ReactElement)[] | undefined {
   const physicalLocation = getFirstPhysicalLocation(item);
   const isRequestableOnline =
     physicalLocation?.accessConditions?.[0]?.method?.id === 'online-request';
+  const accessMethod =
+    physicalLocation?.accessConditions?.[0]?.method?.label || ' ';
+  const accessMethodColumn =
+    isRequestableOnline && encoreLink ? (
+      <ButtonInlineLink text={accessMethod} link={encoreLink} />
+    ) : (
+      <>{accessMethod}</>
+    );
+  const accessStatus =
+    physicalLocation?.accessConditions?.[0]?.status?.label || ' ';
+  const accessTerms = physicalLocation?.accessConditions[0]?.terms || ' ';
   const locationId = physicalLocation?.locationType.id;
   const locationLabel = physicalLocation && getLocationLabel(physicalLocation);
   const locationShelfmark =
     physicalLocation && getLocationShelfmark(physicalLocation);
   const shelfmark = `${locationLabel ?? ''} ${locationShelfmark ?? ''}`;
-  const accessLabel =
-    physicalLocation?.accessConditions?.[0]?.method?.label ?? '';
 
   if (locationId !== 'on-order') {
     return [
       // We don't want to display items that are on order in a table, we just show the location label
-      showItemStatus && item.status?.label,
+      item.title || ' ',
       shelfmark,
-      isRequestableOnline && encoreLink ? (
-        <ButtonInlineLink text="Request item" link={encoreLink} />
-      ) : (
-        accessLabel || physicalLocation?.locationType.label
-      ),
-      item.title || 'n/a',
+      accessMethodColumn,
+      accessStatus,
+      accessTerms,
     ].filter(Boolean);
   }
 }
 
-function createBodyRows(items, encoreLink, showItemStatus) {
-  return items
-    .map(item => createBodyRow(item, encoreLink, showItemStatus))
-    .filter(Boolean);
+function createBodyRows(items, encoreLink) {
+  return items.map(item => createBodyRow(item, encoreLink)).filter(Boolean);
 }
 
 type Props = {
@@ -83,22 +79,14 @@ const PhysicalItems: FunctionComponent<Props> = ({
   encoreLink,
 }: Props) => {
   const [physicalItems, setPhysicalItems] = useState(items);
-  const hasStatus = physicalItems.some(item => item.status);
-  const { showItemStatus } = useContext(TogglesContext);
   const headerRow = [
-    hasStatus && showItemStatus && 'Status',
-    'Location/Shelfmark',
-    'Access',
     'Title',
+    'Location/Shelfmark',
+    'Access method',
+    'Access status',
+    'Access terms',
   ].filter(Boolean);
-  const bodyRows = createBodyRows(physicalItems, encoreLink, showItemStatus);
-
-  const accessCondtionsTerms = items
-    .map(item => {
-      const physicalLocation = getFirstPhysicalLocation(item);
-      return physicalLocation?.accessConditions[0]?.terms ?? null;
-    })
-    .filter(Boolean);
+  const bodyRows = createBodyRows(physicalItems, encoreLink);
 
   const itemsOnOrder = items
     .map(item => {
@@ -144,19 +132,7 @@ const PhysicalItems: FunctionComponent<Props> = ({
           />
         </Space>
       )}
-      {accessCondtionsTerms[0] && (
-        <Space
-          v={{
-            size: 'l',
-            properties: ['margin-bottom'],
-          }}
-        >
-          <WorkDetailsText
-            title="Access conditions"
-            text={accessCondtionsTerms}
-          />
-        </Space>
-      )}
+
       {itemsOnOrder[0] && (
         <Space
           v={{

--- a/playwright/test/workPrototype.test.ts
+++ b/playwright/test/workPrototype.test.ts
@@ -18,10 +18,6 @@ beforeAll(async () => {
       name: 'toggle_showPhysicalItems',
       value: 'true',
     },
-    {
-      name: 'toggle_showItemStatus',
-      value: 'true',
-    },
   ];
   const overriddenCookies = defaultToggleAndTestCookies.map(cookie => {
     const matchingOverrideCookie = toggleOverrides.find(
@@ -45,7 +41,7 @@ beforeAll(async () => {
 
 async function getWhereToFindItAndEncoreLink() {
   const whereToFindIt = await page.$('h2:has-text("Where to find it")');
-  const encoreLink = await page.$('a:has-text("Request item")');
+  const encoreLink = await page.$('a:has-text("Online request")');
 
   return {
     whereToFindIt,
@@ -58,22 +54,12 @@ async function getAvailableOnline() {
   return availableOnline;
 }
 
-async function getStatus() {
-  const status = await page.waitForSelector('th:has-text("Status")');
-  return status;
-}
 describe(`Scenario 1: a user wants to see relevant information about where a work's items are located and the access status of those items where applicable`, () => {
   test(`works that have a physical item location display a 'Where to find it' section with a link`, async () => {
     await workWithPhysicalLocationOnly();
     const { whereToFindIt, encoreLink } = await getWhereToFindItAndEncoreLink();
     expect(whereToFindIt).toBeTruthy();
     expect(encoreLink).toBeTruthy();
-  });
-
-  test(`works with a physical location item available to request display an access status`, async () => {
-    await workWithPhysicalLocationOnly();
-    const status = await getStatus();
-    expect(status).toBeTruthy();
   });
 
   test(`works with only a physical location don't display an 'Available online' section`, async () => {

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -45,13 +45,6 @@ export default {
       description: 'Shows physical items and their locations on the work page',
     },
     {
-      id: 'showItemStatus',
-      title: 'Show physical item status',
-      defaultValue: false,
-      description:
-        'Shows the physical item status in the table (requires showPhysicalItems to be turned on)',
-    },
-    {
       id: 'apiToolbar',
       title: 'API toolbar',
       defaultValue: false,


### PR DESCRIPTION
## Who is this for?
People who want to figure out what to display about physical items.

## What is it doing for them?
Putting everything in its own column to see where the gaps are/what is redundant/what can be collated.

This was the agreed direction post design review – all of this is behind the `showPhysicalItems` toggle. This PR also removes the `showItemStatus` toggle (won't be required in its current form).

![image](https://user-images.githubusercontent.com/1394592/123325356-d6de3c80-d52f-11eb-8bdb-57c87ec46073.png)
