### PR TITLE
Don't send multiple copies of the crop data

### DIFF
--- a/common/model/image.ts
+++ b/common/model/image.ts
@@ -1,5 +1,7 @@
 import { Tasl } from './tasl';
 
+export type Crop = '32:15' | '16:9' | 'square';
+
 export type ImageType = {
   contentUrl: string;
   width: number;
@@ -7,7 +9,7 @@ export type ImageType = {
   alt: string | null;
   tasl?: Tasl;
   crops: {
-    [key: string]: ImageType;
+    [key in Crop]?: ImageType;
   };
 };
 

--- a/content/webapp/components/ArticleCard/ArticleCard.tsx
+++ b/content/webapp/components/ArticleCard/ArticleCard.tsx
@@ -24,7 +24,7 @@ const ArticleCard: FunctionComponent<Props> = ({
   xOfY,
 }: Props) => {
   const url = linkResolver(article);
-  const image = article.squareImage;
+  const image = article.image?.crops['square'];
 
   const seriesWithSchedule = article.series.find(
     series => (series.schedule ?? []).length > 0
@@ -70,7 +70,7 @@ const ArticleCard: FunctionComponent<Props> = ({
             // title of the item in the list.
             //
             // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
-            image={{...image, alt: ""}}
+            image={{ ...image, alt: '' }}
             sizes={{
               xlarge: 1 / 3,
               large: 1 / 3,

--- a/content/webapp/components/Installation/Installation.tsx
+++ b/content/webapp/components/Installation/Installation.tsx
@@ -30,21 +30,7 @@ const Installation: FunctionComponent<Props> = ({ installation }: Props) => {
     });
   }, []);
 
-  const FeaturedMedia = getFeaturedMedia({
-    id: installation.id,
-    title: installation.title,
-    promo: installation.promo,
-    body: installation.body,
-    standfirst: installation.standfirst,
-    promoImage: installation.promoImage,
-    promoText: installation.promoText,
-    image: installation.image,
-    squareImage: installation.squareImage,
-    widescreenImage: installation.widescreenImage,
-    superWidescreenImage: installation.superWidescreenImage,
-    labels: installation.labels,
-    metadataDescription: installation.metadataDescription,
-  });
+  const FeaturedMedia = getFeaturedMedia(installation);
 
   const breadcrumbs = {
     items: [

--- a/content/webapp/pages/season.tsx
+++ b/content/webapp/pages/season.tsx
@@ -74,13 +74,15 @@ const SeasonPage = ({
   projects,
   books,
 }: Props): ReactElement<Props> => {
+  const superWidescreenImage = season.image?.crops['32:15'];
+
   const Header = (
     <SeasonsHeader
       labels={{ labels: season.labels }}
       title={season.title}
       FeaturedMedia={
-        season.superWidescreenImage ? (
-          <UiImage {...season.superWidescreenImage} sizesQueries="" />
+        superWidescreenImage ? (
+          <UiImage {...superWidescreenImage} sizesQueries="" />
         ) : undefined
       }
       standfirst={season?.standfirst}

--- a/content/webapp/services/prismic/transformers/articles.ts
+++ b/content/webapp/services/prismic/transformers/articles.ts
@@ -60,7 +60,6 @@ export function transformArticleToArticleBasic(article: Article): ArticleBasic {
     promoImage,
     labels,
     promoText,
-    squareImage,
     color,
   }) => ({
     type,
@@ -75,7 +74,6 @@ export function transformArticleToArticleBasic(article: Article): ArticleBasic {
     promoImage,
     labels,
     promoText,
-    squareImage,
     color,
   }))(article);
 }

--- a/content/webapp/services/prismic/transformers/images.ts
+++ b/content/webapp/services/prismic/transformers/images.ts
@@ -2,7 +2,7 @@ import { Image, PromoSliceZone } from '../types';
 import { RichTextField } from '@prismicio/types';
 import { CaptionedImage } from '@weco/common/model/captioned-image';
 import isEmptyObj from '@weco/common/utils/is-empty-object';
-import { ImageType } from '@weco/common/model/image';
+import { Crop, ImageType } from '@weco/common/model/image';
 import { ImagePromo } from '../../../types/image-promo';
 import { asRichText, asText } from '.';
 import * as prismicT from '@prismicio/types';
@@ -19,7 +19,6 @@ export const placeHolderImage: ImageType = {
   crops: {},
 };
 
-type Crop = '16:9' | '32:15' | 'square';
 export function transformCaptionedImage(
   frag: { image: Image; caption: RichTextField },
   crop?: Crop

--- a/content/webapp/services/prismic/transformers/index.ts
+++ b/content/webapp/services/prismic/transformers/index.ts
@@ -166,13 +166,6 @@ export function transformLabelType(
   };
 }
 
-type PromoImage = {
-  image?: ImageType;
-  squareImage?: ImageType;
-  widescreenImage?: ImageType;
-  superWidescreenImage?: ImageType;
-};
-
 // TODO: Consider moving this into a dedicated file for body transformers.
 // TODO: Rather than doing transformation inline, have this function consistently
 // call out to other transformer functions (a la contentList).
@@ -386,23 +379,14 @@ export function transformGenericFields(doc: Doc): GenericContentFields {
   const { data } = doc;
   const promo = data.promo && transformImagePromo(data.promo);
 
-  const promoImage: PromoImage =
+  const image: ImageType | undefined =
     data.promo && data.promo.length > 0
       ? data.promo
           .filter((slice: prismicT.Slice) => slice.primary.image)
-          .map(({ primary: { image } }) => {
-            return {
-              image: transformImage(image),
-              squareImage: transformImage(image.square),
-              widescreenImage: transformImage(image['16:9']),
-              superWidescreenImage: transformImage(image['32:15']),
-            };
-          })
-          .find(_ => _) || {} // just get the first one;
-      : {};
+          .map(({ primary: { image } }) => transformImage(image))
+          .find(_ => _) || undefined // just get the first one;
+      : undefined;
 
-  const { image, squareImage, widescreenImage, superWidescreenImage } =
-    promoImage;
   const body = data.body ? transformBody(data.body) : [];
   const standfirst = body.find(slice => slice.type === 'standfirst');
   const metadataDescription = asText(data.metadataDescription);
@@ -412,13 +396,10 @@ export function transformGenericFields(doc: Doc): GenericContentFields {
     title: asTitle(data.title),
     body: body,
     standfirst: standfirst && standfirst.value,
-    promo: promo,
+    promo,
     promoText: promo && promo.caption,
     promoImage: promo && promo.image,
     image,
-    squareImage,
-    widescreenImage,
-    superWidescreenImage,
     metadataDescription,
     // we pass an empty array here to be overriden by each content type
     // TODO: find a way to enforce this.

--- a/content/webapp/services/prismic/types/index.ts
+++ b/content/webapp/services/prismic/types/index.ts
@@ -60,8 +60,6 @@ type Dimension = {
   height: number;
 };
 
-export type Crop = '32:15' | '16:9' | 'square';
-
 // Currently the Prismic types only allow you to specify 1 image
 type ThumbnailedImageField<Thumbnails extends Record<string, Dimension>> =
   FilledImageFieldImage & {

--- a/content/webapp/types/articles.ts
+++ b/content/webapp/types/articles.ts
@@ -26,7 +26,6 @@ export type ArticleBasic = {
   promoImage?: Picture;
   labels: Label[];
   promoText?: string;
-  squareImage?: ImageType;
   color?: ColorSelection;
 };
 

--- a/content/webapp/types/generic-content-fields.ts
+++ b/content/webapp/types/generic-content-fields.ts
@@ -24,9 +24,6 @@ export type GenericContentFields = {
   promoText?: string;
   promoImage?: Picture;
   image?: ImageType;
-  squareImage?: ImageType;
-  widescreenImage?: ImageType;
-  superWidescreenImage?: ImageType;
   metadataDescription?: string;
   labels: Label[];
 };

--- a/content/webapp/utils/page-header.tsx
+++ b/content/webapp/utils/page-header.tsx
@@ -11,7 +11,8 @@ export function getFeaturedMedia(
   isPicture?: boolean
 ): FeaturedMedia | undefined {
   const image = fields.promo && fields.promo.image;
-  const { squareImage, widescreenImage } = fields;
+  const squareImage = fields.image?.crops['square'];
+  const widescreenImage = fields.image?.crops['16:9'];
   const { body } = fields;
 
   const hasFeaturedVideo = body.length > 0 && body[0].type === 'videoEmbed';
@@ -38,7 +39,8 @@ export function getFeaturedMedia(
 export function getHeroPicture(
   fields: GenericContentFields
 ): ReactElement<typeof Picture> | undefined {
-  const { squareImage, widescreenImage } = fields;
+  const squareImage = fields.image?.crops['square'];
+  const widescreenImage = fields.image?.crops['16:9'];
 
   return (
     squareImage &&


### PR DESCRIPTION
Another piece extracted from https://github.com/wellcomecollection/wellcomecollection.org/pull/7838.

## Who is this for?

People who want whizzy fast pages.

## What is it doing for them?

Reducing the amount of data we send on the page, by not duplicating information about image crops. It's a modest gain, but all gains are good:

<table>
<tr><th>page</th><th>before</th><th>after</th></tr>
<tr><td>/</td><td>291KB</td><td>286KB (–1.7%)</td></tr>
<tr><td>/exhibitions/YLi_BhAAACEAebzp</td><td>294KB</td><td>288KB (–2%)</td></tr>
<tr><td>/articles/YjMIUhEAACAAWeQ_</td><td>246KB</td><td>244KB (–1%)</td></tr>
<tr><td>/articles/Yi8toBIAACIA1p4T</td><td>214KB</td><td>212KB (–1%)</td></tr>
</table>

There are also a couple of easy wins, by removing a few intermediate values we don't need.