### PR TITLE
use correct fetch links for articles series

### DIFF
--- a/common/services/prismic/fetch-links.js
+++ b/common/services/prismic/fetch-links.js
@@ -82,7 +82,7 @@ export const exhibitionResourcesFields = [
   'exhibition-resources.description',
   'exhibition-resources.icon',
 ];
-export const articleSeriesFields = ['series.name', 'series.description'];
+export const articleSeriesFields = ['series.title'];
 export const articleFormatsFields = [
   'article-formats.title',
   'article-formats.description',

--- a/common/services/prismic/pages.js
+++ b/common/services/prismic/pages.js
@@ -16,6 +16,7 @@ import type { Page } from '../../model/pages';
 import type { SiblingsGroup } from '../../model/siblings-group';
 import type { PrismicDocument, PaginatedResults } from './types';
 import {
+  articleSeriesFields,
   pagesFields,
   collectionVenuesFields,
   eventSeriesFields,
@@ -99,6 +100,7 @@ export async function getPage(
     id,
     {
       fetchLinks: pagesFields.concat(
+        articleSeriesFields,
         eventSeriesFields,
         collectionVenuesFields,
         exhibitionFields,
@@ -148,6 +150,7 @@ export async function getPages(
       page,
       pageSize,
       fetchLinks: pagesFields.concat(
+        articleSeriesFields,
         eventSeriesFields,
         collectionVenuesFields,
         exhibitionFields,


### PR DESCRIPTION
`.name` is not a field, and `.description` is not used.