### PR TITLE
Display the three *newest* events on an event series page

### DIFF
--- a/content/webapp/components/Exhibition/Exhibition.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.tsx
@@ -232,22 +232,6 @@ const Exhibition: FC<Props> = ({ exhibition, pages }) => {
     ],
   };
 
-  const genericFields = {
-    id: exhibition.id,
-    title: exhibition.title,
-    promo: exhibition.promo,
-    body: exhibition.body,
-    standfirst: exhibition.standfirst,
-    promoImage: exhibition.promoImage,
-    promoText: exhibition.promoText,
-    image: exhibition.image,
-    squareImage: exhibition.squareImage,
-    widescreenImage: exhibition.widescreenImage,
-    superWidescreenImage: exhibition.superWidescreenImage,
-    labels: exhibition.labels,
-    metadataDescription: exhibition.metadataDescription,
-  };
-
   // TODO: Do we need to re-cast to Date here?  We've sometimes seen issues
   // caused by JSON serialisation, but that should be handled elsewhere by
   // the fixExhibitionDatesInJson helper.
@@ -261,9 +245,9 @@ const Exhibition: FC<Props> = ({ exhibition, pages }) => {
   );
 
   // This is for content that we don't have the crops for in Prismic
-  const maybeHeroPicture = getHeroPicture(genericFields);
+  const maybeHeroPicture = getHeroPicture(exhibition);
   const maybeFeaturedMedia = !maybeHeroPicture
-    ? getFeaturedMedia(genericFields)
+    ? getFeaturedMedia(exhibition)
     : undefined;
 
   const Header = (

--- a/content/webapp/pages/article-series.tsx
+++ b/content/webapp/pages/article-series.tsx
@@ -107,26 +107,10 @@ const ArticleSeriesPage: FC<Props> = props => {
     ],
   };
 
-  const genericFields = {
-    id: series.id,
-    title: series.title,
-    promo: series.promo,
-    body: series.body,
-    standfirst: series.standfirst,
-    promoImage: series.promoImage,
-    promoText: series.promoText,
-    image: series.image,
-    squareImage: series.squareImage,
-    widescreenImage: series.widescreenImage,
-    superWidescreenImage: series.superWidescreenImage,
-    labels: series.labels,
-    metadataDescription: series.metadataDescription,
-  };
-
   const ContentTypeInfo = series.standfirst && (
     <PageHeaderStandfirst html={series.standfirst} />
   );
