### PR TITLE
Search tabs

### DIFF
--- a/common/views/components/BaseTabs/BaseTabs.tsx
+++ b/common/views/components/BaseTabs/BaseTabs.tsx
@@ -9,9 +9,11 @@ import {
   FunctionComponent,
   Fragment,
 } from 'react';
-import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
+import { AppContext } from '../AppContext/AppContext';
 import styled from 'styled-components';
-import { classNames } from '@weco/common/utils/classnames';
+import { classNames } from '../../../utils/classnames';
+import Space from '../styled/Space';
+import ConditionalWrapper from '../ConditionalWrapper/ConditionalWrapper';
 
 const TabList = styled.div.attrs({
   role: 'tablist',
@@ -50,7 +52,7 @@ type TabPanelProps = {
 const TabPanel = styled.div.attrs((props: TabPanelProps) => ({
   id: props.id,
   role: props.isEnhanced ? 'tabpanel' : undefined,
-  hidden: !props.isActive,
+  hidden: props.isEnhanced ? !props.isActive : false,
   'aria-expanded': props.isEnhanced ? props.isActive : undefined,
 }))<TabPanelProps>``;
 
@@ -149,9 +151,9 @@ const Tabs: FunctionComponent<Props> = ({
   return (
     <>
       {/* if isEnhanced then we want to create the tablist to control the panels,
-      if not then the tabs will be appear above there respective panel (see below)
+      if not then the tabs will be appear above their respective panel (see below)
       */}
-      {isEnhanced &&
+      {isEnhanced && (
         <TabList ref={tabListRef} aria-label={label}>
           {tabs.map(({ id, tab }) => (
             <Tab
@@ -168,19 +170,28 @@ const Tabs: FunctionComponent<Props> = ({
             </Tab>
           ))}
         </TabList>
-      }
+      )}
       {tabs.map(({ id, tab, tabPanel }) => (
         <Fragment key={id}>
           {/* if it's not enhanced the tab appears above its related panel */}
-          {!isEnhanced && tab(id === activeId, false)}
-          <TabPanel
-            key={id}
-            id={id}
-            isActive={id === activeId}
-            isEnhanced={isEnhanced}
+          {!isEnhanced && tab(id === activeId || !isEnhanced, false)}
+          <ConditionalWrapper
+            condition={!isEnhanced}
+            wrapper={children => (
+              <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
+                {children}
+              </Space>
+            )}
           >
-            {tabPanel}
-          </TabPanel>
+            <TabPanel
+              key={id}
+              id={id}
+              isActive={id === activeId}
+              isEnhanced={isEnhanced}
+            >
+              {tabPanel}
+            </TabPanel>
+          </ConditionalWrapper>
         </Fragment>
       ))}
     </>

--- a/common/views/components/BaseTabs/BaseTabs.tsx
+++ b/common/views/components/BaseTabs/BaseTabs.tsx
@@ -52,7 +52,7 @@ type TabPanelProps = {
 const TabPanel = styled.div.attrs((props: TabPanelProps) => ({
   id: props.id,
   role: props.isEnhanced ? 'tabpanel' : undefined,
-  hidden: props.isEnhanced ? !props.isActive : false,
+  hidden: !props.isActive,
   'aria-expanded': props.isEnhanced ? props.isActive : undefined,
 }))<TabPanelProps>``;
 
@@ -174,7 +174,9 @@ const Tabs: FunctionComponent<Props> = ({
       {tabs.map(({ id, tab, tabPanel }) => (
         <Fragment key={id}>
           {/* if it's not enhanced the tab appears above its related panel */}
-          {!isEnhanced && tab(id === activeId || !isEnhanced, false)}
+          {!isEnhanced && (
+            <noscript>{tab(id === activeId || !isEnhanced, false)}</noscript>
+          )}
           <ConditionalWrapper
             condition={!isEnhanced}
             wrapper={children => (
@@ -191,6 +193,16 @@ const Tabs: FunctionComponent<Props> = ({
             >
               {tabPanel}
             </TabPanel>
+            <noscript>
+              <TabPanel
+                key={id}
+                id={`${id}-2`}
+                isActive={id !== activeId}
+                isEnhanced={isEnhanced}
+              >
+                {tabPanel}
+              </TabPanel>
+            </noscript>
           </ConditionalWrapper>
         </Fragment>
       ))}

--- a/common/views/components/SearchForm/SearchForm.tsx
+++ b/common/views/components/SearchForm/SearchForm.tsx
@@ -29,16 +29,6 @@ import { LinkProps } from '../../../model/link-props';
 import { Filter } from '../../../services/catalogue/filters';
 import { formDataAsUrlQuery } from '../../../utils/forms';
 
-type StyledFormProps = {
-  isEnhanced: boolean
-}
-
-const StyledForm = styled(Space).attrs((props: StyledFormProps) => ({
-  as: 'form',
-  v: props.isEnhanced ? {} : { size: 'l', properties: ['margin-bottom'] },
-}))<StyledFormProps>`
-`;
-
 const SearchInputWrapper = styled.div`
   font-size: 20px;
 

--- a/common/views/components/SearchForm/SearchForm.tsx
+++ b/common/views/components/SearchForm/SearchForm.tsx
@@ -74,219 +74,225 @@ type Props = {
   filters: Filter[];
 };
 
-const SearchForm = forwardRef(({
-  query,
-  sort,
-  sortOrder,
-  linkResolver,
-  ariaDescribedBy,
-  isImageSearch,
-  shouldShowFilters,
-  showSortBy,
-  filters,
-}: Props,
-  ref): ReactElement<Props> => {
-  const { isEnhanced } = useContext(AppContext);
-  const searchForm = useRef<HTMLFormElement>(null);
-  // This is the query used by the input, that is then eventually passed to the
-  // Router
-  const [inputQuery, setInputQuery] = useState(query);
-  const searchInput = useRef<HTMLInputElement>(null);
-  const [forceState, setForceState] = useState(false);
-  const [portalSortOrder, setPortalSortOrder] = useState(sortOrder);
-
-  function submit() {
-    searchForm.current &&
-      searchForm.current.dispatchEvent(
-        new window.Event('submit', { cancelable: true })
-      );
-  }
-
-  useImperativeHandle(ref, () => ({
-    submit
-  }))
-
-  useEffect(() => {
-    // This has been added in as the rerendering of createPortal does not trigger
-    // Manually force this to trigger to rerender so the createPortal gets created
-    // The refresh or going to another page does not retrigger the createPortal call
-    // This is referred inside the paginator component
-    // Adhoc: Added set timeout for some reason allows it to work.
-    setTimeout(() => {
-      !forceState && setForceState(true);
-    }, 0);
-  }, []);
-
-  // We need to make sure that the changes to `query` affect `inputQuery` as
-  // when we navigate between pages which all contain `SearchForm`, each
-  // instance of that component maintains it's own state so they go out of sync.
-  // TODO: Think about if this is worth it.
-  useEffect(() => {
-    if (query !== inputQuery) {
-      setInputQuery(query);
-    }
-  }, [query]);
-
-  useEffect(() => {
-    if (portalSortOrder !== sortOrder) {
-      submit();
-    }
-  }, [portalSortOrder]);
-
-  function updateUrl(form: HTMLFormElement) {
-    const urlQuery = formDataAsUrlQuery(form);
-
-    // TODO: remove sortOrder
-    // We do this as the JS form uses a portal, due to the control being
-    // outside of the for to obtain this value.
-    const sort =
-      portalSortOrder === 'asc' || portalSortOrder === 'desc'
-        ? 'production.dates'
-        : undefined;
-
-    const link = linkResolver({
-      ...urlQuery,
-      sortOrder: portalSortOrder,
+const SearchForm = forwardRef(
+  (
+    {
+      query,
       sort,
-    });
+      sortOrder,
+      linkResolver,
+      ariaDescribedBy,
+      isImageSearch,
+      shouldShowFilters,
+      showSortBy,
+      filters,
+    }: Props,
+    ref
+  ): ReactElement<Props> => {
+    const { isEnhanced } = useContext(AppContext);
+    const searchForm = useRef<HTMLFormElement>(null);
+    // This is the query used by the input, that is then eventually passed to the
+    // Router
+    const [inputQuery, setInputQuery] = useState(query);
+    const searchInput = useRef<HTMLInputElement>(null);
+    const [forceState, setForceState] = useState(false);
+    const [portalSortOrder, setPortalSortOrder] = useState(sortOrder);
 
-    return Router.push(link.href, link.as);
-  }
+    function submit() {
+      searchForm.current &&
+        searchForm.current.dispatchEvent(
+          new window.Event('submit', { cancelable: true })
+        );
+    }
 
-  return (
-    <form
-      role="search"
-      ref={searchForm}
-      className="relative"
-      action={isImageSearch ? '/images' : '/works'}
-      aria-describedby={ariaDescribedBy}
-      onSubmit={event => {
-        event.preventDefault();
+    useImperativeHandle(ref, () => ({
+      submit,
+    }));
 
-        trackEvent({
-          category: 'SearchForm',
-          action: 'submit search',
-          label: query,
-        });
+    useEffect(() => {
+      // This has been added in as the rerendering of createPortal does not trigger
+      // Manually force this to trigger to rerender so the createPortal gets created
+      // The refresh or going to another page does not retrigger the createPortal call
+      // This is referred inside the paginator component
+      // Adhoc: Added set timeout for some reason allows it to work.
+      setTimeout(() => {
+        !forceState && setForceState(true);
+      }, 0);
+    }, []);
 
-        updateUrl(event.currentTarget);
-        return false;
-      }}
-    >
-      <Space
-        h={{ size: 'l', properties: ['padding-left', 'padding-right'] }}
-        v={{ size: 'm', properties: ['padding-top', 'padding-bottom'] }}
+    // We need to make sure that the changes to `query` affect `inputQuery` as
+    // when we navigate between pages which all contain `SearchForm`, each
+    // instance of that component maintains it's own state so they go out of sync.
+    // TODO: Think about if this is worth it.
+    useEffect(() => {
+      if (query !== inputQuery) {
+        setInputQuery(query);
+      }
+    }, [query]);
+
+    useEffect(() => {
+      if (portalSortOrder !== sortOrder) {
+        submit();
+      }
+    }, [portalSortOrder]);
+
+    function updateUrl(form: HTMLFormElement) {
+      const urlQuery = formDataAsUrlQuery(form);
+
+      // TODO: remove sortOrder
+      // We do this as the JS form uses a portal, due to the control being
+      // outside of the for to obtain this value.
+      const sort =
+        portalSortOrder === 'asc' || portalSortOrder === 'desc'
+          ? 'production.dates'
+          : undefined;
+
+      const link = linkResolver({
+        ...urlQuery,
+        sortOrder: portalSortOrder,
+        sort,
+      });
+
+      return Router.push(link.href, link.as);
+    }
+
+    return (
+      <form
+        role="search"
+        ref={searchForm}
+        className="relative"
+        action={isImageSearch ? '/images' : '/works'}
+        aria-describedby={ariaDescribedBy}
+        onSubmit={event => {
+          event.preventDefault();
+
+          trackEvent({
+            category: 'SearchForm',
+            action: 'submit search',
+            label: query,
+          });
+
+          updateUrl(event.currentTarget);
+          return false;
+        }}
       >
-        <SearchInputWrapper className="relative">
-          <TextInput
-            id={`${isImageSearch ? 'images' : 'works'}-search-input`}
-            label={isImageSearch ? 'Search for images' : 'Search the catalogue'}
-            name="query"
-            value={inputQuery}
-            setValue={setInputQuery}
-            ref={searchInput}
-            required={true}
-            big={true}
-            placeholder={''}
-            ariaLabel={
-              isImageSearch ? searchFormInputImage : searchFormInputCatalogue
-            }
-          />
-
-          {inputQuery && (
-            <ClearSearch
-              inputRef={searchInput}
+        <Space
+          h={{ size: 'l', properties: ['padding-left', 'padding-right'] }}
+          v={{ size: 'm', properties: ['padding-top', 'padding-bottom'] }}
+        >
+          <SearchInputWrapper className="relative">
+            <TextInput
+              id={`${isImageSearch ? 'images' : 'works'}-search-input`}
+              label={
+                isImageSearch ? 'Search for images' : 'Search the catalogue'
+              }
+              name="query"
+              value={inputQuery}
               setValue={setInputQuery}
-              gaEvent={{
-                category: 'SearchForm',
-                action: 'clear search',
-                label: 'works-search',
-              }}
-              right={102}
+              ref={searchInput}
+              required={true}
+              big={true}
+              placeholder={''}
+              ariaLabel={
+                isImageSearch ? searchFormInputImage : searchFormInputCatalogue
+              }
             />
-          )}
-        </SearchInputWrapper>
-      </Space>
-      {shouldShowFilters && (
-        <SearchFilters
-          query={query}
-          linkResolver={linkResolver}
-          searchForm={searchForm}
-          changeHandler={submit}
-          filters={filters}
-        />
-      )}
-      {!isImageSearch && isEnhanced && (
-        <SearchFormSortByPortal id="sort-select-portal">
-          <SearchSortOrderWrapper>
-            <Select
-              name="portalSortOrder"
-              label="Sort by:"
-              value={portalSortOrder || ''}
-              options={[
-                {
-                  value: '',
-                  text: 'Relevance',
-                },
-                {
-                  value: 'asc',
-                  text: 'Oldest to newest',
-                },
-                {
-                  value: 'desc',
-                  text: 'Newest to oldest',
-                },
-              ]}
-              onChange={event => {
-                setPortalSortOrder(event.currentTarget.value);
-              }}
-            />
-          </SearchSortOrderWrapper>
-        </SearchFormSortByPortal>
-      )}
-      <noscript>
-        {!isImageSearch && showSortBy && (
-          <>
-            <Space v={{ size: 's', properties: ['margin-bottom'] }}>
-              <SelectUncontrolled
-                name="sort"
-                label="Sort by"
-                defaultValue={sort || ''}
+
+            {inputQuery && (
+              <ClearSearch
+                inputRef={searchInput}
+                setValue={setInputQuery}
+                gaEvent={{
+                  category: 'SearchForm',
+                  action: 'clear search',
+                  label: 'works-search',
+                }}
+                right={102}
+              />
+            )}
+          </SearchInputWrapper>
+        </Space>
+        {shouldShowFilters && (
+          <SearchFilters
+            query={query}
+            linkResolver={linkResolver}
+            searchForm={searchForm}
+            changeHandler={submit}
+            filters={filters}
+          />
+        )}
+        {!isImageSearch && isEnhanced && (
+          <SearchFormSortByPortal id="sort-select-portal">
+            <SearchSortOrderWrapper>
+              <Select
+                name="portalSortOrder"
+                label="Sort by:"
+                value={portalSortOrder || ''}
                 options={[
                   {
                     value: '',
                     text: 'Relevance',
                   },
                   {
-                    value: 'production.dates',
-                    text: 'Production dates',
+                    value: 'asc',
+                    text: 'Oldest to newest',
+                  },
+                  {
+                    value: 'desc',
+                    text: 'Newest to oldest',
+                  },
+                ]}
+                onChange={event => {
+                  setPortalSortOrder(event.currentTarget.value);
+                }}
+              />
+            </SearchSortOrderWrapper>
+          </SearchFormSortByPortal>
+        )}
+        <noscript>
+          {!isImageSearch && showSortBy && (
+            <>
+              <Space v={{ size: 's', properties: ['margin-bottom'] }}>
+                <SelectUncontrolled
+                  name="sort"
+                  label="Sort by"
+                  defaultValue={sort || ''}
+                  options={[
+                    {
+                      value: '',
+                      text: 'Relevance',
+                    },
+                    {
+                      value: 'production.dates',
+                      text: 'Production dates',
+                    },
+                  ]}
+                />
+              </Space>
+              <SelectUncontrolled
+                name="sortOrder"
+                label="Sort order"
+                defaultValue={sortOrder || ''}
+                options={[
+                  {
+                    value: 'asc',
+                    text: 'Ascending',
+                  },
+                  {
+                    value: 'desc',
+                    text: 'Descending',
                   },
                 ]}
               />
-            </Space>
-            <SelectUncontrolled
-              name="sortOrder"
-              label="Sort order"
-              defaultValue={sortOrder || ''}
-              options={[
-                {
-                  value: 'asc',
-                  text: 'Ascending',
-                },
-                {
-                  value: 'desc',
-                  text: 'Descending',
-                },
-              ]}
-            />
-          </>
-        )}
-      </noscript>
-      <SearchButtonWrapper>
-        <ButtonSolid text="Search" isTextHidden={false} isBig={true} />
-      </SearchButtonWrapper>
-    </form>
-  );
-});
+            </>
+          )}
+        </noscript>
+        <SearchButtonWrapper>
+          <ButtonSolid text="Search" isTextHidden={false} isBig={true} />
+        </SearchButtonWrapper>
+      </form>
+    );
+  }
+);
 
 export default SearchForm;

--- a/common/views/components/SearchTabs/SearchTabs.tsx
+++ b/common/views/components/SearchTabs/SearchTabs.tsx
@@ -133,7 +133,7 @@ const SearchTabs: FunctionComponent<Props> = ({
                   className={classNames({
                     'plain-link': true,
                   })}
-                  aria-current={isActive ? "page" : undefined}
+                  aria-current={isActive ? 'page' : undefined}
                 >
                   {children}
                 </a>
@@ -225,7 +225,7 @@ const SearchTabs: FunctionComponent<Props> = ({
                   className={classNames({
                     'plain-link': true,
                   })}
-                  aria-current={isActive ? "page" : undefined}
+                  aria-current={isActive ? 'page' : undefined}
                 >
                   {children}
                 </a>
@@ -293,7 +293,7 @@ const SearchTabs: FunctionComponent<Props> = ({
   ];
 
   function onTabClick(id: string) {
-    if(id === 'tab-images'){
+    if (id === 'tab-images') {
       searchImagesFormRef?.current?.submit();
     } else {
       searchWorksFormRef?.current?.submit();


### PR DESCRIPTION
Fixes #6841

- Shows all panels in no js world
- improves layout and styling of no js tabs

With javascript:
![Screenshot 2021-07-29 at 15 31 31](https://user-images.githubusercontent.com/6051896/127511057-c2c33558-d58f-48b7-93b1-05a204627bcc.png)

Without javascript:
![Screenshot 2021-07-29 at 15 36 20](https://user-images.githubusercontent.com/6051896/127511550-fc51e1e6-5a58-448e-bf4a-32a7de711ce4.png)

What it currently looks like without javascript:
![Screenshot 2021-07-29 at 15 35 34](https://user-images.githubusercontent.com/6051896/127511667-44cb1077-b612-4d93-b77b-c39e82eef004.png)

