### PR TITLE
Start 'Read full transcript' button

### DIFF
--- a/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
+++ b/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
@@ -71,7 +71,7 @@ type Props = {
 const Stop: FC<{ stop: Stop }> = ({ stop }) => {
   const { isEnhanced } = useContext(AppContext);
   const hasShowFullTranscriptionButton =
-    (stop.transcription?.length || 0 > 1) && isEnhanced;
+    (stop.transcription?.length || 0) > 1 && isEnhanced; // We only show the button if there is more than one paragraph
   const transcriptionFirstParagraph = stop.transcription?.slice(0, 1);
   const [isFullTranscription, setIsFullTranscription] = useState(true);
   const [transcriptionText, setTranscriptionText] = useState(
@@ -104,16 +104,7 @@ const Stop: FC<{ stop: Stop }> = ({ stop }) => {
           {stop.image?.contentUrl && (
             <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
               <PrismicImageWrapper>
-                <PrismicImage
-                  image={{
-                    contentUrl: stop.image.contentUrl,
-                    width: stop.image.width,
-                    height: stop.image.height,
-                    alt: stop.image.alt,
-                  }}
-                  sizes={{}}
-                  quality={`low`}
-                />
+                <PrismicImage image={stop.image} sizes={{}} quality={`low`} />
               </PrismicImageWrapper>
             </Space>
           )}
@@ -124,9 +115,7 @@ const Stop: FC<{ stop: Stop }> = ({ stop }) => {
             <h3>Audio transcript</h3>
             <div id="transcription-text">
               <PrismicHtmlBlock
-                html={
-                  transcriptionText as [prismicT.RTNode, ...prismicT.RTNode[]]
-                }
+                html={transcriptionText as prismicT.RichTextField}
               />
             </div>
             {hasShowFullTranscriptionButton && (

--- a/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
+++ b/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
@@ -79,6 +79,8 @@ const Stop: FC<{ stop: Stop }> = ({ stop }) => {
   );
 
   useEffect(() => {
+    // Show full audio transcripts by default and hide them once we know
+    // JavaScript is available
     setIsFullTranscription(false);
   }, []);
 

--- a/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
+++ b/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
@@ -122,11 +122,13 @@ const Stop: FC<{ stop: Stop }> = ({ stop }) => {
         {transcriptionText && (
           <Transcription>
             <h3>Audio transcript</h3>
-            <PrismicHtmlBlock
-              html={
-                transcriptionText as [prismicT.RTNode, ...prismicT.RTNode[]]
-              }
-            />
+            <div id="transcription-text">
+              <PrismicHtmlBlock
+                html={
+                  transcriptionText as [prismicT.RTNode, ...prismicT.RTNode[]]
+                }
+              />
+            </div>
             {hasShowFullTranscriptionButton && (
               <ButtonOutlined
                 ariaControls="transcription-text"


### PR DESCRIPTION
Part of #8147

Adding a button to show more of an audio transcript.

- First paragraph will be shown and the rest revealed on click
- The button won't display if there's only one paragraph
- All paragraphs will be displayed initially and hidden when JS fires to ensure all text is always available

![image](https://user-images.githubusercontent.com/1394592/181243894-af078287-9637-4127-9fef-52a2ecbd02b5.png)

Styles are still tbd in #8147 – this PR is really only addressing the show/hide logic