### PR TITLE
Warn when an event's start time is after the end time

### DIFF
--- a/content/webapp/services/prismic/transformers/events.ts
+++ b/content/webapp/services/prismic/transformers/events.ts
@@ -200,6 +200,16 @@ export function transformEvent(
           endDateTime: transformTimestamp(endDateTime),
         };
 
+        if (
+          range.startDateTime &&
+          range.endDateTime &&
+          range.startDateTime > range.endDateTime
+        ) {
+          console.warn(
+            `Start time for event ${document.id} is after the end time; this is probably a bug in Prismic`
+          );
+        }
+
         return isNotUndefined(range.startDateTime) &&
           isNotUndefined(range.endDateTime)
           ? {


### PR DESCRIPTION
## Who is this for?

Content editors/devs.

## What is it doing for them?

Making it easier to spot when event data in Prismic is wrong.