### PR TITLE
Don't link to self if schedule length === 1

### DIFF
--- a/content/webapp/pages/article.tsx
+++ b/content/webapp/pages/article.tsx
@@ -252,47 +252,45 @@ const ArticlePage: FC<Props> = ({ article }) => {
     />
   );
 
-  const Siblings =
-    listOfSeries &&
-    listOfSeries
-      .map(({ series, articles }) => {
-        if (series.schedule.length > 0 && positionInSerial) {
-          const firstArticleFromSchedule = series.schedule.find(
-            i => i.partNumber === 1
-          );
-          const firstArticleTitle = firstArticleFromSchedule?.title;
-          const firstArticle = articles.find(
-            i => i.title === firstArticleTitle
-          );
+  function getNextUp(
+    series: ArticleSeries,
+    articles: Article[],
+    currentPosition?: number
+  ) {
+    if (series.schedule.length > 0 && currentPosition) {
+      const firstArticleFromSchedule = series.schedule.find(
+        i => i.partNumber === 1
+      );
+      const firstArticleTitle = firstArticleFromSchedule?.title;
+      const firstArticle = articles.find(i => i.title === firstArticleTitle);
 
-          const nextArticleFromSchedule = series.schedule.find(
-            i => i.partNumber === positionInSerial + 1
-          );
-          const nextArticleTitle = nextArticleFromSchedule?.title;
-          const nextArticle = articles.find(i => i.title === nextArticleTitle);
+      const nextArticleFromSchedule = series.schedule.find(
+        i => i.partNumber === currentPosition + 1
+      );
+      const nextArticleTitle = nextArticleFromSchedule?.title;
+      const nextArticle = articles.find(i => i.title === nextArticleTitle);
 
-          const nextUp =
-            positionInSerial === series.schedule.length &&
-            series.schedule.length > 1
-              ? firstArticle
-              : nextArticle || null;
+      const nextUp =
+        currentPosition === series.schedule.length && series.schedule.length > 1
+          ? firstArticle
+          : nextArticle || null;
 
-          return nextUp ? (
-            <SeriesNavigation
-              key={series.id}
-              series={series}
-              items={[nextUp]}
-            />
-          ) : null;
-        } else {
-          // Overkill? Should this happen on the API?
-          const dedupedArticles = articles
-            .filter(a => a.id !== article.id)
-            .slice(0, 2);
-          return <SeriesNavigation series={series} items={dedupedArticles} />;
-        }
-      })
-      .filter(Boolean);
+      return nextUp ? (
+        <SeriesNavigation key={series.id} series={series} items={[nextUp]} />
+      ) : null;
+    } else {
+      const dedupedArticles = articles
+        .filter(a => a.id !== article.id)
+        .slice(0, 2);
+      return <SeriesNavigation series={series} items={dedupedArticles} />;
+    }
+  }
+
+  const Siblings = listOfSeries
+    ?.map(({ series, articles }) => {
+      return getNextUp(series, articles, positionInSerial);
+    })
+    .filter(Boolean);
 
   return (
     <PageLayout

--- a/content/webapp/pages/article.tsx
+++ b/content/webapp/pages/article.tsx
@@ -261,7 +261,9 @@ const ArticlePage: FC<Props> = ({ article }) => {
             i => i.partNumber === 1
           );
           const firstArticleTitle = firstArticleFromSchedule?.title;
-          const firstArticle = articles.find(i => i.title === firstArticleTitle);
+          const firstArticle = articles.find(
+            i => i.title === firstArticleTitle
+          );
 
           const nextArticleFromSchedule = series.schedule.find(
             i => i.partNumber === positionInSerial + 1
@@ -270,7 +272,8 @@ const ArticlePage: FC<Props> = ({ article }) => {
           const nextArticle = articles.find(i => i.title === nextArticleTitle);
 
           const nextUp =
-            positionInSerial === series.schedule.length
+            positionInSerial === series.schedule.length &&
+            series.schedule.length > 1
               ? firstArticle
               : nextArticle || null;
 

--- a/playwright/test/articles.test.ts
+++ b/playwright/test/articles.test.ts
@@ -1,6 +1,7 @@
-import { article } from './contexts';
+import { article, articleWithMockSiblings } from './contexts';
 import { baseUrl } from './helpers/urls';
 import { makeDefaultToggleAndTestCookies } from './helpers/utils';
+import { oneScheduleItem } from './mocks/one-schedule-item';
 
 const domain = new URL(baseUrl).host;
 
@@ -39,12 +40,31 @@ describe('articles', () => {
     //
     // See https://github.com/wellcomecollection/wellcomecollection.org/issues/7461
 
+    await article('YPAnpxAAACIAbz2c');
+    await page.waitForSelector('a >> text="Happiness in time"');
+  });
+
+  test('an article in a serial with further parts in a schedule will link to the next part', async () => {
+    await article('YRzdyREAACEAqIu-');
+    await page.waitForSelector(
+      'a >> text="Finding out where my lithium comes from"'
+    );
+  });
+
+  test('the last article in a serial will link to the first part', async () => {
     await article('YUrz5RAAACIA4ZrH');
     await page.waitForSelector(
-      'div >> text="Diagnosed bipolar, prescribed lithium"'
+      'a >> text="Diagnosed bipolar, prescribed lithium"'
     );
+  });
 
-    await article('YPAnpxAAACIAbz2c');
-    await page.waitForSelector('div >> text="Happiness in time"');
+  test('no related story is shown for an article in a serial with only one schedule item', async () => {
+    await articleWithMockSiblings('YeUumhAAAJMQMtKc', oneScheduleItem);
+
+    expect(
+      await page.isVisible(
+        `a >> text="Deciding a date for the end of the world"`
+      )
+    ).toBeFalsy();
   });
 });

--- a/playwright/test/contexts.ts
+++ b/playwright/test/contexts.ts
@@ -1,6 +1,6 @@
 import { baseUrl, useStageApis } from './helpers/urls';
 import { Response } from 'playwright';
-
+import type { PrismicApiSearchResponse } from '@weco/common/services/prismic/types';
 export function gotoWithoutCache(url: string): Promise<null | Response> {
   return page.goto(`${url}?cachebust=${Date.now()}`);
 }
@@ -100,6 +100,19 @@ const article = async (id: string): Promise<void> => {
   await gotoWithoutCache(`${baseUrl}/articles/${id}`);
 };
 
+const articleWithMockSiblings = async (
+  id: string,
+  response: PrismicApiSearchResponse
+): Promise<void> => {
+  await context.route('**/api/**', route =>
+    route.fulfill({
+      status: 200,
+      body: JSON.stringify(response),
+    })
+  );
+  await gotoWithoutCache(`${baseUrl}/articles/${id}`);
+};
+
 export const isMobile = Boolean(deviceName);
 
 export {
@@ -118,4 +131,5 @@ export {
   itemWithRestrictedAndNonRestrictedAccess,
   itemWithNonRestrictedAndOpenAccess,
   article,
+  articleWithMockSiblings,
 };

--- a/playwright/test/mocks/one-schedule-item.ts
+++ b/playwright/test/mocks/one-schedule-item.ts
@@ -1,0 +1,824 @@
+export const oneScheduleItem = {
+  page: 1,
+  results_per_page: 20,
+  results_size: 1,
+  total_results_size: 1,
+  total_pages: 1,
+  next_page: null,
+  prev_page: null,
+  results: [
+    {
+      id: 'YeUumhAAAJMQMtKc',
+      uid: null,
+      url: null,
+      type: 'articles',
+      href: 'https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=YfFSxxEAACQAnD2t&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22YeUumhAAAJMQMtKc%22%29+%5D%5D',
+      tags: [],
+      first_publication_date: new Date('2022-01-20T10:00:00+0000'),
+      last_publication_date: new Date('2022-01-25T10:28:34+0000'),
+      slugs: ['deciding-a-date-for-the-end-of-the-world'],
+      linked_documents: [],
+      lang: 'en-gb',
+      alternate_languages: [],
+      slug: '',
+      alternateLanguages: [],
+      isBroken: false,
+      data: {
+        title: [
+          {
+            type: 'heading1',
+            text: 'Deciding a date for the end of the world',
+            spans: [],
+          },
+        ],
+        format: {
+          link_type: 'Document',
+        },
+        body: [
+          {
+            slice_type: 'standfirst',
+            slice_label: null,
+            items: [],
+            primary: {
+              text: [
+                {
+                  type: 'paragraph',
+                  text: 'For centuries, humans have anticipated their own extinction. Although the Christian apocalypse brings life on Earth to a close, other cultures, such as the Maya, have included a new beginning in the end, creating cyclical rather than linear calendars. Historian Charlotte Sleigh examines why the end, periodically, seems nigh, and what we can learn from past predictions.',
+                  spans: [],
+                },
+              ],
+            },
+          },
+          {
+            slice_type: 'text',
+            slice_label: null,
+            items: [],
+            primary: {
+              text: [
+                {
+                  type: 'paragraph',
+                  text: 'In 2017, the highly respected Scripps Institution of Oceanography gave humans a 5 per cent chance of extinction by the century’s end. Scripps put a figure on the swirling fears related to climate change, the reasonable but as then unquantified risk that we might bring about our own demise. ',
+                  spans: [
+                    {
+                      start: 80,
+                      end: 111,
+                      type: 'hyperlink',
+                      data: {
+                        link_type: 'Web',
+                        url: 'https://scripps.ucsd.edu/news/new-climate-risk-classification-created-account-potential-existential-threats',
+                      },
+                    },
+                  ],
+                },
+                {
+                  type: 'paragraph',
+                  text: 'It wasn’t the first time that people had thought about their own end. For many hundreds of years, we have projected an imminent termination to our world, whether through the capriciousness of the gods or as a result of our own actions.',
+                  spans: [],
+                },
+                {
+                  type: 'paragraph',
+                  text: 'This series will look at previous prophecies and sciences of annihilation, asking what we can learn from these curious episodes. Why did the end seem nigh, and how did people respond in each of these moments? Climate change is different from the subjects of those false alarms, but with the benefit of their history, we might approach the brink a little more wisely this time.',
+                  spans: [],
+                },
+              ],
+            },
+          },
+          {
+            slice_type: 'text',
+            slice_label: null,
+            items: [],
+            primary: {
+              text: [
+                {
+                  type: 'heading2',
+                  text: 'The end...',
+                  spans: [],
+                },
+              ],
+            },
+          },
+          {
+            slice_type: 'text',
+            slice_label: null,
+            items: [],
+            primary: {
+              text: [
+                {
+                  type: 'paragraph',
+                  text: 'For those of us living in the West, the Christian religion has been largely responsible for shaping our expectations of the end of the world. Christians are told to think and act with their final reckoning in mind. St Paul advised the Corinthians: “[T]he time is short. From now on... those who buy something, [should live] as if it were not theirs to keep.” ',
+                  spans: [],
+                },
+                {
+                  type: 'paragraph',
+                  text: 'At the Christian apocalypse, Christ will return and take the faithful with him to heaven, while sinners are condemned to hell. This prophecy is recorded in the Book of Revelation, one of 66 texts that were compiled around 400 CE to form the complete Bible. ',
+                  spans: [],
+                },
+                {
+                  type: 'paragraph',
+                  text: 'Bound books were an innovation at this time, and they went together well with a religion that was uniquely premised upon a linear time structure, from Creation to Fall, salvation to judgement. At the book’s end, Revelation narrated the closure of all earthly things. History now had a last page, waiting to be revealed before the clapping shut of the covers: “The End.”',
+                  spans: [
+                    {
+                      start: 222,
+                      end: 223,
+                      type: 'em',
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+          {
+            slice_type: 'gifVideo',
+            slice_label: null,
+            items: [],
+            primary: {
+              caption: [
+                {
+                  type: 'paragraph',
+                  text: '“Cyclic calendars – loops of time of different lengths that came in and out of synchronisation – were the norm in ancient and early modern Mesoamerica.”',
+                  spans: [],
+                },
+              ],
+              tasl: 'Deciding a date for the end of the world | | | | | Gergo Varga (varrgo.com) for Wellcome Collection |',
+              video: {
+                link_type: 'Media',
+                name: 'WellColl - Ch1 - Solo2.mp4',
+                kind: 'document',
+                url: 'https://wellcomecollection.cdn.prismic.io/wellcomecollection/c86d41c5-dbe1-4dae-867f-4523bdfc9ccd_WellColl+-+Ch1+-+Solo2.mp4',
+                size: '7328302',
+              },
+              playbackRate: null,
+              autoPlay: true,
+              loop: true,
+              mute: true,
+              showControls: false,
+            },
+          },
+          {
+            slice_type: 'text',
+            slice_label: null,
+            items: [],
+            primary: {
+              text: [
+                {
+                  type: 'heading2',
+                  text: '... or a bloody fresh start?',
+                  spans: [],
+                },
+              ],
+            },
+          },
+          {
+            slice_type: 'text',
+            slice_label: null,
+            items: [],
+            primary: {
+              text: [
+                {
+                  type: 'paragraph',
+                  text: 'But there is, in principle, no need for the apocalypse to be a last-page, final event. Time, in many cultures, is cyclic: after the end of the world comes a fresh beginning.',
+                  spans: [],
+                },
+                {
+                  type: 'paragraph',
+                  text: 'One of the key Maya calendars was a round of 7,200 days. In the epic prophecy ‘Cuceb’ (“that which revolves”), Katun was a god who embodied the era. When he began to limp, as scholar John Bierhorst explains, it was time to find a human surrogate. This person had to be tortured or even killed to make way for the next era. ',
+                  spans: [
+                    {
+                      start: 111,
+                      end: 116,
+                      type: 'hyperlink',
+                      data: {
+                        link_type: 'Web',
+                        url: 'https://en.wikipedia.org/wiki/K%CA%BCatun',
+                      },
+                    },
+                    {
+                      start: 172,
+                      end: 206,
+                      type: 'hyperlink',
+                      data: {
+                        link_type: 'Web',
+                        url: 'https://www.google.co.uk/books/edition/Four_Masterworks_of_American_Indian_Lite/w_QrEAAAQBAJ?hl=en&gbpv=1',
+                      },
+                    },
+                  ],
+                },
+                {
+                  type: 'paragraph',
+                  text: 'Cyclic calendars – loops of time of different lengths that came in and out of synchronisation – were the norm in ancient and early modern Mesoamerica. The sacred tzolkʼin cycle of 260 days combined with the solar year, the haab’, to produce a long calendar round that resets every 52 years. One round of the long calendar was not far off life expectancy for a Mayan or a Zapotec. The end of the calendar might be the end of the world for someone whose life matched its beginning and end, but everyone else would carry on.',
+                  spans: [],
+                },
+                {
+                  type: 'paragraph',
+                  text: 'Appropriately enough, the codices on which the Mayans recorded their calendars were not bound as books, with their linear narrative, but folded out on giant sheets of bark-based paper. They burned easily when the Europeans consigned them, all but four, to the flames.',
+                  spans: [
+                    {
+                      start: 239,
+                      end: 251,
+                      type: 'hyperlink',
+                      data: {
+                        link_type: 'Web',
+                        url: 'https://en.wikipedia.org/wiki/Maya_codices',
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+          {
+            slice_type: 'text',
+            slice_label: null,
+            items: [],
+            primary: {
+              text: [
+                {
+                  type: 'heading2',
+                  text: 'World without end',
+                  spans: [],
+                },
+              ],
+            },
+          },
+          {
+            slice_type: 'text',
+            slice_label: null,
+            items: [],
+            primary: {
+              text: [
+                {
+                  type: 'paragraph',
+                  text: 'Although Christians ostensibly believed in an apocalypse, fewer than three centuries after decimating the ‘primitive’ Mesoamericans, European settlers developed their own mythological time system that imagined a world without end. It was called the futures market, and from the latter half of the 19th century, it dominated US trade in agricultural and other goods. ',
+                  spans: [],
+                },
+                {
+                  type: 'paragraph',
+                  text: 'Capitalism depends upon everyone committing to imagining the future, and not just any kind of future, but a cheery, business-as-usual future. The promise of future profit, built on debt in the present, demands it. Trades in ‘futures’ promised prices for commodities that had yet to even be produced or delivered. St Paul would most certainly have disapproved. ',
+                  spans: [
+                    {
+                      start: 11,
+                      end: 23,
+                      type: 'hyperlink',
+                      data: {
+                        link_type: 'Web',
+                        url: 'https://www.mpifg.de/forschung/forschung/diskussion/zukunft.asp',
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+          {
+            slice_type: 'gifVideo',
+            slice_label: null,
+            items: [],
+            primary: {
+              caption: [
+                {
+                  type: 'paragraph',
+                  text: '“Goodman began tying to synchronise Mayan calendars to the modern, Western one. What was the zero point of Mesoamerican time?”',
+                  spans: [],
+                },
+              ],
+              tasl: 'Deciding a date for the end of the world | | | | | Gergo Varga (varrgo.com) for Wellcome Collection |',
+              video: {
+                link_type: 'Media',
+                name: 'WellColl - Ch1 - Solo1.mp4',
+                kind: 'document',
+                url: 'https://wellcomecollection.cdn.prismic.io/wellcomecollection/0acd8ccf-ae0f-4245-8106-f100e12e8d53_WellColl+-+Ch1+-+Solo1.mp4',
+                size: '5637201',
+              },
+              playbackRate: null,
+              autoPlay: true,
+              loop: true,
+              mute: true,
+              showControls: false,
+            },
+          },
+          {
+            slice_type: 'text',
+            slice_label: null,
+            items: [],
+            primary: {
+              text: [
+                {
+                  type: 'paragraph',
+                  text: 'Joseph T Goodman was caught between the heritage of Christ and capital. As a successful newspaper editor in 19th-century Nevada, he helped create the accelerated flow of information that bred the futures markets. Upon giving up the paper, Goodman went into the heart of capital, taking up a seat on the Pacific Stock Exchange and becoming a successful trader and investor. So far so futurist. ',
+                  spans: [],
+                },
+                {
+                  type: 'paragraph',
+                  text: 'But at the same time, Goodman became obsessed with Mayan calendars. He learned that a non-repeating ‘long count’ had been in use before the European invasion, providing a historical dating system (used on monuments) that was anchored in a creation event. ',
+                  spans: [],
+                },
+                {
+                  type: 'paragraph',
+                  text: 'Goodman began trying to synchronise this calendar to the modern, Western one. What was the zero point of Mesoamerican time?',
+                  spans: [],
+                },
+              ],
+            },
+          },
+          {
+            slice_type: 'text',
+            slice_label: null,
+            items: [],
+            primary: {
+              text: [
+                {
+                  type: 'heading2',
+                  text: 'The apocalypse of 2012',
+                  spans: [],
+                },
+              ],
+            },
+          },
+          {
+            slice_type: 'text',
+            slice_label: null,
+            items: [],
+            primary: {
+              text: [
+                {
+                  type: 'paragraph',
+                  text: 'Goodman eventually figured out an answer. No matter that the Maya were unlikely to have thought of time’s start in the literal way that 20th-century Americans did. He pinpointed the start date for the Mayan calendar as 11 August 3114 BCE. The book of Western mythology had a new first page, based in American cultures, and calculated by science.',
+                  spans: [
+                    {
+                      start: 19,
+                      end: 40,
+                      type: 'hyperlink',
+                      data: {
+                        link_type: 'Web',
+                        url: 'https://en.wikipedia.org/wiki/Mesoamerican_Long_Count_calendar',
+                      },
+                    },
+                  ],
+                },
+                {
+                  type: 'paragraph',
+                  text: 'This first page inevitably invited a last page: a moment of ending. New Agers and conspiracy theorists counted forwards to find the end of the world. The end-date of a 5,126-year-long cycle in the Mesoamerican Long Count calendar was 21 December 2012.',
+                  spans: [
+                    {
+                      start: 68,
+                      end: 102,
+                      type: 'hyperlink',
+                      data: {
+                        link_type: 'Web',
+                        url: 'https://en.wikipedia.org/wiki/2012_phenomenon#Origins',
+                      },
+                    },
+                    {
+                      start: 234,
+                      end: 250,
+                      type: 'hyperlink',
+                      data: {
+                        link_type: 'Web',
+                        url: 'https://en.wikipedia.org/wiki/2012_phenomenon',
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+          {
+            slice_type: 'text',
+            slice_label: null,
+            items: [],
+            primary: {
+              text: [
+                {
+                  type: 'paragraph',
+                  text: 'Despite the specific, carefully calculated date, people could not agree upon the details of how the apocalypse would happen. Explanations read like a list of science-fiction disaster films: depending on whether you studied Ancient Egyptians or Mayans, or relied on your own hallucinogenic revelations, it might come in the form of a disastrous reversal of the Earth’s magnetic field,  a planetary collision, or a supermassive black hole.',
+                  spans: [],
+                },
+                {
+                  type: 'paragraph',
+                  text: 'The believers had missed the point. Just as Goodman never reconciled his desire to pinpoint “the end” with a career predicated on the end never coming, perhaps it was less painful to deflect their attention away from reality and towards alien conspiracy theories instead. ',
+                  spans: [],
+                },
+                {
+                  type: 'paragraph',
+                  text: 'By the time 2012 rolled around, the world had already gone through one of its periodic financial Cucebs. The global banking meltdown of 2008 had sacrificed the world’s poorest and most climate-vulnerable in schemes of ‘austerity’ to restart the cycle of profit. Meanwhile, the planet grew hotter and hotter. It was apparently harder to imagine getting rid of capitalism than it was to imagine the end of the world itself.',
+                  spans: [
+                    {
+                      start: 344,
+                      end: 369,
+                      type: 'hyperlink',
+                      data: {
+                        link_type: 'Web',
+                        url: 'https://en.wikipedia.org/wiki/Capitalist_Realism',
+                        target: '_blank',
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+        outroResearchItem: {
+          link_type: 'Any',
+        },
+        outroResearchLinkText: [],
+        outroReadItem: {
+          link_type: 'Any',
+        },
+        outroReadLinkText: [],
+        outroVisitItem: {
+          link_type: 'Any',
+        },
+        outroVisitLinkText: [],
+        contributors: [
+          {
+            role: {
+              id: 'WcUWeCgAAFws-nGh',
+              type: 'editorial-contributor-roles',
+              tags: [],
+              slug: 'author',
+              lang: 'en-gb',
+              first_publication_date: new Date('2017-09-22T13:56:23+0000'),
+              last_publication_date: new Date('2020-06-19T10:53:42+0000'),
+              data: {
+                title: [
+                  {
+                    type: 'heading1',
+                    text: 'Author',
+                    spans: [],
+                  },
+                ],
+                describedBy: 'words',
+              },
+              link_type: 'Document',
+              isBroken: false,
+            },
+            contributor: {
+              id: 'YRpSlhEAADJD3zoo',
+              type: 'people',
+              tags: [],
+              slug: 'charlotte-sleigh',
+              lang: 'en-gb',
+              first_publication_date: new Date('2021-08-16T11:57:18+0000'),
+              last_publication_date: new Date('2021-08-23T08:56:25+0000'),
+              data: {
+                name: 'Charlotte Sleigh',
+                description: [
+                  {
+                    type: 'paragraph',
+                    text: 'Charlotte Sleigh is an interdisciplinary writer and practitioner in the science humanities. Her most recent book is ‘Human’ (Reaktion, 2020). She is Honorary Professor at the Department of Science and Technology Studies, UCL, and current president of the British Society for the History of Science.',
+                    spans: [],
+                  },
+                ],
+                image: {
+                  dimensions: {
+                    width: 607,
+                    height: 612,
+                  },
+                  alt: 'Head and shoulders photo of a woman with short, fair hair, against a background of hills and fields.',
+                  copyright:
+                    'Charlotte Sleigh | Charlotte Sleigh | | | All Rights Reserved | |',
+                  url: 'https://images.prismic.io/wellcomecollection/d61588da-fe2b-4384-9688-e49a25ac7cee_Charlotte-Sleigh-headshot.jpg?auto=compress,format',
+                  '32:15': {
+                    dimensions: {
+                      width: 3200,
+                      height: 1500,
+                    },
+                    alt: 'Head and shoulders photo of a woman with short, fair hair, against a background of hills and fields.',
+                    copyright:
+                      'Charlotte Sleigh | Charlotte Sleigh | | | All Rights Reserved | |',
+                    url: 'https://images.prismic.io/wellcomecollection/d61588da-fe2b-4384-9688-e49a25ac7cee_Charlotte-Sleigh-headshot.jpg?auto=compress,format&rect=0,164,607,285&w=3200&h=1500',
+                  },
+                  '16:9': {
+                    dimensions: {
+                      width: 3200,
+                      height: 1800,
+                    },
+                    alt: 'Head and shoulders photo of a woman with short, fair hair, against a background of hills and fields.',
+                    copyright:
+                      'Charlotte Sleigh | Charlotte Sleigh | | | All Rights Reserved | |',
+                    url: 'https://images.prismic.io/wellcomecollection/d61588da-fe2b-4384-9688-e49a25ac7cee_Charlotte-Sleigh-headshot.jpg?auto=compress,format&rect=0,135,607,341&w=3200&h=1800',
+                  },
+                  square: {
+                    dimensions: {
+                      width: 3200,
+                      height: 3200,
+                    },
+                    alt: 'Head and shoulders photo of a woman with short, fair hair, against a background of hills and fields.',
+                    copyright:
+                      'Charlotte Sleigh | Charlotte Sleigh | | | All Rights Reserved | |',
+                    url: 'https://images.prismic.io/wellcomecollection/d61588da-fe2b-4384-9688-e49a25ac7cee_Charlotte-Sleigh-headshot.jpg?auto=compress,format&rect=0,2,607,607&w=3200&h=3200',
+                  },
+                },
+                sameAs: [
+                  {
+                    link: 'https://hellobookwhisperer.com/',
+                    title: [
+                      {
+                        type: 'paragraph',
+                        text: 'Charlotte Sleigh’s website',
+                        spans: [],
+                      },
+                    ],
+                  },
+                  {
+                    link: null,
+                    title: [],
+                  },
+                ],
+              },
+              link_type: 'Document',
+              isBroken: false,
+            },
+            description: [],
+          },
+          {
+            role: {
+              id: 'Wux6DyIAAO5n3lzk',
+              type: 'editorial-contributor-roles',
+              tags: [],
+              slug: 'artist',
+              lang: 'en-gb',
+              first_publication_date: new Date('2018-05-04T15:19:48+0000'),
+              last_publication_date: new Date('2019-08-14T14:31:04+0000'),
+              data: {
+                title: [
+                  {
+                    type: 'heading1',
+                    text: 'Artist',
+                    spans: [],
+                  },
+                ],
+                describedBy: 'artwork',
+              },
+              link_type: 'Document',
+              isBroken: false,
+            },
+            contributor: {
+              id: 'YdbTcRAAACEA8fbJ',
+              type: 'people',
+              tags: [],
+              slug: 'gergo-varga',
+              lang: 'en-gb',
+              first_publication_date: new Date('2022-01-06T11:43:17+0000'),
+              last_publication_date: new Date('2022-01-19T12:56:39+0000'),
+              data: {
+                name: 'Gergo Varga',
+                description: [
+                  {
+                    type: 'paragraph',
+                    text: 'varrgo is a place where Gergo creates and animates mixed-media projects, particularly in the style of collages and cut-outs. He enjoys working with things that have already had a life, from old magazines to scribbles in a notebook. His longest-running creative project is ‘oners’, where he visualises one-minute quotes from contemporary thinkers.',
+                    spans: [
+                      {
+                        start: 6,
+                        end: 7,
+                        type: 'em',
+                      },
+                      {
+                        start: 279,
+                        end: 281,
+                        type: 'em',
+                      },
+                    ],
+                  },
+                ],
+                image: {
+                  dimensions: {
+                    width: 750,
+                    height: 750,
+                  },
+                  alt: 'Black and white head and shoulders collaged artwork showing a portrait of Gergo Varga.',
+                  copyright: 'Gergo Varga  | | | | | Gergo Varga |',
+                  url: 'https://images.prismic.io/wellcomecollection/eb7dfba1-52c0-48d0-b412-7dc20b702c80_Selfportrait_site2.jpeg?auto=compress,format',
+                  '32:15': {
+                    dimensions: {
+                      width: 3200,
+                      height: 1500,
+                    },
+                    alt: 'Black and white head and shoulders collaged artwork showing a portrait of Gergo Varga.',
+                    copyright: 'Gergo Varga  | | | | | Gergo Varga |',
+                    url: 'https://images.prismic.io/wellcomecollection/eb7dfba1-52c0-48d0-b412-7dc20b702c80_Selfportrait_site2.jpeg?auto=compress,format&rect=0,173,750,352&w=3200&h=1500',
+                  },
+                  '16:9': {
+                    dimensions: {
+                      width: 3200,
+                      height: 1800,
+                    },
+                    alt: 'Black and white head and shoulders collaged artwork showing a portrait of Gergo Varga.',
+                    copyright: 'Gergo Varga  | | | | | Gergo Varga |',
+                    url: 'https://images.prismic.io/wellcomecollection/eb7dfba1-52c0-48d0-b412-7dc20b702c80_Selfportrait_site2.jpeg?auto=compress,format&rect=0,120,750,422&w=3200&h=1800',
+                  },
+                  square: {
+                    dimensions: {
+                      width: 3200,
+                      height: 3200,
+                    },
+                    alt: 'Black and white head and shoulders collaged artwork showing a portrait of Gergo Varga.',
+                    copyright: 'Gergo Varga  | | | | | Gergo Varga |',
+                    url: 'https://images.prismic.io/wellcomecollection/eb7dfba1-52c0-48d0-b412-7dc20b702c80_Selfportrait_site2.jpeg?auto=compress,format&rect=0,0,750,750&w=3200&h=3200',
+                  },
+                },
+                sameAs: [
+                  {
+                    link: 'https://varrgo.com',
+                    title: [
+                      {
+                        type: 'paragraph',
+                        text: 'varrgo.com',
+                        spans: [],
+                      },
+                    ],
+                  },
+                  {
+                    link: 'https://www.instagram.com/vargergo/',
+                    title: [
+                      {
+                        type: 'paragraph',
+                        text: '@vargergo on Instagram',
+                        spans: [],
+                      },
+                    ],
+                  },
+                ],
+              },
+              link_type: 'Document',
+              isBroken: false,
+            },
+            description: [],
+          },
+        ],
+        contributorsTitle: [],
+        promo: [
+          {
+            slice_type: 'editorialImage',
+            slice_label: null,
+            items: [],
+            primary: {
+              caption: [
+                {
+                  type: 'paragraph',
+                  text: 'When will the world end? Charlotte Sleigh explores how our obsession with dates and dramatic imaginings of the end can distract us from the dangers slowly creeping up on us. ',
+                  spans: [],
+                },
+              ],
+              image: {
+                dimensions: {
+                  width: 3840,
+                  height: 2160,
+                },
+                alt: "Mixed media digital artwork combining found imagery from vintage magazines and books with painted and textured elements. The overall hues are blues, yellows and reds. The illustration is split in two by a red and yellow line running vertically through the image at a slight angle. On the left side of this line is the black and white archive image of the head and upper body of a man with a white beard wearing a suit from the Victorian era. The top half of his head from his nose up has been replaced with strips of newspapers arranged in a step formation to resemble a Mayan temple. The first level of newspaper has the word 'Revelations' in all caps. As the levels rise the words, 'calendar', December 21st', 'Maya' and '2012' appear in newspaper print. At the top of the temple structure is a bright light and an explosion of red and yellow wedges shooting up into the blue background. A large crack runs down through the temple. On the right side of the vertical lines, the image of this temple structure is duplicated and enlarged to reveal it in more detail and crop out the man's lower head. A small figure can now be seen flying through the air, propelled by the force of the explosion.",
+                copyright:
+                  'Deciding a date for the end of the world | | | | | Gergo Varga (varrgo.com) for Wellcome Collection |',
+                url: 'https://images.prismic.io/wellcomecollection/760b74c4-bf1a-46d4-a995-0bb4014542ce_WellColl+-+Ch1+-+Headline.jpg?auto=compress,format',
+                '32:15': {
+                  dimensions: {
+                    width: 3200,
+                    height: 1500,
+                  },
+                  alt: "Mixed media digital artwork combining found imagery from vintage magazines and books with painted and textured elements. The overall hues are blues, yellows and reds. The illustration is split in two by a red and yellow line running vertically through the image at a slight angle. On the left side of this line is the black and white archive image od the head and upper body of a man with a white beard wearing a suit from the Victorian era. The top half of his head from his nose up has been replaced with strips of newspapers arranged in a step formation to resemble a Mayan temple. The first level of newspaper has the word 'Revelations' in all caps. As the levels rise the words, 'calendar', December 21st', 'Maya' and '2012' appear in newspaper print. At the top of the temple structure is a bright light and an explosion of red and yellow wedges shooting up into the blue background. A large crack runs down through the temple. On the right side of the vertical lines, the image of this temple structure is duplicated and enlarged to reveal it in more detail and crop out the man's lower head. A small figure can now be seen flying through the air, propelled by the force of the explosion.",
+                  copyright:
+                    'Deciding a date for the end of the world | | | | | Gergo Varga (varrgo.com) for Wellcome Collection |',
+                  url: 'https://images.prismic.io/wellcomecollection/760b74c4-bf1a-46d4-a995-0bb4014542ce_WellColl+-+Ch1+-+Headline.jpg?auto=compress,format&rect=0,320,3840,1800&w=3200&h=1500',
+                },
+                '16:9': {
+                  dimensions: {
+                    width: 3200,
+                    height: 1800,
+                  },
+                  alt: "Mixed media digital artwork combining found imagery from vintage magazines and books with painted and textured elements. The overall hues are blues, yellows and reds. The illustration is split in two by a red and yellow line running vertically through the image at a slight angle. On the left side of this line is the black and white archive image od the head and upper body of a man with a white beard wearing a suit from the Victorian era. The top half of his head from his nose up has been replaced with strips of newspapers arranged in a step formation to resemble a Mayan temple. The first level of newspaper has the word 'Revelations' in all caps. As the levels rise the words, 'calendar', December 21st', 'Maya' and '2012' appear in newspaper print. At the top of the temple structure is a bright light and an explosion of red and yellow wedges shooting up into the blue background. A large crack runs down through the temple. On the right side of the vertical lines, the image of this temple structure is duplicated and enlarged to reveal it in more detail and crop out the man's lower head. A small figure can now be seen flying through the air, propelled by the force of the explosion.",
+                  copyright:
+                    'Deciding a date for the end of the world | | | | | Gergo Varga (varrgo.com) for Wellcome Collection |',
+                  url: 'https://images.prismic.io/wellcomecollection/760b74c4-bf1a-46d4-a995-0bb4014542ce_WellColl+-+Ch1+-+Headline.jpg?auto=compress,format&rect=0,0,3840,2160&w=3200&h=1800',
+                },
+                square: {
+                  dimensions: {
+                    width: 3200,
+                    height: 3200,
+                  },
+                  alt: "Mixed media digital artwork combining found imagery from vintage magazines and books with painted and textured elements. The overall hues are blues, yellows and reds. The illustration is split in two by a red and yellow line running vertically through the image at a slight angle. On the left side of this line is the black and white archive image od the head and upper body of a man with a white beard wearing a suit from the Victorian era. The top half of his head from his nose up has been replaced with strips of newspapers arranged in a step formation to resemble a Mayan temple. The first level of newspaper has the word 'Revelations' in all caps. As the levels rise the words, 'calendar', December 21st', 'Maya' and '2012' appear in newspaper print. At the top of the temple structure is a bright light and an explosion of red and yellow wedges shooting up into the blue background. A large crack runs down through the temple. On the right side of the vertical lines, the image of this temple structure is duplicated and enlarged to reveal it in more detail and crop out the man's lower head. A small figure can now be seen flying through the air, propelled by the force of the explosion.",
+                  copyright:
+                    'Deciding a date for the end of the world | | | | | Gergo Varga (varrgo.com) for Wellcome Collection |',
+                  url: 'https://images.prismic.io/wellcomecollection/760b74c4-bf1a-46d4-a995-0bb4014542ce_WellColl+-+Ch1+-+Headline.jpg?auto=compress,format&rect=1488,0,2160,2160&w=3200&h=3200',
+                },
+              },
+              link: null,
+            },
+          },
+        ],
+        metadataDescription: [],
+        series: [
+          {
+            series: {
+              id: 'YeUt6xAAAIAWMs9o',
+              type: 'series',
+              tags: [],
+              slug: 'apocalypse-how',
+              lang: 'en-gb',
+              first_publication_date: new Date('2022-01-18T16:00:20+0000'),
+              last_publication_date: new Date('2022-01-19T12:22:36+0000'),
+              data: {
+                title: [
+                  {
+                    type: 'heading1',
+                    text: 'Apocalypse How?',
+                    spans: [],
+                  },
+                ],
+                schedule: [
+                  {
+                    title: [
+                      {
+                        type: 'heading1',
+                        text: 'Deciding a date for the end of the world',
+                        spans: [],
+                      },
+                    ],
+                    publishDate: '2022-01-20T10:00:00+0000',
+                  },
+                ],
+                promo: [
+                  {
+                    slice_type: 'editorialImage',
+                    slice_label: null,
+                    items: [],
+                    primary: {
+                      caption: [
+                        {
+                          type: 'paragraph',
+                          text: 'Over many centuries, the end has periodically seemed nigh. Charlotte Sleigh explores what has led to these predictions, and how history can help us think about our current fears of annihilation.',
+                          spans: [],
+                        },
+                      ],
+                      image: {
+                        dimensions: {
+                          width: 3840,
+                          height: 2160,
+                        },
+                        alt: "Mixed media digital artwork combining found imagery from vintage magazines and books with painted and textured elements. The overall hues are blues, yellows and reds. The illustration is split in two by a red and yellow line running vertically through the image at a slight angle. On the left side of this line is the black and white archive image of the head and upper body of a man with a white beard wearing a suit from the Victorian era. The top half of his head from his nose up has been replaced with strips of newspapers arranged in a step formation to resemble a Mayan temple. The first level of newspaper has the word 'Revelations' in all caps. As the levels rise the words, 'calendar', December 21st', 'Maya' and '2012' appear in newspaper print. At the top of the temple structure is a bright light and an explosion of red and yellow wedges shooting up into the blue background. A large crack runs down through the temple. On the right side of the vertical lines, the image of this temple structure is duplicated and enlarged to reveal it in more detail and crop out the man's lower head. A small figure can now be seen flying through the air, propelled by the force of the explosion.",
+                        copyright:
+                          'Deciding a date for the end of the world | | | | | Gergo Varga (varrgo.com) for Wellcome Collection |',
+                        url: 'https://images.prismic.io/wellcomecollection/760b74c4-bf1a-46d4-a995-0bb4014542ce_WellColl+-+Ch1+-+Headline.jpg?auto=compress,format',
+                        '32:15': {
+                          dimensions: {
+                            width: 3200,
+                            height: 1500,
+                          },
+                          alt: "Mixed media digital artwork combining found imagery from vintage magazines and books with painted and textured elements. The overall hues are blues, yellows and reds. The illustration is split in two by a red and yellow line running vertically through the image at a slight angle. On the left side of this line is the black and white archive image od the head and upper body of a man with a white beard wearing a suit from the Victorian era. The top half of his head from his nose up has been replaced with strips of newspapers arranged in a step formation to resemble a Mayan temple. The first level of newspaper has the word 'Revelations' in all caps. As the levels rise the words, 'calendar', December 21st', 'Maya' and '2012' appear in newspaper print. At the top of the temple structure is a bright light and an explosion of red and yellow wedges shooting up into the blue background. A large crack runs down through the temple. On the right side of the vertical lines, the image of this temple structure is duplicated and enlarged to reveal it in more detail and crop out the man's lower head. A small figure can now be seen flying through the air, propelled by the force of the explosion.",
+                          copyright:
+                            'Deciding a date for the end of the world | | | | | Gergo Varga (varrgo.com) for Wellcome Collection |',
+                          url: 'https://images.prismic.io/wellcomecollection/760b74c4-bf1a-46d4-a995-0bb4014542ce_WellColl+-+Ch1+-+Headline.jpg?auto=compress,format&rect=0,298,3840,1800&w=3200&h=1500',
+                        },
+                        '16:9': {
+                          dimensions: {
+                            width: 3200,
+                            height: 1800,
+                          },
+                          alt: "Mixed media digital artwork combining found imagery from vintage magazines and books with painted and textured elements. The overall hues are blues, yellows and reds. The illustration is split in two by a red and yellow line running vertically through the image at a slight angle. On the left side of this line is the black and white archive image od the head and upper body of a man with a white beard wearing a suit from the Victorian era. The top half of his head from his nose up has been replaced with strips of newspapers arranged in a step formation to resemble a Mayan temple. The first level of newspaper has the word 'Revelations' in all caps. As the levels rise the words, 'calendar', December 21st', 'Maya' and '2012' appear in newspaper print. At the top of the temple structure is a bright light and an explosion of red and yellow wedges shooting up into the blue background. A large crack runs down through the temple. On the right side of the vertical lines, the image of this temple structure is duplicated and enlarged to reveal it in more detail and crop out the man's lower head. A small figure can now be seen flying through the air, propelled by the force of the explosion.",
+                          copyright:
+                            'Deciding a date for the end of the world | | | | | Gergo Varga (varrgo.com) for Wellcome Collection |',
+                          url: 'https://images.prismic.io/wellcomecollection/760b74c4-bf1a-46d4-a995-0bb4014542ce_WellColl+-+Ch1+-+Headline.jpg?auto=compress,format&rect=0,0,3840,2160&w=3200&h=1800',
+                        },
+                        square: {
+                          dimensions: {
+                            width: 3200,
+                            height: 3200,
+                          },
+                          alt: "Mixed media digital artwork combining found imagery from vintage magazines and books with painted and textured elements. The overall hues are blues, yellows and reds. The illustration is split in two by a red and yellow line running vertically through the image at a slight angle. On the left side of this line is the black and white archive image od the head and upper body of a man with a white beard wearing a suit from the Victorian era. The top half of his head from his nose up has been replaced with strips of newspapers arranged in a step formation to resemble a Mayan temple. The first level of newspaper has the word 'Revelations' in all caps. As the levels rise the words, 'calendar', December 21st', 'Maya' and '2012' appear in newspaper print. At the top of the temple structure is a bright light and an explosion of red and yellow wedges shooting up into the blue background. A large crack runs down through the temple. On the right side of the vertical lines, the image of this temple structure is duplicated and enlarged to reveal it in more detail and crop out the man's lower head. A small figure can now be seen flying through the air, propelled by the force of the explosion.",
+                          copyright:
+                            'Deciding a date for the end of the world | | | | | Gergo Varga (varrgo.com) for Wellcome Collection |',
+                          url: 'https://images.prismic.io/wellcomecollection/760b74c4-bf1a-46d4-a995-0bb4014542ce_WellColl+-+Ch1+-+Headline.jpg?auto=compress,format&rect=1499,0,2160,2160&w=3200&h=3200',
+                        },
+                      },
+                      link: null,
+                    },
+                  },
+                ],
+              },
+              link_type: 'Document',
+              isBroken: false,
+            },
+            positionInSeries: null,
+          },
+        ],
+        seasons: [
+          {
+            season: {
+              link_type: 'Document',
+            },
+          },
+        ],
+        parents: [
+          {
+            order: null,
+            parent: {
+              link_type: 'Document',
+            },
+          },
+        ],
+        publishDate: null,
+      },
+    },
+  ],
+  version: 'b47651d',
+  license: 'All Rights Reserved',
+};


### PR DESCRIPTION
As a result of the changes in #7589 an article that is part of a serial that only has one part published will display a link to itself at the end of the article e.g. https://wellcomecollection.org/articles/YXKJQREAACMARPGd

This PR checks that there is more than one article in the schedule to prevent this from happening.