### PR TITLE
label font colour bug

### DIFF
--- a/common/views/components/Label/Label.tsx
+++ b/common/views/components/Label/Label.tsx
@@ -37,7 +37,6 @@ const Label: FunctionComponent<Props> = ({
   label,
   defaultLabelColor = 'yellow',
 }: Props) => {
-  console.log(label);
   return (
     <LabelContainer
       v={{

--- a/common/views/components/Label/Label.tsx
+++ b/common/views/components/Label/Label.tsx
@@ -37,6 +37,7 @@ const Label: FunctionComponent<Props> = ({
   label,
   defaultLabelColor = 'yellow',
 }: Props) => {
+  console.log(label);
   return (
     <LabelContainer
       v={{
@@ -50,7 +51,10 @@ const Label: FunctionComponent<Props> = ({
         overrides: { large: 2 },
       }}
       fontColor={
-        label.textColor || (label.labelColor === 'black' ? 'yellow' : 'black')
+        label.textColor ||
+        (label.labelColor === 'black' || defaultLabelColor === 'black'
+          ? 'yellow'
+          : 'black')
       }
       labelColor={label.labelColor || defaultLabelColor}
     >


### PR DESCRIPTION
Fixes a bug introduced by #6919, which causes certain labels to have the same background and font colour

Before:
![Screenshot 2021-08-19 at 15 24 56](https://user-images.githubusercontent.com/6051896/130086604-7b6996a1-a263-4b53-832f-27cac6edb8df.png)

After:
![Screenshot 2021-08-19 at 15 25 20](https://user-images.githubusercontent.com/6051896/130086641-10d9fd54-dd4e-4a4a-9998-439fda674256.png)
