### PR TITLE
add reference number to item viewer

### DIFF
--- a/common/views/components/IIIFViewer/ViewerSidebar.tsx
+++ b/common/views/components/IIIFViewer/ViewerSidebar.tsx
@@ -199,6 +199,20 @@ const ViewerSidebar: FunctionComponent<Props> = ({ mainViewerRef }: Props) => {
           </div>
         )}
 
+        {work.referenceNumber && (
+          <div data-test-id="reference-number">
+            <LinkLabels
+              heading={'Reference'}
+              items={[
+                {
+                  text: work.referenceNumber,
+                  url: null,
+                },
+              ]}
+            />
+          </div>
+        )}
+
         <Space v={{ size: 'm', properties: ['margin-top'] }}>
           <WorkLink id={work.id} source="viewer_back_link">
             <a

--- a/common/views/components/LinkLabels/LinkLabels.tsx
+++ b/common/views/components/LinkLabels/LinkLabels.tsx
@@ -32,10 +32,10 @@ const ItemText = styled(Space).attrs<LinkOrSpanSpaceAttrs>(props => ({
   className: classNames({
     [font('hnr', 5)]: true,
     'border-left-width-1 border-color-marble': props.addBorder,
-  })
+  }),
 }))<LinkOrSpanSpaceAttrs>``;
 
-const LinkLabels = ({ items, heading, icon }: Props) => (
+const LinkLabels = ({ items, heading, icon }: Props) =>
   heading ? (
     <dl
       className={classNames({
@@ -43,21 +43,22 @@ const LinkLabels = ({ items, heading, icon }: Props) => (
         'flex--wrap': true,
         'no-margin': true,
         [font('hnb', 5)]: true,
-      })}>
-        <Space
-          as="dt"
-          h={{ size: 's', properties: ['margin-right'] }}
-          className={classNames({
-            flex: true,
-          })}
-        >
-          {icon && (
-            <Space as="span" h={{ size: 's', properties: ['margin-right'] }}>
-              <Icon name={icon} />
-            </Space>
-          )}
-          {heading}
-        </Space>
+      })}
+    >
+      <Space
+        as="dt"
+        h={{ size: 's', properties: ['margin-right'] }}
+        className={classNames({
+          flex: true,
+        })}
+      >
+        {icon && (
+          <Space as="span" h={{ size: 's', properties: ['margin-right'] }}>
+            <Icon name={icon} />
+          </Space>
+        )}
+        {heading}
+      </Space>
       {items.map(({ url, text }, i) => (
         <dd
           key={`${url || text}-${i}`}
@@ -65,30 +66,36 @@ const LinkLabels = ({ items, heading, icon }: Props) => (
             'no-margin': true,
           })}
         >
-          <ItemText url={url || null} addBorder={i !== 0}>{text}</ItemText>
+          <ItemText url={url || null} addBorder={i !== 0}>
+            {text}
+          </ItemText>
         </dd>
       ))}
     </dl>
   ) : (
-    <ul className={classNames({
-      flex: true,
-      'plain-list': true,
-      'flex--wrap': true,
-      'no-margin': true,
-      'no-padding': true,
-      [font('hnb', 5)]: true,
-    })}>
+    <ul
+      className={classNames({
+        flex: true,
+        'plain-list': true,
+        'flex--wrap': true,
+        'no-margin': true,
+        'no-padding': true,
+        [font('hnb', 5)]: true,
+      })}
+    >
       {items.map(({ url, text }, i) => (
         <li
           key={`${url || text}-${i}`}
           className={classNames({
             'no-margin': true,
-          })}>
-            <ItemText url={url || null} addBorder={i !== 0}>{text}</ItemText>
+          })}
+        >
+          <ItemText url={url || null} addBorder={i !== 0}>
+            {text}
+          </ItemText>
         </li>
       ))}
     </ul>
-  )
-);
+  );
 
 export default LinkLabels;

