### PR TITLE
Remove /build/ folder from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,4 +6,3 @@
 
 /CODEOWNERS	@wellcomecollection/buildkite-admin
 /.buildkite/    @wellcomecollection/buildkite-admin
-/builds/      	@wellcomecollection/buildkite-admin


### PR DESCRIPTION
We don't need to protect this folder because it doesn't exist in this repository.