### PR TITLE
Fix a bug in the "next available date" over the weekend

### DIFF
--- a/catalogue/webapp/test/utils/dates.test.ts
+++ b/catalogue/webapp/test/utils/dates.test.ts
@@ -173,6 +173,71 @@ describe('determineNextAvailableDate', () => {
     expect(result).toEqual(new Date('2021-12-11 11:00'));
   });
 
+  // defers requests over the weekend appropriately
+  // this encodes the test cases from https://github.com/wellcomecollection/wellcomecollection.org/issues/8215
+  test.each([
+    {
+      // 'Before Monday 10am
+      requestMade: new Date('2022-09-05T09:59:59+0100'), // Monday
+      firstVisits: new Date('2022-09-06T09:59:59+0100'), // Tuesday
+    },
+    {
+      // Monday 10.01
+      requestMade: new Date('2022-09-05T10:01:01+0100'), // Monday
+      firstVisits: new Date('2022-09-07T10:01:01+0100'), // Wednesday
+    },
+    {
+      // Before Tuesday 10am
+      requestMade: new Date('2022-09-06T09:59:59+0100'), // Tuesday
+      firstVisits: new Date('2022-09-07T09:59:59+0100'), // Wednesday
+    },
+    {
+      // Tuesday 10.01
+      requestMade: new Date('2022-09-06T10:01:01+0100'), // Tuesday
+      firstVisits: new Date('2022-09-08T10:01:01+0100'), // Thursday
+    },
+    {
+      // Before Wednesday 10am
+      requestMade: new Date('2022-09-07T09:59:59+0100'), // Wednesday
+      firstVisits: new Date('2022-09-08T09:59:59+0100'), // Thursday
+    },
+    {
+      // Thursday 10.01
+      requestMade: new Date('2022-09-08T10:01:01+0100'), // Thursday
+      firstVisits: new Date('2022-09-10T10:01:01+0100'), // Saturday
+    },
+    {
+      // Before Friday 10am
+      requestMade: new Date('2022-09-09T09:59:59+0100'), // Friday
+      firstVisits: new Date('2022-09-10T09:59:59+0100'), // Saturday
+    },
+    {
+      // Friday 10.01
+      requestMade: new Date('2022-09-09T10:01:01+0100'), // Friday
+      firstVisits: new Date('2022-09-12T10:01:01+0100'), // Monday
+    },
+    {
+      // Before Saturday 10am
+      requestMade: new Date('2022-09-10T09:59:59+0100'), // Saturday
+      firstVisits: new Date('2022-09-12T09:59:59+0100'), // Monday
+    },
+    {
+      // Saturday 10.01
+      requestMade: new Date('2022-09-10T10:01:01+0100'), // Saturday
+      firstVisits: new Date('2022-09-13T10:01:01+0100'), // Tuesday
+    },
+  ])(
+    'an item ordered at $requestMade can be retrieved on $firstVisits',
+    ({ requestMade, firstVisits }) => {
+      const result = determineNextAvailableDate(
+        requestMade,
+        [0], // Sunday
+        []
+      );
+      expect(result).toEqual(firstVisits);
+    }
+  );
+
   it('defers weekend requests until Tuesday, to avoid a rush of retrievals on Monday', () => {
     const result = determineNextAvailableDate(
       new Date('2021-12-10 10:30'),

--- a/catalogue/webapp/test/utils/dates.test.ts
+++ b/catalogue/webapp/test/utils/dates.test.ts
@@ -127,33 +127,6 @@ describe('findClosedDays', () => {
   });
 });
 
-describe('findNextPickUpDay: finds the earliest date on which requested items can be picked up', () => {
-  it('returns the same date provided if it occurs on one of the regular open days', () => {
-    const result = findNextPickUpDay(
-      new Date('2022-01-15'), // Saturday
-      [0, 1, 2], // Sunday, Monday, Tuesday,
-      []
-    );
-    expect(result).toEqual(new Date('2022-01-15')); // Saturday
-  });
-  it('leaves a full working day between the request and retrieval', () => {
-    const result = findNextPickUpDay(
-      new Date('2022-01-16'), // Sunday
-      [0, 1, 2], // Sunday, Monday, Tuesday
-      []
-    );
-    expect(result).toEqual(new Date('2022-01-20')); // Thursday
-  });
-  it("doesn't return a date if there are no regular days that are open", () => {
-    const result = findNextPickUpDay(
-      new Date('2022-01-16'), // Sunday
-      [0, 1, 2, 3, 4, 5, 6],
-      []
-    );
-    expect(result).toBeUndefined();
-  });
-});
-
 describe('determineNextAvailableDate', () => {
   it('adds a single day to the current date, if the time is before 10am', () => {
     const result = determineNextAvailableDate(
@@ -238,15 +211,6 @@ describe('determineNextAvailableDate', () => {
     }
   );
 
-  it('defers weekend requests until Tuesday, to avoid a rush of retrievals on Monday', () => {
-    const result = determineNextAvailableDate(
-      new Date('2021-12-10 10:30'),
-      [0],
-      []
-    );
-    expect(result).toEqual(new Date('2021-12-14 10:30')); // Tuesday
-  });
-
   it("doesn't return a date if there are no regular days that are open", () => {
     const result = determineNextAvailableDate(
       new Date(),
@@ -304,13 +268,20 @@ describe('determineNextAvailableDate', () => {
   });
 
   it('accounts for exceptional closure dates', () => {
-    const exceptionalClosure = new Date('2021-12-13'); // Monday
+    const exceptionalClosure = new Date('2021-12-13T12:00:00Z'); // Monday
     const result = determineNextAvailableDate(
-      new Date('2021-12-10 10:30'), // Friday
-      [0],
+      new Date('2021-12-10T12:00:00Z'), // Friday
+      [0], // Sunday
       [exceptionalClosure]
     );
-    expect(result).toEqual(new Date('2021-12-15 10:30')); // Wednesday
+
+    // It's past 10am on Friday, so:
+    //
+    //    - the library staff can retrieve the item from the stores on Saturday
+    //    - nothing happens on Sunday/Monday because the library is closed
+    //    - the user can view the item on Tuesday
+    //
+    expect(result).toEqual(new Date('2021-12-14T12:00:00Z')); // Tuesday
   });
 });
 

--- a/catalogue/webapp/test/utils/dates.test.ts
+++ b/catalogue/webapp/test/utils/dates.test.ts
@@ -282,6 +282,27 @@ describe('determineNextAvailableDate', () => {
     expect(result4).toEqual(new Date('2022-09-08T10:30:00+0100'));
   });
 
+  // This is based on an issue reported by email on 16 September 2022 to the
+  // digital@wellcomecollection.org DL
+  it('accounts for exceptional closure dates (Sept 2022 bank holiday)', () => {
+    // Monday, the bank holiday for the state funeral of Queen Elizabeth II
+    const stateFuneral = new Date('2022-09-19T12:00:00+0100');
+
+    const result = determineNextAvailableDate(
+      new Date('2022-09-16T18:00:00+0100'), // Friday evening
+      [0], // Sunday
+      [stateFuneral]
+    );
+
+    // It's past 10am on Friday, so:
+    //
+    //    - the library staff can retrieve the item from the stores on Saturday
+    //    - nothing happens on Sunday/Monday because the library is closed
+    //    - the user can view the item on Tuesday
+    //
+    expect(result).toEqual(new Date('2022-09-20T18:00:00+0100'));
+  });
+
   it('accounts for exceptional closure dates', () => {
     const exceptionalClosure = new Date('2021-12-13'); // Monday
     const result = determineNextAvailableDate(

--- a/catalogue/webapp/test/utils/dates.test.ts
+++ b/catalogue/webapp/test/utils/dates.test.ts
@@ -177,57 +177,57 @@ describe('determineNextAvailableDate', () => {
   // this encodes the test cases from https://github.com/wellcomecollection/wellcomecollection.org/issues/8215
   test.each([
     {
-      // 'Before Monday 10am
+      description: 'Before Monday 10am',
       requestMade: new Date('2022-09-05T09:59:59+0100'), // Monday
       firstVisits: new Date('2022-09-06T09:59:59+0100'), // Tuesday
     },
     {
-      // Monday 10.01
+      description: 'Monday 10.01',
       requestMade: new Date('2022-09-05T10:01:01+0100'), // Monday
       firstVisits: new Date('2022-09-07T10:01:01+0100'), // Wednesday
     },
     {
-      // Before Tuesday 10am
+      description: 'Before Tuesday 10am',
       requestMade: new Date('2022-09-06T09:59:59+0100'), // Tuesday
       firstVisits: new Date('2022-09-07T09:59:59+0100'), // Wednesday
     },
     {
-      // Tuesday 10.01
+      description: 'Tuesday 10.01',
       requestMade: new Date('2022-09-06T10:01:01+0100'), // Tuesday
       firstVisits: new Date('2022-09-08T10:01:01+0100'), // Thursday
     },
     {
-      // Before Wednesday 10am
+      description: 'Before Wednesday 10am',
       requestMade: new Date('2022-09-07T09:59:59+0100'), // Wednesday
       firstVisits: new Date('2022-09-08T09:59:59+0100'), // Thursday
     },
     {
-      // Thursday 10.01
+      description: 'Thursday 10.01',
       requestMade: new Date('2022-09-08T10:01:01+0100'), // Thursday
       firstVisits: new Date('2022-09-10T10:01:01+0100'), // Saturday
     },
     {
-      // Before Friday 10am
+      description: 'Before Friday 10am',
       requestMade: new Date('2022-09-09T09:59:59+0100'), // Friday
       firstVisits: new Date('2022-09-10T09:59:59+0100'), // Saturday
     },
     {
-      // Friday 10.01
+      description: 'Friday 10.01',
       requestMade: new Date('2022-09-09T10:01:01+0100'), // Friday
       firstVisits: new Date('2022-09-12T10:01:01+0100'), // Monday
     },
     {
-      // Before Saturday 10am
+      description: 'Before Saturday 10am',
       requestMade: new Date('2022-09-10T09:59:59+0100'), // Saturday
       firstVisits: new Date('2022-09-12T09:59:59+0100'), // Monday
     },
     {
-      // Saturday 10.01
+      description: 'Saturday 10.01',
       requestMade: new Date('2022-09-10T10:01:01+0100'), // Saturday
       firstVisits: new Date('2022-09-13T10:01:01+0100'), // Tuesday
     },
   ])(
-    'an item ordered at $requestMade can be retrieved on $firstVisits',
+    '$description: an item ordered at $requestMade can be retrieved on $firstVisits',
     ({ requestMade, firstVisits }) => {
       const result = determineNextAvailableDate(
         requestMade,


### PR DESCRIPTION
(Sorry, I saw the initial email from Cassandra before seeing Natalie had sent it to David.)

The existing logic was quite complicated, and had a bug. I discovered this by writing a series of new test cases based on #8215, and realising we were dropping a day somewhere.

In particular, we were double-counting the retrieval day.  In particular, this logic inside `determineNextAvailableDate`:

    determineNextAvailableDate {
        …

        // If a request is made before 10am, the next _potential_ pick-up date is the
        // next day otherwise, it is two days' time.
        const isBeforeTen = hourInLondon < 10;
        const nextAvailableDate = addDays(date, isBeforeTen ? 1 : 2);

        findNextPickUpDay(nextAvailableDate, …)
    }

    findNextPickUpDay(date) {
        …

        // If the library is closed on this day, we want to set the pick-up day to be
        // the next open day plus one, so that e.g. Monday morning isn't a scramble
        // for library staff handling the weekend's requests. Since this function
        // calls itself recursively, we add one day if we're closed this day and
        // the next, but add two days if we're closed this day and open the next.
        if (isClosedThisDay && isOpenNextDay)
            return findNextPickUpDay(date + 2)
        if (isClosedThisDay)
            return findNextPickUpDay(date + 1)
        else
            return date

could fail as follows:

*   It's Friday at 6pm.
*   `determineNextAvailableDate(Fri @ 6pm)`: that's not before 10am, so the next available date is Sunday.  Pass this to `findNextPickUpDay()`.
*   `findNextPickUpDay(Sun)`: the library is closed on Sunday, and it's open on Monday.  Add two extra days; try Tuesday.
*   `findNextPickUpDay(Tues)`: the library is open today, so the reader can visit their item.

but we lost the Saturday.  LE&E staff could have retrieved the item that day and given it to the reader on Monday.

This patch tries to simplify the approach:

*   What's the next working day on or after today?  This is when LE&E staff will retrieve the item.  (Whether we allow today depends on whether it's before 10am.)
*   What's the next working day after that?  This is when the reader can visit the item.

In particular, we do away with the recursive `findNextPickUpDay` function, whose purpose was non-obvious and I think was causing confusion.