### PR TITLE
Use em for letter-spacing

### DIFF
--- a/common/views/themes/inter-typography.ts
+++ b/common/views/themes/inter-typography.ts
@@ -227,7 +227,7 @@ export const typography = css<GlobalStyleProps>`
 
   .body-text {
     line-height: 1.6;
-    letter-spacing: 0.005rem;
+    letter-spacing: 0.0044em;
 
     h1 {
       ${fontFamilyMixin('wb', true)}


### PR DESCRIPTION
☝️ 

Using `em`s instead of `rem`s means that the letter spacing will remain proportional when the font-size changes at different breakpoints.