### PR TITLE
Fix images test

### DIFF
--- a/playwright/test/images.test.ts
+++ b/playwright/test/images.test.ts
@@ -51,7 +51,7 @@ test.describe('Image search', () => {
     } else {
       await clickActionColourDropDown(page);
       await selectColourInPicker(page);
-      await page.click('body');
+      await clickActionColourDropDown(page);
     }
     await expectItemIsVisible(searchResultsContainer, page);
     await expectItemsIsVisible(imagesResultsListItem, 1, page);


### PR DESCRIPTION
## Who is this for?
Devs

## What is it doing for them?
Fixes [images test failing ](https://buildkite.com/wellcomecollection/wc-dot-org-end-to-end-tests/builds/1666#01833687-9022-40d6-9457-ec800d5811ba) by closing the color filter modal in a different way