### PR TITLE
Add space below search tabs

### DIFF
--- a/content/webapp/components/Body/CollectionsStaticContent.tsx
+++ b/content/webapp/components/Body/CollectionsStaticContent.tsx
@@ -2,22 +2,25 @@ import { FunctionComponent, ReactElement } from 'react';
 import Layout12 from '@weco/common/views/components/Layout12/Layout12';
 import SearchTabs from '@weco/common/views/components/SearchTabs/SearchTabs';
 import { emptyWorksProps } from '@weco/common/views/components/WorksLink/WorksLink';
+import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
 
 const CollectionsStaticContent: FunctionComponent = (): ReactElement => {
   const { query, sort, sortOrder } = emptyWorksProps;
   return (
     <>
       <Layout12>
-        <SearchTabs
-          query={query}
-          sort={sort}
-          sortOrder={sortOrder}
-          worksFilters={[]}
-          imagesFilters={[]}
-          shouldShowDescription={false}
-          shouldShowFilters={false}
-          showSortBy={false}
-        />
+        <SpacingSection>
+          <SearchTabs
+            query={query}
+            sort={sort}
+            sortOrder={sortOrder}
+            worksFilters={[]}
+            imagesFilters={[]}
+            shouldShowDescription={false}
+            shouldShowFilters={false}
+            showSortBy={false}
+          />
+        </SpacingSection>
       </Layout12>
     </>
   );


### PR DESCRIPTION
Removing top padding from 'landing-page' rows with white backgrounds has caused the search box on `/collections` to be too close to the rest of the page content. Wrapping the search box in a `SpacingSection` tidies this up.

__Before__
<img width="471" alt="image" src="https://user-images.githubusercontent.com/1394592/173336924-8aff1887-c01b-41de-ae8e-edd3f16938f2.png">


__After__
<img width="622" alt="image" src="https://user-images.githubusercontent.com/1394592/173336582-6772df2c-3100-48c5-ad62-f8401818b6df.png">
