### PR TITLE
Remove an unnecessary use of lodash.flattenDeep

### DIFF
--- a/catalogue/webapp/components/ArchiveTree/ArchiveTree.test.tsx
+++ b/catalogue/webapp/components/ArchiveTree/ArchiveTree.test.tsx
@@ -1,0 +1,82 @@
+import { getTabbableIds } from './ArchiveTree';
+
+describe('getTabbableIds', () => {
+  it('finds all IDs', () => {
+    const tree = [
+      {
+        work: { id: 'PENROSE' },
+      },
+      {
+        work: { id: 'CRICK' },
+      },
+    ];
+
+    const result = getTabbableIds(tree as any);
+    expect(result).toStrictEqual(['PENROSE', 'CRICK']);
+  });
+
+  it('includes IDs of nodes which aren’t open', () => {
+    const tree = [
+      {
+        work: { id: 'PENROSE' },
+        openStatus: true,
+      },
+      {
+        work: { id: 'CRICK' },
+        openStatus: false,
+      },
+    ];
+
+    const result = getTabbableIds(tree as any);
+    expect(result).toStrictEqual(['PENROSE', 'CRICK']);
+  });
+
+  it('only recurses into the children of open elements', () => {
+    const tree = [
+      {
+        work: { id: 'PENROSE' },
+        openStatus: true,
+        children: [
+          { work: { id: 'PENROSE/1' } },
+          { work: { id: 'PENROSE/2' } },
+          {
+            work: { id: 'PENROSE/3' },
+            openStatus: false,
+            children: [{ work: { id: 'PENROSE/3/1' } }],
+          },
+          {
+            work: { id: 'PENROSE/4' },
+            openStatus: true,
+            children: [{ work: { id: 'PENROSE/4/1' } }],
+          },
+        ],
+      },
+      {
+        work: { id: 'CRICK' },
+        openStatus: false,
+        children: [
+          { work: { id: 'CRICK/1' } },
+          { work: { id: 'CRICK/2' } },
+          {
+            // Although this child is open, because the parent is closed we shouldn't
+            // recurse down to it.
+            work: { id: 'CRICK/3' },
+            openStatus: true,
+            children: [{ work: { id: 'CRICK/3/1' } }],
+          },
+        ],
+      },
+    ];
+
+    const result = getTabbableIds(tree as any);
+    expect(result).toStrictEqual([
+      'PENROSE',
+      'PENROSE/1',
+      'PENROSE/2',
+      'PENROSE/3',
+      'PENROSE/4',
+      'PENROSE/4/1',
+      'CRICK',
+    ]);
+  });
+});

--- a/catalogue/webapp/components/ArchiveTree/ArchiveTree.tsx
+++ b/catalogue/webapp/components/ArchiveTree/ArchiveTree.tsx
@@ -6,7 +6,6 @@ import {
   FunctionComponent,
   RefObject,
 } from 'react';
-import flattenDeep from 'lodash.flattendeep';
 import styled from 'styled-components';
 import { classNames, font } from '@weco/common/utils/classnames';
 import { getWorkClientSide } from '../../services/catalogue/works';
@@ -211,14 +210,13 @@ type UiTreeNode = {
 export type UiTree = UiTreeNode[];
 
 export function getTabbableIds(tree: UiTree): string[] {
-  const tabbableIds = tree.reduce((acc: (string | string[])[], curr) => {
+  return tree.reduce((acc: string[], curr) => {
     acc.push(curr.work.id);
     if (curr.openStatus && curr.children) {
-      acc.push(getTabbableIds(curr.children));
+      acc = acc.concat(getTabbableIds(curr.children));
     }
     return acc;
   }, []);
-  return flattenDeep(tabbableIds);
 }
 
 function updateOpenStatus({

--- a/common/package.json
+++ b/common/package.json
@@ -26,7 +26,6 @@
     "@types/gtag.js": "^0.0.3",
     "@types/jest": "^27.0.2",
     "@types/lodash.debounce": "^4.0.6",
-    "@types/lodash.groupby": "^4.6.6",
     "@types/styled-components": "^5.1.15",
     "@types/uuid": "^8.3.0",
     "@weco/toggles": "1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4363,13 +4363,6 @@
   dependencies:
     "@types/lodash" "*"
 
-"@types/lodash.groupby@^4.6.6":
-  version "4.6.6"
-  resolved "https://registry.yarnpkg.com/@types/lodash.groupby/-/lodash.groupby-4.6.6.tgz#4d9b61a4d8b0d83d384975cabfed4c1769d6792e"
-  integrity sha512-kwg3T7Ia63KtDNoQQR8hKrLHCAgrH4I44l5uEMuA6JCbj7DiSccaV4tNV1vbjtAOpX990SolVthJCmBVtRVRgw==
-  dependencies:
-    "@types/lodash" "*"
-
 "@types/lodash@*":
   version "4.14.177"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.177.tgz#f70c0d19c30fab101cad46b52be60363c43c4578"


### PR DESCRIPTION
Spotted upon code read. We're calling `flattenDeep` to flatten an array `(string | string[])[]`, but we're constructing the array ourselves – we can skip needing to flatten it later.

(Specifically, I realised the bundle size increase in #8494 is because I accidentally added a lodash import – so I had a quick search for other uses of lodash that could come out.)