### PR TITLE
Don't include title in button text

### DIFF
--- a/content/webapp/components/Discussion/Discussion.tsx
+++ b/content/webapp/components/Discussion/Discussion.tsx
@@ -22,7 +22,6 @@ const Discussion: FunctionComponent<Props> = ({ title, text }: Props) => {
   const { isEnhanced } = useContext(AppContext);
   const [isActive, setIsActive] = useState(true);
   const [textToShow, setTextToShow] = useState(text);
-  const lowercaseTitle = title?.toLowerCase();
   const firstPartOfText = text?.slice(0, 2);
   useEffect(() => {
     setIsActive(false);
@@ -52,9 +51,7 @@ const Discussion: FunctionComponent<Props> = ({ title, text }: Props) => {
                   setIsActive(!isActive);
                 }}
                 text={
-                  isActive
-                    ? `Hide ${lowercaseTitle}`
-                    : `Read full ${lowercaseTitle}`
+                  isActive ? `Hide full transcript` : `Read full transcript`
                 }
               />
             </ButtonContainer>


### PR DESCRIPTION
Fixes #8170

<img width="893" alt="image" src="https://user-images.githubusercontent.com/1394592/179764604-f7a79db6-74e4-4d4e-a935-f1c07006313f.png">
