### PR TITLE
Fix "change password"

### DIFF
--- a/identity/webapp/src/frontend/MyAccount/ChangePassword.tsx
+++ b/identity/webapp/src/frontend/MyAccount/ChangePassword.tsx
@@ -103,7 +103,14 @@ export const ChangePassword: React.FC<ChangeDetailsModalContentProps> = ({
       {submissionErrorMessage && (
         <StatusAlert type="failure">{submissionErrorMessage}</StatusAlert>
       )}
-      <form onSubmit={handleSubmit(data => updatePassword(data, onComplete))}>
+      <form
+        onSubmit={handleSubmit(data =>
+          updatePassword(
+            { password: data.password, newPassword: data.newPassword },
+            onComplete
+          )
+        )}
+      >
         <FieldMargin>
           <PasswordInput
             label="Current password"


### PR DESCRIPTION
The simpler proxying exposed that we were sending the password confirmation too, which API gateway didn't like