### PR TITLE
Stop test failing if disableRequesting toggle is turned on

### DIFF
--- a/catalogue/webapp/components/LibraryMembersBar/LibraryMembersBar.tsx
+++ b/catalogue/webapp/components/LibraryMembersBar/LibraryMembersBar.tsx
@@ -93,7 +93,9 @@ const LibraryMembersBar: FC = () => {
         >
           Library members:
         </Space>
-        <span className={font('intr', 5)}>{requestingDisabled}</span>
+        <span data-test-id="requestingDisabled" className={font('intr', 5)}>
+          {requestingDisabled}
+        </span>
       </StyledComponent>
     );
   }

--- a/playwright/test/work.test.ts
+++ b/playwright/test/work.test.ts
@@ -9,9 +9,7 @@ import { Page } from 'playwright';
 const getWhereToFindItAndEncoreLink = async (page: Page) => {
   const whereToFindIt = await page.$('h2:has-text("Where to find it")');
   const encoreLink = await page.$('a:has-text("Request item")');
-  const unavailableBanner = await page.$(
-    'span:has-text("Requesting is currently unavailable, while our building is closed.")'
-  );
+  const unavailableBanner = await page.$("[data-test-id='requestingDisabled']");
 
   return {
     whereToFindIt,
@@ -36,8 +34,6 @@ test.describe(
       const { whereToFindIt, encoreLink, unavailableBanner } =
         await getWhereToFindItAndEncoreLink(page);
       expect(whereToFindIt).toBeTruthy();
-
-      // TODO: Remove the check for the unavailableBanner when the building is reopened.
       expect(encoreLink || unavailableBanner).toBeTruthy();
     });
 


### PR DESCRIPTION
When we last turned on the disableRequesting toggle, it caused a test to fail and prevents us from deploying.

The test is looking for the presence of some specific text in the banner that appears on the work page when requesting is disabled. The problem is, the text is likely to change depending on the reason for disabling the requesting functionality.

This PR changes the test to look for the presence of a data-test-id, that wraps the text, instead.