### PR TITLE
Lazy deploys of the edge Lambdas

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-.git
 terraform*
 */terraform
 node_modules

--- a/cache/edge_lambdas/Dockerfile
+++ b/cache/edge_lambdas/Dockerfile
@@ -1,12 +1,10 @@
 FROM public.ecr.aws/docker/library/node:12-slim
 
-VOLUME /dist
+RUN apt-get update && apt-get install -yq --no-install-recommends git zip
 
-RUN apt-get update && apt-get install -yq --no-install-recommends zip
-
-WORKDIR /usr/src/app/webapp
-
-ADD . /usr/src/app/webapp
+ADD .git /repo/.git
+ADD cache/edge_lambdas /repo/cache/edge_lambdas
+WORKDIR /repo/cache/edge_lambdas
 
 RUN yarn && yarn build && yarn cache clean
 

--- a/cache/edge_lambdas/deploy.js
+++ b/cache/edge_lambdas/deploy.js
@@ -36,6 +36,8 @@ try {
     { encoding: 'utf-8' }
   );
 
+  console.log(`Last Git commit to modify this package was ${lastGitCommit}`);
+
   const bucket = 'weco-lambdas';
   const key = 'edge_lambda_origin.zip';
 

--- a/cache/edge_lambdas/deploy.js
+++ b/cache/edge_lambdas/deploy.js
@@ -1,22 +1,60 @@
 const AWS = require('aws-sdk');
 const s3 = new AWS.S3({ apiVersion: '2006-03-01' });
 
+const childProcess = require('child_process');
 const fs = require('fs');
 
-try {
+function uploadNewLambdaPackage(bucket, key, lastGitCommit) {
   const data = fs.readFileSync('edge_lambda_origin.zip');
 
-  const params = {
+  const putParams = {
     Body: data,
-    Bucket: 'weco-lambdas',
-    Key: 'edge_lambda_origin.zip',
+    Bucket: bucket,
+    Key: key,
     ACL: 'private',
     ContentType: 'application/zip',
+    Metadata: {
+      'gitCommit': lastGitCommit,
+    },
   };
 
-  s3.putObject(params, function(err, data) {
+  s3.putObject(putParams, function(err, data) {
     if (err) console.log(err, err.stack);
     else console.log('Finished uploading edge_lambda_origin.zip');
+  });
+}
+
+try {
+  // Get the last Git commit that modified the edge_lambdas folder.
+  //
+  // The Lambda should be totally determined by the contents of
+  // this folder, so if it hasn't changed we can skip the deployment.
+  //
+  // This will reduce churn in the associated Terraform stack.
+  const lastGitCommit = childProcess.execSync(
+    'git log -n 1 --pretty=format:%H -- .',
+    { encoding: 'utf-8' }
+  );
+
+  const bucket = 'weco-lambdas';
+  const key = 'edge_lambda_origin.zip';
+
+  const getParams = {
+    Bucket: bucket,
+    Key: key,
+  };
+
+  s3.headObject(getParams, function(err, data) {
+    if (err) {
+      console.log(err, err.stack);
+    } else {
+      if (data.Metadata !== null && data.Metadata.gitcommit === lastGitCommit) {
+        console.log("S3 deployment package is already up-to-date; skipping deployment");
+      } else {
+        console.log("S3 deployment package is stale; uploading new Lambda");
+        uploadNewLambdaPackage(bucket, key, lastGitCommit);
+      }
+    }
   });
 } catch (e) {
   console.log('Error:', e.stack);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,9 +29,11 @@ services:
       context: ./dash
   edge_lambdas:
     build:
-      context: ./cache/edge_lambdas
+      context: .
+      dockerfile: cache/edge_lambdas/Dockerfile
     volumes:
       - ~/.aws:/root/.aws
+      - ./cache/edge_lambdas/deploy.js:/repo/cache/edge_lambdas/deploy.js
     environment:
       - AWS_PROFILE
   toggles:


### PR DESCRIPTION
## Who is this for?

Devs.

## What is it doing for them?

Currently we publish a new version of the edge Lambdas on every deploy to main. This means that whenever you want to do Terraform in the `cache` stack, it wants to redeploy all the CloudFront distributions with new Lambdas, even though they haven't meaningfully changed. This is annoying and means you potentially miss actually breaking changes in CloudFront (😱).

This patch makes the deployment a bit more self-aware, so it (1) tags the S3 object with the commit they were built from and (2) doesn't reupload an object if that commit hasn't changed.