### PR TITLE
Leave IIIF thumbnail URIs alone

### DIFF
--- a/common/test/utils/convert-image-uri.test.ts
+++ b/common/test/utils/convert-image-uri.test.ts
@@ -1,4 +1,7 @@
-import { convertImageUri } from '../../utils/convert-image-uri';
+import {
+  convertIiifImageUri,
+  convertImageUri,
+} from '../../utils/convert-image-uri';
 
 describe('convertImageUri for Prismic images', () => {
   it('creates a full-sized image', () => {
@@ -101,6 +104,16 @@ describe('convertImageUri for IIIF images', () => {
     );
     expect(result).toEqual(
       'https://iiif.wellcomecollection.org/image/b0005/full/300%2C/0/default.jpg'
+    );
+  });
+
+  it('ignores a thumbnail', () => {
+    const result = convertIiifImageUri(
+      'https://iiif.wellcomecollection.org/thumbs/b30598977_0001.jp2/full/!200,200/0/default.jpg',
+      'full'
+    );
+    expect(result).toEqual(
+      'https://iiif.wellcomecollection.org/thumbs/b30598977_0001.jp2/full/!200,200/0/default.jpg'
     );
   });
 });

--- a/common/utils/convert-image-uri.js
+++ b/common/utils/convert-image-uri.js
@@ -2,11 +2,13 @@
 import urlTemplate from 'url-template';
 
 const prismicBaseUri = 'https://images.prismic.io/wellcomecollection';
-const iiifBaseUri = 'https://iiif.wellcomecollection.org/image/';
+const iiifImageUri = 'https://iiif.wellcomecollection.org/image/';
+const iiifThumbUri = 'https://iiif.wellcomecollection.org/thumbs/';
+
 function determineSrc(url: string): string {
   if (url.startsWith(prismicBaseUri)) {
     return 'prismic';
-  } else if (url.startsWith(iiifBaseUri)) {
+  } else if (url.startsWith(iiifImageUri)) {
     return 'iiif';
   } else {
     return 'unknown';
@@ -100,16 +102,16 @@ export function convertIiifImageUri(
   originalUri: string,
   requiredSize: number | 'full'
 ): string {
-  if (determineIfGif(originalUri)) {
+  if (determineIfGif(originalUri) || originalUri.startsWith(iiifThumbUri)) {
     return originalUri;
   } else {
-    const imageIdentifier = originalUri.split(iiifBaseUri)[1].split('/', 2)[0];
+    const imageIdentifier = originalUri.split(iiifImageUri)[1].split('/', 2)[0];
 
     const params = {
       size: requiredSize === 'full' ? 'full' : `${requiredSize},`,
       format: determineFinalFormat(originalUri),
     };
-    return iiifImageTemplate(`${iiifBaseUri}${imageIdentifier}`)(params);
+    return iiifImageTemplate(`${iiifImageUri}${imageIdentifier}`)(params);
   }
 }
 

--- a/common/utils/convert-image-uri.js
+++ b/common/utils/convert-image-uri.js
@@ -3,7 +3,6 @@ import urlTemplate from 'url-template';
 
 const prismicBaseUri = 'https://images.prismic.io/wellcomecollection';
 const iiifImageUri = 'https://iiif.wellcomecollection.org/image/';
-const iiifThumbUri = 'https://iiif.wellcomecollection.org/thumbs/';
 
 function determineSrc(url: string): string {
   if (url.startsWith(prismicBaseUri)) {
@@ -102,7 +101,7 @@ export function convertIiifImageUri(
   originalUri: string,
   requiredSize: number | 'full'
 ): string {
-  if (determineIfGif(originalUri) || originalUri.startsWith(iiifThumbUri)) {
+  if (determineIfGif(originalUri) || !originalUri.startsWith(iiifImageUri)) {
     return originalUri;
   } else {
     const imageIdentifier = originalUri.split(iiifImageUri)[1].split('/', 2)[0];


### PR DESCRIPTION
This fixes the issue with /works in staging.

All the URLs in the catalogue app are coming from `iiif.wc.org`, but that's not the same as them coming from `iiif.wc.org/image` – which is what this function was assuming. Now we explicitly ignore thumbnails and have a test to boot.