### PR TITLE
add identity aliases to prod cache

### DIFF
--- a/cache/cloudfront_prod.tf
+++ b/cache/cloudfront_prod.tf
@@ -51,6 +51,8 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
     "blog.wellcomecollection.org",
     "content.wellcomecollection.org",
     "content.www.wellcomecollection.org",
+    "identity.wellcomecollection.org",
+    "identity.www.wellcomecollection.org",
     "works.wellcomecollection.org",
     "works.www.wellcomecollection.org",
   ]

--- a/identity/terraform/locals.tf
+++ b/identity/terraform/locals.tf
@@ -64,7 +64,7 @@ resource "random_password" "koa_session_keys" {
   }
 }
 
-data "aws_ssm_parameter" "context_path"{
+data "aws_ssm_parameter" "context_path" {
   for_each = toset(local.service_env_names)
 
   name = "/identity/${each.key}/account_management_system/context_path"


### PR DESCRIPTION
Adds the identity aliases to the prod CloudFront distro to serve next assets.

I am starting to feel this isn't as scalable.