### PR TITLE
[DO NOT MERGE] Suppress alerts from the items API

### DIFF
--- a/cache/.terraform.lock.hcl
+++ b/cache/.terraform.lock.hcl
@@ -1,0 +1,17 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.2.0"
+  hashes = [
+    "h1:2K5LQkuWRS2YN1/YoNaHn9MAzjuTX8Gaqy6i8Mbfv8Y=",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.75.2"
+  constraints = "~> 3.70"
+  hashes = [
+    "h1:lcSLAmkNM1FvNhqAEbh2oTZRqF37HKRh1Di8LvssYBY=",
+  ]
+}

--- a/cache/send_slack_alert_for_5xx_errors.js
+++ b/cache/send_slack_alert_for_5xx_errors.js
@@ -305,6 +305,10 @@ function isInterestingError(hit) {
     return false;
   }
 
+  if (hit.path.indexOf('/api/works/items') !== -1) {
+    return false;
+  }
+
   return true;
 }
 


### PR DESCRIPTION
While Sierra is down for maintenance, every request to the items API is failing.

Stop it spamming #wc-platform-alerts.

We'll need to revert this when it's back up.