### PR TITLE
Scroll to center of landscape images on thumbnail click

### DIFF
--- a/common/views/components/IIIFViewer/GridViewer.tsx
+++ b/common/views/components/IIIFViewer/GridViewer.tsx
@@ -18,6 +18,7 @@ import GlobalInfoBarContext from '@weco/common/views/components/GlobalInfoBarCon
 import { IIIFCanvas, SearchResults } from '@weco/common/model/iiif';
 import ItemViewerContext from '../ItemViewerContext/ItemViewerContext';
 import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
+import { scrollViewer } from './MainViewer';
 
 const Defs = styled.svg`
   position: absolute;
@@ -48,6 +49,7 @@ type CellProps = {
     setActiveIndex: (i: number) => void;
     canvases: IIIFCanvas[];
     searchResults: SearchResults;
+    mainAreaWidth: number;
   };
 };
 
@@ -62,6 +64,7 @@ const Cell = memo(({ columnIndex, rowIndex, style, data }: CellProps) => {
     setActiveIndex,
     canvases,
     searchResults,
+    mainAreaWidth,
   } = data;
   const itemIndex = rowIndex * columnCount + columnIndex;
   const currentCanvas = canvases[itemIndex];
@@ -85,9 +88,12 @@ const Cell = memo(({ columnIndex, rowIndex, style, data }: CellProps) => {
             <IIIFCanvasThumbnail
               canvas={currentCanvas}
               clickHandler={() => {
-                mainViewerRef &&
-                  mainViewerRef.current &&
-                  mainViewerRef.current.scrollToItem(itemIndex, 'start');
+                scrollViewer(
+                  currentCanvas,
+                  itemIndex,
+                  mainViewerRef?.current,
+                  mainAreaWidth
+                );
                 setActiveIndex(itemIndex);
                 setGridVisible(false);
               }}
@@ -226,6 +232,7 @@ const GridViewer: FunctionComponent<Props> = ({
             setActiveIndex,
             canvases,
             searchResults,
+            mainAreaWidth,
           }}
           onScroll={({ scrollTop }) => setNewScrollOffset(scrollTop)}
           ref={grid}

--- a/common/views/components/IIIFViewer/MainViewer.tsx
+++ b/common/views/components/IIIFViewer/MainViewer.tsx
@@ -305,6 +305,35 @@ const ItemRenderer = memo(({ style, index, data }: ItemRendererProps) => {
 
 ItemRenderer.displayName = 'ItemRenderer';
 
+export function scrollViewer(
+  currentCanvas: IIIFCanvas,
+  canvasIndex: number,
+  viewer: FixedSizeList | null,
+  mainAreaWidth: number
+): void {
+  const isLandscape = currentCanvas.width > currentCanvas.height;
+
+  // If an image is landscape, it will tend to appear too low in the viewport
+  // on account of the FixedSizedList necessarily being comprised of square items.
+  // To circumvent this, if the image is landscape
+  // 1. We calculate the rendered height of the image
+  // 2. We half the difference between that and the square item it sits inside
+  // 3. We scroll that distance, putting the top of the image at the top of the viewport
+
+  if (isLandscape) {
+    const ratio = currentCanvas.height / currentCanvas.width;
+    const renderedHeight = mainAreaWidth * ratio * 0.8; // TODO: 0.8 = 80% max-width image in container. Variable.
+    const heightOfPreviousItems = canvasIndex * (viewer?.props.itemSize || 0);
+    const distanceToScroll =
+      heightOfPreviousItems +
+      ((viewer?.props.itemSize || 0) - renderedHeight) / 2;
+    viewer?.scrollTo(distanceToScroll);
+  } else {
+    // 4. Otherwise, if it's portrait, we go to the start of the image
+    viewer?.scrollToItem(canvasIndex, 'start');
+  }
+}
+
 type Props = {
   mainViewerRef: RefObject<FixedSizeList>;
   mainAreaRef: RefObject<HTMLDivElement>;
@@ -353,26 +382,8 @@ const MainViewer: FunctionComponent<Props> = ({
       setActiveIndex(canvasIndex);
       currentCanvas = canvases && canvases[canvasIndex];
       const viewer = mainViewerRef?.current;
-      const isLandscape = currentCanvas.width > currentCanvas.height;
 
-      // If an image is landscape, it will tend to appear too low in the viewport
-      // on account of the FixedSizedList necessarily being comprised of square items.
-      // To circumvent this, if the image is landscape
-      // 1. We calculate the rendered height of the image
-      // 2. We half the difference between that and the square item it sits inside
-      // 3. We scroll that distance, putting the top of the image at the top of the viewport
-      if (isLandscape) {
-        const ratio = currentCanvas.height / currentCanvas.width;
-        const renderedHeight = mainAreaWidth * ratio * 0.8; // TODO: 0.8 = 80% max-width image in container. Variable.
-        const heightOfPreviousItems =
-          canvasIndex * (viewer?.props.itemSize || 0);
-        const distanceToScroll =
-          heightOfPreviousItems +
-          ((viewer?.props.itemSize || 0) - renderedHeight) / 2;
-        viewer?.scrollTo(distanceToScroll);
-      } else {
-        viewer?.scrollToItem(canvasIndex, 'start');
-      }
+      scrollViewer(currentCanvas, canvasIndex, viewer, mainAreaWidth);
       setFirstRender(false);
       const mainImageService = {
         '@id': currentCanvas


### PR DESCRIPTION
## Who is this for?
People who want images to be centered in the viewport.

## What is it doing for them?
We currently center the images on initial render, but not when you click on a thumbnail from the grid view. This reuses the logic from the former for the latter.