### PR TITLE
Use PhysicalItem type for PhysicalItemDetails

### DIFF
--- a/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
+++ b/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
@@ -4,6 +4,11 @@ import ButtonInlineLink from '@weco/common/views/components/ButtonInlineLink/But
 import Space from '@weco/common/views/components/styled/Space';
 import { classNames, font } from '@weco/common/utils/classnames';
 import IsArchiveContext from '@weco/common/views/components/IsArchiveContext/IsArchiveContext';
+import { PhysicalItem, PhysicalLocation } from '@weco/common/model/catalogue';
+import {
+  getLocationLabel,
+  getLocationShelfmark,
+} from '@weco/common/utils/works';
 
 const Row = styled(Space).attrs({
   v: { size: 'm', properties: ['margin-bottom'] },
@@ -56,26 +61,39 @@ const Grid = styled.div<{ isArchive: boolean }>`
 `;
 
 export type Props = {
-  title: string;
-  itemNote?: string;
-  location: string;
-  shelfmark: string;
-  accessMethod?: string;
-  requestItemUrl?: string;
-  accessNote?: string;
+  item: PhysicalItem;
+  encoreLink?: string;
+  isLast: boolean;
 };
 
-const PhysicalItemDetails: FunctionComponent<Props & { isLast: boolean }> = ({
-  title,
-  itemNote,
-  location,
-  shelfmark,
-  accessMethod,
-  requestItemUrl,
-  accessNote,
+function getFirstPhysicalLocation(
+  item: PhysicalItem
+): PhysicalLocation | undefined {
+  // In practice we only expect one physical location per item
+  return item.locations?.find(location => location.type === 'PhysicalLocation');
+}
+
+const PhysicalItemDetails: FunctionComponent<Props> = ({
+  item,
+  encoreLink,
   isLast,
 }) => {
   const isArchive = useContext(IsArchiveContext);
+  const physicalLocation = getFirstPhysicalLocation(item);
+  const isRequestableOnline =
+    physicalLocation?.accessConditions?.[0]?.method?.id === 'online-request';
+  const accessMethod =
+    physicalLocation?.accessConditions?.[0]?.method?.label || '';
+  const accessNote = physicalLocation?.accessConditions?.[0]?.note;
+  const locationLabel = physicalLocation && getLocationLabel(physicalLocation);
+  const locationShelfmark =
+    physicalLocation && getLocationShelfmark(physicalLocation);
+
+  const title = item.title || '';
+  const itemNote = item.note || '';
+  const location = locationLabel || '';
+  const shelfmark = locationShelfmark || '';
+  const requestItemUrl = isRequestableOnline ? encoreLink : undefined;
 
   return (
     <Wrapper underline={!isLast}>

--- a/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
+++ b/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
@@ -1,16 +1,10 @@
 import { FunctionComponent, useState, useEffect } from 'react';
-import PhysicalItemDetails, {
-  Props as PhysicalItemDetailsProps,
-} from '../PhysicalItemDetails/PhysicalItemDetails';
+import PhysicalItemDetails from '../PhysicalItemDetails/PhysicalItemDetails';
 import {
   PhysicalItem,
   ItemsWork,
   CatalogueApiError,
 } from '@weco/common/model/catalogue';
-import {
-  getLocationLabel,
-  getLocationShelfmark,
-} from '@weco/common/utils/works';
 import { isCatalogueApiError } from '../../pages/api/works/items/[workId]';
 import ExpandableList from '@weco/common/views/components/ExpandableList/ExpandableList';
 
@@ -20,42 +14,6 @@ async function fetchWorkItems(
   const items = await fetch(`/api/works/items/${workId}`);
   const itemsJson = await items.json();
   return itemsJson;
-}
-
-function getFirstPhysicalLocation(item) {
-  // In practice we only expect one physical location per item
-  return item.locations?.find(location => location.type === 'PhysicalLocation');
-}
-
-function createPhysicalItem(
-  item: PhysicalItem,
-  encoreLink: string | undefined
-): PhysicalItemDetailsProps | undefined {
-  const physicalLocation = getFirstPhysicalLocation(item);
-  const isRequestableOnline =
-    physicalLocation?.accessConditions?.[0]?.method?.id === 'online-request';
-  const accessMethodLabel =
-    physicalLocation?.accessConditions?.[0]?.method?.label || '';
-  const accessNote = physicalLocation?.accessConditions?.[0]?.note;
-  const locationLabel = physicalLocation && getLocationLabel(physicalLocation);
-  const locationShelfmark =
-    physicalLocation && getLocationShelfmark(physicalLocation);
-
-  return {
-    title: item.title || '',
-    itemNote: item.note || '',
-    location: locationLabel || '',
-    shelfmark: locationShelfmark || '',
-    accessMethod: accessMethodLabel,
-    requestItemUrl: isRequestableOnline ? encoreLink : undefined,
-    accessNote: accessNote,
-  };
-}
-
-function createPhysicalItems(items, encoreLink) {
-  return items
-    .map(item => createPhysicalItem(item, encoreLink))
-    .filter(Boolean);
 }
 
 type Props = {
@@ -70,7 +28,6 @@ const PhysicalItems: FunctionComponent<Props> = ({
   encoreLink,
 }: Props) => {
   const [physicalItems, setPhysicalItems] = useState(items);
-  const itemsToRender = createPhysicalItems(physicalItems, encoreLink);
 
   useEffect(() => {
     const addStatusToItems = async () => {
@@ -97,10 +54,11 @@ const PhysicalItems: FunctionComponent<Props> = ({
 
   return (
     <ExpandableList
-      listItems={itemsToRender.map((props, index) => (
+      listItems={physicalItems.map((item, index) => (
         <PhysicalItemDetails
-          {...props}
-          isLast={index === itemsToRender.length - 1}
+          item={item}
+          encoreLink={encoreLink}
+          isLast={index === physicalItems.length - 1}
           key={index}
         />
       ))}

--- a/common/model/catalogue.ts
+++ b/common/model/catalogue.ts
@@ -165,6 +165,14 @@ type AccessCondition = {
   terms?: string;
   to?: string;
   type: 'AccessCondition';
+  method?: AccessMethod;
+  note?: string;
+};
+
+type AccessMethod = {
+  id: string;
+  label: string;
+  type: 'AccessMethod';
 };
 
 type AccessStatus = {


### PR DESCRIPTION
Using what we get from the API for types in the `PhysicalItemDetails` component (per [this suggestion](https://github.com/wellcomecollection/wellcomecollection.org/pull/6838#discussion_r678253277)).