### PR TITLE
Don't add story label to unpublished cards

### DIFF
--- a/content/webapp/components/SearchResults/SearchResults.tsx
+++ b/content/webapp/components/SearchResults/SearchResults.tsx
@@ -117,7 +117,7 @@ const SearchResults: FunctionComponent<Props> = ({
             title={item.title || ''}
             partNumber={item.partNumber}
             color={item.color}
-            primaryLabels={[{ text: 'Story' }]}
+            primaryLabels={[]}
             secondaryLabels={[]}
             description={`Available ${formatDate(item.publishDate)}`}
             Image={<ImagePlaceholder color={item.color} />}

--- a/content/webapp/components/SearchResults/SearchResults.tsx
+++ b/content/webapp/components/SearchResults/SearchResults.tsx
@@ -117,7 +117,12 @@ const SearchResults: FunctionComponent<Props> = ({
             title={item.title || ''}
             partNumber={item.partNumber}
             color={item.color}
-            primaryLabels={[]}
+            primaryLabels={
+              /* We don't show a label on items that haven't been published yet, because
+               * we don't know whether they're a story, comic, etc.
+               * See https://github.com/wellcomecollection/wellcomecollection.org/pull/7568 */
+              []
+            }
             secondaryLabels={[]}
             description={`Available ${formatDate(item.publishDate)}`}
             Image={<ImagePlaceholder color={item.color} />}


### PR DESCRIPTION
☝️ 

We don't know that upcoming serial parts are going to be stories – they could be comics as [here](https://wellcomecollection.org/series/YbNK-hEAACIAZe82)

__Before__
![image](https://user-images.githubusercontent.com/1394592/149782588-5df2b3d6-f519-46de-826d-85af4df8879c.png)


__After__
![image](https://user-images.githubusercontent.com/1394592/149782644-b6098520-9293-41a0-893d-fa1f7d293676.png)
