### PR TITLE
Remember to serialise API results using superjson

### DIFF
--- a/content/webapp/components/SeriesNavigation/SeriesNavigation.tsx
+++ b/content/webapp/components/SeriesNavigation/SeriesNavigation.tsx
@@ -3,14 +3,14 @@ import MoreLink from '@weco/common/views/components/MoreLink/MoreLink';
 import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
 import Layout8 from '@weco/common/views/components/Layout8/Layout8';
 import { Series } from '../../types/series';
-import { Article } from '../../types/articles';
+import { ArticleBasic } from '../../types/articles';
 import { ArticleScheduleItem } from '../../types/article-schedule-items';
 import Space from '@weco/common/views/components/styled/Space';
 import SearchResults from '../SearchResults/SearchResults';
 
 type Props = {
   series: Series;
-  items: readonly (Article | ArticleScheduleItem)[];
+  items: readonly (ArticleBasic | ArticleScheduleItem)[];
   isPodcast: boolean;
 };
 

--- a/content/webapp/pages/api/articles/index.ts
+++ b/content/webapp/pages/api/articles/index.ts
@@ -3,7 +3,10 @@ import { isNotUndefined, isString } from '@weco/common/utils/array';
 import { createClient } from '../../../services/prismic/fetch';
 import { fetchArticles } from '../../../services/prismic/fetch/articles';
 import { transformQuery } from '../../../services/prismic/transformers/paginated-results';
-import { transformArticle } from '../../../services/prismic/transformers/articles';
+import {
+  transformArticle,
+  transformArticleToArticleBasic,
+} from '../../../services/prismic/transformers/articles';
 import superjson from 'superjson';
 
 type NotFound = { notFound: true };
@@ -20,7 +23,9 @@ export default async (
     const query = await fetchArticles(client, parsedParams);
 
     if (query) {
-      const articles = transformQuery(query, transformArticle);
+      const articles = transformQuery(query, article =>
+        transformArticleToArticleBasic(transformArticle(article))
+      );
       return res.status(200).json(superjson.stringify(articles));
     }
   }

--- a/content/webapp/pages/api/articles/index.ts
+++ b/content/webapp/pages/api/articles/index.ts
@@ -4,15 +4,13 @@ import { createClient } from '../../../services/prismic/fetch';
 import { fetchArticles } from '../../../services/prismic/fetch/articles';
 import { transformQuery } from '../../../services/prismic/transformers/paginated-results';
 import { transformArticle } from '../../../services/prismic/transformers/articles';
-import { PaginatedResults } from '@weco/common/services/prismic/types';
-import { Article } from '../../../types/articles';
+import superjson from 'superjson';
 
