### PR TITLE
Refactor the way events get grouped in "What's On"

### DIFF
--- a/content/webapp/components/EventDateRange/EventDateRange.tsx
+++ b/content/webapp/components/EventDateRange/EventDateRange.tsx
@@ -1,10 +1,10 @@
 import { getEarliestFutureDateRange } from '@weco/common/utils/dates';
 import DateRange from '@weco/common/views/components/DateRange/DateRange';
 import { FC } from 'react';
-import { Event, EventBasic } from '../../types/events';
+import { HasTimeRanges } from '../../types/events';
 
 type Props = {
-  event: Event | EventBasic;
+  event: HasTimeRanges;
   splitTime?: boolean;
   fromDate?: Date;
 };

--- a/content/webapp/components/EventsByMonth/EventsByMonth.tsx
+++ b/content/webapp/components/EventsByMonth/EventsByMonth.tsx
@@ -6,12 +6,7 @@ import { Link } from '../../types/link';
 import Space from '@weco/common/views/components/styled/Space';
 import CssGridContainer from '@weco/common/views/components/styled/CssGridContainer';
 import CardGrid from '../CardGrid/CardGrid';
-import {
-  groupEventsByMonth,
-  parseLabel,
-  sortByEarliestFutureDateRange,
-  startOf,
-} from './group-event-utils';
+import { groupEventsByMonth, startOf } from './group-event-utils';
 
 type Props = {
   events: EventBasic[];
@@ -30,46 +25,21 @@ class EventsByMonth extends Component<Props, State> {
   render(): JSX.Element {
     const { events, links } = this.props;
     const { activeId } = this.state;
-    const monthsIndex = {
-      1: 'January',
-      2: 'February',
-      3: 'March',
-      4: 'April',
-      5: 'May',
-      6: 'June',
-      7: 'July',
-      8: 'August',
-      9: 'September',
-      10: 'October',
-      11: 'November',
-      12: 'December',
-    };
 
     const eventsInMonths = groupEventsByMonth(events);
 
     // Order months correctly.  This returns the headings for each month,
     // now in chronological order.
-    const monthHeadings = Object.keys(eventsInMonths)
-      .sort((a, b) =>
-        // Because these are YYYY-MM strings (e.g. '2001-02'), we can use
-        // lexicographic ordering for the correct results here.
-        a >= b ? 1 : -1
-      )
-      .map(label => {
-        const yearMonth = parseLabel(label);
+    const groups = eventsInMonths.map(({ month, events }) => {
+      const id = `${month.month}-${month.year}`.toLowerCase();
 
-        return {
-          id: label,
-          url: `#${label}`,
-          text: monthsIndex[yearMonth.month],
-        };
-      });
-
-    // Need to order the events for each month based on their earliest future date range
-    Object.keys(eventsInMonths).map(label => {
-      eventsInMonths[label] = sortByEarliestFutureDateRange(
-        eventsInMonths[label]
-      );
+      return {
+        id,
+        url: `#${id}`,
+        text: month.month,
+        month,
+        events,
+      };
     });
 
     return (
@@ -84,8 +54,8 @@ class EventsByMonth extends Component<Props, State> {
               >
                 <SegmentedControl
                   id="monthControls"
-                  activeId={monthHeadings[0]?.id}
-                  items={monthHeadings}
+                  activeId={groups[0]?.id}
+                  items={groups}
                   extraClasses={'segmented-control__list--inline'}
                   onActiveIdChange={id => {
                     this.setState({ activeId: id });
@@ -96,38 +66,25 @@ class EventsByMonth extends Component<Props, State> {
           </CssGridContainer>
         </Space>
 
-        {monthHeadings.map(month => (
+        {groups.map(g => (
           <div
-            key={month.id}
+            key={g.id}
             className={classNames({
               [cssGrid({ s: 12, m: 12, l: 12, xl: 12 })]: true,
             })}
             style={{
               display: !activeId
                 ? 'block'
-                : activeId === month.id
+                : activeId === g.id
                 ? 'block'
                 : 'none',
             }}
           >
-            <CssGridContainer>
-              <div className="css-grid">
-                <h2
-                  id={month.id}
-                  className={classNames({
-                    tabfocus: true,
-                    [cssGrid({ s: 12, m: 12, l: 12, xl: 12 })]: true,
-                  })}
-                >
-                  {month.id}
-                </h2>
-              </div>
-            </CssGridContainer>
             <CardGrid
-              items={eventsInMonths[month.id]}
+              items={g.events}
               itemsPerRow={3}
               links={links}
-              fromDate={startOf(parseLabel(month.id))}
+              fromDate={startOf(g.month)}
             />
           </div>
         ))}

--- a/content/webapp/components/EventsByMonth/group-event-utils.test.ts
+++ b/content/webapp/components/EventsByMonth/group-event-utils.test.ts
@@ -1,275 +1,169 @@
-import {
-  createLabel,
-  findMonthsThatEventSpans,
-  getMonthsInDateRange,
-  groupEventsByMonth,
-  sortByEarliestFutureDateRange,
-} from './group-event-utils';
-
-describe('createLabel', () => {
-  it('zero-pads the month value', () => {
-    expect(createLabel({ year: 2001, month: 1 })).toEqual('2001-02');
-  });
-
-  it('gets the right label', () => {
-    expect(createLabel({ year: 2001, month: 11 })).toEqual('2001-12');
-  });
-});
+import { getMonthsInDateRange, groupEventsByMonth } from './group-event-utils';
 
 describe('getMonthsInDateRange', () => {
   it('finds a single month', () => {
     const result = getMonthsInDateRange({
-      start: new Date(2001, 1, 1),
-      end: new Date(2001, 1, 5),
+      start: new Date('2001-01-01'),
+      end: new Date('2001-01-05'),
     });
-    expect(result).toEqual([{ year: 2001, month: 1 }]);
+    expect(result).toEqual([{ year: 2001, month: 'January' }]);
   });
 
   it('finds multiple months', () => {
     const result = getMonthsInDateRange({
-      start: new Date(2001, 1, 1),
-      end: new Date(2001, 3, 6),
+      start: new Date('2001-01-01'),
+      end: new Date('2001-03-06'),
     });
     expect(result).toEqual([
-      { year: 2001, month: 1 },
-      { year: 2001, month: 2 },
-      { year: 2001, month: 3 },
+      { year: 2001, month: 'January' },
+      { year: 2001, month: 'February' },
+      { year: 2001, month: 'March' },
     ]);
   });
-});
 
-describe('findMonthsThatEventSpans', () => {
-  it('finds the correct months for each event', () => {
-    const event1 = {
-      id: '1',
-      times: [
-        {
-          range: {
-            startDateTime: new Date(2001, 1, 1),
-            endDateTime: new Date(2001, 1, 5),
-          },
-          isFullyBooked: false,
-        },
-      ],
-    };
-
-    const event2 = {
-      id: '2',
-      times: [
-        {
-          range: {
-            startDateTime: new Date(2001, 1, 1),
-            endDateTime: new Date(2001, 3, 6),
-          },
-          isFullyBooked: false,
-        },
-      ],
-    };
-
-    const result = findMonthsThatEventSpans([event1, event2]);
-
+  it('finds months across a year boundary', () => {
+    const result = getMonthsInDateRange({
+      start: new Date('2001-12-01'),
+      end: new Date('2002-02-07'),
+    });
     expect(result).toEqual([
-      { event: event1, months: [{ year: 2001, month: 1 }] },
-      {
-        event: event2,
-        months: [
-          { year: 2001, month: 1 },
-          { year: 2001, month: 2 },
-          { year: 2001, month: 3 },
-        ],
-      },
-    ]);
-  });
-
-  it('groups multi-month events correctly', () => {
-    const events = [
-      {
-        times: [
-          {
-            range: {
-              startDateTime: new Date('2022-10-18T09:30:00.000Z'),
-              endDateTime: new Date('2022-10-18T14:30:00.000Z'),
-            },
-          },
-          {
-            range: {
-              startDateTime: new Date('2022-11-08T10:30:00.000Z'),
-              endDateTime: new Date('2022-11-08T15:30:00.000Z'),
-            },
-          },
-        ],
-        title: 'HIV and AIDs',
-      },
-      {
-        times: [
-          {
-            range: {
-              startDateTime: new Date('2022-10-06T18:00:00.000Z'),
-              endDateTime: new Date('2022-10-06T18:30:00.000Z'),
-            },
-          },
-        ],
-        title: 'Legacy',
-      },
-      {
-        times: [
-          {
-            range: {
-              startDateTime: new Date('2022-09-17T10:00:00.000Z'),
-              endDateTime: new Date('2022-09-17T11:00:00.000Z'),
-            },
-          },
-        ],
-        title: 'Wandering Womb',
-      },
-    ];
-
-    const result = findMonthsThatEventSpans(events);
-
-    expect(result).toStrictEqual([
-      {
-        event: events[0],
-        months: [
-          { year: 2022, month: 9 },
-          { year: 2022, month: 10 },
-        ],
-      },
-      {
-        event: events[1],
-        months: [{ year: 2022, month: 9 }],
-      },
-      {
-        event: events[2],
-        months: [{ year: 2022, month: 8 }],
-      },
+      { year: 2001, month: 'December' },
+      { year: 2002, month: 'January' },
+      { year: 2002, month: 'February' },
     ]);
   });
 });
 
 describe('groupEventsByMonth', () => {
-  it('puts each event in the right month', () => {
-    const event1 = {
-      id: '1',
+  it('works', () => {
+    // This is based on the state of the "What's on" page on 8 September 2022
+    const evShockingTreatment = {
       times: [
         {
           range: {
-            startDateTime: new Date(2101, 1, 1),
-            endDateTime: new Date(2101, 1, 5),
+            startDateTime: new Date('2022-10-08T16:30:00.000Z'),
+            endDateTime: new Date('2022-10-08T17:30:00.000Z'),
           },
-          isFullyBooked: false,
         },
       ],
+      title: 'Shocking Treatment',
     };
 
-    const event2 = {
-      id: '2',
+    const evLifeWithoutAir = {
       times: [
         {
           range: {
-            startDateTime: new Date(2101, 1, 1),
-            endDateTime: new Date(2101, 3, 6),
+            startDateTime: new Date('2022-10-06T18:00:00.000Z'),
+            endDateTime: new Date('2022-10-06T19:00:00.000Z'),
           },
-          isFullyBooked: false,
         },
       ],
+      title: 'Life Without Air with Daisy Lafarge',
     };
 
-    const result = groupEventsByMonth([event1, event2]);
-
-    expect(result).toEqual({
-      '2101-02': [event1, event2],
-      '2101-04': [event2],
-    });
-  });
-});
-
-describe('sortByEarliestFutureDateRange', () => {
-  it('sorts a group of events correctly', () => {
-    // These examples are based on events from a bug report, where an event
-    // happening at the end of the month was appearing one happening at the
-    // start of the month, because the later event had only just been added
-    // to Prismic.
-    //
-    // See https://wellcome.slack.com/archives/C8X9YKM5X/p1651224877047299
-    const eventSlalom = {
-      title: 'Slalom',
+    const evHivAndAids = {
       times: [
         {
           range: {
-            startDateTime: new Date('2032-05-25T23:00:00.000Z'),
-            endDateTime: new Date('2032-05-27T23:00:00.000Z'),
+            startDateTime: new Date('2022-10-18T09:30:00.000Z'),
+            endDateTime: new Date('2022-10-18T14:30:00.000Z'),
           },
-          isFullyBooked: false,
+        },
+        {
+          range: {
+            startDateTime: new Date('2022-11-08T10:30:00.000Z'),
+            endDateTime: new Date('2022-11-08T15:30:00.000Z'),
+          },
+        },
+        {
+          range: {
+            startDateTime: new Date('2022-11-30T10:30:00.000Z'),
+            endDateTime: new Date('2022-11-30T15:30:00.000Z'),
+          },
         },
       ],
+      title: 'HIV and AIDS',
     };
 
-    const eventGardenersQT = {
-      title: 'Gardeners’ Question Time',
+    const evLegacy = {
       times: [
         {
           range: {
-            startDateTime: new Date('2032-05-09T17:00:00.000Z'),
-            endDateTime: new Date('2032-05-09T19:00:00.000Z'),
+            startDateTime: new Date('2022-10-06T18:00:00.000Z'),
+            endDateTime: new Date('2022-10-06T18:30:00.000Z'),
           },
-          isFullyBooked: false,
         },
       ],
+      title: 'Legacy',
     };
 
-    const eventMentalHealth = {
-      title: 'The Nature of Mental Health',
+    const evCovid19 = {
       times: [
         {
           range: {
-            startDateTime: new Date('2032-05-12T18:00:00.000Z'),
-            endDateTime: new Date('2032-05-12T19:30:00.000Z'),
+            startDateTime: new Date('2022-09-28T18:00:00.000Z'),
+            endDateTime: new Date('2022-09-28T19:30:00.000Z'),
           },
-          isFullyBooked: false,
         },
       ],
+      title: 'The Covid-19 Legacy',
     };
 
-    const eventWomb = {
+    const evThatStinks = {
+      times: [
+        {
+          range: {
+            startDateTime: new Date('2022-09-29T17:00:00.000Z'),
+            endDateTime: new Date('2022-09-29T18:00:00.000Z'),
+          },
+        },
+      ],
+      title: 'That Stinks',
+    };
+
+    const evWanderingWomb = {
+      times: [
+        {
+          range: {
+            startDateTime: new Date('2022-09-17T10:00:00.000Z'),
+            endDateTime: new Date('2022-09-17T11:00:00.000Z'),
+          },
+        },
+        {
+          range: {
+            startDateTime: new Date('2022-09-17T12:00:00.000Z'),
+            endDateTime: new Date('2022-09-17T13:00:00.000Z'),
+          },
+        },
+      ],
       title: 'Wandering Womb',
-      times: [
-        {
-          range: {
-            startDateTime: new Date('2032-05-14T10:00:00.000Z'),
-            endDateTime: new Date('2032-05-14T16:00:00.000Z'),
-          },
-          isFullyBooked: false,
-        },
-      ],
     };
 
-    const eventTouch = {
-      title: 'Personal Touch',
-      times: [
-        {
-          range: {
-            startDateTime: new Date('2032-05-07T09:00:00.000Z'),
-            endDateTime: new Date('2032-05-07T16:00:00.000Z'),
-          },
-          isFullyBooked: false,
-        },
-      ],
-    };
+    const events = [
+      evShockingTreatment,
+      evLifeWithoutAir,
+      evHivAndAids,
+      evLegacy,
+      evCovid19,
+      evThatStinks,
+      evWanderingWomb,
+    ];
 
-    const result = sortByEarliestFutureDateRange([
-      eventSlalom,
-      eventGardenersQT,
-      eventMentalHealth,
-      eventWomb,
-      eventTouch,
-    ]);
+    const groupedEvents = groupEventsByMonth(events);
 
-    expect(result).toEqual([
-      eventTouch,
-      eventGardenersQT,
-      eventMentalHealth,
-      eventWomb,
-      eventSlalom,
+    expect(groupedEvents).toStrictEqual([
+      {
+        month: { month: 'September', year: 2022 },
+        events: [evWanderingWomb, evCovid19, evThatStinks],
+      },
+      {
+        month: { month: 'October', year: 2022 },
+        events: [evLegacy, evLifeWithoutAir, evShockingTreatment, evHivAndAids],
+      },
+      {
+        month: { month: 'November', year: 2022 },
+        events: [evHivAndAids],
+      },
     ]);
   });
 });

--- a/content/webapp/components/EventsByMonth/group-event-utils.ts
+++ b/content/webapp/components/EventsByMonth/group-event-utils.ts
@@ -1,146 +1,163 @@
-import {
-  getEarliestFutureDateRange,
-  isFuture,
-  isSameDay,
-  isSameMonth,
-} from '@weco/common/utils/dates';
-import { DateTimeRange } from '../../types/events';
+import { isNotUndefined } from '@weco/common/utils/array';
+import { getDatesBetween } from '@weco/common/utils/dates';
+import { HasTimeRanges } from '../../types/events';
 
-type HasTimes = {
-  times: { range: DateTimeRange }[];
-};
-
-// Note: here months are 0-indexed, to match the months used by the built-in
-// JavaScript date type.
 export type YearMonth = {
   year: number;
-  month: number;
+  month: string;
 };
 
-// Creates a label in the form YYYY-MM, e.g. "2001-02"
-//
-// Note: here months are 1-indexed, because this value is displayed in the UI and
-// used to construct fragment URLs.
-export function createLabel({ year, month }: YearMonth): string {
-  return `${year}-${(month + 1).toString().padStart(2, '0')}`;
-}
-
-export function parseLabel(label: string): YearMonth {
-  const year = parseInt(label.slice(0, 4), 10);
-  const month = parseInt(label.slice(5, 7), 10);
-  return { year, month };
-}
-
-/** Returns the UTC start of a given month.
- *
- * Note: we use UTC to ensure consistent behaviour, and because our comparison
- * functions (e.g. isSameMonth) use UTC dates also.
- */
+/** Returns the UTC start of a given month. */
 export function startOf({ year, month }: YearMonth): Date {
-  return new Date(
-    `${year}-${(month + 1).toString().padStart(2, '0')}-01T01:01:01Z`
+  return new Date(`1 ${month} ${year}`);
+}
+
+// Note: UTC months are 0-indexed
+const utcMonthNames = {
+  0: 'January',
+  1: 'February',
+  2: 'March',
+  3: 'April',
+  4: 'May',
+  5: 'June',
+  6: 'July',
+  7: 'August',
+  8: 'September',
+  9: 'October',
+  10: 'November',
+  11: 'December',
+};
+
+/** Returns a list of all the months that fall on or between two dates.
+ *
+ * e.g. getDatesBetween({ start: 2001-01-01, end: 2001-04-05 })
+ *    => { January 2001, February 2001, March 2001, April 2001 }
+ *
+ */
+export function getMonthsInDateRange({
+  start,
+  end,
+}: {
+  start: Date;
+  end: Date;
+}): YearMonth[] {
+  console.assert(
+    start < end,
+    `Asked to find months in date range start=${start}, end=${end}`
+  );
+
+  const result: YearMonth[] = [];
+
+  getDatesBetween({ start, end }).forEach(d => {
+    const m = {
+      year: d.getUTCFullYear(),
+      month: utcMonthNames[d.getUTCMonth()],
+    };
+
+    if (!result.length) {
+      result.push(m);
+    } else {
+      const latestResult = result[result.length - 1];
+
+      if (latestResult.year !== m.year || latestResult.month !== m.month) {
+        result.push(m);
+      }
+    }
+  });
+
+  return result;
+}
+
+function isInMonth(d: Date, yearMonth: YearMonth): boolean {
+  return (
+    d.getUTCFullYear() === yearMonth.year &&
+    utcMonthNames[d.getUTCMonth()] === yearMonth.month
   );
 }
 
-// recursive - TODO: make tail recursive?
-type StartEnd = { start: Date; end: Date };
-
-export function getMonthsInDateRange(
-  { start, end }: StartEnd,
-  acc: YearMonth[] = []
-): YearMonth[] {
-  if (isSameMonth(start, end) || start <= end) {
-    const yearMonth = {
-      year: start.getFullYear(),
-      month: start.getMonth(),
-    };
-    const newAcc = acc.concat(yearMonth);
-    const newStart = startOf({
-      ...yearMonth,
-      month: yearMonth.month + 1,
-    });
-    return getMonthsInDateRange({ start: newStart, end }, newAcc);
-  } else {
-    return acc;
-  }
+function minDate(dates: Date[]): Date {
+  return dates.reduce((a, b) => (a < b ? a : b));
 }
 
-// For each event, find the months that it spans.
-export function findMonthsThatEventSpans<T extends HasTimes>(
+function maxDate(dates: Date[]): Date {
+  return dates.reduce((a, b) => (a > b ? a : b));
+}
+
+function getEarliestStartTime({ times }: HasTimeRanges): Date {
+  return minDate(times.map(t => t.range.startDateTime));
+}
+
+function getLatestStartTime({ times }: HasTimeRanges): Date {
+  return maxDate(times.map(t => t.range.startDateTime));
+}
+
+type GroupedEvent<T> = {
+  month: YearMonth;
+  events: T[];
+};
+
+export function groupEventsByMonth<T extends HasTimeRanges>(
   events: T[]
-): {
-  event: T;
-  months: YearMonth[];
-}[] {
-  return events
-    .filter(event => event.times.length > 0)
-    .map(event => {
-      const firstRange = event.times[0];
-      const lastRange = event.times[event.times.length - 1];
+): GroupedEvent<T>[] {
+  // Work out the min/max bounds for the list of events.
+  const earliestStartTime = minDate(events.map(getEarliestStartTime));
+  const latestStartTime = maxDate(events.map(getLatestStartTime));
 
-      const start = firstRange.range.startDateTime;
-      const end = lastRange.range.endDateTime;
+  // Work out what months this should cover
+  //
+  // This gives us the list of months that will appear in the segmented control
+  // on the "What's on" page
+  const monthSpan = getMonthsInDateRange({
+    start: earliestStartTime,
+    end: latestStartTime,
+  });
 
-      const months = getMonthsInDateRange({ start, end });
-      return { event, months };
-    });
-}
+  // For each month, work out (a) what events should be included and
+  // (b) what order those events should appear in.
+  return monthSpan.map(month => {
+    const eventsInMonth = events
+      .map(ev => {
+        // For each event, we ask:
+        //
+        //    - does it have any start times in this month?
+        //        => should it appear in the list of events for this month?
+        //
+        //    - what's the earliest time it starts in this month?
+        //        => where should it appear in the order of events for this month?
+        //
+        const rangesInMonth = ev.times
+          .map(t => t.range)
+          .filter(t => isInMonth(t.startDateTime, month));
 
-// Key: a YYYY-MM month label like "2001-02"
-// Value: a list of events that fall somewhere in this month
-export function groupEventsByMonth<T extends HasTimes>(
-  events: T[]
-): Record<string, T[]> {
-  return findMonthsThatEventSpans(events).reduce((acc, { event, months }) => {
-    months.forEach(month => {
-      // Only add if it has a time in the month that is the same or after today
-      //
-      // NOTE: this means a very long-running event wouldn't appear in the events
-      // for a month, e.g. a Jan-Feb-Mar event wouldn't appear in the February events.
-      // Do we have any such long-running events?  If so, this is probably okay.
-      const hasDateInMonthRemaining = event.times.find(time => {
-        const start = time.range.startDateTime;
-        const end = time.range.endDateTime;
+        return rangesInMonth.length > 0
+          ? {
+              event: ev,
+              earliestRangeInMonth: rangesInMonth.reduce((a, b) =>
+                a.startDateTime < b.startDateTime ? a : b
+              ),
+            }
+          : undefined;
+      })
+      .filter(isNotUndefined)
+      .sort((a, b) => {
+        // We sort the events within each month by their earliest start date,
+        // so events appear in the order they're going to occur.
+        //
+        // If there are two events that start at the same time, we sort them by
+        // end time.  This is an arbitrary choice, and just for consistent behaviour.
+        const rangeA = a.earliestRangeInMonth;
+        const rangeB = b.earliestRangeInMonth;
 
-        const endsInMonth = isSameMonth(end, startOf(month));
+        return rangeA.startDateTime > rangeB.startDateTime
+          ? 1
+          : rangeA.startDateTime < rangeB.startDateTime
+          ? -1
+          : rangeA.endDateTime > rangeB.endDateTime
+          ? 1
+          : -1;
+      })
+      .map(ev => ev.event);
 
-        const startsInMonth = isSameMonth(start, startOf(month));
-
-        const today = new Date();
-        const isNotClosedYet = isSameDay(end, today) || isFuture(end);
-
-        return (endsInMonth || startsInMonth) && isNotClosedYet;
-      });
-      if (hasDateInMonthRemaining) {
-        const label = createLabel(month);
-
-        if (!acc[label]) {
-          acc[label] = [];
-        }
-        acc[label].push(event);
-      }
-    });
-    return acc;
-  }, {} as Record<string, T[]>);
-}
-
-function getEarliestStart(t: HasTimes): Date | undefined {
-  const times = t.times.map(time => ({
-    start: time.range.startDateTime,
-    end: time.range.endDateTime,
-  }));
-
-  const earliestRange = getEarliestFutureDateRange(times);
-  return earliestRange && earliestRange.start;
-}
-
-export function sortByEarliestFutureDateRange<T extends HasTimes>(
-  events: T[]
-): T[] {
-  return events.sort((a, b) => {
-    const startA = getEarliestStart(a);
-    const startB = getEarliestStart(b);
-
-    return startA && startB && startA > startB ? 1 : -1;
+    return { month, events: eventsInMonth };
   });
 }

--- a/content/webapp/types/events.ts
+++ b/content/webapp/types/events.ts
@@ -65,6 +65,10 @@ export type ThirdPartyBooking = {
   url: string;
 };
 
+export type HasTimeRanges = {
+  times: { range: DateTimeRange }[];
+};
+
 export type HasTimes = {
   times: EventTime[];
 };


### PR DESCRIPTION
The existing implementation was quite difficult to follow -- it was broken down into lots of small functions, and it was tricky to see how they interacted.

It had some quite tricksy behaviour around things like 0-indexed months (which we don't use anywhere else) and the ordering of events.  This is one of those times you wonder how the previous version ever worked correctly (and based on a quick test, maybe it didn't).

This patch replaces it with a hopefully simpler and more readable implementation:

1. Work out the min/max bounds for the list of events
2. Work out what month that covers
3. For each month, work out (a) what events should be included and (b) what order they should appear in

A lot of the intermediate functions are gone, and internally events are grouped by their English name, not a 0-indexed value.

I've tested it on the current What's On page, which has a somewhat complex series of events, and it seems to behave correctly.