### PR TITLE
Don't use buildingClosure toggle

### DIFF
--- a/content/webapp/pages/whats-on.tsx
+++ b/content/webapp/pages/whats-on.tsx
@@ -59,7 +59,7 @@ import { GetServerSideProps } from 'next';
 import { AppErrorProps } from '@weco/common/views/pages/_app';
 import { removeUndefinedProps } from '@weco/common/utils/json';
 import { getServerData } from '@weco/common/server-data';
-import { usePrismicData, useToggles } from '@weco/common/server-data/Context';
+import { usePrismicData } from '@weco/common/server-data/Context';
 import {
   exhibitionLd,
   eventLd,
@@ -132,29 +132,29 @@ function getWeekendToDate(today) {
   }
 }
 
-const ClosedMessage = () => (
-  <>
-    <Space
-      v={{
-        size: 'm',
-        properties: ['margin-bottom'],
-      }}
-      as="p"
-      className={classNames({
-        [font('wb', 2)]: true,
-      })}
-    >
-      Our exhibitions are closed today, but our <a href={cafePromo.url}>café</a>{' '}
-      and <a href={shopPromo.url}>shop</a> are open for your visit.
-    </Space>
-    <Space
-      v={{
-        size: 'l',
-        properties: ['margin-top', 'margin-bottom'],
-      }}
-    ></Space>
-  </>
-);
+// const ClosedMessage = () => (
+//   <>
+//     <Space
+//       v={{
+//         size: 'm',
+//         properties: ['margin-bottom'],
+//       }}
+//       as="p"
+//       className={classNames({
+//         [font('wb', 2)]: true,
+//       })}
+//     >
+//       Our exhibitions are closed today, but our <a href={cafePromo.url}>café</a>{' '}
+//       and <a href={shopPromo.url}>shop</a> are open for your visit.
+//     </Space>
+//     <Space
+//       v={{
+//         size: 'l',
+//         properties: ['margin-top', 'margin-bottom'],
+//       }}
+//     ></Space>
+//   </>
+// );
 
 type DateRangeProps = {
   dateRange: (Date | Moment)[];
@@ -391,7 +391,6 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   };
 
 const WhatsOnPage: FunctionComponent<Props> = props => {
-  const { buildingClosure } = useToggles();
   const { period, dateRange, tryTheseTooPromos, eatShopPromos, featuredText } =
     props;
 
@@ -453,9 +452,10 @@ const WhatsOnPage: FunctionComponent<Props> = props => {
         />
         <Layout12>
           <DateRange dateRange={dateRange} period={period} />
-          {!buildingClosure &&
-            period === 'today' &&
-            todaysOpeningHours?.isClosed && <ClosedMessage />}
+          {/* TODO put back when building, shop and cafe are open normally */}
+          {/* {period === 'today' && todaysOpeningHours?.isClosed && (
+            <ClosedMessage />
+          )} */}
         </Layout12>
         <Space v={{ size: 'l', properties: ['margin-top'] }}>
           {period === 'current-and-coming-up' && (


### PR DESCRIPTION
## Background
Pre-covid times, /whats-on/today used to display a message at the top of the page on a Monday (when the galleries are ordinarily closed), highlighting the fact the cafe and shop were still open.

This message has been commented out since the start of the lockdowns.

While I was refactoring opening times (#7532), I wrapped the code responsible in the buildingClosure toggle.

I thought this made sense at the time, but it doesn't for 2 reasons:

1. We use this toggle to determine whether to display the requesting button on works, and we want to turn this on again before the building is open. (so maybe want to call the toggle something else, but that's another story)
2. Even if the building is open, the shop and cafe may not necessarily be (at least this has happened before), so we may want to revisit what the message says.

Long story short, I've commented the code our for now instead of using the toggle.