### PR TITLE
Remove unnecessarily stacked promises from prismic-fetching pages

### DIFF
--- a/common/services/prismic/exhibitions.js
+++ b/common/services/prismic/exhibitions.js
@@ -311,12 +311,10 @@ export async function getExhibitions(
     memoizedPrismic
   );
 
-  const uiExhibitions: UiExhibition[] = paginatedResults.results.map(
-    parseExhibitionDoc
-  );
-  const exhibitionsWithPermAfterCurrent = putPermanentAfterCurrentExhibitions(
-    uiExhibitions
-  );
+  const uiExhibitions: UiExhibition[] =
+    paginatedResults.results.map(parseExhibitionDoc);
+  const exhibitionsWithPermAfterCurrent =
+    putPermanentAfterCurrentExhibitions(uiExhibitions);
 
   // { ...paginatedResults, results: uiExhibitions } should work, but Flow still
   // battles with spreading.
@@ -405,8 +403,8 @@ export async function getExhibitionWithRelatedContent({
   memoizedPrismic: ?Object,
   id: string,
 }) {
-  const exhibitionPromise = await getExhibition(request, id, memoizedPrismic);
-  const pagesPromise = await getPages(
+  const exhibitionPromise = getExhibition(request, id, memoizedPrismic);
+  const pagesPromise = getPages(
     request,
     {
       predicates: [Prismic.Predicates.at('my.pages.parents.parent', id)],

--- a/common/services/prismic/pages.js
+++ b/common/services/prismic/pages.js
@@ -183,8 +183,8 @@ export async function getPageSiblings(
   memoizedPrismic: ?Object
 ): Promise<SiblingsGroup[]> {
   const relatedPagePromises = (page.parentPages &&
-    page.parentPages.map(async parentPage => {
-      const pagePromise = await getPages(
+    page.parentPages.map(parentPage =>
+      getPages(
         req,
         {
           predicates: [
@@ -192,9 +192,8 @@ export async function getPageSiblings(
           ],
         },
         memoizedPrismic
-      );
-      return pagePromise;
-    })) || [Promise.resolve([])];
+      )
+    )) || [Promise.resolve([])];
   const relatedPages = await Promise.all(relatedPagePromises);
   const siblingsWithLandingTitle = relatedPages.map((results, i) => {
     return {

--- a/common/services/prismic/seasons.ts
+++ b/common/services/prismic/seasons.ts
@@ -76,27 +76,27 @@ export async function getSeasonWithContent({
   memoizedPrismic: Record<string, unknown>;
   id: string;
 }): Promise<SeasonWithContent | undefined> {
-  const seasonPromise = await getSeason(request, id, memoizedPrismic);
+  const seasonPromise = getSeason(request, id, memoizedPrismic);
 
-  const articlesPromise = await getArticles(
+  const articlesPromise = getArticles(
     request,
     { predicates: [Prismic.Predicates.at('my.articles.seasons.season', id)] },
     memoizedPrismic
   );
 
-  const booksPromise = await getBooks(
+  const booksPromise = getBooks(
     request,
     { predicates: [Prismic.Predicates.at('my.books.seasons.season', id)] },
     memoizedPrismic
   );
 
-  const eventsPromise = await getEvents(
+  const eventsPromise = getEvents(
     request,
     { predicates: [Prismic.Predicates.at('my.events.seasons.season', id)] },
     memoizedPrismic
   );
 
-  const exhibitionsPromise = await getExhibitions(
+  const exhibitionsPromise = getExhibitions(
     request,
     {
       predicates: [Prismic.Predicates.at('my.exhibitions.seasons.season', id)],
@@ -104,7 +104,7 @@ export async function getSeasonWithContent({
     memoizedPrismic
   );
 
-  const pagesPromise = await getPages(
+  const pagesPromise = getPages(
     request,
     {
       predicates: [Prismic.Predicates.at('my.pages.seasons.season', id)],
@@ -112,7 +112,7 @@ export async function getSeasonWithContent({
     memoizedPrismic
   );
 
-  const articleSeriesPromise = await getMultipleArticleSeries(
+  const articleSeriesPromise = getMultipleArticleSeries(
     request,
     {
       predicates: [Prismic.Predicates.at('my.series.seasons.season', id)],
@@ -120,7 +120,7 @@ export async function getSeasonWithContent({
     memoizedPrismic
   );
 
-  const projectsPromise = await getProjects(
+  const projectsPromise = getProjects(
     request,
     {
       predicates: [Prismic.Predicates.at('my.projects.seasons.season', id)],

--- a/content/webapp/pages/guides.tsx
+++ b/content/webapp/pages/guides.tsx
@@ -106,7 +106,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async (
 ) => {
   const globalContextData = getGlobalContextData(ctx);
   const { format, memoizedPrismic } = ctx.query;
-  const guidesPromise = await getGuides(
+  const guidesPromise = getGuides(
     ctx.req,
     {
       format,

--- a/content/webapp/pages/homepage.tsx
+++ b/content/webapp/pages/homepage.tsx
@@ -72,7 +72,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
     const globalContextData = getGlobalContextData(context);
     const { id, memoizedPrismic } = context.query;
-    const articlesPromise = await getArticles(
+    const articlesPromise = getArticles(
       context.req,
       { pageSize: 4 },
       memoizedPrismic

--- a/content/webapp/pages/stories.tsx
+++ b/content/webapp/pages/stories.tsx
@@ -91,7 +91,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       memoizedPrismic
     );
 
-    const storiesPagePromise = await getPage(
+    const storiesPagePromise = getPage(
       context.req,
       prismicPageIds.stories,
       memoizedPrismic

--- a/content/webapp/pages/whats-on.js
+++ b/content/webapp/pages/whats-on.js
@@ -363,7 +363,7 @@ export class WhatsOnPage extends Component<Props> {
     const { memoizedPrismic } = ctx.query;
 
     // call prisimic for specific content for section page such as featured text
-    const whatsOnPagePromise = await getPage(
+    const whatsOnPagePromise = getPage(
       ctx.req,
       prismicPageIds.whatsOn,
       memoizedPrismic


### PR DESCRIPTION
Some `await`s have snuck in meaning that our well-intentioned `Promise.all()`s are not actually running all of the promises in parallel