### PR TITLE
Add some very primitive tests with cURL

### DIFF
--- a/.buildkite/expected_200_urls.txt
+++ b/.buildkite/expected_200_urls.txt
@@ -1,1 +1,5 @@
+# https://wellcome.slack.com/archives/C294K7D5M/p1638794220158000
 /covid-book-your-ticket
+
+# https://wellcome.slack.com/archives/C8X9YKM5X/p1638456535135800
+/articles/W9m2QxcAAF8AFvE5

--- a/.buildkite/expected_200_urls.txt
+++ b/.buildkite/expected_200_urls.txt
@@ -1,0 +1,1 @@
+/covid-book-your-ticket

--- a/.buildkite/expected_404_urls.txt
+++ b/.buildkite/expected_404_urls.txt
@@ -1,0 +1,1 @@
+/exhibitions/abc

--- a/.buildkite/pipeline.deployment.yml
+++ b/.buildkite/pipeline.deployment.yml
@@ -21,6 +21,12 @@ steps:
 
   - wait
 
+  - label: "Check URLs"
+    command:
+      .buildkite/scripts/check_urls_with_curl.sh
+    agents:
+      queue: nano
+
   - label: "Trigger e2e tests"
     if: build.env("BUILDKITE_GITHUB_DEPLOYMENT_TASK") == "deploy:weco"
     command: ".buildkite/scripts/trigger-e2e.sh"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,9 @@
 - label: "check pages with cURL"
   command:
     curl "https://wellcomecollection.org/covid-book-your-ticket"
+  agents:
+    queue: nano
+
 
 # - label: ":docker: build common"
 #   plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,6 @@
 - label: "check pages with cURL"
   command:
-    curl "https://wellcomecollection.org/covid-book-your-ticket"
+    .buildkite/scripts/check_urls_with_curl.sh
   agents:
     queue: nano
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,111 +1,193 @@
-- label: "check pages with cURL"
-  command:
-    .buildkite/scripts/check_urls_with_curl.sh
-  agents:
-    queue: nano
+- label: ":docker: build common"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        build:
+          - common
+        image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
 
+- label: ":docker: build catalogue"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        build:
+          - catalogue
+        image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
 
-# - label: ":docker: build common"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         build:
-#           - common
-#         image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
-#
-# - label: ":docker: build catalogue"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         build:
-#           - catalogue
-#         image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
-#
-# - label: ":docker: build content"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         build:
-#           - content
-#         image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
-#
-# - label: ":docker: build edge_lambdas"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         build:
-#           - edge_lambdas
-#         image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
-#
-# - label: ":docker: build identity"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         build:
-#           - identity
-#         image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
-#
-# - label: "diff prismic model"
+- label: ":docker: build content"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        build:
+          - content
+        image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
+
+- label: ":docker: build edge_lambdas"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        build:
+          - edge_lambdas
+        image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
+
+- label: ":docker: build identity"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        build:
+          - identity
+        image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
+
+- label: "diff prismic model"
+  branches: "main"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        run: prismic_model
+        env:
+          - CI
+        command: ["yarn", "diffCustomTypes"]
+
+- wait
+
+- label: "test common"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        run: common
+        command: ["yarn", "test"]
+
+- label: "test catalogue"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        run: catalogue
+        command: ["yarn", "test"]
+
+- label: "test content"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        run: content
+        command: ["yarn", "test"]
+
+- label: "test identity"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        run: identity
+        command: ["yarn", "test"]
+
+- label: "test edge_lambdas"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        run: edge_lambdas
+        command: ["yarn", "test"]
+
+- wait
+
+- label: "deploy catalogue (ecr image)"
+  branches: "main"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        push:
+          - catalogue:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/catalogue_webapp:ref.${BUILDKITE_COMMIT}
+          - catalogue:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/catalogue_webapp:latest
+
+- label: "deploy catalogue (bundle analysis)"
+  branches: "main"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        run: catalogue
+        command: [ "yarn", "deployBundleAnalysis" ]
+        env:
+          - AWS_ACCESS_KEY_ID
+          - AWS_SECRET_ACCESS_KEY
+          - AWS_SESSION_TOKEN
+
+- label: "deploy content (ecr image)"
+  branches: "main"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        push:
+          - content:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/content_webapp:ref.${BUILDKITE_COMMIT}
+          - content:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/content_webapp:latest
+
+- label: "deploy content (bundle analysis)"
+  branches: "main"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        run: content
+        command: [ "yarn", "deployBundleAnalysis" ]
+        env:
+          - AWS_ACCESS_KEY_ID
+          - AWS_SECRET_ACCESS_KEY
+          - AWS_SESSION_TOKEN
+
+- label: "deploy identity (ecr image)"
+  branches: "main"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        push:
+          - identity:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/identity_webapp:ref.${BUILDKITE_COMMIT}
+          - identity:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/identity_webapp:latest
+
+# - label: "deploy identity (bundle analysis)"
 #   branches: "main"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         run: prismic_model
