### PR TITLE
Remove use of bg-[color] class

### DIFF
--- a/cardigan/stories/global/spacing/spacing.stories.tsx
+++ b/cardigan/stories/global/spacing/spacing.stories.tsx
@@ -1,40 +1,46 @@
 import { FunctionComponent } from 'react';
+import styled from 'styled-components';
+
 import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
 import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
 
+const ColorSection = styled.div<{ bgColor: string }>`
+  background-color: ${props => props.theme.color(props.bgColor)};
+`;
+
 export const Spacing: FunctionComponent = () => {
   return (
-    <div className="bg-cream font-white">
+    <ColorSection bgColor="cream" className="font-white">
       <SpacingSection>
-        <div className="bg-green" style={{ minHeight: '200px' }}>
+        <ColorSection bgColor="green" style={{ minHeight: '200px' }}>
           Section
-        </div>
+        </ColorSection>
       </SpacingSection>
       <SpacingSection>
-        <div className="bg-green" style={{ minHeight: '200px' }}>
+        <ColorSection bgColor="green" style={{ minHeight: '200px' }}>
           Section
           <SpacingComponent>
-            <div className="bg-teal" style={{ minHeight: '100px' }}>
+            <ColorSection bgColor="teal" style={{ minHeight: '100px' }}>
               Component
-            </div>
+            </ColorSection>
           </SpacingComponent>
           <SpacingComponent>
-            <div className="bg-teal" style={{ minHeight: '100px' }}>
+            <ColorSection bgColor="teal" style={{ minHeight: '100px' }}>
               Component
-            </div>
+            </ColorSection>
           </SpacingComponent>
           <SpacingComponent>
-            <div className="bg-teal" style={{ minHeight: '100px' }}>
+            <ColorSection bgColor="teal" style={{ minHeight: '100px' }}>
               Component
-            </div>
+            </ColorSection>
           </SpacingComponent>
-        </div>
+        </ColorSection>
       </SpacingSection>
       <SpacingSection>
-        <div className="bg-green" style={{ minHeight: '200px' }}>
+        <ColorSection bgColor="green" style={{ minHeight: '200px' }}>
           Section
-        </div>
+        </ColorSection>
       </SpacingSection>
-    </div>
+    </ColorSection>
   );
 };

--- a/catalogue/webapp/components/IIIFImage/IIIFImage.tsx
+++ b/catalogue/webapp/components/IIIFImage/IIIFImage.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react';
 import Image, { ImageLoaderProps } from 'next/image';
