### PR TITLE
Look up exhibitions on single exhibition pages with the new typed fetcher

### DIFF
--- a/common/model/exhibitions.ts
+++ b/common/model/exhibitions.ts
@@ -26,6 +26,8 @@ export type Exhibition = GenericContentFields & {
   prismicDocument: any;
 };
 
+// TODO: I'm pretty sure we don't use this featuredImageList anywhere,
+// and we could collapse this into Exhibition.
 export type UiExhibition = Exhibition & {
   featuredImageList: Picture[];
 };

--- a/common/services/prismic/exhibitions.js
+++ b/common/services/prismic/exhibitions.js
@@ -1,6 +1,6 @@
 // @flow
 import Prismic from '@prismicio/client';
-import { getDocument, getDocuments, getTypeByIds } from './api';
+import { getDocuments, getTypeByIds } from './api';
 import { parseMultiContent } from './multi-content';
 import {
   exhibitionFields,
@@ -19,8 +19,6 @@ import {
   articleSeriesFields,
   articleFormatsFields,
   articlesFields,
-  eventsFields,
-  seasonsFields,
 } from './fetch-links';
 // $FlowFixMe (ts)
 import { breakpoints } from '../../utils/breakpoints';
@@ -55,7 +53,6 @@ import type {
   ExhibitionFormat,
 } from '../../model/exhibitions';
 import type { MultiContent } from '../../model/multi-content';
-import { getPages } from './pages';
 
 const startField = 'my.exhibitions.start';
 const endField = 'my.exhibitions.end';
@@ -289,65 +286,6 @@ function putPermanentAfterCurrentExhibitions(
     ...groupedResults.comingUp,
     ...groupedResults.past,
   ];
-}
-
-async function getExhibition(
-  id: string,
-  req: ?Request,
-  memoizedPrismic: ?Object
-): Promise<?UiExhibition> {
-  const document = await getDocument(
-    req,
-    id,
-    {
-      fetchLinks: peopleFields.concat(
-        exhibitionFields,
-        organisationsFields,
-        contributorsFields,
-        placesFields,
-        exhibitionResourcesFields,
-        eventSeriesFields,
-        articlesFields,
-        eventsFields,
-        seasonsFields
-      ),
-    },
-    memoizedPrismic
-  );
-
-  if (document && document.type === 'exhibitions') {
-    const exhibition = parseExhibitionDoc(document);
-    return exhibition;
-  }
-}
-
-export async function getExhibitionWithRelatedContent({
-  request,
-  id,
-  memoizedPrismic,
-}: {
-  request: ?Request,
-  memoizedPrismic: ?Object,
-  id: string,
-}) {
-  const exhibitionPromise = getExhibition(id, request, memoizedPrismic);
-  const pagesPromise = getPages(
-    request,
-    {
-      predicates: [Prismic.Predicates.at('my.pages.parents.parent', id)],
-    },
-    memoizedPrismic
-  );
-
-  const [exhibition, pages] = await Promise.all([
-    exhibitionPromise,
-    pagesPromise,
-  ]);
-
-  return {
-    exhibition,
-    pages,
-  };
 }
 
 type ExhibitionRelatedContent = {|

--- a/content/webapp/pages/exhibition.tsx
+++ b/content/webapp/pages/exhibition.tsx
@@ -1,6 +1,5 @@
 import { UiExhibition } from '@weco/common/model/exhibitions';
 import { Page } from '@weco/common/model/pages';
-import { getExhibitionWithRelatedContent } from '@weco/common/services/prismic/exhibitions';
 import Exhibition from '../components/Exhibition/Exhibition';
 import Installation from '../components/Installation/Installation';
 import { AppErrorProps, WithGaDimensions } from '@weco/common/views/pages/_app';
@@ -8,6 +7,11 @@ import { FC } from 'react';
 import { GetServerSideProps } from 'next';
 import { removeUndefinedProps } from '@weco/common/utils/json';
 import { getServerData } from '@weco/common/server-data';
+import { createClient } from '../services/prismic/fetch';
+import { fetchExhibition } from 'services/prismic/fetch/exhibitions';
+import { transformQuery } from 'services/prismic/transformers/paginated-results';
+import { transformPage } from 'services/prismic/transformers/pages';
+import { transformExhibition } from 'services/prismic/transformers/exhibitions';
 
 type Props = {
   exhibition: UiExhibition;
@@ -25,21 +29,27 @@ const ExhibitionPage: FC<Props> = ({ exhibition, pages }) => {
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
     const serverData = await getServerData(context);
-    const { id, memoizedPrismic } = context.query;
-    const { exhibition, pages } = await getExhibitionWithRelatedContent({
-      request: context.req,
-      id,
-      memoizedPrismic,
-    });
+    const { id } = context.query;
+
+    const client = createClient(context);
+    const { exhibition, pages } = await fetchExhibition(client, id as string);
 
     if (exhibition) {
+      const exhibitionDoc = transformExhibition(exhibition);
+      const relatedPages = transformQuery(pages, transformPage);
+
       return {
         props: removeUndefinedProps({
-          exhibition,
-          pages: pages?.results || [],
+          // TODO: This is a temporary shim until we can get rid of the UiExhibition
+          // type.  Ideally we'd pass the exhibitionDoc directly here.
+          exhibition: {
+            ...exhibitionDoc,
+            featuredImageList: [],
+          },
+          pages: relatedPages?.results || [],
           serverData,
           gaDimensions: {
-            partOf: exhibition.seasons.map(season => season.id),
+            partOf: exhibitionDoc.seasons.map(season => season.id),
           },
         }),
       };

--- a/content/webapp/services/prismic/fetch/exhibitions.ts
+++ b/content/webapp/services/prismic/fetch/exhibitions.ts
@@ -1,13 +1,67 @@
-import { fetcher } from '.';
+import { fetcher, GetServerSidePropsPrismicClient } from '.';
 import { ExhibitionPrismicDocument } from '../types/exhibitions';
-import { exhibitionFormatsFetchLinks as fetchLinks } from '../types';
+import { Query } from '@prismicio/types';
+import { fetchPages } from './pages';
+import * as prismic from 'prismic-client-beta';
+import { PagePrismicDocument } from '../types/pages';
+import {
+  exhibitionFields,
+  exhibitionResourcesFields,
+  placesFields,
+  eventSeriesFields,
+  organisationsFields,
+  peopleFields,
+  contributorsFields,
+  articlesFields,
+  eventsFields,
+  seasonsFields,
+} from '@weco/common/services/prismic/fetch-links';
+
+const fetchLinks = peopleFields.concat(
+  exhibitionFields,
+  organisationsFields,
+  contributorsFields,
+  placesFields,
+  exhibitionResourcesFields,
+  eventSeriesFields,
+  articlesFields,
+  eventsFields,
+  seasonsFields
+);
 
 const exhibitionsFetcher = fetcher<ExhibitionPrismicDocument>(
   'exhibitions',
   fetchLinks
 );
 
-export const fetchExhibition = exhibitionsFetcher.getById;
+export type FetchExhibitionResult = {
+  exhibition?: ExhibitionPrismicDocument;
+  pages: Query<PagePrismicDocument>;
+};
+
+export async function fetchExhibition(
+  client: GetServerSidePropsPrismicClient,
+  id: string
+): Promise<FetchExhibitionResult> {
+  const exhibitionPromise = exhibitionsFetcher.getById(client, id);
+  const pageQueryPromise = fetchPages(
+    client,
+    {
+      predicates: [prismic.predicate.at('my.pages.parents.parent', id)],
+    }
+  );
+
+  const [exhibition, pages] = await Promise.all([
+    exhibitionPromise,
+    pageQueryPromise,
+  ]);
+
+  return {
+    exhibition,
+    pages,
+  }
+}
+
 export const fetchExhibitions = exhibitionsFetcher.getByType;
 export const fetchExhibitionsClientSide =
   exhibitionsFetcher.getByTypeClientSide;


### PR DESCRIPTION
Chipping away at https://github.com/wellcomecollection/wellcomecollection.org/issues/7363 and https://github.com/wellcomecollection/wellcomecollection.org/issues/7302

While looking at this, I'm pretty sure the UiExhibition type is redundant now, and we could flip everything over to Exhibition – but it'll be much easier to do that once the entire codebase is checked with TypeScript, so I'm not going to do that just now.