### PR TITLE
Make some small improvements to diffCustomTypes

### DIFF
--- a/prismic-model/diffCustomTypes.ts
+++ b/prismic-model/diffCustomTypes.ts
@@ -55,7 +55,7 @@ export default async function diffContentTypes(
           }
         } catch (e) {
           console.warn(
-            `Prismic has type ${remoteCustomType.id}, but it can't be found locally: ${e}`
+            `Prismic has type ${remoteCustomType.id}, but it can't be loaded locally: ${e}`
           );
           return { id: remoteCustomType.id };
         }

--- a/prismic-model/diffCustomTypes.ts
+++ b/prismic-model/diffCustomTypes.ts
@@ -6,7 +6,15 @@ import { error, success } from './console';
 import { isCi, secrets } from './config';
 import { diffJson, Delta, isEmpty, printDelta } from './differ';
 
-export default async function diffContentTypes(credentials?): Promise<void> {
+type Credentials = {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken: string;
+};
+
+export default async function diffContentTypes(
+  credentials?: Credentials
+): Promise<void> {
   await setEnvsFromSecrets(secrets, credentials);
 
   const resp = await fetch(`https://customtypes.prismic.io/customtypes`, {

--- a/prismic-model/diffCustomTypes.ts
+++ b/prismic-model/diffCustomTypes.ts
@@ -34,7 +34,6 @@ export default async function diffContentTypes(
   const deltas = (
     await Promise.all(
       remoteCustomTypes.map(async remoteCustomType => {
-
         // We can get an error here if somebody adds a type in
         // the Prismic GUI, but doesn't define it locally.
         //
@@ -55,9 +54,11 @@ export default async function diffContentTypes(
             return { id: remoteCustomType.id };
           }
         } catch (e) {
-          console.warn(`Prismic has type ${remoteCustomType.id}, but it's not defined locally`);
+          console.warn(
+            `Prismic has type ${remoteCustomType.id}, but it can't be found locally: ${e}`
+          );
           return { id: remoteCustomType.id };
-        };
+        }
       })
     )
   ).filter(Boolean) as { id: string }[];

--- a/prismic-model/diffCustomTypes.ts
+++ b/prismic-model/diffCustomTypes.ts
@@ -4,7 +4,7 @@ import fetch from 'node-fetch';
 import { CustomType } from './src/types/CustomType';
 import { error, success } from './console';
 import { isCi, secrets } from './config';
-import { diffJson, Delta, isEmpty, printDelta } from './differ';
+import { diffJson, isEmpty, printDelta } from './differ';
 
 type Credentials = {
   accessKeyId: string;


### PR DESCRIPTION
In particular, it may fail to load a local model for reasons other than "the model doesn't exist" – e.g. if there's a syntax error in the file. Make the error more accurate.