### PR TITLE
Fetch workId from correct source

### DIFF
--- a/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
+++ b/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
@@ -85,20 +85,21 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
   );
 
   const imageRenderer = useCallback(galleryImage => {
+    const photo: GalleryImageProps = galleryImage.photo;
     return (
       <ImageContainer key={galleryImage.key} role="listitem">
         <ImageCard
-          id={galleryImage.photo.id}
-          workId={galleryImage.photo.source.id}
+          id={photo.id}
+          workId={photo.source.id}
           image={{
-            contentUrl: galleryImage.photo.src,
-            width: galleryImage.photo.width - imageMargin * 2,
-            height: galleryImage.photo.height,
-            alt: galleryImage.photo.source.title,
+            contentUrl: photo.src,
+            width: photo.width - imageMargin * 2,
+            height: photo.height,
+            alt: photo.source.title,
           }}
           onClick={event => {
             event.preventDefault();
-            setExpandedImage(galleryImage.photo);
+            setExpandedImage(photo);
             setIsActive(true);
           }}
           layout="fixed"

--- a/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
+++ b/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
@@ -89,7 +89,7 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
       <ImageContainer key={galleryImage.key} role="listitem">
         <ImageCard
           id={galleryImage.photo.id}
-          workId={galleryImage.photo.workId}
+          workId={galleryImage.photo.source.id}
           image={{
             contentUrl: galleryImage.photo.src,
             width: galleryImage.photo.width - imageMargin * 2,


### PR DESCRIPTION
## Who is this for?
Users

## What is it doing for them?
Gets the work id from the source, previously wasn't fetching it at all. Only happens when using Gallery (so when more than 2 images in results, and with JS activated). Did not see it because we usually access the work's page from the modal, which had the correct link. But [as flagged here](https://wellcome.slack.com/archives/C8X9YKM5X/p1663338896261959), opening the link in a new tab gave us a 404.