### PR TITLE
Fix a persistent source of 500 errors from DLCS 404'ing manifests

### DIFF
--- a/catalogue/webapp/pages/download.tsx
+++ b/catalogue/webapp/pages/download.tsx
@@ -167,7 +167,8 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     }
 
     const manifestUrl =
-      sierraId && `https://wellcomelibrary.org/iiif/${sierraId}/manifest`;
+      sierraId &&
+      `https://iiif.wellcomecollection.org/presentation/v2/${sierraId}`;
 
     const manifest = manifestUrl && (await (await fetch(manifestUrl)).json());
 

--- a/catalogue/webapp/pages/download.tsx
+++ b/catalogue/webapp/pages/download.tsx
@@ -170,7 +170,39 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       sierraId &&
       `https://iiif.wellcomecollection.org/presentation/v2/${sierraId}`;
 
-    const manifest = manifestUrl && (await (await fetch(manifestUrl)).json());
+    const iiifResponse = manifestUrl && (await fetch(manifestUrl));
+
+    // A user should never end up on a /download page that points to a non-existent
+    // IIIF manifest, but we do see a persistent trickle of such requests.
+    // Possibly URLs that used to resolve, but have since been removed?
+    //
+    // In these cases, DLCS returns a 404 and the response text like
+    //
+    //      No IIIF resource found for v2/b18037343
+    //
+    // If we don't catch the 404 here, this bubbles up as an internal server error
+    // when we try to parse the JSON, with the error
+    //
+    //      FetchError: invalid json response body at https://iiif.wellcomecollection.org/presentation/v2/b18037343
+    //      reason: Unexpected token N in JSON at position 0
+    //
+    if (iiifResponse && iiifResponse.status === 404) {
+      return appError(
+        context,
+        404,
+        `There is no IIIF manifest for ${sierraId}`
+      );
+    }
+
+    // I don't know what status codes DLCS should return apart from 200 and 404 --
+    // this warning is to make debugging easier if we see other issues here.
+    if (iiifResponse && iiifResponse.status === 200) {
+      console.warn(
+        `Unexpected status when fetching IIIF manifest: ${iiifResponse.status}`
+      );
+    }
+
+    const manifest = iiifResponse && (await iiifResponse.json());
 
     const work = await getWork({
       id: workId,

--- a/catalogue/webapp/pages/download.tsx
+++ b/catalogue/webapp/pages/download.tsx
@@ -196,7 +196,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
 
     // I don't know what status codes DLCS should return apart from 200 and 404 --
     // this warning is to make debugging easier if we see other issues here.
-    if (iiifResponse && iiifResponse.status === 200) {
+    if (iiifResponse && iiifResponse.status !== 200) {
       console.warn(
         `Unexpected status when fetching IIIF manifest: ${iiifResponse.status}`
       );


### PR DESCRIPTION
If you visit https://wellcomecollection.org/works/rku7vrtb/download?sierraId=b18037343, you get a 500 error. The underlying cause is a missing manifest in DLCS, which returns an HTTP 404 and the text:

> No IIIF resource found for v2/b18037343

which we can't parse as JSON.

There's nothing sensible we can do in this case, so return a 404 to the user.

No user should be landing on these pages, but we have a persistent trickle of them – possibly for pages that no longer exist? Throw them in the 404 bin so other errors can stand out.