### PR TITLE
remove showHoldingsOnWork toggle

### DIFF
--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -80,7 +80,7 @@ export const unrequestableStatusIds = ['temporarily-unavailable'];
 export const unrequestableMethodIds = ['not-requestable', 'open-shelves'];
 
 const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
-  const { showHoldingsOnWork, enableRequesting } = useContext(TogglesContext);
+  const { enableRequesting } = useContext(TogglesContext);
   const isArchive = useContext(IsArchiveContext);
 
   const itemUrl = itemLink({ workId: work.id }, 'work');
@@ -267,7 +267,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
   const Holdings = () => {
     return (
       <>
-        {showHoldingsOnWork && holdings.length > 0 ? (
+        {holdings.length > 0 ? (
           <WorkDetailsSection headingText="Holdings">
             {holdings.map((holding, i) => {
               const locationLabel =

--- a/common/test/fixtures/globalContextData.js
+++ b/common/test/fixtures/globalContextData.js
@@ -1,6 +1,5 @@
 export default {
   toggles: {
-    showHoldingsOnWork: true,
     buildingReopening: true,
     showLogin: false,
     showItemRequestFlow: false,

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -8,12 +8,6 @@ type ABTest = {
 export default {
   toggles: [
     {
-      id: 'showHoldingsOnWork',
-      title: 'Show holdings on the work page',
-      description: 'Shows the holding information for a work',
-      defaultValue: true,
-    },
-    {
       id: 'buildingReopening',
       title: 'Wellcome Collection reopening UI changes',
       description:


### PR DESCRIPTION
## Who is this for?
Developers who don't want unnecessary code in the codebase


## What is it doing for them?
Removing the showHoldingsOnWork toggle, which has [been on by default for everyone since the beginning on June](https://github.com/wellcomecollection/wellcomecollection.org/pull/6572)