### PR TITLE
Remove some unnecessary interpolation in attributes

### DIFF
--- a/cardigan/stories/components/Buttons/Buttons.stories.tsx
+++ b/cardigan/stories/components/Buttons/Buttons.stories.tsx
@@ -64,18 +64,18 @@ const DropdownButtonTemplate = args => {
           <li>
             <CheckboxRadio
               id="1"
-              type={`checkbox`}
+              type="checkbox"
               text="Manuscripts (1,856)"
             />
           </li>
           <li>
-            <CheckboxRadio id="2" type={`checkbox`} text="Archives (1,784)" />
+            <CheckboxRadio id="2" type="checkbox" text="Archives (1,784)" />
           </li>
           <li>
-            <CheckboxRadio id="3" type={`checkbox`} text="Images (2,122)" />
+            <CheckboxRadio id="3" type="checkbox" text="Images (2,122)" />
           </li>
           <li>
-            <CheckboxRadio id="4" type={`checkbox`} text="Books (12,465)" />
+            <CheckboxRadio id="4" type="checkbox" text="Books (12,465)" />
           </li>
         </ul>
       </div>

--- a/cardigan/stories/components/PageHeader/PageHeader.stories.tsx
+++ b/cardigan/stories/components/PageHeader/PageHeader.stories.tsx
@@ -157,7 +157,7 @@ const EventContentTypeInfo = () => (
         <Space
           as="span"
           h={{ size: 'xs', properties: ['margin-right'] }}
-          className={`flex flex--v-center`}
+          className="flex flex--v-center"
         >
           <Dot color={'marble'} />
         </Space>
@@ -173,7 +173,7 @@ const ExhibitionContentTypeInfo = () => (
       <Space
         as="span"
         h={{ size: 'xs', properties: ['margin-right'] }}
-        className={`flex flex--v-center`}
+        className="flex flex--v-center"
       >
         <Dot color={'marble'} />
       </Space>

--- a/catalogue/webapp/components/ArchiveBreadcrumb/ArchiveBreadcrumb.tsx
+++ b/catalogue/webapp/components/ArchiveBreadcrumb/ArchiveBreadcrumb.tsx
@@ -131,7 +131,7 @@ const ArchiveBreadcrumb: FunctionComponent<Props> = ({ work }: Props) => {
                 <ul>
                   {middleCrumbs.map(crumb => {
                     return (
-                      <li key={crumb.id} className={`flex`}>
+                      <li key={crumb.id} className="flex">
                         <Icon
                           matchText={true}
                           color={'currentColor'}

--- a/catalogue/webapp/components/Download/Download.tsx
+++ b/catalogue/webapp/components/Download/Download.tsx
@@ -159,7 +159,7 @@ const Download: NextPage<Props> = ({
               {license && (
                 <>
                   <SpacingComponent>
-                    <Divider color={`pumice`} isKeyline={true} />
+                    <Divider color="pumice" isKeyline={true} />
                   </SpacingComponent>
                   <SpacingComponent>
                     <div>

--- a/catalogue/webapp/components/IIIFViewer/NoScriptViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/NoScriptViewer.tsx
@@ -200,7 +200,7 @@ const NoScriptViewer: FunctionComponent<NoScriptViewerProps> = ({
               width={800}
               src={imageUrl}
               srcSet={srcSet}
-              sizes={`(min-width: 860px) 800px, calc(92.59vw + 22px)`}
+              sizes="(min-width: 860px) 800px, calc(92.59vw + 22px)"
               lang={lang}
               alt={
                 (canvasOcr && canvasOcr.replace(/"/g, '')) ||
@@ -213,7 +213,7 @@ const NoScriptViewer: FunctionComponent<NoScriptViewerProps> = ({
               width={800}
               src={urlTemplate && urlTemplate({ size: '800,' })}
               srcSet={srcSet}
-              sizes={`(min-width: 860px) 800px, calc(92.59vw + 22px)`}
+              sizes="(min-width: 860px) 800px, calc(92.59vw + 22px)"
               lang={lang}
               alt={
                 (canvasOcr && canvasOcr.replace(/"/g, '')) ||

--- a/catalogue/webapp/components/IIIFViewer/ViewerBottomBar.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerBottomBar.tsx
@@ -123,7 +123,7 @@ const ViewerBottomBar: FunctionComponent<Props> = ({ viewerRef }: Props) => {
                 }}
               >
                 <Icon icon={expand} />
-                <span className={`btn__text`}>Full screen</span>
+                <span className="btn__text">Full screen</span>
               </ShameButton>
             </Space>
           </div>

--- a/catalogue/webapp/components/IIIFViewer/ViewerTopBar.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerTopBar.tsx
@@ -229,7 +229,7 @@ const ViewerTopBar: FunctionComponent<Props> = ({ viewerRef }: Props) => {
             <>
               <ShameButton
                 data-test-id="toggle-info-desktop"
-                className={`viewer-desktop`}
+                className="viewer-desktop"
                 isDark
                 onClick={() => {
                   setIsDesktopSidebarActive(!isDesktopSidebarActive);
@@ -245,13 +245,13 @@ const ViewerTopBar: FunctionComponent<Props> = ({ viewerRef }: Props) => {
                   color={'white'}
                   rotate={isDesktopSidebarActive ? undefined : 180}
                 />
-                <span className={`visually-hidden`}>
+                <span className="visually-hidden">
                   {isDesktopSidebarActive ? 'Hide info' : 'Show info'}
                 </span>
               </ShameButton>
               <ShameButton
                 data-test-id="toggle-info-mobile"
-                className={`viewer-mobile`}
+                className="viewer-mobile"
                 isDark
                 onClick={() => {
                   setIsMobileSidebarActive(!isMobileSidebarActive);
@@ -367,7 +367,7 @@ const ViewerTopBar: FunctionComponent<Props> = ({ viewerRef }: Props) => {
                   ) : (
                     <>
                       <Icon icon={expand} />
-                      <span className={`btn__text`}>Full screen</span>
+                      <span className="btn__text">Full screen</span>
                     </>
                   )}
                 </ShameButton>

--- a/catalogue/webapp/components/ItemRequestModal/ConfirmedDialog.tsx
+++ b/catalogue/webapp/components/ItemRequestModal/ConfirmedDialog.tsx
@@ -22,7 +22,7 @@ const ConfirmedDialog: FC<ConfirmedDialogProps> = ({ currentHoldNumber }) => {
         level 3) for one week from your selected pickup date.
       </p>
       <CTAs>
-        <ButtonSolidLink text={`View your library account`} link={'/account'} />
+        <ButtonSolidLink text="View your library account" link={'/account'} />
       </CTAs>
     </>
   );

--- a/catalogue/webapp/components/ItemRequestModal/ConfirmedDialog.tsx
+++ b/catalogue/webapp/components/ItemRequestModal/ConfirmedDialog.tsx
@@ -11,7 +11,7 @@ const ConfirmedDialog: FC<ConfirmedDialogProps> = ({ currentHoldNumber }) => {
   return (
     <>
       <Header>
-        <span className={`h2`}>Request confirmed</span>
+        <span className="h2">Request confirmed</span>
         <CurrentRequests
           allowedHoldRequests={allowedRequests}
           currentHoldRequests={currentHoldNumber}

--- a/catalogue/webapp/components/ItemRequestModal/ErrorDialog.tsx
+++ b/catalogue/webapp/components/ItemRequestModal/ErrorDialog.tsx
@@ -12,7 +12,7 @@ type ErrorDialogProps = {
 const ErrorDialog: FC<ErrorDialogProps> = ({ setIsActive, errorMessage }) => (
   <>
     <Header>
-      <span className={`h2`}>Request failed</span>
+      <span className="h2">Request failed</span>
     </Header>
     <p className="no-margin">{errorMessage || defaultRequestErrorMessage}</p>
     <CTAs>

--- a/catalogue/webapp/components/ItemRequestModal/ErrorDialog.tsx
+++ b/catalogue/webapp/components/ItemRequestModal/ErrorDialog.tsx
@@ -18,7 +18,7 @@ const ErrorDialog: FC<ErrorDialogProps> = ({ setIsActive, errorMessage }) => (
     <CTAs>
       <ButtonSolid
         colors={themeValues.buttonColors.greenTransparentGreen}
-        text={`Close`}
+        text="Close"
         clickHandler={() => setIsActive(false)}
       />
     </CTAs>

--- a/catalogue/webapp/components/ItemRequestModal/RequestDialog.tsx
+++ b/catalogue/webapp/components/ItemRequestModal/RequestDialog.tsx
@@ -159,12 +159,12 @@ const RequestDialog: FC<RequestDialogProps> = ({
           v={{ size: 's', properties: ['margin-bottom'] }}
           className={'inline-block'}
         >
-          <ButtonSolid text={`Confirm request`} />
+          <ButtonSolid text="Confirm request" />
         </Space>
         <ButtonSolid
           colors={themeValues.buttonColors.greenTransparentGreen}
           type={ButtonTypes.button}
-          text={`Cancel`}
+          text="Cancel"
           clickHandler={() => setIsActive(false)}
         />
       </CTAs>

--- a/catalogue/webapp/components/ItemRequestModal/RequestDialog.tsx
+++ b/catalogue/webapp/components/ItemRequestModal/RequestDialog.tsx
@@ -101,7 +101,7 @@ const RequestDialog: FC<RequestDialogProps> = ({
   return (
     <Request onSubmit={handleConfirmRequest}>
       <Header>
-        <span className={`h2`}>Request item</span>
+        <span className="h2">Request item</span>
         <CurrentRequests
           allowedHoldRequests={allowedRequests}
           currentHoldRequests={currentHoldNumber}

--- a/catalogue/webapp/components/Work/Work.tsx
+++ b/catalogue/webapp/components/Work/Work.tsx
@@ -148,7 +148,7 @@ const Work: FunctionComponent<Props> = ({
             </div>
 
             <div className="container">
-              <Divider color={`pumice`} isKeyline={true} />
+              <Divider color="pumice" isKeyline={true} />
               <ArchiveDetailsContainer>
                 <ArchiveTree work={work} />
                 <Space

--- a/catalogue/webapp/components/Work/Work.tsx
+++ b/catalogue/webapp/components/Work/Work.tsx
@@ -153,7 +153,7 @@ const Work: FunctionComponent<Props> = ({
                 <ArchiveTree work={work} />
                 <Space
                   v={{ size: 'xl', properties: ['padding-top'] }}
-                  className={`flex-1`}
+                  className="flex-1"
                 >
                   <WorkDetails work={work} />
                 </Space>

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -778,7 +778,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
       {(locationOfWork || physicalItems.length > 0) && renderWhereToFindIt()}
 
       <WorkDetailsSection headingText="Permanent link">
-        <div className={`${font('intr', 5)}`}>
+        <div className={font('intr', 5)}>
           <CopyUrl
             id={work.id}
             url={`https://wellcomecollection.org/works/${work.id}`}

--- a/catalogue/webapp/components/WorkDetailsSection/WorkDetailsSection.tsx
+++ b/catalogue/webapp/components/WorkDetailsSection/WorkDetailsSection.tsx
@@ -19,7 +19,7 @@ const WorkDetailsSection: FunctionComponent<Props> = ({
     <>
       {!isArchive && (
         <>
-          <Divider color={`pumice`} isKeyline={true} />
+          <Divider color="pumice" isKeyline={true} />
           <SpacingComponent />
         </>
       )}

--- a/catalogue/webapp/components/WorksSearchResult/WorksSearchResult.tsx
+++ b/catalogue/webapp/components/WorksSearchResult/WorksSearchResult.tsx
@@ -88,7 +88,7 @@ const WorkSearchResult: FunctionComponent<Props> = ({
       <WorkLink
         id={work.id}
         resultPosition={resultPosition}
-        source={`works_search_result`}
+        source="works_search_result"
         passHref
       >
         <Space

--- a/catalogue/webapp/components/WorksSearchResult/WorksSearchResultV2.tsx
+++ b/catalogue/webapp/components/WorksSearchResult/WorksSearchResultV2.tsx
@@ -77,7 +77,7 @@ const WorkSearchResultV2: FC<Props> = ({ work, resultPosition }: Props) => {
     <WorkLink
       id={work.id}
       resultPosition={resultPosition}
-      source={`works_search_result`}
+      source="works_search_result"
       passHref
     >
       <Space

--- a/common/utils/classnames.ts
+++ b/common/utils/classnames.ts
@@ -56,7 +56,7 @@ export function classNames(classNames: ClassNames): string {
   }
 }
 
-export function conditionalClassNames(obj: Record<string, boolean>): string {
+function conditionalClassNames(obj: Record<string, boolean>): string {
   return Object.keys(obj)
     .map(key => {
       if (obj[key]) {

--- a/common/views/components/ClearSearch/ClearSearch.tsx
+++ b/common/views/components/ClearSearch/ClearSearch.tsx
@@ -18,7 +18,7 @@ const ClearSearch: FunctionComponent<Props> = ({
   return (
     <button
       style={right ? { right: `${right}px` } : undefined}
-      className={`absolute line-height-1 plain-button v-center no-padding`}
+      className="absolute line-height-1 plain-button v-center no-padding"
       onClick={() => {
         gaEvent && trackEvent(gaEvent);
         setValue('');

--- a/common/views/components/Footer/Footer.tsx
+++ b/common/views/components/Footer/Footer.tsx
@@ -184,7 +184,7 @@ const Footer: FunctionComponent<Props> = ({ venues, hide = false }: Props) => {
     <Wrapper ref={footer}>
       <div className="container">
         <div className="grid">
-          <div className={`${grid({ s: 12, m: 12, l: 4 })}`}>
+          <div className={grid({ s: 12, m: 12, l: 4 })}>
             <Space
               v={{
                 size: 'm',
@@ -202,7 +202,7 @@ const Footer: FunctionComponent<Props> = ({ venues, hide = false }: Props) => {
               <FooterNav />
             </FooterNavWrapper>
           </div>
-          <div className={`${grid({ s: 12, m: 6, l: 4 })}`}>
+          <div className={grid({ s: 12, m: 6, l: 4 })}>
             <Space
               v={{
                 size: 'm',

--- a/common/views/components/Footer/FooterNav.tsx
+++ b/common/views/components/Footer/FooterNav.tsx
@@ -25,7 +25,7 @@ const FooterNav: FunctionComponent = () => {
   return (
     <div>
       <nav>
-        <ul className={`plain-list no-margin no-padding`}>
+        <ul className="plain-list no-margin no-padding">
           {links.map((link, i) => (
             <li key={link.title}>
               <NavLink id={`footer-nav-${i}`} as="a" href={link.href}>

--- a/common/views/components/InfoBanner/InfoBanner.tsx
+++ b/common/views/components/InfoBanner/InfoBanner.tsx
@@ -72,7 +72,7 @@ const InfoBanner: FunctionComponent<Props> = ({
                   <Space
                     h={{ size: 'm', properties: ['margin-right'] }}
                     v={{ size: 'xs', properties: ['margin-top'] }}
-                    className={`flex`}
+                    className="flex"
                   >
                     <Icon icon={information} />
                     <span className="visually-hidden" id="note">

--- a/common/views/components/LabelsList/LabelsList.tsx
+++ b/common/views/components/LabelsList/LabelsList.tsx
@@ -20,7 +20,7 @@ const LabelsList: FunctionComponent<Props> = ({
     }}
     h={{ size: 'm', properties: ['padding-right'] }}
     as="ul"
-    className={`flex plain-list no-padding flex--wrap`}
+    className="flex plain-list no-padding flex--wrap"
     style={{ marginLeft: 0, marginTop: 0 }}
   >
     {labels.filter(Boolean).map((label, i) => (

--- a/common/views/components/ModalMoreFilters/ModalMoreFilters.tsx
+++ b/common/views/components/ModalMoreFilters/ModalMoreFilters.tsx
@@ -106,7 +106,7 @@ const CheckboxFilter = ({ f, changeHandler }: CheckboxFilterProps) => {
           >
             <CheckboxRadio
               id={`desktop-${id}`}
-              type={`checkbox`}
+              type="checkbox"
               text={`${label} (${count})`}
               value={value}
               name={f.id}

--- a/common/views/components/PageHeader/PageHeader.tsx
+++ b/common/views/components/PageHeader/PageHeader.tsx
@@ -125,7 +125,7 @@ const PageHeader: FunctionComponent<Props> = ({
   return (
     <>
       <div
-        className={`row relative`}
+        className="row relative"
         style={{
           backgroundImage: backgroundTexture
             ? `url(${backgroundTexture})`

--- a/common/views/components/Paginator/Paginator.tsx
+++ b/common/views/components/Paginator/Paginator.tsx
@@ -150,7 +150,7 @@ const Paginator: FunctionComponent<Props> = ({
               </Rotator>
             </Space>
           )}
-          <span className={`font-pewter`}>
+          <span className="font-pewter">
             Page {currentPage} of {totalPages}
           </span>
           {nextLink && next && (

--- a/common/views/components/RadioGroup/RadioGroup.tsx
+++ b/common/views/components/RadioGroup/RadioGroup.tsx
@@ -44,7 +44,7 @@ const RadioGroup: FunctionComponent<Props> = ({
         <CheckboxRadio
           id={id}
           text={label}
-          type={`radio`}
+          type="radio"
           name={name}
           value={value}
           checked={selected === value}

--- a/common/views/components/SearchFilters/SearchFiltersDesktop.tsx
+++ b/common/views/components/SearchFilters/SearchFiltersDesktop.tsx
@@ -55,7 +55,7 @@ const CheckboxFilter = ({ f, changeHandler }: CheckboxFilterProps) => {
             <li key={`${f.id}-${id}`}>
               <CheckboxRadio
                 id={id}
-                type={`checkbox`}
+                type="checkbox"
                 text={`${label} (${count})`}
                 value={value}
                 name={f.id}

--- a/common/views/components/SearchFilters/SearchFiltersMobile.tsx
+++ b/common/views/components/SearchFilters/SearchFiltersMobile.tsx
@@ -124,7 +124,7 @@ const CheckboxFilter = ({ f, changeHandler }: CheckboxFilterProps) => {
             >
               <CheckboxRadio
                 id={`mobile-${id}`}
-                type={`checkbox`}
+                type="checkbox"
                 text={`${label} (${count})`}
                 value={value}
                 name={f.id}

--- a/common/views/components/SectionHeader/SectionHeader.tsx
+++ b/common/views/components/SectionHeader/SectionHeader.tsx
@@ -39,7 +39,7 @@ const SectionHeader: FC<Props> = ({ title }) => {
             <Space
               as="h2"
               h={{ size: 's', properties: ['margin-left'] }}
-              className={`inline`}
+              className="inline"
             >
               <TitleWrapper>{title}</TitleWrapper>
             </Space>

--- a/common/views/components/StatusIndicator/StatusIndicator.tsx
+++ b/common/views/components/StatusIndicator/StatusIndicator.tsx
@@ -20,7 +20,7 @@ const StatusIndicator: FC<Props> = ({ start, end, statusOverride }: Props) => {
       <Space
         as="span"
         h={{ size: 'xs', properties: ['margin-right'] }}
-        className={`flex flex--v-center`}
+        className="flex flex--v-center"
       >
         <Dot color={color} />
       </Space>

--- a/content/webapp/components/Contributors/Contributor.tsx
+++ b/content/webapp/components/Contributors/Contributor.tsx
@@ -63,7 +63,7 @@ const Contributor: FC<ContributorType> = ({
           )}
         </Space>
         <div>
-          <div className={`flex flex--h-baseline`}>
+          <div className="flex flex--h-baseline">
             <h3
               className={classNames({
                 [font('intb', 4)]: true,

--- a/content/webapp/components/EventCard/EventCard.tsx
+++ b/content/webapp/components/EventCard/EventCard.tsx
@@ -58,7 +58,7 @@ const EventCard: FC<Props> = ({ event, xOfY }) => {
       <>
         <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
           <Space v={{ size: 's', properties: ['margin-top'] }}>
-            <WatchLabel text={`Available to watch`} />
+            <WatchLabel text="Available to watch" />
           </Space>
         </Space>
       </>

--- a/content/webapp/components/EventDatesLink/EventDatesLink.tsx
+++ b/content/webapp/components/EventDatesLink/EventDatesLink.tsx
@@ -11,7 +11,7 @@ type Props = {
 const EventDatesLink: FunctionComponent<Props> = ({ id }: Props) => {
   return (
     <a
-      href={`#dates`}
+      href="#dates"
       onClick={() => {
         trackEvent({
           category: 'EventDatesLink',

--- a/content/webapp/components/EventPromo/EventPromo.tsx
+++ b/content/webapp/components/EventPromo/EventPromo.tsx
@@ -130,7 +130,7 @@ const EventPromo: FC<Props> = ({
 
           {event.availableOnline && (
             <Space v={{ size: 's', properties: ['margin-top'] }}>
-              <WatchLabel text={`Available to watch`} />
+              <WatchLabel text="Available to watch" />
             </Space>
           )}
 
@@ -212,7 +212,7 @@ const EventPromo: FC<Props> = ({
           h={{ size: 'm', properties: ['padding-left', 'padding-right'] }}
           v={{ size: 'm', properties: ['padding-bottom'] }}
         >
-          <Divider color={`white`} isKeyline={true} />
+          <Divider color="white" isKeyline={true} />
           <Space v={{ size: 's', properties: ['padding-top'] }}>
             <LabelsList
               labels={event.secondaryLabels}

--- a/content/webapp/components/EventPromo/EventPromo.tsx
+++ b/content/webapp/components/EventPromo/EventPromo.tsx
@@ -164,7 +164,7 @@ const EventPromo: FC<Props> = ({
               <Space
                 as="span"
                 h={{ size: 'xs', properties: ['margin-right'] }}
-                className={`flex flex--v-center`}
+                className="flex flex--v-center"
               >
                 <Dot color={'red'} />
               </Space>
@@ -181,7 +181,7 @@ const EventPromo: FC<Props> = ({
           )}
 
           {!isPast && event.times.length > 1 && (
-            <p className={`${font('intb', 6)}`}>See all dates/times</p>
+            <p className={font('intb', 6)}>See all dates/times</p>
           )}
 
           {isPast && !event.availableOnline && (
@@ -189,7 +189,7 @@ const EventPromo: FC<Props> = ({
               <Space
                 as="span"
                 h={{ size: 'xs', properties: ['margin-right'] }}
-                className={`flex flex--v-center`}
+                className="flex flex--v-center"
               >
                 <Dot color={'marble'} />
               </Space>

--- a/content/webapp/components/EventSchedule/EventBookingButton.tsx
+++ b/content/webapp/components/EventSchedule/EventBookingButton.tsx
@@ -15,7 +15,7 @@ function getButtonMarkup(event: Event) {
   if (!event.eventbriteId) return;
 
   if (event.isCompletelySoldOut) {
-    return <Message text={`Fully booked`} />;
+    return <Message text="Fully booked" />;
   } else {
     return (
       <div
@@ -36,7 +36,7 @@ function getBookingEnquiryMarkup(event: Event) {
   if (!event.bookingEnquiryTeam) return;
 
   if (event.isCompletelySoldOut) {
-    return <Message text={`Fully booked`} />;
+    return <Message text="Fully booked" />;
   } else {
     return (
       <ButtonSolidLink

--- a/content/webapp/components/EventSchedule/EventScheduleItem.tsx
+++ b/content/webapp/components/EventSchedule/EventScheduleItem.tsx
@@ -124,7 +124,7 @@ const EventScheduleItem: FC<Props> = ({ event, isNotLinked }) => {
                 <p className={`${font('intr', 5)} no-margin`}>
                   <a href={`/events/${event.id}`}>
                     Full event details
-                    <span className={`visually-hidden`}>
+                    <span className="visually-hidden">
                       {' '}
                       about {event.title}
                     </span>

--- a/content/webapp/components/Exhibition/Exhibition.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.tsx
@@ -304,7 +304,7 @@ const Exhibition: FC<Props> = ({ exhibition, jsonLd, pages }) => {
         {(exhibitionOfs.length > 0 || pages.length > 0) && (
           <SearchResults
             items={[...exhibitionOfs, ...pages]}
-            title={`In this exhibition`}
+            title="In this exhibition"
           />
         )}
 
@@ -318,7 +318,7 @@ const Exhibition: FC<Props> = ({ exhibition, jsonLd, pages }) => {
         {exhibitionAbouts.length > 0 && (
           <SearchResults
             items={exhibitionAbouts}
-            title={`About this exhibition`}
+            title="About this exhibition"
           />
         )}
       </ContentPage>

--- a/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
+++ b/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
@@ -190,7 +190,7 @@ const Stop: FC<{ stop: Stop; isFirstStop: boolean }> = ({
               properties: ['margin-bottom'],
             }}
           >
-            <Divider color={`pumice`} isKeyline={true} />
+            <Divider color="pumice" isKeyline={true} />
           </Space>
           <div className="flex flex--wrap">
             <Tombstone />
@@ -266,7 +266,7 @@ const Stop: FC<{ stop: Stop; isFirstStop: boolean }> = ({
                         <PrismicImage
                           image={image}
                           sizes={{}}
-                          quality={`low`}
+                          quality="low"
                         />
                       </PrismicImageWrapper>
                     </Space>

--- a/content/webapp/components/ImageGallery/ImageGallery.tsx
+++ b/content/webapp/components/ImageGallery/ImageGallery.tsx
@@ -335,8 +335,8 @@ const ImageGallery: FunctionComponent<{ id: number } & Props> = ({
                     ariaExpanded={isActive}
                     ref={closeButtonRef}
                     replace={true}
-                    colorScheme={`light`}
-                    text={`close`}
+                    colorScheme="light"
+                    text="close"
                     icon={cross}
                     clickHandler={handleCloseClicked}
                   />

--- a/content/webapp/components/LayoutPaginatedResults/LayoutPaginatedResults.tsx
+++ b/content/webapp/components/LayoutPaginatedResults/LayoutPaginatedResults.tsx
@@ -86,7 +86,7 @@ const LayoutPaginatedResults: FC<Props> = ({
             ? paginatedResults.totalResults
             : null}
         </Space>
-        <Divider color={`pumice`} isKeyline={true} />
+        <Divider color="pumice" isKeyline={true} />
       </Layout12>
     )}
     {showFreeAdmissionMessage && (

--- a/content/webapp/components/MediaObjectBase/MediaObjectBase.tsx
+++ b/content/webapp/components/MediaObjectBase/MediaObjectBase.tsx
@@ -4,12 +4,7 @@ import {
   ReactElement,
   ReactNode,
 } from 'react';
-import {
-  grid,
-  font,
-  conditionalClassNames,
-  classNames,
-} from '@weco/common/utils/classnames';
+import { grid, font, classNames } from '@weco/common/utils/classnames';
 import DateRange from '@weco/common/views/components/DateRange/DateRange';
 import EventDateRange from '../EventDateRange/EventDateRange';
 import StatusIndicator from '@weco/common/views/components/StatusIndicator/StatusIndicator';
@@ -123,7 +118,7 @@ const MediaObjectBase: FunctionComponent<Props> = ({
         ].filter(Boolean) as VerticalSpaceProperty[],
       }}
       url={urlProp}
-      className={conditionalClassNames({
+      className={classNames({
         grid: true,
         'card-link': Boolean(url),
         [extraClasses || '']: Boolean(extraClasses),

--- a/content/webapp/components/NewsletterSignup/NewsletterSignup.tsx
+++ b/content/webapp/components/NewsletterSignup/NewsletterSignup.tsx
@@ -173,7 +173,7 @@ const NewsletterSignup: FC<Props> = ({
               big={true}
               value={emailValue}
               setValue={setEmailValue}
-              errorMessage={`Enter a valid email address.`}
+              errorMessage="Enter a valid email address."
               {...emailValidation}
             />
           </Space>
@@ -181,7 +181,7 @@ const NewsletterSignup: FC<Props> = ({
           <Space v={{ size: 'xl', properties: ['margin-bottom'] }}>
             <CheckboxRadio
               id="whats_on"
-              type={`checkbox`}
+              type="checkbox"
               text="I'd like to receive regular updates from Wellcome Collection"
               value="addressbook_40131"
               name="addressbook_40131"
@@ -209,7 +209,7 @@ const NewsletterSignup: FC<Props> = ({
                 >
                   <CheckboxRadio
                     id={addressBook.slug}
-                    type={`checkbox`}
+                    type="checkbox"
                     text={addressBook.label}
                     value={`address_${addressBook.id}`}
                     name={`address_${addressBook.id}`}

--- a/content/webapp/components/NewsletterSignup/NewsletterSignup.tsx
+++ b/content/webapp/components/NewsletterSignup/NewsletterSignup.tsx
@@ -231,7 +231,7 @@ const NewsletterSignup: FC<Props> = ({
             </div>
           )}
 
-          <p className={`${font('intr', 6)}`}>
+          <p className={font('intr', 6)}>
             We use a third-party provider,{' '}
             <a href="https://dotdigital.com/terms/privacy-policy/">
               dotdigital

--- a/content/webapp/components/Outro/Outro.tsx
+++ b/content/webapp/components/Outro/Outro.tsx
@@ -65,7 +65,7 @@ const Outro: FC<Props> = ({
 
   return (
     <div>
-      <Divider color={`black`} isStub={true} />
+      <Divider color="black" isStub={true} />
       <Space
         v={{
           size: 'm',

--- a/content/webapp/components/SimpleCardGrid/SimpleCardGrid.tsx
+++ b/content/webapp/components/SimpleCardGrid/SimpleCardGrid.tsx
@@ -23,7 +23,7 @@ const CardGridFeaturedCard = ({ item }: CardGridFeaturedCardProps) => {
   return (
     <Layout12>
       <FeaturedCard
-        id={`featured-card`}
+        id="featured-card"
         image={
           image && {
             ...image,

--- a/content/webapp/components/StoryPromo/StoryPromo.tsx
+++ b/content/webapp/components/StoryPromo/StoryPromo.tsx
@@ -103,10 +103,7 @@ const StoryPromo: FunctionComponent<Props> = ({
               properties: ['margin-bottom'],
             }}
             as="h2"
-            className={`
-            promo-link__title
-            ${font('wb', 3)}
-          `}
+            className={`promo-link__title ${font('wb', 3)}`}
           >
             {article.title}
           </Space>

--- a/content/webapp/components/VenueHours/VenueHours.tsx
+++ b/content/webapp/components/VenueHours/VenueHours.tsx
@@ -98,7 +98,7 @@ const VenueHours: FunctionComponent<Props> = ({ venue, weight }) => {
         <>
           <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
             <span className="is-hidden-s">
-              <Divider color={`pumice`} isKeyline={true} />
+              <Divider color="pumice" isKeyline={true} />
             </span>
           </Space>
           <VenueHoursImage v={{ size: 'm', properties: ['margin-bottom'] }}>

--- a/content/webapp/pages/event-series.tsx
+++ b/content/webapp/pages/event-series.tsx
@@ -154,7 +154,7 @@ const EventSeriesPage: FC<Props> = ({
         contributors={series.contributors}
       >
         {upcomingEvents.length > 0 ? (
-          <SearchResults items={upcomingEvents} title={`What's next`} />
+          <SearchResults items={upcomingEvents} title="What's next" />
         ) : (
           <h2 className="h2">
             No events scheduled at the moment, check back soon…
@@ -165,7 +165,7 @@ const EventSeriesPage: FC<Props> = ({
           <Space v={{ size: 'xl', properties: ['margin-top'] }}>
             <SearchResults
               items={pastEvents}
-              title={`What we've done before`}
+              title="What we've done before"
             />
           </Space>
         )}

--- a/content/webapp/pages/event.tsx
+++ b/content/webapp/pages/event.tsx
@@ -110,9 +110,10 @@ function DateList(event: Event) {
           return (
             <TimeWrapper key={index}>
               <div
-                className={`${
-                  isDayPast(eventTime.range.endDateTime) ? 'font-pewter' : ''
-                } flex-1`}
+                className={classNames({
+                  'font-pewer': isDayPast(eventTime.range.endDateTime),
+                  'flex-1': true,
+                })}
               >
                 <DateRange
                   start={eventTime.range.startDateTime}

--- a/content/webapp/pages/event.tsx
+++ b/content/webapp/pages/event.tsx
@@ -92,7 +92,7 @@ function EventStatus({ text, color }: EventStatusProps) {
         <Space
           as="span"
           h={{ size: 'xs', properties: ['margin-right'] }}
-          className={`flex flex--v-center`}
+          className="flex flex--v-center"
         >
           <Dot color={color} />
         </Space>
@@ -477,7 +477,7 @@ const EventPage: NextPage<Props> = ({ event, jsonLd }: Props) => {
         {event.audiences.map(audience => {
           if (audience.description) {
             return (
-              <div className={`body-text`} key={audience.title}>
+              <div className="body-text" key={audience.title}>
                 <h2>For {audience.title}</h2>
                 <PrismicHtmlBlock html={audience.description} />
               </div>

--- a/content/webapp/pages/event.tsx
+++ b/content/webapp/pages/event.tsx
@@ -363,7 +363,7 @@ const EventPage: NextPage<Props> = ({ event, jsonLd }: Props) => {
             {event.bookingEnquiryTeam && (
               <>
                 {event.isCompletelySoldOut ? (
-                  <Message text={`Fully booked`} />
+                  <Message text="Fully booked" />
                 ) : (
                   <ButtonSolidLink
                     link={`mailto:${event.bookingEnquiryTeam.email}?subject=${event.title}`}

--- a/content/webapp/pages/newsletter.tsx
+++ b/content/webapp/pages/newsletter.tsx
@@ -64,7 +64,7 @@ const Newsletter: FC<Props> = ({ result }) => {
             size: 'xl',
             properties: ['padding-bottom'],
           }}
-          className={`row`}
+          className="row"
         >
           <div className="container">
             <div className="grid">

--- a/content/webapp/pages/whats-on.tsx
+++ b/content/webapp/pages/whats-on.tsx
@@ -249,7 +249,7 @@ const Header = ({
                     )}
                   </div>
                 )}
-                <NextLink href={`/opening-times`} as={`/opening-times`}>
+                <NextLink href="/opening-times" as="/opening-times">
                   <a
                     className={classNames({
                       [font('intb', 5)]: true,

--- a/identity/webapp/copy.tsx
+++ b/identity/webapp/copy.tsx
@@ -86,7 +86,7 @@ export const ApplicationReceived: FC<{ email: string }> = ({ email }) => (
         .
       </p>
       <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
-        <Divider color={`pumice`} isKeyline />
+        <Divider color="pumice" isKeyline />
       </Space>
       <p>
         <strong>Didn’t receive an email?</strong>

--- a/identity/webapp/pages/index.tsx
+++ b/identity/webapp/pages/index.tsx
@@ -69,7 +69,7 @@ type DetailListProps = {
 const Detail: FC<DetailProps> = ({ label, value }) => (
   <>
     <dt className={font('intb', 5)}>{label}</dt>
-    <StyledDd className={`${font('intr', 5)}`}>{value}</StyledDd>
+    <StyledDd className={font('intr', 5)}>{value}</StyledDd>
   </>
 );
 
@@ -102,7 +102,7 @@ const TextButton: FC<ComponentPropsWithoutRef<'button'>> = ({
 );
 
 const RequestsFailed: FC<{ retry: () => void }> = ({ retry }) => (
-  <p className={`${font('intr', 5)}`}>
+  <p className={font('intr', 5)}>
     Something went wrong fetching your item requests.
     <TextButton
       onClick={() => {
@@ -311,7 +311,7 @@ const AccountPage: NextPage<Props> = ({ user: auth0UserClaims }) => {
                       return (
                         <Space
                           as="p"
-                          className={`${font('intr', 5)}`}
+                          className={font('intr', 5)}
                           v={{
                             size: 's',
                             properties: ['margin-bottom'],
@@ -326,7 +326,7 @@ const AccountPage: NextPage<Props> = ({ user: auth0UserClaims }) => {
                         <>
                           <Space
                             as="p"
-                            className={`${font('intb', 5)}`}
+                            className={font('intb', 5)}
                             v={{ size: 's', properties: ['margin-bottom'] }}
                           >{`You have requested ${requestedItems.totalResults} out of ${allowedRequests} items`}</Space>
                           <ProgressBar>
@@ -389,7 +389,7 @@ const AccountPage: NextPage<Props> = ({ user: auth0UserClaims }) => {
                             ]}
                           />
                           <Space
-                            className={`${font('intr', 5)}`}
+                            className={font('intr', 5)}
                             v={{
                               size: 'l',
                               properties: ['margin-top'],

--- a/identity/webapp/pages/index.tsx
+++ b/identity/webapp/pages/index.tsx
@@ -120,7 +120,7 @@ const AccountStatus: FC<ComponentProps<typeof StatusAlert>> = ({
 }) => {
   return (
     <StatusAlert type={type}>
-      <Icon icon={info2} color={`currentColor`} />
+      <Icon icon={info2} color="currentColor" />
       <Space
         h={{
           size: 's',
@@ -219,7 +219,7 @@ const AccountPage: NextPage<Props> = ({ user: auth0UserClaims }) => {
   };
 
   return (
-    <PageWrapper title={`Your library account`}>
+    <PageWrapper title="Your library account">
       <Header
         v={{
           size: 'l',

--- a/identity/webapp/pages/registration.tsx
+++ b/identity/webapp/pages/registration.tsx
@@ -103,7 +103,7 @@ const RegistrationPage: NextPage<Props> = ({
   };
 
   return (
-    <PageWrapper title={`Registration`}>
+    <PageWrapper title="Registration">
       <Layout10>
         <Space v={{ size: 'xl', properties: ['margin-top'] }}>
           <Container>

--- a/identity/webapp/src/frontend/MyAccount/DeleteAccount.tsx
+++ b/identity/webapp/src/frontend/MyAccount/DeleteAccount.tsx
@@ -130,7 +130,7 @@ export const DeleteAccount: React.FC<ChangeDetailsModalContentProps> = ({
             />
             <ButtonSolidLink
               colors={themeValues.buttonColors.greenTransparentGreen}
-              link={`/account`}
+              link="/account"
               clickHandler={onCancel}
               text="No, go back to my account"
             />

--- a/identity/webapp/src/frontend/Registration/AccountCreated.tsx
+++ b/identity/webapp/src/frontend/Registration/AccountCreated.tsx
@@ -10,7 +10,7 @@ import { info2 } from '@weco/common/icons';
 
 export const AccountCreated: React.FC = () => {
   return (
-    <PageWrapper title={`Account created`}>
+    <PageWrapper title="Account created">
       <Layout10>
         <Space v={{ size: 'xl', properties: ['margin-top'] }}>
           <Container>

--- a/identity/webapp/src/frontend/Registration/RegistrationInformation.tsx
+++ b/identity/webapp/src/frontend/Registration/RegistrationInformation.tsx
@@ -23,7 +23,7 @@ const RegistrationInformation: FC<Props> = ({ email }) => {
           properties: ['margin-top', 'margin-bottom'],
         }}
       >
-        <Divider color={`pumice`} isKeyline />
+        <Divider color="pumice" isKeyline />
       </Space>
     </>
   );


### PR DESCRIPTION
While looking at #8419, I noticed that there are a few places where we have unnecessary interpolation in classNames, e.g.

```typescript
<div className={`row`}>
```

could just be

```typescript
<div className="row">
```

I wrote a script to find all the instances and automagically fix them.

<details><summary>replace_interpolations.py</summary>

```python
#!/usr/bin/env python3

import os
import re

def get_file_paths_under(root=".", *, suffix=""):
    """Generates the paths to every file under ``root``."""
    if not os.path.isdir(root):
        raise ValueError(f"Cannot find files under non-existent directory: {root!r}")

    for dirpath, _, filenames in os.walk(root):
        for f in filenames:
            if os.path.isfile(os.path.join(dirpath, f)) and f.lower().endswith(suffix):
                yield os.path.join(dirpath, f)

for path in get_file_paths_under(suffix=(".ts", ".tsx")):
    if "/node_modules/" in path:
        continue

    if "/cache/" in path:
        continue

    old_contents = open(path).read()

    if 'className=' not in old_contents:
        continue

    new_contents = re.sub('([a-zA-Z]+)={`([a-z0-9\- ]+)`}', r'\1="\2"', old_contents)

    if old_contents == new_contents:
        continue

    with open(path, "w") as outfile:
        outfile.write(new_contents)

    print(path)
    # break
```

</details>