### PR TITLE
Remove some uses of `london()` from the event components

### DIFF
--- a/content/webapp/components/EventSchedule/EventSchedule.tsx
+++ b/content/webapp/components/EventSchedule/EventSchedule.tsx
@@ -3,14 +3,13 @@ import type { EventSchedule as EventScheduleType } from '../../types/events';
 import EventScheduleItem from './EventScheduleItem';
 import { groupEventsBy } from '../../services/prismic/events';
 import Space from '@weco/common/views/components/styled/Space';
-import { Event } from '../../types/events';
 
 type Props = {
   schedule: EventScheduleType;
 };
 
 const EventSchedule: FC<Props> = ({ schedule }) => {
-  const events = schedule.map(({ event }) => event as Event);
+  const events = schedule.map(({ event }) => event);
   const groupedEvents = groupEventsBy(events, 'day');
   const isNotLinkedIds = schedule
     .map(({ event, isNotLinked }) => {

--- a/content/webapp/components/EventSchedule/EventSchedule.tsx
+++ b/content/webapp/components/EventSchedule/EventSchedule.tsx
@@ -1,7 +1,7 @@
 import { Fragment, FC } from 'react';
 import type { EventSchedule as EventScheduleType } from '../../types/events';
 import EventScheduleItem from './EventScheduleItem';
-import { groupEventsBy } from '../../services/prismic/events';
+import { groupEventsByDay } from '../../services/prismic/events';
 import Space from '@weco/common/views/components/styled/Space';
 
 type Props = {
@@ -10,7 +10,7 @@ type Props = {
 
 const EventSchedule: FC<Props> = ({ schedule }) => {
   const events = schedule.map(({ event }) => event);
-  const groupedEvents = groupEventsBy(events, 'day');
+  const groupedEvents = groupEventsByDay(events);
   const isNotLinkedIds = schedule
     .map(({ event, isNotLinked }) => {
       return isNotLinked ? event.id : null;

--- a/content/webapp/services/prismic/events.ts
+++ b/content/webapp/services/prismic/events.ts
@@ -96,11 +96,6 @@ export function orderEventsByNextAvailableDate<T extends HasTimes>(
     .map(({ event }) => event);
 }
 
-const GroupByFormat = {
-  day: 'dddd',
-  month: 'MMMM',
-};
-type GroupDatesBy = keyof typeof GroupByFormat;
 type EventsGroup = {
   label: string;
   start: Date;
@@ -126,13 +121,10 @@ export function groupEventsByDay(events: Event[]): EventsGroup[] {
     });
 
   // Convert the range into an array of labeled event groups
-  const ranges: EventsGroup[] = getRanges(
-    {
-      start: london(range.start).startOf('day'),
-      end: london(range.end).endOf('day'),
-    },
-    'day'
-  ).map(range => ({
+  const ranges: EventsGroup[] = getRanges({
+    start: london(range.start).startOf('day'),
+    end: london(range.end).endOf('day'),
+  }).map(range => ({
     label: range.label,
     start: range.start.toDate(),
     end: range.end.toDate(),
@@ -200,21 +192,17 @@ type Range = {
 };
 
 // TODO: maybe use a Map?
-function getRanges(
-  { start, end }: RangeProps,
-  groupBy: GroupDatesBy,
-  acc: Range[] = []
-): Range[] {
-  if (start.isBefore(end, groupBy) || start.isSame(end, groupBy)) {
-    const newStart = start.clone().add(1, groupBy);
+function getRanges({ start, end }: RangeProps, acc: Range[] = []): Range[] {
+  if (start.isBefore(end, 'day') || start.isSame(end, 'day')) {
+    const newStart = start.clone().add(1, 'day');
     const newAcc: Range[] = acc.concat([
       {
         label: formatDayDate(start),
-        start: start.clone().startOf(groupBy),
-        end: start.clone().endOf(groupBy),
+        start: start.clone().startOf('day'),
+        end: start.clone().endOf('day'),
       },
     ]);
-    return getRanges({ start: newStart, end }, groupBy, newAcc);
+    return getRanges({ start: newStart, end }, newAcc);
   } else {
     return acc;
   }

--- a/content/webapp/services/prismic/events.ts
+++ b/content/webapp/services/prismic/events.ts
@@ -108,10 +108,7 @@ type EventsGroup = {
   events: Event[];
 };
 
-export function groupEventsBy(
-  events: Event[],
-  groupBy: GroupDatesBy
-): EventsGroup[] {
+export function groupEventsByDay(events: Event[]): EventsGroup[] {
   // Get the full range of all the events
   const range = events
     .map(({ times }) =>
@@ -131,10 +128,10 @@ export function groupEventsBy(
   // Convert the range into an array of labeled event groups
   const ranges: EventsGroup[] = getRanges(
     {
-      start: london(range.start).startOf(groupBy),
-      end: london(range.end).endOf(groupBy),
+      start: london(range.start).startOf('day'),
+      end: london(range.end).endOf('day'),
     },
-    groupBy
+    'day'
   ).map(range => ({
     label: range.label,
     start: range.start.toDate(),

--- a/content/webapp/services/prismic/events.ts
+++ b/content/webapp/services/prismic/events.ts
@@ -230,7 +230,7 @@ export function isEventPast({ times }: Event): boolean {
   return !hasFutureEvents;
 }
 
-export function upcomingDatesFullyBooked(event: Event | EventBasic): boolean {
+export function upcomingDatesFullyBooked(event: HasTimes): boolean {
   const upcoming =
     event.times.length > 0
       ? event.times.filter(({ range }) => !isPast(range.endDateTime))

--- a/content/webapp/services/prismic/events.ts
+++ b/content/webapp/services/prismic/events.ts
@@ -1,10 +1,10 @@
-import { Moment } from 'moment';
-import { london, formatDayDate } from '@weco/common/utils/format-date';
+import { formatDayDate } from '@weco/common/utils/format-date';
 import {
   getNextWeekendDateRange,
   isDayPast,
   isFuture,
   isPast,
+  isSameDay,
 } from '@weco/common/utils/dates';
 import { Event, EventBasic, HasTimes } from '../../types/events';
 import { isNotUndefined } from '@weco/common/utils/array';
@@ -122,12 +122,10 @@ export function groupEventsByDay(events: Event[]): EventsGroup[] {
 
   // Convert the range into an array of labeled event groups
   const ranges: EventsGroup[] = getRanges({
-    start: london(range.start).startOf('day'),
-    end: london(range.end).endOf('day'),
+    start: startOfDay(range.start),
+    end: endOfDay(range.end),
   }).map(range => ({
-    label: range.label,
-    start: range.start.toDate(),
-    end: range.end.toDate(),
+    ...range,
     events: [],
   }));
 
@@ -181,25 +179,25 @@ export function groupEventsByDay(events: Event[]): EventsGroup[] {
 }
 
 type RangeProps = {
-  start: Moment;
-  end: Moment;
+  start: Date;
+  end: Date;
 };
 
 type Range = {
   label: string;
-  start: Moment;
-  end: Moment;
+  start: Date;
+  end: Date;
 };
 
 // TODO: maybe use a Map?
 function getRanges({ start, end }: RangeProps, acc: Range[] = []): Range[] {
-  if (start.isBefore(end, 'day') || start.isSame(end, 'day')) {
-    const newStart = start.clone().add(1, 'day');
+  if (start < end || isSameDay(start, end)) {
+    const newStart = addDays(start, 1);
     const newAcc: Range[] = acc.concat([
       {
         label: formatDayDate(start),
-        start: start.clone().startOf('day'),
-        end: start.clone().endOf('day'),
+        start: startOfDay(start),
+        end: endOfDay(start),
       },
     ]);
     return getRanges({ start: newStart, end }, newAcc);

--- a/content/webapp/services/prismic/transformers/events.test.ts
+++ b/content/webapp/services/prismic/transformers/events.test.ts
@@ -1,4 +1,4 @@
-import { groupEventsBy } from '../../../services/prismic/events';
+import { groupEventsByDay } from '../../../services/prismic/events';
 import { getLastEndTime, getEventbriteId } from './events';
 import { data as uiEventData } from '../../../components/CardGrid/DailyTourPromo';
 import { transformTimestamp } from '.';
@@ -85,7 +85,7 @@ const multiDayEvents = [
 
 describe('Events', () => {
   it('groups events by daterange', () => {
-    const eventsGroupedByDay = groupEventsBy(multiDayEvents, 'day');
+    const eventsGroupedByDay = groupEventsByDay(multiDayEvents);
     expect(eventsGroupedByDay.length).toBe(7);
     eventsGroupedByDay.forEach((eventsGroup, i) => {
       // Friday


### PR DESCRIPTION
For #7831.

This removes some calls to `london()` that I believe are now superfluous; in particular, because we can now get `Date` values passed reliably through props to client-side components, we can trust that `d: Date` is actually a `Date`, and not a string that's snuck past.