### PR TITLE
Don't use Moment to format duration on a works page

### DIFF
--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -1,4 +1,3 @@
-import moment from 'moment';
 import NextLink from 'next/link';
 import { FunctionComponent, useContext, useState } from 'react';
 import { classNames, font } from '@weco/common/utils/classnames';
@@ -56,6 +55,7 @@ import {
 } from '../../utils/requesting';
 import { useToggles } from '@weco/common/server-data/Context';
 import { themeValues } from '@weco/common/views/themes/config';
+import { formatDuration } from '@weco/common/utils/format-date';
 
 type Props = {
   work: Work;
@@ -165,8 +165,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
   ];
 
   // 'About this work' data
-  const duration =
-    work.duration && moment.utc(work.duration).format('HH:mm:ss');
+  const duration = work.duration && formatDuration(work.duration);
 
   // 'Identifiers' data
   const isbnIdentifiers = work.identifiers.filter(id => {

--- a/common/utils/format-date.test.ts
+++ b/common/utils/format-date.test.ts
@@ -4,6 +4,7 @@ import {
   formatDay,
   formatDayDate,
   formatDayMonth,
+  formatDuration,
   formatTime,
   formatYear,
 } from './format-date';
@@ -161,4 +162,18 @@ describe('formatDateRangeWithMessage', () => {
 
     expect(result).toEqual({ text: 'Now on', color: 'green' });
   });
+});
+
+describe('formatDuration', () => {
+  test.each([
+    { seconds: 1, formattedDuration: '00:00:01' },
+    { seconds: 59, formattedDuration: '00:00:59' },
+    { seconds: 60 * 12, formattedDuration: '00:12:00' },
+    { seconds: 60 * 83 + 13, formattedDuration: '01:23:13' },
+  ])(
+    '$seconds seconds is formatted as $formattedDuration',
+    ({ seconds, formattedDuration }) => {
+      expect(formatDuration(seconds)).toStrictEqual(formattedDuration);
+    }
+  );
 });

--- a/common/utils/format-date.ts
+++ b/common/utils/format-date.ts
@@ -59,3 +59,18 @@ export function formatYear(date: Date): string {
 export function formatDayMonth(date: Date): string {
   return london(date).format('D MMMM');
 }
+
+export function formatDuration(seconds: number): string {
+  const secondsPerMinute = 60;
+  const secondsPerHour = 60 * secondsPerMinute;
+
+  const hours = Math.floor(seconds / secondsPerHour);
+  const minutes = Math.floor((seconds % secondsPerHour) / secondsPerMinute);
+  const remainingSeconds = seconds % secondsPerMinute;
+
+  const HH = String(hours).padStart(2, '0');
+  const MM = String(minutes).padStart(2, '0');
+  const SS = String(remainingSeconds).padStart(2, '0');
+
+  return `${HH}:${MM}:${SS}`;
+}

--- a/common/utils/format-date.ts
+++ b/common/utils/format-date.ts
@@ -68,6 +68,12 @@ export function formatDuration(seconds: number): string {
   const minutes = Math.floor((seconds % secondsPerHour) / secondsPerMinute);
   const remainingSeconds = seconds % secondsPerMinute;
 
+  console.assert(
+    hours * secondsPerHour + minutes * secondsPerMinute + remainingSeconds ===
+      seconds,
+    `${hours ** secondsPerHour + minutes * secondsPerMinute} != ${seconds}`
+  );
+
   const HH = String(hours).padStart(2, '0');
   const MM = String(minutes).padStart(2, '0');
   const SS = String(remainingSeconds).padStart(2, '0');


### PR DESCRIPTION
It's definitely overkill: durations have no awareness of timezones and don't need any complicated datetime logic.

For https://github.com/wellcomecollection/wellcomecollection.org/issues/7831.