### PR TITLE
Fix some 500s for seasons and guides pages

### DIFF
--- a/common/services/prismic/seasons.ts
+++ b/common/services/prismic/seasons.ts
@@ -46,7 +46,7 @@ export function parseSeason(document: PrismicDocument): Season {
 export async function getSeason(
   req: IncomingMessage | undefined,
   id: string,
-  memoizedPrismic: Record<string, unknown>
+  memoizedPrismic?: Record<string, unknown>
 ): Promise<Season | undefined> {
   const season = await getDocument(
     req,

--- a/content/webapp/pages/guides.tsx
+++ b/content/webapp/pages/guides.tsx
@@ -13,6 +13,7 @@ import {
   getGuides,
   getGuideFormats,
 } from '@weco/common/services/prismic/guides';
+import { removeUndefinedProps } from '@weco/common/utils/json';
 import { Page } from '@weco/common/model/pages';
 import { PaginatedResults } from '@weco/common/services/prismic/types';
 import { Format } from '@weco/common/model/format';
@@ -122,12 +123,12 @@ export const getServerSideProps: GetServerSideProps<Props> = async (
 
   if (guides) {
     return {
-      props: {
+      props: removeUndefinedProps({
         guides,
         guideFormats,
         formatId: format || null,
         globalContextData,
-      },
+      }),
     };
   } else {
     return { notFound: true };

--- a/content/webapp/pages/guides.tsx
+++ b/content/webapp/pages/guides.tsx
@@ -2,7 +2,7 @@
 // @ts-nocheck
 // Before working on this file, please get it to typecheck,
 // I have had to add this here to unblock some work
-import { NextPageContext } from 'next';
+import { GetServerSideProps, NextPageContext } from 'next';
 import { FunctionComponent, ReactElement } from 'react';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
@@ -101,26 +101,19 @@ const GuidePage = ({
   );
 };
 
-GuidePage.getInitialProps = async (
+export const getServerSideProps: GetServerSideProps<Props> = async (
   ctx: NextPageContext
-): Promise<Props | { statusCode: number }> => {
+) => {
   const globalContextData = getGlobalContextData(ctx);
-  const { format } = ctx.query;
-  const { memoizedPrismic } = ctx.query.memoizedPrismic as unknown as Record<
-    string,
-    unknown
-  >;
-  const memo = Array.isArray(memoizedPrismic)
-    ? memoizedPrismic[0]
-    : memoizedPrismic;
+  const { format, memoizedPrismic } = ctx.query;
   const guidesPromise = await getGuides(
     ctx.req,
     {
       format,
     },
-    memo
+    memoizedPrismic
   );
-  const guideFormatsPromise = getGuideFormats(ctx.req, memo);
+  const guideFormatsPromise = getGuideFormats(ctx.req, memoizedPrismic);
 
   const [guides, guideFormats] = await Promise.all([
     guidesPromise,
@@ -129,13 +122,15 @@ GuidePage.getInitialProps = async (
 
   if (guides) {
     return {
-      guides,
-      guideFormats,
-      formatId: format || null,
-      globalContextData,
+      props: {
+        guides,
+        guideFormats,
+        formatId: format || null,
+        globalContextData,
+      },
     };
   } else {
-    return { statusCode: 404 };
+    return { notFound: true };
   }
 };
 

--- a/content/webapp/pages/season.tsx
+++ b/content/webapp/pages/season.tsx
@@ -7,6 +7,7 @@ import SeasonsHeader from '@weco/common/views/components/SeasonsHeader/SeasonsHe
 import { UiImage } from '@weco/common/views/components/Images/Images';
 import { convertImageUri } from '@weco/common/utils/convert-image-uri';
 import { contentLd } from '@weco/common/utils/json-ld';
+import { removeUndefinedProps } from '@weco/common/utils/json';
 import Body from '@weco/common/views/components/Body/Body';
 import { getSeasonWithContent } from '@weco/common/services/prismic/seasons';
 import CardGrid from '@weco/common/views/components/CardGrid/CardGrid';
@@ -102,7 +103,12 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     });
 
     if (seasonWithContent) {
-      return { props: { ...seasonWithContent, globalContextData } };
+      return {
+        props: removeUndefinedProps({
+          ...seasonWithContent,
+          globalContextData,
+        }),
+      };
     } else {
       return { notFound: true };
     }


### PR DESCRIPTION
We were using `getInitialProps` and returning a `statusCode: 404`, which no longer works. This PR changes these pages to use `getServerSideProps` (like other pages), which can return a `notFound: true`.