### PR TITLE
Reduce label padding

### DIFF
--- a/common/views/components/Label/Label.tsx
+++ b/common/views/components/Label/Label.tsx
@@ -39,14 +39,12 @@ const Label: FunctionComponent<Props> = ({
   return (
     <LabelContainer
       v={{
-        size: 's',
+        size: 'xs',
         properties: ['padding-top', 'padding-bottom'],
-        overrides: { large: 2 },
       }}
       h={{
-        size: 's',
+        size: 'xs',
         properties: ['padding-left', 'padding-right'],
-        overrides: { large: 2 },
       }}
       fontColor={
         label.textColor ||


### PR DESCRIPTION
Part of #8041 

Design QA on the labels to reduce padding from 6 to 4 px after the switch from Helvetica to Inter