### PR TITLE
Add a regression test for the ImageCard component

### DIFF
--- a/catalogue/webapp/components/ImageCard/ImageCard.test.tsx
+++ b/catalogue/webapp/components/ImageCard/ImageCard.test.tsx
@@ -1,0 +1,35 @@
+import { mountWithTheme } from '@weco/common/test/fixtures/enzyme-helpers';
+import { Props as ImageProps } from '@weco/common/views/components/Image/Image';
+import ImageCard from './ImageCard';
+
+describe('ImageCard', () => {
+  const props: ImageProps = {
+    contentUrl: 'https://iiif.wellcomecollection.org/image/V0043039/info.json',
+    width: 300,
+    height: 300,
+    alt: '',
+  };
+
+  it('renders a IIIF image URL', () => {
+    const component = mountWithTheme(
+      <ImageCard
+        id="1"
+        workId="zxahbyqz"
+        image={props}
+        onClick={event => {
+          console.log(event);
+        }}
+      />
+    );
+
+    console.log(component.html());
+
+    expect(
+      component
+        .html()
+        .includes(
+          'https://iiif.wellcomecollection.org/image/V0043039/full/300%2C/0/default.jpg'
+        )
+    ).toBeTruthy();
+  });
+});

--- a/common/utils/convert-image-uri.ts
+++ b/common/utils/convert-image-uri.ts
@@ -115,19 +115,32 @@ export function convertIiifImageUri(
   }
 }
 
-export function convertImageUri(
+export function convertPrismicImageUri(
   originalUri: string,
   requiredSize: number | 'full'
 ): string {
-  const imageSrc = determineSrc(originalUri);
-  if (imageSrc === 'prismic') {
+  if (!originalUri.startsWith(prismicBaseUri)) {
+    return originalUri;
+  } else {
     const parts = prismicTemplateParts(originalUri, requiredSize);
     return prismicImageTemplate(parts.base)({
       ...parts.params,
     });
-  } else if (imageSrc === 'iiif') {
-    return convertIiifImageUri(originalUri, requiredSize);
-  } else {
-    return originalUri;
+  }
+}
+
+export function convertImageUri(
+  originalUri: string,
+  requiredSize: number | 'full'
+): string {
+  switch (determineSrc(originalUri)) {
+    case 'prismic':
+      return convertPrismicImageUri(originalUri, requiredSize);
+
+    case 'iiif':
+      return convertIiifImageUri(originalUri, requiredSize);
+
+    default:
+      return originalUri;
   }
 }

--- a/common/views/components/JsonLd/JsonLd.tsx
+++ b/common/views/components/JsonLd/JsonLd.tsx
@@ -1,9 +1,11 @@
+import { FC } from 'react';
+
 export type JsonLdObj = { '@type': string };
 type Props = {
   data: JsonLdObj | JsonLdObj[];
 };
 
-const JsonLd = ({ data }: Props) => {
+const JsonLd: FC<Props> = ({ data }: Props) => {
   return (
     <script
       type="application/ld+json"

--- a/common/views/components/Picture/Picture.tsx
+++ b/common/views/components/Picture/Picture.tsx
@@ -72,7 +72,7 @@ type PictureFromImagesProps = {
   extraClasses?: string;
   isFull: boolean;
 };
-export const PictureFromImages = ({
+export const PictureFromImages: FunctionComponent<PictureFromImagesProps> = ({
   images,
   extraClasses,
   isFull = false,


### PR DESCRIPTION
## Who is this for?

Devs.

## What is it doing for them?

Making sure they don't break components unexpectedly.

This salvages the usable bits of https://github.com/wellcomecollection/wellcomecollection.org/pull/7987, and adds a regression test for the component that actually broke – a IIIF info URL was being passed in and not converted properly.