### PR TITLE
Only load the COVID icons on pages, not all <ContentPage>

### DIFF
--- a/content/webapp/components/ContentPage/ContentPage.tsx
+++ b/content/webapp/components/ContentPage/ContentPage.tsx
@@ -24,7 +24,6 @@ import SpacingComponent from '@weco/common/views/components/SpacingComponent/Spa
 import CompactCard from '../CompactCard/CompactCard';
 import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImage';
 import Space from '@weco/common/views/components/styled/Space';
-import { WeAreGoodToGo } from '@weco/common/views/components/CovidIcons/CovidIcons';
 import BannerCard from '../BannerCard/BannerCard';
 import Contributors from '../Contributors/Contributors';
 import Outro from '../Outro/Outro';
@@ -49,6 +48,7 @@ type Props = {
     visitLinkText?: string;
     visitItem?: MultiContent;
   };
+  postOutroContent?: ReactNode;
   seasons?: Season[];
   contributors?: Contributor[];
   contributorTitle?: string;
@@ -106,6 +106,7 @@ const ContentPage = ({
   children,
   RelatedContent = [],
   outroProps,
+  postOutroContent,
   seasons = [],
   contributors,
   contributorTitle,
@@ -190,13 +191,7 @@ const ContentPage = ({
             </SpacingSection>
           )}
 
-          {id === prismicPageIds.covidWelcomeBack && (
-            <Layout8>
-              <div style={{ width: '100px' }}>
-                <WeAreGoodToGo />
-              </div>
-            </Layout8>
-          )}
+          {postOutroContent && <Layout8>{postOutroContent}</Layout8>}
 
           {seasons.length > 0 &&
             seasons.map(season => (

--- a/content/webapp/pages/page.tsx
+++ b/content/webapp/pages/page.tsx
@@ -43,6 +43,7 @@ import { getCrop } from '@weco/common/model/image';
 import { isPicture, isVideoEmbed, BodySlice } from '../types/body';
 import { isNotUndefined } from '@weco/common/utils/array';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
+import { WeAreGoodToGo } from '@weco/common/views/components/CovidIcons/CovidIcons';
 
 export type Props = {
   page: PageType;
@@ -293,9 +294,11 @@ export const Page: FC<Props> = ({
       };
     });
 
+    /* eslint-disable @typescript-eslint/no-non-null-assertion */
     const orderedItems: PageType[] = groupWithOrder
       .filter(s => Boolean(s.order))
       .sort((a, b) => a.order! - b.order!);
+    /* eslint-enable @typescript-eslint/no-non-null-assertion */
 
     const unorderedItems: PageType[] = groupWithOrder.filter(s => !s.order);
 
@@ -333,6 +336,13 @@ export const Page: FC<Props> = ({
   // we put elsewhere on the website, e.g. in the header.
   const pathname = vanityUrl || `/pages/${page.id}`;
 
+  const postOutroContent =
+    page.id === prismicPageIds.covidWelcomeBack ? (
+      <div style={{ width: '100px' }}>
+        <WeAreGoodToGo />
+      </div>
+    ) : null;
+
   return (
     <PageLayout
       title={page.title}
@@ -363,6 +373,7 @@ export const Page: FC<Props> = ({
          * - Explore around a subject (siblings)
          */
         RelatedContent={[...Children, ...Siblings]}
+        postOutroContent={postOutroContent}
         contributors={page.contributors}
         seasons={page.seasons}
       />


### PR DESCRIPTION
The `<WeAreGoodToGo>` component is 27KB of icon that only appears on a single page; currently we load it for everything in the content app. This is inefficient; let's move it into the Page component.