### PR TITLE
Add WC_ cookies to allow lists cloudfront 

### DIFF
--- a/cache/modules/cloudfront_policies/cache_policies.tf
+++ b/cache/modules/cloudfront_policies/cache_policies.tf
@@ -89,7 +89,8 @@ resource "aws_cloudfront_cache_policy" "weco_apps" {
           distinct(
             concat(
               local.toggles_cookies,
-              local.works_cookies
+              local.works_cookies,
+              local.userpreference_cookies,
             )
           )
         )

--- a/cache/modules/cloudfront_policies/locals.tf
+++ b/cache/modules/cloudfront_policies/locals.tf
@@ -1,6 +1,7 @@
 locals {
   toggles_cookies = ["toggles", "toggle_*"]
   works_cookies   = ["_queryType"]
+  userpreference_cookies = ["WC_*"]
 
   content_query_params = [
     "cachebust",

--- a/cache/modules/cloudfront_policies/request_policies.tf
+++ b/cache/modules/cloudfront_policies/request_policies.tf
@@ -10,7 +10,12 @@ resource "aws_cloudfront_origin_request_policy" "host_query_and_toggles" {
     cookie_behavior = "whitelist"
 
     cookies {
-      items = local.toggles_cookies
+      items = sort(
+          concat(
+            local.toggles_cookies,
+            local.userpreference_cookies,
+          )
+        )
     }
   }
 


### PR DESCRIPTION

## Who is this for?

People wanting to have their preference cookie read in guide types

## What is it doing for them?

This should mean we can read the `WC_userPreferenceGuideType` on the client side within server context.

## Terraform plan

```
Terraform will perform the following actions:

  # module.cloudfront_policies.aws_cloudfront_cache_policy.weco_apps will be updated in-place
  ~ resource "aws_cloudfront_cache_policy" "weco_apps" {
        id          = "b2c915f......"
        name        = "weco-apps"
        # (5 unchanged attributes hidden)

      ~ parameters_in_cache_key_and_forwarded_to_origin {
            # (2 unchanged attributes hidden)

          ~ cookies_config {
                # (1 unchanged attribute hidden)

              ~ cookies {
                  ~ items = [
                      + "WC_*",
                        # (3 unchanged elements hidden)
                    ]
                }
            }


            # (2 unchanged blocks hidden)
        }
    }

  # module.cloudfront_policies.aws_cloudfront_origin_request_policy.host_query_and_toggles will be updated in-place
  ~ resource "aws_cloudfront_origin_request_policy" "host_query_and_toggles" {
        id      = "7d466a9...."
        name    = "host-query-and-toggles"
        # (2 unchanged attributes hidden)

      ~ cookies_config {
            # (1 unchanged attribute hidden)

          ~ cookies {
              ~ items = [
                  + "WC_*",
                    # (2 unchanged elements hidden)
                ]
            }
        }


        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 2 to change, 0 to destroy.
```
