### PR TITLE
Use the wellcome.org URL in the cookie banner, not the old ac.uk URL

### DIFF
--- a/common/views/components/CookieNotice/CookieNotice.tsx
+++ b/common/views/components/CookieNotice/CookieNotice.tsx
@@ -78,7 +78,7 @@ const CookieNotice: FunctionComponent<Props> = ({ source }) => {
               >
                 <h2 className="no-margin inline">Wellcome uses cookies.</h2>
               </Space>
-              <a href="https://wellcome.ac.uk/about-us/terms-use#cookies">
+              <a href="https://wellcome.org/who-we-are/privacy-and-terms#cookies">
                 Read our policy
               </a>
             </div>


### PR DESCRIPTION
## Who is this for?

People who care about super whizzy-fast web browsing.

## What is it doing for them?

Skipping an unnecessary redirect.