### PR TITLE
Introduce proper types for the Body slice, not 'any'

### DIFF
--- a/content/webapp/components/FeaturedCard/FeaturedCard.tsx
+++ b/content/webapp/components/FeaturedCard/FeaturedCard.tsx
@@ -22,6 +22,11 @@ import StatusIndicator from '@weco/common/views/components/StatusIndicator/Statu
 import { formatDate } from '@weco/common/utils/format-date';
 import { trackEvent } from '@weco/common/utils/ga';
 import linkResolver from '../../services/prismic/link-resolver';
+import { Page } from '../../types/pages';
+import { EventSeries } from '../../types/event-series';
+import { Book } from '../../types/books';
+import { Event } from '../../types/events';
+import { Guide } from '../../types/guides';
 
 type PartialFeaturedCard = {
   id: string;
@@ -53,7 +58,15 @@ export function convertCardToFeaturedCardProps(
 }
 
 export function convertItemToFeaturedCardProps(
-  item: ArticleBasic | ExhibitionBasic | Season
+  item:
+    | ArticleBasic
+    | ExhibitionBasic
+    | Season
+    | Page
+    | EventSeries
+    | Book
+    | Event
+    | Guide
 ) {
   return {
     id: item.id,

--- a/content/webapp/components/ImageGallery/ImageGallery.tsx
+++ b/content/webapp/components/ImageGallery/ImageGallery.tsx
@@ -237,7 +237,7 @@ export type Props = {
   isStandalone: boolean;
 };
 
-const ImageGallery: FunctionComponent<{ id: string } & Props> = ({
+const ImageGallery: FunctionComponent<{ id: number } & Props> = ({
   id,
   title,
   items,
@@ -283,7 +283,7 @@ const ImageGallery: FunctionComponent<{ id: string } & Props> = ({
       trackEvent({
         category: `Control`,
         action: 'close ImageGallery',
-        label: id,
+        label: id.toString(),
       });
     }
 
@@ -296,7 +296,7 @@ const ImageGallery: FunctionComponent<{ id: string } & Props> = ({
     trackEvent({
       category: `${isButton ? 'Button' : 'CaptionedImage'}`,
       action: 'open ImageGallery',
-      label: id,
+      label: id.toString(),
     });
 
     setIsActive(true);

--- a/content/webapp/components/MediaObjectList/MediaObjectList.tsx
+++ b/content/webapp/components/MediaObjectList/MediaObjectList.tsx
@@ -3,7 +3,7 @@ import MediaObject, {
   Props as MediaObjectProps,
 } from '../MediaObject/MediaObject';
 
-type Props = {
+export type Props = {
   items: MediaObjectProps[];
 };
 

--- a/content/webapp/components/VenueHours/VenueHours.tsx
+++ b/content/webapp/components/VenueHours/VenueHours.tsx
@@ -21,7 +21,7 @@ import {
 import Space from '@weco/common/views/components/styled/Space';
 import { usePrismicData } from '@weco/common/server-data/Context';
 import { Venue } from '@weco/common/model/opening-hours';
-import { Weight } from '../../types/generic-content-fields';
+import { Weight } from '../../types/body';
 
 const VenueHoursImage = styled(Space)`
   ${props => props.theme.media.medium`

--- a/content/webapp/pages/homepage.tsx
+++ b/content/webapp/pages/homepage.tsx
@@ -50,6 +50,7 @@ import {
 } from '../services/prismic/transformers/exhibitions';
 import { ImageType } from '@weco/common/model/image';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
+import { isContentList, isStandfirst } from 'types/body';
 
 const PageHeading = styled(Space).attrs({
   as: 'h1',
@@ -147,8 +148,8 @@ const Homepage: FC<Props> = props => {
 
   const articles = props.articles;
   const page = props.page;
-  const standFirst = page.body.find(slice => slice.type === 'standfirst');
-  const lists = page.body.filter(slice => slice.type === 'contentList');
+  const standFirst = page.body.find(isStandfirst);
+  const lists = page.body.filter(isContentList);
   const headerList = lists.length === 2 ? lists[0] : null;
   const contentList = lists.length === 2 ? lists[1] : lists[0];
 
@@ -181,7 +182,7 @@ const Homepage: FC<Props> = props => {
           )}
           <SpacingComponent>
             <SimpleCardGrid
-              items={headerList.value.items}
+              items={headerList.value.items as any[]}
               isFeaturedFirst={true}
             />
           </SpacingComponent>
@@ -206,17 +207,19 @@ const Homepage: FC<Props> = props => {
       {contentList && (
         <SpacingSection>
           <SpacingComponent>
-            <SectionHeader title={contentList.value.title} />
+            <SectionHeader title={contentList.value.title || ''} />
           </SpacingComponent>
           <SpacingComponent>
             <SimpleCardGrid
-              items={contentList.value.items.map(item => {
-                if (item.type === 'seasons') {
-                  return convertItemToCardProps(item);
-                } else {
-                  return item;
-                }
-              })}
+              items={
+                contentList.value.items.map(item => {
+                  if (item.type === 'seasons') {
+                    return convertItemToCardProps(item);
+                  } else {
+                    return item;
+                  }
+                }) as any[]
+              }
             />
           </SpacingComponent>
         </SpacingSection>

--- a/content/webapp/pages/homepage.tsx
+++ b/content/webapp/pages/homepage.tsx
@@ -212,13 +212,9 @@ const Homepage: FC<Props> = props => {
           <SpacingComponent>
             <SimpleCardGrid
               items={
-                contentList.value.items.map(item => {
-                  if (item.type === 'seasons') {
-                    return convertItemToCardProps(item);
-                  } else {
-                    return item;
-                  }
-                }) as any[]
+                contentList.value.items.map(item =>
+                  item.type === 'seasons' ? convertItemToCardProps(item) : item
+                ) as any[]
               }
             />
           </SpacingComponent>

--- a/content/webapp/pages/homepage.tsx
+++ b/content/webapp/pages/homepage.tsx
@@ -72,7 +72,7 @@ const CreamBox = styled(Space).attrs({
 
 type Props = {
   exhibitions: ExhibitionBasic[];
-  events: EventBasic[];
+  nextSevenDaysEvents: EventBasic[];
   articles: ArticleBasic[];
   jsonLd: JsonLdObj[];
   standfirst?: BodySlice & { type: 'standfirst' };
@@ -121,6 +121,10 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     const events = transformQuery(eventsQuery, event =>
       transformEventToEventBasic(transformEvent(event))
     ).results;
+    const nextSevenDaysEvents = orderEventsByNextAvailableDate(
+      filterEventsForNext7Days(events)
+    );
+
     const exhibitions = transformExhibitionsQuery(exhibitionsQuery).results;
 
     const standfirst = page.body.find(isStandfirst);
@@ -131,7 +135,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
         props: removeUndefinedProps({
           articles: basicArticles,
           exhibitions,
-          events,
+          nextSevenDaysEvents,
           serverData,
           jsonLd,
           standfirst,
@@ -144,18 +148,14 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   };
 
 const Homepage: FC<Props> = ({
-  events: jsonEvents,
+  nextSevenDaysEvents: jsonEvents,
   exhibitions: jsonExhibitions,
   articles,
   jsonLd,
   standfirst,
   contentLists,
 }) => {
-  const events = jsonEvents.map(fixEventDatesInJson);
-  const nextSevenDaysEvents = orderEventsByNextAvailableDate(
-    filterEventsForNext7Days(events)
-  );
-
+  const nextSevenDaysEvents = jsonEvents.map(fixEventDatesInJson);
   const exhibitions = jsonExhibitions.map(fixExhibitionDatesInJson);
 
   const headerList = contentLists.length === 2 ? contentLists[0] : null;

--- a/content/webapp/pages/page.tsx
+++ b/content/webapp/pages/page.tsx
@@ -39,6 +39,8 @@ import {
 import { createClient } from '../services/prismic/fetch';
 import { transformPage } from '../services/prismic/transformers/pages';
 import { getCrop } from '@weco/common/model/image';
+import { isPicture, isVideoEmbed } from 'types/body';
+import { isNotUndefined } from '@weco/common/utils/array';
 
 type Props = {
   page: PageType;
@@ -128,23 +130,28 @@ const Page: FC<Props> = ({ page, siblings, children, ordersInParents }) => {
     ? landingHeaderBackgroundLs
     : headerBackgroundLs;
 
+  const featuredPicture =
+    page.body.length > 1 && isPicture(page.body[0]) ? page.body[0] : undefined;
+
+  const featuredVideo =
+    page.body.length > 1 && isVideoEmbed(page.body[0])
+      ? page.body[0]
+      : undefined;
+
   const hasFeaturedMedia =
-    page.body.length > 1 &&
-    (page.body[0].type === 'picture' || page.body[0].type === 'videoEmbed');
+    isNotUndefined(featuredPicture) || isNotUndefined(featuredVideo);
 
   const body = hasFeaturedMedia
     ? page.body.slice(1, page.body.length)
     : page.body;
 
-  const featuredMedia = hasFeaturedMedia ? (
-    page.body[0].type === 'picture' ? (
-      <UiImage
-        {...(getCrop(page.body[0].value.image, '16:9') ||
-          page.body[0].value.image)}
-      />
-    ) : page.body[0].type === 'videoEmbed' ? (
-      <VideoEmbed {...page.body[0].value} />
-    ) : undefined
+  const featuredMedia = featuredPicture ? (
+    <UiImage
+      {...((getCrop(featuredPicture.value.image, '16:9') ||
+        featuredPicture.value.image) as any)}
+    />
+  ) : featuredVideo ? (
+    <VideoEmbed {...featuredVideo.value} />
   ) : undefined;
 
   const hiddenBreadcrumbPages = [prismicPageIds.covidWelcomeBack];

--- a/content/webapp/services/prismic/transformers/body.test.ts
+++ b/content/webapp/services/prismic/transformers/body.test.ts
@@ -40,8 +40,8 @@ describe('media object list slices', () => {
           items: [
             {
               title: 'Only book for your household or bubble',
-              text: null,
-              image: null,
+              text: undefined,
+              image: undefined,
             },
           ],
         },

--- a/content/webapp/services/prismic/transformers/body.ts
+++ b/content/webapp/services/prismic/transformers/body.ts
@@ -22,22 +22,7 @@ import {
   Discussion as DiscussionSlice,
   Body,
 } from '../types/body';
-import { Props as TableProps } from '@weco/common/views/components/Table/Table';
 import { Props as ContactProps } from '@weco/common/views/components/Contact/Contact';
-import { Props as IframeProps } from '@weco/common/views/components/Iframe/Iframe';
-import { Props as InfoBlockProps } from '@weco/common/views/components/InfoBlock/InfoBlock';
-import { Props as AsyncSearchResultsProps } from '../../../components/SearchResults/AsyncSearchResults';
-import { Props as SearchResultsProps } from '../../../components/SearchResults/SearchResults';
-import { Props as QuoteProps } from '../../../components/Quote/Quote';
-import { Props as ImageGalleryProps } from '../../../components/ImageGallery/ImageGallery';
-import { Props as DeprecatedImageListProps } from '../../../components/DeprecatedImageList/DeprecatedImageList';
-import { Props as GifVideoProps } from '../../../components/GifVideo/GifVideo';
-import { Props as TitledTextListProps } from '../../../components/TitledTextList/TitledTextList';
-import { Props as TagsGroupProps } from '@weco/common/views/components/TagsGroup/TagsGroup';
-import { Props as MapProps } from '../../../components/Map/Map';
-import { Props as DiscussionProps } from '../../../components/Discussion/Discussion';
-import { Props as EmbedProps } from '@weco/common/views/components/VideoEmbed/VideoEmbed';
-import { MediaObjectType } from '../../../types/media-object';
 import { isNotUndefined } from '@weco/common/utils/array';
 import {
   isFilledLinkToDocumentWithData,
@@ -46,7 +31,6 @@ import {
 import { TeamPrismicDocument } from '../types/teams';
 import { transformCaptionedImage } from './images';
 import { transformImage } from '@weco/common/services/prismic/transformers/images';
-import { CaptionedImage } from '@weco/common/model/captioned-image';
 import {
   transformLink,
   asRichText,
@@ -56,8 +40,7 @@ import {
 } from '.';
 import { transformTaslFromString } from '@weco/common/services/prismic/transformers';
 import { LinkField, RelationField, RichTextField } from '@prismicio/types';
-import { BodyType, Weight } from '../../../types/generic-content-fields';
-import { Venue } from '@weco/common/model/opening-hours';
+import { BodySlice, Weight } from '../../../types/body';
 import { transformCollectionVenue } from '@weco/common/services/prismic/transformers/collection-venues';
 import { GuidePrismicDocument } from '../types/guides';
 import { SeasonPrismicDocument } from '../types/seasons';
@@ -90,15 +73,7 @@ export function getWeight(weight: string | null): Weight {
   }
 }
 
-type ParsedSlice<TypeName extends string, Value> = {
-  type: TypeName;
-  weight?: Weight;
-  value: Value;
-};
-
-function transformStandfirstSlice(
-  slice: StandfirstSlice
-): ParsedSlice<'standfirst', RichTextField> {
+function transformStandfirstSlice(slice: StandfirstSlice): BodySlice {
   return {
     type: 'standfirst',
     weight: getWeight(slice.slice_label),
@@ -106,9 +81,7 @@ function transformStandfirstSlice(
   };
 }
 
-function transformTextSlice(
-  slice: TextSlice
-): ParsedSlice<'text', RichTextField> {
+function transformTextSlice(slice: TextSlice): BodySlice {
   return {
     type: 'text',
     weight: getWeight(slice.slice_label),
@@ -116,7 +89,7 @@ function transformTextSlice(
   };
 }
 
-function transformMapSlice(slice: MapSlice): ParsedSlice<'map', MapProps> {
+function transformMapSlice(slice: MapSlice): BodySlice {
   return {
     type: 'map',
     value: {
@@ -134,9 +107,7 @@ function transformTableCsv(tableData: string): string[][] {
     .map(row => row.split('|').map(cell => cell.trim()));
 }
 
-function transformTableSlice(
-  slice: TableSlice
-): ParsedSlice<'table', TableProps> {
+function transformTableSlice(slice: TableSlice): BodySlice {
   return {
     type: 'table',
     value: {
@@ -149,29 +120,19 @@ function transformTableSlice(
   };
 }
 
-function transformMediaObjectListSlice(
-  slice: MediaObjectListSlice
-): ParsedSlice<'mediaObjectList', { items: MediaObjectType[] }> {
+function transformMediaObjectListSlice(slice: MediaObjectListSlice): BodySlice {
   return {
     type: 'mediaObjectList',
     value: {
       items: slice.items
         .map(mediaObject => {
           if (mediaObject) {
-            // make sure we have the content we require
-            const title = mediaObject.title.length
-              ? mediaObject?.title
-              : undefined;
-            const text = mediaObject.text.length
-              ? mediaObject?.text
-              : undefined;
-            const image = mediaObject.image?.square?.dimensions
-              ? mediaObject.image
-              : undefined;
             return {
-              title: title ? asTitle(title) : null,
-              text: text ? asRichText(text) || null : null,
-              image: transformImage(image) || null,
+              title: asTitle(mediaObject.title),
+              text: mediaObject.text.length
+                ? asRichText(mediaObject.text)
+                : undefined,
+              image: transformImage(mediaObject.image)!,
             };
           }
         })
@@ -193,9 +154,7 @@ function transformTeamToContact(team: TeamPrismicDocument): ContactProps {
   };
 }
 
-function transformContactSlice(
-  slice: ContactSlice
-): ParsedSlice<'contact', ContactProps> | undefined {
+function transformContactSlice(slice: ContactSlice): BodySlice | undefined {
   return isFilledLinkToDocumentWithData(slice.primary.content)
     ? {
         type: 'contact',
@@ -204,9 +163,7 @@ function transformContactSlice(
     : undefined;
 }
 
-function transformEditorialImageSlice(
-  slice: EditorialImageSlice
-): ParsedSlice<'picture', CaptionedImage> {
+function transformEditorialImageSlice(slice: EditorialImageSlice): BodySlice {
   return {
     weight: getWeight(slice.slice_label),
     type: 'picture',
@@ -216,7 +173,7 @@ function transformEditorialImageSlice(
 
 function transformEditorialImageGallerySlice(
   slice: EditorialImageGallerySlice
-): ParsedSlice<'imageGallery', ImageGalleryProps> {
+): BodySlice {
   return {
     type: 'imageGallery',
     value: {
@@ -229,7 +186,7 @@ function transformEditorialImageGallerySlice(
 
 function transformDeprecatedImageListSlice(
   slice: DeprecatedImageListSlice
-): ParsedSlice<'deprecatedImageList', DeprecatedImageListProps> {
+): BodySlice {
   return {
     type: 'deprecatedImageList',
     weight: getWeight(slice.slice_label),
@@ -250,9 +207,7 @@ function transformDeprecatedImageListSlice(
   };
 }
 
-function transformGifVideoSlice(
-  slice: GifVideoSlice
-): ParsedSlice<'gifVideo', GifVideoProps> | undefined {
+function transformGifVideoSlice(slice: GifVideoSlice): BodySlice | undefined {
   const playbackRate = slice.primary.playbackRate
     ? parseFloat(slice.primary.playbackRate)
     : 1;
@@ -299,9 +254,7 @@ function transformTitledTextItem({
   };
 }
 
-function transformTitledTextListSlice(
-  slice: TitledTextListSlice
-): ParsedSlice<'titledTextList', TitledTextListProps> {
+function transformTitledTextListSlice(slice: TitledTextListSlice): BodySlice {
   return {
     type: 'titledTextList',
     value: {
@@ -310,9 +263,7 @@ function transformTitledTextListSlice(
   };
 }
 
-function transformDiscussionSlice(
-  slice: DiscussionSlice
-): ParsedSlice<'discussion', DiscussionProps> {
+function transformDiscussionSlice(slice: DiscussionSlice): BodySlice {
   return {
     type: 'discussion',
     value: {
@@ -322,9 +273,7 @@ function transformDiscussionSlice(
   };
 }
 
-function transformInfoBlockSlice(
-  slice: InfoBlockSlice
-): ParsedSlice<'infoBlock', InfoBlockProps> {
+function transformInfoBlockSlice(slice: InfoBlockSlice): BodySlice {
   return {
     type: 'infoBlock',
     value: {
@@ -336,9 +285,7 @@ function transformInfoBlockSlice(
   };
 }
 
-function transformIframeSlice(
-  slice: IframeSlice
-): ParsedSlice<'iframe', IframeProps> {
+function transformIframeSlice(slice: IframeSlice): BodySlice {
   return {
     type: 'iframe',
     weight: getWeight(slice.slice_label),
@@ -349,9 +296,7 @@ function transformIframeSlice(
   };
 }
 
-function transformQuoteSlice(
-  slice: QuoteSlice | QuoteV2Slice
-): ParsedSlice<'quote', QuoteProps> {
+function transformQuoteSlice(slice: QuoteSlice | QuoteV2Slice): BodySlice {
   return {
     type: 'quote',
     weight: getWeight(slice.slice_label),
@@ -364,9 +309,7 @@ function transformQuoteSlice(
   };
 }
 
-function transformTagListSlice(
-  slice: TagListSlice
-): ParsedSlice<'tagList', TagsGroupProps> {
+function transformTagListSlice(slice: TagListSlice): BodySlice {
   return {
     type: 'tagList',
     value: {
@@ -382,9 +325,7 @@ function transformTagListSlice(
   };
 }
 
-function transformSearchResultsSlice(
-  slice: SearchResultsSlice
-): ParsedSlice<'searchResults', AsyncSearchResultsProps> {
+function transformSearchResultsSlice(slice: SearchResultsSlice): BodySlice {
   return {
     type: 'searchResults',
     weight: getWeight(slice.slice_label),
@@ -397,12 +338,7 @@ function transformSearchResultsSlice(
 
 function transformCollectionVenueSlice(
   slice: CollectionVenueSlice
-):
-  | ParsedSlice<
-      'collectionVenue',
-      { content: Venue; showClosingTimes: boolean }
-    >
-  | undefined {
+): BodySlice | undefined {
   return isFilledLinkToDocumentWithData(slice.primary.content)
     ? {
         type: 'collectionVenue',
@@ -415,9 +351,7 @@ function transformCollectionVenueSlice(
     : undefined;
 }
 
-function transformEmbedSlice(
-  slice: EmbedSlice
-): ParsedSlice<'videoEmbed' | 'soundcloudEmbed', EmbedProps> | undefined {
+function transformEmbedSlice(slice: EmbedSlice): BodySlice | undefined {
   const embed = slice.primary.embed;
 
   if (embed.provider_name === 'Vimeo') {
@@ -481,9 +415,7 @@ function transformEmbedSlice(
   }
 }
 
-function transformContentListSlice(
-  slice: ContentListSlice
-): ParsedSlice<'contentList', SearchResultsProps> {
+function transformContentListSlice(slice: ContentListSlice): BodySlice {
   type ContentListPrismicDocument =
     | PagePrismicDocument
     | EventSeriesPrismicDocument
@@ -533,7 +465,7 @@ function transformContentListSlice(
   };
 }
 
-export function transformBody(body: Body): BodyType {
+export function transformBody(body: Body): BodySlice[] {
   return body
     .map(slice => {
       switch (slice.slice_type) {

--- a/content/webapp/services/prismic/transformers/index.ts
+++ b/content/webapp/services/prismic/transformers/index.ts
@@ -31,7 +31,7 @@ import { ArticleFormat } from '../types/article-format';
 import { ArticleFormatId } from '@weco/common/services/prismic/content-format-ids';
 import * as prismicT from '@prismicio/types';
 import { transformBody } from './body';
-import { isStandfirst } from 'types/body';
+import { isStandfirst } from '../../../types/body';
 
 type Doc = PrismicDocument<CommonPrismicFields>;
 

--- a/content/webapp/services/prismic/transformers/index.ts
+++ b/content/webapp/services/prismic/transformers/index.ts
@@ -31,6 +31,7 @@ import { ArticleFormat } from '../types/article-format';
 import { ArticleFormatId } from '@weco/common/services/prismic/content-format-ids';
 import * as prismicT from '@prismicio/types';
 import { transformBody } from './body';
+import { isStandfirst } from 'types/body';
 
 type Doc = PrismicDocument<CommonPrismicFields>;
 
@@ -147,14 +148,14 @@ export function transformGenericFields(doc: Doc): GenericContentFields {
       : undefined;
 
   const body = data.body ? transformBody(data.body) : [];
-  const standfirst = body.find(slice => slice.type === 'standfirst');
+  const standfirst = body.find(isStandfirst);
   const metadataDescription = asText(data.metadataDescription);
 
   return {
     id: doc.id,
     title: asTitle(data.title),
-    body: body,
-    standfirst: standfirst && standfirst.value,
+    body,
+    standfirst: standfirst?.value,
     promo,
     image,
     metadataDescription,

--- a/content/webapp/types/body.ts
+++ b/content/webapp/types/body.ts
@@ -1,0 +1,79 @@
+import { Props as TableProps } from '@weco/common/views/components/Table/Table';
+import { Props as ContactProps } from '@weco/common/views/components/Contact/Contact';
+import { Props as IframeProps } from '@weco/common/views/components/Iframe/Iframe';
+import { Props as InfoBlockProps } from '@weco/common/views/components/InfoBlock/InfoBlock';
+import { Props as AsyncSearchResultsProps } from '../components/SearchResults/AsyncSearchResults';
+import { Props as QuoteProps } from '../components/Quote/Quote';
+import { Props as ImageGalleryProps } from '../components/ImageGallery/ImageGallery';
+import { Props as DeprecatedImageListProps } from '../components/DeprecatedImageList/DeprecatedImageList';
+import { Props as GifVideoProps } from '../components/GifVideo/GifVideo';
+import { Props as TitledTextListProps } from '../components/TitledTextList/TitledTextList';
+import { Props as TagsGroupProps } from '@weco/common/views/components/TagsGroup/TagsGroup';
+import { Props as MapProps } from '../components/Map/Map';
+import { Props as DiscussionProps } from '../components/Discussion/Discussion';
+import { Props as EmbedProps } from '@weco/common/views/components/VideoEmbed/VideoEmbed';
+import { Props as MediaObjectListProps } from '../components/MediaObjectList/MediaObjectList';
+import * as prismicT from '@prismicio/types';
+import { CaptionedImage } from '@weco/common/model/captioned-image';
+import { Venue } from '@weco/common/model/opening-hours';
+import { Page } from './pages';
+import { EventSeries } from './event-series';
+import { Book } from './books';
+import { Event } from './events';
+import { Article } from './articles';
+import { Exhibition } from './exhibitions';
+import { Card } from './card';
+import { Season } from './seasons';
+import { Guide } from './guides';
+
+export type Weight = 'default' | 'featured' | 'standalone' | 'supporting';
+
+type Slice<TypeName extends string, Value> = {
+  type: TypeName;
+  weight?: Weight;
+  value: Value;
+};
+
+type ContentList = {
+  title?: string;
+  items: (
+    | Page
+    | EventSeries
+    | Book
+    | Event
+    | Article
+    | Exhibition
+    | Card
+    | Season
+    | Guide
+  )[];
+};
+
+export function isContentList(
+  slice: BodySlice
+): slice is BodySlice & { type: 'contentList' } {
+  return slice.type === 'contentList';
+}
+
+export type BodySlice =
+  | Slice<'standfirst', prismicT.RichTextField>
+  | Slice<'text', prismicT.RichTextField>
+  | Slice<'map', MapProps>
+  | Slice<'table', TableProps>
+  | Slice<'mediaObjectList', MediaObjectListProps>
+  | Slice<'contact', ContactProps>
+  | Slice<'picture', CaptionedImage>
+  | Slice<'imageGallery', ImageGalleryProps>
+  | Slice<'deprecatedImageList', DeprecatedImageListProps>
+  | Slice<'gifVideo', GifVideoProps>
+  | Slice<'titledTextList', TitledTextListProps>
+  | Slice<'discussion', DiscussionProps>
+  | Slice<'infoBlock', InfoBlockProps>
+  | Slice<'iframe', IframeProps>
+  | Slice<'quote', QuoteProps>
+  | Slice<'tagList', TagsGroupProps>
+  | Slice<'searchResults', AsyncSearchResultsProps>
+  | Slice<'collectionVenue', { content: Venue; showClosingTimes: boolean }>
+  | Slice<'videoEmbed', EmbedProps>
+  | Slice<'soundcloudEmbed', EmbedProps>
+  | Slice<'contentList', ContentList>;

--- a/content/webapp/types/body.ts
+++ b/content/webapp/types/body.ts
@@ -55,6 +55,24 @@ export function isContentList(
   return slice.type === 'contentList';
 }
 
+export function isVideoEmbed(
+  slice: BodySlice
+): slice is BodySlice & { type: 'videoEmbed' } {
+  return slice.type === 'videoEmbed';
+}
+
+export function isPicture(
+  slice: BodySlice
+): slice is BodySlice & { type: 'picture' } {
+  return slice.type === 'picture';
+}
+
+export function isStandfirst(
+  slice: BodySlice
+): slice is BodySlice & { type: 'standfirst' } {
+  return slice.type === 'standfirst';
+}
+
 export type BodySlice =
   | Slice<'standfirst', prismicT.RichTextField>
   | Slice<'text', prismicT.RichTextField>

--- a/content/webapp/types/card.ts
+++ b/content/webapp/types/card.ts
@@ -6,6 +6,10 @@ import { Season } from './seasons';
 import { Page, ParentPage } from './pages';
 import { Series } from './series';
 import linkResolver from '../services/prismic/link-resolver';
+import { EventSeries } from './event-series';
+import { Book } from './books';
+import { Exhibition } from './exhibitions';
+import { Guide } from './guides';
 
 export type Card = {
   type: 'card';
@@ -18,7 +22,17 @@ export type Card = {
 };
 
 export function convertItemToCardProps(
-  item: Article | Event | Season | Page | Series | ParentPage
+  item:
+    | Article
+    | Event
+    | Season
+    | Page
+    | Series
+    | ParentPage
+    | EventSeries
+    | Book
+    | Exhibition
+    | Guide
 ): Card {
   const format =
     'format' in item
@@ -31,7 +45,7 @@ export function convertItemToCardProps(
 
   return {
     type: 'card',
-    format: format,
+    format: format as any,
     title: item.title,
     order: 'order' in item ? item.order : undefined,
     description: (item.promo && item.promo.caption) ?? undefined,

--- a/content/webapp/types/generic-content-fields.ts
+++ b/content/webapp/types/generic-content-fields.ts
@@ -2,23 +2,13 @@ import { ImagePromo } from './image-promo';
 import { ImageType } from '@weco/common/model/image';
 import { Label } from '@weco/common/model/labels';
 import * as prismicT from '@prismicio/types';
-
-export type Weight = 'default' | 'featured' | 'standalone' | 'supporting';
-
-type BodySlice = {
-  type: string;
-  weight?: Weight;
-  // TODO: Sync up types with the body slices and the components they return
-  value: any;
-};
-
-export type BodyType = BodySlice[];
+import { BodySlice } from './body';
 
 export type GenericContentFields = {
   id: string;
   title: string;
   promo?: ImagePromo;
-  body: BodyType;
+  body: BodySlice[];
   standfirst?: prismicT.RichTextField;
   image?: ImageType;
   metadataDescription?: string;

--- a/content/webapp/utils/page-header.tsx
+++ b/content/webapp/utils/page-header.tsx
@@ -5,6 +5,7 @@ import { FeaturedMedia } from '@weco/common/views/components/PageHeader/PageHead
 import Picture from '@weco/common/views/components/Picture/Picture';
 import VideoEmbed from '@weco/common/views/components/VideoEmbed/VideoEmbed';
 import { ReactElement } from 'react';
+import { isVideoEmbed } from 'types/body';
 import { GenericContentFields } from '../types/generic-content-fields';
 
 export function getFeaturedMedia(
@@ -16,10 +17,11 @@ export function getFeaturedMedia(
   const widescreenImage = getCrop(fields.image, '16:9');
   const { body } = fields;
 
-  const hasFeaturedVideo = body.length > 0 && body[0].type === 'videoEmbed';
+  const featuredVideo =
+    body.length > 0 && isVideoEmbed(body[0]) ? body[0] : undefined;
 
-  const featuredMedia = hasFeaturedVideo ? (
-    <VideoEmbed {...body[0].value} />
+  const featuredMedia = featuredVideo ? (
+    <VideoEmbed {...featuredVideo.value} />
   ) : isPicture && widescreenImage && squareImage ? (
     <Picture
       images={[


### PR DESCRIPTION
This introduces a proper type for body slices that get rendered in components, rather than using `any`. This allows us to lean much more heavily on the type checker for these parts, rather than trusting that they're okay. It's the final part of the work to tidy up the body-handling code.

Because this is a potentially disruptive change, I've run the bulk Prismic checker against it locally; I'll update this PR note when it's done.

I also ended up slicing quite a bit out of the homepage and moving it to the server-side while getting this to compile. 🙌 

Closes https://github.com/wellcomecollection/wellcomecollection.org/issues/7753