### PR TITLE
Remove lazy sizes

### DIFF
--- a/common/views/components/IframeContainer/IframeContainer.tsx
+++ b/common/views/components/IframeContainer/IframeContainer.tsx
@@ -1,0 +1,72 @@
+import styled from 'styled-components';
+const IframeContainer = styled.div`
+  padding-bottom: 56.25%; /* 16:9 */
+  height: 0;
+  position: relative;
+
+  .overlay {
+    position: absolute;
+    display: none;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    background: rgba(0, 0, 0, 0.2);
+    z-index: 1;
+    transition: background 600ms ease;
+
+    .enhanced & {
+      display: block;
+    }
+  }
+
+  .trigger {
+    position: absolute;
+    z-index: 2;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+
+    &:hover,
+    &:focus {
+      .overlay {
+        background: ${props => props.theme.color('transparent')};
+      }
+    }
+
+    .enhanced & {
+      cursor: pointer;
+    }
+  }
+
+  .launch {
+    position: absolute;
+    display: none;
+    z-index: 1;
+    top: 50%;
+    left: 50%;
+    transform: translateY(-50%) translateX(-50%);
+
+    .enhanced & {
+      display: block;
+    }
+  }
+
+  .close {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    z-index: 2;
+  }
+
+  .iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+`;
+
+export default IframeContainer;

