### PR TITLE
Daypicker styling

### DIFF
--- a/catalogue/webapp/components/RequestingDayPicker/RequestingDayPicker.tsx
+++ b/catalogue/webapp/components/RequestingDayPicker/RequestingDayPicker.tsx
@@ -40,28 +40,13 @@ const DayPickerWrapper = styled.div<DayPickerWrapperProps>`
   }
   .DayPicker-wrapper {
     position: relative;
-    -webkit-flex-direction: row;
-    -moz-box-orient: horizontal;
-    -moz-box-direction: normal;
-    -ms-flex-direction: row;
     flex-direction: row;
     padding-bottom: 1em;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
     user-select: none;
   }
   .DayPicker-Months {
-    display: -webkit-flex;
-    display: -moz-box;
-    display: -ms-flexbox;
     display: flex;
-    -webkit-flex-wrap: wrap;
-    -ms-flex-wrap: wrap;
     flex-wrap: wrap;
-    -webkit-justify-content: center;
-    -moz-box-pack: center;
-    -ms-flex-pack: center;
     justify-content: center;
   }
   .DayPicker-Month {
@@ -69,9 +54,6 @@ const DayPickerWrapper = styled.div<DayPickerWrapperProps>`
     margin: 1em 1em 0;
     border-spacing: 0;
     border-collapse: collapse;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
     user-select: none;
   }
   .DayPicker-NavButton {
@@ -164,7 +146,6 @@ const DayPickerWrapper = styled.div<DayPickerWrapperProps>`
     border: none;
     background-color: transparent;
     background-image: none;
-    -webkit-box-shadow: none;
     box-shadow: none;
     color: #4a90e2;
     font-size: 0.875em;
@@ -211,7 +192,6 @@ const DayPickerWrapper = styled.div<DayPickerWrapperProps>`
     left: 0;
     z-index: 1;
     background: #fff;
-    -webkit-box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);
     box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);
   }
 

--- a/catalogue/webapp/components/RequestingDayPicker/RequestingDayPicker.tsx
+++ b/catalogue/webapp/components/RequestingDayPicker/RequestingDayPicker.tsx
@@ -6,7 +6,6 @@ import {
   ExceptionalOpeningHoursDay,
 } from '@weco/common/model/opening-hours';
 import { london } from '@weco/common/utils/format-date';
-// import 'react-day-picker/lib/style.css';
 import LocaleUtils from 'react-day-picker/moment';
 import styled from 'styled-components';
 import AlignFont from '@weco/common/views/components/styled/AlignFont';
