### PR TITLE
Fix a bug in the event transformer

### DIFF
--- a/content/webapp/services/prismic/transformers/events.ts
+++ b/content/webapp/services/prismic/transformers/events.ts
@@ -228,15 +228,15 @@ export function transformEvent(
     ...audiencesLabels,
     ...interpretationsLabels,
     ...relaxedPerformanceLabel,
-  ].map(text => { return { text }; });
+  ].map(text => ({ text }));
 
   const primaryLabels = [
     ...formatLabel,
     ...audiencesLabels,
     ...relaxedPerformanceLabel,
-  ].map(text => { return { text }; });
+  ].map(text => ({ text }));
   
-  const secondaryLabels = [...interpretationsLabels].map(text => { return { text }; });
+  const secondaryLabels = [...interpretationsLabels].map(text => ({ text }));
 
   // We want to display the scheduleLength on EventPromos,
   // but don't want to make an extra API request to populate the schedule for every event in a list.


### PR DESCRIPTION
This is breaking https://wellcomecollection.org/events/X8j2TxIAACIAk-Fx and one other event page. I spotted it while working on #7765.

We were getting an error in determineDateRange because calling `reduce()` on an empty list is an error, but on further inspection, we don't need this function at all.

Previously the type checker was unable to tell us this, because we called it in one object then unpacked it into another later:

```typescript
function transformEvent(): Event {
  const event = { dateRange: determineDateRange() }

  // do some stuff

  return { ...event }
```

By consolidating everything into the return statement, the type checker tells us this field/function is unused (and several more besides).