### PR TITLE
Call the registration API from the identity web app

### DIFF
--- a/identity/webapp/jest.config.js
+++ b/identity/webapp/jest.config.js
@@ -5,6 +5,7 @@ module.exports = {
       preset: 'ts-jest',
       testEnvironment: 'node',
       testMatch: [
+        '<rootDir>/pages/**/*.test.ts',
         '<rootDir>/src/middleware/**/*.test.ts',
         '<rootDir>/src/routes/**/*.test.ts',
         '<rootDir>/src/utility/**/*.test.ts',

--- a/identity/webapp/pages/api/registration.test.ts
+++ b/identity/webapp/pages/api/registration.test.ts
@@ -1,0 +1,87 @@
+import { getUserIdFromToken } from './registration';
+
+describe('getUserIdFromToken', () => {
+  it('rejects an invalid token', () => {
+    const token = 'this_is.not_a.valid_jwt';
+    const secret = '123';
+
+    expect(() => getUserIdFromToken(token, secret)).toThrow(
+      'Error: Invalid session_token in decode'
+    );
+  });
+
+  it('rejects a token which is a string', () => {
+    // This token was created using https://jwt.io/ with the payload
+    // "\"hello world\"""
+    const token =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ImhlbGxvIHdvcmxkIg.tJ6vz_pS3m2q1sfp1o5VBg0aDLM1-7PMK33SUx7fePQ';
+    const secret = '123';
+
+    expect(() => getUserIdFromToken(token, secret)).toThrow(
+      'Cannot get user ID from a token with a string payload'
+    );
+  });
+
+  it('extracts the user ID from a payload', () => {
+    // This token was created using https://jwt.io/ with the payload
+    //
+    //    {
+    //      "sub": "auth0|p1234567"
+    //    }
+    //
+    const token =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhdXRoMHxwMTIzNDU2NyJ9.3x0oPrTuo4dDe1hOKX_5ARksY26nDtd2P1w7gJm9R2I';
+    const secret = '123';
+
+    expect(getUserIdFromToken(token, secret)).toBe('1234567');
+  });
+
+  it('rejects a payload with a malformed user ID', () => {
+    // This token was created using https://jwt.io/ with the payload
+    //
+    //    {
+    //      "sub": "not a real user ID"
+    //    }
+    //
+    const token =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJub3QgYSByZWFsIHVzZXIgSUQifQ.H5ElnFhsN7gi7dEWejxg31ct6OrSxOAMYQUxMxqVmAc';
+    const secret = '123';
+
+    expect(() => getUserIdFromToken(token, secret)).toThrow(
+      'Cannot get user ID from payload'
+    );
+  });
+
+  it('rejects a payload with a missing user ID', () => {
+    // This token was created using https://jwt.io/ with the payload
+    //
+    //    {
+    //      "sub": null
+    //    }
+    //
+    const token =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOm51bGx9.b9vr1ufzq2J4fhsmtyhSlezJNAIhCL8ZIgVnWV19WBs';
+    const secret = '123';
+
+    expect(() => getUserIdFromToken(token, secret)).toThrow(
+      'Cannot get user ID from payload'
+    );
+  });
+});
+
+jest.mock('next/config', () => () => ({
+  serverRuntimeConfig: {
+    sessionKeys: 'test_test_test',
+    siteBaseUrl: 'http://test.test',
+    identityBasePath: '/account',
+    auth0: {
+      domain: 'test.test',
+      clientID: 'test',
+      clientSecret: 'test',
+    },
+    remoteApi: {
+      host: 'test.test',
+      apiKey: 'test',
+    },
+  },
+}));

--- a/identity/webapp/pages/api/registration.test.ts
+++ b/identity/webapp/pages/api/registration.test.ts
@@ -6,7 +6,7 @@ describe('getUserIdFromToken', () => {
     const secret = '123';
 
     expect(() => getUserIdFromToken(token, secret)).toThrow(
-      'Error: Invalid session_token in decode'
+      'Invalid session_token in decode'
     );
   });
 

--- a/identity/webapp/pages/api/registration.ts
+++ b/identity/webapp/pages/api/registration.ts
@@ -7,10 +7,6 @@ import jwt from 'jsonwebtoken';
 
 const { serverRuntimeConfig: config } = getConfig();
 
-function responseCodeIs(responseCode: number) {
-  return (status: number) => status === responseCode;
-}
-
 // TODO: Stuff this in state somewhere, so we reuse the same instance
 function getMachineToMachineInstance() {
   return authenticatedInstanceFactory(
@@ -24,7 +20,7 @@ function getMachineToMachineInstance() {
           grant_type: 'client_credentials',
         },
         {
-          validateStatus: responseCodeIs(200),
+          validateStatus: (status: number) => status === 200,
         }
       );
 

--- a/identity/webapp/pages/api/registration.ts
+++ b/identity/webapp/pages/api/registration.ts
@@ -81,6 +81,8 @@ export default async (
   const { state, firstName, lastName, termsAndConditions, sessionToken } =
     req.body;
 
+  // TODO: Test we'll fail if you get down here without these things,
+  // because I broke it briefly :see_no_evil:
   if (
     !state ||
     !firstName ||
@@ -89,6 +91,8 @@ export default async (
     !sessionToken
   ) {
     console.error('Missing required fields');
+    res.redirect(302, `/account/error`);
+    return;
   }
 
   const userId = getUserIdFromToken(sessionToken);

--- a/identity/webapp/pages/api/registration.ts
+++ b/identity/webapp/pages/api/registration.ts
@@ -107,18 +107,12 @@ export default async (
   try {
     const axios = await identityApiClient();
 
-    axios
-      .put(`/users/${userId}/registration`, {
-        firstName,
-        lastName,
-      })
-      .then(() => {
-        res.redirect(302, redirectUri);
-      })
-      .catch(error => {
-        console.error(error);
-        res.redirect(302, `/account/error`);
-      });
+    await axios.put(`/users/${userId}/registration`, {
+      firstName,
+      lastName,
+    });
+
+    res.redirect(302, redirectUri);
   } catch (error) {
     console.error(error);
     res.redirect(302, `/account/error`);

--- a/identity/webapp/pages/api/registration.ts
+++ b/identity/webapp/pages/api/registration.ts
@@ -104,7 +104,7 @@ export default async (
         lastName,
       })
       .then(() => {
-        res.redirect(302, `${redirectUri}`);
+        res.redirect(302, redirectUri);
       })
       .catch(error => {
         console.error(error);

--- a/identity/webapp/pages/api/registration.ts
+++ b/identity/webapp/pages/api/registration.ts
@@ -2,52 +2,127 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { decodeToken } from '../../src/utility/jwt-codec';
 import axios from 'axios';
 import getConfig from 'next/config';
+import { authenticatedInstanceFactory } from 'src/utility/auth';
+import jwt from 'jsonwebtoken';
 
 const { serverRuntimeConfig: config } = getConfig();
 
-export default (req: NextApiRequest, res: NextApiResponse): void => {
-  if (req.method === 'POST') {
-    const { state, firstName, lastName, termsAndConditions, sessionToken } =
-      req.body;
+function responseCodeIs(responseCode: number) {
+  return (status: number) => status === responseCode;
+}
 
-    if (
-      !state ||
-      !firstName ||
-      !lastName ||
-      !termsAndConditions ||
-      !sessionToken
-    ) {
-      console.error('Missing required fields');
-      res.redirect(302, `/account/error`);
-    }
+// TODO: Stuff this in state somewhere, so we reuse the same instance
+function getMachineToMachineInstance() {
+  return authenticatedInstanceFactory(
+    async () => {
+      const response = await axios.post(
+        `https://${config.auth0.domain}/oauth/token`,
+        {
+          client_id: config.auth0.clientID,
+          client_secret: config.auth0.clientSecret,
+          audience: config.remoteApi.host,
+          grant_type: 'client_credentials',
+        },
+        {
+          validateStatus: responseCodeIs(200),
+        }
+      );
 
-    try {
-      const decodedToken = decodeToken(sessionToken);
-
-      if (typeof decodedToken !== 'string') {
-        const redirectUri = `${config.auth0.domain}/continue?state=${state}`;
-        const { sub } = decodedToken;
-        const userIdPrefix = /auth0\|p/;
-        const userId = sub.replace(userIdPrefix, '');
-
-        axios
-          .put(`/api/users/${userId}/registration`, {
-            firstName,
-            lastName,
-          })
-          .then(() => {
-            res.redirect(302, `${redirectUri}`);
-          })
-          .catch(error => {
-            console.error(error);
-            res.redirect(302, `/account/error`);
-          });
+      const accessToken = response.data.access_token;
+      const decodedToken = jwt.decode(accessToken);
+      if (
+        decodedToken &&
+        typeof decodedToken === 'object' &&
+        decodedToken.exp
+      ) {
+        return { accessToken, expiresAt: decodedToken.exp };
+      } else {
+        throw new Error("Can't extract expiry claim from token");
       }
-    } catch (error) {
-      console.error(error);
-      res.redirect(302, `/account/error`);
+    },
+    () => ({
+      baseURL: config.remoteApi.host,
+      headers: {
+        'x-api-key': config.remoteApi.apiKey,
+      },
+      timeout: 10 * 1000, // 10 seconds
+    })
+  );
+}
+
+// Guard clause that token is okay, but we don't care about anything more
+// TODO: Proper comment and error messages here
+function getUserIdFromToken(sessionToken: string): string {
+  try {
+    const token = decodeToken(sessionToken);
+
+    if (typeof token === 'string') {
+      throw new Error('BOOM!');
     }
-  } else {
+
+    const { sub } = token;
+    const userIdPrefix = /auth0\|p/;
+    return sub.replace(userIdPrefix, '');
+  } catch (error) {
+    throw new Error(error);
+  }
+}
+
+export default async (
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> => {
+  console.log(`@@AWLC registration.ts 1`);
+  console.log(`@@AWLC registration.ts 2 req.method = ${req.method}`);
+  if (req.method !== 'POST') {
     res.redirect('/account');
+    return;
+  }
+  console.log(`@@AWLC registration.ts 3`);
+
+  const { state, firstName, lastName, termsAndConditions, sessionToken } =
+    req.body;
+  console.log(`@@AWLC registration.ts 4`);
+
+  if (
+    !state ||
+    !firstName ||
+    !lastName ||
+    !termsAndConditions ||
+    !sessionToken
+  ) {
+    console.log(`@@AWLC registration.ts 4a = error!!!`);
+    console.error('Missing required fields');
+    res.redirect(302, `/account/error`);
+  }
+
+  console.log(`@@AWLC registration.ts 5`);
+
+  const userId = getUserIdFromToken(sessionToken);
+
+  console.log(`@@AWLC registration.ts 6`);
+
+  const redirectUri = `${config.auth0.domain}/continue?state=${state}`;
+
+  try {
+    console.log(`@@AWLC registration.ts 7`);
+    const axios = await getMachineToMachineInstance()();
+    console.log(`@@AWLC registration.ts 8`);
+
+    axios
+      .put(`/users/${userId}/registration`, {
+        firstName,
+        lastName,
+      })
+      .then(() => {
+        res.redirect(302, `${redirectUri}`);
+      })
+      .catch(error => {
+        console.error(error);
+        res.redirect(302, `/account/error`);
+      });
+  } catch (error) {
+    console.error(error);
+    res.redirect(302, `/account/error`);
   }
 };

--- a/identity/webapp/pages/api/registration.ts
+++ b/identity/webapp/pages/api/registration.ts
@@ -46,31 +46,27 @@ export function getUserIdFromToken(
   sessionToken: string,
   secret: string
 ): string {
-  try {
-    const token = decodeToken(sessionToken, secret);
+  const token = decodeToken(sessionToken, secret);
 
-    if (typeof token === 'string') {
-      throw new Error('Cannot get user ID from a token with a string payload');
-    }
-
-    const { sub } = token;
-
-    if (typeof sub !== 'string') {
-      throw new Error('Cannot get user ID from payload');
-    }
-
-    // This is possibly over-defensive, but it's hard to imagine when we'd get
-    // a user ID here which didn't start with this prefix -- so if we do, flag
-    // it as an error for further investigation.
-    const userIdPrefix = 'auth0|p';
-    if (!sub.startsWith(userIdPrefix)) {
-      throw new Error('Cannot get user ID from payload');
-    }
-
-    return sub.replace(userIdPrefix, '');
-  } catch (error) {
-    throw new Error(error);
+  if (typeof token === 'string') {
+    throw new Error('Cannot get user ID from a token with a string payload');
   }
+
+  const { sub } = token;
+
+  if (typeof sub !== 'string') {
+    throw new Error('Cannot get user ID from payload');
+  }
+
+  // This is possibly over-defensive, but it's hard to imagine when we'd get
+  // a user ID here which didn't start with this prefix -- so if we do, flag
+  // it as an error for further investigation.
+  const userIdPrefix = 'auth0|p';
+  if (!sub.startsWith(userIdPrefix)) {
+    throw new Error('Cannot get user ID from payload');
+  }
+
+  return sub.replace(userIdPrefix, '');
 }
 
 export default async (

--- a/identity/webapp/pages/api/registration.ts
+++ b/identity/webapp/pages/api/registration.ts
@@ -5,7 +5,7 @@ import getConfig from 'next/config';
 import { authenticatedInstanceFactory } from '../../src/utility/auth';
 import jwt from 'jsonwebtoken';
 
-const config = getConfig().serverRuntimeConfig;
+const { serverRuntimeConfig: config } = getConfig();
 
 const identityApiClient = authenticatedInstanceFactory(
   async () => {

--- a/identity/webapp/pages/api/registration.ts
+++ b/identity/webapp/pages/api/registration.ts
@@ -52,6 +52,7 @@ function getMachineToMachineInstance() {
 
 // Guard clause that token is okay, but we don't care about anything more
 // TODO: Proper comment and error messages here
+// TODO: Test this function
 function getUserIdFromToken(sessionToken: string): string {
   try {
     const token = decodeToken(sessionToken);
@@ -72,17 +73,13 @@ export default async (
   req: NextApiRequest,
   res: NextApiResponse
 ): Promise<void> => {
-  console.log(`@@AWLC registration.ts 1`);
-  console.log(`@@AWLC registration.ts 2 req.method = ${req.method}`);
   if (req.method !== 'POST') {
     res.redirect('/account');
     return;
   }
-  console.log(`@@AWLC registration.ts 3`);
 
   const { state, firstName, lastName, termsAndConditions, sessionToken } =
     req.body;
-  console.log(`@@AWLC registration.ts 4`);
 
   if (
     !state ||
@@ -91,23 +88,15 @@ export default async (
     !termsAndConditions ||
     !sessionToken
   ) {
-    console.log(`@@AWLC registration.ts 4a = error!!!`);
     console.error('Missing required fields');
-    res.redirect(302, `/account/error`);
   }
 
-  console.log(`@@AWLC registration.ts 5`);
-
   const userId = getUserIdFromToken(sessionToken);
-
-  console.log(`@@AWLC registration.ts 6`);
 
   const redirectUri = `${config.auth0.domain}/continue?state=${state}`;
 
   try {
-    console.log(`@@AWLC registration.ts 7`);
     const axios = await getMachineToMachineInstance()();
-    console.log(`@@AWLC registration.ts 8`);
 
     axios
       .put(`/users/${userId}/registration`, {

--- a/identity/webapp/pages/api/registration.ts
+++ b/identity/webapp/pages/api/registration.ts
@@ -2,63 +2,71 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { decodeToken } from '../../src/utility/jwt-codec';
 import axios from 'axios';
 import getConfig from 'next/config';
-import { authenticatedInstanceFactory } from 'src/utility/auth';
+import { authenticatedInstanceFactory } from '../../src/utility/auth';
 import jwt from 'jsonwebtoken';
 
-const { serverRuntimeConfig: config } = getConfig();
+const config = getConfig().serverRuntimeConfig;
 
-// TODO: Stuff this in state somewhere, so we reuse the same instance
-function getMachineToMachineInstance() {
-  return authenticatedInstanceFactory(
-    async () => {
-      const response = await axios.post(
-        `https://${config.auth0.domain}/oauth/token`,
-        {
-          client_id: config.auth0.clientID,
-          client_secret: config.auth0.clientSecret,
-          audience: config.remoteApi.host,
-          grant_type: 'client_credentials',
-        },
-        {
-          validateStatus: (status: number) => status === 200,
-        }
-      );
-
-      const accessToken = response.data.access_token;
-      const decodedToken = jwt.decode(accessToken);
-      if (
-        decodedToken &&
-        typeof decodedToken === 'object' &&
-        decodedToken.exp
-      ) {
-        return { accessToken, expiresAt: decodedToken.exp };
-      } else {
-        throw new Error("Can't extract expiry claim from token");
-      }
-    },
-    () => ({
-      baseURL: config.remoteApi.host,
-      headers: {
-        'x-api-key': config.remoteApi.apiKey,
+const identityApiClient = authenticatedInstanceFactory(
+  async () => {
+    const response = await axios.post(
+      `https://${config.auth0.domain}/oauth/token`,
+      {
+        client_id: config.auth0.clientID,
+        client_secret: config.auth0.clientSecret,
+        audience: config.remoteApi.host,
+        grant_type: 'client_credentials',
       },
-      timeout: 10 * 1000, // 10 seconds
-    })
-  );
-}
+      {
+        validateStatus: (status: number) => status === 200,
+      }
+    );
 
-// Guard clause that token is okay, but we don't care about anything more
-// TODO: Proper comment and error messages here
-// TODO: Test this function
-function getUserIdFromToken(sessionToken: string): string {
+    const accessToken = response.data.access_token;
+    const decodedToken = jwt.decode(accessToken);
+    if (decodedToken && typeof decodedToken === 'object' && decodedToken.exp) {
+      return { accessToken, expiresAt: decodedToken.exp };
+    } else {
+      throw new Error("Can't extract expiry claim from token");
+    }
+  },
+  () => ({
+    baseURL: config.remoteApi.host,
+    headers: {
+      'x-api-key': config.remoteApi.apiKey,
+    },
+    timeout: 10 * 1000, // 10 seconds
+  })
+);
+
+/** Extracts the user ID from a session token, or throws if the user ID
+ * can't be retrieved.
+ */
+export function getUserIdFromToken(
+  sessionToken: string,
+  secret: string
+): string {
   try {
-    const token = decodeToken(sessionToken);
+    const token = decodeToken(sessionToken, secret);
 
     if (typeof token === 'string') {
-      throw new Error('BOOM!');
+      throw new Error('Cannot get user ID from a token with a string payload');
     }
 
     const { sub } = token;
-    const userIdPrefix = /auth0\|p/;
+
+    if (typeof sub !== 'string') {
+      throw new Error('Cannot get user ID from payload');
+    }
+
+    // This is possibly over-defensive, but it's hard to imagine when we'd get
+    // a user ID here which didn't start with this prefix -- so if we do, flag
+    // it as an error for further investigation.
+    const userIdPrefix = 'auth0|p';
+    if (!sub.startsWith(userIdPrefix)) {
+      throw new Error('Cannot get user ID from payload');
+    }
+
     return sub.replace(userIdPrefix, '');
   } catch (error) {
     throw new Error(error);
@@ -91,12 +99,13 @@ export default async (
     return;
   }
 
-  const userId = getUserIdFromToken(sessionToken);
+  const secret = config.auth0.actionSecret;
+  const userId = getUserIdFromToken(sessionToken, secret);
 
-  const redirectUri = `${config.auth0.domain}/continue?state=${state}`;
+  const redirectUri = `https://${config.auth0.domain}/continue?state=${state}`;
 
   try {
-    const axios = await getMachineToMachineInstance()();
+    const axios = await identityApiClient();
 
     axios
       .put(`/users/${userId}/registration`, {

--- a/identity/webapp/pages/registration.tsx
+++ b/identity/webapp/pages/registration.tsx
@@ -30,6 +30,7 @@ import { SimplifiedServerData } from '@weco/common/server-data/types';
 import { RegistrationInputs, decodeToken } from '../src/utility/jwt-codec';
 import { stringFromStringOrStringArray } from '@weco/common/utils/array';
 import RegistrationInformation from '../src/frontend/Registration/RegistrationInformation';
+import getConfig from 'next/config';
 
 type Props = {
   serverData: SimplifiedServerData;
@@ -47,8 +48,10 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     );
     let email = '';
 
+    const config = getConfig();
+
     try {
-      const token = decodeToken(sessionToken);
+      const token = decodeToken(sessionToken, config.auth0.actionSecret);
 
       if (typeof token !== 'string') {
         email = token.email;

--- a/identity/webapp/pages/registration.tsx
+++ b/identity/webapp/pages/registration.tsx
@@ -32,6 +32,8 @@ import { stringFromStringOrStringArray } from '@weco/common/utils/array';
 import RegistrationInformation from '../src/frontend/Registration/RegistrationInformation';
 import getConfig from 'next/config';
 
+const { serverRuntimeConfig: config } = getConfig();
+
 type Props = {
   serverData: SimplifiedServerData;
   sessionToken: string;
@@ -47,8 +49,6 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       context.query.session_token
     );
     let email = '';
-
-    const config = getConfig();
 
     try {
       const token = decodeToken(sessionToken, config.auth0.actionSecret);

--- a/identity/webapp/src/utility/auth.ts
+++ b/identity/webapp/src/utility/auth.ts
@@ -2,7 +2,7 @@
 // token in the default headers.
 //
 // It's copied from a file that does the same thing in the identity repo:
-// https://github.com/wellcomecollection/identity/blob/main/packages/shared/identity-common/src/auth.ts
+// https://github.com/wellcomecollection/identity/blob/5ceab09040b253fb79d7b5399ef31bda9571ad0c/packages/shared/identity-common/src/auth.ts
 
 import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
 
@@ -18,7 +18,7 @@ const tokenExpiryThreshold = 30;
 export const authenticatedInstanceFactory = (
   getToken: () => Promise<Token>,
   getInstanceConfig: () => AxiosRequestConfig = () => ({})
-) => {
+): (() => Promise<AxiosInstance>) => {
   let instance: AxiosInstance | undefined;
   let accessToken: string | undefined;
   let expiresAt = 0;
@@ -34,11 +34,16 @@ export const authenticatedInstanceFactory = (
         throw e;
       }
 
+      // Note: divergence from identity, because we need two headers here
+      // TODO: Comment properly
+      const instanceConfig = getInstanceConfig();
+
       instance = axios.create({
+        ...instanceConfig,
         headers: {
           Authorization: `Bearer ${accessToken}`,
+          ...instanceConfig.headers,
         },
-        ...getInstanceConfig(),
       });
     }
     return instance;

--- a/identity/webapp/src/utility/auth.ts
+++ b/identity/webapp/src/utility/auth.ts
@@ -34,8 +34,16 @@ export const authenticatedInstanceFactory = (
         throw e;
       }
 
-      // Note: divergence from identity, because we need two headers here
-      // TODO: Comment properly
+      // Note: we diverge from the implementation in identity here, because calling
+      // the identity API requires *two* headers:
+      //
+      //    - An Authorization header with an OAuth access token, which gets set
+      //      inside this function.
+      //    - An x-api-key header with a static API key, which gets passed in via
+      //      getInstanceConfig()
+      //
+      // The implementation in the identity repo doesn't expect to get any headers
+      // from getInstanceConfig(), so it blats them.
       const instanceConfig = getInstanceConfig();
 
       instance = axios.create({

--- a/identity/webapp/src/utility/auth.ts
+++ b/identity/webapp/src/utility/auth.ts
@@ -1,7 +1,7 @@
 // This is a utility for getting axios instances with an OAuth access
 // token in the default headers.
 //
-// It's copied from a file that does the same thing in the identity repo:
+// It's based on a file that does the same thing in the identity repo:
 // https://github.com/wellcomecollection/identity/blob/5ceab09040b253fb79d7b5399ef31bda9571ad0c/packages/shared/identity-common/src/auth.ts
 
 import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';

--- a/identity/webapp/src/utility/auth.ts
+++ b/identity/webapp/src/utility/auth.ts
@@ -1,0 +1,46 @@
+// This is a utility for getting axios instances with an OAuth access
+// token in the default headers.
+//
+// It's copied from a file that does the same thing in the identity repo:
+// https://github.com/wellcomecollection/identity/blob/main/packages/shared/identity-common/src/auth.ts
+
+import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
+
+type Token = {
+  accessToken: string;
+  expiresAt: number; // epoch seconds
+};
+
+// This is the leeway between when the token actually expires, and the time
+// before that after which we'll request a new token
+const tokenExpiryThreshold = 30;
+
+export const authenticatedInstanceFactory = (
+  getToken: () => Promise<Token>,
+  getInstanceConfig: () => AxiosRequestConfig = () => ({})
+) => {
+  let instance: AxiosInstance | undefined;
+  let accessToken: string | undefined;
+  let expiresAt = 0;
+
+  return async (): Promise<AxiosInstance> => {
+    const expiryCutoff = Math.ceil(Date.now() / 1000) + tokenExpiryThreshold;
+    const needsRefresh = Boolean(!accessToken || expiresAt <= expiryCutoff);
+    if (needsRefresh || !instance) {
+      try {
+        ({ accessToken, expiresAt } = await getToken());
+      } catch (e) {
+        console.error('Error fetching token', e);
+        throw e;
+      }
+
+      instance = axios.create({
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+        ...getInstanceConfig(),
+      });
+    }
+    return instance;
+  };
+};

--- a/identity/webapp/src/utility/jwt-codec.ts
+++ b/identity/webapp/src/utility/jwt-codec.ts
@@ -1,7 +1,7 @@
 import { JwtPayload, sign, verify } from 'jsonwebtoken';
 import getConfig from 'next/config';
 
-const { serverRuntimeConfig: config } = getConfig();
+const config = getConfig().serverRuntimeConfig;
 
 // we need some jwt encoding to deal with passing data to an auth0 action
 // https://auth0.com/docs/customize/actions/flows-and-triggers/login-flow/redirect-with-actions#pass-data-back-to-auth0
@@ -14,9 +14,12 @@ export type RegistrationInputs = {
 
 // we first need to decode the session token we receive on redirecting from the post-login flow action
 // this token will come from request query when this handler is used in the context of the registration form i.e. req.query.session_token
-export const decodeToken = (token: string): JwtPayload | string => {
+export const decodeToken = (
+  token: string,
+  secret: string
+): JwtPayload | string => {
   try {
-    const decoded = verify(token, config.auth0.actionSecret);
+    const decoded = verify(token, secret);
     return decoded;
   } catch (e) {
     throw new Error('Invalid session_token in decode');


### PR DESCRIPTION
Current status: early draft. This needs some comments and tidy-up and maybe some testing; for now I wanted to get an end-to-end flow working. I can see it hitting the identity API endpoint and returning a known error which should be fixed once https://github.com/wellcomecollection/identity/pull/348/ is deployed, so I think it's close to working.

## Who is this for?

New members!

## What is it doing for them?

Making sure they can complete the sign-up flow.