### PR TITLE
Modal width

### DIFF
--- a/common/views/components/Modal/Modal.tsx
+++ b/common/views/components/Modal/Modal.tsx
@@ -137,7 +137,7 @@ const BaseModalWindow = styled(Space).attrs<BaseModalProps>({
     bottom: auto;
     height: auto;
     max-height: 90vh;
-    max-width: ${props.width || `${props.theme.sizes.large}px`}
+    max-width: ${props.width || `${props.theme.sizes.large}px`};
     width: ${props.width || 'auto'};
     border-radius: ${props.theme.borderRadiusUnit}px;
 


### PR DESCRIPTION
References  #7137

Fixes the following from the above issue

- The requesting modal is too wide at the largest breakpoint, resulting in line lengths that are too long.