### PR TITLE
Captioned image refactor

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -40,7 +40,6 @@
       },
       "ignoreSelectors": [
         ".*\\.icon*",
-        ".*\\.captioned-image*",
         ".*\\.image*",
         ".*\\.is-.*",
         ".*\\.enhanced.*",

--- a/cardigan/stories/components/CaptionedImage/CaptionedImage.stories.mdx
+++ b/cardigan/stories/components/CaptionedImage/CaptionedImage.stories.mdx
@@ -1,5 +1,5 @@
 import { Meta, Canvas, Story, ArgsTable } from '@storybook/addon-docs/blocks';
-import { CaptionedImage } from '@weco/common/views/components/Images/Images';
+import CaptionedImage from '@weco/content/components/CaptionedImage/CaptionedImage';
 import * as stories from './CaptionedImage.stories.tsx';
 
 <Meta title={`Components/CaptionedImage`} component={CaptionedImage} />

--- a/cardigan/stories/components/CaptionedImage/CaptionedImage.stories.tsx
+++ b/cardigan/stories/components/CaptionedImage/CaptionedImage.stories.tsx
@@ -1,4 +1,4 @@
-import { CaptionedImage } from '@weco/common/views/components/Images/Images';
+import CaptionedImage from '@weco/content/components/CaptionedImage/CaptionedImage';
 import { captionedImage } from '../../content';
 
 const Template = args => <CaptionedImage {...args} />;

--- a/common/views/components/Images/Images.tsx
+++ b/common/views/components/Images/Images.tsx
@@ -119,7 +119,7 @@ export class UiImage extends Component<UiImageProps, UiImageState> {
           alt={alt || ''}
         />
 
-        {showTasl && <Tasl {...tasl} isFull={isFull} />}
+        {showTasl && <Tasl {...tasl} positionTop={isFull} />}
       </Fragment>
     );
   }

--- a/common/views/components/Images/Images.tsx
+++ b/common/views/components/Images/Images.tsx
@@ -1,46 +1,10 @@
-import { Fragment, Component, createRef, ReactNode } from 'react';
+import { Fragment, Component, createRef } from 'react';
 import debounce from 'lodash.debounce';
 import { convertImageUri } from '../../../utils/convert-image-uri';
 import { classNames } from '../../../utils/classnames';
 import { imageSizes } from '../../../utils/image-sizes';
 import Tasl from '../Tasl/Tasl';
 import { ImageType } from '../../../model/image';
-import { CaptionedImage as CaptionedImageType } from '../../../model/captioned-image';
-import Caption from '../Caption/Caption';
-import LL from '../styled/LL';
-import styled from 'styled-components';
-
-type CaptionedImageProps = {
-  isBody?: boolean;
-};
-
-const CaptionedImageFigure = styled.div<CaptionedImageProps>`
-  margin: 0;
-  display: inline-block;
-  width: 100%;
-  text-align: center;
-
-  .image {
-    max-height: 80vh;
-    max-width: 100%;
-
-  }
-
-  noscript .image {
-    max-height: none;
-  }
-
-  ${props =>
-    props.isBody &&
-    `
-    text-align: left;
-
-    .caption {
-      margin-left: 0;
-      margin-right: 0;
-    }
-  `}
-}`;
 
 export type UiImageProps = ImageType & {
   sizesQueries: string;
@@ -157,89 +121,6 @@ export class UiImage extends Component<UiImageProps, UiImageState> {
 
         {showTasl && <Tasl {...tasl} isFull={isFull} />}
       </Fragment>
-    );
-  }
-}
-
-export type UiCaptionedImageProps = CaptionedImageType & {
-  sizesQueries: string;
-  isBody?: boolean;
-  preCaptionNode?: ReactNode;
-  setTitleStyle?: (value: number) => void;
-};
-
-type UiCaptionedImageState = {
-  computedImageWidth?: number;
-  isWidthAuto: boolean;
-  isEnhanced: boolean;
-};
-
-export class CaptionedImage extends Component<
-  UiCaptionedImageProps,
-  UiCaptionedImageState
-> {
-  state: UiCaptionedImageState = {
-    computedImageWidth: undefined,
-    isWidthAuto: false,
-    isEnhanced: false,
-  };
-
-  componentDidMount() {
-    this.setState({
-      isEnhanced: true,
-    });
-  }
-
-  setIsWidthAuto = (value: boolean) => {
-    this.setState({
-      isWidthAuto: value,
-    });
-  };
-
-  setComputedImageWidth = (width: number) => {
-    this.props.setTitleStyle && this.props.setTitleStyle(width);
-    this.setState({
-      computedImageWidth: width,
-    });
-  };
-
-  render() {
-    const { caption, preCaptionNode, image, isBody, sizesQueries } = this.props;
-    const { computedImageWidth, isWidthAuto, isEnhanced } = this.state;
-    const uiImageProps = { ...image, sizesQueries };
-
-    return (
-      <CaptionedImageFigure className={`captioned-image`} isBody={isBody}>
-        <div
-          style={{
-            display: isWidthAuto ? 'inline-block' : undefined,
-          }}
-          className="captioned-image__image-container relative"
-        >
-          {!isWidthAuto && isEnhanced && <LL />}
-          <UiImage
-            {...uiImageProps}
-            setIsWidthAuto={this.setIsWidthAuto}
-            isWidthAuto={isWidthAuto}
-            setComputedImageWidth={this.setComputedImageWidth}
-          />
-        </div>
-        {isWidthAuto && (
-          <Caption
-            width={computedImageWidth}
-            caption={caption}
-            preCaptionNode={preCaptionNode}
-          />
-        )}
-
-        {!isEnhanced && ( // Render the captions for no-JS
-          <Caption
-            width={computedImageWidth}
-            caption={caption}
-            preCaptionNode={preCaptionNode}
-          />
-        )}
-      </CaptionedImageFigure>
     );
   }
 }

