### PR TITLE
Add the new 404 and 500 page text

### DIFF
--- a/common/data/errors.tsx
+++ b/common/data/errors.tsx
@@ -1,7 +1,12 @@
-import { prismicPageIds } from 'services/prismic/hardcoded-id';
-import Layout8 from 'views/components/Layout8/Layout8';
-import MoreLink from 'views/components/MoreLink/MoreLink';
-import Space from 'views/components/styled/Space';
+import { prismicPageIds } from '../services/prismic/hardcoded-id';
+import Layout8 from '../views/components/Layout8/Layout8';
+import MoreLink from '../views/components/MoreLink/MoreLink';
+import Space from '../views/components/styled/Space';
+
+export const errorMessages = {
+  404: 'Not the Wellcome you were expecting?',
+  500: 'This isn’t the page you’re looking for, but how about these?',
+};
 
 export const DefaultErrorText = () => (
   <Layout8>
@@ -61,5 +66,65 @@ export const DefaultErrorText = () => (
         .
       </p>
     </div>
+  </Layout8>
+);
+
+export const NotFoundErrorText = () => (
+  <Layout8>
+    <Space
+      className="plain-list no-padding"
+      as="ul"
+      v={{ size: 'l', properties: ['margin-bottom'] }}
+    >
+      <p>
+        We can’t find the page you’re looking for. Maybe one of these will help:
+      </p>
+      <ul>
+        <li>
+          Find out about our <a href="/whats-on">events and exhibitions</a>
+        </li>
+        <li>
+          <a href="/collections">Search our collections</a>
+        </li>
+        <li>
+          <a href="/pages/Wuw19yIAAK1Z3Smm">Using our library</a>
+        </li>
+        <li>
+          <a href="/get-involved">Collaborating with us</a>
+        </li>
+        <li>
+          <p>
+            Read{' '}
+            <a href="/stories">articles on our Stories publishing platform</a>
+          </p>
+        </li>
+      </ul>
+      <p>
+        You’ll find pages from our old Wellcome Library website and blog
+        archived by the <a href="https://archive.org">Internet Archive</a> in
+        its <a href="https://web.archive.org/">Wayback Machine</a> &ndash;
+        search for wellcome.org.
+      </p>
+      <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
+        <MoreLink
+          url="https://web.archive.org/web/*/wellcomecollection.org"
+          name="See the Wellcome Collection website from 2007&ndash;present"
+        />
+      </Space>
+      <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
+        <MoreLink
+          url="https://web.archive.org/web/*/blog.wellcomecollection.org"
+          name="Read blog posts from 2013&ndash;2017"
+        />
+      </Space>
+      <p>
+        Still can’t find what you want? Contact us if you’ve got a specific
+        query:{' '}
+        <a href="mailto:digital@wellcomecollection.org">
+          digital@wellcomecollection.org
+        </a>
+        .
+      </p>
+    </Space>
   </Layout8>
 );

--- a/common/data/errors.tsx
+++ b/common/data/errors.tsx
@@ -5,7 +5,7 @@ import Space from '../views/components/styled/Space';
 
 export const errorMessages = {
   404: 'Not the Wellcome you were expecting?',
-  500: 'This isn’t the page you’re looking for, but how about these?',
+  500: 'Internal Server Error',
 };
 
 export const DefaultErrorText = () => (
@@ -15,57 +15,23 @@ export const DefaultErrorText = () => (
       as="ul"
       v={{ size: 'l', properties: ['margin-bottom'] }}
     >
-      <Space v={{ size: 'l', properties: ['margin-bottom'] }} as="li">
-        <MoreLink url="/whats-on" name="Our exhibitions and events" />
-      </Space>
-      <Space v={{ size: 'l', properties: ['margin-bottom'] }} as="li">
-        <MoreLink url="/collections" name="Our library" />
-      </Space>
-      <Space v={{ size: 'l', properties: ['margin-bottom'] }} as="li">
-        <MoreLink url="/stories" name="Our stories" />
-      </Space>
-      <Space v={{ size: 'l', properties: ['margin-bottom'] }} as="li">
-        <MoreLink url="/books" name="Our books" />
-      </Space>
-      <Space v={{ size: 'l', properties: ['margin-bottom'] }} as="li">
-        <MoreLink url="/images" name="Our images" />
-      </Space>
-      <Space as="li">
-        <MoreLink
-          url={`/pages/${prismicPageIds.youth}`}
-          name="Our youth programme"
-        />
-      </Space>
+      <p>
+        Looks like something’s not working properly our end. We’ll try to fix it
+        as soon as we can.{' '}
+      </p>
+      <p>In the meantime, here’s what you can do:</p>
+      <ul>
+        <li>
+          In case we missed it, email us at{' '}
+          <a href="mailto:digital@wellcomecollection.org">
+            digital@wellcomecollection.org
+          </a>{' '}
+          and tell us what happened
+        </li>
+        <li>Refresh the page (sometimes it’s a temporary issue)</li>
+        <li>Try again a bit later</li>
+      </ul>
     </Space>
-
-    <div className="body-text">
-      <h2 className="h2">Looking for something published before 2018?</h2>
-      <p>
-        Our websites have been archived by the{' '}
-        <a href="https://archive.org">Internet Archive</a> in its{' '}
-        <a href="https://web.archive.org/">Wayback Machine</a>.
-      </p>
-      <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
-        <MoreLink
-          url="https://web.archive.org/web/*/wellcomecollection.org"
-          name="See the Wellcome Collection website from 2007-present"
-        />
-      </Space>
-      <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
-        <MoreLink
-          url="https://web.archive.org/web/*/blog.wellcomecollection.org"
-          name="Read blog posts from 2013-2017"
-        />
-      </Space>
-      <p>
-        If you{`'`}re looking for something specific you{`'`}d love to see
-        return to this website, email us at{' '}
-        <a href="mailto:digital@wellcomecollection.org">
-          digital@wellcomecollection.org
-        </a>
-        .
-      </p>
-    </div>
   </Layout8>
 );
 

--- a/common/data/errors.tsx
+++ b/common/data/errors.tsx
@@ -1,0 +1,65 @@
+import { prismicPageIds } from 'services/prismic/hardcoded-id';
+import Layout8 from 'views/components/Layout8/Layout8';
+import MoreLink from 'views/components/MoreLink/MoreLink';
+import Space from 'views/components/styled/Space';
+
+export const DefaultErrorText = () => (
+  <Layout8>
+    <Space
+      className="plain-list no-padding"
+      as="ul"
+      v={{ size: 'l', properties: ['margin-bottom'] }}
+    >
+      <Space v={{ size: 'l', properties: ['margin-bottom'] }} as="li">
+        <MoreLink url="/whats-on" name="Our exhibitions and events" />
+      </Space>
+      <Space v={{ size: 'l', properties: ['margin-bottom'] }} as="li">
+        <MoreLink url="/collections" name="Our library" />
+      </Space>
+      <Space v={{ size: 'l', properties: ['margin-bottom'] }} as="li">
+        <MoreLink url="/stories" name="Our stories" />
+      </Space>
+      <Space v={{ size: 'l', properties: ['margin-bottom'] }} as="li">
+        <MoreLink url="/books" name="Our books" />
+      </Space>
+      <Space v={{ size: 'l', properties: ['margin-bottom'] }} as="li">
+        <MoreLink url="/images" name="Our images" />
+      </Space>
+      <Space as="li">
+        <MoreLink
+          url={`/pages/${prismicPageIds.youth}`}
+          name="Our youth programme"
+        />
+      </Space>
+    </Space>
+
+    <div className="body-text">
+      <h2 className="h2">Looking for something published before 2018?</h2>
+      <p>
+        Our websites have been archived by the{' '}
+        <a href="https://archive.org">Internet Archive</a> in its{' '}
+        <a href="https://web.archive.org/">Wayback Machine</a>.
+      </p>
+      <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
+        <MoreLink
+          url="https://web.archive.org/web/*/wellcomecollection.org"
+          name="See the Wellcome Collection website from 2007-present"
+        />
+      </Space>
+      <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
+        <MoreLink
+          url="https://web.archive.org/web/*/blog.wellcomecollection.org"
+          name="Read blog posts from 2013-2017"
+        />
+      </Space>
+      <p>
+        If you{`'`}re looking for something specific you{`'`}d love to see
+        return to this website, email us at{' '}
+        <a href="mailto:digital@wellcomecollection.org">
+          digital@wellcomecollection.org
+        </a>
+        .
+      </p>
+    </div>
+  </Layout8>
+);

--- a/common/data/microcopy.ts
+++ b/common/data/microcopy.ts
@@ -49,11 +49,6 @@ export const a11y = {
     'Large-print guides, transcripts and magnifiers are available in the gallery',
 };
 
-export const errorMessages = {
-  404: 'This isn’t the page you’re looking for, but how about these?',
-  500: 'This isn’t the page you’re looking for, but how about these?',
-};
-
 export const wellcomeImagesRedirectBanner =
   'Coming from Wellcome Images? All freely available images have now been moved to the Wellcome Collection website. Here we’re working to improve data quality, search relevance and tools to help you use these images more easily.';
 

--- a/common/views/components/ErrorPage/ErrorPage.tsx
+++ b/common/views/components/ErrorPage/ErrorPage.tsx
@@ -6,9 +6,12 @@ import PageLayout from '../PageLayout/PageLayout';
 import SpacingSection from '../SpacingSection/SpacingSection';
 import SpacingComponent from '../SpacingComponent/SpacingComponent';
 import Space from '../styled/Space';
-import { errorMessages } from '../../../data/microcopy';
 import { isNotUndefined } from '../../../utils/array';
-import { DefaultErrorText } from 'data/errors';
+import {
+  DefaultErrorText,
+  NotFoundErrorText,
+  errorMessages,
+} from '../../../data/errors';
 
 type Props = {
   statusCode?: number;
@@ -54,7 +57,11 @@ const ErrorPage: FunctionComponent<Props> = ({
         >
           <SpacingSection>
             <SpacingComponent>
-              <DefaultErrorText />
+              {statusCode === 404 ? (
+                <NotFoundErrorText />
+              ) : (
+                <DefaultErrorText />
+              )}
             </SpacingComponent>
           </SpacingSection>
         </div>

--- a/common/views/components/ErrorPage/ErrorPage.tsx
+++ b/common/views/components/ErrorPage/ErrorPage.tsx
@@ -3,14 +3,12 @@ import { headerBackgroundLs } from '../../../utils/backgrounds';
 import { classNames } from '../../../utils/classnames';
 import PageHeader, { headerSpaceSize } from '../PageHeader/PageHeader';
 import PageLayout from '../PageLayout/PageLayout';
-import MoreLink from '../MoreLink/MoreLink';
 import SpacingSection from '../SpacingSection/SpacingSection';
 import SpacingComponent from '../SpacingComponent/SpacingComponent';
-import Layout8 from '../Layout8/Layout8';
 import Space from '../styled/Space';
 import { errorMessages } from '../../../data/microcopy';
 import { isNotUndefined } from '../../../utils/array';
-import { prismicPageIds } from '../../../services/prismic/hardcoded-id';
+import { DefaultErrorText } from 'data/errors';
 
 type Props = {
   statusCode?: number;
@@ -56,84 +54,7 @@ const ErrorPage: FunctionComponent<Props> = ({
         >
           <SpacingSection>
             <SpacingComponent>
-              <Layout8>
-                <Space
-                  className="plain-list no-padding"
-                  as="ul"
-                  v={{ size: 'l', properties: ['margin-bottom'] }}
-                >
-                  <Space
-                    v={{ size: 'l', properties: ['margin-bottom'] }}
-                    as="li"
-                  >
-                    <MoreLink
-                      url="/whats-on"
-                      name="Our exhibitions and events"
-                    />
-                  </Space>
-                  <Space
-                    v={{ size: 'l', properties: ['margin-bottom'] }}
-                    as="li"
-                  >
-                    <MoreLink url="/collections" name="Our library" />
-                  </Space>
-                  <Space
-                    v={{ size: 'l', properties: ['margin-bottom'] }}
-                    as="li"
-                  >
-                    <MoreLink url="/stories" name="Our stories" />
-                  </Space>
-                  <Space
-                    v={{ size: 'l', properties: ['margin-bottom'] }}
-                    as="li"
-                  >
-                    <MoreLink url="/books" name="Our books" />
-                  </Space>
-                  <Space
-                    v={{ size: 'l', properties: ['margin-bottom'] }}
-                    as="li"
-                  >
-                    <MoreLink url="/images" name="Our images" />
-                  </Space>
-                  <Space as="li">
-                    <MoreLink
-                      url={`/pages/${prismicPageIds.youth}`}
-                      name="Our youth programme"
-                    />
-                  </Space>
-                </Space>
-
-                <div className="body-text">
-                  <h2 className="h2">
-                    Looking for something published before 2018?
-                  </h2>
-                  <p>
-                    Our websites have been archived by the{' '}
-                    <a href="https://archive.org">Internet Archive</a> in its{' '}
-                    <a href="https://web.archive.org/">Wayback Machine</a>.
-                  </p>
-                  <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
-                    <MoreLink
-                      url="https://web.archive.org/web/*/wellcomecollection.org"
-                      name="See the Wellcome Collection website from 2007-present"
-                    />
-                  </Space>
-                  <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
-                    <MoreLink
-                      url="https://web.archive.org/web/*/blog.wellcomecollection.org"
-                      name="Read blog posts from 2013-2017"
-                    />
-                  </Space>
-                  <p>
-                    If you{`'`}re looking for something specific you{`'`}d love
-                    to see return to this website, email us at{' '}
-                    <a href="mailto:digital@wellcomecollection.org">
-                      digital@wellcomecollection.org
-                    </a>
-                    .
-                  </p>
-                </div>
-              </Layout8>
+              <DefaultErrorText />
             </SpacingComponent>
           </SpacingSection>
         </div>

--- a/common/views/components/ErrorPage/ErrorPage.tsx
+++ b/common/views/components/ErrorPage/ErrorPage.tsx
@@ -37,6 +37,7 @@ const ErrorPage: FunctionComponent<Props> = ({
       openGraphType={'website'}
       siteSection={null}
       image={undefined}
+      hideNewsletterPromo={true}
     >
       <Space v={{ size: headerSpaceSize, properties: ['padding-bottom'] }}>
         <PageHeader

--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -157,6 +157,7 @@ export type WecoAppProps = AppProps;
 function isErrorPage(route: string): boolean {
   switch (route) {
     case '/404':
+    case '/500':
     case '/ _error':
       return true;
     default:

--- a/content/webapp/pages/500.tsx
+++ b/content/webapp/pages/500.tsx
@@ -1,0 +1,8 @@
+import { NextPage } from 'next';
+import ErrorPage from '@weco/common/views/components/ErrorPage/ErrorPage';
+
+const Page: NextPage = () => {
+  return <ErrorPage statusCode={500} />;
+};
+
+export default Page;


### PR DESCRIPTION
## Who is this for?

Users.

## What is it doing for them?

Providing more helpful error pages. For #8032.

This is what the new pages look like:

<img width="1699" alt="Screenshot 2022-08-01 at 10 32 20" src="https://user-images.githubusercontent.com/301220/182119004-990401e8-7810-48e4-8a09-99789b0474a6.png">

<img width="1699" alt="Screenshot 2022-08-01 at 10 32 18" src="https://user-images.githubusercontent.com/301220/182118996-d52594c8-7a87-438b-af87-8063526caf07.png">

I've added a convenience route `/500` for testing this sort of page; we may need to add an exclusion for it in the Slack alerts.