### PR TITLE
Reduce the size of the JSON bundle we send to pages

### DIFF
--- a/content/webapp/services/prismic/transformers/article-series.ts
+++ b/content/webapp/services/prismic/transformers/article-series.ts
@@ -24,9 +24,7 @@ export const transformArticleSeries = (
   // TODO: This function is quite confusing.  Refactor it and add
   // more helpful comments.
 
-  const articles = transformQuery(articleQuery, transformArticle).results.map(
-    transformArticleToArticleBasic
-  );
+  const articles = transformQuery(articleQuery, transformArticle).results;
 
   // This should never happen in practice -- an article series without
   // any articles should return a 404 before we call this function.
@@ -68,12 +66,12 @@ export const transformArticleSeries = (
                 } as ArticleBasic)
               : item;
           })
-        : articles,
+        : articles.map(transformArticleToArticleBasic),
   };
 
   return (
     series && {
-      articles,
+      articles: articles.map(transformArticleToArticleBasic),
       series: seriesWithItems,
     }
   );

--- a/content/webapp/services/prismic/transformers/articles.ts
+++ b/content/webapp/services/prismic/transformers/articles.ts
@@ -18,7 +18,7 @@ import { isNotUndefined } from '@weco/common/utils/array';
 import { Label } from '@weco/common/model/labels';
 import { Series } from '../../../types/series';
 import { transformSeason } from './seasons';
-import { transformSeries } from './series';
+import { transformSeries, transformSeriesToSeriesBasic } from './series';
 import { SeriesPrismicDocument } from '../types/series';
 import { SeasonPrismicDocument } from '../types/seasons';
 import { Format } from '../../../types/format';
@@ -62,7 +62,7 @@ export function transformArticleToArticleBasic(article: Article): ArticleBasic {
     type,
     id,
     promo,
-    series,
+    series: series.map(transformSeriesToSeriesBasic),
     title,
     format,
     image,

--- a/content/webapp/services/prismic/transformers/contributors.ts
+++ b/content/webapp/services/prismic/transformers/contributors.ts
@@ -9,7 +9,7 @@ import {
   InferDataInterface,
 } from '@weco/common/services/prismic/types';
 
-import { Contributor } from '../../../types/contributors';
+import { Contributor, ContributorBasic } from '../../../types/contributors';
 import { isNotUndefined } from '@weco/common/utils/array';
 import { asRichText, asText } from '.';
 import { ImageType } from '@weco/common/model/image';
@@ -112,4 +112,17 @@ export function transformContributors(
     .filter(isNotUndefined);
 
   return contributors;
+}
+
+export function transformContributorToContributorBasic(
+  contributor: Contributor
+): ContributorBasic {
+  const { type, name, image } = contributor.contributor;
+  return {
+    contributor: {
+      type,
+      name,
+      image,
+    },
+  };
 }

--- a/content/webapp/services/prismic/transformers/event-series.ts
+++ b/content/webapp/services/prismic/transformers/event-series.ts
@@ -1,4 +1,4 @@
-import { EventSeries } from '../../../types/event-series';
+import { EventSeries, EventSeriesBasic } from '../../../types/event-series';
 import { EventSeriesPrismicDocument } from '../types/event-series';
 import { transformGenericFields, asText } from '.';
 import { BackgroundTexture } from '@weco/common/model/background-texture';
@@ -47,4 +47,13 @@ export function transformEventSeries(
     labels,
     contributors,
   };
+}
+
+export function transformEventSeriesToEventSeriesBasic(
+  eventSeries: EventSeries
+): EventSeriesBasic {
+  return (({ id, title }) => ({
+    id,
+    title,
+  }))(eventSeries);
 }

--- a/content/webapp/services/prismic/transformers/events.ts
+++ b/content/webapp/services/prismic/transformers/events.ts
@@ -47,7 +47,10 @@ import {
 import { SeasonPrismicDocument } from '../types/seasons';
 import { EventSeriesPrismicDocument } from '../types/event-series';
 import { PlacePrismicDocument } from '../types/places';
-import { transformContributors } from './contributors';
+import {
+  transformContributors,
+  transformContributorToContributorBasic,
+} from './contributors';
 import * as prismicH from '@prismicio/helpers';
 
 function transformEventBookingType(
@@ -397,7 +400,7 @@ export function transformEventToEventBasic(event: Event): EventBasic {
     series,
     secondaryLabels,
     cost,
-    contributors,
+    contributors: contributors.map(transformContributorToContributorBasic),
   }))(event);
 }
 

--- a/content/webapp/services/prismic/transformers/events.ts
+++ b/content/webapp/services/prismic/transformers/events.ts
@@ -32,7 +32,10 @@ import {
   transformTimestamp,
 } from '.';
 import { transformSeason } from './seasons';
