### PR TITLE
Tidy up some newsletter signup code

### DIFF
--- a/common/data/dotdigital.ts
+++ b/common/data/dotdigital.ts
@@ -1,17 +1,17 @@
-type Campaign = {
+type AddressBook = {
   id: number;
   slug: string;
   label: string;
   description?: string;
 };
 
-export const newsletterCampaign: Campaign = {
+export const newsletterAddressBook: AddressBook = {
   id: 40131,
   slug: 'newsletter',
   label: 'Newsletter',
 };
 
-export const secondaryCampaigns: Campaign[] = [
+export const secondaryAddressBooks: AddressBook[] = [
   {
     id: 40129,
     slug: 'accessibility',

--- a/common/data/dotdigital.ts
+++ b/common/data/dotdigital.ts
@@ -1,0 +1,36 @@
+type Campaign = {
+  id: number;
+  slug: string;
+  label: string;
+  description?: string;
+};
+
+export const newsletterCampaign: Campaign = {
+  id: 40131,
+  slug: 'newsletter',
+  label: 'Newsletter',
+};
+
+export const secondaryCampaigns: Campaign[] = [
+  {
+    id: 40129,
+    slug: 'accessibility',
+    label: `Access events, tours and activities`,
+  },
+  {
+    id: 40132,
+    slug: 'young_people_14-19',
+    label: `Events and activities for 14 to 19 year-olds`,
+  },
+  {
+    id: 40130,
+    slug: 'teachers',
+    label: `Events and activities for teachers and schools`,
+    description: `Study days and other events for secondary school teachers and school groups`,
+  },
+  {
+    id: 40133,
+    slug: 'youth_and_community_workers',
+    label: `Updates for youth and community workers`,
+  },
+];

--- a/common/data/dotdigital.ts
+++ b/common/data/dotdigital.ts
@@ -15,22 +15,23 @@ export const secondaryCampaigns: Campaign[] = [
   {
     id: 40129,
     slug: 'accessibility',
-    label: `Access events, tours and activities`,
+    label: 'Access events, tours and activities',
   },
   {
     id: 40132,
     slug: 'young_people_14-19',
-    label: `Events and activities for 14 to 19 year-olds`,
+    label: 'Events and activities for 14 to 19 year-olds',
   },
   {
     id: 40130,
     slug: 'teachers',
-    label: `Events and activities for teachers and schools`,
-    description: `Study days and other events for secondary school teachers and school groups`,
+    label: 'Events and activities for teachers and schools',
+    description:
+      'Study days and other events for secondary school teachers and school groups',
   },
   {
     id: 40133,
     slug: 'youth_and_community_workers',
-    label: `Updates for youth and community workers`,
+    label: 'Updates for youth and community workers',
   },
 ];

--- a/common/views/components/NewsletterPromo/NewsletterPromo.tsx
+++ b/common/views/components/NewsletterPromo/NewsletterPromo.tsx
@@ -7,7 +7,7 @@ import TextInput from '../TextInput/TextInput';
 import { trackEvent } from '../../../utils/ga';
 import useValidation from '../../../hooks/useValidation';
 import ButtonSolid from '../ButtonSolid/ButtonSolid';
-import { newsletterCampaign } from '../../../data/dotdigital';
+import { newsletterAddressBook } from '../../../data/dotdigital';
 
 const FormElementWrapper = styled.div`
   width: 100%;
@@ -207,7 +207,7 @@ const NewsletterPromo = () => {
                       <input
                         type="hidden"
                         name="addressBookId"
-                        value={newsletterCampaign.id}
+                        value={newsletterAddressBook.id}
                       />
                       <FormElementWrapper>
                         <TextInput

--- a/common/views/components/NewsletterPromo/NewsletterPromo.tsx
+++ b/common/views/components/NewsletterPromo/NewsletterPromo.tsx
@@ -206,17 +206,6 @@ const NewsletterPromo = () => {
                       onSubmit={handleSubmit}
                       noValidate={isEnhanced}
                     >
-                      <input type="hidden" name="userid" value="225683" />
-                      <input
-                        type="hidden"
-                        name="SIG22a9ece3ebe9b2e10e328f234fd10b3f5686b9f4d45f628f08852417032dc990"
-                        value=""
-                      />
-                      <input
-                        type="hidden"
-                        name="ReturnURL"
-                        value="https://wellcomecollection.org/newsletter"
-                      />
                       <input type="hidden" name="addressbookid" value="40131" />
                       <FormElementWrapper>
                         <TextInput

--- a/common/views/components/NewsletterPromo/NewsletterPromo.tsx
+++ b/common/views/components/NewsletterPromo/NewsletterPromo.tsx
@@ -123,8 +123,8 @@ const NewsletterPromo = () => {
 
     const formEls = [...event.currentTarget.elements];
     const data = {
-      addressbookid: formEls.find(el => el.name === 'addressbookid').value,
-      email: formEls.find(el => el.name === 'email').value,
+      addressBookId: formEls.find(el => el.name === 'addressBookId').value,
+      emailAddress: formEls.find(el => el.name === 'email').value,
     };
 
     const response = await fetch('/newsletter-signup', {
@@ -141,10 +141,7 @@ const NewsletterPromo = () => {
     switch (result) {
       case 'ok':
         setIsSuccess(true);
-        trackEvent({
-          category: 'NewsletterPromo',
-          action: 'submit email',
-        });
+        trackEvent({ category: 'NewsletterPromo', action: 'submit email' });
         break;
       case 'error':
         setIsSubmitError(true);
@@ -206,7 +203,7 @@ const NewsletterPromo = () => {
                       onSubmit={handleSubmit}
                       noValidate={isEnhanced}
                     >
-                      <input type="hidden" name="addressbookid" value="40131" />
+                      <input type="hidden" name="addressBookId" value="40131" />
                       <FormElementWrapper>
                         <TextInput
                           required={true}

--- a/common/views/components/NewsletterPromo/NewsletterPromo.tsx
+++ b/common/views/components/NewsletterPromo/NewsletterPromo.tsx
@@ -7,6 +7,7 @@ import TextInput from '../TextInput/TextInput';
 import { trackEvent } from '../../../utils/ga';
 import useValidation from '../../../hooks/useValidation';
 import ButtonSolid from '../ButtonSolid/ButtonSolid';
+import { newsletterCampaign } from '../../../data/dotdigital';
 
 const FormElementWrapper = styled.div`
   width: 100%;
@@ -203,7 +204,11 @@ const NewsletterPromo = () => {
                       onSubmit={handleSubmit}
                       noValidate={isEnhanced}
                     >
-                      <input type="hidden" name="addressBookId" value="40131" />
+                      <input
+                        type="hidden"
+                        name="addressBookId"
+                        value={newsletterCampaign.id}
+                      />
                       <FormElementWrapper>
                         <TextInput
                           required={true}

--- a/content/webapp/components/NewsletterSignup/NewsletterSignup.tsx
+++ b/content/webapp/components/NewsletterSignup/NewsletterSignup.tsx
@@ -1,4 +1,4 @@
-import { SyntheticEvent, useState, useEffect } from 'react';
+import { SyntheticEvent, useState, useEffect, FC } from 'react';
 import TextInput from '@weco/common/views/components/TextInput/TextInput';
 import CheckboxRadio from '@weco/common/views/components/CheckboxRadio/CheckboxRadio';
 import { font, classNames } from '@weco/common/utils/classnames';
@@ -6,6 +6,7 @@ import Space from '@weco/common/views/components/styled/Space';
 import useValidation from '@weco/common/hooks/useValidation';
 import ButtonSolid from '@weco/common/views/components/ButtonSolid/ButtonSolid';
 import styled from 'styled-components';
+import { secondaryCampaigns } from '@weco/common/data/dotdigital';
 
 const ErrorBox = styled(Space).attrs({
   v: {
@@ -29,38 +30,11 @@ type Props = {
   isConfirmed?: boolean;
 };
 
-type AddressBook = {
-  id: string;
-  label: string;
-  name: string;
-  description?: string;
-};
-
-const addressBooks: AddressBook[] = [
-  {
-    id: 'accessibility',
-    label: `Access events, tours and activities`,
-    name: 'addressbook_40129',
-  },
-  {
-    id: 'young_people_14-19',
-    label: `Events and activities for 14 to 19 year-olds`,
-    name: 'addressbook_40132',
-  },
-  {
-    id: 'teachers',
-    label: `Events and activities for teachers and schools`,
-    name: 'addressbook_40130',
-    description: `Study days and other events for secondary school teachers and school groups`,
-  },
-  {
-    id: 'youth_and_community_workers',
-    label: `Updates for youth and community workers`,
-    name: 'addressbook_40133',
-  },
-];
-
-const NewsletterSignup = ({ isSuccess, isError, isConfirmed }: Props) => {
+const NewsletterSignup: FC<Props> = ({
+  isSuccess,
+  isError,
+  isConfirmed,
+}: Props) => {
   const [checkedInputs, setCheckedInputs] = useState<string[]>([]);
   const [isCheckboxError, setIsCheckboxError] = useState(true);
   const [noValidate, setNoValidate] = useState(false);
@@ -227,19 +201,19 @@ const NewsletterSignup = ({ isSuccess, isError, isConfirmed }: Props) => {
               </legend>
             </Space>
             <ul className="plain-list no-padding">
-              {addressBooks.map(addressBook => (
+              {secondaryCampaigns.map(campaign => (
                 <Space
                   as="li"
                   v={{ size: 'm', properties: ['margin-bottom'] }}
-                  key={addressBook.id}
+                  key={campaign.slug}
                 >
                   <CheckboxRadio
-                    id={addressBook.id}
+                    id={campaign.slug}
                     type={`checkbox`}
-                    text={addressBook.label}
-                    value={addressBook.name}
-                    name={addressBook.name}
-                    checked={checkedInputs.includes(addressBook.id)}
+                    text={campaign.label}
+                    value={`address_${campaign.id}`}
+                    name={`address_${campaign.id}`}
+                    checked={checkedInputs.includes(campaign.slug)}
                     onChange={updateCheckedInputs}
                   />
                 </Space>

--- a/content/webapp/components/NewsletterSignup/NewsletterSignup.tsx
+++ b/content/webapp/components/NewsletterSignup/NewsletterSignup.tsx
@@ -6,7 +6,7 @@ import Space from '@weco/common/views/components/styled/Space';
 import useValidation from '@weco/common/hooks/useValidation';
 import ButtonSolid from '@weco/common/views/components/ButtonSolid/ButtonSolid';
 import styled from 'styled-components';
-import { secondaryCampaigns } from '@weco/common/data/dotdigital';
+import { secondaryAddressBooks } from '@weco/common/data/dotdigital';
 
 const ErrorBox = styled(Space).attrs({
   v: {
@@ -201,19 +201,19 @@ const NewsletterSignup: FC<Props> = ({
               </legend>
             </Space>
             <ul className="plain-list no-padding">
-              {secondaryCampaigns.map(campaign => (
+              {secondaryAddressBooks.map(addressBook => (
                 <Space
                   as="li"
                   v={{ size: 'm', properties: ['margin-bottom'] }}
-                  key={campaign.slug}
+                  key={addressBook.slug}
                 >
                   <CheckboxRadio
-                    id={campaign.slug}
+                    id={addressBook.slug}
                     type={`checkbox`}
-                    text={campaign.label}
-                    value={`address_${campaign.id}`}
-                    name={`address_${campaign.id}`}
-                    checked={checkedInputs.includes(campaign.slug)}
+                    text={addressBook.label}
+                    value={`address_${addressBook.id}`}
+                    name={`address_${addressBook.id}`}
+                    checked={checkedInputs.includes(addressBook.slug)}
                     onChange={updateCheckedInputs}
                   />
                 </Space>

--- a/content/webapp/routeHandlers/handleNewsletterSignup.ts
+++ b/content/webapp/routeHandlers/handleNewsletterSignup.ts
@@ -1,3 +1,4 @@
+import { isUndefined } from '@weco/common/utils/array';
 import fetch from 'node-fetch';
 
 const dotdigitalUsername = process.env.dotdigital_username;
@@ -13,6 +14,19 @@ async function createSubscription({
   addressBookId: string;
 }): Promise<Status> {
   const newsletterApiUrl = 'https://r1-api.dotmailer.com/v2';
+
+  // This should never happen in practice, but it's a useful hint for
+  // anybody doing local development and wondering why sign-ups are
+  // failing.  These should always be configured in the prod app.
+  if (
+    dotdigitalUsername === '' ||
+    dotdigitalPassword === '' ||
+    isUndefined(dotdigitalUsername) ||
+    isUndefined(dotdigitalPassword)
+  ) {
+    console.warn('Missing dotdigital credentials; newsletter sign-up may fail');
+  }
+
   const headers = {
     'Content-Type': 'application/json',
     Authorization: `Basic ${Buffer.from(


### PR DESCRIPTION
For https://github.com/wellcomecollection/wellcomecollection.org/issues/8166

This doesn't change any of the behaviour; it's some refactoring in advance of actually fixing it properly.

My thinking is that we send a _list_ of newsletter IDs to the `/newsletter-signup` endpoint, e.g.

```json
{
  "email": "henry@example.com",
  "addressBookIds": [1234, 2345, 3456]
}
```

The endpoint subscribes you to all of them, and returns `ok|error` depending on whether they all succeeded.

But this refactoring doesn't rely on that; even if we go a different approach I think these clean-ups are useful.