### PR TITLE
Run the yarn commands in a single Docker step

### DIFF
--- a/cardigan/Dockerfile
+++ b/cardigan/Dockerfile
@@ -13,16 +13,10 @@ ADD ./catalogue/webapp ./catalogue/webapp
 ADD ./content/webapp ./content/webapp
 ADD ./toggles/webapp ./toggles/webapp
 ADD ./identity/webapp ./identity/webapp
-
-RUN yarn setupCommon && \
-    yarn cache clean
-
 ADD ./cardigan ./cardigan
 
-WORKDIR /usr/src/app/webapp/cardigan
+RUN ./cardigan/run_yarn.sh
 
-RUN yarn install && \
-    yarn build && \
-    yarn cache clean
+WORKDIR /usr/src/app/webapp/cardigan
 
 CMD ["true"]

--- a/cardigan/run_yarn.sh
+++ b/cardigan/run_yarn.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Because we want to run yarn twice (once in the root, once in 'cardigan'),
+# we run them both in this bash script as a single layer in the Docker image.
+#
+# This is meant to make building the Cardigan image faster -- we only have to
+# fetch the npm cache once, vs running it in multiple layers and having to
+# re-fetch each time.
+#
+# Conceptually these are equivalent to separate RUN steps in the Dockerfile,
+# but this makes CI go faster.
+#
+# TODO: Do we even need the setupCommon step, or can we bin the first step
+# and collapse this back into the Dockerfile?
+
+set -o errexit
+set -o nounset
+
+yarn setupCommon
+
+cd cardigan
+yarn install
+yarn build
+
+yarn cache clean


### PR DESCRIPTION
## Who is this for?

Devs.

## What is it doing for them?

Trying to make the experience build a bit faster; the Cardigan build dominates pull request builds and I think we can get a fairly quick win; locally this shaves off about a minute off the build.

I'm sure we can make it faster still, but this change doesn't require as much investigation/thinking.