### PR TITLE
remove publishDate

### DIFF
--- a/common/services/prismic/articles.js
+++ b/common/services/prismic/articles.js
@@ -7,7 +7,6 @@ import {
   parseSingleLevelGroup,
   parseLabelType,
   isDocumentLink,
-  checkAndParseImage,
   asText,
 } from './parsers';
 import { parseMultiContent } from './multi-content';
@@ -362,7 +361,7 @@ function parseContentLink(document: ?PrismicDocument): ?MultiContent {
 function parseArticleDoc(document: PrismicDocument): Article {
   const { data } = document;
   // When we imported data into Prismic from the Wordpress blog some content
-  // needed to have it's original publication date displayed. This is no
+  // needed to have its original publication date displayed. This is no
   // longer a feature that editors can, but we still want to display the value
   const datePublished =
     data.publishDate || document.first_publication_date || undefined;

--- a/common/services/prismic/articles.js
+++ b/common/services/prismic/articles.js
@@ -361,8 +361,8 @@ function parseContentLink(document: ?PrismicDocument): ?MultiContent {
 function parseArticleDoc(document: PrismicDocument): Article {
   const { data } = document;
   // When we imported data into Prismic from the Wordpress blog some content
-  // needed to have its original publication date displayed. This is no
-  // longer a feature that editors can, but we still want to display the value
+  // needed to have its original publication date displayed. It is purely a display
+  // value and does not affect ordering.
   const datePublished =
     data.publishDate || document.first_publication_date || undefined;
 

--- a/common/services/prismic/articles.js
+++ b/common/services/prismic/articles.js
@@ -361,8 +361,12 @@ function parseContentLink(document: ?PrismicDocument): ?MultiContent {
 
 function parseArticleDoc(document: PrismicDocument): Article {
   const { data } = document;
+  // When we imported data into Prismic from the Wordpress blog some content
+  // needed to have it's original publication date displayed. This is no
+  // longer a feature that editors can, but we still want to display the value
   const datePublished =
     data.publishDate || document.first_publication_date || undefined;
+
   const article = {
     type: 'articles',
     ...parseGenericFields(document),
@@ -375,6 +379,7 @@ function parseArticleDoc(document: PrismicDocument): Article {
       return parseSeason(season);
     }),
   };
+
   const labels = [
     article.format ? { text: article.format.title || '' } : null,
     article.series.find(series => series.schedule.length > 0)
@@ -420,8 +425,7 @@ export async function getArticles(
   { predicates = [], ...opts }: ArticleQueryProps,
   memoizedPrismic: ?Object
 ): Promise<PaginatedResults<Article>> {
-  const orderings =
-    '[my.articles.publishDate, my.webcomics.publishDate, document.first_publication_date desc]';
+  const orderings = '[document.first_publication_date desc]';
   const paginatedResults = await getDocuments(
     req,
     [Prismic.Predicates.any('document.type', ['articles', 'webcomics'])].concat(

--- a/prismic-model/src/articles.ts
+++ b/prismic-model/src/articles.ts
@@ -48,10 +48,11 @@ const articles: CustomType = {
         parent: link('Parent', 'document', ['exhibitions'], 'Select a parent'),
       }),
     },
-    Migration: {
+    Overrides: {
       publishDate: {
         config: {
-          label: 'Override publish date',
+          label:
+            'Override publish date rendering. This will not affect ordering',
         },
         type: 'Timestamp',
       },

--- a/prismic-model/src/webcomics.ts
+++ b/prismic-model/src/webcomics.ts
@@ -36,14 +36,6 @@ const webcomics: CustomType = {
         series: link('Series', 'document', ['webcomic-series']),
       }),
     },
-    Deprecated: {
-      publishDate: {
-        config: {
-          label: 'Override publish date',
-        },
-        type: 'Timestamp',
-      },
-    },
   },
 };
 

--- a/prismic-model/src/webcomics.ts
+++ b/prismic-model/src/webcomics.ts
@@ -36,6 +36,15 @@ const webcomics: CustomType = {
         series: link('Series', 'document', ['webcomic-series']),
       }),
     },
+    Overrides: {
+      publishDate: {
+        config: {
+          label:
+            'Override publish date rendering. This will not affect ordering',
+        },
+        type: 'Timestamp',
+      },
+    },
   },
 };
 


### PR DESCRIPTION
Removes `publishDate`.

The data for older articles is still available on the documents and will still be rendered, I've left a note to explain this.

This will stop it being used in Prismic in the future.

The ordering actually didn't work anyway.