### PR TITLE
Fix medium spacing-component spacing value

### DIFF
--- a/common/views/components/SpacingComponent/SpacingComponent.tsx
+++ b/common/views/components/SpacingComponent/SpacingComponent.tsx
@@ -9,11 +9,11 @@ const SpacingComponentEl = styled.div.attrs({
     margin-top: ${props => props.theme.spaceAtBreakpoints.small.l}px;
 
     ${props => props.theme.media.medium`
-      margin-top: ${props => props.theme.spaceAtBreakpoints.medium.l}px;
+      margin-top: ${props.theme.spaceAtBreakpoints.medium.l}px;
     `}
 
-    ${props => props.theme.media.medium`
-      margin-top: ${props => props.theme.spaceAtBreakpoints.large.l}px;
+    ${props => props.theme.media.large`
+      margin-top: ${props.theme.spaceAtBreakpoints.large.l}px;
     `}
   }
 `;


### PR DESCRIPTION
## Who is this for?
People who want vertically spaced-out components to have the right space between them at the medium breakpoint

## What is it doing for them?
Fixing an override bug that meant the medium breakpoint immediately used the large breakpoints sizes.

__Before__
small: `16px`
medium: `32px`
large: `32px`

__After__
small: `16px`
medium: `24px`
large: `32px`

<img width="881" alt="Screenshot 2021-09-10 at 08 59 44" src="https://user-images.githubusercontent.com/1394592/132821567-acada7c2-3305-4736-9072-3af660ef1f39.png">

<img width="1088" alt="Screenshot 2021-09-10 at 09 00 38" src="https://user-images.githubusercontent.com/1394592/132821579-5b6e523f-42e1-4bc1-a8f9-905e30e0dbd4.png">

<img width="1267" alt="Screenshot 2021-09-10 at 09 01 19" src="https://user-images.githubusercontent.com/1394592/132821586-c5743e09-1e1d-411a-8f16-0fe63d80a46e.png">
