### PR TITLE
Popup link

### DIFF
--- a/common/server-data/prismic.ts
+++ b/common/server-data/prismic.ts
@@ -33,7 +33,7 @@ export const defaultValue = {
   popupDialog: {
     data: {
       isShown: false,
-      link: null,
+      link: { link_type: 'Web' },
       linkText: null,
       openButtonText: null,
       text: [] as RichTextField,

--- a/common/services/prismic/documents.ts
+++ b/common/services/prismic/documents.ts
@@ -61,7 +61,7 @@ export type PopupDialogPrismicDocument = PrismicDocument<{
   title: KeyTextField;
   text: RichTextField;
   linkText: KeyTextField;
-  link: KeyTextField;
+  link: LinkField;
   isShown: BooleanField;
 }>;
 
@@ -112,7 +112,7 @@ export function emptyGlobalAlert(
 export function emptyPopupDialog(): PopupDialogPrismicDocument {
   return emptyDocument<PopupDialogPrismicDocument>({
     isShown: false,
-    link: null,
+    link: { link_type: 'Web' },
     linkText: null,
     openButtonText: null,
     text: [],

--- a/common/services/prismic/transformers/index.ts
+++ b/common/services/prismic/transformers/index.ts
@@ -1,5 +1,12 @@
 import { Tasl } from '../../../model/tasl';
 import { licenseTypeArray } from '../../../model/license';
+import { LinkField } from '@prismicio/types';
+import { linkResolver } from '../link-resolver';
+import {
+  isFilledLinkToDocumentWithData,
+  isFilledLinkToMediaField,
+  isFilledLinkToWebField,
+} from '../types';
 
 export function transformTaslFromString(pipedString: string | null): Tasl {
   if (pipedString === null) {
@@ -37,5 +44,17 @@ export function transformTaslFromString(pipedString: string | null): Tasl {
     return {
       title: pipedString,
     };
+  }
+}
+
+export function transformLink(
+  link?: LinkField<string, string, any>
+): string | undefined {
+  if (link) {
+    if (isFilledLinkToWebField(link) || isFilledLinkToMediaField(link)) {
+      return link.url;
+    } else if (isFilledLinkToDocumentWithData(link)) {
+      return linkResolver({ id: link.id, type: link.type });
+    }
   }
 }

--- a/common/services/prismic/types/index.ts
+++ b/common/services/prismic/types/index.ts
@@ -1,5 +1,23 @@
-import { PrismicDocument } from '@prismicio/types';
+import {
+  PrismicDocument,
+  RelationField,
+  FilledLinkToDocumentField,
+  FilledLinkToWebField,
+  LinkField,
+  AnyRegularField,
+  GroupField,
+  SliceZone,
+} from '@prismicio/types';
+import { isNotUndefined } from '../../../utils/array';
+import * as prismicH from '@prismicio/helpers';
 
+/**
+ * This is a convenience type for what the generic DataInterface type extend in @prismicio/types
+ */
+export type DataInterface = Record<
+  string,
+  AnyRegularField | GroupField | SliceZone
+>;
 /**
  * This allows us to get the DataInterface from PrismicDocuments when we
  * Need them for `RelationField`s e.g.
@@ -22,3 +40,33 @@ export type PaginatedResults<T> = {
   totalResults: number;
   totalPages: number;
 };
+
+// Guards
+export function isFilledLinkToDocumentWithData<T, L, D extends DataInterface>(
+  field: RelationField<T, L, D> | undefined
+): field is FilledLinkToDocumentField<T, L, D> & { data: DataInterface } {
+  return (
+    isNotUndefined(field) &&
+    'id' in field &&
+    field.isBroken === false &&
+    'data' in field
+  );
+}
+
+export function isFilledLinkToWebField(
+  field: LinkField
+): field is FilledLinkToWebField {
+  return (
+    prismicH.isFilled.link(field) && field.link_type === 'Web' && 'url' in field
+  );
+}
+
+export function isFilledLinkToMediaField(
+  field: LinkField
+): field is FilledLinkToWebField {
+  return (
+    prismicH.isFilled.link(field) &&
+    field.link_type === 'Media' &&
+    'url' in field
+  );
+}

--- a/common/views/components/PopupDialog/PopupDialog.tsx
+++ b/common/views/components/PopupDialog/PopupDialog.tsx
@@ -18,6 +18,7 @@ import { PopupDialogPrismicDocument } from '../../../services/prismic/documents'
 import PrismicHtmlBlock from '../PrismicHtmlBlock/PrismicHtmlBlock';
 import { chat, clear } from '../../../icons';
 import { InferDataInterface } from '../../../services/prismic/types';
+import { transformLink } from '../../../services/prismic/transformers';
 
 type PopupDialogOpenProps = {
   isActive: boolean;
@@ -344,7 +345,7 @@ const PopupDialog: FunctionComponent<Props> = ({ document }: Props) => {
           </div>
         </Space>
         <PopupDialogCTA
-          href={link || undefined}
+          href={transformLink(link)}
           ref={ctaRef}
           tabIndex={isActive ? 0 : -1}
           onKeyDown={handleTrapEndKeyDown}

--- a/content/webapp/services/prismic/transformers/articles.ts
+++ b/content/webapp/services/prismic/transformers/articles.ts
@@ -4,7 +4,7 @@ import { london } from '@weco/common/utils/format-date';
 import {
   isFilledLinkToDocumentWithData,
   isFilledLinkToWebField,
-} from '../types';
+} from '@weco/common/services/prismic/types';
 import { LinkField } from '@prismicio/types';
 import { transformMultiContent } from './multi-content';
 import {

--- a/content/webapp/services/prismic/transformers/body.ts
+++ b/content/webapp/services/prismic/transformers/body.ts
@@ -27,18 +27,15 @@ import { isNotUndefined } from '@weco/common/utils/array';
 import {
   isFilledLinkToDocumentWithData,
   isFilledLinkToMediaField,
-} from '../types';
+} from '@weco/common/services/prismic/types';
 import { TeamPrismicDocument } from '../types/teams';
 import { transformCaptionedImage } from './images';
 import { transformImage } from '@weco/common/services/prismic/transformers/images';
+import { asRichText, transformLabelType, asTitle, asText } from '.';
 import {
   transformLink,
-  asRichText,
-  transformLabelType,
-  asTitle,
-  asText,
-} from '.';
-import { transformTaslFromString } from '@weco/common/services/prismic/transformers';
+  transformTaslFromString,
+} from '@weco/common/services/prismic/transformers';
 import { LinkField, RelationField, RichTextField } from '@prismicio/types';
 import { BodySlice, Weight } from '../../../types/body';
 import { transformCollectionVenue } from '@weco/common/services/prismic/transformers/collection-venues';

--- a/content/webapp/services/prismic/transformers/books.ts
+++ b/content/webapp/services/prismic/transformers/books.ts
@@ -7,7 +7,7 @@ import {
   transformTimestamp,
   transformSingleLevelGroup,
 } from '.';
-import { isFilledLinkToWebField } from '../types';
+import { isFilledLinkToWebField } from '@weco/common/services/prismic/types';
 import { transformSeason } from './seasons';
 import { transformPromoToCaptionedImage } from './images';
 import { SeasonPrismicDocument } from '../types/seasons';

--- a/content/webapp/services/prismic/transformers/card.ts
+++ b/content/webapp/services/prismic/transformers/card.ts
@@ -1,8 +1,8 @@
 import { CardPrismicDocument } from '../types/card';
 import { transformImage } from '@weco/common/services/prismic/transformers/images';
 import { Card } from '../../../types/card';
-import { asText, asTitle, transformFormat, transformLink } from '.';
-
+import { asText, asTitle, transformFormat } from '.';
+import { transformLink } from '@weco/common/services/prismic/transformers';
 export function transformCard(document: CardPrismicDocument): Card {
   const { title, description, image, link } = document.data;
 

--- a/content/webapp/services/prismic/transformers/contributors.ts
+++ b/content/webapp/services/prismic/transformers/contributors.ts
@@ -1,11 +1,14 @@
 import { FilledLinkToDocumentField, PrismicDocument } from '@prismicio/types';
 import {
-  isFilledLinkToDocumentWithData,
   WithContributors,
   isFilledLinkToOrganisationField,
   isFilledLinkToPersonField,
 } from '../types';
-import { InferDataInterface } from '@weco/common/services/prismic/types';
+import {
+  isFilledLinkToDocumentWithData,
+  InferDataInterface,
+} from '@weco/common/services/prismic/types';
+
 import { Contributor } from '../../../types/contributors';
 import { isNotUndefined } from '@weco/common/utils/array';
 import { asRichText, asText } from '.';

--- a/content/webapp/services/prismic/transformers/event-series.ts
+++ b/content/webapp/services/prismic/transformers/event-series.ts
@@ -2,7 +2,7 @@ import { EventSeries } from '../../../types/event-series';
 import { EventSeriesPrismicDocument } from '../types/event-series';
 import { transformGenericFields, asText } from '.';
 import { BackgroundTexture } from '@weco/common/model/background-texture';
-import { isFilledLinkToDocumentWithData } from '../types';
+import { isFilledLinkToDocumentWithData } from '@weco/common/services/prismic/types';
 import { ImageField, KeyTextField } from '@prismicio/types';
 import { isNotUndefined } from '@weco/common/utils/array';
 import { transformContributors } from './contributors';

--- a/content/webapp/services/prismic/transformers/events.ts
+++ b/content/webapp/services/prismic/transformers/events.ts
@@ -30,10 +30,10 @@ import { transformPlace } from './places';
 import isEmptyObj from '@weco/common/utils/is-empty-object';
 import { LabelField } from '@weco/common/model/label-field';
 import {
-  isFilledLinkToDocumentWithData,
+  InferDataInterface,
   isFilledLinkToWebField,
-} from '../types';
-import { InferDataInterface } from '@weco/common/services/prismic/types';
+  isFilledLinkToDocumentWithData,
+} from '@weco/common/services/prismic/types';
 import { SeasonPrismicDocument } from '../types/seasons';
 import { EventSeriesPrismicDocument } from '../types/event-series';
 import { PlacePrismicDocument } from '../types/places';

--- a/content/webapp/services/prismic/transformers/exhibitions.ts
+++ b/content/webapp/services/prismic/transformers/exhibitions.ts
@@ -11,7 +11,10 @@ import {
   ExhibitionFormat as ExhibitionFormatPrismicDocument,
 } from '../types/exhibitions';
 import { Query } from '@prismicio/types';
-import { PaginatedResults } from '@weco/common/services/prismic/types';
+import {
+  PaginatedResults,
+  isFilledLinkToDocumentWithData,
+} from '@weco/common/services/prismic/types';
 import { transformQuery } from './paginated-results';
 import { transformMultiContent } from './multi-content';
 import {
@@ -26,7 +29,6 @@ import {
 import { transformSeason } from './seasons';
 import { transformPlace } from './places';
 import { transformImagePromo, transformPromoToCaptionedImage } from './images';
-import { isFilledLinkToDocumentWithData } from '../types';
 import { Resource } from '../../../types/resource';
 import { SeasonPrismicDocument } from '../types/seasons';
 import { transformContributors } from './contributors';

--- a/content/webapp/services/prismic/transformers/featured-books.ts
+++ b/content/webapp/services/prismic/transformers/featured-books.ts
@@ -1,7 +1,7 @@
 import { isNotUndefined } from '@weco/common/utils/array';
 import { FeaturedBooksPrismicDocument } from '../types/books';
 import { transformBook } from '../transformers/books';
-import { isFilledLinkToDocumentWithData } from '../types';
+import { isFilledLinkToDocumentWithData } from '@weco/common/services/prismic/types';
 import { Book } from '../../../types/books';
 
 export function transformFeaturedBooks(

--- a/content/webapp/services/prismic/transformers/index.ts
+++ b/content/webapp/services/prismic/transformers/index.ts
@@ -6,12 +6,11 @@ import {
   RichTextField,
   TimestampField,
 } from '@prismicio/types';
+import { CommonPrismicFields, WithArticleFormat } from '../types';
 import {
-  CommonPrismicFields,
+  InferDataInterface,
   isFilledLinkToDocumentWithData,
-  WithArticleFormat,
-} from '../types';
-import { InferDataInterface } from '@weco/common/services/prismic/types';
+} from '@weco/common/services/prismic/types';
 import { GenericContentFields } from '../../../types/generic-content-fields';
 import { ImageType } from '@weco/common/model/image';
 import { isNotUndefined, isString } from '@weco/common/utils/array';

--- a/content/webapp/services/prismic/transformers/index.ts
+++ b/content/webapp/services/prismic/transformers/index.ts
@@ -3,16 +3,12 @@ import {
   PrismicDocument,
   FilledLinkToDocumentField,
   KeyTextField,
-  LinkField,
   RichTextField,
   TimestampField,
 } from '@prismicio/types';
-import linkResolver from '../link-resolver';
 import {
   CommonPrismicFields,
   isFilledLinkToDocumentWithData,
-  isFilledLinkToMediaField,
-  isFilledLinkToWebField,
   WithArticleFormat,
 } from '../types';
 import { InferDataInterface } from '@weco/common/services/prismic/types';
@@ -96,18 +92,6 @@ export function asHtml(field?: RichTextField): string | undefined {
 export function asTitle(title: RichTextField): string {
   // We always need a title - blunt validation, but validation none the less
   return asText(title) || '';
-}
-
-export function transformLink(
-  link?: LinkField<string, string, any>
-): string | undefined {
-  if (link) {
-    if (isFilledLinkToWebField(link) || isFilledLinkToMediaField(link)) {
-      return link.url;
-    } else if (isFilledLinkToDocumentWithData(link)) {
-      return linkResolver({ id: link.id, type: link.type });
-    }
-  }
 }
 
 export function transformSingleLevelGroup(

--- a/content/webapp/services/prismic/types/index.ts
+++ b/content/webapp/services/prismic/types/index.ts
@@ -5,13 +5,10 @@ import {
   Slice,
   SliceZone,
   PrismicDocument,
-  AnyRegularField,
   GroupField,
   RelationField,
   FilledLinkToDocumentField,
-  FilledLinkToWebField,
   NumberField,
-  LinkField,
   EmptyLinkField,
 } from '@prismicio/types';
 import { ArticleFormat } from './article-format';
@@ -22,9 +19,10 @@ import { EditorialContributorRole, Organisation, Person } from './contributors';
 import { EventSeriesPrismicDocument } from './event-series';
 import { ExhibitionPrismicDocument } from './exhibitions';
 import { SeasonPrismicDocument } from './seasons';
-import { isNotUndefined } from '@weco/common/utils/array';
-import * as prismicH from '@prismicio/helpers';
-import { InferDataInterface } from '@weco/common/services/prismic/types';
+import {
+  isFilledLinkToDocumentWithData,
+  InferDataInterface,
+} from '@weco/common/services/prismic/types';
 
 export type InferCustomType<T> = T extends PrismicDocument<
   any,
@@ -46,14 +44,6 @@ export type FetchLinks<T extends PrismicDocument> = {
     ? `${InferCustomType<T>}.${D}`
     : never;
 }[keyof InferDataInterface<T>][];
-
-/**
- * This is a convenience type for what the generic DataInterface type extend in @prismicio/types
- */
-export type DataInterface = Record<
-  string,
-  AnyRegularField | GroupField | SliceZone
->;
 
 type Dimension = {
   width: number;
@@ -216,35 +206,6 @@ export const contributorFetchLinks: ContributorFetchLink = [
 ];
 
 // Guards
-export function isFilledLinkToDocumentWithData<T, L, D extends DataInterface>(
-  field: RelationField<T, L, D> | undefined
-): field is FilledLinkToDocumentField<T, L, D> & { data: DataInterface } {
-  return (
-    isNotUndefined(field) &&
-    'id' in field &&
-    field.isBroken === false &&
-    'data' in field
-  );
-}
-
-export function isFilledLinkToWebField(
-  field: LinkField
-): field is FilledLinkToWebField {
-  return (
-    prismicH.isFilled.link(field) && field.link_type === 'Web' && 'url' in field
-  );
-}
-
-export function isFilledLinkToMediaField(
-  field: LinkField
-): field is FilledLinkToWebField {
-  return (
-    prismicH.isFilled.link(field) &&
-    field.link_type === 'Media' &&
-    'url' in field
-  );
-}
-
 export function isFilledLinkToPersonField(
   field: Contributor
 ): field is FilledLinkToDocumentField<

--- a/content/webapp/services/prismic/types/types.test.ts
+++ b/content/webapp/services/prismic/types/types.test.ts
@@ -1,4 +1,4 @@
-import { isFilledLinkToDocumentWithData } from '.';
+import { isFilledLinkToDocumentWithData } from '@weco/common/services/prismic/types';
 
 const emptyLink = {
   link_type: 'Document',


### PR DESCRIPTION
Just remembered when I was working on #7828, I noticed that the link in the popupDialog component is broken.

This fixes that.

It meant moving a few bits from /content to /common so I could use transformLink, which is why there are so many file changes.

Before:
![before](https://user-images.githubusercontent.com/6051896/159728871-b2f067de-aaad-4af0-85c8-d10e39a02cdd.png)

After:
![after](https://user-images.githubusercontent.com/6051896/159728975-23f47603-5a9a-4f67-b5c5-a972edd110cb.png)

