### PR TITLE
fix previews with new Prismic client

### DIFF
--- a/common/views/components/CataloguePageLayout/CataloguePageLayout.tsx
+++ b/common/views/components/CataloguePageLayout/CataloguePageLayout.tsx
@@ -1,8 +1,8 @@
 import { FunctionComponent, useEffect, useState } from 'react';
+import { RichTextNodeType } from '@prismicio/types';
 import PageLayout, { Props as PageLayoutProps } from '../PageLayout/PageLayout';
 import InfoBanner from '../InfoBanner/InfoBanner';
 import { emptyGlobalAlert } from '../../../services/prismic/documents';
-import { RichTextNodeType } from '@prismicio/types';
 
 type Props = {
   hideTopContent?: boolean;

--- a/content/webapp/app.ts
+++ b/content/webapp/app.ts
@@ -1,23 +1,21 @@
 /* eslint-disable @typescript-eslint/no-var-requires, import/first */
 // This needs to be the first module loaded in the application
 require('@weco/common/services/apm/initApm')('content-server');
-
 import Koa from 'koa';
 import Router from 'koa-router';
 import next from 'next';
 import Prismic from '@prismicio/client';
-import linkResolver from '@weco/common/services/prismic/link-resolver';
 import apmErrorMiddleware from '@weco/common/services/apm/errorMiddleware';
 import { init as initServerData } from '@weco/common/server-data';
 import bodyParser from 'koa-bodyparser';
 import handleNewsletterSignup from './routeHandlers/handleNewsletterSignup';
-
 import {
   middleware,
   route,
   handleAllRoute,
   timers as middlewareTimers,
 } from '@weco/common/koa-middleware/withCachedValues';
+import linkResolver from './services/prismic/link-resolver';
 
 // FIXME: Find a way to import this.
 // We can't because it's not a standard es6 module (import and flowtype)
@@ -126,12 +124,21 @@ const appPromise = nextApp
         }
       );
 
+      /**
+       * This is because the type in api.resolve are not true
+       */
+      const retypedLinkResolver = doc => {
+        return (linkResolver(doc) as string) || '/';
+      };
+
       const url = await api
         .getPreviewResolver(token!.toString(), documentId!.toString())
-        .resolve(linkResolver, '/');
+        .resolve(retypedLinkResolver, '/');
+
       ctx.cookies.set('isPreview', 'true', {
         httpOnly: false,
       });
+
       ctx.redirect(url);
     });
 

--- a/content/webapp/package.json
+++ b/content/webapp/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "scripts": {
     "build": "next build",
-    "dev": "NODE_ENV=development nodemon --watch server.ts --exec ts-node --project tsconfig.server.json server",
+    "dev": "NODE_ENV=development nodemon --watch server.ts --watch app.ts --exec ts-node --project tsconfig.server.json server",
     "start": "NODE_ENV=production ts-node-transpile-only --project tsconfig.server.json server",
     "test": "NODE_ENV=test jest --no-cache",
     "test:watch": "yarn test -- --watchAll",

--- a/content/webapp/pages/article.tsx
+++ b/content/webapp/pages/article.tsx
@@ -49,9 +49,9 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     const client = createClient(context);
     const articleDocument = await fetchArticle(client, id);
     const serverData = await getServerData(context);
-    const article = parseArticleDoc(articleDocument);
 
-    if (article) {
+    if (articleDocument) {
+      const article = parseArticleDoc(articleDocument);
       return {
         props: removeUndefinedProps({
           article,

--- a/content/webapp/services/prismic/fetch/articles.ts
+++ b/content/webapp/services/prismic/fetch/articles.ts
@@ -30,13 +30,15 @@ export async function fetchArticle(
   { client }: GetServerSidePropsPrismicClient,
   id: string
 ): Promise<ArticlePrismicDocument | undefined> {
-  const document = await client.getByID<ArticlePrismicDocument>(id, {
-    fetchLinks,
-  });
+  try {
+    const document = await client.getByID<ArticlePrismicDocument>(id, {
+      fetchLinks,
+    });
 
-  if (document.type === 'articles' || document.type === 'webcomics') {
-    return document;
-  }
+    if (document.type === 'articles' || document.type === 'webcomics') {
+      return document;
+    }
+  } catch {}
 }
 
 type Params = Parameters<

--- a/content/webapp/services/prismic/fetch/index.ts
+++ b/content/webapp/services/prismic/fetch/index.ts
@@ -2,14 +2,8 @@ import * as prismic from 'prismic-client-beta';
 import fetch from 'node-fetch';
 import { GetServerSidePropsContext, NextApiRequest } from 'next';
 
-const routes = [
-  {
-    type: 'seasons',
-    path: '/seasons/:uid',
-  },
-];
 const endpoint = prismic.getEndpoint('wellcomecollection');
-const client = prismic.createClient(endpoint, { routes, fetch });
+const client = prismic.createClient(endpoint, { fetch });
 
 export type GetServerSidePropsPrismicClient = {
   type: 'GetServerSidePropsPrismicClient';
@@ -56,5 +50,8 @@ export function createClient(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _: GetServerSidePropsContext | NextApiRequest
 ): GetServerSidePropsPrismicClient {
+  if ('req' in _) {
+    client.enableAutoPreviewsFromReq(_.req);
+  }
   return { type: 'GetServerSidePropsPrismicClient', client };
 }


### PR DESCRIPTION
* Uses new `linkResolver`
* When you fetch and there is no document, the Prismic client error. We catch the error and return nothing so that we will do better error handling
* When we have a `req` we enable preview

The toolbar is also out of date - I will fix this after.