### PR TITLE
Make SegmentedControl list items visible above mobile header

### DIFF
--- a/common/views/components/SegmentedControl/SegmentedControl.tsx
+++ b/common/views/components/SegmentedControl/SegmentedControl.tsx
@@ -137,16 +137,16 @@ const Wrapper = styled.div.attrs({})<IsActiveProps>`
       `
       width: auto;
       position: fixed;
-      top: 24px;
-      right: 18px;
-      z-index: 2;
+      top: 4px;
+      right: 10px;
+      z-index: 7;
     `}
   }
 
   .segmented-control__body {
     display: ${props => (props.isActive ? 'block' : 'none')};
     position: fixed;
-    z-index: 1;
+    z-index: 6; // Ensures that it's above the fixed header on mobile
     top: 0;
     left: 0;
     right: 0;


### PR DESCRIPTION
Fixes #8349 

<img width="581" alt="image" src="https://user-images.githubusercontent.com/1394592/187940793-8aa58360-71a2-4885-a51c-17480c1d3861.png">

This is the most straightforward fix to make the component usable. I think the UX for the mobile version of this component could probably do with revisiting though – the thing that looks like a dropdown could probably just behave like the other dropdowns we use on the site, rather than taking over the entire screen. Opened #8362 to track this.