### PR TITLE
Change variable name for Inter font

### DIFF
--- a/cardigan/stories/components/Cards/Cards.stories.tsx
+++ b/cardigan/stories/components/Cards/Cards.stories.tsx
@@ -58,7 +58,7 @@ const FeaturedCardTemplate = args => {
       <h2 className="font-wb font-size-2">
         Remote diagnosis from wee to the Web
       </h2>
-      <p className="font-hnr font-size-5">
+      <p className="font-intr font-size-5">
         Medical practice might have moved on from when patients posted flasks of
         their urine for doctors to taste, but telehealth today keeps up the
         tradition of remote diagnosis – to our possible detriment.

--- a/cardigan/stories/components/PageHeader/PageHeader.stories.tsx
+++ b/cardigan/stories/components/PageHeader/PageHeader.stories.tsx
@@ -36,21 +36,21 @@ const ContentTypeInfo = (
       <Space
         h={{ size: 's', properties: ['margin-right', 'margin-top'] }}
         className={classNames({
-          [font('hnr', 6)]: true,
+          [font('intr', 6)]: true,
         })}
       >
         <p className="no-margin">
           <span>By </span>
           <span
             className={classNames({
-              [font('hnb', 6)]: true,
+              [font('intb', 6)]: true,
             })}
           >
             Naomi Paxton
           </span>{' '}
           <span
             className={classNames({
-              [font('hnr', 6)]: true,
+              [font('intr', 6)]: true,
               'font-pewter': true,
             })}
           >
@@ -153,7 +153,7 @@ const EventContentTypeInfo = () => (
       Saturday 8 February 2020, 13:00 – 16:00
     </Space>
     <div className="flex">
-      <div className={`${font('hnb', 5)} flex flex--v-center`}>
+      <div className={`${font('intb', 5)} flex flex--v-center`}>
         <Space
           as="span"
           h={{ size: 'xs', properties: ['margin-right'] }}
@@ -169,7 +169,7 @@ const EventContentTypeInfo = () => (
 
 const ExhibitionContentTypeInfo = () => (
   <div className="flex">
-    <div className={`${font('hnb', 5)} flex flex--v-center`}>
+    <div className={`${font('intb', 5)} flex flex--v-center`}>
       <Space
         as="span"
         h={{ size: 'xs', properties: ['margin-right'] }}
@@ -186,7 +186,7 @@ const BookContentTypeInfo = () => (
   <p
     className={classNames({
       'no-margin': true,
-      [font('hnb', 3)]: true,
+      [font('intb', 3)]: true,
     })}
   >
     Loneliness, Health & What Happens When We Find Connection

--- a/cardigan/stories/global/typography/typography.stories.tsx
+++ b/cardigan/stories/global/typography/typography.stories.tsx
@@ -11,7 +11,7 @@ const Font = styled.div`
 
 const FontName = styled.h2.attrs({
   className: classNames({
-    [font('hnb', 6)]: true,
+    [font('intb', 6)]: true,
   }),
 })`
   color: ${props => props.theme.color('red')};
@@ -55,7 +55,7 @@ const TypographyScale = ({ fontFamily }) => {
 };
 
 const sizes = [0, 1, 2, 3, 4, 5, 6];
-const fontFamilies = ['wb', 'hnb', 'hnr', 'lr'];
+const fontFamilies = ['intr', 'intb', 'wb', 'lr'];
 
 const Typography = ({ text }) => {
   return (

--- a/catalogue/webapp/components/ArchiveTree/ArchiveTree.tsx
+++ b/catalogue/webapp/components/ArchiveTree/ArchiveTree.tsx
@@ -194,7 +194,7 @@ const StyledLink = styled.a<StyledLinkProps>`
 
 const RefNumber = styled.span.attrs({
   className: classNames({
-    [font('hnr', 6)]: true,
+    [font('intr', 6)]: true,
   }),
 })`
   line-height: 1;
@@ -668,8 +668,8 @@ const ListItem: FunctionComponent<ListItemProps> = ({
         >
           <StyledLink
             className={classNames({
-              [font('hnb', 6)]: level === 1,
-              [font('hnr', 6)]: level > 1,
+              [font('intb', 6)]: level === 1,
+              [font('intr', 6)]: level > 1,
             })}
             hideFocus={!isKeyboard}
             tabIndex={isEnhanced ? (isSelected ? 0 : -1) : 0}

--- a/catalogue/webapp/components/Calendar/Calendar.tsx
+++ b/catalogue/webapp/components/Calendar/Calendar.tsx
@@ -252,7 +252,7 @@ const Calendar: FC<Props> = ({
       {isKeyboard && <Message>{calendarInstructions}</Message>}
       <Table
         className={classNames({
-          [font('hnb', 6)]: true,
+          [font('intb', 6)]: true,
         })}
         role="grid"
         aria-labelledby="id-grid-label"

--- a/catalogue/webapp/components/Calendar/CalendarStyles.tsx
+++ b/catalogue/webapp/components/Calendar/CalendarStyles.tsx
@@ -27,7 +27,7 @@ export const Header = styled.div`
 
 export const Message = styled.p.attrs(() => ({
   className: classNames({
-    [font('hnr', 6)]: true,
+    [font('intr', 6)]: true,
   }),
 }))`
   background: ${props => props.theme.color('yellow')};

--- a/catalogue/webapp/components/Download/Download.tsx
+++ b/catalogue/webapp/components/Download/Download.tsx
@@ -14,7 +14,7 @@ import { DownloadFormat } from '../DownloadLink/DownloadLink';
 
 export const DownloadOptions = styled.div.attrs(() => ({
   className: classNames({
-    [font('hnb', 4)]: true,
+    [font('intb', 4)]: true,
   }),
 }))`
   white-space: normal;
@@ -69,7 +69,7 @@ const Download: NextPage<Props> = ({
   return (
     <div
       className={classNames({
-        [font('hnr', 5)]: true,
+        [font('intr', 5)]: true,
         'inline-block': isEnhanced,
         relative: true,
       })}
@@ -85,7 +85,7 @@ const Download: NextPage<Props> = ({
           >
             <DownloadOptions
               className={classNames({
-                [font('hnb', 5)]: true,
+                [font('intb', 5)]: true,
               })}
             >
               <SpacingComponent>

--- a/catalogue/webapp/components/DownloadLink/DownloadLink.tsx
+++ b/catalogue/webapp/components/DownloadLink/DownloadLink.tsx
@@ -9,7 +9,7 @@ import { download } from '@weco/common/icons';
 
 const DownloadLinkStyle = styled.a.attrs({
   className: classNames({
-    [font('hnb', 5)]: true,
+    [font('intb', 5)]: true,
   }),
 })`
   display: inline-block;
@@ -61,7 +61,7 @@ const DownloadLink: FunctionComponent<Props> = ({
           as="span"
           h={{ size: 'm', properties: ['margin-left'] }}
           className={classNames({
-            [font('hnb', 5)]: true,
+            [font('intb', 5)]: true,
             'font-pewter': true,
           })}
         >

--- a/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
+++ b/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
@@ -203,7 +203,7 @@ const ExpandedImage: FunctionComponent<Props> = ({
         <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
           <h2
             className={classNames({
-              [font('hnb', 3)]: true,
+              [font('intb', 3)]: true,
               'no-margin': true,
             })}
             dangerouslySetInnerHTML={{ __html: displayTitle }}
@@ -212,7 +212,7 @@ const ExpandedImage: FunctionComponent<Props> = ({
             <Space
               as="h3"
               v={{ size: 's', properties: ['margin-top'] }}
-              className={classNames({ [font('hnb', 5)]: true })}
+              className={classNames({ [font('intb', 5)]: true })}
             >
               {displayContributor}
             </Space>
@@ -220,7 +220,7 @@ const ExpandedImage: FunctionComponent<Props> = ({
         </Space>
         {license && (
           <Space
-            className={font('hnr', 5)}
+            className={font('intr', 5)}
             v={{ size: 'l', properties: ['margin-bottom'] }}
           >
             <License license={license} />
@@ -250,7 +250,7 @@ const ExpandedImage: FunctionComponent<Props> = ({
               <a
                 className={classNames({
                   'inline-block': true,
-                  [font('hnr', 5)]: true,
+                  [font('intr', 5)]: true,
                 })}
               >
                 More about this work

--- a/catalogue/webapp/components/IIIFClickthrough/IIIFClickthrough.tsx
+++ b/catalogue/webapp/components/IIIFClickthrough/IIIFClickthrough.tsx
@@ -49,9 +49,9 @@ const IIIFClickthrough: FunctionComponent<Props> = ({
         />
       )}
       {showClickthroughMessage ? (
-        <div className={font('hnr', 5)}>
+        <div className={font('intr', 5)}>
           {authService?.label && (
-            <h2 className={font('hnb', 4)}>{authService?.label}</h2>
+            <h2 className={font('intb', 4)}>{authService?.label}</h2>
           )}
           {authService?.description && (
             <p

--- a/catalogue/webapp/components/IIIFSearchWithin/IIIFSearchWithin.tsx
+++ b/catalogue/webapp/components/IIIFSearchWithin/IIIFSearchWithin.tsx
@@ -56,7 +56,7 @@ const ListItem = styled.li`
 
 const SearchResult = styled.button.attrs({
   className: classNames({
-    [font('hnr', 6)]: true,
+    [font('intr', 6)]: true,
     'plain-button': true,
   }),
 })`
@@ -73,7 +73,7 @@ const SearchResult = styled.button.attrs({
 const HitData = styled(Space).attrs({
   as: 'span',
   className: classNames({
-    [font('hnb', 6)]: true,
+    [font('intb', 6)]: true,
   }),
 })`
   display: block;

--- a/catalogue/webapp/components/IIIFViewer/IIIFCanvasThumbnail.tsx
+++ b/catalogue/webapp/components/IIIFViewer/IIIFCanvasThumbnail.tsx
@@ -68,7 +68,7 @@ const IIIFViewerThumbNumber = styled.span.attrs<ViewerThumbProps>(props => ({
     'font-white': !props.isActive,
     'font-black': !!props.isActive,
     'bg-yellow': !!props.isActive,
-    [font('hnb', 6)]: true,
+    [font('intb', 6)]: true,
   }),
 }))<ViewerThumbProps>`
   padding: 3px 6px;

--- a/catalogue/webapp/components/IIIFViewer/MainViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/MainViewer.tsx
@@ -228,11 +228,11 @@ const ItemRenderer = memo(({ style, index, data }: ItemRendererProps) => {
         </div>
       ) : isRestricted ? (
         <MessageContainer>
-          <h2 className={font('hnb', 4)}>
+          <h2 className={font('intb', 4)}>
             {imageAuthService && (imageAuthService as AuthService).label}
           </h2>
           <p
-            className={font('hnr', 5)}
+            className={font('intr', 5)}
             dangerouslySetInnerHTML={{
               __html: imageAuthService
                 ? (imageAuthService as AuthService).description

--- a/catalogue/webapp/components/IIIFViewer/ViewerSidebar.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerSidebar.tsx
@@ -45,7 +45,7 @@ const Inner = styled(Space).attrs({
 const AccordionInner = styled(Space).attrs({
   v: { size: 's', properties: ['padding-top', 'padding-bottom'] },
   className: classNames({
-    [font('hnb', 5)]: true,
+    [font('intb', 5)]: true,
   }),
 })`
   button {
@@ -104,7 +104,7 @@ const AccordionItem = ({
           <span>
             <h2
               className={classNames({
-                [font('hnb', 5)]: true,
+                [font('intb', 5)]: true,
                 'no-margin': true,
               })}
             >
@@ -157,14 +157,14 @@ const ViewerSidebar: FunctionComponent<Props> = ({ mainViewerRef }: Props) => {
     <>
       <Inner
         className={classNames({
-          [font('hnb', 5)]: true,
+          [font('intb', 5)]: true,
         })}
       >
         {currentManifestLabel && (
           <span
             data-test-id="current-manifest"
             className={classNames({
-              [font('hnr', 5)]: true,
+              [font('intr', 5)]: true,
             })}
           >
             {currentManifestLabel}
@@ -221,7 +221,7 @@ const ViewerSidebar: FunctionComponent<Props> = ({ mainViewerRef }: Props) => {
           <WorkLink id={work.id} source="viewer_back_link">
             <a
               className={classNames({
-                [font('hnr', 5)]: true,
+                [font('intr', 5)]: true,
                 'flex flex--v-center': true,
               })}
             >
@@ -241,7 +241,7 @@ const ViewerSidebar: FunctionComponent<Props> = ({ mainViewerRef }: Props) => {
           title={'Licence and credit'}
           testId={'license-and-credit'}
         >
-          <div className={font('hnr', 6)}>
+          <div className={font('intr', 6)}>
             {license && license.label && (
               <p>
                 <strong>Licence:</strong>{' '}

--- a/catalogue/webapp/components/IIIFViewer/ViewerStructures.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerStructures.tsx
@@ -31,7 +31,7 @@ const ViewerStructuresPrototype: FunctionComponent<Props> = ({
     v: { size: 'xs', properties: ['padding-top', 'padding-bottom'] },
     h: { size: 'm', properties: ['padding-left', 'padding-right'] },
     className: classNames({
-      [font('hnr', 5)]: true,
+      [font('intr', 5)]: true,
     }),
   })<{ isActive: boolean }>`
     position: relative;

--- a/catalogue/webapp/components/IIIFViewer/ViewerTopBar.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerTopBar.tsx
@@ -21,7 +21,7 @@ import {
 export const ShameButton = styled.button.attrs(() => ({
   className: classNames({
     'relative flex flex--v-center': true,
-    [font('hnb', 5)]: true,
+    [font('intb', 5)]: true,
   }),
 }))<{ isDark?: boolean }>`
   line-height: 1.5;
@@ -178,7 +178,7 @@ const LeftZone = styled.div`
 
 const MiddleZone = styled.div.attrs({
   className: classNames({
-    [font('hnb', 5)]: true,
+    [font('intb', 5)]: true,
   }),
 })`
   display: flex;

--- a/catalogue/webapp/components/ItemRequestModal/RequestDialog.tsx
+++ b/catalogue/webapp/components/ItemRequestModal/RequestDialog.tsx
@@ -107,7 +107,7 @@ const RequestDialog: FC<RequestDialogProps> = ({
       </Header>
       <p
         className={classNames({
-          [font('hnb', 5)]: true,
+          [font('intb', 5)]: true,
           'no-margin': true,
         })}
       >
@@ -130,7 +130,7 @@ const RequestDialog: FC<RequestDialogProps> = ({
             </Space>
             <p
               className={classNames({
-                [font('hnr', 6)]: true,
+                [font('intr', 6)]: true,
                 'no-margin-l': true,
               })}
             >

--- a/catalogue/webapp/components/LibraryMembersBar/LibraryMembersBar.tsx
+++ b/catalogue/webapp/components/LibraryMembersBar/LibraryMembersBar.tsx
@@ -30,13 +30,13 @@ const SignInLink: FC = () => {
     <>
       <Space
         h={{ size: 's', properties: ['margin-right'] }}
-        className={font('hnb', 5)}
+        className={font('intb', 5)}
       >
         Library members:
       </Space>
       <a
         href={loginURL}
-        className={font('hnr', 5)}
+        className={font('intr', 5)}
         onClick={() => {
           trackEvent({
             category: 'library_account',
@@ -57,11 +57,11 @@ type ReloadProps = {
 const Reload: FC<ReloadProps> = ({ reload }) => {
   return (
     <>
-      <span className={font('hnb', 5)}>
+      <span className={font('intb', 5)}>
         Something went wrong trying to check if you are signed in
       </span>{' '}
       <button
-        className={font('hnr', 5)}
+        className={font('intr', 5)}
         onClick={() => {
           reload();
         }}
@@ -93,11 +93,11 @@ const LibraryMembersBar: FC<Props> = () => {
         </Space>
         <Space
           h={{ size: 's', properties: ['margin-right'] }}
-          className={font('hnb', 5)}
+          className={font('intb', 5)}
         >
           Library members:
         </Space>
-        <span className={font('hnr', 5)}>{requestingDisabled}</span>
+        <span className={font('intr', 5)}>{requestingDisabled}</span>
       </StyledComponent>
     );
   }

--- a/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
+++ b/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
@@ -58,7 +58,7 @@ const ButtonWrapper = styled.div<ButtonWrapperProps>`
 
 const DetailHeading = styled.h3.attrs({
   className: classNames({
-    [font('hnb', 5, { small: 3, medium: 3 })]: true,
+    [font('intb', 5, { small: 3, medium: 3 })]: true,
     'no-margin': true,
   }),
 })``;

--- a/catalogue/webapp/components/SearchNoResults/SearchNoResults.tsx
+++ b/catalogue/webapp/components/SearchNoResults/SearchNoResults.tsx
@@ -10,7 +10,7 @@ type Props = {
 
 const QuerySpan = styled.span.attrs({
   className: classNames({
-    [font('hnb', 2)]: true,
+    [font('intb', 2)]: true,
   }),
 })``;
 
@@ -23,7 +23,7 @@ const SearchNoResults: FunctionComponent<Props> = ({
       <div className="container">
         <div className="grid">
           <div className={grid({ s: 12, m: 10, l: 8, xl: 8 })}>
-            <p className={font('hnr', 2)}>
+            <p className={font('intr', 2)}>
               We couldn{`'`}t find anything that matched{' '}
               <QuerySpan>{query}</QuerySpan>
               {hasFilters && (

--- a/catalogue/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.tsx
+++ b/catalogue/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.tsx
@@ -68,7 +68,7 @@ const VisuallySimilarImagesFromApi: FunctionComponent<Props> = ({
       </Wrapper>
       <p
         className={classNames({
-          [font('hnr', 6)]: true,
+          [font('intr', 6)]: true,
           'no-margin': true,
         })}
       >

--- a/catalogue/webapp/components/WorkDetails/ExplanatoryText.tsx
+++ b/catalogue/webapp/components/WorkDetails/ExplanatoryText.tsx
@@ -37,7 +37,7 @@ const Control = styled.button.attrs(props => ({
     'plain-button': true,
     flex: true,
     'flex--v-center': true,
-    [font('hnb', 5)]: true,
+    [font('intb', 5)]: true,
   }),
 }))<ControlProps>`
   cursor: pointer;

--- a/catalogue/webapp/components/WorkDetails/OnlineResources.tsx
+++ b/catalogue/webapp/components/WorkDetails/OnlineResources.tsx
@@ -8,7 +8,7 @@ import styled from 'styled-components';
 const ShowHideButton = styled.button.attrs({
   className: classNames({
     'plain-button no-margin no-padding': true,
-    [font('hnr', 5)]: true,
+    [font('intr', 5)]: true,
   }),
 })`
   text-decoration: underline;
@@ -62,7 +62,7 @@ const OnlineResources: FunctionComponent<Props> = ({ work }: Props) => {
         {firstThreeOnlineResources.map(item => (
           <li
             className={classNames({
-              [font('hnr', 5)]: true,
+              [font('intr', 5)]: true,
             })}
             key={item.location.url}
           >
@@ -77,7 +77,7 @@ const OnlineResources: FunctionComponent<Props> = ({ work }: Props) => {
             {remainingOnlineResources.map((item, index) => (
               <li
                 className={classNames({
-                  [font('hnr', 5)]: true,
+                  [font('intr', 5)]: true,
                 })}
                 key={item.location.url}
               >

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -281,7 +281,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
                     {locationLink && (
                       <a
                         className={classNames({
-                          [font('hnr', 5)]: true,
+                          [font('intr', 5)]: true,
                         })}
                         href={locationLink.url}
                       >
@@ -726,7 +726,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
       {(locationOfWork || physicalItems.length > 0) && renderWhereToFindIt()}
 
       <WorkDetailsSection headingText="Permanent link">
-        <div className={`${font('hnr', 5)}`}>
+        <div className={`${font('intr', 5)}`}>
           <CopyUrl
             id={work.id}
             url={`https://wellcomecollection.org/works/${work.id}`}

--- a/catalogue/webapp/components/WorkDetailsProperty/WorkDetailsProperty.tsx
+++ b/catalogue/webapp/components/WorkDetailsProperty/WorkDetailsProperty.tsx
@@ -22,7 +22,7 @@ const WorkDetailsProperty: FunctionComponent<Props> = ({
       wrapper={children => <SpacingComponent>{children}</SpacingComponent>}
     >
       <div
-        className={`${font('hnr', 5, { small: 3, medium: 3 })}${
+        className={`${font('intr', 5, { small: 3, medium: 3 })}${
           inlineHeading ? ' flex' : ''
         }`}
       >
@@ -38,7 +38,7 @@ const WorkDetailsProperty: FunctionComponent<Props> = ({
                 : { size: 's', properties: [] }
             }
             className={classNames({
-              [font('hnb', 5, { small: 3, medium: 3 })]: true,
+              [font('intb', 5, { small: 3, medium: 3 })]: true,
               'no-margin': !inlineHeading,
             })}
             style={{ marginBottom: 0 }}

--- a/catalogue/webapp/components/WorkHeader/WorkHeader.tsx
+++ b/catalogue/webapp/components/WorkHeader/WorkHeader.tsx
@@ -55,7 +55,7 @@ const WorkHeader: FunctionComponent<Props> = ({
             id="work-info"
             className={classNames({
               'no-margin': true,
-              [font('hnb', 2)]: true,
+              [font('intb', 2)]: true,
               'inline-block': true,
             })}
             // We only send a lang if it's unambiguous -- better to send
@@ -119,7 +119,7 @@ const WorkHeader: FunctionComponent<Props> = ({
             <Space v={{ size: 'm', properties: ['margin-top'] }}>
               <p
                 className={classNames({
-                  [font('hnb', 5)]: true,
+                  [font('intb', 5)]: true,
                   'no-margin': true,
                 })}
               >

--- a/catalogue/webapp/components/WorksSearchResult/WorksSearchResult.tsx
+++ b/catalogue/webapp/components/WorksSearchResult/WorksSearchResult.tsx
@@ -116,7 +116,7 @@ const WorkSearchResult: FunctionComponent<Props> = ({
             <Details>
               <h2
                 className={classNames({
-                  [font('hnb', 4)]: true,
+                  [font('intb', 4)]: true,
                   'card-link__title': true,
                 })}
               >

--- a/catalogue/webapp/pages/download.tsx
+++ b/catalogue/webapp/pages/download.tsx
@@ -99,7 +99,7 @@ const DownloadPage: NextPage<Props> = ({
               as="h1"
               id="work-info"
               className={classNames({
-                [font('hnb', 1)]: true,
+                [font('intb', 1)]: true,
               })}
             >
               {title}

--- a/catalogue/webapp/pages/item.tsx
+++ b/catalogue/webapp/pages/item.tsx
@@ -286,9 +286,9 @@ const ItemPage: NextPage<Props> = ({
         removeCloseButton={true}
         openButtonRef={{ current: null }}
       >
-        <div className={font('hnr', 5)}>
+        <div className={font('intr', 5)}>
           {authService?.label && (
-            <h2 className={font('hnb', 4)}>{authService?.label}</h2>
+            <h2 className={font('intb', 4)}>{authService?.label}</h2>
           )}
           {authService?.description && (
             <div

--- a/common/utils/classnames.ts
+++ b/common/utils/classnames.ts
@@ -22,6 +22,7 @@ export function cssGrid(sizes: SizeMap): string {
   return [base].concat(modifierClasses).join(' ');
 }
 
+// int(r|b) = Inter(regular|bold); wb = Wellcome Bold; lr = Lettera Regular
 type FontFamily = 'intr' | 'intb' | 'wb' | 'lr';
 type FontSize = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 type FontSizeAll = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;

--- a/common/utils/classnames.ts
+++ b/common/utils/classnames.ts
@@ -22,7 +22,7 @@ export function cssGrid(sizes: SizeMap): string {
   return [base].concat(modifierClasses).join(' ');
 }
 
-type FontFamily = 'hnr' | 'hnb' | 'wb' | 'lr';
+type FontFamily = 'intr' | 'intb' | 'wb' | 'lr';
 type FontSize = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 type FontSizeAll = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
 type FontSizeOverrides = {

--- a/common/views/components/AudioPlayer/AudioPlayer.tsx
+++ b/common/views/components/AudioPlayer/AudioPlayer.tsx
@@ -62,7 +62,7 @@ const VolumeControlWrapper = styled.div<{ isMuted: boolean }>`
 const PlayRateWrapper = styled.div.attrs({
   className: classNames({
     flex: true,
-    [font('hnr', 6)]: true,
+    [font('intr', 6)]: true,
   }),
 })`
   gap: 5px;
@@ -373,7 +373,7 @@ export const AudioPlayer: FC<AudioPlayerProps> = ({
   return (
     <figure className="no-margin">
       <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
-        <figcaption className={font('hnb', 5)}>{title}</figcaption>
+        <figcaption className={font('intb', 5)}>{title}</figcaption>
       </Space>
 
       <AudioPlayerGrid>
@@ -399,7 +399,7 @@ export const AudioPlayer: FC<AudioPlayerProps> = ({
           <div className="flex flex--h-space-between">
             <div
               className={classNames({
-                [font('hnr', 6)]: true,
+                [font('intr', 6)]: true,
               })}
               style={{
                 fontVariantNumeric: 'tabular-nums',

--- a/common/views/components/BackToResults/BackToResults.tsx
+++ b/common/views/components/BackToResults/BackToResults.tsx
@@ -20,7 +20,7 @@ const BackToResults: FunctionComponent = () => {
           });
         }}
         className={classNames({
-          [font('hnr', 5)]: true,
+          [font('intr', 5)]: true,
         })}
       >
         <span>{`Back to search${query ? ' results' : ''}`}</span>

--- a/common/views/components/BetaMessage/BetaMessage.tsx
+++ b/common/views/components/BetaMessage/BetaMessage.tsx
@@ -8,7 +8,7 @@ import { underConstruction } from '@weco/common/icons';
 
 const StyledBetaMessage = styled.div.attrs(() => ({
   className: classNames({
-    [font('hnr', 5)]: true,
+    [font('intr', 5)]: true,
     'flex flex--v-center': true,
   }),
 }))`

--- a/common/views/components/BorderlessClickable/BorderlessClickable.tsx
+++ b/common/views/components/BorderlessClickable/BorderlessClickable.tsx
@@ -74,7 +74,7 @@ const Button: FC<BorderlessClickableProps> = (
               {/* We currently only use this in the header sign in button */}
               <span
                 className={classNames({
-                  [font('hnr', 4)]: true,
+                  [font('intr', 4)]: true,
                 })}
                 style={{ transform: 'translateY(0.01em)' }}
               >

--- a/common/views/components/Breadcrumb/Breadcrumb.tsx
+++ b/common/views/components/Breadcrumb/Breadcrumb.tsx
@@ -7,7 +7,7 @@ import { BreadcrumbItems } from '../../../model/breadcrumbs';
 
 const ItemWrapper = styled(Space).attrs(() => ({
   className: classNames({
-    [font('hnr', 6)]: true,
+    [font('intr', 6)]: true,
   }),
 }))``;
 
@@ -36,7 +36,7 @@ const Breadcrumb: FunctionComponent<BreadcrumbItems> = ({
             {prefix}{' '}
             <LinkOrSpanTag
               className={classNames({
-                [font('hnb', 6)]: Boolean(prefix),
+                [font('intb', 6)]: Boolean(prefix),
               })}
               href={url}
             >
@@ -49,7 +49,7 @@ const Breadcrumb: FunctionComponent<BreadcrumbItems> = ({
     {items.length === 0 && (
       <span
         className={classNames({
-          [font('hnr', 6)]: true,
+          [font('intr', 6)]: true,
           'empty-filler': true,
         })}
         style={{ lineHeight: 1 }}

--- a/common/views/components/ButtonSolid/ButtonSolid.tsx
+++ b/common/views/components/ButtonSolid/ButtonSolid.tsx
@@ -77,7 +77,7 @@ export const BaseButtonInner = styled(
   BaseButtonInnerSpan
 ).attrs<BaseButtonInnerProps>(props => ({
   className: classNames({
-    [font(props.isInline ? 'hnr' : 'hnb', 5)]: true,
+    [font(props.isInline ? 'intr' : 'intb', 5)]: true,
     'flex flex--v-center': true,
   }),
 }))`

--- a/common/views/components/Contact/Contact.tsx
+++ b/common/views/components/Contact/Contact.tsx
@@ -32,7 +32,7 @@ const Contact: FunctionComponent<Props> = ({
       >
         <span
           className={classNames({
-            [font('hnb', 4)]: true,
+            [font('intb', 4)]: true,
           })}
         >
           {title}
@@ -42,7 +42,7 @@ const Contact: FunctionComponent<Props> = ({
             as="span"
             h={{ size: 's', properties: ['margin-left'] }}
             className={classNames({
-              [font('hnr', 4)]: true,
+              [font('intr', 4)]: true,
             })}
           >
             {subtitle}
@@ -52,7 +52,7 @@ const Contact: FunctionComponent<Props> = ({
       {phone && (
         <span
           className={classNames({
-            [font('hnr', 4)]: true,
+            [font('intr', 4)]: true,
             block: true,
           })}
         >
@@ -63,7 +63,7 @@ const Contact: FunctionComponent<Props> = ({
         <div>
           <a
             className={classNames({
-              [font('hnr', 4)]: true,
+              [font('intr', 4)]: true,
             })}
             href={`mailto:${email}`}
           >

--- a/common/views/components/CookieNotice/CookieNotice.tsx
+++ b/common/views/components/CookieNotice/CookieNotice.tsx
@@ -10,7 +10,7 @@ import { trackEvent } from '@weco/common/utils/ga';
 
 const CookieNoticeStyle = styled.div.attrs({
   className: classNames({
-    [font('hnb', 4)]: true,
+    [font('intb', 4)]: true,
   }),
 })`
   position: fixed;

--- a/common/views/components/ExpandableList/ExpandableList.tsx
+++ b/common/views/components/ExpandableList/ExpandableList.tsx
@@ -11,7 +11,7 @@ import styled from 'styled-components';
 const ShowHideButton = styled.button.attrs({
   className: classNames({
     'plain-button no-margin no-padding': true,
-    [font('hnr', 5)]: true,
+    [font('intr', 5)]: true,
   }),
 })`
   text-decoration: underline;
@@ -63,7 +63,7 @@ const ExpandableList: FunctionComponent<Props> = ({
           ) => (
             <li
               className={classNames({
-                [font('hnr', 5)]: true,
+                [font('intr', 5)]: true,
               })}
               key={index}
             >
@@ -76,7 +76,7 @@ const ExpandableList: FunctionComponent<Props> = ({
             {remainingListItems.map((item, index) => (
               <li
                 className={classNames({
-                  [font('hnr', 5)]: true,
+                  [font('intr', 5)]: true,
                 })}
                 key={index}
               >

--- a/common/views/components/FindUs/FindUs.tsx
+++ b/common/views/components/FindUs/FindUs.tsx
@@ -9,7 +9,7 @@ import { FunctionComponent } from 'react';
 import { prismicPageIds } from '../../../data/hardcoded-ids';
 const StyledFindUs = styled.div.attrs({
   className: classNames({
-    [font('hnr', 5)]: true,
+    [font('intr', 5)]: true,
   }),
 })`
   &:hover,

--- a/common/views/components/Footer/Footer.tsx
+++ b/common/views/components/Footer/Footer.tsx
@@ -97,7 +97,7 @@ const StrapText = styled.div`
 
 const HygieneItem = styled.li.attrs({
   className: classNames({
-    [font('hnb', 6)]: true,
+    [font('intb', 6)]: true,
   }),
 })`
   width: 100%;
@@ -189,7 +189,7 @@ const Footer: FunctionComponent<Props> = ({ venues, hide = false }: Props) => {
                 properties: ['margin-bottom'],
               }}
               as="h3"
-              className={`relative ${font('hnr', 4)}`}
+              className={`relative ${font('intr', 4)}`}
             >
               <span className="hidden">Wellcome collection</span>
               <NavBrand href="#">
@@ -207,7 +207,7 @@ const Footer: FunctionComponent<Props> = ({ venues, hide = false }: Props) => {
                 properties: ['margin-bottom'],
               }}
               as="h3"
-              className={`hidden is-hidden-s is-hidden-m ${font('hnr', 5)}`}
+              className={`hidden is-hidden-s is-hidden-m ${font('intr', 5)}`}
             >
               Finding us:
             </Space>
@@ -220,7 +220,7 @@ const Footer: FunctionComponent<Props> = ({ venues, hide = false }: Props) => {
           <div
             className={classNames({
               [grid({ s: 12, m: 6, l: 4, xl: 4 })]: true,
-              [font('hnr', 5)]: true,
+              [font('intr', 5)]: true,
             })}
           >
             <Space
@@ -229,7 +229,7 @@ const Footer: FunctionComponent<Props> = ({ venues, hide = false }: Props) => {
                 properties: ['margin-bottom'],
               }}
               as="h3"
-              className={`hidden is-hidden-s is-hidden-m ${font('hnr', 5)}`}
+              className={`hidden is-hidden-s is-hidden-m ${font('intr', 5)}`}
             >
               {`Opening times:`}
             </Space>
@@ -240,13 +240,13 @@ const Footer: FunctionComponent<Props> = ({ venues, hide = false }: Props) => {
               >
                 <div
                   className={classNames({
-                    [font('hnr', 5)]: true,
+                    [font('intr', 5)]: true,
                     'float-l': true,
                   })}
                 >
                   <h4
                     className={classNames({
-                      [font('hnb', 5)]: true,
+                      [font('intb', 5)]: true,
                       'no-margin': true,
                     })}
                   >{`Today's opening times`}</h4>
@@ -264,7 +264,7 @@ const Footer: FunctionComponent<Props> = ({ venues, hide = false }: Props) => {
           <FooterLeft>
             <FooterStrap
               className={classNames({
-                [font('hnb', 6)]: true,
+                [font('intb', 6)]: true,
               })}
             >
               <Space as="span" h={{ size: 's', properties: ['margin-right'] }}>
@@ -278,7 +278,7 @@ const Footer: FunctionComponent<Props> = ({ venues, hide = false }: Props) => {
                 properties: ['margin-top', 'padding-bottom', 'margin-bottom'],
               }}
               className={classNames({
-                [font('hnb', 6)]: true,
+                [font('intb', 6)]: true,
                 'flex flex--v-center': true,
               })}
             >

--- a/common/views/components/Footer/FooterSocial.tsx
+++ b/common/views/components/Footer/FooterSocial.tsx
@@ -57,7 +57,7 @@ const Link = styled(Space).attrs({
     properties: ['margin-bottom'],
   },
   as: 'a',
-  className: font('hnb', 6),
+  className: font('intb', 6),
 })<LinkProps>`
   color: ${props => props.theme.color('white')};
   text-decoration: none;

--- a/common/views/components/Header/DesktopSignIn.tsx
+++ b/common/views/components/Header/DesktopSignIn.tsx
@@ -38,7 +38,7 @@ const DesktopSignIn: FC = () => {
               text={
                 <span
                   className={classNames({
-                    [font('hnr', 6)]: true,
+                    [font('intr', 6)]: true,
                   })}
                 >
                   Library sign in
@@ -56,7 +56,7 @@ const DesktopSignIn: FC = () => {
           </span>
           <span
             className={`display-none headerMedium-display-block headerLarge-display-none ${font(
-              'hnr',
+              'intr',
               6
             )}`}
           >
@@ -79,7 +79,7 @@ const DesktopSignIn: FC = () => {
             label={
               <span
                 className={classNames({
-                  [font('hnr', 6)]: true,
+                  [font('intr', 6)]: true,
                 })}
               >
                 {user.firstName.charAt(0).toLocaleUpperCase()}
@@ -92,7 +92,7 @@ const DesktopSignIn: FC = () => {
           >
             <span
               className={classNames({
-                [font('hnr', 6)]: true,
+                [font('intr', 6)]: true,
               })}
             >
               <AccountA

--- a/common/views/components/Header/MobileSignIn.tsx
+++ b/common/views/components/Header/MobileSignIn.tsx
@@ -10,7 +10,7 @@ import { trackEvent } from '../../../utils/ga';
 
 const StyledComponent = styled.div.attrs({
   className: classNames({
-    [font('hnr', 5)]: true,
+    [font('intr', 5)]: true,
   }),
 })`
   ${respondTo(
@@ -56,7 +56,7 @@ const MobileSignIn: FC = () => {
       <Space
         h={{ size: 's', properties: ['margin-right'] }}
         className={classNames({
-          [font('hnr', 4)]: true,
+          [font('intr', 4)]: true,
         })}
       >
         <Icon icon={userIcon} matchText={true} />

--- a/common/views/components/InfoBanner/InfoBanner.tsx
+++ b/common/views/components/InfoBanner/InfoBanner.tsx
@@ -68,7 +68,7 @@ const InfoBanner: FunctionComponent<Props> = ({
       <div className="container">
         <div className="grid">
           <div className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>
-            <div className={`flex flex--h-space-between ${font('hnr', 5)}`}>
+            <div className={`flex flex--h-space-between ${font('intr', 5)}`}>
               <div>
                 <span className="flex">
                   <Space

--- a/common/views/components/Label/Label.tsx
+++ b/common/views/components/Label/Label.tsx
@@ -12,7 +12,7 @@ type LabelContainerProps = {
 const LabelContainer = styled(Space).attrs({
   className: classNames({
     'nowrap line-height-1': true,
-    [font('hnb', 6)]: true,
+    [font('intb', 6)]: true,
   }),
 })<LabelContainerProps>`
   color: ${props => props.theme.color(props.fontColor)};

--- a/common/views/components/LinkLabels/LinkLabels.tsx
+++ b/common/views/components/LinkLabels/LinkLabels.tsx
@@ -32,7 +32,7 @@ const ItemText = styled(Space).attrs<LinkOrSpanSpaceAttrs>(props => ({
     ].filter(Boolean),
   },
   className: classNames({
-    [font('hnr', 5)]: true,
+    [font('intr', 5)]: true,
   }),
 }))<LinkOrSpanSpaceAttrs>`
   ${props =>
@@ -53,7 +53,7 @@ const LinkLabels: FunctionComponent<Props> = ({
         flex: true,
         'flex--wrap': true,
         'no-margin': true,
-        [font('hnb', 5)]: true,
+        [font('intb', 5)]: true,
       })}
     >
       <Space
@@ -91,7 +91,7 @@ const LinkLabels: FunctionComponent<Props> = ({
         'flex--wrap': true,
         'no-margin': true,
         'no-padding': true,
-        [font('hnb', 5)]: true,
+        [font('intb', 5)]: true,
       })}
     >
       {items.map(({ url, text }, i) => (

--- a/common/views/components/Message/Message.tsx
+++ b/common/views/components/Message/Message.tsx
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 import { classNames, font } from '../../../utils/classnames';
 import Space from '../styled/Space';
 import styled from 'styled-components';
@@ -10,7 +11,7 @@ const Wrapper = styled(Space).attrs({
   h: { size: 'm', properties: ['padding-left', 'padding-right'] },
   className: classNames({
     'inline-block': true,
-    [font('hnb', 5)]: true,
+    [font('intb', 5)]: true,
   }),
 })`
   border-left: 5px solid ${props => props.theme.color('yellow')};
@@ -20,5 +21,5 @@ type Props = {
   text: string;
 };
 
-const Message = ({ text }: Props) => <Wrapper>{text}</Wrapper>;
+const Message: ReactNode = ({ text }: Props) => <Wrapper>{text}</Wrapper>;
 export default Message;

--- a/common/views/components/Message/Message.tsx
+++ b/common/views/components/Message/Message.tsx
@@ -1,4 +1,3 @@
-import { ReactNode } from 'react';
 import { classNames, font } from '../../../utils/classnames';
 import Space from '../styled/Space';
 import styled from 'styled-components';
@@ -21,5 +20,5 @@ type Props = {
   text: string;
 };
 
-const Message: ReactNode = ({ text }: Props) => <Wrapper>{text}</Wrapper>;
+const Message = ({ text }: Props) => <Wrapper>{text}</Wrapper>;
 export default Message;

--- a/common/views/components/MessageBar/MessageBar.tsx
+++ b/common/views/components/MessageBar/MessageBar.tsx
@@ -9,7 +9,7 @@ const ColouredTag: FunctionComponent<SpaceComponentProps> = styled.span.attrs({
     'inline-block': true,
     'bg-charcoal': true,
     'font-white': true,
-    [font('hnb', 6)]: true,
+    [font('intb', 6)]: true,
   }),
 })<SpaceComponentProps>`
   padding: 0.2em 0.5em;
@@ -34,7 +34,7 @@ const MessageBar: FunctionComponent<Props> = ({ tagText, children }: Props) => (
       properties: ['padding-top', 'padding-bottom'],
     }}
     className={classNames({
-      [font('hnr', 6)]: true,
+      [font('intr', 6)]: true,
     })}
   >
     {tagText && <ColouredTag>{tagText}</ColouredTag>}

--- a/common/views/components/NewsletterPromo/NewsletterPromo.tsx
+++ b/common/views/components/NewsletterPromo/NewsletterPromo.tsx
@@ -1,4 +1,4 @@
-import { useState, useContext } from 'react';
+import { useState, useContext, FC } from 'react';
 import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
 import { font, classNames } from '../../../utils/classnames';
 import Space from '../styled/Space';
@@ -96,7 +96,7 @@ const CopyWrap = styled(Space).attrs({
   `}
 `;
 
-const NewsletterPromo = () => {
+const NewsletterPromo: FC = () => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSuccess, setIsSuccess] = useState(false);
   const [isSubmitError, setIsSubmitError] = useState(false);
@@ -171,7 +171,7 @@ const NewsletterPromo = () => {
                   {!isSuccess && (
                     <p
                       className={classNames({
-                        [font('hnr', 5)]: true,
+                        [font('intr', 5)]: true,
                         'no-margin': true,
                       })}
                     >
@@ -181,7 +181,7 @@ const NewsletterPromo = () => {
                   {isSuccess && (
                     <div
                       className={classNames({
-                        [font('hnr', 5)]: true,
+                        [font('intr', 5)]: true,
                         'spaced-text': true,
                       })}
                     >
@@ -239,7 +239,7 @@ const NewsletterPromo = () => {
               {!isSuccess && (
                 <p
                   className={classNames({
-                    [font('hnr', 6)]: true,
+                    [font('intr', 6)]: true,
                     'no-margin': true,
                   })}
                 >
@@ -251,7 +251,7 @@ const NewsletterPromo = () => {
               v={{ size: 'l', properties: ['margin-top'] }}
               style={{ flexBasis: '100%' }}
             >
-              <p className={font('hnr', 6)} style={{ maxWidth: '800px' }}>
+              <p className={font('intr', 6)} style={{ maxWidth: '800px' }}>
                 We use a third party provider,{' '}
                 <a href="https://dotdigital.com/terms/privacy-policy/">
                   dotdigital

--- a/common/views/components/PageHeader/PageHeader.tsx
+++ b/common/views/components/PageHeader/PageHeader.tsx
@@ -175,7 +175,7 @@ const PageHeader: FunctionComponent<Props> = ({
                 ) : (
                   <span
                     className={classNames({
-                      [font('hnr', 5)]: true,
+                      [font('intr', 5)]: true,
                       flex: true,
                     })}
                   >
@@ -200,7 +200,7 @@ const PageHeader: FunctionComponent<Props> = ({
               <Space
                 v={{ size: 'm', properties: ['margin-bottom'] }}
                 className={classNames({
-                  [font('hnr', 4)]: true,
+                  [font('intr', 4)]: true,
                 })}
               >
                 {ContentTypeInfo}
@@ -248,7 +248,7 @@ const PageHeader: FunctionComponent<Props> = ({
               properties: ['margin-top'],
             }}
             className={classNames({
-              [font('hnb', 4)]: true,
+              [font('intb', 4)]: true,
             })}
           >
             {ContentTypeInfo}

--- a/common/views/components/Paginator/Paginator.tsx
+++ b/common/views/components/Paginator/Paginator.tsx
@@ -103,7 +103,7 @@ const Paginator: FunctionComponent<Props> = ({
         className={classNames({
           flex: true,
           'flex--v-center': true,
-          [font('hnb', 3)]: true,
+          [font('intb', 3)]: true,
         })}
       >
         <TotalResultsWrapper
@@ -120,7 +120,7 @@ const Paginator: FunctionComponent<Props> = ({
           'float-r': true,
           'flex-inline': true,
           'flex--v-center': true,
-          [font('hnr', 5)]: true,
+          [font('intr', 5)]: true,
           'flex-end': true,
         })}
         v={{

--- a/common/views/components/PaletteColorPicker/PaletteColorPicker.tsx
+++ b/common/views/components/PaletteColorPicker/PaletteColorPicker.tsx
@@ -77,7 +77,7 @@ const Swatch = styled.button.attrs((props: SwatchProps) => ({
   type: 'button',
   className: classNames({
     'plain-button': true,
-    [font('hnr', 5)]: true,
+    [font('intr', 5)]: true,
   }),
   'aria-pressed': !!props.ariaPressed,
 }))<SwatchProps>`

--- a/common/views/components/PopupDialog/PopupDialog.tsx
+++ b/common/views/components/PopupDialog/PopupDialog.tsx
@@ -40,7 +40,7 @@ const PopupDialogOpen = styled(Space).attrs<PopupDialogOpenProps>(props => ({
     overrides: { small: 5, medium: 5, large: 5 },
   },
   className: classNames({
-    [font('hnb', 5)]: true,
+    [font('intb', 5)]: true,
     'plain-button line-height-1 flex-inline flex--v-center': true,
   }),
 }))<PopupDialogOpenProps>`
@@ -142,7 +142,7 @@ const PopupDialogCTA = styled(Space).attrs({
     overrides: { small: 5, medium: 5, large: 5 },
   },
   className: classNames({
-    [font('hnb', 5, { small: 3, medium: 3 })]: true,
+    [font('intb', 5, { small: 3, medium: 3 })]: true,
     'bg-purple rounded-corners inline-block': true,
   }),
 })`
@@ -338,7 +338,7 @@ const PopupDialog: FunctionComponent<Props> = ({ document }: Props) => {
           </h2>
           <div
             className={classNames({
-              [font('hnr', 5, { medium: 2, large: 2 })]: true,
+              [font('intr', 5, { medium: 2, large: 2 })]: true,
             })}
           >
             <PrismicHtmlBlock html={text} />

--- a/common/views/components/SearchFilters/ResetActiveFilters.tsx
+++ b/common/views/components/SearchFilters/ResetActiveFilters.tsx
@@ -102,7 +102,7 @@ export const ResetActiveFilters: FunctionComponent<ResetActiveFilters> = ({
       h={{ size: 'm', properties: ['padding-left', 'padding-right'] }}
       className="tokens bg-white"
     >
-      <div className={classNames({ [font('hnb', 5)]: true })} role="status">
+      <div className={classNames({ [font('intb', 5)]: true })} role="status">
         <div>
           <h2 className="inline">
             <Space

--- a/common/views/components/SearchFilters/SearchFiltersDesktop.tsx
+++ b/common/views/components/SearchFilters/SearchFiltersDesktop.tsx
@@ -40,7 +40,7 @@ const CheckboxFilter = ({ f, changeHandler }: CheckboxFilterProps) => {
       <ul
         className={classNames({
           'no-margin no-padding plain-list': true,
-          [font('hnr', 5)]: true,
+          [font('intr', 5)]: true,
         })}
       >
         {f.options.map(({ id, label, value, count, selected }) => {
@@ -75,7 +75,7 @@ const DateRangeFilter = ({ f, changeHandler }: DateRangeFilterProps) => {
   return (
     <Space
       className={classNames({
-        [font('hnr', 5)]: true,
+        [font('intr', 5)]: true,
       })}
     >
       <DropdownButton label={f.label} buttonType={'inline'} id={f.id}>
@@ -184,7 +184,7 @@ const SearchFiltersDesktop: FunctionComponent<SearchFiltersSharedProps> = ({
               <Space
                 h={{ size: 's', properties: ['margin-left'] }}
                 className={classNames({
-                  [font('hnb', 5)]: true,
+                  [font('intb', 5)]: true,
                 })}
               >
                 Filter by
@@ -219,7 +219,7 @@ const SearchFiltersDesktop: FunctionComponent<SearchFiltersSharedProps> = ({
             {modalFilters.length > 0 && (
               <Space
                 className={classNames({
-                  [font('hnr', 5)]: true,
+                  [font('intr', 5)]: true,
                 })}
                 h={{ size: 's', properties: ['margin-left'] }}
               >

--- a/common/views/components/SearchTabs/SearchTabs.tsx
+++ b/common/views/components/SearchTabs/SearchTabs.tsx
@@ -34,7 +34,7 @@ const Tab = styled(Space).attrs({
   h: { size: 'm', properties: ['padding-left', 'padding-right'] },
   className: classNames({
     'flex-inline': true,
-    [font('hnb', 5)]: true,
+    [font('intb', 5)]: true,
   }),
 })<TabProps>`
   background: ${props => props.theme.color('white')};
@@ -148,7 +148,7 @@ const SearchTabs: FunctionComponent<Props> = ({
             h={{ size: 'm', properties: ['padding-left', 'padding-right'] }}
             className={classNames({
               'visually-hidden': !shouldShowDescription,
-              [font('hnr', 5)]: true,
+              [font('intr', 5)]: true,
             })}
             id="library-catalogue-form-description"
           >
@@ -240,7 +240,7 @@ const SearchTabs: FunctionComponent<Props> = ({
             h={{ size: 'm', properties: ['padding-left', 'padding-right'] }}
             className={classNames({
               'visually-hidden': !shouldShowDescription,
-              [font('hnr', 5)]: true,
+              [font('intr', 5)]: true,
             })}
             id="images-form-description"
           >

--- a/common/views/components/SelectContainer/SelectContainer.tsx
+++ b/common/views/components/SelectContainer/SelectContainer.tsx
@@ -14,7 +14,7 @@ type StyledSelectProps = {
 
 const StyledSelect = styled.div.attrs({
   className: classNames({
-    [font('hnr', 5)]: true,
+    [font('intr', 5)]: true,
   }),
 })<StyledSelectProps>`
   position: relative;
@@ -76,7 +76,7 @@ const SelectContainer: FC<Props> = ({ label, hideLabel, children }) => {
           h={{ size: 's', properties: ['margin-right'] }}
           style={{ whiteSpace: 'nowrap' }}
           className={classNames({
-            [font('hnb', 5)]: true,
+            [font('intb', 5)]: true,
             'visually-hidden': !!hideLabel,
           })}
         >

--- a/common/views/components/StackingTable/StackingTable.tsx
+++ b/common/views/components/StackingTable/StackingTable.tsx
@@ -11,7 +11,7 @@ type TableProps = {
 
 const StyledTable = styled.table.attrs({
   className: classNames({
-    [font('hnr', 5)]: true,
+    [font('intr', 5)]: true,
   }),
 })<TableProps>`
    {
@@ -76,7 +76,7 @@ const StyledTh = styled(Space).attrs<ThProps>(props => ({
     ),
   },
   className: classNames({
-    [font('hnb', 5)]: true,
+    [font('intb', 5)]: true,
   }),
 }))<ThProps>`
   background: ${props =>
@@ -129,7 +129,7 @@ const StyledTd = styled(Space).attrs<TdProps>(props => ({
       display: block;
       white-space: nowrap;
       content: ${props => (props.content ? `'${props.content}'` : '')};
-      ${fontFamilyMixin('hnb', true)}
+      ${fontFamilyMixin('intb', true)}
     }
   }
 `;

--- a/common/views/components/StatusIndicator/StatusIndicator.tsx
+++ b/common/views/components/StatusIndicator/StatusIndicator.tsx
@@ -16,7 +16,7 @@ const StatusIndicator: FC<Props> = ({ start, end, statusOverride }: Props) => {
     : formatDateRangeWithMessage({ start, end });
 
   return (
-    <span className={`flex flex--v-center ${font('hnr', 5)}`}>
+    <span className={`flex flex--v-center ${font('intr', 5)}`}>
       <Space
         as="span"
         h={{ size: 'xs', properties: ['margin-right'] }}

--- a/common/views/components/TabNav/TabNav.tsx
+++ b/common/views/components/TabNav/TabNav.tsx
@@ -1,4 +1,4 @@
-import { ComponentType } from 'react';
+import { ComponentType, FC } from 'react';
 import styled from 'styled-components';
 import NextLink from 'next/link';
 import { TextLink } from '../../../model/text-links';
@@ -80,11 +80,11 @@ const NavItem = ({ link, text, selected, onClick }: SelectableTextLink) => (
   </NextLink>
 );
 
-const TabNav = ({ items }: Props) => {
+const TabNav: FC = ({ items }: Props) => {
   return (
     <div
       className={classNames({
-        [font('hnb', 4)]: true,
+        [font('intb', 4)]: true,
       })}
     >
       <ul

--- a/common/views/components/Table/Table.tsx
+++ b/common/views/components/Table/Table.tsx
@@ -93,7 +93,7 @@ const TableWrap = styled.div`
 
 const TableTable = styled.table.attrs({
   className: classNames({
-    [font('hnr', 5)]: true,
+    [font('intr', 5)]: true,
   }),
 })`
   width: 100%;

--- a/common/views/components/Tags/Tags.tsx
+++ b/common/views/components/Tags/Tags.tsx
@@ -25,7 +25,7 @@ type PartWithSeparatorProps = {
 
 const PartWithSeparator = styled.span.attrs({
   className: classNames({
-    [font('hnr', 5)]: true,
+    [font('intr', 5)]: true,
   }),
 })<PartWithSeparatorProps>`
   &:after {
@@ -80,7 +80,7 @@ const Tags: FunctionComponent<Props> = ({
                         <span
                           className={classNames({
                             [font(
-                              i === 0 && isFirstPartBold ? 'hnb' : 'hnr',
+                              i === 0 && isFirstPartBold ? 'intb' : 'intr',
                               5
                             )]: true,
                           })}

--- a/common/views/components/TextInput/TextInput.tsx
+++ b/common/views/components/TextInput/TextInput.tsx
@@ -129,7 +129,7 @@ export const TextInputErrorMessage = styled.span.attrs({
   role: 'alert',
   'data-test-id': 'TextInputErrorMessage',
   className: classNames({
-    'font-hnb': true,
+    'font-intb': true,
   }),
 })`
   display: block;

--- a/common/views/components/ToolbarSegmentedControl/ToolbarSegmentedControl.tsx
+++ b/common/views/components/ToolbarSegmentedControl/ToolbarSegmentedControl.tsx
@@ -42,7 +42,7 @@ const ButtonInner = styled(Space).attrs({
   },
   className: classNames({
     'flex flex--v-center flex--h-center': true,
-    [font('hnb', 5)]: true,
+    [font('intb', 5)]: true,
   }),
 })<{ isActive: boolean }>`
   color: ${props => props.theme.color('white')};

--- a/common/views/components/WatchLabel/WatchLabel.tsx
+++ b/common/views/components/WatchLabel/WatchLabel.tsx
@@ -22,7 +22,7 @@ const WatchIconWrapper = styled.div`
 const WatchText = styled(Space).attrs({
   v: { size: 's', properties: ['margin-left'] },
   className: classNames({
-    [font('hnr', 6)]: true,
+    [font('intr', 6)]: true,
   }),
 })`
   color: ${props => props.theme.color('pewter')};
@@ -35,7 +35,7 @@ type Props = {
 const WatchLabel: FunctionComponent<Props> = ({ text }: Props) => (
   <div
     className={classNames({
-      [font('hnr', 4)]: true,
+      [font('intr', 4)]: true,
       'flex flex--v-center': true,
     })}
   >

--- a/common/views/themes/typography.ts
+++ b/common/views/themes/typography.ts
@@ -50,11 +50,11 @@ export const fontSizesAtBreakpoints = {
 };
 
 const fontFamilies = {
-  hnb: {
+  intr: {
     base: `Inter, sans-serif;`,
     full: `Inter, sans-serif;`,
   },
-  hnr: {
+  intb: {
     base: `Inter, sans-serif;`,
     full: `Inter, sans-serif;`,
   },
@@ -88,21 +88,21 @@ export const fontFamilyMixin = (
 };
 
 export const typography = css<GlobalStyleProps>`
-  .font-hnb {
+  .font-intb {
     font-weight: bold;
   }
 
-  .font-hnr {
+  .font-intr {
     font-weight: normal;
   }
 
   ${props => `
-    .font-hnb {
-      ${fontFamilyMixin('hnb', !!props.isFontsLoaded)};
+    .font-intb {
+      ${fontFamilyMixin('intb', !!props.isFontsLoaded)};
     }
 
-    .font-hnr {
-      ${fontFamilyMixin('hnr', !!props.isFontsLoaded)};
+    .font-intr {
+      ${fontFamilyMixin('intr', !!props.isFontsLoaded)};
     }
 
     .font-wb {
@@ -119,7 +119,7 @@ export const typography = css<GlobalStyleProps>`
   }
 
   body {
-    ${fontFamilyMixin('hnr', true)}
+    ${fontFamilyMixin('intr', true)}
     ${fontSizeMixin(4)}
     line-height: 1.5;
     color: ${themeValues.color('black')};
@@ -240,7 +240,7 @@ export const typography = css<GlobalStyleProps>`
     }
 
     h3 {
-      ${fontFamilyMixin('hnb', true)}
+      ${fontFamilyMixin('intb', true)}
       ${fontSizeMixin(3)}
     }
 
@@ -285,7 +285,7 @@ export const typography = css<GlobalStyleProps>`
 
     strong,
     b {
-      ${fontFamilyMixin('hnb', true)};
+      ${fontFamilyMixin('intb', true)};
     }
   }
 

--- a/content/webapp/components/BannerCard/BannerCard.tsx
+++ b/content/webapp/components/BannerCard/BannerCard.tsx
@@ -151,14 +151,14 @@ const BannerCard: FunctionComponent<Props> = ({
               size: 's',
               properties: ['margin-top', 'margin-bottom'],
             }}
-            className={`${font('hnr', 5)} font-marble`}
+            className={`${font('intr', 5)} font-marble`}
           >
             <DateRange start={new Date(start)} end={new Date(end)} />
           </Space>
         )}
         <p
           className={classNames({
-            [font('hnr', 5)]: true,
+            [font('intr', 5)]: true,
           })}
         >
           {description}

--- a/content/webapp/components/Body/Body.tsx
+++ b/content/webapp/components/Body/Body.tsx
@@ -5,7 +5,7 @@ import React, {
   FunctionComponent,
   Fragment,
 } from 'react';
-import { classNames } from '@weco/common/utils/classnames';
+import { classNames, font } from '@weco/common/utils/classnames';
 import { Link } from '../../types/link';
 import {
   defaultSerializer,
@@ -190,12 +190,10 @@ const Body: FunctionComponent<Props> = ({
                   >
                     <h2 className="font-wb font-size-2">{firstItem.title}</h2>
                     {isCardType && firstItem.description && (
-                      <p className="font-hnr font-size-5">
-                        {firstItem.description}
-                      </p>
+                      <p className={font('intr', 5)}>{firstItem.description}</p>
                     )}
                     {'promo' in firstItem && firstItem.promo && (
-                      <p className="font-hnr font-size-5">
+                      <p className={font('intr', 5)}>
                         {firstItem.promo.caption}
                       </p>
                     )}

--- a/content/webapp/components/Body/VisitUsStaticContent.tsx
+++ b/content/webapp/components/Body/VisitUsStaticContent.tsx
@@ -34,7 +34,7 @@ const VisitUsStaticContent: FunctionComponent = () => {
         <div
           className={classNames({
             [grid({ s: 12, l: 5, xl: 5 })]: true,
-            [font('hnr', 4)]: true,
+            [font('intr', 4)]: true,
           })}
         >
           <FindUs />
@@ -42,19 +42,19 @@ const VisitUsStaticContent: FunctionComponent = () => {
         <div
           className={classNames({
             [grid({ s: 12, l: 5, xl: 5 })]: true,
-            [font('hnr', 4)]: true,
+            [font('intr', 4)]: true,
           })}
         >
           <div className="flex">
             <div
               className={classNames({
-                [font('hnr', 5)]: true,
+                [font('intr', 5)]: true,
                 'float-l': true,
               })}
             >
               <h2
                 className={classNames({
-                  [font('hnb', 5)]: true,
+                  [font('intb', 5)]: true,
                   'no-margin': true,
                 })}
               >{`Today's opening times`}</h2>

--- a/content/webapp/components/BookPromo/BookPromo.tsx
+++ b/content/webapp/components/BookPromo/BookPromo.tsx
@@ -100,7 +100,7 @@ const BookPromo: FC<Props> = ({ book }) => {
               v={{ size: 's', properties: ['margin-top'] }}
               className={classNames({
                 'no-margin': true,
-                [font('hnb', 5)]: true,
+                [font('intb', 5)]: true,
               })}
             >
               {subtitle}
@@ -111,7 +111,7 @@ const BookPromo: FC<Props> = ({ book }) => {
             <Space v={{ size: 's', properties: ['margin-top'] }}>
               <p
                 className={classNames({
-                  [font('hnr', 5)]: true,
+                  [font('intr', 5)]: true,
                   'no-margin': true,
                 })}
               >

--- a/content/webapp/components/Card/Card.tsx
+++ b/content/webapp/components/Card/Card.tsx
@@ -148,7 +148,7 @@ const Card: FunctionComponent<Props> = ({ item }: Props) => {
             </Space>
           )}
           {item.description && (
-            <p className={`${font('hnr', 5)} no-padding no-margin`}>
+            <p className={`${font('intr', 5)} no-padding no-margin`}>
               {item.description}
             </p>
           )}

--- a/content/webapp/components/Contributors/Contributor.tsx
+++ b/content/webapp/components/Contributors/Contributor.tsx
@@ -66,7 +66,7 @@ const Contributor: FC<ContributorType> = ({
           <div className={`flex flex--h-baseline`}>
             <h3
               className={classNames({
-                [font('hnb', 4)]: true,
+                [font('intb', 4)]: true,
                 'no-margin': true,
               })}
             >
@@ -76,7 +76,7 @@ const Contributor: FC<ContributorType> = ({
               <Space
                 h={{ size: 's', properties: ['margin-left'] }}
                 className={classNames({
-                  [font('hnr', 5)]: true,
+                  [font('intr', 5)]: true,
                   'font-pewter': true,
                 })}
               >
@@ -86,7 +86,7 @@ const Contributor: FC<ContributorType> = ({
           </div>
 
           {role && role.title && (
-            <div className={'font-pewter ' + font('hnb', 5)}>{role.title}</div>
+            <div className={'font-pewter ' + font('intb', 5)}>{role.title}</div>
           )}
 
           {contributor.sameAs.length > 0 && (
@@ -105,7 +105,7 @@ const Contributor: FC<ContributorType> = ({
                 properties: ['margin-top'],
               }}
               className={classNames({
-                [font('hnr', 5)]: true,
+                [font('intr', 5)]: true,
                 'spaced-text': true,
               })}
             >

--- a/content/webapp/components/EventCard/EventCard.tsx
+++ b/content/webapp/components/EventCard/EventCard.tsx
@@ -67,7 +67,7 @@ const EventCard: FC<Props> = ({ event: jsonEvent, xOfY }) => {
     ) : !event.isPast && event.times.length > 1 ? (
       <p
         className={classNames({
-          [font('hnb', 4)]: true,
+          [font('intb', 4)]: true,
           'no-margin': true,
         })}
       >

--- a/content/webapp/components/EventDatesLink/EventDatesLink.tsx
+++ b/content/webapp/components/EventDatesLink/EventDatesLink.tsx
@@ -22,7 +22,7 @@ const EventDatesLink: FunctionComponent<Props> = ({ id }: Props) => {
       className={classNames({
         'flex-inline': true,
         'flex-v-center': true,
-        [font('hnb', 5)]: true,
+        [font('intb', 5)]: true,
       })}
     >
       <Icon icon={arrowSmall} color={'black'} rotate={90} />

--- a/content/webapp/components/EventPromo/EventPromo.tsx
+++ b/content/webapp/components/EventPromo/EventPromo.tsx
@@ -117,7 +117,7 @@ const EventPromo: FC<Props> = ({
             <Space
               v={{ size: 's', properties: ['margin-top', 'margin-bottom'] }}
               className={classNames({
-                [font('hnr', 5)]: true,
+                [font('intr', 5)]: true,
                 'flex flex--v-center': true,
               })}
             >
@@ -135,7 +135,7 @@ const EventPromo: FC<Props> = ({
           )}
 
           {!isPast && (
-            <p className={`${font('hnr', 5)} no-padding no-margin`}>
+            <p className={`${font('intr', 5)} no-padding no-margin`}>
               <EventDateRange
                 event={event}
                 splitTime={true}
@@ -145,13 +145,13 @@ const EventPromo: FC<Props> = ({
           )}
 
           {!isPast && dateString && (
-            <p className={`${font('hnr', 5)} no-padding no-margin`}>
+            <p className={`${font('intr', 5)} no-padding no-margin`}>
               {dateString}
             </p>
           )}
 
           {!isPast && timeString && (
-            <p className={`${font('hnr', 5)} no-padding no-margin`}>
+            <p className={`${font('intr', 5)} no-padding no-margin`}>
               {timeString}
             </p>
           )}
@@ -159,7 +159,7 @@ const EventPromo: FC<Props> = ({
           {upcomingDatesFullyBooked(event) && (
             <Space
               v={{ size: 'm', properties: ['margin-top'] }}
-              className={`${font('hnr', 5)} flex flex--v-center`}
+              className={`${font('intr', 5)} flex flex--v-center`}
             >
               <Space
                 as="span"
@@ -173,7 +173,7 @@ const EventPromo: FC<Props> = ({
           )}
 
           {!isPast && event.scheduleLength > 0 && (
-            <p className={`${font('hnb', 5)} no-padding no-margin`}>
+            <p className={`${font('intb', 5)} no-padding no-margin`}>
               {`${event.scheduleLength} ${
                 event.scheduleLength > 1 ? 'events' : 'event'
               }`}
@@ -181,11 +181,11 @@ const EventPromo: FC<Props> = ({
           )}
 
           {!isPast && event.times.length > 1 && (
-            <p className={`${font('hnb', 6)}`}>See all dates/times</p>
+            <p className={`${font('intb', 6)}`}>See all dates/times</p>
           )}
 
           {isPast && !event.availableOnline && (
-            <div className={`${font('hnr', 5)} flex flex--v-center`}>
+            <div className={`${font('intr', 5)} flex flex--v-center`}>
               <Space
                 as="span"
                 h={{ size: 'xs', properties: ['margin-right'] }}
@@ -201,8 +201,8 @@ const EventPromo: FC<Props> = ({
       {event.series.length > 0 && (
         <CardPostBody>
           {event.series.map(series => (
-            <p key={series.title} className={`${font('hnb', 6)} no-margin`}>
-              <span className={font('hnr', 6)}>Part of</span> {series.title}
+            <p key={series.title} className={`${font('intb', 6)} no-margin`}>
+              <span className={font('intr', 6)}>Part of</span> {series.title}
             </p>
           ))}
         </CardPostBody>

--- a/content/webapp/components/EventSchedule/EventBookingButton.tsx
+++ b/content/webapp/components/EventSchedule/EventBookingButton.tsx
@@ -1,5 +1,5 @@
 import { Event } from '../../types/events';
-import { Fragment } from 'react';
+import { Fragment, ReactNode } from 'react';
 import ButtonSolidLink from '@weco/common/views/components/ButtonSolidLink/ButtonSolidLink';
 import Message from '@weco/common/views/components/Message/Message';
 import { font } from '@weco/common/utils/classnames';
@@ -59,12 +59,12 @@ const EventBookingButtonLink = styled(Space).attrs<EventBookingButtonProps>(
       size: 's',
       properties: ['margin-top'],
     },
-    className: `block font-charcoal ${font('hnr', 4)}`,
+    className: `block font-charcoal ${font('intr', 4)}`,
     href: `mailto:${props.email}?subject=${props.title}`,
   })
 )<EventBookingButtonProps>``;
 
-const EventBookingButton = ({ event }: Props) => {
+const EventBookingButton: ReactNode = ({ event }: Props) => {
   const team = event.bookingEnquiryTeam;
 
   return (

--- a/content/webapp/components/EventSchedule/EventBookingButton.tsx
+++ b/content/webapp/components/EventSchedule/EventBookingButton.tsx
@@ -1,5 +1,5 @@
 import { Event } from '../../types/events';
-import { Fragment, ReactNode } from 'react';
+import { Fragment } from 'react';
 import ButtonSolidLink from '@weco/common/views/components/ButtonSolidLink/ButtonSolidLink';
 import Message from '@weco/common/views/components/Message/Message';
 import { font } from '@weco/common/utils/classnames';
@@ -64,7 +64,7 @@ const EventBookingButtonLink = styled(Space).attrs<EventBookingButtonProps>(
   })
 )<EventBookingButtonProps>``;
 
-const EventBookingButton: ReactNode = ({ event }: Props) => {
+const EventBookingButton = ({ event }: Props) => {
   const team = event.bookingEnquiryTeam;
 
   return (

--- a/content/webapp/components/EventSchedule/EventScheduleItem.tsx
+++ b/content/webapp/components/EventSchedule/EventScheduleItem.tsx
@@ -50,7 +50,7 @@ const EventScheduleItem: FC<Props> = ({ event, isNotLinked }) => {
               return (
                 <h4
                   key={`${event.title} ${startTimeString}`}
-                  className={`${font('hnb', 5)} no-margin`}
+                  className={`${font('intb', 5)} no-margin`}
                 >
                   <time dateTime={startTimeString}>
                     {formatTime(t.range.startDateTime)}
@@ -84,7 +84,7 @@ const EventScheduleItem: FC<Props> = ({ event, isNotLinked }) => {
                   v={{ size: 's', properties: ['margin-bottom'] }}
                   as="p"
                   className={classNames({
-                    [font('hnr', 5)]: true,
+                    [font('intr', 5)]: true,
                   })}
                 >
                   {event.locations[0].title}
@@ -94,7 +94,7 @@ const EventScheduleItem: FC<Props> = ({ event, isNotLinked }) => {
             {event.promo?.caption && (
               <Space
                 v={{ size: 'm', properties: ['margin-bottom'] }}
-                className={font('hnr', 5)}
+                className={font('intr', 5)}
                 dangerouslySetInnerHTML={{ __html: event.promo?.caption }}
               />
             )}
@@ -106,7 +106,7 @@ const EventScheduleItem: FC<Props> = ({ event, isNotLinked }) => {
                   properties: ['margin-top', 'margin-bottom'],
                 }}
               >
-                <p className={`${font('hnr', 5)} no-margin`}>
+                <p className={`${font('intr', 5)} no-margin`}>
                   <a href={`/events/${event.id}`}>
                     Full event details
                     <span className={`visually-hidden`}>
@@ -138,7 +138,7 @@ const EventScheduleItem: FC<Props> = ({ event, isNotLinked }) => {
                     }}
                     className={classNames({
                       'bg-yellow inline-block': true,
-                      [font('hnb', 5)]: true,
+                      [font('intb', 5)]: true,
                     })}
                   >
                     <span>

--- a/content/webapp/components/EventbriteButtons/EventbriteButtons.tsx
+++ b/content/webapp/components/EventbriteButtons/EventbriteButtons.tsx
@@ -11,7 +11,7 @@ const Location = styled(Space).attrs({
   v: { size: 's', properties: ['margin-bottom'] },
   as: 'p',
   className: classNames({
-    [font('hnb', 5)]: true,
+    [font('intb', 5)]: true,
   }),
 })``;
 
@@ -88,7 +88,7 @@ const EventbriteButtons: FC<Props> = ({ event }) => {
           <p
             className={classNames({
               'font-charcoal no-margin': true,
-              [font('hnr', 5)]: true,
+              [font('intr', 5)]: true,
             })}
           >
             Tickets via Eventbrite

--- a/content/webapp/components/Exhibition/Exhibition.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.tsx
@@ -316,7 +316,7 @@ const Exhibition: FC<Props> = ({ exhibition, jsonLd, pages }) => {
 
         {exhibition.end && !isPast(exhibition.end) && (
           <InfoBox title="Visit us" items={getInfoItems(exhibition)}>
-            <p className={`no-margin ${font('hnr', 5)}`}>
+            <p className={`no-margin ${font('intr', 5)}`}>
               <a href="/access">All our accessibility services</a>
             </p>
           </InfoBox>

--- a/content/webapp/components/ExhibitionGuideLinksPromo/ExhibitionGuideLinksPromo.tsx
+++ b/content/webapp/components/ExhibitionGuideLinksPromo/ExhibitionGuideLinksPromo.tsx
@@ -83,7 +83,7 @@ const ExhibitionGuideLinksPromo: FC<Props> = ({ exhibitionGuide }) => {
       <Space v={{ size: 's', properties: ['margin-top'] }}>
         <ul
           className={classNames({
-            [font('hnr', 5)]: true,
+            [font('intr', 5)]: true,
             'no-margin plain-list no-padding': true,
           })}
         >

--- a/content/webapp/components/ExhibitionGuidePromo/ExhibitionGuidePromo.tsx
+++ b/content/webapp/components/ExhibitionGuidePromo/ExhibitionGuidePromo.tsx
@@ -66,7 +66,7 @@ const ExhibitionGuidePromo: FC<Props> = ({ exhibitionGuide }) => {
             <Space v={{ size: 's', properties: ['margin-top'] }}>
               <p
                 className={classNames({
-                  [font('hnr', 5)]: true,
+                  [font('intr', 5)]: true,
                   'no-margin': true,
                 })}
               >

--- a/content/webapp/components/ExhibitionPromo/ExhibitionPromo.tsx
+++ b/content/webapp/components/ExhibitionPromo/ExhibitionPromo.tsx
@@ -82,7 +82,7 @@ const ExhibitionPromo: FC<Props> = ({ exhibition, position = 0 }) => {
             <Space
               as="p"
               v={{ size: 'm', properties: ['margin-bottom'] }}
-              className={`${font('hnr', 5)} no-padding`}
+              className={`${font('intr', 5)} no-padding`}
             >
               <>
                 <time dateTime={formatDate(start)}>{formatDate(start)}</time> –{' '}

--- a/content/webapp/components/FacilityPromo/FacilityPromo.tsx
+++ b/content/webapp/components/FacilityPromo/FacilityPromo.tsx
@@ -56,13 +56,13 @@ const FacilityPromo: FC<FacilityPromoType> = ({
             >
               {title}
             </h2>
-            <p className={`${font('hnr', 5)} no-margin no-padding`}>
+            <p className={`${font('intr', 5)} no-margin no-padding`}>
               {description}
             </p>
 
             {metaText && (
               <Space v={{ size: 'm', properties: ['margin-top'] }}>
-                <div className={`${font('hnb', 6)} flex flex--v-center`}>
+                <div className={`${font('intb', 6)} flex flex--v-center`}>
                   {metaIcon && (
                     <Space
                       as="span"

--- a/content/webapp/components/FeaturedCard/FeaturedCard.tsx
+++ b/content/webapp/components/FeaturedCard/FeaturedCard.tsx
@@ -118,7 +118,7 @@ const FeaturedCardArticleBody: FunctionComponent<FeaturedCardArticleBodyProps> =
         {article.promo?.caption && (
           <p
             className={classNames({
-              [font('hnr', 5)]: true,
+              [font('intr', 5)]: true,
             })}
           >
             {article.promo?.caption}
@@ -127,8 +127,8 @@ const FeaturedCardArticleBody: FunctionComponent<FeaturedCardArticleBodyProps> =
         {article.series.length > 0 && (
           <Space v={{ size: 'l', properties: ['margin-top'] }}>
             {article.series.map(series => (
-              <p key={series.title} className={`${font('hnb', 6)} no-margin`}>
-                <span className={font('hnr', 6)}>Part of</span> {series.title}
+              <p key={series.title} className={`${font('intb', 6)} no-margin`}>
+                <span className={font('intr', 6)}>Part of</span> {series.title}
               </p>
             ))}
           </Space>
@@ -163,7 +163,7 @@ const FeaturedCardExhibitionBody = ({
         <Space
           as="p"
           v={{ size: 'm', properties: ['margin-bottom'] }}
-          className={`${font('hnr', 4)} no-margin no-padding`}
+          className={`${font('intr', 4)} no-margin no-padding`}
         >
           <>
             <time dateTime={exhibition.start.toUTCString()}>

--- a/content/webapp/components/FeaturedText/FeaturedText.tsx
+++ b/content/webapp/components/FeaturedText/FeaturedText.tsx
@@ -13,7 +13,7 @@ const FeaturedText: FC<Props> = ({ html, htmlSerializer }: Props) => (
   <div
     className={classNames({
       'body-text': true,
-      [font('hnr', 4)]: true,
+      [font('intr', 4)]: true,
     })}
   >
     <PrismicHtmlBlock html={html} htmlSerializer={htmlSerializer} />

--- a/content/webapp/components/ImageGallery/ImageGallery.tsx
+++ b/content/webapp/components/ImageGallery/ImageGallery.tsx
@@ -374,7 +374,7 @@ const ImageGallery: FunctionComponent<{ id: number } & Props> = ({
                           properties: ['margin-bottom'],
                         }}
                         className={classNames({
-                          [font('hnb', 5)]: true,
+                          [font('intb', 5)]: true,
                         })}
                       >
                         {i + 1} of {items.length}

--- a/content/webapp/components/InfoBox/InfoBox.tsx
+++ b/content/webapp/components/InfoBox/InfoBox.tsx
@@ -32,7 +32,7 @@ const InfoBox: FC<Props> = ({ title, items, children }) => {
       >
         {items.map(({ title, description, icon }, i) => (
           <Fragment key={i}>
-            <div className={font('hnb', 4)}>
+            <div className={font('intb', 4)}>
               {icon && (title || description) && (
                 <Space
                   h={{ size: 's', properties: ['margin-right'] }}
@@ -42,7 +42,7 @@ const InfoBox: FC<Props> = ({ title, items, children }) => {
                 </Space>
               )}
               {title && (
-                <h3 className={classNames([font('hnb', 5)])}>{title}</h3>
+                <h3 className={classNames([font('intb', 5)])}>{title}</h3>
               )}
               {description && (
                 <Space
@@ -51,7 +51,7 @@ const InfoBox: FC<Props> = ({ title, items, children }) => {
                     properties: ['margin-bottom'],
                   }}
                   className={classNames({
-                    [font('hnr', 5)]: true,
+                    [font('intr', 5)]: true,
                   })}
                 >
                   <PrismicHtmlBlock html={description} />

--- a/content/webapp/components/Installation/Installation.tsx
+++ b/content/webapp/components/Installation/Installation.tsx
@@ -105,7 +105,7 @@ const Installation: FunctionComponent<Props> = ({
       >
         {installation.end && !isPast(installation.end) && (
           <InfoBox title="Visit us" items={getInfoItems(installation)}>
-            <p className={`no-margin ${font('hnr', 5)}`}>
+            <p className={`no-margin ${font('intr', 5)}`}>
               <a href="/access">All our accessibility services</a>
             </p>
           </InfoBox>

--- a/content/webapp/components/LayoutPaginatedResults/LayoutPaginatedResults.tsx
+++ b/content/webapp/components/LayoutPaginatedResults/LayoutPaginatedResults.tsx
@@ -94,7 +94,7 @@ const LayoutPaginatedResults: FC<Props> = ({
         <div className="flex-inline flex--v-center">
           <span
             className={classNames({
-              [font('hnb', 4)]: true,
+              [font('intb', 4)]: true,
             })}
           >
             Free admission

--- a/content/webapp/components/MediaObjectBase/MediaObjectBase.tsx
+++ b/content/webapp/components/MediaObjectBase/MediaObjectBase.tsx
@@ -161,11 +161,11 @@ const MediaObjectBase: FunctionComponent<Props> = ({
           <div
             className={classNames({
               'spaced-text': true,
-              [font('hnr', 5)]: !descriptionIsString,
+              [font('intr', 5)]: !descriptionIsString,
             })}
           >
             {descriptionIsString ? (
-              <p className={font('hnr', 5)}>{description}</p>
+              <p className={font('intr', 5)}>{description}</p>
             ) : (
               description
             )}

--- a/content/webapp/components/NewsletterSignup/NewsletterSignup.tsx
+++ b/content/webapp/components/NewsletterSignup/NewsletterSignup.tsx
@@ -77,7 +77,7 @@ const NewsletterSignup: FC<Props> = ({
         <div className="body-text">
           <p
             className={classNames({
-              [font('hnb', 3)]: true,
+              [font('intb', 3)]: true,
             })}
           >
             Thank you for confirming your email address
@@ -102,7 +102,7 @@ const NewsletterSignup: FC<Props> = ({
         <div className="body-text">
           <p
             className={classNames({
-              [font('hnb', 3)]: true,
+              [font('intb', 3)]: true,
             })}
           >
             You’re signed up
@@ -119,7 +119,7 @@ const NewsletterSignup: FC<Props> = ({
         <div className="body-text">
           <p
             className={classNames({
-              [font('hnb', 3)]: true,
+              [font('intb', 3)]: true,
             })}
           >
             Sorry, there’s been a problem
@@ -132,7 +132,7 @@ const NewsletterSignup: FC<Props> = ({
         <div className="body-text">
           <p
             className={classNames({
-              [font('hnb', 3)]: true,
+              [font('intb', 3)]: true,
             })}
           >
             Want to hear more from us?
@@ -194,7 +194,7 @@ const NewsletterSignup: FC<Props> = ({
             <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
               <legend
                 className={classNames({
-                  [font('hnb', 4)]: true,
+                  [font('intb', 4)]: true,
                 })}
               >
                 You might also be interested in receiving updates on:
@@ -231,7 +231,7 @@ const NewsletterSignup: FC<Props> = ({
             </div>
           )}
 
-          <p className={`${font('hnr', 6)}`}>
+          <p className={`${font('intr', 6)}`}>
             We use a third-party provider,{' '}
             <a href="https://dotdigital.com/terms/privacy-policy/">
               dotdigital

--- a/content/webapp/components/OnThisPageAnchors/OnThisPageAnchors.tsx
+++ b/content/webapp/components/OnThisPageAnchors/OnThisPageAnchors.tsx
@@ -6,7 +6,7 @@ import { FunctionComponent, ReactElement } from 'react';
 
 const Anchor = styled.a.attrs(() => ({
   className: classNames({
-    [font('hnb', 5)]: true,
+    [font('intb', 5)]: true,
   }),
 }))`
   color: ${props => props.theme.color('green')};

--- a/content/webapp/components/Quote/Quote.tsx
+++ b/content/webapp/components/Quote/Quote.tsx
@@ -15,7 +15,7 @@ const Quote: FC<Props> = ({ text, citation, isPullOrReview }) => {
     <blockquote
       className={classNames({
         'quote--pull': isPullOrReview,
-        [font('hnr', 2)]: isPullOrReview,
+        [font('intr', 2)]: isPullOrReview,
         'quote no-margin': true,
       })}
     >
@@ -28,7 +28,7 @@ const Quote: FC<Props> = ({ text, citation, isPullOrReview }) => {
         <footer className="quote__footer flex">
           <cite
             className={`quote__cite flex flex--v-end font-pewter ${font(
-              'hnr',
+              'intr',
               5
             )}`}
           >

--- a/content/webapp/components/SeasonsHeader/SeasonsHeader.tsx
+++ b/content/webapp/components/SeasonsHeader/SeasonsHeader.tsx
@@ -63,7 +63,7 @@ const SeasonsHeader: FunctionComponent<Props> = ({
                         </h1>
                       </Space>
                       {start && end && (
-                        <div className={font('hnr', 5)}>
+                        <div className={font('intr', 5)}>
                           <DateRange
                             start={new Date(start)}
                             end={new Date(end)}

--- a/content/webapp/components/SimpleCardGrid/SimpleCardGrid.tsx
+++ b/content/webapp/components/SimpleCardGrid/SimpleCardGrid.tsx
@@ -55,7 +55,7 @@ const CardGridFeaturedCard = ({ item }: CardGridFeaturedCardProps) => {
       >
         {item.title && <h2 className="font-wb font-size-2">{item.title}</h2>}
         {item.description && (
-          <p className="font-hnr font-size-5">{item.description}</p>
+          <p className="font-intr font-size-5">{item.description}</p>
         )}
       </FeaturedCard>
     </Layout12>

--- a/content/webapp/components/StoryPromo/StoryPromo.tsx
+++ b/content/webapp/components/StoryPromo/StoryPromo.tsx
@@ -117,7 +117,7 @@ const StoryPromo: FunctionComponent<Props> = ({
             <p
               className={classNames({
                 'inline-block no-margin': true,
-                [font('hnr', 5)]: true,
+                [font('intr', 5)]: true,
               })}
             >
               {article.promo?.caption}
@@ -128,8 +128,8 @@ const StoryPromo: FunctionComponent<Props> = ({
       {article.series.length > 0 && (
         <CardPostBody>
           {article.series.map(series => (
-            <p key={series.id} className={`${font('hnb', 6)} no-margin`}>
-              <span className={font('hnr', 6)}>Part of</span> {series.title}
+            <p key={series.id} className={`${font('intb', 6)} no-margin`}>
+              <span className={font('intr', 6)}>Part of</span> {series.title}
             </p>
           ))}
         </CardPostBody>

--- a/content/webapp/components/TitledTextList/TitledTextList.tsx
+++ b/content/webapp/components/TitledTextList/TitledTextList.tsx
@@ -9,7 +9,7 @@ import * as prismicT from '@prismicio/types';
 
 const HeadingLink = styled.a.attrs({
   className: classNames({
-    [font('hnb', 4)]: true,
+    [font('intb', 4)]: true,
   }),
 })`
   cursor: pointer;

--- a/content/webapp/components/VenueHours/VenueHours.tsx
+++ b/content/webapp/components/VenueHours/VenueHours.tsx
@@ -143,7 +143,7 @@ const VenueHours: FunctionComponent<Props> = ({ venue, weight }) => {
         <ul
           className={classNames({
             'plain-list no-padding no-margin': true,
-            [font('hnr', 5)]: true,
+            [font('intr', 5)]: true,
           })}
         >
           {venue?.openingHours.regular.map(
@@ -177,7 +177,7 @@ const VenueHours: FunctionComponent<Props> = ({ venue, weight }) => {
             >
               <h3
                 className={classNames({
-                  [font('hnb', 5)]: true,
+                  [font('intb', 5)]: true,
                 })}
               >
                 <div
@@ -197,7 +197,7 @@ const VenueHours: FunctionComponent<Props> = ({ venue, weight }) => {
               <ul
                 className={classNames({
                   'plain-list no-padding no-margin': true,
-                  [font('hnr', 5)]: true,
+                  [font('intr', 5)]: true,
                 })}
               >
                 {upcomingExceptionalPeriod.map(p => (

--- a/content/webapp/pages/article.tsx
+++ b/content/webapp/pages/article.tsx
@@ -209,7 +209,7 @@ const ArticlePage: FC<Props> = ({ article, jsonLd }) => {
           <p
             className={classNames({
               'no-margin': true,
-              [font('hnr', 6)]: true,
+              [font('intr', 6)]: true,
             })}
           >
             {article.contributors.length > 0 &&
@@ -225,7 +225,7 @@ const ArticlePage: FC<Props> = ({ article, jsonLd }) => {
                   )}
                   <span
                     className={classNames({
-                      [font('hnb', 6)]: true,
+                      [font('intb', 6)]: true,
                     })}
                   >
                     {contributor.name}
@@ -247,7 +247,7 @@ const ArticlePage: FC<Props> = ({ article, jsonLd }) => {
             <span
               className={classNames({
                 'block font-pewter': true,
-                [font('hnr', 6)]: true,
+                [font('intr', 6)]: true,
               })}
             >
               <HTMLDate date={new Date(article.datePublished)} />

--- a/content/webapp/pages/book.tsx
+++ b/content/webapp/pages/book.tsx
@@ -135,7 +135,7 @@ const BookPage: FunctionComponent<Props> = props => {
             <p
               className={classNames({
                 'no-margin': true,
-                [font('hnb', 3)]: true,
+                [font('intb', 3)]: true,
               })}
             >
               {book.subtitle}

--- a/content/webapp/pages/event.tsx
+++ b/content/webapp/pages/event.tsx
@@ -89,7 +89,7 @@ type EventStatusProps = {
 function EventStatus({ text, color }: EventStatusProps) {
   return (
     <div className="flex">
-      <div className={`${font('hnb', 5)} flex flex--v-center`}>
+      <div className={`${font('intb', 5)} flex flex--v-center`}>
         <Space
           as="span"
           h={{ size: 'xs', properties: ['margin-right'] }}
@@ -352,7 +352,7 @@ const EventPage: NextPage<Props> = ({ jsonEvent, jsonLd }: Props) => {
                       <Space v={{ size: 's', properties: ['margin-top'] }}>
                         <p
                           className={`no-margin font-charcoal ${font(
-                            'hnr',
+                            'intr',
                             5
                           )}`}
                         >
@@ -398,7 +398,7 @@ const EventPage: NextPage<Props> = ({ jsonEvent, jsonLd }: Props) => {
                     as="a"
                     className={classNames({
                       'block font-charcoal': true,
-                      [font('hnb', 5)]: true,
+                      [font('intb', 5)]: true,
                     })}
                   >
                     <span>{event.bookingEnquiryTeam.email}</span>
@@ -461,7 +461,7 @@ const EventPage: NextPage<Props> = ({ jsonEvent, jsonLd }: Props) => {
               .filter(Boolean) as LabelField[]
           }
         >
-          <p className={`no-margin ${font('hnr', 5)}`}>
+          <p className={`no-margin ${font('intr', 5)}`}>
             <a
               href={`https://wellcomecollection.org/pages/${prismicPageIds.bookingAndAttendingOurEvents}`}
             >

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -112,7 +112,7 @@ const TypeOption: FC<TypeOptionProps> = ({ url, title, text, color, icon }) => (
         h={{ size: 'm', properties: ['padding-left', 'padding-right'] }}
       >
         <h2 className="h2">{title}</h2>
-        <p className={`${font('hnr', 5)}`}>{text}</p>
+        <p className={`${font('intr', 5)}`}>{text}</p>
         {icon && <Icon icon={icon} />}
       </Space>
     </TypeLink>
@@ -267,7 +267,7 @@ const Stops: FC<StopsProps> = ({ stops, type }) => {
               </>
             ) : (
               <>
-                <span className={font('hnb', 5)}>
+                <span className={font('intb', 5)}>
                   {number}. {title}
                 </span>
                 <p>There is no content to display</p>

--- a/content/webapp/pages/whats-on.tsx
+++ b/content/webapp/pages/whats-on.tsx
@@ -164,7 +164,7 @@ const DateRange = ({ dateRange, period }: DateRangeProps) => {
       }}
       as="p"
       className={classNames({
-        [font('hnr', 5)]: true,
+        [font('intr', 5)]: true,
       })}
     >
       {period === 'today' && (
@@ -220,7 +220,7 @@ const Header = ({
                       as="span"
                       h={{ size: 'm', properties: ['margin-right'] }}
                       className={classNames({
-                        [font('hnb', 5)]: true,
+                        [font('intb', 5)]: true,
                       })}
                     >
                       Galleries
@@ -240,7 +240,7 @@ const Header = ({
                           as="span"
                           h={{ size: 'm', properties: ['margin-right'] }}
                           className={classNames({
-                            [font('hnr', 5)]: true,
+                            [font('intr', 5)]: true,
                           })}
                         >
                           <>
@@ -256,7 +256,7 @@ const Header = ({
                 <NextLink href={`/opening-times`} as={`/opening-times`}>
                   <a
                     className={classNames({
-                      [font('hnb', 5)]: true,
+                      [font('intb', 5)]: true,
                     })}
                   >{`Full opening times`}</a>
                 </NextLink>
@@ -536,7 +536,7 @@ const WhatsOnPage: FunctionComponent<Props> = props => {
                 <Layout12>
                   <div className="flex flex--v-center flex--h-space-between">
                     <h2 className="h1">Exhibitions and Events</h2>
-                    <span className={font('hnb', 4)}>Free admission</span>
+                    <span className={font('intb', 4)}>Free admission</span>
                   </div>
                 </Layout12>
               </Space>

--- a/identity/webapp/pages/index.tsx
+++ b/identity/webapp/pages/index.tsx
@@ -68,8 +68,8 @@ type DetailListProps = {
 
 const Detail: FC<DetailProps> = ({ label, value }) => (
   <>
-    <dt className={font('hnb', 5)}>{label}</dt>
-    <StyledDd className={`${font('hnr', 5)}`}>{value}</StyledDd>
+    <dt className={font('intb', 5)}>{label}</dt>
+    <StyledDd className={`${font('intr', 5)}`}>{value}</StyledDd>
   </>
 );
 
@@ -88,7 +88,7 @@ const TextButton: FC<ComponentPropsWithoutRef<'button'>> = ({
   ...props
 }) => (
   <button
-    className={font('hnr', 5)}
+    className={font('intr', 5)}
     style={{
       border: 'none',
       background: 'none',
@@ -102,7 +102,7 @@ const TextButton: FC<ComponentPropsWithoutRef<'button'>> = ({
 );
 
 const RequestsFailed: FC<{ retry: () => void }> = ({ retry }) => (
-  <p className={`${font('hnr', 5)}`}>
+  <p className={`${font('intr', 5)}`}>
     Something went wrong fetching your item requests.
     <TextButton
       onClick={() => {
@@ -311,7 +311,7 @@ const AccountPage: NextPage<Props> = ({ user: auth0UserClaims }) => {
                       return (
                         <Space
                           as="p"
-                          className={`${font('hnr', 5)}`}
+                          className={`${font('intr', 5)}`}
                           v={{
                             size: 's',
                             properties: ['margin-bottom'],
@@ -326,7 +326,7 @@ const AccountPage: NextPage<Props> = ({ user: auth0UserClaims }) => {
                         <>
                           <Space
                             as="p"
-                            className={`${font('hnb', 5)}`}
+                            className={`${font('intb', 5)}`}
                             v={{ size: 's', properties: ['margin-bottom'] }}
                           >{`You have requested ${requestedItems.totalResults} out of ${allowedRequests} items`}</Space>
                           <ProgressBar>
@@ -389,7 +389,7 @@ const AccountPage: NextPage<Props> = ({ user: auth0UserClaims }) => {
                             ]}
                           />
                           <Space
-                            className={`${font('hnr', 5)}`}
+                            className={`${font('intr', 5)}`}
                             v={{
                               size: 'l',
                               properties: ['margin-top'],
@@ -415,7 +415,7 @@ const AccountPage: NextPage<Props> = ({ user: auth0UserClaims }) => {
           </SectionHeading>
           <Container>
             <Wrapper>
-              <p className={font('hnr', 5)}>
+              <p className={font('intr', 5)}>
                 If you no longer wish to be a library member, you can cancel
                 your membership. The library team will be notified and your
                 online account will be closed.

--- a/identity/webapp/pages/registration.tsx
+++ b/identity/webapp/pages/registration.tsx
@@ -170,7 +170,7 @@ const RegistrationPage: NextPage<Props> = ({
                     </SpacingComponent>
 
                     <SpacingComponent>
-                      <h3 className={font('hnb', 5)}>
+                      <h3 className={font('intb', 5)}>
                         {collectionsResearchAgreementTitle}
                       </h3>
                       <Controller

--- a/identity/webapp/src/frontend/MyAccount/ChangeEmail.tsx
+++ b/identity/webapp/src/frontend/MyAccount/ChangeEmail.tsx
@@ -95,7 +95,7 @@ export const ChangeEmail: React.FC<ChangeDetailsModalContentProps> = ({
       <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
         <h3
           className={classNames({
-            [font('hnb', 5)]: true,
+            [font('intb', 5)]: true,
             'no-margin': true,
           })}
         >
@@ -103,7 +103,7 @@ export const ChangeEmail: React.FC<ChangeDetailsModalContentProps> = ({
         </h3>
         <p
           className={classNames({
-            [font('hnr', 5)]: true,
+            [font('intr', 5)]: true,
             'no-margin': true,
           })}
         >

--- a/identity/webapp/src/frontend/MyAccount/DeleteAccount.tsx
+++ b/identity/webapp/src/frontend/MyAccount/DeleteAccount.tsx
@@ -94,7 +94,7 @@ export const DeleteAccount: React.FC<ChangeDetailsModalContentProps> = ({
       )}
       <div
         className={classNames({
-          [font('hnr', 5)]: true,
+          [font('intr', 5)]: true,
         })}
       >
         <p>

--- a/identity/webapp/src/frontend/Registration/AccountCreated.tsx
+++ b/identity/webapp/src/frontend/Registration/AccountCreated.tsx
@@ -24,31 +24,29 @@ export const AccountCreated: React.FC = () => {
                 you&apos;ll need to verify your email address.
               </SuccessMessage>
               <SpacingComponent />
-              <p className="font-hnr">
+              <p className="font-intr">
                 We&apos;ve sent you an email with a link to verify your email
                 address and activate your library account. Please do this within
                 the next 24 hours, before the link expires.
               </p>
-              <p className="font-hnr">
+              <p className="font-intr">
                 You won&apos;t be able to sign in until you have activated your
                 account.
               </p>
-              <h2 className="font-hnr" style={{ fontWeight: 'bold' }}>
-                Didn&apos;t receive an email?
-              </h2>
-              <p className="font-hnr">
+              <h2 className="font-intb">Didn&apos;t receive an email?</h2>
+              <p className="font-intr">
                 If you don&apos;t see an email from us within the next few
                 minutes, please check the following:
               </p>
               <ul>
-                <li className="font-hnr">
+                <li className="font-intr">
                   Is the email is in your spam/junk folder?
                 </li>
-                <li className="font-hnr">
+                <li className="font-intr">
                   Was the email address you entered correct?
                 </li>
               </ul>
-              <p className="font-hnr" style={{ fontWeight: 'bold' }}>
+              <p className="font-intb">
                 If you still haven&apos;t received a verification email or need
                 any other help with your account, please contact{' '}
                 <a href="mailto:library@wellcomecollection.org">

--- a/identity/webapp/src/frontend/Registration/Registration.style.ts
+++ b/identity/webapp/src/frontend/Registration/Registration.style.ts
@@ -6,7 +6,7 @@ export const ExternalLink = styled.a`
   white-space: nowrap;
 `;
 
-const AlertBox = styled.div.attrs({ role: 'alert', className: 'font-hnr' })`
+const AlertBox = styled.div.attrs({ role: 'alert', className: 'font-intr' })`
   padding: 1em 2em;
   display: flex;
   flex-direction: column;

--- a/identity/webapp/src/frontend/Registration/RegistrationInformation.tsx
+++ b/identity/webapp/src/frontend/Registration/RegistrationInformation.tsx
@@ -13,9 +13,9 @@ const RegistrationInformation: FC<Props> = ({ email }) => {
     <>
       <SectionHeading as="h1">Apply for a library membership</SectionHeading>
 
-      <h2 className={font('hnb', 4)}>Your details</h2>
+      <h2 className={font('intb', 4)}>Your details</h2>
       <p className="no-margin">
-        Email address: <strong className={font('hnb', 5)}>{email}</strong>
+        Email address: <strong className={font('intb', 5)}>{email}</strong>
       </p>
       <Space
         v={{

--- a/identity/webapp/src/frontend/components/Form.style.ts
+++ b/identity/webapp/src/frontend/components/Form.style.ts
@@ -2,12 +2,13 @@ import { FieldError } from 'react-hook-form';
 import styled from 'styled-components';
 import { SolidButton } from '@weco/common/views/components/ButtonSolid/ButtonSolid';
 import Space from '@weco/common/views/components/styled/Space';
+import { font } from '@weco/common/utils/classnames';
 
 export const FieldMargin = styled(Space).attrs({
   v: { size: 'm', properties: ['margin-bottom'] },
 })``;
 
-export const Label = styled.label.attrs({ className: 'font-hnr font-size-4' })`
+export const Label = styled.label.attrs({ className: font('intr', 4) })`
   display: block;
   font-weight: bold;
 `;

--- a/identity/webapp/src/frontend/components/Layout.style.ts
+++ b/identity/webapp/src/frontend/components/Layout.style.ts
@@ -22,7 +22,7 @@ export const Wrapper = styled(Space).attrs<WrapperProps>(props => ({
       : ['padding-top', 'padding-bottom'],
   },
   h: { size: 'l', properties: ['padding-left', 'padding-right'] },
-  className: font('hnr', 5),
+  className: font('intr', 5),
 }))<WrapperProps>`
   position: relative;
 `;

--- a/identity/webapp/src/frontend/components/PasswordInput/PasswordInput.style.ts
+++ b/identity/webapp/src/frontend/components/PasswordInput/PasswordInput.style.ts
@@ -13,7 +13,7 @@ export const RulesListWrapper = styled(Space).attrs({
   h: { size: 'm', properties: ['padding-left', 'padding-right'] },
   v: { size: 'm', properties: ['padding-top', 'padding-bottom'] },
   className: classNames({
-    [font('hnr', 5)]: true,
+    [font('intr', 5)]: true,
   }),
 })`
   border: 1px solid ${props => props.theme.color('smoke')};


### PR DESCRIPTION
## Who is this for?
Devs, for readability of what's being used when integrating.

## What is it doing for them?
Helvetica Neue was changed to using Inter. This commit is not perfecting it, mostly just renaming the variable. Inter doesn't use a different font for bold/regular where Helvetica did, so that could have been treated as part of it (see `fontFamilies` in typography.ts), but as we have a review of the fonts we'll need to do as part of the new designs (more flexibility on weight?) I went for simple.