### PR TITLE
Remove sort_search import

### DIFF
--- a/common/styles/non-critical.scss
+++ b/common/styles/non-critical.scss
@@ -5,5 +5,4 @@ $is-next: false !default;
 @import 'utilities/all';
 
 // Non Critical
-@import 'components/sort_search';
 @import 'components/tabs';


### PR DESCRIPTION
`sort_search.scss` doesn't exist anymore.