### PR TITLE
Exhibition guide landing page

### DIFF
--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -27,15 +27,18 @@ type GuideType = typeof typeNames[number];
 type Props = {
   exhibitionGuide: ExhibitionGuide;
   jsonLd: JsonLdObj;
-  // type: string; // TODO union - content type/guide format
-  // id: string;
+  type?: GuideType;
 };
+
+function isValidType(type) {
+  return typeNames.includes(type);
+}
 
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
     const serverData = await getServerData(context);
-    const { id } = context.query; // TODO should we have another page template to handle type or do everything in here?
     if (!looksLikePrismicId(id) || !serverData.toggles.exhibitionGuides) {
+    const { id, type } = context.query;
       return { notFound: true };
     }
 
@@ -54,6 +57,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
           exhibitionGuide,
           jsonLd,
           serverData,
+          type: isValidType(type) ? (type as GuideType) : undefined,
         }),
       };
     } else {
@@ -62,8 +66,8 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   };
 
 const ExhibitionGuidesPage: FC<Props> = props => {
-  const { exhibitionGuide, jsonLd } = props;
   const pathname = `guides/exhibition/${exhibitionGuide.id}`; // TODO /id/content-type
+  const { exhibitionGuide, jsonLd, type } = props;
   return (
     <PageLayout
       title={exhibitionGuide.title || ''}

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -66,8 +66,10 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   };
 
 const ExhibitionGuidesPage: FC<Props> = props => {
-  const pathname = `guides/exhibition/${exhibitionGuide.id}`; // TODO /id/content-type
   const { exhibitionGuide, jsonLd, type } = props;
+  const pathname = `guides/exhibition/${exhibitionGuide.id}${
+    type ? `/${type}` : ''
+  }`;
   return (
     <PageLayout
       title={exhibitionGuide.title || ''}

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -1,7 +1,6 @@
 import { ExhibitionGuide } from '../types/exhibition-guides';
 import { createClient } from '../services/prismic/fetch';
 import { fetchExhibitionGuide } from '../services/prismic/fetch/exhibition-guides';
-// import { transformQuery } from '../services/prismic/transformers/paginated-results';
 import { transformExhibitionGuide } from '../services/prismic/transformers/exhibition-guides';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import { FC } from 'react';

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -18,8 +18,8 @@ import { AppErrorProps } from '@weco/common/views/pages/_app';
 
 const typeNames = [
   'bsl',
-  'audio-with-description',
-  'audio-without-description',
+  'audio-with-descriptions',
+  'audio-without-descriptions',
   'captions-and-transcripts',
 ] as const;
 type GuideType = typeof typeNames[number];
@@ -75,9 +75,9 @@ const ExhibitionStops = props => {
   switch (type) {
     case 'bsl':
       return <p>bsl</p>;
-    case 'audio-with-description':
+    case 'audio-with-descriptions':
       return <p>audio with description</p>;
-    case 'audio-without-description':
+    case 'audio-without-descriptions':
       return <p>audio without description</p>;
     case 'captions-and-transcripts':
       return <ExhibitionCaptions stops={stops} />;
@@ -88,7 +88,7 @@ const ExhibitionStops = props => {
 
 const ExhibitionGuidesPage: FC<Props> = props => {
   const { exhibitionGuide, jsonLd, type } = props;
-  const pathname = `guides/exhibition/${exhibitionGuide.id}${
+  const pathname = `guides/exhibitions/${exhibitionGuide.id}${
     type ? `/${type}` : ''
   }`;
   return (
@@ -102,7 +102,34 @@ const ExhibitionGuidesPage: FC<Props> = props => {
       image={exhibitionGuide.image || undefined}
     >
       {!type ? (
-        <p>links</p>
+        <Layout10>
+          <Space v={{ size: 'xl', properties: ['margin-top'] }}>
+            <a href={`/${pathname}/audio-without-descriptions`}>
+              <h2>Listen, without audio descriptions</h2>
+              <p>Find out more about the exhibition with short audio tracks.</p>
+            </a>
+            <a href={`/${pathname}/audio-with-descriptions`}>
+              <h2>Listen, with audio descriptions</h2>
+              <p>
+                Find out more about the exhibition with short audio tracks,
+                including descriptions of the objects.
+              </p>
+            </a>
+            <a href={`/${pathname}/captions-and-transcripts`}>
+              <h2>Read captions and transcripts</h2>
+              <p>
+                All the wall and label texts from the gallery, and images of the
+                objects, great for those without headphones.
+              </p>
+            </a>
+            <a href={`/${pathname}/bsl`}>
+              <h2>Watch BSL videos</h2>
+              <p>
+                Commentary about the exhibition in British Sign Language videos.
+              </p>
+            </a>
+          </Space>
+        </Layout10>
       ) : (
         <Layout10>
           <Space v={{ size: 'xl', properties: ['margin-top'] }}>

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -16,6 +16,14 @@ import ExhibitionCaptions from '../components/ExhibitionCaptions/ExhibitionCapti
 import { GetServerSideProps } from 'next';
 import { AppErrorProps } from '@weco/common/views/pages/_app';
 
+const typeNames = [
+  'bsl',
+  'audio-with-description',
+  'audio-without-description',
+  'captions-and-transcripts',
+] as const;
+type GuideType = typeof typeNames[number];
+
 type Props = {
   exhibitionGuide: ExhibitionGuide;
   jsonLd: JsonLdObj;

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -17,15 +17,12 @@ import { GetServerSideProps } from 'next';
 import { AppErrorProps } from '@weco/common/views/pages/_app';
 import styled from 'styled-components';
 
-const TypeLink = styled(Space).attrs({
-  as: 'a',
-  v: { size: 'm', properties: ['padding-top', 'padding-bottom'] },
-  h: { size: 'm', properties: ['padding-left', 'padding-right'] },
-})`
+const TypeLink = styled.a`
   flex-basis: calc(50% - 20px);
   flex-grow: 0;
   flex-shrink: 0;
 
+  padding: 10px;
   text-decoration: none;
   background: ${props => props.theme.color('turquoise', 'light')};
 
@@ -122,31 +119,34 @@ const ExhibitionGuidesPage: FC<Props> = props => {
     >
       {!type ? (
         <Layout10>
+          <Space v={{ size: 'xl', properties: ['margin-top'] }}>
+            <h1 className="h1">{`Choose the ${exhibitionGuide.title} guide for you`}</h1>
+          </Space>
           <Space
-            v={{ size: 'xl', properties: ['margin-top'] }}
+            v={{ size: 'l', properties: ['margin-top'] }}
             className="flex flex--wrap"
             style={{ gap: '10px' }}
           >
             <TypeLink href={`/${pathname}/audio-without-descriptions`}>
-              <h2>Listen, without audio descriptions</h2>
+              <h2 className="h2">Listen, without audio descriptions</h2>
               <p>Find out more about the exhibition with short audio tracks.</p>
             </TypeLink>
             <TypeLink href={`/${pathname}/audio-with-descriptions`}>
-              <h2>Listen, with audio descriptions</h2>
+              <h2 className="h2">Listen, with audio descriptions</h2>
               <p>
                 Find out more about the exhibition with short audio tracks,
                 including descriptions of the objects.
               </p>
             </TypeLink>
             <TypeLink href={`/${pathname}/captions-and-transcripts`}>
-              <h2>Read captions and transcripts</h2>
+              <h2 className="h2">Read captions and transcripts</h2>
               <p>
                 All the wall and label texts from the gallery, and images of the
                 objects, great for those without headphones.
               </p>
             </TypeLink>
             <TypeLink href={`/${pathname}/bsl`}>
-              <h2>Watch BSL videos</h2>
+              <h2 className="h2">Watch BSL videos</h2>
               <p>
                 Commentary about the exhibition in British Sign Language videos.
               </p>

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -70,6 +70,22 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     }
   };
 
+const ExhibitionStops = props => {
+  const { type, stops } = props;
+  switch (type) {
+    case 'bsl':
+      return <p>bsl</p>;
+    case 'audio-with-description':
+      return <p>audio with description</p>;
+    case 'audio-without-description':
+      return <p>audio without description</p>;
+    case 'captions-and-transcripts':
+      return <ExhibitionCaptions stops={stops} />;
+    default:
+      return null;
+  }
+};
+
 const ExhibitionGuidesPage: FC<Props> = props => {
   const { exhibitionGuide, jsonLd, type } = props;
   const pathname = `guides/exhibition/${exhibitionGuide.id}${
@@ -85,22 +101,24 @@ const ExhibitionGuidesPage: FC<Props> = props => {
       siteSection={'whats-on'}
       image={exhibitionGuide.image || undefined}
     >
-      <Layout10>
-        <Space v={{ size: 'xl', properties: ['margin-top'] }}>
-          <h2>{exhibitionGuide.title}</h2>
-        </Space>
-        <Space v={{ size: 'xl', properties: ['margin-top'] }}>
-          <h3>Introduction</h3>
-          {exhibitionGuide.relatedExhibition && (
-            <p>{exhibitionGuide.relatedExhibition.description}</p>
-          )}
-        </Space>
-        <Space v={{ size: 'xl', properties: ['margin-top'] }}>
-          <ExhibitionCaptions
-            stops={exhibitionGuide.components}
-          ></ExhibitionCaptions>
-        </Space>
-      </Layout10>
+      {!type ? (
+        <p>links</p>
+      ) : (
+        <Layout10>
+          <Space v={{ size: 'xl', properties: ['margin-top'] }}>
+            <h2>{exhibitionGuide.title}</h2>
+          </Space>
+          <Space v={{ size: 'xl', properties: ['margin-top'] }}>
+            <h3>Introduction</h3>
+            {exhibitionGuide.relatedExhibition && (
+              <p>{exhibitionGuide.relatedExhibition.description}</p>
+            )}
+          </Space>
+          <Space v={{ size: 'xl', properties: ['margin-top'] }}>
+            <ExhibitionStops type={type} stops={exhibitionGuide.components} />
+          </Space>
+        </Layout10>
+      )}
     </PageLayout>
   );
 };

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -15,6 +15,25 @@ import Space from '@weco/common/views/components/styled/Space';
 import ExhibitionCaptions from '../components/ExhibitionCaptions/ExhibitionCaptions';
 import { GetServerSideProps } from 'next';
 import { AppErrorProps } from '@weco/common/views/pages/_app';
+import styled from 'styled-components';
+
+const TypeLink = styled(Space).attrs({
+  as: 'a',
+  v: { size: 'm', properties: ['padding-top', 'padding-bottom'] },
+  h: { size: 'm', properties: ['padding-left', 'padding-right'] },
+})`
+  flex-basis: calc(50% - 20px);
+  flex-grow: 0;
+  flex-shrink: 0;
+
+  text-decoration: none;
+  background: ${props => props.theme.color('turquoise', 'light')};
+
+  &:hover,
+  &:focus {
+    background: ${props => props.theme.color('marble')};
+  }
+`;
 
 const typeNames = [
   'bsl',
@@ -24,15 +43,15 @@ const typeNames = [
 ] as const;
 type GuideType = typeof typeNames[number];
 
+function isValidType(type) {
+  return typeNames.includes(type);
+}
+
 type Props = {
   exhibitionGuide: ExhibitionGuide;
   jsonLd: JsonLdObj;
   type?: GuideType;
 };
-
-function isValidType(type) {
-  return typeNames.includes(type);
-}
 
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
@@ -103,31 +122,35 @@ const ExhibitionGuidesPage: FC<Props> = props => {
     >
       {!type ? (
         <Layout10>
-          <Space v={{ size: 'xl', properties: ['margin-top'] }}>
-            <a href={`/${pathname}/audio-without-descriptions`}>
+          <Space
+            v={{ size: 'xl', properties: ['margin-top'] }}
+            className="flex flex--wrap"
+            style={{ gap: '10px' }}
+          >
+            <TypeLink href={`/${pathname}/audio-without-descriptions`}>
               <h2>Listen, without audio descriptions</h2>
               <p>Find out more about the exhibition with short audio tracks.</p>
-            </a>
-            <a href={`/${pathname}/audio-with-descriptions`}>
+            </TypeLink>
+            <TypeLink href={`/${pathname}/audio-with-descriptions`}>
               <h2>Listen, with audio descriptions</h2>
               <p>
                 Find out more about the exhibition with short audio tracks,
                 including descriptions of the objects.
               </p>
-            </a>
-            <a href={`/${pathname}/captions-and-transcripts`}>
+            </TypeLink>
+            <TypeLink href={`/${pathname}/captions-and-transcripts`}>
               <h2>Read captions and transcripts</h2>
               <p>
                 All the wall and label texts from the gallery, and images of the
                 objects, great for those without headphones.
               </p>
-            </a>
-            <a href={`/${pathname}/bsl`}>
+            </TypeLink>
+            <TypeLink href={`/${pathname}/bsl`}>
               <h2>Watch BSL videos</h2>
               <p>
                 Commentary about the exhibition in British Sign Language videos.
               </p>
-            </a>
+            </TypeLink>
           </Space>
         </Layout10>
       ) : (

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -37,8 +37,13 @@ function isValidType(type) {
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
     const serverData = await getServerData(context);
-    if (!looksLikePrismicId(id) || !serverData.toggles.exhibitionGuides) {
     const { id, type } = context.query;
+
+    if (
+      !looksLikePrismicId(id) ||
+      !serverData.toggles.exhibitionGuides ||
+      (type && !isValidType(type))
+    ) {
       return { notFound: true };
     }
 


### PR DESCRIPTION
Building on #8162

This renders links to the four guide types at /guides/exhibitions/{id}:
![Screenshot 2022-08-02 at 12 59 47](https://user-images.githubusercontent.com/6051896/182382608-18752347-3067-4f74-8134-a355ff885286.png)

It renders the type of guide for each stop at /guides/exhibitions/{id}/{type}:
_Note this is only really working for 'captions-and-transcripts' currently. The others are next on the todo list._

![Screenshot 2022-08-02 at 13 00 56](https://user-images.githubusercontent.com/6051896/182382699-4b5339b0-8821-4a6e-835f-84731f3a2ac5.png)

![Screenshot 2022-08-02 at 13 00 18](https://user-images.githubusercontent.com/6051896/182382715-af7461d1-4cc0-44cb-9af9-7a21757965c7.png)

Renders a 404 for an invalid type.

N.B. There is obviously still styling work to do subsequently.
