### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # These are default codeowners, later rules take precedence
-*	@davidpmccormick @gestchild @jamesgorrie
+*	@wellcomecollection/js-ts-reviewers
 
 # To ensure only properly audited changes are run in CI, we require reviews
 # from @wellcomecollection/buildkite-admin when updating pipeline config

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,9 @@
-*   @davidpmccormick @gestchild @jamesgorrie
+# These are default codeowners, later rules take precedence
+*	@davidpmccormick @gestchild @jamesgorrie
+
+# To ensure only properly audited changes are run in CI, we require reviews
+# from @wellcomecollection/buildkite-admin when updating pipeline config
+
+/CODEOWNERS	@wellcomecollection/buildkite-admin
+/.buildkite/    @wellcomecollection/buildkite-admin
+/builds/      	@wellcomecollection/buildkite-admin


### PR DESCRIPTION
In order to ensure that changes to code run in the CI environment are properly reviewed, this change enforces that members of the @wellcomecollection/buildkite-admin group must approve changes to code run during in CI.

This is in conjunction with adding branch protection rules to main in the repo configuration.

As this repository names existing `CODEOWNERS` this change maintains that, but forces changes to the `CODEOWNERS` file to be reviewed by @wellcomecollection/buildkite-admin to prevent unintended permissions expansion.