### PR TITLE
use template string

### DIFF
--- a/catalogue/webapp/components/ItemRequestModal/ItemRequestModal.tsx
+++ b/catalogue/webapp/components/ItemRequestModal/ItemRequestModal.tsx
@@ -74,7 +74,9 @@ const CurrentRequests: FC<{
 }> = ({ allowedHoldRequests, currentHoldRequests }) =>
   typeof currentHoldRequests !== 'undefined' ? (
     <CurrentRequestCount>
-      ${currentHoldRequests}/${allowedHoldRequests} item${currentHoldRequests !== 1 ? 's' : ''} requested
+      {`${currentHoldRequests}/${allowedHoldRequests} item${
+        currentHoldRequests !== 1 ? 's' : ''
+      } requested`}
     </CurrentRequestCount>
   ) : null;
 


### PR DESCRIPTION
Just noticed this string was wasn't delimited properly, so the variable names were showing instead of their values