--- a/common/views/components/Picture/Picture.tsx
+++ b/common/views/components/Picture/Picture.tsx
@@ -52,7 +52,7 @@ export const Picture: FunctionComponent<Props> = ({
           />
         )}
       </picture>
-      {tasl && <Tasl {...tasl} isFull={isFull} />}
+      {tasl && <Tasl {...tasl} positionTop={isFull} />}
     </figure>
   );
 };
@@ -106,7 +106,7 @@ export const PictureFromImages = ({
           />
         )}
       </picture>
-      {lastImage && <Tasl {...lastImage.tasl} isFull={isFull} />}
+      {lastImage && <Tasl {...lastImage.tasl} positionTop={isFull} />}
     </figure>
   );
 };

--- a/common/views/components/Tasl/Tasl.tsx
+++ b/common/views/components/Tasl/Tasl.tsx
@@ -14,7 +14,7 @@ type StyledTaslProps = {
 };
 
 const StyledTasl = styled.div.attrs({
-  className: `${font('lr', 6)} plain-text tasl`, // Still need the tasl class as it's used with .image-gallery-v2 styles
+  className: `${font('lr', 6)} plain-text tasl`, // Need the tasl class as it's used with ImageGallery styled components
 })<StyledTaslProps>`
   text-align: right;
   top: ${props => (props.positionAtTop ? 0 : 'auto')};
@@ -147,11 +147,11 @@ function getCopyrightHtml(copyrightHolder, copyrightLink) {
 }
 
 export type Props = MarkUpProps & {
-  isFull: boolean;
+  positionTop?: boolean;
 };
 
 const Tasl: FunctionComponent<Props> = ({
-  isFull,
+  positionTop = false,
   title,
   author,
   sourceName,
@@ -174,10 +174,10 @@ const Tasl: FunctionComponent<Props> = ({
   }
 
   return [title, sourceName, copyrightHolder].some(_ => _) ? (
-    <StyledTasl positionAtTop={isFull} isEnhanced={isEnhanced}>
+    <StyledTasl positionAtTop={positionTop} isEnhanced={isEnhanced}>
       <TaslButton
         onClick={toggleWithAnalytics}
-        positionAtTop={isFull}
+        positionAtTop={positionTop}
         aria-expanded={isActive}
         aria-controls={title || sourceName || copyrightHolder || ''}
       >

--- a/common/views/themes/utility-classes.ts
+++ b/common/views/themes/utility-classes.ts
@@ -547,14 +547,6 @@ export const utilityClasses = css<GlobalStyleProps>`
 
     &.lazyloaded {
       opacity: 1;
-
-      .captioned-image & {
-        opacity: 1;
-      }
-    }
-
-    .captioned-image & {
-      opacity: 0;
     }
   }
 `;

--- a/content/webapp/components/Body/Body.tsx
+++ b/content/webapp/components/Body/Body.tsx
@@ -12,7 +12,7 @@ import {
   dropCapSerializer,
 } from '../HTMLSerializers/HTMLSerializers';
 import { prismicPageIds } from '@weco/common/services/prismic/hardcoded-id';
-import { CaptionedImage } from '@weco/common/views/components/Images/Images';
+import CaptionedImage from '../CaptionedImage/CaptionedImage';
 import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
 import SectionHeader from '@weco/common/views/components/SectionHeader/SectionHeader';
 import Space from '@weco/common/views/components/styled/Space';
@@ -342,17 +342,17 @@ const Body: FunctionComponent<Props> = ({
               that width isn't an adequate means to illustrate a difference */}
                 {slice.type === 'picture' && slice.weight === 'default' && (
                   <Layout10>
-                    <CaptionedImage {...slice.value} sizesQueries={''} />
+                    <CaptionedImage {...slice.value} />
                   </Layout10>
                 )}
                 {slice.type === 'picture' && slice.weight === 'standalone' && (
                   <Layout12>
-                    <CaptionedImage {...slice.value} sizesQueries={''} />
+                    <CaptionedImage {...slice.value} />
                   </Layout12>
                 )}
                 {slice.type === 'picture' && slice.weight === 'supporting' && (
                   <LayoutWidth width={minWidth}>
-                    <CaptionedImage {...slice.value} sizesQueries={''} />
+                    <CaptionedImage {...slice.value} />
                   </LayoutWidth>
                 )}
                 {slice.type === 'imageGallery' && (

--- a/content/webapp/components/CaptionedImage/CaptionedImage.tsx
+++ b/content/webapp/components/CaptionedImage/CaptionedImage.tsx
@@ -1,0 +1,73 @@
+import { FC, ReactNode } from 'react';
+import Caption from '@weco/common/views/components/Caption/Caption';
+import styled from 'styled-components';
+import { CaptionedImage as CaptionedImageType } from '@weco/common/model/captioned-image';
+import PrismicImageWithTasl from '../PrismicImageWithTasl/PrismicImageWithTasl';
+
+type CaptionedImageProps = {
+  isBody?: boolean;
+};
+
+const CaptionedImageFigure = styled.div<CaptionedImageProps>`
+  margin: 0;
+  display: inline-block;
+  width: 100%;
+    text-align: center;
+
+  ${props =>
+    props.isBody &&
+    `
+    text-align: left;
+
+    .caption {
+      margin-left: 0;
+      margin-right: 0;
+    }
+  `}
+}`;
+
+type ImageContainerInnerProps = {
+  aspectRatio?: number;
+};
+
+const ImageContainerInner = styled.div<ImageContainerInnerProps>`
+  position: relative;
+  max-height: 80vh;
+  aspect-ratio: ${props => props.aspectRatio};
+  margin: 0 auto;
+`;
+
+type UiCaptionedImageProps = CaptionedImageType & {
+  isBody?: boolean;
+  preCaptionNode?: ReactNode;
+};
+
+const CaptionedImage: FC<UiCaptionedImageProps> = ({
+  caption,
+  preCaptionNode,
+  image,
+  isBody,
+}) => {
+  const uiImageProps = { ...image };
+  return (
+    <CaptionedImageFigure isBody={isBody}>
+      <ImageContainerInner
+        aspectRatio={uiImageProps.width / uiImageProps.height}
+      >
+        <PrismicImageWithTasl
+          image={uiImageProps}
+          sizes={{
+            xlarge: 1,
+            large: 1,
+            medium: 1,
+            small: 1,
+          }}
+          quality={75}
+        />
+        <Caption caption={caption} preCaptionNode={preCaptionNode} />
+      </ImageContainerInner>
+    </CaptionedImageFigure>
+  );
+};
+
+export default CaptionedImage;

--- a/content/webapp/components/DeprecatedImageList/DeprecatedImageList.tsx
+++ b/content/webapp/components/DeprecatedImageList/DeprecatedImageList.tsx
@@ -1,4 +1,4 @@
-import { CaptionedImage } from '@weco/common/views/components/Images/Images';
+import CaptionedImage from '../CaptionedImage/CaptionedImage';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
 import { CaptionedImage as CaptionedImageType } from '@weco/common/model/captioned-image';
 import { FunctionComponent } from 'react';
@@ -18,10 +18,7 @@ const DeprecatedImageList: FunctionComponent<Props> = ({ items }: Props) => {
       {items.map((item, i) => (
         <div className="body-text" key={i}>
           <h2>{item.title}</h2>
-          <CaptionedImage
-            {...item.image}
-            sizesQueries="(min-width: 1540px) 1402px, (min-width: 600px) 92.39vw, 100vw"
-          />
+          <CaptionedImage {...item.image} />
           <PrismicHtmlBlock html={item.description} />
         </div>
       ))}

--- a/content/webapp/components/GifVideo/GifVideo.tsx
+++ b/content/webapp/components/GifVideo/GifVideo.tsx
@@ -193,7 +193,7 @@ const GifVideo: FunctionComponent<Props> = ({
           (tasl.title ||
             tasl.sourceName ||
             tasl.copyrightHolder ||
-            tasl.license) && <Tasl {...tasl} isFull={false} />}
+            tasl.license) && <Tasl {...tasl} />}
       </div>
       {caption && <Caption width={computedVideoWidth} caption={caption} />}
     </figure>

--- a/content/webapp/components/ImageGallery/ImageGallery.tsx
+++ b/content/webapp/components/ImageGallery/ImageGallery.tsx
@@ -9,42 +9,25 @@ import styled from 'styled-components';
 import { font, classNames } from '@weco/common/utils/classnames';
 import { CaptionedImage as CaptionedImageProps } from '@weco/common/model/captioned-image';
 import { repeatingLsBlack } from '@weco/common/utils/backgrounds';
-import { breakpoints } from '@weco/common/utils/breakpoints';
 import { trackEvent } from '@weco/common/utils/ga';
-import { CaptionedImage } from '@weco/common/views/components/Images/Images';
+import CaptionedImage from '../CaptionedImage/CaptionedImage';
 import WobblyEdge from '@weco/common/views/components/WobblyEdge/WobblyEdge';
 import ButtonSolid from '@weco/common/views/components/ButtonSolid/ButtonSolid';
 import Control from '@weco/common/views/components/Buttons/Control/Control';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import Layout12 from '@weco/common/views/components/Layout12/Layout12';
-import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
+import Layout8 from '@weco/common/views/components/Layout8/Layout8';
 import Space from '@weco/common/views/components/styled/Space';
 import { cross, gallery } from '@weco/common/icons';
 import { PageBackgroundContext } from '../ContentPage/ContentPage';
 
-type TitleStyle = {
-  transform?: string;
-  maxWidth?: string;
-  opacity?: number;
-};
-
-const GalleryTitle = styled(Space).attrs<{
-  titleStyle: TitleStyle;
-  isEnhanced: boolean;
-}>(props => ({
+const GalleryTitle = styled(Space).attrs({
   v: { size: 'm', properties: ['margin-bottom'] },
   as: 'span',
-  style: props.titleStyle,
   className: classNames({
     'flex flex--v-top': true,
   }),
-}))<{ titleStyle: TitleStyle; isEnhanced: boolean }>`
-  ${props =>
-    props.isEnhanced &&
-    `
-    opacity: 0;
-  `}
-`;
+})``;
 
 const Gallery = styled.div.attrs({
   className: 'row relative',
@@ -60,6 +43,18 @@ const Gallery = styled.div.attrs({
   .tasl {
     display: none;
   }
+
+  img {
+    transition: filter 400ms ease;
+  }
+
+  ${props =>
+    !props.isActive &&
+    `
+      img:hover {
+        filter: brightness(80%);
+      }
+    `}
 
   ${props =>
     props.isActive &&
@@ -91,50 +86,7 @@ const Gallery = styled.div.attrs({
       `
       }
     }
