### PR TITLE
Add subjects to the front-end image search

### DIFF
--- a/cache/edge_lambdas/src/redirects.ts
+++ b/cache/edge_lambdas/src/redirects.ts
@@ -213,6 +213,7 @@ export const queryRedirects: Record<string, QueryRedirect> = {
       'images.color',
       'locations.license',
       'source.genres.label',
+      'source.subjects.label',
       'source.contributors.agent.label',
       'page',
     ]),

--- a/cache/modules/cloudfront_policies/locals.tf
+++ b/cache/modules/cloudfront_policies/locals.tf
@@ -46,6 +46,7 @@ locals {
     "source",
     "source.contributors.agent.label",
     "source.genres.label",
+    "source.subjects.label",
     "toggle",
   ]
 

--- a/catalogue/webapp/pages/images.tsx
+++ b/catalogue/webapp/pages/images.tsx
@@ -252,6 +252,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     const aggregations = [
       'locations.license',
       'source.genres.label',
+      'source.subjects.label',
       'source.contributors.agent.label',
     ];
     const apiProps = imagesRouteToApiUrl(params, { aggregations });

--- a/common/model/catalogue.ts
+++ b/common/model/catalogue.ts
@@ -312,6 +312,7 @@ export type WorkAggregations = {
 export type ImageAggregations = {
   license?: CatalogueAggregation;
   'source.genres.label'?: CatalogueAggregation;
+  'source.subjects.label'?: CatalogueAggregation;
   'source.contributors.agent.label'?: CatalogueAggregation;
   type: 'Aggregations';
 };

--- a/common/services/catalogue/api.ts
+++ b/common/services/catalogue/api.ts
@@ -46,6 +46,7 @@ export type CatalogueImagesApiProps = {
   page?: number;
   'locations.license'?: string[];
   'source.genres.label'?: string[];
+  'source.subjects.label'?: string[];
   'source.contributors.agent.label'?: string[];
   color?: string;
 };
@@ -79,6 +80,7 @@ export function worksPropsToImagesProps(
     page: worksProps.page,
     'locations.license': undefined,
     'source.genres.label': undefined,
+    'source.subjects.label': undefined,
     'source.contributors.agent.label': undefined,
     color: undefined,
   };

--- a/common/services/catalogue/filters.ts
+++ b/common/services/catalogue/filters.ts
@@ -309,6 +309,25 @@ const sourceGenresFilter = ({
   ),
 });
 
+const sourceSubjectsFilter = ({
+  images,
+  props,
+}: ImagesFilterProps): CheckboxFilter => ({
+  type: 'checkbox',
+  id: 'source.subjects.label',
+  label: 'Subjects',
+  options: filterOptionsWithNonAggregates(
+    images?.aggregations?.['source.subjects.label']?.buckets.map(bucket => ({
+      id: toHtmlId(bucket.data.label),
+      value: quoteVal(bucket.data.label),
+      count: bucket.count,
+      label: bucket.data.label,
+      selected: props['source.subjects.label'].includes(bucket.data.label),
+    })) || [],
+    props['source.subjects.label'].map(quoteVal)
+  ),
+});
+
 const sourceContributorAgentsFilter = ({
   images,
   props,
@@ -337,6 +356,7 @@ const imagesFilters: (props: ImagesFilterProps) => Filter[] = props =>
     colorFilter,
     licensesFilter,
     sourceGenresFilter,
+    sourceSubjectsFilter,
     sourceContributorAgentsFilter,
   ].map(f => f(props));
 

--- a/common/services/catalogue/ts_api.ts
+++ b/common/services/catalogue/ts_api.ts
@@ -7,6 +7,7 @@ export type CatalogueImagesApiProps = {
   page?: number;
   'locations.license'?: string[];
   'source.genres.label'?: string[];
+  'source.subjects.label'?: string[];
   'source.contributors.agent.label'?: string[];
   color?: string;
   aggregations?: string[];
@@ -96,6 +97,8 @@ export function imagesRouteToApiUrl(
     'locations.license': imagesRouteProps['locations.license'],
     'source.genres.label':
       imagesRouteProps['source.genres.label'].map(quoteVal),
+    'source.subjects.label':
+      imagesRouteProps['source.subjects.label'].map(quoteVal),
     'source.contributors.agent.label':
       imagesRouteProps['source.contributors.agent.label'].map(quoteVal),
     ...overrides,
@@ -111,6 +114,7 @@ export function worksPropsToImagesProps(
     page: worksProps.page ?? undefined,
     'locations.license': undefined,
     'source.genres.label': undefined,
+    'source.subjects.label': undefined,
     color: undefined,
   };
 }

--- a/common/views/components/ImagesLink/ImagesLink.tsx
+++ b/common/views/components/ImagesLink/ImagesLink.tsx
@@ -31,6 +31,7 @@ const emptyImagesProps: ImagesProps = {
   page: 1,
   'locations.license': [],
   'source.genres.label': [],
+  'source.subjects.label': [],
   'source.contributors.agent.label': [],
   color: undefined,
 };
@@ -40,6 +41,7 @@ const codecMap = {
   page: numberCodec,
   'locations.license': csvCodec,
   'source.genres.label': quotedCsvCodec,
+  'source.subjects.label': quotedCsvCodec,
   'source.contributors.agent.label': quotedCsvCodec,
   color: maybeStringCodec,
 };

--- a/content/webapp/pages/collections.tsx
+++ b/content/webapp/pages/collections.tsx
@@ -8,8 +8,6 @@ import * as page from './page';
 export const getServerSideProps: GetServerSideProps<
   page.Props | AppErrorProps
 > = async context => {
-  console.log(`collections.getServerSideProps`);
-
   return page.getServerSideProps({
     ...context,
     query: { id: prismicPageIds.collections },


### PR DESCRIPTION
## Who is this for?

Users.

## What is it doing for them?

Allowing them to filter by subjects in the front-end. The filters/aggregations are plumbed into the API and are unlikely to change, so we can add it to the front-end as a useful feature.

It's also part of the (future) onward journey for concepts. If a researcher lands on a concept page and sees a sample of images associated with that subject, they can click through to the images search to see the full list.

For https://github.com/wellcomecollection/platform/issues/5556

<img width="1254" alt="Screenshot 2022-06-21 at 09 40 06" src="https://user-images.githubusercontent.com/301220/174756578-8ea251bf-82fd-4bd3-be6b-880d100b105d.png">


<img width="1254" alt="Screenshot 2022-06-21 at 09 40 15" src="https://user-images.githubusercontent.com/301220/174756527-c31fcd27-1cf9-4133-9015-c0387961afd4.png">

