### PR TITLE
Tidy up some of the body transformers

### DIFF
--- a/common/views/components/TagsGroup/TagsGroup.tsx
+++ b/common/views/components/TagsGroup/TagsGroup.tsx
@@ -3,7 +3,7 @@ import { font } from '../../../utils/classnames';
 import Space from '../styled/Space';
 import Tags, { TagType } from '../Tags/Tags';
 
-type Props = {
+export type Props = {
   title: string | undefined;
   tags: TagType[];
 };

--- a/content/webapp/components/Body/Body.tsx
+++ b/content/webapp/components/Body/Body.tsx
@@ -487,10 +487,7 @@ const Body: FunctionComponent<Props> = ({
                 )}
                 {slice.type === 'tagList' && (
                   <LayoutWidth width={minWidth}>
-                    <TagsGroup
-                      title={slice.value.title}
-                      tags={slice.value.tags}
-                    />
+                    <TagsGroup {...slice.value} />
                   </LayoutWidth>
                 )}
                 {/* deprecated */}

--- a/content/webapp/components/SearchResults/AsyncSearchResults.tsx
+++ b/content/webapp/components/SearchResults/AsyncSearchResults.tsx
@@ -5,7 +5,7 @@ import Space from '@weco/common/views/components/styled/Space';
 import { fetchMultiContentClientSide } from '../../services/prismic/fetch/multi-content';
 import { MultiContent } from '../../types/multi-content';
 
-type Props = {
+export type Props = {
   title?: string;
   query: string;
 };

--- a/content/webapp/services/prismic/transformers/body.ts
+++ b/content/webapp/services/prismic/transformers/body.ts
@@ -10,6 +10,7 @@ import {
   QuoteV2 as QuoteV2Slice,
   Standfirst as StandfirstSlice,
   Table as TableSlice,
+  TagList as TagListSlice,
   TextSlice,
   DeprecatedImageList as DeprecatedImageListSlice,
   TitledTextList as TitledTextListSlice,
@@ -25,6 +26,7 @@ import { Props as ImageGalleryProps } from '../../../components/ImageGallery/Ima
 import { Props as DeprecatedImageListProps } from '../../../components/DeprecatedImageList/DeprecatedImageList';
 import { Props as GifVideoProps } from '../../../components/GifVideo/GifVideo';
 import { Props as TitledTextListProps } from '../../../components/TitledTextList/TitledTextList';
+import { Props as TagsGroupProps } from '@weco/common/views/components/TagsGroup/TagsGroup';
 import { Props as MapProps } from '../../../components/Map/Map';
 import { Props as DiscussionProps } from '../../../components/Discussion/Discussion';
 import { MediaObjectType } from '../../../types/media-object';
@@ -335,6 +337,24 @@ export function transformQuoteSlice(
       citation: slice.primary.citation,
       isPullOrReview:
         slice.slice_label === 'pull' || slice.slice_label === 'review',
+    },
+  };
+}
+
+export function transformTagListSlice(
+  slice: TagListSlice
+): ParsedSlice<'tagList', TagsGroupProps> {
+  return {
+    type: 'tagList',
+    value: {
+      title: asTitle(slice.primary.title),
+      tags: slice.items.map(item => ({
+        textParts: item.linkText ? [item.linkText] : [],
+        linkAttributes: {
+          href: { pathname: transformLink(item.link) },
+          as: { pathname: transformLink(item.link) },
+        },
+      })),
     },
   };
 }

--- a/content/webapp/services/prismic/transformers/body.ts
+++ b/content/webapp/services/prismic/transformers/body.ts
@@ -1,4 +1,5 @@
 import {
+  CollectionVenue as CollectionVenueSlice,
   Contact as ContactSlice,
   EditorialImageSlice,
   EditorialImageGallerySlice,
@@ -51,6 +52,8 @@ import {
 import { transformTaslFromString } from '@weco/common/services/prismic/transformers';
 import { LinkField, RelationField, RichTextField } from '@prismicio/types';
 import { Weight } from '../../../types/generic-content-fields';
+import { Venue } from '@weco/common/model/opening-hours';
+import { transformCollectionVenue } from '@weco/common/services/prismic/transformers/collection-venues';
 
 export function getWeight(weight: string | null): Weight {
   switch (weight) {
@@ -372,4 +375,24 @@ export function transformSearchResultsSlice(
       query: slice.primary.query || '',
     },
   };
+}
+
+export function transformCollectionVenueSlice(
+  slice: CollectionVenueSlice
+):
+  | ParsedSlice<
+      'collectionVenue',
+      { content: Venue; showClosingTimes: boolean }
+    >
+  | undefined {
+  return isFilledLinkToDocumentWithData(slice.primary.content)
+    ? {
+        type: 'collectionVenue',
+        weight: getWeight(slice.slice_label),
+        value: {
+          content: transformCollectionVenue(slice.primary.content),
+          showClosingTimes: slice.primary.showClosingTimes === 'yes',
+        },
+      }
+    : undefined;
 }

--- a/content/webapp/services/prismic/transformers/body.ts
+++ b/content/webapp/services/prismic/transformers/body.ts
@@ -8,6 +8,7 @@ import {
   MediaObjectList as MediaObjectListSlice,
   Quote as QuoteSlice,
   QuoteV2 as QuoteV2Slice,
+  SearchResults as SearchResultsSlice,
   Standfirst as StandfirstSlice,
   Table as TableSlice,
   TagList as TagListSlice,
@@ -21,6 +22,7 @@ import { Props as TableProps } from '@weco/common/views/components/Table/Table';
 import { Props as ContactProps } from '@weco/common/views/components/Contact/Contact';
 import { Props as IframeProps } from '@weco/common/views/components/Iframe/Iframe';
 import { Props as InfoBlockProps } from '@weco/common/views/components/InfoBlock/InfoBlock';
+import { Props as AsyncSearchResultsProps } from '../../../components/SearchResults/AsyncSearchResults';
 import { Props as QuoteProps } from '../../../components/Quote/Quote';
 import { Props as ImageGalleryProps } from '../../../components/ImageGallery/ImageGallery';
 import { Props as DeprecatedImageListProps } from '../../../components/DeprecatedImageList/DeprecatedImageList';
@@ -355,6 +357,19 @@ export function transformTagListSlice(
           as: { pathname: transformLink(item.link) },
         },
       })),
+    },
+  };
+}
+
+export function transformSearchResultsSlice(
+  slice: SearchResultsSlice
+): ParsedSlice<'searchResults', AsyncSearchResultsProps> {
+  return {
+    type: 'searchResults',
+    weight: getWeight(slice.slice_label),
+    value: {
+      title: asText(slice.primary.title),
+      query: slice.primary.query || '',
     },
   };
 }

