### PR TITLE
move data-context-path so it is added to both content and catalogue app

### DIFF
--- a/common/views/components/CataloguePageLayout/CataloguePageLayout.tsx
+++ b/common/views/components/CataloguePageLayout/CataloguePageLayout.tsx
@@ -1,7 +1,6 @@
 import { FunctionComponent, useEffect, useState } from 'react';
 import PageLayout, { Props as PageLayoutProps } from '../PageLayout/PageLayout';
 import InfoBanner from '../InfoBanner/InfoBanner';
-import { prefix } from '@weco/identity/src/utility/prefix';
 
 type Props = {
   hideTopContent?: boolean;
@@ -20,27 +19,25 @@ const CataloguePageLayout: FunctionComponent<Props> = ({
   }, []);
 
   return (
-    <div id="root" data-context-path={prefix}>
-      <PageLayout {...props}>
-        {!hideTopContent && (
-          <>
-            {isRedirectBannerVisible && (
-              <InfoBanner
-                text={[
-                  {
-                    type: 'paragraph',
-                    text: `Coming from Wellcome Images? All freely available images have now been moved to the Wellcome Collection website. Here we're working to improve data quality, search relevance and tools to help you use these images more easily`,
-                    spans: [],
-                  },
-                ]}
-                cookieName="WC_wellcomeImagesRedirect"
-              />
-            )}
-          </>
-        )}
-        {children}
-      </PageLayout>
-    </div>
+    <PageLayout {...props}>
+      {!hideTopContent && (
+        <>
+          {isRedirectBannerVisible && (
+            <InfoBanner
+              text={[
+                {
+                  type: 'paragraph',
+                  text: `Coming from Wellcome Images? All freely available images have now been moved to the Wellcome Collection website. Here we're working to improve data quality, search relevance and tools to help you use these images more easily`,
+                  spans: [],
+                },
+              ]}
+              cookieName="WC_wellcomeImagesRedirect"
+            />
+          )}
+        </>
+      )}
+      {children}
+    </PageLayout>
   );
 };
 

--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -29,6 +29,7 @@ import GlobalInfoBarContext, {
 } from '../GlobalInfoBarContext/GlobalInfoBarContext';
 import TogglesContext from '../TogglesContext/TogglesContext';
 import ApiToolbar from '../ApiToolbar/ApiToolbar';
+import { prefix } from '@weco/identity/src/utility/prefix';
 
 type SiteSection =
   | 'collections'
@@ -227,7 +228,7 @@ const PageLayoutComponent: FunctionComponent<ComponentProps> = ({
         />
       </Head>
 
-      <div>
+      <div id="root" data-context-path={prefix}>
         {apiToolbar && <ApiToolbar />}
         <CookieNotice />
         <a className="visually-hidden visually-hidden-focusable" href="#main">

--- a/common/views/components/PageLayoutDeprecated/PageLayoutDeprecated.js
+++ b/common/views/components/PageLayoutDeprecated/PageLayoutDeprecated.js
@@ -30,6 +30,7 @@ import Space from '../styled/Space';
 import GlobalInfoBarContext from '../GlobalInfoBarContext/GlobalInfoBarContext';
 // $FlowFixMe (tsx)
 import TogglesContext from '../TogglesContext/TogglesContext';
+// $FlowFixMe (tsx)
 import { prefix } from '@weco/identity/src/utility/prefix';
 
 export type Props = {|

--- a/common/views/components/PageLayoutDeprecated/PageLayoutDeprecated.js
+++ b/common/views/components/PageLayoutDeprecated/PageLayoutDeprecated.js
@@ -30,6 +30,7 @@ import Space from '../styled/Space';
 import GlobalInfoBarContext from '../GlobalInfoBarContext/GlobalInfoBarContext';
 // $FlowFixMe (tsx)
 import TogglesContext from '../TogglesContext/TogglesContext';
+import { prefix } from '@weco/identity/src/utility/prefix';
 
 export type Props = {|
   title: string,
@@ -132,7 +133,7 @@ const PageLayout = ({
         )}
       </Head>
 
-      <div>
+      <div id="root" data-context-path={prefix}>
         <CookieNotice />
         <a className="visually-hidden visually-hidden-focusable" href="#main">
           Skip to main content


### PR DESCRIPTION
⬆️ 

It's needed for the [usePrefix function](https://github.com/wellcomecollection/wellcomecollection.org/blob/c7f104edd1ef71858cd09707abc461ab74cabb13/identity/webapp/src/frontend/hooks/usePrefix.ts#L1) which we need to successfully make calls to the identity app api client side