### PR TITLE
Create some very rudimentary concept pages

### DIFF
--- a/catalogue/webapp/pages/concept.tsx
+++ b/catalogue/webapp/pages/concept.tsx
@@ -1,6 +1,8 @@
 import { GetServerSideProps, NextPage } from 'next';
 import {
+  CatalogueResultsList,
   Concept as ConceptType,
+  Image as ImageType,
   Work as WorkType,
 } from '@weco/common/model/catalogue';
 import { removeUndefinedProps } from '@weco/common/utils/json';
@@ -10,15 +12,24 @@ import { isString } from '@weco/common/utils/array';
 import { getConcept } from 'services/catalogue/concepts';
 import CataloguePageLayout from 'components/CataloguePageLayout/CataloguePageLayout';
 import { getWorks } from '../services/catalogue/works';
+import ImageEndpointSearchResults from 'components/ImageEndpointSearchResults/ImageEndpointSearchResults';
+import { getImages } from 'services/catalogue/images';
+import WorksSearchResults from '../components/WorksSearchResults/WorksSearchResults';
 
 type Props = {
   conceptResponse: ConceptType;
-  works: WorkType[];
+  works: CatalogueResultsList<WorkType> | undefined;
+  images: CatalogueResultsList<ImageType> | undefined;
 };
 
-export const ConceptPage: NextPage<Props> = ({ conceptResponse, works }) => {
+export const ConceptPage: NextPage<Props> = ({
+  conceptResponse,
+  works,
+  images,
+}) => {
   const conceptsJson = JSON.stringify(conceptResponse);
   const workJson = JSON.stringify(works);
+  const imagesJson = JSON.stringify(images);
 
   return (
     <CataloguePageLayout
@@ -31,10 +42,82 @@ export const ConceptPage: NextPage<Props> = ({ conceptResponse, works }) => {
       hideNewsletterPromo={true}
     >
       <div className="container">
-        <h1>Concepts API response:</h1>
-        <p>{conceptsJson}</p>
-        <h1>Associated works:</h1>
-        <p>{workJson}</p>
+        <p>
+          <strong>Label</strong>
+          <br />
+          {conceptResponse.label}
+        </p>
+
+        <strong>Identifiers</strong>
+        <ul>
+          {conceptResponse.identifiers?.map(id => (
+            <li key={id.value}>
+              {id.identifierType.label} {id.value}
+            </li>
+          ))}
+        </ul>
+
+        <hr />
+
+        <p>
+          <h2>Matching images</h2>
+        </p>
+
+        {images && images.totalResults ? (
+          <>
+            <ImageEndpointSearchResults images={images} />
+            <p>
+              <a
+                href={`/images?source.subjects.label=${conceptResponse.label}`}
+              >
+                see all matching images ({images.totalResults}) &rarr;
+              </a>
+            </p>
+          </>
+        ) : (
+          <p>There are no matching images</p>
+        )}
+
+        <hr />
+
+        <p>
+          <h2>Matching works</h2>
+        </p>
+
+        {works && works.totalResults ? (
+          <>
+            <WorksSearchResults works={works} />
+            <p>
+              <a href={`/works?subjects.label=${conceptResponse.label}`}>
+                see all matching works ({works.totalResults}) &rarr;
+              </a>
+            </p>
+          </>
+        ) : (
+          <p>There are no matching works</p>
+        )}
+
+        <hr />
+
+        <p>
+          <h2>Debug information</h2>
+        </p>
+        <p>
+          <details>
+            <summary>Concepts API response</summary>
+            <p>{conceptsJson}</p>
+          </details>
+
+          <details>
+            <summary>Works API response</summary>
+            <p>{workJson}</p>
+          </details>
+
+          <details>
+            <summary>Images API response</summary>
+            <p>{imagesJson}</p>
+          </details>
+        </p>
       </div>
     </CataloguePageLayout>
   );
@@ -57,19 +140,26 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       return { notFound: true };
     }
 
-    const conceptPromise = getConcept({
+    const conceptResponse = await getConcept({
       id,
       toggles: serverData.toggles,
     });
 
     const worksPromise = getWorks({
-      params: { subjects: [id] },
+      params: { 'subjects.label': [conceptResponse.label] },
       toggles: serverData.toggles,
+      pageSize: 5,
     });
 
-    const [conceptResponse, worksResponse] = await Promise.all([
-      conceptPromise,
+    const imagesPromise = getImages({
+      params: { 'source.subjects.label': [conceptResponse.label] },
+      toggles: serverData.toggles,
+      pageSize: 5,
+    });
+
+    const [worksResponse, imagesResponse] = await Promise.all([
       worksPromise,
+      imagesPromise,
     ]);
 
     if (conceptResponse.type === 'Error') {
@@ -83,12 +173,14 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       );
     }
 
-    const works = worksResponse.type === 'Error' ? [] : worksResponse.results;
+    const works = worksResponse.type === 'Error' ? undefined : worksResponse;
+    const images = imagesResponse.type === 'Error' ? undefined : imagesResponse;
 
     return {
       props: removeUndefinedProps({
         conceptResponse,
         works,
+        images,
         serverData,
       }),
     };

--- a/catalogue/webapp/pages/concepts.tsx
+++ b/catalogue/webapp/pages/concepts.tsx
@@ -31,7 +31,8 @@ export const ConceptsPage: NextPage<Props> = ({ concepts }) => {
         <p>
           <strong>Prototype note:</strong>
           This is a mostly random selection of concepts from the prototype
-          concepts API. It's meant to help us find examples of concepts pages.
+          concepts API. It&rsquo;s meant to help us find examples of concepts
+          pages.
         </p>
         <ul>
           {concepts.results.map(c => (


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/wellcomecollection.org/pull/8061

## Who is this for?

Gareth.

## What is it doing for them?

Showing the information we currently have available to put on concept pages. It's bare bones and minimal, but it is there.

<img width="1431" alt="Screenshot 2022-07-07 at 08 27 54" src="https://user-images.githubusercontent.com/301220/177716802-bcca42df-f56d-4752-873c-bff225f4bf91.png">
<img width="1431" alt="Screenshot 2022-07-07 at 08 28 12" src="https://user-images.githubusercontent.com/301220/177716805-8bf5e33e-f107-4f7b-9576-546bb04d217c.png">


<img width="1431" alt="Screenshot 2022-07-07 at 08 27 51" src="https://user-images.githubusercontent.com/301220/177716798-e20e0461-0d5b-4d9c-885e-533d2d0bc6ec.png">

