### PR TITLE
Exhibition guides audio listing

### DIFF
--- a/common/views/components/AudioPlayer/AudioPlayer.tsx
+++ b/common/views/components/AudioPlayer/AudioPlayer.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState, FC, Ref, SyntheticEvent } from 'react';
 import { dasherize } from '@weco/common/utils/grammar';
-import Control from '@weco/common/views/components/Buttons/Control/Control';
+import Icon from '@weco/common/views/components/Icon/Icon';
 import {
   play,
   pause,
@@ -15,18 +15,41 @@ import { trackEvent } from '@weco/common/utils/ga';
 const VolumeWrapper = styled.div`
   display: flex;
   align-items: center;
-
-  button {
-    transform: scale(0.7);
-  }
+  gap: 5px;
 
   input {
     width: 60px;
   }
 `;
 
+const PlayPauseButton = styled.button.attrs<{ isPlaying: boolean }>(props => ({
+  className: 'plain-button no-padding',
+  ariaPressed: props.isPlaying,
+}))<{ isPlaying: boolean }>`
+  svg {
+    transform: translateX(${props => (!props.isPlaying ? '2px' : '0')});
+  }
+`;
+
+const PlayPauseInner = styled.div`
+  border: 2px solid ${props => props.theme.color('pewter')};
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const MuteUnmuteButton = styled.button.attrs<{ isMuted: boolean }>(props => ({
+  className: 'plain-button no-padding',
+  ariaPressed: props.isMuted,
+}))``;
+
 // FIXME: this exists because the `volumeMute` icon I created is 1px off
 const VolumeControlWrapper = styled.div<{ isMuted: boolean }>`
+  display: flex;
+
   ${props =>
     props.isMuted &&
     `
@@ -49,22 +72,11 @@ const AudioPlayerGrid = styled.div`
   display: grid;
   grid-template-columns: auto 1fr auto;
   align-items: center;
+  gap: 5px;
 `;
 
 const SecondRow = styled.div`
   grid-column: 1 / -1;
-`;
-
-const PlayControlWrapper = styled(Space).attrs<{ isPlaying: boolean }>({
-  h: { size: 'm', properties: ['margin-right'] },
-})<{ isPlaying: boolean }>`
-  ${props =>
-    !props.isPlaying &&
-    `
-    svg {
-      transform: translateX(2px);
-    }
-  `}
 `;
 
 const PlayRateRadio = styled.input.attrs({
@@ -189,13 +201,12 @@ const Volume: FC<VolumeProps> = ({ audioPlayer, id }) => {
   return (
     <VolumeWrapper>
       <VolumeControlWrapper isMuted={isMuted || volume === 0}>
-        <Control
-          colorScheme="light"
-          icon={isMuted || volume === 0 ? volumeMuted : volumeIcon}
-          clickHandler={onVolumeButtonClick}
-          text={isMuted ? `muted` : `unmuted`}
-          ariaPressed={`${isMuted}`}
-        />
+        <MuteUnmuteButton onClick={onVolumeButtonClick}>
+          <Icon
+            color="pewter"
+            icon={isMuted || volume === 0 ? volumeMuted : volumeIcon}
+          />
+        </MuteUnmuteButton>
       </VolumeControlWrapper>
       <div style={{ lineHeight: 0 }}>
         <label htmlFor={`volume-${id}`}>
@@ -366,15 +377,11 @@ export const AudioPlayer: FC<AudioPlayerProps> = ({
       </Space>
 
       <AudioPlayerGrid>
-        <PlayControlWrapper isPlaying={isPlaying}>
-          <Control
-            colorScheme="light"
-            icon={isPlaying ? pause : play}
-            clickHandler={onTogglePlay}
-            text={isPlaying ? `pause` : `play`}
-            ariaPressed={`${isPlaying}`}
-          />
-        </PlayControlWrapper>
+        <PlayPauseButton onClick={onTogglePlay} isPlaying={isPlaying}>
+          <PlayPauseInner>
+            <Icon color="pewter" icon={isPlaying ? pause : play} />
+          </PlayPauseInner>
+        </PlayPauseButton>
 
         <div className="full-width">
           <Scrubber

--- a/common/views/components/AudioPlayer/AudioPlayer.tsx
+++ b/common/views/components/AudioPlayer/AudioPlayer.tsx
@@ -52,7 +52,7 @@ const AudioPlayerGrid = styled.div`
 `;
 
 const SecondRow = styled.div`
-  grid-column: 2 / -1;
+  grid-column: 1 / -1;
 `;
 
 const PlayControlWrapper = styled(Space).attrs<{ isPlaying: boolean }>({

--- a/common/views/themes/config.ts
+++ b/common/views/themes/config.ts
@@ -118,7 +118,7 @@ export const colors = {
   // Opacity value explanation; We use transparent to provide a background to white text which overlays a variety of images (therefore unknown colour contrast).  This opacity is the lightest we can go, while still providing sufficient contrast to pass WCAG guidlines, when it is displayed above a white background, i.e. worst case scenario.
   inherit: { base: 'inherit', dark: '', light: '' },
   currentColor: { base: 'currentColor', dark: '', light: '' },
-  greenNewPalette: { base: '#e7b792', dark: '', light: '' },
+  newPaletteOrange: { base: '#e7b792', dark: '', light: '' },
 };
 
 const getColor = (name: PaletteColor, variant: ColorVariant = 'base'): string =>

--- a/common/views/themes/config.ts
+++ b/common/views/themes/config.ts
@@ -118,6 +118,7 @@ export const colors = {
   // Opacity value explanation; We use transparent to provide a background to white text which overlays a variety of images (therefore unknown colour contrast).  This opacity is the lightest we can go, while still providing sufficient contrast to pass WCAG guidlines, when it is displayed above a white background, i.e. worst case scenario.
   inherit: { base: 'inherit', dark: '', light: '' },
   currentColor: { base: 'currentColor', dark: '', light: '' },
+  greenNewPalette: { base: '#e7b792', dark: '', light: '' },
 };
 
 const getColor = (name: PaletteColor, variant: ColorVariant = 'base'): string =>

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -55,7 +55,7 @@ const TypeLink = styled.a`
 const Header = styled(Space).attrs({
   v: { size: 'xl', properties: ['padding-top', 'padding-bottom'] },
 })`
-  background: ${props => props.theme.color('greenNewPalette')};
+  background: ${props => props.theme.color('newPaletteOrange')};
 `;
 
 const typeNames = [

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -13,7 +13,7 @@ import { exhibitionGuideLd } from '../services/prismic/transformers/json-ld';
 import { pageDescriptions } from '@weco/common/data/microcopy';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 import { looksLikePrismicId } from '@weco/common/services/prismic';
-import Layout10 from '@weco/common/views/components/Layout10/Layout10';
+import Layout12 from '@weco/common/views/components/Layout12/Layout12';
 import Space from '@weco/common/views/components/styled/Space';
 import ExhibitionCaptions from '../components/ExhibitionCaptions/ExhibitionCaptions';
 import { GetServerSideProps } from 'next';
@@ -23,21 +23,17 @@ import { exhibitionGuidesLinks } from '@weco/common/views/components/Header/Head
 import AudioPlayer from '@weco/common/views/components/AudioPlayer/AudioPlayer';
 import VideoEmbed from '@weco/common/views/components/VideoEmbed/VideoEmbed';
 import ButtonSolidLink from '@weco/common/views/components/ButtonSolidLink/ButtonSolidLink';
+import GridFactory from '@weco/content/components/Body/GridFactory';
+import { font } from '@weco/common/utils/classnames';
 
 type StopProps = {
   width: number;
 };
 const Stop = styled(Space).attrs({
-  as: 'li',
-  v: { size: 'm', properties: ['margin-bottom'] },
+  v: { size: 'm', properties: ['padding-top', 'padding-bottom'] },
+  h: { size: 'm', properties: ['padding-left', 'padding-right'] },
 })<StopProps>`
-  width: 100%;
-  ${props => props.theme.media.large`
-    width: calc(50% - 50px);
-  `}
-  ${props => props.theme.media.xlarge`
-    ${props => `width: calc(${props.width}% - 50px)`};
-  `}
+  background: ${props => props.theme.color('cream')};
 `;
 
 const TypeLink = styled.a`
@@ -118,11 +114,8 @@ const Stops: FC<StopsProps> = ({ stops, type }) => {
   const stopWidth = type === 'bsl' ? 50 : 33;
 
   return (
-    <ul
-      className="plain-list no-margin no-padding flex flex--wrap"
-      style={{ gap: '50px' }}
-    >
-      {stops.map((stop, index) => {
+    <GridFactory
+      items={stops.map((stop, index) => {
         const {
           title,
           number,
@@ -137,22 +130,19 @@ const Stops: FC<StopsProps> = ({ stops, type }) => {
           (type === 'bsl' && bsl?.embedUrl);
         return (
           <Stop key={index} width={stopWidth}>
-            <h2>
-              {number}. {title}
-            </h2>
             {hasContentOfDesiredType ? (
               <>
                 {type === 'audio-with-descriptions' &&
                   audioWithDescription?.url && (
                     <AudioPlayer
-                      title={stop.title} // TODO option not to display title
+                      title={`${number}. ${stop.title}`} // TODO option not to display title
                       audioFile={audioWithDescription.url}
                     />
                   )}
                 {type === 'audio-without-descriptions' &&
                   audioWithoutDescription?.url && (
                     <AudioPlayer
-                      title={title} // TODO option not to display title
+                      title={`${number}. ${stop.title}`} // TODO option not to display title
                       audioFile={audioWithoutDescription.url}
                     />
                   )}
@@ -162,13 +152,16 @@ const Stops: FC<StopsProps> = ({ stops, type }) => {
               </>
             ) : (
               <>
+                <span className={font('hnb', 5)}>
+                  {number}. {title}
+                </span>
                 <p>There is no content to display</p>
               </>
             )}
           </Stop>
         );
       })}
-    </ul>
+    />
   );
 };
 
@@ -207,7 +200,7 @@ const ExhibitionGuidesPage: FC<Props> = props => {
       hideFooter={true}
     >
       {!type ? (
-        <Layout10>
+        <Layout12>
           <Space v={{ size: 'xl', properties: ['margin-top'] }}>
             <h1 className="h1">{`Choose the ${exhibitionGuide.title} guide for you`}</h1>
           </Space>
@@ -241,34 +234,39 @@ const ExhibitionGuidesPage: FC<Props> = props => {
               </p>
             </TypeLink>
           </Space>
-        </Layout10>
+        </Layout12>
       ) : (
-        <Layout10>
-          <Space v={{ size: 'xl', properties: ['margin-top'] }}>
-            <h2>{exhibitionGuide.title}</h2>
-          </Space>
-          <Space v={{ size: 'xl', properties: ['margin-top'] }}>
-            <h3>Introduction</h3>
-            {exhibitionGuide.relatedExhibition && (
-              <p>{exhibitionGuide.relatedExhibition.description}</p>
-            )}
-            <p>
-              <Space as="span" h={{ size: 's', properties: ['margin-right'] }}>
+        <>
+          <Layout12>
+            <Space v={{ size: 'xl', properties: ['margin-top'] }}>
+              <h2>{exhibitionGuide.title}</h2>
+            </Space>
+            <Space v={{ size: 'xl', properties: ['margin-top'] }}>
+              <h3>Introduction</h3>
+              {exhibitionGuide.relatedExhibition && (
+                <p>{exhibitionGuide.relatedExhibition.description}</p>
+              )}
+              <p>
+                <Space
+                  as="span"
+                  h={{ size: 's', properties: ['margin-right'] }}
+                >
+                  <ButtonSolidLink
+                    text="Change guide type"
+                    link={`/guides/exhibitions/${exhibitionGuide.id}`}
+                  />
+                </Space>
                 <ButtonSolidLink
-                  text="Change guide type"
-                  link={`/guides/exhibitions/${exhibitionGuide.id}`}
+                  text="Change exhibition"
+                  link="/guides/exhibitions"
                 />
-              </Space>
-              <ButtonSolidLink
-                text="Change exhibition"
-                link="/guides/exhibitions"
-              />
-            </p>
-          </Space>
+              </p>
+            </Space>
+          </Layout12>
           <Space v={{ size: 'xl', properties: ['margin-top'] }}>
             <ExhibitionStops type={type} stops={exhibitionGuide.components} />
           </Space>
-        </Layout10>
+        </>
       )}
     </PageLayout>
   );

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -14,6 +14,7 @@ import { pageDescriptions } from '@weco/common/data/microcopy';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 import { looksLikePrismicId } from '@weco/common/services/prismic';
 import Layout12 from '@weco/common/views/components/Layout12/Layout12';
+import Layout8 from '@weco/common/views/components/Layout8/Layout8';
 import Space from '@weco/common/views/components/styled/Space';
 import ExhibitionCaptions from '../components/ExhibitionCaptions/ExhibitionCaptions';
 import { GetServerSideProps } from 'next';
@@ -22,7 +23,7 @@ import styled from 'styled-components';
 import { exhibitionGuidesLinks } from '@weco/common/views/components/Header/Header';
 import AudioPlayer from '@weco/common/views/components/AudioPlayer/AudioPlayer';
 import VideoEmbed from '@weco/common/views/components/VideoEmbed/VideoEmbed';
-import ButtonSolidLink from '@weco/common/views/components/ButtonSolidLink/ButtonSolidLink';
+import ButtonOutlinedLink from '@weco/common/views/components/ButtonOutlinedLink/ButtonOutlinedLink';
 import GridFactory from '@weco/content/components/Body/GridFactory';
 import { font } from '@weco/common/utils/classnames';
 
@@ -51,6 +52,12 @@ const TypeLink = styled.a`
   }
 `;
 
+const Header = styled(Space).attrs({
+  v: { size: 'xl', properties: ['padding-top', 'padding-bottom'] },
+})`
+  background: ${props => props.theme.color('greenNewPalette')};
+`;
+
 const typeNames = [
   'bsl',
   'audio-with-descriptions',
@@ -68,6 +75,19 @@ type Props = {
   jsonLd: JsonLdObj;
   type?: GuideType;
 };
+
+function getTypeTitle(type: GuideType): string {
+  switch (type) {
+    case 'bsl':
+      return 'BSL';
+    case 'audio-with-descriptions':
+      return 'Audio with descriptions';
+    case 'audio-without-descriptions':
+      return 'Audio without descriptions';
+    case 'captions-and-transcripts':
+      return 'Captions and transcripts';
+  }
+}
 
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
@@ -237,32 +257,30 @@ const ExhibitionGuidesPage: FC<Props> = props => {
         </Layout12>
       ) : (
         <>
-          <Layout12>
-            <Space v={{ size: 'xl', properties: ['margin-top'] }}>
-              <h2>{exhibitionGuide.title}</h2>
-            </Space>
-            <Space v={{ size: 'xl', properties: ['margin-top'] }}>
-              <h3>Introduction</h3>
-              {exhibitionGuide.relatedExhibition && (
-                <p>{exhibitionGuide.relatedExhibition.description}</p>
-              )}
-              <p>
+          <Header>
+            <Layout8 shift={false}>
+              <>
+                <h2 className="h0 no-margin">{exhibitionGuide.title}</h2>
+                <h3 className="h1">{getTypeTitle(type)}</h3>
+                {exhibitionGuide.relatedExhibition && (
+                  <p>{exhibitionGuide.relatedExhibition.description}</p>
+                )}
                 <Space
                   as="span"
                   h={{ size: 's', properties: ['margin-right'] }}
                 >
-                  <ButtonSolidLink
+                  <ButtonOutlinedLink
                     text="Change guide type"
                     link={`/guides/exhibitions/${exhibitionGuide.id}`}
                   />
                 </Space>
-                <ButtonSolidLink
+                <ButtonOutlinedLink
                   text="Change exhibition"
                   link="/guides/exhibitions"
                 />
-              </p>
-            </Space>
-          </Layout12>
+              </>
+            </Layout8>
+          </Header>
           <Space v={{ size: 'xl', properties: ['margin-top'] }}>
             <ExhibitionStops type={type} stops={exhibitionGuide.components} />
           </Space>


### PR DESCRIPTION
Part of #8261

![image](https://user-images.githubusercontent.com/1394592/183891524-67aab15c-fdda-4c3f-b349-7f27192365d6.png)

- Rearranging the AudioPlayer a bit to make sure it fits at as many grid widths as possible
- I've stopped using the `Control` component for the buttons in order to closer match the designs – this is obviously a bit messy for now, but I think we need to build some new things and then reassess what can be consolidated back into a design system in future
- Buttons in the header area will need updating to have a white background (not currently possible with our buttons)