### PR TITLE
Make sure we pick the square image for contributors

### DIFF
--- a/content/webapp/components/Contributors/Contributor.tsx
+++ b/content/webapp/components/Contributors/Contributor.tsx
@@ -4,6 +4,7 @@ import LinkLabels from '@weco/common/views/components/LinkLabels/LinkLabels';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
 import Space from '@weco/common/views/components/styled/Space';
 import PrismicImage from '../PrismicImage/PrismicImage';
+import { getCrop } from '@weco/common/model/image';
 import { FC } from 'react';
 
 const Contributor: FC<ContributorType> = ({
@@ -13,6 +14,8 @@ const Contributor: FC<ContributorType> = ({
 }: ContributorType) => {
   const descriptionToRender = description || contributor.description;
 
+  const squareImage = getCrop(contributor.image, 'square');
+
   return (
     <div className="grid">
       <div className={`flex ${grid({ s: 12, m: 12, l: 12, xl: 12 })}`}>
@@ -20,7 +23,7 @@ const Contributor: FC<ContributorType> = ({
           style={{ minWidth: '78px' }}
           h={{ size: 'm', properties: ['margin-right'] }}
         >
-          {contributor.image && contributor.type === 'people' && (
+          {squareImage && contributor.type === 'people' && (
             <div
               style={{
                 width: 72,
@@ -35,13 +38,13 @@ const Contributor: FC<ContributorType> = ({
                   transform: 'rotateZ(6deg) scale(1.2)',
                 }}
               >
-                <PrismicImage image={contributor.image} maxWidth={72} />
+                <PrismicImage image={squareImage} maxWidth={72} />
               </div>
             </div>
           )}
-          {contributor.image && contributor.type === 'organisations' && (
+          {squareImage && contributor.type === 'organisations' && (
             <div style={{ width: '72px' }}>
-              <PrismicImage image={contributor.image} maxWidth={72} />
+              <PrismicImage image={squareImage} maxWidth={72} />
             </div>
           )}
         </Space>

--- a/content/webapp/components/Contributors/Contributor.tsx
+++ b/content/webapp/components/Contributors/Contributor.tsx
@@ -4,8 +4,13 @@ import LinkLabels from '@weco/common/views/components/LinkLabels/LinkLabels';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
 import Space from '@weco/common/views/components/styled/Space';
 import PrismicImage from '../PrismicImage/PrismicImage';
+import { FC } from 'react';
 
-const Contributor = ({ contributor, role, description }: ContributorType) => {
+const Contributor: FC<ContributorType> = ({
+  contributor,
+  role,
+  description,
+}: ContributorType) => {
   const descriptionToRender = description || contributor.description;
 
   return (


### PR DESCRIPTION
## Who is this for?

Ben.

## What is it doing for them?

Picking the correct contributor image. See https://wellcome.slack.com/archives/C8X9YKM5X/p1650539203095679

As best I can tell, this has only ever worked by coincidence – we'd use the default crop of the contributor image, which has always been a square crop. It's only when we got a contributor image which was rectangular that this bug finally became noticeable (although it might affect older pages too).

Verified as working locally.