### PR TITLE
Include schedule in seriesFetchLinks

### DIFF
--- a/content/webapp/services/prismic/types/articles.ts
+++ b/content/webapp/services/prismic/types/articles.ts
@@ -29,9 +29,10 @@ export type WithSeries = {
     >;
   }>;
 };
-export const seriesFetchLink: FetchLinks<SeriesPrismicDocument> = [
+export const seriesFetchLinks: FetchLinks<SeriesPrismicDocument> = [
   'series.title',
   'series.promo',
+  'series.schedule',
 ];
 
 export const eventsFetchLinks: FetchLinks<EventPrismicDocument> = [
@@ -64,6 +65,6 @@ export const articlesFetchLinks = [
   ...commonPrismicFieldsFetchLinks,
   ...articleFormatsFetchLinks,
   ...contributorFetchLinks,
-  ...seriesFetchLink,
+  ...seriesFetchLinks,
   ...eventsFetchLinks,
 ];


### PR DESCRIPTION
## Who is this for?
People who want to know if something is part of a serial

## What is it doing for them?
Adding the tag back on to the relevant cards and article pages

![image](https://user-images.githubusercontent.com/1394592/150973570-4abd458e-fa33-4f1f-8ba2-5bfa6ad47563.png)

![image](https://user-images.githubusercontent.com/1394592/150973614-cb1d409f-ffe0-4d24-abd7-bb6fa31a8fe2.png)