-#         env:
-#           - CI
-#         command: ["yarn", "diffCustomTypes"]
-#
-# - wait
-#
-# - label: "test common"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         run: common
-#         command: ["yarn", "test"]
-#
-# - label: "test catalogue"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         run: catalogue
-#         command: ["yarn", "test"]
-#
-# - label: "test content"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         run: content
-#         command: ["yarn", "test"]
-#
-# - label: "test identity"
 #   plugins:
 #     - wellcomecollection/aws-assume-role#v0.2.2:
 #         role: "arn:aws:iam::130871440101:role/experience-ci"
@@ -113,207 +195,118 @@
 #         login: true
 #     - docker-compose#v3.5.0:
 #         run: identity
-#         command: ["yarn", "test"]
-#
-# - label: "test edge_lambdas"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         run: edge_lambdas
-#         command: ["yarn", "test"]
-#
-# - wait
-#
-# - label: "deploy catalogue (ecr image)"
-#   branches: "main"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         push:
-#           - catalogue:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/catalogue_webapp:ref.${BUILDKITE_COMMIT}
-#           - catalogue:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/catalogue_webapp:latest
-#
-# - label: "deploy catalogue (bundle analysis)"
-#   branches: "main"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         run: catalogue
 #         command: [ "yarn", "deployBundleAnalysis" ]
 #         env:
 #           - AWS_ACCESS_KEY_ID
 #           - AWS_SECRET_ACCESS_KEY
 #           - AWS_SESSION_TOKEN
