### PR TITLE
Detect more errors in the URL checker

### DIFF
--- a/playwright/url-checker/ignore.ts
+++ b/playwright/url-checker/ignore.ts
@@ -16,3 +16,11 @@ export const ignoreRequestError = (request: Request): boolean => {
   }
   return false;
 };
+
+// Error logs include network errors and other stuff that we are handling separately
+export const ignoreErrorLog = (errorText: string): boolean => {
+  if (errorText.includes('Failed to load resource')) {
+    return true;
+  }
+  return false;
+};


### PR DESCRIPTION
We saw some errors last week that the URL checker missed, because Next.js was helpfully catching them for us and re-logging a more descriptive error. This approach is more likely to introduce false positives which we'll need to override, but that's OK.