### PR TITLE
Don't use moment for formatting dates

### DIFF
--- a/common/services/prismic/opening-times.ts
+++ b/common/services/prismic/opening-times.ts
@@ -240,7 +240,7 @@ export function getTodaysVenueHours(
   venue: Venue
 ): ExceptionalOpeningHoursDay | OpeningHoursDay | undefined {
   const todaysDate = london();
-  const todayString = formatDay(todaysDate);
+  const todayString = formatDay(todaysDate.toDate());
   const exceptionalOpeningHours =
     venue.openingHours.exceptional &&
     venue.openingHours.exceptional.find(i =>

--- a/common/services/prismic/transformers/collection-venues.ts
+++ b/common/services/prismic/transformers/collection-venues.ts
@@ -41,8 +41,9 @@ export function transformCollectionVenue(
     ? data.modifiedDayOpeningTimes
         .filter((modified: ModifiedDayOpeningTime) => modified.overrideDate)
         .map(modified => {
-          const start = modified.startDateTime;
-          const end = modified.endDateTime;
+          const start =
+            modified.startDateTime && new Date(modified.startDateTime);
+          const end = modified.endDateTime && new Date(modified.endDateTime);
           const isClosed = !start;
           const overrideDate =
             modified.overrideDate && new Date(modified.overrideDate);

--- a/common/utils/dates.test.ts
+++ b/common/utils/dates.test.ts
@@ -1,11 +1,13 @@
 import each from 'jest-each';
 import {
   dayBefore,
+  endOfWeek,
   getNextWeekendDateRange,
   isFuture,
   isPast,
   isSameDay,
   isSameMonth,
+  startOfWeek,
 } from './dates';
 
 it('identifies dates in the past', () => {
@@ -105,24 +107,60 @@ describe('dayBefore', () => {
   });
 });
 
+//
+//    September 2022
+// Su Mo Tu We Th Fr Sa
+//              1  2  3
+//  4  5  6  7  8  9 10
+// 11 12 13 14 15 16 17
+// 18 19 20 21 22 23 24
+//
+describe('startOfWeek and endOfWeek', () => {
+  test.each([
+    { day: new Date('2022-09-09'), expectedStart: new Date('2022-09-04') },
+    { day: new Date('2022-09-10'), expectedStart: new Date('2022-09-04') },
+    { day: new Date('2022-09-11'), expectedStart: new Date('2022-09-11') },
+  ])(
+    'the week containing $day starts on $expectedStart',
+    ({ day, expectedStart }) => {
+      expect(isSameDay(startOfWeek(day), expectedStart)).toBeTruthy();
+    }
+  );
+
+  test.each([
+    { day: new Date('2022-09-09'), expectedEnd: new Date('2022-09-10') },
+    { day: new Date('2022-09-10'), expectedEnd: new Date('2022-09-10') },
+    { day: new Date('2022-09-11'), expectedEnd: new Date('2022-09-17') },
+  ])(
+    'the week containing $day ends on $expectedEnd',
+    ({ day, expectedEnd }) => {
+      expect(isSameDay(endOfWeek(day), expectedEnd)).toBeTruthy();
+    }
+  );
+});
+
+//
+//    September 2022
+// Su Mo Tu We Th Fr Sa
+//              1  2  3
+//  4  5  6  7  8  9 10
+// 11 12 13 14 15 16 17
+// 18 19 20 21 22 23 24
+//
 describe('getNextWeekendDateRange', () => {
   test.each([
-    // Monday
     {
       day: new Date('2022-09-05'),
       weekend: { start: new Date('2022-09-09'), end: new Date('2022-09-11') },
     },
-    // Friday
     {
       day: new Date('2022-09-02'),
       weekend: { start: new Date('2022-09-02'), end: new Date('2022-09-04') },
     },
-    // Saturday
     {
       day: new Date('2022-09-03'),
       weekend: { start: new Date('2022-09-02'), end: new Date('2022-09-04') },
     },
-    // Sunday
     {
       day: new Date('2022-09-04'),
       weekend: { start: new Date('2022-09-02'), end: new Date('2022-09-04') },

--- a/common/utils/dates.ts
+++ b/common/utils/dates.ts
@@ -71,6 +71,19 @@ export function addDays(d: Date, days: number): Date {
   return res;
 }
 
+/** Finds the start and end of the week.
+ *
+ * For the purposes of these two functions, weeks start on a Sunday.
+ *
+ */
+export function startOfWeek(d: Date): Date {
+  return addDays(d, -d.getDay());
+}
+
+export function endOfWeek(d: Date): Date {
+  return addDays(d, 6 - d.getDay());
+}
+
 /** Returns a loose range of Friday–Sunday for the next weekend after the
  * given date, possibly including it.
  *

--- a/common/utils/format-date.test.ts
+++ b/common/utils/format-date.test.ts
@@ -164,6 +164,21 @@ describe('formatDateRangeWithMessage', () => {
   });
 });
 
+it('formats dates and timestamps as in London', () => {
+  // In September, London is in British Summer Time – clocks are one hour
+  // ahead of UTC.
+  const autumnDate = new Date('2022-09-06T23:30:00Z');
+
+  expect(formatTime(autumnDate)).toBe('00:30');
+  expect(formatDayDate(autumnDate)).toBe('Wednesday 7 September 2022');
+
+  // In March, London is in GMT – clocks match UTC
+  const springDate = new Date('2022-03-05T23:30:00Z');
+
+  expect(formatTime(springDate)).toBe('23:30');
+  expect(formatDayDate(springDate)).toBe('Saturday 5 March 2022');
+});
+
 describe('formatDuration', () => {
   test.each([
     { seconds: 1, formattedDuration: '00:00:01' },

--- a/common/utils/format-date.test.ts
+++ b/common/utils/format-date.test.ts
@@ -33,6 +33,9 @@ it('formats a timestamp', () => {
 
   const result2 = formatTime(new Date('2009-03-27T09:41:01Z'));
   expect(result2).toEqual('09:41');
+
+  const result3 = formatTime(new Date('2009-03-27T08:00:01Z'));
+  expect(result3).toEqual('08:00');
 });
 
 it('formats a year', () => {

--- a/common/utils/format-date.ts
+++ b/common/utils/format-date.ts
@@ -30,7 +30,7 @@ export function formatDate(date: Date): string {
 }
 
 export function formatTime(date: Date): string {
-  const hours = formatLondon(date, { hour: '2-digit' });
+  const hours = formatLondon(date, { hour: '2-digit', hourCycle: 'h24' });
   const minutes = formatLondon(date, { minute: '2-digit' });
 
   return `${hours}:${minutes}`;

--- a/common/utils/format-date.ts
+++ b/common/utils/format-date.ts
@@ -10,20 +10,30 @@ export function london(d?: DateTypes): Moment {
   return moment.tz(d, 'Europe/London');
 }
 
-export function formatDay(date: Date | Moment): string {
-  return london(date).format('dddd');
+function formatLondon(date: Date, options: Intl.DateTimeFormatOptions): string {
+  return date.toLocaleString('en-GB', {
+    ...options,
+    timeZone: 'Europe/London',
+  });
 }
 
-export function formatDayDate(date: Date | Moment): string {
-  return london(date).format('dddd D MMMM YYYY');
+export function formatDay(date: Date): string {
+  return formatLondon(date, { weekday: 'long' });
 }
 
-export function formatDate(date: Date | Moment): string {
-  return london(date).format('D MMMM YYYY');
+export function formatDayDate(date: Date): string {
+  return `${formatDay(date)} ${formatDate(date)}`;
 }
 
-export function formatTime(date: DateTypes): string {
-  return london(date).format('HH:mm');
+export function formatDate(date: Date): string {
+  return `${formatDayMonth(date)} ${formatYear(date)}`;
+}
+
+export function formatTime(date: Date): string {
+  const hours = formatLondon(date, { hour: '2-digit' });
+  const minutes = formatLondon(date, { minute: '2-digit' });
+
+  return `${hours}:${minutes}`;
 }
 
 export function formatDateRangeWithMessage({
@@ -53,11 +63,14 @@ export function formatDateRangeWithMessage({
 }
 
 export function formatYear(date: Date): string {
-  return london(date).format('YYYY');
+  return formatLondon(date, { year: 'numeric' });
 }
 
 export function formatDayMonth(date: Date): string {
-  return london(date).format('D MMMM');
+  const day = formatLondon(date, { day: 'numeric' });
+  const month = formatLondon(date, { month: 'long' });
+
+  return `${day} ${month}`;
 }
 
 export function formatDuration(seconds: number): string {

--- a/common/utils/format-date.ts
+++ b/common/utils/format-date.ts
@@ -30,8 +30,8 @@ export function formatDate(date: Date): string {
 }
 
 export function formatTime(date: Date): string {
-  const hours = formatLondon(date, { hour: '2-digit', hourCycle: 'h24' });
-  const minutes = formatLondon(date, { minute: '2-digit' });
+  const hours = formatLondon(date, { hour: '2-digit', hourCycle: 'h23' });
+  const minutes = formatLondon(date, { minute: '2-digit' }).padStart(2, '0');
 
   return `${hours}:${minutes}`;
 }

--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -101,6 +101,7 @@ const PageLayoutComponent: FunctionComponent<Props> = ({
     'Array.prototype.flat',
     'Array.prototype.flatMap',
     'Array.prototype.includes',
+    'Intl.DateTimeFormat',
     'Object.entries',
     'Object.fromEntries',
     'Object.values',

--- a/content/webapp/pages/exhibitions.tsx
+++ b/content/webapp/pages/exhibitions.tsx
@@ -18,8 +18,6 @@ import { transformExhibitionsQuery } from '../services/prismic/transformers/exhi
 import { createClient } from '../services/prismic/fetch';
 import { ExhibitionBasic } from '../types/exhibitions';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
-
-import { london } from '@weco/common/utils/format-date';
 import Layout12 from '@weco/common/views/components/Layout12/Layout12';
 import Space from '@weco/common/views/components/styled/Space';
 import CardGrid from '../components/CardGrid/CardGrid';
@@ -77,7 +75,7 @@ const ExhibitionsPage: FC<Props> = props => {
 
   const partitionedExhibitionItems = exhibitions.results.reduce(
     (acc, result) => {
-      if (london(result.end).isSameOrAfter(london())) {
+      if (result.end && result.end >= new Date()) {
         acc.currentAndUpcoming.push(result);
       } else {
         acc.past.push({

--- a/content/webapp/pages/exhibitions.tsx
+++ b/content/webapp/pages/exhibitions.tsx
@@ -26,6 +26,7 @@ import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
 import { headerBackgroundLs } from '@weco/common/utils/backgrounds';
 import Pagination from '@weco/common/views/components/Pagination/Pagination';
+import { isFuture } from '@weco/common/utils/dates';
 
 type Props = {
   exhibitions: PaginatedResults<ExhibitionBasic>;
@@ -75,7 +76,7 @@ const ExhibitionsPage: FC<Props> = props => {
 
   const partitionedExhibitionItems = exhibitions.results.reduce(
     (acc, result) => {
-      if (result.end && result.end >= new Date()) {
+      if (result.end && isFuture(result.end)) {
         acc.currentAndUpcoming.push(result);
       } else {
         acc.past.push({

--- a/content/webapp/services/prismic/transformers/articles.ts
+++ b/content/webapp/services/prismic/transformers/articles.ts
@@ -98,8 +98,7 @@ export function transformArticle(document: ArticlePrismicDocument): Article {
   // When we imported data into Prismic from the Wordpress blog some content
   // needed to have its original publication date displayed. It is purely a display
   // value and does not affect ordering.
-  const datePublished =
-    data.publishDate || document.first_publication_date || undefined;
+  const datePublished = data.publishDate || document.first_publication_date;
 
   const format = isFilledLinkToDocumentWithData(data.format)
     ? (transformLabelType(data.format) as Format<ArticleFormatId>)
@@ -123,7 +122,7 @@ export function transformArticle(document: ArticlePrismicDocument): Article {
     format,
     series,
     contributors,
-    datePublished: datePublished && new Date(datePublished),
+    datePublished: new Date(datePublished),
     seasons: transformSingleLevelGroup(data.seasons, 'season').map(season =>
       transformSeason(season as SeasonPrismicDocument)
     ),

--- a/content/webapp/services/prismic/transformers/articles.ts
+++ b/content/webapp/services/prismic/transformers/articles.ts
@@ -1,6 +1,5 @@
 import { Article, ArticleBasic } from '../../../types/articles';
 import { ArticlePrismicDocument } from '../types/articles';
-import { london } from '@weco/common/utils/format-date';
 import {
   isFilledLinkToDocumentWithData,
   isFilledLinkToWebField,
@@ -124,7 +123,7 @@ export function transformArticle(document: ArticlePrismicDocument): Article {
     format,
     series,
     contributors,
-    datePublished: london(datePublished).toDate(),
+    datePublished: datePublished && new Date(datePublished),
     seasons: transformSingleLevelGroup(data.seasons, 'season').map(season =>
       transformSeason(season as SeasonPrismicDocument)
     ),

--- a/content/webapp/services/prismic/types/predicates.ts
+++ b/content/webapp/services/prismic/types/predicates.ts
@@ -1,7 +1,12 @@
-import moment from 'moment';
 import { predicate } from '@prismicio/client';
-import { getNextWeekendDateRange } from '@weco/common/utils/dates';
-import { london } from '@weco/common/utils/format-date';
+import {
+  addDays,
+  endOfDay,
+  endOfWeek,
+  getNextWeekendDateRange,
+  startOfDay,
+  startOfWeek,
+} from '@weco/common/utils/dates';
 import { Period } from '../../../types/periods';
 
 type Props = { period?: Period; startField: string; endField: string };
@@ -10,21 +15,23 @@ export const getPeriodPredicates = ({
   startField,
   endField,
 }: Props): string[] => {
-  const now = london(new Date());
-  const startOfDay = moment().startOf('day');
-  const endOfDay = moment().endOf('day');
-  const weekendDateRange = getNextWeekendDateRange(now.toDate());
+  const today = new Date();
+
+  const startOfToday = startOfDay(today);
+  const endOfToday = endOfDay(today);
+
+  const weekendDateRange = getNextWeekendDateRange(today);
   const predicates =
     period === 'coming-up'
-      ? [predicate.dateAfter(startField, endOfDay.toDate())]
+      ? [predicate.dateAfter(startField, endOfToday)]
       : period === 'current-and-coming-up'
-      ? [predicate.dateAfter(endField, startOfDay.toDate())]
+      ? [predicate.dateAfter(endField, startOfToday)]
       : period === 'past'
-      ? [predicate.dateBefore(endField, startOfDay.toDate())]
+      ? [predicate.dateBefore(endField, startOfToday)]
       : period === 'today'
       ? [
-          predicate.dateBefore(startField, endOfDay.toDate()),
-          predicate.dateAfter(endField, startOfDay.toDate()),
+          predicate.dateBefore(startField, endOfToday),
+          predicate.dateAfter(endField, startOfToday),
         ]
       : period === 'this-weekend'
       ? [
@@ -33,16 +40,13 @@ export const getPeriodPredicates = ({
         ]
       : period === 'this-week'
       ? [
-          predicate.dateBefore(startField, now.endOf('week').toDate()),
-          predicate.dateAfter(startField, now.startOf('week').toDate()),
+          predicate.dateBefore(startField, endOfWeek(today)),
+          predicate.dateAfter(startField, startOfWeek(today)),
         ]
       : period === 'next-seven-days'
       ? [
-          predicate.dateBefore(
-            startField,
-            now.add(6, 'days').endOf('day').toDate()
-          ),
-          predicate.dateAfter(endField, startOfDay.toDate()),
+          predicate.dateBefore(startField, endOfDay(addDays(today, 6))),
+          predicate.dateAfter(endField, startOfToday),
         ]
       : [];
 


### PR DESCRIPTION
For https://github.com/wellcomecollection/wellcomecollection.org/issues/7831

I have a suspicion that our date formatting is one of the things keeping Moment in the codebase, because we use it a lot – but I don't think we need it any more; anywhere we format a date now is actually getting a vanilla `Date`.

We have tests around date formatting that I added a while back, and I've added additional tests that timestamps are formatted for London specifically (including when London clocks don't match UTC).

I also discovered we can use `date.toLocaleString` and pass a timezone – so I _think_ we can totally expunge Moment from our date formatting, which might shake it out of the content app entirely. 🤞 

~There's a bit more to do in the catalogue app, but I'm hoping this takes a big chunk out.~

I'd missed some stuff in the opening-times handlers, which are used on every page – but those are next on my hit list.