### PR TITLE
Don't treat alternative titles and other fields as HTML

### DIFF
--- a/catalogue/webapp/components/Download/Download.tsx
+++ b/catalogue/webapp/components/Download/Download.tsx
@@ -1,7 +1,7 @@
 import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
 import { IIIFRendering } from '../../model/iiif';
 import { LicenseData } from '@weco/common/utils/licenses';
-import { useContext, useRef } from 'react';
+import { ReactElement, useContext, useRef } from 'react';
 import styled from 'styled-components';
 import { font, classNames } from '@weco/common/utils/classnames';
 import DownloadLink from '@weco/catalogue/components/DownloadLink/DownloadLink';
@@ -42,23 +42,37 @@ function getFormatString(format: string): DownloadFormat | undefined {
   }
 }
 
-export function getCreditString(
+export function getCredit(
   workId: string,
   title: string,
   iiifImageLocationCredit: string | undefined,
   license: LicenseData
-): string[] {
+): ReactElement {
   const titleCredit = title.replace(/\.$/g, '');
 
-  const linkCredit = iiifImageLocationCredit
-    ? `Credit: <a href="https://wellcomecollection.org/works/${workId}">${iiifImageLocationCredit}</a>. `
-    : ` `;
+  const linkCredit = iiifImageLocationCredit ? (
+    <>
+      Credit:{' '}
+      <a href={`https://wellcomecollection.org/works/${workId}`}>
+        {iiifImageLocationCredit}
+      </a>
+      .
+    </>
+  ) : null;
 
-  const licenseCredit = license.url
-    ? `<a href="${license.url}">${license.label}</a>`
-    : license.label;
+  const licenseCredit: ReactElement = license.url ? (
+    <a href={license.url}>{license.label}</a>
+  ) : (
+    <>{license.label}</>
+  );
 
-  return [`${titleCredit}. ${linkCredit}\n${licenseCredit}`];
+  return (
+    <>
+      <div key="0">
+        {titleCredit}. {linkCredit} {licenseCredit}
+      </div>
+    </>
+  );
 }
 
 type Props = {
@@ -157,7 +171,7 @@ const Download: NextPage<Props> = ({
                       )}
                       <WorkDetailsText
                         title="Credit"
-                        html={getCreditString(
+                        contents={getCredit(
                           workId,
                           title,
                           iiifImageLocationCredit,

--- a/catalogue/webapp/components/Download/Download.tsx
+++ b/catalogue/webapp/components/Download/Download.tsx
@@ -152,19 +152,17 @@ const Download: NextPage<Props> = ({
                       {license.humanReadableText.length > 0 && (
                         <WorkDetailsText
                           title="Licence information"
-                          text={license.humanReadableText}
-                          allowRawHtml={true}
+                          html={license.humanReadableText}
                         />
                       )}
                       <WorkDetailsText
                         title="Credit"
-                        text={getCreditString(
+                        html={getCreditString(
                           workId,
                           title,
                           iiifImageLocationCredit,
                           license
                         )}
-                        allowRawHtml={true}
                       />
                     </div>
                   </SpacingComponent>

--- a/catalogue/webapp/components/Download/Download.tsx
+++ b/catalogue/webapp/components/Download/Download.tsx
@@ -163,10 +163,10 @@ const Download: NextPage<Props> = ({
                   </SpacingComponent>
                   <SpacingComponent>
                     <div>
-                      {license.humanReadableText.length > 0 && (
+                      {license.humanReadableText && (
                         <WorkDetailsText
                           title="Licence information"
-                          html={license.humanReadableText}
+                          contents={license.humanReadableText}
                         />
                       )}
                       <WorkDetailsText

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -685,20 +685,10 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
         )}
 
         {work.edition && (
-          <WorkDetailsText
-            title="Edition"
-            html={[work.edition]}
-            allowDangerousRawHtml={true}
-          />
+          <WorkDetailsText title="Edition" text={work.edition} />
         )}
 
-        {duration && (
-          <WorkDetailsText
-            title="Duration"
-            html={[duration]}
-            allowDangerousRawHtml={true}
-          />
-        )}
+        {duration && <WorkDetailsText title="Duration" text={duration} />}
 
         {remainingNotes.map(note => (
           <WorkDetailsText

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -243,6 +243,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
           <WorkDetailsText
             title={locationOfWork.noteType.label}
             html={locationOfWork.contents}
+            allowDangerousRawHtml={true}
           />
         )}
         <PhysicalItems work={work} items={physicalItems} />
@@ -302,6 +303,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
                         title="Location"
                         noSpacing={true}
                         html={[`${locationLabel} ${locationShelfmark}`]}
+                        allowDangerousRawHtml={true}
                       />
                     )}
 
@@ -311,6 +313,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
                         inlineHeading={true}
                         noSpacing={true}
                         html={[holding.note]}
+                        allowDangerousRawHtml={true}
                       />
                     )}
                   </Space>
@@ -509,7 +512,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
               >
                 <WorkDetailsText
                   title="Licence"
-                  html={[digitalLocationInfo.license.label]}
+                  text={[digitalLocationInfo.license.label]}
                 />
               </Space>
               {digitalLocation?.accessConditions[0]?.terms && (
@@ -523,6 +526,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
                     title="Access conditions"
                     noSpacing={true}
                     html={[digitalLocation?.accessConditions[0]?.terms]}
+                    allowDangerousRawHtml={true}
                   />
                 </Space>
               )}
@@ -604,13 +608,18 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
         )}
 
         {work.description && (
-          <WorkDetailsText title="Description" html={[work.description]} />
+          <WorkDetailsText
+            title="Description"
+            html={[work.description]}
+            allowDangerousRawHtml={true}
+          />
         )}
 
         {work.production.length > 0 && (
           <WorkDetailsText
             title="Publication/Creation"
             html={work.production.map(productionEvent => productionEvent.label)}
+            allowDangerousRawHtml={true}
           />
         )}
 
@@ -618,6 +627,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
           <WorkDetailsText
             title="Physical description"
             html={[work.physicalDescription]}
+            allowDangerousRawHtml={true}
           />
         )}
         {seriesPartOfs.length > 0 && (
@@ -662,24 +672,40 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
             key={note.noteType.label}
             title={note.noteType.label}
             html={note.contents}
+            allowDangerousRawHtml={true}
           />
         ))}
 
         {work.lettering && (
-          <WorkDetailsText title="Lettering" html={[work.lettering]} />
+          <WorkDetailsText
+            title="Lettering"
+            html={[work.lettering]}
+            allowDangerousRawHtml={true}
+          />
         )}
 
         {work.edition && (
-          <WorkDetailsText title="Edition" html={[work.edition]} />
+          <WorkDetailsText
+            title="Edition"
+            html={[work.edition]}
+            allowDangerousRawHtml={true}
+          />
         )}
 
-        {duration && <WorkDetailsText title="Duration" html={[duration]} />}
+        {duration && (
+          <WorkDetailsText
+            title="Duration"
+            html={[duration]}
+            allowDangerousRawHtml={true}
+          />
+        )}
 
         {remainingNotes.map(note => (
           <WorkDetailsText
             key={note.noteType.label}
             title={note.noteType.label}
             html={note.contents}
+            allowDangerousRawHtml={true}
           />
         ))}
 

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -613,7 +613,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
         {work.description && (
           <WorkDetailsText
             title="Description"
-            html={[work.description]}
+            html={work.description}
             allowDangerousRawHtml={true}
           />
         )}
@@ -634,7 +634,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
         {work.physicalDescription && (
           <WorkDetailsText
             title="Physical description"
-            html={[work.physicalDescription]}
+            html={work.physicalDescription}
             allowDangerousRawHtml={true}
           />
         )}

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -302,8 +302,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
                       <WorkDetailsText
                         title="Location"
                         noSpacing={true}
-                        html={[`${locationLabel} ${locationShelfmark}`]}
-                        allowDangerousRawHtml={true}
+                        text={`${locationLabel} ${locationShelfmark}`}
                       />
                     )}
 
@@ -312,8 +311,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
                         title="Note"
                         inlineHeading={true}
                         noSpacing={true}
-                        html={[holding.note]}
-                        allowDangerousRawHtml={true}
+                        text={holding.note}
                       />
                     )}
                   </Space>

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -242,8 +242,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
         {locationOfWork && (
           <WorkDetailsText
             title={locationOfWork.noteType.label}
-            text={locationOfWork.contents}
-            allowRawHtml={true}
+            html={locationOfWork.contents}
           />
         )}
         <PhysicalItems work={work} items={physicalItems} />
