### PR TITLE
Don't use Moment for as many date comparisons

### DIFF
--- a/common/utils/dates.test.ts
+++ b/common/utils/dates.test.ts
@@ -1,5 +1,5 @@
 import each from 'jest-each';
-import { isFuture, isPast, isSameDay } from './dates';
+import { isFuture, isPast, isSameDay, isSameMonth } from './dates';
 
 it('identifies dates in the past', () => {
   expect(isPast(new Date(2001, 1, 1, 1, 1, 1, 999))).toEqual(true);
@@ -43,6 +43,47 @@ describe('isSameDay', () => {
     [new Date(2001, 2, 3, 1, 1, 1), new Date(2022, 5, 7, 19, 11, 13)],
   ]).test('identifies %s and %s as different', (a, b) => {
     const result = isSameDay(a, b);
+    expect(result).toEqual(false);
+  });
+});
+
+describe('isSameMonth', () => {
+  it('says a day is the same as itself', () => {
+    const day = new Date(2001, 1, 1, 1, 1, 1);
+    const result = isSameMonth(day, day);
+
+    expect(result).toEqual(true);
+  });
+
+  it('says two times on the same day are the same', () => {
+    const result = isSameMonth(
+      new Date(2001, 1, 1, 1, 1, 1),
+      new Date(2001, 1, 1, 13, 24, 37)
+    );
+
+    expect(result).toEqual(true);
+  });
+
+  it('says two days in the same month are the same', () => {
+    const result = isSameMonth(
+      new Date(2001, 1, 1, 1, 1, 1),
+      new Date(2001, 1, 13, 4, 21, 53)
+    );
+
+    expect(result).toEqual(true);
+  });
+
+  each([
+    // same year/day, different month
+    [new Date(2001, 2, 1, 1, 1, 1), new Date(2001, 3, 1, 1, 1, 1)],
+
+    // same month of year, different year
+    [new Date(2001, 2, 1, 1, 1, 1), new Date(2005, 2, 1, 1, 1, 1)],
+
+    // completely different months
+    [new Date(2001, 2, 3, 1, 1, 1), new Date(2022, 5, 7, 19, 11, 13)],
+  ]).test('identifies %s and %s as different', (a, b) => {
+    const result = isSameMonth(a, b);
     expect(result).toEqual(false);
   });
 });

