### PR TITLE
Use AppContext for storing audioPlaybackRate

### DIFF
--- a/common/views/components/AppContext/AppContext.tsx
+++ b/common/views/components/AppContext/AppContext.tsx
@@ -4,16 +4,20 @@ import {
   useState,
   useEffect,
   ReactElement,
-  FunctionComponent,
+  FC,
   ReactNode,
 } from 'react';
 import theme, { Size } from '../../../views/themes/default';
+
+export type PlaybackRate = 0.5 | 1 | 1.5 | 2;
 
 type AppContextProps = {
   isEnhanced: boolean;
   isKeyboard: boolean;
   isFullSupportBrowser: boolean;
   windowSize: Size;
+  audioPlaybackRate: PlaybackRate;
+  setAudioPlaybackRate: (rate: PlaybackRate) => void;
 };
 
 const appContextDefaults = {
@@ -21,6 +25,8 @@ const appContextDefaults = {
   isKeyboard: true,
   isFullSupportBrowser: false,
   windowSize: 'small' as Size,
+  audioPlaybackRate: 1 as PlaybackRate,
+  setAudioPlaybackRate: () => null,
 };
 
 export const AppContext = createContext<AppContextProps>(appContextDefaults);
@@ -42,7 +48,7 @@ function getWindowSize(): Size {
   }
 }
 
