### PR TITLE
Use the nice typed fetchers for articles

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -56,6 +56,7 @@
     "nprogress": "^0.2.0",
     "openseadragon": "^2.4.0",
     "prismic-client-beta": "npm:@prismicio/client@beta",
+    "prismic-helpers-beta": "npm:@prismicio/helpers@beta",
     "prismic-dom": "^2.2.6",
     "prismic-reactjs": "^1.3.4",
     "raven-js": "^3.26.3",

--- a/content/webapp/services/prismic/fetch/articles.ts
+++ b/content/webapp/services/prismic/fetch/articles.ts
@@ -1,97 +1,24 @@
-// TODO: It should be possible to drastically simplify this by using a vanilla
-// fetcher, and passing multiple content types (cf. pages.ts).
-//
-// For some reason, whenever I try using it (or adding any fetcher to this file),
-// I get an error from the type checker:
-//
-//      ../../node_modules/prismic-client-beta/dist/index.mjs
-//      Attempted import error: 'asLink' is not exported from '@prismicio/helpers' (imported as 'prismicH').
-//
-// e.g. the following line, which we know works because it compiles perfectly in
-// another file:
-//
-//      const booksFetcher = fetcher<BookPrismicDocument>('books', fetchLinks);
-//
-// will cause the error.
-//
-// I've given up trying to fix this today, but we should come back and resolve it
-// rather than putting new logic in this file.
-//
-// This may get fixed when we update our Prismic API client libraries.
-// See https://github.com/wellcomecollection/wellcomecollection.org/issues/7595
-
 import { Query } from '@prismicio/types';
-import { GetServerSidePropsPrismicClient } from '.';
+import { GetServerSidePropsPrismicClient, GetByTypeParams, fetcher } from '.';
 import { ArticlePrismicDocument, articlesFetchLinks } from '../types/articles';
-import { graphQuery } from '@weco/common/services/prismic/articles';
+import { ContentType } from '../link-resolver';
 
+const contentTypes = ['articles', 'webcomics'];
 const fetchLinks = articlesFetchLinks;
 
-// For other types we use fetcher.getById (see e.g. books.ts).
-//
-// That method looks for matching documents with a single type (e.g. document.type === 'books');
-// because an article can have two types, we can't use that here.
-export async function fetchArticle(
-  { client }: GetServerSidePropsPrismicClient,
-  id: string
-): Promise<ArticlePrismicDocument | undefined> {
-  try {
-    const document = await client.getByID<ArticlePrismicDocument>(id, {
-      fetchLinks,
-    });
+const articlesFetcher = fetcher<ArticlePrismicDocument>(contentTypes as ContentType[], fetchLinks);
 
-    if (document.type === 'articles' || document.type === 'webcomics') {
-      return document;
-    }
-  } catch {}
-}
+export const fetchArticle = articlesFetcher.getById;
 
