### PR TITLE
Don't duplicate promo information in our models

### DIFF
--- a/cardigan/stories/content.ts
+++ b/cardigan/stories/content.ts
@@ -73,25 +73,6 @@ export const bannerCardItem = {
     },
     link: null,
   },
-  promoText:
-    'Our new season explores the intertwined connections between the individual, societal and global health.',
-  promoImage: {
-    contentUrl:
-      'https://images.prismic.io/wellcomecollection%2F92a873e4-b774-4c46-b9b3-75fda00a0ace_b0011048_artistic+interpretation+of+alzheimers_florence+winterflood.jpg?auto=compress,format&rect=0,0,1600,900&w=3200&h=1800',
-    width: 3200,
-    height: 1800,
-    alt: 'An artwork featuring a large painted human hand, surrounded by fragments of maps.',
-    tasl: {
-      title: "Alzheimer's disease",
-      author: 'Florence Winterflood',
-      sourceName: 'Wellcome Collection',
-      sourceLink: 'CC-BY-NC',
-      license: undefined,
-      copyrightHolder: undefined,
-      copyrightLink: undefined,
-    },
-    crops: {},
-  },
   image: {
     contentUrl:
       'https://images.prismic.io/wellcomecollection%2F92a873e4-b774-4c46-b9b3-75fda00a0ace_b0011048_artistic+interpretation+of+alzheimers_florence+winterflood.jpg?auto=compress,format',
@@ -427,25 +408,6 @@ export const event = {
       crops: {},
     },
     link: null,
-  },
-  promoText:
-    'Come and hear Dr Emma Spary discuss her research on the often- overlooked role of priests in the history of pharmacy.',
-  promoImage: {
-    contentUrl:
-      'https://images.prismic.io/wellcomecollection/1689f6e5ead8d3a228d802256213e0998b15b7a2_sdp_20181009_0007.jpg?auto=compress,format',
-    width: 3200,
-    height: 1800,
-    alt: 'Photograph showing a woman giving a talk in the Viewing Room at Wellcome Collection. She is stood at the front of the room looking at a wall mounted television screen. In the foreground are the backs of the heads of the audience.',
-    tasl: {
-      title: 'Exploring Research event',
-      author: 'Steven Pocock',
-      sourceName: 'Wellcome Collection',
-      sourceLink: null,
-      license: 'CC-BY-NC',
-      copyrightHolder: null,
-      copyrightLink: null,
-    },
-    crops: {},
   },
   image: {
     contentUrl:
@@ -798,18 +760,6 @@ export const article = {
     },
     link: null,
   },
-  promoText: 'Do you have any dark clouds following you?',
-  promoImage: {
-    contentUrl:
-      'https://images.prismic.io/wellcomecollection/0b1e482a-fc92-4345-afd2-01bce69424fc_darkcloud_promo.png?auto=compress,format&rect=0,0,1600,900&w=3200&h=1800',
-    width: 3200,
-    height: 1800,
-    alt: 'A cartoon figure has a dark cloud wrapped around them. Both have a solemn look on their face.',
-    tasl: {
-      title: 'Weewaaz',
-    },
-    crops: {},
-  },
   image: {
     contentUrl:
       'https://images.prismic.io/wellcomecollection/0b1e482a-fc92-4345-afd2-01bce69424fc_darkcloud_promo.png?auto=compress,format',
@@ -947,18 +897,6 @@ export const article = {
           crops: {},
         },
         link: null,
-      },
-      promoText: '',
-      promoImage: {
-        contentUrl:
-          'https://images.prismic.io/wellcomecollection/2e78d491-8a35-45fd-8e57-497f50e6273d_promo_main.png?auto=compress,format&rect=0,0,1600,900&w=3200&h=1800',
-        width: 3200,
-        height: 1800,
-        alt: 'Person holding a large red love heart, smiling.',
-        tasl: {
-          title: 'Weewaaz',
-        },
-        crops: {},
       },
       image: {
         contentUrl:

--- a/content/webapp/__mocks__/events.ts
+++ b/content/webapp/__mocks__/events.ts
@@ -63,7 +63,6 @@ const baseEvent: Event = {
     image: image,
     link: `/pages/${prismicPageIds.dailyGuidedTours}`,
   },
-  promoImage: { ...image },
   scheduleLength: 0,
   seasons: [],
   isOnline: false,

--- a/content/webapp/__mocks__/whats-on.ts
+++ b/content/webapp/__mocks__/whats-on.ts
@@ -1127,21 +1127,6 @@ const beingHuman: Exhibition = {
       },
     },
   },
