### PR TITLE
If the location is "open-shelves", display "access: Open shelves"

### DIFF
--- a/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
+++ b/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
@@ -164,16 +164,23 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
             <span className={`inline-block`}>{location}</span>{' '}
             <span className={`inline-block`}>{shelfmark}</span>
           </Box>
-          {!isOpenShelves && (
-            <>
-              <Box>
-                {accessStatus && (
+          <Box>
+            {(isOpenShelves || accessStatus) && (
+              <>
+                <Box>
                   <>
                     <DetailHeading>Access</DetailHeading>
-                    <span>{accessStatus}</span>
+                    <span>
+                      {isOpenShelves && 'Open shelves'}
+                      {!isOpenShelves && accessStatus}
+                    </span>
                   </>
-                )}
-              </Box>
+                </Box>
+              </>
+            )}
+          </Box>
+          {!isOpenShelves && (
+            <>
               <Box isCentered>
                 {hideButton ? (
                   // TODO: fairly sure displaying this `accessMethod` here isn't what we want


### PR DESCRIPTION
## Who is this for?

Library users who want to find things.

## What is it doing for them?

Telling them that an item is on the open shelves and they can find it themselves.

<img width="776" alt="Screenshot 2021-08-24 at 17 17 16" src="https://user-images.githubusercontent.com/301220/130654569-69c58446-898a-4f0e-a90c-367007ca45f3.png">
