### PR TITLE
Use a custom agent that keeps the catalogue API connection alive

### DIFF
--- a/catalogue/webapp/components/ArchiveTree/ArchiveTree.tsx
+++ b/catalogue/webapp/components/ArchiveTree/ArchiveTree.tsx
@@ -9,7 +9,7 @@ import {
 import flattenDeep from 'lodash.flattendeep';
 import styled from 'styled-components';
 import { classNames, font } from '@weco/common/utils/classnames';
-import { getWork } from '../../services/catalogue/works';
+import { getWorkClientSide } from '../../services/catalogue/works';
 import WorkLink from '@weco/common/views/components/WorkLink/WorkLink';
 import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
 import Space from '@weco/common/views/components/styled/Space';
@@ -270,19 +270,14 @@ function createNodeFromWork({
   };
 }
 
-async function getChildren({
-  item,
-  toggles,
-}: {
-  item: UiTreeNode;
-  toggles: Toggles;
-}): Promise<UiTree> {
-  const work = await getWork({ id: item.work.id, toggles });
+async function getChildren(workId: string): Promise<UiTree> {
+  const work = await getWorkClientSide(workId);
+
   return work.type !== 'Error' && work.type !== 'Redirect' && work.parts
     ? work.parts.map(part => ({
         work: part,
         openStatus: false,
-        parentId: item.work.id,
+        parentId: workId,
       }))
     : [];
 }
@@ -368,10 +363,7 @@ async function createArchiveTree({
       const parentId = ancestorArray?.[i - 1]?.id;
       // We add each ancestor and its siblings to the tree
       if (!parentId) {
-        const siblings = await getSiblings({
-          id: curr.id,
-          toggles,
-        });
+        const siblings = await getSiblings({ id: curr.id });
         return siblings;
       }
       if (work.id === curr.id) {
@@ -388,7 +380,6 @@ async function createArchiveTree({
           // For everything else we need more data before creating an array of curr and its siblings
           // This becomes the value of the previous node's children property
           id: curr.id,
-          toggles,
         });
         return updateChildren({
           tree: await acc,
@@ -403,15 +394,13 @@ async function createArchiveTree({
 }
 
 async function getSiblings({
-  id, // id of work to get
-  toggles,
+  id,
   openStatusOverride = false,
 }: {
   id: string;
-  toggles: Toggles;
   openStatusOverride?: boolean;
 }): Promise<UiTreeNode[]> {
-  const currWork = await getWork({ id, toggles });
+  const currWork = await getWorkClientSide(id);
   if (currWork.type !== 'Error' && currWork.type !== 'Redirect') {
     return createSiblingsArray({
       work: {
@@ -459,10 +448,8 @@ async function expandTree({
   setArchiveTree: (tree: UiTree) => void;
   archiveTree: UiTree;
 }) {
-  const children = await getChildren({
-    item: item,
-    toggles,
-  });
+  const children = await getChildren(item.work.id);
+  
   setArchiveTree(
     updateChildren({
       tree: archiveTree,

--- a/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
+++ b/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
@@ -14,7 +14,7 @@ import ButtonSolidLink from '@weco/common/views/components/ButtonSolidLink/Butto
 import Image from '@weco/common/views/components/Image/Image';
 import License from '../License/License';
 import { Image as ImageType, Work } from '@weco/common/model/catalogue';
-import { getWork } from '../../services/catalogue/works';
+import { getWorkClientSide } from '../../services/catalogue/works';
 import {
   useEffect,
   useState,
@@ -226,7 +226,7 @@ const ExpandedImage: FunctionComponent<Props> = ({
 
   useEffect(() => {
     const fetchDetailedWork = async () => {
-      const res = await getWork({ id: workId, toggles });
+      const res = await getWorkClientSide(workId);
       if (res.type === 'Work') {
         setDetailedWork(res);
       }

--- a/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
+++ b/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
@@ -13,6 +13,7 @@ import {
   itemIsRequestable,
   itemIsTemporarilyUnavailable,
 } from '../../utils/requesting';
+import { getWorkItemsClientSide } from 'services/catalogue/works';
 
 type Props = {
   work: Work;
@@ -96,11 +97,7 @@ const PhysicalItems: FunctionComponent<Props> = ({
   useAbortSignalEffect(
     signal => {
       const updateItemsStatus = async () => {
-        const itemsResponse = await fetch(`/api/works/items/${work.id}`, {
-          signal,
-          credentials: 'same-origin',
-        });
-        const items = await itemsResponse.json();
+        const items = await getWorkItemsClientSide(work.id, signal);
 
         if (!isCatalogueApiError(items)) {
           setPhysicalItems(getItemsWithPhysicalLocation(items.results));

--- a/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
+++ b/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
@@ -80,7 +80,6 @@ const PhysicalItems: FunctionComponent<Props> = ({
           `/account/api/users/me/item-requests`,
           {
             signal,
-            credentials: 'same-origin',
           }
         );
         const holds = await holdsResponse.json();
@@ -99,6 +98,7 @@ const PhysicalItems: FunctionComponent<Props> = ({
       const updateItemsStatus = async () => {
         const itemsResponse = await fetch(`/api/works/items/${work.id}`, {
           signal,
+          credentials: 'same-origin',
         });
         const items = await itemsResponse.json();
 

--- a/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
+++ b/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
@@ -80,6 +80,7 @@ const PhysicalItems: FunctionComponent<Props> = ({
           `/account/api/users/me/item-requests`,
           {
             signal,
+            credentials: 'same-origin',
           }
         );
         const holds = await holdsResponse.json();

--- a/catalogue/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.tsx
+++ b/catalogue/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.tsx
@@ -36,7 +36,7 @@ const VisuallySimilarImagesFromApi: FunctionComponent<Props> = ({
 
   useEffect(() => {
     const fetchVisuallySimilarImages = async () => {
-      const fullImage = await getVisuallySimilarImagesClientSide({ id: originalId, toggles });
+      const fullImage = await getVisuallySimilarImagesClientSide(originalId);
 
       if (fullImage && fullImage.type === 'Image') {
         setSimilarImages(fullImage.visuallySimilar || []);

--- a/catalogue/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.tsx
+++ b/catalogue/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.tsx
@@ -3,7 +3,7 @@ import Image from '@weco/common/views/components/Image/Image';
 import { Image as ImageType } from '@weco/common/model/catalogue';
 import { FunctionComponent, useEffect, useState } from 'react';
 import styled from 'styled-components';
-import { getImage } from '../../services/catalogue/images';
+import { getImage, getVisuallySimilarImagesClientSide } from '../../services/catalogue/images';
 import Space from '@weco/common/views/components/styled/Space';
 import { useToggles } from '@weco/common/server-data/Context';
 
@@ -36,15 +36,13 @@ const VisuallySimilarImagesFromApi: FunctionComponent<Props> = ({
 
   useEffect(() => {
     const fetchVisuallySimilarImages = async () => {
-      const fullImage = await getImage({
-        id: originalId,
-        toggles,
-        include: ['visuallySimilar'],
-      });
-      if (fullImage.type === 'Image') {
+      const fullImage = await getVisuallySimilarImagesClientSide({ id: originalId, toggles });
+
+      if (fullImage && fullImage.type === 'Image') {
         setSimilarImages(fullImage.visuallySimilar || []);
       }
     };
+
     fetchVisuallySimilarImages();
   }, [originalId]);
   return similarImages.length === 0 ? null : (

--- a/catalogue/webapp/pages/api/visuallySimilarImages/[imageId].tsx
+++ b/catalogue/webapp/pages/api/visuallySimilarImages/[imageId].tsx
@@ -2,6 +2,7 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import { CatalogueApiError } from '@weco/common/model/catalogue';
 import hasOwnProperty from '@weco/common/utils/has-own-property';
 import { getImage } from 'services/catalogue/images';
+import { getTogglesFromContext } from '@weco/common/server-data/toggles';
 
 export function isCatalogueApiError(response: any): response is CatalogueApiError {
   return Boolean(hasOwnProperty(response, 'type') && response.type === 'Error');
@@ -14,15 +15,21 @@ const VisuallySimilarImagesApi = async (
   const { imageId } = req.query;
   const id = Array.isArray(imageId) ? imageId[0] : imageId;
 
-  // The only toggle we care about is stagingApi.  We get the cookies from
-  // the user's session by passing { credentials: 'same-origin' } in the fetch
-  // request, then we construct this toggle block directly.
-  //
-  // It's a bit of a hack and we could do this better, but it works well enough
-  // and doesn't introduce too much complexity.
-  const toggles = {
-    'stagingApi': req.cookies['toggle_stagingApi'] === 'true',
+  // As the only toggle we care about here for now is the stagingApi
+  // this is a mega hack to get this working so we can remove toggles from the query
+  // TODO : get toggles working here
+  const togglesResp = {
+    toggles: [
+      {
+        id: 'stagingApi',
+        title: 'Staging API',
+        defaultValue: false,
+        description: 'Use the staging catalogue API',
+      },
+    ],
+    tests: [],
   };
+  const toggles = getTogglesFromContext(togglesResp, { req });
 
   const response = await getImage({
     id,

--- a/catalogue/webapp/pages/api/visuallySimilarImages/[imageId].tsx
+++ b/catalogue/webapp/pages/api/visuallySimilarImages/[imageId].tsx
@@ -1,0 +1,48 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { CatalogueApiError } from '@weco/common/model/catalogue';
+import hasOwnProperty from '@weco/common/utils/has-own-property';
+import { getImage } from 'services/catalogue/images';
+
+export function isCatalogueApiError(response: any): response is CatalogueApiError {
+  return Boolean(hasOwnProperty(response, 'type') && response.type === 'Error');
+}
+
+const VisuallySimilarImagesApi = async (
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> => {
+  const { imageId } = req.query;
+  const id = Array.isArray(imageId) ? imageId[0] : imageId;
+
+  // The only toggle we care about is stagingApi.  We get the cookies from
+  // the user's session by passing { credentials: 'same-origin' } in the fetch
+  // request, then we construct this toggle block directly.
+  //
+  // It's a bit of a hack and we could do this better, but it works well enough
+  // and doesn't introduce too much complexity.
+  const toggles = {
+    'stagingApi': req.cookies['toggle_stagingApi'] === 'true',
+  };
+
+  const response = await getImage({
+    id,
+    toggles: toggles,
+    include: ['visuallySimilar'],
+  });
+
+  res.setHeader('Content-Type', 'application/json');
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader(
+    'Cache-Control',
+    'private, no-cache, no-store, max-age=0, must-revalidate'
+  );
+
+  if (isCatalogueApiError(response)) {
+    res.status(response.httpStatus);
+  } else {
+    res.status(200);
+  }
+  res.json(response);
+};
+
+export default VisuallySimilarImagesApi;

--- a/catalogue/webapp/pages/api/visuallySimilarImages/[imageId].tsx
+++ b/catalogue/webapp/pages/api/visuallySimilarImages/[imageId].tsx
@@ -33,7 +33,7 @@ const VisuallySimilarImagesApi = async (
 
   const response = await getImage({
     id,
-    toggles: toggles,
+    toggles,
     include: ['visuallySimilar'],
   });
 

--- a/catalogue/webapp/pages/api/works/[workId].tsx
+++ b/catalogue/webapp/pages/api/works/[workId].tsx
@@ -1,0 +1,51 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { CatalogueApiError } from '@weco/common/model/catalogue';
+import hasOwnProperty from '@weco/common/utils/has-own-property';
+import { getTogglesFromContext } from '@weco/common/server-data/toggles';
+import { getWork } from 'services/catalogue/works';
+
+export function isCatalogueApiError(response: any): response is CatalogueApiError {
+  return Boolean(hasOwnProperty(response, 'type') && response.type === 'Error');
+}
+
+const WorksApi = async (
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> => {
+  const { workId } = req.query;
+  const id = Array.isArray(workId) ? workId[0] : workId;
+
+  // As the only toggle we care about here for now is the stagingApi
+  // this is a mega hack to get this working so we can remove toggles from the query
+  // TODO : get toggles working here
+  const togglesResp = {
+    toggles: [
+      {
+        id: 'stagingApi',
+        title: 'Staging API',
+        defaultValue: false,
+        description: 'Use the staging catalogue API',
+      },
+    ],
+    tests: [],
+  };
+  const toggles = getTogglesFromContext(togglesResp, { req });
+
+  const response = await getWork({ id, toggles });
+
+  res.setHeader('Content-Type', 'application/json');
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader(
+    'Cache-Control',
+    'private, no-cache, no-store, max-age=0, must-revalidate'
+  );
+
+  if (isCatalogueApiError(response)) {
+    res.status(response.httpStatus);
+  } else {
+    res.status(200);
+  }
+  res.json(response);
+};
+
+export default WorksApi;

--- a/catalogue/webapp/pages/api/works/items/[workId].tsx
+++ b/catalogue/webapp/pages/api/works/items/[workId].tsx
@@ -5,7 +5,7 @@ import {
   rootUris,
   globalApiOptions,
   GlobalApiOptions,
-} from '../../../../services/catalogue/common';
+} from '../../../../services/catalogue';
 import hasOwnProperty from '@weco/common/utils/has-own-property';
 import { Toggles } from '@weco/toggles';
 import { getTogglesFromContext } from '@weco/common/server-data/toggles';

--- a/catalogue/webapp/services/catalogue/images.ts
+++ b/catalogue/webapp/services/catalogue/images.ts
@@ -97,3 +97,22 @@ export async function getImage({
     return catalogueApiError();
   }
 }
+
+export async function getVisuallySimilarImagesClientSide({
+  id, toggles
+}: { id: string, toggles: Toggles }): Promise<Image | undefined> {
+  // Using the 'params' parameter here is a bit of a hack; it means we
+  // know the CloudFront distribution will include this parameter in
+  // the cache key.
+  const urlSearchParams = new URLSearchParams();
+  urlSearchParams.set('params', JSON.stringify(toggles));
+
+  const response = await fetch(`/api/visuallySimilarImages/${id}?${urlSearchParams.toString()}`, {
+    credentials: 'same-origin'
+  });
+
+  if (response.ok) {
+    const image: Image = await response.json();
+    return image;
+  }
+}

--- a/catalogue/webapp/services/catalogue/images.ts
+++ b/catalogue/webapp/services/catalogue/images.ts
@@ -98,9 +98,13 @@ export async function getImage({
   }
 }
 
-export async function getVisuallySimilarImagesClientSide(id: string): Promise<Image | undefined> {
+export async function getVisuallySimilarImagesClientSide(
+  id: string
+): Promise<Image | undefined> {
+  // passing credentials: 'same-origin' ensures we pass the cookies to
+  // the API; in particular the toggle cookies
   const response = await fetch(`/api/visuallySimilarImages/${id}`, {
-    credentials: 'same-origin'
+    credentials: 'same-origin',
   });
 
   if (response.ok) {

--- a/catalogue/webapp/services/catalogue/images.ts
+++ b/catalogue/webapp/services/catalogue/images.ts
@@ -98,16 +98,8 @@ export async function getImage({
   }
 }
 
-export async function getVisuallySimilarImagesClientSide({
-  id, toggles
-}: { id: string, toggles: Toggles }): Promise<Image | undefined> {
-  // Using the 'params' parameter here is a bit of a hack; it means we
-  // know the CloudFront distribution will include this parameter in
-  // the cache key.
-  const urlSearchParams = new URLSearchParams();
-  urlSearchParams.set('params', JSON.stringify(toggles));
-
-  const response = await fetch(`/api/visuallySimilarImages/${id}?${urlSearchParams.toString()}`, {
+export async function getVisuallySimilarImagesClientSide(id: string): Promise<Image | undefined> {
+  const response = await fetch(`/api/visuallySimilarImages/${id}`, {
     credentials: 'same-origin'
   });
 

--- a/catalogue/webapp/services/catalogue/images.ts
+++ b/catalogue/webapp/services/catalogue/images.ts
@@ -10,7 +10,8 @@ import {
   catalogueApiError,
   notFound,
   looksLikeCanonicalId,
-} from './common';
+  catalogueFetch,
+} from '.';
 import { Toggles } from '@weco/toggles';
 import { propsToQuery } from '@weco/common/utils/routes';
 
@@ -54,7 +55,7 @@ export async function getImages({
   }/v2/images?${searchParams.toString()}`;
 
   try {
-    const res = await fetch(url);
+    const res = await catalogueFetch(url);
     const json = await res.json();
 
     return json;
@@ -84,7 +85,7 @@ export async function getImage({
     rootUris[apiOptions.env]
   }/v2/images/${id}?${searchParams.toString()}`;
 
-  const res = await fetch(url);
+  const res = await catalogueFetch(url);
 
   if (res.status === 404) {
     return notFound();

--- a/catalogue/webapp/services/catalogue/index.ts
+++ b/catalogue/webapp/services/catalogue/index.ts
@@ -1,7 +1,5 @@
 import { CatalogueApiError } from '@weco/common/model/catalogue';
 import { Toggles } from '@weco/toggles';
-import { Agent } from 'https';
-import fetch, { Response } from 'node-fetch';
 
 export const rootUris = {
   prod: 'https://api.wellcomecollection.org/catalogue',
@@ -34,7 +32,7 @@ export const catalogueApiError = (): CatalogueApiError => ({
 });
 
 // Because we know we'll be making repeated requests to the catalogue API,
-// this custom agent will keep the socket open between individual requests,
+// this header should keep the socket open between individual requests,
 // rather than reconnecting each time.
 //
 // I'm hoping this will reduce the trickle of errors like:
@@ -42,20 +40,11 @@ export const catalogueApiError = (): CatalogueApiError => ({
 //      FetchError: request to https://api.wellcomecollection.org/catalogue/v2/works/...
 //      failed, reason: read ECONNRESET
 //
-// See https://nodejs.org/api/http.html#http_new_agent_options
-//
-const catalogueApiAgent = new Agent({ keepAlive: true });
-
 export const catalogueFetch = (
   url: string,
   options?: Record<string, string>
 ): Promise<Response> => {
-  const fetchOptions = {
-    ...options,
-    agent: catalogueApiAgent,
-  };
-
-  return fetch(url, fetchOptions);
+  return fetch(url, { ...options, headers: { 'connection': 'keep-alive' }});
 };
 
 // Returns true if a string is plausibly a canonical ID, false otherwise.

--- a/catalogue/webapp/services/catalogue/works.ts
+++ b/catalogue/webapp/services/catalogue/works.ts
@@ -103,6 +103,7 @@ export async function getWork({
   }
 
   const apiOptions = globalApiOptions(toggles);
+  console.log(`@@AWLC apiOptionsm for ${id}: ${JSON.stringify(apiOptions)}`);
 
   const params = {
     include: workIncludes,
@@ -177,4 +178,14 @@ export async function getCanvasOcr(
       return missingAltTextMessage;
     }
   }
+}
+
+
+export async function getWorkClientSide(id: string): Promise<WorkResponse> {
+  const response = await fetch(`/api/works/${id}`, {
+    credentials: 'same-origin'
+  });
+
+  const work: WorkResponse = await response.json();
+  return work;
 }

--- a/catalogue/webapp/services/catalogue/works.ts
+++ b/catalogue/webapp/services/catalogue/works.ts
@@ -13,7 +13,8 @@ import {
   looksLikeCanonicalId,
   rootUris,
   notFound,
-} from './common';
+  catalogueFetch,
+} from '.';
 import { Toggles } from '@weco/toggles';
 import { propsToQuery } from '@weco/common/utils/routes';
 
@@ -82,7 +83,7 @@ export async function getWorks({
   const url = `${rootUris[apiOptions.env]}/v2/works?${searchParams}`;
 
   try {
-    const res = await fetch(url);
+    const res = await catalogueFetch(url);
     const json = await res.json();
 
     return json;
@@ -110,7 +111,7 @@ export async function getWork({
   const searchParams = new URLSearchParams(propsToQuery(params)).toString();
   const url = `${rootUris[apiOptions.env]}/v2/works/${id}?${searchParams}`;
 
-  const res = await fetch(url, { redirect: 'manual' });
+  const res = await catalogueFetch(url, { redirect: 'manual' });
 
   // When records from Miro have been merged with Sierra data, we redirect the
   // latter to the former. This would happen quietly on the API request, but we

--- a/catalogue/webapp/services/catalogue/works.ts
+++ b/catalogue/webapp/services/catalogue/works.ts
@@ -2,6 +2,7 @@ import {
   CatalogueApiError,
   CatalogueApiRedirect,
   CatalogueResultsList,
+  ItemsList,
   Work,
 } from '@weco/common/model/catalogue';
 import { IIIFCanvas } from '../../model/iiif';
@@ -17,6 +18,7 @@ import {
 } from '.';
 import { Toggles } from '@weco/toggles';
 import { propsToQuery } from '@weco/common/utils/routes';
+import { PaginatedResults } from '@weco/common/services/prismic/types';
 
 type GetWorkProps = {
   id: string;
@@ -180,12 +182,28 @@ export async function getCanvasOcr(
   }
 }
 
-
-export async function getWorkClientSide(id: string): Promise<WorkResponse> {
-  const response = await fetch(`/api/works/${id}`, {
-    credentials: 'same-origin'
+export async function getWorkClientSide(workId: string): Promise<WorkResponse> {
+  // passing credentials: 'same-origin' ensures we pass the cookies to
+  // the API; in particular the toggle cookies
+  const response = await fetch(`/api/works/${workId}`, {
+    credentials: 'same-origin',
   });
 
   const work: WorkResponse = await response.json();
   return work;
+}
+
+export async function getWorkItemsClientSide(
+  workId: string,
+  signal: AbortSignal | null
+): Promise<ItemsList | CatalogueApiError> {
+  // passing credentials: 'same-origin' ensures we pass the cookies to
+  // the API; in particular the toggle cookies
+  const response = await fetch(`/api/works/items/${workId}`, {
+    signal,
+    credentials: 'same-origin',
+  });
+
+  const items = await response.json();
+  return items;
 }

--- a/catalogue/webapp/services/catalogue/works.ts
+++ b/catalogue/webapp/services/catalogue/works.ts
@@ -105,7 +105,6 @@ export async function getWork({
   }
 
   const apiOptions = globalApiOptions(toggles);
-  console.log(`@@AWLC apiOptionsm for ${id}: ${JSON.stringify(apiOptions)}`);
 
   const params = {
     include: workIncludes,


### PR DESCRIPTION
We're seeing a steady trickle of reset connections between the front-end and the catalogue API; since we know we're always going to be talking to the API, let's try holding the connection open rather than recreating it on every request. Fingers crossed this makes it more reliable!

We do fetch catalogue data asynchronously on the front-end, when we find visually similar images on a work – for that, there's a new endpoint `/api/visuallySimilarImages/[imageId]`. My guess is that this will be beneficial for the user (🤞):

* All connections to the catalogue API come from the server, which can use the keep-alive'd connection
* All connections from the browser go to the front-end app, rather than opening separate connections to the front-end and the catalogue API
* We can toss a bunch of code out of the bundle that's unneeded