### PR TITLE
Add isDangerous prop to solid button

### DIFF
--- a/common/views/components/ButtonSolid/ButtonSolid.tsx
+++ b/common/views/components/ButtonSolid/ButtonSolid.tsx
@@ -107,6 +107,7 @@ export type ButtonSolidBaseProps = {
   isTextHidden?: boolean;
   trackingEvent?: GaEvent;
   isBig?: boolean;
+  isDangerous?: boolean;
   ariaControls?: string;
   ariaExpanded?: boolean;
   ariaLive?: 'off' | 'polite' | 'assertive';
@@ -121,6 +122,7 @@ type SolidButtonProps = {
   href?: string;
   isBig?: boolean;
   ariaLabel?: string;
+  isDangerous?: boolean;
 };
 
 export const SolidButton = styled(BaseButton).attrs<SolidButtonProps>(
@@ -131,9 +133,11 @@ export const SolidButton = styled(BaseButton).attrs<SolidButtonProps>(
     }),
   })
 )<SolidButtonProps>`
-  background: ${props => props.theme.color('green')};
+  background: ${props =>
+    props.theme.color(props.isDangerous ? 'red' : 'green')};
   color: ${props => props.theme.color('white')};
-  border: 2px solid ${props => props.theme.color('green')};
+  border: 2px solid
+    ${props => props.theme.color(props.isDangerous ? 'red' : 'green')};
 
   ${props =>
     props.isBig &&
@@ -142,8 +146,10 @@ export const SolidButton = styled(BaseButton).attrs<SolidButtonProps>(
   `}
 
   &:not([disabled]):hover {
-    background: ${props => props.theme.color('green', 'dark')};
-    border-color: ${props => props.theme.color('green', 'dark')};
+    background: ${props =>
+      props.theme.color(props.isDangerous ? 'red' : 'green', 'dark')};
+    border-color: ${props =>
+      props.theme.color(props.isDangerous ? 'red' : 'green', 'dark')};
   }
 `;
 
@@ -162,6 +168,7 @@ const ButtonSolid = forwardRef(
       ariaLive,
       disabled,
       isBig,
+      isDangerous,
     }: ButtonSolidProps,
     ref: ForwardedRef<HTMLButtonElement>
   ) => {
@@ -178,6 +185,7 @@ const ButtonSolid = forwardRef(
         onClick={handleClick}
         disabled={disabled}
         isBig={isBig}
+        isDangerous={isDangerous}
         ref={ref}
       >
         <BaseButtonInner>

--- a/common/views/themes/config.ts
+++ b/common/views/themes/config.ts
@@ -90,7 +90,7 @@ export const colors = {
   teal: { base: '#006272', dark: '', light: '' },
   cyan: { base: '#298187', dark: '', light: '' },
   turquoise: { base: '#5cb8bf', dark: '', light: '#d3e8e6' },
-  red: { base: '#e01b2f', dark: '', light: '' },
+  red: { base: '#e01b2f', dark: '#c1192a', light: '' },
   orange: { base: '#e87500', dark: '', light: '' },
   yellow: { base: '#ffce3c', dark: '', light: '#fff5d8' },
   brown: { base: '#815e48', dark: '', light: '' },

--- a/identity/webapp/src/frontend/MyAccount/DeleteAccount.tsx
+++ b/identity/webapp/src/frontend/MyAccount/DeleteAccount.tsx
@@ -3,6 +3,7 @@ import { useForm } from 'react-hook-form';
 import { ErrorMessage } from '@hookform/error-message';
 import { FieldMargin, Button, Cancel } from '../components/Form.style';
 import { TextInputErrorMessage } from '@weco/common/views/components/TextInput/TextInput';
+import ButtonSolid, { ButtonTypes } from '@weco/common/views/components/ButtonSolid/ButtonSolid';
 import { ModalContainer, ModalTitle, StatusAlert } from './MyAccount.style';
 import { PasswordInput } from '../components/PasswordInput';
 import { ChangeDetailsModalContentProps } from './ChangeDetailsModal';
@@ -98,9 +99,7 @@ export const DeleteAccount: React.FC<ChangeDetailsModalContentProps> = ({
             )}
           />
         </FieldMargin>
-        <Button isDangerous type="submit">
-          Yes, delete my account
-        </Button>
+        <ButtonSolid isDangerous type={ButtonTypes.submit} text="Yes, delete my account" />
         <Cancel onClick={onCancel}>No, take me back to my account</Cancel>
       </form>
     </ModalContainer>


### PR DESCRIPTION
## Who is this for?
People who want consistent button styles

## What is it doing for them?
Using our pre-existing solid button with a red variant as the 'delete my account' button.

__Before__
![Screenshot 2021-09-27 at 11 06 44](https://user-images.githubusercontent.com/1394592/134890122-5c049e9c-7ab9-4854-91e1-31ce3f4b7c2c.png)
__After__
![Screenshot 2021-09-27 at 11 06 14](https://user-images.githubusercontent.com/1394592/134890170-3e759c32-97f8-4852-8225-33fbc74cca15.png)


