### PR TITLE
Fix/button accessibility

### DIFF
--- a/common/views/components/DropdownButton/DropdownButton.tsx
+++ b/common/views/components/DropdownButton/DropdownButton.tsx
@@ -168,6 +168,7 @@ const DropdownButton: FC<Props> = ({
           iconLeft={iconLeft}
           type="button"
           text={label}
+          aria-label={id}
         />
       )}
       {isEnhanced && (

--- a/common/views/components/Header/DesktopSignIn.tsx
+++ b/common/views/components/Header/DesktopSignIn.tsx
@@ -57,7 +57,6 @@ const DesktopSignIn: FC = () => {
               iconLeft={userIcon}
               id="signedin-dropdown"
               buttonType="borderless"
-              aria-label="signedin-dropdown"
             >
               <a href="/account/api/auth/login">
                 Sign in to your library account
@@ -82,7 +81,6 @@ const DesktopSignIn: FC = () => {
             iconLeft={userIcon}
             id="signedin-dropdown"
             buttonType="borderless"
-            aria-label="signedin-dropdown"
           >
             <span
               className={classNames({

--- a/common/views/components/Header/DesktopSignIn.tsx
+++ b/common/views/components/Header/DesktopSignIn.tsx
@@ -57,6 +57,7 @@ const DesktopSignIn: FC = () => {
               iconLeft={userIcon}
               id="signedin-dropdown"
               buttonType="borderless"
+              aria-label="sign in"
             >
               <a href="/account/api/auth/login">
                 Sign in to your library account
@@ -81,6 +82,7 @@ const DesktopSignIn: FC = () => {
             iconLeft={userIcon}
             id="signedin-dropdown"
             buttonType="borderless"
+            aria-label="sign out"
           >
             <span
               className={classNames({

--- a/common/views/components/Header/DesktopSignIn.tsx
+++ b/common/views/components/Header/DesktopSignIn.tsx
@@ -57,7 +57,7 @@ const DesktopSignIn: FC = () => {
               iconLeft={userIcon}
               id="signedin-dropdown"
               buttonType="borderless"
-              aria-label="sign in"
+              aria-label="signedin-dropdown"
             >
               <a href="/account/api/auth/login">
                 Sign in to your library account
@@ -82,7 +82,7 @@ const DesktopSignIn: FC = () => {
             iconLeft={userIcon}
             id="signedin-dropdown"
             buttonType="borderless"
-            aria-label="sign out"
+            aria-label="signedin-dropdown"
           >
             <span
               className={classNames({


### PR DESCRIPTION
## Who is this for?

When using a screen reader, without an aria-label on the button section, the initials of your user name get read out. I tested using a screen-reader extension, tabbing into the sign in drop down (where you log in) read "Mister [MR] dropdown collapsed". This doesn't really help signify this area as a sign in/out drop down. This makes it inaccessible so our pa11y checks rightfully flagged this for us. 

Ticket: https://github.com/wellcomecollection/wellcomecollection.org/issues/7780



## What is it doing for them?

This PR adds an aria-label so using a screen reader and tabbing to this section will now read: "signed-in drop down".