### PR TITLE
Remove the deprecated template provider from the s3_website provider

### DIFF
--- a/assets/terraform/.terraform.lock.hcl
+++ b/assets/terraform/.terraform.lock.hcl
@@ -19,20 +19,3 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:f6c05e20d9a3fba76ca5f47206dde35e5b43b6821c6cbf57186164ce27ba9f15",
   ]
 }
-
-provider "registry.terraform.io/hashicorp/template" {
-  version = "2.2.0"
-  hashes = [
-    "h1:0wlehNaxBX7GJQnPfQwTNvvAf38Jm0Nv7ssKGMaG6Og=",
-    "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
-    "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
-    "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",
-    "zh:0e3a6c8e16f17f19010accd0844187d524580d9fdb0731f675ffcf4afba03d16",
-    "zh:45f2c594b6f2f34ea663704cc72048b212fe7d16fb4cfd959365fa997228a776",
-    "zh:77ea3e5a0446784d77114b5e851c970a3dde1e08fa6de38210b8385d7605d451",
-    "zh:8a154388f3708e3df5a69122a23bdfaf760a523788a5081976b3d5616f7d30ae",
-    "zh:992843002f2db5a11e626b3fc23dc0c87ad3729b3b3cff08e32ffb3df97edbde",
-    "zh:ad906f4cebd3ec5e43d5cd6dc8f4c5c9cc3b33d2243c89c5fc18f97f7277b51d",
-    "zh:c979425ddb256511137ecd093e23283234da0154b7fa8b21c2687182d9aea8b2",
-  ]
-}

--- a/cardigan/terraform/.terraform.lock.hcl
+++ b/cardigan/terraform/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "4.19.0"
+  hashes = [
+    "h1:Q1pATpL2UxF68UEvZ95Ocsf4HzdMuzuWu8SjV/8WR40=",
+    "zh:22820bfa0065f583298015367f8dc015dffa5b19b76dbd78ecf5da8d7d599573",
+    "zh:31a5c5fade4bd30dbc2b15f448cebb9ed527793c607e8687d3b2101bcf2c4471",
+    "zh:37c9e469e51aa835a5542510561397541de08b62fc15292588382932624fcf88",
+    "zh:398bfe1ba7428ef03293c6618067ddd8c0aaae8bbe764177ae951259228af724",
+    "zh:4610f5a93ef956103d719ae73872a52ecd6cb321452c26a879896348bc27eed9",
+    "zh:4a0d570dc5f01f41538b4eb70086a00dfb25c5d00fd27c950ac209d3609486f6",
+    "zh:4fb65ce84801f82a3beb4e2cb72c5d52ca04d4717ed3890b206da346f02d5def",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9bb3919bd6d94fb22025540f0c1db5eceec8927bd71b8fbdcd295609c999065f",
+    "zh:ce2623a13f74677cdb948607e456ce00407c57333b8310d5c9d053fc3defbc78",
+    "zh:e0d57e8784e6ccfa96fdd07ae1ddcc947be242bc11e7a5dd16b520b4204e0d09",
+    "zh:f988b7c37e95a5b3a493a6b9dcc5ed270136f97d5c0effa84a51940f71626c12",
+  ]
+}

--- a/cardigan/terraform/terraform.tf
+++ b/cardigan/terraform/terraform.tf
@@ -9,24 +9,20 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 2.0"
-  region  = "eu-west-1"
+  region = "eu-west-1"
+
   assume_role {
     role_arn = "arn:aws:iam::130871440101:role/experience-developer"
   }
 }
 
 provider "aws" {
-  version = "~> 2.1"
-  region  = "us-east-1"
-  alias   = "us-east-1"
+  region = "us-east-1"
+  alias  = "us-east-1"
+
   assume_role {
     role_arn = "arn:aws:iam::130871440101:role/experience-developer"
   }
-}
-
-provider "template" {
-  version = "~> 2.1"
 }
 
 module "cardigan" {

--- a/dash/terraform/.terraform.lock.hcl
+++ b/dash/terraform/.terraform.lock.hcl
@@ -1,0 +1,10 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "2.70.1"
+  constraints = "~> 2.2"
+  hashes = [
+    "h1:B+Cs8HwWnLn9ymYI/r3B5S10w1+hOD5WmfFxiLHTUIA=",
+  ]
+}

