### PR TITLE
Accessibility colour filter

### DIFF
--- a/common/views/components/Paginator/Paginator.tsx
+++ b/common/views/components/Paginator/Paginator.tsx
@@ -104,7 +104,7 @@ const Paginator: FunctionComponent<Props> = ({
           [font('hnb', 3)]: true,
         })}
       >
-        <TotalResultsWrapper hideMobileTotalResults={hideMobileTotalResults}>
+        <TotalResultsWrapper hideMobileTotalResults={hideMobileTotalResults} role="status">
           {totalResults} result{totalResults !== 1 ? 's' : ''}
           {query && ` for “${query}”`}
         </TotalResultsWrapper>

--- a/common/views/components/Paginator/Paginator.tsx
+++ b/common/views/components/Paginator/Paginator.tsx
@@ -105,7 +105,7 @@ const Paginator: FunctionComponent<Props> = ({
         })}
       >
         <TotalResultsWrapper hideMobileTotalResults={hideMobileTotalResults} role="status">
-          {totalResults} result{totalResults !== 1 ? 's' : ''}
+          {totalResults} {totalResults !== 1 ? 'results' : 'result'}
           {query && ` for “${query}”`}
         </TotalResultsWrapper>
       </Space>

--- a/common/views/components/PaletteColorPicker/PaletteColorPicker.tsx
+++ b/common/views/components/PaletteColorPicker/PaletteColorPicker.tsx
@@ -140,7 +140,7 @@ const TextWrapper = styled.div`
   margin-top: 8px;
 `;
 
