### PR TITLE
Exhibition guide pages

### DIFF
--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -18,6 +18,7 @@ import { AppErrorProps } from '@weco/common/views/pages/_app';
 import styled from 'styled-components';
 import AudioPlayer from '@weco/common/views/components/AudioPlayer/AudioPlayer';
 import VideoEmbed from '@weco/common/views/components/VideoEmbed/VideoEmbed';
+import ButtonSolidLink from '@weco/common/views/components/ButtonSolidLink/ButtonSolidLink';
 
 const TypeLink = styled.a`
   flex-basis: calc(50% - 20px);
@@ -217,6 +218,18 @@ const ExhibitionGuidesPage: FC<Props> = props => {
             {exhibitionGuide.relatedExhibition && (
               <p>{exhibitionGuide.relatedExhibition.description}</p>
             )}
+            <p>
+              <Space as="span" h={{ size: 's', properties: ['margin-right'] }}>
+                <ButtonSolidLink
+                  text="Change guide type"
+                  link={`/guides/exhibitions/${exhibitionGuide.id}`}
+                />
+              </Space>
+              <ButtonSolidLink
+                text="Change exhibition"
+                link="/guides/exhibitions"
+              />
+            </p>
           </Space>
           <Space v={{ size: 'xl', properties: ['margin-top'] }}>
             <ExhibitionStops type={type} stops={exhibitionGuide.components} />

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -25,7 +25,7 @@ import VideoEmbed from '@weco/common/views/components/VideoEmbed/VideoEmbed';
 import ButtonSolidLink from '@weco/common/views/components/ButtonSolidLink/ButtonSolidLink';
 
 type StopProps = {
-  width: string;
+  width: number;
 };
 const Stop = styled(Space).attrs({
   as: 'li',
@@ -36,7 +36,7 @@ const Stop = styled(Space).attrs({
     width: calc(50% - 50px);
   `}
   ${props => props.theme.media.xlarge`
-    width: ${props => props.width};
+    ${props => `width: calc(${props.width}% - 50px)`};
   `}
 `;
 
@@ -115,7 +115,7 @@ type StopsProps = {
 };
 
 const Stops: FC<StopsProps> = ({ stops, type }) => {
-  const stopWidth = type === 'bsl' ? 'calc(50% - 50px)' : 'calc(33% - 50px)';
+  const stopWidth = type === 'bsl' ? 50 : 33;
 
   return (
     <ul

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -20,6 +20,22 @@ import AudioPlayer from '@weco/common/views/components/AudioPlayer/AudioPlayer';
 import VideoEmbed from '@weco/common/views/components/VideoEmbed/VideoEmbed';
 import ButtonSolidLink from '@weco/common/views/components/ButtonSolidLink/ButtonSolidLink';
 
+type StopProps = {
+  width: string;
+};
+const Stop = styled(Space).attrs({
+  as: 'li',
+  v: { size: 'm', properties: ['margin-bottom'] },
+})<StopProps>`
+  width: 100%;
+  ${props => props.theme.media.large`
+    width: calc(50% - 50px);
+  `}
+  ${props => props.theme.media.xlarge`
+    width: ${props => props.width};
+  `}
+`;
+
 const TypeLink = styled.a`
   flex-basis: calc(50% - 20px);
   flex-grow: 0;
@@ -90,8 +106,13 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   };
 
 const Stops = ({ stops, type }) => {
+  const stopWidth = type === 'bsl' ? 'calc(50% - 50px)' : 'calc(33% - 50px)';
+
   return (
-    <ul className="plain-list no-margin no-padding">
+    <ul
+      className="plain-list no-margin no-padding flex flex--wrap"
+      style={{ gap: '50px' }}
+    >
       {stops.map((stop, index) => {
         const {
           title,
@@ -106,7 +127,7 @@ const Stops = ({ stops, type }) => {
             audioWithoutDescription.url) ||
           (type === 'bsl' && bsl.embedUrl);
         return (
-          <li key={index}>
+          <Stop key={index} width={stopWidth}>
             <h2>
               {number}. {title}
             </h2>
@@ -135,7 +156,7 @@ const Stops = ({ stops, type }) => {
                 <p>There is no content to display</p>
               </>
             )}
-          </li>
+          </Stop>
         );
       })}
     </ul>


### PR DESCRIPTION
Builds on #8233

Just making the pages look and behave a bit more like the prototype
- adds links for changing type/exhibition
- adds some basic layout

![Screenshot 2022-08-03 at 14 03 12](https://user-images.githubusercontent.com/6051896/182627825-7a92c87f-b38b-47d6-b493-bb39b8468483.png)

