### PR TITLE
Tidy up how we do licenses; toss lodash.merge

### DIFF
--- a/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
+++ b/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
@@ -9,7 +9,7 @@ import {
   getDigitalLocationOfType,
   sierraIdFromPresentationManifestUrl,
 } from '../../utils/works';
-import getAugmentedLicenseInfo from '@weco/common/utils/licenses';
+import { getCatalogueLicenseInfo } from '@weco/common/utils/licenses';
 import ButtonSolidLink from '@weco/common/views/components/ButtonSolidLink/ButtonSolidLink';
 import Image from '@weco/common/views/components/Image/Image';
 import License from '../License/License';
@@ -34,7 +34,6 @@ import { expandedViewImageButton } from '@weco/common/text/aria-labels';
 import { toLink as itemLink } from '@weco/common/views/components/ItemLink/ItemLink';
 import { toLink as imageLink } from '@weco/common/views/components/ImageLink/ImageLink';
 import { cross, eye } from '@weco/common/icons';
-import { useToggles } from '@weco/common/server-data/Context';
 
 type Props = {
   image: ImageType;
@@ -187,7 +186,6 @@ const ExpandedImage: FunctionComponent<Props> = ({
   resultPosition,
 }: Props) => {
   const { isKeyboard } = useContext(AppContext);
-  const toggles = useToggles();
   const [detailedWork, setDetailedWork] = useState<Work | undefined>();
   const [canvasDeeplink, setCanvasDeeplink] = useState<
     CanvasLink | undefined
@@ -288,7 +286,7 @@ const ExpandedImage: FunctionComponent<Props> = ({
   const iiifImageLocation = image.locations[0];
   const license =
     iiifImageLocation?.license &&
-    getAugmentedLicenseInfo(iiifImageLocation.license);
+    getCatalogueLicenseInfo(iiifImageLocation.license);
 
   const expandedImageLink =
     image && !canvasDeeplink

--- a/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
+++ b/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
@@ -9,7 +9,7 @@ import {
   getDigitalLocationOfType,
   sierraIdFromPresentationManifestUrl,
 } from '../../utils/works';
-import { getCatalogueLicenseInfo } from '@weco/common/utils/licenses';
+import { getCatalogueLicenseData } from '@weco/common/utils/licenses';
 import ButtonSolidLink from '@weco/common/views/components/ButtonSolidLink/ButtonSolidLink';
 import Image from '@weco/common/views/components/Image/Image';
 import License from '../License/License';
@@ -286,7 +286,7 @@ const ExpandedImage: FunctionComponent<Props> = ({
   const iiifImageLocation = image.locations[0];
   const license =
     iiifImageLocation?.license &&
-    getCatalogueLicenseInfo(iiifImageLocation.license);
+    getCatalogueLicenseData(iiifImageLocation.license);
 
   const expandedImageLink =
     image && !canvasDeeplink

--- a/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
@@ -21,7 +21,7 @@ import {
 import ViewerSidebar from './ViewerSidebar';
 import MainViewer, { scrollViewer } from './MainViewer';
 import ViewerTopBar from './ViewerTopBar';
-import { getCatalogueLicenseInfo } from '@weco/common/utils/licenses';
+import { getCatalogueLicenseData } from '@weco/common/utils/licenses';
 import ItemViewerContext, {
   results,
 } from '../ItemViewerContext/ItemViewerContext';
@@ -343,9 +343,8 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
   );
   const digitalLocation = iiifImageLocation || iiifPresentationLocation;
   const licenseInfo =
-    digitalLocation &&
-    digitalLocation.license &&
-    getCatalogueLicenseInfo(digitalLocation.license);
+    digitalLocation?.license &&
+    getCatalogueLicenseData(digitalLocation.license);
 
   const iiifImageLocationCredit = iiifImageLocation && iiifImageLocation.credit;
   const showDownloadOptions = manifest

--- a/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
@@ -21,7 +21,7 @@ import {
 import ViewerSidebar from './ViewerSidebar';
 import MainViewer, { scrollViewer } from './MainViewer';
 import ViewerTopBar from './ViewerTopBar';
-import getAugmentedLicenseInfo from '@weco/common/utils/licenses';
+import { getCatalogueLicenseInfo } from '@weco/common/utils/licenses';
 import ItemViewerContext, {
   results,
 } from '../ItemViewerContext/ItemViewerContext';
@@ -345,7 +345,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
   const licenseInfo =
     digitalLocation &&
     digitalLocation.license &&
-    getAugmentedLicenseInfo(digitalLocation.license);
+    getCatalogueLicenseInfo(digitalLocation.license);
 
   const iiifImageLocationCredit = iiifImageLocation && iiifImageLocation.credit;
   const showDownloadOptions = manifest

--- a/catalogue/webapp/components/IIIFViewer/ViewerSidebar.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerSidebar.tsx
@@ -18,7 +18,7 @@ import {
   getProductionDates,
   getDigitalLocationOfType,
 } from '../../utils/works';
-import { getCatalogueLicenseInfo } from '@weco/common/utils/licenses';
+import { getCatalogueLicenseData } from '@weco/common/utils/licenses';
 import useIIIFManifestData from '../../hooks/useIIIFManifestData';
 import ViewerStructures from './ViewerStructures';
 import ItemViewerContext from '../ItemViewerContext/ItemViewerContext';
@@ -149,7 +149,7 @@ const ViewerSidebar: FunctionComponent<Props> = ({ mainViewerRef }: Props) => {
 
   const license =
     digitalLocation?.license &&
-    getCatalogueLicenseInfo(digitalLocation.license);
+    getCatalogueLicenseData(digitalLocation.license);
   const { iiifCredit } = useIIIFManifestData(work);
   const searchService = manifest && getSearchService(manifest);
   const credit = (digitalLocation && digitalLocation.credit) || iiifCredit;

--- a/catalogue/webapp/components/IIIFViewer/ViewerSidebar.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerSidebar.tsx
@@ -18,7 +18,7 @@ import {
   getProductionDates,
   getDigitalLocationOfType,
 } from '../../utils/works';
-import getAugmentedLicenseInfo from '@weco/common/utils/licenses';
+import { getCatalogueLicenseInfo } from '@weco/common/utils/licenses';
 import useIIIFManifestData from '../../hooks/useIIIFManifestData';
 import ViewerStructures from './ViewerStructures';
 import ItemViewerContext from '../ItemViewerContext/ItemViewerContext';
@@ -148,9 +148,8 @@ const ViewerSidebar: FunctionComponent<Props> = ({ mainViewerRef }: Props) => {
     iiifPresentationLocation || iiifImageLocation;
 
   const license =
-    digitalLocation &&
-    digitalLocation.license &&
-    getAugmentedLicenseInfo(digitalLocation.license);
+    digitalLocation?.license &&
+    getCatalogueLicenseInfo(digitalLocation.license);
   const { iiifCredit } = useIIIFManifestData(work);
   const searchService = manifest && getSearchService(manifest);
   const credit = (digitalLocation && digitalLocation.credit) || iiifCredit;

--- a/catalogue/webapp/pages/download.tsx
+++ b/catalogue/webapp/pages/download.tsx
@@ -4,7 +4,7 @@ import {
   getDownloadOptionsFromImageUrl,
   getDigitalLocationOfType,
 } from '../utils/works';
-import { getCatalogueLicenseInfo } from '@weco/common/utils/licenses';
+import { getCatalogueLicenseData } from '@weco/common/utils/licenses';
 import {
   getDownloadOptionsFromManifest,
   getIIIFPresentationCredit,
@@ -48,7 +48,7 @@ const DownloadPage: NextPage<Props> = ({
   const digitalLocation = iiifImageLocation || iiifPresentationLocation;
   const license =
     digitalLocation?.license &&
-    getCatalogueLicenseInfo(digitalLocation.license);
+    getCatalogueLicenseData(digitalLocation.license);
 
   const iiifImageLocationUrl =
     iiifImageLocation &&

--- a/catalogue/webapp/pages/download.tsx
+++ b/catalogue/webapp/pages/download.tsx
@@ -4,7 +4,7 @@ import {
   getDownloadOptionsFromImageUrl,
   getDigitalLocationOfType,
 } from '../utils/works';
-import getAugmentedLicenseInfo from '@weco/common/utils/licenses';
+import { getCatalogueLicenseInfo } from '@weco/common/utils/licenses';
 import {
   getDownloadOptionsFromManifest,
   getIIIFPresentationCredit,
@@ -47,9 +47,8 @@ const DownloadPage: NextPage<Props> = ({
     : null;
   const digitalLocation = iiifImageLocation || iiifPresentationLocation;
   const license =
-    digitalLocation &&
-    digitalLocation.license &&
-    getAugmentedLicenseInfo(digitalLocation.license);
+    digitalLocation?.license &&
+    getCatalogueLicenseInfo(digitalLocation.license);
 
   const iiifImageLocationUrl =
     iiifImageLocation &&

--- a/catalogue/webapp/utils/works.ts
+++ b/catalogue/webapp/utils/works.ts
@@ -12,7 +12,8 @@ import {
 import { IIIFRendering } from '../model/iiif';
 import { convertIiifImageUri } from '@weco/common/utils/convert-image-uri';
 import { Label } from '@weco/common/model/labels';
-import getAugmentedLicenseInfo, {
+import {
+  getCatalogueLicenseInfo,
   LicenseData,
 } from '@weco/common/utils/licenses';
 
@@ -333,7 +334,7 @@ export function getDigitalLocationInfo(
     accessCondition: getAccessConditionForDigitalLocation(digitalLocation),
     license:
       digitalLocation?.license &&
-      getAugmentedLicenseInfo(digitalLocation.license),
+      getCatalogueLicenseInfo(digitalLocation.license),
   };
 }
 

--- a/catalogue/webapp/utils/works.ts
+++ b/catalogue/webapp/utils/works.ts
@@ -13,7 +13,7 @@ import { IIIFRendering } from '../model/iiif';
 import { convertIiifImageUri } from '@weco/common/utils/convert-image-uri';
 import { Label } from '@weco/common/model/labels';
 import {
-  getCatalogueLicenseInfo,
+  getCatalogueLicenseData,
   LicenseData,
 } from '@weco/common/utils/licenses';
 
@@ -334,7 +334,7 @@ export function getDigitalLocationInfo(
     accessCondition: getAccessConditionForDigitalLocation(digitalLocation),
     license:
       digitalLocation?.license &&
-      getCatalogueLicenseInfo(digitalLocation.license),
+      getCatalogueLicenseData(digitalLocation.license),
   };
 }
 

--- a/common/package.json
+++ b/common/package.json
@@ -45,7 +45,6 @@
     "lazysizes": "^5.2.1",
     "lodash.debounce": "^4.0.8",
     "lodash.groupby": "^4.6.0",
-    "lodash.merge": "^4.6.2",
     "moment": "^2.20.1",
     "moment-timezone": "^0.5.14",
     "next": "^11.1.2",

--- a/common/utils/licenses.ts
+++ b/common/utils/licenses.ts
@@ -1,29 +1,29 @@
-import merge from 'lodash.merge';
+// We have to deal with licenses from two sources:
+//
+//    - the catalogue API (in the catalogue app), which returns the LicenseAPIData type
+//    - the Prismic API (in the content app)
+//
+// The catalogue API provides licenses as the `CatalogueLicenseData` type; the
+// Prismic API only returns a license ID.
+//
+// We augment the catalogue API types with extra data (e.g. icons and human-readable
+// text) so we can display licenses properly in the catalogue app.
 
-// We have to deal with licenses in both the Catalogue App (using the catalogue API) and the Content App (using the Prismic API)
-// The catalogue API provides licenses as follows:
-export type LicenseAPIData = {
+type CatalogueLicenseData = {
   id: string;
   label: string;
   url: string;
   type: 'License';
 };
 
-// For the UI, we want to add to this data, with an icons array, description and human readable text.
 type CcIcons = 'cc' | 'ccBy' | 'ccNc' | 'ccNd' | 'ccPdm' | 'ccZero' | 'ccSa';
-export type LicenseData = LicenseAPIData & {
+export type LicenseData = CatalogueLicenseData & {
   icons: CcIcons[];
   description?: string;
   humanReadableText: string[];
 };
-// This is achieved with the getAugmentedLicenseInfo function and the data contained in the additionalData object.
 
-// However, the only license information we receive from Prismic is a license id.
-// We therefore duplicate the data that the catalogue API provides (defaultLicenseMap),
-// combine it with the additionalData and use the getLicenseInfo function,
-// for the sole purpose of displaying license information on the Content App.
-
-export const additionalData = {
+const additionalData = {
   pdm: {
     icons: ['ccPdm'],
     humanReadableText: [
@@ -92,17 +92,7 @@ export const additionalData = {
   },
 };
 
-export default function getAugmentedLicenseInfo(
-  license: LicenseAPIData
-): LicenseData {
-  const additionalLicenseData = additionalData[license.id.toLowerCase()];
-  return {
-    ...license,
-    ...additionalLicenseData,
-  };
-}
-
-const defaultLicenseMap = {
+const catalogueLicenses: Record<string, CatalogueLicenseData> = {
   pdm: {
     id: 'pdm',
     label: 'Public Domain Mark',
@@ -173,8 +163,24 @@ const defaultLicenseMap = {
   },
 };
 
-export const mergedLicenseMap = merge(additionalData, defaultLicenseMap);
+// Given a license from the catalogue API, return the license with extra
+// information needed to display it in the UI.
+export function getCatalogueLicenseInfo(
+  license: CatalogueLicenseData
+): LicenseData {
+  const additionalLicenseData = additionalData[license.id.toLowerCase()];
+  return {
+    ...license,
+    ...additionalLicenseData,
+  };
+}
 
-export function getLicenseInfo(licenseId: string): LicenseData {
-  return mergedLicenseMap[licenseId.toLowerCase()];
+// Given a license ID from Prismic, return the equivalent license data as
+// we'd receive it from the catalogue API.
+//
+// Note: we don't include the augmented data here because the content app doesn't
+// use it.  (At time of writing, the only component that uses license data is <Tasl>,
+// which wants a URL and label.)
+export function getPrismicLicenseInfo(licenseId: string): CatalogueLicenseData {
+  return catalogueLicenses[licenseId.toLowerCase()];
 }

--- a/common/utils/licenses.ts
+++ b/common/utils/licenses.ts
@@ -165,7 +165,7 @@ const catalogueLicenses: Record<string, CatalogueLicenseData> = {
 
 // Given a license from the catalogue API, return the license with extra
 // information needed to display it in the UI.
-export function getCatalogueLicenseInfo(
+export function getCatalogueLicenseData(
   license: CatalogueLicenseData
 ): LicenseData {
   const additionalLicenseData = additionalData[license.id.toLowerCase()];
@@ -181,6 +181,6 @@ export function getCatalogueLicenseInfo(
 // Note: we don't include the augmented data here because the content app doesn't
 // use it.  (At time of writing, the only component that uses license data is <Tasl>,
 // which wants a URL and label.)
-export function getPrismicLicenseInfo(licenseId: string): CatalogueLicenseData {
+export function getPrismicLicenseData(licenseId: string): CatalogueLicenseData {
   return catalogueLicenses[licenseId.toLowerCase()];
 }

--- a/common/views/components/Tasl/Tasl.tsx
+++ b/common/views/components/Tasl/Tasl.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent, useContext, useState } from 'react';
 import { font, classNames } from '../../../utils/classnames';
-import { getPrismicLicenseInfo } from '../../../utils/licenses';
+import { getPrismicLicenseData } from '../../../utils/licenses';
 import { trackEvent } from '../../../utils/ga';
 import { AppContext } from '../../components/AppContext/AppContext';
 import Icon from '../Icon/Icon';
@@ -68,7 +68,7 @@ function getMarkup({
   copyrightHolder,
   copyrightLink,
 }: MarkUpProps) {
-  const licenseData = license && getPrismicLicenseInfo(license);
+  const licenseData = license && getPrismicLicenseData(license);
 
   return (
     <>

--- a/common/views/components/Tasl/Tasl.tsx
+++ b/common/views/components/Tasl/Tasl.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent, useContext, useState } from 'react';
 import { font, classNames } from '../../../utils/classnames';
-import { getLicenseInfo } from '../../../utils/licenses';
+import { getPrismicLicenseInfo } from '../../../utils/licenses';
 import { trackEvent } from '../../../utils/ga';
 import { AppContext } from '../../components/AppContext/AppContext';
 import Icon from '../Icon/Icon';
@@ -68,17 +68,17 @@ function getMarkup({
   copyrightHolder,
   copyrightLink,
 }: MarkUpProps) {
-  const licenseInfo = license && getLicenseInfo(license);
+  const licenseData = license && getPrismicLicenseInfo(license);
 
   return (
     <>
       {getTitleHtml(title, author, sourceLink)}
       {getSourceHtml(sourceName, sourceLink)}
       {getCopyrightHtml(copyrightHolder, copyrightLink)}
-      {licenseInfo && (
+      {licenseData && (
         <>
-          <a rel="license" href={licenseInfo.url}>
-            {licenseInfo.label}
+          <a rel="license" href={licenseData.url}>
+            {licenseData.label}
           </a>
           .
         </>


### PR DESCRIPTION
We were using lodash.merge to combine two sources of license data.  The combined data was only being used in the Tasl component, and that component only needed one source of the license data.  This was completely wasteful and adding an unnecessary dependency; we can remove lodash.merge and make the license code easier to follow at the same time.

## Who is this for?

People who use our website.

## What is it doing for them?

Making it a tiny bit more smol.