### PR TITLE
Increase the quality of images on the stories homepage

### DIFF
--- a/content/webapp/components/StoryPromo/StoryPromo.tsx
+++ b/content/webapp/components/StoryPromo/StoryPromo.tsx
@@ -81,7 +81,7 @@ const StoryPromo: FunctionComponent<Props> = ({
               medium: 1 / 2,
               small: 1,
             }}
-            quality="low"
+            quality="medium"
           />
         )}
 


### PR DESCRIPTION
On my Retina display but without my glasses on, I can see noticeable compression artefacts in both the top card and also the card for the latest comic. I think we should consider bumping the quality for these cards.

<img width="1250" alt="Screenshot 2022-07-06 at 08 55 11" src="https://user-images.githubusercontent.com/301220/177499569-eb297ddf-010b-4227-a7c1-194df7069b66.png">
