### PR TITLE
add link text but visually hide it

### DIFF
--- a/common/views/components/Header/DesktopSignIn.tsx
+++ b/common/views/components/Header/DesktopSignIn.tsx
@@ -26,7 +26,12 @@ const DesktopSignIn: FC = () => {
 
   return state === 'initial' || state === 'loading' ? (
     <span className="display-none headerMedium-display-block">
-      <BorderlessLink iconLeft={userIcon} text={null} href="/account" />
+      <BorderlessLink
+        iconLeft={userIcon}
+        text="Library account"
+        isTextHidden={true}
+        href="/account"
+      />
     </span>
   ) : (
     <>


### PR DESCRIPTION
[Fixes the Pa11y error of having a link with no link text](https://wellcome.slack.com/archives/CUA669WHH/p1660896552376159)

Looks like this has always been an issue, but doesn't usually get caught as the link is replaced with a different one when the users logged in status is determined. It would appear that when pa11y ran this time, that status update took longer than normal.

I've added text to the link, but hidden it visually, so there is no change to how the page previously rendered.
