### PR TITLE
Don't blow up the contributor images unnecessarily

### DIFF
--- a/content/webapp/components/Contributors/Contributor.tsx
+++ b/content/webapp/components/Contributors/Contributor.tsx
@@ -31,13 +31,13 @@ const Contributor = ({ contributor, role, description }: ContributorType) => {
                   transform: 'rotateZ(6deg) scale(1.2)',
                 }}
               >
-                <PrismicImage image={contributor.image} />
+                <PrismicImage image={contributor.image} maxWidth={72} />
               </div>
             </div>
           )}
           {contributor.image && contributor.type === 'organisations' && (
             <div style={{ width: '72px' }}>
-              <PrismicImage image={contributor.image} />
+              <PrismicImage image={contributor.image} maxWidth={72} />
             </div>
           )}
         </Space>

--- a/content/webapp/components/PrismicImage/PrismicImage.tsx
+++ b/content/webapp/components/PrismicImage/PrismicImage.tsx
@@ -1,4 +1,4 @@
-import Image from 'next/image';
+import Image, { ImageLoaderProps } from 'next/image';
 import { classNames } from '@weco/common/utils/classnames';
 import {
   Breakpoint,
@@ -11,8 +11,9 @@ type BreakpointSizes = Partial<Record<Breakpoint, number>>;
 type Props = {
   image: Picture | ImageType;
   sizes?: BreakpointSizes;
-  width?: number;
-  height?: number;
+
+  // The maximum width at which the image will be displayed
+  maxWidth?: number;
 };
 
 export function convertBreakpointSizesToSizes(
@@ -39,32 +40,59 @@ export function convertBreakpointSizesToSizes(
  * make it run in places like Cardigan and allows us to work with things
  * like prismic using `rect` for crops
  */
-const prismicLoader = ({ src, width, quality }) => {
-  // e.g. src: https://images.prismic.io/wellcomecollection/5cf4b151-8fa1-47d1-9546-3115debc3b04_Viscera+web+image.jpg?auto=compress,format&rect=0,0,3838,2159&w=3200&h=1800
-  const url = new URL(src);
-  const searchParams = new URLSearchParams();
-  searchParams.set(`w`, width);
-  searchParams.set(`auto`, 'compress,format');
-  searchParams.set(`rect`, url.searchParams.get('rect') || '');
-  searchParams.set(`q`, quality || 75);
+function createPrismicLoader(maxWidth: number) {
+  return ({ src, width, quality }: ImageLoaderProps) => {
+    // e.g. src: https://images.prismic.io/wellcomecollection/5cf4b151-8fa1-47d1-9546-3115debc3b04_Viscera+web+image.jpg?auto=compress,format&rect=0,0,3838,2159&w=3200&h=1800
+    const url = new URL(src);
+    const searchParams = new URLSearchParams();
 
-  return `${url.origin}${url.pathname}?${searchParams.toString()}`;
-};
+    // This is working around a poor interaction between the Next Image component
+    // and Prismic.
+    //
+    // In particular, this loader will be called for a range of sizes, even if they're
+    // wider than the original image.  I think the component assumes that any image
+    // resizing service would return the original image in that case, but Prismic will
+    // upscale the image instead.
+    //
+    // e.g. if the original image is 100×100 and you pass ?w=200, Prismic will merrily
+    // return an upscaled image that's larger than you need.
+    //
+    // This clamps the width to a configured maximum, e.g. if you know the image will
+    // only be used in a specific context.  It won't ask Prismic for a larger image.
+    if (width < maxWidth) {
+      searchParams.set(`w`, width.toString());
+    } else {
+      searchParams.set(`w`, maxWidth.toString());
+    }
+    
+    searchParams.set(`auto`, 'compress,format');
+    searchParams.set(`rect`, url.searchParams.get('rect') || '');
+    searchParams.set(`q`, (quality || 75).toString());
+  
+    return `${url.origin}${url.pathname}?${searchParams.toString()}`;
+  }
+}
 
 /**
  * the intention here is to become part of the new defacto image component on the site
  * usurping UiImage which has reached a state where it is so bloated it is hard to refactor.
  * This is aimed solely at the Prismic image rendering for now.
  */
-const PrismicImage = ({ image, sizes, width, height }: Props) => {
+const PrismicImage = ({ image, sizes, maxWidth }: Props) => {
   const sizesString = sizes
     ? convertBreakpointSizesToSizes(sizes).join(', ')
     : undefined;
 
+  // Callers pass the CSS width; we triple it so we still get crisp images on
+  // high-resolution displays, but remember not to go beyond the original image!
+  const maxLoaderWidth = maxWidth
+    ? Math.min(maxWidth * 3, image.width)
+    : image.width;
+
   return (
     <Image
-      width={width ?? image.width}
-      height={height ?? image.height}
+      width={image.width}
+      height={image.height}
       layout="responsive"
       className={classNames({
         'image bg-charcoal font-white': true,
@@ -72,7 +100,7 @@ const PrismicImage = ({ image, sizes, width, height }: Props) => {
       sizes={sizesString}
       src={image.contentUrl}
       alt={image.alt}
-      loader={prismicLoader}
+      loader={createPrismicLoader(maxLoaderWidth)}
     />
   );
 };


### PR DESCRIPTION
Follows #7722

While reading some stories (shocking, I know, actually using the site as a reader), I noticed that contributor images were quite slow to load. This is because of a poor interaction between the Next Image component and the way Prismic resizes images, which is explained in the new comment in the PrismicImage component. We're loading unnecessarily large images; larger than if we weren't doing any resizing at all (!).

On my 5K iMac, I was getting 1338px wide images… which are shown at 72px wide.

This patch modifies the PrismicImage component in two ways:

* We'll never ask Prismic for a resized version that's wider than the original image; this is pure waste
* Callers can tell this component that they'll only be using the image up to a certain width; it then constrains resized versions to be no wider than necessary

On a quick glance over the currently featured stories, the average contributor image is ~200KB… now down to ~3KB. **That means we’re saving ~200KB of bandwidth per contributor, per article.**

We can probably optimise our use of this image further, e.g. in the article cards, but that's unlikely to be this egregious.