### PR TITLE
add publicRuntimeConfig to tests

### DIFF
--- a/common/views/components/ApmContext/ApmContext.tsx
+++ b/common/views/components/ApmContext/ApmContext.tsx
@@ -1,4 +1,4 @@
-import type { ApmBase } from '@elastic/apm-rum';
+import { ApmBase } from '@elastic/apm-rum';
 import getConfig from 'next/config';
 import { createContext, FunctionComponent } from 'react';
 import useApmRum from './useApmRum';

--- a/content/webapp/jest.config.js
+++ b/content/webapp/jest.config.js
@@ -2,4 +2,5 @@ module.exports = {
   setupFilesAfterEnv: ['@weco/common/test/setupTests.js'],
   snapshotSerializers: ['enzyme-to-json/serializer'],
   transformIgnorePatterns: ['node_modules(?!/@weco(?!.*node_modules))'],
+  setupFiles: ['<rootDir>/jest.setup.js'],
 };

--- a/content/webapp/test/pages/whats-on.test.js
+++ b/content/webapp/test/pages/whats-on.test.js
@@ -1,15 +1,5 @@
-import { setConfig } from 'next/config';
 import { whatsOn } from '@weco/common/test/fixtures/pages/whats-on';
 import { mountWithTheme } from '@weco/common/test/fixtures/enzyme-helpers';
-
-const apmConfig = {
-  environment: 'dev',
-  serverUrl: 'https://apm',
-  centralConfig: true,
-};
-setConfig({
-  publicRuntimeConfig: { ...apmConfig },
-});
 
 // We pull in the page after we've set the config
 const WhatsOnPage = require('../../pages/whats-on').default;

--- a/content/webapp/test/pages/whats-on.test.js
+++ b/content/webapp/test/pages/whats-on.test.js
@@ -1,6 +1,18 @@
+import { setConfig } from 'next/config';
 import { whatsOn } from '@weco/common/test/fixtures/pages/whats-on';
-import WhatsOnPage from '../../pages/whats-on';
 import { mountWithTheme } from '@weco/common/test/fixtures/enzyme-helpers';
+
+const apmConfig = {
+  environment: 'dev',
+  serverUrl: 'https://apm',
+  centralConfig: true,
+};
+setConfig({
+  publicRuntimeConfig: { ...apmConfig },
+});
+
+// We pull in the page after we've set the config
+const WhatsOnPage = require('../../pages/whats-on').default;
 
 const featuredExhibitionSelector = '[data-test-id="featured-exhibition"]';
 const noExhibitionsSelector = '[data-test-id="no-exhibitions"]';


### PR DESCRIPTION
## Who is this for?
People who want a fixed build

## What is it doing for them?
Adds the `publicRuntimeConfig` to the what's on test. I'm keeping the test as it's got some useful logic, although I am not sure that's the way we want to be testing it. 

Fixes the build