### PR TITLE
Opening times

### DIFF
--- a/catalogue/webapp/components/ItemRequestModal/ItemRequestModal.tsx
+++ b/catalogue/webapp/components/ItemRequestModal/ItemRequestModal.tsx
@@ -7,6 +7,7 @@ import {
 } from '@weco/common/model/opening-hours';
 import { london, londonFromFormat } from '@weco/common/utils/format-date';
 import { collectionVenueId } from '@weco/common/services/prismic/hardcoded-id';
+import { transformCollectionVenues } from '@weco/common/services/prismic/transformers/collection-venues';
 import {
   determineNextAvailableDate,
   convertOpeningHoursDayToDayNumber,
@@ -15,10 +16,7 @@ import {
   isRequestableDate,
 } from '@weco/catalogue/utils/dates';
 import { usePrismicData, useToggles } from '@weco/common/server-data/Context';
-import {
-  parseCollectionVenues,
-  getVenueById,
-} from '@weco/common/services/prismic/opening-times';
+import { getVenueById } from '@weco/common/services/prismic/opening-times';
 import Modal from '@weco/common/views/components/Modal/Modal';
 import ButtonSolidLink from '@weco/common/views/components/ButtonSolidLink/ButtonSolidLink';
 import ButtonSolid from '@weco/common/views/components/ButtonSolid/ButtonSolid';
@@ -158,7 +156,7 @@ const RequestDialog: FC<RequestDialogProps> = ({
   // We get the regular and exceptional days on which the library is closed from Prismic data,
   // so we can make these unavailable in the calendar.
   const { collectionVenues } = usePrismicData();
-  const venues = parseCollectionVenues(collectionVenues);
+  const venues = transformCollectionVenues(collectionVenues);
   const libraryVenue = getVenueById(venues, collectionVenueId.libraries.id);
   const regularLibraryOpeningTimes = libraryVenue?.openingHours.regular || [];
   const regularClosedDays = findClosedDays(regularLibraryOpeningTimes).map(

--- a/common/services/prismic/opening-times.ts
+++ b/common/services/prismic/opening-times.ts
@@ -7,14 +7,11 @@ import type {
   ExceptionalPeriod,
   OverrideDate,
   Venue,
-  OpeningHours,
   OpeningHoursDay,
   ExceptionalOpeningHoursDay,
-  SpecialOpeningHours,
 } from '../../model/opening-hours';
 import { CollectionVenuePrismicDocument } from '../../services/prismic/documents';
 import { Moment } from 'moment';
-import { objToJsonLd } from '../../utils/json-ld';
 import { isNotUndefined } from '../../utils/array';
 import * as prismicH from 'prismic-helpers-beta';
 
@@ -364,40 +361,4 @@ export function getTodaysVenueHours(
     venue.openingHours.regular &&
     venue.openingHours.regular.find(i => i.dayOfWeek === todayString);
   return exceptionalOpeningHours || regularOpeningHours;
-}
-
-export function openingHoursToOpeningHoursSpecification(
-  openingHours: OpeningHours | undefined
-): {
-  openingHoursSpecification: OpeningHoursDay[];
-  specialOpeningHoursSpecification: SpecialOpeningHours[];
-} {
-  return {
-    openingHoursSpecification: openingHours?.regular
-      ? openingHours.regular.map(openingHoursDay => {
-          const specObject = objToJsonLd(
-            {
-              dayOfWeek: openingHoursDay.dayOfWeek,
-              opens: openingHoursDay.opens,
-              closes: openingHoursDay.closes,
-            },
-            'OpeningHoursSpecification',
-            false
-          );
-          delete specObject.note;
-          return specObject;
-        })
-      : [],
-    specialOpeningHoursSpecification: openingHours?.exceptional
-      ? openingHours.exceptional.map(openingHoursDate => {
-          const specObject = {
-            opens: openingHoursDate.opens,
-            closes: openingHoursDate.closes,
-            validFrom: openingHoursDate.overrideDate?.format('DD MMMM YYYY'),
-            validThrough: openingHoursDate.overrideDate?.format('DD MMMM YYYY'),
-          };
-          return objToJsonLd(specObject, 'OpeningHoursSpecification', false);
-        })
-      : [],
-  };
 }

--- a/common/services/prismic/opening-times.ts
+++ b/common/services/prismic/opening-times.ts
@@ -261,22 +261,6 @@ export function createRegularDay(
   };
 }
 
-export function convertJsonDateStringsToMoment(jsonVenue: Venue): Venue {
-  const exceptionalMoment =
-    jsonVenue.openingHours.exceptional &&
-    jsonVenue.openingHours.exceptional.map(e => ({
-      ...e,
-      overrideDate: london(e.overrideDate),
-    }));
-  return {
-    ...jsonVenue,
-    openingHours: {
-      regular: jsonVenue.openingHours.regular,
-      exceptional: exceptionalMoment,
-    },
-  };
-}
-
 export function parseCollectionVenue(
   venue: CollectionVenuePrismicDocument
 ): Venue {

--- a/common/services/prismic/opening-times.ts
+++ b/common/services/prismic/opening-times.ts
@@ -1,8 +1,6 @@
-import { Query } from '@prismicio/types';
 import { london } from '../../utils/format-date';
 import groupBy from 'lodash.groupby';
 import type {
-  Day,
   OverrideType,
   ExceptionalPeriod,
   OverrideDate,
@@ -10,10 +8,8 @@ import type {
   OpeningHoursDay,
   ExceptionalOpeningHoursDay,
 } from '../../model/opening-hours';
-import { CollectionVenuePrismicDocument } from '../../services/prismic/documents';
 import { Moment } from 'moment';
 import { isNotUndefined } from '../../utils/array';
-import * as prismicH from 'prismic-helpers-beta';
 
 export function exceptionalOpeningDates(venues: Venue[]): OverrideDate[] {
   return venues
@@ -240,95 +236,9 @@ export function getUpcomingExceptionalPeriods(
   return nextUpcomingPeriods;
 }
 
-export function createRegularDay(
-  day: Day,
-  venue: CollectionVenuePrismicDocument
-): OpeningHoursDay {
-  const { data } = venue;
-  const lowercaseDay = day.toLowerCase();
-  const start = data && data[lowercaseDay][0].startDateTime;
-  const end = data && data[lowercaseDay][0].endDateTime;
-  const isClosed = !start;
-  // If there is no start time from prismic, then we set both opens and closes to 00:00.
-  // This is necessary for the json-ld schema data, so Google knows when the venues are closed.
-  // See https://developers.google.com/search/docs/advanced/structured-data/local-business#business-hours (All-day hours tab)
-  // "To show a business is closed all day, set both opens and closes properties to '00:00'""
-  return {
-    dayOfWeek: day,
-    opens: start ? london(start).format('HH:mm') : '00:00',
-    closes: start && end ? london(end).format('HH:mm') : '00:00',
-    isClosed,
-  };
-}
-
-export function parseCollectionVenue(
-  venue: CollectionVenuePrismicDocument
-): Venue {
-  const data = venue.data;
-  const exceptionalOpeningHours = data.modifiedDayOpeningTimes
-    ? data.modifiedDayOpeningTimes
-        .filter(modified => modified.overrideDate)
-        .map(modified => {
-          const start = modified.startDateTime;
-          const end = modified.endDateTime;
-          const isClosed = !start;
-          const overrideDate = modified.overrideDate
-            ? london(modified.overrideDate)
-            : undefined;
-          const overrideType = modified.type ?? 'other';
-          if (overrideDate) {
-            return {
-              overrideDate,
-              overrideType,
-              // If there is no start time from prismic, then we set both opens and closes to 00:00.
-              // This is necessary for the json-ld schema data, so Google knows when the venues are closed.
-              // See https://developers.google.com/search/docs/advanced/structured-data/local-business#business-hours (All-day hours tab)
-              // "To show a business is closed all day, set both opens and closes properties to '00:00'""
-              opens: start ? london(start).format('HH:mm') : '00:00',
-              closes: start && end ? london(end).format('HH:mm') : '00:00',
-              isClosed,
-            };
-          }
-        })
-    : [];
-
-  return {
-    id: venue.id as string,
-    order: data.order ?? undefined,
-    name: data.title ?? '',
-    openingHours: {
-      regular: [
-        createRegularDay('Monday', venue),
-        createRegularDay('Tuesday', venue),
-        createRegularDay('Wednesday', venue),
-        createRegularDay('Thursday', venue),
-        createRegularDay('Friday', venue),
-        createRegularDay('Saturday', venue),
-        createRegularDay('Sunday', venue),
-      ],
-      exceptional: exceptionalOpeningHours.filter(isNotUndefined),
-    },
-    image: data.image,
-    url: 'url' in data.link ? data.link.url : undefined,
-    linkText: prismicH.asText(data?.linkText),
-  };
-}
-
 export function getVenueById(venues: Venue[], id: string): Venue | undefined {
   const venue = venues.find(venue => venue.id === id);
   return venue;
-}
-
-export function parseCollectionVenues(
-  doc: Query<CollectionVenuePrismicDocument>
-): Venue[] {
-  const venues = doc.results.map(venue => {
-    return parseCollectionVenue(venue);
-  });
-
-  return venues.sort((a, b) => {
-    return Number(a.order) - Number(b.order);
-  });
 }
 
 export function getTodaysVenueHours(

--- a/common/services/prismic/transformers/collection-venues.ts
+++ b/common/services/prismic/transformers/collection-venues.ts
@@ -1,0 +1,92 @@
+import { Query } from '@prismicio/types';
+import { london } from '../../../utils/format-date';
+import type { Day, Venue, OpeningHoursDay } from '../../../model/opening-hours';
+import { CollectionVenuePrismicDocument } from '../documents';
+import { isNotUndefined } from '../../../utils/array';
+import * as prismicH from 'prismic-helpers-beta';
+
+function createRegularDay(
+  day: Day,
+  venue: CollectionVenuePrismicDocument
+): OpeningHoursDay {
+  const { data } = venue;
+  const lowercaseDay = day.toLowerCase();
+  const start = data && data[lowercaseDay][0].startDateTime;
+  const end = data && data[lowercaseDay][0].endDateTime;
+  const isClosed = !start;
+  // If there is no start time from prismic, then we set both opens and closes to 00:00.
+  // This is necessary for the json-ld schema data, so Google knows when the venues are closed.
+  // See https://developers.google.com/search/docs/advanced/structured-data/local-business#business-hours (All-day hours tab)
+  // "To show a business is closed all day, set both opens and closes properties to '00:00'""
+  return {
+    dayOfWeek: day,
+    opens: start ? london(start).format('HH:mm') : '00:00',
+    closes: start && end ? london(end).format('HH:mm') : '00:00',
+    isClosed,
+  };
+}
+
+export function transformCollectionVenue(
+  venue: CollectionVenuePrismicDocument
+): Venue {
+  const data = venue.data;
+  const exceptionalOpeningHours = data.modifiedDayOpeningTimes
+    ? data.modifiedDayOpeningTimes
+        .filter(modified => modified.overrideDate)
+        .map(modified => {
+          const start = modified.startDateTime;
+          const end = modified.endDateTime;
+          const isClosed = !start;
+          const overrideDate = modified.overrideDate
+            ? london(modified.overrideDate)
+            : undefined;
+          const overrideType = modified.type ?? 'other';
+          if (overrideDate) {
+            return {
+              overrideDate,
+              overrideType,
+              // If there is no start time from prismic, then we set both opens and closes to 00:00.
+              // This is necessary for the json-ld schema data, so Google knows when the venues are closed.
+              // See https://developers.google.com/search/docs/advanced/structured-data/local-business#business-hours (All-day hours tab)
+              // "To show a business is closed all day, set both opens and closes properties to '00:00'""
+              opens: start ? london(start).format('HH:mm') : '00:00',
+              closes: start && end ? london(end).format('HH:mm') : '00:00',
+              isClosed,
+            };
+          }
+        })
+    : [];
+
+  return {
+    id: venue.id as string,
+    order: data.order ?? undefined,
+    name: data.title ?? '',
+    openingHours: {
+      regular: [
+        createRegularDay('Monday', venue),
+        createRegularDay('Tuesday', venue),
+        createRegularDay('Wednesday', venue),
+        createRegularDay('Thursday', venue),
+        createRegularDay('Friday', venue),
+        createRegularDay('Saturday', venue),
+        createRegularDay('Sunday', venue),
+      ],
+      exceptional: exceptionalOpeningHours.filter(isNotUndefined),
+    },
+    image: data.image,
+    url: 'url' in data.link ? data.link.url : undefined,
+    linkText: prismicH.asText(data?.linkText),
+  };
+}
+
+export function transformCollectionVenues(
+  doc: Query<CollectionVenuePrismicDocument>
+): Venue[] {
+  const venues = doc.results.map(venue => {
+    return transformCollectionVenue(venue);
+  });
+
+  return venues.sort((a, b) => {
+    return Number(a.order) - Number(b.order);
+  });
+}

--- a/common/utils/json-ld.ts
+++ b/common/utils/json-ld.ts
@@ -2,6 +2,11 @@ import { convertImageUri } from './convert-image-uri';
 import { Organization } from '../model/organization';
 import { BreadcrumbItems } from '../model/breadcrumbs';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
+import type {
+  OpeningHours,
+  OpeningHoursDay,
+  SpecialOpeningHours,
+} from '../model/opening-hours';
 
 export function objToJsonLd<T>(obj: T, type: string, root = true) {
   const jsonObj = JSON.parse(JSON.stringify(obj));
@@ -80,4 +85,38 @@ function imageLd(image: Image) {
       'ImageObject'
     )
   );
+}
+
+export function openingHoursLd(openingHours: OpeningHours | undefined): {
+  openingHoursSpecification: OpeningHoursDay[];
+  specialOpeningHoursSpecification: SpecialOpeningHours[];
+} {
+  return {
+    openingHoursSpecification: openingHours?.regular
+      ? openingHours.regular.map(openingHoursDay => {
+          const specObject = objToJsonLd(
+            {
+              dayOfWeek: openingHoursDay.dayOfWeek,
+              opens: openingHoursDay.opens,
+              closes: openingHoursDay.closes,
+            },
+            'OpeningHoursSpecification',
+            false
+          );
+          delete specObject.note;
+          return specObject;
+        })
+      : [],
+    specialOpeningHoursSpecification: openingHours?.exceptional
+      ? openingHours.exceptional.map(openingHoursDate => {
+          const specObject = {
+            opens: openingHoursDate.opens,
+            closes: openingHoursDate.closes,
+            validFrom: openingHoursDate.overrideDate?.format('DD MMMM YYYY'),
+            validThrough: openingHoursDate.overrideDate?.format('DD MMMM YYYY'),
+          };
+          return objToJsonLd(specObject, 'OpeningHoursSpecification', false);
+        })
+      : [],
+  };
 }

--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -13,10 +13,8 @@ import PopupDialog from '../PopupDialog/PopupDialog';
 import Space from '../styled/Space';
 import { museumLd, libraryLd, openingHoursLd } from '../../../utils/json-ld';
 import { collectionVenueId } from '../../../services/prismic/hardcoded-id';
-import {
-  getVenueById,
-  parseCollectionVenues,
-} from '../../../services/prismic/opening-times';
+import { transformCollectionVenues } from '@weco/common/services/prismic/transformers/collection-venues';
+import { getVenueById } from '../../../services/prismic/opening-times';
 import { wellcomeCollectionGallery } from '../../../model/organization';
 import GlobalInfoBarContext, {
   GlobalInfoBarContextProvider,
@@ -105,7 +103,7 @@ const PageLayoutComponent: FunctionComponent<Props> = ({
 
   const absoluteUrl = `https://wellcomecollection.org${urlString}`;
   const { popupDialog, collectionVenues, globalAlert } = usePrismicData();
-  const venues = parseCollectionVenues(collectionVenues);
+  const venues = transformCollectionVenues(collectionVenues);
   const galleries =
     venues && getVenueById(venues, collectionVenueId.galleries.id);
   const library =

--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -11,11 +11,10 @@ import NewsletterPromo from '../NewsletterPromo/NewsletterPromo';
 import Footer from '../Footer/Footer';
 import PopupDialog from '../PopupDialog/PopupDialog';
 import Space from '../styled/Space';
-import { museumLd, libraryLd } from '../../../utils/json-ld';
+import { museumLd, libraryLd, openingHoursLd } from '../../../utils/json-ld';
 import { collectionVenueId } from '../../../services/prismic/hardcoded-id';
 import {
   getVenueById,
-  openingHoursToOpeningHoursSpecification,
   parseCollectionVenues,
 } from '../../../services/prismic/opening-times';
 import { wellcomeCollectionGallery } from '../../../model/organization';
@@ -115,11 +114,11 @@ const PageLayoutComponent: FunctionComponent<Props> = ({
   const libraryOpeningHours = library && library.openingHours;
   const wellcomeCollectionGalleryWithHours = {
     ...wellcomeCollectionGallery,
-    ...openingHoursToOpeningHoursSpecification(galleriesOpeningHours),
+    ...openingHoursLd(galleriesOpeningHours),
   };
   const wellcomeLibraryWithHours = {
     ...wellcomeCollectionGallery,
-    ...openingHoursToOpeningHoursSpecification(libraryOpeningHours),
+    ...openingHoursLd(libraryOpeningHours),
   };
 
   const polyfillFeatures = [

--- a/content/webapp/components/Body/VisitUsStaticContent.tsx
+++ b/content/webapp/components/Body/VisitUsStaticContent.tsx
@@ -9,7 +9,7 @@ import Layout12 from '@weco/common/views/components/Layout12/Layout12';
 import OpeningTimes from '@weco/common/views/components/OpeningTimes/OpeningTimes';
 import { clock } from '@weco/common/icons';
 import { usePrismicData } from '@weco/common/server-data/Context';
-import { parseCollectionVenues } from '@weco/common/services/prismic/opening-times';
+import { transformCollectionVenues } from '@weco/common/services/prismic/transformers/collection-venues';
 
 type ContainerProps = {
   children: ReactNode;
@@ -28,7 +28,7 @@ const Container: FunctionComponent<ContainerProps> = ({
 
 const VisitUsStaticContent: FunctionComponent = () => {
   const { collectionVenues } = usePrismicData();
-  const venues = parseCollectionVenues(collectionVenues);
+  const venues = transformCollectionVenues(collectionVenues);
 
   return (
     <Container>

--- a/content/webapp/components/VenueHours/VenueHours.tsx
+++ b/content/webapp/components/VenueHours/VenueHours.tsx
@@ -12,7 +12,6 @@ import {
   getUpcomingExceptionalPeriods,
   exceptionalOpeningDates,
   exceptionalOpeningPeriods,
-  convertJsonDateStringsToMoment,
   exceptionalOpeningPeriodsAllDates,
   parseCollectionVenues,
 } from '@weco/common/services/prismic/opening-times';
@@ -87,10 +86,7 @@ const VenueHours: FunctionComponent<Props> = ({ venue, weight }) => {
     groupedExceptionalDates
   );
   const backfilledExceptionalPeriods = venue
-    ? backfillExceptionalVenueDays(
-        convertJsonDateStringsToMoment(venue),
-        exceptionalPeriodsAllDates
-      )
+    ? backfillExceptionalVenueDays(venue, exceptionalPeriodsAllDates)
     : [];
   const upcomingExceptionalPeriods =
     backfilledExceptionalPeriods &&

--- a/content/webapp/components/VenueHours/VenueHours.tsx
+++ b/content/webapp/components/VenueHours/VenueHours.tsx
@@ -13,8 +13,8 @@ import {
   exceptionalOpeningDates,
   exceptionalOpeningPeriods,
   exceptionalOpeningPeriodsAllDates,
-  parseCollectionVenues,
 } from '@weco/common/services/prismic/opening-times';
+import { transformCollectionVenues } from '@weco/common/services/prismic/transformers/collection-venues';
 import Space from '@weco/common/views/components/styled/Space';
 import { usePrismicData } from '@weco/common/server-data/Context';
 import { Venue } from '@weco/common/model/opening-hours';
@@ -78,7 +78,7 @@ type Props = {
 
 const VenueHours: FunctionComponent<Props> = ({ venue, weight }) => {
   const { collectionVenues } = usePrismicData();
-  const venues = parseCollectionVenues(collectionVenues);
+  const venues = transformCollectionVenues(collectionVenues);
   const allExceptionalDates = exceptionalOpeningDates(venues);
   const groupedExceptionalDates =
     exceptionalOpeningPeriods(allExceptionalDates);

--- a/content/webapp/pages/whats-on.tsx
+++ b/content/webapp/pages/whats-on.tsx
@@ -19,8 +19,8 @@ import { clock } from '@weco/common/icons';
 import {
   getTodaysVenueHours,
   getVenueById,
-  parseCollectionVenues,
 } from '@weco/common/services/prismic/opening-times';
+import { transformCollectionVenues } from '@weco/common/services/prismic/transformers/collection-venues';
 import {
   cafePromo,
   // shopPromo,
@@ -413,7 +413,7 @@ const WhatsOnPage: FunctionComponent<Props> = props => {
     : `What’s on`;
 
   const { collectionVenues } = usePrismicData();
-  const venues = parseCollectionVenues(collectionVenues);
+  const venues = transformCollectionVenues(collectionVenues);
   const galleries = getVenueById(venues, collectionVenueId.galleries.id);
   const todaysOpeningHours = galleries && getTodaysVenueHours(galleries);
 

--- a/content/webapp/services/prismic/transformers/index.ts
+++ b/content/webapp/services/prismic/transformers/index.ts
@@ -22,7 +22,7 @@ import {
   BodyType,
   GenericContentFields,
 } from '../../../types/generic-content-fields';
-import { parseCollectionVenue } from '@weco/common/services/prismic/opening-times';
+import { transformCollectionVenue } from '@weco/common/services/prismic/transformers/collection-venues';
 import { ImageType } from '@weco/common/model/image';
 import { Body } from '../types/body';
 import { isNotUndefined, isString } from '@weco/common/utils/array';
@@ -269,7 +269,7 @@ export function transformBody(body: Body): BodyType {
                 type: 'collectionVenue',
                 weight: getWeight(slice.slice_label),
                 value: {
-                  content: parseCollectionVenue(slice.primary.content),
+                  content: transformCollectionVenue(slice.primary.content),
                   showClosingTimes: slice.primary.showClosingTimes,
                 },
               }


### PR DESCRIPTION
Last bit of tidying up opening-times.ts

- Renames parseCollectionVenue/s to transformCollectionVenue/s and moves them to their own file, to be more consistent with the content app transformers
- moves (and renames) the function for generating opening hours json-ld to sit with the other json-ld functions.
