### PR TITLE
Requesting pickup date

### DIFF
--- a/identity/webapp/pages/index.tsx
+++ b/identity/webapp/pages/index.tsx
@@ -40,6 +40,7 @@ import { font } from '@weco/common/utils/classnames';
 import { allowedRequests } from '@weco/common/values/requests';
 import { info2 } from '@weco/common/icons';
 import StackingTable from '@weco/common/views/components/StackingTable/StackingTable';
+import HTMLDate from '@weco/common/views/components/HTMLDate/HTMLDate';
 import AlignFont from '@weco/common/views/components/styled/AlignFont';
 import { useUser } from '@weco/common/views/components/UserProvider/UserProvider';
 import { getServerData } from '@weco/common/server-data';

--- a/identity/webapp/pages/index.tsx
+++ b/identity/webapp/pages/index.tsx
@@ -287,6 +287,7 @@ const AccountPage: NextPage<Props> = ({ user: auth0UserClaims }) => {
                             />
                           </ProgressBar>
                           <StackingTable
+                            maxWidth={enablePickUpDate ? 1180 : 980}
                             rows={[
                               [
                                 'Title',

--- a/identity/webapp/pages/index.tsx
+++ b/identity/webapp/pages/index.tsx
@@ -288,33 +288,47 @@ const AccountPage: NextPage<Props> = ({ user: auth0UserClaims }) => {
                           </ProgressBar>
                           <StackingTable
                             rows={[
-                              ['Title', 'Status', 'Pickup location'],
-                              ...requestedItems.results.map(result => [
-                                <>
-                                  <ItemTitle
-                                    as="a"
-                                    href={`/works/${result.workId}`}
-                                  >
-                                    {result.workTitle || 'Unknown title'}
-                                  </ItemTitle>
-                                  {result.item.title && (
-                                    <Space
-                                      v={{
-                                        size: 's',
-                                        properties: ['margin-top'],
-                                      }}
+                              [
+                                'Title',
+                                'Status',
+                                enablePickUpDate
+                                  ? 'Pickup date requested'
+                                  : null,
+                                'Pickup location',
+                              ].filter(Boolean),
+                              ...requestedItems.results.map(result =>
+                                [
+                                  <>
+                                    <ItemTitle
+                                      as="a"
+                                      href={`/works/${result.workId}`}
                                     >
-                                      <ItemTitle>{result.item.title}</ItemTitle>
-                                    </Space>
-                                  )}
-                                </>,
-                                <ItemStatus key={`${result.item.id}-status`}>
-                                  {result.status.label}
-                                </ItemStatus>,
-                                <ItemPickup key={`${result.item.id}-pickup`}>
-                                  {result.pickupLocation.label}
-                                </ItemPickup>,
-                              ]),
+                                      {result.workTitle || 'Unknown title'}
+                                    </ItemTitle>
+                                    {result.item.title && (
+                                      <Space
+                                        v={{
+                                          size: 's',
+                                          properties: ['margin-top'],
+                                        }}
+                                      >
+                                        <ItemTitle>
+                                          {result.item.title}
+                                        </ItemTitle>
+                                      </Space>
+                                    )}
+                                  </>,
+                                  <ItemStatus key={`${result.item.id}-status`}>
+                                    {result.status.label}
+                                  </ItemStatus>,
+                                  enablePickUpDate ? (
+                                    <HTMLDate date={new Date()} /> // TODO need to pass in the actual date once it's available on resuilt
+                                  ) : null,
+                                  <ItemPickup key={`${result.item.id}-pickup`}>
+                                    {result.pickupLocation.label}
+                                  </ItemPickup>,
+                                ].filter(Boolean)
+                              ),
                             ]}
                           />
                           <Space

--- a/identity/webapp/pages/index.tsx
+++ b/identity/webapp/pages/index.tsx
@@ -52,6 +52,7 @@ import {
   auth0UserProfileToUserInfo,
 } from '@weco/common/model/user';
 import { Claims } from '@auth0/nextjs-auth0';
+import { useToggles } from '@weco/common/server-data/Context';
 
 type DetailProps = {
   label: string;
@@ -154,6 +155,7 @@ const AccountPage: NextPage<Props> = ({ user: auth0UserClaims }) => {
     state: requestedItemsState,
     fetchRequests,
   } = useRequestedItems();
+  const { enablePickUpDate } = useToggles();
   const { user: contextUser } = useUser();
   const [isEmailUpdated, setIsEmailUpdated] = useState(false);
   const [isPasswordUpdated, setIsPasswordUpdated] = useState(false);


### PR DESCRIPTION
References #7459

Adds a column to the requests table, on the account page, for displaying the 'Pickup request date'. At the moment that data isn't available, so just uses today's date as a placeholder. This is behind the enablePickUpDate toggle.

![Screenshot 2022-01-11 at 12 13 03](https://user-images.githubusercontent.com/6051896/148953079-d793722c-fb43-426f-b422-8af593a8f25b.png)

![Screenshot 2022-01-11 at 12 13 13](https://user-images.githubusercontent.com/6051896/148953087-89268c78-f87c-4405-85f3-7f3b178e6c45.png)

[Zeplin design for reference](https://app.zeplin.io/project/5aab926b4b6efde01259e959/screen/618bd8950b7cb4aac42090b4)

