### PR TITLE
Omit some transformed fields we don't need

### DIFF
--- a/common/services/prismic/transformers/images.ts
+++ b/common/services/prismic/transformers/images.ts
@@ -68,7 +68,7 @@ function transformFilledImage(image: FilledImageFieldImage): ImageType {
     height: image.dimensions.height,
     alt,
     tasl,
-    simpleCrops,
-    richCrops,
+    simpleCrops: Object.keys(simpleCrops).length > 0 ? simpleCrops : undefined,
+    richCrops: Object.keys(richCrops).length > 0 ? richCrops : undefined,
   };
 }

--- a/content/webapp/components/StoryPromo/StoryPromo.tsx
+++ b/content/webapp/components/StoryPromo/StoryPromo.tsx
@@ -11,7 +11,9 @@ import { isNotUndefined } from '@weco/common/utils/array';
 import linkResolver from '@weco/common/services/prismic/link-resolver';
 
 type Props = {
-  article: ArticleBasic;
+  article: ArticleBasic & {
+    series: { id: string; title: string }[];
+  };
   position: number;
   hidePromoText?: boolean;
   hasTransparentBackground?: boolean;

--- a/content/webapp/pages/stories.tsx
+++ b/content/webapp/pages/stories.tsx
@@ -153,10 +153,24 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     )!.series;
     const featuredText = getPageFeaturedText(transformPage(storiesPage!));
 
