### PR TITLE
Remove uses of classNames that can be plain strings 

### DIFF
--- a/cardigan/stories/components/PageHeader/PageHeader.stories.tsx
+++ b/cardigan/stories/components/PageHeader/PageHeader.stories.tsx
@@ -1,6 +1,6 @@
 import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
 import PageHeaderStandfirst from '@weco/content/components/PageHeaderStandfirst/PageHeaderStandfirst';
-import { classNames, font } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import Picture from '@weco/common/views/components/Picture/Picture';
 import Space from '@weco/common/views/components/styled/Space';
 import Dot from '@weco/common/views/components/Dot/Dot';
@@ -27,33 +27,15 @@ const ContentTypeInfo = (
         },
       ]}
     />
-    <div
-      className={classNames({
-        flex: true,
-        'flex--h-baseline': true,
-      })}
-    >
+    <div className="flex flex--h-baseline">
       <Space
         h={{ size: 's', properties: ['margin-right', 'margin-top'] }}
-        className={classNames({
-          [font('intr', 6)]: true,
-        })}
+        className={font('intr', 6)}
       >
         <p className="no-margin">
           <span>By </span>
-          <span
-            className={classNames({
-              [font('intb', 6)]: true,
-            })}
-          >
-            Naomi Paxton
-          </span>{' '}
-          <span
-            className={classNames({
-              [font('intr', 6)]: true,
-              'font-pewter': true,
-            })}
-          >
+          <span className={font('intb', 6)}>Naomi Paxton</span>{' '}
+          <span className={`${font('intr', 6)} font-pewter`}>
             17 April 2019
           </span>
         </p>
@@ -146,9 +128,7 @@ const EventContentTypeInfo = () => (
         size: 's',
         properties: ['margin-bottom'],
       }}
-      className={classNames({
-        'flex flex--wrap': true,
-      })}
+      className="flex flex--wrap"
     >
       Saturday 8 February 2020, 13:00 – 16:00
     </Space>
@@ -183,12 +163,7 @@ const ExhibitionContentTypeInfo = () => (
 );
 
 const BookContentTypeInfo = () => (
-  <p
-    className={classNames({
-      'no-margin': true,
-      [font('intb', 3)]: true,
-    })}
-  >
+  <p className={`no-margin ${font('intb', 3)}`}>
     Loneliness, Health & What Happens When We Find Connection
   </p>
 );

--- a/cardigan/stories/global/icons/icons.stories.tsx
+++ b/cardigan/stories/global/icons/icons.stories.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent } from 'react';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import * as icons from '@weco/common/icons';
-import { font, classNames } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import styled from 'styled-components';
 
 const IconWrapper = styled.div`
@@ -16,9 +16,7 @@ const IconWrapper = styled.div`
 `;
 
 const IconId = styled.p.attrs({
-  className: classNames({
-    [font('lr', 5)]: true,
-  }),
+  className: font('lr', 5),
 })`
   hyphens: auto;
 `;

--- a/cardigan/stories/global/palette/palette.stories.tsx
+++ b/cardigan/stories/global/palette/palette.stories.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent } from 'react';
 import { themeValues } from '@weco/common/views/themes/config';
 import styled from 'styled-components';
-import { classNames, font } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 
 const PaletteSection = styled.div`
   display: flex;
@@ -14,9 +14,7 @@ const PaletteBlock = styled.div`
 `;
 
 const PaletteName = styled.h2.attrs({
-  classname: classNames({
-    [font('lr', 5)]: true,
-  }),
+  classname: font('lr', 5),
 })``;
 
 const PaletteColor = styled.div<{ hasBorder: boolean }>`
@@ -34,15 +32,11 @@ const PaletteColor = styled.div<{ hasBorder: boolean }>`
 `;
 
 const PaletteHex = styled.div.attrs({
-  className: classNames({
-    [font('lr', 5)]: true,
-  }),
+  className: font('lr', 5),
 })``;
 
 const PaletteCode = styled.code.attrs({
-  className: classNames({
-    [font('lr', 5)]: true,
-  }),
+  className: font('lr', 5),
 })``;
 
 function hexToRgb(hex) {

--- a/cardigan/stories/global/typography/typography.stories.tsx
+++ b/cardigan/stories/global/typography/typography.stories.tsx
@@ -1,7 +1,7 @@
 import Table from '@weco/common/views/components/Table/Table';
 import { fontSizesAtBreakpoints } from '@weco/common/views/themes/typography';
 import styled from 'styled-components';
-import { classNames, font } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import MoreLink from '@weco/common/views/components/MoreLink/MoreLink';
 
 const Font = styled.div`
@@ -10,9 +10,7 @@ const Font = styled.div`
 `;
 
 const FontName = styled.h2.attrs({
-  className: classNames({
-    [font('intb', 6)]: true,
-  }),
+  className: font('intb', 6),
 })`
   color: ${props => props.theme.color('red')};
 `;

--- a/catalogue/webapp/components/ArchiveTree/ArchiveTree.tsx
+++ b/catalogue/webapp/components/ArchiveTree/ArchiveTree.tsx
@@ -193,9 +193,7 @@ const StyledLink = styled.a<StyledLinkProps>`
 `;
 
 const RefNumber = styled.span.attrs({
-  className: classNames({
-    [font('intr', 6)]: true,
-  }),
+  className: font('intr', 6),
 })`
   line-height: 1;
   display: block;
@@ -734,9 +732,7 @@ const NestedList: FunctionComponent<NestedListProps> = ({
       }
       tabIndex={level === 1 && isEnhanced ? 0 : undefined}
       role={isEnhanced ? (level === 1 ? 'tree' : 'group') : undefined}
-      className={classNames({
-        'font-size-5': true,
-      })}
+      className="font-size-5"
     >
       {archiveTree &&
         archiveTree.map((item, i) => {
@@ -903,13 +899,7 @@ const ArchiveTree: FunctionComponent<{ work: Work }> = ({
           <Space
             v={{ size: 'l', properties: ['padding-top', 'padding-bottom'] }}
           >
-            <h2
-              className={classNames({
-                [font('wb', 4)]: true,
-              })}
-            >
-              Collection contents
-            </h2>
+            <h2 className={font('wb', 4)}>Collection contents</h2>
             <Tree isEnhanced={isEnhanced}>
               {isEnhanced && (
                 <TreeInstructions>{instructions}</TreeInstructions>

--- a/catalogue/webapp/components/AudioList/AudioList.tsx
+++ b/catalogue/webapp/components/AudioList/AudioList.tsx
@@ -1,5 +1,4 @@
 import { FC } from 'react';
-import { classNames } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 import AudioPlayer from '@weco/common/views/components/AudioPlayer/AudioPlayer';
 import DownloadLink from '../DownloadLink/DownloadLink';
@@ -31,11 +30,7 @@ const AudioList: FC<Props> = ({
           <img src={thumbnail.id} alt="" />
         </Space>
       )} */}
-      <ol
-        className={classNames({
-          'no-margin no-padding plain-list': true,
-        })}
-      >
+      <ol className="no-margin no-padding plain-list">
         {items.map((item, index) => (
           <>
             {item.sound.id && (

--- a/catalogue/webapp/components/Calendar/Calendar.tsx
+++ b/catalogue/webapp/components/Calendar/Calendar.tsx
@@ -1,7 +1,7 @@
 import { FC, useState, useEffect, useRef, useContext } from 'react';
 import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
 import { DayNumber } from '@weco/common/model/opening-hours';
-import { classNames, font } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import {
   getCalendarRows,
   firstDayOfWeek,
@@ -309,9 +309,7 @@ const Calendar: FC<Props> = ({
       </Header>
       {isKeyboard && <Message>{calendarInstructions}</Message>}
       <Table
-        className={classNames({
-          [font('intb', 6)]: true,
-        })}
+        className={font('intb', 6)}
         role="grid"
         aria-labelledby="id-grid-label"
         onKeyDown={event => {

--- a/catalogue/webapp/components/Calendar/CalendarStyles.tsx
+++ b/catalogue/webapp/components/Calendar/CalendarStyles.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { classNames, font } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 
 export const DatePicker = styled.div`
   padding: 1em;
@@ -26,9 +26,7 @@ export const Header = styled.div`
 `;
 
 export const Message = styled.p.attrs(() => ({
-  className: classNames({
-    [font('intr', 6)]: true,
-  }),
+  className: font('intr', 6),
 }))`
   background: ${props => props.theme.color('yellow')};
   padding: ${props => `${props.theme.spacingUnit * 2}px`};

--- a/catalogue/webapp/components/Download/Download.tsx
+++ b/catalogue/webapp/components/Download/Download.tsx
@@ -13,9 +13,7 @@ import { NextPage } from 'next';
 import { DownloadFormat } from '../DownloadLink/DownloadLink';
 
 export const DownloadOptions = styled.div.attrs(() => ({
-  className: classNames({
-    [font('intb', 4)]: true,
-  }),
+  className: font('intb', 4),
 }))`
   white-space: normal;
   color: ${props => props.theme.color('black')};
