### PR TITLE
Don't be too permissive with the viewer

### DIFF
--- a/catalogue/webapp/utils/iiif.ts
+++ b/catalogue/webapp/utils/iiif.ts
@@ -56,7 +56,7 @@ export function getAuthService(
       //
       // If there is a mixture of restricted images and non restricted images, we show the auth service of the non restricted ones, 'e.g. open with advisory', as these can still be viewd.
       // Individual images that are restricted won't be displayed anyway.
-      return hasAtLeastOneNonAuthService
+      return hasAtLeastOneNonAuthService && !nonRestrictedService
         ? undefined
         : nonRestrictedService || restrictedService;
     } else {

--- a/catalogue/webapp/utils/iiif.ts
+++ b/catalogue/webapp/utils/iiif.ts
@@ -46,9 +46,9 @@ export function getAuthService(
           service?.['@id'] !==
           'https://iiif.wellcomecollection.org/auth/restrictedlogin'
       );
-      const hasAtLeastOneNonAuthService = iiifManifest.service.some(
-        service => !service.authService
-      );
+      const isOpen =
+        iiifManifest.service.some(service => !service.authService) &&
+        !nonRestrictedService;
       // If any of the manifest services don't include an `authService` then we can show the viewer without a modal.
       // e.g. if the manifest is a mixture of open and restricted images, then
       // DLCS will hide the images that are restricted -- and we can let the
@@ -56,9 +56,7 @@ export function getAuthService(
       //
       // If there is a mixture of restricted images and non restricted images, we show the auth service of the non restricted ones, 'e.g. open with advisory', as these can still be viewd.
       // Individual images that are restricted won't be displayed anyway.
-      return hasAtLeastOneNonAuthService && !nonRestrictedService
-        ? undefined
-        : nonRestrictedService || restrictedService;
+      return isOpen ? undefined : nonRestrictedService || restrictedService;
     } else {
       return iiifManifest.service.authService;
     }

--- a/playwright/test/contexts.ts
+++ b/playwright/test/contexts.ts
@@ -39,6 +39,27 @@ const itemWithAltText = async (params: {
   );
 };
 
+const itemWithOnlyOpenAccess = async (): Promise<void> => {
+  context.addCookies(requiredCookies);
+  await gotoWithoutCache(`${baseUrl}/works/w8t2vh3w/items`);
+};
+const itemWithOnlyRestrictedAccess = async (): Promise<void> => {
+  context.addCookies(requiredCookies);
+  await gotoWithoutCache(`${baseUrl}/works/zg3pt2bp/items`);
+};
+const itemWithRestrictedAndOpenAccess = async (): Promise<void> => {
+  context.addCookies(requiredCookies);
+  await gotoWithoutCache(`${baseUrl}/works/p9gepwjs/items`);
+};
+const itemWithRestrictedAndNonRestrictedAccess = async (): Promise<void> => {
+  context.addCookies(requiredCookies);
+  await gotoWithoutCache(`${baseUrl}/works/jsmqcwvt/items`);
+};
+const itemWithNonRestrictedAndOpenAccess = async (): Promise<void> => {
+  context.addCookies(requiredCookies);
+  await gotoWithoutCache(`${baseUrl}/works/fa7pymra/items`);
+};
+
 const itemWithSearchAndStructures = async (): Promise<void> => {
   context.addCookies(requiredCookies);
   await gotoWithoutCache(`${baseUrl}/works/re9cyhkt/items`);
@@ -91,5 +112,10 @@ export {
   workWithPhysicalLocationOnly,
   workWithDigitalLocationOnly,
   workWithDigitalLocationAndLocationNote,
+  itemWithOnlyOpenAccess,
+  itemWithOnlyRestrictedAccess,
+  itemWithRestrictedAndOpenAccess,
+  itemWithRestrictedAndNonRestrictedAccess,
+  itemWithNonRestrictedAndOpenAccess,
   article,
 };

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -3,6 +3,11 @@ import {
   itemWithSearchAndStructures,
   itemWithReferenceNumber,
   itemWithAltText,
+  itemWithOnlyOpenAccess,
+  itemWithOnlyRestrictedAccess,
+  itemWithRestrictedAndOpenAccess,
+  itemWithRestrictedAndNonRestrictedAccess,
+  itemWithNonRestrictedAndOpenAccess,
 } from './contexts';
 import { isMobile } from './actions/common';
 import { volumesNavigationLabel, searchWithinLabel } from './text/aria-labels';
@@ -283,5 +288,32 @@ describe('Scenario 10: A user wants to be able to access alt text for the images
     await page.waitForSelector(`img[alt='22900393554']`);
     const imagesWithSameText = await page.$$(`img[alt='22900393554']`);
     expect(imagesWithSameText.length).toBe(1);
+  });
+});
+
+describe.only('Scenario 11: A user wants to view an item with access restrictions', () => {
+  test('an item with only open access items will not display a modal', async () => {
+    await itemWithOnlyOpenAccess();
+    await page.waitForSelector(`h1`);
+  });
+
+  test('an item with only restricted access items will not display a modal', async () => {
+    await itemWithOnlyRestrictedAccess();
+    await page.waitForSelector(`h1`);
+  });
+
+  test('an item with a mix of restricted and open access items will not display a modal', async () => {
+    await itemWithRestrictedAndOpenAccess();
+    await page.waitForSelector(`h1`);
+  });
+
+  test('an item with a mix of restricted and non-restricted access items will display a modal', async () => {
+    await itemWithRestrictedAndNonRestrictedAccess();
+    await page.waitForSelector(`button:has-text('Show the content')`);
+  });
+
+  test('an item with a mix of non-restricted and open access items will display a modal', async () => {
+    await itemWithNonRestrictedAndOpenAccess();
+    await page.waitForSelector(`button:has-text('Show the content')`);
   });
 });

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -291,29 +291,43 @@ describe('Scenario 10: A user wants to be able to access alt text for the images
   });
 });
 
