### PR TITLE
Fix a broken link on the homepage

### DIFF
--- a/common/services/prismic/transformers/index.test.ts
+++ b/common/services/prismic/transformers/index.test.ts
@@ -1,4 +1,4 @@
-import { transformTaslFromString } from '.';
+import { transformLink, transformTaslFromString } from '.';
 
 describe('transformTaslFromString', () => {
   it('returns an empty tasl if the input is null', () => {
@@ -20,5 +20,19 @@ describe('transformTaslFromString', () => {
       sourceName: 'Science Museum London',
       title: 'Mandrake root, England, 1501-1700',
     });
+  });
+});
+
+describe('transformLink', () => {
+  it('transforms a document link without data', () => {
+    const result = transformLink({
+      id: 'YoedaBEAACMAXnil',
+      type: 'projects',
+      slug: 'ellen-reid-soundwalk-at-regents-park',
+      link_type: 'Document',
+      isBroken: false,
+    });
+
+    expect(result).toBe('/projects/YoedaBEAACMAXnil');
   });
 });

--- a/common/services/prismic/transformers/index.ts
+++ b/common/services/prismic/transformers/index.ts
@@ -3,7 +3,7 @@ import { licenseTypeArray } from '../../../model/license';
 import { LinkField } from '@prismicio/types';
 import { linkResolver } from '../link-resolver';
 import {
-  isFilledLinkToDocumentWithData,
+  isFilledLinkToDocument,
   isFilledLinkToMediaField,
   isFilledLinkToWebField,
 } from '../types';
@@ -59,7 +59,7 @@ export function transformLink(
   if (link) {
     if (isFilledLinkToWebField(link) || isFilledLinkToMediaField(link)) {
       return link.url;
-    } else if (isFilledLinkToDocumentWithData(link)) {
+    } else if (isFilledLinkToDocument(link)) {
       return linkResolver({ id: link.id, type: link.type });
     }
   }

--- a/common/services/prismic/transformers/index.ts
+++ b/common/services/prismic/transformers/index.ts
@@ -61,6 +61,8 @@ export function transformLink(
       return link.url;
     } else if (isFilledLinkToDocument(link)) {
       return linkResolver({ id: link.id, type: link.type });
+    } else {
+      console.warn(`Unable to construct link for ${JSON.stringify(link)}`);
     }
   }
 }

--- a/common/services/prismic/types/index.ts
+++ b/common/services/prismic/types/index.ts
@@ -42,15 +42,16 @@ export type PaginatedResults<T> = {
 };
 
 // Guards
+export function isFilledLinkToDocument<T, L, D extends DataInterface>(
+  field: RelationField<T, L, D> | undefined
+): field is FilledLinkToDocumentField<T, L, D> {
+  return isNotUndefined(field) && 'id' in field && field.isBroken === false;
+}
+
 export function isFilledLinkToDocumentWithData<T, L, D extends DataInterface>(
   field: RelationField<T, L, D> | undefined
 ): field is FilledLinkToDocumentField<T, L, D> & { data: DataInterface } {
-  return (
-    isNotUndefined(field) &&
-    'id' in field &&
-    field.isBroken === false &&
-    'data' in field
-  );
+  return isFilledLinkToDocument(field) && 'data' in field;
 }
 
 export function isFilledLinkToWebField(


### PR DESCRIPTION
Tracing through the code, the problem is that when we fetch the project, we don't fetch a `data` field on the document.  This causes transformLink() to discard the entire link, and then the card doesn't go anywhere.

I don't think we need to check there's data behind the document here -- we only use the ID and type to create the link, so knowing that the link isn't broken should be sufficient.

(The alternative is updating the fetcher to get the `data` field, but since we'd instantly discard it that seems wasteful.)

## Who is this for?

Danny.

## What is it doing for them?

Making the top homepage card clickable.