### PR TITLE
Restore the lighthouse report on deploy

### DIFF
--- a/.github/workflows/lighthouse_integration.yml
+++ b/.github/workflows/lighthouse_integration.yml
@@ -1,0 +1,26 @@
+name: Lighthouse integration
+
+on: deployment_status
+jobs:
+  run_lighthouse:
+    name: Lighthouse report
+    runs-on: ubuntu-20.04
+    if: |
+      github.event.deployment.task == 'deploy:weco' &&
+      github.event.deployment_status.state == 'success'
+    steps:
+      - uses: actions/checkout@v2
+      - name: Create URLs list
+        id: urls
+        run: ./.github/scripts/get-lighthouse-urls.sh
+        env:
+          DEPLOYMENT_ID: ${{ github.event.deployment.id }}
+          DEPLOYMENT_STATUS_ID: ${{ github.event.deployment_status.id }}
+      - name: Run report and upload results
+        uses: treosh/lighthouse-ci-action@v8
+        with:
+          urls: ${{ steps.urls.outputs.list }}
+          serverBaseUrl: https://lighthouse.wellcomecollection.org
+          serverToken: ${{ secrets.LHCI_BUILD_TOKEN }}
+        env:
+          LHCI_BUILD_CONTEXT__CURRENT_BRANCH: "main"


### PR DESCRIPTION
https://github.com/wellcomecollection/wellcomecollection.org/pull/7671 was a little over-enthusiastic, the LHCI report on deploys is actually useful and was what caught https://github.com/wellcomecollection/wellcomecollection.org/pull/7833