### PR TITLE
Reduce html size books

### DIFF
--- a/content/webapp/components/BookPromo/BookPromo.tsx
+++ b/content/webapp/components/BookPromo/BookPromo.tsx
@@ -1,7 +1,7 @@
 import { font, classNames } from '@weco/common/utils/classnames';
 import { trackEvent } from '@weco/common/utils/ga';
 import UiImage from '@weco/common/views/components/Image/Image';
-import { Book } from '../../types/books';
+import { BookBasic } from '../../types/books';
 import Space from '@weco/common/views/components/styled/Space';
 import styled from 'styled-components';
 import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
@@ -38,7 +38,7 @@ const LinkOrSpanSpace = styled(Space).attrs<LinkOrSpanSpaceAttrs>(props => ({
 }))<LinkOrSpanSpaceAttrs>``;
 
 type Props = {
-  book: Book;
+  book: BookBasic;
 };
 
 const BookPromo: FunctionComponent<Props> = ({ book }: Props): ReactElement => {

--- a/content/webapp/components/BookPromo/BookPromo.tsx
+++ b/content/webapp/components/BookPromo/BookPromo.tsx
@@ -1,7 +1,7 @@
 import { font, classNames } from '@weco/common/utils/classnames';
 import { trackEvent } from '@weco/common/utils/ga';
 import UiImage from '@weco/common/views/components/Image/Image';
-import { ImageType } from '@weco/common/model/image';
+import { Book } from '../../types/books';
 import Space from '@weco/common/views/components/styled/Space';
 import styled from 'styled-components';
 import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
@@ -27,14 +27,6 @@ const BookPromoImage = styled(Space).attrs({
   transform: translateX(-50%) rotate(2deg);
 `;
 
-type Props = {
-  url: string;
-  title: string;
-  subtitle?: string;
-  description?: string;
-  image?: ImageType;
-};
-
 type LinkOrSpanSpaceAttrs = {
   url?: string;
   elem?: string;
@@ -45,13 +37,12 @@ const LinkOrSpanSpace = styled(Space).attrs<LinkOrSpanSpaceAttrs>(props => ({
   href: props.url || undefined,
 }))<LinkOrSpanSpaceAttrs>``;
 
-const BookPromo: FunctionComponent<Props> = ({
-  url,
-  image,
-  title,
-  subtitle,
-  description,
-}: Props): ReactElement => {
+type Props = {
+  book: Book;
+};
+
+const BookPromo: FunctionComponent<Props> = ({ book }: Props): ReactElement => {
+  const { id, title, subtitle, promoText, cover } = book;
   return (
     <LinkOrSpanSpace
       v={{
@@ -59,7 +50,7 @@ const BookPromo: FunctionComponent<Props> = ({
         properties: ['padding-top'],
       }}
       h={{ size: 'm', properties: ['padding-left', 'padding-right'] }}
-      url={url}
+      url={`/books/${id}`}
       className={classNames({
         'block promo-link plain-link': true,
       })}
@@ -73,12 +64,12 @@ const BookPromo: FunctionComponent<Props> = ({
     >
       <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
         <BookPromoImageContainer>
-          {image && image.contentUrl && (
+          {cover?.contentUrl && (
             <BookPromoImage v={{ size: 'l', properties: ['bottom'] }}>
               <UiImage
-                contentUrl={image.contentUrl}
-                width={image.width || 0}
-                height={image.height || 0}
+                contentUrl={cover.contentUrl}
+                width={cover.width || 0}
+                height={cover.height || 0}
                 alt=""
                 sizesQueries="(min-width: 1420px) 386px, (min-width: 960px) calc(28.64vw - 15px), (min-width: 600px) calc(50vw - 54px), calc(100vw - 36px)"
               />
@@ -129,7 +120,7 @@ const BookPromo: FunctionComponent<Props> = ({
             </Space>
           )}
 
-          {description && (
+          {promoText && (
             <Space v={{ size: 's', properties: ['margin-top'] }}>
               <p
                 className={classNames({
@@ -137,7 +128,7 @@ const BookPromo: FunctionComponent<Props> = ({
                   'no-margin': true,
                 })}
               >
-                {description}
+                {promoText}
               </p>
             </Space>
           )}

--- a/content/webapp/components/CardGrid/CardGrid.tsx
+++ b/content/webapp/components/CardGrid/CardGrid.tsx
@@ -66,15 +66,7 @@ const CardGrid: FunctionComponent<Props> = ({
                   hidePromoText={hidePromoText}
                 />
               )}
-              {item.type === 'books' && (
-                <BookPromo
-                  url={`/books/${item.id}`}
-                  title={item.title}
-                  subtitle={item.subtitle}
-                  description={item.promoText}
-                  image={item.cover}
-                />
-              )}
+              {item.type === 'books' && <BookPromo book={item} />}
               {(item.type === 'pages' || item.type === 'series') && (
                 <Card item={convertItemToCardProps(item)} />
               )}

--- a/content/webapp/components/LayoutPaginatedResults/LayoutPaginatedResults.tsx
+++ b/content/webapp/components/LayoutPaginatedResults/LayoutPaginatedResults.tsx
@@ -14,14 +14,14 @@ import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
 import { headerBackgroundLs } from '@weco/common/utils/backgrounds';
 import { FC, ReactElement } from 'react';
 import CardGrid from '../CardGrid/CardGrid';
-import { Book } from '../../types/books';
+import { BookBasic } from '../../types/books';
 import { Guide } from '../../types/guides';
 import * as prismicT from '@prismicio/types';
 
 type PaginatedResultsTypes =
   | PaginatedResults<Exhibition>
   | PaginatedResults<EventBasic>
-  | PaginatedResults<Book>
+  | PaginatedResults<BookBasic>
   | PaginatedResults<ArticleBasic>
   | PaginatedResults<Guide>;
 

--- a/content/webapp/components/SearchResults/SearchResults.tsx
+++ b/content/webapp/components/SearchResults/SearchResults.tsx
@@ -97,10 +97,10 @@ const SearchResults: FunctionComponent<Props> = ({
             description={item.promo && item.promo.caption}
             urlOverride={item.promo && item.promo.link}
             Image={
-              item.image &&
-              item.image.crops &&
-              item.image.crops.square && (
-                <Image {...item.image.crops.square} alt="" />
+              item.cover &&
+              item.cover.crops &&
+              item.cover.crops.square && (
+                <Image {...item.cover.crops.square} alt="" />
               )
             }
             xOfY={{ x: index + 1, y: items.length }}

--- a/content/webapp/pages/books.tsx
+++ b/content/webapp/pages/books.tsx
@@ -9,14 +9,17 @@ import { FunctionComponent } from 'react';
 import { getServerData } from '@weco/common/server-data';
 import { createClient } from '../services/prismic/fetch';
 import { transformQuery } from '../services/prismic/transformers/paginated-results';
-import { transformBook } from '../services/prismic/transformers/books';
+import {
+  transformBook,
+  transformBookToBookBasic,
+} from '../services/prismic/transformers/books';
 import { fetchBooks } from '../services/prismic/fetch/books';
-import { Book } from '../types/books';
+import { BookBasic } from '../types/books';
 import { getPage } from '../utils/query-params';
 import { pageDescriptions } from '@weco/common/data/microcopy';
 
 type Props = {
-  books: PaginatedResults<Book>;
+  books: PaginatedResults<BookBasic>;
 };
 
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
@@ -31,7 +34,10 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       page,
       pageSize: 21,
     });
-    const books = transformQuery(booksQuery, transformBook);
+
+    const books = transformQuery(booksQuery, book =>
+      transformBookToBookBasic(transformBook(book))
+    );
 
     const serverData = await getServerData(context);
     if (books) {
@@ -57,7 +63,7 @@ const BooksPage: FunctionComponent<Props> = props => {
       jsonLd={{ '@type': 'WebPage' }}
       openGraphType={'website'}
       siteSection={null}
-      image={firstBook && firstBook.image}
+      image={firstBook && firstBook.cover}
     >
       <SpacingSection>
         <LayoutPaginatedResults

--- a/content/webapp/pages/stories.tsx
+++ b/content/webapp/pages/stories.tsx
@@ -44,13 +44,14 @@ import {
 import * as prismic from '@prismicio/client';
 import { transformArticleSeries } from '../services/prismic/transformers/article-series';
 import { transformFeaturedBooks } from '../services/prismic/transformers/featured-books';
-import { Book } from '../types/books';
+import { transformBookToBookBasic } from '../services/prismic/transformers/books';
+import { BookBasic } from '../types/books';
 
 type Props = {
   articles: ArticleBasic[];
   series: Series;
   featuredText?: FeaturedTextType;
-  featuredBooks: Book[];
+  featuredBooks: BookBasic[];
 };
 
 const SerialisedSeries = ({ series }: { series: Series }) => {
@@ -133,7 +134,15 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     const articles = transformQuery(articlesQuery, article =>
       transformArticleToArticleBasic(transformArticle(article))
     );
-    const featuredBooks = transformFeaturedBooks(featuredBooksDoc);
+
+    const featuredBooks = transformFeaturedBooks(featuredBooksDoc).map(
+      transformBookToBookBasic
+    );
+    console.log('one', transformFeaturedBooks(featuredBooksDoc));
+    console.log(
+      'two',
+      transformFeaturedBooks(featuredBooksDoc).map(transformBookToBookBasic)
+    );
 
     // The featured series and stories page should always exist
     const series = transformArticleSeries(

--- a/content/webapp/pages/stories.tsx
+++ b/content/webapp/pages/stories.tsx
@@ -138,11 +138,6 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     const featuredBooks = transformFeaturedBooks(featuredBooksDoc).map(
       transformBookToBookBasic
     );
-    console.log('one', transformFeaturedBooks(featuredBooksDoc));
-    console.log(
-      'two',
-      transformFeaturedBooks(featuredBooksDoc).map(transformBookToBookBasic)
-    );
 
     // The featured series and stories page should always exist
     const series = transformArticleSeries(

--- a/content/webapp/services/prismic/transformers/books.ts
+++ b/content/webapp/services/prismic/transformers/books.ts
@@ -1,4 +1,4 @@
-import { Book } from '../../../types/books';
+import { Book, BookBasic } from '../../../types/books';
 import { BookPrismicDocument } from '../types/books';
 import {
   transformGenericFields,
@@ -12,6 +12,18 @@ import { transformSeason } from './seasons';
 import { transformPromoToCaptionedImage } from './images';
 import { SeasonPrismicDocument } from '../types/seasons';
 import { transformContributors } from './contributors';
+
+export function transformBookToBookBasic(book: Book): BookBasic {
+  // returns what is required to render BookPromos and book JSON-LD
+  return (({ type, id, title, subtitle, promoText, cover }) => ({
+    type,
+    id,
+    title,
+    subtitle,
+    promoText,
+    cover,
+  }))(book);
+}
 
 export function transformBook(document: BookPrismicDocument): Book {
   const { data } = document;

--- a/content/webapp/services/prismic/transformers/books.ts
+++ b/content/webapp/services/prismic/transformers/books.ts
@@ -15,13 +15,15 @@ import { transformContributors } from './contributors';
 
 export function transformBookToBookBasic(book: Book): BookBasic {
   // returns what is required to render BookPromos and book JSON-LD
-  return (({ type, id, title, subtitle, promoText, cover }) => ({
+  return (({ type, id, title, subtitle, promoText, cover, promo, labels }) => ({
     type,
     id,
     title,
     subtitle,
     promoText,
     cover,
+    promo,
+    labels,
   }))(book);
 }
 

--- a/content/webapp/types/books.ts
+++ b/content/webapp/types/books.ts
@@ -3,6 +3,8 @@ import { ImageType } from '@weco/common/model/image';
 import * as prismicT from '@prismicio/types';
 import { Contributor } from './contributors';
 import { Season } from './seasons';
+import { ImagePromo } from './image-promo';
+import { Label } from '@weco/common/model/labels';
 
 type Review = {
   text: prismicT.RichTextField;
@@ -18,6 +20,8 @@ export type BookBasic = {
   subtitle?: string;
   promoText?: string;
   cover?: ImageType;
+  promo?: ImagePromo | undefined;
+  labels: Label[];
 };
 
 export type Book = GenericContentFields & {

--- a/content/webapp/types/books.ts
+++ b/content/webapp/types/books.ts
@@ -9,6 +9,17 @@ type Review = {
   citation: prismicT.RichTextField;
 };
 
+export type BookBasic = {
+  // this is a mix of props from GenericContentFields and Book
+  // and is only what is required to render BookPromos and json-ld
+  type: 'books';
+  id: string;
+  title: string;
+  subtitle?: string;
+  promoText?: string;
+  cover?: ImageType;
+};
+
 export type Book = GenericContentFields & {
   type: 'books';
   subtitle?: string;

--- a/content/webapp/types/multi-content.ts
+++ b/content/webapp/types/multi-content.ts
@@ -1,6 +1,6 @@
 import { EventSeries } from './event-series';
 import { ArticleBasic } from './articles';
-import { Book } from './books';
+import { BookBasic } from './books';
 import { EventBasic } from './events';
 import { Exhibition } from './exhibitions';
 import { Page } from './pages';
@@ -12,7 +12,7 @@ import { Project } from './projects';
 export type MultiContent =
   | Page
   | EventSeries
-  | Book
+  | BookBasic
   | EventBasic
   | ArticleBasic
   | Exhibition


### PR DESCRIPTION
Relates to https://github.com/wellcomecollection/wellcomecollection.org/issues/7796

This covers books.

Where BookPromos and CompactCards (with book type) is rendered, we will now only return the required data from getServerSideProps, rather than the data needed to render the entire book.
