### PR TITLE
Improve how we use vanity URLs on the site

### DIFF
--- a/content/webapp/app.ts
+++ b/content/webapp/app.ts
@@ -39,6 +39,12 @@ function pageVanityUrl(
   // Redirect specific page IDs to their vanity URL.  In some cases, this also
   // means redirecting them to a different template (e.g. the homepage needs
   // to go to the homepage template, not the page template with ID=Xph...)
+  //
+  // Note: we have similar logic in a Lambda@Edge that's part of the CloudFront
+  // distribution, but we duplicate it here because this is the most up-to-date
+  // definition of vanity URLs.
+  //
+  // See https://github.com/wellcomecollection/wellcomecollection.org/blob/main/cache/edge_lambdas/src/redirects.ts
   router.redirect(`/pages/${pageId}`, url, permanentRedirect);
 
   route(url, template, router, app, { id: pageId });

--- a/content/webapp/app.ts
+++ b/content/webapp/app.ts
@@ -27,6 +27,8 @@ const dev = process.env.NODE_ENV !== 'production';
 const nextApp = next({ dev });
 const handle = nextApp.getRequestHandler();
 
+const permanentRedirect = 301;
+
 function pageVanityUrl(
   router: Router,
   app,
@@ -34,6 +36,11 @@ function pageVanityUrl(
   pageId: string,
   template = '/page'
 ) {
+  // Redirect specific page IDs to their vanity URL.  In some cases, this also
+  // means redirecting them to a different template (e.g. the homepage needs
+  // to go to the homepage template, not the page template with ID=Xph...)
+  router.redirect(`/pages/${pageId}`, url, permanentRedirect);
+
   route(url, template, router, app, { id: pageId });
 }
 
@@ -84,7 +91,6 @@ const appPromise = nextApp
     route(`/books/:id(${prismicId})`, '/book', router, nextApp);
 
     route(`/places/:id(${prismicId})`, '/place', router, nextApp);
-    route(`/pages/:id(${prismicId})`, '/page', router, nextApp);
     route(`/seasons/:id(${prismicId})`, '/season', router, nextApp);
 
     route('/newsletter', '/newsletter', router, nextApp);
@@ -122,6 +128,17 @@ const appPromise = nextApp
     pageVanityUrl(router, nextApp, '/about-us', prismicPageIds.aboutUs);
     pageVanityUrl(router, nextApp, '/get-involved', prismicPageIds.getInvolved);
     pageVanityUrl(router, nextApp, '/user-panel', prismicPageIds.userPanel);
+
+    router.redirect(
+      `/pages/${prismicPageIds.stories}`,
+      '/stories',
+      permanentRedirect
+    );
+
+    // We define this _after_ the vanity URLs and redirects for specific page IDs;
+    // this means this route will only serve pages that we want to be accessible by
+    // ID and not a vanity URL.
+    route(`/pages/:id(${prismicId})`, '/page', router, nextApp);
 
     router.post('/newsletter-signup', handleNewsletterSignup);
 

--- a/content/webapp/app.ts
+++ b/content/webapp/app.ts
@@ -89,9 +89,7 @@ const appPromise = nextApp
 
     route('/newsletter', '/newsletter', router, nextApp);
 
-    route('/collections', '/page', router, nextApp, {
-      id: prismicPageIds.collections,
-    });
+    pageVanityUrl(router, nextApp, '/collections', prismicPageIds.collections);
 
     route('/guides', '/guides', router, nextApp);
     route(`/guides/:id(${prismicId})`, '/page', router, nextApp);

--- a/content/webapp/pages/page.tsx
+++ b/content/webapp/pages/page.tsx
@@ -14,7 +14,6 @@ import {
   landingHeaderBackgroundLs,
 } from '@weco/common/utils/backgrounds';
 import {
-  homepageId,
   prismicPageIds,
   sectionLevelPages,
 } from '@weco/common/services/prismic/hardcoded-id';

--- a/content/webapp/pages/page.tsx
+++ b/content/webapp/pages/page.tsx
@@ -14,6 +14,7 @@ import {
   landingHeaderBackgroundLs,
 } from '@weco/common/utils/backgrounds';
 import {
+  homepageId,
   prismicPageIds,
   sectionLevelPages,
 } from '@weco/common/services/prismic/hardcoded-id';
@@ -60,6 +61,17 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
     const serverData = await getServerData(context);
     const { id } = context.query;
+
+    // Although the homepage has a Prismic ID, you can't actually view it as a page.
+    // If somebody somehow lands here, send them to the proper homepage.
+    if (id === homepageId) {
+      return {
+        redirect: {
+          destination: `/`,
+          permanent: true,
+        },
+      };
+    }
 
     const client = createClient(context);
 


### PR DESCRIPTION
This makes a couple of improvements to our vanity URLs:

* If you land on a page with a vanity URL, you get redirected to the correct page. This is particularly useful when crossing templates, e.g. https://wellcomecollection.org/pages/XphUbREAACMAgRNP is pretty useless, because that page ID is a placeholder for the homepage.

  Although this is also handled by a CloudFront redirection Lambda, there are a few cases (e.g. /visit-us, /collections) where that's not working correctly.

* We use the vanity URLs for the `<link rel="canonical">` in the header of the page, so we get the correct URLs in e.g. Google search results.

This alone isn't especially interesting, but it means we can be sure that if somebody is looking at `/visit-us` or `/collections`, they're doing it through the vanity URL and not the vanilla page template – and I think that unlocks some potential performance wins. I'll do those in a separate PR.