### PR TITLE
account for richtext or keytext for contributor names

### DIFF
--- a/.buildkite/expected_200_urls.txt
+++ b/.buildkite/expected_200_urls.txt
@@ -9,3 +9,6 @@
 # https://wellcome.slack.com/archives/C8X9YKM5X/p1638800127140100
 /event-series/WlYT_SQAACcAWccj
 /articles/WpmW_yUAAKUUF6mV
+
+# https://github.com/wellcomecollection/wellcomecollection.org/issues/7438
+/exhibitions/XOVfTREAAOJmx-Uw

--- a/content/webapp/services/prismic/transformers/contributors.ts
+++ b/content/webapp/services/prismic/transformers/contributors.ts
@@ -2,7 +2,7 @@ import { PrismicDocument, KeyTextField } from '@prismicio/types';
 import * as prismicH from 'prismic-helpers-beta';
 import { isFilledLinkToDocumentWithData, WithContributors } from '../types';
 import { Contributor } from '../../../types/contributors';
-import { isNotUndefined } from '@weco/common/utils/array';
+import { isNotUndefined, isString } from '@weco/common/utils/array';
 import {
   transformKeyTextField,
   transformRichTextField,
@@ -27,9 +27,10 @@ export function transformContributorAgent(
         })
         .filter(isNotUndefined),
     };
-
+    
+    // The .name field can be either RichText or Text.
     const name =
-      typeof agent.data.name === 'string'
+      isString(agent.data.name === 'string')
         ? transformKeyTextField(agent.data.name)
         : Array.isArray(agent.data.name)
         ? transformRichTextFieldToString(agent.data.name)

--- a/content/webapp/services/prismic/transformers/contributors.ts
+++ b/content/webapp/services/prismic/transformers/contributors.ts
@@ -30,7 +30,7 @@ export function transformContributorAgent(
     
     // The .name field can be either RichText or Text.
     const name =
-      isString(agent.data.name === 'string')
+      isString(agent.data.name)
         ? transformKeyTextField(agent.data.name)
         : Array.isArray(agent.data.name)
         ? transformRichTextFieldToString(agent.data.name)

--- a/content/webapp/services/prismic/transformers/contributors.ts
+++ b/content/webapp/services/prismic/transformers/contributors.ts
@@ -9,13 +9,14 @@ import {
   transformRichTextFieldToString,
 } from '.';
 
+type Agent = WithContributors['contributors'][number]['contributor'];
+
 export function transformContributorAgent(
-  agent: WithContributors['contributors'][number]['contributor']
+  agent: Agent
 ): Contributor['contributor'] | undefined {
   if (isFilledLinkToDocumentWithData(agent)) {
     const commonFields = {
       id: agent.id,
-      name: agent.data.name ?? undefined,
       description: transformRichTextField(agent.data.description),
       image: agent.data.image,
       sameAs: (agent.data.sameAs ?? [])
@@ -27,14 +28,23 @@ export function transformContributorAgent(
         .filter(isNotUndefined),
     };
 
+    const name =
+      typeof agent.data.name === 'string'
+        ? transformKeyTextField(agent.data.name)
+        : Array.isArray(agent.data.name)
+        ? transformRichTextFieldToString(agent.data.name)
+        : undefined;
+
     if (agent.type === 'organisations') {
       return {
         type: agent.type,
+        name,
         ...commonFields,
       };
     } else if (agent.type === 'people') {
       return {
         type: agent.type,
+        name,
         ...commonFields,
         // I'm not sure why I have to coerce this type here as it is that type?
         pronouns: transformKeyTextField(agent.data.pronouns as KeyTextField),

--- a/content/webapp/services/prismic/types/contributors.ts
+++ b/content/webapp/services/prismic/types/contributors.ts
@@ -39,7 +39,7 @@ export type Person = PrismicDocument<
 const organisationType = 'organisations';
 export type Organisation = PrismicDocument<
   {
-    name: KeyTextField;
+    name: RichTextField;
     description: RichTextField;
     image: Image;
     sameAs: GroupField<{


### PR DESCRIPTION
Turns out the prismic model is the issue. `.name` can either be `RichText` or `Text`. Once we change the type in the source data, the type system catches these errors.

The implementation around it isn't great, but when reading union `RelationField` types, seems it's all a bit fiddly as it greats a union of the `type` field and the `data` field but doesn't allow you to differentiate on it.

e.g. 
```
if (agent.type === 'organisations') {
  agent.data // <= this isn't of type `Organisation['data']`.
}
```