### PR TITLE
Report the number of errors (or not) in the Prismic lint output

### DIFF
--- a/prismic-model/lintPrismicData.ts
+++ b/prismic-model/lintPrismicData.ts
@@ -67,11 +67,15 @@ function detectBrokenInterpretationTypeLinks(doc: any): string[] {
 async function run() {
   const snapshotDir = await downloadPrismicSnapshot();
 
+  let totalErrors = 0;
+
   for (const doc of getPrismicDocuments(snapshotDir)) {
     const errors = [
       ...detectEur01Safelinks(doc),
       ...detectBrokenInterpretationTypeLinks(doc),
     ];
+
+    totalErrors += errors.length;
 
     // If there are any errors, report them to the console.
     if (errors.length > 0) {
@@ -85,6 +89,15 @@ async function run() {
       }
       console.log('');
     }
+  }
+
+  if (totalErrors === 0) {
+    console.log(chalk.green('✅ No errors detected'));
+  } else {
+    console.log(
+      chalk.red(`🚨 ${totalErrors} error${totalErrors > 1 ? 's' : ''} detected`)
+    );
+    process.exit(1);
   }
 }
 


### PR DESCRIPTION
## Who is this for?

Devs.

## What is it doing for them?

Helping them to quantify the number of errors they're seeing.

<img width="1458" alt="Screenshot 2022-09-02 at 13 16 49" src="https://user-images.githubusercontent.com/301220/188142095-59568a8b-71d8-4335-a1e2-7e95a52497a5.png">


<img width="1458" alt="Screenshot 2022-09-02 at 13 23 50" src="https://user-images.githubusercontent.com/301220/188142077-9618ebec-63c7-47d8-b6f6-60b232c13fcd.png">
