### PR TITLE
Fix support for rendering pages whose content type isn't 'page'

### DIFF
--- a/.buildkite/expected_200_urls.txt
+++ b/.buildkite/expected_200_urls.txt
@@ -28,3 +28,6 @@
 /projects/YEIYwhAAACIANd6T
 /seasons/YEY3ZBAAACEASBjA
 /series/X8YMWBIAACUAhwAx
+
+# This is an article which is the 'webcomics' type underneath
+/articles/YbNRQBEAACMAZfvG

--- a/.buildkite/expected_200_urls.txt
+++ b/.buildkite/expected_200_urls.txt
@@ -1,5 +1,3 @@
-/guides/YL9OAxIAAB8AHsyv
-
 # https://wellcome.slack.com/archives/C294K7D5M/p1638794220158000
 /covid-book-your-ticket
 
@@ -18,3 +16,15 @@
 
 # This is an article with an event link in the "Try these next" section
 /articles/W_LXOxcAACwAxC5_
+
+# This is an example of every content type in Prismic (as of January 2022)
+/articles/YbNRQBEAACMAZfvG
+/books/YRpf9xEAADVQ33g6
+/event-series/XLWcIBEAAGC6wYZr
+/events/YUMsAxAAACUASyMn
+/exhibitions/YLjGYhAAACMAed2Z
+/guides/YL9OAxIAAB8AHsyv
+/pages/YLnuVRAAACMAftOt
+/projects/YEIYwhAAACIANd6T
+/seasons/YEY3ZBAAACEASBjA
+/series/X8YMWBIAACUAhwAx

--- a/common/services/prismic/articles.js
+++ b/common/services/prismic/articles.js
@@ -22,7 +22,7 @@ import type {
   PrismicQueryOpts,
 } from './types';
 
