### PR TITLE
Temp fix to debug rerouting on concept pages

### DIFF
--- a/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
+++ b/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
@@ -7,7 +7,7 @@ import { useRouter } from 'next/router';
 
 type Props = {
   images: CatalogueResultsList<Image>;
-  hasModal: boolean;
+  hasModal?: boolean;
 };
 
 const ImageEndpointSearchResults: FunctionComponent<Props> = ({
@@ -39,7 +39,7 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
   useEffect(() => {
     // If there is a set expandedImage and it's a different one than the current queried one
     // Change URL to reflect the change
-    if (!!expandedImage && routerImageId !== expandedImage.id) {
+    if (!!expandedImage && routerImageId !== expandedImage.id && hasModal) {
       router.push(
         `${router.pathname}?${page ? 'page=' + page + '&' : ''}imageId=${
           expandedImage.id
@@ -54,7 +54,7 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
 
   useEffect(() => {
     // If isActive changes to false, reset the URL to no imageId
-    if (!isActive) {
+    if (!isActive && hasModal) {
       router.push(
         `${router.pathname}${page ? '?page=' + page : ''}`,
         undefined,
@@ -68,7 +68,7 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
   useEffect(() => {
     // If there is an imageId in the query, fetch that image and display it
     // Otherwise ensure modal is closed and URL resets
-    routerImageId ? getImage(routerImageId) : setIsActive(false);
+    routerImageId && hasModal ? getImage(routerImageId) : setIsActive(false);
   }, [routerImageId]);
 
   return (

--- a/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
+++ b/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
@@ -7,10 +7,12 @@ import { useRouter } from 'next/router';
 
 type Props = {
   images: CatalogueResultsList<Image>;
+  hasModal: boolean;
 };
 
 const ImageEndpointSearchResults: FunctionComponent<Props> = ({
   images,
+  hasModal = true,
 }: Props) => {
   const router = useRouter();
   const { page, imageId: routerImageId } = router.query;
@@ -83,25 +85,29 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
               alt: '',
             }}
             onClick={event => {
-              event.preventDefault();
-              setExpandedImage(result);
-              setIsActive(true);
+              if (hasModal) {
+                event.preventDefault();
+                setExpandedImage(result);
+                setIsActive(true);
+              }
             }}
           />
         </li>
       ))}
-      <Modal
-        id={'expanded-image-dialog'}
-        isActive={isActive}
-        setIsActive={setIsActive}
-        width={'80vw'}
-      >
-        <ExpandedImage
-          resultPosition={expandedImagePosition}
-          image={expandedImage}
-          setExpandedImage={setExpandedImage}
-        />
-      </Modal>
+      {hasModal && (
+        <Modal
+          id={'expanded-image-dialog'}
+          isActive={isActive}
+          setIsActive={setIsActive}
+          width={'80vw'}
+        >
+          <ExpandedImage
+            resultPosition={expandedImagePosition}
+            image={expandedImage}
+            setExpandedImage={setExpandedImage}
+          />
+        </Modal>
+      )}
     </ul>
   );
 };

--- a/catalogue/webapp/pages/concept.tsx
+++ b/catalogue/webapp/pages/concept.tsx
@@ -58,9 +58,9 @@ const ConceptDescription = styled.section`
 // TODO use preset styles for sectionTitle?
 const ConceptImages = styled(Space)`
   background-color: ${props => props.theme.color('black')};
-  color: ${props => props.theme.color('white')};
 
   .sectionTitle {
+    color: ${props => props.theme.color('white')};
     font-size: 1.75rem;
     margin-bottom: 1.875rem;
   }
@@ -181,7 +181,7 @@ export const ConceptPage: NextPage<Props> = ({
             <h2 className="sectionTitle">Images</h2>
             {/* TODO images get a white border over a certain screen size */}
             {/* TODO mobile; smaller images? */}
-            <ImageEndpointSearchResults images={images} />
+            <ImageEndpointSearchResults images={images} hasModal={false} />
             <SeeMoreButton
               text={`All images (${images.totalResults})`}
               link={`/images?source.subjects.label=${conceptResponse.label}`}


### PR DESCRIPTION
## Who is this for?
Devs, designers

## What is it doing for them?
#8350 has made ImageEndpointSearchResults more navigable on `images`, but it clashes with the routing that's being done for `concepts/{id}`. Pages that have this component now get their URL to revert back to `concept`, which 404s.

This is a temporary fix, but we'll either need to revert that change and do it differently, or not allow modals on Concept pages.