### PR TITLE
[WIP] Don't show the quoted query parameters in the filters UI

### DIFF
--- a/common/services/catalogue/filters.ts
+++ b/common/services/catalogue/filters.ts
@@ -52,11 +52,11 @@ type FilterOption = {
 };
 
 function filterOptionsWithNonAggregates({
-  options,
+  options = [],
   values,
   showEmptyBuckets = false,
 }: {
-  options: FilterOption[];
+  options?: FilterOption[];
   values: string[];
   showEmptyBuckets?: boolean;
 }) {
@@ -119,14 +119,13 @@ const workTypeFilter = ({
   id: 'workType',
   label: 'Formats',
   options: filterOptionsWithNonAggregates({
-    options:
-      works?.aggregations?.workType.buckets.map(bucket => ({
-        id: bucket.data.id,
-        value: bucket.data.id,
-        count: bucket.count,
-        label: bucket.data.label,
-        selected: props.workType.includes(bucket.data.id),
-      })) || [],
+    options: works?.aggregations?.workType.buckets.map(bucket => ({
+      id: bucket.data.id,
+      value: bucket.data.id,
+      count: bucket.count,
+      label: bucket.data.label,
+      selected: props.workType.includes(bucket.data.id),
+    })),
     values: props.workType,
   }),
 });
@@ -139,14 +138,13 @@ const subjectsFilter = ({
   id: 'subjects.label',
   label: 'Subjects',
   options: filterOptionsWithNonAggregates({
-    options:
-      works?.aggregations?.['subjects.label']?.buckets.map(bucket => ({
-        id: toHtmlId(bucket.data.label),
-        value: quoteVal(bucket.data.label),
-        count: bucket.count,
-        label: bucket.data.label,
-        selected: props['subjects.label'].includes(bucket.data.label),
-      })) || [],
+    options: works?.aggregations?.['subjects.label']?.buckets.map(bucket => ({
+      id: toHtmlId(bucket.data.label),
+      value: quoteVal(bucket.data.label),
+      count: bucket.count,
+      label: bucket.data.label,
+      selected: props['subjects.label'].includes(bucket.data.label),
+    })),
     values: props['subjects.label'].map(quoteVal),
   }),
 });
@@ -156,14 +154,13 @@ const genresFilter = ({ works, props }: WorksFilterProps): CheckboxFilter => ({
   id: 'genres.label',
   label: 'Types/Techniques',
   options: filterOptionsWithNonAggregates({
-    options:
-      works?.aggregations?.['genres.label']?.buckets.map(bucket => ({
-        id: toHtmlId(bucket.data.label),
-        value: quoteVal(bucket.data.label),
-        count: bucket.count,
-        label: bucket.data.label,
-        selected: props['genres.label'].includes(bucket.data.label),
-      })) || [],
+    options: works?.aggregations?.['genres.label']?.buckets.map(bucket => ({
+      id: toHtmlId(bucket.data.label),
+      value: quoteVal(bucket.data.label),
+      count: bucket.count,
+      label: bucket.data.label,
+      selected: props['genres.label'].includes(bucket.data.label),
+    })),
     values: props['genres.label'].map(quoteVal),
   }),
 });
@@ -177,18 +174,17 @@ const contributorsAgentFilter = ({
     id: 'contributors.agent.label',
     label: 'Contributors',
     options: filterOptionsWithNonAggregates({
-      options:
-        works?.aggregations?.['contributors.agent.label']?.buckets.map(
-          bucket => ({
-            id: toHtmlId(bucket.data.label),
-            value: quoteVal(bucket.data.label),
-            count: bucket.count,
-            label: bucket.data.label,
-            selected: props['contributors.agent.label'].includes(
-              bucket.data.label
-            ),
-          })
-        ) || [],
+      options: works?.aggregations?.['contributors.agent.label']?.buckets.map(
+        bucket => ({
+          id: toHtmlId(bucket.data.label),
+          value: quoteVal(bucket.data.label),
+          count: bucket.count,
+          label: bucket.data.label,
+          selected: props['contributors.agent.label'].includes(
+            bucket.data.label
+          ),
+        })
+      ),
       values: props['contributors.agent.label'].map(quoteVal),
     }),
   };
@@ -202,14 +198,13 @@ const languagesFilter = ({
   id: 'languages',
   label: 'Languages',
   options: filterOptionsWithNonAggregates({
-    options:
-      works?.aggregations?.languages?.buckets.map(bucket => ({
-        id: bucket.data.id,
-        value: bucket.data.id,
-        count: bucket.count,
-        label: bucket.data.label,
-        selected: props.languages.includes(bucket.data.id),
-      })) || [],
+    options: works?.aggregations?.languages?.buckets.map(bucket => ({
+      id: bucket.data.id,
+      value: bucket.data.id,
+      count: bucket.count,
+      label: bucket.data.label,
+      selected: props.languages.includes(bucket.data.id),
+    })),
     values: props.languages,
   }),
 });
@@ -255,14 +250,13 @@ const availabilitiesFilter = ({
   id: 'availabilities',
   label: 'Locations',
   options: filterOptionsWithNonAggregates({
-    options:
-      works?.aggregations?.availabilities?.buckets.map(bucket => ({
-        id: bucket.data.id,
-        value: bucket.data.id,
-        count: bucket.count,
-        label: bucket.data.label,
-        selected: props.availabilities.includes(bucket.data.id),
-      })) || [],
+    options: works?.aggregations?.availabilities?.buckets.map(bucket => ({
+      id: bucket.data.id,
+      value: bucket.data.id,
+      count: bucket.count,
+      label: bucket.data.label,
+      selected: props.availabilities.includes(bucket.data.id),
+    })),
     values: props.availabilities,
   }),
 });
@@ -320,14 +314,13 @@ const licensesFilter = ({
   id: 'locations.license',
   label: 'Licenses',
   options: filterOptionsWithNonAggregates({
-    options:
-      images.aggregations?.license?.buckets.map(bucket => ({
-        id: bucket.data.id,
-        value: bucket.data.id,
-        count: bucket.count,
-        label: licenseLabels[bucket.data.id] || bucket.data.label,
-        selected: props['locations.license'].includes(bucket.data.id),
-      })) || [],
+    options: images.aggregations?.license?.buckets.map(bucket => ({
+      id: bucket.data.id,
+      value: bucket.data.id,
+      count: bucket.count,
+      label: licenseLabels[bucket.data.id] || bucket.data.label,
+      selected: props['locations.license'].includes(bucket.data.id),
+    })),
     values: props['locations.license'],
     showEmptyBuckets: true,
   }),
@@ -341,14 +334,15 @@ const sourceGenresFilter = ({
   id: 'source.genres.label',
   label: 'Types/Techniques',
   options: filterOptionsWithNonAggregates({
-    options:
-      images?.aggregations?.['source.genres.label']?.buckets.map(bucket => ({
+    options: images?.aggregations?.['source.genres.label']?.buckets.map(
+      bucket => ({
         id: toHtmlId(bucket.data.label),
         value: quoteVal(bucket.data.label),
         count: bucket.count,
         label: bucket.data.label,
         selected: props['source.genres.label'].includes(bucket.data.label),
-      })) || [],
+      })
+    ),
     values: props['source.genres.label'].map(quoteVal),
   }),
 });
@@ -361,14 +355,15 @@ const sourceSubjectsFilter = ({
   id: 'source.subjects.label',
   label: 'Subjects',
   options: filterOptionsWithNonAggregates({
-    options:
-      images?.aggregations?.['source.subjects.label']?.buckets.map(bucket => ({
+    options: images?.aggregations?.['source.subjects.label']?.buckets.map(
+      bucket => ({
         id: toHtmlId(bucket.data.label),
         value: quoteVal(bucket.data.label),
         count: bucket.count,
         label: bucket.data.label,
         selected: props['source.subjects.label'].includes(bucket.data.label),
-      })) || [],
+      })
+    ),
     values: props['source.subjects.label'].map(quoteVal),
   }),
 });
@@ -381,18 +376,17 @@ const sourceContributorAgentsFilter = ({
   id: 'source.contributors.agent.label',
   label: 'Contributors',
   options: filterOptionsWithNonAggregates({
-    options:
-      images?.aggregations?.['source.contributors.agent.label']?.buckets.map(
-        bucket => ({
-          id: toHtmlId(bucket.data.label),
-          value: quoteVal(bucket.data.label),
-          count: bucket.count,
-          label: bucket.data.label,
-          selected: props['source.contributors.agent.label'].includes(
-            bucket.data.label
-          ),
-        })
-      ) || [],
+    options: images?.aggregations?.[
+      'source.contributors.agent.label'
+    ]?.buckets.map(bucket => ({
+      id: toHtmlId(bucket.data.label),
+      value: quoteVal(bucket.data.label),
+      count: bucket.count,
+      label: bucket.data.label,
+      selected: props['source.contributors.agent.label'].includes(
+        bucket.data.label
+      ),
+    })),
     values: props['source.contributors.agent.label'].map(quoteVal),
   }),
 });

--- a/common/services/catalogue/filters.ts
+++ b/common/services/catalogue/filters.ts
@@ -5,6 +5,7 @@ import { toHtmlId } from '../../utils/string';
 import { ImagesProps } from '../../views/components/ImagesLink/ImagesLink';
 import { WorksProps } from '../../views/components/WorksLink/WorksLink';
 import { isNotUndefined } from '../../utils/array';
+import { isString } from 'lodash';
 
 export type DateRangeFilter = {
   type: 'dateRange';
@@ -43,11 +44,14 @@ export type ColorFilter = {
 
 export type Filter = CheckboxFilter | DateRangeFilter | ColorFilter;
 
-type FilterOption = {
-  id: string;
+type Value = {
   value: string;
-  count: number;
   label: string;
+};
+
+type FilterOption = Value & {
+  id: string;
+  count: number;
   selected: boolean;
 };
 
@@ -57,9 +61,13 @@ function filterOptionsWithNonAggregates({
   showEmptyBuckets = false,
 }: {
   options?: FilterOption[];
-  values: string[];
+  values: Value[] | string[];
   showEmptyBuckets?: boolean;
 }) {
+  const selectedValues: Value[] = values.map(v =>
+    isString(v) ? { label: v, value: v } : v
+  );
+
   // We can get filter options from two places:
   //
   //    - The list of aggregations on the catalogue API response
@@ -70,13 +78,13 @@ function filterOptionsWithNonAggregates({
   // list of filters (so they can see/cancel it), but if it's an uncommon value
   // it may not be in the API aggregations.  We need to add it manually.
   const aggregationValues = options.map(option => option.value);
-  const nonAggregateOptions = values
-    .filter(value => !aggregationValues.includes(value))
-    .map(label => ({
+  const nonAggregateOptions = selectedValues
+    .filter(({ value }) => !aggregationValues.includes(value))
+    .map(({ label, value }) => ({
       id: toHtmlId(label),
-      value: label,
+      value,
       count: 0,
-      label: label,
+      label,
       selected: true,
     }));
 
@@ -145,7 +153,10 @@ const subjectsFilter = ({
       label: bucket.data.label,
       selected: props['subjects.label'].includes(bucket.data.label),
     })),
-    values: props['subjects.label'].map(quoteVal),
+    values: props['subjects.label'].map(label => ({
+      label,
+      value: quoteVal(label),
+    })),
   }),
 });
 
@@ -161,7 +172,10 @@ const genresFilter = ({ works, props }: WorksFilterProps): CheckboxFilter => ({
       label: bucket.data.label,
       selected: props['genres.label'].includes(bucket.data.label),
     })),
-    values: props['genres.label'].map(quoteVal),
+    values: props['genres.label'].map(label => ({
+      label,
+      value: quoteVal(label),
+    })),
   }),
 });
 
@@ -185,7 +199,10 @@ const contributorsAgentFilter = ({
           ),
         })
       ),
-      values: props['contributors.agent.label'].map(quoteVal),
+      values: props['contributors.agent.label'].map(label => ({
+        label,
+        value: quoteVal(label),
+      })),
     }),
   };
 };