@@ -302,8 +301,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
                       <WorkDetailsText
                         title="Location"
                         noSpacing={true}
-                        text={[`${locationLabel} ${locationShelfmark}`]}
-                        allowRawHtml={true}
+                        html={[`${locationLabel} ${locationShelfmark}`]}
                       />
                     )}
 
@@ -312,8 +310,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
                         title="Note"
                         inlineHeading={true}
                         noSpacing={true}
-                        text={[holding.note]}
-                        allowRawHtml={true}
+                        html={[holding.note]}
                       />
                     )}
                   </Space>
@@ -512,8 +509,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
               >
                 <WorkDetailsText
                   title="Licence"
-                  text={[digitalLocationInfo.license.label]}
-                  allowRawHtml={true}
+                  html={[digitalLocationInfo.license.label]}
                 />
               </Space>
               {digitalLocation?.accessConditions[0]?.terms && (
@@ -526,8 +522,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
                   <WorkDetailsText
                     title="Access conditions"
                     noSpacing={true}
-                    text={[digitalLocation?.accessConditions[0]?.terms]}
-                    allowRawHtml={true}
+                    html={[digitalLocation?.accessConditions[0]?.terms]}
                   />
                 </Space>
               )}
@@ -545,12 +540,11 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
                     {digitalLocationInfo.license.humanReadableText.length >
                       0 && (
                       <WorkDetailsText
-                        text={digitalLocationInfo.license.humanReadableText}
-                        allowRawHtml={true}
+                        html={digitalLocationInfo.license.humanReadableText}
                       />
                     )}
                     <WorkDetailsText
