### PR TITLE
Audio guide UI fixes

### DIFF
--- a/common/views/components/AudioPlayer/AudioPlayer.tsx
+++ b/common/views/components/AudioPlayer/AudioPlayer.tsx
@@ -41,7 +41,7 @@ const PlayPauseButton = styled.button.attrs<{ isPlaying: boolean }>(props => ({
 `;
 
 const PlayPauseInner = styled.div`
-  border: 2px solid ${props => props.theme.color('pewter')};
+  border: 2px solid ${props => props.theme.color('green')};
   border-radius: 50%;
   width: 40px;
   height: 40px;
@@ -392,7 +392,7 @@ export const AudioPlayer: FC<AudioPlayerProps> = ({
       <AudioPlayerGrid>
         <PlayPauseButton onClick={onTogglePlay} isPlaying={isPlaying}>
           <PlayPauseInner>
-            <Icon color="pewter" icon={isPlaying ? pause : play} />
+            <Icon color="green" icon={isPlaying ? pause : play} />
           </PlayPauseInner>
         </PlayPauseButton>
 

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -57,6 +57,7 @@ const Stop = styled(Space).attrs({
   h: { size: 'm', properties: ['padding-left', 'padding-right'] },
 })`
   background: ${props => props.theme.color('cream')};
+  height: 100%;
 `;
 
 const TypeList = styled.ul.attrs({
@@ -271,8 +272,13 @@ const Stops: FC<StopsProps> = ({ stops, type }) => {
     <GridFactory
       items={stops
         .map((stop, index) => {
-          const { number, audioWithDescription, audioWithoutDescription, bsl } =
-            stop;
+          const {
+            number,
+            audioWithDescription,
+            audioWithoutDescription,
+            bsl,
+            title,
+          } = stop;
           const hasContentOfDesiredType =
             (type === 'audio-with-descriptions' && audioWithDescription?.url) ||
             (type === 'audio-without-descriptions' &&
@@ -283,7 +289,7 @@ const Stops: FC<StopsProps> = ({ stops, type }) => {
               {type === 'audio-with-descriptions' &&
                 audioWithDescription?.url && (
                   <AudioPlayer
-                    title={number ? `${number}. ${stop.title}` : stop.title}
+                    title={`${number}. ${stop.title}`}
                     audioFile={audioWithDescription.url}
                   />
                 )}
@@ -298,7 +304,13 @@ const Stops: FC<StopsProps> = ({ stops, type }) => {
                 <VideoEmbed embedUrl={bsl.embedUrl as string} />
               )}
             </Stop>
-          ) : undefined;
+          ) : (
+            <Stop key={index}>
+              <span className={font('intb', 5)}>
+                {number}. {title}
+              </span>
+            </Stop>
+          );
         })
         .filter(isNotUndefined)}
     />
@@ -438,6 +450,7 @@ const ExhibitionGuidePage: FC<Props> = props => {
     type ? `/${type}` : ''
   }`;
   const typeColor = getTypeColor(type);
+  const numberedStops = exhibitionGuide.components.filter(c => c.number);
 
   return (
     <PageLayout
@@ -482,31 +495,26 @@ const ExhibitionGuidePage: FC<Props> = props => {
         <>
           <Header color={typeColor}>
             <Layout8 shift={false}>
-              <>
-                <h2 className="h0 no-margin">{exhibitionGuide.title}</h2>
-                <h3 className="h1">{getTypeTitle(type)}</h3>
-                {exhibitionGuide.relatedExhibition && (
-                  <p>{exhibitionGuide.relatedExhibition.description}</p>
-                )}
-                <Space
-                  as="span"
-                  h={{ size: 's', properties: ['margin-right'] }}
-                >
-                  <ButtonSolidLink
-                    colors={themeValues.buttonColors.charcoalWhiteCharcoal}
-                    text="Change guide type"
-                    link={`/guides/exhibitions/${exhibitionGuide.id}`}
-                    clickHandler={() => {
-                      deleteCookie('WC_userPreferenceGuideType');
-                    }}
-                  />
-                </Space>
+              <h2 className="h0 no-margin">{exhibitionGuide.title}</h2>
+              <h3 className="h1">{getTypeTitle(type)}</h3>
+              {exhibitionGuide.relatedExhibition && (
+                <p>{exhibitionGuide.relatedExhibition.description}</p>
+              )}
+              <Space as="span" h={{ size: 's', properties: ['margin-right'] }}>
                 <ButtonSolidLink
                   colors={themeValues.buttonColors.charcoalWhiteCharcoal}
-                  text="Change exhibition"
-                  link="/guides/exhibitions"
+                  text="Change guide type"
+                  link={`/guides/exhibitions/${exhibitionGuide.id}`}
+                  clickHandler={() => {
+                    deleteCookie('WC_userPreferenceGuideType');
+                  }}
                 />
-              </>
+              </Space>
+              <ButtonSolidLink
+                colors={themeValues.buttonColors.charcoalWhiteCharcoal}
+                text="Change exhibition"
+                link="/guides/exhibitions"
+              />
             </Layout8>
           </Header>
 
@@ -514,9 +522,8 @@ const ExhibitionGuidePage: FC<Props> = props => {
             <Layout10 isCentered={false}>
               {userPreferenceSet ? (
                 <p>
-                  This exhibition has {exhibitionGuide.components.length} stops.
-                  You selected this type of guide previously, but you can also
-                  select{' '}
+                  This exhibition has {numberedStops.length} stops. You selected
+                  this type of guide previously, but you can also select{' '}
                   <a
                     href={`/guides/exhibitions/${exhibitionGuide.id}`}
                     onClick={() => {
@@ -527,14 +534,12 @@ const ExhibitionGuidePage: FC<Props> = props => {
                   </a>
                 </p>
               ) : (
-                <p>
-                  This exhibition has {exhibitionGuide.components.length} stops.
-                </p>
+                <p>This exhibition has {numberedStops.length} stops.</p>
               )}
             </Layout10>
           </Space>
 
-          <ExhibitionStops type={type} stops={exhibitionGuide.components} />
+          <ExhibitionStops type={type} stops={numberedStops} />
         </>
       )}
       {otherExhibitionGuides.results.length > 0 && (

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -284,7 +284,7 @@ const Stops: FC<StopsProps> = ({ stops, type }) => {
               {type === 'audio-with-descriptions' &&
                 audioWithDescription?.url && (
                   <AudioPlayer
-                    title={`${number}. ${stop.title}`}
+                    title={number ? `${number}. ${stop.title}` : stop.title}
                     audioFile={audioWithDescription.url}
                   />
                 )}

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -46,7 +46,6 @@ import {
   audioDescribed,
   speechToText,
 } from '@weco/common/icons';
-import { isNotUndefined } from '@weco/common/utils/array';
 
 const PromoContainer = styled.div`
   background: ${props => props.theme.color('cream')};
@@ -270,49 +269,47 @@ type StopsProps = {
 const Stops: FC<StopsProps> = ({ stops, type }) => {
   return (
     <GridFactory
-      items={stops
-        .map((stop, index) => {
-          const {
-            number,
-            audioWithDescription,
-            audioWithoutDescription,
-            bsl,
-            title,
-          } = stop;
-          const hasContentOfDesiredType =
-            (type === 'audio-with-descriptions' && audioWithDescription?.url) ||
-            (type === 'audio-without-descriptions' &&
-              audioWithoutDescription?.url) ||
-            (type === 'bsl' && bsl?.embedUrl);
-          return hasContentOfDesiredType ? (
-            <Stop key={index}>
-              {type === 'audio-with-descriptions' &&
-                audioWithDescription?.url && (
-                  <AudioPlayer
-                    title={`${number}. ${stop.title}`}
-                    audioFile={audioWithDescription.url}
-                  />
-                )}
-              {type === 'audio-without-descriptions' &&
-                audioWithoutDescription?.url && (
-                  <AudioPlayer
-                    title={`${number}. ${stop.title}`}
-                    audioFile={audioWithoutDescription.url}
-                  />
-                )}
-              {type === 'bsl' && bsl?.embedUrl && (
-                <VideoEmbed embedUrl={bsl.embedUrl as string} />
+      items={stops.map((stop, index) => {
+        const {
+          number,
+          audioWithDescription,
+          audioWithoutDescription,
+          bsl,
+          title,
+        } = stop;
+        const hasContentOfDesiredType =
+          (type === 'audio-with-descriptions' && audioWithDescription?.url) ||
+          (type === 'audio-without-descriptions' &&
+            audioWithoutDescription?.url) ||
+          (type === 'bsl' && bsl?.embedUrl);
+        return hasContentOfDesiredType ? (
+          <Stop key={index}>
+            {type === 'audio-with-descriptions' &&
+              audioWithDescription?.url && (
+                <AudioPlayer
+                  title={`${number}. ${stop.title}`}
+                  audioFile={audioWithDescription.url}
+                />
               )}
-            </Stop>
-          ) : (
-            <Stop key={index}>
-              <span className={font('intb', 5)}>
-                {number}. {title}
-              </span>
-            </Stop>
-          );
-        })
-        .filter(isNotUndefined)}
+            {type === 'audio-without-descriptions' &&
+              audioWithoutDescription?.url && (
+                <AudioPlayer
+                  title={`${number}. ${stop.title}`}
+                  audioFile={audioWithoutDescription.url}
+                />
+              )}
+            {type === 'bsl' && bsl?.embedUrl && (
+              <VideoEmbed embedUrl={bsl.embedUrl as string} />
+            )}
+          </Stop>
+        ) : (
+          <Stop key={index}>
+            <span className={font('intb', 5)}>
+              {number}. {title}
+            </span>
+          </Stop>
+        );
+      })}
     />
   );
 };

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -46,18 +46,16 @@ import {
   audioDescribed,
   speechToText,
 } from '@weco/common/icons';
+import { isNotUndefined } from '@weco/common/utils/array';
 
 const PromoContainer = styled.div`
   background: ${props => props.theme.color('cream')};
 `;
-type StopProps = {
-  width: number;
-};
 
 const Stop = styled(Space).attrs({
   v: { size: 'm', properties: ['padding-top', 'padding-bottom'] },
   h: { size: 'm', properties: ['padding-left', 'padding-right'] },
-})<StopProps>`
+})`
   background: ${props => props.theme.color('cream')};
 `;
 
@@ -270,56 +268,40 @@ type StopsProps = {
 };
 
 const Stops: FC<StopsProps> = ({ stops, type }) => {
-  const stopWidth = type === 'bsl' ? 50 : 33;
-
   return (
     <GridFactory
-      items={stops.map((stop, index) => {
-        const {
-          title,
-          number,
-          audioWithDescription,
-          audioWithoutDescription,
-          bsl,
-        } = stop;
-        const hasContentOfDesiredType =
-          (type === 'audio-with-descriptions' && audioWithDescription?.url) ||
-          (type === 'audio-without-descriptions' &&
-            audioWithoutDescription?.url) ||
-          (type === 'bsl' && bsl?.embedUrl);
-        return (
-          <Stop key={index} width={stopWidth}>
-            {hasContentOfDesiredType ? (
-              <>
-                {type === 'audio-with-descriptions' &&
-                  audioWithDescription?.url && (
-                    <AudioPlayer
-                      title={`${number}. ${stop.title}`}
-                      audioFile={audioWithDescription.url}
-                    />
-                  )}
-                {type === 'audio-without-descriptions' &&
-                  audioWithoutDescription?.url && (
-                    <AudioPlayer
-                      title={`${number}. ${stop.title}`}
-                      audioFile={audioWithoutDescription.url}
-                    />
-                  )}
-                {type === 'bsl' && bsl?.embedUrl && (
-                  <VideoEmbed embedUrl={bsl.embedUrl as string} />
+      items={stops
+        .map((stop, index) => {
+          const { number, audioWithDescription, audioWithoutDescription, bsl } =
+            stop;
+          const hasContentOfDesiredType =
+            (type === 'audio-with-descriptions' && audioWithDescription?.url) ||
+            (type === 'audio-without-descriptions' &&
+              audioWithoutDescription?.url) ||
+            (type === 'bsl' && bsl?.embedUrl);
+          return hasContentOfDesiredType ? (
+            <Stop key={index}>
+              {type === 'audio-with-descriptions' &&
+                audioWithDescription?.url && (
+                  <AudioPlayer
+                    title={`${number}. ${stop.title}`}
+                    audioFile={audioWithDescription.url}
+                  />
                 )}
-              </>
-            ) : (
-              <>
-                <span className={font('intb', 5)}>
-                  {number}. {title}
-                </span>
-                <p>There is no content to display</p>
-              </>
-            )}
-          </Stop>
-        );
-      })}
+              {type === 'audio-without-descriptions' &&
+                audioWithoutDescription?.url && (
+                  <AudioPlayer
+                    title={`${number}. ${stop.title}`}
+                    audioFile={audioWithoutDescription.url}
+                  />
+                )}
+              {type === 'bsl' && bsl?.embedUrl && (
+                <VideoEmbed embedUrl={bsl.embedUrl as string} />
+              )}
+            </Stop>
+          ) : undefined;
+        })
+        .filter(isNotUndefined)}
     />
   );
 };
@@ -528,9 +510,10 @@ const ExhibitionGuidePage: FC<Props> = props => {
               </>
             </Layout8>
           </Header>
-          <Space h={{ size: 'l', properties: ['padding-left'] }}>
-            {userPreferenceSet ? (
-              <Space v={{ size: 'l', properties: ['margin-top'] }}>
+
+          <Space v={{ size: 'l', properties: ['margin-top'] }}>
+            <Layout10 isCentered={false}>
+              {userPreferenceSet ? (
                 <p>
                   This exhibition has {exhibitionGuide.components.length} stops.
                   This is a {type} guide, which you have used previously, but
@@ -544,16 +527,15 @@ const ExhibitionGuidePage: FC<Props> = props => {
                     another type of guide.
                   </a>
                 </p>
-              </Space>
-            ) : (
-              <Space v={{ size: 'l', properties: ['margin-top'] }}>
+              ) : (
                 <p>
                   This exhibition has {exhibitionGuide.components.length} stops.
                 </p>
-              </Space>
-            )}
-            <ExhibitionStops type={type} stops={exhibitionGuide.components} />
+              )}
+            </Layout10>
           </Space>
+
+          <ExhibitionStops type={type} stops={exhibitionGuide.components} />
         </>
       )}
       {otherExhibitionGuides.results.length > 0 && (

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -155,11 +155,10 @@ type Props = {
 function getTypeTitle(type: GuideType): string {
   switch (type) {
     case 'bsl':
-      return 'BSL';
+      return 'Watch BSL videos';
     case 'audio-with-descriptions':
-      return 'Audio with descriptions';
     case 'audio-without-descriptions':
-      return 'Audio without descriptions';
+      return 'Listen to audio'; // We don't yet have any audio with descriptions so don't want to imply that we do
     case 'captions-and-transcripts':
       return 'Captions and transcripts';
   }
@@ -516,8 +515,8 @@ const ExhibitionGuidePage: FC<Props> = props => {
               {userPreferenceSet ? (
                 <p>
                   This exhibition has {exhibitionGuide.components.length} stops.
-                  This is a {type} guide, which you have used previously, but
-                  you can also select{' '}
+                  You selected this type of guide previously, but you can also
+                  select{' '}
                   <a
                     href={`/guides/exhibitions/${exhibitionGuide.id}`}
                     onClick={() => {

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -328,7 +328,7 @@ type ExhibitionLinksProps = {
   pathname: string;
 };
 
-function cookieHandler(key, data) {
+function cookieHandler(key: string, data: string) {
   // We set the cookie to expire in 8 hours (the maximum length of time the collection is open for in a day)
   const options = { maxAge: 8 * 60 * 60, path: '/' };
   setCookie(key, data, options);
@@ -412,7 +412,7 @@ const ExhibitionLinks: FC<ExhibitionLinksProps> = ({ stops, pathname }) => {
   );
 };
 
-function getTypeColor(type) {
+function getTypeColor(type?: GuideType) {
   switch (type) {
     case 'bsl':
       return 'newPaletteBlue';


### PR DESCRIPTION
Part of #8290

- Only stops with numbers will render (and be counted) above
- Play button colour/border changed to green
- Global alert banner won't display on pages with `/guides/exhibitions` in the URL (updated on Prismic)
- Updated the header to read "Listen to audio" for `audio-with-descriptions` and `audio-without-descriptions` to prevent the illusion of choice when we (at least currently) only have audio without descriptions.
- Grid alignment fixes
