### PR TITLE
Exhibitions current past

### DIFF
--- a/common/data/microcopy.ts
+++ b/common/data/microcopy.ts
@@ -101,3 +101,6 @@ export const calendarInstructions =
 
 export const requestingDisabled =
   'Requesting is unavailable until 09:00 on Monday 6 June';
+
+export const pastExhibitionsStrapline =
+  'Take a look ar our past exhibitions and installations.';

--- a/content/webapp/components/ExhibitionPromo/ExhibitionPromo.tsx
+++ b/content/webapp/components/ExhibitionPromo/ExhibitionPromo.tsx
@@ -17,7 +17,7 @@ type Props = {
 };
 
 const ExhibitionPromo: FC<Props> = ({ exhibition, position = 0 }) => {
-  const { start, end, statusOverride, isPermanent } = exhibition;
+  const { start, end, statusOverride, isPermanent, hideStatus } = exhibition;
   const url = linkResolver(exhibition);
   const image = exhibition.promo?.image;
 
@@ -90,11 +90,13 @@ const ExhibitionPromo: FC<Props> = ({ exhibition, position = 0 }) => {
             </Space>
           )}
 
-          <StatusIndicator
-            start={start}
-            end={end ?? new Date()}
-            statusOverride={statusOverride}
-          />
+          {!hideStatus && (
+            <StatusIndicator
+              start={start}
+              end={end ?? new Date()}
+              statusOverride={statusOverride}
+            />
+          )}
         </div>
       </CardBody>
     </CardOuter>

--- a/content/webapp/pages/exhibitions.tsx
+++ b/content/webapp/pages/exhibitions.tsx
@@ -82,19 +82,23 @@ const ExhibitionsPage: FC<Props> = props => {
   };
   const firstExhibition = exhibitions[0];
 
-  const currentAndUpcomingExhibitions = {
-    ...exhibitions,
-    results: exhibitions.results.filter(result => {
-      return london(result.end).isSameOrAfter(london());
-    }),
-  };
-
-  const pastExhibitions = {
-    ...exhibitions,
-    results: exhibitions.results.filter(result => {
-      return london(result.end).isBefore(london());
-    }),
-  };
+  const partitionedExhibitionItems = exhibitions.results.reduce(
+    (acc, result) => {
+      if (london(result.end).isSameOrAfter(london())) {
+        acc.currentAndUpcoming.push(result);
+      } else {
+        acc.past.push({
+          ...result,
+          hideStatus: true,
+        });
+      }
+      return acc;
+    },
+    { currentAndUpcoming: [], past: [] } as {
+      currentAndUpcoming: ExhibitionBasic[];
+      past: ExhibitionBasic[];
+    }
+  );
 
   const paginationRoot = `exhibitions${period ? `/${period}` : ''}`;
 
