### PR TITLE
Prevent descenders getting chopped off in Select component

### DIFF
--- a/common/views/components/SelectContainer/SelectContainer.tsx
+++ b/common/views/components/SelectContainer/SelectContainer.tsx
@@ -5,16 +5,18 @@ import styled from 'styled-components';
 import Space from '../styled/Space';
 import Icon from '../Icon/Icon';
 import { classNames, font } from '../../../utils/classnames';
+import useIsFontsLoaded from '@weco/common/hooks/useIsFontsLoaded';
 
-type IsKeyboardProps = {
+type StyledSelectProps = {
   isKeyboard: boolean;
+  isFontsLoaded: boolean;
 };
 
 const StyledSelect = styled.div.attrs({
   className: classNames({
     [font('hnr', 5)]: true,
   }),
-})<IsKeyboardProps>`
+})<StyledSelectProps>`
   position: relative;
 
   .icon {
@@ -33,6 +35,14 @@ const StyledSelect = styled.div.attrs({
     border: 2px solid ${props => props.theme.color('pumice')};
     border-radius: ${props => props.theme.borderRadiusUnit}px;
     background-color: ${props => props.theme.color('white')};
+
+    // TODO: Remove this if/when we stop using Helvetica World
+    ${props =>
+      props.isFontsLoaded &&
+      `
+      padding: 4px 30px 8px 12px;
+      line-height: 1.5;
+    `}
 
     &::-ms-expand {
       display: none;
@@ -62,9 +72,10 @@ type Props = {
 
 const SelectContainer: FC<Props> = ({ label, hideLabel, children }) => {
   const { isKeyboard } = useContext(AppContext);
+  const isFontsLoaded = useIsFontsLoaded();
 
   return (
-    <StyledSelect isKeyboard={isKeyboard}>
+    <StyledSelect isKeyboard={isKeyboard} isFontsLoaded={isFontsLoaded}>
       <label>
         <Space
           as="span"

--- a/common/views/components/SelectContainer/SelectContainer.tsx
+++ b/common/views/components/SelectContainer/SelectContainer.tsx
@@ -40,7 +40,7 @@ const StyledSelect = styled.div.attrs({
     ${props =>
       props.isFontsLoaded &&
       `
-      padding: 4px 30px 8px 12px;
+      padding: 4px 36px 8px 12px;
       line-height: 1.5;
     `}
 


### PR DESCRIPTION
## Who is this for?
People who want to be able to see all of the letters in a select box

__Before__
![Screenshot 2022-05-17 at 10 14 00](https://user-images.githubusercontent.com/1394592/168776656-f2156a9d-abac-4a68-9bae-6521b843e734.png)

__After__
![Screenshot 2022-05-17 at 10 24 30](https://user-images.githubusercontent.com/1394592/168778044-016438bd-3f8c-4376-b533-fa4d5acb5de8.png)

