### PR TITLE
Add manual-request to the list of  unrequestable methods

### DIFF
--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -78,7 +78,11 @@ function getItemLinkState({
 }
 
 export const unrequestableStatusIds = ['temporarily-unavailable'];
-export const unrequestableMethodIds = ['not-requestable', 'open-shelves'];
+export const unrequestableMethodIds = [
+  'not-requestable',
+  'open-shelves',
+  'manual-request',
+];
 
 const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
   const { enableRequesting } = useContext(TogglesContext);


### PR DESCRIPTION
## Who is this for?
Logged in users

## What is it doing for them?
Not giving them a 'Request item' button when the item has a method of `manual-request`