### PR TITLE
Convert a few more parser methods to TypeScript

### DIFF
--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -12,23 +12,18 @@ import type {
 import type { LabelField } from '../../model/label-field';
 import { dasherize } from '../../utils/grammar';
 import linkResolver from './link-resolver';
-import type { HTMLSerializer } from 'prismic-reactjs';
-import type { Element } from 'react';
 
 export function asText(maybeContent: ?HTMLString): ?string {
   return maybeContent && RichText.asText(maybeContent).trim();
 }
 
-export function asHtml(
-  maybeContent: ?HTMLString,
-  htmlSerializer?: HTMLSerializer<Element<any>>
-) {
+export function asHtml(maybeContent: ?HTMLString) {
   // Prismic can send us empty html elements which can lead to unwanted UI in templates.
   // Check that `asText` wouldn't return an empty string.
   const isEmpty = !maybeContent || (asText(maybeContent) || '').trim() === '';
   return isEmpty
     ? null
-    : RichText.asHtml(maybeContent, linkResolver, htmlSerializer).trim();
+    : RichText.asHtml(maybeContent, linkResolver).trim();
 }
 
 export function parseTitle(title: HTMLString): string {

--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -3,7 +3,6 @@ import { RichText } from 'prismic-dom';
 // $FlowFixMe (tsx)
 import { HTMLString, PrismicFragment } from './types';
 import flattenDeep from 'lodash.flattendeep';
-import type { Format } from '../../model/format';
 import type { Link } from '../../model/link';
 import type {
   BackgroundTexture,
@@ -11,7 +10,6 @@ import type {
 } from '../../model/background-texture';
 import type { LabelField } from '../../model/label-field';
 import { dasherize } from '../../utils/grammar';
-import linkResolver from './link-resolver';
 
 export function asText(maybeContent: ?HTMLString): ?string {
   return maybeContent && RichText.asText(maybeContent).trim();

--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -17,15 +17,6 @@ export function asText(maybeContent: ?HTMLString): ?string {
   return maybeContent && RichText.asText(maybeContent).trim();
 }
 
-export function asHtml(maybeContent: ?HTMLString) {
-  // Prismic can send us empty html elements which can lead to unwanted UI in templates.
-  // Check that `asText` wouldn't return an empty string.
-  const isEmpty = !maybeContent || (asText(maybeContent) || '').trim() === '';
-  return isEmpty
-    ? null
-    : RichText.asHtml(maybeContent, linkResolver).trim();
-}
-
 export function parseTitle(title: HTMLString): string {
   // We always need a title - blunt validation, but validation none the less
   return asText(title) || '';
@@ -59,16 +50,6 @@ export function parseSingleLevelGroup(
       .map<PrismicFragment>(fragItem => fragItem[singlePropertyName])
   );
   /* eslint-enable */
-}
-
-export function parseFormat(frag: Object): ?Format {
-  return isDocumentLink(frag)
-    ? {
-        id: frag.id,
-        title: parseTitle(frag.data.title),
-        description: asHtml(frag.data.description),
-      }
-    : null;
 }
 
 // If a link is non-existant, it can either be returned as `null`, or as an

--- a/content/webapp/components/ArticleCard/ArticleCard.tsx
+++ b/content/webapp/components/ArticleCard/ArticleCard.tsx
@@ -51,7 +51,7 @@ const ArticleCard: FunctionComponent<Props> = ({
   const isPodcast = format?.id === ArticleFormatIds.Podcast;
 
   const labels = [
-    format?.data.title ? prismicH.asText(format.data.title) : undefined,
+    format?.title,
     isSerial ? 'Serial' : undefined,
   ]
     .filter(isNotUndefined)

--- a/content/webapp/components/StoryPromo/StoryPromo.tsx
+++ b/content/webapp/components/StoryPromo/StoryPromo.tsx
@@ -59,7 +59,7 @@ const StoryPromo: FunctionComponent<Props> = ({
   const isSerial = Boolean(seriesWithSchedule);
 
   const labels = [
-    format?.data.title ? prismicH.asText(format.data.title) : undefined,
+    format?.title,
     isSerial ? 'Serial' : undefined,
   ]
     .filter(isNotUndefined)

--- a/content/webapp/services/prismic/transformers/body.ts
+++ b/content/webapp/services/prismic/transformers/body.ts
@@ -30,7 +30,7 @@ import {
 import { TeamPrismicDocument } from '../types/teams';
 import { transformCaptionedImage, transformImage } from './images';
 import { CaptionedImage } from '@weco/common/model/captioned-image';
-import { transformLink, transformRichTextField, transformStructuredText, transformTaslFromString } from '.';
+import { transformLink, asHtmlString, transformStructuredText, transformTaslFromString } from '.';
 import { LinkField, RelationField, RichTextField } from '@prismicio/types';
 
 export type Weight = 'default' | 'featured' | 'standalone' | 'supporting';
@@ -192,7 +192,7 @@ export function transformGifVideoSlice(
         type: 'gifVideo',
         weight: getWeight(slice.slice_label),
         value: {
-          caption: transformRichTextField(slice.primary.caption),
+          caption: asHtmlString(slice.primary.caption),
           videoUrl: slice.primary.video.url,
           playbackRate,
           tasl: transformTaslFromString(slice.primary.tasl),

--- a/content/webapp/services/prismic/transformers/body.ts
+++ b/content/webapp/services/prismic/transformers/body.ts
@@ -30,7 +30,7 @@ import {
 import { TeamPrismicDocument } from '../types/teams';
 import { transformCaptionedImage, transformImage } from './images';
 import { CaptionedImage } from '@weco/common/model/captioned-image';
-import { transformLink, asHtmlString, transformStructuredText, transformTaslFromString } from '.';
+import { transformLink, asRichText, transformStructuredText, transformTaslFromString } from '.';
 import { LinkField, RelationField, RichTextField } from '@prismicio/types';
 
 export type Weight = 'default' | 'featured' | 'standalone' | 'supporting';
@@ -192,7 +192,7 @@ export function transformGifVideoSlice(
         type: 'gifVideo',
         weight: getWeight(slice.slice_label),
         value: {
-          caption: asHtmlString(slice.primary.caption),
+          caption: asRichText(slice.primary.caption),
           videoUrl: slice.primary.video.url,
           playbackRate,
           tasl: transformTaslFromString(slice.primary.tasl),

--- a/content/webapp/services/prismic/transformers/books.ts
+++ b/content/webapp/services/prismic/transformers/books.ts
@@ -3,7 +3,7 @@ import { BookPrismicDocument } from '../types/books';
 import {
   transformGenericFields,
   transformKeyTextField,
-  transformRichTextField,
+  asHtmlString,
   transformRichTextFieldToString,
   transformTimestamp,
 } from '.';
@@ -37,8 +37,8 @@ export function transformBook(document: BookPrismicDocument): Book {
     isbn: transformKeyTextField(data.isbn),
     reviews: data.reviews?.map(review => {
       return {
-        text: review.text && transformRichTextField(review.text) || [],
-        citation: review.citation && transformRichTextField(review.citation) || [],
+        text: review.text && asHtmlString(review.text) || [],
+        citation: review.citation && asHtmlString(review.citation) || [],
       };
     }),
     datePublished: data.datePublished ? transformTimestamp(data.datePublished) : undefined,

--- a/content/webapp/services/prismic/transformers/books.ts
+++ b/content/webapp/services/prismic/transformers/books.ts
@@ -3,14 +3,12 @@ import { BookPrismicDocument } from '../types/books';
 import {
   transformGenericFields,
   transformKeyTextField,
+  transformRichTextField,
   transformRichTextFieldToString,
   transformTimestamp,
 } from '.';
 import { isFilledLinkToWebField } from '../types';
-import {
-  asHtml,
-  parseSingleLevelGroup,
-} from '@weco/common/services/prismic/parsers';
+import { parseSingleLevelGroup } from '@weco/common/services/prismic/parsers';
 import { transformSeason } from './seasons';
 import { transformPromoToCaptionedImage } from './images';
 
@@ -39,8 +37,8 @@ export function transformBook(document: BookPrismicDocument): Book {
     isbn: transformKeyTextField(data.isbn),
     reviews: data.reviews?.map(review => {
       return {
-        text: review.text && asHtml(review.text),
-        citation: review.citation && asHtml(review.citation),
+        text: review.text && transformRichTextField(review.text) || [],
+        citation: review.citation && transformRichTextField(review.citation) || [],
       };
     }),
     datePublished: data.datePublished ? transformTimestamp(data.datePublished) : undefined,

--- a/content/webapp/services/prismic/transformers/books.ts
+++ b/content/webapp/services/prismic/transformers/books.ts
@@ -3,7 +3,7 @@ import { BookPrismicDocument } from '../types/books';
 import {
   transformGenericFields,
   transformKeyTextField,
-  asHtmlString,
+  asRichText,
   transformRichTextFieldToString,
   transformTimestamp,
 } from '.';
@@ -37,8 +37,8 @@ export function transformBook(document: BookPrismicDocument): Book {
     isbn: transformKeyTextField(data.isbn),
     reviews: data.reviews?.map(review => {
       return {
-        text: review.text && asHtmlString(review.text) || [],
-        citation: review.citation && asHtmlString(review.citation) || [],
+        text: review.text && asRichText(review.text) || [],
+        citation: review.citation && asRichText(review.citation) || [],
       };
     }),
     datePublished: data.datePublished ? transformTimestamp(data.datePublished) : undefined,

--- a/content/webapp/services/prismic/transformers/card.ts
+++ b/content/webapp/services/prismic/transformers/card.ts
@@ -1,20 +1,19 @@
 import { CardPrismicDocument } from '../types/card';
 import {
   parseTitle,
-  parseFormat,
   asText,
 } from '@weco/common/services/prismic/parsers';
 import { transformImage } from './images';
 import { Card } from '@weco/common/model/card';
-import { transformLink } from '.';
+import { transformFormat, transformLink } from '.';
 
 export function transformCard(document: CardPrismicDocument): Card {
-  const { title, format, description, image, link } = document.data;
+  const { title, description, image, link } = document.data;
 
   return {
     type: 'card',
     title: parseTitle(title),
-    format: parseFormat(format),
+    format: transformFormat(document),
     description: asText(description),
     image: transformImage(image),
     link: transformLink(link),

--- a/content/webapp/services/prismic/transformers/contributors.ts
+++ b/content/webapp/services/prismic/transformers/contributors.ts
@@ -9,7 +9,7 @@ import { Contributor } from '../../../types/contributors';
 import { isNotUndefined, isString } from '@weco/common/utils/array';
 import {
   transformKeyTextField,
-  transformRichTextField,
+  asHtmlString,
   transformRichTextFieldToString,
 } from '.';
 
@@ -31,7 +31,7 @@ export function transformContributorAgent(
   if (isFilledLinkToDocumentWithData(agent)) {
     const commonFields = {
       id: agent.id,
-      description: transformRichTextField(agent.data.description),
+      description: asHtmlString(agent.data.description),
       image: agent.data.image || defaultContributorImage,
       sameAs: (agent.data.sameAs ?? [])
         .map(sameAs => {
@@ -87,7 +87,7 @@ export function transformContributors(
           }
         : undefined;
 
-      const description = transformRichTextField(contributor.description);
+      const description = asHtmlString(contributor.description);
 
       return agent
         ? {

--- a/content/webapp/services/prismic/transformers/contributors.ts
+++ b/content/webapp/services/prismic/transformers/contributors.ts
@@ -9,7 +9,7 @@ import { Contributor } from '../../../types/contributors';
 import { isNotUndefined, isString } from '@weco/common/utils/array';
 import {
   transformKeyTextField,
-  asHtmlString,
+  asRichText,
   transformRichTextFieldToString,
 } from '.';
 
@@ -31,7 +31,7 @@ export function transformContributorAgent(
   if (isFilledLinkToDocumentWithData(agent)) {
     const commonFields = {
       id: agent.id,
-      description: asHtmlString(agent.data.description),
+      description: asRichText(agent.data.description),
       image: agent.data.image || defaultContributorImage,
       sameAs: (agent.data.sameAs ?? [])
         .map(sameAs => {
@@ -87,7 +87,7 @@ export function transformContributors(
           }
         : undefined;
 
-      const description = asHtmlString(contributor.description);
+      const description = asRichText(contributor.description);
 
       return agent
         ? {

--- a/content/webapp/services/prismic/transformers/events.ts
+++ b/content/webapp/services/prismic/transformers/events.ts
@@ -17,13 +17,12 @@ import { isNotUndefined } from '@weco/common/utils/array';
 import { GroupField, Query, RelationField } from '@prismicio/types';
 import {
   asText,
-  parseFormat,
   parseLabelType,
   parseSingleLevelGroup,
   parseTitle,
 } from '@weco/common/services/prismic/parsers';
 import { isPast } from '@weco/common/utils/dates';
-import { transformGenericFields, transformTimestamp } from '.';
+import { transformFormat, transformGenericFields, transformTimestamp } from '.';
 import { HTMLString } from '@weco/common/services/prismic/types';
 import { transformSeason } from './seasons';
 import { transformEventSeries } from './event-series';
@@ -235,7 +234,7 @@ export function transformEvent(
         : undefined,
     bookingType: transformEventBookingType(document),
     cost: data.cost || undefined,
-    format: data.format && parseFormat(data.format),
+    format: transformFormat(document),
     interpretations,
     policies: Array.isArray(data.policies)
       ? transformEventPolicyLabels(data.policies, 'policy')

--- a/content/webapp/services/prismic/transformers/exhibitions.ts
+++ b/content/webapp/services/prismic/transformers/exhibitions.ts
@@ -13,13 +13,12 @@ import { transformQuery } from './paginated-results';
 import { london } from '@weco/common/utils/format-date';
 import { transformMultiContent } from './multi-content';
 import {
-  asHtml,
   asText,
   parseSingleLevelGroup,
   parseTitle,
 } from '@weco/common/services/prismic/parsers';
 import { link } from './vendored-helpers';
-import { transformGenericFields, transformRichTextField, transformTimestamp } from '.';
+import { asHtml, transformGenericFields, transformRichTextField, transformTimestamp } from '.';
 import { transformSeason } from './seasons';
 import { transformPlace } from './places';
 import { transformImagePromo, transformPromoToCaptionedImage } from './images';

--- a/content/webapp/services/prismic/transformers/exhibitions.ts
+++ b/content/webapp/services/prismic/transformers/exhibitions.ts
@@ -18,7 +18,7 @@ import {
   parseTitle,
 } from '@weco/common/services/prismic/parsers';
 import { link } from './vendored-helpers';
-import { asHtml, transformGenericFields, transformRichTextField, transformTimestamp } from '.';
+import { asHtml, asHtmlString, transformGenericFields, transformTimestamp } from '.';
 import { transformSeason } from './seasons';
 import { transformPlace } from './places';
 import { transformImagePromo, transformPromoToCaptionedImage } from './images';
@@ -99,8 +99,8 @@ export function transformExhibition(
   const start = transformTimestamp(data.start)!;
   const end = data.end ? transformTimestamp(data.end) : undefined;
   const statusOverride = asText(data.statusOverride);
-  const bslInfo = transformRichTextField(data.bslInfo);
-  const audioDescriptionInfo = transformRichTextField(data.audioDescriptionInfo);
+  const bslInfo = asHtmlString(data.bslInfo);
+  const audioDescriptionInfo = asHtmlString(data.audioDescriptionInfo);
 
   const promoCrop = '16:9';
   const promoImage =

--- a/content/webapp/services/prismic/transformers/exhibitions.ts
+++ b/content/webapp/services/prismic/transformers/exhibitions.ts
@@ -18,7 +18,7 @@ import {
   parseTitle,
 } from '@weco/common/services/prismic/parsers';
 import { link } from './vendored-helpers';
-import { asHtml, asHtmlString, transformGenericFields, transformTimestamp } from '.';
+import { asHtml, asRichText, transformGenericFields, transformTimestamp } from '.';
 import { transformSeason } from './seasons';
 import { transformPlace } from './places';
 import { transformImagePromo, transformPromoToCaptionedImage } from './images';
@@ -99,8 +99,8 @@ export function transformExhibition(
   const start = transformTimestamp(data.start)!;
   const end = data.end ? transformTimestamp(data.end) : undefined;
   const statusOverride = asText(data.statusOverride);
-  const bslInfo = asHtmlString(data.bslInfo);
-  const audioDescriptionInfo = asHtmlString(data.audioDescriptionInfo);
+  const bslInfo = asRichText(data.bslInfo);
+  const audioDescriptionInfo = asRichText(data.audioDescriptionInfo);
 
   const promoCrop = '16:9';
   const promoImage =

--- a/content/webapp/services/prismic/transformers/guides.ts
+++ b/content/webapp/services/prismic/transformers/guides.ts
@@ -5,10 +5,10 @@ import {
   GuideFormatPrismicDocument,
 } from '../types/guides';
 import {
-  parseFormat,
+  parseTitle,
   parseOnThisPage,
 } from '@weco/common/services/prismic/parsers';
-import { transformGenericFields, transformTimestamp } from '.';
+import { asHtml, transformFormat, transformGenericFields, transformTimestamp } from '.';
 import { links as headerLinks } from '@weco/common/views/components/Header/Header';
 
 export function transformGuide(document: GuidePrismicDocument): Guide {
@@ -23,7 +23,7 @@ export function transformGuide(document: GuidePrismicDocument): Guide {
   const promo = genericFields.promo;
   return {
     type: 'guides',
-    format: data.format && parseFormat(data.format),
+    format: transformFormat(document),
     ...genericFields,
     onThisPage: data.body ? parseOnThisPage(data.body) : [],
     showOnThisPage: data.showOnThisPage || false,
@@ -37,7 +37,11 @@ export function transformGuide(document: GuidePrismicDocument): Guide {
 export function transformGuideFormat(
   document: GuideFormatPrismicDocument
 ): GuideFormat {
-  const format: DeprecatedFormat = parseFormat(document);
+  const format: DeprecatedFormat = {
+    id: document.id,
+    title: parseTitle(document.data.title),
+    description: asHtml(document.data.description),
+  };
 
   return {
     ...format,

--- a/content/webapp/services/prismic/transformers/images.ts
+++ b/content/webapp/services/prismic/transformers/images.ts
@@ -9,7 +9,7 @@ import isEmptyObj from '@weco/common/utils/is-empty-object';
 import { ImageType } from '@weco/common/model/image';
 import { asText } from '@weco/common/services/prismic/parsers';
 import { ImagePromo } from '@weco/common/model/image-promo';
-import { transformRichTextField, transformTaslFromString } from '.';
+import { asHtmlString, transformTaslFromString } from '.';
 
 export const placeHolderImage: ImageType = {
   contentUrl: 'https://via.placeholder.com/1600x900?text=%20',
@@ -43,7 +43,7 @@ export function transformCaptionedImage(
   const image = crop ? frag.image[crop] : frag.image;
   return {
     image: transformImage(image) || placeHolderImage,
-    caption: transformRichTextField(frag.caption) || [],
+    caption: asHtmlString(frag.caption) || [],
   };
 }
 

--- a/content/webapp/services/prismic/transformers/images.ts
+++ b/content/webapp/services/prismic/transformers/images.ts
@@ -9,7 +9,7 @@ import isEmptyObj from '@weco/common/utils/is-empty-object';
 import { ImageType } from '@weco/common/model/image';
 import { asText } from '@weco/common/services/prismic/parsers';
 import { ImagePromo } from '@weco/common/model/image-promo';
-import { asHtmlString, transformTaslFromString } from '.';
+import { asRichText, transformTaslFromString } from '.';
 
 export const placeHolderImage: ImageType = {
   contentUrl: 'https://via.placeholder.com/1600x900?text=%20',
@@ -43,7 +43,7 @@ export function transformCaptionedImage(
   const image = crop ? frag.image[crop] : frag.image;
   return {
     image: transformImage(image) || placeHolderImage,
-    caption: asHtmlString(frag.caption) || [],
+    caption: asRichText(frag.caption) || [],
   };
 }
 

--- a/content/webapp/services/prismic/transformers/index.ts
+++ b/content/webapp/services/prismic/transformers/index.ts
@@ -32,9 +32,9 @@ import { transformEvent } from './events';
 import { transformSeason } from './seasons';
 import { transformCard } from './card';
 import { MultiContentPrismicDocument } from '../types/multi-content';
-import { GuidePrismicDocument } from '../types/guides';
+import { GuidePrismicDocument, WithGuideFormat } from '../types/guides';
 import { SeasonPrismicDocument } from '../types/seasons';
-import { CardPrismicDocument } from '../types/card';
+import { CardPrismicDocument, WithCardFormat } from '../types/card';
 import {
   getWeight,
   transformContactSlice,
@@ -49,9 +49,11 @@ import {
 } from './body';
 import { transformImage, transformImagePromo } from './images';
 import { Tasl } from '@weco/common/model/tasl';
-
 import { LicenseType, licenseTypeArray } from '@weco/common/model/license';
 import { HTMLString } from '@weco/common/services/prismic/types';
+import { WithPageFormat } from '../types/pages';
+import { WithEventFormat } from '../types/events';
+import { Format } from '@weco/common/model/format';
 
 type Meta = {
   title: string;
@@ -110,11 +112,15 @@ export function transformSeries(document: PrismicDocument<WithSeries>) {
     .filter(isFilledLinkToDocumentWithData);
 }
 
-export function transformFormat(document: PrismicDocument<WithArticleFormat>) {
+export function transformFormat(document: { data: WithArticleFormat | WithCardFormat | WithEventFormat | WithGuideFormat | WithPageFormat }) {
   const { format } = document.data;
 
   if (isFilledLinkToDocumentWithData(format) && format.data) {
-    return format;
+    return {
+      id: format.id,
+      title: parseTitle(format.data.title),
+      description: asHtml(format.data.description),
+    };
   }
 }
 

--- a/content/webapp/services/prismic/transformers/index.ts
+++ b/content/webapp/services/prismic/transformers/index.ts
@@ -134,6 +134,13 @@ export function transformRichTextField(
   return field && field.length > 0 ? (field as HTMLString) : undefined;
 }
 
+export function asHtml(field?: RichTextField): string | undefined {
+  // Prismic can send us empty html elements which can lead to unwanted UI in templates.
+  // Check that `asText` wouldn't return an empty string.
+  const isEmpty = !field || (asText(field) || '').trim() === '';
+  return isEmpty ? undefined : prismicH.asHTML(field).trim();
+}
+
 // Prismic return `[ { type: 'paragraph', text: '', spans: [] } ]` when you have
 // inserted text, then removed it, so we need to do this check.
 export function isStructuredText(field: RichTextField): boolean {

--- a/content/webapp/services/prismic/transformers/index.ts
+++ b/content/webapp/services/prismic/transformers/index.ts
@@ -128,9 +128,7 @@ export function transformTimestamp(field: TimestampField): Date | undefined {
 }
 
 // Prismic often returns empty RichText fields as `[]`, this filters them out
-export function transformRichTextField(
-  field: RichTextField
-): HTMLString | undefined {
+export function asHtmlString(field: RichTextField): HTMLString | undefined {
   return field && field.length > 0 ? (field as HTMLString) : undefined;
 }
 

--- a/content/webapp/services/prismic/transformers/index.ts
+++ b/content/webapp/services/prismic/transformers/index.ts
@@ -134,7 +134,7 @@ export function transformTimestamp(field: TimestampField): Date | undefined {
 }
 
 // Prismic often returns empty RichText fields as `[]`, this filters them out
-export function asHtmlString(field: RichTextField): HTMLString | undefined {
+export function asRichText(field: RichTextField): HTMLString | undefined {
   return field && field.length > 0 ? (field as HTMLString) : undefined;
 }
 

--- a/content/webapp/services/prismic/transformers/index.ts
+++ b/content/webapp/services/prismic/transformers/index.ts
@@ -112,7 +112,7 @@ export function transformSeries(document: PrismicDocument<WithSeries>) {
     .filter(isFilledLinkToDocumentWithData);
 }
 
-export function transformFormat(document: { data: WithArticleFormat | WithCardFormat | WithEventFormat | WithGuideFormat | WithPageFormat }) {
+export function transformFormat(document: { data: WithArticleFormat | WithCardFormat | WithEventFormat | WithGuideFormat | WithPageFormat }): Format | undefined {
   const { format } = document.data;
 
   if (isFilledLinkToDocumentWithData(format) && format.data) {

--- a/content/webapp/services/prismic/transformers/pages.ts
+++ b/content/webapp/services/prismic/transformers/pages.ts
@@ -2,12 +2,11 @@ import { FeaturedText } from '@weco/common/model/text';
 import { Page } from '../../../types/pages';
 import { PagePrismicDocument } from '../types/pages';
 import {
-  parseFormat,
   parseOnThisPage,
   parseSingleLevelGroup,
 } from '@weco/common/services/prismic/parsers';
 import { links as headerLinks } from '@weco/common/views/components/Header/Header';
-import { transformGenericFields, transformTimestamp } from '.';
+import { transformFormat, transformGenericFields, transformTimestamp } from '.';
 import { transformSeason } from './seasons';
 
 export function transformPage(document: PagePrismicDocument): Page {
@@ -33,7 +32,7 @@ export function transformPage(document: PagePrismicDocument): Page {
   const promo = genericFields.promo;
   return {
     type: 'pages',
-    format: data.format && parseFormat(data.format),
+    format: transformFormat(document),
     ...genericFields,
     seasons,
     parentPages,

--- a/content/webapp/services/prismic/types/card.ts
+++ b/content/webapp/services/prismic/types/card.ts
@@ -21,17 +21,21 @@ type Label = {
   description: RichTextField;
 };
 const typeEnum = 'card';
+
+export type WithCardFormat = {
+  format: 
+    | RelationField<
+        'article-formats',
+        'en-gb',
+        InferDataInterface<ArticleFormat>
+      >
+    | RelationField<'event-formats', 'en-gb', InferDataInterface<EventFormat>>
+    | RelationField<'labels', 'en-gb', InferDataInterface<Label>>;
+};
+
 export type CardPrismicDocument = PrismicDocument<
   {
     title: RichTextField;
-    format:
-      | RelationField<
-          'article-formats',
-          'en-gb',
-          InferDataInterface<ArticleFormat>
-        >
-      | RelationField<'event-formats', 'en-gb', InferDataInterface<EventFormat>>
-      | RelationField<'labels', 'en-gb', InferDataInterface<Label>>;
     description: RichTextField;
     image: Image;
     link: LinkField;
@@ -39,6 +43,7 @@ export type CardPrismicDocument = PrismicDocument<
   } & WithContributors &
     WithExhibitionParents &
     WithSeasons &
+    WithCardFormat &
     CommonPrismicFields,
   typeof typeEnum
 >;

--- a/content/webapp/services/prismic/types/events.ts
+++ b/content/webapp/services/prismic/types/events.ts
@@ -103,13 +103,16 @@ const teamFetchLinks: FetchLinks<Team> = [
   'teams.url',
 ];
 
+export type WithEventFormat = {
+  format: RelationField<
+    'event-formats',
+    'en-gb',
+    InferDataInterface<EventFormat>
+  >;
+};
+
 export type EventPrismicDocument = PrismicDocument<
   {
-    format: RelationField<
-      'event-formats',
-      'en-gb',
-      InferDataInterface<EventFormat>
-    >;
     locations: GroupField<{
       location: RelationField<
         'place',
@@ -176,6 +179,7 @@ export type EventPrismicDocument = PrismicDocument<
   } & WithContributors &
     WithEventSeries &
     WithExhibitionParents &
+    WithEventFormat &
     WithSeasons &
     CommonPrismicFields,
   typeof typeEnum

--- a/content/webapp/services/prismic/types/guides.ts
+++ b/content/webapp/services/prismic/types/guides.ts
@@ -23,19 +23,23 @@ export type GuideFormatPrismicDocument = PrismicDocument<
   'guide-formats'
 >;
 
+export type WithGuideFormat = {
+  format: RelationField<
+    'guide-formats',
+    'en-gb',
+    InferDataInterface<GuideFormatPrismicDocument>
+  >;
+};
+
 export type GuidePrismicDocument = PrismicDocument<
   {
-    format: RelationField<
-      'guide-formats',
-      'en-gb',
-      InferDataInterface<GuideFormatPrismicDocument>
-    >;
     datePublished: TimestampField;
     availableOnline: BooleanField;
     showOnThisPage: BooleanField;
   } & WithContributors &
     WithExhibitionParents &
     WithSeasons &
+    WithGuideFormat &
     CommonPrismicFields,
   typeof typeEnum
 >;

--- a/content/webapp/services/prismic/types/pages.ts
+++ b/content/webapp/services/prismic/types/pages.ts
@@ -23,13 +23,16 @@ type PageFormat = PrismicDocument<
   'page-formats'
 >;
 
+export type WithPageFormat = {
+  format: RelationField<
+    'page-formats',
+    'en-gb',
+    InferDataInterface<PageFormat>
+  >;
+};
+
 export type PagePrismicDocument = PrismicDocument<
   {
-    format: RelationField<
-      'page-formats',
-      'en-gb',
-      InferDataInterface<PageFormat>
-    >;
     datePublished: TimestampField;
     isOnline: BooleanField;
     availableOnline: BooleanField;
@@ -37,6 +40,7 @@ export type PagePrismicDocument = PrismicDocument<
   } & WithContributors &
     WithExhibitionParents &
     WithSeasons &
+    WithPageFormat &
     CommonPrismicFields,
   typeof typeEnum
 >;


### PR DESCRIPTION
For #7302. This snips a few more bits out of `parsers.js`.

My ultimate goal is that we'll have three functions like:

- `asText()` – returns plain text
- `asHtml()` – returns HTML
- `asHtmlString()` – currently returns out HTMLString type, but at some point it'll return the RichTextField, because that's what various Prismic components want to receive

And all three are better than calling Prismic helper methods directly because they remove nulls/empty values and extra whitespace.