### PR TITLE
Allow header to have custom nav links and no library login

### DIFF
--- a/cardigan/stories/components/Header/Header.stories.mdx
+++ b/cardigan/stories/components/Header/Header.stories.mdx
@@ -13,4 +13,11 @@ import * as stories from './Header.stories.tsx';
   <Story story={stories.basic} inline={false} />
 </Canvas>
 
+
+## `Exhibition guides`
+
+<Canvas>
+  <Story story={stories.exhibitionGuides} inline={false} />
+</Canvas>
+
 <ArgsTable />

--- a/cardigan/stories/components/Header/Header.stories.tsx
+++ b/cardigan/stories/components/Header/Header.stories.tsx
@@ -1,10 +1,19 @@
-import Header, { links } from '@weco/common/views/components/Header/Header';
+import Header, {
+  exhibitionGuidesLinks,
+} from '@weco/common/views/components/Header/Header';
 
 const Template = args => <Header {...args} />;
 export const basic = Template.bind({});
 basic.args = {
   siteSection: 'stories',
   isActive: true,
-  links,
 };
 basic.storyName = 'Header';
+
+export const exhibitionGuides = Template.bind({});
+exhibitionGuides.args = {
+  siteSection: undefined,
+  customNavLinks: exhibitionGuidesLinks,
+  showLibraryLogin: false,
+};
+exhibitionGuides.storyName = 'Exhibition guides';

--- a/cardigan/stories/components/Header/Header.stories.tsx
+++ b/cardigan/stories/components/Header/Header.stories.tsx
@@ -12,7 +12,6 @@ basic.storyName = 'Header';
 
 export const exhibitionGuides = Template.bind({});
 exhibitionGuides.args = {
-  siteSection: undefined,
   customNavLinks: exhibitionGuidesLinks,
   showLibraryLogin: false,
 };

--- a/common/views/components/Header/Header.tsx
+++ b/common/views/components/Header/Header.tsx
@@ -324,7 +324,7 @@ export const links: NavLink[] = [
 
 export const exhibitionGuidesLinks: NavLink[] = [
   {
-    href: '/guides/exhibition-guides',
+    href: '/guides/exhibitions',
     title: 'Exhibition guides',
   },
 ];

--- a/common/views/components/Header/Header.tsx
+++ b/common/views/components/Header/Header.tsx
@@ -324,7 +324,7 @@ export const links: NavLink[] = [
 
 export const exhibitionGuidesLinks: NavLink[] = [
   {
-    href: '/exhibition-guides',
+    href: '/guides/exhibition-guides',
     title: 'Exhibition guides',
   },
 ];

--- a/common/views/components/Header/Header.tsx
+++ b/common/views/components/Header/Header.tsx
@@ -286,7 +286,7 @@ type NavLink = {
 type Props = {
   siteSection: string | null;
   customNavLinks?: NavLink[];
-  showLibraryLogin: boolean;
+  showLibraryLogin?: boolean;
 };
 
 export const links: NavLink[] = [

--- a/common/views/components/Header/Header.tsx
+++ b/common/views/components/Header/Header.tsx
@@ -277,11 +277,19 @@ const HeaderLink = styled.a<{ isActive: boolean }>`
   `}
 `;
 
-type Props = {
-  siteSection: string | null;
+type NavLink = {
+  href: string;
+  title: string;
+  siteSection?: string;
 };
 
-export const links = [
+type Props = {
+  siteSection: string | null;
+  customNavLinks?: NavLink[];
+  showLibraryLogin: boolean;
+};
+
+export const links: NavLink[] = [
   {
     href: '/visit-us',
     title: 'Visit us',
@@ -314,7 +322,18 @@ export const links = [
   },
 ];
 
-const Header: FC<Props> = ({ siteSection }) => {
+export const exhibitionGuidesLinks: NavLink[] = [
+  {
+    href: '/exhibition-guides',
+    title: 'Exhibition guides',
+  },
+];
+
+const Header: FC<Props> = ({
+  siteSection,
+  customNavLinks,
+  showLibraryLogin = true,
+}) => {
   const [isActive, setIsActive] = useState(false);
 
   return (
@@ -351,7 +370,7 @@ const Header: FC<Props> = ({ siteSection }) => {
               <HeaderList
                 className={`plain-list ${font('wb', 5)} no-margin no-padding`}
               >
-                {links.map((link, i) => (
+                {(customNavLinks || links).map((link, i) => (
                   <HeaderItem key={i}>
                     <HeaderLink
                       isActive={link.siteSection === siteSection}
@@ -364,10 +383,10 @@ const Header: FC<Props> = ({ siteSection }) => {
                     </HeaderLink>
                   </HeaderItem>
                 ))}
-                <MobileSignIn />
+                {showLibraryLogin && <MobileSignIn />}
               </HeaderList>
             </HeaderNav>
-            <DesktopSignIn />
+            {showLibraryLogin && <DesktopSignIn />}
           </NavLoginWrapper>
         </div>
       </div>


### PR DESCRIPTION
The exhibition guides area has a requirement for a less busy header with only one link and no option to login to a library account.

This PR lets the `Header` optionally accept `customNavLinks` and adds a `showLibraryLogin` prop defaulted to `true`.

<img width="1070" alt="image" src="https://user-images.githubusercontent.com/1394592/182366599-e5354720-2d77-4f5c-b07e-6cc49cf668b0.png">