### PR TITLE
Tidy up the datetime-types on the "What's on" page

### DIFF
--- a/content/webapp/pages/whats-on.tsx
+++ b/content/webapp/pages/whats-on.tsx
@@ -78,6 +78,7 @@ import {
   transformExhibitionsQuery,
 } from '../services/prismic/transformers/exhibitions';
 import { FacilityPromo as FacilityPromoType } from '../types/facility-promo';
+import { getNextWeekendDateRange } from '@weco/common/utils/dates';
 
 const segmentedControlItems = [
   {
@@ -117,30 +118,13 @@ export function getMomentsForPeriod(period: Period): (Moment | undefined)[] {
     case 'today':
       return [todaysDate.startOf('day'), todaysDate.endOf('day')];
     case 'this-weekend':
-      return [getWeekendFromDate(todaysDate), getWeekendToDate(todaysDate)];
+      const { start, end } = getNextWeekendDateRange(todaysDate);
+      return [start, end];
     // FIXME: this isn't really 'this week', but the 'next seven days' (needs UX/content rethink?)
     case 'this-week':
       return [todaysDate.startOf('day'), todaysDatePlusSix.endOf('day')];
     default:
       return [todaysDate.startOf('day'), undefined];
-  }
-}
-
-function getWeekendFromDate(today) {
-  const todayInteger = today.day(); // day() return Sun as 0, Sat as 6
-  if (todayInteger !== 0) {
-    return london(today).day(5);
-  } else {
-    return london(today).day(-2);
-  }
-}
-
-function getWeekendToDate(today) {
-  const todayInteger = today.day(); // day() return Sun as 0, Sat as 6
-  if (todayInteger === 0) {
-    return london(today);
-  } else {
-    return london(today).day(7);
   }
 }
 

--- a/content/webapp/pages/whats-on.tsx
+++ b/content/webapp/pages/whats-on.tsx
@@ -102,7 +102,7 @@ export type Props = {
   events: PaginatedResults<EventBasic>;
   availableOnlineEvents: PaginatedResults<EventBasic>;
   period: string;
-  dateRange: any[];
+  dateRange: (Moment | undefined)[];
   tryTheseTooPromos: FacilityPromoType[];
   eatShopPromos: FacilityPromoType[];
   featuredText: FeaturedTextType;

--- a/content/webapp/pages/whats-on.tsx
+++ b/content/webapp/pages/whats-on.tsx
@@ -112,7 +112,6 @@ export type Props = {
 
 export function getMomentsForPeriod(period: Period): (Moment | undefined)[] {
   const todaysDate = london();
-  const todaysDatePlusSix = todaysDate.clone().add(6, 'days');
 
   switch (period) {
     case 'today':
@@ -120,9 +119,6 @@ export function getMomentsForPeriod(period: Period): (Moment | undefined)[] {
     case 'this-weekend':
       const { start, end } = getNextWeekendDateRange(todaysDate);
       return [start, end];
-    // FIXME: this isn't really 'this week', but the 'next seven days' (needs UX/content rethink?)
-    case 'this-week':
-      return [todaysDate.startOf('day'), todaysDatePlusSix.endOf('day')];
     default:
       return [todaysDate.startOf('day'), undefined];
   }


### PR DESCRIPTION
I noticed we had `dateRange: any[]` on this page, which is a warning in VS Code.

I started tugging on the thread, discovered the types aren't quite right, found a place we could reuse an existing helper, and generally tidied it up a little.