### PR TITLE
Cache the e2e test image between builds to make them go faster

### DIFF
--- a/.buildkite/pipeline.e2e-universal.yml
+++ b/.buildkite/pipeline.e2e-universal.yml
@@ -1,22 +1,23 @@
 steps:
+  - label: "build e2e test image"
+    command: ./playwright/get_playwright_image.sh
+
   - label: "e2e test:desktop [$DEPLOYMENT_ENVIRONMENT]"
-    plugins:
-      - docker-compose#v3.5.0:
-          run: e2e
-          env:
-            - PLAYWRIGHT_BASE_URL=$PLAYWRIGHT_BASE_URL
-            - USE_STAGE_APIS=$USE_STAGE_APIS
-          command: ["yarn", "test"]
+    command:
+      docker run --rm \
+        --env PLAYWRIGHT_BASE_URL=$PLAYWRIGHT_BASE_URL \
+        --env USE_STAGE_APIS=$USE_STAGE_APIS \
+        130871440101.dkr.ecr.eu-west-1.amazonaws.com/weco/playwright \
+        yarn test
     retry:
       automatic: true
 
   - label: "e2e test:mobile [$DEPLOYMENT_ENVIRONMENT]"
-    plugins:
-      - docker-compose#v3.5.0:
-          run: e2e
-          env:
-            - PLAYWRIGHT_BASE_URL=$PLAYWRIGHT_BASE_URL
-            - USE_STAGE_APIS=$USE_STAGE_APIS
-          command: ["yarn", "test:mobile"]
+    command:
+      docker run --rm \
+        --env PLAYWRIGHT_BASE_URL=$PLAYWRIGHT_BASE_URL \
+        --env USE_STAGE_APIS=$USE_STAGE_APIS \
+        130871440101.dkr.ecr.eu-west-1.amazonaws.com/weco/playwright \
+        yarn test:mobile
     retry:
       automatic: true

--- a/.buildkite/pipeline.e2e-universal.yml
+++ b/.buildkite/pipeline.e2e-universal.yml
@@ -1,11 +1,20 @@
 steps:
   - label: "build e2e test image"
     command: ./playwright/get_playwright_image.sh
+    plugins:
+      - wellcomecollection/aws-assume-role#v0.2.2:
+          role: "arn:aws:iam::130871440101:role/experience-ci"
+      - ecr#v2.1.1:
+          login: true
 
   - wait
 
   - label: "e2e test:desktop [$DEPLOYMENT_ENVIRONMENT]"
     plugins:
+      - wellcomecollection/aws-assume-role#v0.2.2:
+          role: "arn:aws:iam::130871440101:role/experience-ci"
+      - ecr#v2.1.1:
+          login: true
       - docker-compose#v3.5.0:
           run: e2e
           env:
@@ -17,6 +26,10 @@ steps:
 
   - label: "e2e test:mobile [$DEPLOYMENT_ENVIRONMENT]"
     plugins:
+      - wellcomecollection/aws-assume-role#v0.2.2:
+          role: "arn:aws:iam::130871440101:role/experience-ci"
+      - ecr#v2.1.1:
+          login: true
       - docker-compose#v3.5.0:
           run: e2e
           env:

--- a/.buildkite/pipeline.e2e-universal.yml
+++ b/.buildkite/pipeline.e2e-universal.yml
@@ -2,22 +2,26 @@ steps:
   - label: "build e2e test image"
     command: ./playwright/get_playwright_image.sh
 
+  - wait
+
   - label: "e2e test:desktop [$DEPLOYMENT_ENVIRONMENT]"
-    command:
-      docker run --rm \
-        --env PLAYWRIGHT_BASE_URL=$PLAYWRIGHT_BASE_URL \
-        --env USE_STAGE_APIS=$USE_STAGE_APIS \
-        130871440101.dkr.ecr.eu-west-1.amazonaws.com/weco/playwright \
-        yarn test
+    plugins:
+      - docker-compose#v3.5.0:
+          run: e2e
+          env:
+            - PLAYWRIGHT_BASE_URL=$PLAYWRIGHT_BASE_URL
+            - USE_STAGE_APIS=$USE_STAGE_APIS
+          command: ["yarn", "test"]
     retry:
       automatic: true
 
   - label: "e2e test:mobile [$DEPLOYMENT_ENVIRONMENT]"
-    command:
-      docker run --rm \
-        --env PLAYWRIGHT_BASE_URL=$PLAYWRIGHT_BASE_URL \
-        --env USE_STAGE_APIS=$USE_STAGE_APIS \
-        130871440101.dkr.ecr.eu-west-1.amazonaws.com/weco/playwright \
-        yarn test:mobile
+    plugins:
+      - docker-compose#v3.5.0:
+          run: e2e
+          env:
+            - PLAYWRIGHT_BASE_URL=$PLAYWRIGHT_BASE_URL
+            - USE_STAGE_APIS=$USE_STAGE_APIS
+          command: ["yarn", "test:mobile"]
     retry:
       automatic: true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,6 +6,8 @@
           login: true
     command: ./playwright/get_playwright_image.sh
 
+  - wait
+
   - label: "e2e test:desktop [$DEPLOYMENT_ENVIRONMENT]"
     plugins:
       - wellcomecollection/aws-assume-role#v0.2.2:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -18,7 +18,7 @@ steps:
       - docker-compose#v3.5.0:
           run: e2e
           env:
-            - PLAYWRIGHT_BASE_URL=$PLAYWRIGHT_BASE_URL
+            - PLAYWRIGHT_BASE_URL=https://www-stage.wellcomecollection.org/
             - USE_STAGE_APIS=$USE_STAGE_APIS
           command: ["yarn", "test"]
     retry:
@@ -33,7 +33,7 @@ steps:
       - docker-compose#v3.5.0:
           run: e2e
           env:
-            - PLAYWRIGHT_BASE_URL=$PLAYWRIGHT_BASE_URL
+            - PLAYWRIGHT_BASE_URL=https://www-stage.wellcomecollection.org/
             - USE_STAGE_APIS=$USE_STAGE_APIS
           command: ["yarn", "test:mobile"]
     retry:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,234 +1,115 @@
-- label: ":docker: build common"
-  key: "build_common"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        build:
-          - common
-        image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
+  - label: "build e2e test image"
+    command: ./playwright/get_playwright_image.sh
 
