### PR TITLE
Requesting toggle

### DIFF
--- a/catalogue/webapp/components/LibraryMembersBar/LibraryMembersBar.tsx
+++ b/catalogue/webapp/components/LibraryMembersBar/LibraryMembersBar.tsx
@@ -7,6 +7,7 @@ import { useLoginURLWithReturnToCurrent } from '@weco/common/utils/useLoginURLWi
 import { font } from '@weco/common/utils/classnames';
 import { memberCard } from '@weco/common/icons';
 import { trackEvent } from '@weco/common/utils/ga';
+import { useToggles } from '@weco/common/server-data/Context';
 
 const StyledComponent = styled(Space).attrs({
   h: { size: 'm', properties: ['padding-left', 'padding-right'] },
@@ -80,24 +81,23 @@ type Props = {
   requestingUnavailable?: boolean;
 };
 
-const LibraryMembersBar: FC<Props> = ({ requestingUnavailable }) => {
+const LibraryMembersBar: FC<Props> = () => {
   const { state, reload } = useUser();
-
-  // We originally designed this banner for the building closure in Christmas 2021.
-  //
-  // We're keeping the banner around in case we need to disable requesting again for
-  // other reasons in future – we can reuse the same design.
-  //
-  // If you do need to disable requesting, remember to update the wording in the explanation.
-  if (requestingUnavailable) {
+  const { disableRequesting } = useToggles();
+  if (disableRequesting) {
     return (
       <StyledComponent>
         <Space h={{ size: 's', properties: ['margin-right'] }}>
           <Icon icon={memberCard} />
         </Space>
-        <span className={font('hnb', 5)}>Library members:</span>{' '}
+        <Space
+          h={{ size: 's', properties: ['margin-right'] }}
+          className={font('hnb', 5)}
+        >
+          Library members:
+        </Space>
         <span className={font('hnr', 5)}>
-          Requesting is currently unavailable.
+          requesting is currently unavailable
         </span>
       </StyledComponent>
     );

--- a/catalogue/webapp/components/LibraryMembersBar/LibraryMembersBar.tsx
+++ b/catalogue/webapp/components/LibraryMembersBar/LibraryMembersBar.tsx
@@ -8,6 +8,7 @@ import { font } from '@weco/common/utils/classnames';
 import { memberCard } from '@weco/common/icons';
 import { trackEvent } from '@weco/common/utils/ga';
 import { useToggles } from '@weco/common/server-data/Context';
+import { requestingDisabled } from '@weco/common/data/microcopy';
 
 const StyledComponent = styled(Space).attrs({
   h: { size: 'm', properties: ['padding-left', 'padding-right'] },
@@ -96,9 +97,7 @@ const LibraryMembersBar: FC<Props> = () => {
         >
           Library members:
         </Space>
-        <span className={font('hnr', 5)}>
-          requesting is currently unavailable
-        </span>
+        <span className={font('hnr', 5)}>{requestingDisabled}</span>
       </StyledComponent>
     );
   }

--- a/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
+++ b/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
@@ -22,10 +22,7 @@ import { useUser } from '@weco/common/views/components/UserProvider/UserProvider
 import { itemIsRequestable } from '../../utils/requesting';
 import Placeholder from '@weco/common/views/components/Placeholder/Placeholder';
 import ButtonOutlined from '@weco/common/views/components/ButtonOutlined/ButtonOutlined';
-import {
-  sierraAccessMethodtoNewLabel,
-  requestingDisabled,
-} from '@weco/common/data/microcopy';
+import { sierraAccessMethodtoNewLabel } from '@weco/common/data/microcopy';
 import { trackEvent } from '@weco/common/utils/ga';
 import { useToggles } from '@weco/common/server-data/Context';
 
@@ -230,33 +227,29 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
           columnWidths={[180, 200, undefined, undefined]}
         />
 
-        {(accessNote || isHeldByUser || disableRequesting) && (
+        {(accessNote || isHeldByUser) && (
           <Space v={{ size: 'm', properties: ['margin-top'] }}>
             <DetailHeading>Note</DetailHeading>
-            {disableRequesting ? (
-              requestingDisabled
-            ) : (
-              <Placeholder
-                nRows={3}
-                // We don't know exactly what we'll render until we know whether the user holds this item
-                isLoading={
-                  accessDataIsStale ||
-                  userNotLoaded ||
-                  (userState === 'signedin' && !userHeldItems)
-                }
-                maxWidth="50%"
-              >
-                <span
-                  dangerouslySetInnerHTML={{
-                    // if the user currently has this item on hold, we don't want
-                    // to show the note that says another user has it
-                    __html: isHeldByUser
-                      ? 'You have requested this item.'
-                      : accessNote || '', // This is always defined
-                  }}
-                />
-              </Placeholder>
-            )}
+            <Placeholder
+              nRows={3}
+              // We don't know exactly what we'll render until we know whether the user holds this item
+              isLoading={
+                accessDataIsStale ||
+                userNotLoaded ||
+                (userState === 'signedin' && !userHeldItems)
+              }
+              maxWidth="50%"
+            >
+              <span
+                dangerouslySetInnerHTML={{
+                  // if the user currently has this item on hold, we don't want
+                  // to show the note that says another user has it
+                  __html: isHeldByUser
+                    ? 'You have requested this item.'
+                    : accessNote || '', // This is always defined
+                }}
+              />
+            </Placeholder>
           </Space>
         )}
       </Wrapper>

--- a/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
+++ b/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
@@ -22,8 +22,12 @@ import { useUser } from '@weco/common/views/components/UserProvider/UserProvider
 import { itemIsRequestable } from '../../utils/requesting';
 import Placeholder from '@weco/common/views/components/Placeholder/Placeholder';
 import ButtonOutlined from '@weco/common/views/components/ButtonOutlined/ButtonOutlined';
-import { sierraAccessMethodtoNewLabel } from '@weco/common/data/microcopy';
+import {
+  sierraAccessMethodtoNewLabel,
+  requestingDisabled,
+} from '@weco/common/data/microcopy';
 import { trackEvent } from '@weco/common/utils/ga';
+import { useToggles } from '@weco/common/server-data/Context';
 
 const Wrapper = styled(Space).attrs({
   v: { size: 'm', properties: ['margin-bottom', 'padding-bottom'] },
@@ -79,6 +83,7 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
   isLast,
 }) => {
   const { state: userState } = useUser();
+  const { disableRequesting } = useToggles();
   const isArchive = useContext(IsArchiveContext);
   const requestButtonRef = useRef<HTMLButtonElement | null>(null);
 
@@ -123,7 +128,8 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
   const showAccessMethod = !isOpenShelves;
   const isRequestable = itemIsRequestable(item) && !requestWasCompleted;
 
-  const showButton = isRequestable && userState === 'signedin';
+  const showButton =
+    isRequestable && userState === 'signedin' && !disableRequesting;
 
   const userNotLoaded = userState === 'loading' || userState === 'initial';
 
@@ -223,29 +229,34 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
           maxWidth={isArchive ? 980 : 620}
           columnWidths={[180, 200, undefined, undefined]}
         />
-        {(accessNote || isHeldByUser) && (
+
+        {(accessNote || isHeldByUser || disableRequesting) && (
           <Space v={{ size: 'm', properties: ['margin-top'] }}>
             <DetailHeading>Note</DetailHeading>
-            <Placeholder
-              nRows={3}
-              // We don't know exactly what we'll render until we know whether the user holds this item
-              isLoading={
-                accessDataIsStale ||
-                userNotLoaded ||
-                (userState === 'signedin' && !userHeldItems)
-              }
-              maxWidth="50%"
-            >
-              <span
-                dangerouslySetInnerHTML={{
-                  // if the user currently has this item on hold, we don't want
-                  // to show the note that says another user has it
-                  __html: isHeldByUser
-                    ? 'You have requested this item.'
-                    : accessNote || '', // This is always defined
-                }}
-              />
-            </Placeholder>
+            {disableRequesting ? (
+              requestingDisabled
+            ) : (
+              <Placeholder
+                nRows={3}
+                // We don't know exactly what we'll render until we know whether the user holds this item
+                isLoading={
+                  accessDataIsStale ||
+                  userNotLoaded ||
+                  (userState === 'signedin' && !userHeldItems)
+                }
+                maxWidth="50%"
+              >
+                <span
+                  dangerouslySetInnerHTML={{
+                    // if the user currently has this item on hold, we don't want
+                    // to show the note that says another user has it
+                    __html: isHeldByUser
+                      ? 'You have requested this item.'
+                      : accessNote || '', // This is always defined
+                  }}
+                />
+              </Placeholder>
+            )}
           </Space>
         )}
       </Wrapper>

--- a/common/data/microcopy.ts
+++ b/common/data/microcopy.ts
@@ -98,3 +98,6 @@ export const inOurBuilding = 'In our building';
 // These are the instructions for people navigating the calendar component with a keyboard.
 export const calendarInstructions =
   'Use the arrow keys to move around the calendar. Use the home key to move to the beginning of a row. Use the end key to move to the end of a row. When focused on a date you can select it with the Enter or Space key.';
+
+export const requestingDisabled =
+  'Requesting is unavailable until Monday 6 June 09:00';

--- a/common/data/microcopy.ts
+++ b/common/data/microcopy.ts
@@ -100,4 +100,4 @@ export const calendarInstructions =
   'Use the arrow keys to move around the calendar. Use the home key to move to the beginning of a row. Use the end key to move to the end of a row. When focused on a date you can select it with the Enter or Space key.';
 
 export const requestingDisabled =
-  'Requesting is unavailable until Monday 6 June 09:00';
+  'Requesting is unavailable until 09:00 on Monday 6 June';

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -20,7 +20,7 @@ const toggles = {
       title: 'Disables requesting functionality',
       description:
         'Replaces the "sign into your library account to request items" message, with "requesting is currently unavailable". Adds a note to say when requesting will be available again.',
-      defaultValue: true,
+      defaultValue: false,
     },
     {
       id: 'enablePickUpDate',

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -16,10 +16,10 @@ const toggles = {
   // This should probably be called `features` as we have feature toggles, and a/b testing toggles.
   toggles: [
     {
-      id: 'enableRequesting',
-      title: 'Enables login and requesting functionality',
+      id: 'disableRequesting',
+      title: 'Disables requesting functionality',
       description:
-        'Puts login links in the headers and enables requesting functionality on works pages ',
+        'Replaces the "sign into your library account to request items" message, with "requesting is currently unavailable". Adds a note to say when requesting will be available again.',
       defaultValue: true,
     },
     {


### PR DESCRIPTION
Fixes #8010

- ~Replaces the "sign into your library account to request items" message, with "requesting is currently unavailable". (This will show regardless of whether the user is logged in or not)~
- ~Adds a note to say when requesting will be available again.~

When switched on the toggle:
- Removes the 'Request item' button
- Replaces the "sign into your library account to request items" message, with a message to say requesting is unavailable until a specific date. (This will show regardless of whether the user is logged in or not)

![Screenshot 2022-05-26 at 11 12 33](https://user-images.githubusercontent.com/6051896/170468979-895bc51f-849e-4a43-b2e7-8fadb8e4850c.png)


