### PR TITLE
Rename the genres filter on the image search

### DIFF
--- a/common/services/catalogue/filters.ts
+++ b/common/services/catalogue/filters.ts
@@ -296,7 +296,7 @@ const sourceGenresFilter = ({
 }: ImagesFilterProps): CheckboxFilter => ({
   type: 'checkbox',
   id: 'source.genres.label',
-  label: 'Genres',
+  label: 'Types/Techniques',
   options: filterOptionsWithNonAggregates(
     images?.aggregations?.['source.genres.label']?.buckets.map(bucket => ({
       id: toHtmlId(bucket.data.label),


### PR DESCRIPTION
This makes the label consistent with how data is shown on pages.

Closes https://github.com/wellcomecollection/wellcomecollection.org/issues/8097

<img width="784" alt="Screenshot 2022-07-01 at 13 23 52" src="https://user-images.githubusercontent.com/301220/176893826-b8fd8122-220e-4382-847c-b41286386b1b.png">

