### PR TITLE
Redact all query params under the `/account` prefix

### DIFF
--- a/cache/send_slack_alert_for_5xx_errors.js
+++ b/cache/send_slack_alert_for_5xx_errors.js
@@ -150,7 +150,7 @@ function createDisplayUrl(protocol, host, path, query) {
   //
   //      https://wc.org/account/api?password=[cor... REDACTED]&code=[sek... REDACTED]
   //
-  if (path.startsWith('/account/api') && query !== null) {
+  if (path.startsWith('/account') && query !== null) {
     const originalParams = new URLSearchParams(query);
 
     const redactedParams = Array.from(originalParams.entries()).map(function (


### PR DESCRIPTION
There are some endpoints containing PII that aren't under the `/account/api` prefix, in particular the `/account/success?email=[email address]` endpoint that we direct users to after they complete the sign-up process.

We'll still be able to find the exact query parameters from the CloudFront logs if we need them; this just means we're less likely to drop PII in Slack.