### PR TITLE
render cards for guide type

### DIFF
--- a/content/webapp/components/CardGrid/CardGrid.tsx
+++ b/content/webapp/components/CardGrid/CardGrid.tsx
@@ -68,7 +68,8 @@ const CardGrid: FunctionComponent<Props> = ({
               {item.type === 'books' && <BookPromo book={item} />}
               {(item.type === 'pages' ||
                 item.type === 'series' ||
-                item.type === 'projects') && (
+                item.type === 'projects' ||
+                item.type === 'guides') && (
                 <Card item={convertItemToCardProps(item)} />
               )}
             </div>


### PR DESCRIPTION
While I was catching up with the guides workshop I was looking at the /guides page we already have and noticed the cards weren't displaying.

This fixes that.

Before:
![Screenshot 2022-06-24 at 17 17 37](https://user-images.githubusercontent.com/6051896/175905467-5e20d747-cafc-44fa-af27-3dc07e422d0a.png)

After:
![Screenshot 2022-06-24 at 17 17 48](https://user-images.githubusercontent.com/6051896/175905523-cb0e7930-e21f-425c-9b4e-1cafad30ece4.png)




