### PR TITLE
Outlined button variant

### DIFF
--- a/cardigan/stories/components/Buttons/Buttons.stories.tsx
+++ b/cardigan/stories/components/Buttons/Buttons.stories.tsx
@@ -24,6 +24,7 @@ buttonOutlined.args = {
   icon: eye,
   text: 'Click me',
   isOnDark: false,
+  isDangerous: false,
 };
 buttonOutlined.storyName = 'ButtonOutlined';
 

--- a/common/views/components/ButtonOutlined/ButtonOutlined.tsx
+++ b/common/views/components/ButtonOutlined/ButtonOutlined.tsx
@@ -24,11 +24,17 @@ function getColor(
   isDangerous: boolean | undefined
 ): ButtonColor {
   if (isOnDark) {
-    return 'white';
-  } else if (isDangerous) {
-    return 'red';
+    if (isDangerous) {
+      return 'red'; // TODO We don't use this with isOnDark anywhere yet, but it will fail accessibility contrast criteria. Issue captured here:
+    } else {
+      return 'white';
+    }
   } else {
-    return 'green';
+    if (isDangerous) {
+      return 'red';
+    } else {
+      return 'green';
+    }
   }
 }
 
@@ -56,6 +62,7 @@ export type ButtonOutlinedBaseProps = {
   type?: 'submit' | 'reset' | 'button';
   isTextHidden?: boolean;
   isOnDark?: boolean;
+  isDangerous?: boolean;
   trackingEvent?: GaEvent;
   ariaControls?: string;
   ariaExpanded?: boolean;
@@ -79,6 +86,7 @@ const ButtonOutlined = forwardRef<HTMLButtonElement, ButtonOutlinedProps>(
       isTextHidden,
       trackingEvent,
       isOnDark,
+      isDangerous,
       clickHandler,
       ariaControls,
       ariaExpanded,
@@ -95,6 +103,7 @@ const ButtonOutlined = forwardRef<HTMLButtonElement, ButtonOutlinedProps>(
       <OutlinedButton
         type={type}
         isOnDark={isOnDark}
+        isDangerous={isDangerous}
         aria-controls={ariaControls}
         aria-expanded={ariaExpanded}
         aria-live={ariaLive}

--- a/common/views/components/ButtonOutlined/ButtonOutlined.tsx
+++ b/common/views/components/ButtonOutlined/ButtonOutlined.tsx
@@ -25,7 +25,7 @@ function getColor(
 ): ButtonColor {
   if (isOnDark) {
     if (isDangerous) {
-      return 'red'; // TODO We don't use this with isOnDark anywhere yet, but it will fail accessibility contrast criteria. Issue captured here:
+      return 'red'; // TODO We don't use this with isOnDark anywhere yet, but it will fail accessibility contrast criteria. Issue #7059
     } else {
       return 'white';
     }

--- a/common/views/components/ButtonOutlined/ButtonOutlined.tsx
+++ b/common/views/components/ButtonOutlined/ButtonOutlined.tsx
@@ -14,7 +14,23 @@ import { IconSvg } from '@weco/common/icons';
 type OutlinedButtonProps = {
   href?: string;
   isOnDark?: boolean;
+  isDangerous?: boolean;
 };
+
+type ButtonColor = 'white' | 'green' | 'red';
+
+function getColor(
+  isOnDark: boolean | undefined,
+  isDangerous: boolean | undefined
+): ButtonColor {
+  if (isOnDark) {
+    return 'white';
+  } else if (isDangerous) {
+    return 'red';
+  } else {
+    return 'green';
+  }
+}
 
 export const OutlinedButton = styled(BaseButton).attrs<OutlinedButtonProps>(
   props => ({
@@ -24,9 +40,10 @@ export const OutlinedButton = styled(BaseButton).attrs<OutlinedButtonProps>(
   })
 )<OutlinedButtonProps>`
   border: 2px solid
-    ${props => props.theme.color(props.isOnDark ? 'white' : 'green')};
+    ${props => props.theme.color(getColor(props.isOnDark, props.isDangerous))};
   background: ${props => props.theme.color('transparent')};
-  color: ${props => props.theme.color(props.isOnDark ? 'white' : 'green')};
+  color: ${props =>
+    props.theme.color(getColor(props.isOnDark, props.isDangerous))};
 
   &:hover {
     text-decoration: underline;


### PR DESCRIPTION
References #6971

Adds an 'isDangerous' prop to the ButtonOutlined component so it can be used for the account page 'Request deletion' button.
![Screenshot 2021-09-20 at 15 43 19](https://user-images.githubusercontent.com/6051896/134026012-5cdcd1b8-d148-4e8f-b02b-6191cd363f7b.png)

This has highlighted some accessibility issues captured in #7059
