### PR TITLE
expose env variable to the browser

### DIFF
--- a/catalogue/webapp/.env.production
+++ b/catalogue/webapp/.env.production
@@ -3,3 +3,4 @@
 # This discrepancy is accounted for by a CONTEXT_PATH env var.
 # See the Identity README for a full account: https://github.com/wellcomecollection/wellcomecollection.org/blob/main/identity/webapp/README.md#context-path
 CONTEXT_PATH="account"
+NEXT_PUBLIC_CONTEXT_PATH="account"

--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -29,7 +29,6 @@ import GlobalInfoBarContext, {
 } from '../GlobalInfoBarContext/GlobalInfoBarContext';
 import TogglesContext from '../TogglesContext/TogglesContext';
 import ApiToolbar from '../ApiToolbar/ApiToolbar';
-import { prefix } from '@weco/identity/src/utility/prefix';
 
 type SiteSection =
   | 'collections'
@@ -229,7 +228,14 @@ const PageLayoutComponent: FunctionComponent<ComponentProps> = ({
         />
       </Head>
 
-      <div id="root" data-context-path={prefix}>
+      <div
+        id="root"
+        data-context-path={
+          process.env.NEXT_PUBLIC_CONTEXT_PATH
+            ? `/${process.env.NEXT_PUBLIC_CONTEXT_PATH}`
+            : undefined
+        }
+      >
         {apiToolbar && <ApiToolbar />}
         <CookieNotice />
         <a className="visually-hidden visually-hidden-focusable" href="#main">


### PR DESCRIPTION
Needed to [expose the context path variable to the browser](https://nextjs.org/docs/basic-features/environment-variables#exposing-environment-variables-to-the-browser), so that the correct api url was always used when on stage/prod

[Explanation of context path](https://github.com/wellcomecollection/wellcomecollection.org/tree/main/identity/webapp#context-path)
