### PR TITLE
Only send alt/tasl once for images, not for every crop

### DIFF
--- a/common/model/image.ts
+++ b/common/model/image.ts
@@ -2,16 +2,54 @@ import { Tasl } from './tasl';
 
 export type Crop = '32:15' | '16:9' | 'square';
 
-export type ImageType = {
+type ImageBase = {
   contentUrl: string;
   width: number;
   height: number;
+};
+
+export type ImageType = ImageBase & {
   alt: string | null;
   tasl?: Tasl;
-  crops: {
+
+  // We distinguish between two types of crop:
+  //
+  //  - A "simple" crop is one where we've just adjusted the boundary, but
+  //    the alt text and tasl are the same.  In this case, we can skip copying
+  //    identical data onto all the different crops.  This has a non-trivial benefit
+  //    for page weight.
+  //  - A "rich" crop is where the image has new alt text or tasl, e.g. because
+  //    the crop focuses on something distinct.  In this case, we need to include
+  //    the new alt/tasl data.
+  //
+  // Downstream callers should never access these fields directly -- instead, they
+  // should use getCrop(), which ensures they get the correct alt/tasl data.
+  simpleCrops?: {
+    [key in Crop]?: ImageBase;
+  };
+  richCrops?: {
     [key in Crop]?: ImageType;
   };
 };
+
+export function getCrop(
+  image: ImageType | undefined,
+  crop: Crop
+): ImageType | undefined {
+  const richImage = image?.richCrops && image?.richCrops[crop];
+  const simpleImage = image?.simpleCrops && image?.simpleCrops[crop];
+
+  return (
+    richImage ||
+    (simpleImage
+      ? {
+          ...simpleImage,
+          alt: image.alt,
+          tasl: image.tasl,
+        }
+      : undefined)
+  );
+}
 
 export type UiImageType = ImageType & {
   sizesQueries: string;

--- a/common/services/prismic/transformers/images.ts
+++ b/common/services/prismic/transformers/images.ts
@@ -1,5 +1,6 @@
 import { EmptyImageFieldImage, FilledImageFieldImage } from '@prismicio/types';
-import { ImageType } from '@weco/common/model/image';
+import { ImageType } from '../../../model/image';
+import { isUndefined } from '../../../utils/array';
 import { transformTaslFromString } from '.';
 
 // when images have crops, event if the image isn't attached, we get e.g.
@@ -36,12 +37,38 @@ function transformFilledImage(image: FilledImageFieldImage): ImageType {
       return acc;
     }, {});
 
+  const alt = image.alt!;
+
+  const simpleCrops = Object.keys(crops)
+    .filter(key => {
+      return (
+        crops[key].alt === alt &&
+        JSON.stringify(crops[key].tasl) === JSON.stringify(tasl)
+      );
+    })
+    .reduce((acc, key) => {
+      acc[key] = {
+        contentUrl: crops[key].contentUrl,
+        width: crops[key].width,
+        height: crops[key].height,
+      };
+      return acc;
+    }, {});
+
+  const richCrops = Object.keys(crops)
+    .filter(key => isUndefined(simpleCrops[key]))
+    .reduce((acc, key) => {
+      acc[key] = crops[key];
+      return acc;
+    }, {});
+
   return {
     contentUrl: image.url,
     width: image.dimensions.width,
     height: image.dimensions.height,
-    alt: image.alt!,
-    tasl: tasl,
-    crops: crops,
+    alt,
+    tasl,
+    simpleCrops,
+    richCrops,
   };
 }

--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -22,7 +22,7 @@ import ApiToolbar from '../ApiToolbar/ApiToolbar';
 import { usePrismicData, useToggles } from '../../../server-data/Context';
 import useHotjar from '../../../hooks/useHotjar';
 import { defaultPageTitle } from '@weco/common/data/microcopy';
-import { ImageType } from '@weco/common/model/image';
+import { getCrop, ImageType } from '@weco/common/model/image';
 import { convertImageUri } from '@weco/common/utils/convert-image-uri';
 
 export type SiteSection =
@@ -147,8 +147,7 @@ const PageLayoutComponent: FunctionComponent<Props> = ({
   //
   // See https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/summary-card-with-large-image
   // for more information on Twitter cards.
-  const socialPreviewCardImage =
-    image && image.crops['32:15'] ? image.crops['32:15'] : image;
+  const socialPreviewCardImage = getCrop(image, '32:15') || image;
 
   const imageUrl =
     socialPreviewCardImage &&

--- a/content/webapp/components/ArticleCard/ArticleCard.tsx
+++ b/content/webapp/components/ArticleCard/ArticleCard.tsx
@@ -8,6 +8,7 @@ import { isNotUndefined } from '@weco/common/utils/array';
 import PrismicImage from '../PrismicImage/PrismicImage';
 import { ArticleBasic } from '../../types/articles';
 import linkResolver from '../../services/prismic/link-resolver';
+import { getCrop } from '@weco/common/model/image';
 
 type Props = {
   article: ArticleBasic;
@@ -24,7 +25,7 @@ const ArticleCard: FunctionComponent<Props> = ({
   xOfY,
 }: Props) => {
   const url = linkResolver(article);
-  const image = article.image?.crops['square'];
+  const image = getCrop(article.image, 'square');
 
   const seriesWithSchedule = article.series.find(
     series => (series.schedule ?? []).length > 0

--- a/content/webapp/components/BannerCard/BannerCard.tsx
+++ b/content/webapp/components/BannerCard/BannerCard.tsx
@@ -10,6 +10,7 @@ import ButtonOutlined from '@weco/common/views/components/ButtonOutlined/ButtonO
 import DateRange from '@weco/common/views/components/DateRange/DateRange';
 import { arrowSmall } from '@weco/common/icons';
 import linkResolver from '../../services/prismic/link-resolver';
+import { getCrop } from '@weco/common/model/image';
 
 type CardOuterProps = {
   background: 'charcoal' | 'cream';
@@ -86,16 +87,18 @@ const BannerCard: FunctionComponent<Props> = ({
     image: item.promo &&
       item.promo.image && {
         contentUrl: item.promo.image.contentUrl,
+        // We intentionally omit the alt text on promos, so screen reader
+        // users don't have to listen to the alt text before hearing the
+        // title of the item in the list.
+        //
+        // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
         alt: '',
         width: 1600,
         height: 900,
         tasl: item.promo.image.tasl,
         crops: {
           '16:9': {
-            contentUrl:
-              item.image && item.image.crops && item.image.crops['16:9']
-                ? item.image.crops['16:9'].contentUrl
-                : '',
+            contentUrl: getCrop(item.image, '16:9')?.contentUrl || '',
             alt: '',
             width: 1600,
             height: 900,

--- a/content/webapp/components/BookPromo/BookPromo.tsx
+++ b/content/webapp/components/BookPromo/BookPromo.tsx
@@ -73,7 +73,7 @@ const BookPromo: FunctionComponent<Props> = ({ book }: Props): ReactElement => {
                 // We intentionally omit the alt text on promos, so screen reader
                 // users don't have to listen to the alt text before hearing the
                 // title of the item in the list.
-                //             
+                //
                 // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
                 alt=""
                 sizesQueries="(min-width: 1420px) 386px, (min-width: 960px) calc(28.64vw - 15px), (min-width: 600px) calc(50vw - 54px), calc(100vw - 36px)"

--- a/content/webapp/components/Card/Card.tsx
+++ b/content/webapp/components/Card/Card.tsx
@@ -7,6 +7,7 @@ import Space from '@weco/common/views/components/styled/Space';
 import styled from 'styled-components';
 import { FunctionComponent } from 'react';
 import PartNumberIndicator from '../PartNumberIndicator/PartNumberIndicator';
+import { getCrop } from '@weco/common/model/image';
 
 type Props = {
   item: CardType;
@@ -75,6 +76,8 @@ export const CardBody = styled(Space).attrs(() => ({
 `;
 
 const Card: FunctionComponent<Props> = ({ item }: Props) => {
+  const image = getCrop(item.image, '16:9');
+
   return (
     <CardOuter
       href={item.link}
@@ -87,9 +90,9 @@ const Card: FunctionComponent<Props> = ({ item }: Props) => {
       }}
     >
       <div className="relative">
-        {item.image && item.image.crops && item.image.crops['16:9'] && (
+        {image && (
           <UiImage
-            {...item.image.crops['16:9']}
+            {...image}
             // We intentionally omit the alt text on promos, so screen reader
             // users don't have to listen to the alt text before hearing the
             // title of the item in the list.

--- a/content/webapp/components/EventCard/EventCard.tsx
+++ b/content/webapp/components/EventCard/EventCard.tsx
@@ -4,6 +4,7 @@ import Image from '@weco/common/views/components/Image/Image';
 import StatusIndicator from '@weco/common/views/components/StatusIndicator/StatusIndicator';
 import EventDateRange from '../EventDateRange/EventDateRange';
 import { classNames, font } from '@weco/common/utils/classnames';
+import { getCrop } from '@weco/common/model/image';
 
 type Props = {
   event: EventBasic;
@@ -13,9 +14,8 @@ type Props = {
 const EventCard = ({ event, xOfY }: Props) => {
   const DateRangeComponent = <EventDateRange event={event} />;
 
-  const ImageComponent = event.image &&
-    event.image.crops &&
-    event.image.crops.square && <Image {...event.image.crops.square} />;
+  const squareImage = getCrop(event.image, 'square');
+  const ImageComponent = squareImage && <Image {...squareImage} />;
 
   const firstTime = event.times[0];
   const lastTime = event.times[event.times.length - 1];

--- a/content/webapp/components/EventPromo/EventPromo.tsx
+++ b/content/webapp/components/EventPromo/EventPromo.tsx
@@ -55,7 +55,6 @@ const EventPromo: FC<Props> = ({
         {event.promoImage && (
           <UiImage
             {...event.promoImage}
-            crops={{}}
             // We intentionally omit the alt text on promos, so screen reader
             // users don't have to listen to the alt text before hearing the
             // title of the item in the list.

--- a/content/webapp/components/MediaObject/MediaObject.tsx
+++ b/content/webapp/components/MediaObject/MediaObject.tsx
@@ -3,7 +3,7 @@ import Image from '@weco/common/views/components/Image/Image';
 import MediaObjectBase, {
   HasImageProps,
 } from '../MediaObjectBase/MediaObjectBase';
-import { ImageType } from '@weco/common/model/image';
+import { getCrop, ImageType } from '@weco/common/model/image';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
 import styled from 'styled-components';
 import { grid, classNames, font } from '@weco/common/utils/classnames';
@@ -57,8 +57,9 @@ export const MediaObject: FunctionComponent<Props> = ({
   image,
   sizesQueries,
 }: Props): ReactElement<Props> => {
-  const ImageComponent = image?.crops?.square && (
-    <Image {...image.crops.square} sizesQueries={sizesQueries} />
+  const squareImage = getCrop(image, 'square');
+  const ImageComponent = squareImage && (
+    <Image {...squareImage} sizesQueries={sizesQueries} />
   );
 
   const description = text && <PrismicHtmlBlock html={text} />;

--- a/content/webapp/components/SearchResults/SearchResults.tsx
+++ b/content/webapp/components/SearchResults/SearchResults.tsx
@@ -10,6 +10,7 @@ import ImagePlaceholder from '../ImagePlaceholder/ImagePlaceholder';
 import Space from '@weco/common/views/components/styled/Space';
 import ArticleCard from '../ArticleCard/ArticleCard';
 import { ArticleScheduleItem } from '../../types/article-schedule-items';
+import { getCrop } from '@weco/common/model/image';
 
 const Result = styled.div`
   border-top: 1px solid ${props => props.theme.color('pumice')};
@@ -57,15 +58,13 @@ const SearchResults: FunctionComponent<Props> = ({
             description={item.promo && item.promo.caption}
             urlOverride={item.promo && item.promo.link}
             Image={
-              item.image &&
-              item.image.crops &&
-              item.image.crops.square && (
+              getCrop(item.image, 'square') && (
                 // We intentionally omit the alt text on promos, so screen reader
                 // users don't have to listen to the alt text before hearing the
                 // title of the item in the list.
                 //
                 // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
-                <Image {...item.image.crops.square} alt="" />
+                <Image {...getCrop(item.image, 'square')!} alt="" />
               )
             }
             xOfY={{ x: index + 1, y: items.length }}
@@ -82,15 +81,13 @@ const SearchResults: FunctionComponent<Props> = ({
             description={item.promo && item.promo.caption}
             urlOverride={item.promo && item.promo.link}
             Image={
-              item.image &&
-              item.image.crops &&
-              item.image.crops.square && (
+              getCrop(item.image, 'square') && (
                 // We intentionally omit the alt text on promos, so screen reader
                 // users don't have to listen to the alt text before hearing the
                 // title of the item in the list.
                 //
                 // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
-                <Image {...item.image.crops.square} alt="" />
+                <Image {...getCrop(item.image, 'square')!} alt="" />
               )
             }
             xOfY={{ x: index + 1, y: items.length }}
@@ -107,15 +104,13 @@ const SearchResults: FunctionComponent<Props> = ({
             description={item.promo && item.promo.caption}
             urlOverride={item.promo && item.promo.link}
             Image={
-              item.cover &&
-              item.cover.crops &&
-              item.cover.crops.square && (
+              getCrop(item.cover, 'square') && (
                 // We intentionally omit the alt text on promos, so screen reader
                 // users don't have to listen to the alt text before hearing the
                 // title of the item in the list.
                 //
                 // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
-                <Image {...item.cover.crops.square} alt="" />
+                <Image {...getCrop(item.cover, 'square')!} alt="" />
               )
             }
             xOfY={{ x: index + 1, y: items.length }}
@@ -158,15 +153,13 @@ const SearchResults: FunctionComponent<Props> = ({
             secondaryLabels={[]}
             description={item.promoText}
             Image={
-              item.image &&
-              item.image.crops &&
-              item.image.crops.square && (
+              getCrop(item.image, 'square') && (
                 // We intentionally omit the alt text on promos, so screen reader
                 // users don't have to listen to the alt text before hearing the
                 // title of the item in the list.
                 //
                 // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
-                <Image {...item.image.crops.square} alt="" />
+                <Image {...getCrop(item.image, 'square')!} alt="" />
               )
             }
             xOfY={{ x: index + 1, y: items.length }}

--- a/content/webapp/components/SimpleCardGrid/SimpleCardGrid.tsx
+++ b/content/webapp/components/SimpleCardGrid/SimpleCardGrid.tsx
@@ -5,6 +5,8 @@ import Layout12 from '@weco/common/views/components/Layout12/Layout12';
 import Space from '@weco/common/views/components/styled/Space';
 import CssGridContainer from '@weco/common/views/components/styled/CssGridContainer';
 import FeaturedCard from '../FeaturedCard/FeaturedCard';
+import { getCrop } from '@weco/common/model/image';
+import { FC } from 'react';
 
 type Props = {
   items: readonly CardType[];
@@ -16,7 +18,7 @@ type CardGridFeaturedCardProps = {
 };
 
 const CardGridFeaturedCard = ({ item }: CardGridFeaturedCardProps) => {
-  const image = item.image ? item.image.crops['16:9'] : undefined;
+  const image = getCrop(item.image, '16:9');
 
   return (
     <Layout12>
@@ -58,7 +60,7 @@ const CardGridFeaturedCard = ({ item }: CardGridFeaturedCardProps) => {
   );
 };
 
-const CardGrid = ({ items, isFeaturedFirst }: Props) => {
+const CardGrid: FC<Props> = ({ items, isFeaturedFirst }: Props) => {
   const cards = items.filter(item => item.type === 'card');
   const threeCards = isFeaturedFirst ? cards.slice(1) : cards.slice(0, 3);
   const featuredCard = isFeaturedFirst ? cards[0] : cards[3];

--- a/content/webapp/components/VenueHours/VenueHours.tsx
+++ b/content/webapp/components/VenueHours/VenueHours.tsx
@@ -114,7 +114,6 @@ const VenueHours: FunctionComponent<Props> = ({ venue, weight }) => {
                 contentUrl={venue.image.contentUrl}
                 width={1600}
                 height={900}
-                crops={{}}
                 alt={venue.image?.alt}
                 sizesQueries="(min-width: 1340px) 303px, (min-width: 960px) calc(30.28vw - 68px), (min-width: 600px) calc(50vw - 42px), calc(100vw - 36px)"
                 extraClasses=""

--- a/content/webapp/pages/homepage.tsx
+++ b/content/webapp/pages/homepage.tsx
@@ -83,7 +83,6 @@ const pageImage: ImageType = {
   width: 800,
   height: 450,
   alt: '',
-  crops: {},
 };
 
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =

--- a/content/webapp/pages/newsletter.tsx
+++ b/content/webapp/pages/newsletter.tsx
@@ -44,7 +44,6 @@ const Newsletter: FC<Props> = ({ result }) => {
         width: 800,
         height: 662,
         alt: '',
-        crops: {},
       }}
     >
       <PageHeader

--- a/content/webapp/pages/season.tsx
+++ b/content/webapp/pages/season.tsx
@@ -52,6 +52,7 @@ import { Page } from '../types/pages';
 import { Project } from '../types/projects';
 import { Series } from '../types/series';
 import { looksLikePrismicId } from '../services/prismic';
+import { getCrop } from '@weco/common/model/image';
 
 type Props = {
   season: Season;
@@ -74,7 +75,7 @@ const SeasonPage = ({
   projects,
   books,
 }: Props): ReactElement<Props> => {
-  const superWidescreenImage = season.image?.crops['32:15'];
+  const superWidescreenImage = getCrop(season.image, '32:15');
 
   const Header = (
     <SeasonsHeader

--- a/content/webapp/services/prismic/transformers/contributors.ts
+++ b/content/webapp/services/prismic/transformers/contributors.ts
@@ -19,7 +19,6 @@ const defaultContributorImage: ImageType = {
   contentUrl:
     'https://images.prismic.io/wellcomecollection%2F021d6105-3308-4210-8f65-d207e04c2cb2_contributor_default%402x.png?auto=compress,format',
   alt: '',
-  crops: {},
 };
 
 function transformCommonFields(

--- a/content/webapp/services/prismic/transformers/images.ts
+++ b/content/webapp/services/prismic/transformers/images.ts
@@ -16,7 +16,6 @@ export const placeHolderImage: ImageType = {
   tasl: {
     sourceName: 'Unknown',
   },
-  crops: {},
 };
 
 export function transformCaptionedImage(

--- a/content/webapp/types/card.ts
+++ b/content/webapp/types/card.ts
@@ -1,4 +1,4 @@
-import { ImageType } from '@weco/common/model/image';
+import { getCrop, ImageType } from '@weco/common/model/image';
 import { Format } from './format';
 import { Event } from './events';
 import { Article } from './articles';
@@ -39,21 +39,20 @@ export function convertItemToCardProps(
       item.promo && item.promo.image
         ? {
             contentUrl: item.promo.image.contentUrl,
+            // We intentionally omit the alt text on promos, so screen reader
+            // users don't have to listen to the alt text before hearing the
+            // title of the item in the list.
+            //
+            // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
             alt: '',
             width: 1600,
             height: 900,
             tasl: item.promo.image.tasl,
-            crops: {
+            simpleCrops: {
               '16:9': {
-                contentUrl:
-                  item.image && item.image.crops && item.image.crops['16:9']
-                    ? item.image.crops['16:9'].contentUrl
-                    : '',
-                alt: '',
+                contentUrl: getCrop(item.image, '16:9')?.contentUrl || '',
                 width: 1600,
                 height: 900,
-                crops: {},
-                tasl: item.promo.image.tasl,
               },
             },
           }

--- a/content/webapp/utils/page-header.tsx
+++ b/content/webapp/utils/page-header.tsx
@@ -1,3 +1,4 @@
+import { getCrop } from '@weco/common/model/image';
 import { breakpoints } from '@weco/common/utils/breakpoints';
 import { UiImage } from '@weco/common/views/components/Images/Images';
 import { FeaturedMedia } from '@weco/common/views/components/PageHeader/PageHeader';
@@ -11,8 +12,8 @@ export function getFeaturedMedia(
   isPicture?: boolean
 ): FeaturedMedia | undefined {
   const image = fields.promo && fields.promo.image;
-  const squareImage = fields.image?.crops['square'];
-  const widescreenImage = fields.image?.crops['16:9'];
+  const squareImage = getCrop(fields.image, 'square');
+  const widescreenImage = getCrop(fields.image, '16:9');
   const { body } = fields;
 
   const hasFeaturedVideo = body.length > 0 && body[0].type === 'videoEmbed';
@@ -30,7 +31,7 @@ export function getFeaturedMedia(
   ) : widescreenImage ? (
     <UiImage {...widescreenImage} sizesQueries="" />
   ) : image ? (
-    <UiImage {...image} crops={{}} sizesQueries="" />
+    <UiImage {...image} sizesQueries="" />
   ) : undefined;
 
   return featuredMedia;
@@ -39,8 +40,8 @@ export function getFeaturedMedia(
 export function getHeroPicture(
   fields: GenericContentFields
 ): ReactElement<typeof Picture> | undefined {
-  const squareImage = fields.image?.crops['square'];
-  const widescreenImage = fields.image?.crops['16:9'];
+  const squareImage = getCrop(fields.image, 'square');
+  const widescreenImage = getCrop(fields.image, '16:9');
 
   return (
     squareImage &&


### PR DESCRIPTION
The editorial team helpfully write detailed alt text descriptions for all our images, but we're duplicating them across every individual crop of an image -- even though they're often the same.

This patch introduces `simpleCrops` (which don't have custom alt text/tasl) and `richCrops` (which do).  This reduces the size of pages because we send less in `__NEXT_DATA__`:

<table>
<tr><th>page</th><th>before</th><th>after</th></tr>
<tr><td>/</td><td>279KB</td><td>264KB (−5%)</td></tr>
<tr><td>/stories</td><td>651KB</td><td>573KB (−12%)</td></tr>
<tr><td>/articles/YjMIUhEAACAAWeQ_</td><td>244KB</td><td>228KB (−7%)</td></tr>
<tr><td>/series/WleP3iQAACUAYEoN</td><td>1.5MB</td><td>1.3MB (−13%)</td></tr>
</table>

Replaces/closes #7838.

## Who is this for?

People who use the website.

## What is it doing for them?

Making it whizzy fast.