### PR TITLE
Archive physical items

### DIFF
--- a/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
+++ b/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
@@ -17,7 +17,7 @@ const Row = styled(Space).attrs({
 const Grid = styled.div<{ isArchive: boolean }>`
   ${props => props.theme.media[props.isArchive ? 'large' : 'medium']`
     display: grid;
-    grid-template-columns: minmax(120px, 200px) 150px 125px;
+    grid-template-columns: minmax(120px, 200px) minmax(100px, 150px) 125px;
     grid-column-gap: 30px;
   `}
 `;

--- a/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
+++ b/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
@@ -1,8 +1,9 @@
-import { FunctionComponent } from 'react';
+import { FunctionComponent, useContext } from 'react';
 import styled from 'styled-components';
 import ButtonInlineLink from '@weco/common/views/components/ButtonInlineLink/ButtonInlineLink';
 import Space from '@weco/common/views/components/styled/Space';
 import { classNames, font } from '@weco/common/utils/classnames';
+import IsArchiveContext from '@weco/common/views/components/IsArchiveContext/IsArchiveContext';
 
 const Wrapper = styled.div`
   border-bottom: 1px solid ${props => props.theme.color('pumice')};
@@ -13,10 +14,10 @@ const Row = styled(Space).attrs({
   v: { size: 'm', properties: ['margin-bottom'] },
 })``;
 
-const Grid = styled.div`
-  ${props => props.theme.media.medium`
+const Grid = styled.div<{ isArchive: boolean }>`
+  ${props => props.theme.media[props.isArchive ? 'large' : 'medium']`
     display: grid;
-    grid-template-columns: 200px 150px 125px;
+    grid-template-columns: minmax(120px, 200px) 150px 125px;
     grid-column-gap: 30px;
   `}
 `;
@@ -69,6 +70,8 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
   accessNote,
   color,
 }) => {
+  const isArchive = useContext(IsArchiveContext);
+
   return (
     <Wrapper>
       {(title || itemNote) && (
@@ -82,7 +85,7 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
         </Row>
       )}
       <Row>
-        <Grid>
+        <Grid isArchive={isArchive}>
           <Box>
             <DetailHeading>Location</DetailHeading>
             <span>{locationAndShelfmark}</span>

--- a/catalogue/webapp/components/Work/Work.tsx
+++ b/catalogue/webapp/components/Work/Work.tsx
@@ -16,6 +16,7 @@ import Divider from '@weco/common/views/components/Divider/Divider';
 import styled from 'styled-components';
 import { WithGlobalContextData } from '@weco/common/views/components/GlobalContextProvider/GlobalContextProvider';
 import SearchContext from '@weco/common/views/components/SearchContext/SearchContext';
+import IsArchiveContext from '@weco/common/views/components/IsArchiveContext/IsArchiveContext';
 
 const ArchiveDetailsContainer = styled.div`
   display: block;
@@ -40,7 +41,7 @@ const Work: FunctionComponent<Props> = ({
 }: Props): ReactElement<Props> => {
   const { link: searchLink } = useContext(SearchContext);
 
-  const isInArchive = work.parts.length > 0 || work.partOf.length > 0;
+  const isArchive = work.parts.length > 0 || work.partOf.length > 0;
 
   const workData = {
     workType: (work.workType ? work.workType.label : '').toLocaleLowerCase(),
@@ -62,101 +63,103 @@ const Work: FunctionComponent<Props> = ({
       : null;
 
   return (
-    <CataloguePageLayout
-      title={work.title}
-      description={work.description || work.title}
-      url={{ pathname: `/works/${work.id}`, query: {} }}
-      openGraphType={'website'}
-      jsonLd={workLd(work)}
-      siteSection={'collections'}
-      imageUrl={imageUrl}
-      imageAltText={work.title}
-      hideNewsletterPromo={true}
-      globalContextData={globalContextData}
-    >
-      <div className="container">
-        <div className="grid">
-          <div
-            className={classNames({
-              [grid({ s: 12, m: 12, l: 12, xl: 12 })]: true,
-            })}
-          >
-            <Space v={{ size: 'l', properties: ['margin-top'] }}>
-              <SearchTabs
-                query={searchLink.as.query?.query?.toString() || ''}
-                sort={searchLink.as.query?.sort?.toString()}
-                sortOrder={searchLink.as.query?.sortOrder?.toString()}
-                worksFilters={[]}
-                imagesFilters={[]}
-                shouldShowDescription={false}
-                shouldShowFilters={false}
-                showSortBy={false}
-              />
+    <IsArchiveContext.Provider value={isArchive}>
+      <CataloguePageLayout
+        title={work.title}
+        description={work.description || work.title}
+        url={{ pathname: `/works/${work.id}`, query: {} }}
+        openGraphType={'website'}
+        jsonLd={workLd(work)}
+        siteSection={'collections'}
+        imageUrl={imageUrl}
+        imageAltText={work.title}
+        hideNewsletterPromo={true}
+        globalContextData={globalContextData}
+      >
+        <div className="container">
+          <div className="grid">
+            <div
+              className={classNames({
+                [grid({ s: 12, m: 12, l: 12, xl: 12 })]: true,
+              })}
+            >
+              <Space v={{ size: 'l', properties: ['margin-top'] }}>
+                <SearchTabs
+                  query={searchLink.as.query?.query?.toString() || ''}
+                  sort={searchLink.as.query?.sort?.toString()}
+                  sortOrder={searchLink.as.query?.sortOrder?.toString()}
+                  worksFilters={[]}
+                  imagesFilters={[]}
+                  shouldShowDescription={false}
+                  shouldShowFilters={false}
+                  showSortBy={false}
+                />
+              </Space>
+            </div>
+          </div>
+          <div className="grid">
+            <Space
+              v={{
+                size: 's',
+                properties: ['padding-top', 'padding-bottom'],
+              }}
+              className={classNames({
+                [grid({ s: 12 })]: true,
+              })}
+            >
+              <BackToResults />
             </Space>
           </div>
         </div>
-        <div className="grid">
-          <Space
-            v={{
-              size: 's',
-              properties: ['padding-top', 'padding-bottom'],
-            }}
-            className={classNames({
-              [grid({ s: 12 })]: true,
-            })}
-          >
-            <BackToResults />
-          </Space>
-        </div>
-      </div>
 
-      {isInArchive ? (
-        <>
-          <div className="container">
-            <div className="grid">
-              <Space
-                v={{
-                  size: 's',
-                  properties: ['padding-top', 'padding-bottom'],
-                }}
-                className={classNames({
-                  [grid({ s: 12 })]: true,
-                })}
-              >
-                <ArchiveBreadcrumb work={work} />
-              </Space>
+        {isArchive ? (
+          <>
+            <div className="container">
+              <div className="grid">
+                <Space
+                  v={{
+                    size: 's',
+                    properties: ['padding-top', 'padding-bottom'],
+                  }}
+                  className={classNames({
+                    [grid({ s: 12 })]: true,
+                  })}
+                >
+                  <ArchiveBreadcrumb work={work} />
+                </Space>
+              </div>
             </div>
-          </div>
-          <div className="container">
-            <div className="grid">
-              <WorkHeader work={work} />
+            <div className="container">
+              <div className="grid">
+                <WorkHeader work={work} />
+              </div>
             </div>
-          </div>
 
-          <div className="container">
-            <Divider color={`pumice`} isKeyline={true} />
-            <ArchiveDetailsContainer>
-              <ArchiveTree work={work} />
-              <Space
-                v={{ size: 'xl', properties: ['padding-top'] }}
-                className={`flex-1`}
-              >
-                <WorkDetails work={work} />
-              </Space>
-            </ArchiveDetailsContainer>
-          </div>
-        </>
-      ) : (
-        <>
-          <div className="container">
-            <div className="grid">
-              <WorkHeader work={work} />
+            <div className="container">
+              <Divider color={`pumice`} isKeyline={true} />
+              <ArchiveDetailsContainer>
+                <ArchiveTree work={work} />
+                <Space
+                  v={{ size: 'xl', properties: ['padding-top'] }}
+                  className={`flex-1`}
+                >
+                  <WorkDetails work={work} />
+                </Space>
+              </ArchiveDetailsContainer>
             </div>
-          </div>
-          <WorkDetails work={work} />
-        </>
-      )}
-    </CataloguePageLayout>
+          </>
+        ) : (
+          <>
+            <div className="container">
+              <div className="grid">
+                <WorkHeader work={work} />
+              </div>
+            </div>
+            <WorkDetails work={work} />
+          </>
+        )}
+      </CataloguePageLayout>
+    </IsArchiveContext.Provider>
   );
 };
 

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -46,6 +46,7 @@ import useIIIFManifestData from '@weco/common/hooks/useIIIFManifestData';
 import IIIFClickthrough from '@weco/common/views/components/IIIFClickthrough/IIIFClickthrough';
 import OnlineResources from './OnlineResources';
 import ExpandableList from '@weco/common/views/components/ExpandableList/ExpandableList';
+import IsArchiveContext from '@weco/common/views/components/IsArchiveContext/IsArchiveContext';
 type Props = {
   work: Work;
 };
@@ -74,6 +75,7 @@ function getItemLinkState({
 
 const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
   const { showPhysicalItems, showHoldingsOnWork } = useContext(TogglesContext);
+  const isArchive = useContext(IsArchiveContext);
 
   const itemUrl = itemLink({ workId: work.id }, 'work');
 
@@ -202,15 +204,10 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
     video,
   });
 
-  const isInArchive = work.parts.length > 0 || work.partOf.length > 0;
-
   const holdings = getHoldings(work);
 
   const WhereToFindIt = () => (
-    <WorkDetailsSection
-      headingText="Where to find it"
-      isInArchive={isInArchive}
-    >
+    <WorkDetailsSection headingText="Where to find it">
       {locationOfWork && (
         <WorkDetailsText
           title={locationOfWork.noteType.label}
@@ -245,7 +242,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
     return (
       <>
         {showHoldingsOnWork && holdings.length > 0 ? (
-          <WorkDetailsSection headingText="Holdings" isInArchive={isInArchive}>
+          <WorkDetailsSection headingText="Holdings">
             {holdings.map((holding, i) => {
               const locationLabel =
                 holding.location && getLocationLabel(holding.location);
@@ -325,10 +322,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
   const Content = () => (
     <>
       {digitalLocation && itemLinkState !== 'useNoLink' && (
-        <WorkDetailsSection
-          headingText="Available online"
-          isInArchive={isInArchive}
-        >
+        <WorkDetailsSection headingText="Available online">
           <ConditionalWrapper
             condition={Boolean(tokenService)}
             wrapper={children =>
@@ -561,10 +555,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
       <OnlineResources work={work} />
 
       {work.images && work.images.length > 0 && (
-        <WorkDetailsSection
-          headingText="Selected images from this work"
-          isInArchive={isInArchive}
-        >
+        <WorkDetailsSection headingText="Selected images from this work">
           <ButtonOutlinedLink
             text={
               work.images.length > 1
@@ -581,10 +572,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
         </WorkDetailsSection>
       )}
 
-      <WorkDetailsSection
-        headingText="About this work"
-        isInArchive={isInArchive}
-      >
+      <WorkDetailsSection headingText="About this work">
         {work.alternativeTitles.length > 0 && (
           <WorkDetailsText
             title="Also known as"
@@ -680,7 +668,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
         )}
       </WorkDetailsSection>
       {work.subjects.length > 0 && (
-        <WorkDetailsSection headingText="Subjects" isInArchive={isInArchive}>
+        <WorkDetailsSection headingText="Subjects">
           <WorkDetailsTags
             tags={work.subjects.map(s => {
               return {
@@ -701,10 +689,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
 
       {(locationOfWork || showEncoreLink) && <WhereToFindIt />}
 
-      <WorkDetailsSection
-        headingText="Permanent link"
-        isInArchive={isInArchive}
-      >
+      <WorkDetailsSection headingText="Permanent link">
         <div className={`${font('hnr', 5)}`}>
           <CopyUrl
             id={work.id}
@@ -714,7 +699,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
       </WorkDetailsSection>
 
       {isbnIdentifiers.length > 0 && (
-        <WorkDetailsSection headingText="Identifiers" isInArchive={isInArchive}>
+        <WorkDetailsSection headingText="Identifiers">
           {isbnIdentifiers.length > 0 && (
             <WorkDetailsList
               title="ISBN"
@@ -732,7 +717,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
     </>
   );
 
-  return isInArchive ? (
+  return isArchive ? (
     <Space h={{ size: 'l', properties: ['padding-left', 'padding-right'] }}>
       <Content />
     </Space>

--- a/catalogue/webapp/components/WorkDetailsSection/WorkDetailsSection.tsx
+++ b/catalogue/webapp/components/WorkDetailsSection/WorkDetailsSection.tsx
@@ -2,21 +2,22 @@ import Divider from '@weco/common/views/components/Divider/Divider';
 import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
 import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
 import { classNames, grid, font } from '@weco/common/utils/classnames';
-import { FunctionComponent, PropsWithChildren } from 'react';
+import { FunctionComponent, PropsWithChildren, useContext } from 'react';
+import IsArchiveContext from '@weco/common/views/components/IsArchiveContext/IsArchiveContext';
 
 type Props = PropsWithChildren<{
   headingText?: string;
-  isInArchive?: boolean;
 }>;
 
 const WorkDetailsSection: FunctionComponent<Props> = ({
   headingText,
   children,
-  isInArchive,
 }: Props) => {
+  const isArchive = useContext(IsArchiveContext);
+
   return (
     <>
-      {!isInArchive && (
+      {!isArchive && (
         <>
           <Divider color={`pumice`} isKeyline={true} />
           <SpacingComponent />
@@ -25,7 +26,7 @@ const WorkDetailsSection: FunctionComponent<Props> = ({
       <SpacingSection>
         <div
           className={classNames({
-            grid: !isInArchive,
+            grid: !isArchive,
           })}
         >
           <div
@@ -35,7 +36,7 @@ const WorkDetailsSection: FunctionComponent<Props> = ({
                 m: 12,
                 l: 4,
                 xl: 4,
-              })]: !isInArchive,
+              })]: !isArchive,
             })}
           >
             {headingText && (
@@ -57,7 +58,7 @@ const WorkDetailsSection: FunctionComponent<Props> = ({
                 m: 12,
                 l: 8,
                 xl: 7,
-              })]: !isInArchive,
+              })]: !isArchive,
             })}
           >
             {children}

--- a/common/views/components/ArchiveBreadcrumb/ArchiveBreadcrumb.tsx
+++ b/common/views/components/ArchiveBreadcrumb/ArchiveBreadcrumb.tsx
@@ -4,8 +4,9 @@ import DropdownButton from '../DropdownButton/DropdownButton';
 import Icon from '../Icon/Icon';
 import WorkTitle from '@weco/common/views/components/WorkTitle/WorkTitle';
 import { getArchiveAncestorArray } from '@weco/common/utils/works';
-import { FunctionComponent, ReactNode } from 'react';
+import { FunctionComponent, ReactNode, useContext } from 'react';
 import WorkLink from '../WorkLink/WorkLink';
+import IsArchiveContext from '@weco/common/views/components/IsArchiveContext/IsArchiveContext';
 
 const ArchiveBreadcrumbNav = styled.nav`
   * {
@@ -104,9 +105,9 @@ const ArchiveBreadcrumb: FunctionComponent<Props> = ({ work }: Props) => {
     alternativeTitles: work.alternativeTitles,
     referenceNumber: work.referenceNumber,
   };
-  const isInArchive = work.parts.length > 0 || work.partOf.length > 0;
+  const isArchive = useContext(IsArchiveContext);
 
-  return isInArchive ? (
+  return isArchive ? (
     <ArchiveBreadcrumbNav>
       <ul>
         {firstCrumb && (

--- a/common/views/components/ArchiveTree/ArchiveTree.tsx
+++ b/common/views/components/ArchiveTree/ArchiveTree.tsx
@@ -21,6 +21,7 @@ import { RelatedWork, Work } from '@weco/common/model/catalogue';
 import Modal, { ModalContext } from '@weco/common/views/components/Modal/Modal';
 import ButtonSolid from '@weco/common/views/components/ButtonSolid/ButtonSolid';
 import { Toggles } from '@weco/toggles';
+import IsArchiveContext from '@weco/common/views/components/IsArchiveContext/IsArchiveContext';
 
 const TreeContainer = styled.div`
   border-right: 1px solid ${props => props.theme.color('pumice')};
@@ -841,6 +842,7 @@ const ArchiveTree: FunctionComponent<{ work: Work }> = ({
   const [archiveTree, setArchiveTree] = useState(createBasicTree({ work }));
   const [tabbableId, setTabbableId] = useState<string>();
   const openButtonRef = useRef(null);
+  const isArchive = useContext(IsArchiveContext);
 
   useEffect(() => {
     const elementToFocus = tabbableId && document.getElementById(tabbableId);
@@ -850,9 +852,6 @@ const ArchiveTree: FunctionComponent<{ work: Work }> = ({
   }, [archiveTree, tabbableId]);
 
   const selected = useRef<HTMLAnchorElement>(null);
-  const isInArchive =
-    (work.parts && work.parts.length > 0) ||
-    (work.partOf && work.partOf.length > 0);
 
   useEffect(() => {
     async function setupTree() {
@@ -879,7 +878,7 @@ const ArchiveTree: FunctionComponent<{ work: Work }> = ({
     initialLoad.current = false;
   }, [work.id]);
 
-  return isInArchive ? (
+  return isArchive ? (
     <>
       {windowSize === 'small' && isEnhanced ? (
         <>

--- a/common/views/components/IsArchiveContext/IsArchiveContext.tsx
+++ b/common/views/components/IsArchiveContext/IsArchiveContext.tsx
@@ -1,0 +1,4 @@
+import { createContext } from 'react';
+
+const IsArchiveContext = createContext<boolean>(false);
+export default IsArchiveContext;


### PR DESCRIPTION
## Who is this for?
People looking at physical items on archive pages

## What is it doing for them?
Stacking the physical item details sooner on account of the reduced space in the right-hand column

Adding an `IsArchiveContext` to avoid having to drill props down several layers of components that shouldn't have to care about whether the page they're on is an archive page or not.

![image](https://user-images.githubusercontent.com/1394592/126791648-8a203b35-3bed-446b-bb8f-e4cb6d52b90e.png)
