### PR TITLE
Remember to prettyify all redacted query params

### DIFF
--- a/identity/webapp/src/app.ts
+++ b/identity/webapp/src/app.ts
@@ -85,7 +85,7 @@ export async function createApp(): Promise<Koa> {
         // Because they aren't actually URL characters, we put back the
         // original brackets for ease of readability.
         const redactedUrl = formatUrl(parsedUrl).replace(
-          '%5Bredacted%5D',
+          /%5Bredacted%5D/g,
           '[redacted]'
         );
 


### PR DESCRIPTION
Currently we're getting logs like

> -x- GET /account/error?client_id=[redacted]&connection=%5Bredacted%5D&lang=%5Bredacted%5D&error=%5Bredacted%5D&error_description=%5Bredacted%5D&tracking=%5Bredacted%5D 200 503ms 131.09kb

which should be

> -x- GET /account/error?client_id=[redacted]&connection=[redacted]&lang=[redacted]&error=[redacted]&error_description=[redacted]&tracking=[redacted] 200 503ms 131.09kb

but _somebody_ forgot that `str.replace()` only replaces the first instance
of the original value; you need a regex if you want everything replaced.

## Who is this for?

Devs.

## What is it doing for them?

Making logs more readable.