### PR TITLE
Handle getting an `undefined` passed to `link()`

### DIFF
--- a/content/webapp/services/prismic/transformers/events.ts
+++ b/content/webapp/services/prismic/transformers/events.ts
@@ -77,15 +77,16 @@ export function transformEvent(
     )
     .filter(Boolean);
 
-  const bookingEnquiryTeam: Team | undefined = link(data.bookingEnquiryTeam)
-    ? {
-        id: data.bookingEnquiryTeam.id,
-        title: asText(data.bookingEnquiryTeam.data?.title) || '',
-        email: data.bookingEnquiryTeam.data!.email!,
-        phone: data.bookingEnquiryTeam.data!.phone!,
-        url: data.bookingEnquiryTeam.data!.url!,
-      }
-    : undefined;
+  const bookingEnquiryTeam: Team | undefined =
+    data.bookingEnquiryTeam && link(data.bookingEnquiryTeam)
+      ? {
+          id: data.bookingEnquiryTeam.id,
+          title: asText(data.bookingEnquiryTeam.data?.title) || '',
+          email: data.bookingEnquiryTeam.data!.email!,
+          phone: data.bookingEnquiryTeam.data!.phone!,
+          url: data.bookingEnquiryTeam.data!.url!,
+        }
+      : undefined;
 
   const thirdPartyBooking = {
     name: data.thirdPartyBookingName,

--- a/content/webapp/services/prismic/transformers/vendored-helpers.ts
+++ b/content/webapp/services/prismic/transformers/vendored-helpers.ts
@@ -17,6 +17,7 @@ import type {
   LinkField,
   SliceZone,
 } from '@prismicio/types';
+import { isNotUndefined } from '@weco/common/utils/array';
 
 /**
  * Determines if a Link field is filled.
@@ -25,7 +26,7 @@ import type {
  *
  * @returns `true` if `field` is filled, `false` otherwise.
  *
- * From https://github.com/prismicio/prismic-helpers/blob/b7c404126ff8cce47b2afd408a2ff901a9ebb1fd/src/isFilled.ts#L103-L121
+ * Based on https://github.com/prismicio/prismic-helpers/blob/b7c404126ff8cce47b2afd408a2ff901a9ebb1fd/src/isFilled.ts#L103-L121
  */
 export const link = <
   TypeEnum = string,
@@ -35,7 +36,7 @@ export const link = <
     AnyRegularField | GroupField | SliceZone
   > = never
 >(
-  field: LinkField<TypeEnum, LangEnum, DataInterface>
+  field: LinkField<TypeEnum, LangEnum, DataInterface> | undefined
 ): field is LinkField<TypeEnum, LangEnum, DataInterface, 'filled'> => {
-  return 'id' in field || 'url' in field;
+  return isNotUndefined(field) ? 'id' in field || 'url' in field : false;
 };


### PR DESCRIPTION
This fixes the error on http://www-stage.wellcomecollection.org/articles/W_LXOxcAACwAxC5_

I'm not sure why this wasn't caught by TypeScript. 😕 