### PR TITLE
Accessibility colour slider

### DIFF
--- a/.buildkite/pipeline.deploy-stage.yml
+++ b/.buildkite/pipeline.deploy-stage.yml
@@ -32,8 +32,7 @@ steps:
   - wait
 
   - block: ":rocket: deploy to prod"
-    prompt: "Have you checked the change on staging?"
-    prompt: "Have you checked the main landing pages on staging?"
+    prompt: "Have you checked the change and main landing pages on staging?"
 
   - label: "deploy to prod"
     trigger: "experience-deploy-prod"

--- a/common/views/components/DropdownButton/DropdownButton.tsx
+++ b/common/views/components/DropdownButton/DropdownButton.tsx
@@ -149,7 +149,7 @@ const DropdownButton: FunctionComponent<Props> = ({
 
     if (isActive) {
       focusables &&
-        focusables.forEach(focusable => focusable.removeAttribute('tabIndex'));
+        focusables.forEach(focusable => focusable.setAttribute('tabIndex', '0'));
       const firstFocusable = focusables && focusables[0];
 
       firstFocusable && firstFocusable.focus();


### PR DESCRIPTION
Fixes #6550

- focusable elements inside dropdowns have their tabindex set to -1 when hidden to prevent users from being able to reach them
- when the drop down is open and users should be able to reach those elements, we were relying on removing the tabindex property to achieve this.
- this only worked for natively tabbable elements and not for controls such as the colour slider
- setting the tabIndex to 0 for elements fixes this problem