### PR TITLE
Login button

### DIFF
--- a/common/services/prismic/hardcoded-id.js
+++ b/common/services/prismic/hardcoded-id.js
@@ -37,6 +37,7 @@ export const prismicPageIds = {
   stories: 'YD_E-BAAACEAK5LX',
   aboutUs: 'Wuw2MSIAACtd3Stq',
   copyrightClearance: 'YGSEhxAAACgAXL4E',
+  register: 'X_2eexEAACQAZLBi',
 };
 
 export const getNameFromCollectionVenue = (id: string) => {

--- a/common/views/components/CataloguePageLayout/CataloguePageLayout.tsx
+++ b/common/views/components/CataloguePageLayout/CataloguePageLayout.tsx
@@ -1,7 +1,6 @@
 import { FunctionComponent, useEffect, useState } from 'react';
 import PageLayout, { Props as PageLayoutProps } from '../PageLayout/PageLayout';
 import InfoBanner from '../InfoBanner/InfoBanner';
-import SignIn from '../SignIn/SignIn';
 import { prefix } from '@weco/identity/src/utility/prefix';
 
 type Props = {
@@ -14,7 +13,6 @@ const CataloguePageLayout: FunctionComponent<Props> = ({
   ...props
 }: Props) => {
   const [isRedirectBannerVisible, setIsRedirectBannerVisible] = useState(false);
-  const { showLogin } = props.globalContextData.toggles;
   useEffect(() => {
     if (window.location.search.match('wellcomeImagesUrl')) {
       setIsRedirectBannerVisible(true);
@@ -38,7 +36,6 @@ const CataloguePageLayout: FunctionComponent<Props> = ({
                 cookieName="WC_wellcomeImagesRedirect"
               />
             )}
-            {showLogin && <SignIn />}
           </>
         )}
         {children}

--- a/common/views/components/Header/HeaderPrototype.tsx
+++ b/common/views/components/Header/HeaderPrototype.tsx
@@ -421,6 +421,10 @@ const Header: FunctionComponent<Props> = ({ siteSection }) => {
             </HeaderNav>
             <DesktopLogin>
               <DropdownButton
+                // FIXME: If we go with this approach, the DropdownButton should probably
+                // be able to take an optional icon
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
                 label={
                   <div className="flex flex--v-center">
                     <div style={{ transform: 'translateY(0.15em)' }}>

--- a/common/views/components/Header/HeaderPrototype.tsx
+++ b/common/views/components/Header/HeaderPrototype.tsx
@@ -1,0 +1,413 @@
+import { FunctionComponent, useState } from 'react';
+import { font, classNames } from '../../../utils/classnames';
+import WellcomeCollectionBlack from '../../../icons/wellcome_collection_black';
+import styled from 'styled-components';
+import { respondBetween, respondTo } from '@weco/common/views/themes/mixins';
+import DropdownButton from '@weco/common/views/components/DropdownButton/DropdownButton';
+import Icon from '@weco/common/views/components/Icon/Icon';
+import SignIn from '@weco/common/views/components/SignIn/SignIn';
+import Space from '@weco/common/views/components/styled/Space';
+
+const NavLoginWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  ${respondTo(
+    'headerMedium',
+    `
+    width: 100%;
+  `
+  )}
+`;
+
+const DesktopLogin = styled.div`
+  display: none;
+
+  ${respondTo(
+    'headerMedium',
+    `
+    display: block;
+  `
+  )}
+`;
+
+type WrapperProps = {
+  isBurgerOpen: boolean;
+  navHeight: number;
+};
+const Wrapper = styled.div.attrs({
+  className: classNames({
+    'grid bg-white': true,
+  }),
+})<WrapperProps>`
+  border-bottom: 1px solid ${props => props.theme.color('pumice')};
+
+  ${props =>
+    props.isBurgerOpen &&
+    `${respondBetween(
+      'small',
+      'headerMedium',
+      `
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      z-index: 10;
+    `
+    )}
+  `}
+  height: ${props => props.navHeight}px;
+`;
+
+const Burger = styled.div`
+  display: block;
+
+  ${respondTo(
+    'headerMedium',
+    `
+    display: none;
+  `
+  )}
+`;
+
+const BurgerTrigger = styled.a<{ isActive: boolean }>`
+  position: relative;
+  width: 1.2rem;
+  height: 0.9rem;
+  display: block;
+
+  // TODO: replace with svg-sprite icon
+  span {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: ${props => props.theme.color('black')};
+    transition: transform 400ms ease;
+    transform-origin: center center;
+
+    &:nth-child(2) {
+      top: 50%;
+    }
+
+    &:last-child {
+      top: 100%;
+    }
+
+    ${props =>
+      props.isActive &&
+      `
+        &:first-child {
+          top: 0.5rem;
+          transform: rotate(45deg);
+        }
+
+        &:nth-child(2) {
+          display: none;
+        }
+
+        &:last-child {
+          top: 0.5rem;
+          transform: rotate(-45deg);
+          bottom: auto;
+        }
+    `}
+  }
+`;
+
+const HeaderBrand = styled.div`
+  display: flex;
+  flex: 1;
+  // This is to account for the burger as we want it to be dead centre.
+  margin-left: -20px;
+
+  ${props => `
+    ${respondTo(
+      'headerMedium',
+      `
+      margin-left: 0;
+      flex: 0 0 auto;
+      margin-right: 1.5rem;
+      padding-right: 1.5rem;
+      border-right: 1px solid ${props.theme.color('pumice')};
+      width: auto;
+      display: block;
+    `
+    )}
+  `}
+
+  a {
+    margin: 0 auto;
+  }
+`;
+
+const HeaderNav = styled.nav<{ isActive: boolean }>`
+  display: ${props => (props.isActive ? 'block' : 'none')};
+  background: ${props => props.theme.color('white')};
+  position: absolute;
+  z-index: 1;
+  top: 100%;
+  left: 0;
+  right: 0;
+  padding-left: ${props =>
+    props.theme.grid.s.padding + props.theme.grid.s.gutter}px;
+  padding-right: ${props => props.theme.grid.s.padding}px;
+
+  ${props => `
+    ${respondBetween(
+      'small',
+      'headerMedium',
+      `
+      border-top: 1px solid ${props.theme.color('pumice')};
+      min-height: 100vh;
+    `
+    )}
+  `}
+
+
+  ${props => `
+    ${respondTo(
+      'medium',
+      `
+      padding-left: ${props.theme.grid.m.padding + props.theme.grid.m.gutter}px;
+      padding-right: ${props.theme.grid.m.padding}px;
+    `
+    )}
+  `}
+
+  ${respondTo(
+    'headerMedium',
+    `
+    position: static;
+    display: block;
+    margin-top: 0;
+    padding-left: 0;
+    padding-right: 0;
+  `
+  )}
+
+`;
+
+const HeaderList = styled.ul`
+  margin-left: -0.3rem;
+
+  ${respondTo(
+    'headerMedium',
+    `
+    display: flex;
+  `
+  )}
+`;
+
+const HeaderItem = styled.li`
+  border-bottom: 1px solid ${props => props.theme.color('pumice')};
+
+  // TODO: the vw units below are tightly coupled to the
+  // number of nav items and number of characters in them.
+  // This is a stop-gap ahead of nav design rework.
+
+  ${respondTo(
+    'headerMedium',
+    `
+    border-bottom: 0;
+    margin-right: 0.6vw;
+  `
+  )}
+
+  ${respondBetween(
+    'headerMedium',
+    'large',
+    `
+    font-size: 1.5vw;
+  `
+  )}
+
+  ${respondTo(
+    'xlarge',
+    `
+    margin-right: 1.4rem;
+  `
+  )}
+`;
+
+const HeaderLink = styled.a<{ isActive: boolean }>`
+  padding: 2rem 0.3rem;
+  display: inline-block;
+  text-decoration: none;
+  position: relative;
+  z-index: 1;
+  transition: color 400ms ease;
+
+  ${respondTo(
+    'headerMedium',
+    `
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+  `
+  )}
+
+  &:after {
+    content: '';
+    position: absolute;
+    bottom: 1.9rem;
+    height: 0.6rem;
+    left: 0;
+    width: 0;
+    background: ${props => props.theme.color('yellow')};
+    z-index: -1;
+    transition: width 200ms ease;
+
+    ${respondTo(
+      'headerMedium',
+      `
+      bottom: 0.9rem;
+    `
+    )}
+  }
+
+  &:hover,
+  &:focus {
+    &:after {
+      width: 100%;
+
+      // Prevent iOS double-tap link issue
+      // https://css-tricks.com/annoying-mobile-double-tap-link-issue/
+      @media (pointer: coarse) {
+        width: 0;
+      }
+    }
+  }
+
+  ${props =>
+    props.isActive &&
+    `
+    &:after {
+      width: 100%;
+    }
+  `}
+`;
+
+export const navHeight = 85;
+
+type Props = {
+  siteSection: string | null;
+};
+
+export const links = [
+  {
+    href: '/visit-us',
+    title: 'Visit us',
+    siteSection: 'visit-us',
+  },
+  {
+    href: '/whats-on',
+    title: "What's on",
+    siteSection: 'whats-on',
+  },
+  {
+    href: '/stories',
+    title: 'Stories',
+    siteSection: 'stories',
+  },
+  {
+    href: '/collections',
+    title: 'Collections',
+    siteSection: 'collections',
+  },
+  {
+    href: '/get-involved',
+    title: 'Get involved',
+    siteSection: 'get-involved',
+  },
+  {
+    href: '/about-us',
+    title: 'About us',
+    siteSection: 'about-us',
+  },
+];
+
+const Header: FunctionComponent<Props> = ({ siteSection }) => {
+  const [isActive, setIsActive] = useState(false);
+
+  return (
+    <Wrapper navHeight={navHeight} isBurgerOpen={isActive}>
+      <div
+        className="relative grid__cell"
+        style={{ paddingTop: '15px', paddingBottom: '15px' }}
+      >
+        <div className="flex flex--v-center container">
+          <Burger>
+            <BurgerTrigger
+              isActive={isActive}
+              href="#footer-nav-1"
+              id="header-burger-trigger"
+              aria-label="menu"
+              onClick={event => {
+                event.preventDefault();
+                setIsActive(!isActive);
+              }}
+            >
+              <span />
+              <span />
+              <span />
+            </BurgerTrigger>
+          </Burger>
+          <HeaderBrand>
+            <a href="/" className="header__brand-link">
+              <WellcomeCollectionBlack />
+            </a>
+          </HeaderBrand>
+          <NavLoginWrapper>
+            <HeaderNav
+              isActive={isActive}
+              id="header-nav"
+              aria-labelledby="header-burger-trigger"
+            >
+              <HeaderList
+                className={`plain-list ${font('wb', 5)} no-margin no-padding`}
+              >
+                {links.map((link, i) => (
+                  <HeaderItem key={i}>
+                    <HeaderLink
+                      isActive={link.siteSection === siteSection}
+                      href={link.href}
+                      {...(link.siteSection === siteSection
+                        ? { 'aria-current': true }
+                        : {})}
+                    >
+                      {link.title}
+                    </HeaderLink>
+                  </HeaderItem>
+                ))}
+              </HeaderList>
+            </HeaderNav>
+            <DesktopLogin>
+              <DropdownButton
+                label={
+                  <div className="flex flex--v-center">
+                    <div style={{ transform: 'translateY(0.15em)' }}>
+                      <Icon name={'user'} />
+                    </div>
+                    <Space
+                      h={{ size: 's', properties: ['margin-left'] }}
+                      className="is-hidden-s is-hidden-m is-hidden-l"
+                    >
+                      Library sign in
+                    </Space>
+                  </div>
+                }
+                isInline={true}
+              >
+                <SignIn />
+              </DropdownButton>
+            </DesktopLogin>
+          </NavLoginWrapper>
+        </div>
+      </div>
+    </Wrapper>
+  );
+};
+
+export default Header;

--- a/common/views/components/Header/HeaderPrototype.tsx
+++ b/common/views/components/Header/HeaderPrototype.tsx
@@ -21,8 +21,38 @@ const NavLoginWrapper = styled.div`
   )}
 `;
 
+const MobileLogin = styled.div`
+  ${respondTo(
+    'headerMedium',
+    `
+    display: none;
+  `
+  )}
+  display: flex;
+  margin-top: 10px;
+
+  a {
+    position: relative;
+
+    &:first-child {
+      margin-right: 10px;
+      padding-right: 10px;
+
+      &:after {
+        position: absolute;
+        right: 0;
+        content: '|';
+      }
+    }
+  }
+`;
+
 const DesktopLogin = styled.div`
   display: none;
+
+  a {
+    display: block;
+  }
 
   ${respondTo(
     'headerMedium',
@@ -161,7 +191,8 @@ const HeaderNav = styled.nav<{ isActive: boolean }>`
       'headerMedium',
       `
       border-top: 1px solid ${props.theme.color('pumice')};
-      min-height: 100vh;
+      height: calc(100vh - 84px);
+      overflow: auto;
     `
     )}
   `}
@@ -233,7 +264,7 @@ const HeaderItem = styled.li`
 `;
 
 const HeaderLink = styled.a<{ isActive: boolean }>`
-  padding: 2rem 0.3rem;
+  padding: 1.4rem 0.3rem;
   display: inline-block;
   text-decoration: none;
   position: relative;
@@ -243,7 +274,6 @@ const HeaderLink = styled.a<{ isActive: boolean }>`
   ${respondTo(
     'headerMedium',
     `
-    padding-top: 1rem;
     padding-bottom: 1rem;
   `
   )}
@@ -251,7 +281,7 @@ const HeaderLink = styled.a<{ isActive: boolean }>`
   &:after {
     content: '';
     position: absolute;
-    bottom: 1.9rem;
+    bottom: 1.3rem;
     height: 0.6rem;
     left: 0;
     width: 0;
@@ -381,6 +411,12 @@ const Header: FunctionComponent<Props> = ({ siteSection }) => {
                     </HeaderLink>
                   </HeaderItem>
                 ))}
+                <MobileLogin>
+                  <Space h={{ size: 's', properties: ['margin-right'] }}>
+                    <Icon name={'user'} />
+                  </Space>
+                  <SignIn />
+                </MobileLogin>
               </HeaderList>
             </HeaderNav>
             <DesktopLogin>

--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -5,6 +5,7 @@ import Head from 'next/head';
 import convertUrlToString from '../../../utils/convert-url-to-string';
 // $FlowFixMe (tsx)
 import Header from '../Header/Header';
+import HeaderPrototype from '../Header/HeaderPrototype';
 import InfoBanner from '../InfoBanner/InfoBanner';
 import CookieNotice from '../CookieNotice/CookieNotice';
 import NewsletterPromo from '../NewsletterPromo/NewsletterPromo';
@@ -69,7 +70,7 @@ const PageLayoutComponent: FunctionComponent<ComponentProps> = ({
   hideFooter = false,
   excludeRoleMain = false,
 }: ComponentProps) => {
-  const { apiToolbar } = useContext(TogglesContext);
+  const { apiToolbar, showLogin } = useContext(TogglesContext);
   const urlString = convertUrlToString(url);
   const fullTitle =
     title !== ''
@@ -233,7 +234,11 @@ const PageLayoutComponent: FunctionComponent<ComponentProps> = ({
         <a className="visually-hidden visually-hidden-focusable" href="#main">
           Skip to main content
         </a>
-        <Header siteSection={siteSection} />
+        {showLogin ? (
+          <HeaderPrototype siteSection={siteSection} />
+        ) : (
+          <Header siteSection={siteSection} />
+        )}
         {globalAlert &&
           globalAlert.isShown === 'show' &&
           (!globalAlert.routeRegex ||

--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -3,7 +3,6 @@ import { Url } from '../../../model/link-props';
 import { JsonLdObj } from '../JsonLd/JsonLd';
 import Head from 'next/head';
 import convertUrlToString from '../../../utils/convert-url-to-string';
-// $FlowFixMe (tsx)
 import Header from '../Header/Header';
 import HeaderPrototype from '../Header/HeaderPrototype';
 import InfoBanner from '../InfoBanner/InfoBanner';

--- a/common/views/components/PageLayoutDeprecated/PageLayoutDeprecated.js
+++ b/common/views/components/PageLayoutDeprecated/PageLayoutDeprecated.js
@@ -8,6 +8,7 @@ import Head from 'next/head';
 import convertUrlToString from '../../../utils/convert-url-to-string';
 // $FlowFixMe (tsx)
 import Header from '../Header/Header';
+import HeaderPrototype from '../Header/HeaderPrototype';
 // $FlowFixMe (tsx)
 import InfoBanner from '../InfoBanner/InfoBanner';
 // $FlowFixMe(tsx)
@@ -26,8 +27,6 @@ import OpeningTimesContext from '../OpeningTimesContext/OpeningTimesContext';
 import Space from '../styled/Space';
 // $FlowFixMe (tsx)
 import GlobalInfoBarContext from '../GlobalInfoBarContext/GlobalInfoBarContext';
-// $FlowFixMe (tsx)
-import SignIn from '../SignIn/SignIn';
 // $FlowFixMe (tsx)
 import TogglesContext from '../TogglesContext/TogglesContext';
 import { prismicPageIds } from '../../../services/prismic/hardcoded-id';
@@ -151,10 +150,11 @@ const PageLayout = ({
         <a className="visually-hidden visually-hidden-focusable" href="#main">
           Skip to main content
         </a>
-        <Header siteSection={siteSection} />
-        {showLogin &&
-          url.pathname &&
-          url.pathname.match(prismicPageIds.collections) && <SignIn />}
+        {showLogin ? (
+          <HeaderPrototype siteSection={siteSection} />
+        ) : (
+          <Header siteSection={siteSection} />
+        )}
         <GlobalAlertContext.Consumer>
           {globalAlert =>
             globalAlert &&

--- a/common/views/components/PageLayoutDeprecated/PageLayoutDeprecated.js
+++ b/common/views/components/PageLayoutDeprecated/PageLayoutDeprecated.js
@@ -8,6 +8,7 @@ import Head from 'next/head';
 import convertUrlToString from '../../../utils/convert-url-to-string';
 // $FlowFixMe (tsx)
 import Header from '../Header/Header';
+// $FlowFixMe (tsx)
 import HeaderPrototype from '../Header/HeaderPrototype';
 // $FlowFixMe (tsx)
 import InfoBanner from '../InfoBanner/InfoBanner';

--- a/common/views/components/SignIn/SignIn.tsx
+++ b/common/views/components/SignIn/SignIn.tsx
@@ -1,55 +1,46 @@
 import { FunctionComponent } from 'react';
+import { prismicPageIds } from '@weco/common/services/prismic/hardcoded-id';
+import styled from 'styled-components';
+import { font, classNames } from '@weco/common/utils/classnames';
 import {
   useUserInfo,
   withUserInfo,
 } from '@weco/identity/src/frontend/MyAccount/UserInfoContext';
-import { useRouter } from 'next/router';
-import { font } from '../../../utils/classnames';
-import Space from '../styled/Space';
-import Layout12 from '../Layout12/Layout12';
-import styled from 'styled-components';
 
-const SignInContainer = styled.div`
-  display: flex;
-`;
-
-const StyledSignIn = styled(Space).attrs({
-  className: font('hnm', 5),
-  h: {
-    size: 'l',
-    properties: ['padding-right', 'padding-left'],
-  },
-  v: {
-    size: 'm',
-    properties: ['padding-top', 'padding-bottom'],
-  }
-})`
-  margin-left: auto;
-  background: ${props => props.theme.color('smoke')};
-`;
+const AccountLink = styled.a.attrs({
+  className: classNames({
+    block: true,
+    [font('hnr', 5)]: true,
+  }),
+})``;
 
 const SignIn: FunctionComponent = () => {
   const { user } = useUserInfo();
-  return  (
-    <Layout12>
-      <SignInContainer>
-        <StyledSignIn>
-          {!user && (
-            <>
-              <a href="/account">Library account sign in</a> |{' '}
-              <a href="/pages/X_2eexEAACQAZLBi">Register</a>
-            </>
-          )}
-          {user && (
-            <>
-              <a href="/account">My library account</a> |{' '}
-              <a href="/account/logout">Sign out</a>
-            </>
-          )}
-        </StyledSignIn>
-      </SignInContainer>
-    </Layout12>
-  )
+  return (
+    <>
+      {!user && (
+        <>
+          <AccountLink href="/account">Sign in to library account</AccountLink>
+          <AccountLink
+            className="block"
+            href={`/pages/${prismicPageIds.register}`}
+          >
+            Register
+          </AccountLink>
+        </>
+      )}
+      {user && (
+        <>
+          <AccountLink className="block" href="/account">
+            My library account
+          </AccountLink>
+          <AccountLink className="block" href="/account/logout">
+            Sign out
+          </AccountLink>
+        </>
+      )}
+    </>
+  );
 };
 
 export default withUserInfo(SignIn);

--- a/common/views/components/SignIn/SignIn.tsx
+++ b/common/views/components/SignIn/SignIn.tsx
@@ -1,45 +1,32 @@
 import { FunctionComponent } from 'react';
 import { prismicPageIds } from '@weco/common/services/prismic/hardcoded-id';
-import styled from 'styled-components';
 import { font, classNames } from '@weco/common/utils/classnames';
 import {
   useUserInfo,
   withUserInfo,
 } from '@weco/identity/src/frontend/MyAccount/UserInfoContext';
 
-const AccountLink = styled.a.attrs({
-  className: classNames({
-    block: true,
-    [font('hnr', 5)]: true,
-  }),
-})``;
-
 const SignIn: FunctionComponent = () => {
   const { user } = useUserInfo();
   return (
-    <>
+    <div
+      className={classNames({
+        [font('hnr', 5)]: true,
+      })}
+    >
       {!user && (
         <>
-          <AccountLink href="/account">Sign in to library account</AccountLink>
-          <AccountLink
-            className="block"
-            href={`/pages/${prismicPageIds.register}`}
-          >
-            Register
-          </AccountLink>
+          <a href="/account">Sign in to library account</a>
+          <a href={`/pages/${prismicPageIds.register}`}>Register</a>
         </>
       )}
       {user && (
         <>
-          <AccountLink className="block" href="/account">
-            My library account
-          </AccountLink>
-          <AccountLink className="block" href="/account/logout">
-            Sign out
-          </AccountLink>
+          <a href="/account">My library account</a>
+          <a href="/account/logout">Sign out</a>
         </>
       )}
-    </>
+    </div>
   );
 };
 

--- a/identity/webapp/src/frontend/components/PageWrapper.tsx
+++ b/identity/webapp/src/frontend/components/PageWrapper.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import Header from '@weco/common/views/components/Header/Header';
+import HeaderPrototype from '@weco/common/views/components/Header/HeaderPrototype';
 
 export const PageWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   return (
     <>
-      <Header siteSection="collections" />
+      <HeaderPrototype siteSection="collections" />
       <div>{children}</div>
     </>
   );


### PR DESCRIPTION
## Who is this for?
People who want to sign into their library account

## What is it doing for them?
Moving the login to a consistent location in the header

I duped the `Header` component to create `HeaderPrototype` with the required amends to make this work, so that the amount of toggle logic could be kept to a minimum. Since the Header isn't likely to undergo much if any change while we figure this out, this felt like the right way to go.

Behind the `showLogin` toggle.

__Big__
<img width="1269" alt="Screenshot 2021-07-14 at 14 48 29" src="https://user-images.githubusercontent.com/1394592/125633513-b78a2d4a-520e-4a7b-81ba-b3833563e506.png">

__Medium__
<img width="840" alt="Screenshot 2021-07-14 at 14 48 46" src="https://user-images.githubusercontent.com/1394592/125633540-6dd052a0-675a-4a12-9235-c1493f3d29e2.png">


__Small__
<img width="570" alt="Screenshot 2021-07-14 at 14 49 13" src="https://user-images.githubusercontent.com/1394592/125633578-899a8348-ee56-4dd9-8132-dee74ec4e69f.png">
