### PR TITLE
Create a TypeScript version of parseGenericFields

### DIFF
--- a/common/model/events.ts
+++ b/common/model/events.ts
@@ -75,6 +75,11 @@ export type EventSchedule = {
   isNotLinked: boolean;
 }[];
 
+export type ThirdPartyBooking = {
+  name?: string;
+  url: string;
+};
+
 export type Event = GenericContentFields & {
   format?: Format;
   hasEarlyRegistration: boolean;
@@ -90,10 +95,7 @@ export type Event = GenericContentFields & {
   bookingInformation?: HTMLString;
   cost?: string;
   bookingType?: string;
-  thirdPartyBooking?: {
-    name?: string;
-    url: string;
-  };
+  thirdPartyBooking?: ThirdPartyBooking;
   scheduleLength: number;
   schedule?: EventSchedule;
   eventbriteId?: string;

--- a/common/model/multi-content.ts
+++ b/common/model/multi-content.ts
@@ -20,4 +20,5 @@ export type MultiContent =
   | ArticleScheduleItem
   | UiExhibition
   | Weblink
-  | ArticleSeries;
+  | ArticleSeries
+  | Weblink;

--- a/content/webapp/services/prismic/transformers/articles.ts
+++ b/content/webapp/services/prismic/transformers/articles.ts
@@ -3,7 +3,6 @@ import { ArticlePrismicDocument } from '../types/articles';
 import {
   asText,
   isDocumentLink,
-  parseGenericFields,
   parseLabelType,
   parseSingleLevelGroup,
 } from '@weco/common/services/prismic/parsers';
@@ -15,12 +14,16 @@ import {
   isFilledLinkToWebField,
 } from '../types';
 import { LinkField } from '@prismicio/types';
-import { MultiContent, transformMultiContent } from './multi-content';
-import { Weblink } from '@weco/common/model/weblinks';
+import { transformMultiContent } from './multi-content';
+import { transformGenericFields } from '.';
+import { MultiContent as DeprecatedMultiContent } from '@weco/common/model/multi-content';
+import { isNotUndefined } from '@weco/common/utils/array';
+import { Label } from '@weco/common/model/labels';
+import { Series } from 'types/series';
 
-export function transformContentLink(
+function transformContentLink(
   document?: LinkField
-): MultiContent | Weblink | undefined {
+): DeprecatedMultiContent | undefined {
   if (!document) {
     return;
   }
@@ -36,42 +39,47 @@ export function transformContentLink(
   }
 
   if (isFilledLinkToDocumentWithData(document)) {
-    return transformMultiContent(document);
+    return transformMultiContent(document) as
+      | DeprecatedMultiContent
+      | undefined;
   }
 }
 
 export function transformArticle(document: ArticlePrismicDocument): Article {
   const { data } = document;
+  const genericFields = transformGenericFields(document);
+
   // When we imported data into Prismic from the Wordpress blog some content
   // needed to have its original publication date displayed. It is purely a display
   // value and does not affect ordering.
-
   const datePublished =
     data.publishDate || document.first_publication_date || undefined;
 
-  const article = {
-    type: 'articles',
-    ...parseGenericFields(document),
-    format: isDocumentLink(data.format) ? parseLabelType(data.format) : null,
-    datePublished: london(datePublished).toDate(),
-    series: parseSingleLevelGroup(data.series, 'series').map(series => {
+  const format = isDocumentLink(data.format)
+    ? parseLabelType(data.format)
+    : null;
+
+  const series: Series[] = parseSingleLevelGroup(data.series, 'series').map(
+    series => {
       return parseArticleSeries(series);
-    }),
+    }
+  );
+
+  const labels: Label[] = [
+    format ? { text: format.title || '' } : undefined,
+    series.find(s => s.schedule.length > 0) ? { text: 'Serial' } : undefined,
+  ].filter(isNotUndefined);
+
+  return {
+    ...genericFields,
+    type: 'articles',
+    labels: labels.length > 0 ? labels : [{ text: 'Story' }],
+    format,
+    series,
+    datePublished: london(datePublished).toDate(),
     seasons: parseSingleLevelGroup(data.seasons, 'season').map(season => {
       return parseSeason(season);
     }),
-  };
-
-  const labels = [
-    article.format ? { text: article.format.title || '' } : null,
-    article.series.find(series => series.schedule.length > 0)
-      ? { text: 'Serial' }
-      : null,
-  ].filter(Boolean);
-
-  return {
-    ...article,
-    labels: labels.length > 0 ? labels : [{ text: 'Story' }],
     outroResearchLinkText: asText(data.outroResearchLinkText),
     outroResearchItem: transformContentLink(data.outroResearchItem),
     outroReadLinkText: asText(data.outroReadLinkText),

--- a/content/webapp/services/prismic/transformers/books.ts
+++ b/content/webapp/services/prismic/transformers/books.ts
@@ -1,10 +1,13 @@
 import { Book } from '../../../types/books';
 import { BookPrismicDocument } from '../types/books';
-import { transformKeyTextField, transformRichTextFieldToString } from '.';
+import {
+  transformGenericFields,
+  transformKeyTextField,
+  transformRichTextFieldToString,
+} from '.';
 import { isFilledLinkToWebField } from '../types';
 import {
   asHtml,
-  parseGenericFields,
   parsePromoToCaptionedImage,
   parseSingleLevelGroup,
   parseSeason,
@@ -15,7 +18,7 @@ import {
 export function transformBook(document: BookPrismicDocument): Book {
   const { data } = document;
 
-  const genericFields = parseGenericFields(document);
+  const genericFields = transformGenericFields(document);
   // We do this over the general parser as we want the not 16:9 image.
   const cover =
     data.promo &&
@@ -37,13 +40,12 @@ export function transformBook(document: BookPrismicDocument): Book {
     format: transformKeyTextField(data.format),
     extent: transformKeyTextField(data.extent),
     isbn: transformKeyTextField(data.isbn),
-    reviews:
-      data.reviews?.map(review => {
-        return {
-          text: review.text && asHtml(review.text),
-          citation: review.citation && asHtml(review.citation),
-        };
-      }),
+    reviews: data.reviews?.map(review => {
+      return {
+        text: review.text && asHtml(review.text),
+        citation: review.citation && asHtml(review.citation),
+      };
+    }),
     datePublished: data.datePublished && parseTimestamp(data.datePublished),
     cover: cover && cover.image,
     seasons,

--- a/content/webapp/services/prismic/transformers/event-series.ts
+++ b/content/webapp/services/prismic/transformers/event-series.ts
@@ -1,15 +1,13 @@
 import { EventSeries } from '../../../types/event-series';
 import { EventSeriesPrismicDocument } from '../types/event-series';
-import {
-  parseGenericFields,
-  parseBackgroundTexture,
-} from '@weco/common/services/prismic/parsers';
+import { parseBackgroundTexture } from '@weco/common/services/prismic/parsers';
 import { link } from './vendored-helpers';
+import { transformGenericFields } from '.';
 
 export function transformEventSeries(
   document: EventSeriesPrismicDocument
 ): EventSeries {
-  const genericFields = parseGenericFields(document);
+  const genericFields = transformGenericFields(document);
   const backgroundTexture =
     document.data.backgroundTexture &&
     link(document.data.backgroundTexture) &&

--- a/content/webapp/services/prismic/transformers/pages.ts
+++ b/content/webapp/services/prismic/transformers/pages.ts
@@ -4,17 +4,17 @@ import { Page } from '../../../types/pages';
 import { PagePrismicDocument } from '../types/pages';
 import {
   parseFormat,
-  parseGenericFields,
   parseOnThisPage,
   parseSingleLevelGroup,
   parseTimestamp,
 } from '@weco/common/services/prismic/parsers';
 import { parseSeason } from '@weco/common/services/prismic/seasons';
 import { links as headerLinks } from '@weco/common/views/components/Header/Header';
+import { transformGenericFields } from '.';
 
 export function transformPage(document: PagePrismicDocument): Page {
   const { data } = document;
-  const genericFields = parseGenericFields(document);
+  const genericFields = transformGenericFields(document);
   const seasons = parseSingleLevelGroup(data.seasons, 'season').map(season => {
     return parseSeason(season);
   });
@@ -41,7 +41,7 @@ export function transformPage(document: PagePrismicDocument): Page {
     parentPages,
     onThisPage: data.body ? parseOnThisPage(data.body) : [],
     showOnThisPage: data.showOnThisPage || false,
-    promo: promo && promo.image ? promo : null,
+    promo: promo && promo.image ? promo : undefined,
     datePublished: data.datePublished && parseTimestamp(data.datePublished),
     siteSection: siteSection,
     prismicDocument: document,


### PR DESCRIPTION
For https://github.com/wellcomecollection/wellcomecollection.org/issues/7363

The reason I'm going after this function first is that it calls `parseBody()` … which calls `parseMultiContent()` … which calls all the type-specific parsers, creating a nice circular loop that keeps everything in JavaScript.

I've also got a local test harness running against a snapshot of Prismic, which is fetching every bit of Prismic content – to catch mistakes before they get deployed. 😅 