### PR TITLE
Remove blog.wellcomecollection.org as a prod alias

### DIFF
--- a/cache/cloudfront_prod.tf
+++ b/cache/cloudfront_prod.tf
@@ -4,7 +4,6 @@ module "prod_wc_org_cloudfront_distribution" {
   namespace = "prod"
   aliases = [
     "wellcomecollection.org",
-    "blog.wellcomecollection.org",
     "content.wellcomecollection.org",
     "content.www.wellcomecollection.org",
     "identity.wellcomecollection.org",


### PR DESCRIPTION
This is part of https://github.com/wellcomecollection/wellcomecollection.org/issues/8273