### PR TITLE
Use a much more naïve approach to email verification

### DIFF
--- a/identity/webapp/pages/validated.tsx
+++ b/identity/webapp/pages/validated.tsx
@@ -104,6 +104,10 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
         // this data from the server side. It isn't really a security issue,
         // as it does not (and cannot) mutate anything that we trust (ie tokens).
         // It is really just here so that we show the correct UI.
+        //
+        // Previously we tried redirecting the user to the login screen, as a way
+        // to do silent auth and refresh their profile, but this didn't work because
+        // the Auth0 session is separate from our application session.
         authSession.user.email_verified = true;
       }
     }


### PR DESCRIPTION
The approach I tried in https://github.com/wellcomecollection/wellcomecollection.org/pull/7624 didn't work reliably - the silent auth sometimes failed because the auth0 session is separate to our application session (sigh). This approach is not ideal, but it's fairly foolproof.