### PR TITLE
Use tqdm for tryAllContentPages

### DIFF
--- a/prismic-model/package.json
+++ b/prismic-model/package.json
@@ -25,6 +25,7 @@
     "json-diff": "^0.9.0",
     "node-fetch": "2",
     "prompts": "^2.4.2",
+    "tqdm": "^2.0.3",
     "ts-node": "^10.4.0",
     "typescript": "^4.4.4",
     "yargs": "^17.2.1"

--- a/prismic-model/tryAllContentPages.ts
+++ b/prismic-model/tryAllContentPages.ts
@@ -12,6 +12,7 @@ import { error } from './console';
 import { downloadPrismicSnapshot } from './downloadSnapshot';
 import fs from 'fs';
 import fetch from 'node-fetch';
+import tqdm from 'tqdm';
 
 type PrismicDocument = {
   id: string;
@@ -80,11 +81,17 @@ async function run() {
     .filter(({ type }) => !nonVisibleTypes.has(type))
     .map(doc => createUrl(prefix, doc));
 
-  for (const u of urls) {
+  const pageErrors = [];
+
+  for await (const u of tqdm(urls)) {
     const resp = await fetch(u);
     if (resp.status !== 200) {
-      error(`${resp.status} ${u}`);
+      pageErrors.push(`${resp.status} ${u}`);
     }
+  }
+
+  for (const message of pageErrors) {
+    error(message);
   }
 }
 

--- a/prismic-model/yarn.lock
+++ b/prismic-model/yarn.lock
@@ -2859,6 +2859,11 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
+tqdm@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/tqdm/-/tqdm-2.0.3.tgz#62789819a6c9260854a58c52dec4e378cec021a8"
+  integrity sha512-Ju50G550gspkjd1AiJ/jFBHe2dii9s+KPntEsq0o73BqywqzNWPUM8/FD3zM1rOH7OGLoH7pGSGI90Ct+Yd/5Q==
+
 tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"


### PR DESCRIPTION
This gives you a progress bar in the output, which is useful for checking that it is checking pages, and an estimate of when it will finish.

e.g.

    $ ts-node tryAllContentPages
    |##########| 2102/2107 99% [elapsed: 03:27, left: 00:02, 10.14 iters/s]
    !!! 404 http://localhost:3000/series/YxDE0hEAACMAdaCf
    !!! 404 http://localhost:3000/exhibition-guides/YvJ4UhAAAPgZztMl
    !!! 404 http://localhost:3000/exhibition-guides/YvUALRAAACMA2h8V
    !!! 404 http://localhost:3000/exhibition-guides/Ytk2IREAACcA--2o
    !!! 500 http://localhost:3000/pages/Wvl1wiAAADMJ3zNe
    !!! 500 http://localhost:3000/pages/WwQHTSAAANBfDYXU
    !!! 404 http://localhost:3000/series/X8D9qxIAACIAcKSf
    !!! 404 http://localhost:3000/exhibition-resources/W5KUFCYAACYAG-T4
    !!! 500 http://localhost:3000/pages/Wuw19yIAAK1Z3Smm
    ✨  Done in 209.94s.

Another small bit done while looking at #8363.

For those who haven't used it before: `yarn tryAllContentPages` is a tool you can use to make a request for every entry in Prismic against a locally running copy of the site. Super handy during big refactoring if you want to check you haven't broken something.