-type Params = Parameters<
-  GetServerSidePropsPrismicClient['client']['getByType']
->[1];
-export async function fetchArticles(
-  { client }: GetServerSidePropsPrismicClient,
-  params: Params = {}
-): Promise<Query<ArticlePrismicDocument>> {
-  const orderings = ['document.first_publication_date desc'];
-  
-  /**
-   * articles and webcomics share the same functionality as we
-   * can't change the types of documents in Prismic.
-   *
-   * We thus have to fetch both here
-   * {@link} https://community.prismic.io/t/import-export-change-type-of-imported-document/7814
-   */
-  const articleAndWebcomicPredicate =
-    '[any(document.type, ["articles", "webcomics"])]';
-
-  const document = await client.get<ArticlePrismicDocument>({
-    fetchLinks,
-    orderings,
-    graphQuery,
+export const fetchArticles = (
+  client: GetServerSidePropsPrismicClient,
+  params: GetByTypeParams = {}
+): Promise<Query<ArticlePrismicDocument>> => {
+  return articlesFetcher.getByType(client, {
     ...params,
-    predicates: [articleAndWebcomicPredicate, ...(params.predicates ?? [])],
+    orderings: [
+      { field: 'document.first_publication_date', direction: 'desc' },
+    ],
   });
-
-  return document;
-}
-
-export async function fetchArticlesClientSide(
-  params?: Params
-): Promise<Query<ArticlePrismicDocument> | undefined> {
-  // If you add more parameters here, you have to update the corresponding cache behaviour
-  // in the CloudFront distribution, or you may get incorrect behaviour.
-  //
-  // e.g. at one point we forgot to include the "params" query in the cache key,
-  // so every article was showing the same set of related stories.
-  //
-  // See https://github.com/wellcomecollection/wellcomecollection.org/issues
-  const urlSearchParams = new URLSearchParams();
-  urlSearchParams.set('params', JSON.stringify(params));
-  const response = await fetch(`/api/articles?${urlSearchParams.toString()}`);
-
-  if (response.ok) {
-    const json = await response.json();
-    return json;
-  }
-}
+};
+export const fetchArticlesClientSide = articlesFetcher.getByTypeClientSide;

--- a/content/webapp/services/prismic/fetch/index.ts
+++ b/content/webapp/services/prismic/fetch/index.ts
@@ -77,10 +77,9 @@ export function fetcher<Document extends PrismicDocument>(
         // it matches the content type.  So e.g. going to /events/<exhibition ID> will
         // return a 404, rather than a 500 as we find we're missing a bunch of fields
         // we need to render the page.
-        const predicates =
-          isString(contentType) 
-            ? [prismic.predicate.at('document.type', contentType)]
-            : [prismic.predicate.any('document.type', contentType)];
+        const predicates = isString(contentType)
+          ? [prismic.predicate.at('document.type', contentType)]
+          : [prismic.predicate.any('document.type', contentType)];
 
         return await client.getByID<Document>(id, {
           fetchLinks,
@@ -90,11 +89,11 @@ export function fetcher<Document extends PrismicDocument>(
     },
 
     /** Get all the documents of a given type.
-      * 
-      * If `contentType` is an array, this fetches all the documents of any specified type.
-      * This is useful if we use the same fetch/transform method for multiple documents with
-      * different types in Prismic, e.g. articles which could be 'article' or 'webcomic'.
-      */
+     *
+     * If `contentType` is an array, this fetches all the documents of any specified type.
+     * This is useful if we use the same fetch/transform method for multiple documents with
+     * different types in Prismic, e.g. articles which could be 'article' or 'webcomic'.
+     */
     getByType: async (
       { client }: GetServerSidePropsPrismicClient,
       params: GetByTypeParams = {}
@@ -105,14 +104,13 @@ export function fetcher<Document extends PrismicDocument>(
         ? params.predicates
         : [];
 
-      const response =
-        isString(contentType)
-          ? await client.getByType<Document>(contentType, {
+      const response = isString(contentType)
+        ? await client.getByType<Document>(contentType, {
             ...params,
             fetchLinks,
             predicates: [...predicates, delistPredicate],
           })
-          : await client.get<Document>({
+        : await client.get<Document>({
             ...params,
             fetchLinks,
             predicates: [
@@ -138,10 +136,11 @@ export function fetcher<Document extends PrismicDocument>(
       const urlSearchParams = new URLSearchParams();
       urlSearchParams.set('params', JSON.stringify(params));
 
-      const url =
-        isString(contentType)
-          ? `/api/${contentType[0]}?${urlSearchParams.toString()}`
-          : `/api/${contentType}?${urlSearchParams.toString()}`;
+      // If we have multiple content types, just query on the first one client-side.
+      // It's not ideal, but I can't think of an easy and better way to do this right now.
+      const url = isString(contentType)
+        ? `/api/${contentType}?${urlSearchParams.toString()}`
+        : `/api/${contentType[0]}?${urlSearchParams.toString()}`;
 
       const response = await fetch(url);
 

--- a/content/webapp/services/prismic/fetch/index.ts
+++ b/content/webapp/services/prismic/fetch/index.ts
@@ -137,9 +137,13 @@ export function fetcher<Document extends PrismicDocument>(
       // See https://github.com/wellcomecollection/wellcomecollection.org/issues
       const urlSearchParams = new URLSearchParams();
       urlSearchParams.set('params', JSON.stringify(params));
-      const response = await fetch(
-        `/api/${contentType}?${urlSearchParams.toString()}`
-      );
+
+      const url =
+        isString(contentType)
+          ? `/api/${contentType[0]}?${urlSearchParams.toString()}`
+          : `/api/${contentType}?${urlSearchParams.toString()}`;
+
+      const response = await fetch(url);
 
       if (response.ok) {
         const json: Query<Document> = await response.json();

--- a/yarn.lock
+++ b/yarn.lock
@@ -14567,7 +14567,7 @@ pretty-hrtime@^1.0.3:
   resolved "https://registry.yarnpkg.com/@prismicio/client/-/client-6.0.0-beta.3.tgz#848876d236730eb6503fc7541f17000f19a10114"
   integrity sha512-AZn0u5Ah6q4PGAlGvKyVSv3OfAbM1DjGpbZWedkMiBGJ6t/tB5GyaIh2Znsfdkw8QuL80041yURdsGXaQeE2HQ==
   dependencies:
-    "@prismicio/helpers" "^2.0.0-beta.0"
+    "@prismicio/helpers" "^2.0.0-beta.3"
     "@prismicio/types" "^0.1.15"
 
 prismic-dom@^2.2.6:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3239,14 +3239,13 @@
   resolved "https://registry.yarnpkg.com/@prismicio/helpers/-/helpers-1.0.5.tgz#2be60a1b44e6c33d7918fa74fe67648dc8af0c15"
   integrity sha512-TPpuAFHNxlCTrEihHnRKcq6zc0oZV0sfz5/iHoSpl5vorwPbwZWiF88JGeflNdefW4A69b5A3x3mfptKPdpoxg==
 
-"@prismicio/helpers@^2.0.0-beta.0", "prismic-helpers-beta@npm:@prismicio/helpers@beta":
-  name prismic-helpers-beta
-  version "2.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@prismicio/helpers/-/helpers-2.0.0-beta.3.tgz#510d483d1cebab1d963eba08ef1bfae9820fd4eb"
-  integrity sha512-YaMRZ6JBb9f/+BXWq9V+xSQGOnWK3+8ebKi9GSeOjit+JOEZDSBn0hE87j6X7wp8cG5KTqXyBXsmd2vOh8IhdA==
+"@prismicio/helpers@^2.0.0-beta.0":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@prismicio/helpers/-/helpers-2.0.1.tgz#f2fee681adccac3955363a35301c54bd51031d37"
+  integrity sha512-MDy3VClwXSy3itmLLThrg+010+TBp77wC/ATM4eUYc4XprPrwJnE3hCsmztxrm+hN8ZxS0cu2KnNDahRMts1jA==
   dependencies:
-    "@prismicio/richtext" "^2.0.0-beta.1"
-    "@prismicio/types" "^0.1.17"
+    "@prismicio/richtext" "^2.0.1"
+    "@prismicio/types" "^0.1.22"
     escape-html "^1.0.3"
 
 "@prismicio/richtext@^1.1.0":
@@ -3261,10 +3260,22 @@
   dependencies:
     "@prismicio/types" "^0.1.15"
 
+"@prismicio/richtext@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@prismicio/richtext/-/richtext-2.0.1.tgz#6342f071601d88e99ca03faab382202087fd55a5"
+  integrity sha512-sM+eusvE4PsKnwefDRd0ai3Ny59XJ54dn6xfwq0Fyqj0LAcuyB2gRjSufbIqYOZ1r4JKMQArDKrypNEcrbBFkA==
+  dependencies:
+    "@prismicio/types" "^0.1.22"
+
 "@prismicio/types@^0.1.15", "@prismicio/types@^0.1.17":
   version "0.1.17"
   resolved "https://registry.yarnpkg.com/@prismicio/types/-/types-0.1.17.tgz#79979e2f98297c04fe0869bf80be224d9f120a4d"
   integrity sha512-zjzuBT3vpYSA8rkWztJ8S1u0Qsu0pE1casSEblBMeoml6IjDoDVSaRZ6jftAxmkwhiuK6Rg/k3JkFDVSYELO+Q==
+
+"@prismicio/types@^0.1.22":
+  version "0.1.22"
+  resolved "https://registry.yarnpkg.com/@prismicio/types/-/types-0.1.22.tgz#fd8e6e419b002ec90ff9ed8e579a1ecce6e5bb80"
+  integrity sha512-lA2tDAN/4rSou/D1ZNMJEytqyl8MGdO1jX3e+u37t2MpQgPUXj30j7qVdhfTcimIlDgKCAB3oyVmJw/RA8n6Kg==
 
 "@reach/router@^1.3.4":
   version "1.3.4"
@@ -14567,7 +14578,7 @@ pretty-hrtime@^1.0.3:
   resolved "https://registry.yarnpkg.com/@prismicio/client/-/client-6.0.0-beta.3.tgz#848876d236730eb6503fc7541f17000f19a10114"
   integrity sha512-AZn0u5Ah6q4PGAlGvKyVSv3OfAbM1DjGpbZWedkMiBGJ6t/tB5GyaIh2Znsfdkw8QuL80041yURdsGXaQeE2HQ==
   dependencies:
-    "@prismicio/helpers" "^2.0.0-beta.3"
+    "@prismicio/helpers" "^2.0.0-beta.0"
     "@prismicio/types" "^0.1.15"
 
 prismic-dom@^2.2.6:
@@ -14578,6 +14589,15 @@ prismic-dom@^2.2.6:
     "@prismicio/helpers" "^1.0.4"
     "@prismicio/richtext" "^1.1.0"
     escape-html "1.0.3"
+
+"prismic-helpers-beta@npm:@prismicio/helpers@beta":
+  version "2.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@prismicio/helpers/-/helpers-2.0.0-beta.3.tgz#510d483d1cebab1d963eba08ef1bfae9820fd4eb"
+  integrity sha512-YaMRZ6JBb9f/+BXWq9V+xSQGOnWK3+8ebKi9GSeOjit+JOEZDSBn0hE87j6X7wp8cG5KTqXyBXsmd2vOh8IhdA==
+  dependencies:
+    "@prismicio/richtext" "^2.0.0-beta.1"
+    "@prismicio/types" "^0.1.17"
+    escape-html "^1.0.3"
 
 prismic-helpers@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
For https://github.com/wellcomecollection/wellcomecollection.org/issues/7363 / https://github.com/wellcomecollection/wellcomecollection.org/issues/7426

I don't actually expect this to work, because it keeps failing with this error:

```
$ yarn build
yarn run v1.22.10
$ next build
info  - Using webpack 5. Reason: Enabled by default https://nextjs.org/docs/messages/webpack5
info  - Checking validity of types
info  - Using external babel configuration from /Users/alexwlchan/repos/dotorg/content/webapp/babel.config.js
info  - Creating an optimized production build
Failed to compile.

../../node_modules/prismic-client-beta/dist/index.mjs
Attempted import error: 'asLink' is not exported from '@prismicio/helpers' (imported as 'prismicH').


> Build error occurred
Error: > Build failed because of webpack errors
    at /Users/alexwlchan/repos/dotorg/node_modules/next/dist/build/index.js:397:19
    at async Span.traceAsyncFn (/Users/alexwlchan/repos/dotorg/node_modules/next/dist/telemetry/trace/trace.js:60:20)
    at async Object.build [as default] (/Users/alexwlchan/repos/dotorg/node_modules/next/dist/build/index.js:77:25)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

I'm struggling to work out why this change triggers this behaviour, so leaving it here to stare at for a bit and see if anybody else has a thought on what I've done wrong.