### PR TITLE
Add tzitzit to METS images, hide link if license is INC

### DIFF
--- a/common/model/catalogue.ts
+++ b/common/model/catalogue.ts
@@ -151,7 +151,7 @@ type LocationType = {
   type: 'LocationType';
 };
 
-type License = {
+export type License = {
   id: string;
   label: string;
   url: string;

--- a/common/model/catalogue.ts
+++ b/common/model/catalogue.ts
@@ -94,7 +94,7 @@ type ContributorRole = {
   type: 'ContributionRole';
 };
 
-type Contributor = {
+export type Contributor = {
   agent: Agent;
   roles: ContributorRole[];
   type: 'Contributor';

--- a/common/views/components/ApiToolbar/ApiToolbar.tsx
+++ b/common/views/components/ApiToolbar/ApiToolbar.tsx
@@ -3,7 +3,13 @@ import { FunctionComponent, useEffect, useState } from 'react';
 import { ParsedUrlQuery } from 'querystring';
 import cookies from 'next-cookies';
 import useIsomorphicLayoutEffect from '../../../hooks/useIsomorphicLayoutEffect';
-import { Work, Location, Image, Contributor } from '../../../model/catalogue';
+import {
+  Work,
+  Location,
+  Image,
+  Contributor,
+  License,
+} from '../../../model/catalogue';
 import { looksLikePrismicId } from '../../../services/prismic';
 
 type Prop = {
@@ -46,17 +52,19 @@ function setTzitzitParams({
 }: {
   title: string;
   sourceLink: string;
-  licence: string;
+  licence: License | undefined;
   contributors: Contributor[] | undefined;
 }): Prop | undefined {
+  const licenceId = licence?.id.toUpperCase();
+
   // We should not be using in copyright images in Stories
-  if (licence === 'INC') return;
+  if (licenceId === 'INC') return;
 
   const params = new URLSearchParams();
   params.set('title', title);
   params.set('sourceName', 'Wellcome Collection');
   params.set('sourceLink', sourceLink);
-  if (licence) params.set('licence', licence);
+  if (licenceId) params.set('licence', licenceId);
   if (contributors && contributors.length > 0)
     params.set('author', contributors[0].agent.label);
 
@@ -76,7 +84,7 @@ async function createTzitzitImageLink(
   return setTzitzitParams({
     title: image.source.title,
     sourceLink: window.location.toString(),
-    licence: image.locations[0].license.id.toUpperCase(),
+    licence: image.locations[0].license,
     contributors: image.source.contributors,
   });
 }
@@ -99,8 +107,8 @@ async function createTzitzitWorkLink(
     sourceLink: window.location.toString(),
     licence:
       digitalLocation?.type === 'DigitalLocation'
-        ? digitalLocation.license.id.toUpperCase()
-        : '',
+        ? digitalLocation.license
+        : undefined,
     contributors: work.contributors,
   });
 }


### PR DESCRIPTION
This is still a bit of a WIP as I'm figuring out all the types; please do comment anything that could help make this better, or be done differently.

## Who is this for?
Editorial team

## What is it doing for them?
- Adds the tzitzit tools for digitised images (making it easier to get copyright information for digitised images, so Stories editors spend less time copy/pasting.)
- Will now hide the link when the licence is INC (in copyright)
- Closes #8246