### PR TITLE
Ignore deployment tags on weco-deployed services

### DIFF
--- a/catalogue/terraform/provider.tf
+++ b/catalogue/terraform/provider.tf
@@ -8,6 +8,11 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::130871440101:role/experience-developer"
   }
+
+  # Ignore deployment tags on services
+  ignore_tags {
+    keys = ["deployment:label"]
+  }
 }
 
 provider "aws" {
@@ -20,6 +25,11 @@ provider "aws" {
 
   assume_role {
     role_arn = "arn:aws:iam::130871440101:role/experience-developer"
+  }
+
+  # Ignore deployment tags on services
+  ignore_tags {
+    keys = ["deployment:label"]
   }
 }
 

--- a/content/terraform/provider.tf
+++ b/content/terraform/provider.tf
@@ -8,6 +8,11 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::130871440101:role/experience-developer"
   }
+
+  # Ignore deployment tags on services
+  ignore_tags {
+    keys = ["deployment:label"]
+  }
 }
 
 provider "aws" {
@@ -20,6 +25,11 @@ provider "aws" {
 
   assume_role {
     role_arn = "arn:aws:iam::130871440101:role/experience-developer"
+  }
+
+  # Ignore deployment tags on services
+  ignore_tags {
+    keys = ["deployment:label"]
   }
 }
 

--- a/identity/terraform/provider.tf
+++ b/identity/terraform/provider.tf
@@ -31,6 +31,11 @@ provider "aws" {
   default_tags {
     tags = local.default_prod_tags
   }
+
+  # Ignore deployment tags on services
+  ignore_tags {
+    keys = ["deployment:label"]
+  }
 }
 
 provider "aws" {
@@ -44,5 +49,10 @@ provider "aws" {
 
   default_tags {
     tags = local.default_stage_tags
+  }
+
+  # Ignore deployment tags on services
+  ignore_tags {
+    keys = ["deployment:label"]
   }
 }

--- a/lighthouse/terraform/provider.tf
+++ b/lighthouse/terraform/provider.tf
@@ -4,6 +4,11 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::130871440101:role/experience-developer"
   }
+
+  # Ignore deployment tags on services
+  ignore_tags {
+    keys = ["deployment:label"]
+  }
 }
 
 provider "aws" {


### PR DESCRIPTION
We have this in other repos, without it we get unnecessary state thrash