### PR TITLE
Log out the user post-registration; kick them to a success page

### DIFF
--- a/identity/webapp/pages/index.tsx
+++ b/identity/webapp/pages/index.tsx
@@ -6,7 +6,7 @@ import React, {
 } from 'react';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import { GetServerSideProps, NextPage } from 'next';
-import { withPageAuthRequiredSSR } from '../src/utility/auth0';
+import auth0, { withPageAuthRequiredSSR } from '../src/utility/auth0';
 import { ChangeDetailsModal } from '../src/frontend/MyAccount/ChangeDetailsModal';
 import { PageWrapper } from '../src/frontend/components/PageWrapper';
 import {
@@ -54,6 +54,7 @@ import {
 import { Claims } from '@auth0/nextjs-auth0';
 import { useToggles } from '@weco/common/server-data/Context';
 import { sierraStatusCodeToLabel } from '@weco/common/data/microcopy';
+import { URLSearchParams } from 'url';
 
 type DetailProps = {
   label: string;
@@ -140,6 +141,49 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   withPageAuthRequiredSSR({
     getServerSideProps: async context => {
       const serverData = await getServerData(context);
+
+      // When a user goes through the registration flow, we create a user
+      // with a placeholder name and *then* update their name in Sierra.
+      //
+      // This causes an issue if they go from the registration flow directly
+      // to their account page:
+      //
+      //    - We can't update their name directly with the Auth0 management
+      //      API, because it's synced from Sierra.
+      //    - Auth0 syncs data from Sierra whenever the user authenticates,
+      //      i.e. logs in [2], and despite trying I haven't found an easy way
+      //      to get Auth0 to re-sync without a login.
+      //
+      // So to get something working for sign-up, we assume that anybody who
+      // signs in with the placeholder surname has just signed up, and we log
+      // them out and redirect to the /success page.
+      //
+      // When they log back in, Auth0 will re-sync their data and pick up their
+      // updated name.
+      //
+      // This is less than ideal, but it gets _something_ working, and we can
+      // revisit re-syncing user data without a login later.
+      //
+      // [1]: https://wellcome.slack.com/archives/CUA669WHH/p1656325929053499?thread_ts=1656322401.443269&cid=CUA669WHH
+      // [2]: https://auth0.com/docs/manage-users/user-accounts/user-profiles#caching-user-profiles
+      //
+      const session = auth0.getSession(context.req, context.res);
+
+      if (session.user.family_name === 'Auth0_Registration_tempLastName') {
+        const successParams = new URLSearchParams();
+        successParams.append('email', session.user.email);
+
+        const params = new URLSearchParams();
+        params.append('returnTo', `/success?${successParams}`);
+
+        return {
+          redirect: {
+            destination: `/api/auth/logout?${params}`,
+            permanent: false,
+          },
+        };
+      }
+
       return {
         props: removeUndefinedProps({
           serverData,
@@ -169,6 +213,7 @@ const AccountPage: NextPage<Props> = ({ user: auth0UserClaims }) => {
     auth0UserProfileToUserInfo(auth0UserClaims as Auth0UserProfile);
 
   const router = useRouter();
+
   const logoutOnDeletionRequest = () => {
     router.replace(
       `/api/auth/logout?returnTo=${encodeURIComponent('/delete-requested')}`


### PR DESCRIPTION
The comment on the index page explains how this works; I haven't found a good way to refresh the user metadata in Auth0 without a log-in, and at this point I'd rather get _something_ working than keep plugging away at what's a relatively small part of the process.

The copy on the success page will need reviewing properly, but I think this is good enough to prove the concept.

(I haven't been able to test this because going through the login page on staging kicks you to `www-stage.wc.org`, so this will need to be tested in staging – but I think it looks plausible.)