### PR TITLE
Tidy up the naming of default/initial values of toggles

### DIFF
--- a/toggles/webapp/deploy.test.ts
+++ b/toggles/webapp/deploy.test.ts
@@ -1,87 +1,118 @@
 import { withDefaultValuesUnmodified } from './deploy';
-import { Toggle } from './toggles';
+import { PublishedToggle, ToggleDefinition } from './toggles';
 
-const remote: Toggle[] = [
-  {
-    id: 'toggle1',
-    title: 'title1',
-    description: 'description1',
+function getPublishedToggle(id: number): PublishedToggle {
+  return {
+    id: `toggle-${id}`,
+    title: `title-${id}`,
+    description: `description-${id}`,
     defaultValue: true,
-  },
-  {
-    id: 'toggle2',
-    title: 'title2',
-    description: 'description2',
-    defaultValue: false,
-  },
-];
+  };
+}
 
-it('adds tests', () => {
-  const expected = [
-    remote[0],
-    remote[1],
-    {
-      id: 'toggle3',
-      title: 'title3',
-      description: 'description3',
-      defaultValue: true,
-    },
+function getToggleDefinition(id: number): ToggleDefinition {
+  return {
+    id: `toggle-${id}`,
+    title: `title-${id}`,
+    description: `description-${id}`,
+    initialValue: true,
+  };
+}
+
+it('adds a new toggle definition', () => {
+  const remote = [getPublishedToggle(1), getPublishedToggle(2)];
+  const definitions = [
+    getToggleDefinition(1),
+    getToggleDefinition(2),
+    getToggleDefinition(3),
   ];
-  const newRemote = withDefaultValuesUnmodified(remote, expected);
+  const newRemote = withDefaultValuesUnmodified(remote, definitions);
+
+  const expected = [
+    getPublishedToggle(1),
+    getPublishedToggle(2),
+    getPublishedToggle(3),
+  ];
 
   expect(newRemote).toStrictEqual(expected);
 });
 
 it('removes tests', () => {
-  const expected = [
-    remote[0],
-    {
-      id: 'toggle3',
-      title: 'title3',
-      description: 'description3',
-      defaultValue: true,
-    },
-  ];
-  const newRemote = withDefaultValuesUnmodified(remote, expected);
+  const remote = [getPublishedToggle(1)];
+  const definitions = [getToggleDefinition(1), getToggleDefinition(3)];
+
+  const newRemote = withDefaultValuesUnmodified(remote, definitions);
+
+  const expected = [getPublishedToggle(1), getPublishedToggle(3)];
 
   expect(newRemote).toStrictEqual(expected);
 });
 
 it('updates existing toggles leaving defaultValue unmodified', () => {
-  const updated = [
+  const remote = [
     {
-      id: remote[0].id,
-      title: 'updated title1',
-      description: 'updated description1',
-      defaultValue: !remote[0].defaultValue,
+      id: 'id-1',
+      title: 'title1',
+      description: 'description1',
+      defaultValue: true,
     },
     {
-      id: remote[1].id,
-      title: 'updated title2',
-      description: 'updated description2',
-      defaultValue: !remote[1].defaultValue,
+      id: 'id-2',
+      title: 'title2',
+      description: 'description2',
+      defaultValue: true,
     },
     {
-      id: 'toggle3',
+      id: 'id-3',
       title: 'title3',
       description: 'description3',
       defaultValue: true,
     },
   ];
 
-  const expected = [
+  const definitions = [
     {
-      ...updated[0],
-      defaultValue: remote[0].defaultValue,
+      id: 'id-1',
+      title: 'updated title1',
+      description: 'updated description1',
+      initialValue: false,
     },
     {
-      ...updated[1],
-      defaultValue: remote[1].defaultValue,
+      id: 'id-2',
+      title: 'updated title2',
+      description: 'updated description2',
+      initialValue: false,
     },
-    updated[2],
+    {
+      id: 'id-3',
+      title: 'title3',
+      description: 'description3',
+      initialValue: true,
+    },
   ];
 
-  const newRemote = withDefaultValuesUnmodified(remote, updated);
+  const newRemote = withDefaultValuesUnmodified(remote, definitions);
+
+  const expected = [
+    {
+      id: 'id-1',
+      title: 'updated title1',
+      description: 'updated description1',
+      defaultValue: true,
+    },
+    {
+      id: 'id-2',
+      title: 'updated title2',
+      description: 'updated description2',
+      defaultValue: true,
+    },
+    {
+      id: 'id-3',
+      title: 'title3',
+      description: 'description3',
+      defaultValue: true,
+    },
+  ];
 
   expect(newRemote).toStrictEqual(expected);
 });

--- a/toggles/webapp/deploy.ts
+++ b/toggles/webapp/deploy.ts
@@ -1,35 +1,49 @@
 import { S3Client } from '@aws-sdk/client-s3';
+import { info } from 'console';
 import { TogglesResp } from '.';
 import { getTogglesObject, putTogglesObject } from './s3-utils';
-import localToggles, { Toggle } from './toggles';
+import localToggles, { PublishedToggle, ToggleDefinition } from './toggles';
 
 export const withDefaultValuesUnmodified = (
-  from: Toggle[],
-  to: Toggle[]
-): Toggle[] => {
+  publishedToggles: PublishedToggle[],
+  definitions: ToggleDefinition[]
+): PublishedToggle[] => {
   /**
    * We don't deploy over the defaultValue as this can be set manually by
-   * updating the toggle via setDefaultValueFor.
+   * updating the toggle via setDefaultValueFor.  We want to make updating
+   * the default value of a toggle an explicit action.
    *
    * If we have turned a toggle off manually - we expect it to remain
    * off even after a deploy.
    *
    */
-  const toggles = to.map(toggle => {
-    const { defaultValue } = from.find(({ id }) => id === toggle.id) ?? {
-      defaultValue: toggle.defaultValue,
-    };
+  return definitions.map(toggle => {
+    const matchingToggle = publishedToggles.find(({ id }) => id === toggle.id);
 
-    if (defaultValue !== toggle.defaultValue) {
-      console.log(
-        `Ignoring new default value of ${toggle.id}; use setDefaultValueFor (old: ${defaultValue}, new: ${toggle.defaultValue})`
+    if (
+      typeof matchingToggle !== 'undefined' &&
+      matchingToggle.defaultValue !== toggle.initialValue
+    ) {
+      info(
+        `${toggle.id}: the published value is ${matchingToggle.defaultValue} and will not be replaced`
       );
+      info(`If you want to update the published value, run:`);
+      info(`    yarn setDefaultValueFor --${toggle.id}=${toggle.initialValue}`);
+      info('');
     }
 
-    return { ...toggle, defaultValue };
-  });
+    const defaultValue =
+      typeof matchingToggle !== 'undefined'
+        ? matchingToggle?.defaultValue
+        : toggle.initialValue;
 
-  return toggles;
+    return {
+      id: toggle.id,
+      description: toggle.description,
+      title: toggle.title,
+      defaultValue,
+    };
+  });
 };
 
 export async function deploy(client: S3Client): Promise<void> {

--- a/toggles/webapp/index.ts
+++ b/toggles/webapp/index.ts
@@ -1,4 +1,4 @@
-import toggleConfig, { ABTest, Toggle } from './toggles';
+import toggleConfig, { ABTest, PublishedToggle } from './toggles';
 
 const toggleIds = toggleConfig.toggles.map(toggle => toggle.id);
 const testIds = toggleConfig.tests.map(test => test.id);
@@ -8,7 +8,7 @@ type TestId = typeof testIds[number];
 
 // As togglesConfig is what is served at https://toggles.wellcomecollection.org/toggles.json
 // This allows methods fetching that URL to type the data fetched
-export type TogglesResp = { toggles: Toggle[]; tests: ABTest[] };
+export type TogglesResp = { toggles: PublishedToggle[]; tests: ABTest[] };
 
 // Don't be tempted to make the keys on this optional - keeping them
 // as required means we catch dead code left over from removed toggles

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -1,7 +1,14 @@
-export type Toggle = {
+type ToggleBase = {
   id: string;
   title: string;
   description: string;
+};
+
+export type ToggleDefinition = ToggleBase & {
+  initialValue: boolean;
+};
+
+export type PublishedToggle = ToggleBase & {
   defaultValue: boolean;
 };
 
@@ -19,32 +26,33 @@ const toggles = {
       id: 'disableRequesting',
       title: 'Disables requesting functionality',
       description:
-        'Replaces the "sign into your library account to request items" message, with "requesting is currently unavailable". Adds a note to say when requesting will be available again.',
-      defaultValue: false,
+        'Replaces the "sign into your library account to request items" message, with "requesting is currently unavailable". Adds a note to say when requesting will be available again.' +
+        'See documentation link (tbc).',
+      initialValue: false,
     },
     {
       id: 'stagingApi',
       title: 'Staging API',
-      defaultValue: false,
+      initialValue: false,
       description: 'Use the staging catalogue API',
     },
     {
       id: 'apiToolbar',
       title: 'API toolbar',
-      defaultValue: false,
+      initialValue: false,
       description: 'A toolbar to help us navigate the secret depths of the API',
     },
     {
       id: 'conceptsPages',
       title: 'Concepts pages',
-      defaultValue: false,
+      initialValue: false,
       description:
         'View pages for concepts (subjects and people) and link to them from works pages',
     },
     {
       id: 'exhibitionGuides',
       title: 'Exhibition guides',
-      defaultValue: false,
+      initialValue: false,
       description: 'View pages related to exhibition guides',
     },
   ] as const,


### PR DESCRIPTION
As I've been explaining it to a few people recently, I've noticed there's a bit of confusing naming.  In particular, if you look in `toggles.ts`, here's a toggle definition:

```typescript
{
  id: 'exhibitionGuides',
  title: 'Exhibition guides',
  description: 'View pages related to exhibition guides',
  defaultValue: false,
},
```

Here's what the toggle looks like in the published JSON:

```json
{
  "id": "exhibitionGuides",
  "description": "View pages related to exhibition guides",
  "title": "Exhibition guides",
  "defaultValue": false
}
```

You might think you can update the default value by updating the value in `toggles.ts` and running `yarn deploy` -- but no!

If you wanted to update the default value, you can never change it through `toggles.ts` – that value is set on the toggle's initial deployment, but after that you have to set it with `yarn setDefaultValueFor`.  This is to make sure that default toggle values are only changed in a deliberate, intentional way.

To make it clearer that the `defaultValue` in `toggles.ts` won't affect the published value, I've changed that type to use `initialValue`: 

```typescript
{
  id: 'exhibitionGuides',
  title: 'Exhibition guides',
  description: 'View pages related to exhibition guides',
  initialValue: false,
},
```

I hope this makes the intention a bit more obvious, and less confusing.
