### PR TITLE
fallback for browsers that don’t support aspect-ratio

### DIFF
--- a/content/webapp/components/CaptionedImage/CaptionedImage.tsx
+++ b/content/webapp/components/CaptionedImage/CaptionedImage.tsx
@@ -27,7 +27,7 @@ const CaptionedImageFigure = styled.div<CaptionedImageProps>`
 }`;
 
 type ImageContainerInnerProps = {
-  aspectRatio?: number;
+  aspectRatio: number;
 };
 
 const ImageContainerInner = styled.div<ImageContainerInnerProps>`
@@ -35,6 +35,12 @@ const ImageContainerInner = styled.div<ImageContainerInnerProps>`
   max-height: 80vh;
   aspect-ratio: ${props => props.aspectRatio};
   margin: 0 auto;
+  @supports not (aspect-ratio: auto) {
+    max-width: 90%;
+    ${props => props.theme.media.large`
+      max-width: ${props.aspectRatio > 1 ? '80%' : '50%'};
+    `};
+  }
 `;
 
 type UiCaptionedImageProps = CaptionedImageType & {


### PR DESCRIPTION
The [CaptionedImage refactor](https://github.com/wellcomecollection/wellcomecollection.org/pull/7963) makes use of the CSS aspect-ratio property to simplify and improve the performance of the component. However, it changes the display of captioned images quite dramatically for [browser that don't support the property](https://caniuse.com/mdn-css_properties_aspect-ratio)

This PR provides a better experience for users of those browsers, by making it behave much more like browsers that do support it, i.e. displaying the images at a reasonable size.

Before:

![lb4](https://user-images.githubusercontent.com/6051896/168555444-ef9a3fc5-6822-4518-b233-99a9b94ea055.png)


After: 
![lafter](https://user-images.githubusercontent.com/6051896/168555463-a5678ba9-3c37-441e-acd1-7dc78c8ac568.png)

