### PR TITLE
Concept style changes/fixes

### DIFF
--- a/catalogue/webapp/components/WorksSearchResult/WorksSearchResultV2.styles.tsx
+++ b/catalogue/webapp/components/WorksSearchResult/WorksSearchResultV2.styles.tsx
@@ -1,0 +1,48 @@
+import styled from 'styled-components';
+import Space from '@weco/common/views/components/styled/Space';
+
+export const Container = styled.div`
+  ${props => props.theme.media.medium`
+  display: flex;
+`}
+`;
+
+export const Preview = styled(Space)`
+  display: flex;
+  flex: 1 1 100%;
+  justify-content: center;
+  align-items: center;
+  height: 120px;
+  width: 120px;
+  max-width: 120px;
+  margin-bottom: ${props => props.theme.spacingUnit * 2}px;
+  margin-right: 1rem;
+  background-color: ${props => props.theme.color('black')};
+
+  ${props => props.theme.media.medium`
+  margin-bottom: 0;
+`}
+`;
+
+export const PreviewImage = styled.img`
+  max-width: calc(100% - 10px);
+  max-height: calc(100% - 10px);
+  width: auto;
+  height: auto;
+`;
+
+export const Details = styled.div`
+  flex: 1 1 100%;
+  ${props => props.theme.media.medium`
+  max-width: 900px;
+`}
+`;
+
+export const WorkInformation = styled.div`
+  display: flex;
+  color: ${props => props.theme.color('pewter')};
+`;
+
+export const WorkTitleHeading = styled.h3`
+  margin-bottom: 0.5rem;
+`;

--- a/catalogue/webapp/components/WorksSearchResult/WorksSearchResultV2.tsx
+++ b/catalogue/webapp/components/WorksSearchResult/WorksSearchResultV2.tsx
@@ -1,11 +1,10 @@
 import { FC } from 'react';
-import styled from 'styled-components';
 
 // Types
 import { Work } from '@weco/common/model/catalogue';
 
 // Helpers/Utils
