### PR TITLE
make button labels uniquely descriptive

### DIFF
--- a/common/views/components/Tasl/Tasl.tsx
+++ b/common/views/components/Tasl/Tasl.tsx
@@ -188,7 +188,7 @@ const Tasl: FunctionComponent<Props> = ({
             extraClasses="icon--white"
           />
           <span className="visually-hidden">
-            {isActive ? 'hide image information' : 'show image information'}
+            {isActive ? `hide credit information for image '${title}'` : `show credit information for image '${title}'`}
           </span>
         </TaslIcon>
       </TaslButton>


### PR DESCRIPTION
References #6743

The accessibility issue is that the image information buttons all have duplicate text that don't really describe what they do.
<img width="964" alt="1" src="https://user-images.githubusercontent.com/6051896/125062470-52022f80-e0a6-11eb-828f-77ebc89ff52e.png">

The suggested solution in the accessibility report is to remove the buttons completely and always display the text below the image, which I'm uncomfortable doing without discussion with the wider team.

Until then, I've made the labels more descriptive and unique by using the image title.
