### PR TITLE
Day picker for requested items

### DIFF
--- a/catalogue/webapp/components/ItemRequestModal/ItemRequestModal.tsx
+++ b/catalogue/webapp/components/ItemRequestModal/ItemRequestModal.tsx
@@ -12,6 +12,28 @@ import LL from '@weco/common/views/components/styled/LL';
 import { allowedRequests } from '@weco/common/values/requests';
 import RequestingDayPicker from '../RequestingDayPicker/RequestingDayPicker';
 
+const PickUpDate = styled(Space).attrs({
+  v: {
+    size: 's',
+    properties: [
+      'margin-top',
+      'margin-bottom',
+      'padding-top',
+      'padding-bottom',
+    ],
+  },
+})`
+  border-top: 1px solid ${props => props.theme.color('smoke')};
+  border-bottom: 1px solid ${props => props.theme.color('smoke')};
+
+  @media (min-width: 600px) {
+    display: flex;
+    justify-content: space-between;
+    gap: 20px;
+    min-width: min(80vw, 700px);
+  }
+`;
+
 const Header = styled(Space).attrs({
   v: { size: 'm', properties: ['margin-bottom'] },
 })`
@@ -117,10 +139,30 @@ const RequestDialog: FC<RequestDialogProps> = ({
         {item.title && <span>{item.title}</span>}
       </p>
 
-      <RequestingDayPicker
-        pickUpDate={pickUpDate}
-        setPickUpDate={setPickUpDate}
-      />
+      <Space v={{ size: 'm', properties: ['margin-top', 'margin-bottom'] }}>
+        <PickUpDate>
+          <div>
+            <p className="no-margin">
+              The date you would like to view this item in the library
+            </p>
+            <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
+              <p
+                className={classNames({
+                  [font('hnr', 6)]: true,
+                  'no-margin': true,
+                })}
+              >
+                Item requests need to be placed by 10am the day before your
+                visit
+              </p>
+            </Space>
+          </div>
+          <RequestingDayPicker
+            pickUpDate={pickUpDate}
+            setPickUpDate={setPickUpDate}
+          />
+        </PickUpDate>
+      </Space>
 
       <CTAs>
         <Space

--- a/catalogue/webapp/components/ItemRequestModal/ItemRequestModal.tsx
+++ b/catalogue/webapp/components/ItemRequestModal/ItemRequestModal.tsx
@@ -11,6 +11,7 @@ import { classNames, font } from '@weco/common/utils/classnames';
 import LL from '@weco/common/views/components/styled/LL';
 import { allowedRequests } from '@weco/common/values/requests';
 import RequestingDayPicker from '../RequestingDayPicker/RequestingDayPicker';
+import { useToggles } from '@weco/common/server-data/Context';
 
 const PickUpDate = styled(Space).attrs({
   v: {
@@ -107,6 +108,7 @@ const RequestDialog: FC<RequestDialogProps> = ({
   setIsActive,
   currentHoldNumber,
 }) => {
+  const { enablePickUpDate } = useToggles();
   const [pickUpDate, setPickUpDate] = useState<Date | undefined>();
 
   function handleConfirmRequest(event: FormEvent<HTMLFormElement>) {
@@ -139,30 +141,32 @@ const RequestDialog: FC<RequestDialogProps> = ({
         {item.title && <span>{item.title}</span>}
       </p>
 
-      <Space v={{ size: 'm', properties: ['margin-top', 'margin-bottom'] }}>
-        <PickUpDate>
-          <div>
-            <p className="no-margin">
-              The date you would like to view this item in the library
-            </p>
-            <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
-              <p
-                className={classNames({
-                  [font('hnr', 6)]: true,
-                  'no-margin': true,
-                })}
-              >
-                Item requests need to be placed by 10am the day before your
-                visit
+      {enablePickUpDate && (
+        <Space v={{ size: 'm', properties: ['margin-top', 'margin-bottom'] }}>
+          <PickUpDate>
+            <div>
+              <p className="no-margin">
+                The date you would like to view this item in the library
               </p>
-            </Space>
-          </div>
-          <RequestingDayPicker
-            pickUpDate={pickUpDate}
-            setPickUpDate={setPickUpDate}
-          />
-        </PickUpDate>
-      </Space>
+              <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
+                <p
+                  className={classNames({
+                    [font('hnr', 6)]: true,
+                    'no-margin': true,
+                  })}
+                >
+                  Item requests need to be placed by 10am the day before your
+                  visit
+                </p>
+              </Space>
+            </div>
+            <RequestingDayPicker
+              pickUpDate={pickUpDate}
+              setPickUpDate={setPickUpDate}
+            />
+          </PickUpDate>
+        </Space>
+      )}
 
       <CTAs>
         <Space

--- a/catalogue/webapp/components/RequestingDayPicker/RequestingDayPicker.tsx
+++ b/catalogue/webapp/components/RequestingDayPicker/RequestingDayPicker.tsx
@@ -89,10 +89,19 @@ const DayPickerWrapper = styled.div<DayPickerWrapperProps>`
     }
   }
 