@@ -343,7 +360,10 @@ const sourceGenresFilter = ({
         selected: props['source.genres.label'].includes(bucket.data.label),
       })
     ),
-    values: props['source.genres.label'].map(quoteVal),
+    values: props['source.genres.label'].map(label => ({
+      label,
+      value: quoteVal(label),
+    })),
   }),
 });
 
@@ -364,7 +384,10 @@ const sourceSubjectsFilter = ({
         selected: props['source.subjects.label'].includes(bucket.data.label),
       })
     ),
-    values: props['source.subjects.label'].map(quoteVal),
+    values: props['source.subjects.label'].map(label => ({
+      label,
+      value: quoteVal(label),
+    })),
   }),
 });
 
@@ -387,7 +410,10 @@ const sourceContributorAgentsFilter = ({
         bucket.data.label
       ),
     })),
-    values: props['source.contributors.agent.label'].map(quoteVal),
+    values: props['source.contributors.agent.label'].map(label => ({
+      label,
+      value: quoteVal(label),
+    })),
   }),
 });
 

--- a/common/test/services/catalogue/filters.test.ts
+++ b/common/test/services/catalogue/filters.test.ts
@@ -49,12 +49,15 @@ describe('filter options', () => {
       works: worksAggregations,
       props: fromWorksQuery({
         // An aggregation we know isn't in the fixture response
-        'contributors.agent.label': '"Non existant"',
+        'contributors.agent.label': '"Non existent"',
       }),
     }).find(f => f.id === 'contributors.agent.label') as CheckboxFilter;
 
     expect(
-      filter.options.find(option => option.label === '"Non existant"')
+      filter.options.find(
+        option =>
+          option.label === 'Non existent' && option.value === '"Non existent"'
+      )
     ).toBeTruthy();
   });
 