-#
-# - label: "deploy content (ecr image)"
-#   branches: "main"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         push:
-#           - content:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/content_webapp:ref.${BUILDKITE_COMMIT}
-#           - content:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/content_webapp:latest
-#
-# - label: "deploy content (bundle analysis)"
-#   branches: "main"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         run: content
-#         command: [ "yarn", "deployBundleAnalysis" ]
-#         env:
-#           - AWS_ACCESS_KEY_ID
-#           - AWS_SECRET_ACCESS_KEY
-#           - AWS_SESSION_TOKEN
-#
-# - label: "deploy identity (ecr image)"
-#   branches: "main"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         push:
-#           - identity:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/identity_webapp:ref.${BUILDKITE_COMMIT}
-#           - identity:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/identity_webapp:latest
-#
-# # - label: "deploy identity (bundle analysis)"
-# #   branches: "main"
-# #   plugins:
-# #     - wellcomecollection/aws-assume-role#v0.2.2:
-# #         role: "arn:aws:iam::130871440101:role/experience-ci"
-# #     - ecr#v2.1.1:
-# #         login: true
-# #     - docker-compose#v3.5.0:
-# #         run: identity
-# #         command: [ "yarn", "deployBundleAnalysis" ]
-# #         env:
-# #           - AWS_ACCESS_KEY_ID
-# #           - AWS_SECRET_ACCESS_KEY
-# #           - AWS_SESSION_TOKEN
-#
-# - label: "deploy dash"
-#   branches: "main"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         run: dash
-#         command: [ "yarn", "deploy" ]
-#         env:
-#           - AWS_ACCESS_KEY_ID
-#           - AWS_SECRET_ACCESS_KEY
-#           - AWS_SESSION_TOKEN
-#
-# - label: "deploy cardigan"
-#   branches: "main"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         run: cardigan
-#         command: [ "yarn", "deploy" ]
-#         env:
-#           - AWS_ACCESS_KEY_ID
-#           - AWS_SECRET_ACCESS_KEY
-#           - AWS_SESSION_TOKEN
-#
-# - label: "deploy toggles"
-#   branches: "main"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         run: toggles
-#         command: [ "yarn", "deploy" ]
-#         env:
-#           - AWS_ACCESS_KEY_ID
-#           - AWS_SECRET_ACCESS_KEY
-#           - AWS_SESSION_TOKEN
-#           - CI
-#
-# - label: "deploy pa11y"
-#   branches: "main"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         run: pa11y
-#         command: [ "yarn", "deploy" ]
-#         env:
-#           - AWS_ACCESS_KEY_ID
-#           - AWS_SECRET_ACCESS_KEY
-#           - AWS_SESSION_TOKEN
-#
-# - label: "deploy edge_lambdas"
-#   branches: "main"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         run: edge_lambdas
-#         command: [ "yarn", "deploy" ]
-#         env:
-#           - AWS_ACCESS_KEY_ID
-#           - AWS_SECRET_ACCESS_KEY
-#           - AWS_SESSION_TOKEN
-#
-# - label: "deploy updown"
-#   branches: "main"
-#   skip: "To avoid overriding manual work that is occuring"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         run: updown
-#         command: [ "yarn", "checks" ]
-#         env:
-#           - AWS_ACCESS_KEY_ID
-#           - AWS_SECRET_ACCESS_KEY
-#           - AWS_SESSION_TOKEN
-#
-# - label: "deploy assets"
-#   branches: "main"
-#   commands: ./assets/deploy_assets.sh
-#   agents:
-#     queue: nano
-#
-# - wait
-#
-# - label: "Trigger stage deployment"
-#   branches: "main"
-#   plugins:
-#     - wellcomecollection/github-deployments#v0.2.4:
-#         assume_role: "arn:aws:iam::130871440101:role/experience-ci"
-#         environment: stage
-#         ref: "${BUILDKITE_COMMIT}"
-#   agents:
-#     queue: nano
+
+- label: "deploy dash"
+  branches: "main"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        run: dash
+        command: [ "yarn", "deploy" ]
+        env:
+          - AWS_ACCESS_KEY_ID
+          - AWS_SECRET_ACCESS_KEY
+          - AWS_SESSION_TOKEN
+
+- label: "deploy cardigan"
+  branches: "main"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        run: cardigan
+        command: [ "yarn", "deploy" ]
+        env:
+          - AWS_ACCESS_KEY_ID
+          - AWS_SECRET_ACCESS_KEY
+          - AWS_SESSION_TOKEN
+
+- label: "deploy toggles"
+  branches: "main"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        run: toggles
+        command: [ "yarn", "deploy" ]
+        env:
+          - AWS_ACCESS_KEY_ID
+          - AWS_SECRET_ACCESS_KEY
+          - AWS_SESSION_TOKEN
+          - CI
+
+- label: "deploy pa11y"
+  branches: "main"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        run: pa11y
+        command: [ "yarn", "deploy" ]
+        env:
+          - AWS_ACCESS_KEY_ID
+          - AWS_SECRET_ACCESS_KEY
+          - AWS_SESSION_TOKEN
+
+- label: "deploy edge_lambdas"
+  branches: "main"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        run: edge_lambdas
+        command: [ "yarn", "deploy" ]
+        env:
+          - AWS_ACCESS_KEY_ID
+          - AWS_SECRET_ACCESS_KEY
+          - AWS_SESSION_TOKEN
+
+- label: "deploy updown"
+  branches: "main"
+  skip: "To avoid overriding manual work that is occuring"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        run: updown
+        command: [ "yarn", "checks" ]
+        env:
+          - AWS_ACCESS_KEY_ID
+          - AWS_SECRET_ACCESS_KEY
+          - AWS_SESSION_TOKEN
+
+- label: "deploy assets"
+  branches: "main"
+  commands: ./assets/deploy_assets.sh
+  agents:
+    queue: nano
+
+- wait
+
+- label: "Trigger stage deployment"
+  branches: "main"
+  plugins:
+    - wellcomecollection/github-deployments#v0.2.4:
+        assume_role: "arn:aws:iam::130871440101:role/experience-ci"
+        environment: stage
+        ref: "${BUILDKITE_COMMIT}"
+  agents:
+    queue: nano

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,192 +1,63 @@
-- label: ":docker: build common"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        build:
-          - common
-        image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
+- label: "check pages with cURL"
+  script:
+    curl "https://wellcomecollection.org/covid-book-your-ticket"
 
