### PR TITLE
Select green UI bugs

### DIFF
--- a/common/views/components/Paginator/Paginator.tsx
+++ b/common/views/components/Paginator/Paginator.tsx
@@ -115,7 +115,6 @@ const Paginator: FunctionComponent<Props> = ({
           'float-r': true,
           'flex-inline': true,
           'flex--v-center': true,
-          'font-pewter': true,
           [font('hnr', 5)]: true,
           'flex-end': true,
         })}
@@ -147,7 +146,7 @@ const Paginator: FunctionComponent<Props> = ({
               />
             </Space>
           )}
-          <span>
+          <span className={`font-pewter`}>
             Page {currentPage} of {totalPages}
           </span>
           {nextLink && next && (

--- a/common/views/components/SelectContainer/SelectContainer.js
+++ b/common/views/components/SelectContainer/SelectContainer.js
@@ -66,7 +66,7 @@ const SelectContainer = ({ label, children }: Props) => {
       <label>
         <Space
           as="span"
-          h={{ size: 'm', properties: ['margin-right'] }}
+          h={{ size: 's', properties: ['margin-right'] }}
           className={classNames({
             [font('hnb', 5)]: true,
           })}

--- a/common/views/themes/config.ts
+++ b/common/views/themes/config.ts
@@ -122,7 +122,7 @@ export const themeValues = {
     yellow: { base: '#ffce3c', dark: '', light: '#fff5d8' },
     brown: { base: '#815e48', dark: '', light: '' },
     cream: { base: '#f0ede3', dark: '', light: '' },
-    green: { base: '#00786c', dark: '#146a5c', light: '' },
+    green: { base: '#007868', dark: '#146a5c', light: '' },
     charcoal: { base: '#323232', dark: '#2e2e2e', light: '' },
     pewter: { base: '#6b6b6b', dark: '', light: '' },
     silver: { base: '#8f8f8f', dark: '', light: '' },

--- a/identity/webapp/src/frontend/MyAccount/MyAccount.style.ts
+++ b/identity/webapp/src/frontend/MyAccount/MyAccount.style.ts
@@ -62,7 +62,7 @@ const colours = {
   success: css`
     background-color: rgba(0, 120, 108, 0.1);
     border: 1px solid rgba(0, 120, 108, 0.3);
-    color: #00786c;
+    color: ${props => props.theme.color('green')};
   `,
   failure: css`
     background-color: rgba(224, 27, 47, 0.1);

--- a/identity/webapp/src/frontend/Registration/Registration.style.ts
+++ b/identity/webapp/src/frontend/Registration/Registration.style.ts
@@ -30,7 +30,7 @@ export const ErrorAlert = styled(AlertBox)`
 
 export const SuccessMessage = styled(AlertBox)`
   background-color: rgba(0, 120, 108, 0.1);
-  color: #00786c;
+  color: ${props => props.theme.color('green')};
 `;
 
 export const Checkbox = styled(CheckboxRadio).attrs({ type: 'checkbox' })``;


### PR DESCRIPTION
Parts of #6656 

- We have inconsistencies in the shade of green between our old and new palette. Updating all greens to #007868.
- Reduce space between label and select
- I can't see the misalignment of the text inside the select box, so was loathe to give it snowflake 'shift-up-one-pixel' treatment. @GarethOrmerod can you let me know what it needs?

![image](https://user-images.githubusercontent.com/1394592/124106694-5c944780-da5c-11eb-8476-0e783ba74cd2.png)
