### PR TITLE
Speculative URL checker improvements

### DIFF
--- a/playwright/url-checker/check-url.ts
+++ b/playwright/url-checker/check-url.ts
@@ -26,6 +26,12 @@ export type Failures = {
 
 export type Result = Success | Failures;
 
+const cachebustUrl = (url: string): string => {
+  const parsedUrl = new URL(url);
+  parsedUrl.searchParams.set('cachebust', Date.now().toString());
+  return parsedUrl.toString();
+};
+
 export const urlChecker =
   (browser: Browser) =>
   async (url: string, expectedStatus: number): Promise<Result> => {
@@ -87,7 +93,7 @@ export const urlChecker =
     });
 
     try {
-      const response = await page.goto(url);
+      const response = await page.goto(cachebustUrl(url));
       const status = response?.status();
       if (status !== expectedStatus) {
         return {

--- a/playwright/url-checker/cli.ts
+++ b/playwright/url-checker/cli.ts
@@ -39,10 +39,7 @@ const action = async (options: Options): Promise<void> => {
     const table = resultTable({ urls, liveProgress: !!options.tty });
     table.init();
 
-    // We saw intermittent flakiness in the "Check URLs" tests when this was
-    // set to 10; a few URLs would fail out of every batch on the first run.
-    // I'm trying a lower number to see if that improves things.
-    const maxCheckConcurrency = 5;
+    const maxCheckConcurrency = 10;
 
     const rateLimit = pLimit(maxCheckConcurrency);
     await Promise.all(


### PR DESCRIPTION
- Cachebusting
- Ignore aborted requests
- Close pages before exiting