--- a/common/utils/dates.test.ts
+++ b/common/utils/dates.test.ts
@@ -1,4 +1,5 @@
-import { isFuture, isPast } from './dates';
+import each from 'jest-each';
+import { isFuture, isPast, isSameDay } from './dates';
 
 it('identifies dates in the past', () => {
   expect(isPast(new Date(2001, 1, 1, 1, 1, 1, 999))).toEqual(true);
@@ -6,4 +7,42 @@ it('identifies dates in the past', () => {
 
 it('identifies dates in the future', () => {
   expect(isFuture(new Date(3000, 1, 1, 1, 1, 1, 1))).toEqual(true);
+});
+
+describe('isSameDay', () => {
+  it('says a day is the same as itself', () => {
+    const day = new Date(2001, 1, 1, 1, 1, 1);
+    const result = isSameDay(day, day);
+
+    expect(result).toEqual(true);
+  });
+
+  it('says two times on the same day are the same', () => {
+    const result = isSameDay(
+      new Date(2001, 1, 1, 1, 1, 1),
+      new Date(2001, 1, 1, 13, 24, 37)
+    );
+
+    expect(result).toEqual(true);
+  });
+
+  each([
+    // same day of the week as returned by Date.getDay()
+    [new Date(2001, 2, 3, 1, 1, 1), new Date(2001, 2, 10, 1, 1, 1)],
+
+    // same year/month, different day
+    [new Date(2001, 2, 3, 1, 1, 1), new Date(2001, 2, 10, 1, 1, 1)],
+
+    // same year/day, different month
+    [new Date(2001, 2, 3, 1, 1, 1), new Date(2001, 10, 3, 1, 1, 1)],
+
+    // same month/day, different year
+    [new Date(2001, 2, 3, 1, 1, 1), new Date(2022, 2, 3, 1, 1, 1)],
+
+    // completely different days
+    [new Date(2001, 2, 3, 1, 1, 1), new Date(2022, 5, 7, 19, 11, 13)],
+  ]).test('identifies %s and %s as different', (a, b) => {
+    const result = isSameDay(a, b);
+    expect(result).toEqual(false);
+  });
 });

--- a/common/utils/dates.ts
+++ b/common/utils/dates.ts
@@ -17,12 +17,12 @@ export function getEarliestFutureDateRange(
 
 export function isPast(date: Date): boolean {
   const now = new Date();
-  return date.valueOf() < now.valueOf();
+  return date < now;
 }
 
 export function isFuture(date: Date): boolean {
   const now = new Date();
-  return date.valueOf() > now.valueOf();
+  return date > now;
 }
 
 export function isSameMonth(date1: Date, date2: Date): boolean {

--- a/common/utils/dates.ts
+++ b/common/utils/dates.ts
@@ -25,6 +25,14 @@ export function isFuture(date: Date): boolean {
   return date.valueOf() > now.valueOf();
 }
 
+export function isSameDay(date1: Date, date2: Date): boolean {
+  return (
+    date1.getFullYear() === date2.getFullYear() &&
+    date1.getMonth() === date2.getMonth() &&
+    date1.getDate() === date2.getDate()
+  );
+}
+
 export function getNextWeekendDateRange(date: DateTypes): DateRange {
   const today = london(date);
   const todayInteger = today.day(); // day() return Sun as 0, Sat as 6

--- a/common/utils/dates.ts
+++ b/common/utils/dates.ts
@@ -1,17 +1,18 @@
 import { DateTypes, london } from './format-date';
 import { DateRange } from '../model/date-range';
-import { Moment } from 'moment';
 
 export function getEarliestFutureDateRange(
   dateRanges: DateRange[],
-  fromDate: Moment | undefined = london()
+  fromDate: Date | undefined = new Date()
 ): DateRange | undefined {
+  const now = new Date();
+
   return dateRanges
     .sort((a, b) => a.start.valueOf() - b.start.valueOf())
     .find(
       range =>
-        london(range.end).isSameOrAfter(fromDate, 'day') &&
-        london(range.end).isSameOrAfter(london(), 'day')
+        (isSameDay(range.end, fromDate) || range.end > fromDate) &&
+        (isSameDay(range.end, now) || range.end > now)
     );
 }
 

--- a/common/utils/dates.ts
+++ b/common/utils/dates.ts
@@ -25,12 +25,15 @@ export function isFuture(date: Date): boolean {
   return date.valueOf() > now.valueOf();
 }
 
-export function isSameDay(date1: Date, date2: Date): boolean {
+export function isSameMonth(date1: Date, date2: Date): boolean {
   return (
     date1.getFullYear() === date2.getFullYear() &&
-    date1.getMonth() === date2.getMonth() &&
-    date1.getDate() === date2.getDate()
+    date1.getMonth() === date2.getMonth()
   );
+}
+
+export function isSameDay(date1: Date, date2: Date): boolean {
+  return isSameMonth(date1, date2) && date1.getDate() === date2.getDate();
 }
 
 export function getNextWeekendDateRange(date: DateTypes): DateRange {

--- a/common/utils/dates.ts
+++ b/common/utils/dates.ts
@@ -10,9 +10,9 @@ export function getEarliestFutureDateRange(
   return dateRanges
     .sort((a, b) => (a.start > b.start ? 1 : -1))
     .find(
-      range =>
-        (isSameDay(range.end, fromDate) || range.end > fromDate) &&
-        (isSameDay(range.end, now) || range.end > now)
+      ({ end }) =>
+        (isSameDay(end, fromDate) || end > fromDate) &&
+        (isSameDay(end, now) || end > now)
     );
 }
 

--- a/common/utils/dates.ts
+++ b/common/utils/dates.ts
@@ -8,7 +8,7 @@ export function getEarliestFutureDateRange(
   const now = new Date();
 
   return dateRanges
-    .sort((a, b) => a.start.valueOf() - b.start.valueOf())
+    .sort((a, b) => (a.start > b.start ? 1 : -1))
     .find(
       range =>
         (isSameDay(range.end, fromDate) || range.end > fromDate) &&

--- a/common/views/components/DateRange/DateRange.tsx
+++ b/common/views/components/DateRange/DateRange.tsx
@@ -1,9 +1,9 @@
 import { FunctionComponent } from 'react';
-import { london } from '../../../utils/format-date';
 import HTMLDate from '../HTMLDate/HTMLDate';
 import HTMLDayDate from '../HTMLDayDate/HTMLDayDate';
 import HTMLTime from '../HTMLTime/HTMLTime';
 import { DateRange as DateRangeProps } from '../../../model/date-range';
+import { isSameDay } from '../../../utils/dates';
 
 const TimeRange = ({ start, end }: DateRangeProps) => (
   <>
@@ -19,9 +19,7 @@ const DateRange: FunctionComponent<Props> = ({
   end,
   splitTime,
 }: Props) => {
-  const isSameDay = london(start).isSame(end, 'day');
-
-  return isSameDay ? (
+  return isSameDay(start, end) ? (
     <>
       <HTMLDayDate date={start} />
       {splitTime ? '' : ', '}

--- a/content/webapp/components/CardGrid/CardGrid.tsx
+++ b/content/webapp/components/CardGrid/CardGrid.tsx
@@ -1,5 +1,4 @@
 import { FunctionComponent } from 'react';
-import moment from 'moment';
 import { classNames, cssGrid } from '@weco/common/utils/classnames';
 import { Link } from '../../types/link';
 import { convertItemToCardProps } from '../../types/card';
@@ -21,7 +20,7 @@ type Props = {
   itemsPerRow: number;
   itemsHaveTransparentBackground?: boolean;
   links?: Link[];
-  fromDate?: moment.Moment;
+  fromDate?: Date;
 };
 
 const CardGrid: FunctionComponent<Props> = ({

--- a/content/webapp/components/EventDateRange/EventDateRange.tsx
+++ b/content/webapp/components/EventDateRange/EventDateRange.tsx
@@ -1,12 +1,11 @@
 import { getEarliestFutureDateRange } from '@weco/common/utils/dates';
 import DateRange from '@weco/common/views/components/DateRange/DateRange';
 import { Event, EventBasic } from '../../types/events';
-import { Moment } from 'moment';
 
 type Props = {
   event: Event | EventBasic;
   splitTime?: boolean;
-  fromDate?: Moment;
+  fromDate?: Date;
 };
 
 const EventDateRange = ({ event, splitTime, fromDate }: Props) => {

--- a/content/webapp/components/EventPromo/EventPromo.tsx
+++ b/content/webapp/components/EventPromo/EventPromo.tsx
@@ -1,5 +1,4 @@
 import { FC } from 'react';
-import moment from 'moment';
 import { font, classNames } from '@weco/common/utils/classnames';
 import { trackEvent } from '@weco/common/utils/ga';
 import { UiImage } from '@weco/common/views/components/Images/Images';
@@ -21,7 +20,7 @@ type Props = {
   position?: number;
   dateString?: string;
   timeString?: string;
-  fromDate?: moment.Moment;
+  fromDate?: Date;
 };
 
 function getLocationText(isOnline?: boolean, place?: Place): string {

--- a/content/webapp/components/EventsByMonth/EventsByMonth.tsx
+++ b/content/webapp/components/EventsByMonth/EventsByMonth.tsx
@@ -46,11 +46,15 @@ function getMonthsInDateRange(
   acc: YearMonth[] = []
 ): YearMonth[] {
   if (isSameMonth(start, end) || start <= end) {
-    const newAcc = acc.concat({
+    const yearMonth = {
       year: start.getFullYear(),
       month: start.getMonth(),
+    };
+    const newAcc = acc.concat(yearMonth);
+    const newStart = startOf({
+      ...yearMonth,
+      month: yearMonth.month + 1,
     });
-    const newStart = new Date(start.getFullYear(), start.getMonth() + 1, 1);
     return getMonthsInDateRange({ start: newStart, end }, newAcc);
   } else {
     return acc;

--- a/content/webapp/components/EventsByMonth/EventsByMonth.tsx
+++ b/content/webapp/components/EventsByMonth/EventsByMonth.tsx
@@ -141,9 +141,11 @@ class EventsByMonth extends Component<Props, State> {
     // Order months correctly.  This returns the headings for each month,
     // now in chronological order.
     const monthHeadings = Object.keys(eventsInMonths)
-      .sort((a, b) => {
-        return london(a).toDate().getTime() - london(b).toDate().getTime();
-      })
+      .sort((a, b) =>
+        // Because these are YYYY-MM strings (e.g. '2001-02'), we can use
+        // lexicographic ordering for the correct results here.
+        a >= b ? 1 : -1
+      )
       .map(month => ({
         id: month,
         url: `#${month}`,

--- a/content/webapp/components/EventsByMonth/EventsByMonth.tsx
+++ b/content/webapp/components/EventsByMonth/EventsByMonth.tsx
@@ -2,7 +2,12 @@ import { Component } from 'react';
 import sortBy from 'lodash.sortby';
 import { Moment } from 'moment';
 import { london } from '@weco/common/utils/format-date';
-import { getEarliestFutureDateRange } from '@weco/common/utils/dates';
+import {
+  getEarliestFutureDateRange,
+  isFuture,
+  isSameDay,
+  isSameMonth,
+} from '@weco/common/utils/dates';
 import { classNames, cssGrid } from '@weco/common/utils/classnames';
 import SegmentedControl from '@weco/common/views/components/SegmentedControl/SegmentedControl';
 import { EventBasic } from '../../types/events';
@@ -88,27 +93,22 @@ class EventsByMonth extends Component<Props, State> {
           // for a month, e.g. a Jan-Feb-Mar event wouldn't appear in the February events.
           // Do we have any such long-running events?  If so, this is probably okay.
           const hasDateInMonthRemaining = event.times.find(time => {
-            const end = london(time.range.endDateTime);
-            const start = london(time.range.startDateTime);
             const monthAndYear = london(month);
 
-            const endsInMonth = end.isSame(
-              london({
-                M: monthAndYear.month(),
-                Y: monthAndYear.year(),
-              }),
-              'month'
+            const endsInMonth = isSameMonth(
+              time.range.endDateTime,
+              monthAndYear.toDate()
             );
 
-            const startsInMonth = start.isSame(
-              london({
-                M: monthAndYear.month(),
-                Y: monthAndYear.year(),
-              }),
-              'month'
+            const startsInMonth = isSameMonth(
+              time.range.startDateTime,
+              monthAndYear.toDate()
             );
 
-            const isNotClosedYet = end.isSameOrAfter(london(), 'day');
+            const today = new Date();
+            const isNotClosedYet =
+              isSameDay(time.range.endDateTime, today) ||
+              isFuture(time.range.endDateTime);
 
             return (endsInMonth || startsInMonth) && isNotClosedYet;
           });

--- a/content/webapp/components/EventsByMonth/EventsByMonth.tsx
+++ b/content/webapp/components/EventsByMonth/EventsByMonth.tsx
@@ -118,20 +118,15 @@ class EventsByMonth extends Component<Props, State> {
           // for a month, e.g. a Jan-Feb-Mar event wouldn't appear in the February events.
           // Do we have any such long-running events?  If so, this is probably okay.
           const hasDateInMonthRemaining = event.times.find(time => {
-            const endsInMonth = isSameMonth(
-              time.range.endDateTime,
-              startOf(month)
-            );
+            const start = time.range.startDateTime;
+            const end = time.range.endDateTime;
 
-            const startsInMonth = isSameMonth(
-              time.range.startDateTime,
-              startOf(month)
-            );
+            const endsInMonth = isSameMonth(end, startOf(month));
+
+            const startsInMonth = isSameMonth(start, startOf(month));
 
             const today = new Date();
-            const isNotClosedYet =
-              isSameDay(time.range.endDateTime, today) ||
-              isFuture(time.range.endDateTime);
+            const isNotClosedYet = isSameDay(end, today) || isFuture(end);
 
             return (endsInMonth || startsInMonth) && isNotClosedYet;
           });


### PR DESCRIPTION
## Who is this for?

Developers.

## What is it doing for them?

Follows https://github.com/wellcomecollection/wellcomecollection.org/pull/7829. This introduces two helpers `isSameDay(Date, Date)` and `isSameMonth(Date, Date)` which are a stand-in for a similar method `Moment.isSame(Moment, 'day' | 'month')`. Date comparison logic is timezone-agnostic, and so we don't need to be casting to London timezones before we compare here.

This is somewhat tricky to test because we only have one upcoming event at the moment, but I've stared at it quite hard to check I've not broken anything. 🤞

For https://github.com/wellcomecollection/wellcomecollection.org/issues/7831