### PR TITLE
Use names for the expiry times in the CloudFront distros

### DIFF
--- a/cache/cloudfront_prod.tf
+++ b/cache/cloudfront_prod.tf
@@ -63,8 +63,8 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
     viewer_protocol_policy = "redirect-to-https"
     target_origin_id       = local.default_origin_id
     min_ttl                = 0
-    default_ttl            = 3600
-    max_ttl                = 86400
+    default_ttl            = local.one_hour
+    max_ttl                = local.one_day
 
     forwarded_values {
       headers      = ["Host"]
@@ -121,8 +121,8 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
     target_origin_id       = local.default_origin_id
     path_pattern           = "/works*"
     min_ttl                = 0
-    default_ttl            = 3600
-    max_ttl                = 86400
+    default_ttl            = local.one_hour
+    max_ttl                = local.one_day
 
     forwarded_values {
       headers      = ["Host"]
@@ -180,8 +180,8 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
     target_origin_id       = local.default_origin_id
     path_pattern           = "/account*"
     min_ttl                = 0
-    default_ttl            = 3600
-    max_ttl                = 86400
+    default_ttl            = local.one_hour
+    max_ttl                = local.one_day
 
     forwarded_values {
       headers      = ["*"]
@@ -201,8 +201,8 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
     target_origin_id       = local.default_origin_id
     path_pattern           = "/images*"
     min_ttl                = 0
-    default_ttl            = 3600
-    max_ttl                = 86400
+    default_ttl            = local.one_hour
+    max_ttl                = local.one_day
 
     forwarded_values {
       headers      = ["Host"]
@@ -252,8 +252,8 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
     cached_methods         = ["HEAD", "GET"]
     viewer_protocol_policy = "redirect-to-https"
     min_ttl                = 0
-    default_ttl            = 86400
-    max_ttl                = 31536000
+    default_ttl            = local.one_day
+    max_ttl                = local.one_year
 
     forwarded_values {
       headers      = ["Host"]
@@ -277,8 +277,8 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
     cached_methods         = ["HEAD", "GET"]
     viewer_protocol_policy = "redirect-to-https"
     min_ttl                = 0
-    default_ttl            = 86400
-    max_ttl                = 31536000
+    default_ttl            = local.one_day
+    max_ttl                = local.one_year
 
     forwarded_values {
       headers      = ["Host"]
@@ -297,8 +297,8 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
     cached_methods         = ["HEAD", "GET"]
     viewer_protocol_policy = "redirect-to-https"
     min_ttl                = 0
-    default_ttl            = 60
-    max_ttl                = 60
+    default_ttl            = local.one_minute
+    max_ttl                = local.one_minute
 
     forwarded_values {
       headers      = ["Host"]
@@ -320,9 +320,9 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
     allowed_methods        = ["HEAD", "GET"]
     cached_methods         = ["HEAD", "GET"]
     viewer_protocol_policy = "redirect-to-https"
-    min_ttl                = 86400
-    default_ttl            = 86400
-    max_ttl                = 3153600
+    min_ttl                = local.one_day
+    default_ttl            = local.one_day
+    max_ttl                = local.one_year
 
     forwarded_values {
       query_string = false
@@ -339,9 +339,9 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
     allowed_methods        = ["HEAD", "GET"]
     cached_methods         = ["HEAD", "GET"]
     viewer_protocol_policy = "redirect-to-https"
-    min_ttl                = 86400
-    default_ttl            = 86400
-    max_ttl                = 3153600
+    min_ttl                = local.one_day
+    default_ttl            = local.one_day
+    max_ttl                = local.one_year
 
     forwarded_values {
       query_string = false

--- a/cache/cloudfront_stage.tf
+++ b/cache/cloudfront_stage.tf
@@ -32,8 +32,8 @@ resource "aws_cloudfront_distribution" "stage_wc_org" {
     viewer_protocol_policy = "redirect-to-https"
     target_origin_id       = local.default_origin_id
     min_ttl                = 0
-    default_ttl            = 3600
-    max_ttl                = 86400
+    default_ttl            = local.one_hour
+    max_ttl                = local.one_day
 
     forwarded_values {
       headers      = ["Host"]
@@ -90,8 +90,8 @@ resource "aws_cloudfront_distribution" "stage_wc_org" {
     target_origin_id       = local.default_origin_id
     path_pattern           = "/works*"
     min_ttl                = 0
-    default_ttl            = 3600
-    max_ttl                = 86400
+    default_ttl            = local.one_hour
+    max_ttl                = local.one_day
 
     forwarded_values {
       headers      = ["Host"]
@@ -149,8 +149,8 @@ resource "aws_cloudfront_distribution" "stage_wc_org" {
     target_origin_id       = local.default_origin_id
     path_pattern           = "/account*"
     min_ttl                = 0
-    default_ttl            = 3600
-    max_ttl                = 86400
+    default_ttl            = local.one_hour
+    max_ttl                = local.one_day
 
     forwarded_values {
       headers      = ["*"]
@@ -170,8 +170,8 @@ resource "aws_cloudfront_distribution" "stage_wc_org" {
     target_origin_id       = local.default_origin_id
     path_pattern           = "/images*"
     min_ttl                = 0
-    default_ttl            = 3600
-    max_ttl                = 86400
+    default_ttl            = local.one_hour
+    max_ttl                = local.one_day
 
     forwarded_values {
       headers      = ["Host"]
@@ -221,8 +221,8 @@ resource "aws_cloudfront_distribution" "stage_wc_org" {
     cached_methods         = ["HEAD", "GET"]
     viewer_protocol_policy = "redirect-to-https"
     min_ttl                = 0
-    default_ttl            = 86400
-    max_ttl                = 31536000
+    default_ttl            = local.one_day
+    max_ttl                = local.one_year
 
     forwarded_values {
       headers      = ["Host"]
@@ -246,8 +246,8 @@ resource "aws_cloudfront_distribution" "stage_wc_org" {
     cached_methods         = ["HEAD", "GET"]
     viewer_protocol_policy = "redirect-to-https"
     min_ttl                = 0
-    default_ttl            = 86400
-    max_ttl                = 31536000
+    default_ttl            = local.one_day
+    max_ttl                = local.one_year
 
     forwarded_values {
       headers      = ["Host"]
@@ -266,8 +266,8 @@ resource "aws_cloudfront_distribution" "stage_wc_org" {
     cached_methods         = ["HEAD", "GET"]
     viewer_protocol_policy = "redirect-to-https"
     min_ttl                = 0
-    default_ttl            = 60
-    max_ttl                = 60
+    default_ttl            = local.one_minute
+    max_ttl                = local.one_minute
 
     forwarded_values {
       headers      = ["Host"]
@@ -289,9 +289,9 @@ resource "aws_cloudfront_distribution" "stage_wc_org" {
     allowed_methods        = ["HEAD", "GET"]
     cached_methods         = ["HEAD", "GET"]
     viewer_protocol_policy = "redirect-to-https"
-    min_ttl                = 86400
-    default_ttl            = 86400
-    max_ttl                = 3153600
+    min_ttl                = local.one_day
+    default_ttl            = local.one_day
+    max_ttl                = local.one_year
 
     forwarded_values {
       query_string = false
@@ -308,9 +308,9 @@ resource "aws_cloudfront_distribution" "stage_wc_org" {
     allowed_methods        = ["HEAD", "GET"]
     cached_methods         = ["HEAD", "GET"]
     viewer_protocol_policy = "redirect-to-https"
-    min_ttl                = 86400
-    default_ttl            = 86400
-    max_ttl                = 3153600
+    min_ttl                = local.one_day
+    default_ttl            = local.one_day
+    max_ttl                = local.one_year
 
     forwarded_values {
       query_string = false

--- a/cache/locals.tf
+++ b/cache/locals.tf
@@ -3,4 +3,9 @@ locals {
   edge_lambda_response_version = 67
 
   wellcome_cdn_cert_arn = "arn:aws:acm:us-east-1:130871440101:certificate/bb840c52-56bb-4bf8-86f8-59e7deaf9c98"
+
+  one_minute = 60
+  one_hour   = 60 * 60
+  one_day    = 24 * local.one_hour
+  one_year   = 365 * local.one_day
 }


### PR DESCRIPTION
This just makes them a little easier to reason about. Plus exposed the fact that in some cases, we're caching values for 36.5 days rather than a year. 🙈 