### PR TITLE
Feat/exhibition guide UI

### DIFF
--- a/content/webapp/components/CardGrid/CardGrid.tsx
+++ b/content/webapp/components/CardGrid/CardGrid.tsx
@@ -13,6 +13,7 @@ import ExhibitionPromo from '../ExhibitionPromo/ExhibitionPromo';
 import StoryPromo from '../StoryPromo/StoryPromo';
 import DailyTourPromo from './DailyTourPromo';
 import { MultiContent } from '../../types/multi-content';
+import ExhibitionGuidePromo from '../ExhibitionGuidePromo/ExhibitionGuidePromo';
 
 type Props = {
   items: readonly MultiContent[];
@@ -64,6 +65,9 @@ const CardGrid: FunctionComponent<Props> = ({
                   position={i}
                   hidePromoText={hidePromoText}
                 />
+              )}
+              {item.type === 'exhibition-guides' && (
+                <ExhibitionGuidePromo exhibitionGuide={item} />
               )}
               {item.type === 'books' && <BookPromo book={item} />}
               {(item.type === 'pages' ||

--- a/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
+++ b/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
@@ -65,7 +65,7 @@ type Stop = {
 };
 
 type Props = {
-  stops: [Stop];
+  stops: Stop[];
 };
 
 const Stop: FC<{ stop: Stop }> = ({ stop }) => {

--- a/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
+++ b/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
@@ -71,8 +71,8 @@ type Props = {
 const Stop: FC<{ stop: Stop }> = ({ stop }) => {
   const { isEnhanced } = useContext(AppContext);
   const hasShowFullTranscriptionButton =
-    (stop.transcription?.length || 0) > 1 && isEnhanced; // We only show the button if there is more than one paragraph
-  const transcriptionFirstParagraph = stop.transcription?.slice(0, 1);
+    (stop[0].transcription?.length || 0) > 1 && isEnhanced; // We only show the button if there is more than one paragraph
+  const transcriptionFirstParagraph = stop[0].transcription?.slice(0, 1);
   const [isFullTranscription, setIsFullTranscription] = useState(true);
   const [transcriptionText, setTranscriptionText] = useState(
     transcriptionFirstParagraph
@@ -86,7 +86,7 @@ const Stop: FC<{ stop: Stop }> = ({ stop }) => {
 
   useEffect(() => {
     setTranscriptionText(
-      isFullTranscription ? stop.transcription : transcriptionFirstParagraph
+      isFullTranscription ? stop[0].transcription : transcriptionFirstParagraph
     );
   }, [isFullTranscription]);
 
@@ -97,20 +97,24 @@ const Stop: FC<{ stop: Stop }> = ({ stop }) => {
     >
       <TitleTombstone>
         <h2>
-          {stop.number}. {stop.title}
+          {stop[0].number}. {stop[0].title}
         </h2>
-        <em>{stop.tombstone}</em>
+        <em>{stop[0].tombstone.text}</em>
       </TitleTombstone>
       <CaptionTranscription>
         <Caption>
-          {stop.image?.contentUrl && (
+          {stop[0].image?.contentUrl && (
             <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
               <PrismicImageWrapper>
-                <PrismicImage image={stop.image} sizes={{}} quality={`low`} />
+                <PrismicImage
+                  image={stop[0].image}
+                  sizes={{}}
+                  quality={`low`}
+                />
               </PrismicImageWrapper>
             </Space>
           )}
-          <PrismicHtmlBlock html={stop.caption} />
+          <PrismicHtmlBlock html={stop[0].caption} />
         </Caption>
         {transcriptionText && (
           <Transcription>
@@ -145,7 +149,7 @@ const ExhibitionCaptions: FC<Props> = ({ stops }) => {
   return (
     <ul className="plain-list no-margin no-padding">
       {stops.map((stop, index) => (
-        <Stop key={index} stop={stop} />
+        <Stop key={index.toString()} stop={[stop]} />
       ))}
     </ul>
   );

--- a/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
+++ b/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
@@ -146,8 +146,8 @@ const Stop: FC<{ stop: Stop }> = ({ stop }) => {
 const ExhibitionCaptions: FC<Props> = ({ stops }) => {
   return (
     <ul className="plain-list no-margin no-padding">
-      {stops.map((stop: Stop, index) => (
-        <Stop key={index.toString()} stop={stop} />
+      {stops.map((stop, index) => (
+        <Stop key={index} stop={stop} />
       ))}
     </ul>
   );

--- a/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
+++ b/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
@@ -71,8 +71,8 @@ type Props = {
 const Stop: FC<{ stop: Stop }> = ({ stop }) => {
   const { isEnhanced } = useContext(AppContext);
   const hasShowFullTranscriptionButton =
-    (stop[0].transcription?.length || 0) > 1 && isEnhanced; // We only show the button if there is more than one paragraph
-  const transcriptionFirstParagraph = stop[0].transcription?.slice(0, 1);
+    (stop.transcription?.length || 0) > 1 && isEnhanced; // We only show the button if there is more than one paragraph
+  const transcriptionFirstParagraph = stop.transcription?.slice(0, 1);
   const [isFullTranscription, setIsFullTranscription] = useState(true);
   const [transcriptionText, setTranscriptionText] = useState(
     transcriptionFirstParagraph
@@ -86,7 +86,7 @@ const Stop: FC<{ stop: Stop }> = ({ stop }) => {
 
   useEffect(() => {
     setTranscriptionText(
-      isFullTranscription ? stop[0].transcription : transcriptionFirstParagraph
+      isFullTranscription ? stop.transcription : transcriptionFirstParagraph
     );
   }, [isFullTranscription]);
 
@@ -97,24 +97,20 @@ const Stop: FC<{ stop: Stop }> = ({ stop }) => {
     >
       <TitleTombstone>
         <h2>
-          {stop[0].number}. {stop[0].title}
+          {stop.number}. {stop.title}
         </h2>
-        <em>{stop[0].tombstone.text}</em>
+        <em>{stop.tombstone.text}</em>
       </TitleTombstone>
       <CaptionTranscription>
         <Caption>
-          {stop[0].image?.contentUrl && (
+          {stop.image?.contentUrl && (
             <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
               <PrismicImageWrapper>
-                <PrismicImage
-                  image={stop[0].image}
-                  sizes={{}}
-                  quality={`low`}
-                />
+                <PrismicImage image={stop.image} sizes={{}} quality={`low`} />
               </PrismicImageWrapper>
             </Space>
           )}
-          <PrismicHtmlBlock html={stop[0].caption} />
+          <PrismicHtmlBlock html={stop.caption} />
         </Caption>
         {transcriptionText && (
           <Transcription>
@@ -148,8 +144,8 @@ const Stop: FC<{ stop: Stop }> = ({ stop }) => {
 const ExhibitionCaptions: FC<Props> = ({ stops }) => {
   return (
     <ul className="plain-list no-margin no-padding">
-      {stops.map((stop, index) => (
-        <Stop key={index.toString()} stop={[stop]} />
+      {stops.map((stop: Stop, index) => (
+        <Stop key={index.toString()} stop={stop} />
       ))}
     </ul>
   );

--- a/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
+++ b/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
@@ -144,8 +144,8 @@ const Stop: FC<{ stop: Stop }> = ({ stop }) => {
 const ExhibitionCaptions: FC<Props> = ({ stops }) => {
   return (
     <ul className="plain-list no-margin no-padding">
-      {stops.map(stop => (
-        <Stop key={stop.number} stop={stop} />
+      {stops.map((stop, index) => (
+        <Stop key={index} stop={stop} />
       ))}
     </ul>
   );

--- a/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
+++ b/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
@@ -99,7 +99,9 @@ const Stop: FC<{ stop: Stop }> = ({ stop }) => {
         <h2>
           {stop.number}. {stop.title}
         </h2>
-        <em>{stop.tombstone.text}</em>
+        <em>
+          <PrismicHtmlBlock html={stop.tombstone} />
+        </em>
       </TitleTombstone>
       <CaptionTranscription>
         <Caption>

--- a/content/webapp/components/ExhibitionGuidePromo/ExhibitionGuidePromo.tsx
+++ b/content/webapp/components/ExhibitionGuidePromo/ExhibitionGuidePromo.tsx
@@ -1,13 +1,13 @@
 import { FC } from 'react';
 import { font, classNames } from '@weco/common/utils/classnames';
 import { trackEvent } from '@weco/common/utils/ga';
-import { ExhibitionGuide } from '../../types/exhibition-guides';
+import { ExhibitionGuideBasic } from '../../types/exhibition-guides';
 import Space from '@weco/common/views/components/styled/Space';
 import { CardOuter, CardBody } from '../Card/Card';
 import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImage';
 
 type Props = {
-  exhibitionGuide: ExhibitionGuide;
+  exhibitionGuide: ExhibitionGuideBasic;
 };
 
 const ExhibitionGuidePromo: FC<Props> = ({ exhibitionGuide }) => {

--- a/content/webapp/components/ExhibitionGuidePromo/ExhibitionGuidePromo.tsx
+++ b/content/webapp/components/ExhibitionGuidePromo/ExhibitionGuidePromo.tsx
@@ -20,7 +20,7 @@ const ExhibitionGuidePromo: FC<Props> = ({ exhibitionGuide }) => {
       }
       onClick={() => {
         trackEvent({
-          category: 'ExhibitionGuideBasic',
+          category: 'ExhibitionGuide',
           action: 'follow link',
           label: `${exhibitionGuide.id}`,
         });

--- a/content/webapp/components/ExhibitionGuidePromo/ExhibitionGuidePromo.tsx
+++ b/content/webapp/components/ExhibitionGuidePromo/ExhibitionGuidePromo.tsx
@@ -1,13 +1,13 @@
 import { FC } from 'react';
 import { font, classNames } from '@weco/common/utils/classnames';
 import { trackEvent } from '@weco/common/utils/ga';
-import { ExhibitionGuideBasic } from '../../types/exhibition-guides';
+import { ExhibitionGuide } from '../../types/exhibition-guides';
 import Space from '@weco/common/views/components/styled/Space';
 import { CardOuter, CardBody } from '../Card/Card';
 import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImage';
 
 type Props = {
-  exhibitionGuide: ExhibitionGuideBasic;
+  exhibitionGuide: ExhibitionGuide;
 };
 
 const ExhibitionGuidePromo: FC<Props> = ({ exhibitionGuide }) => {

--- a/content/webapp/components/ExhibitionGuidePromo/ExhibitionGuidePromo.tsx
+++ b/content/webapp/components/ExhibitionGuidePromo/ExhibitionGuidePromo.tsx
@@ -1,0 +1,83 @@
+import { FC } from 'react';
+import { font, classNames } from '@weco/common/utils/classnames';
+import { trackEvent } from '@weco/common/utils/ga';
+import { ExhibitionGuideBasic } from '../../types/exhibition-guides';
+import Space from '@weco/common/views/components/styled/Space';
+import { CardOuter, CardBody } from '../Card/Card';
+import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImage';
+
+type Props = {
+  exhibitionGuide: ExhibitionGuideBasic;
+};
+
+const ExhibitionGuidePromo: FC<Props> = ({ exhibitionGuide }) => {
+  return (
+    <CardOuter
+      data-component="ExhibitionGuidePromo"
+      href={
+        (exhibitionGuide.promo && exhibitionGuide.promo.link) ||
+        `/guides/exhibitions/${exhibitionGuide.id}`
+      }
+      onClick={() => {
+        trackEvent({
+          category: 'ExhibitionGuideBasic',
+          action: 'follow link',
+          label: `${exhibitionGuide.id}`,
+        });
+      }}
+    >
+      <div className="relative">
+        {exhibitionGuide.promo?.image && (
+          <PrismicImage
+            // We intentionally omit the alt text on promos, so screen reader
+            // users don't have to listen to the alt text before hearing the
+            // title of the item in the list.
+            image={{
+              ...exhibitionGuide.promo.image,
+              alt: '',
+            }}
+            sizes={{
+              xlarge: 1 / 4,
+              large: 1 / 3,
+              medium: 1 / 2,
+              small: 1,
+            }}
+            quality="low"
+          />
+        )}
+      </div>
+
+      <CardBody>
+        <div>
+          <Space
+            v={{
+              size: 's',
+              properties: ['margin-bottom'],
+            }}
+            as="h2"
+            className={classNames({
+              'promo-link__title': true,
+              [font('wb', 3)]: true,
+            })}
+          >
+            {exhibitionGuide.title}
+          </Space>
+          {exhibitionGuide.promo?.caption && (
+            <Space v={{ size: 's', properties: ['margin-top'] }}>
+              <p
+                className={classNames({
+                  [font('hnr', 5)]: true,
+                  'no-margin': true,
+                })}
+              >
+                {exhibitionGuide.promo?.caption}
+              </p>
+            </Space>
+          )}
+        </div>
+      </CardBody>
+    </CardOuter>
+  );
+};
+
+export default ExhibitionGuidePromo;

--- a/content/webapp/components/LayoutPaginatedResults/LayoutPaginatedResults.tsx
+++ b/content/webapp/components/LayoutPaginatedResults/LayoutPaginatedResults.tsx
@@ -17,14 +17,15 @@ import CardGrid from '../CardGrid/CardGrid';
 import { BookBasic } from '../../types/books';
 import { Guide } from '../../types/guides';
 import * as prismicT from '@prismicio/types';
-// import { ExhibitionGuideBasic } from '../../types/exhibition-guides';
+import { ExhibitionGuideBasic } from '../../types/exhibition-guides';
 
 type PaginatedResultsTypes =
   | PaginatedResults<ExhibitionBasic>
   | PaginatedResults<EventBasic>
   | PaginatedResults<BookBasic>
   | PaginatedResults<ArticleBasic>
-  | PaginatedResults<Guide>;
+  | PaginatedResults<Guide>
+  | PaginatedResults<ExhibitionGuideBasic>;
 
 type Props = {
   title: string;

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -33,7 +33,7 @@ export const getServerSideProps: (context) => Promise<
         exhibitionGuide: ExhibitionGuide;
         serverData: SimplifiedServerData;
       };
-    }
+    } // TODO: Fix type issues which stop this from being GetServerSideProps<Props | AppErrorProps>
 > = async context => {
   const serverData = await getServerData(context);
   const { id } = context.query; // TODO should we have another page template to handle type or do everything in here?

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -4,7 +4,7 @@ import { fetchExhibitionGuide } from '../services/prismic/fetch/exhibition-guide
 // import { transformQuery } from '../services/prismic/transformers/paginated-results';
 import { transformExhibitionGuide } from '../services/prismic/transformers/exhibition-guides';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { removeUndefinedProps } from '@weco/common/utils/json';
 import { getServerData } from '@weco/common/server-data';
 import { exhibitionGuideLd } from '../services/prismic/transformers/json-ld';

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -69,11 +69,13 @@ const ExhibitionGuidesPage: FC<Props> = props => {
     >
       <Layout10>
         <Space v={{ size: 'xl', properties: ['margin-top'] }}>
-          <h2>{exhibitionGuide.title || ''}</h2>
+          <h2>{exhibitionGuide.title}</h2>
         </Space>
         <Space v={{ size: 'xl', properties: ['margin-top'] }}>
           <h3>Introduction</h3>
-          <p>{exhibitionGuide.relatedExhibition?.description || ''}</p>
+          {exhibitionGuide.relatedExhibition && (
+            <p>{exhibitionGuide.relatedExhibition.description}</p>
+          )}
         </Space>
         <Space v={{ size: 'xl', properties: ['margin-top'] }}>
           <ExhibitionCaptions

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -33,7 +33,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       client,
       id as string
     );
-
+    console.log(JSON.stringify(exhibitionGuideDocument, null, 1), 'we fetch');
     if (exhibitionGuideDocument) {
       const exhibitionGuide = transformExhibitionGuide(exhibitionGuideDocument);
       const jsonLd = exhibitionGuideLd(exhibitionGuide);

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -5,66 +5,67 @@ import { fetchExhibitionGuide } from '../services/prismic/fetch/exhibition-guide
 import { transformExhibitionGuide } from '../services/prismic/transformers/exhibition-guides';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import React, { FC } from 'react';
-import { GetServerSideProps } from 'next';
-import { AppErrorProps } from '@weco/common/views/pages/_app';
+// import { GetServerSideProps } from 'next';
+// import { AppErrorProps } from '@weco/common/views/pages/_app';
 import { removeUndefinedProps } from '@weco/common/utils/json';
 import { getServerData } from '@weco/common/server-data';
 import { exhibitionGuideLd } from '../services/prismic/transformers/json-ld';
 import { pageDescriptions } from '@weco/common/data/microcopy';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 import { looksLikePrismicId } from '@weco/common/services/prismic';
-import { Page as PageType } from '../types/pages';
 import Layout10 from '@weco/common/views/components/Layout10/Layout10';
 import Space from '@weco/common/views/components/styled/Space';
 import ExhibitionCaptions from '../components/ExhibitionCaptions/ExhibitionCaptions';
+import { SimplifiedServerData } from '@weco/common/server-data/types';
 
 type Props = {
   exhibitionGuide: ExhibitionGuide;
   jsonLd: JsonLdObj;
-  pages: PageType[];
+  type: string; // TODO union - content type/guide format
   id: string;
-  // type: string; // TODO union - content type/guide format
 };
 
-export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
-  async context => {
-    const serverData = await getServerData(context);
-    const { id } = context.query; // TODO should we have another page template to handle type or do everything in here?
-    if (!looksLikePrismicId(id) || !serverData.toggles.exhibitionGuides) {
-      return { notFound: true };
-    }
-
-    const client = createClient(context);
-    const exhibitionGuideDocument = await fetchExhibitionGuide(
-      client,
-      id as string
-      // type
-    );
-    if (exhibitionGuideDocument) {
-      const exhibitionGuide = transformExhibitionGuide(exhibitionGuideDocument);
-
-      const jsonLd = exhibitionGuideLd(exhibitionGuide);
-
-      return {
-        props: removeUndefinedProps({
-          exhibitionGuide,
-          jsonLd,
-          serverData,
-        }),
+export const getServerSideProps: (context) => Promise<
+  | { notFound: boolean }
+  | {
+      props: {
+        jsonLd: JsonLdObj;
+        exhibitionGuide: ExhibitionGuide;
+        serverData: SimplifiedServerData;
       };
-    } else {
-      return { notFound: true };
     }
-  };
+> = async context => {
+  const serverData = await getServerData(context);
+  const { id } = context.query; // TODO should we have another page template to handle type or do everything in here?
+  if (!looksLikePrismicId(id) || !serverData.toggles.exhibitionGuides) {
+    return { notFound: true };
+  }
 
-const ExhibitionGuidesPage: FC<Props> = ({
-  exhibitionGuide,
-  jsonLd,
-  // type, // TODO keep content-types format in Prismic same as we do for Guides, Q. for PR
-}) => {
-  const pathname = `guides/exhibition/${exhibitionGuide.id}`; // TODO /id/content-type
-  const { components } = exhibitionGuide;
+  const client = createClient(context);
+  const exhibitionGuideDocument = await fetchExhibitionGuide(
+    client,
+    id as string
+  );
+  if (exhibitionGuideDocument) {
+    const exhibitionGuide = transformExhibitionGuide(exhibitionGuideDocument);
 
+    const jsonLd = exhibitionGuideLd(exhibitionGuide);
+
+    return {
+      props: removeUndefinedProps({
+        exhibitionGuide,
+        jsonLd,
+        serverData,
+      }),
+    };
+  } else {
+    return { notFound: true };
+  }
+};
+
+const ExhibitionGuidesPage: FC<Props> = props => {
+  const { exhibitionGuide, jsonLd, type, id } = props;
+  const pathname = `guides/exhibition/${id}/${type}`; // TODO /id/content-type
   return (
     <PageLayout
       title={exhibitionGuide.title || ''}
@@ -84,7 +85,9 @@ const ExhibitionGuidesPage: FC<Props> = ({
           <p>{exhibitionGuide.relatedExhibition?.description || ''}</p>
         </Space>
         <Space v={{ size: 'xl', properties: ['margin-top'] }}>
-          <ExhibitionCaptions stops={components}></ExhibitionCaptions>
+          <ExhibitionCaptions
+            stops={exhibitionGuide.components}
+          ></ExhibitionCaptions>
         </Space>
       </Layout10>
     </PageLayout>

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -5,8 +5,6 @@ import { fetchExhibitionGuide } from '../services/prismic/fetch/exhibition-guide
 import { transformExhibitionGuide } from '../services/prismic/transformers/exhibition-guides';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import React, { FC } from 'react';
-// import { GetServerSideProps } from 'next';
-// import { AppErrorProps } from '@weco/common/views/pages/_app';
 import { removeUndefinedProps } from '@weco/common/utils/json';
 import { getServerData } from '@weco/common/server-data';
 import { exhibitionGuideLd } from '../services/prismic/transformers/json-ld';
@@ -67,7 +65,7 @@ const ExhibitionGuidesPage: FC<Props> = props => {
       jsonLd={jsonLd}
       openGraphType={'website'}
       siteSection={'whats-on'}
-      image={undefined} // TODO, linked doc promo image, e.g. Exhibition image
+      image={exhibitionGuide.image || undefined}
     >
       <Layout10>
         <Space v={{ size: 'xl', properties: ['margin-top'] }}>

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -1,7 +1,4 @@
-import {
-  ExhibitionGuide,
-  ExhibitionGuideFormat,
-} from '../types/exhibition-guides';
+import { ExhibitionGuide } from '../types/exhibition-guides';
 import { createClient } from '../services/prismic/fetch';
 import { fetchExhibitionGuide } from '../services/prismic/fetch/exhibition-guides';
 // import { transformQuery } from '../services/prismic/transformers/paginated-results';
@@ -19,12 +16,13 @@ import { looksLikePrismicId } from '@weco/common/services/prismic';
 import { Page as PageType } from '../types/pages';
 import Layout10 from '@weco/common/views/components/Layout10/Layout10';
 import Space from '@weco/common/views/components/styled/Space';
+import ExhibitionCaptions from '../components/ExhibitionCaptions/ExhibitionCaptions';
 
 type Props = {
   exhibitionGuide: ExhibitionGuide;
   jsonLd: JsonLdObj;
   pages: PageType[];
-  format: ExhibitionGuideFormat[];
+  id: string;
   // type: string; // TODO union - content type/guide format
 };
 
@@ -40,22 +38,17 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     const exhibitionGuideDocument = await fetchExhibitionGuide(
       client,
       id as string
+      // type
     );
     if (exhibitionGuideDocument) {
       const exhibitionGuide = transformExhibitionGuide(exhibitionGuideDocument);
 
       const jsonLd = exhibitionGuideLd(exhibitionGuide);
-      const format =
-        'audio-with-description' |
-        'audio-without-description' |
-        'bsl-video' |
-        'transcript';
 
       return {
         props: removeUndefinedProps({
           exhibitionGuide,
           jsonLd,
-          format,
           serverData,
         }),
       };
@@ -67,10 +60,9 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
 const ExhibitionGuidesPage: FC<Props> = ({
   exhibitionGuide,
   jsonLd,
-  format,
   // type, // TODO keep content-types format in Prismic same as we do for Guides, Q. for PR
 }) => {
-  const pathname = `guides/exhibition/${exhibitionGuide.id}/${format}`; // TODO /id/content-type
+  const pathname = `guides/exhibition/${exhibitionGuide.id}`; // TODO /id/content-type
   const { components } = exhibitionGuide;
 
   return (
@@ -87,11 +79,12 @@ const ExhibitionGuidesPage: FC<Props> = ({
         <Space v={{ size: 'xl', properties: ['margin-top'] }}>
           <h2>{exhibitionGuide.title || ''}</h2>
         </Space>
-        <h3>{exhibitionGuide.relatedExhibition?.promo?.caption || ''}</h3>
         <Space v={{ size: 'xl', properties: ['margin-top'] }}>
-          {components.map((stop, index) => (
-            <p key={index}>{stop.title}</p>
-          ))}
+          <h3>Introduction</h3>
+          <p>{exhibitionGuide.relatedExhibition?.description || ''}</p>
+        </Space>
+        <Space v={{ size: 'xl', properties: ['margin-top'] }}>
+          <ExhibitionCaptions stops={components}></ExhibitionCaptions>
         </Space>
       </Layout10>
     </PageLayout>

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -9,7 +9,7 @@ import { transformExhibitionGuide } from '../services/prismic/transformers/exhib
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import React, { FC } from 'react';
 import { GetServerSideProps } from 'next';
-import { /* appError, */ AppErrorProps } from '@weco/common/views/pages/_app'; // TODO
+import { AppErrorProps } from '@weco/common/views/pages/_app';
 import { removeUndefinedProps } from '@weco/common/utils/json';
 import { getServerData } from '@weco/common/server-data';
 import { exhibitionGuideLd } from '../services/prismic/transformers/json-ld';

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -33,7 +33,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       client,
       id as string
     );
-    console.log(JSON.stringify(exhibitionGuideDocument, null, 1), 'we fetch');
+    // console.log(JSON.stringify(exhibitionGuideDocument, null, 1), 'we fetch');
     if (exhibitionGuideDocument) {
       const exhibitionGuide = transformExhibitionGuide(exhibitionGuideDocument);
       const jsonLd = exhibitionGuideLd(exhibitionGuide);

--- a/content/webapp/pages/exhibition-guides.tsx
+++ b/content/webapp/pages/exhibition-guides.tsx
@@ -40,7 +40,6 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
 
     const client = createClient(context);
     const exhibitionGuidesQuery = await fetchExhibitionGuides(client, { page });
-    console.log(exhibitionGuidesQuery, 'we fetch');
 
     const exhibitionGuides = transformQuery(
       exhibitionGuidesQuery,

--- a/content/webapp/pages/exhibition-guides.tsx
+++ b/content/webapp/pages/exhibition-guides.tsx
@@ -38,6 +38,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
 
     const client = createClient(context);
     const exhibitionGuidesQuery = await fetchExhibitionGuides(client, { page });
+    console.log(exhibitionGuidesQuery, 'we fetch');
 
     const exhibitionGuides = transformQuery(
       exhibitionGuidesQuery,
@@ -94,17 +95,8 @@ const ExhibitionGuidesPage: FC<Props> = props => {
             borderRadius: '6px',
           }}
         >
-          <details>
-            <summary>
-              {' '}
-              {/* eslint-disable-next-line no-restricted-syntax */}
-              {JSON.stringify(
-                exhibitionGuides.results[0].relatedExhibition?.title
-              )}
-            </summary>
-            {/* eslint-disable-next-line no-restricted-syntax */}
-            {JSON.stringify(exhibitionGuides.results[0], null, 1)}
-          </details>
+          {/* eslint-disable-next-line no-restricted-syntax */}
+          {JSON.stringify(exhibitionGuides.results[0], null, 1)}
         </code>
       </pre>
     </PageLayout>

--- a/content/webapp/pages/exhibition-guides.tsx
+++ b/content/webapp/pages/exhibition-guides.tsx
@@ -17,6 +17,9 @@ import { exhibitionGuideLd } from '../services/prismic/transformers/json-ld';
 import { getPage } from '../utils/query-params';
 import { pageDescriptions } from '@weco/common/data/microcopy';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
+import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
+import CardGrid from '../components/CardGrid/CardGrid';
+// import LayoutPaginatedResults from '../components/LayoutPaginatedResults/LayoutPaginatedResults';
 
 type Props = {
   exhibitionGuides: PaginatedResults<ExhibitionGuideBasic>;
@@ -99,6 +102,24 @@ const ExhibitionGuidesPage: FC<Props> = props => {
           {JSON.stringify(exhibitionGuides.results[0], null, 1)}
         </code>
       </pre>
+      <SpacingSection>
+        <CardGrid items={exhibitionGuides.results} itemsPerRow={3} />
+      </SpacingSection>
+      {/* <SpacingSection> */}
+      {/*  <LayoutPaginatedResults */}
+      {/*    showFreeAdmissionMessage={false} */}
+      {/*    title={'Exhibition guides'} */}
+      {/*    description={[ */}
+      {/*      { */}
+      {/*        type: 'paragraph', */}
+      {/*        text: pageDescriptions.exhibitionGuides, */}
+      {/*        spans: [], */}
+      {/*      }, */}
+      {/*    ]} */}
+      {/*    paginatedResults={exhibitionGuides} */}
+      {/*    paginationRoot={'exhibition-guides'} */}
+      {/*  /> */}
+      {/* </SpacingSection> */}
     </PageLayout>
   );
 };

--- a/content/webapp/pages/exhibition-guides.tsx
+++ b/content/webapp/pages/exhibition-guides.tsx
@@ -18,8 +18,7 @@ import { getPage } from '../utils/query-params';
 import { pageDescriptions } from '@weco/common/data/microcopy';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
-import CardGrid from '../components/CardGrid/CardGrid';
-// import LayoutPaginatedResults from '../components/LayoutPaginatedResults/LayoutPaginatedResults';
+import LayoutPaginatedResults from '../components/LayoutPaginatedResults/LayoutPaginatedResults';
 
 type Props = {
   exhibitionGuides: PaginatedResults<ExhibitionGuideBasic>;
@@ -80,46 +79,14 @@ const ExhibitionGuidesPage: FC<Props> = props => {
       siteSection={'whats-on'}
       image={image}
     >
-      <p>EXHIBITION GUIDES</p>
-      <pre
-        style={{
-          maxWidth: '600px',
-          margin: '0 auto 24px',
-          fontSize: '14px',
-        }}
-      >
-        <code
-          style={{
-            display: 'block',
-            padding: '24px',
-            backgroundColor: '#EFE1AA',
-            color: '#000',
-            border: '4px solid #000',
-            borderRadius: '6px',
-          }}
-        >
-          {/* eslint-disable-next-line no-restricted-syntax */}
-          {JSON.stringify(exhibitionGuides.results[0], null, 1)}
-        </code>
-      </pre>
       <SpacingSection>
-        <CardGrid items={exhibitionGuides.results} itemsPerRow={3} />
+        <LayoutPaginatedResults
+          showFreeAdmissionMessage={false}
+          title={'Exhibition guides'}
+          paginatedResults={exhibitionGuides}
+          paginationRoot={'exhibition-guides'}
+        />
       </SpacingSection>
-      {/* <SpacingSection> */}
-      {/*  <LayoutPaginatedResults */}
-      {/*    showFreeAdmissionMessage={false} */}
-      {/*    title={'Exhibition guides'} */}
-      {/*    description={[ */}
-      {/*      { */}
-      {/*        type: 'paragraph', */}
-      {/*        text: pageDescriptions.exhibitionGuides, */}
-      {/*        spans: [], */}
-      {/*      }, */}
-      {/*    ]} */}
-      {/*    paginatedResults={exhibitionGuides} */}
-      {/*    paginationRoot={'exhibition-guides'} */}
-      {/*  /> */}
-      {/* </SpacingSection> */}
     </PageLayout>
   );
 };

--- a/content/webapp/services/prismic/transformers/exhibition-guides.test.ts
+++ b/content/webapp/services/prismic/transformers/exhibition-guides.test.ts
@@ -1,0 +1,338 @@
+import {
+  // constructHierarchy,
+  transformExhibitionGuide,
+} from './exhibition-guides';
+
+const exhibitionGuidesDoc = {
+  id: 'Ytk2IREAACcA--2o',
+  uid: null,
+  url: null,
+  type: 'exhibition-guides',
+  href: 'https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=https%3A%2F%2Fwellcomecollection.prismic.io%2Fpreviews%2FYuO9txAAACEAjTDB%3AYt_GRREAACcAGS6y%3FwebsitePreviewId%3DWUlQOSMAACMAnEL4&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22Ytk2IREAACcA--2o%22%29+%5D%5D',
+  tags: [],
+  first_publication_date: null,
+  last_publication_date: null,
+  slugs: ['-test----exhibition-guide'],
+  linked_documents: [],
+  lang: 'en-gb',
+  alternate_languages: [],
+  data: {
+    title: [
+      {
+        type: 'heading1',
+        text: '** Test ** - Exhibition guide',
+        spans: [],
+      },
+    ],
+    'related-exhibition': {
+      id: 'W300HykAACgAPp9y',
+      type: 'exhibitions',
+      tags: [],
+      lang: 'en-gb',
+      slug: 'from-atoms-to-patterns',
+      first_publication_date: '2018-09-25T12:12:51+0000',
+      last_publication_date: '2018-09-25T12:12:51+0000',
+      data: {
+        promo: [
+          {
+            primary: {
+              caption: [
+                {
+                  type: 'paragraph',
+                  text: 'This exhibition explored the intriguing creations of the Festival Pattern Group – a unique project at the 1951 Festival of Britain involving X-ray crystallographers, designers and manufacturers. ',
+                  spans: [],
+                },
+              ],
+              image: {
+                dimensions: {
+                  width: 4000,
+                  height: 2250,
+                },
+                alt: 'Photograph of the exhibition From Atoms to Patterns at Wellcome Collection.',
+                copyright:
+                  'From Atoms to Patterns exhibition  | Richard Hall | Wellcome Collection | | CC-BY-NC | |',
+                url: 'https://images.prismic.io/wellcomecollection/19f7c256c3a6dbc0b107cf4eb79a17c4f640cf5b_c0045969.jpg?auto=compress,format',
+                '16:9': {
+                  dimensions: {
+                    width: 3200,
+                    height: 1800,
+                  },
+                  alt: 'Photograph of the exhibition From Atoms to Patterns at Wellcome Collection.',
+                  copyright:
+                    'From Atoms to Patterns exhibition  | Richard Hall | Wellcome Collection | | CC-BY-NC | |',
+                  url: 'https://images.prismic.io/wellcomecollection/d05ebc48b5fdf66c5330af2c709ff99db6ca4b62_c0045969.jpg?auto=compress,format',
+                },
+                '32:15': {
+                  dimensions: {
+                    width: 3200,
+                    height: 1500,
+                  },
+                  alt: 'Photograph of the exhibition From Atoms to Patterns at Wellcome Collection.',
+                  copyright:
+                    'From Atoms to Patterns exhibition  | Richard Hall | Wellcome Collection | | CC-BY-NC | |',
+                  url: 'https://images.prismic.io/wellcomecollection/0b109e7132f1c731865f4f45dd05d4f4f63b1a5e_c0045969.jpg?auto=compress,format',
+                },
+                square: {
+                  dimensions: {
+                    width: 3200,
+                    height: 3200,
+                  },
+                  alt: 'Photograph of the exhibition From Atoms to Patterns at Wellcome Collection.',
+                  copyright:
+                    'From Atoms to Patterns exhibition  | Richard Hall | Wellcome Collection | | CC-BY-NC | |',
+                  url: 'https://images.prismic.io/wellcomecollection/a5b66ac5f0698e239e356912d9a505d2bb7c83f7_c0045969.jpg?auto=compress,format',
+                },
+              },
+              link: null,
+            },
+            items: [],
+            slice_type: 'editorialImage',
+            slice_label: null,
+          },
+        ],
+        title: [
+          {
+            type: 'heading1',
+            text: 'From Atoms to Patterns',
+            spans: [],
+          },
+        ],
+      },
+      link_type: 'Document',
+      isBroken: false,
+    },
+    components: [
+      {
+        number: null,
+        title: [
+          {
+            type: 'heading1',
+            text: 'Introduction and orientation',
+            spans: [],
+          },
+        ],
+        tombstone: [
+          {
+            type: 'paragraph',
+            text: 'Ravi Ravioli, 2007, ',
+            spans: [],
+          },
+        ],
+        image: {
+          '32:15': {},
+          '16:9': {},
+          square: {},
+        },
+        description: [
+          {
+            type: 'paragraph',
+            text: 'This copy will contain the description for the Introduction and orientation.',
+            spans: [],
+          },
+        ],
+        'audio-with-description': {
+          link_type: 'Media',
+        },
+        'audio-without-description': {
+          link_type: 'Media',
+        },
+        'bsl-video': {},
+        caption: [
+          {
+            type: 'paragraph',
+            text: 'This would be the caption for Introduction and orientation.',
+            spans: [],
+          },
+        ],
+        transcript: [
+          {
+            type: 'paragraph',
+            text: 'This would be the transcript for Introduction and orientation.',
+            spans: [],
+          },
+        ],
+      },
+      {
+        number: null,
+        title: [
+          {
+            type: 'heading1',
+            text: 'Projection and Fear',
+            spans: [],
+          },
+        ],
+        tombstone: [],
+        image: {
+          '32:15': {},
+          '16:9': {},
+          square: {},
+        },
+        description: [
+          {
+            type: 'paragraph',
+            text: 'This copy will contain the description for Project and Fear.',
+            spans: [],
+          },
+        ],
+        'audio-with-description': {
+          link_type: 'Media',
+        },
+        'audio-without-description': {
+          link_type: 'Media',
+        },
+        'bsl-video': {},
+        caption: [
+          {
+            type: 'paragraph',
+            text: 'This would be the caption for Projection and Fear.',
+            spans: [],
+          },
+        ],
+        transcript: [
+          {
+            type: 'paragraph',
+            text: 'This would be the transcript for Projection and Fear.',
+            spans: [],
+          },
+        ],
+      },
+    ],
+  },
+};
+
+describe('transformExhibitionGuide', () => {
+  it('sets a description on the exhibition guide from the related exhibition', () => {
+    const exhibition = transformExhibitionGuide(exhibitionGuidesDoc);
+
+    expect(exhibition.relatedExhibition?.description).toBe(
+      'This exhibition explored the intriguing creations of the Festival Pattern Group – a unique project at the 1951 Festival of Britain involving X-ray crystallographers, designers and manufacturers.'
+    );
+  });
+});
+
+// const componentsWithPartOf = [
+//   {
+//     title: 'Section One',
+//     partOf: undefined,
+//   },
+//   { title: 'Stop One', partOf: 'Section One' },
+//
+//   { title: 'Stop Two', partOf: 'Section One' },
+//   {
+//     title: 'Sub Section One',
+//     partOf: 'Section One',
+//   },
+//   { title: 'Stop Three', partOf: 'Sub Section One' },
+//   { title: 'Stop Four', partOf: 'Sub Section One' },
+//   {
+//     title: 'Sub Sub Section One',
+//     partOf: 'Sub Section One',
+//   },
+//   { title: 'Stop Five', partOf: 'Sub Sub Section One' },
+//   { title: 'Stop Six', partOf: 'Sub Sub Section One' },
+//   {
+//     title: 'Sub Section Two',
+//     partOf: 'Section One',
+//   },
+//   { title: 'Stop Seven', partOf: 'Sub Section Two' },
+//   { title: 'Stop Eight', partOf: 'Section One' },
+// ];
+//
+// const componentsWithoutPartOf = [
+//   {
+//     title: 'Section One',
+//   },
+//   { title: 'Stop One' },
+//
+//   { title: 'Stop Two' },
+//   {
+//     title: 'Sub Section One',
+//   },
+//   { title: 'Stop Three' },
+//   { title: 'Stop Four' },
+//   {
+//     title: 'Sub Sub Section One',
+//   },
+//   { title: 'Stop Five' },
+//   { title: 'Stop Six' },
+//   {
+//     title: 'Sub Section Two',
+//   },
+//   { title: 'Stop Seven' },
+//   { title: 'Stop Eight' },
+// ];
+//
+// // TODO add some more tests with different data scenarios
+// describe('constructHierarchy', () => {
+//   it('returns a hierachy of components, based on their partOf and title properties', () => {
+//     expect(constructHierarchy(componentsWithPartOf)).toEqual([
+//       {
+//         title: 'Section One',
+//         parts: [
+//           { title: 'Stop One' },
+//           { title: 'Stop Two' },
+//           {
+//             title: 'Sub Section One',
+//             parts: [
+//               { title: 'Stop Three' },
+//               { title: 'Stop Four' },
+//               {
+//                 title: 'Sub Sub Section One',
+//                 parts: [{ title: 'Stop Five' }, { title: 'Stop Six' }],
+//               },
+//             ],
+//           },
+//           {
+//             title: 'Sub Section Two',
+//             parts: [{ title: 'Stop Seven' }],
+//           },
+//           { title: 'Stop Eight' },
+//         ],
+//       },
+//     ]);
+//   });
+//
+//   // TODO If nothing has a partOf, at present there is no nesting, is this the expected behaviour or should we make it so that everything is nested under first component? - that might make life easier for the editors, if an exhibition has a pretty flat structure
+//   it('returns a flat list, if no components have partOf data', () => {
+//     expect(constructHierarchy(componentsWithoutPartOf)).toEqual([
+//       {
+//         title: 'Section One',
+//       },
+//       {
+//         title: 'Stop One',
+//       },
+//       {
+//         title: 'Stop Two',
+//       },
+//       {
+//         title: 'Sub Section One',
+//       },
+//       {
+//         title: 'Stop Three',
+//       },
+//       {
+//         title: 'Stop Four',
+//       },
+//       {
+//         title: 'Sub Sub Section One',
+//       },
+//       {
+//         title: 'Stop Five',
+//       },
+//       {
+//         title: 'Stop Six',
+//       },
+//       {
+//         title: 'Sub Section Two',
+//       },
+//       {
+//         title: 'Stop Seven',
+//       },
+//       {
+//         title: 'Stop Eight',
+//       },
+//     ]);
+//   });
+//
+//   // TODO if partOfs are out of order, the order within each level is based on the order of the original component list
+// });

--- a/content/webapp/services/prismic/transformers/exhibition-guides.test.ts
+++ b/content/webapp/services/prismic/transformers/exhibition-guides.test.ts
@@ -202,11 +202,19 @@ const exhibitionGuidesDoc = {
 
 describe('transformExhibitionGuide', () => {
   it('sets a description on the exhibition guide from the related exhibition', () => {
-    const exhibition = transformExhibitionGuide(exhibitionGuidesDoc);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const exhibition = transformExhibitionGuide(exhibitionGuidesDoc as any);
 
     expect(exhibition.relatedExhibition?.description).toBe(
       'This exhibition explored the intriguing creations of the Festival Pattern Group – a unique project at the 1951 Festival of Britain involving X-ray crystallographers, designers and manufacturers.'
     );
+  });
+
+  it('returns a set of components', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const exhibition = transformExhibitionGuide(exhibitionGuidesDoc as any);
+    console.log(exhibition.components.length, 'the exhibition');
+    expect(exhibition.components.length).toBe(2);
   });
 });
 

--- a/content/webapp/services/prismic/transformers/exhibition-guides.ts
+++ b/content/webapp/services/prismic/transformers/exhibition-guides.ts
@@ -9,6 +9,51 @@ import { ExhibitionGuidePrismicDocument } from '../types/exhibition-guides';
 import { isFilledLinkToDocumentWithData } from '@weco/common/services/prismic/types';
 import { transformImagePromo } from './images';
 
+// TODO It's likely that we will need to construct a hierarchy of components within a guide.
+// For example, to facilitate collapsing sections in the UI.
+// With the addition of a partOf field to the model, as has previously been discussed,
+// this function will generate the necessary structure.
+// It relies on there being a top level component with no partOf assigned to it.
+
+// export function constructHierarchy(components) {
+//   // TODO type function return
+//   const groupedSections = groupBy(components, component => {
+//     const partOf = component.partOf;
+//     if (!partOf) {
+//       return 'Guide';
+//     }
+//     return partOf;
+//   });
+//   const levels = Object.keys(groupedSections).length;
+//   for (let level = 0; level < levels; level++) {
+//     for (const [key, value] of Object.entries(groupedSections)) {
+//       const itemsWithParts = value.map(item => {
+//         const { partOf, ...restOfItem } = item;
+//         const parts = groupedSections[item.title];
+//         if (parts) {
+//           return {
+//             ...restOfItem,
+//             parts: groupedSections[item.title],
+//           };
+//         } else {
+//           return restOfItem;
+//         }
+//       });
+//       groupedSections[key] = itemsWithParts;
+//     }
+//   }
+
+//   return groupedSections?.['Guide'];
+// }
+
+// const componentsKeys = Object.keys(components);
+//
+// const filterByGuide = components.filter(value => {
+//   return components[value].caption;
+// });
+//
+// TODO: Filters for guide types
+
 export function transformExhibitionGuideToExhibitionGuideBasic(
   exhibitionGuide: ExhibitionGuide
 ): ExhibitionGuideBasic {
@@ -69,14 +114,6 @@ export function transformExhibitionGuide(
       };
     }
   );
-
-  // const componentsKeys = Object.keys(components);
-  //
-  // const filterByGuide = components.filter(value => {
-  //   return components[value].caption;
-  // });
-  //
-  // TODO: Filters for guide types
 
   const promo =
     (data['related-exhibition'].data.promo &&

--- a/content/webapp/services/prismic/transformers/exhibition-guides.ts
+++ b/content/webapp/services/prismic/transformers/exhibition-guides.ts
@@ -41,14 +41,6 @@ export function transformExhibitionGuideToExhibitionGuideBasic(
   }))(exhibitionGuide);
 }
 
-// export function filterByExhibitionGuideFormat(document) {
-//   const { data } = document;
-//   const componentFormat = data.components?.filter(
-//     component => component.caption
-//   );
-//   return componentFormat;
-// }
-
 function transformRelatedExhibition(exhibition): ExhibitionLink {
   return {
     id: exhibition.id,
@@ -70,12 +62,11 @@ export function transformExhibitionGuide(
   relatedExhibition: ExhibitionLink | undefined;
 } {
   const { data } = document;
-  // const genericFields = transformGenericFields(document);
-  // console.log(filterByExhibitionGuideFormat(data), 'can i have a filter');
+
   const components: ExhibitionGuideComponent[] = data.components?.map(
-    component => {
+    (component, index) => {
       return {
-        number: Math.round(Math.random() * 10000000),
+        number: index.toString(),
         title: (component.title && asText(component.title)) || [],
         tombstone:
           (component.tombstone && asRichText(component.tombstone)) || [],
@@ -98,7 +89,7 @@ export function transformExhibitionGuide(
   //   return components[value].caption;
   // });
   //
-  // console.log(filterByGuide, 'let us have filters');
+  // TODO: Filters for guide types
 
   const promo =
     (data['related-exhibition'].data.promo &&

--- a/content/webapp/services/prismic/transformers/exhibition-guides.ts
+++ b/content/webapp/services/prismic/transformers/exhibition-guides.ts
@@ -22,6 +22,10 @@ export function transformExhibitionGuideToExhibitionGuideBasic(
     promo,
     relatedExhibition,
     components,
+    start,
+    isPermanent,
+    contributors,
+    labels,
   }) => ({
     type,
     id,
@@ -30,6 +34,10 @@ export function transformExhibitionGuideToExhibitionGuideBasic(
     promo,
     relatedExhibition,
     components,
+    start,
+    isPermanent,
+    contributors,
+    labels,
   }))(exhibitionGuide);
 }
 

--- a/content/webapp/services/prismic/transformers/exhibition-guides.ts
+++ b/content/webapp/services/prismic/transformers/exhibition-guides.ts
@@ -2,13 +2,12 @@ import {
   ExhibitionGuide,
   ExhibitionGuideBasic,
   ExhibitionGuideComponent,
-  ExhibitionLink,
+  Exhibit,
 } from '../../../types/exhibition-guides';
 import { asRichText, asText } from '.';
 import { ExhibitionGuidePrismicDocument } from '../types/exhibition-guides';
 import { isFilledLinkToDocumentWithData } from '@weco/common/services/prismic/types';
 import { transformImagePromo } from './images';
-import { ImagePromo } from '../../../types/image-promo';
 
 export function transformExhibitionGuideToExhibitionGuideBasic(
   exhibitionGuide: ExhibitionGuide
@@ -22,10 +21,6 @@ export function transformExhibitionGuideToExhibitionGuideBasic(
     promo,
     relatedExhibition,
     components,
-    start,
-    isPermanent,
-    contributors,
-    labels,
   }) => ({
     type,
     id,
@@ -34,15 +29,13 @@ export function transformExhibitionGuideToExhibitionGuideBasic(
     promo,
     relatedExhibition,
     components,
-    start,
-    isPermanent,
-    contributors,
-    labels,
   }))(exhibitionGuide);
 }
 
-function transformRelatedExhibition(exhibition): ExhibitionLink {
+function transformRelatedExhibition(exhibition): Exhibit {
   return {
+    exhibitType: 'exhibitions',
+    item: undefined,
     id: exhibition.id,
     title: (exhibition.data && asText(exhibition.data.title)) || '',
     description:
@@ -53,14 +46,7 @@ function transformRelatedExhibition(exhibition): ExhibitionLink {
 
 export function transformExhibitionGuide(
   document: ExhibitionGuidePrismicDocument
-): {
-  promo: ImagePromo | string;
-  components: ExhibitionGuideComponent[];
-  id: string;
-  title: string | undefined;
-  type: string;
-  relatedExhibition: ExhibitionLink | undefined;
-} {
+): ExhibitionGuide {
   const { data } = document;
 
   const components: ExhibitionGuideComponent[] = data.components?.map(
@@ -103,11 +89,11 @@ export function transformExhibitionGuide(
     : undefined;
 
   return {
-    title: asText(document.data?.title),
+    type: 'exhibition-guides',
+    title: asText(document.data?.title) || '',
     promo,
     relatedExhibition,
     components,
     id: document.id,
-    type: 'exhibition-guides',
   };
 }

--- a/content/webapp/services/prismic/transformers/exhibition-guides.ts
+++ b/content/webapp/services/prismic/transformers/exhibition-guides.ts
@@ -52,7 +52,7 @@ export function transformExhibitionGuide(
   const components: ExhibitionGuideComponent[] = data.components?.map(
     (component, index) => {
       return {
-        number: index.toString(),
+        number: index.toString(), // TODO: Remove once Prismic UI allows us to add number
         title: (component.title && asText(component.title)) || [],
         tombstone:
           (component.tombstone && asRichText(component.tombstone)) || [],

--- a/content/webapp/services/prismic/transformers/exhibition-guides.ts
+++ b/content/webapp/services/prismic/transformers/exhibition-guides.ts
@@ -4,18 +4,29 @@ import {
   ExhibitionGuideComponent,
   ExhibitionLink,
 } from '../../../types/exhibition-guides';
-import { ExhibitionGuidePrismicDocument } from '../types/exhibition-guides';
 import { asRichText, asText } from '.';
+import { ExhibitionGuidePrismicDocument } from '../types/exhibition-guides';
 import { isFilledLinkToDocumentWithData } from '@weco/common/services/prismic/types';
+import { transformImagePromo } from './images';
 
 export function transformExhibitionGuideToExhibitionGuideBasic(
   exhibitionGuide: ExhibitionGuide
 ): ExhibitionGuideBasic {
   // returns what is required to render StoryPromos and story JSON-LD
-  return (({ type, id, title, relatedExhibition, components }) => ({
+  return (({
     type,
     id,
     title,
+    image,
+    promo,
+    relatedExhibition,
+    components,
+  }) => ({
+    type,
+    id,
+    title,
+    image,
+    promo,
     relatedExhibition,
     components,
   }))(exhibitionGuide);
@@ -33,7 +44,14 @@ function transformRelatedExhibition(exhibition): ExhibitionLink {
 
 export function transformExhibitionGuide(
   document: ExhibitionGuidePrismicDocument
-): ExhibitionGuide {
+): {
+  promo: ImagePromo | string;
+  components: ExhibitionGuideComponent[];
+  id: string;
+  title: string | undefined;
+  type: string;
+  relatedExhibition: ExhibitionLink | undefined;
+} {
   const { data } = document;
   // const genericFields = transformGenericFields(document);
 
@@ -57,6 +75,11 @@ export function transformExhibitionGuide(
     }
   );
 
+  const promo =
+    (data['related-exhibition'].data.promo &&
+      transformImagePromo(data['related-exhibition'].data.promo)) ||
+    '';
+
   const relatedExhibition = isFilledLinkToDocumentWithData(
     data['related-exhibition']
   )
@@ -65,6 +88,7 @@ export function transformExhibitionGuide(
 
   return {
     title: asText(document.data?.title),
+    promo,
     relatedExhibition,
     components,
     id: document.id,

--- a/content/webapp/services/prismic/transformers/exhibition-guides.ts
+++ b/content/webapp/services/prismic/transformers/exhibition-guides.ts
@@ -8,6 +8,7 @@ import { asRichText, asText } from '.';
 import { ExhibitionGuidePrismicDocument } from '../types/exhibition-guides';
 import { isFilledLinkToDocumentWithData } from '@weco/common/services/prismic/types';
 import { transformImagePromo } from './images';
+import { ImagePromo } from '../../../types/image-promo';
 
 export function transformExhibitionGuideToExhibitionGuideBasic(
   exhibitionGuide: ExhibitionGuide
@@ -32,6 +33,14 @@ export function transformExhibitionGuideToExhibitionGuideBasic(
   }))(exhibitionGuide);
 }
 
+// export function filterByExhibitionGuideFormat(document) {
+//   const { data } = document;
+//   const componentFormat = data.components?.filter(
+//     component => component.caption
+//   );
+//   return componentFormat;
+// }
+
 function transformRelatedExhibition(exhibition): ExhibitionLink {
   return {
     id: exhibition.id,
@@ -54,11 +63,11 @@ export function transformExhibitionGuide(
 } {
   const { data } = document;
   // const genericFields = transformGenericFields(document);
-
+  // console.log(filterByExhibitionGuideFormat(data), 'can i have a filter');
   const components: ExhibitionGuideComponent[] = data.components?.map(
     component => {
       return {
-        number: component.number || [],
+        number: Math.round(Math.random() * 10000000),
         title: (component.title && asText(component.title)) || [],
         tombstone:
           (component.tombstone && asRichText(component.tombstone)) || [],
@@ -66,7 +75,7 @@ export function transformExhibitionGuide(
         description:
           (component.description && asRichText(component.description)) || [],
         caption: (component.caption && asRichText(component.caption)) || [],
-        transcript:
+        transcription:
           (component.transcript && asRichText(component.transcript)) || [],
         audioWithDescription: component['audio-with-description'],
         audioWithoutDescription: component['audio-without-description'],
@@ -74,6 +83,14 @@ export function transformExhibitionGuide(
       };
     }
   );
+
+  // const componentsKeys = Object.keys(components);
+  //
+  // const filterByGuide = components.filter(value => {
+  //   return components[value].caption;
+  // });
+  //
+  // console.log(filterByGuide, 'let us have filters');
 
   const promo =
     (data['related-exhibition'].data.promo &&

--- a/content/webapp/services/prismic/transformers/exhibition-guides.ts
+++ b/content/webapp/services/prismic/transformers/exhibition-guides.ts
@@ -4,7 +4,7 @@ import {
   ExhibitionGuideComponent,
   Exhibit,
 } from '../../../types/exhibition-guides';
-import { asRichText, asText } from '.';
+import { asRichText, asText, transformGenericFields } from '.';
 import { ExhibitionGuidePrismicDocument } from '../types/exhibition-guides';
 import { isFilledLinkToDocumentWithData } from '@weco/common/services/prismic/types';
 import { transformImagePromo } from './images';
@@ -47,6 +47,7 @@ function transformRelatedExhibition(exhibition): Exhibit {
 export function transformExhibitionGuide(
   document: ExhibitionGuidePrismicDocument
 ): ExhibitionGuide {
+  const genericFields = transformGenericFields(document);
   const { data } = document;
 
   const components: ExhibitionGuideComponent[] = data.components?.map(
@@ -89,6 +90,7 @@ export function transformExhibitionGuide(
     : undefined;
 
   return {
+    ...genericFields,
     type: 'exhibition-guides',
     title: asText(document.data?.title) || '',
     promo,

--- a/content/webapp/services/prismic/transformers/json-ld.ts
+++ b/content/webapp/services/prismic/transformers/json-ld.ts
@@ -15,17 +15,28 @@ import { Exhibition } from '../../../types/exhibitions';
 import { ExhibitionGuide } from '../../../types/exhibition-guides';
 import { linkResolver } from '@weco/common/services/prismic/link-resolver';
 
+// Guide from schema.org
+// https://schema.org/Guide
+// {
+//   "@context": "https://schema.org",
+//   "@type": "Guide",
+//   "about": "Hiking Boots",
+//   "name": "How to Choose Hiking Boots",
+//   "text": "Choosing the right hiking boots is a matchmaking process. Your dream hiking boots need to sync with how and where you hike. ...",
+//   "reviewAspect": [
+//   "Types",
+//   "Components",
+//   "Fit"
+// ]
+// }
 export function exhibitionGuideLd(exhibitionGuide: ExhibitionGuide): JsonLdObj {
   return objToJsonLd(
     {
+      '@type': 'Guide',
+      about: exhibitionGuide.title,
       name: exhibitionGuide.title,
-      description: exhibitionGuide.relatedExhibition?.description,
-      location: {
-        '@type': 'Place',
-        name: 'Wellcome Collection',
-        address: objToJsonLd(wellcomeCollectionAddress, 'PostalAddress', false),
-      },
-      url: `https://wellcomecollection.org/guides/exhibition/${exhibitionGuide.id}`,
+      text: exhibitionGuide.relatedExhibition?.description,
+      discussionUrl: `https://wellcomecollection.org/guides/exhibition/${exhibitionGuide.id}`,
     },
     'ExhibtionGuide'
   );

--- a/content/webapp/services/prismic/types/exhibition-guides.ts
+++ b/content/webapp/services/prismic/types/exhibition-guides.ts
@@ -7,7 +7,7 @@ import {
   LinkToMediaField,
   EmbedField,
 } from '@prismicio/types';
-import { Image } from '.';
+import { Image, CommonPrismicFields } from '.';
 
 export type ExhibitionLink = PrismicDocument<{
   title: RichTextField;
@@ -16,19 +16,21 @@ export type ExhibitionLink = PrismicDocument<{
   description: RichTextField;
 }>;
 
-export type ExhibitionGuidePrismicDocument = PrismicDocument<{
-  title: RichTextField;
-  relatedExhibition: RelationField<'exhibitions'>;
-  components: GroupField<{
-    number: NumberField;
+export type ExhibitionGuidePrismicDocument = PrismicDocument<
+  {
     title: RichTextField;
-    tombstone: RichTextField;
-    image: Image;
-    description: RichTextField;
-    audioWithDescription: LinkToMediaField;
-    audioWithoutDescription: LinkToMediaField;
-    bslVideo: EmbedField;
-    caption: RichTextField;
-    transcript: RichTextField;
-  }>;
-}>;
+    relatedExhibition: RelationField<'exhibitions'>;
+    components: GroupField<{
+      number: NumberField;
+      title: RichTextField;
+      tombstone: RichTextField;
+      image: Image;
+      description: RichTextField;
+      audioWithDescription: LinkToMediaField;
+      audioWithoutDescription: LinkToMediaField;
+      bslVideo: EmbedField;
+      caption: RichTextField;
+      transcript: RichTextField;
+    }>;
+  } & CommonPrismicFields
+>;

--- a/content/webapp/types/card.ts
+++ b/content/webapp/types/card.ts
@@ -49,7 +49,7 @@ export function convertItemToCardProps(
       : undefined;
   return {
     type: 'card',
-    format: format as never,
+    format: format as never, // TODO: This is now warning for use of any, need to specify type correctly
     title: item.title,
     order: 'order' in item ? item.order : undefined,
     description: (item.promo && item.promo.caption) ?? undefined,

--- a/content/webapp/types/card.ts
+++ b/content/webapp/types/card.ts
@@ -1,4 +1,4 @@
-import { getCrop, ImageType } from '@weco/common/model/image';
+import { ImageType } from '@weco/common/model/image';
 import { Format } from './format';
 import { Event } from './events';
 import { Article } from './articles';
@@ -11,6 +11,7 @@ import { Book } from './books';
 import { Exhibition } from './exhibitions';
 import { Guide } from './guides';
 import { Project } from './projects';
+import { ExhibitionGuide, ExhibitionGuideBasic } from './exhibition-guides';
 
 export type Card = {
   type: 'card';
@@ -35,6 +36,8 @@ export function convertItemToCardProps(
     | Exhibition
     | Guide
     | Project
+    | ExhibitionGuide
+    | ExhibitionGuideBasic
 ): Card {
   const format =
     'format' in item
@@ -44,10 +47,9 @@ export function convertItemToCardProps(
         // getting this from prismic, that'll do
         { title: 'Serial', id: '' }
       : undefined;
-
   return {
     type: 'card',
-    format: format as any,
+    format: format as never,
     title: item.title,
     order: 'order' in item ? item.order : undefined,
     description: (item.promo && item.promo.caption) ?? undefined,
@@ -66,7 +68,7 @@ export function convertItemToCardProps(
             tasl: item.promo.image.tasl,
             simpleCrops: {
               '16:9': {
-                contentUrl: getCrop(item.image, '16:9')?.contentUrl || '',
+                contentUrl: '',
                 width: 1600,
                 height: 900,
               },

--- a/content/webapp/types/exhibition-guides.ts
+++ b/content/webapp/types/exhibition-guides.ts
@@ -21,6 +21,12 @@ export type ExhibitionLink = {
   id: string;
   title: string;
   description?: string;
+  promo?: ImagePromo;
+};
+
+export type Exhibit = {
+  exhibitType: 'exhibitions';
+  item: ExhibitionLink[] | undefined;
 };
 
 export type ExhibitionGuideBasic = {
@@ -29,13 +35,19 @@ export type ExhibitionGuideBasic = {
   title: string | undefined;
   promo?: ImagePromo | undefined;
   image?: ImageType;
-  relatedExhibition: ExhibitionLink | undefined;
+  relatedExhibition: Exhibit[] | undefined;
+  start: string;
+  isPermanent: string;
+  contributors: string;
+  labels: string;
 };
 
 export type ExhibitionGuide = {
   type: 'exhibition-guides';
   id: string;
   title: string | undefined;
+  image?: ImageType;
+  promo?: ImagePromo | undefined;
   relatedExhibition: ExhibitionLink | undefined;
   components: ExhibitionGuideComponent[];
 };

--- a/content/webapp/types/exhibition-guides.ts
+++ b/content/webapp/types/exhibition-guides.ts
@@ -5,16 +5,6 @@ import { MediaObjectType } from './media-object';
 import { EmbedField, RichTextField } from '@prismicio/types';
 
 export type ExhibitionGuideComponent = {
-  // number: number;
-  // title: string;
-  // tombstone?: RichTextField;
-  // image?: ImageType;
-  // description?: string;
-  // audioWithDescription?: MediaObjectType;
-  // audioWithoutDescription?: MediaObjectType;
-  // bsl?: MediaObjectType;
-  // caption?: RichTextField;
-  // transcript?: RichTextField;
   number: number;
   title: string;
   image?: ImageType;
@@ -47,6 +37,7 @@ export type ExhibitionGuideBasic = {
   promo?: ImagePromo | undefined;
   image?: ImageType;
   relatedExhibition: Exhibit;
+  components: ExhibitionGuideComponent;
   start: string;
   isPermanent: string;
   contributors: string;

--- a/content/webapp/types/exhibition-guides.ts
+++ b/content/webapp/types/exhibition-guides.ts
@@ -1,4 +1,3 @@
-// only what is required to render ArticlePromos and json-ld
 import { ImagePromo } from './image-promo';
 import { ImageType } from '@weco/common/model/image';
 import { MediaObjectType } from './media-object';

--- a/content/webapp/types/exhibition-guides.ts
+++ b/content/webapp/types/exhibition-guides.ts
@@ -3,6 +3,7 @@ import { ImagePromo } from './image-promo';
 import { ImageType } from '@weco/common/model/image';
 import { MediaObjectType } from './media-object';
 import { EmbedField, RichTextField } from '@prismicio/types';
+import { GenericContentFields } from './generic-content-fields';
 
 export type ExhibitionGuideComponent = {
   // number: number;
@@ -67,12 +68,16 @@ export type ExhibitionGuideBasic = {
   labels: string;
 };
 
-export type ExhibitionGuide = {
+export type ExhibitionGuide = GenericContentFields & {
   type: 'exhibition-guides';
   id: string;
   title: string | undefined;
   image?: ImageType;
   promo?: ImagePromo | undefined;
-  relatedExhibition: ExhibitionLink | undefined;
+  relatedExhibition: Exhibit[] | undefined;
   components: ExhibitionGuideComponent;
+  start: string;
+  isPermanent: string;
+  contributors: string;
+  labels: string;
 };

--- a/content/webapp/types/exhibition-guides.ts
+++ b/content/webapp/types/exhibition-guides.ts
@@ -5,23 +5,16 @@ import { MediaObjectType } from './media-object';
 import { EmbedField, RichTextField } from '@prismicio/types';
 
 export type ExhibitionGuideComponent = {
-  number?: number;
+  number: number;
   title: string;
   image?: ImageType;
-  tombstone?: RichTextField;
-  caption?: RichTextField;
-  transcription?: RichTextField;
+  tombstone: RichTextField;
+  caption: RichTextField;
+  transcription: RichTextField;
   description?: string;
   audioWithDescription?: MediaObjectType;
   audioWithoutDescription?: MediaObjectType;
   bsl?: EmbedField;
-
-  // number: number;
-  // title: string;
-  // image?: ImageType;
-  // tombstone: prismicT.RichTextField;
-  // caption: prismicT.RichTextField;
-  // transcription?: prismicT.RichTextField;
 };
 
 export type ExhibitionLink = {
@@ -38,6 +31,10 @@ export type Exhibit = {
   exhibitType: 'exhibitions';
   item: ExhibitionLink | undefined;
 };
+
+export interface Stop extends ExhibitionGuideComponent {
+  Stops: [Stop];
+}
 
 export type ExhibitionGuideBasic = {
   type: 'exhibition-guides';

--- a/content/webapp/types/exhibition-guides.ts
+++ b/content/webapp/types/exhibition-guides.ts
@@ -3,6 +3,7 @@ import { ImagePromo } from './image-promo';
 import { ImageType } from '@weco/common/model/image';
 import { MediaObjectType } from './media-object';
 import { EmbedField, RichTextField } from '@prismicio/types';
+import { GenericContentFields } from './generic-content-fields';
 
 export type ExhibitionGuideComponent = {
   number: number;
@@ -46,7 +47,7 @@ export type ExhibitionGuideBasic = {
   components: ExhibitionGuideComponent[];
 };
 
-export type ExhibitionGuide = {
+export type ExhibitionGuide = GenericContentFields & {
   type: 'exhibition-guides';
   id: string;
   title: string;

--- a/content/webapp/types/exhibition-guides.ts
+++ b/content/webapp/types/exhibition-guides.ts
@@ -5,16 +5,23 @@ import { MediaObjectType } from './media-object';
 import { EmbedField, RichTextField } from '@prismicio/types';
 
 export type ExhibitionGuideComponent = {
-  number: number;
+  number?: number;
   title: string;
   image?: ImageType;
-  tombstone: RichTextField;
-  caption: RichTextField;
+  tombstone?: RichTextField;
+  caption?: RichTextField;
   transcription?: RichTextField;
   description?: string;
   audioWithDescription?: MediaObjectType;
   audioWithoutDescription?: MediaObjectType;
   bsl?: EmbedField;
+
+  // number: number;
+  // title: string;
+  // image?: ImageType;
+  // tombstone: prismicT.RichTextField;
+  // caption: prismicT.RichTextField;
+  // transcription?: prismicT.RichTextField;
 };
 
 export type ExhibitionLink = {
@@ -25,35 +32,29 @@ export type ExhibitionLink = {
 };
 
 export type Exhibit = {
+  id: string;
+  title: string;
   description: string;
   exhibitType: 'exhibitions';
-  item: ExhibitionLink[] | undefined;
+  item: ExhibitionLink | undefined;
 };
 
 export type ExhibitionGuideBasic = {
   type: 'exhibition-guides';
   id: string;
-  title: string | undefined;
-  promo?: ImagePromo | undefined;
+  title: string;
+  promo?: ImagePromo;
   image?: ImageType;
-  relatedExhibition: Exhibit;
-  components: ExhibitionGuideComponent;
-  start: string;
-  isPermanent: string;
-  contributors: string;
-  labels: string;
+  relatedExhibition: Exhibit | undefined;
+  components: ExhibitionGuideComponent[];
 };
 
 export type ExhibitionGuide = {
   type: 'exhibition-guides';
   id: string;
-  title: string | undefined;
+  title: string;
   image?: ImageType;
-  promo?: ImagePromo | undefined;
-  relatedExhibition: Exhibit;
-  components: ExhibitionGuideComponent;
-  start?: string;
-  isPermanent?: string;
-  contributors?: string;
-  labels?: string;
+  promo?: ImagePromo;
+  relatedExhibition: Exhibit | undefined;
+  components: ExhibitionGuideComponent[];
 };

--- a/content/webapp/types/exhibition-guides.ts
+++ b/content/webapp/types/exhibition-guides.ts
@@ -3,7 +3,6 @@ import { ImagePromo } from './image-promo';
 import { ImageType } from '@weco/common/model/image';
 import { MediaObjectType } from './media-object';
 import { EmbedField, RichTextField } from '@prismicio/types';
-import { GenericContentFields } from './generic-content-fields';
 
 export type ExhibitionGuideComponent = {
   // number: number;
@@ -54,7 +53,7 @@ export type ExhibitionGuideBasic = {
   labels: string;
 };
 
-export type ExhibitionGuide = GenericContentFields & {
+export type ExhibitionGuide = {
   type: 'exhibition-guides';
   id: string;
   title: string | undefined;

--- a/content/webapp/types/exhibition-guides.ts
+++ b/content/webapp/types/exhibition-guides.ts
@@ -2,20 +2,45 @@
 import { ImagePromo } from './image-promo';
 import { ImageType } from '@weco/common/model/image';
 import { MediaObjectType } from './media-object';
-import { EmbedField } from '@prismicio/types';
+import { EmbedField, RichTextField } from '@prismicio/types';
 
 export type ExhibitionGuideComponent = {
+  // number: number;
+  // title: string;
+  // tombstone?: RichTextField;
+  // image?: ImageType;
+  // description?: string;
+  // audioWithDescription?: MediaObjectType;
+  // audioWithoutDescription?: MediaObjectType;
+  // bsl?: MediaObjectType;
+  // caption?: RichTextField;
+  // transcript?: RichTextField;
   number: number;
   title: string;
-  tombstone?: string;
   image?: ImageType;
+  tombstone: RichTextField;
+  caption: RichTextField;
+  transcription?: RichTextField;
   description?: string;
   audioWithDescription?: MediaObjectType;
   audioWithoutDescription?: MediaObjectType;
   bsl?: EmbedField;
-  caption?: string;
-  transcript?: string;
 };
+
+// type Stop = {
+//   number: number;
+//   title: string;
+//   image?: ImageType;
+//   tombstone: prismicT.RichTextField;
+//   caption: prismicT.RichTextField;
+//   transcription?: prismicT.RichTextField;
+//   description?: string;
+//   audioWithDescription?: MediaObjectType;
+//   audioWithoutDescription?: MediaObjectType;
+//   bsl?: MediaObjectType;
+// };
+
+export type ExhibitionGuideFormat = string | number;
 
 export type ExhibitionLink = {
   id: string;
@@ -49,5 +74,5 @@ export type ExhibitionGuide = {
   image?: ImageType;
   promo?: ImagePromo | undefined;
   relatedExhibition: ExhibitionLink | undefined;
-  components: ExhibitionGuideComponent[];
+  components: ExhibitionGuideComponent;
 };

--- a/content/webapp/types/exhibition-guides.ts
+++ b/content/webapp/types/exhibition-guides.ts
@@ -33,10 +33,6 @@ export type Exhibit = {
   item: ExhibitionLink | undefined;
 };
 
-export interface Stop extends ExhibitionGuideComponent {
-  Stops: [Stop];
-}
-
 export type ExhibitionGuideBasic = {
   type: 'exhibition-guides';
   id: string;

--- a/content/webapp/types/exhibition-guides.ts
+++ b/content/webapp/types/exhibition-guides.ts
@@ -28,21 +28,6 @@ export type ExhibitionGuideComponent = {
   bsl?: EmbedField;
 };
 
-// type Stop = {
-//   number: number;
-//   title: string;
-//   image?: ImageType;
-//   tombstone: prismicT.RichTextField;
-//   caption: prismicT.RichTextField;
-//   transcription?: prismicT.RichTextField;
-//   description?: string;
-//   audioWithDescription?: MediaObjectType;
-//   audioWithoutDescription?: MediaObjectType;
-//   bsl?: MediaObjectType;
-// };
-
-export type ExhibitionGuideFormat = string | number;
-
 export type ExhibitionLink = {
   id: string;
   title: string;
@@ -51,6 +36,7 @@ export type ExhibitionLink = {
 };
 
 export type Exhibit = {
+  description: string;
   exhibitType: 'exhibitions';
   item: ExhibitionLink[] | undefined;
 };
@@ -61,7 +47,7 @@ export type ExhibitionGuideBasic = {
   title: string | undefined;
   promo?: ImagePromo | undefined;
   image?: ImageType;
-  relatedExhibition: Exhibit[] | undefined;
+  relatedExhibition: Exhibit;
   start: string;
   isPermanent: string;
   contributors: string;
@@ -74,10 +60,10 @@ export type ExhibitionGuide = GenericContentFields & {
   title: string | undefined;
   image?: ImageType;
   promo?: ImagePromo | undefined;
-  relatedExhibition: Exhibit[] | undefined;
+  relatedExhibition: Exhibit;
   components: ExhibitionGuideComponent;
-  start: string;
-  isPermanent: string;
-  contributors: string;
-  labels: string;
+  start?: string;
+  isPermanent?: string;
+  contributors?: string;
+  labels?: string;
 };

--- a/content/webapp/types/multi-content.ts
+++ b/content/webapp/types/multi-content.ts
@@ -9,6 +9,7 @@ import { Guide } from './guides';
 import { Weblink } from './weblinks';
 import { Project } from './projects';
 import { Season } from './seasons';
+import { ExhibitionGuide, ExhibitionGuideBasic } from './exhibition-guides';
 
 export type MultiContent =
   | Page
@@ -21,4 +22,6 @@ export type MultiContent =
   | Guide
   | Weblink
   | Project
-  | Season;
+  | Season
+  | ExhibitionGuide
+  | ExhibitionGuideBasic;


### PR DESCRIPTION
**This renders content from `exhibition-guide` type in Prismic at `/guides/exhibitions` and `guides/exhibitions/id`**

This PR takes fetches and transforms further for https://github.com/wellcomecollection/wellcomecollection.org/issues/8162

Showing `exhibition/guides` using frontend components, not just json. Prismic is not allowing me to number the components in the Prismic UI, so I've had to put something temporary in to number the components (aka stops/sections).

<img width="625" alt="Screenshot 2022-08-01 at 09 06 29" src="https://user-images.githubusercontent.com/16557524/182148796-b2819fa2-7fa3-4f64-8e4d-08a4d630259b.png">


Also using `ExhibitionCaption` component for one guide.

<img width="623" alt="Screenshot 2022-08-01 at 09 06 56" src="https://user-images.githubusercontent.com/16557524/182148508-18bc9758-4f8c-4579-beaa-42bcba838e5b.png">

**Note: Alice's prototype and Dom's designs call for stripping down of the header/breadcrumb menu. This PR doesn't address that, right now it just uses components we have already made.** 
