### PR TITLE
Add some policies to reduce the size of our ECR repos

### DIFF
--- a/infrastructure/experience/ecr.tf
+++ b/infrastructure/experience/ecr.tf
@@ -34,7 +34,7 @@ resource "aws_ecr_repository" "content_webapp" {
 
 resource "aws_ecr_lifecycle_policy" "content_webapp" {
   repository = aws_ecr_repository.content_webapp.name
-  policy     = local.ecr_policy_only_keep_the_last_50_images
+  policy     = local.ecr_policy_only_keep_the_last_100_images
 }
 
 resource "aws_ecr_repository" "catalogue_webapp" {
@@ -47,7 +47,7 @@ resource "aws_ecr_repository" "catalogue_webapp" {
 
 resource "aws_ecr_lifecycle_policy" "catalogue_webapp" {
   repository = aws_ecr_repository.catalogue_webapp.name
-  policy     = local.ecr_policy_only_keep_the_last_50_images
+  policy     = local.ecr_policy_only_keep_the_last_100_images
 }
 
 resource "aws_ecr_repository" "identity_webapp" {
@@ -60,5 +60,5 @@ resource "aws_ecr_repository" "identity_webapp" {
 
 resource "aws_ecr_lifecycle_policy" "identity_webapp" {
   repository = aws_ecr_repository.identity_webapp.name
-  policy     = local.ecr_policy_only_keep_the_last_50_images
+  policy     = local.ecr_policy_only_keep_the_last_100_images
 }

--- a/infrastructure/experience/ecr_policy.tf
+++ b/infrastructure/experience/ecr_policy.tf
@@ -1,0 +1,36 @@
+locals {
+  ecr_policy_expire_images_after_3_days = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Expire images after 3 days"
+        selection = {
+          tagStatus   = "any"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = 3
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+
+  ecr_policy_only_keep_the_last_50_images = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Only keep the last 50 images in a repo"
+        selection = {
+          tagStatus   = "any"
+          countType   = "imageCountMoreThan"
+          countNumber = 50
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}

--- a/infrastructure/experience/ecr_policy.tf
+++ b/infrastructure/experience/ecr_policy.tf
@@ -17,15 +17,15 @@ locals {
     ]
   })
 
-  ecr_policy_only_keep_the_last_50_images = jsonencode({
+  ecr_policy_only_keep_the_last_100_images = jsonencode({
     rules = [
       {
         rulePriority = 1
-        description  = "Only keep the last 50 images in a repo"
+        description  = "Only keep the last 100 images in a repo"
         selection = {
           tagStatus   = "any"
           countType   = "imageCountMoreThan"
-          countNumber = 50
+          countNumber = 100
         }
         action = {
           type = "expire"

--- a/infrastructure/modules/certificate/provider.tf
+++ b/infrastructure/modules/certificate/provider.tf
@@ -2,6 +2,8 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+
+      configuration_aliases = [aws.dns]
     }
   }
 }


### PR DESCRIPTION
We're currently keeping ~1.8TB and spending ~$180 a month on keeping a big collection of Docker images we'll never use. Let's add a lifecycle policy to keep the size of the repos manageable.