### PR TITLE
Select icon placement

### DIFF
--- a/common/views/components/SearchForm/SearchForm.tsx
+++ b/common/views/components/SearchForm/SearchForm.tsx
@@ -58,7 +58,9 @@ const SearchButtonWrapper = styled.div.attrs({
   `}
 `;
 
-const SearchSortOrderWrapper = styled.div`
+const SearchSortOrderWrapper = styled(Space).attrs({
+  h: { size: 'm', properties: ['margin-right'] },
+})`
   color: ${props => props.theme.color('black')};
 `;
 

--- a/common/views/components/SelectContainer/SelectContainer.tsx
+++ b/common/views/components/SelectContainer/SelectContainer.tsx
@@ -20,9 +20,10 @@ const StyledSelect = styled.div.attrs({
   position: relative;
 
   .icon {
+    position: absolute;
     pointer-events: none;
     top: 6px;
-    right: 36px;
+    right: 6px;
   }
 
   select {
@@ -35,6 +36,7 @@ const StyledSelect = styled.div.attrs({
     border: 2px solid ${props => props.theme.color('pumice')};
     border-radius: ${props => props.theme.borderRadiusUnit}px;
     background-color: ${props => props.theme.color('white')};
+    width: 100%;
 
     &::-ms-expand {
       display: none;
@@ -68,10 +70,11 @@ const SelectContainer: FC<Props> = ({ label, hideLabel, children }) => {
 
   return (
     <StyledSelect isKeyboard={isKeyboard} isFontsLoaded={isFontsLoaded}>
-      <label>
+      <label className="flex flex--v-center">
         <Space
           as="span"
           h={{ size: 's', properties: ['margin-right'] }}
+          style={{ whiteSpace: 'nowrap' }}
           className={classNames({
             [font('hnb', 5)]: true,
             'visually-hidden': !!hideLabel,


### PR DESCRIPTION
Fixes #8177

- Makes `select` fill all available horizontal space (makes alignment more predictable)
- Position the chevron `absolute`
- Add extra space between `Sort by:` filter and pagination (required now because of making `select` full-width)
<img width="364" alt="Screenshot 2022-07-20 at 10 05 06" src="https://user-images.githubusercontent.com/1394592/179943418-fd6e9d1b-863b-4562-ab01-abd2d7979e5c.png">

