### PR TITLE
If an item is restricted, don't show it on the page

### DIFF
--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -69,7 +69,7 @@ function getItemLinkState({
   if (accessCondition === 'permission-required' && sierraIdFromManifestUrl) {
     return 'useLibraryLink';
   }
-  if (accessCondition === 'closed') {
+  if (accessCondition === 'closed' || accessCondition === 'restricted') {
     return 'useNoLink';
   }
   if (itemUrl && !(audioItems.length > 0) && !video) {


### PR DESCRIPTION
## Who is this for?

People looking at restricted digitised items, e.g. the audio file on https://wellcomecollection.org/works/ae9m5mbx

## What is it doing for them?

Making sure a broken audio player doesn't appear on the page.

I've tested this locally and confirmed that (1) the audio player no longer appears when it's restricted and (2) the audio player still appears when it's open.

For https://github.com/wellcomecollection/wellcomecollection.org/issues/7861