### PR TITLE
Fix the broken /articles page

### DIFF
--- a/content/webapp/pages/articles.tsx
+++ b/content/webapp/pages/articles.tsx
@@ -18,9 +18,11 @@ import { getServerData } from '@weco/common/server-data';
 import { articleLd } from '../services/prismic/transformers/json-ld';
 import { getPage } from '../utils/query-params';
 import { pageDescriptions } from '@weco/common/data/microcopy';
+import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 
 type Props = {
   articles: PaginatedResults<ArticleBasic>;
+  jsonLd: JsonLdObj[];
 };
 
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
@@ -33,20 +35,26 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
 
     const client = createClient(context);
     const articlesQuery = await fetchArticles(client, { page });
-    const articles = transformQuery(articlesQuery, article =>
-      transformArticleToArticleBasic(transformArticle(article))
-    );
+
+    const articles = transformQuery(articlesQuery, transformArticle);
+    const jsonLd = articles.results.map(articleLd);
+    const basicArticles = {
+      ...articles,
+      results: articles.results.map(transformArticleToArticleBasic),
+    };
+
     const serverData = await getServerData(context);
 
     return {
       props: removeUndefinedProps({
-        articles,
+        articles: basicArticles,
+        jsonLd,
         serverData,
       }),
     };
   };
 
-const ArticlesPage: FC<Props> = ({ articles }: Props) => {
+const ArticlesPage: FC<Props> = ({ articles, jsonLd }: Props) => {
   const firstArticle = articles.results[0];
 
   return (
@@ -54,7 +62,7 @@ const ArticlesPage: FC<Props> = ({ articles }: Props) => {
       title={'Articles'}
       description={pageDescriptions.articles}
       url={{ pathname: `/articles` }}
-      jsonLd={articles.results.map(articleLd)}
+      jsonLd={jsonLd}
       openGraphType={'website'}
       siteSection={'stories'}
       image={firstArticle.image}


### PR DESCRIPTION
This issue was introduced in https://github.com/wellcomecollection/wellcomecollection.org/pull/7844; now we pre-build the JSON-LD for articles we don't have to send the contributor data, but we hadn't fixed it on this page.

I'm mildly surprised the type checker didn't catch this for us, but it's working now.