### PR TITLE
Fix the pluralisation of '1 volumes available online'

### DIFF
--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -469,7 +469,9 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
                     >
                       Contains:{' '}
                       {childManifestsCount > 0
-                        ? `${childManifestsCount} volumes`
+                        ? `${childManifestsCount} ${
+                            childManifestsCount === 1 ? 'volume' : 'volumes'
+                          }`
                         : imageCount > 0
                         ? `${imageCount} ${
                             imageCount === 1 ? 'image' : 'images'

--- a/catalogue/webapp/components/WorkHeader/WorkHeader.tsx
+++ b/catalogue/webapp/components/WorkHeader/WorkHeader.tsx
@@ -119,7 +119,8 @@ const WorkHeader: FunctionComponent<Props> = ({
                   'no-margin': true,
                 })}
               >
-                <Number color="yellow" number={childManifestsCount} /> volumes
+                <Number color="yellow" number={childManifestsCount} />
+                {childManifestsCount === 1 ? ' volume ' : ' volumes '}
                 online
               </p>
             </Space>


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/wellcomecollection.org/issues/7517

Before:

![](https://user-images.githubusercontent.com/301220/147859323-7fbdf4e6-9c9e-428f-93ee-20bd60bb0229.png)

After:

<img width="641" alt="Screenshot 2022-01-04 at 08 56 41" src="https://user-images.githubusercontent.com/301220/148034090-d8b2cf7a-ec3d-4be7-9722-b6b808daadaf.png">

This component gets the count by doing an async load of the IIIF manifests, which seems moderately fiddly to mock in tests, so no tests for this.