### PR TITLE
Render JSON-LD on the server side

### DIFF
--- a/content/webapp/components/Exhibition/Exhibition.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.tsx
@@ -29,7 +29,6 @@ import Body from '../Body/Body';
 import SearchResults from '../SearchResults/SearchResults';
 import ContentPage from '../ContentPage/ContentPage';
 import Contributors from '../Contributors/Contributors';
-import { exhibitionLd } from '../../services/prismic/transformers/json-ld';
 import { isNotUndefined } from '@weco/common/utils/array';
 import { a11y } from '@weco/common/data/microcopy';
 import { fetchExhibitionRelatedContentClientSide } from '../../services/prismic/fetch/exhibitions';
@@ -38,6 +37,7 @@ import { Book } from '../../types/books';
 import { Article } from '../../types/articles';
 import { Event as EventType } from '../../types/events';
 import * as prismicT from '@prismicio/types';
+import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 
 type ExhibitionItem = LabelField & {
   icon?: IconSvg;
@@ -197,10 +197,11 @@ export function getInfoItems(exhibition: ExhibitionType): ExhibitionItem[] {
 
 type Props = {
   exhibition: ExhibitionType;
+  jsonLd: JsonLdObj;
   pages: PageType[];
 };
 
-const Exhibition: FC<Props> = ({ exhibition, pages }) => {
+const Exhibition: FC<Props> = ({ exhibition, jsonLd, pages }) => {
   type ExhibitionOf = (ExhibitionType | EventType)[];
   type ExhibitionAbout = (Book | Article)[];
 
@@ -284,7 +285,7 @@ const Exhibition: FC<Props> = ({ exhibition, pages }) => {
         exhibition.metadataDescription || exhibition.promo?.caption || ''
       }
       url={{ pathname: `/exhibitions/${exhibition.id}` }}
-      jsonLd={exhibitionLd(exhibition)}
+      jsonLd={jsonLd}
       openGraphType={'website'}
       siteSection={'whats-on'}
       image={exhibition.image}

--- a/content/webapp/components/Installation/Installation.tsx
+++ b/content/webapp/components/Installation/Installation.tsx
@@ -12,15 +12,19 @@ import { font } from '@weco/common/utils/classnames';
 import { isPast } from '@weco/common/utils/dates';
 import Body from '../Body/Body';
 import ContentPage from '../ContentPage/ContentPage';
-import { exhibitionLd } from '../../services/prismic/transformers/json-ld';
 import { isNotUndefined } from '@weco/common/utils/array';
 import { fetchExhibitExhibition } from '../../services/prismic/fetch/exhibitions';
+import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 
 type Props = {
   installation: InstallationType;
+  jsonLd: JsonLdObj;
 };
 
-const Installation: FunctionComponent<Props> = ({ installation }: Props) => {
+const Installation: FunctionComponent<Props> = ({
+  installation,
+  jsonLd,
+}: Props) => {
   const [partOf, setPartOf] = useState<InstallationType>();
   useEffect(() => {
     fetchExhibitExhibition(installation.id).then(exhibition => {
@@ -87,7 +91,7 @@ const Installation: FunctionComponent<Props> = ({ installation }: Props) => {
         installation.metadataDescription || installation.promo?.caption || ''
       }
       url={{ pathname: `/installations/${installation.id}` }}
-      jsonLd={exhibitionLd(installation)}
+      jsonLd={jsonLd}
       openGraphType={'website'}
       siteSection={'whats-on'}
       image={installation.image}

--- a/content/webapp/pages/article.tsx
+++ b/content/webapp/pages/article.tsx
@@ -27,9 +27,11 @@ import { articleLd } from '../services/prismic/transformers/json-ld';
 import { looksLikePrismicId } from '../services/prismic';
 import { bodySquabblesSeries } from '@weco/common/services/prismic/hardcoded-id';
 import { transformArticle } from '../services/prismic/transformers/articles';
+import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 
 type Props = {
   article: Article;
+  jsonLd: JsonLdObj;
 } & WithGaDimensions;
 
 function articleHasOutro(article: Article) {
@@ -51,9 +53,11 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
 
     if (articleDocument) {
       const article = transformArticle(articleDocument);
+      const jsonLd = articleLd(article);
       return {
         props: removeUndefinedProps({
           article,
+          jsonLd,
           serverData,
           gaDimensions: {
             partOf: article.seasons
@@ -119,7 +123,7 @@ function getNextUp(
   }
 }
 
-const ArticlePage: FC<Props> = ({ article }) => {
+const ArticlePage: FC<Props> = ({ article, jsonLd }) => {
   const [listOfSeries, setListOfSeries] = useState<ArticleSeriesList>();
 
   useEffect(() => {
@@ -292,7 +296,7 @@ const ArticlePage: FC<Props> = ({ article }) => {
       title={article.title}
       description={article.metadataDescription || article.promo?.caption || ''}
       url={{ pathname: `/articles/${article.id}` }}
-      jsonLd={articleLd(article)}
+      jsonLd={jsonLd}
       openGraphType={'article'}
       siteSection={'stories'}
       image={article.image}

--- a/content/webapp/pages/article.tsx
+++ b/content/webapp/pages/article.tsx
@@ -27,7 +27,6 @@ import { articleLd } from '../services/prismic/transformers/json-ld';
 import { looksLikePrismicId } from '../services/prismic';
 import { bodySquabblesSeries } from '@weco/common/services/prismic/hardcoded-id';
 import { transformArticle } from '../services/prismic/transformers/articles';
-import * as prismic from '@prismicio/client';
 
 type Props = {
   article: Article;

--- a/content/webapp/pages/event.tsx
+++ b/content/webapp/pages/event.tsx
@@ -58,6 +58,7 @@ import { headerBackgroundLs } from '@weco/common/utils/backgrounds';
 import { isDayPast, isPast } from '@weco/common/utils/dates';
 
 import * as prismicT from '@prismicio/types';
+import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 
 const TimeWrapper = styled(Space).attrs({
   v: {
@@ -77,6 +78,7 @@ const DateWrapper = styled.div.attrs({
 
 type Props = {
   jsonEvent: Event;
+  jsonLd: JsonLdObj[];
 } & WithGaDimensions;
 
 // TODO: Probably use the StatusIndicator?
@@ -160,7 +162,7 @@ const eventInterpretationIcons: Record<string, IconSvg> = {
   audioDescribed: audioDescribed,
 };
 
-const EventPage: NextPage<Props> = ({ jsonEvent }: Props) => {
+const EventPage: NextPage<Props> = ({ jsonEvent, jsonLd }: Props) => {
   const [scheduledIn, setScheduledIn] = useState<Event>();
   const getScheduledIn = async () => {
     const scheduledInQuery = await fetchEventsClientSide({
@@ -289,7 +291,7 @@ const EventPage: NextPage<Props> = ({ jsonEvent }: Props) => {
       title={event.title}
       description={event.metadataDescription || event.promo?.caption || ''}
       url={{ pathname: `/events/${event.id}` }}
-      jsonLd={eventLd(event)}
+      jsonLd={jsonLd}
       openGraphType={'website'}
       siteSection={'whats-on'}
       image={event.image}
@@ -520,12 +522,15 @@ export const getServerSideProps: GetServerSideProps<Props> = async context => {
 
   const event = transformEvent(eventDocument, scheduleQuery);
 
+  const jsonLd = eventLd(event);
+
   // This is a bit of nonsense as the event type has loads `undefined` values
   // which we could pick out explicitly, or do this.
   // See: https://github.com/vercel/next.js/discussions/11209#discussioncomment-35915
   return {
     props: removeUndefinedProps({
       jsonEvent: JSON.parse(JSON.stringify(event)),
+      jsonLd,
       serverData,
       gaDimensions: {
         partOf: event.seasons

--- a/content/webapp/pages/events.tsx
+++ b/content/webapp/pages/events.tsx
@@ -24,11 +24,13 @@ import {
 import { transformQuery } from '../services/prismic/transformers/paginated-results';
 import { pageDescriptions } from '@weco/common/data/microcopy';
 import { EventBasic } from '../types/events';
+import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 
 type Props = {
   title: string;
   events: PaginatedResults<EventBasic>;
   period?: Period;
+  jsonLd: JsonLdObj[];
 };
 
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
@@ -63,11 +65,13 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
 
     if (events) {
       const title = (period === 'past' ? 'Past e' : 'E') + 'vents';
+      const jsonLd = events.results.flatMap(eventLd);
       return {
         props: removeUndefinedProps({
           events,
           title,
           period: period as Period,
+          jsonLd,
           serverData,
         }),
       };
@@ -77,7 +81,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   };
 
 const EventsPage: FC<Props> = props => {
-  const { events, title, period } = props;
+  const { events, title, period, jsonLd } = props;
   const convertedEvents = events.results.map(fixEventDatesInJson);
   const convertedPaginatedResults = {
     ...events,
@@ -92,7 +96,7 @@ const EventsPage: FC<Props> = props => {
       title={title}
       description={pageDescriptions.events}
       url={{ pathname: `/events${period ? `/${period}` : ''}` }}
-      jsonLd={events.results.flatMap(eventLd)}
+      jsonLd={jsonLd}
       openGraphType={'website'}
       siteSection={'whats-on'}
       image={firstEvent?.image}

--- a/content/webapp/pages/exhibition.tsx
+++ b/content/webapp/pages/exhibition.tsx
@@ -16,19 +16,26 @@ import {
   transformExhibition,
 } from '../services/prismic/transformers/exhibitions';
 import { looksLikePrismicId } from '../services/prismic';
+import { exhibitionLd } from 'services/prismic/transformers/json-ld';
+import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 
 type Props = {
   exhibition: ExhibitionType;
+  jsonLd: JsonLdObj;
   pages: PageType[];
 } & WithGaDimensions;
 
-const ExhibitionPage: FC<Props> = ({ exhibition: jsonExhibition, pages }) => {
+const ExhibitionPage: FC<Props> = ({
+  exhibition: jsonExhibition,
+  pages,
+  jsonLd,
+}) => {
   const exhibition = fixExhibitionDatesInJson(jsonExhibition);
 
   if (exhibition.format && exhibition.format.title === 'Installation') {
-    return <Installation installation={exhibition} />;
+    return <Installation installation={exhibition} jsonLd={jsonLd} />;
   } else {
-    return <Exhibition exhibition={exhibition} pages={pages} />;
+    return <Exhibition exhibition={exhibition} jsonLd={jsonLd} pages={pages} />;
   }
 };
 
@@ -47,11 +54,13 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     if (exhibition) {
       const exhibitionDoc = transformExhibition(exhibition);
       const relatedPages = transformQuery(pages, transformPage);
+      const jsonLd = exhibitionLd(exhibitionDoc);
 
       return {
         props: removeUndefinedProps({
           exhibition: exhibitionDoc,
           pages: relatedPages?.results || [],
+          jsonLd,
           serverData,
           gaDimensions: {
             partOf: exhibitionDoc.seasons.map(season => season.id),

--- a/content/webapp/pages/exhibitions.tsx
+++ b/content/webapp/pages/exhibitions.tsx
@@ -18,11 +18,13 @@ import {
 } from '../services/prismic/transformers/exhibitions';
 import { createClient } from '../services/prismic/fetch';
 import { ExhibitionBasic } from '../types/exhibitions';
+import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 
 type Props = {
   exhibitions: PaginatedResults<ExhibitionBasic>;
   period?: Period;
   title: string;
+  jsonLd: JsonLdObj[];
 };
 
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
@@ -44,11 +46,13 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
 
     if (exhibitions && exhibitions.results.length > 0) {
       const title = (period === 'past' ? 'Past e' : 'E') + 'xhibitions';
+      const jsonLd = exhibitions.results.map(exhibitionLd);
       return {
         props: removeUndefinedProps({
           exhibitions,
           title,
           period: period as Period,
+          jsonLd,
           serverData,
         }),
       };
@@ -58,7 +62,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   };
 
 const ExhibitionsPage: FC<Props> = props => {
-  const { exhibitions: jsonExhibitions, period, title } = props;
+  const { exhibitions: jsonExhibitions, period, title, jsonLd } = props;
   const exhibitions = {
     ...jsonExhibitions,
     results: jsonExhibitions.results.map(fixExhibitionDatesInJson),
@@ -70,7 +74,7 @@ const ExhibitionsPage: FC<Props> = props => {
       title={title}
       description={pageDescriptions.exhibitions}
       url={{ pathname: `/exhibitions${period ? `/${period}` : ''}` }}
-      jsonLd={exhibitions.results.map(exhibitionLd)}
+      jsonLd={jsonLd}
       openGraphType={'website'}
       siteSection={'whats-on'}
       image={firstExhibition && firstExhibition.image}

--- a/content/webapp/pages/homepage.tsx
+++ b/content/webapp/pages/homepage.tsx
@@ -6,8 +6,6 @@ import SpacingSection from '@weco/common/views/components/SpacingSection/Spacing
 import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import { ArticleBasic } from '../types/articles';
-import { Page as PageType } from '../types/pages';
-import { PaginatedResults } from '@weco/common/services/prismic/types';
 import Space from '@weco/common/views/components/styled/Space';
 import Layout10 from '@weco/common/views/components/Layout10/Layout10';
 import SimpleCardGrid from '../components/SimpleCardGrid/SimpleCardGrid';

--- a/content/webapp/pages/page.tsx
+++ b/content/webapp/pages/page.tsx
@@ -41,12 +41,14 @@ import { transformPage } from '../services/prismic/transformers/pages';
 import { getCrop } from '@weco/common/model/image';
 import { isPicture, isVideoEmbed } from 'types/body';
 import { isNotUndefined } from '@weco/common/utils/array';
+import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 
 type Props = {
   page: PageType;
   siblings: SiblingsGroup<PageType>[];
   children: SiblingsGroup<PageType>;
   ordersInParents: OrderInParent[];
+  jsonLd: JsonLdObj;
 } & WithGaDimensions;
 
 type OrderInParent = {
@@ -93,12 +95,15 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
         siblings: (await fetchChildren(client, page)).map(transformPage),
       };
 
+      const jsonLd = contentLd(page);
+
       return {
         props: removeUndefinedProps({
           page,
           siblings,
           children,
           ordersInParents,
+          jsonLd,
           serverData,
           gaDimensions: {
             partOf: page.seasons.map(season => season.id),
@@ -110,7 +115,13 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     }
   };
 
-const Page: FC<Props> = ({ page, siblings, children, ordersInParents }) => {
+const Page: FC<Props> = ({
+  page,
+  siblings,
+  children,
+  ordersInParents,
+  jsonLd,
+}) => {
   function makeLabels(title?: string): LabelsListProps | undefined {
     if (!title) return;
 
@@ -265,7 +276,7 @@ const Page: FC<Props> = ({ page, siblings, children, ordersInParents }) => {
       title={page.title}
       description={page.metadataDescription || page.promo?.caption || ''}
       url={{ pathname: `/pages/${page.id}` }}
-      jsonLd={contentLd(page)}
+      jsonLd={jsonLd}
       openGraphType={'website'}
       siteSection={page?.siteSection as SiteSection}
       image={page.image}

--- a/content/webapp/pages/season.tsx
+++ b/content/webapp/pages/season.tsx
@@ -53,6 +53,7 @@ import { Project } from '../types/projects';
 import { Series } from '../types/series';
 import { looksLikePrismicId } from '../services/prismic';
 import { getCrop } from '@weco/common/model/image';
+import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 
 type Props = {
   season: Season;
@@ -63,6 +64,7 @@ type Props = {
   pages: Page[];
   projects: Project[];
   series: Series[];
+  jsonLd: JsonLdObj;
 };
 
 const SeasonPage = ({
@@ -74,6 +76,7 @@ const SeasonPage = ({
   series,
   projects,
   books,
+  jsonLd,
 }: Props): ReactElement<Props> => {
   const superWidescreenImage = getCrop(season.image, '32:15');
 
@@ -109,7 +112,7 @@ const SeasonPage = ({
       title={season.title}
       description={season.metadataDescription || season.promo?.caption || ''}
       url={{ pathname: `/seasons/${season.id}` }}
-      jsonLd={contentLd(season)}
+      jsonLd={jsonLd}
       siteSection={'whats-on'}
       openGraphType={'website'}
       image={season.image}
@@ -203,6 +206,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     const season = seasonDoc && transformSeason(seasonDoc);
 
     if (season) {
+      const jsonLd = contentLd(season);
       const serverData = await getServerData(context);
       return {
         props: removeUndefinedProps({
@@ -214,6 +218,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
           pages: pages.results,
           projects: projects.results,
           series: series.results,
+          jsonLd,
           serverData,
         }),
       };

--- a/content/webapp/pages/whats-on.tsx
+++ b/content/webapp/pages/whats-on.tsx
@@ -106,6 +106,7 @@ export type Props = {
   tryTheseTooPromos: FacilityPromoType[];
   eatShopPromos: FacilityPromoType[];
   featuredText: FeaturedTextType;
+  jsonLd: JsonLdObj[];
 };
 
 export function getMomentsForPeriod(period: Period): (Moment | undefined)[] {
@@ -379,6 +380,11 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     );
 
     if (period && events && exhibitions) {
+      const jsonLd = [
+        ...exhibitions.results.map(exhibitionLd),
+        ...events.results.map(eventLd),
+      ] as JsonLdObj[];
+
       return {
         props: removeUndefinedProps({
           period,
@@ -389,6 +395,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
           tryTheseTooPromos: [readingRoomPromo],
           eatShopPromos: [cafePromo],
           cafePromo,
+          jsonLd,
           featuredText: featuredText!,
           serverData,
         }),
@@ -399,8 +406,14 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   };
 
 const WhatsOnPage: FunctionComponent<Props> = props => {
-  const { period, dateRange, tryTheseTooPromos, eatShopPromos, featuredText } =
-    props;
+  const {
+    period,
+    dateRange,
+    tryTheseTooPromos,
+    eatShopPromos,
+    featuredText,
+    jsonLd,
+  } = props;
 
   const events = props.events.results.map(fixEventDatesInJson);
   const availableOnlineEvents =
@@ -431,12 +444,7 @@ const WhatsOnPage: FunctionComponent<Props> = props => {
       title={pageTitle}
       description={pageDescriptions.whatsOn}
       url={{ pathname: `/whats-on` }}
-      jsonLd={
-        [
-          ...exhibitions.map(exhibitionLd),
-          ...events.map(eventLd),
-        ] as JsonLdObj[]
-      }
+      jsonLd={jsonLd}
       openGraphType={'website'}
       siteSection={'whats-on'}
       image={firstExhibition && firstExhibition.image}


### PR DESCRIPTION
Easy performance win; it allows us to shake some transformer code out of the client bundle.

We have actually done this once before, but I bundled it in with some unrelated changes to venue handling which caused breakage, so we ended up rolling it all back (because of the way objects get mangled when they pass through server-side props) – but JSON-LD is already JSON, so passing it through the JSON props shouldn't be an issue.