### PR TITLE
Debugging redirect for user preference cookie

### DIFF
--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -227,10 +227,14 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
         sameSite: false
       });
     }
-    console.log(hasUserPreference, 'do we get a user preference?');
+    // TOD0: The logs below are temporary to be removed once debugging is complete
+    console.log(
+      hasUserPreference,
+      'hasUserPreference: do we get a user preference?'
+    );
     console.log(
       context.resolvedUrl,
-      'what is the resolved url in this context?'
+      'context.resolvedUrl: what is the resolved url in this context?'
     );
     // We want to check for a user guide type preference cookie, and redirect to the appropriate type
     if (

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -227,7 +227,11 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
         sameSite: false
       });
     }
-
+    console.log(hasUserPreference, 'do we get a user preference?');
+    console.log(
+      context.resolvedUrl,
+      'what is the resolved url in this context?'
+    );
     // We want to check for a user guide type preference cookie, and redirect to the appropriate type
     if (
       hasUserPreference &&

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -223,6 +223,8 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
         res,
         req,
         maxAge: 8 * 60 * 60,
+        path: '/',
+        sameSite: false
       });
     }
 
@@ -234,7 +236,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       return {
         redirect: {
           permanent: false,
-          destination: `${id}/${userPreferenceGuideType}?userPreferenceSet=true`,
+          destination: `/${userPreferenceGuideType}?userPreferenceSet=true`,
         },
       };
     }
@@ -347,7 +349,7 @@ type ExhibitionLinksProps = {
 
 function cookieHandler(key, data) {
   // We set the cookie to expire in 8 hours (the maximum length of time the collection is open for in a day)
-  const options = { maxAge: 8 * 60 * 60 };
+  const options = { maxAge: 8 * 60 * 60, path: '/', sameSite: false };
   setCookie(key, data, options);
 }
 

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -224,10 +224,11 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
         req,
         maxAge: 8 * 60 * 60,
         path: '/',
-        sameSite: false
+        // TOD0: @@Mel The line below is temporary to be removed once debugging is complete
+        sameSite: false,
       });
     }
-    // TOD0: The logs below are temporary to be removed once debugging is complete
+    // TOD0: @@Mel The logs below are temporary to be removed once debugging is complete
     console.log(
       hasUserPreference,
       'hasUserPreference: do we get a user preference?'
@@ -357,6 +358,7 @@ type ExhibitionLinksProps = {
 
 function cookieHandler(key, data) {
   // We set the cookie to expire in 8 hours (the maximum length of time the collection is open for in a day)
+  // TOD0: @@Mel The sameSite attribute below is temporary to be removed once debugging is complete
   const options = { maxAge: 8 * 60 * 60, path: '/', sameSite: false };
   setCookie(key, data, options);
 }


### PR DESCRIPTION
## Who is this for?

Anyone who wants to set a guide type preference and be redirected to that type.
Console logs for devs to debug this issue.

## What is it doing for them?

Hopefully this will make sure the redirect based on context url and cookie redirects the user to their preferred guide type. 