### PR TITLE
Align pagination

### DIFF
--- a/cardigan/stories/components/Pagination/Pagination.stories.tsx
+++ b/cardigan/stories/components/Pagination/Pagination.stories.tsx
@@ -5,7 +5,7 @@ export const basic = Template.bind({});
 basic.args = {
   prevPage: 1,
   currentPage: 2,
-  pageCount: 10,
+  totalPages: 10,
   nextPage: 3,
   prevQueryString: '#',
   nextQueryString: '#',

--- a/common/views/components/Buttons/Control/Control.tsx
+++ b/common/views/components/Buttons/Control/Control.tsx
@@ -238,6 +238,7 @@ const BaseControl: FC<Props> = (
           scroll={scroll}
           replace={replace}
           prefetch={prefetch}
+          passHref
         >
           <Wrapper as="a" ref={ref} {...attrs}>
             <InnerControl text={text} icon={icon} />

--- a/common/views/components/Pagination/Pagination.tsx
+++ b/common/views/components/Pagination/Pagination.tsx
@@ -7,13 +7,13 @@ import { arrow } from '@weco/common/icons';
 import styled from 'styled-components';
 
 export type Props = {
-  total: number;
-  prevPage?: number;
+  totalResults: number;
   currentPage: number;
   totalPages: number;
+  prevPage?: number;
   nextPage?: number;
-  nextQueryString?: string;
   prevQueryString?: string;
+  nextQueryString?: string;
   range?: {
     beginning: number;
     end: number;
@@ -34,24 +34,22 @@ const PaginatorContainer = styled(Space).attrs({
   justify-content: flex-end;
 `;
 
-const PaginatorWrapper = styled.div.attrs({
-  className: 'font-pewter',
-})`
+const PaginatorWrapper = styled.nav`
   display: flex;
   align-items: center;
 `;
 
 const Pagination: FunctionComponent<Props> = ({
-  prevPage,
   currentPage,
   totalPages,
+  prevPage,
   nextPage,
-  nextQueryString,
   prevQueryString,
+  nextQueryString,
 }: Props) => {
   return (
     <PaginatorContainer>
-      <PaginatorWrapper aria-label="Pagination navigation" role="navigation">
+      <PaginatorWrapper aria-label="pagination">
         {prevPage && prevQueryString && (
           <Space as="span" h={{ size: 'm', properties: ['margin-right'] }}>
             <Rotator rotate={180}>
@@ -73,7 +71,7 @@ const Pagination: FunctionComponent<Props> = ({
           </Space>
         )}
 
-        <span>
+        <span className="font-pewter">
           Page {currentPage} of {totalPages}
         </span>
 
@@ -104,13 +102,13 @@ export default Pagination;
 export class PaginationFactory {
   static fromList(
     l: [],
-    total: number,
+    totalResults: number,
     currentPage = 1,
     pageSize = 32,
     getParams = {}
   ): Props {
     const size = l.length;
-    const totalPages = Math.ceil(total / pageSize);
+    const totalPages = Math.ceil(totalResults / pageSize);
     const prevPage =
       totalPages > 1 && currentPage !== 1 ? currentPage - 1 : undefined;
     const nextPage =
@@ -125,14 +123,14 @@ export class PaginationFactory {
     const nextQueryString = buildQueryString(nextPage, getParams);
     const prevQueryString = buildQueryString(prevPage, getParams);
     const pagination: Props = {
-      total,
-      range,
-      totalPages,
+      totalResults,
       currentPage,
-      nextPage,
+      totalPages,
       prevPage,
-      nextQueryString,
+      nextPage,
       prevQueryString,
+      nextQueryString,
+      range,
     };
     return pagination;
   }

--- a/common/views/components/Pagination/Pagination.tsx
+++ b/common/views/components/Pagination/Pagination.tsx
@@ -28,8 +28,7 @@ const PaginatorContainer = styled(Space).attrs({
     overrides: { small: 5, medium: 5, large: 1 },
   },
 })`
-  float: right;
-  display: inline-flex;
+  display: flex;
   align-items: center;
   justify-content: flex-end;
 `;

--- a/common/views/components/Pagination/Pagination.tsx
+++ b/common/views/components/Pagination/Pagination.tsx
@@ -4,12 +4,13 @@ import Control from '../Buttons/Control/Control';
 import Space from '../styled/Space';
 import Rotator from '../styled/Rotator';
 import { arrow } from '@weco/common/icons';
+import styled from 'styled-components';
 
 export type Props = {
   total: number;
   prevPage?: number;
   currentPage: number;
-  pageCount: number;
+  totalPages: number;
   nextPage?: number;
   nextQueryString?: string;
   prevQueryString?: string;
@@ -19,65 +20,85 @@ export type Props = {
   };
 };
 
+const PaginatorContainer = styled(Space).attrs({
+  className: font('intr', 5),
+  v: {
+    size: 'm',
+    properties: ['padding-top', 'padding-bottom'],
+    overrides: { small: 5, medium: 5, large: 1 },
+  },
+})`
+  float: right;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+`;
+
+const PaginatorWrapper = styled.div.attrs({
+  className: 'font-pewter',
+})`
+  display: flex;
+  align-items: center;
+`;
+
 const Pagination: FunctionComponent<Props> = ({
   prevPage,
   currentPage,
-  pageCount,
+  totalPages,
   nextPage,
   nextQueryString,
   prevQueryString,
-}: Props) => (
-  <div
-    className={`pagination float-r flex-inline flex--v-center font-pewter ${font(
-      'lr',
-      6
-    )}`}
-  >
-    {prevPage && prevQueryString && (
-      <Space as="span" h={{ size: 'm', properties: ['margin-right'] }}>
-        <Rotator rotate={180}>
-          <Control
-            link={{
-              // TODO: Fix the type checking here
-              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-              // @ts-ignore: Works but should be of LinkProps Type
-              href: prevQueryString,
-              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-              // @ts-ignore: Works but should be of LinkProps Type
-              as: prevQueryString,
-            }}
-            colorScheme="light"
-            icon={arrow}
-            text={`Previous (page ${prevPage})`}
-          />
-        </Rotator>
-      </Space>
-    )}
+}: Props) => {
+  return (
+    <PaginatorContainer>
+      <PaginatorWrapper aria-label="Pagination navigation" role="navigation">
+        {prevPage && prevQueryString && (
+          <Space as="span" h={{ size: 'm', properties: ['margin-right'] }}>
+            <Rotator rotate={180}>
+              <Control
+                link={{
+                  // TODO: Fix the type checking here
+                  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                  // @ts-ignore: Works but should be of LinkProps Type
+                  href: prevQueryString,
+                  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                  // @ts-ignore: Works but should be of LinkProps Type
+                  as: prevQueryString,
+                }}
+                colorScheme="light"
+                icon={arrow}
+                text={`Previous (page ${prevPage})`}
+              />
+            </Rotator>
+          </Space>
+        )}
 
-    <span>
-      Page {currentPage} of {pageCount}
-    </span>
+        <span>
+          Page {currentPage} of {totalPages}
+        </span>
 
-    {nextPage && nextQueryString && (
-      <Space as="span" h={{ size: 'm', properties: ['margin-left'] }}>
-        <Control
-          link={{
-            // TODO: Fix the type checking here
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore: Works but should be of LinkProps Type
-            href: nextQueryString,
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore: Works but should be of LinkProps Type
-            as: nextQueryString,
-          }}
-          colorScheme="light"
-          icon={arrow}
-          text={`Next (page ${nextPage})`}
-        />
-      </Space>
-    )}
-  </div>
-);
+        {nextPage && nextQueryString && (
+          <Space as="span" h={{ size: 'm', properties: ['margin-left'] }}>
+            <Control
+              link={{
+                // TODO: Fix the type checking here
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore: Works but should be of LinkProps Type
+                href: nextQueryString,
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore: Works but should be of LinkProps Type
+                as: nextQueryString,
+              }}
+              colorScheme="light"
+              icon={arrow}
+              text={`Next (page ${nextPage})`}
+            />
+          </Space>
+        )}
+      </PaginatorWrapper>
+    </PaginatorContainer>
+  );
+};
 
 export default Pagination;
 export class PaginationFactory {
@@ -89,11 +110,13 @@ export class PaginationFactory {
     getParams = {}
   ): Props {
     const size = l.length;
-    const pageCount = Math.ceil(total / pageSize);
+    const totalPages = Math.ceil(total / pageSize);
     const prevPage =
-      pageCount > 1 && currentPage !== 1 ? currentPage - 1 : undefined;
+      totalPages > 1 && currentPage !== 1 ? currentPage - 1 : undefined;
     const nextPage =
-      pageCount > 1 && currentPage !== pageCount ? currentPage + 1 : undefined;
+      totalPages > 1 && currentPage !== totalPages
+        ? currentPage + 1
+        : undefined;
     const beginning = pageSize * currentPage - pageSize + 1;
     const range = {
       beginning,
@@ -104,7 +127,7 @@ export class PaginationFactory {
     const pagination: Props = {
       total,
       range,
-      pageCount,
+      totalPages,
       currentPage,
       nextPage,
       prevPage,

--- a/common/views/components/Paginator/Paginator.tsx
+++ b/common/views/components/Paginator/Paginator.tsx
@@ -22,16 +22,32 @@ type Props = {
   isLoading?: boolean;
 };
 
+const PaginatorContainer = styled(Space).attrs({
+  className: font('intr', 5),
+  v: {
+    size: 'm',
+    properties: ['padding-top', 'padding-bottom'],
+    overrides: { small: 5, medium: 5, large: 1 },
+  },
+})`
+  float: right;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+`;
+
 type PaginatorWrapperProps = {
   hideMobilePagination: boolean | undefined;
 };
 const PaginatorWrapper = styled.div.attrs<PaginatorWrapperProps>(props => ({
   className: classNames({
     'is-hidden-s': Boolean(props.hideMobilePagination),
-    flex: true,
-    'flex--v-center': true,
+    'font-pewter': true,
   }),
-}))<PaginatorWrapperProps>``;
+}))<PaginatorWrapperProps>`
+  display: flex;
+  align-items: center;
+`;
 
 type TotalResultsWrapperProps = {
   hideMobileTotalResults: boolean | undefined;
@@ -57,42 +73,42 @@ const Paginator: FunctionComponent<Props> = ({
   isLoading,
 }: Props) => {
   const totalPages = Math.ceil(totalResults / pageSize);
-  const next = currentPage < totalPages ? currentPage + 1 : null;
-  const prev = currentPage > 1 ? currentPage - 1 : null;
+  const nextPage = currentPage < totalPages ? currentPage + 1 : null;
+  const prevPage = currentPage > 1 ? currentPage - 1 : null;
 
-  const prevLink = prev
+  const prevQueryString = prevPage
     ? {
         href: {
           ...link.href,
           query: {
             ...link.href.query,
-            page: prev,
+            page: prevPage,
           },
         },
         as: {
           ...link.as,
           query: {
             ...link?.as?.query,
-            page: prev,
+            page: prevPage,
           },
         },
       }
     : null;
 
-  const nextLink = next
+  const nextQueryString = nextPage
     ? {
         href: {
           ...link.href,
           query: {
             ...link.href.query,
-            page: next,
+            page: nextPage,
           },
         },
         as: {
           ...link.as,
           query: {
             ...link?.as?.query,
-            page: next,
+            page: nextPage,
           },
         },
       }
@@ -112,59 +128,50 @@ const Paginator: FunctionComponent<Props> = ({
           {query && ` for “${query}”`}
         </TotalResultsWrapper>
       </Space>
-      <Space
-        className={
-          'pagination float-r flex-inline flex--v-center flex-end' +
-          ' ' +
-          font('intr', 5)
-        }
-        v={{
-          size: 'm',
-          properties: ['padding-top', 'padding-bottom'],
-          overrides: { small: 5, medium: 5, large: 1 },
-        }}
-      >
+      <PaginatorContainer>
         {showPortal && <div id="sort-select-portal"></div>}
         <PaginatorWrapper
           hideMobilePagination={hideMobilePagination}
           aria-label="Pagination navigation"
           role="navigation"
         >
-          {prevLink && prev && (
+          {prevPage && prevQueryString && (
             <Space as="span" h={{ size: 'm', properties: ['margin-right'] }}>
               <Rotator rotate={180}>
                 <Control
-                  link={prevLink}
-                  clickHandler={event => {
-                    onPageChange(event, prev);
-                  }}
+                  link={prevQueryString}
                   colorScheme="light"
                   icon={arrow}
-                  text={`Previous (page ${prev})`}
+                  text={`Previous (page ${prevPage})`}
                   disabled={isLoading}
+                  clickHandler={event => {
+                    onPageChange(event, prevPage);
+                  }}
                 />
               </Rotator>
             </Space>
           )}
-          <span className="font-pewter">
+
+          <span>
             Page {currentPage} of {totalPages}
           </span>
-          {nextLink && next && (
+
+          {nextPage && nextQueryString && (
             <Space as="span" h={{ size: 'm', properties: ['margin-left'] }}>
               <Control
-                link={nextLink}
-                clickHandler={event => {
-                  onPageChange(event, next);
-                }}
+                link={nextQueryString}
                 colorScheme="light"
                 icon={arrow}
-                text={`Next (page ${next})`}
+                text={`Next (page ${nextPage})`}
                 disabled={isLoading}
+                clickHandler={event => {
+                  onPageChange(event, nextPage);
+                }}
               />
             </Space>
           )}
         </PaginatorWrapper>
-      </Space>
+      </PaginatorContainer>
     </Fragment>
   );
 };

--- a/common/views/components/Paginator/Paginator.tsx
+++ b/common/views/components/Paginator/Paginator.tsx
@@ -10,13 +10,13 @@ import { arrow } from '@weco/common/icons';
 type PageChangeFunction = (event: Event, page: number) => Promise<void>;
 
 type Props = {
-  query?: string;
-  showPortal?: boolean;
+  totalResults: number;
   currentPage: number;
   pageSize: number;
-  totalResults: number;
   link: LinkProps;
   onPageChange: PageChangeFunction;
+  query?: string;
+  showPortal?: boolean;
   hideMobilePagination?: boolean;
   hideMobileTotalResults?: boolean;
   isLoading?: boolean;
@@ -39,10 +39,9 @@ const PaginatorContainer = styled(Space).attrs({
 type PaginatorWrapperProps = {
   hideMobilePagination: boolean | undefined;
 };
-const PaginatorWrapper = styled.div.attrs<PaginatorWrapperProps>(props => ({
+const PaginatorWrapper = styled.nav.attrs<PaginatorWrapperProps>(props => ({
   className: classNames({
     'is-hidden-s': Boolean(props.hideMobilePagination),
-    'font-pewter': true,
   }),
 }))<PaginatorWrapperProps>`
   display: flex;
@@ -61,13 +60,13 @@ const TotalResultsWrapper = styled.div.attrs<TotalResultsWrapperProps>(
 )<TotalResultsWrapperProps>``;
 
 const Paginator: FunctionComponent<Props> = ({
-  query,
-  showPortal,
+  totalResults,
   currentPage,
   pageSize,
-  totalResults,
   link,
   onPageChange,
+  query,
+  showPortal,
   hideMobilePagination,
   hideMobileTotalResults,
   isLoading,
@@ -132,8 +131,7 @@ const Paginator: FunctionComponent<Props> = ({
         {showPortal && <div id="sort-select-portal"></div>}
         <PaginatorWrapper
           hideMobilePagination={hideMobilePagination}
-          aria-label="Pagination navigation"
-          role="navigation"
+          aria-label="pagination"
         >
           {prevPage && prevQueryString && (
             <Space as="span" h={{ size: 'm', properties: ['margin-right'] }}>
@@ -152,7 +150,7 @@ const Paginator: FunctionComponent<Props> = ({
             </Space>
           )}
 
-          <span>
+          <span className="font-pewter">
             Page {currentPage} of {totalPages}
           </span>
 

--- a/common/views/components/Paginator/Paginator.tsx
+++ b/common/views/components/Paginator/Paginator.tsx
@@ -30,8 +30,7 @@ const PaginatorContainer = styled(Space).attrs({
     overrides: { small: 5, medium: 5, large: 1 },
   },
 })`
-  float: right;
-  display: inline-flex;
+  display: flex;
   align-items: center;
   justify-content: flex-end;
 `;

--- a/content/webapp/components/CardGrid/CardGrid.tsx
+++ b/content/webapp/components/CardGrid/CardGrid.tsx
@@ -1,4 +1,4 @@
-import { ForwardedRef, forwardRef, FunctionComponent } from 'react';
+import { FunctionComponent } from 'react';
 import { classNames, cssGrid } from '@weco/common/utils/classnames';
 import { Link } from '../../types/link';
 import { convertItemToCardProps } from '../../types/card';
@@ -25,20 +25,17 @@ type Props = {
   fromDate?: Date;
 };
 
-const CardGrid: FunctionComponent<Props> = (
-  {
-    items,
-    hidePromoText,
-    itemsPerRow,
-    itemsHaveTransparentBackground = false,
-    links,
-    fromDate,
-  }: Props,
-  ref?: ForwardedRef<HTMLDivElement>
-) => {
+const CardGrid: FunctionComponent<Props> = ({
+  items,
+  hidePromoText,
+  itemsPerRow,
+  itemsHaveTransparentBackground = false,
+  links,
+  fromDate,
+}: Props) => {
   const gridColumns = itemsPerRow === 4 ? 3 : 4;
   return (
-    <div ref={ref} tabIndex={-1}>
+    <div>
       <CssGridContainer>
         <div className="css-grid">
           {items.map((item, i) => (
@@ -105,4 +102,4 @@ const CardGrid: FunctionComponent<Props> = (
   );
 };
 
-export default forwardRef<HTMLDivElement, Props>(CardGrid);
+export default CardGrid;

--- a/content/webapp/components/CardGrid/CardGrid.tsx
+++ b/content/webapp/components/CardGrid/CardGrid.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent } from 'react';
+import { ForwardedRef, forwardRef, FunctionComponent } from 'react';
 import { classNames, cssGrid } from '@weco/common/utils/classnames';
 import { Link } from '../../types/link';
 import { convertItemToCardProps } from '../../types/card';
@@ -25,17 +25,20 @@ type Props = {
   fromDate?: Date;
 };
 
-const CardGrid: FunctionComponent<Props> = ({
-  items,
-  hidePromoText,
-  itemsPerRow,
-  itemsHaveTransparentBackground = false,
-  links,
-  fromDate,
-}: Props) => {
+const CardGrid: FunctionComponent<Props> = (
+  {
+    items,
+    hidePromoText,
+    itemsPerRow,
+    itemsHaveTransparentBackground = false,
+    links,
+    fromDate,
+  }: Props,
+  ref?: ForwardedRef<HTMLDivElement>
+) => {
   const gridColumns = itemsPerRow === 4 ? 3 : 4;
   return (
-    <div>
+    <div ref={ref} tabIndex={-1}>
       <CssGridContainer>
         <div className="css-grid">
           {items.map((item, i) => (
@@ -102,4 +105,4 @@ const CardGrid: FunctionComponent<Props> = ({
   );
 };
 
-export default CardGrid;
+export default forwardRef<HTMLDivElement, Props>(CardGrid);

--- a/content/webapp/components/LayoutPaginatedResults/LayoutPaginatedResults.tsx
+++ b/content/webapp/components/LayoutPaginatedResults/LayoutPaginatedResults.tsx
@@ -107,7 +107,7 @@ const LayoutPaginatedResults: FC<Props> = ({
         <Layout12>
           <div className="text-align-right">
             <Pagination
-              total={paginatedResults.totalResults}
+              totalResults={paginatedResults.totalResults}
               currentPage={paginatedResults.currentPage}
               totalPages={paginatedResults.totalPages}
               prevPage={

--- a/content/webapp/components/LayoutPaginatedResults/LayoutPaginatedResults.tsx
+++ b/content/webapp/components/LayoutPaginatedResults/LayoutPaginatedResults.tsx
@@ -109,7 +109,7 @@ const LayoutPaginatedResults: FC<Props> = ({
             <Pagination
               total={paginatedResults.totalResults}
               currentPage={paginatedResults.currentPage}
-              pageCount={paginatedResults.totalPages}
+              totalPages={paginatedResults.totalPages}
               prevPage={
                 paginatedResults.currentPage > 1
                   ? paginatedResults.currentPage - 1

--- a/content/webapp/pages/exhibitions.tsx
+++ b/content/webapp/pages/exhibitions.tsx
@@ -1,6 +1,5 @@
 import type { GetServerSideProps } from 'next';
-import { FC, useEffect, useRef, useState } from 'react';
-import { useRouter } from 'next/router';
+import { FC } from 'react';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import { Period } from '../types/periods';
 import { PaginatedResults } from '@weco/common/services/prismic/types';
@@ -72,10 +71,6 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   };
 
 const ExhibitionsPage: FC<Props> = props => {
-  const { query } = useRouter();
-  const contentSection = useRef<HTMLDivElement>(null);
-  const [currentPage, setCurrentPage] = useState(query?.page || '1');
-
   const { exhibitions, period, title, jsonLd } = props;
   const firstExhibition = exhibitions[0];
 
@@ -98,14 +93,6 @@ const ExhibitionsPage: FC<Props> = props => {
   );
 
   const paginationRoot = `exhibitions${period ? `/${period}` : ''}`;
-
-  useEffect(() => {
-    if (query.page !== currentPage && contentSection?.current) {
-      setCurrentPage(query.page || '1');
-      contentSection.current.focus();
-      contentSection.current.scrollIntoView({ behavior: 'smooth' });
-    }
-  }, [query]);
 
   return (
     <PageLayout
@@ -167,7 +154,6 @@ const ExhibitionsPage: FC<Props> = props => {
               items={partitionedExhibitionItems.past}
               itemsHaveTransparentBackground={true}
               itemsPerRow={3}
-              ref={contentSection}
             />
             {exhibitions.totalPages > 1 && (
               <Layout12>

--- a/content/webapp/pages/exhibitions.tsx
+++ b/content/webapp/pages/exhibitions.tsx
@@ -161,7 +161,7 @@ const ExhibitionsPage: FC<Props> = props => {
                   <Pagination
                     total={exhibitions.totalResults}
                     currentPage={exhibitions.currentPage}
-                    pageCount={exhibitions.totalPages}
+                    totalPages={exhibitions.totalPages}
                     prevPage={
                       exhibitions.currentPage > 1
                         ? exhibitions.currentPage - 1

--- a/content/webapp/pages/exhibitions.tsx
+++ b/content/webapp/pages/exhibitions.tsx
@@ -1,5 +1,6 @@
 import type { GetServerSideProps } from 'next';
-import { FC } from 'react';
+import { FC, useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/router';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import { Period } from '../types/periods';
 import { PaginatedResults } from '@weco/common/services/prismic/types';
@@ -71,6 +72,10 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   };
 
 const ExhibitionsPage: FC<Props> = props => {
+  const { query } = useRouter();
+  const contentSection = useRef<HTMLDivElement>(null);
+  const [currentPage, setCurrentPage] = useState(query?.page || '1');
+
   const { exhibitions, period, title, jsonLd } = props;
   const firstExhibition = exhibitions[0];
 
@@ -93,6 +98,14 @@ const ExhibitionsPage: FC<Props> = props => {
   );
 
   const paginationRoot = `exhibitions${period ? `/${period}` : ''}`;
+
+  useEffect(() => {
+    if (query.page !== currentPage && contentSection?.current) {
+      setCurrentPage(query.page || '1');
+      contentSection.current.focus();
+      contentSection.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [query]);
 
   return (
     <PageLayout
@@ -154,12 +167,13 @@ const ExhibitionsPage: FC<Props> = props => {
               items={partitionedExhibitionItems.past}
               itemsHaveTransparentBackground={true}
               itemsPerRow={3}
+              ref={contentSection}
             />
             {exhibitions.totalPages > 1 && (
               <Layout12>
                 <div className="text-align-right">
                   <Pagination
-                    total={exhibitions.totalResults}
+                    totalResults={exhibitions.totalResults}
                     currentPage={exhibitions.currentPage}
                     totalPages={exhibitions.totalPages}
                     prevPage={


### PR DESCRIPTION
## Who is this for?
Users

## What is it doing for them?
Allows pagination to be keyboard navigable.
Also aligned how it looked across the site and var names they were using. Eventually we'll need to look into pagination bit more deeply ([see comments on ticket](https://github.com/wellcomecollection/wellcomecollection.org/issues/8394))


Paginator
<img width="292" alt="paginator2" src="https://user-images.githubusercontent.com/110461050/190201766-279007c4-147a-4fa4-8c9d-69cac85bef8a.png">


Pagination before/after
<img width="299" alt="pagination2" src="https://user-images.githubusercontent.com/110461050/190201422-19332d87-c040-4721-9eb7-7b4dc8ed1441.png">
<img width="279" alt="Screenshot 2022-09-14 at 16 46 03" src="https://user-images.githubusercontent.com/110461050/190201494-0bb937c5-bed5-411f-987e-6def8db56f07.png">


Closes #8394 