### PR TITLE
Images routing with modals

### DIFF
--- a/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
+++ b/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
@@ -35,7 +35,7 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
   };
 
   useEffect(() => {
-    // If there is a set expandedImage and it's a different one that the current queried one
+    // If there is a set expandedImage and it's a different one than the current queried one
     // Change URL to reflect the change
     if (!!expandedImage && routerImageId !== expandedImage.id) {
       router.push(
@@ -65,7 +65,7 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
 
   useEffect(() => {
     // If there is an imageId in the query, fetch that image and display it
-    // Otherwise ensure modal is closed and URL gets resetted
+    // Otherwise ensure modal is closed and URL resets
     routerImageId ? getImage(routerImageId) : setIsActive(false);
   }, [routerImageId]);
 

--- a/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
+++ b/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
@@ -1,8 +1,9 @@
-import { FunctionComponent, useState } from 'react';
+import { FunctionComponent, useEffect, useState } from 'react';
 import ExpandedImage from '../ExpandedImage/ExpandedImage';
 import ImageCard from '../ImageCard/ImageCard';
 import { Image, CatalogueResultsList } from '@weco/common/model/catalogue';
 import Modal from '@weco/common/views/components/Modal/Modal';
+import { useRouter } from 'next/router';
 
 type Props = {
   images: CatalogueResultsList<Image>;
@@ -11,6 +12,9 @@ type Props = {
 const ImageEndpointSearchResults: FunctionComponent<Props> = ({
   images,
 }: Props) => {
+  const router = useRouter();
+  const { page, imageId: routerImageId } = router.query;
+
   const [expandedImage, setExpandedImage] = useState<Image | undefined>();
   // In the case that the modal changes the expanded image to
   // be one that isn't on this results page, this index will be -1
@@ -18,6 +22,52 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
     img => expandedImage && img.id === expandedImage.id
   );
   const [isActive, setIsActive] = useState(false);
+
+  // Gets the image as it might not be in the current results, and displays it.
+  const getImage = async routerImageId => {
+    const apiUrl = `https://api.wellcomecollection.org/catalogue/v2/images/${routerImageId}`;
+    const image: Image = await fetch(apiUrl).then(res => res.json());
+
+    if (image) {
+      setExpandedImage(image);
+      setIsActive(true);
+    }
+  };
+
+  useEffect(() => {
+    // If there is a set expandedImage and it's a different one that the current queried one
+    // Change URL to reflect the change
+    if (!!expandedImage && routerImageId !== expandedImage.id) {
+      router.push(
+        `${router.pathname}?${page ? 'page=' + page + '&' : ''}imageId=${
+          expandedImage.id
+        }`,
+        undefined,
+        {
+          shallow: true,
+        }
+      );
+    }
+  }, [expandedImage]);
+
+  useEffect(() => {
+    // If isActive changes to false, reset the URL to no imageId
+    if (!isActive) {
+      router.push(
+        `${router.pathname}${page ? '?page=' + page : ''}`,
+        undefined,
+        {
+          shallow: true,
+        }
+      );
+    }
+  }, [isActive]);
+
+  useEffect(() => {
+    // If there is an imageId in the query, fetch that image and display it
+    // Otherwise ensure modal is closed and URL gets resetted
+    routerImageId ? getImage(routerImageId) : setIsActive(false);
+  }, [routerImageId]);
 
   return (
     <ul className="flex flex--wrap plain-list no-padding no-margin" role="list">

--- a/catalogue/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.tsx
+++ b/catalogue/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.tsx
@@ -52,7 +52,7 @@ const VisuallySimilarImagesFromApi: FunctionComponent<Props> = ({
       <h3 className={font('wb', 5)}>Visually similar images</h3>
       <Wrapper>
         {similarImages.map(related => (
-          <a key={related.id} onClick={() => onClickImage(related)} href="#">
+          <a key={related.id} onClick={() => onClickImage(related)}>
             <IIIFImage
               layout="raw"
               image={{

--- a/catalogue/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.tsx
+++ b/catalogue/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.tsx
@@ -6,6 +6,8 @@ import { getImage } from '../../services/catalogue/images';
 import Space from '@weco/common/views/components/styled/Space';
 import { useToggles } from '@weco/common/server-data/Context';
 import IIIFImage from '../IIIFImage/IIIFImage';
+import { useRouter } from 'next/router';
+import Link from 'next/link';
 
 type Props = {
   originalId: string;
@@ -33,6 +35,8 @@ const VisuallySimilarImagesFromApi: FunctionComponent<Props> = ({
 }: Props) => {
   const [similarImages, setSimilarImages] = useState<ImageType[]>([]);
   const toggles = useToggles();
+  const router = useRouter();
+  const { page } = router.query;
 
   useEffect(() => {
     const fetchVisuallySimilarImages = async () => {
@@ -52,18 +56,27 @@ const VisuallySimilarImagesFromApi: FunctionComponent<Props> = ({
       <h3 className={font('wb', 5)}>Visually similar images</h3>
       <Wrapper>
         {similarImages.map(related => (
-          <a key={related.id} onClick={() => onClickImage(related)}>
-            <IIIFImage
-              layout="raw"
-              image={{
-                contentUrl: related.locations[0]?.url,
-                width: 180,
-                height: 180,
-                alt: '',
-              }}
-              width={180}
-            />
-          </a>
+          <Link
+            key={related.id}
+            href={`${router.pathname}?${
+              page ? 'page=' + page + '&' : ''
+            }imageId=${related.id}`}
+            shallow={true}
+            passHref
+          >
+            <a onClick={() => onClickImage(related)}>
+              <IIIFImage
+                layout="raw"
+                image={{
+                  contentUrl: related.locations[0]?.url,
+                  width: 180,
+                  height: 180,
+                  alt: '',
+                }}
+                width={180}
+              />
+            </a>
+          </Link>
         ))}
       </Wrapper>
       <p


### PR DESCRIPTION
## Who is this for?
Users

## What is it doing for them?
Allows them to browse through images, going back and forth when clicking related images. Currently it only keeps displaying the same image until the user leaves `/images`. Would also allow for sharing `/images` with a modal opened if the user wanted it.

Closes #8350 