### PR TITLE
Account for exceptional closures in requesting date logic

### DIFF
--- a/catalogue/webapp/components/ItemRequestModal/useAvailableDates.ts
+++ b/catalogue/webapp/components/ItemRequestModal/useAvailableDates.ts
@@ -30,6 +30,7 @@ export const useAvailableDates = (): AvailableDates => {
   const libraryVenue = getVenueById(venues, collectionVenueId.libraries.id);
 
   const regularLibraryOpeningTimes = libraryVenue?.openingHours.regular || [];
+
   const closedDays = findClosedDays(regularLibraryOpeningTimes).map(
     convertOpeningHoursDayToDayNumber
   );
@@ -42,7 +43,11 @@ export const useAvailableDates = (): AvailableDates => {
     })
     .filter(Boolean);
 
-  const nextAvailable = determineNextAvailableDate(today(), closedDays);
+  const nextAvailable = determineNextAvailableDate(
+    today(),
+    closedDays,
+    exceptionalClosedDates
+  );
 
   // There should be a minimum of a 2 week window in which to select a date
   const minimumLastAvailable = nextAvailable && addDays(nextAvailable, 13);

--- a/catalogue/webapp/components/ItemRequestModal/useAvailableDates.ts
+++ b/catalogue/webapp/components/ItemRequestModal/useAvailableDates.ts
@@ -30,7 +30,6 @@ export const useAvailableDates = (): AvailableDates => {
   const libraryVenue = getVenueById(venues, collectionVenueId.libraries.id);
 
   const regularLibraryOpeningTimes = libraryVenue?.openingHours.regular || [];
-
   const closedDays = findClosedDays(regularLibraryOpeningTimes).map(
     convertOpeningHoursDayToDayNumber
   );

--- a/catalogue/webapp/test/utils/dates.test.ts
+++ b/catalogue/webapp/test/utils/dates.test.ts
@@ -200,7 +200,7 @@ describe('determineNextAvailableDate', () => {
     expect(result1).toEqual(new Date('2021-12-10T09:30:00Z'));
 
     // Paris is an hour ahead of London, so a request made at 11:30 in Paris is
-    // at 19:30 in London -- it can’t be fulfilled the next day.
+    // at 10:30 in London -- it can’t be fulfilled the next day.
     const date2 = new Date('2021-12-09T11:30:00+0100');
 
     const result2 = determineNextAvailableDate(date2, [0], []);

--- a/catalogue/webapp/test/utils/dates.test.ts
+++ b/catalogue/webapp/test/utils/dates.test.ts
@@ -178,7 +178,7 @@ describe('determineNextAvailableDate', () => {
       new Date('2021-12-10 10:30'),
       [0],
       []
-    ); // Sunday
+    );
     expect(result).toEqual(new Date('2021-12-14 10:30')); // Tuesday
   });
 
@@ -223,7 +223,7 @@ describe('determineNextAvailableDate', () => {
       new Date('2021-12-10 10:30'), // Friday
       [0],
       [exceptionalClosure]
-    ); // Sunday
+    );
     expect(result).toEqual(new Date('2021-12-15 10:30')); // Wednesday
   });
 });