--- a/playwright/test/contexts.ts
+++ b/playwright/test/contexts.ts
@@ -48,6 +48,11 @@ const workWithPhysicalAndDigitalLocation = async (): Promise<void> => {
   await page.goto(`${baseUrl}/works/works/r9kpkq8e`);
 };
 
+const itemWithReferenceNumber = async (): Promise<void> => {
+  context.addCookies(requiredCookies);
+  await page.goto(`${baseUrl}/works/qqra7v28/items`);
+};
+
 const worksSearch = async (): Promise<void> => {
   context.addCookies(requiredCookies);
   await page.goto(`${baseUrl}/works`);
@@ -59,6 +64,7 @@ export {
   multiVolumeItem,
   worksSearch,
   itemWithSearchAndStructures,
+  itemWithReferenceNumber,
   workWithPhysicalAndDigitalLocation,
   workWithPhysicalLocationOnly,
   workWithDigitalLocationOnly,

--- a/playwright/test/selectors/item.ts
+++ b/playwright/test/selectors/item.ts
@@ -7,6 +7,7 @@ export const smallImageDownload = `${itemDownloadsModal} li:nth-of-type(1) a`;
 export const fullItemDownload = `${itemDownloadsModal} li:nth-of-type(3) a`;
 export const workContributors = `[data-test-id="work-contributors"]`;
 export const workDates = `[data-test-id="work-dates"]`;
+export const referenceNumber = `[data-test-id="reference-number"]`;
 export const fullscreenButton = 'css=button >> text="Full screen"';
 export const searchWithinResultsHeader = `[data-test-id="results-header"]`;
 export const mainViewer = `[data-test-id=main-viewer] > div`;

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -1,4 +1,8 @@
-import { multiVolumeItem, itemWithSearchAndStructures } from './contexts';
+import {
+  multiVolumeItem,
+  itemWithSearchAndStructures,
+  itemWithReferenceNumber,
+} from './contexts';
 import { isMobile } from './actions/common';
 import { volumesNavigationLabel, searchWithinLabel } from './text/aria-labels';
 import {
@@ -18,6 +22,7 @@ import {
   mobilePageGridButtons,
   toggleInfoDesktop,
   toggleInfoMobile,
+  referenceNumber,
 } from './selectors/item';
 import { baseUrl } from './helpers/urls';
 import { makeDefaultToggleAndTestCookies } from './helpers/utils';
@@ -120,16 +125,14 @@ describe.skip('Scenario 2: A user wants to use the content offline', () => {
 });
 
 describe('Scenario 3: A user wants information about the item they are viewing', () => {
-  beforeAll(async () => {
-    await multiVolumeItem();
-  });
-
   test('the item has a title', async () => {
+    await multiVolumeItem();
     const title = await page.textContent('h1');
     expect(title).toBe('Practica seu Lilium medicinae / [Bernard de Gordon].');
   });
 
   test('the item has contributor information', async () => {
+    await multiVolumeItem();
     const contributors = await page.textContent(workContributors);
     expect(contributors).toBe(
       'Bernard, de Gordon, approximately 1260-approximately 1318.'
@@ -137,9 +140,16 @@ describe('Scenario 3: A user wants information about the item they are viewing',
   });
 
   test('the item has date information', async () => {
+    await multiVolumeItem();
     const dates = await page.textContent(workDates);
     // TODO: this text isn't very explanitory and should probably be updated in the DOM
     expect(dates).toBe('Date1496[7]');
+  });
+
+  test('the item has reference number information', async () => {
+    await itemWithReferenceNumber();
+    const dates = await page.textContent(referenceNumber);
+    expect(dates).toBe('ReferenceWA/HMM/BU/1');
   });
 });
 


### PR DESCRIPTION
## Who is this for?
People who don't want to have to navigate back to the work to see the reference number of a work

## What is it doing for them?
Show the reference number of the work in the item viewer

<img width="893" alt="Screenshot 2021-07-07 at 12 39 45" src="https://user-images.githubusercontent.com/31692/124753360-cb701580-df20-11eb-981b-f60287dc5496.png">