-export const AppContextProvider: FunctionComponent<AppContextProviderProps> = ({
+export const AppContextProvider: FC<AppContextProviderProps> = ({
   children,
 }: AppContextProviderProps): ReactElement<AppContextProviderProps> => {
   const [isEnhanced, setIsEnhanced] = useState(appContextDefaults.isEnhanced);
@@ -52,6 +58,9 @@ export const AppContextProvider: FunctionComponent<AppContextProviderProps> = ({
   );
   const [windowSize, setWindowSize] = useState<Size>(
     appContextDefaults.windowSize
+  );
+  const [audioPlaybackRate, setAudioPlaybackRate] = useState(
+    appContextDefaults.audioPlaybackRate
   );
 
   useEffect(() => {
@@ -109,6 +118,8 @@ export const AppContextProvider: FunctionComponent<AppContextProviderProps> = ({
         isKeyboard,
         isFullSupportBrowser,
         windowSize,
+        audioPlaybackRate,
+        setAudioPlaybackRate,
       }}
     >
       {children}

--- a/common/views/components/AppContext/AppContext.tsx
+++ b/common/views/components/AppContext/AppContext.tsx
@@ -9,15 +9,13 @@ import {
 } from 'react';
 import theme, { Size } from '../../../views/themes/default';
 
-export type PlaybackRate = 0.5 | 1 | 1.5 | 2;
-
 type AppContextProps = {
   isEnhanced: boolean;
   isKeyboard: boolean;
   isFullSupportBrowser: boolean;
   windowSize: Size;
-  audioPlaybackRate: PlaybackRate;
-  setAudioPlaybackRate: (rate: PlaybackRate) => void;
+  audioPlaybackRate: number;
+  setAudioPlaybackRate: (rate: number) => void;
 };
 
 const appContextDefaults = {
@@ -25,7 +23,7 @@ const appContextDefaults = {
   isKeyboard: true,
   isFullSupportBrowser: false,
   windowSize: 'small' as Size,
-  audioPlaybackRate: 1 as PlaybackRate,
+  audioPlaybackRate: 1,
   setAudioPlaybackRate: () => null,
 };
 

--- a/common/views/components/AudioPlayer/AudioPlayer.tsx
+++ b/common/views/components/AudioPlayer/AudioPlayer.tsx
@@ -19,10 +19,7 @@ import Space from '@weco/common/views/components/styled/Space';
 import { classNames, font } from '@weco/common/utils/classnames';
 import styled from 'styled-components';
 import { trackEvent } from '@weco/common/utils/ga';
-import {
-  AppContext,
-  PlaybackRate,
-} from '@weco/common/views/components/AppContext/AppContext';
+import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
 
 const VolumeWrapper = styled.div`
   display: flex;
@@ -145,12 +142,8 @@ type PlayRateProps = {
 const PlayRate: FC<PlayRateProps> = ({ audioPlayer, id }) => {
   const { audioPlaybackRate, setAudioPlaybackRate } = useContext(AppContext);
   const speeds = [0.5, 1, 1.5, 2];
-  const [currentActiveSpeedIndex, setCurrentActiveSpeedIndex] = useState<
-    typeof speeds[number]
-  >(speeds.indexOf(audioPlaybackRate));
 
   useEffect(() => {
-    setCurrentActiveSpeedIndex(speeds.indexOf(audioPlaybackRate));
     audioPlayer.playbackRate = audioPlaybackRate;
   }, [audioPlaybackRate]);
 
@@ -161,8 +154,7 @@ const PlayRate: FC<PlayRateProps> = ({ audioPlayer, id }) => {
       label: id,
     });
 
-    setAudioPlaybackRate(speed as PlaybackRate);
-    setCurrentActiveSpeedIndex(speeds.indexOf(speed));
+    setAudioPlaybackRate(speed);
     audioPlayer.playbackRate = speed;
   }
 
@@ -172,7 +164,7 @@ const PlayRate: FC<PlayRateProps> = ({ audioPlayer, id }) => {
         <PlayRateLabel
           key={speed}
           htmlFor={`playrate-${speed}-${id}`}
-          isActive={speeds[currentActiveSpeedIndex] === speed}
+          isActive={audioPlaybackRate === speed}
         >
           <PlayRateRadio
             id={`playrate-${speed}-${id}`}

--- a/common/views/components/AudioPlayer/AudioPlayer.tsx
+++ b/common/views/components/AudioPlayer/AudioPlayer.tsx
@@ -1,4 +1,12 @@
-import { useEffect, useRef, useState, FC, Ref, SyntheticEvent } from 'react';
+import {
+  useEffect,
+  useRef,
+  useState,
+  FC,
+  Ref,
+  SyntheticEvent,
+  useContext,
+} from 'react';
 import { dasherize } from '@weco/common/utils/grammar';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import {
@@ -11,6 +19,10 @@ import Space from '@weco/common/views/components/styled/Space';
 import { classNames, font } from '@weco/common/utils/classnames';
 import styled from 'styled-components';
 import { trackEvent } from '@weco/common/utils/ga';
+import {
+  AppContext,
+  PlaybackRate,
+} from '@weco/common/views/components/AppContext/AppContext';
 
 const VolumeWrapper = styled.div`
   display: flex;
@@ -131,9 +143,16 @@ type PlayRateProps = {
 };
 
 const PlayRate: FC<PlayRateProps> = ({ audioPlayer, id }) => {
+  const { audioPlaybackRate, setAudioPlaybackRate } = useContext(AppContext);
   const speeds = [0.5, 1, 1.5, 2];
-  const [currentActiveSpeedIndex, setCurrentActiveSpeedIndex] =
-    useState<typeof speeds[number]>(1);
+  const [currentActiveSpeedIndex, setCurrentActiveSpeedIndex] = useState<
+    typeof speeds[number]
+  >(speeds.indexOf(audioPlaybackRate));
+
+  useEffect(() => {
+    setCurrentActiveSpeedIndex(speeds.indexOf(audioPlaybackRate));
+    audioPlayer.playbackRate = audioPlaybackRate;
+  }, [audioPlaybackRate]);
 
   function updatePlaybackRate(speed: number) {
     trackEvent({
@@ -141,6 +160,8 @@ const PlayRate: FC<PlayRateProps> = ({ audioPlayer, id }) => {
       action: `set speed to ${speed}x`,
       label: id,
     });
+
+    setAudioPlaybackRate(speed as PlaybackRate);
     setCurrentActiveSpeedIndex(speeds.indexOf(speed));
     audioPlayer.playbackRate = speed;
   }


### PR DESCRIPTION
## Who is this for?
People who don't want to update their playback rate for every audio player

## What is it doing for them?
Updating their preference throughout the app

![audioPlaybackRate](https://user-images.githubusercontent.com/1394592/185178888-8b56604b-6277-463a-8fc1-95dedba61107.gif)

Is this a good idea/the right way to do it? I'm not sure.

