### PR TITLE
Check we're actually formatting months correctly

### DIFF
--- a/catalogue/webapp/components/ItemRequestModal/ItemRequestModal.tsx
+++ b/catalogue/webapp/components/ItemRequestModal/ItemRequestModal.tsx
@@ -9,6 +9,7 @@ import LL from '@weco/common/views/components/styled/LL';
 import RequestDialog from './RequestDialog';
 import ConfirmedDialog from './ConfirmedDialog';
 import ErrorDialog from './ErrorDialog';
+import { formatDateForRequestsAPI } from './format-date';
 
 type Props = {
   work: Work;
@@ -51,15 +52,6 @@ const ItemRequestModal: FC<Props> = ({
     setCurrentHoldNumber(initialHoldNumber);
   }, [initialHoldNumber]); // This will update when the PhysicalItemDetails component renders and the userHolds are updated
 
-  // Formats a date as YYYY-MM-DD, e.g. 2022-09-21
-  function formatDate(d: Date): string {
-    const years = d.getUTCFullYear().toString();
-    const months = d.getUTCMonth().toString().padStart(2, '0');
-    const days = d.getUTCDate().toString().padStart(2, '0');
-
-    return `${years}-${months}-${days}`;
-  }
-
   async function confirmRequest(pickupDate: Date) {
     setRequestingState('requesting');
     try {
@@ -68,7 +60,7 @@ const ItemRequestModal: FC<Props> = ({
         body: JSON.stringify({
           workId: work.id,
           itemId: item.id,
-          pickupDate: formatDate(pickupDate),
+          pickupDate: formatDateForRequestsAPI(pickupDate),
           type: 'Item',
         }),
         headers: {

--- a/catalogue/webapp/components/ItemRequestModal/format-date.test.ts
+++ b/catalogue/webapp/components/ItemRequestModal/format-date.test.ts
@@ -1,4 +1,8 @@
-import { dateAsValue, dateFromValue } from './format-date';
+import {
+  dateAsValue,
+  dateFromValue,
+  formatDateForRequestsAPI,
+} from './format-date';
 
 test.each([
   { d: new Date('2022-09-21T00:00:00Z'), s: '21-09-2022' },
@@ -6,4 +10,11 @@ test.each([
 ])('the date $d is serialised as $s', ({ d, s }) => {
   expect(dateAsValue(d)).toBe(s);
   expect(dateFromValue(s)).toStrictEqual(d);
+});
+
+test.each([
+  { d: new Date('2022-09-21T00:00:00Z'), s: '2022-09-21' },
+  { d: new Date('2022-09-08T00:00:00Z'), s: '2022-09-08' },
+])('the date $d is formatted for the requests API as $s', ({ d, s }) => {
+  expect(formatDateForRequestsAPI(d)).toBe(s);
 });

--- a/catalogue/webapp/components/ItemRequestModal/format-date.test.ts
+++ b/catalogue/webapp/components/ItemRequestModal/format-date.test.ts
@@ -15,6 +15,10 @@ test.each([
 test.each([
   { d: new Date('2022-09-21T00:00:00Z'), s: '2022-09-21' },
   { d: new Date('2022-09-08T00:00:00Z'), s: '2022-09-08' },
+  { d: new Date('2022-12-31T00:00:00Z'), s: '2022-12-31' },
+  // Check we're using the calendar date, and not the ISO week date
+  // (See https://alexwlchan.net/2021/01/what-year-it-it)
+  { d: new Date('2021-01-01T00:00:00Z'), s: '2021-01-01' },
 ])('the date $d is formatted for the requests API as $s', ({ d, s }) => {
   expect(formatDateForRequestsAPI(d)).toBe(s);
 });

--- a/catalogue/webapp/components/ItemRequestModal/format-date.ts
+++ b/catalogue/webapp/components/ItemRequestModal/format-date.ts
@@ -17,3 +17,12 @@ export function dateFromValue(s: string): Date {
   // affected by the user's timezone.
   return new Date(`${years}-${months}-${days}T00:00:00Z`);
 }
+
+// Formats a date as YYYY-MM-DD, e.g. 2022-09-21
+export function formatDateForRequestsAPI(d: Date): string {
+  const years = d.getUTCFullYear().toString();
+  const months = (d.getUTCMonth() + 1).toString().padStart(2, '0');
+  const days = d.getUTCDate().toString().padStart(2, '0');
+
+  return `${years}-${months}-${days}`;
+}


### PR DESCRIPTION
UTC months are 0-indexed, not 1-indexed.  This was causing requests to be placed for the previous month. Tentative fix for https://github.com/wellcomecollection/wellcomecollection.org/issues/8457

I'm on a train; I don't have reliable enough Internet to test properly, but even if this isn't the whole issue it's definitely wrong.

## Who is this for?

People requesting items.

## What is it doing for them?

Making sure requests are placed for the right month.