### PR TITLE
Date picker bug

### DIFF
--- a/catalogue/webapp/components/ItemRequestModal/RequestDialog.tsx
+++ b/catalogue/webapp/components/ItemRequestModal/RequestDialog.tsx
@@ -72,7 +72,7 @@ const RequestDialog: FC<RequestDialogProps> = ({
     event.preventDefault();
 
     const pickUpDateMoment = pickUpDate && moment(pickUpDate, 'DD-MM-YYYY');
-    // NB. We want a moment object that represents tbe selected date
+    // NB. We want a moment object that represents the selected date
     // We previously were previously using a moment with a London timzone here,
     // which could erroneously change the date depending on the timezone the user was in.
 

--- a/catalogue/webapp/components/ItemRequestModal/RequestDialog.tsx
+++ b/catalogue/webapp/components/ItemRequestModal/RequestDialog.tsx
@@ -1,7 +1,6 @@
 import { FC, FormEvent, useState } from 'react';
 import { useAvailableDates } from './useAvailableDates';
 import { isRequestableDate } from '../../utils/dates';
-import { london, londonFromFormat } from '@weco/common/utils/format-date';
 import { trackEvent } from '@weco/common/utils/ga';
 import { allowedRequests } from '@weco/common/values/requests';
 import { classNames, font } from '@weco/common/utils/classnames';
@@ -12,7 +11,7 @@ import ButtonOutlined from '@weco/common/views/components/ButtonOutlined/ButtonO
 import { PhysicalItem, Work } from '@weco/common/model/catalogue';
 import { useToggles } from '@weco/common/server-data/Context';
 import styled from 'styled-components';
-import { Moment } from 'moment';
+import moment, { Moment } from 'moment';
 import { CTAs, CurrentRequests, Header } from './common';
 
 const PickUpDate = styled(Space).attrs({
@@ -72,9 +71,10 @@ const RequestDialog: FC<RequestDialogProps> = ({
   function handleConfirmRequest(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
-    const pickUpDateMoment = pickUpDate
-      ? londonFromFormat(pickUpDate, 'DD-MM-YYYY')
-      : availableDates.nextAvailable || london();
+    const pickUpDateMoment = pickUpDate && moment(pickUpDate, 'DD-MM-YYYY');
+    // NB. We want a moment object that represents tbe selected date
+    // We previously were previously using a moment with a London timzone here,
+    // which could erroneously change the date depending on the timezone the user was in.
 
     if (
       !enablePickUpDate ||

--- a/catalogue/webapp/components/ItemRequestModal/RequestDialog.tsx
+++ b/catalogue/webapp/components/ItemRequestModal/RequestDialog.tsx
@@ -71,7 +71,9 @@ const RequestDialog: FC<RequestDialogProps> = ({
   function handleConfirmRequest(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
-    const pickUpDateMoment = pickUpDate && moment(pickUpDate, 'DD-MM-YYYY');
+    const pickUpDateMoment = pickUpDate
+      ? moment(pickUpDate, 'DD-MM-YYYY')
+      : undefined;
     // NB. We want a moment object that represents the selected date
     // We previously were previously using a moment with a London timzone here,
     // which could erroneously change the date depending on the timezone the user was in.

--- a/catalogue/webapp/components/ItemRequestModal/useAvailableDates.ts
+++ b/catalogue/webapp/components/ItemRequestModal/useAvailableDates.ts
@@ -43,10 +43,7 @@ export const useAvailableDates = (): AvailableDates => {
     })
     .filter(Boolean);
 
-  const nextAvailable = determineNextAvailableDate(
-    london(new Date()),
-    closedDays
-  );
+  const nextAvailable = determineNextAvailableDate(london(), closedDays);
 
   // There should be a minimum of a 2 week window in which to select a date
   const minimumLastAvailable = nextAvailable?.clone().add(13, 'days');

--- a/catalogue/webapp/utils/dates.ts
+++ b/catalogue/webapp/utils/dates.ts
@@ -192,7 +192,6 @@ export function isRequestableDate(params: {
   excludedDays: DayNumber[];
 }): boolean {
   const { date, startDate, endDate, excludedDates, excludedDays } = params;
-
   const isExceptionalClosedDay = excludedDates.some(moment =>
     moment.isSame(date, 'day')
   );
@@ -203,17 +202,13 @@ export function isRequestableDate(params: {
       (!startDate && !endDate) ||
         // both start and end date
         (startDate &&
-          date.startOf('day').isSameOrAfter(startDate.startOf('day')) &&
+          date.isSameOrAfter(startDate, 'day') &&
           endDate &&
-          date.startOf('day').isSameOrBefore(endDate.startOf('day'))) ||
+          date.isSameOrBefore(endDate, 'day')) ||
         // only start date
-        (startDate &&
-          !endDate &&
-          date.startOf('day').isSameOrAfter(startDate.startOf('day'))) ||
+        (startDate && !endDate && date.isSameOrAfter(startDate, 'day')) ||
         // only end date
-        (endDate &&
-          !startDate &&
-          date.startOf('day').isSameOrBefore(endDate.startOf('day')))
+        (endDate && !startDate && date.isSameOrBefore(endDate, 'day'))
     ) && // both start and end date
     !isExceptionalClosedDay &&
     !isRegularClosedDay

--- a/common/utils/format-date.ts
+++ b/common/utils/format-date.ts
@@ -10,10 +10,6 @@ export function london(d?: DateTypes): Moment {
   return moment.tz(d, 'Europe/London');
 }
 
-export function londonFromFormat(d: DateTypes, format: string): Moment {
-  return moment(d, format).tz('Europe/London');
-}
-
 export function formatDay(date: Date | Moment): string {
   return london(date).format('dddd');
 }


### PR DESCRIPTION
Fixes #8095

There were a couple of things happening here:

- we were using the selected pick up date to create a Moment with a London timezone. This was problematic because if the user was in a different timezone it could erroneously change the date.
- the function to determine if the selected date was a valid date to choose was taking timezones into account, when it shouldn't have, it just needs to compare the day, which it now does.