### PR TITLE
Remove the self-registration toggle

### DIFF
--- a/identity/webapp/pages/success.tsx
+++ b/identity/webapp/pages/success.tsx
@@ -24,15 +24,6 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async (context: GetServerSidePropsContext) => {
     const serverData = await getServerData(context);
 
-    if (!serverData.toggles.selfRegistration) {
-      return {
-        redirect: {
-          destination: '/',
-          permanent: false,
-        },
-      };
-    }
-
     const { email } = context.query;
 
     return {

--- a/toggles/webapp/deploy.ts
+++ b/toggles/webapp/deploy.ts
@@ -19,6 +19,13 @@ export const withDefaultValuesUnmodified = (
     const { defaultValue } = from.find(({ id }) => id === toggle.id) ?? {
       defaultValue: toggle.defaultValue,
     };
+
+    if (defaultValue !== toggle.defaultValue) {
+      console.log(
+        `Ignoring new default value of ${toggle.id}; use setDefaultValueFor (old: ${defaultValue}, new: ${toggle.defaultValue})`
+      );
+    }
+
     return { ...toggle, defaultValue };
   });
 

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -41,12 +41,6 @@ const toggles = {
       description: 'A toolbar to help us navigate the secret depths of the API',
     },
     {
-      id: 'selfRegistration',
-      title: 'Self registration',
-      defaultValue: true,
-      description: 'Allow users to sign up for an account',
-    },
-    {
       id: 'conceptsPages',
       title: 'Concepts pages',
       defaultValue: false,

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -43,7 +43,7 @@ const toggles = {
     {
       id: 'selfRegistration',
       title: 'Self registration',
-      defaultValue: false,
+      defaultValue: true,
       description: 'Allow users to sign up for an account',
     },
     {


### PR DESCRIPTION
If you have this toggle enabled, you can see `/account/success`. That's it – it's not protecting the sign-up link or sign-up form or anything we'd want to protect, so we might as well remove it rather than update the default value. (Although I have updated it to true until this gets merged and deployed.)