### PR TITLE
Revert a change that broke next/image rendering inside cards

### DIFF
--- a/content/webapp/types/card.ts
+++ b/content/webapp/types/card.ts
@@ -1,4 +1,4 @@
-import { ImageType } from '@weco/common/model/image';
+import { getCrop, ImageType } from '@weco/common/model/image';
 import { Format } from './format';
 import { Event } from './events';
 import { Article } from './articles';
@@ -68,7 +68,7 @@ export function convertItemToCardProps(
             tasl: item.promo.image.tasl,
             simpleCrops: {
               '16:9': {
-                contentUrl: '',
+                contentUrl: getCrop(item.image, '16:9')?.contentUrl || '',
                 width: 1600,
                 height: 900,
               },


### PR DESCRIPTION
☝️ 

Interesting to note that an empty string in the `src` of a `next/image` caused it to break, so our fallback (`|| ''`) isn't really any use. I think we should probably use the background pattern that we use elsewhere as a default placeholder 1. so that the site continues to work if we hit this again and 2. so we have more of an idea what's gone wrong when we do. For debate/another PR though.