-import { transformEventSeries } from './event-series';
+import {
+  transformEventSeries,
+  transformEventSeriesToEventSeriesBasic,
+} from './event-series';
 import { transformPlace } from './places';
 import isEmptyObj from '@weco/common/utils/is-empty-object';
 import { LabelField } from '@weco/common/model/label-field';
@@ -184,9 +187,9 @@ export function transformEvent(
     data.thirdPartyBookingUrl,
     data.thirdPartyBookingName
   );
-  const series = transformSingleLevelGroup(data.series, 'series').map(series =>
-    transformEventSeries(series as EventSeriesPrismicDocument)
-  );
+  const series = transformSingleLevelGroup(data.series, 'series')
+    .map(series => transformEventSeries(series as EventSeriesPrismicDocument))
+    .map(transformEventSeriesToEventSeriesBasic);
 
   const seasons = transformSingleLevelGroup(data.seasons, 'season').map(
     season => transformSeason(season as SeasonPrismicDocument)

--- a/content/webapp/services/prismic/transformers/exhibitions.ts
+++ b/content/webapp/services/prismic/transformers/exhibitions.ts
@@ -29,7 +29,10 @@ import { transformSeason } from './seasons';
 import { transformPlace } from './places';
 import { Resource } from '../../../types/resource';
 import { SeasonPrismicDocument } from '../types/seasons';
-import { transformContributors } from './contributors';
+import {
+  transformContributors,
+  transformContributorToContributorBasic,
+} from './contributors';
 import * as prismicH from '@prismicio/helpers';
 
 // TODO: Use better types than Record<string, any>.
@@ -179,7 +182,7 @@ export function transformExhibitionToExhibitionBasic(
     end,
     isPermanent,
     statusOverride,
-    contributors,
+    contributors: contributors.map(transformContributorToContributorBasic),
     labels,
   }))(exhibition);
 }

--- a/content/webapp/services/prismic/transformers/json-ld.ts
+++ b/content/webapp/services/prismic/transformers/json-ld.ts
@@ -78,8 +78,7 @@ export function exhibitionLd(exhibition: Exhibition): JsonLdObj {
   );
 }
 
