### PR TITLE
hack in redirection back to work pages from account page

### DIFF
--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -257,7 +257,17 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
               </Space>
               <AlignFont>
                 <span className={font('hnb', 5)}>Library members:</span>{' '}
-                <a href="/account" className={font('hnr', 5)}>
+                <a
+                  href="/account"
+                  className={font('hnr', 5)}
+                  onClick={event => {
+                    // This is a very hacked together piece of work that allows us to read this cookie
+                    // and respond to it in the idnetity app
+                    event.preventDefault();
+                    document.cookie = `returnTo=${window.location.pathname}; path=/`;
+                    window.location.href = event.currentTarget.href;
+                  }}
+                >
                   sign in to your library account to request items
                 </a>
               </AlignFont>

--- a/identity/webapp/src/routes/index.ts
+++ b/identity/webapp/src/routes/index.ts
@@ -15,13 +15,26 @@ const unAuthenticatedPages: string[] = [
 
 export const indexPage: RouteMiddleware = context => {
   const bundle = context.routes.url('assets-bundles');
+  if (context.request.URL.pathname === '/works/abcdef') {
+    context.response.body = 'works';
+    return;
+  }
 
   if (
     context.isAuthenticated() ||
     unAuthenticatedPages.includes(context.request.URL.pathname)
   ) {
     console.log('current user ->', context.state.user);
-    context.response.body = buildHtml(bundle, getContextPath());
+
+    // This cookie is set on the login button before we do the auth dance
+    // Hack, indeed.
+    const returnTo = context.cookies.get('returnTo');
+    if (returnTo) {
+      context.cookies.set('returnTo', null);
+      context.redirect(returnTo);
+    } else {
+      context.response.body = buildHtml(bundle, getContextPath());
+    }
     return;
   }
 


### PR DESCRIPTION
This will redirect a user back to the work page when they login from a work page.

Adds a cookie when you use the login link, reads once you're authenticated, and returns you there instead of to the `/account` homepage.

This would probably be better but because "This solution takes a little more work to implement" I am adding this as a contigency so we can do testing.

https://auth0.com/docs/users/redirect-users-after-login#use-state-parameters