### PR TITLE
Make gzip work again

### DIFF
--- a/cache/modules/cloudfront_policies/cache_policies.tf
+++ b/cache/modules/cloudfront_policies/cache_policies.tf
@@ -7,6 +7,8 @@ resource "aws_cloudfront_cache_policy" "toggle_cookies_only" {
   max_ttl     = local.one_day
 
   parameters_in_cache_key_and_forwarded_to_origin {
+    enable_accept_encoding_gzip = true
+
     cookies_config {
       cookie_behavior = "whitelist"
 
@@ -34,6 +36,8 @@ resource "aws_cloudfront_cache_policy" "static_content" {
   max_ttl     = local.one_year
 
   parameters_in_cache_key_and_forwarded_to_origin {
+    enable_accept_encoding_gzip = true
+
     cookies_config {
       cookie_behavior = "none"
     }
@@ -57,6 +61,8 @@ resource "aws_cloudfront_cache_policy" "weco_apps" {
   max_ttl     = local.one_day
 
   parameters_in_cache_key_and_forwarded_to_origin {
+    enable_accept_encoding_gzip = true
+
     cookies_config {
       cookie_behavior = "whitelist"
 
@@ -103,6 +109,8 @@ resource "aws_cloudfront_cache_policy" "short_lived_toggles_only" {
   max_ttl     = local.one_minute
 
   parameters_in_cache_key_and_forwarded_to_origin {
+    enable_accept_encoding_gzip = true
+
     cookies_config {
       cookie_behavior = "whitelist"
 

--- a/common/next/next.config.js
+++ b/common/next/next.config.js
@@ -24,7 +24,9 @@ const createConfig =
     return withMDX(
       withTM({
         ...defaultConfig,
-        compress: false, // We handle this in the nginx sidecar
+        // We handle compression in the nginx sidecar
+        // Are you having problems with this? Make sure CloudFront is forwarding Accept-Encoding headers to our apps!
+        compress: false,
         images: options.images || {},
         assetPrefix:
           isProd && prodSubdomain

--- a/common/next/next.config.js
+++ b/common/next/next.config.js
@@ -24,6 +24,7 @@ const createConfig =
     return withMDX(
       withTM({
         ...defaultConfig,
+        compress: false, // We handle this in the nginx sidecar
         images: options.images || {},
         assetPrefix:
           isProd && prodSubdomain

--- a/identity/webapp/next.config.js
+++ b/identity/webapp/next.config.js
@@ -31,7 +31,9 @@ const config = function () {
   });
 
   return withTM({
-    compress: false, // We handle this in the nginx sidecar
+    // We handle compression in the nginx sidecar
+    // Are you having problems with this? Make sure CloudFront is forwarding Accept-Encoding headers to our apps!
+    compress: false,
     assetPrefix:
       isProd && prodSubdomain
         ? `https://${prodSubdomain}.wellcomecollection.org${basePath}`

--- a/identity/webapp/next.config.js
+++ b/identity/webapp/next.config.js
@@ -31,6 +31,7 @@ const config = function () {
   });
 
   return withTM({
+    compress: false, // We handle this in the nginx sidecar
     assetPrefix:
       isProd && prodSubdomain
         ? `https://${prodSubdomain}.wellcomecollection.org${basePath}`


### PR DESCRIPTION
I was just looking at the Lighthouse reports to see if we'd be able to notice the impact of @gestchild's recent changes when I noticed a _massive_ performance drop in January:
<img width="366" alt="image" src="https://user-images.githubusercontent.com/4429247/159299149-71601210-6ebf-4a76-aab9-11971775576d.png">

Gzip compression just stopped working! This was around the time that I was messing with CloudFront, and sure enough, that was the issue. Although we have correctly configured nginx to compress stuff, we weren't forwarding the headers correctly - this PR fixes that.
