### PR TITLE
deprecate description field and a couple others

### DIFF
--- a/cardigan/stories/content.js
+++ b/cardigan/stories/content.js
@@ -288,7 +288,6 @@ export const editorialSeries = [
       },
     ],
     color: 'turquoise',
-    commissionedLength: 6,
     schedule: [
       {
         title: [{ type: 'heading1', text: 'First heading', spans: [] }],

--- a/common/model/exhibitions.js
+++ b/common/model/exhibitions.js
@@ -26,7 +26,6 @@ export type Exhibition = {|
   isPermanent: boolean,
   statusOverride: ?string,
   intro: ?HTMLString,
-  description: HTMLString,
   contributors: Contributor[],
   place: ?Place,
   exhibits: {|

--- a/common/model/exhibitions.ts
+++ b/common/model/exhibitions.ts
@@ -23,7 +23,6 @@ export type Exhibition = GenericContentFields & {
   isPermanent: boolean;
   statusOverride?: string;
   intro?: HTMLString;
-  description: HTMLString;
   contributors: Contributor[];
   place?: Place;
   exhibits: {

--- a/common/services/prismic/exhibitions.js
+++ b/common/services/prismic/exhibitions.js
@@ -186,7 +186,6 @@ export function parseExhibitionDoc(document: PrismicDocument): UiExhibition {
   const format = data.format && parseExhibitionFormat(data.format);
   const url = `/exhibitions/${id}`;
   const title = parseTitle(data.title);
-  const description = parseDescription(data.description);
   const start = parseTimestamp(data.start);
   const end = data.end && parseTimestamp(data.end);
   const statusOverride = asText(data.statusOverride);
@@ -208,7 +207,6 @@ export function parseExhibitionDoc(document: PrismicDocument): UiExhibition {
     type: 'exhibitions',
     shortTitle: data.shortTitle && asText(data.shortTitle),
     format: format,
-    description: description,
     intro: intro,
     contributors: data.contributors ? parseContributors(data.contributors) : [],
     start: start,

--- a/prismic-model/src/events.ts
+++ b/prismic-model/src/events.ts
@@ -89,12 +89,6 @@ const events: CustomType = {
         parent: link('Parent', 'document', ['exhibitions'], 'Select a parent'),
       }),
     },
-    Deprecated: {
-      description: structuredText('Description', 'multi', [
-        'heading2',
-        'list-item',
-      ]),
-    },
   },
 };
 

--- a/prismic-model/src/exhibitions.ts
+++ b/prismic-model/src/exhibitions.ts
@@ -71,7 +71,6 @@ const exhibitions: CustomType = {
       drupalPath: text('Drupal path'),
     },
     Deprecated: {
-      description,
       intro: {
         type: 'StructuredText',
         config: {

--- a/prismic-model/src/series.ts
+++ b/prismic-model/src/series.ts
@@ -41,12 +41,6 @@ const articleSeries: CustomType = {
         season: link('Season', 'document', ['seasons'], 'Select a Season'),
       }),
     },
-    Deprecated: {
-      description: structuredText(
-        '[Deprecated] Description. Please use standfirst slice'
-      ),
-      commissionedLength: number('[Deprecated] Commissioned length'),
-    },
   },
 };
 


### PR DESCRIPTION
Used to be the way we pulled in promo information ages ago.
Now we just use the Promo.

related to #7277 