### PR TITLE
Don't use Moment to construct our Prismic predicates

### DIFF
--- a/common/utils/dates.test.ts
+++ b/common/utils/dates.test.ts
@@ -1,5 +1,14 @@
 import each from 'jest-each';
-import { dayBefore, isFuture, isPast, isSameDay, isSameMonth } from './dates';
+import {
+  dayBefore,
+  endOfWeek,
+  isFuture,
+  isPast,
+  isSameDay,
+  isSameMonth,
+  startOfWeek,
+} from './dates';
+import { london } from './format-date';
 
 it('identifies dates in the past', () => {
   expect(isPast(new Date(2001, 1, 1, 1, 1, 1, 999))).toEqual(true);
@@ -96,4 +105,39 @@ describe('dayBefore', () => {
   ])('the day before $day is $prevDay', ({ day, prevDay }) => {
     expect(dayBefore(day)).toStrictEqual(prevDay);
   });
+});
+
+describe('startOfWeek', () => {
+  test.each([
+    { day: new Date('2022-09-02'), expectedStart: new Date('2022-08-28') },
+    { day: new Date('2022-09-01'), expectedStart: new Date('2022-08-28') },
+    { day: new Date('2022-08-28'), expectedStart: new Date('2022-08-28') },
+  ])(
+    'the start of the week containing $day is $expectedStart',
+    ({ day, expectedStart }) => {
+      expect(startOfWeek(day)).toStrictEqual(expectedStart);
+      console.log(
+        `${startOfWeek(day)}, ${london(day).startOf('week').toDate()}`
+      );
+      expect(
+        isSameDay(startOfWeek(day), london(day).startOf('week').toDate())
+      ).toBeTruthy();
+    }
+  );
+});
+
+describe('endOfWeek', () => {
+  test.each([
+    { day: new Date('2022-09-02'), expectedStart: new Date('2022-09-03') },
+    { day: new Date('2022-09-01'), expectedStart: new Date('2022-09-03') },
+    { day: new Date('2022-08-27'), expectedStart: new Date('2022-08-27') },
+  ])(
+    'the start of the week containing $day is $expectedStart',
+    ({ day, expectedStart }) => {
+      expect(endOfWeek(day)).toStrictEqual(expectedStart);
+      expect(
+        isSameDay(endOfWeek(day), london(day).endOf('week').toDate())
+      ).toBeTruthy();
+    }
+  );
 });

--- a/common/utils/dates.ts
+++ b/common/utils/dates.ts
@@ -47,13 +47,6 @@ export function isDayPast(date: Date): boolean {
   }
 }
 
-// Returns the day before the current date
-export function dayBefore(date: Date): Date {
-  const prevDay = new Date(date);
-  prevDay.setDate(date.getDate() - 1);
-  return prevDay;
-}
-
 export function getNextWeekendDateRange(date: DateTypes): DateRange {
   const today = london(date);
   const todayInteger = today.day(); // day() return Sun as 0, Sat as 6
@@ -66,4 +59,29 @@ export function getNextWeekendDateRange(date: DateTypes): DateRange {
     start: start.startOf('day').toDate(),
     end: end.endOf('day').toDate(),
   };
+}
+
+// Returns the day before the current date
+export function dayBefore(date: Date): Date {
+  const prevDay = new Date(date);
+  prevDay.setDate(date.getDate() - 1);
+  return prevDay;
+}
+
+export function startOfDay(d: Date): Date {
+  const res = new Date(d);
+  res.setUTCHours(0, 0, 0, 0);
+  return res;
+}
+
+export function endOfDay(d: Date): Date {
+  const res = new Date(d);
+  res.setUTCHours(23, 59, 59, 999);
+  return res;
+}
+
+export function addDays(d: Date, days: number): Date {
+  const res = new Date(d);
+  res.setDate(res.getDate() + days);
+  return res;
 }

--- a/common/utils/dates.ts
+++ b/common/utils/dates.ts
@@ -63,9 +63,7 @@ export function getNextWeekendDateRange(date: DateTypes): DateRange {
 
 // Returns the day before the current date
 export function dayBefore(date: Date): Date {
-  const prevDay = new Date(date);
-  prevDay.setDate(date.getDate() - 1);
-  return prevDay;
+  return addDays(date, -1);
 }
 
 export function startOfDay(d: Date): Date {
@@ -78,6 +76,16 @@ export function endOfDay(d: Date): Date {
   const res = new Date(d);
   res.setUTCHours(23, 59, 59, 999);
   return res;
+}
+
+// Get the start of the week; this assumes weeks start on a Sunday
+export function startOfWeek(d: Date): Date {
+  return addDays(d, -d.getDay());
+}
+
+// Get the start of the week; this assumes weeks start on a Sunday
+export function endOfWeek(d: Date): Date {
+  return addDays(d, 6 - d.getDay());
 }
 
 export function addDays(d: Date, days: number): Date {

--- a/content/webapp/services/prismic/events.ts
+++ b/content/webapp/services/prismic/events.ts
@@ -1,10 +1,13 @@
 import { Moment } from 'moment';
 import { london, formatDayDate } from '@weco/common/utils/format-date';
 import {
+  addDays,
+  endOfDay,
   getNextWeekendDateRange,
   isDayPast,
   isFuture,
   isPast,
+  startOfDay,
 } from '@weco/common/utils/dates';
 import { Event, EventBasic, HasTimes } from '../../types/events';
 import { isNotUndefined } from '@weco/common/utils/array';
@@ -42,24 +45,6 @@ function filterEventsByTimeRange(
       );
     });
   });
