### PR TITLE
Online and/or in the building

### DIFF
--- a/content/webapp/__mocks__/events.ts
+++ b/content/webapp/__mocks__/events.ts
@@ -1,0 +1,87 @@
+import { UiEvent } from '@weco/common/model/events';
+import { prismicPageIds } from '@weco/common/services/prismic/hardcoded-id';
+import { HTMLString } from '@weco/common/services/prismic/types';
+
+const image = {
+  contentUrl:
+    'https://images.prismic.io/wellcomecollection/7657f9e9-0733-444d-b1b2-6ae0bafa0ff9_c7c94c39161dcfe15d9abd8b40256ea2b40f52b9_c0139861.jpg?auto=compress,format',
+  width: 2996,
+  height: 2000,
+  alt: '',
+  crops: {},
+};
+
+const place = {
+  id: 'Wn1fvyoAACgAH_yG',
+  title: 'Reading Room',
+  body: [],
+  labels: [],
+  level: 2,
+  information: [
+    {
+      type: 'paragraph',
+      text: 'We’ll be in the Reading Room on level 2. You can walk up the spiral staircase to the Reading Room door, or take the lift up and then head left from the Library Desk.',
+      spans: [],
+    },
+  ] as HTMLString,
+};
+
+const baseEvent: UiEvent = {
+  type: 'events',
+  id: 'tours',
+  title: 'Daily Guided Tours and Discussions',
+  times: [],
+  series: [],
+  place: undefined,
+  bookingEnquiryTeam: undefined,
+  interpretations: [],
+  audiences: [],
+  policies: [],
+  bookingInformation: undefined,
+  cost: undefined,
+  bookingType: undefined,
+  thirdPartyBooking: undefined,
+  isCompletelySoldOut: false,
+  isPast: false,
+  isRelaxedPerformance: false,
+  format: {
+    id: 'WmYRpCQAACUAn-Ap',
+    title: 'Gallery tour',
+    description: undefined,
+  },
+  body: [],
+  dateRange: {
+    firstDate: new Date(),
+    lastDate: new Date(),
+    repeats: 0,
+  },
+  image: image,
+  hasEarlyRegistration: false,
+  labels: [
+    {
+      text: 'Gallery tour',
+    },
+  ],
+  primaryLabels: [],
+  secondaryLabels: [],
+  promo: {
+    image: image,
+    link: `/pages/${prismicPageIds.dailyGuidedTours}`,
+  },
+  promoImage: { ...image },
+  displayEnd: new Date(),
+  displayStart: new Date(),
+  scheduleLength: 0,
+  seasons: [],
+  isOnline: false,
+  availableOnline: false,
+  prismicDocument: undefined,
+};
+
+export const eventWithPlace: UiEvent = { ...baseEvent, place };
+export const eventOnline: UiEvent = { ...baseEvent, isOnline: true };
+export const eventWithPlaceOnline: UiEvent = {
+  ...baseEvent,
+  place,
+  isOnline: true,
+};

--- a/content/webapp/components/EventPromo/EventPromo.test.tsx
+++ b/content/webapp/components/EventPromo/EventPromo.test.tsx
@@ -32,7 +32,7 @@ describe('EventPromo', () => {
     expect(screen.getByText('Reading Room'));
   });
 
