### PR TITLE
Exhibition editable a11y info

### DIFF
--- a/common/model/exhibitions.js
+++ b/common/model/exhibitions.js
@@ -22,6 +22,7 @@ export type Exhibition = {|
   end: ?Date,
   isPermanent: boolean,
   statusOverride: ?string,
+  accessContentOverride: ?string,
   place: ?Place,
   exhibits: {|
     exhibitType: 'exhibitions',

--- a/common/model/exhibitions.ts
+++ b/common/model/exhibitions.ts
@@ -18,6 +18,7 @@ export type Exhibition = GenericContentFields & {
   end?: Date;
   isPermanent: boolean;
   statusOverride?: string;
+  accessContentOverride?: string;
   place?: Place;
   exhibits: Exhibit[];
   resources: Resource[];

--- a/common/services/prismic/exhibitions.js
+++ b/common/services/prismic/exhibitions.js
@@ -136,6 +136,7 @@ export function parseExhibitionDoc(document: PrismicDocument): UiExhibition {
   const start = parseTimestamp(data.start);
   const end = data.end && parseTimestamp(data.end);
   const statusOverride = asText(data.statusOverride);
+  const accessContentOverride = asText(data.accessContentOverride);
   const promoImage =
     promo && promo.length > 0
       ? parsePromoToCaptionedImage(data.promo)
@@ -154,6 +155,7 @@ export function parseExhibitionDoc(document: PrismicDocument): UiExhibition {
     end: end,
     isPermanent: parseBoolean(data.isPermanent),
     statusOverride: statusOverride,
+    accessContentOverride: accessContentOverride,
     place: isDocumentLink(data.place) ? parsePlace(data.place) : undefined,
     exhibits: data.exhibits ? parseExhibits(data.exhibits) : [],
     promo: promoImage && {

--- a/content/webapp/components/Exhibition/Exhibition.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.tsx
@@ -133,7 +133,10 @@ function getResourcesItems(exhibition: UiExhibition): ExhibitionItem[] {
   });
 }
 
-function getAccessibilityItems(): ExhibitionItem[] {
+function getAccessibilityItems(exhibition: UiExhibition): ExhibitionItem[] {
+  const defaultAccessContent =
+    'Large-print guides, transcripts and magnifiers are available in the gallery';
+
   return [
     {
       id: undefined,
@@ -153,7 +156,7 @@ function getAccessibilityItems(): ExhibitionItem[] {
       description: [
         {
           type: 'paragraph',
-          text: 'Large-print guides, transcripts and magnifiers are available in the gallery',
+          text: exhibition.accessContentOverride || defaultAccessContent,
           spans: [],
         },
       ],
@@ -169,7 +172,7 @@ export function getInfoItems(exhibition: UiExhibition): ExhibitionItem[] {
     getTodaysHoursObject(),
     getPlaceObject(exhibition),
     ...getResourcesItems(exhibition),
-    ...getAccessibilityItems(),
+    ...getAccessibilityItems(exhibition),
   ].filter(isNotUndefined);
 }
 

--- a/prismic-model/package.json
+++ b/prismic-model/package.json
@@ -1,7 +1,5 @@
 {
   "scripts": {
-    "convertFromSrc": "ts-node convertFromSrc",
-    "convertFromRemote": "ts-node convertFromRemote",
     "sliceAnalysis": "ts-node sliceAnalysis",
     "deployType": "ts-node deployType",
     "diffCustomTypes": "ts-node diffCustomTypes"

--- a/prismic-model/src/exhibitions.ts
+++ b/prismic-model/src/exhibitions.ts
@@ -27,6 +27,7 @@ const exhibitions: CustomType = {
       end: timestamp('End date'),
       isPermanent: booleanDeprecated('Is permanent?'),
       statusOverride: structuredText('Status override', 'single'),
+      accessContentOverride: singleLineText('Access content override'),
       place,
     },
     'In this exhibition': {


### PR DESCRIPTION
Part of #7597

## Who is this for?
Content editors

## What is it doing for them?
Allowing them to change the access content information in the yellow box on a per-exhibition basis.

![image](https://user-images.githubusercontent.com/1394592/151363678-5be48be3-78e5-4dfe-bd8b-54cd64233376.png)

<img width="627" alt="Screenshot 2022-01-27 at 12 48 17" src="https://user-images.githubusercontent.com/1394592/151363591-beee3cc9-1b5f-49c5-b599-4327108cc46e.png">

If no `Access content override` is added, 'Large-print guides, transcripts and magnifiers are available in the gallery' will continue to display by default.


