### PR TITLE
Setting a user preference cookie for guide type

### DIFF
--- a/content/webapp/package.json
+++ b/content/webapp/package.json
@@ -17,6 +17,7 @@
     "@types/styled-components": "^5.1.15",
     "@types/supertest": "^2.0.11",
     "@weco/common": "1.0.0",
+    "cookies-next": "^2.1.1",
     "google-maps": "^3.3.0",
     "jest": "^27.3.1",
     "koa": "^2.5.0",

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -311,6 +311,7 @@ type ExhibitionLinksProps = {
   pathname: string;
 };
 const ExhibitionLinks: FC<ExhibitionLinksProps> = ({ stops, pathname }) => {
+  const hasUserPreference = hasCookie('userPreferenceGuideType');
   const hasBSLVideo = stops.some(
     stop => stop.bsl.embedUrl // it can't be undefined can it?
   );
@@ -326,7 +327,7 @@ const ExhibitionLinks: FC<ExhibitionLinksProps> = ({ stops, pathname }) => {
 
   return (
     <TypeList>
-      {hasAudioWithoutDescriptions && (
+      {!hasUserPreference && hasAudioWithoutDescriptions && (
         <TypeOption
           url={`/${pathname}/audio-without-descriptions`}
           title="Listen, without audio descriptions"
@@ -340,7 +341,7 @@ const ExhibitionLinks: FC<ExhibitionLinksProps> = ({ stops, pathname }) => {
           }}
         />
       )}
-      {hasAudioWithDescriptions && (
+      {!hasUserPreference && hasAudioWithDescriptions && (
         <TypeOption
           url={`/${pathname}/audio-with-descriptions`}
           title="Listen, with audio descriptions"
@@ -356,7 +357,7 @@ const ExhibitionLinks: FC<ExhibitionLinksProps> = ({ stops, pathname }) => {
           }}
         />
       )}
-      {hasCaptionsOrTranscripts && (
+      {!hasUserPreference && hasCaptionsOrTranscripts && (
         <TypeOption
           url={`/${pathname}/captions-and-transcripts`}
           title="Read captions and transcripts"
@@ -372,7 +373,7 @@ const ExhibitionLinks: FC<ExhibitionLinksProps> = ({ stops, pathname }) => {
           }}
         />
       )}
-      {hasBSLVideo && (
+      {!hasUserPreference && hasBSLVideo && (
         <TypeOption
           url={`/${pathname}/bsl`}
           title="Watch BSL videos"
@@ -439,7 +440,7 @@ const ExhibitionGuidePage: FC<Props> = props => {
       hideNewsletterPromo={true}
       hideFooter={true}
     >
-      {!type ? (
+      {!type && !hasUserPreference ? (
         <Layout10 isCentered={false}>
           <SpacingSection>
             <Space

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -3,6 +3,7 @@ import {
   ExhibitionGuideBasic,
   ExhibitionGuideComponent,
 } from '../types/exhibition-guides';
+import { getCookie, setCookie } from 'cookies-next';
 import { PaginatedResults } from '@weco/common/services/prismic/types';
 import { createClient } from '../services/prismic/fetch';
 import {
@@ -15,7 +16,7 @@ import {
 } from '../services/prismic/transformers/exhibition-guides';
 import { transformQuery } from '../services/prismic/transformers/paginated-results';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
-import { FC } from 'react';
+import { FC, SyntheticEvent } from 'react';
 import { IconSvg } from '@weco/common/icons/types';
 import { font, classNames } from '@weco/common/utils/classnames';
 import { removeUndefinedProps } from '@weco/common/utils/json';
@@ -102,11 +103,19 @@ type TypeOptionProps = {
     | 'newPaletteSalmon'
     | 'newPaletteBlue';
   icon?: IconSvg;
+  onClick?: (event: SyntheticEvent<HTMLAnchorElement>) => void;
 };
 
-const TypeOption: FC<TypeOptionProps> = ({ url, title, text, color, icon }) => (
+const TypeOption: FC<TypeOptionProps> = ({
+  url,
+  title,
+  text,
+  color,
+  icon,
+  onClick,
+}) => (
   <TypeItem>
-    <TypeLink href={url} color={color}>
+    <TypeLink href={url} color={color} onClick={onClick}>
       <Space
         v={{ size: 'm', properties: ['padding-top', 'padding-bottom'] }}
         h={{ size: 'm', properties: ['padding-left', 'padding-right'] }}
@@ -314,6 +323,7 @@ const ExhibitionLinks: FC<ExhibitionLinksProps> = ({ stops, pathname }) => {
   const hasAudioWithDescriptions = stops.some(
     stop => stop.audioWithDescription?.url
   );
+
   return (
     <TypeList>
       {hasAudioWithoutDescriptions && (
@@ -322,6 +332,12 @@ const ExhibitionLinks: FC<ExhibitionLinksProps> = ({ stops, pathname }) => {
           title="Listen, without audio descriptions"
           text="Find out more about the exhibition with short audio tracks."
           color="newPaletteOrange"
+          onClick={event => {
+            event.stopPropagation();
+            setCookie('userPreferenceGuideType', 'audio-without-descriptions', {
+              maxAge: 6000,
+            });
+          }}
         />
       )}
       {hasAudioWithDescriptions && (
@@ -332,6 +348,12 @@ const ExhibitionLinks: FC<ExhibitionLinksProps> = ({ stops, pathname }) => {
         including descriptions of the objects."
           color="newPaletteSalmon"
           icon={audioDescribed}
+          onClick={event => {
+            event.stopPropagation();
+            setCookie('userPreferenceGuideType', 'audio-with-descriptions', {
+              maxAge: 6000,
+            });
+          }}
         />
       )}
       {hasCaptionsOrTranscripts && (
@@ -342,6 +364,12 @@ const ExhibitionLinks: FC<ExhibitionLinksProps> = ({ stops, pathname }) => {
               objects, great for those without headphones."
           color="newPaletteMint"
           icon={speechToText}
+          onClick={event => {
+            event.stopPropagation();
+            setCookie('userPreferenceGuideType', 'captions-and-transcripts', {
+              maxAge: 6000,
+            });
+          }}
         />
       )}
       {hasBSLVideo && (
@@ -351,6 +379,17 @@ const ExhibitionLinks: FC<ExhibitionLinksProps> = ({ stops, pathname }) => {
           text="Commentary about the exhibition in British Sign Language videos."
           color="newPaletteBlue"
           icon={britishSignLanguage}
+          onClick={event => {
+            event.stopPropagation();
+            setCookie('userPreferenceGuideType', 'bsl', {
+              maxAge: 6000,
+            });
+            const testCookieContent = getCookie('userPreferenceGuideType');
+            console.log(
+              testCookieContent,
+              'This is the preference cookie that has been set'
+            );
+          }}
         />
       )}
     </TypeList>
@@ -447,6 +486,7 @@ const ExhibitionGuidePage: FC<Props> = props => {
             </Layout8>
           </Header>
           <Space v={{ size: 'xl', properties: ['margin-top'] }}>
+            {/* TODO: conditional to show user preference guide based on cookie*!/ */}
             <ExhibitionStops type={type} stops={exhibitionGuide.components} />
           </Space>
         </>

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -4,6 +4,7 @@ import {
   ExhibitionGuideComponent,
 } from '../types/exhibition-guides';
 import { getCookie, hasCookie, setCookie } from 'cookies-next';
+import { useRouter } from 'next/router';
 import { PaginatedResults } from '@weco/common/services/prismic/types';
 import { createClient } from '../services/prismic/fetch';
 import {
@@ -31,7 +32,7 @@ import Space from '@weco/common/views/components/styled/Space';
 import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
 import CardGrid from '../components/CardGrid/CardGrid';
 import ExhibitionCaptions from '../components/ExhibitionCaptions/ExhibitionCaptions';
-import { GetServerSideProps } from 'next';
+import { GetServerSideProps, NextApiRequest, NextApiResponse } from 'next';
 import { AppErrorProps } from '@weco/common/views/pages/_app';
 import styled from 'styled-components';
 import { exhibitionGuidesLinks } from '@weco/common/views/components/Header/Header';
@@ -310,6 +311,14 @@ type ExhibitionLinksProps = {
   stops: ExhibitionGuideComponent[];
   pathname: string;
 };
+
+function cookieHandler(key, data, req: NextApiRequest, res: NextApiResponse) {
+  console.log(key, data, 'we are in the cookie handler function <<<<');
+  // We set the cookie to expire in a certain amount of time
+  const options = { req, res, maxAge: 6000 };
+  setCookie(key, data, options);
+}
+
 const ExhibitionLinks: FC<ExhibitionLinksProps> = ({ stops, pathname }) => {
   const hasUserPreference = hasCookie('userPreferenceGuideType');
   const hasBSLVideo = stops.some(
@@ -335,9 +344,10 @@ const ExhibitionLinks: FC<ExhibitionLinksProps> = ({ stops, pathname }) => {
           color="newPaletteOrange"
           onClick={event => {
             event.stopPropagation();
-            setCookie('userPreferenceGuideType', 'audio-without-descriptions', {
-              maxAge: 6000,
-            });
+            cookieHandler(
+              'userPreferenceGuideType',
+              'audio-without-descriptions'
+            );
           }}
         />
       )}
@@ -349,12 +359,12 @@ const ExhibitionLinks: FC<ExhibitionLinksProps> = ({ stops, pathname }) => {
         including descriptions of the objects."
           color="newPaletteSalmon"
           icon={audioDescribed}
-          onClick={event => {
-            event.stopPropagation();
-            setCookie('userPreferenceGuideType', 'audio-with-descriptions', {
-              maxAge: 6000,
-            });
-          }}
+          // onClick={event => {
+          //   event.stopPropagation();
+          //   setCookie('userPreferenceGuideType', 'audio-with-descriptions', {
+          //     maxAge: 6000,
+          //   });
+          // }}
         />
       )}
       {!hasUserPreference && hasCaptionsOrTranscripts && (
@@ -365,12 +375,12 @@ const ExhibitionLinks: FC<ExhibitionLinksProps> = ({ stops, pathname }) => {
               objects, great for those without headphones."
           color="newPaletteMint"
           icon={speechToText}
-          onClick={event => {
-            event.stopPropagation();
-            setCookie('userPreferenceGuideType', 'captions-and-transcripts', {
-              maxAge: 6000,
-            });
-          }}
+          // onClick={event => {
+          //   event.stopPropagation();
+          //   setCookie('userPreferenceGuideType', 'captions-and-transcripts', {
+          //     maxAge: 6000,
+          //   });
+          // }}
         />
       )}
       {!hasUserPreference && hasBSLVideo && (
@@ -380,17 +390,17 @@ const ExhibitionLinks: FC<ExhibitionLinksProps> = ({ stops, pathname }) => {
           text="Commentary about the exhibition in British Sign Language videos."
           color="newPaletteBlue"
           icon={britishSignLanguage}
-          onClick={event => {
-            event.stopPropagation();
-            setCookie('userPreferenceGuideType', 'bsl', {
-              maxAge: 6000,
-            });
-            const testCookieContent = getCookie('userPreferenceGuideType');
-            console.log(
-              testCookieContent,
-              'This is the preference cookie that has been set'
-            );
-          }}
+          // onClick={event => {
+          //   event.stopPropagation();
+          //   setCookie('userPreferenceGuideType', 'bsl', {
+          //     maxAge: 6000,
+          //   });
+          //   const testCookieContent = getCookie('userPreferenceGuideType');
+          //   console.log(
+          //     testCookieContent,
+          //     'This is the preference cookie that has been set'
+          //   );
+          // }}
         />
       )}
     </TypeList>
@@ -422,7 +432,20 @@ const ExhibitionGuidePage: FC<Props> = props => {
   const userPreferencePathname = `guides/exhibitions/${exhibitionGuide.id}${
     type ? `/${userPreferenceGuideType}` : ''
   }`;
+  console.log(userPreferencePathname, 'this is the user preference pathname');
   const typeColor = getTypeColor(type);
+  const router = useRouter();
+  if (hasUserPreference) {
+    router
+      .push(
+        `guides/exhibitions/${exhibitionGuide.id}/${userPreferenceGuideType}`
+      )
+      // .push({
+      //   pathname: `guides/exhibitions/${exhibitionGuide.id}`,
+      //   query: { type: userPreferenceGuideType },
+      // })
+      .then(() => window.scrollTo(0, 0));
+  }
 
   return (
     <PageLayout

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -3,7 +3,7 @@ import {
   ExhibitionGuideBasic,
   ExhibitionGuideComponent,
 } from '../types/exhibition-guides';
-import { getCookie, setCookie } from 'cookies-next';
+import { getCookie, hasCookie, setCookie } from "cookies-next";
 import { PaginatedResults } from '@weco/common/services/prismic/types';
 import { createClient } from '../services/prismic/fetch';
 import {
@@ -413,8 +413,13 @@ function getTypeColor(type) {
 
 const ExhibitionGuidePage: FC<Props> = props => {
   const { exhibitionGuide, jsonLd, type, otherExhibitionGuides } = props;
+  const hasUserPreference = hasCookie('userPreferenceGuideType');
   const pathname = `guides/exhibitions/${exhibitionGuide.id}${
     type ? `/${type}` : ''
+  }`;
+  const userPreferenceGuideType = getCookie('userPreferenceGuideType');
+  const userPreferencePathname = `guides/exhibitions/${exhibitionGuide.id}${
+    type ? `/${userPreferenceGuideType}` : ''
   }`;
   const typeColor = getTypeColor(type);
 
@@ -422,7 +427,7 @@ const ExhibitionGuidePage: FC<Props> = props => {
     <PageLayout
       title={`${exhibitionGuide.title} guide` || ''}
       description={pageDescriptions.exhibitionGuides}
-      url={{ pathname: pathname }}
+      url={{ pathname: hasUserPreference ? userPreferencePathname : pathname }}
       jsonLd={jsonLd}
       openGraphType={'website'}
       siteSection={'exhibition-guides'}
@@ -486,8 +491,14 @@ const ExhibitionGuidePage: FC<Props> = props => {
             </Layout8>
           </Header>
           <Space v={{ size: 'xl', properties: ['margin-top'] }}>
-            {/* TODO: conditional to show user preference guide based on cookie*!/ */}
-            <ExhibitionStops type={type} stops={exhibitionGuide.components} />
+            {hasUserPreference ? (
+              <ExhibitionStops
+                type={userPreferenceGuideType as GuideType}
+                stops={exhibitionGuide.components}
+              />
+            ) : (
+              <ExhibitionStops type={type} stops={exhibitionGuide.components} />
+            )}
           </Space>
         </>
       )}

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -531,7 +531,6 @@ const ExhibitionGuidePage: FC<Props> = props => {
           </Header>
           <Space v={{ size: 'xl', properties: ['margin-top'] }}>
             {userPreferenceSet ? (
-              // TODO: implement delete cookie on click of Change guide type
               <p>
                 This exhibition has {exhibitionGuide.components.length} stops.
                 You have indicated a preference for this guide type, to select

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -3,7 +3,7 @@ import {
   ExhibitionGuideBasic,
   ExhibitionGuideComponent,
 } from '../types/exhibition-guides';
-import { getCookie, hasCookie, setCookie } from "cookies-next";
+import { getCookie, hasCookie, setCookie } from 'cookies-next';
 import { PaginatedResults } from '@weco/common/services/prismic/types';
 import { createClient } from '../services/prismic/fetch';
 import {

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -3,7 +3,7 @@ import {
   ExhibitionGuideBasic,
   ExhibitionGuideComponent,
 } from '../types/exhibition-guides';
-import { getCookie, hasCookie, setCookie } from 'cookies-next';
+import { getCookie, hasCookie, setCookie, deleteCookie } from 'cookies-next';
 import { PaginatedResults } from '@weco/common/services/prismic/types';
 import { createClient } from '../services/prismic/fetch';
 import {
@@ -515,6 +515,10 @@ const ExhibitionGuidePage: FC<Props> = props => {
                     colors={themeValues.buttonColors.charcoalWhiteCharcoal}
                     text="Change guide type"
                     link={`/guides/exhibitions/${exhibitionGuide.id}`}
+                    clickHandler={event => {
+                      event.stopPropagation();
+                      deleteCookie('WC_userPreferenceGuideType');
+                    }}
                   />
                 </Space>
                 <ButtonSolidLink

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -511,8 +511,7 @@ const ExhibitionGuidePage: FC<Props> = props => {
                     colors={themeValues.buttonColors.charcoalWhiteCharcoal}
                     text="Change guide type"
                     link={`/guides/exhibitions/${exhibitionGuide.id}`}
-                    clickHandler={event => {
-                      event.stopPropagation();
+                    clickHandler={() => {
                       deleteCookie('WC_userPreferenceGuideType');
                     }}
                   />
@@ -525,17 +524,29 @@ const ExhibitionGuidePage: FC<Props> = props => {
               </>
             </Layout8>
           </Header>
-          <Space v={{ size: 'xl', properties: ['margin-top'] }}>
+          <Space h={{ size: 'l', properties: ['padding-left'] }}>
             {userPreferenceSet ? (
-              <p>
-                This exhibition has {exhibitionGuide.components.length} stops.
-                You have indicated a preference for this guide type, to select
-                another type select Change guide type.
-              </p>
+              <Space v={{ size: 'l', properties: ['margin-top'] }}>
+                <p>
+                  This exhibition has {exhibitionGuide.components.length} stops.
+                  This is a {type} guide, which you have used previously, but
+                  you can also select{' '}
+                  <a
+                    href={`/guides/exhibitions/${exhibitionGuide.id}`}
+                    onClick={() => {
+                      deleteCookie('WC_userPreferenceGuideType');
+                    }}
+                  >
+                    another type of guide.
+                  </a>
+                </p>
+              </Space>
             ) : (
-              <p>
-                This exhibition has {exhibitionGuide.components.length} stops.
-              </p>
+              <Space v={{ size: 'l', properties: ['margin-top'] }}>
+                <p>
+                  This exhibition has {exhibitionGuide.components.length} stops.
+                </p>
+              </Space>
             )}
             <ExhibitionStops type={type} stops={exhibitionGuide.components} />
           </Space>

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -151,7 +151,7 @@ type Props = {
   jsonLd: JsonLdObj;
   type?: GuideType;
   otherExhibitionGuides: PaginatedResults<ExhibitionGuideBasic>;
-  userPreferenceSet: string | string[] | undefined;
+  userPreferenceSet?: string | string[];
 };
 
 function getTypeTitle(type: GuideType): string {
@@ -370,8 +370,7 @@ const ExhibitionLinks: FC<ExhibitionLinksProps> = ({ stops, pathname }) => {
           title="Listen, without audio descriptions"
           text="Find out more about the exhibition with short audio tracks."
           color="newPaletteOrange"
-          onClick={event => {
-            event.stopPropagation();
+          onClick={() => {
             cookieHandler(
               'WC_userPreferenceGuideType',
               'audio-without-descriptions'
@@ -387,8 +386,7 @@ const ExhibitionLinks: FC<ExhibitionLinksProps> = ({ stops, pathname }) => {
         including descriptions of the objects."
           color="newPaletteSalmon"
           icon={audioDescribed}
-          onClick={event => {
-            event.stopPropagation();
+          onClick={() => {
             cookieHandler(
               'WC_userPreferenceGuideType',
               'audio-with-descriptions'
@@ -404,8 +402,7 @@ const ExhibitionLinks: FC<ExhibitionLinksProps> = ({ stops, pathname }) => {
               objects, great for those without headphones."
           color="newPaletteMint"
           icon={speechToText}
-          onClick={event => {
-            event.stopPropagation();
+          onClick={() => {
             cookieHandler(
               'WC_userPreferenceGuideType',
               'captions-and-transcripts'
@@ -420,8 +417,7 @@ const ExhibitionLinks: FC<ExhibitionLinksProps> = ({ stops, pathname }) => {
           text="Commentary about the exhibition in British Sign Language videos."
           color="newPaletteBlue"
           icon={britishSignLanguage}
-          onClick={event => {
-            event.stopPropagation();
+          onClick={() => {
             cookieHandler('WC_userPreferenceGuideType', 'bsl');
           }}
         />

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -151,7 +151,7 @@ type Props = {
   jsonLd: JsonLdObj;
   type?: GuideType;
   otherExhibitionGuides: PaginatedResults<ExhibitionGuideBasic>;
-  userPreferenceSet: boolean;
+  userPreferenceSet: string | string[] | undefined;
 };
 
 function getTypeTitle(type: GuideType): string {
@@ -217,12 +217,12 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     });
 
     // We want to set a user preference cookie if the qr code url contains a guide type
-    // 28000 is 8 hours - the average length of time the collection is open for
+    // 28000 is 8 hours (the maximum length of time the collection is open for in a day)
     if (usingQRCode) {
       setCookie('WC_userPreferenceGuideType', type, {
         res,
         req,
-        maxAge: 28800,
+        maxAge: 8 * 60 * 60,
       });
     }
 
@@ -343,8 +343,8 @@ type ExhibitionLinksProps = {
 };
 
 function cookieHandler(key, data) {
-  // We set the cookie to expire in 8 hours (the average length of time the gallery is open for each day)
-  const options = { maxAge: 28800 };
+  // We set the cookie to expire in 8 hours (the maximum length of time the collection is open for in a day)
+  const options = { maxAge: 8 * 60 * 60 };
   setCookie(key, data, options);
 }
 
@@ -527,11 +527,11 @@ const ExhibitionGuidePage: FC<Props> = props => {
           </Header>
           <Space v={{ size: 'xl', properties: ['margin-top'] }}>
             {userPreferenceSet ? (
+              // TODO: implement delete cookie on click of Change guide type
               <p>
                 This exhibition has {exhibitionGuide.components.length} stops.
                 You have indicated a preference for this guide type, to select
-                another type click Change guide type. // TODO: implement delete
-                cookie on click of Change guide type
+                another type select Change guide type.
               </p>
             ) : (
               <p>

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -217,7 +217,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     });
 
     // We want to set a user preference cookie if the qr code url contains a guide type
-    // 28000 is 8 hours (the maximum length of time the collection is open for in a day)
+    // 8 hours (the maximum length of time the collection is open for in a day)
     if (usingQRCode) {
       setCookie('WC_userPreferenceGuideType', type, {
         res,

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -151,6 +151,7 @@ type Props = {
   jsonLd: JsonLdObj;
   type?: GuideType;
   otherExhibitionGuides: PaginatedResults<ExhibitionGuideBasic>;
+  userPreferenceSet: boolean;
 };
 
 function getTypeTitle(type: GuideType): string {
@@ -169,7 +170,7 @@ function getTypeTitle(type: GuideType): string {
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
     const serverData = await getServerData(context);
-    const { id, type, usingQRCode } = context.query;
+    const { id, type, usingQRCode, userPreferenceSet } = context.query;
     const { res, req } = context;
 
     if (
@@ -230,7 +231,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       return {
         redirect: {
           permanent: false,
-          destination: `${id}/${userPreferenceGuideType}`,
+          destination: `${id}/${userPreferenceGuideType}?userPreferenceSet=true`,
         },
       };
     }
@@ -251,6 +252,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
               result => result.id !== id
             ),
           },
+          userPreferenceSet,
         }),
       };
     } else {
@@ -444,7 +446,13 @@ function getTypeColor(type) {
 }
 
 const ExhibitionGuidePage: FC<Props> = props => {
-  const { exhibitionGuide, jsonLd, type, otherExhibitionGuides } = props;
+  const {
+    exhibitionGuide,
+    jsonLd,
+    type,
+    otherExhibitionGuides,
+    userPreferenceSet,
+  } = props;
   const pathname = `guides/exhibitions/${exhibitionGuide.id}${
     type ? `/${type}` : ''
   }`;
@@ -518,6 +526,18 @@ const ExhibitionGuidePage: FC<Props> = props => {
             </Layout8>
           </Header>
           <Space v={{ size: 'xl', properties: ['margin-top'] }}>
+            {userPreferenceSet ? (
+              <p>
+                This exhibition has {exhibitionGuide.components.length} stops.
+                You have indicated a preference for this guide type, to select
+                another type click Change guide type. // TODO: implement delete
+                cookie on click of Change guide type
+              </p>
+            ) : (
+              <p>
+                This exhibition has {exhibitionGuide.components.length} stops.
+              </p>
+            )}
             <ExhibitionStops type={type} stops={exhibitionGuide.components} />
           </Space>
         </>

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -169,7 +169,7 @@ function getTypeTitle(type: GuideType): string {
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
     const serverData = await getServerData(context);
-    const { id, type } = context.query;
+    const { id, type, usingQRCode } = context.query;
     const { res, req } = context;
 
     if (
@@ -215,8 +215,17 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       res,
     });
 
+    // We want to set a user preference cookie if the qr code url contains a guide type
+    // 28000 is 8 hours - the average length of time the collection is open for
+    if (usingQRCode) {
+      setCookie('WC_userPreferenceGuideType', type, {
+        res,
+        req,
+        maxAge: 28800,
+      });
+    }
+
     // We want to check for a user guide type preference cookie, and redirect to the appropriate type
-    // TODO: We can adjust this conditional to check the QR code url query params for a type
     if (hasUserPreference && req.url === `/guides/exhibitions/${id}`) {
       return {
         redirect: {
@@ -332,9 +341,8 @@ type ExhibitionLinksProps = {
 };
 
 function cookieHandler(key, data) {
-  console.log(key, data, 'we are in the cookie handler function <<<<');
-  // We set the cookie to expire in 24 hours
-  const options = { maxAge: 84000 };
+  // We set the cookie to expire in 8 hours (the average length of time the gallery is open for each day)
+  const options = { maxAge: 28800 };
   setCookie(key, data, options);
 }
 

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -4,7 +4,6 @@ import {
   ExhibitionGuideComponent,
 } from '../types/exhibition-guides';
 import { getCookie, hasCookie, setCookie } from 'cookies-next';
-import { useRouter } from 'next/router';
 import { PaginatedResults } from '@weco/common/services/prismic/types';
 import { createClient } from '../services/prismic/fetch';
 import {
@@ -32,7 +31,7 @@ import Space from '@weco/common/views/components/styled/Space';
 import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
 import CardGrid from '../components/CardGrid/CardGrid';
 import ExhibitionCaptions from '../components/ExhibitionCaptions/ExhibitionCaptions';
-import { GetServerSideProps, NextApiRequest, NextApiResponse } from 'next';
+import { GetServerSideProps } from 'next';
 import { AppErrorProps } from '@weco/common/views/pages/_app';
 import styled from 'styled-components';
 import { exhibitionGuidesLinks } from '@weco/common/views/components/Header/Header';
@@ -413,10 +412,7 @@ const ExhibitionLinks: FC<ExhibitionLinksProps> = ({ stops, pathname }) => {
           icon={britishSignLanguage}
           onClick={event => {
             event.stopPropagation();
-            cookieHandler(
-              'WC_userPreferenceGuideType',
-              'bsl'
-            );
+            cookieHandler('WC_userPreferenceGuideType', 'bsl');
           }}
         />
       )}


### PR DESCRIPTION
## Who is this for?

Guide users. Based on ticket https://github.com/wellcomecollection/wellcomecollection.org/issues/8188

## What is it doing for them?

**1. Sets a user preference cookie based on chosen guide type.**
When a user selects a guide type, we create a preference cookie `WC_userPreferenceGuideType` and set it to that guide type. When that same user visits any exhibition guide, we send them directly to their preferred type based on that cookie, and we append the url with a parameter indicating the preference is set. 

**2. Sets a user preference cookie based on QR code.** 
If a user visits from a QR code, based on a url like `http://localhost:3002/guides/exhibitions/Ytk2IREAACcA--2o/audio-without-descriptions?usingQRCode=true`, we set `WC_userPreferenceGuideType` based on the guide type in that url.

In both cases:
- we use the userPreferenceSet param to conditionally change the text above the stops to let the user know this preference has been set. ~_TODO: I need to implement the deleteCookie when a user clicks the 'Change guide type' button, as this indicates a change in their preference._~ Now done.
- the cookie lasts 8 hours, which is the maximum amount of time of day the galleries are open. I discussed both of these points with Dom and Alice.

**What does that look like (gif showing case 1 above)**

![userpreference_opt4](https://user-images.githubusercontent.com/16557524/185192444-4138b94c-fb6f-4364-9897-947d433f3d23.gif)

**and a screenshot of viewing an exhibition after a preference cookie has been set:**
<img width="1346" alt="Screenshot 2022-08-17 at 17 28 24" src="https://user-images.githubusercontent.com/16557524/185193748-8248b261-10af-4c09-948a-779f32aa6460.png">


