### PR TITLE
Make player rate radios less busy

### DIFF
--- a/common/views/components/AudioPlayer/AudioPlayer.tsx
+++ b/common/views/components/AudioPlayer/AudioPlayer.tsx
@@ -97,7 +97,7 @@ const PlayRateLabel = styled.label<{ isActive: boolean }>`
   border-radius: 5px;
   text-align: center;
   background: ${props =>
-    props.theme.color(props.isActive ? 'yellow' : 'marble')};
+    props.isActive ? props.theme.color('yellow') : undefined}; ;
 `;
 
 const formatVolume = (vol: number): string => {


### PR DESCRIPTION
A suggestion from @GarethOrmerod to make the playrate radio buttons less visually busy (which will help to reduce clutter when we have multiple players side-by-side e.g. on listing pages)

__Before__
<img width="428" alt="image" src="https://user-images.githubusercontent.com/1394592/183931761-7ddb6316-5b53-42dc-a33b-e396c8104d6e.png">

__After__
<img width="419" alt="image" src="https://user-images.githubusercontent.com/1394592/183930604-e9d59022-9304-4ac8-8578-2d1a2cb4dc45.png">
