### PR TITLE
Serve Prismic from cdn to avoid 429s

### DIFF
--- a/common/koa-middleware/withMemoizedPrismic.js
+++ b/common/koa-middleware/withMemoizedPrismic.js
@@ -1,7 +1,7 @@
 const Raven = require('raven-js');
 const Prismic = require('prismic-javascript');
 const oneMinute = 1000 * 60;
-const apiUri = 'https://wellcomecollection.prismic.io/api/v2';
+const apiUri = 'https://wellcomecollection.cdn.prismic.io/api/v2';
 
 let memoizedPrismic;
 async function getMemoizedPrismic() {

--- a/common/services/prismic/api.js
+++ b/common/services/prismic/api.js
@@ -9,7 +9,7 @@ import type {
 } from './types';
 import Cookies from 'cookies';
 
-const apiUri = 'https://wellcomecollection.prismic.io/api/v2';
+const apiUri = 'https://wellcomecollection.cdn.prismic.io/api/v2';
 
 export function isPreview(req: ?Request): boolean {
   const cookies = req && new Cookies(req);

--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -250,7 +250,7 @@ const WecoApp: FunctionComponent<WecoAppProps> = ({
     // Prismic preview and validation warnings
     if (document.cookie.match('isPreview=true')) {
       window.prismic = {
-        endpoint: 'https://wellcomecollection.prismic.io/api/v2',
+        endpoint: 'https://wellcomecollection.cdn.prismic.io/api/v2',
       };
       const prismicScript = document.createElement('script');
       prismicScript.src = '//static.cdn.prismic.io/prismic.min.js';

--- a/content/webapp/app.js
+++ b/content/webapp/app.js
@@ -100,7 +100,7 @@ module.exports = app
 
       const token = ctx.request.query.token;
       const api = await Prismic.getApi(
-        'https://wellcomecollection.prismic.io/api/v2',
+        'https://wellcomecollection.cdn.prismic.io/api/v2',
         {
           req: ctx.request,
         }

--- a/rss/webapp/stories/index.js
+++ b/rss/webapp/stories/index.js
@@ -49,7 +49,7 @@ const storyGraphQuery = `{
 
 const stories = async (req, res) => {
   const api = await Prismic.getApi(
-    'https://wellcomecollection.prismic.io/api/v2'
+    'https://wellcomecollection.cdn.prismic.io/api/v2'
   );
   const stories = await api.query(
     [Prismic.Predicates.any('document.type', ['articles', 'webcomics'])],


### PR DESCRIPTION
## Who is this for?
People who want to see content from Prismic

## What is it doing for them?
Making api calls to a cdn

We have seen `http 429` errors for certain urls, and Primsic have updated their docs to advise using the version of their api at a cdn. https://community.prismic.io/t/what-are-the-api-limits/5789