### PR TITLE
Stacking table component

### DIFF
--- a/common/views/components/StackingTable/StackingTable.jsx
+++ b/common/views/components/StackingTable/StackingTable.jsx
@@ -22,7 +22,6 @@ const StyledTable = styled.table.attrs({
       display: block;
     }
     thead {
-      // TODO check styling across browsers
       // hidden visually, but still available to screen readers
       overflow: hidden;
       position: relative;

--- a/common/views/components/StackingTable/StackingTable.jsx
+++ b/common/views/components/StackingTable/StackingTable.jsx
@@ -1,0 +1,99 @@
+import styled from 'styled-components';
+import Space from '../styled/Space';
+import { font, classNames } from '../../../utils/classnames';
+
+const StyledTable = styled.table.attrs({
+  className: classNames({
+    [font('hnr', 5)]: true,
+  }),
+})`
+   {
+    width: 100%;
+    border-collapse: collapse;
+    text-align: left;
+  }
+
+  @media (max-width: ${props => props.theme.sizes.large}px) {
+    table,
+    thead,
+    tbody,
+    th,
+    td,
+    tr {
+      display: block;
+    }
+
+    thead {
+      // TODO check styling across browsers
+      // hidden visually, but still available to screen readers
+      overflow: hidden;
+      position: relative;
+    }
+    thead tr {
+      position: absolute;
+    }
+  }
+`;
+
+const StyledTh = styled(Space).attrs({
+  as: 'th',
+  v: { size: 's', properties: ['padding-top', 'padding-bottom'] },
+  h: { size: 'm', properties: ['padding-left', 'padding-right'] },
+  className: classNames({
+    [font('hnb', 5)]: true,
+  }),
+})`
+  background: ${props => props.theme.color('pumice')};
+  white-space: nowrap;
+`;
+
+const StyledTd = styled(Space).attrs({
+  as: 'td',
+  v: { size: 's', properties: ['padding-top', 'padding-bottom'] },
+  h: { size: 'm', properties: ['padding-left', 'padding-right'] },
+})`
+  @media (max-width: ${props => props.theme.sizes.large}px) {
+    :before {
+      display: block;
+      white-space: nowrap;
+      content: ${props => `'${props.content}'`};
+    }
+  }
+`;
+
+type Props = {
+  rows: string[],
+  caption: string,
+};
+
+const StackingTable: FunctionComponent<Props> = ({
+  rows,
+  caption,
+}: Props): ReactElement<Props> => {
+  const headerRow = rows[0];
+  const bodyRows = rows.slice(1);
+  return (
+    <StyledTable>
+      <thead>
+        <tr>
+          {headerRow.map((data, index) => (
+            <StyledTh key={index}>{data}</StyledTh>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {bodyRows.map((row, index) => (
+          <tr key={index}>
+            {row.map((data, index) => (
+              <StyledTd key={index} content={`${headerRow[index]}`}>
+                {data}
+              </StyledTd>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </StyledTable>
+  );
+};
+
+export default StackingTable;

--- a/common/views/components/StackingTable/StackingTable.jsx
+++ b/common/views/components/StackingTable/StackingTable.jsx
@@ -10,7 +10,6 @@ const StyledTable = styled.table.attrs({
    {
     width: 100%;
     border-collapse: collapse;
-    text-align: left;
   }
 
   @media (max-width: ${props => props.theme.sizes.large}px) {
@@ -31,12 +30,16 @@ const StyledTable = styled.table.attrs({
     thead tr {
       position: absolute;
     }
-    tr {
-      border-bottom: 1px solid ${props => props.theme.color('pumice')};
-    }
-    tr:last-of-type {
-      border: none;
-    }
+  }
+`;
+
+const StyledTr = styled(Space).attrs({
+  as: 'tr',
+})`
+  border-bottom: 1px solid ${props => props.theme.color('pumice')};
+
+  &:last-of-type {
+    border: none;
   }
 `;
 
@@ -50,14 +53,30 @@ const StyledTh = styled(Space).attrs({
 })`
   background: ${props => props.theme.color('pumice')};
   white-space: nowrap;
+  text-align: left;
+  vertical-align: top;
+  @media (max-width: ${props => props.theme.sizes.large}px) {
+    padding-left: 0;
+  }
 `;
 
 const StyledTd = styled(Space).attrs({
   as: 'td',
-  v: { size: 's', properties: ['padding-top', 'padding-bottom'] },
+  v: { size: 'm', properties: ['padding-top', 'padding-bottom'] },
   h: { size: 'm', properties: ['padding-left', 'padding-right'] },
 })`
+  text-align: left;
+  vertical-align: top;
   @media (max-width: ${props => props.theme.sizes.large}px) {
+    padding-left: 0;
+    padding-top: 0;
+    padding-bottom: ${props => `${props.theme.spacingUnit}px`};
+    &:first-of-type {
+      padding-top: ${props => `${props.theme.spacingUnit * 2}px`};
+    }
+    &:last-of-type {
+      padding-bottom: ${props => `${props.theme.spacingUnit * 3}px`};
+    }
     :before {
       display: block;
       white-space: nowrap;
@@ -68,7 +87,7 @@ const StyledTd = styled(Space).attrs({
 `;
 
 type Props = {
-  rows: string[],
+  rows: (string | ReactElement)[][],
   caption: string,
 };
 
@@ -89,13 +108,13 @@ const StackingTable: FunctionComponent<Props> = ({
       </thead>
       <tbody>
         {bodyRows.map((row, index) => (
-          <tr key={index}>
+          <StyledTr key={index}>
             {row.map((data, index) => (
               <StyledTd key={index} content={`${headerRow[index]}`}>
                 {data}
               </StyledTd>
             ))}
-          </tr>
+          </StyledTr>
         ))}
       </tbody>
     </StyledTable>

--- a/common/views/components/StackingTable/StackingTable.jsx
+++ b/common/views/components/StackingTable/StackingTable.jsx
@@ -22,7 +22,6 @@ const StyledTable = styled.table.attrs({
     tr {
       display: block;
     }
-
     thead {
       // TODO check styling across browsers
       // hidden visually, but still available to screen readers
@@ -31,6 +30,12 @@ const StyledTable = styled.table.attrs({
     }
     thead tr {
       position: absolute;
+    }
+    tr {
+      border-bottom: 1px solid ${props => props.theme.color('pumice')};
+    }
+    tr:last-of-type {
+      border: none;
     }
   }
 `;
@@ -57,6 +62,7 @@ const StyledTd = styled(Space).attrs({
       display: block;
       white-space: nowrap;
       content: ${props => `'${props.content}'`};
+      font-weight: bold;
     }
   }
 `;

--- a/identity/webapp/pages/account.tsx
+++ b/identity/webapp/pages/account.tsx
@@ -21,7 +21,8 @@ import {
   StyledDd,
   ProgressBar,
   ProgressIndicator,
-  TruncateTitle,
+  ItemTitle,
+  ItemStatus,
 } from '../src/frontend/MyAccount/MyAccount.style';
 import { Loading } from '../src/frontend/MyAccount/Loading';
 import { ChangeEmail } from '../src/frontend/MyAccount/ChangeEmail';
@@ -139,8 +140,6 @@ const AccountPage: NextPage = () => {
         </div>
       </Header>
       <Layout10>
-        import StackingTable from
-        '@weco/common/views/components/StackingTable/StackingTable';
         {isLoading && <Loading />}
         {!isLoading && (
           <>
@@ -227,26 +226,10 @@ const AccountPage: NextPage = () => {
                       rows={[
                         ['Title', 'Status', 'Pickup location'],
                         ...requests.results.map(result => [
-                          <TruncateTitle href={`/works/${result.workId}`}>
+                          <ItemTitle href={`/works/${result.workId}`}>
                             {result.item.title || result.workTitle || ''}
-                          </TruncateTitle>,
-                          result.status.label,
-                          result.pickupLocation.label,
-                        ]),
-                        ...requests.results.map(result => [
-                          // TODO remove this
-                          <TruncateTitle href={`/works/${result.workId}`}>
-                            {result.item.title || result.workTitle || ''}
-                          </TruncateTitle>,
-                          result.status.label,
-                          result.pickupLocation.label,
-                        ]),
-                        ...requests.results.map(result => [
-                          // TODO remove this
-                          <TruncateTitle href={`/works/${result.workId}`}>
-                            {result.item.title || result.workTitle || ''}
-                          </TruncateTitle>,
-                          result.status.label,
+                          </ItemTitle>,
+                          <ItemStatus>{result.status.label}</ItemStatus>,
                           result.pickupLocation.label,
                         ]),
                       ]}

--- a/identity/webapp/pages/account.tsx
+++ b/identity/webapp/pages/account.tsx
@@ -33,11 +33,11 @@ import WobblyEdge from '@weco/common/views/components/WobblyEdge/WobblyEdge';
 import Layout12 from '@weco/common/views/components/Layout12/Layout12';
 import Layout10 from '@weco/common/views/components/Layout10/Layout10';
 import Space from '@weco/common/views/components/styled/Space';
-import Table from '@weco/common/views/components/Table/Table';
 import { font } from '@weco/common/utils/classnames';
 import { RequestsList } from '@weco/common/model/requesting';
 import { allowedRequests } from '@weco/common/values/requests';
 import { info2 } from '@weco/common/icons';
+import StackingTable from '@weco/common/views/components/StackingTable/StackingTable';
 
 type DetailProps = {
   label: string;
@@ -139,6 +139,8 @@ const AccountPage: NextPage = () => {
         </div>
       </Header>
       <Layout10>
+        import StackingTable from
+        '@weco/common/views/components/StackingTable/StackingTable';
         {isLoading && <Loading />}
         {!isLoading && (
           <>
@@ -221,13 +223,26 @@ const AccountPage: NextPage = () => {
                         }
                       />
                     </ProgressBar>
-                    <Table
-                      hasRowHeaders={false}
-                      plain={true}
-                      withBorder={false}
+                    <StackingTable
                       rows={[
                         ['Title', 'Status', 'Pickup location'],
                         ...requests.results.map(result => [
+                          <TruncateTitle href={`/works/${result.workId}`}>
+                            {result.item.title || result.workTitle || ''}
+                          </TruncateTitle>,
+                          result.status.label,
+                          result.pickupLocation.label,
+                        ]),
+                        ...requests.results.map(result => [
+                          // TODO remove this
+                          <TruncateTitle href={`/works/${result.workId}`}>
+                            {result.item.title || result.workTitle || ''}
+                          </TruncateTitle>,
+                          result.status.label,
+                          result.pickupLocation.label,
+                        ]),
+                        ...requests.results.map(result => [
+                          // TODO remove this
                           <TruncateTitle href={`/works/${result.workId}`}>
                             {result.item.title || result.workTitle || ''}
                           </TruncateTitle>,

--- a/identity/webapp/pages/account.tsx
+++ b/identity/webapp/pages/account.tsx
@@ -23,6 +23,7 @@ import {
   ProgressIndicator,
   ItemTitle,
   ItemStatus,
+  ItemPickup,
 } from '../src/frontend/MyAccount/MyAccount.style';
 import { Loading } from '../src/frontend/MyAccount/Loading';
 import { ChangeEmail } from '../src/frontend/MyAccount/ChangeEmail';
@@ -226,11 +227,25 @@ const AccountPage: NextPage = () => {
                       rows={[
                         ['Title', 'Status', 'Pickup location'],
                         ...requests.results.map(result => [
-                          <ItemTitle href={`/works/${result.workId}`}>
-                            {result.item.title || result.workTitle || ''}
-                          </ItemTitle>,
+                          <>
+                            <ItemTitle as="a" href={`/works/${result.workId}`}>
+                              {result.workTitle || ''}
+                            </ItemTitle>
+                            {result.item.title && (
+                              <Space
+                                v={{
+                                  size: 's',
+                                  properties: ['margin-top'],
+                                }}
+                              >
+                                <ItemTitle>{result.item.title}</ItemTitle>
+                              </Space>
+                            )}
+                          </>,
                           <ItemStatus>{result.status.label}</ItemStatus>,
-                          result.pickupLocation.label,
+                          <ItemPickup>
+                            {result.pickupLocation.label}
+                          </ItemPickup>,
                         ]),
                       ]}
                     />

--- a/identity/webapp/pages/account.tsx
+++ b/identity/webapp/pages/account.tsx
@@ -247,13 +247,15 @@ const AccountPage: NextPage = () => {
                       ]}
                     />
                     <Space
-                      className={`${font('hnb', 5)}`}
+                      className={`${font('hnr', 5)}`}
                       v={{
                         size: 'l',
                         properties: ['margin-top', 'margin-bottom'],
                       }}
                     >
-                      If you wish to cancel a hold, please{' '}
+                      Requests made will be available to pick up from the
+                      library for two weeks. If you wish to cancel a hold,
+                      please{' '}
                       <a href="mailto:library@wellcomecollection.org">
                         contact the library team.
                       </a>

--- a/identity/webapp/src/frontend/MyAccount/MyAccount.style.ts
+++ b/identity/webapp/src/frontend/MyAccount/MyAccount.style.ts
@@ -50,7 +50,7 @@ export const ModalContainer = styled.aside`
   }
 `;
 
-export const ItemTitle = styled.a`
+export const ItemTitle = styled.span`
   display: inline-block;
   min-width: 300px;
   max-width: 600px;
@@ -61,6 +61,10 @@ export const ItemTitle = styled.a`
 `
 
 export const ItemStatus = styled.span`
+  white-space: nowrap;
+`
+
+export const ItemPickup = styled.span`
   white-space: nowrap;
 `
 

--- a/identity/webapp/src/frontend/MyAccount/MyAccount.style.ts
+++ b/identity/webapp/src/frontend/MyAccount/MyAccount.style.ts
@@ -50,12 +50,18 @@ export const ModalContainer = styled.aside`
   }
 `;
 
-export const TruncateTitle = styled.a`
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+export const ItemTitle = styled.a`
   display: inline-block;
-  max-width: 60ch;
+  min-width: 300px;
+  max-width: 600px;
+
+  @media (max-width: ${props => props.theme.sizes.large}px) {
+    min-width: 100%;
+  }
+`
+
+export const ItemStatus = styled.span`
+  white-space: nowrap;
 `
 
 export const ModalTitle = styled.h2.attrs({ className: font('wb', 3) })``;


### PR DESCRIPTION
References #6971

Adds a new responsive table component (styled as[ designs](https://app.zeplin.io/project/5aab926b4b6efde01259e959/screen/612de6c97e13d916c5085075)) which stacks cell rows on small screens. 

Uses this component on the account page, so we can fix the following issues in the above ticket and have it look good at all screen sizes.

- Item requests table should handle long titles appropriately (max width on column + text wrapping)
- show item title below work title

Before (small screens):
![small-b4](https://user-images.githubusercontent.com/6051896/134533026-ff933abd-cc08-49e9-a721-9b3260b3cd60.png)

After (small screens):
![small-after](https://user-images.githubusercontent.com/6051896/134533090-a20ff5fa-3c8a-4f42-a8a4-8863c04a3def.png)

Before (large screens):
![desk-b4](https://user-images.githubusercontent.com/6051896/134533172-3ec1ae53-be4d-46d9-b38f-9b6a753ad9ff.png)

After (large screens):
![Screenshot 2021-09-23 at 15 18 41](https://user-images.githubusercontent.com/6051896/134533214-a7c37c4f-8322-4024-8845-684d8e871647.png)



