### PR TITLE
Take the ab test cookies out of the playwright tests

### DIFF
--- a/playwright/test/articles.test.ts
+++ b/playwright/test/articles.test.ts
@@ -1,17 +1,15 @@
 import { article, articleWithMockSiblings } from './contexts';
 import { baseUrl } from './helpers/urls';
-import { makeDefaultToggleAndTestCookies } from './helpers/utils';
+import { makeDefaultToggleCookies } from './helpers/utils';
 import { oneScheduleItem } from './mocks/one-schedule-item';
 
 const domain = new URL(baseUrl).host;
 
 beforeAll(async () => {
-  const defaultToggleAndTestCookies = await makeDefaultToggleAndTestCookies(
-    domain
-  );
+  const defaultToggleCookies = await makeDefaultToggleCookies(domain);
   await context.addCookies([
     { name: 'WC_cookiesAccepted', value: 'true', domain: domain, path: '/' },
-    ...defaultToggleAndTestCookies,
+    ...defaultToggleCookies,
   ]);
 });
 

--- a/playwright/test/events.test.ts
+++ b/playwright/test/events.test.ts
@@ -1,16 +1,14 @@
 import { event } from './contexts';
 import { baseUrl } from './helpers/urls';
-import { makeDefaultToggleAndTestCookies } from './helpers/utils';
+import { makeDefaultToggleCookies } from './helpers/utils';
 
 const domain = new URL(baseUrl).host;
 
 beforeAll(async () => {
-  const defaultToggleAndTestCookies = await makeDefaultToggleAndTestCookies(
-    domain
-  );
+  const defaultToggleCookies = await makeDefaultToggleCookies(domain);
   await context.addCookies([
     { name: 'WC_cookiesAccepted', value: 'true', domain: domain, path: '/' },
-    ...defaultToggleAndTestCookies,
+    ...defaultToggleCookies,
   ]);
 });
 

--- a/playwright/test/helpers/utils.ts
+++ b/playwright/test/helpers/utils.ts
@@ -23,7 +23,7 @@ export async function makeDefaultToggleCookies(
   );
   const { toggles } = data;
 
-  return [...toggles].map(t => {
+  return toggles.map(t => {
     return {
       name: `${togglePrefix}${t.id}`,
       value: t.defaultValue.toString(),

--- a/playwright/test/helpers/utils.ts
+++ b/playwright/test/helpers/utils.ts
@@ -15,15 +15,15 @@ export type CookieType = {
 
 const togglePrefix = 'toggle_';
 
-export async function makeDefaultToggleAndTestCookies(
+export async function makeDefaultToggleCookies(
   domain: string
 ): Promise<CookieType[]> {
   const { data } = await axios.get(
     'https://toggles.wellcomecollection.org/toggles.json'
   );
-  const { toggles, tests } = data;
+  const { toggles } = data;
 
-  return [...toggles, ...tests].map(t => {
+  return [...toggles].map(t => {
     return {
       name: `${togglePrefix}${t.id}`,
       value: t.defaultValue.toString(),

--- a/playwright/test/request-items.test.ts
+++ b/playwright/test/request-items.test.ts
@@ -1,14 +1,12 @@
 import { workWithPhysicalLocationOnly } from './contexts';
 import { baseUrl } from './helpers/urls';
-import { makeDefaultToggleAndTestCookies } from './helpers/utils';
+import { makeDefaultToggleCookies } from './helpers/utils';
 
 const domain = new URL(baseUrl).host;
 
 beforeAll(async () => {
-  const defaultToggleAndTestCookies = await makeDefaultToggleAndTestCookies(
-    domain
-  );
-  await context.addCookies(defaultToggleAndTestCookies);
+  const defaultToggleCookies = await makeDefaultToggleCookies(domain);
+  await context.addCookies(defaultToggleCookies);
 });
 
 describe.skip('Scenario 1: researcher is logged out', () => {

--- a/playwright/test/stories.test.ts
+++ b/playwright/test/stories.test.ts
@@ -1,16 +1,14 @@
 import { gotoWithoutCache } from './contexts';
 import { baseUrl } from './helpers/urls';
-import { makeDefaultToggleAndTestCookies } from './helpers/utils';
+import { makeDefaultToggleCookies } from './helpers/utils';
 
 const domain = new URL(baseUrl).host;
 
 beforeAll(async () => {
-  const defaultToggleAndTestCookies = await makeDefaultToggleAndTestCookies(
-    domain
-  );
+  const defaultToggleCookies = await makeDefaultToggleCookies(domain);
   await context.addCookies([
     { name: 'WC_cookiesAccepted', value: 'true', domain: domain, path: '/' },
-    ...defaultToggleAndTestCookies,
+    ...defaultToggleCookies,
   ]);
 });
 

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -31,7 +31,7 @@ import {
   referenceNumber,
 } from './selectors/item';
 import { baseUrl } from './helpers/urls';
-import { makeDefaultToggleAndTestCookies } from './helpers/utils';
+import { makeDefaultToggleCookies } from './helpers/utils';
 
 const domain = new URL(baseUrl).host;
 
@@ -41,9 +41,7 @@ async function searchWithin(query: string) {
 }
 
 beforeAll(async () => {
-  const defaultToggleAndTestCookies = await makeDefaultToggleAndTestCookies(
-    domain
-  );
+  const defaultToggleAndTestCookies = await makeDefaultToggleCookies(domain);
   await context.addCookies([
     { name: 'WC_cookiesAccepted', value: 'true', domain: domain, path: '/' },
     ...defaultToggleAndTestCookies,


### PR DESCRIPTION
☝️ 

In the Playwright tests we add all of the toggle cookies set to their default values, so we can be sure we’re testing what most users are seeing. Up to now, we were also adding the A/B test toggles to these, and we’d been erroneously expecting these to have a default value (which is now making TypeScript complain). I think it makes more sense to remove the A/B test toggles altogether.