### PR TITLE
add initial state for sign in button

### DIFF
--- a/common/views/components/Header/DesktopSignIn.tsx
+++ b/common/views/components/Header/DesktopSignIn.tsx
@@ -23,7 +23,11 @@ const AccountA = styled(Space).attrs<AccountAProps>(props => ({
 const DesktopSignIn: FC = () => {
   const { state, user } = useUser();
 
-  return state === 'initial' ? null : (
+  return state === 'initial' || state === 'loading' ? (
+    <span className="display-none headerMedium-display-block">
+      <BorderlessLink iconLeft={userIcon} text={null} href="/account" />
+    </span>
+  ) : (
     <>
       {state === 'signedout' && (
         <>


### PR DESCRIPTION
Ref #7120
Fixes #7087

Adds an initial state to the sign in button to just be the littler person icon, which is then filled in with either the login button or initials.

This could probably use some tidy up, but there is work going on in the header that will almost definitely affect this, so we can wait till then.


https://user-images.githubusercontent.com/31692/136775721-c61acdc4-1613-49e8-99d4-c9234f3be0b9.mov

The above shows the refresh of the page.

The font bounced around on the component above due to some annoying font-loading issues I have locally.