### PR TITLE
Add a allowRawHtml parameter to <WorkDetailsText>

### DIFF
--- a/catalogue/webapp/components/Download/Download.tsx
+++ b/catalogue/webapp/components/Download/Download.tsx
@@ -153,6 +153,7 @@ const Download: NextPage<Props> = ({
                         <WorkDetailsText
                           title="Licence information"
                           text={license.humanReadableText}
+                          allowRawHtml={true}
                         />
                       )}
                       <WorkDetailsText
@@ -163,6 +164,7 @@ const Download: NextPage<Props> = ({
                           iiifImageLocationCredit,
                           license
                         )}
+                        allowRawHtml={true}
                       />
                     </div>
                   </SpacingComponent>

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -235,6 +235,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
           <WorkDetailsText
             title={locationOfWork.noteType.label}
             text={locationOfWork.contents}
+            allowRawHtml={true}
           />
         )}
         <PhysicalItems work={work} items={physicalItems} />
@@ -294,6 +295,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
                         title="Location"
                         noSpacing={true}
                         text={[`${locationLabel} ${locationShelfmark}`]}
+                        allowRawHtml={true}
                       />
                     )}
 
@@ -303,6 +305,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
                         inlineHeading={true}
                         noSpacing={true}
                         text={[holding.note]}
+                        allowRawHtml={true}
                       />
                     )}
                   </Space>
@@ -494,6 +497,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
                 <WorkDetailsText
                   title="Licence"
                   text={[digitalLocationInfo.license.label]}
+                  allowRawHtml={true}
                 />
               </Space>
               {digitalLocation?.accessConditions[0]?.terms && (
@@ -507,6 +511,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
                     title="Access conditions"
                     noSpacing={true}
                     text={[digitalLocation?.accessConditions[0]?.terms]}
+                    allowRawHtml={true}
                   />
                 </Space>
               )}
@@ -525,6 +530,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
                       0 && (
                       <WorkDetailsText
                         text={digitalLocationInfo.license.humanReadableText}
+                        allowRawHtml={true}
                       />
                     )}
                     <WorkDetailsText
@@ -540,6 +546,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
                           .filter(Boolean)
                           .join(' '),
                       ]}
+                      allowRawHtml={true}
                     />
                   </>
                 </ExplanatoryText>
@@ -575,17 +582,23 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
           <WorkDetailsText
             title="Also known as"
             text={work.alternativeTitles}
+            allowRawHtml={true}
           />
         )}
 
         {work.description && (
-          <WorkDetailsText title="Description" text={[work.description]} />
+          <WorkDetailsText
+            title="Description"
+            text={[work.description]}
+            allowRawHtml={true}
+          />
         )}
 
         {work.production.length > 0 && (
           <WorkDetailsText
             title="Publication/Creation"
             text={work.production.map(productionEvent => productionEvent.label)}
+            allowRawHtml={true}
           />
         )}
 
@@ -593,6 +606,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
           <WorkDetailsText
             title="Physical description"
             text={[work.physicalDescription]}
+            allowRawHtml={true}
           />
         )}
         {seriesPartOfs.length > 0 && (
@@ -637,24 +651,40 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
             key={note.noteType.label}
             title={note.noteType.label}
             text={note.contents}
+            allowRawHtml={true}
           />
         ))}
 
         {work.lettering && (
-          <WorkDetailsText title="Lettering" text={[work.lettering]} />
+          <WorkDetailsText
+            title="Lettering"
+            text={[work.lettering]}
+            allowRawHtml={true}
+          />
         )}
 
         {work.edition && (
-          <WorkDetailsText title="Edition" text={[work.edition]} />
+          <WorkDetailsText
+            title="Edition"
+            text={[work.edition]}
+            allowRawHtml={true}
+          />
         )}
 
-        {duration && <WorkDetailsText title="Duration" text={[duration]} />}
+        {duration && (
+          <WorkDetailsText
+            title="Duration"
+            text={[duration]}
+            allowRawHtml={true}
+          />
+        )}
 
         {remainingNotes.map(note => (
           <WorkDetailsText
             key={note.noteType.label}
             title={note.noteType.label}
             text={note.contents}
+            allowRawHtml={true}
           />
         ))}
 

--- a/catalogue/webapp/components/WorkDetailsText/WorkDetailsText.test.tsx
+++ b/catalogue/webapp/components/WorkDetailsText/WorkDetailsText.test.tsx
@@ -1,0 +1,26 @@
+import { mountWithTheme } from '@weco/common/test/fixtures/enzyme-helpers';
+import WorkDetailsText from './WorkDetailsText';
+
+describe('WorkDetailsText', () => {
+  it('renders HTML as-is if allowRawHtml=true', () => {
+    const component = mountWithTheme(
+      <WorkDetailsText
+        text={['This is <strong>bold</strong> text']}
+        allowRawHtml={true}
+      />
+    );
+
+    expect(component.html().includes('<strong>bold</strong>')).toBeTruthy();
+  });
+
+  it('escapes HTML if allowRawHtml=false', () => {
+    const component = mountWithTheme(
+      <WorkDetailsText
+        text={['You write HTML with angle brackets like <em>']}
+        allowRawHtml={false}
+      />
+    );
+
+    expect(component.html().includes('&lt;em&gt;')).toBeTruthy();
+  });
+});

--- a/catalogue/webapp/components/WorkDetailsText/WorkDetailsText.tsx
+++ b/catalogue/webapp/components/WorkDetailsText/WorkDetailsText.tsx
@@ -5,6 +5,7 @@ type Props = {
   title?: string;
   inlineHeading?: boolean;
   noSpacing?: boolean;
+  allowRawHtml: boolean;
   text: string[];
 };
 
@@ -12,6 +13,7 @@ const WorkDetailsText: FunctionComponent<Props> = ({
   title,
   inlineHeading = false,
   noSpacing = false,
+  allowRawHtml,
   text,
 }: Props) => {
   return (
@@ -22,7 +24,11 @@ const WorkDetailsText: FunctionComponent<Props> = ({
     >
       <div className="spaced-text">
         {text.map((para, i) => {
-          return <div key={i} dangerouslySetInnerHTML={{ __html: para }} />;
+          return allowRawHtml ? (
+            <div key={i} dangerouslySetInnerHTML={{ __html: para }} />
+          ) : (
+            <div key={i}>{para}</div>
+          );
         })}
       </div>
     </WorkDetailsProperty>

--- a/catalogue/webapp/pages/download.tsx
+++ b/catalogue/webapp/pages/download.tsx
@@ -127,11 +127,13 @@ const DownloadPage: NextPage<Props> = ({
                   <WorkDetailsText
                     title="License information"
                     text={license.humanReadableText}
+                    allowRawHtml={true}
                   />
                 )}
                 <WorkDetailsText
                   title="Credit"
                   text={getCreditString(workId, title, credit, license)}
+                  allowRawHtml={true}
                 />
               </div>
             </SpacingComponent>


### PR DESCRIPTION
Initially this is set to true, to mimic the existing behaviour -- but now this choice is configurable and explicit when we use the component. Currently it looks like we allow raw HTML in *any* field, which probably isn't what we want.

This opens the door to marking some fields as "should not contain HTML" in a future patch.

For https://github.com/wellcomecollection/platform/issues/5579; follows #8311