### PR TITLE
Use the prod/stage networking for the identity-admin app

### DIFF
--- a/identity-admin/terraform/.terraform.lock.hcl
+++ b/identity-admin/terraform/.terraform.lock.hcl
@@ -2,22 +2,9 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "2.47.0"
-  constraints = "~> 2.47.0"
+  version = "3.52.0"
   hashes = [
-    "h1:3qUZ+SZqdtlxCd4Luyz+MqHclZvnigwrY8LyKvIvq4U=",
-    "zh:0fafbaf8e62fc50dcb8ddfb57f8efaf2bf3c7aea3089edaf6dff294c644cbce5",
-    "zh:2647648813faefd98fda44af8cd54c8f458eec4bfa9f90d626e12c97851947e1",
-    "zh:34aa643bcb88392ba1528594a7474db0c52b3c00f7dbc1f7014d7e5aa8b02c5d",
-    "zh:61151c1ee60f5a221c085e8395e10052028560dd2e59b13e2ad926a163f8aa87",
-    "zh:623f1079c97f4fe55a506926361b2b86e5f5774218bd25a73131e5f389fcf66a",
-    "zh:6b44b84fbb1d8291bce79224f49fe0b177f971f96e042a638fe64bf99dceca7c",
-    "zh:9d126313acd9c3c66ca0a75fa84b1f8590c287227b2394c64d272c3453ac822a",
-    "zh:a1af70560370fe2facb1f6b1499bd4962f8927ac82c22e64dc86481db68f1afb",
-    "zh:cdba220fe92ad9110642369011ba6f323f1d93e2f3ea98c05720d45474da1210",
-    "zh:effddbc178eae941a3e80e6e3b5714cafeda1113609c7be9c06b481c01298cba",
-    "zh:f8ac343a11d66823b24e44f65eae49481a9def5e9d4bfb0875bf9e8b96c0d9d9",
-    "zh:f911141012df4eb79e401c5863e16569773b454eb2cac30e6a3323bb303bedb2",
+    "h1:Fy/potyWfS8NVumHqWi6STgaQUX66diUmgZDfFNBeXU=",
   ]
 }
 

