### PR TITLE
Try adding an oembed endpoint

### DIFF
--- a/content/webapp/app.ts
+++ b/content/webapp/app.ts
@@ -204,6 +204,22 @@ const appPromise = nextApp
       ctx.redirect(url);
     });
 
+    router.get('/oembed', async ctx => {
+      const iframeUrl = ctx.query.url;
+      const width = ctx.query.width || '320';
+      const height = ctx.query.height || '300';
+
+      const oembedResponseObject = {
+        type: 'rich',
+        version: '1.0',
+        width,
+        height,
+        html: `<iframe style='width: 100%; overflow: hidden;' src='${iframeUrl}' width='${width}' height='${height}' frameborder='0' scrolling='no'></iframe>`,
+      };
+      ctx.res.setHeader('Content-Type', 'application/json');
+      ctx.body = JSON.stringify(oembedResponseObject);
+    });
+
     router.get('/content/management/healthcheck', async ctx => {
       ctx.status = 200;
       ctx.body = 'ok';


### PR DESCRIPTION
Waiting to hear back from Chromatic about whether we can have an open-source plan for their tool that would allow us to embed Storybook stories inside e.g. GitBook.

In the meantime, I thought the [oEmbed spec](https://oembed.com/) looked relatively straightforward so wanted to see if we could conform to it ourselves. I thought I'd covered the required parts to get something to work, but no dice locally – not sure if the fact that it's local is an issue.

Any thoughts on whether or not this is a good idea/where the endpoint should live/why it doesn't work gratefully received.