### PR TITLE
use URLSearchParams to send search params to API

### DIFF
--- a/catalogue/webapp/services/catalogue/common.ts
+++ b/catalogue/webapp/services/catalogue/common.ts
@@ -1,5 +1,4 @@
 import { CatalogueApiError } from '@weco/common/model/catalogue';
-import { propsToQuery } from '@weco/common/utils/routes';
 import { Toggles } from '@weco/toggles';
 
 export const rootUris = {
@@ -15,14 +14,6 @@ export type GlobalApiOptions = {
 export const globalApiOptions = (toggles?: Toggles): GlobalApiOptions => ({
   env: toggles?.stagingApi ? 'stage' : 'prod',
 });
-
-export const queryString = (params: { [key: string]: any }): string => {
-  const strings = Object.keys(propsToQuery(params)).map(key => {
-    const val = params[key];
-    return `${key}=${val}`;
-  });
-  return strings.length > 0 ? `?${strings.join('&')}` : '';
-};
 
 export const notFound = (): CatalogueApiError => ({
   errorType: 'http',

--- a/catalogue/webapp/services/catalogue/images.ts
+++ b/catalogue/webapp/services/catalogue/images.ts
@@ -7,12 +7,12 @@ import { CatalogueImagesApiProps } from '@weco/common/services/catalogue/ts_api'
 import {
   rootUris,
   globalApiOptions,
-  queryString,
   catalogueApiError,
   notFound,
   getTeiIndexName,
 } from './common';
 import { Toggles } from '@weco/toggles';
+import { propsToQuery } from '@weco/common/utils/routes';
 
 type GetImagesProps = {
   params: CatalogueImagesApiProps;
@@ -46,10 +46,15 @@ export async function getImages({
     pageSize,
     _index: index,
   };
-  const filterQueryString = queryString(extendedParams);
-  const url = encodeURI(
-    `${rootUris[apiOptions.env]}/v2/images${filterQueryString}`
-  );
+
+  const searchParams = new URLSearchParams(
+    propsToQuery(extendedParams)
+  ).toString();
+
+  const url = `${
+    rootUris[apiOptions.env]
+  }/v2/images?${searchParams.toString()}`;
+
   try {
     const res = await fetch(url);
     const json = await res.json();
@@ -72,8 +77,12 @@ export async function getImage({
     include: include,
     _index: index,
   };
-  const query = queryString(params);
-  const url = encodeURI(`${rootUris[apiOptions.env]}/v2/images/${id}${query}`);
+
+  const searchParams = new URLSearchParams(propsToQuery(params));
+
+  const url = `${
+    rootUris[apiOptions.env]
+  }/v2/images/${id}?${searchParams.toString()}`;
 
   try {
     const res = await fetch(url);

--- a/catalogue/webapp/services/catalogue/works.ts
+++ b/catalogue/webapp/services/catalogue/works.ts
@@ -10,12 +10,12 @@ import Raven from 'raven-js';
 import {
   catalogueApiError,
   globalApiOptions,
-  queryString,
   rootUris,
   notFound,
   getTeiIndexName,
 } from './common';
 import { Toggles } from '@weco/toggles';
+import { propsToQuery } from '@weco/common/utils/routes';
 
 type GetWorkProps = {
   id: string;
@@ -73,10 +73,12 @@ export async function getWorks({
     include: worksIncludes,
     _index: index,
   };
-  const filterQueryString = queryString(extendedParams);
-  const url = encodeURI(
-    `${rootUris[apiOptions.env]}/v2/works${filterQueryString}`
-  );
+
+  const searchParams = new URLSearchParams(
+    propsToQuery(extendedParams)
+  ).toString();
+
+  const url = `${rootUris[apiOptions.env]}/v2/works?${searchParams}`;
 
   try {
     const res = await fetch(url);
@@ -101,8 +103,10 @@ export async function getWork({
     include: workIncludes,
     _index: index,
   };
-  const query = queryString(params);
-  const url = encodeURI(`${rootUris[apiOptions.env]}/v2/works/${id}${query}`);
+
+  const searchParams = new URLSearchParams(propsToQuery(params)).toString();
+  const url = `${rootUris[apiOptions.env]}/v2/works/${id}?${searchParams}`;
+
   const res = await fetch(url, { redirect: 'manual' });
 
   // When records from Miro have been merged with Sierra data, we redirect the

--- a/common/utils/routes.ts
+++ b/common/utils/routes.ts
@@ -19,11 +19,9 @@ type Codec<T> = {
 type CodecMap = Record<string, Codec<unknown>>;
 // Gets the returns type of decode, and creates the type
 // { key: returnTypeOfDecode }
-export type FromCodecMap<Map extends CodecMap> = UndefinableToOptional<
-  {
-    [K in keyof Map]: ReturnType<Map[K]['decode']>;
-  }
->;
+export type FromCodecMap<Map extends CodecMap> = UndefinableToOptional<{
+  [K in keyof Map]: ReturnType<Map[K]['decode']>;
+}>;
 
 function paramParser<T>(
   param: QueryParam,
@@ -202,7 +200,7 @@ export function encodeQuery<T>(props: T, codecMap: CodecMap): ParsedUrlQuery {
 
 export function propsToQuery(
   props: Record<string, string | string[] | number | undefined>
-): ParsedUrlQuery {
+): Record<string, string> {
   return Object.keys(props).reduce((acc, key) => {
     const val = props[key];
 

--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -139,6 +139,7 @@ const PageLayoutComponent: FunctionComponent<ComponentProps> = ({
     'Object.fromEntries',
     'WeakMap',
     'URL',
+    'URLSearchParams',
   ];
 
   const globalInfoBar = useContext(GlobalInfoBarContext);


### PR DESCRIPTION
Fixes: https://github.com/wellcomecollection/wellcomecollection.org/issues/7290

Uses [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) when we are trying to use URL search params.

I can't think of a test that would help with this, which would be ensuring that the `client -> app -> API` path uses the right parameters without it making me feel like I am testing the URLSearchParameters functionality.

Removes the `queryString` abstraction for the same reason, `URLSearchParameters` is that abstraction. 

Adds it to the polyfill.io as [IE doesn't support it](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams#browser_compatibility) (although we are already using it).