### PR TITLE
Fix drop caps on stories

### DIFF
--- a/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock.tsx
+++ b/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock.tsx
@@ -10,7 +10,7 @@ type Props = {
 const PrismicHtmlBlock = ({ html, htmlSerializer }: Props) => (
   <PrismicRichText
     field={html}
-    htmlSerializer={htmlSerializer}
+    components={htmlSerializer}
     linkResolver={linkResolver}
   />
 );

--- a/content/webapp/components/HTMLSerializers/HTMLSerializers.tsx
+++ b/content/webapp/components/HTMLSerializers/HTMLSerializers.tsx
@@ -211,19 +211,7 @@ export const dropCapSerializer: JSXFunctionSerializer = (
   children,
   key
 ) => {
-  // Note: `key.toString() === '0'` might look strange, because isn't `key`
-  // already a string?
-  //
-  // For some reason, we're getting passed `key` as a number here, so we
-  // need this or drop caps don't work correctly.
-  //
-  // TODO: Work out why this isn't being caught by the type checker elsewhere,
-  // and fix it properly.
-  if (
-    type === RichTextNodeType.paragraph &&
-    key.toString() === '0' &&
-    children[0] !== undefined
-  ) {
+  if (type === RichTextNodeType.paragraph && children[0] !== undefined) {
     const firstChild = children[0];
     const firstCharacters =
       firstChild.props &&


### PR DESCRIPTION
There were two issues preventing drop caps from appearing:

*   In the newest version of the Prismic libraries, the `htmlSerializer` property has been replaced with `components`.  Allegedly it supports the old property for back-compatibility, but local testing shows the drop cap serializer was never being called.
*   Remove the assertion that the `key` is 0.  We already check that we're in the first paragraph in `Body.tsx`, and inspecting these keys we see they may not necessarily be zero (in a local build, they're an int that increases on every reload: 85, 166, 247).

This seems to fix drop caps on articles.

## Who is this for?

Kate, who asked about it in Slack: https://wellcome.slack.com/archives/C1PK7TS0L/p1647427112434309

## What is it doing for them?

Making the drop caps work properly.