### PR TITLE
add all types to prismic models

### DIFF
--- a/prismic-model/deployType.ts
+++ b/prismic-model/deployType.ts
@@ -4,16 +4,9 @@ import * as dotenv from 'dotenv';
 import * as jsondiffpatch from 'jsondiffpatch';
 import prompts from 'prompts';
 import { error, success } from './console';
+import { CustomType } from './src/types/CustomType';
 
 dotenv.config();
-
-type PrismicCustomType = {
-  id: string;
-  label: string;
-  repeatable: boolean;
-  json: unknown;
-  status: boolean;
-};
 
 const { id, argsConfirm } = yargs(process.argv.slice(2))
   .usage('Usage: $0 --id [customTypeId]')
@@ -24,7 +17,7 @@ const { id, argsConfirm } = yargs(process.argv.slice(2))
   .parseSync();
 
 async function run() {
-  const remoteType: PrismicCustomType = await fetch(
+  const remoteType: CustomType = await fetch(
     `https://customtypes.prismic.io/customtypes/${id}`,
     {
       headers: {

--- a/prismic-model/deployType.ts
+++ b/prismic-model/deployType.ts
@@ -24,9 +24,6 @@ const { id, argsConfirm } = yargs(process.argv.slice(2))
   .parseSync();
 
 async function run() {
-  // There are things that we don't currently control in the model here, but can
-  // e.g. repeatable, label etc. For now we just replicate remote.
-  // TODO: control the data in the repo.
   const remoteType: PrismicCustomType = await fetch(
     `https://customtypes.prismic.io/customtypes/${id}`,
     {
@@ -39,15 +36,7 @@ async function run() {
 
   const localType = (await import(`./src/${id}`)).default;
 
-  const data: PrismicCustomType = {
-    id,
-    label: remoteType.label,
-    repeatable: remoteType.repeatable,
-    status: remoteType.status,
-    json: localType,
-  };
-
-  const delta = jsondiffpatch.diff(remoteType, data);
+  const delta = jsondiffpatch.diff(remoteType, localType);
   const diff = jsondiffpatch.formatters.console.format(delta, remoteType);
 
   console.info('------------------------');
@@ -74,7 +63,7 @@ async function run() {
         repository: process.env.PRISMIC_REPOSITORY,
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify(data),
+      body: JSON.stringify(localType),
     }
   );
 

--- a/prismic-model/diffCustomTypes.ts
+++ b/prismic-model/diffCustomTypes.ts
@@ -1,0 +1,43 @@
+import { CustomType } from './src/types/CustomType';
+import * as dotenv from 'dotenv';
+import * as jsondiffpatch from 'jsondiffpatch';
+import fetch from 'node-fetch';
+import { error, success } from './console';
+
+dotenv.config();
+
+async function run() {
+  const remoteCustomTypes: CustomType[] = await fetch(
+    `https://customtypes.prismic.io/customtypes`,
+    {
+      headers: {
+        Authorization: `Bearer ${process.env.PRISMIC_BEARER_TOKEN}`,
+        repository: process.env.PRISMIC_REPOSITORY,
+      },
+    }
+  ).then(resp => resp.json());
+
+  const deltas = (
+    await Promise.all(
+      remoteCustomTypes.map(async remoteCustomType => {
+        const localCustomType = (await import(`./src/${remoteCustomType.id}`))
+          .default;
+
+        const delta = jsondiffpatch.diff(remoteCustomType, localCustomType);
+
+        if (delta) {
+          return { id: remoteCustomType.id, delta };
+        }
+      })
+    )
+  ).filter(Boolean);
+
+  if (deltas.length > 0) {
+    error(`Diffs found on ${deltas.map(delta => delta.id).join(', ')}`);
+    process.exit(1);
+  }
+
+  success('No diffs found on custom types');
+}
+
+run();

--- a/prismic-model/package.json
+++ b/prismic-model/package.json
@@ -3,7 +3,8 @@
     "convertFromSrc": "ts-node convertFromSrc",
     "convertFromRemote": "ts-node convertFromRemote",
     "contentHasSlice": "ts-node contentHasSlice",
-    "deployType": "ts-node deployType"
+    "deployType": "ts-node deployType",
+    "diffCustomTypes": "ts-node diffCustomTypes"
   },
   "dependencies": {
     "@prismicio/client": "^5.1.0",

--- a/prismic-model/src/article-formats.ts
+++ b/prismic-model/src/article-formats.ts
@@ -1,4 +1,12 @@
+import { CustomType } from './types/CustomType';
 import label from './types/label';
 
-const ArticleFormat = label('Article format');
-export default ArticleFormat;
+const articleFormats: CustomType = {
+  id: 'article-formats',
+  label: 'Story format',
+  repeatable: true,
+  status: true,
+  json: label('Article format'),
+};
+
+export default articleFormats;

--- a/prismic-model/src/articles.ts
+++ b/prismic-model/src/articles.ts
@@ -7,80 +7,87 @@ import articleBody from './parts/article-body';
 import contributorsWithTitle from './parts/contributorsWithTitle';
 import singleLineText from './parts/single-line-text';
 import structuredText from './parts/structured-text';
+import { CustomType } from './types/CustomType';
 
-const Article = {
-  Article: {
-    title,
-    format: link('Format', 'document', ['article-formats']),
-    body: articleBody,
-  },
-  Outro: {
-    outroResearchItem: link('Outro: Research item'),
-    outroResearchLinkText: singleLineText('Outro: Research link text'),
-    outroReadItem: link('Outro: Read item'),
-    outroReadLinkText: singleLineText('Outro: Read link text'),
-    outroVisitItem: link('Outro: Visit item'),
-    outroVisitLinkText: singleLineText('Outro: Visit link text'),
-  },
-  Contributors: contributorsWithTitle(),
-  Promo: {
-    promo,
-  },
-  Metadata: {
-    metadataDescription: structuredText('Metadata description', 'single'),
-  },
-  'Content relationships': {
-    series: list('Series', {
-      series: link('Series', 'document', ['series']),
-      positionInSeries: number('Position in series'),
-    }),
-    seasons: list('Seasons', {
-      season: link('Season', 'document', ['seasons'], 'Select a Season'),
-    }),
-    parents: list('Parents', {
-      order: number('Order'),
-      parent: link('Parent', 'document', ['exhibitions'], 'Select a parent'),
-    }),
-  },
-  Migration: {
-    publishDate: {
-      config: {
-        label: 'Override publish date',
-      },
-      type: 'Timestamp',
+const articles: CustomType = {
+  id: 'articles',
+  label: 'Story',
+  repeatable: true,
+  status: true,
+  json: {
+    Story: {
+      title,
+      format: link('Format', 'document', ['article-formats']),
+      body: articleBody,
     },
-    wordpressSlug: {
-      config: {
-        label: 'Wordpress slug',
-      },
-      type: 'Text',
+    Outro: {
+      outroResearchItem: link('Outro: Research item'),
+      outroResearchLinkText: singleLineText('Outro: Research link text'),
+      outroReadItem: link('Outro: Read item'),
+      outroReadLinkText: singleLineText('Outro: Read link text'),
+      outroVisitItem: link('Outro: Visit item'),
+      outroVisitLinkText: singleLineText('Outro: Visit link text'),
     },
-    // TODO: deprecate
-    contributorsDeprecated: {
-      type: 'Slices',
-      fieldset: 'Contributors',
-      config: {
-        choices: {
-          person: {
-            type: 'Slice',
-            fieldset: 'Person',
-            'non-repeat': {
-              role: {
-                type: 'Link',
-                config: {
-                  label: 'Role',
-                  select: 'document',
-                  customtypes: ['editorial-contributor-roles'],
-                  tags: ['editorial'],
+    Contributors: contributorsWithTitle(),
+    Promo: {
+      promo,
+    },
+    Metadata: {
+      metadataDescription: structuredText('Metadata description', 'single'),
+    },
+    'Content relationships': {
+      series: list('Series', {
+        series: link('Series', 'document', ['series']),
+        positionInSeries: number('Position in series'),
+      }),
+      seasons: list('Seasons', {
+        season: link('Season', 'document', ['seasons'], 'Select a Season'),
+      }),
+      parents: list('Parents', {
+        order: number('Order'),
+        parent: link('Parent', 'document', ['exhibitions'], 'Select a parent'),
+      }),
+    },
+    Migration: {
+      publishDate: {
+        config: {
+          label: 'Override publish date',
+        },
+        type: 'Timestamp',
+      },
+      wordpressSlug: {
+        config: {
+          label: 'Wordpress slug',
+        },
+        type: 'Text',
+      },
+      // TODO: deprecate
+      contributorsDeprecated: {
+        type: 'Slices',
+        fieldset: 'Contributors',
+        config: {
+          choices: {
+            person: {
+              type: 'Slice',
+              fieldset: 'Person',
+              'non-repeat': {
+                role: {
+                  type: 'Link',
+                  config: {
+                    label: 'Role',
+                    select: 'document',
+                    customtypes: ['editorial-contributor-roles'],
+                    tags: ['editorial'],
+                  },
                 },
-              },
-              person: {
-                type: 'Link',
-                config: {
-                  label: 'Person',
-                  select: 'document',
-                  customtypes: ['people'],
-                  placeholder: 'Select a person…',
+                person: {
+                  type: 'Link',
+                  config: {
+                    label: 'Person',
+                    select: 'document',
+                    customtypes: ['people'],
+                    placeholder: 'Select a person…',
+                  },
                 },
               },
             },
@@ -91,4 +98,4 @@ const Article = {
   },
 };
 
-export default Article;
+export default articles;

--- a/prismic-model/src/audiences.ts
+++ b/prismic-model/src/audiences.ts
@@ -1,11 +1,18 @@
 import title from './parts/title';
 import structuredText from './parts/structured-text';
+import { CustomType } from './types/CustomType';
 
-const Audiences = {
-  Audience: {
-    title,
-    description: structuredText('Description', 'single'),
+const audiences: CustomType = {
+  id: 'audiences',
+  label: 'Audience',
+  repeatable: true,
+  status: true,
+  json: {
+    Audience: {
+      title,
+      description: structuredText('Description', 'single'),
+    },
   },
 };
 
-export default Audiences;
+export default audiences;

--- a/prismic-model/src/background-textures.ts
+++ b/prismic-model/src/background-textures.ts
@@ -1,15 +1,23 @@
-const BackgroundTexture = {
-  'Background texture': {
-    image: {
-      type: 'Image',
-    },
-    name: {
-      type: 'Text',
-      config: {
-        label: 'name',
+import { CustomType } from './types/CustomType';
+
+const backgroundTexture: CustomType = {
+  id: 'background-textures',
+  label: 'Background texture',
+  repeatable: true,
+  status: true,
+  json: {
+    'Background texture': {
+      image: {
+        type: 'Image',
+      },
+      name: {
+        type: 'Text',
+        config: {
+          label: 'name',
+        },
       },
     },
   },
 };
 
-export default BackgroundTexture;
+export default backgroundTexture;

--- a/prismic-model/src/books.ts
+++ b/prismic-model/src/books.ts
@@ -8,47 +8,54 @@ import promo from './parts/promo';
 import timestamp from './parts/timestamp';
 import contributorsWithTitle from './parts/contributorsWithTitle';
 import number from './parts/number';
+import { CustomType } from './types/CustomType';
 
-const Books = {
-  Book: {
-    title,
-    subtitle: structuredText('Subtitle', 'single'),
-    body: body,
-    orderLink: link('Order link', 'web'),
-    price: text('Price'),
-    format: text('Format'),
-    extent: text('Extent'),
-    isbn: text('ISBN'),
-    reviews: list('Reviews', {
-      text: structuredText('Review'),
-      citation: structuredText('Citation', 'single'),
-    }),
-    datePublished: timestamp('Date published'),
-  },
-  Contributors: contributorsWithTitle(),
-  Promo: {
-    promo,
-  },
-  Metadata: {
-    metadataDescription: structuredText('Metadata description', 'single'),
-  },
-  'Content relationships': {
-    seasons: list('Seasons', {
-      season: link('Season', 'document', ['seasons'], 'Select a Season'),
-    }),
-    parents: list('Parents', {
-      order: number('Order'),
-      parent: link('Parent', 'document', ['exhibitions'], 'Select a parent'),
-    }),
-  },
-  Migration: {
-    drupalPromoImage: link('Drupal promo image', 'web'),
-    drupalNid: text('Drupal node ID'),
-    drupalPath: text('Drupal path'),
-    authorName: structuredText("Author's name", 'single'),
-    authorImage: link("Author's image", 'web'),
-    authorDescription: structuredText('About the author', 'single'),
+const books: CustomType = {
+  id: 'books',
+  label: 'Book',
+  repeatable: true,
+  status: true,
+  json: {
+    Book: {
+      title,
+      subtitle: structuredText('Subtitle', 'single'),
+      body: body,
+      orderLink: link('Order link', 'web'),
+      price: text('Price'),
+      format: text('Format'),
+      extent: text('Extent'),
+      isbn: text('ISBN'),
+      reviews: list('Reviews', {
+        text: structuredText('Review'),
+        citation: structuredText('Citation', 'single'),
+      }),
+      datePublished: timestamp('Date published'),
+    },
+    Contributors: contributorsWithTitle(),
+    Promo: {
+      promo,
+    },
+    Metadata: {
+      metadataDescription: structuredText('Metadata description', 'single'),
+    },
+    'Content relationships': {
+      seasons: list('Seasons', {
+        season: link('Season', 'document', ['seasons'], 'Select a Season'),
+      }),
+      parents: list('Parents', {
+        order: number('Order'),
+        parent: link('Parent', 'document', ['exhibitions'], 'Select a parent'),
+      }),
+    },
+    Migration: {
+      drupalPromoImage: link('Drupal promo image', 'web'),
+      drupalNid: text('Drupal node ID'),
+      drupalPath: text('Drupal path'),
+      authorName: structuredText("Author's name", 'single'),
+      authorImage: link("Author's image", 'web'),
+      authorDescription: structuredText('About the author', 'single'),
+    },
   },
 };
 
-export default Books;
+export default books;

--- a/prismic-model/src/card.ts
+++ b/prismic-model/src/card.ts
@@ -2,19 +2,26 @@ import structuredText from './parts/structured-text';
 import title from './parts/title';
 import image from './parts/image';
 import link from './parts/link';
+import { CustomType } from './types/CustomType';
 
-const Cards = {
-  Card: {
-    title,
-    format: link('Format', 'document', [
-      'event-formats',
-      'article-formats',
-      'labels',
-    ]),
-    description: structuredText('Description', 'single'),
-    image: image('Image'),
-    link: link('Link'),
+const card: CustomType = {
+  id: 'card',
+  label: 'Card',
+  repeatable: true,
+  status: true,
+  json: {
+    Card: {
+      title,
+      format: link('Format', 'document', [
+        'event-formats',
+        'article-formats',
+        'labels',
+      ]),
+      description: structuredText('Description', 'single'),
+      image: image('Image'),
+      link: link('Link'),
+    },
   },
 };
 
-export default Cards;
+export default card;

--- a/prismic-model/src/collection-venue.ts
+++ b/prismic-model/src/collection-venue.ts
@@ -4,119 +4,126 @@ import select from './parts/select';
 import image from './parts/image';
 import link from './parts/link';
 import structuredText from './parts/structured-text';
+import { CustomType } from './types/CustomType';
 
-const CollectionVenue = {
-  Main: {
-    title: {
-      type: 'Text',
-      config: {
-        label: 'Title',
+const collectionVenue: CustomType = {
+  id: 'collection-venue',
+  label: 'Collection venue',
+  repeatable: true,
+  status: true,
+  json: {
+    Main: {
+      title: {
+        type: 'Text',
+        config: {
+          label: 'Title',
+        },
       },
+      order: number('Order'),
+      image: image('Image'),
+      link: link('Link', 'web', [], 'Enter url'),
+      linkText: structuredText('Linktext', 'single'),
     },
-    order: number('Order'),
-    image: image('Image'),
-    link: link('Link', 'web', [], 'Enter url'),
-    linkText: structuredText('Linktext', 'single'),
-  },
-  'Regular opening times': {
-    monday: {
-      type: 'Group',
-      fieldset: "Monday's times",
-      config: {
-        repeat: false,
-        fields: {
-          startDateTime: timestamp('Opens'),
-          endDateTime: timestamp('Closes'),
+    'Regular opening times': {
+      monday: {
+        type: 'Group',
+        fieldset: "Monday's times",
+        config: {
+          repeat: false,
+          fields: {
+            startDateTime: timestamp('Opens'),
+            endDateTime: timestamp('Closes'),
+          },
+        },
+      },
+      tuesday: {
+        type: 'Group',
+        fieldset: "Tuesday's times",
+        config: {
+          repeat: false,
+          fields: {
+            startDateTime: timestamp('Opens'),
+            endDateTime: timestamp('Closes'),
+          },
+        },
+      },
+      wednesday: {
+        type: 'Group',
+        fieldset: "Wednesday's times",
+        config: {
+          repeat: false,
+          fields: {
+            startDateTime: timestamp('Opens'),
+            endDateTime: timestamp('Closes'),
+          },
+        },
+      },
+      thursday: {
+        type: 'Group',
+        fieldset: "Thursday's times",
+        config: {
+          repeat: false,
+          fields: {
+            startDateTime: timestamp('Opens'),
+            endDateTime: timestamp('Closes'),
+          },
+        },
+      },
+      friday: {
+        type: 'Group',
+        fieldset: "Friday's times",
+        config: {
+          repeat: false,
+          fields: {
+            startDateTime: timestamp('Opens'),
+            endDateTime: timestamp('Closes'),
+          },
+        },
+      },
+      saturday: {
+        type: 'Group',
+        fieldset: "Saturday's times",
+        config: {
+          repeat: false,
+          fields: {
+            startDateTime: timestamp('Opens'),
+            endDateTime: timestamp('Closes'),
+          },
+        },
+      },
+      sunday: {
+        type: 'Group',
+        fieldset: "Sunday's times",
+        config: {
+          repeat: false,
+          fields: {
+            startDateTime: timestamp('Opens'),
+            endDateTime: timestamp('Closes'),
+          },
         },
       },
     },
-    tuesday: {
-      type: 'Group',
-      fieldset: "Tuesday's times",
-      config: {
-        repeat: false,
-        fields: {
-          startDateTime: timestamp('Opens'),
-          endDateTime: timestamp('Closes'),
-        },
-      },
-    },
-    wednesday: {
-      type: 'Group',
-      fieldset: "Wednesday's times",
-      config: {
-        repeat: false,
-        fields: {
-          startDateTime: timestamp('Opens'),
-          endDateTime: timestamp('Closes'),
-        },
-      },
-    },
-    thursday: {
-      type: 'Group',
-      fieldset: "Thursday's times",
-      config: {
-        repeat: false,
-        fields: {
-          startDateTime: timestamp('Opens'),
-          endDateTime: timestamp('Closes'),
-        },
-      },
-    },
-    friday: {
-      type: 'Group',
-      fieldset: "Friday's times",
-      config: {
-        repeat: false,
-        fields: {
-          startDateTime: timestamp('Opens'),
-          endDateTime: timestamp('Closes'),
-        },
-      },
-    },
-    saturday: {
-      type: 'Group',
-      fieldset: "Saturday's times",
-      config: {
-        repeat: false,
-        fields: {
-          startDateTime: timestamp('Opens'),
-          endDateTime: timestamp('Closes'),
-        },
-      },
-    },
-    sunday: {
-      type: 'Group',
-      fieldset: "Sunday's times",
-      config: {
-        repeat: false,
-        fields: {
-          startDateTime: timestamp('Opens'),
-          endDateTime: timestamp('Closes'),
-        },
-      },
-    },
-  },
-  'Modified opening times': {
-    modifiedDayOpeningTimes: {
-      type: 'Group',
-      fieldset: 'Modified day opening times',
-      config: {
-        fields: {
-          overrideDate: timestamp('Override date'),
-          type: select('Override type', [
-            'Bank holiday',
-            'Easter',
-            'Christmas and New Year',
-            'Late Spectacular',
-            'other',
-          ]),
-          startDateTime: timestamp('Opens'),
-          endDateTime: timestamp('Closes'),
+    'Modified opening times': {
+      modifiedDayOpeningTimes: {
+        type: 'Group',
+        fieldset: 'Modified day opening times',
+        config: {
+          fields: {
+            overrideDate: timestamp('Override date'),
+            type: select('Override type', [
+              'Bank holiday',
+              'Easter',
+              'Christmas and New Year',
+              'Late Spectacular',
+              'other',
+            ]),
+            startDateTime: timestamp('Opens'),
+            endDateTime: timestamp('Closes'),
+          },
         },
       },
     },
   },
 };
 
-export default CollectionVenue;
+export default collectionVenue;

--- a/prismic-model/src/curated-lists.ts
+++ b/prismic-model/src/curated-lists.ts
@@ -1,83 +1,91 @@
-const CuratedLists = {
-  'Curated list': {
-    uid: {
-      type: 'UID',
-      config: {
-        label: 'uid',
+import { CustomType } from './types/CustomType';
+
+const curatedLists: CustomType = {
+  id: 'curated-lists',
+  label: 'Curated list',
+  repeatable: true,
+  status: true,
+  json: {
+    'Curated list': {
+      uid: {
+        type: 'UID',
+        config: {
+          label: 'uid',
+        },
       },
-    },
-    title: {
-      type: 'StructuredText',
-      config: {
-        label: 'Title',
-        single: 'paragraph',
-        useAsTitle: true,
+      title: {
+        type: 'StructuredText',
+        config: {
+          label: 'Title',
+          single: 'paragraph',
+          useAsTitle: true,
+        },
       },
-    },
-    description: {
-      type: 'StructuredText',
-      config: {
-        label: 'Description',
-        multi: 'paragraph,em,strong,hyperlink',
+      description: {
+        type: 'StructuredText',
+        config: {
+          label: 'Description',
+          multi: 'paragraph,em,strong,hyperlink',
+        },
       },
-    },
-    body: {
-      type: 'Slices',
-      fieldset: 'Section',
-      config: {
-        choices: {
-          contentList: {
-            type: 'Slice',
-            fieldset: 'Content List',
-            description: 'A list of content',
-            icon: 'face',
-            display: 'list',
-            'non-repeat': {
-              title: {
-                type: 'StructuredText',
-                config: {
-                  single: 'heading1',
-                  label: 'Title',
+      body: {
+        type: 'Slices',
+        fieldset: 'Section',
+        config: {
+          choices: {
+            contentList: {
+              type: 'Slice',
+              fieldset: 'Content List',
+              description: 'A list of content',
+              icon: 'face',
+              display: 'list',
+              'non-repeat': {
+                title: {
+                  type: 'StructuredText',
+                  config: {
+                    single: 'heading1',
+                    label: 'Title',
+                  },
+                },
+              },
+              repeat: {
+                content: {
+                  type: 'Link',
+                  config: {
+                    select: 'document',
+                    customtypes: [
+                      'articles',
+                      'webcomics',
+                      'series',
+                      'webcomic-series',
+                    ],
+                    label: 'Content',
+                  },
                 },
               },
             },
-            repeat: {
-              content: {
-                type: 'Link',
-                config: {
-                  select: 'document',
-                  customtypes: [
-                    'articles',
-                    'webcomics',
-                    'series',
-                    'webcomic-series',
-                  ],
-                  label: 'Content',
+            stories: {
+              type: 'Slice',
+              fieldset: 'Stories',
+              description: 'Stories - newest to oldest',
+              icon: 'face',
+              display: 'list',
+              'non-repeat': {
+                title: {
+                  type: 'StructuredText',
+                  config: {
+                    single: 'heading1',
+                    label: 'Title',
+                  },
                 },
               },
-            },
-          },
-          stories: {
-            type: 'Slice',
-            fieldset: 'Stories',
-            description: 'Stories - newest to oldest',
-            icon: 'face',
-            display: 'list',
-            'non-repeat': {
-              title: {
-                type: 'StructuredText',
-                config: {
-                  single: 'heading1',
-                  label: 'Title',
-                },
-              },
-            },
-            repeat: {
-              text: {
-                type: 'StructuredText',
-                config: {
-                  single: 'heading1',
-                  label: 'text',
+              repeat: {
+                text: {
+                  type: 'StructuredText',
+                  config: {
+                    single: 'heading1',
+                    label: 'text',
+                  },
                 },
               },
             },
@@ -88,4 +96,4 @@ const CuratedLists = {
   },
 };
 
-export default CuratedLists;
+export default curatedLists;

--- a/prismic-model/src/editorial-contributor-roles.ts
+++ b/prismic-model/src/editorial-contributor-roles.ts
@@ -1,11 +1,18 @@
 import structuredText from './parts/structured-text';
 import text from './parts/text';
+import { CustomType } from './types/CustomType';
 
-const ContributorRoles = {
-  Contributor: {
-    title: structuredText('Title', 'single', ['heading1']),
-    describedBy: text('Word to describe output of the role'),
+const editorialContributorRoles: CustomType = {
+  id: 'editorial-contributor-roles',
+  label: 'Contributor role',
+  repeatable: true,
+  status: true,
+  json: {
+    Contributor: {
+      title: structuredText('Title', 'single', ['heading1']),
+      describedBy: text('Word to describe output of the role'),
+    },
   },
 };
 
-export default ContributorRoles;
+export default editorialContributorRoles;

--- a/prismic-model/src/event-formats.ts
+++ b/prismic-model/src/event-formats.ts
@@ -1,4 +1,12 @@
+import { CustomType } from './types/CustomType';
 import label from './types/label';
 
-const EventFormats = label('Event format');
-export default EventFormats;
+const eventFormats: CustomType = {
+  id: 'event-formats',
+  label: 'Event format',
+  repeatable: true,
+  status: true,
+  json: label('Event format'),
+};
+
+export default eventFormats;

--- a/prismic-model/src/event-policies.ts
+++ b/prismic-model/src/event-policies.ts
@@ -1,4 +1,12 @@
+import { CustomType } from './types/CustomType';
 import label from './types/label';
 
-const EventPolicies = label('Event policy');
-export default EventPolicies;
+const eventPolicies: CustomType = {
+  id: 'event-policies',
+  label: 'Event policy',
+  repeatable: true,
+  status: true,
+  json: label('Event policy'),
+};
+
+export default eventPolicies;

--- a/prismic-model/src/event-series.ts
+++ b/prismic-model/src/event-series.ts
@@ -4,22 +4,29 @@ import body from './parts/body';
 import contributorsWithTitle from './parts/contributorsWithTitle';
 import link from './parts/link';
 import structuredText from './parts/structured-text';
+import { CustomType } from './types/CustomType';
 
-const EventSeries = {
-  'Event series': {
-    title,
-    backgroundTexture: link('Background texture', 'document', [
-      'background-textures',
-    ]),
-    body,
-  },
-  Contributors: contributorsWithTitle(),
-  Promo: {
-    promo,
-  },
-  Metadata: {
-    metadataDescription: structuredText('Metadata description', 'single'),
+const eventSeries: CustomType = {
+  id: 'event-series',
+  label: 'Event series',
+  repeatable: true,
+  status: true,
+  json: {
+    'Event series': {
+      title,
+      backgroundTexture: link('Background texture', 'document', [
+        'background-textures',
+      ]),
+      body,
+    },
+    Contributors: contributorsWithTitle(),
+    Promo: {
+      promo,
+    },
+    Metadata: {
+      metadataDescription: structuredText('Metadata description', 'single'),
+    },
   },
 };
 
-export default EventSeries;
+export default eventSeries;

--- a/prismic-model/src/events.ts
+++ b/prismic-model/src/events.ts
@@ -12,83 +12,90 @@ import contributorsWithTitle from './parts/contributorsWithTitle';
 import body from './parts/body';
 import boolean from './parts/boolean';
 import number from './parts/number';
+import { CustomType } from './types/CustomType';
 
-const Events = {
-  Event: {
-    title,
-    format: link('Format', 'document', ['event-formats']),
-    place: place,
-    isOnline: boolean('Happens Online?', false),
-    availableOnline: boolean('Available Online?', false),
-    times: list('Times', {
-      startDateTime: timestamp('Start'),
-      endDateTime: timestamp('End'),
-      isFullyBooked: booleanDeprecated('Fully booked'),
-    }),
-    body,
-  },
-  Access: {
-    isRelaxedPerformance: booleanDeprecated('Relaxed'),
-    interpretations: list('Interpretations', {
-      interpretationType: link('Interpretation', 'document', [
-        'interpretation-types',
+const events: CustomType = {
+  id: 'events',
+  label: 'Event',
+  repeatable: true,
+  status: true,
+  json: {
+    Event: {
+      title,
+      format: link('Format', 'document', ['event-formats']),
+      place: place,
+      isOnline: boolean('Happens Online?', false),
+      availableOnline: boolean('Available Online?', false),
+      times: list('Times', {
+        startDateTime: timestamp('Start'),
+        endDateTime: timestamp('End'),
+        isFullyBooked: booleanDeprecated('Fully booked'),
+      }),
+      body,
+    },
+    Access: {
+      isRelaxedPerformance: booleanDeprecated('Relaxed'),
+      interpretations: list('Interpretations', {
+        interpretationType: link('Interpretation', 'document', [
+          'interpretation-types',
+        ]),
+        isPrimary: booleanDeprecated('Primary interprtation'),
+        extraInformation: structuredText('Extra information'),
+      }),
+      audiences: list('Audiences', {
+        audience: link('Audience', 'document', ['audiences']),
+      }),
+    },
+    Reservation: {
+      ticketSalesStart: timestamp('Ticket sales start'),
+      bookingEnquiryTeam: link('Booking enquiry team', 'document', ['teams']),
+      eventbriteEvent: embed('Eventbrite event'),
+      // This is what it was labelled on the UI,
+      // so that's what we're calling it here
+      thirdPartyBookingName: text('Third party booking name'),
+      thirdPartyBookingUrl: link('Third party booking url', 'web'),
+      bookingInformation: structuredText('Extra information'),
+      policies: list('Policies', {
+        policy: link('Policy', 'document', ['event-policies']),
+      }),
+      hasEarlyRegistration: booleanDeprecated('Early registration'),
+      cost: text('Cost'),
+    },
+    Schedule: {
+      schedule: list('Events', {
+        event: link('Event', 'document', ['events']),
+        isNotLinked: booleanDeprecated('Suppress link to event'),
+      }),
+      backgroundTexture: link('Background texture', 'document', [
+        'background-textures',
       ]),
-      isPrimary: booleanDeprecated('Primary interprtation'),
-      extraInformation: structuredText('Extra information'),
-    }),
-    audiences: list('Audiences', {
-      audience: link('Audience', 'document', ['audiences']),
-    }),
-  },
-  Reservation: {
-    ticketSalesStart: timestamp('Ticket sales start'),
-    bookingEnquiryTeam: link('Booking enquiry team', 'document', ['teams']),
-    eventbriteEvent: embed('Eventbrite event'),
-    // This is what it was labelled on the UI,
-    // so that's what we're calling it here
-    thirdPartyBookingName: text('Third party booking name'),
-    thirdPartyBookingUrl: link('Third party booking url', 'web'),
-    bookingInformation: structuredText('Extra information'),
-    policies: list('Policies', {
-      policy: link('Policy', 'document', ['event-policies']),
-    }),
-    hasEarlyRegistration: booleanDeprecated('Early registration'),
-    cost: text('Cost'),
-  },
-  Schedule: {
-    schedule: list('Events', {
-      event: link('Event', 'document', ['events']),
-      isNotLinked: booleanDeprecated('Suppress link to event'),
-    }),
-    backgroundTexture: link('Background texture', 'document', [
-      'background-textures',
-    ]),
-  },
-  Contributors: contributorsWithTitle(),
-  Promo: {
-    promo,
-  },
-  Metadata: {
-    metadataDescription: structuredText('Metadata description', 'single'),
-  },
-  'Content relationships': {
-    series: list('Event series', {
-      series: link('Series', 'document', ['event-series']),
-    }),
-    seasons: list('Seasons', {
-      season: link('Season', 'document', ['seasons'], 'Select a Season'),
-    }),
-    parents: list('Parents', {
-      order: number('Order'),
-      parent: link('Parent', 'document', ['exhibitions'], 'Select a parent'),
-    }),
-  },
-  Deprecated: {
-    description: structuredText('Description', 'multi', [
-      'heading2',
-      'list-item',
-    ]),
+    },
+    Contributors: contributorsWithTitle(),
+    Promo: {
+      promo,
+    },
+    Metadata: {
+      metadataDescription: structuredText('Metadata description', 'single'),
+    },
+    'Content relationships': {
+      series: list('Event series', {
+        series: link('Series', 'document', ['event-series']),
+      }),
+      seasons: list('Seasons', {
+        season: link('Season', 'document', ['seasons'], 'Select a Season'),
+      }),
+      parents: list('Parents', {
+        order: number('Order'),
+        parent: link('Parent', 'document', ['exhibitions'], 'Select a parent'),
+      }),
+    },
+    Deprecated: {
+      description: structuredText('Description', 'multi', [
+        'heading2',
+        'list-item',
+      ]),
+    },
   },
 };
 
-export default Events;
+export default events;

--- a/prismic-model/src/exhibition-formats.ts
+++ b/prismic-model/src/exhibition-formats.ts
@@ -1,4 +1,12 @@
+import { CustomType } from './types/CustomType';
 import label from './types/label';
 
-const ExhibitionFormats = label('Exhibition format');
-export default ExhibitionFormats;
+const exhibitionFormats: CustomType = {
+  id: 'exhibition-formats',
+  label: 'Exhibition format',
+  repeatable: true,
+  status: true,
+  json: label('Exhibition format'),
+};
+
+export default exhibitionFormats;

--- a/prismic-model/src/exhibition-resources.ts
+++ b/prismic-model/src/exhibition-resources.ts
@@ -1,12 +1,19 @@
 import label from './types/label';
 import select from './parts/select';
+import { CustomType } from './types/CustomType';
 
 const typeLabel = 'Exhibition resource';
 const labelObject = label(typeLabel);
-const exhibitionResources = {
-  [typeLabel]: {
-    ...labelObject[typeLabel],
-    icon: select('Icon type', ['information', 'family']),
+const exhibitionResources: CustomType = {
+  id: 'exhibition-resources',
+  label: typeLabel,
+  repeatable: true,
+  status: true,
+  json: {
+    [typeLabel]: {
+      ...labelObject[typeLabel],
+      icon: select('Icon type', ['information', 'family']),
+    },
   },
 };
 

--- a/prismic-model/src/exhibitions.ts
+++ b/prismic-model/src/exhibitions.ts
@@ -12,118 +12,125 @@ import body from './parts/body';
 import booleanDeprecated from './parts/boolean-deprecated';
 import singleLineText from './parts/single-line-text';
 import number from './parts/number';
+import { CustomType } from './types/CustomType';
 
-const Exhibitions = {
-  Exhibition: {
-    format: link('Format', 'document', ['exhibition-formats']),
-    title,
-    shortTitle: singleLineText('Short title', 'heading1'),
-    body,
-    start: timestamp('Start date'),
-    end: timestamp('End date'),
-    isPermanent: booleanDeprecated('Is permanent?'),
-    statusOverride: structuredText('Status override', 'single'),
-    place,
-  },
-  'In this exhibition': {
-    exhibits: list('Exhibits', {
-      item: link('Exhibit', 'document', ['exhibitions']),
-    }),
-    events: list('Gallery tours', {
-      item: link('Gallery tour', 'document', ['events']),
-    }),
-  },
-  'About this exhibition': {
-    articles: list('Articles', {
-      item: link('Article', 'document', ['articles']),
-    }),
-  },
-  Resources: {
-    resources: list('Resources', {
-      resource: link('Resource', 'document', ['exhibition-resources']),
-    }),
-  },
-  Contributors: contributorsWithTitle(),
-  Promo: {
-    promo,
-  },
-  Metadata: {
-    metadataDescription: structuredText('Metadata description', 'single'),
-  },
-  'Content relationships': {
-    seasons: list('Seasons', {
-      season: link('Season', 'document', ['seasons'], 'Select a Season'),
-    }),
-    parents: list('Parents', {
-      order: number('Order'),
-      parent: link('Parent', 'document', ['exhibitions'], 'Select a parent'),
-    }),
-  },
-  Migration: {
-    drupalPromoImage: link('Drupal promo image', 'web'),
-    drupalNid: text('Drupal node ID'),
-    drupalPath: text('Drupal path'),
-  },
-  Deprecated: {
-    description,
-    intro: {
-      type: 'StructuredText',
-      config: {
-        label: 'Intro',
-        multi: 'heading2',
-      },
+const exhibitions: CustomType = {
+  id: 'exhibitions',
+  label: 'Exhibition',
+  repeatable: true,
+  status: true,
+  json: {
+    Exhibition: {
+      format: link('Format', 'document', ['exhibition-formats']),
+      title,
+      shortTitle: singleLineText('Short title', 'heading1'),
+      body,
+      start: timestamp('Start date'),
+      end: timestamp('End date'),
+      isPermanent: booleanDeprecated('Is permanent?'),
+      statusOverride: structuredText('Status override', 'single'),
+      place,
     },
-    textAndCaptionsDocument: link('Text and captions document', 'media'),
-    promoList: {
-      type: 'Group',
-      config: {
-        label: 'Related Promos',
-        fields: {
-          image: {
-            type: 'Image',
-            config: {
-              label: 'Image',
-              thumbnails: [
-                {
-                  name: '16:9',
-                  width: 3200,
-                  height: 1800,
-                },
-                {
-                  name: 'square',
-                  width: 3200,
-                  height: 3200,
-                },
-              ],
+    'In this exhibition': {
+      exhibits: list('Exhibits', {
+        item: link('Exhibit', 'document', ['exhibitions']),
+      }),
+      events: list('Gallery tours', {
+        item: link('Gallery tour', 'document', ['events']),
+      }),
+    },
+    'About this exhibition': {
+      articles: list('Articles', {
+        item: link('Article', 'document', ['articles']),
+      }),
+    },
+    Resources: {
+      resources: list('Resources', {
+        resource: link('Resource', 'document', ['exhibition-resources']),
+      }),
+    },
+    Contributors: contributorsWithTitle(),
+    Promo: {
+      promo,
+    },
+    Metadata: {
+      metadataDescription: structuredText('Metadata description', 'single'),
+    },
+    'Content relationships': {
+      seasons: list('Seasons', {
+        season: link('Season', 'document', ['seasons'], 'Select a Season'),
+      }),
+      parents: list('Parents', {
+        order: number('Order'),
+        parent: link('Parent', 'document', ['exhibitions'], 'Select a parent'),
+      }),
+    },
+    Migration: {
+      drupalPromoImage: link('Drupal promo image', 'web'),
+      drupalNid: text('Drupal node ID'),
+      drupalPath: text('Drupal path'),
+    },
+    Deprecated: {
+      description,
+      intro: {
+        type: 'StructuredText',
+        config: {
+          label: 'Intro',
+          multi: 'heading2',
+        },
+      },
+      textAndCaptionsDocument: link('Text and captions document', 'media'),
+      promoList: {
+        type: 'Group',
+        config: {
+          label: 'Related Promos',
+          fields: {
+            image: {
+              type: 'Image',
+              config: {
+                label: 'Image',
+                thumbnails: [
+                  {
+                    name: '16:9',
+                    width: 3200,
+                    height: 1800,
+                  },
+                  {
+                    name: 'square',
+                    width: 3200,
+                    height: 3200,
+                  },
+                ],
+              },
             },
-          },
-          type: {
-            type: 'Select',
-            config: {
-              label: 'Type',
-              options: ['gallery', 'book', 'event', 'article'],
+            type: {
+              type: 'Select',
+              config: {
+                label: 'Type',
+                options: ['gallery', 'book', 'event', 'article'],
+              },
             },
-          },
-          title: {
-            type: 'StructuredText',
-            config: {
-              single: 'heading3',
-              label: 'Title',
+            title: {
+              type: 'StructuredText',
+              config: {
+                single: 'heading3',
+                label: 'Title',
+              },
             },
-          },
-          description: {
-            type: 'StructuredText',
-            config: {
-              single: 'paragraph',
-              label: 'Description',
+            description: {
+              type: 'StructuredText',
+              config: {
+                single: 'paragraph',
+                label: 'Description',
+              },
             },
-          },
-          link: {
-            config: {
-              label: 'Link',
-              select: 'web',
+            link: {
+              config: {
+                label: 'Link',
+                select: 'web',
+              },
+              type: 'Link',
             },
-            type: 'Link',
           },
         },
       },
@@ -131,4 +138,4 @@ const Exhibitions = {
   },
 };
 
-export default Exhibitions;
+export default exhibitions;

--- a/prismic-model/src/global-alert.ts
+++ b/prismic-model/src/global-alert.ts
@@ -1,16 +1,23 @@
 import structuredText from './parts/structured-text';
 import select from './parts/select';
 import text from './parts/text';
+import { CustomType } from './types/CustomType';
 
-const GlobalAlert = {
-  'Global alert': {
-    text: structuredText('text', 'multi', ['heading2'], 'text'),
-    isShown: select('Display', ['hide', 'show'], 'hide', 'Show or hide'),
-    routeRegex: text(
-      'Write a pipe-separated (|) list of page paths here if you only want the alert to display on certain pages. Leave empty if you want the alert to appear on all pages.',
-      'path(s) to match'
-    ),
+const globalAlert: CustomType = {
+  id: 'global-alert',
+  label: 'Global alert',
+  repeatable: false,
+  status: true,
+  json: {
+    'Global alert': {
+      text: structuredText('text', 'multi', ['heading2'], 'text'),
+      isShown: select('Display', ['hide', 'show'], 'hide', 'Show or hide'),
+      routeRegex: text(
+        'Write a pipe-separated (|) list of page paths here if you only want the alert to display on certain pages. Leave empty if you want the alert to appear on all pages.',
+        'path(s) to match'
+      ),
+    },
   },
 };
 
-export default GlobalAlert;
+export default globalAlert;

--- a/prismic-model/src/guide-formats.ts
+++ b/prismic-model/src/guide-formats.ts
@@ -1,4 +1,12 @@
+import { CustomType } from './types/CustomType';
 import label from './types/label';
 
-const GuideFormat = label('Guide format');
-export default GuideFormat;
+const guideFormat: CustomType = {
+  id: 'guide-formats',
+  label: 'Guide format',
+  repeatable: true,
+  status: true,
+  json: label('Guide format'),
+};
+
+export default guideFormat;

--- a/prismic-model/src/guides.ts
+++ b/prismic-model/src/guides.ts
@@ -5,24 +5,31 @@ import link from './parts/link';
 import timestamp from './parts/timestamp';
 import structuredText from './parts/structured-text';
 import boolean from './parts/boolean';
+import { CustomType } from './types/CustomType';
 
-const Guide = {
-  Guide: {
-    title,
-    format: link('Format', 'document', ['guide-formats']),
-    datePublished: timestamp('Date published'),
-    showOnThisPage: boolean(
-      "Show 'On this page' anchor links. This will only appear if there are more than 2 H2s in the body",
-      false
-    ),
-    body,
-  },
-  Promo: {
-    promo,
-  },
-  Metadata: {
-    metadataDescription: structuredText('Metadata description', 'single'),
+const guides: CustomType = {
+  id: 'guides',
+  label: 'Guide',
+  repeatable: true,
+  status: true,
+  json: {
+    Guide: {
+      title,
+      format: link('Format', 'document', ['guide-formats']),
+      datePublished: timestamp('Date published'),
+      showOnThisPage: boolean(
+        "Show 'On this page' anchor links. This will only appear if there are more than 2 H2s in the body",
+        false
+      ),
+      body,
+    },
+    Promo: {
+      promo,
+    },
+    Metadata: {
+      metadataDescription: structuredText('Metadata description', 'single'),
+    },
   },
 };
 
-export default Guide;
+export default guides;

--- a/prismic-model/src/interpretation-types.ts
+++ b/prismic-model/src/interpretation-types.ts
@@ -1,20 +1,27 @@
 import title from './parts/title';
 import structuredText from './parts/structured-text';
+import { CustomType } from './types/CustomType';
 
-const Interpretations = {
-  Interpretation: {
-    title,
-    // TODO: This should be a Key text field
-    // see: https://prismic.io/docs/core-concepts/key-text
-    abbreviation: structuredText('Abbreviation', 'single', [], undefined, [
-      'paragraph',
-    ]),
-    description: structuredText('Message'),
-    primaryDescription: structuredText(
-      'Message if primary interpretation',
-      'multi'
-    ),
+const interpretationTypes: CustomType = {
+  id: 'interpretation-types',
+  label: 'Interpretation type',
+  repeatable: true,
+  status: true,
+  json: {
+    'Interpretation type': {
+      title,
+      // TODO: This should be a Key text field
+      // see: https://prismic.io/docs/core-concepts/key-text
+      abbreviation: structuredText('Abbreviation', 'single', [], undefined, [
+        'paragraph',
+      ]),
+      description: structuredText('Message'),
+      primaryDescription: structuredText(
+        'Message if primary interpretation',
+        'multi'
+      ),
+    },
   },
 };
 
-export default Interpretations;
+export default interpretationTypes;

--- a/prismic-model/src/labels.ts
+++ b/prismic-model/src/labels.ts
@@ -1,4 +1,12 @@
+import { CustomType } from './types/CustomType';
 import label from './types/label';
 
-const Label = label('Label');
-export default Label;
+const labels: CustomType = {
+  id: 'labels',
+  label: 'Label',
+  repeatable: true,
+  status: true,
+  json: label('Label'),
+};
+
+export default labels;

--- a/prismic-model/src/organisations.ts
+++ b/prismic-model/src/organisations.ts
@@ -4,16 +4,25 @@ import image from './parts/image';
 import list from './parts/list';
 import title from './parts/title';
 import heading from './parts/heading';
+import { CustomType } from './types/CustomType';
 
-export default {
-  Organisation: {
-    name: title,
-    description: description,
-    image: image('Image'),
-    sameAs: list('Same as', {
-      link: text('Link'),
-      title: heading('Title (override)'),
-    }),
-    url: text('URL (deprecated)'),
+const organisations: CustomType = {
+  id: 'organisations',
+  label: 'Organisation',
+  repeatable: true,
+  status: true,
+  json: {
+    Organisation: {
+      name: title,
+      description: description,
+      image: image('Image'),
+      sameAs: list('Same as', {
+        link: text('Link'),
+        title: heading('Title (override)'),
+      }),
+      url: text('URL (deprecated)'),
+    },
   },
 };
+
+export default organisations;

--- a/prismic-model/src/page-formats.ts
+++ b/prismic-model/src/page-formats.ts
@@ -1,4 +1,12 @@
+import { CustomType } from './types/CustomType';
 import label from './types/label';
 
-const PageFormat = label('Page format');
-export default PageFormat;
+const pageFormats: CustomType = {
+  id: 'page-formats',
+  label: 'Page format',
+  repeatable: true,
+  status: true,
+  json: label('Page format'),
+};
+
+export default pageFormats;

--- a/prismic-model/src/pages.ts
+++ b/prismic-model/src/pages.ts
@@ -9,45 +9,52 @@ import structuredText from './parts/structured-text';
 import number from './parts/number';
 import boolean from './parts/boolean';
 import contributorsWithTitle from './parts/contributorsWithTitle';
+import { CustomType } from './types/CustomType';
 
-const Page = {
-  Page: {
-    title,
-    format: link('Format', 'document', ['page-formats']),
-    datePublished: timestamp('Date published'),
-    showOnThisPage: boolean(
-      "Show 'On this page' anchor links. This will only appear if there are more than 2 H2s in the body",
-      false
-    ),
-    body,
-  },
-  Promo: {
-    promo,
-  },
-  Metadata: {
-    metadataDescription: structuredText('Metadata description', 'single'),
-  },
-  'Content relationships': {
-    seasons: list('Seasons', {
-      season: link('Season', 'document', ['seasons'], 'Select a Season'),
-    }),
-    parents: list('Parent pages', {
-      order: number('Order'),
-      parent: link(
-        'Parent page',
-        'document',
-        ['pages', 'exhibitions'],
-        'Select a parent page'
+const pages: CustomType = {
+  id: 'pages',
+  label: 'Page',
+  repeatable: true,
+  status: true,
+  json: {
+    Page: {
+      title,
+      format: link('Format', 'document', ['page-formats']),
+      datePublished: timestamp('Date published'),
+      showOnThisPage: boolean(
+        "Show 'On this page' anchor links. This will only appear if there are more than 2 H2s in the body",
+        false
       ),
-    }),
-  },
-  Contributors: contributorsWithTitle(),
-  // TODO: (drupal migration) Remove this
-  Migration: {
-    drupalPromoImage: link('Drupal promo image', 'web'),
-    drupalNid: text('Drupal node ID'),
-    drupalPath: text('Drupal path'),
+      body,
+    },
+    Promo: {
+      promo,
+    },
+    Metadata: {
+      metadataDescription: structuredText('Metadata description', 'single'),
+    },
+    'Content relationships': {
+      seasons: list('Seasons', {
+        season: link('Season', 'document', ['seasons'], 'Select a Season'),
+      }),
+      parents: list('Parent pages', {
+        order: number('Order'),
+        parent: link(
+          'Parent page',
+          'document',
+          ['pages', 'exhibitions'],
+          'Select a parent page'
+        ),
+      }),
+    },
+    Contributors: contributorsWithTitle(),
+    // TODO: (drupal migration) Remove this
+    Migration: {
+      drupalPromoImage: link('Drupal promo image', 'web'),
+      drupalNid: text('Drupal node ID'),
+      drupalPath: text('Drupal path'),
+    },
   },
 };
 
-export default Page;
+export default pages;

--- a/prismic-model/src/people.ts
+++ b/prismic-model/src/people.ts
@@ -3,16 +3,25 @@ import description from './parts/description';
 import image from './parts/image';
 import list from './parts/list';
 import structuredText from './parts/structured-text';
+import { CustomType } from './types/CustomType';
 
-export default {
-  Person: {
-    name: text('Full name'),
-    description: description,
-    pronouns: text('Pronouns'),
-    image: image('Image'),
-    sameAs: list('Same as', {
-      link: text('Link'),
-      title: structuredText('Link text', 'single'),
-    }),
+const people: CustomType = {
+  id: 'people',
+  label: 'Person',
+  repeatable: true,
+  status: true,
+  json: {
+    Person: {
+      name: text('Full name'),
+      description: description,
+      pronouns: text('Pronouns'),
+      image: image('Image'),
+      sameAs: list('Same as', {
+        link: text('Link'),
+        title: structuredText('Link text', 'single'),
+      }),
+    },
   },
 };
+
+export default people;

--- a/prismic-model/src/places.ts
+++ b/prismic-model/src/places.ts
@@ -3,16 +3,23 @@ import geolocation from './parts/geolocation';
 import number from './parts/number';
 import body from './parts/body';
 import structuredText from './parts/structured-text';
+import { CustomType } from './types/CustomType';
 
-const Place = {
-  Place: {
-    title,
-    geolocation: geolocation(),
-    level: number('Level'),
-    capacity: number('Capacity'),
-    locationInformation: structuredText('Location information'),
-    body,
+const places: CustomType = {
+  id: 'places',
+  label: 'Place',
+  repeatable: true,
+  status: true,
+  json: {
+    Place: {
+      title,
+      geolocation: geolocation(),
+      level: number('Level'),
+      capacity: number('Capacity'),
+      locationInformation: structuredText('Location information'),
+      body,
+    },
   },
 };
 
-export default Place;
+export default places;

--- a/prismic-model/src/popup-dialog.ts
+++ b/prismic-model/src/popup-dialog.ts
@@ -2,16 +2,23 @@ import structuredText from './parts/structured-text';
 import text from './parts/text';
 import boolean from './parts/boolean';
 import link from './parts/link';
+import { CustomType } from './types/CustomType';
 
-const PopupDialog = {
-  PopupDialog: {
-    openButtonText: text('Open button text'),
-    title: text('Title inside the open dialog'),
-    text: structuredText('Text inside the open dialog', 'single'),
-    linkText: text('CTA inside the open dialog button text'),
-    link: link('CTA inside the open dialog button link', 'web'),
-    isShown: boolean('Is shown?', false),
+const popupDialog: CustomType = {
+  id: 'popup-dialog',
+  label: 'Popup dialog',
+  repeatable: false,
+  status: true,
+  json: {
+    'Popup dialog': {
+      openButtonText: text('Open button text'),
+      title: text('Title inside the open dialog'),
+      text: structuredText('Text inside the open dialog', 'single'),
+      linkText: text('CTA inside the open dialog button text'),
+      link: link('CTA inside the open dialog button link', 'web'),
+      isShown: boolean('Is shown?', false),
+    },
   },
 };
 
-export default PopupDialog;
+export default popupDialog;

--- a/prismic-model/src/project-formats.ts
+++ b/prismic-model/src/project-formats.ts
@@ -1,4 +1,12 @@
+import { CustomType } from './types/CustomType';
 import label from './types/label';
 
-const ProjectFormat = label('Project format');
-export default ProjectFormat;
+const projectFormat: CustomType = {
+  id: 'project-formats',
+  label: 'Project format',
+  repeatable: true,
+  status: true,
+  json: label('Project format'),
+};
+
+export default projectFormat;

--- a/prismic-model/src/projects.ts
+++ b/prismic-model/src/projects.ts
@@ -6,27 +6,34 @@ import contributorsWithTitle from './parts/contributorsWithTitle';
 import link from './parts/link';
 import list from './parts/list';
 import timestamp from './parts/timestamp';
+import { CustomType } from './types/CustomType';
 
-const Project = {
-  Project: {
-    title,
-    format: link('Format', 'document', ['project-formats']),
-    start: timestamp('Start date'),
-    end: timestamp('End date'),
-    body,
-  },
-  Contributors: contributorsWithTitle(),
-  Promo: {
-    promo,
-  },
-  'Content relationships': {
-    seasons: list('Seasons', {
-      season: link('Season', 'document', ['seasons'], 'Select a Season'),
-    }),
-  },
-  Metadata: {
-    metadataDescription: structuredText('Metadata description', 'single'),
+const projects: CustomType = {
+  id: 'projects',
+  label: 'Project',
+  repeatable: true,
+  status: true,
+  json: {
+    Project: {
+      title,
+      format: link('Format', 'document', ['project-formats']),
+      start: timestamp('Start date'),
+      end: timestamp('End date'),
+      body,
+    },
+    Contributors: contributorsWithTitle(),
+    Promo: {
+      promo,
+    },
+    'Content relationships': {
+      seasons: list('Seasons', {
+        season: link('Season', 'document', ['seasons'], 'Select a Season'),
+      }),
+    },
+    Metadata: {
+      metadataDescription: structuredText('Metadata description', 'single'),
+    },
   },
 };
 
-export default Project;
+export default projects;

--- a/prismic-model/src/seasons.ts
+++ b/prismic-model/src/seasons.ts
@@ -2,17 +2,24 @@ import title from './parts/title';
 import promo from './parts/promo';
 import body from './parts/body';
 import timestamp from './parts/timestamp';
+import { CustomType } from './types/CustomType';
 
-const SeasonPage = {
-  Season: {
-    title: title,
-    start: timestamp('Start date'),
-    end: timestamp('End date'),
-    body,
-  },
-  Promo: {
-    promo,
+const Season: CustomType = {
+  id: 'seasons',
+  label: 'Season',
+  repeatable: true,
+  status: true,
+  json: {
+    Season: {
+      title: title,
+      start: timestamp('Start date'),
+      end: timestamp('End date'),
+      body,
+    },
+    Promo: {
+      promo,
+    },
   },
 };
 
-export default SeasonPage;
+export default Season;

--- a/prismic-model/src/series.ts
+++ b/prismic-model/src/series.ts
@@ -9,40 +9,47 @@ import text from './parts/text';
 import timestamp from './parts/timestamp';
 import structuredText from './parts/structured-text';
 import link from './parts/link';
+import { CustomType } from './types/CustomType';
 
-// This is called `ArticleSeries` and the filename `series`, as it was a
+// This is called `ArticleSeries` and the id `series`, as it was a
 // mistake we made way back when when all we were doing was articles
-const ArticleSeries = {
-  'Article series': {
-    title: title,
-    color: select('Colour', ['teal', 'red', 'green', 'purple']),
-    body,
-  },
-  Schedule: {
-    schedule: list('Schedule', {
+const articleSeries: CustomType = {
+  id: 'series',
+  label: 'Story series',
+  repeatable: true,
+  status: true,
+  json: {
+    'Story series': {
       title: title,
-      publishDate: timestamp('Date to be published'),
-    }),
-  },
-  Contributors: contributorsWithTitle(),
-  Promo: {
-    promo,
-  },
-  Metadata: {
-    metadataDescription: structuredText('Metadata description', 'single'),
-  },
-  'Content relationships': {
-    seasons: list('Seasons', {
-      season: link('Season', 'document', ['seasons'], 'Select a Season'),
-    }),
-  },
-  Deprecated: {
-    description: structuredText(
-      '[Deprecated] Description. Please use standfirst slice'
-    ),
-    commissionedLength: number('[Deprecated] Commissioned length'),
-    wordpressSlug: text('[Deprecated] Wordpress slug'),
+      color: select('Colour', ['teal', 'red', 'green', 'purple']),
+      body,
+    },
+    Schedule: {
+      schedule: list('Schedule', {
+        title: title,
+        publishDate: timestamp('Date to be published'),
+      }),
+    },
+    Contributors: contributorsWithTitle(),
+    Promo: {
+      promo,
+    },
+    Metadata: {
+      metadataDescription: structuredText('Metadata description', 'single'),
+    },
+    'Content relationships': {
+      seasons: list('Seasons', {
+        season: link('Season', 'document', ['seasons'], 'Select a Season'),
+      }),
+    },
+    Deprecated: {
+      description: structuredText(
+        '[Deprecated] Description. Please use standfirst slice'
+      ),
+      commissionedLength: number('[Deprecated] Commissioned length'),
+      wordpressSlug: text('[Deprecated] Wordpress slug'),
+    },
   },
 };
 
-export default ArticleSeries;
+export default articleSeries;

--- a/prismic-model/src/teams.ts
+++ b/prismic-model/src/teams.ts
@@ -1,14 +1,20 @@
 import structuredText from './parts/structured-text';
 import text from './parts/text';
 
-const Teams = {
-  Contact: {
-    title: structuredText('Title', 'single', ['heading1']),
-    subtitle: structuredText('Subtitle', 'single'),
-    email: text('Email'),
-    phone: text('Phone'),
-    url: text('URL'),
+const teams = {
+  id: 'teams',
+  label: 'Team',
+  repeatable: true,
+  status: true,
+  json: {
+    Team: {
+      title: structuredText('Title', 'single', ['heading1']),
+      subtitle: structuredText('Subtitle', 'single'),
+      email: text('Email'),
+      phone: text('Phone'),
+      url: text('URL'),
+    },
   },
 };
 
-export default Teams;
+export default teams;

--- a/prismic-model/src/types/CustomType.ts
+++ b/prismic-model/src/types/CustomType.ts
@@ -1,0 +1,7 @@
+export type CustomType = {
+  id: string;
+  label: string;
+  repeatable: boolean;
+  status: boolean;
+  json: unknown;
+};

--- a/prismic-model/src/webcomic-series.ts
+++ b/prismic-model/src/webcomic-series.ts
@@ -4,17 +4,26 @@ import title from './parts/title';
 import structuredText from './parts/structured-text';
 import promo from './parts/promo';
 import contributorsWithTitle from './parts/contributorsWithTitle';
+import { CustomType } from './types/CustomType';
 
-export default {
-  '[Deprecated] Webcomic series': {
-    title: title,
-    description: structuredText('Description'),
-  },
-  Contributors: contributorsWithTitle(),
-  Promo: {
-    promo,
-  },
-  Metadata: {
-    metadataDescription: structuredText('Metadata description', 'single'),
+const webcomicSeries: CustomType = {
+  id: 'webcomic-series',
+  label: '[Deprecated] Webcomic series',
+  repeatable: true,
+  status: false,
+  json: {
+    '[Deprecated] Webcomic series': {
+      title: title,
+      description: structuredText('Description'),
+    },
+    Contributors: contributorsWithTitle(),
+    Promo: {
+      promo,
+    },
+    Metadata: {
+      metadataDescription: structuredText('Metadata description', 'single'),
+    },
   },
 };
+
+export default webcomicSeries;

--- a/prismic-model/src/webcomics.ts
+++ b/prismic-model/src/webcomics.ts
@@ -5,37 +5,46 @@ import promo from './parts/promo';
 import articleBody from './parts/article-body';
 import contributorsWithTitle from './parts/contributorsWithTitle';
 import structuredText from './parts/structured-text';
+import { CustomType } from './types/CustomType';
 
-export default {
-  Webcomic: {
-    title,
-    format: link('Format', 'document', ['article-formats']),
-    image: {
-      type: 'Image',
-      config: {
-        label: 'Webcomic',
+const webcomics: CustomType = {
+  id: 'webcomics',
+  label: 'Webcomic',
+  repeatable: true,
+  status: false,
+  json: {
+    Webcomic: {
+      title,
+      format: link('Format', 'document', ['article-formats']),
+      image: {
+        type: 'Image',
+        config: {
+          label: 'Webcomic',
+        },
       },
+      body: articleBody,
     },
-    body: articleBody,
-  },
-  Contributors: contributorsWithTitle(),
-  Promo: {
-    promo,
-  },
-  Metadata: {
-    metadataDescription: structuredText('Metadata description', 'single'),
-  },
-  'Content relationships': {
-    series: list('Series', {
-      series: link('Series', 'document', ['webcomic-series']),
-    }),
-  },
-  Deprecated: {
-    publishDate: {
-      config: {
-        label: 'Override publish date',
+    Contributors: contributorsWithTitle(),
+    Promo: {
+      promo,
+    },
+    Metadata: {
+      metadataDescription: structuredText('Metadata description', 'single'),
+    },
+    'Content relationships': {
+      series: list('Series', {
+        series: link('Series', 'document', ['webcomic-series']),
+      }),
+    },
+    Deprecated: {
+      publishDate: {
+        config: {
+          label: 'Override publish date',
+        },
+        type: 'Timestamp',
       },
-      type: 'Timestamp',
     },
   },
 };
+
+export default webcomics;


### PR DESCRIPTION
Now that we've removed all the unused inactive types from Prismic, we can store, and hence deploy, all data from our tool

~Next up a diff across all types to run in CI.~ `diffCustomTypes` has been added to help me have confidence this works, I'll add it to CI next.