### PR TITLE
Use the typed fetchers for children/siblings of pages

### DIFF
--- a/common/model/siblings-group.js
+++ b/common/model/siblings-group.js
@@ -1,7 +1,0 @@
-import type { Page } from './pages';
-
-export type SiblingsGroup = {|
-  id: string,
-  title: string,
-  siblings: Page[],
-|};

--- a/common/model/siblings-group.ts
+++ b/common/model/siblings-group.ts
@@ -1,7 +1,5 @@
-import { Page } from './pages';
-
-export type SiblingsGroup = {
+export type SiblingsGroup<T> = {
   id: string;
   title: string;
-  siblings: Page[];
+  siblings: T[];
 };

--- a/common/services/prismic/pages.js
+++ b/common/services/prismic/pages.js
@@ -151,30 +151,3 @@ export async function getPageSiblings(
   });
   return siblingsWithLandingTitle;
 }
-
-export async function getChildren(
-  page: Page,
-  req: ?Request,
-  memoizedPrismic: ?Object
-): Promise<SiblingsGroup> {
-  try {
-    const children = await getPages(
-      req,
-      {
-        predicates: [Prismic.Predicates.at('my.pages.parents.parent', page.id)],
-      },
-      memoizedPrismic
-    );
-    return {
-      id: page.id,
-      title: page.title,
-      siblings: children.results || [],
-    };
-  } catch (e) {
-    return {
-      id: page.id,
-      title: page.title,
-      siblings: [],
-    };
-  }
-}

--- a/common/services/prismic/pages.js
+++ b/common/services/prismic/pages.js
@@ -1,6 +1,4 @@
 // @flow
-import Prismic from '@prismicio/client';
-import { getDocuments } from './api';
 import {
   parseTimestamp,
   parseGenericFields,
@@ -13,25 +11,7 @@ import { parseSeason } from './seasons';
 // $FlowFixMe (tsx)
 import { links } from '../../views/components/Header/Header';
 import type { Page } from '../../model/pages';
-import type { SiblingsGroup } from '../../model/siblings-group';
-import type { PrismicDocument, PaginatedResults } from './types';
-import {
-  articleSeriesFields,
-  pagesFields,
-  collectionVenuesFields,
-  eventSeriesFields,
-  exhibitionFields,
-  teamsFields,
-  eventsFields,
-  cardsFields,
-  eventFormatsFields,
-  articleFormatsFields,
-  labelsFields,
-  seasonsFields,
-  contributorsFields,
-  peopleFields,
-  bookFields,
-} from './fetch-links';
+import type { PrismicDocument } from './types';
 
 export function parsePage(document: PrismicDocument): Page {
   const { data } = document;
@@ -67,87 +47,4 @@ export function parsePage(document: PrismicDocument): Page {
     siteSection: siteSection,
     prismicDocument: document,
   };
-}
-
-type Order = 'desc' | 'asc';
-type GetPagesProps = {|
-  predicates?: Prismic.Predicates[],
-  order?: Order,
-  page?: number,
-  pageSize?: number,
-|};
-
-export async function getPages(
-  req: ?Request,
-  {
-    predicates = [],
-    order = 'desc',
-    page = 1,
-    pageSize = 100,
-  }: GetPagesProps = {},
-  memoizedPrismic: ?Object
-): Promise<PaginatedResults<Page>> {
-  const paginatedResults = await getDocuments(
-    req,
-    [Prismic.Predicates.any('document.type', ['pages'])].concat(predicates),
-    {
-      page,
-      pageSize,
-      fetchLinks: pagesFields.concat(
-        articleSeriesFields,
-        eventSeriesFields,
-        collectionVenuesFields,
-        exhibitionFields,
-        teamsFields,
-        eventsFields,
-        cardsFields,
-        eventFormatsFields,
-        articleFormatsFields,
-        labelsFields,
-        seasonsFields,
-        contributorsFields,
-        peopleFields,
-        bookFields
-      ),
-    },
-    memoizedPrismic
-  );
-
-  const pages: Page[] = paginatedResults.results.map(parsePage);
-
-  return {
-    currentPage: paginatedResults.currentPage,
-    pageSize: paginatedResults.pageSize,
-    totalResults: paginatedResults.totalResults,
-    totalPages: paginatedResults.totalPages,
-    results: pages,
-  };
-}
-
-export async function getPageSiblings(
-  page: Page,
-  req: ?Request,
-  memoizedPrismic: ?Object
-): Promise<SiblingsGroup[]> {
-  const relatedPagePromises = (page.parentPages &&
-    page.parentPages.map(parentPage =>
-      getPages(
-        req,
-        {
-          predicates: [
-            Prismic.Predicates.at('my.pages.parents.parent', parentPage.id),
-          ],
-        },
-        memoizedPrismic
-      )
-    )) || [Promise.resolve([])];
-  const relatedPages = await Promise.all(relatedPagePromises);
-  const siblingsWithLandingTitle = relatedPages.map((results, i) => {
-    return {
-      id: page.parentPages[i].id,
-      title: page.parentPages[i].title,
-      siblings: results.results.filter(sibling => sibling.id !== page.id),
-    };
-  });
-  return siblingsWithLandingTitle;
 }

--- a/content/webapp/pages/page.tsx
+++ b/content/webapp/pages/page.tsx
@@ -36,7 +36,6 @@ import { contentLd } from '../services/prismic/transformers/json-ld';
 import { fetchChildren, fetchPage } from '../services/prismic/fetch/pages';
 import { createClient } from '../services/prismic/fetch';
 import { transformPage } from '../services/prismic/transformers/pages';
-import { transformQuery } from '../services/prismic/transformers/paginated-results';
 
 type Props = {
   page: PageType;
@@ -78,14 +77,14 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
           };
         }) || [];
 
