### PR TITLE
pass contributors through as object

### DIFF
--- a/content/webapp/pages/book.tsx
+++ b/content/webapp/pages/book.tsx
@@ -156,7 +156,7 @@ const BookPage: FC<Props> = props => {
         id={book.id}
         Header={Header}
         Body={<Body body={book.body} pageId={book.id} />}
-        contributorProps={book.contributors}
+        contributorProps={{ contributors: book.contributors }}
         seasons={book.seasons}
       >
         <Fragment>


### PR DESCRIPTION
Moving the Contributors types into TypeScript would have caught this.

This is how it is done in the other pages, we can revisit this once this is deployed.