### PR TITLE
Send a synthetic 'result: ok|error' page on newsletter signup, not the full Dotdigital response

### DIFF
--- a/common/views/components/NewsletterPromo/NewsletterPromo.tsx
+++ b/common/views/components/NewsletterPromo/NewsletterPromo.tsx
@@ -136,20 +136,17 @@ const NewsletterPromo = () => {
     });
 
     const json = await response.json();
-    const { status } = json;
+    const { result } = json;
 
-    switch (status) {
-      case 'ContactChallenged':
-      case 'ContactAdded':
-      case 'PendingOptIn':
-      case 'Subscribed':
+    switch (result) {
+      case 'ok':
         setIsSuccess(true);
         trackEvent({
           category: 'NewsletterPromo',
           action: 'submit email',
         });
         break;
-      default:
+      case 'error':
         setIsSubmitError(true);
         emailValidation.setIsValid(false);
     }

--- a/content/webapp/routeHandlers/handleNewsletterSignup.ts
+++ b/content/webapp/routeHandlers/handleNewsletterSignup.ts
@@ -52,6 +52,17 @@ async function handleNewsletterSignup(ctx, next) {
     ctx.body = newJson;
   }
 
+  // We don't want to send the full Dotdigital response to the page,
+  // just the status.
+  //
+  // The Dotdigital response returns all the data about a particular user,
+  // including first/last name and postcode.  These fields are sparsely
+  // populated among our users so it's fairly unlikely you'd be able to find
+  // anything interesting this way… but there's no reason to expose it.
+  ctx.body = {
+    status: ctx.body.status,
+  };
+
   next();
 }
 


### PR DESCRIPTION
This simplifies the `/newsletter-signup` endpoint, and also hints at a way forward for https://github.com/wellcomecollection/wellcomecollection.org/issues/8166. Currently that endpoint takes:

* an email address
* a single mailing list ID

and subscribes the user to that list, and that list alone. Now it returns a simple `result: ok|error` response, we could adapt it to take a list of multiple mailing list IDs, and use that on the newsletter page. We already have most of the machinery in place, and we could consolidate on a single approach to newsletter sign-ups.

See discussion in Slack: https://wellcome.slack.com/archives/CUA669WHH/p1658499405551999