### PR TITLE
Split a couple of classNames so the font() is on one line

### DIFF
--- a/common/views/components/Header/DesktopSignIn.tsx
+++ b/common/views/components/Header/DesktopSignIn.tsx
@@ -52,10 +52,11 @@ const DesktopSignIn: FC = () => {
             />
           </span>
           <span
-            className={`display-none headerMedium-display-block headerLarge-display-none ${font(
-              'intr',
-              6
-            )}`}
+            className={
+              'display-none headerMedium-display-block headerLarge-display-none' +
+              ' ' +
+              font('intr', 6)
+            }
           >
             <DropdownButton
               label=""

--- a/common/views/components/Pagination/Pagination.tsx
+++ b/common/views/components/Pagination/Pagination.tsx
@@ -28,10 +28,11 @@ const Pagination: FunctionComponent<Props> = ({
   prevQueryString,
 }: Props) => (
   <div
-    className={`pagination float-r flex-inline flex--v-center font-pewter ${font(
-      'lr',
-      6
-    )}`}
+    className={
+      'pagination float-r flex-inline flex--v-center font-pewter' +
+      ' ' +
+      font('lr', 6)
+    }
   >
     {prevPage && prevQueryString && (
       <Space as="span" h={{ size: 'm', properties: ['margin-right'] }}>

--- a/common/views/components/PopupDialog/PopupDialog.tsx
+++ b/common/views/components/PopupDialog/PopupDialog.tsx
@@ -39,10 +39,10 @@ const PopupDialogOpen = styled(Space).attrs<PopupDialogOpenProps>(props => ({
     properties: ['padding-left', 'padding-right'],
     overrides: { small: 5, medium: 5, large: 5 },
   },
-  className: `${font(
-    'intb',
-    5
-  )} plain-button line-height-1 flex-inline flex--v-center`,
+  className:
+    font('intb', 5) +
+    ' ' +
+    'plain-button line-height-1 flex-inline flex--v-center',
 }))<PopupDialogOpenProps>`
   color: ${props => props.theme.color('purple')};
   position: fixed;

--- a/common/views/components/SegmentedControl/SegmentedControl.tsx
+++ b/common/views/components/SegmentedControl/SegmentedControl.tsx
@@ -1,4 +1,4 @@
-import { Component, Fragment } from 'react';
+import { Component, Fragment, ReactElement } from 'react';
 import { chevron, cross } from '@weco/common/icons';
 import { classNames, font } from '../../../utils/classnames';
 import Icon from '../Icon/Icon';
@@ -211,7 +211,7 @@ class SegmentedControl extends Component<Props, State> {
     isActive: false,
   };
 
-  setActiveId(id: string) {
+  setActiveId(id: string): void {
     this.setState({
       activeId: id,
     });
@@ -221,13 +221,13 @@ class SegmentedControl extends Component<Props, State> {
     }
   }
 
-  componentDidMount() {
+  componentDidMount(): void {
     this.setActiveId(
       this.props.activeId || (this.props.items[0] && this.props.items[0].id)
     );
   }
 
-  render() {
+  render(): ReactElement {
     const { id, items, extraClasses } = this.props;
     const { activeId, isActive } = this.state;
 
@@ -269,7 +269,7 @@ class SegmentedControl extends Component<Props, State> {
                 <DrawerItem isFirst={i === 0} key={item.id}>
                   <a
                     onClick={e => {
-                      const url = e.currentTarget.getAttribute('href')!;
+                      const url = e.currentTarget.href;
                       const isHash = url.startsWith('#');
 
                       trackEvent({
@@ -305,7 +305,7 @@ class SegmentedControl extends Component<Props, State> {
               <ItemInner
                 isActive={item.id === activeId}
                 onClick={e => {
-                  const url = e.currentTarget.getAttribute('href')!;
+                  const url = e.currentTarget.href;
                   const isHash = url.startsWith('#');
 
                   trackEvent({

--- a/common/views/components/SegmentedControl/SegmentedControl.tsx
+++ b/common/views/components/SegmentedControl/SegmentedControl.tsx
@@ -175,10 +175,10 @@ const Wrapper = styled.div.attrs({})<IsActiveProps>`
 const MobileControlsContainer = styled(Space).attrs({
   v: { size: 'm', properties: ['padding-top', 'padding-bottom'] },
   h: { size: 'm', properties: ['padding-left', 'padding-right'] },
-  className: `${font(
-    'wb',
-    4
-  )} segmented-control__button-text font-white flex--h-space-between rounded-diagonal`,
+  className:
+    font('wb', 4) +
+    ' ' +
+    'segmented-control__button-text font-white flex--h-space-between rounded-diagonal',
 })`
   display: flex;
   background-color: ${props => props.theme.color('black')};

--- a/content/webapp/pages/event.tsx
+++ b/content/webapp/pages/event.tsx
@@ -345,10 +345,9 @@ const EventPage: NextPage<Props> = ({ event, jsonLd }: Props) => {
                     {event.thirdPartyBooking.name && (
                       <Space v={{ size: 's', properties: ['margin-top'] }}>
                         <p
-                          className={`no-margin font-charcoal ${font(
-                            'intr',
-                            5
-                          )}`}
+                          className={
+                            'no-margin font-charcoal' + ' ' + font('intr', 5)
+                          }
                         >
                           with {event.thirdPartyBooking.name}
                         </p>


### PR DESCRIPTION
Follows https://github.com/wellcomecollection/wellcomecollection.org/pull/8432

One of the things I tried to do is avoid string interpolation in a way that means the formatter would split `font('intr', 6)` (or similar) across multiple lines, because that's way less readable IMO. This fixes a couple of other instances of that.

The other changes in SegmentedControl are because the pre-commit hook wouldn't let me commit until I fixed all the outstanding warnings.