### PR TITLE
update creator to tombstone 

### DIFF
--- a/prismic-model/src/exhibition-guides.ts
+++ b/prismic-model/src/exhibition-guides.ts
@@ -28,6 +28,8 @@ const exhibitionGuides: CustomType = {
         number: number('Position number'),
         title,
         tombstone: structuredText('Tombstone', 'single'),
+        // Info on the choice for the name tombstone instead of creator
+        // https://wellcome.slack.com/archives/CUA669WHH/p1658396258859169
         image: image('image'),
         description: structuredText('Description', 'single'),
         'audio-with-description': link('Audio', 'media', []),

--- a/prismic-model/src/exhibition-guides.ts
+++ b/prismic-model/src/exhibition-guides.ts
@@ -27,7 +27,7 @@ const exhibitionGuides: CustomType = {
       components: list('Guide Component', {
         number: number('Position number'),
         title,
-        creator: structuredText('Creator', 'single'),
+        tombstone: structuredText('Tombstone', 'single'),
         image: image('image'),
         description: structuredText('Description', 'single'),
         'audio-with-description': link('Audio', 'media', []),


### PR DESCRIPTION
based on chat with Danny and Alice a better name for this field is 'tombstone'. 

An example of tombstone (previously creator) can be seen in the below screenshot where you see 'Phil Nobel 2020'. [More examples of the kind of thing that goes in that space](https://alicerichmond.github.io/digital-guide-prototype/joy/transandcapsjoy.html)

![image](https://user-images.githubusercontent.com/16557524/180202970-e04ca2ab-6bd7-405c-a56e-f907291052a2.png)

