### PR TITLE
Exhibition/EventPromo

### DIFF
--- a/cardigan/stories/components/Cards/Cards.stories.mdx
+++ b/cardigan/stories/components/Cards/Cards.stories.mdx
@@ -3,7 +3,7 @@ import CompactCardReadme from '@weco/common/views/components/CompactCard/README.
 import BannerCardReadme from '@weco/common/views/components/BannerCard/README.md';
 import FeaturedCardReadme from '@weco/common/views/components/FeaturedCard/README.md';
 import EventPromoReadme from '@weco/common/views/components/EventPromo/README.md';
-import ExhibitionPromoReadme from '@weco/common/views/components/ExhibitionPromo/README.md';
+import ExhibitionPromoReadme from '@weco/content/components/ExhibitionPromo/README.md';
 import StoryPromoReadme from '@weco/content/components/StoryPromo/README.md';
 import * as stories from './Cards.stories.tsx';
 

--- a/cardigan/stories/components/Cards/Cards.stories.mdx
+++ b/cardigan/stories/components/Cards/Cards.stories.mdx
@@ -2,7 +2,7 @@ import { Meta, Canvas, Story, ArgsTable, Description } from '@storybook/addon-do
 import CompactCardReadme from '@weco/common/views/components/CompactCard/README.md';
 import BannerCardReadme from '@weco/common/views/components/BannerCard/README.md';
 import FeaturedCardReadme from '@weco/common/views/components/FeaturedCard/README.md';
-import EventPromoReadme from '@weco/common/views/components/EventPromo/README.md';
+import EventPromoReadme from '@weco/content/components/EventPromo/README.md';
 import ExhibitionPromoReadme from '@weco/content/components/ExhibitionPromo/README.md';
 import StoryPromoReadme from '@weco/content/components/StoryPromo/README.md';
 import * as stories from './Cards.stories.tsx';

--- a/cardigan/stories/components/Cards/Cards.stories.tsx
+++ b/cardigan/stories/components/Cards/Cards.stories.tsx
@@ -1,7 +1,7 @@
 import CompactCard from '@weco/common/views/components/CompactCard/CompactCard';
 import BannerCard from '@weco/common/views/components/BannerCard/BannerCard';
 import FeaturedCard from '@weco/common/views/components/FeaturedCard/FeaturedCard';
-import EventPromo from '@weco/common/views/components/EventPromo/EventPromo';
+import EventPromo from '@weco/content/components/EventPromo/EventPromo';
 import ExhibitionPromo from '@weco/content/components/ExhibitionPromo/ExhibitionPromo';
 import StoryPromo from '@weco/content/components/StoryPromo/StoryPromo';
 

--- a/cardigan/stories/components/Cards/Cards.stories.tsx
+++ b/cardigan/stories/components/Cards/Cards.stories.tsx
@@ -2,7 +2,7 @@ import CompactCard from '@weco/common/views/components/CompactCard/CompactCard';
 import BannerCard from '@weco/common/views/components/BannerCard/BannerCard';
 import FeaturedCard from '@weco/common/views/components/FeaturedCard/FeaturedCard';
 import EventPromo from '@weco/common/views/components/EventPromo/EventPromo';
-import ExhibitionPromo from '@weco/common/views/components/ExhibitionPromo/ExhibitionPromo';
+import ExhibitionPromo from '@weco/content/components/ExhibitionPromo/ExhibitionPromo';
 import StoryPromo from '@weco/content/components/StoryPromo/StoryPromo';
 
 import { UiImage } from '@weco/common/views/components/Images/Images';

--- a/common/model/exhibitions.ts
+++ b/common/model/exhibitions.ts
@@ -37,9 +37,9 @@ export type ExhibitionPromo = {
   url: string;
   title: string;
   shortTitle?: string;
-  image: ImageType;
+  image?: ImageType;
   squareImage?: Picture;
-  start: Date;
+  start?: Date;
   end?: Date;
   statusOverride?: string;
 };

