### PR TITLE
Add some CloudFront Alarms for 5xx errors

### DIFF
--- a/cache/alarms.tf
+++ b/cache/alarms.tf
@@ -14,6 +14,7 @@ resource "aws_cloudwatch_metric_alarm" "cloudfront_prod_5xx" {
 
   dimensions = {
     DistributionId = aws_cloudfront_distribution.wellcomecollection_org.id
+    Region         = "Global"
   }
 
   alarm_actions = [local.cloudfront_error_topic_arn]
@@ -31,6 +32,7 @@ resource "aws_cloudwatch_metric_alarm" "cloudfront_stage_5xx" {
 
   dimensions = {
     DistributionId = aws_cloudfront_distribution.stage_wc_org.id
+    Region         = "Global"
   }
 
   alarm_actions = [local.cloudfront_error_topic_arn]

--- a/cache/alarms.tf
+++ b/cache/alarms.tf
@@ -1,0 +1,37 @@
+locals {
+  cloudfront_error_topic_arn = data.terraform_remote_state.monitoring.outputs.experience_cloudfront_alerts_topic_arn
+}
+
+resource "aws_cloudwatch_metric_alarm" "cloudfront_prod_5xx" {
+  alarm_name          = "cloudfront_wc.org_error_5xx"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "5xxErrorRate"
+  namespace           = "AWS/CloudFront"
+  period              = 60
+  threshold           = 0
+  statistic           = "Average"
+
+  dimensions = {
+    DistributionId = aws_cloudfront_distribution.wellcomecollection_org.id
+  }
+
+  alarm_actions = [local.cloudfront_error_topic_arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "cloudfront_stage_5xx" {
+  alarm_name          = "cloudfront_stage.wc.org_error_5xx"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "5xxErrorRate"
+  namespace           = "AWS/CloudFront"
+  period              = 60
+  threshold           = 0
+  statistic           = "Average"
+
+  dimensions = {
+    DistributionId = aws_cloudfront_distribution.stage_wc_org.id
+  }
+
+  alarm_actions = [local.cloudfront_error_topic_arn]
+}

--- a/cache/terraform.tf
+++ b/cache/terraform.tf
@@ -60,6 +60,17 @@ data "terraform_remote_state" "assets" {
   }
 }
 
+data "terraform_remote_state" "monitoring" {
+  backend = "s3"
+
+  config = {
+    bucket   = "wellcomecollection-platform-infra"
+    key      = "terraform/monitoring.tfstate"
+    region   = "eu-west-1"
+    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+  }
+}
+
 output "s3_edge_lambda_origin_version_id" {
   value = data.aws_s3_bucket_object.edge_lambda_origin.version_id
 }


### PR DESCRIPTION
## Who is this for?

Developers and people who work on wc.org.

## What is it doing for them?

Giving them alerts in Slack when the site has a 5xx error.