-# Note: we have two variants of the "build cardigan" CI step.
+  - label: "e2e test:desktop [$DEPLOYMENT_ENVIRONMENT]"
+    command:
+      docker run --rm \
+        --env PLAYWRIGHT_BASE_URL=$PLAYWRIGHT_BASE_URL \
+        --env USE_STAGE_APIS=$USE_STAGE_APIS \
+        130871440101.dkr.ecr.eu-west-1.amazonaws.com/weco/playwright \
+        yarn test
+    retry:
+      automatic: true
+
+  - label: "e2e test:mobile [$DEPLOYMENT_ENVIRONMENT]"
+    command:
+      docker run --rm \
+        --env PLAYWRIGHT_BASE_URL=$PLAYWRIGHT_BASE_URL \
+        --env USE_STAGE_APIS=$USE_STAGE_APIS \
+        130871440101.dkr.ecr.eu-west-1.amazonaws.com/weco/playwright \
+        yarn test:mobile
+    retry:
+      automatic: true
 #
-# In pull requests, we don't need to publish the image to ECR, because
-# there is no later "test cardigan" step that would use the published image.
-# This saves ~1m from the Cardigan build, which is one of the longest
-# in PR builds.
 #
-# In main builds, we do need to publish the image to ECR, because it's
-# used again later in the "deploy Cardigan" step.
+# - label: ":docker: build common"
+#   key: "build_common"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         build:
+#           - common
+#         image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
 #
-- label: ":docker: build cardigan"
-  key: "build_cardigan_main"
-  if: build.branch == "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        build:
-          - cardigan
-        image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
-- label: ":docker: build cardigan"
-  key: "build_cardigan_pr"
-  if: build.branch != "main"
-  command: docker-compose build cardigan
-
-- label: ":docker: build catalogue"
-  key: "build_catalogue"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        build:
-          - catalogue
-        image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
-
-- label: ":docker: build content"
-  key: "build_content"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        build:
-          - content
-        image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
-
-- label: ":docker: build edge_lambdas"
-  key: "build_edge_lambdas"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        build:
-          - edge_lambdas
-        image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
-
-- label: ":docker: build identity"
-  key: "build_identity"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        build:
-          - identity
-        image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
-
-- label: "diff prismic model"
-  branches: "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: prismic_model
-        env:
-          - CI
-        command: ["yarn", "diffCustomTypes"]
-
-- label: "test common"
-  depends_on: "build_common"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: common
-        command: ["yarn", "test"]
-
-- label: "test catalogue"
-  depends_on: "build_catalogue"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: catalogue
-        command: ["yarn", "test"]
-
-- label: "test content"
-  depends_on: "build_content"
-  # Some content tests fail because the mocks do not match reality.
-  # However,work is in train to get reality closer to the mocks.
-  # For this reason, it is inappropriate to fix either right now.
-  # Instead, allow a failure in this step to be reported, but not
-  # block the build.
-  # Remove this *as soon* as the step starts passing again.
-  soft_fail: true
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: content
-        command: ["yarn", "test"]
-
-- label: "test identity"
-  depends_on: "build_identity"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: identity
-        command: ["yarn", "test"]
-
-- label: "test edge_lambdas"
-  depends_on: "build_edge_lambdas"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: edge_lambdas
-        command: ["yarn", "test"]
-
-- wait
-
-- label: "deploy catalogue (ecr image)"
-  branches: "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        push:
-          - catalogue:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/catalogue_webapp:ref.${BUILDKITE_COMMIT}
-          - catalogue:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/catalogue_webapp:latest
-
-- label: "deploy catalogue (bundle analysis)"
-  branches: "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: catalogue
-        command: [ "yarn", "deployBundleAnalysis" ]
-        env:
-          - AWS_ACCESS_KEY_ID
-          - AWS_SECRET_ACCESS_KEY
-          - AWS_SESSION_TOKEN
-
-- label: "deploy content (ecr image)"
-  branches: "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        push:
-          - content:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/content_webapp:ref.${BUILDKITE_COMMIT}
-          - content:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/content_webapp:latest
-
-- label: "deploy content (bundle analysis)"
-  branches: "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: content
-        command: [ "yarn", "deployBundleAnalysis" ]
-        env:
-          - AWS_ACCESS_KEY_ID
-          - AWS_SECRET_ACCESS_KEY
-          - AWS_SESSION_TOKEN
-
-- label: "deploy identity (ecr image)"
-  branches: "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        push:
-          - identity:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/identity_webapp:ref.${BUILDKITE_COMMIT}
-          - identity:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/identity_webapp:latest
-
-# - label: "deploy identity (bundle analysis)"
+# # Note: we have two variants of the "build cardigan" CI step.
+# #
+# # In pull requests, we don't need to publish the image to ECR, because
+# # there is no later "test cardigan" step that would use the published image.
+# # This saves ~1m from the Cardigan build, which is one of the longest
+# # in PR builds.
+# #
+# # In main builds, we do need to publish the image to ECR, because it's
+# # used again later in the "deploy Cardigan" step.
+# #
+# - label: ":docker: build cardigan"
+#   key: "build_cardigan_main"
+#   if: build.branch == "main"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         build:
+#           - cardigan
+#         image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
+# - label: ":docker: build cardigan"
+#   key: "build_cardigan_pr"
+#   if: build.branch != "main"
+#   command: docker-compose build cardigan
+#
+# - label: ":docker: build catalogue"
+#   key: "build_catalogue"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         build:
+#           - catalogue
+#         image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
+#
+# - label: ":docker: build content"
+#   key: "build_content"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         build:
+#           - content
+#         image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
+#
+# - label: ":docker: build edge_lambdas"
+#   key: "build_edge_lambdas"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         build:
+#           - edge_lambdas
+#         image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
+#
+# - label: ":docker: build identity"
+#   key: "build_identity"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         build:
+#           - identity
+#         image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
+#
+# - label: "diff prismic model"
 #   branches: "main"
 #   plugins:
 #     - wellcomecollection/aws-assume-role#v0.2.2:
@@ -236,119 +117,262 @@
 #     - ecr#v2.1.1:
 #         login: true
 #     - docker-compose#v3.5.0:
