### PR TITLE
Use Inter direct from rsms.me/inter

### DIFF
--- a/common/views/themes/base/fonts.ts
+++ b/common/views/themes/base/fonts.ts
@@ -6,9 +6,9 @@ export const fonts = css<GlobalStyleProps>`
     font-family: 'Inter';
     font-style: normal;
     font-weight: 400;
-    src: url('https://i.wellcomecollection.org/assets/fonts/inter-v11-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-regular.woff2')
+    src: url('https://i.wellcomecollection.org/assets/fonts/Inter-Regular.woff2')
         format('woff2'),
-      url('https://i.wellcomecollection.org/assets/fonts/inter-v11-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-regular.woff')
+      url('https://i.wellcomecollection.org/assets/fonts/Inter-Regular.woff')
         format('woff');
     font-display: swap;
   }
@@ -16,9 +16,9 @@ export const fonts = css<GlobalStyleProps>`
     font-family: 'Inter';
     font-style: normal;
     font-weight: 700;
-    src: url('https://i.wellcomecollection.org/assets/fonts/inter-v11-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-700.woff2')
+    src: url('https://i.wellcomecollection.org/assets/fonts/Inter-Bold.woff2')
         format('woff2'),
-      url('https://i.wellcomecollection.org/assets/fonts/inter-v11-vietnamese_latin-ext_latin_greek-ext_greek_cyrillic-ext_cyrillic-700.woff')
+      url('https://i.wellcomecollection.org/assets/fonts/Inter-Bold.woff')
         format('woff');
     font-display: swap;
   }


### PR DESCRIPTION
[Strange A in Inter](https://wellcome.slack.com/archives/C8X9YKM5X/p1653423700761289) e.g. in the title of [this page](https://wellcomecollection.org/works/va2vy7wb).

[Issue in Google fonts](https://github.com/google/fonts/issues/2602)

Using the font downloaded direct from [the designer's site](https://rsms.me/inter/) rather than using the [conversion tool](https://google-webfonts-helper.herokuapp.com/fonts/inter?subsets=cyrillic,cyrillic-ext,greek,greek-ext,latin,latin-ext,vietnamese) (which operates on Google fonts) solves the issue. The conversion tool allowed for subsetting character sets, but since we need all of them I don't think fact we can no longer do this is a problem.

__Before__
<img width="154" alt="image" src="https://user-images.githubusercontent.com/1394592/170184275-fc98e018-bbfa-4e95-bdf2-c43d029b166c.png">

__After__
<img width="151" alt="image" src="https://user-images.githubusercontent.com/1394592/170184357-d940773f-213e-42b7-abd1-2c023246d3e6.png">
