### PR TITLE
Fix the sorting of events on the "What's on" page

### DIFF
--- a/content/webapp/components/EventsByMonth/EventsByMonth.tsx
+++ b/content/webapp/components/EventsByMonth/EventsByMonth.tsx
@@ -6,7 +6,12 @@ import { Link } from '../../types/link';
 import Space from '@weco/common/views/components/styled/Space';
 import CssGridContainer from '@weco/common/views/components/styled/CssGridContainer';
 import CardGrid from '../CardGrid/CardGrid';
-import { groupEventsByMonth, parseLabel, startOf } from './group-event-utils';
+import {
+  groupEventsByMonth,
+  parseLabel,
+  sortByEarliestFutureDateRange,
+  startOf,
+} from './group-event-utils';
 
 type Props = {
   events: EventBasic[];

--- a/content/webapp/components/EventsByMonth/EventsByMonth.tsx
+++ b/content/webapp/components/EventsByMonth/EventsByMonth.tsx
@@ -27,7 +27,7 @@ class EventsByMonth extends Component<Props, State> {
     activeId: undefined,
   };
 
-  render() {
+  render(): JSX.Element {
     const { events, links } = this.props;
     const { activeId } = this.state;
     const monthsIndex = {

--- a/content/webapp/components/EventsByMonth/EventsByMonth.tsx
+++ b/content/webapp/components/EventsByMonth/EventsByMonth.tsx
@@ -1,6 +1,4 @@
 import { Component } from 'react';
-import sortBy from 'lodash.sortby';
-import { getEarliestFutureDateRange } from '@weco/common/utils/dates';
 import { classNames, cssGrid } from '@weco/common/utils/classnames';
 import SegmentedControl from '@weco/common/views/components/SegmentedControl/SegmentedControl';
 import { EventBasic } from '../../types/events';
@@ -64,18 +62,10 @@ class EventsByMonth extends Component<Props, State> {
 
     // Need to order the events for each month based on their earliest future date range
     Object.keys(eventsInMonths).map(label => {
-      eventsInMonths[label] = sortBy(eventsInMonths[label], [
-        m => {
-          const times = m.times.map(time => ({
-            start: time.range.startDateTime,
-            end: time.range.endDateTime,
-          }));
-          const fromDate = startOf(parseLabel(label));
-
-          const earliestRange = getEarliestFutureDateRange(times, fromDate);
-          return earliestRange && earliestRange.start;
-        },
-      ]);
+      eventsInMonths[label] = sortByEarliestFutureDateRange(
+        label,
+        eventsInMonths[label]
+      );
     });
 
     return (

--- a/content/webapp/components/EventsByMonth/EventsByMonth.tsx
+++ b/content/webapp/components/EventsByMonth/EventsByMonth.tsx
@@ -68,7 +68,6 @@ class EventsByMonth extends Component<Props, State> {
     // Need to order the events for each month based on their earliest future date range
     Object.keys(eventsInMonths).map(label => {
       eventsInMonths[label] = sortByEarliestFutureDateRange(
-        label,
         eventsInMonths[label]
       );
     });

--- a/content/webapp/components/EventsByMonth/group-event-utils.test.ts
+++ b/content/webapp/components/EventsByMonth/group-event-utils.test.ts
@@ -3,6 +3,7 @@ import {
   findMonthsThatEventSpans,
   getMonthsInDateRange,
   groupEventsByMonth,
+  sortByEarliestFutureDateRange,
 } from './group-event-utils';
 
 describe('createLabel', () => {
@@ -115,5 +116,96 @@ describe('groupEventsByMonth', () => {
       '2101-02': [event1, event2],
       '2101-04': [event2],
     });
+  });
+});
+
+describe('sortByEarliestFutureDateRange', () => {
+  it('sorts a group of events correctly', () => {
+    // These examples are based on events from a bug report, where an event
+    // happening at the end of the month was appearing one happening at the
+    // start of the month, because the later event had only just been added
+    // to Prismic.
+    //
+    // See https://wellcome.slack.com/archives/C8X9YKM5X/p1651224877047299
+    const eventSlalom = {
+      title: 'Slalom',
+      times: [
+        {
+          range: {
+            startDateTime: new Date('2022-05-25T23:00:00.000Z'),
+            endDateTime: new Date('2022-05-27T23:00:00.000Z'),
+          },
+          isFullyBooked: false,
+        },
+      ],
+    };
+
+    const eventGardenersQT = {
+      title: 'Gardeners’ Question Time',
+      times: [
+        {
+          range: {
+            startDateTime: new Date('2022-05-09T17:00:00.000Z'),
+            endDateTime: new Date('2022-05-09T19:00:00.000Z'),
+          },
+          isFullyBooked: false,
+        },
+      ],
+    };
+
+    const eventMentalHealth = {
+      title: 'The Nature of Mental Health',
+      times: [
+        {
+          range: {
+            startDateTime: new Date('2022-05-12T18:00:00.000Z'),
+            endDateTime: new Date('2022-05-12T19:30:00.000Z'),
+          },
+          isFullyBooked: false,
+        },
+      ],
+    };
+
+    const eventWomb = {
+      title: 'Wandering Womb',
+      times: [
+        {
+          range: {
+            startDateTime: new Date('2022-05-14T10:00:00.000Z'),
+            endDateTime: new Date('2022-05-14T16:00:00.000Z'),
+          },
+          isFullyBooked: false,
+        },
+      ],
+    };
+
+    const eventTouch = {
+      title: 'Personal Touch',
+      times: [
+        {
+          range: {
+            startDateTime: new Date('2022-05-07T09:00:00.000Z'),
+            endDateTime: new Date('2022-05-07T16:00:00.000Z'),
+          },
+          isFullyBooked: false,
+        },
+      ],
+    };
+
+    const result = sortByEarliestFutureDateRange([
+      eventSlalom,
+      eventGardenersQT,
+      eventMentalHealth,
+      eventWomb,
+      eventTouch,
+    ]);
+
+    expect(result).toEqual([
+      eventTouch,
+      eventGardenersQT,
+      eventMentalHealth,
+      eventWomb,
+      eventSlalom,
+    ]);
   });
 });

--- a/content/webapp/components/EventsByMonth/group-event-utils.ts
+++ b/content/webapp/components/EventsByMonth/group-event-utils.ts
@@ -121,7 +121,6 @@ export function groupEventsByMonth<T extends HasTimes>(
 }
 
 export function sortByEarliestFutureDateRange<T extends HasTimes>(
-  label: string,
   events: T[]
 ): T[] {
   return sortBy(events, [
@@ -130,9 +129,8 @@ export function sortByEarliestFutureDateRange<T extends HasTimes>(
         start: time.range.startDateTime,
         end: time.range.endDateTime,
       }));
-      const fromDate = startOf(parseLabel(label));
 
-      const earliestRange = getEarliestFutureDateRange(times, fromDate);
+      const earliestRange = getEarliestFutureDateRange(times);
       return earliestRange && earliestRange.start;
     },
   ]);

--- a/content/webapp/components/EventsByMonth/group-event-utils.ts
+++ b/content/webapp/components/EventsByMonth/group-event-utils.ts
@@ -1,6 +1,12 @@
 // Utilities for grouping events
 
-import { isFuture, isSameDay, isSameMonth } from '@weco/common/utils/dates';
+import sortBy from 'lodash.sortby';
+import {
+  getEarliestFutureDateRange,
+  isFuture,
+  isSameDay,
+  isSameMonth,
+} from '@weco/common/utils/dates';
 import { EventTime } from '../../types/events';
 
 type HasTimes = {
@@ -112,4 +118,22 @@ export function groupEventsByMonth<T extends HasTimes>(
     });
     return acc;
   }, {} as Record<string, T[]>);
+}
+
+export function sortByEarliestFutureDateRange<T extends HasTimes>(
+  label: string,
+  events: T[]
+): T[] {
+  return sortBy(events, [
+    m => {
+      const times = m.times.map(time => ({
+        start: time.range.startDateTime,
+        end: time.range.endDateTime,
+      }));
+      const fromDate = startOf(parseLabel(label));
+
+      const earliestRange = getEarliestFutureDateRange(times, fromDate);
+      return earliestRange && earliestRange.start;
+    },
+  ]);
 }


### PR DESCRIPTION
## Who is this for?

Lalita.

## What is it doing for them?

Making the dates _right order in display the_ on the what's on page: https://wellcome.slack.com/archives/C8X9YKM5X/p1651224877047299

I haven't checked, but this bug was probably a casualty of some of my Moment-esque refactoring. Inevitably, the bit of code I thought I was leaving as-is and didn't test had a bug in it…