@@ -116,11 +114,7 @@ const Download: NextPage<Props> = ({
             isOnDark={useDarkControl}
             id={ariaControlsId}
           >
-            <DownloadOptions
-              className={classNames({
-                [font('intb', 5)]: true,
-              })}
-            >
+            <DownloadOptions className={font('intb', 5)}>
               <SpacingComponent>
                 <ul className="plain-list no-margin no-padding">
                   {downloadOptions

--- a/catalogue/webapp/components/DownloadLink/DownloadLink.tsx
+++ b/catalogue/webapp/components/DownloadLink/DownloadLink.tsx
@@ -1,6 +1,6 @@
 import { trackEvent as trackGaEvent, GaEvent } from '@weco/common/utils/ga';
 import styled from 'styled-components';
-import { font, classNames } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import Space from '@weco/common/views/components/styled/Space';
 import { FunctionComponent } from 'react';
@@ -8,9 +8,7 @@ import { trackEvent } from '@weco/common/services/conversion/track';
 import { download } from '@weco/common/icons';
 
 const DownloadLinkStyle = styled.a.attrs({
-  className: classNames({
-    [font('intb', 5)]: true,
-  }),
+  className: font('intb', 5),
 })`
   display: inline-block;
   white-space: nowrap;
@@ -60,10 +58,7 @@ const DownloadLink: FunctionComponent<Props> = ({
         <Space
           as="span"
           h={{ size: 'm', properties: ['margin-left'] }}
-          className={classNames({
-            [font('intb', 5)]: true,
-            'font-pewter': true,
-          })}
+          className={`${font('intb', 5)} font-pewter`}
         >
           {format}
         </Space>

--- a/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
+++ b/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
@@ -4,7 +4,7 @@ import {
   getServiceId,
 } from '../../utils/iiif';
 import NextLink from 'next/link';
-import { font, classNames } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import {
   getDigitalLocationOfType,
   sierraIdFromPresentationManifestUrl,
@@ -202,17 +202,14 @@ const ExpandedImage: FunctionComponent<Props> = ({
       <InfoWrapper>
         <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
           <h2
-            className={classNames({
-              [font('intb', 3)]: true,
-              'no-margin': true,
-            })}
+            className={`${font('intb', 3)} no-margin`}
             dangerouslySetInnerHTML={{ __html: displayTitle }}
           />
           {displayContributor && (
             <Space
               as="h3"
               v={{ size: 's', properties: ['margin-top'] }}
-              className={classNames({ [font('intb', 5)]: true })}
+              className={font('intb', 5)}
             >
               {displayContributor}
             </Space>
@@ -247,12 +244,7 @@ const ExpandedImage: FunctionComponent<Props> = ({
               source={trackingSource}
               resultPosition={resultPosition}
             >
-              <a
-                className={classNames({
-                  'inline-block': true,
-                  [font('intr', 5)]: true,
-                })}
-              >
+              <a className={`inline-block ${font('intr', 5)}`}>
                 More about this work
               </a>
             </WorkLink>

--- a/catalogue/webapp/components/IIIFSearchWithin/IIIFSearchWithin.tsx
+++ b/catalogue/webapp/components/IIIFSearchWithin/IIIFSearchWithin.tsx
@@ -8,7 +8,7 @@ import {
 import { getSearchService } from '../../utils/iiif';
 import TextInput from '@weco/common/views/components/TextInput/TextInput';
 import styled from 'styled-components';
-import { classNames, font } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import ButtonSolid from '@weco/common/views/components/ButtonSolid/ButtonSolid';
 import ItemViewerContext from '../ItemViewerContext/ItemViewerContext';
 import { FixedSizeList } from 'react-window';
@@ -32,9 +32,7 @@ const SearchInputWrapper = styled.div`
 `;
 
 const SearchButtonWrapper = styled.div.attrs({
-  className: classNames({
-    absolute: true,
-  }),
+  className: 'absolute',
 })`
   top: 50%;
   transform: translateY(-50%);
@@ -55,10 +53,7 @@ const ListItem = styled.li`
 `;
 
 const SearchResult = styled.button.attrs({
-  className: classNames({
-    [font('intr', 6)]: true,
-    'plain-button': true,
-  }),
+  className: `${font('intr', 6)} plain-button`,
 })`
   cursor: pointer;
   display: block;
@@ -72,9 +67,7 @@ const SearchResult = styled.button.attrs({
 
 const HitData = styled(Space).attrs({
   as: 'span',
-  className: classNames({
-    [font('intb', 6)]: true,
-  }),
+  className: font('intb', 6),
 })`
   display: block;
   background: ${props => props.theme.color('charcoal')};

--- a/catalogue/webapp/components/IIIFViewer/IIIFViewerImage.tsx
+++ b/catalogue/webapp/components/IIIFViewer/IIIFViewerImage.tsx
@@ -1,4 +1,3 @@
-import { classNames } from '@weco/common/utils/classnames';
 import { forwardRef } from 'react';
 import styled from 'styled-components';
 
@@ -49,9 +48,7 @@ const IIIFViewerImage = (
       lang={lang}
       width={width}
       height={height}
-      className={classNames({
-        image: true,
-      })}
+      className="image"
       onLoad={() => {
         loadHandler && loadHandler();
       }}

--- a/catalogue/webapp/components/IIIFViewer/NoScriptViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/NoScriptViewer.tsx
@@ -1,6 +1,5 @@
 import NextLink from 'next/link';
 import styled from 'styled-components';
-import { classNames } from '@weco/common/utils/classnames';
 import { getServiceId } from '../../utils/iiif';
 import IIIFViewerImage from './IIIFViewerImage';
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
@@ -87,11 +86,7 @@ export const PaginatorButtons = (
     nextLink,
   }: PaginatorRenderFunctionProps) => {
     return (
-      <div
-        className={classNames({
-          'flex flex--column flex--v-center flex--h-center': true,
-        })}
-      >
+      <div className="flex flex--column flex--v-center flex--h-center">
         {prevLink && (
           <Space v={{ size: 's', properties: ['margin-bottom'] }}>
             <Rotator rotate={270}>

--- a/catalogue/webapp/components/IIIFViewer/ViewerSidebar.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerSidebar.tsx
@@ -44,9 +44,7 @@ const Inner = styled(Space).attrs({
 
 const AccordionInner = styled(Space).attrs({
   v: { size: 's', properties: ['padding-top', 'padding-bottom'] },
-  className: classNames({
-    [font('intb', 5)]: true,
-  }),
+  className: font('intb', 5),
 })`
   button {
     width: 100%;
@@ -95,21 +93,12 @@ const AccordionItem = ({
     <Item data-test-id={testId}>
       <AccordionInner onClick={() => setIsActive(!isActive)}>
         <button
-          className={classNames({
-            'plain-button no-margin no-padding': true,
-          })}
+          className="plain-button no-margin no-padding"
           aria-expanded={isActive ? 'true' : 'false'}
           aria-controls={toHtmlId(title)}
         >
           <span>
-            <h2
-              className={classNames({
-                [font('intb', 5)]: true,
-                'no-margin': true,
-              })}
-            >
-              {title}
-            </h2>
+            <h2 className={`${font('intb', 5)} no-margin`}>{title}</h2>
             <Icon
               icon={chevron}
               color={'white'}
@@ -155,18 +144,9 @@ const ViewerSidebar: FunctionComponent<Props> = ({ mainViewerRef }: Props) => {
 
   return (
     <>
-      <Inner
-        className={classNames({
-          [font('intb', 5)]: true,
-        })}
-      >
+      <Inner className={font('intb', 5)}>
         {currentManifestLabel && (
-          <span
-            data-test-id="current-manifest"
-            className={classNames({
-              [font('intr', 5)]: true,
-            })}
-          >
+          <span data-test-id="current-manifest" className={font('intr', 5)}>
             {currentManifestLabel}
           </span>
         )}
@@ -219,12 +199,7 @@ const ViewerSidebar: FunctionComponent<Props> = ({ mainViewerRef }: Props) => {
 
         <Space v={{ size: 'm', properties: ['margin-top'] }}>
           <WorkLink id={work.id} source="viewer_back_link">
-            <a
-              className={classNames({
-                [font('intr', 5)]: true,
-                'flex flex--v-center': true,
-              })}
-            >
+            <a className={`${font('intr', 5)} flex flex--v-center`}>
               Catalogue details
               <Space
                 h={{ size: 's', properties: ['margin-left'] }}

--- a/catalogue/webapp/components/IIIFViewer/ViewerStructures.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerStructures.tsx
@@ -2,7 +2,7 @@ import { getStructures, groupStructures, getCanvases } from '../../utils/iiif';
 import { useContext, FunctionComponent, RefObject } from 'react';
 import { FixedSizeList } from 'react-window';
 import ItemViewerContext from '../ItemViewerContext/ItemViewerContext';
-import { classNames, font } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 import styled from 'styled-components';
 
@@ -19,9 +19,7 @@ const ViewerStructuresPrototype: FunctionComponent<Props> = ({
   const groupedStructures = groupStructures(canvases, structures);
 
   const List = styled.ul.attrs({
-    className: classNames({
-      'plain-list no-margin no-padding': true,
-    }),
+    className: 'plain-list no-margin no-padding',
   })`
     border-left: 1px solid ${props => props.theme.color('pewter')};
   `;
@@ -30,9 +28,7 @@ const ViewerStructuresPrototype: FunctionComponent<Props> = ({
     as: 'li',
     v: { size: 'xs', properties: ['padding-top', 'padding-bottom'] },
     h: { size: 'm', properties: ['padding-left', 'padding-right'] },
-    className: classNames({
-      [font('intr', 5)]: true,
-    }),
+    className: font('intr', 5),
   })<{ isActive: boolean }>`
     position: relative;
 

--- a/catalogue/webapp/components/IIIFViewer/ViewerTopBar.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerTopBar.tsx
@@ -177,9 +177,7 @@ const LeftZone = styled.div`
 `;
 
 const MiddleZone = styled.div.attrs({
-  className: classNames({
-    [font('intb', 5)]: true,
-  }),
+  className: font('intb', 5),
 })`
   display: flex;
   justify-content: center;

--- a/catalogue/webapp/components/ItemRequestModal/RequestDialog.tsx
+++ b/catalogue/webapp/components/ItemRequestModal/RequestDialog.tsx
@@ -3,7 +3,7 @@ import { useAvailableDates } from './useAvailableDates';
 import { isRequestableDate } from '../../utils/dates';
 import { trackEvent } from '@weco/common/utils/ga';
 import { allowedRequests } from '@weco/common/values/requests';
-import { classNames, font } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 import RequestingDayPicker from '../RequestingDayPicker/RequestingDayPicker';
 import ButtonSolid, {
@@ -107,12 +107,7 @@ const RequestDialog: FC<RequestDialogProps> = ({
           currentHoldRequests={currentHoldNumber}
         />
       </Header>
-      <p
-        className={classNames({
-          [font('intb', 5)]: true,
-          'no-margin': true,
-        })}
-      >
+      <p className={`${font('intb', 5)} no-margin`}>
         You are about to request the following item:
       </p>
       <Space v={{ size: 's', properties: ['margin-bottom'] }}>
@@ -130,12 +125,7 @@ const RequestDialog: FC<RequestDialogProps> = ({
                 Select the date you would like to view this item in the library.
               </p>
             </Space>
-            <p
-              className={classNames({
-                [font('intr', 6)]: true,
-                'no-margin-l': true,
-              })}
-            >
+            <p className={`${font('intr', 6)} no-margin-l`}>
               Item requests need to be placed by 10am on the working day before
               your visit. Please bear in mind the library is closed on Sundays.
             </p>

--- a/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
+++ b/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
@@ -7,7 +7,7 @@ import {
 } from 'react';
 import styled from 'styled-components';
 import Space from '@weco/common/views/components/styled/Space';
-import { classNames, font } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import IsArchiveContext from '../IsArchiveContext/IsArchiveContext';
 import { PhysicalItem, Work } from '@weco/common/model/catalogue';
 import {
@@ -58,10 +58,7 @@ const ButtonWrapper = styled.div<ButtonWrapperProps>`
 `;
 
 const DetailHeading = styled.h3.attrs({
-  className: classNames({
-    [font('intb', 5, { small: 3, medium: 3 })]: true,
-    'no-margin': true,
-  }),
+  className: `${font('intb', 5, { small: 3, medium: 3 })} no-margin`,
 })``;
 
 export type Props = {

--- a/catalogue/webapp/components/SearchNoResults/SearchNoResults.tsx
+++ b/catalogue/webapp/components/SearchNoResults/SearchNoResults.tsx
@@ -1,5 +1,5 @@
 import Space from '@weco/common/views/components/styled/Space';
-import { font, grid, classNames } from '@weco/common/utils/classnames';
+import { font, grid } from '@weco/common/utils/classnames';
 import styled from 'styled-components';
 import { FunctionComponent } from 'react';
 
@@ -9,9 +9,7 @@ type Props = {
 };
 
 const QuerySpan = styled.span.attrs({
-  className: classNames({
-    [font('intb', 2)]: true,
-  }),
+  className: font('intb', 2),
 })``;
 
 const SearchNoResults: FunctionComponent<Props> = ({

--- a/catalogue/webapp/components/SearchTitle/SearchTitle.tsx
+++ b/catalogue/webapp/components/SearchTitle/SearchTitle.tsx
@@ -22,9 +22,7 @@ const SearchTitle: FunctionComponent<Props> = ({
             size: 'm',
             properties: ['margin-bottom'],
           }}
-          className={classNames([
-            'flex flex--h-space-between flex--v-center flex--wrap',
-          ])}
+          className="flex flex--h-space-between flex--v-center flex--wrap"
         >
           <Space
             as="h1"

--- a/catalogue/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.tsx
+++ b/catalogue/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.tsx
@@ -1,4 +1,4 @@
-import { font, classNames } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import { Image as ImageType } from '@weco/common/model/catalogue';
 import { FunctionComponent, useEffect, useState } from 'react';
 import styled from 'styled-components';
@@ -66,12 +66,7 @@ const VisuallySimilarImagesFromApi: FunctionComponent<Props> = ({
           </a>
         ))}
       </Wrapper>
-      <p
-        className={classNames({
-          [font('intr', 6)]: true,
-          'no-margin': true,
-        })}
-      >
+      <p className={`${font('intr', 6)} no-margin`}>
         These images have similar shapes and structural features. We use machine
         learning to detect visual similarity across all images in our
         collection.

--- a/catalogue/webapp/components/Work/Work.tsx
+++ b/catalogue/webapp/components/Work/Work.tsx
@@ -1,6 +1,6 @@
 import { Work as WorkType } from '@weco/common/model/catalogue';
 import { useContext, useEffect, FunctionComponent, ReactElement } from 'react';
-import { grid, classNames } from '@weco/common/utils/classnames';
+import { grid } from '@weco/common/utils/classnames';
 import { getDigitalLocationOfType } from '../../utils/works';
 import { removeIdiomaticTextTags } from '@weco/common/utils/string';
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
@@ -90,11 +90,7 @@ const Work: FunctionComponent<Props> = ({
       >
         <div className="container">
           <div className="grid">
-            <div
-              className={classNames({
-                [grid({ s: 12, m: 12, l: 12, xl: 12 })]: true,
-              })}
-            >
+            <div className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>
               <Space v={{ size: 'l', properties: ['margin-top'] }}>
                 <SearchTabs
                   query={searchLink.as.query?.query?.toString() || ''}
@@ -115,9 +111,7 @@ const Work: FunctionComponent<Props> = ({
                 size: 's',
                 properties: ['padding-top', 'padding-bottom'],
               }}
-              className={classNames({
-                [grid({ s: 12 })]: true,
-              })}
+              className={grid({ s: 12 })}
             >
               <BackToResults />
             </Space>
@@ -133,9 +127,7 @@ const Work: FunctionComponent<Props> = ({
                     size: 's',
                     properties: ['padding-top', 'padding-bottom'],
                   }}
-                  className={classNames({
-                    [grid({ s: 12 })]: true,
-                  })}
+                  className={grid({ s: 12 })}
                 >
                   <ArchiveBreadcrumb work={work} />
                 </Space>

--- a/catalogue/webapp/components/WorkDetails/ExplanatoryText.tsx
+++ b/catalogue/webapp/components/WorkDetails/ExplanatoryText.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react';
 import styled from 'styled-components';
 import { plus } from '@weco/common/icons';
-import { classNames, font } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import Space from '@weco/common/views/components/styled/Space';
 
@@ -33,12 +33,7 @@ type ControlProps = {
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
 const Control = styled.button.attrs(props => ({
-  className: classNames({
-    'plain-button': true,
-    flex: true,
-    'flex--v-center': true,
-    [font('intb', 5)]: true,
-  }),
+  className: `plain-button flex flex--v-center ${font('intb', 5)}`,
 }))<ControlProps>`
   cursor: pointer;
   padding: 0;

--- a/catalogue/webapp/components/WorkDetails/OnlineResources.tsx
+++ b/catalogue/webapp/components/WorkDetails/OnlineResources.tsx
@@ -1,15 +1,12 @@
 import { useEffect, useState, useRef, FunctionComponent } from 'react';
-import { font, classNames } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import { getItemsByLocationType } from '../../utils/works';
 import WorkDetailsSection from '../WorkDetailsSection/WorkDetailsSection';
 import { DigitalLocation, Work } from '@weco/common/model/catalogue';
 import styled from 'styled-components';
 
 const ShowHideButton = styled.button.attrs({
-  className: classNames({
-    'plain-button no-margin no-padding': true,
-    [font('intr', 5)]: true,
-  }),
+  className: `plain-button no-margin no-padding ${font('intr', 5)}`,
 })`
   text-decoration: underline;
 
@@ -54,18 +51,9 @@ const OnlineResources: FunctionComponent<Props> = ({ work }: Props) => {
 
   return onlineResources.length > 0 ? (
     <WorkDetailsSection headingText="Online resources">
-      <ul
-        className={classNames({
-          'plain-list no-margin no-padding': true,
-        })}
-      >
+      <ul className="plain-list no-margin no-padding">
         {firstThreeOnlineResources.map(item => (
-          <li
-            className={classNames({
-              [font('intr', 5)]: true,
-            })}
-            key={item.location.url}
-          >
+          <li className={font('intr', 5)} key={item.location.url}>
             {item.title && `${item.title}: `}
             <a href={item.location.url}>
               {item.title ? `View resource` : item.location.linkText}
@@ -75,12 +63,7 @@ const OnlineResources: FunctionComponent<Props> = ({ work }: Props) => {
         {isShowingRemainingOnlineResources && (
           <>
             {remainingOnlineResources.map((item, index) => (
-              <li
-                className={classNames({
-                  [font('intr', 5)]: true,
-                })}
-                key={item.location.url}
-              >
+              <li className={font('intr', 5)} key={item.location.url}>
                 {item.title && `${item.title}: `}
                 <a
                   href={item.location.url}

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -1,6 +1,6 @@
 import NextLink from 'next/link';
 import { FunctionComponent, useContext, useState } from 'react';
-import { classNames, font } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import { downloadUrl } from '../../services/catalogue/urls';
 import { toLink as worksLink } from '@weco/common/views/components/WorksLink/WorksLink';
 import { toLink as imagesLink } from '@weco/common/views/components/ImagesLink/ImagesLink';
@@ -288,12 +288,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
                     v={{ size: 's', properties: ['margin-bottom'] }}
                   >
                     {locationLink && (
-                      <a
-                        className={classNames({
-                          [font('intr', 5)]: true,
-                        })}
-                        href={locationLink.url}
-                      >
+                      <a className={font('intr', 5)} href={locationLink.url}>
                         {locationLink.linkText}
                       </a>
                     )}
@@ -424,11 +419,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
                   </Space>
                 )}
 
-                <div
-                  className={classNames({
-                    'flex flex-h-center': true,
-                  })}
-                >
+                <div className="flex flex-h-center">
                   {itemUrl && (
                     <Space
                       as="span"
@@ -477,12 +468,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
                       properties: ['margin-top'],
                     }}
                   >
-                    <p
-                      className={classNames({
-                        'no-margin': true,
-                        [font('lr', 6)]: true,
-                      })}
-                    >
+                    <p className={`no-margin ${font('lr', 6)}`}>
                       Contains:{' '}
                       {childManifestsCount > 0
                         ? `${childManifestsCount} ${

--- a/catalogue/webapp/components/WorkDetailsList/WorkDetailsList.tsx
+++ b/catalogue/webapp/components/WorkDetailsList/WorkDetailsList.tsx
@@ -1,5 +1,4 @@
 import Space from '@weco/common/views/components/styled/Space';
-import { classNames } from '@weco/common/utils/classnames';
 import WorkDetailsProperty from '../WorkDetailsProperty/WorkDetailsProperty';
 import { FunctionComponent } from 'react';
 
@@ -14,9 +13,7 @@ const WorkDetailsList: FunctionComponent<Props> = ({ title, list }: Props) => {
           properties: ['margin-bottom'],
         }}
         as="ul"
-        className={classNames({
-          'plain-list no-margin no-padding': true,
-        })}
+        className="plain-list no-margin no-padding"
       >
         {list.map((item, i) => (
           <li key={i} style={{ listStylePosition: 'inside' }}>

--- a/catalogue/webapp/components/WorkDetailsSection/WorkDetailsSection.tsx
+++ b/catalogue/webapp/components/WorkDetailsSection/WorkDetailsSection.tsx
@@ -40,12 +40,7 @@ const WorkDetailsSection: FunctionComponent<Props> = ({
             })}
           >
             {headingText && (
-              <h2
-                className={classNames({
-                  [font('wb', 4)]: true,
-                  'work-details-heading': true,
-                })}
-              >
+              <h2 className={`${font('wb', 4)} work-details-heading`}>
                 {headingText}
               </h2>
             )}

--- a/catalogue/webapp/components/WorkHeader/WorkHeader.tsx
+++ b/catalogue/webapp/components/WorkHeader/WorkHeader.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent, ReactElement } from 'react';
 import { Work } from '@weco/common/model/catalogue';
-import { font, classNames, grid } from '@weco/common/utils/classnames';
+import { font, grid } from '@weco/common/utils/classnames';
 import {
   getProductionDates,
   getArchiveLabels,
@@ -16,9 +16,7 @@ import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
 import useIIIFManifestData from '../../hooks/useIIIFManifestData';
 
 const WorkHeaderContainer = styled.div.attrs({
-  className: classNames({
-    flex: true,
-  }),
+  className: 'flex',
 })`
   width: 100%;
   align-content: flex-start;
@@ -47,17 +45,13 @@ const WorkHeader: FunctionComponent<Props> = ({
           size: 'm',
           properties: ['margin-bottom'],
         }}
-        className={classNames([grid({ s: 12, m: 12, l: 10, xl: 10 })])}
+        className={grid({ s: 12, m: 12, l: 10, xl: 10 })}
       >
         <SpacingComponent>
           <h1
             aria-live="polite"
             id="work-info"
-            className={classNames({
-              'no-margin': true,
-              [font('intb', 2)]: true,
-              'inline-block': true,
-            })}
+            className={`no-margin ${font('intb', 2)} inline-block`}
             // We only send a lang if it's unambiguous -- better to send
             // no language than the wrong one.
             lang={
@@ -117,12 +111,7 @@ const WorkHeader: FunctionComponent<Props> = ({
 
           {childManifestsCount > 0 && (
             <Space v={{ size: 'm', properties: ['margin-top'] }}>
-              <p
-                className={classNames({
-                  [font('intb', 5)]: true,
-                  'no-margin': true,
-                })}
-              >
+              <p className={`${font('intb', 5)} no-margin`}>
                 <Number color="yellow" number={childManifestsCount} />
                 {childManifestsCount === 1 ? ' volume ' : ' volumes '}
                 online

--- a/catalogue/webapp/components/WorksSearchResult/WorksSearchResult.tsx
+++ b/catalogue/webapp/components/WorksSearchResult/WorksSearchResult.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 import { Work } from '@weco/common/model/catalogue';
-import { classNames, font } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import LinkLabels from '@weco/common/views/components/LinkLabels/LinkLabels';
 import {
   getArchiveLabels,
@@ -40,9 +40,7 @@ const Details = styled.div`
 `;
 const Preview = styled(Space).attrs<SpaceComponentProps>(() => ({
   h: { size: 'm', properties: ['padding-left'] },
-  className: classNames({
-    'text-align-center': true,
-  }),
+  className: 'text-align-center',
 }))`
   flex-grow: 0;
   flex-shrink: 0;
@@ -97,11 +95,7 @@ const WorkSearchResult: FunctionComponent<Props> = ({
             size: 'm',
             properties: ['padding-top', 'padding-bottom'],
           }}
-          className={classNames({
-            'plain-link': true,
-            block: true,
-            'card-link': true,
-          })}
+          className="plain-link block card-link"
           onClick={() => {
             // We've left `WorkCard` here for legacy tracking.
             // We don't really use it.
@@ -114,12 +108,7 @@ const WorkSearchResult: FunctionComponent<Props> = ({
         >
           <Container>
             <Details>
-              <h2
-                className={classNames({
-                  [font('intb', 4)]: true,
-                  'card-link__title': true,
-                })}
-              >
+              <h2 className={`${font('intb', 4)} card-link__title`}>
                 <WorkTitle title={work.title} />
               </h2>
 

--- a/catalogue/webapp/components/WorksSearchResult/WorksSearchResultV2.tsx
+++ b/catalogue/webapp/components/WorksSearchResult/WorksSearchResultV2.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { Work } from '@weco/common/model/catalogue';
 
 // Helpers/Utils
-import { classNames, font } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import {
   getArchiveLabels,
   getProductionDates,
@@ -86,11 +86,7 @@ const WorkSearchResultV2: FC<Props> = ({ work, resultPosition }: Props) => {
           size: 'l',
           properties: ['padding-top', 'padding-bottom'],
         }}
-        className={classNames({
-          'plain-link': true,
-          block: true,
-          'card-link': true,
-        })}
+        className="plain-link block card-link"
         onClick={() => {
           // We've left `WorkCard` here for legacy tracking.
           // We don't really use it.
@@ -124,12 +120,7 @@ const WorkSearchResultV2: FC<Props> = ({ work, resultPosition }: Props) => {
             >
               <LabelsList labels={cardLabels} defaultLabelColor="cream" />
             </Space>
-            <WorkTitleHeading
-              className={classNames({
-                [font('intb', 4)]: true,
-                'card-link__title': true,
-              })}
-            >
+            <WorkTitleHeading className={`${font('intb', 4)} card-link__title`}>
               <WorkTitle title={work.title} />
             </WorkTitleHeading>
 

--- a/catalogue/webapp/pages/download.tsx
+++ b/catalogue/webapp/pages/download.tsx
@@ -1,5 +1,5 @@
 import { Work } from '@weco/common/model/catalogue';
-import { classNames, font } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import {
   getDownloadOptionsFromImageUrl,
   getDigitalLocationOfType,
@@ -102,9 +102,7 @@ const DownloadPage: NextPage<Props> = ({
               }}
               as="h1"
               id="work-info"
-              className={classNames({
-                [font('intb', 1)]: true,
-              })}
+              className={font('intb', 1)}
             >
               {title}
             </Space>

--- a/catalogue/webapp/pages/images.tsx
+++ b/catalogue/webapp/pages/images.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState, ReactElement, useContext } from 'react';
 import Router from 'next/router';
 import Head from 'next/head';
 import { CatalogueResultsList, Image } from '@weco/common/model/catalogue';
-import { grid, classNames } from '@weco/common/utils/classnames';
+import { grid } from '@weco/common/utils/classnames';
 import convertUrlToString from '@weco/common/utils/convert-url-to-string';
 import CataloguePageLayout from '../components/CataloguePageLayout/CataloguePageLayout';
 import Paginator from '@weco/common/views/components/Paginator/Paginator';
@@ -153,7 +153,7 @@ const Images: NextPage<Props> = ({
             size: 'l',
             properties: ['padding-bottom'],
           }}
-          className={classNames(['row'])}
+          className="row"
         >
           <div className="container">
             <SearchTitle isVisuallyHidden={Boolean(images)} />
@@ -182,11 +182,7 @@ const Images: NextPage<Props> = ({
             <Space v={{ size: 'l', properties: ['padding-top'] }}>
               <div className="container">
                 <div className="grid">
-                  <div
-                    className={classNames({
-                      [grid({ s: 12, m: 12, l: 12, xl: 12 })]: true,
-                    })}
-                  >
+                  <div className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>
                     <ImagesPagination
                       query={query}
                       page={page}
@@ -218,11 +214,7 @@ const Images: NextPage<Props> = ({
               >
                 <div className="container">
                   <div className="grid">
-                    <div
-                      className={classNames({
-                        [grid({ s: 12, m: 12, l: 12, xl: 12 })]: true,
-                      })}
-                    >
+                    <div className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>
                       <ImagesPagination
                         query={query}
                         page={page}

--- a/catalogue/webapp/pages/works.tsx
+++ b/catalogue/webapp/pages/works.tsx
@@ -1,7 +1,7 @@
 import { Fragment, useEffect, useState, useContext } from 'react';
 import Router from 'next/router';
 import Head from 'next/head';
-import { grid, classNames } from '@weco/common/utils/classnames';
+import { grid } from '@weco/common/utils/classnames';
 import convertUrlToString from '@weco/common/utils/convert-url-to-string';
 import CataloguePageLayout from '../components/CataloguePageLayout/CataloguePageLayout';
 import Paginator from '@weco/common/views/components/Paginator/Paginator';
@@ -107,7 +107,7 @@ const Works: NextPage<Props> = ({ works, worksRouteProps }) => {
             size: 'l',
             properties: ['padding-bottom'],
           }}
-          className={classNames(['row'])}
+          className="row"
         >
           <div className="container">
             {/* Showing the h1 on `/works` (without a query string) in an attempt to
@@ -138,11 +138,7 @@ const Works: NextPage<Props> = ({ works, worksRouteProps }) => {
             <Space v={{ size: 'l', properties: ['padding-top'] }}>
               <div className="container">
                 <div className="grid">
-                  <div
-                    className={classNames({
-                      [grid({ s: 12, m: 12, l: 12, xl: 12 })]: true,
-                    })}
-                  >
+                  <div className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>
                     <div className="flex flex--h-space-between flex--v-center flex--wrap">
                       <Fragment>
                         <Paginator
@@ -201,11 +197,7 @@ const Works: NextPage<Props> = ({ works, worksRouteProps }) => {
               >
                 <div className="container">
                   <div className="grid">
-                    <div
-                      className={classNames({
-                        [grid({ s: 12, m: 12, l: 12, xl: 12 })]: true,
-                      })}
-                    >
+                    <div className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>
                       <div className="flex flex--h-space-between flex--v-center flex--wrap">
                         <Fragment>
                           <Paginator

--- a/common/views/components/AudioPlayer/AudioPlayer.tsx
+++ b/common/views/components/AudioPlayer/AudioPlayer.tsx
@@ -16,7 +16,7 @@ import {
   volume as volumeIcon,
 } from '@weco/common/icons';
 import Space from '@weco/common/views/components/styled/Space';
-import { classNames, font } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import styled from 'styled-components';
 import { trackEvent } from '@weco/common/utils/ga';
 import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
@@ -69,10 +69,7 @@ const VolumeControlWrapper = styled.div<{ isMuted: boolean }>`
 `;
 
 const PlayRateWrapper = styled.div.attrs({
-  className: classNames({
-    flex: true,
-    [font('intr', 6)]: true,
-  }),
+  className: `flex ${font('intr', 6)}`,
 })`
   gap: 5px;
 `;
@@ -411,9 +408,7 @@ export const AudioPlayer: FC<AudioPlayerProps> = ({
         <SecondRow>
           <div className="flex flex--h-space-between">
             <div
-              className={classNames({
-                [font('intr', 6)]: true,
-              })}
+              className={font('intr', 6)}
               style={{
                 fontVariantNumeric: 'tabular-nums',
                 whiteSpace: 'nowrap',

--- a/common/views/components/BackToResults/BackToResults.tsx
+++ b/common/views/components/BackToResults/BackToResults.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent, useContext } from 'react';
 import NextLink from 'next/link';
-import { font, classNames } from '../../../utils/classnames';
+import { font } from '../../../utils/classnames';
 import { trackEvent } from '../../../utils/ga';
 import SearchContext from '../SearchContext/SearchContext';
 
@@ -19,9 +19,7 @@ const BackToResults: FunctionComponent = () => {
             label: `${query} | page: ${page || 1}`,
           });
         }}
-        className={classNames({
-          [font('intr', 5)]: true,
-        })}
+        className={font('intr', 5)}
       >
         <span>{`Back to search${query ? ' results' : ''}`}</span>
       </a>

--- a/common/views/components/BaseTabs/BaseTabs.tsx
+++ b/common/views/components/BaseTabs/BaseTabs.tsx
@@ -10,7 +10,6 @@ import {
 } from 'react';
 import { AppContext } from '../AppContext/AppContext';
 import styled from 'styled-components';
-import { classNames } from '../../../utils/classnames';
 
 const TabList = styled.div.attrs({
   role: 'tablist',
@@ -23,9 +22,7 @@ type TabProps = {
 };
 
 const Tab = styled.button.attrs((props: TabProps) => ({
-  className: classNames({
-    'plain-button no-padding': true,
-  }),
+  className: 'plain-button no-padding',
   role: 'tab',
   tabIndex: props.isActive ? 0 : -1,
   'aria-selected': props.isActive,

--- a/common/views/components/BaseTabs/BaseTabs.tsx
+++ b/common/views/components/BaseTabs/BaseTabs.tsx
@@ -7,7 +7,6 @@ import {
   useEffect,
   ReactElement,
   FunctionComponent,
-  Fragment,
 } from 'react';
 import { AppContext } from '../AppContext/AppContext';
 import styled from 'styled-components';

--- a/common/views/components/BetaMessage/BetaMessage.tsx
+++ b/common/views/components/BetaMessage/BetaMessage.tsx
@@ -1,16 +1,13 @@
 import { useEffect, ReactElement, FunctionComponent } from 'react';
 import { trackEvent } from '@weco/common/utils/ga';
-import { font, classNames } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import styled from 'styled-components';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import Space from '@weco/common/views/components/styled/Space';
 import { underConstruction } from '@weco/common/icons';
 
 const StyledBetaMessage = styled.div.attrs(() => ({
-  className: classNames({
-    [font('intr', 5)]: true,
-    'flex flex--v-center': true,
-  }),
+  className: `${font('intr', 5)} flex flex--v-center`,
 }))`
   border-left: ${props => `4px solid ${props.theme.color('purple')}`};
   padding-left: ${props => props.theme.spacingUnit}px;

--- a/common/views/components/BorderlessClickable/BorderlessClickable.tsx
+++ b/common/views/components/BorderlessClickable/BorderlessClickable.tsx
@@ -73,9 +73,7 @@ const Button: FC<BorderlessClickableProps> = (
               {/* This is all a little hacky and will need some tidy up */}
               {/* We currently only use this in the header sign in button */}
               <span
-                className={classNames({
-                  [font('intr', 4)]: true,
-                })}
+                className={font('intr', 4)}
                 style={{ transform: 'translateY(0.01em)' }}
               >
                 <Icon icon={iconLeft} matchText={true} />

--- a/common/views/components/Breadcrumb/Breadcrumb.tsx
+++ b/common/views/components/Breadcrumb/Breadcrumb.tsx
@@ -6,19 +6,13 @@ import styled from 'styled-components';
 import { BreadcrumbItems } from '../../../model/breadcrumbs';
 
 const ItemWrapper = styled(Space).attrs(() => ({
-  className: classNames({
-    [font('intr', 6)]: true,
-  }),
+  className: font('intr', 6),
 }))``;
 
 const Breadcrumb: FunctionComponent<BreadcrumbItems> = ({
   items,
 }: BreadcrumbItems): ReactElement => (
-  <div
-    className={classNames({
-      flex: true,
-    })}
-  >
+  <div className="flex">
     {items
       .filter(({ isHidden }) => !isHidden)
       .map(({ text, url, prefix }, i) => {
@@ -48,10 +42,7 @@ const Breadcrumb: FunctionComponent<BreadcrumbItems> = ({
     {/* We do this so that the page doesn't bounce around if we don't have any breadcrumbs */}
     {items.length === 0 && (
       <span
-        className={classNames({
-          [font('intr', 6)]: true,
-          'empty-filler': true,
-        })}
+        className={`${font('intr', 6)} empty-filler`}
         style={{ lineHeight: 1 }}
       />
     )}

--- a/common/views/components/ButtonSolid/ButtonSolid.tsx
+++ b/common/views/components/ButtonSolid/ButtonSolid.tsx
@@ -75,10 +75,7 @@ const BaseButtonInnerSpan = styled.span<BaseButtonInnerProps>``;
 export const BaseButtonInner = styled(
   BaseButtonInnerSpan
 ).attrs<BaseButtonInnerProps>(props => ({
-  className: classNames({
-    [font(props.isInline ? 'intr' : 'intb', 5)]: true,
-    'flex flex--v-center': true,
-  }),
+  className: `${font(props.isInline ? 'intr' : 'intb', 5)} flex flex--v-center`,
 }))`
   height: 1em;
 `;
@@ -94,9 +91,7 @@ export const ButtonIconWrapper = styled(
     size: 'xs',
     properties: [`${props.iconAfter ? 'margin-left' : 'margin-right'}`],
   },
-  className: classNames({
-    'flex-inline': true,
-  }),
+  className: 'flex-inline',
 }))<ButtonIconWrapperAttrsProps>`
   // Prevent icon within .spaced-text parent having top margin
   margin-top: 0;

--- a/common/views/components/Buttons/Control/Control.tsx
+++ b/common/views/components/Buttons/Control/Control.tsx
@@ -4,13 +4,10 @@ import { LinkProps } from '../../../../model/link-props';
 import Icon from '../../Icon/Icon';
 import { GaEvent, trackEvent } from '../../../../utils/ga';
 import styled from 'styled-components';
-import { classNames } from '@weco/common/utils/classnames';
 import { IconSvg } from '@weco/common/icons';
 
 const ControlInner = styled.div.attrs({
-  className: classNames({
-    'flex-inline flex--v-center flex--h-center': true,
-  }),
+  className: 'flex-inline flex--v-center flex--h-center',
 })`
   width: 100%;
   height: 100%;

--- a/common/views/components/Caption/Caption.tsx
+++ b/common/views/components/Caption/Caption.tsx
@@ -1,5 +1,5 @@
 import * as prismicT from '@prismicio/types';
-import { font, classNames } from '../../../utils/classnames';
+import { font } from '../../../utils/classnames';
 import { FunctionComponent, ReactNode } from 'react';
 import PrismicHtmlBlock from '../PrismicHtmlBlock/PrismicHtmlBlock';
 import Space from '../styled/Space';
@@ -42,10 +42,7 @@ const Caption: FunctionComponent<Props> = ({
       }}
       as="figcaption"
       style={width ? { width: `${width}px` } : undefined}
-      className={classNames({
-        [font('lr', 6)]: true,
-        'caption h-center': true,
-      })}
+      className={`${font('lr', 6)} caption h-center`}
     >
       <CaptionWrapper>
         {preCaptionNode}

--- a/common/views/components/CheckboxRadio/CheckboxRadio.tsx
+++ b/common/views/components/CheckboxRadio/CheckboxRadio.tsx
@@ -5,24 +5,19 @@ import {
   ReactNode,
 } from 'react';
 import styled from 'styled-components';
-import { classNames } from '../../../utils/classnames';
 import Space from '../styled/Space';
 import Icon from '../Icon/Icon';
 import { check, indicator } from '@weco/common/icons';
 
 const CheckboxRadioLabel = styled.label.attrs({
-  className: classNames({
-    'flex-inline flex--v-center': true,
-  }),
+  className: 'flex-inline flex--v-center',
 })`
   cursor: pointer;
 `;
 
 const CheckboxRadioBoxSpan = styled.span<{ type: string }>``;
 const CheckboxRadioBox = styled(CheckboxRadioBoxSpan).attrs({
-  className: classNames({
-    'flex-inline flex--v-center flex--h-center relative': true,
-  }),
+  className: 'flex-inline flex--v-center flex--h-center relative',
 })`
   width: 1.3em;
   height: 1.3em;

--- a/common/views/components/Contact/Contact.tsx
+++ b/common/views/components/Contact/Contact.tsx
@@ -1,4 +1,4 @@
-import { font, classNames } from '../../../utils/classnames';
+import { font } from '../../../utils/classnames';
 import Space from '../styled/Space';
 import { FunctionComponent, ReactElement } from 'react';
 import styled from 'styled-components';
@@ -25,48 +25,22 @@ const Contact: FunctionComponent<Props> = ({
 }: Props): ReactElement => {
   return (
     <Wrapper>
-      <span
-        className={classNames({
-          block: true,
-        })}
-      >
-        <span
-          className={classNames({
-            [font('intb', 4)]: true,
-          })}
-        >
-          {title}
-        </span>
+      <span className="block">
+        <span className={font('intb', 4)}>{title}</span>
         {subtitle && (
           <Space
             as="span"
             h={{ size: 's', properties: ['margin-left'] }}
-            className={classNames({
-              [font('intr', 4)]: true,
-            })}
+            className={font('intr', 4)}
           >
             {subtitle}
           </Space>
         )}
       </span>
-      {phone && (
-        <span
-          className={classNames({
-            [font('intr', 4)]: true,
-            block: true,
-          })}
-        >
-          {phone}
-        </span>
-      )}
+      {phone && <span className={`${font('intr', 4)} block`}>{phone}</span>}
       {email && (
         <div>
-          <a
-            className={classNames({
-              [font('intr', 4)]: true,
-            })}
-            href={`mailto:${email}`}
-          >
+          <a className={font('intr', 4)} href={`mailto:${email}`}>
             {email}
           </a>
         </div>

--- a/common/views/components/CookieNotice/CookieNotice.tsx
+++ b/common/views/components/CookieNotice/CookieNotice.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import cookie from 'cookie-cutter';
-import { font, classNames } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import { useState, useEffect, FunctionComponent } from 'react';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import Space from '@weco/common/views/components/styled/Space';
@@ -9,9 +9,7 @@ import { clear, cookies } from '@weco/common/icons';
 import { trackEvent } from '@weco/common/utils/ga';
 
 const CookieNoticeStyle = styled.div.attrs({
-  className: classNames({
-    [font('intb', 4)]: true,
-  }),
+  className: font('intb', 4),
 })`
   position: fixed;
   background: ${props => props.theme.color('teal')};

--- a/common/views/components/DropdownButton/DropdownButton.tsx
+++ b/common/views/components/DropdownButton/DropdownButton.tsx
@@ -2,7 +2,6 @@ import { CSSTransition } from 'react-transition-group';
 import { useState, useRef, useEffect, useContext, FC, ReactNode } from 'react';
 import { usePopper } from 'react-popper';
 import styled from 'styled-components';
-import { classNames } from '../../../utils/classnames';
 import getFocusableElements from '../../../utils/get-focusable-elements';
 import Space from '../styled/Space';
 import ButtonSolid, { ButtonTypes } from '../ButtonSolid/ButtonSolid';
@@ -12,9 +11,7 @@ import { chevron, IconSvg } from '../../../icons';
 import { themeValues } from '@weco/common/views/themes/config';
 
 const DropdownWrapper = styled.div.attrs({
-  className: classNames({
-    'flex-inline relative': true,
-  }),
+  className: 'flex-inline relative',
 })``;
 
 type DropdownProps = {

--- a/common/views/components/ExpandableList/ExpandableList.tsx
+++ b/common/views/components/ExpandableList/ExpandableList.tsx
@@ -5,14 +5,11 @@ import {
   FunctionComponent,
   ReactElement,
 } from 'react';
-import { font, classNames } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import styled from 'styled-components';
 
 const ShowHideButton = styled.button.attrs({
-  className: classNames({
-    'plain-button no-margin no-padding': true,
-    [font('intr', 5)]: true,
-  }),
+  className: `plain-button no-margin no-padding ${font('intr', 5)}`,
 })`
   text-decoration: underline;
 
@@ -51,22 +48,13 @@ const ExpandableList: FunctionComponent<Props> = ({
 
   return listItems.length > 0 ? (
     <>
-      <ul
-        className={classNames({
-          'plain-list no-margin no-padding': true,
-        })}
-      >
+      <ul className="plain-list no-margin no-padding">
         {firstListItems.map(
           (
             item,
             index // TODO way of getting better key?
           ) => (
-            <li
-              className={classNames({
-                [font('intr', 5)]: true,
-              })}
-              key={index}
-            >
+            <li className={font('intr', 5)} key={index}>
               {item}
             </li>
           )
@@ -74,12 +62,7 @@ const ExpandableList: FunctionComponent<Props> = ({
         {isShowingRemainingListItems && (
           <>
             {remainingListItems.map((item, index) => (
-              <li
-                className={classNames({
-                  [font('intr', 5)]: true,
-                })}
-                key={index}
-              >
+              <li className={font('intr', 5)} key={index}>
                 {/* if item is a link then add href and index 0 */}
                 {item}
               </li>

--- a/common/views/components/FindUs/FindUs.tsx
+++ b/common/views/components/FindUs/FindUs.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { font, classNames } from '../../../utils/classnames';
+import { font } from '../../../utils/classnames';
 import {
   wellcomeCollectionGallery,
   wellcomeCollectionAddress,
@@ -8,9 +8,7 @@ import Space from '../styled/Space';
 import { FunctionComponent } from 'react';
 import { prismicPageIds } from '../../../data/hardcoded-ids';
 const StyledFindUs = styled.div.attrs({
-  className: classNames({
-    [font('intr', 5)]: true,
-  }),
+  className: font('intr', 5),
 })`
   &:hover,
   &:focus {
@@ -55,17 +53,11 @@ const FindUs: FunctionComponent = () => (
         properties: ['margin-bottom'],
       }}
       as="p"
-      className={classNames({
-        block: true,
-      })}
+      className="block"
     >
       <a href={`/pages/${prismicPageIds.gettingHere}`}>Getting here</a>
     </Space>
-    <p
-      className={classNames({
-        block: true,
-      })}
-    >
+    <p className="block">
       <a
         className="plain-link"
         href={`tel:${wellcomeCollectionGallery.telephone}`}

--- a/common/views/components/Footer/Footer.tsx
+++ b/common/views/components/Footer/Footer.tsx
@@ -32,9 +32,7 @@ const FooterNavWrapper = styled(Space).attrs({
 const HygieneNav = styled(Space).attrs({
   as: 'nav',
   h: { size: 'l', properties: ['margin-bottom'] },
-  className: classNames({
-    'relative flex-1': true,
-  }),
+  className: 'relative flex-1',
 })`
   border-bottom: 1px solid ${props => props.theme.color('charcoal')};
 `;
@@ -42,19 +40,14 @@ const HygieneNav = styled(Space).attrs({
 const HygieneList = styled(Space).attrs({
   as: 'ul',
   h: { size: 'l', properties: ['margin-top', 'margin-bottom'] },
-  className: classNames({
-    'plain-list no-margin no-padding': true,
-    'flex flex--h-space-between': true,
-  }),
+  className: 'plain-list no-margin no-padding flex flex--h-space-between',
 })`
   border-top: 1px solid ${props => props.theme.color('charcoal')};
 `;
 
 const FooterBottom = styled(Space).attrs({
   v: { size: 'xl', properties: ['padding-bottom'] },
-  className: classNames({
-    'flex flex--wrap flex--h-space-between flex--v-start': true,
-  }),
+  className: 'flex flex--wrap flex--h-space-between flex--v-start',
 })`
   border-top: 1px solid ${props => props.theme.color('charcoal')};
 `;
@@ -66,9 +59,7 @@ const NavBrand = styled.a`
 `;
 
 const FooterLeft = styled.div.attrs({
-  className: classNames({
-    'flex flex--v-start': true,
-  }),
+  className: 'flex flex--v-start',
 })`
   flex-wrap: wrap;
 
@@ -104,9 +95,7 @@ const StrapText = styled.div`
 `;
 
 const HygieneItem = styled.li.attrs({
-  className: classNames({
-    [font('intb', 6)]: true,
-  }),
+  className: font('intb', 6),
 })`
   width: 100%;
   text-align: center;
@@ -220,10 +209,9 @@ const Footer: FunctionComponent<Props> = ({ venues, hide = false }: Props) => {
             </TopBorderBox>
           </div>
           <div
-            className={classNames({
-              [grid({ s: 12, m: 6, l: 4, xl: 4 })]: true,
-              [font('intr', 5)]: true,
-            })}
+            className={
+              grid({ s: 12, m: 6, l: 4, xl: 4 }) + ' ' + font('intr', 5)
+            }
           >
             <Space
               v={{
@@ -240,17 +228,9 @@ const Footer: FunctionComponent<Props> = ({ venues, hide = false }: Props) => {
                 className={'flex'}
                 v={{ size: 'l', properties: ['padding-top'] }}
               >
-                <div
-                  className={classNames({
-                    [font('intr', 5)]: true,
-                    'float-l': true,
-                  })}
-                >
+                <div className={`${font('intr', 5)} float-l`}>
                   <h4
-                    className={classNames({
-                      [font('intb', 5)]: true,
-                      'no-margin': true,
-                    })}
+                    className={`${font('intb', 5)} no-margin`}
                   >{`Today's opening times`}</h4>
                   {venues && <OpeningTimes venues={venues} />}
                   <Space v={{ size: 's', properties: ['margin-top'] }} as="p">
@@ -264,11 +244,7 @@ const Footer: FunctionComponent<Props> = ({ venues, hide = false }: Props) => {
         <FooterSocial />
         <FooterBottom>
           <FooterLeft>
-            <FooterStrap
-              className={classNames({
-                [font('intb', 6)]: true,
-              })}
-            >
+            <FooterStrap className={font('intb', 6)}>
               <Space as="span" h={{ size: 's', properties: ['margin-right'] }}>
                 <Icon icon={wellcome} />
               </Space>
@@ -279,16 +255,9 @@ const Footer: FunctionComponent<Props> = ({ venues, hide = false }: Props) => {
                 size: 'm',
                 properties: ['margin-top', 'padding-bottom', 'margin-bottom'],
               }}
-              className={classNames({
-                [font('intb', 6)]: true,
-                'flex flex--v-center': true,
-              })}
+              className={`${font('intb', 6)} flex flex--v-center`}
             >
-              <div
-                className={classNames({
-                  flex: true,
-                })}
-              >
+              <div className="flex">
                 <Space h={{ size: 's', properties: ['margin-right'] }}>
                   <Icon icon={cc} />
                 </Space>

--- a/common/views/components/Header/DesktopSignIn.tsx
+++ b/common/views/components/Header/DesktopSignIn.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react';
 import styled from 'styled-components';
-import { font, classNames } from '../../../utils/classnames';
+import { font } from '../../../utils/classnames';
 import { useUser } from '../UserProvider/UserProvider';
 import DropdownButton from '../DropdownButton/DropdownButton';
 import Space from '../styled/Space';
@@ -40,15 +40,7 @@ const DesktopSignIn: FC = () => {
           <span className="display-none headerLarge-display-block">
             <BorderlessLink
               iconLeft={userIcon}
-              text={
-                <span
-                  className={classNames({
-                    [font('intr', 6)]: true,
-                  })}
-                >
-                  Library sign in
-                </span>
-              }
+              text={<span className={font('intr', 6)}>Library sign in</span>}
               href="/account/api/auth/login"
               onClick={() => {
                 trackEvent({
@@ -82,11 +74,7 @@ const DesktopSignIn: FC = () => {
         <span className="display-none headerMedium-display-block">
           <DropdownButton
             label={
-              <span
-                className={classNames({
-                  [font('intr', 6)]: true,
-                })}
-              >
+              <span className={font('intr', 6)}>
                 {user.firstName.charAt(0).toLocaleUpperCase()}
                 {user.lastName.charAt(0).toLocaleUpperCase()}
               </span>
@@ -95,11 +83,7 @@ const DesktopSignIn: FC = () => {
             id="signedin-dropdown"
             buttonType="borderless"
           >
-            <span
-              className={classNames({
-                [font('intr', 6)]: true,
-              })}
-            >
+            <span className={font('intr', 6)}>
               <AccountA
                 as="a"
                 onClick={() => {

--- a/common/views/components/Header/MobileSignIn.tsx
+++ b/common/views/components/Header/MobileSignIn.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react';
 import styled from 'styled-components';
-import { classNames, font } from '../../../utils/classnames';
+import { font } from '../../../utils/classnames';
 import { respondTo } from '../../themes/mixins';
 import Space from '../styled/Space';
 import Icon from '../Icon/Icon';
@@ -9,9 +9,7 @@ import { user as userIcon } from '../../../icons';
 import { trackEvent } from '../../../utils/ga';
 
 const StyledComponent = styled.div.attrs({
-  className: classNames({
-    [font('intr', 5)]: true,
-  }),
+  className: font('intr', 5),
 })`
   ${respondTo(
     'headerMedium',
@@ -55,9 +53,7 @@ const MobileSignIn: FC = () => {
     <StyledComponent>
       <Space
         h={{ size: 's', properties: ['margin-right'] }}
-        className={classNames({
-          [font('intr', 4)]: true,
-        })}
+        className={font('intr', 4)}
       >
         <Icon icon={userIcon} matchText={true} />
       </Space>

--- a/common/views/components/Label/Label.tsx
+++ b/common/views/components/Label/Label.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent } from 'react';
 import { Label as LabelType, LabelColor } from '../../../model/labels';
-import { font, classNames } from '../../../utils/classnames';
+import { font } from '../../../utils/classnames';
 import Space from '../styled/Space';
 import styled from 'styled-components';
 
@@ -10,10 +10,7 @@ type LabelContainerProps = {
 };
 
 const LabelContainer = styled(Space).attrs({
-  className: classNames({
-    'nowrap line-height-1': true,
-    [font('intb', 6)]: true,
-  }),
+  className: `nowrap line-height-1 ${font('intb', 6)}`,
 })<LabelContainerProps>`
   color: ${props => props.theme.color(props.fontColor)};
   background-color: ${props => props.theme.color(props.labelColor)};

--- a/common/views/components/Layout/Layout.tsx
+++ b/common/views/components/Layout/Layout.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, FunctionComponent } from 'react';
-import { classNames, grid, SizeMap } from '../../../utils/classnames';
+import { grid, SizeMap } from '../../../utils/classnames';
 
 type Props = {
   gridSizes: SizeMap;
@@ -9,13 +9,7 @@ type Props = {
 const Layout: FunctionComponent<Props> = ({ gridSizes, children }: Props) => (
   <div className="container">
     <div className="grid">
-      <div
-        className={classNames({
-          [grid(gridSizes)]: true,
-        })}
-      >
-        {children}
-      </div>
+      <div className={grid(gridSizes)}>{children}</div>
     </div>
   </div>
 );

--- a/common/views/components/LinkLabels/LinkLabels.tsx
+++ b/common/views/components/LinkLabels/LinkLabels.tsx
@@ -1,5 +1,5 @@
 import { FunctionComponent } from 'react';
-import { font, classNames } from '../../../utils/classnames';
+import { font } from '../../../utils/classnames';
 import Icon from '../Icon/Icon';
 import Space from '../styled/Space';
 import styled from 'styled-components';
@@ -31,9 +31,7 @@ const ItemText = styled(Space).attrs<LinkOrSpanSpaceAttrs>(props => ({
       props.addBorder ? 'padding-left' : undefined,
     ].filter(Boolean),
   },
-  className: classNames({
-    [font('intr', 5)]: true,
-  }),
+  className: font('intr', 5),
 }))<LinkOrSpanSpaceAttrs>`
   ${props =>
     props.addBorder &&
@@ -48,20 +46,11 @@ const LinkLabels: FunctionComponent<Props> = ({
   icon,
 }: Props) =>
   heading ? (
-    <dl
-      className={classNames({
-        flex: true,
-        'flex--wrap': true,
-        'no-margin': true,
-        [font('intb', 5)]: true,
-      })}
-    >
+    <dl className={`flex flex--wrap no-margin ${font('intb', 5)}`}>
       <Space
         as="dt"
         h={{ size: 's', properties: ['margin-right'] }}
-        className={classNames({
-          flex: true,
-        })}
+        className="flex"
       >
         {icon && (
           <Space as="span" h={{ size: 's', properties: ['margin-right'] }}>
@@ -71,12 +60,7 @@ const LinkLabels: FunctionComponent<Props> = ({
         {heading}
       </Space>
       {items.map(({ url, text }, i) => (
-        <dd
-          key={`${url || text}-${i}`}
-          className={classNames({
-            'no-margin': true,
-          })}
-        >
+        <dd key={`${url || text}-${i}`} className="no-margin">
           <ItemText url={url || null} addBorder={i !== 0}>
             {text}
           </ItemText>
@@ -85,22 +69,14 @@ const LinkLabels: FunctionComponent<Props> = ({
     </dl>
   ) : (
     <ul
-      className={classNames({
-        flex: true,
-        'plain-list': true,
-        'flex--wrap': true,
-        'no-margin': true,
-        'no-padding': true,
-        [font('intb', 5)]: true,
-      })}
+      className={
+        'flex plain-list flex--wrap no-margin no-padding' +
+        ' ' +
+        font('intb', 5)
+      }
     >
       {items.map(({ url, text }, i) => (
-        <li
-          key={`${url || text}-${i}`}
-          className={classNames({
-            'no-margin': true,
-          })}
-        >
+        <li key={`${url || text}-${i}`} className="no-margin">
           <ItemText url={url || null} addBorder={i !== 0}>
             {text}
           </ItemText>

--- a/common/views/components/Message/Message.tsx
+++ b/common/views/components/Message/Message.tsx
@@ -1,4 +1,4 @@
-import { classNames, font } from '../../../utils/classnames';
+import { font } from '../../../utils/classnames';
 import Space from '../styled/Space';
 import styled from 'styled-components';
 import { FC } from 'react';
@@ -9,10 +9,7 @@ const Wrapper = styled(Space).attrs({
     properties: ['padding-top', 'padding-bottom'],
   },
   h: { size: 'm', properties: ['padding-left', 'padding-right'] },
-  className: classNames({
-    'inline-block': true,
-    [font('intb', 5)]: true,
-  }),
+  className: `inline-block ${font('intb', 5)}`,
 })`
   border-left: 5px solid ${props => props.theme.color('yellow')};
 `;

--- a/common/views/components/NewsletterPromo/NewsletterPromo.tsx
+++ b/common/views/components/NewsletterPromo/NewsletterPromo.tsx
@@ -169,22 +169,10 @@ const NewsletterPromo: FC = () => {
                     {isSuccess ? 'Thank you for signing up!' : headingText}
                   </h2>
                   {!isSuccess && (
-                    <p
-                      className={classNames({
-                        [font('intr', 5)]: true,
-                        'no-margin': true,
-                      })}
-                    >
-                      {bodyText}
-                    </p>
+                    <p className={`${font('intr', 5)} no-margin`}>{bodyText}</p>
                   )}
                   {isSuccess && (
-                    <div
-                      className={classNames({
-                        [font('intr', 5)]: true,
-                        'spaced-text': true,
-                      })}
-                    >
+                    <div className={`${font('intr', 5)} spaced-text`}>
                       <p>
                         If this is the first time you have subscribed to one of
                         our newsletters, you will receive an email asking you to
@@ -237,12 +225,7 @@ const NewsletterPromo: FC = () => {
                 )}
               </BoxInner>
               {!isSuccess && (
-                <p
-                  className={classNames({
-                    [font('intr', 6)]: true,
-                    'no-margin': true,
-                  })}
-                >
+                <p className={`${font('intr', 6)} no-margin`}>
                   <a href="/newsletter">All our newsletters</a>
                 </p>
               )}

--- a/common/views/components/PageHeader/PageHeader.tsx
+++ b/common/views/components/PageHeader/PageHeader.tsx
@@ -1,4 +1,4 @@
-import { font, classNames } from '../../../utils/classnames';
+import { font } from '../../../utils/classnames';
 import Breadcrumb from '../Breadcrumb/Breadcrumb';
 import LabelsList from '../LabelsList/LabelsList';
 import PrismicImage from '../PrismicImage/PrismicImage';
@@ -175,14 +175,7 @@ const PageHeader: FunctionComponent<Props> = ({
                     <Breadcrumb {...breadcrumbs} />
                   </div>
                 ) : (
-                  <span
-                    className={classNames({
-                      [font('intr', 5)]: true,
-                      flex: true,
-                    })}
-                  >
-                    &nbsp;
-                  </span>
+                  <span className={`${font('intr', 5)} flex`}>&nbsp;</span>
                 )}
               </Space>
             )}
@@ -201,9 +194,7 @@ const PageHeader: FunctionComponent<Props> = ({
             {isContentTypeInfoBeforeMedia && ContentTypeInfo && (
               <Space
                 v={{ size: 'm', properties: ['margin-bottom'] }}
-                className={classNames({
-                  [font('intr', 4)]: true,
-                })}
+                className={font('intr', 4)}
               >
                 {ContentTypeInfo}
               </Space>
@@ -221,12 +212,7 @@ const PageHeader: FunctionComponent<Props> = ({
         )}
 
         {HeroPicture && (
-          <div
-            className={classNames({
-              relative: true,
-            })}
-            style={{ height: '100%' }}
-          >
+          <div className="relative" style={{ height: '100%' }}>
             <HeroPictureBackground bgColor={heroImageBgColor} />
 
             <HeroPictureContainer>
@@ -247,9 +233,7 @@ const PageHeader: FunctionComponent<Props> = ({
               size: 'l',
               properties: ['margin-top'],
             }}
-            className={classNames({
-              [font('intb', 4)]: true,
-            })}
+            className={font('intb', 4)}
           >
             {ContentTypeInfo}
           </Space>

--- a/common/views/components/Paginator/Paginator.tsx
+++ b/common/views/components/Paginator/Paginator.tsx
@@ -100,11 +100,7 @@ const Paginator: FunctionComponent<Props> = ({
     <Fragment>
       <Space
         h={{ size: 'm', properties: ['margin-right'] }}
-        className={classNames({
-          flex: true,
-          'flex--v-center': true,
-          [font('intb', 3)]: true,
-        })}
+        className={`flex flex--v-center ${font('intb', 3)}`}
       >
         <TotalResultsWrapper
           hideMobileTotalResults={hideMobileTotalResults}
@@ -115,14 +111,11 @@ const Paginator: FunctionComponent<Props> = ({
         </TotalResultsWrapper>
       </Space>
       <Space
-        className={classNames({
-          pagination: true,
-          'float-r': true,
-          'flex-inline': true,
-          'flex--v-center': true,
-          [font('intr', 5)]: true,
-          'flex-end': true,
-        })}
+        className={
+          'pagination float-r flex-inline flex--v-center flex-end' +
+          ' ' +
+          font('intr', 5)
+        }
         v={{
           size: 'm',
           properties: ['padding-top', 'padding-bottom'],

--- a/common/views/components/PaletteColorPicker/PaletteColorPicker.tsx
+++ b/common/views/components/PaletteColorPicker/PaletteColorPicker.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import { FunctionComponent, useEffect, useRef, useState } from 'react';
 import HueSlider from './HueSlider';
 import { hexToHsv, hsvToHex } from './conversions';
-import { classNames, font } from '../../../utils/classnames';
+import { font } from '../../../utils/classnames';
 
 type Props = {
   name: string;
@@ -75,10 +75,7 @@ type SwatchProps = {
 
 const Swatch = styled.button.attrs((props: SwatchProps) => ({
   type: 'button',
-  className: classNames({
-    'plain-button': true,
-    [font('intr', 5)]: true,
-  }),
+  className: `plain-button ${font('intr', 5)}`,
   'aria-pressed': !!props.ariaPressed,
 }))<SwatchProps>`
   position: relative;

--- a/common/views/components/RadioGroup/RadioGroup.tsx
+++ b/common/views/components/RadioGroup/RadioGroup.tsx
@@ -2,7 +2,6 @@ import React, { FunctionComponent } from 'react';
 
 import CheckboxRadio from '../CheckboxRadio/CheckboxRadio';
 import Space from '../styled/Space';
-import { classNames } from '../../../utils/classnames';
 
 export type RadioGroupOption = {
   value: string;
@@ -37,9 +36,7 @@ const RadioGroup: FunctionComponent<Props> = ({
             ? { size: 'm', properties: ['margin-right'] }
             : undefined
         }
-        className={classNames({
-          'flex-inline flex--h-center': true,
-        })}
+        className="flex-inline flex--h-center"
       >
         <CheckboxRadio
           id={id}

--- a/common/views/components/SearchFilters/ResetActiveFilters.tsx
+++ b/common/views/components/SearchFilters/ResetActiveFilters.tsx
@@ -5,7 +5,7 @@ import { LinkProps } from '@weco/common/model/link-props';
 import Icon from '../Icon/Icon';
 import Space from '../styled/Space';
 import NextLink from 'next/link';
-import { font, classNames } from '../../../utils/classnames';
+import { font } from '../../../utils/classnames';
 import { Filter } from '../../../services/catalogue/filters';
 import { getColorDisplayName } from '../../components/PaletteColorPicker/PaletteColorPicker';
 import { cross } from '@weco/common/icons';
@@ -106,7 +106,7 @@ export const ResetActiveFilters: FunctionComponent<ResetActiveFilters> = ({
 
   return (
     <Wrapper>
-      <div className={classNames({ [font('intb', 5)]: true })} role="status">
+      <div className={font('intb', 5)} role="status">
         <div>
           <h2 className="inline">
             <Space

--- a/common/views/components/SearchForm/SearchForm.tsx
+++ b/common/views/components/SearchForm/SearchForm.tsx
@@ -11,7 +11,6 @@ import Router from 'next/router';
 import styled from 'styled-components';
 import TextInput from '../TextInput/TextInput';
 import ButtonSolid from '../ButtonSolid/ButtonSolid';
-import { classNames } from '../../../utils/classnames';
 import { trackEvent } from '../../../utils/ga';
 import SearchFilters from '../SearchFilters/SearchFilters';
 import Select from '../Select/Select';
@@ -38,9 +37,7 @@ const SearchInputWrapper = styled.div`
 `;
 
 const SearchButtonWrapper = styled.div.attrs({
-  className: classNames({
-    absolute: true,
-  }),
+  className: 'absolute',
 })`
   top: ${props => props.theme.spacingUnits['3'] + 6}px;
   right: ${props => props.theme.spacingUnits['5'] + 6}px;

--- a/common/views/components/SearchTabs/SearchTabs.tsx
+++ b/common/views/components/SearchTabs/SearchTabs.tsx
@@ -23,10 +23,7 @@ const Tab = styled(Space).attrs({
   as: 'span',
   v: { size: 'm', properties: ['padding-top', 'padding-bottom'] },
   h: { size: 'm', properties: ['padding-left', 'padding-right'] },
-  className: classNames({
-    'flex-inline': true,
-    [font('intb', 5)]: true,
-  }),
+  className: `flex-inline ${font('intb', 5)}`,
 })<TabProps>`
   background: ${props => props.theme.color('white')};
   border-left: 1px solid ${props => props.theme.color('pumice')};
@@ -111,9 +108,7 @@ const SearchTabs: FunctionComponent<Props> = ({
                 }}
               >
                 <a
-                  className={classNames({
-                    'plain-link': true,
-                  })}
+                  className="plain-link"
                   aria-current={isActive ? 'page' : undefined}
                 >
                   {children}
@@ -203,9 +198,7 @@ const SearchTabs: FunctionComponent<Props> = ({
                 }}
               >
                 <a
-                  className={classNames({
-                    'plain-link': true,
-                  })}
+                  className="plain-link"
                   aria-current={isActive ? 'page' : undefined}
                 >
                   {children}

--- a/common/views/components/SelectContainer/SelectContainer.tsx
+++ b/common/views/components/SelectContainer/SelectContainer.tsx
@@ -13,9 +13,7 @@ type StyledSelectProps = {
 };
 
 const StyledSelect = styled.div.attrs({
-  className: classNames({
-    [font('intr', 5)]: true,
-  }),
+  className: font('intr', 5),
 })<StyledSelectProps>`
   position: relative;
 

--- a/common/views/components/StackingTable/StackingTable.tsx
+++ b/common/views/components/StackingTable/StackingTable.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import Space from '../styled/Space';
-import { font, classNames } from '../../../utils/classnames';
+import { font } from '../../../utils/classnames';
 import { fontFamilyMixin } from '../../themes/typography';
 import { ReactElement, FunctionComponent, ReactNode } from 'react';
 
@@ -10,9 +10,7 @@ type TableProps = {
 };
 
 const StyledTable = styled.table.attrs({
-  className: classNames({
-    [font('intr', 5)]: true,
-  }),
+  className: font('intr', 5),
 })<TableProps>`
    {
     table-layout: ${props => (props.useFixedWidth ? 'fixed' : 'auto')};
@@ -75,9 +73,7 @@ const StyledTh = styled(Space).attrs<ThProps>(props => ({
       Boolean
     ),
   },
-  className: classNames({
-    [font('intb', 5)]: true,
-  }),
+  className: font('intb', 5),
 }))<ThProps>`
   background: ${props =>
     props.plain

--- a/common/views/components/TabNav/TabNav.tsx
+++ b/common/views/components/TabNav/TabNav.tsx
@@ -63,10 +63,7 @@ const NavItem = ({ link, text, selected, onClick }: SelectableTextLink) => (
         properties: ['padding-top', 'padding-bottom'],
       }}
       as="a"
-      className={classNames({
-        'plain-link': true,
-        block: true,
-      })}
+      className="plain-link block"
       onClick={onClick}
     >
       <NavItemInner
@@ -82,17 +79,8 @@ const NavItem = ({ link, text, selected, onClick }: SelectableTextLink) => (
 
 const TabNav: FC = ({ items }: Props) => {
   return (
-    <div
-      className={classNames({
-        [font('intb', 4)]: true,
-      })}
-    >
-      <ul
-        className={classNames({
-          'plain-list no-margin no-padding': true,
-          'flex flex--wrap': true,
-        })}
-      >
+    <div className={font('intb', 4)}>
+      <ul className="plain-list no-margin no-padding flex flex--wrap">
         {items.map(item => (
           <li
             key={item.text}

--- a/common/views/components/TabNav/TabNavV2.tsx
+++ b/common/views/components/TabNav/TabNavV2.tsx
@@ -70,16 +70,9 @@ const NavItemInner = styled(Space).attrs<NavItemInnerProps>(props => {
 
 const TabNavV2: FC<Props> = ({ items, setSelectedTab, color }: Props) => {
   return (
-    <div
-      className={classNames({
-        [font('intb', 4)]: true,
-      })}
-    >
+    <div className={font('intb', 4)}>
       <ul
-        className={classNames({
-          'plain-list no-margin no-padding': true,
-          'flex flex--wrap': true,
-        })}
+        className="plain-list no-margin no-padding flex flex--wrap"
         role="tablist"
       >
         {items.map(item => (

--- a/common/views/components/TabNav/TabNavV2.tsx
+++ b/common/views/components/TabNav/TabNavV2.tsx
@@ -79,7 +79,7 @@ const TabNavV2: FC<Props> = ({
   isDarkMode = false,
 }: Props) => {
   return (
-    <div className={font('intb', 4)}>
+    <div className={font('intb', 5)}>
       <ul
         className="plain-list no-margin no-padding flex flex--wrap"
         role="tablist"

--- a/common/views/components/TabNav/TabNavV2.tsx
+++ b/common/views/components/TabNav/TabNavV2.tsx
@@ -1,6 +1,5 @@
 import { FC, Dispatch, SetStateAction } from 'react';
 import styled from 'styled-components';
-// import { NextLinkType } from '@weco/common/model/next-link-type';
 import Space from '../styled/Space';
 import { font, classNames } from '../../../utils/classnames';
 

--- a/common/views/components/Table/Table.tsx
+++ b/common/views/components/Table/Table.tsx
@@ -12,7 +12,7 @@ import {
   FunctionComponent,
   ReactElement,
 } from 'react';
-import { font, classNames } from '../../../utils/classnames';
+import { font } from '../../../utils/classnames';
 import Space from '../styled/Space';
 import Rotator from '../styled/Rotator';
 import Control from '../Buttons/Control/Control';
@@ -345,11 +345,7 @@ const Table: FunctionComponent<Props> = ({
                 </TableTr>
               </TableThead>
             )}
-            <TableTbody
-              className={classNames({
-                'has-row-headers': hasRowHeaders,
-              })}
-            >
+            <TableTbody className="has-row-headers">
               {bodyRows.map((row, index) => (
                 <TableRow
                   key={index}

--- a/common/views/components/Tags/Tags.tsx
+++ b/common/views/components/Tags/Tags.tsx
@@ -1,4 +1,4 @@
-import { font, classNames } from '../../../utils/classnames';
+import { font } from '../../../utils/classnames';
 import NextLink from 'next/link';
 import Space from '../styled/Space';
 import { SolidButton } from '../ButtonSolid/ButtonSolid';
@@ -25,9 +25,7 @@ type PartWithSeparatorProps = {
 };
 
 const PartWithSeparator = styled.span.attrs({
-  className: classNames({
-    [font('intr', 5)]: true,
-  }),
+  className: font('intr', 5),
 })<PartWithSeparatorProps>`
   &:after {
     display: ${props => (props.isLast ? 'none' : 'inline')};
@@ -49,11 +47,7 @@ const Tags: FunctionComponent<Props> = ({
 }: Props): ReactElement<Props> => {
   return (
     <Space v={{ size: 's', negative: true, properties: ['margin-bottom'] }}>
-      <ul
-        className={classNames({
-          'plain-list no-margin no-padding': true,
-        })}
-      >
+      <ul className="plain-list no-margin no-padding">
         {/* Have to use index for key because some LCSH and MSH are the same and therefore textParts aren't unique */}
         {tags.map(({ textParts, linkAttributes }, i) => {
           return (
@@ -65,9 +59,7 @@ const Tags: FunctionComponent<Props> = ({
                 properties: ['margin-bottom'],
               }}
               h={{ size: 's', properties: ['margin-right'] }}
-              className={classNames({
-                'inline-block': true,
-              })}
+              className="inline-block"
             >
               <NextLink {...linkAttributes} passHref>
                 <SolidButton
@@ -82,12 +74,11 @@ const Tags: FunctionComponent<Props> = ({
                         isLast={i === arr.length - 1}
                       >
                         <span
-                          className={classNames({
-                            [font(
-                              i === 0 && isFirstPartBold ? 'intb' : 'intr',
-                              5
-                            )]: true,
-                          })}
+                          className={
+                            i === 0 && isFirstPartBold
+                              ? font('intb', 5)
+                              : font('intr', 5)
+                          }
                         >
                           {part}
                         </span>

--- a/common/views/components/TextInput/TextInput.tsx
+++ b/common/views/components/TextInput/TextInput.tsx
@@ -2,7 +2,6 @@ import { forwardRef, useContext, useState, RefObject, FC } from 'react';
 import styled from 'styled-components';
 import Icon from '../Icon/Icon';
 import { AppContext } from '../AppContext/AppContext';
-import { classNames } from '../../../utils/classnames';
 import { check } from '@weco/common/icons';
 
 type TextInputWrapProps = {
@@ -11,9 +10,7 @@ type TextInputWrapProps = {
   hasErrorBorder: boolean;
 };
 export const TextInputWrap = styled.div.attrs({
-  className: classNames({
-    'flex relative': true,
-  }),
+  className: 'flex relative',
 })<TextInputWrapProps>`
   border: 1px solid ${props => props.theme.color('pumice')};
   border-radius: 6px;
@@ -43,9 +40,7 @@ type TextInputLabelProps = {
   hasValue: boolean;
 };
 export const TextInputLabel = styled.label.attrs({
-  className: classNames({
-    absolute: true,
-  }),
+  className: 'absolute',
 })<TextInputLabelProps>`
   /* Styles for browsers that don't support :focus-within (<=IE11) */
   font-size: 14px;
@@ -115,9 +110,7 @@ export const TextInputInput = styled.input.attrs(props => ({
 
 const TextInputCheckmark = styled.span.attrs({
   'data-test-id': 'TextInputCheckmark',
-  className: classNames({
-    absolute: true,
-  }),
+  className: 'absolute',
 })`
   top: 50%;
   transform: translateY(-50%);
@@ -128,9 +121,7 @@ const TextInputCheckmark = styled.span.attrs({
 export const TextInputErrorMessage = styled.span.attrs({
   role: 'alert',
   'data-test-id': 'TextInputErrorMessage',
-  className: classNames({
-    'font-intb': true,
-  }),
+  className: 'font-intb',
 })`
   display: block;
   font-size: 14px;

--- a/common/views/components/ToolbarSegmentedControl/ToolbarSegmentedControl.tsx
+++ b/common/views/components/ToolbarSegmentedControl/ToolbarSegmentedControl.tsx
@@ -1,15 +1,13 @@
 import { FunctionComponent, SyntheticEvent } from 'react';
 import Icon from '../Icon/Icon';
 import styled from 'styled-components';
-import { classNames, font } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import Space from '../styled/Space';
 import { IconSvg } from '@weco/common/icons';
 
 const List = styled.ul.attrs({
-  className: classNames({
-    'no-margin no-padding plain-list': true,
-    'flex-inline flex--v-center flex--h-center': true,
-  }),
+  className:
+    'no-margin no-padding plain-list flex-inline flex--v-center flex--h-center',
 })`
   border: 2px solid ${props => props.theme.color('pewter')};
   border-radius: 5px;
@@ -25,9 +23,7 @@ const Item = styled.li<{ isActive: boolean }>`
 
 const Button = styled.button.attrs({
   type: 'button',
-  className: classNames({
-    'flex plain-button no-margin no-padding': true,
-  }),
+  className: 'flex plain-button no-margin no-padding',
 })``;
 
 const ButtonInner = styled(Space).attrs({
@@ -40,10 +36,7 @@ const ButtonInner = styled(Space).attrs({
     size: 'xs',
     properties: ['padding-top', 'padding-bottom'],
   },
-  className: classNames({
-    'flex flex--v-center flex--h-center': true,
-    [font('intb', 5)]: true,
-  }),
+  className: `flex flex--v-center flex--h-center ${font('intb', 5)}`,
 })<{ isActive: boolean }>`
   color: ${props => props.theme.color('white')};
 `;

--- a/common/views/components/WatchLabel/WatchLabel.tsx
+++ b/common/views/components/WatchLabel/WatchLabel.tsx
@@ -1,4 +1,4 @@
-import { classNames, font } from '../../../../common/utils/classnames';
+import { font } from '../../../../common/utils/classnames';
 import { FunctionComponent, ReactElement } from 'react';
 import styled from 'styled-components';
 import Icon from '../Icon/Icon';
@@ -21,9 +21,7 @@ const WatchIconWrapper = styled.div`
 
 const WatchText = styled(Space).attrs({
   v: { size: 's', properties: ['margin-left'] },
-  className: classNames({
-    [font('intr', 6)]: true,
-  }),
+  className: font('intr', 6),
 })`
   color: ${props => props.theme.color('pewter')};
 `;
@@ -33,12 +31,7 @@ type Props = {
 };
 
 const WatchLabel: FunctionComponent<Props> = ({ text }: Props) => (
-  <div
-    className={classNames({
-      [font('intr', 4)]: true,
-      'flex flex--v-center': true,
-    })}
-  >
+  <div className={`${font('intr', 4)} flex flex--v-center`}>
     <WatchIconWrapper>
       <Icon icon={play} matchText={true} />
     </WatchIconWrapper>

--- a/content/webapp/components/BannerCard/BannerCard.tsx
+++ b/content/webapp/components/BannerCard/BannerCard.tsx
@@ -1,4 +1,4 @@
-import { classNames, font } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
 import { trackEvent } from '@weco/common/utils/ga';
 import { FunctionComponent } from 'react';
@@ -139,10 +139,7 @@ const BannerCard: FunctionComponent<Props> = ({
             properties: ['margin-top', 'margin-bottom'],
           }}
           as="h2"
-          className={classNames({
-            'promo-link__title': true,
-            [font('wb', 2)]: true,
-          })}
+          className={`promo-link__title ${font('wb', 2)}`}
         >
           {title}
         </Space>
@@ -157,13 +154,7 @@ const BannerCard: FunctionComponent<Props> = ({
             <DateRange start={start} end={end} />
           </Space>
         )}
-        <p
-          className={classNames({
-            [font('intr', 5)]: true,
-          })}
-        >
-          {description}
-        </p>
+        <p className={font('intr', 5)}>{description}</p>
         <ButtonSolid
           colors={themeValues.buttonColors.whiteTransparentWhite}
           isIconAfter={true}

--- a/content/webapp/components/Body/Body.tsx
+++ b/content/webapp/components/Body/Body.tsx
@@ -6,7 +6,7 @@ import React, {
   Fragment,
 } from 'react';
 import styled from 'styled-components';
-import { classNames, font } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import { Link } from '../../types/link';
 import {
   defaultSerializer,
@@ -271,11 +271,7 @@ const Body: FunctionComponent<Props> = ({
   };
 
   return (
-    <div
-      className={classNames({
-        'basic-body': true,
-      })}
-    >
+    <div className="basic-body">
       {filteredBody.length < 1 && (
         <AdditionalContent
           index={0}

--- a/content/webapp/components/Body/GridFactory.tsx
+++ b/content/webapp/components/Body/GridFactory.tsx
@@ -1,5 +1,5 @@
 import { FC, ReactElement } from 'react';
-import { classNames, grid } from '@weco/common/utils/classnames';
+import { grid } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 
 type Grid = {
@@ -66,9 +66,7 @@ const GridFactory: FC<Props> = ({ items, overrideGridSizes }) => {
           <Space
             v={{ size: 'l', properties: ['margin-bottom'] }}
             key={index}
-            className={classNames({
-              [grid(gridSizes[index % gridSizes.length])]: true,
-            })}
+            className={grid(gridSizes[index % gridSizes.length])}
           >
             {item}
           </Space>

--- a/content/webapp/components/Body/VisitUsStaticContent.tsx
+++ b/content/webapp/components/Body/VisitUsStaticContent.tsx
@@ -1,5 +1,5 @@
 import { FunctionComponent, ReactNode } from 'react';
-import { classNames, font, grid } from '@weco/common/utils/classnames';
+import { font, grid } from '@weco/common/utils/classnames';
 import FindUs from '@weco/common/views/components/FindUs/FindUs';
 import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
 import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
@@ -31,33 +31,15 @@ const VisitUsStaticContent: FunctionComponent = () => {
   return (
     <Container>
       <div className="grid">
-        <div
-          className={classNames({
-            [grid({ s: 12, l: 5, xl: 5 })]: true,
-            [font('intr', 4)]: true,
-          })}
-        >
+        <div className={`${grid({ s: 12, l: 5, xl: 5 })} ${font('intr', 4)}`}>
           <FindUs />
         </div>
-        <div
-          className={classNames({
-            [grid({ s: 12, l: 5, xl: 5 })]: true,
-            [font('intr', 4)]: true,
-          })}
-        >
+        <div className={`${grid({ s: 12, l: 5, xl: 5 })} ${font('intr', 4)}`}>
           <div className="flex">
-            <div
-              className={classNames({
-                [font('intr', 5)]: true,
-                'float-l': true,
-              })}
-            >
-              <h2
-                className={classNames({
-                  [font('intb', 5)]: true,
-                  'no-margin': true,
-                })}
-              >{`Today's opening times`}</h2>
+            <div className={`${font('intr', 5)} float-l`}>
+              <h2 className={`${font('intb', 5)} no-margin`}>
+                Today’s opening times
+              </h2>
               {venues && <OpeningTimes venues={venues} />}
               <Space
                 v={{

--- a/content/webapp/components/BookPromo/BookPromo.tsx
+++ b/content/webapp/components/BookPromo/BookPromo.tsx
@@ -1,4 +1,4 @@
-import { font, classNames } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import { trackEvent } from '@weco/common/utils/ga';
 import { BookBasic } from '../../types/books';
 import Space from '@weco/common/views/components/styled/Space';
@@ -31,9 +31,7 @@ const BookPromo: FC<Props> = ({ book }) => {
       }}
       h={{ size: 'm', properties: ['padding-left', 'padding-right'] }}
       url={`/books/${id}`}
-      className={classNames({
-        'block promo-link plain-link': true,
-      })}
+      className="block promo-link plain-link"
       onClick={() => {
         trackEvent({
           category: 'BookPromo',
@@ -84,12 +82,7 @@ const BookPromo: FC<Props> = ({ book }) => {
             </Space>
           </Space>
           {title && (
-            <h3
-              className={classNames({
-                'no-margin promo-link__title': true,
-                [font('wb', 4)]: true,
-              })}
-            >
+            <h3 className={`no-margin promo-link__title ${font('wb', 4)}`}>
               {title}
             </h3>
           )}
@@ -98,10 +91,7 @@ const BookPromo: FC<Props> = ({ book }) => {
             <Space
               as="h4"
               v={{ size: 's', properties: ['margin-top'] }}
-              className={classNames({
-                'no-margin': true,
-                [font('intb', 5)]: true,
-              })}
+              className={`no-margin ${font('intb', 5)}`}
             >
               {subtitle}
             </Space>
@@ -109,14 +99,7 @@ const BookPromo: FC<Props> = ({ book }) => {
 
           {promo?.caption && (
             <Space v={{ size: 's', properties: ['margin-top'] }}>
-              <p
-                className={classNames({
-                  [font('intr', 5)]: true,
-                  'no-margin': true,
-                })}
-              >
-                {promo?.caption}
-              </p>
+              <p className={`${font('intr', 5)} no-margin`}>{promo?.caption}</p>
             </Space>
           )}
         </Space>

--- a/content/webapp/components/Card/Card.tsx
+++ b/content/webapp/components/Card/Card.tsx
@@ -1,5 +1,5 @@
 import { Card as CardType } from '../../types/card';
-import { font, classNames } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import { trackEvent } from '@weco/common/utils/ga';
 import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
 import Space from '@weco/common/views/components/styled/Space';
@@ -139,10 +139,7 @@ const Card: FunctionComponent<Props> = ({ item }: Props) => {
                 properties: ['margin-bottom'],
               }}
               as="h2"
-              className={classNames({
-                'promo-link__title': true,
-                [font('wb', 3)]: true,
-              })}
+              className={`promo-link__title ${font('wb', 3)}`}
             >
               {item.title}
             </Space>

--- a/content/webapp/components/Contributors/Contributor.tsx
+++ b/content/webapp/components/Contributors/Contributor.tsx
@@ -1,4 +1,4 @@
-import { font, grid, classNames } from '@weco/common/utils/classnames';
+import { font, grid } from '@weco/common/utils/classnames';
 import { Contributor as ContributorType } from '../../types/contributors';
 import LinkLabels from '@weco/common/views/components/LinkLabels/LinkLabels';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
@@ -64,21 +64,13 @@ const Contributor: FC<ContributorType> = ({
         </Space>
         <div>
           <div className="flex flex--h-baseline">
-            <h3
-              className={classNames({
-                [font('intb', 4)]: true,
-                'no-margin': true,
-              })}
-            >
+            <h3 className={`${font('intb', 4)} no-margin`}>
               {contributor.name}
             </h3>
             {contributor.type === 'people' && contributor.pronouns && (
               <Space
                 h={{ size: 's', properties: ['margin-left'] }}
-                className={classNames({
-                  [font('intr', 5)]: true,
-                  'font-pewter': true,
-                })}
+                className={`${font('intr', 5)} font-pewter`}
               >
                 ({contributor.pronouns})
               </Space>
@@ -104,10 +96,7 @@ const Contributor: FC<ContributorType> = ({
                 size: 's',
                 properties: ['margin-top'],
               }}
-              className={classNames({
-                [font('intr', 5)]: true,
-                'spaced-text': true,
-              })}
+              className={`${font('intr', 5)} spaced-text`}
             >
               <PrismicHtmlBlock html={descriptionToRender} />
             </Space>

--- a/content/webapp/components/EventCard/EventCard.tsx
+++ b/content/webapp/components/EventCard/EventCard.tsx
@@ -4,7 +4,7 @@ import CompactCard from '../CompactCard/CompactCard';
 import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImage';
 import StatusIndicator from '@weco/common/views/components/StatusIndicator/StatusIndicator';
 import EventDateRange from '../EventDateRange/EventDateRange';
-import { classNames, font } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import { getCrop } from '@weco/common/model/image';
 import Space from '@weco/common/views/components/styled/Space';
 import WatchLabel from '@weco/common/views/components/WatchLabel/WatchLabel';
@@ -63,14 +63,7 @@ const EventCard: FC<Props> = ({ event, xOfY }) => {
         </Space>
       </>
     ) : !event.isPast && event.times.length > 1 ? (
-      <p
-        className={classNames({
-          [font('intb', 4)]: true,
-          'no-margin': true,
-        })}
-      >
-        See all dates/times
-      </p>
+      <p className={`${font('intb', 4)} no-margin`}>See all dates/times</p>
     ) : undefined;
 
   return (

--- a/content/webapp/components/EventDatesLink/EventDatesLink.tsx
+++ b/content/webapp/components/EventDatesLink/EventDatesLink.tsx
@@ -1,5 +1,5 @@
 import { FunctionComponent } from 'react';
-import { font, classNames } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import { trackEvent } from '@weco/common/utils/ga';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import { arrowSmall } from '@weco/common/icons';
@@ -19,11 +19,7 @@ const EventDatesLink: FunctionComponent<Props> = ({ id }: Props) => {
           label: id,
         });
       }}
-      className={classNames({
-        'flex-inline': true,
-        'flex-v-center': true,
-        [font('intb', 5)]: true,
-      })}
+      className={`flex-inline flex-v-center ${font('intb', 5)}`}
     >
       <Icon icon={arrowSmall} color={'black'} rotate={90} />
       <span>{`See all dates`}</span>

--- a/content/webapp/components/EventPromo/EventPromo.tsx
+++ b/content/webapp/components/EventPromo/EventPromo.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react';
-import { font, classNames } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import { trackEvent } from '@weco/common/utils/ga';
 import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
 import Dot from '@weco/common/views/components/Dot/Dot';
@@ -105,10 +105,7 @@ const EventPromo: FC<Props> = ({
               properties: ['margin-bottom'],
             }}
             as="h2"
-            className={classNames({
-              'promo-link__title': true,
-              [font('wb', 3)]: true,
-            })}
+            className={`promo-link__title ${font('wb', 3)}`}
           >
             {event.title}
           </Space>
@@ -116,10 +113,7 @@ const EventPromo: FC<Props> = ({
           {(event.isOnline || event.locations.length > 0) && (
             <Space
               v={{ size: 's', properties: ['margin-top', 'margin-bottom'] }}
-              className={classNames({
-                [font('intr', 5)]: true,
-                'flex flex--v-center': true,
-              })}
+              className={`${font('intr', 5)} flex flex--v-center`}
             >
               <Icon icon={location} matchText />
               <Space h={{ size: 'xs', properties: ['margin-left'] }}>

--- a/content/webapp/components/EventbriteButtons/EventbriteButtons.tsx
+++ b/content/webapp/components/EventbriteButtons/EventbriteButtons.tsx
@@ -2,7 +2,7 @@ import { FC } from 'react';
 import { Event } from '../../types/events';
 import ButtonSolid from '@weco/common/views/components/ButtonSolid/ButtonSolid';
 import ButtonSolidLink from '@weco/common/views/components/ButtonSolidLink/ButtonSolidLink';
-import { font, classNames } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 import { ticket } from '@weco/common/icons';
 import styled from 'styled-components';
@@ -10,9 +10,7 @@ import styled from 'styled-components';
 const Location = styled(Space).attrs({
   v: { size: 's', properties: ['margin-bottom'] },
   as: 'p',
-  className: classNames({
-    [font('intb', 5)]: true,
-  }),
+  className: font('intb', 5),
 })``;
 
 type Props = {
@@ -85,12 +83,7 @@ const EventbriteButtons: FC<Props> = ({ event }) => {
               </Space>
             </>
           )}
-          <p
-            className={classNames({
-              'font-charcoal no-margin': true,
-              [font('intr', 5)]: true,
-            })}
-          >
+          <p className={`font-charcoal no-margin ${font('intr', 5)}`}>
             Tickets via Eventbrite
           </p>
         </>

--- a/content/webapp/components/EventsByMonth/EventsByMonth.tsx
+++ b/content/webapp/components/EventsByMonth/EventsByMonth.tsx
@@ -1,5 +1,5 @@
 import { Component } from 'react';
-import { classNames, cssGrid } from '@weco/common/utils/classnames';
+import { cssGrid } from '@weco/common/utils/classnames';
 import SegmentedControl from '@weco/common/views/components/SegmentedControl/SegmentedControl';
 import { EventBasic } from '../../types/events';
 import { Link } from '../../types/link';
@@ -47,11 +47,7 @@ class EventsByMonth extends Component<Props, State> {
         <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
           <CssGridContainer>
             <div className="css-grid">
-              <div
-                className={classNames({
-                  [cssGrid({ s: 12, m: 12, l: 12, xl: 12 })]: true,
-                })}
-              >
+              <div className={cssGrid({ s: 12, m: 12, l: 12, xl: 12 })}>
                 <SegmentedControl
                   id="monthControls"
                   activeId={groups[0]?.id}
@@ -69,9 +65,7 @@ class EventsByMonth extends Component<Props, State> {
         {groups.map(g => (
           <div
             key={g.id}
-            className={classNames({
-              [cssGrid({ s: 12, m: 12, l: 12, xl: 12 })]: true,
-            })}
+            className={cssGrid({ s: 12, m: 12, l: 12, xl: 12 })}
             style={{
               display: !activeId
                 ? 'block'

--- a/content/webapp/components/EventsByMonth/EventsByMonth.tsx
+++ b/content/webapp/components/EventsByMonth/EventsByMonth.tsx
@@ -1,5 +1,5 @@
 import { Component } from 'react';
-import { cssGrid } from '@weco/common/utils/classnames';
+import { classNames, cssGrid } from '@weco/common/utils/classnames';
 import SegmentedControl from '@weco/common/views/components/SegmentedControl/SegmentedControl';
 import { EventBasic } from '../../types/events';
 import { Link } from '../../types/link';

--- a/content/webapp/components/ExhibitionGuideLinksPromo/ExhibitionGuideLinksPromo.tsx
+++ b/content/webapp/components/ExhibitionGuideLinksPromo/ExhibitionGuideLinksPromo.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react';
-import { font, classNames } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import { ExhibitionGuideBasic } from '../../types/exhibition-guides';
 import Space from '@weco/common/views/components/styled/Space';
 import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImage';
@@ -79,20 +79,13 @@ const ExhibitionGuideLinksPromo: FC<Props> = ({ exhibitionGuide }) => {
             properties: ['margin-top', 'margin-bottom'],
           }}
           as="h3"
-          className={classNames({
-            [font('wb', 3)]: true,
-          })}
+          className={font('wb', 3)}
         >
           {exhibitionGuide.title}
         </Space>
       </ExhibitionTitleLink>
       <Space v={{ size: 's', properties: ['margin-top'] }}>
-        <ul
-          className={classNames({
-            [font('intr', 5)]: true,
-            'no-margin plain-list no-padding': true,
-          })}
-        >
+        <ul className={`${font('intr', 5)} no-margin plain-list no-padding`}>
           {links.map((link, i) => (
             <TypeListItem key={i} url={link.url} text={link.text} />
           ))}

--- a/content/webapp/components/ExhibitionGuidePromo/ExhibitionGuidePromo.tsx
+++ b/content/webapp/components/ExhibitionGuidePromo/ExhibitionGuidePromo.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react';
-import { font, classNames } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import { trackEvent } from '@weco/common/utils/ga';
 import { ExhibitionGuideBasic } from '../../types/exhibition-guides';
 import Space from '@weco/common/views/components/styled/Space';
@@ -55,21 +55,13 @@ const ExhibitionGuidePromo: FC<Props> = ({ exhibitionGuide }) => {
               properties: ['margin-bottom'],
             }}
             as="h2"
-            className={classNames({
-              'promo-link__title': true,
-              [font('wb', 3)]: true,
-            })}
+            className={`promo-link__title ${font('wb', 3)}`}
           >
             {exhibitionGuide.title}
           </Space>
           {exhibitionGuide.promo?.caption && (
             <Space v={{ size: 's', properties: ['margin-top'] }}>
-              <p
-                className={classNames({
-                  [font('intr', 5)]: true,
-                  'no-margin': true,
-                })}
-              >
+              <p className={`${font('intr', 5)} no-margin`}>
                 {exhibitionGuide.promo?.caption}
               </p>
             </Space>

--- a/content/webapp/components/ExhibitionPromo/ExhibitionPromo.tsx
+++ b/content/webapp/components/ExhibitionPromo/ExhibitionPromo.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react';
-import { font, classNames } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import { trackEvent } from '@weco/common/utils/ga';
 import { formatDate } from '@weco/common/utils/format-date';
 import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
@@ -70,10 +70,7 @@ const ExhibitionPromo: FC<Props> = ({ exhibition, position = 0 }) => {
               size: 's',
               properties: ['margin-bottom'],
             }}
-            className={classNames({
-              'promo-link__title': true,
-              [font('wb', 3)]: true,
-            })}
+            className={`promo-link__title ${font('wb', 3)}`}
           >
             {exhibition.title}
           </Space>

--- a/content/webapp/components/FacilityPromo/FacilityPromo.tsx
+++ b/content/webapp/components/FacilityPromo/FacilityPromo.tsx
@@ -1,4 +1,4 @@
-import { font, classNames } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import { trackEvent } from '@weco/common/utils/ga';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImage';
@@ -48,14 +48,7 @@ const FacilityPromo: FC<FacilityPromoType> = ({
 
         <CardBody>
           <div>
-            <h2
-              className={classNames({
-                'promo-link__title': true,
-                [font('wb', 4)]: true,
-              })}
-            >
-              {title}
-            </h2>
+            <h2 className={`promo-link__title ${font('wb', 4)}`}>{title}</h2>
             <p className={`${font('intr', 5)} no-margin no-padding`}>
               {description}
             </p>

--- a/content/webapp/components/FeaturedText/FeaturedText.tsx
+++ b/content/webapp/components/FeaturedText/FeaturedText.tsx
@@ -1,5 +1,5 @@
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
-import { font, classNames } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import { JSXFunctionSerializer } from '@prismicio/react';
 import * as prismicT from '@prismicio/types';
 import { FC } from 'react';
@@ -10,12 +10,7 @@ type Props = {
 };
 
 const FeaturedText: FC<Props> = ({ html, htmlSerializer }: Props) => (
-  <div
-    className={classNames({
-      'body-text': true,
-      [font('intr', 4)]: true,
-    })}
-  >
+  <div className={`body-text ${font('intr', 4)}`}>
     <PrismicHtmlBlock html={html} htmlSerializer={htmlSerializer} />
   </div>
 );

--- a/content/webapp/components/GifVideo/GifVideo.tsx
+++ b/content/webapp/components/GifVideo/GifVideo.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent, useState, useEffect, useRef } from 'react';
 import debounce from 'lodash.debounce';
 import throttle from 'lodash.throttle';
-import { font, classNames } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import { trackEvent } from '@weco/common/utils/ga';
 import Tasl from '@weco/common/views/components/Tasl/Tasl';
 import Caption from '@weco/common/views/components/Caption/Caption';
@@ -18,9 +18,7 @@ const Video = styled.video`
 
 const PlayPause = styled.button.attrs({
   'aria-label': 'play/pause button',
-  className: classNames({
-    'no-margin no-padding plain-button absolute': true,
-  }),
+  className: 'no-margin no-padding plain-button absolute',
 })`
   background: transparent;
   border: 0;
@@ -31,9 +29,7 @@ const PlayPause = styled.button.attrs({
 `;
 
 const Text = styled.span.attrs({
-  className: classNames({
-    [font('lr', 5)]: true,
-  }),
+  className: font('lr', 5),
 })<{ isPlaying: boolean }>`
   display: block;
   background: ${props => props.theme.color('charcoal')};

--- a/content/webapp/components/ImageGallery/ImageGallery.tsx
+++ b/content/webapp/components/ImageGallery/ImageGallery.tsx
@@ -24,9 +24,7 @@ import { PageBackgroundContext } from '../ContentPage/ContentPage';
 const GalleryTitle = styled(Space).attrs({
   v: { size: 'm', properties: ['margin-bottom'] },
   as: 'span',
-  className: classNames({
-    'flex flex--v-top': true,
-  }),
+  className: 'flex flex--v-top',
 })``;
 
 const Gallery = styled.div.attrs({
@@ -273,9 +271,7 @@ const ImageGallery: FunctionComponent<{ id: number } & Props> = ({
         pageBackground={pageBackground}
       >
         <div
-          className={classNames({
-            'absolute background': true,
-          })}
+          className="absolute background"
           style={{
             bottom: 0,
             width: `100%`,
@@ -292,9 +288,7 @@ const ImageGallery: FunctionComponent<{ id: number } & Props> = ({
                   }
                 : undefined
             }
-            className={classNames({
-              relative: true,
-            })}
+            className="relative"
           >
             {isStandalone && (
               <div className="absolute standalone-wobbly-edge">
@@ -313,9 +307,7 @@ const ImageGallery: FunctionComponent<{ id: number } & Props> = ({
                   size: 'm',
                   properties: ['padding-top'],
                 }}
-                className={classNames({
-                  'close-wrapper absolute': true,
-                })}
+                className="close-wrapper absolute"
               >
                 <Space
                   v={{
@@ -373,9 +365,7 @@ const ImageGallery: FunctionComponent<{ id: number } & Props> = ({
                           size: 'm',
                           properties: ['margin-bottom'],
                         }}
-                        className={classNames({
-                          [font('intb', 5)]: true,
-                        })}
+                        className={font('intb', 5)}
                       >
                         {i + 1} of {items.length}
                       </Space>

--- a/content/webapp/components/LayoutPaginatedResults/LayoutPaginatedResults.tsx
+++ b/content/webapp/components/LayoutPaginatedResults/LayoutPaginatedResults.tsx
@@ -2,7 +2,7 @@ import Layout12 from '@weco/common/views/components/Layout12/Layout12';
 import Divider from '@weco/common/views/components/Divider/Divider';
 import Pagination from '@weco/common/views/components/Pagination/Pagination';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
-import { classNames, font } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import { Period } from '../../types/periods';
 import { ExhibitionBasic } from '../../types/exhibitions';
 import { EventBasic } from '../../types/events';
@@ -69,12 +69,7 @@ const LayoutPaginatedResults: FC<Props> = ({
             size: 'l',
             properties: ['padding-bottom'],
           }}
-          className={classNames({
-            flex: true,
-            'flex--v-center': true,
-            'font-pewter': true,
-            [font('lr', 6)]: true,
-          })}
+          className={`flex flex--v-center font-pewter ${font('lr', 6)}`}
         >
           {paginatedResults.pageSize * paginatedResults.currentPage -
             (paginatedResults.pageSize - 1)}
@@ -92,13 +87,7 @@ const LayoutPaginatedResults: FC<Props> = ({
     {showFreeAdmissionMessage && (
       <Layout12>
         <div className="flex-inline flex--v-center">
-          <span
-            className={classNames({
-              [font('intb', 4)]: true,
-            })}
-          >
-            Free admission
-          </span>
+          <span className={font('intb', 4)}>Free admission</span>
         </div>
       </Layout12>
     )}

--- a/content/webapp/components/MediaObject/MediaObject.tsx
+++ b/content/webapp/components/MediaObject/MediaObject.tsx
@@ -6,7 +6,7 @@ import MediaObjectBase, {
 import { getCrop, ImageType } from '@weco/common/model/image';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
 import styled from 'styled-components';
-import { grid, classNames, font } from '@weco/common/utils/classnames';
+import { grid, font } from '@weco/common/utils/classnames';
 import * as prismicT from '@prismicio/types';
 
 export type Props = {
@@ -44,10 +44,7 @@ const TextWrapper = styled.div.attrs<HasImageProps>(props => {
 })<HasImageProps>``;
 
 const TitleWrapper = styled.div.attrs({
-  className: classNames({
-    'card-link__title': true,
-    [font('wb', 4)]: true,
-  }),
+  className: `card-link__title ${font('wb', 4)}`,
 })``;
 
 export const MediaObject: FunctionComponent<Props> = ({

--- a/content/webapp/components/MediaObjectBase/MediaObjectBase.test.tsx
+++ b/content/webapp/components/MediaObjectBase/MediaObjectBase.test.tsx
@@ -10,7 +10,7 @@ import {
 import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImage';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
 import styled from 'styled-components';
-import { grid, classNames, font } from '@weco/common/utils/classnames';
+import { grid, font } from '@weco/common/utils/classnames';
 
 const getBaseTitleClass = number => {
   return `card-link__title font-wb font-size-${number}`;
@@ -47,10 +47,7 @@ const TextWrapper = styled.div.attrs<HasImageProps>(props => {
 })<HasImageProps>``;
 
 const TitleWrapper = styled.div.attrs({
-  className: classNames({
-    'card-link__title': true,
-    [font('wb', 4)]: true,
-  }),
+  className: `card-link__title ${font('wb', 4)}`,
 })``;
 
 const extraClass = 'my_extra_extra_class';

--- a/content/webapp/components/NewsletterSignup/NewsletterSignup.tsx
+++ b/content/webapp/components/NewsletterSignup/NewsletterSignup.tsx
@@ -1,7 +1,7 @@
 import { SyntheticEvent, useState, useEffect, FC } from 'react';
 import TextInput from '@weco/common/views/components/TextInput/TextInput';
 import CheckboxRadio from '@weco/common/views/components/CheckboxRadio/CheckboxRadio';
-import { font, classNames } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 import useValidation from '@weco/common/hooks/useValidation';
 import ButtonSolid from '@weco/common/views/components/ButtonSolid/ButtonSolid';
@@ -75,11 +75,7 @@ const NewsletterSignup: FC<Props> = ({
     <>
       {isConfirmed && (
         <div className="body-text">
-          <p
-            className={classNames({
-              [font('intb', 3)]: true,
-            })}
-          >
+          <p className={font('intb', 3)}>
             Thank you for confirming your email address
           </p>
           <p>
@@ -100,13 +96,7 @@ const NewsletterSignup: FC<Props> = ({
 
       {isSuccess && (
         <div className="body-text">
-          <p
-            className={classNames({
-              [font('intb', 3)]: true,
-            })}
-          >
-            You’re signed up
-          </p>
+          <p className={font('intb', 3)}>You’re signed up</p>
           <p>
             If this is the first time you’ve subscribed to updates from us, you
             will receive an email asking you to confirm. Please check your email
@@ -117,26 +107,14 @@ const NewsletterSignup: FC<Props> = ({
 
       {isError && (
         <div className="body-text">
-          <p
-            className={classNames({
-              [font('intb', 3)]: true,
-            })}
-          >
-            Sorry, there’s been a problem
-          </p>
+          <p className={font('intb', 3)}>Sorry, there’s been a problem</p>
           <p>Please try again.</p>
         </div>
       )}
 
       {!isConfirmed && !isSuccess && !isError && (
         <div className="body-text">
-          <p
-            className={classNames({
-              [font('intb', 3)]: true,
-            })}
-          >
-            Want to hear more from us?
-          </p>
+          <p className={font('intb', 3)}>Want to hear more from us?</p>
         </div>
       )}
 
@@ -192,11 +170,7 @@ const NewsletterSignup: FC<Props> = ({
 
           <Space v={{ size: 's', properties: ['margin-bottom'] }} as="fieldset">
             <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
-              <legend
-                className={classNames({
-                  [font('intb', 4)]: true,
-                })}
-              >
+              <legend className={font('intb', 4)}>
                 You might also be interested in receiving updates on:
               </legend>
             </Space>

--- a/content/webapp/components/OnThisPageAnchors/OnThisPageAnchors.tsx
+++ b/content/webapp/components/OnThisPageAnchors/OnThisPageAnchors.tsx
@@ -1,13 +1,11 @@
 import Space from '@weco/common/views/components/styled/Space';
 import styled from 'styled-components';
 import { Link } from '../../types/link';
-import { classNames, font } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import { FunctionComponent, ReactElement } from 'react';
 
 const Anchor = styled.a.attrs(() => ({
-  className: classNames({
-    [font('intb', 5)]: true,
-  }),
+  className: font('intb', 5),
 }))`
   color: ${props => props.theme.color('green')};
 `;

--- a/content/webapp/components/Outro/Outro.tsx
+++ b/content/webapp/components/Outro/Outro.tsx
@@ -1,6 +1,5 @@
 import { MultiContent } from '../../types/multi-content';
 import { isNotUndefined } from '@weco/common/utils/array';
-import { classNames } from '@weco/common/utils/classnames';
 import { trackEvent } from '@weco/common/utils/ga';
 import CompactCard from '../CompactCard/CompactCard';
 import Divider from '@weco/common/views/components/Divider/Divider';
@@ -72,20 +71,12 @@ const Outro: FC<Props> = ({
           properties: ['margin-top'],
         }}
         as="h2"
-        className={classNames({
-          h1: true,
-        })}
+        className="h1"
       >
         Try these next
       </Space>
 
-      <ul
-        className={classNames({
-          'no-margin': true,
-          'no-padding': true,
-          'plain-list': true,
-        })}
-      >
+      <ul className="no-margin no-padding plain-list">
         {[researchItem, readItem, visitItem]
           .filter(isNotUndefined)
           .map((item, index, arr) => {

--- a/content/webapp/components/PageHeaderStandfirst/PageHeaderStandfirst.tsx
+++ b/content/webapp/components/PageHeaderStandfirst/PageHeaderStandfirst.tsx
@@ -1,6 +1,5 @@
 import { FunctionComponent } from 'react';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
-import { classNames } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 import * as prismicT from '@prismicio/types';
 
@@ -14,10 +13,7 @@ const PageHeaderStandfirst: FunctionComponent<Props> = ({ html }: Props) => (
       size: 's',
       properties: ['margin-top'],
     }}
-    className={classNames({
-      'body-text': true,
-      'first-para-no-margin': true,
-    })}
+    className="body-text first-para-no-margin"
   >
     <PrismicHtmlBlock html={html} />
   </Space>

--- a/content/webapp/components/PartNumberIndicator/PartNumberIndicator.tsx
+++ b/content/webapp/components/PartNumberIndicator/PartNumberIndicator.tsx
@@ -1,4 +1,4 @@
-import { classNames, font } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import { ColorSelection } from '../../types/color-selections';
 import Number from '@weco/common/views/components/Number/Number';
 import { FunctionComponent, ReactElement } from 'react';
@@ -14,11 +14,7 @@ const PartNumberIndicator: FunctionComponent<Props> = ({
   color,
   description = 'Part',
 }: Props): ReactElement<Props> => (
-  <div
-    className={classNames({
-      [font('wb', 5)]: true,
-    })}
-  >
+  <div className={font('wb', 5)}>
     {description}
     <Number color={color} number={number} />
   </div>

--- a/content/webapp/components/Quote/Quote.tsx
+++ b/content/webapp/components/Quote/Quote.tsx
@@ -27,10 +27,9 @@ const Quote: FC<Props> = ({ text, citation, isPullOrReview }) => {
       {citation && (
         <footer className="quote__footer flex">
           <cite
-            className={`quote__cite flex flex--v-end font-pewter ${font(
-              'intr',
-              5
-            )}`}
+            className={
+              'quote__cite flex flex--v-end font-pewter' + ' ' + font('intr', 5)
+            }
           >
             <PrismicHtmlBlock html={citation} />
           </cite>

--- a/content/webapp/components/SimpleCardGrid/SimpleCardGrid.tsx
+++ b/content/webapp/components/SimpleCardGrid/SimpleCardGrid.tsx
@@ -1,4 +1,4 @@
-import { classNames, cssGrid } from '@weco/common/utils/classnames';
+import { cssGrid } from '@weco/common/utils/classnames';
 import { Card as CardType } from '../../types/card';
 import Card from '../Card/Card';
 import Layout12 from '@weco/common/views/components/Layout12/Layout12';
@@ -75,17 +75,7 @@ const CardGrid: FC<Props> = ({ items, isFeaturedFirst }: Props) => {
       <CssGridContainer>
         <div className="css-grid">
           {threeCards.map((item, i) => (
-            <div
-              key={i}
-              className={classNames({
-                [cssGrid({
-                  s: 12,
-                  m: 4,
-                  l: 4,
-                  xl: 4,
-                })]: true,
-              })}
-            >
+            <div key={i} className={cssGrid({ s: 12, m: 4, l: 4, xl: 4 })}>
               <Card item={item} />
             </div>
           ))}

--- a/content/webapp/components/TitledTextList/TitledTextList.tsx
+++ b/content/webapp/components/TitledTextList/TitledTextList.tsx
@@ -2,15 +2,13 @@ import { FunctionComponent } from 'react';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
 import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
 import Space from '@weco/common/views/components/styled/Space';
-import { classNames, font } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import styled from 'styled-components';
 import { LabelField } from '@weco/common/model/label-field';
 import * as prismicT from '@prismicio/types';
 
 const HeadingLink = styled.a.attrs({
-  className: classNames({
-    [font('intb', 4)]: true,
-  }),
+  className: font('intb', 4),
 })`
   cursor: pointer;
   text-decoration: underline;

--- a/content/webapp/pages/article.tsx
+++ b/content/webapp/pages/article.tsx
@@ -2,7 +2,7 @@ import { GetServerSideProps } from 'next';
 import { Fragment, FC, useState, useEffect, ReactElement } from 'react';
 import { Article } from '../types/articles';
 import { Series } from '../types/series';
-import { classNames, font } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import { capitalize } from '@weco/common/utils/grammar';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import HTMLDate from '@weco/common/views/components/HTMLDate/HTMLDate';
@@ -199,19 +199,9 @@ const ArticlePage: FC<Props> = ({ article, jsonLd }) => {
   const ContentTypeInfo = (
     <Fragment>
       {article.standfirst && <PageHeaderStandfirst html={article.standfirst} />}
-      <div
-        className={classNames({
-          flex: true,
-          'flex--h-baseline': true,
-        })}
-      >
+      <div className="flex flex--h-baseline">
         <Space v={{ size: 's', properties: ['margin-top'] }}>
-          <p
-            className={classNames({
-              'no-margin': true,
-              [font('intr', 6)]: true,
-            })}
-          >
+          <p className={`no-margin ${font('intr', 6)}`}>
             {article.contributors.length > 0 &&
               article.contributors.map(({ contributor, role }, i, arr) => (
                 <Fragment key={contributor.id}>
@@ -223,13 +213,7 @@ const ArticlePage: FC<Props> = ({ article, jsonLd }) => {
                       by{' '}
                     </span>
                   )}
-                  <span
-                    className={classNames({
-                      [font('intb', 6)]: true,
-                    })}
-                  >
-                    {contributor.name}
-                  </span>
+                  <span className={font('intb', 6)}>{contributor.name}</span>
                   <Space
                     as="span"
                     h={{
@@ -244,12 +228,7 @@ const ArticlePage: FC<Props> = ({ article, jsonLd }) => {
 
             {article.contributors.length > 0 && ' '}
 
-            <span
-              className={classNames({
-                'block font-pewter': true,
-                [font('intr', 6)]: true,
-              })}
-            >
+            <span className={`block font-pewter ${font('intr', 6)}`}>
               <HTMLDate date={article.datePublished} />
             </span>
           </p>

--- a/content/webapp/pages/book.tsx
+++ b/content/webapp/pages/book.tsx
@@ -4,7 +4,7 @@ import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
 import ButtonSolidLink from '@weco/common/views/components/ButtonSolidLink/ButtonSolidLink';
 import HTMLDate from '@weco/common/views/components/HTMLDate/HTMLDate';
-import { font, grid, classNames } from '@weco/common/utils/classnames';
+import { font, grid } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 import BookImage from '../components/BookImage/BookImage';
 import styled from 'styled-components';
@@ -130,14 +130,7 @@ const BookPage: FunctionComponent<Props> = props => {
       ContentTypeInfo={
         <Fragment>
           {book.subtitle && (
-            <p
-              className={classNames({
-                'no-margin': true,
-                [font('intb', 3)]: true,
-              })}
-            >
-              {book.subtitle}
-            </p>
+            <p className={`no-margin ${font('intb', 3)}`}>{book.subtitle}</p>
           )}
         </Fragment>
       }

--- a/content/webapp/pages/event.tsx
+++ b/content/webapp/pages/event.tsx
@@ -263,9 +263,7 @@ const EventPage: NextPage<Props> = ({ event, jsonLd }: Props) => {
               size: 's',
               properties: ['margin-bottom'],
             }}
-            className={classNames({
-              'flex flex--wrap': true,
-            })}
+            className="flex flex--wrap"
           >
             <EventDateRange event={event} />
             <Space h={{ size: 's', properties: ['margin-left'] }}>
@@ -392,10 +390,7 @@ const EventPage: NextPage<Props> = ({ event, jsonLd }: Props) => {
                       properties: ['margin-top'],
                     }}
                     as="a"
-                    className={classNames({
-                      'block font-charcoal': true,
-                      [font('intb', 5)]: true,
-                    })}
+                    className={`block font-charcoal ${font('intb', 5)}`}
                   >
                     <span>{event.bookingEnquiryTeam.email}</span>
                   </Space>

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -19,7 +19,7 @@ import { transformQuery } from '../services/prismic/transformers/paginated-resul
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import { FC, SyntheticEvent } from 'react';
 import { IconSvg } from '@weco/common/icons/types';
-import { font, classNames } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import { removeUndefinedProps } from '@weco/common/utils/json';
 import { getServerData } from '@weco/common/server-data';
 import { exhibitionGuideLd } from '../services/prismic/transformers/json-ld';
@@ -477,9 +477,7 @@ const ExhibitionGuidePage: FC<Props> = props => {
           <SpacingSection>
             <Space
               v={{ size: 'l', properties: ['margin-top'] }}
-              className={classNames({
-                [font('wb', 1)]: true,
-              })}
+              className={font('wb', 1)}
             >
               <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
                 <h1

--- a/content/webapp/pages/homepage.tsx
+++ b/content/webapp/pages/homepage.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react';
 import styled from 'styled-components';
-import { classNames, font } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import SectionHeader from '@weco/common/views/components/SectionHeader/SectionHeader';
 import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
 import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
@@ -156,9 +156,7 @@ const Homepage: FC<Props> = ({
         <SpacingSection>
           <Space
             v={{ size: 'l', properties: ['margin-top'] }}
-            className={classNames({
-              [font('wb', 1)]: true,
-            })}
+            className={font('wb', 1)}
           >
             <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
               <h1 className="no-margin">{homepageHeading}</h1>

--- a/content/webapp/pages/whats-on.tsx
+++ b/content/webapp/pages/whats-on.tsx
@@ -3,7 +3,7 @@ import NextLink from 'next/link';
 import { ExhibitionBasic } from '../types/exhibitions';
 import { EventBasic } from '../types/events';
 import { Period } from '../types/periods';
-import { classNames, font, grid, cssGrid } from '@weco/common/utils/classnames';
+import { font, grid, cssGrid } from '@weco/common/utils/classnames';
 import {
   getPageFeaturedText,
   transformPage,
@@ -129,9 +129,7 @@ export function getRangeForPeriod(period: Period): { start: Date; end?: Date } {
 //         properties: ['margin-bottom'],
 //       }}
 //       as="p"
-//       className={classNames({
-//         [font('wb', 2)]: true,
-//       })}
+//       className={font('wb', 2)}
 //     >
 //       Our exhibitions are closed today, but our <a href={cafePromo.url}>café</a>{' '}
 //       and <a href={shopPromo.url}>shop</a> are open for your visit.
@@ -159,9 +157,7 @@ const DateRange = ({ dateRange, period }: DateRangeProps) => {
         properties: ['margin-bottom'],
       }}
       as="p"
-      className={classNames({
-        [font('intr', 5)]: true,
-      })}
+      className={font('intr', 5)}
     >
       {period === 'today' && (
         <time dateTime={formatDate(start)}>{formatDate(start)}</time>
@@ -198,9 +194,7 @@ const Header = ({
         size: 'l',
         properties: ['padding-top'],
       }}
-      className={classNames({
-        row: true,
-      })}
+      className="row"
     >
       <div className="container">
         <div className="grid">
@@ -215,9 +209,7 @@ const Header = ({
                     <Space
                       as="span"
                       h={{ size: 'm', properties: ['margin-right'] }}
-                      className={classNames({
-                        [font('intb', 5)]: true,
-                      })}
+                      className={font('intb', 5)}
                     >
                       Galleries
                       {todaysOpeningHours.isClosed ? ' closed ' : ' open '}
@@ -235,9 +227,7 @@ const Header = ({
                         <Space
                           as="span"
                           h={{ size: 'm', properties: ['margin-right'] }}
-                          className={classNames({
-                            [font('intr', 5)]: true,
-                          })}
+                          className={font('intr', 5)}
                         >
                           <>
                             <time>{todaysOpeningHours.opens}</time>
@@ -250,11 +240,7 @@ const Header = ({
                   </div>
                 )}
                 <NextLink href="/opening-times" as="/opening-times">
-                  <a
-                    className={classNames({
-                      [font('intb', 5)]: true,
-                    })}
-                  >{`Full opening times`}</a>
+                  <a className={font('intb', 5)}>Full opening times</a>
                 </NextLink>
               </div>
             </div>
@@ -265,9 +251,7 @@ const Header = ({
                 size: 's',
                 properties: ['margin-top', 'margin-bottom'],
               }}
-              className={classNames({
-                [grid({ s: 12, m: 10, l: 8, xl: 8 })]: true,
-              })}
+              className={grid({ s: 12, m: 10, l: 8, xl: 8 })}
             >
               <FeaturedText
                 html={featuredText.value}
@@ -280,9 +264,7 @@ const Header = ({
               size: 'm',
               properties: ['margin-top', 'margin-bottom'],
             }}
-            className={classNames({
-              [grid({ s: 12, m: 10, l: 7, xl: 7 })]: true,
-            })}
+            className={grid({ s: 12, m: 10, l: 7, xl: 7 })}
           >
             <SegmentedControl
               ariaCurrentText="page"
@@ -548,17 +530,13 @@ const WhatsOnPage: FunctionComponent<Props> = props => {
           </SpacingComponent>
           <SpacingComponent>
             <CssGridContainer>
-              <div
-                className={classNames({
-                  'css-grid': true,
-                })}
-              >
+              <div className="css-grid">
                 <div
-                  className={classNames({
-                    'css-grid__scroll-container container--scroll touch-scroll':
-                      true,
-                    [cssGrid({ s: 12, m: 12, l: 12, xl: 12 })]: true,
-                  })}
+                  className={
+                    'css-grid__scroll-container container--scroll touch-scroll' +
+                    ' ' +
+                    cssGrid({ s: 12, m: 12, l: 12, xl: 12 })
+                  }
                 >
                   <div className="css-grid grid--scroll card-theme card-theme--transparent">
                     {tryTheseTooPromos.concat(eatShopPromos).map(promo => (

--- a/identity/webapp/src/frontend/MyAccount/ChangeEmail.tsx
+++ b/identity/webapp/src/frontend/MyAccount/ChangeEmail.tsx
@@ -16,7 +16,7 @@ import ButtonSolid, {
 } from '@weco/common/views/components/ButtonSolid/ButtonSolid';
 import Space from '@weco/common/views/components/styled/Space';
 import { useUser } from '@weco/common/views/components/UserProvider/UserProvider';
-import { font, classNames } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 
 type ChangeEmailInputs = {
   email: string;
@@ -93,22 +93,8 @@ export const ChangeEmail: React.FC<ChangeDetailsModalContentProps> = ({
         <StatusAlert type="failure">{submissionErrorMessage}</StatusAlert>
       )}
       <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
-        <h3
-          className={classNames({
-            [font('intb', 5)]: true,
-            'no-margin': true,
-          })}
-        >
-          Email
-        </h3>
-        <p
-          className={classNames({
-            [font('intr', 5)]: true,
-            'no-margin': true,
-          })}
-        >
-          {user?.email}
-        </p>
+        <h3 className={`${font('intb', 5)} no-margin`}>Email</h3>
+        <p className={`${font('intr', 5)} no-margin`}>{user?.email}</p>
       </Space>
       <form onSubmit={handleSubmit(onSubmit)}>
         <FieldMargin>

--- a/identity/webapp/src/frontend/MyAccount/DeleteAccount.tsx
+++ b/identity/webapp/src/frontend/MyAccount/DeleteAccount.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { classNames, font } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import { ErrorMessage } from '@hookform/error-message';
 import { FieldMargin } from '../components/Form.style';
 import { TextInputErrorMessage } from '@weco/common/views/components/TextInput/TextInput';
@@ -92,11 +92,7 @@ export const DeleteAccount: React.FC<ChangeDetailsModalContentProps> = ({
       {submissionErrorMessage && (
         <StatusAlert type="failure">{submissionErrorMessage}</StatusAlert>
       )}
-      <div
-        className={classNames({
-          [font('intr', 5)]: true,
-        })}
-      >
+      <div className={font('intr', 5)}>
         <p>
           Are you sure you want to delete your account? Your account will be
           closed and you won’t be able to request any items.

--- a/identity/webapp/src/frontend/components/PasswordInput/PasswordInput.style.ts
+++ b/identity/webapp/src/frontend/components/PasswordInput/PasswordInput.style.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import Space from '@weco/common/views/components/styled/Space';
-import { classNames, font } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 
 export const ShowPasswordButton = styled.button.attrs({ type: 'button' })`
   height: 55px;
@@ -12,9 +12,7 @@ export const ShowPasswordButton = styled.button.attrs({ type: 'button' })`
 export const RulesListWrapper = styled(Space).attrs({
   h: { size: 'm', properties: ['padding-left', 'padding-right'] },
   v: { size: 'm', properties: ['padding-top', 'padding-bottom'] },
-  className: classNames({
-    [font('intr', 5)]: true,
-  }),
+  className: font('intr', 5),
 })`
   border: 1px solid ${props => props.theme.color('smoke')};
   border-radius: ${props => props.theme.borderRadiusUnit}px;


### PR DESCRIPTION
We only need to use classNames when there's a condition that might mean a style isn't being used.  If all the conditions are `true`, we can remove the function and replace it with a string interpolation.

Note: in a few cases, I've made what might seem like non-obvious choices for formatting the string, e.g. in Quote.tsx:

```typescript
className={
  'quote__cite flex flex--v-end font-pewter' + ' ' + font('intr', 5)
}
```

rather than

```typescript
className={
  `quote__cite flex flex--v-end font-pewter ${font('intr', 5)}`
}
```

This is me fighting the auto-formatter and trying to preserve readability; in that example, the code gets formatted as

```typescript
className={
  `quote__cite flex flex--v-end font-pewter ${font(
    'intr',
     5
  )}`
}
```

which seems far less readable to me.  I've tried to keep small functions like `font()` and `grid()` on a single line, even if it means making the overall className look a bit different.

For #8419