### PR TITLE
Switch to using a single version of the Prismic client in the content app

### DIFF
--- a/content/webapp/app.ts
+++ b/content/webapp/app.ts
@@ -4,7 +4,6 @@ require('@weco/common/services/apm/initApm')('content-server');
 import Koa from 'koa';
 import Router from 'koa-router';
 import next from 'next';
-import Prismic from '@prismicio/client';
 import { apmErrorMiddleware } from '@weco/common/services/apm/errorMiddleware';
 import { init as initServerData } from '@weco/common/server-data';
 import bodyParser from 'koa-bodyparser';
@@ -20,6 +19,7 @@ import {
 } from '@weco/common/services/prismic/hardcoded-id';
 import { Periods } from '@weco/common/model/periods';
 import linkResolver from './services/prismic/link-resolver';
+import * as prismic from 'prismic-client-beta';
 
 const periodPaths = Object.values(Periods).join('|');
 
@@ -124,15 +124,11 @@ const appPromise = nextApp
 
     router.get('/preview', async ctx => {
       // Kill any cookie we had set, as it think it is causing issues.
-      ctx.cookies.set(Prismic.previewCookie);
+      ctx.cookies.set('io.prismic.preview');
 
-      const { token, documentId } = ctx.request.query;
-      const api = await Prismic.getApi(
-        'https://wellcomecollection.cdn.prismic.io/api/v2',
-        {
-          req: ctx.request,
-        }
-      );
+      const endpoint = prismic.getEndpoint('wellcomecollection');
+      const client = prismic.createClient(endpoint, { fetch });
+      client.enableAutoPreviewsFromReq(ctx.request);
 
       /**
        * This is because the type in api.resolve are not true
@@ -141,9 +137,11 @@ const appPromise = nextApp
         return (linkResolver(doc) as string) || '/';
       };
 
-      const url = await api
-        .getPreviewResolver(token!.toString(), documentId!.toString())
-        .resolve(retypedLinkResolver, '/');
+      const url = await client
+        .resolvePreviewURL({
+          linkResolver: retypedLinkResolver,
+          defaultURL: '/',
+        });
 
       ctx.cookies.set('isPreview', 'true', {
         httpOnly: false,

--- a/content/webapp/app.ts
+++ b/content/webapp/app.ts
@@ -124,7 +124,7 @@ const appPromise = nextApp
 
     router.get('/preview', async ctx => {
       // Kill any cookie we had set, as it think it is causing issues.
-      ctx.cookies.set('io.prismic.preview');
+      ctx.cookies.set(prismic.cookie.preview);
 
       const endpoint = prismic.getEndpoint('wellcomecollection');
       const client = prismic.createClient(endpoint, { fetch });
@@ -137,11 +137,10 @@ const appPromise = nextApp
         return (linkResolver(doc) as string) || '/';
       };
 
-      const url = await client
-        .resolvePreviewURL({
-          linkResolver: retypedLinkResolver,
-          defaultURL: '/',
-        });
+      const url = await client.resolvePreviewURL({
+        linkResolver: retypedLinkResolver,
+        defaultURL: '/',
+      });
 
       ctx.cookies.set('isPreview', 'true', {
         httpOnly: false,

--- a/content/webapp/package.json
+++ b/content/webapp/package.json
@@ -11,7 +11,6 @@
     "deployBundleAnalysis": "aws s3 sync .dist s3://dash.wellcomecollection.org/bundles --only-show-errors --acl public-read"
   },
   "dependencies": {
-    "@prismicio/client": "^5.1.0",
     "@types/jest": "^27.0.2",
     "@types/koa-router": "^7.4.4",
     "@types/styled-components": "^5.1.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3120,13 +3120,6 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.10.2.tgz#0798c03351f0dea1a5a4cabddf26a55a7cbee590"
   integrity sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ==
 
-"@prismicio/client@^5.1.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@prismicio/client/-/client-5.1.0.tgz#f236d7fca09535d61e599872e7c38afda62b8b3c"
-  integrity sha512-LCb+arVVxJOoPM+8qfLCC/Dqse7mh+Q1k3oo5W5Uzu7vVO+vtc7CUYHxgCDkvekakYHc9407kwWu65ErZw+CPQ==
-  dependencies:
-    cross-fetch "^3.0.6"
-
 "@prismicio/helpers@^1.0.4":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@prismicio/helpers/-/helpers-1.0.5.tgz#2be60a1b44e6c33d7918fa74fe67648dc8af0c15"
@@ -7298,13 +7291,6 @@ create-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
-
-cross-fetch@^3.0.6:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.4.tgz#9723f3a3a247bf8b89039f3a380a9244e8fa2f39"
-  integrity sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==
-  dependencies:
-    node-fetch "2.6.1"
 
 cross-spawn@7.0.3, cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"


### PR DESCRIPTION
This is following the instructions from Prismic's migration guide:
https://prismic.io/docs/technologies/prismic-client-v6-migration-guide

We still have a few other versions of old Prismic libraries hanging around (e.g. prismic-reactjs, prismic-dom). Upgrading those is sufficiently complicated as to warrant its own patch.

For #7363 and #7595.