### PR TITLE
Toggles

### DIFF
--- a/toggles/README.md
+++ b/toggles/README.md
@@ -59,7 +59,8 @@ You can change a toggle's `defaultValue` via:
 yarn setDefaultValueFor --{toggle_id}=true
 ```
 
-[martin-fowler-feature-toggles]: https://martinfowler.com/articles/feature-toggles.html
-[toggles-dashboard]: https://dash.wellcomecollection.org/toggles/
-[toggles]: https://toggles.wellcomecollection.org/toggles.json
+## Useful links
+- ["Feature Toggles (aka Feature Flags)" - by Martin Fowler](https://martinfowler.com/articles/feature-toggles.html)
+- [Toggles Dashboard](https://dash.wellcomecollection.org/toggles)
+- [Toggles](https://toggles.wellcomecollection.org/toggles.json)
 

--- a/toggles/webapp/package.json
+++ b/toggles/webapp/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "scripts": {
     "test": "jest",
-    "deploy": "ts-node ./scripts/deploy"
+    "deploy": "ts-node ./scripts/deploy",
+    "setDefaultValueFor": "ts-node ./scripts/setDefaultValueFor"
   },
   "devDependencies": {
     "@aws-sdk/client-s3": "^3.39.0",

--- a/toggles/webapp/scripts/setDefaultValueFor.ts
+++ b/toggles/webapp/scripts/setDefaultValueFor.ts
@@ -1,0 +1,22 @@
+import { S3Client } from '@aws-sdk/client-s3';
+import { getCreds } from '@weco/ts-aws/sts';
+import { region } from '../config';
+import { setDefaultValueFor } from '../setDefaultValueFor';
+
+export const isCi = process.env.CI === 'true';
+
+async function run() {
+  const credentials = isCi ? undefined : await getCreds('experience', 'admin');
+
+  const s3Client = new S3Client({
+    region,
+    credentials,
+  });
+
+  await setDefaultValueFor(s3Client);
+}
+
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/toggles/webapp/scripts/setDefaultValueFor.ts
+++ b/toggles/webapp/scripts/setDefaultValueFor.ts
@@ -6,7 +6,9 @@ import { setDefaultValueFor } from '../setDefaultValueFor';
 export const isCi = process.env.CI === 'true';
 
 async function run() {
-  const credentials = isCi ? undefined : await getCreds('experience', 'admin');
+  const credentials = isCi
+    ? undefined
+    : await getCreds('experience', 'developer');
 
   const s3Client = new S3Client({
     region,

--- a/toggles/webapp/setDefaultValueFor.ts
+++ b/toggles/webapp/setDefaultValueFor.ts
@@ -1,9 +1,13 @@
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
-import { key } from './config';
+import { key, region } from './config';
 import { getTogglesObject, putTogglesObject } from './s3-utils';
-import { CreateInvalidationCommand } from '@aws-sdk/client-cloudfront';
+import {
+  CloudFrontClient,
+  CreateInvalidationCommand,
+} from '@aws-sdk/client-cloudfront';
 import { S3Client } from '@aws-sdk/client-s3';
+import { getCreds } from '@weco/ts-aws/sts';
 
 const argv = yargs(hideBin(process.argv)).parseSync();
 
@@ -39,6 +43,8 @@ export async function setDefaultValueFor(client: S3Client) {
   }
 
   // create an invalidation on the object
+  const credentials = await getCreds('experience', 'admin');
+  const newClient = new CloudFrontClient({ region, credentials });
   const command = new CreateInvalidationCommand({
     DistributionId: 'E34PPJX23D6HKG',
     InvalidationBatch: {
@@ -46,6 +52,6 @@ export async function setDefaultValueFor(client: S3Client) {
       CallerReference: `TogglesInvalidationCallerReference${Date.now()}`,
     },
   });
-  const response = await client.send(command);
+  const response = await newClient.send(command);
   console.info(response);
 }

--- a/toggles/webapp/setDefaultValueFor.ts
+++ b/toggles/webapp/setDefaultValueFor.ts
@@ -49,7 +49,7 @@ async function run() {
   const command = new CreateInvalidationCommand({
     DistributionId: 'E34PPJX23D6HKG',
     InvalidationBatch: {
-      Paths: { Items: [`/${key}.json`], Quantity: 1 },
+      Paths: { Items: [`/${key}`], Quantity: 1 },
       CallerReference: `TogglesInvalidationCallerReference${Date.now()}`,
     },
   });


### PR DESCRIPTION
## Who is this for?
People who want toggle deployment to work as described in the README

## What is it doing for them?
main things are:
- Adding a script, so we can run `yarn setDefaultValueFor --{toggle_id}=true` to update defaults
- Making the invalidation path correct, so the Cloudfront cache for the toggles gets cleared after a change