### PR TITLE
Update guide stop numbers

### DIFF
--- a/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
+++ b/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
@@ -97,7 +97,8 @@ const Stop: FC<{ stop: Stop }> = ({ stop }) => {
     >
       <TitleTombstone>
         <h2>
-          {stop.number}. {stop.title}
+          {stop.number ? `${stop.number}. ` : ''}
+          {stop.title}
         </h2>
         <em>
           <PrismicHtmlBlock html={stop.tombstone} />

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -1,4 +1,7 @@
-import { ExhibitionGuide } from '../types/exhibition-guides';
+import {
+  ExhibitionGuide,
+  ExhibitionGuideComponent,
+} from '../types/exhibition-guides';
 import { createClient } from '../services/prismic/fetch';
 import { fetchExhibitionGuide } from '../services/prismic/fetch/exhibition-guides';
 import { transformExhibitionGuide } from '../services/prismic/transformers/exhibition-guides';
@@ -88,7 +91,12 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     }
   };
 
-const Stops = ({ stops, type }) => {
+type StopsProps = {
+  stops: ExhibitionGuideComponent[];
+  type?: GuideType;
+};
+
+const Stops: FC<StopsProps> = ({ stops, type }) => {
   return (
     <ul className="plain-list no-margin no-padding">
       {stops.map((stop, index) => {
@@ -100,10 +108,10 @@ const Stops = ({ stops, type }) => {
           bsl,
         } = stop;
         const hasContentOfDesiredType =
-          (type === 'audio-with-descriptions' && audioWithDescription.url) ||
+          (type === 'audio-with-descriptions' && audioWithDescription?.url) ||
           (type === 'audio-without-descriptions' &&
-            audioWithoutDescription.url) ||
-          (type === 'bsl' && bsl.embedUrl);
+            audioWithoutDescription?.url) ||
+          (type === 'bsl' && bsl?.embedUrl);
         return (
           <li key={index}>
             <h2>
@@ -112,21 +120,21 @@ const Stops = ({ stops, type }) => {
             {hasContentOfDesiredType ? (
               <>
                 {type === 'audio-with-descriptions' &&
-                  audioWithDescription.url && (
+                  audioWithDescription?.url && (
                     <AudioPlayer
                       title={stop.title} // TODO option not to display title
                       audioFile={audioWithDescription.url}
                     />
                   )}
                 {type === 'audio-without-descriptions' &&
-                  audioWithoutDescription.url && (
+                  audioWithoutDescription?.url && (
                     <AudioPlayer
                       title={title} // TODO option not to display title
                       audioFile={audioWithoutDescription.url}
                     />
                   )}
-                {type === 'bsl' && bsl.embedUrl && (
-                  <VideoEmbed embedUrl={bsl.embedUrl} />
+                {type === 'bsl' && bsl?.embed_url && (
+                  <VideoEmbed embedUrl={bsl.embed_url} />
                 )}
               </>
             ) : (
@@ -144,9 +152,7 @@ const Stops = ({ stops, type }) => {
 const ExhibitionStops = ({ type, stops }) => {
   switch (type) {
     case 'bsl':
-      return <Stops stops={stops} type={type} />;
     case 'audio-with-descriptions':
-      return <Stops stops={stops} type={type} />;
     case 'audio-without-descriptions':
       return <Stops stops={stops} type={type} />;
     case 'captions-and-transcripts':

--- a/content/webapp/services/prismic/transformers/exhibition-guides.ts
+++ b/content/webapp/services/prismic/transformers/exhibition-guides.ts
@@ -116,9 +116,9 @@ export function transformExhibitionGuide(
   const { data } = document;
 
   const components: ExhibitionGuideComponent[] = data.components?.map(
-    (component, index) => {
+    component => {
       return {
-        number: index.toString(), // TODO: Remove once Prismic UI allows us to add number
+        number: component.number || '',
         title: (component.title && asText(component.title)) || [],
         tombstone:
           (component.tombstone && asRichText(component.tombstone)) || [],

--- a/content/webapp/types/exhibition-guides.ts
+++ b/content/webapp/types/exhibition-guides.ts
@@ -1,8 +1,8 @@
 import { ImagePromo } from './image-promo';
 import { ImageType } from '@weco/common/model/image';
-import { MediaObjectType } from './media-object';
 import { EmbedField, RichTextField } from '@prismicio/types';
 import { GenericContentFields } from './generic-content-fields';
+import { Link } from './link';
 
 export type ExhibitionGuideComponent = {
   number: number;
@@ -12,8 +12,8 @@ export type ExhibitionGuideComponent = {
   caption: RichTextField;
   transcription: RichTextField;
   description?: string;
-  audioWithDescription?: MediaObjectType;
-  audioWithoutDescription?: MediaObjectType;
+  audioWithDescription?: Link;
+  audioWithoutDescription?: Link;
   bsl?: EmbedField;
 };
 


### PR DESCRIPTION
Use the stop numbers added in Prismic.

For another PR: Add some placeholder text in the Prismic number field so that it's (hopefully) more obvious that you can enter numbers in the borderless field to the right of the thing that you expect to be the number field.