### PR TITLE
Fix archive layout

### DIFF
--- a/catalogue/webapp/components/Work/Work.tsx
+++ b/catalogue/webapp/components/Work/Work.tsx
@@ -137,7 +137,10 @@ const Work: FunctionComponent<Props> = ({
             <Divider color={`pumice`} isKeyline={true} />
             <ArchiveDetailsContainer>
               <ArchiveTree work={work} />
-              <Space v={{ size: 'l', properties: ['padding-top'] }}>
+              <Space
+                v={{ size: 'xl', properties: ['padding-top'] }}
+                className={`flex-1`}
+              >
                 <WorkDetails work={work} />
               </Space>
             </ArchiveDetailsContainer>

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -733,11 +733,9 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
   );
 
   return isInArchive ? (
-    <div className="container">
-      <div className="grid">
-        <Content />
-      </div>
-    </div>
+    <Space h={{ size: 'l', properties: ['padding-left', 'padding-right'] }}>
+      <Content />
+    </Space>
   ) : (
     <Layout12>
       <Content />

--- a/catalogue/webapp/components/WorkDetailsSection/WorkDetailsSection.tsx
+++ b/catalogue/webapp/components/WorkDetailsSection/WorkDetailsSection.tsx
@@ -6,19 +6,17 @@ import { FunctionComponent, PropsWithChildren } from 'react';
 
 type Props = PropsWithChildren<{
   headingText?: string;
-  withDivider?: boolean;
   isInArchive?: boolean;
 }>;
 
 const WorkDetailsSection: FunctionComponent<Props> = ({
   headingText,
   children,
-  withDivider = true,
   isInArchive,
 }: Props) => {
   return (
     <>
-      {withDivider && (
+      {!isInArchive && (
         <>
           <Divider color={`pumice`} isKeyline={true} />
           <SpacingComponent />
@@ -27,7 +25,7 @@ const WorkDetailsSection: FunctionComponent<Props> = ({
       <SpacingSection>
         <div
           className={classNames({
-            grid: true,
+            grid: !isInArchive,
           })}
         >
           <div
@@ -38,12 +36,6 @@ const WorkDetailsSection: FunctionComponent<Props> = ({
                 l: 4,
                 xl: 4,
               })]: !isInArchive,
-              [grid({
-                s: 12,
-                m: 12,
-                l: 12,
-                xl: 12,
-              })]: isInArchive,
             })}
           >
             {headingText && (
@@ -66,12 +58,6 @@ const WorkDetailsSection: FunctionComponent<Props> = ({
                 l: 8,
                 xl: 7,
               })]: !isInArchive,
-              [grid({
-                s: 12,
-                m: 12,
-                l: 12,
-                xl: 12,
-              })]: isInArchive,
             })}
           >
             {children}


### PR DESCRIPTION
The right-hand area of archive pages contains superfluous `container`s and `grid`s which have max-widths that can cause the page to scroll horizontally when there's too much content.

This removes them and makes line-breaking predictable and spacing simpler to reason about.