### PR TITLE
Use empty string for alt if we get null from Prismic

### DIFF
--- a/common/model/image.ts
+++ b/common/model/image.ts
@@ -4,7 +4,7 @@ export type ImageType = {
   contentUrl: string;
   width: number;
   height: number;
-  alt: string;
+  alt: string | null;
   tasl?: Tasl;
   crops: {
     [key: string]: ImageType;

--- a/common/model/picture.ts
+++ b/common/model/picture.ts
@@ -4,7 +4,7 @@ export type Picture = {
   contentUrl: string;
   width: number;
   height: number;
-  alt: string;
+  alt: string | null;
   tasl?: Tasl;
   minWidth?: string; // This must have a CSS unit attached
 };

--- a/common/views/components/Image/Image.tsx
+++ b/common/views/components/Image/Image.tsx
@@ -9,7 +9,7 @@ import { FunctionComponent } from 'react';
 export type Props = {
   contentUrl: string;
   width?: number;
-  alt: string;
+  alt: string | null;
   tasl?: Tasl;
   height?: number;
   caption?: string;

--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -153,7 +153,7 @@ const PageLayoutComponent: FunctionComponent<Props> = ({
   const imageUrl =
     socialPreviewCardImage &&
     convertImageUri(socialPreviewCardImage.contentUrl, 800);
-  const imageAltText = socialPreviewCardImage?.alt;
+  const imageAltText = socialPreviewCardImage?.alt || '';
 
   return (
     <>

--- a/content/webapp/components/PrismicImage/PrismicImage.tsx
+++ b/content/webapp/components/PrismicImage/PrismicImage.tsx
@@ -1,3 +1,4 @@
+import { FC } from 'react';
 import Image, { ImageLoaderProps } from 'next/image';
 import { classNames } from '@weco/common/utils/classnames';
 import {
@@ -78,7 +79,7 @@ function createPrismicLoader(maxWidth: number) {
  * usurping UiImage which has reached a state where it is so bloated it is hard to refactor.
  * This is aimed solely at the Prismic image rendering for now.
  */
-const PrismicImage = ({ image, sizes, maxWidth }: Props) => {
+const PrismicImage: FC<Props> = ({ image, sizes, maxWidth }) => {
   const sizesString = sizes
     ? convertBreakpointSizesToSizes(sizes).join(', ')
     : undefined;
@@ -99,7 +100,7 @@ const PrismicImage = ({ image, sizes, maxWidth }: Props) => {
       })}
       sizes={sizesString}
       src={image.contentUrl}
-      alt={image.alt}
+      alt={image.alt || ''}
       loader={createPrismicLoader(maxLoaderWidth)}
     />
   );


### PR DESCRIPTION
Fixes #7746

Making sure there's an alt attribute on all images (we thought we'd always get something from Prismic, but turns out it can be `null`)