### PR TITLE
Consolidate all the identity web app copy in a single file

### DIFF
--- a/identity/webapp/copy.tsx
+++ b/identity/webapp/copy.tsx
@@ -112,3 +112,19 @@ export const collectionsResearchAgreementLabel = (
     .{' '}
   </>
 );
+
+export const DeleteRequestedText = () => (
+  <>
+    <SectionHeading as="h1">Delete request received</SectionHeading>
+
+    <p>Your request for account deletion has been received.</p>
+
+    <p>
+      Our Library enquiries team will now progress your request. If there are
+      any issues they will be in touch otherwise your account will be removed.
+    </p>
+    <p>
+      <a href="/">Return to homepage</a>
+    </p>
+  </>
+);

--- a/identity/webapp/copy.tsx
+++ b/identity/webapp/copy.tsx
@@ -1,0 +1,52 @@
+// This is copy for the identity web app that's hard-coded, rather than fetched from Prismic.
+//
+// It's longer than microcopy so it doesn't live in the microcopy file (microcopy.ts), but
+// we keep it in one place for similar reasons:
+//
+//    - All this text can be reviewed for consistency
+//    - It's easier for non-developers to work out if something is hard-coded, and isn't
+//      something they can update on their own, e.g. if the Editorial team are wondering
+//      why they can't update some text in Prismic.
+//
+
+import { FC } from 'react';
+import { SectionHeading } from './src/frontend/components/Layout.style';
+
+type ValidatedSuccessTextProps = {
+  isNewSignUp: boolean;
+};
+
+export const ValidatedSuccessText: FC<ValidatedSuccessTextProps> = ({
+  isNewSignUp,
+}: ValidatedSuccessTextProps) => (
+  <>
+    <SectionHeading as="h1">Email verified</SectionHeading>
+    <p>Thank you for verifying your email address.</p>
+    {isNewSignUp && (
+      <div data-test-id="new-sign-up">
+        <p>
+          You can now request up to 15 items from our closed stores in the
+          library.
+        </p>
+        <p>
+          If you want to access subscription databases, e-journals and e-books,
+          you need to bring a form of personal identification (ID) and proof of
+          address to the admissions desk in the library.
+        </p>
+      </div>
+    )}
+  </>
+);
+
+export const ValidatedFailedText: FC<{ message: string | string[] }> = ({
+  message,
+}) => (
+  <>
+    <SectionHeading as="h1">Failed to verify email</SectionHeading>
+    <p>{message}</p>
+    <p>
+      If you need help, please{' '}
+      <a href="mailto:library@wellcomecollection.org">contact the library</a>.
+    </p>
+  </>
+);

--- a/identity/webapp/copy.tsx
+++ b/identity/webapp/copy.tsx
@@ -12,7 +12,7 @@
 import Divider from '@weco/common/views/components/Divider/Divider';
 import Space from '@weco/common/views/components/styled/Space';
 import { FC } from 'react';
