### PR TITLE
Fix inter media query

### DIFF
--- a/common/views/themes/inter-typography.ts
+++ b/common/views/themes/inter-typography.ts
@@ -71,7 +71,7 @@ const fontFamilies = {
 const fontSizeMixin = size => {
   return breakpointNames
     .map(name => {
-      return `@media (min-width: ${themeValues.sizes[name]}rem) {
+      return `@media (min-width: ${themeValues.sizes[name]}px) {
       font-size: ${fontSizesAtBreakpoints[name][size]}rem;
     }`;
     })

--- a/content/webapp/components/PageHeaderStandfirst/PageHeaderStandfirst.tsx
+++ b/content/webapp/components/PageHeaderStandfirst/PageHeaderStandfirst.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent } from 'react';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
-import { classNames, font } from '@weco/common/utils/classnames';
+import { classNames } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 import * as prismicT from '@prismicio/types';
 
@@ -15,7 +15,6 @@ const PageHeaderStandfirst: FunctionComponent<Props> = ({ html }: Props) => (
       properties: ['margin-top'],
     }}
     className={classNames({
-      [font('hnr', 3)]: true,
       'body-text': true,
       'first-para-no-margin': true,
     })}


### PR DESCRIPTION
Fixing the font size media query that still needs to respond to `px` even though the font values are in `rem`.

Standfirst should be the same font size as body copy, so undoing that change also.