+#         run: prismic_model
+#         env:
+#           - CI
+#         command: ["yarn", "diffCustomTypes"]
+#
+# - label: "test common"
+#   depends_on: "build_common"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: common
+#         command: ["yarn", "test"]
+#
+# - label: "test catalogue"
+#   depends_on: "build_catalogue"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: catalogue
+#         command: ["yarn", "test"]
+#
+# - label: "test content"
+#   depends_on: "build_content"
+#   # Some content tests fail because the mocks do not match reality.
+#   # However,work is in train to get reality closer to the mocks.
+#   # For this reason, it is inappropriate to fix either right now.
+#   # Instead, allow a failure in this step to be reported, but not
+#   # block the build.
+#   # Remove this *as soon* as the step starts passing again.
+#   soft_fail: true
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: content
+#         command: ["yarn", "test"]
+#
+# - label: "test identity"
+#   depends_on: "build_identity"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
 #         run: identity
+#         command: ["yarn", "test"]
+#
+# - label: "test edge_lambdas"
+#   depends_on: "build_edge_lambdas"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: edge_lambdas
+#         command: ["yarn", "test"]
+#
+# - wait
+#
+# - label: "deploy catalogue (ecr image)"
+#   branches: "main"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         push:
+#           - catalogue:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/catalogue_webapp:ref.${BUILDKITE_COMMIT}
+#           - catalogue:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/catalogue_webapp:latest
+#
+# - label: "deploy catalogue (bundle analysis)"
+#   branches: "main"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: catalogue
 #         command: [ "yarn", "deployBundleAnalysis" ]
 #         env:
 #           - AWS_ACCESS_KEY_ID
 #           - AWS_SECRET_ACCESS_KEY
 #           - AWS_SESSION_TOKEN
-
-- label: "deploy dash"
-  branches: "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: dash
-        command: [ "yarn", "deploy" ]
-        env:
-          - AWS_ACCESS_KEY_ID
-          - AWS_SECRET_ACCESS_KEY
-          - AWS_SESSION_TOKEN
-
-- label: "deploy cardigan"
-  branches: "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: cardigan
-        command: [ "yarn", "deploy" ]
-        env:
-          - AWS_ACCESS_KEY_ID
-          - AWS_SECRET_ACCESS_KEY
-          - AWS_SESSION_TOKEN
-
-- label: "deploy toggles"
-  branches: "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: toggles
-        command: [ "yarn", "deploy" ]
-        env:
-          - AWS_ACCESS_KEY_ID
-          - AWS_SECRET_ACCESS_KEY
-          - AWS_SESSION_TOKEN
-          - CI
-
-- label: "deploy pa11y"
-  branches: "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: pa11y
-        command: [ "yarn", "deploy" ]
-        env:
-          - AWS_ACCESS_KEY_ID
-          - AWS_SECRET_ACCESS_KEY
-          - AWS_SESSION_TOKEN
-
-- label: "deploy edge_lambdas"
-  branches: "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: edge_lambdas
-        command: [ "yarn", "deploy" ]
-        env:
-          - AWS_ACCESS_KEY_ID
-          - AWS_SECRET_ACCESS_KEY
-          - AWS_SESSION_TOKEN
-
-- label: "deploy updown"
-  branches: "main"
-  skip: "To avoid overriding manual work that is occuring"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: updown
-        command: [ "yarn", "checks" ]
-        env:
-          - AWS_ACCESS_KEY_ID
-          - AWS_SECRET_ACCESS_KEY
-          - AWS_SESSION_TOKEN
-
-- label: "deploy assets"
-  branches: "main"
-  commands: ./assets/deploy_assets.sh
-  agents:
-    queue: nano
-
-- wait
-
-- label: "Trigger stage deployment"
-  branches: "main"
-  plugins:
-    - wellcomecollection/github-deployments#v0.2.4:
-        assume_role: "arn:aws:iam::130871440101:role/experience-ci"
-        environment: stage
-        ref: "${BUILDKITE_COMMIT}"
-  agents:
-    queue: nano
+#
+# - label: "deploy content (ecr image)"
+#   branches: "main"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         push:
+#           - content:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/content_webapp:ref.${BUILDKITE_COMMIT}
+#           - content:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/content_webapp:latest
+#
+# - label: "deploy content (bundle analysis)"
+#   branches: "main"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: content
+#         command: [ "yarn", "deployBundleAnalysis" ]
+#         env:
+#           - AWS_ACCESS_KEY_ID
+#           - AWS_SECRET_ACCESS_KEY
+#           - AWS_SESSION_TOKEN
+#
+# - label: "deploy identity (ecr image)"
+#   branches: "main"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         push:
+#           - identity:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/identity_webapp:ref.${BUILDKITE_COMMIT}
+#           - identity:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/identity_webapp:latest
+#
+# # - label: "deploy identity (bundle analysis)"
+# #   branches: "main"
+# #   plugins:
+# #     - wellcomecollection/aws-assume-role#v0.2.2:
+# #         role: "arn:aws:iam::130871440101:role/experience-ci"
+# #     - ecr#v2.1.1:
+# #         login: true
+# #     - docker-compose#v3.5.0:
+# #         run: identity
+# #         command: [ "yarn", "deployBundleAnalysis" ]
+# #         env:
+# #           - AWS_ACCESS_KEY_ID
+# #           - AWS_SECRET_ACCESS_KEY
+# #           - AWS_SESSION_TOKEN
+#
+# - label: "deploy dash"
+#   branches: "main"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: dash
+#         command: [ "yarn", "deploy" ]
+#         env:
+#           - AWS_ACCESS_KEY_ID
+#           - AWS_SECRET_ACCESS_KEY
+#           - AWS_SESSION_TOKEN
+#
+# - label: "deploy cardigan"
+#   branches: "main"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: cardigan
+#         command: [ "yarn", "deploy" ]
+#         env:
+#           - AWS_ACCESS_KEY_ID
+#           - AWS_SECRET_ACCESS_KEY
+#           - AWS_SESSION_TOKEN
+#
+# - label: "deploy toggles"
+#   branches: "main"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: toggles
+#         command: [ "yarn", "deploy" ]
+#         env:
+#           - AWS_ACCESS_KEY_ID
+#           - AWS_SECRET_ACCESS_KEY
+#           - AWS_SESSION_TOKEN
+#           - CI
+#
+# - label: "deploy pa11y"
+#   branches: "main"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: pa11y
+#         command: [ "yarn", "deploy" ]
+#         env:
+#           - AWS_ACCESS_KEY_ID
+#           - AWS_SECRET_ACCESS_KEY
+#           - AWS_SESSION_TOKEN
+#
+# - label: "deploy edge_lambdas"
+#   branches: "main"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: edge_lambdas
+#         command: [ "yarn", "deploy" ]
+#         env:
+#           - AWS_ACCESS_KEY_ID
+#           - AWS_SECRET_ACCESS_KEY
+#           - AWS_SESSION_TOKEN
+#
+# - label: "deploy updown"
+#   branches: "main"
+#   skip: "To avoid overriding manual work that is occuring"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: updown
+#         command: [ "yarn", "checks" ]
+#         env:
+#           - AWS_ACCESS_KEY_ID
+#           - AWS_SECRET_ACCESS_KEY
+#           - AWS_SESSION_TOKEN
+#
+# - label: "deploy assets"
+#   branches: "main"
+#   commands: ./assets/deploy_assets.sh
+#   agents:
+#     queue: nano
+#
+# - wait
+#
+# - label: "Trigger stage deployment"
+#   branches: "main"
+#   plugins:
+#     - wellcomecollection/github-deployments#v0.2.4:
+#         assume_role: "arn:aws:iam::130871440101:role/experience-ci"
+#         environment: stage
+#         ref: "${BUILDKITE_COMMIT}"
+#   agents:
+#     queue: nano

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -16,8 +16,7 @@
         login: true
   command:
     docker run --rm \
