### PR TITLE
Fix the way we redact query parameters in logs

### DIFF
--- a/identity/webapp/src/utility/logging.test.ts
+++ b/identity/webapp/src/utility/logging.test.ts
@@ -1,0 +1,27 @@
+import { redactUrl } from './logging';
+
+describe('redactUrl', () => {
+  it('redacts query parameters in URLs', () => {
+    const url =
+      'https://example.com/account?token=supersekrit&state=anothersekrit';
+    const redactedUrl = redactUrl(url);
+
+    expect(redactedUrl).toBe(
+      'https://example.com/account?token=[redacted]&state=[redacted]'
+    );
+  });
+
+  it('skips URLs without query parameters', () => {
+    const url = 'https://example.com/account';
+    const redactedUrl = redactUrl(url);
+
+    expect(redactedUrl).toBe(url);
+  });
+
+  it('redacts relative URLs', () => {
+    const url = '/account?token=supersekrit&state=anothersekrit';
+    const redactedUrl = redactUrl(url);
+
+    expect(redactedUrl).toBe('/account?token=[redacted]&state=[redacted]');
+  });
+});

--- a/identity/webapp/src/utility/logging.ts
+++ b/identity/webapp/src/utility/logging.ts
@@ -1,0 +1,39 @@
+import { format as formatUrl, parse } from 'url'; // eslint-disable-line node/no-deprecated-api
+
+// This function redacts query parameters in URLs, so we have a URL that's
+// safe to log.  For example, we might get a log including:
+//
+//      /account/registration?session_token=eyJhbGciOi...{some sort of jwt}
+//
+// where the JWT could be decoded to reveal personal information including
+// email address and IP address.
+//
+// This function will replace the URL with:
+//
+//      /account/registration?session_token=[redacted]
+//
+// It is deliberately un-picky about what it redacts, because we'd rather
+// remove something innocent (e.g. ?refresh=true) than miss something sensitive.
+export const redactUrl = (url: string): string => {
+  // Note: we use a deprecated API here because we're working with
+  // relative URLs, e.g. `/account`.
+  //
+  // The WHATWG URL API that the deprecation message suggests doesn't
+  // work for this use case; it wants absolute URLs.
+  const parsedUrl = parse(url);
+  const params = new URLSearchParams(parsedUrl.query);
+
+  for (const key of params.keys()) {
+    params.set(key, '[redacted]');
+  }
+
+  parsedUrl.query = params.toString();
+  parsedUrl.search = `?${params.toString()}`;
+
+  // When the square brackets get URL-encoded, they're replaced with
+  // percent characters, e.g. `/account?token=%5Bredacted%5D`.
+  //
+  // Because they aren't actually URL characters, we put back the
+  // original brackets for ease of readability.
+  return formatUrl(parsedUrl).replace(/%5Bredacted%5D/g, '[redacted]');
+};

--- a/identity/webapp/src/utility/logging.ts
+++ b/identity/webapp/src/utility/logging.ts
@@ -21,6 +21,12 @@ export const redactUrl = (url: string): string => {
   // The WHATWG URL API that the deprecation message suggests doesn't
   // work for this use case; it wants absolute URLs.
   const parsedUrl = parse(url);
+
+  // If there are no query parameters to redact, we don't need to do anything.
+  if (parsedUrl.query === null) {
+    return url;
+  }
+
   const params = new URLSearchParams(parsedUrl.query);
 
   for (const key of params.keys()) {


### PR DESCRIPTION
## Who is this for?

Devs reading app logs.

## What is it doing for them?

Making the URLs more accurate. Here's an [example of what the logs look like](https://logging.wellcomecollection.org/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2022-08-15T06:00:17.208Z',to:'2022-08-15T06:15:13.822Z'))&_a=(columns:!(log),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'94746ad0-81c5-11eb-b41a-c9fd641654c0',key:ecs_cluster,negate:!f,params:(query:experience-frontend-prod),type:phrase),query:(match_phrase:(ecs_cluster:experience-frontend-prod))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'94746ad0-81c5-11eb-b41a-c9fd641654c0',key:service_name,negate:!f,params:(query:identity-18012021-prod),type:phrase),query:(match_phrase:(service_name:identity-18012021-prod)))),index:'94746ad0-81c5-11eb-b41a-c9fd641654c0',interval:auto,query:(language:kuery,query:''),sort:!(!('@timestamp',desc)))):

```
-x- GET /account/api/auth/me? 401 4ms 110b
<-- GET /account/api/auth/me?
```

That question mark is misleading – this request didn't come with an empty query string; it's a bug in the code I wrote to redact query parameters in logged URLs.

This patch moves that redaction code into a dedicated function, so it can be tested properly, and includes both a test and a fix for this bug.