### PR TITLE
Show where to find it when there are physical items

### DIFF
--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -711,7 +711,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
 
       <Holdings />
 
-      {(locationOfWork || showEncoreLink) && <WhereToFindIt />}
+      {(locationOfWork || showEncoreLink || physicalItems) && <WhereToFindIt />}
 
       <WorkDetailsSection headingText="Permanent link">
         <div className={`${font('hnr', 5)}`}>


### PR DESCRIPTION
Bug [mentioned in Slack](https://wellcome.slack.com/archives/C016NQB58N4/p1633345802084900) about works not displaying physical items even though they are in the API.

Certain items don't have a `locationOfWork` or `encoreLink`, and the presence of one of these is what we were basing showing the 'Where to find it' section on. But we also want to show that section if there are `physicalItems`.

![image](https://user-images.githubusercontent.com/1394592/135864638-ffa6a516-b51c-4001-87f5-b28d7cbf1c60.png)