### PR TITLE
Link to Prismic pages from the API toolbar

### DIFF
--- a/common/services/prismic/index.test.ts
+++ b/common/services/prismic/index.test.ts
@@ -1,0 +1,20 @@
+import { looksLikePrismicId } from '.';
+import { homepageId, prismicPageIds } from './hardcoded-id';
+
+describe('looksLikePrismicId', () => {
+  it('thinks Prismic IDs look like Prismic IDs', () => {
+    expect(looksLikePrismicId('Wuw2MSIAACtd3StS')).toBeTruthy();
+    expect(looksLikePrismicId(prismicPageIds.press)).toBeTruthy();
+    expect(looksLikePrismicId(homepageId)).toBeTruthy();
+  });
+
+  it('thinks catalogue IDs don’t look like Prismic IDs', () => {
+    expect(looksLikePrismicId('va2vy7wb')).toBeFalsy();
+    expect(looksLikePrismicId('s42juuaz')).toBeFalsy();
+  });
+
+  it('thinks malicious inputs don’t look like Prismic IDs', () => {
+    expect(looksLikePrismicId('<script>alert("BOOM!");</script>')).toBeFalsy();
+    expect(looksLikePrismicId('DROP TABLE names;')).toBeFalsy();
+  });
+});

--- a/common/services/prismic/index.ts
+++ b/common/services/prismic/index.ts
@@ -1,0 +1,19 @@
+// Returns true if a query parameter is plausibly a Prismic ID, false otherwise.
+//
+// There's no way for the front-end to know what strings are valid Prismic IDs
+// (only Prismic itself knows that), but it can reject certain classes of
+// strings that it knows definitely aren't.
+//
+// e.g. an empty string definitely isn't a Prismic ID.
+//
+// This is useful for rejecting queries that are obviously malformed, which might
+// be attempts to inject malicious data into Prismic queries.
+//
+// Note: we use this to distinguish it from catalogue IDs, which are (as of May 2022)
+// eight characters long.
+
+import { isString } from '@weco/common/utils/array';
+
+export const looksLikePrismicId = (
+  id: string | string[] | undefined
+): boolean => (isString(id) ? /^([A-Za-z0-9-_]{9,})$/.test(id) : false);

--- a/common/views/components/ApiToolbar/ApiToolbar.tsx
+++ b/common/views/components/ApiToolbar/ApiToolbar.tsx
@@ -4,6 +4,7 @@ import { ParsedUrlQuery } from 'querystring';
 import cookies from 'next-cookies';
 import useIsomorphicLayoutEffect from '../../../hooks/useIsomorphicLayoutEffect';
 import { Work, Location } from '../../../model/catalogue';