+  .DayPickerInput-OverlayWrapper {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+  }
+
   .DayPickerInput-Overlay {
     border-radius: 6px;
-    top: 30px;
     right: 0;
+    left: auto;
+    top: calc(100% + 10px);
   }
 `;
 

--- a/catalogue/webapp/components/RequestingDayPicker/RequestingDayPicker.tsx
+++ b/catalogue/webapp/components/RequestingDayPicker/RequestingDayPicker.tsx
@@ -20,6 +20,21 @@ const DayPickerWrapper = styled.div<DayPickerWrapperProps>`
     line-height: 1;
   }
 
+  .DayPickerInput-Overlay {
+    &:before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 50%;
+      width: 0;
+      height: 0;
+      border-left: 10px solid transparent;
+      border-right: 10px solid transparent;
+      border-top: 10px solid ${props => props.theme.color('white')};
+      transform: translateX(-50%) rotate(180deg) translateY(100%);
+    }
+  }
+
   .DayPicker-Day--disabled,
   .DayPicker-Day--today {
     color: ${props => props.theme.color('marble')};

--- a/catalogue/webapp/components/RequestingDayPicker/RequestingDayPicker.tsx
+++ b/catalogue/webapp/components/RequestingDayPicker/RequestingDayPicker.tsx
@@ -1,0 +1,177 @@
+import { FC } from 'react';
+import DayPickerInput from 'react-day-picker/DayPickerInput';
+import { london } from '@weco/common/utils/format-date';
+import 'react-day-picker/lib/style.css';
+import { formatDate, parseDate } from 'react-day-picker/moment';
+import styled from 'styled-components';
+import AlignFont from '@weco/common/views/components/styled/AlignFont';
+import Icon from '@weco/common/views/components/Icon/Icon';
+import { chevron } from '@weco/common/icons';
+import { classNames, font } from '@weco/common/utils/classnames';
+import { fontFamilyMixin } from '@weco/common/views/themes/typography';
+
+const DayPickerWrapper = styled.div`
+  .DayPicker-Day {
+    line-height: 1;
+  }
+
+  .DayPicker-Day--disabled,
+  .DayPicker-Day--today {
+    color: ${props => props.theme.color('marble')};
+  }
+
+  .DayPicker-Day--today {
+    font-weight: inherit;
+  }
+
+  .DayPicker-Day--selected:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside) {
+    background-color: ${props => props.theme.color('yellow')};
+    color: ${props => props.theme.color('black')};
+  }
+
+  .DayPicker:not(.DayPicker--interactionDisabled)
+    .DayPicker-Day:not(.DayPicker-Day--disabled):not(.DayPicker-Day--selected):not(.DayPicker-Day--outside):hover {
+    background-color: ${props => props.theme.color('yellow', 'light')};
+  }
+
+  .DayPicker-NavBar {
+    position: absolute;
+    right: 1rem;
+    top: 20px;
+  }
+
+  .DayPicker-Caption {
+    color: ${props => props.theme.color('pewter')};
+    font-size: 15px;
+    ${fontFamilyMixin('hnb', true)};
+  }
+`;
+
+const IconWrapper = styled.div.attrs({
+  className: classNames({
+    [font('hnr', 3)]: true,
+  }),
+})`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background-color: ${props => props.theme.color('smoke')};
+  transition: background-color ${props => props.theme.transitionProperties};
+  cursor: pointer;
+
+  &:hover {
+    background-color: ${props => props.theme.color('marble')};
+  }
+`;
+
+type Props = {
+  pickUpDate?: Date;
+  setPickUpDate: (date: Date) => void;
+};
+
+const RequestingDayPicker: FC<Props> = ({
+  pickUpDate,
+  setPickUpDate,
+}: Props) => {
+  function renderDay(day: Date) {
+    const date = day.getDate();
+    return <AlignFont>{date}</AlignFont>;
+  }
+
+  const Weekday = ({ weekday, className, localeUtils, locale }) => {
+    const weekdayName = localeUtils.formatWeekdayLong(weekday, locale);
+    return (
+      <div
+        className={classNames({
+          [className]: true,
+          [font('hnb', 5)]: true,
+        })}
+        title={weekdayName}
+      >
+        {weekdayName.slice(0, 1)}
+      </div>
+    );
+  };
+
+  const Navbar = ({ onPreviousClick, onNextClick, className }) => {
+    return (
+      <div className={className}>
+        <button
+          className="plain-button no-padding"
+          onClick={() => onPreviousClick()}
+        >
+          <IconWrapper>
+            <Icon
+              matchText={true}
+              color={'pewter'}
+              icon={chevron}
+              rotate={90}
+            />
+          </IconWrapper>
+        </button>
+        <button className="plain-button" onClick={() => onNextClick()}>
+          <IconWrapper>
+            <Icon
+              matchText={true}
+              color={'pewter'}
+              icon={chevron}
+              rotate={270}
+            />
+          </IconWrapper>
+        </button>
+      </div>
+    );
+  };
+
+  const now = london(new Date());
+  const nextAvailableDate = london(new Date());
+  const twoWeeksFromNow = london(new Date());
+  twoWeeksFromNow.add(14, 'days');
+  const isBeforeTen = now.isBefore(10);
+  // If it's before 10am, we can request on the next day
+  // otherwise, in two days' time
+  nextAvailableDate.add(isBeforeTen ? 1 : 2, 'days');
+  const nextAvailableDateIsSunday = nextAvailableDate.day() === 0;
+  // …if that's a Sunday, move it to Monday
+  nextAvailableDate.add(nextAvailableDateIsSunday ? 1 : 0, 'days');
+
+  function handleOnDayChange(date: Date) {
+    setPickUpDate(date);
+  }
+  return (
+    <DayPickerWrapper>
+      <DayPickerInput
+        formatDate={formatDate}
+        parseDate={parseDate}
+        format="D MMMM YYYY"
+        placeholder={`Select a date`}
+        onDayChange={handleOnDayChange}
+        value={pickUpDate}
+        inputProps={{
+          required: true,
+        }}
+        dayPickerProps={{
+          renderDay: renderDay,
+          navbarElement: Navbar,
+          weekdayElement: Weekday,
+          firstDayOfWeek: 1,
+          fromMonth: nextAvailableDate.toDate(),
+          toMonth: twoWeeksFromNow.toDate(),
+          disabledDays: [
+            { daysOfWeek: [0] }, // Sundays
+            {
+              before: nextAvailableDate.toDate(),
+              after: twoWeeksFromNow.toDate(),
+            },
+            // TODO: add holidays/exceptional dates from Prismic
+          ],
+        }}
+      />
+    </DayPickerWrapper>
+  );
+};
+
+export default RequestingDayPicker;

--- a/catalogue/webapp/components/RequestingDayPicker/RequestingDayPicker.tsx
+++ b/catalogue/webapp/components/RequestingDayPicker/RequestingDayPicker.tsx
@@ -6,7 +6,7 @@ import { formatDate, parseDate } from 'react-day-picker/moment';
 import styled from 'styled-components';
 import AlignFont from '@weco/common/views/components/styled/AlignFont';
 import Icon from '@weco/common/views/components/Icon/Icon';
-import { chevron } from '@weco/common/icons';
+import { chevron, calendar } from '@weco/common/icons';
 import { classNames, font } from '@weco/common/utils/classnames';
 import { fontFamilyMixin } from '@weco/common/views/themes/typography';
 
@@ -44,6 +44,30 @@ const DayPickerWrapper = styled.div`
     color: ${props => props.theme.color('pewter')};
     font-size: 15px;
     ${fontFamilyMixin('hnb', true)};
+  }
+
+  .DayPickerInput {
+    display: flex;
+    align-items: center;
+    padding: 10px;
+    border-radius: 6px;
+    border: 1px solid ${props => props.theme.color('marble')};
+
+    &:focus-within {
+      box-shadow: ${props => props.theme.focusBoxShadow};
+    }
+
+    input {
+      width: 100%;
+
+      &,
+      &:focus,
+      &:focus-visible {
+        border: 0;
+        outline: 0;
+        appearance: none;
+      }
+    }
   }
 `;
 
@@ -138,6 +162,22 @@ const RequestingDayPicker: FC<Props> = ({
   // …if that's a Sunday, move it to Monday
   nextAvailableDate.add(nextAvailableDateIsSunday ? 1 : 0, 'days');
 
+  const WrappedInput = props => {
+    return (
+      <>
+        <input {...props} />
+        <span
+          className={classNames({
+            [font('hnr', 3)]: true,
+            'flex-inline': true,
+          })}
+        >
+          <Icon color={'pewter'} matchText icon={calendar} />
+        </span>
+      </>
+    );
+  };
+
   function handleOnDayChange(date: Date) {
     setPickUpDate(date);
   }
@@ -150,6 +190,7 @@ const RequestingDayPicker: FC<Props> = ({
         placeholder={`Select a date`}
         onDayChange={handleOnDayChange}
         value={pickUpDate}
+        component={WrappedInput}
         inputProps={{
           required: true,
         }}

--- a/catalogue/webapp/components/RequestingDayPicker/RequestingDayPicker.tsx
+++ b/catalogue/webapp/components/RequestingDayPicker/RequestingDayPicker.tsx
@@ -64,6 +64,7 @@ const DayPickerWrapper = styled.div<DayPickerWrapperProps>`
   }
 
   .DayPickerInput {
+    min-width: 190px;
     position: relative;
     display: flex;
     align-items: center;
@@ -88,14 +89,10 @@ const DayPickerWrapper = styled.div<DayPickerWrapperProps>`
     }
   }
 
-  .DayPickerInput-OverlayWrapper {
-    position: absolute;
-    top: 100%;
-    left: 10px;
-  }
-
   .DayPickerInput-Overlay {
     border-radius: 6px;
+    top: 30px;
+    right: 0;
   }
 `;
 

--- a/catalogue/webapp/components/RequestingDayPicker/RequestingDayPicker.tsx
+++ b/catalogue/webapp/components/RequestingDayPicker/RequestingDayPicker.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useState } from 'react';
 import DayPickerInput from 'react-day-picker/DayPickerInput';
 import { london } from '@weco/common/utils/format-date';
 import 'react-day-picker/lib/style.css';
@@ -10,7 +10,12 @@ import { chevron, calendar } from '@weco/common/icons';
 import { classNames, font } from '@weco/common/utils/classnames';
 import { fontFamilyMixin } from '@weco/common/views/themes/typography';
 
-const DayPickerWrapper = styled.div`
+type DayPickerWrapperProps = {
+  isPrevMonthDisabled: boolean;
+  isNextMonthDisabled: boolean;
+};
+
+const DayPickerWrapper = styled.div<DayPickerWrapperProps>`
   .DayPicker-Day {
     line-height: 1;
   }
@@ -38,6 +43,18 @@ const DayPickerWrapper = styled.div`
     position: absolute;
     right: 1rem;
     top: 20px;
+
+    button:nth-of-type(1) {
+      visibility: ${props =>
+        props.isPrevMonthDisabled ? 'hidden' : 'visible'};
+      pointer-events: ${props => (props.isPrevMonthDisabled ? 'none' : 'auto')};
+    }
+
+    button:nth-of-type(2) {
+      visibility: ${props =>
+        props.isNextMonthDisabled ? 'hidden' : 'visible'};
+      pointer-events: ${props => (props.isNextMonthDisabled ? 'none' : 'auto')};
+    }
   }
 
   .DayPicker-Caption {
@@ -135,6 +152,7 @@ const RequestingDayPicker: FC<Props> = ({
     return (
       <div className={className}>
         <button
+          type="button"
           className="plain-button no-padding"
           onClick={() => onPreviousClick()}
         >
@@ -147,7 +165,11 @@ const RequestingDayPicker: FC<Props> = ({
             />
           </IconWrapper>
         </button>
-        <button className="plain-button" onClick={() => onNextClick()}>
+        <button
+          type="button"
+          className="plain-button"
+          onClick={() => onNextClick()}
+        >
           <IconWrapper>
             <Icon
               matchText={true}
@@ -197,11 +219,26 @@ const RequestingDayPicker: FC<Props> = ({
     );
   };
 
+  const fromMonth = nextAvailableDate.toDate();
+  const toMonth = twoWeeksFromNow.toDate();
+
+  const [isPrevMonthDisabled, setIsPrevMonthDisabled] = useState(true);
+  const [isNextMonthDisabled, setIsNextMonthDisabled] = useState(false);
+
+  function handleOnMonthChange(month: Date) {
+    setIsPrevMonthDisabled(london(month).isSameOrBefore(fromMonth, 'month'));
+    setIsNextMonthDisabled(london(month).isSameOrAfter(toMonth, 'month'));
+  }
+
   function handleOnDayChange(date: Date) {
     setPickUpDate(date);
   }
+
   return (
-    <DayPickerWrapper>
+    <DayPickerWrapper
+      isPrevMonthDisabled={isPrevMonthDisabled}
+      isNextMonthDisabled={isNextMonthDisabled}
+    >
       <DayPickerInput
         formatDate={formatDate}
         parseDate={parseDate}
@@ -218,9 +255,10 @@ const RequestingDayPicker: FC<Props> = ({
           renderDay: renderDay,
           navbarElement: Navbar,
           weekdayElement: Weekday,
+          onMonthChange: handleOnMonthChange,
           firstDayOfWeek: 1,
-          fromMonth: nextAvailableDate.toDate(),
-          toMonth: twoWeeksFromNow.toDate(),
+          fromMonth,
+          toMonth,
           disabledDays: [
             { daysOfWeek: [0] }, // Sundays
             {

--- a/catalogue/webapp/components/RequestingDayPicker/RequestingDayPicker.tsx
+++ b/catalogue/webapp/components/RequestingDayPicker/RequestingDayPicker.tsx
@@ -47,6 +47,7 @@ const DayPickerWrapper = styled.div`
   }
 
   .DayPickerInput {
+    position: relative;
     display: flex;
     align-items: center;
     padding: 10px;
@@ -68,6 +69,16 @@ const DayPickerWrapper = styled.div`
         appearance: none;
       }
     }
+  }
+
+  .DayPickerInput-OverlayWrapper {
+    position: absolute;
+    top: 100%;
+    left: 10px;
+  }
+
+  .DayPickerInput-Overlay {
+    border-radius: 6px;
   }
 `;
 
@@ -150,6 +161,14 @@ const RequestingDayPicker: FC<Props> = ({
     );
   };
 
+  const Overlay = ({ classNames, selectedDay, children, ...props }) => {
+    return (
+      <div className={classNames.overlayWrapper} {...props}>
+        <div className={classNames.overlay}>{children}</div>
+      </div>
+    );
+  };
+
   const now = london(new Date());
   const nextAvailableDate = london(new Date());
   const twoWeeksFromNow = london(new Date());
@@ -194,6 +213,7 @@ const RequestingDayPicker: FC<Props> = ({
         inputProps={{
           required: true,
         }}
+        overlayComponent={Overlay}
         dayPickerProps={{
           renderDay: renderDay,
           navbarElement: Navbar,

--- a/catalogue/webapp/package.json
+++ b/catalogue/webapp/package.json
@@ -35,6 +35,7 @@
     "nodemon": "^1.17.5",
     "raven-js": "^3.27.0",
     "react": "^17.0.2",
+    "react-day-picker": "^7.4.10",
     "react-dom": "^17.0.2",
     "react-ga": "^2.5.6",
     "react-test-renderer": "^16.4.1",

--- a/catalogue/webapp/server.ts
+++ b/catalogue/webapp/server.ts
@@ -1,7 +1,7 @@
 import appPromise, { timers } from './app';
 import { clear as clearServerDataTimers } from '@weco/common/server-data';
 
-const port = process.env.PORT ?? 3000;
+const port = process.env.PORT ?? 3001;
 
 const serverPromise = appPromise
   .then(app => {

--- a/common/views/components/Modal/Modal.tsx
+++ b/common/views/components/Modal/Modal.tsx
@@ -104,7 +104,6 @@ const BaseModalWindow = styled(Space).attrs<BaseModalProps>({
   left: 0;
   right: 0;
   position: fixed;
-  overflow: auto;
   transition: opacity 350ms ease, transform 350ms ease;
 
   &,

--- a/common/views/components/Modal/Modal.tsx
+++ b/common/views/components/Modal/Modal.tsx
@@ -104,6 +104,7 @@ const BaseModalWindow = styled(Space).attrs<BaseModalProps>({
   left: 0;
   right: 0;
   position: fixed;
+  overflow: auto;
   transition: opacity 350ms ease, transform 350ms ease;
 
   &,

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -21,6 +21,12 @@ export default {
       defaultValue: false,
     },
     {
+      id: 'enablePickUpDate',
+      title: 'Enables pick up date functionality',
+      description: 'Adds a date picker to the requesting modal',
+      defaultValue: false,
+    },
+    {
       id: 'stagingApi',
       title: 'Staging API',
       defaultValue: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -15497,6 +15497,13 @@ react-colorful@^5.1.2:
   resolved "https://registry.yarnpkg.com/react-colorful/-/react-colorful-5.4.0.tgz#e05e602469f9768234f29c1bad9ec1f4e86145a2"
   integrity sha512-k7QJXuQGWevr/V8hoMJ1wBW9i2CVhBdDXpBf3jy/AAtzVyYtsFqEAT+y+NOGiSG1cmnGTreqm5EFLXlVaKbPLQ==
 
+react-day-picker@^7.4.10:
+  version "7.4.10"
+  resolved "https://registry.yarnpkg.com/react-day-picker/-/react-day-picker-7.4.10.tgz#d3928fa65c04379ad28c76de22aa85374a8361e1"
+  integrity sha512-/QkK75qLKdyLmv0kcVzhL7HoJPazoZXS8a6HixbVoK6vWey1Od1WRLcxfyEiUsRfccAlIlf6oKHShqY2SM82rA==
+  dependencies:
+    prop-types "^15.6.2"
+
 react-dev-utils@^11.0.3:
   version "11.0.4"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-11.0.4.tgz#a7ccb60257a1ca2e0efe7a83e38e6700d17aa37a"


### PR DESCRIPTION
Part of #7266

## Who is this for?
LE&E

## What is it doing for them?
Letting them know when users want to pick up their held items.

![image](https://user-images.githubusercontent.com/1394592/142731644-4900b67e-db3e-4d65-95ed-646698761f13.png)

- Having the day picker break out of the modal window would be tricky. I think it would be possible with a `Portal` . Since JS is required for the calendar overlay, I think it could be a justifiable use-case if required, but for the time-being I've kept it simple, and the calendar loads in within the modal, creating more scrollable space if required.
- I've hidden the prev/next month buttons where appropriate, because there's only a relatively narrow date-range that can be selected
- I made some font and shade-of-grey design decisions that'll need reviewing(!)
- Things get a little bit weird responsively, so I removed the colon after 'The date you would like to view this item in the library'.

__TODO__
- [ ] Include holidays and exceptional closure dates from Prismic as disabled
- [ ] Should the 2-weeks-from-now cut-off take into account any holiday/exceptional closures?
- [ ] Send date through to Sierra
- [ ] Test

