### PR TITLE
Event locations

### DIFF
--- a/common/data/microcopy.ts
+++ b/common/data/microcopy.ts
@@ -92,3 +92,5 @@ export const sierraAccessMethodtoNewLabel = {
   'Manual request': 'Manual request',
   'Online request': 'Online request',
 };
+
+export const inOurBuilding = 'In our building';

--- a/content/webapp/__mocks__/events.ts
+++ b/content/webapp/__mocks__/events.ts
@@ -75,6 +75,10 @@ export const eventWithOneLocation: Event = {
   ...baseEvent,
   locations: [location],
 };
+export const eventWithMultipleLocations: Event = {
+  ...baseEvent,
+  locations: [location, location],
+};
 export const eventOnline: Event = { ...baseEvent, isOnline: true };
 export const eventWithOneLocationOnline: Event = {
   ...baseEvent,

--- a/content/webapp/__mocks__/events.ts
+++ b/content/webapp/__mocks__/events.ts
@@ -11,7 +11,7 @@ const image = {
   crops: {},
 };
 
-const location = {
+export const location = {
   id: 'Wn1fvyoAACgAH_yG',
   title: 'Reading Room',
   body: [],

--- a/content/webapp/components/EventPromo/EventPromo.test.tsx
+++ b/content/webapp/components/EventPromo/EventPromo.test.tsx
@@ -9,6 +9,7 @@ import {
   eventWithOneLocation,
   eventOnline,
   eventWithOneLocationOnline,
+  eventWithMultipleLocations,
 } from '../../__mocks__/events';
 jest.spyOn(Context, 'useToggles').mockImplementation(() => ({
   enablePickUpDate: true,
@@ -30,6 +31,11 @@ describe('EventPromo', () => {
   it('Shows a specific location when it is the only location for an event', () => {
     renderComponent(eventWithOneLocation);
     expect(screen.getByText('Reading Room'));
+  });
+
+  it('Shows a generic location when there are multiple physical locations', () => {
+    renderComponent(eventWithMultipleLocations);
+    expect(screen.getByText('In our building'));
   });
 
   it('Shows when an event is online', () => {

--- a/content/webapp/components/EventPromo/EventPromo.test.tsx
+++ b/content/webapp/components/EventPromo/EventPromo.test.tsx
@@ -2,10 +2,11 @@ import { render, screen } from '@testing-library/react';
 import prismicData from '@weco/common/test/fixtures/prismicData/prismic-data';
 import { ThemeProvider } from 'styled-components';
 import theme from '@weco/common/views/themes/default';
-import EventPromo from './EventPromo';
+import EventPromo, { getLocationText } from './EventPromo';
 import * as Context from '@weco/common/server-data/Context';
 import { Event } from '@weco/common/model/events';
 import {
+  location,
   eventWithOneLocation,
   eventOnline,
   eventWithOneLocationOnline,
@@ -46,5 +47,39 @@ describe('EventPromo', () => {
   it('Shows when an event is a physical/online hybrid', () => {
     renderComponent(eventWithOneLocationOnline);
     expect(screen.getByText('Online | In our building'));
+  });
+});
+
+describe.only('getLocationText', () => {
+  it('returns the specific location given one physical location only (and not online)', () => {
+    const locationText = getLocationText(false, [location]);
+    expect(locationText).toEqual('Reading Room');
+  });
+
+  it('returns "In our building" given one physical location which has the name "Throughout the building"', () => {
+    const locationText = getLocationText(false, [
+      {
+        ...location,
+        title: 'Throughout the building',
+      },
+    ]);
+    expect(locationText).toEqual('In our building');
+  });
+
+  it('returns "In our building" given more than one physical location (and not online)', () => {
+    const locationText = getLocationText(false, [location, location]);
+    expect(locationText).toEqual('In our building');
+  });
+
+  it('returns "Online" if an event is online only', () => {
+    const locationText = getLocationText(true, []);
+    expect(locationText).toEqual('Online');
+  });
+
+  it('returns "Online | In our building" if an event is online and has one or more physical locations', () => {
+    const locationText = getLocationText(true, [location]);
+    const locationText2 = getLocationText(true, [location, location]);
+    expect(locationText).toEqual('Online | In our building');
+    expect(locationText2).toEqual('Online | In our building');
   });
 });

--- a/content/webapp/components/EventPromo/EventPromo.test.tsx
+++ b/content/webapp/components/EventPromo/EventPromo.test.tsx
@@ -39,6 +39,6 @@ describe('EventPromo', () => {
 
   it('Shows when an event is a physical/online hybrid', () => {
     renderComponent(eventWithOneLocationOnline);
-    expect(screen.getByText('Online & In our building'));
+    expect(screen.getByText('Online | In our building'));
   });
 });

--- a/content/webapp/components/EventPromo/EventPromo.tsx
+++ b/content/webapp/components/EventPromo/EventPromo.tsx
@@ -31,7 +31,9 @@ export function getLocationText(isOnline?: boolean, place?: Place[]): string {
   // * If an event is only in venue, in multiple locations, we display 'In our building'
   // * If an event is only online, we display 'Online'
   // * If an event is online and in venue, we display 'Online | In our building'
-  // * If an event has a single Primsic location, 'Throughout the building', we display 'In our building'
+  // * If an event has a single Prismic location, 'Throughout the building', we display 'In our building'
+  //   This is how the editorial team used to do multi-location events before we added proper support
+  //   for multiple locations.
   if (!isOnline && isNotUndefined(place) && place.length === 1) {
     return place[0].title === 'Throughout the building'
       ? inOurBuilding

--- a/content/webapp/components/EventPromo/EventPromo.tsx
+++ b/content/webapp/components/EventPromo/EventPromo.tsx
@@ -14,6 +14,8 @@ import Icon from '@weco/common/views/components/Icon/Icon';
 import { location } from '@weco/common/icons';
 import AlignFont from '@weco/common/views/components/styled/AlignFont';
 import { Place } from '../../types/places';
+import { isNotUndefined } from '@weco/common/utils/array';
+import { inOurBuilding } from '@weco/common/data/microcopy';
 
 type Props = {
   event: EventBasic;
@@ -23,10 +25,18 @@ type Props = {
   fromDate?: Date;
 };
 
-function getLocationText(isOnline?: boolean, place?: Place): string {
-  if (!isOnline && place) return place.title;
+function getLocationText(isOnline?: boolean, place?: Place[]): string {
+  if (!isOnline && isNotUndefined(place) && place.length === 1) {
+    return place[0].title;
+  }
 
-  return `Online${place ? ' & In our building' : ''}`;
+  if (!isOnline && isNotUndefined(place) && place.length > 1) {
+    return inOurBuilding;
+  }
+
+  return `Online${
+    isNotUndefined(place) && place.length > 0 ? ` | ${inOurBuilding}` : ''
+  }`;
 }
 
 const EventPromo: FC<Props> = ({
@@ -89,7 +99,7 @@ const EventPromo: FC<Props> = ({
             {event.title}
           </Space>
 
-          {(event.isOnline || event.locations[0]) && (
+          {(event.isOnline || event.locations.length > 0) && (
             <Space
               v={{ size: 's', properties: ['margin-top', 'margin-bottom'] }}
               className={classNames({
@@ -100,7 +110,7 @@ const EventPromo: FC<Props> = ({
               <Icon icon={location} matchText />
               <Space h={{ size: 'xs', properties: ['margin-left'] }}>
                 <AlignFont>
-                  {getLocationText(event.isOnline, event.locations[0])}
+                  {getLocationText(event.isOnline, event.locations)}
                 </AlignFont>
               </Space>
             </Space>

--- a/content/webapp/components/EventPromo/EventPromo.tsx
+++ b/content/webapp/components/EventPromo/EventPromo.tsx
@@ -25,9 +25,17 @@ type Props = {
   fromDate?: Date;
 };
 
-function getLocationText(isOnline?: boolean, place?: Place[]): string {
+export function getLocationText(isOnline?: boolean, place?: Place[]): string {
+  // Acceptance criteria from https://github.com/wellcomecollection/wellcomecollection.org/issues/7818
+  // * If an event is only in venue, in a single location, we display the specific location (e.g. 'Reading Room')
+  // * If an event is only in venue, in multiple locations, we display 'In our building'
+  // * If an event is only online, we display 'Online'
+  // * If an event is online and in venue, we display 'Online | In our building'
+  // * If an event has a single Primsic location, 'Throughout the building', we display 'In our building'
   if (!isOnline && isNotUndefined(place) && place.length === 1) {
-    return place[0].title;
+    return place[0].title === 'Throughout the building'
+      ? inOurBuilding
+      : place[0].title;
   }
 
   if (!isOnline && isNotUndefined(place) && place.length > 1) {

--- a/playwright/test/helpers/utils.ts
+++ b/playwright/test/helpers/utils.ts
@@ -22,6 +22,7 @@ export async function makeDefaultToggleCookies(
     'https://toggles.wellcomecollection.org/toggles.json'
   );
   const { toggles } = data;
+  console.log(toggles);
 
   return toggles.map(t => {
     return {

--- a/playwright/test/helpers/utils.ts
+++ b/playwright/test/helpers/utils.ts
@@ -22,7 +22,6 @@ export async function makeDefaultToggleCookies(
     'https://toggles.wellcomecollection.org/toggles.json'
   );
   const { toggles } = data;
-  console.log(toggles);
 
   return toggles.map(t => {
     return {


### PR DESCRIPTION
Closes #7818

Note there are past events that occurred at multiple physical locations and in order to handle these the content team created a new location called 'Throughout the building'. Since these will be read as single locations, they will continue to display as 'Throughout the building' on cards, unless they are retroactively updated to include the two or more _actual_ locations at which they occurred.