### PR TITLE
Fix the types in works.tsx and _app.tsx

### DIFF
--- a/catalogue/webapp/pages/works.tsx
+++ b/catalogue/webapp/pages/works.tsx
@@ -30,10 +30,10 @@ import { worksFilters } from '@weco/common/services/catalogue/filters';
 import { getServerData } from '@weco/common/server-data';
 import { CatalogueResultsList, Work } from '@weco/common/model/catalogue';
 
-type Props = WithPageview & {
+type Props = {
   works: CatalogueResultsList<Work>;
   worksRouteProps: WorksRouteProps;
-};
+} & WithPageview;
 
 const Works: NextPage<Props> = ({ works, worksRouteProps }) => {
   const [loading, setLoading] = useState(false);

--- a/catalogue/webapp/pages/works.tsx
+++ b/catalogue/webapp/pages/works.tsx
@@ -14,17 +14,26 @@ import SearchTabs from '@weco/common/views/components/SearchTabs/SearchTabs';
 import SearchNoResults from '../components/SearchNoResults/SearchNoResults';
 import { removeUndefinedProps } from '@weco/common/utils/json';
 import SearchTitle from '../components/SearchTitle/SearchTitle';
-import { GetServerSidePropsContext, NextPage } from 'next';
-import { appError, PageProps } from '@weco/common/views/pages/_app';
+import { GetServerSideProps, NextPage } from 'next';
+import {
+  appError,
+  AppErrorProps,
+  WithPageview,
+} from '@weco/common/views/pages/_app';
 import {
   fromQuery,
   toLink,
+  WorksProps as WorksRouteProps,
 } from '@weco/common/views/components/WorksLink/WorksLink';
 import SearchContext from '@weco/common/views/components/SearchContext/SearchContext';
 import { worksFilters } from '@weco/common/services/catalogue/filters';
 import { getServerData } from '@weco/common/server-data';
+import { CatalogueResultsList, Work } from '@weco/common/model/catalogue';
 
-type Props = PageProps<typeof getServerSideProps>;
+type Props = WithPageview & {
+  works: CatalogueResultsList<Work>;
+  worksRouteProps: WorksRouteProps;
+};
 
 const Works: NextPage<Props> = ({ works, worksRouteProps }) => {
   const [loading, setLoading] = useState(false);
@@ -251,48 +260,47 @@ const Works: NextPage<Props> = ({ works, worksRouteProps }) => {
   );
 };
 
-export const getServerSideProps = async (
-  context: GetServerSidePropsContext
-) => {
-  const serverData = await getServerData(context);
-  const props = fromQuery(context.query);
+export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
+  async context => {
+    const serverData = await getServerData(context);
+    const props = fromQuery(context.query);
 
-  const aggregations = [
-    'workType',
-    'availabilities',
-    'genres.label',
-    'languages',
-    'subjects.label',
-    'contributors.agent.label',
-  ];
+    const aggregations = [
+      'workType',
+      'availabilities',
+      'genres.label',
+      'languages',
+      'subjects.label',
+      'contributors.agent.label',
+    ];
 
-  const _queryType = cookies(context)._queryType;
+    const _queryType = cookies(context)._queryType;
 
-  const worksApiProps = worksRouteToApiUrl(props, {
-    _queryType,
-    aggregations,
-  });
+    const worksApiProps = worksRouteToApiUrl(props, {
+      _queryType,
+      aggregations,
+    });
 
-  const works = await getWorks({
-    params: worksApiProps,
-    toggles: serverData.toggles,
-  });
+    const works = await getWorks({
+      params: worksApiProps,
+      toggles: serverData.toggles,
+    });
 
-  if (works.type === 'Error') {
-    return appError(context, works.httpStatus, works.description);
-  }
+    if (works.type === 'Error') {
+      return appError(context, works.httpStatus, works.description);
+    }
 
-  return {
-    props: removeUndefinedProps({
-      works,
-      worksRouteProps: props,
-      serverData,
-      pageview: {
-        name: 'works',
-        properties: works ? { totalResults: works.totalResults } : {},
-      },
-    }),
+    return {
+      props: removeUndefinedProps({
+        works,
+        worksRouteProps: props,
+        serverData,
+        pageview: {
+          name: 'works',
+          properties: works ? { totalResults: works.totalResults } : {},
+        },
+      }),
+    };
   };
-};
 
 export default Works;

--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -1,4 +1,4 @@
-import { GetServerSidePropsContext, InferGetServerSidePropsType } from 'next';
+import { GetServerSidePropsContext } from 'next';
 import { AppProps } from 'next/app';
 import Router from 'next/router';
 import ReactGA from 'react-ga';
@@ -16,30 +16,13 @@ import { isServerData, defaultServerData } from '../../server-data/types';
 import { ServerDataContext } from '../../server-data/Context';
 import UserProvider from '../components/UserProvider/UserProvider';
 import { ApmContextProvider } from '../components/ApmContext/ApmContext';
+import { PrismicData, SimplifiedPrismicData } from '../../server-data/prismic';
 
 declare global {
   interface Window {
-    prismic: any;
+    prismic: PrismicData | SimplifiedPrismicData | { endpoint: string };
   }
 }
-
-/**
- * This allows us to use appError() in Page.getServerSideProps
- * and still infer it's props return type if it didn't error.
- * e.g.
- * type BadProps = InferGetServerSidePropsType<typeof getServerSideProps> // { id: string } | AppErrorProps
- * type Props = PageProps<typeof getServerSideProps> // { id: string }
- * const Page = (props: Props) => {}
- * export const getServerSideProps = context => {
- *   const { id } = context.query
- *   if (!id) return appError(context, 400, 'ID please')
- *   else return { props: { id } }
- * }
- */
-export type PageProps<GetServerSideProps> = Exclude<
-  InferGetServerSidePropsType<GetServerSideProps>,
-  AppErrorProps
->;
 
 export type AppErrorProps = {
   err: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4080,7 +4080,7 @@
   resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.3.3.tgz#85bc74ba782fb7aa3a514d11767832b0e3bc6803"
   integrity sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==
 
-"@types/cookie@^0.4.0":
+"@types/cookie@^0.4.0", "@types/cookie@^0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.1.tgz#bfd02c1f2224567676c1545199f87c3a861d878d"
   integrity sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==
@@ -4395,6 +4395,11 @@
   version "14.17.33"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.33.tgz#011ee28e38dc7aee1be032ceadf6332a0ab15b12"
   integrity sha512-noEeJ06zbn3lOh4gqe2v7NMGS33jrulfNqYFDjjEbhpDEHR5VTxgYNQSBqBlJIsBJW3uEYDgD6kvMnrrhGzq8g==
+
+"@types/node@^16.10.2":
+  version "16.11.52"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.52.tgz#d797437435455f237800c171d05639f0335c37b9"
+  integrity sha512-GnstYouCa9kbYokBCWEVrszJ1P2rGAQpKrqACHKuixkaT8XGu8nsqHvEUIGqDs5vwtsJ7LrYqnPDKRD1V+M39A==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -7157,6 +7162,15 @@ cookiejar@^2.1.0:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.3.tgz#fc7a6216e408e74414b90230050842dacda75acc"
   integrity sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==
+
+cookies-next@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/cookies-next/-/cookies-next-2.1.1.tgz#8d82f1b78fccfb19d9d7c26766fa5707a3ec4695"
+  integrity sha512-AZGZPdL1hU3jCjN2UMJTGhLOYzNUN9Gm+v8BdptYIHUdwz397Et1p+sZRfvAl8pKnnmMdX2Pk9xDRKCGBum6GA==
+  dependencies:
+    "@types/cookie" "^0.4.1"
+    "@types/node" "^16.10.2"
+    cookie "^0.4.0"
 
 cookies@~0.8.0:
   version "0.8.0"


### PR DESCRIPTION
For some reason, the linter that runs on pre-commit is being extra strict today, and warning me about:

* The lack of a return type on `getServerSideProps` in `works.tsx`
* An `any` type in `_app.tsx`

In both cases, we can specify the types explicitly, so let's do that – with the bonus that we can remove some circular and magic type logic of the form "it returns whatever it returns".

## Who is this for?

Me.

## What is it doing for them?

Allowing me to commit code. Also unblocking #8307.