-                      text={[
+                      html={[
                         [
                           `Credit: ${work.title.replace(/\.$/g, '')}.`,
                           credit &&
@@ -562,7 +556,6 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
                           .filter(Boolean)
                           .join(' '),
                       ]}
-                      allowRawHtml={true}
                     />
                   </>
                 </ExplanatoryText>
@@ -597,32 +590,25 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
         {work.alternativeTitles.length > 0 && (
           <WorkDetailsText
             title="Also known as"
-            text={work.alternativeTitles}
-            allowRawHtml={true}
+            html={work.alternativeTitles}
           />
         )}
 
         {work.description && (
-          <WorkDetailsText
-            title="Description"
-            text={[work.description]}
-            allowRawHtml={true}
-          />
+          <WorkDetailsText title="Description" html={[work.description]} />
         )}
 
         {work.production.length > 0 && (
           <WorkDetailsText
             title="Publication/Creation"
-            text={work.production.map(productionEvent => productionEvent.label)}
-            allowRawHtml={true}
+            html={work.production.map(productionEvent => productionEvent.label)}
           />
         )}
 
         {work.physicalDescription && (
           <WorkDetailsText
             title="Physical description"
-            text={[work.physicalDescription]}
-            allowRawHtml={true}
+            html={[work.physicalDescription]}
           />
         )}
         {seriesPartOfs.length > 0 && (
@@ -666,41 +652,25 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
           <WorkDetailsText
             key={note.noteType.label}
             title={note.noteType.label}
-            text={note.contents}
-            allowRawHtml={true}
+            html={note.contents}
           />
         ))}
 
         {work.lettering && (
-          <WorkDetailsText
-            title="Lettering"
-            text={[work.lettering]}
-            allowRawHtml={true}
-          />
+          <WorkDetailsText title="Lettering" html={[work.lettering]} />
         )}
 
         {work.edition && (
-          <WorkDetailsText
-            title="Edition"
-            text={[work.edition]}
-            allowRawHtml={true}
-          />
+          <WorkDetailsText title="Edition" html={[work.edition]} />
         )}
 
-        {duration && (
-          <WorkDetailsText
-            title="Duration"
-            text={[duration]}
-            allowRawHtml={true}
-          />
-        )}
+        {duration && <WorkDetailsText title="Duration" html={[duration]} />}
 
         {remainingNotes.map(note => (
           <WorkDetailsText
             key={note.noteType.label}
             title={note.noteType.label}
-            text={note.contents}
-            allowRawHtml={true}
+            html={note.contents}
           />
         ))}
 

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -537,10 +537,9 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
                   controlText="Can I use this?"
                 >
                   <>
-                    {digitalLocationInfo.license.humanReadableText.length >
-                      0 && (
+                    {digitalLocationInfo.license.humanReadableText && (
                       <WorkDetailsText
-                        html={digitalLocationInfo.license.humanReadableText}
+                        contents={digitalLocationInfo.license.humanReadableText}
                       />
                     )}
                     <WorkDetailsText

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -523,8 +523,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
                   <WorkDetailsText
                     title="Access conditions"
                     noSpacing={true}
-                    html={[digitalLocation?.accessConditions[0]?.terms]}
-                    allowDangerousRawHtml={true}
+                    text={digitalLocation?.accessConditions[0]?.terms}
                   />
                 </Space>
               )}
@@ -619,11 +618,16 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
           />
         )}
 
