### PR TITLE
Less 500 errors from API endpoints

### DIFF
--- a/content/webapp/pages/api/articles/index.ts
+++ b/content/webapp/pages/api/articles/index.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { isString } from '@weco/common/utils/array';
+import { isNotUndefined, isString } from '@weco/common/utils/array';
 import { createClient } from '../../../services/prismic/fetch';
 import { fetchArticles } from '../../../services/prismic/fetch/articles';
 import { transformQuery } from '../../../services/prismic/transformers/paginated-results';
@@ -16,12 +16,15 @@ export default async (
 ) => {
   const { params } = req.query;
   const parsedParams = isString(params) ? JSON.parse(params) : undefined;
-  const client = createClient({ req });
-  const query = await fetchArticles(client, parsedParams);
 
-  if (query) {
-    const articles = transformQuery(query, transformArticle);
-    return res.status(200).json(articles);
+  if (isNotUndefined(parsedParams)) {
+    const client = createClient({ req });
+    const query = await fetchArticles(client, parsedParams);
+
+    if (query) {
+      const articles = transformQuery(query, transformArticle);
+      return res.status(200).json(articles);
+    }
   }
 
   return res.status(404).json({ notFound: true });

--- a/content/webapp/pages/api/events/index.ts
+++ b/content/webapp/pages/api/events/index.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { isString } from '@weco/common/utils/array';
+import { isNotUndefined, isString } from '@weco/common/utils/array';
 import { createClient } from '../../../services/prismic/fetch';
 import { fetchEvents } from '../../../services/prismic/fetch/events';
 import { PaginatedResults } from '@weco/common/services/prismic/types';
@@ -16,12 +16,15 @@ export default async (
 ): Promise<void> => {
   const { params } = req.query;
   const parsedParams = isString(params) ? JSON.parse(params) : undefined;
-  const client = createClient({ req });
-  const query = await fetchEvents(client, parsedParams);
 
-  if (query) {
-    const events = transformQuery(query, transformEvent);
-    return res.status(200).json(events);
+  if (isNotUndefined(parsedParams)) {
+    const client = createClient({ req });
+    const query = await fetchEvents(client, parsedParams);
+
+    if (query) {
+      const events = transformQuery(query, transformEvent);
+      return res.status(200).json(events);
+    }
   }
 
   return res.status(404).json({ notFound: true });

--- a/content/webapp/pages/api/exhibitions/index.ts
+++ b/content/webapp/pages/api/exhibitions/index.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { isString } from '@weco/common/utils/array';
+import { isNotUndefined, isString } from '@weco/common/utils/array';
 import { createClient } from '../../../services/prismic/fetch';
 import { fetchExhibitions } from '../../../services/prismic/fetch/exhibitions';
 import { transformExhibitionsQuery } from '../../../services/prismic/transformers/exhibitions';
@@ -15,12 +15,15 @@ export default async (
 ): Promise<void> => {
   const { params } = req.query;
   const parsedParams = isString(params) ? JSON.parse(params) : undefined;
-  const client = createClient({ req });
-  const query = await fetchExhibitions(client, parsedParams);
 
-  if (query) {
-    const exhibitions = transformExhibitionsQuery(query);
-    return res.status(200).json(exhibitions);
+  if (isNotUndefined(parsedParams)) {
+    const client = createClient({ req });
+    const query = await fetchExhibitions(client, parsedParams);
+
+    if (query) {
+      const exhibitions = transformExhibitionsQuery(query);
+      return res.status(200).json(exhibitions);
+    }
   }
 
   return res.status(404).json({ notFound: true });


### PR DESCRIPTION
If you look in our CloudFront logs, you see a stack of errors from API endpoints like `/api/events` when you don't pass any parameters; this patch makes them 404 instead of 500.