### PR TITLE
Move event contributors below yellow box

### DIFF
--- a/content/webapp/pages/event.tsx
+++ b/content/webapp/pages/event.tsx
@@ -324,7 +324,6 @@ const EventPage: NextPage<Props> = ({ jsonEvent }: Props) => {
               />
             </>
           )}
-
         {!event.isPast && !showTicketSalesStart(event.ticketSalesStart) && (
           <>
             {event.eventbriteId && (
@@ -429,7 +428,6 @@ const EventPage: NextPage<Props> = ({ jsonEvent }: Props) => {
               )}
           </>
         )}
-
         <InfoBox
           title="Need to know"
           items={
@@ -475,14 +473,16 @@ const EventPage: NextPage<Props> = ({ jsonEvent }: Props) => {
             </a>
           </p>
         </InfoBox>
-
+        {/* We deliberately position the contributors below the schedule, so a
+        reader can see all the events in a festival/multi-part event before they
+        see the contributors. This was agreed in April 2022 with the content
+        team. */}
         {event.contributors.length > 0 && (
           <Contributors
             contributors={event.contributors}
             titlePrefix="About your"
           />
         )}
-
         {event.audiences.map(audience => {
           if (audience.description) {
             return (

--- a/content/webapp/pages/event.tsx
+++ b/content/webapp/pages/event.tsx
@@ -302,12 +302,6 @@ const EventPage: NextPage<Props> = ({ jsonEvent }: Props) => {
         // We hide contributors as we render them higher up the page on events
         hideContributors={true}
       >
-        {event.contributors.length > 0 && (
-          <Contributors
-            contributors={event.contributors}
-            titlePrefix="About your"
-          />
-        )}
         <DateWrapper>
           <h2 id="dates">Dates</h2>
           {DateList(event)}
@@ -481,6 +475,13 @@ const EventPage: NextPage<Props> = ({ jsonEvent }: Props) => {
             </a>
           </p>
         </InfoBox>
+
+        {event.contributors.length > 0 && (
+          <Contributors
+            contributors={event.contributors}
+            titlePrefix="About your"
+          />
+        )}
 
         {event.audiences.map(audience => {
           if (audience.description) {


### PR DESCRIPTION
## Who is this for?
Everyone

## What is it doing for them?
Moving the more relevant event content closer to the top of the page

