### PR TITLE
Tidy up some JSON-LD types; move the Organisation contact info into the 'data' directory

### DIFF
--- a/catalogue/webapp/utils/json-ld.ts
+++ b/catalogue/webapp/utils/json-ld.ts
@@ -1,7 +1,8 @@
 import { Work as WorkType } from '@weco/common/model/catalogue';
 import { objToJsonLd } from '@weco/common/utils/json-ld';
+import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 
-export function workLd(work: WorkType) {
+export function workLd(work: WorkType): JsonLdObj {
   const creators = (work.contributors || []).map(c => {
     return {
       '@type': c.agent.type,
@@ -29,6 +30,6 @@ export function workLd(work: WorkType) {
       thumbnailUrl: work?.thumbnail?.url,
       license: work?.thumbnail?.license?.url,
     },
-    'CreativeWork'
+    { type: 'CreativeWork' }
   );
 }

--- a/common/README.md
+++ b/common/README.md
@@ -1,0 +1,8 @@
+# @weco/common
+
+This contains some code which is shared among the front-end apps.
+
+Of particular interest:
+
+*   The `data` directory holds most the hard-coded data for the site (e.g. microcopy, error messages, contact information).
+    We keep it in one place so it can be easily reviewed and updated across the site.

--- a/common/data/organization.ts
+++ b/common/data/organization.ts
@@ -1,0 +1,36 @@
+import { objToJsonLd } from '../utils/json-ld';
+import { Organization } from '../model/organization';
+
+export const wellcomeCollectionAddress = {
+  addressLocality: 'London',
+  postalCode: 'NW1 2BE',
+  streetAddress: '183 Euston Road',
+  addressCountry: 'UK',
+  addressMap:
+    'https://www.google.co.uk/maps/dir//Wellcome+Collection,+Euston+Road,+London/@51.5258128,-0.136211,17z/data=!4m8!4m7!1m0!1m5!1m1!1s0x48761b25f10b008f:0xed51ac6f865b038a!2m2!1d-0.133945!2d51.525851',
+};
+
+export const wellcomeCollectionGallery: Organization = {
+  name: 'Wellcome Collection',
+  url: 'https://wellcomecollection.org',
+  logo: {
+    url: 'https://i.wellcomecollection.org/assets/icons/apple-touch-icon.png',
+  },
+  sameAs: [
+    'https://twitter.com/ExploreWellcome',
+    'https://www.facebook.com/wellcomecollection',
+    'https://www.instagram.com/wellcomecollection/',
+    'https://www.youtube.com/user/WellcomeCollection',
+    'https://soundcloud.com/wellcomecollection',
+    'https://www.tripadvisor.co.uk/Attraction_Review-g186338-d662065-Reviews-Wellcome_Collection-London_England.html',
+  ],
+  openingHoursSpecification: [],
+  address: objToJsonLd(wellcomeCollectionAddress, {
+    type: 'PostalAddress',
+    root: false,
+  }),
+  isAccessibleForFree: true,
+  publicAccess: true,
+  telephone: '+4420 7611 2222',
+  displayTelephone: '+44 (0)20 7611 2222',
+};

--- a/common/model/opening-hours.ts
+++ b/common/model/opening-hours.ts
@@ -33,7 +33,7 @@ export type OpeningHoursDay = {
   dayOfWeek: Day;
   opens: string;
   closes: string;
-  isClosed: boolean;
+  isClosed?: boolean;
 };
 
 export type ExceptionalOpeningHoursDay = {
@@ -41,7 +41,7 @@ export type ExceptionalOpeningHoursDay = {
   overrideType: OverrideType;
   opens: string;
   closes: string;
-  isClosed: boolean;
+  isClosed?: boolean;
 };
 
 export type OpeningHours = {
@@ -63,6 +63,6 @@ export type Venue = {
 export type SpecialOpeningHours = {
   opens: string;
   closes: string;
-  validFrom: Date;
-  validThrough: Date;
+  validFrom: Date | string;
+  validThrough: Date | string;
 };

--- a/common/model/organization.ts
+++ b/common/model/organization.ts
@@ -1,5 +1,4 @@
 import type { OpeningHoursDay, SpecialOpeningHours } from './opening-hours';
-import { objToJsonLd } from '../utils/json-ld';
 
 type PostalAddress = {
   addressLocality: string;
@@ -21,38 +20,4 @@ export type Organization = {
   isAccessibleForFree: boolean;
   telephone: string;
   displayTelephone: string;
-};
-
-export const wellcomeCollectionAddress = {
-  addressLocality: 'London',
-  postalCode: 'NW1 2BE',
-  streetAddress: '183 Euston Road',
-  addressCountry: 'UK',
-  addressMap:
-    'https://www.google.co.uk/maps/dir//Wellcome+Collection,+Euston+Road,+London/@51.5258128,-0.136211,17z/data=!4m8!4m7!1m0!1m5!1m1!1s0x48761b25f10b008f:0xed51ac6f865b038a!2m2!1d-0.133945!2d51.525851',
-};
-
-export const wellcomeCollectionGallery: Organization = {
-  name: 'Wellcome Collection',
-  url: 'https://wellcomecollection.org',
-  logo: {
-    url: 'https://i.wellcomecollection.org/assets/icons/apple-touch-icon.png',
-  },
-  sameAs: [
-    'https://twitter.com/ExploreWellcome',
-    'https://www.facebook.com/wellcomecollection',
-    'https://www.instagram.com/wellcomecollection/',
-    'https://www.youtube.com/user/WellcomeCollection',
-    'https://soundcloud.com/wellcomecollection',
-    'https://www.tripadvisor.co.uk/Attraction_Review-g186338-d662065-Reviews-Wellcome_Collection-London_England.html',
-  ],
-  openingHoursSpecification: [],
-  address: objToJsonLd(wellcomeCollectionAddress, {
-    type: 'PostalAddress',
-    root: false,
-  }),
-  isAccessibleForFree: true,
-  publicAccess: true,
-  telephone: '+4420 7611 2222',
-  displayTelephone: '+44 (0)20 7611 2222',
 };

--- a/common/model/organization.ts
+++ b/common/model/organization.ts
@@ -47,11 +47,10 @@ export const wellcomeCollectionGallery: Organization = {
     'https://www.tripadvisor.co.uk/Attraction_Review-g186338-d662065-Reviews-Wellcome_Collection-London_England.html',
   ],
   openingHoursSpecification: [],
-  address: objToJsonLd(
-    wellcomeCollectionAddress,
-    'PostalAddress',
-    false
-  ) as PostalAddress,
+  address: objToJsonLd(wellcomeCollectionAddress, {
+    type: 'PostalAddress',
+    root: false,
+  }),
   isAccessibleForFree: true,
   publicAccess: true,
   telephone: '+4420 7611 2222',

--- a/common/utils/json-ld.ts
+++ b/common/utils/json-ld.ts
@@ -2,7 +2,11 @@ import { convertImageUri } from './convert-image-uri';
 import { Organization } from '../model/organization';
 import { BreadcrumbItems } from '../model/breadcrumbs';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
-import type { OpeningHours } from '../model/opening-hours';
+import type {
+  OpeningHours,
+  OpeningHoursDay,
+  SpecialOpeningHours,
+} from '../model/opening-hours';
 
 type ObjToJsonLdProps = { type: string; root?: boolean };
 
@@ -88,8 +92,8 @@ function imageLd(image: Image) {
 }
 
 export function openingHoursLd(openingHours: OpeningHours | undefined): {
-  openingHoursSpecification: JsonLdObj[];
-  specialOpeningHoursSpecification: JsonLdObj[];
+  openingHoursSpecification: OpeningHoursDay[];
+  specialOpeningHoursSpecification: SpecialOpeningHours[];
 } {
   return {
     openingHoursSpecification: openingHours?.regular

--- a/common/utils/json-ld.ts
+++ b/common/utils/json-ld.ts
@@ -2,13 +2,14 @@ import { convertImageUri } from './convert-image-uri';
 import { Organization } from '../model/organization';
 import { BreadcrumbItems } from '../model/breadcrumbs';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
-import type {
-  OpeningHours,
-  OpeningHoursDay,
-  SpecialOpeningHours,
-} from '../model/opening-hours';
+import type { OpeningHours } from '../model/opening-hours';
 
-export function objToJsonLd<T>(obj: T, type: string, root = true) {
+type ObjToJsonLdProps = { type: string; root?: boolean };
+
+export function objToJsonLd<T>(
+  obj: T,
+  { type, root = true }: ObjToJsonLdProps
+): T & JsonLdObj {
   const jsonObj = JSON.parse(JSON.stringify(obj));
   const jsonLdAddition = root
     ? {
@@ -25,21 +26,21 @@ export function museumLd(museum: Organization): JsonLdObj {
       ...museum,
       logo: imageLd(museum.logo),
     },
-    'Museum'
+    { type: 'Museum' }
   );
 }
 
-export function libraryLd(library: Organization) {
+export function libraryLd(library: Organization): JsonLdObj {
   return objToJsonLd(
     {
       ...library,
       logo: imageLd(library.logo),
     },
-    'Library'
+    { type: 'Library' }
   );
 }
 
-export function breadcrumbsLd(breadcrumbs: BreadcrumbItems) {
+export function breadcrumbsLd(breadcrumbs: BreadcrumbItems): JsonLdObj {
   return objToJsonLd(
     {
       itemListElement: breadcrumbs.items.map(({ url, text }, i) => {
@@ -49,12 +50,11 @@ export function breadcrumbsLd(breadcrumbs: BreadcrumbItems) {
             name: text,
             item: `https://wellcomecollection.org${url}`,
           },
-          'ListItem',
-          false
+          { type: 'ListItem', root: false }
         );
       }),
     },
-    'BreadcrumbList'
+    { type: 'BreadcrumbList' }
   );
 }
 
@@ -62,8 +62,8 @@ type WebpageProps = {
   url: string;
 };
 
-export function webpageLd(url: WebpageProps) {
-  return objToJsonLd({ url }, 'WebPage');
+export function webpageLd(url: WebpageProps): JsonLdObj {
+  return objToJsonLd({ url }, { type: 'WebPage' });
 }
 
 type Image = {
@@ -82,29 +82,26 @@ function imageLd(image: Image) {
         width: image.width,
         height: image.height,
       },
-      'ImageObject'
+      { type: 'ImageObject' }
     )
   );
 }
 
 export function openingHoursLd(openingHours: OpeningHours | undefined): {
-  openingHoursSpecification: OpeningHoursDay[];
-  specialOpeningHoursSpecification: SpecialOpeningHours[];
+  openingHoursSpecification: JsonLdObj[];
+  specialOpeningHoursSpecification: JsonLdObj[];
 } {
   return {
     openingHoursSpecification: openingHours?.regular
       ? openingHours.regular.map(openingHoursDay => {
-          const specObject = objToJsonLd(
+          return objToJsonLd(
             {
               dayOfWeek: openingHoursDay.dayOfWeek,
               opens: openingHoursDay.opens,
               closes: openingHoursDay.closes,
             },
-            'OpeningHoursSpecification',
-            false
+            { type: 'OpeningHoursSpecification', root: false }
           );
-          delete specObject.note;
-          return specObject;
         })
       : [],
     specialOpeningHoursSpecification: openingHours?.exceptional
@@ -115,7 +112,10 @@ export function openingHoursLd(openingHours: OpeningHours | undefined): {
             validFrom: openingHoursDate.overrideDate?.format('DD MMMM YYYY'),
             validThrough: openingHoursDate.overrideDate?.format('DD MMMM YYYY'),
           };
-          return objToJsonLd(specObject, 'OpeningHoursSpecification', false);
+          return objToJsonLd(specObject, {
+            type: 'OpeningHoursSpecification',
+            root: false,
+          });
         })
       : [],
   };

--- a/common/views/components/FindUs/FindUs.tsx
+++ b/common/views/components/FindUs/FindUs.tsx
@@ -3,7 +3,7 @@ import { font, classNames } from '../../../utils/classnames';
 import {
   wellcomeCollectionGallery,
   wellcomeCollectionAddress,
-} from '../../../model/organization';
+} from '../../../data/organization';
 import Space from '../styled/Space';
 import { FunctionComponent } from 'react';
 import { prismicPageIds } from '../../../services/prismic/hardcoded-id';

--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -14,7 +14,7 @@ import { museumLd, libraryLd, openingHoursLd } from '../../../utils/json-ld';
 import { collectionVenueId } from '../../../services/prismic/hardcoded-id';
 import { transformCollectionVenues } from '@weco/common/services/prismic/transformers/collection-venues';
 import { getVenueById } from '../../../services/prismic/opening-times';
-import { wellcomeCollectionGallery } from '../../../model/organization';
+import { wellcomeCollectionGallery } from '../../../data/organization';
 import GlobalInfoBarContext, {
   GlobalInfoBarContextProvider,
 } from '../GlobalInfoBarContext/GlobalInfoBarContext';

--- a/content/webapp/services/prismic/transformers/json-ld.ts
+++ b/content/webapp/services/prismic/transformers/json-ld.ts
@@ -38,7 +38,7 @@ export function exhibitionGuideLd(exhibitionGuide: ExhibitionGuide): JsonLdObj {
       text: exhibitionGuide.relatedExhibition?.description,
       discussionUrl: `https://wellcomecollection.org/guides/exhibition/${exhibitionGuide.id}`,
     },
-    'ExhibtionGuide'
+    { type: 'ExhibitionGuide' }
   );
 }
 
@@ -52,7 +52,10 @@ export function exhibitionLd(exhibition: Exhibition): JsonLdObj {
       location: {
         '@type': 'Place',
         name: 'Wellcome Collection',
-        address: objToJsonLd(wellcomeCollectionAddress, 'PostalAddress', false),
+        address: objToJsonLd(wellcomeCollectionAddress, {
+          type: 'PostalAddress',
+          root: false,
+        }),
       },
       startDate: exhibition.start,
       endDate: exhibition.end,
@@ -67,12 +70,11 @@ export function exhibitionLd(exhibition: Exhibition): JsonLdObj {
               ? getImageUrlAtSize(contributor.image, { w: 600 })
               : undefined,
           },
-          type,
-          false
+          { type, root: false }
         );
       }),
     },
-    'ExhibitionEvent'
+    { type: 'ExhibitionEvent' }
   );
 }
 
@@ -94,11 +96,10 @@ export function eventLd(event: Event | EventBasic): JsonLdObj[] {
           location: {
             '@type': 'Place',
             name: 'Wellcome Collection',
-            address: objToJsonLd(
-              wellcomeCollectionAddress,
-              'PostalAddress',
-              false
-            ),
+            address: objToJsonLd(wellcomeCollectionAddress, {
+              type: 'PostalAddress',
+              root: false,
+            }),
           },
           startDate: event.times.map(time => time.range.startDateTime),
           endDate: event.times.map(time => time.range.endDateTime),
@@ -117,12 +118,11 @@ export function eventLd(event: Event | EventBasic): JsonLdObj[] {
                   ? getImageUrlAtSize(contributor.image, { w: 600 })
                   : undefined,
               },
-              type,
-              false
+              { type, root: false }
             );
           }),
         },
