### PR TITLE
Fix the "Worry Lines" series page

### DIFF
--- a/common/services/prismic/hardcoded-id.ts
+++ b/common/services/prismic/hardcoded-id.ts
@@ -71,6 +71,5 @@ export const sectionLevelPages = [
   prismicPageIds.getInvolved,
 ];
 
-// A couple of article series that still use the `webcomics` type.
+// The only series that uses the `webcomics` type.
 export const bodySquabblesSeries = 'WleP3iQAACUAYEoN';
-export const worryLinesSeries = 'X76JKBMAACIAqtZ2';

--- a/content/webapp/pages/article-series.tsx
+++ b/content/webapp/pages/article-series.tsx
@@ -18,10 +18,7 @@ import SearchResults from '../components/SearchResults/SearchResults';
 import ContentPage from '../components/ContentPage/ContentPage';
 import { looksLikePrismicId } from '../services/prismic';
 import { createClient } from 'services/prismic/fetch';
-import {
-  bodySquabblesSeries,
-  worryLinesSeries,
-} from '@weco/common/services/prismic/hardcoded-id';
+import { bodySquabblesSeries } from '@weco/common/services/prismic/hardcoded-id';
 import { fetchArticles } from 'services/prismic/fetch/articles';
 import * as prismic from 'prismic-client-beta';
 import { isNotUndefined } from '@weco/common/utils/array';
@@ -43,12 +40,12 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
 
     const client = createClient(context);
 
-    // GOTCHA: This is for two series where we have the `webcomics` type.
+    // GOTCHA: This is for a series where we have the `webcomics` type.
     // This will have to remain like this until we figure out how to migrate them.
     // We create new webcomics as an article with comic format, and add
     // an article-series to them.
     const seriesField =
-      id === bodySquabblesSeries || id === worryLinesSeries
+      id === bodySquabblesSeries
         ? 'my.webcomics.series.series'
         : 'my.articles.series.series';
 

--- a/content/webapp/pages/article.tsx
+++ b/content/webapp/pages/article.tsx
@@ -29,6 +29,10 @@ import {
 import { transformContributors } from '../services/prismic/transformers/contributors';
 import { articleLd } from '../services/prismic/transformers/json-ld';
 import { looksLikePrismicId } from 'services/prismic';
+import {
+  bodySquabblesSeries,
+  worryLinesSeries,
+} from '@weco/common/services/prismic/hardcoded-id';
 
 type Props = {
   article: Article;
@@ -117,7 +121,7 @@ const ArticlePage: FC<Props> = ({ article }) => {
       const series = article.series[0];
       if (series) {
         const seriesField =
-          series.id === 'WleP3iQAACUAYEoN' || series.id === 'X8D9qxIAACIAcKSf'
+          series.id === bodySquabblesSeries || series.id === worryLinesSeries
             ? 'my.webcomics.series.series'
             : 'my.articles.series.series';
 

--- a/content/webapp/pages/article.tsx
+++ b/content/webapp/pages/article.tsx
@@ -29,10 +29,7 @@ import {
 import { transformContributors } from '../services/prismic/transformers/contributors';
 import { articleLd } from '../services/prismic/transformers/json-ld';
 import { looksLikePrismicId } from 'services/prismic';
-import {
-  bodySquabblesSeries,
-  worryLinesSeries,
-} from '@weco/common/services/prismic/hardcoded-id';
+import { bodySquabblesSeries } from '@weco/common/services/prismic/hardcoded-id';
 
 type Props = {
   article: Article;
@@ -121,7 +118,7 @@ const ArticlePage: FC<Props> = ({ article }) => {
       const series = article.series[0];
       if (series) {
         const seriesField =
-          series.id === bodySquabblesSeries || series.id === worryLinesSeries
+          series.id === bodySquabblesSeries
             ? 'my.webcomics.series.series'
             : 'my.articles.series.series';
 


### PR DESCRIPTION
The series page for "Worry Lines" is https://wellcomecollection.org/series/X76JKBMAACIAqtZ2, but it's been 404'ing for a while, because the Prismic query for finding articles on the page is wrong – it returns an empty result set, so the page 404s.

It looks like somebody migrated it out of the "webcomic" type, so we no longer need the special casing on the article series page.