### PR TITLE
Add serverData to images page

### DIFF
--- a/catalogue/webapp/pages/images.tsx
+++ b/catalogue/webapp/pages/images.tsx
@@ -269,6 +269,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
 
     return {
       props: removeUndefinedProps({
+        serverData,
         images,
         imagesRouteProps: params,
         pageview: {


### PR DESCRIPTION
## Who is this for?
Devs

## What is it doing for them?
Letting them see the `/images` page in development