### PR TITLE
Link to the Lighthouse URL from the GitHub Actions output

### DIFF
--- a/.github/workflows/lighthouse_integration.yml
+++ b/.github/workflows/lighthouse_integration.yml
@@ -24,3 +24,5 @@ jobs:
           serverToken: ${{ secrets.LHCI_BUILD_TOKEN }}
         env:
           LHCI_BUILD_CONTEXT__CURRENT_BRANCH: "main"
+      - name: Get link to results
+        run: echo https://lighthouse.wellcomecollection.org/app/projects/wellcomecollection.org/dashboard


### PR DESCRIPTION
So somebody looking at a GitHub Actions run can find the results.

## Who is this for?

Me.

## What is it doing for them?

Helping me find the Lighthouse scores.