### PR TITLE
convert day strings back to Moments

### DIFF
--- a/common/services/prismic/transformers/collection-venues.ts
+++ b/common/services/prismic/transformers/collection-venues.ts
@@ -94,7 +94,7 @@ export function transformCollectionVenues(
 }
 
 // venue is passed down as JSON, so need to convert the date strings back to Moment objects
-export function convertTimeStringsBackToMoments(venue: Venue): Venue {
+export function fixVenueDatesInJson(venue: Venue): Venue {
   return {
     ...venue,
     openingHours: {

--- a/common/services/prismic/transformers/collection-venues.ts
+++ b/common/services/prismic/transformers/collection-venues.ts
@@ -92,3 +92,17 @@ export function transformCollectionVenues(
     return Number(a.order) - Number(b.order);
   });
 }
+
+// venue is passed down as JSON, so need to convert the date strings back to Moment objects
+export function convertTimeStringsBackToMoments(venue: Venue): Venue {
+  return {
+    ...venue,
+    openingHours: {
+      regular: venue.openingHours.regular,
+      exceptional: venue.openingHours.exceptional.map(exceptionalOpening => ({
+        ...exceptionalOpening,
+        overrideDate: london(exceptionalOpening.overrideDate),
+      })),
+    },
+  };
+}

--- a/content/webapp/components/VenueClosedPeriods/VenueClosedPeriods.tsx
+++ b/content/webapp/components/VenueClosedPeriods/VenueClosedPeriods.tsx
@@ -3,6 +3,7 @@ import {
   getExceptionalVenueDays,
   groupConsecutiveExceptionalDays,
 } from '@weco/common/services/prismic/opening-times';
+import { convertTimeStringsBackToMoments } from '@weco/common/services/prismic/transformers/collection-venues';
 import {
   collectionVenueId,
   getNameFromCollectionVenue,
@@ -15,7 +16,9 @@ type Props = {
 };
 
 const VenueClosedPeriods: FunctionComponent<Props> = ({ venue }) => {
-  const exceptionalVenueDays = venue ? getExceptionalVenueDays(venue) : [];
+  const exceptionalVenueDays = venue
+    ? getExceptionalVenueDays(convertTimeStringsBackToMoments(venue))
+    : [];
   const onlyClosedDays = exceptionalVenueDays.filter(day => day.isClosed);
   const groupedConsectiveClosedDays =
     groupConsecutiveExceptionalDays(onlyClosedDays);

--- a/content/webapp/components/VenueClosedPeriods/VenueClosedPeriods.tsx
+++ b/content/webapp/components/VenueClosedPeriods/VenueClosedPeriods.tsx
@@ -3,7 +3,7 @@ import {
   getExceptionalVenueDays,
   groupConsecutiveExceptionalDays,
 } from '@weco/common/services/prismic/opening-times';
-import { convertTimeStringsBackToMoments } from '@weco/common/services/prismic/transformers/collection-venues';
+import { fixVenueDatesInJson } from '@weco/common/services/prismic/transformers/collection-venues';
 import {
   collectionVenueId,
   getNameFromCollectionVenue,
@@ -17,7 +17,7 @@ type Props = {
 
 const VenueClosedPeriods: FunctionComponent<Props> = ({ venue }) => {
   const exceptionalVenueDays = venue
-    ? getExceptionalVenueDays(convertTimeStringsBackToMoments(venue))
+    ? getExceptionalVenueDays(fixVenueDatesInJson(venue))
     : [];
   const onlyClosedDays = exceptionalVenueDays.filter(day => day.isClosed);
   const groupedConsectiveClosedDays =

--- a/content/webapp/components/VenueHours/VenueHours.tsx
+++ b/content/webapp/components/VenueHours/VenueHours.tsx
@@ -1,5 +1,9 @@
 import { FunctionComponent, Fragment } from 'react';
-import { formatDay, formatDayMonth } from '@weco/common/utils/format-date';
+import {
+  formatDay,
+  formatDayMonth,
+  london,
+} from '@weco/common/utils/format-date';
 import styled from 'styled-components';
 import { classNames, font } from '@weco/common/utils/classnames';
 import MoreLink from '@weco/common/views/components/MoreLink/MoreLink';
@@ -76,6 +80,20 @@ type Props = {
   weight: Weight;
 };
 
+// venue is passed down as JSON, so need to convert the date strings back to Moment objects
+function convertTimeStringsBackToMoments(venue) {
+  return {
+    ...venue,
+    openingHours: {
+      regular: venue.openingHours.regular,
+      exceptional: venue.openingHours.exceptional.map(exceptionalOpening => ({
+        ...exceptionalOpening,
+        overrideDate: london(exceptionalOpening.overrideDate),
+      })),
+    },
+  };
+}
+
 const VenueHours: FunctionComponent<Props> = ({ venue, weight }) => {
   const { collectionVenues } = usePrismicData();
   const venues = transformCollectionVenues(collectionVenues);
@@ -86,7 +104,10 @@ const VenueHours: FunctionComponent<Props> = ({ venue, weight }) => {
     groupedExceptionalDates
   );
   const backfilledExceptionalPeriods = venue
-    ? backfillExceptionalVenueDays(venue, exceptionalPeriodsAllDates)
+    ? backfillExceptionalVenueDays(
+        convertTimeStringsBackToMoments(venue),
+        exceptionalPeriodsAllDates
+      )
     : [];
   const upcomingExceptionalPeriods =
     backfilledExceptionalPeriods &&

--- a/content/webapp/components/VenueHours/VenueHours.tsx
+++ b/content/webapp/components/VenueHours/VenueHours.tsx
@@ -1,9 +1,5 @@
 import { FunctionComponent, Fragment } from 'react';
-import {
-  formatDay,
-  formatDayMonth,
-  london,
-} from '@weco/common/utils/format-date';
+import { formatDay, formatDayMonth } from '@weco/common/utils/format-date';
 import styled from 'styled-components';
 import { classNames, font } from '@weco/common/utils/classnames';
 import MoreLink from '@weco/common/views/components/MoreLink/MoreLink';
@@ -18,7 +14,10 @@ import {
   exceptionalOpeningPeriods,
   exceptionalOpeningPeriodsAllDates,
 } from '@weco/common/services/prismic/opening-times';
-import { transformCollectionVenues } from '@weco/common/services/prismic/transformers/collection-venues';
+import {
+  transformCollectionVenues,
+  convertTimeStringsBackToMoments,
+} from '@weco/common/services/prismic/transformers/collection-venues';
 import Space from '@weco/common/views/components/styled/Space';
 import { usePrismicData } from '@weco/common/server-data/Context';
 import { Venue } from '@weco/common/model/opening-hours';
@@ -79,20 +78,6 @@ type Props = {
   venue: Venue;
   weight: Weight;
 };
-
-// venue is passed down as JSON, so need to convert the date strings back to Moment objects
-function convertTimeStringsBackToMoments(venue) {
-  return {
-    ...venue,
-    openingHours: {
-      regular: venue.openingHours.regular,
-      exceptional: venue.openingHours.exceptional.map(exceptionalOpening => ({
-        ...exceptionalOpening,
-        overrideDate: london(exceptionalOpening.overrideDate),
-      })),
-    },
-  };
-}
 
 const VenueHours: FunctionComponent<Props> = ({ venue, weight }) => {
   const { collectionVenues } = usePrismicData();

--- a/content/webapp/components/VenueHours/VenueHours.tsx
+++ b/content/webapp/components/VenueHours/VenueHours.tsx
@@ -16,7 +16,7 @@ import {
 } from '@weco/common/services/prismic/opening-times';
 import {
   transformCollectionVenues,
-  convertTimeStringsBackToMoments,
+  fixVenueDatesInJson,
 } from '@weco/common/services/prismic/transformers/collection-venues';
 import Space from '@weco/common/views/components/styled/Space';
 import { usePrismicData } from '@weco/common/server-data/Context';
@@ -90,7 +90,7 @@ const VenueHours: FunctionComponent<Props> = ({ venue, weight }) => {
   );
   const backfilledExceptionalPeriods = venue
     ? backfillExceptionalVenueDays(
-        convertTimeStringsBackToMoments(venue),
+        fixVenueDatesInJson(venue),
         exceptionalPeriodsAllDates
       )
     : [];


### PR DESCRIPTION
Noticed this while working on #7796

venue is passed down as JSON, so we need to convert the date strings back to Moment objects, similar to [what we do for event dates](https://github.com/wellcomecollection/wellcomecollection.org/blob/195673ec1c4b92f2980b9b4499fab34df7c781d6/content/webapp/services/prismic/transformers/events.ts#L329)

At the moment a page will error if it uses the VenueHours component with a venue that has exceptional dates

