### PR TITLE
Stories landing custom type amendments

### DIFF
--- a/prismic-model/src/stories-landing.ts
+++ b/prismic-model/src/stories-landing.ts
@@ -10,14 +10,22 @@ const featuredBooks: CustomType = {
   repeatable: false,
   status: true,
   json: {
+    Main: {
+      introText: multiLineText({
+        label: 'Introductory text',
+        placeholder: 'This will appear at the top of the stories landing page.',
+      }),
+    },
     'Featured stories/series': {
-      title,
-      description: multiLineText({ label: 'description' }),
+      storiesTitle: title,
+      storiesDescription: multiLineText({ label: 'description' }),
       stories: list('stories', {
         story: link('story/series', 'document', ['articles', 'series']),
       }),
     },
     'Featured books': {
+      booksTitle: title,
+      booksDescription: multiLineText({ label: 'description' }),
       books: list('books', { book: link('book', 'document', ['books']) }),
     },
   },


### PR DESCRIPTION
relates to #8398 

We currently get featured text from a separate page in Prismic to provide the introductory text at the top of the stories landing page. It made sense to add a field for this to the stories-landing custom-type instead.

Also making the title and description for each of the lists editable in Prismic, rather than being hardcoded
