### PR TITLE
Add some typing for ArticleSeriesList

### DIFF
--- a/content/webapp/components/SearchResults/SearchResults.tsx
+++ b/content/webapp/components/SearchResults/SearchResults.tsx
@@ -1,4 +1,4 @@
-import { Fragment } from 'react';
+import { Fragment, FunctionComponent } from 'react';
 import styled from 'styled-components';
 import type { MultiContent } from '@weco/common/model/multi-content';
 import { grid } from '@weco/common/utils/classnames';
@@ -21,12 +21,12 @@ type Props = {
   showPosition?: boolean;
 };
 
-const SearchResults = ({
+const SearchResults: FunctionComponent<Props> = ({
   items,
   title,
   summary,
   showPosition = false,
-}: Props) => (
+}) => (
   <Fragment>
     {title && (
       <Space

--- a/content/webapp/components/SeriesNavigation/SeriesNavigation.tsx
+++ b/content/webapp/components/SeriesNavigation/SeriesNavigation.tsx
@@ -1,3 +1,4 @@
+import { FunctionComponent } from 'react';
 import MoreLink from '@weco/common/views/components/MoreLink/MoreLink';
 import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
 import Layout8 from '@weco/common/views/components/Layout8/Layout8';
@@ -12,7 +13,7 @@ type Props = {
   items: readonly (Article | ArticleScheduleItem)[];
 };
 
-const SeriesNavigation = ({ series, items }: Props) => {
+const SeriesNavigation: FunctionComponent<Props> = ({ series, items }) => {
   const showPosition = !!(series.schedule && series.schedule.length > 0);
   return (
     <SpacingComponent>

--- a/content/webapp/pages/article.tsx
+++ b/content/webapp/pages/article.tsx
@@ -1,6 +1,7 @@
 import { GetServerSideProps } from 'next';
 import { Fragment, FC, useState, useEffect } from 'react';
 import { Article } from '@weco/common/model/articles';
+import { ArticleSeries } from '@weco/common/model/article-series';
 import { parseArticleDoc } from '@weco/common/services/prismic/articles';
 import { classNames, font } from '@weco/common/utils/classnames';
 import { capitalize } from '@weco/common/utils/grammar';
@@ -69,8 +70,13 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     }
   };
 
+type ArticleSeriesList = {
+  series: ArticleSeries;
+  articles: Article[];
+}[];
+
 const ArticlePage: FC<Props> = ({ article }) => {
-  const [listOfSeries, setListOfSeries] = useState<any[]>();
+  const [listOfSeries, setListOfSeries] = useState<ArticleSeriesList>();
 
   useEffect(() => {
     async function setSeries() {
@@ -87,7 +93,8 @@ const ArticlePage: FC<Props> = ({ article }) => {
             predicates: [`[at(${seriesField}, "${series.id}")]`],
           }));
 
-        const articles = articlesInSeries?.results.map(parseArticleDoc);
+        const articles =
+          articlesInSeries?.results.map(doc => parseArticleDoc(doc)) ?? [];
 
         if (series) {
           setListOfSeries([{ series, articles }]);
@@ -269,13 +276,7 @@ const ArticlePage: FC<Props> = ({ article }) => {
           const dedupedArticles = articles
             .filter(a => a.id !== article.id)
             .slice(0, 2);
-          return (
-            <SeriesNavigation
-              key={series.id}
-              series={series}
-              items={dedupedArticles}
-            />
-          );
+          return <SeriesNavigation series={series} items={dedupedArticles} />;
         }
       })
       .filter(Boolean);


### PR DESCRIPTION
If fetching the related stories for an article (which happens client side) failed, then the whole page would error as we were trying to run array methods on non existent arrays.

This should fix that.
