### PR TITLE
Add 'view_archive' event for heatmap trigger

### DIFF
--- a/catalogue/webapp/components/Work/Work.tsx
+++ b/catalogue/webapp/components/Work/Work.tsx
@@ -46,7 +46,7 @@ const Work: FunctionComponent<Props> = ({
     (work.partOf.length > 0 && work.partOf[0].totalParts)
   );
 
-  useHotjar(isArchive);
+  useHotjar(isArchive, 'view_archive');
 
   const workData = {
     workType: (work.workType ? work.workType.label : '').toLocaleLowerCase(),


### PR DESCRIPTION
☝️

In order to overlay heatmap data on an archive page, we need to use [hotjar events](https://help.hotjar.com/hc/en-us/articles/115011867948) as there's nothing in the URL to distinguish a work from an archive work.