### PR TITLE
Return a 404 if we can't fetch an IIIF manifest

### DIFF
--- a/catalogue/webapp/pages/item.tsx
+++ b/catalogue/webapp/pages/item.tsx
@@ -409,8 +409,13 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     )?.url;
     const iiifImageLocation = getDigitalLocationOfType(work, 'iiif-image');
 
-    const manifestOrCollection =
-      iiifPresentationUrl && (await getIIIFManifest(iiifPresentationUrl));
+    let manifestOrCollection;
+    try {
+      manifestOrCollection =
+        iiifPresentationUrl && (await getIIIFManifest(iiifPresentationUrl));
+    } catch (e) {
+      return { notFound: true };
+    }
 
     if (manifestOrCollection) {
       // This happens when the main manifest is actually a Collection (manifest of manifest).


### PR DESCRIPTION
Related to https://github.com/wellcomecollection/platform/issues/5323; the underlying issue there will be fixed but we should be defensive about these things