### PR TITLE
Make sure we always set a new server-data timer

### DIFF
--- a/common/server-data/index.ts
+++ b/common/server-data/index.ts
@@ -1,3 +1,18 @@
+/**
+ * This module fetches data from remote sources that:
+ *
+ *    - we need on every request/page
+ *    - doesn't change very often
+ *
+ * e.g. default toggle values, or our opening hours.
+ *
+ * Because this data changes infrequently, it's helpful to cache it on
+ * the server, than fetch it on every single request.  We do this by fetching
+ * this data on a fixed interval, and saving it to a JSON file on the local disk.
+ * When we need this data to serve a request, we read it from the JSON cache
+ * rather than going back to the remote source.
+ */
+
 import path from 'path';
 import { promises as fs } from 'fs';
 import { GetServerSidePropsContext } from 'next';
@@ -44,20 +59,27 @@ async function read(key: Key, defaultValue: DefaulVal<Key>) {
 
 const timers = new Map<Key, NodeJS.Timer>();
 async function write(key: Key, fetch: () => Promise<DefaulVal<Key>>) {
-  const data = await fetch();
-  const fileName = path.join(pathName, `${key}.json`);
-  await fs.mkdir(pathName, { recursive: true });
+  try {
+    const data = await fetch();
+    const fileName = path.join(pathName, `${key}.json`);
+    await fs.mkdir(pathName, { recursive: true });
 
-  // Write the JSON to a temp file, then rename it.  On most filesystems,
-  // the rename is an atomic operation.
-  //
-  // This means that whenever you try to read ${key}.json, you'll always get
-  // a valid JSON.  If we wrote directly to the file, you might get an
-  // empty file or invalid JSON if you tried to read while we were writing.
-  const tmpFileName = path.join(pathName, `${key}.json.tmp`);
-  await fs.writeFile(tmpFileName, JSON.stringify(data));
-  await fs.rename(tmpFileName, fileName);
+    // Write the JSON to a temp file, then rename it.  On most filesystems,
+    // the rename is an atomic operation.
+    //
+    // This means that whenever you try to read ${key}.json, you'll always get
+    // a valid JSON.  If we wrote directly to the file, you might get an
+    // empty file or invalid JSON if you tried to read while we were writing.
+    const tmpFileName = path.join(pathName, `${key}.json.tmp`);
+    await fs.writeFile(tmpFileName, JSON.stringify(data));
+    await fs.rename(tmpFileName, fileName);
+  } catch (e) {
+    console.error('Could not update server data', e);
+  }
 
+  // We have to make sure this timer is set even if fetching the data fails
+  // on a particular attempt, otherwise a single failure means a running app
+  // will never fetch new server data again.
   const timer = setTimeout(() => {
     clearTimeout(timer);
     write(key, fetch);


### PR DESCRIPTION
It looks like sometimes the `fetch()` method for server data can fail, and so we'd never set a timer to fetch new server data later – that instance of the app would just get stuck on whatever the last value of the data was, and never fetch new toggles/global values.

The logs show us apps where this has happened; in particular [this line in the Prismic fetcher](https://github.com/wellcomecollection/wellcomecollection.org/blob/28a37d84b3e7ccb7613acb16a559e38d6b569af2/common/server-data/prismic.ts#L69):

```typescript
console.error(`Failed to fetch ${keys[i]} from Prismic`, result.reason);
```

If you search our logs for "Failed to fetch", you'll find several instances of it. The longer a task is up, the more likely it is to get a failure which would cause this issue.

Practically speaking, I think (🤞) this will fix the intermittent issues we've had with toggles and global data, because they all go through this method and would fail in this way.