### PR TITLE
Use contextUrl not req.url

### DIFF
--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -227,7 +227,10 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     }
 
     // We want to check for a user guide type preference cookie, and redirect to the appropriate type
-    if (hasUserPreference && req.url === `/guides/exhibitions/${id}`) {
+    if (
+      hasUserPreference &&
+      context.resolvedUrl === `/guides/exhibitions/${id}`
+    ) {
       return {
         redirect: {
           permanent: false,


### PR DESCRIPTION

## Who is this for?

People using the guides

## What is it doing for them?

It should now read the user preference cookie and redirect any other exhibition guides, based on that user preference cookie