### PR TITLE
Surface errors from the requesting API in the error dialog

### DIFF
--- a/catalogue/webapp/components/ItemRequestModal/ItemRequestModal.tsx
+++ b/catalogue/webapp/components/ItemRequestModal/ItemRequestModal.tsx
@@ -26,7 +26,11 @@ import ButtonSolid from '@weco/common/views/components/ButtonSolid/ButtonSolid';
 import ButtonOutlined from '@weco/common/views/components/ButtonOutlined/ButtonOutlined';
 import Space from '@weco/common/views/components/styled/Space';
 import styled from 'styled-components';
-import { PhysicalItem, Work } from '@weco/common/model/catalogue';
+import {
+  CatalogueApiError,
+  PhysicalItem,
+  Work,
+} from '@weco/common/model/catalogue';
 import { classNames, font } from '@weco/common/utils/classnames';
 import LL from '@weco/common/views/components/styled/LL';
 import { allowedRequests } from '@weco/common/values/requests';
@@ -382,16 +386,17 @@ const ConfirmedDialog: FC<ConfirmedDialogProps> = ({ currentHoldNumber }) => (
 
 type ErrorDialogProps = {
   setIsActive: (value: boolean) => void;
+  errorMessage?: string;
 };
 
-const ErrorDialog: FC<ErrorDialogProps> = ({ setIsActive }) => (
+const ErrorDialog: FC<ErrorDialogProps> = ({ setIsActive, errorMessage }) => (
   <>
     <Header>
       <span className={`h2`}>Request failed</span>
     </Header>
     <p className="no-margin">
-      {/* TODO: get error code and construct appropriate message from response - see #6916 */}
-      There was a problem requesting this item. Please try again.
+      {errorMessage ||
+        'There was a problem requesting this item. Please try again.'}
     </p>
     <CTAs>
       <ButtonOutlined text={`Close`} clickHandler={() => setIsActive(false)} />
@@ -411,6 +416,7 @@ const ItemRequestModal: FC<Props> = ({
   ...modalProps
 }) => {
   const [requestingState, setRequestingState] = useState<RequestingState>();
+  const [requestingErrorMessage, setRequestingError] = useState<string>();
   const [currentHoldNumber, setCurrentHoldNumber] = useState(initialHoldNumber);
   function innerSetIsActive(value: boolean) {
     if (requestingState === 'requesting') return; // we don't want the modal to close during an api call
@@ -443,11 +449,20 @@ const ItemRequestModal: FC<Props> = ({
         },
       });
       if (!response.ok) {
+        try {
+          const error: CatalogueApiError = await response.json();
+          setRequestingError(error.description);
+        } catch (e) {
+          console.warn('Unable to parse error response from API');
+        }
+
         setRequestingState('error');
         // TODO: something to Sentry?
       } else {
         setRequestingState('confirmed');
-        // If we get the users current holds, immediately following a successful request, the api response isn't updated quickly enough to include the new request
+        // If we get the user's current holds, immediately following a successful request, the api response
+        // isn't updated quickly enough to include the new request.
+        //
         // We therefore increment the currentHoldNumber manually following a successful request
         setCurrentHoldNumber(holdNumber => (holdNumber || 0) + 1);
         onSuccess();
@@ -458,12 +473,20 @@ const ItemRequestModal: FC<Props> = ({
     }
   }
 
-  function renderModalContent(requestingState: RequestingState) {
+  function renderModalContent(
+    requestingState: RequestingState,
+    requestingErrorMessage?: string
+  ) {
     switch (requestingState) {
       case 'requesting':
         return <LL />;
       case 'error':
-        return <ErrorDialog setIsActive={innerSetIsActive} />;
+        return (
+          <ErrorDialog
+            setIsActive={innerSetIsActive}
+            errorMessage={requestingErrorMessage}
+          />
+        );
       case 'confirmed':
         return <ConfirmedDialog currentHoldNumber={currentHoldNumber} />;
       default:
@@ -488,7 +511,11 @@ const ItemRequestModal: FC<Props> = ({
       setIsActive={innerSetIsActive}
       openButtonRef={openButtonRef}
     >
-      {<div aria-live="assertive">{renderModalContent(requestingState)}</div>}
+      {
+        <div aria-live="assertive">
+          {renderModalContent(requestingState, requestingErrorMessage)}
+        </div>
+      }
     </Modal>
   );
 };


### PR DESCRIPTION
## Who is this for?

People who have problems requesting items.

## What is it doing for them?

Including more detailed information about why their request went wrong, e.g. if their account has expired (https://github.com/wellcomecollection/wellcomecollection.org/issues/7451).

For https://github.com/wellcomecollection/wellcomecollection.org/issues/6916