--- a/content/webapp/services/prismic/transformers/index.ts
+++ b/content/webapp/services/prismic/transformers/index.ts
@@ -51,6 +51,7 @@ import {
   transformQuoteSlice,
   transformStandfirstSlice,
   transformTableSlice,
+  transformTagListSlice,
   transformTextSlice,
   transformTitledTextListSlice,
 } from './body';
@@ -350,19 +351,7 @@ export function transformBody(body: Body): BodyType {
           return transformDiscussionSlice(slice);
 
         case 'tagList':
-          return {
-            type: 'tagList',
-            value: {
-              title: asTitle(slice.primary.title),
-              tags: slice.items.map(item => ({
-                textParts: [item.linkText],
-                linkAttributes: {
-                  href: { pathname: transformLink(item.link), query: '' },
-                  as: { pathname: transformLink(item.link), query: '' },
-                },
-              })),
-            },
-          };
+          return transformTagListSlice(slice);
 
         // Deprecated
         case 'imageList':

--- a/content/webapp/services/prismic/transformers/index.ts
+++ b/content/webapp/services/prismic/transformers/index.ts
@@ -20,7 +20,6 @@ import {
   BodyType,
   GenericContentFields,
 } from '../../../types/generic-content-fields';
-import { transformCollectionVenue } from '@weco/common/services/prismic/transformers/collection-venues';
 import { ImageType } from '@weco/common/model/image';
 import { Body } from '../types/body';
 import { isNotUndefined, isString } from '@weco/common/utils/array';
@@ -38,6 +37,7 @@ import { SeasonPrismicDocument } from '../types/seasons';
 import { CardPrismicDocument, WithCardFormat } from '../types/card';
 import {
   getWeight,
+  transformCollectionVenueSlice,
   transformContactSlice,
   transformDeprecatedImageListSlice,
   transformDiscussionSlice,
@@ -239,16 +239,7 @@ export function transformBody(body: Body): BodyType {
           };
 
         case 'collectionVenue':
-          return isFilledLinkToDocumentWithData(slice.primary.content)
-            ? {
-                type: 'collectionVenue',
-                weight: getWeight(slice.slice_label),
-                value: {
-                  content: transformCollectionVenue(slice.primary.content),
-                  showClosingTimes: slice.primary.showClosingTimes,
-                },
-              }
-            : undefined;
+          return transformCollectionVenueSlice(slice);
 
         case 'searchResults':
           return transformSearchResultsSlice(slice);

--- a/content/webapp/services/prismic/transformers/index.ts
+++ b/content/webapp/services/prismic/transformers/index.ts
@@ -49,6 +49,7 @@ import {
   transformMapSlice,
   transformMediaObjectListSlice,
   transformQuoteSlice,
+  transformSearchResultsSlice,
   transformStandfirstSlice,
   transformTableSlice,
   transformTagListSlice,
@@ -250,18 +251,7 @@ export function transformBody(body: Body): BodyType {
             : undefined;
 
         case 'searchResults':
-          return {
-            type: 'searchResults',
-            weight: getWeight(slice.slice_label),
-            value: {
-              title: asText(slice.primary.title),
-              query: slice.primary.query,
-              // TODO: The untyped version of this code had `slice.primary.pageSize`, but
-              // there's no such field on the Prismic model.  Should it be on the model?
-              // Does it matter?  Investigate further.
-              pageSize: 4,
-            },
-          };
+          return transformSearchResultsSlice(slice);
 
         case 'quote':
         case 'quoteV2':

--- a/content/webapp/services/prismic/types/body.ts
+++ b/content/webapp/services/prismic/types/body.ts
@@ -95,7 +95,7 @@ export type Map = Slice<
   }
 >;
 
-type CollectionVenue = Slice<
+export type CollectionVenue = Slice<
   'collectionVenue',
   {
     content: RelationField<'collection-venue'>;

--- a/content/webapp/services/prismic/types/body.ts
+++ b/content/webapp/services/prismic/types/body.ts
@@ -173,7 +173,7 @@ type ContentList = Slice<
   }
 >;
 
-type SearchResults = Slice<
+export type SearchResults = Slice<
   'searchResults',
   { title: RichTextField; query: KeyTextField }
 >;

--- a/content/webapp/services/prismic/types/body.ts
+++ b/content/webapp/services/prismic/types/body.ts
@@ -122,7 +122,7 @@ export type Discussion = Slice<
   }
 >;
 
-type TagList = Slice<
+export type TagList = Slice<
   'tagList',
   {
     title: RichTextField;


### PR DESCRIPTION
For https://github.com/wellcomecollection/wellcomecollection.org/issues/7753

This is continuing to break up the mega-long `transformBody()` method, and stick some types around it so we can keep leaning on the type checker.