### PR TITLE
Rationalise page header spacing

### DIFF
--- a/content/webapp/components/Body/Body.tsx
+++ b/content/webapp/components/Body/Body.tsx
@@ -221,6 +221,8 @@ const Body: FunctionComponent<Props> = ({
                       properties:
                         isLast && sectionTheme.rowBackground === 'white'
                           ? ['padding-top']
+                          : isFirst && sectionTheme.rowBackground === 'white'
+                          ? ['padding-bottom']
                           : ['padding-top', 'padding-bottom'],
                     }}
                     className={classNames({

--- a/content/webapp/pages/stories.tsx
+++ b/content/webapp/pages/stories.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react';
-import { classNames, grid } from '@weco/common/utils/classnames';
+import { classNames } from '@weco/common/utils/classnames';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import Layout12 from '@weco/common/views/components/Layout12/Layout12';
 import SectionHeader from '@weco/common/views/components/SectionHeader/SectionHeader';
@@ -19,7 +19,8 @@ import {
   transformPage,
 } from '../services/prismic/transformers/pages';
 import { FeaturedText as FeaturedTextType } from '../types/text';
-import { SectionPageHeader } from '@weco/common/views/components/styled/SectionPageHeader';
+import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
+import Layout8 from '@weco/common/views/components/Layout8/Layout8';
 import { GetServerSideProps } from 'next';
 import { AppErrorProps } from '@weco/common/views/pages/_app';
 import { removeUndefinedProps } from '@weco/common/utils/json';
@@ -185,49 +186,31 @@ const StoriesPage: FC<Props> = ({
       image={firstArticle && firstArticle.image}
       rssUrl={'https://rss.wellcomecollection.org/stories'}
     >
-      <SpacingSection>
-        <Space
-          v={{
-            size: 'l',
-            properties: ['padding-top', 'padding-bottom'],
-          }}
-          className={classNames({
-            row: true,
-          })}
-        >
-          <div className="container">
-            <div className="grid">
-              <div
-                className={classNames({
-                  [grid({ s: 12, m: 12, l: 7, xl: 7 })]: true,
-                })}
+      <PageHeader
+        breadcrumbs={{ items: [] }}
+        title={'Stories'}
+        isContentTypeInfoBeforeMedia={false}
+        sectionLevelPage={true}
+      />
+      <>
+        {featuredText && featuredText.value && (
+          <Layout8 shift={false}>
+            <div className="body-text spaced-text">
+              <Space
+                v={{
+                  size: 'xl',
+                  properties: ['margin-bottom'],
+                }}
               >
-                <SectionPageHeader sectionLevelPage={true}>
-                  Stories
-                </SectionPageHeader>
-                {featuredText && featuredText.value && (
-                  <Space
-                    v={{
-                      size: 's',
-                      properties: ['margin-top'],
-                    }}
-                    className={classNames({
-                      'first-para-no-margin body-text': true,
-                    })}
-                  >
-                    {
-                      <FeaturedText
-                        html={featuredText.value}
-                        htmlSerializer={defaultSerializer}
-                      />
-                    }
-                  </Space>
-                )}
-              </div>
+                <FeaturedText
+                  html={featuredText.value}
+                  htmlSerializer={defaultSerializer}
+                />
+              </Space>
             </div>
-          </div>
-        </Space>
-      </SpacingSection>
+          </Layout8>
+        )}
+      </>
 
       <SpacingSection>
         <div


### PR DESCRIPTION
Part of #8041 

https://user-images.githubusercontent.com/1394592/171401161-9df42dc5-d464-460f-8700-98fb17100b5a.mp4

Using the `PageHeader` component on the Stories page, and removing top padding from body sections that have a white background.
