### PR TITLE
Add a very rudimentary "list of concepts" page

### DIFF
--- a/catalogue/webapp/app.ts
+++ b/catalogue/webapp/app.ts
@@ -34,6 +34,7 @@ const appPromise = nextApp.prepare().then(async () => {
   route('/works/:workId/images', '/image', router, nextApp);
   route('/works/:workId/download', '/download', router, nextApp);
 
+  route('/concepts', '/concepts', router, nextApp);
   route('/concepts/:id', '/concept', router, nextApp);
 
   router.get('/works/management/healthcheck', async ctx => {

--- a/catalogue/webapp/pages/concepts.tsx
+++ b/catalogue/webapp/pages/concepts.tsx
@@ -1,0 +1,77 @@
+import { GetServerSideProps, NextPage } from 'next';
+import {
+  Concept as ConceptType,
+  CatalogueResultsList,
+} from '@weco/common/model/catalogue';
+import { removeUndefinedProps } from '@weco/common/utils/json';
+import { appError, AppErrorProps } from '@weco/common/views/pages/_app';
+import { getServerData } from '@weco/common/server-data';
+import { getConcepts } from 'services/catalogue/concepts';
+import CataloguePageLayout from 'components/CataloguePageLayout/CataloguePageLayout';
+
+type Props = {
+  concepts: CatalogueResultsList<ConceptType>;
+};
+
+export const ConceptsPage: NextPage<Props> = ({ concepts }) => {
+  return (
+    <CataloguePageLayout
+      title={'Concepts'}
+      description={'<TBC>'}
+      url={{ pathname: '/concepts' }}
+      openGraphType={'website'}
+      siteSection={'collections'}
+      jsonLd={{ '@type': 'WebPage' }}
+      hideNewsletterPromo={true}
+    >
+      <div className="container">
+        <p>
+          <h1>Concepts</h1>
+        </p>
+        <p>
+          <strong>Prototype note:</strong>
+          This is a mostly random selection of concepts from the prototype
+          concepts API. It's meant to help us find examples of concepts pages.
+        </p>
+        <ul>
+          {concepts.results.map(c => (
+            <li key={c.id}>
+              <a href={`/concepts/${c.id}`}>{c.label}</a>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </CataloguePageLayout>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
+  async context => {
+    const serverData = await getServerData(context);
+
+    // Note: These pages don't need to be behind a toggle, but I'm putting them here
+    // as a way to test the concepts toggle.
+    //
+    // We will want a toggle in place for linking to concepts from works pages.
+    if (!serverData.toggles.conceptsPages) {
+      return { notFound: true };
+    }
+
+    const concepts = await getConcepts({
+      params: {},
+      toggles: serverData.toggles,
+    });
+
+    if (concepts.type === 'Error') {
+      return appError(context, concepts.httpStatus, concepts.description);
+    }
+
+    return {
+      props: removeUndefinedProps({
+        concepts,
+        serverData,
+      }),
+    };
+  };
+
+export default ConceptsPage;


### PR DESCRIPTION
Spun out of #8061.

## Who is this for?

People testing the concepts prototype.

## What is it doing for them?

Giving them a list of concepts to click on.

If you have the `conceptsPages` toggle, this page will give you a mostly random selection of concepts pages to go and look at.

<img width="756" alt="Screenshot 2022-06-22 at 15 36 18" src="https://user-images.githubusercontent.com/301220/175056478-b4f0dd7b-9802-4cc2-aeff-2ca260edbe40.png">