-      const childrenQueryPromise = await fetchChildren(client, page.id);
-
       // TODO: Why are we putting 'children' in a 'siblings' attribute?
       // Fix this janky naming.
       const children = {
         id: page.id,
         title: page.title,
-        siblings: transformQuery(childrenQueryPromise, transformPage).results,
+        siblings: (await fetchChildren(client, page.id)).map(c =>
+          transformPage(c)
+        ),
       };
 
       return {

--- a/content/webapp/pages/page.tsx
+++ b/content/webapp/pages/page.tsx
@@ -70,7 +70,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       ).map(group => {
         return {
           ...group,
-          siblings: group.siblings.map(s => transformPage(s)),
+          siblings: group.siblings.map(transformPage),
         };
       });
       const ordersInParents: OrderInParent[] =
@@ -88,9 +88,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       const children = {
         id: page.id,
         title: page.title,
-        siblings: (await fetchChildren(client, page)).map(c =>
-          transformPage(c)
-        ),
+        siblings: (await fetchChildren(client, page)).map(transformPage),
       };
 
       return {

--- a/content/webapp/pages/page.tsx
+++ b/content/webapp/pages/page.tsx
@@ -8,10 +8,7 @@ import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
 import VideoEmbed from '@weco/common/views/components/VideoEmbed/VideoEmbed';
 import { UiImage } from '@weco/common/views/components/Images/Images';
 import { convertImageUri } from '@weco/common/utils/convert-image-uri';
-import {
-  getPageSiblings,
-  getChildren,
-} from '@weco/common/services/prismic/pages';
+import { getPageSiblings } from '@weco/common/services/prismic/pages';
 import { Page as PageType } from '@weco/common/model/pages';
 import { SiblingsGroup } from '@weco/common/model/siblings-group';
 import {
@@ -36,9 +33,10 @@ import CardGrid from '../components/CardGrid/CardGrid';
 import Body from '../components/Body/Body';
 import ContentPage from '../components/ContentPage/ContentPage';
 import { contentLd } from '../services/prismic/transformers/json-ld';
-import { fetchPage } from '../services/prismic/fetch/pages';
+import { fetchChildren, fetchPage } from '../services/prismic/fetch/pages';
 import { createClient } from '../services/prismic/fetch';
 import { transformPage } from '../services/prismic/transformers/pages';
+import { transformQuery } from '../services/prismic/transformers/paginated-results';
 
 type Props = {
   page: PageType;
@@ -60,6 +58,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     const { id, memoizedPrismic } = context.query;
 
     const client = createClient(context);
+
     const pageLookup = await fetchPage(client, id as string);
     const page = pageLookup && transformPage(pageLookup);
 
@@ -79,7 +78,16 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
           };
         }) || [];
 
