### PR TITLE
Lighthouse CI integration tests/reports

### DIFF
--- a/.github/workflows/lighthouse_integration.yml
+++ b/.github/workflows/lighthouse_integration.yml
@@ -1,0 +1,33 @@
+name: Lighthouse integration
+
+on: [deployment_status]
+
+jobs:
+  run_lighthouse:
+    name: Lighthouse report
+    runs-on: ubuntu-20.04
+    if: |
+      github.event.deployment.task == "deploy:weco" &&
+      github.event.deployment_status.state == "success"
+    steps:
+       - uses: actions/checkout@v2
+       - name: Create URLs list
+         id: urls
+         run: |
+           # prepend the deployment URL to all the paths
+           URLS=$(awk '{print "${{ github.event.deployment_status.target_url }}" $0}' .github/actions/workflows/lighthouse_integration_paths.txt)
+
+           # escape the newlines as per:
+           # https://trstringer.com/github-actions-multiline-strings/
+           URLS="${URLS//'%'/'%25'}"
+           URLS="${URLS//$'\n'/'%0A'}"
+           URLS="${URLS//$'\r'/'%0D'}"
+
+           # set the step output
+           echo "::set-output name=list::$URLS"
+       - name: Run report and upload results
+         uses: treosh/lighthouse-ci-action@v8
+         with:
+           urls: ${{ steps.urls.outputs.list }}
+           serverBaseUrl: https://lighthouse.wellcomecollection.org
+           serverToken: ${{ secrets.LHCI_BUILD_TOKEN }}

--- a/.github/workflows/lighthouse_integration_paths.txt
+++ b/.github/workflows/lighthouse_integration_paths.txt
@@ -1,0 +1,7 @@
+/works
+/works/kxvgmysq
+/works/kxvgmysq/items
+/whats-on
+/articles
+/series/X24JnhEAAMplRFYN
+/articles/YCppthUAACgAaYI5


### PR DESCRIPTION
Depends on https://github.com/wellcomecollection/wellcomecollection.org/pull/6860

This adds an action to run Lighthouse reports after every deployment, and upload the results to our lighthouse server.