### PR TITLE
Add hotjar to some pages

### DIFF
--- a/catalogue/webapp/pages/works.tsx
+++ b/catalogue/webapp/pages/works.tsx
@@ -34,7 +34,6 @@ import {
   toLink,
   WorksProps,
 } from '@weco/common/views/components/WorksLink/WorksLink';
-import useHotjar from '@weco/common/hooks/useHotjar';
 import SearchContext from '@weco/common/views/components/SearchContext/SearchContext';
 import { worksFilters } from '@weco/common/services/catalogue/filters';
 
@@ -53,8 +52,6 @@ const Works: NextPage<Props> = ({
   globalContextData,
 }: Props) => {
   const [loading, setLoading] = useState(false);
-
-  useHotjar(Boolean(works.results.length > 0));
 
   const {
     query,

--- a/common/services/prismic/hardcoded-id.js
+++ b/common/services/prismic/hardcoded-id.js
@@ -35,6 +35,8 @@ export const prismicPageIds = {
   whatsOn: 'YD_IQxAAACUAK6HG',
   getInvolved: 'YDaZmxMAACIAT9u8',
   stories: 'YD_E-BAAACEAK5LX',
+  aboutUs: 'Wuw2MSIAACtd3Stq',
+  copyrightClearance: 'YGSEhxAAACgAXL4E',
 };
 
 export const getNameFromCollectionVenue = (id: string) => {

--- a/common/views/components/PageLayoutDeprecated/PageLayoutDeprecated.js
+++ b/common/views/components/PageLayoutDeprecated/PageLayoutDeprecated.js
@@ -63,7 +63,19 @@ const PageLayout = ({
   hideNewsletterPromo = false,
   hideFooter = false,
 }: Props) => {
-  useHotjar(url === '/'); // Hotjar on the homepage only
+  const hotjarUrls = [
+    'whats-on',
+    'stories',
+    'events',
+    prismicPageIds.aboutUs,
+    prismicPageIds.getInvolved,
+    prismicPageIds.visitUs,
+    prismicPageIds.collections,
+    prismicPageIds.copyrightClearance,
+  ];
+  const shouldLoadHotjar =
+    url === '/' || hotjarUrls.some(u => url?.pathname.match(u));
+  useHotjar(shouldLoadHotjar);
   const urlString = convertUrlToString(url);
   const fullTitle =
     title !== ''

--- a/common/views/components/PageLayoutDeprecated/PageLayoutDeprecated.js
+++ b/common/views/components/PageLayoutDeprecated/PageLayoutDeprecated.js
@@ -31,6 +31,7 @@ import SignIn from '../SignIn/SignIn';
 // $FlowFixMe (tsx)
 import TogglesContext from '../TogglesContext/TogglesContext';
 import { prismicPageIds } from '../../../services/prismic/hardcoded-id';
+import useHotjar from '@weco/common/hooks/useHotjar';
 
 export type Props = {|
   title: string,
@@ -61,6 +62,7 @@ const PageLayout = ({
   hideNewsletterPromo = false,
   hideFooter = false,
 }: Props) => {
+  useHotjar(url === '/'); // Hotjar on the homepage only
   const urlString = convertUrlToString(url);
   const fullTitle =
     title !== ''

--- a/common/views/components/PageLayoutDeprecated/PageLayoutDeprecated.js
+++ b/common/views/components/PageLayoutDeprecated/PageLayoutDeprecated.js
@@ -31,6 +31,7 @@ import SignIn from '../SignIn/SignIn';
 // $FlowFixMe (tsx)
 import TogglesContext from '../TogglesContext/TogglesContext';
 import { prismicPageIds } from '../../../services/prismic/hardcoded-id';
+// $FlowFixMe (ts)
 import useHotjar from '@weco/common/hooks/useHotjar';
 
 export type Props = {|

--- a/common/views/components/PageLayoutDeprecated/PageLayoutDeprecated.js
+++ b/common/views/components/PageLayoutDeprecated/PageLayoutDeprecated.js
@@ -74,7 +74,7 @@ const PageLayout = ({
     prismicPageIds.copyrightClearance,
   ];
   const shouldLoadHotjar =
-    url === '/' || hotjarUrls.some(u => url?.pathname.match(u));
+    url === '/' || hotjarUrls.some(u => url.pathname && url.pathname.match(u));
   useHotjar(shouldLoadHotjar);
   const urlString = convertUrlToString(url);
   const fullTitle =


### PR DESCRIPTION
## Who is this for?
@taceybadgerbrook 

## What is it doing for them?
Adding Hotjar to the ~homepage~[ pages listed below.](https://github.com/wellcomecollection/wellcomecollection.org/pull/6687#issuecomment-870584173)

`homepage.js` is a `Class` component, so the hook can't be used in a straightforward manner. I tried creating an HOC but failed. I also had an abortive attempt at converting it to a `FunctionComponent` with `getServerSideProps` instead of `getInitialProps` – [there is much stricter checking](https://github.com/vercel/next.js/issues/11993#issuecomment-617937409) for the former in development and I didn't think this was the time to solve those problems necessarily, so this seemed like the sensible approach in the end (and can still be backed out of easily at the point we want to stop using Hotjar on the homepage).

@alicerichmond while doing this work I noticed we still have Hotjar running on works search pages. Do you need this still, or can it be removed?