### PR TITLE
Book images

### DIFF
--- a/cardigan/stories/components/PageHeader/PageHeader.stories.tsx
+++ b/cardigan/stories/components/PageHeader/PageHeader.stories.tsx
@@ -292,5 +292,15 @@ book.args = {
   ContentTypeInfo: <BookContentTypeInfo />,
   isContentTypeInfoBeforeMedia: true,
   breadcrumbs: { items: [{ text: 'Books', url: '#' }] },
-  FeaturedMedia: <BookImage image={bookImage} />,
+  FeaturedMedia: (
+    <BookImage
+      image={bookImage}
+      sizes={{
+        xlarge: 1 / 2,
+        large: 1 / 2,
+        medium: 1 / 2,
+        small: 1,
+      }}
+    />
+  ),
 };

--- a/content/webapp/components/BookImage/BookImage.tsx
+++ b/content/webapp/components/BookImage/BookImage.tsx
@@ -5,7 +5,7 @@ import { FunctionComponent, ReactElement } from 'react';
 import PrismicImage, {
   BreakpointSizes,
 } from '@weco/common/views/components/PrismicImage/PrismicImage';
-import { UiImageType } from '@weco/common/model/image';
+import { ImageType } from '@weco/common/model/image';
 
 const BookPromoImageContainer = styled.div.attrs({
   className: classNames({
@@ -28,7 +28,7 @@ const BookPromoImage = styled(Space).attrs({
 `;
 
 type Props = {
-  image: UiImageType;
+  image: ImageType;
   sizes: BreakpointSizes;
   quality?: number;
 };

--- a/content/webapp/components/BookImage/BookImage.tsx
+++ b/content/webapp/components/BookImage/BookImage.tsx
@@ -1,54 +1,60 @@
 import styled from 'styled-components';
 import Space from '@weco/common/views/components/styled/Space';
-import { UiImage } from '@weco/common/views/components/Images/Images';
 import { classNames } from '@weco/common/utils/classnames';
-import { UiImageType } from '@weco/common/model/image';
 import { FunctionComponent, ReactElement } from 'react';
+import PrismicImage, {
+  BreakpointSizes,
+} from '@weco/common/views/components/PrismicImage/PrismicImage';
+import { UiImageType } from '@weco/common/model/image';
 
-const Outer = styled('div').attrs({
+const BookPromoImageContainer = styled.div.attrs({
   className: classNames({
-    'bg-cream relative h-center': true,
+    'bg-cream relative': true,
   }),
 })`
-  height: 70vh;
-  max-height: 100vw;
-  max-width: 600px;
+  height: 0;
+  padding-top: 100%;
   transform: rotate(-2deg);
 `;
 
-const Inner = styled('div').attrs({
+const BookPromoImage = styled(Space).attrs({
   className: classNames({
     absolute: true,
   }),
 })`
-  bottom: 0;
-  width: 66vw;
+  width: 66%;
   left: 50%;
-  transform: translateX(-50%) rotate(2deg) translateY(-5vw);
-
-  ${props => props.theme.media.large`
-    transform: translateX(-50%) rotate(2deg) translateY(-50px);
-  `}
+  transform: translateX(-50%) rotate(2deg);
 `;
 
 type Props = {
   image: UiImageType;
+  sizes: BreakpointSizes;
+  quality?: number;
 };
 
 const BookImage: FunctionComponent<Props> = ({
   image,
+  sizes,
+  quality,
 }: Props): ReactElement<Props> => {
   return (
-    <Space v={{ size: 'xl', properties: ['margin-top', 'padding-top'] }}>
-      <Outer>
-        <Inner>
-          <UiImage
-            extraClasses="margin-h-auto width-auto max-height-70vh"
-            {...image}
+    <BookPromoImageContainer>
+      {image.contentUrl && (
+        <BookPromoImage v={{ size: 'l', properties: ['bottom'] }}>
+          <PrismicImage
+            image={{
+              contentUrl: image.contentUrl || '',
+              width: image.width,
+              height: image.height,
+              alt: image?.alt,
+            }}
+            sizes={sizes}
+            quality={quality}
           />
-        </Inner>
-      </Outer>
-    </Space>
+        </BookPromoImage>
+      )}
+    </BookPromoImageContainer>
   );
 };
 

--- a/content/webapp/components/BookPromo/BookPromo.tsx
+++ b/content/webapp/components/BookPromo/BookPromo.tsx
@@ -1,31 +1,11 @@
 import { font, classNames } from '@weco/common/utils/classnames';
 import { trackEvent } from '@weco/common/utils/ga';
-import UiImage from '@weco/common/views/components/Image/Image';
 import { BookBasic } from '../../types/books';
 import Space from '@weco/common/views/components/styled/Space';
 import styled from 'styled-components';
 import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
 import { FunctionComponent, ReactElement } from 'react';
-
-const BookPromoImageContainer = styled.div.attrs({
-  className: classNames({
-    'bg-cream relative': true,
-  }),
-})`
-  height: 0;
-  padding-top: 100%;
-  transform: rotate(-2deg);
-`;
-
-const BookPromoImage = styled(Space).attrs({
-  className: classNames({
-    absolute: true,
-  }),
-})`
-  width: 66%;
-  left: 50%;
-  transform: translateX(-50%) rotate(2deg);
-`;
+import BookImage from '../../components/BookImage/BookImage';
 
 type LinkOrSpanSpaceAttrs = {
   url?: string;
@@ -63,24 +43,25 @@ const BookPromo: FunctionComponent<Props> = ({ book }: Props): ReactElement => {
       }}
     >
       <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
-        <BookPromoImageContainer>
-          {cover?.contentUrl && (
-            <BookPromoImage v={{ size: 'l', properties: ['bottom'] }}>
-              <UiImage
-                contentUrl={cover.contentUrl}
-                width={cover.width || 0}
-                height={cover.height || 0}
-                // We intentionally omit the alt text on promos, so screen reader
-                // users don't have to listen to the alt text before hearing the
-                // title of the item in the list.
-                //
-                // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
-                alt=""
-                sizesQueries="(min-width: 1420px) 386px, (min-width: 960px) calc(28.64vw - 15px), (min-width: 600px) calc(50vw - 54px), calc(100vw - 36px)"
-              />
-            </BookPromoImage>
-          )}
-        </BookPromoImageContainer>
+        <BookImage
+          image={{
+            contentUrl: cover?.contentUrl || '',
+            width: cover?.width || 0,
+            height: cover?.height || 0,
+            // We intentionally omit the alt text on promos, so screen reader
+            // users don't have to listen to the alt text before hearing the
+            // title of the item in the list.
+            //
+            // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
+            alt: '',
+          }}
+          sizes={{
+            xlarge: 1 / 6,
+            large: 1 / 6,
+            medium: 1 / 3,
+            small: 1,
+          }}
+        />
         <Space
           h={{
             size: 'l',

--- a/content/webapp/pages/book.tsx
+++ b/content/webapp/pages/book.tsx
@@ -18,6 +18,7 @@ import { createClient } from '../services/prismic/fetch';
 import { transformBook } from '../services/prismic/transformers/books';
 import { Book } from '../types/books';
 import { looksLikePrismicId } from '../services/prismic';
+import Layout8 from '@weco/common/views/components/Layout8/Layout8';
 
 const MetadataWrapper = styled.div`
   border-top: 1px solid ${props => props.theme.color('smoke')};
@@ -99,7 +100,15 @@ const BookPage: FunctionComponent<Props> = props => {
 
   const { book } = props;
   const FeaturedMedia = book.cover && (
-    <BookImage image={{ ...book.cover, sizesQueries: '' }} />
+    <Space v={{ size: 'xl', properties: ['margin-top', 'padding-top'] }}>
+      <Layout8>
+        <BookImage
+          image={{ ...book.cover }}
+          sizes={{ xlarge: 1 / 3, large: 1 / 3, medium: 1 / 3, small: 1 }}
+          quality={75}
+        />
+      </Layout8>
+    </Space>
   );
   const breadcrumbs = {
     items: [


### PR DESCRIPTION
Relates to #7932

Using PrismicImage for book images and have tweaked the BookImage component, so we can use it in both the BookPromo component and on the book page, rather than replicating styles in both places.
