### PR TITLE
Confirm request modal

### DIFF
--- a/catalogue/webapp/components/ConfirmItemRequest/ConfirmItemRequest.tsx
+++ b/catalogue/webapp/components/ConfirmItemRequest/ConfirmItemRequest.tsx
@@ -1,11 +1,14 @@
-import { FunctionComponent, RefObject } from 'react';
+import { FunctionComponent, RefObject, useState } from 'react';
 import Modal from '@weco/common/views/components/Modal/Modal';
+import ButtonSolidLink from '@weco/common/views/components/ButtonSolidLink/ButtonSolidLink';
+import ButtonOutlinedLink from '@weco/common/views/components/ButtonOutlinedLink/ButtonOutlinedLink';
 import ButtonSolid from '@weco/common/views/components/ButtonSolid/ButtonSolid';
 import ButtonOutlined from '@weco/common/views/components/ButtonOutlined/ButtonOutlined';
 import Space from '@weco/common/views/components/styled/Space';
 import styled from 'styled-components';
 import { PhysicalItem, Work } from '@weco/common/model/catalogue';
 import { classNames, font } from '@weco/common/utils/classnames';
+import LL from '@weco/common/views/components/styled/LL';
 
 const Header = styled(Space).attrs({
   v: { size: 'm', properties: ['margin-bottom'] },
@@ -15,10 +18,25 @@ const Header = styled(Space).attrs({
   align-items: center;
 `;
 
+const Request = styled.div<{ isLoading: boolean }>`
+  opacity: ${props => (props.isLoading ? 0.2 : 1)};
+  transition: opacity ${props => props.theme.transitionProperties};
+`;
+
 const Remaining = styled(Space).attrs({
-  h: { size: 's', properties: ['padding-left'] },
+  h: { size: 's', properties: ['padding-left', 'margin-left'] },
 })`
   border-left: 5px solid ${props => props.theme.color('yellow')};
+`;
+
+const BeforeYourVisit = styled(Space).attrs({
+  as: 'p',
+  h: { size: 'm', properties: ['padding-left'] },
+  className: classNames({
+    [font('hnr', 5)]: true,
+  }),
+})`
+  border-left: 8px solid ${props => props.theme.color('yellow')};
 `;
 
 const CTAs = styled(Space).attrs({
@@ -34,39 +52,181 @@ type Props = {
   openButtonRef: RefObject<HTMLButtonElement>;
 };
 
-const ConfirmItemRequest: FunctionComponent<Props> = props => {
-  const { item, work, setIsActive, ...modalProps } = props;
+type RequestDialogProps = {
+  isLoading: boolean;
+  work: Work;
+  item: PhysicalItem;
+  confirmRequest: () => void;
+  setIsActive: (value: boolean) => void;
+};
 
-  return (
-    <Modal {...modalProps} setIsActive={setIsActive}>
-      <Header>
-        <span className={`h2`}>Request item</span>
-        <Remaining>7/15 items remaining</Remaining>
-      </Header>
-      <p
+const RequestDialog: FunctionComponent<RequestDialogProps> = ({
+  isLoading,
+  work,
+  item,
+  confirmRequest,
+  setIsActive,
+}) => (
+  <Request isLoading={isLoading}>
+    <Header>
+      <span className={`h2`}>Request item</span>
+      <Remaining>7/15 items remaining</Remaining>
+    </Header>
+    <p
+      className={classNames({
+        [font('hnb', 5)]: true,
+        'no-margin': true,
+      })}
+    >
+      You are about to request the following item:
+    </p>
+    <p className={'no-margin'}>
+      {work.title && <span className="block">{work.title}</span>}
+      {item.title && <span>{item.title}</span>}
+    </p>
+    <CTAs>
+      <Space
+        h={{ size: 'l', properties: ['margin-right'] }}
+        v={{ size: 's', properties: ['margin-bottom'] }}
+        className={'inline-block'}
+      >
+        <ButtonSolid
+          disabled={isLoading}
+          text={`Confirm request`}
+          clickHandler={confirmRequest}
+        />
+      </Space>
+      <ButtonOutlined
+        disabled={isLoading}
+        text={`Cancel request`}
+        clickHandler={() => setIsActive(false)}
+      />
+    </CTAs>
+  </Request>
+);
+
+type ConfirmedDialogProps = {
+  work: Work;
+  item: PhysicalItem;
+};
+
+const ConfirmedDialog: FunctionComponent<ConfirmedDialogProps> = ({
+  work,
+  item,
+}) => (
+  <>
+    <Header>
+      <span className={`h2`}>Request confirmed</span>
+      <Remaining>6/15 items remaining</Remaining>
+    </Header>
+    <p
+      className={classNames({
+        [font('hnb', 5)]: true,
+        'no-margin': true,
+      })}
+    >
+      You have successfully requested:
+    </p>
+    <p>
+      {work.title && <span className="block">{work.title}</span>}
+      {item.title && <span>{item.title}</span>}
+    </p>
+
+    <p>
+      It will be available to pick up from the library (Rare Materials Room, 2nd
+      Floor) for two weeks.
+    </p>
+    <BeforeYourVisit>
+      <span
         className={classNames({
           [font('hnb', 5)]: true,
-          'no-margin': true,
         })}
       >
-        You are about to request the following item:
-      </p>
-      <p className={'no-margin'}>
-        {work.title && <span className="block">{work.title}</span>}
-        {item.title && <span>{item.title}</span>}
-      </p>
-      <CTAs>
-        <Space
-          h={{ size: 'l', properties: ['margin-right'] }}
-          className={'inline-block'}
-        >
-          <ButtonSolid text={`Confirm request`} />
-        </Space>
-        <ButtonOutlined
-          text={`Cancel request`}
-          clickHandler={() => setIsActive(false)}
+        Before your visit:
+      </span>{' '}
+      you will need to book a time slot for a library and museum ticket{' '}
+      <em>(with material access)</em> at least 72 hours in advance of any visit.
+    </BeforeYourVisit>
+    <CTAs>
+      <Space
+        h={{ size: 'l', properties: ['margin-right'] }}
+        v={{ size: 's', properties: ['margin-bottom'] }}
+        className={'inline-block'}
+      >
+        <ButtonSolidLink
+          text={`Book a ticket`}
+          link={'/covid-book-your-ticket'}
         />
-      </CTAs>
+      </Space>
+      <ButtonOutlinedLink
+        text={`View your library account`}
+        link={'/account'}
+      />
+    </CTAs>
+  </>
+);
+
+type ErrorDialogProps = {
+  setIsActive: (value: boolean) => void;
+};
+
+const ErrorDialog: FunctionComponent<ErrorDialogProps> = ({ setIsActive }) => (
+  <>
+    <Header>
+      <span className={`h2`}>Request failed</span>
+    </Header>
+    <p className="no-margin">
+      There was a problem requesting this item. Please try again.
+    </p>
+    <CTAs>
+      <ButtonOutlined text={`Close`} clickHandler={() => setIsActive(false)} />
+    </CTAs>
+  </>
+);
+
+const ConfirmItemRequest: FunctionComponent<Props> = props => {
+  const { item, work, setIsActive, ...modalProps } = props;
+  const [isConfirmed, setIsConfirmed] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isError, setIsError] = useState(false); // TODO: implement this if something goes wrong with API call
+
+  function innerSetIsActive(value: boolean) {
+    if (value) {
+      setIsActive(true);
+    } else if (isLoading) {
+      // disable close dialog button during api call
+    } else {
+      setIsActive(false);
+      setIsConfirmed(false);
+      setIsError(false);
+    }
+  }
+
+  function confirmRequest() {
+    setIsLoading(true);
+    // setIsError(true); // uncomment to test the error UI
+
+    setTimeout(() => {
+      // TODO: the items api request goes here
+      setIsConfirmed(true);
+      setIsLoading(false);
+    }, 2000);
+  }
+
+  return (
+    <Modal {...modalProps} setIsActive={innerSetIsActive}>
+      {isLoading && <LL />}
+      {isError && <ErrorDialog setIsActive={innerSetIsActive} />}
+      {isConfirmed && !isError && <ConfirmedDialog work={work} item={item} />}
+      {!isConfirmed && !isError && (
+        <RequestDialog
+          isLoading={isLoading}
+          work={work}
+          item={item}
+          confirmRequest={confirmRequest}
+          setIsActive={innerSetIsActive}
+        />
+      )}
     </Modal>
   );
 };

--- a/catalogue/webapp/components/ConfirmItemRequest/ConfirmItemRequest.tsx
+++ b/catalogue/webapp/components/ConfirmItemRequest/ConfirmItemRequest.tsx
@@ -1,9 +1,10 @@
-import { FunctionComponent, RefObject, useState } from 'react';
+import { FunctionComponent, useState, useRef } from 'react';
 import Modal from '@weco/common/views/components/Modal/Modal';
 import ButtonSolidLink from '@weco/common/views/components/ButtonSolidLink/ButtonSolidLink';
 import ButtonOutlinedLink from '@weco/common/views/components/ButtonOutlinedLink/ButtonOutlinedLink';
 import ButtonSolid from '@weco/common/views/components/ButtonSolid/ButtonSolid';
 import ButtonOutlined from '@weco/common/views/components/ButtonOutlined/ButtonOutlined';
+import ButtonInline from '@weco/common/views/components/ButtonInline/ButtonInline';
 import Space from '@weco/common/views/components/styled/Space';
 import styled from 'styled-components';
 import { PhysicalItem, Work } from '@weco/common/model/catalogue';
@@ -49,7 +50,6 @@ type Props = {
   isActive: boolean;
   setIsActive: (value: boolean) => void;
   id: string;
-  openButtonRef: RefObject<HTMLButtonElement>;
 };
 
 type RequestDialogProps = {
@@ -185,6 +185,7 @@ const ErrorDialog: FunctionComponent<ErrorDialogProps> = ({ setIsActive }) => (
 );
 
 const ConfirmItemRequest: FunctionComponent<Props> = props => {
+  const openButtonRef = useRef<HTMLButtonElement>(null);
   const { item, work, setIsActive, ...modalProps } = props;
   const [isConfirmed, setIsConfirmed] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
@@ -214,20 +215,32 @@ const ConfirmItemRequest: FunctionComponent<Props> = props => {
   }
 
   return (
-    <Modal {...modalProps} setIsActive={innerSetIsActive}>
-      {isLoading && <LL />}
-      {isError && <ErrorDialog setIsActive={innerSetIsActive} />}
-      {isConfirmed && !isError && <ConfirmedDialog work={work} item={item} />}
-      {!isConfirmed && !isError && (
-        <RequestDialog
-          isLoading={isLoading}
-          work={work}
-          item={item}
-          confirmRequest={confirmRequest}
-          setIsActive={innerSetIsActive}
-        />
-      )}
-    </Modal>
+    <>
+      <ButtonInline
+        ref={openButtonRef}
+        text={'Request item'}
+        clickHandler={() => setIsActive(true)}
+      />
+
+      <Modal
+        {...modalProps}
+        setIsActive={innerSetIsActive}
+        openButtonRef={openButtonRef}
+      >
+        {isLoading && <LL />}
+        {isError && <ErrorDialog setIsActive={innerSetIsActive} />}
+        {isConfirmed && !isError && <ConfirmedDialog work={work} item={item} />}
+        {!isConfirmed && !isError && (
+          <RequestDialog
+            isLoading={isLoading}
+            work={work}
+            item={item}
+            confirmRequest={confirmRequest}
+            setIsActive={innerSetIsActive}
+          />
+        )}
+      </Modal>
+    </>
   );
 };
 

--- a/catalogue/webapp/components/ConfirmItemRequest/ConfirmItemRequest.tsx
+++ b/catalogue/webapp/components/ConfirmItemRequest/ConfirmItemRequest.tsx
@@ -1,13 +1,29 @@
 import { FunctionComponent, RefObject } from 'react';
 import Modal from '@weco/common/views/components/Modal/Modal';
 import ButtonSolid from '@weco/common/views/components/ButtonSolid/ButtonSolid';
+import ButtonOutlined from '@weco/common/views/components/ButtonOutlined/ButtonOutlined';
+import Space from '@weco/common/views/components/styled/Space';
 import styled from 'styled-components';
 import { PhysicalItem, Work } from '@weco/common/model/catalogue';
+import { classNames, font } from '@weco/common/utils/classnames';
 
-const Header = styled.div`
+const Header = styled(Space).attrs({
+  v: { size: 'm', properties: ['margin-bottom'] },
+})`
   display: flex;
   justify-content: space-between;
+  align-items: center;
 `;
+
+const Remaining = styled(Space).attrs({
+  h: { size: 's', properties: ['padding-left'] },
+})`
+  border-left: 5px solid ${props => props.theme.color('yellow')};
+`;
+
+const CTAs = styled(Space).attrs({
+  v: { size: 'l', properties: ['margin-top'] },
+})``;
 
 type Props = {
   work: Work;
@@ -19,21 +35,38 @@ type Props = {
 };
 
 const ConfirmItemRequest: FunctionComponent<Props> = props => {
-  const { item, work, ...modalProps } = props;
+  const { item, work, setIsActive, ...modalProps } = props;
 
   return (
-    <Modal {...modalProps}>
+    <Modal {...modalProps} setIsActive={setIsActive}>
       <Header>
-        <span>Request item</span>
-        <span>7/10 items remaining</span>
+        <span className={`h2`}>Request item</span>
+        <Remaining>7/15 items remaining</Remaining>
       </Header>
-      <p>You are about to request the following item:</p>
-      <p>
+      <p
+        className={classNames({
+          [font('hnb', 5)]: true,
+          'no-margin': true,
+        })}
+      >
+        You are about to request the following item:
+      </p>
+      <p className={'no-margin'}>
         {work.title && <span className="block">{work.title}</span>}
         {item.title && <span>{item.title}</span>}
       </p>
-      <ButtonSolid text={`Confirm request`} />
-      <a>Cancel request</a>
+      <CTAs>
+        <Space
+          h={{ size: 'l', properties: ['margin-right'] }}
+          className={'inline-block'}
+        >
+          <ButtonSolid text={`Confirm request`} />
+        </Space>
+        <ButtonOutlined
+          text={`Cancel request`}
+          clickHandler={() => setIsActive(false)}
+        />
+      </CTAs>
     </Modal>
   );
 };

--- a/catalogue/webapp/components/ConfirmItemRequest/ConfirmItemRequest.tsx
+++ b/catalogue/webapp/components/ConfirmItemRequest/ConfirmItemRequest.tsx
@@ -1,0 +1,41 @@
+import { FunctionComponent, RefObject } from 'react';
+import Modal from '@weco/common/views/components/Modal/Modal';
+import ButtonSolid from '@weco/common/views/components/ButtonSolid/ButtonSolid';
+import styled from 'styled-components';
+import { PhysicalItem, Work } from '@weco/common/model/catalogue';
+
+const Header = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+type Props = {
+  work: Work;
+  item: PhysicalItem;
+  isActive: boolean;
+  setIsActive: (value: boolean) => void;
+  id: string;
+  openButtonRef: RefObject<HTMLButtonElement>;
+};
+
+const ConfirmItemRequest: FunctionComponent<Props> = props => {
+  const { item, work, ...modalProps } = props;
+
+  return (
+    <Modal {...modalProps}>
+      <Header>
+        <span>Request item</span>
+        <span>7/10 items remaining</span>
+      </Header>
+      <p>You are about to request the following item:</p>
+      <p>
+        {work.title && <span className="block">{work.title}</span>}
+        {item.title && <span>{item.title}</span>}
+      </p>
+      <ButtonSolid text={`Confirm request`} />
+      <a>Cancel request</a>
+    </Modal>
+  );
+};
+
+export default ConfirmItemRequest;

--- a/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
+++ b/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
@@ -1,14 +1,18 @@
-import { FunctionComponent, useContext } from 'react';
+import { FunctionComponent, useContext, useRef, useState } from 'react';
 import styled from 'styled-components';
+import ButtonInline from '@weco/common/views/components/ButtonInline/ButtonInline';
 import ButtonInlineLink from '@weco/common/views/components/ButtonInlineLink/ButtonInlineLink';
 import Space from '@weco/common/views/components/styled/Space';
 import { classNames, font } from '@weco/common/utils/classnames';
 import IsArchiveContext from '@weco/common/views/components/IsArchiveContext/IsArchiveContext';
-import { PhysicalItem, PhysicalLocation } from '@weco/common/model/catalogue';
+import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
+import { PhysicalItem, Work } from '@weco/common/model/catalogue';
 import {
   getLocationLabel,
   getLocationShelfmark,
+  getFirstPhysicalLocation,
 } from '@weco/common/utils/works';
+import ConfirmItemRequest from '../ConfirmItemRequest/ConfirmItemRequest';
 
 const Row = styled(Space).attrs({
   v: { size: 'm', properties: ['margin-bottom'] },
@@ -62,23 +66,21 @@ const Grid = styled.div<{ isArchive: boolean }>`
 
 export type Props = {
   item: PhysicalItem;
+  work: Work;
   encoreLink?: string;
   isLast: boolean;
 };
 
-function getFirstPhysicalLocation(
-  item: PhysicalItem
-): PhysicalLocation | undefined {
-  // In practice we only expect one physical location per item
-  return item.locations?.find(location => location.type === 'PhysicalLocation');
-}
-
 const PhysicalItemDetails: FunctionComponent<Props> = ({
   item,
+  work,
   encoreLink,
   isLast,
 }) => {
+  const openButtonRef = useRef<HTMLButtonElement>(null);
+  const [isActive, setIsActive] = useState(false);
   const isArchive = useContext(IsArchiveContext);
+  const { showLogin } = useContext(TogglesContext);
   const physicalLocation = getFirstPhysicalLocation(item);
   const isRequestableOnline =
     physicalLocation?.accessConditions?.[0]?.method?.id === 'online-request';
@@ -120,7 +122,30 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
           </Box>
           <Box isCentered>
             {requestItemUrl && (
-              <ButtonInlineLink text={'Request item'} link={requestItemUrl} />
+              <>
+                {showLogin ? (
+                  <>
+                    <ButtonInline
+                      ref={openButtonRef}
+                      text={'Request item'}
+                      clickHandler={() => setIsActive(true)}
+                    />
+                    <ConfirmItemRequest
+                      openButtonRef={openButtonRef}
+                      isActive={isActive}
+                      setIsActive={setIsActive}
+                      id={'test'}
+                      item={item}
+                      work={work}
+                    />
+                  </>
+                ) : (
+                  <ButtonInlineLink
+                    text={'Request item'}
+                    link={requestItemUrl}
+                  />
+                )}
+              </>
             )}
           </Box>
         </Grid>

--- a/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
+++ b/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
@@ -1,6 +1,5 @@
-import { FunctionComponent, useContext, useRef, useState } from 'react';
+import { FunctionComponent, useContext, useState } from 'react';
 import styled from 'styled-components';
-import ButtonInline from '@weco/common/views/components/ButtonInline/ButtonInline';
 import ButtonInlineLink from '@weco/common/views/components/ButtonInlineLink/ButtonInlineLink';
 import Space from '@weco/common/views/components/styled/Space';
 import { classNames, font } from '@weco/common/utils/classnames';
@@ -77,7 +76,6 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
   encoreLink,
   isLast,
 }) => {
-  const openButtonRef = useRef<HTMLButtonElement>(null);
   const [isActive, setIsActive] = useState(false);
   const isArchive = useContext(IsArchiveContext);
   const { showItemRequestFlow } = useContext(TogglesContext);
@@ -124,21 +122,13 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
             {requestItemUrl && (
               <>
                 {showItemRequestFlow ? (
-                  <>
-                    <ButtonInline
-                      ref={openButtonRef}
-                      text={'Request item'}
-                      clickHandler={() => setIsActive(true)}
-                    />
-                    <ConfirmItemRequest
-                      openButtonRef={openButtonRef}
-                      isActive={isActive}
-                      setIsActive={setIsActive}
-                      id={'test'}
-                      item={item}
-                      work={work}
-                    />
-                  </>
+                  <ConfirmItemRequest
+                    isActive={isActive}
+                    setIsActive={setIsActive}
+                    id={'test'}
+                    item={item}
+                    work={work}
+                  />
                 ) : (
                   <ButtonInlineLink
                     text={'Request item'}

--- a/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
+++ b/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
@@ -80,7 +80,7 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
   const openButtonRef = useRef<HTMLButtonElement>(null);
   const [isActive, setIsActive] = useState(false);
   const isArchive = useContext(IsArchiveContext);
-  const { showLogin } = useContext(TogglesContext);
+  const { showItemRequestFlow } = useContext(TogglesContext);
   const physicalLocation = getFirstPhysicalLocation(item);
   const isRequestableOnline =
     physicalLocation?.accessConditions?.[0]?.method?.id === 'online-request';
@@ -123,7 +123,7 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
           <Box isCentered>
             {requestItemUrl && (
               <>
-                {showLogin ? (
+                {showItemRequestFlow ? (
                   <>
                     <ButtonInline
                       ref={openButtonRef}

--- a/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
+++ b/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
@@ -3,6 +3,7 @@ import PhysicalItemDetails from '../PhysicalItemDetails/PhysicalItemDetails';
 import {
   PhysicalItem,
   ItemsWork,
+  Work,
   CatalogueApiError,
 } from '@weco/common/model/catalogue';
 import { isCatalogueApiError } from '../../pages/api/works/items/[workId]';
@@ -17,13 +18,13 @@ async function fetchWorkItems(
 }
 
 type Props = {
-  workId: string;
+  work: Work;
   items: PhysicalItem[];
   encoreLink: string | undefined;
 };
 
 const PhysicalItems: FunctionComponent<Props> = ({
-  workId,
+  work,
   items,
   encoreLink,
 }: Props) => {
@@ -31,7 +32,7 @@ const PhysicalItems: FunctionComponent<Props> = ({
 
   useEffect(() => {
     const addStatusToItems = async () => {
-      const items = await fetchWorkItems(workId);
+      const items = await fetchWorkItems(work.id);
       if (!isCatalogueApiError(items)) {
         const mergedItems = physicalItems.map(currentItem => {
           const matchingItem = items.results?.find(
@@ -57,6 +58,7 @@ const PhysicalItems: FunctionComponent<Props> = ({
       listItems={physicalItems.map((item, index) => (
         <PhysicalItemDetails
           item={item}
+          work={work}
           encoreLink={encoreLink}
           isLast={index === physicalItems.length - 1}
           key={index}

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -237,7 +237,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
       )}
       {showPhysicalItems && physicalItems && (
         <PhysicalItems
-          workId={work.id}
+          work={work}
           items={physicalItems}
           encoreLink={encoreLink}
         />

--- a/common/utils/works.ts
+++ b/common/utils/works.ts
@@ -340,3 +340,9 @@ export function getLocationLink(
     };
   }
 }
+
+export function getFirstPhysicalLocation(
+  item: PhysicalItem
+): PhysicalLocation | undefined {
+  return item.locations?.find(location => location.type === 'PhysicalLocation');
+}

--- a/playwright/test/request-items.test.ts
+++ b/playwright/test/request-items.test.ts
@@ -1,3 +1,24 @@
+import { workWithPhysicalLocationOnly } from './contexts';
+import { baseUrl } from './helpers/urls';
+import { makeDefaultToggleAndTestCookies } from './helpers/utils';
+
+const domain = new URL(baseUrl).host;
+
+beforeAll(async () => {
+  const defaultToggleAndTestCookies = await makeDefaultToggleAndTestCookies(
+    domain
+  );
+  await context.addCookies([
+    {
+      name: 'toggle_showItemRequestFlow',
+      value: 'true',
+      domain: domain,
+      path: '/',
+    },
+    ...defaultToggleAndTestCookies,
+  ]);
+});
+
 describe('Scenario 1: researcher is logged out', () => {
   test('Link to login/registration is displayed', () => {
     // Log out
@@ -27,10 +48,11 @@ describe('Scenario 3: researcher is a library member', () => {
 });
 
 describe('Scenario 4: researcher is logged in', () => {
-  test('Items display their requestability', () => {
-    // Log in
-    // Go to work page with requestable items
-    // Expect request button for each requestable item
+  test.only('Items display their requestability', async () => {
+    // TODO: Log in instead of setting toggle
+    await workWithPhysicalLocationOnly();
+    const requestButtons = await page.$$('button:has-text("Request item")');
+    expect(requestButtons.length).toBe(2);
   });
 });
 

--- a/playwright/test/request-items.test.ts
+++ b/playwright/test/request-items.test.ts
@@ -48,7 +48,7 @@ describe('Scenario 3: researcher is a library member', () => {
 });
 
 describe('Scenario 4: researcher is logged in', () => {
-  test.only('Items display their requestability', async () => {
+  test('Items display their requestability', async () => {
     // TODO: Log in instead of setting toggle
     await workWithPhysicalLocationOnly();
     const requestButtons = await page.$$('button:has-text("Request item")');
@@ -57,37 +57,35 @@ describe('Scenario 4: researcher is logged in', () => {
 });
 
 describe('Scenario 5: researcher initiates item request', () => {
-  beforeAll(() => {
-    // Log in
-    // Go to work page with requestable items
-    // Click request button
+  beforeAll(async () => {
+    // TODO: Log in instead of setting toggle
+    await workWithPhysicalLocationOnly();
+    await page.click('button:has-text("Request item")');
   });
 
-  test('Account indicates number of remaining requests', () => {
-    // Expect x of y requests remaining
+  test('Account indicates number of remaining requests', async () => {
+    const remainingRequests = await page.$(':has-text("7/15 items remaining")');
+    expect(remainingRequests).toBeTruthy();
   });
 
-  test('Researcher can cancel request', () => {
-    // Click cancel request button
-    // Expect item not to have been requested
-    // Expect to see request button for item
+  test.only('Researcher can cancel request', async () => {
+    await page.click('button:has-text("Cancel request")');
+    const requestButtons = await page.$$('button:has-text("Request item")');
+    expect(requestButtons.length).toBe(2);
   });
 });
 
 describe('Scenario 6: researcher confirms item request', () => {
-  beforeAll(() => {
-    // Log in
-    // Go to work page with requestable items
-    // Click request button
+  beforeAll(async () => {
+    // TODO: Log in instead of setting toggle
+    await workWithPhysicalLocationOnly();
+    await page.click('button:has-text("Request item")');
   });
 
-  test('Researcher can confirm request', () => {
-    // Expect
-    // Click confirm button
-    // Expect item to have been requested
-    // Expect success message
-    // Expect location/duration information
-    // Expect process for collection information
-    // Expect book a ticket button
+  test('Researcher can confirm request', async () => {
+    await page.click('button:has-text("Confirm request")');
+    await page.waitForSelector(':has-text("Request confirmed")');
+    await page.waitForSelector(':has-text("6/15 items remaining")');
+    await page.waitForSelector('a:has-text("Book a ticket")');
   });
 });

--- a/playwright/test/request-items.test.ts
+++ b/playwright/test/request-items.test.ts
@@ -68,7 +68,7 @@ describe('Scenario 5: researcher initiates item request', () => {
     expect(remainingRequests).toBeTruthy();
   });
 
-  test.only('Researcher can cancel request', async () => {
+  test('Researcher can cancel request', async () => {
     await page.click('button:has-text("Cancel request")');
     const requestButtons = await page.$$('button:has-text("Request item")');
     expect(requestButtons.length).toBe(2);

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -27,6 +27,13 @@ export default {
       defaultValue: false,
     },
     {
+      id: 'showItemRequestFlow',
+      title: 'Show item request user flow',
+      description:
+        'Makes the Request item button call the items API and show the relevant request/confirm modal flow',
+      defaultValue: false,
+    },
+    {
       id: 'stagingApi',
       title: 'Staging API',
       defaultValue: false,


### PR DESCRIPTION
Related to #6537

## Who is this for?
People who want to request items

## What is it doing for them?
Giving them UI to confirm their request

This PR mocks the loading state and the request confirmed state, as well as the number of requestable items the user has left on their account. We'll wire this up to the items API and users in subsequent pieces of work.

https://user-images.githubusercontent.com/1394592/128361311-f59e3c8f-295c-46e6-a499-133988960eeb.mp4

I've left out the date-picker for now, because it feels too vague at the moment. And I've used an outlined button for the 'Cancel request' CTA for the time being, because we haven't got a button-styled-like-a-link at the moment.

__TODO:__
- [x] Add toggle specific to requesting instead of using `showLogin`
- [x] Add Confirmation modal
- [x] Tests for user stories
