### PR TITLE
Add a Prismic lint for broken interpretation type links

### DIFF
--- a/prismic-model/lintPrismicData.ts
+++ b/prismic-model/lintPrismicData.ts
@@ -44,11 +44,34 @@ function detectEur01Safelinks(doc: any): string[] {
   return [];
 }
 
+// Look for broken links to interpretation types on events.
+//
+// These manifest as small black squares (on promo cards) or small yellow
+// squares (on the event pages).
+//
+// See e.g. https://wellcome.slack.com/archives/C8X9YKM5X/p1662107045936069
+function detectBrokenInterpretationTypeLinks(doc: any): string[] {
+  if (doc.type === 'events') {
+    const brokenLinks = doc.data.interpretations.filter(
+      it => it.interpretationType.type === 'broken_type'
+    );
+
+    if (brokenLinks.length > 0) {
+      return ['- link to an interpretation type is broken'];
+    }
+  }
+
+  return [];
+}
+
 async function run() {
   const snapshotDir = await downloadPrismicSnapshot();
 
   for (const doc of getPrismicDocuments(snapshotDir)) {
-    const errors = detectEur01Safelinks(doc);
+    const errors = [
+      ...detectEur01Safelinks(doc),
+      ...detectBrokenInterpretationTypeLinks(doc),
+    ];
 
     // If there are any errors, report them to the console.
     if (errors.length > 0) {


### PR DESCRIPTION
For https://wellcome.slack.com/archives/C8X9YKM5X/p1662107045936069

## Who is this for?

The Editorial team.

## What is it doing for them?

Helping us identify broken links to interpretation types that should be removed to avoid mysterious black squares appearing on the site.