### PR TITLE
Fix redirects on work pages

### DIFF
--- a/catalogue/webapp/pages/work.tsx
+++ b/catalogue/webapp/pages/work.tsx
@@ -38,7 +38,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     if (workResponse.type === 'Redirect') {
       return {
         redirect: {
-          destination: workResponse.redirectToId,
+          destination: `/works/${workResponse.redirectToId}`,
           permanent: workResponse.status === 301,
         },
       };


### PR DESCRIPTION
Somewhere between our app code and the user, the redirection path changes from `${workId}` to `/${workId}`.  This breaks redirections on the site, because

    https://wellcomecollection.org/works/${redirectedWorkId}

gets redirected to

    https://wellcomecollection.org/${redirectedWorkId}

which is a 404 error.

By hard-coding the /works prefix, redirects should work properly.

## Who is this for?

Me, when I spotted broken redirects in https://wellcome.slack.com/archives/C8X9YKM5X/p1646569642569749

## What is it doing for them?

Making redirects work well good proper.