### PR TITLE
Add render tests for the catalogue app top-level pages

### DIFF
--- a/catalogue/webapp/components/SearchTitle/SearchTitle.tsx
+++ b/catalogue/webapp/components/SearchTitle/SearchTitle.tsx
@@ -2,9 +2,20 @@ import { FunctionComponent, ReactElement } from 'react';
 import { grid, classNames } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 
-const SearchTitle: FunctionComponent = (): ReactElement => {
+type Props = {
+  isVisuallyHidden: boolean;
+};
+
+const SearchTitle: FunctionComponent<Props> = ({
+  isVisuallyHidden,
+}): ReactElement => {
   return (
-    <div className="grid">
+    <div
+      className={classNames({
+        grid: true,
+        'visually-hidden': isVisuallyHidden,
+      })}
+    >
       <div className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>
         <Space
           v={{

--- a/catalogue/webapp/pages/images.tsx
+++ b/catalogue/webapp/pages/images.tsx
@@ -168,7 +168,7 @@ const Images: NextPage<Props> = ({
           className={classNames(['row'])}
         >
           <div className="container">
-            {!images && <SearchTitle />}
+            <SearchTitle isVisuallyHidden={Boolean(images)} />
 
             <div className="grid">
               <div className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>
@@ -262,45 +262,44 @@ const Images: NextPage<Props> = ({
   );
 };
 
-export const getServerSideProps: GetServerSideProps<
-  Props | AppErrorProps
-> = async context => {
-  const globalContextData = getGlobalContextData(context);
-  const params = fromQuery(context.query);
-  const aggregations = [
-    'locations.license',
-    'source.genres.label',
-    'source.contributors.agent.label',
-  ];
-  const apiProps = imagesRouteToApiUrl(params, { aggregations });
-  const hasQuery = !!(params.query && params.query !== '');
-  const images = hasQuery
-    ? await getImages({
-        params: apiProps,
-        toggles: globalContextData.toggles,
-      })
-    : undefined;
+export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
+  async context => {
+    const globalContextData = getGlobalContextData(context);
+    const params = fromQuery(context.query);
+    const aggregations = [
+      'locations.license',
+      'source.genres.label',
+      'source.contributors.agent.label',
+    ];
+    const apiProps = imagesRouteToApiUrl(params, { aggregations });
+    const hasQuery = !!(params.query && params.query !== '');
+    const images = hasQuery
+      ? await getImages({
+          params: apiProps,
+          toggles: globalContextData.toggles,
+        })
+      : undefined;
 
-  if (images && images.type === 'Error') {
-    return appError(context, images.httpStatus, 'Images API error');
-  }
+    if (images && images.type === 'Error') {
+      return appError(context, images.httpStatus, 'Images API error');
+    }
 
-  return {
-    props: removeUndefinedProps({
-      images,
-      imagesRouteProps: params,
-      apiProps,
-      globalContextData,
-      pageview: {
-        name: 'images',
-        properties: images
-          ? {
-              totalResults: images.totalResults,
-            }
-          : {},
-      },
-    }),
+    return {
+      props: removeUndefinedProps({
+        images,
+        imagesRouteProps: params,
+        apiProps,
+        globalContextData,
+        pageview: {
+          name: 'images',
+          properties: images
+            ? {
+                totalResults: images.totalResults,
+              }
+            : {},
+        },
+      }),
+    };
   };
-};
 
 export default Images;

--- a/catalogue/webapp/pages/works.tsx
+++ b/catalogue/webapp/pages/works.tsx
@@ -23,6 +23,7 @@ import WorksSearchResults from '../components/WorksSearchResults/WorksSearchResu
 import SearchTabs from '@weco/common/views/components/SearchTabs/SearchTabs';
 import SearchNoResults from '../components/SearchNoResults/SearchNoResults';
 import { removeUndefinedProps } from '@weco/common/utils/json';
+import SearchTitle from '../components/SearchTitle/SearchTitle';
 import { GetServerSideProps, NextPage } from 'next';
 import {
   appError,
@@ -133,6 +134,8 @@ const Works: NextPage<Props> = ({
           className={classNames(['row'])}
         >
           <div className="container">
+            <SearchTitle isVisuallyHidden={Boolean(works)} />
+
             <div className="grid">
               <div className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>
                 <Space v={{ size: 'l', properties: ['margin-top'] }}>
@@ -279,49 +282,48 @@ const Works: NextPage<Props> = ({
   );
 };
 
-export const getServerSideProps: GetServerSideProps<
-  Props | AppErrorProps
-> = async context => {
-  const globalContextData = getGlobalContextData(context);
-  const props = fromQuery(context.query);
+export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
+  async context => {
+    const globalContextData = getGlobalContextData(context);
+    const props = fromQuery(context.query);
 
-  const aggregations = [
-    'workType',
-    'availabilities',
-    'genres.label',
-    'languages',
-    'subjects.label',
-    'contributors.agent.label',
-  ];
+    const aggregations = [
+      'workType',
+      'availabilities',
+      'genres.label',
+      'languages',
+      'subjects.label',
+      'contributors.agent.label',
+    ];
 
-  const _queryType = cookies(context)._queryType;
+    const _queryType = cookies(context)._queryType;
 
-  const worksApiProps = worksRouteToApiUrl(props, {
-    _queryType,
-    aggregations,
-  });
+    const worksApiProps = worksRouteToApiUrl(props, {
+      _queryType,
+      aggregations,
+    });
 
-  const works = await getWorks({
-    params: worksApiProps,
-    toggles: globalContextData.toggles,
-  });
+    const works = await getWorks({
+      params: worksApiProps,
+      toggles: globalContextData.toggles,
+    });
 
-  if (works.type === 'Error') {
-    return appError(context, works.httpStatus, works.description);
-  }
+    if (works.type === 'Error') {
+      return appError(context, works.httpStatus, works.description);
+    }
 
-  return {
-    props: removeUndefinedProps({
-      works,
-      worksRouteProps: props,
-      apiProps: worksApiProps,
-      globalContextData,
-      pageview: {
-        name: 'works',
-        properties: works ? { totalResults: works.totalResults } : {},
-      },
-    }),
+    return {
+      props: removeUndefinedProps({
+        works,
+        worksRouteProps: props,
+        apiProps: worksApiProps,
+        globalContextData,
+        pageview: {
+          name: 'works',
+          properties: works ? { totalResults: works.totalResults } : {},
+        },
+      }),
+    };
   };
-};
 
 export default Works;

--- a/playwright/test/landing-pages.test.ts
+++ b/playwright/test/landing-pages.test.ts
@@ -5,6 +5,8 @@ import {
   storiesUrl,
   collectionsUrl,
   aboutUsUrl,
+  worksUrl,
+  imagesUrl,
 } from './helpers/urls';
 import { gotoWithoutCache } from './contexts';
 
@@ -63,5 +65,23 @@ describe('Top-level landing pages', () => {
     ]);
 
     expect(content).toBe('About us');
+  });
+
+  test('the works page renders with a status code of 200', async () => {
+    const [, content] = await Promise.all([
+      gotoWithoutCache(worksUrl),
+      page.textContent('h1'),
+    ]);
+
+    expect(content).toBe('Search the collections');
+  });
+
+  test('the images page renders with a status code of 200', async () => {
+    const [, content] = await Promise.all([
+      gotoWithoutCache(imagesUrl),
+      page.textContent('h1'),
+    ]);
+
+    expect(content).toBe('Search the collections');
   });
 });

--- a/playwright/test/landing-pages.test.ts
+++ b/playwright/test/landing-pages.test.ts
@@ -11,7 +11,7 @@ import {
 import { gotoWithoutCache } from './contexts';
 
 describe('Top-level landing pages', () => {
-  test('the homepage renders with a status code of 200', async () => {
+  test('the homepage renders with an accessible title', async () => {
     const [, content] = await Promise.all([
       gotoWithoutCache(homepageUrl),
       page.textContent('h1'),
@@ -22,7 +22,7 @@ describe('Top-level landing pages', () => {
     );
   });
 
-  test('the visit us page renders with a status code of 200', async () => {
+  test('the visit us page renders with an accessible title', async () => {
     const [, content] = await Promise.all([
       gotoWithoutCache(visitUsUrl),
       page.textContent('h1'),
@@ -31,7 +31,7 @@ describe('Top-level landing pages', () => {
     expect(content).toBe('Visit us');
   });
 
-  test(`the what's on page renders with a status code of 200`, async () => {
+  test(`the what's on page renders with an accessible title`, async () => {
     const [, content] = await Promise.all([
       gotoWithoutCache(whatsOnUrl),
       page.textContent('h1'),
@@ -40,7 +40,7 @@ describe('Top-level landing pages', () => {
     expect(content).toBe("What's on");
   });
 
-  test(`the stories page renders with a status code of 200`, async () => {
+  test(`the stories page renders with an accessible title`, async () => {
     const [, content] = await Promise.all([
       gotoWithoutCache(storiesUrl),
       page.textContent('h1'),
@@ -49,7 +49,7 @@ describe('Top-level landing pages', () => {
     expect(content).toBe('Stories');
   });
 
-  test('the collections page renders with a status code of 200', async () => {
+  test('the collections page renders with an accessible title', async () => {
     const [, content] = await Promise.all([
       gotoWithoutCache(collectionsUrl),
       page.textContent('h1'),
@@ -58,7 +58,7 @@ describe('Top-level landing pages', () => {
     expect(content).toBe('Collections');
   });
 
-  test('the about us page renders with a status code of 200', async () => {
+  test('the about us page renders with an accessible title', async () => {
     const [, content] = await Promise.all([
       gotoWithoutCache(aboutUsUrl),
       page.textContent('h1'),
@@ -67,7 +67,7 @@ describe('Top-level landing pages', () => {
     expect(content).toBe('About us');
   });
 
-  test('the works page renders with a status code of 200', async () => {
+  test('the works page renders with an accessible title', async () => {
     const [, content] = await Promise.all([
       gotoWithoutCache(worksUrl),
       page.textContent('h1'),
@@ -76,7 +76,7 @@ describe('Top-level landing pages', () => {
     expect(content).toBe('Search the collections');
   });
 
-  test('the images page renders with a status code of 200', async () => {
+  test('the images page renders with an accessible title', async () => {
     const [, content] = await Promise.all([
       gotoWithoutCache(imagesUrl),
       page.textContent('h1'),


### PR DESCRIPTION
## Who is this for?
People who want confidence in the catalogue app

## What is it doing for them?
Testing the `/works` and `/images` routes, checking that they render with an expected `h1`.

There currently isn't an `h1` on `/works` at all, and it's only rendered on `/images` if there aren't any images to display. This makes sure there's always one present, and hides it with css (but keeps it accessible to screenreaders) where appropriate.