### PR TITLE
Start using the typed fetchers for events on some pages

### DIFF
--- a/common/services/prismic/events.js
+++ b/common/services/prismic/events.js
@@ -45,10 +45,10 @@ import isEmptyObj from '../../utils/is-empty-object';
 import { london } from '../../utils/format-date';
 import { isPast } from '../../utils/dates';
 
-const startField = 'my.events.times.startDateTime';
-const endField = 'my.events.times.endDateTime';
+export const startField = 'my.events.times.startDateTime';
+export const endField = 'my.events.times.endDateTime';
 
-const graphQuery = `{
+export const graphQuery = `{
   events {
     ...eventsFields
     format {

--- a/content/webapp/pages/whats-on.tsx
+++ b/content/webapp/pages/whats-on.tsx
@@ -8,7 +8,6 @@ import { PaginatedResults } from '@weco/common/services/prismic/types';
 import { classNames, font, grid, cssGrid } from '@weco/common/utils/classnames';
 import { getExhibitions } from '@weco/common/services/prismic/exhibitions';
 import { getPageFeaturedText } from '../services/prismic/transformers/pages';
-import { getEvents } from '@weco/common/services/prismic/events';
 import {
   filterEventsForToday,
   filterEventsForWeekend,
@@ -67,6 +66,9 @@ import { FeaturedCardExhibition } from '../components/FeaturedCard/FeaturedCard'
 import { fetchPage } from '../services/prismic/fetch/pages';
 import { createClient } from '../services/prismic/fetch';
 import { transformPage } from '../services/prismic/transformers/pages';
+import { fetchEvents } from 'services/prismic/fetch/events';
+import { transformQuery } from 'services/prismic/transformers/paginated-results';
+import { transformEvent } from 'services/prismic/transformers/events';
 
 const segmentedControlItems = [
   {
@@ -338,36 +340,37 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       memoizedPrismic
     );
 
-    const eventsPromise = getEvents(
-      context.req,
+    const eventsQueryPromise = fetchEvents(
+      client,
       {
         period: 'current-and-coming-up',
         pageSize: 100,
       },
-      memoizedPrismic
     );
 
-    const availableOnlineEventsPromise = getEvents(
-      context.req,
+    const availableOnlineEventsQueryPromise = fetchEvents(
+      client,
       {
         period: 'past',
         pageSize: 6,
         availableOnline: true,
       },
-      memoizedPrismic
     );
 
-    const [exhibitions, events, availableOnlineEvents, whatsOnPage] =
+    const [exhibitions, eventsQuery, availableOnlineEventsQuery, whatsOnPage] =
       await Promise.all([
         exhibitionsPromise,
-        eventsPromise,
-        availableOnlineEventsPromise,
+        eventsQueryPromise,
+        availableOnlineEventsQueryPromise,
         whatsOnPagePromise,
       ]);
 
     const dateRange = getMomentsForPeriod(period);
 
     const featuredText = whatsOnPage && getPageFeaturedText(transformPage(whatsOnPage));
+
+    const events = transformQuery(eventsQuery, transformEvent);
+    const availableOnlineEvents = transformQuery(availableOnlineEventsQuery, transformEvent);
 
     if (period && events && exhibitions) {
       return {

--- a/content/webapp/services/prismic/fetch/events.ts
+++ b/content/webapp/services/prismic/fetch/events.ts
@@ -2,7 +2,7 @@ import { fetcher, GetServerSidePropsPrismicClient } from '.';
 import { EventPrismicDocument, eventsFetchLinks } from '../types/events';
 import { Query } from '@prismicio/types';
 import { getPeriodPredicates } from '../types/predicates';
-import { startField, endField, graphQuery } from '@weco/common/services/prismic';
+import { startField, endField, graphQuery } from '@weco/common/services/prismic/events';
 import * as prismic from 'prismic-client-beta';
 
 const fetchLinks = eventsFetchLinks;
@@ -18,6 +18,7 @@ type FetchEventsQueryParams = {
   availableOnline?: boolean,
   page?: number,
   pageSize?: number,
+  orderings?: (prismic.Ordering | string)[];
 };
 
 export const fetchEvents = (
@@ -28,13 +29,14 @@ export const fetchEvents = (
     isOnline,
     availableOnline,
     page,
-    pageSize
+    pageSize,
+    orderings = []
   }: FetchEventsQueryParams
 ): Promise<Query<EventPrismicDocument>> => {
   const order = period === 'past' ? 'desc' : 'asc';
-  const orderings =
+  const startTimeOrderings =
     order === 'desc'
-      ? [{ field: 'my.events.times.startDateTime', order: 'desc' }]
+      ? [{ field: 'my.events.times.startDateTime', direction: 'desc' }] as prismic.Ordering[]
       : [];
 
   const dateRangePredicates = period
@@ -58,7 +60,10 @@ export const fetchEvents = (
         ...availableOnlinePredicates,
         ...predicates
       ],
-      orderings,
+      orderings: [
+        ...orderings,
+        ...startTimeOrderings,
+      ],
       page,
       pageSize,
       graphQuery

--- a/content/webapp/services/prismic/fetch/events.ts
+++ b/content/webapp/services/prismic/fetch/events.ts
@@ -43,12 +43,21 @@ export const fetchEvents = (
     ? getPeriodPredicates({ period, startField, endField })
     : [];
 
+  // NOTE: Ideally we'd use the Prismic DSL to construct these predicates rather
+  // than dropping in raw strings, but they interfere with the type checker.
+  //
+  // The current version of the Prismic libraries require the second argument of
+  // the 'at()' predicate to be a `string | number | (string | number)[]`, but they
+  // need to be booleans.
+  //
+  // TODO: When we upgrade the Prismic client libraries, convert these to the DSL.
+  // 
   const onlinePredicates = isOnline
-    ? [prismic.predicate.at('my.events.isOnline', true)]
+    ? ['[at("my.events.isOnline", true)]']
     : [];
 
   const availableOnlinePredicates = availableOnline
-    ? [prismic.predicate.at('my.events.availableOnline', true)]
+    ? ['[at("my.events.availableOnline", true)]']
     : [];
 
   return eventsFetcher.getByType(

--- a/content/webapp/services/prismic/fetch/events.ts
+++ b/content/webapp/services/prismic/fetch/events.ts
@@ -1,10 +1,69 @@
-import { fetcher } from '.';
+import { fetcher, GetServerSidePropsPrismicClient } from '.';
 import { EventPrismicDocument, eventsFetchLinks } from '../types/events';
+import { Query } from '@prismicio/types';
+import { getPeriodPredicates } from '../types/predicates';
+import { startField, endField, graphQuery } from '@weco/common/services/prismic';
+import * as prismic from 'prismic-client-beta';
 
 const fetchLinks = eventsFetchLinks;
 
 const eventsFetcher = fetcher<EventPrismicDocument>('events', fetchLinks);
 
 export const fetchEvent = eventsFetcher.getById;
-export const fetchEvents = eventsFetcher.getByType;
+
+type FetchEventsQueryParams = {
+  predicates?: string[];
+  period?: 'current-and-coming-up' | 'past',
+  isOnline?: boolean,
+  availableOnline?: boolean,
+  page?: number,
+  pageSize?: number,
+};
+
+export const fetchEvents = (
+  client: GetServerSidePropsPrismicClient,
+  {
+    predicates = [],
+    period,
+    isOnline,
+    availableOnline,
+    page,
+    pageSize
+  }: FetchEventsQueryParams
+): Promise<Query<EventPrismicDocument>> => {
+  const order = period === 'past' ? 'desc' : 'asc';
+  const orderings =
+    order === 'desc'
+      ? [{ field: 'my.events.times.startDateTime', order: 'desc' }]
+      : [];
+
+  const dateRangePredicates = period
+    ? getPeriodPredicates({ period, startField, endField })
+    : [];
+
+  const onlinePredicates = isOnline
+    ? [prismic.predicate.at('my.events.isOnline', true)]
+    : [];
+
+  const availableOnlinePredicates = availableOnline
+    ? [prismic.predicate.at('my.events.availableOnline', true)]
+    : [];
+
+  return eventsFetcher.getByType(
+    client,
+    {
+      predicates: [
+        ...dateRangePredicates,
+        ...onlinePredicates,
+        ...availableOnlinePredicates,
+        ...predicates
+      ],
+      orderings,
+      page,
+      pageSize,
+      graphQuery
+    }
+  )
+};
+
 export const fetchEventsClientSide = eventsFetcher.getByTypeClientSide;

--- a/content/webapp/services/prismic/types/events.ts
+++ b/content/webapp/services/prismic/types/events.ts
@@ -78,7 +78,7 @@ type EventPolicy = PrismicDocument<
   },
   'event-policies'
 >;
-const eventPoliciyFetchLink: FetchLinks<EventPolicy> = [
+const eventPolicyFetchLink: FetchLinks<EventPolicy> = [
   'event-policies.title',
   'event-policies.description',
 ];
@@ -184,7 +184,7 @@ export const eventsFetchLinks = [
   ...eventFormatFetchLink,
   ...interpretationTypeFetchLinks,
   ...audienceFetchLinks,
-  ...eventPoliciyFetchLink,
+  ...eventPolicyFetchLink,
   ...placesFetchLink,
   ...teamFetchLinks,
   ...backgroundTexturesFetchLink,


### PR DESCRIPTION
Continuing to chip away at https://github.com/wellcomecollection/wellcomecollection.org/issues/7363. I can't use this everywhere because one use is within a `useEffect()` and I haven't worked out how to used the typed fetchers in there yet, but this is still a step forward.

I've tested the changed pages locally, and I can see the right data coming through.