--- a/dash/terraform/terraform.tf
+++ b/dash/terraform/terraform.tf
@@ -11,8 +11,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 2.2"
-  region  = "eu-west-1"
+  region = "eu-west-1"
 
   assume_role {
     role_arn = "arn:aws:iam::130871440101:role/experience-developer"
@@ -20,17 +19,12 @@ provider "aws" {
 }
 
 provider "aws" {
-  version = "~> 2.2"
-  region  = "us-east-1"
-  alias   = "us-east-1"
+  region = "us-east-1"
+  alias  = "us-east-1"
 
   assume_role {
     role_arn = "arn:aws:iam::130871440101:role/experience-developer"
   }
-}
-
-provider "template" {
-  version = "~> 2.0"
 }
 
 module "dash" {

--- a/infrastructure/modules/s3_website/s3.tf
+++ b/infrastructure/modules/s3_website/s3.tf
@@ -1,15 +1,13 @@
-data "template_file" "website_policy" {
-  template = file("${path.module}/s3-website-policy.json")
-
-  vars = {
-    website_uri = var.website_uri
-  }
-}
-
 resource "aws_s3_bucket" "website_bucket" {
   bucket = var.website_uri
   acl    = "public-read"
-  policy = data.template_file.website_policy.rendered
+
+  policy = templatefile(
+    "${path.module}/s3-website-policy.json",
+    {
+      website_uri = var.website_uri
+    }
+  )
 
   website {
     index_document = "index.html"

--- a/static/terraform/.terraform.lock.hcl
+++ b/static/terraform/.terraform.lock.hcl
@@ -1,0 +1,9 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "4.19.0"
+  hashes = [
+    "h1:Q1pATpL2UxF68UEvZ95Ocsf4HzdMuzuWu8SjV/8WR40=",
+  ]
+}

--- a/static/terraform/terraform.tf
+++ b/static/terraform/terraform.tf
@@ -8,22 +8,18 @@ terraform {
   }
 }
 
-provider "template" {
-  version = "~> 2.1"
-}
-
 provider "aws" {
-  version = "~> 2.0"
-  region  = "eu-west-1"
+  region = "eu-west-1"
+
   assume_role {
-    role_arn = "arn:aws:iam::130871440101:role/experience-developer"
+    role_arn = "arn:aws:iam::130871440101:role/experience-admin"
   }
 }
 
 provider "aws" {
-  version = "~> 2.0"
-  region  = "us-east-1"
-  alias   = "us-east-1"
+  region = "us-east-1"
+  alias  = "us-east-1"
+
   assume_role {
     role_arn = "arn:aws:iam::130871440101:role/experience-developer"
   }

--- a/toggles/terraform/.terraform.lock.hcl
+++ b/toggles/terraform/.terraform.lock.hcl
@@ -1,0 +1,9 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "4.19.0"
+  hashes = [
+    "h1:Q1pATpL2UxF68UEvZ95Ocsf4HzdMuzuWu8SjV/8WR40=",
+  ]
+}

--- a/toggles/terraform/terraform.tf
+++ b/toggles/terraform/terraform.tf
@@ -11,22 +11,16 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 2.0"
-  region  = "eu-west-1"
+  region = "eu-west-1"
   assume_role {
     role_arn = "arn:aws:iam::130871440101:role/experience-developer"
   }
 }
 
 provider "aws" {
-  version = "~> 2.1"
-  region  = "us-east-1"
-  alias   = "us-east-1"
+  region = "us-east-1"
+  alias  = "us-east-1"
   assume_role {
     role_arn = "arn:aws:iam::130871440101:role/experience-developer"
   }
-}
-
-provider "template" {
-  version = "~> 2.1"
 }


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5557. These are all no-op changes in Terraform.