-  const FeaturedMedia = getFeaturedMedia(genericFields);
+  const FeaturedMedia = getFeaturedMedia(series);
   const Header = (
     <PageHeader
       breadcrumbs={breadcrumbs}

--- a/content/webapp/pages/article.tsx
+++ b/content/webapp/pages/article.tsx
@@ -178,22 +178,6 @@ const ArticlePage: FC<Props> = ({ article }) => {
     />
   );
 
-  const genericFields = {
-    id: article.id,
-    title: article.title,
-    promo: article.promo,
-    body: article.body,
-    standfirst: article.standfirst,
-    promoImage: article.promoImage,
-    promoText: article.promoText,
-    image: article.image,
-    squareImage: article.squareImage,
-    widescreenImage: article.widescreenImage,
-    superWidescreenImage: article.superWidescreenImage,
-    labels: article.labels,
-    metadataDescription: article.metadataDescription,
-  };
-
   const ContentTypeInfo = (
     <Fragment>
       {article.standfirst && <PageHeaderStandfirst html={article.standfirst} />}
@@ -257,9 +241,9 @@ const ArticlePage: FC<Props> = ({ article }) => {
   );
 
   // This is for content that we don't have the crops for in Prismic
-  const maybeHeroPicture = getHeroPicture(genericFields);
+  const maybeHeroPicture = getHeroPicture(article);
   const maybeFeaturedMedia = !maybeHeroPicture
-    ? getFeaturedMedia(genericFields)
+    ? getFeaturedMedia(article)
     : undefined;
   const isImageGallery =
     article.format &&

--- a/content/webapp/pages/event-series.tsx
+++ b/content/webapp/pages/event-series.tsx
@@ -134,10 +134,10 @@ const EventSeriesPage: FC<Props> = ({ series, events: jsonEvents }) => {
     })
     .sort((a, b) => {
       const aStartTime = Math.min(
-        ...a.times.map(aTime => aTime.range.startDateTime.getTime())
+        ...a.times.map(aTime => aTime.range.startDateTime.valueOf())
       );
       const bStartTime = Math.min(
-        ...b.times.map(bTime => bTime.range.startDateTime.getTime())
+        ...b.times.map(bTime => bTime.range.startDateTime.valueOf())
       );
       return aStartTime - bStartTime;
     });
@@ -146,10 +146,10 @@ const EventSeriesPage: FC<Props> = ({ series, events: jsonEvents }) => {
     .filter(event => upcomingEventsIds.indexOf(event.id) === -1)
     .sort((a, b) => {
       const aStartTime = Math.min(
-        ...a.times.map(aTime => aTime.range.startDateTime.getTime())
+        ...a.times.map(aTime => aTime.range.startDateTime.valueOf())
       );
       const bStartTime = Math.min(
-        ...b.times.map(bTime => bTime.range.startDateTime.getTime())
+        ...b.times.map(bTime => bTime.range.startDateTime.valueOf())
       );
       return aStartTime - bStartTime;
     })

--- a/content/webapp/pages/event-series.tsx
+++ b/content/webapp/pages/event-series.tsx
@@ -1,6 +1,6 @@
 import { GetServerSideProps } from 'next';
 import { EventSeries } from '../types/event-series';
-import { Event, EventBasic } from '../types/events';
+import { EventBasic } from '../types/events';
 import { FC } from 'react';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import HeaderBackground from '@weco/common/views/components/HeaderBackground/HeaderBackground';
@@ -31,7 +31,7 @@ import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 
 type Props = {
   series: EventSeries;
-  jsonLd: JsonLdObj;
+  jsonLd: JsonLdObj[];
   pastEvents: EventBasic[];
   upcomingEvents: EventBasic[];
 };

--- a/content/webapp/pages/event-series.tsx
+++ b/content/webapp/pages/event-series.tsx
@@ -154,23 +154,7 @@ const EventSeriesPage: FC<Props> = ({
     ],
   };
 
-  const genericFields = {
-    id: series.id,
-    title: series.title,
-    promo: series.promo,
-    body: series.body,
-    standfirst: series.standfirst,
-    promoImage: series.promoImage,
-    promoText: series.promoText,
-    image: series.image,
-    squareImage: series.squareImage,
-    widescreenImage: series.widescreenImage,
-    superWidescreenImage: series.superWidescreenImage,
-    labels: series.labels,
-    metadataDescription: series.metadataDescription,
-  };
-
-  const FeaturedMedia = getFeaturedMedia(genericFields);
+  const FeaturedMedia = getFeaturedMedia(series);
   const Header = (
     <PageHeader
       breadcrumbs={breadcrumbs}

--- a/content/webapp/pages/event-series.tsx
+++ b/content/webapp/pages/event-series.tsx
@@ -199,10 +199,9 @@ const EventSeriesPage: FC<Props> = ({
         Body={<Body body={series.body} pageId={series.id} />}
         contributors={series.contributors}
       >
-        {upcomingEvents.length > 0 && (
+        {upcomingEvents.length > 0 ? (
           <SearchResults items={upcomingEvents} title={`What's next`} />
-        )}
-        {upcomingEvents.length === 0 && (
+        ) : (
           <h2 className="h2">
             No events scheduled at the moment, check back soon…
           </h2>

--- a/content/webapp/pages/event.tsx
+++ b/content/webapp/pages/event.tsx
@@ -185,22 +185,7 @@ const EventPage: NextPage<Props> = ({ jsonEvent }: Props) => {
 
   const event = fixEventDatesInJson(jsonEvent);
 
-  const genericFields = {
-    id: event.id,
-    title: event.title,
-    promo: event.promo,
-    body: event.body,
-    standfirst: event.standfirst,
-    promoImage: event.promoImage,
-    promoText: event.promoText,
-    image: event.image,
-    squareImage: event.squareImage,
-    widescreenImage: event.widescreenImage,
-    labels: event.labels,
-    metadataDescription: event.metadataDescription,
-  };
-
-  const maybeFeaturedMedia = getFeaturedMedia(genericFields);
+  const maybeFeaturedMedia = getFeaturedMedia(event);
   const hasFeaturedVideo =
     event.body.length > 0 && event.body[0].type === 'videoEmbed';
   const body = hasFeaturedVideo


### PR DESCRIPTION
## Who is this for?

Lalita, who noticed in Slack that we're displaying the three *oldest* events in a series, vs the three *newest*. Flipping the ordering in `getPastEvents` does the trick. See https://wellcome.slack.com/archives/C3N7J05TK/p1647884830511289

Additionally, I did some refactoring to reduce the size of this page – we fetch *all* the events for a series, but we only display a handful of them. I've moved that filtering into `getServerSideProps`, so we only send events we're actually going to render. Combining that with Gareth's work on sending "basic" properties makes a substantial difference:

Looking at /event-series/W5Zj_CYAACQALK5B:

<table><tr><th>page</th><th>size</th></tr>
<tr><td>original page</td><td>663KB</td></tr>
<tr><td>using EventBasic</td><td>551KB (–17%)</td></tr>
<tr><td>filtering the events we send</td><td>253KB (–62%)</td></tr>
</table>

We can probably do stuff like this elsewhere, but I haven't gone looking.

## What is it doing for them?

Showing the right events, and showing them faster.