### PR TITLE
Fix e2e test

### DIFF
--- a/playwright/test/images.test.ts
+++ b/playwright/test/images.test.ts
@@ -50,7 +50,7 @@ describe('Image search', () => {
     await page.waitForNavigation();
     await expectItemIsVisible(searchResultsContainer);
     await expectItemsIsVisible(imagesResultsListItem, 1);
-
+    await page.click('body');
     await clickActionClickSearchResultItem(1);
     await expectItemIsVisible(modalexpandedImageViewMoreButton);
 


### PR DESCRIPTION
The [colour filter is larger now because of this accessibility fix](https://github.com/wellcomecollection/wellcomecollection.org/pull/6722).

This was causing an e2e test to fail as it was covering the first search result link, which needed to be activated.

This PR adds a step to dismiss the colour filter once it's been used.