-      --env PLAYWRIGHT_BASE_URL=$PLAYWRIGHT_BASE_URL \
-      --env USE_STAGE_APIS=$USE_STAGE_APIS \
+      --env PLAYWRIGHT_BASE_URL=https://www-stage.wellcomecollection.org \
       130871440101.dkr.ecr.eu-west-1.amazonaws.com/weco/playwright:latest \
       yarn test
   retry:
@@ -31,8 +30,7 @@
         login: true
   command:
     docker run --rm \
-      --env PLAYWRIGHT_BASE_URL=$PLAYWRIGHT_BASE_URL \
-      --env USE_STAGE_APIS=$USE_STAGE_APIS \
+      --env PLAYWRIGHT_BASE_URL=https://www-stage.wellcomecollection.org \
       130871440101.dkr.ecr.eu-west-1.amazonaws.com/weco/playwright:latest \
       yarn test:mobile
   retry:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,11 +1,20 @@
 steps:
   - label: "build e2e test image"
     command: ./playwright/get_playwright_image.sh
+    plugins:
+      - wellcomecollection/aws-assume-role#v0.2.2:
+          role: "arn:aws:iam::130871440101:role/experience-ci"
+      - ecr#v2.1.1:
+          login: true
 
   - wait
 
   - label: "e2e test:desktop [$DEPLOYMENT_ENVIRONMENT]"
     plugins:
+      - wellcomecollection/aws-assume-role#v0.2.2:
+          role: "arn:aws:iam::130871440101:role/experience-ci"
+      - ecr#v2.1.1:
+          login: true
       - docker-compose#v3.5.0:
           run: e2e
           env:
@@ -17,6 +26,10 @@ steps:
 
   - label: "e2e test:mobile [$DEPLOYMENT_ENVIRONMENT]"
     plugins:
+      - wellcomecollection/aws-assume-role#v0.2.2:
+          role: "arn:aws:iam::130871440101:role/experience-ci"
+      - ecr#v2.1.1:
+          login: true
       - docker-compose#v3.5.0:
           run: e2e
           env:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,42 +1,42 @@
-  - label: "build e2e test image"
-    plugins:
-      - wellcomecollection/aws-assume-role#v0.2.2:
-          role: "arn:aws:iam::130871440101:role/experience-ci"
-      - ecr#v2.1.1:
-          login: true
-    command: ./playwright/get_playwright_image.sh
+- label: "build e2e test image"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+  command: ./playwright/get_playwright_image.sh
 
-  - wait
+- wait
 
-  - label: "e2e test:desktop [$DEPLOYMENT_ENVIRONMENT]"
-    plugins:
-      - wellcomecollection/aws-assume-role#v0.2.2:
-          role: "arn:aws:iam::130871440101:role/experience-ci"
-      - ecr#v2.1.1:
-          login: true
-    command:
-      docker run --rm \
-        --env PLAYWRIGHT_BASE_URL=$PLAYWRIGHT_BASE_URL \
-        --env USE_STAGE_APIS=$USE_STAGE_APIS \
-        130871440101.dkr.ecr.eu-west-1.amazonaws.com/weco/playwright \
-        yarn test
-    retry:
-      automatic: true
+- label: "e2e test:desktop [$DEPLOYMENT_ENVIRONMENT]"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+  command:
+    docker run --rm \
+      --env PLAYWRIGHT_BASE_URL=$PLAYWRIGHT_BASE_URL \
+      --env USE_STAGE_APIS=$USE_STAGE_APIS \
+      130871440101.dkr.ecr.eu-west-1.amazonaws.com/weco/playwright:latest \
+      yarn test
+  retry:
+    automatic: true
 
-  - label: "e2e test:mobile [$DEPLOYMENT_ENVIRONMENT]"
-    plugins:
-      - wellcomecollection/aws-assume-role#v0.2.2:
-          role: "arn:aws:iam::130871440101:role/experience-ci"
-      - ecr#v2.1.1:
-          login: true
-    command:
-      docker run --rm \
-        --env PLAYWRIGHT_BASE_URL=$PLAYWRIGHT_BASE_URL \
-        --env USE_STAGE_APIS=$USE_STAGE_APIS \
-        130871440101.dkr.ecr.eu-west-1.amazonaws.com/weco/playwright \
-        yarn test:mobile
-    retry:
-      automatic: true
+- label: "e2e test:mobile [$DEPLOYMENT_ENVIRONMENT]"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+  command:
+    docker run --rm \
+      --env PLAYWRIGHT_BASE_URL=$PLAYWRIGHT_BASE_URL \
+      --env USE_STAGE_APIS=$USE_STAGE_APIS \
+      130871440101.dkr.ecr.eu-west-1.amazonaws.com/weco/playwright:latest \
+      yarn test:mobile
+  retry:
+    automatic: true
 #
 #
 # - label: ":docker: build common"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,40 +1,30 @@
-- label: "build e2e test image"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-  command: ./playwright/get_playwright_image.sh
+steps:
+  - label: "build e2e test image"
+    command: ./playwright/get_playwright_image.sh
 
-- wait
+  - wait
 
