### PR TITLE
Don't intercap the name "Tripadvisor" in the footer

### DIFF
--- a/common/views/components/Footer/FooterSocial.tsx
+++ b/common/views/components/Footer/FooterSocial.tsx
@@ -115,8 +115,8 @@ const items: SocialItem[] = [
   },
   {
     url: 'https://www.tripadvisor.co.uk/Attraction_Review-g186338-d662065-Reviews-Wellcome_Collection-London_England.html',
-    title: 'TripAdvisor',
-    service: 'TripAdvisor',
+    title: 'Tripadvisor',
+    service: 'Tripadvisor',
     icon: tripadvisor,
   },
 ];


### PR DESCRIPTION
## Who is this for?

Fans of branding and spelling.

## What is it doing for them?

Getting the Tripadvisor brand right.

<img width="214" alt="Screenshot 2022-04-11 at 09 43 33" src="https://user-images.githubusercontent.com/301220/162699064-61061b0d-096e-45b7-acc8-009eb0adc2b4.png">