### PR TITLE
Use the new typed fetchers for getExhibitions

### DIFF
--- a/common/services/prismic/exhibitions.js
+++ b/common/services/prismic/exhibitions.js
@@ -4,7 +4,6 @@ import { getDocuments, getTypeByIds } from './api';
 import { parseMultiContent } from './multi-content';
 import {
   exhibitionFields,
-  exhibitionResourcesFields,
   eventAccessOptionsFields,
   teamsFields,
   eventFormatsFields,
@@ -38,24 +37,14 @@ import {
 // $FlowFixMe (tsx)
 import { parseSeason } from './seasons';
 // $FlowFixMe
-import { london } from '../../utils/format-date';
-import { getPeriodPredicates } from './utils';
-import type { Period } from '../../model/periods';
 import type { Resource } from '../../model/resource';
-import type {
-  PrismicFragment,
-  PaginatedResults,
-  PrismicDocument,
-} from './types';
+import type { PrismicFragment, PrismicDocument } from './types';
 import type {
   UiExhibition,
   UiExhibit,
   ExhibitionFormat,
 } from '../../model/exhibitions';
 import type { MultiContent } from '../../model/multi-content';
-
-const startField = 'my.exhibitions.start';
-const endField = 'my.exhibitions.end';
 
 function parseResourceTypeList(
   fragment: PrismicFragment[],
@@ -192,102 +181,6 @@ export function parseExhibitionDoc(document: PrismicDocument): UiExhibition {
     : [{ text: 'Exhibition' }];
 
   return { ...exhibition, labels };
-}
-
-type Order = 'desc' | 'asc';
-type GetExhibitionsProps = {|
-  predicates?: Prismic.Predicates[],
-  order?: Order,
-  period?: Period,
-  page?: number,
-|};
-export async function getExhibitions(
-  req: ?Request,
-  {
-    predicates = [],
-    order = 'desc',
-    period,
-    page = 1,
-  }: GetExhibitionsProps = {},
-  memoizedPrismic: ?Object
-): Promise<PaginatedResults<UiExhibition>> {
-  const orderings = `[my.exhibitions.isPermanent desc,${endField}${
-    order === 'desc' ? ' desc' : ''
-  }]`;
-  const periodPredicates = period
-    ? getPeriodPredicates(period, startField, endField)
-    : [];
-  const paginatedResults = await getDocuments(
-    req,
-    [Prismic.Predicates.any('document.type', ['exhibitions'])].concat(
-      predicates,
-      periodPredicates
-    ),
-    {
-      fetchLinks: peopleFields.concat(
-        organisationsFields,
-        contributorsFields,
-        placesFields,
-        exhibitionFields,
-        exhibitionResourcesFields
-      ),
-      orderings,
-      page,
-    },
-    memoizedPrismic
-  );
-
-  const uiExhibitions: UiExhibition[] =
-    paginatedResults.results.map(parseExhibitionDoc);
-  const exhibitionsWithPermAfterCurrent =
-    putPermanentAfterCurrentExhibitions(uiExhibitions);
-
-  // { ...paginatedResults, results: uiExhibitions } should work, but Flow still
-  // battles with spreading.
-  return {
-    currentPage: paginatedResults.currentPage,
-    pageSize: paginatedResults.pageSize,
-    totalResults: paginatedResults.totalResults,
-    totalPages: paginatedResults.totalPages,
-    results: exhibitionsWithPermAfterCurrent,
-  };
-}
-
-function putPermanentAfterCurrentExhibitions(
-  exhibitions: UiExhibition[]
-): UiExhibition[] {
-  // We order the list this way as, from a user's perspective, seeing the
-  // temporary exhibitions is more urgent, so they're at the front of the list,
-  // but there's no good way to express that ordering through Prismic's ordering
-  const groupedResults = exhibitions.reduce(
-    (acc, result) => {
-      // Wishing there was `groupBy`.
-      if (result.isPermanent) {
-        acc.permanent.push(result);
-      } else if (london(result.start).isAfter(london())) {
-        acc.comingUp.push(result);
-      } else if (result.end && london(result.end).isBefore(london())) {
-        acc.past.push(result);
-      } else {
-        acc.current.push(result);
-      }
-
-      return acc;
-    },
-    {
-      current: [],
-      permanent: [],
-      comingUp: [],
-      past: [],
-    }
-  );
-
-  return [
-    ...groupedResults.current,
-    ...groupedResults.permanent,
-    ...groupedResults.comingUp,
-    ...groupedResults.past,
-  ];
 }
 
 type ExhibitionRelatedContent = {|

--- a/content/webapp/components/ExhibitionsAndEvents/ExhibitionsAndEvents.tsx
+++ b/content/webapp/components/ExhibitionsAndEvents/ExhibitionsAndEvents.tsx
@@ -1,16 +1,17 @@
-import { UiExhibition } from '@weco/common/model/exhibitions';
+import { Exhibition } from '@weco/common/model/exhibitions';
 import { UiEvent } from '@weco/common/model/events';
 import { Link } from '@weco/common/model/link';
 import CardGrid from '../CardGrid/CardGrid';
+import { FunctionComponent } from 'react';
 
 type Props = {
-  exhibitions: UiExhibition[];
+  exhibitions: Exhibition[];
   events: UiEvent[];
-  extras?: (UiExhibition | UiEvent)[];
+  extras?: (Exhibition | UiEvent)[];
   links?: Link[];
 };
 
-const ExhibitionsAndEvents = ({
+const ExhibitionsAndEvents: FunctionComponent<Props> = ({
   exhibitions,
   events,
   extras = [],
@@ -24,7 +25,7 @@ const ExhibitionsAndEvents = ({
     exhibition => !exhibition.isPermanent
   );
 
-  const items: (UiExhibition | UiEvent)[] = [
+  const items: (Exhibition | UiEvent)[] = [
     ...otherExhibitions,
     ...events,
     ...permanentExhibitions,

--- a/content/webapp/components/FeaturedCard/FeaturedCard.tsx
+++ b/content/webapp/components/FeaturedCard/FeaturedCard.tsx
@@ -4,7 +4,7 @@ import {
   UiImageProps,
   UiImage,
 } from '@weco/common/views/components/Images/Images';
-import { UiExhibition } from '@weco/common/model/exhibitions';
+import { Exhibition } from '@weco/common/model/exhibitions';
 import { UiEvent } from '@weco/common/model/events';
 import {
   Article,
@@ -54,7 +54,7 @@ export function convertCardToFeaturedCardProps(
 }
 
 export function convertItemToFeaturedCardProps(
-  item: Article | UiEvent | UiExhibition | Season
+  item: Article | UiEvent | Exhibition | Season
 ) {
   return {
     id: item.id,
@@ -127,13 +127,13 @@ const FeaturedCardArticleBody: FunctionComponent<FeaturedCardArticleBodyProps> =
   };
 
 type FeaturedCardExhibitionProps = {
-  exhibition: UiExhibition;
+  exhibition: Exhibition;
   background: string;
   color: string;
 };
 
 type FeaturedCardExhibitionBodyProps = {
-  exhibition: UiExhibition;
+  exhibition: Exhibition;
 };
 
 const FeaturedCardExhibitionBody = ({

--- a/content/webapp/components/LayoutPaginatedResults/LayoutPaginatedResults.tsx
+++ b/content/webapp/components/LayoutPaginatedResults/LayoutPaginatedResults.tsx
@@ -4,7 +4,7 @@ import Pagination from '@weco/common/views/components/Pagination/Pagination';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
 import { classNames, font } from '@weco/common/utils/classnames';
 import type { Period } from '@weco/common/model/periods';
-import type { UiExhibition } from '@weco/common/model/exhibitions';
+import { Exhibition } from '@weco/common/model/exhibitions';
 import type { UiEvent } from '@weco/common/model/events';
 import type { Article } from '@weco/common/model/articles';
 import type {
@@ -20,7 +20,7 @@ import CardGrid from '../CardGrid/CardGrid';
 import { Book } from '../../types/books';
 
 type PaginatedResultsTypes =
-  | PaginatedResults<UiExhibition>
+  | PaginatedResults<Exhibition>
   | PaginatedResults<UiEvent>
   | PaginatedResults<Book>
   | PaginatedResults<Article>;

--- a/content/webapp/pages/season.tsx
+++ b/content/webapp/pages/season.tsx
@@ -29,7 +29,7 @@ import { transformQuery } from '../services/prismic/transformers/paginated-resul
 import { transformArticle } from '../services/prismic/transformers/articles';
 import { transformBook } from '../services/prismic/transformers/books';
 import { transformEvent } from '../services/prismic/transformers/events';
-import { transformExhibition } from '../services/prismic/transformers/exhibitions';
+import { transformExhibitionsQuery } from '../services/prismic/transformers/exhibitions';
 import { transformPage } from '../services/prismic/transformers/pages';
 import { transformProject } from '../services/prismic/transformers/projects';
 import { transformSeries } from '../services/prismic/transformers/series';
@@ -146,7 +146,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     });
     const exhibitionsQueryPromise = fetchExhibitions(client, {
       predicates: [`[at(my.exhibitions.seasons.season, "${id}")]`],
-      orderings: [`my.exhibitions.isPermanent desc, my.exhibitions.end desc`],
+      order: 'desc',
     });
     const pagesQueryPromise = fetchPages(client, {
       predicates: [`[at(my.pages.seasons.season, "${id}")]`],
@@ -183,7 +183,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     const articles = transformQuery(articlesQuery, transformArticle);
     const books = transformQuery(booksQuery, transformBook);
     const events = transformQuery(eventsQuery, transformEvent);
-    const exhibitions = transformQuery(exhibitionsQuery, transformExhibition);
+    const exhibitions = transformExhibitionsQuery(exhibitionsQuery);
     const pages = transformQuery(pagesQuery, transformPage);
     const projects = transformQuery(projectsQuery, transformProject);
     const series = transformQuery(seriesQuery, transformSeries);

--- a/content/webapp/pages/whats-on.tsx
+++ b/content/webapp/pages/whats-on.tsx
@@ -1,13 +1,15 @@
 import { FunctionComponent } from 'react';
 import { Moment } from 'moment';
 import NextLink from 'next/link';
-import { UiExhibition } from '@weco/common/model/exhibitions';
+import { Exhibition } from '@weco/common/model/exhibitions';
 import { UiEvent } from '@weco/common/model/events';
 import { Period } from '@weco/common/model/periods';
 import { PaginatedResults } from '@weco/common/services/prismic/types';
 import { classNames, font, grid, cssGrid } from '@weco/common/utils/classnames';
-import { getExhibitions } from '@weco/common/services/prismic/exhibitions';
-import { getPageFeaturedText } from '../services/prismic/transformers/pages';
+import {
+  getPageFeaturedText,
+  transformPage,
+} from '../services/prismic/transformers/pages';
 import {
   filterEventsForToday,
   filterEventsForWeekend,
@@ -21,7 +23,7 @@ import {
 } from '@weco/common/services/prismic/opening-times';
 import {
   cafePromo,
-  shopPromo,
+  // shopPromo,
   readingRoomPromo,
   dailyTourPromo,
 } from '../data/facility-promos';
@@ -65,11 +67,12 @@ import CardGrid from '../components/CardGrid/CardGrid';
 import { FeaturedCardExhibition } from '../components/FeaturedCard/FeaturedCard';
 import { fetchPage } from '../services/prismic/fetch/pages';
 import { createClient } from '../services/prismic/fetch';
-import { transformPage } from '../services/prismic/transformers/pages';
 import { fetchEvents } from '../services/prismic/fetch/events';
 import { transformQuery } from '../services/prismic/transformers/paginated-results';
 import { transformEvent } from '../services/prismic/transformers/events';
 import { pageDescriptions } from '@weco/common/data/microcopy';
+import { fetchExhibitions } from 'services/prismic/fetch/exhibitions';
+import { transformExhibitionsQuery } from 'services/prismic/transformers/exhibitions';
 
 const segmentedControlItems = [
   {
@@ -90,7 +93,7 @@ const segmentedControlItems = [
 ];
 
 export type Props = {
-  exhibitions: PaginatedResults<UiExhibition>;
+  exhibitions: PaginatedResults<Exhibition>;
   events: PaginatedResults<UiEvent>;
   availableOnlineEvents: PaginatedResults<UiEvent>;
   period: string;
@@ -315,7 +318,6 @@ const Header = ({
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
     const serverData = await getServerData(context);
-    const { memoizedPrismic } = context.query;
 
     const client = createClient(context);
 
@@ -329,46 +331,45 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     // would it be faster to skip all the fetchLinks?  Is that possible?
     const whatsOnPagePromise = fetchPage(client, prismicPageIds.whatsOn);
 
-    const exhibitionsPromise = getExhibitions(
-      context.req,
-      {
-        period,
-        order: 'asc',
-      },
-      memoizedPrismic
-    );
+    const exhibitionsQueryPromise = fetchExhibitions(client, {
+      period,
+      order: 'asc',
+    });
 
-    const eventsQueryPromise = fetchEvents(
-      client,
-      {
-        period: 'current-and-coming-up',
-        pageSize: 100,
-      },
-    );
+    const eventsQueryPromise = fetchEvents(client, {
+      period: 'current-and-coming-up',
+      pageSize: 100,
+    });
 
-    const availableOnlineEventsQueryPromise = fetchEvents(
-      client,
-      {
-        period: 'past',
-        pageSize: 6,
-        availableOnline: true,
-      },
-    );
+    const availableOnlineEventsQueryPromise = fetchEvents(client, {
+      period: 'past',
+      pageSize: 6,
+      availableOnline: true,
+    });
 
-    const [exhibitions, eventsQuery, availableOnlineEventsQuery, whatsOnPage] =
-      await Promise.all([
-        exhibitionsPromise,
-        eventsQueryPromise,
-        availableOnlineEventsQueryPromise,
-        whatsOnPagePromise,
-      ]);
+    const [
+      exhibitionsQuery,
+      eventsQuery,
+      availableOnlineEventsQuery,
+      whatsOnPage,
+    ] = await Promise.all([
+      exhibitionsQueryPromise,
+      eventsQueryPromise,
+      availableOnlineEventsQueryPromise,
+      whatsOnPagePromise,
+    ]);
 
     const dateRange = getMomentsForPeriod(period);
 
-    const featuredText = whatsOnPage && getPageFeaturedText(transformPage(whatsOnPage));
+    const featuredText =
+      whatsOnPage && getPageFeaturedText(transformPage(whatsOnPage));
 
     const events = transformQuery(eventsQuery, transformEvent);
-    const availableOnlineEvents = transformQuery(availableOnlineEventsQuery, transformEvent);
+    const exhibitions = transformExhibitionsQuery(exhibitionsQuery);
+    const availableOnlineEvents = transformQuery(
+      availableOnlineEventsQuery,
+      transformEvent
+    );
 
     if (period && events && exhibitions) {
       return {

--- a/content/webapp/services/prismic/transformers/exhibitions.ts
+++ b/content/webapp/services/prismic/transformers/exhibitions.ts
@@ -2,6 +2,10 @@ import { parseExhibitionDoc } from '@weco/common/services/prismic/exhibitions';
 import { Exhibition as DeprecatedExhibition } from '@weco/common/model/exhibitions';
 import { Exhibition } from '../../../types/exhibitions';
 import { ExhibitionPrismicDocument } from '../types/exhibitions';
+import { Query } from '@prismicio/types';
+import { PaginatedResults } from '@weco/common/services/prismic/types';
+import { transformQuery } from './paginated-results';
+import { london } from '@weco/common/utils/format-date';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function transformExhibition(
@@ -13,4 +17,52 @@ export function transformExhibition(
     ...exhibition,
     prismicDocument: document,
   };
+}
+
+export function transformExhibitionsQuery(
+  query: Query<ExhibitionPrismicDocument>
+): PaginatedResults<Exhibition> {
+  const paginatedResult = transformQuery(query, transformExhibition);
+
+  return {
+    ...paginatedResult,
+    results: putPermanentAfterCurrentExhibitions(paginatedResult.results),
+  };
+}
+
+function putPermanentAfterCurrentExhibitions(
+  exhibitions: Exhibition[]
+): Exhibition[] {
+  // We order the list this way as, from a user's perspective, seeing the
+  // temporary exhibitions is more urgent, so they're at the front of the list,
+  // but there's no good way to express that ordering through Prismic's ordering
+  const groupedResults = exhibitions.reduce(
+    (acc, result) => {
+      // Wishing there was `groupBy`.
+      if (result.isPermanent) {
+        acc.permanent.push(result);
+      } else if (london(result.start).isAfter(london())) {
+        acc.comingUp.push(result);
+      } else if (result.end && london(result.end).isBefore(london())) {
+        acc.past.push(result);
+      } else {
+        acc.current.push(result);
+      }
+
+      return acc;
+    },
+    {
+      current: [] as Exhibition[],
+      permanent: [] as Exhibition[],
+      comingUp: [] as Exhibition[],
+      past: [] as Exhibition[],
+    }
+  );
+
+  return [
+    ...groupedResults.current,
+    ...groupedResults.permanent,
+    ...groupedResults.comingUp,
+    ...groupedResults.past,
+  ];
 }


### PR DESCRIPTION
For #7363 / #7426

This replaces the getExhibitions function, which allows us to start cleaning up the UiExhibition type also. I'm having weird type checker errors locally, so pushing into CI to see if that fixes it.