### PR TITLE
Set card body padding the same at all breakpoints (more at bottom)

### DIFF
--- a/common/views/components/Card/Card.tsx
+++ b/common/views/components/Card/Card.tsx
@@ -33,17 +33,22 @@ export const CardOuter = styled.a.attrs(() => ({
 `;
 
 export const CardBody = styled(Space).attrs(() => ({
-  v: { size: 'm', properties: ['padding-top', 'padding-bottom'] },
+  v: { size: 'm', properties: ['padding-top'] },
+  h: {
+    size: 'm',
+    properties: ['padding-left', 'padding-right'],
+    overrides: { small: 5, medium: 5, large: 5 },
+  },
   className: 'flex flex--column flex-1',
 }))`
   justify-content: space-between;
 
   ${props =>
-    props.theme.makeSpacePropertyValues(
-      'm',
-      ['padding-left', 'padding-right'],
-      false
-    )}
+    props.theme.makeSpacePropertyValues('l', ['padding-bottom'], false, {
+      small: 8,
+      medium: 8,
+      large: 8,
+    })}
 
   .card-theme.card-theme--transparent & {
     padding-left: 0;


### PR DESCRIPTION
Resolves #6270 

Setting the `CardBody` padding to the following across all breakpoints:

top: `16px`
right: `16px`
bottom: `32px`
left: `16px`

![image](https://user-images.githubusercontent.com/1394592/124507195-3b698900-ddc5-11eb-8bdf-810699269a00.png)
