### PR TITLE
Include the 'params' query parameter in the CloudFront cache

### DIFF
--- a/cache/cloudfront_prod.tf
+++ b/cache/cloudfront_prod.tf
@@ -77,6 +77,13 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
         "result",
         "toggle",
         "uri",
+
+        # This is used to fetch articles client-side, e.g. related stories.
+        # When it's missing, we may show the wrong stories as "read this next"
+        # on articles.
+        #
+        # See https://github.com/wellcomecollection/wellcomecollection.org/issues
+        "params",
       ]
 
       cookies {

--- a/cache/cloudfront_stage.tf
+++ b/cache/cloudfront_stage.tf
@@ -46,6 +46,13 @@ resource "aws_cloudfront_distribution" "stage_wc_org" {
         "result",
         "toggle",
         "uri",
+
+        # This is used to fetch articles client-side, e.g. related stories.
+        # When it's missing, we may show the wrong stories as "read this next"
+        # on articles.
+        #
+        # See https://github.com/wellcomecollection/wellcomecollection.org/issues
+        "params",
       ]
 
       cookies {

--- a/content/webapp/services/prismic/fetch/articles.ts
+++ b/content/webapp/services/prismic/fetch/articles.ts
@@ -52,6 +52,13 @@ export async function fetchArticles(
 export async function fetchArticlesClientSide(
   params?: Params
 ): Promise<Query<ArticlePrismicDocument> | undefined> {
+  // If you add more parameters here, you have to update the corresponding cache behaviour
+  // in the CloudFront distribution, or you may get incorrect behaviour.
+  //
+  // e.g. at one point we forgot to include the "params" query in the cache key,
+  // so every article was showing the same set of related stories.
+  //
+  // See https://github.com/wellcomecollection/wellcomecollection.org/issues
   const urlSearchParams = new URLSearchParams();
   urlSearchParams.set('params', JSON.stringify(params));
   const response = await fetch(`/api/articles?${urlSearchParams.toString()}`);

--- a/playwright/test/articles.test.ts
+++ b/playwright/test/articles.test.ts
@@ -14,7 +14,28 @@ beforeAll(async () => {
   ]);
 });
 
-test('contributors are shown on articles', async () => {
-  await article('Ya4jyRAAAGNLAejB');
-  await page.waitForSelector('h3 >> text="Yiling Zhang"');
+describe('articles', () => {
+  test('contributors are shown on articles', async () => {
+    await article('Ya4jyRAAAGNLAejB');
+    await page.waitForSelector('h3 >> text="Yiling Zhang"');
+  });
+
+  test('related stories are shown on articles', async () => {
+    // We're deliberately testing multiple stories here, to catch an issue where
+    // the "related stories" section can show related stories for the wrong series.
+    //
+    // Note: at time of writing, the related stories were looked up using an /api/articles
+    // endpoint which was being incorrectly cached in CloudFront.  This test may start
+    // failing even if the application code hasn't changed.
+    //
+    // See https://github.com/wellcomecollection/wellcomecollection.org/issues/7461
+
+    await article('YUrz5RAAACIA4ZrH');
+    await page.waitForSelector(
+      'div >> text="Conflicted and confused about lithium"'
+    );
+
+    await article('YPAnpxAAACIAbz2c');
+    await page.waitForSelector('div >> text="This is a MOOD"');
+  });
 });


### PR DESCRIPTION
Otherwise we'll cache the first request for related stories to /api/articles, and the same list is shown on all articles.

Tentatively closes https://github.com/wellcomecollection/wellcomecollection.org/issues/7461; this is already applied.