### PR TITLE
Clarify that we want isSameDay(…, 'London') in the DateRange component

### DIFF
--- a/cardigan/stories/components/DateRange/DateRange.stories.mdx
+++ b/cardigan/stories/components/DateRange/DateRange.stories.mdx
@@ -19,4 +19,10 @@ import * as stories from './DateRange.stories.tsx';
   <Story story={stories.acrossMultipleDays} />
 </Canvas>
 
+## With date/time on separate lines
+
+<Canvas>
+  <Story story={stories.withSplit} />
+</Canvas>
+
 <ArgsTable />

--- a/cardigan/stories/components/DateRange/DateRange.stories.tsx
+++ b/cardigan/stories/components/DateRange/DateRange.stories.tsx
@@ -20,3 +20,11 @@ acrossMultipleDays.args = {
   end: oneWeekFromNow,
 };
 acrossMultipleDays.storyName = 'Across multiple days';
+
+export const withSplit = Template.bind({});
+withSplit.args = {
+  start: now,
+  end: oneHourFromNow,
+  splitTime: true,
+};
+withSplit.storyName = 'With date/time on separate lines';

--- a/common/views/components/DateRange/DateRange.test.tsx
+++ b/common/views/components/DateRange/DateRange.test.tsx
@@ -4,7 +4,7 @@ import DateRange from './DateRange';
 describe('DateRange', () => {
   it('renders a date + time range if the start/end are on the same day', () => {
     const start = new Date('2022-09-18T12:00:00+0100');
-    const end = new Date('2022-09-18T14:30:00+0100');
+    const end   = new Date('2022-09-18T14:30:00+0100'); // prettier-ignore
 
     const component = mountWithTheme(<DateRange start={start} end={end} />);
     expect(component.html()).toEqual(
@@ -15,7 +15,7 @@ describe('DateRange', () => {
 
   it('renders a date range if the start/end are on different days', () => {
     const start = new Date('2022-09-18T12:00:00+0100');
-    const end = new Date('2022-09-25T12:00:00+0100');
+    const end   = new Date('2022-09-25T12:00:00+0100'); // prettier-ignore
 
     const component = mountWithTheme(<DateRange start={start} end={end} />);
     expect(component.html()).toEqual(
@@ -26,7 +26,7 @@ describe('DateRange', () => {
 
   it('can split a date/time across multiple lines', () => {
     const start = new Date('2022-09-18T12:00:00+0100');
-    const end = new Date('2022-09-18T14:30:00+0100');
+    const end   = new Date('2022-09-18T14:30:00+0100'); // prettier-ignore
 
     const component = mountWithTheme(
       <DateRange start={start} end={end} splitTime={true} />

--- a/common/views/components/DateRange/DateRange.test.tsx
+++ b/common/views/components/DateRange/DateRange.test.tsx
@@ -54,4 +54,22 @@ describe('DateRange', () => {
         '<span><time datetime="2022-09-17T23:30:00.000Z">00:30</time> – <time datetime="2022-09-18T00:30:00.000Z">01:30</time></span>'
     );
   });
+
+  it('renders a date range if the start/end are on different London days', () => {
+    // It seems unlikely we would ever schedule an event this late in the
+    // day, but let’s make sure we handle it properly.  Note that these two
+    // times are on the same UTC day, but different London days.
+
+    //                             -18T22:30:00 UTC
+    const start = new Date('2022-09-18T23:30:00+0100');
+
+    //                             -18T23:30:00 UTC
+    const end   = new Date('2022-09-19T00:30:00+0100'); // prettier-ignore
+
+    const component = mountWithTheme(<DateRange start={start} end={end} />);
+    expect(component.html()).toEqual(
+      '<time datetime="2022-09-18T22:30:00.000Z">18 September 2022</time> – ' +
+        '<time datetime="2022-09-18T23:30:00.000Z">19 September 2022</time>'
+    );
+  });
 });

--- a/common/views/components/DateRange/DateRange.test.tsx
+++ b/common/views/components/DateRange/DateRange.test.tsx
@@ -39,7 +39,8 @@ describe('DateRange', () => {
 
   it('renders a date + time range if the start/end are on the same London day', () => {
     // It seems unlikely we would ever schedule an event this early in the
-    // day, but let’s make sure we handle it properly.
+    // day, but let’s make sure we handle it properly.  Note that these two
+    // times are on the same London day, but different UTC days.
 
     //                             -17T23:30:00 UTC
     const start = new Date('2022-09-18T00:30:00+0100');

--- a/common/views/components/DateRange/DateRange.test.tsx
+++ b/common/views/components/DateRange/DateRange.test.tsx
@@ -1,0 +1,39 @@
+import { mountWithTheme } from '@weco/common/test/fixtures/enzyme-helpers';
+import DateRange from './DateRange';
+
+describe('DateRange', () => {
+  it('renders a date + time range if the start/end are on the same day', () => {
+    const start = new Date('2022-09-18T12:00:00+0100');
+    const end = new Date('2022-09-18T14:30:00+0100');
+
+    const component = mountWithTheme(<DateRange start={start} end={end} />);
+    expect(component.html()).toEqual(
+      '<time datetime="2022-09-18T11:00:00.000Z">Sunday 18 September 2022</time>, ' +
+        '<span><time datetime="2022-09-18T11:00:00.000Z">12:00</time> – <time datetime="2022-09-18T13:30:00.000Z">14:30</time></span>'
+    );
+  });
+
+  it('renders a date range if the start/end are on different days', () => {
+    const start = new Date('2022-09-18T12:00:00+0100');
+    const end = new Date('2022-09-25T12:00:00+0100');
+
+    const component = mountWithTheme(<DateRange start={start} end={end} />);
+    expect(component.html()).toEqual(
+      '<time datetime="2022-09-18T11:00:00.000Z">18 September 2022</time> – ' +
+        '<time datetime="2022-09-25T11:00:00.000Z">25 September 2022</time>'
+    );
+  });
+
+  it('can split a date/time across multiple lines', () => {
+    const start = new Date('2022-09-18T12:00:00+0100');
+    const end = new Date('2022-09-18T14:30:00+0100');
+
+    const component = mountWithTheme(
+      <DateRange start={start} end={end} splitTime={true} />
+    );
+    expect(component.html()).toEqual(
+      '<time datetime="2022-09-18T11:00:00.000Z">Sunday 18 September 2022</time>' +
+        '<span class="block"><time datetime="2022-09-18T11:00:00.000Z">12:00</time> – <time datetime="2022-09-18T13:30:00.000Z">14:30</time></span>'
+    );
+  });
+});

--- a/common/views/components/DateRange/DateRange.test.tsx
+++ b/common/views/components/DateRange/DateRange.test.tsx
@@ -36,4 +36,21 @@ describe('DateRange', () => {
         '<span class="block"><time datetime="2022-09-18T11:00:00.000Z">12:00</time> – <time datetime="2022-09-18T13:30:00.000Z">14:30</time></span>'
     );
   });
+
+  it('renders a date + time range if the start/end are on the same London day', () => {
+    // It seems unlikely we would ever schedule an event this early in the
+    // day, but let’s make sure we handle it properly.
+
+    //                             -17T23:30:00 UTC
+    const start = new Date('2022-09-18T00:30:00+0100');
+
+    //                             -18T00:30:00 UTC
+    const end   = new Date('2022-09-18T01:30:00+0100'); // prettier-ignore
+
+    const component = mountWithTheme(<DateRange start={start} end={end} />);
+    expect(component.html()).toEqual(
+      '<time datetime="2022-09-17T23:30:00.000Z">Sunday 18 September 2022</time>, ' +
+        '<span><time datetime="2022-09-17T23:30:00.000Z">00:30</time> – <time datetime="2022-09-18T00:30:00.000Z">01:30</time></span>'
+    );
+  });
 });

--- a/common/views/components/DateRange/DateRange.tsx
+++ b/common/views/components/DateRange/DateRange.tsx
@@ -36,7 +36,7 @@ const DateRange: FunctionComponent<Props> = ({
   end,
   splitTime,
 }: Props) => {
-  return isSameDay(start, end) ? (
+  return isSameDay(start, end, 'London') ? (
     <>
       <HTMLDayDate date={start} />
       {splitTime ? '' : ', '}

--- a/common/views/components/DateRange/DateRange.tsx
+++ b/common/views/components/DateRange/DateRange.tsx
@@ -14,6 +14,23 @@ const TimeRange = ({ start, end }: DateRangeProps) => (
 type Props = {
   splitTime?: boolean;
 } & DateRangeProps;
+
+/** Renders a date/time range.
+ *
+ * Examples:
+ *
+ *    1 March 2022 – 8 March 2022
+ *
+ *    1 March 2022, 13:15 – 14:15
+ *
+ *    1 March 2022
+ *    13:15 – 14:15
+ *
+ * The component will automatically decide whether to render a date range
+ * or a date and time range.  The `splitTime` prop controls whether the
+ * time is shown on a separate line.
+ *
+ */
 const DateRange: FunctionComponent<Props> = ({
   start,
   end,


### PR DESCRIPTION
For https://github.com/wellcomecollection/wellcomecollection.org/issues/7831

We use `isSameDay()` in the DateRange component, and I wasn't sure if we want London or UTC. I wrote some additional documentation and tests, and that made it clear to me that we want a London-based comparison (although admittedly it's an edge case).

* We only render the times if the start/end are on the same day
* The times are rendered in a London timezone

There are two tests for the edge cases where this would cause weirdness if we don't do a London isSameDay() comparison:

* same London day, different UTC day
* different London day, same UTC day

The component itself is only a one-line change; the rest of the patch is the context that convinced me it was the right change to make.