### PR TITLE
Filter out IIIF media elements which can't be downloaded

### DIFF
--- a/catalogue/webapp/components/Download/Download.tsx
+++ b/catalogue/webapp/components/Download/Download.tsx
@@ -25,7 +25,7 @@ export const DownloadOptions = styled.div.attrs(() => ({
   }
 `;
 
-export function getFormatString(format: string): DownloadFormat | undefined {
+function getFormatString(format: string): DownloadFormat | undefined {
   switch (format) {
     case 'application/pdf':
       return 'PDF';

--- a/catalogue/webapp/model/iiif.ts
+++ b/catalogue/webapp/model/iiif.ts
@@ -84,10 +84,17 @@ export type IIIFMediaElement = {
   service?: AuthService | AuthService[];
 };
 
+// This occurs on some born-digital presentation manifests,
+// e.g. https://iiif.wellcomecollection.org/presentation/v2/b29696586
+export type EmptyIIIFMediaElement = {
+  label: string;
+  thumbnail: string;
+}
+
 type IIIFMediaSequence = {
   '@id': string;
   '@type': string;
-  elements: IIIFMediaElement[];
+  elements: (IIIFMediaElement | EmptyIIIFMediaElement)[];
 };
 
 export type IIIFSequence = {

--- a/catalogue/webapp/utils/iiif.ts
+++ b/catalogue/webapp/utils/iiif.ts
@@ -10,10 +10,17 @@ import {
   AuthServiceService,
   IIIFAnnotationResource,
   IIIFThumbnailService,
+  EmptyIIIFMediaElement,
 } from '../model/iiif';
 import { fetchJson } from '@weco/common/utils/http';
 import cloneDeep from 'lodash.clonedeep';
 import { isNotUndefined } from '@weco/common/utils/array';
+
+const isFilledMediaElement = (
+  element: IIIFMediaElement | EmptyIIIFMediaElement
+): element is IIIFMediaElement => {
+  return '@id' in element;
+}
 
 export function getServiceId(canvas?: IIIFCanvas): string | undefined {
   const serviceSrc = canvas?.images[0]?.resource?.service;
@@ -198,6 +205,7 @@ export function getDownloadOptionsFromManifest(
     ? iiifManifest.mediaSequences.reduce((acc: IIIFRendering[], sequence) => {
         return acc.concat(
           sequence.elements
+            .filter(isFilledMediaElement)
             .map(element => {
               return {
                 '@id': element['@id'],
@@ -285,8 +293,9 @@ export function getVideo(
     );
   return (
     videoSequence &&
-    videoSequence.elements.find(
-      element => element['@type'] === 'dctypes:MovingImage'
+    videoSequence.elements
+      .filter(isFilledMediaElement)
+      .find(element => element['@type'] === 'dctypes:MovingImage'
     )
   );
 }
@@ -294,7 +303,9 @@ export function getVideo(
 export function getAudio(iiifManifest: IIIFManifest): IIIFMediaElement[] {
   const audioSequences = (iiifManifest.mediaSequences || [])
     .flatMap(sequence =>
-      sequence.elements.find(element => element['@type'] === 'dctypes:Sound')
+      sequence.elements
+        .filter(isFilledMediaElement)
+        .find(element => element['@type'] === 'dctypes:Sound')
     )
     .filter(isNotUndefined);
 


### PR DESCRIPTION
There are some IIIF presentation manifests that don't have an `@id` on an element in the media sequence, e.g. https://iiif.wellcomecollection.org/presentation/v2/b29696586

```json
"mediaSequences": [
  {
    "@id": "https://iiif.wellcomecollection.org/iiif/b29696586/xsequence/s0",
    "@type": "ixif:MediaSequence",
    "label": "XSequence 0",
    "elements": [
      {
        "label": "Arts and Health Witness Seminar: Programme",
        "thumbnail": "https://iiif.wellcomecollection.org/thumb/b29696586"
      }
    ]
  }
],
```

Our model expects the `@id` to be present, and the Download component explodes if it's `undefined`.  This causes certain pages to fail, e.g. https://wellcomecollection.org/works/akbf645k

This patch filters out sparse media elements, so our downstream components can assume they have all the fields they need.