### PR TITLE
Set @jest-environment node on server tests

### DIFF
--- a/catalogue/webapp/test/server.test.ts
+++ b/catalogue/webapp/test/server.test.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment node
+ */
 import request from 'supertest';
 import serverPromise from '../server';
 

--- a/content/webapp/test/server.test.ts
+++ b/content/webapp/test/server.test.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment node
+ */
 import request from 'supertest';
 import serverPromise from '../server';
 


### PR DESCRIPTION
Noticed [tests were breaking here](https://buildkite.com/wellcomecollection/experience/builds/4231#b501edc4-c17f-412f-8bbb-228c08ca91f2) as `window` was available. 

This makes sure we're testing in the right environment.