### PR TITLE
Rearrange children siblings

### DIFF
--- a/content/webapp/pages/page.tsx
+++ b/content/webapp/pages/page.tsx
@@ -56,48 +56,45 @@ type OrderInParent = {
   type: 'pages' | 'exhibitions';
 };
 
-export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
-  async context => {
-    const globalContextData = getGlobalContextData(context);
-    const { id, memoizedPrismic } = context.query;
-    const page: PageType | undefined = await getPage(
-      context.req,
-      id,
-      memoizedPrismic
-    );
-    if (page) {
-      const siblings = await getPageSiblings(
-        page,
-        context.req,
-        memoizedPrismic
-      );
-      const ordersInParents: OrderInParent[] =
-        page.parentPages.map(p => {
-          return {
-            id: p.id,
-            title: p.title,
-            order: p.order,
-            type: p.type,
-          };
-        }) || [];
+export const getServerSideProps: GetServerSideProps<
+  Props | AppErrorProps
+> = async context => {
+  const globalContextData = getGlobalContextData(context);
+  const { id, memoizedPrismic } = context.query;
+  const page: PageType | undefined = await getPage(
+    context.req,
+    id,
+    memoizedPrismic
+  );
+  if (page) {
+    const siblings = await getPageSiblings(page, context.req, memoizedPrismic);
+    const ordersInParents: OrderInParent[] =
+      page.parentPages.map(p => {
+        return {
+          id: p.id,
+          title: p.title,
+          order: p.order,
+          type: p.type,
+        };
+      }) || [];
 
-      const children = await getChildren(page, context.req, memoizedPrismic);
-      return {
-        props: removeUndefinedProps({
-          page,
-          siblings,
-          children,
-          ordersInParents,
-          globalContextData,
-          gaDimensions: {
-            partOf: page.seasons.map<string>(season => season.id),
-          },
-        }),
-      };
-    } else {
-      return { notFound: true };
-    }
-  };
+    const children = await getChildren(page, context.req, memoizedPrismic);
+    return {
+      props: removeUndefinedProps({
+        page,
+        siblings,
+        children,
+        ordersInParents,
+        globalContextData,
+        gaDimensions: {
+          partOf: page.seasons.map<string>(season => season.id),
+        },
+      }),
+    };
+  } else {
+    return { notFound: true };
+  }
+};
 
 const Page: FC<Props> = ({
   page,
@@ -276,7 +273,7 @@ const Page: FC<Props> = ({
             sectionLevelPage={sectionLevelPage}
           />
         }
-        RelatedContent={[...Siblings, ...Children]}
+        RelatedContent={[...Children, ...Siblings]}
         contributorProps={{ contributors: page.contributors }}
         seasons={page.seasons}
       />

--- a/content/webapp/pages/page.tsx
+++ b/content/webapp/pages/page.tsx
@@ -76,7 +76,7 @@ export const getServerSideProps: GetServerSideProps<
           order: p.order,
           type: p.type,
         };
-      }) || [];
+      }) || []; 
 
     const children = await getChildren(page, context.req, memoizedPrismic);
     return {
@@ -273,6 +273,11 @@ const Page: FC<Props> = ({
             sectionLevelPage={sectionLevelPage}
           />
         }
+        /**
+         * We use this order because people want to:
+         * - Explore deeper into a subject (children)
+         * - Explore around a subject (siblings)
+         */
         RelatedContent={[...Children, ...Siblings]}
         contributorProps={{ contributors: page.contributors }}
         seasons={page.seasons}


### PR DESCRIPTION
As per a discussion with @DominiqueMarshall 

People want to, in priority:
* Explore deeper into a subject (children)
* Explore around a subject (siblings)

This allows for that.

## Before
![Screenshot 2021-09-29 at 10 20 04](https://user-images.githubusercontent.com/31692/135240711-e67dbef0-4646-4474-bce5-704539854c5b.png)

## After
![Screenshot 2021-09-29 at 09 51 38](https://user-images.githubusercontent.com/31692/135240727-a35961c3-d660-484d-89a6-4a1f79909fdb.png)
