### PR TITLE
Don't return a 500 error/exception if looking up IDs with spaces

### DIFF
--- a/.buildkite/expected_404_urls.txt
+++ b/.buildkite/expected_404_urls.txt
@@ -1,1 +1,6 @@
 /exhibitions/abc
+
+# A real URL we saw, where the work ID had somehow been mangled to
+# add a bunch of spaces.  The corresponding wellcomeimages.org URL
+# redirects correctly, so we just check this 404s.
+/works/%E2%80%8Cqvku%E2%80%8Czu%E2%80%8C5w?wellcomeImagesUrl=/indexplus/image/L0025863.html

--- a/catalogue/webapp/services/catalogue/works.ts
+++ b/catalogue/webapp/services/catalogue/works.ts
@@ -93,6 +93,16 @@ export async function getWork({
   id,
   toggles,
 }: GetWorkProps): Promise<WorkResponse> {
+  // We have occasionally seen requests for URLs with IDs which are
+  // obviously wrong, e.g. with spaces or special characters.
+  //
+  // In these cases, there's no point forwarding the request to the API
+  // (and we could serve 500 errors from malformed IDs).  If the ID isn't
+  // alphanumeric, reject it immediately.
+  if (!/^([a-z0-9]+)$/.test(id)) {
+    return notFound();
+  }
+
   const apiOptions = globalApiOptions(toggles);
 
   const params = {

--- a/catalogue/webapp/test/services/catalogue/works.test.ts
+++ b/catalogue/webapp/test/services/catalogue/works.test.ts
@@ -1,0 +1,15 @@
+import { getWork } from '../../../services/catalogue/works';
+
+it('returns a 404 Not Found for a work ID that’s not alphanumeric', () => {
+  const id = 'a\u200Bb';
+
+  getWork({ id: id, toggles: {} }).then(result => {
+    expect(result).toStrictEqual({
+      errorType: 'http',
+      httpStatus: 404,
+      label: 'Not Found',
+      description: '',
+      type: 'Error',
+    });
+  });
+});


### PR DESCRIPTION
## Who is this for?

People who monitor the 500 errors on wc.org.

## What is it doing for them?

Squashing one of them, in particular the error you get if you visit:

https://wellcomecollection.org/works/%E2%80%8Cqvku%E2%80%8Czu%E2%80%8C5w?wellcomeImagesUrl=/indexplus/image/L0025863.html

That's a URL that somebody visited earlier today, and among other things that URL has the Unicode zero-width joining space `\u200C`. How did they get there? No idea – but we should return a 404 instead of a 500.

I'd like us to get to the point where we're not serving *any* 500 errors.