-- label: ":docker: build catalogue"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        build:
-          - catalogue
-        image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
-
-- label: ":docker: build content"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        build:
-          - content
-        image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
-
-- label: ":docker: build edge_lambdas"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        build:
-          - edge_lambdas
-        image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
-
-- label: ":docker: build identity"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        build:
-          - identity
-        image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
-
-- label: "diff prismic model"
-  branches: "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: prismic_model
-        env:
-          - CI
-        command: ["yarn", "diffCustomTypes"]
-
-- wait
-
-- label: "test common"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: common
-        command: ["yarn", "test"]
-
-- label: "test catalogue"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: catalogue
-        command: ["yarn", "test"]
-
-- label: "test content"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: content
-        command: ["yarn", "test"]
-
-- label: "test identity"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: identity
-        command: ["yarn", "test"]
-
-- label: "test edge_lambdas"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: edge_lambdas
-        command: ["yarn", "test"]
-
-- wait
-
-- label: "deploy catalogue (ecr image)"
-  branches: "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        push:
-          - catalogue:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/catalogue_webapp:ref.${BUILDKITE_COMMIT}
-          - catalogue:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/catalogue_webapp:latest
-
-- label: "deploy catalogue (bundle analysis)"
-  branches: "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: catalogue
-        command: [ "yarn", "deployBundleAnalysis" ]
-        env:
-          - AWS_ACCESS_KEY_ID
-          - AWS_SECRET_ACCESS_KEY
-          - AWS_SESSION_TOKEN
-
-- label: "deploy content (ecr image)"
-  branches: "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        push:
-          - content:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/content_webapp:ref.${BUILDKITE_COMMIT}
-          - content:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/content_webapp:latest
-
-- label: "deploy content (bundle analysis)"
-  branches: "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: content
-        command: [ "yarn", "deployBundleAnalysis" ]
-        env:
-          - AWS_ACCESS_KEY_ID
-          - AWS_SECRET_ACCESS_KEY
-          - AWS_SESSION_TOKEN
-
-- label: "deploy identity (ecr image)"
-  branches: "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        push:
-          - identity:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/identity_webapp:ref.${BUILDKITE_COMMIT}
-          - identity:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/identity_webapp:latest
-
-# - label: "deploy identity (bundle analysis)"
+# - label: ":docker: build common"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         build:
+#           - common
+#         image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
+#
+# - label: ":docker: build catalogue"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         build:
+#           - catalogue
+#         image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
+#
+# - label: ":docker: build content"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         build:
+#           - content
+#         image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
+#
+# - label: ":docker: build edge_lambdas"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         build:
+#           - edge_lambdas
+#         image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
+#
+# - label: ":docker: build identity"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         build:
+#           - identity
+#         image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
+#
+# - label: "diff prismic model"
 #   branches: "main"
 #   plugins:
 #     - wellcomecollection/aws-assume-role#v0.2.2:
@@ -194,119 +65,252 @@
 #     - ecr#v2.1.1:
 #         login: true
 #     - docker-compose#v3.5.0:
+#         run: prismic_model
+#         env:
+#           - CI
+#         command: ["yarn", "diffCustomTypes"]
+#
+# - wait
+#
+# - label: "test common"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: common
+#         command: ["yarn", "test"]
+#
+# - label: "test catalogue"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: catalogue
+#         command: ["yarn", "test"]
+#
+# - label: "test content"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: content
+#         command: ["yarn", "test"]
+#
+# - label: "test identity"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
 #         run: identity
+#         command: ["yarn", "test"]
+#
+# - label: "test edge_lambdas"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: edge_lambdas
+#         command: ["yarn", "test"]
+#
+# - wait
+#
+# - label: "deploy catalogue (ecr image)"
+#   branches: "main"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         push:
+#           - catalogue:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/catalogue_webapp:ref.${BUILDKITE_COMMIT}
+#           - catalogue:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/catalogue_webapp:latest
+#
+# - label: "deploy catalogue (bundle analysis)"
+#   branches: "main"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: catalogue
 #         command: [ "yarn", "deployBundleAnalysis" ]
 #         env:
 #           - AWS_ACCESS_KEY_ID
 #           - AWS_SECRET_ACCESS_KEY
 #           - AWS_SESSION_TOKEN
