### PR TITLE
Guard against bad Sierra IDs on the download page

### DIFF
--- a/catalogue/webapp/pages/download.tsx
+++ b/catalogue/webapp/pages/download.tsx
@@ -27,6 +27,7 @@ import { GetServerSideProps, NextPage } from 'next';
 import { appError, AppErrorProps } from '@weco/common/views/pages/_app';
 import { getServerData } from '@weco/common/server-data';
 import { looksLikeCanonicalId } from 'services/catalogue';
+import { looksLikeSierraId } from '@weco/common/services/catalogue/sierra';
 
 type Props = {
   workId: string;
@@ -150,7 +151,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     const serverData = await getServerData(context);
     const { workId, sierraId } = context.query;
 
-    if (!looksLikeCanonicalId(workId) || typeof sierraId !== 'string') {
+    if (!looksLikeCanonicalId(workId) || !looksLikeSierraId(sierraId)) {
       return {
         notFound: true,
       };

--- a/common/services/catalogue/sierra.test.ts
+++ b/common/services/catalogue/sierra.test.ts
@@ -1,0 +1,23 @@
+import { looksLikeSierraId } from './sierra';
+
+describe('looksLikeSierraId', () => {
+  it('allows a pure-numeric Sierra ID', () => {
+    expect(looksLikeSierraId('b12345678')).toBeTruthy();
+  });
+
+  it('allows a Sierra ID with a non-numeric check digit', () => {
+    expect(looksLikeSierraId('b1234560x')).toBeTruthy();
+  });
+
+  it('rejects IDs which don’t look like Sierra', () => {
+    // A Prismic ID
+    expect(looksLikeSierraId('XphUbREAACMAgRNP')).toBeFalsy();
+
+    // The wrong length of ID
+    expect(looksLikeSierraId('b1')).toBeFalsy();
+    expect(looksLikeSierraId('b12345678901234567890')).toBeFalsy();
+
+    // Something clearly malicious
+    expect(looksLikeSierraId('../etc/passwd')).toBeFalsy();
+  });
+});

--- a/common/services/catalogue/sierra.ts
+++ b/common/services/catalogue/sierra.ts
@@ -11,5 +11,6 @@
 
 import { isString } from '@weco/common/utils/array';
 
-export const looksLikeSierraId = (id: string | string[] | undefined): boolean =>
-  isString(id) ? /^(b[0-9]{7}[0-9x])$/.test(id) : false;
+export const looksLikeSierraId = (
+  id: string | string[] | undefined
+): id is string => (isString(id) ? /^(b[0-9]{7}[0-9x])$/.test(id) : false);

--- a/common/services/catalogue/sierra.ts
+++ b/common/services/catalogue/sierra.ts
@@ -1,0 +1,15 @@
+// Returns true if a query parameter is plausibly a Sierra ID, false otherwise.
+//
+// There's no way for the front-end to know what strings are valid Sierra IDs
+// (only Sierra itself knows that), but it can reject certain classes of
+// strings that it knows definitely aren't.
+//
+// e.g. an empty string definitely isn't a Sierra ID.
+//
+// A Sierra ID is a string starting with 'b', seven digits, then an eighth
+// check digit which may be an 'x'.
+
+import { isString } from '@weco/common/utils/array';
+
+export const looksLikeSierraId = (id: string | string[] | undefined): boolean =>
+  isString(id) ? /^(b[0-9]{7}[0-9x])$/.test(id) : false;


### PR DESCRIPTION
Previously we'd send a download request to DLCS, regardless of what was passed as the sierraId field.  This could cause 500 errors, if we passed something that DLCS couldn't handle, e.g.

    /works/amuh57db/download?sierraId=../etc/passwd

This has been the source of several 500 errors in the #wc-platform-alerts channel recently, from somebody trying to break into the server.

By filtering for strings that look like plausible Sierra IDs here, we reduce the number of obviously bad queries we send to DLCS and cut out a source of 500 errors.

Follows #8332.