### PR TITLE
Link to the raw catalogue API query in the API toolbar

### DIFF
--- a/catalogue/webapp/pages/images.tsx
+++ b/catalogue/webapp/pages/images.tsx
@@ -150,6 +150,17 @@ const Images: NextPage<Props> = ({
         jsonLd={{ '@type': 'WebPage' }}
         siteSection="collections"
         image={undefined}
+        apiToolbarLinks={
+          images
+            ? [
+                {
+                  id: 'catalogue-api-query',
+                  label: 'Catalogue API query',
+                  link: images._requestUrl,
+                },
+              ]
+            : []
+        }
       >
         <Space
           v={{

--- a/catalogue/webapp/pages/works.tsx
+++ b/catalogue/webapp/pages/works.tsx
@@ -101,6 +101,13 @@ const Works: NextPage<Props> = ({ works, worksRouteProps }) => {
         jsonLd={{ '@type': 'WebPage' }}
         siteSection="collections"
         excludeRoleMain={true}
+        apiToolbarLinks={[
+          {
+            id: 'catalogue-api-query',
+            label: 'Catalogue API query',
+            link: works._requestUrl,
+          },
+        ]}
       >
         <Space
           v={{

--- a/catalogue/webapp/services/catalogue/index.ts
+++ b/catalogue/webapp/services/catalogue/index.ts
@@ -95,7 +95,10 @@ export async function catalogueQuery<Params, Result extends ResultType>(
     const res = await catalogueFetch(url);
     const json = await res.json();
 
-    return json;
+    return {
+      ...json,
+      _requestUrl: url,
+    };
   } catch (error) {
     return catalogueApiError();
   }

--- a/common/model/catalogue.ts
+++ b/common/model/catalogue.ts
@@ -340,4 +340,8 @@ export type CatalogueResultsList<Result extends ResultType> = {
     : Result extends Concept
     ? ConceptAggregations
     : null;
+
+  // We include the URL used to fetch data from the catalogue API for
+  // debugging purposes.
+  _requestUrl: string;
 };

--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -18,7 +18,7 @@ import { wellcomeCollectionGallery } from '../../../data/organization';
 import GlobalInfoBarContext, {
   GlobalInfoBarContextProvider,
 } from '../GlobalInfoBarContext/GlobalInfoBarContext';
-import ApiToolbar from '../ApiToolbar/ApiToolbar';
+import ApiToolbar, { ApiToolbarLink } from '../ApiToolbar/ApiToolbar';
 import { usePrismicData, useToggles } from '../../../server-data/Context';
 import { defaultPageTitle } from '@weco/common/data/microcopy';
 import { getCrop, ImageType } from '@weco/common/model/image';
@@ -52,6 +52,7 @@ export type Props = {
   hideFooter?: boolean;
   excludeRoleMain?: boolean;
   headerProps?: HeaderProps;
+  apiToolbarLinks?: ApiToolbarLink[];
 };
 
 const PageLayoutComponent: FunctionComponent<Props> = ({
@@ -68,6 +69,7 @@ const PageLayoutComponent: FunctionComponent<Props> = ({
   hideFooter = false,
   excludeRoleMain = false,
   headerProps,
+  apiToolbarLinks = [],
 }) => {
   const { apiToolbar } = useToggles();
   const urlString = convertUrlToString(url);
@@ -252,7 +254,7 @@ const PageLayoutComponent: FunctionComponent<Props> = ({
       </Head>
 
       <div id="root">
-        {apiToolbar && <ApiToolbar />}
+        {apiToolbar && <ApiToolbar extraLinks={apiToolbarLinks} />}
         <CookieNotice source={url.pathname || ''} />
         <a className="visually-hidden visually-hidden-focusable" href="#main">
           Skip to main content


### PR DESCRIPTION
Jonathan and I have just had a confusing incident where we seemed to be getting mismatched results between the front-end and the API, because the front-end knew to quote the values, and we didn't.

This adds a link to the catalogue API query from the API toolbar, which should make this sort of thing easier to reason about – we can easily see what queries the front-end is making.

## Who is this for?

Developers.

## What is it doing for them?

Making it easier to debug the collections search.