### PR TITLE
remove enableRequesting toggle

### DIFF
--- a/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
+++ b/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
@@ -6,7 +6,6 @@ import {
   useState,
 } from 'react';
 import styled from 'styled-components';
-import ButtonOutlinedLink from '@weco/common/views/components/ButtonOutlinedLink/ButtonOutlinedLink';
 import Space from '@weco/common/views/components/styled/Space';
 import { classNames, font } from '@weco/common/utils/classnames';
 import IsArchiveContext from '../IsArchiveContext/IsArchiveContext';
@@ -15,7 +14,6 @@ import {
   getLocationLabel,
   getLocationShelfmark,
   getFirstPhysicalLocation,
-  getEncoreLink,
   getFirstAccessCondition,
 } from '../../utils/works';
 import ItemRequestModal from '../ItemRequestModal/ItemRequestModal';
@@ -24,7 +22,6 @@ import { useUser } from '@weco/common/views/components/UserProvider/UserProvider
 import { itemIsRequestable } from '../../utils/requesting';
 import Placeholder from '@weco/common/views/components/Placeholder/Placeholder';
 import ButtonOutlined from '@weco/common/views/components/ButtonOutlined/ButtonOutlined';
-import { useToggles } from '@weco/common/server-data/Context';
 
 const Wrapper = styled(Space).attrs({
   v: { size: 'm', properties: ['margin-bottom', 'padding-bottom'] },
@@ -79,9 +76,8 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
   userHeldItems,
   isLast,
 }) => {
-  const { state: userState, enabled: userEnabled } = useUser();
+  const { state: userState } = useUser();
   const isArchive = useContext(IsArchiveContext);
-  const { enableRequesting } = useToggles();
   const requestButtonRef = useRef<HTMLButtonElement | null>(null);
 
   const [requestModalIsActive, setRequestModalIsActive] = useState(false);
@@ -109,9 +105,6 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
 
   const isOpenShelves = physicalLocation?.locationType.id === 'open-shelves';
 
-  const isRequestableOnline = accessCondition?.method?.id === 'online-request';
-  const requestItemUrl = isRequestableOnline ? getEncoreLink(work) : undefined;
-
   const accessMethod = accessCondition?.method?.label || '';
   const accessStatus = (() => {
     if (requestWasCompleted) {
@@ -128,11 +121,9 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
   const showAccessMethod = !isOpenShelves;
   const isRequestable = itemIsRequestable(item) && !requestWasCompleted;
 
-  const showButton = enableRequesting
-    ? isRequestable && userState === 'signedin'
-    : !!requestItemUrl;
-  const userNotLoaded =
-    userEnabled && (userState === 'loading' || userState === 'initial');
+  const showButton = isRequestable && userState === 'signedin';
+
+  const userNotLoaded = userState === 'loading' || userState === 'initial';
 
   const title = item.title || '';
   const itemNote = item.note || '';
@@ -140,17 +131,13 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
   const shelfmark = locationShelfmark || '';
 
   function createRows() {
-    const requestButton = enableRequesting ? (
+    const requestButton = (
       <ButtonOutlined
         disabled={userState !== 'signedin'}
         ref={requestButtonRef}
         text={'Request item'}
         clickHandler={() => setRequestModalIsActive(true)}
       />
-    ) : (
-      requestItemUrl && (
-        <ButtonOutlinedLink text={'Request item'} link={requestItemUrl} />
-      )
     );
 
     const headingRow = [
@@ -167,8 +154,7 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
       </>,
     ];
 
-    const isLoading =
-      accessDataIsStale || (enableRequesting && isRequestable && userNotLoaded);
+    const isLoading = accessDataIsStale || (isRequestable && userNotLoaded);
     if (showAccessStatus) {
       dataRow.push(
         <Placeholder isLoading={isLoading} nRows={2} maxWidth="75%">
@@ -204,17 +190,15 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
 
   return (
     <>
-      {enableRequesting && (
-        <ItemRequestModal
-          isActive={requestModalIsActive}
-          setIsActive={setRequestModalIsActive}
-          item={item}
-          work={work}
-          initialHoldNumber={userHeldItems?.size}
-          onSuccess={() => setRequestWasCompleted(true)}
-          openButtonRef={requestButtonRef}
-        />
-      )}
+      <ItemRequestModal
+        isActive={requestModalIsActive}
+        setIsActive={setRequestModalIsActive}
+        item={item}
+        work={work}
+        initialHoldNumber={userHeldItems?.size}
+        onSuccess={() => setRequestWasCompleted(true)}
+        openButtonRef={requestButtonRef}
+      />
       <Wrapper underline={!isLast}>
         {(title || itemNote) && (
           <Space v={{ size: 'm', properties: ['margin-bottom'] }}>

--- a/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
+++ b/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
@@ -13,7 +13,6 @@ import {
   itemIsRequestable,
   itemIsTemporarilyUnavailable,
 } from '../../utils/requesting';
-import { useToggles } from '@weco/common/server-data/Context';
 
 type Props = {
   work: Work;
@@ -22,19 +21,14 @@ type Props = {
 
 type ItemsState = 'stale' | 'up-to-date';
 
-const getItemsState = (
-  items: PhysicalItem[],
-  enableRequesting: boolean
-): ItemsState =>
-  items.some(itemIsTemporarilyUnavailable) ||
-  (enableRequesting && items.some(itemIsRequestable))
+const getItemsState = (items: PhysicalItem[]): ItemsState =>
+  items.some(itemIsTemporarilyUnavailable) || items.some(itemIsRequestable)
     ? 'stale'
     : 'up-to-date';
 
 const useItemsState = (
   items: PhysicalItem[]
 ): [ItemsState, (s: ItemsState) => void] => {
-  const { enableRequesting } = useToggles();
   /* https://github.com/wellcomecollection/wellcomecollection.org/issues/7120#issuecomment-938035546
    *
    * What if we don’t call the items API? There are two possible error cases:
@@ -56,11 +50,11 @@ const useItemsState = (
    * In all other cases the items API would be a no-op.
    */
   const [itemsState, setItemsState] = useState<ItemsState>(
-    getItemsState(items, enableRequesting)
+    getItemsState(items)
   );
 
   useEffect(() => {
-    setItemsState(getItemsState(items, enableRequesting));
+    setItemsState(getItemsState(items));
   }, [items]);
 
   return [itemsState, setItemsState];

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -50,7 +50,6 @@ import {
   itemIsRequestable,
   itemIsTemporarilyUnavailable,
 } from '../../utils/requesting';
-import { useToggles } from '@weco/common/server-data/Context';
 
 type Props = {
   work: Work;
@@ -79,7 +78,6 @@ function getItemLinkState({
 }
 
 const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
-  const { enableRequesting } = useToggles();
   const isArchive = useContext(IsArchiveContext);
 
   const itemUrl = itemLink({ workId: work.id }, 'work');
@@ -225,15 +223,13 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
   const renderWhereToFindIt = () => {
     return (
       <WorkDetailsSection headingText="Where to find it">
-        {enableRequesting &&
-          physicalItems.some(
-            item =>
-              itemIsRequestable(item) || itemIsTemporarilyUnavailable(item)
-          ) && (
-            <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
-              <LibraryMembersBar />
-            </Space>
-          )}
+        {physicalItems.some(
+          item => itemIsRequestable(item) || itemIsTemporarilyUnavailable(item)
+        ) && (
+          <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
+            <LibraryMembersBar />
+          </Space>
+        )}
         {locationOfWork && (
           <WorkDetailsText
             title={locationOfWork.noteType.label}

--- a/catalogue/webapp/test/works.test.ts
+++ b/catalogue/webapp/test/works.test.ts
@@ -2,7 +2,6 @@ import {
   getProductionDates,
   getItemsWith,
   getItemIdentifiersWith,
-  getWorkIdentifiersWith,
   getArchiveAncestorArray,
   getDigitalLocationOfType,
   getAccessConditionForDigitalLocation,
@@ -33,17 +32,6 @@ describe('getItemsWith', () => {
 
     expect(items.length).toBe(1);
     expect(items[0].id).toBe('ys3ern6x');
-  });
-});
-
-describe('getWorkIdentifiersWith', () => {
-  it('gets the work identifiers indicated by the parameters', () => {
-    const identifiers = getWorkIdentifiersWith(workFixture, {
-      identifierId: 'sierra-system-number',
-    });
-
-    expect(identifiers.length).toBe(1);
-    expect(identifiers[0]).toBe('b16656180');
   });
 });
 

--- a/catalogue/webapp/utils/works.ts
+++ b/catalogue/webapp/utils/works.ts
@@ -71,19 +71,6 @@ export function getDownloadOptionsFromImageUrl(
   }
 }
 
-export function getEncoreLink(work: Work): string | undefined {
-  const sierraWorkIds = getWorkIdentifiersWith(work, {
-    identifierId: 'sierra-system-number',
-  });
-  const sierraId = sierraWorkIds[0];
-  return sierraId
-    ? `http://encore.wellcomelibrary.org/iii/encore/record/C__R${sierraId.substr(
-        0,
-        sierraId.length - 1
-      )}`
-    : undefined;
-}
-
 export function sierraIdFromPresentationManifestUrl(
   iiifPresentationLocation: string
 ): string {

--- a/catalogue/webapp/utils/works.ts
+++ b/catalogue/webapp/utils/works.ts
@@ -209,21 +209,6 @@ export function getItemsWith(
   );
 }
 
-type WorkProps = {
-  identifierId: string;
-};
-
-export function getWorkIdentifiersWith(
-  work: Work,
-  { identifierId }: WorkProps
-): string[] {
-  return work.identifiers.reduce((acc: string[], identifier) => {
-    return identifier.identifierType.id === identifierId
-      ? acc.concat(identifier.value)
-      : acc;
-  }, []);
-}
-
 export function getItemIdentifiersWith(
   work: Work,
   { identifierId, locationType }: ItemProps,

--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -3,7 +3,6 @@ import { Url } from '../../../model/link-props';
 import { JsonLdObj } from '../JsonLd/JsonLd';
 import Head from 'next/head';
 import convertUrlToString from '../../../utils/convert-url-to-string';
-import Header from '../Header/Header';
 import HeaderPrototype from '../Header/HeaderPrototype';
 import InfoBanner from '../InfoBanner/InfoBanner';
 import CookieNotice from '../CookieNotice/CookieNotice';
@@ -94,7 +93,7 @@ const PageLayoutComponent: FunctionComponent<Props> = ({
     u => url.pathname && url.pathname.match(u)
   );
   useHotjar(shouldLoadHotjar);
-  const { apiToolbar, enableRequesting } = useToggles();
+  const { apiToolbar } = useToggles();
   const urlString = convertUrlToString(url);
   const fullTitle =
     title !== ''
@@ -281,11 +280,9 @@ const PageLayoutComponent: FunctionComponent<Props> = ({
         <a className="visually-hidden visually-hidden-focusable" href="#main">
           Skip to main content
         </a>
-        {enableRequesting ? (
-          <HeaderPrototype siteSection={siteSection} />
-        ) : (
-          <Header siteSection={siteSection} />
-        )}
+
+        <HeaderPrototype siteSection={siteSection} />
+
         {globalAlert.data.isShown === 'show' &&
           (!globalAlert.data.routeRegex ||
             urlString.match(new RegExp(globalAlert.data.routeRegex))) && (

--- a/common/views/components/UserProvider/UserProvider.tsx
+++ b/common/views/components/UserProvider/UserProvider.tsx
@@ -5,18 +5,16 @@ import {
   UserInfo,
 } from '../../../model/user';
 import { useAbortSignalEffect } from '../../../hooks/useAbortSignalEffect';
-import { useToggles } from '../../../server-data/Context';
 
 export type State = 'initial' | 'loading' | 'signedin' | 'signedout' | 'failed';
+
 type Props = {
-  enabled: boolean;
   user: UserInfo | undefined;
   state: State;
   reload: (abortSignal?: AbortSignal) => Promise<void>;
 };
 
 const defaultUserContext: Props = {
-  enabled: false,
   user: undefined,
   state: 'initial',
   reload: async () => void 0,
@@ -29,7 +27,7 @@ export function useUser(): Props {
   return contextState;
 }
 
-const UserProvider: FC<{ enabled: boolean }> = ({ children, enabled }) => {
+const UserProvider: FC = ({ children }) => {
   const [user, setUser] = useState<UserInfo>();
   const [state, setState] = useState<State>('initial');
 
@@ -84,33 +82,15 @@ const UserProvider: FC<{ enabled: boolean }> = ({ children, enabled }) => {
 
   return (
     <UserContext.Provider
-      value={
-        enabled
-          ? {
-              enabled,
-              user,
-              state,
-              reload: (abortSignal?: AbortSignal) =>
-                fetchUser(abortSignal, true),
-            }
-          : defaultUserContext
-      }
+      value={{
+        user,
+        state,
+        reload: (abortSignal?: AbortSignal) => fetchUser(abortSignal, true),
+      }}
     >
       {children}
     </UserContext.Provider>
   );
 };
 
-const ToggledUserProvider: FC<{ forceEnable?: boolean }> = ({
-  children,
-  forceEnable,
-}) => {
-  const toggles = useToggles();
-  return (
-    <UserProvider enabled={Boolean(toggles.enableRequesting || forceEnable)}>
-      {children}
-    </UserProvider>
-  );
-};
-
-export default ToggledUserProvider;
+export default UserProvider;

--- a/playwright/test/request-items.test.ts
+++ b/playwright/test/request-items.test.ts
@@ -8,15 +8,7 @@ beforeAll(async () => {
   const defaultToggleAndTestCookies = await makeDefaultToggleAndTestCookies(
     domain
   );
-  await context.addCookies([
-    {
-      name: 'toggle_enableRequesting',
-      value: 'true',
-      domain: domain,
-      path: '/',
-    },
-    ...defaultToggleAndTestCookies,
-  ]);
+  await context.addCookies(defaultToggleAndTestCookies);
 });
 
 describe.skip('Scenario 1: researcher is logged out', () => {


### PR DESCRIPTION
Fixes #7778 

The toggle is working intermittently and I think we need to look at this separately.

This PR removes the use of the toggle for the requesting work. We'll lose the ability to turn it of quickly (without code changes and a deploy), but it will fix this issue.

