### PR TITLE
We don't need to use node-fetch for client-side fetchers

### DIFF
--- a/content/webapp/services/prismic/fetch/articles.ts
+++ b/content/webapp/services/prismic/fetch/articles.ts
@@ -338,5 +338,8 @@ export const fetchArticles = (
   });
 };
 
+// Note: this is used to fetch the "Read more from this series" at the
+// bottom of an article page; you can test it by checking that articles
+// load on e.g. http://localhost:3000/articles/Yhz_4BAAACQAtzA4
 export const fetchArticlesClientSide =
   clientSideFetcher<Article>('articles').getByTypeClientSide;

--- a/content/webapp/services/prismic/fetch/exhibitions.ts
+++ b/content/webapp/services/prismic/fetch/exhibitions.ts
@@ -157,6 +157,9 @@ export const fetchExhibitionRelatedContent = async (
   });
 };
 
+// Note: this is used to fetch the "Related to this exhibition" at the
+// bottom of an article page; you can test it by checking that the discussion
+// loads on http://localhost:3000/exhibitions/X2s3IBMAAHbq_CtG
 export const fetchExhibitionRelatedContentClientSide = async (
   ids: string[]
 ): Promise<ExhibitionRelatedContent | undefined> => {

--- a/content/webapp/services/prismic/fetch/index.ts
+++ b/content/webapp/services/prismic/fetch/index.ts
@@ -1,6 +1,5 @@
 import { Query, PrismicDocument } from '@prismicio/types';
 import * as prismic from '@prismicio/client';
-import fetch from 'node-fetch';
 import { GetServerSidePropsContext, NextApiRequest } from 'next';
 import { ContentType } from '../link-resolver';
 import { isString } from '@weco/common/utils/array';


### PR DESCRIPTION
Based on an off-hand comment from @jamieparkinson yesterday – we don't need to be pulling in node-fetch here, and we probably don't want to.

I've also added some notes on how to test these methods, because I keep having to rediscover them!