### PR TITLE
Search query input is not required

### DIFF
--- a/common/views/components/SearchForm/SearchForm.tsx
+++ b/common/views/components/SearchForm/SearchForm.tsx
@@ -195,7 +195,6 @@ const SearchForm = forwardRef(
               value={inputQuery}
               setValue={setInputQuery}
               ref={searchInput}
-              required={true}
               big={true}
               placeholder={''}
               ariaLabel={


### PR DESCRIPTION
Some users want to be able to do a filters-only search, they already have the option of navigating to `/works` but this makes it a bit easier to get there