### PR TITLE
Fixes e2e test (hopefully)

### DIFF
--- a/playwright/test/selectors/images.ts
+++ b/playwright/test/selectors/images.ts
@@ -4,7 +4,7 @@ import { mobileModal, searchResultsContainer } from './search';
 export const searchImagesForm =
   'form[aria-describedby="images-form-description"]';
 export const colourSelectorFilterDropDown = `${searchImagesForm} button[aria-controls="images.color"]`;
-export const colourSelector = 'button[color="000000"]';
+export const colourSelector = 'button[color="8b572a"]';
 
 // results list
 export const imagesResultsListItem = `${searchResultsContainer} li[role="listitem"]`;


### PR DESCRIPTION
Filtering by brown this time.

The first item in the results [when filtering by black](https://github.com/wellcomecollection/wellcomecollection.org/pull/8336/files), was an image that is part of a work, and so the regex check on the url when following the 'view image' link failed 

When filtering by brown, the first item in the results is a stand alone image so the regex passes.
