### PR TITLE
Use `basePath` for the /account prefix when in Next-land

### DIFF
--- a/identity/webapp/next.config.js
+++ b/identity/webapp/next.config.js
@@ -29,6 +29,7 @@ const config = function (webpack) {
   });
 
   return withTM({
+    basePath: '/account',
     assetPrefix:
       isProd && prodSubdomain
         ? `https://${prodSubdomain}.wellcomecollection.org`

--- a/identity/webapp/pages/delete-requested.tsx
+++ b/identity/webapp/pages/delete-requested.tsx
@@ -3,8 +3,8 @@ import {
   Container,
   Wrapper,
   SectionHeading,
-} from '../../src/frontend/components/Layout.style';
-import { PageWrapper } from '../../src/frontend/components/PageWrapper';
+} from '../src/frontend/components/Layout.style';
+import { PageWrapper } from '../src/frontend/components/PageWrapper';
 import Layout10 from '@weco/common/views/components/Layout10/Layout10';
 import Space from '@weco/common/views/components/styled/Space';
 import { getServerData } from '@weco/common/server-data';

--- a/identity/webapp/pages/error.tsx
+++ b/identity/webapp/pages/error.tsx
@@ -1,11 +1,11 @@
 import { GetServerSideProps, NextPage } from 'next';
 import { OutlinedButton } from '@weco/common/views/components/ButtonOutlined/ButtonOutlined';
-import { PageWrapper } from '../../src/frontend/components/PageWrapper';
+import { PageWrapper } from '../src/frontend/components/PageWrapper';
 import {
   Container,
   Wrapper,
   SectionHeading,
-} from '../../src/frontend/components/Layout.style';
+} from '../src/frontend/components/Layout.style';
 import Layout10 from '@weco/common/views/components/Layout10/Layout10';
 import Space from '@weco/common/views/components/styled/Space';
 import { getServerData } from '@weco/common/server-data';

--- a/identity/webapp/pages/index.tsx
+++ b/identity/webapp/pages/index.tsx
@@ -153,9 +153,7 @@ const AccountPage: NextPage = () => {
 
   const logoutOnDeletionRequest = () => {
     router.replace(
-      `/account/logout?returnTo=${encodeURIComponent(
-        '/account/delete-requested'
-      )}`
+      `/logout?returnTo=${encodeURIComponent('/delete-requested')}`
     );
   };
 

--- a/identity/webapp/pages/registration.tsx
+++ b/identity/webapp/pages/registration.tsx
@@ -1,11 +1,11 @@
 import { useEffect, FormEvent } from 'react';
-import usePasswordRules from '../../src/frontend/hooks/usePasswordRules';
+import usePasswordRules from '../src/frontend/hooks/usePasswordRules';
 import { NextPage, GetServerSideProps } from 'next';
 import { useForm, Controller, useWatch } from 'react-hook-form';
 import { ErrorMessage } from '@hookform/error-message';
 import NextLink from 'next/link';
-import { AccountCreated } from '../../src/frontend/Registration/AccountCreated';
-import { PageWrapper } from '../../src/frontend/components/PageWrapper';
+import { AccountCreated } from '../src/frontend/Registration/AccountCreated';
+import { PageWrapper } from '../src/frontend/components/PageWrapper';
 import { useRouter } from 'next/router';
 import {
   Cancel,
@@ -14,12 +14,12 @@ import {
   ExternalLink,
   CheckboxLabel,
   InProgress,
-} from '../../src/frontend/Registration/Registration.style';
+} from '../src/frontend/Registration/Registration.style';
 import {
   Container,
   Wrapper,
   SectionHeading,
-} from '../../src/frontend/components/Layout.style';
+} from '../src/frontend/components/Layout.style';
 import WellcomeTextInput, {
   TextInputErrorMessage,
 } from '@weco/common/views/components/TextInput/TextInput';
@@ -27,14 +27,14 @@ import Icon from '@weco/common/views/components/Icon/Icon';
 import {
   useRegisterUser,
   RegistrationError,
-} from '../../src/frontend/Registration/useRegisterUser';
-import { usePageTitle } from '../../src/frontend/hooks/usePageTitle';
+} from '../src/frontend/Registration/useRegisterUser';
+import { usePageTitle } from '../src/frontend/hooks/usePageTitle';
 import {
   validEmailPattern,
   validPasswordPattern,
-} from '../../src/frontend/components/ValidationPatterns';
-import { PasswordRules } from '../../src/frontend/components/PasswordInput';
-import { PasswordInput } from '../../src/frontend/Registration/PasswordInput';
+} from '../src/frontend/components/ValidationPatterns';
+import { PasswordRules } from '../src/frontend/components/PasswordInput';
+import { PasswordInput } from '../src/frontend/Registration/PasswordInput';
 import Layout10 from '@weco/common/views/components/Layout10/Layout10';
 import Space from '@weco/common/views/components/styled/Space';
 import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
@@ -114,7 +114,7 @@ const RegistrationPage: NextPage = () => {
                       <span id="error-text">
                         An account with this email address already exists,
                         please{' '}
-                        <NextLink href="/account">
+                        <NextLink href="/">
                           <a>sign in</a>
                         </NextLink>
                         .

--- a/identity/webapp/pages/validated.tsx
+++ b/identity/webapp/pages/validated.tsx
@@ -1,11 +1,11 @@
 import { GetServerSideProps, NextPage } from 'next';
-import { PageWrapper } from '../../src/frontend/components/PageWrapper';
+import { PageWrapper } from '../src/frontend/components/PageWrapper';
 import {
   Container,
   Wrapper,
   SectionHeading,
-} from '../../src/frontend/components/Layout.style';
-import { HighlightMessage } from '../../src/frontend/Registration/Registration.style';
+} from '../src/frontend/components/Layout.style';
+import { HighlightMessage } from '../src/frontend/Registration/Registration.style';
 import ButtonSolidLink from '@weco/common/views/components/ButtonSolidLink/ButtonSolidLink';
 import Layout10 from '@weco/common/views/components/Layout10/Layout10';
 import Space from '@weco/common/views/components/styled/Space';
