### PR TITLE
Fix the grouping of events on event pages

### DIFF
--- a/content/webapp/components/EventsByMonth/EventsByMonth.tsx
+++ b/content/webapp/components/EventsByMonth/EventsByMonth.tsx
@@ -15,10 +15,9 @@ import CssGridContainer from '@weco/common/views/components/styled/CssGridContai
 import CardGrid from '../CardGrid/CardGrid';
 import {
   createLabel,
-  getMonthsInDateRange,
+  findMonthsThatEventSpans,
   parseLabel,
   startOf,
-  YearMonth,
 } from './group-event-utils';
 
 type Props = {
@@ -53,34 +52,12 @@ class EventsByMonth extends Component<Props, State> {
       12: 'December',
     };
 
-    // Returns a list of events and the months they fall in.
-    // The months are formatted as YYYY-MM labels like "2001-02".
-    const eventsWithMonths: {
-      event: EventBasic;
-      months: YearMonth[];
-    }[] = events
-      .filter(event => event.times.length > 0)
-      .map(event => {
-        const firstRange = event.times[0];
-        const lastRange = event.times[event.times.length - 1];
-
-        const start = firstRange.range.startDateTime;
-        const end = lastRange.range.endDateTime;
-
-        const months = getMonthsInDateRange({ start, end });
-        return { event, months };
-      });
-
-    eventsWithMonths.forEach(({ event, months }) => {
-      console.log(`@@AWLC event=${event.id}`);
-      console.log(`@@AWLC months=${JSON.stringify(months)}`);
-      console.log('');
-    });
+    const eventsWithTheirMonths = findMonthsThatEventSpans(events);
 
     // Key: a YYYY-MM month label like "2001-02"
     // Value: a list of events that fall somewhere in this month
     const eventsInMonths: Record<string, EventBasic[]> =
-      eventsWithMonths.reduce((acc, { event, months }) => {
+      eventsWithTheirMonths.reduce((acc, { event, months }) => {
         months.forEach(month => {
           // Only add if it has a time in the month that is the same or after today
           //

--- a/content/webapp/components/EventsByMonth/group-event-utils.test.ts
+++ b/content/webapp/components/EventsByMonth/group-event-utils.test.ts
@@ -1,7 +1,19 @@
 import {
+  createLabel,
   findMonthsThatEventSpans,
   getMonthsInDateRange,
+  groupEventsByMonth,
 } from './group-event-utils';
+
+describe('createLabel', () => {
+  it('zero-pads the month value', () => {
+    expect(createLabel({ year: 2001, month: 1 })).toEqual('2001-02');
+  });
+
+  it('gets the right label', () => {
+    expect(createLabel({ year: 2001, month: 11 })).toEqual('2001-12');
+  });
+});
 
 describe('getMonthsInDateRange', () => {
   it('finds a single month', () => {
@@ -66,5 +78,42 @@ describe('findMonthsThatEventSpans', () => {
         ],
       },
     ]);
+  });
+});
+
+describe('groupEventsByMonth', () => {
+  it('puts each event in the right month', () => {
+    const event1 = {
+      id: '1',
+      times: [
+        {
+          range: {
+            startDateTime: new Date(2101, 1, 1),
+            endDateTime: new Date(2101, 1, 5),
+          },
+          isFullyBooked: false,
+        },
+      ],
+    };
+
+    const event2 = {
+      id: '2',
+      times: [
+        {
+          range: {
+            startDateTime: new Date(2101, 1, 1),
+            endDateTime: new Date(2101, 3, 6),
+          },
+          isFullyBooked: false,
+        },
+      ],
+    };
+
+    const result = groupEventsByMonth([event1, event2]);
+
+    expect(result).toEqual({
+      '2101-02': [event1, event2],
+      '2101-04': [event2],
+    });
   });
 });

--- a/content/webapp/components/EventsByMonth/group-event-utils.test.ts
+++ b/content/webapp/components/EventsByMonth/group-event-utils.test.ts
@@ -1,0 +1,23 @@
+import { getMonthsInDateRange } from './group-event-utils';
+
+describe('getMonthsInDateRange', () => {
+  it('finds a single month', () => {
+    const result = getMonthsInDateRange({
+      start: new Date(2001, 1, 1),
+      end: new Date(2001, 1, 5),
+    });
+    expect(result).toEqual([{ year: 2001, month: 1 }]);
+  });
+
+  it('finds multiple months', () => {
+    const result = getMonthsInDateRange({
+      start: new Date(2001, 1, 1),
+      end: new Date(2001, 3, 6),
+    });
+    expect(result).toEqual([
+      { year: 2001, month: 1 },
+      { year: 2001, month: 2 },
+      { year: 2001, month: 3 },
+    ]);
+  });
+});

--- a/content/webapp/components/EventsByMonth/group-event-utils.test.ts
+++ b/content/webapp/components/EventsByMonth/group-event-utils.test.ts
@@ -1,4 +1,7 @@
-import { getMonthsInDateRange } from './group-event-utils';
+import {
+  findMonthsThatEventSpans,
+  getMonthsInDateRange,
+} from './group-event-utils';
 
 describe('getMonthsInDateRange', () => {
   it('finds a single month', () => {
@@ -18,6 +21,50 @@ describe('getMonthsInDateRange', () => {
       { year: 2001, month: 1 },
       { year: 2001, month: 2 },
       { year: 2001, month: 3 },
+    ]);
+  });
+});
+
+describe('findMonthsThatEventSpans', () => {
+  it('finds the correct months for each event', () => {
+    const event1 = {
+      id: '1',
+      times: [
+        {
+          range: {
+            startDateTime: new Date(2001, 1, 1),
+            endDateTime: new Date(2001, 1, 5),
+          },
+          isFullyBooked: false,
+        },
+      ],
+    };
+
+    const event2 = {
+      id: '2',
+      times: [
+        {
+          range: {
+            startDateTime: new Date(2001, 1, 1),
+            endDateTime: new Date(2001, 3, 6),
+          },
+          isFullyBooked: false,
+        },
+      ],
+    };
+
+    const result = findMonthsThatEventSpans([event1, event2]);
+
+    expect(result).toEqual([
+      { event: event1, months: [{ year: 2001, month: 1 }] },
+      {
+        event: event2,
+        months: [
+          { year: 2001, month: 1 },
+          { year: 2001, month: 2 },
+          { year: 2001, month: 3 },
+        ],
+      },
     ]);
   });
 });

--- a/content/webapp/components/EventsByMonth/group-event-utils.ts
+++ b/content/webapp/components/EventsByMonth/group-event-utils.ts
@@ -1,0 +1,46 @@
+// Utilities for grouping events
+
+import { isSameMonth } from '@weco/common/utils/dates';
+
+export type YearMonth = {
+  year: number;
+  month: number;
+};
+
+// Creates a label in the form YYYY-MM, e.g. "2001-02"
+export function createLabel(ym: YearMonth): string {
+  return startOf(ym).toISOString().slice(0, 7);
+}
+
+export function parseLabel(label: string): YearMonth {
+  const year = parseInt(label.slice(0, 4), 10);
+  const month = parseInt(label.slice(5, 7), 10);
+  return { year, month };
+}
+
+export function startOf({ year, month }: YearMonth): Date {
+  return new Date(year, month, 1);
+}
+
+// recursive - TODO: make tail recursive?
+type StartEnd = { start: Date; end: Date };
+
+export function getMonthsInDateRange(
+  { start, end }: StartEnd,
+  acc: YearMonth[] = []
+): YearMonth[] {
+  if (isSameMonth(start, end) || start <= end) {
+    const yearMonth = {
+      year: start.getFullYear(),
+      month: start.getMonth(),
+    };
+    const newAcc = acc.concat(yearMonth);
+    const newStart = startOf({
+      ...yearMonth,
+      month: yearMonth.month + 1,
+    });
+    return getMonthsInDateRange({ start: newStart, end }, newAcc);
+  } else {
+    return acc;
+  }
+}

--- a/content/webapp/components/EventsByMonth/group-event-utils.ts
+++ b/content/webapp/components/EventsByMonth/group-event-utils.ts
@@ -1,6 +1,11 @@
 // Utilities for grouping events
 
 import { isSameMonth } from '@weco/common/utils/dates';
+import { EventTime } from '../../types/events';
+
+type HasTimes = {
+  times: EventTime[];
+};
 
 export type YearMonth = {
   year: number;
@@ -43,4 +48,25 @@ export function getMonthsInDateRange(
   } else {
     return acc;
   }
+}
+
+// For each event, find the months that it spans.
+export function findMonthsThatEventSpans<T extends HasTimes>(
+  events: T[]
+): {
+  event: T;
+  months: YearMonth[];
+}[] {
+  return events
+    .filter(event => event.times.length > 0)
+    .map(event => {
+      const firstRange = event.times[0];
+      const lastRange = event.times[event.times.length - 1];
+
+      const start = firstRange.range.startDateTime;
+      const end = lastRange.range.endDateTime;
+
+      const months = getMonthsInDateRange({ start, end });
+      return { event, months };
+    });
 }

--- a/content/webapp/services/prismic/events.test.ts
+++ b/content/webapp/services/prismic/events.test.ts
@@ -1,0 +1,34 @@
+import { orderEventsByNextAvailableDate } from './events';
+
+describe('orderEventsByNextAvailableDate', () => {
+  it('returns events in the right order', () => {
+    const aprilEvent = {
+      id: 'April-YjhVlhEAACEAcYb1',
+      times: [
+        {
+          range: {
+            startDateTime: new Date(2032, 3, 25, 15, 30, 0),
+            endDateTime: new Date(2032, 3, 25, 16, 30, 0),
+          },
+          isFullyBooked: false,
+        },
+      ],
+    };
+
+    const marchEvent = {
+      id: 'March-YhTyEhMAADOEddAT',
+      times: [
+        {
+          range: {
+            startDateTime: new Date(2032, 2, 24, 18, 0, 0),
+            endDateTime: new Date(2032, 2, 25, 19, 30, 0),
+          },
+          isFullyBooked: false,
+        },
+      ],
+    };
+
+    const result = orderEventsByNextAvailableDate([aprilEvent, marchEvent]);
+    expect(result).toEqual([marchEvent, aprilEvent]);
+  });
+});

--- a/content/webapp/services/prismic/events.ts
+++ b/content/webapp/services/prismic/events.ts
@@ -6,9 +6,9 @@ import {
   isDayPast,
   isFuture,
 } from '@weco/common/utils/dates';
-import { Event, EventBasic, EventTime } from '../../types/events';
+import { Event, EventBasic } from '../../types/events';
 
-function getNextDateInFuture(event: EventBasic): EventTime | undefined {
+function getNextDateInFuture(event: EventBasic): Date | undefined {
   const futureTimes = event.times.filter(time =>
     isFuture(time.range.startDateTime)
   );
@@ -20,7 +20,7 @@ function getNextDateInFuture(event: EventBasic): EventTime | undefined {
       time.range.startDateTime <= closestStartingDate.range.startDateTime
         ? time
         : closestStartingDate
-    );
+    ).range.startDateTime;
   }
 }
 

--- a/content/webapp/services/prismic/events.ts
+++ b/content/webapp/services/prismic/events.ts
@@ -1,25 +1,26 @@
 import sortBy from 'lodash.sortby';
 import { Moment } from 'moment';
 import { london, formatDayDate } from '@weco/common/utils/format-date';
-import { getNextWeekendDateRange, isDayPast } from '@weco/common/utils/dates';
+import {
+  getNextWeekendDateRange,
+  isDayPast,
+  isFuture,
+} from '@weco/common/utils/dates';
 import { Event, EventBasic, EventTime } from '../../types/events';
 
 function getNextDateInFuture(event: EventBasic): EventTime | undefined {
-  const now = new Date();
-  const futureTimes = event.times.filter(time => {
-    return time.range.endDateTime.getDate() >= now.getDate();
-  });
+  const futureTimes = event.times.filter(time =>
+    isFuture(time.range.startDateTime)
+  );
 
   if (futureTimes.length === 0) {
     return undefined;
   } else {
-    return futureTimes.reduce((closestStartingDate, time) => {
-      if (time.range.startDateTime <= closestStartingDate.range.startDateTime) {
-        return time;
-      } else {
-        return closestStartingDate;
-      }
-    });
+    return futureTimes.reduce((closestStartingDate, time) =>
+      time.range.startDateTime <= closestStartingDate.range.startDateTime
+        ? time
+        : closestStartingDate
+    );
   }
 }
 


### PR DESCRIPTION
Lalita has [pointed out in Slack](https://wellcome.slack.com/archives/C8X9YKM5X/p1648151459847929) that events are displaying in the wrong order: the April event appears before the March event:

<img width="874" alt="Screenshot 2022-03-24 at 20 49 19" src="https://user-images.githubusercontent.com/301220/160007840-18e0ca49-4730-4d40-a4f1-f7f7b4810dfb.png">

But hold on… this is a filter tab for March events. Why is the April event even showing here?!

The answer is that I broke it, but because we only had a single upcoming event at the time, nobody noticed. The error was introduced in this PR: https://github.com/wellcomecollection/wellcomecollection.org/pull/7832/files#diff-e9bdfcf97955502ca4eebae736c06db00aa9a374235669cee4a0198696ee9b62

I got a list of events, then mapped them to a list of events with months, e.g.

```
[ { event: event1, months: [ { year: 2001, month: 1 } ] }]
[ { event: event2, months: [ { year: 2001, month: 1, year: 2002, month: 2 } ] }]
[ { event: event3, months: [ { year: 2001, month: 2, year: 2002, month: 3 } ] }]
```

These then got squashed down into YYYY-MM labels:

```
[ { event: event1, months: [ 2001-01 ] }]
[ { event: event2, months: [ 2001-01, 2001-02 ] }]
[ { event: event3, months: [ 2001-02, 2001-03 ] }]
```

and then I reversed the map and grouped by labels:

```
{
  2001-01: [event1, event2]
  2001-02: [event2, event3]
  2001-03: [event3]
}
```

but something a little funky happens in that `createLabel()` function I don't fully understand – I was trying to be clever about ISO date strings, and actually the labels aren't always what you expect. It's so simple! It should obviously do the right thing! But it doesn't.

In particular, it looks like the April event is getting the label `2022-03` so it's being put in the March group, but then the sorting logic gets confused because it can't find out when in March this event falls.

This patch:

* Fixes the createLabel() function and adds some tests for it
* Adds some tests for the other logic in EventsByMonth, because it's fiddly enough that it's liable to break easily, and this should prevent similar bugs slipping in

And now we get nice segmented groups:

<img width="462" alt="Screenshot 2022-03-24 at 20 55 48" src="https://user-images.githubusercontent.com/301220/160008765-784588e7-d22f-4f20-b41b-83ae067113f1.png">
 