### PR TITLE
Don't send PaginatedResults on the whats-on page

### DIFF
--- a/content/webapp/__mocks__/whats-on.ts
+++ b/content/webapp/__mocks__/whats-on.ts
@@ -1197,28 +1197,11 @@ export const whatsOn: (hasExhibition: boolean) => WhatsOnProps = (
   hasExhibition: boolean
 ) => ({
   period: 'current-and-coming-up',
-  exhibitions: {
-    currentPage: 1,
-    pageSize: 20,
-    totalResults: 1,
-    totalPages: 1,
-    results: [hasExhibition ? beingHuman : undefined].filter(isNotUndefined),
-  },
-  events: {
-    currentPage: 1,
-    pageSize: 100,
-    totalResults: 0,
-    totalPages: 0,
-    results: [],
-  },
-  availableOnlineEvents: {
-    currentPage: 1,
-    pageSize: 100,
-    totalResults: 0,
-    totalPages: 0,
-    results: [],
-  },
-  dateRange: ['2020-11-05T00:00:00.000Z', null],
+  exhibitions: hasExhibition ? [beingHuman] : [],
+  events: [],
+  availableOnlineEvents: [],
+  dateRange: { start: new Date(2020, 11, 5) },
+  jsonLd: [],
   tryTheseTooPromos: [
     {
       type: 'promo',

--- a/content/webapp/pages/whats-on.tsx
+++ b/content/webapp/pages/whats-on.tsx
@@ -3,7 +3,6 @@ import NextLink from 'next/link';
 import { ExhibitionBasic } from '../types/exhibitions';
 import { EventBasic } from '../types/events';
 import { Period } from '../types/periods';
-import { PaginatedResults } from '@weco/common/services/prismic/types';
 import { classNames, font, grid, cssGrid } from '@weco/common/utils/classnames';
 import {
   getPageFeaturedText,
@@ -98,9 +97,9 @@ const segmentedControlItems = [
 ];
 
 export type Props = {
-  exhibitions: PaginatedResults<ExhibitionBasic>;
-  events: PaginatedResults<EventBasic>;
-  availableOnlineEvents: PaginatedResults<EventBasic>;
+  exhibitions: ExhibitionBasic[];
+  events: EventBasic[];
+  availableOnlineEvents: EventBasic[];
   period: string;
   dateRange: { start: Date; end?: Date };
   tryTheseTooPromos: FacilityPromoType[];
@@ -352,17 +351,17 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
 
     const events = transformQuery(eventsQuery, event =>
       transformEventToEventBasic(transformEvent(event))
-    );
-    const exhibitions = transformExhibitionsQuery(exhibitionsQuery);
+    ).results;
+    const exhibitions = transformExhibitionsQuery(exhibitionsQuery).results;
     const availableOnlineEvents = transformQuery(
       availableOnlineEventsQuery,
       event => transformEventToEventBasic(transformEvent(event))
-    );
+    ).results;
 
     if (period && events && exhibitions) {
       const jsonLd = [
-        ...exhibitions.results.map(exhibitionLd),
-        ...events.results.map(eventLd),
+        ...exhibitions.map(exhibitionLd),
+        ...events.map(eventLd),
       ] as JsonLdObj[];
 
       return {
@@ -395,10 +394,10 @@ const WhatsOnPage: FunctionComponent<Props> = props => {
     jsonLd,
   } = props;
 
-  const events = props.events.results.map(fixEventDatesInJson);
+  const events = props.events.map(fixEventDatesInJson);
   const availableOnlineEvents =
-    props.availableOnlineEvents.results.map(fixEventDatesInJson);
-  const exhibitions = props.exhibitions.results.map(fixExhibitionDatesInJson);
+    props.availableOnlineEvents.map(fixEventDatesInJson);
+  const exhibitions = props.exhibitions.map(fixExhibitionDatesInJson);
 
   const firstExhibition = exhibitions[0];
 


### PR DESCRIPTION
We only need a list of exhibitions/events to render the page; pagination is handled by per-type pages.

Quick win spun out of #8363.