### PR TITLE
Use event locations in stead of place in templates

### DIFF
--- a/common/model/events.ts
+++ b/common/model/events.ts
@@ -88,6 +88,7 @@ export type Event = GenericContentFields & {
   series: EventSeries[];
   seasons: Season[];
   place?: Place;
+  locations: Place[];
   bookingEnquiryTeam?: Team;
   interpretations: Interpretation[];
   audiences: Audience[];

--- a/content/webapp/__mocks__/events.ts
+++ b/content/webapp/__mocks__/events.ts
@@ -11,7 +11,7 @@ const image = {
   crops: {},
 };
 
-const place = {
+const location = {
   id: 'Wn1fvyoAACgAH_yG',
   title: 'Reading Room',
   body: [],
@@ -33,6 +33,7 @@ const baseEvent: UiEvent = {
   times: [],
   series: [],
   place: undefined,
+  locations: [],
   bookingEnquiryTeam: undefined,
   interpretations: [],
   audiences: [],
@@ -78,10 +79,13 @@ const baseEvent: UiEvent = {
   prismicDocument: undefined,
 };
 
-export const eventWithPlace: UiEvent = { ...baseEvent, place };
-export const eventOnline: UiEvent = { ...baseEvent, isOnline: true };
-export const eventWithPlaceOnline: UiEvent = {
+export const eventWithOneLocation: UiEvent = {
   ...baseEvent,
-  place,
+  locations: [location],
+};
+export const eventOnline: UiEvent = { ...baseEvent, isOnline: true };
+export const eventWithOneLocationOnline: UiEvent = {
+  ...baseEvent,
+  locations: [location],
   isOnline: true,
 };

--- a/content/webapp/components/CardGrid/DailyTourPromo.tsx
+++ b/content/webapp/components/CardGrid/DailyTourPromo.tsx
@@ -18,6 +18,7 @@ export const data: UiEvent = {
   times: [],
   series: [],
   place: undefined,
+  locations: [],
   bookingEnquiryTeam: undefined,
   interpretations: [],
   audiences: [],

--- a/content/webapp/components/EventPromo/EventPromo.test.tsx
+++ b/content/webapp/components/EventPromo/EventPromo.test.tsx
@@ -6,9 +6,9 @@ import EventPromo from './EventPromo';
 import * as Context from '@weco/common/server-data/Context';
 import { UiEvent } from '@weco/common/model/events';
 import {
-  eventWithPlace,
+  eventWithOneLocation,
   eventOnline,
-  eventWithPlaceOnline,
+  eventWithOneLocationOnline,
 } from '../../__mocks__/events';
 jest.spyOn(Context, 'useToggles').mockImplementation(() => ({
   enablePickUpDate: true,
@@ -28,7 +28,7 @@ const renderComponent = (event: UiEvent) => {
 
 describe('EventPromo', () => {
   it('Shows a specific location when it is the only location for an event', () => {
-    renderComponent(eventWithPlace);
+    renderComponent(eventWithOneLocation);
     expect(screen.getByText('Reading Room'));
   });
 
@@ -38,7 +38,7 @@ describe('EventPromo', () => {
   });
 
   it('Shows when an event is a physical/online hybrid', () => {
-    renderComponent(eventWithPlaceOnline);
+    renderComponent(eventWithOneLocationOnline);
     expect(screen.getByText('Online & In our building'));
   });
 });

--- a/content/webapp/components/EventPromo/EventPromo.tsx
+++ b/content/webapp/components/EventPromo/EventPromo.tsx
@@ -90,7 +90,7 @@ const EventPromo: FC<Props> = ({
             {event.title}
           </Space>
 
-          {(event.isOnline || event.place) && (
+          {(event.isOnline || event.locations[0]) && (
             <Space
               v={{ size: 's', properties: ['margin-top', 'margin-bottom'] }}
               className={classNames({
@@ -101,7 +101,7 @@ const EventPromo: FC<Props> = ({
               <Icon icon={location} matchText />
               <Space h={{ size: 'xs', properties: ['margin-left'] }}>
                 <AlignFont>
-                  {getLocationText(event.isOnline, event.place)}
+                  {getLocationText(event.isOnline, event.locations[0])}
                 </AlignFont>
               </Space>
             </Space>

--- a/content/webapp/components/EventSchedule/EventScheduleItem.tsx
+++ b/content/webapp/components/EventSchedule/EventScheduleItem.tsx
@@ -78,7 +78,7 @@ const EventScheduleItem = ({ event, isNotLinked }: Props) => {
             >
               {event.title}
             </Space>
-            {event.place && (
+            {event.locations[0] && (
               <Space
                 v={{ size: 's', properties: ['margin-bottom'] }}
                 as="p"
@@ -86,7 +86,7 @@ const EventScheduleItem = ({ event, isNotLinked }: Props) => {
                   [font('hnr', 5)]: true,
                 })}
               >
-                {event.place.title}
+                {event.locations[0].title}
               </Space>
             )}
 

--- a/content/webapp/pages/event.tsx
+++ b/content/webapp/pages/event.tsx
@@ -480,10 +480,10 @@ const EventPage: NextPage<Props> = ({ jsonEvent }: Props) => {
           title="Need to know"
           items={
             [
-              event.place && {
+              event.locations[0] && {
                 id: undefined,
                 title: 'Location',
-                description: event.place.information,
+                description: event.locations[0].information,
               },
               event.bookingInformation && {
                 id: undefined,


### PR DESCRIPTION
Part of #7639 and #7681

Now that all Prismic event `places` have been moved to be the first of an event's newly created `locations`, we can stop using `event.place` altogether.

This is like for like – there won't be a difference in what displays on the frontend.