-  promoText:
-    'Our new permanent gallery explores trust, identity and health in a changing world.',
-  promoImage: {
-    contentUrl:
-      'https://images.prismic.io/wellcomecollection/3eb4b341-6471-4610-9f12-c97f5c7be0bc_SDP_20201005_0278-81.jpg?auto=compress,format&rect=0,0,2955,1662&w=3200&h=1800',
-    width: 3200,
-    height: 1800,
-    alt: 'Photograph of a museum gallery space with display cases and exhibits. In the foreground is a woman wearing a face covering and a pair of yellow over the ear headphones. She is in the process of plugging the headphones into the socket of an audio exhibit. To the right of her is another woman also wearing a face covering who is looking up at a transparent model of human being. In the far distance is a man, also wearing a face covering who is exploring the exhibiton.',
-    tasl: {
-      title: 'Being Human gallery',
-      author: 'Steven Pocock',
-      sourceName: 'Wellcome Collection',
-      license: 'CC-BY-NC',
-    },
-  },
   image: {
     contentUrl:
       'https://images.prismic.io/wellcomecollection/3eb4b341-6471-4610-9f12-c97f5c7be0bc_SDP_20201005_0278-81.jpg?auto=compress,format',
@@ -1154,78 +1139,6 @@ const beingHuman: Exhibition = {
       sourceName: 'Wellcome Collection',
       license: 'CC-BY-NC',
     },
-    crops: {
-      '32:15': {
-        contentUrl:
-          'https://images.prismic.io/wellcomecollection/3eb4b341-6471-4610-9f12-c97f5c7be0bc_SDP_20201005_0278-81.jpg?auto=compress,format&rect=0,10,2955,1385&w=3200&h=1500',
-        width: 3200,
-        height: 1500,
-        alt: 'Photograph of a museum gallery space with display cases and exhibits. In the foreground is a woman wearing a face covering and a pair of yellow over the ear headphones. She is in the process of plugging the headphones into the socket of an audio exhibit. To the right of her is another woman also wearing a face covering who is looking up at a transparent model of human being. In the far distance is a man, also wearing a face covering who is exploring the exhibiton.',
-        tasl: {
-          title: 'Being Human gallery',
-          author: 'Steven Pocock',
-          sourceName: 'Wellcome Collection',
-          license: 'CC-BY-NC',
-        },
-        crops: {},
-      },
-      '16:9': {
-        contentUrl:
-          'https://images.prismic.io/wellcomecollection/3eb4b341-6471-4610-9f12-c97f5c7be0bc_SDP_20201005_0278-81.jpg?auto=compress,format&rect=0,0,2955,1662&w=3200&h=1800',
-        width: 3200,
-        height: 1800,
-        alt: 'Photograph of a museum gallery space with display cases and exhibits. In the foreground is a woman wearing a face covering and a pair of yellow over the ear headphones. She is in the process of plugging the headphones into the socket of an audio exhibit. To the right of her is another woman also wearing a face covering who is looking up at a transparent model of human being. In the far distance is a man, also wearing a face covering who is exploring the exhibiton.',
-        tasl: {
-          title: 'Being Human gallery',
-          author: 'Steven Pocock',
-          sourceName: 'Wellcome Collection',
-          license: 'CC-BY-NC',
-        },
-        crops: {},
-      },
-      square: {
-        contentUrl:
-          'https://images.prismic.io/wellcomecollection/3eb4b341-6471-4610-9f12-c97f5c7be0bc_SDP_20201005_0278-81.jpg?auto=compress,format&rect=1185,0,1662,1662&w=3200&h=3200',
-        width: 3200,
-        height: 3200,
-        alt: 'Photograph of a museum gallery space with display cases and exhibits. In the foreground is a woman wearing a face covering and a pair of yellow over the ear headphones. She is in the process of plugging the headphones into the socket of an audio exhibit. To the right of her is another woman also wearing a face covering who is looking up at a transparent model of human being. In the far distance is a man, also wearing a face covering who is exploring the exhibiton.',
-        tasl: {
-          title: 'Being Human gallery',
-          author: 'Steven Pocock',
-          sourceName: 'Wellcome Collection',
-          license: 'CC-BY-NC',
-        },
-        crops: {},
-      },
-    },
-  },
-  squareImage: {
-    contentUrl:
-      'https://images.prismic.io/wellcomecollection/3eb4b341-6471-4610-9f12-c97f5c7be0bc_SDP_20201005_0278-81.jpg?auto=compress,format&rect=1185,0,1662,1662&w=3200&h=3200',
-    width: 3200,
-    height: 3200,
-    alt: 'Photograph of a museum gallery space with display cases and exhibits. In the foreground is a woman wearing a face covering and a pair of yellow over the ear headphones. She is in the process of plugging the headphones into the socket of an audio exhibit. To the right of her is another woman also wearing a face covering who is looking up at a transparent model of human being. In the far distance is a man, also wearing a face covering who is exploring the exhibiton.',
-    tasl: {
-      title: 'Being Human gallery',
-      author: 'Steven Pocock',
-      sourceName: 'Wellcome Collection',
-      license: 'CC-BY-NC',
-    },
-    crops: {},
-  },
-  widescreenImage: {
-    contentUrl:
-      'https://images.prismic.io/wellcomecollection/3eb4b341-6471-4610-9f12-c97f5c7be0bc_SDP_20201005_0278-81.jpg?auto=compress,format&rect=0,0,2955,1662&w=3200&h=1800',
-    width: 3200,
-    height: 1800,
-    alt: 'Photograph of a museum gallery space with display cases and exhibits. In the foreground is a woman wearing a face covering and a pair of yellow over the ear headphones. She is in the process of plugging the headphones into the socket of an audio exhibit. To the right of her is another woman also wearing a face covering who is looking up at a transparent model of human being. In the far distance is a man, also wearing a face covering who is exploring the exhibiton.',
-    tasl: {
-      title: 'Being Human gallery',
-      author: 'Steven Pocock',
-      sourceName: 'Wellcome Collection',
-      license: 'CC-BY-NC',
-    },
-    crops: {},
   },
   metadataDescription: '',
   labels: [{ text: 'Permanent exhibition' }],

