### PR TITLE
Fix usage of dasherize and make captions guide type work again

### DIFF
--- a/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
+++ b/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
@@ -225,7 +225,7 @@ const Stop: FC<{ stop: Stop; isFirstStop: boolean }> = ({
         >
           <div className="flex flex--wrap container">
             <Tombstone>
-              <TombstoneTitle id={dasherize(title)}>
+              <TombstoneTitle id={dasherize(`${title}`)}>
                 {!hasContext && title}
               </TombstoneTitle>
               <div className={font('intr', 4)}>

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -456,7 +456,6 @@ const ExhibitionGuidePage: FC<Props> = props => {
   }`;
   const typeColor = getTypeColor(type);
   const numberedStops = exhibitionGuide.components.filter(c => c.number);
-
   return (
     <PageLayout
       title={`${exhibitionGuide.title} guide` || ''}


### PR DESCRIPTION


## Who is this for?

Any guide users

## What is it doing for them?

In one case of `title` the type was an object, not a string. I have forced that title to be a string when feeding it to the dasherize function, this fixes the captions guide type pages which were 500'ing. 