### PR TITLE
Moving events to content app

### DIFF
--- a/common/model/seasons.js
+++ b/common/model/seasons.js
@@ -1,6 +1,5 @@
 // @flow
 import type { GenericContentFields } from './generic-content-fields';
-import type { Event } from './events';
 import type { Exhibition } from './exhibitions';
 import type { Page } from './pages';
 import type { ArticleSeries } from './article-series';
@@ -13,7 +12,6 @@ export type Season = {
 
 export type SeasonWithContent = {
   season: Season,
-  events: Event[],
   exhibitions: Exhibition[],
   pages: Page[],
   articleSeries: ArticleSeries[],

--- a/common/model/seasons.ts
+++ b/common/model/seasons.ts
@@ -1,5 +1,4 @@
 import { GenericContentFields } from './generic-content-fields';
-import { Event } from './events';
 import { Exhibition } from './exhibitions';
 import { Page } from './pages';
 import { ArticleSeries } from './article-series';
@@ -13,7 +12,6 @@ export type Season = GenericContentFields & {
 
 export type SeasonWithContent = {
   season: Season;
-  events: Event[];
   exhibitions: Exhibition[];
   pages: Page[];
   articleSeries: ArticleSeries[];

--- a/common/services/prismic/seasons.ts
+++ b/common/services/prismic/seasons.ts
@@ -1,7 +1,6 @@
 import Prismic from '@prismicio/client';
 import { PrismicDocument } from './types';
 import { getDocument } from './api';
-import { getEvents } from './events';
 import { getExhibitions } from './exhibitions';
 import { getPages } from './pages';
 import { getProjects } from './projects';
@@ -12,13 +11,7 @@ import {
   parseSingleLevelGroup,
   parseTimestamp,
 } from './parsers';
-import {
-  pagesFields,
-  articlesFields,
-  bookFields,
-  eventsFields,
-  exhibitionFields,
-} from './fetch-links';
+import { pagesFields, exhibitionFields } from './fetch-links';
 import { IncomingMessage } from 'http';
 
 export function parseSeason(document: PrismicDocument): Season {
@@ -51,12 +44,7 @@ export async function getSeason(
     req,
     id,
     {
-      fetchLinks: pagesFields.concat(
-        articlesFields,
-        bookFields,
-        eventsFields,
-        exhibitionFields
-      ),
+      fetchLinks: pagesFields.concat(exhibitionFields),
     },
     memoizedPrismic
   );
@@ -76,12 +64,6 @@ export async function getSeasonWithContent({
   id: string;
 }): Promise<SeasonWithContent | undefined> {
   const seasonPromise = getSeason(request, id, memoizedPrismic);
-
-  const eventsPromise = getEvents(
-    request,
-    { predicates: [Prismic.Predicates.at('my.events.seasons.season', id)] },
-    memoizedPrismic
-  );
 
   const exhibitionsPromise = getExhibitions(
     request,
@@ -115,10 +97,9 @@ export async function getSeasonWithContent({
     memoizedPrismic
   );
 
-  const [season, events, exhibitions, pages, articleSeries, projects] =
+  const [season, exhibitions, pages, articleSeries, projects] =
     await Promise.all([
       seasonPromise,
-      eventsPromise,
       exhibitionsPromise,
       pagesPromise,
       articleSeriesPromise,
@@ -128,7 +109,6 @@ export async function getSeasonWithContent({
   if (season) {
     return {
       season,
-      events: events?.results || [],
       exhibitions: exhibitions?.results || [],
       pages: pages?.results || [],
       articleSeries: articleSeries?.results || [],

--- a/content/webapp/pages/season.tsx
+++ b/content/webapp/pages/season.tsx
@@ -121,6 +121,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     });
     const eventsQueryPromise = fetchEvents(client, {
       predicates: [`[at(my.events.seasons.season, "${id}")]`],
+      orderings: ['my.events.times.startDateTime'],
     });
 
     const { memoizedPrismic } = context.query;

--- a/content/webapp/services/prismic/fetch/index.ts
+++ b/content/webapp/services/prismic/fetch/index.ts
@@ -102,6 +102,7 @@ export function fetcher<Document extends PrismicDocument>(
 
       const response = await client.getByType<Document>(contentType, {
         ...params,
+        fetchLinks,
         predicates: [...predicates, delistPredicate],
       });
       return response;


### PR DESCRIPTION
References #7363

Displays events on season pages, using the new fetch and transform methods