-
-- label: "deploy dash"
-  branches: "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: dash
-        command: [ "yarn", "deploy" ]
-        env:
-          - AWS_ACCESS_KEY_ID
-          - AWS_SECRET_ACCESS_KEY
-          - AWS_SESSION_TOKEN
-
-- label: "deploy cardigan"
-  branches: "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: cardigan
-        command: [ "yarn", "deploy" ]
-        env:
-          - AWS_ACCESS_KEY_ID
-          - AWS_SECRET_ACCESS_KEY
-          - AWS_SESSION_TOKEN
-
-- label: "deploy toggles"
-  branches: "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: toggles
-        command: [ "yarn", "deploy" ]
-        env:
-          - AWS_ACCESS_KEY_ID
-          - AWS_SECRET_ACCESS_KEY
-          - AWS_SESSION_TOKEN
-          - CI
-
-- label: "deploy pa11y"
-  branches: "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: pa11y
-        command: [ "yarn", "deploy" ]
-        env:
-          - AWS_ACCESS_KEY_ID
-          - AWS_SECRET_ACCESS_KEY
-          - AWS_SESSION_TOKEN
-
-- label: "deploy edge_lambdas"
-  branches: "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: edge_lambdas
-        command: [ "yarn", "deploy" ]
-        env:
-          - AWS_ACCESS_KEY_ID
-          - AWS_SECRET_ACCESS_KEY
-          - AWS_SESSION_TOKEN
-
-- label: "deploy updown"
-  branches: "main"
-  skip: "To avoid overriding manual work that is occuring"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: updown
-        command: [ "yarn", "checks" ]
-        env:
-          - AWS_ACCESS_KEY_ID
-          - AWS_SECRET_ACCESS_KEY
-          - AWS_SESSION_TOKEN
-
-- label: "deploy assets"
-  branches: "main"
-  commands: ./assets/deploy_assets.sh
-  agents:
-    queue: nano
-
-- wait
-
-- label: "Trigger stage deployment"
-  branches: "main"
-  plugins:
-    - wellcomecollection/github-deployments#v0.2.4:
-        assume_role: "arn:aws:iam::130871440101:role/experience-ci"
-        environment: stage
-        ref: "${BUILDKITE_COMMIT}"
-  agents:
-    queue: nano
+#
+# - label: "deploy content (ecr image)"
+#   branches: "main"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         push:
+#           - content:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/content_webapp:ref.${BUILDKITE_COMMIT}
+#           - content:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/content_webapp:latest
+#
+# - label: "deploy content (bundle analysis)"
+#   branches: "main"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: content
+#         command: [ "yarn", "deployBundleAnalysis" ]
+#         env:
+#           - AWS_ACCESS_KEY_ID
+#           - AWS_SECRET_ACCESS_KEY
+#           - AWS_SESSION_TOKEN
+#
+# - label: "deploy identity (ecr image)"
+#   branches: "main"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         push:
+#           - identity:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/identity_webapp:ref.${BUILDKITE_COMMIT}
+#           - identity:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/identity_webapp:latest
+#
+# # - label: "deploy identity (bundle analysis)"
+# #   branches: "main"
+# #   plugins:
+# #     - wellcomecollection/aws-assume-role#v0.2.2:
+# #         role: "arn:aws:iam::130871440101:role/experience-ci"
+# #     - ecr#v2.1.1:
+# #         login: true
+# #     - docker-compose#v3.5.0:
+# #         run: identity
+# #         command: [ "yarn", "deployBundleAnalysis" ]
+# #         env:
+# #           - AWS_ACCESS_KEY_ID
+# #           - AWS_SECRET_ACCESS_KEY
+# #           - AWS_SESSION_TOKEN
+#
+# - label: "deploy dash"
+#   branches: "main"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: dash
+#         command: [ "yarn", "deploy" ]
+#         env:
+#           - AWS_ACCESS_KEY_ID
+#           - AWS_SECRET_ACCESS_KEY
+#           - AWS_SESSION_TOKEN
+#
+# - label: "deploy cardigan"
+#   branches: "main"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: cardigan
+#         command: [ "yarn", "deploy" ]
+#         env:
+#           - AWS_ACCESS_KEY_ID
+#           - AWS_SECRET_ACCESS_KEY
+#           - AWS_SESSION_TOKEN
+#
+# - label: "deploy toggles"
+#   branches: "main"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: toggles
+#         command: [ "yarn", "deploy" ]
+#         env:
+#           - AWS_ACCESS_KEY_ID
+#           - AWS_SECRET_ACCESS_KEY
+#           - AWS_SESSION_TOKEN
+#           - CI
+#
+# - label: "deploy pa11y"
+#   branches: "main"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: pa11y
+#         command: [ "yarn", "deploy" ]
+#         env:
+#           - AWS_ACCESS_KEY_ID
+#           - AWS_SECRET_ACCESS_KEY
+#           - AWS_SESSION_TOKEN
+#
+# - label: "deploy edge_lambdas"
+#   branches: "main"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: edge_lambdas
+#         command: [ "yarn", "deploy" ]
+#         env:
+#           - AWS_ACCESS_KEY_ID
+#           - AWS_SECRET_ACCESS_KEY
+#           - AWS_SESSION_TOKEN
+#
+# - label: "deploy updown"
+#   branches: "main"
+#   skip: "To avoid overriding manual work that is occuring"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: updown
+#         command: [ "yarn", "checks" ]
+#         env:
+#           - AWS_ACCESS_KEY_ID
+#           - AWS_SECRET_ACCESS_KEY
+#           - AWS_SESSION_TOKEN
+#
+# - label: "deploy assets"
+#   branches: "main"
+#   commands: ./assets/deploy_assets.sh
+#   agents:
+#     queue: nano
+#
+# - wait
+#
+# - label: "Trigger stage deployment"
+#   branches: "main"
+#   plugins:
+#     - wellcomecollection/github-deployments#v0.2.4:
+#         assume_role: "arn:aws:iam::130871440101:role/experience-ci"
+#         environment: stage
+#         ref: "${BUILDKITE_COMMIT}"
+#   agents:
+#     queue: nano

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 - label: "check pages with cURL"
-  script:
+  command:
     curl "https://wellcomecollection.org/covid-book-your-ticket"
 
 # - label: ":docker: build common"

