### PR TITLE
Image quality

### DIFF
--- a/cardigan/stories/components/Cards/Cards.stories.tsx
+++ b/cardigan/stories/components/Cards/Cards.stories.tsx
@@ -25,7 +25,7 @@ compactCard.args = {
   url: 'https://wellcomecollection.org',
   title: 'Wellcome Collection',
   description: singleLineOfText(10, 25),
-  Image: <PrismicImage image={imageProps} />,
+  Image: <PrismicImage image={imageProps} quality="medium" />,
   DateInfo: null,
   Tags: null,
   primaryLabels: primaryLabelList,

--- a/cardigan/stories/components/PageHeader/PageHeader.stories.tsx
+++ b/cardigan/stories/components/PageHeader/PageHeader.stories.tsx
@@ -229,7 +229,9 @@ const bookImage = {
   crops: {},
   sizesQueries: '',
 };
-const EventFeaturedMedia = () => <PrismicImage image={eventImage} />;
+const EventFeaturedMedia = () => (
+  <PrismicImage image={eventImage} quality="medium" />
+);
 
 const Template = args => <PageHeader {...args} />;
 
@@ -301,6 +303,7 @@ book.args = {
         medium: 1 / 2,
         small: 1,
       }}
+      quality="medium"
     />
   ),
 };

