### PR TITLE
Have 30 images results instead of 25

### DIFF
--- a/catalogue/webapp/pages/images.tsx
+++ b/catalogue/webapp/pages/images.tsx
@@ -263,7 +263,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     const images = await getImages({
       params: apiProps,
       toggles: serverData.toggles,
-      pageSize: 25,
+      pageSize: 30,
     });
 
     if (images && images.type === 'Error') {


### PR DESCRIPTION
## Who is this for?
Users

## What is it doing for them?
Gets them more results on a page, based on a request from Jonathan