### PR TITLE
skip updown build step

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -226,7 +226,7 @@
 
 - label: "deploy updown"
   branches: "main"
-  skip: "The updown deploy script doesn't currently work with updates as expected"
+  skip: "To avoid overriding manual work that is occuring"
   plugins:
     - wellcomecollection/aws-assume-role#v0.2.2:
         role: "arn:aws:iam::130871440101:role/experience-ci"


### PR DESCRIPTION
The current state of updown is that the config creates a whole load of new checks because we use `url` as an identifier.

While I update this and check that we are in a good state, I'd like to disable auto-deploying the config. 