### PR TITLE
Add a concepts toggle and a bare-bones page

### DIFF
--- a/catalogue/webapp/app.ts
+++ b/catalogue/webapp/app.ts
@@ -29,6 +29,7 @@ const appPromise = nextApp.prepare().then(async () => {
 
   // Next routing
   route('/works/:id', '/work', router, nextApp);
+  route('/concepts/:id', '/concept', router, nextApp);
   route('/works', '/works', router, nextApp);
   route('/works/:workId/items', '/item', router, nextApp);
   route('/works/:workId/images', '/image', router, nextApp);

--- a/catalogue/webapp/pages/concept.tsx
+++ b/catalogue/webapp/pages/concept.tsx
@@ -1,0 +1,97 @@
+import { GetServerSideProps, NextPage } from 'next';
+import {
+  Concept as ConceptType,
+  Work as WorkType,
+} from '@weco/common/model/catalogue';
+import { removeUndefinedProps } from '@weco/common/utils/json';
+import { appError, AppErrorProps } from '@weco/common/views/pages/_app';
+import { getServerData } from '@weco/common/server-data';
+import { isString } from '@weco/common/utils/array';
+import { getConcept } from 'services/catalogue/concepts';
+import CataloguePageLayout from 'components/CataloguePageLayout/CataloguePageLayout';
+import { getWorks } from '../services/catalogue/works';
+
+type Props = {
+  conceptResponse: ConceptType;
+  works: WorkType[];
+};
+
+export const ConceptPage: NextPage<Props> = ({ conceptResponse, works }) => {
+  const conceptsJson = JSON.stringify(conceptResponse);
+  const workJson = JSON.stringify(works);
+
+  return (
+    <CataloguePageLayout
+      title={conceptResponse.label}
+      description={'<TBC>'}
+      url={{ pathname: `/concepts/${conceptResponse.id}`, query: {} }}
+      openGraphType={'website'}
+      siteSection={'collections'}
+      jsonLd={{ '@type': 'WebPage' }}
+      hideNewsletterPromo={true}
+    >
+      <div className="container">
+        <h1>Concepts API response:</h1>
+        <p>{conceptsJson}</p>
+        <h1>Associated works:</h1>
+        <p>{workJson}</p>
+      </div>
+    </CataloguePageLayout>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
+  async context => {
+    const serverData = await getServerData(context);
+    const { id } = context.query;
+
+    // Note: These pages don't need to be behind a toggle, but I'm putting them here
+    // as a way to test the concepts toggle.
+    //
+    // We will want a toggle in place for linking to concepts from works pages.
+    if (!serverData.toggles.conceptsPages) {
+      return { notFound: true };
+    }
+
+    if (!isString(id)) {
+      return { notFound: true };
+    }
+
+    const conceptPromise = getConcept({
+      id,
+      toggles: serverData.toggles,
+    });
+
+    const worksPromise = getWorks({
+      params: { subjects: [id] },
+      toggles: serverData.toggles,
+    });
+
+    const [conceptResponse, worksResponse] = await Promise.all([
+      conceptPromise,
+      worksPromise,
+    ]);
+
+    if (conceptResponse.type === 'Error') {
+      if (conceptResponse.httpStatus === 404) {
+        return { notFound: true };
+      }
+      return appError(
+        context,
+        conceptResponse.httpStatus,
+        conceptResponse.description
+      );
+    }
+
+    const works = worksResponse.type === 'Error' ? [] : worksResponse.results;
+
+    return {
+      props: removeUndefinedProps({
+        conceptResponse,
+        works,
+        serverData,
+      }),
+    };
+  };
+
+export default ConceptPage;

--- a/catalogue/webapp/services/catalogue/concepts.ts
+++ b/catalogue/webapp/services/catalogue/concepts.ts
@@ -1,0 +1,44 @@
+import { CatalogueApiError, Concept } from '@weco/common/model/catalogue';
+import { Toggles } from '@weco/toggles';
+import {
+  catalogueApiError,
+  catalogueFetch,
+  globalApiOptions,
+  looksLikeCanonicalId,
+  notFound,
+  rootUris,
+} from '.';
+
+type GetConceptProps = {
+  id: string;
+  toggles: Toggles;
+};
+
+type ConceptResponse = Concept | CatalogueApiError;
+
+export async function getConcept({
+  id,
+  toggles,
+}: GetConceptProps): Promise<ConceptResponse> {
+  if (!looksLikeCanonicalId(id)) {
+    return notFound();
+  }
+
+  const apiOptions = globalApiOptions(toggles);
+
+  const url = `${rootUris[apiOptions.env]}/v2/concepts/${id}`;
+
+  const res = await catalogueFetch(url, { redirect: 'manual' });
+
+  // TODO: If we ever do redirects in the concepts API, support it here
+
+  if (res.status === 404) {
+    return notFound();
+  }
+
+  try {
+    return await res.json();
+  } catch (e) {
+    return catalogueApiError();
+  }
+}

--- a/common/model/catalogue.ts
+++ b/common/model/catalogue.ts
@@ -116,7 +116,7 @@ type Genre = {
 
 type ConceptType = 'Concept' | 'Period' | 'Place';
 
-type Concept = {
+export type Concept = {
   id?: string;
   identifiers?: Identifier[];
   label: string;

--- a/common/services/catalogue/ts_api.ts
+++ b/common/services/catalogue/ts_api.ts
@@ -50,6 +50,7 @@ export type CatalogueWorksApiProps = {
   'production.dates.to'?: string;
   'genres.label'?: string[];
   'subjects.label'?: string[];
+  subjects?: string[];
   'contributors.agent.label'?: string[];
   languages?: string[];
   _queryType?: string;

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -51,7 +51,7 @@ const toggles = {
       title: 'Concepts pages',
       defaultValue: false,
       description:
-        'View pages for concepts (subjects and people) and links to them from works pages',
+        'View pages for concepts (subjects and people) and link to them from works pages',
     },
   ] as const,
   tests: [] as ABTest[],

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -46,6 +46,13 @@ const toggles = {
       defaultValue: false,
       description: 'Allow users to sign up for an account',
     },
+    {
+      id: 'conceptsPages',
+      title: 'Concepts pages',
+      defaultValue: false,
+      description:
+        'View pages for concepts (subjects and people) and links to them from works pages',
+    },
   ] as const,
   tests: [] as ABTest[],
 };


### PR DESCRIPTION
## Who is this for?

Devs.

## What is it doing for them?

Establishing the bare bones of a page for individual concepts. Right now it just spews JSON onto the page, so nobody can mistake it for something actually designed, and then we can start to finesse it into Gareth's designs.

Mostly this is about the internal mechanics for the front-end app:

* Creating a toggle for concepts
* Talking to the catalogue API
* Creating a basic route for per-concept pages

I got this by copy/pasting the similar code for work pages.

<img width="1121" alt="Screenshot 2022-06-10 at 11 24 19" src="https://user-images.githubusercontent.com/301220/173045901-030aca2b-d846-4fd3-aab9-4e77c7f3dae3.png">
