### PR TITLE
Wrap overrideDate in london to make it a Moment object

### DIFF
--- a/common/services/prismic/opening-times.ts
+++ b/common/services/prismic/opening-times.ts
@@ -244,9 +244,11 @@ export function getTodaysVenueHours(
   const todayString = todaysDate.format('dddd');
   const exceptionalOpeningHours =
     venue.openingHours.exceptional &&
-    venue.openingHours.exceptional.find(i =>
-      todaysDate.startOf('day').isSame(i.overrideDate.startOf('day'))
-    );
+    venue.openingHours.exceptional.find(i => {
+      return todaysDate
+        .startOf('day')
+        .isSame(london(i.overrideDate).startOf('day'));
+    });
   const regularOpeningHours =
     venue.openingHours.regular &&
     venue.openingHours.regular.find(i => i.dayOfWeek === todayString);


### PR DESCRIPTION
## Who is this for?
People who want the site to work

## What is it doing for them?
Making sure things that should be `Moment` objects are so method calls work.

I don't think this is the _proper_ fix, but it should make things work again.