--- a/common/model/picture.ts
+++ b/common/model/picture.ts
@@ -3,7 +3,7 @@ import { Tasl } from './tasl';
 export type Picture = {
   contentUrl: string;
   width: number;
-  height: number | null;
+  height: number;
   alt: string;
   tasl: Tasl;
   minWidth: string | null; // This must have a CSS unit attached

--- a/common/views/components/EventPromo/README.md
+++ b/common/views/components/EventPromo/README.md
@@ -1,3 +1,0 @@
-## Purpose
-
-[Edit this on GitHub](https://github.com/wellcomecollection/wellcomecollection.org/edit/main/common/views/components/EventPromo/README.md)

--- a/common/views/components/ExhibitionPromo/README.md
+++ b/common/views/components/ExhibitionPromo/README.md
@@ -1,3 +1,0 @@
-## Purpose
-
-[Edit this on GitHub](https://github.com/wellcomecollection/wellcomecollection.org/edit/main/common/views/components/ExhibitionPromo/README.md)

--- a/content/webapp/components/CardGrid/CardGrid.tsx
+++ b/content/webapp/components/CardGrid/CardGrid.tsx
@@ -10,7 +10,6 @@ import { Book } from '@weco/common/model/books';
 import { Article } from '@weco/common/model/articles';
 import { Page } from '@weco/common/model/pages';
 import { ArticleSeries } from '@weco/common/model/article-series';
-import ExhibitionPromo from '@weco/common/views/components/ExhibitionPromo/ExhibitionPromo';
 import EventPromo from '@weco/common/views/components/EventPromo/EventPromo';
 import BookPromo from '@weco/common/views/components/BookPromo/BookPromo';
 import Layout12 from '@weco/common/views/components/Layout12/Layout12';
@@ -18,6 +17,7 @@ import MoreLink from '@weco/common/views/components/MoreLink/MoreLink';
 import Space from '@weco/common/views/components/styled/Space';
 import CssGridContainer from '@weco/common/views/components/styled/CssGridContainer';
 import Card from '@weco/common/views/components/Card/Card';
+import ExhibitionPromo from '../ExhibitionPromo/ExhibitionPromo';
 import StoryPromo from '../StoryPromo/StoryPromo';
 
 import DailyTourPromo from './DailyTourPromo';
@@ -71,16 +71,20 @@ const CardGrid: FunctionComponent<Props> = ({
             >
               {item.id === 'tours' && <DailyTourPromo />}
 
-              {item.type === 'exhibitions' && ( // TODO: (remove Picture type)
+              {item.type === 'exhibitions' && (
                 <ExhibitionPromo
                   id={item.id}
                   url={`/exhibitions/${item.id}`}
                   title={item.title}
                   shortTitle={item.shortTitle}
-                  format={item.format} // TODO: (remove Picture type)
-                  image={item.promoImage}
-                  start={!item.isPermanent ? item.start : null}
-                  end={!item.isPermanent ? item.end : null}
+                  format={item.format}
+                  image={
+                    item.promoImage
+                      ? { ...item.promoImage, crops: {} }
+                      : undefined
+                  }
+                  start={!item.isPermanent ? item.start : undefined}
+                  end={!item.isPermanent ? item.end : undefined}
                   statusOverride={item.statusOverride}
                   position={i}
                 />

--- a/content/webapp/components/CardGrid/CardGrid.tsx
+++ b/content/webapp/components/CardGrid/CardGrid.tsx
@@ -1,5 +1,5 @@
 import { FunctionComponent } from 'react';
-import Moment from 'moment';
+import moment from 'moment';
 import { classNames, cssGrid } from '@weco/common/utils/classnames';
 import { Link } from '@weco/common/model/link';
 import { convertItemToCardProps } from '@weco/common/model/card';
@@ -39,7 +39,7 @@ type Props = {
   itemsPerRow: number;
   itemsHaveTransparentBackground?: boolean;
   links?: Link[];
-  fromDate?: typeof Moment;
+  fromDate?: moment.Moment;
 };
 
 const CardGrid: FunctionComponent<Props> = ({

--- a/content/webapp/components/CardGrid/CardGrid.tsx
+++ b/content/webapp/components/CardGrid/CardGrid.tsx
@@ -10,13 +10,13 @@ import { Book } from '@weco/common/model/books';
 import { Article } from '@weco/common/model/articles';
 import { Page } from '@weco/common/model/pages';
 import { ArticleSeries } from '@weco/common/model/article-series';
-import EventPromo from '@weco/common/views/components/EventPromo/EventPromo';
 import BookPromo from '@weco/common/views/components/BookPromo/BookPromo';
 import Layout12 from '@weco/common/views/components/Layout12/Layout12';
 import MoreLink from '@weco/common/views/components/MoreLink/MoreLink';
 import Space from '@weco/common/views/components/styled/Space';
 import CssGridContainer from '@weco/common/views/components/styled/CssGridContainer';
 import Card from '@weco/common/views/components/Card/Card';
+import EventPromo from '../EventPromo/EventPromo';
 import ExhibitionPromo from '../ExhibitionPromo/ExhibitionPromo';
 import StoryPromo from '../StoryPromo/StoryPromo';
 

--- a/content/webapp/components/CardGrid/DailyTourPromo.tsx
+++ b/content/webapp/components/CardGrid/DailyTourPromo.tsx
@@ -1,3 +1,4 @@
+import { UiEvent } from '@weco/common/model/events';
 import EventPromo from '../EventPromo/EventPromo';
 
 const image = {
@@ -16,31 +17,31 @@ const image = {
     title: null,
   },
   crops: {},
+  minWidth: null,
 };
 
-export const data = {
+export const data: UiEvent = {
   type: 'events',
   id: 'tours',
   title: 'Daily Guided Tours and Discussions',
   times: [],
   series: [],
-  place: null,
-  bookingEnquiryTeam: null,
+  place: undefined,
+  bookingEnquiryTeam: undefined,
   interpretations: [],
   audiences: [],
   policies: [],
-  bookingInformation: null,
-  cost: null,
-  bookingType: null,
-  thirdPartyBooking: null,
+  bookingInformation: undefined,
+  cost: undefined,
+  bookingType: undefined,
+  thirdPartyBooking: undefined,
   isCompletelySoldOut: false,
   isPast: false,
   isRelaxedPerformance: false,
   format: {
     id: 'WmYRpCQAACUAn-Ap',
     title: 'Gallery tour',
-    shortName: null,
-    description: null,
+    description: undefined,
   },
   body: [],
   contributors: [],
@@ -69,7 +70,7 @@ export const data = {
   squareImage: null,
   widescreenImage: null,
   superWidescreenImage: null,
-  ticketSalesStart: null,
+  ticketSalesStart: undefined,
   displayEnd: new Date(),
   displayStart: new Date(),
   standfirst: null,

--- a/content/webapp/components/CardGrid/DailyTourPromo.tsx
+++ b/content/webapp/components/CardGrid/DailyTourPromo.tsx
@@ -1,4 +1,4 @@
-import EventPromo from '@weco/common/views/components/EventPromo/EventPromo';
+import EventPromo from '../EventPromo/EventPromo';
 
 const image = {
   contentUrl:

--- a/content/webapp/components/EventDatesLink/README.md
+++ b/content/webapp/components/EventDatesLink/README.md
@@ -2,4 +2,4 @@
 
 To scroll a user to the list of dates and times on an event page.
 
-[Edit this on GitHub](https://github.com/wellcomecollection/wellcomecollection.org/edit/main/common/views/components/EventDatesLink/README.md)
+[Edit this on GitHub](https://github.com/wellcomecollection/wellcomecollection.org/edit/main/content/webapp/components/EventsDatesLink/README.md)

--- a/content/webapp/components/EventPromo/EventPromo.tsx
+++ b/content/webapp/components/EventPromo/EventPromo.tsx
@@ -1,31 +1,27 @@
-// @flow
-// $FlowFixMe (ts)
-import { font, classNames } from '../../../utils/classnames';
-import { trackEvent } from '../../../utils/ga';
-import { UiImage } from '../Images/Images';
-// $FlowFixMe (tsx)
-import LabelsList from '../LabelsList/LabelsList';
-// $FlowFixMe (tsx)
-import Dot from '../Dot/Dot';
-import EventDateRange from '../EventDateRange/EventDateRange';
-import { type UiEvent, isEventFullyBooked } from '../../../model/events';
-import Moment from 'moment';
-// $FlowFixMe (tsx)
-import Space from '../styled/Space';
-// $FlowFixMe (tsx)
-import { CardOuter, CardBody, CardPostBody } from '../Card/Card';
-/* $FlowFixMe (tsx) */
-import Divider from '../Divider/Divider';
-/* $FlowFixMe (ts) */
-import WatchLabel from '../WatchLabel/WatchLabel';
+import moment from 'moment';
+import { font, classNames } from '@weco/common/utils/classnames';
+import { trackEvent } from '@weco/common/utils/ga';
+import { UiImage } from '@weco/common/views/components/Images/Images';
+import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
+import Dot from '@weco/common/views/components/Dot/Dot';
+import EventDateRange from '@weco/common/views/components/EventDateRange/EventDateRange';
+import { UiEvent, isEventFullyBooked } from '@weco/common/model/events';
+import Space from '@weco/common/views/components/styled/Space';
+import {
+  CardOuter,
+  CardBody,
+  CardPostBody,
+} from '@weco/common/views/components/Card/Card';
+import Divider from '@weco/common/views/components/Divider/Divider';
+import WatchLabel from '@weco/common/views/components/WatchLabel/WatchLabel';
 
-type Props = {|
-  event: UiEvent,
-  position?: number,
-  dateString?: string,
-  timeString?: string,
-  fromDate?: Moment,
-|};
+type Props = {
+  event: UiEvent;
+  position?: number;
+  dateString?: string;
+  timeString?: string;
+  fromDate?: moment.Moment;
+};
 
 const EventPromo = ({
   event,
@@ -50,9 +46,7 @@ const EventPromo = ({
       }}
     >
       <div className="relative">
-        {/* FIXME: Image type tidy */}
         {event.promoImage && (
-          // $FlowFixMe
           <UiImage
             {...event.promoImage}
             alt=""

--- a/content/webapp/components/EventPromo/README.md
+++ b/content/webapp/components/EventPromo/README.md
@@ -1,0 +1,3 @@
+## Purpose
+
+[Edit this on GitHub](https://github.com/wellcomecollection/wellcomecollection.org/edit/main/content/webapp/components/EventPromo/README.md)

--- a/content/webapp/components/ExhibitionPromo/ExhibitionPromo.tsx
+++ b/content/webapp/components/ExhibitionPromo/ExhibitionPromo.tsx
@@ -1,30 +1,23 @@
-// @flow
 import { Fragment } from 'react';
-// $FlowFixMe (ts)
-import { font, classNames } from '../../../utils/classnames';
-import { trackEvent } from '../../../utils/ga';
-import { formatDate } from '../../../utils/format-date';
-import { UiImage } from '../Images/Images';
-// $FlowFixMe (tsx)
-import LabelsList from '../LabelsList/LabelsList';
-import { type ExhibitionPromo as ExhibitionPromoProps } from '../../../model/exhibitions';
-import StatusIndicator from '../StatusIndicator/StatusIndicator';
-// $FlowFixMe (tsx)
-import Space from '../styled/Space';
-// $FlowFixMe (tsx)
-import { CardOuter, CardBody } from '../Card/Card';
+import { font, classNames } from '@weco/common/utils/classnames';
+import { trackEvent } from '@weco/common/utils/ga';
+import { formatDate } from '@weco/common/utils/format-date';
+import { ExhibitionPromo as ExhibitionPromoProps } from '@weco/common/model/exhibitions';
+import { UiImage } from '@weco/common/views/components/Images/Images';
+import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
+import StatusIndicator from '@weco/common/views/components/StatusIndicator/StatusIndicator';
+import Space from '@weco/common/views/components/styled/Space';
+import { CardOuter, CardBody } from '@weco/common/views/components/Card/Card';
 
-type Props = {|
-  ...ExhibitionPromoProps,
-  position?: number,
-|};
+type Props = ExhibitionPromoProps & {
+  position?: number;
+};
 
 const ExhibitionPromo = ({
   format,
   id,
   url,
   title,
-  shortTitle,
   image,
   start,
   end,

--- a/content/webapp/components/ExhibitionPromo/README.md
+++ b/content/webapp/components/ExhibitionPromo/README.md
@@ -1,0 +1,3 @@
+## Purpose
+
+[Edit this on GitHub](https://github.com/wellcomecollection/wellcomecollection.org/edit/main/content/webapp/components/ExhibitionPromo/README.md)

--- a/content/webapp/components/SeasonsHeader/README.md
+++ b/content/webapp/components/SeasonsHeader/README.md
@@ -2,4 +2,4 @@
 
 Header for Seasons page.
 
-[Edit this on GitHub](https://github.com/wellcomecollection/wellcomecollection.org/edit/main/common/views/components/SeasonsHeader/README.md)
+[Edit this on GitHub](https://github.com/wellcomecollection/wellcomecollection.org/edit/main/content/webapp/components/SeasonsHeader/README.md)


### PR DESCRIPTION
## Who is this for?
Me wanting to move more prismic stuff over but can't because of common/content coupling

## What is it doing for them?
Moves over some more components that aren't common

There's a couple of gross pieces with images (`UiImage`, `ImageType`, `Picture` <= these are all in our system annoyingly), but that what the refactoring is going to help remove

#7302
#7363 