### PR TITLE
URL-encode document IDs

### DIFF
--- a/common/services/prismic/api.js
+++ b/common/services/prismic/api.js
@@ -44,7 +44,10 @@ export async function getDocument(
     memoizedPrismic && !isPreview(req)
       ? memoizedPrismic
       : await getPrismicApi(req);
-  const doc = await prismicApi.getByID(id, opts);
+  // If the ID has characters like `"` in it, Prismic returns a 400
+  // rather than a 404
+  const safeId = encodeURIComponent(id)
+  const doc = await prismicApi.getByID(safeId, opts);
   return doc;
 }
 


### PR DESCRIPTION
[Occasionally](https://logging.wellcomecollection.org/app/discover#/?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-1w,to:now))&_a=(columns:!(url.full,http.response.status_code),filters:!(),index:apm_static_index_pattern_id,interval:auto,query:(language:kuery,query:'processor.event:%22transaction%22%20AND%20transaction.id:%223bba8a6f6cd489d3%22%20AND%20trace.id:%22ec238fc5daeaa6a80039f560ba863eca%22'),sort:!(!('@timestamp',desc)))) we get 500s from malformed document IDs (likely due to dodgy links) with special characters in - this gets rid of those