### PR TITLE
Use transform image for venue

### DIFF
--- a/common/model/opening-hours.ts
+++ b/common/model/opening-hours.ts
@@ -1,4 +1,5 @@
 import { Moment } from 'moment';
+import { ImageType } from './image';
 
 export type Day =
   | 'Monday'
@@ -55,7 +56,7 @@ export type Venue = {
   openingHours: OpeningHours;
   url?: string;
   linkText?: string;
-  image?: any; // TODO
+  image?: ImageType;
 };
 
 // http://schema.org/specialOpeningHoursSpecification

--- a/common/services/prismic/transformers/collection-venues.ts
+++ b/common/services/prismic/transformers/collection-venues.ts
@@ -7,6 +7,7 @@ import {
 } from '../documents';
 import { isNotUndefined } from '../../../utils/array';
 import * as prismicH from '@prismicio/helpers';
+import { transformImage } from './images';
 
 function createRegularDay(
   day: Day,
@@ -76,7 +77,7 @@ export function transformCollectionVenue(
       ],
       exceptional: exceptionalOpeningHours.filter(isNotUndefined),
     },
-    image: data.image,
+    image: transformImage(data.image),
     url: 'url' in data.link ? data.link.url : undefined,
     linkText: prismicH.asText(data?.linkText),
   };

--- a/common/services/prismic/transformers/images.ts
+++ b/common/services/prismic/transformers/images.ts
@@ -1,0 +1,47 @@
+import { EmptyImageFieldImage, FilledImageFieldImage } from '@prismicio/types';
+import { ImageType } from '@weco/common/model/image';
+import { transformTaslFromString } from '.';
+
+// when images have crops, event if the image isn't attached, we get e.g.
+// { '32:15': {}, '16:9': {}, square: {} }
+function isImageLink(
+  maybeImage: EmptyImageFieldImage | FilledImageFieldImage
+): maybeImage is FilledImageFieldImage {
+  return Boolean(maybeImage && maybeImage.dimensions);
+}
+
+export function transformImage(
+  maybeImage: EmptyImageFieldImage | FilledImageFieldImage | undefined
+): ImageType | undefined {
+  return maybeImage && isImageLink(maybeImage)
+    ? transformFilledImage(maybeImage)
+    : undefined;
+}
+
+// These are the props returned on a prismic image object
+const prismicImageProps = ['dimensions', 'alt', 'copyright', 'url'];
+
+// We don't export this, as we probably always want to check ^ first
+function transformFilledImage(image: FilledImageFieldImage): ImageType {
+  const tasl = transformTaslFromString(image.copyright);
+  const crops = Object.keys(image)
+    .filter(key => prismicImageProps.indexOf(key) === -1)
+    .filter(key => isImageLink(image[key]))
+    .map(key => ({
+      key,
+      image: transformFilledImage(image[key]),
+    }))
+    .reduce((acc, { key, image }) => {
+      acc[key] = image;
+      return acc;
+    }, {});
+
+  return {
+    contentUrl: image.url,
+    width: image.dimensions.width,
+    height: image.dimensions.height,
+    alt: image.alt!,
+    tasl: tasl,
+    crops: crops,
+  };
+}

--- a/common/services/prismic/transformers/index.ts
+++ b/common/services/prismic/transformers/index.ts
@@ -1,0 +1,41 @@
+import { Tasl } from '../../../model/tasl';
+import { licenseTypeArray } from '../../../model/license';
+
+export function transformTaslFromString(pipedString: string | null): Tasl {
+  if (pipedString === null) {
+    return { title: '' };
+  }
+
+  // We expect a string of title|author|sourceName|sourceLink|license|copyrightHolder|copyrightLink
+  // e.g. Self|Rob Bidder|||CC-BY-NC
+  try {
+    const list = (pipedString || '').split('|');
+    const v = list
+      .concat(Array(7 - list.length))
+      .map(v => (!v.trim() ? undefined : v.trim()));
+
+    const [
+      title,
+      author,
+      sourceName,
+      sourceLink,
+      maybeLicense,
+      copyrightHolder,
+      copyrightLink,
+    ] = v;
+    const license = licenseTypeArray.find(l => l === maybeLicense);
+    return {
+      title,
+      author,
+      sourceName,
+      sourceLink,
+      license,
+      copyrightHolder,
+      copyrightLink,
+    };
+  } catch (e) {
+    return {
+      title: pipedString,
+    };
+  }
+}

