### PR TITLE
Change property name to fix test

### DIFF
--- a/catalogue/webapp/components/IIIFImage/IIIFImage.tsx
+++ b/catalogue/webapp/components/IIIFImage/IIIFImage.tsx
@@ -14,9 +14,9 @@ import {
 } from '@weco/common/views/components/PrismicImage/PrismicImage';
 
 const StyledImage = styled(Image).attrs({ className: 'font-charcoal' })<{
-  bgColor: string;
+  background: string;
 }>`
-  background-color: ${props => props.theme.color(props.bgColor)};
+  background-color: ${props => props.theme.color(props.background)};
 `;
 
 const IIIFLoader = ({ src, width }: ImageLoaderProps) => {
@@ -33,7 +33,7 @@ export type Props = {
   layout: 'raw' | 'fill' | 'fixed';
   priority?: boolean;
   width?: number;
-  bgColor?: string;
+  background?: string;
 };
 
 const IIIFImage: FC<Props> = ({
@@ -43,7 +43,7 @@ const IIIFImage: FC<Props> = ({
   layout,
   priority = false,
   width = 300,
-  bgColor = 'white',
+  background = 'white',
 }) => {
   const sizesString = sizes
     ? convertBreakpointSizesToSizes(sizes).join(', ')
@@ -79,7 +79,7 @@ const IIIFImage: FC<Props> = ({
         priority={priority}
         placeholder="blur"
         blurDataURL={transparentGreyPNG}
-        bgColor={bgColor}
+        background={background}
       />
     );
   }
@@ -94,7 +94,7 @@ const IIIFImage: FC<Props> = ({
       onLoadingComplete={onLoadingComplete}
       objectFit="contain"
       priority={priority}
-      bgColor={bgColor}
+      background={background}
     />
   );
 };

--- a/catalogue/webapp/components/ImageCard/ImageCard.tsx
+++ b/catalogue/webapp/components/ImageCard/ImageCard.tsx
@@ -15,7 +15,7 @@ type Props = {
   image: ImageType;
   layout: 'raw' | 'fill' | 'fixed';
   onClick: (event: SyntheticEvent<HTMLAnchorElement>) => void;
-  bgColor?: string;
+  background?: string;
 };
 
 const StyledLink = styled.a<{
@@ -35,7 +35,7 @@ const ImageCard: FC<Props> = ({
   image,
   layout,
   onClick,
-  bgColor,
+  background,
 }: Props) => {
   const { isEnhanced } = useContext(AppContext);
 
@@ -55,7 +55,7 @@ const ImageCard: FC<Props> = ({
         width={image.width}
         height={image.height}
       >
-        <IIIFImage image={image} layout={layout} bgColor={bgColor} />
+        <IIIFImage image={image} layout={layout} background={background} />
       </StyledLink>
     </NextLink>
   );

--- a/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
+++ b/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
@@ -19,7 +19,7 @@ import Space from '@weco/common/views/components/styled/Space';
 
 type Props = {
   images: CatalogueResultsList<Image>;
-  bgColor?: string;
+  background?: string;
 };
 
 type GalleryImageProps = Image & {
@@ -57,7 +57,7 @@ const ImageContainer = styled.li`
 
 const ImageEndpointSearchResults: FunctionComponent<Props> = ({
   images,
-  bgColor,
+  background,
 }: Props) => {
   const { isFullSupportBrowser } = useContext(AppContext);
   const [expandedImage, setExpandedImage] = useState<Image | undefined>();
@@ -102,7 +102,7 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
             setIsActive(true);
           }}
           layout="fixed"
-          bgColor={bgColor}
+          background={background}
         />
       </ImageContainer>
     );
@@ -151,7 +151,7 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
                     }
                   }}
                   layout="fill"
-                  bgColor={bgColor}
+                  background={background}
                 />
               </Space>
             </li>

--- a/catalogue/webapp/pages/concept.tsx
+++ b/catalogue/webapp/pages/concept.tsx
@@ -169,7 +169,10 @@ export const ConceptPage: NextPage<Props> = ({
         >
           <div className="container">
             <h2 className="sectionTitle font-size-2">Images</h2>
-            <ImageEndpointSearchResults images={images} bgColor="transparent" />
+            <ImageEndpointSearchResults
+              images={images}
+              background="transparent"
+            />
             <SeeMoreButton
               text={`All images (${images.totalResults})`}
               link={`/images?source.subjects.label=${conceptResponse.label}`}


### PR DESCRIPTION
## Who is this for?
Devs - blocked by broken e2e in staging

## What is it doing for them?
Fixes e2e test that fails
```
 React does not recognize the `bgColor` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `bgcolor` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```