### PR TITLE
Stop the p from being optional in userIdPrefix

### DIFF
--- a/identity/webapp/pages/api/registration.ts
+++ b/identity/webapp/pages/api/registration.ts
@@ -27,7 +27,7 @@ export default (req: NextApiRequest, res: NextApiResponse): void => {
       if (typeof decodedToken !== 'string') {
         const redirectUri = `${config.auth0.domain}/continue?state=${state}`;
         const { sub } = decodedToken;
-        const userIdPrefix = /auth0\|p?/;
+        const userIdPrefix = /auth0\|p/;
         const userId = sub.replace(userIdPrefix, '');
 
         axios


### PR DESCRIPTION
☝️ 

Because [the ID will always include a `p`](https://github.com/wellcomecollection/identity/pull/293#issuecomment-1120913520)