--- a/common/views/components/VideoEmbed/VideoEmbed.tsx
+++ b/common/views/components/VideoEmbed/VideoEmbed.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent } from 'react';
-import Caption from '@weco/common/views/components/Caption/Caption';
-import { IframeContainer } from '@weco/common/views/components/Iframe/Iframe';
+import Caption from '../Caption/Caption';
+import IframeContainer from '../IframeContainer/IframeContainer';
 import * as prismicT from '@prismicio/types';
 
 export type Props = {

--- a/content/webapp/components/Body/Body.tsx
+++ b/content/webapp/components/Body/Body.tsx
@@ -22,7 +22,7 @@ import FeaturedText from '../FeaturedText/FeaturedText';
 import VideoEmbed from '@weco/common/views/components/VideoEmbed/VideoEmbed';
 import GifVideo from '../GifVideo/GifVideo';
 import Contact from '@weco/common/views/components/Contact/Contact';
-import Iframe from '@weco/common/views/components/Iframe/Iframe';
+import Iframe from '../Iframe/Iframe';
 import DeprecatedImageList from '../DeprecatedImageList/DeprecatedImageList';
 import Layout from '@weco/common/views/components/Layout/Layout';
 import Layout8 from '@weco/common/views/components/Layout8/Layout8';

--- a/content/webapp/components/BookImage/BookImage.tsx
+++ b/content/webapp/components/BookImage/BookImage.tsx
@@ -28,11 +28,13 @@ const BookPromoImage = styled(Space).attrs({
 type Props = {
   image: UiImageType;
   sizes: BreakpointSizes;
+  quality: number;
 };
 
 const BookImage: FunctionComponent<Props> = ({
   image,
   sizes,
+  quality,
 }: Props): ReactElement<Props> => {
   return (
     <BookPromoImageContainer>
@@ -46,6 +48,7 @@ const BookImage: FunctionComponent<Props> = ({
               alt: image?.alt,
             }}
             sizes={sizes}
+            quality={quality}
           />
         </BookPromoImage>
       )}

--- a/content/webapp/components/BookImage/BookImage.tsx
+++ b/content/webapp/components/BookImage/BookImage.tsx
@@ -28,7 +28,7 @@ const BookPromoImage = styled(Space).attrs({
 type Props = {
   image: UiImageType;
   sizes: BreakpointSizes;
-  quality: number;
+  quality?: number;
 };
 
 const BookImage: FunctionComponent<Props> = ({

--- a/content/webapp/components/BookImage/BookImage.tsx
+++ b/content/webapp/components/BookImage/BookImage.tsx
@@ -1,54 +1,55 @@
 import styled from 'styled-components';
 import Space from '@weco/common/views/components/styled/Space';
-import { UiImage } from '@weco/common/views/components/Images/Images';
 import { classNames } from '@weco/common/utils/classnames';
-import { UiImageType } from '@weco/common/model/image';
 import { FunctionComponent, ReactElement } from 'react';
+import PrismicImage, { BreakpointSizes } from '../PrismicImage/PrismicImage';
+import { UiImageType } from '@weco/common/model/image';
 
-const Outer = styled('div').attrs({
+const BookPromoImageContainer = styled.div.attrs({
   className: classNames({
-    'bg-cream relative h-center': true,
+    'bg-cream relative': true,
   }),
 })`
-  height: 70vh;
-  max-height: 100vw;
-  max-width: 600px;
+  height: 0;
+  padding-top: 100%;
   transform: rotate(-2deg);
 `;
 
-const Inner = styled('div').attrs({
+const BookPromoImage = styled(Space).attrs({
   className: classNames({
     absolute: true,
   }),
 })`
-  bottom: 0;
-  width: 66vw;
+  width: 66%;
   left: 50%;
-  transform: translateX(-50%) rotate(2deg) translateY(-5vw);
-
-  ${props => props.theme.media.large`
-    transform: translateX(-50%) rotate(2deg) translateY(-50px);
-  `}
+  transform: translateX(-50%) rotate(2deg);
 `;
 
 type Props = {
   image: UiImageType;
+  sizes: BreakpointSizes;
 };
 
 const BookImage: FunctionComponent<Props> = ({
   image,
+  sizes,
 }: Props): ReactElement<Props> => {
   return (
-    <Space v={{ size: 'xl', properties: ['margin-top', 'padding-top'] }}>
-      <Outer>
-        <Inner>
-          <UiImage
-            extraClasses="margin-h-auto width-auto max-height-70vh"
-            {...image}
+    <BookPromoImageContainer>
+      {image.contentUrl && (
+        <BookPromoImage v={{ size: 'l', properties: ['bottom'] }}>
+          <PrismicImage
+            image={{
+              contentUrl: image.contentUrl || '',
+              width: image.width,
+              height: image.height,
+              alt: image?.alt,
+            }}
+            sizes={sizes}
           />
-        </Inner>
-      </Outer>
-    </Space>
+        </BookPromoImage>
+      )}
+    </BookPromoImageContainer>
   );
 };
 

--- a/content/webapp/components/BookPromo/BookPromo.tsx
+++ b/content/webapp/components/BookPromo/BookPromo.tsx
@@ -48,6 +48,11 @@ const BookPromo: FunctionComponent<Props> = ({ book }: Props): ReactElement => {
             contentUrl: cover?.contentUrl || '',
             width: cover?.width || 0,
             height: cover?.height || 0,
+            // We intentionally omit the alt text on promos, so screen reader
+            // users don't have to listen to the alt text before hearing the
+            // title of the item in the list.
+            //
+            // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
             alt: '',
             sizesQueries: '',
           }}

--- a/content/webapp/components/BookPromo/BookPromo.tsx
+++ b/content/webapp/components/BookPromo/BookPromo.tsx
@@ -1,32 +1,11 @@
 import { font, classNames } from '@weco/common/utils/classnames';
 import { trackEvent } from '@weco/common/utils/ga';
-import PrismicImage from '../PrismicImage/PrismicImage';
-import { getCrop } from '@weco/common/model/image';
 import { BookBasic } from '../../types/books';
 import Space from '@weco/common/views/components/styled/Space';
 import styled from 'styled-components';
 import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
 import { FunctionComponent, ReactElement } from 'react';
-
-const BookPromoImageContainer = styled.div.attrs({
-  className: classNames({
-    'bg-cream relative': true,
-  }),
-})`
-  height: 0;
-  padding-top: 100%;
-  transform: rotate(-2deg);
-`;
-
-const BookPromoImage = styled(Space).attrs({
-  className: classNames({
-    absolute: true,
-  }),
-})`
-  width: 66%;
-  left: 50%;
-  transform: translateX(-50%) rotate(2deg);
-`;
+import BookImage from '../../components/BookImage/BookImage';
 
 type LinkOrSpanSpaceAttrs = {
   url?: string;
@@ -64,26 +43,21 @@ const BookPromo: FunctionComponent<Props> = ({ book }: Props): ReactElement => {
       }}
     >
       <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
-        <BookPromoImageContainer>
-          {cover?.contentUrl && (
-            <BookPromoImage v={{ size: 'l', properties: ['bottom'] }}>
-              <PrismicImage
-                image={{
-                  contentUrl: cover.contentUrl || '',
-                  width: cover.width || 0,
-                  height: cover.height || 0,
-                  alt: '',
-                }}
-                sizes={{
-                  xlarge: 1 / 6,
-                  large: 1 / 6,
-                  medium: 1 / 2,
-                  small: 1,
-                }}
-              />
-            </BookPromoImage>
-          )}
-        </BookPromoImageContainer>
+        <BookImage
+          image={{
+            contentUrl: cover?.contentUrl || '',
+            width: cover?.width || 0,
+            height: cover?.height || 0,
+            alt: '',
+            sizesQueries: '',
+          }}
+          sizes={{
+            xlarge: 1 / 6,
+            large: 1 / 6,
+            medium: 1 / 3,
+            small: 1,
+          }}
+        />
         <Space
           h={{
             size: 'l',

--- a/content/webapp/components/BookPromo/BookPromo.tsx
+++ b/content/webapp/components/BookPromo/BookPromo.tsx
@@ -1,6 +1,7 @@
 import { font, classNames } from '@weco/common/utils/classnames';
 import { trackEvent } from '@weco/common/utils/ga';
-import UiImage from '@weco/common/views/components/Image/Image';
+import PrismicImage from '../PrismicImage/PrismicImage';
+import { getCrop } from '@weco/common/model/image';
 import { BookBasic } from '../../types/books';
 import Space from '@weco/common/views/components/styled/Space';
 import styled from 'styled-components';
@@ -66,17 +67,19 @@ const BookPromo: FunctionComponent<Props> = ({ book }: Props): ReactElement => {
         <BookPromoImageContainer>
           {cover?.contentUrl && (
             <BookPromoImage v={{ size: 'l', properties: ['bottom'] }}>
-              <UiImage
-                contentUrl={cover.contentUrl}
-                width={cover.width || 0}
-                height={cover.height || 0}
-                // We intentionally omit the alt text on promos, so screen reader
-                // users don't have to listen to the alt text before hearing the
-                // title of the item in the list.
-                //
-                // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
-                alt=""
-                sizesQueries="(min-width: 1420px) 386px, (min-width: 960px) calc(28.64vw - 15px), (min-width: 600px) calc(50vw - 54px), calc(100vw - 36px)"
+              <PrismicImage
+                image={{
+                  contentUrl: cover.contentUrl || '',
+                  width: cover.width || 0,
+                  height: cover.height || 0,
+                  alt: '',
+                }}
+                sizes={{
+                  xlarge: 1 / 6,
+                  large: 1 / 6,
+                  medium: 1 / 2,
+                  small: 1,
+                }}
               />
             </BookPromoImage>
           )}

--- a/content/webapp/components/Card/Card.tsx
+++ b/content/webapp/components/Card/Card.tsx
@@ -8,6 +8,7 @@ import styled from 'styled-components';
 import { FunctionComponent } from 'react';
 import PartNumberIndicator from '../PartNumberIndicator/PartNumberIndicator';
 import { getCrop } from '@weco/common/model/image';
+import PrismicImage from '../PrismicImage/PrismicImage';
 
 type Props = {
   item: CardType;
@@ -91,16 +92,14 @@ const Card: FunctionComponent<Props> = ({ item }: Props) => {
     >
       <div className="relative">
         {image && (
-          <UiImage
-            {...image}
-            // We intentionally omit the alt text on promos, so screen reader
-            // users don't have to listen to the alt text before hearing the
-            // title of the item in the list.
-            //
-            // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
-            alt=""
-            sizesQueries="(min-width: 1420px) 386px, (min-width: 960px) calc(28.64vw - 15px), (min-width: 600px) calc(33.24vw - 43px), calc(100vw - 36px)"
-            showTasl={false}
+          <PrismicImage
+            image={image}
+            sizes={{
+              xlarge: 1 / 4,
+              large: 1 / 4,
+              medium: 1 / 2,
+              small: 1,
+            }}
           />
         )}
         {item.format && (

--- a/content/webapp/components/Card/Card.tsx
+++ b/content/webapp/components/Card/Card.tsx
@@ -1,7 +1,6 @@
 import { Card as CardType } from '../../types/card';
 import { font, classNames } from '@weco/common/utils/classnames';
 import { trackEvent } from '@weco/common/utils/ga';
-import { UiImage } from '@weco/common/views/components/Images/Images';
 import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
 import Space from '@weco/common/views/components/styled/Space';
 import styled from 'styled-components';

--- a/content/webapp/components/EventPromo/EventPromo.tsx
+++ b/content/webapp/components/EventPromo/EventPromo.tsx
@@ -1,7 +1,6 @@
 import { FC } from 'react';
 import { font, classNames } from '@weco/common/utils/classnames';
 import { trackEvent } from '@weco/common/utils/ga';
-import { UiImage } from '@weco/common/views/components/Images/Images';
 import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
 import Dot from '@weco/common/views/components/Dot/Dot';
 import EventDateRange from '../EventDateRange/EventDateRange';
@@ -17,6 +16,8 @@ import AlignFont from '@weco/common/views/components/styled/AlignFont';
 import { Place } from '../../types/places';
 import { isNotUndefined } from '@weco/common/utils/array';
 import { inOurBuilding } from '@weco/common/data/microcopy';
+import PrismicImage from '../PrismicImage/PrismicImage';
+import { getCrop } from '@weco/common/model/image';
 
 type Props = {
   event: EventBasic;
@@ -73,16 +74,22 @@ const EventPromo: FC<Props> = ({
     >
       <div className="relative">
         {event.promo?.image && (
-          <UiImage
-            {...event.promo?.image}
-            // We intentionally omit the alt text on promos, so screen reader
-            // users don't have to listen to the alt text before hearing the
-            // title of the item in the list.
-            //
-            // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
-            alt=""
-            sizesQueries="(min-width: 1420px) 386px, (min-width: 960px) calc(28.64vw - 15px), (min-width: 600px) calc(50vw - 54px), calc(100vw - 36px)"
-            showTasl={false}
+          <PrismicImage
+            image={{
+              contentUrl: event.promo.image.contentUrl || '',
+              width: 1600,
+              height: 900,
+              // We intentionally omit the alt text on promos, so screen reader
+              // users don't have to listen to the alt text before hearing the
+              // title of the item in the list.
+              alt: '',
+            }}
+            sizes={{
+              xlarge: 1 / 4,
+              large: 1 / 3,
+              medium: 1 / 2,
+              small: 1,
+            }}
           />
         )}
 

--- a/content/webapp/components/EventPromo/EventPromo.tsx
+++ b/content/webapp/components/EventPromo/EventPromo.tsx
@@ -17,7 +17,6 @@ import { Place } from '../../types/places';
 import { isNotUndefined } from '@weco/common/utils/array';
 import { inOurBuilding } from '@weco/common/data/microcopy';
 import PrismicImage from '../PrismicImage/PrismicImage';
-import { getCrop } from '@weco/common/model/image';
 
 type Props = {
   event: EventBasic;

--- a/content/webapp/components/ExhibitionPromo/ExhibitionPromo.tsx
+++ b/content/webapp/components/ExhibitionPromo/ExhibitionPromo.tsx
@@ -1,4 +1,4 @@
-import { Fragment } from 'react';
+import { Fragment, FC } from 'react';
 import { font, classNames } from '@weco/common/utils/classnames';
 import { trackEvent } from '@weco/common/utils/ga';
 import { formatDate } from '@weco/common/utils/format-date';
@@ -16,7 +16,7 @@ type Props = {
   position?: number;
 };
 
-const ExhibitionPromo = ({ exhibition, position = 0 }: Props) => {
+const ExhibitionPromo: FC<Props> = ({ exhibition, position = 0 }) => {
   const { start, end, statusOverride, isPermanent } = exhibition;
   const url = linkResolver(exhibition);
   const image = exhibition.promo?.image;
@@ -47,7 +47,7 @@ const ExhibitionPromo = ({ exhibition, position = 0 }: Props) => {
             // title of the item in the list.
             //
             // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
-            image={{...image, alt: ""}}
+            image={image}
             sizes={{
               xlarge: 1 / 3,
               large: 1 / 3,

--- a/content/webapp/components/FacilityPromo/FacilityPromo.tsx
+++ b/content/webapp/components/FacilityPromo/FacilityPromo.tsx
@@ -1,7 +1,7 @@
 import { font, classNames } from '@weco/common/utils/classnames';
 import { trackEvent } from '@weco/common/utils/ga';
 import Icon from '@weco/common/views/components/Icon/Icon';
-import { UiImage } from '@weco/common/views/components/Images/Images';
+import PrismicImage from '../PrismicImage/PrismicImage';
 import Space from '@weco/common/views/components/styled/Space';
 import { CardOuter, CardBody } from '../Card/Card';
 import { FacilityPromo as FacilityPromoType } from '../../types/facility-promo';
@@ -38,7 +38,15 @@ const FacilityPromo: FC<FacilityPromoType> = ({
     >
       <div>
         <div className="rounded-corners overflow-hidden">
-          <UiImage {...uiImageProps} />
+          <PrismicImage
+            image={uiImageProps}
+            sizes={{
+              xlarge: 1 / 4,
+              large: 1 / 3,
+              medium: 1 / 2,
+              small: 1,
+            }}
+          />
         </div>
 
         <CardBody>

--- a/content/webapp/components/FeaturedCard/FeaturedCard.tsx
+++ b/content/webapp/components/FeaturedCard/FeaturedCard.tsx
@@ -24,7 +24,6 @@ import { EventSeries } from '../../types/event-series';
 import { Book } from '../../types/books';
 import { Event } from '../../types/events';
 import { Guide } from '../../types/guides';
-
 import PrismicImage from '../PrismicImage/PrismicImage';
 
 type PartialFeaturedCard = {
@@ -296,11 +295,12 @@ const FeaturedCard: FunctionComponent<Props> = ({
             <PrismicImage
               image={image}
               sizes={{
-                xlarge: 1 / 3,
-                large: 1 / 3,
+                xlarge: 1 / 2,
+                large: 1 / 2,
                 medium: 1 / 2,
                 small: 1,
               }}
+              quality={75}
             />
           )}
         </FeaturedCardLeft>

--- a/content/webapp/components/Iframe/Iframe.tsx
+++ b/content/webapp/components/Iframe/Iframe.tsx
@@ -1,81 +1,11 @@
 import { Component, Fragment, createRef } from 'react';
 import { trackEvent } from '@weco/common/utils/ga';
-import { UiImage } from '@weco/common/views/components/Images/Images';
+import PrismicImage from '../PrismicImage/PrismicImage';
 import Control from '@weco/common/views/components/Buttons/Control/Control';
 import ButtonSolid from '@weco/common/views/components/ButtonSolid/ButtonSolid';
-import { ImageType } from '@weco/common/model/image';
-import styled from 'styled-components';
+import IframeContainer from '@weco/common/views/components/IframeContainer/IframeContainer';
 import { cross } from '@weco/common/icons';
-
-export const IframeContainer = styled.div`
-  padding-bottom: 56.25%; /* 16:9 */
-  height: 0;
-  position: relative;
-
-  .overlay {
-    position: absolute;
-    display: none;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    background: rgba(0, 0, 0, 0.2);
-    z-index: 1;
-    transition: background 600ms ease;
-
-    .enhanced & {
-      display: block;
-    }
-  }
-
-  .trigger {
-    position: absolute;
-    z-index: 2;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-
-    &:hover,
-    &:focus {
-      .overlay {
-        background: ${props => props.theme.color('transparent')};
-      }
-    }
-
-    .enhanced & {
-      cursor: pointer;
-    }
-  }
-
-  .launch {
-    position: absolute;
-    display: none;
-    z-index: 1;
-    top: 50%;
-    left: 50%;
-    transform: translateY(-50%) translateX(-50%);
-
-    .enhanced & {
-      display: block;
-    }
-  }
-
-  .close {
-    position: absolute;
-    top: 12px;
-    right: 12px;
-    z-index: 2;
-  }
-
-  .iframe {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-  }
-`;
+import { ImageType } from '@weco/common/model/image';
 
 export type Props = {
   image: ImageType;
@@ -129,7 +59,16 @@ class Iframe extends Component<Props, State> {
                 </span>
               </span>
             )}
-            <UiImage {...imageObject} />
+            <PrismicImage
+              image={imageObject}
+              sizes={{
+                xlarge: 1,
+                large: 1,
+                medium: 1,
+                small: 1,
+              }}
+              quality={100}
+            />
             {this.state.iframeShowing && (
               <Control
                 colorScheme="light"

--- a/content/webapp/components/Iframe/Iframe.tsx
+++ b/content/webapp/components/Iframe/Iframe.tsx
@@ -62,12 +62,12 @@ class Iframe extends Component<Props, State> {
             <PrismicImage
               image={imageObject}
               sizes={{
-                xlarge: 1,
-                large: 1,
+                xlarge: 1 / 2,
+                large: 1 / 2,
                 medium: 1,
                 small: 1,
               }}
-              quality={100}
+              quality={60}
             />
             {this.state.iframeShowing && (
               <Control

--- a/content/webapp/components/PrismicImage/PrismicImage.tsx
+++ b/content/webapp/components/PrismicImage/PrismicImage.tsx
@@ -67,7 +67,7 @@ function createPrismicLoader(maxWidth: number) {
 
     searchParams.set(`auto`, 'compress,format');
     searchParams.set(`rect`, url.searchParams.get('rect') || '');
-    searchParams.set(`q`, (quality || 20).toString());
+    searchParams.set(`q`, (quality || 10).toString());
 
     return `${url.origin}${url.pathname}?${searchParams.toString()}`;
   };

--- a/content/webapp/components/PrismicImage/PrismicImage.tsx
+++ b/content/webapp/components/PrismicImage/PrismicImage.tsx
@@ -66,7 +66,7 @@ function createPrismicLoader(maxWidth: number) {
 
     searchParams.set(`auto`, 'compress,format');
     searchParams.set(`rect`, url.searchParams.get('rect') || '');
-    searchParams.set(`q`, (quality || 75).toString());
+    searchParams.set(`q`, (quality || 40).toString());
 
     return `${url.origin}${url.pathname}?${searchParams.toString()}`;
   };

--- a/content/webapp/components/PrismicImage/PrismicImage.tsx
+++ b/content/webapp/components/PrismicImage/PrismicImage.tsx
@@ -13,6 +13,7 @@ type Props = {
   sizes?: BreakpointSizes;
   // The maximum width at which the image will be displayed
   maxWidth?: number;
+  quality?: number;
 };
 
 export function convertBreakpointSizesToSizes(
@@ -66,7 +67,7 @@ function createPrismicLoader(maxWidth: number) {
 
     searchParams.set(`auto`, 'compress,format');
     searchParams.set(`rect`, url.searchParams.get('rect') || '');
-    searchParams.set(`q`, (quality || 40).toString());
+    searchParams.set(`q`, (quality || 20).toString());
 
     return `${url.origin}${url.pathname}?${searchParams.toString()}`;
   };
@@ -77,7 +78,7 @@ function createPrismicLoader(maxWidth: number) {
  * usurping UiImage which has reached a state where it is so bloated it is hard to refactor.
  * This is aimed solely at the Prismic image rendering for now.
  */
-const PrismicImage: FC<Props> = ({ image, sizes, maxWidth }) => {
+const PrismicImage: FC<Props> = ({ image, sizes, maxWidth, quality }) => {
   const sizesString = sizes
     ? convertBreakpointSizesToSizes(sizes).join(', ')
     : undefined;
@@ -100,6 +101,7 @@ const PrismicImage: FC<Props> = ({ image, sizes, maxWidth }) => {
       src={image.contentUrl}
       alt={image.alt || ''}
       loader={createPrismicLoader(maxLoaderWidth)}
+      quality={quality}
     />
   );
 };

--- a/content/webapp/components/PrismicImage/PrismicImage.tsx
+++ b/content/webapp/components/PrismicImage/PrismicImage.tsx
@@ -5,14 +5,12 @@ import {
   Breakpoint,
   sizes as breakpointSizes,
 } from '@weco/common/views/themes/config';
-import { Picture } from '@weco/common/model/picture';
 import { ImageType } from '@weco/common/model/image';
 
-type BreakpointSizes = Partial<Record<Breakpoint, number>>;
+export type BreakpointSizes = Partial<Record<Breakpoint, number>>;
 type Props = {
-  image: Picture | ImageType;
+  image: ImageType;
   sizes?: BreakpointSizes;
-
   // The maximum width at which the image will be displayed
   maxWidth?: number;
 };

--- a/content/webapp/components/VenueHours/VenueHours.tsx
+++ b/content/webapp/components/VenueHours/VenueHours.tsx
@@ -5,7 +5,8 @@ import { classNames, font } from '@weco/common/utils/classnames';
 import MoreLink from '@weco/common/views/components/MoreLink/MoreLink';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import Divider from '@weco/common/views/components/Divider/Divider';
-import { UiImage } from '@weco/common/views/components/Images/Images';
+import PrismicImage from '../PrismicImage/PrismicImage';
+import { getCrop } from '@weco/common/model/image';
 import { clock } from '@weco/common/icons';
 import {
   backfillExceptionalVenueDays,
@@ -110,14 +111,19 @@ const VenueHours: FunctionComponent<Props> = ({ venue, weight }) => {
           </Space>
           <VenueHoursImage v={{ size: 'm', properties: ['margin-bottom'] }}>
             {venue?.image?.contentUrl && (
-              <UiImage
-                contentUrl={venue.image.contentUrl}
-                width={1600}
-                height={900}
-                alt={venue.image?.alt}
-                sizesQueries="(min-width: 1340px) 303px, (min-width: 960px) calc(30.28vw - 68px), (min-width: 600px) calc(50vw - 42px), calc(100vw - 36px)"
-                extraClasses=""
-                showTasl={false}
+              <PrismicImage
+                image={{
+                  contentUrl: getCrop(venue.image, '16:9')?.contentUrl || '',
+                  width: 1600,
+                  height: 900,
+                  alt: venue.image?.alt,
+                }}
+                sizes={{
+                  xlarge: 1 / 6,
+                  large: 1 / 6,
+                  medium: 1 / 2,
+                  small: 1,
+                }}
               />
             )}
           </VenueHoursImage>

--- a/content/webapp/pages/book.tsx
+++ b/content/webapp/pages/book.tsx
@@ -105,7 +105,8 @@ const BookPage: FunctionComponent<Props> = props => {
       <Layout8>
         <BookImage
           image={{ ...book.cover, sizesQueries: '' }}
-          sizes={{ xlarge: 1 / 3, large: 1 / 3, medium: 1 / 3, small: 1 }} // TODO
+          sizes={{ xlarge: 1 / 3, large: 1 / 3, medium: 1 / 3, small: 1 }}
+          quality={75}
         />
       </Layout8>
     </Space>

--- a/content/webapp/pages/book.tsx
+++ b/content/webapp/pages/book.tsx
@@ -18,6 +18,7 @@ import { createClient } from '../services/prismic/fetch';
 import { transformBook } from '../services/prismic/transformers/books';
 import { Book } from '../types/books';
 import { looksLikePrismicId } from '../services/prismic';
+import Layout8 from '@weco/common/views/components/Layout8/Layout8';
 
 const MetadataWrapper = styled.div`
   border-top: 1px solid ${props => props.theme.color('smoke')};
@@ -99,7 +100,15 @@ const BookPage: FunctionComponent<Props> = props => {
 
   const { book } = props;
   const FeaturedMedia = book.cover && (
-    <BookImage image={{ ...book.cover, sizesQueries: '' }} />
+    <Space v={{ size: 'xl', properties: ['margin-top', 'padding-top'] }}>
+      {/* //TODO remove sizesQueries, once removed from UIImageType */}
+      <Layout8>
+        <BookImage
+          image={{ ...book.cover, sizesQueries: '' }}
+          sizes={{ xlarge: 1 / 3, large: 1 / 3, medium: 1 / 3, small: 1 }} // TODO
+        />
+      </Layout8>
+    </Space>
   );
   const breadcrumbs = {
     items: [

--- a/content/webapp/pages/homepage.tsx
+++ b/content/webapp/pages/homepage.tsx
@@ -6,8 +6,6 @@ import SpacingSection from '@weco/common/views/components/SpacingSection/Spacing
 import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import { ArticleBasic } from '../types/articles';
-import { Page as PageType } from '../types/pages';
-import { PaginatedResults } from '@weco/common/services/prismic/types';
 import Space from '@weco/common/views/components/styled/Space';
 import Layout10 from '@weco/common/views/components/Layout10/Layout10';
 import SimpleCardGrid from '../components/SimpleCardGrid/SimpleCardGrid';

--- a/content/webapp/pages/page.tsx
+++ b/content/webapp/pages/page.tsx
@@ -6,7 +6,7 @@ import HTMLDate from '@weco/common/views/components/HTMLDate/HTMLDate';
 import HeaderBackground from '@weco/common/views/components/HeaderBackground/HeaderBackground';
 import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
 import VideoEmbed from '@weco/common/views/components/VideoEmbed/VideoEmbed';
-import { UiImage } from '@weco/common/views/components/Images/Images';
+import PrismicImage from '../components/PrismicImage/PrismicImage';
 import { Page as PageType } from '../types/pages';
 import { SiblingsGroup } from '../types/siblings-group';
 import {
@@ -146,9 +146,18 @@ const Page: FC<Props> = ({ page, siblings, children, ordersInParents }) => {
     : page.body;
 
   const featuredMedia = featuredPicture ? (
-    <UiImage
-      {...((getCrop(featuredPicture.value.image, '16:9') ||
-        featuredPicture.value.image) as any)}
+    <PrismicImage
+      image={{
+        ...((getCrop(featuredPicture.value.image, '16:9') ||
+          featuredPicture.value.image) as any),
+      }}
+      sizes={{
+        xlarge: 1,
+        large: 1,
+        medium: 1,
+        small: 1,
+      }}
+      quality={75}
     />
   ) : featuredVideo ? (
     <VideoEmbed {...featuredVideo.value} />

--- a/content/webapp/pages/season.tsx
+++ b/content/webapp/pages/season.tsx
@@ -2,8 +2,8 @@ import { GetServerSideProps } from 'next';
 import { ReactElement } from 'react';
 import { Season } from '../types/seasons';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
-import SeasonsHeader from '@weco/content/components/SeasonsHeader/SeasonsHeader';
-import { UiImage } from '@weco/common/views/components/Images/Images';
+import SeasonsHeader from '../components/SeasonsHeader/SeasonsHeader';
+import PrismicImage from '../components/PrismicImage/PrismicImage';
 import { removeUndefinedProps } from '@weco/common/utils/json';
 import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
 import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
@@ -83,7 +83,15 @@ const SeasonPage = ({
       title={season.title}
       FeaturedMedia={
         superWidescreenImage ? (
-          <UiImage {...superWidescreenImage} sizesQueries="" />
+          <PrismicImage
+            image={superWidescreenImage}
+            sizes={{
+              xlarge: 1,
+              large: 1,
+              medium: 1,
+              small: 1,
+            }}
+          />
         ) : undefined
       }
       standfirst={season?.standfirst}

--- a/content/webapp/pages/season.tsx
+++ b/content/webapp/pages/season.tsx
@@ -91,6 +91,7 @@ const SeasonPage = ({
               medium: 1,
               small: 1,
             }}
+            quality={75}
           />
         ) : undefined
       }

--- a/content/webapp/types/body.ts
+++ b/content/webapp/types/body.ts
@@ -1,6 +1,6 @@
 import { Props as TableProps } from '@weco/common/views/components/Table/Table';
 import { Props as ContactProps } from '@weco/common/views/components/Contact/Contact';
-import { Props as IframeProps } from '@weco/common/views/components/Iframe/Iframe';
+import { Props as IframeProps } from '@weco/content/components/Iframe/Iframe';
 import { Props as InfoBlockProps } from '@weco/common/views/components/InfoBlock/InfoBlock';
 import { Props as AsyncSearchResultsProps } from '../components/SearchResults/AsyncSearchResults';
 import { Props as QuoteProps } from '../components/Quote/Quote';

--- a/content/webapp/utils/page-header.tsx
+++ b/content/webapp/utils/page-header.tsx
@@ -1,6 +1,6 @@
 import { getCrop } from '@weco/common/model/image';
 import { breakpoints } from '@weco/common/utils/breakpoints';
-import { UiImage } from '@weco/common/views/components/Images/Images';
+import PrismicImage from '../components/PrismicImage/PrismicImage';
 import { FeaturedMedia } from '@weco/common/views/components/PageHeader/PageHeader';
 import Picture from '@weco/common/views/components/Picture/Picture';
 import VideoEmbed from '@weco/common/views/components/VideoEmbed/VideoEmbed';
@@ -31,11 +31,28 @@ export function getFeaturedMedia(
       isFull={true}
     />
   ) : widescreenImage ? (
-    <UiImage {...widescreenImage} sizesQueries="" />
+    <PrismicImage
+      image={widescreenImage}
+      sizes={{
+        xlarge: 1,
+        large: 1,
+        medium: 1,
+        small: 1,
+      }}
+      quality={75}
+    />
   ) : image ? (
-    <UiImage {...image} sizesQueries="" />
+    <PrismicImage
+      image={image}
+      sizes={{
+        xlarge: 1,
+        large: 1,
+        medium: 1,
+        small: 1,
+      }}
+      quality={75}
+    />
   ) : undefined;
-
   return featuredMedia;
 }
 


### PR DESCRIPTION
References #7932

Goes a long way to being able to remove lazySizes, by replacing instances of the UiImage component with PrismicImage (still need to sort out the CaptionedImage component and a few other bits which are proving a little trickier).

I've tweaked the PrismicImage component so we can pass a quality prop for the image and reduced the default image quality. This means we can specify higher quality images for things like FeaturedCards, Headers and Image galleries, while it is reduced for promo images where it's not so important. This has led to significant reduction in page weight.

For example (on 1338+px screen, with a fully scrolled page):

  | Image sizes before | Image sizes after | % change
-- | -- | -- | --
Home page | 384kB | 178kB | -54%
What's on page | 276kB | 182kB | -34%
Stories pages | 829kB | 339kB | -59%
/seasons/YEY3ZBAAACEASBjA | 563kB | 299kB | -47%
/events/past | 1300kB | 707kB | -46%
/books | 506kB | 182kB | -64%
/books/YW7YOREAACIANh4F | 268kB | 53kB | -80%

</google-sheets-html-origin>

We may want to tweak the default quality, but I think it is reasonable. See below:

Example of promo images before:
![b4](https://user-images.githubusercontent.com/6051896/167083519-f9f23bf7-3524-4c1e-962e-80e7f2c7856b.png)

Example of promo images with new reduced default quality:
![after](https://user-images.githubusercontent.com/6051896/167083544-711a1fcd-3025-4ada-b25f-47a9cc9e2e2e.png)

I've also had to move some components from common into the content app and have tweaked the BookImage component, so we can use it in both the BookPromo component and on the book page, rather than replicating styles in both places.