### PR TITLE
Fix the remaining requests display when the user has 0 holds

### DIFF
--- a/catalogue/webapp/components/ConfirmItemRequest/ConfirmItemRequest.tsx
+++ b/catalogue/webapp/components/ConfirmItemRequest/ConfirmItemRequest.tsx
@@ -48,17 +48,15 @@ const CTAs = styled(Space).attrs({
 const RemainingRequests: FC<{
   allowedHoldRequests: number;
   currentHoldRequests?: number;
-}> = ({ allowedHoldRequests, currentHoldRequests }) => (
-  <>
-    {currentHoldRequests && (
-      <Remaining>
-        {`${
-          allowedHoldRequests - currentHoldRequests
-        }/${allowedHoldRequests} requests remaining`}
-      </Remaining>
-    )}
-  </>
-);
+}> = ({ allowedHoldRequests, currentHoldRequests }) =>
+  typeof currentHoldRequests !== 'undefined' ? (
+    <Remaining>
+      {`${Math.max(
+        allowedHoldRequests - currentHoldRequests,
+        0
+      )}/${allowedHoldRequests} requests remaining`}
+    </Remaining>
+  ) : null;
 
 type Props = {
   work: Work;


### PR DESCRIPTION
Makes it not like this:
![image](https://user-images.githubusercontent.com/4429247/139278513-035e1544-3d2b-4f2d-b1de-3ee5565f836b.png)
