### PR TITLE
Be super-duper explicit that isSameDayOrBefore is London-only

### DIFF
--- a/catalogue/webapp/components/Calendar/Calendar.tsx
+++ b/catalogue/webapp/components/Calendar/Calendar.tsx
@@ -164,8 +164,8 @@ function handleKeyDown(
     const moveToDate = newDate(date, key);
     setUpdateFocus(true);
     if (
-      isSameDayOrBefore(min, moveToDate, 'London') &&
-      isSameDayOrBefore(moveToDate, max, 'London')
+      isSameDayOrBefore(min, moveToDate) &&
+      isSameDayOrBefore(moveToDate, max)
     ) {
       // 'day' is for granularity, [] means inclusive (https://momentjscom.readthedocs.io/en/latest/moment/05-query/06-is-between/)
       setTabbableDate(moveToDate);

--- a/catalogue/webapp/components/Calendar/Calendar.tsx
+++ b/catalogue/webapp/components/Calendar/Calendar.tsx
@@ -164,8 +164,8 @@ function handleKeyDown(
     const moveToDate = newDate(date, key);
     setUpdateFocus(true);
     if (
-      isSameDayOrBefore(min, moveToDate) &&
-      isSameDayOrBefore(moveToDate, max)
+      isSameDayOrBefore(min, moveToDate, 'London') &&
+      isSameDayOrBefore(moveToDate, max, 'London')
     ) {
       // 'day' is for granularity, [] means inclusive (https://momentjscom.readthedocs.io/en/latest/moment/05-query/06-is-between/)
       setTabbableDate(moveToDate);

--- a/catalogue/webapp/utils/dates.ts
+++ b/catalogue/webapp/utils/dates.ts
@@ -238,14 +238,12 @@ export function isRequestableDate(params: {
         // both start and end date
         (startDate &&
           endDate &&
-          isSameDayOrBefore(startDate, date, 'London') &&
-          isSameDayOrBefore(date, endDate, 'London')) ||
+          isSameDayOrBefore(startDate, date) &&
+          isSameDayOrBefore(date, endDate)) ||
         // only start date
-        (startDate &&
-          !endDate &&
-          isSameDayOrBefore(startDate, date, 'London')) ||
+        (startDate && !endDate && isSameDayOrBefore(startDate, date)) ||
         // only end date
-        (endDate && !startDate && isSameDayOrBefore(date, endDate, 'London'))
+        (endDate && !startDate && isSameDayOrBefore(date, endDate))
     ) && // both start and end date
     !isExceptionalClosedDay &&
     !isRegularClosedDay

--- a/common/utils/dates.test.ts
+++ b/common/utils/dates.test.ts
@@ -31,19 +31,19 @@ describe('isSameDay', () => {
 
   describe('ComparisonMode', () => {
     const september19Midnight = new Date(
-      // aka Sun Sep 18 2022 23:00:00 UTC
+      // = Sep 18 2022 23:00:00 UTC
       'Mon Sep 19 2022 00:00:00 GMT+0100 (British Summer Time)'
     );
     const september18TwentyThreeThirty = new Date(
-      // aka Sun Sep 18 2022 22:30:00 UTC
+      // = Sep 18 2022 22:30:00 UTC
       'Sun Sep 18 2022 23:30:00 GMT+0100 (British Summer Time)'
     );
     const september19MidnightThirty = new Date(
-      // aka Sun Sep 18 2022 23:30:00 UTC
+      // = Sep 18 2022 23:30:00 UTC
       'Mon Sep 19 2022 00:30:00 GMT+0100 (British Summer Time)'
     );
     const september19Midday = new Date(
-      // aka Sun Sep 18 2022 11:00:00 UTC
+      // = Sep 19 2022 11:00:00 UTC
       'Mon Sep 19 2022 12:00:00 GMT+0100 (British Summer Time)'
     );
 

--- a/common/utils/dates.test.ts
+++ b/common/utils/dates.test.ts
@@ -119,11 +119,11 @@ describe('isSameDayOrBefore', () => {
 
   it('says two times on the same day in London are the same, even if they’re different UTC days', () => {
     const date1 = new Date(
-      // = -09-01T23:30:00 UTC
+      // =    -01T23:30:00 UTC
       '2002-09-02T00:30:00+0100'
     );
     const date2 = new Date(
-      // = -09-02T00:30:00 UTC
+      // =    -02T00:30:00 UTC
       '2002-09-02T01:30:00+0100'
     );
 

--- a/common/utils/dates.test.ts
+++ b/common/utils/dates.test.ts
@@ -44,7 +44,7 @@ describe('isSameDay', () => {
     );
     const september19Midday = new Date(
       // aka Sun Sep 18 2022 11:00:00 UTC
-     'Mon Sep 19 2022 12:00:00 GMT+0100 (British Summer Time)'
+      'Mon Sep 19 2022 12:00:00 GMT+0100 (British Summer Time)'
     );
 
     it('says midnight {x} BST in London is on the same day as midday {x} BST using a comparison mode of "London"', () => {

--- a/common/utils/dates.test.ts
+++ b/common/utils/dates.test.ts
@@ -127,8 +127,22 @@ describe('isSameDayOrBefore', () => {
       '2002-09-02T01:30:00+0100'
     );
 
-    expect(isSameDayOrBefore(date1, date2, 'London')).toEqual(true);
-    expect(isSameDayOrBefore(date2, date1, 'London')).toEqual(true);
+    expect(isSameDayOrBefore(date1, date2)).toEqual(true);
+    expect(isSameDayOrBefore(date2, date1)).toEqual(true);
+  });
+
+  it('knows how dates on different days in London are ordered, even if they’re the same UTC day', () => {
+    const date1 = new Date(
+      // =    -01T22:30:00 UTC
+      '2002-09-01T23:30:00+0100'
+    );
+    const date2 = new Date(
+      // =    -01T23:30:00 UTC
+      '2002-09-02T00:30:00+0100'
+    );
+
+    expect(isSameDayOrBefore(date1, date2)).toEqual(true);
+    expect(isSameDayOrBefore(date2, date1)).toEqual(false);
   });
 
   it('knows how dates on different days are ordered', () => {

--- a/common/utils/dates.test.ts
+++ b/common/utils/dates.test.ts
@@ -117,6 +117,20 @@ describe('isSameDayOrBefore', () => {
     expect(isSameDayOrBefore(date2, date1)).toEqual(true);
   });
 
+  it('says two times on the same day in London are the same, even if they’re different UTC days', () => {
+    const date1 = new Date(
+      // = -09-01T23:30:00 UTC
+      '2002-09-02T00:30:00+0100'
+    );
+    const date2 = new Date(
+      // = -09-02T00:30:00 UTC
+      '2002-09-02T01:30:00+0100'
+    );
+
+    expect(isSameDayOrBefore(date1, date2, 'London')).toEqual(true);
+    expect(isSameDayOrBefore(date2, date1, 'London')).toEqual(true);
+  });
+
   it('knows how dates on different days are ordered', () => {
     const date1 = new Date('2001-01-01T01:01:01Z');
     const date2 = new Date('2002-02-02T02:02:02Z');

--- a/common/utils/dates.ts
+++ b/common/utils/dates.ts
@@ -53,18 +53,24 @@ export function isSameDay(
   }
 }
 
-// Note: the order of arguments to this function is designed so you can
-// concatenate them and get sensible-looking results.
-//
-//      isSameDayOrBefore(A, B) && isSameDayOrBefore(B, C)
-//        => isSameDayOrBefore(A, C)
-//
-export function isSameDayOrBefore(
-  date1: Date,
-  date2: Date,
-  mode: ComparisonMode = 'UTC'
-): boolean {
-  return isSameDay(date1, date2, mode) || date1 <= date2;
+/** Returns true if `date1` is on the same day or before `date2`,
+ * false otherwise.
+ *
+ * This compares the dates in London, not UTC.  See the tests for examples
+ * of edge cases where there are different UTC days but this function still
+ * returns true.
+ *
+ * Note: the order of arguments to this function is designed so you can
+ * concatenate them and get sensible-looking results.
+ *
+ *    isSameDayOrBefore(A, B) && isSameDayOrBefore(B, C)
+ *      => isSameDayOrBefore(A, C)
+ *
+ * (The fancy term is "transitive".)
+ *
+ */
+export function isSameDayOrBefore(date1: Date, date2: Date): boolean {
+  return isSameDay(date1, date2, 'London') || date1 <= date2;
 }
 
 // Returns true if 'date' falls on a past day; false otherwise.


### PR DESCRIPTION
## Who is this for?

Devs.

## What is it doing for them?

We only use `isSameDayOrBefore` to decide what dates a user can pick for requesting items, and there we want a London comparison (both in the visual calendar and the dropdown picker).

This patch doesn't change the behaviour of `isSameDayOrBefore` at all, but does make it very explicit that's what we want:

* I've removed the `mode` argument, because it should only ever be `London`
* I've added more tests that it's doing a London comparison, not a UTC comparison
* I've written a function comment that explains this is doing London comparisons

Follows https://github.com/wellcomecollection/wellcomecollection.org/pull/8455, where we added this `mode` argument. I suspect we can also remove it from `isSameDay()`, but I don't want to change too much at once.

For https://github.com/wellcomecollection/wellcomecollection.org/issues/7831