### PR TITLE
Update the account page after somebody verifies their email

### DIFF
--- a/identity/webapp/pages/validated.tsx
+++ b/identity/webapp/pages/validated.tsx
@@ -62,10 +62,11 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     const didSucceed = success === 'true';
 
     if (didSucceed) {
-      // The email validation state is held within the ID token, which will be
-      // refreshed by fetching a new access token.
+      // The email validation state is held within the ID token, which we need to
+      // refresh after fetching a new access token.
       try {
         await auth0.getAccessToken(req, res, { refresh: true });
+        await auth0.getSession(req, res);
       } catch (e) {
         // It doesn't matter if this fails; it means the user doesn't currently have a session
       }


### PR DESCRIPTION
In my local testing, this seems to fix the issue -- if I hit the post-email verification page and then refresh my account page, the banner telling me to verify my email is gone.

I've tested this locally and confirmed that:

* My account page doesn't update if I omit the line
* My account page does update if I include the line

so tentatively I think this works, although it feels far too simple. 🤷‍♀️ 