### PR TITLE
change default value of enableRequesting

### DIFF
--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -21,7 +21,7 @@ const toggles = {
       title: 'Enables login and requesting functionality',
       description:
         'Puts login links in the headers and enables requesting functionality on works pages ',
-      defaultValue: false,
+      defaultValue: true,
     },
     {
       id: 'enablePickUpDate',


### PR DESCRIPTION
This doesn't actually do anything. The way to update a default value of a toggle is to [use a script](https://github.com/wellcomecollection/wellcomecollection.org/tree/main/toggles#deployment).

I'm just changing this to keep it consistent with what is live.
