### PR TITLE
Add tei toggle

### DIFF
--- a/catalogue/webapp/services/catalogue/images.ts
+++ b/catalogue/webapp/services/catalogue/images.ts
@@ -39,12 +39,18 @@ export async function getImages({
   pageSize = 25,
 }: GetImagesProps): Promise<CatalogueResultsList<Image> | CatalogueApiError> {
   const apiOptions = globalApiOptions(toggles);
+  let index;
+  if (toggles?.tei) {
+    const elasticConfigResponse = await fetch(
+      'https://api.wellcomecollection.org/catalogue/v2/_elasticConfig'
+    );
+    const elasticConfig = await elasticConfigResponse.json();
+    index = `${elasticConfig.imagesIndex}-tei-on`;
+  }
   const extendedParams = {
     ...params,
     pageSize,
-    _index: apiOptions.indexOverrideSuffix
-      ? `images-${apiOptions.indexOverrideSuffix}`
-      : null,
+    _index: index,
   };
   const filterQueryString = queryString(extendedParams);
   const url = `${rootUris[apiOptions.env]}/v2/images${filterQueryString}`;
@@ -64,11 +70,17 @@ export async function getImage({
   include = [],
 }: GetImageProps): Promise<Image | CatalogueApiError> {
   const apiOptions = globalApiOptions(toggles);
+  let index;
+  if (toggles?.tei) {
+    const elasticConfigResponse = await fetch(
+      'https://api.wellcomecollection.org/catalogue/v2/_elasticConfig'
+    );
+    const elasticConfig = await elasticConfigResponse.json();
+    index = `${elasticConfig.imagesIndex}-tei-on`;
+  }
   const params = {
     include: include,
-    _index: apiOptions.indexOverrideSuffix
-      ? `images-${apiOptions.indexOverrideSuffix}`
-      : null,
+    _index: index,
   };
   const query = queryString(params);
   const url = `${rootUris[apiOptions.env]}/v2/images/${id}${query}`;

--- a/catalogue/webapp/services/catalogue/images.ts
+++ b/catalogue/webapp/services/catalogue/images.ts
@@ -11,6 +11,7 @@ import {
   queryString,
   catalogueApiError,
   notFound,
+  getTeiIndexName,
 } from './common';
 import { Toggles } from '@weco/toggles';
 
@@ -39,14 +40,8 @@ export async function getImages({
   pageSize = 25,
 }: GetImagesProps): Promise<CatalogueResultsList<Image> | CatalogueApiError> {
   const apiOptions = globalApiOptions(toggles);
-  let index;
-  if (toggles?.tei) {
-    const elasticConfigResponse = await fetch(
-      'https://api.wellcomecollection.org/catalogue/v2/_elasticConfig'
-    );
-    const elasticConfig = await elasticConfigResponse.json();
-    index = `${elasticConfig.imagesIndex}-tei-on`;
-  }
+  const index = await getTeiIndexName(toggles, 'images');
+
   const extendedParams = {
     ...params,
     pageSize,
@@ -70,14 +65,8 @@ export async function getImage({
   include = [],
 }: GetImageProps): Promise<Image | CatalogueApiError> {
   const apiOptions = globalApiOptions(toggles);
-  let index;
-  if (toggles?.tei) {
-    const elasticConfigResponse = await fetch(
-      'https://api.wellcomecollection.org/catalogue/v2/_elasticConfig'
-    );
-    const elasticConfig = await elasticConfigResponse.json();
-    index = `${elasticConfig.imagesIndex}-tei-on`;
-  }
+  const index = await getTeiIndexName(toggles, 'images');
+
   const params = {
     include: include,
     _index: index,

--- a/catalogue/webapp/services/catalogue/works.ts
+++ b/catalogue/webapp/services/catalogue/works.ts
@@ -14,18 +14,19 @@ import {
   queryString,
   rootUris,
   notFound,
+  getTeiIndexName,
 } from './common';
 import { Toggles } from '@weco/toggles';
 
 type GetWorkProps = {
   id: string;
-  toggles?: Toggles;
+  toggles: Toggles;
 };
 
 type GetWorksProps = {
   params: CatalogueWorksApiProps;
   pageSize?: number;
-  toggles?: Toggles;
+  toggles: Toggles;
 };
 
 const worksIncludes = [
@@ -65,14 +66,8 @@ export async function getWorks({
   pageSize = 25,
 }: GetWorksProps): Promise<CatalogueResultsList | CatalogueApiError> {
   const apiOptions = globalApiOptions(toggles);
-  let index;
-  if (toggles?.tei) {
-    const elasticConfigResponse = await fetch(
-      'https://api.wellcomecollection.org/catalogue/v2/_elasticConfig'
-    );
-    const elasticConfig = await elasticConfigResponse.json();
-    index = `${elasticConfig.worksIndex}-tei-on`;
-  }
+  const index = await getTeiIndexName(toggles, 'works');
+
   const extendedParams = {
     ...params,
     pageSize,
@@ -99,14 +94,8 @@ export async function getWork({
   toggles,
 }: GetWorkProps): Promise<WorkResponse> {
   const apiOptions = globalApiOptions(toggles);
-  let index;
-  if (toggles?.tei) {
-    const elasticConfigResponse = await fetch(
-      'https://api.wellcomecollection.org/catalogue/v2/_elasticConfig'
-    );
-    const elasticConfig = await elasticConfigResponse.json();
-    index = `${elasticConfig.worksIndex}-tei-on`;
-  }
+  const index = await getTeiIndexName(toggles, 'works');
+
   const params = {
     include: workIncludes,
     _index: index,

--- a/catalogue/webapp/services/catalogue/works.ts
+++ b/catalogue/webapp/services/catalogue/works.ts
@@ -65,13 +65,19 @@ export async function getWorks({
   pageSize = 25,
 }: GetWorksProps): Promise<CatalogueResultsList | CatalogueApiError> {
   const apiOptions = globalApiOptions(toggles);
+  let index;
+  if (toggles?.tei) {
+    const elasticConfigResponse = await fetch(
+      'https://api.wellcomecollection.org/catalogue/v2/_elasticConfig'
+    );
+    const elasticConfig = await elasticConfigResponse.json();
+    index = `${elasticConfig.worksIndex}-tei-on`;
+  }
   const extendedParams = {
     ...params,
     pageSize,
     include: worksIncludes,
-    _index: apiOptions.indexOverrideSuffix
-      ? `works-${apiOptions.indexOverrideSuffix}`
-      : undefined,
+    _index: index,
   };
   const filterQueryString = queryString(extendedParams);
   const url = `${rootUris[apiOptions.env]}/v2/works${filterQueryString}`;
@@ -93,11 +99,17 @@ export async function getWork({
   toggles,
 }: GetWorkProps): Promise<WorkResponse> {
   const apiOptions = globalApiOptions(toggles);
+  let index;
+  if (toggles?.tei) {
+    const elasticConfigResponse = await fetch(
+      'https://api.wellcomecollection.org/catalogue/v2/_elasticConfig'
+    );
+    const elasticConfig = await elasticConfigResponse.json();
+    index = `${elasticConfig.worksIndex}-tei-on`;
+  }
   const params = {
     include: workIncludes,
-    _index: apiOptions.indexOverrideSuffix
-      ? `works-${apiOptions.indexOverrideSuffix}`
-      : null,
+    _index: index,
   };
   const query = queryString(params);
   const url = `${rootUris[apiOptions.env]}/v2/works/${id}${query}`;

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -39,6 +39,12 @@ export default {
       defaultValue: false,
       description: 'A toolbar to help us navigate the secret depths of the API',
     },
+    {
+      id: 'tei',
+      title: 'Tei visible',
+      defaultValue: false,
+      description: 'Makes Tei visible',
+    },
   ] as const,
   tests: [] as ABTest[],
 };


### PR DESCRIPTION
## Who is this for?
Everyone who's interested in tei in wellcomecollection.org

## What is it doing for them?
It's showing tei works in the frontend and, in instances where a sierra or calm record exists for a tei, it will redirect those to tei