### PR TITLE
Center clock icon on the what's on page

### DIFF
--- a/content/webapp/pages/whats-on.tsx
+++ b/content/webapp/pages/whats-on.tsx
@@ -251,6 +251,7 @@ const Header = ({
                     {!todaysOpeningHours.isClosed && (
                       <>
                         <Space
+                          className="flex"
                           as="span"
                           h={{ size: 's', properties: ['margin-right'] }}
                         >


### PR DESCRIPTION
__Before__
<img width="497" alt="image" src="https://user-images.githubusercontent.com/1394592/179974109-fc903315-aa6c-4ba2-9bf3-9bb60c354a90.png">

__After__
<img width="486" alt="image" src="https://user-images.githubusercontent.com/1394592/179973981-f932508d-e725-4f77-8f43-156c71388430.png">