### PR TITLE
Don't throw a 500 error on /api/exhibitions-related-content

### DIFF
--- a/content/webapp/pages/api/exhibitions-related-content/index.ts
+++ b/content/webapp/pages/api/exhibitions-related-content/index.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { isString } from '@weco/common/utils/array';
+import { isString, isUndefined } from '@weco/common/utils/array';
 import { createClient } from '../../../services/prismic/fetch';
 import { fetchExhibitionRelatedContent } from '../../../services/prismic/fetch/exhibitions';
 import { transformExhibitionRelatedContent } from '../../../services/prismic/transformers/exhibitions';
@@ -7,15 +7,19 @@ import { ExhibitionRelatedContent } from '../../../types/exhibitions';
 
 type Data = ExhibitionRelatedContent;
 type NotFound = { notFound: true };
+type UserError = { description: string };
 
 export default async (
   req: NextApiRequest,
-  res: NextApiResponse<Data | NotFound>
+  res: NextApiResponse<Data | NotFound | UserError>
 ): Promise<void> => {
   const { params } = req.query;
-  const parsedParams: string[] = isString(params)
-    ? JSON.parse(params)
-    : undefined;
+
+  if (!isString(params)) {
+    return res.status(400).json({ description: 'Missing params' });
+  }
+
+  const parsedParams: string[] = JSON.parse(params);
   const client = createClient({ req });
 
   if (parsedParams.length === 0) {


### PR DESCRIPTION
Normally we pass the exhibition we want to get related content for in the `params` query parameter, but something has been hitting the API and not passing that -- then `parsedParams` becomes undefined, and getting the length of it throws a type error.

You can't do anything useful with this endpoint, so just 400 out.