--- a/identity-admin/terraform/locals.tf
+++ b/identity-admin/terraform/locals.tf
@@ -22,9 +22,13 @@ locals {
 
   nginx_image = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx_experience:78090f62ee23a39a1b4e929f25417bfa128c2aa8"
 
-  vpc_id          = data.terraform_remote_state.infra_shared.outputs.identity_vpc_id
-  private_subnets = data.terraform_remote_state.infra_shared.outputs.identity_vpc_private_subnets
-  public_subnets  = data.terraform_remote_state.infra_shared.outputs.identity_vpc_public_subnets
+  prod_vpc_id          = data.terraform_remote_state.infra_shared.outputs.identity_prod_vpc_id
+  prod_private_subnets = data.terraform_remote_state.infra_shared.outputs.identity_prod_vpc_private_subnets
+  prod_public_subnets  = data.terraform_remote_state.infra_shared.outputs.identity_prod_vpc_public_subnets
+
+  stage_vpc_id          = data.terraform_remote_state.infra_shared.outputs.identity_stage_vpc_id
+  stage_private_subnets = data.terraform_remote_state.infra_shared.outputs.identity_stage_vpc_private_subnets
+  stage_public_subnets  = data.terraform_remote_state.infra_shared.outputs.identity_stage_vpc_public_subnets
 
   service_env_names = ["stage", "prod"]
 

--- a/identity-admin/terraform/main.tf
+++ b/identity-admin/terraform/main.tf
@@ -46,4 +46,8 @@ module "identity-admin-stage" {
 
   private_subnets = local.stage_private_subnets
   vpc_id          = local.stage_vpc_id
+
+  providers = {
+    aws = aws.stage
+  }
 }

--- a/identity-admin/terraform/main.tf
+++ b/identity-admin/terraform/main.tf
@@ -20,8 +20,8 @@ module "identity-admin-prod" {
   env_vars        = local.service_env["prod"]["env_vars"]
   secret_env_vars = local.service_env["prod"]["secret_env_vars"]
 
-  private_subnets = local.private_subnets
-  vpc_id          = local.vpc_id
+  private_subnets = local.prod_private_subnets
+  vpc_id          = local.prod_vpc_id
 }
 
 module "identity-admin-stage" {
@@ -44,6 +44,6 @@ module "identity-admin-stage" {
   env_vars        = local.service_env["stage"]["env_vars"]
   secret_env_vars = local.service_env["stage"]["secret_env_vars"]
 
-  private_subnets = local.private_subnets
-  vpc_id          = local.vpc_id
+  private_subnets = local.stage_private_subnets
+  vpc_id          = local.stage_vpc_id
 }

--- a/identity-admin/terraform/provider.tf
+++ b/identity-admin/terraform/provider.tf
@@ -1,18 +1,49 @@
+locals {
+  default_tags = {
+    TerraformConfigurationURL = "https://github.com/wellcomecollection/wellcomecollection.org/tree/main/identity-admin"
+    Department                = "Digital Platform"
+    Division                  = "Culture and Society"
+    Use                       = "Identity APIs"
+  }
+
+  default_prod_tags = merge(
+    local.default_tags,
+    {
+      Environment = "Production"
+    }
+  )
+
+  default_stage_tags = merge(
+    local.default_tags,
+    {
+      Environment = "Staging"
+    }
+  )
+}
+
 provider "aws" {
-  region  = var.aws_region
+  region = var.aws_region
 
   assume_role {
     role_arn = "arn:aws:iam::770700576653:role/identity-developer"
   }
+
+  default_tags {
+    tags = local.default_prod_tags
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+  alias  = "stage"
+
+  assume_role {
+    role_arn = "arn:aws:iam::770700576653:role/identity-developer"
+  }
+
+  default_tags {
+    tags = local.default_stage_tags
+  }
 }
 
 provider "template" {}
-
-provider "aws" {
-  alias  = "platform"
-  region = var.aws_region
-
-  assume_role {
-    role_arn = "arn:aws:iam::760097843905:role/platform-developer"
-  }
-}

--- a/identity-admin/terraform/stack/provider.tf
+++ b/identity-admin/terraform/stack/provider.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}

--- a/identity/terraform/.terraform.lock.hcl
+++ b/identity/terraform/.terraform.lock.hcl
@@ -1,0 +1,35 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "3.52.0"
+  hashes = [
+    "h1:Fy/potyWfS8NVumHqWi6STgaQUX66diUmgZDfFNBeXU=",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.1.0"
+  hashes = [
+    "h1:rKYu5ZUbXwrLG1w81k7H3nce/Ys6yAxXhWcbtk36HjY=",
+    "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
+    "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",
+    "zh:4f251b0eda5bb5e3dc26ea4400dba200018213654b69b4a5f96abee815b4f5ff",
+    "zh:7011332745ea061e517fe1319bd6c75054a314155cb2c1199a5b01fe1889a7e2",
+    "zh:738ed82858317ccc246691c8b85995bc125ac3b4143043219bd0437adc56c992",
+    "zh:7dbe52fac7bb21227acd7529b487511c91f4107db9cc4414f50d04ffc3cab427",
+    "zh:a3a9251fb15f93e4cfc1789800fc2d7414bbc18944ad4c5c98f466e6477c42bc",
+    "zh:a543ec1a3a8c20635cf374110bd2f87c07374cf2c50617eee2c669b3ceeeaa9f",
+    "zh:d9ab41d556a48bd7059f0810cf020500635bfc696c9fc3adab5ea8915c1d886b",
+    "zh:d9e13427a7d011dbd654e591b0337e6074eef8c3b9bb11b2e39eaaf257044fd7",
+    "zh:f7605bd1437752114baf601bdf6931debe6dc6bfe3006eb7e9bb9080931dca8a",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/template" {
+  version     = "2.2.0"
+  constraints = "~> 2.1"
+  hashes = [
+    "h1:0wlehNaxBX7GJQnPfQwTNvvAf38Jm0Nv7ssKGMaG6Og=",
+  ]
+}

--- a/identity/terraform/main.tf
+++ b/identity/terraform/main.tf
@@ -44,4 +44,8 @@ module "identity-stage" {
   secret_env_vars = local.service_env["stage"]["secret_env_vars"]
 
   subdomain = "identity.www-stage"
+
+  providers = {
+    aws = aws.stage
+  }
 }

--- a/identity/terraform/provider.tf
+++ b/identity/terraform/provider.tf
@@ -1,24 +1,48 @@
+locals {
+  default_tags = {
+    TerraformConfigurationURL = "https://github.com/wellcomecollection/wellcomecollection.org/tree/main/identity"
+    Department                = "Digital Platform"
+    Division                  = "Culture and Society"
+    Use                       = "Identity APIs"
+  }
+
+  default_prod_tags = merge(
+    local.default_tags,
+    {
+      Environment = "Production"
+    }
+  )
+
+  default_stage_tags = merge(
+    local.default_tags,
+    {
+      Environment = "Staging"
+    }
+  )
+}
+
 provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::130871440101:role/experience-developer"
   }
 
-  region  = var.aws_region
-  version = "~> 2.47.0"
-}
+  region = var.aws_region
 
-provider "template" {
-  version = "~> 2.1"
-}
-
-provider "aws" {
-  alias = "platform"
-
-  region  = var.aws_region
-  version = "~> 2.47.0"
-
-  assume_role {
-    role_arn = "arn:aws:iam::760097843905:role/platform-developer"
+  default_tags {
+    tags = local.default_prod_tags
   }
 }
 
+provider "aws" {
+  alias = "stage"
+
+  assume_role {
+    role_arn = "arn:aws:iam::130871440101:role/experience-developer"
+  }
+
+  region = var.aws_region
+
+  default_tags {
+    tags = local.default_stage_tags
+  }
+}

--- a/identity/terraform/stack/provider.tf
+++ b/identity/terraform/stack/provider.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}

--- a/infrastructure/experience/.terraform.lock.hcl
+++ b/infrastructure/experience/.terraform.lock.hcl
@@ -2,21 +2,8 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "2.47.0"
-  constraints = "~> 2.47.0"
+  version = "3.52.0"
   hashes = [
-    "h1:3qUZ+SZqdtlxCd4Luyz+MqHclZvnigwrY8LyKvIvq4U=",
-    "zh:0fafbaf8e62fc50dcb8ddfb57f8efaf2bf3c7aea3089edaf6dff294c644cbce5",
-    "zh:2647648813faefd98fda44af8cd54c8f458eec4bfa9f90d626e12c97851947e1",
-    "zh:34aa643bcb88392ba1528594a7474db0c52b3c00f7dbc1f7014d7e5aa8b02c5d",
-    "zh:61151c1ee60f5a221c085e8395e10052028560dd2e59b13e2ad926a163f8aa87",
-    "zh:623f1079c97f4fe55a506926361b2b86e5f5774218bd25a73131e5f389fcf66a",
-    "zh:6b44b84fbb1d8291bce79224f49fe0b177f971f96e042a638fe64bf99dceca7c",
-    "zh:9d126313acd9c3c66ca0a75fa84b1f8590c287227b2394c64d272c3453ac822a",
-    "zh:a1af70560370fe2facb1f6b1499bd4962f8927ac82c22e64dc86481db68f1afb",
-    "zh:cdba220fe92ad9110642369011ba6f323f1d93e2f3ea98c05720d45474da1210",
-    "zh:effddbc178eae941a3e80e6e3b5714cafeda1113609c7be9c06b481c01298cba",
-    "zh:f8ac343a11d66823b24e44f65eae49481a9def5e9d4bfb0875bf9e8b96c0d9d9",
-    "zh:f911141012df4eb79e401c5863e16569773b454eb2cac30e6a3323bb303bedb2",
+    "h1:Fy/potyWfS8NVumHqWi6STgaQUX66diUmgZDfFNBeXU=",
   ]
 }

