### PR TITLE
Allow story series in the 'About this exhibition' section

### DIFF
--- a/content/webapp/components/Exhibition/Exhibition.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.tsx
@@ -32,9 +32,11 @@ import Contributors from '../Contributors/Contributors';
 import { isNotUndefined } from '@weco/common/utils/array';
 import { a11y } from '@weco/common/data/microcopy';
 import { fetchExhibitionRelatedContentClientSide } from '../../services/prismic/fetch/exhibitions';
-import { Exhibition as ExhibitionType } from '../../types/exhibitions';
-import { Book } from '../../types/books';
-import { Article } from '../../types/articles';
+import {
+  Exhibition as ExhibitionType,
+  ExhibitionAbout,
+} from '../../types/exhibitions';
+
 import { Event as EventType } from '../../types/events';
 import * as prismicT from '@prismicio/types';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
@@ -203,10 +205,11 @@ type Props = {
 
 const Exhibition: FC<Props> = ({ exhibition, jsonLd, pages }) => {
   type ExhibitionOf = (ExhibitionType | EventType)[];
-  type ExhibitionAbout = (Book | Article)[];
 
   const [exhibitionOfs, setExhibitionOfs] = useState<ExhibitionOf>([]);
-  const [exhibitionAbouts, setExhibitionAbouts] = useState<ExhibitionAbout>([]);
+  const [exhibitionAbouts, setExhibitionAbouts] = useState<ExhibitionAbout[]>(
+    []
+  );
 
   useEffect(() => {
     const ids = exhibition.relatedIds;

--- a/content/webapp/components/SearchResults/SearchResults.tsx
+++ b/content/webapp/components/SearchResults/SearchResults.tsx
@@ -126,6 +126,29 @@ const SearchResults: FunctionComponent<Props> = ({
                 xOfY={{ x: index + 1, y: items.length }}
               />
             )}
+            {item.type === 'series' && (
+              <CompactCard
+                url={`/series/${item.id}`}
+                title={item.title || ''}
+                partNumber={undefined}
+                color={undefined}
+                primaryLabels={item.labels}
+                secondaryLabels={[]}
+                description={item.promo && item.promo.caption}
+                urlOverride={item.promo && item.promo.link}
+                Image={
+                  getCrop(item.image, 'square') && (
+                    // We intentionally omit the alt text on promos, so screen reader
+                    // users don't have to listen to the alt text before hearing the
+                    // title of the item in the list.
+                    //
+                    // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
+                    <Image {...getCrop(item.image, 'square')!} alt="" />
+                  )
+                }
+                xOfY={{ x: index + 1, y: items.length }}
+              />
+            )}
             {item.type === 'article-schedule-items' && (
               <CompactCard
                 title={item.title || ''}

--- a/content/webapp/pages/api/exhibitions-related-content/index.ts
+++ b/content/webapp/pages/api/exhibitions-related-content/index.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { isString, isUndefined } from '@weco/common/utils/array';
+import { isString } from '@weco/common/utils/array';
 import { createClient } from '../../../services/prismic/fetch';
 import { fetchExhibitionRelatedContent } from '../../../services/prismic/fetch/exhibitions';
 import { transformExhibitionRelatedContent } from '../../../services/prismic/transformers/exhibitions';

--- a/content/webapp/services/prismic/transformers/exhibitions.ts
+++ b/content/webapp/services/prismic/transformers/exhibitions.ts
@@ -278,7 +278,8 @@ export const transformExhibitionRelatedContent = (
       doc => doc.type === 'exhibitions' || doc.type === 'events'
     ),
     exhibitionAbouts: parsedContent.filter(
-      doc => doc.type === 'books' || doc.type === 'articles'
+      doc =>
+        doc.type === 'books' || doc.type === 'articles' || doc.type === 'series'
     ),
   } as ExhibitionRelatedContent;
 };

--- a/content/webapp/types/exhibitions.ts
+++ b/content/webapp/types/exhibitions.ts
@@ -1,4 +1,5 @@
 import { Article } from './articles';
+import { Series } from './series';
 import { Book } from './books';
 import { Contributor } from './contributors';
 import { Event } from './events';
@@ -58,7 +59,9 @@ export type Exhibit = {
   item: Exhibition;
 };
 
+export type ExhibitionAbout = Book | Article | Series;
+
 export type ExhibitionRelatedContent = {
   exhibitionOfs: (Exhibition | Event)[];
-  exhibitionAbouts: (Book | Article)[];
+  exhibitionAbouts: ExhibitionAbout[];
 };


### PR DESCRIPTION
## Who is this for?
Content team ([from Slack](https://wellcome.slack.com/archives/C8X9YKM5X/p1653472879466709))

## What is it doing for them?
Allowing them to add story series as related items on an exhibition page

![image](https://user-images.githubusercontent.com/1394592/170256842-dd51b47c-7804-4b1a-86de-58e5b576a48e.png)
