### PR TITLE
remove tweakpoints

### DIFF
--- a/common/views/themes/config.ts
+++ b/common/views/themes/config.ts
@@ -136,10 +136,10 @@ export const themeValues = {
     medium: 600,
     large: 960,
     xlarge: 1338,
-  },
-  tweakpoints: {
+    // Tweakpoints
     // Occasionally we need to respond to specific breakpoints beyond the defaults
     headerMedium: 825,
+    headerLarge: 1040,
   },
   gutter: {
     small: 18,
@@ -197,7 +197,5 @@ export const themeValues = {
   },
 };
 
-type BaseBreakpoint = keyof typeof themeValues.sizes;
-type TweakBreakpoint = keyof typeof themeValues.tweakpoints;
-export type Breakpoint = BaseBreakpoint | TweakBreakpoint;
+export type Breakpoint = keyof typeof themeValues.sizes;
 export type PaletteColor = keyof typeof colors;

--- a/common/views/themes/default.ts
+++ b/common/views/themes/default.ts
@@ -109,10 +109,10 @@ const sizesClasses = Object.keys(themeValues.sizes).reduce((acc, size) => {
 // I know this is the case, but typescript and `.keys` and `.reduce` doesn't play all that nice
 // TODO: Make sure the implementation meets these types
 // see: https://fettblog.eu/typescript-better-object-keys/
-const cls = ({
+const cls = {
   ...classes,
   ...sizesClasses,
-} as any) as Classes & SizedClasses;
+} as any as Classes & SizedClasses;
 
 export type GlobalStyleProps = {
   toggles?: { [key: string]: boolean };

--- a/common/views/themes/mixins.ts
+++ b/common/views/themes/mixins.ts
@@ -1,8 +1,7 @@
 import { themeValues, ColumnKey, Breakpoint } from './config';
 
 export function respondTo(breakpoint: Breakpoint, content: string): string {
-  return `@media (min-width: ${themeValues.sizes[breakpoint] ??
-    themeValues.tweakpoints[breakpoint]}px) {
+  return `@media (min-width: ${themeValues.sizes[breakpoint]}px) {
    ${content}
  }`;
 }
@@ -12,9 +11,9 @@ export function respondBetween(
   maxBreakpoint: Breakpoint,
   content: string
 ): string {
-  return `@media (min-width: ${themeValues.sizes[minBreakpoint] ??
-    themeValues.tweakpoints[minBreakpoint]}px) and (max-width: ${(themeValues
-    .sizes[maxBreakpoint] ?? themeValues.tweakpoints[maxBreakpoint]) - 1}px) {
+  return `@media (min-width: ${
+    themeValues.sizes[minBreakpoint]
+  }px) and (max-width: ${themeValues.sizes[maxBreakpoint] - 1}px) {
     ${content}
   }`;
 }


### PR DESCRIPTION
I found myself doing a lot of work to try and make sure that where ever we use breakpoints, we merge in tweakpoints. An example would [here](https://github.com/wellcomecollection/wellcomecollection.org/blob/main/common/views/themes/default.ts#L124-L146).

Given we never differentiate between them, this pattern seems to simplify things. Is also removes the potential to have duplicate keys which would cause undesired behavior.

I've added `headerLarge: 1040` as I need it for some header work I am doing.