-}
-
-function startOfDay(d: Date): Date {
-  const res = new Date(d);
-  res.setUTCHours(0, 0, 0, 0);
-  return res;
-}
-
-function endOfDay(d: Date): Date {
-  const res = new Date(d);
-  res.setUTCHours(23, 59, 59, 999);
-  return res;
-}
-
-function addDays(d: Date, days: number): Date {
-  const res = new Date(d);
-  res.setDate(res.getDate() + days);
-  return res;
 }
 
 export function filterEventsForNext7Days(events: EventBasic[]): EventBasic[] {

--- a/content/webapp/services/prismic/fetch/events.ts
+++ b/content/webapp/services/prismic/fetch/events.ts
@@ -131,19 +131,12 @@ export const fetchEvents = (
     ? getPeriodPredicates({ period, startField, endField })
     : [];
 
-  // NOTE: Ideally we'd use the Prismic DSL to construct these predicates rather
-  // than dropping in raw strings, but they interfere with the type checker.
-  //
-  // The current version of the Prismic libraries require the second argument of
-  // the 'at()' predicate to be a `string | number | (string | number)[]`, but they
-  // need to be booleans.
-  //
-  // TODO: When we upgrade the Prismic client libraries, convert these to the DSL.
-  //
-  const onlinePredicates = isOnline ? ['[at(my.events.isOnline, true)]'] : [];
+  const onlinePredicates = isOnline
+    ? [prismic.predicate.at('my.events.isOnline', 'true')]
+    : [];
 
   const availableOnlinePredicates = availableOnline
-    ? ['[at(my.events.availableOnline, true)]']
+    ? [prismic.predicate.at('my.events.availableOnline', 'true')]
     : [];
 
   return eventsFetcher.getByType(client, {

--- a/content/webapp/services/prismic/fetch/index.ts
+++ b/content/webapp/services/prismic/fetch/index.ts
@@ -156,9 +156,7 @@ export function clientSideFetcher<TransformedDocument>(endpoint: string) {
       const response = await fetch(url);
 
       if (response.ok) {
-        const json: PaginatedResults<TransformedDocument> =
-          await response.json();
-        return json;
+        return response.json();
       }
     },
   };

--- a/content/webapp/services/prismic/types/predicates.ts
+++ b/content/webapp/services/prismic/types/predicates.ts
@@ -1,7 +1,12 @@
-import moment from 'moment';
 import { predicate } from '@prismicio/client';
-import { getNextWeekendDateRange } from '@weco/common/utils/dates';
-import { london } from '@weco/common/utils/format-date';
+import {
+  addDays,
+  endOfDay,
+  endOfWeek,
+  getNextWeekendDateRange,
+  startOfDay,
+  startOfWeek,
+} from '@weco/common/utils/dates';
 import { Period } from '../../../types/periods';
 
 type Props = { period?: Period; startField: string; endField: string };
@@ -10,21 +15,23 @@ export const getPeriodPredicates = ({
   startField,
   endField,
 }: Props): string[] => {
-  const now = london(new Date());
-  const startOfDay = moment().startOf('day');
-  const endOfDay = moment().endOf('day');
+  const now = new Date();
+
+  const startOfToday = startOfDay(now);
+  const endOfToday = endOfDay(now);
+
   const weekendDateRange = getNextWeekendDateRange(now);
   const predicates =
     period === 'coming-up'
-      ? [predicate.dateAfter(startField, endOfDay.toDate())]
+      ? [predicate.dateAfter(startField, endOfToday)]
       : period === 'current-and-coming-up'
-      ? [predicate.dateAfter(endField, startOfDay.toDate())]
+      ? [predicate.dateAfter(endField, startOfToday)]
       : period === 'past'
-      ? [predicate.dateBefore(endField, startOfDay.toDate())]
+      ? [predicate.dateBefore(endField, startOfToday)]
       : period === 'today'
       ? [
-          predicate.dateBefore(startField, endOfDay.toDate()),
-          predicate.dateAfter(endField, startOfDay.toDate()),
+          predicate.dateBefore(startField, endOfToday),
+          predicate.dateAfter(endField, startOfToday),
         ]
       : period === 'this-weekend'
       ? [
@@ -33,16 +40,13 @@ export const getPeriodPredicates = ({
         ]
       : period === 'this-week'
       ? [
-          predicate.dateBefore(startField, now.endOf('week').toDate()),
-          predicate.dateAfter(startField, now.startOf('week').toDate()),
+          predicate.dateBefore(startField, endOfWeek(now)),
+          predicate.dateAfter(startField, startOfWeek(now)),
         ]
       : period === 'next-seven-days'
       ? [
-          predicate.dateBefore(
-            startField,
-            now.add(6, 'days').endOf('day').toDate()
-          ),
-          predicate.dateAfter(endField, startOfDay.toDate()),
+          predicate.dateBefore(startField, endOfDay(addDays(now, 6))),
+          predicate.dateAfter(endField, startOfToday),
         ]
       : [];
 


### PR DESCRIPTION
For https://github.com/wellcomecollection/wellcomecollection.org/issues/7831

All these predicates are constructed on the server-side, where we should have fairly reliable UTC timestamps.