### PR TITLE
Request the new token format

### DIFF
--- a/identity/webapp/src/routes/auth0-auth.ts
+++ b/identity/webapp/src/routes/auth0-auth.ts
@@ -5,6 +5,15 @@ import { config } from '../config';
 import * as querystring from 'query-string';
 import { URL } from 'url';
 
+const identityApiScopes = [
+  'create:requests',
+  'delete:patron',
+  'read:user',
+  'read:requests',
+  'update:email',
+  'update:password',
+];
+
 const loginAction: RouteMiddleware = (ctx, next) => {
   if (!ctx.session.returnTo) {
     // Don't overwrite returnTo if e.g. user enters wrong password
@@ -12,7 +21,8 @@ const loginAction: RouteMiddleware = (ctx, next) => {
   }
 
   koaPassport.authenticate('auth0', {
-    scope: 'openid profile email',
+    scope: ['openid', ...identityApiScopes].join(' '),
+    audience: config.remoteApi.host,
   })(ctx, next);
 };
 


### PR DESCRIPTION
By requesting a token for the Identity API audience (https://github.com/wellcomecollection/identity/pull/217), we will be able to use the new authorizer (https://github.com/wellcomecollection/identity/pull/218).

By including the `openid` scope, [we can still use that token](https://auth0.com/docs/security/tokens/access-tokens/get-access-tokens#multiple-audiences) with the existing authorizer! Win-win 🎉 