-import { classNames, font } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import {
   getArchiveLabels,
   getProductionDates,
@@ -20,42 +19,19 @@ import LinkLabels from '@weco/common/views/components/LinkLabels/LinkLabels';
 import WorkTitle from '../WorkTitle/WorkTitle';
 import WorkLink from '@weco/common/views/components/WorkLink/WorkLink';
 import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
+import {
+  Container,
+  Details,
+  Preview,
+  PreviewImage,
+  WorkInformation,
+  WorkTitleHeading,
+} from './WorksSearchResultV2.styles';
 
 type Props = {
   work: Work;
   resultPosition: number;
 };
-
-const Container = styled.div`
-  ${props => props.theme.media.medium`
-    display: flex;
-  `}
-`;
-const Preview = styled(Space)`
-  height: 120px;
-  width: 120px;
-  margin-bottom: ${props => props.theme.spacingUnit * 2}px;
-  margin-right: 1rem;
-  position: relative;
-  text-align: center;
-  background-color: ${props => props.theme.color('black')};
-
-  ${props => props.theme.media.medium`
-    margin-bottom: 0;
-  `}
-`;
-const Details = styled.div`
-  ${props => props.theme.media.medium`
-    max-width: 900px;
-  `}
-`;
-const WorkInformation = styled.div`
-  display: flex;
-  color: ${props => props.theme.color('pewter')};
-`;
-const WorkTitleHeading = styled.h3`
-  margin-bottom: 0.5rem;
-`;
 
 // TODO: remove, hack to handle the fact that we are pulling through PDF thumbnails.
 // These will be removed from the API at some stage.
@@ -77,7 +53,7 @@ const WorkSearchResultV2: FC<Props> = ({ work, resultPosition }: Props) => {
     <WorkLink
       id={work.id}
       resultPosition={resultPosition}
-      source={`works_search_result`}
+      source="works_search_result"
       passHref
     >
       <Space
@@ -86,11 +62,7 @@ const WorkSearchResultV2: FC<Props> = ({ work, resultPosition }: Props) => {
           size: 'l',
           properties: ['padding-top', 'padding-bottom'],
         }}
-        className={classNames({
-          'plain-link': true,
-          block: true,
-          'card-link': true,
-        })}
+        className="plain-link block card-link"
         onClick={() => {
           // We've left `WorkCard` here for legacy tracking.
           // We don't really use it.
@@ -104,12 +76,7 @@ const WorkSearchResultV2: FC<Props> = ({ work, resultPosition }: Props) => {
         <Container>
           {work.thumbnail && !isPdfThumbnail(work.thumbnail) && (
             <Preview>
-              <img
-                style={{
-                  width: 'auto',
-                  height: '110px',
-                  marginTop: '5px',
-                }}
+              <PreviewImage
                 alt={`view ${work.title}`}
                 src={convertIiifImageUri(work.thumbnail.url, 120)}
               />
@@ -124,12 +91,7 @@ const WorkSearchResultV2: FC<Props> = ({ work, resultPosition }: Props) => {
             >
               <LabelsList labels={cardLabels} defaultLabelColor="cream" />
             </Space>
-            <WorkTitleHeading
-              className={classNames({
-                [font('intb', 4)]: true,
-                'card-link__title': true,
-              })}
-            >
+            <WorkTitleHeading className={`${font('intb', 4)} card-link__title`}>
               <WorkTitle title={work.title} />
             </WorkTitleHeading>
 
@@ -146,13 +108,17 @@ const WorkSearchResultV2: FC<Props> = ({ work, resultPosition }: Props) => {
               )}
               {primaryContributorLabel && (
                 <>
-                  |
-                  <Space
-                    h={{
-                      size: 's',
-                      properties: ['margin-left'],
-                    }}
-                  >
+                  {productionDates.length > 0 && (
+                    <Space
+                      h={{
+                        size: 'xs',
+                        properties: ['margin-right'],
+                      }}
+                    >
+                      |
+                    </Space>
+                  )}
+                  <Space>
                     <LinkLabels
                       items={[
                         {

--- a/catalogue/webapp/components/WorksSearchResults/WorksSearchResultsV2.tsx
+++ b/catalogue/webapp/components/WorksSearchResults/WorksSearchResultsV2.tsx
@@ -14,6 +14,10 @@ const SearchResultListItem = styled.li`
 
   &:first-child {
     border-top: 0;
+
+    & > a {
+      padding-top: 0;
+    }
   }
 `;
 

--- a/catalogue/webapp/pages/concept.tsx
+++ b/catalogue/webapp/pages/concept.tsx
@@ -35,7 +35,8 @@ type Props = {
   conceptResponse: ConceptType;
   worksAbout: CatalogueResultsList<WorkType> | undefined;
   worksBy: CatalogueResultsList<WorkType> | undefined;
-  images: CatalogueResultsList<ImageType> | undefined;
+  imagesAbout: CatalogueResultsList<ImageType> | undefined;
+  imagesBy: CatalogueResultsList<ImageType> | undefined;
 };
 
 const leadingColor = 'yellow';
@@ -45,9 +46,9 @@ const ConceptHero = styled(Space)`
   background-color: ${props => props.theme.color(leadingColor, 'light')};
 
   h1 {
-    font-size: 4rem;
+    font-size: 3.1875rem;
     line-height: 1.2;
-    margin-bottom: 2.5rem;
+    margin-bottom: 2.125rem;
   }
 `;
 
@@ -115,13 +116,18 @@ export const ConceptPage: NextPage<Props> = ({
   conceptResponse,
   worksAbout,
   worksBy,
-  images,
+  imagesAbout,
+  imagesBy,
 }) => {
-  const [selectedTab, setSelectedTab] = useState('works-about');
+  // TODO allow for multiple TabNav within the page
+  const [selectedWorksTab, setSelectedWorksTab] = useState('works-about');
+  const [selectedImagesTab, setSelectedImagesTab] = useState('images-about');
 
   const hasWorks = !!(worksBy?.totalResults || worksAbout?.totalResults);
   const hasWorksTabs = !!(worksBy?.totalResults && worksAbout?.totalResults);
-
+  const hasImages = !!(imagesBy?.totalResults || imagesAbout?.totalResults);
+  const hasImagesTabs = !!(imagesBy?.totalResults && imagesAbout?.totalResults);
+  console.log(selectedWorksTab);
   return (
     // TODO fill meta information; who decides this?
     <CataloguePageLayout
@@ -162,18 +168,56 @@ export const ConceptPage: NextPage<Props> = ({
         </div>
       </ConceptHero>
 
-      {!!images?.totalResults && (
+      {hasImages && (
         <ConceptImages
           as="section"
           v={{ size: 'xl', properties: ['padding-top', 'padding-bottom'] }}
         >
           <div className="container">
             <h2 className="sectionTitle font-size-2">Images</h2>
-            <ImageEndpointSearchResults images={images} />
-            <SeeMoreButton
-              text={`All images (${images.totalResults})`}
-              link={`/images?source.subjects.label=${conceptResponse.label}`}
-            />
+            {hasImagesTabs && (
+              <TabNavV2
+                items={[
+                  {
+                    id: 'images-about',
+                    text: `Images about ${conceptResponse.label} ${
+                      imagesAbout ? `(${imagesAbout.totalResults})` : ''
+                    }`,
+                    selected: selectedImagesTab === 'images-about',
+                  },
+                  {
+                    id: 'images-by',
+                    text: `Images by ${conceptResponse.label} ${
+                      imagesBy ? `(${imagesBy.totalResults})` : ''
+                    }`,
+                    selected: selectedImagesTab === 'images-by',
+                  },
+                ]}
+                // TODO do we want to change these? Decide when we land on a color
+                // color={leadingColor}
+                setSelectedTab={setSelectedImagesTab}
+              />
+            )}
+            {((hasImagesTabs && selectedImagesTab === 'images-about') ||
+              (!hasImagesTabs && !!imagesAbout?.totalResults)) && (
+              <>
+                <ImageEndpointSearchResults images={imagesAbout} />
+                <SeeMoreButton
+                  text={`All images (${imagesAbout.totalResults})`}
+                  link={`/images?source.subjects.label=${conceptResponse.label}`}
+                />
+              </>
+            )}
+            {((hasImagesTabs && selectedImagesTab === 'images-by') ||
+              (!hasImagesTabs && !!imagesBy?.totalResults)) && (
+              <>
+                <ImageEndpointSearchResults images={imagesBy} />
+                <SeeMoreButton
+                  text={`All images (${imagesBy.totalResults})`}
+                  link={`/images?source.subjects.label=${conceptResponse.label}`}
+                />
+              </>
+            )}
           </div>
         </ConceptImages>
       )}
@@ -196,19 +240,19 @@ export const ConceptPage: NextPage<Props> = ({
                       text: `Works about ${conceptResponse.label} ${
                         worksAbout ? `(${worksAbout.totalResults})` : ''
                       }`,
-                      selected: selectedTab === 'works-about',
+                      selected: selectedWorksTab === 'works-about',
                     },
                     {
                       id: 'works-by',
                       text: `Works by ${conceptResponse.label} ${
                         worksBy ? `(${worksBy.totalResults})` : ''
                       }`,
-                      selected: selectedTab === 'works-by',
+                      selected: selectedWorksTab === 'works-by',
                     },
                   ]}
                   // TODO do we want to change these? Decide when we land on a color
                   // color={leadingColor}
-                  setSelectedTab={setSelectedTab}
+                  setSelectedTab={setSelectedWorksTab}
                 />
               )}
             </div>
@@ -224,25 +268,27 @@ export const ConceptPage: NextPage<Props> = ({
             }}
           >
             <div className="container">
-              {selectedTab === 'works-about' && !!worksAbout?.totalResults && (
+              {((hasWorksTabs && selectedWorksTab === 'works-about') ||
+                (!hasWorksTabs && !!worksAbout?.totalResults)) && (
                 <div role="tabpanel">
                   {/* TODO modify WorksSearchResults to be used instead when we're ready to use it across */}
                   <WorksSearchResultsV2 works={worksAbout} />
                   <Space v={{ size: 'l', properties: ['padding-top'] }}>
                     <SeeMoreButton
-                      text={`All works about ${conceptResponse.label} (${worksAbout.totalResults})`}
+                      text="All works"
                       link={`/works?subjects.label=${conceptResponse.label}`}
                     />
                   </Space>
                 </div>
               )}
-              {selectedTab === 'works-by' && !!worksBy?.totalResults && (
+              {((hasWorksTabs && selectedWorksTab === 'works-by') ||
+                (!hasWorksTabs && !!worksBy?.totalResults)) && (
                 <div role="tabpanel">
                   {/* TODO modify WorksSearchResults to be used instead when we're ready to use it across */}
                   <WorksSearchResultsV2 works={worksBy} />
                   <Space v={{ size: 'l', properties: ['padding-top'] }}>
                     <SeeMoreButton
-                      text={`All works by ${conceptResponse.label} (${worksBy.totalResults})`}
+                      text="All works"
                       link={`/works?subjects.label=${conceptResponse.label}`}
                     />
                   </Space>
@@ -290,14 +336,29 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       pageSize: 5,
     });
 
-    const imagesPromise = getImages({
+    const imagesAboutPromise = getImages({
       params: { 'source.subjects.label': [conceptResponse.label] },
       toggles: serverData.toggles,
       pageSize: 8,
     });
 
-    const [worksAboutResponse, worksByResponse, imagesResponse] =
-      await Promise.all([worksAboutPromise, worksByPromise, imagesPromise]);
+    const imagesByPromise = getImages({
+      params: { 'source.contributors.agent.label': [conceptResponse.label] },
+      toggles: serverData.toggles,
+      pageSize: 8,
+    });
+
+    const [
+      worksAboutResponse,
+      worksByResponse,
+      imagesAboutResponse,
+      imagesByResponse,
+    ] = await Promise.all([
+      worksAboutPromise,
+      worksByPromise,
+      imagesAboutPromise,
+      imagesByPromise,
+    ]);
 
     if (conceptResponse.type === 'Error') {
       if (conceptResponse.httpStatus === 404) {
@@ -314,14 +375,18 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       worksAboutResponse.type === 'Error' ? undefined : worksAboutResponse;
     const worksBy =
       worksByResponse.type === 'Error' ? undefined : worksByResponse;
-    const images = imagesResponse.type === 'Error' ? undefined : imagesResponse;
+    const imagesAbout =
+      imagesAboutResponse.type === 'Error' ? undefined : imagesAboutResponse;
+    const imagesBy =
+      imagesByResponse.type === 'Error' ? undefined : imagesByResponse;
 
     return {
       props: removeUndefinedProps({
         conceptResponse,
         worksAbout,
         worksBy,
-        images,
+        imagesAbout,
+        imagesBy,
         serverData,
       }),
     };

--- a/catalogue/webapp/pages/concept.tsx
+++ b/catalogue/webapp/pages/concept.tsx
@@ -119,7 +119,6 @@ export const ConceptPage: NextPage<Props> = ({
   imagesAbout,
   imagesBy,
 }) => {
-  // TODO allow for multiple TabNav within the page
   const [selectedWorksTab, setSelectedWorksTab] = useState('works-about');
   const [selectedImagesTab, setSelectedImagesTab] = useState('images-about');
 
@@ -127,7 +126,7 @@ export const ConceptPage: NextPage<Props> = ({
   const hasWorksTabs = !!(worksBy?.totalResults && worksAbout?.totalResults);
   const hasImages = !!(imagesBy?.totalResults || imagesAbout?.totalResults);
   const hasImagesTabs = !!(imagesBy?.totalResults && imagesAbout?.totalResults);
-  console.log(selectedWorksTab);
+
   return (
     // TODO fill meta information; who decides this?
     <CataloguePageLayout
@@ -147,7 +146,7 @@ export const ConceptPage: NextPage<Props> = ({
             <h1 className="font-intb">{conceptResponse.label}</h1>
             {/* TODO dynamise */}
             {FAKE_DATA.description && (
-              <p className={font('intr', 4)}>{FAKE_DATA.description}</p>
+              <p className="font-size-5">{FAKE_DATA.description}</p>
             )}
             {/* TODO dynamise */}
             {FAKE_DATA.urls?.length > 0 &&
@@ -174,7 +173,8 @@ export const ConceptPage: NextPage<Props> = ({
           v={{ size: 'xl', properties: ['padding-top', 'padding-bottom'] }}
         >
           <div className="container">
-            <h2 className="sectionTitle font-size-2">Images</h2>
+            <h2 className={`sectionTitle ${font('wb', 3)}`}>Images</h2>
+
             {hasImagesTabs && (
               <TabNavV2
                 items={[
@@ -196,34 +196,39 @@ export const ConceptPage: NextPage<Props> = ({
                 // TODO do we want to change these? Decide when we land on a color
                 // color={leadingColor}
                 setSelectedTab={setSelectedImagesTab}
+                isDarkMode
               />
             )}
-            {((hasImagesTabs && selectedImagesTab === 'images-about') ||
-              (!hasImagesTabs && !!imagesAbout?.totalResults)) && (
-              <>
-                <ImageEndpointSearchResults
-                  images={imagesAbout}
-                  background="transparent"
-                />
-                <SeeMoreButton
-                  text={`All images (${imagesAbout.totalResults})`}
-                  link={`/images?source.subjects.label=${conceptResponse.label}`}
-                />
-              </>
-            )}
-            {((hasImagesTabs && selectedImagesTab === 'images-by') ||
-              (!hasImagesTabs && !!imagesBy?.totalResults)) && (
-              <>
-                <ImageEndpointSearchResults
-                  images={imagesBy}
-                  background="transparent"
-                />
-                <SeeMoreButton
-                  text={`All images (${imagesBy.totalResults})`}
-                  link={`/images?source.subjects.label=${conceptResponse.label}`}
-                />
-              </>
-            )}
+            <Space v={{ size: 'l', properties: ['margin-top'] }}>
+              {((hasImagesTabs && selectedImagesTab === 'images-about') ||
+                (!hasImagesTabs && !!imagesAbout?.totalResults)) && (
+                <>
+                  <ImageEndpointSearchResults
+                    images={imagesAbout}
+                    background="transparent"
+                  />
+                  <Space v={{ size: 'm', properties: ['margin-top'] }}>
+                    <SeeMoreButton
+                      text={`All images (${imagesAbout.totalResults})`}
+                      link={`/images?source.subjects.label=${conceptResponse.label}`}
+                    />
+                  </Space>
+                </>
+              )}
+              {((hasImagesTabs && selectedImagesTab === 'images-by') ||
+                (!hasImagesTabs && !!imagesBy?.totalResults)) && (
+                <>
+                  <ImageEndpointSearchResults
+                    images={imagesBy}
+                    background="transparent"
+                  />
+                  <SeeMoreButton
+                    text={`All images (${imagesBy.totalResults})`}
+                    link={`/images?source.subjects.label=${conceptResponse.label}`}
+                  />
+                </>
+              )}
+            </Space>
           </div>
         </ConceptImages>
       )}
@@ -236,7 +241,7 @@ export const ConceptPage: NextPage<Props> = ({
             hasWorksTabs={hasWorksTabs}
           >
             <div className="container">
-              <h2 className="font-size-2">Works</h2>
+              <h2 className={`${font('wb', 3)}`}>Works</h2>
               {/* TODO responsive tabs + accessible navigation */}
               {hasWorksTabs && (
                 <TabNavV2
@@ -268,9 +273,7 @@ export const ConceptPage: NextPage<Props> = ({
             as="section"
             v={{
               size: 'xl',
-              properties: hasWorksTabs
-                ? ['padding-top', 'padding-bottom']
-                : ['padding-bottom'],
+              properties: ['margin-top', 'margin-bottom'],
             }}
           >
             <div className="container">
@@ -281,7 +284,7 @@ export const ConceptPage: NextPage<Props> = ({
                   <WorksSearchResultsV2 works={worksAbout} />
                   <Space v={{ size: 'l', properties: ['padding-top'] }}>
                     <SeeMoreButton
-                      text="All works"
+                      text={`All works (${worksAbout.totalResults})`}
                       link={`/works?subjects.label=${conceptResponse.label}`}
                     />
                   </Space>
@@ -294,7 +297,7 @@ export const ConceptPage: NextPage<Props> = ({
                   <WorksSearchResultsV2 works={worksBy} />
                   <Space v={{ size: 'l', properties: ['padding-top'] }}>
                     <SeeMoreButton
-                      text="All works"
+                      text={`All works (${worksBy.totalResults})`}
                       link={`/works?subjects.label=${conceptResponse.label}`}
                     />
                   </Space>

--- a/common/views/components/TabNav/TabNavV2.tsx
+++ b/common/views/components/TabNav/TabNavV2.tsx
@@ -10,17 +10,18 @@ type SelectableTextLink = {
   // TODO we probably want anchors here so people can share the url/go back to the correct section?
   // link: NextLinkType;
   selected: boolean;
-  color?: string;
 };
 
 type Props = {
   items: SelectableTextLink[];
   setSelectedTab: Dispatch<SetStateAction<string>>;
   color?: string;
+  isDarkMode?: boolean;
 };
 
 type NavItemInnerProps = {
   selected: boolean;
+  isDarkMode?: boolean;
 };
 
 const NavItemInner = styled(Space).attrs<NavItemInnerProps>(props => {
@@ -35,6 +36,9 @@ const NavItemInner = styled(Space).attrs<NavItemInnerProps>(props => {
   z-index: 1;
   padding: 1em 0.3em;
   cursor: pointer;
+  color: ${props => props.theme.color(props.isDarkMode ? 'white' : 'black')};
+  opacity: ${props => (props.selected ? '1' : '0.6')};
+  transition: all ${props => props.theme.transitionProperties};
 
   &:after {
     content: '';
@@ -44,9 +48,9 @@ const NavItemInner = styled(Space).attrs<NavItemInnerProps>(props => {
     left: 0;
     width: 0;
     background-color: ${props => {
-      return props.color
-        ? props.theme.color(props.color)
-        : props.theme.color('black');
+      return props.theme.color(
+        props.color ? props.color : props.isDarkMode ? 'white' : 'black'
+      );
     }};
     z-index: -1;
     transition: width 200ms ease;
@@ -69,9 +73,14 @@ const NavItemInner = styled(Space).attrs<NavItemInnerProps>(props => {
   }
 `;
 
-const TabNavV2: FC<Props> = ({ items, setSelectedTab, color }: Props) => {
+const TabNavV2: FC<Props> = ({
+  items,
+  setSelectedTab,
+  color,
+  isDarkMode = false,
+}: Props) => {
   return (
-    <div className={font('intb', 4)}>
+    <div className={font('intb', 5)}>
       <ul
         className="plain-list no-margin no-padding flex flex--wrap"
         role="tablist"
@@ -95,6 +104,7 @@ const TabNavV2: FC<Props> = ({ items, setSelectedTab, color }: Props) => {
               v={{ size: 'm', properties: ['padding-top'] }}
               selected={item.selected}
               color={color}
+              isDarkMode={isDarkMode}
             >
               {item.text}
             </NavItemInner>

--- a/common/views/components/TabNav/TabNavV2.tsx
+++ b/common/views/components/TabNav/TabNavV2.tsx
@@ -27,11 +27,11 @@ const NavItemInner = styled(Space).attrs<NavItemInnerProps>(props => {
   return {
     className: classNames({
       selected: props.selected,
-      block: true,
-      relative: true,
     }),
   };
 })<NavItemInnerProps>`
+  display: block;
+  position: relative;
   z-index: 1;
   padding: 1em 0.3em;
   cursor: pointer;
@@ -71,16 +71,9 @@ const NavItemInner = styled(Space).attrs<NavItemInnerProps>(props => {
 
 const TabNavV2: FC<Props> = ({ items, setSelectedTab, color }: Props) => {
   return (
-    <div
-      className={classNames({
-        [font('intb', 4)]: true,
-      })}
-    >
+    <div className={font('intb', 4)}>
       <ul
-        className={classNames({
-          'plain-list no-margin no-padding': true,
-          'flex flex--wrap': true,
-        })}
+        className="plain-list no-margin no-padding flex flex--wrap"
         role="tablist"
       >
         {items.map(item => (


### PR DESCRIPTION
## Who is this for?
Devs/Designer

## What is it doing for them?

Made changes/fixes on Concept page based on updated design and debugging. Examples below, see mainly tabs, spacing, font-size, image preview:

Buxton before
<img width="472" alt="Buxton - before" src="https://user-images.githubusercontent.com/110461050/189942876-abb9a770-dda8-498e-92f3-1eb033be2950.png">

Buxton after
<img width="453" alt="Buxton - after" src="https://user-images.githubusercontent.com/110461050/189942858-f4b52522-64ee-410c-b1cd-2d4601480b62.png">

---
GB Before
<img width="349" alt="GB - before" src="https://user-images.githubusercontent.com/110461050/189942891-048c29b4-e94c-4dbe-afd6-43c1224802ef.png">

GB After
<img width="372" alt="GB - after" src="https://user-images.githubusercontent.com/110461050/189942885-1c6de4da-14ca-4a64-949e-e3296258fb27.png">