-- label: "e2e test:desktop [$DEPLOYMENT_ENVIRONMENT]"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-  command:
-    docker run --rm \
-      --env PLAYWRIGHT_BASE_URL=https://www-stage.wellcomecollection.org \
-      130871440101.dkr.ecr.eu-west-1.amazonaws.com/weco/playwright:latest \
-      yarn test
-  retry:
-    automatic: true
+  - label: "e2e test:desktop [$DEPLOYMENT_ENVIRONMENT]"
+    plugins:
+      - docker-compose#v3.5.0:
+          run: e2e
+          env:
+            - PLAYWRIGHT_BASE_URL=$PLAYWRIGHT_BASE_URL
+            - USE_STAGE_APIS=$USE_STAGE_APIS
+          command: ["yarn", "test"]
+    retry:
+      automatic: true
 
-- label: "e2e test:mobile [$DEPLOYMENT_ENVIRONMENT]"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-  command:
-    docker run --rm \
-      --env PLAYWRIGHT_BASE_URL=https://www-stage.wellcomecollection.org \
-      130871440101.dkr.ecr.eu-west-1.amazonaws.com/weco/playwright:latest \
-      yarn test:mobile
-  retry:
-    automatic: true
+  - label: "e2e test:mobile [$DEPLOYMENT_ENVIRONMENT]"
+    plugins:
+      - docker-compose#v3.5.0:
+          run: e2e
+          env:
+            - PLAYWRIGHT_BASE_URL=$PLAYWRIGHT_BASE_URL
+            - USE_STAGE_APIS=$USE_STAGE_APIS
+          command: ["yarn", "test:mobile"]
+    retry:
+      automatic: true
 #
 #
 # - label: ":docker: build common"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -18,7 +18,7 @@ steps:
       - docker-compose#v3.5.0:
           run: e2e
           env:
-            - PLAYWRIGHT_BASE_URL=https://www-stage.wellcomecollection.org/
+            - PLAYWRIGHT_BASE_URL=https://www-stage.wellcomecollection.org
             - USE_STAGE_APIS=$USE_STAGE_APIS
           command: ["yarn", "test"]
     retry:
@@ -33,7 +33,7 @@ steps:
       - docker-compose#v3.5.0:
           run: e2e
           env:
-            - PLAYWRIGHT_BASE_URL=https://www-stage.wellcomecollection.org/
+            - PLAYWRIGHT_BASE_URL=https://www-stage.wellcomecollection.org
             - USE_STAGE_APIS=$USE_STAGE_APIS
           command: ["yarn", "test:mobile"]
     retry:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,17 @@
   - label: "build e2e test image"
+    plugins:
+      - wellcomecollection/aws-assume-role#v0.2.2:
+          role: "arn:aws:iam::130871440101:role/experience-ci"
+      - ecr#v2.1.1:
+          login: true
     command: ./playwright/get_playwright_image.sh
 
   - label: "e2e test:desktop [$DEPLOYMENT_ENVIRONMENT]"
+    plugins:
+      - wellcomecollection/aws-assume-role#v0.2.2:
+          role: "arn:aws:iam::130871440101:role/experience-ci"
+      - ecr#v2.1.1:
+          login: true
     command:
       docker run --rm \
         --env PLAYWRIGHT_BASE_URL=$PLAYWRIGHT_BASE_URL \
@@ -12,6 +22,11 @@
       automatic: true
 
   - label: "e2e test:mobile [$DEPLOYMENT_ENVIRONMENT]"
+    plugins:
+      - wellcomecollection/aws-assume-role#v0.2.2:
+          role: "arn:aws:iam::130871440101:role/experience-ci"
+      - ecr#v2.1.1:
+          login: true
     command:
       docker run --rm \
         --env PLAYWRIGHT_BASE_URL=$PLAYWRIGHT_BASE_URL \

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,187 +1,235 @@
-steps:
-  - label: "build e2e test image"
-    command: ./playwright/get_playwright_image.sh
-    plugins:
-      - wellcomecollection/aws-assume-role#v0.2.2:
-          role: "arn:aws:iam::130871440101:role/experience-ci"
-      - ecr#v2.1.1:
-          login: true
+- label: ":docker: build common"
+  key: "build_common"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        build:
+          - common
+        image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
 
-  - wait
+# Note: we have two variants of the "build cardigan" CI step.
+#
+# In pull requests, we don't need to publish the image to ECR, because
+# there is no later "test cardigan" step that would use the published image.
+# This saves ~1m from the Cardigan build, which is one of the longest
+# in PR builds.
+#
+# In main builds, we do need to publish the image to ECR, because it's
+# used again later in the "deploy Cardigan" step.
+#
+- label: ":docker: build cardigan"
+  key: "build_cardigan_main"
+  if: build.branch == "main"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        build:
+          - cardigan
+        image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
+- label: ":docker: build cardigan"
+  key: "build_cardigan_pr"
+  if: build.branch != "main"
+  command: docker-compose build cardigan
 
-  - label: "e2e test:desktop [$DEPLOYMENT_ENVIRONMENT]"
-    plugins:
-      - wellcomecollection/aws-assume-role#v0.2.2:
-          role: "arn:aws:iam::130871440101:role/experience-ci"
-      - ecr#v2.1.1:
-          login: true
-      - docker-compose#v3.5.0:
-          run: e2e
-          env:
-            - PLAYWRIGHT_BASE_URL=https://www-stage.wellcomecollection.org
-            - USE_STAGE_APIS=$USE_STAGE_APIS
-          command: ["yarn", "test"]
-    retry:
-      automatic: true
+- label: ":docker: build catalogue"
+  key: "build_catalogue"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        build:
+          - catalogue
+        image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
 