-
-    .captioned-image__image-container {
-      background: ${props.theme.color('charcoal')};
-
-      &:before {
-        display: none;
-      }
-      &:hover:before {
-        opacity: 0;
-      }
-    }
   `}
-
-  .captioned-image__image-container {
-    &:before {
-      content: '';
-      position: absolute;
-      top: 0;
-      bottom: 0;
-      left: 0;
-      right: 0;
-      opacity: 0;
-      background: ${props => props.theme.color('charcoal')};
-      transition: opacity 400ms ease;
-    }
-
-    &:hover:before {
-      opacity: 0.3;
-    }
-  }
-
-  &:before {
-    content: '';
-    position: absolute;
-    top: 100px;
-    right: 0;
-    left: 0;
-    bottom: 0;
-    transition: all 400ms ease;
-
-    @include respond-to('medium') {
-      top: 200px;
-    }
-  }
 
   transition: all 400ms ease;
 
@@ -244,15 +196,9 @@ const ImageGallery: FunctionComponent<{ id: number } & Props> = ({
   isStandalone,
 }) => {
   const [isActive, setIsActive] = useState(true);
-  const [titleStyle, setTitleStyle] = useState<TitleStyle>({
-    transform: undefined,
-    maxWidth: undefined,
-    opacity: undefined,
-  });
   const openButtonRef = useRef<HTMLButtonElement>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
   const headingRef = useRef<HTMLHeadingElement>(null);
-  const { isEnhanced } = useContext(AppContext);
   const pageBackground = useContext(PageBackgroundContext);
 
   useEffect(() => {
@@ -306,27 +252,19 @@ const ImageGallery: FunctionComponent<{ id: number } & Props> = ({
     return isActive ? items : [items[0]];
   };
 
-  // We want the image gallery title to be aligned with the first image
-  // So we adjust the translateX and width accordingly
-  function updateTitleStyle(value: number) {
-    setTitleStyle({
-      transform: `translateX(calc((100vw - ${value}px) / 2))`,
-      maxWidth: `${value}px`,
-      opacity: 1,
-    });
-  }
-
   return (
     <>
       {!isStandalone && (
-        <GalleryTitle titleStyle={titleStyle} isEnhanced={isEnhanced}>
-          <Space as="span" h={{ size: 's', properties: ['margin-right'] }}>
-            <Icon icon={gallery} />
-          </Space>
-          <h2 id={`gallery-${id}`} className="h2 no-margin" ref={headingRef}>
-            {title || 'In pictures'}
-          </h2>
-        </GalleryTitle>
+        <Layout8>
+          <GalleryTitle>
+            <Space as="span" h={{ size: 's', properties: ['margin-right'] }}>
+              <Icon icon={gallery} />
+            </Space>
+            <h2 id={`gallery-${id}`} className="h2 no-margin" ref={headingRef}>
+              {title || 'In pictures'}
+            </h2>
+          </GalleryTitle>
+        </Layout8>
       )}
       <Gallery
         isActive={isActive}
@@ -428,11 +366,6 @@ const ImageGallery: FunctionComponent<{ id: number } & Props> = ({
                 <CaptionedImage
                   image={captionedImage.image}
                   caption={captionedImage.caption}
-                  setTitleStyle={i === 0 ? updateTitleStyle : undefined}
-                  sizesQueries={`
-                          (min-width: ${breakpoints.xlarge}) calc(${breakpoints.xlarge} - 120px),
-                          calc(100vw - 84px)
-                        `}
                   preCaptionNode={
                     items.length > 1 ? (
                       <Space
@@ -452,7 +385,7 @@ const ImageGallery: FunctionComponent<{ id: number } & Props> = ({
               </Space>
             ))}
 
-            {titleStyle && (
+            {!isStandalone && (
               <ButtonContainer isHidden={isActive}>
                 <ButtonSolid
                   ref={openButtonRef}

--- a/content/webapp/components/PrismicImageWithTasl/PrismicImageWithTasl.tsx
+++ b/content/webapp/components/PrismicImageWithTasl/PrismicImageWithTasl.tsx
@@ -1,0 +1,14 @@
+import { FC } from 'react';
+import Tasl from '@weco/common/views/components/Tasl/Tasl';
+import PrismicImage, { Props } from '@weco/common/views/components/PrismicImage/PrismicImage';
+
+const PrismicImageWithTasl: FC<Props> = ({ image, sizes, quality }) => {
+  return (
+    <div className="relative">
+      <PrismicImage image={image} sizes={sizes} quality={quality} />
+      <Tasl {...image.tasl} />
+    </div>
+  );
+};
+
+export default PrismicImageWithTasl;

--- a/content/webapp/components/PrismicImageWithTasl/PrismicImageWithTasl.tsx
+++ b/content/webapp/components/PrismicImageWithTasl/PrismicImageWithTasl.tsx
@@ -1,6 +1,8 @@
 import { FC } from 'react';
 import Tasl from '@weco/common/views/components/Tasl/Tasl';
-import PrismicImage, { Props } from '@weco/common/views/components/PrismicImage/PrismicImage';
+import PrismicImage, {
+  Props,
+} from '@weco/common/views/components/PrismicImage/PrismicImage';
 
 const PrismicImageWithTasl: FC<Props> = ({ image, sizes, quality }) => {
   return (


### PR DESCRIPTION
Relates to #7932

- Puts the CaptionedImage component in it's own file
- Converts it to a functional component
- Makes use of the [aspect-ratio CSS property](https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio) to simplify the component (we'd previously been [calculating image widths and changing CSS properties with javascript](https://github.com/wellcomecollection/wellcomecollection.org/pull/3414) in order to achieve the required layout)
- Creates a PrismicImageWithTasl component to use inside CaptionedImage