### PR TITLE
Use more TypeScript for transformers; start to get into helper functions

### DIFF
--- a/common/model/events.ts
+++ b/common/model/events.ts
@@ -33,6 +33,7 @@ export type UiEventSeries = EventSeries & {
 type InterpretationType = {
   id: string;
   title: string;
+  abbreviation?: string;
   description?: HTMLString;
   primaryDescription?: HTMLString;
 };

--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -747,25 +747,11 @@ export function parseGenericFields(doc: PrismicFragment): GenericContentFields {
       ? data.promo
           .filter(slice => slice.primary.image)
           .map(({ primary: { image } }) => {
-            const originalImage = isImageLink(image) && parseImage(image);
-            const squareImage =
-              image.square &&
-              isImageLink(image.square) &&
-              parseImage(image.square);
-            const widescreenImage =
-              image['16:9'] &&
-              isImageLink(image['16:9']) &&
-              parseImage(image['16:9']);
-            const superWidescreenImage =
-              image['32:15'] &&
-              isImageLink(image['32:15']) &&
-              parseImage(image['32:15']);
-
             return {
-              image: originalImage,
-              squareImage,
-              widescreenImage,
-              superWidescreenImage,
+              image: checkAndParseImage(image),
+              squareImage: checkAndParseImage(image.square),
+              widescreenImage: checkAndParseImage(image['16:9']),
+              superWidescreenImage: checkAndParseImage(image['32:15']),
             };
           })
           .find(_ => _)

--- a/content/webapp/services/prismic/transformers/articles.ts
+++ b/content/webapp/services/prismic/transformers/articles.ts
@@ -7,8 +7,6 @@ import {
   parseLabelType,
   parseSingleLevelGroup,
 } from '@weco/common/services/prismic/parsers';
-import { parseSeason } from '@weco/common/services/prismic/seasons';
-import { parseArticleSeries } from '@weco/common/services/prismic/article-series';
 import { london } from '@weco/common/utils/format-date';
 import {
   isFilledLinkToDocumentWithData,
@@ -17,6 +15,8 @@ import {
 import { LinkField } from '@prismicio/types';
 import { MultiContent, transformMultiContent } from './multi-content';
 import { Weblink } from '@weco/common/model/weblinks';
+import { transformSeries } from './series';
+import { transformSeason } from './seasons';
 
 export function transformContentLink(
   document?: LinkField
@@ -55,10 +55,10 @@ export function transformArticle(document: ArticlePrismicDocument): Article {
     format: isDocumentLink(data.format) ? parseLabelType(data.format) : null,
     datePublished: london(datePublished).toDate(),
     series: parseSingleLevelGroup(data.series, 'series').map(series => {
-      return parseArticleSeries(series);
+      return transformSeries(series);
     }),
     seasons: parseSingleLevelGroup(data.seasons, 'season').map(season => {
-      return parseSeason(season);
+      return transformSeason(season);
     }),
   };
 

--- a/content/webapp/services/prismic/transformers/articles.ts
+++ b/content/webapp/services/prismic/transformers/articles.ts
@@ -3,7 +3,6 @@ import { ArticlePrismicDocument } from '../types/articles';
 import {
   asText,
   isDocumentLink,
-  parseGenericFields,
   parseLabelType,
   parseSingleLevelGroup,
 } from '@weco/common/services/prismic/parsers';
@@ -17,6 +16,7 @@ import { MultiContent, transformMultiContent } from './multi-content';
 import { Weblink } from '@weco/common/model/weblinks';
 import { transformSeries } from './series';
 import { transformSeason } from './seasons';
+import { transformGenericFields } from '.';
 
 export function transformContentLink(
   document?: LinkField
@@ -51,7 +51,7 @@ export function transformArticle(document: ArticlePrismicDocument): Article {
 
   const article = {
     type: 'articles',
-    ...parseGenericFields(document),
+    ...transformGenericFields(document),
     format: isDocumentLink(data.format) ? parseLabelType(data.format) : null,
     datePublished: london(datePublished).toDate(),
     series: parseSingleLevelGroup(data.series, 'series').map(series => {

--- a/content/webapp/services/prismic/transformers/articles.ts
+++ b/content/webapp/services/prismic/transformers/articles.ts
@@ -17,6 +17,8 @@ import { Weblink } from '@weco/common/model/weblinks';
 import { transformSeries } from './series';
 import { transformSeason } from './seasons';
 import { transformGenericFields } from '.';
+import { isNotUndefined } from '@weco/common/utils/array';
+import { MultiContent as DeprecatedMultiContent } from '@weco/common/model/multi-content';
 
 export function transformContentLink(
   document?: LinkField
@@ -63,21 +65,22 @@ export function transformArticle(document: ArticlePrismicDocument): Article {
   };
 
   const labels = [
-    article.format ? { text: article.format.title || '' } : null,
+    article.format ? { text: article.format.title || '' } : undefined,
     article.series.find(series => series.schedule.length > 0)
       ? { text: 'Serial' }
-      : null,
-  ].filter(Boolean);
+      : undefined,
+  ].filter(isNotUndefined);
 
   return {
     ...article,
+    type: 'articles',
     labels: labels.length > 0 ? labels : [{ text: 'Story' }],
     outroResearchLinkText: asText(data.outroResearchLinkText),
-    outroResearchItem: transformContentLink(data.outroResearchItem),
+    outroResearchItem: transformContentLink(data.outroResearchItem) as (DeprecatedMultiContent | undefined),
     outroReadLinkText: asText(data.outroReadLinkText),
-    outroReadItem: transformContentLink(data.outroReadItem),
+    outroReadItem: transformContentLink(data.outroReadItem) as (DeprecatedMultiContent | undefined),
     outroVisitLinkText: asText(data.outroVisitLinkText),
-    outroVisitItem: transformContentLink(data.outroVisitItem),
+    outroVisitItem: transformContentLink(data.outroVisitItem) as (DeprecatedMultiContent | undefined),
     prismicDocument: document,
   };
 }

--- a/content/webapp/services/prismic/transformers/books.ts
+++ b/content/webapp/services/prismic/transformers/books.ts
@@ -1,21 +1,23 @@
 import { Book } from '../../../types/books';
 import { BookPrismicDocument } from '../types/books';
-import { transformKeyTextField, transformRichTextFieldToString } from '.';
+import {
+  transformGenericFields,
+  transformKeyTextField,
+  transformRichTextFieldToString,
+} from '.';
 import { isFilledLinkToWebField } from '../types';
 import {
   asHtml,
-  parseGenericFields,
   parsePromoToCaptionedImage,
   parseSingleLevelGroup,
   parseSeason,
   parseTimestamp,
 } from '@weco/common/services/prismic/parsers';
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function transformBook(document: BookPrismicDocument): Book {
   const { data } = document;
 
-  const genericFields = parseGenericFields(document);
+  const genericFields = transformGenericFields(document);
   // We do this over the general parser as we want the not 16:9 image.
   const cover =
     data.promo &&
@@ -37,13 +39,12 @@ export function transformBook(document: BookPrismicDocument): Book {
     format: transformKeyTextField(data.format),
     extent: transformKeyTextField(data.extent),
     isbn: transformKeyTextField(data.isbn),
-    reviews:
-      data.reviews?.map(review => {
-        return {
-          text: review.text && asHtml(review.text),
-          citation: review.citation && asHtml(review.citation),
-        };
-      }),
+    reviews: data.reviews?.map(review => {
+      return {
+        text: review.text && asHtml(review.text),
+        citation: review.citation && asHtml(review.citation),
+      };
+    }),
     datePublished: data.datePublished && parseTimestamp(data.datePublished),
     cover: cover && cover.image,
     seasons,

--- a/content/webapp/services/prismic/transformers/event-series.ts
+++ b/content/webapp/services/prismic/transformers/event-series.ts
@@ -1,15 +1,13 @@
 import { EventSeries } from '../../../types/event-series';
 import { EventSeriesPrismicDocument } from '../types/event-series';
-import {
-  parseGenericFields,
-  parseBackgroundTexture,
-} from '@weco/common/services/prismic/parsers';
+import { parseBackgroundTexture } from '@weco/common/services/prismic/parsers';
 import { link } from './vendored-helpers';
+import { transformGenericFields } from '.';
 
 export function transformEventSeries(
   document: EventSeriesPrismicDocument
 ): EventSeries {
-  const genericFields = parseGenericFields(document);
+  const genericFields = transformGenericFields(document);
   const backgroundTexture =
     document.data.backgroundTexture &&
     link(document.data.backgroundTexture) &&

--- a/content/webapp/services/prismic/transformers/events.ts
+++ b/content/webapp/services/prismic/transformers/events.ts
@@ -9,7 +9,6 @@ import {
   isDocumentLink,
   parseBoolean,
   parseFormat,
-  parseGenericFields,
   parseLabelTypeList,
   parsePlace,
   parseSingleLevelGroup,
@@ -25,6 +24,7 @@ import {
 } from '@weco/common/services/prismic/events';
 import { parseEventSeries } from '@weco/common/services/prismic/event-series';
 import { isPast } from '@weco/common/utils/dates';
+import { transformGenericFields } from '.';
 
 export function transformEvent(
   document: EventPrismicDocument,
@@ -34,7 +34,7 @@ export function transformEvent(
   const scheduleLength = isDocumentLink(data.schedule.map(s => s.event)[0])
     ? data.schedule.length
     : 0;
-  const genericFields = parseGenericFields(document);
+  const genericFields = transformGenericFields(document);
   const eventSchedule =
     scheduleQuery && scheduleQuery.results
       ? scheduleQuery.results.map(doc => transformEvent(doc))

--- a/content/webapp/services/prismic/transformers/exhibitions.ts
+++ b/content/webapp/services/prismic/transformers/exhibitions.ts
@@ -16,7 +16,6 @@ import {
   isDocumentLink,
   isEmptyHtmlString,
   parseBoolean,
-  parseGenericFields,
   parseImagePromo,
   parsePlace,
   parsePromoToCaptionedImage,
@@ -32,11 +31,12 @@ import {
   parseResourceTypeList,
 } from '@weco/common/services/prismic/exhibitions';
 import { parseSeason } from '@weco/common/services/prismic/seasons';
+import { transformGenericFields } from '.';
 
 export function transformExhibition(
   document: ExhibitionPrismicDocument
 ): Exhibition {
-  const genericFields = parseGenericFields(document);
+  const genericFields = transformGenericFields(document);
   const data = document.data;
   const promo = data.promo;
   const exhibits = data.exhibits

--- a/content/webapp/services/prismic/transformers/index.ts
+++ b/content/webapp/services/prismic/transformers/index.ts
@@ -86,8 +86,8 @@ export function transformFormat(document: PrismicDocument<WithArticleFormat>) {
 
 // This is to avoid introducing nulls into our codebase
 export function transformKeyTextField(
-  field: KeyTextField
-): KeyTextField | undefined {
+  field: KeyTextField | null
+): string | undefined {
   return field ?? undefined;
 }
 

--- a/content/webapp/services/prismic/transformers/index.ts
+++ b/content/webapp/services/prismic/transformers/index.ts
@@ -85,19 +85,38 @@ export function transformFormat(document: PrismicDocument<WithArticleFormat>) {
 }
 
 // This is to avoid introducing nulls into our codebase
-export function transformKeyTextField(field: KeyTextField) {
+export function transformKeyTextField(
+  field: KeyTextField
+): KeyTextField | undefined {
   return field ?? undefined;
 }
 
 // Prismic often returns empty RichText fields as `[]`, this filters them out
-export function transformRichTextField(field: RichTextField) {
+export function transformRichTextField(
+  field: RichTextField
+): RichTextField | undefined {
   return field && field.length > 0 ? field : undefined;
 }
 
 // We have to use this annoyingly often as right at the beginning of the project
 // we created titles as `RichTextField`s.
-export function transformRichTextFieldToString(field: RichTextField) {
+export function transformRichTextFieldToString(
+  field: RichTextField
+): string | undefined {
   return field && field.length > 0 ? prismicH.asText(field) : undefined;
+}
+
+export function asText(maybeContent?: RichTextField): string | undefined {
+  return maybeContent && prismicH.asText(maybeContent).trim();
+}
+
+export function transformTitle(field: RichTextField): string {
+  // We always need a title - blunt validation, but validation none the less
+  return asText(field) || '';
+}
+
+export function transformBoolean(fragment: 'yes' | null): boolean {
+  return fragment === 'yes';
 }
 
 type PromoImage = {
@@ -130,7 +149,7 @@ export function transformGenericFields(doc: Doc): GenericContentFields {
     promoImage;
   const body = data.body ? parseBody(data.body) : [];
   const standfirst = body.find(slice => slice.type === 'standfirst');
-  const metadataDescription = asText(data.metadataDescription);
+  const metadataDescription = data.metadataDescription || undefined;
 
   return {
     id: doc.id,

--- a/content/webapp/services/prismic/transformers/pages.ts
+++ b/content/webapp/services/prismic/transformers/pages.ts
@@ -3,17 +3,17 @@ import { Page } from '../../../types/pages';
 import { PagePrismicDocument } from '../types/pages';
 import {
   parseFormat,
-  parseGenericFields,
   parseOnThisPage,
   parseSingleLevelGroup,
   parseTimestamp,
 } from '@weco/common/services/prismic/parsers';
 import { links as headerLinks } from '@weco/common/views/components/Header/Header';
 import { transformSeason } from './seasons';
+import { transformGenericFields } from '.';
 
 export function transformPage(document: PagePrismicDocument): Page {
   const { data } = document;
-  const genericFields = parseGenericFields(document);
+  const genericFields = transformGenericFields(document);
   const seasons = parseSingleLevelGroup(data.seasons, 'season').map(season => {
     return transformSeason(season);
   });

--- a/content/webapp/services/prismic/transformers/pages.ts
+++ b/content/webapp/services/prismic/transformers/pages.ts
@@ -1,5 +1,4 @@
 import { FeaturedText } from '@weco/common/model/text';
-import { parsePage } from '@weco/common/services/prismic/pages';
 import { Page } from '../../../types/pages';
 import { PagePrismicDocument } from '../types/pages';
 import {
@@ -7,21 +6,21 @@ import {
   parseGenericFields,
   parseOnThisPage,
   parseSingleLevelGroup,
-  parseSeason,
   parseTimestamp,
 } from '@weco/common/services/prismic/parsers';
 import { links as headerLinks } from '@weco/common/views/components/Header/Header';
+import { transformSeason } from './seasons';
 
 export function transformPage(document: PagePrismicDocument): Page {
   const { data } = document;
   const genericFields = parseGenericFields(document);
   const seasons = parseSingleLevelGroup(data.seasons, 'season').map(season => {
-    return parseSeason(season);
+    return transformSeason(season);
   });
   const parentPages = parseSingleLevelGroup(data.parents, 'parent').map(
     (parent, index) => {
       return {
-        ...parsePage(parent),
+        ...transformPage(parent),
         order: data.parents[index].order,
         type: parent.type,
       };

--- a/content/webapp/services/prismic/transformers/series.ts
+++ b/content/webapp/services/prismic/transformers/series.ts
@@ -3,15 +3,15 @@ import { SeriesPrismicDocument } from '../types/series';
 import {
   asText,
   isStructuredText,
-  parseGenericFields,
   parseSingleLevelGroup,
 } from '@weco/common/services/prismic/parsers';
 import { transformSeason } from './seasons';
 import { london } from '@weco/common/utils/dates';
+import { transformGenericFields } from '.';
 
 export function transformSeries(document: SeriesPrismicDocument): Series {
   const { data } = document;
-  const genericFields = parseGenericFields(document);
+  const genericFields = transformGenericFields(document);
   const standfirst = genericFields.standfirst || null;
   const color = data.color;
   const schedule = data.schedule

--- a/content/webapp/services/prismic/transformers/series.ts
+++ b/content/webapp/services/prismic/transformers/series.ts
@@ -1,14 +1,47 @@
-import { parseArticleSeries } from '@weco/common/services/prismic/article-series';
-import { ArticleSeries as DeprecatedArticleSeries } from '@weco/common/model/article-series';
 import { Series } from '../../../types/series';
 import { SeriesPrismicDocument } from '../types/series';
+import {
+  asText,
+  isStructuredText,
+  parseGenericFields,
+  parseSingleLevelGroup,
+} from '@weco/common/services/prismic/parsers';
+import { transformSeason } from './seasons';
+import { london } from '@weco/common/utils/dates';
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function transformSeries(document: SeriesPrismicDocument): Series {
-  const series: DeprecatedArticleSeries = parseArticleSeries(document);
+  const { data } = document;
+  const genericFields = parseGenericFields(document);
+  const standfirst = genericFields.standfirst || null;
+  const color = data.color;
+  const schedule = data.schedule
+    ? data.schedule
+        .filter(({ title }) => isStructuredText(title))
+        .map((item, i) => {
+          return {
+            type: 'article-schedule-items',
+            id: `${document.id}_${i}`,
+            title: asText(item.title),
+            publishDate: london(item.publishDate).toDate(),
+            partNumber: i + 1,
+            color,
+          };
+        })
+    : [];
+  const labels = [{ text: schedule.length > 0 ? 'Serial' : 'Series' }];
+  const seasons = parseSingleLevelGroup(data.seasons, 'season').map(season => {
+    return transformSeason(season);
+  });
 
   return {
-    ...series,
+    ...genericFields,
+    type: 'series',
+    labels,
+    schedule,
+    standfirst,
+    color: data.color,
+    items: [],
+    seasons,
     prismicDocument: document,
   };
 }


### PR DESCRIPTION
For https://github.com/wellcomecollection/wellcomecollection.org/issues/7363.

This one gets parseGenericFields into TypeScript, which itself isn't that interesting – but the parseBody method that it calls *is*, because that calls the parseMultiContent function which creates the circular dependencies that are preventing us from deleting the JavaScript bits… for now!