### PR TITLE
Show h1 on /works in an attempt to stop Google sitelinking confusing anchors

### DIFF
--- a/catalogue/webapp/pages/works.tsx
+++ b/catalogue/webapp/pages/works.tsx
@@ -64,6 +64,8 @@ const Works: NextPage<Props> = ({
   }, []);
 
   const filters = worksFilters({ works, props: worksRouteProps });
+  const url = toLink({ ...worksRouteProps }, 'unknown').as;
+  const isWorksLanding = url.query ? Object.keys(url.query).length === 0 : true;
 
   return (
     <Fragment>
@@ -90,7 +92,7 @@ const Works: NextPage<Props> = ({
       <CataloguePageLayout
         title={`${query ? `${query} | ` : ''}Catalogue search`}
         description="Search the Wellcome Collection catalogue"
-        url={toLink({ ...worksRouteProps }, 'unknown').as}
+        url={url}
         openGraphType={'website'}
         jsonLd={{ '@type': 'WebPage' }}
         siteSection={'collections'}
@@ -107,8 +109,9 @@ const Works: NextPage<Props> = ({
           className={classNames(['row'])}
         >
           <div className="container">
-            <SearchTitle isVisuallyHidden={Boolean(works)} />
-
+            {/* Showing the h1 on `/works` (without a query string) in an attempt to
+            have Google use it as the link text in sitelinks */}
+            <SearchTitle isVisuallyHidden={Boolean(works) && !isWorksLanding} />
             <div className="grid">
               <div className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>
                 <Space v={{ size: 'l', properties: ['margin-top'] }}>

--- a/catalogue/webapp/pages/works.tsx
+++ b/catalogue/webapp/pages/works.tsx
@@ -110,7 +110,8 @@ const Works: NextPage<Props> = ({
         >
           <div className="container">
             {/* Showing the h1 on `/works` (without a query string) in an attempt to
-            have Google use it as the link text in sitelinks */}
+            have Google use it as the link text in sitelinks
+            https://github.com/wellcomecollection/wellcomecollection.org/issues/7297 */}
             <SearchTitle isVisuallyHidden={Boolean(works) && !isWorksLanding} />
             <div className="grid">
               <div className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>


### PR DESCRIPTION
From what I can tell, giving Google any kind of sitemap won't have an influence on what they decide to put in the sitelinks below the hit for a search result.

As a variation on a theme from the solution we went with previously, this will make sure the h1 ('Search the collections') is visible on `/works`, which _might_ make them use that instead.

![image](https://user-images.githubusercontent.com/1394592/141474445-d4c81310-f9ab-4a25-acaa-ec831dd634af.png)
