### PR TITLE
Update to use new items API format

### DIFF
--- a/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
+++ b/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
@@ -91,10 +91,10 @@ const PhysicalItems: FunctionComponent<Props> = ({
 
   useEffect(() => {
     const addStatusToItems = async () => {
-      const work = await fetchWorkItems(workId);
-      if (!isCatalogueApiError(work)) {
+      const items = await fetchWorkItems(workId);
+      if (!isCatalogueApiError(items)) {
         const mergedItems = physicalItems.map(currentItem => {
-          const matchingItem = work.items?.find(
+          const matchingItem = items.results?.find(
             item => item.id === currentItem.id
           );
           return {

--- a/common/model/catalogue.ts
+++ b/common/model/catalogue.ts
@@ -36,15 +36,9 @@ export type Work = {
 };
 
 export type ItemsWork = {
-  id: string;
-  items: {
-    id: string;
-    status: {
-      id: string;
-      label: string;
-      type: string;
-    };
-  }[];
+  type: 'ItemsList';
+  totalResults: number;
+  results: Item<Location>[];
 };
 
 export type Holding = {


### PR DESCRIPTION
The items API endpoint has changed to return an `ItemsList` this change updates the `PhysicalItems` component to reflect that. 

This change is for folk who want to be able to update item access status for requesting.

Follows https://github.com/wellcomecollection/catalogue-api/pull/164