### PR TITLE
Make sure we quote parameters properly when searching for works/images on a concept page

### DIFF
--- a/catalogue/webapp/pages/concept.tsx
+++ b/catalogue/webapp/pages/concept.tsx
@@ -9,6 +9,7 @@ import { looksLikeCanonicalId } from 'services/catalogue';
 import { getConcept } from 'services/catalogue/concepts';
 import { getWorks } from '../services/catalogue/works';
 import { getImages } from 'services/catalogue/images';
+import { toLink as toImagesLink } from '@weco/common/views/components/ImagesLink/ImagesLink';
 import { toLink as toWorksLink } from '@weco/common/views/components/WorksLink/WorksLink';
 
 // Components
@@ -80,13 +81,7 @@ const ConceptWorksHeader = styled(Space).attrs({
     hasWorksTabs ? '#fbfaf4' : 'white'};
 `;
 
-const SeeMoreButton = ({
-  text,
-  link,
-}: {
-  text: string;
-  link: string | LinkProps;
-}) => (
+const SeeMoreButton = ({ text, link }: { text: string; link: LinkProps }) => (
   <ButtonSolidLink
     text={text}
     link={link}
@@ -192,7 +187,12 @@ export const ConceptPage: NextPage<Props> = ({
                   <Space v={{ size: 'm', properties: ['margin-top'] }}>
                     <SeeMoreButton
                       text={`All images (${imagesAbout.totalResults})`}
-                      link={`/images?source.subjects.label=${conceptResponse.label}`}
+                      link={toImagesLink(
+                        {
+                          'source.subjects.label': [conceptResponse.label],
+                        },
+                        'concept/images_about'
+                      )}
                     />
                   </Space>
                 </div>
@@ -210,7 +210,14 @@ export const ConceptPage: NextPage<Props> = ({
                   />
                   <SeeMoreButton
                     text={`All images (${imagesBy.totalResults})`}
-                    link={`/images?source.contributors.agent.label=${conceptResponse.label}`}
+                    link={toImagesLink(
+                      {
+                        'source.contributors.agent.label': [
+                          conceptResponse.label,
+                        ],
+                      },
+                      'concept/images_by'
+                    )}
                   />
                 </div>
               )}

--- a/catalogue/webapp/pages/concept.tsx
+++ b/catalogue/webapp/pages/concept.tsx
@@ -9,6 +9,7 @@ import { looksLikeCanonicalId } from 'services/catalogue';
 import { getConcept } from 'services/catalogue/concepts';
 import { getWorks } from '../services/catalogue/works';
 import { getImages } from 'services/catalogue/images';
+import { toLink as toWorksLink } from '@weco/common/views/components/WorksLink/WorksLink';
 
 // Components
 import CataloguePageLayout from 'components/CataloguePageLayout/CataloguePageLayout';
@@ -30,6 +31,7 @@ import { arrow } from '@weco/common/icons';
 import Space from '@weco/common/views/components/styled/Space';
 import TabNavV2 from '@weco/common/views/components/TabNav/TabNavV2';
 import { font } from '@weco/common/utils/classnames';
+import { LinkProps } from 'next/link';
 
 type Props = {
   conceptResponse: ConceptType;
@@ -78,7 +80,13 @@ const ConceptWorksHeader = styled(Space).attrs({
     hasWorksTabs ? '#fbfaf4' : 'white'};
 `;
 
-const SeeMoreButton = ({ text, link }: { text: string; link: string }) => (
+const SeeMoreButton = ({
+  text,
+  link,
+}: {
+  text: string;
+  link: string | LinkProps;
+}) => (
   <ButtonSolidLink
     text={text}
     link={link}
@@ -269,7 +277,12 @@ export const ConceptPage: NextPage<Props> = ({
                   <Space v={{ size: 'l', properties: ['padding-top'] }}>
                     <SeeMoreButton
                       text={`All works (${worksAbout.totalResults})`}
-                      link={`/works?subjects.label=${conceptResponse.label}`}
+                      link={toWorksLink(
+                        {
+                          'subjects.label': [conceptResponse.label],
+                        },
+                        'concept/works_about'
+                      )}
                     />
                   </Space>
                 </div>
@@ -286,7 +299,12 @@ export const ConceptPage: NextPage<Props> = ({
                   <Space v={{ size: 'l', properties: ['padding-top'] }}>
                     <SeeMoreButton
                       text={`All works (${worksBy.totalResults})`}
-                      link={`/works?subjects.label=${conceptResponse.label}`}
+                      link={toWorksLink(
+                        {
+                          'contributors.agent.label': [conceptResponse.label],
+                        },
+                        'concept/works_by'
+                      )}
                     />
                   </Space>
                 </div>

--- a/catalogue/webapp/pages/images.tsx
+++ b/catalogue/webapp/pages/images.tsx
@@ -7,7 +7,6 @@ import { grid } from '@weco/common/utils/classnames';
 import convertUrlToString from '@weco/common/utils/convert-url-to-string';
 import CataloguePageLayout from '../components/CataloguePageLayout/CataloguePageLayout';
 import Paginator from '@weco/common/views/components/Paginator/Paginator';
-import { imagesRouteToApiUrl } from '@weco/common/services/catalogue/api';
 import Space from '@weco/common/views/components/styled/Space';
 import ImageEndpointSearchResults from '../components/ImageEndpointSearchResults/ImageEndpointSearchResults';
 import { getImages } from '../services/catalogue/images';
@@ -251,7 +250,10 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       'source.subjects.label',
       'source.contributors.agent.label',
     ];
-    const apiProps = imagesRouteToApiUrl(params, { aggregations });
+    const apiProps = {
+      ...params,
+      aggregations,
+    };
     const images = await getImages({
       params: apiProps,
       toggles: serverData.toggles,

--- a/catalogue/webapp/pages/works.tsx
+++ b/catalogue/webapp/pages/works.tsx
@@ -5,7 +5,6 @@ import { grid } from '@weco/common/utils/classnames';
 import convertUrlToString from '@weco/common/utils/convert-url-to-string';
 import CataloguePageLayout from '../components/CataloguePageLayout/CataloguePageLayout';
 import Paginator from '@weco/common/views/components/Paginator/Paginator';
-import { worksRouteToApiUrl } from '@weco/common/services/catalogue/api';
 import Space from '@weco/common/views/components/styled/Space';
 import { getWorks } from '../services/catalogue/works';
 import cookies from 'next-cookies';

--- a/catalogue/webapp/pages/works.tsx
+++ b/catalogue/webapp/pages/works.tsx
@@ -268,10 +268,11 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
 
     const _queryType = cookies(context)._queryType;
 
-    const worksApiProps = worksRouteToApiUrl(props, {
+    const worksApiProps = {
+      ...props,
       _queryType,
       aggregations,
-    });
+    };
 
     const works = await getWorks({
       params: worksApiProps,

--- a/catalogue/webapp/services/catalogue/images.ts
+++ b/catalogue/webapp/services/catalogue/images.ts
@@ -16,6 +16,11 @@ import {
 } from '.';
 import { Toggles } from '@weco/toggles';
 import { propsToQuery } from '@weco/common/utils/routes';
+import {
+  emptyImagesProps,
+  ImagesProps,
+  toQuery,
+} from '@weco/common/views/components/ImagesLink/ImagesLink';
 
 type ImageInclude =
   | 'visuallySimilar'
@@ -31,10 +36,25 @@ type GetImageProps = {
   include?: ImageInclude[];
 };
 
+/** Run a query with the images API.
+ *
+ * Note: this method is responsible for encoding parameters in an API-compatible
+ * way, e.g. wrapping strings in quotes.  Callers should pass in an unencoded
+ * set of parameters.
+ *
+ * https://wellcomecollection.org/images?source.subjects.label=%22Germany%2C+East%22
+ */
 export async function getImages(
   props: QueryProps<CatalogueImagesApiProps>
 ): Promise<CatalogueResultsList<Image> | CatalogueApiError> {
-  return catalogueQuery('images', props);
+  const params: ImagesProps = {
+    ...emptyImagesProps,
+    ...props.params,
+  };
+
+  const query = toQuery(params);
+
+  return catalogueQuery('images', { ...props, params: query });
 }
 
 export async function getImage({

--- a/catalogue/webapp/services/catalogue/works.ts
+++ b/catalogue/webapp/services/catalogue/works.ts
@@ -19,6 +19,12 @@ import {
 } from '.';
 import { Toggles } from '@weco/toggles';
 import { propsToQuery } from '@weco/common/utils/routes';
+import {
+  emptyWorksProps,
+  toLink,
+  toQuery,
+  WorksProps,
+} from '@weco/common/views/components/WorksLink/WorksLink';
 
 type GetWorkProps = {
   id: string;
@@ -59,11 +65,25 @@ const redirect = (id: string, status = 302): CatalogueApiRedirect => ({
   status,
 });
 
+/** Run a query with the works API.
+ *
+ * Note: this method is responsible for encoding parameters in an API-compatible
+ * way, e.g. wrapping strings in quotes.  Callers should pass in an unencoded
+ * set of parameters.
+ *
+ * https://wellcomecollection.org/works?subjects.label=%22Thackrah%2C+Charles+Turner%2C+1795-1833%22
+ */
 export async function getWorks(
   props: QueryProps<CatalogueWorksApiProps>
 ): Promise<CatalogueResultsList<Work> | CatalogueApiError> {
-  const extendedParams = {
+  const params: WorksProps = {
+    ...emptyWorksProps,
     ...props.params,
+  };
+  const query = toQuery(params);
+
+  const extendedParams = {
+    ...query,
     include: worksIncludes,
   };
 

--- a/common/services/catalogue/api.ts
+++ b/common/services/catalogue/api.ts
@@ -65,32 +65,6 @@ export type CatalogueConceptsApiProps = {
   page?: number;
 };
 
-export function worksRouteToApiUrl(
-  worksProps: WorksProps,
-  overrides: Partial<CatalogueWorksApiProps>
-): CatalogueWorksApiProps {
-  return {
-    query: worksProps.query,
-    page: worksProps.page,
-    workType: worksProps.workType,
-    'items.locations.locationType': worksProps['items.locations.locationType'],
-    availabilities: worksProps.availabilities,
-    sort: worksProps.sort,
-    sortOrder: worksProps.sortOrder,
-    'partOf.title': worksProps['partOf.title'],
-    'production.dates.from': toIsoDateString(
-      worksProps['production.dates.from']
-    ),
-    'production.dates.to': toIsoDateString(worksProps['production.dates.to']),
-    languages: worksProps.languages,
-    'genres.label': worksProps['genres.label'].map(quoteVal),
-    'subjects.label': worksProps['subjects.label'].map(quoteVal),
-    'contributors.agent.label':
-      worksProps['contributors.agent.label'].map(quoteVal),
-    ...overrides,
-  };
-}
-
 export function imagesRouteToApiUrl(
   imagesRouteProps: ImagesProps,
   overrides: Partial<CatalogueImagesApiProps>

--- a/common/services/catalogue/api.ts
+++ b/common/services/catalogue/api.ts
@@ -64,22 +64,3 @@ export type CatalogueImagesApiProps = {
 export type CatalogueConceptsApiProps = {
   page?: number;
 };
-
-export function imagesRouteToApiUrl(
-  imagesRouteProps: ImagesProps,
-  overrides: Partial<CatalogueImagesApiProps>
-): CatalogueImagesApiProps {
-  return {
-    query: imagesRouteProps.query,
-    page: imagesRouteProps.page,
-    color: imagesRouteProps.color,
-    'locations.license': imagesRouteProps['locations.license'],
-    'source.genres.label':
-      imagesRouteProps['source.genres.label'].map(quoteVal),
-    'source.subjects.label':
-      imagesRouteProps['source.subjects.label'].map(quoteVal),
-    'source.contributors.agent.label':
-      imagesRouteProps['source.contributors.agent.label'].map(quoteVal),
-    ...overrides,
-  };
-}

--- a/common/utils/routes.ts
+++ b/common/utils/routes.ts
@@ -1,7 +1,7 @@
 import { LinkProps } from 'next/link';
 import { ParsedUrlQuery } from 'querystring';
 import { PropsWithChildren } from 'react';
-import { isNotUndefined, isUndefined } from './array';
+import { isNotUndefined } from './array';
 import { parseCsv, quoteVal } from './csv';
 import { isInTuple } from './type-guards';
 import { OptionalToUndefined, UndefinableToOptional } from './utility-types';

--- a/common/views/components/ImagesLink/ImagesLink.tsx
+++ b/common/views/components/ImagesLink/ImagesLink.tsx
@@ -17,6 +17,8 @@ import {
 const imagesPropsSources = [
   'search/paginator',
   'canonical_link',
+  'concept/images_about',
+  'concept/images_by',
   'images_search_context',
   'work_details/images',
   'unknown',

--- a/common/views/components/ImagesLink/ImagesLink.tsx
+++ b/common/views/components/ImagesLink/ImagesLink.tsx
@@ -86,4 +86,4 @@ const ImagesLink: FunctionComponent<Props> = ({
 };
 
 export default ImagesLink;
-export { toLink, fromQuery, emptyImagesProps };
+export { toLink, toQuery, fromQuery, emptyImagesProps };

--- a/common/views/components/WorksLink/WorksLink.tsx
+++ b/common/views/components/WorksLink/WorksLink.tsx
@@ -20,6 +20,8 @@ const worksPropsSources = [
   'canonical_link',
   'meta_link',
   'search/paginator',
+  'concept/works_about',
+  'concept/works_by',
   'works_search_context',
   'work_details/contributors',
   'work_details/genres',

--- a/common/views/components/WorksLink/WorksLink.tsx
+++ b/common/views/components/WorksLink/WorksLink.tsx
@@ -72,7 +72,7 @@ const fromQuery: (params: ParsedUrlQuery) => WorksProps = params => {
   return decodeQuery<WorksProps>(params, codecMap);
 };
 
-export const toQuery: (props: WorksProps) => ParsedUrlQuery = props => {
+const toQuery: (props: WorksProps) => ParsedUrlQuery = props => {
   return encodeQuery<WorksProps>(props, codecMap);
 };
 
@@ -109,4 +109,4 @@ const WorksLink: FunctionComponent<Props> = ({
 };
 
 export default WorksLink;
-export { toLink, fromQuery, emptyWorksProps };
+export { toLink, toQuery, fromQuery, emptyWorksProps };

--- a/common/views/components/WorksLink/WorksLink.tsx
+++ b/common/views/components/WorksLink/WorksLink.tsx
@@ -72,7 +72,7 @@ const fromQuery: (params: ParsedUrlQuery) => WorksProps = params => {
   return decodeQuery<WorksProps>(params, codecMap);
 };
 
-const toQuery: (props: WorksProps) => ParsedUrlQuery = props => {
+export const toQuery: (props: WorksProps) => ParsedUrlQuery = props => {
   return encodeQuery<WorksProps>(props, codecMap);
 };
 

--- a/playwright/test/concept.test.ts
+++ b/playwright/test/concept.test.ts
@@ -2,6 +2,7 @@ import { test as base, expect } from '@playwright/test';
 import { concept } from './contexts';
 import { baseUrl } from './helpers/urls';
 import { makeDefaultToggleCookies } from './helpers/utils';
+import { worksByThisPerson } from './selectors/concepts';
 
 const domain = new URL(baseUrl).host;
 
@@ -56,20 +57,19 @@ test.describe('concepts', () => {
 
     // Note: the `link-reset` class is added by ButtonSolid, and is a way to
     // make sure we find the "All Works" link, and not a link to an individual work.
-
-    const aboutThisWork = await page.waitForSelector(
+    const aboutThisPerson = await page.waitForSelector(
       'div[aria-labelledby="tab-worksAbout"] a.link-reset'
     );
 
-    const content = await aboutThisWork.textContent();
+    const content = await aboutThisPerson.textContent();
 
     expect(content?.startsWith('All works')).toBe(true);
-    expect(await aboutThisWork.getAttribute('href')).toBe(
+    expect(await aboutThisPerson.getAttribute('href')).toBe(
       '/works?subjects.label=%22Stephens%2C+Joanna%22'
     );
   });
 
-  test.only('concept pages link to a filtered search for works by this subject/person', async ({
+  test('concept pages link to a filtered search for works by this subject/person', async ({
     page,
     context,
   }) => {
@@ -77,18 +77,19 @@ test.describe('concepts', () => {
     // we're quoting the link to a filtered search.
     await concept(conceptIds['Stephens, Joanna'], context, page);
 
+    await page.click(worksByThisPerson);
+
     // Note: the `link-reset` class is added by ButtonSolid, and is a way to
     // make sure we find the "All Works" link, and not a link to an individual work.
-
-    const aboutThisWork = await page.waitForSelector(
+    const byThisPerson = await page.waitForSelector(
       'div[aria-labelledby="tab-worksBy"] a.link-reset'
     );
 
-    const content = await aboutThisWork.textContent();
+    const content = await byThisPerson.textContent();
 
     expect(content?.startsWith('All works')).toBe(true);
-    expect(await aboutThisWork.getAttribute('href')).toBe(
-      '/works?contributors.label=%22Stephens%2C+Joanna%22'
+    expect(await byThisPerson.getAttribute('href')).toBe(
+      '/works?contributors.agent.label=%22Stephens%2C+Joanna%22'
     );
   });
 

--- a/playwright/test/concept.test.ts
+++ b/playwright/test/concept.test.ts
@@ -27,6 +27,7 @@ const test = base.extend({
 
 const conceptIds = {
   'Thackrah, Charles Turner, 1795-1833': 'd46ea7yk',
+  'John, the Baptist, Saint': 'qd86ycny',
 };
 
 test.describe('concepts', () => {
@@ -39,5 +40,12 @@ test.describe('concepts', () => {
       page
     );
     await page.waitForSelector('h2 >> text="Works"');
+  });
+
+  test('concepts get a list of related images', async ({ page, context }) => {
+    // I've deliberately picked a complicated ID with commas here, to make sure
+    // we're quoting the query we send to the images API.
+    await concept(conceptIds['John, the Baptist, Saint'], context, page);
+    await page.waitForSelector('h2 >> text="Images"');
   });
 });

--- a/playwright/test/concept.test.ts
+++ b/playwright/test/concept.test.ts
@@ -27,9 +27,18 @@ const test = base.extend({
 });
 
 const conceptIds = {
+  // Chosen because there are no associated works if you don't quote
+  // the search properly.
   'Thackrah, Charles Turner, 1795-1833': 'd46ea7yk',
+
+  // Chosen because there are no associated images if you don't quote
+  // the search properly.
   'John, the Baptist, Saint': 'qd86ycny',
+
+  // Chosen because there are works both about and by this person
   'Stephens, Joanna': 'pg43g9hn',
+
+  // Chosen because there are images both about and by this person
   'Darwin, Charles, 1809-1882': 'v3m7uhy9',
 };
 

--- a/playwright/test/concept.test.ts
+++ b/playwright/test/concept.test.ts
@@ -1,0 +1,43 @@
+import { test as base } from '@playwright/test';
+import { concept } from './contexts';
+import { baseUrl } from './helpers/urls';
+import { makeDefaultToggleCookies } from './helpers/utils';
+
+const domain = new URL(baseUrl).host;
+
+const test = base.extend({
+  context: async ({ context }, use) => {
+    const defaultToggleCookies = await makeDefaultToggleCookies(domain);
+
+    // This adds the conceptsPages toggle so the e2e tests can see the concept pages,
+    // but once they're out from behind a toggle we can remove this.
+    await context.addCookies([
+      {
+        name: 'toggle_conceptsPages',
+        value: 'true',
+        domain,
+        path: '/',
+      },
+      ...defaultToggleCookies.filter(c => c.name !== 'toggle_conceptsPages'),
+    ]);
+
+    await use(context);
+  },
+});
+
+const conceptIds = {
+  'Thackrah, Charles Turner, 1795-1833': 'd46ea7yk',
+};
+
+test.describe('concepts', () => {
+  test('concepts get a list of associated works', async ({ page, context }) => {
+    // I've deliberately picked a complicated ID with commas here, to make sure
+    // we're quoting the query we send to the works API.
+    await concept(
+      conceptIds['Thackrah, Charles Turner, 1795-1833'],
+      context,
+      page
+    );
+    await page.waitForSelector('h2 >> text="Works"');
+  });
+});

--- a/playwright/test/contexts.ts
+++ b/playwright/test/contexts.ts
@@ -178,6 +178,15 @@ const article = async (
   await gotoWithoutCache(`${baseUrl}/articles/${id}`, page);
 };
 
+const concept = async (
+  id: string,
+  context: BrowserContext,
+  page: Page
+): Promise<void> => {
+  await context.addCookies(requiredCookies);
+  await gotoWithoutCache(`${baseUrl}/concepts/${id}`, page);
+};
+
 const articleWithMockSiblings = async (
   id: string,
   response: Record<string, any>,
@@ -221,5 +230,6 @@ export {
   itemWithNonRestrictedAndOpenAccess,
   article,
   articleWithMockSiblings,
+  concept,
   isMobile,
 };

--- a/playwright/test/selectors/concepts.ts
+++ b/playwright/test/selectors/concepts.ts
@@ -1,0 +1,2 @@
+export const worksByThisPerson = 'css=button#tab-works-by';
+export const worksByThisSubject = 'css=button#tab-works-by"';

--- a/playwright/test/selectors/concepts.ts
+++ b/playwright/test/selectors/concepts.ts
@@ -1,2 +1,5 @@
 export const worksByThisPerson = 'css=button#tab-works-by';
-export const worksByThisSubject = 'css=button#tab-works-by"';
+export const worksByThisSubject = 'css=button#tab-works-by';
+
+export const imagesByThisPerson = 'css=button#tab-images-by';
+export const imagesByThisSubject = 'css=button#tab-images-by';


### PR DESCRIPTION
Replaces https://github.com/wellcomecollection/wellcomecollection.org/pull/8493

This is a simpler change with better testing.

* When you search for works/images, all the query parameter encoding happens inside `getWorks()` and `getImages()`. This means we get the correct results on concept pages with concept labels that need to be quoted (i.e. that contain commas).

* We already have functions for creating links to works/image search results with the correct query parameter encoding, but we weren't calling them from the concept pages. Now we are.

* The link from "Works by a subject" were linking to a subject search; now they link to a contributor search.

* I've added some e2e tests for the flow on the per-concept pages, which also gives us a nice set of examples to test with.