@@ -127,21 +131,21 @@ const ExhibitionsPage: FC<Props> = props => {
         backgroundTexture={headerBackgroundLs}
         highlightHeading={true}
       />
-      {currentAndUpcomingExhibitions.results.length > 0 && (
+      {partitionedExhibitionItems.currentAndUpcoming.length > 0 && (
         <>
           <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
             <SectionHeader title="Current exhibitions" />
           </Space>
           <SpacingSection>
             <CardGrid
-              items={currentAndUpcomingExhibitions.results}
+              items={partitionedExhibitionItems.currentAndUpcoming}
               itemsPerRow={3}
             />
           </SpacingSection>
         </>
       )}
 
-      {pastExhibitions.results.length > 0 && (
+      {partitionedExhibitionItems.past.length > 0 && (
         <>
           {!period && (
             <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
@@ -155,10 +159,7 @@ const ExhibitionsPage: FC<Props> = props => {
           )}
           <SpacingSection>
             <CardGrid
-              items={pastExhibitions.results.map(exhibition => ({
-                ...exhibition,
-                hideStatus: true,
-              }))}
+              items={partitionedExhibitionItems.past}
               itemsHaveTransparentBackground={true}
               itemsPerRow={3}
             />

--- a/content/webapp/pages/exhibitions.tsx
+++ b/content/webapp/pages/exhibitions.tsx
@@ -1,7 +1,6 @@
 import type { GetServerSideProps } from 'next';
 import { FC } from 'react';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
-import LayoutPaginatedResults from '../components/LayoutPaginatedResults/LayoutPaginatedResults';
 import { Period } from '../types/periods';
 import { PaginatedResults } from '@weco/common/services/prismic/types';
 import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
@@ -10,7 +9,10 @@ import { removeUndefinedProps } from '@weco/common/utils/json';
 import { getServerData } from '@weco/common/server-data';
 import { exhibitionLd } from '../services/prismic/transformers/json-ld';
 import { getPage } from '../utils/query-params';
-import { pageDescriptions } from '@weco/common/data/microcopy';
+import {
+  pageDescriptions,
+  pastExhibitionsStrapline,
+} from '@weco/common/data/microcopy';
 import { fetchExhibitions } from '../services/prismic/fetch/exhibitions';
 import {
   fixExhibitionDatesInJson,
@@ -19,6 +21,16 @@ import {
 import { createClient } from '../services/prismic/fetch';
 import { ExhibitionBasic } from '../types/exhibitions';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
+
+import { london } from '@weco/common/utils/format-date';
+import Layout12 from '@weco/common/views/components/Layout12/Layout12';
+import Space from '@weco/common/views/components/styled/Space';
+import CardGrid from '../components/CardGrid/CardGrid';
+import SectionHeader from '@weco/common/views/components/SectionHeader/SectionHeader';
+import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
+import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
+import { headerBackgroundLs } from '@weco/common/utils/backgrounds';
+import Pagination from '@weco/common/views/components/Pagination/Pagination';
 
 type Props = {
   exhibitions: PaginatedResults<ExhibitionBasic>;
@@ -38,6 +50,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     }
 
     const { period } = context.query;
+
     const exhibitionsQuery = await fetchExhibitions(client, {
       page,
       period: period as Period,
@@ -69,6 +82,22 @@ const ExhibitionsPage: FC<Props> = props => {
   };
   const firstExhibition = exhibitions[0];
 
+  const currentAndUpcomingExhibitions = {
+    ...exhibitions,
+    results: exhibitions.results.filter(result => {
+      return london(result.end).isSameOrAfter(london());
+    }),
+  };
+
+  const pastExhibitions = {
+    ...exhibitions,
+    results: exhibitions.results.filter(result => {
+      return london(result.end).isBefore(london());
+    }),
+  };
+
+  const paginationRoot = `exhibitions${period ? `/${period}` : ''}`;
+
   return (
     <PageLayout
       title={title}
@@ -79,21 +108,98 @@ const ExhibitionsPage: FC<Props> = props => {
       siteSection={'whats-on'}
       image={firstExhibition && firstExhibition.image}
     >
-      <SpacingSection>
-        <LayoutPaginatedResults
-          showFreeAdmissionMessage={true}
-          title={title}
-          description={[
-            {
-              type: 'paragraph',
-              text: pageDescriptions.exhibitions,
-              spans: [],
-            },
-          ]}
-          paginatedResults={exhibitions}
-          paginationRoot={`exhibitions${period ? `/${period}` : ''}`}
-        />
-      </SpacingSection>
+      <PageHeader
+        breadcrumbs={{ items: [] }}
+        title={title}
+        ContentTypeInfo={
+          pageDescriptions.exhibitions && (
+            <PrismicHtmlBlock
+              html={[
+                {
+                  type: 'paragraph',
+                  text: pageDescriptions.exhibitions,
+                  spans: [],
+                },
+              ]}
+            />
+          )
+        }
+        backgroundTexture={headerBackgroundLs}
+        highlightHeading={true}
+      />
+      {currentAndUpcomingExhibitions.results.length > 0 && (
+        <>
+          <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
+            <SectionHeader title="Current exhibitions" />
+          </Space>
+          <SpacingSection>
+            <CardGrid
+              items={currentAndUpcomingExhibitions.results}
+              itemsPerRow={3}
+            />
+          </SpacingSection>
+        </>
+      )}
+
+      {pastExhibitions.results.length > 0 && (
+        <>
+          {!period && (
+            <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
+              <SectionHeader title="Past Exhibitions" />
+              <Layout12>
+                <Space v={{ size: 'm', properties: ['margin-top'] }}>
+                  <p className="no-margin">{pastExhibitionsStrapline}</p>
+                </Space>
+              </Layout12>
+            </Space>
+          )}
+          <SpacingSection>
+            <CardGrid
+              items={pastExhibitions.results.map(exhibition => ({
+                ...exhibition,
+                hideStatus: true,
+              }))}
+              itemsHaveTransparentBackground={true}
+              itemsPerRow={3}
+            />
+            {exhibitions.totalPages > 1 && (
+              <Layout12>
+                <div className="text-align-right">
+                  <Pagination
+                    total={exhibitions.totalResults}
+                    currentPage={exhibitions.currentPage}
+                    pageCount={exhibitions.totalPages}
+                    prevPage={
+                      exhibitions.currentPage > 1
+                        ? exhibitions.currentPage - 1
+                        : undefined
+                    }
+                    nextPage={
+                      exhibitions.currentPage < exhibitions.totalPages
+                        ? exhibitions.currentPage + 1
+                        : undefined
+                    }
+                    prevQueryString={
+                      `/${paginationRoot}` +
+                      (period ? `/${period}` : '') +
+                      (exhibitions.currentPage > 1
+                        ? `?page=${exhibitions.currentPage - 1}`
+                        : '')
+                    }
+                    nextQueryString={
+                      `/${paginationRoot}` +
+                      (period ? `/${period}` : '') +
+                      (exhibitions.currentPage < exhibitions.totalPages
+                        ? `?page=${exhibitions.currentPage + 1}`
+                        : '')
+                    }
+                  />
+                </div>
+              </Layout12>
+            )}
+          </SpacingSection>
+        </>
+      )}
     </PageLayout>
   );
 };

--- a/content/webapp/types/exhibitions.ts
+++ b/content/webapp/types/exhibitions.ts
@@ -34,6 +34,7 @@ export type ExhibitionBasic = {
   contributors: Contributor[];
   labels: Label[];
   image?: ImageType;
+  hideStatus?: boolean;
 };
 
 export type Exhibition = GenericContentFields & {


### PR DESCRIPTION
Relates to #8019 and applies the changes discussed with @DominiqueMarshall 

Namely:
- Splitting the exhibitions into 2 distinct groups with headers and a strapline for past exhibitions
- removing the background from past exhibition cards
- removing the 'past' status from past exhibition cards

![screencapture-localhost-3002-exhibitions-2022-06-21-16_59_08](https://user-images.githubusercontent.com/6051896/174849973-bdb38656-25a1-4f62-8301-f3d437a8c037.png)

N.B I'm unable to remove the bold from the page header without affecting all page headers on the site.
