### PR TITLE
Refactor venue components

### DIFF
--- a/common/services/prismic/opening-times.ts
+++ b/common/services/prismic/opening-times.ts
@@ -233,10 +233,9 @@ export function backfillExceptionalVenueDays(
 }
 
 export function groupConsecutiveDays(
-  openingHoursPeriods: ExceptionalOpeningHoursDay[][]
+  dates: ExceptionalOpeningHoursDay[]
 ): ExceptionalOpeningHoursDay[][] {
-  return openingHoursPeriods
-    .reduce((acc, curr) => acc.concat(curr), [])
+  return dates
     .sort((a, b) => {
       return a.overrideDate?.diff(b.overrideDate, 'days') ?? 0;
     })

--- a/common/services/prismic/opening-times.ts
+++ b/common/services/prismic/opening-times.ts
@@ -275,14 +275,6 @@ export function getUpcomingExceptionalPeriods(
   return nextUpcomingPeriods;
 }
 
-export function getExceptionalClosedDays(
-  openingHoursPeriods: ExceptionalOpeningHoursDay[][]
-): ExceptionalOpeningHoursDay[][] {
-  return openingHoursPeriods.map(period =>
-    period.filter(date => date.opens === null)
-  );
-}
-
 export function createRegularDay(
   day: Day,
   venue: CollectionVenuePrismicDocument

--- a/common/services/prismic/opening-times.ts
+++ b/common/services/prismic/opening-times.ts
@@ -327,7 +327,11 @@ export function parseCollectionVenue(
     return {
       overrideDate,
       overrideType,
-      opens: start ? london(start).format('HH:mm') : '00:00', // See comment in createRegularDay for why these get set to 00:00
+      // If there is no start time from prismic, then we set both opens and closes to 00:00.
+      // This is necessary for the json-ld schema data, so Google knows when the venues are closed.
+      // See https://developers.google.com/search/docs/advanced/structured-data/local-business#business-hours (All-day hours tab)
+      // "To show a business is closed all day, set both opens and closes properties to '00:00'""
+      opens: start ? london(start).format('HH:mm') : '00:00',
       closes: start && end ? london(end).format('HH:mm') : '00:00',
       isClosed,
     };

--- a/common/views/components/DateRange/DateRange.tsx
+++ b/common/views/components/DateRange/DateRange.tsx
@@ -1,24 +1,14 @@
-import { Fragment, FunctionComponent } from 'react';
-import { formatTime, formatDayDate, london } from '../../../utils/format-date';
+import { FunctionComponent } from 'react';
+import { london } from '../../../utils/format-date';
 import HTMLDate from '../HTMLDate/HTMLDate';
+import HTMLDayDate from '../HTMLDayDate/HTMLDayDate';
+import HTMLTime from '../HTMLTime/HTMLTime';
 import { DateRange as DateRangeProps } from '../../../model/date-range';
 
-type DateProps = {
-  date: Date;
-};
-
-const HTMLDayDate = ({ date }: DateProps) => (
-  <time dateTime={date.toISOString()}>{formatDayDate(date)}</time>
-);
-
-const HTMLTime = ({ date }: DateProps) => (
-  <time dateTime={date.toISOString()}>{formatTime(date)}</time>
-);
-
 const TimeRange = ({ start, end }: DateRangeProps) => (
-  <Fragment>
+  <>
     <HTMLTime date={start} />—<HTMLTime date={end} />
-  </Fragment>
+  </>
 );
 
 type Props = {
@@ -32,22 +22,22 @@ const DateRange: FunctionComponent<Props> = ({
   const isSameDay = london(start).isSame(end, 'day');
 
   return (
-    <Fragment>
+    <>
       {isSameDay && (
-        <Fragment>
+        <>
           <HTMLDayDate date={start} />
           {splitTime ? '' : ', '}
           <span className={splitTime ? 'block' : undefined}>
             <TimeRange start={start} end={end} />
           </span>
-        </Fragment>
+        </>
       )}
       {!isSameDay && (
-        <Fragment>
+        <>
           <HTMLDate date={start} />—<HTMLDate date={end} />
-        </Fragment>
+        </>
       )}
-    </Fragment>
+    </>
   );
 };
 

--- a/common/views/components/HTMLDate/HTMLDate.tsx
+++ b/common/views/components/HTMLDate/HTMLDate.tsx
@@ -1,10 +1,11 @@
+import { FunctionComponent } from 'react';
 import { formatDate } from '../../../utils/format-date';
 
 type Props = {
   date: Date;
 };
 
-const HTMLDate = ({ date }: Props) => (
+const HTMLDate: FunctionComponent<Props> = ({ date }) => (
   <time dateTime={date.toISOString()}>{formatDate(date)}</time>
 );
 

--- a/common/views/components/HTMLDayDate/HTMLDayDate.tsx
+++ b/common/views/components/HTMLDayDate/HTMLDayDate.tsx
@@ -1,0 +1,12 @@
+import { FunctionComponent } from 'react';
+import { formatDayDate } from '../../../utils/format-date';
+
+type Props = {
+  date: Date;
+};
+
+const HTMLDayDate: FunctionComponent<Props> = ({ date }) => (
+  <time dateTime={date.toISOString()}>{formatDayDate(date)}</time>
+);
+
+export default HTMLDayDate;

--- a/common/views/components/HTMLTime/HTMLTime.tsx
+++ b/common/views/components/HTMLTime/HTMLTime.tsx
@@ -1,0 +1,12 @@
+import { FunctionComponent } from 'react';
+import { formatTime } from '../../../utils/format-date';
+
+type Props = {
+  date: Date;
+};
+
+const HTMLTime: FunctionComponent<Props> = ({ date }) => (
+  <time dateTime={date.toISOString()}>{formatTime(date)}</time>
+);
+
+export default HTMLTime;

--- a/common/views/components/VenueClosedPeriods/VenueClosedPeriods.tsx
+++ b/common/views/components/VenueClosedPeriods/VenueClosedPeriods.tsx
@@ -1,24 +1,20 @@
 import { FunctionComponent } from 'react';
 import {
   getExceptionalVenueDays,
-  parseOpeningTimes,
-  getVenueById,
   groupConsecutiveDays,
 } from '../../../services/prismic/opening-times';
-import { formatDayDate } from '@weco/common/utils/format-date';
+import { formatDayDate } from '../../../utils/format-date';
 import {
   collectionVenueId,
   getNameFromCollectionVenue,
-} from '@weco/common/services/prismic/hardcoded-id';
-import { usePrismicData } from '../../../server-data/Context';
+} from '../../../services/prismic/hardcoded-id';
+import { Venue } from '../../../model/opening-hours';
+
 type Props = {
-  venueId: string;
+  venue: Venue;
 };
 
-const VenueClosedPeriods: FunctionComponent<Props> = ({ venueId }) => {
-  const prismicData = usePrismicData();
-  const openingTimes = parseOpeningTimes(prismicData.collectionVenues);
-  const venue = getVenueById(openingTimes, venueId);
+const VenueClosedPeriods: FunctionComponent<Props> = ({ venue }) => {
   const exceptionalVenueDays = venue ? getExceptionalVenueDays(venue) : [];
   const onlyClosedDays = exceptionalVenueDays.filter(day => day.isClosed);
   const groupedConsectiveClosedDays = groupConsecutiveDays(onlyClosedDays);
@@ -26,8 +22,8 @@ const VenueClosedPeriods: FunctionComponent<Props> = ({ venueId }) => {
   return groupedConsectiveClosedDays[0] &&
     groupedConsectiveClosedDays[0].length > 0 ? (
     <div className="body-text">
-      <h2>{getNameFromCollectionVenue(venueId)} closures</h2>
-      {venueId === collectionVenueId.libraries.id && (
+      <h2>{getNameFromCollectionVenue(venue.id)} closures</h2>
+      {venue.id === collectionVenueId.libraries.id && (
         <p className="no-margin">
           Planning a research visit? Our library is closed over bank holiday
           weekends and between Christmas Eve and New Year{`'`}s Day:

--- a/common/views/components/VenueClosedPeriods/VenueClosedPeriods.tsx
+++ b/common/views/components/VenueClosedPeriods/VenueClosedPeriods.tsx
@@ -60,12 +60,10 @@ const VenueClosedPeriods: FunctionComponent<Props> = ({ venue }) => {
             closedGroup.length > 0 && (
               <li key={i}>
                 {firstDate}
-                {/* // TODO check firstDate on page */}
                 {lastDate && (
                   <>
                     &mdash;
                     {lastDate}
-                    {/* // TODO check lastDate on page */}
                   </>
                 )}
               </li>

--- a/common/views/components/VenueClosedPeriods/VenueClosedPeriods.tsx
+++ b/common/views/components/VenueClosedPeriods/VenueClosedPeriods.tsx
@@ -1,12 +1,9 @@
 import { FunctionComponent } from 'react';
-import { Venue } from '@weco/common/model/opening-hours';
 import {
-  backfillExceptionalVenueDays,
-  getExceptionalOpeningPeriods,
-  getExceptionalClosedDays,
-  groupConsecutiveDays,
-  convertJsonDateStringsToMoment,
+  getExceptionalVenueDays,
   parseOpeningTimes,
+  getVenueById,
+  groupConsecutiveDays,
 } from '../../../services/prismic/opening-times';
 import { formatDayDate } from '@weco/common/utils/format-date';
 import {
@@ -15,28 +12,22 @@ import {
 } from '@weco/common/services/prismic/hardcoded-id';
 import { usePrismicData } from '../../../server-data/Context';
 type Props = {
-  venue: Venue;
+  venueId: string;
 };
 
-const VenueClosedPeriods: FunctionComponent<Props> = ({ venue }) => {
+const VenueClosedPeriods: FunctionComponent<Props> = ({ venueId }) => {
   const prismicData = usePrismicData();
   const openingTimes = parseOpeningTimes(prismicData.collectionVenues);
-  const exceptionalPeriods = getExceptionalOpeningPeriods(openingTimes);
-  const backfilledExceptionalPeriods = backfillExceptionalVenueDays(
-    convertJsonDateStringsToMoment(venue),
-    exceptionalPeriods
-  );
-  const onlyClosedDays =
-    backfilledExceptionalPeriods &&
-    getExceptionalClosedDays(backfilledExceptionalPeriods);
-  const groupedConsectiveClosedDays = onlyClosedDays
-    ? groupConsecutiveDays(onlyClosedDays)
-    : [[]];
+  const venue = getVenueById(openingTimes, venueId);
+  const exceptionalVenueDays = venue ? getExceptionalVenueDays(venue) : [];
+  const onlyClosedDays = exceptionalVenueDays.filter(day => day.isClosed);
+  const groupedConsectiveClosedDays = groupConsecutiveDays(onlyClosedDays);
+
   return groupedConsectiveClosedDays[0] &&
     groupedConsectiveClosedDays[0].length > 0 ? (
     <div className="body-text">
-      <h2>{getNameFromCollectionVenue(venue.id)} closures</h2>
-      {venue.id === collectionVenueId.libraries.id && (
+      <h2>{getNameFromCollectionVenue(venueId)} closures</h2>
+      {venueId === collectionVenueId.libraries.id && (
         <p className="no-margin">
           Planning a research visit? Our library is closed over bank holiday
           weekends and between Christmas Eve and New Year{`'`}s Day:

--- a/common/views/components/VenueClosedPeriods/VenueClosedPeriods.tsx
+++ b/common/views/components/VenueClosedPeriods/VenueClosedPeriods.tsx
@@ -3,12 +3,12 @@ import {
   getExceptionalVenueDays,
   groupConsecutiveDays,
 } from '../../../services/prismic/opening-times';
-import { formatDayDate } from '../../../utils/format-date';
 import {
   collectionVenueId,
   getNameFromCollectionVenue,
 } from '../../../services/prismic/hardcoded-id';
 import { Venue } from '../../../model/opening-hours';
+import HTMLDayDate from '../HTMLDayDate/HTMLDayDate';
 
 type Props = {
   venue: Venue;
@@ -31,26 +31,20 @@ const VenueClosedPeriods: FunctionComponent<Props> = ({ venue }) => {
       )}
 
       <ul>
-        {/* TODO date range component */}
         {groupedConsectiveClosedDays.map((closedGroup, i) => {
-          const firstDate =
-            closedGroup[0].overrideDate &&
-            formatDayDate(closedGroup[0].overrideDate?.toDate());
+          const firstDate = closedGroup[0].overrideDate?.toDate();
           const lastDate =
-            closedGroup.length > 1 &&
-            closedGroup[closedGroup.length - 1].overrideDate
-              ? formatDayDate(
-                  closedGroup[closedGroup.length - 1].overrideDate!.toDate()
-                )
+            closedGroup.length > 1
+              ? closedGroup[closedGroup.length - 1].overrideDate?.toDate()
               : undefined;
           return (
             closedGroup.length > 0 && (
               <li key={i}>
-                {firstDate}
+                {firstDate && <HTMLDayDate date={firstDate} />}
                 {lastDate && (
                   <>
                     &mdash;
-                    {lastDate}
+                    <HTMLDayDate date={lastDate} />
                   </>
                 )}
               </li>

--- a/content/webapp/components/Body/Body.tsx
+++ b/content/webapp/components/Body/Body.tsx
@@ -422,7 +422,7 @@ const Body: FunctionComponent<Props> = ({
                   <>
                     {slice.value.showClosingTimes && (
                       <LayoutWidth width={minWidth}>
-                        <VenueClosedPeriods venue={slice.value.content} />
+                        <VenueClosedPeriods venueId={slice.value.content.id} />
                       </LayoutWidth>
                     )}
                     {!slice.value.showClosingTimes && (

--- a/content/webapp/components/Body/Body.tsx
+++ b/content/webapp/components/Body/Body.tsx
@@ -450,7 +450,7 @@ const Body: FunctionComponent<Props> = ({
                           }
                         >
                           <VenueHours
-                            venue={slice.value.content}
+                            venueId={slice.value.content.id}
                             weight={slice.weight || 'default'}
                           />
                         </Layout>

--- a/content/webapp/components/Body/Body.tsx
+++ b/content/webapp/components/Body/Body.tsx
@@ -422,7 +422,7 @@ const Body: FunctionComponent<Props> = ({
                   <>
                     {slice.value.showClosingTimes && (
                       <LayoutWidth width={minWidth}>
-                        <VenueClosedPeriods venueId={slice.value.content.id} />
+                        <VenueClosedPeriods venue={slice.value.content} />
                       </LayoutWidth>
                     )}
                     {!slice.value.showClosingTimes && (

--- a/content/webapp/components/VenueHours/VenueHours.tsx
+++ b/content/webapp/components/VenueHours/VenueHours.tsx
@@ -1,7 +1,6 @@
 import { FunctionComponent, Fragment } from 'react';
 import { formatDay, formatDayMonth } from '@weco/common/utils/format-date';
 import styled from 'styled-components';
-import { Venue } from '@weco/common/model/opening-hours';
 import { Weight } from '@weco/common/services/prismic/parsers';
 import { classNames, font } from '@weco/common/utils/classnames';
 import MoreLink from '@weco/common/views/components/MoreLink/MoreLink';
@@ -14,6 +13,7 @@ import {
   getUpcomingExceptionalPeriods,
   getExceptionalOpeningPeriods,
   convertJsonDateStringsToMoment,
+  getVenueById,
   parseOpeningTimes,
 } from '@weco/common/services/prismic/opening-times';
 import Space from '@weco/common/views/components/styled/Space';
@@ -71,18 +71,22 @@ const JauntyBox = styled(Space).attrs(() => ({
 const randomPx = () => `${Math.floor(Math.random() * 20)}px`;
 
 type Props = {
-  venue: Venue;
+  venueId: string;
   weight: Weight;
 };
 
-const VenueHours: FunctionComponent<Props> = ({ venue, weight }) => {
+const VenueHours: FunctionComponent<Props> = ({ venueId, weight }) => {
   const prismicData = usePrismicData();
   const openingTimes = parseOpeningTimes(prismicData.collectionVenues);
+  const venue = getVenueById(openingTimes, venueId);
+
   const exceptionalPeriods = getExceptionalOpeningPeriods(openingTimes);
-  const backfilledExceptionalPeriods = backfillExceptionalVenueDays(
-    convertJsonDateStringsToMoment(venue),
-    exceptionalPeriods
-  );
+  const backfilledExceptionalPeriods = venue
+    ? backfillExceptionalVenueDays(
+        convertJsonDateStringsToMoment(venue),
+        exceptionalPeriods
+      )
+    : [];
   const upcomingExceptionalPeriods =
     backfilledExceptionalPeriods &&
     getUpcomingExceptionalPeriods(backfilledExceptionalPeriods);
@@ -98,7 +102,7 @@ const VenueHours: FunctionComponent<Props> = ({ venue, weight }) => {
             </span>
           </Space>
           <VenueHoursImage v={{ size: 'm', properties: ['margin-bottom'] }}>
-            {venue.image && venue.image?.url && (
+            {venue?.image?.url && (
               <UiImage
                 contentUrl={venue.image.url}
                 width={1600}
@@ -121,7 +125,7 @@ const VenueHours: FunctionComponent<Props> = ({ venue, weight }) => {
             h2: true,
           })}
         >
-          {isFeatured && venue.name ? venue.name : 'Opening hours'}
+          {isFeatured && venue?.name ? venue.name : 'Opening hours'}
         </Space>
         <ul
           className={classNames({
@@ -129,7 +133,7 @@ const VenueHours: FunctionComponent<Props> = ({ venue, weight }) => {
             [font('hnr', 5)]: true,
           })}
         >
-          {venue.openingHours.regular.map(
+          {venue?.openingHours.regular.map(
             ({ dayOfWeek, opens, closes, isClosed }) => (
               <li key={dayOfWeek}>
                 {dayOfWeek} {isClosed ? 'Closed' : `${opens}—${closes}`}
@@ -204,8 +208,8 @@ const VenueHours: FunctionComponent<Props> = ({ venue, weight }) => {
         }}
         style={{ clear: 'both' }}
       >
-        {isFeatured && venue.linkText && venue.url && (
-          <MoreLink url={venue.url} name={venue.linkText} />
+        {isFeatured && venue?.linkText && venue?.url && (
+          <MoreLink url={venue?.url} name={venue?.linkText} />
         )}
       </Space>
     </>


### PR DESCRIPTION
References #7525
  
- Primarily fixes the VenueClosedPeriods component so it's doing what is intended.

The component should display all the upcoming exceptional dates on which a particular venue is closed, but it was also showing the exceptional dates for other venues, if it was also normally closed on that day too.

Before:
![b4](https://user-images.githubusercontent.com/6051896/148759396-0e2314fb-19bc-47df-a6fb-b5c9a1c2e00e.gif)

After:
![Screenshot 2022-01-06 at 23 42 59](https://user-images.githubusercontent.com/6051896/148759309-5c696a6b-ebba-498a-9a99-b34190f3f224.png)

Also adds a bit of typing and makes use of components we have elsewhere for displaying dates