-describe.only('Scenario 11: A user wants to view an item with access restrictions', () => {
+describe('Scenario 11: A user wants to view an item with access restrictions', () => {
+  // If we display a modal, we wait until it is dismissed before showing anything in the
+  // main element. If there's no modal, we won't see a 'Show the content' button and we will see an h1.
+  // If there is a modal, we won't see an h1 and we will see a 'Show the content' button.
   test('an item with only open access items will not display a modal', async () => {
     await itemWithOnlyOpenAccess();
     await page.waitForSelector(`h1`);
+    expect(
+      await page.isVisible(`button:has-text('Show the content')`)
+    ).toBeFalsy();
   });
 
   test('an item with only restricted access items will not display a modal', async () => {
     await itemWithOnlyRestrictedAccess();
     await page.waitForSelector(`h1`);
+    expect(
+      await page.isVisible(`button:has-text('Show the content')`)
+    ).toBeFalsy();
   });
 
   test('an item with a mix of restricted and open access items will not display a modal', async () => {
     await itemWithRestrictedAndOpenAccess();
     await page.waitForSelector(`h1`);
+    expect(
+      await page.isVisible(`button:has-text('Show the content')`)
+    ).toBeFalsy();
   });
 
   test('an item with a mix of restricted and non-restricted access items will display a modal', async () => {
     await itemWithRestrictedAndNonRestrictedAccess();
     await page.waitForSelector(`button:has-text('Show the content')`);
+    expect(await page.isVisible(`h1`)).toBeFalsy();
   });
 
   test('an item with a mix of non-restricted and open access items will display a modal', async () => {
     await itemWithNonRestrictedAndOpenAccess();
     await page.waitForSelector(`button:has-text('Show the content')`);
+    expect(await page.isVisible(`h1`)).toBeFalsy();
   });
 });


### PR DESCRIPTION
## Who is this for?
People who want to be warned about viewer advisory content.

## What is it doing for them?
Showing them a modal.

#7529 was too permissive. In the instance where a work has e.g. three manifests, one that is restricted, one that is open with advisory and one that is open, we still need to show the modal because of the open with advisory content.

TODO: 
- [x]  tests