### PR TITLE
Make regex for eventbrite id more permissive

### DIFF
--- a/content/webapp/services/prismic/transformers/events.test.ts
+++ b/content/webapp/services/prismic/transformers/events.test.ts
@@ -1,5 +1,5 @@
 import { groupEventsBy } from '../../../services/prismic/events';
-import { getLastEndTime } from './events';
+import { getLastEndTime, getEventbriteId } from './events';
 import { data as uiEventData } from '../../../components/CardGrid/DailyTourPromo';
 import { transformTimestamp } from '.';
 import { EventTime } from '../../../types/events';
@@ -82,21 +82,35 @@ const multiDayEvents = [
     ],
   },
 ];
-it('groups events by daterange', () => {
-  const eventsGroupedByDay = groupEventsBy(multiDayEvents, 'day');
-  expect(eventsGroupedByDay.length).toBe(7);
-  eventsGroupedByDay.forEach((eventsGroup, i) => {
-    // Friday
-    if (i === 4) {
-      expect(eventsGroup.events.length).toBe(0);
-    } else {
-      expect(eventsGroup.events.length).toBe(1);
-    }
-  });
-});
 
-it('returns the last end time from the lastest date', () => {
-  const lastEndTime = getLastEndTime(eventTimes);
-  const expectedEndTime = transformTimestamp('2020-02-18T19:00:00+0000');
-  expect(lastEndTime).toStrictEqual(expectedEndTime);
+describe('Events', () => {
+  it('groups events by daterange', () => {
+    const eventsGroupedByDay = groupEventsBy(multiDayEvents, 'day');
+    expect(eventsGroupedByDay.length).toBe(7);
+    eventsGroupedByDay.forEach((eventsGroup, i) => {
+      // Friday
+      if (i === 4) {
+        expect(eventsGroup.events.length).toBe(0);
+      } else {
+        expect(eventsGroup.events.length).toBe(1);
+      }
+    });
+  });
+
+  it('returns the last end time from the lastest date', () => {
+    const lastEndTime = getLastEndTime(eventTimes);
+    const expectedEndTime = transformTimestamp('2020-02-18T19:00:00+0000');
+    expect(lastEndTime).toStrictEqual(expectedEndTime);
+  });
+
+  it('gets Eventbrite IDs from embed URLs', () => {
+    const embedUrl1 =
+      'https://www.eventbrite.com/e/test-event-1-tickets-5398972389';
+    const embedUrl2 = 'https://www.eventbrite.com/e/5398972389';
+    const embedUrl3 = 'https://www.eventbrite.com';
+
+    expect(getEventbriteId(embedUrl1)).toBe('test-event-1-tickets-5398972389');
+    expect(getEventbriteId(embedUrl2)).toBe('5398972389');
+    expect(getEventbriteId(embedUrl3)).toBeUndefined();
+  });
 });

--- a/content/webapp/services/prismic/transformers/events.ts
+++ b/content/webapp/services/prismic/transformers/events.ts
@@ -81,6 +81,12 @@ export function transformEventPolicyLabels(
     .map(label => transformLabelType(label));
 }
 
+export function getEventbriteId(url: string): string | undefined {
+  const match = /\/e\/(.+)/.exec(url);
+
+  return match?.[1];
+}
+
 export function transformEvent(
   document: EventPrismicDocument,
   scheduleQuery?: Query<EventPrismicDocument>
@@ -119,12 +125,9 @@ export function transformEvent(
     )
     .filter(isNotUndefined);
 
-  const matchedId =
-    data.eventbriteEvent && data.eventbriteEvent.embed_url
-      ? /\/e\/(.+)/.exec(data.eventbriteEvent.embed_url)
-      : null;
-  const eventbriteId =
-    data.eventbriteEvent && matchedId !== null ? matchedId[1] : '';
+  const eventbriteId = data.eventbriteEvent?.embed_url
+    ? getEventbriteId(data.eventbriteEvent.embed_url)
+    : undefined;
 
   const audiences: Audience[] = data.audiences
     .map(audience =>

--- a/content/webapp/services/prismic/transformers/events.ts
+++ b/content/webapp/services/prismic/transformers/events.ts
@@ -121,7 +121,7 @@ export function transformEvent(
 
   const matchedId =
     data.eventbriteEvent && data.eventbriteEvent.embed_url
-      ? /\/e\/([0-9]+)/.exec(data.eventbriteEvent.embed_url)
+      ? /\/e\/(.+)/.exec(data.eventbriteEvent.embed_url)
       : null;
   const eventbriteId =
     data.eventbriteEvent && matchedId !== null ? matchedId[1] : '';


### PR DESCRIPTION
We currently only search for a number after the `/e/` in the eventbrite URL, but eventbrite urls now contain part of the events title also. It's fair to say _anything_ after the `/e/` is the ID, so switching the regex from `[0-9]` to `.` seems reasonable.