+import { looksLikePrismicId } from 'services/prismic';
 
 type Prop = {
   id: string;
@@ -26,44 +27,72 @@ const includes = [
   'succeededBy',
   'holdings',
 ];
-const routeProps = {
-  '/work': async (query: ParsedUrlQuery): Promise<Prop[]> => {
-    const { id } = query;
-    const apiUrl = `https://api.wellcomecollection.org/catalogue/v2/works/${id}?include=${includes}`;
-    const work: Work = await fetch(apiUrl).then(res => res.json());
 
-    const apiLink = {
-      id: 'json',
-      label: 'JSON',
-      link: apiUrl,
-    };
+function getRouteProps(path: string) {
+  switch (path) {
+    case '/work':
+      return async (query: ParsedUrlQuery): Promise<Prop[]> => {
+        const { id } = query;
+        const apiUrl = `https://api.wellcomecollection.org/catalogue/v2/works/${id}?include=${includes}`;
+        const work: Work = await fetch(apiUrl).then(res => res.json());
 
-    const iiifItem = work.items
-      ?.reduce((acc, item) => {
-        return acc.concat(item.locations);
-      }, [] as Location[])
-      ?.find(location => location.locationType.id.startsWith('iiif'));
+        const apiLink = {
+          id: 'json',
+          label: 'JSON',
+          link: apiUrl,
+        };
 
-    const iiifLink = iiifItem &&
-      iiifItem.type === 'DigitalLocation' && {
-        id: 'iiif',
-        label: 'IIIF',
-        link: iiifItem.url,
+        const iiifItem = work.items
+          ?.reduce((acc, item) => {
+            return acc.concat(item.locations);
+          }, [] as Location[])
+          ?.find(location => location.locationType.id.startsWith('iiif'));
+
+        const iiifLink = iiifItem &&
+          iiifItem.type === 'DigitalLocation' && {
+            id: 'iiif',
+            label: 'IIIF',
+            link: iiifItem.url,
+          };
+
+        const links = [
+          apiLink,
+          iiifLink,
+          ...work.identifiers.map(id => ({
+            id: id.value,
+            label: id.identifierType.label,
+            value: id.value,
+          })),
+        ].filter(Boolean) as Prop[];
+
+        return links;
       };
 
-    const links = [
-      apiLink,
-      iiifLink,
-      ...work.identifiers.map(id => ({
-        id: id.value,
-        label: id.identifierType.label,
-        value: id.value,
-      })),
-    ].filter(Boolean) as Prop[];
+    default:
+      return async (query: ParsedUrlQuery): Promise<Prop[]> => {
+        const { id } = query;
 
-    return links;
-  },
-};
+        // On some Prismic pages, the ID will be in the query data, e.g. /events/YeViLhAAAJMQM7IY
+        // will have the query {"id": "YeViLhAAAJMQM7IY"}
+        //
+        // If it looks like a Prismic ID, we can guess how to get to the page in Prismic.
+        // This isn't perfect -- there may be cases where the link doesn't work (e.g. if it's
+        // not actually a Prismic ID, or the page is unpublished) -- but hopefully something
+        // that works 95% of the time is still useful.
+        if (looksLikePrismicId(id)) {
+          const prismicLink = {
+            id: 'prismic',
+            label: 'Prismic',
+            link: `https://wellcomecollection.prismic.io/documents~b=working&c=published&l=en-gb/${id}/`,
+          };
+
+          return [prismicLink];
+        } else {
+          return [];
+        }
+      };
+  }
+}
 
 const ApiToolbar: FunctionComponent = () => {
   const cookieName = 'apiToolbarMini';
@@ -76,7 +105,7 @@ const ApiToolbar: FunctionComponent = () => {
   }, []);
 
   useEffect(() => {
-    const fn = routeProps[router.route];
+    const fn = getRouteProps(router.route);
     if (fn) {
       fn(router.query).then(setProps);
     }

--- a/common/views/components/ApiToolbar/ApiToolbar.tsx
+++ b/common/views/components/ApiToolbar/ApiToolbar.tsx
@@ -4,7 +4,7 @@ import { ParsedUrlQuery } from 'querystring';
 import cookies from 'next-cookies';
 import useIsomorphicLayoutEffect from '../../../hooks/useIsomorphicLayoutEffect';
 import { Work, Location } from '../../../model/catalogue';
-import { looksLikePrismicId } from 'services/prismic';
+import { looksLikePrismicId } from '../../../services/prismic';
 
 type Prop = {
   id: string;

--- a/content/webapp/pages/article-series.tsx
+++ b/content/webapp/pages/article-series.tsx
@@ -15,7 +15,7 @@ import { getServerData } from '@weco/common/server-data';
 import Body from '../components/Body/Body';
 import SearchResults from '../components/SearchResults/SearchResults';
 import ContentPage from '../components/ContentPage/ContentPage';
-import { looksLikePrismicId } from '../services/prismic';
+import { looksLikePrismicId } from '@weco/common/services/prismic';
 import { createClient } from '../services/prismic/fetch';
 import { bodySquabblesSeries } from '@weco/common/services/prismic/hardcoded-id';
 import { fetchArticles } from '../services/prismic/fetch/articles';

--- a/content/webapp/pages/article.tsx
+++ b/content/webapp/pages/article.tsx
@@ -24,7 +24,7 @@ import {
   fetchArticlesClientSide,
 } from '../services/prismic/fetch/articles';
 import { articleLd } from '../services/prismic/transformers/json-ld';
-import { looksLikePrismicId } from '../services/prismic';
+import { looksLikePrismicId } from '@weco/common/services/prismic';
 import { bodySquabblesSeries } from '@weco/common/services/prismic/hardcoded-id';
 import { transformArticle } from '../services/prismic/transformers/articles';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';

--- a/content/webapp/pages/book.tsx
+++ b/content/webapp/pages/book.tsx
@@ -17,7 +17,7 @@ import { fetchBook } from '../services/prismic/fetch/books';
 import { createClient } from '../services/prismic/fetch';
 import { transformBook } from '../services/prismic/transformers/books';
 import { Book } from '../types/books';
-import { looksLikePrismicId } from '../services/prismic';
+import { looksLikePrismicId } from '@weco/common/services/prismic';
 import Layout8 from '@weco/common/views/components/Layout8/Layout8';
 
 const MetadataWrapper = styled.div`

--- a/content/webapp/pages/event-series.tsx
+++ b/content/webapp/pages/event-series.tsx
@@ -14,7 +14,7 @@ import Body from '../components/Body/Body';
 import ContentPage from '../components/ContentPage/ContentPage';
 import SearchResults from '../components/SearchResults/SearchResults';
 import { eventLd } from '../services/prismic/transformers/json-ld';
-import { looksLikePrismicId } from '../services/prismic';
+import { looksLikePrismicId } from '@weco/common/services/prismic';
 import { fetchEvents } from '../services/prismic/fetch/events';
 import { createClient } from '../services/prismic/fetch';
 import * as prismic from '@prismicio/client';

--- a/content/webapp/pages/exhibition.tsx
+++ b/content/webapp/pages/exhibition.tsx
@@ -15,7 +15,7 @@ import {
   fixExhibitionDatesInJson,
   transformExhibition,
 } from '../services/prismic/transformers/exhibitions';
-import { looksLikePrismicId } from '../services/prismic';
+import { looksLikePrismicId } from '@weco/common/services/prismic';
 import { exhibitionLd } from 'services/prismic/transformers/json-ld';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 

--- a/content/webapp/pages/season.tsx
+++ b/content/webapp/pages/season.tsx
@@ -51,7 +51,7 @@ import { ExhibitionBasic } from '../types/exhibitions';
 import { Page } from '../types/pages';
 import { Project } from '../types/projects';
 import { Series } from '../types/series';
-import { looksLikePrismicId } from '../services/prismic';
+import { looksLikePrismicId } from '@weco/common/services/prismic';
 import { getCrop } from '@weco/common/model/image';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 


### PR DESCRIPTION
## Who is this for?

Content editors. Also me.

## What is it doing for them?

Making it easier to find where a page is defined in the Prismic web editor, by adding an inferred link to the API toolbar.

<img width="1181" alt="Screenshot 2022-05-27 at 14 56 40" src="https://user-images.githubusercontent.com/301220/170713891-a76e62d1-bb8e-4541-9d05-678b32ee8d5c.png">

This has several shortcomings:

* Some pages won't have it, in particular ones where we infer the page ID (the homepage, /visit-us, /collections, /stories)
* It's not 100% guaranteed to be a working URL – it's using a crude heuristic, not anything we get from Prismic itself. In particular I think it might fail for unpublished pages, but those are probably near the top of the list of entries in Prismic.
* Is it part of the API? Ehhhhhh… but this component is not exactly designed or curated; it's a collection of quick wins to make staff's lives easier rather than a properly-designed component, and this doesn't make it better or worse.