### PR TITLE
Don't throw a 500 error if you look up a missing book

### DIFF
--- a/.buildkite/expected_404_urls.txt
+++ b/.buildkite/expected_404_urls.txt
@@ -1,9 +1,9 @@
-/exhibitions/abc
-
 # A real URL we saw, where the work ID had somehow been mangled to
 # add a bunch of spaces.  The corresponding wellcomeimages.org URL
 # redirects correctly, so we just check this 404s.
 /works/%E2%80%8Cqvku%E2%80%8Czu%E2%80%8C5w?wellcomeImagesUrl=/indexplus/image/L0025863.html
 
 # See https://github.com/wellcomecollection/wellcomecollection.org/issues/7417
-/articles/yykk4hiaacqaqifn
+/articles/notfound
+/books/notfound
+/exhibitions/notfound

--- a/content/webapp/services/prismic/fetch/articles.ts
+++ b/content/webapp/services/prismic/fetch/articles.ts
@@ -3,6 +3,11 @@ import { GetServerSidePropsPrismicClient } from '.';
 import { ArticlePrismicDocument, articlesFetchLinks } from '../types/articles';
 
 const fetchLinks = articlesFetchLinks;
+
+// For other types we use fetcher.getById (see e.g. books.ts).
+//
+// That method looks for matching documents with a single type (e.g. document.type === 'books');
+// because an article can have two types, we can't use that here.
 export async function fetchArticle(
   { client }: GetServerSidePropsPrismicClient,
   id: string

--- a/content/webapp/services/prismic/fetch/index.ts
+++ b/content/webapp/services/prismic/fetch/index.ts
@@ -75,13 +75,15 @@ export function fetcher<Document extends PrismicDocument>(
       { client }: GetServerSidePropsPrismicClient,
       id: string
     ): Promise<Document | undefined> => {
-      const document = await client.getByID<Document>(id, {
-        fetchLinks,
-      });
+      try {
+        const document = await client.getByID<Document>(id, {
+          fetchLinks,
+        });
 
-      if (document.type === contentType) {
-        return document;
-      }
+        if (document.type === contentType) {
+          return document;
+        }
+      } catch {}
     },
 
     getByType: async (


### PR DESCRIPTION
I suspect this affects other types of page as well (e.g. event series) but a 500'ing book was where I initially saw this error. Somebody ended up on https://wellcomecollection.org/books/tel%3A%2B4420%207611%202222