### PR TITLE
Handle the post-verification profile refresh from the server side

### DIFF
--- a/identity/webapp/src/frontend/Registration/AccountValidated.test.tsx
+++ b/identity/webapp/src/frontend/Registration/AccountValidated.test.tsx
@@ -16,6 +16,23 @@ jest.mock('@weco/common/server-data', () => ({
     (await import('@weco/common/server-data/types')).defaultServerData,
 }));
 
+jest.mock('next/config', () => () => ({
+  serverRuntimeConfig: {
+    sessionKeys: 'test_test_test',
+    siteBaseUrl: 'http://test.test',
+    identityBasePath: '/account',
+    auth0: {
+      domain: 'test.test',
+      clientID: 'test',
+      clientSecret: 'test',
+    },
+    remoteApi: {
+      host: 'test.test',
+      apiKey: 'test',
+    },
+  },
+}));
+
 const renderPage = (location: string) => {
   const url = new URL(`https://test.host/${location}`);
   const success = url.searchParams.get('success') === 'true';


### PR DESCRIPTION
The way we were doing this (a) was bad and (b) didn't work.

The way that the [Auth0-owned endpoint](https://github.com/auth0/nextjs-auth0/blob/70f59193b637ba5c5525359282b3c78b555b286b/src/handlers/profile.ts#L59-L84) does profile refreshes involves meddling with both the Auth0 management API and the user's session. This isn't something we should do ourselves, so this redirecting ping-pong is (imo) probably the most sound way of doing this.