### PR TITLE
Fix keep-alive behaviour

### DIFF
--- a/catalogue/webapp/package.json
+++ b/catalogue/webapp/package.json
@@ -23,6 +23,7 @@
     "@types/supertest": "^2.0.11",
     "@weco/common": "1.0.0",
     "@weco/toggles": "1.0.0",
+    "agentkeepalive": "^4.2.1",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^24.5.0",
     "jest": "^27.3.1",

--- a/catalogue/webapp/services/catalogue/index.ts
+++ b/catalogue/webapp/services/catalogue/index.ts
@@ -1,3 +1,5 @@
+import fetch, { Response } from 'node-fetch';
+import { HttpsAgent as Agent } from 'agentkeepalive';
 import { CatalogueApiError } from '@weco/common/model/catalogue';
 import { Toggles } from '@weco/toggles';
 
@@ -31,20 +33,33 @@ export const catalogueApiError = (): CatalogueApiError => ({
   type: 'Error',
 });
 
-// Because we know we'll be making repeated requests to the catalogue API,
-// this header should keep the socket open between individual requests,
-// rather than reconnecting each time.
+// By default, the next.js polyfill for node-fetch enables keep-alive by default.
+// https://nextjs.org/docs/api-reference/next.config.js/disabling-http-keep-alive
 //
-// I'm hoping this will reduce the trickle of errors like:
+// This is great, but it leads us to occasionally see errors like this one:
 //
 //      FetchError: request to https://api.wellcomecollection.org/catalogue/v2/works/...
 //      failed, reason: read ECONNRESET
 //
+// That's because the (client) HTTP agent is keeping the socket open indefinitely, but
+// the server has other ideas:
+//
+// - default "idle-timeout" in akka-http is 60s https://doc.akka.io/docs/akka-http/current/configuration.html
+// - NLBs have a fixed idle timeout of 350s https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html#connection-idle-timeout
+//
+// As such, we use an agent which is configured to expire free sockets after 59s
+// A good explanation of the problem, as well as the solution, is available here:
+// https://connectreport.com/blog/tuning-http-keep-alive-in-node-js/
+const agentKeepAlive = new Agent({
+  keepAlive: true,
+  freeSocketTimeout: 1000 * 59, // 1s less than the akka-http idle timeout
+});
+
 export const catalogueFetch = (
   url: string,
   options?: Record<string, string>
 ): Promise<Response> => {
-  return fetch(url, { ...options, headers: { 'connection': 'keep-alive' }});
+  return fetch(url, { ...options, agent: agentKeepAlive });
 };
 
 // Returns true if a string is plausibly a canonical ID, false otherwise.

--- a/catalogue/webapp/services/catalogue/index.ts
+++ b/catalogue/webapp/services/catalogue/index.ts
@@ -36,7 +36,7 @@ export const catalogueApiError = (): CatalogueApiError => ({
 // By default, the next.js polyfill for node-fetch enables keep-alive by default.
 // https://nextjs.org/docs/api-reference/next.config.js/disabling-http-keep-alive
 //
-// This is great, but it leads us to occasionally see errors like this one:
+// This is great, but it leads us occasionally to see errors like this one:
 //
 //      FetchError: request to https://api.wellcomecollection.org/catalogue/v2/works/...
 //      failed, reason: read ECONNRESET

--- a/yarn.lock
+++ b/yarn.lock
@@ -5060,6 +5060,15 @@ agent-base@6:
   dependencies:
     debug "4"
 
+agentkeepalive@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-4.2.1.tgz#a7975cbb9f83b367f06c90cc51ff28fe7d499717"
+  integrity sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==
+  dependencies:
+    debug "^4.1.0"
+    depd "^1.1.2"
+    humanize-ms "^1.2.1"
+
 aggregate-error@^3.0.0, aggregate-error@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.1.0.tgz#92670ff50f5359bdb7a3e0d40d0ec30c5737687a"
@@ -7624,15 +7633,15 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
+depd@^1.1.2, depd@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
+  integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
+
 depd@^2.0.0, depd@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
-
-depd@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
-  integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
 
 des.js@^1.0.0:
   version "1.0.1"
@@ -9983,6 +9992,13 @@ human-signals@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
+
+humanize-ms@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/humanize-ms/-/humanize-ms-1.2.1.tgz#c46e3159a293f6b896da29316d8b6fe8bb79bbed"
+  integrity sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=
+  dependencies:
+    ms "^2.0.0"
 
 humanize-number@0.0.2:
   version "0.0.2"
@@ -12570,7 +12586,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@^2.1.1:
+ms@^2.0.0, ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==


### PR DESCRIPTION
Enabling keep-alive in https://github.com/wellcomecollection/wellcomecollection.org/pull/7770 did not fix the `ECONNRESET`s we've been seeing - that's likely because keep-alive was actually already enabled in Next.js [by default](https://nextjs.org/docs/api-reference/next.config.js/disabling-http-keep-alive).

I suspect that the `ECONNRESET`s are in fact _caused_ by the keep-alive, as there needs to be a socket open for it to be reset. This PR adds a timeout to open sockets which should - as per https://connectreport.com/blog/tuning-http-keep-alive-in-node-js/https://connectreport.com/blog/tuning-http-keep-alive-in-node-js/ - sort this out 🤞 