### PR TITLE
Add some tests for convert-image-uri

### DIFF
--- a/common/test/utils/convert-image-uri.test.ts
+++ b/common/test/utils/convert-image-uri.test.ts
@@ -1,0 +1,54 @@
+import { convertImageUri } from '../../utils/convert-image-uri';
+
+describe('convertImageUri for Prismic images', () => {
+  it('creates a full-sized image', () => {
+    const result = convertImageUri(
+      'https://images.prismic.io/wellcomecollection/EP_0001.jpg',
+      'full'
+    );
+
+    expect(result).toEqual(
+      'https://images.prismic.io/wellcomecollection/EP_0001.jpg?auto=&rect=&w=full&h='
+    );
+  });
+
+  it('replaces an existing width parameter with a number', () => {
+    const result = convertImageUri(
+      'https://images.prismic.io/wellcomecollection/EP_0002.jpg?w=100',
+      200
+    );
+
+    expect(result).toEqual(
+      'https://images.prismic.io/wellcomecollection/EP_0002.jpg?auto=&rect=&w=200&h='
+    );
+  });
+
+  it('updates an existing height parameter based on the width', () => {
+    const result = convertImageUri(
+      'https://images.prismic.io/wellcomecollection/EP_0003.jpg?w=100&h=200',
+      300
+    );
+
+    expect(result).toEqual(
+      'https://images.prismic.io/wellcomecollection/EP_0003.jpg?auto=&rect=&w=300&h=600'
+    );
+  });
+
+  it('removes unrecognised parameters', () => {
+    const fullResult = convertImageUri(
+      'https://images.prismic.io/wellcomecollection/EP_0004.jpg?token=sekrit',
+      'full'
+    );
+    expect(fullResult).toEqual(
+      'https://images.prismic.io/wellcomecollection/EP_0004.jpg?auto=&rect=&w=full&h='
+    );
+
+    const wideResult = convertImageUri(
+      'https://images.prismic.io/wellcomecollection/EP_0004.jpg?token=sekrit',
+      300
+    );
+    expect(wideResult).toEqual(
+      'https://images.prismic.io/wellcomecollection/EP_0004.jpg?auto=&rect=&w=300&h='
+    );
+  });
+});

--- a/common/test/utils/convert-image-uri.test.ts
+++ b/common/test/utils/convert-image-uri.test.ts
@@ -1,4 +1,7 @@
-import { convertImageUri } from '../../utils/convert-image-uri';
+import {
+  convertIiifUriToInfoUri,
+  convertImageUri,
+} from '../../utils/convert-image-uri';
 
 describe('convertImageUri for Prismic images', () => {
   it('creates a full-sized image', () => {
@@ -49,6 +52,78 @@ describe('convertImageUri for Prismic images', () => {
     );
     expect(wideResult).toEqual(
       'https://images.prismic.io/wellcomecollection/EP_0004.jpg?auto=&rect=&w=300&h='
+    );
+  });
+});
+
+describe('convertImageUri for IIIF images', () => {
+  it('passes through GIFs unmodified', () => {
+    const result = convertImageUri(
+      'https://iiif.wellcomecollection.org/image/b0001.gif',
+      'full'
+    );
+    expect(result).toEqual(
+      'https://iiif.wellcomecollection.org/image/b0001.gif'
+    );
+  });
+
+  it('sets the size parameter on a URI to full', () => {
+    const result = convertImageUri(
+      'https://iiif.wellcomecollection.org/image/b0002.jpg',
+      'full'
+    );
+    expect(result).toEqual(
+      'https://iiif.wellcomecollection.org/image/b0002.jpg/full/full/0/default.jpg'
+    );
+  });
+
+  it('sets the size parameter on a URI to a number', () => {
+    const result = convertImageUri(
+      'https://iiif.wellcomecollection.org/image/b0003.jpg',
+      300
+    );
+    expect(result).toEqual(
+      'https://iiif.wellcomecollection.org/image/b0003.jpg/full/300%2C/0/default.jpg'
+    );
+  });
+
+  it('returns a URI for a PNG image', () => {
+    const result = convertImageUri(
+      'https://iiif.wellcomecollection.org/image/b0004.png',
+      300
+    );
+    expect(result).toEqual(
+      'https://iiif.wellcomecollection.org/image/b0004.png/full/300%2C/0/default.png'
+    );
+  });
+
+  it('defaults to a URI for a JPEG image', () => {
+    const result = convertImageUri(
+      'https://iiif.wellcomecollection.org/image/b0005',
+      300
+    );
+    expect(result).toEqual(
+      'https://iiif.wellcomecollection.org/image/b0005/full/300%2C/0/default.jpg'
+    );
+  });
+});
+
+describe('convertIiifUriToInfoUri', () => {
+  it('finds the info.json for a IIIF URI', () => {
+    const result = convertIiifUriToInfoUri(
+      'https://iiif.wellcomecollection.org/image/b0006.jpg/full/300%2C/0/default.jpg'
+    );
+    expect(result).toEqual(
+      'https://iiif.wellcomecollection.org/image/b0006.jpg/info.json'
+    );
+  });
+
+  it('finds the info.json for an unrecognised URI', () => {
+    const result = convertIiifUriToInfoUri(
+      'https://iiif.wellcomecollection.org/image/b0007.jp2'
+    );
+    expect(result).toEqual(
+      'https://iiif.wellcomecollection.org/image/b0007.jp2/info.json'
     );
   });
 });

--- a/common/utils/convert-image-uri.js
+++ b/common/utils/convert-image-uri.js
@@ -110,13 +110,15 @@ export function convertImageUri(
     if (determineIfGif(originalUri)) {
       return originalUri;
     } else {
-      const imagePath = originalUri.split(iiifBaseUri)[1].split('/', 2)[0];
+      const imageIdentifier = originalUri
+        .split(iiifBaseUri)[1]
+        .split('/', 2)[0];
 
       const params = {
         size: requiredSize === 'full' ? 'full' : `${requiredSize},`,
         format: determineFinalFormat(originalUri),
       };
-      return iiifImageTemplate(`${iiifBaseUri}${imagePath}`)(params);
+      return iiifImageTemplate(`${iiifBaseUri}${imageIdentifier}`)(params);
     }
   } else {
     return originalUri;

--- a/common/utils/convert-image-uri.js
+++ b/common/utils/convert-image-uri.js
@@ -126,6 +126,12 @@ export function convertImageUri(
 }
 
 export function convertIiifUriToInfoUri(originalUriPath: string) {
+  // Note: this regex assumes that our image identifiers have a three-letter
+  // file extension.  This won't always be the case, e.g. Miro images have
+  // identifiers like "B0009730".
+  //
+  // Is this going to be an issue?  Would we be better off counting slashes
+  // in the URL?
   const match =
     originalUriPath &&
     originalUriPath.match(


### PR DESCRIPTION
## Who is this for?

Me

## What is it doing for them?

Because I think we can and should tidy up this code further, in particular:

* Rewriting it in TypeScript
* Splitting out the IIIF and Prismic pieces – in most circumstances we can unambiguously say whether we're dealing with a IIIF or Prismic URL, so let's call the correct function directly.

The tests add a safety net against possible future refactoring.