### PR TITLE
change color selection to what editors can select

### DIFF
--- a/cardigan/stories/components/ImagePlaceholder/ImagePlaceholder.stories.tsx
+++ b/cardigan/stories/components/ImagePlaceholder/ImagePlaceholder.stories.tsx
@@ -3,6 +3,6 @@ import ImagePlaceholder from '@weco/common/views/components/ImagePlaceholder/Ima
 const Template = args => <ImagePlaceholder {...args} />;
 export const basic = Template.bind({});
 basic.args = {
-  color: 'turquoise',
+  color: 'teal',
 };
 basic.storyName = 'ImagePlaceholder';

--- a/cardigan/stories/content.ts
+++ b/cardigan/stories/content.ts
@@ -287,7 +287,7 @@ export const editorialSeries = [
         spans: [],
       },
     ],
-    color: 'turquoise',
+    color: 'teal',
     schedule: [
       {
         title: [{ type: 'heading1', text: 'First heading', spans: [] }],

--- a/common/model/articles.ts
+++ b/common/model/articles.ts
@@ -3,7 +3,6 @@ import { GenericContentFields } from './generic-content-fields';
 import { ColorSelection } from './color-selections';
 import { MultiContent } from './multi-content';
 import { Season } from './seasons';
-import { EditorialSeriesColour } from './editorial-series';
 import { Format } from './format';
 import { ArticleFormatId } from './content-format-id';
 
@@ -34,6 +33,6 @@ export function getPositionInSeries(article: Article): number | undefined {
   }
 }
 
-export function getArticleColor(article: Article): EditorialSeriesColour {
+export function getArticleColor(article: Article): ColorSelection {
   return article.series.map(series => series.color).find(Boolean) || 'purple';
 }

--- a/common/model/color-selections.js
+++ b/common/model/color-selections.js
@@ -1,10 +1,11 @@
 // @flow
-
+// These colours should match those available to editors in the Prismic model
+// see: https://github.com/wellcomecollection/wellcomecollection.org/blob/main/prismic-model/src/series.ts#L22
 export const ColorSelections = {
-  Turquoise: 'turquoise',
-  Red: 'red',
   Green: 'green',
   Purple: 'purple',
+  Red: 'red',
+  Teal: 'teal',
 };
 
 export type ColorSelection = $Values<typeof ColorSelections>;

--- a/common/model/color-selections.ts
+++ b/common/model/color-selections.ts
@@ -1,9 +1,10 @@
+// These colours should match those available to editors in the Prismic model
+// see: https://github.com/wellcomecollection/wellcomecollection.org/blob/main/prismic-model/src/series.ts#L22
 export const ColorSelections = {
-  Turquoise: 'turquoise',
-  Teal: 'teal',
-  Red: 'red',
   Green: 'green',
   Purple: 'purple',
+  Red: 'red',
+  Teal: 'teal',
 } as const;
 
 export type ColorSelection =

--- a/common/model/editorial-series.ts
+++ b/common/model/editorial-series.ts
@@ -1,12 +1,7 @@
-export type EditorialSeriesColour =
-  | 'teal'
-  | 'turquoise'
-  | 'red'
-  | 'green'
-  | 'purple';
+import { ColorSelection } from './color-selections';
 
 export type EditorialSeries = {
   name: string;
   description: string;
-  colour: EditorialSeriesColour;
+  colour: ColorSelection;
 };

--- a/prismic-model/src/series.ts
+++ b/prismic-model/src/series.ts
@@ -19,7 +19,7 @@ const articleSeries: CustomType = {
   json: {
     'Story series': {
       title: title,
-      color: select('Colour', ['teal', 'red', 'green', 'purple']),
+      color: select('Colour', ['green', 'purple', 'red', 'teal']),
       body,
     },
     Schedule: {


### PR DESCRIPTION
#7363 

Removes `turquoise` as the editors can't select that color.

We could have this as common config somewhere, but we don't share code with the prismic model, so didn't want to cross that dependency line.