### PR TITLE
Add a script for checking all content pages

### DIFF
--- a/prismic-model/.gitignore
+++ b/prismic-model/.gitignore
@@ -1,0 +1,1 @@
+snapshot.*

--- a/prismic-model/README.md
+++ b/prismic-model/README.md
@@ -37,3 +37,21 @@ $ ts-node sliceAnalysis --type embed
 ```
 
 See the file comment on [sliceAnalysis.ts](./sliceAnalysis.ts)
+
+## Analysing our Prismic content in bulk
+
+We have a tool that will download a complete snapshot of our Prismic metadata for you.
+This is useful if you want to do bulk analysis of our Prismic data.
+
+```console
+$ yarn downloadSnapshot
+...
+Downloaded Prismic snapshot to snapshot.master.Yhe_-xMAADOEgW3d
+```
+
+One especially common case is checking that we haven't broken any Prismic content after a refactor.
+If you have a locally running content app (`yarn content` in the repo root), you can check that none of our Prismic content is broken:
+
+```console
+$ yarn tryAllContentPages
+```

--- a/prismic-model/downloadSnapshot.ts
+++ b/prismic-model/downloadSnapshot.ts
@@ -1,0 +1,81 @@
+/** This script downloads all the Prismic content to a local snapshot.
+ *
+ * This is useful for doing bulk analysis of the Prismic data, or looking for
+ * specific examples of a particular slice of feature in use.
+ */
+
+import fs from 'fs';
+import fetch from 'node-fetch';
+import { error, success } from './console';
+
+async function getMasterRef(): Promise<string> {
+  const resp = await fetch('https://wellcomecollection.cdn.prismic.io/api');
+
+  type RootResponse = {
+    refs: [{ id: string; ref: string }];
+  };
+
+  const json: RootResponse = await resp.json();
+
+  return json.refs.find(r => r.id === 'master').ref;
+}
+
+type ApiResponse = {
+  pageNumber: number;
+  json: any;
+};
+
+async function* getApiResponses(
+  masterRef: string
+): AsyncGenerator<ApiResponse> {
+  const pageSize = 100;
+  let url = `https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=${masterRef}&pageSize=${pageSize}`;
+
+  while (url !== null) {
+    const resp = await fetch(url);
+    const json = await resp.json();
+    const pageNumber: number = json.page;
+
+    yield { pageNumber, json };
+
+    url = json.next_page;
+  }
+}
+
+export async function downloadPrismicSnapshot(): Promise<string> {
+  const masterRef = await getMasterRef();
+  const snapshotDir = `snapshot.${masterRef}`;
+
+  if (fs.existsSync(snapshotDir)) {
+    return snapshotDir;
+  }
+
+  console.log(`Prismic master ref is ${masterRef}`);
+
+  const tmpDir = `${snapshotDir}.tmp`;
+  fs.mkdir(tmpDir, err => {
+    if (err && err.code !== 'EEXIST') {
+      throw err;
+    }
+  });
+
+  for await (const { pageNumber, json } of getApiResponses(masterRef)) {
+    console.log(`Downloading page ${pageNumber}...`);
+    fs.writeFileSync(
+      `${tmpDir}/page${pageNumber}.json`,
+      JSON.stringify(json, null, 2)
+    );
+  }
+
+  fs.renameSync(tmpDir, snapshotDir);
+
+  success(`Downloaded Prismic snapshot to ${snapshotDir}`);
+  return snapshotDir;
+}
+
+if (require.main === module) {
+  downloadPrismicSnapshot().catch(err => {
+    error(err);
+    process.exit(1);
+  });
+}

--- a/prismic-model/package.json
+++ b/prismic-model/package.json
@@ -2,7 +2,9 @@
   "scripts": {
     "sliceAnalysis": "ts-node sliceAnalysis",
     "deployType": "ts-node deployType",
-    "diffCustomTypes": "ts-node diffCustomTypes"
+    "diffCustomTypes": "ts-node diffCustomTypes",
+    "downloadSnapshot": "ts-node downloadSnapshot",
+    "tryAllPages": "ts-node tryAllPages"
   },
   "license": "MIT",
   "dependencies": {

--- a/prismic-model/package.json
+++ b/prismic-model/package.json
@@ -4,7 +4,7 @@
     "deployType": "ts-node deployType",
     "diffCustomTypes": "ts-node diffCustomTypes",
     "downloadSnapshot": "ts-node downloadSnapshot",
-    "tryAllPages": "ts-node tryAllPages"
+    "tryAllContentPages": "ts-node tryAllContentPages"
   },
   "license": "MIT",
   "dependencies": {

--- a/prismic-model/tryAllContentPages.ts
+++ b/prismic-model/tryAllContentPages.ts
@@ -58,31 +58,32 @@ const nonVisibleTypes = new Set([
   'teams',
 ]);
 
-function createUrl({ id, type }: PrismicDocument): string {
+function createUrl(prefix: string, { id, type }: PrismicDocument): string {
   switch (type) {
     case 'webcomics':
-      return `http://localhost:3000/articles/${id}`;
+      return `${prefix}/articles/${id}`;
 
     case 'webcomic-series':
