### PR TITLE
Deploy pa11y after a prod deploy

### DIFF
--- a/.buildkite/pipeline.deployment.yml
+++ b/.buildkite/pipeline.deployment.yml
@@ -45,7 +45,7 @@ steps:
           environment: prod
           ref: "${BUILDKITE_COMMIT}"
 
-  - label: "deploy pa11y"
+  - label: "Update pa11y dashboard"
     branches: "main"
     if: build.env("BUILDKITE_GITHUB_DEPLOYMENT_ENVIRONMENT") == "prod"
     plugins:

--- a/.buildkite/pipeline.deployment.yml
+++ b/.buildkite/pipeline.deployment.yml
@@ -44,3 +44,19 @@ steps:
           assume_role: "arn:aws:iam::130871440101:role/experience-ci"
           environment: prod
           ref: "${BUILDKITE_COMMIT}"
+
+  - label: "deploy pa11y"
+    branches: "main"
+    if: build.env("BUILDKITE_GITHUB_DEPLOYMENT_ENVIRONMENT") == "prod"
+    plugins:
+      - wellcomecollection/aws-assume-role#v0.2.2:
+          role: "arn:aws:iam::130871440101:role/experience-ci"
+      - ecr#v2.1.1:
+          login: true
+      - docker-compose#v3.5.0:
+          run: pa11y
+          command: [ "yarn", "deploy" ]
+          env:
+            - AWS_ACCESS_KEY_ID
+            - AWS_SECRET_ACCESS_KEY
+            - AWS_SESSION_TOKEN

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -282,21 +282,6 @@
           - AWS_SESSION_TOKEN
           - CI
 
-- label: "deploy pa11y"
-  branches: "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: pa11y
-        command: [ "yarn", "deploy" ]
-        env:
-          - AWS_ACCESS_KEY_ID
-          - AWS_SECRET_ACCESS_KEY
-          - AWS_SESSION_TOKEN
-
 - label: "deploy edge_lambdas"
   branches: "main"
   plugins:

--- a/pa11y/README.md
+++ b/pa11y/README.md
@@ -1,0 +1,5 @@
+# pa11y
+
+This is automated accessibility testing for wellcomecollection.org.
+
+The results are shown as a dashboard at <https://dash.wellcomecollection.org/pa11y>.


### PR DESCRIPTION
## Who is this for?

People who look at the pa11y dashboard.

## What is it doing for them?

Tentatively fixing https://github.com/wellcomecollection/wellcomecollection.org/issues/3728. Gareth mentioned in standup that our pa11y dashboard is always one deploy behind, because we run it as part of the merge to main – before we deploy. By moving it to run after a prod deploy is complete, I think we'll get more up-to-date results?