### PR TITLE
Add superWidescreenImage crop for Seasons page

### DIFF
--- a/common/model/generic-content-fields.js
+++ b/common/model/generic-content-fields.js
@@ -23,6 +23,7 @@ export type GenericContentFields = {|
   image: ?ImageType,
   squareImage: ?ImageType,
   widescreenImage: ?ImageType,
+  superWidescreenImage: ?ImageType,
   metadataDescription: ?string,
   labels: Label[],
 |};

--- a/common/model/generic-content-fields.ts
+++ b/common/model/generic-content-fields.ts
@@ -21,6 +21,7 @@ export type GenericContentFields = {
   image: ImageType | null;
   squareImage: ImageType | null;
   widescreenImage: ImageType | null;
+  superWidescreenImage: ImageType | null;
   metadataDescription: string | null;
   labels: Label[];
 };

--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -898,13 +898,25 @@ export function parseGenericFields(doc: PrismicFragment): GenericContentFields {
               image['16:9'] &&
               isImageLink(image['16:9']) &&
               parseImage(image['16:9']);
+            const superWidescreenImage =
+              image['32:15'] && parseImage(image['32:15']);
 
-            return { image: originalImage, squareImage, widescreenImage };
+            return {
+              image: originalImage,
+              squareImage,
+              widescreenImage,
+              superWidescreenImage,
+            };
           })
           .find(_ => _)
       : {}; // just get the first one;
 
-  const { image, squareImage, widescreenImage } = promoImages;
+  const {
+    image,
+    squareImage,
+    widescreenImage,
+    superWidescreenImage,
+  } = promoImages;
   const body = data.body ? parseBody(data.body) : [];
   const standfirst = body.find(slice => slice.type === 'standfirst');
   const metadataDescription = asText(data.metadataDescription);
@@ -922,6 +934,7 @@ export function parseGenericFields(doc: PrismicFragment): GenericContentFields {
     image,
     squareImage,
     widescreenImage,
+    superWidescreenImage,
     metadataDescription,
     // we pass an empty array here to be overriden by each content type
     // TODO: find a way to enforce this.

--- a/common/views/components/DailyTourPromo/DailyTourPromo.js
+++ b/common/views/components/DailyTourPromo/DailyTourPromo.js
@@ -69,6 +69,7 @@ export const data = {
   promoText: null,
   squareImage: null,
   widescreenImage: null,
+  superWidescreenImage: null,
   ticketSalesStart: null,
   displayEnd: new Date(),
   displayStart: new Date(),

--- a/content/webapp/components/Exhibition/Exhibition.js
+++ b/content/webapp/components/Exhibition/Exhibition.js
@@ -203,6 +203,7 @@ const Exhibition = ({ exhibition, pages }: Props) => {
     image: exhibition.image,
     squareImage: exhibition.squareImage,
     widescreenImage: exhibition.widescreenImage,
+    superWidescreenImage: exhibition.superWidescreenImage,
     labels: exhibition.labels,
     metadataDescription: exhibition.metadataDescription,
   };

--- a/content/webapp/components/Installation/Installation.js
+++ b/content/webapp/components/Installation/Installation.js
@@ -48,6 +48,7 @@ const Installation = ({ installation }: Props) => {
     image: installation.image,
     squareImage: installation.squareImage,
     widescreenImage: installation.widescreenImage,
+    superWidescreenImage: installation.superWidescreenImage,
     labels: installation.labels,
     metadataDescription: installation.metadataDescription,
   });

--- a/content/webapp/pages/article-series.js
+++ b/content/webapp/pages/article-series.js
@@ -86,6 +86,7 @@ export class ArticleSeriesPage extends Component<Props> {
       image: series.image,
       squareImage: series.squareImage,
       widescreenImage: series.widescreenImage,
+      superWidescreenImage: series.superWidescreenImage,
       labels: series.labels,
       metadataDescription: series.metadataDescription,
     };

--- a/content/webapp/pages/article.js
+++ b/content/webapp/pages/article.js
@@ -131,6 +131,7 @@ export class ArticlePage extends Component<Props, State> {
       image: article.image,
       squareImage: article.squareImage,
       widescreenImage: article.widescreenImage,
+      superWidescreenImage: article.superWidescreenImage,
       labels: article.labels,
       metadataDescription: article.metadataDescription,
     };

--- a/content/webapp/pages/event-series.js
+++ b/content/webapp/pages/event-series.js
@@ -82,6 +82,7 @@ export class EventSeriesPage extends Component<Props> {
       image: series.image,
       squareImage: series.squareImage,
       widescreenImage: series.widescreenImage,
+      superWidescreenImage: series.superWidescreenImage,
       labels: series.labels,
       metadataDescription: series.metadataDescription,
     };

--- a/content/webapp/pages/season.tsx
+++ b/content/webapp/pages/season.tsx
@@ -28,7 +28,9 @@ const SeasonPage = ({
     <SeasonsHeader
       labels={{ labels: season.labels }}
       title={season.title}
-      FeaturedMedia={<UiImage {...season.widescreenImage} sizesQueries="" />}
+      FeaturedMedia={
+        <UiImage {...season.superWidescreenImage} sizesQueries="" />
+      }
       standfirst={season?.standfirst}
       start={season.start}
       end={season.end}


### PR DESCRIPTION
Fixes #6819

## Who is this for?
People looking at season pages

## What is it doing for them?
Reducing the featured image height. The Zeplin comp used an `18:9` ratio. We don't have this in Prismic, but the `32:15` crop is pretty close.