### PR TITLE
use everyday types for pageview.properties

### DIFF
--- a/catalogue/webapp/pages/work.tsx
+++ b/catalogue/webapp/pages/work.tsx
@@ -73,8 +73,11 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
           // we shouldn't overload this
           // these metrics allow us to report back on breadth of collection accessed
           properties: {
-            workType: workResponse.workType,
-            identifiers: workResponse.identifiers,
+            workType: workResponse.workType.id,
+            identifiers: workResponse.identifiers.map(id => id.value),
+            identifierTypes: workResponse.identifiers.map(
+              id => id.identifierType.id
+            ),
           },
         },
       }),

--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -54,7 +54,7 @@ export type AppErrorProps = {
 
 type Pageview = {
   name: string;
-  properties: Record<string, unknown>;
+  properties: Record<string, string[] | number[] | string | number | undefined>;
 };
 
 export type WithPageview = {


### PR DESCRIPTION
Because of [the mappings set here](https://github.com/wellcomecollection/reporting/blob/main/conversion_analytics/elasticsearch/conversion_index.json#L44-L67) - we can't send object types through on the `properties` fields of the pageview.

This sets the types to reflect this and changes the objects we were trying to send through.