### PR TITLE
Fix tabbing

### DIFF
--- a/common/utils/get-focusable-elements.js
+++ b/common/utils/get-focusable-elements.js
@@ -4,7 +4,7 @@
 const getFocusableElements = (el: HTMLElement): HTMLElement[] => {
   return [
     ...el.querySelectorAll(
-      'button, [href]:not([tabindex="-1"]), input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      'button, [href]:not([tabindex="-1"]), input, select, textarea, [tabindex]:not([tabindex="-1"]), [role=slider]'
     ),
   ];
 };

--- a/common/views/components/DropdownButton/DropdownButton.tsx
+++ b/common/views/components/DropdownButton/DropdownButton.tsx
@@ -156,7 +156,7 @@ const DropdownButton: FunctionComponent<Props> = ({
           focusable.setAttribute('tabIndex', '-1')
         );
     }
-  }, [isActive]);
+  }, [isActive, children]);
 
   return (
     <DropdownWrapper ref={dropdownWrapperRef}>


### PR DESCRIPTION
Noticed that if the page loads with an active colour filter, then it's possible to navigate to the colour filters via the keyboard when they are not visible, so keyboard focus essentially disappears. 

![Screenshot 2021-07-08 at 15 07 43](https://user-images.githubusercontent.com/6051896/124937147-08123e80-dfff-11eb-8a17-07bf8315413d.png)

This stops that from happening

