### PR TITLE
Fetch related content on exhibitions using the new typed fetchers

### DIFF
--- a/common/services/prismic/exhibitions.js
+++ b/common/services/prismic/exhibitions.js
@@ -1,23 +1,3 @@
-// @flow
-import { getTypeByIds } from './api';
-import { parseMultiContent } from './multi-content';
-import {
-  exhibitionFields,
-  eventAccessOptionsFields,
-  teamsFields,
-  eventFormatsFields,
-  placesFields,
-  interpretationTypesFields,
-  audiencesFields,
-  eventSeriesFields,
-  organisationsFields,
-  peopleFields,
-  contributorsFields,
-  eventPoliciesFields,
-  articleSeriesFields,
-  articleFormatsFields,
-  articlesFields,
-} from './fetch-links';
 // $FlowFixMe (ts)
 import { breakpoints } from '../../utils/breakpoints';
 import {
@@ -44,7 +24,6 @@ import type {
   UiExhibit,
   ExhibitionFormat,
 } from '../../model/exhibitions';
-import type { MultiContent } from '../../model/multi-content';
 
 function parseResourceTypeList(
   fragment: PrismicFragment[],
@@ -185,47 +164,4 @@ export function parseExhibitionDoc(document: PrismicDocument): UiExhibition {
     : [{ text: 'Exhibition' }];
 
   return { ...exhibition, labels };
-}
-
-type ExhibitionRelatedContent = {|
-  exhibitionOfs: MultiContent[],
-  exhibitionAbouts: MultiContent[],
-|};
-
-export async function getExhibitionRelatedContent(
-  req: ?Request,
-  ids: string[]
-): Promise<ExhibitionRelatedContent> {
-  const fetchLinks = [
-    eventAccessOptionsFields,
-    teamsFields,
-    eventFormatsFields,
-    placesFields,
-    interpretationTypesFields,
-    audiencesFields,
-    organisationsFields,
-    peopleFields,
-    contributorsFields,
-    eventSeriesFields,
-    eventPoliciesFields,
-    contributorsFields,
-    articleSeriesFields,
-    articleFormatsFields,
-    exhibitionFields,
-    articlesFields,
-  ];
-  const types = ['exhibitions', 'events', 'articles', 'books'];
-  const extraContent = await getTypeByIds(req, types, ids, { fetchLinks });
-  const parsedContent = parseMultiContent(extraContent.results).filter(doc => {
-    return !(doc.type === 'events' && doc.isPast);
-  });
-
-  return {
-    exhibitionOfs: parsedContent.filter(
-      doc => doc.type === 'exhibitions' || doc.type === 'events'
-    ),
-    exhibitionAbouts: parsedContent.filter(
-      doc => doc.type === 'books' || doc.type === 'articles'
-    ),
-  };
 }

--- a/content/webapp/services/prismic/fetch/index.ts
+++ b/content/webapp/services/prismic/fetch/index.ts
@@ -141,7 +141,7 @@ export function fetcher<Document extends PrismicDocument>(
       // e.g. at one point we forgot to include the "params" query in the cache key,
       // so every article was showing the same set of related stories.
       //
-      // See https://github.com/wellcomecollection/wellcomecollection.org/issues
+      // See https://github.com/wellcomecollection/wellcomecollection.org/issues/7461
       const urlSearchParams = new URLSearchParams();
       urlSearchParams.set('params', JSON.stringify(params));
 

--- a/content/webapp/services/prismic/transformers/exhibitions.ts
+++ b/content/webapp/services/prismic/transformers/exhibitions.ts
@@ -1,11 +1,18 @@
 import { parseExhibitionDoc } from '@weco/common/services/prismic/exhibitions';
 import { Exhibition as DeprecatedExhibition } from '@weco/common/model/exhibitions';
-import { Exhibition } from '../../../types/exhibitions';
-import { ExhibitionPrismicDocument } from '../types/exhibitions';
+import {
+  Exhibition,
+  ExhibitionRelatedContent,
+} from '../../../types/exhibitions';
+import {
+  ExhibitionPrismicDocument,
+  ExhibitionRelatedContentPrismicDocument,
+} from '../types/exhibitions';
 import { Query } from '@prismicio/types';
 import { PaginatedResults } from '@weco/common/services/prismic/types';
 import { transformQuery } from './paginated-results';
 import { london } from '@weco/common/utils/format-date';
+import { transformMultiContent } from './multi-content';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function transformExhibition(
@@ -66,3 +73,23 @@ function putPermanentAfterCurrentExhibitions(
     ...groupedResults.past,
   ];
 }
+
+export const transformExhibitionRelatedContent = (
+  query: Query<ExhibitionRelatedContentPrismicDocument>
+): ExhibitionRelatedContent => {
+  const parsedContent = transformQuery(
+    query,
+    transformMultiContent
+  ).results.filter(doc => {
+    return !(doc.type === 'events' && doc.isPast);
+  });
+
+  return {
+    exhibitionOfs: parsedContent.filter(
+      doc => doc.type === 'exhibitions' || doc.type === 'events'
+    ),
+    exhibitionAbouts: parsedContent.filter(
+      doc => doc.type === 'books' || doc.type === 'articles'
+    ),
+  } as ExhibitionRelatedContent;
+};

--- a/content/webapp/services/prismic/types/exhibitions.ts
+++ b/content/webapp/services/prismic/types/exhibitions.ts
@@ -13,6 +13,9 @@ import {
   WithExhibitionParents,
   WithSeasons,
 } from '.';
+import { ArticlePrismicDocument } from './articles';
+import { BookPrismicDocument } from './books';
+import { EventPrismicDocument } from './events';
 
 const typeEnum = 'exhibitions';
 
@@ -55,3 +58,9 @@ export type ExhibitionPrismicDocument = PrismicDocument<
     CommonPrismicFields,
   typeof typeEnum
 >;
+
+export type ExhibitionRelatedContentPrismicDocument =
+  | ExhibitionPrismicDocument
+  | EventPrismicDocument
+  | ArticlePrismicDocument
+  | BookPrismicDocument;

--- a/content/webapp/types/exhibitions.ts
+++ b/content/webapp/types/exhibitions.ts
@@ -1,6 +1,9 @@
 import { Exhibition as DeprecatedExhibition } from '@weco/common/model/exhibitions';
 import { Override } from '@weco/common/utils/utility-types';
 import { ExhibitionPrismicDocument } from '../services/prismic/types/exhibitions';
+import { Article } from './articles';
+import { Book } from './books';
+import { Event } from './events';
 
 export type Exhibition = Override<
   DeprecatedExhibition,
@@ -8,3 +11,8 @@ export type Exhibition = Override<
     prismicDocument: ExhibitionPrismicDocument;
   }
 >;
+
+export type ExhibitionRelatedContent = {
+  exhibitionOfs: (Exhibition | Event)[];
+  exhibitionAbouts: (Book | Article)[];
+};


### PR DESCRIPTION
For https://github.com/wellcomecollection/wellcomecollection.org/issues/7363 / https://github.com/wellcomecollection/wellcomecollection.org/issues/7426; this takes out another client-side fetcher.

At some point I think we should rethink how the API works – currently it returns the raw Prismic documents, but that means we have to send the Prismic types to the browser, so we can transform them into our models. It feels like it would be more efficient to have it return our types, already transformed – but that's a question for a separate PR.

I've checked this is working locally using the related content on http://localhost:3000/exhibitions/XFHHShUAAAU_pE70