### PR TITLE
Set date hours to zero to make sure we're comparing like with like

### DIFF
--- a/catalogue/webapp/utils/dates.ts
+++ b/catalogue/webapp/utils/dates.ts
@@ -212,7 +212,7 @@ export function isRequestableDate(params: {
 }): boolean {
   const { date, startDate, endDate, excludedDates, excludedDays } = params;
   const isExceptionalClosedDay = excludedDates.some(excluded =>
-    isSameDay(excluded, date)
+    isSameDay(excluded, date, 'London')
   );
   const isRegularClosedDay = excludedDays.includes(date.getDay() as DayNumber);
   return (
@@ -222,12 +222,14 @@ export function isRequestableDate(params: {
         // both start and end date
         (startDate &&
           endDate &&
-          isSameDayOrBefore(startDate, date) &&
-          isSameDayOrBefore(date, endDate)) ||
+          isSameDayOrBefore(startDate, date, 'London') &&
+          isSameDayOrBefore(date, endDate, 'London')) ||
         // only start date
-        (startDate && !endDate && isSameDayOrBefore(startDate, date)) ||
+        (startDate &&
+          !endDate &&
+          isSameDayOrBefore(startDate, date, 'London')) ||
         // only end date
-        (endDate && !startDate && isSameDayOrBefore(date, endDate))
+        (endDate && !startDate && isSameDayOrBefore(date, endDate, 'London'))
     ) && // both start and end date
     !isExceptionalClosedDay &&
     !isRegularClosedDay

--- a/common/utils/dates.test.ts
+++ b/common/utils/dates.test.ts
@@ -29,11 +29,15 @@ describe('isSameDay', () => {
     expect(result).toEqual(true);
   });
 
-  it('says two times on the same day are the same', () => {
-    const result = isSameDay(
-      new Date(2001, 1, 1, 1, 1, 1),
-      new Date(2001, 1, 1, 13, 24, 37)
-    );
+  it.only('says two times on the same day are the same', () => {
+    const date1 = new Date(
+      'Mon Sep 19 2022 00:00:00 GMT+0100 (British Summer Time)'
+    ); // Date/time format from Prismic (on the 18th/19th date divide)
+    const date2 = new Date(
+      'Mon Sep 19 2022 11:47:08 GMT+0100 (British Summer Time)'
+    ); // Unambiguously the 19th
+
+    const result = isSameDay(date1, date2);
 
     expect(result).toEqual(true);
   });

--- a/common/utils/dates.test.ts
+++ b/common/utils/dates.test.ts
@@ -43,7 +43,7 @@ describe('isSameDay', () => {
       'Mon Sep 19 2022 12:00:00 GMT+0100 (British Summer Time)'
     );
 
-    it('says midnight BST in London is on the same day as midday BST using a comparison mode of "London"', () => {
+    it('says midnight {x} BST in London is on the same day as midday {x} BST using a comparison mode of "London"', () => {
       const result = isSameDay(
         september19Midnight,
         september19Midday,
@@ -52,12 +52,12 @@ describe('isSameDay', () => {
       expect(result).toEqual(true);
     });
 
-    it('says midnight BST in London is not on the same day as midday BST using a comparison mode of "UTC"', () => {
+    it('says midnight {x} BST in London is not on the same day as midday {x} BST using a comparison mode of "UTC"', () => {
       const result = isSameDay(september19Midnight, september19Midday, 'UTC');
       expect(result).toEqual(false);
     });
 
-    it('says 23:30 BST in London is not on the same day as 00:30 BST using a comparison mode of "London"', () => {
+    it('says 23:30 {x} BST in London is not on the same day as 00:30 {x+1} BST using a comparison mode of "London"', () => {
       const result = isSameDay(
         september18TwentyThreeThirty,
         september19MidnightThirty,
@@ -66,7 +66,7 @@ describe('isSameDay', () => {
       expect(result).toEqual(false);
     });
 
-    it('says 23:30 BST in London is on the same day as 00:30 BST using a comparison mode of "UTC"', () => {
+    it('says 23:30 {x} BST in London is on the same day as 00:30 {x+1} BST using a comparison mode of "UTC"', () => {
       const result = isSameDay(
         september18TwentyThreeThirty,
         september19MidnightThirty,

--- a/common/utils/dates.test.ts
+++ b/common/utils/dates.test.ts
@@ -31,16 +31,20 @@ describe('isSameDay', () => {
 
   describe('ComparisonMode', () => {
     const september19Midnight = new Date(
+      // aka Sun Sep 18 2022 23:00:00 UTC
       'Mon Sep 19 2022 00:00:00 GMT+0100 (British Summer Time)'
     );
     const september18TwentyThreeThirty = new Date(
+      // aka Sun Sep 18 2022 22:30:00 UTC
       'Sun Sep 18 2022 23:30:00 GMT+0100 (British Summer Time)'
     );
     const september19MidnightThirty = new Date(
+      // aka Sun Sep 18 2022 23:30:00 UTC
       'Mon Sep 19 2022 00:30:00 GMT+0100 (British Summer Time)'
     );
     const september19Midday = new Date(
-      'Mon Sep 19 2022 12:00:00 GMT+0100 (British Summer Time)'
+      // aka Sun Sep 18 2022 11:00:00 UTC
+     'Mon Sep 19 2022 12:00:00 GMT+0100 (British Summer Time)'
     );
 
     it('says midnight {x} BST in London is on the same day as midday {x} BST using a comparison mode of "London"', () => {

--- a/common/utils/dates.test.ts
+++ b/common/utils/dates.test.ts
@@ -29,17 +29,51 @@ describe('isSameDay', () => {
     expect(result).toEqual(true);
   });
 
-  it.only('says two times on the same day are the same', () => {
-    const date1 = new Date(
+  describe.only('ComparisonMode', () => {
+    const september19Midnight = new Date(
       'Mon Sep 19 2022 00:00:00 GMT+0100 (British Summer Time)'
-    ); // Date/time format from Prismic (on the 18th/19th date divide)
-    const date2 = new Date(
-      'Mon Sep 19 2022 11:47:08 GMT+0100 (British Summer Time)'
-    ); // Unambiguously the 19th
+    );
+    const september18TwentyThreeThirty = new Date(
+      'Sun Sep 18 2022 23:30:00 GMT+0100 (British Summer Time)'
+    );
+    const september19MidnightThirty = new Date(
+      'Mon Sep 19 2022 00:30:00 GMT+0100 (British Summer Time)'
+    );
+    const september19Midday = new Date(
+      'Mon Sep 19 2022 12:00:00 GMT+0100 (British Summer Time)'
+    );
 
-    const result = isSameDay(date1, date2);
+    it('says midnight BST in London is on the same day as midday BST using a comparison mode of "London"', () => {
+      const result = isSameDay(
+        september19Midnight,
+        september19Midday,
+        'London'
+      );
+      expect(result).toEqual(true);
+    });
 
-    expect(result).toEqual(true);
+    it('says midnight BST in London is not on the same day as midday BST using a comparison mode of "UTC"', () => {
+      const result = isSameDay(september19Midnight, september19Midday, 'UTC');
+      expect(result).toEqual(false);
+    });
+
+    it('says 23:30 BST in London is not on the same day as 00:30 BST using a comparison mode of "London"', () => {
+      const result = isSameDay(
+        september18TwentyThreeThirty,
+        september19MidnightThirty,
+        'London'
+      );
+      expect(result).toEqual(false);
+    });
+
+    it('says 23:30 BST in London is on the same day as 00:30 BST using a comparison mode of "UTC"', () => {
+      const result = isSameDay(
+        september18TwentyThreeThirty,
+        september19MidnightThirty,
+        'UTC'
+      );
+      expect(result).toEqual(true);
+    });
   });
 
   each([
@@ -199,6 +233,7 @@ describe('getNextWeekendDateRange', () => {
     },
   ])('the next weekend after $day is $weekend', ({ day, weekend }) => {
     const range = getNextWeekendDateRange(day);
+
     expect(isSameDay(range.start, weekend.start)).toBeTruthy();
     expect(isSameDay(range.end, weekend.end)).toBeTruthy();
   });

--- a/common/utils/dates.test.ts
+++ b/common/utils/dates.test.ts
@@ -29,7 +29,7 @@ describe('isSameDay', () => {
     expect(result).toEqual(true);
   });
 
-  describe.only('ComparisonMode', () => {
+  describe('ComparisonMode', () => {
     const september19Midnight = new Date(
       'Mon Sep 19 2022 00:00:00 GMT+0100 (British Summer Time)'
     );

--- a/common/utils/dates.ts
+++ b/common/utils/dates.ts
@@ -1,4 +1,5 @@
 import { DateRange } from '../model/date-range';
+import { formatDayDate } from './format-date';
 
 // This is just to allow us to mock values in tests
 export function today(): Date {
@@ -37,16 +38,19 @@ export function isSameMonth(date1: Date, date2: Date): boolean {
   );
 }
 
-export function isSameDay(date1: Date, date2: Date): boolean {
-  const d1 = new Date(date1);
-  const d2 = new Date(date2);
-
-  // Set the hours to be equal on both dates to account for any off-by-one
-  // timezone issues
-  d1.setHours(0, 0, 0, 0);
-  d2.setHours(0, 0, 0, 0);
-
-  return isSameMonth(d1, d2) && d1.getUTCDate() === d2.getUTCDate();
+type ComparisonMode = 'UTC' | 'London';
+export function isSameDay(
+  date1: Date,
+  date2: Date,
+  mode: ComparisonMode = 'UTC'
+): boolean {
+  if (mode === 'UTC') {
+    return (
+      isSameMonth(date1, date2) && date1.getUTCDate() === date2.getUTCDate()
+    );
+  } else {
+    return formatDayDate(date1) === formatDayDate(date2);
+  }
 }
 
 // Note: the order of arguments to this function is designed so you can
@@ -55,8 +59,12 @@ export function isSameDay(date1: Date, date2: Date): boolean {
 //      isSameDayOrBefore(A, B) && isSameDayOrBefore(B, C)
 //        => isSameDayOrBefore(A, C)
 //
-export function isSameDayOrBefore(date1: Date, date2: Date): boolean {
-  return isSameDay(date1, date2) || date1 <= date2;
+export function isSameDayOrBefore(
+  date1: Date,
+  date2: Date,
+  mode: ComparisonMode = 'UTC'
+): boolean {
+  return isSameDay(date1, date2, mode) || date1 <= date2;
 }
 
 // Returns true if 'date' falls on a past day; false otherwise.

--- a/common/utils/dates.ts
+++ b/common/utils/dates.ts
@@ -38,7 +38,15 @@ export function isSameMonth(date1: Date, date2: Date): boolean {
 }
 
 export function isSameDay(date1: Date, date2: Date): boolean {
-  return isSameMonth(date1, date2) && date1.getUTCDate() === date2.getUTCDate();
+  const d1 = new Date(date1);
+  const d2 = new Date(date2);
+
+  // Set the hours to be equal on both dates to account for any off-by-one
+  // timezone issues
+  d1.setHours(0, 0, 0, 0);
+  d2.setHours(0, 0, 0, 0);
+
+  return isSameMonth(d1, d2) && d1.getUTCDate() === d2.getUTCDate();
 }
 
 // Note: the order of arguments to this function is designed so you can


### PR DESCRIPTION
Making sure the correct dates are removed from the date picker.

Sunday doesn't appear in the screenshot below because it is a 'regular closed day', and Monday doesn't appear because it's an 'exceptional closed day'.

Handling this date logic makes me feel uneasy. Would date-fns be a better option (lighter touch than Moment, but far better tested than our homegrown versions).

![image](https://user-images.githubusercontent.com/1394592/190102877-c8355572-11ab-4c2b-83f4-ce03a25a1924.png)
