### PR TITLE
remove nginx ssm param

### DIFF
--- a/content/terraform/data.tf
+++ b/content/terraform/data.tf
@@ -9,8 +9,3 @@ data "terraform_remote_state" "experience_shared" {
     region = "eu-west-1"
   }
 }
-
-data "aws_ssm_parameter" "nginx_image_uri" {
-  name     = "/platform/images/latest/nginx_experience"
-  provider = aws.platform
-}

--- a/content/terraform/locals.tf
+++ b/content/terraform/locals.tf
@@ -42,6 +42,5 @@ locals {
   stage_app_image = "${data.terraform_remote_state.experience_shared.outputs.content_webapp_ecr_uri}:env.stage"
   prod_app_image  = "${data.terraform_remote_state.experience_shared.outputs.content_webapp_ecr_uri}:env.prod"
 
-  // Latest is available at data.aws_ssm_parameter.nginx_image_uri.value - test in staging before deployment
   nginx_image = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx_experience:78090f62ee23a39a1b4e929f25417bfa128c2aa8"
 }


### PR DESCRIPTION
## Who is this for?
People who dislike reading comments

## What is it doing for them?
Removes a comment and the offending code it referrs to.

The code also happens to point at a ssm param that doesn't exist.
