### PR TITLE
Better fix for elements being flush against the cream/white border 

### DIFF
--- a/content/webapp/components/ContentPage/ContentPage.tsx
+++ b/content/webapp/components/ContentPage/ContentPage.tsx
@@ -136,6 +136,7 @@ const ContentPage = ({
           </Space>
         )}
         <div
+          style={{ overflow: 'auto' }} // prevent margin collapsing for children
           className={classNames({
             'bg-cream': isCreamy,
           })}

--- a/content/webapp/components/SeriesNavigation/SeriesNavigation.tsx
+++ b/content/webapp/components/SeriesNavigation/SeriesNavigation.tsx
@@ -33,7 +33,7 @@ const SeriesNavigation: FunctionComponent<Props> = ({
           items={items}
           showPosition={showPosition}
         />
-        <Space v={{ size: 'm', properties: ['margin-top', 'margin-bottom'] }}>
+        <Space v={{ size: 'm', properties: ['margin-top'] }}>
           <MoreLink
             name={`More from ${series.title}`}
             url={`/${series.type}/${series.id}`}


### PR DESCRIPTION
The fix in #8185 was a bit short-sighted and only dealt with one component that can appear after the body of an article.

This change ensures that there will always be the desired amount of padding at the end of the cream section of an article.