### PR TITLE
add new UserProvider and SigninBar

### DIFF
--- a/catalogue/webapp/components/SignInBar/SignInBar.tsx
+++ b/catalogue/webapp/components/SignInBar/SignInBar.tsx
@@ -1,0 +1,98 @@
+import { FC } from 'react';
+import styled from 'styled-components';
+import Space from '@weco/common/views/components/styled/Space';
+import Icon from '@weco/common/views/components/Icon/Icon';
+import LL from '@weco/common/views/components/styled/LL';
+import AlignFont from '@weco/common/views/components/styled/AlignFont';
+import { useUser } from '@weco/common/views/components/UserProvider/UserProvider';
+import { font } from '@weco/common/utils/classnames';
+
+const StyledComponent = styled(Space).attrs({
+  h: { size: 'm', properties: ['padding-left', 'padding-right'] },
+  v: { size: 's', properties: ['padding-top', 'padding-bottom'] },
+})`
+  background: ${props => props.theme.color('turquoise', 'light')};
+  display: flex;
+  align-items: flex-start;
+  position: relative;
+
+  .icon {
+    transform: translateY(0.1em);
+  }
+`;
+
+const SignInLink: FC = () => {
+  return (
+    <AlignFont>
+      <span className={font('hnb', 5)}>Library members:</span>{' '}
+      <a
+        href="/account"
+        className={font('hnr', 5)}
+        onClick={event => {
+          // This is a very hacked together piece of work that allows us to read this cookie
+          // and respond to it in the identity app
+          event.preventDefault();
+          document.cookie = `returnTo=${window.location.pathname}; path=/`;
+          window.location.href = event.currentTarget.href;
+        }}
+      >
+        sign in to your library account to request items
+      </a>
+    </AlignFont>
+  );
+};
+
+type ReloadProps = {
+  reload: () => void;
+};
+const Reload: FC<ReloadProps> = ({ reload }) => {
+  return (
+    <AlignFont>
+      <span className={font('hnb', 5)}>
+        Something went wrong trying to check if you are signed in
+      </span>{' '}
+      <button
+        className={font('hnr', 5)}
+        onClick={() => {
+          reload();
+        }}
+        style={{
+          border: 'none',
+          background: 'none',
+          cursor: 'pointer',
+          borderBottom: '1px solid',
+        }}
+      >
+        Try again
+      </button>
+    </AlignFont>
+  );
+};
+
+const Loading = () => {
+  return (
+    <>
+      <AlignFont>
+        <span className={font('hnb', 5)}>Loading...</span>
+      </AlignFont>
+      <LL small={true} />
+    </>
+  );
+};
+
+const SignInBar: FC = () => {
+  const { state, reload } = useUser();
+
+  return state === 'signedin' || state === 'initial' ? null : (
+    <StyledComponent>
+      <Space h={{ size: 's', properties: ['margin-right'] }}>
+        <Icon name="memberCard" />
+      </Space>
+      {state === 'loading' && <Loading />}
+      {state === 'signedout' && <SignInLink />}
+      {state === 'failed' && <Reload reload={reload} />}
+    </StyledComponent>
+  );
+};
+
+export default SignInBar;

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -56,7 +56,7 @@ type Props = {
 
 // At the moment we aren't set up to cope with access conditions,
 // 'permission-required', so we pass them off to the UV on the library site
-// If we have audio or video, then we show it in situ/S and don't link to the Item page
+// If we have audio or video, then we show it in situ and don't link to the Item page
 type ItemLinkState = 'useItemLink' | 'useLibraryLink' | 'useNoLink';
 function getItemLinkState({
   accessCondition,

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -48,31 +48,15 @@ import IIIFClickthrough from '@weco/common/views/components/IIIFClickthrough/III
 import OnlineResources from './OnlineResources';
 import ExpandableList from '@weco/common/views/components/ExpandableList/ExpandableList';
 import IsArchiveContext from '@weco/common/views/components/IsArchiveContext/IsArchiveContext';
-import styled from 'styled-components';
-import Icon from '@weco/common/views/components/Icon/Icon';
-import AlignFont from '@weco/common/views/components/styled/AlignFont';
-import { useUserInfo } from '@weco/common/views/components/UserInfoContext';
+import SignInBar from '../SignInBar/SignInBar';
 
 type Props = {
   work: Work;
 };
 
-const SignInNotice = styled(Space).attrs({
-  h: { size: 'm', properties: ['padding-left', 'padding-right'] },
-  v: { size: 's', properties: ['padding-top', 'padding-bottom'] },
-})`
-  background: ${props => props.theme.color('turquoise', 'light')};
-  display: flex;
-  align-items: flex-start;
-
-  .icon {
-    transform: translateY(0.1em);
-  }
-`;
-
 // At the moment we aren't set up to cope with access conditions,
 // 'permission-required', so we pass them off to the UV on the library site
-// If we have audio or video, then we show it in situ and don't link to the Item page
+// If we have audio or video, then we show it in situ/S and don't link to the Item page
 type ItemLinkState = 'useItemLink' | 'useLibraryLink' | 'useNoLink';
 function getItemLinkState({
   accessCondition,
@@ -97,17 +81,18 @@ export const unrequestableMethodIds = ['not-requestable', 'open-shelves'];
 
 const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
   const { showHoldingsOnWork, enableRequesting } = useContext(TogglesContext);
-  const { user, isLoading } = useUserInfo();
   const isArchive = useContext(IsArchiveContext);
 
   const itemUrl = itemLink({ workId: work.id }, 'work');
 
   // Determine digital location
   const iiifImageLocation = getDigitalLocationOfType(work, 'iiif-image');
+
   const iiifPresentationLocation = getDigitalLocationOfType(
     work,
     'iiif-presentation'
   );
+
   const digitalLocation: DigitalLocation | undefined =
     iiifPresentationLocation || iiifImageLocation;
 
@@ -115,14 +100,17 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
     width: number;
     height: number;
   }>();
+
   const fetchImageJson = async () => {
     try {
       const imageJson =
         iiifImageLocation &&
         (await fetch(iiifImageLocation.url).then(resp => resp.json()));
+
       setImageJson(imageJson);
     } catch (e) {}
   };
+
   useEffect(() => {
     fetchImageJson();
   }, []);
@@ -139,15 +127,18 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
     iiifPresentationDownloadOptions = [],
     iiifDownloadEnabled,
   } = useIIIFManifestData(work);
+
   const authService =
     (video && getMediaClickthroughService(video)) ||
     (audio && getMediaClickthroughService(audio));
+
   const tokenService = authService && getTokenService(authService);
 
   // iiif-presentation locations don't have credit info in the work API currently, so we try and get it from the manifest
   const credit = (digitalLocation && digitalLocation.credit) || iiifCredit;
 
   const iiifImageLocationUrl = iiifImageLocation && iiifImageLocation.url;
+
   const iiifImageDownloadOptions = iiifImageLocationUrl
     ? getDownloadOptionsFromImageUrl({
         url: iiifImageLocationUrl,
@@ -187,10 +178,12 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
   const encoreLink = sierraWorkId && getEncoreLink(sierraWorkId);
 
   const physicalItems = getItemsWithPhysicalLocation(work);
-  const showLibraryLogin = physicalItems.some(item => {
+
+  const hasRequestableItems = physicalItems.some(item => {
     const physicalLocation = getFirstPhysicalLocation(item); // ok because there is only one physical location in reality
     const methodId = physicalLocation?.accessConditions?.[0]?.method?.id || '';
     const statusId = physicalLocation?.accessConditions?.[0]?.status?.id || '';
+
     return !(
       unrequestableStatusIds.includes(statusId) ||
       unrequestableMethodIds.includes(methodId)
@@ -249,29 +242,9 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
   const WhereToFindIt = () => {
     return (
       <WorkDetailsSection headingText="Where to find it">
-        {enableRequesting && !isLoading && !user && showLibraryLogin && (
+        {enableRequesting && hasRequestableItems && (
           <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
-            <SignInNotice>
-              <Space h={{ size: 's', properties: ['margin-right'] }}>
-                <Icon name="memberCard" />
-              </Space>
-              <AlignFont>
-                <span className={font('hnb', 5)}>Library members:</span>{' '}
-                <a
-                  href="/account"
-                  className={font('hnr', 5)}
-                  onClick={event => {
-                    // This is a very hacked together piece of work that allows us to read this cookie
-                    // and respond to it in the identity app
-                    event.preventDefault();
-                    document.cookie = `returnTo=${window.location.pathname}; path=/`;
-                    window.location.href = event.currentTarget.href;
-                  }}
-                >
-                  sign in to your library account to request items
-                </a>
-              </AlignFont>
-            </SignInNotice>
+            <SignInBar />
           </Space>
         )}
         {locationOfWork && (

--- a/common/views/components/GlobalContextProvider/GlobalContextProvider.tsx
+++ b/common/views/components/GlobalContextProvider/GlobalContextProvider.tsx
@@ -13,6 +13,7 @@ import TogglesContext from '../TogglesContext/TogglesContext';
 import { parseCollectionVenues } from '../../../services/prismic/opening-times';
 import { Toggles } from '@weco/toggles';
 import { ApmContextProvider } from '../ApmContext/ApmContext';
+import UserProvider from '../UserProvider/UserProvider';
 
 export type GlobalContextData = {
   toggles: Toggles;
@@ -44,6 +45,7 @@ const GlobalContextProvider: FunctionComponent<Props> = ({
 }: Props) => {
   const parsedOpeningTimes =
     value.openingTimes && parseCollectionVenues(value.openingTimes);
+
   return (
     <Context.Provider value={value}>
       <ApmContextProvider>
@@ -51,7 +53,7 @@ const GlobalContextProvider: FunctionComponent<Props> = ({
           <GlobalAlertContext.Provider value={value.globalAlert}>
             <PopupDialogContext.Provider value={value.popupDialog}>
               <TogglesContext.Provider value={value.toggles}>
-                {children}
+                <UserProvider>{children}</UserProvider>
               </TogglesContext.Provider>
             </PopupDialogContext.Provider>
           </GlobalAlertContext.Provider>

--- a/common/views/components/UserProvider/UserProvider.tsx
+++ b/common/views/components/UserProvider/UserProvider.tsx
@@ -1,0 +1,85 @@
+import { createContext, FC, useContext, useEffect, useState } from 'react';
+import { withAppPathPrefix } from '../../../utils/identity-path-prefix';
+import { UserInfo } from '../../../model/user';
+import TogglesContext from '../TogglesContext/TogglesContext';
+
+type State = 'initial' | 'loading' | 'signedin' | 'signedout' | 'failed';
+type Props = {
+  user: UserInfo | undefined;
+  state: State;
+  enabled: boolean;
+  reload: () => void;
+};
+
+export const UserContext = createContext<Props>({
+  user: undefined,
+  state: 'initial',
+  enabled: false,
+  reload: () => {
+    // no-op - we could probably try fill this out, but I can't really see the benefit
+  },
+});
+
+export function useUser(): Props {
+  const contextState = useContext(UserContext);
+  return contextState;
+}
+
+const UserProvider: FC = ({ children }) => {
+  const [user, setUser] = useState<UserInfo>();
+  const [state, setState] = useState<State>('initial');
+
+  const fetchUser = async () => {
+    setState('loading');
+    try {
+      const resp = await fetch(withAppPathPrefix('/api/users/me'));
+
+      switch (resp.status) {
+        case 401:
+          setState('signedout');
+          break;
+
+        case 200:
+          const data = await resp.json();
+          setState('signedin');
+          setUser(data);
+          break;
+
+        default:
+          setState('failed');
+      }
+    } catch (e) {
+      setState('failed');
+    }
+  };
+
+  useEffect(() => {
+    fetchUser();
+  }, []);
+
+  return (
+    <UserContext.Provider
+      value={{
+        user,
+        state,
+        // We can remove this once we're untoggled
+        enabled: true,
+        reload: fetchUser,
+      }}
+    >
+      {children}
+    </UserContext.Provider>
+  );
+};
+
+const ToggledUserProvider: FC = ({ children }) => {
+  const toggles = useContext(TogglesContext);
+
+  return toggles.enableRequesting ? (
+    <UserProvider>{children}</UserProvider>
+  ) : (
+    <>{children}</>
+  );
+};
+
+export default ToggledUserProvider;

--- a/common/views/components/styled/LL.js
+++ b/common/views/components/styled/LL.js
@@ -1,15 +1,16 @@
 import styled from 'styled-components';
 
+// We could use `zoom` for props.small, but it isn't supported in Firefox
+// see: https://bugzilla.mozilla.org/show_bug.cgi?id=390936
 const LL = styled.div`
   position: absolute;
   opacity: 0.2;
   left: 50%;
   top: 50%;
   transform: translateX(-50%) translateY(-50%);
-  width: 50px;
-  height: 80px;
+  width: ${props => (props.small ? '25px' : '50px')};
+  height: ${props => (props.small ? '40px' : '80px')};
   animation: animate-ll;
-  ${props => props.small && 'zoom: 0.5;'}
 
   &:before,
   &:after {
@@ -17,7 +18,7 @@ const LL = styled.div`
     position: absolute;
     top: 0;
     bottom: 0;
-    width: 20px;
+    width: ${props => (props.small ? '10px' : '20px')};
     background: ${props =>
       props.theme.color(props.lighten ? 'silver' : 'black')};
   }


### PR DESCRIPTION
## Who is this for?
People who want to know how their sign in is going.

## What is it doing for them?
Creates a new `UserProvider`. We do have a `UserInfoProvider`, which is similar but it uses a few patterns that are not like we use elsewhere across the codebase, and we needed a few more states. I didn't refactor it as it's used in the `identity-admin`, which is being decommissioned, and then we can just remove it and use this one.

The `UserProvider` only does any async stuff if the toggle is on, otherwise renders just the children avoiding running this for public users, which it currently does.

Fixes #6975

Creates a signin bar that uses that state.

**No JS**
Nothing, we don't support that yet

**Loading**
![Screen Recording 2021-09-02 at 10 10 05](https://user-images.githubusercontent.com/31692/131817857-a8742b0c-d7f9-4154-9422-b1dd92dad4a8.gif)

**Signed out**
![Screenshot 2021-09-02 at 10 10 24](https://user-images.githubusercontent.com/31692/131817891-5333d5a6-6754-41e3-84c6-d3fac285dcc3.png)

**Something went wrong**
![Screenshot 2021-09-02 at 10 10 37](https://user-images.githubusercontent.com/31692/131817943-03d4006b-c56f-4df0-a6fb-a564a6bc364f.png)

**Signed in** 
Nothing the blue bar goes away

This component doesn't need so many visible states, it could probably just show if you are signed out or something failed, but is more for illustrating how we will do this for things like the request button etc. [There is an issue for this here](https://github.com/wellcomecollection/wellcomecollection.org/issues/7002).