### PR TITLE
More build improvements

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -173,6 +173,21 @@
           - identity:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/identity_webapp:ref.${BUILDKITE_COMMIT}
           - identity:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/identity_webapp:latest
 
+- label: "deploy identity (bundle analysis)"
+  branches: "main"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        run: identity
+        command: [ "yarn", "deployBundleAnalysis" ]
+        env:
+          - AWS_ACCESS_KEY_ID
+          - AWS_SECRET_ACCESS_KEY
+          - AWS_SESSION_TOKEN
+
 - label: "deploy dash"
   branches: "main"
   plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -203,21 +203,6 @@
           - AWS_SECRET_ACCESS_KEY
           - AWS_SESSION_TOKEN
 
-- label: "deploy dash"
-  branches: "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: dash
-        command: [ "yarn", "deploy" ]
-        env:
-          - AWS_ACCESS_KEY_ID
-          - AWS_SECRET_ACCESS_KEY
-          - AWS_SESSION_TOKEN
-
 - label: "deploy toggles"
   branches: "main"
   plugins:

--- a/catalogue/Dockerfile
+++ b/catalogue/Dockerfile
@@ -1,7 +1,7 @@
 # This image should be built with the parent directory as context
 FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/node:14.17.6
 
-RUN apt-get update && apt-get install -y awscli rename
+RUN apt-get update && apt-get install -y awscli
 
 WORKDIR /app
 

--- a/content/Dockerfile
+++ b/content/Dockerfile
@@ -1,7 +1,7 @@
 # This image should be built with the parent directory as context
 FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/node:14.17.6
 
-RUN apt-get update && apt-get install -y awscli rename
+RUN apt-get update && apt-get install -y awscli
 
 WORKDIR /app
 

--- a/identity/Dockerfile
+++ b/identity/Dockerfile
@@ -1,7 +1,7 @@
 # This image should be built with the parent directory as context
 FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/node:14.17.6
 
-RUN apt-get update && apt-get install -y awscli rename
+RUN apt-get update && apt-get install -y awscli
 
 WORKDIR /app
 


### PR DESCRIPTION
## Who is this for?

People who work on this repo.

## What is it doing for them?

Making the build faster and whizzier (🤞). For https://github.com/wellcomecollection/wellcomecollection.org/issues/7038 and https://github.com/wellcomecollection/platform/issues/5359

- We were deploying dash twice. Let's not do that.
- We weren't running the identity bundle analysis in main. Let's do that. (Although I'm not sure the bundle analysis is working correctly – if you look in [s3://dash.wc.org/bundles](https://console.aws.amazon.com/s3/object/dash.wellcomecollection.org?prefix=bundles%2Fcatalogue.browser.latest.json&region=eu-west-1#), it doesn't look like anything's been uploaded for a long time.)
- Do we actually need that `rename` dependency? I'm not sure.
- ~Standardise on an Alpine-based Node base image, which is \~9x smaller (41MB vs 350MB).~