### PR TITLE
Redact PII in nginx logs from the identity web app

### DIFF
--- a/identity/terraform/.terraform.lock.hcl
+++ b/identity/terraform/.terraform.lock.hcl
@@ -2,34 +2,39 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "3.52.0"
+  version = "4.21.0"
   hashes = [
-    "h1:Fy/potyWfS8NVumHqWi6STgaQUX66diUmgZDfFNBeXU=",
+    "h1:laCXW8oQgDRQ4jzYQ9rUToNW0wPZS6FzeYuX6dGQa9Y=",
+    "zh:16529a8ac663845da9214a75f5a32a2d0daf393612e46259b6dff10f1b8b50ed",
+    "zh:1ae36386d4862a489a3981a482a537c16f8a1588a445b60f173d1f13fcc3552e",
+    "zh:5ab0f63784f7216528855272b341d3cbfbf378dc6ee23796debead505aff58a2",
+    "zh:5f28fec15d2e58623b0cdb610e36703b3035fb3a61289c6d8a4705fca5144cb8",
+    "zh:60b664b6d34b27609b3b4273dffa41ff2c6d15bb01e326bcd6a40944f9cc9839",
+    "zh:6a9010783b1c4574956e047d9981e96f8d4bbdd7057496ad35bb81acc0efa862",
+    "zh:8631ceb0187605305e2045f1f6aded046ba17e0cad64663011dd55c8a20330ec",
+    "zh:891ac1b0053c435b939462b1872ab383e72a8de05454164def2b96a362f7a729",
+    "zh:92bccfd7517abeda2ac6ddb78f1819742cafdba87af2074929d57cd7f2256c22",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ad169953f8b9441624064815bd4b82b12ab20ba3e2f033ecf019d6a25ae42175",
+    "zh:b46eccb3bec96ace8863cd0302de475dd22e4bdd2176ddb82e76f998424e7ac3",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/random" {
-  version = "3.1.0"
+  version = "3.3.2"
   hashes = [
-    "h1:rKYu5ZUbXwrLG1w81k7H3nce/Ys6yAxXhWcbtk36HjY=",
-    "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
-    "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",
-    "zh:4f251b0eda5bb5e3dc26ea4400dba200018213654b69b4a5f96abee815b4f5ff",
-    "zh:7011332745ea061e517fe1319bd6c75054a314155cb2c1199a5b01fe1889a7e2",
-    "zh:738ed82858317ccc246691c8b85995bc125ac3b4143043219bd0437adc56c992",
-    "zh:7dbe52fac7bb21227acd7529b487511c91f4107db9cc4414f50d04ffc3cab427",
-    "zh:a3a9251fb15f93e4cfc1789800fc2d7414bbc18944ad4c5c98f466e6477c42bc",
-    "zh:a543ec1a3a8c20635cf374110bd2f87c07374cf2c50617eee2c669b3ceeeaa9f",
-    "zh:d9ab41d556a48bd7059f0810cf020500635bfc696c9fc3adab5ea8915c1d886b",
-    "zh:d9e13427a7d011dbd654e591b0337e6074eef8c3b9bb11b2e39eaaf257044fd7",
-    "zh:f7605bd1437752114baf601bdf6931debe6dc6bfe3006eb7e9bb9080931dca8a",
-  ]
-}
-
-provider "registry.terraform.io/hashicorp/template" {
-  version     = "2.2.0"
-  constraints = "~> 2.1"
-  hashes = [
-    "h1:0wlehNaxBX7GJQnPfQwTNvvAf38Jm0Nv7ssKGMaG6Og=",
+    "h1:Fu0IKMy46WsO5Y6KfuH9IFkkuxZjE/gIcgtB7GWkTtc=",
+    "zh:038293aebfede983e45ee55c328e3fde82ae2e5719c9bd233c324cfacc437f9c",
+    "zh:07eaeab03a723d83ac1cc218f3a59fceb7bbf301b38e89a26807d1c93c81cef8",
+    "zh:427611a4ce9d856b1c73bea986d841a969e4c2799c8ac7c18798d0cc42b78d32",
+    "zh:49718d2da653c06a70ba81fd055e2b99dfd52dcb86820a6aeea620df22cd3b30",
+    "zh:5574828d90b19ab762604c6306337e6cd430e65868e13ef6ddb4e25ddb9ad4c0",
+    "zh:7222e16f7833199dabf1bc5401c56d708ec052b2a5870988bc89ff85b68a5388",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:b1b2d7d934784d2aee98b0f8f07a8ccfc0410de63493ae2bf2222c165becf938",
+    "zh:b8f85b6a20bd264fcd0814866f415f0a368d1123cd7879c8ebbf905d370babc8",
+    "zh:c3813133acc02bbebddf046d9942e8ba5c35fc99191e3eb057957dafc2929912",
+    "zh:e7a41dbc919d1de800689a81c240c27eec6b9395564630764ebb323ea82ac8a9",
+    "zh:ee6d23208449a8eaa6c4f203e33f5176fa795b4b9ecf32903dffe6e2574732c2",
   ]
 }

--- a/identity/terraform/stack/main.tf
+++ b/identity/terraform/stack/main.tf
@@ -23,6 +23,14 @@ module "identity-service-18012021" {
 
   secret_env_vars = merge({}, var.secret_env_vars)
 
+  # We have a custom nginx container that redacts the values of
+  # sensitive query parameters, e.g. email, to avoid leaking PII
+  # into the shared logging cluster.
+  nginx_container_config = {
+    image_name    = "uk.ac.wellcome/nginx_frontend_identity"
+    container_tag = "39d58d9252e68c954e85323f3ac07eb3c0f580e8"
+  }
+
   vpc_id  = local.vpc_id
   subnets = local.private_subnets
 

--- a/infrastructure/modules/service/main.tf
+++ b/infrastructure/modules/service/main.tf
@@ -39,9 +39,8 @@ module "nginx_container" {
   forward_port      = var.container_port
   log_configuration = module.log_router_container.container_log_configuration
 
-  // This has an increased max request body size, and increased proxy buffer sizes
-  container_tag = "9b95057b716a60f9891f77111b0bd524b85839aa"
-  image_name    = "uk.ac.wellcome/nginx_frontend"
+  container_tag = var.nginx_container_config["container_tag"]
+  image_name    = var.nginx_container_config["image_name"]
 }
 
 module "app_container" {

--- a/infrastructure/modules/service/variables.tf
+++ b/infrastructure/modules/service/variables.tf
@@ -16,6 +16,19 @@ variable "container_port" {
   type = number
 }
 
+variable "nginx_container_config" {
+  type = object({
+    image_name    = string
+    container_tag = string
+  })
+
+  // This has an increased max request body size, and increased proxy buffer sizes
+  default = {
+    image_name    = "uk.ac.wellcome/nginx_frontend"
+    container_tag = "9b95057b716a60f9891f77111b0bd524b85839aa"
+  }
+}
+
 variable "security_group_ids" {
   type = list(string)
 }


### PR DESCRIPTION
For https://github.com/wellcomecollection/wellcomecollection.org/issues/8121

This uses the custom Docker image defined in https://github.com/wellcomecollection/platform-infrastructure/pull/312. It's already deployed in staging and tested as working.