### PR TITLE
Fix a bunch of eslint warnings

### DIFF
--- a/catalogue/webapp/components/Calendar/calendar-utils.ts
+++ b/catalogue/webapp/components/Calendar/calendar-utils.ts
@@ -1,7 +1,7 @@
 import moment, { Moment } from 'moment';
 
-export function groupIntoSize(array: any[], size): any[][] {
-  const result = [] as any[];
+export function groupIntoSize<T>(array: T[], size: number): T[][] {
+  const result: T[][] = [];
   for (let i = 0; i < array.length; i += size) {
     const group = array.slice(i, i + size);
     result.push(group);

--- a/catalogue/webapp/components/IIIFViewer/Padlock.tsx
+++ b/catalogue/webapp/components/IIIFViewer/Padlock.tsx
@@ -1,3 +1,4 @@
+import { FC } from 'react';
 import styled from 'styled-components';
 // TODO names and colours from theme
 const StyledPadlock = styled.div`
@@ -71,7 +72,7 @@ const StyledPadlock = styled.div`
   }
 `;
 
-const Padlock = () => (
+const Padlock: FC = () => (
   <StyledPadlock>
     <div></div>
   </StyledPadlock>

--- a/catalogue/webapp/components/License/License.tsx
+++ b/catalogue/webapp/components/License/License.tsx
@@ -1,9 +1,10 @@
 import { LicenseData } from '@weco/common/utils/licenses';
+import { FC } from 'react';
 type Props = {
   license: LicenseData;
 };
 
-const License = ({ license }: Props) => {
+const License: FC<Props> = ({ license }: Props) => {
   return (
     <>
       {license.description && `${license.description} `}

--- a/catalogue/webapp/pages/_app.tsx
+++ b/catalogue/webapp/pages/_app.tsx
@@ -2,12 +2,13 @@ import NextApp, { NextWebVitalsMetric, AppContext } from 'next/app';
 import App, { WecoAppProps } from '@weco/common/views/pages/_app';
 import { SearchContextProvider } from '@weco/common/views/components/SearchContext/SearchContext';
 import { gtagReportWebVitals } from '@weco/common/utils/gtag';
+import { ReactElement } from 'react';
 
 export function reportWebVitals(metric: NextWebVitalsMetric): void {
   gtagReportWebVitals(metric);
 }
 
-export default function CatalogueApp(props: WecoAppProps) {
+export default function CatalogueApp(props: WecoAppProps): ReactElement {
   return (
     <SearchContextProvider>
       <App {...props} />

--- a/common/views/components/SelectUncontrolled/SelectUncontrolled.tsx
+++ b/common/views/components/SelectUncontrolled/SelectUncontrolled.tsx
@@ -1,3 +1,4 @@
+import { FC } from 'react';
 import SelectContainer from '../SelectContainer/SelectContainer';
 
 type Props = {
@@ -10,7 +11,12 @@ type Props = {
   }[];
 };
 
-const SelectUncontrolled = ({ name, label, options, defaultValue }: Props) => {
+const SelectUncontrolled: FC<Props> = ({
+  name,
+  label,
+  options,
+  defaultValue,
+}: Props) => {
   return (
     <SelectContainer label={label}>
       <select name={name} defaultValue={defaultValue}>

--- a/content/webapp/pages/api/articles/index.ts
+++ b/content/webapp/pages/api/articles/index.ts
@@ -13,7 +13,7 @@ type NotFound = { notFound: true };
 export default async (
   req: NextApiRequest,
   res: NextApiResponse<Data | NotFound>
-) => {
+): Promise<void> => {
   const { params } = req.query;
   const parsedParams = isString(params) ? JSON.parse(params) : undefined;
 

--- a/dash/webapp/pages/pa11y.tsx
+++ b/dash/webapp/pages/pa11y.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useState, useEffect } from 'react';
+import { Fragment, useState, useEffect, FC } from 'react';
 import styled from 'styled-components';
 import Header from '../components/Header';
 
@@ -34,7 +34,7 @@ const Issue = styled.div`
       : ''}
 `;
 
-const Index = () => {
+const Index: FC = () => {
   const [resultsList, setResultsList] = useState(null);
 
   useEffect(() => {

--- a/dash/webapp/pages/toggles.tsx
+++ b/dash/webapp/pages/toggles.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, FC } from 'react';
 import styled from 'styled-components';
 import getCookies from 'next-cookies';
 import Header from '../components/Header';
@@ -67,7 +67,7 @@ type AbTest = {
   description: string;
 };
 
-const IndexPage = () => {
+const IndexPage: FC = () => {
   const [toggleStates, setToggleStates] = useState<ToggleStates>({});
   const [toggles, setToggles] = useState<Toggle[]>([]);
   const [abTests, setAbTests] = useState<AbTest[]>([]);

--- a/identity/webapp/copy.tsx
+++ b/identity/webapp/copy.tsx
@@ -123,7 +123,7 @@ export const collectionsResearchAgreementLabel = (
   </>
 );
 
-export const DeleteRequestedText = () => (
+export const DeleteRequestedText: FC = () => (
   <>
     <SectionHeading as="h1">Delete request received</SectionHeading>
 

--- a/identity/webapp/src/frontend/hooks/useSendVerificationEmail.tsx
+++ b/identity/webapp/src/frontend/hooks/useSendVerificationEmail.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import axios, { AxiosError } from 'axios';
+import axios from 'axios';
 
 // These are the four states:
 //

--- a/playwright/test/helpers/safeWaitForNavigation.ts
+++ b/playwright/test/helpers/safeWaitForNavigation.ts
@@ -2,7 +2,7 @@ import { Page, errors as playwrightErrors } from 'playwright';
 
 // See comment on `gotoWithoutCache` in `contexts.ts`, it's non-trivial to
 // do this in a DRY way so the behaviour is duplicated here
-const safeWaitForNavigation = async (page: Page) => {
+const safeWaitForNavigation = async (page: Page): Promise<void> => {
   try {
     await page.waitForNavigation({
       waitUntil: 'load',

--- a/toggles/webapp/deploy.ts
+++ b/toggles/webapp/deploy.ts
@@ -32,7 +32,7 @@ export const withDefaultValuesUnmodified = (
   return toggles;
 };
 
-export async function deploy(client: S3Client) {
+export async function deploy(client: S3Client): Promise<void> {
   const remoteToggles = await getTogglesObject(client);
 
   const togglesToDeploy = withDefaultValuesUnmodified(remoteToggles.toggles, [

--- a/toggles/webapp/s3-utils.ts
+++ b/toggles/webapp/s3-utils.ts
@@ -1,6 +1,7 @@
 import {
   GetObjectCommand,
   PutObjectCommand,
+  PutObjectCommandOutput,
   S3Client,
 } from '@aws-sdk/client-s3';
 import { Readable } from 'stream';
@@ -17,7 +18,7 @@ async function streamToString(stream: Readable): Promise<string> {
   });
 }
 
-export async function getTogglesObject(client: S3Client) {
+export async function getTogglesObject(client: S3Client): Promise<TogglesResp> {
   const getObjectCommand = new GetObjectCommand({
     Bucket: bucket,
     Key: key,
@@ -32,7 +33,10 @@ export async function getTogglesObject(client: S3Client) {
   return toggles;
 }
 
-export async function putTogglesObject(client: S3Client, obj: TogglesResp) {
+export async function putTogglesObject(
+  client: S3Client,
+  obj: TogglesResp
+): Promise<PutObjectCommandOutput> {
   const putObjectCommand = new PutObjectCommand({
     Bucket: bucket,
     Key: `${key}`,

--- a/toggles/webapp/setDefaultValueFor.ts
+++ b/toggles/webapp/setDefaultValueFor.ts
@@ -11,7 +11,7 @@ import { getCreds } from '@weco/ts-aws/sts';
 
 const argv = yargs(hideBin(process.argv)).parseSync();
 
-export async function setDefaultValueFor(client: S3Client) {
+export async function setDefaultValueFor(client: S3Client): Promise<void> {
   const remoteToggles = await getTogglesObject(client);
 
   const toggles = remoteToggles.toggles.map(toggle => {

--- a/updown/checks.ts
+++ b/updown/checks.ts
@@ -30,7 +30,7 @@ const secretsManager = new AWS.SecretsManager();
 const getSecretParams = { SecretId: 'builds/updown_api_key' };
 
 export type Check = {
-  token?: string;
+  token: string;
 } & CheckOptions;
 
 let client: UpdownClient;
@@ -89,11 +89,11 @@ secretsManager
     }
 
     const deletionRequests = deletions.map(check => {
-      return client.deleteCheck(check.token!);
+      return client.deleteCheck(check.token);
     });
 
     const updatesRequests = updates.map(check => {
-      return client.updateCheck(check.token!, {
+      return client.updateCheck(check.token, {
         alias: check.alias,
         period: 60,
       });

--- a/updown/expected-checks.ts
+++ b/updown/expected-checks.ts
@@ -1,5 +1,4 @@
-import { CheckInterval } from 'node-updown/lib/types/Check';
-import { Check } from './checks';
+import { CheckInterval, CheckOptions } from 'node-updown/lib/types/Check';
 
 const contentChecks = [
   {
@@ -107,7 +106,7 @@ const expectedChecks = contentChecks.concat(worksChecks, apiChecks, [
 ]);
 
 function withOriginPrefix(originPrefix: string) {
-  return ({ url, alias }: Check) => [
+  return ({ url, alias }: CheckOptions) => [
     {
       url: `https://${originPrefix}.wellcomecollection.org${url}`,
       alias: `${alias} (origin)`,

--- a/updown/utils.ts
+++ b/updown/utils.ts
@@ -1,3 +1,4 @@
+import { CheckOptions } from 'node-updown/lib/types/Check';
 import { Check } from './checks';
 
 type CheckKey = keyof Check;
@@ -13,10 +14,10 @@ function checksAreEqual(check1: Check, check2: Check): boolean {
   return areEqual;
 }
 
-function removeDuplicates(
-  targetArray: Check[],
-  comparisonArray: Check[]
-): Check[] {
+function removeDuplicates<T extends { url: string }>(
+  targetArray: T[],
+  comparisonArray: { url: string }[]
+): T[] {
   return targetArray.filter(targetCheck => {
     return !comparisonArray.some(check => {
       return targetCheck.url === check.url;
@@ -26,11 +27,11 @@ function removeDuplicates(
 
 export function getDeltas(
   currentChecks: Check[],
-  expectedChecks: Check[]
+  expectedChecks: CheckOptions[]
 ): {
   deletions: Check[];
   updates: Check[];
-  additions: Check[];
+  additions: CheckOptions[];
 } {
   // deletions: any URLs in the current checks, not in the expected checks
   const deletions = removeDuplicates(currentChecks, expectedChecks);


### PR DESCRIPTION
The pre-commit checks on my laptop have become way more aggressive recently, treating warnings as errors. They're not wrong, but it's mildly annoying to encounter when I'm in the middle of committing code.

This patch fixes a bunch of the easiest warnings; there's plenty more but this takes us in the right direction.

Before:

```
$ yarn run eslint --fix --max-warnings=0 .
✖ 210 problems (11 errors, 199 warnings)
```

After:

```
$ yarn run eslint --fix --max-warnings=0 .
✖ 190 problems (10 errors, 180 warnings)
```