-function getColorDisplayName(color: string | null) {
+export function getColorDisplayName(color: string | null) {
   if(color) {
     const matchingPaletteColor = palette.find(swatch => swatch.hexValue.toUpperCase() === color.toUpperCase());
     const hexValue = `#${color.toUpperCase()}`;
@@ -149,6 +149,7 @@ function getColorDisplayName(color: string | null) {
     return 'None'
   }
 }
+
 const PaletteColorPicker: FunctionComponent<Props> = ({
   name,
   color,

--- a/common/views/components/PaletteColorPicker/PaletteColorPicker.tsx
+++ b/common/views/components/PaletteColorPicker/PaletteColorPicker.tsx
@@ -81,16 +81,20 @@ const Swatches = styled.div`
   flex-wrap: wrap;
 `;
 
-const Swatch = styled.button.attrs({
+type SwatchProps = {
+  color: string;
+  ariaPressed: boolean;
+};
+
+
+const Swatch = styled.button.attrs((props: SwatchProps) => ({
   type: 'button',
   className: classNames({
     'plain-button': true,
     [font('hnr', 5)]: true,
   }),
-})<{
-  color: string;
-  selected: boolean;
-}>`
+  'aria-pressed': props.ariaPressed ? true : false,
+}))<SwatchProps>`
   position: relative;
   padding-left: 40px;
   flex: 1 0 50%;
@@ -106,7 +110,7 @@ const Swatch = styled.button.attrs({
     width: 32px;
     border-radius: 50%;
     background-color: ${({ color }) => `#${color}`};
-    border: ${({ selected }) => (selected ? '3px solid #555' : 'none')};
+    border: ${({ ariaPressed }) => (ariaPressed ? '3px solid #555' : 'none')};
   }
 `;
 
@@ -176,7 +180,7 @@ const PaletteColorPicker: FunctionComponent<Props> = ({
           <Swatch
             key={swatch.hexValue}
             color={swatch.hexValue}
-            selected={colorState === swatch.hexValue}
+            ariaPressed={colorState === swatch.hexValue}
             onClick={() => setColorState(swatch.hexValue)}
           >
             {swatch.colorName}

--- a/common/views/components/PaletteColorPicker/PaletteColorPicker.tsx
+++ b/common/views/components/PaletteColorPicker/PaletteColorPicker.tsx
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import { FunctionComponent, useEffect, useRef, useState } from 'react';
 import HueSlider from './HueSlider';
 import { hexToHsv, hsvToHex } from './conversions';
+import { classNames, font } from '../../../utils/classnames';
 
 type Props = {
   name: string;
@@ -16,7 +17,8 @@ type ColorSwatch = {
   colorName: string | null;
   colorHue: Hue | null;
 }
-const palette: ColorSwatch[] = [
+
+export const palette: ColorSwatch[] = [
   {
     hexValue: 'e02020',
     colorName: 'red',
@@ -79,17 +81,33 @@ const Swatches = styled.div`
   flex-wrap: wrap;
 `;
 
-const Swatch = styled.button.attrs({ type: 'button' })<{
+const Swatch = styled.button.attrs({
+  type: 'button',
+  className: classNames({
+    'plain-button': true,
+    [font('hnr', 5)]: true,
+  }),
+})<{
   color: string;
   selected: boolean;
 }>`
-  height: 32px;
-  width: 32px;
-  border-radius: 50%;
-  display: inline-block;
-  background-color: ${({ color }) => `#${color}`};
-  margin: 4px;
-  border: ${({ selected }) => (selected ? '3px solid #555' : 'none')};
+  position: relative;
+  padding-left: 40px;
+  flex: 1 0 50%;
+  line-height: normal;
+  margin-bottom: 8px;
+
+  &:before {
+    content: '';
+    position: absolute;
+    top: 4px;
+    left: 0;
+    height: 32px;
+    width: 32px;
+    border-radius: 50%;
+    background-color: ${({ color }) => `#${color}`};
+    border: ${({ selected }) => (selected ? '3px solid #555' : 'none')};
+  }
 `;
 
 const Slider = styled(HueSlider)`
@@ -118,6 +136,15 @@ const TextWrapper = styled.div`
   margin-top: 8px;
 `;
 
+function getColorDisplayName(color: string | null) {
+  if(color) {
+    const matchingPaletteColor = palette.find(swatch => swatch.hexValue.toUpperCase() === color.toUpperCase());
+    const hexValue = `#${color.toUpperCase()}`;
+    return matchingPaletteColor ? matchingPaletteColor.colorName : hexValue;
+  } else {
+    return 'None'
+  }
+}
 const PaletteColorPicker: FunctionComponent<Props> = ({
   name,
   color,
@@ -139,6 +166,8 @@ const PaletteColorPicker: FunctionComponent<Props> = ({
     }
   }, [colorState]);
 
+  const matchingPaletteColor = colorState && palette.find(swatch => swatch.hexValue.toUpperCase() === colorState.toUpperCase());
+
   return (
     <Wrapper>
       <input type="hidden" name={name} value={colorState || ''} />
@@ -149,7 +178,9 @@ const PaletteColorPicker: FunctionComponent<Props> = ({
             color={swatch.hexValue}
             selected={colorState === swatch.hexValue}
             onClick={() => setColorState(swatch.hexValue)}
-          />
+          >
+            {swatch.colorName}
+          </Swatch>
         ))}
       </Swatches>
       <Slider
@@ -158,7 +189,7 @@ const PaletteColorPicker: FunctionComponent<Props> = ({
       />
       <TextWrapper>
         <ColorLabel active={!!colorState}>
-          {colorState ? `#${colorState.toUpperCase()}` : 'None'}
+          {getColorDisplayName(colorState || null)}
         </ColorLabel>
         <ClearButton onClick={() => setColorState(undefined)}>
           Clear

--- a/common/views/components/PaletteColorPicker/PaletteColorPicker.tsx
+++ b/common/views/components/PaletteColorPicker/PaletteColorPicker.tsx
@@ -9,17 +9,64 @@ type Props = {
   onChangeColor: (color?: string) => void;
 };
 
-const palette: string[] = [
-  'e02020',
-  'ff47d1',
-  'fa6400',
-  'f7b500',
-  '8b572a',
-  '6dd400',
-  '22bbff',
-  '8339e8',
-  '000000',
-  'd9d3d3',
+type Hue = 'red' | 'yellow' | 'blue' | 'orange' | 'green' | 'violet' | 'red-orange' | 'yellow-orange' | 'yellow-green' | 'blue-green';
+
+type ColorSwatch = {
+  hexValue: string;
+  colorName: string | null;
+  colorHue: Hue | null;
+}
+const palette: ColorSwatch[] = [
+  {
+    hexValue: 'e02020',
+    colorName: 'red',
+    colorHue: 'red',
+  },
+  {
+    hexValue: 'ff47d1',
+    colorName: 'pink',
+    colorHue: 'red',
+  },
+  {
+    hexValue: 'fa6400',
+    colorName: 'orange',
+    colorHue: 'orange',
+  },
+  {
+    hexValue: 'f7b500',
+    colorName: 'yellow',
+    colorHue: 'yellow',
+  },
+  {
+    hexValue: '8b572a',
+    colorName: 'brown',
+    colorHue: 'orange',
+  },
+  {
+    hexValue: '6dd400',
+    colorName: 'green',
+    colorHue: 'green',
+  },
+  {
+    hexValue: '22bbff',
+    colorName: 'blue',
+    colorHue: 'blue',
+  },
+  {
+    hexValue: '8339e8',
+    colorName: 'violet',
+    colorHue: 'violet',
+  },
+  {
+    hexValue: '000000',
+    colorName: 'black',
+    colorHue: null,
+  },
+  {
+    hexValue: 'd9d3d3',
+    colorName: 'grey',
+    colorHue: null,
+  },
 ];
 
 const Wrapper = styled.div`
@@ -98,15 +145,15 @@ const PaletteColorPicker: FunctionComponent<Props> = ({
       <Swatches>
         {palette.map(swatch => (
           <Swatch
-            key={swatch}
-            color={swatch}
-            selected={colorState === swatch}
-            onClick={() => setColorState(swatch)}
+            key={swatch.hexValue}
+            color={swatch.hexValue}
+            selected={colorState === swatch.hexValue}
+            onClick={() => setColorState(swatch.hexValue)}
           />
         ))}
       </Swatches>
       <Slider
-        hue={hexToHsv(colorState || palette[0]).h}
+        hue={hexToHsv(colorState || palette[0].hexValue).h}
         onChangeHue={h => setColorState(hsvToHex({ h, s: 80, v: 90 }))}
       />
       <TextWrapper>

--- a/common/views/components/PaletteColorPicker/PaletteColorPicker.tsx
+++ b/common/views/components/PaletteColorPicker/PaletteColorPicker.tsx
@@ -87,6 +87,7 @@ const Swatch = styled.button.attrs((props: SwatchProps) => ({
   flex: 1 0 50%;
   line-height: normal;
   margin-bottom: 8px;
+  cursor: pointer;
 
   &:before {
     content: '';

--- a/common/views/components/PaletteColorPicker/PaletteColorPicker.tsx
+++ b/common/views/components/PaletteColorPicker/PaletteColorPicker.tsx
@@ -10,64 +10,51 @@ type Props = {
   onChangeColor: (color?: string) => void;
 };
 
-type Hue = 'red' | 'yellow' | 'blue' | 'orange' | 'green' | 'violet' | 'red-orange' | 'yellow-orange' | 'yellow-green' | 'blue-green';
-
 type ColorSwatch = {
   hexValue: string;
   colorName: string | null;
-  colorHue: Hue | null;
 }
 
 export const palette: ColorSwatch[] = [
   {
     hexValue: 'e02020',
     colorName: 'red',
-    colorHue: 'red',
   },
   {
     hexValue: 'ff47d1',
     colorName: 'pink',
-    colorHue: 'red',
   },
   {
     hexValue: 'fa6400',
     colorName: 'orange',
-    colorHue: 'orange',
   },
   {
     hexValue: 'f7b500',
     colorName: 'yellow',
-    colorHue: 'yellow',
   },
   {
     hexValue: '8b572a',
     colorName: 'brown',
-    colorHue: 'orange',
   },
   {
     hexValue: '6dd400',
     colorName: 'green',
-    colorHue: 'green',
   },
   {
     hexValue: '22bbff',
     colorName: 'blue',
-    colorHue: 'blue',
   },
   {
     hexValue: '8339e8',
     colorName: 'violet',
-    colorHue: 'violet',
   },
   {
     hexValue: '000000',
     colorName: 'black',
-    colorHue: null,
   },
   {
     hexValue: 'd9d3d3',
     colorName: 'grey',
-    colorHue: null,
   },
 ];
 

--- a/common/views/components/ResetActiveFilters/ResetActiveFilters.tsx
+++ b/common/views/components/ResetActiveFilters/ResetActiveFilters.tsx
@@ -102,7 +102,7 @@ export const ResetActiveFilters: FunctionComponent<ResetActiveFilters> = ({
       h={{ size: 'm', properties: ['padding-left', 'padding-right'] }}
       className="tokens bg-white"
     >
-      <div className={classNames({ [font('hnb', 5)]: true })}>
+      <div className={classNames({ [font('hnb', 5)]: true })} role="status">
         <div>
           <h2 className="inline">
             <Space

--- a/common/views/components/ResetActiveFilters/ResetActiveFilters.tsx
+++ b/common/views/components/ResetActiveFilters/ResetActiveFilters.tsx
@@ -7,6 +7,7 @@ import NextLink from 'next/link';
 import { font, classNames } from '../../../utils/classnames';
 import styled from 'styled-components';
 import { Filter } from '../../../services/catalogue/filters';
+import { getColorDisplayName } from '../../components/PaletteColorPicker/PaletteColorPicker';
 
 type ResetActiveFilters = {
   query: string;
@@ -203,7 +204,7 @@ export const ResetActiveFilters: FunctionComponent<ResetActiveFilters> = ({
                     <a>
                       <CancelFilter>
                         {f.label}
-                        <ColorSwatch color={`#${f.color}`} />
+                        <ColorSwatch color={`#${f.color}`}><span className="visually-hidden">{getColorDisplayName(f.color)}</span></ColorSwatch>
                       </CancelFilter>
                     </a>
                   </NextLink>


### PR DESCRIPTION
Fixes #6563 - issues with colour filter

- adds text labels to filter buttons, so we aren't relying on colour to covey meaning and gives screenreaders and voice activation users something to work with
- adds aria role=status to elements that are updated so changes get announced by screenreaders
- adds text alternative for colours shown in active filters

Adding the text labels to the filter buttons has design implications @GarethOrmerod:

Before:
<img width="443" alt="Screenshot 2021-07-05 at 12 27 01" src="https://user-images.githubusercontent.com/6051896/124499914-b5dedc80-ddb6-11eb-8e21-26a55f26c0a9.png">

After:
![Screenshot 2021-07-05 at 17 22 42](https://user-images.githubusercontent.com/6051896/124499940-c1320800-ddb6-11eb-82ed-ad3bf500916b.png)

