### PR TITLE
Replace our bespoke HTMLString type with the built-in Prismic type

### DIFF
--- a/common/model/captioned-image.ts
+++ b/common/model/captioned-image.ts
@@ -1,7 +1,7 @@
 import { ImageType } from './image';
-import { HTMLString } from '../services/prismic/types';
+import * as prismicT from '@prismicio/types';
 
 export type CaptionedImage = {
-  caption: HTMLString;
+  caption: prismicT.RichTextField;
   image: ImageType;
 };

--- a/common/model/label-field.ts
+++ b/common/model/label-field.ts
@@ -1,8 +1,8 @@
-import { HTMLString } from '@weco/common/services/prismic/types';
+import * as prismicT from '@prismicio/types';
 import { ArticleFormatId } from '@weco/common/services/prismic/content-format-ids';
 
 export type LabelField = {
   id?: ArticleFormatId;
   title?: string;
-  description?: HTMLString;
+  description?: prismicT.RichTextField;
 };

--- a/common/services/prismic/types.ts
+++ b/common/services/prismic/types.ts
@@ -17,32 +17,6 @@ export type PrismicDocument = {
   url?: string;
 };
 
-type HTMLSpanTypes =
-  | 'heading2'
-  | 'heading3'
-  | 'paragraph'
-  | 'strong'
-  | 'em'
-  | 'hyperlink'
-  | 'strike'
-  | 'list-item'
-  | 'embed';
-
-type HTMLSpan = {
-  type: HTMLSpanTypes;
-  start: number;
-  end: number;
-  data?: Record<string, unknown>;
-};
-
-type HTMLStringBlock = {
-  type: HTMLSpanTypes;
-  text: string;
-  spans: HTMLSpan[];
-};
-
-export type HTMLString = HTMLStringBlock[];
-
 // This is the type we want to convert prismic
 // to as it mirrors the catalogue API
 export type PaginatedResults<T> = {

--- a/common/services/prismic/types.ts
+++ b/common/services/prismic/types.ts
@@ -17,7 +17,7 @@ export type PrismicDocument = {
   url?: string;
 };
 
-export type HTMLSpanTypes =
+type HTMLSpanTypes =
   | 'heading2'
   | 'heading3'
   | 'paragraph'
@@ -28,14 +28,14 @@ export type HTMLSpanTypes =
   | 'list-item'
   | 'embed';
 
-export type HTMLSpan = {
+type HTMLSpan = {
   type: HTMLSpanTypes;
   start: number;
   end: number;
   data?: Record<string, unknown>;
 };
 
-export type HTMLStringBlock = {
+type HTMLStringBlock = {
   type: HTMLSpanTypes;
   text: string;
   spans: HTMLSpan[];

--- a/common/views/components/Caption/Caption.tsx
+++ b/common/views/components/Caption/Caption.tsx
@@ -1,4 +1,4 @@
-import { HTMLString } from '../../../services/prismic/types';
+import * as prismicT from '@prismicio/types';
 import { font, classNames } from '../../../utils/classnames';
 import { FunctionComponent, ReactNode } from 'react';
 import PrismicHtmlBlock from '../PrismicHtmlBlock/PrismicHtmlBlock';
@@ -13,7 +13,7 @@ const CaptionWrapper = styled(Space).attrs({
 `;
 
 type Props = {
-  caption: HTMLString;
+  caption: prismicT.RichTextField;
   preCaptionNode?: ReactNode;
   width?: number;
 };

--- a/common/views/components/InfoBanner/InfoBanner.tsx
+++ b/common/views/components/InfoBanner/InfoBanner.tsx
@@ -7,7 +7,6 @@ import Space from '../styled/Space';
 import usePrevious from '../../../hooks/usePrevious';
 import { cross, information } from '@weco/common/icons';
 import { GlobalAlertPrismicDocument } from '../../../services/prismic/documents';
-import { HTMLString } from '../../../services/prismic/types';
 
 type Props = {
   cookieName?: string;
@@ -82,7 +81,7 @@ const InfoBanner: FunctionComponent<Props> = ({
                     </span>
                   </Space>
                   <div className="body-text spaced-text">
-                    <PrismicHtmlBlock html={text as HTMLString} />
+                    <PrismicHtmlBlock html={text} />
                   </div>
                 </span>
               </div>

--- a/common/views/components/InfoBlock/InfoBlock.tsx
+++ b/common/views/components/InfoBlock/InfoBlock.tsx
@@ -1,10 +1,10 @@
 import Space from '@weco/common/views/components/styled/Space';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
-import { HTMLString } from '../../../services/prismic/types';
 import ButtonOutlinedLink from '@weco/common/views/components/ButtonOutlinedLink/ButtonOutlinedLink';
 import { dasherize } from '@weco/common/utils/grammar';
 import { FunctionComponent, ReactElement } from 'react';
 import styled from 'styled-components';
+import * as prismicT from '@prismicio/types';
 
 const Wrapper = styled(Space).attrs({
   h: { size: 'l', properties: ['padding-left', 'padding-right'] },
@@ -14,7 +14,7 @@ const Wrapper = styled(Space).attrs({
 
 export type Props = {
   title: string;
-  text: HTMLString;
+  text: prismicT.RichTextField;
   linkText: string | null;
   link?: string;
 };

--- a/common/views/components/PopupDialog/PopupDialog.tsx
+++ b/common/views/components/PopupDialog/PopupDialog.tsx
@@ -17,7 +17,6 @@ import { AppContext } from '../AppContext/AppContext';
 import { PopupDialogPrismicDocument } from '../../../services/prismic/documents';
 import PrismicHtmlBlock from '../PrismicHtmlBlock/PrismicHtmlBlock';
 import { chat, clear } from '@weco/common/icons';
-import { HTMLString } from '../../../services/prismic/types';
 
 type PopupDialogOpenProps = {
   isActive: boolean;
@@ -340,7 +339,7 @@ const PopupDialog: FunctionComponent<Props> = ({ document }: Props) => {
               [font('hnr', 5, { medium: 2, large: 2 })]: true,
             })}
           >
-            <PrismicHtmlBlock html={text as HTMLString} />
+            <PrismicHtmlBlock html={text} />
           </div>
         </Space>
         <PopupDialogCTA

--- a/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock.tsx
+++ b/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock.tsx
@@ -1,16 +1,15 @@
-import { HTMLString } from '../../../services/prismic/types';
 import { linkResolver } from '../../../services/prismic/link-resolver';
 import { JSXFunctionSerializer, PrismicRichText } from '@prismicio/react';
 import * as prismicT from '@prismicio/types';
 
 type Props = {
-  html: HTMLString;
+  html: prismicT.RichTextField;
   htmlSerializer?: JSXFunctionSerializer;
 };
 
 const PrismicHtmlBlock = ({ html, htmlSerializer }: Props) => (
   <PrismicRichText
-    field={html as prismicT.RichTextField}
+    field={html}
     htmlSerializer={htmlSerializer}
     linkResolver={linkResolver}
   />

--- a/common/views/components/VideoEmbed/VideoEmbed.tsx
+++ b/common/views/components/VideoEmbed/VideoEmbed.tsx
@@ -1,11 +1,11 @@
 import { FunctionComponent } from 'react';
 import Caption from '@weco/common/views/components/Caption/Caption';
-import { HTMLString } from '@weco/common/services/prismic/types';
 import { IframeContainer } from '@weco/common/views/components/Iframe/Iframe';
+import * as prismicT from '@prismicio/types';
 
 type Props = {
   embedUrl: string;
-  caption?: HTMLString;
+  caption?: prismicT.RichTextField;
 };
 
 const VideoEmbed: FunctionComponent<Props> = ({ embedUrl, caption }: Props) => (

--- a/content/webapp/__mocks__/events.ts
+++ b/content/webapp/__mocks__/events.ts
@@ -1,6 +1,6 @@
 import { UiEvent } from '@weco/common/model/events';
 import { prismicPageIds } from '@weco/common/services/prismic/hardcoded-id';
-import { HTMLString } from '@weco/common/services/prismic/types';
+import * as prismicT from '@prismicio/types';
 
 const image = {
   contentUrl:
@@ -23,7 +23,7 @@ const location = {
       text: 'We’ll be in the Reading Room on level 2. You can walk up the spiral staircase to the Reading Room door, or take the lift up and then head left from the Library Desk.',
       spans: [],
     },
-  ] as HTMLString,
+  ] as prismicT.RichTextField,
 };
 
 const baseEvent: UiEvent = {

--- a/content/webapp/components/Contributors/Contributor.tsx
+++ b/content/webapp/components/Contributors/Contributor.tsx
@@ -4,7 +4,6 @@ import LinkLabels from '@weco/common/views/components/LinkLabels/LinkLabels';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
 import Space from '@weco/common/views/components/styled/Space';
 import PrismicImage from '../PrismicImage/PrismicImage';
-import { HTMLString } from '@weco/common/services/prismic/types';
 
 const Contributor = ({ contributor, role, description }: ContributorType) => {
   const descriptionToRender = description || contributor.description;
@@ -88,7 +87,7 @@ const Contributor = ({ contributor, role, description }: ContributorType) => {
                 'spaced-text': true,
               })}
             >
-              <PrismicHtmlBlock html={descriptionToRender as HTMLString} />
+              <PrismicHtmlBlock html={descriptionToRender} />
             </Space>
           )}
         </div>

--- a/content/webapp/components/DeprecatedImageList/DeprecatedImageList.tsx
+++ b/content/webapp/components/DeprecatedImageList/DeprecatedImageList.tsx
@@ -1,15 +1,15 @@
 import { CaptionedImage } from '@weco/common/views/components/Images/Images';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
 import { CaptionedImage as CaptionedImageType } from '@weco/common/model/captioned-image';
-import { HTMLString } from '@weco/common/services/prismic/types';
 import { FunctionComponent } from 'react';
+import * as prismicT from '@prismicio/types';
 
 export type Props = {
   items: {
     title: string;
     subtitle: string;
     image: CaptionedImageType;
-    description: HTMLString;
+    description: prismicT.RichTextField;
   }[];
 };
 const DeprecatedImageList: FunctionComponent<Props> = ({ items }: Props) => {

--- a/content/webapp/components/Discussion/Discussion.tsx
+++ b/content/webapp/components/Discussion/Discussion.tsx
@@ -32,7 +32,7 @@ const Discussion: FunctionComponent<Props> = ({ title, text }: Props) => {
     if (isActive) {
       setTextToShow(text);
     } else {
-      setTextToShow(firstPartOfText);
+      setTextToShow(firstPartOfText as [prismicT.RTNode, ...prismicT.RTNode[]]);
     }
   }, [isActive]);
 

--- a/content/webapp/components/Discussion/Discussion.tsx
+++ b/content/webapp/components/Discussion/Discussion.tsx
@@ -1,10 +1,10 @@
 import { FunctionComponent, useState, useEffect, useContext } from 'react';
-import { HTMLString } from '@weco/common/services/prismic/types';
 import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
 import ButtonSolid from '@weco/common/views/components/ButtonSolid/ButtonSolid';
 import styled from 'styled-components';
 import { plus } from '@weco/common/icons';
+import * as prismicT from '@prismicio/types';
 
 const ButtonContainer = styled.div`
   position: absolute;
@@ -15,7 +15,7 @@ const ButtonContainer = styled.div`
 
 export type Props = {
   title: string | null;
-  text: HTMLString;
+  text: prismicT.RichTextField;
 };
 
 const Discussion: FunctionComponent<Props> = ({ title, text }: Props) => {

--- a/content/webapp/components/FeaturedText/FeaturedText.tsx
+++ b/content/webapp/components/FeaturedText/FeaturedText.tsx
@@ -1,10 +1,10 @@
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
-import { HTMLString } from '@weco/common/services/prismic/types';
 import { font, classNames } from '@weco/common/utils/classnames';
 import { JSXFunctionSerializer } from '@prismicio/react';
+import * as prismicT from '@prismicio/types';
 
 type Props = {
-  html: HTMLString;
+  html: prismicT.RichTextField;
   htmlSerializer?: JSXFunctionSerializer;
 };
 

--- a/content/webapp/components/GifVideo/GifVideo.tsx
+++ b/content/webapp/components/GifVideo/GifVideo.tsx
@@ -5,10 +5,10 @@ import { font, classNames } from '@weco/common/utils/classnames';
 import { trackEvent } from '@weco/common/utils/ga';
 import Tasl from '@weco/common/views/components/Tasl/Tasl';
 import Caption from '@weco/common/views/components/Caption/Caption';
-import { HTMLString } from '@weco/common/services/prismic/types';
 import { Tasl as TaslType } from '@weco/common/model/tasl';
 import styled from 'styled-components';
 import { isNotUndefined } from '@weco/common/utils/array';
+import * as prismicT from '@prismicio/types';
 
 const Video = styled.video`
   max-height: 80vh;
@@ -48,7 +48,7 @@ const Text = styled.span.attrs({
 export type Props = {
   playbackRate: number;
   videoUrl: string;
-  caption?: HTMLString;
+  caption?: prismicT.RichTextField;
   tasl?: TaslType;
   autoPlay: boolean;
   loop: boolean;

--- a/content/webapp/components/LayoutPaginatedResults/LayoutPaginatedResults.tsx
+++ b/content/webapp/components/LayoutPaginatedResults/LayoutPaginatedResults.tsx
@@ -7,10 +7,7 @@ import { Period } from '../../types/periods';
 import { Exhibition } from '../../types/exhibitions';
 import { Event } from '../../types/events';
 import { Article } from '../../types/articles';
-import type {
-  PaginatedResults,
-  HTMLString,
-} from '@weco/common/services/prismic/types';
+import { PaginatedResults } from '@weco/common/services/prismic/types';
 import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
 import Space from '@weco/common/views/components/styled/Space';
 import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
@@ -19,6 +16,7 @@ import { FC, ReactElement } from 'react';
 import CardGrid from '../CardGrid/CardGrid';
 import { Book } from '../../types/books';
 import { Guide } from '../../types/guides';
+import * as prismicT from '@prismicio/types';
 
 type PaginatedResultsTypes =
   | PaginatedResults<Exhibition>
@@ -29,7 +27,7 @@ type PaginatedResultsTypes =
 
 type Props = {
   title: string;
-  description?: HTMLString;
+  description?: prismicT.RichTextField;
   paginationRoot: string;
   paginatedResults: PaginatedResultsTypes;
   period?: Period;

--- a/content/webapp/components/MediaObject/MediaObject.tsx
+++ b/content/webapp/components/MediaObject/MediaObject.tsx
@@ -5,13 +5,13 @@ import MediaObjectBase, {
 } from '../MediaObjectBase/MediaObjectBase';
 import { ImageType } from '@weco/common/model/image';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
-import { HTMLString } from '@weco/common/services/prismic/types';
 import styled from 'styled-components';
 import { grid, classNames, font } from '@weco/common/utils/classnames';
+import * as prismicT from '@prismicio/types';
 
 export type Props = {
   title: string;
-  text?: HTMLString;
+  text?: prismicT.RichTextField;
   image: ImageType;
   sizesQueries?: string;
 };

--- a/content/webapp/components/PageHeaderStandfirst/PageHeaderStandfirst.tsx
+++ b/content/webapp/components/PageHeaderStandfirst/PageHeaderStandfirst.tsx
@@ -1,10 +1,12 @@
 import { FunctionComponent } from 'react';
-import { HTMLString } from '@weco/common/services/prismic/types';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
 import { classNames } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
+import * as prismicT from '@prismicio/types';
 
-type Props = { html: HTMLString };
+type Props = {
+  html: prismicT.RichTextField;
+};
 
 const PageHeaderStandfirst: FunctionComponent<Props> = ({ html }: Props) => (
   <Space

--- a/content/webapp/components/Quote/Quote.tsx
+++ b/content/webapp/components/Quote/Quote.tsx
@@ -1,11 +1,11 @@
-import { HTMLString } from '@weco/common/services/prismic/types';
 import { font, classNames } from '@weco/common/utils/classnames';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
 import Space from '@weco/common/views/components/styled/Space';
+import * as prismicT from '@prismicio/types';
 
 export type Props = {
-  text: HTMLString;
-  citation?: HTMLString;
+  text: prismicT.RichTextField;
+  citation?: prismicT.RichTextField;
   isPullOrReview: boolean;
 };
 

--- a/content/webapp/components/SeasonsHeader/SeasonsHeader.tsx
+++ b/content/webapp/components/SeasonsHeader/SeasonsHeader.tsx
@@ -8,7 +8,7 @@ import { FunctionComponent, ComponentProps, ReactElement } from 'react';
 import Space from '@weco/common/views/components/styled/Space';
 import PageHeaderStandfirst from '../PageHeaderStandfirst/PageHeaderStandfirst';
 import styled from 'styled-components';
-import { HTMLString } from '@weco/common/services/prismic/types';
+import * as prismicT from '@prismicio/types';
 import DateRange from '@weco/common/views/components/DateRange/DateRange';
 
 const HeaderWrapper = styled.div`
@@ -23,7 +23,7 @@ type Props = {
   labels: ComponentProps<typeof LabelsList>;
   title: string;
   FeaturedMedia?: ReactElement<typeof UiImage>;
-  standfirst?: HTMLString;
+  standfirst?: prismicT.RichTextField;
   start?: Date;
   end?: Date;
 };

--- a/content/webapp/components/TitledTextList/TitledTextList.tsx
+++ b/content/webapp/components/TitledTextList/TitledTextList.tsx
@@ -1,11 +1,11 @@
 import { FunctionComponent } from 'react';
-import { HTMLString } from '@weco/common/services/prismic/types';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
 import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
 import Space from '@weco/common/views/components/styled/Space';
 import { classNames, font } from '@weco/common/utils/classnames';
 import styled from 'styled-components';
 import { LabelField } from '@weco/common/model/label-field';
+import * as prismicT from '@prismicio/types';
 
 const HeadingLink = styled.a.attrs({
   className: classNames({
@@ -27,7 +27,7 @@ export type Props = {
   items: {
     title?: string;
     link?: string;
-    text?: HTMLString;
+    text?: prismicT.RichTextField;
     label?: LabelField;
   }[];
 };

--- a/content/webapp/pages/event.tsx
+++ b/content/webapp/pages/event.tsx
@@ -458,15 +458,19 @@ const EventPage: NextPage<Props> = ({ jsonEvent }: Props) => {
                 event.interpretations.map(
                   ({ interpretationType, isPrimary, extraInformation }) => {
                     const iconName = camelize(interpretationType.title);
+
+                    const description = [
+                      isPrimary
+                        ? interpretationType.primaryDescription
+                        : interpretationType.description,
+                      extraInformation
+                    ].filter(isNotUndefined);
+
                     return {
                       id: undefined,
                       icon: eventInterpretationIcons[iconName],
                       title: interpretationType.title,
-                      description: (
-                        (isPrimary
-                          ? interpretationType.primaryDescription
-                          : interpretationType.description) || []
-                      ).concat(extraInformation || []),
+                      description,
                     };
                   }
                 )

--- a/content/webapp/services/prismic/transformers/body.ts
+++ b/content/webapp/services/prismic/transformers/body.ts
@@ -46,7 +46,6 @@ import {
 } from '.';
 import { LinkField, RelationField, RichTextField } from '@prismicio/types';
 import { Weight } from '../../../types/generic-content-fields';
-import { HTMLString } from '@weco/common/services/prismic/types';
 
 export function getWeight(weight: string | null): Weight {
   switch (weight) {
@@ -304,7 +303,7 @@ export function transformInfoBlockSlice(
     type: 'infoBlock',
     value: {
       title: asTitle(slice.primary.title),
-      text: slice.primary.text as HTMLString,
+      text: slice.primary.text,
       linkText: slice.primary.linkText,
       link: transformLink(slice.primary.link),
     },
@@ -331,8 +330,8 @@ export function transformQuoteSlice(
     type: 'quote',
     weight: getWeight(slice.slice_label),
     value: {
-      text: slice.primary.text as HTMLString,
-      citation: slice.primary.citation as HTMLString,
+      text: slice.primary.text,
+      citation: slice.primary.citation,
       isPullOrReview:
         slice.slice_label === 'pull' || slice.slice_label === 'review',
     },

--- a/content/webapp/services/prismic/transformers/events.ts
+++ b/content/webapp/services/prismic/transformers/events.ts
@@ -23,7 +23,6 @@ import {
   transformSingleLevelGroup,
   transformTimestamp,
 } from '.';
-import { HTMLString } from '@weco/common/services/prismic/types';
 import { transformSeason } from './seasons';
 import { transformEventSeries } from './event-series';
 import { transformPlace } from './places';
@@ -108,13 +107,11 @@ export function transformEvent(
               abbreviation: interpretation.interpretationType.data?.abbreviation
                 ? asText(interpretation.interpretationType.data?.abbreviation)
                 : undefined,
-              description: interpretation.interpretationType.data
-                ?.description as HTMLString,
-              primaryDescription: interpretation.interpretationType.data
-                ?.primaryDescription as HTMLString,
+              description: interpretation.interpretationType.data?.description,
+              primaryDescription: interpretation.interpretationType.data?.primaryDescription,
             },
             isPrimary: Boolean(interpretation.isPrimary),
-            extraInformation: interpretation.extraInformation as HTMLString,
+            extraInformation: interpretation.extraInformation,
           }
         : undefined
     )
@@ -135,9 +132,7 @@ export function transformEvent(
             title: audience.audience.data?.title
               ? asTitle(audience.audience.data?.title)
               : '',
-            description: audience.audience.data?.description as
-              | HTMLString
-              | undefined,
+            description: audience.audience.data?.description,
           }
         : undefined
     )
@@ -242,7 +237,7 @@ export function transformEvent(
     thirdPartyBooking,
     bookingInformation:
       data.bookingInformation && data.bookingInformation.length > 1
-        ? (data.bookingInformation as HTMLString)
+        ? data.bookingInformation
         : undefined,
     bookingType: transformEventBookingType(document),
     cost: data.cost || undefined,

--- a/content/webapp/services/prismic/transformers/index.ts
+++ b/content/webapp/services/prismic/transformers/index.ts
@@ -59,7 +59,6 @@ import {
 import { transformImage, transformImagePromo } from './images';
 import { Tasl } from '@weco/common/model/tasl';
 import { licenseTypeArray } from '@weco/common/model/license';
-import { HTMLString } from '@weco/common/services/prismic/types';
 import { WithPageFormat } from '../types/pages';
 import { WithEventFormat } from '../types/events';
 import { Format } from '../../../types/format';
@@ -135,8 +134,8 @@ function nonEmpty(field?: RichTextField): field is RichTextField {
   return isNotUndefined(field) && (asText(field) || '').trim() !== '';
 }
 
-export function asRichText(field: RichTextField): HTMLString | undefined {
-  return nonEmpty(field) ? (field as HTMLString) : undefined;
+export function asRichText(field: RichTextField): RichTextField | undefined {
+  return nonEmpty(field) ? field : undefined;
 }
 
 export function asHtml(field?: RichTextField): string | undefined {
@@ -182,7 +181,7 @@ export function transformLabelType(
     id: format.id as ArticleFormatId,
     title: asText(format.data.title),
     description: format.data.description
-      ? (format.data.description as HTMLString)
+      ? format.data.description
       : [],
   };
 }

--- a/content/webapp/services/prismic/transformers/places.ts
+++ b/content/webapp/services/prismic/transformers/places.ts
@@ -1,5 +1,4 @@
 import { Place } from '../../../types/places';
-import { HTMLString } from '@weco/common/services/prismic/types';
 import { transformGenericFields } from '.';
 import { PlacePrismicDocument } from '../types/places';
 
@@ -10,7 +9,7 @@ export function transformPlace(doc: PlacePrismicDocument): Place {
     level: doc.data.level || 0,
     capacity: doc.data.capacity || undefined,
     information: doc.data.locationInformation
-      ? (doc.data.locationInformation as HTMLString)
+      ? doc.data.locationInformation
       : undefined,
   };
 }

--- a/content/webapp/types/books.ts
+++ b/content/webapp/types/books.ts
@@ -1,12 +1,12 @@
 import { GenericContentFields } from './generic-content-fields';
 import { ImageType } from '@weco/common/model/image';
-import { HTMLString } from '@weco/common/services/prismic/types';
+import * as prismicT from '@prismicio/types';
 import { Contributor } from './contributors';
 import { Season } from './seasons';
 
 type Review = {
-  text: HTMLString;
-  citation: HTMLString;
+  text: prismicT.RichTextField;
+  citation: prismicT.RichTextField;
 };
 
 export type Book = GenericContentFields & {

--- a/content/webapp/types/contributors.ts
+++ b/content/webapp/types/contributors.ts
@@ -1,5 +1,5 @@
 import { ImageType } from '@weco/common/model/image';
-import { HTMLString } from '@weco/common/services/prismic/types';
+import * as prismicT from '@prismicio/types';
 
 type SameAs = {
   link: string;
@@ -10,7 +10,7 @@ type Person = {
   type: 'people';
   id: string;
   name?: string;
-  description?: HTMLString;
+  description?: prismicT.RichTextField;
   image: ImageType;
   sameAs: SameAs;
   pronouns?: string;
@@ -20,7 +20,7 @@ type Organisation = {
   type: 'organisations';
   id: string;
   name?: string;
-  description?: HTMLString;
+  description?: prismicT.RichTextField;
   image: ImageType;
   sameAs: SameAs;
 };
@@ -34,5 +34,5 @@ type ContributorRole = {
 export type Contributor = {
   contributor: Person | Organisation;
   role?: ContributorRole;
-  description?: HTMLString;
+  description?: prismicT.RichTextField;
 };

--- a/content/webapp/types/events.ts
+++ b/content/webapp/types/events.ts
@@ -6,7 +6,7 @@ import { LabelField } from '@weco/common/model/label-field';
 import { Place } from './places';
 import { Season } from './seasons';
 import { Label } from '@weco/common/model/labels';
-import { HTMLString } from '@weco/common/services/prismic/types';
+import * as prismicT from '@prismicio/types';
 
 export type DateTimeRange = {
   startDateTime: Date;
@@ -28,14 +28,14 @@ type EventSeries = {
 type InterpretationType = {
   id: string;
   title: string;
-  description?: HTMLString;
-  primaryDescription?: HTMLString;
+  description?: prismicT.RichTextField;
+  primaryDescription?: prismicT.RichTextField;
 };
 
 export type Interpretation = {
   interpretationType: InterpretationType;
   isPrimary: boolean;
-  extraInformation?: HTMLString;
+  extraInformation?: prismicT.RichTextField;
 };
 
 export type Team = {

--- a/content/webapp/types/events.ts
+++ b/content/webapp/types/events.ts
@@ -25,7 +25,7 @@ type EventSeries = {
 };
 
 // E.g. 'British sign language interpreted' | 'Audio described' | 'Speech-to-Text';
-type InterpretationType = {
+export type InterpretationType = {
   id: string;
   title: string;
   description?: prismicT.RichTextField;
@@ -49,7 +49,7 @@ export type Team = {
 export type Audience = {
   id: string;
   title: string;
-  description?: HTMLString;
+  description?: prismicT.RichTextField;
 };
 
 export type DateRange = {
@@ -81,7 +81,7 @@ export type Event = GenericContentFields & {
   interpretations: Interpretation[];
   audiences: Audience[];
   policies: LabelField[];
-  bookingInformation?: HTMLString;
+  bookingInformation?: prismicT.RichTextField;
   cost?: string;
   bookingType?: string;
   thirdPartyBooking?: ThirdPartyBooking;

--- a/content/webapp/types/exhibitions.ts
+++ b/content/webapp/types/exhibitions.ts
@@ -6,7 +6,7 @@ import { Place } from './places';
 import { GenericContentFields } from './generic-content-fields';
 import { Resource } from './resource';
 import { Season } from './seasons';
-import { HTMLString } from '@weco/common/services/prismic/types';
+import * as prismicT from '@prismicio/types';
 
 // e.g. 'Permanent'
 export type ExhibitionFormat = {
@@ -23,8 +23,8 @@ export type Exhibition = GenericContentFields & {
   end?: Date;
   isPermanent: boolean;
   statusOverride?: string;
-  bslInfo?: HTMLString;
-  audioDescriptionInfo?: HTMLString;
+  bslInfo?: prismicT.RichTextField;
+  audioDescriptionInfo?: prismicT.RichTextField;
   place?: Place;
   exhibits: Exhibit[];
   resources: Resource[];

--- a/content/webapp/types/generic-content-fields.ts
+++ b/content/webapp/types/generic-content-fields.ts
@@ -2,7 +2,7 @@ import { ImagePromo } from './image-promo';
 import { Picture } from '@weco/common/model/picture';
 import { ImageType } from '@weco/common/model/image';
 import { Label } from '@weco/common/model/labels';
-import { HTMLString } from '@weco/common/services/prismic/types';
+import * as prismicT from '@prismicio/types';
 
 export type Weight = 'default' | 'featured' | 'standalone' | 'supporting';
 
@@ -20,7 +20,7 @@ export type GenericContentFields = {
   title: string;
   promo?: ImagePromo;
   body: BodyType;
-  standfirst?: HTMLString;
+  standfirst?: prismicT.RichTextField;
   promoText?: string;
   promoImage?: Picture;
   image?: ImageType;

--- a/content/webapp/types/media-object.ts
+++ b/content/webapp/types/media-object.ts
@@ -1,8 +1,8 @@
-import { HTMLString } from '@weco/common/services/prismic/types';
+import * as prismicT from '@prismicio/types';
 import { ImageType } from '@weco/common/model/image';
 
 export type MediaObjectType = {
   title: string | null;
-  text: HTMLString | null;
+  text: prismicT.RichTextField | null;
   image: ImageType | null;
 };

--- a/content/webapp/types/places.ts
+++ b/content/webapp/types/places.ts
@@ -1,10 +1,10 @@
 import { GenericContentFields } from './generic-content-fields';
-import { HTMLString } from '@weco/common/services/prismic/types';
+import * as prismicT from '@prismicio/types';
 
 export type Place = GenericContentFields & {
   id: string;
   title: string;
   level: number;
   capacity?: number;
-  information?: HTMLString;
+  information?: prismicT.RichTextField;
 };

--- a/content/webapp/types/text.ts
+++ b/content/webapp/types/text.ts
@@ -1,5 +1,7 @@
+import * as prismicT from '@prismicio/types';
+
 export type FeaturedText = {
   type: 'text';
   weight: 'featured';
-  value: any[];
+  value: prismicT.RichTextField;
 };


### PR DESCRIPTION
Follows #7765; part of #7752. We end up casting to/from our bespoke type; we might as well ditch it and hopefully save some bytes.