### PR TITLE
Do an initial pass on the email verification copy

### DIFF
--- a/identity/webapp/pages/validated.tsx
+++ b/identity/webapp/pages/validated.tsx
@@ -5,7 +5,6 @@ import {
   Wrapper,
   SectionHeading,
 } from '../src/frontend/components/Layout.style';
-import { HighlightMessage } from '../src/frontend/Registration/Registration.style';
 import ButtonSolidLink from '@weco/common/views/components/ButtonSolidLink/ButtonSolidLink';
 import Layout10 from '@weco/common/views/components/Layout10/Layout10';
 import Space from '@weco/common/views/components/styled/Space';
@@ -36,17 +35,15 @@ const ValidatedPage: NextPage<Props> = ({ success, message, isNewSignUp }) => {
                   {isNewSignUp && (
                     <div data-test-id="new-sign-up">
                       <p>
-                        The library team will review your application and will
-                        confirm your membership within the next 72 hours. In the
-                        meantime, you can browse through{' '}
-                        <a href="/collections">our digital collections</a> or
-                        sign in to your account below.
+                        You can now request up to 15 items from our closed
+                        stores in the library.
                       </p>
-                      <HighlightMessage>
-                        <strong>Reminder:</strong> you will need to email a form
-                        of personal identification (ID) and proof of address to
-                        the Library team in order to confirm your details.
-                      </HighlightMessage>
+                      <p>
+                        If you want to access subscription databases, e-journals
+                        and e-books, you need to bring a form of personal
+                        identification (ID) and proof of address to the
+                        admissions desk in the library.
+                      </p>
                     </div>
                   )}
                   <ButtonSolidLink
@@ -66,13 +63,10 @@ const ValidatedPage: NextPage<Props> = ({ success, message, isNewSignUp }) => {
                   <p>{message}</p>
                   <p>
                     If you need help, please{' '}
-                    <a
-                      href="https://wellcomelibrary.org/using-the-library/services-and-facilities/contact-us/"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      contact us
+                    <a href="mailto:library@wellcomecollection.org">
+                      contact the library
                     </a>
+                    .
                   </p>
                 </>
               )}

--- a/identity/webapp/src/frontend/Registration/AccountValidated.test.tsx
+++ b/identity/webapp/src/frontend/Registration/AccountValidated.test.tsx
@@ -89,8 +89,8 @@ describe('AccountValidated', () => {
   it('shows a link to login on success', () => {
     renderPage('/validated?success=true&supportSignUp=true');
     const links = screen.getAllByRole('link');
-    const link = links[1];
-    expect(link).toHaveTextContent('Sign in');
+    const link = links.find(lk => lk.textContent === 'Sign in');
+    expect(link).toBeDefined();
     expect(link).toHaveAttribute('href', '/account');
   });
 

--- a/identity/webapp/src/frontend/Registration/AccountValidated.test.tsx
+++ b/identity/webapp/src/frontend/Registration/AccountValidated.test.tsx
@@ -97,12 +97,10 @@ describe('AccountValidated', () => {
   it('shows a link to customer support on failure', () => {
     renderPage('/validated?success=false');
     const link = screen.getByRole('link');
-    expect(link).toHaveTextContent(/contact us/i);
+    expect(link).toHaveTextContent(/contact the library/i);
     expect(link).toHaveAttribute(
       'href',
-      'https://wellcomelibrary.org/using-the-library/services-and-facilities/contact-us/'
+      'mailto:library@wellcomecollection.org'
     );
-    expect(link).toHaveAttribute('target', '_blank');
-    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
   });
 });


### PR DESCRIPTION
For https://github.com/wellcomecollection/wellcomecollection.org/issues/8178

It now says:

<blockquote><h3>Email verified</h3>
<p>Thank you for verifying your email address.</p>
<p>
                        You can now request up to 15 items from our closed
                        stores in the library.
                      </p>
                      <p>
                        If you want to access subscription databases, e-journals
                        and e-books, you need to bring a form of personal
                        identification (ID) and proof of address to the
                        admissions desk in the library.
                      </p></blockquote>

This is based on the copy from the success page and removes the reference to emailing in your proof of ID.

I'm going to merge this once it goes green so we can get _something_ live ASAP.