### PR TITLE
Create a TypeScript version of parseTimestamp

### DIFF
--- a/common/model/events.ts
+++ b/common/model/events.ts
@@ -9,7 +9,7 @@ import { Season } from './seasons';
 import { HTMLString } from '../services/prismic/types';
 import { Label } from './labels';
 
-type DateTimeRange = {
+export type DateTimeRange = {
   startDateTime: Date;
   endDateTime: Date;
 };

--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -1,5 +1,5 @@
 // @flow
-import { RichText, Date as PrismicDate } from 'prismic-dom';
+import { RichText } from 'prismic-dom';
 // $FlowFixMe (tsx)
 import { PrismicLink, HTMLString, PrismicFragment } from './types';
 import flattenDeep from 'lodash.flattendeep';
@@ -48,10 +48,6 @@ export function parseRichText(maybeContent: ?HTMLString) {
 export function parseTitle(title: HTMLString): string {
   // We always need a title - blunt validation, but validation none the less
   return asText(title) || '';
-}
-
-export function parseTimestamp(frag: PrismicFragment): Date {
-  return PrismicDate(frag);
 }
 
 export function parseBackgroundTexture(

--- a/content/webapp/services/prismic/transformers/books.ts
+++ b/content/webapp/services/prismic/transformers/books.ts
@@ -4,12 +4,12 @@ import {
   transformGenericFields,
   transformKeyTextField,
   transformRichTextFieldToString,
+  transformTimestamp,
 } from '.';
 import { isFilledLinkToWebField } from '../types';
 import {
   asHtml,
   parseSingleLevelGroup,
-  parseTimestamp,
 } from '@weco/common/services/prismic/parsers';
 import { transformSeason } from './seasons';
 import { transformPromoToCaptionedImage } from './images';
@@ -43,7 +43,7 @@ export function transformBook(document: BookPrismicDocument): Book {
         citation: review.citation && asHtml(review.citation),
       };
     }),
-    datePublished: data.datePublished && parseTimestamp(data.datePublished),
+    datePublished: data.datePublished ? transformTimestamp(data.datePublished) : undefined,
     cover: cover && cover.image,
     seasons,
     prismicDocument: document,

--- a/content/webapp/services/prismic/transformers/events.test.ts
+++ b/content/webapp/services/prismic/transformers/events.test.ts
@@ -1,7 +1,7 @@
 import { groupEventsBy } from '../../../services/prismic/events';
 import { getLastEndTime } from './events';
-import { parseTimestamp } from '@weco/common/services/prismic/parsers';
 import { data as uiEventData } from '../../../components/CardGrid/DailyTourPromo';
+import { transformTimestamp } from '.';
 
 const eventTimes = [
   {
@@ -88,6 +88,6 @@ it('groups events by daterange', () => {
 
 it('returns the last end time from the lastest date', () => {
   const lastEndTime = getLastEndTime(eventTimes);
-  const expectedEndTime = parseTimestamp('2020-02-18T19:00:00+0000');
+  const expectedEndTime = transformTimestamp('2020-02-18T19:00:00+0000');
   expect(lastEndTime).toStrictEqual(expectedEndTime);
 });

--- a/content/webapp/services/prismic/transformers/exhibitions.ts
+++ b/content/webapp/services/prismic/transformers/exhibitions.ts
@@ -20,12 +20,11 @@ import {
   asText,
   isEmptyHtmlString,
   parseSingleLevelGroup,
-  parseTimestamp,
   parseTitle,
 } from '@weco/common/services/prismic/parsers';
 import { link } from './vendored-helpers';
 import { parseResourceTypeList } from '@weco/common/services/prismic/exhibitions';
-import { transformGenericFields } from '.';
+import { transformGenericFields, transformTimestamp } from '.';
 import { transformSeason } from './seasons';
 import { transformPlace } from './places';
 import { transformImagePromo, transformPromoToCaptionedImage } from './images';
@@ -77,8 +76,8 @@ export function transformExhibition(
 
   const url = `/exhibitions/${id}`;
   const title = parseTitle(data.title);
-  const start = parseTimestamp(data.start);
-  const end = data.end && parseTimestamp(data.end);
+  const start = transformTimestamp(data.start)!;
+  const end = data.end ? transformTimestamp(data.end) : undefined;
   const statusOverride = asText(data.statusOverride);
   const bslInfo = isEmptyHtmlString(data.bslInfo)
     ? undefined

--- a/content/webapp/services/prismic/transformers/guides.ts
+++ b/content/webapp/services/prismic/transformers/guides.ts
@@ -7,9 +7,8 @@ import {
 import {
   parseFormat,
   parseOnThisPage,
-  parseTimestamp,
 } from '@weco/common/services/prismic/parsers';
-import { transformGenericFields } from '.';
+import { transformGenericFields, transformTimestamp } from '.';
 import { links as headerLinks } from '@weco/common/views/components/Header/Header';
 
 export function transformGuide(document: GuidePrismicDocument): Guide {
@@ -29,7 +28,7 @@ export function transformGuide(document: GuidePrismicDocument): Guide {
     onThisPage: data.body ? parseOnThisPage(data.body) : [],
     showOnThisPage: data.showOnThisPage || false,
     promo: promo && promo.image ? promo : undefined,
-    datePublished: data.datePublished && parseTimestamp(data.datePublished),
+    datePublished: data.datePublished ? transformTimestamp(data.datePublished) : undefined,
     siteSection: siteSection,
     prismicDocument: document,
   };

--- a/content/webapp/services/prismic/transformers/index.ts
+++ b/content/webapp/services/prismic/transformers/index.ts
@@ -1,5 +1,5 @@
 import * as prismicH from 'prismic-helpers-beta';
-import { PrismicDocument, KeyTextField, RichTextField } from '@prismicio/types';
+import { PrismicDocument, KeyTextField, RichTextField, TimestampField } from '@prismicio/types';
 import { Label } from '@weco/common/model/labels';
 import { WithSeries } from '../types/articles';
 import linkResolver from '../link-resolver';
@@ -120,6 +120,10 @@ export function transformFormat(document: PrismicDocument<WithArticleFormat>) {
 // This is to avoid introducing nulls into our codebase
 export function transformKeyTextField(field: KeyTextField) {
   return field ?? undefined;
+}
+
+export function transformTimestamp(field: TimestampField): Date | undefined {
+  return prismicH.asDate(field) || undefined;
 }
 
 // Prismic often returns empty RichText fields as `[]`, this filters them out

--- a/content/webapp/services/prismic/transformers/pages.ts
+++ b/content/webapp/services/prismic/transformers/pages.ts
@@ -5,10 +5,9 @@ import {
   parseFormat,
   parseOnThisPage,
   parseSingleLevelGroup,
-  parseTimestamp,
 } from '@weco/common/services/prismic/parsers';
 import { links as headerLinks } from '@weco/common/views/components/Header/Header';
-import { transformGenericFields } from '.';
+import { transformGenericFields, transformTimestamp } from '.';
 import { transformSeason } from './seasons';
 
 export function transformPage(document: PagePrismicDocument): Page {
@@ -41,7 +40,7 @@ export function transformPage(document: PagePrismicDocument): Page {
     onThisPage: data.body ? parseOnThisPage(data.body) : [],
     showOnThisPage: data.showOnThisPage || false,
     promo: promo && promo.image ? promo : undefined,
-    datePublished: data.datePublished && parseTimestamp(data.datePublished),
+    datePublished: data.datePublished ? transformTimestamp(data.datePublished) : undefined,
     siteSection: siteSection,
     prismicDocument: document,
   };

--- a/content/webapp/services/prismic/transformers/seasons.ts
+++ b/content/webapp/services/prismic/transformers/seasons.ts
@@ -1,14 +1,13 @@
-import { transformGenericFields } from '.';
+import { transformGenericFields, transformTimestamp } from '.';
 import { Season } from '../../../types/seasons';
 import { SeasonPrismicDocument } from '../types/seasons';
-import { parseTimestamp } from '@weco/common/services/prismic/parsers';
 
 export function transformSeason(document: SeasonPrismicDocument): Season {
   const { data } = document;
   const genericFields = transformGenericFields(document);
   const promo = genericFields.promo;
-  const start = parseTimestamp(data.start);
-  const end = data.end && parseTimestamp(data.end);
+  const start = transformTimestamp(data.start)!;
+  const end = data.end ? transformTimestamp(data.end) : undefined;
   return {
     type: 'seasons',
     start,

--- a/content/webapp/services/prismic/transformers/seasons.ts
+++ b/content/webapp/services/prismic/transformers/seasons.ts
@@ -6,12 +6,10 @@ export function transformSeason(document: SeasonPrismicDocument): Season {
   const { data } = document;
   const genericFields = transformGenericFields(document);
   const promo = genericFields.promo;
-  const start = transformTimestamp(data.start)!;
-  const end = data.end ? transformTimestamp(data.end) : undefined;
   return {
     type: 'seasons',
-    start,
-    end,
+    start: transformTimestamp(data.start),
+    end: transformTimestamp(data.end),
     ...genericFields,
     labels: [{ text: 'Season' }],
     promo: promo && promo.image && promo,

--- a/content/webapp/services/prismic/transformers/series.ts
+++ b/content/webapp/services/prismic/transformers/series.ts
@@ -1,10 +1,9 @@
 import { Series } from '../../../types/series';
 import { SeriesPrismicDocument } from '../types/series';
-import { isStructuredText, transformGenericFields } from '.';
+import { isStructuredText, transformGenericFields, transformTimestamp } from '.';
 import {
   asText,
   parseSingleLevelGroup,
-  parseTimestamp,
 } from '@weco/common/services/prismic/parsers';
 import { london } from '@weco/common/utils/format-date';
 import { transformSeason } from './seasons';
@@ -23,7 +22,7 @@ export function transformSeries(document: SeriesPrismicDocument): Series {
             type: 'article-schedule-items',
             id: `${document.id}_${i}`,
             title: asText(item.title),
-            publishDate: london(parseTimestamp(item.publishDate)).toDate(),
+            publishDate: london(transformTimestamp(item.publishDate)).toDate(),
             partNumber: i + 1,
             color,
           };


### PR DESCRIPTION
For #7363.

Hopefully this is quite a mild change; mostly what this does is force us to be a bit stricter/more explicit about `null` and `undefined`. In particular, the old `parseTimestamp` method could return `null` in some circumstances, but we weren't really checking it properly – now we have to handle it properly.