### PR TITLE
Use the new fetch/transform methods for articles on two more pages

### DIFF
--- a/content/webapp/pages/homepage.tsx
+++ b/content/webapp/pages/homepage.tsx
@@ -1,7 +1,6 @@
 import { FC } from 'react';
 import styled from 'styled-components';
 import { classNames, font } from '@weco/common/utils/classnames';
-import { getArticles } from '@weco/common/services/prismic/articles';
 import { getPage } from '@weco/common/services/prismic/pages';
 import SectionHeader from '@weco/common/views/components/SectionHeader/SectionHeader';
 import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
@@ -31,6 +30,10 @@ import { getServerData } from '@weco/common/server-data';
 import ExhibitionsAndEvents from '../components/ExhibitionsAndEvents/ExhibitionsAndEvents';
 import CardGrid from '../components/CardGrid/CardGrid';
 import { articleLd } from '../services/prismic/transformers/json-ld';
+import { createClient } from 'services/prismic/fetch';
+import { fetchArticles } from 'services/prismic/fetch/articles';
+import { transformQuery } from 'services/prismic/transformers/paginated-results';
+import { transformArticle } from 'services/prismic/transformers/articles';
 
 const PageHeading = styled(Space).attrs({
   as: 'h1',
@@ -67,11 +70,11 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
     const serverData = await getServerData(context);
     const { id, memoizedPrismic } = context.query;
-    const articlesPromise = getArticles(
-      context.req,
-      { pageSize: 4 },
-      memoizedPrismic
-    );
+
+    const client = createClient(context);
+
+    const articlesQueryPromise = fetchArticles(client, { pageSize: 4 });
+
     const exhibitionsPromise = getExhibitions(
       context.req,
       {
@@ -88,12 +91,14 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       memoizedPrismic
     );
     const pagePromise = getPage(context.req, id, memoizedPrismic);
-    const [exhibitions, events, articles, page] = await Promise.all([
+    const [exhibitions, events, articlesQuery, page] = await Promise.all([
       exhibitionsPromise,
       eventsPromise,
-      articlesPromise,
+      articlesQueryPromise,
       pagePromise,
     ]);
+
+    const articles = transformQuery(articlesQuery, transformArticle);
 
     if (events && exhibitions && articles && page) {
       return {

--- a/content/webapp/pages/stories.tsx
+++ b/content/webapp/pages/stories.tsx
@@ -1,5 +1,4 @@
 import { FC } from 'react';
-import { getArticles } from '@weco/common/services/prismic/articles';
 import { getArticleSeries } from '@weco/common/services/prismic/article-series';
 import { convertImageUri } from '@weco/common/utils/convert-image-uri';
 import { classNames, grid } from '@weco/common/utils/classnames';
@@ -30,6 +29,10 @@ import CardGrid from '../components/CardGrid/CardGrid';
 import { FeaturedCardArticle } from '../components/FeaturedCard/FeaturedCard';
 import { ArticlePrismicDocument } from '../services/prismic/types/articles';
 import { articleLd } from '../services/prismic/transformers/json-ld';
+import { createClient } from 'services/prismic/fetch';
+import { fetchArticles } from 'services/prismic/fetch/articles';
+import { transformQuery } from 'services/prismic/transformers/paginated-results';
+import { transformArticle } from 'services/prismic/transformers/articles';
 
 type Props = {
   articles: Article[];
@@ -81,8 +84,12 @@ const pageDescription =
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
     const serverData = await getServerData(context);
-    const { page = 1, memoizedPrismic } = context.query;
-    const articlesPromise = getArticles(context.req, { page }, memoizedPrismic);
+    const { memoizedPrismic } = context.query;
+
+    const client = createClient(context);
+
+    const articlesQueryPromise = fetchArticles(client);
+
     // TODO: we're hardcoding a series id here in order to display whichever series
     // the content team has chosen to be featured on the stories page. This would
     // ideally come from Prismic to take devs/deployments out of the loop.
@@ -98,11 +105,12 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       memoizedPrismic
     );
 
-    const [articles, seriesAndArticles, storiesPage] = await Promise.all([
-      articlesPromise,
+    const [articlesQuery, seriesAndArticles, storiesPage] = await Promise.all([
+      articlesQueryPromise,
       seriesPromise,
       storiesPagePromise,
     ]);
+    const articles = transformQuery(articlesQuery, transformArticle);
     const series = seriesAndArticles && seriesAndArticles.series;
     const featuredText = storiesPage && getPageFeaturedText(storiesPage);
 


### PR DESCRIPTION
Chipping away at https://github.com/wellcomecollection/wellcomecollection.org/issues/7363

I can't do any more right now because query parameters get a bit complicated, and that's a separate patch. (More explanation below.)