### PR TITLE
Use nano runners for the weco-deploy tasks

### DIFF
--- a/.buildkite/pipeline.deployment.yml
+++ b/.buildkite/pipeline.deployment.yml
@@ -16,6 +16,8 @@ steps:
               "--environment-id", "$BUILDKITE_GITHUB_DEPLOYMENT_ENVIRONMENT",
               "--description", $BUILDKITE_BUILD_URL,
               "--confirmation-wait-for", 3540 ] # Session times out at 3600s / 1 hour
+    agents:
+      queue: nano
 
   - wait
 


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5289

## Who is this for?

People who want to spend less money.

## What is it doing for them?

Running build tasks on less expensive instances.