### PR TITLE
Bring improved error messages from requesting api 

### DIFF
--- a/catalogue/webapp/components/ItemRequestModal/ItemRequestModal.tsx
+++ b/catalogue/webapp/components/ItemRequestModal/ItemRequestModal.tsx
@@ -36,6 +36,7 @@ import LL from '@weco/common/views/components/styled/LL';
 import { allowedRequests } from '@weco/common/values/requests';
 import RequestingDayPicker from '../RequestingDayPicker/RequestingDayPicker';
 import { convertDayNumberToDay } from '../../utils/dates';
+import { defaultRequestErrorMessage } from '@weco/common/data/microcopy';
 
 function arrayofItemsToText(arr) {
   if (arr.length === 1) return arr[0];
@@ -394,11 +395,7 @@ const ErrorDialog: FC<ErrorDialogProps> = ({ setIsActive, errorMessage }) => (
     <Header>
       <span className={`h2`}>Request failed</span>
     </Header>
-    <p className="no-margin">
-      {/* TODO: get error code and construct appropriate message from response - see #6916 */}
-      {errorMessage ||
-        'There was a problem requesting this item. Please try again.'}
-    </p>
+    <p className="no-margin">{errorMessage || defaultRequestErrorMessage}</p>
     <CTAs>
       <ButtonOutlined text={`Close`} clickHandler={() => setIsActive(false)} />
     </CTAs>
@@ -449,9 +446,9 @@ const ItemRequestModal: FC<Props> = ({
           'Content-Type': 'application/json',
         },
       });
-      const responseJson = await response.json();
       if (!response.ok) {
         setRequestingState('error');
+        const responseJson = await response.json();
         const error: CatalogueApiError = responseJson;
         throw error;
       } else {
@@ -470,9 +467,7 @@ const ItemRequestModal: FC<Props> = ({
 
   function renderModalContent(
     requestingState: RequestingState,
-    requestingErrorMessage?:
-      | string
-      | 'There was a problem requesting this item. Please try again.'
+    requestingErrorMessage?: string
   ) {
     switch (requestingState) {
       case 'requesting':

--- a/common/data/microcopy.ts
+++ b/common/data/microcopy.ts
@@ -64,3 +64,6 @@ export const sierraStatusCodeToLabel = {
   i: 'Available to view',
   t: 'In transit',
 };
+
+export const defaultRequestErrorMessage =
+  'There was a problem requesting this item. Please try again.';


### PR DESCRIPTION
## Who is this for?
This is for people who will be requesting items from the collection. The requesting service API can respond with an error under several circumstances. At present we just tell the user that the request failed and ask then to try again. 
Ticket: https://github.com/wellcomecollection/wellcomecollection.org/issues/6916

## What is it doing for them?

We want to ensure we are displaying informative error messages to people using the requesting service.

## What does that look like?

I was able to replicate the error of trying to request an item when I have already reached my limit, this at least demonstrates the process of getting the `error.description` back from the API. In theory, it should work for each error case set by the API. 

![requestingerrormessage_opt](https://user-images.githubusercontent.com/16557524/156385218-8987aaa2-f92c-4d53-a65f-95f697afe3cc.gif)


## Please note
I saw [a PR](https://github.com/wellcomecollection/catalogue-api/pull/319) that has been merged in the API to change the error copy to use can't instead of cannot, but you'll see in the attached gif that cannot still appears. I'll need to investigate that.