### PR TITLE
Make cream stretch the whole page

### DIFF
--- a/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
@@ -78,7 +78,7 @@ const ZoomedImage = dynamic(() => import('./ZoomedImage'), {
 
 const Grid = styled.div`
   display: grid;
-  height: calc(100vh - 85px); // FIXME: use variable for header height
+  height: calc(100vh - ${props => props.theme.headerHeight}px);
   overflow: hidden;
   grid-template-columns: [left-edge] minmax(200px, 3fr) [desktop-sidebar-end main-start desktop-topbar-start] 9fr [right-edge];
   grid-template-rows: [top-edge] min-content [desktop-main-start desktop-topbar-end] 1fr [mobile-bottombar-start mobile-main-end] min-content [bottom-edge];

--- a/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
@@ -78,7 +78,7 @@ const ZoomedImage = dynamic(() => import('./ZoomedImage'), {
 
 const Grid = styled.div`
   display: grid;
-  height: calc(100vh - ${props => props.theme.headerHeight}px);
+  height: calc(100vh - ${props => props.theme.navHeight}px);
   overflow: hidden;
   grid-template-columns: [left-edge] minmax(200px, 3fr) [desktop-sidebar-end main-start desktop-topbar-start] 9fr [right-edge];
   grid-template-rows: [top-edge] min-content [desktop-main-start desktop-topbar-end] 1fr [mobile-bottombar-start mobile-main-end] min-content [bottom-edge];

--- a/catalogue/webapp/components/IIIFViewer/NoScriptViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/NoScriptViewer.tsx
@@ -22,7 +22,7 @@ import { arrow } from '@weco/common/icons';
 const NoScriptViewerEl = styled.div`
   display: flex;
   flex-direction: row-reverse;
-  height: calc(100vh - ${props => props.theme.headerHeight}px);
+  height: calc(100vh - ${props => props.theme.navHeight}px);
 `;
 
 const NoScriptViewerMain = styled.div`

--- a/catalogue/webapp/components/IIIFViewer/NoScriptViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/NoScriptViewer.tsx
@@ -22,7 +22,7 @@ import { arrow } from '@weco/common/icons';
 const NoScriptViewerEl = styled.div`
   display: flex;
   flex-direction: row-reverse;
-  height: calc(100vh - 85px);
+  height: calc(100vh - ${props => props.theme.headerHeight}px);
 `;
 
 const NoScriptViewerMain = styled.div`

--- a/common/views/components/Header/Header.tsx
+++ b/common/views/components/Header/Header.tsx
@@ -6,7 +6,6 @@ import { respondBetween, respondTo } from '@weco/common/views/themes/mixins';
 
 type WrapperProps = {
   isBurgerOpen: boolean;
-  navHeight: number;
 };
 const Wrapper = styled.div.attrs({
   className: classNames({
@@ -29,7 +28,7 @@ const Wrapper = styled.div.attrs({
     `
     )}
   `}
-  height: ${props => props.navHeight}px;
+  height: ${props => props.theme.headerHeight}px;
 `;
 
 const Burger = styled.div`
@@ -139,7 +138,6 @@ const HeaderNav = styled.nav<{ isActive: boolean }>`
     )}
   `}
 
-
   ${props => `
     ${respondTo(
       'medium',
@@ -160,7 +158,6 @@ const HeaderNav = styled.nav<{ isActive: boolean }>`
     padding-right: 0;
   `
   )}
-
 `;
 
 const HeaderList = styled.ul`
@@ -270,8 +267,6 @@ const HeaderLink = styled.a<{ isActive: boolean }>`
   `}
 `;
 
-export const navHeight = 85;
-
 type Props = {
   siteSection: string | null;
 };
@@ -313,7 +308,7 @@ const Header: FunctionComponent<Props> = ({ siteSection }) => {
   const [isActive, setIsActive] = useState(false);
 
   return (
-    <Wrapper navHeight={navHeight} isBurgerOpen={isActive}>
+    <Wrapper isBurgerOpen={isActive}>
       <div
         className="relative grid__cell"
         style={{ paddingTop: '15px', paddingBottom: '15px' }}

--- a/common/views/components/Header/Header.tsx
+++ b/common/views/components/Header/Header.tsx
@@ -28,7 +28,7 @@ const Wrapper = styled.div.attrs({
     `
     )}
   `}
-  height: ${props => props.theme.headerHeight}px;
+  height: ${props => props.theme.navHeight}px;
 `;
 
 const Burger = styled.div`

--- a/common/views/components/Header/HeaderPrototype.tsx
+++ b/common/views/components/Header/HeaderPrototype.tsx
@@ -47,7 +47,7 @@ const Wrapper = styled.div.attrs({
     `
     )}
   `}
-  height: ${props => props.theme.headerHeight}px;
+  height: ${props => props.theme.navHeight}px;
 `;
 
 const Burger = styled.div`

--- a/common/views/components/Header/HeaderPrototype.tsx
+++ b/common/views/components/Header/HeaderPrototype.tsx
@@ -22,7 +22,6 @@ const NavLoginWrapper = styled.div`
 
 type WrapperProps = {
   isBurgerOpen: boolean;
-  navHeight: number;
 };
 
 const Wrapper = styled.div.attrs({
@@ -48,7 +47,7 @@ const Wrapper = styled.div.attrs({
     `
     )}
   `}
-  height: ${props => props.navHeight}px;
+  height: ${props => props.theme.headerHeight}px;
 `;
 
 const Burger = styled.div`
@@ -279,8 +278,6 @@ const HeaderLink = styled.a<{ isActive: boolean }>`
   `}
 `;
 
-export const navHeight = 85;
-
 type Props = {
   siteSection: string | null;
 };
@@ -322,7 +319,7 @@ const Header: FC<Props> = ({ siteSection }) => {
   const [isActive, setIsActive] = useState(false);
 
   return (
-    <Wrapper navHeight={navHeight} isBurgerOpen={isActive}>
+    <Wrapper isBurgerOpen={isActive}>
       <div className="relative grid__cell">
         <div className="flex flex--v-center container">
           <Burger>

--- a/common/views/themes/config.ts
+++ b/common/views/themes/config.ts
@@ -189,6 +189,7 @@ export const themeValues = {
       xl: spacingUnits['10'],
     },
   },
+  headerHeight: 85,
   fontVerticalOffset: '0.15em',
   grid,
   colors,

--- a/common/views/themes/config.ts
+++ b/common/views/themes/config.ts
@@ -189,7 +189,7 @@ export const themeValues = {
       xl: spacingUnits['10'],
     },
   },
-  headerHeight: 85,
+  navHeight: 85,
   fontVerticalOffset: '0.15em',
   grid,
   colors,

--- a/identity/webapp/src/frontend/components/PageWrapper.tsx
+++ b/identity/webapp/src/frontend/components/PageWrapper.tsx
@@ -9,6 +9,7 @@ import Favicons from '@weco/common/views/components/Favicons/Favicons';
 const Main = styled.div`
   @media (min-width: ${props => props.theme.sizes.medium}px) {
     background: ${props => props.theme.color('cream')};
+    min-height: calc(100vh - ${props => props.theme.headerHeight}px)
   }
 `;
 export const PageWrapper: FC = ({

--- a/identity/webapp/src/frontend/components/PageWrapper.tsx
+++ b/identity/webapp/src/frontend/components/PageWrapper.tsx
@@ -9,7 +9,7 @@ import Favicons from '@weco/common/views/components/Favicons/Favicons';
 const Main = styled.div`
   @media (min-width: ${props => props.theme.sizes.medium}px) {
     background: ${props => props.theme.color('cream')};
-    min-height: calc(100vh - ${props => props.theme.headerHeight}px)
+    min-height: calc(100vh - ${props => props.theme.navHeight}px)
   }
 `;
 export const PageWrapper: FC = ({


### PR DESCRIPTION
## Who is this for?
People who want the page background to fill the viewport

## What is it doing for them?
Making sure the cream `main` element is at least as high as the body of the page.

This isn't the neatest way of achieving it, but it's pretty straightforward and should be easy to update as and when.

![Screenshot 2021-09-24 at 17 07 50](https://user-images.githubusercontent.com/1394592/134707001-9dc4e5b2-02c3-4cf0-8198-c651e65d2256.png)


