### PR TITLE
Calendar bug

### DIFF
--- a/catalogue/webapp/components/Calendar/Calendar.tsx
+++ b/catalogue/webapp/components/Calendar/Calendar.tsx
@@ -168,9 +168,13 @@ const Calendar: FC<Props> = ({
             aria-label="previous month"
             disabled={previousMonthDisabled}
             onClick={() => {
-              const newMonth = tabbableDate.clone().subtract(1, 'month');
               setUpdateFocus(false); // if we are navigating the calendar by month controls, we don't want to update the focus
-              setTabbableDate(newMonth);
+              const newMonth = tabbableDate.clone().subtract(1, 'month');
+              if (newMonth.isBefore(min, 'day')) {
+                setTabbableDate(min);
+              } else {
+                setTabbableDate(newMonth);
+              }
               setPreviousMonthDisabled(
                 newMonth.clone().subtract(1, 'month').isBefore(min, 'month')
               );
@@ -193,9 +197,13 @@ const Calendar: FC<Props> = ({
             aria-label="next month"
             disabled={nextMonthDisabled}
             onClick={() => {
-              const newMonth = tabbableDate.clone().add(1, 'month');
               setUpdateFocus(false); // if we are navigating the calendar by month controls, we don't want to update the focus
-              setTabbableDate(newMonth);
+              const newMonth = tabbableDate.clone().add(1, 'month');
+              if (newMonth.isAfter(max, 'day')) {
+                setTabbableDate(max);
+              } else {
+                setTabbableDate(newMonth);
+              }
               setPreviousMonthDisabled(
                 newMonth.clone().subtract(1, 'month').isBefore(min, 'month')
               );


### PR DESCRIPTION
Relates to #7756

Using the month controls on the calendar could lead to a situation where a user could tab to a date outside the available range. This stops that from happening
