### PR TITLE
Feat/ Exhibition guide anchor links

### DIFF
--- a/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
+++ b/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
@@ -225,7 +225,7 @@ const Stop: FC<{ stop: Stop; isFirstStop: boolean }> = ({
         >
           <div className="flex flex--wrap container">
             <Tombstone>
-              <TombstoneTitle id={dasherize(`${title}`)}>
+              <TombstoneTitle id={dasherize(title)}>
                 {!hasContext && title}
               </TombstoneTitle>
               <div className={font('intr', 4)}>
@@ -252,9 +252,7 @@ const Stop: FC<{ stop: Stop; isFirstStop: boolean }> = ({
               {hasContext && (
                 <>
                   {!isFirstStop && title.length > 0 && (
-                    <ContextTitle id={dasherize(`${title}`)}>
-                      {title}
-                    </ContextTitle>
+                    <ContextTitle id={dasherize(title)}>{title}</ContextTitle>
                   )}
                   <PrismicHtmlBlock html={context as prismicT.RichTextField} />
                 </>

--- a/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
+++ b/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
@@ -192,7 +192,7 @@ const Stop: FC<{ stop: Stop; isFirstStop: boolean }> = ({
           >
             <Divider color={`pumice`} isKeyline={true} />
           </Space>
-          <div className="flex flex--wrap" id={dasherize(`${title}`)}>
+          <div className="flex flex--wrap">
             <Tombstone />
             {/* This empty Tombstone is needed for correct alignmennt of the standaloneTitle */}
             <Space

--- a/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
+++ b/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
@@ -11,6 +11,7 @@ import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper
 import Divider from '@weco/common/views/components/Divider/Divider';
 import { font } from '@weco/common/utils/classnames';
 import { themeValues } from '@weco/common/views/themes/config';
+import { dasherize } from '@weco/common/utils/grammar';
 
 function getTypeColor(type: string): string {
   // importing this from exhibition-guide.tsx was causing a storybook build failure
@@ -191,7 +192,7 @@ const Stop: FC<{ stop: Stop; isFirstStop: boolean }> = ({
           >
             <Divider color={`pumice`} isKeyline={true} />
           </Space>
-          <div className="flex flex--wrap">
+          <div className="flex flex--wrap" id={dasherize(`${title}`)}>
             <Tombstone />
             {/* This empty Tombstone is needed for correct alignmennt of the standaloneTitle */}
             <Space
@@ -202,7 +203,9 @@ const Stop: FC<{ stop: Stop; isFirstStop: boolean }> = ({
               }}
               v={{ size: 'l', properties: ['margin-bottom'] }}
             >
-              <StandaloneTitle>{standaloneTitle}</StandaloneTitle>
+              <StandaloneTitle id={dasherize(`${standaloneTitle}`)}>
+                {standaloneTitle}
+              </StandaloneTitle>
             </Space>
           </div>
         </div>
@@ -222,7 +225,9 @@ const Stop: FC<{ stop: Stop; isFirstStop: boolean }> = ({
         >
           <div className="flex flex--wrap container">
             <Tombstone>
-              <TombstoneTitle>{!hasContext && title}</TombstoneTitle>
+              <TombstoneTitle id={dasherize(`${title}`)}>
+                {!hasContext && title}
+              </TombstoneTitle>
               <div className={font('intr', 4)}>
                 <PrismicHtmlBlock html={tombstone} />
               </div>
@@ -238,14 +243,18 @@ const Stop: FC<{ stop: Stop; isFirstStop: boolean }> = ({
                   }}
                   v={{ size: 'l', properties: ['margin-bottom'] }}
                 >
-                  <StandaloneTitle>{title}</StandaloneTitle>
+                  <StandaloneTitle id={dasherize(title)}>
+                    {title}
+                  </StandaloneTitle>
                 </Space>
               )}
 
               {hasContext && (
                 <>
                   {!isFirstStop && title.length > 0 && (
-                    <ContextTitle>{title}</ContextTitle>
+                    <ContextTitle id={dasherize(`${title}`)}>
+                      {title}
+                    </ContextTitle>
                   )}
                   <PrismicHtmlBlock html={context as prismicT.RichTextField} />
                 </>

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -51,6 +51,7 @@ import {
   speechToText,
 } from '@weco/common/icons';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
+import { dasherize } from '@weco/common/utils/grammar';
 
 const PromoContainer = styled.div`
   background: ${props => props.theme.color('cream')};
@@ -293,7 +294,7 @@ const Stops: FC<StopsProps> = ({ stops, type }) => {
             audioWithoutDescription?.url) ||
           (type === 'bsl' && bsl?.embedUrl);
         return hasContentOfDesiredType ? (
-          <Stop key={index} id={`${number}. ${stop.title}`}>
+          <Stop key={index} id={dasherize(title)}>
             {type === 'audio-with-descriptions' &&
               audioWithDescription?.url && (
                 <AudioPlayer
@@ -313,7 +314,7 @@ const Stops: FC<StopsProps> = ({ stops, type }) => {
             )}
           </Stop>
         ) : (
-          <Stop key={index} id={`${title}`}>
+          <Stop key={index} id={dasherize(title)}>
             <span className={font('intb', 5)}>
               {number}. {title}
             </span>

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -270,6 +270,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
 type StopsProps = {
   stops: ExhibitionGuideComponent[];
   type?: GuideType;
+  id?: number;
 };
 
 const Stops: FC<StopsProps> = ({ stops, type }) => {
@@ -292,7 +293,7 @@ const Stops: FC<StopsProps> = ({ stops, type }) => {
             audioWithoutDescription?.url) ||
           (type === 'bsl' && bsl?.embedUrl);
         return hasContentOfDesiredType ? (
-          <Stop key={index}>
+          <Stop key={index} id={`${number}. ${stop.title}`}>
             {type === 'audio-with-descriptions' &&
               audioWithDescription?.url && (
                 <AudioPlayer
@@ -312,7 +313,7 @@ const Stops: FC<StopsProps> = ({ stops, type }) => {
             )}
           </Stop>
         ) : (
-          <Stop key={index}>
+          <Stop key={index} id={`${title}`}>
             <span className={font('intb', 5)}>
               {number}. {title}
             </span>


### PR DESCRIPTION
## Who is this for?

Exhibition guide users and editors https://github.com/wellcomecollection/wellcomecollection.org/issues/8359

## What is it doing for them?

Allowing us to have urls to link to individual stops within an exhibition guide page i.e. in audio (with or without description) and bsl we link to the title of the audio and video, in captions and transcripts we link to `standAlone` section titles, context titles, and tombstone titles. The url contains the id of the particular stop/section, the id outputs as `#the-title-of-the-stop-or-thing`.

Some examples:
**weco.org/guides/exhibitions/YvJ4UhAAAPgZztMl/audio-without-descriptions#weeping---joy-in-the-passions--humorously-delineated** brings you to that 'stop'

**weco.org/guides/exhibitions/YvJ4UhAAAPgZztMl/captions-and-transcripts#projection-and-fear** brings you to the projection and fear section 

**weco.org/guides/exhibitions/YvJ4UhAAAPgZztMl/captions-and-transcripts#joy-inside-our-tears** brings you to the tombstone title for that object in a stop