### PR TITLE
Stop logging proxied 40x statuses as errors

### DIFF
--- a/identity/webapp/src/utility/api-caller.ts
+++ b/identity/webapp/src/utility/api-caller.ts
@@ -28,7 +28,7 @@ export async function callRemoteApi(
     url: path,
     method: context.method as AxiosMethod,
     headers: identityAxios.defaults.headers.common,
-    validateStatus: (status: number) => status >= 200 && status < 300,
+    validateStatus: (status: number) => status >= 200 && status < 500,
   };
 
   if (isAuthenticated(context.state)) {


### PR DESCRIPTION
They aren't errors in that they are not unexpected