### PR TITLE
Create a TypeScript version of parseBody

### DIFF
--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -430,7 +430,7 @@ export function parseMediaObjectList(
   });
 }
 
-export function parseTitledTextItem(item) {
+function parseTitledTextItem(item) {
   return {
     title: parseTitle(item.title),
     text: parseStructuredText(item.text),

--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -106,7 +106,7 @@ export function checkAndParseImage(frag: ?PrismicFragment): ?ImageType {
 // These are the props returned on a prismic image object
 const prismicImageProps = ['dimensions', 'alt', 'copyright', 'url'];
 // We don't export this, as we probably always want to check ^ first
-function parseImage(frag: PrismicFragment): ImageType {
+export function parseImage(frag: PrismicFragment): ImageType {
   const tasl = parseTaslFromString(frag.copyright);
   const crops = Object.keys(frag)
     .filter(key => prismicImageProps.indexOf(key) === -1)
@@ -207,7 +207,7 @@ export function parseTaslFromString(pipedString: string): Tasl {
   }
 }
 
-function parseTeamToContact(team: PrismicFragment) {
+export function parseTeamToContact(team: PrismicFragment) {
   const {
     data: { title, subtitle, email, phone },
   } = team;
@@ -293,7 +293,7 @@ export function parseBoolean(fragment: PrismicFragment): boolean {
   return Boolean(fragment);
 }
 
-function parseStructuredText(maybeFragment: ?any): ?HTMLString {
+export function parseStructuredText(maybeFragment: ?any): ?HTMLString {
   return maybeFragment && isStructuredText((maybeFragment: HTMLString))
     ? (maybeFragment: HTMLString)
     : null;
@@ -366,7 +366,7 @@ export function isImageLink(fragment: ?PrismicFragment): boolean {
 
 export type Weight = 'default' | 'featured' | 'standalone' | 'supporting';
 
-function getWeight(weight: ?string): Weight {
+export function getWeight(weight: ?string): Weight {
   switch (weight) {
     case 'featured':
       return weight;
@@ -430,7 +430,7 @@ export function parseMediaObjectList(
   });
 }
 
-function parseTitledTextItem(item) {
+export function parseTitledTextItem(item) {
   return {
     title: parseTitle(item.title),
     text: parseStructuredText(item.text),
@@ -796,7 +796,7 @@ export function parseGenericFields(doc: PrismicFragment): GenericContentFields {
   };
 }
 
-function parseTableCsv(tableData: string): string[][] {
+export function parseTableCsv(tableData: string): string[][] {
   return tableData
     .trim()
     .split(/[\r\n]+/)

--- a/content/webapp/services/prismic/transformers/index.ts
+++ b/content/webapp/services/prismic/transformers/index.ts
@@ -1,8 +1,8 @@
 import * as prismicH from 'prismic-helpers-beta';
 import { PrismicDocument, KeyTextField, RichTextField } from '@prismicio/types';
 import { Label } from '@weco/common/model/labels';
-import { WithSeries } from '../types/articles';
-import linkResolver from '../link-resolver';
+import { ArticlePrismicDocument, WithSeries } from '../types/articles';
+import linkResolver, { ContentType } from '../link-resolver';
 import {
   CommonPrismicFields,
   Image,
@@ -17,15 +17,44 @@ import type {
   SliceZone,
 } from '@prismicio/types';
 import { link } from './vendored-helpers';
-import { GenericContentFields } from '@weco/common/model/generic-content-fields';
+import {
+  BodyType,
+  GenericContentFields,
+} from '@weco/common/model/generic-content-fields';
 import {
   asText,
   checkAndParseImage,
-  parseBody,
+  getWeight,
+  parseCaptionedImage,
+  parseImage,
   parseImagePromo,
+  parseLink,
+  parseMediaObjectList,
+  parseRichText,
+  parseStructuredText,
+  parseTableCsv,
+  parseTaslFromString,
+  parseTeamToContact,
   parseTitle,
+  parseTitledTextItem,
 } from '@weco/common/services/prismic/parsers';
+import { parseCollectionVenue } from '@weco/common/services/prismic/opening-times';
 import { ImageType } from '@weco/common/model/image';
+import { Body } from '../types/body';
+import { isNotUndefined } from '@weco/common/utils/array';
+import { transformPage } from './pages';
+import { transformGuide } from './guides';
+import { transformEventSeries } from './event-series';
+import { transformExhibition } from './exhibitions';
+import { transformArticle } from './articles';
+import { transformEvent } from './events';
+import { transformSeason } from './seasons';
+import { PagePrismicDocument } from '../types/pages';
+import { GuidePrismicDocument } from '../types/guides';
+import { EventSeriesPrismicDocument } from '../types/event-series';
+import { ExhibitionPrismicDocument } from '../types/exhibitions';
+import { EventPrismicDocument } from '../types/events';
+import { SeasonPrismicDocument } from '../types/seasons';
 
 type Meta = {
   title: string;
@@ -130,6 +159,320 @@ type PromoImage = {
   superWidescreenImage?: ImageType;
 };
 
+export function transformBody(body: Body): BodyType {
+  return body
+    .map(slice => {
+      switch (slice.slice_type) {
+        case 'standfirst':
+          return {
+            type: 'standfirst',
+            weight: getWeight(slice.slice_label),
+            value: slice.primary.text,
+          };
+
+        case 'text':
+          return {
+            type: 'text',
+            weight: getWeight(slice.slice_label),
+            value: slice.primary.text,
+          };
+
+        case 'map':
+          return {
+            type: 'map',
+            value: {
+              title: asText(slice.primary.title),
+              latitude: slice.primary.geolocation.latitude,
+              longitude: slice.primary.geolocation.longitude,
+            },
+          };
+
+        case 'editorialImage':
+          return {
+            weight: getWeight(slice.slice_label),
+            type: 'picture',
+            value: parseCaptionedImage(slice.primary),
+          };
+
+        case 'editorialImageGallery':
+          return {
+            type: 'imageGallery',
+            weight: getWeight(slice.slice_label),
+            value: {
+              title: asText(slice.primary.title),
+              items: slice.items.map(item => parseCaptionedImage(item)),
+            },
+          };
+
+        case 'titledTextList':
+          return {
+            type: 'titledTextList',
+            value: {
+              items: slice.items.map(item => parseTitledTextItem(item)),
+            },
+          };
+
+        case 'contentList':
+          const contents: FilledLinkToDocumentField<
+            ContentType,
+            string,
+            never
+          >[] = slice.items
+            .map(item => item.content)
+            .filter(isFilledLinkToDocumentWithData);
+
+          return {
+            type: 'contentList',
+            weight: getWeight(slice.slice_label),
+            value: {
+              title: asText(slice.primary.title),
+              // TODO: The old code would look up a `hasFeatured` field on `slice.primary`,
+              // but that doesn't exist in our Prismic model.
+              // hasFeatured: slice.primary.hasFeatured,
+              items: contents
+                .map(content => {
+                  switch (content.type) {
+                    case 'pages':
+                      return transformPage(
+                        content.data! as PagePrismicDocument
+                      );
+                    case 'guides':
+                      return transformGuide(
+                        content.data! as GuidePrismicDocument
+                      );
+                    case 'event-series':
+                      return transformEventSeries(
+                        content.data! as EventSeriesPrismicDocument
+                      );
+                    case 'exhibitions':
+                      return transformExhibition(
+                        content.data! as ExhibitionPrismicDocument
+                      );
+                    case 'articles':
+                      return transformArticle(
+                        content.data! as ArticlePrismicDocument
+                      );
+                    case 'events':
+                      return transformEvent(
+                        content.data! as EventPrismicDocument
+                      );
+                    case 'seasons':
+                      return transformSeason(
+                        content.data! as SeasonPrismicDocument
+                      );
+                  }
+                })
+                .filter(Boolean),
+            },
+          };
+
+        case 'collectionVenue':
+          return {
+            type: 'collectionVenue',
+            weight: getWeight(slice.slice_label),
+            value: {
+              content: parseCollectionVenue(slice.primary.content),
+              showClosingTimes: slice.primary.showClosingTimes,
+            },
+          };
+
+        case 'searchResults':
+          return {
+            type: 'searchResults',
+            weight: getWeight(slice.slice_label),
+            value: {
+              title: asText(slice.primary.title),
+              query: slice.primary.query,
+              pageSize: slice.primary.pageSize || 4,
+            },
+          };
+
+        case 'quote':
+        case 'quoteV2':
+          return {
+            type: 'quote',
+            weight: getWeight(slice.slice_label),
+            value: {
+              text: slice.primary.text,
+              citation: slice.primary.citation,
+              isPullOrReview:
+                slice.slice_label === 'pull' || slice.slice_label === 'review',
+            },
+          };
+
+        case 'iframe':
+          return {
+            type: 'iframe',
+            weight: slice.slice_label,
+            value: {
+              src: slice.primary.iframeSrc,
+              image: parseImage(slice.primary.previewImage),
+            },
+          };
+
+        case 'gifVideo':
+          return {
+            type: 'gifVideo',
+            weight: slice.slice_label,
+            value: {
+              caption: parseRichText(slice.primary.caption),
+              videoUrl: slice.primary.video && slice.primary.video.url,
+              playbackRate: slice.primary.playbackRate || 1,
+              tasl: parseTaslFromString(slice.primary.tasl),
+              autoPlay:
+                slice.primary.autoPlay === null ? true : slice.primary.autoPlay, // handle old content before these fields existed
+              loop: slice.primary.loop === null ? true : slice.primary.loop,
+              mute: slice.primary.mute === null ? true : slice.primary.mute,
+              showControls:
+                slice.primary.showControls === null
+                  ? false
+                  : slice.primary.showControls,
+            },
+          };
+
+        case 'contact':
+          return slice.primary.content.isBroken === false
+            ? {
+                type: 'contact',
+                value: parseTeamToContact(slice.primary.content),
+              }
+            : undefined;
+
+        case 'embed':
+          const embed = slice.primary.embed;
+
+          if (embed.provider_name === 'Vimeo') {
+            const embedUrl = slice.primary.embed.html.match(
+              /src="([-a-zA-Z0-9://.?=_]+)?/
+            )[1];
+            return {
+              type: 'videoEmbed',
+              weight: getWeight(slice.slice_label),
+              value: {
+                embedUrl: `${embedUrl}?rel=0`,
+                caption: slice.primary.caption,
+              },
+            };
+          }
+
+          if (embed.provider_name === 'SoundCloud') {
+            const apiUrl = embed.html.match(/url=([^&]*)&/);
+            const secretToken = embed.html.match(/secret_token=([^"]*)"/);
+            const secretTokenString =
+              secretToken && secretToken[1]
+                ? `%3Fsecret_token%3D${secretToken[1]}`
+                : '';
+
+            return {
+              type: 'soundcloudEmbed',
+              weight: getWeight(slice.slice_label),
+              value: {
+                embedUrl: `https://w.soundcloud.com/player/?url=${apiUrl[1]}${secretTokenString}&color=%23ff5500&inverse=false&auto_play=false&show_user=true`,
+                caption: slice.primary.caption,
+              },
+            };
+          }
+
+          if (embed.provider_name === 'YouTube') {
+            // The embed will be a blob of HTML of the form
+            //
+            //    <iframe src=\"https://www.youtube.com/embed/RTlA8X0EJ7w...\" ...></iframe>
+            //
+            // We want to add the query parameter ?rel=0
+            const embedUrl =
+              slice.primary.embed.html.match(/src="([^"]+)"?/)[1];
+
+            const embedUrlWithEnhancedPrivacy = embedUrl.replace(
+              'www.youtube.com',
+              'www.youtube-nocookie.com'
+            );
+
+            const newEmbedUrl = embedUrl.includes('?')
+              ? embedUrlWithEnhancedPrivacy.replace('?', '?rel=0&')
+              : `${embedUrlWithEnhancedPrivacy}?rel=0`;
+
+            return {
+              type: 'videoEmbed',
+              weight: getWeight(slice.slice_label),
+              value: {
+                embedUrl: newEmbedUrl,
+                caption: slice.primary.caption,
+              },
+            };
+          }
+          break;
+
+        case 'table':
+          return {
+            type: 'table',
+            value: {
+              rows: parseTableCsv(slice.primary.tableData),
+              caption: slice.primary.caption,
+              hasRowHeaders: slice.primary.hasRowHeaders,
+            },
+          };
+
+        case 'infoBlock':
+          return {
+            type: 'infoBlock',
+            value: {
+              title: parseTitle(slice.primary.title),
+              text: slice.primary.text,
+              linkText: slice.primary.linkText,
+              link: slice.primary.link,
+            },
+          };
+
+        case 'discussion':
+          return {
+            type: 'discussion',
+            value: {
+              title: parseTitle(slice.primary.title),
+              text: parseStructuredText(slice.primary.text),
+            },
+          };
+
+        case 'tagList':
+          return {
+            type: 'tagList',
+            value: {
+              title: parseTitle(slice.primary.title),
+              tags: slice.items.map(item => ({
+                textParts: [item.linkText],
+                linkAttributes: {
+                  href: { pathname: parseLink(item.link), query: '' },
+                  as: { pathname: parseLink(item.link), query: '' },
+                },
+              })),
+            },
+          };
+
+        // Deprecated
+        case 'imageList':
+          return {
+            type: 'deprecatedImageList',
+            weight: getWeight(slice.slice_label),
+            value: {
+              items: slice.items.map(item => ({
+                title: parseTitle(item.title),
+                subtitle: parseTitle(item.subtitle),
+                image: parseCaptionedImage(item),
+                description: parseStructuredText(item.description),
+              })),
+            },
+          };
+        case 'mediaObjectList':
+          return {
+            type: 'mediaObjectList',
+            value: {
+              items: parseMediaObjectList(slice.items),
+            },
+          };
+      }
+    })
+    .filter(isNotUndefined);
+}
+
 export function transformGenericFields(doc: Doc): GenericContentFields {
   const { data } = doc;
   const promo = data.promo && parseImagePromo(data.promo);
@@ -151,7 +494,7 @@ export function transformGenericFields(doc: Doc): GenericContentFields {
 
   const { image, squareImage, widescreenImage, superWidescreenImage } =
     promoImage;
-  const body = data.body ? parseBody(data.body) : [];
+  const body = data.body ? transformBody(data.body) : [];
   const standfirst = body.find(slice => slice.type === 'standfirst');
   const metadataDescription = asText(data.metadataDescription);
 

--- a/content/webapp/services/prismic/transformers/index.ts
+++ b/content/webapp/services/prismic/transformers/index.ts
@@ -166,6 +166,10 @@ function transformTitledTextItem(item) {
   };
 }
 
+// TODO: Consider moving this into a dedicated file for body transformers.
+// TODO: Rather than doing transformation inline, have this function consistently
+// call out to other transformer functions (a la contentList).
+// See https://github.com/wellcomecollection/wellcomecollection.org/pull/7679/files#r811138079
 export function transformBody(body: Body): BodyType {
   return body
     .map(slice => {

--- a/content/webapp/services/prismic/transformers/index.ts
+++ b/content/webapp/services/prismic/transformers/index.ts
@@ -1,8 +1,8 @@
 import * as prismicH from 'prismic-helpers-beta';
 import { PrismicDocument, KeyTextField, RichTextField } from '@prismicio/types';
 import { Label } from '@weco/common/model/labels';
-import { ArticlePrismicDocument, WithSeries } from '../types/articles';
-import linkResolver, { ContentType } from '../link-resolver';
+import { WithSeries } from '../types/articles';
+import linkResolver from '../link-resolver';
 import {
   CommonPrismicFields,
   Image,
@@ -49,12 +49,6 @@ import { transformExhibition } from './exhibitions';
 import { transformArticle } from './articles';
 import { transformEvent } from './events';
 import { transformSeason } from './seasons';
-import { PagePrismicDocument } from '../types/pages';
-import { GuidePrismicDocument } from '../types/guides';
-import { EventSeriesPrismicDocument } from '../types/event-series';
-import { ExhibitionPrismicDocument } from '../types/exhibitions';
-import { EventPrismicDocument } from '../types/events';
-import { SeasonPrismicDocument } from '../types/seasons';
 
 type Meta = {
   title: string;
@@ -213,14 +207,6 @@ export function transformBody(body: Body): BodyType {
           };
 
         case 'contentList':
-          const contents: FilledLinkToDocumentField<
-            ContentType,
-            string,
-            never
-          >[] = slice.items
-            .map(item => item.content)
-            .filter(isFilledLinkToDocumentWithData);
-
           return {
             type: 'contentList',
             weight: getWeight(slice.slice_label),
@@ -229,37 +215,25 @@ export function transformBody(body: Body): BodyType {
               // TODO: The old code would look up a `hasFeatured` field on `slice.primary`,
               // but that doesn't exist in our Prismic model.
               // hasFeatured: slice.primary.hasFeatured,
-              items: contents
+              items: slice.items
+                .map(item => item.content)
+                .filter(isFilledLinkToDocumentWithData)
                 .map(content => {
                   switch (content.type) {
                     case 'pages':
-                      return transformPage(
-                        content.data! as PagePrismicDocument
-                      );
+                      return transformPage(content);
                     case 'guides':
-                      return transformGuide(
-                        content.data! as GuidePrismicDocument
-                      );
+                      return transformGuide(content);
                     case 'event-series':
-                      return transformEventSeries(
-                        content.data! as EventSeriesPrismicDocument
-                      );
+                      return transformEventSeries(content);
                     case 'exhibitions':
-                      return transformExhibition(
-                        content.data! as ExhibitionPrismicDocument
-                      );
+                      return transformExhibition(content);
                     case 'articles':
-                      return transformArticle(
-                        content.data! as ArticlePrismicDocument
-                      );
+                      return transformArticle(content);
                     case 'events':
-                      return transformEvent(
-                        content.data! as EventPrismicDocument
-                      );
+                      return transformEvent(content);
                     case 'seasons':
-                      return transformSeason(
-                        content.data! as SeasonPrismicDocument
-                      );
+                      return transformSeason(content);
                   }
                 })
                 .filter(Boolean),

--- a/content/webapp/services/prismic/transformers/index.ts
+++ b/content/webapp/services/prismic/transformers/index.ts
@@ -279,7 +279,10 @@ export function transformBody(body: Body): BodyType {
             value: {
               title: asText(slice.primary.title),
               query: slice.primary.query,
-              pageSize: slice.primary.pageSize || 4,
+              // TODO: The untyped version of this code had `slice.primary.pageSize`, but
+              // there's no such field on the Prismic model.  Should it be on the model?
+              // Does it matter?  Investigate further.
+              pageSize: 4,
             },
           };
 
@@ -340,9 +343,10 @@ export function transformBody(body: Body): BodyType {
           const embed = slice.primary.embed;
 
           if (embed.provider_name === 'Vimeo') {
-            const embedUrl = slice.primary.embed.html.match(
+            const embedUrl = slice.primary.embed.html?.match(
               /src="([-a-zA-Z0-9://.?=_]+)?/
-            )[1];
+            )![1];
+
             return {
               type: 'videoEmbed',
               weight: getWeight(slice.slice_label),
@@ -354,8 +358,8 @@ export function transformBody(body: Body): BodyType {
           }
 
           if (embed.provider_name === 'SoundCloud') {
-            const apiUrl = embed.html.match(/url=([^&]*)&/);
-            const secretToken = embed.html.match(/secret_token=([^"]*)"/);
+            const apiUrl = embed.html!.match(/url=([^&]*)&/)!;
+            const secretToken = embed.html!.match(/secret_token=([^"]*)"/);
             const secretTokenString =
               secretToken && secretToken[1]
                 ? `%3Fsecret_token%3D${secretToken[1]}`
@@ -378,7 +382,7 @@ export function transformBody(body: Body): BodyType {
             //
             // We want to add the query parameter ?rel=0
             const embedUrl =
-              slice.primary.embed.html.match(/src="([^"]+)"?/)[1];
+              slice.primary.embed.html!.match(/src="([^"]+)"?/)![1];
 
             const embedUrlWithEnhancedPrivacy = embedUrl.replace(
               'www.youtube.com',

--- a/content/webapp/services/prismic/types/body.ts
+++ b/content/webapp/services/prismic/types/body.ts
@@ -15,7 +15,7 @@ import {
 import { isUndefined } from '@weco/common/utils/array';
 import { Image } from '.';
 
-type TextSlice = Slice<'slice', { text: RichTextField }>;
+type TextSlice = Slice<'text', { text: RichTextField }>;
 
 export type EditorialImageSlice = Slice<
   'editorialImage',

--- a/content/webapp/services/prismic/types/body.ts
+++ b/content/webapp/services/prismic/types/body.ts
@@ -53,13 +53,13 @@ type Iframe = Slice<
   }
 >;
 
-type Quote = Slice<
-  'quote',
-  {
-    text: RichTextField;
-    citation: RichTextField;
-  }
->;
+type QuotePrimaryFields = {
+  text: RichTextField;
+  citation: RichTextField;
+};
+
+type Quote = Slice<'quote', QuotePrimaryFields>;
+type QuoteV2 = Slice<'quoteV2', QuotePrimaryFields>;
 
 type Standfirst = Slice<
   'standfirst',
@@ -172,6 +172,17 @@ type SearchResults = Slice<
   { title: RichTextField; query: KeyTextField }
 >;
 
+type DeprecatedImageList = Slice<
+  'imageList',
+  Record<string, never>,
+  {
+    title: RichTextField;
+    subtitle: RichTextField;
+    description: RichTextField;
+    image: Image;
+  }
+>;
+
 type MediaObjectList = Slice<
   'mediaObjectList',
   Record<string, never>,
@@ -185,6 +196,7 @@ export type SliceTypes =
   | GifVideoSlice
   | Iframe
   | Quote
+  | QuoteV2
   | Standfirst
   | Table
   | Embed
@@ -197,7 +209,8 @@ export type SliceTypes =
   | TitledTextList
   | ContentList
   | SearchResults
-  | MediaObjectList;
+  | MediaObjectList
+  | DeprecatedImageList;
 
 export type Body = SliceZone<SliceTypes>;
 


### PR DESCRIPTION
For https://github.com/wellcomecollection/wellcomecollection.org/issues/7363, follows #7673

This breaks the deadlock of JavaScript code where, say, parseArticleDoc calls transformGenericFields, which calls parseMultiContent, which calls parseBody … which calls parseArticleDoc. I copy/pasted the existing implementation of parseBody, tweaked it to make TypeScript happy, and called it done.

I also checked every bit of Prismic content in a local build to see that it wasn't 500'ing.