### PR TITLE
Daypicker closed days

### DIFF
--- a/catalogue/webapp/components/RequestingDayPicker/RequestingDayPicker.tsx
+++ b/catalogue/webapp/components/RequestingDayPicker/RequestingDayPicker.tsx
@@ -253,9 +253,9 @@ const RequestingDayPicker: FC<Props> = ({
     regularClosedDays
   );
 
-  // there should be a 2 week window in which to select a date
-  const lastAvailableDate = nextAvailableDate.clone().add(13, 'days');
-  // we want to know if the library is closed on any days during the selection window
+  // There should be a 2 week window in which to select a date
+  const lastAvailableDate = nextAvailableDate?.clone().add(13, 'days') || null;
+  // We want to know if the library is closed on any days during the selection window
   // so that we can extend the lastAvailableDate to take these into account
   const extendedLastAvailableDate = extendEndDate({
     startDate: nextAvailableDate,
@@ -280,8 +280,8 @@ const RequestingDayPicker: FC<Props> = ({
     );
   };
 
-  const fromMonth = nextAvailableDate.toDate();
-  const toMonth = extendedLastAvailableDate.toDate();
+  const fromMonth = nextAvailableDate?.toDate() ?? new Date();
+  const toMonth = extendedLastAvailableDate?.toDate() ?? new Date();
 
   const [isPrevMonthDisabled, setIsPrevMonthDisabled] = useState(true);
   const [isNextMonthDisabled, setIsNextMonthDisabled] = useState(false);
@@ -297,8 +297,8 @@ const RequestingDayPicker: FC<Props> = ({
 
   const disabledDays = [
     {
-      before: nextAvailableDate.toDate(),
-      after: extendedLastAvailableDate.toDate(),
+      before: nextAvailableDate?.toDate() ?? new Date(),
+      after: extendedLastAvailableDate?.toDate() ?? new Date(),
     },
     { daysOfWeek: regularClosedDays },
     ...exceptionalClosedDates.map(moment => moment.toDate()),

--- a/catalogue/webapp/test/utils/dates.test.ts
+++ b/catalogue/webapp/test/utils/dates.test.ts
@@ -159,9 +159,17 @@ describe('determineNextAvailableDate', () => {
     expect(result.toDate()).toEqual(london('2021-12-11 11:00').toDate());
   });
 
-  it('returns the following Monday rather than a Sunday', () => {
+  it('returns the following Monday rather than a Sunday, if the Sunday is the only closed day', () => {
     const result = determineNextAvailableDate(london('2021-12-10 10:30'), [0]);
     expect(result.toDate()).toEqual(london('2021-12-13 10:30').toDate());
+  });
+
+  it("doesn't return a date if there are no regular days that are open", () => {
+    const result = determineNextAvailableDate(
+      london(new Date()),
+      [0, 1, 2, 3, 4, 5, 6]
+    );
+    expect(result).toEqual(null);
   });
 });
 

--- a/catalogue/webapp/test/utils/dates.test.ts
+++ b/catalogue/webapp/test/utils/dates.test.ts
@@ -6,6 +6,7 @@ import {
   groupExceptionalClosedDates,
   extendEndDate,
   findClosedDays,
+  findNextRegularOpenDay,
 } from '../../utils/dates';
 import { OverrideType } from '@weco/common/model/opening-hours';
 
@@ -120,6 +121,30 @@ describe('findClosedDays', () => {
         isClosed: true,
       },
     ]);
+  });
+});
+
+describe('findNextRegularOpenDay: finds the earliest date on which the venue is normally open', () => {
+  it('returns the same date provided if it occurs on one of the regular open days', () => {
+    const result = findNextRegularOpenDay(
+      london('2022-01-15'), // Saturday
+      [0, 1, 2] // Sunday, Monday, Tuesday
+    );
+    expect(result.toDate()).toEqual(london('2022-01-15').toDate()); // Saturday
+  });
+  it('returns the date of the next regular open day, if the date provided is a regular closed day', () => {
+    const result = findNextRegularOpenDay(
+      london('2022-01-16'), // Sunday
+      [0, 1, 2] // Sunday, Monday, Tuesday
+    );
+    expect(result.toDate()).toEqual(london('2022-01-19').toDate()); // Wednesday
+  });
+  it.only("doesn't return a date if there are no regular days that are open", () => {
+    const result = findNextRegularOpenDay(
+      london('2022-01-16'), // Sunday
+      [0, 1, 2, 3, 4, 5, 6]
+    );
+    expect(result).toEqual(null);
   });
 });
 

--- a/catalogue/webapp/test/utils/dates.test.ts
+++ b/catalogue/webapp/test/utils/dates.test.ts
@@ -97,7 +97,9 @@ const exceptionalOpeningHours = [
 describe('findClosedDays', () => {
   it('filters out any non closed days from regular opening hours', () => {
     const result = findClosedDays(regularOpeningHours);
-    expect(result).toEqual([{ dayOfWeek: 'Sunday' }]);
+    expect(result).toEqual([
+      { dayOfWeek: 'Sunday', opens: '00:00', closes: '00:00', isClosed: true },
+    ]);
   });
 
   it('filters out any non closed days from exceptional opening hours', () => {
@@ -106,14 +108,16 @@ describe('findClosedDays', () => {
       {
         overrideDate: london('2021-12-25T00:00:00.000Z'),
         overrideType: 'Christmas and New Year',
-        opens: undefined,
-        closes: undefined,
+        opens: '00:00',
+        closes: '00:00',
+        isClosed: true,
       },
       {
         overrideDate: london('2021-12-27T00:00:00.000Z'),
         overrideType: 'Christmas and New Year',
-        opens: undefined,
-        closes: undefined,
+        opens: '00:00',
+        closes: '00:00',
+        isClosed: true,
       },
     ]);
   });

--- a/catalogue/webapp/test/utils/dates.test.ts
+++ b/catalogue/webapp/test/utils/dates.test.ts
@@ -139,7 +139,7 @@ describe('findNextRegularOpenDay: finds the earliest date on which the venue is 
     );
     expect(result.toDate()).toEqual(london('2022-01-19').toDate()); // Wednesday
   });
-  it.only("doesn't return a date if there are no regular days that are open", () => {
+  it("doesn't return a date if there are no regular days that are open", () => {
     const result = findNextRegularOpenDay(
       london('2022-01-16'), // Sunday
       [0, 1, 2, 3, 4, 5, 6]

--- a/catalogue/webapp/test/utils/dates.test.ts
+++ b/catalogue/webapp/test/utils/dates.test.ts
@@ -300,4 +300,26 @@ describe('extendEndDate: Determines the end date to use, so that there are alway
 
     expect(result.toDate()).toEqual(london(new Date('2019-12-31')).toDate());
   });
+
+  it("doesn't return a date if no start date is provided", () => {
+    const result = extendEndDate({
+      startDate: null,
+      endDate: london(new Date('2020-01-10')),
+      exceptionalClosedDates: exceptionalClosedDates,
+      regularClosedDays: [0],
+    });
+
+    expect(result).toEqual(null);
+  });
+
+  it("doesn't return a date if no end date is provided", () => {
+    const result = extendEndDate({
+      startDate: london(new Date('2019-12-24')),
+      endDate: null,
+      exceptionalClosedDates: exceptionalClosedDates,
+      regularClosedDays: [0],
+    });
+
+    expect(result).toEqual(null);
+  });
 });

--- a/catalogue/webapp/utils/dates.ts
+++ b/catalogue/webapp/utils/dates.ts
@@ -7,7 +7,7 @@ import {
 export function findClosedDays(
   days: (OpeningHoursDay | ExceptionalOpeningHoursDay)[]
 ): (OpeningHoursDay | ExceptionalOpeningHoursDay)[] {
-  return days.filter(day => !day.opens);
+  return days.filter(day => day.isClosed);
 }
 
 type DayNumber = 0 | 1 | 2 | 3 | 4 | 5 | 6;


### PR DESCRIPTION
## Who is this for?
People who want the day picker to make days on which the venue is closed, unavailable for selection

- uses the isClosed property introduced in #7532 to determine closed days
- adds tests for the possibility that the venue is closed every day
- updates functions to account for the fact that the venue may be closed every day
