### PR TITLE
Card post body

### DIFF
--- a/common/views/components/Card/Card.tsx
+++ b/common/views/components/Card/Card.tsx
@@ -36,7 +36,7 @@ export const CardPostBody = styled(Space).attrs({
   v: {
     size: 'm',
     properties: ['padding-bottom'],
-    overrides: { small: 4, medium: 4, large: 4 },
+    overrides: { small: 5, medium: 5, large: 5 },
   },
   h: {
     size: 'm',

--- a/common/views/components/Card/Card.tsx
+++ b/common/views/components/Card/Card.tsx
@@ -32,6 +32,19 @@ export const CardOuter = styled.a.attrs(() => ({
   }
 `;
 
+export const CardPostBody = styled(Space).attrs({
+  v: {
+    size: 'm',
+    properties: ['padding-bottom'],
+    overrides: { small: 4, medium: 4, large: 4 },
+  },
+  h: {
+    size: 'm',
+    properties: ['padding-left', 'padding-right'],
+    overrides: { small: 5, medium: 5, large: 5 },
+  },
+})``;
+
 export const CardBody = styled(Space).attrs(() => ({
   v: { size: 'm', properties: ['padding-top'] },
   h: {

--- a/common/views/components/EventPromo/EventPromo.js
+++ b/common/views/components/EventPromo/EventPromo.js
@@ -12,7 +12,7 @@ import Moment from 'moment';
 // $FlowFixMe (tsx)
 import Space from '../styled/Space';
 // $FlowFixMe (tsx)
-import { CardOuter, CardBody } from '../Card/Card';
+import { CardOuter, CardBody, CardPostBody } from '../Card/Card';
 /* $FlowFixMe (tsx) */
 import Divider from '../Divider/Divider';
 /* $FlowFixMe (ts) */
@@ -157,17 +157,16 @@ const EventPromo = ({
             </div>
           )}
         </div>
-
-        {event.series.length > 0 && (
-          <Space v={{ size: 'm', properties: ['margin-top'] }}>
-            {event.series.map(series => (
-              <p key={series.title} className={`${font('hnb', 6)} no-margin`}>
-                <span className={font('hnr', 6)}>Part of</span> {series.title}
-              </p>
-            ))}
-          </Space>
-        )}
       </CardBody>
+      {event.series.length > 0 && (
+        <CardPostBody>
+          {event.series.map(series => (
+            <p key={series.title} className={`${font('hnb', 6)} no-margin`}>
+              <span className={font('hnr', 6)}>Part of</span> {series.title}
+            </p>
+          ))}
+        </CardPostBody>
+      )}
       {event.secondaryLabels.length > 0 && (
         <Space
           h={{ size: 'm', properties: ['padding-left', 'padding-right'] }}

--- a/common/views/components/StoryPromo/StoryPromo.tsx
+++ b/common/views/components/StoryPromo/StoryPromo.tsx
@@ -10,7 +10,7 @@ import { UiImage } from '../Images/Images';
 import LabelsList from '../LabelsList/LabelsList';
 import PartNumberIndicator from '../PartNumberIndicator/PartNumberIndicator';
 import Space from '../styled/Space';
-import { CardOuter, CardBody } from '../Card/Card';
+import { CardOuter, CardBody, CardPostBody } from '../Card/Card';
 
 type Props = {
   item: Article;
@@ -93,17 +93,16 @@ const StoryPromo: FunctionComponent<Props> = ({
             </p>
           )}
         </div>
-
-        {item.series.length > 0 && (
-          <Space v={{ size: 'l', properties: ['margin-top'] }}>
-            {item.series.map(series => (
-              <p key={series.title} className={`${font('hnb', 6)} no-margin`}>
-                <span className={font('hnr', 6)}>Part of</span> {series.title}
-              </p>
-            ))}
-          </Space>
-        )}
       </CardBody>
+      {item.series.length > 0 && (
+        <CardPostBody>
+          {item.series.map(series => (
+            <p key={series.title} className={`${font('hnb', 6)} no-margin`}>
+              <span className={font('hnr', 6)}>Part of</span> {series.title}
+            </p>
+          ))}
+        </CardPostBody>
+      )}
     </CardOuter>
   );
 };


### PR DESCRIPTION
## Who is this for?
People who want the `Part of…` labels to feel attached to the bottom of a card (after the increase in `CardBody` bottom padding in #6723 to address #6270).

## What is it doing for them?
Moving them outside the `CardBody` into their own `CardPostBody` component with less padding.

__Before__
<img width="409" alt="Screenshot 2021-07-07 at 12 03 16" src="https://user-images.githubusercontent.com/1394592/124748761-67971e00-df1b-11eb-91ed-dd2145dd1a5f.png">

__After__
<img width="409" alt="Screenshot" src="https://user-images.githubusercontent.com/1394592/124748641-46363200-df1b-11eb-884b-d54939a59a17.png">