### PR TITLE
Add comments explaining why we omit alt text on promos

### DIFF
--- a/content/webapp/components/ArticleCard/ArticleCard.tsx
+++ b/content/webapp/components/ArticleCard/ArticleCard.tsx
@@ -65,7 +65,12 @@ const ArticleCard: FunctionComponent<Props> = ({
       Image={
         (image && (
           <PrismicImage
-            image={image}
+            // We intentionally omit the alt text on promos, so screen reader
+            // users don't have to listen to the alt text before hearing the
+            // title of the item in the list.
+            //
+            // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
+            image={{...image, alt: ""}}
             sizes={{
               xlarge: 1 / 3,
               large: 1 / 3,

--- a/content/webapp/components/BookPromo/BookPromo.tsx
+++ b/content/webapp/components/BookPromo/BookPromo.tsx
@@ -70,6 +70,11 @@ const BookPromo: FunctionComponent<Props> = ({ book }: Props): ReactElement => {
                 contentUrl={cover.contentUrl}
                 width={cover.width || 0}
                 height={cover.height || 0}
+                // We intentionally omit the alt text on promos, so screen reader
+                // users don't have to listen to the alt text before hearing the
+                // title of the item in the list.
+                //             
+                // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
                 alt=""
                 sizesQueries="(min-width: 1420px) 386px, (min-width: 960px) calc(28.64vw - 15px), (min-width: 600px) calc(50vw - 54px), calc(100vw - 36px)"
               />

--- a/content/webapp/components/Card/Card.tsx
+++ b/content/webapp/components/Card/Card.tsx
@@ -90,6 +90,11 @@ const Card: FunctionComponent<Props> = ({ item }: Props) => {
         {item.image && item.image.crops && item.image.crops['16:9'] && (
           <UiImage
             {...item.image.crops['16:9']}
+            // We intentionally omit the alt text on promos, so screen reader
+            // users don't have to listen to the alt text before hearing the
+            // title of the item in the list.
+            //
+            // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
             alt=""
             sizesQueries="(min-width: 1420px) 386px, (min-width: 960px) calc(28.64vw - 15px), (min-width: 600px) calc(33.24vw - 43px), calc(100vw - 36px)"
             showTasl={false}

--- a/content/webapp/components/EventPromo/EventPromo.tsx
+++ b/content/webapp/components/EventPromo/EventPromo.tsx
@@ -56,6 +56,11 @@ const EventPromo: FC<Props> = ({
           <UiImage
             {...event.promoImage}
             crops={{}}
+            // We intentionally omit the alt text on promos, so screen reader
+            // users don't have to listen to the alt text before hearing the
+            // title of the item in the list.
+            //
+            // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
             alt=""
             sizesQueries="(min-width: 1420px) 386px, (min-width: 960px) calc(28.64vw - 15px), (min-width: 600px) calc(50vw - 54px), calc(100vw - 36px)"
             showTasl={false}

--- a/content/webapp/components/ExhibitionPromo/ExhibitionPromo.tsx
+++ b/content/webapp/components/ExhibitionPromo/ExhibitionPromo.tsx
@@ -47,7 +47,7 @@ const ExhibitionPromo = ({ exhibition, position = 0 }: Props) => {
             // title of the item in the list.
             //
             // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
-            image={...image, alt: ""}
+            image={{...image, alt: ""}}
             sizes={{
               xlarge: 1 / 3,
               large: 1 / 3,

--- a/content/webapp/components/ExhibitionPromo/ExhibitionPromo.tsx
+++ b/content/webapp/components/ExhibitionPromo/ExhibitionPromo.tsx
@@ -42,7 +42,12 @@ const ExhibitionPromo = ({ exhibition, position = 0 }: Props) => {
       <div className="relative">
         {isNotUndefined(image) ? (
           <PrismicImage
-            image={image}
+            // We intentionally omit the alt text on promos, so screen reader
+            // users don't have to listen to the alt text before hearing the
+            // title of the item in the list.
+            //
+            // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
+            image={...image, alt: ""}
             sizes={{
               xlarge: 1 / 3,
               large: 1 / 3,

--- a/content/webapp/components/FeaturedCard/FeaturedCard.tsx
+++ b/content/webapp/components/FeaturedCard/FeaturedCard.tsx
@@ -58,6 +58,11 @@ export function convertItemToFeaturedCardProps(
   return {
     id: item.id,
     image: item.promoImage && {
+      // We intentionally omit the alt text on promos, so screen reader
+      // users don't have to listen to the alt text before hearing the
+      // title of the item in the list.
+      //
+      // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
       alt: '',
       contentUrl: item.promoImage.contentUrl,
       width: item.promoImage.width,

--- a/content/webapp/components/SearchResults/SearchResults.tsx
+++ b/content/webapp/components/SearchResults/SearchResults.tsx
@@ -60,6 +60,11 @@ const SearchResults: FunctionComponent<Props> = ({
               item.image &&
               item.image.crops &&
               item.image.crops.square && (
+                // We intentionally omit the alt text on promos, so screen reader
+                // users don't have to listen to the alt text before hearing the
+                // title of the item in the list.
+                //
+                // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
                 <Image {...item.image.crops.square} alt="" />
               )
             }
@@ -80,6 +85,11 @@ const SearchResults: FunctionComponent<Props> = ({
               item.image &&
               item.image.crops &&
               item.image.crops.square && (
+                // We intentionally omit the alt text on promos, so screen reader
+                // users don't have to listen to the alt text before hearing the
+                // title of the item in the list.
+                //
+                // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
                 <Image {...item.image.crops.square} alt="" />
               )
             }
@@ -100,6 +110,11 @@ const SearchResults: FunctionComponent<Props> = ({
               item.cover &&
               item.cover.crops &&
               item.cover.crops.square && (
+                // We intentionally omit the alt text on promos, so screen reader
+                // users don't have to listen to the alt text before hearing the
+                // title of the item in the list.
+                //
+                // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
                 <Image {...item.cover.crops.square} alt="" />
               )
             }
@@ -146,6 +161,11 @@ const SearchResults: FunctionComponent<Props> = ({
               item.image &&
               item.image.crops &&
               item.image.crops.square && (
+                // We intentionally omit the alt text on promos, so screen reader
+                // users don't have to listen to the alt text before hearing the
+                // title of the item in the list.
+                //
+                // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
                 <Image {...item.image.crops.square} alt="" />
               )
             }

--- a/content/webapp/components/StoryPromo/StoryPromo.tsx
+++ b/content/webapp/components/StoryPromo/StoryPromo.tsx
@@ -69,7 +69,12 @@ const StoryPromo: FunctionComponent<Props> = ({
       <div className="relative">
         {isNotUndefined(image) && (
           <PrismicImage
-            image={image}
+            // We intentionally omit the alt text on promos, so screen reader
+            // users don't have to listen to the alt text before hearing the
+            // title of the item in the list.
+            //
+            // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
+            image={...image, alt: ''}
             sizes={{
               xlarge: 1 / 3,
               large: 1 / 3,

--- a/content/webapp/components/StoryPromo/StoryPromo.tsx
+++ b/content/webapp/components/StoryPromo/StoryPromo.tsx
@@ -74,7 +74,7 @@ const StoryPromo: FunctionComponent<Props> = ({
             // title of the item in the list.
             //
             // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
-            image={...image, alt: ''}
+            image={{...image, alt: ''}}
             sizes={{
               xlarge: 1 / 3,
               large: 1 / 3,


### PR DESCRIPTION
For #6007.  This is an intentional omission, but you can only find it by looking in the Git blame history -- so a well-meaning developer might revert it without realising why we've done it this way.  These comments make this a bit easier to understand and will avoid reversions.

See also #6586, where this change was originally made. It's been rolled back in a few places already, so I've un-rolled it back.

## Who is this for?

Me.

## What is it doing for them?

Helping me remember why this code is written this way.