### PR TITLE
Add DescriptionList to Cardigan

### DIFF
--- a/cardigan/stories/components/DescriptionList/DescriptionList.stories.mdx
+++ b/cardigan/stories/components/DescriptionList/DescriptionList.stories.mdx
@@ -1,0 +1,16 @@
+import { Meta, Canvas, Story, ArgsTable, Description } from '@storybook/addon-docs/blocks';
+import DescriptionList from '@weco/common/views/components/DescriptionList/DescriptionList';
+import Readme from '@weco/common/views/components/DescriptionList/README.md';
+import * as stories from './DescriptionList.stories.tsx';
+
+<Meta title={`Components/DescriptionList`} component={DescriptionList} />
+
+# DescriptionList
+
+<Description>{Readme}</Description>
+
+<Canvas>
+  <Story story={stories.basic} />
+</Canvas>
+
+<ArgsTable />

--- a/cardigan/stories/components/DescriptionList/DescriptionList.stories.tsx
+++ b/cardigan/stories/components/DescriptionList/DescriptionList.stories.tsx
@@ -1,0 +1,27 @@
+import DescriptionList from '@weco/common/views/components/DescriptionList/DescriptionList';
+
+const Template = args => <DescriptionList {...args} />;
+export const basic = Template.bind({});
+basic.args = {
+  title: 'Vol 3.',
+  items: [
+    {
+      term: 'Location/shelfmark',
+      description: 'Closed stores EPB/B/14982',
+    },
+    {
+      term: 'Status',
+      description: 'Temporarily unavailable',
+    },
+    {
+      term: 'Access',
+      description: 'Closed stores',
+    },
+    {
+      term: 'Access conditions',
+      description:
+        'Item is in use by another reader. Please ask at the enquiry desk',
+    },
+  ],
+};
+basic.storyName = 'DescriptionList';

--- a/common/views/components/DescriptionList/DescriptionList.tsx
+++ b/common/views/components/DescriptionList/DescriptionList.tsx
@@ -1,0 +1,54 @@
+import { FunctionComponent, ReactElement } from 'react';
+import styled from 'styled-components';
+import { classNames, font } from '@weco/common/utils/classnames';
+
+const List = styled.dl`
+  display: grid;
+  grid-column-gap: 20px;
+  grid-row-gap: 6px;
+  grid-template-columns: min-content 1fr;
+  margin: 0;
+`;
+
+const Term = styled.dt.attrs({
+  className: classNames({
+    [font('hnb', 5)]: true,
+  }),
+})``;
+
+const Description = styled.dd.attrs({
+  className: classNames({
+    [font('hnr', 5)]: true,
+  }),
+})`
+  margin-left: 0;
+`;
+
+type Props = {
+  title: string;
+  items: { term: string; description: string | ReactElement }[];
+};
+
+const DescriptionList: FunctionComponent<Props> = ({ title, items }) => {
+  return (
+    <>
+      <h3
+        className={classNames({
+          [font('hnb', 4)]: true,
+        })}
+      >
+        {title}
+      </h3>
+      <List>
+        {items.map(({ term, description }) => (
+          <>
+            <Term>{term}</Term>
+            <Description>{description}</Description>
+          </>
+        ))}
+      </List>
+    </>
+  );
+};
+
+export default DescriptionList;

--- a/common/views/components/DescriptionList/README.md
+++ b/common/views/components/DescriptionList/README.md
@@ -1,0 +1,3 @@
+## Purpose
+
+To display metadata about an item.


### PR DESCRIPTION
Part of #6695

## Who is this for?
People who want physical items laid out in a description list instead of a table.

## What is it doing for them?
Getting the necessary component into Cardigan before putting any real data into it.

![image](https://user-images.githubusercontent.com/1394592/124148324-7434f580-da87-11eb-9f27-372e720e6712.png)
