### PR TITLE
Fix the appearance of dates in the footer

### DIFF
--- a/common/services/prismic/documents.ts
+++ b/common/services/prismic/documents.ts
@@ -16,7 +16,7 @@ import {
   BooleanField,
 } from '@prismicio/types';
 
-type DayField = GroupField<{
+export type DayField = GroupField<{
   startDateTime: TimestampField;
   endDateTime: TimestampField;
 }>;

--- a/common/services/prismic/transformers/collection-venues.test.ts
+++ b/common/services/prismic/transformers/collection-venues.test.ts
@@ -1,0 +1,40 @@
+import { createRegularDay } from './collection-venues';
+
+describe('createRegularDay', () => {
+  const venue = {
+    id: 'WsuZKh8AAOG_NyUo',
+    data: {
+      title: 'Wellcome Café',
+      order: 4,
+      monday: [
+        {
+          startDateTime: '2022-01-23T10:00:00+0000',
+          endDateTime: '2022-01-23T18:00:00+0000',
+        },
+      ],
+      tuesday: [],
+      wednesday: [],
+      thursday: [],
+      friday: [],
+      saturday: [],
+      sunday: [],
+      modifiedDayOpeningTimes: [],
+    },
+  };
+
+  it('gets the opening times for a venue which is open today', () => {
+    const day = createRegularDay('Monday', venue as any);
+
+    expect(day.opens).toBe('10:00');
+    expect(day.closes).toBe('18:00');
+    expect(day.isClosed).toBe(false);
+  });
+
+  it('gets the opening times for a closed venue', () => {
+    const day = createRegularDay('Tuesday', venue as any);
+
+    expect(day.opens).toBe('00:00');
+    expect(day.closes).toBe('00:00');
+    expect(day.isClosed).toBe(true);
+  });
+});

--- a/common/services/prismic/transformers/collection-venues.ts
+++ b/common/services/prismic/transformers/collection-venues.ts
@@ -6,20 +6,26 @@ import { formatTime } from '../../../utils/format-date';
 import { Day, Venue, OpeningHoursDay } from '../../../model/opening-hours';
 import {
   CollectionVenuePrismicDocument,
+  DayField,
   ModifiedDayOpeningTime,
 } from '../documents';
 import { isNotUndefined } from '../../../utils/array';
 import * as prismicH from '@prismicio/helpers';
 import { transformImage } from './images';
 
-function createRegularDay(
+export function createRegularDay(
   day: Day,
   venue: CollectionVenuePrismicDocument | CollectionVenuePrismicDocumentLite
 ): OpeningHoursDay {
   const { data } = venue;
   const lowercaseDay = day.toLowerCase();
-  const start = data && data[lowercaseDay][0].startDateTime;
-  const end = data && data[lowercaseDay][0].endDateTime;
+
+  const dayField = data && (data[lowercaseDay] as DayField);
+
+  const start =
+    dayField[0]?.startDateTime && new Date(dayField[0]?.startDateTime);
+  const end = dayField[0]?.endDateTime && new Date(dayField[0]?.endDateTime);
+
   const isClosed = !start;
   // If there is no start time from prismic, then we set both opens and closes to 00:00.
   // This is necessary for the json-ld schema data, so Google knows when the venues are closed.


### PR DESCRIPTION
The problem is that the type checker can't derive a better type for `data[lowercaseDay][0]` than `any`, so it thinks the `{start,end}DateTime` values are fine to be passed to `formatTime`, when we need to cast them to `Date` objects first.

Adding some tests and intermediate types fixes the appearance of opening times in the footer.

🙈 