### PR TITLE
remove organisations URL

### DIFF
--- a/prismic-model/src/organisations.ts
+++ b/prismic-model/src/organisations.ts
@@ -20,7 +20,6 @@ const organisations: CustomType = {
         link: text('Link'),
         title: heading('Title (override)'),
       }),
-      url: text('URL (deprecated)'),
     },
   },
 };


### PR DESCRIPTION
Saw the word deprecated. We now use `SameAs`.
We don't render the URL either. 

A list just in case:
https://gist.github.com/jamesgorrie/735abe06a43a598c3ab690b485b38bdf