### PR TITLE
Don't throw a 500 error if somebody paginates off the end of /articles

### DIFF
--- a/.buildkite/expected_200_urls.txt
+++ b/.buildkite/expected_200_urls.txt
@@ -40,3 +40,7 @@
 # Schools page, but it shouldn't be redirected.  See the router in
 # the content app, where we enable case-sensitive routing.
 /pages/Wuw2MSIAACtd3Sts
+
+# This page won't serve anything especially useful, but we want to
+# make sure it won't throw a 500 error
+/articles?page=343

--- a/content/webapp/pages/articles.tsx
+++ b/content/webapp/pages/articles.tsx
@@ -55,7 +55,9 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   };
 
 const ArticlesPage: FC<Props> = ({ articles, jsonLd }: Props) => {
-  const firstArticle = articles.results[0];
+  // `articles` could be empty if somebody paginates off the end of the list,
+  // e.g. /articles?page=500
+  const image = articles.results[0]?.image;
 
   return (
     <PageLayout
@@ -65,7 +67,7 @@ const ArticlesPage: FC<Props> = ({ articles, jsonLd }: Props) => {
       jsonLd={jsonLd}
       openGraphType={'website'}
       siteSection={'stories'}
-      image={firstArticle.image}
+      image={image}
     >
       <SpacingSection>
         <LayoutPaginatedResults


### PR DESCRIPTION
## Who is this for?

Devs.

## What is it doing for them?

Making sure we don't alarm on somebody doing this. They won't get particularly insightful results, but nor will they pop an alarm for us to triage:

<img width="1144" alt="Screenshot 2022-06-06 at 07 20 20" src="https://user-images.githubusercontent.com/301220/172106346-26668189-9dbb-42f5-9f00-746c26d460e9.png">
