### PR TITLE
Fix a couple of warnings from the type checker

### DIFF
--- a/catalogue/webapp/components/ImageCard/ImageCard.tsx
+++ b/catalogue/webapp/components/ImageCard/ImageCard.tsx
@@ -1,4 +1,4 @@
-import { SyntheticEvent, useContext } from 'react';
+import { FC, SyntheticEvent, useContext, FC } from 'react';
 import NextLink from 'next/link';
 
 import { trackEvent } from '@weco/common/utils/ga';
@@ -56,7 +56,7 @@ const ImageWrap = styled(Space).attrs({
   }
 `;
 
-const ImageCard = ({ id, image, onClick, workId }: Props) => {
+const ImageCard: FC<Props> = ({ id, image, onClick, workId }: Props) => {
   const { isEnhanced } = useContext(AppContext);
 
   return (

--- a/catalogue/webapp/components/ImageCard/ImageCard.tsx
+++ b/catalogue/webapp/components/ImageCard/ImageCard.tsx
@@ -1,4 +1,4 @@
-import { FC, SyntheticEvent, useContext, FC } from 'react';
+import { FC, SyntheticEvent, useContext } from 'react';
 import NextLink from 'next/link';
 
 import { trackEvent } from '@weco/common/utils/ga';

--- a/common/views/components/StatusIndicator/StatusIndicator.tsx
+++ b/common/views/components/StatusIndicator/StatusIndicator.tsx
@@ -2,6 +2,7 @@ import { font } from '../../../utils/classnames';
 import { formatDateRangeWithMessage } from '../../../utils/format-date';
 import Space from '../styled/Space';
 import Dot from '../Dot/Dot';
+import { FC } from 'react';
 
 type Props = {
   start: Date;
@@ -9,7 +10,7 @@ type Props = {
   statusOverride?: string;
 };
 
-const StatusIndicator = ({ start, end, statusOverride }: Props) => {
+const StatusIndicator: FC<Props> = ({ start, end, statusOverride }: Props) => {
   const { color, text } = statusOverride
     ? { color: 'marble', text: statusOverride }
     : formatDateRangeWithMessage({ start, end });

--- a/content/webapp/components/FacilityPromo/FacilityPromo.tsx
+++ b/content/webapp/components/FacilityPromo/FacilityPromo.tsx
@@ -2,35 +2,25 @@ import { font, classNames } from '@weco/common/utils/classnames';
 import { trackEvent } from '@weco/common/utils/ga';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import { UiImage } from '@weco/common/views/components/Images/Images';
-import { ImageType } from '@weco/common/model/image';
 import Space from '@weco/common/views/components/styled/Space';
 import { CardOuter, CardBody } from '../Card/Card';
-import { IconSvg } from '@weco/common/icons';
-
-type Props = {
-  id: string;
-  url: string;
-  title: string;
-  imageProps: ImageType;
-  description: string;
-  metaText?: string;
-  metaIcon?: IconSvg;
-};
+import { FacilityPromo as FacilityPromoType } from '../../types/facility-promo';
+import { FC } from 'react';
 
 const sizesQueries =
   '(min-width: 1420px) 475px, (min-width: 960px) 34.32vw, (min-width: 600px) calc(50vw - 54px), calc(100vw - 36px)';
 
-const FacilityPromo = ({
+const FacilityPromo: FC<FacilityPromoType> = ({
   id,
   url,
   title,
-  imageProps,
+  image,
   description,
   metaText,
   metaIcon,
-}: Props) => {
+}: FacilityPromoType) => {
   const uiImageProps = {
-    ...imageProps,
+    ...image,
     sizesQueries,
   };
   return (

--- a/content/webapp/data/facility-promos.ts
+++ b/content/webapp/data/facility-promos.ts
@@ -1,9 +1,8 @@
 import { clock, memberCard } from '@weco/common/icons';
+import { FacilityPromo } from 'types/facility-promo';
 
-export const readingRoomPromo = {
-  type: 'promo',
+export const readingRoomPromo: FacilityPromo = {
   id: 'readingRoomPromo',
-  contentType: 'place',
   title: 'Reading Room',
   url: 'https://wellcomecollection.org/pages/Wvlk4yAAAB8A3ufp',
   metaIcon: clock,
@@ -11,7 +10,6 @@ export const readingRoomPromo = {
   description:
     'Drop in to find inspiration and indulge your curiosity. It’s a gallery, a social space, and a place to unwind.',
   image: {
-    type: 'picture',
     contentUrl:
       'https://images.prismic.io/wellcomecollection/1f71dfb0-c65e-4e35-affd-19a78545f0f1_SDP_20201005_0649-41-Edit.jpg?auto=compress,format',
     width: 408,
@@ -20,16 +18,13 @@ export const readingRoomPromo = {
   },
 };
 
-export const cafePromo = {
-  type: 'promo',
+export const cafePromo: FacilityPromo = {
   id: 'cafePromo',
-  contentType: 'place',
   title: 'Café',
   url: 'https://wellcomecollection.org/pages/Wvl1wiAAADMJ3zNe',
   description:
     'Join us for a quick cup of coffee and a pastry, afternoon tea, or a light meal with a glass of wine.',
   image: {
-    type: 'picture',
     contentUrl:
       'https://images.prismic.io/wellcomecollection/3062e92b-693f-4dd0-9435-f63d6bc370e7_SDP_20201005_0365-176-Edit.jpg?auto=compress,format',
     width: 408,
@@ -38,10 +33,8 @@ export const cafePromo = {
   },
 };
 
-export const libraryPromo = {
-  type: 'promo',
+export const libraryPromo: FacilityPromo = {
   id: 'libraryPromo',
-  contentType: 'place',
   title: 'Library',
   url: 'https://wellcomecollection.org/pages/Wuw19yIAAK1Z3Smm',
   description:
@@ -49,7 +42,6 @@ export const libraryPromo = {
   metaIcon: memberCard,
   metaText: 'Membership not required',
   image: {
-    type: 'picture',
     contentUrl:
       'https://s3-eu-west-1.amazonaws.com/static.wellcomecollection.org/daily-promo-images/wellcome-library.png',
     width: 408,
@@ -58,15 +50,12 @@ export const libraryPromo = {
   },
 };
 
-export const restaurantPromo = {
-  type: 'promo',
+export const restaurantPromo: FacilityPromo = {
   id: 'restaurantPromo',
-  contentType: 'place',
   title: 'Restaurant',
   url: 'https://wellcomecollection.org/pages/Wuw19yIAAK1Z3Snk',
   description: 'Enjoy delicious lunches, drinks and afternoon tea on level 2.',
   image: {
-    type: 'picture',
     contentUrl:
       'https://images.prismic.io/wellcomecollection%2Fc2475694-73e3-4309-ba6d-100a25fe6864_restaurant.png?auto=compress,format',
     width: 408,
@@ -75,51 +64,16 @@ export const restaurantPromo = {
   },
 };
 
-export const shopPromo = {
-  type: 'promo',
+export const shopPromo: FacilityPromo = {
   id: 'shopPromo',
-  contentType: 'place',
   title: 'Shop',
   url: 'https://wellcomecollection.org/pages/WwgaIh8AAB8AGhC_',
   description: 'Come and browse a selection of our quirky gifts and books.',
   image: {
-    type: 'picture',
     contentUrl:
       'https://images.prismic.io/wellcomecollection%2Fb9feb700-cb89-47cc-be19-75b37adc2061_shop.png',
     width: 408,
     height: 229,
-    alt: '',
-  },
-};
-
-export const dailyTourPromo = {
-  id: 'tours',
-  title: 'Daily Guided Tours and Discussions',
-  url: 'https://wellcomecollection.org/pages/Wuw19yIAAK1Z3Sma',
-  start: null,
-  end: null,
-  isMultiDate: false,
-  isFullyBooked: false,
-  hasNotFullyBookedTimes: false,
-  description: null,
-  series: [],
-  schedule: [],
-  dateString: 'Tuesday–Sunday',
-  timeString: '11:45, 14:45 and 15:45',
-  format: {
-    id: 'WmYRpCQAACUAn-Ap',
-    title: 'Gallery tour',
-    shortName: null,
-    description: null,
-  },
-  bookingType: null,
-  interpretations: [],
-  image: {
-    type: 'picture',
-    contentUrl:
-      'https://images.prismic.io/wellcomecollection/7657f9e9-0733-444d-b1b2-6ae0bafa0ff9_c7c94c39161dcfe15d9abd8b40256ea2b40f52b9_c0139861.jpg?auto=compress,format',
-    width: 2996,
-    height: 2000,
     alt: '',
   },
 };

--- a/content/webapp/pages/whats-on.tsx
+++ b/content/webapp/pages/whats-on.tsx
@@ -25,7 +25,6 @@ import {
   cafePromo,
   // shopPromo,
   readingRoomPromo,
-  dailyTourPromo,
 } from '../data/facility-promos';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import SegmentedControl from '@weco/common/views/components/SegmentedControl/SegmentedControl';
@@ -78,6 +77,7 @@ import {
   fixExhibitionDatesInJson,
   transformExhibitionsQuery,
 } from '../services/prismic/transformers/exhibitions';
+import { FacilityPromo as FacilityPromoType } from '../types/facility-promo';
 
 const segmentedControlItems = [
   {
@@ -103,8 +103,8 @@ export type Props = {
   availableOnlineEvents: PaginatedResults<EventBasic>;
   period: string;
   dateRange: any[];
-  tryTheseTooPromos: any[];
-  eatShopPromos: any[];
+  tryTheseTooPromos: FacilityPromoType[];
+  eatShopPromos: FacilityPromoType[];
   featuredText: FeaturedTextType;
 };
 
@@ -389,7 +389,6 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
           tryTheseTooPromos: [readingRoomPromo],
           eatShopPromos: [cafePromo],
           cafePromo,
-          dailyTourPromo,
           featuredText: featuredText!,
           serverData,
         }),
@@ -595,15 +594,7 @@ const WhatsOnPage: FunctionComponent<Props> = props => {
                           xl: 4,
                         })}
                       >
-                        <FacilityPromo
-                          id={promo.id}
-                          title={promo.title}
-                          url={promo.url}
-                          description={promo.description}
-                          imageProps={promo.image}
-                          metaText={promo.metaText}
-                          metaIcon={promo.metaIcon}
-                        />
+                        <FacilityPromo {...promo} />
                       </div>
                     ))}
                   </div>

--- a/content/webapp/services/prismic/transformers/json-ld.ts
+++ b/content/webapp/services/prismic/transformers/json-ld.ts
@@ -14,7 +14,7 @@ import { objToJsonLd } from '@weco/common/utils/json-ld';
 import { Exhibition } from '../../../types/exhibitions';
 import { linkResolver } from '@weco/common/services/prismic/link-resolver';
 
-export function exhibitionLd(exhibition: Exhibition) {
+export function exhibitionLd(exhibition: Exhibition): JsonLdObj {
   const promoImage = exhibition.promo?.image;
   return objToJsonLd(
     {
@@ -160,7 +160,7 @@ function orgLd(org: Organization) {
   );
 }
 
-export function contentLd(content: Page | Season) {
+export function contentLd(content: Page | Season): JsonLdObj {
   const contributors = content.type === 'seasons' ? [] : content.contributors;
 
   const author: Contributor = contributors.find(

--- a/content/webapp/types/facility-promo.ts
+++ b/content/webapp/types/facility-promo.ts
@@ -1,0 +1,12 @@
+import { IconSvg } from '@weco/common/icons';
+import { ImageType } from '@weco/common/model/image';
+
+export type FacilityPromo = {
+  id: string;
+  url: string;
+  title: string;
+  image: ImageType;
+  description: string;
+  metaText?: string;
+  metaIcon?: IconSvg;
+};


### PR DESCRIPTION
I was getting some warnings about missing return types and use of `any`; this patch fixes them.  In particular, I've added a `FacilityPromo` type for use with the component of the same name, which lets me tidy up some of the facility promo data.

The daily tour promo isn't being used on the what's on page, and the data is duplicated in the DailyTourPromo component.  We can remove it from the what's on page and save a bit of data.