### PR TITLE
Don't look for an Encore link when requesting is unavailable

### DIFF
--- a/playwright/test/work.test.ts
+++ b/playwright/test/work.test.ts
@@ -7,10 +7,12 @@ import {
 async function getWhereToFindItAndEncoreLink() {
   const whereToFindIt = await page.$('h2:has-text("Where to find it")');
   const encoreLink = await page.$('a:has-text("Request item")');
+  const unavailableBanner = await page.$('span:has-text("Requesting is currently unavailable, while our building is closed.")');
 
   return {
     whereToFindIt,
     encoreLink,
+    unavailableBanner,
   };
 }
 
@@ -22,9 +24,11 @@ async function getAvailableOnline() {
 describe(`Scenario 1: a user wants to see relevant information about where a work's items are located`, () => {
   test(`works that have a physical item location display a 'Where to find it' section with a link`, async () => {
     await workWithPhysicalLocationOnly();
-    const { whereToFindIt, encoreLink } = await getWhereToFindItAndEncoreLink();
+    const { whereToFindIt, encoreLink, unavailableBanner } = await getWhereToFindItAndEncoreLink();
     expect(whereToFindIt).toBeTruthy();
-    expect(encoreLink).toBeTruthy();
+    
+    // TODO: Remove the check for the unavailableBanner when the building is reopened.
+    expect(encoreLink || unavailableBanner).toBeTruthy();
   });
 
   test(`works with only a physical location don't display an 'Available online' section`, async () => {


### PR DESCRIPTION
To stop the e2e tests for requesting failing: https://buildkite.com/wellcomecollection/experience-e2e/builds/602#8c262486-d2ff-4b63-af43-719cb4f5337a