-    const basicSeries = {
+    // Note: an ArticleBasic contains a lot of information, but we only use
+    // a little bit of the series information in the <CardGrid> component
+    // where this gets used.
+    //
+    // This basic-ification removes some of the heaviest fields that we aren't
+    // using, to keep the page weight down.
+    const basicSeries: SerialisedSeriesProps = {
       ...transformSeriesToSeriesBasic(series),
       promo: series.promo,
-      items: series.items,
+      items: series.items.map(item => ({
+        ...item,
+        image: undefined,
+        series: item.series.map(s => ({
+          id: s.id,
+          title: s.title,
+          schedule: [],
+        })),
+      })),
     };
 
     if (articles && articles.results) {

--- a/content/webapp/pages/stories.tsx
+++ b/content/webapp/pages/stories.tsx
@@ -4,7 +4,7 @@ import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import Layout12 from '@weco/common/views/components/Layout12/Layout12';
 import SectionHeader from '@weco/common/views/components/SectionHeader/SectionHeader';
 import { ArticleBasic } from '../types/articles';
-import { Series } from '../types/series';
+import { SeriesBasic } from '../types/series';
 import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
 import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
 import Space from '@weco/common/views/components/styled/Space';
@@ -48,16 +48,23 @@ import { transformFeaturedBooks } from '../services/prismic/transformers/feature
 import { transformBookToBookBasic } from '../services/prismic/transformers/books';
 import { BookBasic } from '../types/books';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
+import { ImagePromo } from '../types/image-promo';
+import { transformSeriesToSeriesBasic } from 'services/prismic/transformers/series';
+
+type SerialisedSeriesProps = SeriesBasic & {
+  promo?: ImagePromo;
+  items: ArticleBasic[];
+};
 
 type Props = {
   articles: ArticleBasic[];
-  series: Series;
+  series: SerialisedSeriesProps;
   featuredText?: FeaturedTextType;
   featuredBooks: BookBasic[];
   jsonLd: JsonLdObj[];
 };
 
-const SerialisedSeries = ({ series }: { series: Series }) => {
+const SerialisedSeries = ({ series }: { series: SerialisedSeriesProps }) => {
   return (
     <div>
       <Layout12>
@@ -90,11 +97,7 @@ const SerialisedSeries = ({ series }: { series: Series }) => {
           </Space>
         </Space>
       </Layout12>
-      <CardGrid
-        items={series.items as ArticleBasic[]}
-        hidePromoText={true}
-        itemsPerRow={3}
-      />
+      <CardGrid items={series.items} hidePromoText={true} itemsPerRow={3} />
     </div>
   );
 };
@@ -150,11 +153,17 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     )!.series;
     const featuredText = getPageFeaturedText(transformPage(storiesPage!));
 
+    const basicSeries = {
+      ...transformSeriesToSeriesBasic(series),
+      promo: series.promo,
+      items: series.items,
+    };
+
     if (articles && articles.results) {
       return {
         props: removeUndefinedProps({
           articles: basicArticles,
-          series,
+          series: basicSeries,
           featuredText,
           serverData,
           featuredBooks,

--- a/content/webapp/services/prismic/transformers/articles.ts
+++ b/content/webapp/services/prismic/transformers/articles.ts
@@ -24,6 +24,7 @@ import { SeasonPrismicDocument } from '../types/seasons';
 import { Format } from '../../../types/format';
 import { ArticleFormatId } from '@weco/common/data/content-format-ids';
 import { transformContributors } from './contributors';
+import { noAltTextBecausePromo } from './images';
 
 function transformContentLink(document?: LinkField): MultiContent | undefined {
   if (!document) {
@@ -61,7 +62,13 @@ export function transformArticleToArticleBasic(article: Article): ArticleBasic {
   }) => ({
     type,
     id,
-    promo,
+    promo: promo && {
+      ...promo,
+      image: promo.image && {
+        ...promo.image,
+        ...noAltTextBecausePromo,
+      },
+    },
     series: series.map(transformSeriesToSeriesBasic),
     title,
     format,
@@ -72,6 +79,7 @@ export function transformArticleToArticleBasic(article: Article): ArticleBasic {
     // so we can omit sending any other crops.
     image: image && {
       ...image,
+      ...noAltTextBecausePromo,
       simpleCrops: image.simpleCrops?.square && {
         square: image.simpleCrops.square,
       },

--- a/content/webapp/services/prismic/transformers/articles.ts
+++ b/content/webapp/services/prismic/transformers/articles.ts
@@ -67,6 +67,7 @@ export function transformArticleToArticleBasic(article: Article): ArticleBasic {
       image: promo.image && {
         ...promo.image,
         ...noAltTextBecausePromo,
+        tasl: undefined,
       },
     },
     series: series.map(transformSeriesToSeriesBasic),
@@ -80,6 +81,7 @@ export function transformArticleToArticleBasic(article: Article): ArticleBasic {
     image: image && {
       ...image,
       ...noAltTextBecausePromo,
+      tasl: undefined,
       simpleCrops: image.simpleCrops?.square && {
         square: image.simpleCrops.square,
       },

--- a/content/webapp/services/prismic/transformers/articles.ts
+++ b/content/webapp/services/prismic/transformers/articles.ts
@@ -65,10 +65,20 @@ export function transformArticleToArticleBasic(article: Article): ArticleBasic {
     series: series.map(transformSeriesToSeriesBasic),
     title,
     format,
-    image,
     datePublished,
     labels,
     color,
+    // We only use the square crop of an image in the <ArticleCard> component,
+    // so we can omit sending any other crops.
+    image: image && {
+      ...image,
+      simpleCrops: image.simpleCrops?.square && {
+        square: image.simpleCrops.square,
+      },
+      richCrops: image.richCrops?.square && {
+        square: image.richCrops.square,
+      },
+    },
   }))(article);
 }
 

--- a/content/webapp/services/prismic/transformers/exhibitions.ts
+++ b/content/webapp/services/prismic/transformers/exhibitions.ts
@@ -34,6 +34,7 @@ import {
   transformContributorToContributorBasic,
 } from './contributors';
 import * as prismicH from '@prismicio/helpers';
+import { noAltTextBecausePromo } from './images';
 
 // TODO: Use better types than Record<string, any>.
 //
@@ -176,7 +177,14 @@ export function transformExhibitionToExhibitionBasic(
     type,
     id,
     title,
-    promo,
+    promo: promo && {
+      ...promo,
+      image: promo.image && {
+        ...promo.image,
+        ...noAltTextBecausePromo,
+        tasl: undefined,
+      },
+    },
     format,
     start,
     end,

--- a/content/webapp/services/prismic/transformers/images.ts
+++ b/content/webapp/services/prismic/transformers/images.ts
@@ -55,6 +55,21 @@ export function transformPromoToCaptionedImage(
   }
 }
 
+// We intentionally omit the alt text on promos, so screen reader
+// users don't have to listen to the alt text before hearing the
+// title of the item in the list.
+//
+// This is a named constant we can mix in when we want to omit alt
+// text, so we only have to write this parent comment once, and not
+// copy it everywhere.  e.g.
+//
+//      promo = { ...promo, ...noAltTextBecausePromo }
+//
+// See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
+export const noAltTextBecausePromo = {
+  alt: null,
+};
+
 // null is valid to use the default image,
 // which isn't on a property, but rather at the root
 export function transformImagePromo(

--- a/content/webapp/services/prismic/transformers/index.ts
+++ b/content/webapp/services/prismic/transformers/index.ts
@@ -114,7 +114,7 @@ export function transformLabelType(
   return {
     id: format.id as ArticleFormatId,
     title: asText(format.data.title),
-    description: format.data.description ? format.data.description : [],
+    description: format.data.description ? format.data.description : undefined,
   };
 }
 


### PR DESCRIPTION
Spotted while poking at page weight in #8378; they're irrelevant to that patch, but making empty values `undefined` means they won't be sent as part of the page props.

<table><tr><th></th><th>before</th><th>after</th></tr>
<tr><td>homepage</td><td>244.92 kB</td><td>229.64 kB (&minus;6.5%)</td></tr>
<tr><td>/stories</td><td>388.88 kB</td><td>313.19 kB (&minus;20%)</td></tr>
<tr><td>/articles/Yp3GthEAACIAwRi9</td><td>201.79 kB</td><td>199.56 kB (&minus;1.5%)</td></tr>
</table>