### PR TITLE
Seasons aspect ratio

### DIFF
--- a/common/views/components/FeaturedCard/FeaturedCard.js
+++ b/common/views/components/FeaturedCard/FeaturedCard.js
@@ -233,7 +233,7 @@ const FeaturedCardRight = styled.div.attrs({
   padding-left: ${props => (props.isReversed ? 0 : props.theme.gutter.small)}px;
   padding-right: ${props =>
     props.isReversed ? props.theme.gutter.small : 0}px;
-  transform: translateY(-26px);
+  transform: translateY(-28px); // Height of a label (font size + padding)
   width: 100%;
   height: 100%;
   min-height: 200px;

--- a/common/views/components/SimpleCardGrid/SimpleCardGrid.js
+++ b/common/views/components/SimpleCardGrid/SimpleCardGrid.js
@@ -24,7 +24,7 @@ const CardGridFeaturedCard = ({ item }: CardGridFeaturedCardProps) => (
     <FeaturedCard
       id={`featured-card`}
       image={{
-        ...item.image,
+        ...item.image.crops['16:9'],
         alt: '',
         sizesQueries:
           '(min-width: 1420px) 698px, (min-width: 960px) 50.23vw, (min-width: 600px) calc(100vw - 84px), 100vw',

--- a/common/views/components/SimpleCardGrid/SimpleCardGrid.js
+++ b/common/views/components/SimpleCardGrid/SimpleCardGrid.js
@@ -30,7 +30,17 @@ const CardGridFeaturedCard = ({ item }: CardGridFeaturedCardProps) => (
           '(min-width: 1420px) 698px, (min-width: 960px) 50.23vw, (min-width: 600px) calc(100vw - 84px), 100vw',
         showTasl: false,
       }}
-      labels={item.format ? [{ text: item.format.title }] : []}
+      labels={
+        item.format
+          ? [
+              {
+                text: item.format.title,
+                labelColor:
+                  item.format.title === 'Season' ? 'orange' : undefined,
+              },
+            ]
+          : []
+      }
       link={{
         url: item.link || '',
         text: item.title || '',

--- a/common/views/components/SimpleCardGrid/SimpleCardGrid.js
+++ b/common/views/components/SimpleCardGrid/SimpleCardGrid.js
@@ -19,42 +19,46 @@ type CardGridFeaturedCardProps = {|
   item: CardType,
 |};
 
-const CardGridFeaturedCard = ({ item }: CardGridFeaturedCardProps) => (
-  <Layout12>
-    <FeaturedCard
-      id={`featured-card`}
-      image={{
-        ...item.image.crops['16:9'],
-        alt: '',
-        sizesQueries:
-          '(min-width: 1420px) 698px, (min-width: 960px) 50.23vw, (min-width: 600px) calc(100vw - 84px), 100vw',
-        showTasl: false,
-      }}
-      labels={
-        item.format
-          ? [
-              {
-                text: item.format.title,
-                labelColor:
-                  item.format.title === 'Season' ? 'orange' : undefined,
-              },
-            ]
-          : []
-      }
-      link={{
-        url: item.link || '',
-        text: item.title || '',
-      }}
-      background="charcoal"
-      color="white"
-    >
-      {item.title && <h2 className="font-wb font-size-2">{item.title}</h2>}
-      {item.description && (
-        <p className="font-hnr font-size-5">{item.description}</p>
-      )}
-    </FeaturedCard>
-  </Layout12>
-);
+const CardGridFeaturedCard = ({ item }: CardGridFeaturedCardProps) => {
+  const image = item.image ? item.image.crops['16:9'] : {};
+
+  return (
+    <Layout12>
+      <FeaturedCard
+        id={`featured-card`}
+        image={{
+          ...image,
+          alt: '',
+          sizesQueries:
+            '(min-width: 1420px) 698px, (min-width: 960px) 50.23vw, (min-width: 600px) calc(100vw - 84px), 100vw',
+          showTasl: false,
+        }}
+        labels={
+          item.format
+            ? [
+                {
+                  text: item.format.title,
+                  labelColor:
+                    item.format.title === 'Season' ? 'orange' : undefined,
+                },
+              ]
+            : []
+        }
+        link={{
+          url: item.link || '',
+          text: item.title || '',
+        }}
+        background="charcoal"
+        color="white"
+      >
+        {item.title && <h2 className="font-wb font-size-2">{item.title}</h2>}
+        {item.description && (
+          <p className="font-hnr font-size-5">{item.description}</p>
+        )}
+      </FeaturedCard>
+    </Layout12>
+  );
+};
 
 const CardGrid = ({ items, isFeaturedFirst }: Props) => {
   const cards = items.filter(item => item.type === 'card');


### PR DESCRIPTION
- Fixing FeaturedCard image aspect ratio to be 16:9
- Shifting label up to prevent gap at tablet size (because labels have changed size recently)
- Making label orange when it's a Season

![image](https://user-images.githubusercontent.com/1394592/126480201-dcfdba25-68af-4dbf-90d1-2f4d68c06b6f.png)
