### PR TITLE
Don't log the world

### DIFF
--- a/identity/webapp/pages/api/users/[[...users]].ts
+++ b/identity/webapp/pages/api/users/[[...users]].ts
@@ -2,6 +2,7 @@ import { NextApiHandler } from 'next';
 import getConfig from 'next/config';
 import auth0 from '../../../src/utility/auth0';
 import axios, { AxiosInstance, Method as AxiosMethod } from 'axios';
+import { AccessTokenError } from '@auth0/nextjs-auth0';
 
 const { serverRuntimeConfig: config } = getConfig();
 
@@ -32,9 +33,13 @@ const handleIdentityApiRequest: NextApiHandler = auth0.withApiAuthRequired(
 
       res.status(remoteResponse.status).send(remoteResponse.data);
     } catch (e) {
-      // Something went wrong with getting the access token
-      console.error('Unexpected authentication error', e);
-      res.status(401).send({ message: 'Authentication error' });
+      if (e instanceof AccessTokenError) {
+        // Something went wrong with getting the access token
+        console.error('Unexpected authentication error', e);
+        res.status(401).send(e);
+      } else {
+        throw e;
+      }
     }
   }
 );

--- a/identity/webapp/pages/api/users/[[...users]].ts
+++ b/identity/webapp/pages/api/users/[[...users]].ts
@@ -14,22 +14,28 @@ export const identityAxios: AxiosInstance = axios.create({
 
 const handleIdentityApiRequest: NextApiHandler = auth0.withApiAuthRequired(
   async (req, res) => {
-    const { accessToken } = await auth0.getAccessToken(req, res);
-    const path = `/users/` + (req.query['users'] as string[]).join('/');
-    const remoteResponse = await identityAxios
-      .request({
-        url: path,
-        method: req.method as AxiosMethod,
-        data: req.body,
-        headers: {
-          ...identityAxios.defaults.headers.common,
-          Authorization: `Bearer ${accessToken}`,
-        },
-        validateStatus: (status: number) => status >= 200 && status < 500,
-      })
-      .catch(error => error.response);
+    try {
+      const { accessToken } = await auth0.getAccessToken(req, res);
+      const path = `/users/` + (req.query['users'] as string[]).join('/');
+      const remoteResponse = await identityAxios
+        .request({
+          url: path,
+          method: req.method as AxiosMethod,
+          data: req.body,
+          headers: {
+            ...identityAxios.defaults.headers.common,
+            Authorization: `Bearer ${accessToken}`,
+          },
+          validateStatus: (status: number) => status >= 200 && status < 500,
+        })
+        .catch(error => error.response);
 
-    res.status(remoteResponse.status).send(remoteResponse.data);
+      res.status(remoteResponse.status).send(remoteResponse.data);
+    } catch (e) {
+      // Something went wrong with getting the access token
+      console.error('Unexpected authentication error', e);
+      res.status(401).send({ message: 'Authentication error' });
+    }
   }
 );
 

--- a/identity/webapp/pages/api/users/[[...users]].ts
+++ b/identity/webapp/pages/api/users/[[...users]].ts
@@ -27,10 +27,7 @@ const handleIdentityApiRequest: NextApiHandler = auth0.withApiAuthRequired(
         },
         validateStatus: (status: number) => status >= 200 && status < 500,
       })
-      .catch(error => {
-        console.error(error);
-        return error.response;
-      });
+      .catch(error => error.response);
 
     res.status(remoteResponse.status).send(remoteResponse.data);
   }


### PR DESCRIPTION
This makes logs from the (proxied) identity API a bit less chatty and liable to divulge tokens