### PR TITLE
Don't try to redirect /youth inside the Edge Lambda

### DIFF
--- a/cache/.terraform.lock.hcl
+++ b/cache/.terraform.lock.hcl
@@ -1,6 +1,13 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.2.0"
+  hashes = [
+    "h1:2K5LQkuWRS2YN1/YoNaHn9MAzjuTX8Gaqy6i8Mbfv8Y=",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "3.70.0"
   constraints = "~> 3.70"

--- a/cache/README.md
+++ b/cache/README.md
@@ -28,12 +28,4 @@ We do this by setting a `toggle_{key}=true|false` that is then read via the stan
 
 `toggler` runs @ the `origin-request` and `origin-response` of [the lambda@edgfe lifecycle](https://docs.aws.amazon.com/lambda/latest/dg/lambda-edge.html).
 
-## Deployment of lambda@edge
-
-* Run `terraform apply` to deploy the latest lambda versions to the `stage` cloudfront distribution
-* Make note of the `edge_lambda_request_version` and `edge_lambda_response_version` numbers output to the console
-* Once deployed check <www-stage.wellcomecollection.org> to make sure everything is working as expected
-* To deploy to `prod` bump the `edge_lambda_request_version` and `edge_lambda_response_version` in [`terraform.tf`](./terraform.tf) to the new versions
-* Run `terraform apply`
-
 [lambda-sequence-diagram]: (https://mermaid-js.github.io/mermaid-live-editor/edit#eyJjb2RlIjoic2VxdWVuY2VEaWFncmFtXG5wYXJ0aWNpcGFudCBFbmRfdXNlclxucGFydGljaXBhbnQgQ2xvdWRGcm9udFxucGFydGljaXBhbnQgTGFtYmRhX29yaWdpbl9yZXF1ZXN0XG5wYXJ0aWNpcGFudCBMYW1iZGFfb3JpZ2luX3Jlc3BvbnNlXG5wYXJ0aWNpcGFudCBPcmlnaW5cbkVuZF91c2VyLT4-Q2xvdWRGcm9udDogcmVxdWVzdFxuQ2xvdWRGcm9udC0-PkxhbWJkYV9vcmlnaW5fcmVxdWVzdDogcmVxdWVzdFxuYWx0IGlzIGluIHRlc3RcbiAgICBMYW1iZGFfb3JpZ2luX3JlcXVlc3QtPj5PcmlnaW46IHNlbmQgZGVmYXVsdCBjbGllbnQgY29va2llc1xuZWxzZSBzaG91bGQgYmUgaW4gdGVzdFxuICAgIExhbWJkYV9vcmlnaW5fcmVxdWVzdC0-Pk9yaWdpbjogYXBwZW5kIHRvZ2dsZV94IGNvb2tpZSBoZWFkZXJcbiAgICBMYW1iZGFfb3JpZ2luX3JlcXVlc3QtPj5PcmlnaW46IGFwcGVuZCB4LXRvZ2dsZWQgaGVhZGVyXG5lbmRcbk9yaWdpbi0-PkxhbWJkYV9vcmlnaW5fcmVzcG9uc2U6IHJlc3BvbnNlXG5hbHQgaGFzIHgtdG9nZ2xlZCBoZWFkZXJcbiAgICBMYW1iZGFfb3JpZ2luX3Jlc3BvbnNlLT4-RW5kX3VzZXI6IHNlbmQgU2V0LWNvb2tpZSBoZWFkZXIgdG8geC10b2dnbGVkIFxuZW5kXG4iLCJtZXJtYWlkIjoie1xuICBcInRoZW1lXCI6IFwiZGVmYXVsdFwiXG59IiwidXBkYXRlRWRpdG9yIjpmYWxzZSwiYXV0b1N5bmMiOnRydWUsInVwZGF0ZURpYWdyYW0iOmZhbHNlfQ)

--- a/cache/edge_lambdas/README.md
+++ b/cache/edge_lambdas/README.md
@@ -1,0 +1,38 @@
+# edge_lambdas
+
+## Updating the Lambda deployment package
+
+Normally this happens in Buildkite, but you can also build a deployment package locally if you're testing something.
+
+1.  Build the Lambda deployment package by running this command in the root of the repo:
+
+    ```
+    docker-compose build edge_lambdas
+    ```
+
+2.  Upload the Lambda deployment package by running this command in the root of the repo:
+
+    ```
+    AWS_PROFILE=experience-dev docker-compose run edge_lambdas yarn deploy
+    ```
+
+
+## Deploying the Edge Lambda to CloudFront
+
+1.  In the `cache` folder, apply the Terraform to use the latest Lambda in staging:
+
+    ```
+    terraform plan -out=terraform.plan
+    terraform apply terraform.plan
+    ```
+
+    Among the outputs will be the edge Lambda version IDs, e.g.
+
+    ```
+    latest_edge_lambda_origin_request_version = "83"
+    latest_edge_lambda_origin_response_version = "84"
+    ```
+
+2.  Check your changes are working correctly on <www-stage.wellcomecollection.org>
+
+3.  Update the version numbers in [`locals.tf`](../locals.tf), then re-run Terraform to update the Lambdas in prod.

--- a/cache/edge_lambdas/src/redirects.ts
+++ b/cache/edge_lambdas/src/redirects.ts
@@ -136,7 +136,6 @@ const contentRedirects: Record<string, string> = {
   '/articles/museums-in-context-the-birth-of-the-public-museum':
     '/articles/W_0kHhEAADUAbHiJ',
   '/articles/the-power-of-unicorns': '/articles/W_1gyREAADIAbXjT',
-  '/youth': '/pages/Wuw2MSIAACtd3Ssg',
   '/young-people': '/pages/Wuw2MSIAACtd3Ssg',
   '/openplatform': '/pages/WvljzSAAAB4E3uMF',
   '/the-hub': '/pages/Wuw2MSIAACtd3SsU',

--- a/cache/locals.tf
+++ b/cache/locals.tf
@@ -1,6 +1,6 @@
 locals {
-  edge_lambda_request_version  = 81
-  edge_lambda_response_version = 82
+  edge_lambda_request_version  = 83
+  edge_lambda_response_version = 84
 
   wellcome_cdn_cert_arn = "arn:aws:acm:us-east-1:130871440101:certificate/bb840c52-56bb-4bf8-86f8-59e7deaf9c98"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,10 @@ services:
   edge_lambdas:
     build:
       context: ./cache/edge_lambdas
+    volumes:
+      - ~/.aws:/root/.aws
+    environment:
+      - AWS_PROFILE
   toggles:
     build:
       context: ./toggles


### PR DESCRIPTION
After I was mucking around in vanity URLs, we ended up with a redirect loop:

```mermaid
graph TD
    A(/pages/Wuw2MSIAACtd3Ste) -->|edge Lambda| vanity
    vanity["/youth"] -->|edge Lambda| B(/pages/Wuw2MSIAACtd3Ssg)
    B -->|front-end app| vanity
```  

- Wuw…Ssg is the ID of the page in Prismic
- Wuw…Ste doesn't seem to exist

I've left the non-existent page ID in place, in case it's significant, and removed the redirect in the Edge Lambda from /youth to the page ID. This seems to get the page working, which is what we want.

I've also added more instructions about how to manage these Lambdas.