### PR TITLE
Capture errors for APM

### DIFF
--- a/catalogue/webapp/app.js
+++ b/catalogue/webapp/app.js
@@ -9,6 +9,7 @@ const {
   route,
   handleAllRoute,
 } = require('@weco/common/koa-middleware/withCachedValues');
+const apmErrorMiddleware = require('@weco/common/services/apm/errorMiddleware');
 const withQueryType = require('./middleware/withQueryType');
 
 const dev = process.env.NODE_ENV !== 'production';
@@ -21,6 +22,7 @@ module.exports = app
     const server = new Koa();
     const router = new Router();
 
+    server.use(apmErrorMiddleware);
     server.use(withQueryType);
     server.use(middleware);
 

--- a/common/services/apm/errorMiddleware.js
+++ b/common/services/apm/errorMiddleware.js
@@ -1,0 +1,11 @@
+const apm = require('elastic-apm-node');
+
+module.exports = async (ctx, next) => {
+  try {
+    await next();
+  } catch (error) {
+    // https://www.elastic.co/guide/en/apm/agent/nodejs/master/koa.html#koa-error-logging
+    apm.captureError(error);
+    throw error;
+  }
+};

--- a/content/webapp/app.js
+++ b/content/webapp/app.js
@@ -6,6 +6,7 @@ const Router = require('koa-router');
 const next = require('next');
 const Prismic = require('prismic-javascript');
 const linkResolver = require('@weco/common/services/prismic/link-resolver');
+const apmErrorMiddleware = require('@weco/common/services/apm/errorMiddleware');
 const bodyParser = require('koa-bodyparser');
 const handleNewsletterSignup = require('./routeHandlers/handleNewsletterSignup');
 
@@ -43,6 +44,7 @@ module.exports = app
     const server = new Koa();
     const router = new Router();
 
+    server.use(apmErrorMiddleware);
     server.use(middleware);
     server.use(bodyParser());
 

--- a/identity/webapp/src/app.ts
+++ b/identity/webapp/src/app.ts
@@ -16,6 +16,7 @@ import { TypedRouter } from './utility/typed-router';
 import { configureLocalAuth } from './utility/configure-local-auth';
 import { config } from './config';
 import { configureAuth0 } from './utility/configure-auth0';
+import apmErrorMiddleware from '@weco/common/services/apm/errorMiddleware';
 /* eslint-enable @typescript-eslint/no-var-requires, import/first */
 
 export async function createApp(
@@ -28,6 +29,7 @@ export async function createApp(
   await nextApp.prepare();
 
   const app = new Koa();
+  app.use(apmErrorMiddleware);
 
   app.context.routes = router;
 


### PR DESCRIPTION
APM currently traces errors as if they were normal responses - this makes them more explicit and useful. I would be interested in switching some of our monitoring to use APM rather than CloudFront...