### PR TITLE
Add featured-books to prismic model

### DIFF
--- a/prismic-model/src/featured-books.ts
+++ b/prismic-model/src/featured-books.ts
@@ -1,0 +1,17 @@
+import link from './parts/link';
+import list from './parts/list';
+import { CustomType } from './types/CustomType';
+
+const featuredBooks: CustomType = {
+  id: 'featured-books',
+  label: 'Featured books',
+  repeatable: false,
+  status: true,
+  json: {
+    'Featured books': {
+      books: list('books', link('book', 'document', ['books'], 'book')),
+    },
+  },
+};
+
+export default featuredBooks;


### PR DESCRIPTION
## Who is this for?
Content team

## What is it doing for them?
Giving them a custom type to allow for cms-able books on the `/stories` page