-  - label: "e2e test:mobile [$DEPLOYMENT_ENVIRONMENT]"
-    plugins:
-      - wellcomecollection/aws-assume-role#v0.2.2:
-          role: "arn:aws:iam::130871440101:role/experience-ci"
-      - ecr#v2.1.1:
-          login: true
-      - docker-compose#v3.5.0:
-          run: e2e
-          env:
-            - PLAYWRIGHT_BASE_URL=https://www-stage.wellcomecollection.org
-            - USE_STAGE_APIS=$USE_STAGE_APIS
-          command: ["yarn", "test:mobile"]
-    retry:
-      automatic: true
-#
-#
-# - label: ":docker: build common"
-#   key: "build_common"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         build:
-#           - common
-#         image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
-#
-# # Note: we have two variants of the "build cardigan" CI step.
-# #
-# # In pull requests, we don't need to publish the image to ECR, because
-# # there is no later "test cardigan" step that would use the published image.
-# # This saves ~1m from the Cardigan build, which is one of the longest
-# # in PR builds.
-# #
-# # In main builds, we do need to publish the image to ECR, because it's
-# # used again later in the "deploy Cardigan" step.
-# #
-# - label: ":docker: build cardigan"
-#   key: "build_cardigan_main"
-#   if: build.branch == "main"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         build:
-#           - cardigan
-#         image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
-# - label: ":docker: build cardigan"
-#   key: "build_cardigan_pr"
-#   if: build.branch != "main"
-#   command: docker-compose build cardigan
-#
-# - label: ":docker: build catalogue"
-#   key: "build_catalogue"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         build:
-#           - catalogue
-#         image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
-#
-# - label: ":docker: build content"
-#   key: "build_content"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         build:
-#           - content
-#         image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
-#
-# - label: ":docker: build edge_lambdas"
-#   key: "build_edge_lambdas"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         build:
-#           - edge_lambdas
-#         image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
-#
-# - label: ":docker: build identity"
-#   key: "build_identity"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         build:
-#           - identity
-#         image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
-#
-# - label: "diff prismic model"
+- label: ":docker: build content"
+  key: "build_content"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        build:
+          - content
+        image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
+
+- label: ":docker: build edge_lambdas"
+  key: "build_edge_lambdas"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        build:
+          - edge_lambdas
+        image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
+
+- label: ":docker: build identity"
+  key: "build_identity"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        build:
+          - identity
+        image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
+
+- label: "diff prismic model"
+  branches: "main"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        run: prismic_model
+        env:
+          - CI
+        command: ["yarn", "diffCustomTypes"]
+
+- label: "test common"
+  depends_on: "build_common"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        run: common
+        command: ["yarn", "test"]
+
+- label: "test catalogue"
+  depends_on: "build_catalogue"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        run: catalogue
+        command: ["yarn", "test"]
+
+- label: "test content"
+  depends_on: "build_content"
+  # Some content tests fail because the mocks do not match reality.
+  # However,work is in train to get reality closer to the mocks.
+  # For this reason, it is inappropriate to fix either right now.
+  # Instead, allow a failure in this step to be reported, but not
+  # block the build.
+  # Remove this *as soon* as the step starts passing again.
+  soft_fail: true
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        run: content
+        command: ["yarn", "test"]
+
+- label: "test identity"
+  depends_on: "build_identity"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        run: identity
+        command: ["yarn", "test"]
+
+- label: "test edge_lambdas"
+  depends_on: "build_edge_lambdas"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        run: edge_lambdas
+        command: ["yarn", "test"]
+
+- wait
+
+- label: "deploy catalogue (ecr image)"
+  branches: "main"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        push:
+          - catalogue:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/catalogue_webapp:ref.${BUILDKITE_COMMIT}
+          - catalogue:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/catalogue_webapp:latest
+
+- label: "deploy catalogue (bundle analysis)"
+  branches: "main"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        run: catalogue
+        command: [ "yarn", "deployBundleAnalysis" ]
+        env:
+          - AWS_ACCESS_KEY_ID
+          - AWS_SECRET_ACCESS_KEY
+          - AWS_SESSION_TOKEN
+
+- label: "deploy content (ecr image)"
+  branches: "main"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        push:
+          - content:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/content_webapp:ref.${BUILDKITE_COMMIT}
+          - content:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/content_webapp:latest
+
+- label: "deploy content (bundle analysis)"
+  branches: "main"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        run: content
+        command: [ "yarn", "deployBundleAnalysis" ]
+        env:
+          - AWS_ACCESS_KEY_ID
+          - AWS_SECRET_ACCESS_KEY
+          - AWS_SESSION_TOKEN
+
+- label: "deploy identity (ecr image)"
+  branches: "main"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        push:
+          - identity:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/identity_webapp:ref.${BUILDKITE_COMMIT}
+          - identity:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/identity_webapp:latest
+
+# - label: "deploy identity (bundle analysis)"
 #   branches: "main"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         run: prismic_model
-#         env:
-#           - CI
-#         command: ["yarn", "diffCustomTypes"]
-#
-# - label: "test common"
-#   depends_on: "build_common"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         run: common
-#         command: ["yarn", "test"]
-#
-# - label: "test catalogue"
-#   depends_on: "build_catalogue"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         run: catalogue
-#         command: ["yarn", "test"]
-#
-# - label: "test content"
-#   depends_on: "build_content"
-#   # Some content tests fail because the mocks do not match reality.
-#   # However,work is in train to get reality closer to the mocks.
-#   # For this reason, it is inappropriate to fix either right now.
-#   # Instead, allow a failure in this step to be reported, but not
-#   # block the build.
-#   # Remove this *as soon* as the step starts passing again.
-#   soft_fail: true
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         run: content
-#         command: ["yarn", "test"]
-#
-# - label: "test identity"
-#   depends_on: "build_identity"
 #   plugins:
 #     - wellcomecollection/aws-assume-role#v0.2.2:
 #         role: "arn:aws:iam::130871440101:role/experience-ci"
@@ -189,208 +237,118 @@ steps:
 #         login: true
 #     - docker-compose#v3.5.0:
 #         run: identity
-#         command: ["yarn", "test"]
-#
-# - label: "test edge_lambdas"
-#   depends_on: "build_edge_lambdas"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         run: edge_lambdas
-#         command: ["yarn", "test"]
-#
-# - wait
-#
-# - label: "deploy catalogue (ecr image)"
-#   branches: "main"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         push:
-#           - catalogue:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/catalogue_webapp:ref.${BUILDKITE_COMMIT}
-#           - catalogue:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/catalogue_webapp:latest
-#
-# - label: "deploy catalogue (bundle analysis)"
-#   branches: "main"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         run: catalogue
 #         command: [ "yarn", "deployBundleAnalysis" ]
 #         env:
 #           - AWS_ACCESS_KEY_ID
 #           - AWS_SECRET_ACCESS_KEY
 #           - AWS_SESSION_TOKEN
