### PR TITLE
platform-5415: don't return non-archive ancestors

### DIFF
--- a/catalogue/webapp/test/works.test.ts
+++ b/catalogue/webapp/test/works.test.ts
@@ -212,6 +212,9 @@ describe('getArchiveAncestorArray', () => {
         type: 'Series',
         totalParts: 1,
         totalDescendentParts: 2,
+        alternativeTitles: [],
+        availableOnline: false,
+        availabilities: [],
       },
       {
         referenceNumber: 'a/b',
@@ -219,6 +222,9 @@ describe('getArchiveAncestorArray', () => {
         type: 'Collection',
         totalParts: 1,
         totalDescendentParts: 1,
+        alternativeTitles: [],
+        availableOnline: false,
+        availabilities: [],
         partOf: [
           {
             referenceNumber: 'a',
@@ -226,6 +232,9 @@ describe('getArchiveAncestorArray', () => {
             type: 'Series',
             totalParts: 1,
             totalDescendentParts: 2,
+            alternativeTitles: [],
+            availableOnline: false,
+            availabilities: [],
           },
         ],
       },

--- a/catalogue/webapp/test/works.test.ts
+++ b/catalogue/webapp/test/works.test.ts
@@ -210,16 +210,22 @@ describe('getArchiveAncestorArray', () => {
         referenceNumber: 'a',
         title: 'An Archive Series',
         type: 'Series',
+        totalParts: 1,
+        totalDescendentParts: 2,
       },
       {
         referenceNumber: 'a/b',
         title: 'An Archive Collection',
         type: 'Collection',
+        totalParts: 1,
+        totalDescendentParts: 1,
         partOf: [
           {
             referenceNumber: 'a',
             title: 'An Archive Series',
             type: 'Series',
+            totalParts: 1,
+            totalDescendentParts: 2,
           },
         ],
       },

--- a/catalogue/webapp/test/works.test.ts
+++ b/catalogue/webapp/test/works.test.ts
@@ -11,6 +11,8 @@ import { getTabbableIds } from '../components/ArchiveTree/ArchiveTree';
 import {
   workFixture,
   workWithPartOf,
+  workWithLibrarySeriesPartOf,
+  workWithMixedPartOf,
 } from '@weco/common/test/fixtures/catalogueApi/work';
 import { uiTree, idArray } from '../__mocks__/uiTree';
 
@@ -62,6 +64,13 @@ describe('getItemIdentifiersWith', () => {
 });
 
 describe('getArchiveAncestorArray', () => {
+  it('Does not get the ancestors of a non-archive work', () => {
+    const archiveAncestorArray = getArchiveAncestorArray(
+      workWithLibrarySeriesPartOf
+    );
+    expect(archiveAncestorArray).toStrictEqual([]);
+  });
+
   it('gets the ancestors of an archive work', () => {
     const archiveAncestorArray = getArchiveAncestorArray(workWithPartOf);
     expect(archiveAncestorArray).toStrictEqual([
@@ -190,6 +199,29 @@ describe('getArchiveAncestorArray', () => {
         totalDescendentParts: 9,
         totalParts: 9,
         type: 'Series',
+      },
+    ]);
+  });
+
+  it('Does not return non-archive parents', () => {
+    const archiveAncestorArray = getArchiveAncestorArray(workWithMixedPartOf);
+    expect(archiveAncestorArray).toStrictEqual([
+      {
+        referenceNumber: 'a',
+        title: 'An Archive Series',
+        type: 'Series',
+      },
+      {
+        referenceNumber: 'a/b',
+        title: 'An Archive Collection',
+        type: 'Collection',
+        partOf: [
+          {
+            referenceNumber: 'a',
+            title: 'An Archive Series',
+            type: 'Series',
+          },
+        ],
       },
     ]);
   });

--- a/catalogue/webapp/utils/works.ts
+++ b/catalogue/webapp/utils/works.ts
@@ -297,15 +297,54 @@ export const getCardLabels = (work: Work): Label[] => {
 };
 
 function makeArchiveAncestorArray(partOfArray, nextPart) {
-  if (!nextPart) return partOfArray;
+  /*
+  Recursively populate a list of ancestors (i.e. things that this object is "part of")
+
+  Objects outside of this strict single-parent hierarchy are ignored.
+
+  The returned list is ordered from closest to furthest (parent, grandparent, great grandparent).
+  */
+  if (!nextPart) {
+    return partOfArray;
+  }
   return makeArchiveAncestorArray(
     [...partOfArray, nextPart],
-    nextPart?.partOf?.[0]
+    hierarchicalParentOf(nextPart)
   );
 }
 
+function hierarchicalParentOf(work) {
+  /*
+  Return the immediate parent of a Work within a strict single parent hierarchy.
+
+  The partOf member of a Work contains a tree of objects to which this Work belongs.
+
+  In strictly hierarchical content (Archive Collection data), each Work will have
+  maximally one partOf value. However, partOf is a list that may contain other
+  parents or containers.
+
+  Only those with an appropriate path-like referenceNumber value are part of the hierarchy.
+
+  partOf relationships may exist without referenceNumber values.
+  These should be excluded from the ancestor hierarchy as they
+  may represent an excessively broad member lists or multi-parent hierarchies
+  such as Library Series.
+  */
+  if (!work || !work.partOf) {
+    return;
+  }
+  for (const candidate of work.partOf) {
+    if (candidate.referenceNumber) {
+      return candidate;
+    }
+  }
+}
+
 export function getArchiveAncestorArray(work: Work): RelatedWork[] {
-  return makeArchiveAncestorArray([], work?.partOf?.[0]).reverse();
+  /*
+  Return all the ancestors of work starting with the most distant.
+  */
+  return makeArchiveAncestorArray([], hierarchicalParentOf(work)).reverse();
 }
 
 type DigitalLocationInfo = {

--- a/catalogue/webapp/utils/works.ts
+++ b/catalogue/webapp/utils/works.ts
@@ -323,9 +323,11 @@ function hierarchicalParentOf(work) {
   maximally one partOf value. However, partOf is a list that may contain other
   parents or containers.
 
-  Only those with an appropriate path-like referenceNumber value are part of the hierarchy.
+  The number of child objects that any given object in the partOf hierarchy has is
+  stored in the totalParts property.
 
-  partOf relationships may exist without referenceNumber values.
+  Any object in the partOf list that has no parts is not part of the hierarchy.
+
   These should be excluded from the ancestor hierarchy as they
   may represent an excessively broad member lists or multi-parent hierarchies
   such as Library Series.
@@ -334,7 +336,7 @@ function hierarchicalParentOf(work) {
     return;
   }
   for (const candidate of work.partOf) {
-    if (candidate.referenceNumber) {
+    if (candidate.totalParts) {
       return candidate;
     }
   }

--- a/common/test/fixtures/catalogueApi/work.ts
+++ b/common/test/fixtures/catalogueApi/work.ts
@@ -368,6 +368,40 @@ export const workFixture: Work = {
   type: 'Work',
 };
 
+/*
+partOf objects that represent a Library Series do not have Archive referenceNumbers.
+*/
+
+export const workWithLibrarySeriesPartOf: Work = {
+  alternativeTitles: [],
+  availabilities: [
+    {
+      id: 'in-library',
+      label: 'In the library',
+      type: 'Availability',
+    },
+  ],
+  id: 'xwk27yj7',
+  partOf: [
+    {
+      title: 'Edinburgh medical and surgical journal',
+      type: 'Series',
+    },
+  ],
+  physicalDescription: 'pages 23-28',
+  title: 'Notice of an instance of molluscum chronicum / by Henry Nebel.',
+  type: 'Work',
+  workType: {
+    id: 'a',
+    label: 'Books',
+    type: 'Format',
+  },
+};
+
+/*
+An Archive Work with a partOf hierarchy.
+partOf entries in Archive Works have hierarchical reference numbers.
+*/
 export const workWithPartOf: Work = {
   holdings: [],
   id: 'pbtyx2xx',
@@ -662,4 +696,42 @@ export const workWithPartOf: Work = {
     },
   ],
   type: 'Work',
+};
+
+export const workWithMixedPartOf: Work = {
+  alternativeTitles: [],
+  availabilities: [
+    {
+      id: 'in-library',
+      label: 'In the library',
+      type: 'Availability',
+    },
+  ],
+  referenceNumber: 'a/b/c',
+  id: 'baadf00d',
+  title: 'Something I made up',
+  type: 'Work',
+  workType: {
+    id: 'a',
+    label: 'Books',
+    type: 'Format',
+  },
+  partOf: [
+    {
+      title: 'A Library Series',
+      type: 'Series',
+    },
+    {
+      referenceNumber: 'a/b',
+      title: 'An Archive Collection',
+      type: 'Collection',
+      partOf: [
+        {
+          referenceNumber: 'a',
+          title: 'An Archive Series',
+          type: 'Series',
+        },
+      ],
+    },
+  ],
 };

--- a/common/test/fixtures/catalogueApi/work.ts
+++ b/common/test/fixtures/catalogueApi/work.ts
@@ -387,7 +387,6 @@ export const workWithLibrarySeriesPartOf: Work = {
       id: 'gzgg4hzp',
       title: 'Edinburgh medical and surgical journal',
       type: 'Series',
-      referenceNumber: 'A Library Series',
       alternativeTitles: [],
       referenceNumber: 'Edinburgh medical and surgical journal',
       availableOnline: false,
@@ -411,6 +410,8 @@ export const workWithLibrarySeriesPartOf: Work = {
   precededBy: [],
   succeededBy: [],
   notes: [],
+  parts: [],
+  holdings: [],
 };
 
 /*
@@ -732,17 +733,18 @@ export const workWithMixedPartOf: Work = {
   },
   partOf: [
     {
+      id: 'cafed00d',
       title: 'A Library Series',
       referenceNumber: 'A Library Series',
       type: 'Series',
       totalParts: 0,
       totalDescendentParts: 0,
       alternativeTitles: [],
-      referenceNumber: '',
       availableOnline: false,
       availabilities: [],
     },
     {
+      id: 'cafebeef',
       referenceNumber: 'a/b',
       title: 'An Archive Collection',
       type: 'Collection',
@@ -753,6 +755,7 @@ export const workWithMixedPartOf: Work = {
       availabilities: [],
       partOf: [
         {
+          id: 'f00dcafe',
           referenceNumber: 'a',
           title: 'An Archive Series',
           type: 'Series',
@@ -775,4 +778,7 @@ export const workWithMixedPartOf: Work = {
   precededBy: [],
   succeededBy: [],
   notes: [],
+  parts: [],
+  holdings: [],
+  physicalDescription: '',
 };

--- a/common/test/fixtures/catalogueApi/work.ts
+++ b/common/test/fixtures/catalogueApi/work.ts
@@ -720,16 +720,22 @@ export const workWithMixedPartOf: Work = {
     {
       title: 'A Library Series',
       type: 'Series',
+      totalParts: 0,
+      totalDescendentParts: 0,
     },
     {
       referenceNumber: 'a/b',
       title: 'An Archive Collection',
       type: 'Collection',
+      totalParts: 1,
+      totalDescendentParts: 1,
       partOf: [
         {
           referenceNumber: 'a',
           title: 'An Archive Series',
           type: 'Series',
+          totalParts: 1,
+          totalDescendentParts: 2,
         },
       ],
     },

--- a/common/test/fixtures/catalogueApi/work.ts
+++ b/common/test/fixtures/catalogueApi/work.ts
@@ -402,6 +402,15 @@ export const workWithLibrarySeriesPartOf: Work = {
     label: 'Books',
     type: 'Format',
   },
+  subjects: [],
+  genres: [],
+  contributors: [],
+  identifiers: [],
+  production: [],
+  languages: [],
+  precededBy: [],
+  succeededBy: [],
+  notes: [],
 };
 
 /*
@@ -705,7 +714,6 @@ export const workWithPartOf: Work = {
 };
 
 export const workWithMixedPartOf: Work = {
-  alternativeTitles: [],
   availabilities: [
     {
       id: 'in-library',
@@ -757,4 +765,14 @@ export const workWithMixedPartOf: Work = {
       ],
     },
   ],
+  alternativeTitles: [],
+  subjects: [],
+  genres: [],
+  contributors: [],
+  identifiers: [],
+  production: [],
+  languages: [],
+  precededBy: [],
+  succeededBy: [],
+  notes: [],
 };

--- a/common/test/fixtures/catalogueApi/work.ts
+++ b/common/test/fixtures/catalogueApi/work.ts
@@ -384,8 +384,14 @@ export const workWithLibrarySeriesPartOf: Work = {
   id: 'xwk27yj7',
   partOf: [
     {
+      id: 'gzgg4hzp',
       title: 'Edinburgh medical and surgical journal',
       type: 'Series',
+      referenceNumber: 'A Library Series',
+      alternativeTitles: [],
+      referenceNumber: 'Edinburgh medical and surgical journal',
+      availableOnline: false,
+      availabilities: [],
     },
   ],
   physicalDescription: 'pages 23-28',
@@ -719,9 +725,14 @@ export const workWithMixedPartOf: Work = {
   partOf: [
     {
       title: 'A Library Series',
+      referenceNumber: 'A Library Series',
       type: 'Series',
       totalParts: 0,
       totalDescendentParts: 0,
+      alternativeTitles: [],
+      referenceNumber: '',
+      availableOnline: false,
+      availabilities: [],
     },
     {
       referenceNumber: 'a/b',
@@ -729,6 +740,9 @@ export const workWithMixedPartOf: Work = {
       type: 'Collection',
       totalParts: 1,
       totalDescendentParts: 1,
+      alternativeTitles: [],
+      availableOnline: false,
+      availabilities: [],
       partOf: [
         {
           referenceNumber: 'a',
@@ -736,6 +750,9 @@ export const workWithMixedPartOf: Work = {
           type: 'Series',
           totalParts: 1,
           totalDescendentParts: 2,
+          alternativeTitles: [],
+          availableOnline: false,
+          availabilities: [],
         },
       ],
     },


### PR DESCRIPTION
https://github.com/wellcomecollection/platform/issues/5415
(as part of preliminary work for https://github.com/wellcomecollection/platform/issues/5408)

## What is it doing for them?

This change ensures that there is a way to prevent new partOf relationships creating unexpected and explosive hierarchy trees.

The signal as to whether to include it in the hierarchy is whether it has any parts underneath it.  This means that there is no need for an API change specifically to serve this UI (e.g. an "includeInHierarchy" field).