-type Data = PaginatedResults<Article>;
 type NotFound = { notFound: true };
 
 export default async (
   req: NextApiRequest,
-  res: NextApiResponse<Data | NotFound>
+  res: NextApiResponse<string | NotFound>
 ): Promise<void> => {
   const { params } = req.query;
   const parsedParams = isString(params) ? JSON.parse(params) : undefined;
@@ -23,7 +21,7 @@ export default async (
 
     if (query) {
       const articles = transformQuery(query, transformArticle);
-      return res.status(200).json(articles);
+      return res.status(200).json(superjson.stringify(articles));
     }
   }
 

--- a/content/webapp/pages/api/events/index.ts
+++ b/content/webapp/pages/api/events/index.ts
@@ -2,17 +2,15 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import { isNotUndefined, isString } from '@weco/common/utils/array';
 import { createClient } from '../../../services/prismic/fetch';
 import { fetchEvents } from '../../../services/prismic/fetch/events';
-import { PaginatedResults } from '@weco/common/services/prismic/types';
-import { Event } from '../../../types/events';
 import { transformEvent } from '../../../services/prismic/transformers/events';
 import { transformQuery } from '../../../services/prismic/transformers/paginated-results';
+import superjson from 'superjson';
 
-type Data = PaginatedResults<Event>;
 type NotFound = { notFound: true };
 
 export default async (
   req: NextApiRequest,
-  res: NextApiResponse<Data | NotFound>
+  res: NextApiResponse<string | NotFound>
 ): Promise<void> => {
   const { params } = req.query;
   const parsedParams = isString(params) ? JSON.parse(params) : undefined;
@@ -23,7 +21,7 @@ export default async (
 
     if (query) {
       const events = transformQuery(query, transformEvent);
-      return res.status(200).json(events);
+      return res.status(200).json(superjson.stringify(events));
     }
   }
 

--- a/content/webapp/pages/api/exhibitions-related-content/index.ts
+++ b/content/webapp/pages/api/exhibitions-related-content/index.ts
@@ -3,15 +3,14 @@ import { isString } from '@weco/common/utils/array';
 import { createClient } from '../../../services/prismic/fetch';
 import { fetchExhibitionRelatedContent } from '../../../services/prismic/fetch/exhibitions';
 import { transformExhibitionRelatedContent } from '../../../services/prismic/transformers/exhibitions';
-import { ExhibitionRelatedContent } from '../../../types/exhibitions';
+import superjson as 'superjson';
 
-type Data = ExhibitionRelatedContent;
 type NotFound = { notFound: true };
 type UserError = { description: string };
 
 export default async (
   req: NextApiRequest,
-  res: NextApiResponse<Data | NotFound | UserError>
+  res: NextApiResponse<string | NotFound | UserError>
 ): Promise<void> => {
   const { params } = req.query;
 
@@ -33,7 +32,7 @@ export default async (
 
   if (query) {
     const exhibitions = transformExhibitionRelatedContent(query);
-    return res.status(200).json(exhibitions);
+    return res.status(200).json(superjson.stringify(exhibitions));
   }
 
   return res.status(404).json({ notFound: true });

--- a/content/webapp/pages/api/exhibitions-related-content/index.ts
+++ b/content/webapp/pages/api/exhibitions-related-content/index.ts
@@ -22,10 +22,12 @@ export default async (
   const client = createClient({ req });
 
   if (parsedParams.length === 0) {
-    return res.status(200).json({
-      exhibitionOfs: [],
-      exhibitionAbouts: [],
-    });
+    return res.status(200).json(
+      superjson.stringify({
+        exhibitionOfs: [],
+        exhibitionAbouts: [],
+      })
+    );
   }
 
   const query = await fetchExhibitionRelatedContent(client, parsedParams);

--- a/content/webapp/pages/api/exhibitions-related-content/index.ts
+++ b/content/webapp/pages/api/exhibitions-related-content/index.ts
@@ -3,7 +3,7 @@ import { isString } from '@weco/common/utils/array';
 import { createClient } from '../../../services/prismic/fetch';
 import { fetchExhibitionRelatedContent } from '../../../services/prismic/fetch/exhibitions';
 import { transformExhibitionRelatedContent } from '../../../services/prismic/transformers/exhibitions';
-import superjson as 'superjson';
+import superjson from 'superjson';
 
 type NotFound = { notFound: true };
 type UserError = { description: string };

--- a/content/webapp/pages/api/exhibitions/index.ts
+++ b/content/webapp/pages/api/exhibitions/index.ts
@@ -3,15 +3,13 @@ import { isNotUndefined, isString } from '@weco/common/utils/array';
 import { createClient } from '../../../services/prismic/fetch';
 import { fetchExhibitions } from '../../../services/prismic/fetch/exhibitions';
 import { transformExhibitionsQuery } from '../../../services/prismic/transformers/exhibitions';
-import { PaginatedResults } from '@weco/common/services/prismic/types';
-import { ExhibitionBasic } from '../../../types/exhibitions';
+import superjson from 'superjson';
 
-type Data = PaginatedResults<ExhibitionBasic>;
 type NotFound = { notFound: true };
 
 export default async (
   req: NextApiRequest,
-  res: NextApiResponse<Data | NotFound>
+  res: NextApiResponse<string | NotFound>
 ): Promise<void> => {
   const { params } = req.query;
   const parsedParams = isString(params) ? JSON.parse(params) : undefined;
@@ -22,7 +20,7 @@ export default async (
 
     if (query) {
       const exhibitions = transformExhibitionsQuery(query);
-      return res.status(200).json(exhibitions);
+      return res.status(200).json(superjson.stringify(exhibitions));
     }
   }
 

--- a/content/webapp/pages/article.tsx
+++ b/content/webapp/pages/article.tsx
@@ -1,6 +1,6 @@
 import { GetServerSideProps } from 'next';
 import { Fragment, FC, useState, useEffect, ReactElement } from 'react';
-import { Article } from '../types/articles';
+import { Article, ArticleBasic } from '../types/articles';
 import { Series } from '../types/series';
 import { classNames, font } from '@weco/common/utils/classnames';
 import { capitalize } from '@weco/common/utils/grammar';
@@ -73,12 +73,12 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
 
 type ArticleSeriesList = {
   series: Series;
-  articles: Article[];
+  articles: ArticleBasic[];
 }[];
 
 function getNextUp(
   series: Series,
-  articles: Article[],
+  articles: ArticleBasic[],
   article: Article,
   currentPosition: number | undefined,
   isPodcast: boolean

--- a/content/webapp/services/prismic/fetch/articles.ts
+++ b/content/webapp/services/prismic/fetch/articles.ts
@@ -7,7 +7,7 @@ import {
 } from '.';
 import { ArticlePrismicDocument, articlesFetchLinks } from '../types/articles';
 import { ContentType } from '@weco/common/services/prismic/content-types';
-import { Article } from '../../../types/articles';
+import { Article, ArticleBasic } from '../../../types/articles';
 
 const contentTypes: ContentType[] = ['articles', 'webcomics'];
 const fetchLinks = articlesFetchLinks;
@@ -339,4 +339,4 @@ export const fetchArticles = (
 };
 
 export const fetchArticlesClientSide =
-  clientSideFetcher<Article>('articles').getByTypeClientSide;
+  clientSideFetcher<ArticleBasic>('articles').getByTypeClientSide;

--- a/content/webapp/services/prismic/fetch/index.ts
+++ b/content/webapp/services/prismic/fetch/index.ts
@@ -5,6 +5,7 @@ import { GetServerSidePropsContext, NextApiRequest } from 'next';
 import { ContentType } from '@weco/common/services/prismic/content-types';
 import { isString } from '@weco/common/utils/array';
 import { PaginatedResults } from '@weco/common/services/prismic/types';
+import superjson from 'superjson';
 
 const endpoint = prismic.getEndpoint('wellcomecollection');
 const client = prismic.createClient(endpoint, { fetch });
@@ -156,9 +157,8 @@ export function clientSideFetcher<TransformedDocument>(endpoint: string) {
       const response = await fetch(url);
 
       if (response.ok) {
-        const json: PaginatedResults<TransformedDocument> =
-          await response.json();
-        return json;
+        const json = await response.text();
+        return superjson.parse<PaginatedResults<TransformedDocument>>(json);
       }
     },
   };


### PR DESCRIPTION
If you look at a page with related content (e.g. https://wellcomecollection.org/articles/YdQ6AhAAAJMQ5mEg), we fetch the related content asynchronously through the content API (e.g. `/api/articles`). This means it bypasses the superjson handling we use in `getServerSideProps`, and all your `Date` values are strings. This breaks as soon as you try to treat a string date as a `Date`, and the page returns a 404. Sadness.

This patch:

* Uses superjson to serialise and deserialise content in these APIs, so `Date` values will be preserved (cf #8396)
* Only sends an `ArticleBasic` through the articles API, not the full article – this cuts the response from 281KB to 14KB, a 20x reduction (!)

I've tested it locally, and the broken article is no longer breaking.