### PR TITLE
Create a TypeScript version of parseLink

### DIFF
--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -1,7 +1,7 @@
 // @flow
 import { RichText } from 'prismic-dom';
 // $FlowFixMe (tsx)
-import { PrismicLink, HTMLString, PrismicFragment } from './types';
+import { HTMLString, PrismicFragment } from './types';
 import flattenDeep from 'lodash.flattendeep';
 import type { Format } from '../../model/format';
 import type { Link } from '../../model/link';
@@ -74,16 +74,6 @@ export function parseFormat(frag: Object): ?Format {
         description: asHtml(frag.data.description),
       }
     : null;
-}
-
-export function parseLink(link?: PrismicLink): ?string {
-  if (link) {
-    if (link.link_type === 'Web' || link.link_type === 'Media') {
-      return link.url;
-    } else if (link.link_type === 'Document' && isDocumentLink(link)) {
-      return linkResolver(link);
-    }
-  }
 }
 
 // If a link is non-existant, it can either be returned as `null`, or as an

--- a/common/services/prismic/types.ts
+++ b/common/services/prismic/types.ts
@@ -17,12 +17,6 @@ export type PrismicDocument = {
   url?: string;
 };
 
-export type PrismicLink = {
-  link_type: 'Web' | 'Document' | 'Media';
-  url?: string;
-  id?: string;
-};
-
 export type HTMLSpanTypes =
   | 'heading2'
   | 'heading3'

--- a/common/views/components/InfoBlock/InfoBlock.tsx
+++ b/common/views/components/InfoBlock/InfoBlock.tsx
@@ -1,8 +1,7 @@
 import Space from '@weco/common/views/components/styled/Space';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
-import { HTMLString, PrismicLink } from '../../../services/prismic/types';
+import { HTMLString } from '../../../services/prismic/types';
 import ButtonOutlinedLink from '@weco/common/views/components/ButtonOutlinedLink/ButtonOutlinedLink';
-import { parseLink } from '@weco/common/services/prismic/parsers';
 import { dasherize } from '@weco/common/utils/grammar';
 import { FunctionComponent, ReactElement } from 'react';
 import styled from 'styled-components';
@@ -17,7 +16,7 @@ type Props = {
   title: string;
   text: HTMLString;
   linkText: string | null;
-  link: PrismicLink | null;
+  link: string | undefined;
 };
 
 const InfoBlock: FunctionComponent<Props> = ({
@@ -26,8 +25,6 @@ const InfoBlock: FunctionComponent<Props> = ({
   linkText,
   link,
 }: Props): ReactElement<Props> => {
-  const parsedLink = parseLink(link);
-
   return (
     <Wrapper>
       <h2 id={dasherize(title)} className="h2">
@@ -36,9 +33,9 @@ const InfoBlock: FunctionComponent<Props> = ({
       <div className="spaced-text body-text">
         <PrismicHtmlBlock html={text} />
       </div>
-      {parsedLink && linkText && (
+      {link && linkText && (
         <Space v={{ size: 'l', properties: ['margin-top'] }}>
-          <ButtonOutlinedLink link={parsedLink} text={linkText} />
+          <ButtonOutlinedLink link={link} text={linkText} />
         </Space>
       )}
     </Wrapper>

--- a/common/views/components/InfoBlock/InfoBlock.tsx
+++ b/common/views/components/InfoBlock/InfoBlock.tsx
@@ -16,7 +16,7 @@ type Props = {
   title: string;
   text: HTMLString;
   linkText: string | null;
-  link: string | undefined;
+  link?: string;
 };
 
 const InfoBlock: FunctionComponent<Props> = ({

--- a/common/views/components/PopupDialog/PopupDialog.tsx
+++ b/common/views/components/PopupDialog/PopupDialog.tsx
@@ -16,7 +16,6 @@ import { trackEvent } from '../../../utils/ga';
 import { AppContext } from '../AppContext/AppContext';
 import { PopupDialogPrismicDocument } from '../../../services/prismic/documents';
 import PrismicHtmlBlock from '../PrismicHtmlBlock/PrismicHtmlBlock';
-import { parseLink } from '@weco/common/services/prismic/parsers';
 import { chat, clear } from '@weco/common/icons';
 import { HTMLString } from '../../../services/prismic/types';
 
@@ -345,7 +344,7 @@ const PopupDialog: FunctionComponent<Props> = ({ document }: Props) => {
           </div>
         </Space>
         <PopupDialogCTA
-          href={parseLink(link)}
+          href={link || undefined}
           ref={ctaRef}
           tabIndex={isActive ? 0 : -1}
           onKeyDown={handleTrapEndKeyDown}

--- a/content/webapp/services/prismic/transformers/body.ts
+++ b/content/webapp/services/prismic/transformers/body.ts
@@ -19,7 +19,6 @@ import { Props as DiscussionProps } from '@weco/common/views/components/Discussi
 import { MediaObjectType } from '@weco/common/model/media-object';
 import {
   parseLabelType,
-  parseLink,
   parseTitle,
   asText,
 } from '@weco/common/services/prismic/parsers';
@@ -31,7 +30,7 @@ import {
 import { TeamPrismicDocument } from '../types/teams';
 import { transformCaptionedImage, transformImage } from './images';
 import { CaptionedImage } from '@weco/common/model/captioned-image';
-import { transformRichTextField, transformStructuredText, transformTaslFromString } from '.';
+import { transformLink, transformRichTextField, transformStructuredText, transformTaslFromString } from '.';
 import { LinkField, RelationField, RichTextField } from '@prismicio/types';
 
 export type Weight = 'default' | 'featured' | 'standalone' | 'supporting';
@@ -224,7 +223,7 @@ function transformTitledTextItem({
   return {
     title: parseTitle(title),
     text: transformStructuredText(text),
-    link: parseLink(link),
+    link: transformLink(link),
     label: isFilledLinkToDocumentWithData(label) ? parseLabelType(label) : null,
   };
 }

--- a/content/webapp/services/prismic/transformers/card.ts
+++ b/content/webapp/services/prismic/transformers/card.ts
@@ -3,10 +3,10 @@ import {
   parseTitle,
   parseFormat,
   asText,
-  parseLink,
 } from '@weco/common/services/prismic/parsers';
 import { transformImage } from './images';
 import { Card } from '@weco/common/model/card';
+import { transformLink } from '.';
 
 export function transformCard(document: CardPrismicDocument): Card {
   const { title, format, description, image, link } = document.data;
@@ -17,6 +17,6 @@ export function transformCard(document: CardPrismicDocument): Card {
     format: parseFormat(format),
     description: asText(description),
     image: transformImage(image),
-    link: parseLink(link),
+    link: transformLink(link),
   };
 }


### PR DESCRIPTION
I'm also trying to get some of the Prismic document models out of the components, and only use transformed types there -- so a few of the links are now being parsed before being passed to the components, not after.

For #7363.