### PR TITLE
change link display property, so focus border aligns nicely

### DIFF
--- a/common/views/components/Header/Header.tsx
+++ b/common/views/components/Header/Header.tsx
@@ -111,6 +111,7 @@ const HeaderBrand = styled.div`
   `}
 
   a {
+    display: inline-block;
     margin: 0 auto;
   }
 `;
@@ -335,7 +336,7 @@ const Header: FunctionComponent<Props> = ({ siteSection }) => {
             </BurgerTrigger>
           </Burger>
           <HeaderBrand>
-            <a href="/" className="header__brand-link">
+            <a href="/">
               <WellcomeCollectionBlack />
             </a>
           </HeaderBrand>

--- a/common/views/components/Header/HeaderPrototype.tsx
+++ b/common/views/components/Header/HeaderPrototype.tsx
@@ -169,6 +169,7 @@ const HeaderBrand = styled.div`
   `}
 
   a {
+    display: inline-block;
     margin: 0 auto;
   }
 `;
@@ -385,7 +386,7 @@ const Header: FunctionComponent<Props> = ({ siteSection }) => {
             </BurgerTrigger>
           </Burger>
           <HeaderBrand>
-            <a href="/" className="header__brand-link">
+            <a href="/">
               <WellcomeCollectionBlack />
             </a>
           </HeaderBrand>


### PR DESCRIPTION
Before:
<img width="247" alt="Screenshot 2021-07-14 at 16 51 07" src="https://user-images.githubusercontent.com/6051896/125661836-2c914f13-61a2-4a53-a961-f0b0deedb927.png">

After:
<img width="289" alt="Screenshot 2021-07-14 at 17 46 07" src="https://user-images.githubusercontent.com/6051896/125661847-1ee78434-c47f-4bb0-8b3a-a1746bd2679a.png">

