### PR TITLE
Split out the collections/visit us static content

### DIFF
--- a/content/webapp/app.ts
+++ b/content/webapp/app.ts
@@ -87,7 +87,6 @@ const appPromise = nextApp
     route(`/events/:id(${prismicId})`, '/event', router, nextApp);
     route(`/event-series/:id(${prismicId})`, '/event-series', router, nextApp);
 
-    route('/stories', '/stories', router, nextApp);
     route('/articles', '/articles', router, nextApp);
     route(`/articles/:id(${prismicId})`, '/article', router, nextApp);
     route(`/series/:id(${prismicId})`, '/article-series', router, nextApp);
@@ -100,8 +99,6 @@ const appPromise = nextApp
     route(`/seasons/:id(${prismicId})`, '/season', router, nextApp);
 
     route('/newsletter', '/newsletter', router, nextApp);
-
-    pageVanityUrl(router, nextApp, '/collections', prismicPageIds.collections);
 
     route('/guides', '/guides', router, nextApp);
     route(`/guides/:id(${prismicId})`, '/page', router, nextApp);
@@ -124,13 +121,6 @@ const appPromise = nextApp
       '/covid-welcome-back',
       prismicPageIds.covidWelcomeBack
     );
-    pageVanityUrl(
-      router,
-      nextApp,
-      '/visit-us',
-      prismicPageIds.visitUs,
-      '/page'
-    );
     pageVanityUrl(router, nextApp, '/about-us', prismicPageIds.aboutUs);
     pageVanityUrl(router, nextApp, '/get-involved', prismicPageIds.getInvolved);
     pageVanityUrl(router, nextApp, '/user-panel', prismicPageIds.userPanel);
@@ -140,6 +130,21 @@ const appPromise = nextApp
       '/stories',
       permanentRedirect
     );
+    route('/stories', '/stories', router, nextApp);
+
+    router.redirect(
+      `/pages/${prismicPageIds.collections}`,
+      '/collections',
+      permanentRedirect
+    );
+    route('/collections', '/collections', router, nextApp);
+
+    router.redirect(
+      `/pages/${prismicPageIds.visitUs}`,
+      '/visit-us',
+      permanentRedirect
+    );
+    route('/visit-us', '/visit-us', router, nextApp);
 
     // We define this _after_ the vanity URLs and redirects for specific page IDs;
     // this means this route will only serve pages that we want to be accessible by

--- a/content/webapp/components/Body/Body.tsx
+++ b/content/webapp/components/Body/Body.tsx
@@ -85,7 +85,7 @@ type Props = {
   minWidth?: 10 | 8;
   isLanding?: boolean;
   sectionLevelPage?: boolean;
-  staticContent: ReactElement | null;
+  staticContent?: ReactElement;
 };
 
 type ContentListSlice = BodySlice & { type: 'contentList' };

--- a/content/webapp/components/Body/Body.tsx
+++ b/content/webapp/components/Body/Body.tsx
@@ -42,8 +42,6 @@ import GridFactory, { sectionLevelPageGrid } from './GridFactory';
 import Card from '../Card/Card';
 import { convertItemToCardProps } from '../../types/card';
 import { BodySlice, isContentList } from '../../types/body';
-import VisitUsStaticContent from './VisitUsStaticContent';
-import CollectionsStaticContent from './CollectionsStaticContent';
 import AsyncSearchResults from '../SearchResults/AsyncSearchResults';
 import SearchResults from '../SearchResults/SearchResults';
 import VenueHours from '../VenueHours/VenueHours';
@@ -87,6 +85,7 @@ type Props = {
   minWidth?: 10 | 8;
   isLanding?: boolean;
   sectionLevelPage?: boolean;
+  staticContent: ReactElement | null;
 };
 
 type ContentListSlice = BodySlice & { type: 'contentList' };
