### PR TITLE
Filter and keep label for first main contributor only in Search Result

### DIFF
--- a/catalogue/webapp/components/WorkHeader/WorkHeader.tsx
+++ b/catalogue/webapp/components/WorkHeader/WorkHeader.tsx
@@ -36,6 +36,10 @@ const WorkHeader: FunctionComponent<Props> = ({
   const cardLabels = getCardLabels(work);
   const { childManifestsCount } = useIIIFManifestData(work);
 
+  const primaryContributorLabel = work.contributors.find(
+    contributor => contributor.primary
+  )?.agent.label;
+
   return (
     <WorkHeaderContainer>
       <Space
@@ -63,12 +67,12 @@ const WorkHeader: FunctionComponent<Props> = ({
             <WorkTitle title={work.title} />
           </h1>
 
-          {work.contributors.length > 0 && (
+          {primaryContributorLabel && (
             <Space h={{ size: 'm', properties: ['margin-right'] }}>
               <LinkLabels
                 items={[
                   {
-                    text: work.contributors[0].agent.label,
+                    text: primaryContributorLabel,
                     url: null,
                   },
                 ]}

--- a/catalogue/webapp/components/WorksSearchResult/WorksSearchResult.tsx
+++ b/catalogue/webapp/components/WorksSearchResult/WorksSearchResult.tsx
@@ -79,6 +79,10 @@ const WorkSearchResult: FunctionComponent<Props> = ({
   const archiveLabels = getArchiveLabels(work);
   const cardLabels = getCardLabels(work);
 
+  const primaryContributorLabel = work.contributors.find(
+    contributor => contributor.primary
+  )?.agent.label;
+
   return (
     <Wrapper>
       <WorkLink
@@ -119,12 +123,12 @@ const WorkSearchResult: FunctionComponent<Props> = ({
                 <WorkTitle title={work.title} />
               </h2>
 
-              {work.contributors.length > 0 && (
+              {primaryContributorLabel && (
                 <Space h={{ size: 'm', properties: ['margin-right'] }}>
                   <LinkLabels
                     items={[
                       {
-                        text: work.contributors[0].agent.label,
+                        text: primaryContributorLabel,
                       },
                     ]}
                   />

--- a/common/model/catalogue.ts
+++ b/common/model/catalogue.ts
@@ -98,6 +98,7 @@ type Contributor = {
   agent: Agent;
   roles: ContributorRole[];
   type: 'Contributor';
+  primary: boolean;
 };
 
 type Subject = {

--- a/common/test/fixtures/catalogueApi/work.ts
+++ b/common/test/fixtures/catalogueApi/work.ts
@@ -35,6 +35,7 @@ export const workFixture: Work = {
       },
       roles: [],
       type: 'Contributor',
+      primary: true,
     },
     {
       agent: {
@@ -43,6 +44,7 @@ export const workFixture: Work = {
       },
       roles: [],
       type: 'Contributor',
+      primary: false,
     },
     {
       agent: {
@@ -51,6 +53,7 @@ export const workFixture: Work = {
       },
       roles: [],
       type: 'Contributor',
+      primary: false,
     },
   ],
   identifiers: [


### PR DESCRIPTION
## Who is this for?
Users/researchers

## What is it doing for them?
For [#5582](https://github.com/wellcomecollection/platform/issues/5582), only displays one main contributor