### PR TITLE
embed youtube videos with privacy-enhanced mode

### DIFF
--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -642,11 +642,15 @@ export function parseBody(fragment: PrismicFragment[]): BodyType {
             const embedUrl = slice.primary.embed.html.match(
               /src="([-a-zA-Z0-9://.?=_]+)?/
             )[1];
+            const embedUrlWithEnhancedPrivacy = embedUrl.replace(
+              'www.youtube.com',
+              'www.youtube-nocookie.com'
+            );
             return {
               type: 'videoEmbed',
               weight: getWeight(slice.slice_label),
               value: {
-                embedUrl: `${embedUrl}?rel=0`,
+                embedUrl: `${embedUrlWithEnhancedPrivacy}?rel=0`,
                 caption: slice.primary.caption,
               },
             };


### PR DESCRIPTION
While looking at youtube cookies as part of #7581, it became apparent we should probably be embedding the videos with [privacy-enhanced mode turned on](https://support.google.com/youtube/answer/171780?hl=en-GB#zippy=%2Cturn-on-privacy-enhanced-mode)

This does that.

Essentially, it will reduce (but not completely eliminate) the number of cookies that get set by youtube and most will only be set once a user plays the video and not before.

The effect of turning on privacy-enhanced mode is: 

"The privacy-enhanced mode of the YouTube embedded player prevents the use of views of embedded YouTube content from influencing the viewer's browsing experience on YouTube. This means that the view of a video shown in the privacy-enhanced mode of the embedded player will not be used to personalise the YouTube browsing experience, either within your privacy-enhanced mode embedded player or in the viewer's subsequent YouTube viewing experience. 

If ads are served on a video shown in the privacy-enhanced mode of the embedded player, those ads will likewise be non-personalised. In addition, the view of a video shown in the privacy-enhanced mode of the embedded player will not be used to personalise advertising shown to the viewer outside of your site or app."