### PR TITLE
download options on works that are open with advisory

### DIFF
--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -51,7 +51,7 @@ type Props = {
   work: Work;
 };
 
-// At the moment we aren't set up to cope with access conditions 'open-with-advisory, 'restricted',
+// At the moment we aren't set up to cope with access conditions,
 // 'permission-required', so we pass them off to the UV on the library site
 // If we have audio or video, then we show it in situ and don't link to the Item page
 type ItemLinkState = 'useItemLink' | 'useLibraryLink' | 'useNoLink';
@@ -193,8 +193,15 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
     return ![...orderedNotes, locationOfWork].some(n => n === note);
   });
 
-  const showDownloadOptions =
-    iiifDownloadEnabled !== undefined ? iiifDownloadEnabled : true;
+  function determineDownloadVisibility(iiifDownloadEnabled) {
+    if (digitalLocationInfo?.accessCondition === 'open-with-advisory') {
+      return false;
+    } else {
+      return iiifDownloadEnabled !== undefined ? iiifDownloadEnabled : true;
+    }
+  }
+
+  const showDownloadOptions = determineDownloadVisibility(iiifDownloadEnabled);
 
   const itemLinkState = getItemLinkState({
     accessCondition: digitalLocationInfo?.accessCondition,


### PR DESCRIPTION
References #6840

This stops the download options showing on works that have an access condition of open with advisory.
This is because they don't work until the user has accepted the consent message, which is only possible on the item page at present.

We may want to look at adding the open with advisory consent on the work page, but until that is discussed, this stops people ending up with an error.

To download such works the user will have to view the item, accept the consent message and then use the download options on the item page.

![download](https://user-images.githubusercontent.com/6051896/127349771-fabdee35-4a8e-46d1-8f6a-e1c4a817dcfe.gif)


![Screenshot 2021-07-28 at 16 15 16](https://user-images.githubusercontent.com/6051896/127349450-67a004d6-edb4-4653-9c95-aa66dcd01a77.png)

![Screenshot 2021-07-28 at 16 14 27](https://user-images.githubusercontent.com/6051896/127349472-626bd6a1-8437-42de-8d51-60bc24b3b583.png)


