### PR TITLE
Don't show 'undefined' if no ref number in a middle crumb

### DIFF
--- a/catalogue/webapp/components/ArchiveBreadcrumb/ArchiveBreadcrumb.test.tsx
+++ b/catalogue/webapp/components/ArchiveBreadcrumb/ArchiveBreadcrumb.test.tsx
@@ -44,6 +44,62 @@ describe('ArchiveBreadcrumb', () => {
     ).toBeTruthy();
   });
 
+  it("omits the reference number in a middle crumb if there isn't one", () => {
+    const w: Work = {
+      id: 'x56u8dnf',
+      title: 'Cĕrita hantu setan',
+      alternativeTitles: [],
+      workType: {
+        id: 'h',
+        label: 'Archives and manuscripts',
+        type: 'Format',
+      },
+      parts: [],
+      partOf: [
+        {
+          id: 'wz7z8468',
+          title: 'Wellcome Malay 3 part 2',
+          partOf: [
+            {
+              id: 'v495u8s2',
+              title: 'Wellcome Malay 3',
+              referenceNumber: 'Wellcome Malay 3',
+              partOf: [],
+              totalParts: 6,
+              totalDescendentParts: 15,
+              type: 'Work',
+            },
+          ],
+          totalParts: 1,
+          totalDescendentParts: 1,
+          type: 'Work',
+        },
+      ],
+      precededBy: [],
+      succeededBy: [],
+      physicalDescription: '1 file',
+      contributors: [],
+      subjects: [],
+      genres: [],
+      identifiers: [],
+      production: [],
+      languages: [],
+      notes: [],
+      holdings: [],
+      availabilities: [],
+      availableOnline: false,
+      type: 'Work',
+    };
+
+    const component = shallowWithTheme(
+      <IsArchiveContext.Provider value={true}>
+        <ArchiveBreadcrumb work={w} />
+      </IsArchiveContext.Provider>
+    );
+    const componentHtml = component.html();
+    expect(componentHtml.indexOf('undefined')).toBe(-1);
+  });
+
   it("omits the reference number in the last crumb if there isn't one", () => {
     const w: Work = {
       id: 'eyfq7xd9',

--- a/catalogue/webapp/components/ArchiveBreadcrumb/ArchiveBreadcrumb.tsx
+++ b/catalogue/webapp/components/ArchiveBreadcrumb/ArchiveBreadcrumb.tsx
@@ -164,7 +164,11 @@ const ArchiveBreadcrumb: FunctionComponent<Props> = ({ work }: Props) => {
                   <ArchiveWorkLink id={crumb.id}>
                     <a className="crumb-inner">
                       <WorkTitle
-                        title={`${crumb.title} ${crumb.referenceNumber}`}
+                        title={`${crumb.title}${
+                          crumb.referenceNumber
+                            ? ` ${crumb.referenceNumber}`
+                            : ''
+                        }`}
                       />
                     </a>
                   </ArchiveWorkLink>


### PR DESCRIPTION
## Who is this for?

People looking at TEI works on our website.

## What is it doing for them?

Putting less "undefined" page jank in their breadcrumb trail. Closes https://github.com/wellcomecollection/wellcomecollection.org/issues/7347

Before:

<img width="649" alt="Screenshot 2021-12-02 at 14 10 31" src="https://user-images.githubusercontent.com/301220/144438508-1b84fb73-c4e5-422b-b53f-dfb0be3dd661.png">

After:

<img width="581" alt="Screenshot 2021-12-02 at 14 10 58" src="https://user-images.githubusercontent.com/301220/144438517-cf4b4980-8409-48e0-8c0c-a00886ab03af.png">

