### PR TITLE
Remove our lodash.groupBy dependency

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -45,7 +45,6 @@
     "jest": "^27.3.1",
     "koa-compose": "^4.1.0",
     "lodash.debounce": "^4.0.8",
-    "lodash.groupby": "^4.6.0",
     "next": "^11.1.2",
     "next-cookies": "^2.0.3",
     "next-transpile-modules": "^8.0.0",

--- a/common/services/prismic/opening-times.ts
+++ b/common/services/prismic/opening-times.ts
@@ -1,5 +1,4 @@
 import { formatDay } from '../../utils/format-date';
-import groupBy from 'lodash.groupby';
 import {
   OverrideType,
   ExceptionalPeriod,
@@ -53,9 +52,17 @@ export function exceptionalOpeningPeriods(
 ): ExceptionalPeriod[] {
   dates.sort((a, b) => Number(a.overrideDate) - Number(b.overrideDate));
 
-  const exceptionalPeriods = Object.values(
-    groupBy(dates, date => date.overrideType)
-  ).flat();
+  const groupedExceptionalPeriods: Record<OverrideType, OverrideDate[]> =
+    dates.reduce((acc, date) => {
+      if (Object.keys(acc).includes(date.overrideType)) {
+        acc[date.overrideType].push(date);
+      } else {
+        acc[date.overrideType] = [date];
+      }
+      return acc;
+    }, {} as Record<OverrideType, OverrideDate[]>);
+
+  const exceptionalPeriods = Object.values(groupedExceptionalPeriods).flat();
 
   let groupedIndex = 0;
   return exceptionalPeriods

--- a/yarn.lock
+++ b/yarn.lock
@@ -12153,11 +12153,6 @@ lodash.flattendeep@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
   integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
 
-lodash.groupby@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.groupby/-/lodash.groupby-4.6.0.tgz#0b08a1dcf68397c397855c3239783832df7403d1"
-  integrity sha1-Cwih3PaDl8OXhVwyOXg4Mt90A9E=
-
 lodash.includes@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"


### PR DESCRIPTION
We only use it in one place, and we can easily replace it with a bit of vanilla TypeScript.

This is something I spotted while poking around in this opening-times code.