-#
-# - label: "deploy content (ecr image)"
-#   branches: "main"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         push:
-#           - content:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/content_webapp:ref.${BUILDKITE_COMMIT}
-#           - content:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/content_webapp:latest
-#
-# - label: "deploy content (bundle analysis)"
-#   branches: "main"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         run: content
-#         command: [ "yarn", "deployBundleAnalysis" ]
-#         env:
-#           - AWS_ACCESS_KEY_ID
-#           - AWS_SECRET_ACCESS_KEY
-#           - AWS_SESSION_TOKEN
-#
-# - label: "deploy identity (ecr image)"
-#   branches: "main"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         push:
-#           - identity:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/identity_webapp:ref.${BUILDKITE_COMMIT}
-#           - identity:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/identity_webapp:latest
-#
-# # - label: "deploy identity (bundle analysis)"
-# #   branches: "main"
-# #   plugins:
-# #     - wellcomecollection/aws-assume-role#v0.2.2:
-# #         role: "arn:aws:iam::130871440101:role/experience-ci"
-# #     - ecr#v2.1.1:
-# #         login: true
-# #     - docker-compose#v3.5.0:
-# #         run: identity
-# #         command: [ "yarn", "deployBundleAnalysis" ]
-# #         env:
-# #           - AWS_ACCESS_KEY_ID
-# #           - AWS_SECRET_ACCESS_KEY
-# #           - AWS_SESSION_TOKEN
-#
-# - label: "deploy dash"
-#   branches: "main"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         run: dash
-#         command: [ "yarn", "deploy" ]
-#         env:
-#           - AWS_ACCESS_KEY_ID
-#           - AWS_SECRET_ACCESS_KEY
-#           - AWS_SESSION_TOKEN
-#
-# - label: "deploy cardigan"
-#   branches: "main"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         run: cardigan
-#         command: [ "yarn", "deploy" ]
-#         env:
-#           - AWS_ACCESS_KEY_ID
-#           - AWS_SECRET_ACCESS_KEY
-#           - AWS_SESSION_TOKEN
-#
-# - label: "deploy toggles"
-#   branches: "main"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         run: toggles
-#         command: [ "yarn", "deploy" ]
-#         env:
-#           - AWS_ACCESS_KEY_ID
-#           - AWS_SECRET_ACCESS_KEY
-#           - AWS_SESSION_TOKEN
-#           - CI
-#
-# - label: "deploy pa11y"
-#   branches: "main"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         run: pa11y
-#         command: [ "yarn", "deploy" ]
-#         env:
-#           - AWS_ACCESS_KEY_ID
-#           - AWS_SECRET_ACCESS_KEY
-#           - AWS_SESSION_TOKEN
-#
-# - label: "deploy edge_lambdas"
-#   branches: "main"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         run: edge_lambdas
-#         command: [ "yarn", "deploy" ]
-#         env:
-#           - AWS_ACCESS_KEY_ID
-#           - AWS_SECRET_ACCESS_KEY
-#           - AWS_SESSION_TOKEN
-#
-# - label: "deploy updown"
-#   branches: "main"
-#   skip: "To avoid overriding manual work that is occuring"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         run: updown
-#         command: [ "yarn", "checks" ]
-#         env:
-#           - AWS_ACCESS_KEY_ID
-#           - AWS_SECRET_ACCESS_KEY
-#           - AWS_SESSION_TOKEN
-#
-# - label: "deploy assets"
-#   branches: "main"
-#   commands: ./assets/deploy_assets.sh
-#   agents:
-#     queue: nano
-#
-# - wait
-#
-# - label: "Trigger stage deployment"
-#   branches: "main"
-#   plugins:
-#     - wellcomecollection/github-deployments#v0.2.4:
-#         assume_role: "arn:aws:iam::130871440101:role/experience-ci"
-#         environment: stage
-#         ref: "${BUILDKITE_COMMIT}"
-#   agents:
-#     queue: nano
+
+- label: "deploy dash"
+  branches: "main"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        run: dash
+        command: [ "yarn", "deploy" ]
+        env:
+          - AWS_ACCESS_KEY_ID
+          - AWS_SECRET_ACCESS_KEY
+          - AWS_SESSION_TOKEN
+
+- label: "deploy cardigan"
+  branches: "main"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        run: cardigan
+        command: [ "yarn", "deploy" ]
+        env:
+          - AWS_ACCESS_KEY_ID
+          - AWS_SECRET_ACCESS_KEY
+          - AWS_SESSION_TOKEN
+
+- label: "deploy toggles"
+  branches: "main"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        run: toggles
+        command: [ "yarn", "deploy" ]
+        env:
+          - AWS_ACCESS_KEY_ID
+          - AWS_SECRET_ACCESS_KEY
+          - AWS_SESSION_TOKEN
+          - CI
+
+- label: "deploy pa11y"
+  branches: "main"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        run: pa11y
+        command: [ "yarn", "deploy" ]
+        env:
+          - AWS_ACCESS_KEY_ID
+          - AWS_SECRET_ACCESS_KEY
+          - AWS_SESSION_TOKEN
+
+- label: "deploy edge_lambdas"
+  branches: "main"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        run: edge_lambdas
+        command: [ "yarn", "deploy" ]
+        env:
+          - AWS_ACCESS_KEY_ID
+          - AWS_SECRET_ACCESS_KEY
+          - AWS_SESSION_TOKEN
+
+- label: "deploy updown"
+  branches: "main"
+  skip: "To avoid overriding manual work that is occuring"
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        run: updown
+        command: [ "yarn", "checks" ]
+        env:
+          - AWS_ACCESS_KEY_ID
+          - AWS_SECRET_ACCESS_KEY
+          - AWS_SESSION_TOKEN
+
+- label: "deploy assets"
+  branches: "main"
+  commands: ./assets/deploy_assets.sh
+  agents:
+    queue: nano
+
+- wait
+
+- label: "Trigger stage deployment"
+  branches: "main"
+  plugins:
+    - wellcomecollection/github-deployments#v0.2.4:
+        assume_role: "arn:aws:iam::130871440101:role/experience-ci"
+        environment: stage
+        ref: "${BUILDKITE_COMMIT}"
+  agents:
+    queue: nano

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,8 @@ services:
   updown:
     build:
       context: ./updown
+  e2e:
+    image: "130871440101.dkr.ecr.eu-west-1.amazonaws.com/weco/playwright:latest"
   prismic_model:
     build:
       context: ./prismic-model

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,10 +39,6 @@ services:
   updown:
     build:
       context: ./updown
-  e2e:
-    build:
-      context: .
-      dockerfile: playwright/Dockerfile
   prismic_model:
     build:
       context: ./prismic-model

--- a/infrastructure/experience/ecr.tf
+++ b/infrastructure/experience/ecr.tf
@@ -62,3 +62,16 @@ resource "aws_ecr_lifecycle_policy" "identity_webapp" {
   repository = aws_ecr_repository.identity_webapp.name
   policy     = local.ecr_policy_only_keep_the_last_100_images
 }
