### PR TITLE
Improve the diffs when deploying the Prismic model

### DIFF
--- a/prismic-model/console.ts
+++ b/prismic-model/console.ts
@@ -5,5 +5,5 @@ export function success(message: string): void {
 }
 
 export function error(message: string): void {
-  console.error(chalk.redBright(message));
+  console.error(`!!! ${chalk.redBright(message)}`);
 }

--- a/prismic-model/deployType.ts
+++ b/prismic-model/deployType.ts
@@ -20,7 +20,7 @@ async function run() {
   const credentials = await getCreds('experience', 'developer');
   await setEnvsFromSecrets(secrets, credentials);
 
-  const remoteType: CustomType = await fetch(
+  const resp = await fetch(
     `https://customtypes.prismic.io/customtypes/${id}`,
     {
       headers: {
@@ -28,7 +28,14 @@ async function run() {
         repository: 'wellcomecollection',
       },
     }
-  ).then(resp => resp.json());
+  );
+
+  if (resp.status === 404) {
+    error(`Prismic does not know about a custom type '${id}'. Do you have the right name?`);
+    process.exit(1);
+  }
+
+  const remoteType: CustomType = await resp.json();
 
   const localType = (await import(`./src/${id}`)).default;
 

--- a/prismic-model/deployType.ts
+++ b/prismic-model/deployType.ts
@@ -2,11 +2,12 @@ import yargs from 'yargs';
 import fetch from 'node-fetch';
 import { setEnvsFromSecrets } from '@weco/ts-aws/secrets-manager';
 import { getCreds } from '@weco/ts-aws/sts';
-import * as jsondiffpatch from 'jsondiffpatch';
 import prompts from 'prompts';
 import { error, success } from './console';
 import { CustomType } from './src/types/CustomType';
 import { secrets } from './config';
+import { diffJson } from './differ'
+import chalk from 'chalk';
 
 const { id, argsConfirm } = yargs(process.argv.slice(2))
   .usage('Usage: $0 --id [customTypeId]')
@@ -39,11 +40,20 @@ async function run() {
 
   const localType = (await import(`./src/${id}`)).default;
 
-  const delta = jsondiffpatch.diff(remoteType, localType);
-  const diff = jsondiffpatch.formatters.console.format(delta, remoteType);
+  const delta = diffJson(remoteType, localType);
 
   console.info('------------------------');
-  console.info(diff);
+  
+  console.info("Only in the remote type; this will be deleted/changed:")
+  const remoteJson = JSON.stringify(delta.oldRecordOnly, null, 2)
+  console.log(chalk.red(remoteJson));
+  
+  console.info("");
+
+  console.info("Only in the local type; this will be added/updated:")
+  const localJson = JSON.stringify(delta.newRecordOnly, null, 2);
+  console.log(chalk.green(localJson));
+  
   console.info('------------------------');
 
   const { confirm } = argsConfirm

--- a/prismic-model/diffCustomTypes.ts
+++ b/prismic-model/diffCustomTypes.ts
@@ -1,10 +1,10 @@
 import { setEnvsFromSecrets } from '@weco/ts-aws/secrets-manager';
 import { getCreds } from '@weco/ts-aws/sts';
-import * as jsondiffpatch from 'jsondiffpatch';
 import fetch from 'node-fetch';
 import { CustomType } from './src/types/CustomType';
 import { error, success } from './console';
 import { isCi, secrets } from './config';
+import { diffJson, Delta, EmptyDelta } from './differ';
 
 export default async function diffContentTypes(credentials?): Promise<void> {
   await setEnvsFromSecrets(secrets, credentials);
@@ -29,14 +29,14 @@ export default async function diffContentTypes(credentials?): Promise<void> {
         const localCustomType = (await import(`./src/${remoteCustomType.id}`))
           .default;
 
-        const delta = jsondiffpatch.diff(remoteCustomType, localCustomType);
+        const delta = diffJson(remoteCustomType, localCustomType);
 
-        if (delta) {
+        if (delta !== EmptyDelta) {
           return { id: remoteCustomType.id, delta };
         }
       })
     )
-  ).filter(Boolean) as { id: string; delta: jsondiffpatch.Delta }[];
+  ).filter(Boolean) as { id: string; delta: Delta }[];
 
   if (deltas.length > 0) {
     error(`Diffs found on ${deltas.map(delta => delta.id).join(', ')}`);

--- a/prismic-model/differ.ts
+++ b/prismic-model/differ.ts
@@ -16,7 +16,7 @@
 //      }
 //
 
-type Delta = {
+export type Delta = {
   oldRecordOnly: Record<string, any>
   newRecordOnly: Record<string, any>
 }

--- a/prismic-model/differ.ts
+++ b/prismic-model/differ.ts
@@ -1,0 +1,74 @@
+// This is a very simple diffing tool for JSON.
+//
+// It works by "subtracting" common key/value pairs from two JSON objects, and returning
+// only the differing keys.
+//
+// e.g. if you had two JSON objects
+//
+//      {"name": "pentagon", "colour": "red", "sides": 5}
+//      {"name": "hexagon", "colour": "red", "sides": 6}
+//
+// then it would "subtract" the common `"colour": "red"` pair and return a diff:
+//
+//      {
+//        oldRecordOnly: {"name": "pentagon", "sides": 5},
+//        newRecordOnly: {"name": "hexagon", "sides": 6}
+//      }
+//
+
+type Delta = {
+  oldRecordOnly: Record<string, any>
+  newRecordOnly: Record<string, any>
+}
+
+export const EmptyDelta = {
+  oldRecordOnly: {},
+  newRecordOnly: {},
+};
+
+export const diffJson = (oldR: Object, newR: Object): Delta => {
+
+  // If they're the same, there's nothing to do!
+  if (oldR === newR) {
+    return EmptyDelta;
+  }
+
+  let oldRecordOnly = {};
+  let newRecordOnly = {};
+  
+  for (const key of Object.keys(oldR)) {
+    // If both objects have the key and it's the same, there's nothing to do
+    //
+    // Casting them to JSON (which is where they started) and comparing strings is
+    // easier than doing object comparisons in JavaScript.
+    if (key in newR && JSON.stringify(newR[key]) == JSON.stringify(oldR[key])) {
+      continue;
+    }
+    // If the keys have different values and they're both objects, recurse down
+    // and compute another diff
+    else if (key in newR && typeof oldR[key] === 'object' && typeof newR[key] === 'object') {
+      const delta = diffJson(oldR[key], newR[key]);
+
+      oldRecordOnly[key] = delta.oldRecordOnly;
+      newRecordOnly[key] = delta.newRecordOnly;
+    }
+    // If the keys have different values and they're not objects, record their
+    // value and move on.
+    else if (key in newR) {
+      oldRecordOnly[key] = oldR[key];
+      newRecordOnly[key] = newR[key];
+    }
+    // Otherwise the key isn't in the new record at all, so record that.
+    else {
+      oldRecordOnly[key] = oldR[key];
+    }
+  }
+  
+  for (const key of Object.keys(newR)) {
+    if (!(key in oldR)) {
+      newRecordOnly[key] = newR[key];
+    }
+  }
+
+  return { oldRecordOnly, newRecordOnly };
+}

--- a/prismic-model/package.json
+++ b/prismic-model/package.json
@@ -19,7 +19,6 @@
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
     "chalk": "^4.1.2",
-    "jsondiffpatch": "^0.4.1",
     "node-fetch": "2",
     "prompts": "^2.4.2",
     "ts-node": "^10.4.0",

--- a/prismic-model/package.json
+++ b/prismic-model/package.json
@@ -4,6 +4,7 @@
     "deployType": "ts-node deployType",
     "diffCustomTypes": "ts-node diffCustomTypes"
   },
+  "license": "MIT",
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "^3.40.0",
     "@aws-sdk/client-sts": "^3.40.0",

--- a/prismic-model/yarn.lock
+++ b/prismic-model/yarn.lock
@@ -687,13 +687,6 @@ ansi-styles@^2.2.1:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
   integrity sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=
 
-ansi-styles@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
-  integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
-  dependencies:
-    color-convert "^1.9.0"
-
 ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
@@ -1506,15 +1499,6 @@ chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.3.0:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
-  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
-  dependencies:
-    ansi-styles "^3.2.1"
-    escape-string-regexp "^1.0.5"
-    supports-color "^5.3.0"
-
 chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
@@ -1566,24 +1550,12 @@ collection-visit@^1.0.0:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
-color-convert@^1.9.0:
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
-  integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
-  dependencies:
-    color-name "1.1.3"
-
 color-convert@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
   integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
   dependencies:
     color-name "~1.1.4"
-
-color-name@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
-  integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
 color-name@~1.1.4:
   version "1.1.4"
@@ -1680,11 +1652,6 @@ detect-indent@^4.0.0:
   dependencies:
     repeating "^2.0.0"
 
-diff-match-patch@^1.0.0:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/diff-match-patch/-/diff-match-patch-1.0.5.tgz#abb584d5f10cd1196dfc55aa03701592ae3f7b37"
-  integrity sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==
-
 diff@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
@@ -1710,7 +1677,7 @@ escalade@^3.1.1:
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
   integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
 
-escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
+escape-string-regexp@^1.0.2:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
@@ -1909,11 +1876,6 @@ has-ansi@^2.0.0:
   integrity sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=
   dependencies:
     ansi-regex "^2.0.0"
-
-has-flag@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
-  integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
 
 has-flag@^4.0.0:
   version "4.0.0"
@@ -2165,14 +2127,6 @@ json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
   integrity sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=
-
-jsondiffpatch@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/jsondiffpatch/-/jsondiffpatch-0.4.1.tgz#9fb085036767f03534ebd46dcd841df6070c5773"
-  integrity sha512-t0etAxTUk1w5MYdNOkZBZ8rvYYN5iL+2dHCCx/DpkFm/bW28M6y5nUS83D4XdZiHy35Fpaw6LBb+F88fHZnVCw==
-  dependencies:
-    chalk "^2.3.0"
-    diff-match-patch "^1.0.0"
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
@@ -2730,13 +2684,6 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
   integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
-
-supports-color@^5.3.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
-  integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
-  dependencies:
-    has-flag "^3.0.0"
 
 supports-color@^7.1.0:
   version "7.2.0"


### PR DESCRIPTION
Previously, running the Prismic deploy tool would dump the *entire model* into your terminal when asking you to compare the diff. This is less than helpful for spotting changes:

<img width="852" alt="Screenshot 2022-01-28 at 09 45 52" src="https://user-images.githubusercontent.com/301220/151525327-91244f3b-fc7a-482a-a7d6-e29f5dad8dc4.png">

You had to scroll around to find the changes, and then when you did, they're only distinguished by red/green, so it's inaccessible:

<img width="852" alt="Screenshot 2022-01-28 at 09 45 59" src="https://user-images.githubusercontent.com/301220/151525577-bf4f47ea-1a01-4abc-9608-3834aae75e44.png">

I couldn't work out how to write a formatter for the custom library (the format is a bit weird), so I ripped it out and wrote my own differ. It's quite conservative; it works by "subtracting" values that are the same in both objects, and showing you what's left. This is what the output looks like now:

<img width="852" alt="Screenshot 2022-01-28 at 09 46 35" src="https://user-images.githubusercontent.com/301220/151525680-7f303610-163d-4089-88de-31bce5d37a9f.png">

Benefits:

* It's much shorter (so we'll actually read it)
* If you're colourblind, the text above the two JSON blobs will tell you what's going on
* You can see the JSON keys that lead to a particular change