-        'Event'
+        { type: 'Event' }
       );
     });
 }
@@ -144,8 +144,7 @@ export function articleLd(article: Article): JsonLdObj {
               ? getImageUrlAtSize(contributor.image, { w: 600 })
               : undefined,
           },
-          type,
-          false
+          { type, root: false }
         );
       }),
       dateCreated: article.datePublished,
@@ -160,8 +159,7 @@ export function articleLd(article: Article): JsonLdObj {
                   ? getImageUrlAtSize(author.contributor.image, { w: 600 })
                   : undefined,
               },
-              'Person',
-              false
+              { type: 'Person', root: false }
             )
           : undefined,
       image: article.promo?.image?.contentUrl,
@@ -169,7 +167,7 @@ export function articleLd(article: Article): JsonLdObj {
       publisher: orgLd(wellcomeCollectionGallery),
       url: `https://wellcomecollection.org/articles/${article.id}`,
     },
-    'Article'
+    { type: 'Article' }
   );
 }
 
@@ -183,7 +181,7 @@ function orgLd(org: Organization) {
         logo: org.logo.url,
         sameAs: org.sameAs,
       },
-      'Organization'
+      { type: 'Organization' }
     )
   );
 }
@@ -211,8 +209,7 @@ export function contentLd(content: Page | Season): JsonLdObj {
                   ? getImageUrlAtSize(author.contributor.image, { w: 600 })
                   : undefined,
               },
