### PR TITLE
Allow past events to display on exhibitions if they're available online

### DIFF
--- a/common/utils/dates.ts
+++ b/common/utils/dates.ts
@@ -1,14 +1,6 @@
 import { DateTypes, london } from './format-date';
 import { DateRange } from '../model/date-range';
 
-export function dateFromDateOrString(date: Date | string): Date {
-  if (typeof date === 'string') {
-    return new Date(date);
-  } else {
-    return date;
-  }
-}
-
 export function getEarliestFutureDateRange(
   dateRanges: DateRange[],
   fromDate: Date | undefined = new Date()

--- a/common/utils/dates.ts
+++ b/common/utils/dates.ts
@@ -1,6 +1,14 @@
 import { DateTypes, london } from './format-date';
 import { DateRange } from '../model/date-range';
 
+export function dateFromDateOrString(date: Date | string): Date {
+  if (typeof date === 'string') {
+    return new Date(date);
+  } else {
+    return date;
+  }
+}
+
 export function getEarliestFutureDateRange(
   dateRanges: DateRange[],
   fromDate: Date | undefined = new Date()

--- a/content/webapp/components/EventCard/EventCard.tsx
+++ b/content/webapp/components/EventCard/EventCard.tsx
@@ -1,3 +1,4 @@
+import { FC } from 'react';
 import { EventBasic } from '../../types/events';
 import CompactCard from '../CompactCard/CompactCard';
 import Image from '@weco/common/views/components/Image/Image';
@@ -5,21 +6,33 @@ import StatusIndicator from '@weco/common/views/components/StatusIndicator/Statu
 import EventDateRange from '../EventDateRange/EventDateRange';
 import { classNames, font } from '@weco/common/utils/classnames';
 import { getCrop } from '@weco/common/model/image';
+import { dateFromDateOrString } from '@weco/common/utils/dates';
 
 type Props = {
   event: EventBasic;
   xOfY: { x: number; y: number };
 };
 
-const EventCard = ({ event, xOfY }: Props) => {
-  const DateRangeComponent = <EventDateRange event={event} />;
+const EventCard: FC<Props> = ({ event, xOfY }) => {
+  const eventTimes = event.times.map(time => ({
+    ...time,
+    range: {
+      startDateTime: dateFromDateOrString(time.range.startDateTime),
+      endDateTime: dateFromDateOrString(time.range.endDateTime),
+    },
+  }));
+  const eventWithDates = {
+    ...event,
+    times: eventTimes,
+  };
+  const DateRangeComponent = <EventDateRange event={eventWithDates} />;
 
-  const squareImage = getCrop(event.image, 'square');
+  const squareImage = getCrop(eventWithDates.image, 'square');
   const ImageComponent = squareImage && <Image {...squareImage} />;
 
-  const firstTime = event.times[0];
-  const lastTime = event.times[event.times.length - 1];
-  const StatusIndicatorComponent = event.isPast ? (
+  const firstTime = eventWithDates.times[0];
+  const lastTime = eventWithDates.times[eventWithDates.times.length - 1];
+  const StatusIndicatorComponent = eventWithDates.isPast ? (
     <StatusIndicator
       start={firstTime.range.startDateTime}
       end={lastTime.range.endDateTime}
@@ -28,17 +41,17 @@ const EventCard = ({ event, xOfY }: Props) => {
 
   return (
     <CompactCard
-      url={`/events/${event.id}`}
-      title={event.title}
-      primaryLabels={event.primaryLabels}
-      secondaryLabels={event.secondaryLabels}
-      urlOverride={event.promo && event.promo.link}
+      url={`/events/${eventWithDates.id}`}
+      title={eventWithDates.title}
+      primaryLabels={eventWithDates.primaryLabels}
+      secondaryLabels={eventWithDates.secondaryLabels}
+      urlOverride={eventWithDates.promo && eventWithDates.promo.link}
       Image={ImageComponent}
       DateInfo={DateRangeComponent}
       StatusIndicator={StatusIndicatorComponent}
       ExtraInfo={
-        !event.isPast &&
-        event.times.length > 1 && (
+        !eventWithDates.isPast &&
+        eventWithDates.times.length > 1 && (
           <p
             className={classNames({
               [font('hnb', 4)]: true,

--- a/content/webapp/components/EventCard/EventCard.tsx
+++ b/content/webapp/components/EventCard/EventCard.tsx
@@ -17,12 +17,12 @@ const EventCard: FC<Props> = ({ event: jsonEvent, xOfY }) => {
   const event = fixEventDatesInJson(jsonEvent);
   const DateRangeComponent = <EventDateRange event={eventWithDates} />;
 
-  const squareImage = getCrop(eventWithDates.image, 'square');
+  const squareImage = getCrop(event.image, 'square');
   const ImageComponent = squareImage && <Image {...squareImage} />;
 
-  const firstTime = eventWithDates.times[0];
-  const lastTime = eventWithDates.times[eventWithDates.times.length - 1];
-  const StatusIndicatorComponent = eventWithDates.isPast ? (
+  const firstTime = event.times[0];
+  const lastTime = event.times[event.times.length - 1];
+  const StatusIndicatorComponent = event.isPast ? (
     <StatusIndicator
       start={firstTime.range.startDateTime}
       end={lastTime.range.endDateTime}
@@ -31,17 +31,17 @@ const EventCard: FC<Props> = ({ event: jsonEvent, xOfY }) => {
 
   return (
     <CompactCard
-      url={`/events/${eventWithDates.id}`}
-      title={eventWithDates.title}
-      primaryLabels={eventWithDates.primaryLabels}
-      secondaryLabels={eventWithDates.secondaryLabels}
-      urlOverride={eventWithDates.promo && eventWithDates.promo.link}
+      url={`/events/${event.id}`}
+      title={event.title}
+      primaryLabels={event.primaryLabels}
+      secondaryLabels={event.secondaryLabels}
+      urlOverride={event.promo && event.promo.link}
       Image={ImageComponent}
       DateInfo={DateRangeComponent}
       StatusIndicator={StatusIndicatorComponent}
       ExtraInfo={
-        !eventWithDates.isPast &&
-        eventWithDates.times.length > 1 && (
+        !event.isPast &&
+        event.times.length > 1 && (
           <p
             className={classNames({
               [font('hnb', 4)]: true,

--- a/content/webapp/components/EventCard/EventCard.tsx
+++ b/content/webapp/components/EventCard/EventCard.tsx
@@ -6,7 +6,7 @@ import StatusIndicator from '@weco/common/views/components/StatusIndicator/Statu
 import EventDateRange from '../EventDateRange/EventDateRange';
 import { classNames, font } from '@weco/common/utils/classnames';
 import { getCrop } from '@weco/common/model/image';
-import { dateFromDateOrString } from '@weco/common/utils/dates';
+import { fixEventDatesInJson } from '../../services/prismic/transformers/events';
 
 type Props = {
   event: EventBasic;
@@ -14,17 +14,7 @@ type Props = {
 };
 
 const EventCard: FC<Props> = ({ event, xOfY }) => {
-  const eventTimes = event.times.map(time => ({
-    ...time,
-    range: {
-      startDateTime: dateFromDateOrString(time.range.startDateTime),
-      endDateTime: dateFromDateOrString(time.range.endDateTime),
-    },
-  }));
-  const eventWithDates = {
-    ...event,
-    times: eventTimes,
-  };
+  const eventWithDates = fixEventDatesInJson(event);
   const DateRangeComponent = <EventDateRange event={eventWithDates} />;
 
   const squareImage = getCrop(eventWithDates.image, 'square');

--- a/content/webapp/components/EventCard/EventCard.tsx
+++ b/content/webapp/components/EventCard/EventCard.tsx
@@ -13,8 +13,8 @@ type Props = {
   xOfY: { x: number; y: number };
 };
 
-const EventCard: FC<Props> = ({ event, xOfY }) => {
-  const eventWithDates = fixEventDatesInJson(event);
+const EventCard: FC<Props> = ({ event: jsonEvent, xOfY }) => {
+  const event = fixEventDatesInJson(jsonEvent);
   const DateRangeComponent = <EventDateRange event={eventWithDates} />;
 
   const squareImage = getCrop(eventWithDates.image, 'square');

--- a/content/webapp/components/EventCard/EventCard.tsx
+++ b/content/webapp/components/EventCard/EventCard.tsx
@@ -15,7 +15,7 @@ type Props = {
 
 const EventCard: FC<Props> = ({ event: jsonEvent, xOfY }) => {
   const event = fixEventDatesInJson(jsonEvent);
-  const DateRangeComponent = <EventDateRange event={eventWithDates} />;
+  const DateRangeComponent = <EventDateRange event={event} />;
 
   const squareImage = getCrop(event.image, 'square');
   const ImageComponent = squareImage && <Image {...squareImage} />;

--- a/content/webapp/services/prismic/transformers/exhibitions.ts
+++ b/content/webapp/services/prismic/transformers/exhibitions.ts
@@ -270,6 +270,7 @@ export const transformExhibitionRelatedContent = (
     query,
     transformMultiContent
   ).results.filter(doc => {
+    // We don't include past events _unless_ they are still available to view online
     return !(doc.type === 'events' && doc.isPast && !doc.availableOnline);
   });
 

--- a/content/webapp/services/prismic/transformers/exhibitions.ts
+++ b/content/webapp/services/prismic/transformers/exhibitions.ts
@@ -270,7 +270,7 @@ export const transformExhibitionRelatedContent = (
     query,
     transformMultiContent
   ).results.filter(doc => {
-    return !(doc.type === 'events' && doc.isPast);
+    return !(doc.type === 'events' && doc.isPast && !doc.availableOnline);
   });
 
   return {


### PR DESCRIPTION
Related to #8030

Historically it didn't make sense to show past events as related content for exhibitions. But now some events are made available online, we still want those to show up even if they happened in the past IRL.

We fetch these client-side and as a result, the dates are formatted as strings initially. This PR adds a function to make sure that we're using dates where we rely on the `Date` API.

I think we might want to update the[ `DateTimeRange` type](https://github.com/wellcomecollection/wellcomecollection.org/blob/12d01bcc9e1044f0fb4e3d9be138391413d25ac9/content/webapp/types/events.ts#L12-L15) to reflect that these _could_ be strings, but I imagine that will require a larger PR to fix all the issues that would ensue.
 