--- a/content/webapp/components/VenueHours/VenueHours.tsx
+++ b/content/webapp/components/VenueHours/VenueHours.tsx
@@ -103,9 +103,9 @@ const VenueHours: FunctionComponent<Props> = ({ venue, weight }) => {
             </span>
           </Space>
           <VenueHoursImage v={{ size: 'm', properties: ['margin-bottom'] }}>
-            {venue?.image?.url && (
+            {venue?.image?.contentUrl && (
               <UiImage
-                contentUrl={venue.image.url}
+                contentUrl={venue.image.contentUrl}
                 width={1600}
                 height={900}
                 crops={{}}

--- a/content/webapp/services/prismic/transformers/body.ts
+++ b/content/webapp/services/prismic/transformers/body.ts
@@ -34,16 +34,17 @@ import {
   isFilledLinkToMediaField,
 } from '../types';
 import { TeamPrismicDocument } from '../types/teams';
-import { transformCaptionedImage, transformImage } from './images';
+import { transformCaptionedImage } from './images';
+import { transformImage } from '@weco/common/services/prismic/transformers/images';
 import { CaptionedImage } from '@weco/common/model/captioned-image';
 import {
   transformLink,
   asRichText,
-  transformTaslFromString,
   transformLabelType,
   asTitle,
   asText,
 } from '.';
+import { transformTaslFromString } from '@weco/common/services/prismic/transformers';
 import { LinkField, RelationField, RichTextField } from '@prismicio/types';
 import { Weight } from '../../../types/generic-content-fields';
 

--- a/content/webapp/services/prismic/transformers/card.ts
+++ b/content/webapp/services/prismic/transformers/card.ts
@@ -1,5 +1,5 @@
 import { CardPrismicDocument } from '../types/card';
-import { transformImage } from './images';
+import { transformImage } from '@weco/common/services/prismic/transformers/images';
 import { Card } from '../../../types/card';
 import { asText, asTitle, transformFormat, transformLink } from '.';
 

--- a/content/webapp/services/prismic/transformers/contributors.ts
+++ b/content/webapp/services/prismic/transformers/contributors.ts
@@ -11,7 +11,7 @@ import { isNotUndefined } from '@weco/common/utils/array';
 import { asRichText, asText } from '.';
 import { ImageType } from '@weco/common/model/image';
 import { Organisation, Person } from '../types/contributors';
-import { transformImage } from './images';
+import { transformImage } from '@weco/common/services/prismic/transformers/images';
 
 const defaultContributorImage: ImageType = {
   width: 64,

--- a/content/webapp/services/prismic/transformers/images.ts
+++ b/content/webapp/services/prismic/transformers/images.ts
@@ -1,15 +1,12 @@
 import { Image, PromoSliceZone } from '../types';
-import {
-  EmptyImageFieldImage,
-  FilledImageFieldImage,
-  RichTextField,
-} from '@prismicio/types';
+import { RichTextField } from '@prismicio/types';
 import { CaptionedImage } from '@weco/common/model/captioned-image';
 import isEmptyObj from '@weco/common/utils/is-empty-object';
 import { ImageType } from '@weco/common/model/image';
 import { ImagePromo } from '../../../types/image-promo';
-import { asRichText, asText, transformTaslFromString } from '.';
+import { asRichText, asText } from '.';
 import * as prismicT from '@prismicio/types';
+import { transformImage } from '@weco/common/services/prismic/transformers/images';
 
 export const placeHolderImage: ImageType = {
   contentUrl: 'https://via.placeholder.com/1600x900?text=%20',
@@ -58,50 +55,6 @@ export function transformPromoToCaptionedImage(
   } else {
     return undefined;
   }
-}
-
-// when images have crops, event if the image isn't attached, we get e.g.
-// { '32:15': {}, '16:9': {}, square: {} }
-function isImageLink(
-  maybeImage: EmptyImageFieldImage | FilledImageFieldImage
-): maybeImage is FilledImageFieldImage {
-  return Boolean(maybeImage && maybeImage.dimensions);
-}
-
-export function transformImage(
-  maybeImage: EmptyImageFieldImage | FilledImageFieldImage | undefined
-): ImageType | undefined {
-  return maybeImage && isImageLink(maybeImage)
-    ? transformFilledImage(maybeImage)
-    : undefined;
-}
-
-// These are the props returned on a prismic image object
-const prismicImageProps = ['dimensions', 'alt', 'copyright', 'url'];
-
-// We don't export this, as we probably always want to check ^ first
-function transformFilledImage(image: FilledImageFieldImage): ImageType {
-  const tasl = transformTaslFromString(image.copyright);
-  const crops = Object.keys(image)
-    .filter(key => prismicImageProps.indexOf(key) === -1)
-    .filter(key => isImageLink(image[key]))
-    .map(key => ({
-      key,
-      image: transformFilledImage(image[key]),
-    }))
-    .reduce((acc, { key, image }) => {
-      acc[key] = image;
-      return acc;
-    }, {});
-
-  return {
-    contentUrl: image.url,
-    width: image.dimensions.width,
-    height: image.dimensions.height,
-    alt: image.alt!,
-    tasl: tasl,
-    crops: crops,
-  };
 }
 
 // null is valid to use the default image,

--- a/content/webapp/services/prismic/transformers/index.ts
+++ b/content/webapp/services/prismic/transformers/index.ts
@@ -54,9 +54,8 @@ import {
   transformTextSlice,
   transformTitledTextListSlice,
 } from './body';
-import { transformImage, transformImagePromo } from './images';
-import { Tasl } from '@weco/common/model/tasl';
-import { licenseTypeArray } from '@weco/common/model/license';
+import { transformImage } from '@weco/common/services/prismic/transformers/images';
+import { transformImagePromo } from './images';
 import { WithPageFormat } from '../types/pages';
 import { WithEventFormat } from '../types/events';
 import { Format } from '../../../types/format';
@@ -425,43 +424,4 @@ export function transformGenericFields(doc: Doc): GenericContentFields {
     // TODO: find a way to enforce this.
     labels: [],
   };
-}
-
-export function transformTaslFromString(pipedString: string | null): Tasl {
-  if (pipedString === null) {
-    return { title: '' };
-  }
-
-  // We expect a string of title|author|sourceName|sourceLink|license|copyrightHolder|copyrightLink
-  // e.g. Self|Rob Bidder|||CC-BY-NC
-  try {
-    const list = (pipedString || '').split('|');
-    const v = list
-      .concat(Array(7 - list.length))
-      .map(v => (!v.trim() ? undefined : v.trim()));
-
-    const [
-      title,
-      author,
-      sourceName,
-      sourceLink,
-      maybeLicense,
-      copyrightHolder,
-      copyrightLink,
-    ] = v;
-    const license = licenseTypeArray.find(l => l === maybeLicense);
-    return {
-      title,
-      author,
-      sourceName,
-      sourceLink,
-      license,
-      copyrightHolder,
-      copyrightLink,
-    };
-  } catch (e) {
-    return {
-      title: pipedString,
-    };
-  }
 }


### PR DESCRIPTION
This does the following:

- moves the transformImage and transformTaslFromString functions to common, so they can be used by transformCollectionVenue.
- adds the correct type to the Venue image property
- updates the VenueHours component to use the contentUrl prop returned by transformImage


