### PR TITLE
Fix the crop of books in their promo

### DIFF
--- a/content/webapp/services/prismic/transformers/exhibitions.ts
+++ b/content/webapp/services/prismic/transformers/exhibitions.ts
@@ -33,7 +33,9 @@ import { isNotUndefined } from '@weco/common/utils/array';
 import { isFilledLinkToDocumentWithData } from '../types';
 import { ExhibitionFormat } from '@weco/common/model/exhibitions';
 
-function transformExhibitionFormat(format: ExhibitionFormatPrismicDocument): ExhibitionFormat {
+function transformExhibitionFormat(
+  format: ExhibitionFormatPrismicDocument
+): ExhibitionFormat {
   return {
     id: format.id,
     title: (format.data && asText(format.data.title)) || '',
@@ -84,9 +86,11 @@ export function transformExhibition(
   const audioDescriptionInfo = isEmptyHtmlString(data.audioDescriptionInfo)
     ? undefined
     : (data.audioDescriptionInfo as HTMLString);
+
+  const promoCrop = '16:9';
   const promoImage =
     promo && promo.length > 0
-      ? transformPromoToCaptionedImage(data.promo)
+      ? transformPromoToCaptionedImage(data.promo, promoCrop)
       : undefined;
 
   const seasons = parseSingleLevelGroup(data.seasons, 'season').map(season => {

--- a/content/webapp/services/prismic/transformers/images.ts
+++ b/content/webapp/services/prismic/transformers/images.ts
@@ -29,7 +29,7 @@ export const placeHolderImage: ImageType = {
 type Crop = '16:9' | '32:15' | 'square';
 export function transformCaptionedImage(
   frag: { image: Image; caption: RichTextField },
-  crop?: Crop | undefined
+  crop?: Crop
 ): CaptionedImage {
   if (isEmptyObj(frag.image)) {
     return {
@@ -55,7 +55,7 @@ export function transformCaptionedImage(
 
 export function transformPromoToCaptionedImage(
   frag: PromoSliceZone,
-  crop: Crop | undefined = '16:9'
+  crop?: Crop
 ): CaptionedImage {
   // We could do more complicated checking here, but this is what we always use.
   const promo = frag[0];


### PR DESCRIPTION
I got confused about the function signature when I converted this from
JavaScript.  The original signature was

    crop: ?Crop = '16:9'

and it was called on the books page with `crop = null`.  If the `crop`
is null, you get the full image.  I thought I could change that to

    crop: Crop | undefined = '16:9'

and then omit the argument on the books page, but I got that wrong --
it caused the book promo to be cropped to 16:9 by default.

Since this function is only used in two places, I've binned the default
and made the use of a 16:9 crop in the one other call explicit.

## Who is this for?

People who make book covers.

## What is it doing for them?

Showing them in their full glory.

See https://wellcome.slack.com/archives/C8X9YKM5X/p1645631512964199