### PR TITLE
Remove covid-book-your-ticket url that's no longer live

### DIFF
--- a/.buildkite/expected_200_urls.txt
+++ b/.buildkite/expected_200_urls.txt
@@ -1,6 +1,3 @@
-# https://wellcome.slack.com/archives/C294K7D5M/p1638794220158000
-/covid-book-your-ticket
-
 # https://wellcome.slack.com/archives/C8X9YKM5X/p1638456535135800
 /articles/W9m2QxcAAF8AFvE5
 


### PR DESCRIPTION
☝️ 

In order to fix the [failing build](https://buildkite.com/wellcomecollection/experience-deployment/builds/687#16ad4468-a398-40b1-a842-61bb646eff2d).