### PR TITLE
Make sure we show projects on season pages

### DIFF
--- a/content/webapp/components/CardGrid/CardGrid.tsx
+++ b/content/webapp/components/CardGrid/CardGrid.tsx
@@ -66,7 +66,9 @@ const CardGrid: FunctionComponent<Props> = ({
                 />
               )}
               {item.type === 'books' && <BookPromo book={item} />}
-              {(item.type === 'pages' || item.type === 'series') && (
+              {(item.type === 'pages' ||
+                item.type === 'series' ||
+                item.type === 'projects') && (
                 <Card item={convertItemToCardProps(item)} />
               )}
             </div>

--- a/content/webapp/services/prismic/transformers/projects.ts
+++ b/content/webapp/services/prismic/transformers/projects.ts
@@ -1,6 +1,10 @@
 import { Project } from '../../../types/projects';
 import { ProjectPrismicDocument } from '../types/projects';
-import { transformGenericFields, transformSingleLevelGroup } from '.';
+import {
+  transformFormat,
+  transformGenericFields,
+  transformSingleLevelGroup,
+} from '.';
 import { transformSeason } from './seasons';
 import { SeasonPrismicDocument } from '../types/seasons';
 
@@ -17,6 +21,7 @@ export function transformProject(document: ProjectPrismicDocument): Project {
   return {
     type: 'projects',
     ...genericFields,
+    format: transformFormat(document),
     seasons,
     promo: promo && promo.image ? promo : undefined,
   };

--- a/content/webapp/types/card.ts
+++ b/content/webapp/types/card.ts
@@ -10,6 +10,7 @@ import { EventSeries } from './event-series';
 import { Book } from './books';
 import { Exhibition } from './exhibitions';
 import { Guide } from './guides';
+import { Project } from './projects';
 
 export type Card = {
   type: 'card';
@@ -33,6 +34,7 @@ export function convertItemToCardProps(
     | Book
     | Exhibition
     | Guide
+    | Project
 ): Card {
   const format =
     'format' in item

--- a/content/webapp/types/projects.ts
+++ b/content/webapp/types/projects.ts
@@ -1,7 +1,9 @@
+import { Format } from './format';
 import { GenericContentFields } from './generic-content-fields';
 import { Season } from './seasons';
 
 export type Project = GenericContentFields & {
   type: 'projects';
+  format: Format | undefined;
   seasons: Season[];
 };


### PR DESCRIPTION
## Who is this for?

Danny.

## What is it doing for them?

Making project pages appear on season pages, per [his request in Slack](https://wellcome.slack.com/archives/C8X9YKM5X/p1649662725784829). We're already fetching them in the page's server-side props, but then they were being passed to the CardGrid component, which didn't know how to render them – this should fix that.

I also tweaked the Project model so we get the label telling us what sort of thing this project is (e.g. "Film").

<img width="1380" alt="Screenshot 2022-04-11 at 09 12 27" src="https://user-images.githubusercontent.com/301220/162693473-dcdfbd5a-a689-434c-82b8-3997e47e1846.png">