+
+resource "aws_ecr_repository" "playwright" {
+  name = "weco/playwright"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "playwright" {
+  repository = aws_ecr_repository.playwright.name
+  policy     = local.ecr_policy_only_keep_the_last_100_images
+}

--- a/playwright/.dockerignore
+++ b/playwright/.dockerignore
@@ -1,0 +1,1 @@
+get_playwright_image.sh

--- a/playwright/Dockerfile
+++ b/playwright/Dockerfile
@@ -1,20 +1,6 @@
 FROM mcr.microsoft.com/playwright:bionic
 
-WORKDIR /usr/src/app/webapp
-
-ADD ./.flowconfig ./.flowconfig
-ADD ./package.json ./package.json
-ADD ./yarn.lock ./yarn.lock
-ADD ./common ./common
-ADD ./flow-typed ./flow-typed
-
-ADD ./toggles/webapp ./toggles/webapp
-
-RUN yarn setupCommon && \
-    yarn cache clean
-
-ADD ./playwright ./playwright
-
+ADD ./playwright /usr/src/app/webapp/playwright
 WORKDIR /usr/src/app/webapp/playwright
 
 RUN yarn install --production=true && \

--- a/playwright/get_playwright_image.sh
+++ b/playwright/get_playwright_image.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# The Docker image we use for Playwright testing is quite large and takes
+# a while to build (~3m), but doesn't change that much -- it's self-contained
+# and only needs to change when we add new tests.
+#
+# To save us building it every time we use it, this script caches built
+# images in an ECR repo.
+#
+# In particular, it pushes new Docker images with two tags:
+#
+#   - latest
+#   - the Git commit ref
+#
+# so downstream builds can just pull "weco/playwright:latest", and this
+# script makes sure that tag always reflects the latest copy of these tests.
+
+set -o errexit
+set -o nounset
+
+ROOT=$(git rev-parse --show-toplevel)
+
+ECR_REPO_PREFIX="130871440101.dkr.ecr.eu-west-1.amazonaws.com"
+
+# Get the last commit that modified the "playwright" folder
+LAST_PLAYWRIGHT_COMMIT=$(git log -n 1 --pretty=format:%H -- "$ROOT/playwright")
+
+# Log in to ECR
+eval $(aws ecr get-login --no-include-email)
+
+# This looks in the "weco/playwright" repo for an image tagged "latest",
+# and then it looks for an image tag "ref.abc…" and extracts the commit.
+#
+# This is the commit of the latest Playwright image.
+#
+# See the jq() manual for a detailed explanation of the syntax:
+# https://stedolan.github.io/jq/manual/#Basicfilters
+#
+# We get a JSON object from the 'describe-images' command like:
+#
+#     {
+#       "imageDetails": [
+#         {
+#           ...
+#           "imageTags": [
+#             "latest",
+#             "7dbca1eff7dc6444a25593ccd37f5f26f335d9dd",
+#           ],
+#         }
+#       ]
+#     }
+#
+# and we want to get that Git commit ID without
+
+LATEST_ECR_COMMIT=$(
+  aws ecr describe-images \
+    --repository-name=weco/playwright \
+    --image-ids='imageTag=latest' |
+  jq -r '
+    .imageDetails[0]
+      | .imageTags
+      | map(select(. | contains("latest") | not))
+      | .[0]'
+)
+
+if [[ "$LATEST_ECR_COMMIT" == "$LAST_PLAYWRIGHT_COMMIT" ]]
+then
+  echo "Latest image in ECR reflects what's in Git, nothing to do ($LAST_PLAYWRIGHT_COMMIT)"
+  exit 0
+else
+  echo "Latest image in ECR ($LATEST_ECR_COMMIT) isn't what's in Git ($LAST_PLAYWRIGHT_COMMIT), so pushing a new image"
+  set -o verbose
+  docker build --tag "weco/playwright:$LAST_PLAYWRIGHT_COMMIT" --file "$ROOT/playwright/Dockerfile" .
+
+  docker tag "weco/playwright:$LAST_PLAYWRIGHT_COMMIT" "$ECR_REPO_PREFIX/weco/playwright:$LAST_PLAYWRIGHT_COMMIT"
+  docker push "$ECR_REPO_PREFIX/weco/playwright:$LAST_PLAYWRIGHT_COMMIT"
+
+  docker tag "weco/playwright:$LAST_PLAYWRIGHT_COMMIT" "$ECR_REPO_PREFIX/weco/playwright:latest"
+  docker push "$ECR_REPO_PREFIX/weco/playwright:latest"
+fi

--- a/playwright/test/stories.test.ts
+++ b/playwright/test/stories.test.ts
@@ -1,7 +1,6 @@
 import { gotoWithoutCache } from './contexts';
 import { baseUrl } from './helpers/urls';
 import { makeDefaultToggleAndTestCookies } from './helpers/utils';
-import { featuredStoriesSeriesId } from '@weco/common/services/prismic/hardcoded-id';
 
 const domain = new URL(baseUrl).host;
 
@@ -19,9 +18,7 @@ describe('stories', () => {
   test('cards for the featured series are shown on /stories', async () => {
     await gotoWithoutCache(`${baseUrl}/stories`);
 
-    const heading = await page.waitForSelector(
-      `a[href="/series/${featuredStoriesSeriesId}"]`
-    );
+    const heading = await page.waitForSelector(`a[href ^= "/series"]`);
     const featuredSeriesTitle = await heading.textContent();
 
     await page.waitForSelector(`p >> text="Part of ${featuredSeriesTitle}"`);


### PR DESCRIPTION
For https://github.com/wellcomecollection/wellcomecollection.org/issues/7706

One of the impediments to deploying to prod is passing the staging end-to-end tests, which take 5–7 minutes, depending on what's already cached locally and how many times we have to retry. Of that, about 2 minutes is spent building a Docker image which almost never changes:

<img width="1143" alt="Screenshot 2022-02-24 at 11 16 06" src="https://user-images.githubusercontent.com/301220/155514174-b2997bdd-555d-4bad-8932-1ca22ed37fc2.png">

This PR steals an idea from elsewhere in the experience build: it creates an ECR repo for these images, and saves the image there based on the Git commit. The first deploy after you update the e2e tests should be slow, but subsequent deploys will be faster because they're pulling a prebuilt image from ECR. 🤞 

By my reckoning, this will shave **~2 minutes** off every deploy of the front end.