### PR TITLE
Small improvements to dev experience with page promo text

### DIFF
--- a/content/webapp/pages/page.tsx
+++ b/content/webapp/pages/page.tsx
@@ -40,7 +40,7 @@ import {
 import { createClient } from '../services/prismic/fetch';
 import { transformPage } from '../services/prismic/transformers/pages';
 import { getCrop } from '@weco/common/model/image';
-import { isPicture, isVideoEmbed } from 'types/body';
+import { isPicture, isVideoEmbed, BodySlice } from '../types/body';
 import { isNotUndefined } from '@weco/common/utils/array';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 
@@ -84,9 +84,11 @@ function isVanityUrl(pageId: string, url: string): boolean {
   return !containsPageId && looksLikeVanityUrl;
 }
 
-function getFeaturedPictureWithTasl(featuredPicture) {
-  const image = (getCrop(featuredPicture.value.image, '16:9') ||
-    featuredPicture.value.image) as any;
+function getFeaturedPictureWithTasl(
+  featuredPicture: BodySlice & { type: 'picture' }
+) {
+  const image =
+    getCrop(featuredPicture.value.image, '16:9') || featuredPicture.value.image;
 
   return (
     <ImageWithTasl

--- a/content/webapp/services/prismic/transformers/pages.ts
+++ b/content/webapp/services/prismic/transformers/pages.ts
@@ -63,8 +63,12 @@ export function transformPage(document: PagePrismicDocument): Page {
   // If somebody puts the description on the image but there's no image, we'll discard
   // that description on the line above, and it won't get rendered on the page.
   //
-  // We should consider whether we really want to be discarding the promo here,
-  // but until then, this warning will at least let us know when it's happening.
+  // The correct fix is probably to move the promo text to the metadata description
+  // in Prismic.  This warning is to help us spot when it's happening.
+  //
+  // (We could also reconsider whether we really want to be discarding the promo
+  // if there's no image, but that's low priority when we're resource constrained.
+  // but until then, this warning will at least let us know when it's happening.)
   if (isUndefined(promo) && isNotUndefined(promoField?.caption)) {
     console.warn(
       `The promo for ${document.id} has a caption but no image; ` +


### PR DESCRIPTION
## Who is this for?

Devs.

## What is it doing for them?

Kate spotted we weren't rendering the description on the Visual Stories page (now fixed): https://wellcome.slack.com/archives/C3N7J05TK/p1655712995336529

The issue is fixable in Prismic so that's what we've done; this should make it slightly easier to spot what's happening if/when the issue recurs. I don't want to open a broader discussion about a small detail of promos right now.