### PR TITLE
Hide close cross on delete account modal

### DIFF
--- a/identity/webapp/src/frontend/MyAccount/DeleteAccount.tsx
+++ b/identity/webapp/src/frontend/MyAccount/DeleteAccount.tsx
@@ -30,6 +30,7 @@ export const DeleteAccount: React.FC<ChangeDetailsModalContentProps> = ({
   onComplete,
   onCancel,
   isActive,
+  setIsModalLoading,
 }) => {
   const defaultValues: DeleteAccountInputs = useMemo(
     () => ({ password: '' }),
@@ -53,6 +54,10 @@ export const DeleteAccount: React.FC<ChangeDetailsModalContentProps> = ({
       onComplete();
     }
   }, [isSuccess, onComplete]);
+
+  useEffect(() => {
+    setIsModalLoading(isLoading);
+  }, [isLoading]);
 
   useEffect(() => {
     switch (error) {


### PR DESCRIPTION
Don't show a close cross on the modal for account delete (same as for other loading modals).