### PR TITLE
Verify email address

### DIFF
--- a/identity/webapp/pages/account/validated.tsx
+++ b/identity/webapp/pages/account/validated.tsx
@@ -32,7 +32,7 @@ const ValidatedPage: NextPage<Props> = ({ success, message, isNewSignUp }) => {
                   <Title>Email verified</Title>
                   <p>Thank you for verifying your email address.</p>
                   {isNewSignUp && (
-                    <>
+                    <div data-test-id="new-sign-up">
                       <p>
                         The library team will review your application and will
                         confirm your membership within the next 72 hours. In the
@@ -45,7 +45,7 @@ const ValidatedPage: NextPage<Props> = ({ success, message, isNewSignUp }) => {
                         of personal identification (ID) and proof of address to
                         the Library team in order to confirm your details.
                       </HighlightMessage>
-                    </>
+                    </div>
                   )}
                   <ButtonSolidLink link="/account" text="Sign in" />
                 </>

--- a/identity/webapp/src/frontend/Registration/AccountValidated.test.tsx
+++ b/identity/webapp/src/frontend/Registration/AccountValidated.test.tsx
@@ -14,10 +14,15 @@ const renderPage = (location: string) => {
   const url = new URL(`https://localhost:3000/${location}`);
   const success = url.searchParams.get('success') === 'true';
   const message = url.searchParams.get('message');
+  const isNewSignUp = url.searchParams.get('supportSignUp') === 'true';
 
   render(
     <ThemeProvider theme={theme}>
-      <ValidatedPage success={success} message={message} />
+      <ValidatedPage
+        success={success}
+        message={message}
+        isNewSignUp={isNewSignUp}
+      />
     </ThemeProvider>
   );
 };
@@ -47,11 +52,21 @@ describe('AccountValidated', () => {
     ).toBeInTheDocument();
   });
 
+  it('shows review process information to new users', () => {
+    renderPage('/account/validated?success=true&supportSignUp=true');
+    expect(screen.getByTestId('new-sign-up')).toBeTruthy();
+  });
+
+  it('does not show review process information to existing users', () => {
+    renderPage('/account/validated?success=true&supportSignUp=false');
+    expect(screen.queryByTestId('new-sign-up')).toBeFalsy();
+  });
+
   it('shows a link to login on success', () => {
-    renderPage('/account/validated?success=true');
+    renderPage('/account/validated?success=true&supportSignUp=true');
     const links = screen.getAllByRole('link');
     const link = links[1];
-    expect(link).toHaveTextContent('Continue to Sign in');
+    expect(link).toHaveTextContent('Sign in');
     expect(link).toHaveAttribute('href', '/account');
   });
 


### PR DESCRIPTION
Part of #7142

## Who is this for?
People who want a logical flow

## What is it doing for them?
Only showing them new user information on the validation page if they're actually a new user. People who change their email and arrive at the validation page will just see a confirmation and a link to sign in.

__new user__
![Screenshot 2021-10-27 at 17 03 40](https://user-images.githubusercontent.com/1394592/139104119-1d81f2b6-25f1-4040-afe6-e08cc4bead21.png)

__existing user after email change__
![Screenshot 2021-10-27 at 17 04 01](https://user-images.githubusercontent.com/1394592/139104095-6f4382bd-9976-403f-a177-da2f00481155.png)