-      return `http://localhost:3000/series/${id}`;
+      return `${prefix}/series/${id}`;
 
     default:
-      return `http://localhost:3000/${type}/${id}`;
+      return `${prefix}/${type}/${id}`;
   }
 }
 
 async function run() {
   const snapshotDir = await downloadPrismicSnapshot();
 
-  const documents = getPrismicDocuments(snapshotDir)
-    .filter(({ type }) => !nonVisibleTypes.has(type));
+  const prefix = 'http://localhost:3000';
 
-  for (const doc of documents) {
-    const url = createUrl(doc);
+  const urls = getPrismicDocuments(snapshotDir)
+    .filter(({ type }) => !nonVisibleTypes.has(type))
+    .map(doc => createUrl(prefix, doc));
 
-    const resp = await fetch(url);
+  for (const u of urls) {
+    const resp = await fetch(u);
     if (resp.status !== 200) {
-      error(`${resp.status} ${url}`);
+      error(`${resp.status} ${u}`);
     }
   }
 }

--- a/prismic-model/tryAllPages.ts
+++ b/prismic-model/tryAllPages.ts
@@ -1,0 +1,86 @@
+import { error } from './console';
+import { downloadPrismicSnapshot } from './downloadSnapshot';
+import fs from 'fs';
+import fetch from 'node-fetch';
+
+type PrismicDocument = {
+  id: string;
+  type: string;
+};
+
+function getPrismicDocuments(snapshotDir: string): PrismicDocument[] {
+  const documents: PrismicDocument[] = [];
+
+  fs.readdirSync(snapshotDir).forEach(file => {
+    const data = fs.readFileSync(`${snapshotDir}/${file}`);
+    const json: { results: PrismicDocument[] } = JSON.parse(data.toString());
+
+    documents.push(...json.results);
+  });
+
+  return documents;
+}
+
+const nonVisibleTypes = new Set([
+  'people',
+  'organisations',
+  'featured-books',
+  'editorial-contributor-roles',
+  'places',
+  'card',
+  'teams',
+  'event-formats',
+  'audiences',
+  'article-formats',
+  'project-formats',
+  'event-policies',
+  'interpretation-types',
+  'exhibition-formats',
+  'labels',
+  'background-textures',
+  'popup-dialog',
+  'guide-formats',
+  'page-formats',
+  'collection-venue',
+  'global-alert',
+]);
+
+async function checkDocument({ id, type }: PrismicDocument) {
+  if (nonVisibleTypes.has(type)) {
+    return;
+  }
+
+  let url: string;
+
+  switch (type) {
+    case 'webcomics':
+      url = `http://localhost:3000/articles/${id}`;
+      break;
+
+    case 'webcomic-series':
+      url = `http://localhost:3000/series/${id}`;
+      break;
+
+    default:
+      url = `http://localhost:3000/${type}/${id}`;
+      break;
+  }
+
+  const resp = await fetch(url);
+  if (resp.status !== 200) {
+    error(`${resp.status} ${url}`);
+  }
+}
+
+async function run() {
+  const snapshotDir = await downloadPrismicSnapshot();
+
+  for (const doc of getPrismicDocuments(snapshotDir)) {
+    await checkDocument(doc);
+  }
+}
+
+run().catch(err => {
+  error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
This is some tooling I've used for the big Prismic refactor (#7363). It adds two new commands:

1. To download a complete snapshot of our Prismic metadata:

    ```console
    $ yarn downloadSnapshot
    ...
    Downloaded Prismic snapshot to snapshot.master.Yhe_-xMAADOEgW3d
    ```

2. To check all the pages against a local content app:

    ```console
    $ yarn tryAllContentPages
    !!! 500 http://localhost:3000/pages/YOwMVBMAACMATaPW
    ```

For now I've been running it locally; you can imagine at some point we might want to run this in CI, but since it takes about 10&nbsp;minutes every time (at least from my home computer), I'm wary to add it as a gate to deployments.