### PR TITLE
Revert images routing changes

### DIFF
--- a/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
+++ b/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
@@ -1,9 +1,8 @@
-import { FunctionComponent, useEffect, useState } from 'react';
+import { FunctionComponent, useState } from 'react';
 import ExpandedImage from '../ExpandedImage/ExpandedImage';
 import ImageCard from '../ImageCard/ImageCard';
 import { Image, CatalogueResultsList } from '@weco/common/model/catalogue';
 import Modal from '@weco/common/views/components/Modal/Modal';
-import { useRouter } from 'next/router';
 
 type Props = {
   images: CatalogueResultsList<Image>;
@@ -12,9 +11,6 @@ type Props = {
 const ImageEndpointSearchResults: FunctionComponent<Props> = ({
   images,
 }: Props) => {
-  const router = useRouter();
-  const { page, imageId: routerImageId } = router.query;
-
   const [expandedImage, setExpandedImage] = useState<Image | undefined>();
   // In the case that the modal changes the expanded image to
   // be one that isn't on this results page, this index will be -1
@@ -22,52 +18,6 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
     img => expandedImage && img.id === expandedImage.id
   );
   const [isActive, setIsActive] = useState(false);
-
-  // Gets the image as it might not be in the current results, and displays it.
-  const getImage = async routerImageId => {
-    const apiUrl = `https://api.wellcomecollection.org/catalogue/v2/images/${routerImageId}`;
-    const image: Image = await fetch(apiUrl).then(res => res.json());
-
-    if (image) {
-      setExpandedImage(image);
-      setIsActive(true);
-    }
-  };
-
-  useEffect(() => {
-    // If there is a set expandedImage and it's a different one than the current queried one
-    // Change URL to reflect the change
-    if (!!expandedImage && routerImageId !== expandedImage.id) {
-      router.push(
-        `${router.pathname}?${page ? 'page=' + page + '&' : ''}imageId=${
-          expandedImage.id
-        }`,
-        undefined,
-        {
-          shallow: true,
-        }
-      );
-    }
-  }, [expandedImage]);
-
-  useEffect(() => {
-    // If isActive changes to false, reset the URL to no imageId
-    if (!isActive) {
-      router.push(
-        `${router.pathname}${page ? '?page=' + page : ''}`,
-        undefined,
-        {
-          shallow: true,
-        }
-      );
-    }
-  }, [isActive]);
-
-  useEffect(() => {
-    // If there is an imageId in the query, fetch that image and display it
-    // Otherwise ensure modal is closed and URL resets
-    routerImageId ? getImage(routerImageId) : setIsActive(false);
-  }, [routerImageId]);
 
   return (
     <ul className="flex flex--wrap plain-list no-padding no-margin" role="list">

--- a/catalogue/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.tsx
+++ b/catalogue/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.tsx
@@ -6,8 +6,6 @@ import { getImage } from '../../services/catalogue/images';
 import Space from '@weco/common/views/components/styled/Space';
 import { useToggles } from '@weco/common/server-data/Context';
 import IIIFImage from '../IIIFImage/IIIFImage';
-import { useRouter } from 'next/router';
-import Link from 'next/link';
 
 type Props = {
   originalId: string;
@@ -35,8 +33,6 @@ const VisuallySimilarImagesFromApi: FunctionComponent<Props> = ({
 }: Props) => {
   const [similarImages, setSimilarImages] = useState<ImageType[]>([]);
   const toggles = useToggles();
-  const router = useRouter();
-  const { page } = router.query;
 
   useEffect(() => {
     const fetchVisuallySimilarImages = async () => {
@@ -56,27 +52,18 @@ const VisuallySimilarImagesFromApi: FunctionComponent<Props> = ({
       <h3 className={font('wb', 5)}>Visually similar images</h3>
       <Wrapper>
         {similarImages.map(related => (
-          <Link
-            key={related.id}
-            href={`${router.pathname}?${
-              page ? 'page=' + page + '&' : ''
-            }imageId=${related.id}`}
-            shallow={true}
-            passHref
-          >
-            <a onClick={() => onClickImage(related)}>
-              <IIIFImage
-                layout="raw"
-                image={{
-                  contentUrl: related.locations[0]?.url,
-                  width: 180,
-                  height: 180,
-                  alt: '',
-                }}
-                width={180}
-              />
-            </a>
-          </Link>
+          <a key={related.id} onClick={() => onClickImage(related)} href="#">
+            <IIIFImage
+              layout="raw"
+              image={{
+                contentUrl: related.locations[0]?.url,
+                width: 180,
+                height: 180,
+                alt: '',
+              }}
+              width={180}
+            />
+          </a>
         ))}
       </Wrapper>
       <p


### PR DESCRIPTION
## Who is this for?
Users

## What is it doing for them?
Reverting the changes (#8350, [original PR here](https://github.com/wellcomecollection/wellcomecollection.org/pull/8351/files)) brings back the navigational "bug", but it wasn't a good fix. It introduced a new bug, clearing query parameters like filters. The ticket will be brought back and different options explored, but as this not good behaviour, better to revert for now to the old one.