### PR TITLE
Remove an unused parameter in getFeaturedMedia

### DIFF
--- a/content/webapp/utils/page-header.tsx
+++ b/content/webapp/utils/page-header.tsx
@@ -10,11 +10,9 @@ import { isVideoEmbed } from 'types/body';
 import { GenericContentFields } from '../types/generic-content-fields';
 
 export function getFeaturedMedia(
-  fields: GenericContentFields,
-  isPicture?: boolean
+  fields: GenericContentFields
 ): FeaturedMedia | undefined {
   const image = fields.promo && fields.promo.image;
-  const squareImage = getCrop(fields.image, 'square');
   const widescreenImage = getCrop(fields.image, '16:9');
   const { body } = fields;
 
@@ -23,14 +21,6 @@ export function getFeaturedMedia(
 
   const featuredMedia = featuredVideo ? (
     <VideoEmbed {...featuredVideo.value} />
-  ) : isPicture && widescreenImage && squareImage ? (
-    <Picture
-      images={[
-        { ...widescreenImage, minWidth: breakpoints.medium },
-        squareImage,
-      ]}
-      isFull={true}
-    />
   ) : widescreenImage ? (
     <ImageWithTasl
       Image={


### PR DESCRIPTION
If you look at where this function is used, we never pass a value for the `isPicture` parameter, so it's always `undefined`.  Let's remove it and save ourselves a few bytes.

✂️ ✂️ ✂️ 