### PR TITLE
Make sure concepts pages are routed to the catalogue app

### DIFF
--- a/cache/modules/wc_org_cloudfront/distribution.tf
+++ b/cache/modules/wc_org_cloudfront/distribution.tf
@@ -131,6 +131,28 @@ resource "aws_cloudfront_distribution" "wc_org" {
     }
   }
 
+  # Concepts
+  ordered_cache_behavior {
+    path_pattern     = "/concepts*"
+    target_origin_id = local.alb_origin_id
+
+    allowed_methods        = local.stateless_methods
+    cached_methods         = local.stateless_methods
+    viewer_protocol_policy = "redirect-to-https"
+
+    cache_policy_id            = var.cache_policies["weco-apps"]
+    origin_request_policy_id   = var.request_policies["host-query-and-toggles"]
+    response_headers_policy_id = var.response_policies["weco-security"]
+
+    dynamic "lambda_function_association" {
+      for_each = local.lambda_associations
+      content {
+        event_type = lambda_function_association.value.event_type
+        lambda_arn = lambda_function_association.value.lambda_arn
+      }
+    }
+  }
+
   # This is for the data fetching routes used in NextJs's getServerSideProps
   # see: https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering
   ordered_cache_behavior {

--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -7,7 +7,7 @@ locals {
 
   // A more restrictive limit for expensive URLs (eg /works)
   restrictive_rate_limit  = 1000
-  restricted_path_regexes = ["^\\/works$", "^\\/images$"]
+  restricted_path_regexes = ["^\\/works$", "^\\/images$", "^\\/concepts$"]
 }
 
 resource "aws_wafv2_web_acl" "wc_org" {

--- a/catalogue/terraform/stack/main.tf
+++ b/catalogue/terraform/stack/main.tf
@@ -96,6 +96,17 @@ module "images_search_rule" {
   path_patterns = ["/images*"]
 }
 
+module "concepts_search_rule" {
+  source = "../../../infrastructure/modules/alb_listener_rule"
+
+  alb_listener_https_arn = var.alb_listener_https_arn
+  alb_listener_http_arn  = var.alb_listener_http_arn
+  target_group_arn       = local.target_group_arn
+
+  priority      = "204"
+  path_patterns = ["/concepts*"]
+}
+
 # We do this as our server side props for next.js are served over
 # /_next/data/{hash}/{page}.json
 # e.g. https://wellcomecollection.org/_next/data/dl7PfaUnoIXaQk0ol_5M8/works.json?query=things&source=search_form%2Fworks

--- a/catalogue/terraform/stack/main.tf
+++ b/catalogue/terraform/stack/main.tf
@@ -16,6 +16,9 @@ module "catalogue-service-17092020" {
     var.service_egress_security_group_id
   ]
 
+  cpu    = 512
+  memory = 1024
+
   env_vars = {
     PROD_SUBDOMAIN  = var.subdomain
     APM_ENVIRONMENT = var.env_suffix

--- a/catalogue/webapp/app.ts
+++ b/catalogue/webapp/app.ts
@@ -29,11 +29,12 @@ const appPromise = nextApp.prepare().then(async () => {
 
   // Next routing
   route('/works/:id', '/work', router, nextApp);
-  route('/concepts/:id', '/concept', router, nextApp);
   route('/works', '/works', router, nextApp);
   route('/works/:workId/items', '/item', router, nextApp);
   route('/works/:workId/images', '/image', router, nextApp);
   route('/works/:workId/download', '/download', router, nextApp);
+
+  route('/concepts/:id', '/concept', router, nextApp);
 
   router.get('/works/management/healthcheck', async ctx => {
     ctx.status = 200;


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5539

## Who is this for?

People working on concepts.

## What is it doing for them?

Letting them see the shiny new pages.