### PR TITLE
Tidy up the convert-image-uri helper

### DIFF
--- a/common/test/utils/convert-image-uri.test.ts
+++ b/common/test/utils/convert-image-uri.test.ts
@@ -4,17 +4,6 @@ import {
 } from '../../utils/convert-image-uri';
 
 describe('convertPrismicImageUri', () => {
-  it('creates a full-sized image', () => {
-    const result = convertPrismicImageUri(
-      'https://images.prismic.io/wellcomecollection/EP_0001.jpg',
-      'full'
-    );
-
-    expect(result).toEqual(
-      'https://images.prismic.io/wellcomecollection/EP_0001.jpg?auto=&rect=&w=full&h='
-    );
-  });
-
   it('replaces an existing width parameter with a number', () => {
     const result = convertPrismicImageUri(
       'https://images.prismic.io/wellcomecollection/EP_0002.jpg?w=100',
@@ -40,10 +29,10 @@ describe('convertPrismicImageUri', () => {
   it('removes unrecognised parameters', () => {
     const fullResult = convertPrismicImageUri(
       'https://images.prismic.io/wellcomecollection/EP_0004.jpg?token=sekrit',
-      'full'
+      400
     );
     expect(fullResult).toEqual(
-      'https://images.prismic.io/wellcomecollection/EP_0004.jpg?auto=&rect=&w=full&h='
+      'https://images.prismic.io/wellcomecollection/EP_0004.jpg?auto=&rect=&w=400&h='
     );
 
     const wideResult = convertPrismicImageUri(

--- a/common/test/utils/convert-image-uri.test.ts
+++ b/common/test/utils/convert-image-uri.test.ts
@@ -1,11 +1,11 @@
 import {
   convertIiifImageUri,
-  convertImageUri,
+  convertPrismicImageUri,
 } from '../../utils/convert-image-uri';
 
-describe('convertImageUri for Prismic images', () => {
+describe('convertPrismicImageUri', () => {
   it('creates a full-sized image', () => {
-    const result = convertImageUri(
+    const result = convertPrismicImageUri(
       'https://images.prismic.io/wellcomecollection/EP_0001.jpg',
       'full'
     );
@@ -16,7 +16,7 @@ describe('convertImageUri for Prismic images', () => {
   });
 
   it('replaces an existing width parameter with a number', () => {
-    const result = convertImageUri(
+    const result = convertPrismicImageUri(
       'https://images.prismic.io/wellcomecollection/EP_0002.jpg?w=100',
       200
     );
@@ -27,7 +27,7 @@ describe('convertImageUri for Prismic images', () => {
   });
 
   it('updates an existing height parameter based on the width', () => {
-    const result = convertImageUri(
+    const result = convertPrismicImageUri(
       'https://images.prismic.io/wellcomecollection/EP_0003.jpg?w=100&h=200',
       300
     );
@@ -38,7 +38,7 @@ describe('convertImageUri for Prismic images', () => {
   });
 
   it('removes unrecognised parameters', () => {
-    const fullResult = convertImageUri(
+    const fullResult = convertPrismicImageUri(
       'https://images.prismic.io/wellcomecollection/EP_0004.jpg?token=sekrit',
       'full'
     );
@@ -46,7 +46,7 @@ describe('convertImageUri for Prismic images', () => {
       'https://images.prismic.io/wellcomecollection/EP_0004.jpg?auto=&rect=&w=full&h='
     );
 
-    const wideResult = convertImageUri(
+    const wideResult = convertPrismicImageUri(
       'https://images.prismic.io/wellcomecollection/EP_0004.jpg?token=sekrit',
       300
     );
@@ -56,9 +56,9 @@ describe('convertImageUri for Prismic images', () => {
   });
 });
 
-describe('convertImageUri for IIIF images', () => {
+describe('convertIiifImageUri', () => {
   it('passes through GIFs unmodified', () => {
-    const result = convertImageUri(
+    const result = convertIiifImageUri(
       'https://iiif.wellcomecollection.org/image/b0001.gif',
       'full'
     );
@@ -68,7 +68,7 @@ describe('convertImageUri for IIIF images', () => {
   });
 
   it('sets the size parameter on a URI to full', () => {
-    const result = convertImageUri(
+    const result = convertIiifImageUri(
       'https://iiif.wellcomecollection.org/image/b0002.jpg',
       'full'
     );
@@ -78,7 +78,7 @@ describe('convertImageUri for IIIF images', () => {
   });
 
   it('sets the size parameter on a URI to a number', () => {
-    const result = convertImageUri(
+    const result = convertIiifImageUri(
       'https://iiif.wellcomecollection.org/image/b0003.jpg',
       300
     );
@@ -88,7 +88,7 @@ describe('convertImageUri for IIIF images', () => {
   });
 
   it('returns a URI for a PNG image', () => {
-    const result = convertImageUri(
+    const result = convertIiifImageUri(
       'https://iiif.wellcomecollection.org/image/b0004.png',
       300
     );
@@ -98,7 +98,7 @@ describe('convertImageUri for IIIF images', () => {
   });
 
   it('defaults to a URI for a JPEG image', () => {
-    const result = convertImageUri(
+    const result = convertIiifImageUri(
       'https://iiif.wellcomecollection.org/image/b0005',
       300
     );

--- a/common/utils/convert-image-uri.ts
+++ b/common/utils/convert-image-uri.ts
@@ -115,19 +115,32 @@ export function convertIiifImageUri(
   }
 }
 
-export function convertImageUri(
+export function convertPrismicImageUri(
   originalUri: string,
   requiredSize: number | 'full'
 ): string {
-  const imageSrc = determineSrc(originalUri);
-  if (imageSrc === 'prismic') {
+  if (!originalUri.startsWith(prismicBaseUri)) {
+    return originalUri;
+  } else {
     const parts = prismicTemplateParts(originalUri, requiredSize);
     return prismicImageTemplate(parts.base)({
       ...parts.params,
     });
-  } else if (imageSrc === 'iiif') {
-    return convertIiifImageUri(originalUri, requiredSize);
-  } else {
-    return originalUri;
+  }
+}
+
+export function convertImageUri(
+  originalUri: string,
+  requiredSize: number | 'full'
+): string {
+  switch (determineSrc(originalUri)) {
+    case 'prismic':
+      return convertPrismicImageUri(originalUri, requiredSize);
+
+    case 'iiif':
+      return convertIiifImageUri(originalUri, requiredSize);
+
+    default:
+      return originalUri;
   }
 }

--- a/common/utils/convert-image-uri.ts
+++ b/common/utils/convert-image-uri.ts
@@ -107,7 +107,7 @@ export function convertIiifImageUri(
 
 export function convertPrismicImageUri(
   originalUri: string,
-  requiredSize: number | 'full'
+  requiredSize: number
 ): string {
   if (!originalUri.startsWith(prismicBaseUri)) {
     return originalUri;

--- a/common/utils/convert-image-uri.ts
+++ b/common/utils/convert-image-uri.ts
@@ -3,16 +3,6 @@ import urlTemplate from 'url-template';
 const prismicBaseUri = 'https://images.prismic.io/wellcomecollection';
 const iiifImageUri = 'https://iiif.wellcomecollection.org/image/';
 
-function determineSrc(url: string): string {
-  if (url.startsWith(prismicBaseUri)) {
-    return 'prismic';
-  } else if (url.startsWith(iiifImageUri)) {
-    return 'iiif';
-  } else {
-    return 'unknown';
-  }
-}
-
 function determineIfGif(originalUriPath: string): boolean {
   return originalUriPath.includes('.gif');
 }
@@ -126,21 +116,5 @@ export function convertPrismicImageUri(
     return prismicImageTemplate(parts.base)({
       ...parts.params,
     });
-  }
-}
-
-export function convertImageUri(
-  originalUri: string,
-  requiredSize: number | 'full'
-): string {
-  switch (determineSrc(originalUri)) {
-    case 'prismic':
-      return convertPrismicImageUri(originalUri, requiredSize);
-
-    case 'iiif':
-      return convertIiifImageUri(originalUri, requiredSize);
-
-    default:
-      return originalUri;
   }
 }

--- a/common/utils/json-ld.ts
+++ b/common/utils/json-ld.ts
@@ -1,4 +1,4 @@
-import { convertImageUri } from './convert-image-uri';
+import { convertPrismicImageUri } from './convert-image-uri';
 import { Organization } from '../model/organization';
 import { BreadcrumbItems } from '../model/breadcrumbs';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
@@ -78,7 +78,7 @@ function imageLd(image: Image) {
     image &&
     objToJsonLd(
       {
-        url: convertImageUri((image.contentUrl || image.url)!, 1200),
+        url: convertPrismicImageUri((image.contentUrl || image.url)!, 1200),
         width: image.width,
         height: image.height,
       },

--- a/common/views/components/Image/Image.tsx
+++ b/common/views/components/Image/Image.tsx
@@ -1,5 +1,5 @@
 import { classNames } from '../../../utils/classnames';
-import { convertImageUri } from '../../../utils/convert-image-uri';
+import { convertPrismicImageUri } from '../../../utils/convert-image-uri';
 import { imageSizes, supportedSizes } from '../../../utils/image-sizes';
 import { isNotUndefined } from '../../../utils/array';
 import { FunctionComponent } from 'react';
@@ -47,11 +47,11 @@ const Img = ({
         'cursor-zoom-in': Boolean(zoomable),
         [`${extraClasses || ''}`]: Boolean(extraClasses),
       })}
-      src={convertImageUri(contentUrl, defaultSize)}
+      src={convertPrismicImageUri(contentUrl, defaultSize)}
       data-srcset={
         srcsetRequired
           ? sizes.map(size => {
-              return `${convertImageUri(contentUrl, size)} ${size}w`;
+              return `${convertPrismicImageUri(contentUrl, size)} ${size}w`;
             })
           : undefined
       }
@@ -77,7 +77,7 @@ const Image: FunctionComponent<Props> = (props: Props) => {
       <img width='${props.width || ''}'
         height='${props.height || ''}'
         class='${classes}'
-        src='${convertImageUri(props.contentUrl, 640)}'
+        src='${convertPrismicImageUri(props.contentUrl, 640)}'
         alt='${props.alt || ''}' />`,
         }}
       />

--- a/common/views/components/JsonLd/JsonLd.tsx
+++ b/common/views/components/JsonLd/JsonLd.tsx
@@ -1,9 +1,11 @@
+import { FC } from 'react';
+
 export type JsonLdObj = { '@type': string };
 type Props = {
   data: JsonLdObj | JsonLdObj[];
 };
 
-const JsonLd = ({ data }: Props) => {
+const JsonLd: FC<Props> = ({ data }: Props) => {
   return (
     <script
       type="application/ld+json"

--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -23,7 +23,7 @@ import { usePrismicData, useToggles } from '../../../server-data/Context';
 import useHotjar from '../../../hooks/useHotjar';
 import { defaultPageTitle } from '@weco/common/data/microcopy';
 import { getCrop, ImageType } from '@weco/common/model/image';
-import { convertImageUri } from '@weco/common/utils/convert-image-uri';
+import { convertPrismicImageUri } from '@weco/common/utils/convert-image-uri';
 
 export type SiteSection =
   | 'collections'
@@ -134,7 +134,7 @@ const PageLayoutComponent: FunctionComponent<Props> = ({
 
   const imageUrl =
     socialPreviewCardImage &&
-    convertImageUri(socialPreviewCardImage.contentUrl, 800);
+    convertPrismicImageUri(socialPreviewCardImage.contentUrl, 800);
   const imageAltText = socialPreviewCardImage?.alt || '';
 
   return (

--- a/common/views/components/Picture/Picture.tsx
+++ b/common/views/components/Picture/Picture.tsx
@@ -72,7 +72,7 @@ type PictureFromImagesProps = {
   extraClasses?: string;
   isFull: boolean;
 };
-export const PictureFromImages = ({
+export const PictureFromImages: FunctionComponent<PictureFromImagesProps> = ({
   images,
   extraClasses,
   isFull = false,

--- a/common/views/components/Picture/Picture.tsx
+++ b/common/views/components/Picture/Picture.tsx
@@ -1,6 +1,6 @@
 import Tasl from '../Tasl/Tasl';
 import { imageSizes } from '../../../utils/image-sizes';
-import { convertImageUri } from '../../../utils/convert-image-uri';
+import { convertPrismicImageUri } from '../../../utils/convert-image-uri';
 import { Picture as PictureProps } from '../../../model/picture';
 import { FunctionComponent } from 'react';
 import { ImageType } from '../../../model/image';
@@ -43,7 +43,10 @@ export const Picture: FunctionComponent<Props> = ({
                   .map(size => {
                     return (
                       image.contentUrl &&
-                      `${convertImageUri(image.contentUrl, size)} ${size}w`
+                      `${convertPrismicImageUri(
+                        image.contentUrl,
+                        size
+                      )} ${size}w`
                     );
                   })
                   .join(', ')}
@@ -55,7 +58,7 @@ export const Picture: FunctionComponent<Props> = ({
         {lastImage && lastImage.contentUrl && lastImage.width && (
           <img
             className="image block"
-            src={convertImageUri(lastImage.contentUrl, lastImage.width)}
+            src={convertPrismicImageUri(lastImage.contentUrl, lastImage.width)}
             alt={lastImage.alt || ''}
           />
         )}
@@ -96,7 +99,7 @@ export const PictureFromImages: FunctionComponent<PictureFromImagesProps> = ({
                 data-srcset={sizes.map(size => {
                   return (
                     image.contentUrl &&
-                    `${convertImageUri(image.contentUrl, size)} ${size}w`
+                    `${convertPrismicImageUri(image.contentUrl, size)} ${size}w`
                   );
                 })}
               />
@@ -109,7 +112,10 @@ export const PictureFromImages: FunctionComponent<PictureFromImagesProps> = ({
             height={lastImage.height}
             width={lastImage.width}
             className="image lazy-image lazyload"
-            data-src={convertImageUri(lastImage.contentUrl, lastImage.width)}
+            data-src={convertPrismicImageUri(
+              lastImage.contentUrl,
+              lastImage.width
+            )}
             alt={lastImage.alt || ''}
           />
         )}

--- a/content/webapp/components/BannerCard/BannerCard.tsx
+++ b/content/webapp/components/BannerCard/BannerCard.tsx
@@ -5,7 +5,7 @@ import { FunctionComponent } from 'react';
 import { Season } from '../../types/seasons';
 import styled from 'styled-components';
 import Space from '@weco/common/views/components/styled/Space';
-import { convertImageUri } from '@weco/common/utils/convert-image-uri';
+import { convertPrismicImageUri } from '@weco/common/utils/convert-image-uri';
 import ButtonOutlined from '@weco/common/views/components/ButtonOutlined/ButtonOutlined';
 import DateRange from '@weco/common/views/components/DateRange/DateRange';
 import { arrowSmall } from '@weco/common/icons';
@@ -170,7 +170,9 @@ const BannerCard: FunctionComponent<Props> = ({
         />
       </Space>
       {image && (
-        <ImageWrapper imageUrl={convertImageUri(image.contentUrl, 640)} />
+        <ImageWrapper
+          imageUrl={convertPrismicImageUri(image.contentUrl, 640)}
+        />
       )}
     </CardOuter>
   );


### PR DESCRIPTION
Small optimisation I've been sitting on for a while.

We had a method `convertImageUri` which took an image URI and a desired size, and would:

1. Infer whether it’s a Prismic or IIIF image
2. Call the appropriate helper function to create a right-sized image URI

But step 1 is somewhat redundant – we can always tell from context whether an image URI will be from Prismic or IIIF, and call the appropriate helper. We already call the dedicated helper for IIIF images without doing any inference on the URL; this patch does the same for Prismic images.