### PR TITLE
Don't send contributor information on EventBasic; image data on ContributorBasic

### DIFF
--- a/content/webapp/pages/event-series.tsx
+++ b/content/webapp/pages/event-series.tsx
@@ -79,16 +79,16 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
 
     if (isNotUndefined(seriesDocument)) {
       const series = transformEventSeries(seriesDocument);
-      const events = transformQuery(eventsQuery, doc =>
-        transformEventToEventBasic(transformEvent(doc))
-      ).results;
+      const fullEvents = transformQuery(eventsQuery, transformEvent).results;
+
+      const events = fullEvents.map(transformEventToEventBasic);
 
       const upcomingEvents = getUpcomingEvents(events);
       const upcomingEventsIds = new Set(upcomingEvents.map(event => event.id));
 
       const pastEvents = getPastEvents(events, upcomingEventsIds);
 
-      const jsonLd = events.flatMap(eventLd);
+      const jsonLd = fullEvents.flatMap(eventLd);
 
       return {
         props: removeUndefinedProps({

--- a/content/webapp/pages/events.tsx
+++ b/content/webapp/pages/events.tsx
@@ -58,16 +58,17 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       availableOnline: availableOnline === 'true',
     });
 
-    const events = transformQuery(eventsQueryPromise, event =>
-      transformEventToEventBasic(transformEvent(event))
-    );
+    const events = transformQuery(eventsQueryPromise, transformEvent);
 
     if (events) {
       const title = (period === 'past' ? 'Past e' : 'E') + 'vents';
       const jsonLd = events.results.flatMap(eventLd);
       return {
         props: removeUndefinedProps({
-          events,
+          events: {
+            ...events,
+            results: events.results.map(transformEventToEventBasic),
+          },
           title,
           period: period as Period,
           jsonLd,

--- a/content/webapp/pages/whats-on.tsx
+++ b/content/webapp/pages/whats-on.tsx
@@ -346,9 +346,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     const featuredText =
       whatsOnPage && getPageFeaturedText(transformPage(whatsOnPage));
 
-    const events = transformQuery(eventsQuery, event =>
-      transformEventToEventBasic(transformEvent(event))
-    ).results;
+    const events = transformQuery(eventsQuery, transformEvent).results;
     const exhibitions = transformExhibitionsQuery(exhibitionsQuery).results;
     const availableOnlineEvents = transformQuery(
       availableOnlineEventsQuery,
@@ -365,7 +363,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
         props: removeUndefinedProps({
           period,
           exhibitions,
-          events,
+          events: events.map(transformEventToEventBasic),
           availableOnlineEvents,
           dateRange,
           jsonLd,

--- a/content/webapp/services/prismic/transformers/contributors.ts
+++ b/content/webapp/services/prismic/transformers/contributors.ts
@@ -117,12 +117,11 @@ export function transformContributors(
 export function transformContributorToContributorBasic(
   contributor: Contributor
 ): ContributorBasic {
-  const { type, name, image } = contributor.contributor;
+  const { type, name } = contributor.contributor;
   return {
     contributor: {
       type,
       name,
-      image,
     },
   };
 }

--- a/content/webapp/services/prismic/transformers/events.ts
+++ b/content/webapp/services/prismic/transformers/events.ts
@@ -47,10 +47,7 @@ import {
 import { SeasonPrismicDocument } from '../types/seasons';
 import { EventSeriesPrismicDocument } from '../types/event-series';
 import { PlacePrismicDocument } from '../types/places';
-import {
-  transformContributors,
-  transformContributorToContributorBasic,
-} from './contributors';
+import { transformContributors } from './contributors';
 import * as prismicH from '@prismicio/helpers';
 
 function transformEventBookingType(
@@ -383,7 +380,6 @@ export function transformEventToEventBasic(event: Event): EventBasic {
     series,
     secondaryLabels,
     cost,
-    contributors,
   }) => ({
     type,
     promo,
@@ -400,7 +396,6 @@ export function transformEventToEventBasic(event: Event): EventBasic {
     series,
     secondaryLabels,
     cost,
-    contributors: contributors.map(transformContributorToContributorBasic),
   }))(event);
 }
 

--- a/content/webapp/services/prismic/transformers/json-ld.ts
+++ b/content/webapp/services/prismic/transformers/json-ld.ts
@@ -1,4 +1,4 @@
-import { EventBasic } from '../../../types/events';
+import { Event } from '../../../types/events';
 import {
   wellcomeCollectionAddress,
   wellcomeCollectionGallery,
@@ -78,7 +78,7 @@ export function exhibitionLd(exhibition: Exhibition): JsonLdObj {
   );
 }
 
-export function eventLd(event: EventBasic): JsonLdObj[] {
+export function eventLd(event: Event): JsonLdObj[] {
   const promoImage = event.promo?.image;
   return event.times
     .map(eventTime => {

--- a/content/webapp/types/contributors.ts
+++ b/content/webapp/types/contributors.ts
@@ -41,6 +41,5 @@ export type ContributorBasic = {
   contributor: {
     type: string;
     name?: string;
-    image: ImageType;
   };
 };

--- a/content/webapp/types/events.ts
+++ b/content/webapp/types/events.ts
@@ -1,4 +1,4 @@
-import { Contributor, ContributorBasic } from './contributors';
+import { Contributor } from './contributors';
 import { GenericContentFields } from './generic-content-fields';
 import { Format } from './format';
 import { LabelField } from '@weco/common/model/label-field';
@@ -86,7 +86,6 @@ export type EventBasic = HasTimes & {
   scheduleLength: number;
   series: EventSeriesBasic[];
   cost?: string;
-  contributors: ContributorBasic[];
 };
 
 export type Event = GenericContentFields & {


### PR DESCRIPTION
While looking at #8416, I noticed that we're sending a full set of contributor data as part of the `EventBasic` model on the `/whats-on` page, even though we don't use it to render the page. We only use the contributor on events to render the JSON-LD, which is already rendered server-side where we have the full `Event` model.

Running locally, this takes the `/whats-on` page from 324.75&nbsp;kB to 308.63&nbsp;kB; about a 5% reduction. It should also reduce the size of the homepage, when it actually has events.