### PR TITLE
render video and audio where appropriate

### DIFF
--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -16,6 +16,8 @@ import ExhibitionCaptions from '../components/ExhibitionCaptions/ExhibitionCapti
 import { GetServerSideProps } from 'next';
 import { AppErrorProps } from '@weco/common/views/pages/_app';
 import styled from 'styled-components';
+import AudioPlayer from '@weco/common/views/components/AudioPlayer/AudioPlayer';
+import VideoEmbed from '@weco/common/views/components/VideoEmbed/VideoEmbed';
 
 const TypeLink = styled.a`
   flex-basis: calc(50% - 20px);
@@ -86,15 +88,67 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     }
   };
 
-const ExhibitionStops = props => {
-  const { type, stops } = props;
+const Stops = ({ stops, type }) => {
+  return (
+    <ul className="plain-list no-margin no-padding">
+      {stops.map((stop, index) => {
+        const {
+          title,
+          number,
+          audioWithDescription,
+          audioWithoutDescription,
+          bsl,
+        } = stop;
+        const hasContentOfDesiredType =
+          (type === 'audio-with-descriptions' && audioWithDescription.url) ||
+          (type === 'audio-without-descriptions' &&
+            audioWithoutDescription.url) ||
+          (type === 'bsl' && bsl.embedUrl);
+        return (
+          <li key={index}>
+            <h2>
+              {number}. {title}
+            </h2>
+            {hasContentOfDesiredType ? (
+              <>
+                {type === 'audio-with-descriptions' &&
+                  audioWithDescription.url && (
+                    <AudioPlayer
+                      title={stop.title} // TODO option not to display title
+                      audioFile={audioWithDescription.url}
+                    />
+                  )}
+                {type === 'audio-without-descriptions' &&
+                  audioWithoutDescription.url && (
+                    <AudioPlayer
+                      title={title} // TODO option not to display title
+                      audioFile={audioWithoutDescription.url}
+                    />
+                  )}
+                {type === 'bsl' && bsl.embedUrl && (
+                  <VideoEmbed embedUrl={bsl.embedUrl} />
+                )}
+              </>
+            ) : (
+              <>
+                <p>There is no content to display</p>
+              </>
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+};
+
+const ExhibitionStops = ({ type, stops }) => {
   switch (type) {
     case 'bsl':
-      return <p>bsl</p>;
+      return <Stops stops={stops} type={type} />;
     case 'audio-with-descriptions':
-      return <p>audio with description</p>;
+      return <Stops stops={stops} type={type} />;
     case 'audio-without-descriptions':
-      return <p>audio without description</p>;
+      return <Stops stops={stops} type={type} />;
     case 'captions-and-transcripts':
       return <ExhibitionCaptions stops={stops} />;
     default:

--- a/content/webapp/services/prismic/transformers/exhibition-guides.ts
+++ b/content/webapp/services/prismic/transformers/exhibition-guides.ts
@@ -89,6 +89,26 @@ function transformRelatedExhibition(exhibition): Exhibit {
   };
 }
 
+function transformYoutubeEmbed(embed) {
+  // TODO share some of this with transformEmbedSlice?
+  if (embed.provider_url === 'https://www.youtube.com/') {
+    const embedUrl = embed.html!.match(/src="([^"]+)"?/)![1];
+
+    const embedUrlWithEnhancedPrivacy = embedUrl.replace(
+      'www.youtube.com',
+      'www.youtube-nocookie.com'
+    );
+
+    const newEmbedUrl = embedUrl.includes('?')
+      ? embedUrlWithEnhancedPrivacy.replace('?', '?rel=0&')
+      : `${embedUrlWithEnhancedPrivacy}?rel=0`;
+
+    return {
+      embedUrl: newEmbedUrl,
+    };
+  }
+}
+
 export function transformExhibitionGuide(
   document: ExhibitionGuidePrismicDocument
 ): ExhibitionGuide {
@@ -108,9 +128,11 @@ export function transformExhibitionGuide(
         caption: (component.caption && asRichText(component.caption)) || [],
         transcription:
           (component.transcript && asRichText(component.transcript)) || [],
-        audioWithDescription: component['audio-with-description'],
-        audioWithoutDescription: component['audio-without-description'],
-        bsl: component['bsl-video'],
+        audioWithDescription: component['audio-with-description'], // TODO make the same as other audio transforms
+        audioWithoutDescription: component['audio-without-description'], // TODO make the same as other audio transforms
+        bsl: component['bsl-video'].provider_name // TODO better way of checking?
+          ? transformYoutubeEmbed(component['bsl-video'])
+          : {},
       };
     }
   );


### PR DESCRIPTION
Building on #8162

This renders the appropriate content for a guide based on the type in the url, e.g.
![Screenshot 2022-08-02 at 18 29 52](https://user-images.githubusercontent.com/6051896/182572430-0062eaf8-ebd5-4fd4-bddc-6cf3fd540cd3.png)

![Screenshot 2022-08-02 at 18 30 14](https://user-images.githubusercontent.com/6051896/182572601-67111c73-a9ba-46c2-8297-3fb9e0f6788e.png)

![Screenshot 2022-08-02 at 13 00 56](https://user-images.githubusercontent.com/6051896/182572456-356903ad-e914-4e79-8a5c-8b6c19ef7b11.png)

**There are a few todos and so some tidying up needed, but thought it would be good to get in and we could maybe split the remaining work.**


