### PR TITLE
Create a shared definition of transformTimestamp

### DIFF
--- a/common/services/prismic/transformers/collection-venues.ts
+++ b/common/services/prismic/transformers/collection-venues.ts
@@ -12,7 +12,7 @@ import {
 import { isNotUndefined } from '../../../utils/array';
 import * as prismicH from '@prismicio/helpers';
 import { transformImage } from './images';
-import { TimestampField } from '@prismicio/types';
+import { transformTimestamp } from '.';
 
 export function createRegularDay(
   day: Day,
@@ -40,10 +40,6 @@ export function createRegularDay(
     closes: start && end ? formatTime(end) : '00:00',
     isClosed,
   };
-}
-
-function transformTimestamp(field: TimestampField): Date | undefined {
-  return prismicH.asDate(field) || undefined;
 }
 
 export function transformCollectionVenue(

--- a/common/services/prismic/transformers/index.ts
+++ b/common/services/prismic/transformers/index.ts
@@ -1,12 +1,13 @@
 import { Tasl } from '../../../model/tasl';
 import { licenseTypeArray } from '../../../model/license';
-import { LinkField } from '@prismicio/types';
 import linkResolver from '../link-resolver';
 import {
   isFilledLinkToDocument,
   isFilledLinkToMediaField,
   isFilledLinkToWebField,
 } from '../types';
+import * as prismicH from '@prismicio/helpers';
+import * as prismicT from '@prismicio/types';
 
 export function transformTaslFromString(pipedString: string | null): Tasl {
   if (pipedString === null) {
@@ -54,7 +55,7 @@ export function transformTaslFromString(pipedString: string | null): Tasl {
 }
 
 export function transformLink(
-  link?: LinkField<string, string, any>
+  link?: prismicT.LinkField<string, string, any>
 ): string | undefined {
   if (link) {
     if (isFilledLinkToWebField(link) || isFilledLinkToMediaField(link)) {
@@ -65,4 +66,17 @@ export function transformLink(
       console.warn(`Unable to construct link for ${JSON.stringify(link)}`);
     }
   }
+}
+
+/** Transform a Prismic timestamp into a JavaScript date.
+ *
+ * Note: this is preferable to passing a value to the `Date` constructor
+ * (i.e. `new Date(…)`) because it handles the timezone offset which is present
+ * in Prismic timestamps, whereas some older browsers can't parse that.
+ *
+ */
+export function transformTimestamp(
+  field: prismicT.TimestampField
+): Date | undefined {
+  return prismicH.asDate(field) || undefined;
 }

--- a/content/webapp/services/prismic/transformers/books.ts
+++ b/content/webapp/services/prismic/transformers/books.ts
@@ -4,7 +4,6 @@ import {
   transformGenericFields,
   asRichText,
   asText,
-  transformTimestamp,
   transformSingleLevelGroup,
 } from '.';
 import { isFilledLinkToWebField } from '@weco/common/services/prismic/types';
@@ -12,6 +11,7 @@ import { transformSeason } from './seasons';
 import { transformPromoToCaptionedImage } from './images';
 import { SeasonPrismicDocument } from '../types/seasons';
 import { transformContributors } from './contributors';
+import { transformTimestamp } from '@weco/common/services/prismic/transformers';
 
 export function transformBookToBookBasic(book: Book): BookBasic {
   // returns what is required to render BookPromos and book JSON-LD

--- a/content/webapp/services/prismic/transformers/events.test.ts
+++ b/content/webapp/services/prismic/transformers/events.test.ts
@@ -1,8 +1,8 @@
 import { groupEventsByDay } from '../../../services/prismic/events';
 import { getLastEndTime, getEventbriteId } from './events';
 import { data as uiEventData } from '../../../components/CardGrid/DailyTourPromo';
-import { transformTimestamp } from '.';
 import { EventTime } from '../../../types/events';
+import { transformTimestamp } from '@weco/common/services/prismic/transformers';
 
 const eventTimes: EventTime[] = [
   {

--- a/content/webapp/services/prismic/transformers/events.ts
+++ b/content/webapp/services/prismic/transformers/events.ts
@@ -29,7 +29,6 @@ import {
   transformGenericFields,
   transformLabelType,
   transformSingleLevelGroup,
-  transformTimestamp,
 } from '.';
 import { transformSeason } from './seasons';
 import {
@@ -49,6 +48,7 @@ import { EventSeriesPrismicDocument } from '../types/event-series';
 import { PlacePrismicDocument } from '../types/places';
 import { transformContributors } from './contributors';
 import * as prismicH from '@prismicio/helpers';
+import { transformTimestamp } from '@weco/common/services/prismic/transformers';
 
 function transformEventBookingType(
   eventDoc: EventPrismicDocument

--- a/content/webapp/services/prismic/transformers/exhibitions.ts
+++ b/content/webapp/services/prismic/transformers/exhibitions.ts
@@ -23,7 +23,6 @@ import {
   asText,
   transformGenericFields,
   transformSingleLevelGroup,
-  transformTimestamp,
 } from '.';
 import { transformSeason } from './seasons';
 import { transformPlace } from './places';
@@ -35,6 +34,7 @@ import {
 } from './contributors';
 import * as prismicH from '@prismicio/helpers';
 import { noAltTextBecausePromo } from './images';
+import { transformTimestamp } from '@weco/common/services/prismic/transformers';
 
 // TODO: Use better types than Record<string, any>.
 //

--- a/content/webapp/services/prismic/transformers/guides.ts
+++ b/content/webapp/services/prismic/transformers/guides.ts
@@ -4,15 +4,10 @@ import {
   GuidePrismicDocument,
   GuideFormatPrismicDocument,
 } from '../types/guides';
-import {
-  asHtml,
-  asTitle,
-  transformFormat,
-  transformGenericFields,
-  transformTimestamp,
-} from '.';
+import { asHtml, asTitle, transformFormat, transformGenericFields } from '.';
 import { links as headerLinks } from '@weco/common/views/components/Header/Header';
 import { transformOnThisPage } from './pages';
+import { transformTimestamp } from '@weco/common/services/prismic/transformers';
 
 export function transformGuide(document: GuidePrismicDocument): Guide {
   const { data } = document;

--- a/content/webapp/services/prismic/transformers/index.ts
+++ b/content/webapp/services/prismic/transformers/index.ts
@@ -4,7 +4,6 @@ import {
   FilledLinkToDocumentField,
   KeyTextField,
   RichTextField,
-  TimestampField,
 } from '@prismicio/types';
 import { CommonPrismicFields, WithArticleFormat } from '../types';
 import {
@@ -47,10 +46,6 @@ export function transformFormat(document: {
       description: asHtml(format.data.description),
     };
   }
-}
-
-export function transformTimestamp(field: TimestampField): Date | undefined {
-  return prismicH.asDate(field) || undefined;
 }
 
 // Prismic often returns empty RichText fields as `[]`, this filters them out

--- a/content/webapp/services/prismic/transformers/pages.ts
+++ b/content/webapp/services/prismic/transformers/pages.ts
@@ -7,7 +7,6 @@ import {
   transformFormat,
   transformGenericFields,
   transformSingleLevelGroup,
-  transformTimestamp,
 } from '.';
 import { transformSeason } from './seasons';
 import { dasherize } from '@weco/common/utils/grammar';
@@ -17,6 +16,7 @@ import { Body } from '../types/body';
 import { SeasonPrismicDocument } from '../types/seasons';
 import { transformContributors } from './contributors';
 import { isNotUndefined, isUndefined } from '@weco/common/utils/array';
+import { transformTimestamp } from '@weco/common/services/prismic/transformers';
 
 export function transformOnThisPage(body: Body): Link[] {
   return flattenDeep(

--- a/content/webapp/services/prismic/transformers/seasons.ts
+++ b/content/webapp/services/prismic/transformers/seasons.ts
@@ -1,4 +1,5 @@
-import { transformGenericFields, transformTimestamp } from '.';
+import { transformTimestamp } from '@weco/common/services/prismic/transformers';
+import { transformGenericFields } from '.';
 import { Season } from '../../../types/seasons';
 import { SeasonPrismicDocument } from '../types/seasons';
 

--- a/content/webapp/services/prismic/transformers/series.ts
+++ b/content/webapp/services/prismic/transformers/series.ts
@@ -1,16 +1,12 @@
 import { Series, SeriesBasic } from '../../../types/series';
 import { SeriesPrismicDocument } from '../types/series';
-import {
-  asTitle,
-  transformGenericFields,
-  transformSingleLevelGroup,
-  transformTimestamp,
-} from '.';
+import { asTitle, transformGenericFields, transformSingleLevelGroup } from '.';
 import { transformSeason } from './seasons';
 import { ArticleScheduleItem } from '../../../types/article-schedule-items';
 import { SeasonPrismicDocument } from '../types/seasons';
 import { isNotUndefined } from '@weco/common/utils/array';
 import { transformContributors } from './contributors';
+import { transformTimestamp } from '@weco/common/services/prismic/transformers';
 
 export function transformSeries(document: SeriesPrismicDocument): Series {
   const { data } = document;


### PR DESCRIPTION
Follows https://github.com/wellcomecollection/wellcomecollection.org/pull/8449

## Who is this for?

Future devs, aka me.

## What is it doing for them?

Explaining why the `transformTimestamp` method is important – I thought it was equivalent to `new Date(…)`, which is why I didn't move it out of `@weco/content` when I was doing refactoring.