### PR TITLE
Change manifest scroll

### DIFF
--- a/common/views/components/IIIFViewer/IIIFViewer.tsx
+++ b/common/views/components/IIIFViewer/IIIFViewer.tsx
@@ -106,7 +106,6 @@ const Sidebar = styled.div<{
   isActiveMobile: boolean;
   isActiveDesktop: boolean;
 }>`
-
   display: ${props => (props.isActiveMobile ? 'inherit' : 'none')};
   align-content: start;
 
@@ -254,6 +253,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
   );
   const firstRotation = firstRotatedImage ? firstRotatedImage.rotation : 0;
   const activeIndexRef = useRef(activeIndex);
+  const initialManifestIndex = useRef(manifestIndex);
 
   useEffect(() => {
     const fetchImageJson = async () => {
@@ -403,9 +403,12 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
   }, [activeIndex]);
 
   useEffect(() => {
-    // FIXME: is this really necessary? Why doesn't setting canvas to 1 in the NextLink handle it?
-    mainViewerRef?.current?.scrollToItem(0);
-  }, [manifestIndex]);
+    if (initialManifestIndex.current === manifestIndex) return;
+    // If we change manifests, it's not enough to rely on the next/link
+    // to scroll us to the first canvas, because it's being handled by
+    // react window
+    mainViewerRef?.current?.scrollToItem(0, 'start');
+  }, [manifestIndex, activeIndex]);
 
   const parentManifestUrl = manifest && manifest.within;
 

--- a/common/views/components/IIIFViewer/IIIFViewer.tsx
+++ b/common/views/components/IIIFViewer/IIIFViewer.tsx
@@ -253,7 +253,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
   );
   const firstRotation = firstRotatedImage ? firstRotatedImage.rotation : 0;
   const activeIndexRef = useRef(activeIndex);
-  const initialManifestIndex = useRef(manifestIndex);
+  const previousManifestIndex = useRef(manifestIndex);
 
   useEffect(() => {
     const fetchImageJson = async () => {
@@ -403,12 +403,14 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
   }, [activeIndex]);
 
   useEffect(() => {
-    if (initialManifestIndex.current === manifestIndex) return;
+    if (previousManifestIndex.current === manifestIndex) return;
+
     // If we change manifests, it's not enough to rely on the next/link
     // to scroll us to the first canvas, because it's being handled by
     // react window
     mainViewerRef?.current?.scrollToItem(0, 'start');
-  }, [manifestIndex, activeIndex]);
+    previousManifestIndex.current = manifestIndex;
+  }, [manifestIndex]);
 
   const parentManifestUrl = manifest && manifest.within;
 


### PR DESCRIPTION
## Who is this for?
People who want to be scrolled to the first canvas right away

## What is it doing for them?
Removing an unnecessary effect that can cause incorrect scroll position on first render.

I wasn't able to replicate the [failing mobile test that this is aiming to fix](https://buildkite.com/wellcomecollection/experience-e2e/builds/174#4b5a9865-edd7-46b3-b9b9-88bb45eea8fb) locally, but anecdotally, this would make sense as a fix based on what's visible in the UI and why the test fails.