### PR TITLE
Display exceptional opening times

### DIFF
--- a/common/services/prismic/opening-times.js
+++ b/common/services/prismic/opening-times.js
@@ -259,7 +259,7 @@ export function getUpcomingExceptionalPeriods(
   const nextUpcomingPeriods = exceptionalPeriods.filter(period => {
     const upcomingPeriod = period.find(d => {
       return (
-        d.overrideDate.isSameOrBefore(london().add(14, 'day'), 'day') &&
+        d.overrideDate.isSameOrBefore(london().add(28, 'day'), 'day') &&
         d.overrideDate.isSameOrAfter(london(), 'day')
       );
     });


### PR DESCRIPTION
## Who is this for?
People who want to know when we are closed

## What is it doing for them?
Displaying the exceptional opening times from 4 weeks out instead of 2 weeks out