### PR TITLE
Accessibility info rel

### DIFF
--- a/common/views/components/Contributor/Contributor.js
+++ b/common/views/components/Contributor/Contributor.js
@@ -3,6 +3,7 @@ import { font, grid, classNames } from '../../../utils/classnames';
 import Image from '../Image/Image';
 // $FlowFixMe (tsx)
 import Avatar from '../Avatar/Avatar';
+// $FlowFixMe (tsx)
 import LinkLabels from '../LinkLabels/LinkLabels';
 import PrismicHtmlBlock from '../PrismicHtmlBlock/PrismicHtmlBlock';
 import type { Contributor as ContributorType } from '../../../model/contributors';

--- a/common/views/components/LinkLabels/LinkLabels.js
+++ b/common/views/components/LinkLabels/LinkLabels.js
@@ -4,6 +4,7 @@ import { font, classNames } from '../../../utils/classnames';
 import Icon from '../Icon/Icon';
 // $FlowFixMe (tsx)
 import Space from '../styled/Space';
+import styled from 'styled-components';
 
 type ItemProps = {|
   url: ?string,
@@ -16,41 +17,21 @@ type Props = {|
   icon?: string,
 |};
 
-const Item = ({url, text, addBorder}) => (
-  url ? (
-    <Space
-      h={{
-        size: 's',
-        properties: [
-          'margin-right',
-          addBorder ? 'padding-left' : undefined,
-        ].filter(Boolean),
-      }}
-      as="a"
-
-      href={url}
-    >
-      {text}
-    </Space>
-  ) : (
-    <Space
-      as="span"
-      h={{
-        size: 's',
-        properties: [
-          'margin-right',
-          addBorder ? 'padding-left' : undefined,
-        ].filter(Boolean),
-      }}
-      className={classNames({
-        [`${font('hnr', 5)}`]: true,
-        'border-left-width-1 border-color-marble': addBorder,
-      })}
-    >
-      {text}
-    </Space>
-  )
-)
+const ItemText = styled(Space).attrs(props => ({
+  as: props.url ? 'a' : 'span',
+  href: props.url || undefined,
+  h: {
+    size: 's',
+    properties: [
+      'margin-right',
+      props.addBorder ? 'padding-left' : undefined,
+    ].filter(Boolean),
+  },
+  className: classNames({
+    [`${font('hnr', 5)}`]: true,
+    'border-left-width-1 border-color-marble': props.addBorder,
+  })
+}))``;
 
 const LinkLabels = ({ items, heading, icon }: Props) => (
   heading ? (
@@ -82,7 +63,7 @@ const LinkLabels = ({ items, heading, icon }: Props) => (
             'no-margin': true,
           })}
         >
-          <Item url={url} text={text} addBorder={i !== 0} />
+          <ItemText url={url} addBorder={i !== 0}>{text}</ItemText>
         </dd>
       ))}
     </dl>
@@ -101,7 +82,7 @@ const LinkLabels = ({ items, heading, icon }: Props) => (
           className={classNames({
             'no-margin': true,
           })}>
-          <Item url={url} text={text} addBorder={i !== 0} />
+            <ItemText url={url} addBorder={i !== 0}>{text}</ItemText>
         </li>
       ))}
     </ul>

--- a/common/views/components/LinkLabels/LinkLabels.js
+++ b/common/views/components/LinkLabels/LinkLabels.js
@@ -16,77 +16,96 @@ type Props = {|
   icon?: string,
 |};
 