--- a/infrastructure/experience/provider.tf
+++ b/infrastructure/experience/provider.tf
@@ -1,17 +1,48 @@
+locals {
+  default_tags = {
+    TerraformConfigurationURL = "https://github.com/wellcomecollection/wellcomecollection.org/tree/main/infrastructure/experience"
+    Department                = "Digital Platform"
+    Division                  = "Culture and Society"
+    Use                       = "Identity APIs"
+  }
+
+  default_prod_tags = merge(
+    local.default_tags,
+    {
+      Environment = "Production"
+    }
+  )
+
+  default_stage_tags = merge(
+    local.default_tags,
+    {
+      Environment = "Staging"
+    }
+  )
+}
+
 provider "aws" {
   region = var.aws_region
 
   assume_role {
     role_arn = "arn:aws:iam::130871440101:role/experience-developer"
   }
+
+  default_tags {
+    tags = local.default_prod_tags
+  }
 }
 
 provider "aws" {
-  alias  = "platform"
   region = var.aws_region
+  alias  = "stage"
 
   assume_role {
-    role_arn = "arn:aws:iam::760097843905:role/platform-developer"
+    role_arn = "arn:aws:iam::130871440101:role/experience-developer"
+  }
+
+  default_tags {
+    tags = local.default_stage_tags
   }
 }
 