-              'Person',
-              false
+              { type: 'Person', root: false }
             )
           : undefined,
       image: promoImage ? getImageUrlAtSize(promoImage, { w: 600 }) : undefined,
@@ -221,6 +218,6 @@ export function contentLd(content: Page | Season): JsonLdObj {
       publisher: orgLd(wellcomeCollectionGallery),
       mainEntityOfPage: `https://wellcomecollection.org${url}`,
     },
-    'Article'
+    { type: 'Article' }
   );
 }

--- a/content/webapp/services/prismic/transformers/json-ld.ts
+++ b/content/webapp/services/prismic/transformers/json-ld.ts
@@ -1,9 +1,9 @@
 import { Event, EventBasic } from '../../../types/events';
 import {
-  Organization,
   wellcomeCollectionAddress,
   wellcomeCollectionGallery,
-} from '@weco/common/model/organization';
+} from '@weco/common/data/organization';
+import { Organization } from '@weco/common/model/organization';
 import { getImageUrlAtSize } from '../types/images';
 import { Article } from '../../../types/articles';
 import { Contributor } from '../../../types/contributors';


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/wellcomecollection.org/issues/7830, or at least as best as we're going to do it for now.

This moves the Organisation contact info into the `data` directory, where I'm gradually trying to consolidate all the hard-coded information and magic strings. It'll be easier to review and manage when it's all in one place.