### PR TITLE
Don't throw a 500 error on /article-series, /exhibition or /event-series

### DIFF
--- a/.buildkite/expected_404_urls.txt
+++ b/.buildkite/expected_404_urls.txt
@@ -13,3 +13,6 @@
 
 # This is a real Prismic ID, but it's an exhibition, not an event
 /events/YZYdQxEAACQAVm7b
+
+# Ignore requests for bare types
+/event-series

--- a/.buildkite/expected_404_urls.txt
+++ b/.buildkite/expected_404_urls.txt
@@ -16,3 +16,7 @@
 
 # Ignore requests for bare types
 /event-series
+
+# Weird characters in the Prismic ID
+# See https://github.com/wellcomecollection/wellcomecollection.org/issues/7611
+/exhibitions/states-mind-tracing-edges-consciousness%22

--- a/catalogue/webapp/pages/image.tsx
+++ b/catalogue/webapp/pages/image.tsx
@@ -16,6 +16,7 @@ import { removeUndefinedProps } from '@weco/common/utils/json';
 import { getWork } from '../services/catalogue/works';
 import { getImage } from '../services/catalogue/images';
 import { getServerData } from '@weco/common/server-data';
+import { isString } from '@weco/common/utils/array';
 
 type Props = {
   image: Image;
@@ -107,7 +108,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     const serverData = await getServerData(context);
     const { id, workId } = context.query;
 
-    if (typeof id !== 'string') {
+    if (!isString(id)) {
       return { notFound: true };
     }
 

--- a/catalogue/webapp/pages/work.tsx
+++ b/catalogue/webapp/pages/work.tsx
@@ -9,6 +9,7 @@ import {
 import { getServerData } from '@weco/common/server-data';
 import Work from '../components/Work/Work';
 import { getWork } from '../services/catalogue/works';
+import { isString } from '@weco/common/utils/array';
 
 type Props = {
   workResponse: WorkType;
@@ -25,7 +26,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     const serverData = await getServerData(context);
     const { id } = context.query;
 
-    if (typeof id !== 'string') {
+    if (!isString(id)) {
       return { notFound: true };
     }
 

--- a/content/webapp/pages/article-series.tsx
+++ b/content/webapp/pages/article-series.tsx
@@ -18,6 +18,7 @@ import { getServerData } from '@weco/common/server-data';
 import Body from '../components/Body/Body';
 import SearchResults from '../components/SearchResults/SearchResults';
 import ContentPage from '../components/ContentPage/ContentPage';
+import { looksLikePrismicId } from '../services/prismic';
 
 type Props = {
   series: ArticleSeries;
@@ -28,6 +29,11 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
     const serverData = await getServerData(context);
     const { id, memoizedPrismic } = context.query;
+
+    if (!looksLikePrismicId(id)) {
+      return { notFound: true };
+    }
+
     const seriesAndArticles = await getArticleSeries(
       context.req,
       {

--- a/content/webapp/pages/article.tsx
+++ b/content/webapp/pages/article.tsx
@@ -18,7 +18,6 @@ import Space from '@weco/common/views/components/styled/Space';
 import { AppErrorProps, WithGaDimensions } from '@weco/common/views/pages/_app';
 import { removeUndefinedProps } from '@weco/common/utils/json';
 import { getServerData } from '@weco/common/server-data';
-import { isString } from '@weco/common/utils/array';
 import PageHeaderStandfirst from '../components/PageHeaderStandfirst/PageHeaderStandfirst';
 import SeriesNavigation from '../components/SeriesNavigation/SeriesNavigation';
 import Body from '../components/Body/Body';
@@ -30,6 +29,7 @@ import {
 } from '../services/prismic/fetch/articles';
 import { transformContributors } from '../services/prismic/transformers/contributors';
 import { articleLd } from '../services/prismic/transformers/json-ld';
+import { looksLikePrismicId } from 'services/prismic';
 
 type Props = {
   article: Article;
@@ -44,12 +44,12 @@ function articleHasOutro(article: Article) {
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
     const { id } = context.query;
-    if (!isString(id)) {
+    if (!looksLikePrismicId(id)) {
       return { notFound: true };
     }
 
     const client = createClient(context);
-    const articleDocument = await fetchArticle(client, id);
+    const articleDocument = await fetchArticle(client, id as string);
     const serverData = await getServerData(context);
 
     if (articleDocument) {

--- a/content/webapp/pages/book.tsx
+++ b/content/webapp/pages/book.tsx
@@ -12,13 +12,13 @@ import styled from 'styled-components';
 import { AppErrorProps, WithGaDimensions } from '@weco/common/views/pages/_app';
 import { removeUndefinedProps } from '@weco/common/utils/json';
 import { getServerData } from '@weco/common/server-data';
-import { isString } from '@weco/common/utils/array';
 import Body from '../components/Body/Body';
 import ContentPage from '../components/ContentPage/ContentPage';
 import { fetchBook } from '../services/prismic/fetch/books';
 import { createClient } from '../services/prismic/fetch';
 import { transformBook } from '../services/prismic/transformers/books';
 import { Book } from '../types/books';
+import { looksLikePrismicId } from '../services/prismic';
 
 const MetadataWrapper = styled.div`
   border-top: 1px solid ${props => props.theme.color('smoke')};
@@ -71,11 +71,11 @@ const BookMetadata = ({ book }: BookMetadataProps) => (
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
     const { id } = context.query;
-    if (!isString(id)) {
+    if (!looksLikePrismicId(id)) {
       return { notFound: true };
     }
     const client = createClient(context);
-    const bookDocument = await fetchBook(client, id);
+    const bookDocument = await fetchBook(client, id as string);
 
     if (bookDocument) {
       const serverData = await getServerData(context);

--- a/content/webapp/pages/event-series.tsx
+++ b/content/webapp/pages/event-series.tsx
@@ -18,6 +18,7 @@ import Body from '../components/Body/Body';
 import ContentPage from '../components/ContentPage/ContentPage';
 import SearchResults from '../components/SearchResults/SearchResults';
 import { eventLd } from '../services/prismic/transformers/json-ld';
+import { looksLikePrismicId } from '../services/prismic';
 
 type Props = {
   series: EventSeries;
@@ -28,6 +29,11 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
     const serverData = await getServerData(context);
     const { id, memoizedPrismic } = context.query;
+
+    if (!looksLikePrismicId(id)) {
+      return { notFound: true };
+    }
+
     const seriesAndEvents = await getEventSeries(
       context.req,
       {

--- a/content/webapp/pages/exhibition.tsx
+++ b/content/webapp/pages/exhibition.tsx
@@ -12,6 +12,7 @@ import { fetchExhibition } from 'services/prismic/fetch/exhibitions';
 import { transformQuery } from 'services/prismic/transformers/paginated-results';
 import { transformPage } from 'services/prismic/transformers/pages';
 import { transformExhibition } from 'services/prismic/transformers/exhibitions';
+import { looksLikePrismicId } from '../services/prismic';
 
 type Props = {
   exhibition: UiExhibition;
@@ -30,6 +31,10 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
     const serverData = await getServerData(context);
     const { id } = context.query;
+
+    if (!looksLikePrismicId(id)) {
+      return { notFound: true };
+    }
 
     const client = createClient(context);
     const { exhibition, pages } = await fetchExhibition(client, id as string);

--- a/content/webapp/pages/season.tsx
+++ b/content/webapp/pages/season.tsx
@@ -158,7 +158,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       predicates: [`[at(my.series.seasons.season, "${id}")]`],
     });
 
-    const seasonDocPromise = fetchSeason(client, id);
+    const seasonDocPromise = fetchSeason(client, id as string);
 
     const [
       articlesQuery,

--- a/content/webapp/pages/season.tsx
+++ b/content/webapp/pages/season.tsx
@@ -23,7 +23,6 @@ import { fetchPages } from '../services/prismic/fetch/pages';
 import { fetchProjects } from '../services/prismic/fetch/projects';
 import { fetchSeries } from '../services/prismic/fetch/series';
 import { fetchSeason } from '../services/prismic/fetch/seasons';
-import { isString } from '@weco/common/utils/array';
 import { createClient } from '../services/prismic/fetch';
 import { transformQuery } from '../services/prismic/transformers/paginated-results';
 import { transformArticle } from '../services/prismic/transformers/articles';
@@ -41,6 +40,7 @@ import { Exhibition } from '../types/exhibitions';
 import { Page } from '../types/pages';
 import { Project } from '../types/projects';
 import { Series } from '../types/series';
+import { looksLikePrismicId } from '../services/prismic';
 
 type Props = {
   season: Season;
@@ -129,7 +129,7 @@ const SeasonPage = ({
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
     const { id } = context.query;
-    if (!isString(id)) {
+    if (!looksLikePrismicId(id)) {
       return { notFound: true };
     }
 

--- a/content/webapp/services/prismic/index.ts
+++ b/content/webapp/services/prismic/index.ts
@@ -7,10 +7,10 @@
 // e.g. an empty string definitely isn't a Prismic ID.
 //
 // This is useful for rejecting queries that are obviously malformed, which might
+// be attempts to inject malicious data into Prismic queries.
 
 import { isString } from '@weco/common/utils/array';
 
-// be attempts to inject malicious data into Prismic queries.
 export const looksLikePrismicId = (
   id: string | string[] | undefined
 ): boolean => (isString(id) ? /^([A-Za-z0-9-_]+)$/.test(id) : false);

--- a/content/webapp/services/prismic/index.ts
+++ b/content/webapp/services/prismic/index.ts
@@ -1,0 +1,16 @@
+// Returns true if a query parameter is plausibly a Prismic ID, false otherwise.
+//
+// There's no way for the front-end to know what strings are valid Prismic IDs
+// (only Prismic itself knows that), but it can reject certain classes of
+// strings that it knows definitely aren't.
+//
+// e.g. an empty string definitely isn't a Prismic ID.
+//
+// This is useful for rejecting queries that are obviously malformed, which might
+
+import { isString } from '@weco/common/utils/array';
+
+// be attempts to inject malicious data into Prismic queries.
+export const looksLikePrismicId = (
+  id: string | string[] | undefined
+): boolean => (isString(id) ? /^([A-Za-z0-9-_]+)$/.test(id) : false);


### PR DESCRIPTION
You can get a 500 error by visiting any of those URLs:

https://wellcomecollection.org/article-series
https://wellcomecollection.org/event-series
https://wellcomecollection.org/exhibition

This is because on those pages, we expect to get an ID (e.g. `/pages/YE99nRAAACMAb7YE`), but in these cases we extract the ID from the URL parameters as `id = undefined`. This explodes when you try to pass it to the Prismic predicate.

This patch updates these URLs so that if we spot we're getting something which definitely isn't a Prismic ID, we return a 404 immediately rather than waiting to go to Prismic. As a neat bonus, this should reduce the potential risk of malicious URLs doing something funky in a Prismic query, because they'll never go that far. (We have seen URL paths that have caused the Prismic API to return 4xx errors.)

Note that the new, typed Prismic fetchers will enforce some good habits here – the `getById()` API expects a string, so it reminds us that we need to make sure `id` really is a string.

Longer term we might want to review how we do this and make it consistent across the board (e.g. how we have a `getPage()` for getting the `page` from the URL query parameters), but that's a bigger piece of work - for now I just want to stem another source of 500 errors. I suspect we'll have better ways to do this once the Prismic refactoring is done.

Closes #7611, although that wasn't the original intention.