### PR TITLE
Fix closeOnEscape logic

### DIFF
--- a/common/views/components/Modal/Modal.tsx
+++ b/common/views/components/Modal/Modal.tsx
@@ -211,10 +211,10 @@ const Modal: FunctionComponent<Props> = ({
 
   useEffect(() => {
     function closeOnEscape(event: KeyboardEvent) {
-      if (event.key !== 'Escape') return;
+      if (event.key !== 'Escape' || !isActive) return;
       closeModal();
     }
-    if (!removeCloseButton && isActive) {
+    if (!removeCloseButton) {
       document.addEventListener('keydown', closeOnEscape);
 
       return () => document.removeEventListener('keydown', closeOnEscape);

--- a/common/views/components/Modal/Modal.tsx
+++ b/common/views/components/Modal/Modal.tsx
@@ -212,15 +212,14 @@ const Modal: FunctionComponent<Props> = ({
   useEffect(() => {
     function closeOnEscape(event: KeyboardEvent) {
       if (event.key !== 'Escape') return;
-
       closeModal();
     }
-    if (!removeCloseButton) {
+    if (!removeCloseButton && isActive) {
       document.addEventListener('keydown', closeOnEscape);
 
       return () => document.removeEventListener('keydown', closeOnEscape);
     }
-  }, []);
+  }, [isActive]);
 
   useEffect(() => {
     if (document && document.documentElement) {

--- a/common/views/components/Modal/Modal.tsx
+++ b/common/views/components/Modal/Modal.tsx
@@ -211,8 +211,9 @@ const Modal: FunctionComponent<Props> = ({
 
   useEffect(() => {
     function closeOnEscape(event: KeyboardEvent) {
-      if (event.key !== 'Escape' || !isActive) return;
-      closeModal();
+      if (event.key === 'Escape' && isActive) {
+        closeModal();
+      }
     }
     if (!removeCloseButton) {
       document.addEventListener('keydown', closeOnEscape);


### PR DESCRIPTION
## Who is this for?
People who don't want to focus the `More filters` button when they press the escape key.

## What is it doing for them?
Checking that a modal window is active before running the `closeOnEscape` handler.

Fixes an issue where pressing the escape key with an expanded image open on the `/images` route will scroll you to the top of the page (to get the `More filters` button – which erroneously gains focus – into view).

This PR _doesn't_ focus the image card that represents the expanded image after you press the escape key. I think this would be the preferred keyboard-accessible behaviour. Will open another PR for it.