### PR TITLE
Use webfont bold instead of browserr bold for mobile headings

### DIFF
--- a/common/views/components/StackingTable/StackingTable.jsx
+++ b/common/views/components/StackingTable/StackingTable.jsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import Space from '../styled/Space';
 import { font, classNames } from '../../../utils/classnames';
+import { fontFamilyMixin } from '../../themes/typography';
 
 const StyledTable = styled.table.attrs({
   className: classNames({
@@ -104,7 +105,7 @@ const StyledTd = styled(Space).attrs(props => ({
       display: block;
       white-space: nowrap;
       content: ${props => (props.content ? `'${props.content}'` : '')};
-      font-weight: bold;
+      ${fontFamilyMixin('hnb', true)}
     }
   }
 `;

--- a/common/views/themes/typography.ts
+++ b/common/views/themes/typography.ts
@@ -77,7 +77,12 @@ const fontSizeMixin = size => {
     .join(' ');
 };
 
-const fontFamilyMixin = (family, isFull) => {
+type FontFamily = keyof typeof fontFamilies;
+
+export const fontFamilyMixin = (
+  family: FontFamily,
+  isFull: boolean
+): string => {
   return `font-family: ${fontFamilies[family][isFull ? 'full' : 'base']}`;
 };
 


### PR DESCRIPTION
Fixes #7135

__before__
![image](https://user-images.githubusercontent.com/1394592/137880821-b6f51c8d-1037-41b7-a2c7-4bad942528fb.png)

__after__
![image](https://user-images.githubusercontent.com/1394592/137880714-7bf90740-0a36-4b58-92a3-f47dd7b31c10.png)
