### PR TITLE
Align request button with top of table headings

### DIFF
--- a/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
+++ b/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
@@ -34,8 +34,13 @@ type ButtonWrapperProps = {
 };
 
 const ButtonWrapper = styled.div<ButtonWrapperProps>`
+  // This transform is to align the request button
+  // with the top of the other table headings
+  transform: translateY(-1.2em);
+
   @media (max-width: ${props => props.styleChangeWidth}px) {
     margin-top: ${props => props.theme.spacingUnit * 2}px;
+    transform: translateY(0);
   }
 `;
 


### PR DESCRIPTION
Fixes #7136 

This is slightly hacky, but I don't think there's another obvious way to align the button given the table markup.

__before__
![image](https://user-images.githubusercontent.com/1394592/137753692-c8fa8b8d-af18-4abe-9890-393a965bd946.png)

__after__
![image](https://user-images.githubusercontent.com/1394592/137753471-8abbd7cf-55e0-4c1c-8f33-6c4d4c885fcd.png)
