### PR TITLE
Return a 404 for image queries for impossible canonical IDs

### DIFF
--- a/catalogue/webapp/services/catalogue/common.ts
+++ b/catalogue/webapp/services/catalogue/common.ts
@@ -30,3 +30,17 @@ export const catalogueApiError = (): CatalogueApiError => ({
   description: '',
   type: 'Error',
 });
+
+// Returns true if a string is plausibly a canonical ID, false otherwise.
+//
+// There's no way for the front-end to know what strings are valid canonical IDs
+// (only the catalogue API knows that), but it can reject certain classes of
+// strings that it knows definitely aren't.
+//
+// e.g. any non-alphanumeric string definitely isn't a canonical ID.
+//
+// This is useful for rejecting queries that are obviously malformed, which might
+// be attempts to inject malicious data into API queries.
+export const looksLikeCanonicalId = (id: string): boolean => {
+  return /^([a-z0-9]+)$/.test(id);
+};

--- a/catalogue/webapp/services/catalogue/images.ts
+++ b/catalogue/webapp/services/catalogue/images.ts
@@ -84,14 +84,14 @@ export async function getImage({
     rootUris[apiOptions.env]
   }/v2/images/${id}?${searchParams.toString()}`;
 
-  try {
-    const res = await fetch(url);
-    const json = await res.json();
-    if (res.status === 404) {
-      return notFound();
-    }
+  const res = await fetch(url);
 
-    return json;
+  if (res.status === 404) {
+    return notFound();
+  }
+
+  try {
+    return await res.json();
   } catch (e) {
     return catalogueApiError();
   }

--- a/catalogue/webapp/services/catalogue/images.ts
+++ b/catalogue/webapp/services/catalogue/images.ts
@@ -9,6 +9,7 @@ import {
   globalApiOptions,
   catalogueApiError,
   notFound,
+  looksLikeCanonicalId,
 } from './common';
 import { Toggles } from '@weco/toggles';
 import { propsToQuery } from '@weco/common/utils/routes';
@@ -67,6 +68,10 @@ export async function getImage({
   toggles,
   include = [],
 }: GetImageProps): Promise<Image | CatalogueApiError> {
+  if (!looksLikeCanonicalId(id)) {
+    return notFound();
+  }
+
   const apiOptions = globalApiOptions(toggles);
 
   const params = {

--- a/catalogue/webapp/services/catalogue/works.ts
+++ b/catalogue/webapp/services/catalogue/works.ts
@@ -10,6 +10,7 @@ import Raven from 'raven-js';
 import {
   catalogueApiError,
   globalApiOptions,
+  looksLikeCanonicalId,
   rootUris,
   notFound,
 } from './common';
@@ -96,13 +97,7 @@ export async function getWork({
   id,
   toggles,
 }: GetWorkProps): Promise<WorkResponse> {
-  // We have occasionally seen requests for URLs with IDs which are
-  // obviously wrong, e.g. with spaces or special characters.
-  //
-  // In these cases, there's no point forwarding the request to the API
-  // (and we could serve 500 errors from malformed IDs).  If the ID isn't
-  // alphanumeric, reject it immediately.
-  if (!/^([a-z0-9]+)$/.test(id)) {
+  if (!looksLikeCanonicalId(id)) {
     return notFound();
   }
 

--- a/catalogue/webapp/services/catalogue/works.ts
+++ b/catalogue/webapp/services/catalogue/works.ts
@@ -131,12 +131,12 @@ export async function getWork({
     return id ? redirect(id, res.status) : notFound();
   }
 
+  if (res.status === 404) {
+    return notFound();
+  }
+
   try {
-    const json = await res.json();
-    if (res.status === 404) {
-      return notFound();
-    }
-    return json;
+    return await res.json();
   } catch (e) {
     return catalogueApiError();
   }


### PR DESCRIPTION
We've seen more attempts by people to inject malicious data into our code in URL query parameters, e.g.

https://wellcomecollection.org/works/kusekcbm/images?id=yn3995ya'||lower('')||'

This is currently returning a 500 error; let's cut it off before we make an API query by 404'ing immediately.

See accompanying PR https://github.com/wellcomecollection/catalogue-api/pull/327