### PR TITLE
change how we check for an error page when erroring for missing serverData

### DIFF
--- a/catalogue/webapp/pages/_error.tsx
+++ b/catalogue/webapp/pages/_error.tsx
@@ -19,7 +19,7 @@ const Page: NextPage<Props> = ({ statusCode }) => {
 Page.getInitialProps = ({ query, res, err }) => {
   delete query.memoizedPrismic;
   const statusCode = res ? res.statusCode : err ? err.statusCode : 404;
-  return { statusCode, skipServerData: true };
+  return { statusCode };
 };
 
 export default Page;


### PR DESCRIPTION
https://github.com/vercel/next.js/discussions/11945#discussioncomment-6790

That describes it best. Basically we can't send any data to _app from the error page as the page is served as soon as the error is hit.

This fixes traces to the correct 500 error when we have one, and 404s render the actual page.

Finding it quite hard to think of how to test page => app interaction...