### PR TITLE
Add some tests for formatDateRangeWithMessage; fix a bug with the last day of exhibitions

### DIFF
--- a/common/utils/format-date.test.ts
+++ b/common/utils/format-date.test.ts
@@ -58,13 +58,38 @@ describe('formatDateRangeWithMessage', () => {
     expect(result).toEqual({ text: 'Coming soon', color: 'marble' });
   });
 
-  it('formats a range that’s already finished', () => {
-    const result = formatDateRangeWithMessage({
-      start: new Date(1999, 1, 1),
-      end: new Date(1999, 2, 1),
+  describe('formats an event that is past', () => {
+    it('says "Past" if the last day was years ago', () => {
+      const result = formatDateRangeWithMessage({
+        start: new Date(1999, 1, 1),
+        end: new Date(1999, 2, 1),
+      expect(result).toEqual({ text: 'Past', color: 'marble' });
     });
 
-    expect(result).toEqual({ text: 'Past', color: 'marble' });
+    it('says "Past" if the last day was yesterday', () => {
+      const end = new Date();
+      end.setDate(end.getDate() - 1);
+      const yesterday = new Date(end);
+
+      const result = formatDateRangeWithMessage({
+        start: new Date(1999, 1, 1),
+        end: yesterday,
+      });
+
+      expect(result).toEqual({ text: 'Past', color: 'marble' });
+    });
+
+    it('does not say "Past" if the last day is today', () => {
+      const today = new Date();
+      today.setHours(1);
+
+      const result = formatDateRangeWithMessage({
+        start: new Date(1999, 1, 1),
+        end: today,
+      });
+
+      expect(result).not.toEqual({ text: 'Past', color: 'marble' });
+    });
   });
 
   describe('formats an event in its final week', () => {

--- a/common/utils/format-date.test.ts
+++ b/common/utils/format-date.test.ts
@@ -1,5 +1,6 @@
 import {
   formatDate,
+  formatDateRangeWithMessage,
   formatDay,
   formatDayDate,
   formatDayMonth,

--- a/common/utils/format-date.test.ts
+++ b/common/utils/format-date.test.ts
@@ -46,3 +46,82 @@ it('formats a day and a month', () => {
   const result2 = formatDayMonth(new Date(2021, 4, 6, 1, 1, 1));
   expect(result2).toEqual('6 May');
 });
+
+describe('formatDateRangeWithMessage', () => {
+  it('formats a range that hasn’t started yet', () => {
+    const result = formatDateRangeWithMessage({
+      start: new Date(2101, 1, 1),
+      end: new Date(2101, 2, 1),
+    });
+
+    expect(result).toEqual({ text: 'Coming soon', color: 'marble' });
+  });
+
+  it('formats a range that’s already finished', () => {
+    const result = formatDateRangeWithMessage({
+      start: new Date(1999, 1, 1),
+      end: new Date(1999, 2, 1),
+    });
+
+    expect(result).toEqual({ text: 'Past', color: 'marble' });
+  });
+
+  describe('formats an event in its final week', () => {
+    it('says "Final week" if the last day is today', () => {
+      const today = new Date();
+
+      const result = formatDateRangeWithMessage({
+        start: new Date(1999, 1, 1),
+        end: today,
+      });
+
+      expect(result).toEqual({ text: 'Final week', color: 'orange' });
+    });
+
+    it('says "Final week" if the last day is tomorrow', () => {
+      const end = new Date();
+      end.setDate(end.getDate() + 1);
+      const tomorrow = new Date(end);
+
+      const result = formatDateRangeWithMessage({
+        start: new Date(1999, 1, 1),
+        end: tomorrow,
+      });
+
+      expect(result).toEqual({ text: 'Final week', color: 'orange' });
+    });
+
+    it('says "Final week" if the last day is 6 days away', () => {
+      const end = new Date();
+      end.setDate(end.getDate() + 6);
+
+      const result = formatDateRangeWithMessage({
+        start: new Date(1999, 1, 1),
+        end,
+      });
+
+      expect(result).toEqual({ text: 'Final week', color: 'orange' });
+    });
+
+    it('says "Now on" if the last day is 7 or more days away', () => {
+      const end = new Date();
+      end.setDate(end.getDate() + 7);
+
+      const result = formatDateRangeWithMessage({
+        start: new Date(1999, 1, 1),
+        end,
+      });
+
+      expect(result).toEqual({ text: 'Now on', color: 'green' });
+    });
+  });
+
+  it('says "Now on" for a currently running event', () => {
+    const result = formatDateRangeWithMessage({
+      start: new Date(1999, 1, 1),
+      end: new Date(2101, 2, 1),
+    });
+
+    expect(result).toEqual({ text: 'Now on', color: 'green' });
+  });
+});

--- a/common/utils/format-date.test.ts
+++ b/common/utils/format-date.test.ts
@@ -63,6 +63,8 @@ describe('formatDateRangeWithMessage', () => {
       const result = formatDateRangeWithMessage({
         start: new Date(1999, 1, 1),
         end: new Date(1999, 2, 1),
+      });
+
       expect(result).toEqual({ text: 'Past', color: 'marble' });
     });
 
@@ -140,6 +142,15 @@ describe('formatDateRangeWithMessage', () => {
 
       expect(result).toEqual({ text: 'Now on', color: 'green' });
     });
+  });
+
+  it('says "Now on" for an event that opened today', () => {
+    const result = formatDateRangeWithMessage({
+      start: new Date(),
+      end: new Date(2101, 2, 1),
+    });
+
+    expect(result).toEqual({ text: 'Now on', color: 'green' });
   });
 
   it('says "Now on" for a currently running event', () => {

--- a/common/utils/format-date.ts
+++ b/common/utils/format-date.ts
@@ -44,7 +44,10 @@ export function formatDateRangeWithMessage({
     return { text: 'Coming soon', color: 'marble' };
   } else if (e.isBefore(now, 'day')) {
     return { text: 'Past', color: 'marble' };
-  } else if (now.isBetween(e.clone().subtract(1, 'w'), e, 'day')) {
+  } else if (
+    now.isBetween(e.clone().subtract(1, 'w'), e, 'day') ||
+    e.isSame(now, 'day')
+  ) {
     return { text: 'Final week', color: 'orange' };
   } else {
     return { text: 'Now on', color: 'green' };


### PR DESCRIPTION
This was a precursor for getting Moment out of this function, but it also uncovered a bug -- because `isBetween()` does an exclusive range (i.e. `a < x < b` rather than `a ≤ x ≤ b`), we'd show "Now on" for an exhibition that was on its final day.  This was caught by the test, and is now fixed.

This is rather important as we have an exhibition closing on Sunday!

## Who is this for?

People with an inability to plan in advance.

## What is it doing for them?

Making sure they know it's their last chance to see an exhibition.