-import { ExternalLink } from 'src/frontend/Registration/Registration.style';
+import { ExternalLink } from './src/frontend/Registration/Registration.style';
 import { SectionHeading } from './src/frontend/components/Layout.style';
 
 type ValidatedSuccessTextProps = {

--- a/identity/webapp/copy.tsx
+++ b/identity/webapp/copy.tsx
@@ -12,6 +12,7 @@
 import Divider from '@weco/common/views/components/Divider/Divider';
 import Space from '@weco/common/views/components/styled/Space';
 import { FC } from 'react';
+import { ExternalLink } from 'src/frontend/Registration/Registration.style';
 import { SectionHeading } from './src/frontend/components/Layout.style';
 
 type ValidatedSuccessTextProps = {
@@ -89,5 +90,25 @@ export const ApplicationReceived: FC<{ email: string }> = ({ email }) => (
         <a href="mailto:library@wellcomecollection.org">contact the library</a>.
       </p>
     </div>
+  </>
+);
+
+export const collectionsResearchAgreementTitle =
+  'Collections research agreement';
+
+export const collectionsResearchAgreementLabel = (
+  <>
+    I will use personal data on living persons for research purposes only. I
+    will not use personal data to support decisions about the person who is the
+    subject of the data, or in a way that causes substantial damage or distress
+    to them. I have read and accept the regulations detailed in the{' '}
+    <ExternalLink
+      href="https://wellcome.org/about-us/governance/privacy-and-terms"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Library’s Terms & Conditions of Use
+    </ExternalLink>
+    .{' '}
   </>
 );

--- a/identity/webapp/copy.tsx
+++ b/identity/webapp/copy.tsx
@@ -9,6 +9,8 @@
 //      why they can't update some text in Prismic.
 //
 
+import Divider from '@weco/common/views/components/Divider/Divider';
+import Space from '@weco/common/views/components/styled/Space';
 import { FC } from 'react';
 import { SectionHeading } from './src/frontend/components/Layout.style';
 
@@ -48,5 +50,44 @@ export const ValidatedFailedText: FC<{ message: string | string[] }> = ({
       If you need help, please{' '}
       <a href="mailto:library@wellcomecollection.org">contact the library</a>.
     </p>
+  </>
+);
+
+export const ApplicationReceived: FC<{ email: string }> = ({ email }) => (
+  <>
+    <SectionHeading as="h1">Application received</SectionHeading>
+    <div className="body-text">
+      <p>Thank you for applying for a library membership.</p>
+      <p>
+        Please click the verification link in the email we’ve just sent to{' '}
+        <strong>{email}</strong>.
+      </p>
+      <p>
+        <strong>Please do this within the next 24 hours.</strong>
+      </p>
+      <p>
+        Once you have verified your email address, you will be able to request
+        up to 15 items from our closed stores to view in the library.
+      </p>
+      <p>
+        If you want to access subscription databases, e-journals and e-books,
+        you need to bring a form of personal identification (ID) and proof of
+        address to the admissions desk in the library.
+      </p>
+      <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
+        <Divider color={`pumice`} isKeyline />
+      </Space>
+      <p>
+        <strong>Didn’t receive an email?</strong>
+      </p>
+      <p>
+        If you still don’t see an email from us within the next few minutes, try
+        checking your junk or spam folder.
+      </p>
+      <p>
+        If you need more help please{' '}
+        <a href="mailto:library@wellcomecollection.org">contact the library</a>.
+      </p>
+    </div>
   </>
 );

--- a/identity/webapp/pages/delete-requested.tsx
+++ b/identity/webapp/pages/delete-requested.tsx
@@ -1,9 +1,5 @@
 import { NextPage, GetServerSideProps } from 'next';
-import {
-  Container,
-  Wrapper,
-  SectionHeading,
-} from '../src/frontend/components/Layout.style';
+import { Container, Wrapper } from '../src/frontend/components/Layout.style';
 import { PageWrapper } from '../src/frontend/components/PageWrapper';
 import Layout10 from '@weco/common/views/components/Layout10/Layout10';
 import Space from '@weco/common/views/components/styled/Space';
@@ -11,6 +7,7 @@ import { getServerData } from '@weco/common/server-data';
 import { AppErrorProps } from '@weco/common/views/pages/_app';
 import { removeUndefinedProps } from '@weco/common/utils/json';
 import { SimplifiedServerData } from '@weco/common/server-data/types';
+import { DeleteRequestedText } from '../copy';
 
 const DeleteRequestedPage: NextPage = () => {
   return (
@@ -19,18 +16,7 @@ const DeleteRequestedPage: NextPage = () => {
         <Space v={{ size: 'xl', properties: ['margin-top'] }}>
           <Container>
             <Wrapper>
-              <SectionHeading as="h1">Delete request received</SectionHeading>
-
-              <p>Your request for account deletion has been received.</p>
-
-              <p>
-                Our Library enquiries team will now progress your request. If
-                there are any issues they will be in touch otherwise your
-                account will be removed.
-              </p>
-              <p>
-                <a href="/">Return to homepage</a>
-              </p>
+              <DeleteRequestedText />
             </Wrapper>
           </Container>
         </Space>

--- a/identity/webapp/pages/registration.tsx
+++ b/identity/webapp/pages/registration.tsx
@@ -6,7 +6,6 @@ import { PageWrapper } from '../src/frontend/components/PageWrapper';
 import { font } from '@weco/common/utils/classnames';
 import {
   Checkbox,
-  ExternalLink,
   CheckboxLabel,
   FullWidthButton,
   FlexStartCheckbox,
@@ -31,6 +30,10 @@ import { RegistrationInputs, decodeToken } from '../src/utility/jwt-codec';
 import { stringFromStringOrStringArray } from '@weco/common/utils/array';
 import RegistrationInformation from '../src/frontend/Registration/RegistrationInformation';
 import getConfig from 'next/config';
+import {
+  collectionsResearchAgreementTitle,
+  collectionsResearchAgreementLabel,
+} from '../copy';
 
 const { serverRuntimeConfig: config } = getConfig();
 
@@ -156,7 +159,7 @@ const RegistrationPage: NextPage<Props> = ({
 
                     <SpacingComponent>
                       <h3 className={font('hnb', 5)}>
-                        Collections research agreement
+                        {collectionsResearchAgreementTitle}
                       </h3>
                       <Controller
                         name="termsAndConditions"
@@ -175,21 +178,7 @@ const RegistrationPage: NextPage<Props> = ({
                               checked={value}
                               text={
                                 <CheckboxLabel>
-                                  I will use personal data on living persons for
-                                  research purposes only. I will not use
-                                  personal data to support decisions about the
-                                  person who is the subject of the data, or in a
-                                  way that causes substantial damage or distress
-                                  to them. I have read and accept the
-                                  regulations detailed in the{' '}
-                                  <ExternalLink
-                                    href="https://wellcome.org/about-us/governance/privacy-and-terms"
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                  >
-                                    Library’s Terms & Conditions of Use
-                                  </ExternalLink>
-                                  .{' '}
+                                  {collectionsResearchAgreementLabel}
                                 </CheckboxLabel>
                               }
                             />

--- a/identity/webapp/pages/success.tsx
+++ b/identity/webapp/pages/success.tsx
@@ -1,10 +1,6 @@
 import { NextPage, GetServerSideProps, GetServerSidePropsContext } from 'next';
 import { PageWrapper } from '../src/frontend/components/PageWrapper';
-import {
-  Container,
-  Wrapper,
-  SectionHeading,
-} from '../src/frontend/components/Layout.style';
+import { Container, Wrapper } from '../src/frontend/components/Layout.style';
 import { usePageTitle } from '../src/frontend/hooks/usePageTitle';
 import Layout8 from '@weco/common/views/components/Layout8/Layout8';
 import Layout10 from '@weco/common/views/components/Layout10/Layout10';
@@ -13,7 +9,7 @@ import { getServerData } from '@weco/common/server-data';
 import { AppErrorProps } from '@weco/common/views/pages/_app';
 import { removeUndefinedProps } from '@weco/common/utils/json';
 import { SimplifiedServerData } from '@weco/common/server-data/types';
-import Divider from '@weco/common/views/components/Divider/Divider';
+import { ApplicationReceived } from '../copy';
 
 type Props = {
   serverData: SimplifiedServerData;
@@ -45,45 +41,7 @@ const SuccessPage: NextPage<Props> = ({ email }) => {
             <Wrapper>
               <Layout8>
                 <Space v={{ size: 'xl', properties: ['padding-top'] }}>
-                  <SectionHeading as="h1">Application received</SectionHeading>
-                  <div className="body-text">
-                    <p>Thank you for applying for a library membership.</p>
-                    <p>
-                      Please click the verification link in the email we’ve just
-                      sent to <strong>{email}</strong>.
-                    </p>
-                    <p>
-                      <strong>Please do this within the next 24 hours.</strong>
-                    </p>
-                    <p>
-                      Once you have verified your email address, you will be
-                      able to request up to 15 items from our closed stores to
-                      view in the library.
-                    </p>
-                    <p>
-                      If you want to access subscription databases, e-journals
-                      and e-books, you need to bring a form of personal
-                      identification (ID) and proof of address to the admissions
-                      desk in the library.
-                    </p>
-                    <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
-                      <Divider color={`pumice`} isKeyline />
-                    </Space>
-                    <p>
-                      <strong>Didn’t receive an email?</strong>
-                    </p>
-                    <p>
-                      If you still don’t see an email from us within the next
-                      few minutes, try checking your junk or spam folder.
-                    </p>
-                    <p>
-                      If you need more help please{' '}
-                      <a href="mailto:library@wellcomecollection.org">
-                        contact the library
-                      </a>
-                      .
-                    </p>
-                  </div>
+                  <ApplicationReceived email={email} />
                 </Space>
               </Layout8>
             </Wrapper>

--- a/identity/webapp/pages/validated.tsx
+++ b/identity/webapp/pages/validated.tsx
@@ -1,10 +1,6 @@
 import { GetServerSideProps, NextPage } from 'next';
 import { PageWrapper } from '../src/frontend/components/PageWrapper';
-import {
-  Container,
-  Wrapper,
-  SectionHeading,
-} from '../src/frontend/components/Layout.style';
+import { Container, Wrapper } from '../src/frontend/components/Layout.style';
 import ButtonSolidLink from '@weco/common/views/components/ButtonSolidLink/ButtonSolidLink';
 import Layout10 from '@weco/common/views/components/Layout10/Layout10';
 import Space from '@weco/common/views/components/styled/Space';
@@ -14,6 +10,7 @@ import { removeUndefinedProps } from '@weco/common/utils/json';
 import { SimplifiedServerData } from '@weco/common/server-data/types';
 import { useUser } from '@weco/common/views/components/UserProvider/UserProvider';
 import auth0 from '../src/utility/auth0';
+import { ValidatedFailedText, ValidatedSuccessText } from '../copy';
 
 const ValidatedPage: NextPage<Props> = ({ success, message, isNewSignUp }) => {
   const { state: userState } = useUser();
@@ -30,22 +27,7 @@ const ValidatedPage: NextPage<Props> = ({ success, message, isNewSignUp }) => {
             <Wrapper>
               {success || urlUsed ? (
                 <>
-                  <SectionHeading as="h1">Email verified</SectionHeading>
-                  <p>Thank you for verifying your email address.</p>
-                  {isNewSignUp && (
-                    <div data-test-id="new-sign-up">
-                      <p>
-                        You can now request up to 15 items from our closed
-                        stores in the library.
-                      </p>
-                      <p>
-                        If you want to access subscription databases, e-journals
-                        and e-books, you need to bring a form of personal
-                        identification (ID) and proof of address to the
-                        admissions desk in the library.
-                      </p>
-                    </div>
-                  )}
+                  <ValidatedSuccessText isNewSignUp={isNewSignUp} />
                   <ButtonSolidLink
                     link="/account"
                     text={
@@ -56,19 +38,7 @@ const ValidatedPage: NextPage<Props> = ({ success, message, isNewSignUp }) => {
                   />
                 </>
               ) : (
-                <>
-                  <SectionHeading as="h1">
-                    Failed to verify email
-                  </SectionHeading>
-                  <p>{message}</p>
-                  <p>
-                    If you need help, please{' '}
-                    <a href="mailto:library@wellcomecollection.org">
-                      contact the library
-                    </a>
-                    .
-                  </p>
-                </>
+                <ValidatedFailedText message={message} />
               )}
             </Wrapper>
           </Container>


### PR DESCRIPTION
For https://github.com/wellcomecollection/wellcomecollection.org/issues/8160

This is similar to the microcopy file for the rest of the site, but I wanted to keep it separate because this contains large blobs of HTML.

This is just a lift-and-shift; I'll make the changes I want to make separately.