### PR TITLE
Re-enable some skipped EventPromo tests

### DIFF
--- a/content/webapp/components/EventPromo/EventPromo.test.tsx
+++ b/content/webapp/components/EventPromo/EventPromo.test.tsx
@@ -47,7 +47,7 @@ describe('EventPromo', () => {
   });
 });
 
-describe.only('getLocationText', () => {
+describe('getLocationText', () => {
   it('returns the specific location given one physical location only (and not online)', () => {
     const locationText = getLocationText(false, [location]);
     expect(locationText).toEqual('Reading Room');


### PR DESCRIPTION
They're passing and they look reasonable; this looks like debugging code that got checked in accidentally.

## Who is this for?

Devs.

## What is it doing for them?

Making sure the tests help us find bugs.