### PR TITLE
update terraform to provide variable to identity frontend

### DIFF
--- a/identity/terraform/locals.tf
+++ b/identity/terraform/locals.tf
@@ -37,6 +37,7 @@ locals {
       SESSION_KEYS        = "identity/${env_name}/account_management_system/session_keys"
       APM_SERVER_URL      = "elasticsearch/logging/apm_server_url"
       APM_SECRET          = "elasticsearch/logging/apm_secret"
+      AUTH0_ACTION_SECRET = "identity/${env_name}/redirect_action_secret"
     }
   } }
 }


### PR DESCRIPTION
## Who is this for?

Initially, David and I so that we can be sure weco frontend identity is using the same secret as the action in identity api. Hopefully, ultimately, this is something for anyone who wants to be able to register. 

## What is it doing for them?

Providing the `process.env` variable we need for decoding the token

## Terraform plan
```
Terraform will perform the following actions:

  # module.identity-prod.module.identity-service-18012021.module.app_container_secrets_permissions.aws_iam_role_policy.allow_read_secrets[0] will be updated in-place
  ~ resource "aws_iam_role_policy" "allow_read_secrets" {
        id     = "identity-18012021-prod_execution_role:terraform-[redacted]"
        name   = "terraform-[redacted]"
      ~ policy = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Resource = [
                          + "arn:aws:ssm:eu-west-1:[redacted]:parameter/aws/reference/secretsmanager/identity/prod/redirect_action_secret",
                            "arn:aws:ssm:eu-west-1:[redacted]:parameter/aws/reference/secretsmanager/identity/prod/account_management_system/session_keys",
                            # (4 unchanged elements hidden)
                        ]
                        # (3 unchanged elements hidden)
                    },
                  ~ {
                      ~ Resource = [
                          + "arn:aws:secretsmanager:eu-west-1:[redacted]:secret:identity/prod/redirect_action_secret*",
                            "arn:aws:secretsmanager:eu-west-1:1[redacted]:secret:identity/prod/account_management_system/session_keys*",
                            # (4 unchanged elements hidden)
                        ]
                        # (3 unchanged elements hidden)
                    },
                ]
                # (1 unchanged element hidden)
            }
        )
        # (1 unchanged attribute hidden)
    }

  # module.identity-prod.module.identity-service-18012021.module.service.aws_ecs_service.service will be updated in-place
  ~ resource "aws_ecs_service" "service" {
        id                                 = "arn:aws:ecs:eu-west-1:[redacted]:service/experience-frontend-prod/identity-18012021-prod"
        name                               = "identity-18012021-prod"
        tags                               = {
            "deployment:env"     = "prod"
            "deployment:service" = "identity_webapp"
        }
      ~ task_definition                    = "arn:aws:ecs:eu-west-1:[redacted]:task-definition/identity-18012021-prod:17" -> (known after apply)
        # (14 unchanged attributes hidden)





        # (5 unchanged blocks hidden)
    }

  # module.identity-prod.module.identity-service-18012021.module.task_definition.aws_ecs_task_definition.task must be replaced
-/+ resource "aws_ecs_task_definition" "task" {
      ~ arn                      = "arn:aws:ecs:eu-west-1:[redacted]:task-definition/identity-18012021-prod:17" -> (known after apply)
      ~ container_definitions    = (sensitive) # forces replacement
      ~ id                       = "identity-18012021-prod" -> (known after apply)
      - ipc_mode                 = "" -> null
      - pid_mode                 = "" -> null
      ~ revision                 = 17 -> (known after apply)
      + skip_destroy             = false
      - tags                     = {} -> null
        # (8 unchanged attributes hidden)
    }

  # module.identity-stage.module.identity-service-18012021.module.app_container_secrets_permissions.aws_iam_role_policy.allow_read_secrets[0] will be updated in-place
  ~ resource "aws_iam_role_policy" "allow_read_secrets" {
        id     = "identity-18012021-stage_execution_role:terraform-[redacted]"
        name   = "terraform-[redacted]"
      ~ policy = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Resource = [
                          + "arn:aws:ssm:eu-west-1:130871440101:parameter/aws/reference/secretsmanager/identity/stage/redirect_action_secret",
                            "arn:aws:ssm:eu-west-1:130871440101:parameter/aws/reference/secretsmanager/identity/stage/account_management_system/session_keys",
                            # (4 unchanged elements hidden)
                        ]
                        # (3 unchanged elements hidden)
                    },
                  ~ {
                      ~ Resource = [
                          + "arn:aws:secretsmanager:eu-west-1:[redacted]:secret:identity/stage/redirect_action_secret*",
                            "arn:aws:secretsmanager:eu-west-1:130871440101:secret:identity/stage/account_management_system/session_keys*",
                            # (4 unchanged elements hidden)
                        ]
                        # (3 unchanged elements hidden)
                    },
                ]
                # (1 unchanged element hidden)
            }
        )
        # (1 unchanged attribute hidden)
    }

  # module.identity-stage.module.identity-service-18012021.module.service.aws_ecs_service.service will be updated in-place
  ~ resource "aws_ecs_service" "service" {
        id                                 = "arn:aws:ecs:eu-west-1:[redacted]:service/experience-frontend-stage/identity-18012021-stage"
        name                               = "identity-18012021-stage"
        tags                               = {
            "deployment:env"     = "stage"
            "deployment:service" = "identity_webapp"
        }
      ~ task_definition                    = "arn:aws:ecs:eu-west-1:[redacted]:task-definition/identity-18012021-stage:11" -> (known after apply)
        # (14 unchanged attributes hidden)





        # (5 unchanged blocks hidden)
    }

  # module.identity-stage.module.identity-service-18012021.module.task_definition.aws_ecs_task_definition.task must be replaced
-/+ resource "aws_ecs_task_definition" "task" {
      ~ arn                      = "arn:aws:ecs:eu-west-1:[redacted]:task-definition/identity-18012021-stage:11" -> (known after apply)
      ~ container_definitions    = (sensitive) # forces replacement
      ~ id                       = "identity-18012021-stage" -> (known after apply)
      - ipc_mode                 = "" -> null
      - pid_mode                 = "" -> null
      ~ revision                 = 11 -> (known after apply)
      + skip_destroy             = false
      - tags                     = {} -> null
        # (8 unchanged attributes hidden)
    }

Plan: 2 to add, 4 to change, 2 to destroy.
```