### PR TITLE
Prismic featured serial

### DIFF
--- a/content/webapp/pages/stories.tsx
+++ b/content/webapp/pages/stories.tsx
@@ -10,10 +10,7 @@ import SpacingSection from '@weco/common/views/components/SpacingSection/Spacing
 import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
 import Space from '@weco/common/views/components/styled/Space';
 import { staticBooks } from '../data/static-books';
-import {
-  prismicPageIds,
-  featuredStoriesSeriesId,
-} from '@weco/common/services/prismic/hardcoded-id';
+import { prismicPageIds } from '@weco/common/services/prismic/hardcoded-id';
 import FeaturedText from '@weco/common/views/components/FeaturedText/FeaturedText';
 import { defaultSerializer } from '../components/HTMLSerializers/HTMLSerializers';
 import {
@@ -98,13 +95,12 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     // TODO: If we're only looking up this page to get the featured text slice,
     // would it be faster to skip all the fetchLinks?  Is that possible?
     const storiesPagePromise = fetchPage(client, prismicPageIds.stories);
+    const featuredSerial = await client.client.getSingle('featured-serial');
+    const featuredSerialId = featuredSerial.data.serial!.id;
 
     const featuredSeriesArticlesQueryPromise = fetchArticles(client, {
       predicates: [
-        prismic.predicate.at(
-          'my.articles.series.series',
-          featuredStoriesSeriesId
-        ),
+        prismic.predicate.at('my.articles.series.series', featuredSerialId),
       ],
       page: 1,
       pageSize: 100,
@@ -120,7 +116,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
 
     // The featured series and stories page should always exist
     const series = transformArticleSeries(
-      featuredStoriesSeriesId,
+      featuredSerialId,
       featuredSeriesArticles
     )!.series;
     const featuredText = getPageFeaturedText(transformPage(storiesPage!));

--- a/prismic-model/src/featured-serial.ts
+++ b/prismic-model/src/featured-serial.ts
@@ -1,0 +1,21 @@
+import { CustomType } from './types/CustomType';
+import link from './parts/link';
+
+const featuredSerial: CustomType = {
+  id: 'featured-serial',
+  label: 'Featured serial',
+  repeatable: false,
+  status: true,
+  json: {
+    'Featured serial': {
+      serial: link(
+        'Serial',
+        'document',
+        ['series'],
+        'Select a serial to display on the Stories landing page'
+      ),
+    },
+  },
+};
+
+export default featuredSerial;


### PR DESCRIPTION
## Who is this for?
Content team

## What is it doing for them?
Allowing them to update the featured serial without input from devs or the need for a manual deployment.

The new singleton custom type in Prismic allows for a link to a serial. This is used to render the serial on the stories landing page.

![image](https://user-images.githubusercontent.com/1394592/153208646-f8a6acd7-31bd-4f9f-9d89-a8202c982a31.png)

This is another request to the api, but I couldn't see a way around that.

Also, I was fighting with TypeScript for a while before I gave up and put in the PR. Any help with keeping TS happy would be appreciated.