--- a/infrastructure/identity/.terraform.lock.hcl
+++ b/infrastructure/identity/.terraform.lock.hcl
@@ -2,21 +2,19 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "2.47.0"
-  constraints = "~> 2.47.0"
+  version = "3.52.0"
   hashes = [
-    "h1:3qUZ+SZqdtlxCd4Luyz+MqHclZvnigwrY8LyKvIvq4U=",
-    "zh:0fafbaf8e62fc50dcb8ddfb57f8efaf2bf3c7aea3089edaf6dff294c644cbce5",
-    "zh:2647648813faefd98fda44af8cd54c8f458eec4bfa9f90d626e12c97851947e1",
-    "zh:34aa643bcb88392ba1528594a7474db0c52b3c00f7dbc1f7014d7e5aa8b02c5d",
-    "zh:61151c1ee60f5a221c085e8395e10052028560dd2e59b13e2ad926a163f8aa87",
-    "zh:623f1079c97f4fe55a506926361b2b86e5f5774218bd25a73131e5f389fcf66a",
-    "zh:6b44b84fbb1d8291bce79224f49fe0b177f971f96e042a638fe64bf99dceca7c",
-    "zh:9d126313acd9c3c66ca0a75fa84b1f8590c287227b2394c64d272c3453ac822a",
-    "zh:a1af70560370fe2facb1f6b1499bd4962f8927ac82c22e64dc86481db68f1afb",
-    "zh:cdba220fe92ad9110642369011ba6f323f1d93e2f3ea98c05720d45474da1210",
-    "zh:effddbc178eae941a3e80e6e3b5714cafeda1113609c7be9c06b481c01298cba",
-    "zh:f8ac343a11d66823b24e44f65eae49481a9def5e9d4bfb0875bf9e8b96c0d9d9",
-    "zh:f911141012df4eb79e401c5863e16569773b454eb2cac30e6a3323bb303bedb2",
+    "h1:Fy/potyWfS8NVumHqWi6STgaQUX66diUmgZDfFNBeXU=",
+    "zh:04a4f8a1b34292fd6a72c1efe03f6f10186ecbdc318df36d462d0be1c21ce72d",
+    "zh:0601006f14f437489902555720dd8fb4e67450356438bab64b61cf6d0e1af681",
+    "zh:14214e996b8db0a2038b74a2ddbea7356b3e53f73003cde2c9069294d9a6c421",
+    "zh:17d1ecc280d776271b0fc0fd6a4033933be8e67eb6a39b7bfb3c242cd218645f",
+    "zh:247ae4bc3b52fba96ed1593e7b23d62da0d2c99498fc0d968fcf28020df3c3aa",
+    "zh:2e0432fabeb5e44d756a5566168768f1b6dea3cc0e5650fac966820e90d18367",
+    "zh:34f6f95b88c5d8c105d9a3b7d2712e7df1181948bfbef33bb6a87d7a77c20c0d",
+    "zh:3de6bf02b9499bf8dc13843da72a03db5ae8188b8157f0e7b3d5bf1d7cd1ac8b",
+    "zh:43198a223ea6d6dfb82deac62b29181c3be18dc77b9ef9f8d44c32b08e44ea5c",
+    "zh:a7de44c9445c100a2823c371df03fcaa9ecb1642750ccdc02294fa6cd1095859",
+    "zh:c3c44bd07e5b6cdb776ff674e39feb708ba3ee3d0dff2c88d1d5db323094d942",
   ]
 }