@@ -62,7 +65,7 @@ describe('filter options', () => {
     const filter = imagesFilters({
       images: imagesAggregations,
       props: fromImagesQuery({
-        'locations.license': '"Non existant"',
+        'locations.license': '"Non existent"',
       }),
     }).find(f => f.id === 'locations.license') as CheckboxFilter;
 


### PR DESCRIPTION
We can get filters from two places:

- The list of aggregations on the catalogue API response
- A specific filter applied by the user

In the latter case, suppose a user clicks through to a filtered search from a work page.  We need to include the filter they clicked on in the list of filters (so they can see/cancel it), but if it's an uncommon value it may not be in the API aggregations.  We need to add it manually.

A filter needs several things, including a `value` (which goes in the URL query parameter) and a `label` (shown to the user). 

We combine these together inside `filterOptionsWithNonAggregates`. The previous signature was as follows:

```typescript
function filterOptionsWithNonAggregates(
  options: FilterOption[],
  values: string[],
  showEmptyBuckets: boolean = boolean
)
```

That `values` is the list of currently selected filter values, which we need to construct the currently-applied filters which aren't in the aggregation. Unfortunately, because we only get a single string here, we need something that works for both `value` and `label`, which meant quoting the value before passing it to this function. Then users see quoted values in the interface, eww:

<img width="429" alt="Screenshot 2022-09-16 at 17 50 17" src="https://user-images.githubusercontent.com/301220/190689620-9082ff27-1f62-47bd-b389-b1499e48cc60.png">

This PR modifies the signature of the function like so (roughly):

```typescript
function filterOptionsWithNonAggregates(
  options: FilterOption[],
  values: { label: string, value: string }[],
  showEmptyBuckets: boolean = boolean
)
```

so callers can pass a separate label/value if necessary – thus removing the quote marks from the UI.

The actual change is a bit more involved to keep the calling of `filterOptionsWithNonAggregates` sensible, but that's the general gist. I've tested it locally and it seems to work.