### PR TITLE
Load webfont in identity app

### DIFF
--- a/cardigan/config/decorators.tsx
+++ b/cardigan/config/decorators.tsx
@@ -2,6 +2,7 @@ import { ReactNode, FunctionComponent } from 'react';
 import { ThemeProvider } from 'styled-components';
 import theme, { GlobalStyle } from '@weco/common/views/themes/default';
 import { AppContextProvider } from '@weco/common/views/components/AppContext/AppContext';
+import useIsFontsLoaded from '@weco/common/hooks/useIsFontsLoaded';
 
 type Props = {
   children: ReactNode;
@@ -9,7 +10,7 @@ type Props = {
 export const ContextDecorator: FunctionComponent<Props> = ({ children }) => {
   return (
     <ThemeProvider theme={theme}>
-      <GlobalStyle />
+      <GlobalStyle isFontsLoaded={useIsFontsLoaded()} />
       <AppContextProvider>
         <div className="enhanced">{children}</div>
       </AppContextProvider>

--- a/common/hooks/useIsFontsLoaded.ts
+++ b/common/hooks/useIsFontsLoaded.ts
@@ -1,6 +1,7 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
-const useIsFontsLoaded = (): void => {
+const useIsFontsLoaded = (): boolean => {
+  const [isFontsLoaded, setIsFontsLoaded] = useState(false);
   useEffect(() => {
     // This needs to be dynamically required as it's only on the client-side
     /* eslint-disable @typescript-eslint/no-var-requires */
@@ -14,12 +15,12 @@ const useIsFontsLoaded = (): void => {
 
     Promise.all([WB.load(), HNR.load(), HNB.load(), LR.load()])
       .then(() => {
-        if (document.documentElement) {
-          document.documentElement.classList.add('fonts-loaded');
-        }
+        setIsFontsLoaded(true);
       })
       .catch(console.log);
   }, []);
+
+  return isFontsLoaded;
 };
 
 export default useIsFontsLoaded;

--- a/common/hooks/useIsFontsLoaded.ts
+++ b/common/hooks/useIsFontsLoaded.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+
+const useIsFontsLoaded = (): void => {
+  useEffect(() => {
+    // This needs to be dynamically required as it's only on the client-side
+    /* eslint-disable @typescript-eslint/no-var-requires */
+    const FontFaceObserver = require('fontfaceobserver');
+    /* eslint-enable @typescript-eslint/no-var-requires */
+
+    const WB = new FontFaceObserver('Wellcome Bold Web', { weight: 'bold' });
+    const HNR = new FontFaceObserver('Helvetica Neue Roman Web');
+    const HNB = new FontFaceObserver('Helvetica Neue Bold Web');
+    const LR = new FontFaceObserver('Lettera Regular Web');
+
+    Promise.all([WB.load(), HNR.load(), HNB.load(), LR.load()])
+      .then(() => {
+        if (document.documentElement) {
+          document.documentElement.classList.add('fonts-loaded');
+        }
+      })
+      .catch(console.log);
+  }, []);
+};
+
+export default useIsFontsLoaded;

--- a/common/views/components/styled/AlignFont.tsx
+++ b/common/views/components/styled/AlignFont.tsx
@@ -1,20 +1,27 @@
 import { FunctionComponent, ReactNode } from 'react';
 import styled from 'styled-components';
+import useIsFontsLoaded from '@weco/common/hooks/useIsFontsLoaded';
 
 type Props = {
   className?: string;
   children: ReactNode;
 };
 
-const Align = styled.span`
-  .fonts-loaded & {
-    transform: translateY(-${props => props.theme.fontVerticalOffset});
+const Align = styled.span<{ isActive: boolean }>`
+  ${props =>
+    props.isActive &&
+    `
+    transform: translateY(-${props.theme.fontVerticalOffset});
     display: inline-block;
-  }
+  `}
 `;
 
 const AlignFont: FunctionComponent<Props> = ({ children, className }) => {
-  return <Align className={className}>{children}</Align>;
+  return (
+    <Align className={className} isActive={useIsFontsLoaded()}>
+      {children}
+    </Align>
+  );
 };
 
 export default AlignFont;

--- a/common/views/pages/_app-deprecated.js
+++ b/common/views/pages/_app-deprecated.js
@@ -36,6 +36,7 @@ import { GlobalInfoBarContextProvider } from '../components/GlobalInfoBarContext
 
 type State = {|
   togglesContext: {},
+  isFontsLoaded: boolean,
 |};
 
 const isServer = typeof window === 'undefined';
@@ -206,6 +207,7 @@ export default class WecoApp extends App {
 
   state: State = {
     togglesContext: toggles,
+    isFontsLoaded: false,
   };
 
   componentWillUnmount() {
@@ -285,9 +287,7 @@ export default class WecoApp extends App {
 
     Promise.all([WB.load(), HNR.load(), HNB.load(), LR.load()])
       .then(() => {
-        if (document.documentElement) {
-          document.documentElement.classList.add('fonts-loaded');
-        }
+        this.setState({ isFontsLoaded: true });
       })
       .catch(console.log);
 
@@ -369,7 +369,7 @@ export default class WecoApp extends App {
   }
 
   render() {
-    const { togglesContext } = this.state;
+    const { togglesContext, isFontsLoaded } = this.state;
     const {
       Component,
       pageProps,
@@ -476,7 +476,10 @@ export default class WecoApp extends App {
                 <GlobalAlertContext.Provider value={globalAlert}>
                   <PopupDialogContext.Provider value={popupDialog}>
                     <ThemeProvider theme={theme}>
-                      <GlobalStyle toggles={toggles} />
+                      <GlobalStyle
+                        toggles={toggles}
+                        isFontsLoaded={isFontsLoaded}
+                      />
                       <OutboundLinkTracker>
                         <Fragment>
                           <LoadingIndicator />

--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -217,9 +217,6 @@ const WecoApp: FunctionComponent<WecoAppProps> = ({
     lazysizes.init();
   }, []);
 
-  // fonts
-  useIsFontsLoaded();
-
   // prismic warnings
   // TODO: This should be componentized
   useEffect(() => {
@@ -297,7 +294,10 @@ const WecoApp: FunctionComponent<WecoAppProps> = ({
     <>
       <AppContextProvider>
         <ThemeProvider theme={theme}>
-          <GlobalStyle toggles={globalContextData.toggles} />
+          <GlobalStyle
+            toggles={globalContextData.toggles}
+            isFontsLoaded={useIsFontsLoaded()}
+          />
           <OutboundLinkTracker>
             <LoadingIndicator />
             {!pageProps.err && <Component {...pageProps} />}

--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -16,6 +16,7 @@ import {
 } from '../components/GlobalContextProvider/GlobalContextProvider';
 import { GetServerSidePropsContext } from 'next';
 import { trackPageview } from '../../services/conversion/track';
+import useIsFontsLoaded from '../../hooks/useIsFontsLoaded';
 
 declare global {
   interface Window {
@@ -217,25 +218,7 @@ const WecoApp: FunctionComponent<WecoAppProps> = ({
   }, []);
 
   // fonts
-  useEffect(() => {
-    // This needs to be dynamically required as it's only on the client-side
-    /* eslint-disable @typescript-eslint/no-var-requires */
-    const FontFaceObserver = require('fontfaceobserver');
-    /* eslint-enable @typescript-eslint/no-var-requires */
-
-    const WB = new FontFaceObserver('Wellcome Bold Web', { weight: 'bold' });
-    const HNR = new FontFaceObserver('Helvetica Neue Roman Web');
-    const HNB = new FontFaceObserver('Helvetica Neue Bold Web');
-    const LR = new FontFaceObserver('Lettera Regular Web');
-
-    Promise.all([WB.load(), HNR.load(), HNB.load(), LR.load()])
-      .then(() => {
-        if (document.documentElement) {
-          document.documentElement.classList.add('fonts-loaded');
-        }
-      })
-      .catch(console.log);
-  }, []);
+  useIsFontsLoaded();
 
   // prismic warnings
   // TODO: This should be componentized

--- a/common/views/themes/default.ts
+++ b/common/views/themes/default.ts
@@ -116,6 +116,7 @@ const cls = ({
 
 export type GlobalStyleProps = {
   toggles?: { [key: string]: boolean };
+  isFontsLoaded?: boolean;
 };
 
 const GlobalStyle = createGlobalStyle<GlobalStyleProps>`

--- a/common/views/themes/typography.ts
+++ b/common/views/themes/typography.ts
@@ -90,37 +90,23 @@ export const typography = css<GlobalStyleProps>`
     font-weight: normal;
   }
 
-  .font-hnb {
-    ${fontFamilyMixin('hnb', false)};
-
-    .fonts-loaded & {
-      ${fontFamilyMixin('hnb', true)};
+  ${props => `
+    .font-hnb {
+      ${fontFamilyMixin('hnb', !!props.isFontsLoaded)};
     }
-  }
 
-  .font-hnr {
-    ${fontFamilyMixin('hnr', false)};
-
-    .fonts-loaded & {
-      ${fontFamilyMixin('hnr', true)}
+    .font-hhr {
+      ${fontFamilyMixin('hnr', !!props.isFontsLoaded)};
     }
-  }
 
-  .font-wb {
-    ${fontFamilyMixin('wb', false)};
-
-    .fonts-loaded & {
-      ${fontFamilyMixin('wb', true)}
+    .font-wb {
+      ${fontFamilyMixin('wb', !!props.isFontsLoaded)};
     }
-  }
 
-  .font-lr {
-    ${fontFamilyMixin('lr', false)};
-
-    .fonts-loaded & {
-      ${fontFamilyMixin('lr', true)}
+    .font-lr {
+      ${fontFamilyMixin('lr', !!props.isFontsLoaded)};
     }
-  }
+  `}
 
   html {
     font-size: 100%;

--- a/common/views/themes/typography.ts
+++ b/common/views/themes/typography.ts
@@ -95,7 +95,7 @@ export const typography = css<GlobalStyleProps>`
       ${fontFamilyMixin('hnb', !!props.isFontsLoaded)};
     }
 
-    .font-hhr {
+    .font-hnr {
       ${fontFamilyMixin('hnr', !!props.isFontsLoaded)};
     }
 

--- a/identity/webapp/.storybook/preview.js
+++ b/identity/webapp/.storybook/preview.js
@@ -4,6 +4,7 @@ import { withKnobs } from '@storybook/addon-knobs';
 import { AppContextProvider } from '@weco/common/views/components/AppContext/AppContext';
 import { ThemeProvider } from 'styled-components';
 import theme, { GlobalStyle } from '@weco/common/views/themes/default';
+import useIsFontsLoaded from '@weco/common/hooks/useIsFontsLoaded';
 
 addDecorator(withKnobs);
 
@@ -12,7 +13,7 @@ const CenterDecorator = (storyFn, { parameters }) => {
 
   return (
     <ThemeProvider theme={theme}>
-      <GlobalStyle />
+      <GlobalStyle isFontsLoaded={useIsFontsLoaded()} />
       <AppContextProvider>{story}</AppContextProvider>
     </ThemeProvider>
   );

--- a/identity/webapp/src/frontend/MyAccount/MyAccount.style.ts
+++ b/identity/webapp/src/frontend/MyAccount/MyAccount.style.ts
@@ -23,7 +23,7 @@ export const DetailWrapper = styled.dl`
   text-overflow: ellipsis;
 `;
 
-export const DetailLabel = styled.dt.attrs({ className: 'font-hnr fonts-loaded font-size-4' })`
+export const DetailLabel = styled.dt.attrs({ className: 'font-hnr font-size-4' })`
   display: block;
   font-weight: bold;
 `;
@@ -103,7 +103,7 @@ export const Section = styled.section`
   }
 `;
 
-export const SectionHeading = styled.h2.attrs({ className: 'font-hnr fonts-loaded font-size-3' })`
+export const SectionHeading = styled.h2.attrs({ className: 'font-hnr font-size-3' })`
   font-weight: bold;
   margin: 0;
 `;

--- a/identity/webapp/src/frontend/components/Form.style.ts
+++ b/identity/webapp/src/frontend/components/Form.style.ts
@@ -6,7 +6,7 @@ export const FieldMargin = styled.div`
   margin-bottom: 1em;
 `;
 
-export const Label = styled.label.attrs({ className: 'font-hnr fonts-loaded font-size-4' })`
+export const Label = styled.label.attrs({ className: 'font-hnr font-size-4' })`
   display: block;
   font-weight: bold;
 `;

--- a/identity/webapp/src/frontend/components/PageWrapper.tsx
+++ b/identity/webapp/src/frontend/components/PageWrapper.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import HeaderPrototype from '@weco/common/views/components/Header/HeaderPrototype';
+import { GlobalStyle } from '@weco/common/views/themes/default';
 import useIsFontsLoaded from '@weco/common/hooks/useIsFontsLoaded';
 
 export const PageWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  useIsFontsLoaded();
-
   return (
     <>
+      <GlobalStyle isFontsLoaded={useIsFontsLoaded()} />
       <HeaderPrototype siteSection="collections" />
       <div>{children}</div>
     </>

--- a/identity/webapp/src/frontend/components/PageWrapper.tsx
+++ b/identity/webapp/src/frontend/components/PageWrapper.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import HeaderPrototype from '@weco/common/views/components/Header/HeaderPrototype';
+import useIsFontsLoaded from '@weco/common/hooks/useIsFontsLoaded';
 
 export const PageWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  useIsFontsLoaded();
+
   return (
     <>
       <HeaderPrototype siteSection="collections" />

--- a/identity/webapp/src/frontend/index.tsx
+++ b/identity/webapp/src/frontend/index.tsx
@@ -3,7 +3,7 @@ import { render } from 'react-dom';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
 import { ThemeProvider, createGlobalStyle } from 'styled-components';
 import { AppContextProvider } from '@weco/common/views/components/AppContext/AppContext';
-import theme, { GlobalStyle } from '@weco/common/views/themes/default';
+import theme from '@weco/common/views/themes/default';
 import { initaliseMiddlewareClient } from '../utility/middleware-api-client';
 import { Registration } from './Registration/Registration';
 import { AccountValidated } from './Registration/AccountValidated';
@@ -28,7 +28,6 @@ if (root) {
   initaliseMiddlewareClient(prefix);
   render(
     <ThemeProvider theme={theme}>
-      <GlobalStyle />
       <PageBackground />
       <AppContextProvider>
         <BrowserRouter basename={prefix || ''} forceRefresh>


### PR DESCRIPTION
☝️ 

~It would have been nicer for this hook to set e.g. an `isFontsLoaded` boolean that we could use in the typography styles now that they're styled-components, but the `_app-deprecated.js` is a class component.~ Realised this wouldn't be too much to add for the `_app-deprecated.js`.