### PR TITLE
continue to show the modal following a successful request

### DIFF
--- a/catalogue/webapp/components/ConfirmItemRequest/ConfirmItemRequest.tsx
+++ b/catalogue/webapp/components/ConfirmItemRequest/ConfirmItemRequest.tsx
@@ -229,7 +229,9 @@ const ConfirmItemRequest: FunctionComponent<Props> = ({
       setIsActive(true);
     } else {
       setIsActive(false);
-      setRequestingState(undefined);
+      if (requestingState !== 'confirmed') {
+        setRequestingState(undefined);
+      }
     }
   }
 
@@ -298,7 +300,7 @@ const ConfirmItemRequest: FunctionComponent<Props> = ({
     }
   }
 
-  return requestingState === 'confirmed' ? (
+  return requestingState === 'confirmed' && !modalProps.isActive ? (
     <span>You have this item on hold</span>
   ) : (
     <>


### PR DESCRIPTION
Following a successful request to the requesting API the modal that displays success/failure info. to the user was closing when we don't want it to.
This stops that happening.

It also resets the requesting state when closing the modal, as long as the state isn't confirmed. This means the button will still show and allow a user to attempt the request again.
