### PR TITLE
Update Hotjar events API call

### DIFF
--- a/common/hooks/useHotjar.ts
+++ b/common/hooks/useHotjar.ts
@@ -34,7 +34,7 @@ async function renderScript() {
 
 const heatMapTrigger = (triggerName: string): void => {
   // Use triggers if page cannot be determinted by url. e.g archive page.
-  // https://help.hotjar.com/hc/en-us/articles/115011867948
+  // https://help.hotjar.com/hc/en-us/articles/4405109971095-Events-API-Reference#the-events-api-call
   try {
     window.hj('event', [triggerName]);
   } catch (e) {}

--- a/common/hooks/useHotjar.ts
+++ b/common/hooks/useHotjar.ts
@@ -36,7 +36,7 @@ const heatMapTrigger = (triggerName: string): void => {
   // Use triggers if page cannot be determinted by url. e.g archive page.
   // https://help.hotjar.com/hc/en-us/articles/115011867948
   try {
-    window.hj('trigger', triggerName);
+    window.hj('event', [triggerName]);
   } catch (e) {}
 };
 

--- a/common/hooks/useHotjar.ts
+++ b/common/hooks/useHotjar.ts
@@ -37,7 +37,9 @@ const heatMapTrigger = (triggerName: string): void => {
   // https://help.hotjar.com/hc/en-us/articles/4405109971095-Events-API-Reference#the-events-api-call
   try {
     window.hj('event', [triggerName]);
-  } catch (e) {}
+  } catch (e) {
+    console.log(e);
+  }
 };
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types


### PR DESCRIPTION
[Hotjar `trigger` is now `event` ](https://help.hotjar.com/hc/en-us/articles/4405109971095-Events-API-Reference#the-events-api-call) and we need to update our `hj` call in order for the new [continuous heatmaps](https://www.hotjar.com/updates/en/onwards-and-upwards-why-and-when-continuous-heatmaps-are-replacing-manual?role=s_HCWoPasV913%3Bs_iSDiKvEm1499%3Bs_pJcjHVwD740%3Bs_OAVVeiyc1497%3Bs_BBKvqAbk2285%3Bs_mqLymRsT1519) to be filterable by any events that we send.