### PR TITLE
Use string instead of array for event

### DIFF
--- a/common/hooks/useHotjar.ts
+++ b/common/hooks/useHotjar.ts
@@ -36,7 +36,6 @@ const heatMapTrigger = (triggerName: string): void => {
   // Use triggers if page cannot be determinted by url. e.g archive page.
   // https://help.hotjar.com/hc/en-us/articles/4405109971095-Events-API-Reference#the-events-api-call
   try {
-    window.hj.debug.on();
     window.hj('event', triggerName);
   } catch (e) {
     console.log(e);

--- a/common/hooks/useHotjar.ts
+++ b/common/hooks/useHotjar.ts
@@ -36,7 +36,8 @@ const heatMapTrigger = (triggerName: string): void => {
   // Use triggers if page cannot be determinted by url. e.g archive page.
   // https://help.hotjar.com/hc/en-us/articles/4405109971095-Events-API-Reference#the-events-api-call
   try {
-    window.hj('event', [triggerName]);
+    window.hj.debug.on();
+    window.hj('event', triggerName);
   } catch (e) {
     console.log(e);
   }


### PR DESCRIPTION
There's discrepancy in the Hotjar docs about whether event names should be passed as a [string](https://help.hotjar.com/hc/en-us/articles/4405109971095-Events-API-Reference#the-events-api-call) or as an [array of strings](https://help.hotjar.com/hc/en-us/articles/360034216634-Hotjar-JavaScript-Functions-Reference#event).

I previously picked the wrong one.