### PR TITLE
Less random storybook

### DIFF
--- a/cardigan/stories/components/DateRange/DateRange.stories.tsx
+++ b/cardigan/stories/components/DateRange/DateRange.stories.tsx
@@ -1,9 +1,9 @@
 import DateRange from '@weco/common/views/components/DateRange/DateRange';
 
-const now = new Date();
-const oneHourFromNow = new Date();
+const now = new Date('2022-03-01T13:15:00Z');
+const oneHourFromNow = new Date('2022-03-01T13:15:00Z');
 oneHourFromNow.setHours(now.getHours() + 1);
-const oneWeekFromNow = new Date();
+const oneWeekFromNow = new Date('2022-03-01T13:15:00Z');
 oneWeekFromNow.setHours(now.getHours() + 168);
 
 const Template = args => <DateRange {...args} />;

--- a/cardigan/stories/content.ts
+++ b/cardigan/stories/content.ts
@@ -289,28 +289,27 @@ export const captionedImage = () => ({
   caption: [
     {
       type: 'paragraph',
-      text: faker.random.words(randomNumber(5, 15)),
+      text: faker.random.words(10),
       spans: [],
     },
   ],
 });
 
-export const singleLineOfText = (min = 3, max = 8) =>
-  faker.random.words(randomNumber(min, max));
+export const singleLineOfText = () => faker.random.words(7);
 
 export const text = () =>
-  Array(randomNumber(1, 2))
+  Array(2)
     .fill()
     .map(() => ({
       type: 'paragraph',
-      text: `${faker.random.words(randomNumber(25, 40))}`,
+      text: `${faker.random.words(30)}`,
       spans: [],
     }));
 
 const smallText = () => [
   {
     type: 'paragraph',
-    text: `${faker.random.words(randomNumber(12, 24))}`,
+    text: `${faker.random.words(20)}`,
     spans: [],
   },
 ];
@@ -480,7 +479,7 @@ export const event: Event = {
 };
 
 export const imageGallery = () => {
-  const items = Array(randomNumber(3, 5)).fill().map(captionedImage);
+  const items = Array(4).fill().map(captionedImage);
   return {
     id: '123',
     title: singleLineOfText(),

--- a/common/views/components/WobblyEdge/WobblyEdge.tsx
+++ b/common/views/components/WobblyEdge/WobblyEdge.tsx
@@ -10,7 +10,9 @@ import debounce from 'lodash.debounce';
 import { prefixedPropertyStyleObject } from '../../../utils/prefixed-property-style-object';
 import styled from 'styled-components';
 
-const Edge = styled.div<{
+const Edge = styled.div.attrs({
+  'data-chromatic': 'ignore',
+})<{
   background: string;
   isRotated: boolean;
   isEnhanced: boolean;

--- a/common/views/components/WobblyEdge/WobblyEdge.tsx
+++ b/common/views/components/WobblyEdge/WobblyEdge.tsx
@@ -11,6 +11,9 @@ import { prefixedPropertyStyleObject } from '../../../utils/prefixed-property-st
 import styled from 'styled-components';
 
 const Edge = styled.div.attrs({
+  // This edge is deliberately random. We don't want Chromatic shout when
+  // there's inevitably a visual difference between builds.
+  // https://www.chromatic.com/docs/ignoring-elements#ignore-dom-elements
   'data-chromatic': 'ignore',
 })<{
   background: string;


### PR DESCRIPTION
## Who is this for?
People who want meaningful visual diffing

## What is it doing for them?
Reducing the randomness from various bits of our storybook stories so they're visually consistent across builds
- The same number of words/paragraphs (as well as the same words) in components
- Using a fixed date for something that was previously using the current time as a base
- Ignoring the `WobblyEdge` component which has deliberate randomness built in

Next step – turn the visual diffing back on in Chromatic and see if any stories are still different between builds (might need to push twice to establish a new baseline).