### PR TITLE
Remove colour square from location

### DIFF
--- a/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
+++ b/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
@@ -41,15 +41,6 @@ const Box = styled(Space).attrs<{ isCentered?: boolean }>(props => ({
     align-self: center;
   `}
 `;
-const Color = styled(Space).attrs({
-  h: { size: 's', properties: ['margin-left'] },
-})<{ color: string }>`
-  width: 1em;
-  height: 1em;
-  display: inline-flex;
-  transform: translateY(0.1em);
-  background: ${props => props.color};
-`;
 
 export type Props = {
   title: string;
@@ -58,7 +49,6 @@ export type Props = {
   accessMethod?: string;
   requestItemUrl?: string;
   accessNote?: string;
-  color?: string;
 };
 
 const PhysicalItemDetails: FunctionComponent<Props> = ({
@@ -68,7 +58,6 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
   accessMethod,
   requestItemUrl,
   accessNote,
-  color,
 }) => {
   const isArchive = useContext(IsArchiveContext);
 
@@ -89,7 +78,6 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
           <Box>
             <DetailHeading>Location</DetailHeading>
             <span>{locationAndShelfmark}</span>
-            {color && <Color color={color} />}
           </Box>
           <Box>
             <DetailHeading>Access</DetailHeading>

--- a/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
+++ b/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
@@ -27,35 +27,11 @@ function getFirstPhysicalLocation(item) {
   return item.locations?.find(location => location.type === 'PhysicalLocation');
 }
 
-// FIXME: These hex values are screengrabbed from a photo of a sign in the building
-// They're not like anything we've got in the palette (not to mention they're
-// quite hard to tell apart for people with less-than-perfect colour vision).
-function getColorForLocation(label: string): string | undefined {
-  switch (label) {
-    case 'Journals':
-      return '#720013';
-    case 'History of Medicine':
-    case 'History of Medicine Collection':
-      return '#9b3700';
-    case 'Medical Collection':
-      return '#a96900';
-    case 'Quick Reference':
-    case 'Quick Ref. Collection':
-      return '#00407e';
-    default:
-      return undefined;
-  }
-}
-
 function createPhysicalItem(
   item: PhysicalItem,
   encoreLink: string | undefined
 ): PhysicalItemProps | undefined {
   const physicalLocation = getFirstPhysicalLocation(item);
-  const isOnOpenShelves = physicalLocation?.locationType?.id === 'open-shelves';
-  const color = isOnOpenShelves
-    ? getColorForLocation(physicalLocation.label)
-    : undefined;
   const isRequestableOnline =
     physicalLocation?.accessConditions?.[0]?.method?.id === 'online-request';
   const accessMethodLabel =
@@ -74,7 +50,6 @@ function createPhysicalItem(
     accessMethod: accessMethodLabel,
     requestItemUrl: isRequestableOnline ? encoreLink : undefined,
     accessNote: accessNote,
-    color: color,
   };
 }
 


### PR DESCRIPTION
The colour square is no longer required for the initial release.

__Before__
![image](https://user-images.githubusercontent.com/1394592/127143995-d28ec67e-9eb1-4baa-b8fc-b74ebe96b824.png)


__After__
![image](https://user-images.githubusercontent.com/1394592/127143950-1fdc103d-ccb0-47aa-a642-dc6cb1e6b82b.png)
