### PR TITLE
Serialise the multi-content API responses with superjson

### DIFF
--- a/content/webapp/pages/api/multi-content/index.ts
+++ b/content/webapp/pages/api/multi-content/index.ts
@@ -6,16 +6,14 @@ import {
   transformMultiContent,
 } from '../../../services/prismic/transformers/multi-content';
 import { fetchMultiContent } from '../../../services/prismic/fetch/multi-content';
-import { PaginatedResults } from '@weco/common/services/prismic/types';
 import { transformQuery } from '../../../services/prismic/transformers/paginated-results';
-import { MultiContent } from '../../../types/multi-content';
+import superjson from 'superjson';
 
-type Data = PaginatedResults<MultiContent>;
 type NotFound = { notFound: true };
 
 export default async (
   req: NextApiRequest,
-  res: NextApiResponse<Data | NotFound>
+  res: NextApiResponse<string | NotFound>
 ): Promise<void> => {
   const { params } = req.query;
   const parsedQuery = isString(params) ? parseQuery(params) : undefined;
@@ -26,7 +24,7 @@ export default async (
 
     if (query) {
       const multiContent = transformQuery(query, transformMultiContent);
-      return res.status(200).json(multiContent);
+      return res.status(200).json(superjson.stringify(multiContent));
     }
   }
 

--- a/content/webapp/services/prismic/fetch/multi-content.ts
+++ b/content/webapp/services/prismic/fetch/multi-content.ts
@@ -23,6 +23,7 @@ import {
 } from '@weco/common/services/prismic/fetch-links';
 import { PaginatedResults } from '@weco/common/services/prismic/types';
 import { MultiContent } from '../../../types/multi-content';
+import superjson from 'superjson';
 
 export const fetchMultiContent = async (
   { client }: GetServerSidePropsPrismicClient,
@@ -102,6 +103,7 @@ export const fetchMultiContentClientSide = async (
   const response = await fetch(url);
 
   if (response.ok) {
-    return response.json();
+    const json = await response.text();
+    return superjson.parse<PaginatedResults<MultiContent>>(json);
   }
 };


### PR DESCRIPTION
The problem is that using vanilla JSON serialisation on Prismic objects will obliterate the `Date` type.

We've fixed this in the page props with a superjson plugin, which adds information about types to the JSON – and then I thought I could delete all the code which "fixes" the types downstream. e.g. where we call `new Date(date)` on a value which should already be a date.

This exposed a case where the types are still being mishandled, which is the client-side API and fetchers. Putting superjson in the middle seems to fix it in local testing.

I looked at adding this to the URL checker, but it passes the current page, so I don't think it adds much.