### PR TITLE
Tidying in the identity app

### DIFF
--- a/common/views/components/CheckboxRadio/CheckboxRadio.tsx
+++ b/common/views/components/CheckboxRadio/CheckboxRadio.tsx
@@ -1,4 +1,9 @@
-import { FunctionComponent, SyntheticEvent, ReactElement } from 'react';
+import {
+  FunctionComponent,
+  SyntheticEvent,
+  ReactElement,
+  ReactNode,
+} from 'react';
 import styled from 'styled-components';
 import { classNames } from '../../../utils/classnames';
 import Space from '../styled/Space';
@@ -69,12 +74,12 @@ const CheckBoxWrapper = styled.div`
 
 type CheckboxRadioProps = {
   type: 'checkbox' | 'radio';
-  id: string;
-  text: string;
+  id?: string;
+  text: ReactNode;
   checked: boolean;
-  name: string;
+  name?: string;
   onChange: (event: SyntheticEvent<HTMLInputElement>) => void;
-  value: string;
+  value?: string;
   ariaLabel?: string;
 };
 

--- a/common/views/components/Table/Table.tsx
+++ b/common/views/components/Table/Table.tsx
@@ -159,7 +159,7 @@ const TableTd = styled(Space).attrs({
 
 type Props = {
   rows: (string | ReactElement)[][];
-  hasRowHeaders: boolean;
+  hasRowHeaders?: boolean;
   caption?: string;
   vAlign?: 'top' | 'middle' | 'bottom';
   plain?: boolean;

--- a/identity/webapp/ecosystem.config.js
+++ b/identity/webapp/ecosystem.config.js
@@ -26,11 +26,7 @@ module.exports = {
             autorestart: true,
             watch: ['src'],
             watch_options: {
-              ignored: 'src/frontend',
-              awaitWriteFinish: {
-                stabilityThreshold: 2000,
-                pollInterval: 100,
-              },
+              ignored: 'src/frontend/**',
             },
             node_args: '--expose-gc --inspect=0.0.0.0:9229',
             max_memory_restart: '2G',

--- a/identity/webapp/package.json
+++ b/identity/webapp/package.json
@@ -14,7 +14,7 @@
     "watch:client": "yarn build:frontend --watch",
     "build": "yarn typecheck && NODE_ENV=production yarn build:schema && NODE_ENV=production yarn build:frontend",
     "build:schema": "node generate-schemas.js",
-    "build:frontend": "webpack --config webpack.frontend.js --entry ./src/frontend/index.tsx --output-path lib/frontend/build",
+    "build:frontend": "webpack --config webpack.frontend.js",
     "typecheck": "tsc --build tsconfig.json",
     "storybook": "start-storybook -p 4009",
     "build-storybook": "build-storybook",

--- a/identity/webapp/src/frontend/MyAccount/MyAccount.style.ts
+++ b/identity/webapp/src/frontend/MyAccount/MyAccount.style.ts
@@ -38,7 +38,7 @@ const OutlinedDangerButtonModifier = css`
   }
 `;
 
-export const Button = styled(OutlinedButton)`
+export const Button = styled(OutlinedButton)<{ isDangerous?: boolean }>`
   justify-content: center;
 
   ${props => props.isDangerous && OutlinedDangerButtonModifier}

--- a/identity/webapp/src/frontend/components/Form.style.ts
+++ b/identity/webapp/src/frontend/components/Form.style.ts
@@ -40,7 +40,7 @@ export const DangerButtonModifier = css`
   }
 `;
 
-export const Button = styled(SolidButton)`
+export const Button = styled(SolidButton)<{ isDangerous?: boolean }>`
   justify-content: center;
 
   ${props => props.isDangerous && DangerButtonModifier}

--- a/identity/webapp/src/router.ts
+++ b/identity/webapp/src/router.ts
@@ -68,8 +68,13 @@ export const router = new TypedRouter({
     'RequestDeleteSchema',
   ],
 
-  'item-requests': [
-    TypedRouter.GETPOST,
+  'get-item-requests': [
+    TypedRouter.GET,
+    '/api/users/:user_id/item-requests',
+    itemRequests,
+  ],
+  'post-item-requests': [
+    TypedRouter.POST,
     '/api/users/:user_id/item-requests',
     itemRequests,
   ],

--- a/identity/webapp/src/routes/assets/index.html.ts
+++ b/identity/webapp/src/routes/assets/index.html.ts
@@ -173,8 +173,6 @@ export default function buildHtml(bundle: string, contextPath = ''): string {
       href="https://i.wellcomecollection.org/assets/icons/safari-pinned-tab.svg"
       color="#000000"
     />
-    <script crossorigin src="https://unpkg.com/react@16/umd/react.development.js"></script>
-    <script crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"></script>
   </head>
   <body>
     <noscript>

--- a/identity/webapp/src/routes/index.ts
+++ b/identity/webapp/src/routes/index.ts
@@ -24,8 +24,6 @@ export const indexPage: RouteMiddleware = context => {
     context.isAuthenticated() ||
     unAuthenticatedPages.includes(context.request.URL.pathname)
   ) {
-    console.log('current user ->', context.state.user);
-
     // This cookie is set on the login button before we do the auth dance
     // Hack, indeed.
     const returnTo = context.cookies.get('returnTo');

--- a/identity/webapp/src/types/application.ts
+++ b/identity/webapp/src/types/application.ts
@@ -18,13 +18,15 @@ export interface ApplicationContext {
   ajv: Ajv;
 }
 
+export type RouteContext<Params = any, Body = any> = ApplicationContext &
+  Omit<RouterParamContext<ApplicationState, ApplicationContext>, 'params'> & {
+    params: Params;
+  } & {
+    requestBody: Body;
+    login: (...args: any[]) => any;
+  };
+
 export type RouteMiddleware<Params = any, Body = any> = Koa.Middleware<
   ApplicationState,
-  ApplicationContext &
-    Omit<RouterParamContext<ApplicationState, ApplicationContext>, 'params'> & {
-      params: Params;
-    } & {
-      requestBody: Body;
-      login: (...args: any[]) => any;
-    }
+  RouteContext<Params, Body>
 >;

--- a/identity/webapp/src/types/weco.ts
+++ b/identity/webapp/src/types/weco.ts
@@ -1,6 +1,0 @@
-declare module '@weco/common/views/components/Table/Table';
-declare module '@weco/common/views/components/CheckboxRadio/CheckboxRadio';
-declare module '@weco/common/views/components/ButtonOutlined/ButtonOutlined';
-declare module '@weco/common/views/components/ButtonSolid/ButtonSolid';
-declare module '@weco/common/views/components/SectionHeader/SectionHeader';
-declare module '@weco/common/views/components/SpacingComponent/SpacingComponent';

--- a/identity/webapp/src/utility/typed-router.ts
+++ b/identity/webapp/src/utility/typed-router.ts
@@ -1,4 +1,4 @@
-import Router from '@koa/router';
+import Router = require('@koa/router');
 import koaBody from 'koa-body';
 import { requestBody } from '../middleware/request-body';
 import { RouteMiddleware } from '../types/application';
@@ -31,7 +31,6 @@ export class TypedRouter<
   static PATCH = 'patch';
   static PUT = 'put';
   static DELETE = 'delete';
-  static GETPOST = 'getpost';
 
   private router = new Router({ prefix: getAppPathPrefix() });
 
@@ -41,20 +40,7 @@ export class TypedRouter<
       const [method, path, func, schemaName] = routes[route];
 
       switch (method) {
-        case TypedRouter.GETPOST:
-          // @ts-ignore
-          this.router.get(route, path, func);
-          // @ts-ignore
-          this.router.post(
-            route,
-            path,
-            koaBody(),
-            requestBody(schemaName),
-            func
-          );
-          break;
         case TypedRouter.PUT:
-          // @ts-ignore
           this.router.put(
             route,
             path,
@@ -64,7 +50,6 @@ export class TypedRouter<
           );
           break;
         case TypedRouter.POST:
-          // @ts-ignore
           this.router.post(
             route,
             path,
@@ -74,7 +59,6 @@ export class TypedRouter<
           );
           break;
         case TypedRouter.PATCH:
-          // @ts-ignore
           this.router.patch(
             route,
             path,
@@ -84,11 +68,9 @@ export class TypedRouter<
           );
           break;
         case TypedRouter.GET:
-          // @ts-ignore
           this.router.get(route, path, func);
           break;
         case TypedRouter.DELETE:
-          // @ts-ignore
           this.router.delete(route, path, func);
           break;
       }

--- a/identity/webapp/src/utility/typed-router.ts
+++ b/identity/webapp/src/utility/typed-router.ts
@@ -1,7 +1,11 @@
 import Router = require('@koa/router');
 import koaBody from 'koa-body';
 import { requestBody } from '../middleware/request-body';
-import { RouteMiddleware } from '../types/application';
+import {
+  ApplicationState,
+  RouteContext,
+  RouteMiddleware,
+} from '../types/application';
 import { getAppPathPrefix } from '@weco/common/utils/identity-path-prefix';
 
 export type RouteWithParams<Props, Body = any> =
@@ -32,7 +36,9 @@ export class TypedRouter<
   static PUT = 'put';
   static DELETE = 'delete';
 
-  private router = new Router({ prefix: getAppPathPrefix() });
+  private router = new Router<ApplicationState, RouteContext>({
+    prefix: getAppPathPrefix(),
+  });
 
   constructor(routes: MappedRoutes) {
     const routeNames = Object.keys(routes) as Routes[];

--- a/identity/webapp/webpack.frontend.js
+++ b/identity/webapp/webpack.frontend.js
@@ -1,4 +1,6 @@
-const createStyledComponentsTransformer = require('typescript-plugin-styled-components').default;
+const webpack = require('webpack');
+const createStyledComponentsTransformer = require('typescript-plugin-styled-components')
+  .default;
 const Dotenv = require('dotenv-webpack');
 const styledComponentsTransformer = createStyledComponentsTransformer({
   displayName: true,
@@ -13,7 +15,9 @@ const browserTargets = {
 module.exports = {
   mode: process.env.NODE_ENV || 'development',
   devtool: process.env.NODE_ENV !== 'production' ? 'inline-source-map' : false,
+  entry: './src/frontend/index.tsx',
   output: {
+    path: __dirname + '/lib/frontend/build',
     // Will be available on the router at `/assets/bundle.js`
     filename: 'bundle.js',
     pathinfo: false,
@@ -86,16 +90,17 @@ module.exports = {
     new Dotenv({
       systemvars: true,
     }),
+    // Components in @weco/common do not necessarily import React, as
+    // doing so is not required in Next.js projects. Providing it here
+    // fixes that without having to load an additional copy of React from
+    // a CDN
+    new webpack.ProvidePlugin({
+      React: 'react',
+    }),
   ],
 
   // Add problem packages to alias.
   resolve: {
     extensions: ['.js', '.ts', '.tsx'],
-  },
-
-  // We could use React from CDN.
-  externals: {
-    react: 'React',
-    'react-dom': 'ReactDOM',
   },
 };


### PR DESCRIPTION
What this does:

- Uses the actual types from `@weco/common`
- Stops using a (duplicate) React from a CDN
- Fixes the `TypedRouter` internal types