### PR TITLE
add box-shadow to image rather than link

### DIFF
--- a/catalogue/webapp/components/ImageCard/ImageCard.tsx
+++ b/catalogue/webapp/components/ImageCard/ImageCard.tsx
@@ -18,6 +18,16 @@ type Props = {
   onClick: (event: SyntheticEvent<HTMLAnchorElement>) => void;
 };
 
+const StyledLink = styled.a`
+  .is-keyboard &:focus {
+    box-shadow: none;
+
+    img {
+      box-shadow: ${props => props.theme.focusBoxShadow};
+    }
+  }
+`;
+
 const ImageWrap = styled(Space).attrs({
   h: { size: 'l', properties: ['margin-right'] },
   v: { size: 'l', properties: ['margin-bottom'] },
@@ -48,25 +58,25 @@ const ImageCard = ({ id, image, onClick, workId }: Props) => {
   const { isEnhanced } = useContext(AppContext);
 
   return (
-    <NextLink {...imageLink({ id, workId }, 'images_search_result')}>
-      <a
-        onClick={event => {
-          trackEvent({
-            category: 'ImageCard',
-            action: 'open ExpandedImage modal',
-            label: id,
-          });
+    <ImageWrap>
+      <NextLink {...imageLink({ id, workId }, 'images_search_result')} passHref>
+        <StyledLink
+          onClick={event => {
+            trackEvent({
+              category: 'ImageCard',
+              action: 'open ExpandedImage modal',
+              label: id,
+            });
 
-          onClick(event);
-        }}
-        id={id}
-        title={isEnhanced ? 'Open modal window' : undefined}
-      >
-        <ImageWrap>
-          <Image {...image} />
-        </ImageWrap>
-      </a>
-    </NextLink>
+            onClick(event);
+          }}
+          id={id}
+          title={isEnhanced ? 'Open modal window' : undefined}
+        >
+            <Image {...image} />
+        </StyledLink>
+      </NextLink>
+    </ImageWrap>
   );
 };
 


### PR DESCRIPTION
Fixes #6742

- adds focus box-shadow around entire image

Before:
![Screenshot 2021-07-08 at 17 00 13](https://user-images.githubusercontent.com/6051896/124954873-74e10500-e00e-11eb-86c6-060634ed75e5.png)

After:
![Screenshot 2021-07-08 at 17 00 21](https://user-images.githubusercontent.com/6051896/124954883-78748c00-e00e-11eb-85c8-406d59a1dbbd.png)

N.B the colour of the box shadow will be addressed in issue #6741
