### PR TITLE
No more Moment in `@weco/catalogue/utils/date`

### DIFF
--- a/cardigan/stories/components/Calendar/Calendar.stories.tsx
+++ b/cardigan/stories/components/Calendar/Calendar.stories.tsx
@@ -7,15 +7,15 @@ const Template = () => {
 
   return (
     <Calendar
-      min={london('2002-04-01')}
-      max={london('2002-05-08')}
+      min={london('2002-04-01T12:00:00Z')}
+      max={london('2002-05-08T12:00:00Z')}
       excludedDates={[
-        london('2002-04-07'),
-        london('2002-04-08'),
-        london('2002-04-09'),
+        london('2002-04-07T12:00:00Z'),
+        london('2002-04-08T12:00:00Z'),
+        london('2002-04-09T12:00:00Z'),
       ]}
       excludedDays={[0]}
-      initialFocusDate={london('2002-04-21')}
+      initialFocusDate={london('2002-04-21T12:00:00Z')}
       chosenDate={date}
       setChosenDate={setDate}
     />

--- a/catalogue/webapp/components/Calendar/Calendar.tsx
+++ b/catalogue/webapp/components/Calendar/Calendar.tsx
@@ -103,10 +103,10 @@ function handleKeyDown(
   if (ENTER.includes(key) || SPACE.includes(key)) {
     if (
       isRequestableDate({
-        date: date,
-        startDate: min,
-        endDate: max,
-        excludedDates,
+        date: date.toDate(),
+        startDate: min.toDate(),
+        endDate: max.toDate(),
+        excludedDates: excludedDates.map(d => d.toDate()),
         excludedDays,
       })
     ) {
@@ -305,10 +305,10 @@ const Calendar: FC<Props> = ({
                   const isDisabled =
                     !date?.date() ||
                     !isRequestableDate({
-                      date: date,
-                      startDate: min,
-                      endDate: max,
-                      excludedDates,
+                      date: date.toDate(),
+                      startDate: min.toDate(),
+                      endDate: max.toDate(),
+                      excludedDates: excludedDates.map(d => d.toDate()),
                       excludedDays,
                     });
                   const isTabbable =

--- a/catalogue/webapp/components/Calendar/CalendarSelect.tsx
+++ b/catalogue/webapp/components/Calendar/CalendarSelect.tsx
@@ -28,10 +28,10 @@ function getAvailableDates(
     .map(date => {
       return (
         isRequestableDate({
-          date,
-          startDate: min,
-          endDate: max,
-          excludedDates,
+          date: date.toDate(),
+          startDate: min.toDate(),
+          endDate: max.toDate(),
+          excludedDates: excludedDates.map(d => d.toDate()),
           excludedDays,
         }) && {
           value: date.format('DD-MM-YYYY'),

--- a/catalogue/webapp/components/ItemRequestModal/RequestDialog.tsx
+++ b/catalogue/webapp/components/ItemRequestModal/RequestDialog.tsx
@@ -82,10 +82,14 @@ const RequestDialog: FC<RequestDialogProps> = ({
       pickUpDateMoment &&
       pickUpDateMoment.isValid() &&
       isRequestableDate({
-        date: pickUpDateMoment,
-        startDate: availableDates.nextAvailable,
-        endDate: availableDates.lastAvailable,
-        excludedDates: availableDates.exceptionalClosedDates,
+        date: pickUpDateMoment.toDate(),
+        startDate:
+          availableDates.nextAvailable && availableDates.nextAvailable.toDate(),
+        endDate:
+          availableDates.lastAvailable && availableDates.lastAvailable.toDate(),
+        excludedDates: availableDates.exceptionalClosedDates.map(d =>
+          d.toDate()
+        ),
         excludedDays: availableDates.closedDays,
       })
     ) {

--- a/catalogue/webapp/components/ItemRequestModal/useAvailableDates.ts
+++ b/catalogue/webapp/components/ItemRequestModal/useAvailableDates.ts
@@ -40,7 +40,7 @@ export const useAvailableDates = (): AvailableDates => {
   const exceptionalClosedDates = findClosedDays(exceptionalLibraryOpeningTimes)
     .map(day => {
       const exceptionalDay = day as ExceptionalOpeningHoursDay;
-      return london(exceptionalDay.overrideDate);
+      return exceptionalDay.overrideDate;
     })
     .filter(Boolean);
 
@@ -54,15 +54,15 @@ export const useAvailableDates = (): AvailableDates => {
   // If the library is closed on any days during the selection window
   // we extend the lastAvailableDate to take these into account
   const lastAvailable = extendEndDate({
-    startDate: nextAvailable && london(nextAvailable),
-    endDate: minimumLastAvailable && london(minimumLastAvailable),
+    startDate: nextAvailable,
+    endDate: minimumLastAvailable,
     exceptionalClosedDates,
     closedDays,
   });
 
   return {
     nextAvailable: nextAvailable && london(nextAvailable),
-    lastAvailable,
+    lastAvailable: lastAvailable && london(lastAvailable),
     exceptionalClosedDates,
     closedDays,
   };

--- a/catalogue/webapp/components/ItemRequestModal/useAvailableDates.ts
+++ b/catalogue/webapp/components/ItemRequestModal/useAvailableDates.ts
@@ -43,21 +43,25 @@ export const useAvailableDates = (): AvailableDates => {
     })
     .filter(Boolean);
 
-  const nextAvailable = determineNextAvailableDate(london(), closedDays);
+  const nextAvailable = determineNextAvailableDate(
+    london().toDate(),
+    closedDays
+  );
 
   // There should be a minimum of a 2 week window in which to select a date
-  const minimumLastAvailable = nextAvailable?.clone().add(13, 'days');
+  const minimumLastAvailable =
+    nextAvailable && london(nextAvailable).clone().add(13, 'days');
   // If the library is closed on any days during the selection window
   // we extend the lastAvailableDate to take these into account
   const lastAvailable = extendEndDate({
-    startDate: nextAvailable,
+    startDate: nextAvailable && london(nextAvailable),
     endDate: minimumLastAvailable,
     exceptionalClosedDates,
     closedDays,
   });
 
   return {
-    nextAvailable,
+    nextAvailable: nextAvailable && london(nextAvailable),
     lastAvailable,
     exceptionalClosedDates,
     closedDays,

--- a/catalogue/webapp/components/ItemRequestModal/useAvailableDates.ts
+++ b/catalogue/webapp/components/ItemRequestModal/useAvailableDates.ts
@@ -63,7 +63,7 @@ export const useAvailableDates = (): AvailableDates => {
   return {
     nextAvailable: nextAvailable && london(nextAvailable),
     lastAvailable: lastAvailable && london(lastAvailable),
-    exceptionalClosedDates,
+    exceptionalClosedDates: exceptionalClosedDates.map(d => london(d)),
     closedDays,
   };
 };

--- a/catalogue/webapp/components/ItemRequestModal/useAvailableDates.ts
+++ b/catalogue/webapp/components/ItemRequestModal/useAvailableDates.ts
@@ -14,6 +14,7 @@ import { usePrismicData } from '@weco/common/server-data/Context';
 import { collectionVenueId } from '@weco/common/data/hardcoded-ids';
 import { transformCollectionVenues } from '@weco/common/services/prismic/transformers/collection-venues';
 import { getVenueById } from '@weco/common/services/prismic/opening-times';
+import { addDays } from '@weco/common/utils/dates';
 
 type AvailableDates = {
   nextAvailable?: Moment;
@@ -49,13 +50,12 @@ export const useAvailableDates = (): AvailableDates => {
   );
 
   // There should be a minimum of a 2 week window in which to select a date
-  const minimumLastAvailable =
-    nextAvailable && london(nextAvailable).clone().add(13, 'days');
+  const minimumLastAvailable = nextAvailable && addDays(nextAvailable, 13);
   // If the library is closed on any days during the selection window
   // we extend the lastAvailableDate to take these into account
   const lastAvailable = extendEndDate({
     startDate: nextAvailable && london(nextAvailable),
-    endDate: minimumLastAvailable,
+    endDate: minimumLastAvailable && london(minimumLastAvailable),
     exceptionalClosedDates,
     closedDays,
   });

--- a/catalogue/webapp/test/components/ItemRequestModal.test.tsx
+++ b/catalogue/webapp/test/components/ItemRequestModal.test.tsx
@@ -9,13 +9,12 @@ import userEvent from '@testing-library/user-event';
 import { getItemsWithPhysicalLocation } from '../../utils/works';
 import * as Context from '@weco/common/server-data/Context';
 import * as DateUtils from '../../utils/dates';
-import { london } from '@weco/common/utils/format-date';
 
 jest.spyOn(Context, 'usePrismicData').mockImplementation(() => prismicData);
 
 jest
   .spyOn(DateUtils, 'determineNextAvailableDate')
-  .mockImplementation(() => london('2022-05-21'));
+  .mockImplementation(() => new Date('2022-05-21'));
 
 const renderComponent = () => {
   const RequestModal = () => {

--- a/catalogue/webapp/test/utils/dates.test.ts
+++ b/catalogue/webapp/test/utils/dates.test.ts
@@ -278,74 +278,74 @@ describe('groupExceptionalClosedDates', () => {
 describe('extendEndDate: Determines the end date to use, so that there are always the same number of available dates between the start and end date', () => {
   it('returns the original end date if no exceptional closed dates occur between the start and end date', () => {
     const result = extendEndDate({
-      startDate: london('2021-11-03'),
-      endDate: london('2021-11-16'),
-      exceptionalClosedDates: exceptionalClosedDates.map(d => london(d)),
+      startDate: new Date('2021-11-03'),
+      endDate: new Date('2021-11-16'),
+      exceptionalClosedDates,
       closedDays: [0],
     });
 
-    expect(result.toDate()).toEqual(new Date('2021-11-16'));
+    expect(result).toEqual(new Date('2021-11-16'));
   });
 
   it('increases the end date by the number of exceptional closed dates that occur between the start and end date', () => {
     const result = extendEndDate({
-      startDate: london('2019-12-28'),
-      endDate: london('2020-01-10'),
-      exceptionalClosedDates: exceptionalClosedDates.map(d => london(d)),
+      startDate: new Date('2019-12-28'),
+      endDate: new Date('2020-01-10'),
+      exceptionalClosedDates,
       closedDays: [],
     });
 
-    expect(result.toDate()).toEqual(new Date('2020-01-15'));
+    expect(result).toEqual(new Date('2020-01-15'));
   });
 
   it('increases the end date again to account for any regular closed days that occur between the start date and an extended end date', () => {
     const result = extendEndDate({
-      startDate: london('2019-12-28'),
-      endDate: london('2020-01-10'),
-      exceptionalClosedDates: exceptionalClosedDates.map(d => london(d)),
+      startDate: new Date('2019-12-28'),
+      endDate: new Date('2020-01-10'),
+      exceptionalClosedDates,
       closedDays: [0],
     });
 
-    expect(result.toDate()).toEqual(new Date('2020-01-16'));
+    expect(result).toEqual(new Date('2020-01-16'));
   });
 
   it('increases the end date again to account for any exceptional closed dates that occur between the start date and an extended end date', () => {
     const result = extendEndDate({
-      startDate: london('2019-12-16'),
-      endDate: london('2019-12-30'),
-      exceptionalClosedDates: exceptionalClosedDates.map(d => london(d)),
+      startDate: new Date('2019-12-16'),
+      endDate: new Date('2019-12-30'),
+      exceptionalClosedDates,
       closedDays: [],
     });
 
-    expect(result.toDate()).toEqual(new Date('2020-01-01'));
+    expect(result).toEqual(new Date('2020-01-01'));
   });
 
   it('repeatedly increases the end date to account for a combination of exceptional closed dates and regular closed days that occur between the start date and extended end dates', () => {
     const result = extendEndDate({
-      startDate: london('2020-01-03'),
-      endDate: london('2020-01-16'),
-      exceptionalClosedDates: exceptionalClosedDates.map(d => london(d)),
+      startDate: new Date('2020-01-03'),
+      endDate: new Date('2020-01-16'),
+      exceptionalClosedDates,
       closedDays: [0],
     });
 
-    expect(result.toDate()).toEqual(new Date('2020-01-24'));
+    expect(result).toEqual(new Date('2020-01-24'));
   });
 
   it("doesn't extend the end date for any regular closed day that occurs between the start date and the extended end date, if that day is also one of the exceptional closed dates", () => {
     const result = extendEndDate({
-      startDate: london('2019-12-24'),
-      endDate: london('2019-12-31'),
-      exceptionalClosedDates: exceptionalClosedDates.map(d => london(d)),
+      startDate: new Date('2019-12-24'),
+      endDate: new Date('2019-12-31'),
+      exceptionalClosedDates,
       closedDays: [2],
     });
 
-    expect(result.toDate()).toEqual(new Date('2019-12-31'));
+    expect(result).toEqual(new Date('2019-12-31'));
   });
 
   it("doesn't return a date if no start date is provided", () => {
     const result = extendEndDate({
-      endDate: london('2020-01-10'),
-      exceptionalClosedDates: exceptionalClosedDates.map(d => london(d)),
+      endDate: new Date('2020-01-10'),
+      exceptionalClosedDates: exceptionalClosedDates,
       closedDays: [0],
     });
 
@@ -354,8 +354,8 @@ describe('extendEndDate: Determines the end date to use, so that there are alway
 
   it("doesn't return a date if no end date is provided", () => {
     const result = extendEndDate({
-      startDate: london('2019-12-24'),
-      exceptionalClosedDates: exceptionalClosedDates.map(d => london(d)),
+      startDate: new Date('2019-12-24'),
+      exceptionalClosedDates,
       closedDays: [0],
     });
 

--- a/catalogue/webapp/test/utils/dates.test.ts
+++ b/catalogue/webapp/test/utils/dates.test.ts
@@ -1,4 +1,3 @@
-import { london } from '@weco/common/utils/format-date';
 import {
   determineNextAvailableDate,
   filterExceptionalClosedDates,
@@ -366,9 +365,9 @@ describe('extendEndDate: Determines the end date to use, so that there are alway
 describe("isRequestableDate: checks the date falls between 2 specified dates and also isn't an excluded date, or excluded day", () => {
   it('returns false if the date falls outside the start and end dates', () => {
     const result = isRequestableDate({
-      date: london('2019-12-12'),
-      startDate: london('2019-12-17'),
-      endDate: london('2019-12-31'),
+      date: new Date('2019-12-12'),
+      startDate: new Date('2019-12-17'),
+      endDate: new Date('2019-12-31'),
       excludedDates: [],
       excludedDays: [],
     });
@@ -377,9 +376,9 @@ describe("isRequestableDate: checks the date falls between 2 specified dates and
 
   it('returns true if the date falls between the start and end dates, inclusive', () => {
     const result = isRequestableDate({
-      date: london('2019-12-17'),
-      startDate: london('2019-12-17'),
-      endDate: london('2019-12-31'),
+      date: new Date('2019-12-17'),
+      startDate: new Date('2019-12-17'),
+      endDate: new Date('2019-12-31'),
       excludedDates: [],
       excludedDays: [],
     });
@@ -388,9 +387,9 @@ describe("isRequestableDate: checks the date falls between 2 specified dates and
 
   it('returns false if the date falls on an excluded Day', () => {
     const result = isRequestableDate({
-      date: london('2019-12-17'), // Tuesday
-      startDate: london('2019-12-17'),
-      endDate: london('2019-12-31'),
+      date: new Date('2019-12-17'), // Tuesday
+      startDate: new Date('2019-12-17'),
+      endDate: new Date('2019-12-31'),
       excludedDates: [],
       excludedDays: [2], // Tuesday
     });
@@ -399,10 +398,10 @@ describe("isRequestableDate: checks the date falls between 2 specified dates and
 
   it('returns false if the date falls on an excluded date', () => {
     const result = isRequestableDate({
-      date: london('2019-12-20'),
-      startDate: london('2019-12-17'),
-      endDate: london('2019-12-31'),
-      excludedDates: [london('2019-12-20')],
+      date: new Date('2019-12-20'),
+      startDate: new Date('2019-12-17'),
+      endDate: new Date('2019-12-31'),
+      excludedDates: [new Date('2019-12-20')],
       excludedDays: [],
     });
     expect(result).toEqual(false);
@@ -410,7 +409,7 @@ describe("isRequestableDate: checks the date falls between 2 specified dates and
 
   it('returns true if there are no start and end dates', () => {
     const result = isRequestableDate({
-      date: london('2019-12-20'),
+      date: new Date('2019-12-20'),
       excludedDates: [],
       excludedDays: [],
     });
@@ -419,8 +418,8 @@ describe("isRequestableDate: checks the date falls between 2 specified dates and
 
   it('returns true if there is no start date and the date falls on or before the end date', () => {
     const result = isRequestableDate({
-      date: london('2019-12-20'),
-      endDate: london('2019-12-31'),
+      date: new Date('2019-12-20'),
+      endDate: new Date('2019-12-31'),
       excludedDates: [],
       excludedDays: [],
     });
@@ -429,8 +428,8 @@ describe("isRequestableDate: checks the date falls between 2 specified dates and
 
   it('returns true if there is no end date and the date falls on or after the start date', () => {
     const result = isRequestableDate({
-      date: london('2019-12-20'),
-      startDate: london('2019-12-17'),
+      date: new Date('2019-12-20'),
+      startDate: new Date('2019-12-17'),
       excludedDates: [],
       excludedDays: [],
     });

--- a/catalogue/webapp/test/utils/dates.test.ts
+++ b/catalogue/webapp/test/utils/dates.test.ts
@@ -154,22 +154,27 @@ describe('findNextPickUpDay: finds the earliest date on which requested items ca
 
 describe('determineNextAvailableDate', () => {
   it('adds a single day to the current date, if the time is before 10am', () => {
-    const result = determineNextAvailableDate(london('2021-12-9 09:00'), [0]);
-    expect(result.toDate()).toEqual(new Date('2021-12-10 09:00'));
+    const result = determineNextAvailableDate(new Date('2021-12-9 09:00'), [0]);
+    expect(result).toEqual(new Date('2021-12-10 09:00'));
   });
 
   it('adds 2 days to the current date, if the time is after 10am', () => {
-    const result = determineNextAvailableDate(london('2021-12-9 11:00'), [0]);
-    expect(result.toDate()).toEqual(new Date('2021-12-11 11:00'));
+    const result = determineNextAvailableDate(new Date('2021-12-9 11:00'), [0]);
+    expect(result).toEqual(new Date('2021-12-11 11:00'));
   });
 
   it('defers weekend requests until Tuesday, to avoid a rush of retrievals on Monday', () => {
-    const result = determineNextAvailableDate(london('2021-12-10 10:30'), [0]); // Sunday
-    expect(result.toDate()).toEqual(new Date('2021-12-14 10:30')); // Tuesday
+    const result = determineNextAvailableDate(new Date('2021-12-10 10:30'), [
+      0,
+    ]); // Sunday
+    expect(result).toEqual(new Date('2021-12-14 10:30')); // Tuesday
   });
 
   it("doesn't return a date if there are no regular days that are open", () => {
-    const result = determineNextAvailableDate(london(), [0, 1, 2, 3, 4, 5, 6]);
+    const result = determineNextAvailableDate(
+      new Date(),
+      [0, 1, 2, 3, 4, 5, 6]
+    );
     expect(result).toBeUndefined();
   });
 
@@ -178,25 +183,25 @@ describe('determineNextAvailableDate', () => {
     // at 09:30 in London -- it can be fulfilled the next day.
     const date1 = new Date('2021-12-09T10:30:00+0100');
 
-    const result1 = determineNextAvailableDate(london(date1), [0]);
-    expect(result1.toDate()).toEqual(new Date('2021-12-10T09:30:00Z'));
+    const result1 = determineNextAvailableDate(date1, [0]);
+    expect(result1).toEqual(new Date('2021-12-10T09:30:00Z'));
 
     // Paris is an hour ahead of London, so a request made at 11:30 in Paris is
     // at 19:30 in London -- it can’t be fulfilled the next day.
     const date2 = new Date('2021-12-09T11:30:00+0100');
 
-    const result2 = determineNextAvailableDate(london(date2), [0]);
-    expect(result2.toDate()).toEqual(new Date('2021-12-11T10:30:00Z'));
+    const result2 = determineNextAvailableDate(date2, [0]);
+    expect(result2).toEqual(new Date('2021-12-11T10:30:00Z'));
 
     // Now run the same tests, but now during British Summer Time when London
     // and UTC are different.
     const date3 = new Date('2022-09-06T10:30:00+0200');
-    const result3 = determineNextAvailableDate(london(date3), [0]);
-    expect(result3.toDate()).toEqual(new Date('2022-09-07T09:30:00+0100'));
+    const result3 = determineNextAvailableDate(date3, [0]);
+    expect(result3).toEqual(new Date('2022-09-07T09:30:00+0100'));
 
     const date4 = new Date('2022-09-06T11:30:00+0200');
-    const result4 = determineNextAvailableDate(london(date4), [0]);
-    expect(result4.toDate()).toEqual(new Date('2022-09-08T10:30:00+0100'));
+    const result4 = determineNextAvailableDate(date4, [0]);
+    expect(result4).toEqual(new Date('2022-09-08T10:30:00+0100'));
   });
 });
 

--- a/catalogue/webapp/test/utils/dates.test.ts
+++ b/catalogue/webapp/test/utils/dates.test.ts
@@ -131,21 +131,21 @@ describe('findClosedDays', () => {
 describe('findNextPickUpDay: finds the earliest date on which requested items can be picked up', () => {
   it('returns the same date provided if it occurs on one of the regular open days', () => {
     const result = findNextPickUpDay(
-      london('2022-01-15'), // Saturday
+      new Date('2022-01-15'), // Saturday
       [0, 1, 2] // Sunday, Monday, Tuesday
     );
-    expect(result.toDate()).toEqual(new Date('2022-01-15')); // Saturday
+    expect(result).toEqual(new Date('2022-01-15')); // Saturday
   });
   it('leaves a full working day between the request and retrieval', () => {
     const result = findNextPickUpDay(
-      london('2022-01-16'), // Sunday
+      new Date('2022-01-16'), // Sunday
       [0, 1, 2] // Sunday, Monday, Tuesday
     );
-    expect(result.toDate()).toEqual(new Date('2022-01-20')); // Thursday
+    expect(result).toEqual(new Date('2022-01-20')); // Thursday
   });
   it("doesn't return a date if there are no regular days that are open", () => {
     const result = findNextPickUpDay(
-      london('2022-01-16'), // Sunday
+      new Date('2022-01-16'), // Sunday
       [0, 1, 2, 3, 4, 5, 6]
     );
     expect(result).toBeUndefined();

--- a/catalogue/webapp/test/utils/dates.test.ts
+++ b/catalogue/webapp/test/utils/dates.test.ts
@@ -15,19 +15,19 @@ import {
 } from '@weco/common/model/opening-hours';
 
 const exceptionalClosedDates = [
-  london('2019-12-03'),
-  london('2019-12-04'),
-  london('2019-12-05'),
-  london('2019-12-17'),
-  london('2019-12-31'),
-  london('2020-01-06'),
-  london('2020-01-07'),
-  london('2020-01-08'),
-  london('2020-01-09'),
-  london('2020-01-18'),
-  london('2020-01-19'),
-  london('2020-01-20'),
-  london('2020-01-22'),
+  new Date('2019-12-03'),
+  new Date('2019-12-04'),
+  new Date('2019-12-05'),
+  new Date('2019-12-17'),
+  new Date('2019-12-31'),
+  new Date('2020-01-06'),
+  new Date('2020-01-07'),
+  new Date('2020-01-08'),
+  new Date('2020-01-09'),
+  new Date('2020-01-18'),
+  new Date('2020-01-19'),
+  new Date('2020-01-20'),
+  new Date('2020-01-22'),
 ];
 
 const regularOpeningHours = [
@@ -213,13 +213,13 @@ describe('filterExceptionalClosedDates', () => {
     );
 
     expect(result).toEqual([
-      london('2019-12-03'),
-      london('2019-12-05'),
-      london('2019-12-17'),
-      london('2019-12-31'),
-      london('2020-01-07'),
-      london('2020-01-09'),
-      london('2020-01-18'),
+      new Date('2019-12-03'),
+      new Date('2019-12-05'),
+      new Date('2019-12-17'),
+      new Date('2019-12-31'),
+      new Date('2020-01-07'),
+      new Date('2020-01-09'),
+      new Date('2020-01-18'),
     ]);
   });
 });
@@ -239,28 +239,28 @@ describe('includedRegularClosedDays', () => {
 describe('groupExceptionalClosedDates', () => {
   it("groups closed dates into those that are excluded by the start and end dates and those that aren't", () => {
     const result = groupExceptionalClosedDates({
-      startDate: london('2020-01-03'),
-      endDate: london('2020-01-16'),
-      exceptionalClosedDates: exceptionalClosedDates,
+      startDate: new Date('2020-01-03'),
+      endDate: new Date('2020-01-16'),
+      exceptionalClosedDates,
     });
 
     expect(result).toEqual({
       included: [
-        london('2020-01-06'),
-        london('2020-01-07'),
-        london('2020-01-08'),
-        london('2020-01-09'),
+        new Date('2020-01-06'),
+        new Date('2020-01-07'),
+        new Date('2020-01-08'),
+        new Date('2020-01-09'),
       ],
       excluded: [
-        london('2019-12-03'),
-        london('2019-12-04'),
-        london('2019-12-05'),
-        london('2019-12-17'),
-        london('2019-12-31'),
-        london('2020-01-18'),
-        london('2020-01-19'),
-        london('2020-01-20'),
-        london('2020-01-22'),
+        new Date('2019-12-03'),
+        new Date('2019-12-04'),
+        new Date('2019-12-05'),
+        new Date('2019-12-17'),
+        new Date('2019-12-31'),
+        new Date('2020-01-18'),
+        new Date('2020-01-19'),
+        new Date('2020-01-20'),
+        new Date('2020-01-22'),
       ],
     });
   });
@@ -271,7 +271,7 @@ describe('extendEndDate: Determines the end date to use, so that there are alway
     const result = extendEndDate({
       startDate: london('2021-11-03'),
       endDate: london('2021-11-16'),
-      exceptionalClosedDates: exceptionalClosedDates,
+      exceptionalClosedDates: exceptionalClosedDates.map(d => london(d)),
       closedDays: [0],
     });
 
@@ -282,7 +282,7 @@ describe('extendEndDate: Determines the end date to use, so that there are alway
     const result = extendEndDate({
       startDate: london('2019-12-28'),
       endDate: london('2020-01-10'),
-      exceptionalClosedDates: exceptionalClosedDates,
+      exceptionalClosedDates: exceptionalClosedDates.map(d => london(d)),
       closedDays: [],
     });
 
@@ -293,7 +293,7 @@ describe('extendEndDate: Determines the end date to use, so that there are alway
     const result = extendEndDate({
       startDate: london('2019-12-28'),
       endDate: london('2020-01-10'),
-      exceptionalClosedDates: exceptionalClosedDates,
+      exceptionalClosedDates: exceptionalClosedDates.map(d => london(d)),
       closedDays: [0],
     });
 
@@ -304,7 +304,7 @@ describe('extendEndDate: Determines the end date to use, so that there are alway
     const result = extendEndDate({
       startDate: london('2019-12-16'),
       endDate: london('2019-12-30'),
-      exceptionalClosedDates: exceptionalClosedDates,
+      exceptionalClosedDates: exceptionalClosedDates.map(d => london(d)),
       closedDays: [],
     });
 
@@ -315,7 +315,7 @@ describe('extendEndDate: Determines the end date to use, so that there are alway
     const result = extendEndDate({
       startDate: london('2020-01-03'),
       endDate: london('2020-01-16'),
-      exceptionalClosedDates: exceptionalClosedDates,
+      exceptionalClosedDates: exceptionalClosedDates.map(d => london(d)),
       closedDays: [0],
     });
 
@@ -326,7 +326,7 @@ describe('extendEndDate: Determines the end date to use, so that there are alway
     const result = extendEndDate({
       startDate: london('2019-12-24'),
       endDate: london('2019-12-31'),
-      exceptionalClosedDates: exceptionalClosedDates,
+      exceptionalClosedDates: exceptionalClosedDates.map(d => london(d)),
       closedDays: [2],
     });
 
@@ -336,7 +336,7 @@ describe('extendEndDate: Determines the end date to use, so that there are alway
   it("doesn't return a date if no start date is provided", () => {
     const result = extendEndDate({
       endDate: london('2020-01-10'),
-      exceptionalClosedDates: exceptionalClosedDates,
+      exceptionalClosedDates: exceptionalClosedDates.map(d => london(d)),
       closedDays: [0],
     });
 
@@ -346,7 +346,7 @@ describe('extendEndDate: Determines the end date to use, so that there are alway
   it("doesn't return a date if no end date is provided", () => {
     const result = extendEndDate({
       startDate: london('2019-12-24'),
-      exceptionalClosedDates: exceptionalClosedDates,
+      exceptionalClosedDates: exceptionalClosedDates.map(d => london(d)),
       closedDays: [0],
     });
 

--- a/catalogue/webapp/test/utils/dates.test.ts
+++ b/catalogue/webapp/test/utils/dates.test.ts
@@ -227,11 +227,20 @@ describe('filterExceptionalClosedDates', () => {
 describe('includedRegularClosedDays', () => {
   it('determines how many regular closed days occur between the start and end dates, inclusive', () => {
     const result = includedRegularClosedDays({
-      startDate: london('2020-01-03'),
-      endDate: london('2020-01-16'),
+      startDate: new Date('2020-01-03'),
+      endDate: new Date('2020-01-16'),
       closedDays: [0, 1, 4],
     });
 
+    // This is the date range:
+    //
+    //        January 2020
+    //     Su Mo Tu We Th Fr Sa
+    //                     3  4
+    //      5  6  7  8  9 10 11
+    //     12 13 14 15 16
+    //
+    // Of these, we're counting Sunday (0), Monday (1) and Thursday (4).
     expect(result).toEqual(6);
   });
 });

--- a/catalogue/webapp/test/utils/dates.test.ts
+++ b/catalogue/webapp/test/utils/dates.test.ts
@@ -438,9 +438,9 @@ describe("isRequestableDate: checks the date falls between 2 specified dates and
 
   it('returns true if there are start and end dates and the date falls on the start date', () => {
     const result = isRequestableDate({
-      date: london('2019-12-17T01:00:00Z'),
-      startDate: london('2019-12-17T12:00:00Z'),
-      endDate: london('2019-12-31'),
+      date: new Date('2019-12-17T01:00:00Z'),
+      startDate: new Date('2019-12-17T12:00:00Z'),
+      endDate: new Date('2019-12-31'),
       excludedDates: [],
       excludedDays: [],
     });

--- a/catalogue/webapp/utils/dates.ts
+++ b/catalogue/webapp/utils/dates.ts
@@ -89,7 +89,7 @@ export function determineNextAvailableDate(
   regularClosedDays: DayNumber[]
 ): Date | undefined {
   const hourInLondon = Number(
-    date.toLocaleString('en-GB', { hour: 'numeric' })
+    date.toLocaleString('en-GB', { hour: 'numeric', timeZone: 'Europe/London' })
   );
   const isBeforeTen = hourInLondon < 10;
   const nextAvailableDate = addDays(date, isBeforeTen ? 1 : 2);

--- a/catalogue/webapp/utils/dates.ts
+++ b/catalogue/webapp/utils/dates.ts
@@ -6,7 +6,6 @@ import {
   ExceptionalOpeningHoursDay,
 } from '@weco/common/model/opening-hours';
 import { addDays } from '@weco/common/utils/dates';
-import { london } from '@weco/common/utils/format-date';
 
 export function findClosedDays(
   days: (OpeningHoursDay | ExceptionalOpeningHoursDay)[]
@@ -87,19 +86,16 @@ export function findNextPickUpDay(
 }
 
 export function determineNextAvailableDate(
-  date: Moment,
+  date: Date,
   regularClosedDays: DayNumber[]
-): Moment | undefined {
-  const nextAvailableDate = date.clone();
-  const isBeforeTen = nextAvailableDate.isBefore(
-    date.clone().set({ hour: 10, m: 0, s: 0, ms: 0 })
+): Date | undefined {
+  const hourInLondon = Number(
+    date.toLocaleString('en-GB', { hour: 'numeric' })
   );
-  nextAvailableDate.add(isBeforeTen ? 1 : 2, 'days');
-  const nextPickUpDay = findNextPickUpDay(
-    nextAvailableDate.toDate(),
-    regularClosedDays
-  );
-  return nextPickUpDay && london(nextPickUpDay);
+  const isBeforeTen = hourInLondon < 10;
+  const nextAvailableDate = addDays(date, isBeforeTen ? 1 : 2);
+
+  return findNextPickUpDay(nextAvailableDate, regularClosedDays);
 }
 
 type groupedExceptionalClosedDates = { included: Moment[]; excluded: Moment[] };

--- a/catalogue/webapp/utils/dates.ts
+++ b/catalogue/webapp/utils/dates.ts
@@ -4,7 +4,12 @@ import {
   Day,
   ExceptionalOpeningHoursDay,
 } from '@weco/common/model/opening-hours';
-import { addDays, getDatesBetween, isSameDay } from '@weco/common/utils/dates';
+import {
+  addDays,
+  getDatesBetween,
+  isSameDay,
+  isSameDayOrBefore,
+} from '@weco/common/utils/dates';
 
 export function findClosedDays(
   days: (OpeningHoursDay | ExceptionalOpeningHoursDay)[]
@@ -215,13 +220,14 @@ export function isRequestableDate(params: {
       // no start and end date
       (!startDate && !endDate) ||
         // both start and end date
-        (startDate && startDate <= date && endDate && date <= endDate) ||
-        // only start date
         (startDate &&
-          !endDate &&
-          (isSameDay(date, startDate) || startDate < date)) ||
+          endDate &&
+          isSameDayOrBefore(startDate, date) &&
+          isSameDayOrBefore(date, endDate)) ||
+        // only start date
+        (startDate && !endDate && isSameDayOrBefore(startDate, date)) ||
         // only end date
-        (endDate && !startDate && (isSameDay(date, endDate) || date < endDate))
+        (endDate && !startDate && isSameDayOrBefore(date, endDate))
     ) && // both start and end date
     !isExceptionalClosedDay &&
     !isRegularClosedDay


### PR DESCRIPTION
For https://github.com/wellcomecollection/wellcomecollection.org/issues/7831

This bins all the uses of Moment in `@weco/catalogue/utils/date` in favour of vanilla Date values. I mostly didn't touch the tests, apart from replacing the input/output values.