### PR TITLE
Don't use Moment in the opening-times model

### DIFF
--- a/catalogue/webapp/components/ItemRequestModal/useAvailableDates.ts
+++ b/catalogue/webapp/components/ItemRequestModal/useAvailableDates.ts
@@ -39,7 +39,7 @@ export const useAvailableDates = (): AvailableDates => {
   const exceptionalClosedDates = findClosedDays(exceptionalLibraryOpeningTimes)
     .map(day => {
       const exceptionalDay = day as ExceptionalOpeningHoursDay;
-      return exceptionalDay.overrideDate as Moment;
+      return london(exceptionalDay.overrideDate);
     })
     .filter(Boolean);
 

--- a/common/model/opening-hours.ts
+++ b/common/model/opening-hours.ts
@@ -1,4 +1,3 @@
-import { Moment } from 'moment';
 import { ImageType } from './image';
 
 export type Day =
@@ -20,13 +19,13 @@ export type OverrideType =
   | 'other';
 
 export type OverrideDate = {
-  overrideDate: Moment;
+  overrideDate: Date;
   overrideType: OverrideType;
 };
 
 export type ExceptionalPeriod = {
   type: OverrideType;
-  dates: Moment[];
+  dates: Date[];
 };
 
 export type OpeningHoursDay = {
@@ -37,7 +36,7 @@ export type OpeningHoursDay = {
 };
 
 export type ExceptionalOpeningHoursDay = {
-  overrideDate: Moment;
+  overrideDate: Date;
   overrideType: OverrideType;
   opens: string;
   closes: string;

--- a/common/services/prismic/opening-times.ts
+++ b/common/services/prismic/opening-times.ts
@@ -1,4 +1,4 @@
-import { london } from '../../utils/format-date';
+import { formatDay, london } from '../../utils/format-date';
 import groupBy from 'lodash.groupby';
 import {
   OverrideType,
@@ -8,8 +8,8 @@ import {
   OpeningHoursDay,
   ExceptionalOpeningHoursDay,
 } from '../../model/opening-hours';
-import { Moment } from 'moment';
 import { isNotUndefined } from '../../utils/array';
+import { isSameDay } from '../../utils/dates';
 
 export function exceptionalOpeningDates(venues: Venue[]): OverrideDate[] {
   return venues
@@ -33,16 +33,8 @@ export function exceptionalOpeningDates(venues: Venue[]): OverrideDate[] {
       const prevDate = lastItem && lastItem.overrideDate;
       if (!i) {
         return true;
-      } else if (
-        firstDate &&
-        firstDate.toDate() instanceof Date &&
-        prevDate &&
-        prevDate.toDate() instanceof Date
-      ) {
-        return (
-          london(firstDate.toDate()).format('YYYY-MM-DD') !==
-          london(prevDate.toDate()).format('YYYY-MM-DD')
-        );
+      } else if (firstDate && prevDate) {
+        return isSameDay(firstDate, prevDate);
       }
     });
 }
@@ -69,7 +61,10 @@ export function exceptionalOpeningPeriods(
         };
       } else if (
         previousDate &&
-        date.overrideDate?.isBefore(previousDate.clone().add(6, 'days')) &&
+        date.overrideDate &&
+        london(date.overrideDate).isBefore(
+          london(previousDate).clone().add(6, 'days')
+        ) &&
         date.overrideType === acc[groupedIndex].type
       ) {
         acc[groupedIndex].dates.push(date.overrideDate);
@@ -84,7 +79,7 @@ export function exceptionalOpeningPeriods(
     }, [] as ExceptionalPeriod[])
     .sort((a, b) => {
       // order groups by their earlist date
-      return a.dates[0].isBefore(b.dates[0]) ? -1 : 1;
+      return a.dates[0] < b.dates[0] ? -1 : 1;
     });
 }
 
@@ -95,9 +90,9 @@ export function exceptionalOpeningPeriodsAllDates(
     const startDate = period.dates[0];
     const lastDate = period.dates[period.dates.length - 1];
 
-    const arrayLength = lastDate.diff(startDate, 'days') + 1;
+    const arrayLength = london(lastDate).diff(startDate, 'days') + 1;
     const completeDateArray = [...Array(arrayLength).keys()].map(i => {
-      return startDate.clone().add(i, 'days');
+      return london(startDate).clone().add(i, 'days').toDate();
     });
 
     return {
@@ -118,17 +113,22 @@ export function groupExceptionalVenueDays(
 ): ExceptionalOpeningHoursDay[][] {
   return exceptionalDays.length > 0
     ? exceptionalDays
-        .sort((a, b) => {
-          return a.overrideDate?.diff(b.overrideDate, 'days') ?? 0;
-        })
+        .sort(
+          (a, b) =>
+            (a.overrideDate &&
+              london(a.overrideDate).diff(b.overrideDate, 'days')) ??
+            0
+        )
         .reduce(
           (acc, date) => {
             const group = acc[acc.length - 1];
             if (
-              (date.overrideDate?.diff(
-                (group[0] && group[0].overrideDate) || date.overrideDate,
-                'days'
-              ) ?? 0) > 14
+              ((date.overrideDate &&
+                london(date.overrideDate).diff(
+                  (group[0] && group[0].overrideDate) || date.overrideDate,
+                  'days'
+                )) ??
+                0) > 14
             ) {
               acc.push([date]);
             } else {
@@ -143,10 +143,10 @@ export function groupExceptionalVenueDays(
 
 export function exceptionalFromRegular(
   venue: Venue,
-  dateToGet: Moment,
+  dateToGet: Date,
   type: OverrideType
 ): ExceptionalOpeningHoursDay {
-  const currentDay = dateToGet.format('dddd');
+  const currentDay = formatDay(dateToGet);
   const regular = venue.openingHours.regular.find(
     hours => hours.dayOfWeek === currentDay
   );
@@ -170,17 +170,17 @@ export function backfillExceptionalVenueDays(
     getExceptionalVenueDays(venue)
   );
   return (allVenueExceptionalPeriods ?? []).map(period => {
-    const sortedDates = period.dates.sort((a, b) => {
-      return a.diff(b, 'days');
-    });
+    const sortedDates = period.dates.sort((a, b) => london(a).diff(b, 'days'));
     const type = period.type || 'other';
     const days = sortedDates
       .map(date => {
-        const matchingVenueGroup = groupedExceptionalDays.find(group => {
-          return group.find(day => day.overrideDate?.isSame(date, 'day'));
-        });
-        const matchingDay = matchingVenueGroup?.find(day =>
-          day.overrideDate?.isSame(date, 'day')
+        const matchingVenueGroup = groupedExceptionalDays.find(group =>
+          group.find(
+            day => day.overrideDate && isSameDay(day.overrideDate, date)
+          )
+        );
+        const matchingDay = matchingVenueGroup?.find(
+          day => day.overrideDate && isSameDay(day.overrideDate, date)
         );
         const backfillDay = exceptionalFromRegular(venue, date, type);
         if (type === 'other') {
@@ -199,15 +199,20 @@ export function groupConsecutiveExceptionalDays(
   dates: ExceptionalOpeningHoursDay[]
 ): ExceptionalOpeningHoursDay[][] {
   return dates
-    .sort((a, b) => {
-      return a.overrideDate?.diff(b.overrideDate, 'days') ?? 0;
-    })
+    .sort(
+      (a, b) =>
+        (a.overrideDate &&
+          london(a.overrideDate).diff(b.overrideDate, 'days')) ??
+        0
+    )
     .reduce((acc, date) => {
       const group = acc[acc.length - 1];
       if (
         !group ||
-        date.overrideDate.diff(group[group.length - 1]?.overrideDate, 'days') >
-          1
+        london(date.overrideDate).diff(
+          group[group.length - 1]?.overrideDate,
+          'days'
+        ) > 1
       ) {
         acc.push([date]);
       } else {
@@ -223,8 +228,9 @@ export function getUpcomingExceptionalPeriods(
   const nextUpcomingPeriods = exceptionalPeriods.filter(period => {
     const upcomingPeriod = period.find(d => {
       return (
-        d.overrideDate?.isSameOrBefore(london().add(28, 'day'), 'day') &&
-        d.overrideDate?.isSameOrAfter(london(), 'day')
+        d.overrideDate &&
+        london(d.overrideDate).isSameOrBefore(london().add(28, 'day'), 'day') &&
+        london(d.overrideDate).isSameOrAfter(london(), 'day')
       );
     });
     return upcomingPeriod || false;
@@ -245,7 +251,7 @@ export function getTodaysVenueHours(
   const exceptionalOpeningHours =
     venue.openingHours.exceptional &&
     venue.openingHours.exceptional.find(i =>
-      todaysDate.startOf('day').isSame(i.overrideDate.startOf('day'))
+      todaysDate.startOf('day').isSame(london(i.overrideDate).startOf('day'))
     );
   const regularOpeningHours =
     venue.openingHours.regular &&

--- a/common/services/prismic/opening-times.ts
+++ b/common/services/prismic/opening-times.ts
@@ -77,7 +77,7 @@ export function exceptionalOpeningPeriods(
       return acc;
     }, [] as ExceptionalPeriod[])
     .sort((a, b) => {
-      // order groups by their earlist date
+      // order groups by their earliest date
       return a.dates[0] < b.dates[0] ? -1 : 1;
     });
 }

--- a/common/services/prismic/opening-times.ts
+++ b/common/services/prismic/opening-times.ts
@@ -226,7 +226,7 @@ export function getUpcomingExceptionalPeriods(
     const upcomingPeriod = period.find(d => {
       return (
         d.overrideDate &&
-        d.overrideDate >= startOfToday &&
+        startOfToday <= d.overrideDate &&
         d.overrideDate <= upcomingUntil
       );
     });

--- a/common/services/prismic/opening-times.ts
+++ b/common/services/prismic/opening-times.ts
@@ -62,9 +62,8 @@ export function exceptionalOpeningPeriods(
       } else if (
         previousDate &&
         date.overrideDate &&
-        london(date.overrideDate).isBefore(
-          london(previousDate).clone().add(6, 'days')
-        ) &&
+        date.overrideDate <
+          london(previousDate).clone().add(6, 'days').toDate() &&
         date.overrideType === acc[groupedIndex].type
       ) {
         acc[groupedIndex].dates.push(date.overrideDate);

--- a/common/services/prismic/opening-times.ts
+++ b/common/services/prismic/opening-times.ts
@@ -242,11 +242,11 @@ export function getTodaysVenueHours(
   venue: Venue
 ): ExceptionalOpeningHoursDay | OpeningHoursDay | undefined {
   const todaysDate = london();
-  const todayString = todaysDate.format('dddd');
+  const todayString = formatDay(todaysDate);
   const exceptionalOpeningHours =
     venue.openingHours.exceptional &&
     venue.openingHours.exceptional.find(i =>
-      todaysDate.startOf('day').isSame(london(i.overrideDate).startOf('day'))
+      isSameDay(todaysDate.toDate(), i.overrideDate)
     );
   const regularOpeningHours =
     venue.openingHours.regular &&

--- a/common/services/prismic/opening-times.ts
+++ b/common/services/prismic/opening-times.ts
@@ -9,7 +9,7 @@ import {
   ExceptionalOpeningHoursDay,
 } from '../../model/opening-hours';
 import { isNotUndefined } from '../../utils/array';
-import { isSameDay } from '../../utils/dates';
+import { dayBefore, isSameDay } from '../../utils/dates';
 
 export function exceptionalOpeningDates(venues: Venue[]): OverrideDate[] {
   return venues
@@ -199,25 +199,20 @@ export function groupConsecutiveExceptionalDays(
   dates: ExceptionalOpeningHoursDay[]
 ): ExceptionalOpeningHoursDay[][] {
   return dates
-    .sort(
-      (a, b) =>
-        (a.overrideDate &&
-          london(a.overrideDate).diff(b.overrideDate, 'days')) ??
-        0
-    )
+    .sort((a, b) => (a.overrideDate > b.overrideDate ? 1 : -1))
     .reduce((acc, date) => {
       const group = acc[acc.length - 1];
+      const lastDayOfGroup = group && group[group.length - 1]?.overrideDate;
+
       if (
-        !group ||
-        london(date.overrideDate).diff(
-          group[group.length - 1]?.overrideDate,
-          'days'
-        ) > 1
+        lastDayOfGroup &&
+        isSameDay(dayBefore(date.overrideDate), lastDayOfGroup)
       ) {
-        acc.push([date]);
-      } else {
         group.push(date);
+      } else {
+        acc.push([date]);
       }
+
       return acc;
     }, [] as ExceptionalOpeningHoursDay[][]);
 }

--- a/common/services/prismic/opening-times.ts
+++ b/common/services/prismic/opening-times.ts
@@ -220,12 +220,15 @@ export function groupConsecutiveExceptionalDays(
 export function getUpcomingExceptionalPeriods(
   exceptionalPeriods: ExceptionalOpeningHoursDay[][]
 ): ExceptionalOpeningHoursDay[][] {
+  const startOfToday = london().startOf('day').toDate();
+  const upcomingUntil = london().add(28, 'day').endOf('day').toDate();
+
   const nextUpcomingPeriods = exceptionalPeriods.filter(period => {
     const upcomingPeriod = period.find(d => {
       return (
         d.overrideDate &&
-        london(d.overrideDate).isSameOrBefore(london().add(28, 'day'), 'day') &&
-        london(d.overrideDate).isSameOrAfter(london(), 'day')
+        d.overrideDate >= startOfToday &&
+        d.overrideDate <= upcomingUntil
       );
     });
     return upcomingPeriod || false;

--- a/common/services/prismic/opening-times.ts
+++ b/common/services/prismic/opening-times.ts
@@ -34,7 +34,7 @@ export function exceptionalOpeningDates(venues: Venue[]): OverrideDate[] {
       if (!i) {
         return true;
       } else if (firstDate && prevDate) {
-        return isSameDay(firstDate, prevDate);
+        return !isSameDay(firstDate, prevDate);
       }
     });
 }

--- a/common/services/prismic/opening-times.ts
+++ b/common/services/prismic/opening-times.ts
@@ -223,13 +223,9 @@ export function getUpcomingExceptionalPeriods(
   const upcomingUntil = london().add(28, 'day').endOf('day').toDate();
 
   const nextUpcomingPeriods = exceptionalPeriods.filter(period => {
-    const upcomingPeriod = period.find(d => {
-      return (
-        d.overrideDate &&
-        startOfToday <= d.overrideDate &&
-        d.overrideDate <= upcomingUntil
-      );
-    });
+    const upcomingPeriod = period.find(
+      d => startOfToday <= d.overrideDate && d.overrideDate <= upcomingUntil
+    );
     return upcomingPeriod || false;
   });
   return nextUpcomingPeriods;

--- a/common/services/prismic/transformers/collection-venues.ts
+++ b/common/services/prismic/transformers/collection-venues.ts
@@ -45,7 +45,7 @@ export function transformCollectionVenue(
           const end = modified.endDateTime;
           const isClosed = !start;
           const overrideDate = modified.overrideDate
-            ? london(modified.overrideDate)
+            ? london(modified.overrideDate).toDate()
             : undefined;
           const overrideType = modified.type ?? 'other';
           if (overrideDate) {
@@ -102,7 +102,7 @@ export function fixVenueDatesInJson(venue: Venue): Venue {
       ...venue.openingHours,
       exceptional: venue.openingHours.exceptional.map(exceptionalOpening => ({
         ...exceptionalOpening,
-        overrideDate: london(exceptionalOpening.overrideDate),
+        overrideDate: new Date(exceptionalOpening.overrideDate),
       })),
     },
   };

--- a/common/services/prismic/transformers/collection-venues.ts
+++ b/common/services/prismic/transformers/collection-venues.ts
@@ -44,7 +44,8 @@ export function transformCollectionVenue(
           const start = modified.startDateTime;
           const end = modified.endDateTime;
           const isClosed = !start;
-          const overrideDate = modified.overrideDate;
+          const overrideDate =
+            modified.overrideDate && new Date(modified.overrideDate);
           const overrideType = modified.type ?? 'other';
           if (overrideDate) {
             return {

--- a/common/services/prismic/transformers/collection-venues.ts
+++ b/common/services/prismic/transformers/collection-venues.ts
@@ -2,7 +2,7 @@ import {
   ResultsLite,
   CollectionVenuePrismicDocumentLite,
 } from '../../../server-data/prismic';
-import { formatTime, london } from '../../../utils/format-date';
+import { formatTime } from '../../../utils/format-date';
 import { Day, Venue, OpeningHoursDay } from '../../../model/opening-hours';
 import {
   CollectionVenuePrismicDocument,
@@ -44,9 +44,7 @@ export function transformCollectionVenue(
           const start = modified.startDateTime;
           const end = modified.endDateTime;
           const isClosed = !start;
-          const overrideDate = modified.overrideDate
-            ? london(modified.overrideDate).toDate()
-            : undefined;
+          const overrideDate = modified.overrideDate;
           const overrideType = modified.type ?? 'other';
           if (overrideDate) {
             return {

--- a/common/test/fixtures/components/galleries-venue.ts
+++ b/common/test/fixtures/components/galleries-venue.ts
@@ -1,4 +1,3 @@
-import { london } from '../../../utils/format-date';
 import { Venue } from '../../../model/opening-hours';
 
 export const galleriesVenue: Venue = {
@@ -52,49 +51,49 @@ export const galleriesVenue: Venue = {
     ],
     exceptional: [
       {
-        overrideDate: london('2022-01-01'),
+        overrideDate: new Date('2022-01-01'),
         overrideType: 'Christmas and New Year',
         opens: '12:00',
         closes: '14:00',
         isClosed: false,
       },
       {
-        overrideDate: london('2021-12-31'),
+        overrideDate: new Date('2021-12-31'),
         overrideType: 'Christmas and New Year',
         opens: '00:00',
         closes: '00:00',
         isClosed: true,
       },
       {
-        overrideDate: london('2021-12-20'),
+        overrideDate: new Date('2021-12-20'),
         overrideType: 'Christmas and New Year',
         opens: '00:00',
         closes: '00:00',
         isClosed: true,
       },
       {
-        overrideDate: london('2022-02-04'),
+        overrideDate: new Date('2022-02-04'),
         overrideType: 'Bank holiday',
         opens: '00:00',
         closes: '00:00',
         isClosed: true,
       },
       {
-        overrideDate: london('2022-02-05'),
+        overrideDate: new Date('2022-02-05'),
         overrideType: 'Bank holiday',
         opens: '00:00',
         closes: '00:00',
         isClosed: true,
       },
       {
-        overrideDate: london('2021-01-05'),
+        overrideDate: new Date('2021-01-05'),
         overrideType: 'Bank holiday',
         opens: '00:00',
         closes: '00:00',
         isClosed: true,
       },
       {
-        overrideDate: london('2022-12-31'),
+        overrideDate: new Date('2022-12-31'),
         overrideType: 'Christmas and New Year',
         opens: '10:00',
         closes: '14:00',

--- a/common/test/fixtures/components/library-venue.ts
+++ b/common/test/fixtures/components/library-venue.ts
@@ -1,4 +1,3 @@
-import { london } from '../../../utils/format-date';
 import { Venue } from '../../../model/opening-hours';
 
 export const libraryVenue: Venue = {
@@ -52,28 +51,28 @@ export const libraryVenue: Venue = {
     ],
     exceptional: [
       {
-        overrideDate: london('2023-01-01'),
+        overrideDate: new Date('2023-01-01'),
         overrideType: 'Christmas and New Year',
         opens: '20:00',
         closes: '21:00',
         isClosed: false,
       },
       {
-        overrideDate: london('2022-12-31'),
+        overrideDate: new Date('2022-12-31'),
         overrideType: 'Christmas and New Year',
         opens: '00:00',
         closes: '00:00',
         isClosed: true,
       },
       {
-        overrideDate: london('2022-12-30'),
+        overrideDate: new Date('2022-12-30'),
         overrideType: 'Christmas and New Year',
         opens: '00:00',
         closes: '00:00',
         isClosed: true,
       },
       {
-        overrideDate: london('2022-12-28'),
+        overrideDate: new Date('2022-12-28'),
         overrideType: 'Christmas and New Year',
         opens: '00:00',
         closes: '00:00',

--- a/common/test/fixtures/components/restaurant-venue.ts
+++ b/common/test/fixtures/components/restaurant-venue.ts
@@ -1,7 +1,6 @@
-import { london } from '../../../utils/format-date';
 import { Venue } from '../../../model/opening-hours';
 
-export const restaurantVenue = {
+export const restaurantVenue: Venue = {
   id: 'WsuYER8AAOG_NyBA',
   order: 3,
   name: 'Restaurant',
@@ -52,7 +51,7 @@ export const restaurantVenue = {
     ],
     exceptional: [
       {
-        overrideDate: london('2022-04-10'),
+        overrideDate: new Date('2022-04-10'),
         overrideType: 'other',
         opens: '00:00',
         closes: '00:00',
@@ -61,4 +60,4 @@ export const restaurantVenue = {
     ],
   },
   linkText: 'Explore the menus',
-} as Venue;
+};

--- a/common/test/services/prismic/opening-times.test.ts
+++ b/common/test/services/prismic/opening-times.test.ts
@@ -10,6 +10,7 @@ import {
   getVenueById,
   getTodaysVenueHours,
   groupConsecutiveExceptionalDays,
+  getVenueHours,
 } from '../../../services/prismic/opening-times';
 import { venues } from '../../../test/fixtures/components/venues';
 import { ExceptionalOpeningHoursDay } from '../../../model/opening-hours';
@@ -643,7 +644,7 @@ describe('opening-times', () => {
 
       const result = getTodaysVenueHours(libraryVenue!);
       expect(result).toEqual({
-        overrideDate: london('2023-01-01'),
+        overrideDate: new Date('2023-01-01'),
         overrideType: 'Christmas and New Year',
         opens: '20:00',
         closes: '21:00',

--- a/common/test/services/prismic/opening-times.test.ts
+++ b/common/test/services/prismic/opening-times.test.ts
@@ -41,47 +41,47 @@ describe('opening-times', () => {
       const result = exceptionalOpeningDates(venues);
       expect(result).toEqual([
         {
-          overrideDate: london('2021-01-05'),
+          overrideDate: new Date('2021-01-05'),
           overrideType: 'Bank holiday',
         },
         {
-          overrideDate: london('2021-12-20'),
+          overrideDate: new Date('2021-12-20'),
           overrideType: 'Christmas and New Year',
         },
         {
-          overrideDate: london('2021-12-31'),
+          overrideDate: new Date('2021-12-31'),
           overrideType: 'Christmas and New Year',
         },
         {
-          overrideDate: london('2022-01-01'),
+          overrideDate: new Date('2022-01-01'),
           overrideType: 'Christmas and New Year',
         },
         {
-          overrideDate: london('2022-02-04'),
+          overrideDate: new Date('2022-02-04'),
           overrideType: 'Bank holiday',
         },
         {
-          overrideDate: london('2022-02-05'),
+          overrideDate: new Date('2022-02-05'),
           overrideType: 'Bank holiday',
         },
         {
-          overrideDate: london('2022-04-10'),
+          overrideDate: new Date('2022-04-10'),
           overrideType: 'other',
         },
         {
-          overrideDate: london('2022-12-28'),
+          overrideDate: new Date('2022-12-28'),
           overrideType: 'Christmas and New Year',
         },
         {
-          overrideDate: london('2022-12-30'),
+          overrideDate: new Date('2022-12-30'),
           overrideType: 'Christmas and New Year',
         },
         {
-          overrideDate: london('2022-12-31'),
+          overrideDate: new Date('2022-12-31'),
           overrideType: 'Christmas and New Year',
         },
         {
-          overrideDate: london('2023-01-01'),
+          overrideDate: new Date('2023-01-01'),
           overrideType: 'Christmas and New Year',
         },
       ]);
@@ -203,16 +203,16 @@ describe('opening-times', () => {
         {
           type: 'Christmas and New Year',
           dates: [
-            london('2020-12-25'),
-            london('2020-12-28'),
-            london('2021-01-01'),
-            london('2021-01-03'),
+            new Date('2020-12-25'),
+            new Date('2020-12-28'),
+            new Date('2021-01-01'),
+            new Date('2021-01-03'),
           ],
         },
       ]);
       expect(result[0].dates.length).toEqual(10);
-      expect(result[0].dates[2].isSame(london('2020-12-27'))).toBe(true);
-      expect(result[0].dates[5].isSame(london('2020-12-30'))).toBe(true);
+      expect(result[0].dates[2]).toEqual(new Date('2020-12-27'));
+      expect(result[0].dates[5]).toEqual(new Date('2020-12-30'));
     });
   });
 
@@ -221,49 +221,49 @@ describe('opening-times', () => {
       const result = getExceptionalVenueDays(galleriesVenue!);
       expect(result).toEqual([
         {
-          overrideDate: london('2022-01-01'),
+          overrideDate: new Date('2022-01-01'),
           overrideType: 'Christmas and New Year',
           opens: '12:00',
           closes: '14:00',
           isClosed: false,
         },
         {
-          overrideDate: london('2021-12-31'),
+          overrideDate: new Date('2021-12-31'),
           overrideType: 'Christmas and New Year',
           opens: '00:00',
           closes: '00:00',
           isClosed: true,
         },
         {
-          overrideDate: london('2021-12-20'),
+          overrideDate: new Date('2021-12-20'),
           overrideType: 'Christmas and New Year',
           opens: '00:00',
           closes: '00:00',
           isClosed: true,
         },
         {
-          overrideDate: london('2022-02-04'),
+          overrideDate: new Date('2022-02-04'),
           overrideType: 'Bank holiday',
           opens: '00:00',
           closes: '00:00',
           isClosed: true,
         },
         {
-          overrideDate: london('2022-02-05'),
+          overrideDate: new Date('2022-02-05'),
           overrideType: 'Bank holiday',
           opens: '00:00',
           closes: '00:00',
           isClosed: true,
         },
         {
-          overrideDate: london('2021-01-05'),
+          overrideDate: new Date('2021-01-05'),
           overrideType: 'Bank holiday',
           opens: '00:00',
           closes: '00:00',
           isClosed: true,
         },
         {
-          overrideDate: london('2022-12-31'),
+          overrideDate: new Date('2022-12-31'),
           overrideType: 'Christmas and New Year',
           opens: '10:00',
           closes: '14:00',
@@ -277,49 +277,49 @@ describe('opening-times', () => {
     it('groups exceptional days, so that each day within a group fall within 14 days of the first day', () => {
       const exceptionalDays: ExceptionalOpeningHoursDay[] = [
         {
-          overrideDate: london('2021-12-21'),
+          overrideDate: new Date('2021-12-21'),
           overrideType: 'Bank holiday',
           opens: '00:00',
           closes: '00:00',
           isClosed: true,
         },
         {
-          overrideDate: london('2022-12-28'),
+          overrideDate: new Date('2022-12-28'),
           overrideType: 'Christmas and New Year',
           opens: '00:00',
           closes: '00:00',
           isClosed: true,
         },
         {
-          overrideDate: london('2022-12-29'),
+          overrideDate: new Date('2022-12-29'),
           overrideType: 'Bank holiday',
           opens: '00:00',
           closes: '00:00',
           isClosed: true,
         },
         {
-          overrideDate: london('2021-12-29'),
+          overrideDate: new Date('2021-12-29'),
           overrideType: 'Bank holiday',
           opens: '00:00',
           closes: '00:00',
           isClosed: true,
         },
         {
-          overrideDate: london('2022-12-30'),
+          overrideDate: new Date('2022-12-30'),
           overrideType: 'Christmas and New Year',
           opens: '00:00',
           closes: '00:00',
           isClosed: true,
         },
         {
-          overrideDate: london('2022-12-31'),
+          overrideDate: new Date('2022-12-31'),
           overrideType: 'Christmas and New Year',
           opens: '00:00',
           closes: '00:00',
           isClosed: true,
         },
         {
-          overrideDate: london('2023-01-01'),
+          overrideDate: new Date('2023-01-01'),
           overrideType: 'Christmas and New Year',
           opens: '20:00',
           closes: '21:00',
@@ -331,14 +331,14 @@ describe('opening-times', () => {
       expect(result).toEqual([
         [
           {
-            overrideDate: london('2021-12-21'),
+            overrideDate: new Date('2021-12-21'),
             overrideType: 'Bank holiday',
             opens: '00:00',
             closes: '00:00',
             isClosed: true,
           },
           {
-            overrideDate: london('2021-12-29'),
+            overrideDate: new Date('2021-12-29'),
             overrideType: 'Bank holiday',
             opens: '00:00',
             closes: '00:00',
@@ -347,35 +347,35 @@ describe('opening-times', () => {
         ],
         [
           {
-            overrideDate: london('2022-12-28'),
+            overrideDate: new Date('2022-12-28'),
             overrideType: 'Christmas and New Year',
             opens: '00:00',
             closes: '00:00',
             isClosed: true,
           },
           {
-            overrideDate: london('2022-12-29'),
+            overrideDate: new Date('2022-12-29'),
             overrideType: 'Bank holiday',
             opens: '00:00',
             closes: '00:00',
             isClosed: true,
           },
           {
-            overrideDate: london('2022-12-30'),
+            overrideDate: new Date('2022-12-30'),
             overrideType: 'Christmas and New Year',
             opens: '00:00',
             closes: '00:00',
             isClosed: true,
           },
           {
-            overrideDate: london('2022-12-31'),
+            overrideDate: new Date('2022-12-31'),
             overrideType: 'Christmas and New Year',
             opens: '00:00',
             closes: '00:00',
             isClosed: true,
           },
           {
-            overrideDate: london('2023-01-01'),
+            overrideDate: new Date('2023-01-01'),
             overrideType: 'Christmas and New Year',
             opens: '20:00',
             closes: '21:00',
@@ -390,12 +390,12 @@ describe('opening-times', () => {
     it('returns an ExceptionalOpeningHoursDay type for a particular date and venue, generated from the regular hours of that venue.', () => {
       const result = exceptionalFromRegular(
         libraryVenue!,
-        london('2021-12-21'),
+        new Date('2021-12-21'),
         'Bank holiday'
       );
 
       expect(result).toEqual({
-        overrideDate: london('2021-12-21'),
+        overrideDate: new Date('2021-12-21'),
         overrideType: 'Bank holiday',
         opens: '10:00',
         closes: '18:00',
@@ -410,59 +410,59 @@ describe('opening-times', () => {
         {
           type: 'Christmas and New Year',
           dates: [
-            london('2022-12-28'),
-            london('2022-12-29'),
-            london('2022-12-30'),
-            london('2022-12-31'),
-            london('2023-01-01'),
-            london('2023-01-02'),
+            new Date('2022-12-28'),
+            new Date('2022-12-29'),
+            new Date('2022-12-30'),
+            new Date('2022-12-31'),
+            new Date('2023-01-01'),
+            new Date('2023-01-02'),
           ],
         },
         {
           type: 'Bank holiday',
-          dates: [london('2021-10-05')],
+          dates: [new Date('2021-10-05')],
         },
       ]);
 
       expect(result).toEqual([
         [
           {
-            overrideDate: london('2022-12-28'),
+            overrideDate: new Date('2022-12-28'),
             overrideType: 'Christmas and New Year',
             opens: '00:00',
             closes: '00:00',
             isClosed: true,
           },
           {
-            overrideDate: london('2022-12-29'),
+            overrideDate: new Date('2022-12-29'),
             overrideType: 'Christmas and New Year',
             opens: '10:00',
             closes: '20:00',
             isClosed: false,
           },
           {
-            overrideDate: london('2022-12-30'),
+            overrideDate: new Date('2022-12-30'),
             overrideType: 'Christmas and New Year',
             opens: '00:00',
             closes: '00:00',
             isClosed: true,
           },
           {
-            overrideDate: london('2022-12-31'),
+            overrideDate: new Date('2022-12-31'),
             overrideType: 'Christmas and New Year',
             opens: '00:00',
             closes: '00:00',
             isClosed: true,
           },
           {
-            overrideDate: london('2023-01-01'),
+            overrideDate: new Date('2023-01-01'),
             overrideType: 'Christmas and New Year',
             opens: '20:00',
             closes: '21:00',
             isClosed: false,
           },
           {
-            overrideDate: london('2023-01-02'),
+            overrideDate: new Date('2023-01-02'),
             overrideType: 'Christmas and New Year',
             opens: '00:00',
             closes: '00:00',
@@ -471,7 +471,7 @@ describe('opening-times', () => {
         ],
         [
           {
-            overrideDate: london('2021-10-05'),
+            overrideDate: new Date('2021-10-05'),
             overrideType: 'Bank holiday',
             opens: '10:00',
             closes: '18:00',
@@ -486,18 +486,18 @@ describe('opening-times', () => {
       const result = backfillExceptionalVenueDays(libraryVenue!, [
         {
           type: 'Bank holiday',
-          dates: [london('2021-10-05')],
+          dates: [new Date('2021-10-05')],
         },
         {
           type: 'other',
-          dates: [london('2021-10-08')],
+          dates: [new Date('2021-10-08')],
         },
       ]);
 
       expect(result).toEqual([
         [
           {
-            overrideDate: london('2021-10-05'),
+            overrideDate: new Date('2021-10-05'),
             overrideType: 'Bank holiday',
             opens: '10:00',
             closes: '18:00',

--- a/common/test/services/prismic/opening-times.test.ts
+++ b/common/test/services/prismic/opening-times.test.ts
@@ -513,28 +513,28 @@ describe('opening-times', () => {
     const exceptionalPeriods: ExceptionalOpeningHoursDay[][] = [
       [
         {
-          overrideDate: london('2021-12-29'),
+          overrideDate: new Date('2021-12-29'),
           overrideType: 'Christmas and New Year',
           opens: '00:00',
           closes: '00:00',
           isClosed: true,
         },
         {
-          overrideDate: london('2021-12-30'),
+          overrideDate: new Date('2021-12-30'),
           overrideType: 'Christmas and New Year',
           opens: '00:00',
           closes: '00:00',
           isClosed: true,
         },
         {
-          overrideDate: london('2021-12-31'),
+          overrideDate: new Date('2021-12-31'),
           overrideType: 'Christmas and New Year',
           opens: '00:00',
           closes: '00:00',
           isClosed: true,
         },
         {
-          overrideDate: london('2022-01-01'),
+          overrideDate: new Date('2022-01-01'),
           overrideType: 'Christmas and New Year',
           opens: '12:00',
           closes: '14:00',
@@ -543,14 +543,14 @@ describe('opening-times', () => {
       ],
       [
         {
-          overrideDate: london('2022-02-04'),
+          overrideDate: new Date('2022-02-04'),
           overrideType: 'Bank holiday',
           opens: '00:00',
           closes: '00:00',
           isClosed: true,
         },
         {
-          overrideDate: london('2022-02-05'),
+          overrideDate: new Date('2022-02-05'),
           overrideType: 'Bank holiday',
           opens: '00:00',
           closes: '00:00',
@@ -579,28 +579,28 @@ describe('opening-times', () => {
       expect(result).toEqual([
         [
           {
-            overrideDate: london('2021-12-29'),
+            overrideDate: new Date('2021-12-29'),
             overrideType: 'Christmas and New Year',
             opens: '00:00',
             closes: '00:00',
             isClosed: true,
           },
           {
-            overrideDate: london('2021-12-30'),
+            overrideDate: new Date('2021-12-30'),
             overrideType: 'Christmas and New Year',
             opens: '00:00',
             closes: '00:00',
             isClosed: true,
           },
           {
-            overrideDate: london('2021-12-31'),
+            overrideDate: new Date('2021-12-31'),
             overrideType: 'Christmas and New Year',
             opens: '00:00',
             closes: '00:00',
             isClosed: true,
           },
           {
-            overrideDate: london('2022-01-01'),
+            overrideDate: new Date('2022-01-01'),
             overrideType: 'Christmas and New Year',
             opens: '12:00',
             closes: '14:00',

--- a/common/test/services/prismic/opening-times.test.ts
+++ b/common/test/services/prismic/opening-times.test.ts
@@ -655,42 +655,42 @@ describe('opening-times', () => {
     it('puts consecutive exceptional dates into groups', () => {
       const result = groupConsecutiveExceptionalDays([
         {
-          overrideDate: london('2022-01-01'),
+          overrideDate: new Date('2022-01-01'),
           overrideType: 'Christmas and New Year',
           opens: '12:00',
           closes: '14:00',
           isClosed: false,
         },
         {
-          overrideDate: london('2021-12-31'),
+          overrideDate: new Date('2021-12-31'),
           overrideType: 'Christmas and New Year',
           opens: '00:00',
           closes: '00:00',
           isClosed: true,
         },
         {
-          overrideDate: london('2022-02-05'),
+          overrideDate: new Date('2022-02-05'),
           overrideType: 'Bank holiday',
           opens: '00:00',
           closes: '00:00',
           isClosed: true,
         },
         {
-          overrideDate: london('2021-12-30'),
+          overrideDate: new Date('2021-12-30'),
           overrideType: 'Christmas and New Year',
           opens: '00:00',
           closes: '00:00',
           isClosed: true,
         },
         {
-          overrideDate: london('2021-12-29'),
+          overrideDate: new Date('2021-12-29'),
           overrideType: 'Christmas and New Year',
           opens: '00:00',
           closes: '00:00',
           isClosed: true,
         },
         {
-          overrideDate: london('2022-02-04'),
+          overrideDate: new Date('2022-02-04'),
           overrideType: 'Bank holiday',
           opens: '00:00',
           closes: '00:00',
@@ -701,28 +701,28 @@ describe('opening-times', () => {
       expect(result).toEqual([
         [
           {
-            overrideDate: london('2021-12-29'),
+            overrideDate: new Date('2021-12-29'),
             overrideType: 'Christmas and New Year',
             opens: '00:00',
             closes: '00:00',
             isClosed: true,
           },
           {
-            overrideDate: london('2021-12-30'),
+            overrideDate: new Date('2021-12-30'),
             overrideType: 'Christmas and New Year',
             opens: '00:00',
             closes: '00:00',
             isClosed: true,
           },
           {
-            overrideDate: london('2021-12-31'),
+            overrideDate: new Date('2021-12-31'),
             overrideType: 'Christmas and New Year',
             opens: '00:00',
             closes: '00:00',
             isClosed: true,
           },
           {
-            overrideDate: london('2022-01-01'),
+            overrideDate: new Date('2022-01-01'),
             overrideType: 'Christmas and New Year',
             opens: '12:00',
             closes: '14:00',
@@ -731,14 +731,14 @@ describe('opening-times', () => {
         ],
         [
           {
-            overrideDate: london('2022-02-04'),
+            overrideDate: new Date('2022-02-04'),
             overrideType: 'Bank holiday',
             opens: '00:00',
             closes: '00:00',
             isClosed: true,
           },
           {
-            overrideDate: london('2022-02-05'),
+            overrideDate: new Date('2022-02-05'),
             overrideType: 'Bank holiday',
             opens: '00:00',
             closes: '00:00',

--- a/common/utils/dates.test.ts
+++ b/common/utils/dates.test.ts
@@ -1,5 +1,5 @@
 import each from 'jest-each';
-import { isFuture, isPast, isSameDay, isSameMonth } from './dates';
+import { dayBefore, isFuture, isPast, isSameDay, isSameMonth } from './dates';
 
 it('identifies dates in the past', () => {
   expect(isPast(new Date(2001, 1, 1, 1, 1, 1, 999))).toEqual(true);
@@ -85,5 +85,15 @@ describe('isSameMonth', () => {
   ]).test('identifies %s and %s as different', (a, b) => {
     const result = isSameMonth(a, b);
     expect(result).toEqual(false);
+  });
+});
+
+describe('dayBefore', () => {
+  test.each([
+    { day: new Date('2022-09-02'), prevDay: new Date('2022-09-01') },
+    { day: new Date('2022-09-01'), prevDay: new Date('2022-08-31') },
+    { day: new Date('2022-01-01'), prevDay: new Date('2021-12-31') },
+  ])('the day before $day is $prevDay', ({ day, prevDay }) => {
+    expect(dayBefore(day)).toStrictEqual(prevDay);
   });
 });

--- a/common/utils/dates.ts
+++ b/common/utils/dates.ts
@@ -47,6 +47,13 @@ export function isDayPast(date: Date): boolean {
   }
 }
 
+// Returns the day before the current date
+export function dayBefore(date: Date): Date {
+  const prevDay = new Date(date);
+  prevDay.setDate(date.getDate() - 1);
+  return prevDay;
+}
+
 export function getNextWeekendDateRange(date: DateTypes): DateRange {
   const today = london(date);
   const todayInteger = today.day(); // day() return Sun as 0, Sat as 6

--- a/common/utils/format-date.test.ts
+++ b/common/utils/format-date.test.ts
@@ -9,33 +9,33 @@ import {
 } from './format-date';
 
 it('formats a day', () => {
-  const result = formatDay(new Date(2001, 1, 1, 1, 1, 1));
+  const result = formatDay(new Date('2001-01-01'));
 
-  expect(result).toEqual('Thursday');
+  expect(result).toEqual('Monday');
 });
 
 it('formats a day with a date', () => {
-  const result = formatDayDate(new Date(2001, 2, 3, 1, 1, 1));
+  const result = formatDayDate(new Date('2001-02-03'));
 
-  expect(result).toEqual('Saturday 3 March 2001');
+  expect(result).toEqual('Saturday 3 February 2001');
 });
 
 it('formats a date', () => {
-  const result = formatDate(new Date(2009, 3, 27, 1, 1, 1));
+  const result = formatDate(new Date('2009-03-27'));
 
-  expect(result).toEqual('27 April 2009');
+  expect(result).toEqual('27 March 2009');
 });
 
 it('formats a timestamp', () => {
-  const result1 = formatTime(new Date(2009, 3, 27, 17, 21, 1));
-  expect(result1).toEqual('18:21');
+  const result1 = formatTime(new Date('2009-03-27T17:21:01Z'));
+  expect(result1).toEqual('17:21');
 
-  const result2 = formatTime(new Date(2009, 3, 27, 9, 41, 1));
-  expect(result2).toEqual('10:41');
+  const result2 = formatTime(new Date('2009-03-27T09:41:01Z'));
+  expect(result2).toEqual('09:41');
 });
 
 it('formats a year', () => {
-  const result = formatYear(new Date(2009, 3, 27, 1, 1, 1));
+  const result = formatYear(new Date('2009-03-27T01:01:01Z'));
 
   expect(result).toEqual('2009');
 });

--- a/common/utils/json-ld.ts
+++ b/common/utils/json-ld.ts
@@ -7,6 +7,7 @@ import type {
   OpeningHoursDay,
   SpecialOpeningHours,
 } from '../model/opening-hours';
+import { formatDate } from './format-date';
 
 type ObjToJsonLdProps = { type: string; root?: boolean };
 
@@ -113,8 +114,8 @@ export function openingHoursLd(openingHours: OpeningHours | undefined): {
           const specObject = {
             opens: openingHoursDate.opens,
             closes: openingHoursDate.closes,
-            validFrom: openingHoursDate.overrideDate?.format('DD MMMM YYYY'),
-            validThrough: openingHoursDate.overrideDate?.format('DD MMMM YYYY'),
+            validFrom: formatDate(openingHoursDate.overrideDate),
+            validThrough: formatDate(openingHoursDate.overrideDate),
           };
           return objToJsonLd(specObject, {
             type: 'OpeningHoursSpecification',

--- a/content/webapp/components/VenueClosedPeriods/VenueClosedPeriods.tsx
+++ b/content/webapp/components/VenueClosedPeriods/VenueClosedPeriods.tsx
@@ -36,10 +36,10 @@ const VenueClosedPeriods: FunctionComponent<Props> = ({ venue }) => {
 
       <ul>
         {groupedConsectiveClosedDays.map((closedGroup, i) => {
-          const firstDate = closedGroup[0].overrideDate?.toDate();
+          const firstDate = closedGroup[0].overrideDate;
           const lastDate =
             closedGroup.length > 1
-              ? closedGroup[closedGroup.length - 1].overrideDate?.toDate()
+              ? closedGroup[closedGroup.length - 1].overrideDate
               : undefined;
           return (
             closedGroup.length > 0 && (

--- a/content/webapp/components/VenueHours/VenueHours.tsx
+++ b/content/webapp/components/VenueHours/VenueHours.tsx
@@ -202,8 +202,8 @@ const VenueHours: FunctionComponent<Props> = ({ venue, weight }) => {
               >
                 {upcomingExceptionalPeriod.map(p => (
                   <li key={p.overrideDate?.toString()}>
-                    {p.overrideDate && formatDay(p.overrideDate.toDate())}{' '}
-                    {p.overrideDate && formatDayMonth(p.overrideDate.toDate())}{' '}
+                    {p.overrideDate && formatDay(p.overrideDate)}{' '}
+                    {p.overrideDate && formatDayMonth(p.overrideDate)}{' '}
                     {p.isClosed ? 'Closed' : `${p.opens} – ${p.closes}`}
                   </li>
                 ))}


### PR DESCRIPTION
For https://github.com/wellcomecollection/wellcomecollection.org/issues/8364 and https://github.com/wellcomecollection/wellcomecollection.org/issues/7831

To sort out passing `Date` values to/from our props, we're going to use a superjson plugin for serialising JSON. It doesn't know how to serialise the `Moment` values we pass in the opening times, so I've modified the opening times model to use a `Date` object instead.

I've tried to be as conservative as I can, because date logic is so fiddly – but the existing suite of tests were super helpful in catching my mistakes. 💪 

I think this is mergeable as a standalone patch, and it opens the door to sorting out the superjson plugin in a new PR.

I've checked the opening times in the footer and on /opening-times, and both look correct.