### PR TITLE
Make the 5xx CloudFront alert Lambda more useful

### DIFF
--- a/cache/send_slack_alert_for_5xx_errors.js
+++ b/cache/send_slack_alert_for_5xx_errors.js
@@ -126,13 +126,18 @@ async function sendSlackMessage(bucket, key, serverErrors, hits) {
   //
   const url = `https://us-east-1.console.aws.amazon.com/s3/object/${bucket}?region=us-east-1&prefix=${key}`;
 
+  const errorCount = `${humanize(lines.length)} error${
+    lines.length > 1 ? 's' : ''
+  }`;
+  const requestCount = `${humanize(hits.length)} request${
+    hits.length > 1 ? 's' : ''
+  }`;
+
   const message =
     '```\n' +
     lines.join('\n') +
     '\n```' +
-    `\n${humanize(lines.length)} errors / ${humanize(
-      hits.length
-    )} requests / <${url}|logs in S3>`;
+    `\n${errorCount} / ${requestCount} / <${url}|logs in S3>`;
 
   const slackPayload = {
     username: `CloudFront: 5xx error${lines.length > 1 ? 's' : ''} detected`,

--- a/cache/send_slack_alert_for_5xx_errors.js
+++ b/cache/send_slack_alert_for_5xx_errors.js
@@ -107,7 +107,12 @@ async function sendSlackMessage(bucket, key, serverErrors, hits) {
     // will log this as '-'
     const query = e['cs-uri-query'] !== '-' ? e['cs-uri-query'] : null;
 
-    return createDisplayUrl(protocol, host, path, query);
+    const url = createDisplayUrl(protocol, host, path, query);
+    const status = e['sc-status'];
+
+    // We assume that most errors are generic 500 errors, but non-500 codes
+    // might be interesting and worth highlighting.
+    return status === 500 ? url : `${url} (${status})`;
   });
 
   // This creates a Markdown-formatted message like:

--- a/cache/send_slack_alert_for_5xx_errors.js
+++ b/cache/send_slack_alert_for_5xx_errors.js
@@ -117,12 +117,16 @@ async function sendSlackMessage(bucket, key, serverErrors, hits) {
 
   // This creates a Markdown-formatted message like:
   //
-  //    The following URLs had errors in CloudFront:
+  //    5 errors / 5K requests / <https://us-east-1…|logs in S3>
   //    ```
   //    https://example.org/badness
   //    https://example.org/more-badness
   //    ```
-  //    5 errors / 5K requests / <https://us-east-1…|logs in S3>
+  //
+  // Note: we put the summary message first so that if there are lots of lines with
+  // errors, the summary doesn't get truncated off the end.
+  //
+  // e.g. https://wellcome.slack.com/archives/CQ720BG02/p1659031456721909
   //
   const url = `https://us-east-1.console.aws.amazon.com/s3/object/${bucket}?region=us-east-1&prefix=${key}`;
 
@@ -134,10 +138,10 @@ async function sendSlackMessage(bucket, key, serverErrors, hits) {
   }`;
 
   const message =
+    `${errorCount} / ${requestCount} / <${url}|logs in S3>\n` +
     '```\n' +
     lines.join('\n') +
-    '\n```' +
-    `\n${errorCount} / ${requestCount} / <${url}|logs in S3>`;
+    '\n```';
 
   const slackPayload = {
     username: `CloudFront: 5xx error${lines.length > 1 ? 's' : ''} detected`,

--- a/cache/send_slack_alert_for_5xx_errors.js
+++ b/cache/send_slack_alert_for_5xx_errors.js
@@ -98,7 +98,7 @@ function humanize(n) {
  * to a public Slack channel, so we need to be a bit careful what we log.
  */
 async function sendSlackMessage(bucket, key, serverErrors, hits) {
-  const urls = serverErrors.map(function (e) {
+  const lines = serverErrors.map(function (e) {
     const protocol = e['cs-protocol'];
     const host = e['x-host-header'];
     const path = e['cs-uri-stem'];
@@ -125,17 +125,17 @@ async function sendSlackMessage(bucket, key, serverErrors, hits) {
   //    5 errors / 5K requests
   //
   const message =
-    'The following URLs had errors in CloudFront:\n```\n' +
-    urls.join('\n') +
+    '```\n' +
+    lines.join('\n') +
     '\n```' +
-    `\n${humanize(urls.length)} errors / ${humanize(hits.length)} requests`;
+    `\n${humanize(lines.length)} errors / ${humanize(hits.length)} requests`;
 
   // TODO: Include a link to the original CloudFront log in this message.
   // I tried including a Markdown link to the S3 console, but I got a 400 error
   // from Slack.
 
   const slackPayload = {
-    username: 'cloudfront-5xx-errors',
+    username: '5xx errors from CloudFront',
     icon_emoji: ':rotating_light:',
     attachments: [
       {

--- a/cache/send_slack_alert_for_5xx_errors.js
+++ b/cache/send_slack_alert_for_5xx_errors.js
@@ -122,20 +122,20 @@ async function sendSlackMessage(bucket, key, serverErrors, hits) {
   //    https://example.org/badness
   //    https://example.org/more-badness
   //    ```
-  //    5 errors / 5K requests
+  //    5 errors / 5K requests / <https://us-east-1…|logs in S3>
   //
+  const url = `https://us-east-1.console.aws.amazon.com/s3/object/${bucket}?region=us-east-1&prefix=${key}`;
+
   const message =
     '```\n' +
     lines.join('\n') +
     '\n```' +
-    `\n${humanize(lines.length)} errors / ${humanize(hits.length)} requests`;
-
-  // TODO: Include a link to the original CloudFront log in this message.
-  // I tried including a Markdown link to the S3 console, but I got a 400 error
-  // from Slack.
+    `\n${humanize(lines.length)} errors / ${humanize(
+      hits.length
+    )} requests / <${url}|logs in S3>`;
 
   const slackPayload = {
-    username: '5xx errors from CloudFront',
+    username: `CloudFront: 5xx error${lines.length > 1 ? 's' : ''} detected`,
     icon_emoji: ':rotating_light:',
     attachments: [
       {


### PR DESCRIPTION
## Who is this for?

Devs.

## What is it doing for them?

Trying to stave off alert fatigue.

* It now tells us what proportion of requests are errors, e.g. `5 errors / 5K requests`. This is useful in diagnosing the severity of an issue; 5/50 errors is much worse than 5/50M.
* It now includes the status code if it isn't 500.
* It now links to the raw CloudFront logs in S3, if we want to dig in further.