### PR TITLE
Make sure September appears in the /whats-on page

### DIFF
--- a/content/webapp/components/EventsByMonth/group-event-utils.test.ts
+++ b/content/webapp/components/EventsByMonth/group-event-utils.test.ts
@@ -80,6 +80,70 @@ describe('findMonthsThatEventSpans', () => {
       },
     ]);
   });
+
+  it('groups multi-month events correctly', () => {
+    const events = [
+      {
+        times: [
+          {
+            range: {
+              startDateTime: new Date('2022-10-18T09:30:00.000Z'),
+              endDateTime: new Date('2022-10-18T14:30:00.000Z'),
+            },
+          },
+          {
+            range: {
+              startDateTime: new Date('2022-11-08T10:30:00.000Z'),
+              endDateTime: new Date('2022-11-08T15:30:00.000Z'),
+            },
+          },
+        ],
+        title: 'HIV and AIDs',
+      },
+      {
+        times: [
+          {
+            range: {
+              startDateTime: new Date('2022-10-06T18:00:00.000Z'),
+              endDateTime: new Date('2022-10-06T18:30:00.000Z'),
+            },
+          },
+        ],
+        title: 'Legacy',
+      },
+      {
+        times: [
+          {
+            range: {
+              startDateTime: new Date('2022-09-17T10:00:00.000Z'),
+              endDateTime: new Date('2022-09-17T11:00:00.000Z'),
+            },
+          },
+        ],
+        title: 'Wandering Womb',
+      },
+    ];
+
+    const result = findMonthsThatEventSpans(events);
+
+    expect(result).toStrictEqual([
+      {
+        event: events[0],
+        months: [
+          { year: 2022, month: 9 },
+          { year: 2022, month: 10 },
+        ],
+      },
+      {
+        event: events[1],
+        months: [{ year: 2022, month: 9 }],
+      },
+      {
+        event: events[2],
+        months: [{ year: 2022, month: 8 }],
+      },
+    ]);
+  });
 });
 
 describe('groupEventsByMonth', () => {

--- a/content/webapp/components/EventsByMonth/group-event-utils.ts
+++ b/content/webapp/components/EventsByMonth/group-event-utils.ts
@@ -31,8 +31,15 @@ export function parseLabel(label: string): YearMonth {
   return { year, month };
 }
 
+/** Returns the UTC start of a given month.
+ *
+ * Note: we use UTC to ensure consistent behaviour, and because our comparison
+ * functions (e.g. isSameMonth) use UTC dates also.
+ */
 export function startOf({ year, month }: YearMonth): Date {
-  return new Date(year, month, 1);
+  return new Date(
+    `${year}-${(month + 1).toString().padStart(2, '0')}-01T01:01:01Z`
+  );
 }
 
 // recursive - TODO: make tail recursive?

--- a/content/webapp/components/EventsByMonth/group-event-utils.ts
+++ b/content/webapp/components/EventsByMonth/group-event-utils.ts
@@ -4,10 +4,10 @@ import {
   isSameDay,
   isSameMonth,
 } from '@weco/common/utils/dates';
-import { EventTime } from '../../types/events';
+import { DateTimeRange } from '../../types/events';
 
 type HasTimes = {
-  times: EventTime[];
+  times: { range: DateTimeRange }[];
 };
 
 // Note: here months are 0-indexed, to match the months used by the built-in


### PR DESCRIPTION
The bug was introduced in https://github.com/wellcomecollection/wellcomecollection.org/pull/8389, when I changed `isSameMonth()` to use UTC instead of the user's local timezone.

This means that the first of the month created by `firstOf(yearMonth)` was actually getting offset back into the previous month, I think – I've added a test based on the behaviour prior to that change, verified it broke in the unpatched code, and works in the patched code. I've also checked the "What's on" page in a local copy of the app, and it looks correct.