### PR TITLE
make changes to spacing and link styling for choose guide ui

### DIFF
--- a/content/webapp/components/ExhibitionGuideLinksPromo/ExhibitionGuideLinksPromo.tsx
+++ b/content/webapp/components/ExhibitionGuideLinksPromo/ExhibitionGuideLinksPromo.tsx
@@ -10,10 +10,14 @@ const Type = styled(Space).attrs({
   v: { size: 'm', properties: ['margin-bottom'] },
 })``;
 
+const TypeListLink = styled.a`
+  text-decoration: none;
+`;
+
 const TypeListItem = ({ url, text }) => {
   return (
     <Type>
-      <a href={url}>{text}</a>
+      <TypeListLink href={url}>{text}</TypeListLink>
     </Type>
   );
 };

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -122,7 +122,7 @@ const TypeOption: FC<TypeOptionProps> = ({
       >
         <h2 className="h2">{title}</h2>
         <p className={`${font('intr', 5)}`}>{text}</p>
-        {icon && <Icon icon={icon} />}
+        {icon ? <Icon icon={icon} /> : <Icon></Icon>}
       </Space>
     </TypeLink>
   </TypeItem>


### PR DESCRIPTION
## Who is this for?

All the peoples who use exhibition guides, but more specifically addresses the points on this ticket https://github.com/wellcomecollection/wellcomecollection.org/issues/8291

## What is it doing for them?

In choosing guide type ui:
- Height and width of the guide options made a bit more consistent (still working on this, as content of text box is different for each guide so hard to align heights).
- tile changed to 'Listen to audio tracks'.
- Removing underline of other gallery titles in the 'other exhibition guides available' section at the bottom of the page.