### PR TITLE
Remove memoizedPrismic from ctx.query in catalogue app

### DIFF
--- a/catalogue/webapp/pages/_app.tsx
+++ b/catalogue/webapp/pages/_app.tsx
@@ -29,6 +29,10 @@ export default function CatalogueApp(props: WecoAppProps) {
 // require different prefixes).
 CatalogueApp.getInitialProps = async (appContext: AppContext) => {
   const globalContextData = getGlobalContextData(appContext.ctx);
+
+  // TODO don't store things like this on `ctx.query`
+  delete appContext.ctx.query.memoizedPrismic; // We need to remove memoizedPrismic value here otherwise we hit circular object issues with JSON.stringify
+
   const initialProps = await NextApp.getInitialProps(appContext);
   return { ...initialProps, globalContextData };
 };


### PR DESCRIPTION
This replicates https://github.com/wellcomecollection/wellcomecollection.org/blob/bae23808de8c91cc5bcb080a15b91bbb2889ec4e/common/views/pages/_app-deprecated.js#L179, it isn't ideal but it gets things working for now