### PR TITLE
Update the edge Lambda for the prod front-end

### DIFF
--- a/cache/locals.tf
+++ b/cache/locals.tf
@@ -3,8 +3,8 @@ data "aws_secretsmanager_secret_version" "slack_webhook" {
 }
 
 locals {
-  edge_lambda_request_version  = 91
-  edge_lambda_response_version = 92
+  edge_lambda_request_version  = 99
+  edge_lambda_response_version = 100
 
   wellcome_cdn_cert_arn = "arn:aws:acm:us-east-1:130871440101:certificate/bb840c52-56bb-4bf8-86f8-59e7deaf9c98"
 


### PR DESCRIPTION
This enables the redirect for `/signup` to a sign-up page.

This is already deployed.