### PR TITLE
Treat eslint warnings as errors in staged files

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   ],
   "lint-staged": {
     "*.{js,ts,tsx}": [
-      "eslint --fix",
+      "eslint --fix --max-warnings=0",
       "git add"
     ]
   },


### PR DESCRIPTION
☝️ 

This should prevent us from checking in any lint issues.