+const Item = ({url, text, addBorder}) => (
+  url ? (
+    <Space
+      h={{
+        size: 's',
+        properties: [
+          'margin-right',
+          addBorder ? 'padding-left' : undefined,
+        ].filter(Boolean),
+      }}
+      as="a"
+
+      href={url}
+    >
+      {text}
+    </Space>
+  ) : (
+    <Space
+      as="span"
+      h={{
+        size: 's',
+        properties: [
+          'margin-right',
+          addBorder ? 'padding-left' : undefined,
+        ].filter(Boolean),
+      }}
+      className={classNames({
+        [`${font('hnr', 5)}`]: true,
+        'border-left-width-1 border-color-marble': addBorder,
+      })}
+    >
+      {text}
+    </Space>
+  )
+)
+
 const LinkLabels = ({ items, heading, icon }: Props) => (
-  <dl
-    className={classNames({
+  heading ? (
+    <dl
+      className={classNames({
+        flex: true,
+        'flex--wrap': true,
+        'no-margin': true,
+        [font('hnb', 5)]: true,
+      })}>
+        <Space
+          as="dt"
+          h={{ size: 's', properties: ['margin-right'] }}
+          className={classNames({
+            flex: true,
+          })}
+        >
+          {icon && (
+            <Space as="span" h={{ size: 's', properties: ['margin-right'] }}>
+              <Icon name={icon} />
+            </Space>
+          )}
+          {heading}
+        </Space>
+      {items.map(({ url, text }, i) => (
+        <dd
+          key={`${url || text}-${i}`}
+          className={classNames({
+            'no-margin': true,
+          })}
+        >
+          <Item url={url} text={text} addBorder={i !== 0} />
+        </dd>
+      ))}
+    </dl>
+  ) : (
+    <ul className={classNames({
       flex: true,
+      'plain-list': true,
       'flex--wrap': true,
       'no-margin': true,
+      'no-padding': true,
       [font('hnb', 5)]: true,
-    })}
-  >
-    {heading && (
-      <Space
-        as="dt"
-        h={{ size: 's', properties: ['margin-right'] }}
-        className={classNames({
-          flex: true,
-        })}
-      >
-        {icon && (
-          <Space as="span" h={{ size: 's', properties: ['margin-right'] }}>
-            <Icon name={icon} />
-          </Space>
-        )}
-        {heading}
-      </Space>
-    )}
-    {items.map(({ url, text }, i) => (
-      <dd
-        key={`${url || text}-${i}`}
-        className={classNames({
-          'no-margin': true,
-        })}
-      >
-        {url ? (
-          <Space
-            h={{
-              size: 's',
-              properties: [
-                'margin-right',
-                i !== 0 ? 'padding-left' : undefined,
-              ].filter(Boolean),
-            }}
-            as="a"
-            className={classNames({
-              [`${font('hnr', 5)}`]: true,
-              'border-left-width-1 border-color-marble': i !== 0,
-            })}
-            href={url}
-          >
-            {text}
-          </Space>
-        ) : (
-          <Space
-            as="span"
-            h={{
-              size: 's',
-              properties: [
-                'margin-right',
-                i !== 0 ? 'padding-left' : undefined,
-              ].filter(Boolean),
-            }}
-            className={classNames({
-              [`${font('hnr', 5)}`]: true,
-              'border-left-width-1 border-color-marble': i !== 0,
-            })}
-          >
-            {text}
-          </Space>
-        )}
-      </dd>
-    ))}
-  </dl>
+    })}>
+      {items.map(({ url, text }, i) => (
+        <li
+          key={`${url || text}-${i}`}
+          className={classNames({
+            'no-margin': true,
+          })}>
+          <Item url={url} text={text} addBorder={i !== 0} />
+        </li>
+      ))}
+    </ul>
+  )
 );
 
 export default LinkLabels;

--- a/common/views/components/LinkLabels/LinkLabels.tsx
+++ b/common/views/components/LinkLabels/LinkLabels.tsx
@@ -1,23 +1,25 @@
-// @flow
 import { font, classNames } from '../../../utils/classnames';
-// $FlowFixMe (tsx)
 import Icon from '../Icon/Icon';
-// $FlowFixMe (tsx)
 import Space from '../styled/Space';
 import styled from 'styled-components';
 
-type ItemProps = {|
-  url: ?string,
-  text: string,
-|};
+type ItemProps = {
+  url?: string | null;
+  text: string;
+};
 
-type Props = {|
-  items: ItemProps[],
-  heading?: string,
-  icon?: string,
-|};
+type Props = {
+  items: ItemProps[];
+  heading?: string;
+  icon?: string;
+};
 
-const ItemText = styled(Space).attrs(props => ({
+type LinkOrSpanSpaceAttrs = {
+  url: string | null;
+  addBorder: boolean;
+};
+
+const ItemText = styled(Space).attrs<LinkOrSpanSpaceAttrs>(props => ({
   as: props.url ? 'a' : 'span',
   href: props.url || undefined,
   h: {
@@ -31,7 +33,7 @@ const ItemText = styled(Space).attrs(props => ({
     [`${font('hnr', 5)}`]: true,
     'border-left-width-1 border-color-marble': props.addBorder,
   })
-}))``;
+}))<LinkOrSpanSpaceAttrs>``;
 
 const LinkLabels = ({ items, heading, icon }: Props) => (
   heading ? (
@@ -63,7 +65,7 @@ const LinkLabels = ({ items, heading, icon }: Props) => (
             'no-margin': true,
           })}
         >
-          <ItemText url={url} addBorder={i !== 0}>{text}</ItemText>
+          <ItemText url={url || null} addBorder={i !== 0}>{text}</ItemText>
         </dd>
       ))}
     </dl>
@@ -82,7 +84,7 @@ const LinkLabels = ({ items, heading, icon }: Props) => (
           className={classNames({
             'no-margin': true,
           })}>
-            <ItemText url={url} addBorder={i !== 0}>{text}</ItemText>
+            <ItemText url={url || null} addBorder={i !== 0}>{text}</ItemText>
         </li>
       ))}
     </ul>

--- a/common/views/components/LinkLabels/LinkLabels.tsx
+++ b/common/views/components/LinkLabels/LinkLabels.tsx
@@ -30,7 +30,7 @@ const ItemText = styled(Space).attrs<LinkOrSpanSpaceAttrs>(props => ({
     ].filter(Boolean),
   },
   className: classNames({
-    [`${font('hnr', 5)}`]: true,
+    [font('hnr', 5)]: true,
     'border-left-width-1 border-color-marble': props.addBorder,
   })
 }))<LinkOrSpanSpaceAttrs>``;


### PR DESCRIPTION
Fixes #6552

- Only use a description list when we have a heading to populate the `<dt>`, otherwise uses an unordered list
- also converts the component to typescript