+        {/* 
+          Note: although production event labels sometimes contain angle brackets, it's
+          normally used to denote a period of time, not HTML tags.
+          
+          e.g. London : County Council, 1900-<1983>
+        */}
         {work.production.length > 0 && (
           <WorkDetailsText
             title="Publication/Creation"
-            html={work.production.map(productionEvent => productionEvent.label)}
-            allowDangerousRawHtml={true}
+            text={work.production.map(productionEvent => productionEvent.label)}
           />
         )}
 

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -543,18 +543,28 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
                       />
                     )}
                     <WorkDetailsText
-                      html={[
-                        [
-                          `Credit: ${work.title.replace(/\.$/g, '')}.`,
-                          credit &&
-                            `<a href="https://wellcomecollection.org/works/${work.id}">${credit}</a>.`,
-                          digitalLocationInfo.license.url
-                            ? `<a href="${digitalLocationInfo.license.url}">${digitalLocationInfo.license.label}</a>`
-                            : digitalLocationInfo.license.label,
-                        ]
-                          .filter(Boolean)
-                          .join(' '),
-                      ]}
+                      contents={
+                        <>
+                          Credit: {work.title.replace(/\.$/g, '')}.
+                          {credit && (
+                            <>
+                              <a
+                                href={`https://wellcomecollection.org/works/${work.id}`}
+                              >
+                                {credit}
+                              </a>
+                              .
+                            </>
+                          )}
+                          {digitalLocationInfo.license.url ? (
+                            <a href={digitalLocationInfo.license.url}>
+                              {digitalLocationInfo.license.label}
+                            </a>
+                          ) : (
+                            digitalLocationInfo.license.label
+                          )}
+                        </>
+                      }
                     />
                   </>
                 </ExplanatoryText>

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -598,6 +598,12 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
       )}
 
       <WorkDetailsSection headingText="About this work">
+        {/*
+          Note: although alternative titles sometimes contain angle brackets, it's
+          normally used to denote a period of time, not HTML tags.
+
+          e.g. Florida Historical Society quarterly, Apr. 1908-<July 1909>
+        */}
         {work.alternativeTitles.length > 0 && (
           <WorkDetailsText
             title="Also known as"

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -676,12 +676,14 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
           />
         ))}
 
