### PR TITLE
Link from account page to works

### DIFF
--- a/common/model/requesting.ts
+++ b/common/model/requesting.ts
@@ -20,6 +20,7 @@ type RequestItem = {
     locations: PhysicalLocation[];
     type: 'Item';
   };
+  workId: string;
   workTitle?: string;
   pickupLocation: PickupLocation;
   status: RequestStatus;

--- a/identity/webapp/src/frontend/MyAccount/MyAccount.style.ts
+++ b/identity/webapp/src/frontend/MyAccount/MyAccount.style.ts
@@ -50,6 +50,14 @@ export const ModalContainer = styled.aside`
   }
 `;
 
+export const TruncateTitle = styled.a`
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: inline-block;
+  max-width: 60ch;
+`
+
 export const ModalTitle = styled.h2.attrs({ className: font('wb', 3) })``;
 
 const colours = {

--- a/identity/webapp/src/frontend/MyAccount/MyAccount.tsx
+++ b/identity/webapp/src/frontend/MyAccount/MyAccount.tsx
@@ -15,6 +15,7 @@ import {
   StyledDd,
   ProgressBar,
   ProgressIndicator,
+  TruncateTitle,
 } from './MyAccount.style';
 import { Loading } from './Loading';
 import { ChangeEmail } from './ChangeEmail';
@@ -81,16 +82,6 @@ async function fetchRequestedItems(userId): Promise<RequestsList | undefined> {
     console.log(e);
   }
 }
-
-// The table display is weird / should not be scrollable
-// This should be sorted out in CSS rather than doing this.
-const truncateTitle_REMOVE_THIS_FUNCTION_ASAP = (
-  str: string,
-  maxLength = 60
-) => {
-  const truncated = str.slice(0, maxLength);
-  return str.length > maxLength ? `${truncated}...` : str;
-};
 
 const Profile: FC = () => {
   const history = useHistory();
@@ -232,9 +223,7 @@ const Profile: FC = () => {
                       rows={[
                         ['Title', 'Status', 'Pickup location'],
                         ...requests.results.map(result => [
-                          truncateTitle_REMOVE_THIS_FUNCTION_ASAP(
-                            result.item.title || result.workTitle || ''
-                          ),
+                          <TruncateTitle href={`/works/${result.workId}`}>{result.item.title || result.workTitle || ''}</TruncateTitle>,
                           result.status.label,
                           result.pickupLocation.label,
                         ]),


### PR DESCRIPTION
Fixes #6979 

Links the title of each held work to the individual work page (`/works/{workId}`).

![image](https://user-images.githubusercontent.com/1394592/133127293-72e05cab-cb22-4792-83ff-f688358ea6bc.png)
