### PR TITLE
Multiple audio

### DIFF
--- a/catalogue/webapp/components/AudioList/AudioList.tsx
+++ b/catalogue/webapp/components/AudioList/AudioList.tsx
@@ -5,29 +5,29 @@ import AudioPlayer from '../AudioPlayer/AudioPlayer';
 import { IIIFMediaElement } from '../../model/iiif';
 
 type Props = {
-  audio: IIIFMediaElement[];
+  items: IIIFMediaElement[];
 };
 
-const AudioList: FC<Props> = ({ audio }) => {
+const AudioList: FC<Props> = ({ items }) => {
   return (
     <ol
       className={classNames({
         'no-margin no-padding plain-list': true,
       })}
     >
-      {audio.map((a, index) => (
+      {items.map((item, index) => (
         <Space
           as="li"
-          key={a['@id']}
+          key={item['@id']}
           v={{ size: 'l', properties: ['margin-bottom'] }}
-          aria-label={audio.length > 1 ? (index + 1).toString() : undefined}
+          aria-label={items.length > 1 ? (index + 1).toString() : undefined}
         >
           <span
             className={classNames({
               'flex flex--v-center': true,
             })}
           >
-            {audio.length > 1 && (
+            {items.length > 1 && (
               <Space
                 aria-hidden="true"
                 h={{ size: 's', properties: ['margin-right'] }}
@@ -35,7 +35,7 @@ const AudioList: FC<Props> = ({ audio }) => {
                 {index + 1}
               </Space>
             )}
-            <AudioPlayer audio={a} />
+            <AudioPlayer audio={item} />
           </span>
         </Space>
       ))}

--- a/catalogue/webapp/components/AudioList/AudioList.tsx
+++ b/catalogue/webapp/components/AudioList/AudioList.tsx
@@ -1,0 +1,46 @@
+import { FC } from 'react';
+import { classNames } from '@weco/common/utils/classnames';
+import Space from '@weco/common/views/components/styled/Space';
+import AudioPlayer from '../AudioPlayer/AudioPlayer';
+import { IIIFMediaElement } from '../../model/iiif';
+
+type Props = {
+  audio: IIIFMediaElement[];
+};
+
+const AudioList: FC<Props> = ({ audio }) => {
+  return (
+    <ol
+      className={classNames({
+        'no-margin no-padding plain-list': true,
+      })}
+    >
+      {audio.map((a, index) => (
+        <Space
+          as="li"
+          key={a['@id']}
+          v={{ size: 'l', properties: ['margin-bottom'] }}
+          aria-label={audio.length > 1 ? (index + 1).toString() : undefined}
+        >
+          <span
+            className={classNames({
+              'flex flex--v-center': true,
+            })}
+          >
+            {audio.length > 1 && (
+              <Space
+                aria-hidden="true"
+                h={{ size: 's', properties: ['margin-right'] }}
+              >
+                {index + 1}
+              </Space>
+            )}
+            <AudioPlayer audio={a} />
+          </span>
+        </Space>
+      ))}
+    </ol>
+  );
+};
+
+export default AudioList;

--- a/catalogue/webapp/components/AudioList/AudioList.tsx
+++ b/catalogue/webapp/components/AudioList/AudioList.tsx
@@ -3,6 +3,7 @@ import { classNames } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 import AudioPlayer from '../AudioPlayer/AudioPlayer';
 import { IIIFMediaElement } from '../../model/iiif';
+import AlignFont from '@weco/common/views/components/styled/AlignFont';
 
 type Props = {
   items: IIIFMediaElement[];
@@ -32,7 +33,7 @@ const AudioList: FC<Props> = ({ items }) => {
                 aria-hidden="true"
                 h={{ size: 's', properties: ['margin-right'] }}
               >
-                {index + 1}
+                <AlignFont>{index + 1}</AlignFont>
               </Space>
             )}
             <AudioPlayer audio={item} />

--- a/catalogue/webapp/components/AudioPlayer/AudioPlayer.tsx
+++ b/catalogue/webapp/components/AudioPlayer/AudioPlayer.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, ReactElement, FunctionComponent } from 'react';
 import useInterval from '@weco/common/hooks/useInterval';
 import { IIIFMediaElement } from '../../model/iiif';
 import MediaAnnotations from '../MediaAnnotations/MediaAnnotations';
+import Space from '@weco/common/views/components/styled/Space';
 
 type Props = {
   audio: IIIFMediaElement;
@@ -52,8 +53,20 @@ const AudioPlayer: FunctionComponent<Props> = ({
     },
     isPlaying ? 1000 : undefined
   );
+  const audioPlaceholderThumbnailUrls = [
+    'https://iiif.wellcomecollection.org/thumb/b22488522',
+    'https://iiif.wellcomecollection.org/thumb/b2248887x',
+  ];
+  const showThumbnail =
+    audio.thumbnail && !audioPlaceholderThumbnailUrls.includes(audio.thumbnail);
+
   return (
-    <>
+    <div>
+      {showThumbnail && (
+        <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
+          <img src={audio.thumbnail} alt={audio.label} />
+        </Space>
+      )}
       <audio
         onPlay={() => {
           setIsPlaying(true);
@@ -73,7 +86,7 @@ const AudioPlayer: FunctionComponent<Props> = ({
         {`Sorry, your browser doesn't support embedded audio.`}
       </audio>
       <MediaAnnotations media={audio} />
-    </>
+    </div>
   );
 };
 

--- a/catalogue/webapp/components/AudioPlayer/AudioPlayer.tsx
+++ b/catalogue/webapp/components/AudioPlayer/AudioPlayer.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState, ReactElement, FunctionComponent } from 'react';
 import useInterval from '@weco/common/hooks/useInterval';
 import { IIIFMediaElement } from '../../model/iiif';
 import MediaAnnotations from '../MediaAnnotations/MediaAnnotations';
-import Space from '@weco/common/views/components/styled/Space';
 
 type Props = {
   audio: IIIFMediaElement;
@@ -53,20 +52,15 @@ const AudioPlayer: FunctionComponent<Props> = ({
     },
     isPlaying ? 1000 : undefined
   );
-  const audioPlaceholderThumbnailUrls = [
-    'https://iiif.wellcomecollection.org/thumb/b22488522',
-    'https://iiif.wellcomecollection.org/thumb/b2248887x',
-  ];
-  const showThumbnail =
-    audio.thumbnail && !audioPlaceholderThumbnailUrls.includes(audio.thumbnail);
 
   return (
     <div>
-      {showThumbnail && (
-        <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
-          <img src={audio.thumbnail} alt={audio.label} />
-        </Space>
-      )}
+      {/* TODO: there are currently thumbnails for all pieces of audio, but
+      the vast majority resolve to a placeholder image that we don't want to display.
+      Instead of trying to work out which ones to display, we're going to wait until
+      the placeholder thumbnails have been removed from the IIIF manifests
+
+      see https://github.com/wellcomecollection/wellcomecollection.org/issues/7596#issuecomment-1026686060 */}
       <audio
         onPlay={() => {
           setIsPlaying(true);

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -130,7 +130,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
 
   const authService =
     (video && getMediaClickthroughService(video)) ||
-    (audio?.[0] && getMediaClickthroughService(audio?.[0]));
+    (audio?.[0] && getMediaClickthroughService(audio[0]));
 
   const tokenService = authService && getTokenService(authService);
 

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -26,7 +26,7 @@ import WorkDetailsText from '../WorkDetailsText/WorkDetailsText';
 import WorkDetailsList from '../WorkDetailsList/WorkDetailsList';
 import WorkDetailsTags from '../WorkDetailsTags/WorkDetailsTags';
 import VideoPlayer from '../VideoPlayer/VideoPlayer';
-import AudioPlayer from '../AudioPlayer/AudioPlayer';
+import AudioList from '../AudioList/AudioList';
 import ButtonSolidLink from '@weco/common/views/components/ButtonSolidLink/ButtonSolidLink';
 import ButtonOutlinedLink from '@weco/common/views/components/ButtonOutlinedLink/ButtonOutlinedLink';
 import ExplanatoryText from './ExplanatoryText';
@@ -51,13 +51,6 @@ import {
   itemIsTemporarilyUnavailable,
 } from '../../utils/requesting';
 import { useToggles } from '@weco/common/server-data/Context';
-import styled from 'styled-components';
-
-const OrderedList = styled.ol`
-  padding: 0;
-  margin: 0;
-  list-style: none;
-`;
 
 type Props = {
   work: Work;
@@ -347,36 +340,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
                 />
               </Space>
             )}
-            {audio?.length > 0 && (
-              <OrderedList>
-                {audio?.map((a, index) => (
-                  <Space
-                    as="li"
-                    key={a['@id']}
-                    v={{ size: 'l', properties: ['margin-bottom'] }}
-                    aria-label={
-                      audio.length > 1 ? (index + 1).toString() : undefined
-                    }
-                  >
-                    <span
-                      className={classNames({
-                        'flex flex--v-center': true,
-                      })}
-                    >
-                      {audio.length > 1 && (
-                        <Space
-                          aria-hidden="true"
-                          h={{ size: 's', properties: ['margin-right'] }}
-                        >
-                          {index + 1}
-                        </Space>
-                      )}
-                      <AudioPlayer audio={a} />
-                    </span>
-                  </Space>
-                ))}
-              </OrderedList>
-            )}
+            {audio?.length > 0 && <AudioList audio={audio} />}
             {itemLinkState === 'useLibraryLink' && (
               <Space
                 as="span"

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -121,7 +121,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
   const {
     imageCount,
     childManifestsCount,
-    audio,
+    audioItems,
     video,
     iiifCredit,
     iiifPresentationDownloadOptions = [],
@@ -130,7 +130,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
 
   const authService =
     (video && getMediaClickthroughService(video)) ||
-    (audio?.[0] && getMediaClickthroughService(audio[0]));
+    (audioItems?.[0] && getMediaClickthroughService(audioItems[0]));
 
   const tokenService = authService && getTokenService(authService);
 
@@ -212,7 +212,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
     accessCondition: digitalLocationInfo?.accessCondition,
     sierraIdFromManifestUrl,
     itemUrl,
-    audio,
+    audio: audioItems?.[0],
     video,
   });
 
@@ -340,7 +340,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
                 />
               </Space>
             )}
-            {audio?.length > 0 && <AudioList audio={audio} />}
+            {audioItems?.length > 0 && <AudioList items={audioItems} />}
             {itemLinkState === 'useLibraryLink' && (
               <Space
                 as="span"

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -64,7 +64,7 @@ function getItemLinkState({
   accessCondition,
   sierraIdFromManifestUrl,
   itemUrl,
-  audio,
+  audioItems,
   video,
 }): ItemLinkState | undefined {
   if (accessCondition === 'permission-required' && sierraIdFromManifestUrl) {
@@ -73,7 +73,7 @@ function getItemLinkState({
   if (accessCondition === 'closed') {
     return 'useNoLink';
   }
-  if (itemUrl && !audio && !video) {
+  if (itemUrl && !(audioItems.length > 0) && !video) {
     return 'useItemLink';
   }
 }
@@ -216,7 +216,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
     accessCondition: digitalLocationInfo?.accessCondition,
     sierraIdFromManifestUrl,
     itemUrl,
-    audio: audioItems?.[0],
+    audioItems,
     video,
   });
 
@@ -344,7 +344,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
                 />
               </Space>
             )}
-            {audioItems?.length > 0 && <AudioList items={audioItems} />}
+            {audioItems.length > 0 && <AudioList items={audioItems} />}
             {itemLinkState === 'useLibraryLink' && (
               <Space
                 as="span"

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -128,9 +128,13 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
     iiifDownloadEnabled,
   } = useIIIFManifestData(work);
 
+  // We display a content advisory warning at the work level, so it is sufficient
+  // to check if any individual piece of audio content requires an advisory notice
+  const audioWithAuthService = audioItems.find(getMediaClickthroughService);
+
   const authService =
     (video && getMediaClickthroughService(video)) ||
-    (audioItems?.[0] && getMediaClickthroughService(audioItems[0]));
+    (audioWithAuthService && getMediaClickthroughService(audioWithAuthService));
 
   const tokenService = authService && getTokenService(authService);
 

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -51,6 +51,13 @@ import {
   itemIsTemporarilyUnavailable,
 } from '../../utils/requesting';
 import { useToggles } from '@weco/common/server-data/Context';
+import styled from 'styled-components';
+
+const OrderedList = styled.ol`
+  padding: 0;
+  margin: 0;
+  list-style: none;
+`;
 
 type Props = {
   work: Work;
@@ -340,14 +347,36 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
                 />
               </Space>
             )}
-            {audio?.map(a => (
-              <Space
-                key={a['@id']}
-                v={{ size: 'l', properties: ['margin-bottom'] }}
-              >
-                <AudioPlayer audio={a} />
-              </Space>
-            ))}
+            {audio?.length > 0 && (
+              <OrderedList>
+                {audio?.map((a, index) => (
+                  <Space
+                    as="li"
+                    key={a['@id']}
+                    v={{ size: 'l', properties: ['margin-bottom'] }}
+                    aria-label={
+                      audio.length > 1 ? (index + 1).toString() : undefined
+                    }
+                  >
+                    <span
+                      className={classNames({
+                        'flex flex--v-center': true,
+                      })}
+                    >
+                      {audio.length > 1 && (
+                        <Space
+                          aria-hidden="true"
+                          h={{ size: 's', properties: ['margin-right'] }}
+                        >
+                          {index + 1}
+                        </Space>
+                      )}
+                      <AudioPlayer audio={a} />
+                    </span>
+                  </Space>
+                ))}
+              </OrderedList>
+            )}
             {itemLinkState === 'useLibraryLink' && (
               <Space
                 as="span"

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -130,7 +130,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
 
   const authService =
     (video && getMediaClickthroughService(video)) ||
-    (audio && getMediaClickthroughService(audio));
+    (audio?.[0] && getMediaClickthroughService(audio?.[0]));
 
   const tokenService = authService && getTokenService(authService);
 
@@ -340,11 +340,14 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
                 />
               </Space>
             )}
-            {audio && (
-              <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
-                <AudioPlayer audio={audio} />
+            {audio?.map(a => (
+              <Space
+                key={a['@id']}
+                v={{ size: 'l', properties: ['margin-bottom'] }}
+              >
+                <AudioPlayer audio={a} />
               </Space>
-            )}
+            ))}
             {itemLinkState === 'useLibraryLink' && (
               <Space
                 as="span"

--- a/catalogue/webapp/hooks/useIIIFManifestData.ts
+++ b/catalogue/webapp/hooks/useIIIFManifestData.ts
@@ -63,6 +63,7 @@ const useIIIFManifestData = (work: Work): IIIFManifestData => {
   const [manifestData, setManifestData] = useState<IIIFManifestData>({
     imageCount: 0,
     childManifestsCount: 0,
+    audio: [],
   });
 
   async function fetchIIIFPresentationManifest(

--- a/catalogue/webapp/hooks/useIIIFManifestData.ts
+++ b/catalogue/webapp/hooks/useIIIFManifestData.ts
@@ -17,7 +17,7 @@ import { getDigitalLocationOfType } from '../utils/works';
 type IIIFManifestData = {
   imageCount: number;
   childManifestsCount: number;
-  audio?: IIIFMediaElement;
+  audio: IIIFMediaElement[];
   video?: IIIFMediaElement;
   iiifCredit?: string;
   iiifPresentationDownloadOptions?: IIIFRendering[];

--- a/catalogue/webapp/hooks/useIIIFManifestData.ts
+++ b/catalogue/webapp/hooks/useIIIFManifestData.ts
@@ -17,7 +17,7 @@ import { getDigitalLocationOfType } from '../utils/works';
 type IIIFManifestData = {
   imageCount: number;
   childManifestsCount: number;
-  audio: IIIFMediaElement[];
+  audioItems: IIIFMediaElement[];
   video?: IIIFMediaElement;
   iiifCredit?: string;
   iiifPresentationDownloadOptions?: IIIFRendering[];
@@ -30,7 +30,7 @@ function parseManifest(manifest: IIIFManifest): IIIFManifestData {
   const childManifestsCount = manifest.manifests
     ? manifest.manifests.length
     : 0;
-  const audio = getAudio(manifest);
+  const audioItems = getAudio(manifest);
   const video = getVideo(manifest);
   const iiifCredit = getIIIFPresentationCredit(manifest);
   const iiifPresentationDownloadOptions =
@@ -43,7 +43,7 @@ function parseManifest(manifest: IIIFManifest): IIIFManifestData {
   return {
     imageCount,
     childManifestsCount,
-    audio,
+    audioItems,
     video,
     iiifCredit,
     iiifPresentationDownloadOptions,
@@ -63,7 +63,7 @@ const useIIIFManifestData = (work: Work): IIIFManifestData => {
   const [manifestData, setManifestData] = useState<IIIFManifestData>({
     imageCount: 0,
     childManifestsCount: 0,
-    audio: [],
+    audioItems: [],
   });
 
   async function fetchIIIFPresentationManifest(

--- a/catalogue/webapp/pages/item.tsx
+++ b/catalogue/webapp/pages/item.tsx
@@ -49,7 +49,7 @@ import {
 import WorkLink from '@weco/common/views/components/WorkLink/WorkLink';
 import { getServerData } from '@weco/common/server-data';
 import AudioList from '../components/AudioList/AudioList';
-
+import { isNotUndefined } from '@weco/common/utils/array';
 const IframeAuthMessage = styled.iframe`
   display: none;
 `;
@@ -88,7 +88,7 @@ type Props = {
   canvases: IIIFCanvas[];
   currentCanvas?: IIIFCanvas;
   video?: Video;
-  audio: IIIFMediaElement[];
+  audioItems?: IIIFMediaElement[];
   iiifImageLocation?: DigitalLocation;
 } & WithPageview;
 
@@ -103,7 +103,7 @@ const ItemPage: NextPage<Props> = ({
   canvases,
   currentCanvas,
   video,
-  audio,
+  audioItems,
   iiifImageLocation,
 }) => {
   const workId = work.id;
@@ -229,10 +229,10 @@ const ItemPage: NextPage<Props> = ({
           src={`${tokenService['@id']}?messageId=1&origin=${origin}`}
         />
       )}
-      {audio?.length > 0 && (
+      {isNotUndefined(audioItems) && audioItems?.length > 0 && (
         <Space v={{ size: 'l', properties: ['margin-top', 'margin-bottom'] }}>
           <Layout12>
-            <AudioList audio={audio} />
+            <AudioList items={audioItems} />
           </Layout12>
         </Space>
       )}
@@ -255,7 +255,7 @@ const ItemPage: NextPage<Props> = ({
           </Space>
         </Layout12>
       )}
-      {!(audio.length > 0) &&
+      {!(isNotUndefined(audioItems) && audioItems.length > 0) &&
         !video &&
         !pdfRendering &&
         !mainImageService &&
@@ -436,7 +436,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
         : manifestOrCollection;
 
       const video = getVideo(manifest);
-      const audio = getAudio(manifest);
+      const audioItems = getAudio(manifest);
 
       const canvases =
         manifest.sequences && manifest.sequences[0].canvases
@@ -460,7 +460,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
           canvases,
           currentCanvas,
           video,
-          audio,
+          audioItems,
           iiifImageLocation,
           pageview,
           serverData,

--- a/catalogue/webapp/pages/item.tsx
+++ b/catalogue/webapp/pages/item.tsx
@@ -48,6 +48,7 @@ import {
 } from '@weco/common/views/components/ItemLink/ItemLink';
 import WorkLink from '@weco/common/views/components/WorkLink/WorkLink';
 import { getServerData } from '@weco/common/server-data';
+import AudioList from '../components/AudioList/AudioList';
 
 const IframeAuthMessage = styled.iframe`
   display: none;
@@ -228,24 +229,13 @@ const ItemPage: NextPage<Props> = ({
           src={`${tokenService['@id']}?messageId=1&origin=${origin}`}
         />
       )}
-      {audio?.map(a => (
-        <Layout12 key={a['@id']}>
-          <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
-            <audio
-              controls
-              style={{
-                maxWidth: '100%',
-                display: 'block',
-                margin: '98px auto 0',
-              }}
-              src={a['@id']}
-              controlsList={!showDownloadOptions ? 'nodownload' : undefined}
-            >
-              {`Sorry, your browser doesn't support embedded audio.`}
-            </audio>
-          </Space>
-        </Layout12>
-      ))}
+      {audio?.length > 0 && (
+        <Space v={{ size: 'l', properties: ['margin-top', 'margin-bottom'] }}>
+          <Layout12>
+            <AudioList audio={audio} />
+          </Layout12>
+        </Space>
+      )}
       {video && (
         <Layout12>
           <Space v={{ size: 'l', properties: ['margin-bottom'] }}>

--- a/catalogue/webapp/pages/item.tsx
+++ b/catalogue/webapp/pages/item.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useState } from 'react';
 import { GetServerSideProps, NextPage } from 'next';
 import { DigitalLocation, Work } from '@weco/common/model/catalogue';
-import { IIIFCanvas, IIIFManifest, AuthService } from '../model/iiif';
+import {
+  IIIFCanvas,
+  IIIFManifest,
+  AuthService,
+  IIIFMediaElement,
+} from '../model/iiif';
 import { getDigitalLocationOfType } from '../utils/works';
 import { fetchJson } from '@weco/common/utils/http';
 import { removeIdiomaticTextTags } from '@weco/common/utils/string';
@@ -66,10 +71,6 @@ function reloadAuthIframe(document, id: string) {
   if (authMessageIframe) authMessageIframe.src = authMessageIframe.src;
 }
 
-type Audio = {
-  '@id': string;
-};
-
 type Video = {
   '@id': string;
   format: string;
@@ -86,7 +87,7 @@ type Props = {
   canvases: IIIFCanvas[];
   currentCanvas?: IIIFCanvas;
   video?: Video;
-  audio?: Audio;
+  audio: IIIFMediaElement[];
   iiifImageLocation?: DigitalLocation;
 } & WithPageview;
 
@@ -227,8 +228,8 @@ const ItemPage: NextPage<Props> = ({
           src={`${tokenService['@id']}?messageId=1&origin=${origin}`}
         />
       )}
-      {audio && (
-        <Layout12>
+      {audio?.map(a => (
+        <Layout12 key={a['@id']}>
           <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
             <audio
               controls
@@ -237,14 +238,14 @@ const ItemPage: NextPage<Props> = ({
                 display: 'block',
                 margin: '98px auto 0',
               }}
-              src={audio['@id']}
+              src={a['@id']}
               controlsList={!showDownloadOptions ? 'nodownload' : undefined}
             >
               {`Sorry, your browser doesn't support embedded audio.`}
             </audio>
           </Space>
         </Layout12>
-      )}
+      ))}
       {video && (
         <Layout12>
           <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
@@ -264,7 +265,7 @@ const ItemPage: NextPage<Props> = ({
           </Space>
         </Layout12>
       )}
-      {!audio &&
+      {!(audio.length > 0) &&
         !video &&
         !pdfRendering &&
         !mainImageService &&

--- a/catalogue/webapp/utils/iiif.ts
+++ b/catalogue/webapp/utils/iiif.ts
@@ -13,6 +13,7 @@ import {
 } from '../model/iiif';
 import { fetchJson } from '@weco/common/utils/http';
 import cloneDeep from 'lodash.clonedeep';
+import { isNotUndefined } from '@weco/common/utils/array';
 
 export function getServiceId(canvas?: IIIFCanvas): string | undefined {
   const serviceSrc = canvas?.images[0]?.resource?.service;
@@ -290,19 +291,14 @@ export function getVideo(
   );
 }
 
-export function getAudio(
-  iiifManifest: IIIFManifest
-): IIIFMediaElement | undefined {
-  const videoSequence =
-    iiifManifest &&
-    iiifManifest.mediaSequences &&
-    iiifManifest.mediaSequences.find(sequence =>
+export function getAudio(iiifManifest: IIIFManifest): IIIFMediaElement[] {
+  const audioSequences = (iiifManifest.mediaSequences || [])
+    .flatMap(sequence =>
       sequence.elements.find(element => element['@type'] === 'dctypes:Sound')
-    );
-  return (
-    videoSequence &&
-    videoSequence.elements.find(element => element['@type'] === 'dctypes:Sound')
-  );
+    )
+    .filter(isNotUndefined);
+
+  return audioSequences;
 }
 
 export function getAnnotationFromMediaElement(

--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -126,6 +126,7 @@ const PageLayoutComponent: FunctionComponent<Props> = ({
     'AbortController',
     'Array.prototype.find',
     'Array.prototype.flat',
+    'Array.prototype.flatMap',
     'Array.prototype.includes',
     'Object.entries',
     'Object.fromEntries',


### PR DESCRIPTION
Part of #7596

## Who is this for?
People who want to access all available audio for a work

## What is it doing for them?
Accounting for the fact that works can have multiple audio parts

This PR doesn't address the display of thumbnail images or pdf transcripts.  [Moving to IIIF v3](https://github.com/wellcomecollection/wellcomecollection.org/issues/7596#issuecomment-1026791303) will better address those issues and reduce the need for us to retrofit complexity into our already-off-spec IIIF version. And is the direction we will presumably want to move in ultimately.

I have started work on the move the v3, but it has grown out of this work, and I don't think there is any need to wait for that before at least displaying the multiple audio parts.

How [Mat Fraser: interview 1](https://wellcomecollection.org/works/b4tj49m4) will appear after this change
![image](https://user-images.githubusercontent.com/1394592/152123172-4e83dbb2-9c62-4149-aa4a-85f15a0b7841.png)
