### PR TITLE
Add pathname to cookie banner close button tracking

### DIFF
--- a/common/views/components/CookieNotice/CookieNotice.tsx
+++ b/common/views/components/CookieNotice/CookieNotice.tsx
@@ -37,7 +37,11 @@ const CloseCookieNotice = styled.button`
   border: 0;
 `;
 
-const CookieNotice: FunctionComponent = () => {
+type Props = {
+  url: string;
+};
+
+const CookieNotice: FunctionComponent<Props> = ({ url }) => {
   const [shouldRender, setShouldRender] = useState(true);
   function hideCookieNotice() {
     cookie.set('WC_cookiesAccepted', 'true', {
@@ -48,6 +52,7 @@ const CookieNotice: FunctionComponent = () => {
     trackEvent({
       category: 'CookieNotice',
       action: 'click close cookie notice button',
+      label: url,
     });
 
     setShouldRender(false);

--- a/common/views/components/CookieNotice/CookieNotice.tsx
+++ b/common/views/components/CookieNotice/CookieNotice.tsx
@@ -38,10 +38,10 @@ const CloseCookieNotice = styled.button`
 `;
 
 type Props = {
-  url: string;
+  source: string;
 };
 
-const CookieNotice: FunctionComponent<Props> = ({ url }) => {
+const CookieNotice: FunctionComponent<Props> = ({ source }) => {
   const [shouldRender, setShouldRender] = useState(true);
   function hideCookieNotice() {
     cookie.set('WC_cookiesAccepted', 'true', {
@@ -52,7 +52,7 @@ const CookieNotice: FunctionComponent<Props> = ({ url }) => {
     trackEvent({
       category: 'CookieNotice',
       action: 'click close cookie notice button',
-      label: url,
+      label: source,
     });
 
     setShouldRender(false);

--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -231,7 +231,7 @@ const PageLayoutComponent: FunctionComponent<ComponentProps> = ({
 
       <div id="root">
         {apiToolbar && <ApiToolbar />}
-        <CookieNotice />
+        <CookieNotice url={url.pathname || ''} />
         <a className="visually-hidden visually-hidden-focusable" href="#main">
           Skip to main content
         </a>

--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -231,7 +231,7 @@ const PageLayoutComponent: FunctionComponent<ComponentProps> = ({
 
       <div id="root">
         {apiToolbar && <ApiToolbar />}
-        <CookieNotice url={url.pathname || ''} />
+        <CookieNotice source={url.pathname || ''} />
         <a className="visually-hidden visually-hidden-focusable" href="#main">
           Skip to main content
         </a>


### PR DESCRIPTION
Part of #7264 

## Who is this for?
Data analysts

## What is it doing for them?
Sending the page path with the close cookie banner event to make it simpler to analyse where users do/don't close the banner.