### PR TITLE
Handle identity API proxy errors which don't have a response

### DIFF
--- a/identity/webapp/pages/api/users/[[...users]].ts
+++ b/identity/webapp/pages/api/users/[[...users]].ts
@@ -33,6 +33,7 @@ const handleIdentityApiRequest: NextApiHandler = auth0.withApiAuthRequired(
           if (error.response) {
             return error.response;
           }
+          // This can occur if, e.g. the TLS certificate for the API has expired.
           console.error('Connection-level error (no response received)', error);
           return {
             status: 500,

--- a/identity/webapp/pages/api/users/[[...users]].ts
+++ b/identity/webapp/pages/api/users/[[...users]].ts
@@ -29,7 +29,16 @@ const handleIdentityApiRequest: NextApiHandler = auth0.withApiAuthRequired(
           },
           validateStatus: (status: number) => status >= 200 && status < 500,
         })
-        .catch(error => error.response);
+        .catch(error => {
+          if (error.response) {
+            return error.response;
+          }
+          console.error('Connection-level error (no response received)', error);
+          return {
+            status: 500,
+            data: { message: 'Error connecting to API' },
+          };
+        });
 
       res.status(remoteResponse.status).send(remoteResponse.data);
     } catch (e) {


### PR DESCRIPTION
This should make problems like the cert expiry from earlier easier to detect