### PR TITLE
Create a new SoundcloudEmbed component with a caption

### DIFF
--- a/content/webapp/components/Body/Body.tsx
+++ b/content/webapp/components/Body/Body.tsx
@@ -53,6 +53,7 @@ import FeaturedCard, {
 } from '../FeaturedCard/FeaturedCard';
 import ImageGallery from '../ImageGallery/ImageGallery';
 import { isNotUndefined } from '@weco/common/utils/array';
+import SoundCloudEmbed from '../SoundCloudEmbed/SoundCloudEmbed';
 
 const Map = dynamic(import('../Map/Map'), {
   ssr: false,
@@ -402,13 +403,7 @@ const Body: FunctionComponent<Props> = ({
                 )}
                 {slice.type === 'soundcloudEmbed' && (
                   <LayoutWidth width={minWidth}>
-                    <iframe
-                      width="100%"
-                      height="140"
-                      frameBorder="no"
-                      title="soundcloud player"
-                      src={slice.value.embedUrl}
-                    />
+                    <SoundCloudEmbed {...slice.value} />
                   </LayoutWidth>
                 )}
                 {slice.type === 'map' && (

--- a/content/webapp/components/SoundCloudEmbed/SoundCloudEmbed.tsx
+++ b/content/webapp/components/SoundCloudEmbed/SoundCloudEmbed.tsx
@@ -1,0 +1,26 @@
+import { FunctionComponent } from 'react';
+import Caption from '@weco/common/views/components/Caption/Caption';
+import * as prismicT from '@prismicio/types';
+
+export type Props = {
+  embedUrl: string;
+  caption?: prismicT.RichTextField;
+};
+
+const SoundCloudEmbed: FunctionComponent<Props> = ({
+  embedUrl,
+  caption,
+}: Props) => (
+  <figure className="no-margin">
+    <iframe
+      width="100%"
+      height="140"
+      frameBorder="no"
+      title="soundcloud player"
+      src={embedUrl}
+    />
+    {caption && <Caption caption={caption} />}
+  </figure>
+);
+
+export default SoundCloudEmbed;


### PR DESCRIPTION
This is modelled on the existing VideoEmbed component, and adds the caption that was previously missing.

## Who is this for?

Alice.

## What is it doing for them?

Making her Soundcloud embed look right. See https://wellcome.slack.com/archives/C8X9YKM5X/p1651580465819869

<img width="775" alt="Screenshot 2022-05-03 at 14 27 12" src="https://user-images.githubusercontent.com/301220/166461511-308a0a22-83a9-4069-a99f-f16729d9b2bf.png">

