### PR TITLE
Don't use Moment for formatDateRangeWithMessage

### DIFF
--- a/common/utils/format-date.ts
+++ b/common/utils/format-date.ts
@@ -1,5 +1,6 @@
 import moment, { Moment } from 'moment';
 import 'moment-timezone';
+import { isFuture, isPast, isSameDay } from './dates';
 
 type DateObj = { M?: number; Y?: number };
 
@@ -36,18 +37,19 @@ export function formatDateRangeWithMessage({
   start: Date;
   end: Date;
 }): { text: string; color: string } {
-  const now = london();
-  const s = london(start);
-  const e = london(end);
+  const today = new Date();
 
-  if (s.isAfter(now, 'day')) {
+  const sevenDaysTime = new Date();
+  sevenDaysTime.setDate(sevenDaysTime.getDate() + 7);
+
+  const closesToday = isSameDay(end, today);
+  const closesInSevenDays = today < end && end < sevenDaysTime;
+
+  if (!isSameDay(today, start) && isFuture(start)) {
     return { text: 'Coming soon', color: 'marble' };
-  } else if (e.isBefore(now, 'day')) {
+  } else if (!isSameDay(today, end) && isPast(end)) {
     return { text: 'Past', color: 'marble' };
-  } else if (
-    now.isBetween(e.clone().subtract(1, 'w'), e, 'day') ||
-    e.isSame(now, 'day')
-  ) {
+  } else if (closesToday || closesInSevenDays) {
     return { text: 'Final week', color: 'orange' };
   } else {
     return { text: 'Now on', color: 'green' };


### PR DESCRIPTION
It's only doing comparisons of dates, which we can do with vanilla Date objects rather than calling out to Moment.

This follows #7863 and passes all the tests in that PR, unmodified.

Part of #7831.