--- a/catalogue/webapp/test/utils/dates.test.ts
+++ b/catalogue/webapp/test/utils/dates.test.ts
@@ -131,21 +131,24 @@ describe('findNextPickUpDay: finds the earliest date on which requested items ca
   it('returns the same date provided if it occurs on one of the regular open days', () => {
     const result = findNextPickUpDay(
       new Date('2022-01-15'), // Saturday
-      [0, 1, 2] // Sunday, Monday, Tuesday
+      [0, 1, 2], // Sunday, Monday, Tuesday,
+      []
     );
     expect(result).toEqual(new Date('2022-01-15')); // Saturday
   });
   it('leaves a full working day between the request and retrieval', () => {
     const result = findNextPickUpDay(
       new Date('2022-01-16'), // Sunday
-      [0, 1, 2] // Sunday, Monday, Tuesday
+      [0, 1, 2], // Sunday, Monday, Tuesday
+      []
     );
     expect(result).toEqual(new Date('2022-01-20')); // Thursday
   });
   it("doesn't return a date if there are no regular days that are open", () => {
     const result = findNextPickUpDay(
       new Date('2022-01-16'), // Sunday
-      [0, 1, 2, 3, 4, 5, 6]
+      [0, 1, 2, 3, 4, 5, 6],
+      []
     );
     expect(result).toBeUndefined();
   });
@@ -153,26 +156,37 @@ describe('findNextPickUpDay: finds the earliest date on which requested items ca
 
 describe('determineNextAvailableDate', () => {
   it('adds a single day to the current date, if the time is before 10am', () => {
-    const result = determineNextAvailableDate(new Date('2021-12-9 09:00'), [0]);
+    const result = determineNextAvailableDate(
+      new Date('2021-12-9 09:00'),
+      [0],
+      []
+    );
     expect(result).toEqual(new Date('2021-12-10 09:00'));
   });
 
   it('adds 2 days to the current date, if the time is after 10am', () => {
-    const result = determineNextAvailableDate(new Date('2021-12-9 11:00'), [0]);
+    const result = determineNextAvailableDate(
+      new Date('2021-12-9 11:00'),
+      [0],
+      []
+    );
     expect(result).toEqual(new Date('2021-12-11 11:00'));
   });
 
   it('defers weekend requests until Tuesday, to avoid a rush of retrievals on Monday', () => {
-    const result = determineNextAvailableDate(new Date('2021-12-10 10:30'), [
-      0,
-    ]); // Sunday
+    const result = determineNextAvailableDate(
+      new Date('2021-12-10 10:30'),
+      [0],
+      []
+    ); // Sunday
     expect(result).toEqual(new Date('2021-12-14 10:30')); // Tuesday
   });
 
   it("doesn't return a date if there are no regular days that are open", () => {
     const result = determineNextAvailableDate(
       new Date(),
-      [0, 1, 2, 3, 4, 5, 6]
+      [0, 1, 2, 3, 4, 5, 6],
+      []
     );
     expect(result).toBeUndefined();
   });
@@ -182,25 +196,35 @@ describe('determineNextAvailableDate', () => {
     // at 09:30 in London -- it can be fulfilled the next day.
     const date1 = new Date('2021-12-09T10:30:00+0100');
 
-    const result1 = determineNextAvailableDate(date1, [0]);
+    const result1 = determineNextAvailableDate(date1, [0], []);
     expect(result1).toEqual(new Date('2021-12-10T09:30:00Z'));
 
     // Paris is an hour ahead of London, so a request made at 11:30 in Paris is
     // at 19:30 in London -- it can’t be fulfilled the next day.
     const date2 = new Date('2021-12-09T11:30:00+0100');
 
-    const result2 = determineNextAvailableDate(date2, [0]);
+    const result2 = determineNextAvailableDate(date2, [0], []);
     expect(result2).toEqual(new Date('2021-12-11T10:30:00Z'));
 
     // Now run the same tests, but now during British Summer Time when London
     // and UTC are different.
     const date3 = new Date('2022-09-06T10:30:00+0200');
-    const result3 = determineNextAvailableDate(date3, [0]);
+    const result3 = determineNextAvailableDate(date3, [0], []);
     expect(result3).toEqual(new Date('2022-09-07T09:30:00+0100'));
 
     const date4 = new Date('2022-09-06T11:30:00+0200');
-    const result4 = determineNextAvailableDate(date4, [0]);
+    const result4 = determineNextAvailableDate(date4, [0], []);
     expect(result4).toEqual(new Date('2022-09-08T10:30:00+0100'));
+  });
+
+  it('accounts for exceptional closure dates', () => {
+    const exceptionalClosure = new Date('2021-12-13'); // Monday
+    const result = determineNextAvailableDate(
+      new Date('2021-12-10 10:30'), // Friday
+      [0],
+      [exceptionalClosure]
+    ); // Sunday
+    expect(result).toEqual(new Date('2021-12-15 10:30')); // Wednesday
   });
 });
 

--- a/catalogue/webapp/utils/dates.ts
+++ b/catalogue/webapp/utils/dates.ts
@@ -76,12 +76,10 @@ export function findNextPickUpDay(
   const nextDay = addDays(date, 1);
   const isClosedThisDay =
     regularClosedDays.includes(date.getDay() as DayNumber) ||
-    exceptionalClosedDates.find(d => d.toDateString() === date.toDateString());
+    exceptionalClosedDates.find(d => isSameDay(d, date, 'London'));
   const isOpenNextDay =
     !regularClosedDays.includes(nextDay.getDay() as DayNumber) &&
-    !exceptionalClosedDates.find(
-      d => d.toDateString() === nextDay.toDateString()
-    );
+    !exceptionalClosedDates.find(d => isSameDay(d, nextDay, 'London'));
 
   if (isClosedThisDay && isOpenNextDay) {
     return findNextPickUpDay(

--- a/catalogue/webapp/utils/dates.ts
+++ b/catalogue/webapp/utils/dates.ts
@@ -108,6 +108,8 @@ export function determineNextAvailableDate(
   const hourInLondon = Number(
     date.toLocaleString('en-GB', { hour: 'numeric', timeZone: 'Europe/London' })
   );
+  // If a request is made before 10am, the next _potential_ pick-up date is the
+  // next day otherwise, it is two days' time.
   const isBeforeTen = hourInLondon < 10;
   const nextAvailableDate = addDays(date, isBeforeTen ? 1 : 2);
 

--- a/catalogue/webapp/utils/dates.ts
+++ b/catalogue/webapp/utils/dates.ts
@@ -66,7 +66,6 @@ export function findNextPickUpDay(
     // All days are closed, so we'll never be able to find a non closed day.
     return undefined;
   }
-  console.log({ date });
 
   // If the library is closed on this day, we want to set the pick-up day to be
   // the next open day plus one, so that e.g. Monday morning isn't a scramble


### PR DESCRIPTION
Up till now, we haven't taken any e.g. bank holidays into account when determining the next available pick-up date for requested items.

With this change, if a request is made after 10am on a Friday and the following Monday is a bank holiday, the next available pick-up date will be the following Wednesday (at present, it would be the Tuesday).