### PR TITLE
Trying to fix: Thin black line on radius corners of content cards

### DIFF
--- a/content/webapp/components/PrismicImage/PrismicImage.test.ts
+++ b/content/webapp/components/PrismicImage/PrismicImage.test.ts
@@ -21,6 +21,6 @@ it('should return sizes in vw values for anything but xlarge breakpoint', () => 
   expect(test).toStrictEqual([
     '(min-width: 960px) 100vw',
     '(min-width: 600px) 50vw',
-    '(min-width: 0px) 33.33333333333333vw',
+    '(min-width: 0px) 33vw',
   ]);
 });

--- a/content/webapp/components/PrismicImage/PrismicImage.tsx
+++ b/content/webapp/components/PrismicImage/PrismicImage.tsx
@@ -28,7 +28,7 @@ export function convertBreakpointSizesToSizes(
       const size =
         breakpoint === 'xlarge'
           ? `${breakpointSize * ratio}px`
-          : `${100 * ratio}vw`;
+          : `${Math.round(100 * ratio)}vw`;
 
       return `(min-width: ${breakpointSize}px) ${size}`;
     }


### PR DESCRIPTION
## Who is this for?
Anyone who visits the site and looks at our content. Radius corners on the top left and right of our content cards have a thin black line. It only shows up on images with a light coloured background, as per bug in ticket https://github.com/wellcomecollection/wellcomecollection.org/issues/7626

## What is it doing for them?
This error is a little hard to pin down as zooming in, changing browser, sometimes refreshing the page will clear the issue. I had a go with changing css in developer tools when I could see the error and rounding out any vw (viewport width) values seemed to clear the issue. 

I convinced myself that rounding the vw value makes sense as we apply ratio logic to images (where in this case small images are 1/3 - hence us getting a 33.33333 value), but we don't apply that same logic to the background - so there will be always be a slight difference in size of image and size of background with viewport. 
