### PR TITLE
Filter for "interesting" errors in the CloudFront logs

### DIFF
--- a/cache/send_slack_alert_for_5xx_errors.js
+++ b/cache/send_slack_alert_for_5xx_errors.js
@@ -276,6 +276,15 @@ function isInterestingError(hit) {
   // as a data-uri to requests.  This generates a noisy Slack log.
   //
   // We can't do anything about this, so ignore it.
+  //
+  // Note: we have to accommodate for the percent-encoding that happens
+  // in CloudFront logs:
+  //
+  //    > decodeURIComponent('%250A%2520')
+  //    "%0A%20"
+  //    > decodeURIComponent('%0A%20')
+  //    "\n"
+  //
   if (
     hit['sc-status'] === 503 &&
     hit['cs-uri-stem'].indexOf('%250A%2520') !== -1


### PR DESCRIPTION
It turns out sending a newline in your URI will cause API Gateway to return a 503 Bad Gateway error, but there's nothing we can do about that. Since _somebody_ is doing that by appending data-uri SVGs to their requests, it's spamming our Slack channel.

Make the bot not do that.

Because this is completely unhelpful:

<img width="698" alt="Screenshot 2022-08-01 at 09 31 17" src="https://user-images.githubusercontent.com/301220/182107374-96d929f8-42c1-43f3-8db3-28fd697c8fa1.png">

