### PR TITLE
hide request button if user is not logged in

### DIFF
--- a/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
+++ b/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
@@ -107,9 +107,10 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
   const locationLabel = physicalLocation && getLocationLabel(physicalLocation);
   const locationShelfmark =
     physicalLocation && getLocationShelfmark(physicalLocation);
-  const hideButton =
+  const hideRequestButton =
     unrequestableStatusIds.some(i => i === accessStatusId) ||
-    unrequestableMethodIds.some(i => i === accessMethodId);
+    unrequestableMethodIds.some(i => i === accessMethodId) ||
+    !user;
   const [userHolds, setUserHolds] = useState<UserHolds | undefined>();
 
   useEffect(() => {
@@ -182,7 +183,7 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
           {!isOpenShelves && (
             <>
               <Box isCentered>
-                {hideButton ? (
+                {hideRequestButton ? (
                   // TODO: fairly sure displaying this `accessMethod` here isn't what we want
                   // (at least not all the time) but it is useful to see e.g. 'Not requestable'
                   isHeldByUser ? (


### PR DESCRIPTION
Fixes #6973

When a user is not logged we show the access method (which is what we do for an unrequestable item).
<img width="758" alt="Screenshot 2021-09-14 at 17 10 00" src="https://user-images.githubusercontent.com/6051896/133295590-e06463f6-8ba4-4f19-aecf-a29b82f24a88.png">

When the user is logged in and the item is requestable, then we display the request button.
<img width="697" alt="Screenshot 2021-09-14 at 17 09 14" src="https://user-images.githubusercontent.com/6051896/133295619-241ed094-0445-472d-9aab-b8add8fd9b0d.png">

