### PR TITLE
Provide warnings when we can't parse the TASL

### DIFF
--- a/common/services/prismic/transformers/index.test.ts
+++ b/common/services/prismic/transformers/index.test.ts
@@ -1,0 +1,24 @@
+import { transformTaslFromString } from '.';
+
+describe('transformTaslFromString', () => {
+  it('returns an empty tasl if the input is null', () => {
+    const result = transformTaslFromString(null);
+    expect(result).toEqual({ title: '' });
+  });
+
+  it('transforms a valid tasl', () => {
+    const result = transformTaslFromString(
+      'Mandrake root, England, 1501-1700 | | Science Museum London | https://collection.sciencemuseumgroup.org.uk/objects/co106410/mandrake-root-england-1501-1700-mandrake-root | CC-BY | |'
+    );
+    expect(result).toEqual({
+      author: undefined,
+      copyrightHolder: undefined,
+      copyrightLink: undefined,
+      license: 'CC-BY',
+      sourceLink:
+        'https://collection.sciencemuseumgroup.org.uk/objects/co106410/mandrake-root-england-1501-1700-mandrake-root',
+      sourceName: 'Science Museum London',
+      title: 'Mandrake root, England, 1501-1700',
+    });
+  });
+});

--- a/common/services/prismic/transformers/index.ts
+++ b/common/services/prismic/transformers/index.ts
@@ -17,6 +17,11 @@ export function transformTaslFromString(pipedString: string | null): Tasl {
   // e.g. Self|Rob Bidder|||CC-BY-NC
   try {
     const list = (pipedString || '').split('|');
+
+    if (list.length > 7) {
+      throw new Error('TASL has more than 7 elements');
+    }
+
     const v = list
       .concat(Array(7 - list.length))
       .map(v => (!v.trim() ? undefined : v.trim()));
@@ -41,6 +46,7 @@ export function transformTaslFromString(pipedString: string | null): Tasl {
       copyrightLink,
     };
   } catch (e) {
+    console.warn(`Unable to parse TASL from input (${pipedString}): ${e}`);
     return {
       title: pipedString,
     };


### PR DESCRIPTION
I noticed we have a couple of captions on Rooted Beings that have invalid TASL information. I don't think it's sensible for us to fix them automatically; instead, log a warning and we can pass them to Editorial to fix.