### PR TITLE
Use redirect instead of axios

### DIFF
--- a/identity/webapp/pages/api/registration.ts
+++ b/identity/webapp/pages/api/registration.ts
@@ -1,6 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { generateNewToken, decodeToken } from '../../src/utility/jwt-codec';
-import axios from 'axios';
 import getConfig from 'next/config';
 
 const { serverRuntimeConfig: config } = getConfig();
@@ -29,15 +28,10 @@ export default (req: NextApiRequest, res: NextApiResponse): void => {
         const newToken = generateNewToken(decodedToken, state, formData);
         const redirectUri = `${config.auth0.domain}/continue`;
 
-        axios
-          .post(redirectUri, { token: newToken })
-          .then(() => {
-            res.redirect(302, `/account`);
-          })
-          .catch(error => {
-            console.error(error);
-            res.redirect(302, `/account/error`);
-          });
+        res.redirect(
+          302,
+          `${redirectUri}?session_token=${newToken}&state=${state}`
+        );
       }
     } catch (error) {
       console.error(error);


### PR DESCRIPTION
Working version of redirecting from the Auth0 action using `res.redirect` and sending the token/state as query params. In draft since the docs don't recommend doing it this way. We haven't been able to make it work using the recommended flow, though, and have [asked a question on the Auth0 community forum](https://community.auth0.com/t/400-error-after-post-when-redirecting-with-an-action/82478). Will wait to hear back on that before deciding what to do with this PR.

__Update:__
The trail's gone cold on why `POST` wouldn't work, but on closer inspection, the requirement to `POST` is only referenced in terms of sending information ['on the front channel'](https://auth0.com/docs/customize/actions/flows-and-triggers/login-flow/redirect-with-actions#send-data-on-the-front-channel), and since we're using a NextJS api route, I don't think this is something we need to adhere to.