### PR TITLE
Expire images in uk.ac.wellcome/buildkite after 7 days

### DIFF
--- a/infrastructure/experience/ecr.tf
+++ b/infrastructure/experience/ecr.tf
@@ -6,6 +6,32 @@ resource "aws_ecr_repository" "buildkite" {
   }
 }
 
+# These images are used for in-build caching within a build pipeline.
+# We don't need to keep them beyond the lifetime of a given build,
+# although we keep them around for a short time so we can re-run build jobs.
+
+resource "aws_ecr_lifecycle_policy" "buildkite" {
+  repository = aws_ecr_repository.buildkite.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Expire images after 7 days"
+        selection = {
+          tagStatus   = "any"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = 7
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}
+
 resource "aws_ecr_repository" "content_webapp" {
   name = "uk.ac.wellcome/content_webapp"
 

--- a/infrastructure/experience/provider.tf
+++ b/infrastructure/experience/provider.tf
@@ -3,7 +3,7 @@ locals {
     TerraformConfigurationURL = "https://github.com/wellcomecollection/wellcomecollection.org/tree/main/infrastructure/experience"
     Department                = "Digital Platform"
     Division                  = "Culture and Society"
-    Use                       = "Identity APIs"
+    Use                       = "Experience infrastructure"
     Environment               = "Production"
   }
 }
@@ -26,5 +26,9 @@ provider "aws" {
 
   assume_role {
     role_arn = "arn:aws:iam::267269328833:role/wellcomecollection-assume_role_hosted_zone_update"
+  }
+
+  default_tags {
+    tags = local.default_tags
   }
 }

--- a/infrastructure/experience/provider.tf
+++ b/infrastructure/experience/provider.tf
@@ -4,21 +4,8 @@ locals {
     Department                = "Digital Platform"
     Division                  = "Culture and Society"
     Use                       = "Identity APIs"
+    Environment               = "Production"
   }
-
-  default_prod_tags = merge(
-    local.default_tags,
-    {
-      Environment = "Production"
-    }
-  )
-
-  default_stage_tags = merge(
-    local.default_tags,
-    {
-      Environment = "Staging"
-    }
-  )
 }
 
 provider "aws" {
@@ -29,20 +16,7 @@ provider "aws" {
   }
 
   default_tags {
-    tags = local.default_prod_tags
-  }
-}
-
-provider "aws" {
-  region = var.aws_region
-  alias  = "stage"
-
-  assume_role {
-    role_arn = "arn:aws:iam::130871440101:role/experience-developer"
-  }
-
-  default_tags {
-    tags = local.default_stage_tags
+    tags = local.default_tags
   }
 }
 


### PR DESCRIPTION
## Who is this for?
People who like money.

## What is it doing for them?
Spending less of it, by not accumulating thousands of unnecessary Docker images in our account.

Closes https://github.com/wellcomecollection/platform/issues/5277