@@ -48,7 +48,7 @@ const ValidatedPage: NextPage<Props> = ({ success, message, isNewSignUp }) => {
                     </div>
                   )}
                   <ButtonSolidLink
-                    link="/account"
+                    link="/"
                     text={
                       userState === 'signedin'
                         ? 'View your library account'

--- a/identity/webapp/src/frontend/Error/Error.test.tsx
+++ b/identity/webapp/src/frontend/Error/Error.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import ErrorPage from '../../../pages/account/error';
+import ErrorPage from '../../../pages/error';
 import { ThemeProvider } from 'styled-components';
 import theme from '@weco/common/views/themes/default';
 

--- a/identity/webapp/src/frontend/MyAccount/MyAccount.test.tsx
+++ b/identity/webapp/src/frontend/MyAccount/MyAccount.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
-import AccountPage from '../../../pages/account';
+import AccountPage from '../../../pages';
 import {
   mockItemRequests,
   mockUser,

--- a/identity/webapp/src/frontend/Registration/AccountValidated.test.tsx
+++ b/identity/webapp/src/frontend/Registration/AccountValidated.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import ValidatedPage from '../../../pages/account/validated';
+import ValidatedPage from '../../../pages/validated';
 import { ThemeProvider } from 'styled-components';
 import theme from '@weco/common/views/themes/default';
 

--- a/identity/webapp/src/frontend/Registration/AccountValidated.test.tsx
+++ b/identity/webapp/src/frontend/Registration/AccountValidated.test.tsx
@@ -17,7 +17,7 @@ jest.mock('@weco/common/server-data', () => ({
 }));
 
 const renderPage = (location: string) => {
-  const url = new URL(`https://localhost:3000/${location}`);
+  const url = new URL(`https://test.host/${location}`);
   const success = url.searchParams.get('success') === 'true';
   const message = url.searchParams.get('message');
   const isNewSignUp = url.searchParams.get('supportSignUp') === 'true';
@@ -36,14 +36,14 @@ const renderPage = (location: string) => {
 
 describe('AccountValidated', () => {
   it('displays a title on successful validation', () => {
-    renderPage('/account/validated?success=true');
+    renderPage('/validated?success=true');
     expect(
       screen.getByRole('heading', { name: /email verified/i })
     ).toBeInTheDocument();
   });
 
   it('displays a title on failed validation', () => {
-    renderPage('/account/validated?success=false');
+    renderPage('/validated?success=false');
     expect(
       screen.getByRole('heading', { name: /failed to verify email/i })
     ).toBeInTheDocument();
@@ -52,7 +52,7 @@ describe('AccountValidated', () => {
   it('displays a email verified title when message is "This URL can be used only once"', () => {
     // relates to #6952
     renderPage(
-      '/account/validated?message=This%20URL%20can%20be%20used%20only%20once&success=false'
+      '/validated?message=This%20URL%20can%20be%20used%20only%20once&success=false'
     );
     expect(
       screen.getByRole('heading', { name: /email verified/i })
@@ -60,25 +60,25 @@ describe('AccountValidated', () => {
   });
 
   it('shows review process information to new users', () => {
-    renderPage('/account/validated?success=true&supportSignUp=true');
+    renderPage('/validated?success=true&supportSignUp=true');
     expect(screen.getByTestId('new-sign-up')).toBeTruthy();
   });
 
   it('does not show review process information to existing users', () => {
-    renderPage('/account/validated?success=true&supportSignUp=false');
+    renderPage('/validated?success=true&supportSignUp=false');
     expect(screen.queryByTestId('new-sign-up')).toBeFalsy();
   });
 
   it('shows a link to login on success', () => {
-    renderPage('/account/validated?success=true&supportSignUp=true');
+    renderPage('/validated?success=true&supportSignUp=true');
     const links = screen.getAllByRole('link');
     const link = links[1];
     expect(link).toHaveTextContent('Sign in');
-    expect(link).toHaveAttribute('href', '/account');
+    expect(link).toHaveAttribute('href', '/');
   });
 
   it('shows a link to customer support on failure', () => {
-    renderPage('/account/validated?success=false');
+    renderPage('/validated?success=false');
     const link = screen.getByRole('link');
     expect(link).toHaveTextContent(/contact us/i);
     expect(link).toHaveAttribute(

--- a/identity/webapp/src/frontend/Registration/Registration.test.tsx
+++ b/identity/webapp/src/frontend/Registration/Registration.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
-import RegistrationPage from '../../../pages/account/registration';
+import RegistrationPage from '../../../pages/registration';
 import userEvent from '@testing-library/user-event';
 import { server } from '../mocks/server';
 import { rest } from 'msw';


### PR DESCRIPTION
This is, annoyingly, necessary in order to use Next.js API routes (so they live at `/account/api/...` and can live harmoniously behind the load balancer), which we need in order to use https://github.com/auth0/nextjs-auth0.

While at the moment it introduces slightly confusing inconsistencies between paths in koa vs Next, pretty much 100% of the custom server logic will be removed by the introduction of the aforementioned auth SDK.