-export function eventLd(event: Event | EventBasic): JsonLdObj[] {
-  // TODO EventBasic
+export function eventLd(event: EventBasic): JsonLdObj[] {
   const promoImage = event.promo?.image;
   return event.times
     .map(eventTime => {

--- a/content/webapp/services/prismic/transformers/series.ts
+++ b/content/webapp/services/prismic/transformers/series.ts
@@ -1,4 +1,4 @@
-import { Series } from '../../../types/series';
+import { Series, SeriesBasic } from '../../../types/series';
 import { SeriesPrismicDocument } from '../types/series';
 import {
   asTitle,
@@ -52,4 +52,13 @@ export function transformSeries(document: SeriesPrismicDocument): Series {
     seasons,
     contributors,
   };
+}
+
+export function transformSeriesToSeriesBasic(series: Series): SeriesBasic {
+  return (({ id, title, color, schedule }) => ({
+    id,
+    title,
+    color,
+    schedule,
+  }))(series);
 }

--- a/content/webapp/services/prismic/types/images.ts
+++ b/content/webapp/services/prismic/types/images.ts
@@ -34,8 +34,8 @@ export function getImageUrlAtSize(
   }
 
   // We remove the `h` param as it's returned from the cropped image in Prismic
-  // but the wrnog value when we apply a new `w` param. ImgIx calculated the height
-  // automatically so ew leave it at that.
+  // but the wrong value when we apply a new `w` param. ImgIx calculated the height
+  // automatically so we leave it at that.
   urlSearchParams.delete('h');
 
   return `${base}?${urlSearchParams.toString()}`;

--- a/content/webapp/types/articles.ts
+++ b/content/webapp/types/articles.ts
@@ -5,7 +5,7 @@ import { GenericContentFields } from './generic-content-fields';
 import { MultiContent } from './multi-content';
 import { Contributor } from './contributors';
 import { Season } from './seasons';
-import { Series } from './series';
+import { Series, SeriesBasic } from './series';
 import { ImagePromo } from './image-promo';
 import { ImageType } from '@weco/common/model/image';
 import { Label } from '@weco/common/model/labels';
@@ -16,7 +16,7 @@ export type ArticleBasic = {
   type: 'articles';
   id: string;
   promo?: ImagePromo | undefined;
-  series: Series[];
+  series: SeriesBasic[];
   title: string;
   format?: Format<ArticleFormatId>;
   image?: ImageType;

--- a/content/webapp/types/contributors.ts
+++ b/content/webapp/types/contributors.ts
@@ -36,3 +36,11 @@ export type Contributor = {
   role?: ContributorRole;
   description?: prismicT.RichTextField;
 };
+
+export type ContributorBasic = {
+  contributor: {
+    type: string;
+    name?: string;
+    image: ImageType;
+  };
+};

--- a/content/webapp/types/event-series.ts
+++ b/content/webapp/types/event-series.ts
@@ -7,3 +7,8 @@ export type EventSeries = GenericContentFields & {
   backgroundTexture?: BackgroundTexture;
   contributors: Contributor[];
 };
+
+export type EventSeriesBasic = {
+  id: string;
+  title: string;
+};

--- a/content/webapp/types/events.ts
+++ b/content/webapp/types/events.ts
@@ -8,6 +8,7 @@ import { Label } from '@weco/common/model/labels';
 import { ImagePromo } from './image-promo';
 import { ImageType } from '@weco/common/model/image';
 import * as prismicT from '@prismicio/types';
+import { EventSeriesBasic } from './event-series';
 
 export type DateTimeRange = {
   startDateTime: Date;
@@ -18,12 +19,6 @@ export type EventTime = {
   range: DateTimeRange;
   isFullyBooked: boolean;
   onlineIsFullyBooked: boolean;
-};
-
-type EventSeries = {
-  id: string;
-  title: string;
-  description?: string;
 };
 
 // E.g. 'British sign language interpreted' | 'Audio described' | 'Speech-to-Text';
@@ -89,7 +84,7 @@ export type EventBasic = HasTimes & {
   locations: Place[];
   availableOnline: boolean;
   scheduleLength: number;
-  series: EventSeries[];
+  series: EventSeriesBasic[];
   cost?: string;
   contributors: Contributor[];
 };
@@ -100,7 +95,7 @@ export type Event = GenericContentFields & {
   hasEarlyRegistration: boolean;
   ticketSalesStart?: Date;
   times: EventTime[];
-  series: EventSeries[];
+  series: EventSeriesBasic[];
   seasons: Season[];
   locations: Place[];
   bookingEnquiryTeam?: Team;

--- a/content/webapp/types/events.ts
+++ b/content/webapp/types/events.ts
@@ -1,4 +1,4 @@
-import { Contributor } from './contributors';
+import { Contributor, ContributorBasic } from './contributors';
 import { GenericContentFields } from './generic-content-fields';
 import { Format } from './format';
 import { LabelField } from '@weco/common/model/label-field';
@@ -86,7 +86,7 @@ export type EventBasic = HasTimes & {
   scheduleLength: number;
   series: EventSeriesBasic[];
   cost?: string;
-  contributors: Contributor[];
+  contributors: ContributorBasic[];
 };
 
 export type Event = GenericContentFields & {

--- a/content/webapp/types/exhibitions.ts
+++ b/content/webapp/types/exhibitions.ts
@@ -1,7 +1,7 @@
 import { Article } from './articles';
 import { Series } from './series';
 import { Book } from './books';
-import { Contributor } from './contributors';
+import { Contributor, ContributorBasic } from './contributors';
 import { Event } from './events';
 import { Place } from './places';
 import { GenericContentFields } from './generic-content-fields';
@@ -31,7 +31,7 @@ export type ExhibitionBasic = {
   end?: Date;
   isPermanent: boolean;
   statusOverride?: string;
-  contributors: Contributor[];
+  contributors: ContributorBasic[];
   labels: Label[];
   image?: ImageType;
   hideStatus?: boolean;

--- a/content/webapp/types/series.ts
+++ b/content/webapp/types/series.ts
@@ -5,6 +5,13 @@ import { ArticleBasic } from './articles';
 import { Contributor } from './contributors';
 import { Season } from './seasons';
 
+export type SeriesBasic = {
+  id: string;
+  title: string;
+  color?: ColorSelection;
+  schedule: ArticleScheduleItem[];
+};
+
 export type Series = GenericContentFields & {
   type: 'series';
   schedule: ArticleScheduleItem[];


### PR DESCRIPTION
## Who is this for?

People using the site.

## What is it doing for them?

Making it be more smol. In particular, we send less Prismic data on the homepage and other pages using the Basic types.

I tested on the homepage in a local build:

<table>
<tr><th></th><th>size of HTML file</th><th>delta</th></tr>
<tr><td>before any changes</td><td>321.0 kB</td><td></td></tr>
<tr><td>with SeriesBasic</td><td>291.8 kB</td><td>&minus;29.2 kB (~9%)</td></tr>
<tr><td>with EventSeriesBasic </td><td>285.3 kB</td><td>&minus;35.7 kB (~11%)
<tr><td>with ContributorBasic </td><td>282.3 kB</td><td>&minus;38.7 kB (~12%)
</td></tr>
</td></tr>
</table>

The bulk of the win seems to be in SeriesBasic, which previously included a lot of information about the contributors and some promo text.

We could keep cutting further, but you're into diminishing returns and the changes get more complex. e.g.

* reducing the amount of image data we send, which lead me to https://github.com/wellcomecollection/wellcomecollection.org/issues/8330 (???)
* filtering the exceptional opening times we send; currently we send the whole list, even exceptions that are long since past, but the whole opening times block is only ~7 kB