### PR TITLE
Physical items layout

### DIFF
--- a/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
+++ b/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
@@ -194,6 +194,7 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
           rows={createRows()}
           plain={true}
           maxWidth={isArchive ? 980 : 620}
+          columnWidths={[220]}
         />
         {accessNote &&
           !isHeldByUser && ( // if the user currently has this item on hold, we don't want to show the note that says another user has it

--- a/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
+++ b/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
@@ -166,9 +166,9 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
 
     const headingRow = [
       'Location',
-      showStatus && 'Status',
-      showAccess && 'Access',
-      showButton && ' ',
+      showStatus ? 'Status' : ' ',
+      showAccess ? 'Access' : ' ',
+      ' ',
     ].filter(Boolean);
 
     const dataRow = [
@@ -176,17 +176,21 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
         <div>{location}</div>
         <div>{shelfmark}</div>
       </>,
-      showStatus && (
+      showStatus ? (
         <span>
           {isOpenShelves && 'Open shelves'}
           {!isOpenShelves && accessStatus}
         </span>
+      ) : (
+        ' '
       ),
-      showAccess && accessMethod,
-      showButton && (
+      showAccess ? accessMethod : ' ',
+      showButton ? (
         <ButtonWrapper styleChangeWidth={isArchive ? 980 : 620}>
           {requestButton}
         </ButtonWrapper>
+      ) : (
+        ' '
       ),
     ].filter(Boolean);
 

--- a/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
+++ b/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
@@ -185,7 +185,19 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
         ' '
       ),
       showAccess ? accessMethod : ' ',
-      showButton ? (
+      enableRequesting ? (
+        !isLoading ? (
+          showButton ? (
+            <ButtonWrapper styleChangeWidth={isArchive ? 980 : 620}>
+              {requestButton}
+            </ButtonWrapper>
+          ) : (
+            ' '
+          )
+        ) : (
+          'Loading...'
+        )
+      ) : showButton ? (
         <ButtonWrapper styleChangeWidth={isArchive ? 980 : 620}>
           {requestButton}
         </ButtonWrapper>

--- a/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
+++ b/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
@@ -63,7 +63,7 @@ const Box = styled(Space).attrs<{ isCentered?: boolean }>(props => ({
 const Grid = styled.div<{ isArchive: boolean }>`
   ${props => props.theme.media[props.isArchive ? 'large' : 'medium']`
     display: grid;
-    grid-template-columns: 160px 160px 125px;
+    grid-template-columns: 160px 170px 125px auto;
     grid-column-gap: 25px;
   `}
 `;
@@ -169,7 +169,7 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
               <>
                 <Box>
                   <>
-                    <DetailHeading>Access</DetailHeading>
+                    <DetailHeading>Status</DetailHeading>
                     <span>
                       {isOpenShelves && 'Open shelves'}
                       {!isOpenShelves && accessStatus}
@@ -181,18 +181,16 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
           </Box>
           {!isOpenShelves && (
             <>
+              <Box>
+                <DetailHeading>Access</DetailHeading>
+                <>{accessMethod}</>
+              </Box>
               <Box isCentered>
-                {hideRequestButton ? (
-                  // TODO: fairly sure displaying this `accessMethod` here isn't what we want
-                  // (at least not all the time) but it is useful to see e.g. 'Not requestable'
-                  isHeldByUser ? (
-                    <span>You have this item on hold</span>
-                  ) : (
-                    <>{accessMethod}</>
-                  )
-                ) : (
+                {enableRequesting && !hideRequestButton ? (
                   <>
-                    {enableRequesting ? (
+                    {isHeldByUser ? (
+                      <span>You have this item on hold</span>
+                    ) : (
                       <ConfirmItemRequest
                         isActive={isActive}
                         setIsActive={setIsActive}
@@ -201,15 +199,15 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
                         user={isLoading ? undefined : user}
                         initialHoldNumber={userHolds?.results.length ?? 0}
                       />
-                    ) : (
-                      <>
-                        {requestItemUrl && (
-                          <ButtonOutlinedLink
-                            text={'Request item'}
-                            link={requestItemUrl}
-                          />
-                        )}
-                      </>
+                    )}
+                  </>
+                ) : (
+                  <>
+                    {requestItemUrl && (
+                      <ButtonOutlinedLink
+                        text={'Request item'}
+                        link={requestItemUrl}
+                      />
                     )}
                   </>
                 )}

--- a/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
+++ b/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
@@ -29,6 +29,16 @@ const Wrapper = styled(Space).attrs({
   `}
 `;
 
+type ButtonWrapperProps = {
+  styleChangeWidth: number;
+};
+
+const ButtonWrapper = styled.div<ButtonWrapperProps>`
+  @media (max-width: ${props => props.styleChangeWidth}px) {
+    margin-top: ${props => props.theme.spacingUnit * 2}px;
+  }
+`;
+
 const DetailHeading = styled.h3.attrs({
   className: classNames({
     [font('hnb', 5, { small: 3, medium: 3 })]: true,
@@ -173,7 +183,11 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
         </span>
       ),
       showAccess && accessMethod,
-      showButton && requestButton,
+      showButton && (
+        <ButtonWrapper styleChangeWidth={isArchive ? 980 : 620}>
+          {requestButton}
+        </ButtonWrapper>
+      ),
     ].filter(Boolean);
 
     return [headingRow, dataRow];

--- a/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
+++ b/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
@@ -17,6 +17,7 @@ import {
   unrequestableStatusIds,
   unrequestableMethodIds,
 } from '../WorkDetails/WorkDetails';
+import StackingTable from '@weco/common/views/components/StackingTable/StackingTable';
 
 const Row = styled(Space).attrs({
   v: { size: 'm', properties: ['margin-bottom'] },
@@ -60,14 +61,6 @@ const Box = styled(Space).attrs<{ isCentered?: boolean }>(props => ({
   `}
 `;
 
-const Grid = styled.div<{ isArchive: boolean }>`
-  ${props => props.theme.media[props.isArchive ? 'large' : 'medium']`
-    display: grid;
-    grid-template-columns: 160px 170px 125px auto;
-    grid-column-gap: 25px;
-  `}
-`;
-
 export type Props = {
   item: PhysicalItem;
   work: Work;
@@ -86,31 +79,52 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
   isLast,
 }) => {
   const { user, isLoading } = useUserInfo();
-  const [isActive, setIsActive] = useState(false);
   const isArchive = useContext(IsArchiveContext);
   const { enableRequesting } = useContext(TogglesContext);
-  const physicalLocation = getFirstPhysicalLocation(item);
+  const [isActive, setIsActive] = useState(false);
+  const [userHolds, setUserHolds] = useState<UserHolds | undefined>();
+
+  const physicalLocation = getFirstPhysicalLocation(item); // ok to assume items only have a single physicalLocation
+
   const isOpenShelves = physicalLocation?.locationType.id === 'open-shelves';
+
   const isRequestableOnline =
     physicalLocation?.accessConditions?.[0]?.method?.id === 'online-request';
+
   const accessMethod =
     physicalLocation?.accessConditions?.[0]?.method?.label || '';
-  const accessMethodId =
-    physicalLocation?.accessConditions?.[0]?.method?.id || '';
-  const accessStatusId =
-    physicalLocation?.accessConditions?.[0]?.status?.id || '';
+
   const accessStatus =
     physicalLocation?.accessConditions?.[0]?.status?.label ||
     (isRequestableOnline ? 'Open' : '');
+
   const accessNote = physicalLocation?.accessConditions?.[0]?.note;
+
   const locationLabel = physicalLocation && getLocationLabel(physicalLocation);
+
   const locationShelfmark =
     physicalLocation && getLocationShelfmark(physicalLocation);
+
+  const requestItemUrl = isRequestableOnline ? encoreLink : undefined;
+
+  // Work out whether to show the requestButton
+  const accessMethodId =
+    physicalLocation?.accessConditions?.[0]?.method?.id || '';
+
+  const accessStatusId =
+    physicalLocation?.accessConditions?.[0]?.status?.id || '';
+
+  // Work out whether to show status and access and request button
+  // TODO tidy up logic about showing button, encorporate isRequestableOnline, encoreUrl
+  const showStatus = isOpenShelves || accessStatus;
+  const showAccess = !isOpenShelves;
   const hideRequestButton =
     unrequestableStatusIds.some(i => i === accessStatusId) ||
     unrequestableMethodIds.some(i => i === accessMethodId) ||
     (!user && enableRequesting);
-  const [userHolds, setUserHolds] = useState<UserHolds | undefined>();
+  const showButton =
+    (enableRequesting && !hideRequestButton) ||
+    (!enableRequesting && requestItemUrl);
 
   useEffect(() => {
     if (!user) return;
@@ -137,95 +151,95 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
   }, [user?.userId]);
 
   const title = item.title || '';
+
   const itemNote = item.note || '';
+
   const location = locationLabel || '';
   const shelfmark = locationShelfmark || '';
-  const requestItemUrl = isRequestableOnline ? encoreLink : undefined;
+
   const isHeldByUser = userHolds
     ? userHolds.results.some(r => r.item.id === item.id)
     : false;
 
-  return (
-    <Wrapper underline={!isLast}>
-      {(title || itemNote) && (
-        <Row>
-          <Box>
-            <DetailHeading>{title}</DetailHeading>
-            {itemNote && (
-              <span dangerouslySetInnerHTML={{ __html: itemNote }} />
-            )}
-          </Box>
-        </Row>
-      )}
-      <Row>
-        <Grid isArchive={isArchive}>
-          <Box>
-            <DetailHeading>Location</DetailHeading>
-            <span className={`inline-block`}>{location}</span>{' '}
-            <span className={`inline-block`}>{shelfmark}</span>
-          </Box>
-          <Box>
-            {(isOpenShelves || accessStatus) && (
-              <>
-                <Box>
-                  <>
-                    <DetailHeading>Status</DetailHeading>
-                    <span>
-                      {isOpenShelves && 'Open shelves'}
-                      {!isOpenShelves && accessStatus}
-                    </span>
-                  </>
-                </Box>
-              </>
-            )}
-          </Box>
-          {!isOpenShelves && (
-            <>
-              <Box>
-                <DetailHeading>Access</DetailHeading>
-                <>{accessMethod}</>
-              </Box>
-              <Box isCentered>
-                {enableRequesting && !hideRequestButton ? (
-                  <>
-                    {isHeldByUser ? (
-                      <span>You have this item on hold</span>
-                    ) : (
-                      <ConfirmItemRequest
-                        isActive={isActive}
-                        setIsActive={setIsActive}
-                        item={item}
-                        work={work}
-                        user={isLoading ? undefined : user}
-                        initialHoldNumber={userHolds?.results.length ?? 0}
-                      />
-                    )}
-                  </>
-                ) : (
-                  <>
-                    {requestItemUrl && (
-                      <ButtonOutlinedLink
-                        text={'Request item'}
-                        link={requestItemUrl}
-                      />
-                    )}
-                  </>
-                )}
-              </Box>
-            </>
+  // TODO cater for when isHeldByUser updates
+  function createRows() {
+    const requestButton =
+      enableRequesting && !hideRequestButton ? (
+        <>
+          {isHeldByUser ? (
+            <span>You have this item on hold</span>
+          ) : (
+            <ConfirmItemRequest
+              isActive={isActive}
+              setIsActive={setIsActive}
+              item={item}
+              work={work}
+              user={isLoading ? undefined : user}
+              initialHoldNumber={userHolds?.results.length ?? 0}
+            />
           )}
-        </Grid>
-      </Row>
-      {accessNote &&
-        !isHeldByUser && ( // if the user currently has this item on hold, we don't want to show the note that says another user has it
+        </>
+      ) : (
+        requestItemUrl &&
+        !hideRequestButton && (
+          <ButtonOutlinedLink text={'Request item'} link={requestItemUrl} />
+        )
+      );
+
+    const headingRow = [
+      'Location',
+      showStatus && 'Status',
+      showAccess && 'Access',
+      showButton && <span>Request link</span>, // TODO visually hidden
+    ].filter(Boolean);
+
+    const dataRow = [
+      <>
+        <div>{location}</div>
+        <div>{shelfmark}</div>
+      </>,
+      showStatus && (
+        <span>
+          {isOpenShelves && 'Open shelves'}
+          {!isOpenShelves && accessStatus}
+        </span>
+      ),
+      showAccess && accessMethod,
+      showButton && requestButton,
+    ].filter(Boolean);
+
+    return [headingRow, dataRow];
+  }
+
+  return (
+    <>
+      <Wrapper underline={!isLast}>
+        {(title || itemNote) && (
           <Row>
             <Box>
-              <DetailHeading>Note</DetailHeading>
-              <span dangerouslySetInnerHTML={{ __html: accessNote }} />
+              <DetailHeading>{title}</DetailHeading>
+              {itemNote && (
+                <span dangerouslySetInnerHTML={{ __html: itemNote }} />
+              )}
             </Box>
           </Row>
         )}
-    </Wrapper>
+        <StackingTable
+          rows={createRows()}
+          plain={true}
+          maxWidth={isArchive ? 980 : 620}
+        />
+        {accessNote &&
+          !isHeldByUser && ( // if the user currently has this item on hold, we don't want to show the note that says another user has it
+            <Row>
+              <Box>
+                <DetailHeading>Note</DetailHeading>
+                <span dangerouslySetInnerHTML={{ __html: accessNote }} />
+              </Box>
+            </Row>
+          )}
+      </Wrapper>
+    </>
   );
 };
 

--- a/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
+++ b/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
@@ -165,7 +165,7 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
       'Location',
       showStatus && 'Status',
       showAccess && 'Access',
-      showButton && <span>Request link</span>, // TODO visually hidden
+      showButton && '',
     ].filter(Boolean);
 
     const dataRow = [

--- a/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
+++ b/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
@@ -165,7 +165,7 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
       'Location',
       showStatus && 'Status',
       showAccess && 'Access',
-      showButton && '',
+      showButton && ' ',
     ].filter(Boolean);
 
     const dataRow = [

--- a/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
+++ b/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
@@ -19,10 +19,6 @@ import {
 } from '../WorkDetails/WorkDetails';
 import StackingTable from '@weco/common/views/components/StackingTable/StackingTable';
 
-const Row = styled(Space).attrs({
-  v: { size: 'm', properties: ['margin-bottom'] },
-})``;
-
 const Wrapper = styled(Space).attrs({
   v: { size: 'm', properties: ['margin-bottom', 'padding-bottom'] },
 })<{ underline: boolean }>`
@@ -31,10 +27,6 @@ const Wrapper = styled(Space).attrs({
     `
     border-bottom: 1px solid ${props.theme.color('pumice')};
   `}
-
-  ${Row}:last-of-type {
-    margin-bottom: 0;
-  }
 `;
 
 const DetailHeading = styled.h3.attrs({
@@ -43,23 +35,6 @@ const DetailHeading = styled.h3.attrs({
     'no-margin': true,
   }),
 })``;
-
-const Box = styled(Space).attrs<{ isCentered?: boolean }>(props => ({
-  v: {
-    size: 's',
-    properties: [props.isCentered ? undefined : 'margin-bottom'],
-  },
-}))<{ isCentered?: boolean }>`
-  ${props =>
-    props.isCentered &&
-    `
-    align-self: center;
-  `}
-
-  ${props => props.theme.media.medium`
-    margin-bottom: 0;
-  `}
-`;
 
 export type Props = {
   item: PhysicalItem;
@@ -215,14 +190,12 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
     <>
       <Wrapper underline={!isLast}>
         {(title || itemNote) && (
-          <Row>
-            <Box>
-              <DetailHeading>{title}</DetailHeading>
-              {itemNote && (
-                <span dangerouslySetInnerHTML={{ __html: itemNote }} />
-              )}
-            </Box>
-          </Row>
+          <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
+            <DetailHeading>{title}</DetailHeading>
+            {itemNote && (
+              <span dangerouslySetInnerHTML={{ __html: itemNote }} />
+            )}
+          </Space>
         )}
         <StackingTable
           rows={createRows()}
@@ -231,12 +204,10 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
         />
         {accessNote &&
           !isHeldByUser && ( // if the user currently has this item on hold, we don't want to show the note that says another user has it
-            <Row>
-              <Box>
-                <DetailHeading>Note</DetailHeading>
-                <span dangerouslySetInnerHTML={{ __html: accessNote }} />
-              </Box>
-            </Row>
+            <Space v={{ size: 'm', properties: ['margin-top'] }}>
+              <DetailHeading>Note</DetailHeading>
+              <span dangerouslySetInnerHTML={{ __html: accessNote }} />
+            </Space>
           )}
       </Wrapper>
     </>

--- a/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
+++ b/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
@@ -136,24 +136,17 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
     ? userHolds.results.some(r => r.item.id === item.id)
     : false;
 
-  // TODO cater for when isHeldByUser updates
   function createRows() {
     const requestButton =
       enableRequesting && !hideRequestButton ? (
-        <>
-          {isHeldByUser ? (
-            <span>You have this item on hold</span>
-          ) : (
-            <ConfirmItemRequest
-              isActive={isActive}
-              setIsActive={setIsActive}
-              item={item}
-              work={work}
-              user={isLoading ? undefined : user}
-              initialHoldNumber={userHolds?.results.length ?? 0}
-            />
-          )}
-        </>
+        <ConfirmItemRequest
+          isActive={isActive}
+          setIsActive={setIsActive}
+          item={item}
+          work={work}
+          user={isLoading ? undefined : user}
+          initialHoldNumber={userHolds?.results.length ?? 0}
+        />
       ) : (
         requestItemUrl &&
         !hideRequestButton && (
@@ -209,6 +202,14 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
               <span dangerouslySetInnerHTML={{ __html: accessNote }} />
             </Space>
           )}
+        {isHeldByUser && (
+          <Space v={{ size: 'm', properties: ['margin-top'] }}>
+            <DetailHeading>Note</DetailHeading>
+            <span
+              dangerouslySetInnerHTML={{ __html: 'You have this item on hold' }}
+            />
+          </Space>
+        )}
       </Wrapper>
     </>
   );

--- a/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
+++ b/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
@@ -92,15 +92,13 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
 
   const requestItemUrl = isRequestableOnline ? encoreLink : undefined;
 
-  // Work out whether to show the requestButton
   const accessMethodId =
     physicalLocation?.accessConditions?.[0]?.method?.id || '';
 
   const accessStatusId =
     physicalLocation?.accessConditions?.[0]?.status?.id || '';
 
-  // Work out whether to show status and access and request button
-  // TODO tidy up logic about showing button, encorporate isRequestableOnline, encoreUrl
+  // Work out whether to show status, access and request button
   const showStatus = isOpenShelves || accessStatus;
   const showAccess = !isOpenShelves;
   const hideRequestButton =
@@ -224,7 +222,7 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
           rows={createRows()}
           plain={true}
           maxWidth={isArchive ? 980 : 620}
-          columnWidths={[220]}
+          columnWidths={[180, 200, null, null]}
         />
         {accessNote &&
           !isHeldByUser && ( // if the user currently has this item on hold, we don't want to show the note that says another user has it
@@ -237,7 +235,9 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
           <Space v={{ size: 'm', properties: ['margin-top'] }}>
             <DetailHeading>Note</DetailHeading>
             <span
-              dangerouslySetInnerHTML={{ __html: 'You have this item on hold' }}
+              dangerouslySetInnerHTML={{
+                __html: 'You have requested this item.',
+              }}
             />
           </Space>
         )}

--- a/common/views/components/StackingTable/StackingTable.jsx
+++ b/common/views/components/StackingTable/StackingTable.jsx
@@ -8,6 +8,7 @@ const StyledTable = styled.table.attrs({
   }),
 })`
    {
+    table-layout: fixed;
     width: 100%;
     border-collapse: collapse;
   }

--- a/common/views/components/StackingTable/StackingTable.jsx
+++ b/common/views/components/StackingTable/StackingTable.jsx
@@ -42,15 +42,23 @@ const StyledTr = styled(Space).attrs({
   }
 `;
 
-const StyledTh = styled(Space).attrs({
+const StyledTh = styled(Space).attrs(props => ({
   as: 'th',
   v: { size: 's', properties: ['padding-top', 'padding-bottom'] },
-  h: { size: 'm', properties: ['padding-left', 'padding-right'] },
+  h: {
+    size: 'm',
+    properties: [props.plain ? '' : 'padding-left', 'padding-right'].filter(
+      Boolean
+    ),
+  },
   className: classNames({
     [font('hnb', 5)]: true,
   }),
-})`
-  background: ${props => props.theme.color('pumice')};
+}))`
+  background: ${props =>
+    props.plain
+      ? props.theme.color('transparent')
+      : props.theme.color('pumice')};
   white-space: nowrap;
   text-align: left;
   vertical-align: top;
@@ -59,11 +67,16 @@ const StyledTh = styled(Space).attrs({
   }
 `;
 
-const StyledTd = styled(Space).attrs({
+const StyledTd = styled(Space).attrs(props => ({
   as: 'td',
   v: { size: 'm', properties: ['padding-top', 'padding-bottom'] },
-  h: { size: 'm', properties: ['padding-left', 'padding-right'] },
-})`
+  h: {
+    size: 'm',
+    properties: [props.plain ? '' : 'padding-left', 'padding-right'].filter(
+      Boolean
+    ),
+  },
+}))`
   text-align: left;
   vertical-align: top;
   @media (max-width: ${props => props.theme.sizes.large}px) {
@@ -87,12 +100,14 @@ const StyledTd = styled(Space).attrs({
 
 type Props = {
   rows: (string | ReactElement)[][],
-  caption: string,
+  caption?: string,
+  plain?: boolean,
 };
 
 const StackingTable: FunctionComponent<Props> = ({
   rows,
   caption,
+  plain,
 }: Props): ReactElement<Props> => {
   const headerRow = rows[0];
   const bodyRows = rows.slice(1);
@@ -101,15 +116,21 @@ const StackingTable: FunctionComponent<Props> = ({
       <thead>
         <tr>
           {headerRow.map((data, index) => (
-            <StyledTh key={index}>{data}</StyledTh>
+            <StyledTh key={index} plain={plain}>
+              {data}
+            </StyledTh>
           ))}
         </tr>
       </thead>
       <tbody>
         {bodyRows.map((row, index) => (
-          <StyledTr key={index}>
+          <StyledTr plain={plain} key={index}>
             {row.map((data, index) => (
-              <StyledTd key={index} content={`${headerRow[index]}`}>
+              <StyledTd
+                key={index}
+                content={`${headerRow[index]}`}
+                plain={plain}
+              >
                 {data}
               </StyledTd>
             ))}

--- a/common/views/components/StackingTable/StackingTable.jsx
+++ b/common/views/components/StackingTable/StackingTable.jsx
@@ -15,7 +15,8 @@ const StyledTable = styled.table.attrs({
 
   @media (max-width: ${props =>
       props.maxWidth ? props.maxWidth : props.theme.sizes.large}px) {
-    table,
+    display: block;
+
     thead,
     tbody,
     th,

--- a/common/views/components/StackingTable/StackingTable.jsx
+++ b/common/views/components/StackingTable/StackingTable.jsx
@@ -101,7 +101,7 @@ const StyledTd = styled(Space).attrs(props => ({
     :before {
       display: block;
       white-space: nowrap;
-      content: ${props => `'${props.content}'`};
+      content: ${props => (props.content ? `'${props.content}'` : '')};
       font-weight: bold;
     }
   }
@@ -139,7 +139,7 @@ const StackingTable: FunctionComponent<Props> = ({
             {row.map((data, index) => (
               <StyledTd
                 key={index}
-                content={`${headerRow[index]}`}
+                content={headerRow[index]}
                 plain={plain}
                 maxWidth={maxWidth}
               >

--- a/common/views/components/StackingTable/StackingTable.jsx
+++ b/common/views/components/StackingTable/StackingTable.jsx
@@ -113,6 +113,7 @@ type Props = {
   caption?: string,
   plain?: boolean,
   maxWidth?: number,
+  columnWidths?: (number | null)[],
 };
 
 const StackingTable: FunctionComponent<Props> = ({
@@ -120,6 +121,7 @@ const StackingTable: FunctionComponent<Props> = ({
   caption,
   plain,
   maxWidth,
+  columnWidths = [],
 }: Props): ReactElement<Props> => {
   const headerRow = rows[0];
   const bodyRows = rows.slice(1);
@@ -128,7 +130,12 @@ const StackingTable: FunctionComponent<Props> = ({
       <thead>
         <tr>
           {headerRow.map((data, index) => (
-            <StyledTh key={index} plain={plain} maxWidth={maxWidth}>
+            <StyledTh
+              key={index}
+              plain={plain}
+              maxWidth={maxWidth}
+              width={columnWidths[index]}
+            >
               {data}
             </StyledTh>
           ))}

--- a/common/views/components/StackingTable/StackingTable.jsx
+++ b/common/views/components/StackingTable/StackingTable.jsx
@@ -12,7 +12,8 @@ const StyledTable = styled.table.attrs({
     border-collapse: collapse;
   }
 
-  @media (max-width: ${props => props.theme.sizes.large}px) {
+  @media (max-width: ${props =>
+      props.maxWidth ? props.maxWidth : props.theme.sizes.large}px) {
     table,
     thead,
     tbody,
@@ -44,7 +45,10 @@ const StyledTr = styled(Space).attrs({
 
 const StyledTh = styled(Space).attrs(props => ({
   as: 'th',
-  v: { size: 's', properties: ['padding-top', 'padding-bottom'] },
+  v: {
+    size: 's',
+    properties: props.plain ? [] : ['padding-top', 'padding-bottom'],
+  },
   h: {
     size: 'm',
     properties: [props.plain ? '' : 'padding-left', 'padding-right'].filter(
@@ -62,14 +66,18 @@ const StyledTh = styled(Space).attrs(props => ({
   white-space: nowrap;
   text-align: left;
   vertical-align: top;
-  @media (max-width: ${props => props.theme.sizes.large}px) {
+  @media (max-width: ${props =>
+      props.maxWidth ? props.maxWidth : props.theme.sizes.large}px) {
     padding-left: 0;
   }
 `;
 
 const StyledTd = styled(Space).attrs(props => ({
   as: 'td',
-  v: { size: 'm', properties: ['padding-top', 'padding-bottom'] },
+  v: {
+    size: 'm',
+    properties: props.plain ? [] : ['padding-top', 'padding-bottom'],
+  },
   h: {
     size: 'm',
     properties: [props.plain ? '' : 'padding-left', 'padding-right'].filter(
@@ -79,7 +87,8 @@ const StyledTd = styled(Space).attrs(props => ({
 }))`
   text-align: left;
   vertical-align: top;
-  @media (max-width: ${props => props.theme.sizes.large}px) {
+  @media (max-width: ${props =>
+      props.maxWidth ? props.maxWidth : props.theme.sizes.large}px) {
     padding-left: 0;
     padding-top: 0;
     padding-bottom: ${props => `${props.theme.spacingUnit}px`};
@@ -102,21 +111,23 @@ type Props = {
   rows: (string | ReactElement)[][],
   caption?: string,
   plain?: boolean,
+  maxWidth?: number,
 };
 
 const StackingTable: FunctionComponent<Props> = ({
   rows,
   caption,
   plain,
+  maxWidth,
 }: Props): ReactElement<Props> => {
   const headerRow = rows[0];
   const bodyRows = rows.slice(1);
   return (
-    <StyledTable>
+    <StyledTable maxWidth={maxWidth}>
       <thead>
         <tr>
           {headerRow.map((data, index) => (
-            <StyledTh key={index} plain={plain}>
+            <StyledTh key={index} plain={plain} maxWidth={maxWidth}>
               {data}
             </StyledTh>
           ))}
@@ -130,6 +141,7 @@ const StackingTable: FunctionComponent<Props> = ({
                 key={index}
                 content={`${headerRow[index]}`}
                 plain={plain}
+                maxWidth={maxWidth}
               >
                 {data}
               </StyledTd>

--- a/common/views/components/StackingTable/StackingTable.jsx
+++ b/common/views/components/StackingTable/StackingTable.jsx
@@ -8,7 +8,7 @@ const StyledTable = styled.table.attrs({
   }),
 })`
    {
-    table-layout: fixed;
+    table-layout: ${props => (props.useFixedWidth ? 'fixed' : 'auto')};
     width: 100%;
     border-collapse: collapse;
   }
@@ -126,7 +126,7 @@ const StackingTable: FunctionComponent<Props> = ({
   const headerRow = rows[0];
   const bodyRows = rows.slice(1);
   return (
-    <StyledTable maxWidth={maxWidth}>
+    <StyledTable maxWidth={maxWidth} useFixedWidth={columnWidths.length > 0}>
       <thead>
         <tr>
           {headerRow.map((data, index) => (


### PR DESCRIPTION
- Uses the StackingTable component to layout the physical items data.
- Always shows Location, Status (access status), and Access (access method) columns if we have the data
- Adds another column for displaying the request button (rather than it replacing the access method data)
- If a user had requested an item, we previously displayed a message to that effect in the status column. This moves it to where the Note is displayed and also changes the text so it doesn't use the term 'hold'. See below:

**User _not_ logged in and has item on request**

Before:
![current-not-logged-in](https://user-images.githubusercontent.com/6051896/135842452-6451ded3-af93-42bb-a1d2-fa9725453376.png)

After:
![Screenshot 2021-10-04 at 12 32 51](https://user-images.githubusercontent.com/6051896/135844545-d0bb8343-eac7-4e68-871e-b566bd5de26a.png)


**User _is_ logged in and has item on request**

Before: 
![current-logged-in](https://user-images.githubusercontent.com/6051896/135842497-d9e4848a-8487-4b26-8647-5c5cafbcc501.png)

After:
![Screenshot 2021-10-04 at 12 32 31](https://user-images.githubusercontent.com/6051896/135844520-a07ae26b-e277-4c9b-a7c4-a12b9442266b.png)

Example with no status data for item:
![Screenshot 2021-10-04 at 11 47 35](https://user-images.githubusercontent.com/6051896/135842591-13d53ec3-91f4-4171-877c-dc274168e927.png)

Example of layout on small screen:
![Screenshot 2021-10-04 at 11 39 00](https://user-images.githubusercontent.com/6051896/135842644-cb30a8db-7b13-45d8-9e58-4d452a4ce994.png)