-const graphQuery = `{
+export const graphQuery = `{
   webcomics {
     ...webcomicsFields
     format {

--- a/common/services/prismic/hardcoded-id.ts
+++ b/common/services/prismic/hardcoded-id.ts
@@ -44,7 +44,14 @@ export const prismicPageIds = {
   aboutUs: 'Wuw2MSIAACtd3Stq',
   copyrightClearance: 'YGSEhxAAACgAXL4E',
   register: 'X_2eexEAACQAZLBi',
+  access: 'Wvm2uiAAAIYQ4FHP',
   contactUs: 'YVMbEBAAAPaMBrz7',
+  openingTimes: 'WwQHTSAAANBfDYXU',
+  press: 'WuxrKCIAAP9h3hmw',
+  schools: 'Wuw2MSIAACtd3StS',
+  userPanel: 'YH17kRAAACoAyWTB',
+  venueHire: 'Wuw2MSIAACtd3SsC',
+  youth: 'Wuw2MSIAACtd3Ste',
 };
 
 export const getNameFromCollectionVenue = (id: string) => {

--- a/content/webapp/app.ts
+++ b/content/webapp/app.ts
@@ -16,7 +16,7 @@ import {
   timers as middlewareTimers,
 } from '@weco/common/koa-middleware/withCachedValues';
 import linkResolver from './services/prismic/link-resolver';
-import { homepageId } from '@weco/common/services/prismic/hardcoded-id';
+import { homepageId, prismicPageIds } from '@weco/common/services/prismic/hardcoded-id';
 
 // FIXME: Find a way to import this.
 // We can't because it's not a standard es6 module (import and flowtype)
@@ -91,18 +91,18 @@ const appPromise = nextApp
     route('/newsletter', '/newsletter', router, nextApp);
 
     route('/collections', '/page', router, nextApp, {
-      id: 'YBfeAhMAACEAqBTx',
+      id: prismicPageIds.collections,
     });
 
     route('/guides', '/guides', router, nextApp);
     route(`/guides/:id(${prismicId})`, '/page', router, nextApp);
 
-    pageVanityUrl(router, nextApp, '/opening-times', 'WwQHTSAAANBfDYXU');
-    pageVanityUrl(router, nextApp, '/what-we-do', 'WwLGFCAAAPMiB_Ps');
-    pageVanityUrl(router, nextApp, '/press', 'WuxrKCIAAP9h3hmw');
-    pageVanityUrl(router, nextApp, '/venue-hire', 'Wuw2MSIAACtd3SsC');
-    pageVanityUrl(router, nextApp, '/access', 'Wvm2uiAAAIYQ4FHP');
-    pageVanityUrl(router, nextApp, '/youth', 'Wuw2MSIAACtd3Ste');
+    pageVanityUrl(router, nextApp, '/opening-times', prismicPageIds.openingTimes);
+    pageVanityUrl(router, nextApp, '/what-we-do', prismicPageIds.whatWeDo);
+    pageVanityUrl(router, nextApp, '/press', prismicPageIds.press);
+    pageVanityUrl(router, nextApp, '/venue-hire', prismicPageIds.venueHire);
+    pageVanityUrl(router, nextApp, '/access', prismicPageIds.access);
+    pageVanityUrl(router, nextApp, '/youth', prismicPageIds.youth);
     pageVanityUrl(router, nextApp, '/schools', 'Wuw2MSIAACtd3StS');
     pageVanityUrl(router, nextApp, '/covid-welcome-back', 'X5amzBIAAB0Aq6Gm');
     pageVanityUrl(

--- a/content/webapp/services/prismic/fetch/articles.ts
+++ b/content/webapp/services/prismic/fetch/articles.ts
@@ -1,3 +1,25 @@
+// TODO: It should be possible to drastically simplify this by using a vanilla
+// fetcher, and passing multiple content types (cf. pages.ts).
+//
+// For some reason, whenever I try using it (or adding any fetcher to this file),
+// I get an error from the type checker:
+//
+//      ../../node_modules/prismic-client-beta/dist/index.mjs
+//      Attempted import error: 'asLink' is not exported from '@prismicio/helpers' (imported as 'prismicH').
+//
+// e.g. the following line, which we know works because it compiles perfectly in
+// another file:
+//
+//      const booksFetcher = fetcher<BookPrismicDocument>('books', fetchLinks);
+//
+// will cause the error.
+//
+// I've given up trying to fix this today, but we should come back and resolve it
+// rather than putting new logic in this file.
+//
+// This may get fixed when we update our Prismic API client libraries.
+// See https://github.com/wellcomecollection/wellcomecollection.org/issues/7595
+
 import { Query } from '@prismicio/types';
 import { GetServerSidePropsPrismicClient } from '.';
 import { ArticlePrismicDocument, articlesFetchLinks } from '../types/articles';

--- a/content/webapp/services/prismic/fetch/index.ts
+++ b/content/webapp/services/prismic/fetch/index.ts
@@ -82,6 +82,8 @@ export function fetcher<Document extends PrismicDocument>(
 
         if (document.type === contentType) {
           return document;
+        } else {
+          console.warn(`Asked to fetch document ${id} as type '${contentType}', but ${id} is actually '${document.type}'`);
         }
       } catch {}
     },

--- a/content/webapp/services/prismic/fetch/index.ts
+++ b/content/webapp/services/prismic/fetch/index.ts
@@ -138,6 +138,13 @@ export function fetcher<Document extends PrismicDocument>(
     getByTypeClientSide: async (
       params?: Params
     ): Promise<Query<Document> | undefined> => {
+      // If you add more parameters here, you have to update the corresponding cache behaviour
+      // in the CloudFront distribution, or you may get incorrect behaviour.
+      //
+      // e.g. at one point we forgot to include the "params" query in the cache key,
+      // so every article was showing the same set of related stories.
+      //
+      // See https://github.com/wellcomecollection/wellcomecollection.org/issues
       const urlSearchParams = new URLSearchParams();
       urlSearchParams.set('params', JSON.stringify(params));
       const response = await fetch(

--- a/content/webapp/services/prismic/fetch/index.ts
+++ b/content/webapp/services/prismic/fetch/index.ts
@@ -74,7 +74,7 @@ type Params = Parameters<
 function hasMatchingContentType(document: PrismicDocument, contentType: ContentType | ContentType[]): boolean {
   return isString(contentType)
     ? document.type === contentType
-    : contentType.map(ct => ct as string).indexOf(document.type) !== -1;
+    : contentType.map(ct => ct as string).includes(document.type);
 }
 
 export function fetcher<Document extends PrismicDocument>(

--- a/content/webapp/services/prismic/fetch/index.ts
+++ b/content/webapp/services/prismic/fetch/index.ts
@@ -74,7 +74,7 @@ type Params = Parameters<
 function hasMatchingContentType(document: PrismicDocument, contentType: ContentType | ContentType[]): boolean {
   return isString(contentType)
     ? document.type === contentType
-    : contentType.map(ct => ct as string).includes(document.type);
+    : (contentType as string[]).includes(document.type);
 }
 
 export function fetcher<Document extends PrismicDocument>(

--- a/content/webapp/services/prismic/fetch/pages.ts
+++ b/content/webapp/services/prismic/fetch/pages.ts
@@ -39,7 +39,10 @@ const fetchLinks = pagesFields.concat(
   guidesFields
 );
 
-const pagesFetcher = fetcher<PagePrismicDocument>('pages', fetchLinks);
+/** Although these are three different document types in Prismic, they all get
+  * rendered (and fetched) by the same component.
+  */
+const pagesFetcher = fetcher<PagePrismicDocument>(['pages', 'guides', 'projects'], fetchLinks);
 
 export const fetchPage = pagesFetcher.getById;
 export const fetchPages = pagesFetcher.getByType;

--- a/content/webapp/services/prismic/link-resolver.ts
+++ b/content/webapp/services/prismic/link-resolver.ts
@@ -10,6 +10,7 @@ const contentTypes = [
   'projects',
   'seasons',
   'series',
+  'webcomics',
 ] as const;
 export type ContentType = typeof contentTypes[number];
 


### PR DESCRIPTION
e.g. compare

https://www-stage.wellcomecollection.org/guides/YL9OAxIAAB8AHsyv
https://www.wellcomecollection.org/guides/YL9OAxIAAB8AHsyv

This was a bug introduced in https://github.com/wellcomecollection/wellcomecollection.org/pull/7590, and caught before we deployed. Specifically, there's a bug lurking in here:

```typescript
const pagesFetcher = fetcher<PagePrismicDocument>('page', fetchLinks);

export const fetchPage = pagesFetcher.getById;
```

When you call that `getById` method, it's doing a check on the content type – if it doesn't match the content type we expect, you get a 404. Because guides and projects are both rendered using the `Page` component (which was calling `fetchPage()`), we'd 404 them out for mismatched content type.

This patch updates the `fetcher` to support multiple content types, because we do the same thing for articles/webcomics. I've also added a complete list of content types to the list of URLs we check before deploying, to prevent any regressions.