--- a/cardigan/stories/components/SeasonsHeader/SeasonsHeader.stories.tsx
+++ b/cardigan/stories/components/SeasonsHeader/SeasonsHeader.stories.tsx
@@ -19,7 +19,7 @@ const headerProps = {
   title: 'What does it mean to be human, now?',
   start: '2021-01-05T00:00:00.000Z',
   end: '2021-01-26T00:00:00.000Z',
-  FeaturedMedia: <PrismicImage image={image} />,
+  FeaturedMedia: <PrismicImage image={image} quality="medium" />,
   standfirst: [
     {
       type: 'paragraph',

--- a/cardigan/stories/components/WobblyBottom/WobblyBottom.stories.tsx
+++ b/cardigan/stories/components/WobblyBottom/WobblyBottom.stories.tsx
@@ -6,7 +6,7 @@ const Template = args => <WobblyBottom {...args} />;
 export const image = Template.bind({});
 image.args = {
   color: 'cream',
-  children: <PrismicImage image={contentImage()} />,
+  children: <PrismicImage image={contentImage()} quality="medium" />,
 };
 
 export const headline = Template.bind({});

--- a/common/views/components/HeightRestrictedPrismicImage/HeightRestrictedPrismicImage.tsx
+++ b/common/views/components/HeightRestrictedPrismicImage/HeightRestrictedPrismicImage.tsx
@@ -2,12 +2,15 @@ import { FC } from 'react';
 import Image from 'next/image';
 import { classNames } from '../../../utils/classnames';
 import { ImageType } from '../../../model/image';
-import { createPrismicLoader } from '../PrismicImage/PrismicImage';
+import {
+  createPrismicLoader,
+  ImageQuality,
+} from '../PrismicImage/PrismicImage';
 
 export type Props = {
   image: ImageType;
   maxWidth?: number;
-  quality?: number;
+  quality: ImageQuality;
 };
 
 function determineSize(viewPortImageDifference): string {
@@ -80,8 +83,7 @@ const HeightRestrictedPrismicImage: FC<Props> = ({
       sizes={`${vSizesString}, calc(100vw - 84px)`}
       src={image.contentUrl}
       alt={image.alt || ''}
-      loader={createPrismicLoader(maxLoaderWidth)}
-      quality={quality}
+      loader={createPrismicLoader(maxLoaderWidth, quality)}
     />
   );
 };

--- a/common/views/components/Iframe/Iframe.tsx
+++ b/common/views/components/Iframe/Iframe.tsx
@@ -137,7 +137,7 @@ class Iframe extends Component<Props, State> {
                 medium: 1,
                 small: 1,
               }}
-              quality={45}
+              quality="medium"
             />
             {this.state.iframeShowing && (
               <Control

--- a/content/webapp/components/ArticleCard/ArticleCard.tsx
+++ b/content/webapp/components/ArticleCard/ArticleCard.tsx
@@ -78,6 +78,7 @@ const ArticleCard: FunctionComponent<Props> = ({
               medium: 1 / 2,
               small: 1,
             }}
+            quality="low"
           />
         )) ||
         undefined

--- a/content/webapp/components/BookImage/BookImage.tsx
+++ b/content/webapp/components/BookImage/BookImage.tsx
@@ -4,6 +4,7 @@ import { classNames } from '@weco/common/utils/classnames';
 import { FunctionComponent, ReactElement } from 'react';
 import PrismicImage, {
   BreakpointSizes,
+  ImageQuality,
 } from '@weco/common/views/components/PrismicImage/PrismicImage';
 import { ImageType } from '@weco/common/model/image';
 
@@ -30,7 +31,7 @@ const BookPromoImage = styled(Space).attrs({
 type Props = {
   image: ImageType;
   sizes: BreakpointSizes;
-  quality?: number;
+  quality: ImageQuality;
 };
 
 const BookImage: FunctionComponent<Props> = ({

--- a/content/webapp/components/BookPromo/BookPromo.tsx
+++ b/content/webapp/components/BookPromo/BookPromo.tsx
@@ -61,6 +61,7 @@ const BookPromo: FunctionComponent<Props> = ({ book }: Props): ReactElement => {
             medium: 1 / 3,
             small: 1,
           }}
+          quality="low"
         />
         <Space
           h={{

--- a/content/webapp/components/CaptionedImage/CaptionedImage.tsx
+++ b/content/webapp/components/CaptionedImage/CaptionedImage.tsx
@@ -68,7 +68,7 @@ const CaptionedImage: FC<UiCaptionedImageProps> = ({
     <CaptionedImageFigure isBody={isBody}>
       <ImageContainerInner aspectRatio={image.width / image.height}>
         <ImageWithTasl
-          Image={<HeightRestrictedPrismicImage image={image} quality={100} />}
+          Image={<HeightRestrictedPrismicImage image={image} quality="high" />}
           tasl={image.tasl}
         />
         <Caption caption={caption} preCaptionNode={preCaptionNode} />

--- a/content/webapp/components/Card/Card.tsx
+++ b/content/webapp/components/Card/Card.tsx
@@ -102,6 +102,7 @@ const Card: FunctionComponent<Props> = ({ item }: Props) => {
               medium: 1 / 2,
               small: 1,
             }}
+            quality="low"
           />
         )}
         {item.format && (

--- a/content/webapp/components/CompactCard/CompactCard.test.tsx
+++ b/content/webapp/components/CompactCard/CompactCard.test.tsx
@@ -19,6 +19,7 @@ describe('CompactCard', () => {
             medium: 1 / 5,
             small: 1 / 4,
           }}
+          quality="low"
         />
       }
       description={mockData.text}

--- a/content/webapp/components/ContentPage/ContentPage.tsx
+++ b/content/webapp/components/ContentPage/ContentPage.tsx
@@ -90,6 +90,7 @@ const ShameWhatWeDoHack = () => (
             medium: 1 / 5,
             small: 1 / 4,
           }}
+          quality="low"
         />
       }
       xOfY={{ x: 1, y: 1 }}

--- a/content/webapp/components/Contributors/Contributor.tsx
+++ b/content/webapp/components/Contributors/Contributor.tsx
@@ -44,13 +44,21 @@ const Contributor: FC<ContributorType> = ({
                   transform: 'rotateZ(6deg) scale(1.2)',
                 }}
               >
-                <PrismicImage image={contributorImage} maxWidth={72} />
+                <PrismicImage
+                  image={contributorImage}
+                  maxWidth={72}
+                  quality="low"
+                />
               </div>
             </div>
           )}
           {contributorImage && contributor.type === 'organisations' && (
             <div style={{ width: '72px' }}>
-              <PrismicImage image={contributorImage} maxWidth={72} />
+              <PrismicImage
+                image={contributorImage}
+                maxWidth={72}
+                quality="low"
+              />
             </div>
           )}
         </Space>

--- a/content/webapp/components/EventCard/EventCard.tsx
+++ b/content/webapp/components/EventCard/EventCard.tsx
@@ -39,6 +39,7 @@ const EventCard: FC<Props> = ({ event: jsonEvent, xOfY }) => {
         medium: 1 / 5,
         small: 1 / 4,
       }}
+      quality="low"
     />
   );
 

--- a/content/webapp/components/EventPromo/EventPromo.tsx
+++ b/content/webapp/components/EventPromo/EventPromo.tsx
@@ -86,6 +86,7 @@ const EventPromo: FC<Props> = ({
               medium: 1 / 2,
               small: 1,
             }}
+            quality="low"
           />
         )}
 

--- a/content/webapp/components/ExhibitionPromo/ExhibitionPromo.tsx
+++ b/content/webapp/components/ExhibitionPromo/ExhibitionPromo.tsx
@@ -54,6 +54,7 @@ const ExhibitionPromo: FC<Props> = ({ exhibition, position = 0 }) => {
               medium: 1 / 2,
               small: 1,
             }}
+            quality="low"
           />
         ) : undefined}
 

--- a/content/webapp/components/FacilityPromo/FacilityPromo.tsx
+++ b/content/webapp/components/FacilityPromo/FacilityPromo.tsx
@@ -42,6 +42,7 @@ const FacilityPromo: FC<FacilityPromoType> = ({
               medium: 1 / 2,
               small: 1,
             }}
+            quality="low"
           />
         </div>
 

--- a/content/webapp/components/FeaturedCard/FeaturedCard.tsx
+++ b/content/webapp/components/FeaturedCard/FeaturedCard.tsx
@@ -294,7 +294,7 @@ const FeaturedCard: FunctionComponent<Props> = ({
                 medium: 1 / 2,
                 small: 1,
               }}
