### PR TITLE
Physical items layout

### DIFF
--- a/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
+++ b/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
@@ -42,7 +42,7 @@ const Color = styled(Space).attrs({
   width: 1em;
   height: 1em;
   display: inline-flex;
-  background: ${props => props.theme.color(props.color)};
+  background: ${props => props.color};
 `;
 
 export type Props = {

--- a/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
+++ b/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
@@ -11,10 +11,12 @@ const Wrapper = styled.div`
 
 const Row = styled(Space).attrs({
   v: { size: 'm', properties: ['margin-bottom'] },
-})`
+})``;
+
+const Grid = styled.div`
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(180px, min-content));
-  grid-column-gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(100px, max-content));
+  grid-column-gap: 30px;
 `;
 
 const DetailHeading = styled.h3.attrs({
@@ -42,6 +44,7 @@ const Color = styled(Space).attrs({
   width: 1em;
   height: 1em;
   display: inline-flex;
+  transform: translateY(0.1em);
   background: ${props => props.color};
 `;
 
@@ -66,27 +69,33 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
 }) => {
   return (
     <Wrapper>
+      {(title || itemNote) && (
+        <Row>
+          <Box>
+            <DetailHeading>{title}</DetailHeading>
+            {itemNote && (
+              <span dangerouslySetInnerHTML={{ __html: itemNote }} />
+            )}
+          </Box>
+        </Row>
+      )}
       <Row>
-        <Box>
-          <DetailHeading>{title}</DetailHeading>
-          {itemNote && <span dangerouslySetInnerHTML={{ __html: itemNote }} />}
-        </Box>
-      </Row>
-      <Row>
-        <Box>
-          <DetailHeading>Location</DetailHeading>
-          <span>{locationAndShelfmark}</span>
-          {color && <Color color={color} />}
-        </Box>
-        <Box>
-          <DetailHeading>Access</DetailHeading>
-          {accessMethod && <span>{accessMethod}</span>}
-        </Box>
-        <Box isCentered>
-          {requestItemUrl && (
-            <ButtonInlineLink text={'Request item'} link={requestItemUrl} />
-          )}
-        </Box>
+        <Grid>
+          <Box>
+            <DetailHeading>Location</DetailHeading>
+            <span>{locationAndShelfmark}</span>
+            {color && <Color color={color} />}
+          </Box>
+          <Box>
+            <DetailHeading>Access</DetailHeading>
+            {accessMethod && <span>{accessMethod}</span>}
+          </Box>
+          <Box isCentered>
+            {requestItemUrl && (
+              <ButtonInlineLink text={'Request item'} link={requestItemUrl} />
+            )}
+          </Box>
+        </Grid>
       </Row>
       {accessNote && (
         <Row>

--- a/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
+++ b/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
@@ -1,21 +1,49 @@
 import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 import ButtonInlineLink from '@weco/common/views/components/ButtonInlineLink/ButtonInlineLink';
+import Space from '@weco/common/views/components/styled/Space';
+import { classNames, font } from '@weco/common/utils/classnames';
 
 const Wrapper = styled.div`
   border-bottom: 1px solid ${props => props.theme.color('pumice')};
-`;
-const Row = styled.div`
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  grid-gap: 20px;
-  margin-bottom: 10px;
+  margin-bottom: 20px;
 `;
 
-const Box = styled.div`
-  padding-bottom: 10px;
+const Row = styled(Space).attrs({
+  v: { size: 'm', properties: ['margin-bottom'] },
+})`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, min-content));
+  grid-column-gap: 20px;
 `;
-const Color = styled.span<{ color: string }>``;
+
+const DetailHeading = styled.h3.attrs({
+  className: classNames({
+    [font('hnb', 5, { small: 3, medium: 3 })]: true,
+    'no-margin': true,
+  }),
+})``;
+
+const Box = styled(Space).attrs<{ isCentered?: boolean }>(props => ({
+  v: {
+    size: 's',
+    properties: [props.isCentered ? undefined : 'margin-bottom'],
+  },
+}))<{ isCentered?: boolean }>`
+  ${props =>
+    props.isCentered &&
+    `
+    align-self: center;
+  `}
+`;
+const Color = styled(Space).attrs({
+  h: { size: 's', properties: ['margin-left'] },
+})<{ color: string }>`
+  width: 1em;
+  height: 1em;
+  display: inline-flex;
+  background: ${props => props.theme.color(props.color)};
+`;
 
 export type Props = {
   title: string;
@@ -24,6 +52,7 @@ export type Props = {
   accessMethod?: string;
   requestItemUrl?: string;
   accessNote?: string;
+  color?: string;
 };
 
 const PhysicalItemDetails: FunctionComponent<Props> = ({
@@ -33,32 +62,31 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
   accessMethod,
   requestItemUrl,
   accessNote,
+  color,
 }) => {
   return (
     <Wrapper>
       <Row>
         <Box>
-          <h3>{title}</h3>
+          <DetailHeading>{title}</DetailHeading>
           {itemNote && <span dangerouslySetInnerHTML={{ __html: itemNote }} />}
         </Box>
       </Row>
       <Row>
         <Box>
-          <h3>Location</h3>
+          <DetailHeading>Location</DetailHeading>
           <span>{locationAndShelfmark}</span>
-          <Color color={'red'} />
+          {color && <Color color={color} />}
         </Box>
         <Box>
-          <h3>Access</h3>
+          <DetailHeading>Access</DetailHeading>
           {accessMethod && <span>{accessMethod}</span>}
         </Box>
-        {requestItemUrl ? (
-          <Box>
+        <Box isCentered>
+          {requestItemUrl && (
             <ButtonInlineLink text={'Request item'} link={requestItemUrl} />
-          </Box>
-        ) : (
-          <Box></Box>
-        )}
+          )}
+        </Box>
       </Row>
       {accessNote && (
         <Row>

--- a/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
+++ b/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
@@ -14,9 +14,11 @@ const Row = styled(Space).attrs({
 })``;
 
 const Grid = styled.div`
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(100px, max-content));
-  grid-column-gap: 30px;
+  ${props => props.theme.media.medium`
+    display: grid;
+    grid-template-columns: 200px 150px 125px;
+    grid-column-gap: 30px;
+  `}
 `;
 
 const DetailHeading = styled.h3.attrs({

--- a/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
+++ b/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
@@ -1,0 +1,74 @@
+import { FunctionComponent } from 'react';
+import styled from 'styled-components';
+import ButtonInlineLink from '@weco/common/views/components/ButtonInlineLink/ButtonInlineLink';
+
+const Wrapper = styled.div`
+  border-bottom: 1px solid ${props => props.theme.color('pumice')};
+`;
+const Row = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  grid-gap: 20px;
+  margin-bottom: 10px;
+`;
+
+const Box = styled.div`
+  padding-bottom: 10px;
+`;
+const Color = styled.span<{ color: string }>``;
+
+export type Props = {
+  title: string;
+  itemNote?: string;
+  locationAndShelfmark: string;
+  accessMethod?: string;
+  requestItemUrl?: string;
+  accessNote?: string;
+};
+
+const PhysicalItemDetails: FunctionComponent<Props> = ({
+  title,
+  itemNote,
+  locationAndShelfmark,
+  accessMethod,
+  requestItemUrl,
+  accessNote,
+}) => {
+  return (
+    <Wrapper>
+      <Row>
+        <Box>
+          <h3>{title}</h3>
+          {itemNote && <span dangerouslySetInnerHTML={{ __html: itemNote }} />}
+        </Box>
+      </Row>
+      <Row>
+        <Box>
+          <h3>Location</h3>
+          <span>{locationAndShelfmark}</span>
+          <Color color={'red'} />
+        </Box>
+        <Box>
+          <h3>Access</h3>
+          {accessMethod && <span>{accessMethod}</span>}
+        </Box>
+        {requestItemUrl ? (
+          <Box>
+            <ButtonInlineLink text={'Request item'} link={requestItemUrl} />
+          </Box>
+        ) : (
+          <Box></Box>
+        )}
+      </Row>
+      {accessNote && (
+        <Row>
+          <Box>
+            <span dangerouslySetInnerHTML={{ __html: accessNote }} />
+          </Box>
+        </Row>
+      )}
+    </Wrapper>
+  );
+};
+
+export default PhysicalItemDetails;

--- a/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
+++ b/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
@@ -27,17 +27,21 @@ function getFirstPhysicalLocation(item) {
   return item.locations?.find(location => location.type === 'PhysicalLocation');
 }
 
+// FIXME: These hex values are screengrabbed from a photo of a sign in the building
+// They're not like anything we've got in the palette (not to mention they're
+// quite hard to tell apart for people with less-than-perfect colour vision).
 function getColorForLocation(label: string): string | undefined {
   switch (label) {
     case 'Journals':
-      return 'green';
+      return '#720013';
     case 'History of Medicine':
-      return 'red';
+    case 'History of Medicine Collection':
+      return '#9b3700';
     case 'Medical Collection':
-      return 'orange';
+      return '#a96900';
     case 'Quick Reference':
-    case 'Student Loan':
-      return 'purple';
+    case 'Quick Ref. Collection':
+      return '#00407e';
     default:
       return undefined;
   }

--- a/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
+++ b/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
@@ -27,11 +27,31 @@ function getFirstPhysicalLocation(item) {
   return item.locations?.find(location => location.type === 'PhysicalLocation');
 }
 
+function getColorForLocation(label: string): string | undefined {
+  switch (label) {
+    case 'Journals':
+      return 'green';
+    case 'History of Medicine':
+      return 'red';
+    case 'Medical Collection':
+      return 'orange';
+    case 'Quick Reference':
+    case 'Student Loan':
+      return 'purple';
+    default:
+      return undefined;
+  }
+}
+
 function createPhysicalItem(
   item: PhysicalItem,
   encoreLink: string | undefined
 ): PhysicalItemProps | undefined {
   const physicalLocation = getFirstPhysicalLocation(item);
+  const isOnOpenShelves = physicalLocation?.locationType?.id === 'open-shelves';
+  const color = isOnOpenShelves
+    ? getColorForLocation(physicalLocation.label)
+    : undefined;
   const isRequestableOnline =
     physicalLocation?.accessConditions?.[0]?.method?.id === 'online-request';
   const accessMethodLabel =
@@ -50,6 +70,7 @@ function createPhysicalItem(
     accessMethod: accessMethodLabel,
     requestItemUrl: isRequestableOnline ? encoreLink : undefined,
     accessNote: accessNote,
+    color: color,
   };
 }
 

--- a/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
+++ b/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
@@ -1,19 +1,17 @@
 import { FunctionComponent, useState, useEffect } from 'react';
+import PhysicalItemDetails, {
+  Props as PhysicalItemProps,
+} from '../PhysicalItemDetails/PhysicalItemDetails';
 import {
   PhysicalItem,
   ItemsWork,
   CatalogueApiError,
 } from '@weco/common/model/catalogue';
-import Space from '@weco/common/views/components/styled/Space';
 import {
   getLocationLabel,
   getLocationShelfmark,
 } from '@weco/common/utils/works';
-import ButtonInlineLink from '@weco/common/views/components/ButtonInlineLink/ButtonInlineLink';
 import { isCatalogueApiError } from '../../pages/api/works/items/[workId]';
-import DescriptionList, {
-  Props as DescriptionListProps,
-} from '@weco/common/views/components/DescriptionList/DescriptionList';
 import ExpandableList from '@weco/common/views/components/ExpandableList/ExpandableList';
 
 async function fetchWorkItems(
@@ -29,49 +27,35 @@ function getFirstPhysicalLocation(item) {
   return item.locations?.find(location => location.type === 'PhysicalLocation');
 }
 
-function createDescriptionList(
+function createPhysicalItem(
   item: PhysicalItem,
   encoreLink: string | undefined
-): DescriptionListProps | undefined {
+): PhysicalItemProps | undefined {
   const physicalLocation = getFirstPhysicalLocation(item);
   const isRequestableOnline =
     physicalLocation?.accessConditions?.[0]?.method?.id === 'online-request';
   const accessMethodLabel =
     physicalLocation?.accessConditions?.[0]?.method?.label || '';
-  const accessMethod =
-    isRequestableOnline && encoreLink ? (
-      <ButtonInlineLink text={accessMethodLabel} link={encoreLink} />
-    ) : (
-      <>{accessMethodLabel}</>
-    );
-  const accessStatus =
-    physicalLocation?.accessConditions?.[0]?.status?.label || '';
   const accessNote = physicalLocation?.accessConditions?.[0]?.note;
-  const accessTerms = physicalLocation?.accessConditions[0]?.terms || '';
   const locationLabel = physicalLocation && getLocationLabel(physicalLocation);
   const locationShelfmark =
     physicalLocation && getLocationShelfmark(physicalLocation);
-  const shelfmark = `${locationLabel ?? ''} ${locationShelfmark ?? ''}`;
+  const locationAndShelfmark = `${locationLabel ?? ''} ${locationShelfmark ??
+    ''}`;
 
   return {
     title: item.title || '',
-    subheading: item.note || '',
-    items: [
-      { term: 'Location/shelfmark', description: shelfmark },
-      accessMethod && { term: 'Access method', description: accessMethod },
-      accessStatus && { term: 'Access status', description: accessStatus },
-      accessTerms && { term: 'Access terms', description: accessTerms },
-      accessNote && {
-        term: 'Access note',
-        description: <span dangerouslySetInnerHTML={{ __html: accessNote }} />, // TODO: Rename WorkTitle to e.g. ApiHtml
-      },
-    ].filter(Boolean),
+    itemNote: item.note || '',
+    locationAndShelfmark: locationAndShelfmark,
+    accessMethod: accessMethodLabel,
+    requestItemUrl: isRequestableOnline ? encoreLink : undefined,
+    accessNote: accessNote,
   };
 }
 
-function createDescriptionLists(items, encoreLink) {
+function createPhysicalItems(items, encoreLink) {
   return items
-    .map(item => createDescriptionList(item, encoreLink))
+    .map(item => createPhysicalItem(item, encoreLink))
     .filter(Boolean);
 }
 
@@ -87,7 +71,7 @@ const PhysicalItems: FunctionComponent<Props> = ({
   encoreLink,
 }: Props) => {
   const [physicalItems, setPhysicalItems] = useState(items);
-  const descriptionLists = createDescriptionLists(physicalItems, encoreLink);
+  const itemsToRender = createPhysicalItems(physicalItems, encoreLink);
 
   useEffect(() => {
     const addStatusToItems = async () => {
@@ -114,18 +98,8 @@ const PhysicalItems: FunctionComponent<Props> = ({
 
   return (
     <ExpandableList
-      listItems={descriptionLists.map((r, index) => (
-        <Space
-          key={index}
-          v={{ size: 'm', properties: ['margin-bottom', 'padding-bottom'] }}
-          style={{ borderBottom: '1px dashed #ddd' }}
-        >
-          <DescriptionList
-            title={r.title}
-            subheading={r.subheading}
-            items={r.items}
-          />
-        </Space>
+      listItems={itemsToRender.map((props, index) => (
+        <PhysicalItemDetails {...props} key={index} />
       ))}
       initialItems={5}
     />


### PR DESCRIPTION
Relates to #6410 

## Who is this for?
People who want to see physical item location/availability/notes

## What is it doing for them?
Improving the layout for them behind the `showPhysicalItems` toggle

I tried various approaches with css grid `auto-fit` and `auto-fill` in conjunction with `minmax` to allow elements in the grid to flow onto another line when there wasn't enough space. But I think the possible inconsistencies in layout both at different breakpoints and between different items meant that having two specific views ('mobile' and 'desktop') felt like it made more sense in the end. This is definitely up for debate, though.

I've included a method to add the (screengrabbed) colours associated with in-venue signage so that we can see it, but it comes with various caveats (see thread in [comment on the issue](https://github.com/wellcomecollection/wellcomecollection.org/issues/6410#issuecomment-884283265)).

I've noticed that this is breaking on archive pages, but I _think_ there is a broader issue with the css on those pages, so don't want to address it in this pr. Opened #6817 for this.

