### PR TITLE
Hopefully fix e2e tests

### DIFF
--- a/.buildkite/pipeline.e2e-universal.yml
+++ b/.buildkite/pipeline.e2e-universal.yml
@@ -32,6 +32,7 @@ steps:
       - docker-compose#v3.5.0:
           run: e2e
           env:
+            - CI=true
             - PLAYWRIGHT_BASE_URL=$PLAYWRIGHT_BASE_URL
             - USE_STAGE_APIS=$USE_STAGE_APIS
           command: ["yarn", "test"]
@@ -49,6 +50,7 @@ steps:
       - docker-compose#v3.5.0:
           run: e2e
           env:
+            - CI=true
             - PLAYWRIGHT_BASE_URL=$PLAYWRIGHT_BASE_URL
             - USE_STAGE_APIS=$USE_STAGE_APIS
           command: ["yarn", "test:mobile"]

--- a/playwright/.dockerignore
+++ b/playwright/.dockerignore
@@ -1,1 +1,2 @@
 get_playwright_image.sh
+node_modules


### PR DESCRIPTION
Wonder how many commits I've made with this claim now! See the big comment in the PR for context. The exposure of the `CI` environment variable to the container I've added here should mean that test output is more readable in Buildkite, too.

Linking the issue in the comment here for any other adventurers out there https://github.com/microsoft/playwright/issues/12182 