### PR TITLE
Don't show 'undefined' in the archive tree if there's no reference number

### DIFF
--- a/catalogue/webapp/components/ArchiveBreadcrumb/ArchiveBreadcrumb.test.tsx
+++ b/catalogue/webapp/components/ArchiveBreadcrumb/ArchiveBreadcrumb.test.tsx
@@ -1,0 +1,83 @@
+import ArchiveBreadcrumb from './ArchiveBreadcrumb';
+import IsArchiveContext from '../IsArchiveContext/IsArchiveContext';
+import { Work } from '@weco/common/model/catalogue';
+import { shallowWithTheme } from '@weco/common/test/fixtures/enzyme-helpers';
+
+describe('ArchiveBreadcrumb', () => {
+  it("includes the reference number in the last crumb if there isn't one", () => {
+    const w: Work = {
+      id: 'atxs4tb9',
+      title: 'Archives 1972',
+      alternativeTitles: [],
+      referenceNumber: 'SA/GMR/A/16',
+      workType: {
+        id: 'h',
+        label: 'Archives and manuscripts',
+        type: 'Format',
+      },
+      parts: [],
+      partOf: [],
+      precededBy: [],
+      succeededBy: [],
+      physicalDescription: '1 file',
+      contributors: [],
+      subjects: [],
+      genres: [],
+      identifiers: [],
+      production: [],
+      languages: [],
+      notes: [],
+      holdings: [],
+      availabilities: [],
+      availableOnline: false,
+      type: 'Work',
+    };
+
+    const component = shallowWithTheme(
+      <IsArchiveContext.Provider value={true}>
+        <ArchiveBreadcrumb work={w} />
+      </IsArchiveContext.Provider>
+    );
+    const componentHtml = component.html();
+    expect(
+      componentHtml.indexOf('Archives 1972 SA/GMR/A/16') > -1
+    ).toBeTruthy();
+  });
+
+  it("omits the reference number in the last crumb if there isn't one", () => {
+    const w: Work = {
+      id: 'eyfq7xd9',
+      title: 'Devīkavaca',
+      alternativeTitles: [],
+      workType: {
+        id: 'h',
+        label: 'Archives and manuscripts',
+        type: 'Format',
+      },
+      parts: [],
+      partOf: [],
+      precededBy: [],
+      succeededBy: [],
+      physicalDescription: '1 file',
+      contributors: [],
+      subjects: [],
+      genres: [],
+      identifiers: [],
+      production: [],
+      languages: [],
+      notes: [],
+      holdings: [],
+      availabilities: [],
+      availableOnline: false,
+      type: 'Work',
+    };
+
+    const component = shallowWithTheme(
+      <IsArchiveContext.Provider value={true}>
+        <ArchiveBreadcrumb work={w} />
+      </IsArchiveContext.Provider>
+    );
+    const componentHtml = component.html();
+    expect(componentHtml.indexOf('undefined')).toBe(-1);
+  });
+});

--- a/catalogue/webapp/components/ArchiveBreadcrumb/ArchiveBreadcrumb.tsx
+++ b/catalogue/webapp/components/ArchiveBreadcrumb/ArchiveBreadcrumb.tsx
@@ -179,7 +179,11 @@ const ArchiveBreadcrumb: FunctionComponent<Props> = ({ work }: Props) => {
             <span className="crumb-inner">
               <AlignFont>
                 <WorkTitle
-                  title={`${lastCrumb.title} ${lastCrumb.referenceNumber}`}
+                  title={`${lastCrumb.title}${
+                    lastCrumb.referenceNumber
+                      ? ` ${lastCrumb.referenceNumber}`
+                      : ''
+                  }`}
                 />
               </AlignFont>
             </span>


### PR DESCRIPTION
This is particularly relevant for TEI works, which don't always have a reference number, but do use an ArchiveTree to display the structure of the manuscript.

Before:

<img width="377" alt="Screenshot 2021-11-15 at 15 21 47" src="https://user-images.githubusercontent.com/301220/141807384-221e8d54-4084-4678-a338-9d2520be39ee.png">

After:

<img width="329" alt="Screenshot 2021-11-15 at 15 21 05" src="https://user-images.githubusercontent.com/301220/141807252-b4e8326f-3880-49bf-9591-29af0cf529ee.png">

For https://github.com/wellcomecollection/catalogue-pipeline/issues/1970