### PR TITLE
Remove hotjar from archive pages

### DIFF
--- a/catalogue/webapp/components/Work/Work.tsx
+++ b/catalogue/webapp/components/Work/Work.tsx
@@ -17,7 +17,6 @@ import Divider from '@weco/common/views/components/Divider/Divider';
 import styled from 'styled-components';
 import SearchContext from '@weco/common/views/components/SearchContext/SearchContext';
 import IsArchiveContext from '../IsArchiveContext/IsArchiveContext';
-import useHotjar from '@weco/common/hooks/useHotjar';
 
 const ArchiveDetailsContainer = styled.div`
   display: block;
@@ -45,10 +44,6 @@ const Work: FunctionComponent<Props> = ({
     work.parts.length ||
     (work.partOf.length > 0 && work.partOf[0].totalParts)
   );
-
-  useHotjar(isArchive, 'view_archive');
-  // TODO: Remove this after we've evaluated how users deal with archive pages.
-  // https://github.com/wellcomecollection/wellcomecollection.org/pull/7916
 
   const workData = {
     workType: (work.workType ? work.workType.label : '').toLocaleLowerCase(),


### PR DESCRIPTION
☝️ 

Hotjar not giving us enough useful insight for archives quick enough so turning off for at least as long as we need to collect data on the learning resource pages