### PR TITLE
Add 'Serial' label if item is of type 'series'

### DIFF
--- a/common/model/card.js
+++ b/common/model/card.js
@@ -21,9 +21,14 @@ export type Card = {|
 export function convertItemToCardProps(
   item: Article | UiEvent | Season | Page | ArticleSeries | ParentPage
 ): Card {
+  const format = item.format
+    ? item.format
+    : item.type === 'series'
+    ? { title: 'Serial' }
+    : null;
   return {
     type: 'card',
-    format: item.format || null,
+    format: format,
     title: item.title,
     order: item.type === 'pages' && item.order ? item.order : null,
     description: item.promo && item.promo.caption,


### PR DESCRIPTION
Fixes #6697 

Series isn't a `format` so doesn't appear in a label for a simple `Card` by default. This feels like a bit of a hack to me – is there a nicer solution?

__Edit:__ I started remodelling the `Card` type to just have `labels`, composed from any labels on the item, preceded by a `format` if present, but it started to feel unnecessarily convoluted.

![image](https://user-images.githubusercontent.com/1394592/124111926-b5b2aa00-da61-11eb-9b02-c7e0f82f2608.png)
