### PR TITLE
add serverData to identity account page

### DIFF
--- a/common/views/components/GlobalContextProvider/GlobalContextProvider.tsx
+++ b/common/views/components/GlobalContextProvider/GlobalContextProvider.tsx
@@ -12,7 +12,6 @@ import PopupDialogContext, {
 import { parseCollectionVenues } from '../../../services/prismic/opening-times';
 import { Toggles } from '@weco/toggles';
 import { ApmContextProvider } from '../ApmContext/ApmContext';
-import UserProvider from '../UserProvider/UserProvider';
 
 export type GlobalContextData = {
   toggles: Toggles;
@@ -51,7 +50,7 @@ const GlobalContextProvider: FunctionComponent<Props> = ({
         <OpeningTimesContext.Provider value={parsedOpeningTimes}>
           <GlobalAlertContext.Provider value={value.globalAlert}>
             <PopupDialogContext.Provider value={value.popupDialog}>
-              <UserProvider>{children}</UserProvider>
+              {children}
             </PopupDialogContext.Provider>
           </GlobalAlertContext.Provider>
         </OpeningTimesContext.Provider>

--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -19,6 +19,7 @@ import { trackPageview } from '../../services/conversion/track';
 import useIsFontsLoaded from '../../hooks/useIsFontsLoaded';
 import { isServerData, defaultServerData } from '../../server-data/types';
 import { ServerDataContext } from '../../server-data/Context';
+import UserProvider from '../components/UserProvider/UserProvider';
 
 declare global {
   interface Window {
@@ -362,25 +363,27 @@ const WecoApp: FunctionComponent<WecoAppProps> = ({
   return (
     <>
       <ServerDataContext.Provider value={serverData}>
-        <AppContextProvider>
-          <ThemeProvider theme={theme}>
-            <GlobalStyle
-              toggles={globalContextData.toggles}
-              isFontsLoaded={useIsFontsLoaded()}
-            />
-            <OutboundLinkTracker>
-              <LoadingIndicator />
-              {!pageProps.err && <Component {...pageProps} />}
-              {pageProps.err && (
-                <ErrorPage
-                  statusCode={pageProps.err.statusCode}
-                  title={pageProps.err.message}
-                  globalContextData={globalContextData}
-                />
-              )}
-            </OutboundLinkTracker>
-          </ThemeProvider>
-        </AppContextProvider>
+        <UserProvider>
+          <AppContextProvider>
+            <ThemeProvider theme={theme}>
+              <GlobalStyle
+                toggles={globalContextData.toggles}
+                isFontsLoaded={useIsFontsLoaded()}
+              />
+              <OutboundLinkTracker>
+                <LoadingIndicator />
+                {!pageProps.err && <Component {...pageProps} />}
+                {pageProps.err && (
+                  <ErrorPage
+                    statusCode={pageProps.err.statusCode}
+                    title={pageProps.err.message}
+                    globalContextData={globalContextData}
+                  />
+                )}
+              </OutboundLinkTracker>
+            </ThemeProvider>
+          </AppContextProvider>
+        </UserProvider>
       </ServerDataContext.Provider>
     </>
   );

--- a/identity/webapp/pages/_app.tsx
+++ b/identity/webapp/pages/_app.tsx
@@ -1,9 +1,7 @@
 import NextApp, { AppContext, NextWebVitalsMetric } from 'next/app';
 import { gtagReportWebVitals } from '@weco/common/utils/gtag';
 import App, { WecoAppProps } from '@weco/common/views/pages/_app';
-import GlobalContextProvider, {
-  getGlobalContextData,
-} from '@weco/common/views/components/GlobalContextProvider/GlobalContextProvider';
+
 export function reportWebVitals(metric: NextWebVitalsMetric): void {
   gtagReportWebVitals(metric);
 }
@@ -11,9 +9,16 @@ export function reportWebVitals(metric: NextWebVitalsMetric): void {
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export default function IdentityApp(props: WecoAppProps) {
   return (
-    <GlobalContextProvider value={props.globalContextData}>
-      <App {...props} />
-    </GlobalContextProvider>
+    <App
+      {...props}
+      // We can remove this once we have removed globalContextData
+      globalContextData={{
+        toggles: { enableRequestion: true },
+        globalAlert: null,
+        popupDialog: null,
+        openingTimes: null,
+      }}
+    />
   );
 }
 
@@ -29,20 +34,11 @@ export default function IdentityApp(props: WecoAppProps) {
 // application images in staging and production environments (which
 // require different prefixes).
 IdentityApp.getInitialProps = async (appContext: AppContext) => {
-  const globalContextData = getGlobalContextData(appContext.ctx);
   const initialProps = await NextApp.getInitialProps(appContext);
   // TODO don't store things like this on `ctx.query`
   delete appContext.ctx.query.memoizedPrismic; // We need to remove memoizedPrismic value here otherwise we hit circular object issues with JSON.stringify
 
   return {
     ...initialProps,
-    // This is a mega hack as toggles don't work for the identity app as it doesn't use the weird
-    // middleware we have in place on other apps that attaches them to the ctx.query.
-    // Instead of reusing this way, we'll establish a better way, and just force `enableRequesting`
-    // for now as that's required for certain identity features.
-    globalContextData: {
-      ...globalContextData,
-      toggles: { enableRequesting: true },
-    },
   };
 };

--- a/identity/webapp/pages/account.tsx
+++ b/identity/webapp/pages/account.tsx
@@ -1,6 +1,6 @@
 import React, { FC, ComponentProps, useState } from 'react';
 import Icon from '@weco/common/views/components/Icon/Icon';
-import { NextPage } from 'next';
+import { GetServerSideProps, NextPage } from 'next';
 import { ChangeDetailsModal } from '../src/frontend/MyAccount/ChangeDetailsModal';
 import { PageWrapper } from '../src/frontend/components/PageWrapper';
 import {
@@ -38,6 +38,10 @@ import { info2 } from '@weco/common/icons';
 import StackingTable from '@weco/common/views/components/StackingTable/StackingTable';
 import AlignFont from '@weco/common/views/components/styled/AlignFont';
 import { useUser } from '@weco/common/views/components/UserProvider/UserProvider';
+import { getServerData } from '@weco/common/server-data';
+import { removeUndefinedProps } from '@weco/common/utils/json';
+import { ServerData } from '@weco/common/server-data/types';
+import { AppErrorProps } from '@weco/common/views/pages/_app';
 
 type DetailProps = {
   label: string;
@@ -85,6 +89,23 @@ const AccountStatus: FC<ComponentProps<typeof StatusAlert>> = ({
     </StatusAlert>
   );
 };
+
+type Props = {
+  serverData: ServerData;
+};
+export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
+  async context => {
+    const serverData = await getServerData(context);
+
+    return {
+      props: removeUndefinedProps({
+        serverData,
+        globalContextData: {
+          toggles: { enableRequesting: true },
+        },
+      }),
+    };
+  };
 
 const AccountPage: NextPage = () => {
   const router = useRouter();

--- a/identity/webapp/src/app.ts
+++ b/identity/webapp/src/app.ts
@@ -19,12 +19,15 @@ import { config } from './config';
 import { configureAuth0 } from './utility/configure-auth0';
 import apmErrorMiddleware from '@weco/common/services/apm/errorMiddleware';
 import { ApplicationContext, ApplicationState } from './types/application';
+import { init as initServerData } from '@weco/common/server-data';
+
 /* eslint-enable @typescript-eslint/no-var-requires, import/first */
 
 export async function createApp(
   router: Router<ApplicationState, ApplicationContext>
 ): Promise<Koa> {
   const isProduction = process.env.NODE_ENV === 'production';
+  await initServerData();
 
   const nextApp = next({
     dev: !isProduction,

--- a/identity/webapp/src/frontend/MyAccount/MyAccount.test.tsx
+++ b/identity/webapp/src/frontend/MyAccount/MyAccount.test.tsx
@@ -18,6 +18,12 @@ jest.mock('../components/PageWrapper', () => ({
   PageWrapper: ({ children }) => <>{children}</>, // eslint-disable-line react/display-name
 }));
 
+jest.mock('@weco/common/server-data', () => ({
+  __esModule: true,
+  getServerData: async () =>
+    (await import('@weco/common/server-data/types')).defaultServerData,
+}));
+
 const renderComponent = () =>
   render(
     <ThemeProvider theme={theme}>

--- a/identity/webapp/src/frontend/components/PageWrapper.tsx
+++ b/identity/webapp/src/frontend/components/PageWrapper.tsx
@@ -1,9 +1,9 @@
 import { FC } from 'react';
+import Head from 'next/head';
+import styled from 'styled-components';
 import HeaderPrototype from '@weco/common/views/components/Header/HeaderPrototype';
 import { GlobalStyle } from '@weco/common/views/themes/default';
 import useIsFontsLoaded from '@weco/common/hooks/useIsFontsLoaded';
-import styled from 'styled-components';
-import Head from 'next/head';
 import Favicons from '@weco/common/views/components/Favicons/Favicons';
 
 const Main = styled.div`


### PR DESCRIPTION
* Moves UserProvider into _app, closer to removing GlobalContextData
* adds serverData to the identity app and account page
* hacks the globalContextData into identity as it's still used in _app, which I have a PR coming soon to remove