### PR TITLE
Use a shared function for getting the page from query params

### DIFF
--- a/content/webapp/pages/articles.tsx
+++ b/content/webapp/pages/articles.tsx
@@ -7,10 +7,11 @@ import LayoutPaginatedResults from '../components/LayoutPaginatedResults/LayoutP
 import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
 import { FC } from 'react';
 import { GetServerSideProps } from 'next';
-import { AppErrorProps } from '@weco/common/views/pages/_app';
+import { appError, AppErrorProps } from '@weco/common/views/pages/_app';
 import { removeUndefinedProps } from '@weco/common/utils/json';
 import { getServerData } from '@weco/common/server-data';
 import { articleLd } from '../services/prismic/transformers/json-ld';
+import { getPage } from '../utils/query-params';
 
 type Props = {
   articles: PaginatedResults<Article>;
@@ -22,7 +23,13 @@ const pageDescription =
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
     const serverData = await getServerData(context);
-    const { page = 1, memoizedPrismic } = context.query;
+
+    const page = getPage(context.query);
+    if (typeof page !== 'number') {
+      return appError(context, 400, page.message);
+    }
+
+    const { memoizedPrismic } = context.query;
     const articles = await getArticles(context.req, { page }, memoizedPrismic);
 
     return {

--- a/content/webapp/pages/exhibitions.tsx
+++ b/content/webapp/pages/exhibitions.tsx
@@ -8,10 +8,11 @@ import type { Period } from '@weco/common/model/periods';
 import type { PaginatedResults } from '@weco/common/services/prismic/types';
 import { convertImageUri } from '@weco/common/utils/convert-image-uri';
 import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
-import { AppErrorProps } from '@weco/common/views/pages/_app';
+import { appError, AppErrorProps } from '@weco/common/views/pages/_app';
 import { removeUndefinedProps } from '@weco/common/utils/json';
 import { getServerData } from '@weco/common/server-data';
 import { exhibitionLd } from '../services/prismic/transformers/json-ld';
+import { getPage } from '../utils/query-params';
 
 type Props = {
   exhibitions: PaginatedResults<UiExhibition>;
@@ -26,7 +27,12 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
     const serverData = await getServerData(context);
 
-    const { page = 1, period, memoizedPrismic } = context.query;
+    const page = getPage(context.query);
+    if (typeof page !== 'number') {
+      return appError(context, 400, page.message);
+    }
+
+    const { period, memoizedPrismic } = context.query;
     const exhibitions = await getExhibitions(
       context.req,
       { page, period },

--- a/content/webapp/test/utils/query-params.test.ts
+++ b/content/webapp/test/utils/query-params.test.ts
@@ -1,0 +1,40 @@
+import { getPage } from "../../pages/utils";
+
+it('returns 1 if no page parameter is supplied', () => {
+  expect(getPage({})).toEqual(1);
+});
+
+it('returns the page parameter as a number, if passed', () => {
+  const query = {
+    'page': '3'
+  };
+
+  expect(getPage(query)).toEqual(3);
+});
+
+it('returns an error if the page parameter is repeated', () => {
+  const query = {
+    'page': ['3', '4']
+  };
+
+  const expectedError = {
+    name: 'Bad Request',
+    message: 'Only supply a single "page" in the query parameter'
+  };
+
+  expect(getPage(query)).toEqual(expectedError);
+});
+
+it("returns an error if the page parameter isn't a number", () => {
+  const query = {
+    'page': 'x'
+  };
+
+  const expectedError = {
+    name: 'Bad Request',
+    message: '"x" is not a number'
+  };
+
+  expect(getPage(query)).toEqual(expectedError);
+});
+

--- a/content/webapp/utils/query-params.ts
+++ b/content/webapp/utils/query-params.ts
@@ -1,0 +1,44 @@
+import { isString, isUndefined } from '@weco/common/utils/array';
+import { ParsedUrlQuery } from 'querystring'
+
+/** Extracts the page from the query parameter.
+  * 
+  * We prefer this to extracting the 'page' directly from the query parameter
+  * because query parameters are of type `string | string[] | undefined`, whereas
+  * downstream APIs tend to want a `number` for page values.
+  * 
+  * If this function returns an Error, it should be returned to the user as a
+  * 400 Bad Request with the supplied message.
+  * 
+  */
+export function getPage(q: ParsedUrlQuery): number | Error {
+  const { page } = q;
+
+  // If the user doesn't supply a page parameter, return 1
+  if (isUndefined(page)) {
+    return 1;
+  }
+
+  // If the user supplies multiple page parameters, we can't do anything
+  // sensible.
+  if (!isString(page)) {
+    return {
+      name: 'Bad Request',
+      message: 'Only supply a single "page" in the query parameter'
+    }
+  }
+
+  // If the user supplies something that isn't an int, we can't do anything sensible.
+  const parsedPage = parseInt(page, 10);
+  if (isNaN(parsedPage)) {
+    return {
+      name: 'Bad Request',
+      
+      // The use of JSON.stringify() here is to wrap the value in quotes, so it's
+      // clear what's part of the error message and what's the user-supplied value.
+      message: `${JSON.stringify(page)} is not a number`
+    };
+  }
+
+  return parsedPage;
+}


### PR DESCRIPTION
This ensures the right types as we finish converting the codebase to TypeScript, and gets us consistent behaviour on all pages that use pagination. It's a follow-up to my comment on https://github.com/wellcomecollection/wellcomecollection.org/pull/7564#discussion_r785761985