### PR TITLE
Override rotated wobbly line margin

### DIFF
--- a/common/views/components/WobblyEdge/WobblyEdge.tsx
+++ b/common/views/components/WobblyEdge/WobblyEdge.tsx
@@ -48,6 +48,11 @@ const Edge = styled.div<{
     transform: rotate(180deg);
     margin-top: 0;
     top: -2px;
+
+    @media (min-width: ${props.theme.sizes.large}px) {
+      margin-top: 0;
+      top: -2px;
+    }
   `}
 `;
 


### PR DESCRIPTION
Fixes #6993

It is overridden by default, but the large breakpoint has different values that also need to be overridden.

![image](https://user-images.githubusercontent.com/1394592/136175488-81697115-b587-4204-b535-ecef7ebf06ad.png)
