### PR TITLE
Show "Listen to more from…" on podcast pages, not "read more from…"

### DIFF
--- a/content/webapp/components/SeriesNavigation/SeriesNavigation.tsx
+++ b/content/webapp/components/SeriesNavigation/SeriesNavigation.tsx
@@ -11,16 +11,24 @@ import SearchResults from '../SearchResults/SearchResults';
 type Props = {
   series: Series;
   items: readonly (Article | ArticleScheduleItem)[];
+  isPodcast: boolean;
 };
 
-const SeriesNavigation: FunctionComponent<Props> = ({ series, items }) => {
+const SeriesNavigation: FunctionComponent<Props> = ({
+  series,
+  items,
+  isPodcast,
+}) => {
   const showPosition = !!(series.schedule && series.schedule.length > 0);
+  const title = isPodcast
+    ? `Listen to more from ${series.title}`
+    : `Read more from ${series.title}`;
   return items.length > 0 ? (
     <SpacingComponent>
       <Layout8>
         <SearchResults
           key={series.id}
-          title={`Read more from ${series.title}`}
+          title={title}
           summary={series.promo?.caption}
           items={items}
           showPosition={showPosition}

--- a/content/webapp/pages/article.tsx
+++ b/content/webapp/pages/article.tsx
@@ -30,7 +30,6 @@ import { articleLd } from '../services/prismic/transformers/json-ld';
 import { looksLikePrismicId } from '../services/prismic';
 import { bodySquabblesSeries } from '@weco/common/services/prismic/hardcoded-id';
 import { transformArticle } from '../services/prismic/transformers/articles';
-import * as prismic from '@prismicio/client';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 
 type Props = {
@@ -142,7 +141,10 @@ const ArticlePage: FC<Props> = ({ article, venueProps, jsonLd }) => {
             ? 'my.webcomics.series.series'
             : 'my.articles.series.series';
 
-        const predicates = [prismic.predicate.at(seriesField, series.id)];
+        // Note: we deliberately use a hard-coded string here instead of the
+        // predicate DSL in the Prismic client library, because it means we don't
+        // send the Prismic client library as part of the browser bundle.
+        const predicates = [`[at(${seriesField}, "${series.id}")]`];
 
         const articlesInSeries = series
           ? await fetchArticlesClientSide({ predicates })

--- a/content/webapp/pages/article.tsx
+++ b/content/webapp/pages/article.tsx
@@ -87,7 +87,8 @@ function getNextUp(
   series: Series,
   articles: Article[],
   article: Article,
-  currentPosition?: number
+  currentPosition?: number,
+  isPodcast: boolean
 ): ReactElement | null {
   if (series.schedule.length > 0 && currentPosition) {
     const firstArticleFromSchedule = series.schedule.find(
@@ -108,13 +109,24 @@ function getNextUp(
         : nextArticle || null;
 
     return nextUp ? (
-      <SeriesNavigation key={series.id} series={series} items={[nextUp]} />
+      <SeriesNavigation
+        key={series.id}
+        series={series}
+        items={[nextUp]}
+        isPodcast={isPodcast}
+      />
     ) : null;
   } else {
     const dedupedArticles = articles
       .filter(a => a.id !== article.id)
       .slice(0, 2);
-    return <SeriesNavigation series={series} items={dedupedArticles} />;
+    return (
+      <SeriesNavigation
+        series={series}
+        items={dedupedArticles}
+        isPodcast={isPodcast}
+      />
+    );
   }
 }
 
@@ -279,7 +291,7 @@ const ArticlePage: FC<Props> = ({ article, venueProps, jsonLd }) => {
 
   const Siblings = listOfSeries
     ?.map(({ series, articles }) => {
-      return getNextUp(series, articles, article, positionInSerial);
+      return getNextUp(series, articles, article, positionInSerial, isPodcast);
     })
     .filter(Boolean);
 


### PR DESCRIPTION
## Who is this for?

People who listen to podcasts.

## What is it doing for them?

Using the right verbs to describe their activity.

This was discussed months ago and a wording agreed by Dom, we just never implemented it. I happened to spot we had the boolean lying around to condition on while reading some code, so figured I'd squash this. Fixes https://github.com/wellcomecollection/wellcomecollection.org/issues/7502