@@ -100,6 +99,7 @@ const Body: FunctionComponent<Props> = ({
   minWidth = 8,
   isLanding = false,
   sectionLevelPage = false,
+  staticContent = null,
 }: Props) => {
   const filteredBody = body
     .filter(slice => !(slice.type === 'picture' && slice.weight === 'featured'))
@@ -143,18 +143,17 @@ const Body: FunctionComponent<Props> = ({
     index,
     sections = [],
     isLanding = false,
+    staticContent,
   }: {
     index: number;
     sections: ContentListSlice[];
     isLanding: boolean;
+    staticContent: ReactElement | null;
   }): ReactElement<Props> | null => {
     if (index === 0) {
       return (
         <>
-          {pageId === prismicPageIds.visitUs && <VisitUsStaticContent />}
-          {pageId === prismicPageIds.collections && (
-            <CollectionsStaticContent />
-          )}
+          {staticContent}
           {onThisPage && onThisPage.length > 2 && showOnThisPage && (
             <SpacingComponent>
               <LayoutWidth width={minWidth}>
@@ -271,6 +270,7 @@ const Body: FunctionComponent<Props> = ({
           index={0}
           sections={sections}
           isLanding={isLanding}
+          staticContent={staticContent}
         />
       )}
 
@@ -299,6 +299,7 @@ const Body: FunctionComponent<Props> = ({
             index={i}
             sections={sections}
             isLanding={isLanding}
+            staticContent={staticContent}
           />
           {!(
             i === 0 &&

--- a/content/webapp/components/Body/Body.tsx
+++ b/content/webapp/components/Body/Body.tsx
@@ -85,7 +85,7 @@ type Props = {
   minWidth?: 10 | 8;
   isLanding?: boolean;
   sectionLevelPage?: boolean;
-  staticContent?: ReactElement;
+  staticContent?: ReactElement | null;
 };
 
 type ContentListSlice = BodySlice & { type: 'contentList' };

--- a/content/webapp/pages/collections.tsx
+++ b/content/webapp/pages/collections.tsx
@@ -1,0 +1,26 @@
+import { prismicPageIds } from '@weco/common/services/prismic/hardcoded-id';
+import { AppErrorProps } from '@weco/common/views/pages/_app';
+import CollectionsStaticContent from 'components/Body/CollectionsStaticContent';
+import { GetServerSideProps } from 'next';
+import { FC } from 'react';
+import * as page from './page';
+
+export const getServerSideProps: GetServerSideProps<
+  page.Props | AppErrorProps
+> = async context => {
+  console.log(`collections.getServerSideProps`);
+
+  return page.getServerSideProps({
+    ...context,
+    query: { id: prismicPageIds.collections },
+  });
+};
+
+const CollectionsPage: FC<page.Props> = (props: page.Props) => {
+  console.log('CollectionsPage');
+  const staticContent = <CollectionsStaticContent />;
+  console.log(staticContent);
+  return <page.Page {...props} staticContent={staticContent} />;
+};
+
+export default CollectionsPage;

--- a/content/webapp/pages/page.tsx
+++ b/content/webapp/pages/page.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, ReactElement } from 'react';
 import PageLayout, {
   SiteSection,
 } from '@weco/common/views/components/PageLayout/PageLayout';
@@ -41,13 +41,15 @@ import { transformPage } from '../services/prismic/transformers/pages';
 import { getCrop } from '@weco/common/model/image';
 import { isPicture, isVideoEmbed } from 'types/body';
 import { isNotUndefined } from '@weco/common/utils/array';
+import VisitUsStaticContent from 'components/Body/VisitUsStaticContent';
 
-type Props = {
+export type Props = {
   page: PageType;
   vanityUrl: string | undefined;
   siblings: SiblingsGroup<PageType>[];
   children: SiblingsGroup<PageType>;
   ordersInParents: OrderInParent[];
+  staticContent: ReactElement | null;
 } & WithGaDimensions;
 
 type OrderInParent = {
@@ -127,6 +129,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
           siblings,
           children,
           ordersInParents,
+          staticContent: null,
           serverData,
           vanityUrl,
           gaDimensions: {
@@ -139,11 +142,12 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     }
   };
 
-const Page: FC<Props> = ({
+export const Page: FC<Props> = ({
   page,
   siblings,
   children,
   ordersInParents,
+  staticContent,
   vanityUrl,
 }) => {
   function makeLabels(title?: string): LabelsListProps | undefined {
@@ -322,6 +326,7 @@ const Page: FC<Props> = ({
             showOnThisPage={page.showOnThisPage}
             isLanding={isLanding}
             sectionLevelPage={sectionLevelPage}
+            staticContent={staticContent}
           />
         }
         /**

--- a/content/webapp/pages/visit-us.tsx
+++ b/content/webapp/pages/visit-us.tsx
@@ -1,0 +1,23 @@
+import { prismicPageIds } from '@weco/common/services/prismic/hardcoded-id';
+import { AppErrorProps } from '@weco/common/views/pages/_app';
+import VisitUsStaticContent from 'components/Body/VisitUsStaticContent';
+import { GetServerSideProps } from 'next';
+import { FC } from 'react';
+import * as page from './page';
+
+export const getServerSideProps: GetServerSideProps<
+  page.Props | AppErrorProps
+> = async context => {
+  return page.getServerSideProps({
+    ...context,
+    query: { id: prismicPageIds.visitUs },
+  });
+};
+
+const VisitUs: FC<page.Props> = (props: page.Props) => {
+  const staticContent = <VisitUsStaticContent />;
+
+  return <page.Page {...props} staticContent={staticContent}></page.Page>;
+};
+
+export default VisitUs;


### PR DESCRIPTION
I don't know if we actually want to merge this, but I wanted to play around a bit with Next and routes and do a bit more React work.

This takes the CollectionsStaticContent component off the critical path for pages, and only loads it if you hit `/collections` (which thanks to #7973, you'll land on even if you're at `/pages/$collectionsPageId`). This should mean we don't have to load the Collections search form (or filters, or tabs, or anything else) if you're not specifically on a collections page.

I've checked both these pages are still loading their static content correctly.