### PR TITLE
image quality tweaks

### DIFF
--- a/cardigan/stories/components/Cards/Cards.stories.tsx
+++ b/cardigan/stories/components/Cards/Cards.stories.tsx
@@ -25,7 +25,7 @@ compactCard.args = {
   url: 'https://wellcomecollection.org',
   title: 'Wellcome Collection',
   description: singleLineOfText(10, 25),
-  Image: <PrismicImage image={imageProps} quality="medium" />,
+  Image: <PrismicImage image={imageProps} quality="low" />,
   DateInfo: null,
   Tags: null,
   primaryLabels: primaryLabelList,

--- a/cardigan/stories/components/PageHeader/PageHeader.stories.tsx
+++ b/cardigan/stories/components/PageHeader/PageHeader.stories.tsx
@@ -230,7 +230,7 @@ const bookImage = {
   sizesQueries: '',
 };
 const EventFeaturedMedia = () => (
-  <PrismicImage image={eventImage} quality="medium" />
+  <PrismicImage image={eventImage} quality="low" />
 );
 
 const Template = args => <PageHeader {...args} />;
@@ -303,7 +303,7 @@ book.args = {
         medium: 1 / 2,
         small: 1,
       }}
-      quality="medium"
+      quality="low"
     />
   ),
 };

--- a/cardigan/stories/components/SeasonsHeader/SeasonsHeader.stories.tsx
+++ b/cardigan/stories/components/SeasonsHeader/SeasonsHeader.stories.tsx
@@ -19,7 +19,7 @@ const headerProps = {
   title: 'What does it mean to be human, now?',
   start: '2021-01-05T00:00:00.000Z',
   end: '2021-01-26T00:00:00.000Z',
-  FeaturedMedia: <PrismicImage image={image} quality="medium" />,
+  FeaturedMedia: <PrismicImage image={image} quality="low" />,
   standfirst: [
     {
       type: 'paragraph',

--- a/cardigan/stories/components/WobblyBottom/WobblyBottom.stories.tsx
+++ b/cardigan/stories/components/WobblyBottom/WobblyBottom.stories.tsx
@@ -6,7 +6,7 @@ const Template = args => <WobblyBottom {...args} />;
 export const image = Template.bind({});
 image.args = {
   color: 'cream',
-  children: <PrismicImage image={contentImage()} quality="medium" />,
+  children: <PrismicImage image={contentImage()} quality="low" />,
 };
 
 export const headline = Template.bind({});

--- a/common/views/components/Iframe/Iframe.tsx
+++ b/common/views/components/Iframe/Iframe.tsx
@@ -137,7 +137,7 @@ class Iframe extends Component<Props, State> {
                 medium: 1,
                 small: 1,
               }}
-              quality="medium"
+              quality="low"
             />
             {this.state.iframeShowing && (
               <Control

--- a/common/views/components/PrismicImage/PrismicImage.tsx
+++ b/common/views/components/PrismicImage/PrismicImage.tsx
@@ -10,7 +10,7 @@ export type Props = {
   sizes?: BreakpointSizes;
   // The maximum width at which the image will be displayed
   maxWidth?: number;
-  quality: 'low' | 'medium' | 'high';
+  quality: 'low' | 'high';
 };
 
 export function convertBreakpointSizesToSizes(
@@ -31,11 +31,10 @@ export function convertBreakpointSizesToSizes(
   );
 }
 
-export type ImageQuality = 'low' | 'medium' | 'high';
+export type ImageQuality = 'low' | 'high';
 
 const imageQuality = {
-  low: '10',
-  medium: '45',
+  low: '50',
   high: '100',
 };
 

--- a/content/webapp/components/FeaturedCard/FeaturedCard.tsx
+++ b/content/webapp/components/FeaturedCard/FeaturedCard.tsx
@@ -294,7 +294,7 @@ const FeaturedCard: FunctionComponent<Props> = ({
                 medium: 1 / 2,
                 small: 1,
               }}
-              quality="medium"
+              quality="low"
             />
           )}
         </FeaturedCardLeft>

--- a/content/webapp/components/StoryPromo/StoryPromo.tsx
+++ b/content/webapp/components/StoryPromo/StoryPromo.tsx
@@ -81,7 +81,7 @@ const StoryPromo: FunctionComponent<Props> = ({
               medium: 1 / 2,
               small: 1,
             }}
-            quality="medium"
+            quality="low"
           />
         )}
 

--- a/content/webapp/pages/book.tsx
+++ b/content/webapp/pages/book.tsx
@@ -105,7 +105,7 @@ const BookPage: FunctionComponent<Props> = props => {
         <BookImage
           image={{ ...book.cover }}
           sizes={{ xlarge: 1 / 3, large: 1 / 3, medium: 1 / 3, small: 1 }}
-          quality="medium"
+          quality="low"
         />
       </Layout8>
     </Space>

--- a/content/webapp/pages/page.tsx
+++ b/content/webapp/pages/page.tsx
@@ -101,7 +101,7 @@ function getFeaturedPictureWithTasl(
             medium: 1,
             small: 1,
           }}
-          quality="medium"
+          quality="low"
         />
       }
       tasl={image?.tasl}

--- a/content/webapp/pages/season.tsx
+++ b/content/webapp/pages/season.tsx
@@ -94,7 +94,7 @@ const SeasonPage = ({
               medium: 1,
               small: 1,
             }}
-            quality="medium"
+            quality="low"
           />
         ) : undefined
       }

--- a/content/webapp/utils/page-header.tsx
+++ b/content/webapp/utils/page-header.tsx
@@ -42,7 +42,7 @@ export function getFeaturedMedia(
             medium: 1,
             small: 1,
           }}
-          quality="medium"
+          quality="low"
         />
       }
       tasl={widescreenImage.tasl}
@@ -58,7 +58,7 @@ export function getFeaturedMedia(
             medium: 1,
             small: 1,
           }}
-          quality="medium"
+          quality="low"
         />
       }
       tasl={image.tasl}


### PR DESCRIPTION
[The current low image quality value, used primarily for promo cards, is causing lots of artifacting](https://wellcome.slack.com/archives/C8X9YKM5X/p1657615604603809), which is obvious on high resolution screens.

We previously had three quality options for Prismic images 'low', 'medium' and 'high'.

This PR removes the medium option and increases the value of the low option, to 50, as recommended by Ben Gilbert.

As noted in the Slack conversation above, we should be mindful of penalising people for who data may be expensive/internet connection poor in order to satisfy people with the best screens, especially as we want to grow our global audience.

With that in mind ,the above changes will add approximately 170kB to the homepage and between 688kB and 970kB to the events/past/ listing pages (The exact amount depends on the image type that is sent, e.g. .avif or .jpg, which is determined by browser support).

If these [costs of mobile data](https://www.cable.co.uk/mobiles/worldwide-data-pricing/) are accurate, for the most expensive country, Equatorial Guinea, that translates to an extra 0.8 cents for the homepage and between 3.3 cents and 4.7 cents for the events listing pages. Is that ok? 