### PR TITLE
remove css import

### DIFF
--- a/catalogue/webapp/components/RequestingDayPicker/RequestingDayPicker.tsx
+++ b/catalogue/webapp/components/RequestingDayPicker/RequestingDayPicker.tsx
@@ -6,7 +6,7 @@ import {
   ExceptionalOpeningHoursDay,
 } from '@weco/common/model/opening-hours';
 import { london } from '@weco/common/utils/format-date';
-import 'react-day-picker/lib/style.css';
+// import 'react-day-picker/lib/style.css';
 import LocaleUtils from 'react-day-picker/moment';
 import styled from 'styled-components';
 import AlignFont from '@weco/common/views/components/styled/AlignFont';


### PR DESCRIPTION
Want to see if this is causing the failing tests we’re seeing due to work pages not loading

It'll mess with the daypicker calendar styles, but that is a work in progress behind a toggle anyway.

If it is the cause it'll unblock us from deploying
![Screenshot 2022-01-13 at 16 17 24](https://user-images.githubusercontent.com/6051896/149368092-2f807228-1e1b-44dd-873f-bf94dba37a7d.png)

