### PR TITLE
Don't show "Read more" if there are no more items

### DIFF
--- a/content/webapp/components/SeriesNavigation/SeriesNavigation.tsx
+++ b/content/webapp/components/SeriesNavigation/SeriesNavigation.tsx
@@ -15,7 +15,7 @@ type Props = {
 
 const SeriesNavigation: FunctionComponent<Props> = ({ series, items }) => {
   const showPosition = !!(series.schedule && series.schedule.length > 0);
-  return (
+  return items.length > 0 ? (
     <SpacingComponent>
       <Layout8>
         <SearchResults
@@ -33,6 +33,8 @@ const SeriesNavigation: FunctionComponent<Props> = ({ series, items }) => {
         </Space>
       </Layout8>
     </SpacingComponent>
+  ) : (
+    <></>
   );
 };
 export default SeriesNavigation;

--- a/content/webapp/components/SeriesNavigation/SeriesNavigation.tsx
+++ b/content/webapp/components/SeriesNavigation/SeriesNavigation.tsx
@@ -33,8 +33,6 @@ const SeriesNavigation: FunctionComponent<Props> = ({ series, items }) => {
         </Space>
       </Layout8>
     </SpacingComponent>
-  ) : (
-    <></>
-  );
+  ) : null;
 };
 export default SeriesNavigation;


### PR DESCRIPTION
This is broken on series pages where there's only one item in the series so far, e.g. https://wellcomecollection.org/articles/YgP2JxMAACAAKVB5

Once a series has >1 items, we'll display the "Read more" link.

## Who is this for?

Keen beans who read the very first article in a comic series.

## What is it doing for them?

Making the page seem less broken/confusing – they can't "read more" because there isn't anything more to read! Not yet, anyway.

At some point we could give this a nicer design treatment, e.g. saying when the next item will be published, but for now the page is at least a bit less wonky.