### PR TITLE
Tidy error message markup/style

### DIFF
--- a/common/data/errors.tsx
+++ b/common/data/errors.tsx
@@ -1,6 +1,6 @@
+import { FC } from 'react';
 import { prismicPageIds } from '../services/prismic/hardcoded-id';
 import Layout8 from '../views/components/Layout8/Layout8';
-import MoreLink from '../views/components/MoreLink/MoreLink';
 import Space from '../views/components/styled/Space';
 
 export const errorMessages = {
@@ -8,12 +8,11 @@ export const errorMessages = {
   500: 'Internal Server Error',
 };
 
-export const DefaultErrorText = () => (
+export const DefaultErrorText: FC = () => (
   <Layout8>
     <Space
-      className="plain-list no-padding"
-      as="ul"
-      v={{ size: 'l', properties: ['margin-bottom'] }}
+      className="body-text"
+      v={{ size: 'l', properties: ['margin-top', 'margin-bottom'] }}
     >
       <p>
         Looks like something’s not working properly our end. We’ll try to fix it
@@ -35,12 +34,11 @@ export const DefaultErrorText = () => (
   </Layout8>
 );
 
-export const NotFoundErrorText = () => (
+export const NotFoundErrorText: FC = () => (
   <Layout8>
     <Space
-      className="plain-list no-padding"
-      as="ul"
-      v={{ size: 'l', properties: ['margin-bottom'] }}
+      className="body-text"
+      v={{ size: 'l', properties: ['margin-top', 'margin-bottom'] }}
     >
       <p>
         We can’t find the page you’re looking for. Maybe one of these will help:
@@ -59,10 +57,8 @@ export const NotFoundErrorText = () => (
           <a href="/get-involved">Collaborating with us</a>
         </li>
         <li>
-          <p>
-            Read{' '}
-            <a href="/stories">articles on our Stories publishing platform</a>
-          </p>
+          Read{' '}
+          <a href="/stories">articles on our Stories publishing platform</a>
         </li>
       </ul>
       <p>


### PR DESCRIPTION
`ul`s are only allowed to contain `li`s (and `script`s and `template`s apparently). Moving the markup around a bit to keep it valid and adding a [`body-text` class](https://github.com/wellcomecollection/wellcomecollection.org/blob/6ab5fb1e754d7e853352c7601b3eb69607ad14ca/common/views/themes/typography.ts#L228-L290) to the root of each section of error text so that they follow our styling for e.g. bullets and links.

<img width="1148" alt="Screenshot 2022-08-08 at 10 55 46" src="https://user-images.githubusercontent.com/1394592/183393646-0449252d-c780-4f30-925c-eaa54ccb63ef.png">

