### PR TITLE
Show appropriate info on compact event cards

### DIFF
--- a/content/webapp/components/EventCard/EventCard.tsx
+++ b/content/webapp/components/EventCard/EventCard.tsx
@@ -7,6 +7,8 @@ import EventDateRange from '../EventDateRange/EventDateRange';
 import { classNames, font } from '@weco/common/utils/classnames';
 import { getCrop } from '@weco/common/model/image';
 import { fixEventDatesInJson } from '../../services/prismic/transformers/events';
+import Space from '@weco/common/views/components/styled/Space';
+import WatchLabel from '@weco/common/views/components/WatchLabel/WatchLabel';
 
 type Props = {
   event: EventBasic;
@@ -15,19 +17,44 @@ type Props = {
 
 const EventCard: FC<Props> = ({ event: jsonEvent, xOfY }) => {
   const event = fixEventDatesInJson(jsonEvent);
-  const DateRangeComponent = <EventDateRange event={event} />;
+  const DateRangeComponent = event.isPast ? undefined : (
+    <EventDateRange event={event} />
+  );
 
   const squareImage = getCrop(event.image, 'square');
   const ImageComponent = squareImage && <Image {...squareImage} />;
 
   const firstTime = event.times[0];
   const lastTime = event.times[event.times.length - 1];
-  const StatusIndicatorComponent = event.isPast ? (
-    <StatusIndicator
-      start={firstTime.range.startDateTime}
-      end={lastTime.range.endDateTime}
-    />
-  ) : undefined;
+
+  // Past events that are available online don't have a status indicator…
+  const StatusIndicatorComponent =
+    event.isPast && !event.availableOnline ? (
+      <StatusIndicator
+        start={firstTime.range.startDateTime}
+        end={lastTime.range.endDateTime}
+      />
+    ) : undefined;
+  // …and they display online availability information.
+  const ExtraInfo =
+    event.isPast && event.availableOnline ? (
+      <>
+        <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
+          <Space v={{ size: 's', properties: ['margin-top'] }}>
+            <WatchLabel text={`Available to watch`} />
+          </Space>
+        </Space>
+      </>
+    ) : !event.isPast && event.times.length > 1 ? (
+      <p
+        className={classNames({
+          [font('hnb', 4)]: true,
+          'no-margin': true,
+        })}
+      >
+        See all dates/times
+      </p>
+    ) : undefined;
 
   return (
     <CompactCard
@@ -39,19 +66,7 @@ const EventCard: FC<Props> = ({ event: jsonEvent, xOfY }) => {
       Image={ImageComponent}
       DateInfo={DateRangeComponent}
       StatusIndicator={StatusIndicatorComponent}
-      ExtraInfo={
-        !event.isPast &&
-        event.times.length > 1 && (
-          <p
-            className={classNames({
-              [font('hnb', 4)]: true,
-              'no-margin': true,
-            })}
-          >
-            See all dates/times
-          </p>
-        )
-      }
+      ExtraInfo={ExtraInfo}
       xOfY={xOfY}
     />
   );


### PR DESCRIPTION
When an event is listed as being related to an exhibition and we're displaying it because it is available online, we need to let people know that's why. If it is past, the dates and the status aren't useful to people under these circumstances.

__Before__
<img width="767" alt="image" src="https://user-images.githubusercontent.com/1394592/170529119-d8b6088c-4610-400f-a404-7d5a50953d73.png">

__After__
<img width="811" alt="image" src="https://user-images.githubusercontent.com/1394592/170529006-d9335342-7b22-4196-8923-b472e406de86.png">
