### PR TITLE
Add audioPlayer to Prismic body

### DIFF
--- a/prismic-model/src/parts/body.ts
+++ b/prismic-model/src/parts/body.ts
@@ -176,6 +176,12 @@ export default {
           ...mediaObject,
         },
       }),
+      audioPlayer: slice('Audio Player', {
+        nonRepeat: {
+          title,
+          audio: link('Audio', 'media', []),
+        },
+      }),
     },
   },
 };


### PR DESCRIPTION
Prep for using the new AudioPlayer within a podcast article's `body`.