### PR TITLE
add outro fetch links to article fetcher

### DIFF
--- a/common/services/prismic/articles.js
+++ b/common/services/prismic/articles.js
@@ -364,6 +364,7 @@ export function parseArticleDoc(document: PrismicDocument): Article {
   // When we imported data into Prismic from the Wordpress blog some content
   // needed to have its original publication date displayed. It is purely a display
   // value and does not affect ordering.
+
   const datePublished =
     data.publishDate || document.first_publication_date || undefined;
 

--- a/content/webapp/services/prismic/fetch/articles.ts
+++ b/content/webapp/services/prismic/fetch/articles.ts
@@ -2,7 +2,19 @@ import { Query } from '@prismicio/types';
 import { GetServerSidePropsPrismicClient } from '.';
 import { ArticlePrismicDocument } from '../articles';
 
+// This is for the outro links
+const documentLinkTypes = [
+  'pages',
+  'event-series',
+  'books',
+  'events',
+  'articles',
+  'exhibitions',
+  'series',
+].flatMap(type => [`${type}.title`, `${type}.promo`]);
+
 const fetchLinks = [
+  ...documentLinkTypes,
   'series.title',
   'article-formats.title',
   'people.name',

--- a/content/webapp/services/prismic/fetch/articles.ts
+++ b/content/webapp/services/prismic/fetch/articles.ts
@@ -15,7 +15,6 @@ const documentLinkTypes = [
 
 const fetchLinks = [
   ...documentLinkTypes,
-  'series.title',
   'article-formats.title',
   'people.name',
   'people.image',


### PR DESCRIPTION
Quick fix, in short we aren't fetching the linked document fields for the outro on articles.

I really hate this part of Prismic:
https://prismic.io/docs/technologies/fetch-linked-document-fields-javascript

Partialled caused through negelegence, lack of testing, and this is all not typed. I'll move this over in a new PR.

https://prismic.io/docs/technologies/fetch-linked-document-fields-javascript