### PR TITLE
Don't focus mobile filters button on first render

### DIFF
--- a/common/views/components/SearchFiltersMobile/SearchFiltersMobile.tsx
+++ b/common/views/components/SearchFiltersMobile/SearchFiltersMobile.tsx
@@ -1,10 +1,10 @@
 import React, {
   useState,
   useRef,
-  useEffect,
   FunctionComponent,
   ReactElement,
 } from 'react';
+import useSkipInitialEffect from '@weco/common/hooks/useSkipInitialEffect';
 import dynamic from 'next/dynamic';
 import useFocusTrap from '../../../hooks/useFocusTrap';
 import { CSSTransition } from 'react-transition-group';
@@ -272,11 +272,10 @@ const SearchFiltersMobile: FunctionComponent<SearchFiltersSharedProps> = ({
   const okFiltersButtonRef = useRef<HTMLButtonElement>(null);
   const filtersModalRef = useRef<HTMLDivElement>(null);
   const [isActive, setIsActive] = useState(false);
-  const firstRender = useRef(true);
 
   useFocusTrap(closeFiltersButtonRef, okFiltersButtonRef);
 
-  useEffect(() => {
+  useSkipInitialEffect(() => {
     function setPageScrollLock(value) {
       if (document.documentElement) {
         if (value) {
@@ -308,13 +307,9 @@ const SearchFiltersMobile: FunctionComponent<SearchFiltersSharedProps> = ({
           focusable.setAttribute('tabIndex', '-1')
         );
 
-      if (!firstRender.current) {
-        openFiltersButtonRef &&
-          openFiltersButtonRef.current &&
-          openFiltersButtonRef.current.focus();
-
-        firstRender.current = false;
-      }
+      openFiltersButtonRef &&
+        openFiltersButtonRef.current &&
+        openFiltersButtonRef.current.focus();
     }
   }, [isActive]);
 

--- a/common/views/components/SearchFiltersMobile/SearchFiltersMobile.tsx
+++ b/common/views/components/SearchFiltersMobile/SearchFiltersMobile.tsx
@@ -272,6 +272,7 @@ const SearchFiltersMobile: FunctionComponent<SearchFiltersSharedProps> = ({
   const okFiltersButtonRef = useRef<HTMLButtonElement>(null);
   const filtersModalRef = useRef<HTMLDivElement>(null);
   const [isActive, setIsActive] = useState(false);
+  const firstRender = useRef(true);
 
   useFocusTrap(closeFiltersButtonRef, okFiltersButtonRef);
 
@@ -307,9 +308,13 @@ const SearchFiltersMobile: FunctionComponent<SearchFiltersSharedProps> = ({
           focusable.setAttribute('tabIndex', '-1')
         );
 
-      openFiltersButtonRef &&
-        openFiltersButtonRef.current &&
-        openFiltersButtonRef.current.focus();
+      if (!firstRender.current) {
+        openFiltersButtonRef &&
+          openFiltersButtonRef.current &&
+          openFiltersButtonRef.current.focus();
+
+        firstRender.current = false;
+      }
     }
   }, [isActive]);
 


### PR DESCRIPTION
Fixes #5671 again.

The mobile search filters modal doesn't use the `Modal` component, so doesn't share the fix that went in for this and subsequently introduced this regression.

I think there are a few modal-like things that aren't using the `Modal` component. It would be good to fix that.