### PR TITLE
Remove the collection, collectionPath and @context fields from the Work model

### DIFF
--- a/catalogue/webapp/__mocks__/catalogue-work.js
+++ b/catalogue/webapp/__mocks__/catalogue-work.js
@@ -302,7 +302,6 @@ const catalogueWork = {
   type: 'Work',
   parts: [],
   partOf: [],
-  '@context': 'https://api.wellcomecollection.org/catalogue/v2/context.json',
 };
 
 export default catalogueWork;

--- a/catalogue/webapp/__mocks__/collection-tree.js
+++ b/catalogue/webapp/__mocks__/collection-tree.js
@@ -291,7 +291,6 @@ const collectionTree = {
     },
   ],
   type: 'Work',
-  '@context': 'https://api.wellcomecollection.org/catalogue/v2/context.json',
 };
 
 export default collectionTree;

--- a/common/model/catalogue.ts
+++ b/common/model/catalogue.ts
@@ -20,8 +20,6 @@ export type Work = {
   edition?: string;
   notes: Note[];
   duration?: number;
-  collectionPath?: CollectionPath;
-  collection?: Collection;
   images?: ImageInclude[];
   parts: RelatedWork[];
   partOf: RelatedWork[];
@@ -245,20 +243,6 @@ type NoteType = {
 type ImageInclude = {
   id: string;
   type: 'Image';
-};
-
-type Collection = {
-  path: CollectionPath;
-  work?: Work;
-  children?: Collection[];
-  type: 'Collection';
-};
-
-type CollectionPath = {
-  path: string;
-  level?: string;
-  label?: string;
-  type: 'CollectionPath';
 };
 
 // Response objects

--- a/common/model/catalogue.ts
+++ b/common/model/catalogue.ts
@@ -29,7 +29,6 @@ export type Work = {
   totalDescendentParts?: number;
   availableOnline: boolean;
   availabilities: Availability[];
-  '@context'?: string;
   holdings: Holding[];
 };
 
@@ -318,7 +317,6 @@ export type ImageAggregations = {
 };
 
 export type CatalogueResultsList<Result = Work> = {
-  '@context': string;
   type: 'ResultList';
   totalResults: number;
   totalPages: number;

--- a/common/test/fixtures/catalogueApi/images-aggregations.ts
+++ b/common/test/fixtures/catalogueApi/images-aggregations.ts
@@ -1,7 +1,6 @@
 import { CatalogueResultsList, Image } from '../../../model/catalogue';
 
 const aggregations: CatalogueResultsList<Image> = {
-  '@context': 'https://api.wellcomecollection.org/catalogue/v2/context.json',
   type: 'ResultList',
   pageSize: 10,
   totalPages: 0,

--- a/common/test/fixtures/catalogueApi/work.ts
+++ b/common/test/fixtures/catalogueApi/work.ts
@@ -200,8 +200,7 @@ export const workFixture: Work = {
       label: 'Thumbnail Image',
       type: 'LocationType',
     },
-    url:
-      'https://iiif.wellcomecollection.org/image/L0053261.jpg/full/300,/0/default.jpg',
+    url: 'https://iiif.wellcomecollection.org/image/L0053261.jpg/full/300,/0/default.jpg',
     license: {
       id: 'cc-by-nc',
       label: 'Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)',
@@ -276,8 +275,7 @@ export const workFixture: Work = {
             label: 'IIIF Image API',
             type: 'LocationType',
           },
-          url:
-            'https://iiif.wellcomecollection.org/image/L0053261.jpg/info.json',
+          url: 'https://iiif.wellcomecollection.org/image/L0053261.jpg/info.json',
           credit: 'Wellcome Collection',
           license: {
             id: 'cc-by-nc',
@@ -368,7 +366,6 @@ export const workFixture: Work = {
   precededBy: [],
   succeededBy: [],
   type: 'Work',
-  '@context': 'https://api.wellcomecollection.org/catalogue/v2/context.json',
 };
 
 export const workWithPartOf: Work = {
@@ -665,5 +662,4 @@ export const workWithPartOf: Work = {
     },
   ],
   type: 'Work',
-  '@context': 'https://api.wellcomecollection.org/catalogue/v2/context.json',
 };

--- a/common/test/fixtures/catalogueApi/works-aggregations.ts
+++ b/common/test/fixtures/catalogueApi/works-aggregations.ts
@@ -1,7 +1,6 @@
 import { CatalogueResultsList, Work } from '../../../model/catalogue';
 
 const aggregations: CatalogueResultsList<Work> = {
-  '@context': 'https://api.wellcomecollection.org/catalogue/v2/context.json',
   type: 'ResultList',
   pageSize: 10,
   totalPages: 13771,


### PR DESCRIPTION
## Who is this for?

Developers who don't want to look at unnecessary code.

## What is it doing for them?

Removing some fields from the Work model that will never be populated in API responses. The `collection` and `collectionPath` fields look like they're from a now-abandoned branch of API design, and we binned all the `@context` URLs a few months back: https://github.com/wellcomecollection/platform/issues/5235