### PR TITLE
update status when work id changes

### DIFF
--- a/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
+++ b/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
@@ -42,26 +42,29 @@ const PhysicalItems: FunctionComponent<Props> = ({
     [userState]
   );
 
-  useAbortSignalEffect(signal => {
-    const updateItemsStatus = async () => {
-      const itemsResponse = await fetch(`/api/works/items/${work.id}`, {
-        signal,
-      });
-      const items = await itemsResponse.json();
+  useAbortSignalEffect(
+    signal => {
+      const updateItemsStatus = async () => {
+        const itemsResponse = await fetch(`/api/works/items/${work.id}`, {
+          signal,
+        });
+        const items = await itemsResponse.json();
 
-      if (!isCatalogueApiError(items)) {
-        const itemsWithPhysicalLocation = items.results.filter(i =>
-          i.locations?.some(location => location.type === 'PhysicalLocation')
-        );
-        setPhysicalItems(itemsWithPhysicalLocation as PhysicalItem[]);
-      }
-      // else {
-      // tell the user something about not being able to retrieve the status of the item(s)
-      // we may find we run into 429s from our rate limiting, so worth bearing in mind that we might want to handle that as a separate case
-      // }
-    };
-    updateItemsStatus().catch(abortErrorHandler); // The items api has more up to date statuses than the catalogue api
-  }, []);
+        if (!isCatalogueApiError(items)) {
+          const itemsWithPhysicalLocation = items.results.filter(i =>
+            i.locations?.some(location => location.type === 'PhysicalLocation')
+          );
+          setPhysicalItems(itemsWithPhysicalLocation as PhysicalItem[]);
+        }
+        // else {
+        // tell the user something about not being able to retrieve the status of the item(s)
+        // we may find we run into 429s from our rate limiting, so worth bearing in mind that we might want to handle that as a separate case
+        // }
+      };
+      updateItemsStatus().catch(abortErrorHandler); // The items api has more up to date statuses than the catalogue api
+    },
+    [work.id]
+  );
 
   return (
     <ExpandableList


### PR DESCRIPTION
Fixes the following issue:

"I just wanted to report something I noticed while replying to an enquiry. A reader was having trouble requesting items from SA/FPA/CB. Some items in that archive were on hold to another reader, therefore unavailable. It looks like when somebody navigates from a file that is unavailable to a file that actually is available on Sierra, the where to find box doesn’t update. This means the request button disappears. Once one refreshes the browser, the correct information is displayed.
When going from an available item to one that is unavailable, the same happens."