@@ -35,6 +34,187 @@ type DayPickerWrapperProps = {
 };
 
 const DayPickerWrapper = styled.div<DayPickerWrapperProps>`
+  .DayPicker {
+    display: inline-block;
+    font-size: 1rem;
+  }
+  .DayPicker-wrapper {
+    position: relative;
+    -webkit-flex-direction: row;
+    -moz-box-orient: horizontal;
+    -moz-box-direction: normal;
+    -ms-flex-direction: row;
+    flex-direction: row;
+    padding-bottom: 1em;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+  }
+  .DayPicker-Months {
+    display: -webkit-flex;
+    display: -moz-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-wrap: wrap;
+    -ms-flex-wrap: wrap;
+    flex-wrap: wrap;
+    -webkit-justify-content: center;
+    -moz-box-pack: center;
+    -ms-flex-pack: center;
+    justify-content: center;
+  }
+  .DayPicker-Month {
+    display: table;
+    margin: 1em 1em 0;
+    border-spacing: 0;
+    border-collapse: collapse;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+  }
+  .DayPicker-NavButton {
+    position: absolute;
+    top: 1em;
+    right: 1.5em;
+    left: auto;
+    display: inline-block;
+    margin-top: 2px;
+    width: 1.25em;
+    height: 1.25em;
+    background-position: 50%;
+    background-size: 50%;
+    background-repeat: no-repeat;
+    color: #8b9898;
+    cursor: pointer;
+  }
+  .DayPicker-NavButton:hover {
+    opacity: 0.8;
+  }
+  .DayPicker-NavButton--prev {
+    margin-right: 1.5em;
+    background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACQAAAAwCAYAAAB5R9gVAAAABGdBTUEAALGPC/xhBQAAAVVJREFUWAnN2G0KgjAYwPHpGfRkaZeqvgQaK+hY3SUHrk1YzNLay/OiEFp92I+/Mp2F2Mh2lLISWnflFjzH263RQjzMZ19wgs73ez0o1WmtW+dgA01VxrE3p6l2GLsnBy1VYQOtVSEH/atCCgqpQgKKqYIOiq2CBkqtggLKqQIKgqgCBjpJ2Y5CdJ+zrT9A7HHSTA1dxUdHgzCqJIEwq0SDsKsEg6iqBIEoq/wEcVRZBXFV+QJxV5mBtlDFB5VjYTaGZ2sf4R9PM7U9ZU+lLuaetPP/5Die3ToO1+u+MKtHs06qODB2zBnI/jBd4MPQm1VkY79Tb18gB+C62FdBFsZR6yeIo1YQiLJWMIiqVjQIu1YSCLNWFgijVjYIuhYYCKoWKAiiFgoopxYaKLUWOii2FgkophYp6F3r42W5A9s9OcgNvva8xQaysKXlFytoqdYmQH6tF3toSUo0INq9AAAAAElFTkSuQmCC');
+  }
+  .DayPicker-NavButton--next {
+    background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACQAAAAwCAYAAAB5R9gVAAAABGdBTUEAALGPC/xhBQAAAXRJREFUWAnN119ugjAcwPHWzJ1gnmxzB/BBE0n24m4xfNkTaOL7wOtsl3AXMMb+Vjaa1BG00N8fSEibPpAP3xAKKs2yjzTPH9RAjhEo9WzPr/Vm8zgE0+gXATAxxuxtqeJ9t5tIwv5AtQAApsfT6TPdbp+kUBcgVwvO51KqVhMkXKsVJFXrOkigVhCIs1Y4iKlWZxB1rX4gwlpRIIpa8SDkWmggrFq4IIRaJKCYWnSgnrXIQV1r8YD+1Vrn+bReagysIFfLABRt31v8oBu1xEBttfRbltmfjgEcWh9snUS2kNdBK6WN1vrOWxObWsz+fjxevsxmB1GQDfINWiev83nhaoiB/CoOU438oPrhXS0WpQ9xc1ZQWxWHqUYe0I0qrKCQKjygDlXIQV2r0IF6ViEBxVTBBSFUQQNhVYkHIVeJAtkNsbQ7c1LtzP6FsObhb2rCKv7NBIGoq4SDmKoEgTirXAcJVGkFSVVpgoSrXICGUMUH/QBZNSUy5XWUhwAAAABJRU5ErkJggg==');
+  }
+  .DayPicker-NavButton--interactionDisabled {
+    display: none;
+  }
+  .DayPicker-Caption {
+    display: table-caption;
+    margin-bottom: 0.5em;
+    padding: 0 0.5em;
+    text-align: left;
+  }
+  .DayPicker-Caption > div {
+    font-weight: 500;
+    font-size: 1.15em;
+  }
+  .DayPicker-Weekdays {
+    display: table-header-group;
+    margin-top: 1em;
+  }
+  .DayPicker-WeekdaysRow {
+    display: table-row;
+  }
+  .DayPicker-Weekday {
+    display: table-cell;
+    padding: 0.5em;
+    color: #8b9898;
+    text-align: center;
+    font-size: 0.875em;
+  }
+  .DayPicker-Weekday abbr[title] {
+    border-bottom: none;
+    text-decoration: none;
+  }
+  .DayPicker-Body {
+    display: table-row-group;
+  }
+  .DayPicker-Week {
+    display: table-row;
+  }
+  .DayPicker-Day {
+    border-radius: 50%;
+    text-align: center;
+  }
+  .DayPicker-Day,
+  .DayPicker-WeekNumber {
+    display: table-cell;
+    padding: 0.5em;
+    vertical-align: middle;
+    cursor: pointer;
+  }
+  .DayPicker-WeekNumber {
+    min-width: 1em;
+    border-right: 1px solid #eaecec;
+    color: #8b9898;
+    text-align: right;
+    font-size: 0.75em;
+  }
+  .DayPicker--interactionDisabled .DayPicker-Day {
+    cursor: default;
+  }
+  .DayPicker-Footer {
+    padding-top: 0.5em;
+  }
+  .DayPicker-TodayButton {
+    border: none;
+    background-color: transparent;
+    background-image: none;
+    -webkit-box-shadow: none;
+    box-shadow: none;
+    color: #4a90e2;
+    font-size: 0.875em;
+    cursor: pointer;
+  }
+  .DayPicker-Day--today {
+    color: #d0021b;
+    font-weight: 700;
+  }
+  .DayPicker-Day--outside {
+    color: #8b9898;
+    cursor: default;
+  }
+  .DayPicker-Day--disabled {
+    color: #dce0e0;
+    cursor: default;
+  }
+  .DayPicker-Day--sunday {
+    background-color: #f7f8f8;
+  }
+  .DayPicker-Day--sunday:not(.DayPicker-Day--today) {
+    color: #dce0e0;
+  }
+  .DayPicker-Day--selected:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside) {
+    position: relative;
+    background-color: #4a90e2;
+    color: #f0f8ff;
+  }
+  .DayPicker-Day--selected:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside):hover {
+    background-color: #51a0fa;
+  }
+  .DayPicker:not(.DayPicker--interactionDisabled)
+    .DayPicker-Day:not(.DayPicker-Day--disabled):not(.DayPicker-Day--selected):not(.DayPicker-Day--outside):hover {
+    background-color: #f0f8ff;
+  }
+  .DayPickerInput {
+    display: inline-block;
+  }
+  .DayPickerInput-OverlayWrapper {
+    position: relative;
+  }
+  .DayPickerInput-Overlay {
+    position: absolute;
+    left: 0;
+    z-index: 1;
+    background: #fff;
+    -webkit-box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);
+  }
+
   .DayPicker-Day {
     line-height: 1;
   }


### PR DESCRIPTION
We remove the styles that we were importing for the Daypicker in #7559, as it was causing problems.

Since we don't import styles anywhere else, and to reduce http requests, I think it makes sense to add the previously imported styles to a styled component.

Before:
![Screenshot 2022-01-13 at 16 17 24](https://user-images.githubusercontent.com/6051896/149752550-80c6feac-f844-4f76-a057-e87c297b4483.png)

After:
![Screenshot 2022-01-17 at 10 21 25](https://user-images.githubusercontent.com/6051896/149752568-ad042bdc-a03d-411c-8476-bac9273bed8d.png)