-              quality={45}
+              quality="medium"
             />
           )}
         </FeaturedCardLeft>

--- a/content/webapp/components/MediaObject/MediaObject.tsx
+++ b/content/webapp/components/MediaObject/MediaObject.tsx
@@ -73,6 +73,7 @@ export const MediaObject: FunctionComponent<Props> = ({
         medium: 1 / 10,
         small: 1 / 10,
       }}
+      quality="low"
     />
   );
 

--- a/content/webapp/components/MediaObjectBase/MediaObjectBase.test.tsx
+++ b/content/webapp/components/MediaObjectBase/MediaObjectBase.test.tsx
@@ -68,6 +68,7 @@ describe('MediaObjectBase', () => {
             medium: 1 / 5,
             small: 1 / 4,
           }}
+          quality="low"
         />
       }
       description={mockData.text}
@@ -156,6 +157,7 @@ describe('MediaObjectBase', () => {
                   medium: 1 / 5,
                   small: 1 / 4,
                 }}
+                quality="low"
               />
             }
             ExtraInfo={null}

--- a/content/webapp/components/SearchResults/SearchResults.tsx
+++ b/content/webapp/components/SearchResults/SearchResults.tsx
@@ -78,6 +78,7 @@ const SearchResults: FunctionComponent<Props> = ({
                         medium: 1 / 5,
                         small: 1 / 4,
                       }}
+                      quality="low"
                     />
                   )
                 }
@@ -112,6 +113,7 @@ const SearchResults: FunctionComponent<Props> = ({
                         medium: 1 / 5,
                         small: 1 / 4,
                       }}
+                      quality="low"
                     />
                   )
                 }
@@ -146,6 +148,7 @@ const SearchResults: FunctionComponent<Props> = ({
                         medium: 1 / 5,
                         small: 1 / 4,
                       }}
+                      quality="low"
                     />
                   )
                 }
@@ -187,6 +190,7 @@ const SearchResults: FunctionComponent<Props> = ({
                         medium: 1 / 5,
                         small: 1 / 4,
                       }}
+                      quality="low"
                     />
                   )
                 }
@@ -243,6 +247,7 @@ const SearchResults: FunctionComponent<Props> = ({
                         medium: 1 / 5,
                         small: 1 / 4,
                       }}
+                      quality="low"
                     />
                   )
                 }

--- a/content/webapp/components/StoryPromo/StoryPromo.tsx
+++ b/content/webapp/components/StoryPromo/StoryPromo.tsx
@@ -81,6 +81,7 @@ const StoryPromo: FunctionComponent<Props> = ({
               medium: 1 / 2,
               small: 1,
             }}
+            quality="low"
           />
         )}
 

--- a/content/webapp/components/VenueHours/VenueHours.tsx
+++ b/content/webapp/components/VenueHours/VenueHours.tsx
@@ -124,6 +124,7 @@ const VenueHours: FunctionComponent<Props> = ({ venue, weight }) => {
                   medium: 1 / 2,
                   small: 1,
                 }}
+                quality="low"
               />
             )}
           </VenueHoursImage>

--- a/content/webapp/pages/book.tsx
+++ b/content/webapp/pages/book.tsx
@@ -105,7 +105,7 @@ const BookPage: FunctionComponent<Props> = props => {
         <BookImage
           image={{ ...book.cover }}
           sizes={{ xlarge: 1 / 3, large: 1 / 3, medium: 1 / 3, small: 1 }}
-          quality={45}
+          quality="medium"
         />
       </Layout8>
     </Space>

--- a/content/webapp/pages/page.tsx
+++ b/content/webapp/pages/page.tsx
@@ -99,7 +99,7 @@ function getFeaturedPictureWithTasl(featuredPicture) {
             medium: 1,
             small: 1,
           }}
-          quality={45}
+          quality="medium"
         />
       }
       tasl={image?.tasl}

--- a/content/webapp/pages/season.tsx
+++ b/content/webapp/pages/season.tsx
@@ -94,7 +94,7 @@ const SeasonPage = ({
               medium: 1,
               small: 1,
             }}
-            quality={45}
+            quality="medium"
           />
         ) : undefined
       }

--- a/content/webapp/utils/page-header.tsx
+++ b/content/webapp/utils/page-header.tsx
@@ -42,7 +42,7 @@ export function getFeaturedMedia(
             medium: 1,
             small: 1,
           }}
-          quality={45}
+          quality="medium"
         />
       }
       tasl={widescreenImage.tasl}
@@ -58,7 +58,7 @@ export function getFeaturedMedia(
             medium: 1,
             small: 1,
           }}
-          quality={45}
+          quality="medium"
         />
       }
       tasl={image.tasl}


### PR DESCRIPTION
Fixes #8026

- Makes the quality prop of the PrismicImage components compulsory and one of three named values.
- Uses the low quality for the small promo/card images as it greatly reduces the page weight of listing pages.
- All other image qualities remain as they were previously