### PR TITLE
Surface repeated character pattern in updated password change modal

### DIFF
--- a/identity/webapp/src/frontend/MyAccount/ChangePassword.test.tsx
+++ b/identity/webapp/src/frontend/MyAccount/ChangePassword.test.tsx
@@ -333,7 +333,7 @@ describe('ChangePassword', () => {
       );
       userEvent.click(screen.getByRole('button', { name: /update password/i }));
       expect(await screen.findByRole('alert')).toHaveTextContent(
-        /an unknown error occurred/i
+        /'There is an issue with this library account password. To resolve this, please contact Library Enquiries (library@wellcomecollection.org)./i
       );
     });
   });

--- a/identity/webapp/src/frontend/MyAccount/ChangePassword.test.tsx
+++ b/identity/webapp/src/frontend/MyAccount/ChangePassword.test.tsx
@@ -333,7 +333,7 @@ describe('ChangePassword', () => {
       );
       userEvent.click(screen.getByRole('button', { name: /update password/i }));
       expect(await screen.findByRole('alert')).toHaveTextContent(
-        /'There is an issue with this library account password. To resolve this, please contact Library Enquiries (library@wellcomecollection.org)./i
+        'There is an issue with this library account password. To resolve this, please contact Library Enquiries (library@wellcomecollection.org).'
       );
     });
   });

--- a/identity/webapp/src/frontend/MyAccount/ChangePassword.tsx
+++ b/identity/webapp/src/frontend/MyAccount/ChangePassword.tsx
@@ -86,8 +86,18 @@ export const ChangePassword: React.FC<ChangeDetailsModalContentProps> = ({
         });
         break;
       }
+      case UpdatePasswordError.REPEATED_CHARACTERS: {
+        setError('newPassword', {
+          type: 'manual',
+          message:
+            "Repeating characters, such as aaaa, ababab, abcabc, won't be accepted as a password.",
+        });
+        break;
+      }
       case UpdatePasswordError.UNKNOWN: {
-        setSubmissionErrorMessage('An unknown error occurred');
+        setSubmissionErrorMessage(
+          'There is an issue with this library account password. To resolve this, please contact Library Enquiries (library@wellcomecollection.org).'
+        );
         break;
       }
     }

--- a/identity/webapp/src/frontend/hooks/useUpdatePassword.ts
+++ b/identity/webapp/src/frontend/hooks/useUpdatePassword.ts
@@ -7,6 +7,7 @@ export enum UpdatePasswordError { // eslint-disable-line no-shadow
   BRUTE_FORCE_BLOCKED,
   DID_NOT_MEET_POLICY,
   UNKNOWN,
+  REPEATED_CHARACTERS,
 }
 
 type UseUpdatePasswordMutation = {
@@ -37,6 +38,19 @@ export function useUpdatePassword(): UseUpdatePasswordMutation {
       })
       .catch((err: AxiosError) => {
         switch (err.response?.status) {
+          case 400: {
+            if (
+              err.response?.data.message.includes(
+                'PIN is not valid : PIN is trivial'
+              )
+            ) {
+              setError(UpdatePasswordError.REPEATED_CHARACTERS);
+              break;
+            } else {
+              setError(UpdatePasswordError.UNKNOWN);
+              break;
+            }
+          }
           case 401: {
             setError(UpdatePasswordError.INCORRECT_PASSWORD);
             break;


### PR DESCRIPTION
## Who is this for?

Anyone who wants to change their password and be told there's a repeated pattern that is not accepted by sierra.
https://github.com/wellcomecollection/wellcomecollection.org/issues/7816

## What is it doing for them?

Previously a patron would get an 'unknown error' when these error occurred. I was trying to just catch the full error in Identity and show that in the relevant place, then realised I would need to make sure that happens where ever we render the change password modal. Last week I thought the modal comes from auth0 direct, but we actually handle the rendering of this in experience. I allowed for the specific case of repeated characters being used in the error cases within updatePassword. While I was there I updated the 'unknown error' to something more like what we have already as a default error elsewhere on site. 

## How does this look?
After a user has put in their current and new password, if repeated characters are used in the new password, the following screen appears.

![Screenshot 2022-04-04 at 16 29 19](https://user-images.githubusercontent.com/16557524/161578700-3318a4eb-2561-4dca-89f8-1d1bd86fe4bc.png)