--- a/.buildkite/scripts/check_urls_with_curl.sh
+++ b/.buildkite/scripts/check_urls_with_curl.sh
@@ -2,13 +2,30 @@
 # This script does some very basic checking of URLs on the site.
 # It fetches them with cURL and compares the status code to the
 # expected status code.
+#
+# It takes two input files:
+#
+#     expected_200_urls.txt
+#     expected_404_urls.txt
+#
+# Each line of these files should contain a URL path/query that
+# you want to assert is either 200 OK or 404 Not Found.
+#
+# The file can include newlines and comments to keep it organised.
+#
+# It's meant to be a barebones regression test for the entire site.
 
 set -o errexit
 set -o nounset
 
-BASE="https://wellcomecollection.org"
+if [[ "${BUILDKITE_GITHUB_DEPLOYMENT_ENVIRONMENT:-prod}" == "stage" ]]
+then
+  BASE="https://www-stage.wellcomecollection.org"
+else
+  BASE="https://wellcomecollection.org"
+fi
 
-for url in $(cat .buildkite/expected_200_urls.txt)
+for url in $(grep ^/ .buildkite/expected_200_urls.txt)
 do
   echo -n "Checking $BASE$url... "
 
@@ -22,7 +39,7 @@ do
   fi
 done
 
-for url in $(cat .buildkite/expected_404_urls.txt)
+for url in $(grep ^/ .buildkite/expected_404_urls.txt)
 do
   echo -n "Checking $BASE$url... "
 

--- a/.buildkite/scripts/check_urls_with_curl.sh
+++ b/.buildkite/scripts/check_urls_with_curl.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# This script does some very basic checking of URLs on the site.
+# It fetches them with cURL and compares the status code to the
+# expected status code.
+
+set -o errexit
+set -o nounset
+
+BASE="https://wellcomecollection.org"
+
+for url in $(cat .buildkite/expected_200_urls.txt)
+do
+  echo -n "Checking $BASE$url... "
+
+  STATUS=$(curl -o /dev/null -s -w "%{http_code}" "$BASE$url")
+  echo "$STATUS"
+
+  if (( $STATUS != 200 ))
+  then
+    echo "!!! Expected 200 OK, got $STATUS"
+    exit 1
+  fi
+done
+
+for url in $(cat .buildkite/expected_404_urls.txt)
+do
+  echo -n "Checking $BASE$url... "
+
+  STATUS=$(curl -o /dev/null -s -w "%{http_code}" "$BASE$url")
+  echo "$STATUS"
+
+  if (( $STATUS != 404 ))
+  then
+    echo "!!! Expected 404 Not Found, got $STATUS"
+    exit 1
+  fi
+done


### PR DESCRIPTION
This PR adds a very primitive set of URL tests for deployments. We iterate through a list of URLs one-by-one and check whether they return a 200 OK/404 Not Found, as expected.

It's meant to make it easy as possible to add URLs, so we get a set of site-level regression tests.