### PR TITLE
Request logged out

### DIFF
--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -74,7 +74,7 @@ function getItemLinkState({
 }
 
 const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
-  const { showPhysicalItems, showHoldingsOnWork } = useContext(TogglesContext);
+  const { showHoldingsOnWork } = useContext(TogglesContext);
   const isArchive = useContext(IsArchiveContext);
 
   const itemUrl = itemLink({ workId: work.id }, 'work');
@@ -221,21 +221,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
           text={locationOfWork.contents}
         />
       )}
-      {showEncoreLink && !showPhysicalItems && (
-        <Space
-          v={{
-            size: 'l',
-            properties: ['margin-bottom'],
-          }}
-        >
-          <WorkDetailsText
-            text={[
-              `<a href="${encoreLink}">Access this item on the Wellcome Library website</a>`,
-            ]}
-          />
-        </Space>
-      )}
-      {showPhysicalItems && physicalItems && (
+      {physicalItems && (
         <PhysicalItems
           workId={work.id}
           items={physicalItems}

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -47,9 +47,26 @@ import IIIFClickthrough from '@weco/common/views/components/IIIFClickthrough/III
 import OnlineResources from './OnlineResources';
 import ExpandableList from '@weco/common/views/components/ExpandableList/ExpandableList';
 import IsArchiveContext from '@weco/common/views/components/IsArchiveContext/IsArchiveContext';
+import styled from 'styled-components';
+import Icon from '@weco/common/views/components/Icon/Icon';
+import AlignFont from '@weco/common/views/components/styled/AlignFont';
+
 type Props = {
   work: Work;
 };
+
+const SignInNotice = styled(Space).attrs({
+  h: { size: 'm', properties: ['padding-left', 'padding-right'] },
+  v: { size: 's', properties: ['padding-top', 'padding-bottom'] },
+})`
+  background: ${props => props.theme.color('smoke')};
+  display: flex;
+  align-items: flex-start;
+
+  .icon {
+    transform: translateY(0.1em);
+  }
+`;
 
 // At the moment we aren't set up to cope with access conditions,
 // 'permission-required', so we pass them off to the UV on the library site
@@ -74,7 +91,7 @@ function getItemLinkState({
 }
 
 const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
-  const { showHoldingsOnWork } = useContext(TogglesContext);
+  const { showHoldingsOnWork, showLogin } = useContext(TogglesContext);
   const isArchive = useContext(IsArchiveContext);
 
   const itemUrl = itemLink({ workId: work.id }, 'work');
@@ -213,8 +230,26 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
 
   const holdings = getHoldings(work);
 
-  const WhereToFindIt = () => (
+  type WhereToFindItProps = {
+    showLogin: boolean;
+  };
+  const WhereToFindIt = ({ showLogin }: WhereToFindItProps) => (
     <WorkDetailsSection headingText="Where to find it">
+      {showLogin && (
+        <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
+          <SignInNotice>
+            <Space h={{ size: 's', properties: ['margin-right'] }}>
+              <Icon name="memberCard" />
+            </Space>
+            <AlignFont>
+              <span className={font('hnb', 5)}>Library members:</span>{' '}
+              <a href="/account" className={font('hnr', 5)}>
+                sign in to your library account to request items
+              </a>
+            </AlignFont>
+          </SignInNotice>
+        </Space>
+      )}
       {locationOfWork && (
         <WorkDetailsText
           title={locationOfWork.noteType.label}
@@ -680,7 +715,9 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
 
       <Holdings />
 
-      {(locationOfWork || showEncoreLink) && <WhereToFindIt />}
+      {(locationOfWork || showEncoreLink) && (
+        <WhereToFindIt showLogin={showLogin} />
+      )}
 
       <WorkDetailsSection headingText="Permanent link">
         <div className={`${font('hnr', 5)}`}>

--- a/playwright/test/workPrototype.test.ts
+++ b/playwright/test/workPrototype.test.ts
@@ -8,17 +8,11 @@ import { baseUrl } from './helpers/urls';
 
 const domain = new URL(baseUrl).host;
 
-// Turn on the showPhysicalItems toggle
 beforeAll(async () => {
   const defaultToggleAndTestCookies = await makeDefaultToggleAndTestCookies(
     domain
   );
-  const toggleOverrides = [
-    {
-      name: 'toggle_showPhysicalItems',
-      value: 'true',
-    },
-  ];
+  const toggleOverrides = [];
   const overriddenCookies = defaultToggleAndTestCookies.map(cookie => {
     const matchingOverrideCookie = toggleOverrides.find(
       override => override.name === cookie.name

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -33,12 +33,6 @@ export default {
       description: 'Use the staging catalogue API',
     },
     {
-      id: 'showPhysicalItems',
-      title: 'Show physical items on the work page',
-      defaultValue: true,
-      description: 'Shows physical items and their locations on the work page',
-    },
-    {
       id: 'apiToolbar',
       title: 'API toolbar',
       defaultValue: false,


### PR DESCRIPTION
## Who is this for?
Library members who are logged out

## What is it doing for them?
Giving them UI to indicate they need to log in in order to request items on a work page

This is currently behind the `showLogin` toggle, and not yet aware of a user's logged-in state (since that is being dealt with in a separate piece of work). 

![image](https://user-images.githubusercontent.com/1394592/128883406-da3f79c2-5739-4aee-bf32-162aca442971.png)
