### PR TITLE
Reinstate text slices on landing pages

### DIFF
--- a/content/webapp/components/Body/Body.tsx
+++ b/content/webapp/components/Body/Body.tsx
@@ -97,7 +97,7 @@ const Wrapper = styled(Space).attrs<{
   rowBackgroundColor: string;
   cardBackgroundColor: string;
 }>(props => ({
-  className: `row card-theme 
+  className: `row card-theme
   bg-${props.rowBackgroundColor}
     card-theme--${props.cardBackgroundColor}`, // Keeping bg-[color] class as some components below are styled based on this parent class.
 }))<{ rowBackgroundColor: string; cardBackgroundColor: string }>`
@@ -311,215 +311,216 @@ const Body: FunctionComponent<Props> = ({
             isLanding={isLanding}
             staticContent={staticContent}
           />
-          {!(i === 0 && slice.type === 'text' && slice.weight === 'featured') &&
-            !isLanding && (
-              <SpacingComponent>
-                <div>
-                  {slice.type === 'text' && (
-                    <LayoutWidth width={minWidth}>
-                      <div className="body-text spaced-text">
-                        {slice.weight !== 'featured' &&
-                          (firstTextSliceIndex === i && isDropCapped ? (
-                            <>
-                              {/*
+          {!(
+            i === 0 &&
+            slice.type === 'text' &&
+            slice.weight === 'featured'
+          ) && (
+            <SpacingComponent>
+              <div>
+                {slice.type === 'text' && (
+                  <LayoutWidth width={minWidth}>
+                    <div className="body-text spaced-text">
+                      {slice.weight !== 'featured' &&
+                        (firstTextSliceIndex === i && isDropCapped ? (
+                          <>
+                            {/*
                               The featured text slice can contain multiple paragraphs,
                               e.g. https://wellcomecollection.org/articles/XcMBBREAACUAtBoV
 
                               The drop cap serializer will see them as two separate paragraphs,
                               so we have to split out the first paragraph here.
                             */}
-                              <PrismicHtmlBlock
-                                html={
-                                  [slice.value[0]] as prismicT.RichTextField
-                                }
-                                htmlSerializer={dropCapSerializer}
-                              />
-                              <PrismicHtmlBlock
-                                html={
-                                  slice.value.slice(1) as prismicT.RichTextField
-                                }
-                                htmlSerializer={defaultSerializer}
-                              />
-                            </>
-                          ) : (
                             <PrismicHtmlBlock
-                              html={slice.value}
+                              html={[slice.value[0]] as prismicT.RichTextField}
+                              htmlSerializer={dropCapSerializer}
+                            />
+                            <PrismicHtmlBlock
+                              html={
+                                slice.value.slice(1) as prismicT.RichTextField
+                              }
                               htmlSerializer={defaultSerializer}
                             />
-                          ))}
-                      </div>
-                    </LayoutWidth>
-                  )}
+                          </>
+                        ) : (
+                          <PrismicHtmlBlock
+                            html={slice.value}
+                            htmlSerializer={defaultSerializer}
+                          />
+                        ))}
+                    </div>
+                  </LayoutWidth>
+                )}
 
-                  {/* TODO: use one layout for all image weights if/when it's established
+                {/* TODO: use one layout for all image weights if/when it's established
               that width isn't an adequate means to illustrate a difference */}
-                  {slice.type === 'picture' && slice.weight === 'default' && (
-                    <Layout10>
-                      <CaptionedImage {...slice.value} />
-                    </Layout10>
-                  )}
-                  {slice.type === 'picture' && slice.weight === 'standalone' && (
-                    <Layout12>
-                      <CaptionedImage {...slice.value} />
-                    </Layout12>
-                  )}
-                  {slice.type === 'picture' && slice.weight === 'supporting' && (
-                    <LayoutWidth width={minWidth}>
-                      <CaptionedImage {...slice.value} />
-                    </LayoutWidth>
-                  )}
-                  {slice.type === 'imageGallery' && (
-                    <ImageGallery {...slice.value} id={imageGalleryIdCount++} />
-                  )}
-                  {slice.type === 'quote' && (
-                    <LayoutWidth width={minWidth}>
-                      <Quote {...slice.value} />
-                    </LayoutWidth>
-                  )}
-                  {slice.type === 'titledTextList' && (
-                    <LayoutWidth width={minWidth}>
-                      <TitledTextList {...slice.value} />
-                    </LayoutWidth>
-                  )}
-                  {slice.type === 'contentList' && (
-                    <LayoutWidth width={minWidth}>
-                      {/* FIXME: this makes what-we-do contentLists synchronous, but it's hacky. */}
-                      {pageId === prismicPageIds.whatWeDo ? (
-                        <SearchResults
-                          title={slice.value.title}
-                          items={slice.value.items}
-                        />
-                      ) : (
-                        <AsyncSearchResults
-                          title={slice.value.title}
-                          query={slice.value.items
-                            .map(item =>
-                              'id' in item ? `id:${item.id}` : undefined
-                            )
-                            .filter(isNotUndefined)
-                            .join(' ')}
-                        />
-                      )}
-                    </LayoutWidth>
-                  )}
-                  {/* TODO: remove this slice type if we're not using it? */}
-                  {slice.type === 'searchResults' && (
-                    <LayoutWidth width={minWidth}>
-                      <AsyncSearchResults {...slice.value} />
-                    </LayoutWidth>
-                  )}
-                  {slice.type === 'videoEmbed' && (
-                    <LayoutWidth width={minWidth}>
-                      <VideoEmbed {...slice.value} />
-                    </LayoutWidth>
-                  )}
-                  {slice.type === 'soundcloudEmbed' && (
-                    <LayoutWidth width={minWidth}>
-                      <SoundCloudEmbed {...slice.value} />
-                    </LayoutWidth>
-                  )}
-                  {slice.type === 'map' && (
-                    <LayoutWidth width={minWidth}>
-                      <Map {...slice.value} />
-                    </LayoutWidth>
-                  )}
-                  {slice.type === 'gifVideo' && (
-                    <Layout10>
-                      <GifVideo {...slice.value} />
-                    </Layout10>
-                  )}
-                  {slice.type === 'iframe' && (
-                    <Layout10>
-                      <Iframe {...slice.value} />
-                    </Layout10>
-                  )}
-                  {slice.type === 'contact' && (
-                    <LayoutWidth width={minWidth}>
-                      <Contact {...slice.value} />
-                    </LayoutWidth>
-                  )}
-                  {slice.type === 'collectionVenue' && (
-                    <>
-                      {slice.value.showClosingTimes && (
-                        <LayoutWidth width={minWidth}>
-                          <VenueClosedPeriods venue={slice.value.content} />
-                        </LayoutWidth>
-                      )}
-                      {!slice.value.showClosingTimes && (
-                        <>
-                          <Layout
-                            gridSizes={
-                              slice.weight === 'featured'
-                                ? {
-                                    s: 12,
-                                    m: 12,
-                                    l: 11,
-                                    shiftL: 1,
-                                    xl: 10,
-                                    shiftXL: 2,
-                                  }
-                                : {
-                                    s: 12,
-                                    m: 10,
-                                    shiftM: 1,
-                                    l: 8,
-                                    shiftL: 2,
-                                    xl: 8,
-                                    shiftXL: 2,
-                                  }
-                            }
-                          >
-                            <VenueHours
-                              venue={slice.value.content}
-                              weight={slice.weight || 'default'}
-                            />
-                          </Layout>
-                        </>
-                      )}
-                    </>
-                  )}
-                  {slice.type === 'table' && (
-                    <LayoutWidth width={minWidth}>
-                      <Table {...slice.value} />
-                    </LayoutWidth>
-                  )}
-                  {slice.type === 'infoBlock' && (
-                    <LayoutWidth width={minWidth}>
-                      <InfoBlock {...slice.value} />
-                    </LayoutWidth>
-                  )}
-                  {slice.type === 'discussion' && (
-                    <WobblyEdgedContainer>
-                      <Discussion
+                {slice.type === 'picture' && slice.weight === 'default' && (
+                  <Layout10>
+                    <CaptionedImage {...slice.value} />
+                  </Layout10>
+                )}
+                {slice.type === 'picture' && slice.weight === 'standalone' && (
+                  <Layout12>
+                    <CaptionedImage {...slice.value} />
+                  </Layout12>
+                )}
+                {slice.type === 'picture' && slice.weight === 'supporting' && (
+                  <LayoutWidth width={minWidth}>
+                    <CaptionedImage {...slice.value} />
+                  </LayoutWidth>
+                )}
+                {slice.type === 'imageGallery' && (
+                  <ImageGallery {...slice.value} id={imageGalleryIdCount++} />
+                )}
+                {slice.type === 'quote' && (
+                  <LayoutWidth width={minWidth}>
+                    <Quote {...slice.value} />
+                  </LayoutWidth>
+                )}
+                {slice.type === 'titledTextList' && (
+                  <LayoutWidth width={minWidth}>
+                    <TitledTextList {...slice.value} />
+                  </LayoutWidth>
+                )}
+                {slice.type === 'contentList' && !isLanding && (
+                  <LayoutWidth width={minWidth}>
+                    {/* FIXME: this makes what-we-do contentLists synchronous, but it's hacky. */}
+                    {pageId === prismicPageIds.whatWeDo ? (
+                      <SearchResults
                         title={slice.value.title}
-                        text={slice.value.text}
+                        items={slice.value.items}
                       />
-                    </WobblyEdgedContainer>
-                  )}
-                  {slice.type === 'tagList' && (
-                    <LayoutWidth width={minWidth}>
-                      <TagsGroup {...slice.value} />
-                    </LayoutWidth>
-                  )}
-                  {/* deprecated */}
-                  {slice.type === 'deprecatedImageList' && (
-                    <LayoutWidth width={minWidth}>
-                      <DeprecatedImageList {...slice.value} />
-                    </LayoutWidth>
-                  )}
-                  {slice.type === 'mediaObjectList' && (
-                    <LayoutWidth width={minWidth}>
-                      <MediaObjectList {...slice.value} />
-                    </LayoutWidth>
-                  )}
-                  {slice.type === 'audioPlayer' && (
-                    <LayoutWidth width={minWidth}>
-                      <AudioPlayer {...slice.value} />
-                    </LayoutWidth>
-                  )}
-                </div>
-              </SpacingComponent>
-            )}
+                    ) : (
+                      <AsyncSearchResults
+                        title={slice.value.title}
+                        query={slice.value.items
+                          .map(item =>
+                            'id' in item ? `id:${item.id}` : undefined
+                          )
+                          .filter(isNotUndefined)
+                          .join(' ')}
+                      />
+                    )}
+                  </LayoutWidth>
+                )}
+                {/* TODO: remove this slice type if we're not using it? */}
+                {slice.type === 'searchResults' && (
+                  <LayoutWidth width={minWidth}>
+                    <AsyncSearchResults {...slice.value} />
+                  </LayoutWidth>
+                )}
+                {slice.type === 'videoEmbed' && (
+                  <LayoutWidth width={minWidth}>
+                    <VideoEmbed {...slice.value} />
+                  </LayoutWidth>
+                )}
+                {slice.type === 'soundcloudEmbed' && (
+                  <LayoutWidth width={minWidth}>
+                    <SoundCloudEmbed {...slice.value} />
+                  </LayoutWidth>
+                )}
+                {slice.type === 'map' && (
+                  <LayoutWidth width={minWidth}>
+                    <Map {...slice.value} />
+                  </LayoutWidth>
+                )}
+                {slice.type === 'gifVideo' && (
+                  <Layout10>
+                    <GifVideo {...slice.value} />
+                  </Layout10>
+                )}
+                {slice.type === 'iframe' && (
+                  <Layout10>
+                    <Iframe {...slice.value} />
+                  </Layout10>
+                )}
+                {slice.type === 'contact' && (
+                  <LayoutWidth width={minWidth}>
+                    <Contact {...slice.value} />
+                  </LayoutWidth>
+                )}
+                {slice.type === 'collectionVenue' && (
+                  <>
+                    {slice.value.showClosingTimes && (
+                      <LayoutWidth width={minWidth}>
+                        <VenueClosedPeriods venue={slice.value.content} />
+                      </LayoutWidth>
+                    )}
+                    {!slice.value.showClosingTimes && (
+                      <>
+                        <Layout
+                          gridSizes={
+                            slice.weight === 'featured'
+                              ? {
+                                  s: 12,
+                                  m: 12,
+                                  l: 11,
+                                  shiftL: 1,
+                                  xl: 10,
+                                  shiftXL: 2,
+                                }
+                              : {
+                                  s: 12,
+                                  m: 10,
+                                  shiftM: 1,
+                                  l: 8,
+                                  shiftL: 2,
+                                  xl: 8,
+                                  shiftXL: 2,
+                                }
+                          }
+                        >
+                          <VenueHours
+                            venue={slice.value.content}
+                            weight={slice.weight || 'default'}
+                          />
+                        </Layout>
+                      </>
+                    )}
+                  </>
+                )}
+                {slice.type === 'table' && (
+                  <LayoutWidth width={minWidth}>
+                    <Table {...slice.value} />
+                  </LayoutWidth>
+                )}
+                {slice.type === 'infoBlock' && (
+                  <LayoutWidth width={minWidth}>
+                    <InfoBlock {...slice.value} />
+                  </LayoutWidth>
+                )}
+                {slice.type === 'discussion' && (
+                  <WobblyEdgedContainer>
+                    <Discussion
+                      title={slice.value.title}
+                      text={slice.value.text}
+                    />
+                  </WobblyEdgedContainer>
+                )}
+                {slice.type === 'tagList' && (
+                  <LayoutWidth width={minWidth}>
+                    <TagsGroup {...slice.value} />
+                  </LayoutWidth>
+                )}
+                {/* deprecated */}
+                {slice.type === 'deprecatedImageList' && (
+                  <LayoutWidth width={minWidth}>
+                    <DeprecatedImageList {...slice.value} />
+                  </LayoutWidth>
+                )}
+                {slice.type === 'mediaObjectList' && (
+                  <LayoutWidth width={minWidth}>
+                    <MediaObjectList {...slice.value} />
+                  </LayoutWidth>
+                )}
+                {slice.type === 'audioPlayer' && (
+                  <LayoutWidth width={minWidth}>
+                    <AudioPlayer {...slice.value} />
+                  </LayoutWidth>
+                )}
+              </div>
+            </SpacingComponent>
+          )}
         </Fragment>
       ))}
     </div>


### PR DESCRIPTION
## Who is this for?
People who expect content from the CMS to be visible on the website

## What is it doing for them?
Re-adding text that was removed from landing pages

The original change was intended to prevent outputting empty `contentList` slices that were wrapped in a `SpacingComponent` which led to extra space being created on the page. I'll create a separate ticket to fix that (properly) again.



