### PR TITLE
Modify getNextWeekendDateRange to use vanilla Date, not Moment

### DIFF
--- a/common/utils/dates.test.ts
+++ b/common/utils/dates.test.ts
@@ -1,5 +1,12 @@
 import each from 'jest-each';
-import { dayBefore, isFuture, isPast, isSameDay, isSameMonth } from './dates';
+import {
+  dayBefore,
+  getNextWeekendDateRange,
+  isFuture,
+  isPast,
+  isSameDay,
+  isSameMonth,
+} from './dates';
 
 it('identifies dates in the past', () => {
   expect(isPast(new Date(2001, 1, 1, 1, 1, 1, 999))).toEqual(true);
@@ -95,5 +102,34 @@ describe('dayBefore', () => {
     { day: new Date('2022-01-01'), prevDay: new Date('2021-12-31') },
   ])('the day before $day is $prevDay', ({ day, prevDay }) => {
     expect(dayBefore(day)).toStrictEqual(prevDay);
+  });
+});
+
+describe('getNextWeekendDateRange', () => {
+  test.each([
+    // Monday
+    {
+      day: new Date('2022-09-05'),
+      weekend: { start: new Date('2022-09-09'), end: new Date('2022-09-11') },
+    },
+    // Friday
+    {
+      day: new Date('2022-09-02'),
+      weekend: { start: new Date('2022-09-02'), end: new Date('2022-09-04') },
+    },
+    // Saturday
+    {
+      day: new Date('2022-09-03'),
+      weekend: { start: new Date('2022-09-02'), end: new Date('2022-09-04') },
+    },
+    // Sunday
+    {
+      day: new Date('2022-09-04'),
+      weekend: { start: new Date('2022-09-02'), end: new Date('2022-09-04') },
+    },
+  ])('the next weekend after $day is $weekend', ({ day, weekend }) => {
+    const range = getNextWeekendDateRange(day);
+    expect(isSameDay(range.start, weekend.start)).toBeTruthy();
+    expect(isSameDay(range.end, weekend.end)).toBeTruthy();
   });
 });

