### PR TITLE
Add an 'id' attribute to <h3> links

### DIFF
--- a/content/webapp/components/HTMLSerializers/HTMLSerializers.tsx
+++ b/content/webapp/components/HTMLSerializers/HTMLSerializers.tsx
@@ -22,7 +22,11 @@ export const defaultSerializer: JSXFunctionSerializer = (
         </h2>
       );
     case RichTextNodeType.heading3:
-      return <h3 key={key}>{children}</h3>;
+      return (
+        <h3 key={key} id={dasherize(element.text)}>
+          {children}
+        </h3>
+      );
     case RichTextNodeType.heading4:
       return <h4 key={key}>{children}</h4>;
     case RichTextNodeType.heading5:


### PR DESCRIPTION
Among other things, this will let us link directly to specific policies on https://wellcomecollection.org/pages/Wvmu3yAAAIUQ4C7F

## Who is this for?

People working on membership.

## What is it doing for them?

Giving them a way to link directly to the Library T&Cs on that page.