### PR TITLE
tag AWS resources in webapps

### DIFF
--- a/catalogue/terraform/.terraform.lock.hcl
+++ b/catalogue/terraform/.terraform.lock.hcl
@@ -18,3 +18,20 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:c3c44bd07e5b6cdb776ff674e39feb708ba3ee3d0dff2c88d1d5db323094d942",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/template" {
+  version = "2.2.0"
+  hashes = [
+    "h1:0wlehNaxBX7GJQnPfQwTNvvAf38Jm0Nv7ssKGMaG6Og=",
+    "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
+    "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
+    "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",
+    "zh:0e3a6c8e16f17f19010accd0844187d524580d9fdb0731f675ffcf4afba03d16",
+    "zh:45f2c594b6f2f34ea663704cc72048b212fe7d16fb4cfd959365fa997228a776",
+    "zh:77ea3e5a0446784d77114b5e851c970a3dde1e08fa6de38210b8385d7605d451",
+    "zh:8a154388f3708e3df5a69122a23bdfaf760a523788a5081976b3d5616f7d30ae",
+    "zh:992843002f2db5a11e626b3fc23dc0c87ad3729b3b3cff08e32ffb3df97edbde",
+    "zh:ad906f4cebd3ec5e43d5cd6dc8f4c5c9cc3b33d2243c89c5fc18f97f7277b51d",
+    "zh:c979425ddb256511137ecd093e23283234da0154b7fa8b21c2687182d9aea8b2",
+  ]
+}

--- a/catalogue/terraform/locals.tf
+++ b/catalogue/terraform/locals.tf
@@ -1,4 +1,26 @@
 locals {
+  default_tags = {
+    TerraformConfigurationURL = "https://github.com/wellcomecollection/wellcomecollection.org/tree/main/catalogue/terraform"
+    Department                = "Digital Platform"
+    Division                  = "Culture and Society"
+    Use                       = "Catalogue Webapp"
+  }
+
+  default_prod_tags = merge(
+    local.default_tags,
+    {
+      Environment = "Production"
+    }
+  )
+
+
+  default_stage_tags = merge(
+    local.default_tags,
+    {
+      Environment = "Staging"
+    }
+  )
+
   prod_cluster_arn  = data.terraform_remote_state.experience_shared.outputs.prod_cluster_arn
   prod_namespace_id = data.terraform_remote_state.experience_shared.outputs.prod_namespace_id
 

--- a/catalogue/terraform/main.tf
+++ b/catalogue/terraform/main.tf
@@ -38,4 +38,8 @@ module "catalogue-stage" {
   service_egress_security_group_id = local.stage_service_egress_security_group_id
 
   subdomain = "works.www-stage"
+
+  providers = {
+    aws = aws.stage
+  }
 }

--- a/catalogue/terraform/provider.tf
+++ b/catalogue/terraform/provider.tf
@@ -1,21 +1,33 @@
 provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = local.default_prod_tags
+  }
+
   assume_role {
     role_arn = "arn:aws:iam::130871440101:role/experience-developer"
   }
