### PR TITLE
Redact all query parameters from the identity app in logs

### DIFF
--- a/identity/webapp/src/app.ts
+++ b/identity/webapp/src/app.ts
@@ -10,6 +10,7 @@ import Router from '@koa/router';
 import next from 'next';
 import { apmErrorMiddleware } from '@weco/common/services/apm/errorMiddleware';
 import { init as initServerData } from '@weco/common/server-data';
+import { format as formatUrl, parse } from 'url'; // eslint-disable-line node/no-deprecated-api
 
 /* eslint-enable @typescript-eslint/no-var-requires, import/first */
 
@@ -28,7 +29,74 @@ export async function createApp(): Promise<Koa> {
   app.use(apmErrorMiddleware);
 
   app.use(json({ pretty: process.env.NODE_ENV !== 'production' }));
-  app.use(logger());
+
+  // This custom logger query parameter values from the logs.
+  //
+  // This is to prevent PII from being written to the logs, in particular
+  // email addresses and other personal information being passed around
+  // as JWTs as part of the sign-up process.
+  //
+  // The default logger might log something like:
+  //
+  //      --> GET /account/registration?session_token=eyJhbGciOi...{some sort of jwt}
+  //
+  // where the JWT could be decoded to reveal personal information including
+  // email address and IP address.
+  //
+  // This logger will replace this with:
+  //
+  //      --> GET /account/registration?session_token=[redacted]
+  //
+  // It is deliberately un-picky about what it redacts, because we're rather
+  // remove something innocent (e.g. ?refresh=true) than miss something sensitive.
+  //
+  // The goal is to keep PII about library users out of the logging cluster.
+  //
+  // See:
+  //
+  //    * Documentation for custom transporters
+  //      https://github.com/koajs/logger#use-custom-transporter
+  //    * Slack discussion about access tokens in logs
+  //      https://wellcome.slack.com/archives/CUA669WHH/p1656593455081159
+  //
+  app.use(
+    logger({
+      transporter: (_, args) => {
+        const [format, method, url, status, time, length] = args;
+
+        const parsedUrl = parse(url);
+        const params = new URLSearchParams(parsedUrl.query);
+
+        for (const key of params.keys()) {
+          params.set(key, '[redacted]');
+        }
+
+        parsedUrl.query = params.toString();
+        parsedUrl.search = `?${params.toString()}`;
+
+        // When the square brackets get URL-encoded, they're replaced with
+        // percent characters, e.g. `/account?token=%5Bredacted%5D`.
+        //
+        // Because they aren't actually URL characters, we put back the
+        // original brackets for ease of readability.
+        const redactedUrl = formatUrl(parsedUrl).replace(
+          '%5Bredacted%5D',
+          '[redacted]'
+        );
+
+        const newArgs = [
+          format,
+          method,
+          redactedUrl,
+          status,
+          time,
+          length,
+        ].filter(Boolean);
+
+        console.log(...newArgs);
+      },
+    })
+  );
 
   const router = new Router();
   router.all('(.*)', async ctx => {

--- a/identity/webapp/src/app.ts
+++ b/identity/webapp/src/app.ts
@@ -47,7 +47,7 @@ export async function createApp(): Promise<Koa> {
   //
   //      --> GET /account/registration?session_token=[redacted]
   //
-  // It is deliberately un-picky about what it redacts, because we're rather
+  // It is deliberately un-picky about what it redacts, because we'd rather
   // remove something innocent (e.g. ?refresh=true) than miss something sensitive.
   //
   // The goal is to keep PII about library users out of the logging cluster.

--- a/identity/webapp/src/app.ts
+++ b/identity/webapp/src/app.ts
@@ -64,6 +64,11 @@ export async function createApp(): Promise<Koa> {
       transporter: (_, args) => {
         const [format, method, url, status, time, length] = args;
 
+        // Note: we use a deprecated API here because we're working with
+        // relative URLs, e.g. `/account`.
+        //
+        // The WHATWG URL API that the deprecation message suggests doesn't
+        // work for this use case; it wants absolute URLs.
         const parsedUrl = parse(url);
         const params = new URLSearchParams(parsedUrl.query);
 


### PR DESCRIPTION
## Who is this for?

Us.

## What is it doing for them?

Making sure we don't log PII about library users into the Kibana logging cluster.

This is an issue for registration, where information about users is being passed around in JWTs that can easily be decoded to reveal email addresses and IP addresses, possibly more. You can see an example of one such log in Slack here: https://wellcome.slack.com/archives/CUA669WHH/p1656593517407499?thread_ts=1656593455.081159&cid=CUA669WHH

As the comment explains, this new logger will redact all query parameters in logs, so we won't routinely be logging sensitive tokens to Kibana.