### PR TITLE
Re-add what's on anchors for no-JS

### DIFF
--- a/content/webapp/components/EventsByMonth/EventsByMonth.tsx
+++ b/content/webapp/components/EventsByMonth/EventsByMonth.tsx
@@ -80,6 +80,15 @@ class EventsByMonth extends Component<Props, State> {
                 : 'none',
             }}
           >
+            <h2
+              className={classNames({
+                container: true,
+                'is-hidden': Boolean(activeId),
+              })}
+              id={g.id}
+            >
+              {g.month.month}
+            </h2>
             <CardGrid
               items={g.events}
               itemsPerRow={3}


### PR DESCRIPTION
## Who is this for?
People without JS

## What is it doing for them?
Giving them anchor links within the what's on page so they can jump to the appropriate month

This used to display YYYY-MM – we don't have obvious access to that format anymore, but I don't think it's important. I've changed it to be the name of the month (without the year, because that seemed superfluous) and I think that's probably ok(/preferable).

<img width="1162" alt="image" src="https://user-images.githubusercontent.com/1394592/189626373-a382e71e-e216-425b-9d76-3d093f5a82e1.png">
