### PR TITLE
Success date

### DIFF
--- a/catalogue/webapp/components/ItemRequestModal/ConfirmedDialog.tsx
+++ b/catalogue/webapp/components/ItemRequestModal/ConfirmedDialog.tsx
@@ -9,9 +9,9 @@ type ConfirmedDialogProps = {
 };
 
 const ConfirmedDialog: FC<ConfirmedDialogProps> = ({ currentHoldNumber }) => {
-  const { enablePickupDate } = useToggles();
-  const maybeExtraText = enablePickupDate
-    ? ' from your selected pick-up date'
+  const { enablePickUpDate } = useToggles();
+  const maybeExtraText = enablePickUpDate
+    ? ' from your selected pickup date'
     : '';
 
   return (
@@ -25,7 +25,7 @@ const ConfirmedDialog: FC<ConfirmedDialogProps> = ({ currentHoldNumber }) => {
       </Header>
       <p>
         It will be available to pick up from the library (Rare Materials Room,
-        level 3) for one week{{ maybeExtraText }}.
+        level 3) for one week{maybeExtraText}.
       </p>
       <CTAs>
         <ButtonSolidLink text={`View your library account`} link={'/account'} />

--- a/catalogue/webapp/components/ItemRequestModal/ConfirmedDialog.tsx
+++ b/catalogue/webapp/components/ItemRequestModal/ConfirmedDialog.tsx
@@ -2,28 +2,36 @@ import { FC } from 'react';
 import { CTAs, CurrentRequests, Header } from './common';
 import { allowedRequests } from '@weco/common/values/requests';
 import ButtonSolidLink from '@weco/common/views/components/ButtonSolidLink/ButtonSolidLink';
+import { useToggles } from '@weco/common/server-data/Context';
 
 type ConfirmedDialogProps = {
   currentHoldNumber?: number;
 };
 
-const ConfirmedDialog: FC<ConfirmedDialogProps> = ({ currentHoldNumber }) => (
-  <>
-    <Header>
-      <span className={`h2`}>Request confirmed</span>
-      <CurrentRequests
-        allowedHoldRequests={allowedRequests}
-        currentHoldRequests={currentHoldNumber}
-      />
-    </Header>
-    <p>
-      It will be available to pick up from the library (Rare Materials Room,
-      level 3) for one week.
-    </p>
-    <CTAs>
-      <ButtonSolidLink text={`View your library account`} link={'/account'} />
-    </CTAs>
-  </>
-);
+const ConfirmedDialog: FC<ConfirmedDialogProps> = ({ currentHoldNumber }) => {
+  const { enablePickupDate } = useToggles();
+  const maybeExtraText = enablePickupDate
+    ? ' from your selected pick-up date'
+    : '';
+
+  return (
+    <>
+      <Header>
+        <span className={`h2`}>Request confirmed</span>
+        <CurrentRequests
+          allowedHoldRequests={allowedRequests}
+          currentHoldRequests={currentHoldNumber}
+        />
+      </Header>
+      <p>
+        It will be available to pick up from the library (Rare Materials Room,
+        level 3) for one week{{ maybeExtraText }}.
+      </p>
+      <CTAs>
+        <ButtonSolidLink text={`View your library account`} link={'/account'} />
+      </CTAs>
+    </>
+  );
+};
 
 export default ConfirmedDialog;

--- a/identity/webapp/pages/index.tsx
+++ b/identity/webapp/pages/index.tsx
@@ -161,6 +161,9 @@ const AccountPage: NextPage<Props> = ({ user: auth0UserClaims }) => {
   const { user: contextUser } = useUser();
   const [isEmailUpdated, setIsEmailUpdated] = useState(false);
   const [isPasswordUpdated, setIsPasswordUpdated] = useState(false);
+  const maybeExtraText = enablePickUpDate
+    ? ' from your selected pickup date'
+    : '';
 
   // Use the user from the context provider as first preference, as it will
   // change without a page reload being required
@@ -349,8 +352,8 @@ const AccountPage: NextPage<Props> = ({ user: auth0UserClaims }) => {
                             }}
                           >
                             Requests made will be available to pick up from the
-                            library for one week. If you wish to cancel a
-                            request, please{' '}
+                            library for one week{maybeExtraText}. If you wish to
+                            cancel a request, please{' '}
                             <a href="mailto:library@wellcomecollection.org">
                               contact the library team.
                             </a>


### PR DESCRIPTION
<img width="1101" alt="Screenshot 2022-05-18 at 14 50 59" src="https://user-images.githubusercontent.com/1394592/169056337-e01b0e7b-78a8-49f2-8ad0-f9c4c291240e.png">

I've used the word 'pickup' because it is how it appears in the column headings. I'd probably have plumped for 'pick-up' otherwise.