--- a/infrastructure/identity/cert.tf
+++ b/infrastructure/identity/cert.tf
@@ -6,7 +6,7 @@ module "wellcomecollection_cert_identity" {
   zone_id = data.aws_route53_zone.zone.id
 
   providers = {
-    aws.dns = aws.dns
+    aws.dns = aws.dns_prod
   }
 
   subject_alternative_names = [

--- a/infrastructure/identity/dns.tf
+++ b/infrastructure/identity/dns.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "prod" {
-  provider = aws.dns
+  provider = aws.dns_prod
 
   name    = "account-admin.wellcomecollection.org"
   type    = "CNAME"
@@ -11,7 +11,7 @@ resource "aws_route53_record" "prod" {
 }
 
 resource "aws_route53_record" "stage" {
-  provider = aws.dns
+  provider = aws.dns_stage
 
   name    = "account-admin-stage.wellcomecollection.org"
   type    = "CNAME"

--- a/infrastructure/identity/locals.tf
+++ b/infrastructure/identity/locals.tf
@@ -9,7 +9,7 @@ locals {
 }
 
 data "aws_route53_zone" "zone" {
-  provider = aws.dns
+  provider = aws.dns_prod
 
   name = "wellcomecollection.org."
 }

--- a/infrastructure/identity/locals.tf
+++ b/infrastructure/identity/locals.tf
@@ -1,7 +1,11 @@
 locals {
-  identity_vpc_id = local.identity_vpcs["identity_vpc_id"]
-  identity_private_subnets = local.identity_vpcs["identity_vpc_private_subnets"]
-  identity_public_subnets  = local.identity_vpcs["identity_vpc_public_subnets"]
+  prod_identity_vpc_id = local.identity_vpcs["identity_prod_vpc_id"]
+  prod_identity_private_subnets = local.identity_vpcs["identity_prod_vpc_private_subnets"]
+  prod_identity_public_subnets  = local.identity_vpcs["identity_prod_vpc_public_subnets"]
+
+  stage_identity_vpc_id = local.identity_vpcs["identity_stage_vpc_id"]
+  stage_identity_private_subnets = local.identity_vpcs["identity_stage_vpc_private_subnets"]
+  stage_identity_public_subnets  = local.identity_vpcs["identity_stage_vpc_public_subnets"]
 }
 
 data "aws_route53_zone" "zone" {

--- a/infrastructure/identity/main.tf
+++ b/infrastructure/identity/main.tf
@@ -3,8 +3,8 @@ module "prod" {
 
   namespace = "prod"
 
-  vpc_id   = local.identity_vpc_id
-  subnets  = local.identity_public_subnets
+  vpc_id   = local.prod_identity_vpc_id
+  subnets  = local.prod_identity_public_subnets
   cert_arn = module.wellcomecollection_cert_identity.arn
 }
 
@@ -13,7 +13,11 @@ module "stage" {
 
   namespace = "stage"
 
-  vpc_id   = local.identity_vpc_id
-  subnets  = local.identity_public_subnets
+  vpc_id   = local.stage_identity_vpc_id
+  subnets  = local.stage_identity_public_subnets
   cert_arn = module.wellcomecollection_cert_identity.arn
+
+  providers = {
+    aws = aws.stage
+  }
 }

--- a/infrastructure/identity/provider.tf
+++ b/infrastructure/identity/provider.tf
@@ -1,8 +1,35 @@
+locals {
+  default_tags = {
+    TerraformConfigurationURL = "https://github.com/wellcomecollection/wellcomecollection.org/tree/main/infrastructure/identity"
+    Department                = "Digital Platform"
+    Division                  = "Culture and Society"
+    Use                       = "Identity APIs"
+  }
+
+  default_prod_tags = merge(
+    local.default_tags,
+    {
+      Environment = "Production"
+    }
+  )
+
+  default_stage_tags = merge(
+    local.default_tags,
+    {
+      Environment = "Staging"
+    }
+  )
+}
+
 provider "aws" {
   region = var.aws_region
 
   assume_role {
     role_arn = "arn:aws:iam::770700576653:role/identity-developer"
+  }
+
+  default_tags {
+    tags = local.default_prod_tags
   }
 }
 
@@ -13,22 +40,34 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::770700576653:role/identity-developer"
   }
-}
 
-provider "aws" {
-  alias  = "platform"
-  region = var.aws_region
-
-  assume_role {
-    role_arn = "arn:aws:iam::760097843905:role/platform-developer"
+  default_tags {
+    tags = local.default_stage_tags
   }
 }
 
 provider "aws" {
   region = "eu-west-1"
-  alias  = "dns"
+  alias  = "dns_prod"
 
   assume_role {
     role_arn = "arn:aws:iam::267269328833:role/wellcomecollection-assume_role_hosted_zone_update"
+  }
+
+  default_tags {
+    tags = local.default_prod_tags
+  }
+}
+
+provider "aws" {
+  region = "eu-west-1"
+  alias  = "dns_stage"
+
+  assume_role {
+    role_arn = "arn:aws:iam::267269328833:role/wellcomecollection-assume_role_hosted_zone_update"
+  }
+
+  default_tags {
+    tags = local.default_stage_tags
   }
 }

--- a/infrastructure/identity/provider.tf
+++ b/infrastructure/identity/provider.tf
@@ -1,5 +1,14 @@
 provider "aws" {
-  region  = var.aws_region
+  region = var.aws_region
+
+  assume_role {
+    role_arn = "arn:aws:iam::770700576653:role/identity-developer"
+  }
+}
+
+provider "aws" {
+  alias  = "stage"
+  region = var.aws_region
 
   assume_role {
     role_arn = "arn:aws:iam::770700576653:role/identity-developer"
@@ -14,8 +23,6 @@ provider "aws" {
     role_arn = "arn:aws:iam::760097843905:role/platform-developer"
   }
 }
-
-
 
 provider "aws" {
   region = "eu-west-1"

--- a/infrastructure/identity/stack/provider.tf
+++ b/infrastructure/identity/stack/provider.tf
@@ -2,8 +2,6 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
-
-      configuration_aliases = [aws.dns]
     }
   }
 }


### PR DESCRIPTION
Previously we had a single VPC + subnets for the identity services, but
now we have separate prod/stage VPCs.

## Who is this for?

Devs who want to plan/apply in this Terraform stack.

## What is it doing for them?

Making it work again. Running a plan against `main` gives the following errors:

```
│ Error: Unsupported attribute
│
│   on locals.tf line 25, in locals:
│   25:   vpc_id          = data.terraform_remote_state.infra_shared.outputs.identity_vpc_id
│     ├────────────────
│     │ data.terraform_remote_state.infra_shared.outputs is object with 15 attributes
│
│ This object does not have an attribute named "identity_vpc_id".
╵
╷
│ Error: Unsupported attribute
│
│   on locals.tf line 26, in locals:
│   26:   private_subnets = data.terraform_remote_state.infra_shared.outputs.identity_vpc_private_subnets
│     ├────────────────
│     │ data.terraform_remote_state.infra_shared.outputs is object with 15 attributes
│
│ This object does not have an attribute named "identity_vpc_private_subnets".
╵
╷
│ Error: Unsupported attribute
│
│   on locals.tf line 27, in locals:
│   27:   public_subnets  = data.terraform_remote_state.infra_shared.outputs.identity_vpc_public_subnets
│     ├────────────────
│     │ data.terraform_remote_state.infra_shared.outputs is object with 15 attributes
│
│ This object does not have an attribute named "identity_vpc_public_subnets".
```

Looking at [the outputs.tf from that stack](https://github.com/wellcomecollection/platform-infrastructure/blob/main/accounts/identity/outputs.tf), the issue is obvious – we used to have one VPC, now we have two.

This change is unapplied; you can see the proposed plan here: https://wellcome.slack.com/archives/CUA669WHH/p1627643776000100