### PR TITLE
Split the types for transforming contributors

### DIFF
--- a/content/webapp/services/prismic/transformers/contributors.ts
+++ b/content/webapp/services/prismic/transformers/contributors.ts
@@ -1,17 +1,14 @@
 import {
   FilledLinkToDocumentField,
   PrismicDocument,
-  FilledImageFieldImage,
 } from '@prismicio/types';
-import * as prismicH from 'prismic-helpers-beta';
-import { isFilledLinkToDocumentWithData, isFilledLinkToPersonField, WithContributors, InferDataInterface, isFilledLinkToOrganisationField, DataInterface } from '../types';
+import { isFilledLinkToDocumentWithData, WithContributors, InferDataInterface, isFilledLinkToOrganisationField, isFilledLinkToPersonField } from '../types';
 import { Contributor } from '../../../types/contributors';
 import { isNotUndefined } from '@weco/common/utils/array';
 import {
   asRichText,
   asText,
 } from '.';
-import { transformImage } from './images';
 import { ImageType } from '@weco/common/model/image';
 import { Organisation, Person } from '../types/contributors';
 
@@ -28,7 +25,7 @@ function transformCommonFields(agent:
   | FilledLinkToDocumentField<'organisations', 'en-gb', InferDataInterface<Organisation>> & { data: Organisation }) {
   return {
     id: agent.id,
-    description: transformRichTextField(agent.data.description),
+    description: asRichText(agent.data.description),
     image: agent.data.image || defaultContributorImage,
   };
 }
