### PR TITLE
Fix the build

### DIFF
--- a/prismic-model/src/exhibition-guides.ts
+++ b/prismic-model/src/exhibition-guides.ts
@@ -34,7 +34,10 @@ const exhibitionGuides: CustomType = {
           allowMultipleParagraphs: false,
         }),
         image: image('image'),
-        description: structuredText('Description', 'single'),
+        description: structuredText({
+          label: 'Description',
+          allowMultipleParagraphs: false,
+        }),
         'audio-with-description': link('Audio with description', 'media', []),
         'audio-without-description': link(
           'Audio without description',


### PR DESCRIPTION
Looks like the [description field of the exhibition-guides, got mistakenly overwritten](https://github.com/wellcomecollection/wellcomecollection.org/pull/8201/files). 

The [structuredText function now takes an object, following Alex's recent change](https://github.com/wellcomecollection/wellcomecollection.org/pull/8200/files). 

This is causing the diffCustomTypes script and hence the build to fail.
