### PR TITLE
Availabilities are now like other filters

### DIFF
--- a/common/test/fixtures/catalogueApi/work.ts
+++ b/common/test/fixtures/catalogueApi/work.ts
@@ -293,8 +293,8 @@ export const workFixture: Work = {
   availableOnline: true,
   availabilities: [
     {
-      id: 'in-library',
-      label: 'In the library',
+      id: 'closed-stores',
+      label: 'Closed stores',
       type: 'Availability',
     },
     {
@@ -376,8 +376,8 @@ export const workWithLibrarySeriesPartOf: Work = {
   alternativeTitles: [],
   availabilities: [
     {
-      id: 'in-library',
-      label: 'In the library',
+      id: 'open-shelves',
+      label: 'Open shelves',
       type: 'Availability',
     },
   ],
@@ -544,8 +544,8 @@ export const workWithPartOf: Work = {
   availableOnline: true,
   availabilities: [
     {
-      id: 'in-library',
-      label: 'In the library',
+      id: 'closed-stores',
+      label: 'Closed stores',
       type: 'Availability',
     },
     {
@@ -717,8 +717,8 @@ export const workWithPartOf: Work = {
 export const workWithMixedPartOf: Work = {
   availabilities: [
     {
-      id: 'in-library',
-      label: 'In the library',
+      id: 'closed-stores',
+      label: 'Closed stores',
       type: 'Availability',
     },
   ],

--- a/common/test/fixtures/catalogueApi/works-aggregations.ts
+++ b/common/test/fixtures/catalogueApi/works-aggregations.ts
@@ -2480,11 +2480,20 @@ const aggregations: CatalogueResultsList<Work> = {
         },
         {
           data: {
-            id: 'in-library',
-            label: 'In the library',
+            id: 'closed-stores',
+            label: 'Closed stores',
             type: 'Availability',
           },
           count: 52178,
+          type: 'AggregationBucket',
+        },
+        {
+          data: {
+            id: 'open-shelves',
+            label: 'Open shelves',
+            type: 'Availability',
+          },
+          count: 12345,
           type: 'AggregationBucket',
         },
       ],

--- a/common/views/components/SearchFilters/SearchFiltersDesktop.tsx
+++ b/common/views/components/SearchFilters/SearchFiltersDesktop.tsx
@@ -135,6 +135,8 @@ const ColorFilter = ({ f, changeHandler }: ColorFilterProps) => {
   );
 };
 
+const nVisibleFilters = 3;
+
 const SearchFiltersDesktop: FunctionComponent<SearchFiltersSharedProps> = ({
   query,
   changeHandler,
@@ -145,12 +147,8 @@ const SearchFiltersDesktop: FunctionComponent<SearchFiltersSharedProps> = ({
   const [showMoreFiltersModal, setShowMoreFiltersModal] = useState(false);
   const openMoreFiltersButtonRef = useRef(null);
 
-  const availabilitiesFilter = filters.find(
-    ({ id }) => id === 'availabilities'
-  );
-  const otherFilters = filters.filter(({ id }) => id !== 'availabilities');
-  const visibleFilters = otherFilters.slice(0, 2);
-  const modalFilters = otherFilters.slice(2);
+  const visibleFilters = filters.slice(0, nVisibleFilters);
+  const modalFilters = filters.slice(nVisibleFilters);
 
   return (
     <>
@@ -247,60 +245,6 @@ const SearchFiltersDesktop: FunctionComponent<SearchFiltersSharedProps> = ({
               </Space>
             )}
           </Space>
-
-          {availabilitiesFilter && availabilitiesFilter.type === 'checkbox' && (
-            <Space
-              v={{ size: 'm', properties: ['margin-bottom'] }}
-              className={classNames({
-                'flex flex--v-center': true,
-              })}
-            >
-              <Icon icon={eye} />
-              <Space
-                h={{ size: 's', properties: ['margin-left'] }}
-                className={classNames({
-                  [font('hnb', 5)]: true,
-                })}
-              >
-                <AlignFont>Show items available</AlignFont>
-              </Space>
-              <Space as="span" h={{ size: 's', properties: ['margin-left'] }}>
-                <ul
-                  className={classNames({
-                    'no-margin no-padding plain-list flex': true,
-                    [font('hnr', 5)]: true,
-                  })}
-                >
-                  {availabilitiesFilter.options
-                    .slice()
-                    // Hack: Ensure 'Online' appears before 'In the library'
-                    .sort(({ label: a }, { label: b }) => b.localeCompare(a))
-                    .map(({ id, label, count, value, selected }) => {
-                      return (
-                        <Space
-                          as="li"
-                          h={{ size: 's', properties: ['margin-left'] }}
-                          key={id}
-                          className={classNames({
-                            flex: true,
-                          })}
-                        >
-                          <CheckboxRadio
-                            id={id}
-                            type={`checkbox`}
-                            text={`${label} (${count})`}
-                            value={value}
-                            name={availabilitiesFilter.id}
-                            checked={selected}
-                            onChange={changeHandler}
-                          />
-                        </Space>
-                      );
-                    })}
-                </ul>
-              </Space>
-            </Space>
-          )}
         </Space>
       </Space>
 

--- a/playwright/test/works-search.test.ts
+++ b/playwright/test/works-search.test.ts
@@ -87,14 +87,15 @@ describe('Scenario 1: The person is looking for an archive', () => {
   });
 });
 
-describe('Scenario 2: The person is searching for a work in the physical library', () => {
+describe('Scenario 2: The person is searching for a work on open shelves', () => {
   test('the work should be browsable to from the search results', async () => {
     await worksSearch();
     await searchFor('Miasma');
-    await selectCheckbox('In the library');
+    await openDropdown('Location');
+    await selectCheckbox('Open shelves');
     await navigateToNextPage();
 
-    expectSearchParam('availabilities', 'in-library');
+    expectSearchParam('availabilities', 'open-shelves');
 
     await navigateToResult(6);
   });
@@ -124,5 +125,19 @@ describe('Scenario 4: The person is searching for a work from Wellcome Images', 
     expectSearchParam('workType', 'q');
 
     await navigateToResult(1);
+  });
+});
+
+describe('Scenario 2: The person is searching for a work in closed stores', () => {
+  test('the work should be browsable to from the search results', async () => {
+    await worksSearch();
+    await searchFor('Miasma');
+    await openDropdown('Location');
+    await selectCheckbox('Closed stores');
+    await navigateToNextPage();
+
+    expectSearchParam('availabilities', 'closed-stores');
+
+    await navigateToResult(6);
   });
 });


### PR DESCRIPTION
There are 3 types of availability, so we're making it into a dropdown - this "just works". To be (vaguely) synchronised with the deployment of https://github.com/wellcomecollection/catalogue-api/pull/395.

<img width="648" alt="image" src="https://user-images.githubusercontent.com/4429247/165345510-89392693-5591-4309-a4c2-be595b92c088.png">

<img width="477" alt="image" src="https://user-images.githubusercontent.com/4429247/165345541-c2eaa633-fc56-4821-a466-c08b35a47fc1.png">
