### PR TITLE
Enable count-only Bot Control

### DIFF
--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -115,6 +115,21 @@ resource "aws_wafv2_web_acl" "wc_org" {
       managed_rule_group_statement {
         name        = "AWSManagedRulesBotControlRuleSet"
         vendor_name = "AWS"
+
+        scope_down_statement {
+          regex_pattern_set_reference_statement {
+            field_to_match {
+              uri_path {}
+            }
+
+            arn = aws_wafv2_regex_pattern_set.restricted_urls.arn
+
+            text_transformation {
+              priority = 1
+              type     = "URL_DECODE"
+            }
+          }
+        }
       }
     }
 

--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -95,9 +95,33 @@ resource "aws_wafv2_web_acl" "wc_org" {
     }
 
     visibility_config {
+      cloudwatch_metrics_enabled = false
+      sampled_requests_enabled   = false
+      metric_name                = "weco-cloudfront-restrictive-rate-limit-${var.namespace}"
+    }
+  }
+
+  rule {
+    name     = "bot-control"
+    priority = 3
+
+    override_action {
+      # We are only counting Bot Control actions for now while we evaluate its impact
+      # https://docs.aws.amazon.com/waf/latest/developerguide/waf-bot-control-deploying.html
+      count {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesBotControlRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
       cloudwatch_metrics_enabled = true
       sampled_requests_enabled   = true
-      metric_name                = "weco-cloudfront-restrictive-rate-limit-${var.namespace}"
+      metric_name                = "weco-cloudfront-acl-bot-control-${var.namespace}"
     }
   }
 


### PR DESCRIPTION
See https://wellcome.slack.com/archives/C3TQSF63C/p1657805460169469 for higher-level reasoning behind this.

This enables Bot Control in count-only mode as per the [rec in the docs](https://docs.aws.amazon.com/waf/latest/developerguide/waf-bot-control-deploying.html), and only for the catalogue endpoints. 