+        {/*
+          Note: although angle brackets are sometimes used in the lettering field,
+          it's usually to denote missing or unclear text, not HTML.
+          
+          e.g. Patient <...>, sup<erior> mesenteric a<rtery>
+          */}
         {work.lettering && (
-          <WorkDetailsText
-            title="Lettering"
-            html={[work.lettering]}
-            allowDangerousRawHtml={true}
-          />
+          <WorkDetailsText title="Lettering" text={work.lettering} />
         )}
 
         {work.edition && (

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -599,7 +599,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
         {work.alternativeTitles.length > 0 && (
           <WorkDetailsText
             title="Also known as"
-            html={work.alternativeTitles}
+            text={work.alternativeTitles}
           />
         )}
 

--- a/catalogue/webapp/components/WorkDetailsText/WorkDetailsText.test.tsx
+++ b/catalogue/webapp/components/WorkDetailsText/WorkDetailsText.test.tsx
@@ -2,25 +2,35 @@ import { mountWithTheme } from '@weco/common/test/fixtures/enzyme-helpers';
 import WorkDetailsText from './WorkDetailsText';
 
 describe('WorkDetailsText', () => {
-  it('renders HTML as-is if allowRawHtml=true', () => {
+  it('renders HTML as-is', () => {
     const component = mountWithTheme(
-      <WorkDetailsText
-        text={['This is <strong>bold</strong> text']}
-        allowRawHtml={true}
-      />
+      <WorkDetailsText html={['This is <strong>bold</strong> text']} />
     );
 
     expect(component.html().includes('<strong>bold</strong>')).toBeTruthy();
   });
 
-  it('escapes HTML if allowRawHtml=false', () => {
+  it('escapes HTML if passed as plain text', () => {
     const component = mountWithTheme(
       <WorkDetailsText
         text={['You write HTML with angle brackets like <em>']}
-        allowRawHtml={false}
       />
     );
 
     expect(component.html().includes('&lt;em&gt;')).toBeTruthy();
+  });
+
+  it('renders raw React elements as-is', () => {
+    const component = mountWithTheme(
+      <WorkDetailsText
+        contents={
+          <>
+            This is a <ul>React</ul> element
+          </>
+        }
+      />
+    );
+
+    expect(component.html().includes('<ul>React</ul>')).toBeTruthy();
   });
 });

--- a/catalogue/webapp/components/WorkDetailsText/WorkDetailsText.test.tsx
+++ b/catalogue/webapp/components/WorkDetailsText/WorkDetailsText.test.tsx
@@ -4,7 +4,10 @@ import WorkDetailsText from './WorkDetailsText';
 describe('WorkDetailsText', () => {
   it('renders HTML as-is', () => {
     const component = mountWithTheme(
-      <WorkDetailsText html={['This is <strong>bold</strong> text']} />
+      <WorkDetailsText
+        html={['This is <strong>bold</strong> text']}
+        allowDangerousRawHtml={true}
+      />
     );
 
     expect(component.html().includes('<strong>bold</strong>')).toBeTruthy();

--- a/catalogue/webapp/components/WorkDetailsText/WorkDetailsText.tsx
+++ b/catalogue/webapp/components/WorkDetailsText/WorkDetailsText.tsx
@@ -1,21 +1,29 @@
 import WorkDetailsProperty from '../WorkDetailsProperty/WorkDetailsProperty';
-import { FunctionComponent } from 'react';
+import { FunctionComponent, ReactElement } from 'react';
 
-type Props = {
+type BaseProps = {
   title?: string;
   inlineHeading?: boolean;
   noSpacing?: boolean;
-  allowRawHtml: boolean;
+};
+
+type TextProps = BaseProps & {
   text: string[];
 };
 
-const WorkDetailsText: FunctionComponent<Props> = ({
-  title,
-  inlineHeading = false,
-  noSpacing = false,
-  allowRawHtml,
-  text,
-}: Props) => {
+type HtmlProps = BaseProps & {
+  html: string[];
+};
+
+type ReactProps = BaseProps & {
+  contents: ReactElement;
+};
+
+type Props = TextProps | HtmlProps | ReactProps;
+
+const WorkDetailsText: FunctionComponent<Props> = props => {
+  const { title, inlineHeading, noSpacing } = props;
+
   return (
     <WorkDetailsProperty
       title={title}
@@ -23,13 +31,13 @@ const WorkDetailsText: FunctionComponent<Props> = ({
       noSpacing={noSpacing}
     >
       <div className="spaced-text">
-        {text.map((para, i) => {
-          return allowRawHtml ? (
+        {'contents' in props && props.contents}
+        {'text' in props &&
+          props.text.map((para, i) => <div key={i}>{para}</div>)}
+        {'html' in props &&
+          props.html.map((para, i) => (
             <div key={i} dangerouslySetInnerHTML={{ __html: para }} />
-          ) : (
-            <div key={i}>{para}</div>
-          );
-        })}
+          ))}
       </div>
     </WorkDetailsProperty>
   );

--- a/catalogue/webapp/components/WorkDetailsText/WorkDetailsText.tsx
+++ b/catalogue/webapp/components/WorkDetailsText/WorkDetailsText.tsx
@@ -1,5 +1,6 @@
 import WorkDetailsProperty from '../WorkDetailsProperty/WorkDetailsProperty';
 import { FunctionComponent, ReactElement } from 'react';
+import { isString } from '@weco/common/utils/array';
 
 type BaseProps = {
   title?: string;
@@ -8,7 +9,7 @@ type BaseProps = {
 };
 
 type TextProps = BaseProps & {
-  text: string[];
+  text: string | string[];
 };
 
 // We don't strictly need the `allowDangerousRawHtml` here, but it's to
@@ -17,7 +18,7 @@ type TextProps = BaseProps & {
 //
 // cf https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml
 type HtmlProps = BaseProps & {
-  html: string[];
+  html: string | string[];
   allowDangerousRawHtml: true;
 };
 
@@ -39,10 +40,18 @@ const WorkDetailsText: FunctionComponent<Props> = props => {
       <div className="spaced-text">
         {'contents' in props && props.contents}
         {'text' in props &&
-          props.text.map((para, i) => <div key={i}>{para}</div>)}
+          (isString(props.text) ? (
+            <div key="0">{props.text}</div>
+          ) : (
+            props.text.map((para, i) => <div key={i}>{para}</div>)
+          ))}
         {'html' in props &&
-          props.html.map((para, i) => (
-            <div key={i} dangerouslySetInnerHTML={{ __html: para }} />
+          (isString(props.html) ? (
+            <div key="0" dangerouslySetInnerHTML={{ __html: props.html }} />
+          ) : (
+            props.html.map((para, i) => (
+              <div key={i} dangerouslySetInnerHTML={{ __html: para }} />
+            ))
           ))}
       </div>
     </WorkDetailsProperty>

--- a/catalogue/webapp/components/WorkDetailsText/WorkDetailsText.tsx
+++ b/catalogue/webapp/components/WorkDetailsText/WorkDetailsText.tsx
@@ -11,8 +11,14 @@ type TextProps = BaseProps & {
   text: string[];
 };
 
+// We don't strictly need the `allowDangerousRawHtml` here, but it's to
+// remind downstream callers that we'll be rendering unescaped HTML from
+// the catalogue API, which might be dangerous.
+//
+// cf https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml
 type HtmlProps = BaseProps & {
   html: string[];
+  allowDangerousRawHtml: true;
 };
 
 type ReactProps = BaseProps & {

--- a/catalogue/webapp/pages/download.tsx
+++ b/catalogue/webapp/pages/download.tsx
@@ -16,7 +16,7 @@ import { getWork } from '../services/catalogue/works';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import Layout8 from '@weco/common/views/components/Layout8/Layout8';
 import Download, {
-  getCreditString,
+  getCredit,
 } from '@weco/catalogue/components/Download/Download';
 import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
 import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
@@ -128,14 +128,12 @@ const DownloadPage: NextPage<Props> = ({
                 {license.humanReadableText.length > 0 && (
                   <WorkDetailsText
                     title="License information"
-                    text={license.humanReadableText}
-                    mode="html"
+                    html={license.humanReadableText}
                   />
                 )}
                 <WorkDetailsText
                   title="Credit"
-                  text={getCreditString(workId, title, credit, license)}
-                  mode="html"
+                  contents={getCredit(workId, title, credit, license)}
                 />
               </div>
             </SpacingComponent>

--- a/catalogue/webapp/pages/download.tsx
+++ b/catalogue/webapp/pages/download.tsx
@@ -129,13 +129,13 @@ const DownloadPage: NextPage<Props> = ({
                   <WorkDetailsText
                     title="License information"
                     text={license.humanReadableText}
-                    allowRawHtml={true}
+                    mode="html"
                   />
                 )}
                 <WorkDetailsText
                   title="Credit"
                   text={getCreditString(workId, title, credit, license)}
-                  allowRawHtml={true}
+                  mode="html"
                 />
               </div>
             </SpacingComponent>

--- a/catalogue/webapp/pages/download.tsx
+++ b/catalogue/webapp/pages/download.tsx
@@ -125,10 +125,10 @@ const DownloadPage: NextPage<Props> = ({
           {license && (
             <SpacingComponent key={license.url}>
               <div>
-                {license.humanReadableText.length > 0 && (
+                {license.humanReadableText && (
                   <WorkDetailsText
                     title="License information"
-                    html={license.humanReadableText}
+                    contents={license.humanReadableText}
                   />
                 )}
                 <WorkDetailsText

--- a/catalogue/webapp/pages/download.tsx
+++ b/catalogue/webapp/pages/download.tsx
@@ -213,6 +213,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
 
     return {
       props: removeUndefinedProps({
+        serverData,
         workId,
         sierraId,
         manifest,

--- a/common/utils/licenses.tsx
+++ b/common/utils/licenses.tsx
@@ -9,6 +9,8 @@
 // We augment the catalogue API types with extra data (e.g. icons and human-readable
 // text) so we can display licenses properly in the catalogue app.
 
+import { ReactElement } from 'react';
+
 type CatalogueLicenseData = {
   id: string;
   label: string;
@@ -20,75 +22,129 @@ type CcIcons = 'cc' | 'ccBy' | 'ccNc' | 'ccNd' | 'ccPdm' | 'ccZero' | 'ccSa';
 export type LicenseData = CatalogueLicenseData & {
   icons: CcIcons[];
   description?: string;
-  humanReadableText: string[];
+  humanReadableText?: ReactElement;
 };
 
 const additionalData = {
   pdm: {
     icons: ['ccPdm'],
-    humanReadableText: [
-      'You can use this work for any purpose without restriction under copyright law.',
-      'Public Domain Mark (PDM) terms and conditions <a href="https://creativecommons.org/publicdomain/mark/1.0">https://creativecommons.org/publicdomain/mark/1.0</a>',
-    ],
+    humanReadableText: (
+      <>
+        <div>
+          You can use this work for any purpose without restriction under
+          copyright law.
+        </div>
+        <div>
+          Public Domain Mark (PDM) terms and conditions{' '}
+          <a href="https://creativecommons.org/publicdomain/mark/1.0">
+            https://creativecommons.org/publicdomain/mark/1.0
+          </a>
+        </div>
+      </>
+    ),
   },
   'cc-0': {
     icons: ['ccZero'],
     description: 'Free to use for any purpose',
-    humanReadableText: [
-      'You can use this work for any purpose without restriction under copyright law.',
-      'Creative Commons Zero (CC0) terms and conditions <a href="https://creativecommons.org/publicdomain/zero/1.0">https://creativecommons.org/publicdomain/zero/1.0</a>',
-    ],
+    humanReadableText: (
+      <>
+        <div>
+          You can use this work for any purpose without restriction under
+          copyright law.
+        </div>
+        <div>
+          Creative Commons Zero (CC0) terms and conditions{' '}
+          <a href="https://creativecommons.org/publicdomain/zero/1.0">
+            https://creativecommons.org/publicdomain/zero/1.0
+          </a>
+        </div>
+      </>
+    ),
   },
   'cc-by': {
     icons: ['cc', 'ccBy'],
     description: 'Free to use with attribution',
-    humanReadableText: [
-      'You can use this work for any purpose, including commercial uses, without restriction under copyright law. You should also provide attribution to the original work, source and licence.',
-      'Creative Commons Attribution (CC BY 4.0) terms and conditions <a href="https://creativecommons.org/licenses/by/4.0">https://creativecommons.org/licenses/by/4.0</a>',
-    ],
+    humanReadableText: (
+      <>
+        <div>
+          You can use this work for any purpose, including commercial uses,
+          without restriction under copyright law. You should also provide
+          attribution to the original work, source and licence.
+        </div>
+        <div>
+          Creative Commons Attribution (CC BY 4.0) terms and conditions{' '}
+          <a href="https://creativecommons.org/licenses/by/4.0">
+            https://creativecommons.org/licenses/by/4.0
+          </a>
+        </div>
+      </>
+    ),
   },
   'cc-by-nc': {
     icons: ['cc', 'ccBy', 'ccNc'],
     description: 'Free to use with attribution for non-commercial purposes',
-    humanReadableText: [
-      'You can use this work for any purpose, as long as it is not primarily intended for or directed to commercial advantage or monetary compensation. You should also provide attribution to the original work, source and licence.',
-      'Creative Commons Attribution Non-Commercial (CC BY-NC 4.0) terms and conditions <a href="https://creativecommons.org/licenses/by-nc/4.0">https://creativecommons.org/licenses/by-nc/4.0</a>',
-    ],
+    humanReadableText: (
+      <>
+        <div>
+          You can use this work for any purpose, as long as it is not primarily
+          intended for or directed to commercial advantage or monetary
+          compensation. You should also provide attribution to the original
+          work, source and licence.
+        </div>
+        <div>
+          Creative Commons Attribution Non-Commercial (CC BY-NC 4.0) terms and
+          conditions{' '}
+          <a href="https://creativecommons.org/licenses/by-nc/4.0">
+            https://creativecommons.org/licenses/by-nc/4.0
+          </a>
+        </div>
+      </>
+    ),
   },
   'cc-by-nc-nd': {
     icons: ['cc', 'ccBy', 'ccNc', 'ccNd'],
     description:
       'Free to use with attribution for non-commercial purposes. No modifications permitted.',
-    humanReadableText: [
-      'You can copy and distribute this work, as long as it is not primarily intended for or directed to commercial advantage or monetary compensation. You should also provide attribution to the original work, source and licence.',
-      'If you make any modifications to or derivatives of the work, it may not be distributed.',
-      'Creative Commons Attribution Non-Commercial No-Derivatives (CC BY-NC-ND 4.0) terms and conditions <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">https://creativecommons.org/licenses/by-nc-nd/4.0/</a>',
-    ],
+    humanReadableText: (
+      <>
+        <div>
+          You can copy and distribute this work, as long as it is not primarily
+          intended for or directed to commercial advantage or monetary
+          compensation. You should also provide attribution to the original
+          work, source and licence.
+        </div>
+        <div>
+          If you make any modifications to or derivatives of the work, it may
+          not be distributed.
+        </div>
+        <div>
+          Creative Commons Attribution Non-Commercial No-Derivatives (CC
+          BY-NC-ND 4.0) terms and conditions{' '}
+          <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">
+            https://creativecommons.org/licenses/by-nc-nd/4.0/
+          </a>
+        </div>
+      </>
+    ),
   },
   'cc-by-nd': {
     icons: ['cc', 'ccBy', 'ccNd'],
     description: 'Free to use with attribution. No modifications permitted.',
-    humanReadableText: [],
   },
   'cc-by-sa': {
     icons: ['cc', 'ccBy'],
-    humanReadableText: [],
   },
   'cc-by-nc-sa': {
     icons: ['cc', 'ccBy', 'ccNc'],
-    humanReadableText: [],
   },
   ogl: {
     icons: [],
-    humanReadableText: [],
   },
   opl: {
     icons: [],
-    humanReadableText: [],
   },
   inc: {
     icons: [],
-    humanReadableText: [],
   },
 };
 


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5579

## Who is this for?

People who like accurate data.

## What is it doing for them?

Allowing the presentation of `alternativeTitles` that include angle brackets in the title. I've checked all the instances of it in a recent catalogue snapshot, and it's used for dates, e.g. `The Jolly Journal <2001–2002>`, so we don't need to render this field as HTML.

I also have half an eye towards the dev interface of `<WorkDetailsText>` here – it feels like we want to minimise the places we're render strings as raw HTML, so I've:

* made it more explicit that you're doing something 🔥 **dangerous** 🔥 
* allow passing React elements as the contents when it's something that comes from the front-end codebase, in particular the license and credit text