### PR TITLE
Render all our JSON-LD as server-side props

### DIFF
--- a/catalogue/webapp/components/Work/Work.tsx
+++ b/catalogue/webapp/components/Work/Work.tsx
@@ -17,6 +17,7 @@ import Divider from '@weco/common/views/components/Divider/Divider';
 import styled from 'styled-components';
 import SearchContext from '@weco/common/views/components/SearchContext/SearchContext';
 import IsArchiveContext from '../IsArchiveContext/IsArchiveContext';
+import { WithVenueProps } from '@weco/common/views/components/PageLayout/PageLayout';
 
 const ArchiveDetailsContainer = styled.div`
   display: block;
@@ -33,10 +34,11 @@ declare global {
 
 type Props = {
   work: WorkType;
-};
+} & WithVenueProps;
 
 const Work: FunctionComponent<Props> = ({
   work,
+  venueProps,
 }: Props): ReactElement<Props> => {
   const { link: searchLink } = useContext(SearchContext);
 
@@ -87,6 +89,7 @@ const Work: FunctionComponent<Props> = ({
         siteSection={'collections'}
         image={image}
         hideNewsletterPromo={true}
+        {...venueProps}
       >
         <div className="container">
           <div className="grid">

--- a/catalogue/webapp/pages/download.tsx
+++ b/catalogue/webapp/pages/download.tsx
@@ -13,7 +13,10 @@ import {
 } from '../utils/iiif';
 import { IIIFManifest } from '../model/iiif';
 import { getWork } from '../services/catalogue/works';
-import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
+import PageLayout, {
+  getServerSideVenueProps,
+  WithVenueProps,
+} from '@weco/common/views/components/PageLayout/PageLayout';
 import Layout8 from '@weco/common/views/components/Layout8/Layout8';
 import Download from '@weco/catalogue/components/Download/Download';
 import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
@@ -30,13 +33,14 @@ type Props = {
   sierraId: string;
   manifest?: IIIFManifest;
   work?: Work;
-};
+} & WithVenueProps;
 
 const DownloadPage: NextPage<Props> = ({
   workId,
   sierraId,
   manifest,
   work,
+  venueProps,
 }) => {
   const title = (manifest && manifest.label) || (work && work.title) || '';
   const iiifImageLocation = work
@@ -87,6 +91,7 @@ const DownloadPage: NextPage<Props> = ({
       jsonLd={{ '@type': 'WebPage' }}
       siteSection={'collections'}
       hideNewsletterPromo={true}
+      {...venueProps}
     >
       <Layout8>
         <SpacingSection>
@@ -217,12 +222,15 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       };
     }
 
+    const venueProps = getServerSideVenueProps(serverData);
+
     return {
       props: removeUndefinedProps({
         workId,
         sierraId,
         manifest,
         work,
+        venueProps,
       }),
     };
   };

--- a/catalogue/webapp/pages/image.tsx
+++ b/catalogue/webapp/pages/image.tsx
@@ -18,13 +18,22 @@ import { getImage } from '../services/catalogue/images';
 import { getServerData } from '@weco/common/server-data';
 import { isString } from '@weco/common/utils/array';
 import { unavailableImageMessage } from '@weco/common/data/microcopy';
+import {
+  getServerSideVenueProps,
+  WithVenueProps,
+} from '@weco/common/views/components/PageLayout/PageLayout';
 
 type Props = {
   image: Image;
   sourceWork: Work;
-} & WithPageview;
+} & WithPageview &
+  WithVenueProps;
 
-const ImagePage: FunctionComponent<Props> = ({ image, sourceWork }: Props) => {
+const ImagePage: FunctionComponent<Props> = ({
+  image,
+  sourceWork,
+  venueProps,
+}: Props) => {
   const title = sourceWork.title || '';
   const iiifImageLocation = image.locations[0];
 
@@ -70,6 +79,7 @@ const ImagePage: FunctionComponent<Props> = ({ image, sourceWork }: Props) => {
       hideNewsletterPromo={true}
       hideFooter={true}
       hideTopContent={true}
+      {...venueProps}
     >
       {iiifImageLocation ? (
         <>
@@ -149,6 +159,8 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       };
     }
 
+    const venueProps = getServerSideVenueProps(serverData);
+
     return {
       props: removeUndefinedProps({
         image,
@@ -157,6 +169,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
           name: 'image',
           properties: {},
         },
+        venueProps,
       }),
     };
   };

--- a/catalogue/webapp/pages/images.tsx
+++ b/catalogue/webapp/pages/images.tsx
@@ -28,11 +28,16 @@ import {
 import SearchContext from '@weco/common/views/components/SearchContext/SearchContext';
 import { imagesFilters } from '@weco/common/services/catalogue/filters';
 import { getServerData } from '@weco/common/server-data';
+import {
+  getServerSideVenueProps,
+  WithVenueProps,
+} from '@weco/common/views/components/PageLayout/PageLayout';
 
 type Props = {
   images?: CatalogueResultsList<Image>;
   imagesRouteProps: ImagesProps;
-} & WithPageview;
+} & WithPageview &
+  WithVenueProps;
 
 type ImagesPaginationProps = {
   query?: string;
@@ -82,6 +87,7 @@ const ImagesPagination = ({
 const Images: NextPage<Props> = ({
   images,
   imagesRouteProps,
+  venueProps,
 }): ReactElement<Props> => {
   const [loading, setLoading] = useState(false);
   const { query, page, color } = imagesRouteProps;
@@ -147,6 +153,7 @@ const Images: NextPage<Props> = ({
         jsonLd={{ '@type': 'WebPage' }}
         siteSection={'collections'}
         image={undefined}
+        {...venueProps}
       >
         <Space
           v={{
@@ -267,6 +274,8 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       return appError(context, images.httpStatus, 'Images API error');
     }
 
+    const venueProps = getServerSideVenueProps(serverData);
+
     return {
       props: removeUndefinedProps({
         serverData,
@@ -280,6 +289,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
               }
             : {},
         },
+        venueProps,
       }),
     };
   };

--- a/catalogue/webapp/pages/item.tsx
+++ b/catalogue/webapp/pages/item.tsx
@@ -51,6 +51,10 @@ import { getServerData } from '@weco/common/server-data';
 import AudioList from '../components/AudioList/AudioList';
 import { isNotUndefined } from '@weco/common/utils/array';
 import { unavailableImageMessage } from '@weco/common/data/microcopy';
+import {
+  getServerSideVenueProps,
+  WithVenueProps,
+} from '@weco/common/views/components/PageLayout/PageLayout';
 const IframeAuthMessage = styled.iframe`
   display: none;
 `;
@@ -91,7 +95,8 @@ type Props = {
   video?: Video;
   audioItems?: IIIFMediaElement[];
   iiifImageLocation?: DigitalLocation;
-} & WithPageview;
+} & WithPageview &
+  WithVenueProps;
 
 const ItemPage: NextPage<Props> = ({
   manifest,
@@ -106,6 +111,7 @@ const ItemPage: NextPage<Props> = ({
   video,
   audioItems,
   iiifImageLocation,
+  venueProps,
 }) => {
   const workId = work.id;
   const [origin, setOrigin] = useState<string>();
@@ -221,6 +227,7 @@ const ItemPage: NextPage<Props> = ({
       hideNewsletterPromo={true}
       hideFooter={true}
       hideTopContent={true}
+      {...venueProps}
     >
       {tokenService && origin && (
         <IframeAuthMessage
@@ -421,6 +428,8 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       return { notFound: true };
     }
 
+    const venueProps = getServerSideVenueProps(serverData);
+
     if (manifestOrCollection) {
       // This happens when the main manifest is actually a Collection (manifest of manifest).
       // see: https://wellcomelibrary.org/iiif/collection/b21293302
@@ -480,6 +489,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
           audioItems,
           iiifImageLocation,
           pageview,
+          venueProps,
           serverData,
         }),
       };
@@ -495,6 +505,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
           canvases: [],
           iiifImageLocation,
           pageview,
+          venueProps,
           serverData,
         }),
       };

--- a/catalogue/webapp/pages/work.tsx
+++ b/catalogue/webapp/pages/work.tsx
@@ -10,15 +10,20 @@ import { getServerData } from '@weco/common/server-data';
 import Work from '../components/Work/Work';
 import { getWork } from '../services/catalogue/works';
 import { isString } from '@weco/common/utils/array';
+import {
+  getServerSideVenueProps,
+  WithVenueProps,
+} from '@weco/common/views/components/PageLayout/PageLayout';
 
 type Props = {
   workResponse: WorkType;
-} & WithPageview;
+} & WithPageview &
+  WithVenueProps;
 
-export const WorkPage: NextPage<Props> = ({ workResponse }) => {
+export const WorkPage: NextPage<Props> = ({ workResponse, venueProps }) => {
   // TODO: remove the <Work> component and move the JSX in here.
   // It was abstracted as we did error handling in the page, and it made it a little clearer.
-  return <Work work={workResponse} />;
+  return <Work work={workResponse} venueProps={venueProps} />;
 };
 
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
@@ -55,6 +60,8 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       );
     }
 
+    const venueProps = getServerSideVenueProps(serverData);
+
     return {
       props: removeUndefinedProps({
         workResponse,
@@ -71,6 +78,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
             ),
           },
         },
+        venueProps,
       }),
     };
   };

--- a/catalogue/webapp/pages/works.tsx
+++ b/catalogue/webapp/pages/works.tsx
@@ -23,10 +23,14 @@ import {
 import SearchContext from '@weco/common/views/components/SearchContext/SearchContext';
 import { worksFilters } from '@weco/common/services/catalogue/filters';
 import { getServerData } from '@weco/common/server-data';
+import {
+  getServerSideVenueProps,
+  WithVenueProps,
+} from '@weco/common/views/components/PageLayout/PageLayout';
 
-type Props = PageProps<typeof getServerSideProps>;
+type Props = PageProps<typeof getServerSideProps> & WithVenueProps;
 
-const Works: NextPage<Props> = ({ works, worksRouteProps }) => {
+const Works: NextPage<Props> = ({ works, worksRouteProps, venueProps }) => {
   const [loading, setLoading] = useState(false);
 
   const {
@@ -92,6 +96,7 @@ const Works: NextPage<Props> = ({ works, worksRouteProps }) => {
         jsonLd={{ '@type': 'WebPage' }}
         siteSection={'collections'}
         excludeRoleMain={true}
+        {...venueProps}
       >
         <Space
           v={{
@@ -282,6 +287,8 @@ export const getServerSideProps = async (
     return appError(context, works.httpStatus, works.description);
   }
 
+  const venueProps = getServerSideVenueProps(serverData);
+
   return {
     props: removeUndefinedProps({
       works,
@@ -291,6 +298,7 @@ export const getServerSideProps = async (
         name: 'works',
         properties: works ? { totalResults: works.totalResults } : {},
       },
+      venueProps,
     }),
   };
 };

--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -10,11 +10,6 @@ import NewsletterPromo from '../NewsletterPromo/NewsletterPromo';
 import Footer from '../Footer/Footer';
 import PopupDialog from '../PopupDialog/PopupDialog';
 import Space from '../styled/Space';
-import { museumLd, libraryLd, openingHoursLd } from '../../../utils/json-ld';
-import { collectionVenueId } from '../../../services/prismic/hardcoded-id';
-import { transformCollectionVenues } from '@weco/common/services/prismic/transformers/collection-venues';
-import { getVenueById } from '../../../services/prismic/opening-times';
-import { wellcomeCollectionGallery } from '../../../model/organization';
 import GlobalInfoBarContext, {
   GlobalInfoBarContextProvider,
 } from '../GlobalInfoBarContext/GlobalInfoBarContext';
@@ -24,6 +19,7 @@ import useHotjar from '../../../hooks/useHotjar';
 import { defaultPageTitle } from '@weco/common/data/microcopy';
 import { getCrop, ImageType } from '@weco/common/model/image';
 import { convertImageUri } from '@weco/common/utils/convert-image-uri';
+import { Venue } from '../../../model/opening-hours';
 
 export type SiteSection =
   | 'collections'
@@ -46,6 +42,9 @@ export type Props = {
   hideNewsletterPromo?: boolean;
   hideFooter?: boolean;
   excludeRoleMain?: boolean;
+  venues: Venue[];
+  museumJsonLd: JsonLdObj;
+  libraryJsonLd: JsonLdObj;
 };
 
 const PageLayoutComponent: FunctionComponent<Props> = ({
@@ -61,6 +60,9 @@ const PageLayoutComponent: FunctionComponent<Props> = ({
   hideNewsletterPromo = false,
   hideFooter = false,
   excludeRoleMain = false,
+  museumJsonLd,
+  libraryJsonLd,
+  venues,
 }) => {
   const hotjarUrls = [
     'YLCu9hEAACYAUiJx',
@@ -101,22 +103,7 @@ const PageLayoutComponent: FunctionComponent<Props> = ({
       : `Wellcome Collection | ${defaultPageTitle}`;
 
   const absoluteUrl = `https://wellcomecollection.org${urlString}`;
