### PR TITLE
add workType and identifiers to work page tracking

### DIFF
--- a/catalogue/webapp/pages/work.tsx
+++ b/catalogue/webapp/pages/work.tsx
@@ -67,7 +67,12 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
         globalContextData,
         pageview: {
           name: 'work',
-          properties: {},
+          // we shouldn't overload this
+          // these metrics allow us to report back on breadth of collection accessed
+          properties: {
+            workType: workResponse.workType,
+            identifiers: workResponse.identifiers,
+          },
         },
       }),
     };


### PR DESCRIPTION
Allows us to query the conversion index on features that will help us define breadth of collection accessed.

I think this work could potentially live in a [transform](https://www.elastic.co/guide/en/elasticsearch/reference/current/transforms.html) across the works/images indecies and the conversion one, but that needs exploration and time.

This will answer the immediate question of "Are people seeing the TEI works?".

 ☝️ question will be part of @taceybadgerbrook's reporting.