-  it.only('Shows when an event is online', () => {
+  it('Shows when an event is online', () => {
     renderComponent(eventOnline);
     expect(screen.getByText('Online'));
   });

--- a/content/webapp/components/EventPromo/EventPromo.test.tsx
+++ b/content/webapp/components/EventPromo/EventPromo.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import prismicData from '@weco/common/test/fixtures/prismicData/prismic-data';
+import { ThemeProvider } from 'styled-components';
+import theme from '@weco/common/views/themes/default';
+import EventPromo from './EventPromo';
+import * as Context from '@weco/common/server-data/Context';
+import { UiEvent } from '@weco/common/model/events';
+import {
+  eventWithPlace,
+  eventOnline,
+  eventWithPlaceOnline,
+} from '../../__mocks__/events';
+jest.spyOn(Context, 'useToggles').mockImplementation(() => ({
+  enablePickUpDate: true,
+}));
+
+jest
+  .spyOn(Context, 'usePrismicData')
+  .mockImplementation(() => prismicData as any);
+
+const renderComponent = (event: UiEvent) => {
+  return render(
+    <ThemeProvider theme={theme}>
+      <EventPromo event={event} />
+    </ThemeProvider>
+  );
+};
+
+describe('EventPromo', () => {
+  it('Shows a specific location when it is the only location for an event', () => {
+    renderComponent(eventWithPlace);
+    expect(screen.getByText('Reading Room'));
+  });
+
+  it.only('Shows when an event is online', () => {
+    renderComponent(eventOnline);
+    expect(screen.getByText('Online'));
+  });
+
+  it('Shows when an event is a physical/online hybrid', () => {
+    renderComponent(eventWithPlaceOnline);
+    expect(screen.getByText('Online & In our building'));
+  });
+});

--- a/content/webapp/components/EventPromo/EventPromo.tsx
+++ b/content/webapp/components/EventPromo/EventPromo.tsx
@@ -14,6 +14,9 @@ import {
 } from '@weco/common/views/components/Card/Card';
 import Divider from '@weco/common/views/components/Divider/Divider';
 import WatchLabel from '@weco/common/views/components/WatchLabel/WatchLabel';
+import Icon from '@weco/common/views/components/Icon/Icon';
+import { location } from '@weco/common/icons';
+import AlignFont from '@weco/common/views/components/styled/AlignFont';
 
 type Props = {
   event: UiEvent;
@@ -80,9 +83,20 @@ const EventPromo = ({
           </Space>
 
           {event.isOnline && !event.availableOnline && (
-            <LabelsList
-              labels={[{ text: 'Online', labelColor: 'transparent' }]}
-            />
+            <Space
+              v={{ size: 's', properties: ['margin-top', 'margin-bottom'] }}
+              className={classNames({
+                [font('hnr', 5)]: true,
+                'flex flex--v-center': true,
+              })}
+            >
+              <Icon icon={location} matchText />
+              <Space h={{ size: 'xs', properties: ['margin-left'] }}>
+                <AlignFont>
+                  Online {event.place ? ' & In our building' : 'only'}
+                </AlignFont>
+              </Space>
+            </Space>
           )}
 
           {event.availableOnline && (

--- a/content/webapp/components/EventPromo/EventPromo.tsx
+++ b/content/webapp/components/EventPromo/EventPromo.tsx
@@ -18,6 +18,7 @@ import WatchLabel from '@weco/common/views/components/WatchLabel/WatchLabel';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import { location } from '@weco/common/icons';
 import AlignFont from '@weco/common/views/components/styled/AlignFont';
+import { Place } from '@weco/common/model/places';
 
 type Props = {
   event: UiEvent;
@@ -26,6 +27,12 @@ type Props = {
   timeString?: string;
   fromDate?: moment.Moment;
 };
+
+function getLocationText(isOnline?: boolean, place?: Place): string {
+  if (!isOnline) return 'In our building';
+
+  return `Online ${place ? '& In our building' : 'only'}`;
+}
 
 const EventPromo: FC<Props> = ({
   event,
@@ -83,22 +90,20 @@ const EventPromo: FC<Props> = ({
             {event.title}
           </Space>
 
-          {event.isOnline && !event.availableOnline && (
-            <Space
-              v={{ size: 's', properties: ['margin-top', 'margin-bottom'] }}
-              className={classNames({
-                [font('hnr', 5)]: true,
-                'flex flex--v-center': true,
-              })}
-            >
-              <Icon icon={location} matchText />
-              <Space h={{ size: 'xs', properties: ['margin-left'] }}>
-                <AlignFont>
-                  Online {event.place ? ' & In our building' : 'only'}
-                </AlignFont>
-              </Space>
+          <Space
+            v={{ size: 's', properties: ['margin-top', 'margin-bottom'] }}
+            className={classNames({
+              [font('hnr', 5)]: true,
+              'flex flex--v-center': true,
+            })}
+          >
+            <Icon icon={location} matchText />
+            <Space h={{ size: 'xs', properties: ['margin-left'] }}>
+              <AlignFont>
+                {getLocationText(event.isOnline, event.place)}
+              </AlignFont>
             </Space>
-          )}
+          </Space>
 
           {event.availableOnline && (
             <Space v={{ size: 's', properties: ['margin-top'] }}>

--- a/content/webapp/components/EventPromo/EventPromo.tsx
+++ b/content/webapp/components/EventPromo/EventPromo.tsx
@@ -31,7 +31,7 @@ type Props = {
 function getLocationText(isOnline?: boolean, place?: Place): string {
   if (!isOnline) return 'In our building';
 
-  return `Online ${place ? '& In our building' : 'only'}`;
+  return `Online${place ? ' & In our building' : ''}`;
 }
 
 const EventPromo: FC<Props> = ({

--- a/content/webapp/components/EventPromo/EventPromo.tsx
+++ b/content/webapp/components/EventPromo/EventPromo.tsx
@@ -1,3 +1,4 @@
+import { FC } from 'react';
 import moment from 'moment';
 import { font, classNames } from '@weco/common/utils/classnames';
 import { trackEvent } from '@weco/common/utils/ga';
@@ -26,13 +27,13 @@ type Props = {
   fromDate?: moment.Moment;
 };
 
-const EventPromo = ({
+const EventPromo: FC<Props> = ({
   event,
   position = 0,
   dateString,
   timeString,
   fromDate,
-}: Props) => {
+}) => {
   const fullyBooked = isEventFullyBooked(event);
   const isPast = event.isPast;
   return (

--- a/content/webapp/components/EventPromo/EventPromo.tsx
+++ b/content/webapp/components/EventPromo/EventPromo.tsx
@@ -29,7 +29,7 @@ type Props = {
 };
 
 function getLocationText(isOnline?: boolean, place?: Place): string {
-  if (!isOnline) return 'In our building';
+  if (!isOnline && place) return place.title;
 
   return `Online${place ? ' & In our building' : ''}`;
 }
@@ -90,20 +90,22 @@ const EventPromo: FC<Props> = ({
             {event.title}
           </Space>
 
-          <Space
-            v={{ size: 's', properties: ['margin-top', 'margin-bottom'] }}
-            className={classNames({
-              [font('hnr', 5)]: true,
-              'flex flex--v-center': true,
-            })}
-          >
-            <Icon icon={location} matchText />
-            <Space h={{ size: 'xs', properties: ['margin-left'] }}>
-              <AlignFont>
-                {getLocationText(event.isOnline, event.place)}
-              </AlignFont>
+          {(event.isOnline || event.place) && (
+            <Space
+              v={{ size: 's', properties: ['margin-top', 'margin-bottom'] }}
+              className={classNames({
+                [font('hnr', 5)]: true,
+                'flex flex--v-center': true,
+              })}
+            >
+              <Icon icon={location} matchText />
+              <Space h={{ size: 'xs', properties: ['margin-left'] }}>
+                <AlignFont>
+                  {getLocationText(event.isOnline, event.place)}
+                </AlignFont>
+              </Space>
             </Space>
-          </Space>
+          )}
 
           {event.availableOnline && (
             <Space v={{ size: 's', properties: ['margin-top'] }}>


### PR DESCRIPTION
Part of #7639

Adding a location label to all events to distinguish between those that are in venue only, online only, or both.

- If an event is only in venue, we display the specific location (e.g. 'Reading Room')
- If an event is only online, we display 'Online'
- If an event is both online and in venue, we display 'Online & In our building'

<img width="1032" alt="image" src="https://user-images.githubusercontent.com/1394592/154493978-966ef013-0cbc-4b71-baef-96d4179be479.png">
