### PR TITLE
Don't show 'Show content' button when it doesn't make sense

### DIFF
--- a/catalogue/webapp/pages/item.tsx
+++ b/catalogue/webapp/pages/item.tsx
@@ -128,6 +128,15 @@ const ItemPage: NextPage<Props> = ({
 
   const authService = getAuthService(manifest);
   const tokenService = authService && getTokenService(authService);
+  const authServiceRestrictedIds = [
+    'https://iiif.wellcomecollection.org/auth/restrictedlogin',
+  ];
+  const isAvailableOnline = authService => {
+    return (
+      authService['@id'] &&
+      !authServiceRestrictedIds.includes(authService['@id'])
+    );
+  };
 
   const sharedPaginatorProps = {
     totalResults: canvases ? canvases.length : 1,
@@ -291,7 +300,7 @@ const ItemPage: NextPage<Props> = ({
               }}
             />
           )}
-          {authService?.['@id'] && origin && (
+          {isAvailableOnline(authService) && origin && (
             <Space
               className={'flex flex-inline'}
               h={{ size: 'm', properties: ['margin-right'] }}

--- a/catalogue/webapp/pages/item.tsx
+++ b/catalogue/webapp/pages/item.tsx
@@ -133,6 +133,7 @@ const ItemPage: NextPage<Props> = ({
   ];
   const isAvailableOnline = authService => {
     return (
+      authService &&
       authService['@id'] &&
       !authServiceRestrictedIds.includes(authService['@id'])
     );
@@ -300,7 +301,7 @@ const ItemPage: NextPage<Props> = ({
               }}
             />
           )}
-          {isAvailableOnline(authService) && origin && (
+          {isAvailableOnline() && origin && (
             <Space
               className={'flex flex-inline'}
               h={{ size: 'm', properties: ['margin-right'] }}

--- a/catalogue/webapp/pages/item.tsx
+++ b/catalogue/webapp/pages/item.tsx
@@ -131,7 +131,7 @@ const ItemPage: NextPage<Props> = ({
   const authServiceRestrictedIds = [
     'https://iiif.wellcomecollection.org/auth/restrictedlogin',
   ];
-  const isAvailableOnline = authService => {
+  const isAvailableOnline = () => {
     return (
       authService &&
       authService['@id'] &&


### PR DESCRIPTION
## Who is this for?
People trying to access restricted material

## What is it doing for them?
Preventing an erroneous 'Show the content' button from displaying when we aren't able to show the content.

__before__
![image](https://user-images.githubusercontent.com/1394592/147085577-518f8f8b-4142-48d7-b1e7-eb3903f6b7db.png)


__after__
![image](https://user-images.githubusercontent.com/1394592/147085330-9876e15e-b69e-4513-8229-374886c5f66e.png)
