### PR TITLE
Don't position show/hide password absolute

### DIFF
--- a/common/views/components/TextInput/TextInput.tsx
+++ b/common/views/components/TextInput/TextInput.tsx
@@ -16,6 +16,8 @@ export const TextInputWrap = styled.div.attrs({
     'flex relative': true,
   }),
 })<TextInputWrapProps>`
+  border: 1px solid ${props => props.theme.color('pumice')};
+  border-radius: 6px;
   font-size: ${props => (props.big ? '20px' : '16px')};
 
   &:focus-within {
@@ -90,8 +92,6 @@ export const TextInputInput = styled.input.attrs(props => ({
   appearance: none;
   border: 0;
   height: 100%;
-  border: 1px solid ${props => props.theme.color('pumice')};
-  border-radius: 6px;
   font-size: inherit;
   width: 100%;
 

--- a/identity/webapp/src/frontend/components/PasswordInput/PasswordInput.style.ts
+++ b/identity/webapp/src/frontend/components/PasswordInput/PasswordInput.style.ts
@@ -3,8 +3,6 @@ import Space from '@weco/common/views/components/styled/Space';
 import { classNames, font } from '@weco/common/utils/classnames';
 
 export const ShowPasswordButton = styled.button.attrs({ type: 'button' })`
-  position: absolute;
-  right: 0;
   height: 55px;
   width: 55px;
   background: none;


### PR DESCRIPTION
Fixes #7154 

## Who is this for?
People who don't want their LastPass plugin icon to overlay the password show/hide button.

## What is it doing for them?
Moving the 'input' border and focus onto the wrapping element