### PR TITLE
Re-inline the favicons in the head

### DIFF
--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -30,7 +30,6 @@ import GlobalInfoBarContext, {
 import TogglesContext from '../TogglesContext/TogglesContext';
 import ApiToolbar from '../ApiToolbar/ApiToolbar';
 import { getContextPath } from '@weco/common/utils/identity-path-prefix';
-import Favicons from '../Favicons/Favicons';
 
 export type SiteSection =
   | 'collections'
@@ -163,7 +162,37 @@ const PageLayoutComponent: FunctionComponent<ComponentProps> = ({
           )}`}
         />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <Favicons />
+        <link
+          rel="apple-touch-icon"
+          sizes="180x180"
+          href="https://i.wellcomecollection.org/assets/icons/apple-touch-icon.png"
+        />
+        <link
+          rel="shortcut icon"
+          href="https://i.wellcomecollection.org/assets/icons/favicon.ico"
+          type="image/ico"
+        />
+        <link
+          rel="icon"
+          type="image/png"
+          href="https://i.wellcomecollection.org/assets/icons/favicon-32x32.png"
+          sizes="32x32"
+        />
+        <link
+          rel="icon"
+          type="image/png"
+          href="https://i.wellcomecollection.org/assets/icons/favicon-16x16.png"
+          sizes="16x16"
+        />
+        <link
+          rel="manifest"
+          href="https://i.wellcomecollection.org/assets/icons/manifest.json"
+        />
+        <link
+          rel="mask-icon"
+          href="https://i.wellcomecollection.org/assets/icons/safari-pinned-tab.svg"
+          color="#000000"
+        />
         <script
           src="https://i.wellcomecollection.org/assets/libs/picturefill.min.js"
           async


### PR DESCRIPTION
I'd thought since the introduction of the `Fragment` element, we no longer needed to avoid componentising things in the `head`. It doesn't seem to be a problem in the identity app, but it is a problem in the content app (possible change between Next versions?).

This re-adds the favicon stuff directly in the `head` rather than imported from the `Favicons` component.

> title, meta or any other elements (e.g. script) need to be contained as direct children of the Head element, or wrapped into maximum one level of <React.Fragment> or arrays—otherwise the tags won't be correctly picked up on client-side navigations.