### PR TITLE
add fields to webcomics to allow migration over to article parsers

### DIFF
--- a/prismic-model/src/webcomics.ts
+++ b/prismic-model/src/webcomics.ts
@@ -2,25 +2,21 @@ import title from './parts/title';
 import list from './parts/list';
 import link from './parts/link';
 import promo from './parts/promo';
-import body from './parts/body';
+import articleBody from './parts/article-body';
 import contributorsWithTitle from './parts/contributorsWithTitle';
 import structuredText from './parts/structured-text';
 
 export default {
   Webcomic: {
     title,
+    format: link('Format', 'document', ['article-formats']),
     image: {
       type: 'Image',
       config: {
         label: 'Webcomic',
       },
     },
-    body,
-  },
-  Series: {
-    series: list('Series', {
-      series: link('Series', 'document', ['webcomic-series']),
-    }),
+    body: articleBody,
   },
   Contributors: contributorsWithTitle(),
   Promo: {
@@ -28,6 +24,11 @@ export default {
   },
   Metadata: {
     metadataDescription: structuredText('Metadata description', 'single'),
+  },
+  'Content relationships': {
+    series: list('Series', {
+      series: link('Series', 'document', ['webcomic-series']),
+    }),
   },
   Deprecated: {
     publishDate: {


### PR DESCRIPTION
reference #7227 

Creates the new fields to for us to migrate the webcomics over to the article structure.