### PR TITLE
Replace the untyped getPage() with the typed fetchPage()

### DIFF
--- a/common/services/prismic/hardcoded-id.ts
+++ b/common/services/prismic/hardcoded-id.ts
@@ -1,6 +1,8 @@
 // Place to store id's of prismic of dynamic content if required.
 // We can always reference all hardcoded prismic id where they are called and remove them later to maintain
 
+export const homepageId = 'XphUbREAACMAgRNP';
+
 export const collectionVenueId = {
   galleries: {
     id: 'Wsttgx8AAJeSNmJ4',

--- a/common/services/prismic/hardcoded-id.ts
+++ b/common/services/prismic/hardcoded-id.ts
@@ -3,6 +3,12 @@
 
 export const homepageId = 'XphUbREAACMAgRNP';
 
+// The ID of the series that's featured on the /stories page.
+//
+// Ideally, this should be configurable in Prismic or by the content team,
+// to take devs out of the loop.
+export const featuredStoriesSeriesId = 'YXKNnxEAACEARPrl';
+
 export const collectionVenueId = {
   galleries: {
     id: 'Wsttgx8AAJeSNmJ4',

--- a/common/services/prismic/pages.js
+++ b/common/services/prismic/pages.js
@@ -1,6 +1,6 @@
 // @flow
 import Prismic from '@prismicio/client';
-import { getDocument, getDocuments } from './api';
+import { getDocuments } from './api';
 import {
   parseTimestamp,
   parseGenericFields,
@@ -31,8 +31,6 @@ import {
   contributorsFields,
   peopleFields,
   bookFields,
-  pagesFormatsFields,
-  guidesFields,
 } from './fetch-links';
 
 export function parsePage(document: PrismicDocument): Page {
@@ -69,41 +67,6 @@ export function parsePage(document: PrismicDocument): Page {
     siteSection: siteSection,
     prismicDocument: document,
   };
-}
-
-export async function getPage(
-  req: ?Request,
-  id: string,
-  memoizedPrismic: ?Object
-): Promise<?Page> {
-  const page = await getDocument(
-    req,
-    id,
-    {
-      fetchLinks: pagesFields.concat(
-        articleSeriesFields,
-        eventSeriesFields,
-        collectionVenuesFields,
-        exhibitionFields,
-        teamsFields,
-        eventsFields,
-        cardsFields,
-        eventFormatsFields,
-        articleFormatsFields,
-        labelsFields,
-        seasonsFields,
-        contributorsFields,
-        peopleFields,
-        bookFields,
-        pagesFormatsFields,
-        guidesFields
-      ),
-    },
-    memoizedPrismic
-  );
-  if (page) {
-    return parsePage(page);
-  }
 }
 
 type Order = 'desc' | 'asc';

--- a/content/webapp/app.ts
+++ b/content/webapp/app.ts
@@ -16,6 +16,7 @@ import {
   timers as middlewareTimers,
 } from '@weco/common/koa-middleware/withCachedValues';
 import linkResolver from './services/prismic/link-resolver';
+import { homepageId } from '@weco/common/services/prismic/hardcoded-id';
 
 // FIXME: Find a way to import this.
 // We can't because it's not a standard es6 module (import and flowtype)
@@ -56,7 +57,7 @@ const appPromise = nextApp
     koaApp.use(withCachedValues);
     koaApp.use(bodyParser());
 
-    pageVanityUrl(router, nextApp, '/', 'XphUbREAACMAgRNP', '/homepage');
+    pageVanityUrl(router, nextApp, '/', homepageId, '/homepage');
     route('/whats-on', '/whats-on', router, nextApp);
     route(`/whats-on/:period(${periodPaths})`, '/whats-on', router, nextApp);
 

--- a/content/webapp/pages/homepage.tsx
+++ b/content/webapp/pages/homepage.tsx
@@ -76,7 +76,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     const client = createClient(context);
 
     const articlesQueryPromise = fetchArticles(client, { pageSize: 4 });
-    const pageLookupPromise = fetchPage(client, homepageId);
+    const pagePromise = fetchPage(client, homepageId);
 
     const exhibitionsPromise = getExhibitions(
       context.req,
@@ -94,15 +94,15 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       memoizedPrismic
     );
 
-    const [exhibitions, events, articlesQuery, pageLookup] = await Promise.all([
+    const [exhibitions, events, articlesQuery, pageDocument] = await Promise.all([
       exhibitionsPromise,
       eventsPromise,
       articlesQueryPromise,
-      pageLookupPromise,
+      pagePromise,
     ]);
 
     // The homepage should always exist in Prismic.
-    const page = transformPage(pageLookup!);
+    const page = transformPage(pageDocument!);
     
     const articles = transformQuery(articlesQuery, transformArticle);
 

--- a/content/webapp/pages/homepage.tsx
+++ b/content/webapp/pages/homepage.tsx
@@ -34,6 +34,7 @@ import { createClient } from '../services/prismic/fetch';
 import { fetchArticles } from '../services/prismic/fetch/articles';
 import { transformQuery } from '../services/prismic/transformers/paginated-results';
 import { transformArticle } from '../services/prismic/transformers/articles';
+import { homepageId } from '@weco/common/services/prismic/hardcoded-id';
 
 const PageHeading = styled(Space).attrs({
   as: 'h1',
@@ -69,7 +70,7 @@ const pageImage =
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
     const serverData = await getServerData(context);
-    const { id, memoizedPrismic } = context.query;
+    const { memoizedPrismic } = context.query;
 
     const client = createClient(context);
 
@@ -90,7 +91,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       },
       memoizedPrismic
     );
-    const pagePromise = getPage(context.req, id, memoizedPrismic);
+    const pagePromise = getPage(context.req, homepageId, memoizedPrismic);
     const [exhibitions, events, articlesQuery, page] = await Promise.all([
       exhibitionsPromise,
       eventsPromise,

--- a/content/webapp/pages/homepage.tsx
+++ b/content/webapp/pages/homepage.tsx
@@ -1,7 +1,6 @@
 import { FC } from 'react';
 import styled from 'styled-components';
 import { classNames, font } from '@weco/common/utils/classnames';
-import { getPage } from '@weco/common/services/prismic/pages';
 import SectionHeader from '@weco/common/views/components/SectionHeader/SectionHeader';
 import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
 import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
@@ -35,6 +34,8 @@ import { fetchArticles } from '../services/prismic/fetch/articles';
 import { transformQuery } from '../services/prismic/transformers/paginated-results';
 import { transformArticle } from '../services/prismic/transformers/articles';
 import { homepageId } from '@weco/common/services/prismic/hardcoded-id';
+import { fetchPage } from 'services/prismic/fetch/pages';
+import { transformPage } from 'services/prismic/transformers/pages';
 
 const PageHeading = styled(Space).attrs({
   as: 'h1',
@@ -75,6 +76,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     const client = createClient(context);
 
     const articlesQueryPromise = fetchArticles(client, { pageSize: 4 });
+    const pageLookupPromise = fetchPage(client, homepageId);
 
     const exhibitionsPromise = getExhibitions(
       context.req,
@@ -91,14 +93,17 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       },
       memoizedPrismic
     );
-    const pagePromise = getPage(context.req, homepageId, memoizedPrismic);
-    const [exhibitions, events, articlesQuery, page] = await Promise.all([
+
+    const [exhibitions, events, articlesQuery, pageLookup] = await Promise.all([
       exhibitionsPromise,
       eventsPromise,
       articlesQueryPromise,
-      pagePromise,
+      pageLookupPromise,
     ]);
 
+    // The homepage should always exist in Prismic.
+    const page = transformPage(pageLookup!);
+    
     const articles = transformQuery(articlesQuery, transformArticle);
 
     if (events && exhibitions && articles && page) {

--- a/content/webapp/pages/page.tsx
+++ b/content/webapp/pages/page.tsx
@@ -9,7 +9,6 @@ import VideoEmbed from '@weco/common/views/components/VideoEmbed/VideoEmbed';
 import { UiImage } from '@weco/common/views/components/Images/Images';
 import { convertImageUri } from '@weco/common/utils/convert-image-uri';
 import {
-  getPage,
   getPageSiblings,
   getChildren,
 } from '@weco/common/services/prismic/pages';
@@ -37,6 +36,9 @@ import CardGrid from '../components/CardGrid/CardGrid';
 import Body from '../components/Body/Body';
 import ContentPage from '../components/ContentPage/ContentPage';
 import { contentLd } from '../services/prismic/transformers/json-ld';
+import { fetchPage } from '../services/prismic/fetch/pages';
+import { createClient } from '../services/prismic/fetch';
+import { transformPage } from '../services/prismic/transformers/pages';
 
 type Props = {
   page: PageType;
@@ -56,11 +58,11 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
     const serverData = await getServerData(context);
     const { id, memoizedPrismic } = context.query;
-    const page: PageType | undefined = await getPage(
-      context.req,
-      id,
-      memoizedPrismic
-    );
+
+    const client = createClient(context);
+    const pageLookup = await fetchPage(client, id as string);
+    const page = pageLookup && transformPage(pageLookup);
+
     if (page) {
       const siblings = await getPageSiblings(
         page,

--- a/content/webapp/pages/stories.tsx
+++ b/content/webapp/pages/stories.tsx
@@ -87,6 +87,9 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     const client = createClient(context);
 
     const articlesQueryPromise = fetchArticles(client);
+
+    // TODO: If we're only looking up this page to get the featured text slice,
+    // would it be faster to skip all the fetchLinks?  Is that possible?
     const storiesPagePromise = fetchPage(client, prismicPageIds.stories);
 
     const seriesPromise = getArticleSeries(

--- a/content/webapp/pages/stories.tsx
+++ b/content/webapp/pages/stories.tsx
@@ -11,7 +11,7 @@ import SpacingSection from '@weco/common/views/components/SpacingSection/Spacing
 import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
 import Space from '@weco/common/views/components/styled/Space';
 import { staticBooks } from '../content/static-books';
-import { prismicPageIds } from '@weco/common/services/prismic/hardcoded-id';
+import { prismicPageIds, featuredStoriesSeriesId } from '@weco/common/services/prismic/hardcoded-id';
 import FeaturedText from '@weco/common/views/components/FeaturedText/FeaturedText';
 import { defaultSerializer } from '../components/HTMLSerializers/HTMLSerializers';
 import { getPage } from '@weco/common/services/prismic/pages';
@@ -88,12 +88,9 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
 
     const articlesQueryPromise = fetchArticles(client);
 
-    // TODO: we're hardcoding a series id here in order to display whichever series
-    // the content team has chosen to be featured on the stories page. This would
-    // ideally come from Prismic to take devs/deployments out of the loop.
     const seriesPromise = getArticleSeries(
       context.req,
-      { id: 'YXKNnxEAACEARPrl' },
+      { id: featuredStoriesSeriesId },
       memoizedPrismic
     );
 

--- a/content/webapp/pages/stories.tsx
+++ b/content/webapp/pages/stories.tsx
@@ -14,8 +14,7 @@ import { staticBooks } from '../content/static-books';
 import { prismicPageIds, featuredStoriesSeriesId } from '@weco/common/services/prismic/hardcoded-id';
 import FeaturedText from '@weco/common/views/components/FeaturedText/FeaturedText';
 import { defaultSerializer } from '../components/HTMLSerializers/HTMLSerializers';
-import { getPage } from '@weco/common/services/prismic/pages';
-import { getPageFeaturedText } from '../services/prismic/transformers/pages';
+import { getPageFeaturedText, transformPage } from '../services/prismic/transformers/pages';
 import { FeaturedText as FeaturedTextType } from '@weco/common/model/text';
 import { SectionPageHeader } from '@weco/common/views/components/styled/SectionPageHeader';
 import { GetServerSideProps } from 'next';
@@ -31,6 +30,7 @@ import { createClient } from '../services/prismic/fetch';
 import { fetchArticles } from '../services/prismic/fetch/articles';
 import { transformQuery } from '../services/prismic/transformers/paginated-results';
 import { transformArticle } from '../services/prismic/transformers/articles';
+import { fetchPage } from 'services/prismic/fetch/pages';
 
 type Props = {
   articles: Article[];
@@ -87,16 +87,11 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     const client = createClient(context);
 
     const articlesQueryPromise = fetchArticles(client);
+    const storiesPagePromise = fetchPage(client, prismicPageIds.stories);
 
     const seriesPromise = getArticleSeries(
       context.req,
       { id: featuredStoriesSeriesId },
-      memoizedPrismic
-    );
-
-    const storiesPagePromise = getPage(
-      context.req,
-      prismicPageIds.stories,
       memoizedPrismic
     );
 
@@ -107,7 +102,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     ]);
     const articles = transformQuery(articlesQuery, transformArticle);
     const series = seriesAndArticles && seriesAndArticles.series;
-    const featuredText = storiesPage && getPageFeaturedText(storiesPage);
+    const featuredText = storiesPage && getPageFeaturedText(transformPage(storiesPage));
 
     if (articles && articles.results) {
       return {

--- a/content/webapp/pages/whats-on.tsx
+++ b/content/webapp/pages/whats-on.tsx
@@ -324,6 +324,9 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       : 'current-and-coming-up';
 
     // call prismic for specific content for section page such as featured text
+
+    // TODO: If we're only looking up this page to get the featured text slice,
+    // would it be faster to skip all the fetchLinks?  Is that possible?
     const whatsOnPagePromise = await fetchPage(client, prismicPageIds.whatsOn);
 
     const exhibitionsPromise = getExhibitions(

--- a/content/webapp/pages/whats-on.tsx
+++ b/content/webapp/pages/whats-on.tsx
@@ -7,7 +7,6 @@ import { Period } from '@weco/common/model/periods';
 import { PaginatedResults } from '@weco/common/services/prismic/types';
 import { classNames, font, grid, cssGrid } from '@weco/common/utils/classnames';
 import { getExhibitions } from '@weco/common/services/prismic/exhibitions';
-import { getPage } from '@weco/common/services/prismic/pages';
 import { getPageFeaturedText } from '../services/prismic/transformers/pages';
 import { getEvents } from '@weco/common/services/prismic/events';
 import {
@@ -65,6 +64,9 @@ import {
 import ExhibitionsAndEvents from '../components/ExhibitionsAndEvents/ExhibitionsAndEvents';
 import CardGrid from '../components/CardGrid/CardGrid';
 import { FeaturedCardExhibition } from '../components/FeaturedCard/FeaturedCard';
+import { fetchPage } from '../services/prismic/fetch/pages';
+import { createClient } from '../services/prismic/fetch';
+import { transformPage } from '../services/prismic/transformers/pages';
 
 const segmentedControlItems = [
   {
@@ -313,20 +315,17 @@ const pageDescription =
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
     const serverData = await getServerData(context);
+    const { memoizedPrismic } = context.query;
+
+    const client = createClient(context);
 
     const period = context.query.period
       ? context.query.period.toString()
       : 'current-and-coming-up';
 
-    const { memoizedPrismic } = context.query;
+    const whatsOnPagePromise = await fetchPage(client, prismicPageIds.whatsOn);
 
-    // call prisimic for specific content for section page such as featured text
-    const whatsOnPagePromise = getPage(
-      context.req,
-      prismicPageIds.whatsOn,
-      memoizedPrismic
-    );
-
+    // call prismic for specific content for section page such as featured text
     const exhibitionsPromise = getExhibitions(
       context.req,
       {
@@ -365,7 +364,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
 
     const dateRange = getMomentsForPeriod(period);
 
-    const featuredText = whatsOnPage && getPageFeaturedText(whatsOnPage);
+    const featuredText = whatsOnPage && getPageFeaturedText(transformPage(whatsOnPage));
 
     if (period && events && exhibitions) {
       return {

--- a/content/webapp/pages/whats-on.tsx
+++ b/content/webapp/pages/whats-on.tsx
@@ -323,9 +323,9 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       ? context.query.period.toString()
       : 'current-and-coming-up';
 
+    // call prismic for specific content for section page such as featured text
     const whatsOnPagePromise = await fetchPage(client, prismicPageIds.whatsOn);
 
-    // call prismic for specific content for section page such as featured text
     const exhibitionsPromise = getExhibitions(
       context.req,
       {

--- a/content/webapp/pages/whats-on.tsx
+++ b/content/webapp/pages/whats-on.tsx
@@ -327,7 +327,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
 
     // TODO: If we're only looking up this page to get the featured text slice,
     // would it be faster to skip all the fetchLinks?  Is that possible?
-    const whatsOnPagePromise = await fetchPage(client, prismicPageIds.whatsOn);
+    const whatsOnPagePromise = fetchPage(client, prismicPageIds.whatsOn);
 
     const exhibitionsPromise = getExhibitions(
       context.req,

--- a/content/webapp/services/prismic/fetch/pages.ts
+++ b/content/webapp/services/prismic/fetch/pages.ts
@@ -1,7 +1,43 @@
 import { fetcher } from '.';
 import { PagePrismicDocument } from '../types/pages';
+import {
+  articleSeriesFields,
+  pagesFields,
+  collectionVenuesFields,
+  eventSeriesFields,
+  exhibitionFields,
+  teamsFields,
+  eventsFields,
+  cardsFields,
+  eventFormatsFields,
+  articleFormatsFields,
+  labelsFields,
+  seasonsFields,
+  contributorsFields,
+  peopleFields,
+  bookFields,
+  pagesFormatsFields,
+  guidesFields,
+} from '@weco/common/services/prismic/fetch-links';
 
-const fetchLinks = [];
+const fetchLinks = pagesFields.concat(
+  articleSeriesFields,
+  eventSeriesFields,
+  collectionVenuesFields,
+  exhibitionFields,
+  teamsFields,
+  eventsFields,
+  cardsFields,
+  eventFormatsFields,
+  articleFormatsFields,
+  labelsFields,
+  seasonsFields,
+  contributorsFields,
+  peopleFields,
+  bookFields,
+  pagesFormatsFields,
+  guidesFields
+);
 
 const pagesFetcher = fetcher<PagePrismicDocument>('pages', fetchLinks);
 


### PR DESCRIPTION
Picking off another bit of https://github.com/wellcomecollection/wellcomecollection.org/issues/7363 and https://github.com/wellcomecollection/wellcomecollection.org/issues/7302, by switching to another typed method for fetching data from Prismic. I've tested it locally on a few pages, and it looks okay.

I also did a bit of other tidying, in particular consolidating a few more Prismic IDs in `hardcoded-id.ts`, so they're easier to find and manage.