### PR TITLE
Fix the broken date filters on the works search

### DIFF
--- a/catalogue/webapp/services/catalogue/works.ts
+++ b/catalogue/webapp/services/catalogue/works.ts
@@ -69,7 +69,7 @@ const redirect = (id: string, status = 302): CatalogueApiRedirect => ({
  * Note: the filter GUI expects users to enter dates as a four-digit year (e.g. 1939).
  * We pin to the start/end of the year so that the range is inclusive.
  *
- * e.g. a user who searches for works 'to 2001' should find works
+ * e.g. a user who searches for works 'to 2001' should find works created in 2001.
  */
 function toIsoDateString(
   s: string | undefined,

--- a/catalogue/webapp/services/catalogue/works.ts
+++ b/catalogue/webapp/services/catalogue/works.ts
@@ -64,6 +64,30 @@ const redirect = (id: string, status = 302): CatalogueApiRedirect => ({
   status,
 });
 
+/** Creates the YYYY-MM-DD date string we pass to the API.
+ *
+ * Note: the filter GUI expects users to enter dates as a four-digit year (e.g. 1939).
+ * We pin to the start/end of the year so that the range is inclusive.
+ *
+ * e.g. a user who searches for works 'to 2001' should find works
+ */
+function toIsoDateString(
+  s: string | undefined,
+  range: 'to' | 'from'
+): string | undefined {
+  if (s) {
+    try {
+      const d = new Date(s);
+      return range === 'from'
+        ? `${d.getUTCFullYear()}-01-01`
+        : `${d.getUTCFullYear()}-12-31`;
+    } catch (e) {
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
 /** Run a query with the works API.
  *
  * Note: this method is responsible for encoding parameters in an API-compatible
@@ -84,6 +108,14 @@ export async function getWorks(
   const extendedParams = {
     ...params,
     ...query,
+    'production.dates.from': toIsoDateString(
+      query['production.dates.from'] as string,
+      'from'
+    ),
+    'production.dates.to': toIsoDateString(
+      query['production.dates.to'] as string,
+      'to'
+    ),
     include: worksIncludes,
   };
 

--- a/common/services/catalogue/api.ts
+++ b/common/services/catalogue/api.ts
@@ -1,18 +1,3 @@
-import { quoteVal } from '../../utils/csv';
-import { ImagesProps } from '../../views/components/ImagesLink/ImagesLink';
-import { WorksProps } from '../../views/components/WorksLink/WorksLink';
-
-function toIsoDateString(s: string | undefined): string | undefined {
-  if (s) {
-    try {
-      return new Date(s).toISOString().split('T')[0];
-    } catch (e) {
-      return undefined;
-    }
-  }
-  return undefined;
-}
-
 type ItemsLocationsAccessConditionsStatus =
   | 'open'
   | 'open-with-advisory'

--- a/playwright/test/works-search.test.ts
+++ b/playwright/test/works-search.test.ts
@@ -21,11 +21,16 @@ const expectSearchParam = (
 ) => {
   console.info('expectSearchParam', { expectedKey, expectedVal });
   const params = new URLSearchParams(page.url());
-  expect(
-    Array.from(params).find(
-      ([key, val]) => key === expectedKey && val === expectedVal
-    )
-  ).toBeTruthy();
+
+  const foundMatchingParam = Array.from(params).find(
+    ([key, val]) => key === expectedKey && val === expectedVal
+  );
+
+  if (!foundMatchingParam) {
+    console.log(page.url());
+  }
+
+  expect(foundMatchingParam).toBeTruthy();
 };
 
 const openDropdown = async (label: string, page: Page) => {
@@ -172,6 +177,41 @@ test.describe(
 
       expectSearchParam('availabilities', 'closed-stores', page);
 
+      await navigateToResult(6, page);
+    });
+  }
+);
+
+test.describe(
+  'Scenario 6: The reader is searching for works from a particular year',
+  () => {
+    test('the work should be browsable to from the search results', async ({
+      page,
+      context,
+    }) => {
+      await worksSearch(context, page);
+      await searchFor('brain', page);
+      await openDropdown('Dates', page);
+
+      // Note: if you put both `page.locator(…).fill(…)` commands in a
+      // single Promise.all(), they can interfere in such a way that only
+      // one of them ends up in the final URL. :-/
+
+      await Promise.all([
+        page.locator('input[name="production.dates.from"]').fill('1939'),
+        safeWaitForNavigation(page),
+      ]);
+
+      await Promise.all([
+        page.locator('input[name="production.dates.to"]').fill('2001'),
+        safeWaitForNavigation(page),
+      ]);
+
+      expectSearchParam('production.dates.from', '1939', page);
+      expectSearchParam('production.dates.to', '2001', page);
+
+      // This is a check that we have actually loaded some results from
+      // the API, and the API hasn't just errored out.
       await navigateToResult(6, page);
     });
   }


### PR DESCRIPTION
In particular this toIsoDateString got accidentally deleted when I was tidying up the filters for concept pages.

## Who is this for?

Anybody who wants to filter by date: https://wellcome.slack.com/archives/C8X9YKM5X/p1663763975934799

## What is it doing for them?

Fixing the bug I introduced in https://github.com/wellcomecollection/wellcomecollection.org/pull/8508