### PR TITLE
Viewer bug - extra image

### DIFF
--- a/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
@@ -254,6 +254,8 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
   const firstRotation = firstRotatedImage ? firstRotatedImage.rotation : 0;
   const activeIndexRef = useRef(activeIndex);
   const previousManifestIndex = useRef(manifestIndex);
+  const hasIiifImage = urlTemplate && imageUrl && iiifImageLocation;
+  const hasImageService = mainImageService['@id'] && currentCanvas;
 
   useEffect(() => {
     const fetchImageJson = async () => {
@@ -488,7 +490,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
           ref={mainAreaRef}
         >
           {!showZoomed && <ImageViewerControls />}
-          {urlTemplate && imageUrl && iiifImageLocation && (
+          {hasIiifImage && !hasImageService && (
             <ImageViewer
               infoUrl={iiifImageLocation.url}
               id={imageUrl}
@@ -504,7 +506,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
               setImageContainerRect={() => undefined}
             />
           )}
-          {mainImageService['@id'] && currentCanvas && (
+          {hasImageService && (
             <MainViewer
               mainViewerRef={mainViewerRef}
               mainAreaRef={mainAreaRef}


### PR DESCRIPTION
If a work has a iiifImageLocation and an image service from a iiif manifest, we only want to show the main viewer

## Who is this for?
People who don't want to see extra images in the viewer

## What is it doing for them?
Stopping this from happening
<img width="878" alt="Screenshot 2021-11-30 at 12 09 49" src="https://user-images.githubusercontent.com/6051896/144045022-a789ba77-4180-45e9-9138-e76e46e0338f.png">