-      const children = await getChildren(page, context.req, memoizedPrismic);
+      const childrenQueryPromise = await fetchChildren(client, page.id);
+
+      // TODO: Why are we putting 'children' in a 'siblings' attribute?
+      // Fix this janky naming.
+      const children = {
+        id: page.id,
+        title: page.title,
+        siblings: transformQuery(childrenQueryPromise, transformPage).results,
+      };
+
       return {
         props: removeUndefinedProps({
           page,

--- a/content/webapp/services/prismic/fetch/pages.ts
+++ b/content/webapp/services/prismic/fetch/pages.ts
@@ -61,7 +61,8 @@ export const fetchChildren = async (
   const predicates = [prismic.predicate.at('my.pages.parents.parent', page.id)];
 
   try {
-    return await fetchPages(client, { predicates }).then(q => q.results);
+    const pages = await fetchPages(client, { predicates })
+    return pages.results
   } catch (e) {
     console.warn(`Error trying to fetch children on page ${page.id}: ${e}`);
     return [];

--- a/content/webapp/services/prismic/fetch/pages.ts
+++ b/content/webapp/services/prismic/fetch/pages.ts
@@ -1,4 +1,6 @@
-import { fetcher } from '.';
+import { Query } from '@prismicio/types';
+import * as prismic from 'prismic-client-beta';
+import { fetcher, GetServerSidePropsPrismicClient } from '.';
 import { PagePrismicDocument } from '../types/pages';
 import {
   articleSeriesFields,
@@ -40,10 +42,24 @@ const fetchLinks = pagesFields.concat(
 );
 
 /** Although these are three different document types in Prismic, they all get
-  * rendered (and fetched) by the same component.
-  */
-const pagesFetcher = fetcher<PagePrismicDocument>(['pages', 'guides', 'projects'], fetchLinks);
+ * rendered (and fetched) by the same component.
+ */
+const pagesFetcher = fetcher<PagePrismicDocument>(
+  ['pages', 'guides', 'projects'],
+  fetchLinks
+);
 
 export const fetchPage = pagesFetcher.getById;
 export const fetchPages = pagesFetcher.getByType;
 export const fetchPagesClientSide = pagesFetcher.getByTypeClientSide;
+
+export const fetchChildren = (
+  client: GetServerSidePropsPrismicClient,
+  pageId: string
+): Promise<Query<PagePrismicDocument>> => {
+  const predicates = [prismic.predicate.at('my.pages.parents.parent', pageId)];
+
+  return fetchPages(client, {
+    predicates,
+  });
+};

--- a/content/webapp/services/prismic/fetch/pages.ts
+++ b/content/webapp/services/prismic/fetch/pages.ts
@@ -76,7 +76,7 @@ export const fetchSiblings = async (
   const relatedPagePromises =
     page.parentPages &&
     page.parentPages.map(parentPage => fetchChildren(client, parentPage));
-  const relatedPages = await Promise.all(relatedPagePromises);
+  const relatedPages = await Promise.all(relatedPagePromises ?? []);
 
   return relatedPages.map((results, i) => {
     return {

--- a/content/webapp/services/prismic/fetch/pages.ts
+++ b/content/webapp/services/prismic/fetch/pages.ts
@@ -74,8 +74,7 @@ export const fetchSiblings = async (
   page: Page
 ): Promise<SiblingsGroup<PagePrismicDocument>[]> => {
   const relatedPagePromises =
-    page.parentPages &&
-    page.parentPages.map(parentPage => fetchChildren(client, parentPage));
+    page.parentPages?.map(parentPage => fetchChildren(client, parentPage));
   const relatedPages = await Promise.all(relatedPagePromises ?? []);
 
   return relatedPages.map((results, i) => {

--- a/content/webapp/services/prismic/fetch/pages.ts
+++ b/content/webapp/services/prismic/fetch/pages.ts
@@ -1,4 +1,3 @@
-import { Query } from '@prismicio/types';
 import * as prismic from 'prismic-client-beta';
 import { fetcher, GetServerSidePropsPrismicClient } from '.';
 import { PagePrismicDocument } from '../types/pages';
@@ -53,13 +52,16 @@ export const fetchPage = pagesFetcher.getById;
 export const fetchPages = pagesFetcher.getByType;
 export const fetchPagesClientSide = pagesFetcher.getByTypeClientSide;
 
-export const fetchChildren = (
+export const fetchChildren = async (
   client: GetServerSidePropsPrismicClient,
   pageId: string
-): Promise<Query<PagePrismicDocument>> => {
+): Promise<PagePrismicDocument[]> => {
   const predicates = [prismic.predicate.at('my.pages.parents.parent', pageId)];
 
-  return fetchPages(client, {
-    predicates,
-  });
+  try {
+    return await fetchPages(client, { predicates }).then(q => q.results);
+  } catch (e) {
+    console.warn(`Error trying to fetch children on page ${pageId}: ${e}`);
+    return [];
+  }
 };


### PR DESCRIPTION
For #7363 / #7426

This replaces the `getChildren` and `getSiblings` functions, which in turn allow us to bin the `getPages` method (which had otherwise been replaced with the typed fetchers).