### PR TITLE
Use Node images from ECR Public, not our vendored repos

### DIFF
--- a/cache/edge_lambdas/Dockerfile
+++ b/cache/edge_lambdas/Dockerfile
@@ -1,4 +1,4 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/node:12.18.3
+FROM public.ecr.aws/docker/library/node:12-slim
 
 VOLUME /dist
 

--- a/cardigan/Dockerfile
+++ b/cardigan/Dockerfile
@@ -1,5 +1,5 @@
 # This image should be built with the parent directory as context
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/node:12.18.3
+FROM public.ecr.aws/docker/library/node:12-slim
 
 WORKDIR /usr/src/app/webapp
 

--- a/catalogue/Dockerfile
+++ b/catalogue/Dockerfile
@@ -1,5 +1,5 @@
 # This image should be built with the parent directory as context
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/node:14.17.6
+FROM public.ecr.aws/docker/library/node:14-slim
 
 RUN apt-get update && apt-get install -y awscli
 

--- a/common/Dockerfile
+++ b/common/Dockerfile
@@ -1,4 +1,4 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/node:12.18.3
+FROM public.ecr.aws/docker/library/node:12-slim
 
 WORKDIR /usr/src/app/webapp
 

--- a/content/Dockerfile
+++ b/content/Dockerfile
@@ -1,5 +1,5 @@
 # This image should be built with the parent directory as context
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/node:14.17.6
+FROM public.ecr.aws/docker/library/node:14-slim
 
 RUN apt-get update && apt-get install -y awscli
 

--- a/dash/Dockerfile
+++ b/dash/Dockerfile
@@ -1,4 +1,4 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/node:12.18.3
+FROM public.ecr.aws/docker/library/node:12-slim
 
 WORKDIR /usr/src/app/webapp
 

--- a/identity/Dockerfile
+++ b/identity/Dockerfile
@@ -1,5 +1,5 @@
 # This image should be built with the parent directory as context
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/node:14.17.6
+FROM public.ecr.aws/docker/library/node:14-slim
 
 RUN apt-get update && apt-get install -y awscli
 

--- a/lighthouse/server/Dockerfile
+++ b/lighthouse/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/node:14-alpine
+FROM public.ecr.aws/docker/library/node:14-slim
 
 WORKDIR /app
 

--- a/pa11y/Dockerfile
+++ b/pa11y/Dockerfile
@@ -1,4 +1,4 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/node:12.18.3
+FROM public.ecr.aws/docker/library/node:12-slim
 
 VOLUME /dist
 

--- a/prismic-model/Dockerfile
+++ b/prismic-model/Dockerfile
@@ -1,4 +1,4 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/node:14-alpine
+FROM public.ecr.aws/docker/library/node:14-slim
 
 COPY package.json yarn.lock ./
 RUN yarn install --frozen-lockfile

--- a/toggles/Dockerfile
+++ b/toggles/Dockerfile
@@ -1,4 +1,4 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/node:12.18.3
+FROM public.ecr.aws/docker/library/node:12-slim
 
 VOLUME /dist
 

--- a/updown/Dockerfile
+++ b/updown/Dockerfile
@@ -1,4 +1,4 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/node:14.14.0
+FROM public.ecr.aws/docker/library/node:14-slim
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
I also took the opportunity to consolidate onto a single image for each major version of Node, and switch to -slim images which are much smaller.

For https://github.com/wellcomecollection/platform/issues/5545, which includes a discussion of the benefits.