### PR TITLE
Fetch credentials for the identity web app on `yarn start:dev`

### DIFF
--- a/identity/webapp/README.md
+++ b/identity/webapp/README.md
@@ -3,3 +3,17 @@
 This is the application for users to manage their accounts.
 
 It handles authentication and session via https://github.com/auth0/nextjs-auth0, and other apps on wellcomecollection.org can request the user's identity from the session by asking for `/account/api/auth/me`.
+
+## Local development
+
+Unlike the `catalogue` and `content` apps, which talk to unauthenticated APIs, the `identity` app needs some credentials to talk to Auth0 and the identity API.
+
+There's a local dev client set up in the [identity repo](https://github.com/wellcomecollection/identity), whose credentials are in Secrets Manager.
+
+If you run:
+
+```console
+$ yarn start:dev
+```
+
+then the app will start using credentials fetched from Secrets Manager.

--- a/identity/webapp/package.json
+++ b/identity/webapp/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "scripts": {
     "start": "NODE_ENV=production ts-node-transpile-only -r tsconfig-paths/register src/index.ts",
-    "start:dev": "NODE_ENV=development nodemon --ignore './src/frontend/' src/index.ts",
+    "start:dev": "CREDENTIALS=$(AWS_PROFILE=identity-dev aws secretsmanager get-secret-value --secret-id=identity/stage/local_dev_client/credentials) NODE_ENV=development nodemon --ignore './src/frontend/' src/index.ts",
     "watch:client": "yarn build:frontend --watch",
     "build": "NODE_ENV=production && yarn build:next",
     "build:next": "next build",

--- a/identity/webapp/src/index.ts
+++ b/identity/webapp/src/index.ts
@@ -2,12 +2,37 @@ import { createApp } from './app';
 import { port } from '../config';
 
 async function main() {
+  if (process.env.NODE_ENV === 'development') {
+    console.log(`Running in dev environment, using secrets from AWS`);
+
+    // We get a string like
+    //
+    //  {
+    //    "ARN": "arn:aws:secretsmanager:eu-west-1:770700576653:secret:identity/stage/local_dev_client/credentials-o2vk5D",
+    //    "SecretString": "{\"api_key\":…}",
+    //  }
+    //
+    // from the Secrets Manager CLI.
+    const credentials = JSON.parse(
+      JSON.parse(process.env.CREDENTIALS)['SecretString']
+    );
+
+    process.env.AUTH0_CLIENT_ID = credentials['client_id'];
+    process.env.AUTH0_DOMAIN = 'stage.account.wellcomecollection.org';
+    process.env.IDENTITY_API_HOST =
+      'https://v1-api.stage.account.wellcomecollection.org';
+    process.env.SITE_BASE_URL = 'http://localhost:3000';
+    process.env.AUTH0_CLIENT_SECRET = credentials['client_secret'];
+    process.env.IDENTITY_API_KEY = credentials['api_key'];
+    process.env.SESSION_KEYS = 'correct-horse-battery-staple'; // https://xkcd.com/936/
+  }
+
   const app = await createApp();
 
   app.listen(port);
 
   if (process.env.NODE_ENV !== 'production') {
-    console.log(`Server ready at: http://localhost:${port}`);
+    console.log(`Server ready at: http://localhost:${port}/account`);
   }
 }
 


### PR DESCRIPTION
## Who is this for?

Devs.

## What is it doing for them?

Making it easier to run the identity web app locally. Closes https://github.com/wellcomecollection/wellcomecollection.org/issues/8288; accompanies https://github.com/wellcomecollection/identity/pull/375