### PR TITLE
Increase the memory of the catalogue ECS task

### DIFF
--- a/catalogue/terraform/stack/main.tf
+++ b/catalogue/terraform/stack/main.tf
@@ -16,8 +16,13 @@ module "catalogue-service-17092020" {
     var.service_egress_security_group_id
   ]
 
+  # Note: in September 2022, we were running with 0.5 vCPU and 1 GB of memory;
+  # we saw occasionally failures where the memory would spike to 100%
+  # and the app would crash.
+  #
+  # We're increasing it to 2 GB to see if that improves reliability.
   cpu    = 512
-  memory = 1024
+  memory = 2048
 
   env_vars = {
     PROD_SUBDOMAIN  = var.subdomain


### PR DESCRIPTION
I'm hoping this will stem the 502 errors we're seeing, which seem to occur when a task runs out of memory, crashes, and drops any requests it was currently processing.

I've already applied this change.