### PR TITLE
add tsconfig to updown and make it not a module

### DIFF
--- a/updown/package.json
+++ b/updown/package.json
@@ -1,6 +1,5 @@
 {
   "name": "updown",
-  "type": "module",
   "scripts": {
     "checks": "ts-node checks"
   },

--- a/updown/tsconfig.json
+++ b/updown/tsconfig.json
@@ -1,0 +1,11 @@
+// Generated via tsc --init
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
Makes updown not a module as it's not a module.
Adds standard `tsconfig` from `tsc --init`