-import { classNames } from '@weco/common/utils/classnames';
+import styled from 'styled-components';
 import { ImageType } from '@weco/common/model/image';
 import {
   iiifImageTemplate,
@@ -10,6 +10,10 @@ import {
   convertBreakpointSizesToSizes,
   BreakpointSizes,
 } from '@weco/common/views/components/PrismicImage/PrismicImage';
+
+const StyledImage = styled(Image).attrs({ className: 'font-charcoal' })`
+  background-color: ${props => props.theme.color('white')};
+`;
 
 const IIIFLoader = ({ src, width }: ImageLoaderProps) => {
   return convertImageUri(src, width);
@@ -55,11 +59,8 @@ const IIIFImage: FC<Props> = ({
           sizes={sizesString}
         />
       ) : (
-        <Image
+        <StyledImage
           layout={layout}
-          className={classNames({
-            'bg-white font-charcoal': true,
-          })}
           sizes={sizesString}
           src={image.contentUrl}
           alt={image.alt || ''}

--- a/catalogue/webapp/components/IIIFViewer/IIIFCanvasThumbnail.tsx
+++ b/catalogue/webapp/components/IIIFViewer/IIIFCanvasThumbnail.tsx
@@ -64,15 +64,17 @@ const ImageContainer = styled.div`
 
 const IIIFViewerThumbNumber = styled.span.attrs<ViewerThumbProps>(props => ({
   className: classNames({
-    'line-height-1': true,
     'font-white': !props.isActive,
     'font-black': !!props.isActive,
-    'bg-yellow': !!props.isActive,
     [font('intb', 6)]: true,
   }),
 }))<ViewerThumbProps>`
   padding: 3px 6px;
   border-radius: 3px;
+  line-height: 1;
+
+  ${props =>
+    !!props.isActive && `background-color: ${props.theme.color('yellow')};`}
 `;
 
 type IIIFCanvasThumbnailProps = {

--- a/catalogue/webapp/components/IIIFViewer/NoScriptViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/NoScriptViewer.tsx
@@ -23,6 +23,7 @@ const NoScriptViewerEl = styled.div`
   display: flex;
   flex-direction: row-reverse;
   height: calc(100vh - ${props => props.theme.navHeight}px);
+  background-color: ${props => props.theme.color('charcoal')};
 `;
 
 const NoScriptViewerMain = styled.div`
@@ -191,7 +192,7 @@ const NoScriptViewer: FunctionComponent<NoScriptViewerProps> = ({
       .join(',');
 
   return (
-    <NoScriptViewerEl className="bg-charcoal">
+    <NoScriptViewerEl>
       <NoScriptViewerMain>
         <NoScriptViewerImageWrapper>
           {iiifImageLocation && imageUrl && (

--- a/common/views/components/ApiToolbar/ApiToolbar.tsx
+++ b/common/views/components/ApiToolbar/ApiToolbar.tsx
@@ -1,5 +1,6 @@
-import { useRouter } from 'next/router';
 import { FunctionComponent, useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import styled from 'styled-components';
 import { ParsedUrlQuery } from 'querystring';
 import cookies from 'next-cookies';
 import useIsomorphicLayoutEffect from '../../../hooks/useIsomorphicLayoutEffect';
@@ -33,6 +34,11 @@ const includes = [
   'succeededBy',
   'holdings',
 ];
+
+const ToolbarContainer = styled.div`
+  background-color: ${props => props.theme.color('purple')};
+  z-index: 100;
+`;
 
 /** tzitzit is a tool used by the Digital Editorial team to create TASL
  * strings for Prismic. https://github.com/wellcomecollection/tzitzit
@@ -217,12 +223,7 @@ const ApiToolbar: FunctionComponent = () => {
   };
 
   return (
-    <div
-      className={`bg-purple font-white flex ${mini && 'inline-block'}`}
-      style={{
-        zIndex: 100,
-      }}
-    >
+    <ToolbarContainer className={`font-white flex ${mini && 'inline-block'}`}>
       <div
         className="flex flex--v-center"
         style={{
@@ -270,7 +271,7 @@ const ApiToolbar: FunctionComponent = () => {
         {!mini && <>🤏</>}
         {mini && <>👐</>}
       </button>
-    </div>
+    </ToolbarContainer>
   );
 };
 

--- a/common/views/components/DropdownButton/DropdownButton.tsx
+++ b/common/views/components/DropdownButton/DropdownButton.tsx
@@ -24,10 +24,9 @@ type DropdownProps = {
 const Dropdown = styled(Space).attrs({
   v: { size: 'm', properties: ['padding-top', 'padding-bottom'] },
   h: { size: 'l', properties: ['padding-left', 'padding-right'] },
-  className: classNames({
-    'rounded-corners shadow bg-white': true,
-  }),
+  className: 'rounded-corners shadow',
 })<DropdownProps>`
+  background-color: ${props => props.theme.color('white')};
   margin-top: -2px;
   z-index: ${props => (props.isActive ? 2 : 1)};
   overflow: auto;

--- a/common/views/components/ErrorPage/ErrorPage.tsx
+++ b/common/views/components/ErrorPage/ErrorPage.tsx
@@ -1,6 +1,5 @@
 import { FunctionComponent } from 'react';
 import { headerBackgroundLs } from '../../../utils/backgrounds';
-import { classNames } from '../../../utils/classnames';
 import PageHeader, { headerSpaceSize } from '../PageHeader/PageHeader';
 import PageLayout from '../PageLayout/PageLayout';
 import SpacingSection from '../SpacingSection/SpacingSection';
@@ -51,21 +50,11 @@ const ErrorPage: FunctionComponent<Props> = ({
           HeroPicture={undefined}
           highlightHeading={true}
         />
-        <div
-          className={classNames({
-            'bg-cream': false,
-          })}
-        >
-          <SpacingSection>
-            <SpacingComponent>
-              {statusCode === 404 ? (
-                <NotFoundErrorText />
-              ) : (
-                <DefaultErrorText />
-              )}
-            </SpacingComponent>
-          </SpacingSection>
-        </div>
+        <SpacingSection>
+          <SpacingComponent>
+            {statusCode === 404 ? <NotFoundErrorText /> : <DefaultErrorText />}
+          </SpacingComponent>
+        </SpacingSection>
       </Space>
     </PageLayout>
   );

--- a/common/views/components/Footer/Footer.tsx
+++ b/common/views/components/Footer/Footer.tsx
@@ -11,6 +11,14 @@ import Space from '../styled/Space';
 import OpeningTimes from '../OpeningTimes/OpeningTimes';
 import { Venue } from '../../../model/opening-hours';
 
+const Wrapper = styled(Space).attrs({
+  v: { size: 'xl', properties: ['padding-top'] },
+  className: 'font-white',
+})`
+  position: relative;
+  background-color: ${props => props.theme.color('black')};
+`;
+
 const FooterNavWrapper = styled(Space).attrs({
   v: {
     size: 'm',
@@ -173,13 +181,7 @@ const Footer: FunctionComponent<Props> = ({ venues, hide = false }: Props) => {
     }
   }, []);
   return (
-    <Space
-      v={{ size: 'xl', properties: ['padding-top'] }}
-      ref={footer}
-      className={classNames({
-        'row bg-black relative font-white': true,
-      })}
-    >
+    <Wrapper ref={footer}>
       <div className="container">
         <div className="grid">
           <div className={`${grid({ s: 12, m: 12, l: 4 })}`}>
@@ -362,7 +364,7 @@ const Footer: FunctionComponent<Props> = ({ venues, hide = false }: Props) => {
           </HygieneNav>
         </FooterBottom>
       </div>
-    </Space>
+    </Wrapper>
   );
 };
 

--- a/common/views/components/Footer/FooterSocial.tsx
+++ b/common/views/components/Footer/FooterSocial.tsx
@@ -70,10 +70,6 @@ const Link = styled(Space).attrs({
   &:focus {
     color: ${props => props.theme.color('green')};
   }
-
-  .icon__shape {
-    fill: ${props => props.theme.color('green')};
-  }
 `;
 
 type SocialItem = {
@@ -128,7 +124,7 @@ const FooterSocial: FC = () => (
       <Cell key={item.title}>
         <Link href={item.url}>
           <Space as="span" h={{ size: 's', properties: ['margin-right'] }}>
-            <Icon icon={item.icon} />
+            <Icon icon={item.icon} color="green" />
           </Space>
           <span>{item.title}</span>
           <span className="visually-hidden">{item.service}</span>

--- a/common/views/components/Header/Header.tsx
+++ b/common/views/components/Header/Header.tsx
@@ -1,6 +1,6 @@
 import { FC, useState } from 'react';
 import styled from 'styled-components';
-import { font, classNames } from '../../../utils/classnames';
+import { font } from '../../../utils/classnames';
 import WellcomeCollectionBlack from '../../../icons/wellcome_collection_black';
 import { respondBetween, respondTo } from '../../themes/mixins';
 import DesktopSignIn from './DesktopSignIn';
@@ -24,12 +24,11 @@ type WrapperProps = {
 };
 
 const Wrapper = styled.div.attrs({
-  className: classNames({
-    'grid bg-white flex--v-center': true,
-  }),
+  className: 'grid flex--v-center',
 })<WrapperProps>`
   position: relative;
   z-index: 6;
+  background-color: ${props => props.theme.color('white')};
   border-bottom: 1px solid ${props => props.theme.color('pumice')};
 
   ${props =>

--- a/common/views/components/HeaderBackground/HeaderBackground.tsx
+++ b/common/views/components/HeaderBackground/HeaderBackground.tsx
@@ -1,4 +1,5 @@
 import { FunctionComponent } from 'react';
+import styled from 'styled-components';
 import { landingHeaderBackgroundLs } from '../../../utils/backgrounds';
 import WobblyEdge from '../WobblyEdge/WobblyEdge';
 
@@ -10,6 +11,27 @@ type Props = {
 
 const defaultBackgroundTexture = landingHeaderBackgroundLs;
 
+const Background = styled.div<{ texture: string | null }>`
+  position: absolute;
+  top: 0;
+  bottom: 100px;
+  width: 100%;
+  overflow: hidden;
+  z-index: -1;
+
+  background-color: ${props => props.theme.color('cream')};
+  ${props =>
+    props.texture &&
+    `background-image: url(${props.texture});
+      background-size: cover;`};
+`;
+
+const WobblyEdgeContainer = styled.div`
+  position: absolute;
+  width: 100%;
+  bottom: 0;
+`;
+
 const HeaderBackground: FunctionComponent<Props> = ({
   backgroundTexture,
   hasWobblyEdge,
@@ -18,31 +40,15 @@ const HeaderBackground: FunctionComponent<Props> = ({
   const texture =
     backgroundTexture ||
     (useDefaultBackgroundTexture ? defaultBackgroundTexture : null);
-  const backgroundStyles = texture
-    ? {
-        backgroundImage: `url(${texture})`,
-        backgroundSize: 'cover',
-      }
-    : {};
-
-  const styles = {
-    top: 0,
-    zIndex: -1,
-    bottom: '100px',
-    ...backgroundStyles,
-  };
 
   return (
-    <div
-      className="absolute overflow-hidden full-width bg-cream"
-      style={styles}
-    >
+    <Background texture={texture}>
       {hasWobblyEdge && (
-        <div className="absolute full-width" style={{ bottom: 0 }}>
+        <WobblyEdgeContainer>
           <WobblyEdge isValley={true} intensity={100} background={'white'} />
-        </div>
+        </WobblyEdgeContainer>
       )}
-    </div>
+    </Background>
   );
 };
 

--- a/common/views/components/HeightRestrictedPrismicImage/HeightRestrictedPrismicImage.tsx
+++ b/common/views/components/HeightRestrictedPrismicImage/HeightRestrictedPrismicImage.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react';
 import Image from 'next/image';
-import { classNames } from '../../../utils/classnames';
+import styled from 'styled-components';
 import { ImageType } from '../../../model/image';
 import {
   createPrismicLoader,
@@ -12,6 +12,12 @@ export type Props = {
   maxWidth?: number;
   quality: ImageQuality;
 };
+
+const PrismicImage = styled(Image).attrs({
+  className: 'font-white',
+})`
+  background-color: ${props => props.theme.color('charcoal')};
+`;
 
 function determineSize(viewPortImageDifference): string {
   // the further from 0 the more extreme the difference
@@ -73,13 +79,10 @@ const HeightRestrictedPrismicImage: FC<Props> = ({
     : image.width;
 
   return (
-    <Image
+    <PrismicImage
       width={image.width}
       height={image.height}
       layout="responsive"
-      className={classNames({
-        'bg-charcoal font-white': true,
-      })}
       sizes={`${vSizesString}, calc(100vw - 84px)`}
       src={image.contentUrl}
       alt={image.alt || ''}

--- a/common/views/components/Icon/Icon.tsx
+++ b/common/views/components/Icon/Icon.tsx
@@ -36,7 +36,7 @@ const Wrapper = styled.div.attrs({
   ${props =>
     props.color &&
     `
-  .icon__svg .icon__shape {
+  .icon__shape {
     fill: ${props.theme.color(props.color)};
   }
 

--- a/common/views/components/Icon/Icon.tsx
+++ b/common/views/components/Icon/Icon.tsx
@@ -36,7 +36,7 @@ const Wrapper = styled.div.attrs({
   ${props =>
     props.color &&
     `
-  .icon__shape {
+  .icon__svg .icon__shape {
     fill: ${props.theme.color(props.color)};
   }
 

--- a/common/views/components/InfoBanner/InfoBanner.tsx
+++ b/common/views/components/InfoBanner/InfoBanner.tsx
@@ -8,12 +8,19 @@ import usePrevious from '../../../hooks/usePrevious';
 import { cross, information } from '../../../icons';
 import { GlobalAlertPrismicDocument } from '../../../services/prismic/documents';
 import { InferDataInterface } from '../../../services/prismic/types';
+import styled from 'styled-components';
 
 type Props = {
   cookieName?: string;
   document: { data: InferDataInterface<GlobalAlertPrismicDocument> };
   onVisibilityChange?: (isVisible: boolean) => void;
 };
+
+const BannerContainer = styled(Space).attrs({
+  v: { size: 'm', properties: ['padding-top', 'padding-bottom'] },
+})`
+  background-color: ${props => props.theme.color('yellow')};
+`;
 
 const InfoBanner: FunctionComponent<Props> = ({
   cookieName,
@@ -55,16 +62,7 @@ const InfoBanner: FunctionComponent<Props> = ({
   }, []);
 
   return isVisible ? (
-    <Space
-      v={{
-        size: 'm',
-        properties: ['padding-top', 'padding-bottom'],
-      }}
-      className={`row bg-yellow`}
-      role="region"
-      aria-labelledby="note"
-      id="notification"
-    >
+    <BannerContainer role="region" aria-labelledby="note" id="notification">
       <div className="container">
         <div className="grid">
           <div className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>
@@ -100,7 +98,7 @@ const InfoBanner: FunctionComponent<Props> = ({
           </div>
         </div>
       </div>
-    </Space>
+    </BannerContainer>
   ) : null;
 };
 

--- a/common/views/components/MessageBar/MessageBar.tsx
+++ b/common/views/components/MessageBar/MessageBar.tsx
@@ -1,18 +1,15 @@
 import { ReactNode, FunctionComponent } from 'react';
 import styled from 'styled-components';
-import { classNames, font } from '../../../utils/classnames';
+import { font } from '../../../utils/classnames';
 import Space, { SpaceComponentProps } from '../styled/Space';
 
 const ColouredTag: FunctionComponent<SpaceComponentProps> = styled.span.attrs({
-  className: classNames({
-    caps: true,
-    'inline-block': true,
-    'bg-charcoal': true,
-    'font-white': true,
-    [font('intb', 6)]: true,
-  }),
+  className: `font-white ${font('intb', 6)}`,
 })<SpaceComponentProps>`
+  display: inline-block;
+  background-color: ${props => props.theme.color('charcoal')};
   padding: 0.2em 0.5em;
+  text-transform: uppercase;
   ${props =>
     props.theme.makeSpacePropertyValues(
       's',
@@ -33,9 +30,7 @@ const MessageBar: FunctionComponent<Props> = ({ tagText, children }: Props) => (
       size: 'm',
       properties: ['padding-top', 'padding-bottom'],
     }}
-    className={classNames({
-      [font('intr', 6)]: true,
-    })}
+    className={font('intr', 6)}
   >
     {tagText && <ColouredTag>{tagText}</ColouredTag>}
     {children}

--- a/common/views/components/Modal/Modal.tsx
+++ b/common/views/components/Modal/Modal.tsx
@@ -8,7 +8,6 @@ import {
   MutableRefObject,
 } from 'react';
 import styled from 'styled-components';
-import { classNames } from '../../../utils/classnames';
 import Space from '../styled/Space';
 import Icon from '../Icon/Icon';
 import { AppContext } from '../AppContext/AppContext';
@@ -87,9 +86,7 @@ const CloseButton = styled(Space).attrs<CloseButtonProps>({
 const BaseModalWindow = styled(Space).attrs<BaseModalProps>({
   v: { size: 'xl', properties: ['padding-top', 'padding-bottom'] },
   h: { size: 'xl', properties: ['padding-left', 'padding-right'] },
-  className: classNames({
-    'shadow bg-white': true,
-  }),
+  className: 'shadow',
 })<BaseModalProps>`
   z-index: 10001;
   top: 0;
@@ -99,6 +96,7 @@ const BaseModalWindow = styled(Space).attrs<BaseModalProps>({
   position: fixed;
   overflow: auto;
   transition: opacity 350ms ease, transform 350ms ease;
+  background-color: ${props => props.theme.color('white')};
 
   &,
   &.fade-exit-done {
@@ -154,9 +152,7 @@ const BaseModalWindow = styled(Space).attrs<BaseModalProps>({
 
 const FiltersModal = styled(BaseModalWindow).attrs<BaseModalProps>({
   v: { size: 'xl', properties: ['padding-top', 'padding-bottom'] },
-  className: classNames({
-    'shadow bg-white': true,
-  }),
+  className: 'shadow',
 })<BaseModalProps>`
   overflow: hidden;
   padding-left: 0px;

--- a/common/views/components/ModalMoreFilters/ModalMoreFilters.tsx
+++ b/common/views/components/ModalMoreFilters/ModalMoreFilters.tsx
@@ -1,6 +1,5 @@
 import React, { FunctionComponent, RefObject, useContext } from 'react';
 import Modal from '../../components/Modal/Modal';
-import { classNames } from '@weco/common/utils/classnames';
 import styled from 'styled-components';
 import Space from '../styled/Space';
 import { searchFilterCheckBox } from '../../../text/aria-labels';
@@ -55,9 +54,7 @@ const FilterSection = styled(Space).attrs({
 `;
 
 const List = styled.ul.attrs({
-  className: classNames({
-    'no-margin no-padding plain-list': true,
-  }),
+  className: 'no-margin no-padding plain-list',
 })`
   display: flex;
   flex-wrap: wrap;
@@ -69,10 +66,9 @@ const List = styled.ul.attrs({
 const FiltersFooter = styled(Space).attrs({
   h: { size: 'l', properties: ['padding-left', 'padding-right'] },
   v: { size: 'l', properties: ['padding-top', 'padding-bottom'] },
-  className: classNames({
-    'bg-white flex flex--v-center flex--h-space-between': true,
-  }),
+  className: 'flex flex--v-center flex--h-space-between',
 })`
+  background-color: ${props => props.theme.color('white')};
   border-top: 1px solid ${props => props.theme.color('pumice')};
   position: fixed;
   bottom: 0;
@@ -84,10 +80,8 @@ const FiltersFooter = styled(Space).attrs({
 const FiltersHeader = styled(Space).attrs({
   h: { size: 'm', properties: ['padding-left', 'padding-right'] },
   v: { size: 'm', properties: ['padding-top', 'padding-bottom'] },
-  className: classNames({
-    absolute: true,
-  }),
 })`
+  position: absolute;
   border-bottom: 1px solid ${props => props.theme.color('pumice')};
   text-align: center;
   top: 0px;
@@ -148,11 +142,7 @@ const MoreFilters: FunctionComponent<MoreFiltersProps> = ({
           <FilterSection key={f.id}>
             <h3 className="h3">{f.label}</h3>
             <Space as="span" h={{ size: 'm', properties: ['margin-right'] }}>
-              <div
-                className={classNames({
-                  'no-margin no-padding plain-list': true,
-                })}
-              >
+              <div className="no-margin no-padding plain-list">
                 {f.type === 'checkbox' && (
                   <CheckboxFilter f={f} changeHandler={changeHandler} />
                 )}

--- a/common/views/components/Number/Number.tsx
+++ b/common/views/components/Number/Number.tsx
@@ -1,5 +1,6 @@
 import { FunctionComponent, ReactElement } from 'react';
-import { classNames, font } from '../../../utils/classnames';
+import styled from 'styled-components';
+import { font } from '../../../utils/classnames';
 import Space from '../styled/Space';
 
 type Props = {
@@ -7,25 +8,25 @@ type Props = {
   color?: string;
 };
 
+const Wrapper = styled(Space)<{ color?: string }>`
+  background-color: ${props => props.theme.color(props.color || 'purple')};
+
+  transform: rotateZ(-6deg);
+  width: 24px;
+  height: 24px;
+  display: inline-block;
+  border-radius: 3px;
+  text-align: center;
+`;
+
 const Number: FunctionComponent<Props> = ({
   number,
   color,
 }: Props): ReactElement<Props> => (
-  <Space
+  <Wrapper
     as="span"
     h={{ size: 's', properties: ['margin-left'] }}
-    className={classNames({
-      [font('wb', 5)]: true,
-      [`bg-${color || 'purple'}`]: true,
-    })}
-    style={{
-      transform: 'rotateZ(-6deg)',
-      width: '24px',
-      height: '24px',
-      display: 'inline-block',
-      borderRadius: '3px',
-      textAlign: 'center',
-    }}
+    className={font('wb', 5)}
   >
     <span
       className={color === 'yellow' ? 'font-black' : 'font-white'}
@@ -33,7 +34,7 @@ const Number: FunctionComponent<Props> = ({
     >
       {number}
     </span>
-  </Space>
+  </Wrapper>
 );
 
 export default Number;

--- a/common/views/components/PageHeader/HighlightedHeading.tsx
+++ b/common/views/components/PageHeader/HighlightedHeading.tsx
@@ -4,6 +4,7 @@ import { FunctionComponent } from 'react';
 
 const Heading = styled(Space)`
   display: block;
+  background-color: ${props => props.theme.color('white')};
 
   @supports (box-decoration-break: clone) {
     display: inline;
@@ -25,7 +26,6 @@ const HighlightedHeading: FunctionComponent<Props> = ({ text }: Props) => {
           properties: ['padding-top', 'padding-bottom'],
         }}
         h={{ size: 'm', properties: ['padding-left', 'padding-right'] }}
-        className={`bg-white`}
       >
         {text}
       </Heading>

--- a/common/views/components/PageHeader/PageHeader.tsx
+++ b/common/views/components/PageHeader/PageHeader.tsx
@@ -25,7 +25,9 @@ import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper
 // The `bottom` values here are coupled to the space
 // beneath the Header in ContentPage.tsx
 export const headerSpaceSize = 'l';
-const HeroPictureBackground = styled.div`
+const HeroPictureBackground = styled.div<{ bgColor: string }>`
+  position: absolute;
+  background-color: ${props => props.theme.color(props.bgColor)};
   height: 50%;
   width: 100%;
   bottom: -${props => props.theme.spaceAtBreakpoints.small[headerSpaceSize]}px;
@@ -225,9 +227,7 @@ const PageHeader: FunctionComponent<Props> = ({
             })}
             style={{ height: '100%' }}
           >
-            <HeroPictureBackground
-              className={`bg-${heroImageBgColor} absolute`}
-            />
+            <HeroPictureBackground bgColor={heroImageBgColor} />
 
             <HeroPictureContainer>
               <WobblyBottom color={heroImageBgColor}>

--- a/common/views/components/PopupDialog/PopupDialog.tsx
+++ b/common/views/components/PopupDialog/PopupDialog.tsx
@@ -10,7 +10,7 @@ import styled from 'styled-components';
 import cookie from 'cookie-cutter';
 import Icon from '../Icon/Icon';
 import Space from '../styled/Space';
-import { classNames, font } from '../../../utils/classnames';
+import { font } from '../../../utils/classnames';
 import getFocusableElements from '../../../utils/get-focusable-elements';
 import { trackEvent } from '../../../utils/ga';
 import { AppContext } from '../AppContext/AppContext';
@@ -39,10 +39,10 @@ const PopupDialogOpen = styled(Space).attrs<PopupDialogOpenProps>(props => ({
     properties: ['padding-left', 'padding-right'],
     overrides: { small: 5, medium: 5, large: 5 },
   },
-  className: classNames({
-    [font('intb', 5)]: true,
-    'plain-button line-height-1 flex-inline flex--v-center': true,
-  }),
+  className: `${font(
+    'intb',
+    5
+  )} plain-button line-height-1 flex-inline flex--v-center`,
 }))<PopupDialogOpenProps>`
   color: ${props => props.theme.color('purple')};
   position: fixed;
@@ -89,10 +89,9 @@ const PopupDialogWindow = styled(Space).attrs({
     properties: ['padding-left', 'padding-right'],
     overrides: { small: 6, medium: 6, large: 6 },
   },
-  className: classNames({
-    'bg-white font-purple': true,
-  }),
+  className: 'font-purple',
 })<PopupDialogWindowProps>`
+  background-color: ${props => props.theme.color('white')};
   border-radius: 20px 0 20px 0;
   box-shadow: 0 2px 60px 0 rgba(0, 0, 0, 0.7);
   opacity: ${props => (props.isActive ? 1 : 0)};
@@ -110,10 +109,8 @@ const PopupDialogWindow = styled(Space).attrs({
 `;
 
 const PopupDialogClose = styled.button.attrs({
-  className: classNames({
-    'absolute plain-button no-margin no-padding flex flex--v-center flex--h-center':
-      true,
-  }),
+  className:
+    'absolute plain-button no-margin no-padding flex flex--v-center flex--h-center',
 })<{ isKeyboard: boolean }>`
   top: 10px;
   right: 10px;
@@ -141,11 +138,12 @@ const PopupDialogCTA = styled(Space).attrs({
     properties: ['padding-left', 'padding-right'],
     overrides: { small: 5, medium: 5, large: 5 },
   },
-  className: classNames({
-    [font('intb', 5, { small: 3, medium: 3 })]: true,
-    'bg-purple rounded-corners inline-block': true,
-  }),
+  className: `${font('intb', 5, {
+    small: 3,
+    medium: 3,
+  })} rounded-corners inline-block`,
 })`
+  background-color: ${props => props.theme.color('purple')};
   color: ${props => props.theme.color('white')};
   transition: all 500ms ease;
   border: 2px solid transparent;
@@ -326,21 +324,15 @@ const PopupDialog: FunctionComponent<Props> = ({ document }: Props) => {
           }}
         >
           <h2
-            className={classNames({
-              [font('wb', 6, {
-                small: 5,
-                medium: 5,
-                large: 5,
-              })]: true,
+            className={font('wb', 6, {
+              small: 5,
+              medium: 5,
+              large: 5,
             })}
           >
             {title}
           </h2>
-          <div
-            className={classNames({
-              [font('intr', 5, { medium: 2, large: 2 })]: true,
-            })}
-          >
+          <div className={font('intr', 5, { medium: 2, large: 2 })}>
             <PrismicHtmlBlock html={text} />
           </div>
         </Space>

--- a/common/views/components/PrismicImage/PrismicImage.tsx
+++ b/common/views/components/PrismicImage/PrismicImage.tsx
@@ -1,8 +1,12 @@
 import { FC } from 'react';
 import Image, { ImageLoaderProps } from 'next/image';
-import { classNames } from '../../../utils/classnames';
+import styled from 'styled-components';
 import { Breakpoint, sizes as breakpointSizes } from '../../themes/config';
 import { ImageType } from '../../../model/image';
+
+const StyledImage = styled(Image).attrs({ className: 'font-white' })`
+  background-color: ${props => props.theme.color('charcoal')};
+`;
 
 export type BreakpointSizes = Partial<Record<Breakpoint, number>>;
 export type Props = {
@@ -94,13 +98,10 @@ const PrismicImage: FC<Props> = ({ image, sizes, maxWidth, quality }) => {
     : image.width;
 
   return (
-    <Image
+    <StyledImage
       width={image.width}
       height={image.height}
       layout="responsive"
-      className={classNames({
-        'bg-charcoal font-white': true,
-      })}
       sizes={sizesString}
       src={image.contentUrl}
       alt={image.alt || ''}

--- a/common/views/components/SearchFilters/ResetActiveFilters.tsx
+++ b/common/views/components/SearchFilters/ResetActiveFilters.tsx
@@ -1,11 +1,11 @@
 import React, { Fragment, FunctionComponent, ReactNode } from 'react';
 import { ParsedUrlQuery } from 'querystring';
+import styled from 'styled-components';
 import { LinkProps } from '@weco/common/model/link-props';
 import Icon from '../Icon/Icon';
 import Space from '../styled/Space';
 import NextLink from 'next/link';
 import { font, classNames } from '../../../utils/classnames';
-import styled from 'styled-components';
 import { Filter } from '../../../services/catalogue/filters';
 import { getColorDisplayName } from '../../components/PaletteColorPicker/PaletteColorPicker';
 import { cross } from '@weco/common/icons';
@@ -24,6 +24,14 @@ const ColorSwatch = styled.span`
   background-color: ${({ color }) => color};
   margin-left: 6px;
   padding-top: 2px;
+`;
+
+const Wrapper = styled(Space).attrs({
+  v: { size: 's', properties: ['padding-top'] },
+  h: { size: 'm', properties: ['padding-left', 'padding-right'] },
+  className: 'tokens',
+})`
+  background-color: ${props => props.theme.color('white')};
 `;
 
 type CancelFilterProps = {
@@ -97,11 +105,7 @@ export const ResetActiveFilters: FunctionComponent<ResetActiveFilters> = ({
   const filterState = Object.fromEntries(filterStateMap);
 
   return (
-    <Space
-      v={{ size: 's', properties: ['padding-top'] }}
-      h={{ size: 'm', properties: ['padding-left', 'padding-right'] }}
-      className="tokens bg-white"
-    >
+    <Wrapper>
       <div className={classNames({ [font('intb', 5)]: true })} role="status">
         <div>
           <h2 className="inline">
@@ -223,6 +227,6 @@ export const ResetActiveFilters: FunctionComponent<ResetActiveFilters> = ({
           </NextLink>
         </div>
       </div>
-    </Space>
+    </Wrapper>
   );
 };

--- a/common/views/components/SearchFilters/SearchFiltersDesktop.tsx
+++ b/common/views/components/SearchFilters/SearchFiltersDesktop.tsx
@@ -4,7 +4,8 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { font, classNames } from '../../../utils/classnames';
+import styled from 'styled-components';
+import { font } from '../../../utils/classnames';
 import { useControlledState } from '../../../utils/useControlledState';
 import Space from '../styled/Space';
 import Icon from '../Icon/Icon';
@@ -34,15 +35,21 @@ type CheckboxFilterProps = {
   f: CheckboxFilterType;
   changeHandler: () => void;
 };
+
+const Wrapper = styled(Space).attrs({
+  v: {
+    size: 'm',
+    properties: ['padding-top'],
+  },
+})`
+  display: flex;
+  background-color: ${props => props.theme.color('pumice')};
+`;
+
 const CheckboxFilter = ({ f, changeHandler }: CheckboxFilterProps) => {
   return (
     <DropdownButton label={f.label} buttonType={'inline'} id={f.id}>
-      <ul
-        className={classNames({
-          'no-margin no-padding plain-list': true,
-          [font('intr', 5)]: true,
-        })}
-      >
+      <ul className={`no-margin no-padding plain-list ${font('intr', 5)}`}>
         {f.options.map(({ id, label, value, count, selected }) => {
           return (
             <li key={`${f.id}-${id}`}>
@@ -73,11 +80,7 @@ const DateRangeFilter = ({ f, changeHandler }: DateRangeFilterProps) => {
   const [to, setTo] = useControlledState(f.to.value);
 
   return (
-    <Space
-      className={classNames({
-        [font('intr', 5)]: true,
-      })}
-    >
+    <Space className={font('intr', 5)}>
       <DropdownButton label={f.label} buttonType={'inline'} id={f.id}>
         <>
           <Space as="span" h={{ size: 'm', properties: ['margin-right'] }}>
@@ -151,41 +154,24 @@ const SearchFiltersDesktop: FunctionComponent<SearchFiltersSharedProps> = ({
 
   return (
     <>
-      <Space
-        v={{
-          size: 'm',
-          properties: ['padding-top'],
-        }}
-        className={classNames({
-          'flex bg-pumice': true,
-        })}
-      >
+      <Wrapper>
         <Space
           h={{ size: 'm', properties: ['padding-left', 'padding-right'] }}
-          className={classNames({
-            'flex flex--h-space-between flex--v-center full-width flex--wrap':
-              true,
-          })}
+          className="flex flex--h-space-between flex--v-center full-width flex--wrap"
         >
           <Space
             v={{ size: 'm', properties: ['margin-bottom'] }}
-            className={classNames({
-              'flex flex--v-center flex--wrap': true,
-            })}
+            className="flex flex--v-center flex--wrap"
           >
             <Space
               as="span"
               h={{ size: 'm', properties: ['margin-right'] }}
-              className={classNames({
-                'flex flex--v-center': true,
-              })}
+              className="flex flex--v-center"
             >
               <Icon icon={filter} />
               <Space
                 h={{ size: 's', properties: ['margin-left'] }}
-                className={classNames({
-                  [font('intb', 5)]: true,
-                })}
+                className={font('intb', 5)}
               >
                 Filter by
               </Space>
@@ -218,9 +204,7 @@ const SearchFiltersDesktop: FunctionComponent<SearchFiltersSharedProps> = ({
 
             {modalFilters.length > 0 && (
               <Space
-                className={classNames({
-                  [font('intr', 5)]: true,
-                })}
+                className={font('intr', 5)}
                 h={{ size: 's', properties: ['margin-left'] }}
               >
                 <ButtonSolid
@@ -248,7 +232,7 @@ const SearchFiltersDesktop: FunctionComponent<SearchFiltersSharedProps> = ({
             )}
           </Space>
         </Space>
-      </Space>
+      </Wrapper>
 
       {activeFiltersCount > 0 && (
         <ResetActiveFilters

--- a/common/views/components/SearchFilters/SearchFiltersMobile.tsx
+++ b/common/views/components/SearchFilters/SearchFiltersMobile.tsx
@@ -11,7 +11,6 @@ import { useControlledState } from '../../../utils/useControlledState';
 import NextLink from 'next/link';
 import { toLink as worksLink } from '../WorksLink/WorksLink';
 import styled from 'styled-components';
-import { classNames } from '../../../utils/classnames';
 import Space from '../styled/Space';
 import Icon from '../Icon/Icon';
 import NumberInput from '@weco/common/views/components/NumberInput/NumberInput';
@@ -36,6 +35,12 @@ const PaletteColorPicker = dynamic(
   import('../PaletteColorPicker/PaletteColorPicker')
 );
 
+const SearchFiltersContainer = styled(Space).attrs({
+  v: { size: 'm', properties: ['padding-top', 'padding-bottom'] },
+})`
+  background-color: ${props => props.theme.color('white')};
+`;
+
 const ShameButtonWrap = styled(Space).attrs({
   v: { size: 'm', properties: ['padding-top', 'padding-bottom'] },
 })`
@@ -48,9 +53,6 @@ const ShameButtonWrap = styled(Space).attrs({
 const FiltersHeader = styled(Space).attrs({
   h: { size: 'm', properties: ['padding-left', 'padding-right'] },
   v: { size: 'l', properties: ['padding-top', 'padding-bottom'] },
-  className: classNames({
-    relative: true,
-  }),
 })`
   border-bottom: 1px solid ${props => props.theme.color('pumice')};
 `;
@@ -61,10 +63,11 @@ const ActiveFilters = styled(Space).attrs({
     properties: ['margin-left', 'padding-left', 'padding-right'],
   },
   v: { size: 'xs', properties: ['padding-top', 'padding-bottom'] },
-  className: classNames({
-    'bg-yellow font-black inline-block rounded-corners text-align-center': true,
-  }),
+  className: 'font-black rounded-corners',
 })`
+  display: inline-block;
+  background-color: ${props => props.theme.color('yellow')};
+  text-align: center;
   min-width: 24px;
 `;
 
@@ -82,11 +85,8 @@ const FilterSection = styled(Space).attrs({
   border-bottom: 1px solid ${props => props.theme.color('pumice')};
 `;
 
-const FiltersScrollable = styled.div.attrs({
-  className: classNames({
-    absolute: true,
-  }),
-})`
+const FiltersScrollable = styled.div`
+  position: absolute;
   width: 100%;
   height: calc(100% - 60px);
   overflow: auto;
@@ -95,10 +95,9 @@ const FiltersScrollable = styled.div.attrs({
 const FiltersFooter = styled(Space).attrs({
   h: { size: 'xl', properties: ['padding-left', 'padding-right'] },
   v: { size: 'xl', properties: ['padding-top', 'padding-bottom'] },
-  className: classNames({
-    'bg-white flex flex--v-center flex--h-space-between': true,
-  }),
+  className: 'flex flex--v-center flex--h-space-between',
 })`
+  background-color: ${props => props.theme.color('white')};
   border-top: 1px solid ${props => props.theme.color('pumice')};
   position: fixed;
   bottom: 0;
@@ -115,11 +114,7 @@ const CheckboxFilter = ({ f, changeHandler }: CheckboxFilterProps) => {
   return (
     <>
       <h3 className="h3">{f.label}</h3>
-      <ul
-        className={classNames({
-          'no-margin no-padding plain-list': true,
-        })}
-      >
+      <ul className={'no-margin no-padding plain-list'}>
         {f.options.map(({ id, label, value, count, selected }) => {
           return (
             <Space
@@ -269,10 +264,7 @@ const SearchFiltersMobile: FunctionComponent<SearchFiltersSharedProps> = ({
   }
 
   return (
-    <Space
-      v={{ size: 'm', properties: ['padding-top', 'padding-bottom'] }}
-      className={classNames({ 'bg-white': true })}
-    >
+    <SearchFiltersContainer>
       <ShameButtonWrap>
         <SolidButton
           type={ButtonTypes.button}
@@ -346,7 +338,7 @@ const SearchFiltersMobile: FunctionComponent<SearchFiltersSharedProps> = ({
           </FiltersFooter>
         </Modal>
       </FocusTrap>
-    </Space>
+    </SearchFiltersContainer>
   );
 };
 

--- a/common/views/components/SegmentedControl/SegmentedControl.tsx
+++ b/common/views/components/SegmentedControl/SegmentedControl.tsx
@@ -21,10 +21,7 @@ const DrawerItem = styled(Space).attrs({
     properties: ['padding-top', 'padding-bottom'],
   },
   as: 'li',
-  className: classNames({
-    [font('wb', 4)]: true,
-    'segmented-control__drawer-item': true,
-  }),
+  className: `${font('wb', 4)} segmented-control__drawer-item`,
 })<DrawerItemProps>`
   border-bottom: 1px solid ${props => props.theme.color('smoke')};
 
@@ -36,14 +33,8 @@ const DrawerItem = styled(Space).attrs({
 `;
 
 const List = styled.ul.attrs({
-  className: classNames({
-    'segmented-control__list': true,
-    'no-margin': true,
-    'no-padding': true,
-    'plain-list': true,
-    'rounded-diagonal': true,
-    'overflow-hidden': true,
-  }),
+  className:
+    'segmented-control__list no-margin no-padding plain-list rounded-diagonal overflow-hidden',
 })`
   border: 1px solid ${props => props.theme.color('black')};
 `;
@@ -53,13 +44,10 @@ type ItemProps = {
 };
 
 const Item = styled.li.attrs({
-  className: classNames({
-    [font('wb', 6)]: true,
-    'segmented-control__item': true,
-    'line-height-1': true,
-    flex: true,
-  }),
+  className: `${font('wb', 6)} segmented-control__item`,
 })<ItemProps>`
+  display: flex;
+  line-height: 1;
   border-right: 1px solid ${props => props.theme.color('black')};
 
   ${props =>
@@ -71,15 +59,16 @@ const Item = styled.li.attrs({
 
 const ItemInner = styled.a.attrs<IsActiveProps>(props => ({
   className: classNames({
-    'is-active bg-black font-white': props.isActive,
-    'bg-white font-black': !props.isActive,
-    block: true,
-    'plain-link': true,
-    'segmented-control__link': true,
-    'transition-bg': true,
-    'no-visible-focus': true,
+    'is-active font-white': props.isActive,
+    'font-black': !props.isActive,
+    'plain-link segmented-control__link transition-bg no-visible-focus': true,
   }),
 }))<IsActiveProps>`
+  display: block;
+
+  background-color: ${props =>
+    props.theme.color(props.isActive ? 'black' : 'white')};
+
   ${props =>
     props.theme.makeSpacePropertyValues(
       'm',
@@ -183,6 +172,25 @@ const Wrapper = styled.div.attrs({})<IsActiveProps>`
   }
 `;
 
+const MobileControlsContainer = styled(Space).attrs({
+  v: { size: 'm', properties: ['padding-top', 'padding-bottom'] },
+  h: { size: 'm', properties: ['padding-left', 'padding-right'] },
+  className: `${font(
+    'wb',
+    4
+  )} segmented-control__button-text font-white flex--h-space-between rounded-diagonal`,
+})`
+  display: flex;
+  background-color: ${props => props.theme.color('black')};
+`;
+
+const MobileControlsModal = styled(Space).attrs({
+  h: { size: 'm', properties: ['padding-left', 'padding-right'] },
+  className: 'segmented-control__body',
+})`
+  background-color: ${props => props.theme.color('white')};
+`;
+
 type Props = {
   id: string;
   items: { id: string; text: string; url: string }[];
@@ -225,39 +233,18 @@ class SegmentedControl extends Component<Props, State> {
 
     return (
       <Wrapper className={extraClasses} isActive={isActive}>
-        <div
-          className={classNames({
-            'segmented-control__drawer': true,
-          })}
-        >
+        <div className="segmented-control__drawer">
           <button className="segmented-control__header plain-button no-margin no-padding">
             {items
               .filter(item => item.id === activeId)
               .map(item => (
                 <Fragment key={item.id}>
-                  <Space
-                    v={{
-                      size: 'm',
-                      properties: ['padding-top', 'padding-bottom'],
-                    }}
-                    h={{
-                      size: 'm',
-                      properties: ['padding-left', 'padding-right'],
-                    }}
-                    className={classNames({
-                      [font('wb', 4)]: true,
-                      'segmented-control__button-text': true,
-                      flex: true,
-                      'bg-black': true,
-                      'font-white': true,
-                      'flex--h-space-between': true,
-                      'rounded-diagonal': true,
-                    })}
+                  <MobileControlsContainer
                     onClick={() => this.setState({ isActive: true })}
                   >
                     <span>{item.text}</span>
                     <Icon icon={chevron} color={'white'} />
-                  </Space>
+                  </MobileControlsContainer>
                   <span
                     className="segmented-control__close"
                     onClick={() => this.setState({ isActive: false })}
@@ -267,27 +254,16 @@ class SegmentedControl extends Component<Props, State> {
                 </Fragment>
               ))}
           </button>
-          <Space
-            h={{ size: 'm', properties: ['padding-left', 'padding-right'] }}
-            id={id}
-            className={classNames({
-              'segmented-control__body': true,
-              'bg-white': true,
-            })}
-          >
+          <MobileControlsModal id={id}>
             <Space
               v={{
                 size: 'm',
                 properties: ['margin-bottom'],
               }}
-              className={classNames({
-                'segmented-control__label': true,
-                block: true,
-              })}
+              className="segmented-control__label block"
             >
               See:
             </Space>
-
             <ul className="segmented-control__drawer-list no-margin no-padding plain-list">
               {items.map((item, i) => (
                 <DrawerItem isFirst={i === 0} key={item.id}>
@@ -314,18 +290,14 @@ class SegmentedControl extends Component<Props, State> {
                       }
                     }}
                     href={item.url}
-                    className={classNames({
-                      'segmented-control__drawer-link': true,
-                      block: true,
-                      'plain-link': true,
-                    })}
+                    className="segmented-control__drawer-link block plain-link"
                   >
                     {item.text}
                   </a>
                 </DrawerItem>
               ))}
             </ul>
-          </Space>
+          </MobileControlsModal>
         </div>
         <List>
           {items.map((item, i) => (

--- a/common/views/components/Table/Table.tsx
+++ b/common/views/components/Table/Table.tsx
@@ -92,9 +92,7 @@ const TableWrap = styled.div`
 `;
 
 const TableTable = styled.table.attrs({
-  className: classNames({
-    [font('intr', 5)]: true,
-  }),
+  className: font('intr', 5),
 })`
   width: 100%;
   border-collapse: collapse;
@@ -105,9 +103,7 @@ const TableThead = styled.thead`
 `;
 
 const TableCaption = styled.caption.attrs({
-  className: classNames({
-    'visually-hidden': true,
-  }),
+  className: 'visually-hidden',
 })``;
 
 const TableTbody = styled.tbody``;
@@ -319,21 +315,11 @@ const Table: FunctionComponent<Props> = ({
         <ScrollButtons isActive={isOverflown}>
           <ScrollButtonWrap isLeft isActive={isLeftActive} ref={leftButtonRef}>
             <Rotator rotate={180}>
-              <Control
-                colorScheme="light"
-                icon={arrow}
-                extraClasses="bg-white font-green"
-                text=""
-              />
+              <Control colorScheme="light" icon={arrow} text="" />
             </Rotator>
           </ScrollButtonWrap>
           <ScrollButtonWrap isActive={isRightActive} ref={rightButtonRef}>
-            <Control
-              colorScheme="light"
-              icon={arrow}
-              extraClasses="bg-white font-green"
-              text=""
-            />
+            <Control colorScheme="light" icon={arrow} text="" />
           </ScrollButtonWrap>
         </ScrollButtons>
         <TableWrap ref={tableWrapRef}>

--- a/common/views/components/Tasl/Tasl.tsx
+++ b/common/views/components/Tasl/Tasl.tsx
@@ -41,12 +41,18 @@ type TaslIconProps = {
   isEnhanced: boolean;
 };
 const TaslIcon = styled.span.attrs({
-  className: 'flex--v-center flex--h-center bg-transparent-black font-white',
+  className: 'flex--v-center flex--h-center font-white',
 })<TaslIconProps>`
+  background: rgba(29, 29, 29, 0.61);
   width: ${props => `${props.theme.iconDimension}px`};
   height: ${props => `${props.theme.iconDimension}px`};
   border-radius: 50%;
   display: ${props => (props.isEnhanced ? 'flex' : 'inline')};
+`;
+
+const InfoContainer = styled(Space)`
+  background-color: ${props => props.theme.color('black')};
+  padding-right: 36px;
 `;
 
 export type MarkUpProps = {
@@ -206,7 +212,7 @@ const Tasl: FunctionComponent<Props> = ({
           </span>
         </TaslIcon>
       </TaslButton>
-      <Space
+      <InfoContainer
         id={title || sourceName || copyrightHolder || ''}
         v={{
           size: 's',
@@ -214,10 +220,9 @@ const Tasl: FunctionComponent<Props> = ({
         }}
         h={{ size: 's', properties: ['padding-left'] }}
         className={classNames({
-          'bg-black font-white': true,
+          'font-white': true,
           'is-hidden': isEnhanced && !isActive,
         })}
-        style={{ paddingRight: '36px' }}
       >
         {getMarkup({
           title,
@@ -228,7 +233,7 @@ const Tasl: FunctionComponent<Props> = ({
           copyrightHolder,
           copyrightLink,
         })}
-      </Space>
+      </InfoContainer>
     </StyledTasl>
   ) : null;
 };

--- a/common/views/components/WobblyEdgedContainer/WobblyEdgedContainer.tsx
+++ b/common/views/components/WobblyEdgedContainer/WobblyEdgedContainer.tsx
@@ -8,6 +8,11 @@ const WobblyEdgeContainer = styled.div`
   width: 100%;
 `;
 
+const Wrapper = styled.div`
+  position: relative;
+  background-color: ${props => props.theme.color('cream')};
+`;
+
 type Props = {
   children: ReactNode;
 };
@@ -16,7 +21,7 @@ const WobblyEdgedContainer: FunctionComponent<Props> = ({
   children,
 }: Props) => {
   return (
-    <div className="bg-cream relative">
+    <Wrapper>
       <WobblyEdgeContainer>
         <WobblyEdge isRotated={true} background={'white'} />
       </WobblyEdgeContainer>
@@ -26,7 +31,7 @@ const WobblyEdgedContainer: FunctionComponent<Props> = ({
       <WobblyEdgeContainer>
         <WobblyEdge background={'white'} />
       </WobblyEdgeContainer>
-    </div>
+    </Wrapper>
   );
 };
 export default WobblyEdgedContainer;

--- a/common/views/components/WobblyRow/WobblyRow.tsx
+++ b/common/views/components/WobblyRow/WobblyRow.tsx
@@ -1,5 +1,6 @@
 import { FunctionComponent, ReactNode } from 'react';
-import { grid, classNames } from '../../../utils/classnames';
+import styled from 'styled-components';
+import { grid } from '../../../utils/classnames';
 import WobblyEdge from '../WobblyEdge/WobblyEdge';
 import { repeatingLsBlack } from '../../../utils/backgrounds';
 
@@ -7,26 +8,29 @@ type Props = {
   children: ReactNode;
 };
 
+const WobblyRowContainer = styled.div.attrs({
+  className: 'font-white',
+})`
+  position: relative;
+  background-color: ${props => props.theme.color('charcoal')};
+`;
+
+const WobblyRowPattern = styled.div`
+  position: absolute;
+  background-image: 'url(${repeatingLsBlack})';
+  background-repeat: no-repeat;
+  background-position: top center;
+  opacity: 0.15;
+  overflow: hidden;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 100%;
+`;
+
 const WobblyRow: FunctionComponent<Props> = ({ children }: Props) => (
-  <div
-    className={classNames({
-      'row bg-charcoal font-white relative': true,
-    })}
-  >
-    <div
-      style={{
-        position: 'absolute',
-        backgroundImage: `url(${repeatingLsBlack})`,
-        backgroundRepeat: 'no-repeat',
-        backgroundPosition: 'top center',
-        opacity: 0.15,
-        overflow: 'hidden',
-        top: 0,
-        left: 0,
-        right: 0,
-        height: '100%',
-      }}
-    ></div>
+  <WobblyRowContainer>
+    <WobblyRowPattern />
     <div className="container">
       <div className="grid" style={{ marginTop: '50px' }}>
         <div
@@ -38,7 +42,7 @@ const WobblyRow: FunctionComponent<Props> = ({ children }: Props) => (
       </div>
     </div>
     <WobblyEdge isValley={false} intensity={35} background={'white'} />
-  </div>
+  </WobblyRowContainer>
 );
 
 export default WobblyRow;

--- a/common/views/themes/config.ts
+++ b/common/views/themes/config.ts
@@ -111,11 +111,6 @@ export const colors = {
     dark: 'transparent',
     light: 'transparent',
   },
-  'transparent-black': {
-    base: 'rgba(29, 29, 29, 0.61)',
-    dark: '',
-    light: '',
-  },
   // Opacity value explanation; We use transparent to provide a background to white text which overlays a variety of images (therefore unknown colour contrast).  This opacity is the lightest we can go, while still providing sufficient contrast to pass WCAG guidlines, when it is displayed above a white background, i.e. worst case scenario.
   inherit: { base: 'inherit', dark: '', light: '' },
   currentColor: { base: 'currentColor', dark: '', light: '' },

--- a/common/views/themes/utility-classes.ts
+++ b/common/views/themes/utility-classes.ts
@@ -13,9 +13,6 @@ export const utilityClasses = css<GlobalStyleProps>`
     .icon__shape {
       fill: ${value.base};
     }
-  }
-  .bg-${key} {
-    background: ${value.base};
   }`;
     })
     .join(' ')}

--- a/common/views/themes/utility-classes.ts
+++ b/common/views/themes/utility-classes.ts
@@ -389,10 +389,6 @@ export const utilityClasses = css<GlobalStyleProps>`
     margin-top: auto;
   }
 
-  .bg-transparent-black {
-    background: rgba(29, 29, 29, 0.61);
-  }
-
   .promo-link {
     height: 100%;
     color: ${themeValues.color('black')};

--- a/content/webapp/components/Body/Body.tsx
+++ b/content/webapp/components/Body/Body.tsx
@@ -99,7 +99,7 @@ const Wrapper = styled(Space).attrs<{
 }>({
   className: `row card-theme 
   bg-${props => props.rowBackgroundColor} 
-    card-theme--${props => props.cardBackgroundColor}`, // Keeping bg-[color] class as other places are styled based on this parent class.
+    card-theme--${props => props.cardBackgroundColor}`, // Keeping bg-[color] class as some components below are styled based on this parent class.
 })<{ rowBackgroundColor: string; cardBackgroundColor: string }>`
   background-color: ${props => props.theme.color(props.rowBackgroundColor)};
 `;

--- a/content/webapp/components/Body/Body.tsx
+++ b/content/webapp/components/Body/Body.tsx
@@ -5,6 +5,7 @@ import React, {
   FunctionComponent,
   Fragment,
 } from 'react';
+import styled from 'styled-components';
 import { classNames, font } from '@weco/common/utils/classnames';
 import { Link } from '../../types/link';
 import {
@@ -91,6 +92,17 @@ type Props = {
 };
 
 type ContentListSlice = BodySlice & { type: 'contentList' };
+
+const Wrapper = styled(Space).attrs<{
+  rowBackgroundColor: string;
+  cardBackgroundColor: string;
+}>({
+  className: `row card-theme 
+  bg-${props => props.rowBackgroundColor} 
+    card-theme--${props => props.cardBackgroundColor}`, // Keeping bg-[color] class as other places are styled based on this parent class.
+})<{ rowBackgroundColor: string; cardBackgroundColor: string }>`
+  background-color: ${props => props.theme.color(props.rowBackgroundColor)};
+`;
 
 const Body: FunctionComponent<Props> = ({
   body,
@@ -215,7 +227,7 @@ const Body: FunctionComponent<Props> = ({
                       isStatic
                     />
                   )}
-                  <Space
+                  <Wrapper
                     v={{
                       size: 'xl',
                       properties:
@@ -225,11 +237,8 @@ const Body: FunctionComponent<Props> = ({
                           ? ['padding-bottom']
                           : ['padding-top', 'padding-bottom'],
                     }}
-                    className={classNames({
-                      'row card-theme': true,
-                      [`bg-${sectionTheme.rowBackground}`]: true,
-                      [`card-theme--${sectionTheme.cardBackground}`]: true,
-                    })}
+                    rowBackgroundColor={sectionTheme.rowBackground}
+                    cardBackgroundColor={sectionTheme.cardBackground}
                   >
                     {section.value.title && (
                       <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
@@ -249,7 +258,7 @@ const Body: FunctionComponent<Props> = ({
                         }
                       />
                     )}
-                  </Space>
+                  </Wrapper>
                   {!isLast && <WobblyEdge background={'white'} isStatic />}
                 </Fragment>
               );

--- a/content/webapp/components/BookImage/BookImage.tsx
+++ b/content/webapp/components/BookImage/BookImage.tsx
@@ -1,6 +1,5 @@
 import styled from 'styled-components';
 import Space from '@weco/common/views/components/styled/Space';
-import { classNames } from '@weco/common/utils/classnames';
 import { FunctionComponent, ReactElement } from 'react';
 import PrismicImage, {
   BreakpointSizes,
@@ -8,21 +7,16 @@ import PrismicImage, {
 } from '@weco/common/views/components/PrismicImage/PrismicImage';
 import { ImageType } from '@weco/common/model/image';
 
-const BookPromoImageContainer = styled.div.attrs({
-  className: classNames({
-    'bg-cream relative': true,
-  }),
-})`
+const BookPromoImageContainer = styled.div`
+  position: relative;
+  background-color: ${props => props.theme.color('cream')};
   height: 0;
   padding-top: 100%;
   transform: rotate(-2deg);
 `;
 
-const BookPromoImage = styled(Space).attrs({
-  className: classNames({
-    absolute: true,
-  }),
-})`
+const BookPromoImage = styled(Space)`
+  position: absolute;
   width: 66%;
   left: 50%;
   transform: translateX(-50%) rotate(2deg);

--- a/content/webapp/components/ContentPage/ContentPage.tsx
+++ b/content/webapp/components/ContentPage/ContentPage.tsx
@@ -10,7 +10,6 @@ import {
   prismicPageIds,
   sectionLevelPages,
 } from '@weco/common/data/hardcoded-ids';
-import { classNames } from '@weco/common/utils/classnames';
 import { Season } from '../../types/seasons';
 import { ElementFromComponent } from '@weco/common/utils/utility-types';
 import { MultiContent } from '../../types/multi-content';
@@ -54,6 +53,12 @@ type Props = {
   contributorTitle?: string;
   hideContributors?: true;
 };
+
+const Wrapper = styled.div<{ isCreamy: boolean }>`
+  overflow: auto;
+  ${props =>
+    props.isCreamy && `background-color: ${props.theme.color('cream')}`};
+`;
 
 const ShameBorder = styled(Space).attrs({
   v: { size: 'l', properties: ['margin-top'] },
@@ -136,12 +141,7 @@ const ContentPage = ({
             {Header}
           </Space>
         )}
-        <div
-          style={{ overflow: 'auto' }} // prevent margin collapsing for children
-          className={classNames({
-            'bg-cream': isCreamy,
-          })}
-        >
+        <Wrapper isCreamy={isCreamy}>
           {shouldRenderBody() && (
             <SpacingSection>
               <div className="basic-page">
@@ -202,7 +202,7 @@ const ContentPage = ({
                 </Layout12>
               </SpacingSection>
             ))}
-        </div>
+        </Wrapper>
       </article>
     </PageBackgroundContext.Provider>
   );

--- a/content/webapp/components/EventSchedule/EventScheduleItem.tsx
+++ b/content/webapp/components/EventSchedule/EventScheduleItem.tsx
@@ -1,5 +1,5 @@
-import { Fragment, FC } from 'react';
-import { grid, font, classNames } from '@weco/common/utils/classnames';
+import { FC } from 'react';
+import { grid, font } from '@weco/common/utils/classnames';
 import EventBookingButton from './EventBookingButton';
 import EventbriteButtons from '../EventbriteButtons/EventbriteButtons';
 import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
@@ -25,6 +25,26 @@ const GridWrapper = styled(Space).attrs({
   border-bottom: 1px solid ${props => props.theme.color('smoke')};
 `;
 
+const EventContainer = styled(Space).attrs({
+  v: {
+    size: 'm',
+    properties: [
+      'margin-top',
+      'margin-bottom',
+      'padding-top',
+      'padding-bottom',
+    ],
+  },
+  h: {
+    size: 'm',
+    properties: ['padding-left', 'padding-right'],
+  },
+  className: font('intb', 5),
+})`
+  display: inline-block;
+  background-color: ${props => props.theme.color('yellow')};
+`;
+
 const EventScheduleItem: FC<Props> = ({ event, isNotLinked }) => {
   const waitForTicketSales =
     event.ticketSalesStart && !isPast(event.ticketSalesStart);
@@ -38,10 +58,7 @@ const EventScheduleItem: FC<Props> = ({ event, isNotLinked }) => {
             size: 'm',
             properties: ['margin-bottom'],
           }}
-          className={classNames({
-            [grid({ s: 12, m: 12, l: 3, xl: 2 })]: true,
-            'no-margin-l': true,
-          })}
+          className={`${grid({ s: 12, m: 12, l: 3, xl: 2 })} no-margin-l`}
         >
           {event.times &&
             event.times.map(t => {
@@ -83,9 +100,7 @@ const EventScheduleItem: FC<Props> = ({ event, isNotLinked }) => {
                 <Space
                   v={{ size: 's', properties: ['margin-bottom'] }}
                   as="p"
-                  className={classNames({
-                    [font('intr', 5)]: true,
-                  })}
+                  className={font('intr', 5)}
                 >
                   {event.locations[0].title}
                 </Space>
@@ -121,32 +136,12 @@ const EventScheduleItem: FC<Props> = ({ event, isNotLinked }) => {
             {!isEventPast(event) &&
               event.ticketSalesStart &&
               waitForTicketSales && (
-                <Fragment>
-                  <Space
-                    v={{
-                      size: 'm',
-                      properties: [
-                        'margin-top',
-                        'margin-bottom',
-                        'padding-top',
-                        'padding-bottom',
-                      ],
-                    }}
-                    h={{
-                      size: 'm',
-                      properties: ['padding-left', 'padding-right'],
-                    }}
-                    className={classNames({
-                      'bg-yellow inline-block': true,
-                      [font('intb', 5)]: true,
-                    })}
-                  >
-                    <span>
-                      Booking opens {formatDayDate(event.ticketSalesStart)}{' '}
-                      {formatTime(event.ticketSalesStart)}
-                    </span>
-                  </Space>
-                </Fragment>
+                <EventContainer>
+                  <span>
+                    Booking opens {formatDayDate(event.ticketSalesStart)}{' '}
+                    {formatTime(event.ticketSalesStart)}
+                  </span>
+                </EventContainer>
               )}
 
             {!isEventPast(event) &&

--- a/content/webapp/components/FeaturedCard/FeaturedCard.tsx
+++ b/content/webapp/components/FeaturedCard/FeaturedCard.tsx
@@ -12,7 +12,7 @@ import { Card } from '../../types/card';
 import { Label } from '@weco/common/model/labels';
 import { Link } from '../../types/link';
 import PartNumberIndicator from '../PartNumberIndicator/PartNumberIndicator';
-import { grid, classNames, font } from '@weco/common/utils/classnames';
+import { grid, font } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
 import StatusIndicator from '@weco/common/views/components/StatusIndicator/StatusIndicator';
@@ -108,21 +108,9 @@ const FeaturedCardArticleBody: FunctionComponent<FeaturedCardArticleBodyProps> =
         {positionInSeries && (
           <PartNumberIndicator number={positionInSeries} color={seriesColor} />
         )}
-        <h2
-          className={classNames({
-            [font('wb', 2)]: true,
-          })}
-        >
-          {article.title}
-        </h2>
+        <h2 className={font('wb', 2)}>{article.title}</h2>
         {article.promo?.caption && (
-          <p
-            className={classNames({
-              [font('intr', 5)]: true,
-            })}
-          >
-            {article.promo?.caption}
-          </p>
+          <p className={font('intr', 5)}>{article.promo?.caption}</p>
         )}
         {article.series.length > 0 && (
           <Space v={{ size: 'l', properties: ['margin-top'] }}>
@@ -152,13 +140,7 @@ const FeaturedCardExhibitionBody = ({
 }: FeaturedCardExhibitionBodyProps) => {
   return (
     <div data-test-id="featured-exhibition">
-      <h2
-        className={classNames({
-          [font('wb', 2)]: true,
-        })}
-      >
-        {exhibition.title}
-      </h2>
+      <h2 className={font('wb', 2)}>{exhibition.title}</h2>
       {!exhibition.statusOverride && exhibition.start && exhibition.end && (
         <Space
           as="p"
@@ -197,23 +179,17 @@ const FeaturedCardWrap = styled.div`
 
 type HasIsReversed = { isReversed: boolean };
 const FeaturedCardLink = styled.a.attrs(() => ({
-  className: classNames({
-    'grid flex-end promo-link plain-link': true,
-  }),
+  className: 'grid flex-end promo-link plain-link',
 }))<HasIsReversed>`
   flex-direction: ${props => (props.isReversed ? 'row-reverse' : 'row')};
 `;
 
 const FeaturedCardLeft = styled.div.attrs({
-  className: classNames({
-    [grid({ s: 12, m: 12, l: 7, xl: 7 })]: true,
-  }),
+  className: grid({ s: 12, m: 12, l: 7, xl: 7 }),
 })``;
 
 const FeaturedCardRight = styled.div.attrs({
-  className: classNames({
-    'flex flex--column': true,
-  }),
+  className: 'flex flex--column',
 })<HasIsReversed>`
   padding-left: ${props => (props.isReversed ? 0 : props.theme.gutter.small)}px;
   padding-right: ${props =>
@@ -235,25 +211,23 @@ const FeaturedCardRight = styled.div.attrs({
   `}
 `;
 
-const FeaturedCardCopy = styled(Space).attrs(() => ({
+const FeaturedCardCopy = styled(Space).attrs<{ color: string }>(props => ({
   h: { size: 'l', properties: ['padding-left', 'padding-right'] },
   v: { size: 'l', properties: ['padding-top', 'padding-bottom'] },
-  className: classNames({
-    'flex-1': true,
-  }),
-}))`
+  className: `flex-1 font-${props.color}`,
+}))<{ background: string }>`
+  background-color: ${props => props.theme.color(props.background)};
+
   ${props => props.theme.media.large`
     margin-right: -${props => props.theme.gutter.large}px;
   `}
 `;
 
-const FeaturedCardShim = styled.div.attrs<{ background: string }>(props => ({
-  className: classNames({
-    [`bg-${props.background}`]: true,
-    'is-hidden-s is-hidden-m relative': true,
-    [grid({ s: 12, m: 11, l: 5, xl: 5 })]: true,
-  }),
-}))<HasIsReversed & { background: string }>`
+const FeaturedCardShim = styled.div.attrs<{ background: string }>({
+  className: `is-hidden-s is-hidden-m ${grid({ s: 12, m: 11, l: 5, xl: 5 })}`,
+})<HasIsReversed & { background: string }>`
+  position: relative;
+  background-color: ${props => props.theme.color(props.background)};
   height: 21px;
   /* Prevent a white line appearing above the shim because of browser rounding errors */
   top: -1px;
@@ -298,32 +272,19 @@ const FeaturedCard: FunctionComponent<Props> = ({
             />
           )}
         </FeaturedCardLeft>
-        <div
-          className={classNames({
-            flex: true,
-            [grid({ s: 12, m: 11, l: 5, xl: 5 })]: true,
-          })}
-        >
+        <div className={`flex ${grid({ s: 12, m: 11, l: 5, xl: 5 })}`}>
           <FeaturedCardRight isReversed={isReversed}>
             {labels && labels.length > 0 ? (
               <LabelsList labels={labels} />
             ) : (
               <div style={{ marginBottom: '26px' }} />
             )}
-            <FeaturedCardCopy
-              className={classNames({
-                [`bg-${background} font-${color}`]: true,
-              })}
-            >
+            <FeaturedCardCopy background={background} color={color}>
               {children}
             </FeaturedCardCopy>
           </FeaturedCardRight>
         </div>
-        <div
-          className={classNames({
-            [grid({ s: 12, m: 12, l: 7, xl: 7 })]: true,
-          })}
-        ></div>
+        <div className={grid({ s: 12, m: 12, l: 7, xl: 7 })}></div>
         <FeaturedCardShim background={background} isReversed={isReversed} />
       </FeaturedCardLink>
     </FeaturedCardWrap>

--- a/content/webapp/components/InfoBox/InfoBox.tsx
+++ b/content/webapp/components/InfoBox/InfoBox.tsx
@@ -1,5 +1,6 @@
-import React, { Fragment, FC, ReactNode } from 'react';
-import { font, classNames } from '@weco/common/utils/classnames';
+import React, { FC, ReactNode } from 'react';
+import styled from 'styled-components';
+import { font } from '@weco/common/utils/classnames';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import { LabelField } from '@weco/common/model/label-field';
@@ -16,52 +17,41 @@ type Props = {
   children: ReactNode;
 };
 
+const InfoContainer = styled(Space).attrs({
+  v: { size: 'l', properties: ['padding-top', 'padding-bottom'] },
+  h: { size: 'l', properties: ['padding-left', 'padding-right'] },
+})`
+  background-color: ${props => props.theme.color('yellow')};
+`;
+
 const InfoBox: FC<Props> = ({ title, items, children }) => {
   return (
     <>
       <h2 className="h2">{title}</h2>
-      <Space
-        v={{
-          size: 'l',
-          properties: ['padding-top', 'padding-bottom'],
-        }}
-        h={{ size: 'l', properties: ['padding-left', 'padding-right'] }}
-        className={classNames({
-          'bg-yellow': true,
-        })}
-      >
+      <InfoContainer>
         {items.map(({ title, description, icon }, i) => (
-          <Fragment key={i}>
-            <div className={font('intb', 4)}>
-              {icon && (title || description) && (
-                <Space
-                  h={{ size: 's', properties: ['margin-right'] }}
-                  className={`float-l`}
-                >
-                  <Icon icon={icon} />
-                </Space>
-              )}
-              {title && (
-                <h3 className={classNames([font('intb', 5)])}>{title}</h3>
-              )}
-              {description && (
-                <Space
-                  v={{
-                    size: 'm',
-                    properties: ['margin-bottom'],
-                  }}
-                  className={classNames({
-                    [font('intr', 5)]: true,
-                  })}
-                >
-                  <PrismicHtmlBlock html={description} />
-                </Space>
-              )}
-            </div>
-          </Fragment>
+          <div key={i}>
+            {icon && (title || description) && (
+              <Space
+                h={{ size: 's', properties: ['margin-right'] }}
+                className={`float-l ${font('intb', 4)}`}
+              >
+                <Icon icon={icon} />
+              </Space>
+            )}
+            {title && <h3 className={font('intb', 5)}>{title}</h3>}
+            {description && (
+              <Space
+                v={{ size: 'm', properties: ['margin-bottom'] }}
+                className={font('intr', 5)}
+              >
+                <PrismicHtmlBlock html={description} />
+              </Space>
+            )}
+          </div>
         ))}
         {children}
-      </Space>
+      </InfoContainer>
     </>
   );
 };

--- a/content/webapp/components/StoryPromo/StoryPromo.tsx
+++ b/content/webapp/components/StoryPromo/StoryPromo.tsx
@@ -1,5 +1,5 @@
 import { FunctionComponent } from 'react';
-import { font, classNames } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import { trackEvent } from '@weco/common/utils/ga';
 import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
 import PartNumberIndicator from '../PartNumberIndicator/PartNumberIndicator';
@@ -16,7 +16,6 @@ type Props = {
   };
   position: number;
   hidePromoText?: boolean;
-  hasTransparentBackground?: boolean;
   sizesQueries?: string;
 };
 
@@ -24,7 +23,6 @@ const StoryPromo: FunctionComponent<Props> = ({
   article,
   position,
   hidePromoText = false,
-  hasTransparentBackground = false,
 }: Props) => {
   const image = article.promo?.image;
   const url = linkResolver(article);
@@ -64,9 +62,6 @@ const StoryPromo: FunctionComponent<Props> = ({
         });
       }}
       href={url}
-      className={classNames({
-        'bg-cream': !hasTransparentBackground,
-      })}
     >
       <div className="relative">
         {isNotUndefined(image) && (
@@ -116,12 +111,7 @@ const StoryPromo: FunctionComponent<Props> = ({
             {article.title}
           </Space>
           {!hidePromoText && isNotUndefined(article.promo?.caption) && (
-            <p
-              className={classNames({
-                'inline-block no-margin': true,
-                [font('intr', 5)]: true,
-              })}
-            >
+            <p className={`inline-block no-margin ${font('intr', 5)}`}>
               {article.promo?.caption}
             </p>
           )}

--- a/content/webapp/components/VenueHours/VenueHours.tsx
+++ b/content/webapp/components/VenueHours/VenueHours.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent, Fragment } from 'react';
 import { formatDay, formatDayMonth } from '@weco/common/utils/format-date';
 import styled from 'styled-components';
-import { classNames, font } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import MoreLink from '@weco/common/views/components/MoreLink/MoreLink';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import Divider from '@weco/common/views/components/Divider/Divider';
@@ -47,11 +47,9 @@ type JauntyBoxProps = {
   bottomLeft: string;
   bottomRight: string;
 };
-const JauntyBox = styled(Space).attrs(() => ({
-  className: classNames({
-    'bg-yellow inline-block': true,
-  }),
-}))<JauntyBoxProps>`
+const JauntyBox = styled(Space)<JauntyBoxProps>`
+  display: inline-block;
+  background-color: ${props => props.theme.color('yellow')};
   padding-left: 30px;
   padding-right: 42px;
   margin-left: -12px;
@@ -128,18 +126,11 @@ const VenueHours: FunctionComponent<Props> = ({ venue, weight }) => {
         <Space
           as="h2"
           h={{ size: 'm', properties: ['padding-right'] }}
-          className={classNames({
-            h2: true,
-          })}
+          className="h2"
         >
           {isFeatured && venue?.name ? venue.name : 'Opening hours'}
         </Space>
-        <ul
-          className={classNames({
-            'plain-list no-padding no-margin': true,
-            [font('intr', 5)]: true,
-          })}
-        >
+        <ul className={`plain-list no-padding no-margin ${font('intr', 5)}`}>
           {venue?.openingHours.regular.map(
             ({ dayOfWeek, opens, closes, isClosed }) => (
               <li key={dayOfWeek}>
@@ -169,16 +160,8 @@ const VenueHours: FunctionComponent<Props> = ({ venue, weight }) => {
               bottomRight={randomPx()}
               bottomLeft={randomPx()}
             >
-              <h3
-                className={classNames({
-                  [font('intb', 5)]: true,
-                })}
-              >
-                <div
-                  className={classNames({
-                    'flex flex--v-center': true,
-                  })}
-                >
+              <h3 className={font('intb', 5)}>
+                <div className="flex flex--v-center">
                   <Space
                     as="span"
                     h={{ size: 's', properties: ['margin-right'] }}
@@ -189,10 +172,7 @@ const VenueHours: FunctionComponent<Props> = ({ venue, weight }) => {
                 </div>
               </h3>
               <ul
-                className={classNames({
-                  'plain-list no-padding no-margin': true,
-                  [font('intr', 5)]: true,
-                })}
+                className={`plain-list no-padding no-margin ${font('intr', 5)}`}
               >
                 {upcomingExceptionalPeriod.map(p => (
                   <li key={p.overrideDate?.toString()}>

--- a/content/webapp/pages/stories.tsx
+++ b/content/webapp/pages/stories.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react';
-import { classNames } from '@weco/common/utils/classnames';
+import styled from 'styled-components';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import Layout12 from '@weco/common/views/components/Layout12/Layout12';
 import SectionHeader from '@weco/common/views/components/SectionHeader/SectionHeader';
@@ -64,36 +64,22 @@ type Props = {
   jsonLd: JsonLdObj[];
 };
 
+const ArticlesContainer = styled.div`
+  background-color: ${props => props.theme.color('cream')};
+`;
+
 const SerialisedSeries = ({ series }: { series: SerialisedSeriesProps }) => {
   return (
     <div>
       <Layout12>
         <Space v={{ size: 'xl', properties: ['margin-bottom'] }}>
-          <h2
-            className={classNames({
-              h1: true,
-              [`font-${series.color}`]: true,
-              'plain-link': true,
-              'no-margin': true,
-            })}
-          >
-            <a
-              className={classNames({
-                'plain-link': true,
-              })}
-              href={`/series/${series.id}`}
-            >
+          <h2 className={`h1 font-${series.color} plain-link no-margin`}>
+            <a className="plain-link" href={`/series/${series.id}`}>
               {series.title}
             </a>
           </h2>
           <Space v={{ size: 'm', properties: ['margin-top'] }}>
-            <p
-              className={classNames({
-                'no-margin': true,
-              })}
-            >
-              {series.promo?.caption}
-            </p>
+            <p className="no-margin">{series.promo?.caption}</p>
           </Space>
         </Space>
       </Layout12>
@@ -236,11 +222,7 @@ const StoriesPage: FC<Props> = ({
       </>
 
       <SpacingSection>
-        <div
-          className={classNames({
-            'row bg-cream row--has-wobbly-background': true,
-          })}
-        >
+        <ArticlesContainer className="row--has-wobbly-background">
           <Space v={{ size: 'xl', properties: ['margin-bottom'] }}>
             <Layout12>
               <FeaturedCardArticle
@@ -266,7 +248,7 @@ const StoriesPage: FC<Props> = ({
               </div>
             </Space>
           </div>
-        </div>
+        </ArticlesContainer>
       </SpacingSection>
 
       <SpacingSection>


### PR DESCRIPTION
## Who is this for?
Devs who style

## What is it doing for them?
Makes the theme the source of truth + start depending on styled-components for styling and moving away from class based styles.

I've also refactored the use of `classNames()` in the components I was changing as it's not necessary when there is no condition to analyse.