### PR TITLE
Don't flex the card body if it's on a transparent back ground

### DIFF
--- a/content/webapp/components/Card/Card.tsx
+++ b/content/webapp/components/Card/Card.tsx
@@ -63,15 +63,15 @@ export const CardBody = styled(Space).attrs(() => ({
 
   ${props =>
     props.theme.makeSpacePropertyValues('l', ['padding-bottom'], false, {
-      small: 8,
-      medium: 8,
-      large: 8,
+      small: 5,
+      medium: 5,
+      large: 5,
     })}
 
   .card-theme.card-theme--transparent & {
     padding-left: 0;
     padding-right: 0;
-    justify-content: unset;
+    flex: none;
   }
 `;
 

--- a/content/webapp/components/Card/Card.tsx
+++ b/content/webapp/components/Card/Card.tsx
@@ -71,6 +71,12 @@ export const CardBody = styled(Space).attrs(() => ({
   .card-theme.card-theme--transparent & {
     padding-left: 0;
     padding-right: 0;
+    /* CardBodys flex in the column axis by default, which makese them
+    stretch to the height of any others on the same row. We don't want
+    this behaviour when the cards don't have backgrounds because it can
+    make the 'Part of' indicator feel disjointed from the rest of the
+    content. Disabling flex altogether at this level is the most
+    straightforward way to get what we want. */
     flex: none;
   }
 `;


### PR DESCRIPTION
Part of #8083 

When cards have a background colour, having the 'Part of' attached to the bottom looks intentional. But when the cards are transparent, having the 'Part of' as far below the body content as whatever happens to be size of the largest bit of card body content in the row (plus some arbitrary margin) can look strange and disconnected (especially if there's a large disparity in body content lengths).

If the cards are on a transparent background, we put the 'Part of' directly below the body content instead. This affects two areas of the site:

- bottom of the homepage:
<img width="865" alt="image" src="https://user-images.githubusercontent.com/1394592/175325584-8270525e-cfb1-464b-9e53-25531a37cb76.png">

- top of the stories page:
<img width="972" alt="image" src="https://user-images.githubusercontent.com/1394592/175326152-f1a05c6d-ff69-4d98-b408-37af438755b8.png">

