### PR TITLE
Reduce html size exhibitions

### DIFF
--- a/content/webapp/components/ExhibitionPromo/ExhibitionPromo.tsx
+++ b/content/webapp/components/ExhibitionPromo/ExhibitionPromo.tsx
@@ -7,12 +7,12 @@ import StatusIndicator from '@weco/common/views/components/StatusIndicator/Statu
 import Space from '@weco/common/views/components/styled/Space';
 import { CardOuter, CardBody } from '../Card/Card';
 import PrismicImage from '../PrismicImage/PrismicImage';
-import { Exhibition } from '../../types/exhibitions';
+import { ExhibitionBasic } from '../../types/exhibitions';
 import linkResolver from '../../services/prismic/link-resolver';
 import { isNotUndefined } from '@weco/common/utils/array';
 
 type Props = {
-  exhibition: Exhibition;
+  exhibition: ExhibitionBasic;
   position?: number;
 };
 

--- a/content/webapp/components/FeaturedCard/FeaturedCard.tsx
+++ b/content/webapp/components/FeaturedCard/FeaturedCard.tsx
@@ -4,7 +4,7 @@ import {
   UiImageProps,
   UiImage,
 } from '@weco/common/views/components/Images/Images';
-import { Exhibition } from '../../types/exhibitions';
+import { ExhibitionBasic } from '../../types/exhibitions';
 import {
   ArticleBasic,
   getPositionInSeries,
@@ -53,7 +53,7 @@ export function convertCardToFeaturedCardProps(
 }
 
 export function convertItemToFeaturedCardProps(
-  item: ArticleBasic | Exhibition | Season
+  item: ArticleBasic | ExhibitionBasic | Season
 ) {
   return {
     id: item.id,
@@ -126,13 +126,13 @@ const FeaturedCardArticleBody: FunctionComponent<FeaturedCardArticleBodyProps> =
   };
 
 type FeaturedCardExhibitionProps = {
-  exhibition: Exhibition;
+  exhibition: ExhibitionBasic;
   background: string;
   color: string;
 };
 
 type FeaturedCardExhibitionBodyProps = {
-  exhibition: Exhibition;
+  exhibition: ExhibitionBasic;
 };
 
 const FeaturedCardExhibitionBody = ({

--- a/content/webapp/components/LayoutPaginatedResults/LayoutPaginatedResults.tsx
+++ b/content/webapp/components/LayoutPaginatedResults/LayoutPaginatedResults.tsx
@@ -4,7 +4,7 @@ import Pagination from '@weco/common/views/components/Pagination/Pagination';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
 import { classNames, font } from '@weco/common/utils/classnames';
 import { Period } from '../../types/periods';
-import { Exhibition } from '../../types/exhibitions';
+import { ExhibitionBasic } from '../../types/exhibitions';
 import { EventBasic } from '../../types/events';
 import { ArticleBasic } from '../../types/articles';
 import { PaginatedResults } from '@weco/common/services/prismic/types';
@@ -19,7 +19,7 @@ import { Guide } from '../../types/guides';
 import * as prismicT from '@prismicio/types';
 
 type PaginatedResultsTypes =
-  | PaginatedResults<Exhibition>
+  | PaginatedResults<ExhibitionBasic>
   | PaginatedResults<EventBasic>
   | PaginatedResults<BookBasic>
   | PaginatedResults<ArticleBasic>

--- a/content/webapp/pages/api/exhibitions/index.ts
+++ b/content/webapp/pages/api/exhibitions/index.ts
@@ -4,9 +4,9 @@ import { createClient } from '../../../services/prismic/fetch';
 import { fetchExhibitions } from '../../../services/prismic/fetch/exhibitions';
 import { transformExhibitionsQuery } from '../../../services/prismic/transformers/exhibitions';
 import { PaginatedResults } from '@weco/common/services/prismic/types';
-import { Exhibition } from '../../../types/exhibitions';
+import { ExhibitionBasic } from '../../../types/exhibitions';
 
-type Data = PaginatedResults<Exhibition>;
+type Data = PaginatedResults<ExhibitionBasic>;
 type NotFound = { notFound: true };
 
 export default async (

--- a/content/webapp/pages/exhibitions.tsx
+++ b/content/webapp/pages/exhibitions.tsx
@@ -14,10 +14,10 @@ import { pageDescriptions } from '@weco/common/data/microcopy';
 import { fetchExhibitions } from '../services/prismic/fetch/exhibitions';
 import { transformExhibitionsQuery } from '../services/prismic/transformers/exhibitions';
 import { createClient } from '../services/prismic/fetch';
-import { Exhibition } from '../types/exhibitions';
+import { ExhibitionBasic } from '../types/exhibitions';
 
 type Props = {
-  exhibitions: PaginatedResults<Exhibition>;
+  exhibitions: PaginatedResults<ExhibitionBasic>;
   period?: Period;
   displayTitle: string;
 };

--- a/content/webapp/pages/homepage.tsx
+++ b/content/webapp/pages/homepage.tsx
@@ -16,7 +16,7 @@ import {
   orderEventsByNextAvailableDate,
   filterEventsForNext7Days,
 } from '../services/prismic/events';
-import { Exhibition } from '../types/exhibitions';
+import { ExhibitionBasic } from '../types/exhibitions';
 import { EventBasic } from '../types/events';
 import { convertItemToCardProps } from '../types/card';
 import { GetServerSideProps } from 'next';
@@ -69,7 +69,7 @@ const CreamBox = styled(Space).attrs({
 `;
 
 type Props = {
-  exhibitions: PaginatedResults<Exhibition>;
+  exhibitions: PaginatedResults<ExhibitionBasic>;
   events: PaginatedResults<EventBasic>;
   articles: PaginatedResults<ArticleBasic>;
   page: PageType;

--- a/content/webapp/pages/season.tsx
+++ b/content/webapp/pages/season.tsx
@@ -40,7 +40,7 @@ import { transformSeason } from '../services/prismic/transformers/seasons';
 import { Article } from '../types/articles';
 import { Book } from '../types/books';
 import { Event } from '../types/events';
-import { Exhibition } from '../types/exhibitions';
+import { ExhibitionBasic } from '../types/exhibitions';
 import { Page } from '../types/pages';
 import { Project } from '../types/projects';
 import { Series } from '../types/series';
@@ -51,7 +51,7 @@ type Props = {
   articles: Article[];
   books: Book[];
   events: Event[];
-  exhibitions: Exhibition[];
+  exhibitions: ExhibitionBasic[];
   pages: Page[];
   projects: Project[];
   series: Series[];

--- a/content/webapp/pages/whats-on.tsx
+++ b/content/webapp/pages/whats-on.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent } from 'react';
 import { Moment } from 'moment';
 import NextLink from 'next/link';
-import { Exhibition } from '../types/exhibitions';
+import { ExhibitionBasic } from '../types/exhibitions';
 import { EventBasic } from '../types/events';
 import { Period } from '../types/periods';
 import { PaginatedResults } from '@weco/common/services/prismic/types';
@@ -98,7 +98,7 @@ const segmentedControlItems = [
 ];
 
 export type Props = {
-  exhibitions: PaginatedResults<Exhibition>;
+  exhibitions: PaginatedResults<ExhibitionBasic>;
   events: PaginatedResults<EventBasic>;
   availableOnlineEvents: PaginatedResults<EventBasic>;
   period: string;

--- a/content/webapp/services/prismic/transformers/exhibitions.ts
+++ b/content/webapp/services/prismic/transformers/exhibitions.ts
@@ -194,6 +194,7 @@ export function transformExhibitionToExhibitionBasic(
     statusOverride,
     contributors,
     labels,
+    promoImage,
   }) => ({
     type,
     id,
@@ -206,6 +207,7 @@ export function transformExhibitionToExhibitionBasic(
     statusOverride,
     contributors,
     labels,
+    promoImage,
   }))(exhibition);
 }
 

--- a/content/webapp/services/prismic/transformers/exhibitions.ts
+++ b/content/webapp/services/prismic/transformers/exhibitions.ts
@@ -2,6 +2,7 @@ import {
   Exhibit,
   ExhibitionFormat,
   Exhibition,
+  ExhibitionBasic,
   ExhibitionRelatedContent,
 } from '../../../types/exhibitions';
 import {
@@ -177,10 +178,43 @@ export function transformExhibition(
   return { ...exhibition, type: 'exhibitions', labels };
 }
 
+export function transformExhibitionToExhibitionBasic(
+  exhibition: Exhibition
+): ExhibitionBasic {
+  // returns what is required to render ExhibitionPromos and exhibition JSON-LD
+  return (({
+    type,
+    id,
+    title,
+    promo,
+    format,
+    start,
+    end,
+    isPermanent,
+    statusOverride,
+    contributors,
+    labels,
+  }) => ({
+    type,
+    id,
+    title,
+    promo,
+    format,
+    start,
+    end,
+    isPermanent,
+    statusOverride,
+    contributors,
+    labels,
+  }))(exhibition);
+}
+
 export function transformExhibitionsQuery(
   query: Query<ExhibitionPrismicDocument>
-): PaginatedResults<Exhibition> {
-  const paginatedResult = transformQuery(query, transformExhibition);
+): PaginatedResults<ExhibitionBasic> {
+  const paginatedResult = transformQuery(query, exhibition =>
+    transformExhibitionToExhibitionBasic(transformExhibition(exhibition))
+  );
 
   return {
     ...paginatedResult,
@@ -189,8 +223,8 @@ export function transformExhibitionsQuery(
 }
 
 function putPermanentAfterCurrentExhibitions(
-  exhibitions: Exhibition[]
-): Exhibition[] {
+  exhibitions: ExhibitionBasic[]
+): ExhibitionBasic[] {
   // We order the list this way as, from a user's perspective, seeing the
   // temporary exhibitions is more urgent, so they're at the front of the list,
   // but there's no good way to express that ordering through Prismic's ordering
@@ -212,10 +246,10 @@ function putPermanentAfterCurrentExhibitions(
       return acc;
     },
     {
-      current: [] as Exhibition[],
-      permanent: [] as Exhibition[],
-      comingUp: [] as Exhibition[],
-      past: [] as Exhibition[],
+      current: [] as ExhibitionBasic[],
+      permanent: [] as ExhibitionBasic[],
+      comingUp: [] as ExhibitionBasic[],
+      past: [] as ExhibitionBasic[],
     }
   );
 

--- a/content/webapp/types/exhibitions.ts
+++ b/content/webapp/types/exhibitions.ts
@@ -6,6 +6,9 @@ import { Place } from './places';
 import { GenericContentFields } from './generic-content-fields';
 import { Resource } from './resource';
 import { Season } from './seasons';
+import { ImagePromo } from './image-promo';
+import { Label } from '@weco/common/model/labels';
+import { ImageType } from '@weco/common/model/image';
 import * as prismicT from '@prismicio/types';
 
 // e.g. 'Permanent'
@@ -13,6 +16,24 @@ export type ExhibitionFormat = {
   id: string;
   title: string;
   description?: string;
+};
+
+export type ExhibitionBasic = {
+  // this is a mix of props from GenericContentFields and Exhibition
+  // and is only what is required to render ExhibitionPromos and json-ld
+  type: 'exhibitions';
+  id: string;
+  title: string;
+  promo?: ImagePromo | undefined;
+  format?: ExhibitionFormat;
+  start: Date;
+  end?: Date;
+  isPermanent: boolean;
+  statusOverride?: string;
+  contributors: Contributor[];
+  labels: Label[];
+  image?: ImageType;
+  promoText?: string;
 };
 
 export type Exhibition = GenericContentFields & {

--- a/content/webapp/types/exhibitions.ts
+++ b/content/webapp/types/exhibitions.ts
@@ -9,6 +9,7 @@ import { Season } from './seasons';
 import { ImagePromo } from './image-promo';
 import { Label } from '@weco/common/model/labels';
 import { ImageType } from '@weco/common/model/image';
+import { Picture } from '@weco/common/model/picture';
 import * as prismicT from '@prismicio/types';
 
 // e.g. 'Permanent'
@@ -34,6 +35,7 @@ export type ExhibitionBasic = {
   labels: Label[];
   image?: ImageType;
   promoText?: string;
+  promoImage?: Picture;
 };
 
 export type Exhibition = GenericContentFields & {

--- a/content/webapp/types/multi-content.ts
+++ b/content/webapp/types/multi-content.ts
@@ -2,7 +2,7 @@ import { EventSeries } from './event-series';
 import { ArticleBasic } from './articles';
 import { BookBasic } from './books';
 import { EventBasic } from './events';
-import { Exhibition } from './exhibitions';
+import { ExhibitionBasic } from './exhibitions';
 import { Page } from './pages';
 import { Series } from './series';
 import { Guide } from './guides';
@@ -15,7 +15,7 @@ export type MultiContent =
   | BookBasic
   | EventBasic
   | ArticleBasic
-  | Exhibition
+  | ExhibitionBasic
   | Series
   | Guide
   | Weblink


### PR DESCRIPTION
Relates to https://github.com/wellcomecollection/wellcomecollection.org/issues/7796

This covers exhibitions.

Where ExhibitionsPromos and exhibition json-ld is rendered, we will now only return the required data from getServerSideProps, rather than the data needed to render the entire exhibition.
