### PR TITLE
Start converting the Prismic transformers to TypeScript

### DIFF
--- a/common/services/prismic/articles.js
+++ b/common/services/prismic/articles.js
@@ -15,7 +15,7 @@ import type { Article } from '../../model/articles';
 import type { MultiContent } from '../../model/multi-content';
 import type { PrismicDocument } from './types';
 
-function parseContentLink(document: ?PrismicDocument): ?MultiContent {
+export function parseContentLink(document: ?PrismicDocument): ?MultiContent {
   if (!document) {
     return;
   }

--- a/content/webapp/pages/article.tsx
+++ b/content/webapp/pages/article.tsx
@@ -2,7 +2,6 @@ import { GetServerSideProps } from 'next';
 import { Fragment, FC, useState, useEffect, ReactElement } from 'react';
 import { Article } from '@weco/common/model/articles';
 import { ArticleSeries } from '@weco/common/model/article-series';
-import { parseArticleDoc } from '@weco/common/services/prismic/articles';
 import { classNames, font } from '@weco/common/utils/classnames';
 import { capitalize } from '@weco/common/utils/grammar';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
@@ -30,6 +29,7 @@ import { transformContributors } from '../services/prismic/transformers/contribu
 import { articleLd } from '../services/prismic/transformers/json-ld';
 import { looksLikePrismicId } from 'services/prismic';
 import { bodySquabblesSeries } from '@weco/common/services/prismic/hardcoded-id';
+import { transformArticle } from 'services/prismic/transformers/articles';
 
 type Props = {
   article: Article;
@@ -53,7 +53,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     const serverData = await getServerData(context);
 
     if (articleDocument) {
-      const article = parseArticleDoc(articleDocument);
+      const article = transformArticle(articleDocument);
       return {
         props: removeUndefinedProps({
           article,

--- a/content/webapp/pages/article.tsx
+++ b/content/webapp/pages/article.tsx
@@ -122,6 +122,7 @@ const ArticlePage: FC<Props> = ({ article }) => {
             ? 'my.webcomics.series.series'
             : 'my.articles.series.series';
 
+        
         const articlesInSeries =
           series &&
           (await fetchArticlesClientSide({
@@ -129,7 +130,7 @@ const ArticlePage: FC<Props> = ({ article }) => {
           }));
 
         const articles =
-          articlesInSeries?.results.map(doc => parseArticleDoc(doc)) ?? [];
+          articlesInSeries?.results.map(doc => transformArticle(doc)) ?? [];
 
         if (series) {
           setListOfSeries([{ series, articles }]);

--- a/content/webapp/services/prismic/transformers/articles.ts
+++ b/content/webapp/services/prismic/transformers/articles.ts
@@ -1,14 +1,55 @@
-import { parseArticleDoc } from '@weco/common/services/prismic/articles';
-import { Article as DeprecatedArticle } from '@weco/common/model/articles';
 import { Article } from '../../../types/articles';
 import { ArticlePrismicDocument } from '../types/articles';
+import {
+  asText,
+  isDocumentLink,
+  parseGenericFields,
+  parseLabelType,
+  parseSingleLevelGroup,
+  parseSeason,
+} from '@weco/common/services/prismic/parsers';
+import { parseContentLink } from '@weco/common/services/prismic/articles';
+import { parseArticleSeries } from '@weco/common/services/prismic/article-series';
+import { london } from '@weco/common/utils/format-date';
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function transformArticle(document: ArticlePrismicDocument): Article {
-  const article: DeprecatedArticle = parseArticleDoc(document);
+  const { data } = document;
+  // When we imported data into Prismic from the Wordpress blog some content
+  // needed to have its original publication date displayed. It is purely a display
+  // value and does not affect ordering.
+
+  const datePublished =
+    data.publishDate || document.first_publication_date || undefined;
+
+  const article = {
+    type: 'articles',
+    ...parseGenericFields(document),
+    format: isDocumentLink(data.format) ? parseLabelType(data.format) : null,
+    datePublished: london(datePublished).toDate(),
+    series: parseSingleLevelGroup(data.series, 'series').map(series => {
+      return parseArticleSeries(series);
+    }),
+    seasons: parseSingleLevelGroup(data.seasons, 'season').map(season => {
+      return parseSeason(season);
+    }),
+  };
+
+  const labels = [
+    article.format ? { text: article.format.title || '' } : null,
+    article.series.find(series => series.schedule.length > 0)
+      ? { text: 'Serial' }
+      : null,
+  ].filter(Boolean);
 
   return {
     ...article,
+    labels: labels.length > 0 ? labels : [{ text: 'Story' }],
+    outroResearchLinkText: asText(data.outroResearchLinkText),
+    outroResearchItem: parseContentLink(data.outroResearchItem),
+    outroReadLinkText: asText(data.outroReadLinkText),
+    outroReadItem: parseContentLink(data.outroReadItem),
+    outroVisitLinkText: asText(data.outroVisitLinkText),
+    outroVisitItem: parseContentLink(data.outroVisitItem),
     prismicDocument: document,
   };
 }

--- a/content/webapp/services/prismic/transformers/books.ts
+++ b/content/webapp/services/prismic/transformers/books.ts
@@ -38,8 +38,7 @@ export function transformBook(document: BookPrismicDocument): Book {
     extent: transformKeyTextField(data.extent),
     isbn: transformKeyTextField(data.isbn),
     reviews:
-      data.reviews &&
-      data.reviews.map(review => {
+      data.reviews?.map(review => {
         return {
           text: review.text && asHtml(review.text),
           citation: review.citation && asHtml(review.citation),

--- a/content/webapp/services/prismic/transformers/event-series.ts
+++ b/content/webapp/services/prismic/transformers/event-series.ts
@@ -1,16 +1,32 @@
-import { parseEventSeries } from '@weco/common/services/prismic/event-series';
-import { EventSeries as DeprecatedEventSeries } from '@weco/common/model/event-series';
 import { EventSeries } from '../../../types/event-series';
 import { EventSeriesPrismicDocument } from '../types/event-series';
+import {
+  parseGenericFields,
+  parseBackgroundTexture,
+} from '@weco/common/services/prismic/parsers';
+import { link } from './vendored-helpers';
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function transformEventSeries(
   document: EventSeriesPrismicDocument
 ): EventSeries {
-  const eventSeries: DeprecatedEventSeries = parseEventSeries(document);
+  const genericFields = parseGenericFields(document);
+  const backgroundTexture =
+    document.data.backgroundTexture &&
+    link(document.data.backgroundTexture) &&
+    document.data.backgroundTexture.data;
+  const labels = [
+    {
+      text: 'Event series',
+    },
+  ];
 
   return {
-    ...eventSeries,
+    ...genericFields,
+    type: 'event-series',
+    backgroundTexture: backgroundTexture
+      ? parseBackgroundTexture(backgroundTexture)
+      : null,
+    labels: labels,
     prismicDocument: document,
   };
 }


### PR DESCRIPTION
For https://github.com/wellcomecollection/wellcomecollection.org/issues/7363

We've now refactored the front-end to fetch documents from Prismic using the new typed fetchers; these then call various `parse()` methods in the common library that are Flow-typed JavaScript. These parser methods are the last major use of Flow in the codebase, and I want to get them flipped over to TypeScript.

All that parsing code is heavily interlinked and dependent; trying to convert it all in one go would almost certainly introduce bugs. This is my attempt to start migrating it in little pieces.

I've taken three uses of the old methods in our TypeScript codebase (`parseArticleDoc`, `parseBook` and `parseEventSeries`), and copy/pasted the definition of those functions into TypeScript. It means we get unchanged functionality, but gradually more and more of this code is in TypeScript. It introduces a bit of duplication, but if we keep picking away at this, we'll be able to start removing the JavaScript versions when the only place they're imported is in a TypeScript file.