-  const { popupDialog, collectionVenues, globalAlert } = usePrismicData();
-  const venues = transformCollectionVenues(collectionVenues);
-  const galleries =
-    venues && getVenueById(venues, collectionVenueId.galleries.id);
-  const library =
-    venues && getVenueById(venues, collectionVenueId.libraries.id);
-  const galleriesOpeningHours = galleries && galleries.openingHours;
-  const libraryOpeningHours = library && library.openingHours;
-  const wellcomeCollectionGalleryWithHours = {
-    ...wellcomeCollectionGallery,
-    ...openingHoursLd(galleriesOpeningHours),
-  };
-  const wellcomeLibraryWithHours = {
-    ...wellcomeCollectionGallery,
-    ...openingHoursLd(libraryOpeningHours),
-  };
+  const { popupDialog, globalAlert } = usePrismicData();
 
   const polyfillFeatures = [
     'default',
@@ -260,15 +247,13 @@ const PageLayoutComponent: FunctionComponent<Props> = ({
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{
-            __html: JSON.stringify(
-              museumLd(wellcomeCollectionGalleryWithHours)
-            ),
+            __html: JSON.stringify(museumJsonLd),
           }}
         />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{
-            __html: JSON.stringify(libraryLd(wellcomeLibraryWithHours)),
+            __html: JSON.stringify(libraryJsonLd),
           }}
         />
       </Head>

--- a/content/webapp/components/Exhibition/Exhibition.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.tsx
@@ -1,7 +1,9 @@
 import { Fragment, useState, useEffect, FC } from 'react';
 import { isPast, isFuture } from '@weco/common/utils/dates';
 import { formatDate } from '@weco/common/utils/format-date';
-import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
+import PageLayout, {
+  WithVenueProps,
+} from '@weco/common/views/components/PageLayout/PageLayout';
 import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
 import { getFeaturedMedia, getHeroPicture } from '../../utils/page-header';
 import DateRange from '@weco/common/views/components/DateRange/DateRange';
@@ -198,9 +200,9 @@ export function getInfoItems(exhibition: ExhibitionType): ExhibitionItem[] {
 type Props = {
   exhibition: ExhibitionType;
   pages: PageType[];
-};
+} & WithVenueProps;
 
-const Exhibition: FC<Props> = ({ exhibition, pages }) => {
+const Exhibition: FC<Props> = ({ exhibition, pages, venueProps }) => {
   type ExhibitionOf = (ExhibitionType | EventType)[];
   type ExhibitionAbout = (Book | Article)[];
 
@@ -288,6 +290,7 @@ const Exhibition: FC<Props> = ({ exhibition, pages }) => {
       openGraphType={'website'}
       siteSection={'whats-on'}
       image={exhibition.image}
+      {...venueProps}
     >
       <ContentPage
         id={exhibition.id}

--- a/content/webapp/components/Exhibition/Exhibition.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.tsx
@@ -31,7 +31,6 @@ import Body from '../Body/Body';
 import SearchResults from '../SearchResults/SearchResults';
 import ContentPage from '../ContentPage/ContentPage';
 import Contributors from '../Contributors/Contributors';
-import { exhibitionLd } from '../../services/prismic/transformers/json-ld';
 import { isNotUndefined } from '@weco/common/utils/array';
 import { a11y } from '@weco/common/data/microcopy';
 import { fetchExhibitionRelatedContentClientSide } from '../../services/prismic/fetch/exhibitions';
@@ -40,6 +39,7 @@ import { Book } from '../../types/books';
 import { Article } from '../../types/articles';
 import { Event as EventType } from '../../types/events';
 import * as prismicT from '@prismicio/types';
+import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 
 type ExhibitionItem = LabelField & {
   icon?: IconSvg;
@@ -200,9 +200,10 @@ export function getInfoItems(exhibition: ExhibitionType): ExhibitionItem[] {
 type Props = {
   exhibition: ExhibitionType;
   pages: PageType[];
+  jsonLd: JsonLdObj;
 } & WithVenueProps;
 
-const Exhibition: FC<Props> = ({ exhibition, pages, venueProps }) => {
+const Exhibition: FC<Props> = ({ exhibition, pages, venueProps, jsonLd }) => {
   type ExhibitionOf = (ExhibitionType | EventType)[];
   type ExhibitionAbout = (Book | Article)[];
 
@@ -286,7 +287,7 @@ const Exhibition: FC<Props> = ({ exhibition, pages, venueProps }) => {
         exhibition.metadataDescription || exhibition.promo?.caption || ''
       }
       url={{ pathname: `/exhibitions/${exhibition.id}` }}
-      jsonLd={exhibitionLd(exhibition)}
+      jsonLd={jsonLd}
       openGraphType={'website'}
       siteSection={'whats-on'}
       image={exhibition.image}

--- a/content/webapp/components/Installation/Installation.tsx
+++ b/content/webapp/components/Installation/Installation.tsx
@@ -14,17 +14,19 @@ import { font } from '@weco/common/utils/classnames';
 import { isPast } from '@weco/common/utils/dates';
 import Body from '../Body/Body';
 import ContentPage from '../ContentPage/ContentPage';
-import { exhibitionLd } from '../../services/prismic/transformers/json-ld';
 import { isNotUndefined } from '@weco/common/utils/array';
 import { fetchExhibitExhibition } from '../../services/prismic/fetch/exhibitions';
+import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 
 type Props = {
   installation: InstallationType;
+  jsonLd: JsonLdObj;
 } & WithVenueProps;
 
 const Installation: FunctionComponent<Props> = ({
   installation,
   venueProps,
+  jsonLd,
 }: Props) => {
   const [partOf, setPartOf] = useState<InstallationType>();
   useEffect(() => {
@@ -92,7 +94,7 @@ const Installation: FunctionComponent<Props> = ({
         installation.metadataDescription || installation.promo?.caption || ''
       }
       url={{ pathname: `/installations/${installation.id}` }}
-      jsonLd={exhibitionLd(installation)}
+      jsonLd={jsonLd}
       openGraphType={'website'}
       siteSection={'whats-on'}
       image={installation.image}

--- a/content/webapp/components/Installation/Installation.tsx
+++ b/content/webapp/components/Installation/Installation.tsx
@@ -1,5 +1,7 @@
 import { FunctionComponent, useEffect, useState } from 'react';
-import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
+import PageLayout, {
+  WithVenueProps,
+} from '@weco/common/views/components/PageLayout/PageLayout';
 import DateAndStatusIndicator from '../DateAndStatusIndicator/DateAndStatusIndicator';
 import StatusIndicator from '@weco/common/views/components/StatusIndicator/StatusIndicator';
 import HeaderBackground from '@weco/common/views/components/HeaderBackground/HeaderBackground';
@@ -18,9 +20,12 @@ import { fetchExhibitExhibition } from '../../services/prismic/fetch/exhibitions
 
 type Props = {
   installation: InstallationType;
-};
+} & WithVenueProps;
 
-const Installation: FunctionComponent<Props> = ({ installation }: Props) => {
+const Installation: FunctionComponent<Props> = ({
+  installation,
+  venueProps,
+}: Props) => {
   const [partOf, setPartOf] = useState<InstallationType>();
   useEffect(() => {
     fetchExhibitExhibition(installation.id).then(exhibition => {
@@ -91,6 +96,7 @@ const Installation: FunctionComponent<Props> = ({ installation }: Props) => {
       openGraphType={'website'}
       siteSection={'whats-on'}
       image={installation.image}
+      {...venueProps}
     >
       <ContentPage
         id={installation.id}

--- a/content/webapp/pages/article-series.tsx
+++ b/content/webapp/pages/article-series.tsx
@@ -1,6 +1,9 @@
 import { GetServerSideProps } from 'next';
 import { FC } from 'react';
-import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
+import PageLayout, {
+  getServerSideVenueProps,
+  WithVenueProps,
+} from '@weco/common/views/components/PageLayout/PageLayout';
 import PageHeaderStandfirst from '../components/PageHeaderStandfirst/PageHeaderStandfirst';
 import HeaderBackground from '@weco/common/views/components/HeaderBackground/HeaderBackground';
 import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
@@ -26,7 +29,8 @@ import { transformArticleSeries } from '../services/prismic/transformers/article
 type Props = {
   series: Series;
   articles: ArticleBasic[];
-} & WithGaDimensions;
+} & WithGaDimensions &
+  WithVenueProps;
 
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
@@ -73,6 +77,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       const result = transformArticleSeries(id as string, articlesQuery);
 
       if (isNotUndefined(result)) {
+        const venueProps = getServerSideVenueProps(serverData);
         const { articles, series } = result;
 
         return {
@@ -83,6 +88,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
             gaDimensions: {
               partOf: series.seasons.map(season => season.id),
             },
+            venueProps,
           }),
         };
       }
@@ -92,7 +98,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   };
 
 const ArticleSeriesPage: FC<Props> = props => {
-  const { series, articles } = props;
+  const { series, articles, venueProps } = props;
   const breadcrumbs = {
     items: [
       {
@@ -138,6 +144,7 @@ const ArticleSeriesPage: FC<Props> = props => {
       siteSection={'stories'}
       openGraphType={'website'}
       image={series.image}
+      {...venueProps}
     >
       <ContentPage
         id={series.id}

--- a/content/webapp/pages/article.tsx
+++ b/content/webapp/pages/article.tsx
@@ -31,9 +31,11 @@ import { looksLikePrismicId } from '../services/prismic';
 import { bodySquabblesSeries } from '@weco/common/services/prismic/hardcoded-id';
 import { transformArticle } from '../services/prismic/transformers/articles';
 import * as prismic from '@prismicio/client';
+import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 
 type Props = {
   article: Article;
+  jsonLd: JsonLdObj;
 } & WithGaDimensions &
   WithVenueProps;
 
@@ -56,6 +58,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
 
     if (articleDocument) {
       const article = transformArticle(articleDocument);
+      const jsonLd = articleLd(article);
       const venueProps = getServerSideVenueProps(serverData);
       return {
         props: removeUndefinedProps({
@@ -67,6 +70,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
               .concat(article.series.map(series => series.id)),
           },
           venueProps,
+          jsonLd,
         }),
       };
     } else {
@@ -114,7 +118,7 @@ function getNextUp(
   }
 }
 
-const ArticlePage: FC<Props> = ({ article, venueProps }) => {
+const ArticlePage: FC<Props> = ({ article, venueProps, jsonLd }) => {
   const [listOfSeries, setListOfSeries] = useState<ArticleSeriesList>();
 
   useEffect(() => {
@@ -284,7 +288,8 @@ const ArticlePage: FC<Props> = ({ article, venueProps }) => {
       title={article.title}
       description={article.metadataDescription || article.promo?.caption || ''}
       url={{ pathname: `/articles/${article.id}` }}
-      jsonLd={articleLd(article)}
+      // TODO: This should be rendered server-side
+      jsonLd={jsonLd}
       openGraphType={'article'}
       siteSection={'stories'}
       image={article.image}

--- a/content/webapp/pages/article.tsx
+++ b/content/webapp/pages/article.tsx
@@ -4,7 +4,10 @@ import { Article } from '../types/articles';
 import { Series } from '../types/series';
 import { classNames, font } from '@weco/common/utils/classnames';
 import { capitalize } from '@weco/common/utils/grammar';
-import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
+import PageLayout, {
+  getServerSideVenueProps,
+  WithVenueProps,
+} from '@weco/common/views/components/PageLayout/PageLayout';
 import HTMLDate from '@weco/common/views/components/HTMLDate/HTMLDate';
 import PartNumberIndicator from '../components/PartNumberIndicator/PartNumberIndicator';
 import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
@@ -31,7 +34,8 @@ import * as prismic from '@prismicio/client';
 
 type Props = {
   article: Article;
-} & WithGaDimensions;
+} & WithGaDimensions &
+  WithVenueProps;
 
 function articleHasOutro(article: Article) {
   return Boolean(
@@ -52,6 +56,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
 
     if (articleDocument) {
       const article = transformArticle(articleDocument);
+      const venueProps = getServerSideVenueProps(serverData);
       return {
         props: removeUndefinedProps({
           article,
@@ -61,6 +66,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
               .map(season => season.id)
               .concat(article.series.map(series => series.id)),
           },
+          venueProps,
         }),
       };
     } else {
@@ -108,7 +114,7 @@ function getNextUp(
   }
 }
 
-const ArticlePage: FC<Props> = ({ article }) => {
+const ArticlePage: FC<Props> = ({ article, venueProps }) => {
   const [listOfSeries, setListOfSeries] = useState<ArticleSeriesList>();
 
   useEffect(() => {
@@ -282,6 +288,7 @@ const ArticlePage: FC<Props> = ({ article }) => {
       openGraphType={'article'}
       siteSection={'stories'}
       image={article.image}
+      {...venueProps}
     >
       <ContentPage
         id={article.id}

--- a/content/webapp/pages/articles.tsx
+++ b/content/webapp/pages/articles.tsx
@@ -7,7 +7,10 @@ import {
   transformArticle,
   transformArticleToArticleBasic,
 } from '../services/prismic/transformers/articles';
-import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
+import PageLayout, {
+  getServerSideVenueProps,
+  WithVenueProps,
+} from '@weco/common/views/components/PageLayout/PageLayout';
 import LayoutPaginatedResults from '../components/LayoutPaginatedResults/LayoutPaginatedResults';
 import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
 import { FC } from 'react';
@@ -23,7 +26,7 @@ import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 type Props = {
   articles: PaginatedResults<ArticleBasic>;
   jsonLd: JsonLdObj[];
-};
+} & WithVenueProps;
 
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
@@ -44,17 +47,19 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     };
 
     const serverData = await getServerData(context);
+    const venueProps = getServerSideVenueProps(serverData);
 
     return {
       props: removeUndefinedProps({
         articles: basicArticles,
         jsonLd,
         serverData,
+        venueProps,
       }),
     };
   };
 
-const ArticlesPage: FC<Props> = ({ articles, jsonLd }: Props) => {
+const ArticlesPage: FC<Props> = ({ articles, jsonLd, venueProps }: Props) => {
   const firstArticle = articles.results[0];
 
   return (
@@ -66,6 +71,7 @@ const ArticlesPage: FC<Props> = ({ articles, jsonLd }: Props) => {
       openGraphType={'website'}
       siteSection={'stories'}
       image={firstArticle.image}
+      {...venueProps}
     >
       <SpacingSection>
         <LayoutPaginatedResults

--- a/content/webapp/pages/book.tsx
+++ b/content/webapp/pages/book.tsx
@@ -1,6 +1,9 @@
 import { GetServerSideProps } from 'next';
 import { Fragment, FunctionComponent } from 'react';
-import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
+import PageLayout, {
+  getServerSideVenueProps,
+  WithVenueProps,
+} from '@weco/common/views/components/PageLayout/PageLayout';
 import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
 import ButtonSolidLink from '@weco/common/views/components/ButtonSolidLink/ButtonSolidLink';
 import HTMLDate from '@weco/common/views/components/HTMLDate/HTMLDate';
@@ -25,7 +28,8 @@ const MetadataWrapper = styled.div`
 
 type Props = {
   book: Book;
-} & WithGaDimensions;
+} & WithGaDimensions &
+  WithVenueProps;
 
 // FIXME: This is nonsense
 type BookMetadataProps = { book: Book };
@@ -78,6 +82,8 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
 
     if (bookDocument) {
       const serverData = await getServerData(context);
+      const venueProps = getServerSideVenueProps(serverData);
+
       const book = transformBook(bookDocument);
 
       return {
@@ -87,6 +93,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
           gaDimensions: {
             partOf: book.seasons.map(season => season.id),
           },
+          venueProps,
         }),
       };
     }
@@ -144,11 +151,12 @@ const BookPage: FunctionComponent<Props> = props => {
     <PageLayout
       title={book.title}
       description={book.metadataDescription || book.promo?.caption || ''}
-      url={{ pathname: `/books/${book.id}`, query: {} }}
+      url={{ pathname: `/books/${book.id}` }}
       jsonLd={{ '@type': 'WebPage' }}
       openGraphType={'book'}
       siteSection={null}
       image={book.image}
+      {...props.venueProps}
     >
       <ContentPage
         id={book.id}

--- a/content/webapp/pages/books.tsx
+++ b/content/webapp/pages/books.tsx
@@ -1,5 +1,8 @@
 import type { GetServerSideProps } from 'next';
-import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
+import PageLayout, {
+  getServerSideVenueProps,
+  WithVenueProps,
+} from '@weco/common/views/components/PageLayout/PageLayout';
 import LayoutPaginatedResults from '../components/LayoutPaginatedResults/LayoutPaginatedResults';
 import { PaginatedResults } from '@weco/common/services/prismic/types';
 import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
@@ -20,7 +23,7 @@ import { pageDescriptions } from '@weco/common/data/microcopy';
 
 type Props = {
   books: PaginatedResults<BookBasic>;
-};
+} & WithVenueProps;
 
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
@@ -41,10 +44,12 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
 
     const serverData = await getServerData(context);
     if (books) {
+      const venueProps = getServerSideVenueProps(serverData);
       return {
         props: removeUndefinedProps({
           books,
           serverData,
+          venueProps,
         }),
       };
     } else {
@@ -52,7 +57,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     }
   };
 const BooksPage: FunctionComponent<Props> = props => {
-  const { books } = props;
+  const { books, venueProps } = props;
   const firstBook = books.results[0];
 
   return (
@@ -64,6 +69,7 @@ const BooksPage: FunctionComponent<Props> = props => {
       openGraphType={'website'}
       siteSection={null}
       image={firstBook && firstBook.cover}
+      {...venueProps}
     >
       <SpacingSection>
         <LayoutPaginatedResults

--- a/content/webapp/pages/event-series.tsx
+++ b/content/webapp/pages/event-series.tsx
@@ -2,7 +2,10 @@ import { GetServerSideProps } from 'next';
 import { EventSeries } from '../types/event-series';
 import { EventBasic } from '../types/events';
 import { FC } from 'react';
-import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
+import PageLayout, {
+  getServerSideVenueProps,
+  WithVenueProps,
+} from '@weco/common/views/components/PageLayout/PageLayout';
 import HeaderBackground from '@weco/common/views/components/HeaderBackground/HeaderBackground';
 import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
 import { getFeaturedMedia } from '../utils/page-header';
@@ -34,7 +37,7 @@ type Props = {
   jsonLd: JsonLdObj[];
   pastEvents: EventBasic[];
   upcomingEvents: EventBasic[];
-};
+} & WithVenueProps;
 
 function getUpcomingEvents(events: EventBasic[]): EventBasic[] {
   return events
@@ -115,6 +118,8 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
 
       const jsonLd = events.flatMap(eventLd);
 
+      const venueProps = getServerSideVenueProps(serverData);
+
       return {
         props: removeUndefinedProps({
           series,
@@ -122,6 +127,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
           pastEvents,
           jsonLd,
           serverData,
+          venueProps,
         }),
       };
     } else {
@@ -134,6 +140,7 @@ const EventSeriesPage: FC<Props> = ({
   jsonLd,
   pastEvents: pastJsonEvents,
   upcomingEvents: upcomingJsonEvents,
+  venueProps,
 }) => {
   // events are passed down through getServerSideProps as JSON, so we nuparse them before moving forward
   // This could probably be done at the time of use, instead of globally...
@@ -176,6 +183,7 @@ const EventSeriesPage: FC<Props> = ({
       openGraphType={'website'}
       siteSection={'whats-on'}
       image={series.image}
+      {...venueProps}
     >
       <ContentPage
         id={series.id}

--- a/content/webapp/pages/event.tsx
+++ b/content/webapp/pages/event.tsx
@@ -60,6 +60,7 @@ import { headerBackgroundLs } from '@weco/common/utils/backgrounds';
 import { isDayPast, isPast } from '@weco/common/utils/dates';
 
 import * as prismicT from '@prismicio/types';
+import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 
 const TimeWrapper = styled(Space).attrs({
   v: {
@@ -79,6 +80,7 @@ const DateWrapper = styled.div.attrs({
 
 type Props = {
   jsonEvent: Event;
+  jsonLd: JsonLdObj[];
 } & WithGaDimensions &
   WithVenueProps;
 
@@ -163,7 +165,11 @@ const eventInterpretationIcons: Record<string, IconSvg> = {
   audioDescribed: audioDescribed,
 };
 
-const EventPage: NextPage<Props> = ({ jsonEvent, venueProps }: Props) => {
+const EventPage: NextPage<Props> = ({
+  jsonEvent,
+  venueProps,
+  jsonLd,
+}: Props) => {
   const [scheduledIn, setScheduledIn] = useState<Event>();
   const getScheduledIn = async () => {
     const scheduledInQuery = await fetchEventsClientSide({
@@ -293,8 +299,7 @@ const EventPage: NextPage<Props> = ({ jsonEvent, venueProps }: Props) => {
       title={event.title}
       description={event.metadataDescription || event.promo?.caption || ''}
       url={{ pathname: `/events/${event.id}` }}
-      // TODO: This should be rendered server-side
-      jsonLd={eventLd(event)}
+      jsonLd={jsonLd}
       openGraphType={'website'}
       siteSection={'whats-on'}
       image={event.image}
@@ -539,6 +544,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async context => {
           .map(season => season.id)
           .concat(event.series.map(series => series.id)),
       },
+      jsonLd: eventLd(event),
       venueProps,
     }),
   };

--- a/content/webapp/pages/events.tsx
+++ b/content/webapp/pages/events.tsx
@@ -27,11 +27,13 @@ import {
 import { transformQuery } from '../services/prismic/transformers/paginated-results';
 import { pageDescriptions } from '@weco/common/data/microcopy';
 import { EventBasic } from '../types/events';
+import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 
 type Props = {
   title: string;
   events: PaginatedResults<EventBasic>;
   period?: Period;
+  jsonLd: JsonLdObj[];
 } & WithVenueProps;
 
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
@@ -73,6 +75,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
           title,
           period: period as Period,
           serverData,
+          jsonLd: events.results.flatMap(eventLd),
           venueProps,
         }),
       };
@@ -97,7 +100,7 @@ const EventsPage: FC<Props> = props => {
       title={title}
       description={pageDescriptions.events}
       url={{ pathname: `/events${period ? `/${period}` : ''}` }}
-      jsonLd={events.results.flatMap(eventLd)}
+      jsonLd={props.jsonLd}
       openGraphType={'website'}
       siteSection={'whats-on'}
       image={firstEvent?.image}

--- a/content/webapp/pages/events.tsx
+++ b/content/webapp/pages/events.tsx
@@ -1,6 +1,9 @@
 import { FC } from 'react';
 import { orderEventsByNextAvailableDate } from '../services/prismic/events';
-import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
+import PageLayout, {
+  getServerSideVenueProps,
+  WithVenueProps,
+} from '@weco/common/views/components/PageLayout/PageLayout';
 import LayoutPaginatedResults from '../components/LayoutPaginatedResults/LayoutPaginatedResults';
 import { PaginatedResults } from '@weco/common/services/prismic/types';
 import { Period } from '../types/periods';
@@ -29,7 +32,7 @@ type Props = {
   title: string;
   events: PaginatedResults<EventBasic>;
   period?: Period;
-};
+} & WithVenueProps;
 
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
@@ -63,12 +66,14 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
 
     if (events) {
       const title = (period === 'past' ? 'Past e' : 'E') + 'vents';
+      const venueProps = getServerSideVenueProps(serverData);
       return {
         props: removeUndefinedProps({
           events,
           title,
           period: period as Period,
           serverData,
+          venueProps,
         }),
       };
     } else {
@@ -77,7 +82,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   };
 
 const EventsPage: FC<Props> = props => {
-  const { events, title, period } = props;
+  const { events, title, period, venueProps } = props;
   const convertedEvents = events.results.map(fixEventDatesInJson);
   const convertedPaginatedResults = {
     ...events,
@@ -96,6 +101,7 @@ const EventsPage: FC<Props> = props => {
       openGraphType={'website'}
       siteSection={'whats-on'}
       image={firstEvent?.image}
+      {...venueProps}
     >
       <SpacingSection>
         <LayoutPaginatedResults

--- a/content/webapp/pages/exhibition.tsx
+++ b/content/webapp/pages/exhibition.tsx
@@ -16,19 +16,34 @@ import {
   transformExhibition,
 } from '../services/prismic/transformers/exhibitions';
 import { looksLikePrismicId } from '../services/prismic';
+import {
+  getServerSideVenueProps,
+  WithVenueProps,
+} from '@weco/common/views/components/PageLayout/PageLayout';
 
 type Props = {
   exhibition: ExhibitionType;
   pages: PageType[];
-} & WithGaDimensions;
+} & WithGaDimensions &
+  WithVenueProps;
 
-const ExhibitionPage: FC<Props> = ({ exhibition: jsonExhibition, pages }) => {
+const ExhibitionPage: FC<Props> = ({
+  exhibition: jsonExhibition,
+  pages,
+  venueProps,
+}) => {
   const exhibition = fixExhibitionDatesInJson(jsonExhibition);
 
   if (exhibition.format && exhibition.format.title === 'Installation') {
-    return <Installation installation={exhibition} />;
+    return <Installation installation={exhibition} venueProps={venueProps} />;
   } else {
-    return <Exhibition exhibition={exhibition} pages={pages} />;
+    return (
+      <Exhibition
+        exhibition={exhibition}
+        pages={pages}
+        venueProps={venueProps}
+      />
+    );
   }
 };
 
@@ -48,6 +63,8 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       const exhibitionDoc = transformExhibition(exhibition);
       const relatedPages = transformQuery(pages, transformPage);
 
+      const venueProps = getServerSideVenueProps(serverData);
+
       return {
         props: removeUndefinedProps({
           exhibition: exhibitionDoc,
@@ -56,6 +73,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
           gaDimensions: {
             partOf: exhibitionDoc.seasons.map(season => season.id),
           },
+          venueProps,
         }),
       };
     } else {

--- a/content/webapp/pages/exhibition.tsx
+++ b/content/webapp/pages/exhibition.tsx
@@ -20,10 +20,13 @@ import {
   getServerSideVenueProps,
   WithVenueProps,
 } from '@weco/common/views/components/PageLayout/PageLayout';
+import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
+import { exhibitionLd } from '../services/prismic/transformers/json-ld';
 
 type Props = {
   exhibition: ExhibitionType;
   pages: PageType[];
+  jsonLd: JsonLdObj;
 } & WithGaDimensions &
   WithVenueProps;
 
@@ -31,17 +34,25 @@ const ExhibitionPage: FC<Props> = ({
   exhibition: jsonExhibition,
   pages,
   venueProps,
+  jsonLd,
 }) => {
   const exhibition = fixExhibitionDatesInJson(jsonExhibition);
 
   if (exhibition.format && exhibition.format.title === 'Installation') {
-    return <Installation installation={exhibition} venueProps={venueProps} />;
+    return (
+      <Installation
+        installation={exhibition}
+        venueProps={venueProps}
+        jsonLd={jsonLd}
+      />
+    );
   } else {
     return (
       <Exhibition
         exhibition={exhibition}
         pages={pages}
         venueProps={venueProps}
+        jsonLd={jsonLd}
       />
     );
   }
@@ -65,6 +76,8 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
 
       const venueProps = getServerSideVenueProps(serverData);
 
+      const jsonLd = exhibitionLd(exhibitionDoc);
+
       return {
         props: removeUndefinedProps({
           exhibition: exhibitionDoc,
@@ -74,6 +87,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
             partOf: exhibitionDoc.seasons.map(season => season.id),
           },
           venueProps,
+          jsonLd,
         }),
       };
     } else {

--- a/content/webapp/pages/exhibitions.tsx
+++ b/content/webapp/pages/exhibitions.tsx
@@ -1,6 +1,9 @@
 import type { GetServerSideProps } from 'next';
 import { FC } from 'react';
-import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
+import PageLayout, {
+  getServerSideVenueProps,
+  WithVenueProps,
+} from '@weco/common/views/components/PageLayout/PageLayout';
 import LayoutPaginatedResults from '../components/LayoutPaginatedResults/LayoutPaginatedResults';
 import { Period } from '../types/periods';
 import { PaginatedResults } from '@weco/common/services/prismic/types';
@@ -23,7 +26,7 @@ type Props = {
   exhibitions: PaginatedResults<ExhibitionBasic>;
   period?: Period;
   title: string;
-};
+} & WithVenueProps;
 
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
@@ -44,12 +47,14 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
 
     if (exhibitions && exhibitions.results.length > 0) {
       const title = (period === 'past' ? 'Past e' : 'E') + 'xhibitions';
+      const venueProps = getServerSideVenueProps(serverData);
       return {
         props: removeUndefinedProps({
           exhibitions,
           title,
           period: period as Period,
           serverData,
+          venueProps,
         }),
       };
     } else {
@@ -58,7 +63,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   };
 
 const ExhibitionsPage: FC<Props> = props => {
-  const { exhibitions: jsonExhibitions, period, title } = props;
+  const { exhibitions: jsonExhibitions, period, title, venueProps } = props;
   const exhibitions = {
     ...jsonExhibitions,
     results: jsonExhibitions.results.map(fixExhibitionDatesInJson),
@@ -74,6 +79,7 @@ const ExhibitionsPage: FC<Props> = props => {
       openGraphType={'website'}
       siteSection={'whats-on'}
       image={firstExhibition && firstExhibition.image}
+      {...venueProps}
     >
       <SpacingSection>
         <LayoutPaginatedResults

--- a/content/webapp/pages/exhibitions.tsx
+++ b/content/webapp/pages/exhibitions.tsx
@@ -21,11 +21,13 @@ import {
 } from '../services/prismic/transformers/exhibitions';
 import { createClient } from '../services/prismic/fetch';
 import { ExhibitionBasic } from '../types/exhibitions';
+import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 
 type Props = {
   exhibitions: PaginatedResults<ExhibitionBasic>;
   period?: Period;
   title: string;
+  jsonLd: JsonLdObj[];
 } & WithVenueProps;
 
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
@@ -48,6 +50,9 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     if (exhibitions && exhibitions.results.length > 0) {
       const title = (period === 'past' ? 'Past e' : 'E') + 'xhibitions';
       const venueProps = getServerSideVenueProps(serverData);
+
+      const jsonLd = exhibitions.results.map(exhibitionLd);
+
       return {
         props: removeUndefinedProps({
           exhibitions,
@@ -55,6 +60,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
           period: period as Period,
           serverData,
           venueProps,
+          jsonLd,
         }),
       };
     } else {
@@ -63,7 +69,13 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   };
 
 const ExhibitionsPage: FC<Props> = props => {
-  const { exhibitions: jsonExhibitions, period, title, venueProps } = props;
+  const {
+    exhibitions: jsonExhibitions,
+    period,
+    title,
+    venueProps,
+    jsonLd,
+  } = props;
   const exhibitions = {
     ...jsonExhibitions,
     results: jsonExhibitions.results.map(fixExhibitionDatesInJson),
@@ -75,7 +87,7 @@ const ExhibitionsPage: FC<Props> = props => {
       title={title}
       description={pageDescriptions.exhibitions}
       url={{ pathname: `/exhibitions${period ? `/${period}` : ''}` }}
-      jsonLd={exhibitions.results.map(exhibitionLd)}
+      jsonLd={jsonLd}
       openGraphType={'website'}
       siteSection={'whats-on'}
       image={firstExhibition && firstExhibition.image}

--- a/content/webapp/pages/guides.tsx
+++ b/content/webapp/pages/guides.tsx
@@ -1,6 +1,9 @@
 import { GetServerSideProps } from 'next';
 import { FunctionComponent } from 'react';
-import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
+import PageLayout, {
+  getServerSideVenueProps,
+  WithVenueProps,
+} from '@weco/common/views/components/PageLayout/PageLayout';
 import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
 import LayoutPaginatedResults from '../components/LayoutPaginatedResults/LayoutPaginatedResults';
 import Layout12 from '@weco/common/views/components/Layout12/Layout12';
@@ -61,12 +64,13 @@ type Props = {
   guides: PaginatedResults<Guide>;
   guideFormats: Format[];
   formatId: string | string[] | null;
-};
+} & WithVenueProps;
 
 const GuidePage: FunctionComponent<Props> = ({
   guides,
   guideFormats,
   formatId,
+  venueProps,
 }: Props) => {
   return (
     <PageLayout
@@ -77,6 +81,7 @@ const GuidePage: FunctionComponent<Props> = ({
       openGraphType={'website'}
       siteSection={'what-we-do'}
       image={undefined}
+      {...venueProps}
     >
       <SpacingSection>
         <LayoutPaginatedResults
@@ -121,12 +126,14 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     );
 
     if (guides) {
+      const venueProps = getServerSideVenueProps(serverData);
       return {
         props: removeUndefinedProps({
           guides,
           guideFormats: guideFormats.results,
           formatId: format || null,
           serverData,
+          venueProps,
         }),
       };
     } else {

--- a/content/webapp/pages/homepage.tsx
+++ b/content/webapp/pages/homepage.tsx
@@ -4,7 +4,10 @@ import { classNames, font } from '@weco/common/utils/classnames';
 import SectionHeader from '@weco/common/views/components/SectionHeader/SectionHeader';
 import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
 import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
-import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
+import PageLayout, {
+  getServerSideVenueProps,
+  WithVenueProps,
+} from '@weco/common/views/components/PageLayout/PageLayout';
 import { ArticleBasic } from '../types/articles';
 import { Page as PageType } from '../types/pages';
 import { PaginatedResults } from '@weco/common/services/prismic/types';
@@ -75,7 +78,7 @@ type Props = {
   articles: ArticleBasic[];
   page: PageType;
   jsonLd: JsonLdObj[];
-};
+} & WithVenueProps;
 
 const pageImage: ImageType = {
   contentUrl:
@@ -121,6 +124,8 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     );
     const exhibitions = transformExhibitionsQuery(exhibitionsQuery);
 
+    const venueProps = getServerSideVenueProps(serverData);
+
     if (events && exhibitions && articles && page) {
       return {
         props: removeUndefinedProps({
@@ -130,6 +135,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
           events,
           serverData,
           jsonLd,
+          venueProps,
         }),
       };
     } else {
@@ -161,6 +167,7 @@ const Homepage: FC<Props> = props => {
       openGraphType={'website'}
       siteSection={null}
       image={pageImage}
+      {...props.venueProps}
     >
       <Layout10>
         <SpacingSection>

--- a/content/webapp/pages/homepage.tsx
+++ b/content/webapp/pages/homepage.tsx
@@ -158,6 +158,7 @@ const Homepage: FC<Props> = ({
   exhibitions: jsonExhibitions,
   articles,
   jsonLd,
+  venueProps,
   standfirst,
   contentLists,
 }) => {
@@ -177,7 +178,7 @@ const Homepage: FC<Props> = ({
       openGraphType={'website'}
       siteSection={null}
       image={pageImage}
-      {...props.venueProps}
+      {...venueProps}
     >
       <Layout10>
         <SpacingSection>

--- a/content/webapp/pages/newsletter.tsx
+++ b/content/webapp/pages/newsletter.tsx
@@ -1,6 +1,9 @@
 import { FC } from 'react';
 import NewsletterSignup from '../components/NewsletterSignup/NewsletterSignup';
-import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
+import PageLayout, {
+  getServerSideVenueProps,
+  WithVenueProps,
+} from '@weco/common/views/components/PageLayout/PageLayout';
 import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
 import { grid } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
@@ -13,22 +16,24 @@ import { landingHeaderBackgroundLs } from '@weco/common/utils/backgrounds';
 
 type Props = {
   result?: string;
-};
+} & WithVenueProps;
 
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
     const serverData = await getServerData(context);
     const { result } = context.query;
+    const venueProps = getServerSideVenueProps(serverData);
 
     return {
       props: removeUndefinedProps({
         result: result ? result.toString() : undefined,
         serverData,
+        venueProps,
       }),
     };
   };
 
-const Newsletter: FC<Props> = ({ result }) => {
+const Newsletter: FC<Props> = ({ result, venueProps }) => {
   return (
     <PageLayout
       title={'Sign up to our newsletter'}
@@ -45,6 +50,7 @@ const Newsletter: FC<Props> = ({ result }) => {
         height: 662,
         alt: '',
       }}
+      {...venueProps}
     >
       <PageHeader
         breadcrumbs={{ items: [] }}

--- a/content/webapp/pages/page.tsx
+++ b/content/webapp/pages/page.tsx
@@ -41,12 +41,14 @@ import {
 import { createClient } from '../services/prismic/fetch';
 import { transformPage } from '../services/prismic/transformers/pages';
 import { getCrop } from '@weco/common/model/image';
+import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 
 type Props = {
   page: PageType;
   siblings: SiblingsGroup<PageType>[];
   children: SiblingsGroup<PageType>;
   ordersInParents: OrderInParent[];
+  jsonLd: JsonLdObj;
 } & WithGaDimensions &
   WithVenueProps;
 
@@ -106,6 +108,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
           gaDimensions: {
             partOf: page.seasons.map(season => season.id),
           },
+          jsonLd: contentLd(page),
           venueProps,
         }),
       };
@@ -120,6 +123,7 @@ const Page: FC<Props> = ({
   children,
   ordersInParents,
   venueProps,
+  jsonLd,
 }) => {
   function makeLabels(title?: string): LabelsListProps | undefined {
     if (!title) return;
@@ -270,7 +274,7 @@ const Page: FC<Props> = ({
       title={page.title}
       description={page.metadataDescription || page.promo?.caption || ''}
       url={{ pathname: `/pages/${page.id}` }}
-      jsonLd={contentLd(page)}
+      jsonLd={jsonLd}
       openGraphType={'website'}
       siteSection={page?.siteSection as SiteSection}
       image={page.image}

--- a/content/webapp/pages/page.tsx
+++ b/content/webapp/pages/page.tsx
@@ -1,6 +1,8 @@
 import { FC } from 'react';
 import PageLayout, {
+  getServerSideVenueProps,
   SiteSection,
+  WithVenueProps,
 } from '@weco/common/views/components/PageLayout/PageLayout';
 import HTMLDate from '@weco/common/views/components/HTMLDate/HTMLDate';
 import HeaderBackground from '@weco/common/views/components/HeaderBackground/HeaderBackground';
@@ -45,7 +47,8 @@ type Props = {
   siblings: SiblingsGroup<PageType>[];
   children: SiblingsGroup<PageType>;
   ordersInParents: OrderInParent[];
-} & WithGaDimensions;
+} & WithGaDimensions &
+  WithVenueProps;
 
 type OrderInParent = {
   id: string;
@@ -91,6 +94,8 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
         siblings: (await fetchChildren(client, page)).map(transformPage),
       };
 
+      const venueProps = getServerSideVenueProps(serverData);
+
       return {
         props: removeUndefinedProps({
           page,
@@ -101,6 +106,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
           gaDimensions: {
             partOf: page.seasons.map(season => season.id),
           },
+          venueProps,
         }),
       };
     } else {
@@ -108,7 +114,13 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     }
   };
 
-const Page: FC<Props> = ({ page, siblings, children, ordersInParents }) => {
+const Page: FC<Props> = ({
+  page,
+  siblings,
+  children,
+  ordersInParents,
+  venueProps,
+}) => {
   function makeLabels(title?: string): LabelsListProps | undefined {
     if (!title) return;
 
@@ -262,6 +274,7 @@ const Page: FC<Props> = ({ page, siblings, children, ordersInParents }) => {
       openGraphType={'website'}
       siteSection={page?.siteSection as SiteSection}
       image={page.image}
+      {...venueProps}
     >
       <ContentPage
         id={page.id}

--- a/content/webapp/pages/season.tsx
+++ b/content/webapp/pages/season.tsx
@@ -56,6 +56,7 @@ import { Project } from '../types/projects';
 import { Series } from '../types/series';
 import { looksLikePrismicId } from '../services/prismic';
 import { getCrop } from '@weco/common/model/image';
+import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 
 type Props = {
   season: Season;
@@ -66,6 +67,7 @@ type Props = {
   pages: Page[];
   projects: Project[];
   series: Series[];
+  jsonLd: JsonLdObj;
 } & WithVenueProps;
 
 const SeasonPage = ({
@@ -78,6 +80,7 @@ const SeasonPage = ({
   projects,
   books,
   venueProps,
+  jsonLd,
 }: Props): ReactElement<Props> => {
   const superWidescreenImage = getCrop(season.image, '32:15');
 
@@ -113,7 +116,7 @@ const SeasonPage = ({
       title={season.title}
       description={season.metadataDescription || season.promo?.caption || ''}
       url={{ pathname: `/seasons/${season.id}` }}
-      jsonLd={contentLd(season)}
+      jsonLd={jsonLd}
       siteSection={'whats-on'}
       openGraphType={'website'}
       image={season.image}
@@ -221,6 +224,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
           projects: projects.results,
           series: series.results,
           serverData,
+          jsonLd: contentLd(season),
           venueProps,
         }),
       };

--- a/content/webapp/pages/season.tsx
+++ b/content/webapp/pages/season.tsx
@@ -1,7 +1,10 @@
 import { GetServerSideProps } from 'next';
 import { ReactElement } from 'react';
 import { Season } from '../types/seasons';
-import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
+import PageLayout, {
+  getServerSideVenueProps,
+  WithVenueProps,
+} from '@weco/common/views/components/PageLayout/PageLayout';
 import SeasonsHeader from '@weco/content/components/SeasonsHeader/SeasonsHeader';
 import { UiImage } from '@weco/common/views/components/Images/Images';
 import { removeUndefinedProps } from '@weco/common/utils/json';
@@ -63,7 +66,7 @@ type Props = {
   pages: Page[];
   projects: Project[];
   series: Series[];
-};
+} & WithVenueProps;
 
 const SeasonPage = ({
   season,
@@ -74,6 +77,7 @@ const SeasonPage = ({
   series,
   projects,
   books,
+  venueProps,
 }: Props): ReactElement<Props> => {
   const superWidescreenImage = getCrop(season.image, '32:15');
 
@@ -113,6 +117,7 @@ const SeasonPage = ({
       siteSection={'whats-on'}
       openGraphType={'website'}
       image={season.image}
+      {...venueProps}
     >
       <ContentPage
         id={season.id}
@@ -204,6 +209,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
 
     if (season) {
       const serverData = await getServerData(context);
+      const venueProps = getServerSideVenueProps(serverData);
       return {
         props: removeUndefinedProps({
           season,
@@ -215,6 +221,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
           projects: projects.results,
           series: series.results,
           serverData,
+          venueProps,
         }),
       };
     } else {

--- a/content/webapp/pages/stories.tsx
+++ b/content/webapp/pages/stories.tsx
@@ -1,6 +1,9 @@
 import { FC } from 'react';
 import { classNames, grid } from '@weco/common/utils/classnames';
-import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
+import PageLayout, {
+  getServerSideVenueProps,
+  WithVenueProps,
+} from '@weco/common/views/components/PageLayout/PageLayout';
 import Layout12 from '@weco/common/views/components/Layout12/Layout12';
 import SectionHeader from '@weco/common/views/components/SectionHeader/SectionHeader';
 import { ArticleBasic } from '../types/articles';
@@ -54,7 +57,7 @@ type Props = {
   featuredText?: FeaturedTextType;
   featuredBooks: BookBasic[];
   jsonLd: JsonLdObj[];
-};
+} & WithVenueProps;
 
 const SerialisedSeries = ({ series }: { series: Series }) => {
   return (
@@ -150,6 +153,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     const featuredText = getPageFeaturedText(transformPage(storiesPage!));
 
     if (articles && articles.results) {
+      const venueProps = getServerSideVenueProps(serverData);
       return {
         props: removeUndefinedProps({
           articles: basicArticles,
@@ -158,6 +162,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
           serverData,
           featuredBooks,
           jsonLd,
+          venueProps,
         }),
       };
     } else {
@@ -171,6 +176,7 @@ const StoriesPage: FC<Props> = ({
   featuredText,
   featuredBooks,
   jsonLd,
+  venueProps,
 }) => {
   const firstArticle = articles[0];
 
@@ -184,6 +190,7 @@ const StoriesPage: FC<Props> = ({
       siteSection={'stories'}
       image={firstArticle && firstArticle.image}
       rssUrl={'https://rss.wellcomecollection.org/stories'}
+      {...venueProps}
     >
       <SpacingSection>
         <Space

--- a/content/webapp/pages/whats-on.tsx
+++ b/content/webapp/pages/whats-on.tsx
@@ -26,7 +26,10 @@ import {
   // shopPromo,
   readingRoomPromo,
 } from '../data/facility-promos';
-import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
+import PageLayout, {
+  getServerSideVenueProps,
+  WithVenueProps,
+} from '@weco/common/views/components/PageLayout/PageLayout';
 import SegmentedControl from '@weco/common/views/components/SegmentedControl/SegmentedControl';
 import EventsByMonth from '../components/EventsByMonth/EventsByMonth';
 import SectionHeader from '@weco/common/views/components/SectionHeader/SectionHeader';
@@ -106,7 +109,7 @@ export type Props = {
   tryTheseTooPromos: FacilityPromoType[];
   eatShopPromos: FacilityPromoType[];
   featuredText: FeaturedTextType;
-};
+} & WithVenueProps;
 
 export function getMomentsForPeriod(period: Period): (Moment | undefined)[] {
   const todaysDate = london();
@@ -379,6 +382,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     );
 
     if (period && events && exhibitions) {
+      const venueProps = getServerSideVenueProps(serverData);
       return {
         props: removeUndefinedProps({
           period,
@@ -391,6 +395,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
           cafePromo,
           featuredText: featuredText!,
           serverData,
+          venueProps,
         }),
       };
     } else {
@@ -399,8 +404,14 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   };
 
 const WhatsOnPage: FunctionComponent<Props> = props => {
-  const { period, dateRange, tryTheseTooPromos, eatShopPromos, featuredText } =
-    props;
+  const {
+    period,
+    dateRange,
+    tryTheseTooPromos,
+    eatShopPromos,
+    featuredText,
+    venueProps,
+  } = props;
 
   const events = props.events.results.map(fixEventDatesInJson);
   const availableOnlineEvents =
@@ -440,6 +451,7 @@ const WhatsOnPage: FunctionComponent<Props> = props => {
       openGraphType={'website'}
       siteSection={'whats-on'}
       image={firstExhibition && firstExhibition.image}
+      {...venueProps}
     >
       <>
         <Header

--- a/content/webapp/pages/whats-on.tsx
+++ b/content/webapp/pages/whats-on.tsx
@@ -109,6 +109,7 @@ export type Props = {
   tryTheseTooPromos: FacilityPromoType[];
   eatShopPromos: FacilityPromoType[];
   featuredText: FeaturedTextType;
+  jsonLd: JsonLdObj[];
 } & WithVenueProps;
 
 export function getMomentsForPeriod(period: Period): (Moment | undefined)[] {
@@ -383,6 +384,10 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
 
     if (period && events && exhibitions) {
       const venueProps = getServerSideVenueProps(serverData);
+      const jsonLd = [
+        ...exhibitions.results.map(exhibitionLd),
+        ...events.results.flatMap(eventLd),
+      ] as JsonLdObj[];
       return {
         props: removeUndefinedProps({
           period,
@@ -396,6 +401,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
           featuredText: featuredText!,
           serverData,
           venueProps,
+          jsonLd,
         }),
       };
     } else {
@@ -411,6 +417,7 @@ const WhatsOnPage: FunctionComponent<Props> = props => {
     eatShopPromos,
     featuredText,
     venueProps,
+    jsonLd,
   } = props;
 
   const events = props.events.results.map(fixEventDatesInJson);
@@ -442,12 +449,7 @@ const WhatsOnPage: FunctionComponent<Props> = props => {
       title={pageTitle}
       description={pageDescriptions.whatsOn}
       url={{ pathname: `/whats-on` }}
-      jsonLd={
-        [
-          ...exhibitions.map(exhibitionLd),
-          ...events.map(eventLd),
-        ] as JsonLdObj[]
-      }
+      jsonLd={jsonLd}
       openGraphType={'website'}
       siteSection={'whats-on'}
       image={firstExhibition && firstExhibition.image}

--- a/content/webapp/services/prismic/transformers/events.ts
+++ b/content/webapp/services/prismic/transformers/events.ts
@@ -286,8 +286,6 @@ export function transformEventToEventBasic(event: Event): EventBasic {
     scheduleLength,
     series,
     secondaryLabels,
-    cost,
-    contributors,
   }) => ({
     type,
     promo,
@@ -303,8 +301,6 @@ export function transformEventToEventBasic(event: Event): EventBasic {
     scheduleLength,
     series,
     secondaryLabels,
-    cost,
-    contributors,
   }))(event);
 }
 

--- a/content/webapp/services/prismic/transformers/json-ld.ts
+++ b/content/webapp/services/prismic/transformers/json-ld.ts
@@ -48,7 +48,7 @@ export function exhibitionLd(exhibition: Exhibition): JsonLdObj {
   );
 }
 
-export function eventLd(event: Event | EventBasic): JsonLdObj[] {
+export function eventLd(event: Event): JsonLdObj[] {
   // TODO EventBasic
   const promoImage = event.promo?.image;
   return event.times

--- a/content/webapp/types/events.ts
+++ b/content/webapp/types/events.ts
@@ -72,7 +72,7 @@ export type ThirdPartyBooking = {
 
 export type EventBasic = {
   // this is a mix of props from GenericContentFields and Event
-  // and is only what is required to render EventPromos and json-ld
+  // and is only what is required to render EventPromos
   type: 'events';
   id: string;
   title: string;
@@ -87,8 +87,6 @@ export type EventBasic = {
   availableOnline: boolean;
   scheduleLength: number;
   series: EventSeries[];
-  cost?: string;
-  contributors: Contributor[];
 };
 
 export type Event = GenericContentFields & {

--- a/content/webapp/types/exhibitions.ts
+++ b/content/webapp/types/exhibitions.ts
@@ -20,7 +20,7 @@ export type ExhibitionFormat = {
 
 export type ExhibitionBasic = {
   // this is a mix of props from GenericContentFields and Exhibition
-  // and is only what is required to render ExhibitionPromos and json-ld
+  // and is only what is required to render ExhibitionPromos
   type: 'exhibitions';
   id: string;
   title: string;


### PR DESCRIPTION
This continues a trend in a few other places – rendering our JSON-LD on the server-side and passing it down through the props. The theory is that it should mean we have to send less data to the front-end, because:

1. We can delete large objects from the *Basic types (contributors are always large)
2. We can shake the JSON-LD transformer code out of the bundle, and just run it server-side

This actually came out of staring at the PageLayout component and realising it does a bunch of stuff we should probably be doing server-side. We shouldn't really be sending any Prismic models to the client.