--- a/content/webapp/components/BookPromo/BookPromo.tsx
+++ b/content/webapp/components/BookPromo/BookPromo.tsx
@@ -42,7 +42,7 @@ type Props = {
 };
 
 const BookPromo: FunctionComponent<Props> = ({ book }: Props): ReactElement => {
-  const { id, title, subtitle, promoText, cover } = book;
+  const { id, title, subtitle, promo, cover } = book;
   return (
     <LinkOrSpanSpace
       v={{
@@ -125,7 +125,7 @@ const BookPromo: FunctionComponent<Props> = ({ book }: Props): ReactElement => {
             </Space>
           )}
 
-          {promoText && (
+          {promo?.caption && (
             <Space v={{ size: 's', properties: ['margin-top'] }}>
               <p
                 className={classNames({
@@ -133,7 +133,7 @@ const BookPromo: FunctionComponent<Props> = ({ book }: Props): ReactElement => {
                   'no-margin': true,
                 })}
               >
-                {promoText}
+                {promo?.caption}
               </p>
             </Space>
           )}

--- a/content/webapp/components/CardGrid/CardGrid.test.tsx
+++ b/content/webapp/components/CardGrid/CardGrid.test.tsx
@@ -17,20 +17,6 @@ describe('CardGrid', () => {
       promo: {
         image: placeHolderImage,
       },
-      promoText:
-        'Our new permanent gallery explores trust, identity and health in a changing world.',
-      promoImage: {
-        contentUrl:
-          'https://images.prismic.io/wellcomecollection/b40da45c5b49cc5dd946dffeddbf8ce114ac0003_ep_000832_058.jpg?auto=compress,format',
-        width: 3200,
-        height: 1800,
-        alt:
-          'Photograph of an exhibition gallery space, with a blue stained wood ' +
-          'wall in the background, in front of which a young man looks at a ' +
-          'life-size artwork of a figure resembling an astronaut. In the ' +
-          'foreground a young woman sits on a wooden bench holding an audio ' +
-          'speaker to her ear.',
-      },
       image: {
         contentUrl:
           'https://images.prismic.io/wellcomecollection/0cfe014fb55e817bb3014c0c06cabf3a2fd5a74a_ep_000832_058.jpg?auto=compress,format',

--- a/content/webapp/components/CardGrid/DailyTourPromo.tsx
+++ b/content/webapp/components/CardGrid/DailyTourPromo.tsx
@@ -34,7 +34,7 @@ export const data: Event = {
     description: undefined,
   },
   body: [],
-  image: image,
+  image,
   hasEarlyRegistration: false,
   labels: [
     {
@@ -44,10 +44,9 @@ export const data: Event = {
   primaryLabels: [],
   secondaryLabels: [],
   promo: {
-    image: image,
+    image,
     link: `/pages/${prismicPageIds.dailyGuidedTours}`,
   },
-  promoImage: image,
   scheduleLength: 0,
   seasons: [],
   isOnline: false,

--- a/content/webapp/components/EventPromo/EventPromo.tsx
+++ b/content/webapp/components/EventPromo/EventPromo.tsx
@@ -52,9 +52,9 @@ const EventPromo: FC<Props> = ({
       }}
     >
       <div className="relative">
-        {event.promoImage && (
+        {event.promo?.image && (
           <UiImage
-            {...event.promoImage}
+            {...event.promo?.image}
             // We intentionally omit the alt text on promos, so screen reader
             // users don't have to listen to the alt text before hearing the
             // title of the item in the list.

--- a/content/webapp/components/EventSchedule/EventScheduleItem.tsx
+++ b/content/webapp/components/EventSchedule/EventScheduleItem.tsx
@@ -87,11 +87,11 @@ const EventScheduleItem: FC<Props> = ({ event, isNotLinked }) => {
               </Space>
             )}
 
-            {event.promoText && (
+            {event.promo?.caption && (
               <Space
                 v={{ size: 'm', properties: ['margin-bottom'] }}
                 className={font('hnr', 5)}
-                dangerouslySetInnerHTML={{ __html: event.promoText }}
+                dangerouslySetInnerHTML={{ __html: event.promo?.caption }}
               />
             )}
 

--- a/content/webapp/components/Exhibition/Exhibition.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.tsx
@@ -280,7 +280,9 @@ const Exhibition: FC<Props> = ({ exhibition, pages }) => {
   return (
     <PageLayout
       title={exhibition.title}
-      description={exhibition.metadataDescription || exhibition.promoText || ''}
+      description={
+        exhibition.metadataDescription || exhibition.promo?.caption || ''
+      }
       url={{ pathname: `/exhibitions/${exhibition.id}` }}
       jsonLd={exhibitionLd(exhibition)}
       openGraphType={'website'}

--- a/content/webapp/components/FeaturedCard/FeaturedCard.tsx
+++ b/content/webapp/components/FeaturedCard/FeaturedCard.tsx
@@ -57,19 +57,19 @@ export function convertItemToFeaturedCardProps(
 ) {
   return {
     id: item.id,
-    image: item.promoImage && {
+    image: item.promo?.image && {
       // We intentionally omit the alt text on promos, so screen reader
       // users don't have to listen to the alt text before hearing the
       // title of the item in the list.
       //
       // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
       alt: '',
-      contentUrl: item.promoImage.contentUrl,
-      width: item.promoImage.width,
-      height: item.promoImage.height || 9,
+      contentUrl: item.promo?.image.contentUrl,
+      width: item.promo?.image.width,
+      height: item.promo?.image.height || 9,
       sizesQueries:
         '(min-width: 1420px) 698px, (min-width: 960px) 50.23vw, (min-width: 600px) calc(100vw - 84px), 100vw',
-      tasl: item.promoImage.tasl,
+      tasl: item.promo?.image.tasl,
       showTasl: false,
       crops: {},
     },
@@ -108,13 +108,13 @@ const FeaturedCardArticleBody: FunctionComponent<FeaturedCardArticleBodyProps> =
         >
           {article.title}
         </h2>
-        {article.promoText && (
+        {article.promo?.caption && (
           <p
             className={classNames({
               [font('hnr', 5)]: true,
             })}
           >
-            {article.promoText}
+            {article.promo?.caption}
           </p>
         )}
         {article.series.length > 0 && (

--- a/content/webapp/components/Installation/Installation.tsx
+++ b/content/webapp/components/Installation/Installation.tsx
@@ -84,7 +84,7 @@ const Installation: FunctionComponent<Props> = ({ installation }: Props) => {
     <PageLayout
       title={installation.title}
       description={
-        installation.metadataDescription || installation.promoText || ''
+        installation.metadataDescription || installation.promo?.caption || ''
       }
       url={{ pathname: `/installations/${installation.id}` }}
       jsonLd={exhibitionLd(installation)}

--- a/content/webapp/components/SearchResults/SearchResults.tsx
+++ b/content/webapp/components/SearchResults/SearchResults.tsx
@@ -151,7 +151,7 @@ const SearchResults: FunctionComponent<Props> = ({
             color={undefined}
             primaryLabels={item.labels}
             secondaryLabels={[]}
-            description={item.promoText}
+            description={item.promo?.caption}
             Image={
               getCrop(item.image, 'square') && (
                 // We intentionally omit the alt text on promos, so screen reader

--- a/content/webapp/components/SeriesNavigation/SeriesNavigation.tsx
+++ b/content/webapp/components/SeriesNavigation/SeriesNavigation.tsx
@@ -21,7 +21,7 @@ const SeriesNavigation: FunctionComponent<Props> = ({ series, items }) => {
         <SearchResults
           key={series.id}
           title={`Read more from ${series.title}`}
-          summary={series.promoText ?? undefined}
+          summary={series.promo?.caption}
           items={items}
           showPosition={showPosition}
         />

--- a/content/webapp/pages/article-series.tsx
+++ b/content/webapp/pages/article-series.tsx
@@ -132,7 +132,7 @@ const ArticleSeriesPage: FC<Props> = props => {
   return (
     <PageLayout
       title={series.title}
-      description={series.metadataDescription || series.promoText || ''}
+      description={series.metadataDescription || series.promo?.caption || ''}
       url={{ pathname: `/series/${series.id}` }}
       jsonLd={{ '@type': 'WebPage' }}
       siteSection={'stories'}

--- a/content/webapp/pages/article.tsx
+++ b/content/webapp/pages/article.tsx
@@ -276,7 +276,7 @@ const ArticlePage: FC<Props> = ({ article }) => {
   return (
     <PageLayout
       title={article.title}
-      description={article.metadataDescription || article.promoText || ''}
+      description={article.metadataDescription || article.promo?.caption || ''}
       url={{ pathname: `/articles/${article.id}` }}
       jsonLd={articleLd(article)}
       openGraphType={'article'}

--- a/content/webapp/pages/book.tsx
+++ b/content/webapp/pages/book.tsx
@@ -143,7 +143,7 @@ const BookPage: FunctionComponent<Props> = props => {
   return (
     <PageLayout
       title={book.title}
-      description={book.metadataDescription || book.promoText || ''}
+      description={book.metadataDescription || book.promo?.caption || ''}
       url={{ pathname: `/books/${book.id}`, query: {} }}
       jsonLd={{ '@type': 'WebPage' }}
       openGraphType={'book'}

--- a/content/webapp/pages/event-series.tsx
+++ b/content/webapp/pages/event-series.tsx
@@ -170,7 +170,7 @@ const EventSeriesPage: FC<Props> = ({
   return (
     <PageLayout
       title={series.title}
-      description={series.metadataDescription || series.promoText || ''}
+      description={series.metadataDescription || series.promo?.caption || ''}
       url={{ pathname: `/event-series/${series.id}` }}
       jsonLd={jsonLd}
       openGraphType={'website'}

--- a/content/webapp/pages/event.tsx
+++ b/content/webapp/pages/event.tsx
@@ -287,7 +287,7 @@ const EventPage: NextPage<Props> = ({ jsonEvent }: Props) => {
   return (
     <PageLayout
       title={event.title}
-      description={event.metadataDescription || event.promoText || ''}
+      description={event.metadataDescription || event.promo?.caption || ''}
       url={{ pathname: `/events/${event.id}` }}
       jsonLd={eventLd(event)}
       openGraphType={'website'}

--- a/content/webapp/pages/page.tsx
+++ b/content/webapp/pages/page.tsx
@@ -255,7 +255,7 @@ const Page: FC<Props> = ({ page, siblings, children, ordersInParents }) => {
   return (
     <PageLayout
       title={page.title}
-      description={page.metadataDescription || page.promoText || ''}
+      description={page.metadataDescription || page.promo?.caption || ''}
       url={{ pathname: `/pages/${page.id}` }}
       jsonLd={contentLd(page)}
       openGraphType={'website'}

--- a/content/webapp/pages/season.tsx
+++ b/content/webapp/pages/season.tsx
@@ -107,7 +107,7 @@ const SeasonPage = ({
   return (
     <PageLayout
       title={season.title}
-      description={season.metadataDescription || season.promoText || ''}
+      description={season.metadataDescription || season.promo?.caption || ''}
       url={{ pathname: `/seasons/${season.id}` }}
       jsonLd={contentLd(season)}
       siteSection={'whats-on'}

--- a/content/webapp/pages/stories.tsx
+++ b/content/webapp/pages/stories.tsx
@@ -84,7 +84,7 @@ const SerialisedSeries = ({ series }: { series: Series }) => {
                 'no-margin': true,
               })}
             >
-              {series.promoText}
+              {series.promo?.caption}
             </p>
           </Space>
         </Space>

--- a/content/webapp/services/prismic/transformers/articles.ts
+++ b/content/webapp/services/prismic/transformers/articles.ts
@@ -56,9 +56,7 @@ export function transformArticleToArticleBasic(article: Article): ArticleBasic {
     format,
     image,
     datePublished,
-    promoImage,
     labels,
-    promoText,
     color,
   }) => ({
     type,
@@ -69,9 +67,7 @@ export function transformArticleToArticleBasic(article: Article): ArticleBasic {
     format,
     image,
     datePublished,
-    promoImage,
     labels,
-    promoText,
     color,
   }))(article);
 }

--- a/content/webapp/services/prismic/transformers/books.ts
+++ b/content/webapp/services/prismic/transformers/books.ts
@@ -15,12 +15,11 @@ import { transformContributors } from './contributors';
 
 export function transformBookToBookBasic(book: Book): BookBasic {
   // returns what is required to render BookPromos and book JSON-LD
-  return (({ type, id, title, subtitle, promoText, cover, promo, labels }) => ({
+  return (({ type, id, title, subtitle, cover, promo, labels }) => ({
     type,
     id,
     title,
     subtitle,
-    promoText,
     cover,
     promo,
     labels,

--- a/content/webapp/services/prismic/transformers/events.ts
+++ b/content/webapp/services/prismic/transformers/events.ts
@@ -278,7 +278,6 @@ export function transformEventToEventBasic(event: Event): EventBasic {
     times,
     image,
     isPast,
-    promoImage,
     primaryLabels,
     title,
     isOnline,
@@ -287,7 +286,6 @@ export function transformEventToEventBasic(event: Event): EventBasic {
     scheduleLength,
     series,
     secondaryLabels,
-    promoText,
     cost,
     contributors,
   }) => ({
@@ -297,7 +295,6 @@ export function transformEventToEventBasic(event: Event): EventBasic {
     times,
     image,
     isPast,
-    promoImage,
     primaryLabels,
     title,
     isOnline,
@@ -306,7 +303,6 @@ export function transformEventToEventBasic(event: Event): EventBasic {
     scheduleLength,
     series,
     secondaryLabels,
-    promoText,
     cost,
     contributors,
   }))(event);

--- a/content/webapp/services/prismic/transformers/exhibitions.ts
+++ b/content/webapp/services/prismic/transformers/exhibitions.ts
@@ -194,7 +194,6 @@ export function transformExhibitionToExhibitionBasic(
     statusOverride,
     contributors,
     labels,
-    promoImage,
   }) => ({
     type,
     id,
@@ -207,7 +206,6 @@ export function transformExhibitionToExhibitionBasic(
     statusOverride,
     contributors,
     labels,
-    promoImage,
   }))(exhibition);
 }
 

--- a/content/webapp/services/prismic/transformers/index.ts
+++ b/content/webapp/services/prismic/transformers/index.ts
@@ -397,8 +397,6 @@ export function transformGenericFields(doc: Doc): GenericContentFields {
     body: body,
     standfirst: standfirst && standfirst.value,
     promo,
-    promoText: promo && promo.caption,
-    promoImage: promo && promo.image,
     image,
     metadataDescription,
     // we pass an empty array here to be overriden by each content type

--- a/content/webapp/services/prismic/transformers/json-ld.ts
+++ b/content/webapp/services/prismic/transformers/json-ld.ts
@@ -5,7 +5,7 @@ import {
   wellcomeCollectionGallery,
 } from '@weco/common/model/organization';
 import { getImageUrlAtSize } from '../types/images';
-import { Article, ArticleBasic } from '../../../types/articles';
+import { Article } from '../../../types/articles';
 import { Contributor } from '../../../types/contributors';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 import { Page } from '../../../types/pages';
@@ -19,7 +19,7 @@ export function exhibitionLd(exhibition: Exhibition) {
   return objToJsonLd(
     {
       name: exhibition.title,
-      description: exhibition.promoText,
+      description: exhibition.promo?.caption,
       image: promoImage ? getImageUrlAtSize(promoImage, { w: 600 }) : undefined,
       location: {
         '@type': 'Place',
@@ -74,7 +74,7 @@ export function eventLd(event: Event | EventBasic): JsonLdObj[] {
           },
           startDate: event.times.map(time => time.range.startDateTime),
           endDate: event.times.map(time => time.range.endDateTime),
-          description: event.promoText,
+          description: event.promo?.caption,
           image: promoImage
             ? getImageUrlAtSize(promoImage, { w: 600 })
             : undefined,
@@ -136,7 +136,7 @@ export function articleLd(article: Article): JsonLdObj {
               false
             )
           : undefined,
-      image: article.promoImage && article.promoImage.contentUrl,
+      image: article.promo?.image?.contentUrl,
       // TODO: isPartOf
       publisher: orgLd(wellcomeCollectionGallery),
       url: `https://wellcomecollection.org/articles/${article.id}`,

--- a/content/webapp/types/articles.ts
+++ b/content/webapp/types/articles.ts
@@ -8,7 +8,6 @@ import { Season } from './seasons';
 import { Series } from './series';
 import { ImagePromo } from './image-promo';
 import { ImageType } from '@weco/common/model/image';
-import { Picture } from '@weco/common/model/picture';
 import { Label } from '@weco/common/model/labels';
 
 export type ArticleBasic = {
@@ -22,9 +21,7 @@ export type ArticleBasic = {
   format?: Format<ArticleFormatId>;
   image?: ImageType;
   datePublished: Date;
-  promoImage?: Picture;
   labels: Label[];
-  promoText?: string;
   color?: ColorSelection;
 };
 

--- a/content/webapp/types/books.ts
+++ b/content/webapp/types/books.ts
@@ -18,7 +18,6 @@ export type BookBasic = {
   id: string;
   title: string;
   subtitle?: string;
-  promoText?: string;
   cover?: ImageType;
   promo?: ImagePromo | undefined;
   labels: Label[];

--- a/content/webapp/types/events.ts
+++ b/content/webapp/types/events.ts
@@ -6,7 +6,6 @@ import { Place } from './places';
 import { Season } from './seasons';
 import { Label } from '@weco/common/model/labels';
 import { ImagePromo } from './image-promo';
-import { Picture } from '@weco/common/model/picture';
 import { ImageType } from '@weco/common/model/image';
 import * as prismicT from '@prismicio/types';
 import { isDayPast } from '@weco/common/utils/dates';
@@ -80,7 +79,6 @@ export type EventBasic = {
   promo?: ImagePromo | undefined;
   times: EventTime[];
   isPast: boolean;
-  promoImage?: Picture;
   primaryLabels: Label[];
   secondaryLabels: Label[];
   image?: ImageType;
@@ -89,7 +87,6 @@ export type EventBasic = {
   availableOnline: boolean;
   scheduleLength: number;
   series: EventSeries[];
-  promoText?: string;
   cost?: string;
   contributors: Contributor[];
 };

--- a/content/webapp/types/exhibitions.ts
+++ b/content/webapp/types/exhibitions.ts
@@ -9,7 +9,6 @@ import { Season } from './seasons';
 import { ImagePromo } from './image-promo';
 import { Label } from '@weco/common/model/labels';
 import { ImageType } from '@weco/common/model/image';
-import { Picture } from '@weco/common/model/picture';
 import * as prismicT from '@prismicio/types';
 
 // e.g. 'Permanent'
@@ -34,8 +33,6 @@ export type ExhibitionBasic = {
   contributors: Contributor[];
   labels: Label[];
   image?: ImageType;
-  promoText?: string;
-  promoImage?: Picture;
 };
 
 export type Exhibition = GenericContentFields & {

--- a/content/webapp/types/generic-content-fields.ts
+++ b/content/webapp/types/generic-content-fields.ts
@@ -1,5 +1,4 @@
 import { ImagePromo } from './image-promo';
-import { Picture } from '@weco/common/model/picture';
 import { ImageType } from '@weco/common/model/image';
 import { Label } from '@weco/common/model/labels';
 import * as prismicT from '@prismicio/types';
@@ -21,8 +20,6 @@ export type GenericContentFields = {
   promo?: ImagePromo;
   body: BodyType;
   standfirst?: prismicT.RichTextField;
-  promoText?: string;
-  promoImage?: Picture;
   image?: ImageType;
   metadataDescription?: string;
   labels: Label[];


### PR DESCRIPTION
Our GenericContentFields model has fields for `promo`, `promoText` and `promoImage`, but if you look at how they're parsed, they duplicate information:

```typescript
    promo,
    promoText: promo && promo.caption,
    promoImage: promo && promo.image,
```

This is unnecessary -- we can remove these fields and the amount of data we send on the page.