### PR TITLE
updating the audio labels 

### DIFF
--- a/prismic-model/src/exhibition-guides.ts
+++ b/prismic-model/src/exhibition-guides.ts
@@ -32,8 +32,12 @@ const exhibitionGuides: CustomType = {
         // https://wellcome.slack.com/archives/CUA669WHH/p1658396258859169
         image: image('image'),
         description: structuredText('Description', 'single'),
-        'audio-with-description': link('Audio', 'media', []),
-        'audio-without-description': link('Audio', 'media', []),
+        'audio-with-description': link('Audio with description', 'media', []),
+        'audio-without-description': link(
+          'Audio without description',
+          'media',
+          []
+        ),
         'bsl-video': embed('Embed (Youtube)'),
         caption: structuredText('Caption', 'multi'),
         transcript: structuredText('Transcript', 'multi'),


### PR DESCRIPTION
to reflect if they are with or without description, this makes it easier for editors using Prismic. 

Who is this for?
Editors 

Before:
<img width="538" alt="Screenshot 2022-07-21 at 14 13 40" src="https://user-images.githubusercontent.com/16557524/180222533-85a76b01-e15d-4a3f-be15-33a0bb49c9a8.png">

After: 
<img width="538" alt="Screenshot 2022-07-21 at 14 15 08" src="https://user-images.githubusercontent.com/16557524/180222600-78ab5206-d817-4aef-af1f-ba7559bf1d8b.png">