@@ -36,54 +33,16 @@ function transformCommonFields(agent:
 export function transformContributorAgent(
   agent: WithContributors['contributors'][number]['contributor']
 ): Contributor['contributor'] | undefined {
-<<<<<<< HEAD
-  if (isFilledLinkToDocumentWithData(agent)) {
-    const commonFields = {
-      id: agent.id,
-      description: asRichText(agent.data.description),
-      image: transformImage(agent.data.image) || defaultContributorImage,
-      sameAs: (agent.data.sameAs ?? [])
-        .map(sameAs => {
-          const link = asText(sameAs.link);
-          const title = prismicH.asText(sameAs.title);
-          return title && link ? { title, link } : undefined;
-        })
-        .filter(isNotUndefined),
-    };
-
-    // The .name field can be either RichText or Text.
-    const name = isString(agent.data.name)
-      ? asText(agent.data.name)
-      : Array.isArray(agent.data.name)
-      ? asText(agent.data.name)
-      : undefined;
-
-    if (agent.type === 'organisations') {
-      return {
-        type: agent.type,
-        name,
-        ...commonFields,
-      };
-    } else if (agent.type === 'people') {
-      return {
-        type: agent.type,
-        name,
-        ...commonFields,
-        // I'm not sure why I have to coerce this type here as it is that type?
-        pronouns: asText(agent.data.pronouns as KeyTextField),
-      };
-    }
-=======
   if (isFilledLinkToPersonField(agent)) {
     return {
       ...transformCommonFields(agent),
       type: agent.type,
-      name: transformKeyTextField(agent.data.name),
-      pronouns: transformKeyTextField(agent.data.pronouns),
+      name: asText(agent.data.name),
+      pronouns: asText(agent.data.pronouns),
       sameAs: (agent.data.sameAs ?? [])
       .map(sameAs => {
-        const link = transformKeyTextField(sameAs.link);
-        const title = transformRichTextFieldToString(sameAs.title);
+        const link = asText(sameAs.link);
+        const title = asRichText(sameAs.title);
         return title && link ? { title, link } : undefined;
       })
       .filter(isNotUndefined)
@@ -92,18 +51,17 @@ export function transformContributorAgent(
     return {
       ...transformCommonFields(agent),
       type: agent.type,
-      name: transformRichTextFieldToString(agent.data.name),
+      name: asRichText(agent.data.name),
       sameAs: (agent.data.sameAs ?? [])
       .map(sameAs => {
-        const link = transformKeyTextField(sameAs.link);
-        const title = transformKeyTextField(sameAs.title);
+        const link = asText(sameAs.link);
+        const title = asText(sameAs.title);
         return title && link ? { title, link } : undefined;
       })
       .filter(isNotUndefined)
     };
   } else {
     return undefined;
->>>>>>> Split the types for transforming contributors
   }
 }
 

--- a/content/webapp/services/prismic/transformers/contributors.ts
+++ b/content/webapp/services/prismic/transformers/contributors.ts
@@ -6,11 +6,13 @@ import { isFilledLinkToDocumentWithData, WithContributors, InferDataInterface, i
 import { Contributor } from '../../../types/contributors';
 import { isNotUndefined } from '@weco/common/utils/array';
 import {
+  asHtml,
   asRichText,
   asText,
 } from '.';
 import { ImageType } from '@weco/common/model/image';
 import { Organisation, Person } from '../types/contributors';
+import { transformImage } from './images';
 
 const defaultContributorImage: ImageType = {
   width: 64,
@@ -26,7 +28,7 @@ function transformCommonFields(agent:
   return {
     id: agent.id,
     description: asRichText(agent.data.description),
-    image: agent.data.image || defaultContributorImage,
+    image: transformImage(agent.data.image) || defaultContributorImage,
   };
 }
 
@@ -42,7 +44,7 @@ export function transformContributorAgent(
       sameAs: (agent.data.sameAs ?? [])
       .map(sameAs => {
         const link = asText(sameAs.link);
-        const title = asRichText(sameAs.title);
+        const title = asHtml(sameAs.title);
         return title && link ? { title, link } : undefined;
       })
       .filter(isNotUndefined)
@@ -51,7 +53,7 @@ export function transformContributorAgent(
     return {
       ...transformCommonFields(agent),
       type: agent.type,
-      name: asRichText(agent.data.name),
+      name: asHtml(agent.data.name),
       sameAs: (agent.data.sameAs ?? [])
       .map(sameAs => {
         const link = asText(sameAs.link);

--- a/content/webapp/services/prismic/types/contributors.ts
+++ b/content/webapp/services/prismic/types/contributors.ts
@@ -3,7 +3,6 @@ import {
   KeyTextField,
   RichTextField,
   GroupField,
-  LinkField,
 } from '@prismicio/types';
 import { Image } from '.';
 
@@ -43,7 +42,7 @@ export type Organisation = PrismicDocument<
     description: RichTextField;
     image: Image;
     sameAs: GroupField<{
-      link: LinkField;
+      link: KeyTextField;
       title: KeyTextField;
     }>;
   },

--- a/content/webapp/services/prismic/types/index.ts
+++ b/content/webapp/services/prismic/types/index.ts
@@ -12,6 +12,8 @@ import {
   FilledLinkToWebField,
   NumberField,
   LinkField,
+  LinkType,
+  EmptyLinkField,
 } from '@prismicio/types';
 import { ArticleFormat } from './article-format';
 import { ExhibitionFormat } from './exhibition-format';
@@ -181,6 +183,11 @@ export const exhibitionsFetchLinks: FetchLinks<ExhibitionPrismicDocument> = [
   'exhibitions.shortTitle',
 ];
 
+type Contributor =
+  | EmptyLinkField<LinkType.Document>
+  | FilledLinkToDocumentField<'people', 'en-gb', InferDataInterface<Person>>
+  | FilledLinkToDocumentField<'organisations', 'en-gb', InferDataInterface<Organisation>>;
+
 export type WithContributors = {
   contributorsTitle: RichTextField;
   contributors: GroupField<{
@@ -189,11 +196,7 @@ export type WithContributors = {
       'en-gb',
       InferDataInterface<EditorialContributorRole>
     >;
-    contributor: RelationField<
-      'people' | 'organisations',
-      'en-gb',
-      InferDataInterface<Person | Organisation>
-    >;
+    contributor: Contributor;
     description: RichTextField;
   }>;
 };
@@ -239,4 +242,16 @@ export function isFilledLinkToMediaField(
   field: LinkField
 ): field is FilledLinkToWebField {
   return link(field) && field.link_type === 'Media' && 'url' in field;
+}
+
+export function isFilledLinkToPersonField(
+  field: Contributor
+): field is FilledLinkToDocumentField<'people', 'en-gb', InferDataInterface<Person>> & { data: Person } {
+  return isFilledLinkToDocumentWithData(field) && field.type === 'people';
+}
+
+export function isFilledLinkToOrganisationField(
+  field: Contributor
+): field is FilledLinkToDocumentField<'organisations', 'en-gb', InferDataInterface<Organisation>> & { data: Organisation }  {
+  return isFilledLinkToDocumentWithData(field) && field.type === 'organisations';
 }


### PR DESCRIPTION
I noticed this while investigating the contributor link issue -- because Person and Organisation are slightly divergent types (one uses a string for the title, the other a structured text field), we lose the benefits of the type checker here.  In particular, the `sameAs` type was `any`, but now we know what it is in both branches.