--- a/common/utils/dates.ts
+++ b/common/utils/dates.ts
@@ -1,4 +1,3 @@
-import { DateTypes, london } from './format-date';
 import { DateRange } from '../model/date-range';
 
 export function getEarliestFutureDateRange(
@@ -28,13 +27,13 @@ export function isFuture(date: Date): boolean {
 
 export function isSameMonth(date1: Date, date2: Date): boolean {
   return (
-    date1.getFullYear() === date2.getFullYear() &&
-    date1.getMonth() === date2.getMonth()
+    date1.getUTCFullYear() === date2.getUTCFullYear() &&
+    date1.getUTCMonth() === date2.getUTCMonth()
   );
 }
 
 export function isSameDay(date1: Date, date2: Date): boolean {
-  return isSameMonth(date1, date2) && date1.getDate() === date2.getDate();
+  return isSameMonth(date1, date2) && date1.getUTCDate() === date2.getUTCDate();
 }
 
 // Returns true if 'date' falls on a past day; false otherwise.
@@ -54,22 +53,41 @@ export function dayBefore(date: Date): Date {
   return prevDay;
 }
 
+export function startOfDay(d: Date): Date {
+  const res = new Date(d);
+  res.setUTCHours(0, 0, 0, 0);
+  return res;
+}
+
+export function endOfDay(d: Date): Date {
+  const res = new Date(d);
+  res.setUTCHours(23, 59, 59, 999);
+  return res;
+}
+
+export function addDays(d: Date, days: number): Date {
+  const res = new Date(d);
+  res.setDate(res.getDate() + days);
+  return res;
+}
+
 /** Returns a loose range of Friday–Sunday for the next weekend after the
  * given date, possibly including it.
  *
  * Note: including Friday seems like a slightly odd choice, but it's the way
  * this function was originally written. ¯\_ (ツ)_/¯
  */
-export function getNextWeekendDateRange(date: DateTypes): DateRange {
-  const today = london(date);
-  const todayInteger = today.day(); // day() return Sun as 0, Sat as 6
+export function getNextWeekendDateRange(date: Date): DateRange {
+  const dayInteger = date.getDay(); // getDay() return Sun as 0, Sat as 6
+  const todayIsSunday = dayInteger === 0;
 
-  const start =
-    todayInteger !== 0 ? london(today).day(5) : london(today).day(-2);
-  const end = todayInteger === 0 ? london(today) : london(today).day(7);
+  const start = todayIsSunday
+    ? addDays(date, -2)
+    : addDays(date, 5 - dayInteger);
+  const end = addDays(start, 2);
 
   return {
-    start: start.startOf('day').toDate(),
-    end: end.endOf('day').toDate(),
+    start: startOfDay(start),
+    end: endOfDay(end),
   };
 }

--- a/common/utils/dates.ts
+++ b/common/utils/dates.ts
@@ -54,6 +54,12 @@ export function dayBefore(date: Date): Date {
   return prevDay;
 }
 
+/** Returns a loose range of Friday–Sunday for the next weekend after the
+ * given date, possibly including it.
+ *
+ * Note: including Friday seems like a slightly odd choice, but it's the way
+ * this function was originally written. ¯\_ (ツ)_/¯
+ */
 export function getNextWeekendDateRange(date: DateTypes): DateRange {
   const today = london(date);
   const todayInteger = today.day(); // day() return Sun as 0, Sat as 6

--- a/content/webapp/pages/whats-on.tsx
+++ b/content/webapp/pages/whats-on.tsx
@@ -12,7 +12,7 @@ import {
   filterEventsForToday,
   filterEventsForWeekend,
 } from '../services/prismic/events';
-import { london, formatDay, formatDate } from '@weco/common/utils/format-date';
+import { formatDay, formatDate } from '@weco/common/utils/format-date';
 import { clock } from '@weco/common/icons';
 import {
   getTodaysVenueHours,
@@ -71,7 +71,11 @@ import {
 import { pageDescriptions } from '@weco/common/data/microcopy';
 import { fetchExhibitions } from '../services/prismic/fetch/exhibitions';
 import { transformExhibitionsQuery } from '../services/prismic/transformers/exhibitions';
-import { getNextWeekendDateRange } from '@weco/common/utils/dates';
+import {
+  endOfDay,
+  getNextWeekendDateRange,
+  startOfDay,
+} from '@weco/common/utils/dates';
 
 const segmentedControlItems = [
   {
@@ -102,18 +106,18 @@ export type Props = {
 };
 
 export function getRangeForPeriod(period: Period): { start: Date; end?: Date } {
-  const todaysDate = london();
+  const today = new Date();
 
   switch (period) {
     case 'today':
       return {
-        start: todaysDate.startOf('day').toDate(),
-        end: todaysDate.endOf('day').toDate(),
+        start: startOfDay(today),
+        end: endOfDay(today),
       };
     case 'this-weekend':
-      return getNextWeekendDateRange(todaysDate);
+      return getNextWeekendDateRange(today);
     default:
-      return { start: todaysDate.startOf('day').toDate() };
+      return { start: startOfDay(today) };
   }
 }
 

--- a/content/webapp/services/prismic/events.ts
+++ b/content/webapp/services/prismic/events.ts
@@ -1,10 +1,13 @@
 import { Moment } from 'moment';
 import { london, formatDayDate } from '@weco/common/utils/format-date';
 import {
+  addDays,
+  endOfDay,
   getNextWeekendDateRange,
   isDayPast,
   isFuture,
   isPast,
+  startOfDay,
 } from '@weco/common/utils/dates';
 import { Event, EventBasic, HasTimes } from '../../types/events';
 import { isNotUndefined } from '@weco/common/utils/array';
@@ -42,24 +45,6 @@ function filterEventsByTimeRange(
       );
     });
   });
-}
-
-function startOfDay(d: Date): Date {
-  const res = new Date(d);
-  res.setUTCHours(0, 0, 0, 0);
-  return res;
-}
-
-function endOfDay(d: Date): Date {
-  const res = new Date(d);
-  res.setUTCHours(23, 59, 59, 999);
-  return res;
-}
-
-function addDays(d: Date, days: number): Date {
-  const res = new Date(d);
-  res.setDate(res.getDate() + days);
-  return res;
 }
 
 export function filterEventsForNext7Days(events: EventBasic[]): EventBasic[] {

--- a/content/webapp/services/prismic/types/predicates.ts
+++ b/content/webapp/services/prismic/types/predicates.ts
@@ -13,7 +13,7 @@ export const getPeriodPredicates = ({
   const now = london(new Date());
   const startOfDay = moment().startOf('day');
   const endOfDay = moment().endOf('day');
-  const weekendDateRange = getNextWeekendDateRange(now);
+  const weekendDateRange = getNextWeekendDateRange(now.toDate());
   const predicates =
     period === 'coming-up'
       ? [predicate.dateAfter(startField, endOfDay.toDate())]


### PR DESCRIPTION
For https://github.com/wellcomecollection/wellcomecollection.org/issues/7831.

I wrote some tests for the old implementation, saw them passing, then I wrote the new implementation without modifying the tests.