### PR TITLE
Use memoized prismic for all cached values

### DIFF
--- a/common/koa-middleware/withCachedValues.js
+++ b/common/koa-middleware/withCachedValues.js
@@ -8,12 +8,12 @@ const withPrismicPreviewStatus = require('./withPrismicPreviewStatus');
 const withMemoizedPrismic = require('./withMemoizedPrismic');
 
 const withCachedValues = compose([
+  withMemoizedPrismic,
   withGlobalAlert,
   withPopupDialog,
   withOpeningtimes,
   withToggles,
   withPrismicPreviewStatus,
-  withMemoizedPrismic,
 ]);
 
 async function route(path, page, router, app, extraParams = {}) {

--- a/common/koa-middleware/withGlobalAlert.js
+++ b/common/koa-middleware/withGlobalAlert.js
@@ -1,22 +1,14 @@
-const Prismic = require('prismic-javascript');
+const withMemoizedPrismicValue = require('./withMemoizedPrismicValue');
 
-let globalAlert = {
-  text: [{ type: 'paragraph', text: null, spans: null }],
-  isShown: 'hide',
-};
-async function getAndSetGlobalAlert() {
-  try {
-    const api = await Prismic.getApi(
-      'https://wellcomecollection.prismic.io/api/v2'
-    );
-    const document = await api.getSingle('global-alert');
-    globalAlert = document.data;
-  } catch (e) {
-    // TODO: Alert to sentry
-  }
-}
-setInterval(getAndSetGlobalAlert, 60000);
-module.exports = function withGlobalAlert(ctx, next) {
-  ctx.globalAlert = globalAlert;
-  return next();
-};
+module.exports = withMemoizedPrismicValue({
+  name: 'globalAlert',
+  getValueFromApi: async api => {
+    try {
+      const document = await api.getSingle('global-alert');
+      return document.data;
+    } catch (e) {
+      // TODO: Alert to sentry
+    }
+  },
+  refreshInterval: 60 * 1000,
+});

--- a/common/koa-middleware/withMemoizedPrismic.js
+++ b/common/koa-middleware/withMemoizedPrismic.js
@@ -13,7 +13,10 @@ async function getMemoizedPrismic() {
 }
 
 setInterval(getMemoizedPrismic, oneMinute);
-module.exports = function withPrismicAPI(ctx, next) {
+module.exports = async function withPrismicAPI(ctx, next) {
+  if (!memoizedPrismic) {
+    await getMemoizedPrismic();
+  }
   ctx.memoizedPrismic = memoizedPrismic;
   return next();
 };

--- a/common/koa-middleware/withMemoizedPrismicValue.js
+++ b/common/koa-middleware/withMemoizedPrismicValue.js
@@ -1,0 +1,22 @@
+const withMemoizedPrismicValue = ({
+  name,
+  getValueFromApi,
+  refreshInterval,
+}) => {
+  let memoized;
+  let lastUpdated = Number.MAX_VALUE;
+  const refresh = async memoizedPrismic => {
+    memoized = await getValueFromApi(memoizedPrismic);
+    lastUpdated = Date.now();
+  };
+
+  return async (ctx, next) => {
+    if (!memoized || Date.now() - lastUpdated > refreshInterval) {
+      await refresh(ctx.memoizedPrismic);
+    }
+    ctx[name] = memoized;
+    return next();
+  };
+};
+
+module.exports = withMemoizedPrismicValue;

--- a/common/koa-middleware/withOpeningTimes.js
+++ b/common/koa-middleware/withOpeningTimes.js
@@ -1,19 +1,16 @@
 const Prismic = require('prismic-javascript');
+const withMemoizedPrismicValue = require('./withMemoizedPrismicValue');
 
-let openingTimes = { results: [] };
-async function getAndSetOpeningTimes() {
-  try {
-    const api = await Prismic.getApi(
-      'https://wellcomecollection.prismic.io/api/v2'
-    );
-    openingTimes = await api.query([
-      Prismic.Predicates.any('document.type', ['collection-venue']),
-    ]);
-  } catch (e) {}
-}
-
-setInterval(getAndSetOpeningTimes, 60000);
-module.exports = function withGlobalAlert(ctx, next) {
-  ctx.openingTimes = openingTimes;
-  return next();
-};
+module.exports = withMemoizedPrismicValue({
+  name: 'openingTimes',
+  getValueFromApi: api => {
+    try {
+      return api.query([
+        Prismic.Predicates.any('document.type', ['collection-venue']),
+      ]);
+    } catch (e) {
+      // TODO: Alert to sentry
+    }
+  },
+  refreshInterval: 60 * 1000,
+});

--- a/common/koa-middleware/withPopupDialog.js
+++ b/common/koa-middleware/withPopupDialog.js
@@ -1,29 +1,14 @@
-const Prismic = require('prismic-javascript');
+const withMemoizedPrismicValue = require('./withMemoizedPrismicValue');
 
-let popupDialog = {
-  openButtonText: null,
-  title: null,
-  text: [],
-  linkText: null,
-  link: { url: null },
-  isShown: false,
-};
-
-async function getAndSetPopupDialog() {
-  try {
-    const api = await Prismic.getApi(
-      'https://wellcomecollection.prismic.io/api/v2'
-    );
-    const document = await api.getSingle('popup-dialog');
-
-    popupDialog = document.data;
-  } catch (e) {
-    // TODO: Sentry?
-  }
-}
-setInterval(getAndSetPopupDialog, 60000);
-
-module.exports = function withPopupDialog(ctx, next) {
-  ctx.popupDialog = popupDialog;
-  return next();
-};
+module.exports = withMemoizedPrismicValue({
+  name: 'popupDialog',
+  getValueFromApi: async api => {
+    try {
+      const document = await api.getSingle('popup-dialog');
+      return document.data;
+    } catch (e) {
+      // TODO: Alert to sentry
+    }
+  },
+  refreshInterval: 60 * 1000,
+});


### PR DESCRIPTION
You may have noticed that `/whats-on` doesn't work until a minute after the application has started, and other pages have missing data until that time.

This doesn't matter in the context of the website because task registration takes longer than that and so hides the problem, but it was causing lighthouse reports to fail. 

The cause of the issue was the use of `setInterval(fetchValue, oneMinute)` - which doesn't run until a minute after startup. As well as fixing this, I made the change to use `memoizedPrismic` for all of its derivative memoized values, rather than re-fetching an API instance for each one.