-
-  region  = var.aws_region
-  version = "~> 2.47.0"
-}
-
-provider "template" {
-  version = "~> 2.1"
 }
 
 provider "aws" {
-  alias = "platform"
+  alias  = "stage"
+  region = var.aws_region
 
-  region  = var.aws_region
-  version = "~> 2.47.0"
+  default_tags {
+    tags = local.default_stage_tags
+  }
+
+  assume_role {
+    role_arn = "arn:aws:iam::130871440101:role/experience-developer"
+  }
+}
+
+provider "template" {}
+
+provider "aws" {
+  alias  = "platform"
+  region = var.aws_region
 
   assume_role {
     role_arn = "arn:aws:iam::760097843905:role/platform-developer"

--- a/catalogue/terraform/stack/provider.tf
+++ b/catalogue/terraform/stack/provider.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}

--- a/catalogue/terraform/terraform.tf
+++ b/catalogue/terraform/terraform.tf
@@ -1,5 +1,9 @@
 terraform {
-  required_version = ">= 0.9"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 
   backend "s3" {
     key            = "build-state/catalogue.tfstate"

--- a/content/terraform/.terraform.lock.hcl
+++ b/content/terraform/.terraform.lock.hcl
@@ -18,3 +18,20 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:c3c44bd07e5b6cdb776ff674e39feb708ba3ee3d0dff2c88d1d5db323094d942",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/template" {
+  version = "2.2.0"
+  hashes = [
+    "h1:0wlehNaxBX7GJQnPfQwTNvvAf38Jm0Nv7ssKGMaG6Og=",
+    "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
+    "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
+    "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",
+    "zh:0e3a6c8e16f17f19010accd0844187d524580d9fdb0731f675ffcf4afba03d16",
+    "zh:45f2c594b6f2f34ea663704cc72048b212fe7d16fb4cfd959365fa997228a776",
+    "zh:77ea3e5a0446784d77114b5e851c970a3dde1e08fa6de38210b8385d7605d451",
+    "zh:8a154388f3708e3df5a69122a23bdfaf760a523788a5081976b3d5616f7d30ae",
+    "zh:992843002f2db5a11e626b3fc23dc0c87ad3729b3b3cff08e32ffb3df97edbde",
+    "zh:ad906f4cebd3ec5e43d5cd6dc8f4c5c9cc3b33d2243c89c5fc18f97f7277b51d",
+    "zh:c979425ddb256511137ecd093e23283234da0154b7fa8b21c2687182d9aea8b2",
+  ]
+}

--- a/content/terraform/locals.tf
+++ b/content/terraform/locals.tf
@@ -1,4 +1,26 @@
 locals {
+  default_tags = {
+    TerraformConfigurationURL = "https://github.com/wellcomecollection/wellcomecollection.org/tree/main/catalogue/terraform"
+    Department                = "Digital Platform"
+    Division                  = "Culture and Society"
+    Use                       = "Content Webapp"
+  }
+
+  default_prod_tags = merge(
+    local.default_tags,
+    {
+      Environment = "Production"
+    }
+  )
+
+
+  default_stage_tags = merge(
+    local.default_tags,
+    {
+      Environment = "Staging"
+    }
+  )
+
   prod_cluster_arn  = data.terraform_remote_state.experience_shared.outputs.prod_cluster_arn
   prod_namespace_id = data.terraform_remote_state.experience_shared.outputs.prod_namespace_id
 
@@ -18,7 +40,7 @@ locals {
   stage_service_egress_security_group_id = data.terraform_remote_state.experience_shared.outputs.stage_service_egress_security_group_id
 
   stage_app_image = "${data.terraform_remote_state.experience_shared.outputs.content_webapp_ecr_uri}:env.stage"
-  prod_app_image = "${data.terraform_remote_state.experience_shared.outputs.content_webapp_ecr_uri}:env.prod"
+  prod_app_image  = "${data.terraform_remote_state.experience_shared.outputs.content_webapp_ecr_uri}:env.prod"
 
   // Latest is available at data.aws_ssm_parameter.nginx_image_uri.value - test in staging before deployment
   nginx_image = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx_experience:78090f62ee23a39a1b4e929f25417bfa128c2aa8"

--- a/content/terraform/locals.tf
+++ b/content/terraform/locals.tf
@@ -1,6 +1,6 @@
 locals {
   default_tags = {
-    TerraformConfigurationURL = "https://github.com/wellcomecollection/wellcomecollection.org/tree/main/catalogue/terraform"
+    TerraformConfigurationURL = "https://github.com/wellcomecollection/wellcomecollection.org/tree/main/content/terraform"
     Department                = "Digital Platform"
     Division                  = "Culture and Society"
     Use                       = "Content Webapp"

--- a/content/terraform/main.tf
+++ b/content/terraform/main.tf
@@ -38,4 +38,8 @@ module "content-stage" {
   service_egress_security_group_id = local.stage_service_egress_security_group_id
 
   subdomain = "content.www-stage"
+
+  providers = {
+    aws = aws.stage
+  }
 }

--- a/content/terraform/provider.tf
+++ b/content/terraform/provider.tf
@@ -1,17 +1,33 @@
 provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = local.default_prod_tags
+  }
+
   assume_role {
     role_arn = "arn:aws:iam::130871440101:role/experience-developer"
   }
-
-  region  = var.aws_region
-  version = "~> 2.47.0"
 }
 
 provider "aws" {
-  alias = "platform"
+  alias  = "stage"
+  region = var.aws_region
 
-  region  = var.aws_region
-  version = "~> 2.47.0"
+  default_tags {
+    tags = local.default_stage_tags
+  }
+
+  assume_role {
+    role_arn = "arn:aws:iam::130871440101:role/experience-developer"
+  }
+}
+
+provider "template" {}
+
+provider "aws" {
+  alias  = "platform"
+  region = var.aws_region
 
   assume_role {
     role_arn = "arn:aws:iam::760097843905:role/platform-developer"

--- a/content/terraform/stack/provider.tf
+++ b/content/terraform/stack/provider.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}

--- a/content/terraform/terraform.tf
+++ b/content/terraform/terraform.tf
@@ -1,4 +1,10 @@
 terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+
 
   backend "s3" {
     key            = "build-state/content.tfstate"

--- a/infrastructure/experience/terraform.tf
+++ b/infrastructure/experience/terraform.tf
@@ -1,8 +1,6 @@
 data "aws_caller_identity" "current" {}
 
 terraform {
-  required_version = ">= 0.9"
-
   backend "s3" {
     role_arn = "arn:aws:iam::130871440101:role/experience-developer"
 


### PR DESCRIPTION
## Who is this for?
Devs wanting to know what resources are associated with which parts of the repo.

## What is it doing for them?
Tags all the AWS resources within the content/catalogue webapps.