### PR TITLE
Break tags

### DIFF
--- a/common/views/components/Tags/Tags.tsx
+++ b/common/views/components/Tags/Tags.tsx
@@ -30,8 +30,9 @@ const PartWithSeparator = styled.span.attrs({
   }),
 })<PartWithSeparatorProps>`
   &:after {
-    padding: ${props => (props.isLast ? 0 : '0 1ch')};
-    content: '${props => props.separator}';
+    display: ${props => (props.isLast ? 'none' : 'inline')};
+    content: '\u00A0${props =>
+      props.separator}\u00A0'; // non-breaking space (\u00A0) keeps characters that would otherwise break (e.g. hyphens) stuck to the preceding text
   }
 `;
 


### PR DESCRIPTION
Closes #6712

Allows tags to break onto two lines.

- Uses the `:after` to keep the separator attached to the preceding copy.
- Uses a non-breaking space before the separator to account for instances where the text would break, e.g. if the text part ended with a hyphen

__without non-breaking space__ (first item in list has break before `|` because the text ends in `-`)
![Screenshot 2021-10-07 at 12 30 53](https://user-images.githubusercontent.com/1394592/136392880-7a7cf8cc-766f-49c3-9f90-70f149618287.png)

__with non-breaking space__
![Screenshot 2021-10-07 at 12 31 10](https://user-images.githubusercontent.com/1394592/136392924-21fa6f66-c889-4d0c-ad90-3e4ead3d8551.png)


