### PR TITLE
Redirect /signup to a sign-up page

### DIFF
--- a/cache/edge_lambdas/src/redirects.ts
+++ b/cache/edge_lambdas/src/redirects.ts
@@ -168,6 +168,10 @@ const contentRedirects: Record<string, string> = {
 
   // See https://wellcome.slack.com/archives/C8X9YKM5X/p1656920569188629
   '/events/YrCXAREAACEAFSTW': '/events/Yqcv7xEAACEA61Co',
+
+  // This is the "nice" URL for new memberships.
+  // See https://github.com/wellcomecollection/wellcomecollection.org/issues/8167
+  '/signup': '/account/api/auth/signup',
 };
 
 /**

--- a/identity/webapp/pages/api/auth/signup.ts
+++ b/identity/webapp/pages/api/auth/signup.ts
@@ -1,0 +1,11 @@
+import auth0 from '../../../src/utility/auth0';
+
+// This will redirect the user directly to the sign-up page.
+//
+// See
+// https://community.auth0.com/t/how-do-i-redirect-users-directly-to-the-hosted-signup-page/42520
+// https://github.com/auth0/nextjs-auth0/issues/16#issuecomment-898565337
+export default async (req, res) =>
+  auth0.handleLogin(req, res, {
+    authorizationParams: { screen_hint: 'signup' },
+  });


### PR DESCRIPTION
This creates a simple flow:

```mermaid
graph LR
    L1[user visits /signup] --> L2[redirected to /account/api/auth/signup]
    L2 --> L3[Auth0 signup page]
```

Arguably we could skip directly from `/signup` straight to the Auth0 signup page; I added the intermediate step for consistency with `/account/api/auth/login` and  `/account/api/auth/logout`. It uses a very similar approach to [those routes](https://github.com/wellcomecollection/wellcomecollection.org/blob/94ad82232480e34ea3e1377b879cba637a021ff5/identity/webapp/pages/api/auth/%5B...auth0%5D.ts) and so it felt sensible to keep them together.