### PR TITLE
Output rem for the font-size in Cardigan

### DIFF
--- a/cardigan/stories/global/typography/typography.stories.mdx
+++ b/cardigan/stories/global/typography/typography.stories.mdx
@@ -10,15 +10,13 @@ We have seven possible sizes for type, numbered `0` to `6`, with `0` being the l
 
 Each of these sizes is responsive, being largest at the large breakpoint, becoming smaller at the medium breakpoint and smaller still at the smallest breakpoint.
 
-In the table below, you can see that if a font is declared to be size `0`, it will be `50px` at the large breakpoint, `40px` at the medium breakpoint and `32px` at the small breakpoint.
-
 <Canvas>
   <Story story={stories.scale} />
 </Canvas>
 
 ## Font families
 
-We use Wellcome Bold, Helvetica Neue, and Lettera on the site.
+We use Wellcome Bold, Inter, and Lettera on the site.
 
 <Canvas>
   <Story story={stories.families} />

--- a/cardigan/stories/global/typography/typography.stories.tsx
+++ b/cardigan/stories/global/typography/typography.stories.tsx
@@ -31,9 +31,9 @@ const TypographyScale = ({ fontFamily }) => {
       return (
         <span
           key={index}
-          style={{ fontSize: `${v}px`, fontFamily: fontFamily }}
+          style={{ fontSize: `${v}rem`, fontFamily: fontFamily }}
         >
-          {v}px
+          {v}rem
         </span>
       );
     });


### PR DESCRIPTION
This was a change we made in the apps a little while ago but didn't port it across to the [type-scale section of Cardigan](https://cardigan.wellcomecollection.org/?path=/docs/global-typography--scale), meaning font-sizes are output in `px` where they should be `rem`.

__Before__
<img width="1030" alt="image" src="https://user-images.githubusercontent.com/1394592/182893820-23cd6194-829d-4a7b-a847-078eab03539a.png">


__After__
<img width="1039" alt="image" src="https://user-images.githubusercontent.com/1394592/182893725-303c8e6a-77c4-4566-b716-84f6213dcd34.png">

