### PR TITLE
adds 14 days to the default pickup date

### DIFF
--- a/catalogue/webapp/components/ItemRequestModal/ItemRequestModal.tsx
+++ b/catalogue/webapp/components/ItemRequestModal/ItemRequestModal.tsx
@@ -245,7 +245,7 @@ const RequestDialog: FC<RequestDialogProps> = ({
         action: 'confirm_request',
         label: `/works/${work.id}`,
       });
-      confirmRequest(pickUpDateMoment);
+      confirmRequest(pickUpDateMoment.add(14, 'days'));
     }
   }
 


### PR DESCRIPTION
People who don't want their holds to expire after 2(ish) days.

Relates to this conversation: https://wellcome.slack.com/archives/C3TQSF63C/p1648052162074989

This is a stop gap measure until we work out how to proceed.