### PR TITLE
Use the name of the colour in the colour filter label

### DIFF
--- a/common/services/catalogue/filters.ts
+++ b/common/services/catalogue/filters.ts
@@ -1,8 +1,10 @@
+import { palette } from '../../views/components/PaletteColorPicker/PaletteColorPicker';
 import { CatalogueResultsList, Work, Image } from '../../model/catalogue';
 import { quoteVal } from '../../utils/csv';
 import { toHtmlId } from '../../utils/string';
 import { ImagesProps } from '../../views/components/ImagesLink/ImagesLink';
 import { WorksProps } from '../../views/components/WorksLink/WorksLink';
+import { isNotUndefined } from '../../utils/array';
 
 export type DateRangeFilter = {
   type: 'dateRange';
@@ -246,12 +248,33 @@ const availabilitiesFilter = ({
   ),
 });
 
-const colorFilter = ({ props }: ImagesFilterProps): ColorFilter => ({
-  type: 'color',
-  id: 'color',
-  label: 'Colours',
-  color: props.color,
-});
+const colorFilter = ({ props }: ImagesFilterProps): ColorFilter => {
+  // In the color filter UI, users can:
+  //
+  //    - pick a named, pre-selected color (e.g. green, violet, red)
+  //    - select an arbitrary color using a hue slider
+  //
+  // We want to make sure the filter is labelled to match what they
+  // selected in the UI, so we:
+  //
+  //    - use our name if it's one of the pre-selected colors
+  //    - use the hex string from the hue slider UI if it's an arbitrary color
+  //
+  // Note that the filter popover uses uppercase hex strings (e.g. #2E2EE6),
+  // so we make sure the label matches.
+  const paletteColor = palette.find(({ hexValue }) => hexValue === props.color);
+
+  const label = isNotUndefined(paletteColor)
+    ? paletteColor.colorName
+    : `#${props.color?.toUpperCase()}`;
+
+  return {
+    type: 'color',
+    id: 'color',
+    label,
+    color: props.color,
+  };
+};
 
 // We want to customise the license labels for our UI as the API
 // ones are, whilst correct, very verbose

--- a/common/views/components/PaletteColorPicker/PaletteColorPicker.tsx
+++ b/common/views/components/PaletteColorPicker/PaletteColorPicker.tsx
@@ -18,43 +18,43 @@ type ColorSwatch = {
 export const palette: ColorSwatch[] = [
   {
     hexValue: 'e02020',
-    colorName: 'red',
+    colorName: 'Red',
   },
   {
     hexValue: 'ff47d1',
-    colorName: 'pink',
+    colorName: 'Pink',
   },
   {
     hexValue: 'fa6400',
-    colorName: 'orange',
+    colorName: 'Orange',
   },
   {
     hexValue: 'f7b500',
-    colorName: 'yellow',
+    colorName: 'Yellow',
   },
   {
     hexValue: '8b572a',
-    colorName: 'brown',
+    colorName: 'Brown',
   },
   {
     hexValue: '6dd400',
-    colorName: 'green',
+    colorName: 'Green',
   },
   {
     hexValue: '22bbff',
-    colorName: 'blue',
+    colorName: 'Blue',
   },
   {
     hexValue: '8339e8',
-    colorName: 'violet',
+    colorName: 'Violet',
   },
   {
     hexValue: '000000',
-    colorName: 'black',
+    colorName: 'Black',
   },
   {
     hexValue: 'd9d3d3',
-    colorName: 'grey',
+    colorName: 'Grey',
   },
 ];
 

--- a/common/views/components/PaletteColorPicker/PaletteColorPicker.tsx
+++ b/common/views/components/PaletteColorPicker/PaletteColorPicker.tsx
@@ -12,7 +12,7 @@ type Props = {
 
 type ColorSwatch = {
   hexValue: string;
-  colorName: string | null;
+  colorName: string;
 };
 
 export const palette: ColorSwatch[] = [


### PR DESCRIPTION
Previously, if a user selected a colour filter in the UI, it would be labelled as simply "Colour", which is completely unhelpful for colour-blind users.  Now, we show either the name from our pre-selected palette or the hex code of the colour they picked.

This is the picker UI it's meant to match:

<img width="337" alt="Screenshot 2022-07-04 at 07 37 05" src="https://user-images.githubusercontent.com/301220/177095813-0d11b5b7-1271-4cd5-a84f-58ecadcb1a5f.png">

## Before

<img width="428" alt="Screenshot 2022-07-04 at 07 36 34" src="https://user-images.githubusercontent.com/301220/177095736-631a9fda-ab57-4587-8508-1e5e24d413ab.png">

## After

<img width="444" alt="Screenshot 2022-07-04 at 07 33 01" src="https://user-images.githubusercontent.com/301220/177095786-ffea6be7-e9cf-463d-90fd-4a5a7e2ece1d.png">

<img width="415" alt="Screenshot 2022-07-04 at 07 32 39" src="https://user-images.githubusercontent.com/301220/177095785-be991cd9-e96c-4943-8c93-2fb719ff7966.png">


