### PR TITLE
Always transform to article basic, even in colour

### DIFF
--- a/content/webapp/services/prismic/transformers/article-series.ts
+++ b/content/webapp/services/prismic/transformers/article-series.ts
@@ -1,6 +1,6 @@
 import { Query } from '@prismicio/types';
 import { Series } from '../../../types/series';
-import { ArticleBasic } from '../../../types/articles';
+import { Article, ArticleBasic } from '../../../types/articles';
 import { ArticlePrismicDocument } from '../types/articles';
 import { transformArticle, transformArticleToArticleBasic } from './articles';
 import { transformQuery } from './paginated-results';
@@ -52,21 +52,23 @@ export const transformArticleSeries = (
         })
       : [];
 
+  // Add some colour
+  const items =
+    schedule.length > 0
+      ? schedule.map(item => {
+          return item.type === 'article-schedule-items' ||
+            item.type === 'articles'
+            ? ({
+                ...item,
+                color: series && series.color,
+              } as Article)
+            : item;
+        })
+      : articles;
+
   const seriesWithItems: Series = {
     ...series,
-    // Add some colour
-    items:
-      schedule.length > 0
-        ? schedule.map(item => {
-            return item.type === 'article-schedule-items' ||
-              item.type === 'articles'
-              ? ({
-                  ...item,
-                  color: series && series.color,
-                } as ArticleBasic)
-              : item;
-          })
-        : articles.map(transformArticleToArticleBasic),
+    items: items.map(transformArticleToArticleBasic),
   };
 
   return (


### PR DESCRIPTION
Previously we were only calling `transformArticleToArticleBasic` if the series didn't have an associated colour, which meant we were sending way more information than we needed.  This ensures we always send a trimmed-down version of articles on series.

This makes the stories homepage dramatically smaller:

<table><tr><td>Before</td><td>562.2 kB</td></tr><tr><td>After</td><td>397.4 kB</td></tr></table>