### PR TITLE
move isEnhanced into useLayoutEffect

### DIFF
--- a/common/views/components/AppContext/AppContext.tsx
+++ b/common/views/components/AppContext/AppContext.tsx
@@ -54,12 +54,17 @@ export const AppContextProvider: FunctionComponent<AppContextProviderProps> = ({
     appContextDefaults.windowSize
   );
 
+  useEffect(() => {
+    setIsEnhanced(true);
+  }, []);
+
   // We need the initial state to be set before rendering to avoid
   // flashing of content, so use `useLayoutEffect` for the initial
   // setting of `windowSize`
   function updateWindowSize() {
     setWindowSize(getWindowSize());
   }
+
   useEffect(() => {
     window.addEventListener('resize', updateWindowSize);
     return () => window.removeEventListener('resize', updateWindowSize);
@@ -67,10 +72,6 @@ export const AppContextProvider: FunctionComponent<AppContextProviderProps> = ({
 
   useIsomorphicLayoutEffect(() => {
     updateWindowSize();
-  }, []);
-
-  useIsomorphicLayoutEffect(() => {
-    setIsEnhanced(true);
   }, []);
 
   useEffect(() => {

--- a/common/views/components/AppContext/AppContext.tsx
+++ b/common/views/components/AppContext/AppContext.tsx
@@ -64,12 +64,16 @@ export const AppContextProvider: FunctionComponent<AppContextProviderProps> = ({
     window.addEventListener('resize', updateWindowSize);
     return () => window.removeEventListener('resize', updateWindowSize);
   }, []);
+
   useIsomorphicLayoutEffect(() => {
     updateWindowSize();
   }, []);
 
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     setIsEnhanced(true);
+  }, []);
+
+  useEffect(() => {
     // The presence of IntersectionObserver is a useful proxy for browsers that we
     // want to support in full: https://caniuse.com/intersectionobserver
     setIsFullSupportBrowser('IntersectionObserver' in window);

--- a/common/views/components/SearchFilters/SearchFilters.tsx
+++ b/common/views/components/SearchFilters/SearchFilters.tsx
@@ -1,10 +1,11 @@
-import { FunctionComponent, ReactElement, useContext } from 'react';
+import { FunctionComponent, ReactElement, useContext, useState } from 'react';
 import { ParsedUrlQuery } from 'querystring';
 import SearchFiltersDesktop from '../SearchFiltersDesktop/SearchFiltersDesktop';
 import SearchFiltersMobile from '../SearchFiltersMobile/SearchFiltersMobile';
 import { LinkProps } from '../../../model/link-props';
 import { Filter } from '../../../services/catalogue/filters';
 import { AppContext } from '../AppContext/AppContext';
+import useIsomorphicLayoutEffect from '../../../hooks/useIsomorphicLayoutEffect';
 
 type Props = {
   query: string;
@@ -23,7 +24,14 @@ const SearchFilters: FunctionComponent<Props> = ({
   filters,
   linkResolver,
 }: Props): ReactElement<Props> => {
-  const { windowSize, isEnhanced } = useContext(AppContext);
+  const { windowSize } = useContext(AppContext);
+  // We use the setIsomorphicLayoutEffect here as we can't use CSS to
+  // create a responsive layout here.
+  // See: https://github.com/wellcomecollection/wellcomecollection.org/issues/6268
+  const [isEnhanced, setIsEnhanced] = useState(false);
+  useIsomorphicLayoutEffect(() => {
+    setIsEnhanced(true);
+  }, []);
 
   const activeFiltersCount = filters
     .map(f => {

--- a/common/views/components/SearchFilters/SearchFilters.tsx
+++ b/common/views/components/SearchFilters/SearchFilters.tsx
@@ -23,7 +23,7 @@ const SearchFilters: FunctionComponent<Props> = ({
   filters,
   linkResolver,
 }: Props): ReactElement<Props> => {
-  const { windowSize } = useContext(AppContext);
+  const { windowSize, isEnhanced } = useContext(AppContext);
 
   const activeFiltersCount = filters
     .map(f => {
@@ -51,18 +51,13 @@ const SearchFilters: FunctionComponent<Props> = ({
     activeFiltersCount,
   };
 
-  return (
+  return isEnhanced ? (
     <>
-      {windowSize === 'small' ? (
-        <>
-          <SearchFiltersMobile {...sharedProps} />
-        </>
-      ) : (
-        <>
-          <SearchFiltersDesktop {...sharedProps} />
-        </>
-      )}
+      {windowSize === 'small' && <SearchFiltersMobile {...sharedProps} />}
+      {windowSize !== 'small' && <SearchFiltersDesktop {...sharedProps} />}
     </>
+  ) : (
+    <SearchFiltersDesktop {...sharedProps} />
   );
 };
 


### PR DESCRIPTION
Inspired by

> However, if your effect is mutating the DOM (via a DOM node ref) and the DOM mutation will change the appearance of the DOM node between the time that it is rendered and your effect mutates it, then you don't want to use useEffect. You'll want to use useLayoutEffect. Otherwise the user could see a flicker when your DOM mutations take effect. This is pretty much the only time you want to avoid useEffect and use useLayoutEffect instead.

-- [Kent C. Dodds](https://kentcdodds.com/blog/useeffect-vs-uselayouteffect)

This is pretty much our use case for `isEnhanced`. Saying that, I am not 💯 that this won't have knock on effects. I'd rather have 1 way of doing this however, and measure where it might be an issue.

Fixes https://github.com/wellcomecollection/wellcomecollection.org/pull/7116