### PR TITLE
Fix a couple of wrinkles in the filter UI

### DIFF
--- a/common/services/catalogue/filters.ts
+++ b/common/services/catalogue/filters.ts
@@ -4,7 +4,7 @@ import { quoteVal } from '../../utils/csv';
 import { toHtmlId } from '../../utils/string';
 import { ImagesProps } from '../../views/components/ImagesLink/ImagesLink';
 import { WorksProps } from '../../views/components/WorksLink/WorksLink';
-import { isNotUndefined } from '../../utils/array';
+import { isNotUndefined, isString } from '../../utils/array';
 
 export type DateRangeFilter = {
   type: 'dateRange';
@@ -51,6 +51,11 @@ type FilterOption = {
   selected: boolean;
 };
 
+type SelectedValue = {
+  label: string;
+  value: string;
+};
+
 /** We build the list of available filters from two lists:
  *
  *    - the list of aggregated values from the API
@@ -68,17 +73,25 @@ function filterOptionsWithNonAggregates({
   showEmptyBuckets = false,
 }: {
   options?: FilterOption[];
-  selectedValues: string[];
+  selectedValues: (string | SelectedValue)[];
   showEmptyBuckets?: boolean;
 }): FilterOption[] {
   const aggregationValues = options.map(option => option.value);
   const nonAggregateOptions = selectedValues
-    .filter(value => !aggregationValues.includes(value))
-    .map(label => ({
-      id: toHtmlId(label),
-      value: label,
+    .map(value =>
+      isString(value)
+        ? {
+            value,
+            label: value,
+          }
+        : value
+    )
+    .filter(({ value }) => !aggregationValues.includes(value))
+    .map(({ label, value }) => ({
+      id: toHtmlId(value),
+      value: value,
       count: 0,
-      label: label,
+      label,
       selected: true,
     }));
 
@@ -147,7 +160,10 @@ const subjectsFilter = ({
       label: bucket.data.label,
       selected: props['subjects.label'].includes(bucket.data.label),
     })),
-    selectedValues: props['subjects.label'].map(quoteVal),
+    selectedValues: props['subjects.label'].map(label => ({
+      value: quoteVal(label),
+      label,
+    })),
   }),
 });
 
@@ -163,7 +179,10 @@ const genresFilter = ({ works, props }: WorksFilterProps): CheckboxFilter => ({
       label: bucket.data.label,
       selected: props['genres.label'].includes(bucket.data.label),
     })),
-    selectedValues: props['genres.label'].map(quoteVal),
+    selectedValues: props['genres.label'].map(label => ({
+      value: quoteVal(label),
+      label,
+    })),
   }),
 });
 
@@ -187,7 +206,10 @@ const contributorsAgentFilter = ({
           ),
         })
       ),
-      selectedValues: props['contributors.agent.label'].map(quoteVal),
+      selectedValues: props['contributors.agent.label'].map(label => ({
+        value: quoteVal(label),
+        label,
+      })),
     }),
   };
 };
@@ -345,7 +367,10 @@ const sourceGenresFilter = ({
         selected: props['source.genres.label'].includes(bucket.data.label),
       })
     ),
-    selectedValues: props['source.genres.label'].map(quoteVal),
+    selectedValues: props['source.genres.label'].map(label => ({
+      value: quoteVal(label),
+      label,
+    })),
   }),
 });
 
@@ -366,7 +391,10 @@ const sourceSubjectsFilter = ({
         selected: props['source.subjects.label'].includes(bucket.data.label),
       })
     ),
-    selectedValues: props['source.subjects.label'].map(quoteVal),
+    selectedValues: props['source.subjects.label'].map(label => ({
+      value: quoteVal(label),
+      label,
+    })),
   }),
 });
 
@@ -389,7 +417,10 @@ const sourceContributorAgentsFilter = ({
         bucket.data.label
       ),
     })),
-    selectedValues: props['source.contributors.agent.label'].map(quoteVal),
+    selectedValues: props['source.contributors.agent.label'].map(label => ({
+      value: quoteVal(label),
+      label,
+    })),
   }),
 });
 

--- a/common/services/catalogue/filters.ts
+++ b/common/services/catalogue/filters.ts
@@ -51,6 +51,17 @@ type FilterOption = {
   selected: boolean;
 };
 
+/** We build the list of available filters from two lists:
+ *
+ *    - the list of aggregated values from the API
+ *    - the list of values the user has already selected, which may not
+ *      appear in the aggregations
+ *
+ * e.g. if a user clicks on an obscure subject from a works page to get a
+ * filtered search, we want to display that obscure subject in the list of
+ * filters even if it doesn't appear in the top N subjects from the API.
+ *
+ */
 function filterOptionsWithNonAggregates(
   options: FilterOption[],
   values: string[],

--- a/common/services/catalogue/filters.ts
+++ b/common/services/catalogue/filters.ts
@@ -63,11 +63,11 @@ type FilterOption = {
  *
  */
 function filterOptionsWithNonAggregates({
-  options,
+  options = [],
   selectedValues,
   showEmptyBuckets = false,
 }: {
-  options: FilterOption[];
+  options?: FilterOption[];
   selectedValues: string[];
   showEmptyBuckets?: boolean;
 }): FilterOption[] {
@@ -121,14 +121,13 @@ const workTypeFilter = ({
   id: 'workType',
   label: 'Formats',
   options: filterOptionsWithNonAggregates({
-    options:
-      works?.aggregations?.workType.buckets.map(bucket => ({
-        id: bucket.data.id,
-        value: bucket.data.id,
-        count: bucket.count,
-        label: bucket.data.label,
-        selected: props.workType.includes(bucket.data.id),
-      })) || [],
+    options: works?.aggregations?.workType.buckets.map(bucket => ({
+      id: bucket.data.id,
+      value: bucket.data.id,
+      count: bucket.count,
+      label: bucket.data.label,
+      selected: props.workType.includes(bucket.data.id),
+    })),
     selectedValues: props.workType,
   }),
 });
@@ -141,14 +140,13 @@ const subjectsFilter = ({
   id: 'subjects.label',
   label: 'Subjects',
   options: filterOptionsWithNonAggregates({
-    options:
-      works?.aggregations?.['subjects.label']?.buckets.map(bucket => ({
-        id: toHtmlId(bucket.data.label),
-        value: quoteVal(bucket.data.label),
-        count: bucket.count,
-        label: bucket.data.label,
-        selected: props['subjects.label'].includes(bucket.data.label),
-      })) || [],
+    options: works?.aggregations?.['subjects.label']?.buckets.map(bucket => ({
+      id: toHtmlId(bucket.data.label),
+      value: quoteVal(bucket.data.label),
+      count: bucket.count,
+      label: bucket.data.label,
+      selected: props['subjects.label'].includes(bucket.data.label),
+    })),
     selectedValues: props['subjects.label'].map(quoteVal),
   }),
 });
@@ -158,14 +156,13 @@ const genresFilter = ({ works, props }: WorksFilterProps): CheckboxFilter => ({
   id: 'genres.label',
   label: 'Types/Techniques',
   options: filterOptionsWithNonAggregates({
-    options:
-      works?.aggregations?.['genres.label']?.buckets.map(bucket => ({
-        id: toHtmlId(bucket.data.label),
-        value: quoteVal(bucket.data.label),
-        count: bucket.count,
-        label: bucket.data.label,
-        selected: props['genres.label'].includes(bucket.data.label),
-      })) || [],
+    options: works?.aggregations?.['genres.label']?.buckets.map(bucket => ({
+      id: toHtmlId(bucket.data.label),
+      value: quoteVal(bucket.data.label),
+      count: bucket.count,
+      label: bucket.data.label,
+      selected: props['genres.label'].includes(bucket.data.label),
+    })),
     selectedValues: props['genres.label'].map(quoteVal),
   }),
 });
@@ -179,18 +176,17 @@ const contributorsAgentFilter = ({
     id: 'contributors.agent.label',
     label: 'Contributors',
     options: filterOptionsWithNonAggregates({
-      options:
-        works?.aggregations?.['contributors.agent.label']?.buckets.map(
-          bucket => ({
-            id: toHtmlId(bucket.data.label),
-            value: quoteVal(bucket.data.label),
-            count: bucket.count,
-            label: bucket.data.label,
-            selected: props['contributors.agent.label'].includes(
-              bucket.data.label
-            ),
-          })
-        ) || [],
+      options: works?.aggregations?.['contributors.agent.label']?.buckets.map(
+        bucket => ({
+          id: toHtmlId(bucket.data.label),
+          value: quoteVal(bucket.data.label),
+          count: bucket.count,
+          label: bucket.data.label,
+          selected: props['contributors.agent.label'].includes(
+            bucket.data.label
+          ),
+        })
+      ),
       selectedValues: props['contributors.agent.label'].map(quoteVal),
     }),
   };
@@ -204,14 +200,13 @@ const languagesFilter = ({
   id: 'languages',
   label: 'Languages',
   options: filterOptionsWithNonAggregates({
-    options:
-      works?.aggregations?.languages?.buckets.map(bucket => ({
-        id: bucket.data.id,
-        value: bucket.data.id,
-        count: bucket.count,
-        label: bucket.data.label,
-        selected: props.languages.includes(bucket.data.id),
-      })) || [],
+    options: works?.aggregations?.languages?.buckets.map(bucket => ({
+      id: bucket.data.id,
+      value: bucket.data.id,
+      count: bucket.count,
+      label: bucket.data.label,
+      selected: props.languages.includes(bucket.data.id),
+    })),
     selectedValues: props.languages,
   }),
 });
@@ -257,14 +252,13 @@ const availabilitiesFilter = ({
   id: 'availabilities',
   label: 'Locations',
   options: filterOptionsWithNonAggregates({
-    options:
-      works?.aggregations?.availabilities?.buckets.map(bucket => ({
-        id: bucket.data.id,
-        value: bucket.data.id,
-        count: bucket.count,
-        label: bucket.data.label,
-        selected: props.availabilities.includes(bucket.data.id),
-      })) || [],
+    options: works?.aggregations?.availabilities?.buckets.map(bucket => ({
+      id: bucket.data.id,
+      value: bucket.data.id,
+      count: bucket.count,
+      label: bucket.data.label,
+      selected: props.availabilities.includes(bucket.data.id),
+    })),
     selectedValues: props.availabilities,
   }),
 });
@@ -322,14 +316,13 @@ const licensesFilter = ({
   id: 'locations.license',
   label: 'Licenses',
   options: filterOptionsWithNonAggregates({
-    options:
-      images.aggregations?.license?.buckets.map(bucket => ({
-        id: bucket.data.id,
-        value: bucket.data.id,
-        count: bucket.count,
-        label: licenseLabels[bucket.data.id] || bucket.data.label,
-        selected: props['locations.license'].includes(bucket.data.id),
-      })) || [],
+    options: images.aggregations?.license?.buckets.map(bucket => ({
+      id: bucket.data.id,
+      value: bucket.data.id,
+      count: bucket.count,
+      label: licenseLabels[bucket.data.id] || bucket.data.label,
+      selected: props['locations.license'].includes(bucket.data.id),
+    })),
     selectedValues: props['locations.license'],
     showEmptyBuckets: true,
   }),
@@ -343,14 +336,15 @@ const sourceGenresFilter = ({
   id: 'source.genres.label',
   label: 'Types/Techniques',
   options: filterOptionsWithNonAggregates({
-    options:
-      images?.aggregations?.['source.genres.label']?.buckets.map(bucket => ({
+    options: images?.aggregations?.['source.genres.label']?.buckets.map(
+      bucket => ({
         id: toHtmlId(bucket.data.label),
         value: quoteVal(bucket.data.label),
         count: bucket.count,
         label: bucket.data.label,
         selected: props['source.genres.label'].includes(bucket.data.label),
-      })) || [],
+      })
+    ),
     selectedValues: props['source.genres.label'].map(quoteVal),
   }),
 });
@@ -363,14 +357,15 @@ const sourceSubjectsFilter = ({
   id: 'source.subjects.label',
   label: 'Subjects',
   options: filterOptionsWithNonAggregates({
-    options:
-      images?.aggregations?.['source.subjects.label']?.buckets.map(bucket => ({
+    options: images?.aggregations?.['source.subjects.label']?.buckets.map(
+      bucket => ({
         id: toHtmlId(bucket.data.label),
         value: quoteVal(bucket.data.label),
         count: bucket.count,
         label: bucket.data.label,
         selected: props['source.subjects.label'].includes(bucket.data.label),
-      })) || [],
+      })
+    ),
     selectedValues: props['source.subjects.label'].map(quoteVal),
   }),
 });
@@ -383,18 +378,17 @@ const sourceContributorAgentsFilter = ({
   id: 'source.contributors.agent.label',
   label: 'Contributors',
   options: filterOptionsWithNonAggregates({
-    options:
-      images?.aggregations?.['source.contributors.agent.label']?.buckets.map(
-        bucket => ({
-          id: toHtmlId(bucket.data.label),
-          value: quoteVal(bucket.data.label),
-          count: bucket.count,
-          label: bucket.data.label,
-          selected: props['source.contributors.agent.label'].includes(
-            bucket.data.label
-          ),
-        })
-      ) || [],
+    options: images?.aggregations?.[
+      'source.contributors.agent.label'
+    ]?.buckets.map(bucket => ({
+      id: toHtmlId(bucket.data.label),
+      value: quoteVal(bucket.data.label),
+      count: bucket.count,
+      label: bucket.data.label,
+      selected: props['source.contributors.agent.label'].includes(
+        bucket.data.label
+      ),
+    })),
     selectedValues: props['source.contributors.agent.label'].map(quoteVal),
   }),
 });

--- a/common/services/catalogue/filters.ts
+++ b/common/services/catalogue/filters.ts
@@ -55,7 +55,7 @@ function filterOptionsWithNonAggregates(
   options: FilterOption[],
   values: string[],
   showEmptyBuckets = false
-) {
+): FilterOption[] {
   const aggregationValues = options.map(option => option.value);
   const nonAggregateOptions = values
     .filter(value => !aggregationValues.includes(value))

--- a/common/services/catalogue/filters.ts
+++ b/common/services/catalogue/filters.ts
@@ -89,7 +89,7 @@ function filterOptionsWithNonAggregates({
     .filter(({ value }) => !aggregationValues.includes(value))
     .map(({ label, value }) => ({
       id: toHtmlId(value),
-      value: value,
+      value,
       label,
       selected: true,
     }));

--- a/common/services/catalogue/filters.ts
+++ b/common/services/catalogue/filters.ts
@@ -96,12 +96,7 @@ function filterOptionsWithNonAggregates({
 
   return nonAggregateOptions
     .concat(options)
-    .filter(
-      option =>
-        showEmptyBuckets ||
-        (option.count && option.count > 0) ||
-        option.selected
-    );
+    .filter(option => showEmptyBuckets || option.count || option.selected);
 }
 
 /** Creates the label for a filter in the GUI.

--- a/common/services/catalogue/filters.ts
+++ b/common/services/catalogue/filters.ts
@@ -62,13 +62,17 @@ type FilterOption = {
  * filters even if it doesn't appear in the top N subjects from the API.
  *
  */
-function filterOptionsWithNonAggregates(
-  options: FilterOption[],
-  values: string[],
-  showEmptyBuckets = false
-): FilterOption[] {
+function filterOptionsWithNonAggregates({
+  options,
+  selectedValues,
+  showEmptyBuckets = false,
+}: {
+  options: FilterOption[];
+  selectedValues: string[];
+  showEmptyBuckets?: boolean;
+}): FilterOption[] {
   const aggregationValues = options.map(option => option.value);
-  const nonAggregateOptions = values
+  const nonAggregateOptions = selectedValues
     .filter(value => !aggregationValues.includes(value))
     .map(label => ({
       id: toHtmlId(label),
@@ -116,16 +120,17 @@ const workTypeFilter = ({
   type: 'checkbox',
   id: 'workType',
   label: 'Formats',
-  options: filterOptionsWithNonAggregates(
-    works?.aggregations?.workType.buckets.map(bucket => ({
-      id: bucket.data.id,
-      value: bucket.data.id,
-      count: bucket.count,
-      label: bucket.data.label,
-      selected: props.workType.includes(bucket.data.id),
-    })) || [],
-    props.workType
-  ),
+  options: filterOptionsWithNonAggregates({
+    options:
+      works?.aggregations?.workType.buckets.map(bucket => ({
+        id: bucket.data.id,
+        value: bucket.data.id,
+        count: bucket.count,
+        label: bucket.data.label,
+        selected: props.workType.includes(bucket.data.id),
+      })) || [],
+    selectedValues: props.workType,
+  }),
 });
 
 const subjectsFilter = ({
@@ -135,32 +140,34 @@ const subjectsFilter = ({
   type: 'checkbox',
   id: 'subjects.label',
   label: 'Subjects',
-  options: filterOptionsWithNonAggregates(
-    works?.aggregations?.['subjects.label']?.buckets.map(bucket => ({
-      id: toHtmlId(bucket.data.label),
-      value: quoteVal(bucket.data.label),
-      count: bucket.count,
-      label: bucket.data.label,
-      selected: props['subjects.label'].includes(bucket.data.label),
-    })) || [],
-    props['subjects.label'].map(quoteVal)
-  ),
+  options: filterOptionsWithNonAggregates({
+    options:
+      works?.aggregations?.['subjects.label']?.buckets.map(bucket => ({
+        id: toHtmlId(bucket.data.label),
+        value: quoteVal(bucket.data.label),
+        count: bucket.count,
+        label: bucket.data.label,
+        selected: props['subjects.label'].includes(bucket.data.label),
+      })) || [],
+    selectedValues: props['subjects.label'].map(quoteVal),
+  }),
 });
 
 const genresFilter = ({ works, props }: WorksFilterProps): CheckboxFilter => ({
   type: 'checkbox',
   id: 'genres.label',
   label: 'Types/Techniques',
-  options: filterOptionsWithNonAggregates(
-    works?.aggregations?.['genres.label']?.buckets.map(bucket => ({
-      id: toHtmlId(bucket.data.label),
-      value: quoteVal(bucket.data.label),
-      count: bucket.count,
-      label: bucket.data.label,
-      selected: props['genres.label'].includes(bucket.data.label),
-    })) || [],
-    props['genres.label'].map(quoteVal)
-  ),
+  options: filterOptionsWithNonAggregates({
+    options:
+      works?.aggregations?.['genres.label']?.buckets.map(bucket => ({
+        id: toHtmlId(bucket.data.label),
+        value: quoteVal(bucket.data.label),
+        count: bucket.count,
+        label: bucket.data.label,
+        selected: props['genres.label'].includes(bucket.data.label),
+      })) || [],
+    selectedValues: props['genres.label'].map(quoteVal),
+  }),
 });
 
 const contributorsAgentFilter = ({
@@ -171,20 +178,21 @@ const contributorsAgentFilter = ({
     type: 'checkbox',
     id: 'contributors.agent.label',
     label: 'Contributors',
-    options: filterOptionsWithNonAggregates(
-      works?.aggregations?.['contributors.agent.label']?.buckets.map(
-        bucket => ({
-          id: toHtmlId(bucket.data.label),
-          value: quoteVal(bucket.data.label),
-          count: bucket.count,
-          label: bucket.data.label,
-          selected: props['contributors.agent.label'].includes(
-            bucket.data.label
-          ),
-        })
-      ) || [],
-      props['contributors.agent.label'].map(quoteVal)
-    ),
+    options: filterOptionsWithNonAggregates({
+      options:
+        works?.aggregations?.['contributors.agent.label']?.buckets.map(
+          bucket => ({
+            id: toHtmlId(bucket.data.label),
+            value: quoteVal(bucket.data.label),
+            count: bucket.count,
+            label: bucket.data.label,
+            selected: props['contributors.agent.label'].includes(
+              bucket.data.label
+            ),
+          })
+        ) || [],
+      selectedValues: props['contributors.agent.label'].map(quoteVal),
+    }),
   };
 };
 
@@ -195,16 +203,17 @@ const languagesFilter = ({
   type: 'checkbox',
   id: 'languages',
   label: 'Languages',
-  options: filterOptionsWithNonAggregates(
-    works?.aggregations?.languages?.buckets.map(bucket => ({
-      id: bucket.data.id,
-      value: bucket.data.id,
-      count: bucket.count,
-      label: bucket.data.label,
-      selected: props.languages.includes(bucket.data.id),
-    })) || [],
-    props.languages
-  ),
+  options: filterOptionsWithNonAggregates({
+    options:
+      works?.aggregations?.languages?.buckets.map(bucket => ({
+        id: bucket.data.id,
+        value: bucket.data.id,
+        count: bucket.count,
+        label: bucket.data.label,
+        selected: props.languages.includes(bucket.data.id),
+      })) || [],
+    selectedValues: props.languages,
+  }),
 });
 
 /*
@@ -225,8 +234,8 @@ const partOfFilter = ({ props }: WorksFilterProps): CheckboxFilter => ({
   label: 'Series',
   excludeFromMoreFilters: true,
   options: props['partOf.title']
-    ? filterOptionsWithNonAggregates(
-        [
+    ? filterOptionsWithNonAggregates({
+        options: [
           {
             id: props['partOf.title'],
             value: props['partOf.title'],
@@ -235,8 +244,8 @@ const partOfFilter = ({ props }: WorksFilterProps): CheckboxFilter => ({
             selected: !!props['partOf.title'],
           },
         ],
-        [props['partOf.title']]
-      )
+        selectedValues: [props['partOf.title']],
+      })
     : [],
 });
 
@@ -247,16 +256,17 @@ const availabilitiesFilter = ({
   type: 'checkbox',
   id: 'availabilities',
   label: 'Locations',
-  options: filterOptionsWithNonAggregates(
-    works?.aggregations?.availabilities?.buckets.map(bucket => ({
-      id: bucket.data.id,
-      value: bucket.data.id,
-      count: bucket.count,
-      label: bucket.data.label,
-      selected: props.availabilities.includes(bucket.data.id),
-    })) || [],
-    props.availabilities
-  ),
+  options: filterOptionsWithNonAggregates({
+    options:
+      works?.aggregations?.availabilities?.buckets.map(bucket => ({
+        id: bucket.data.id,
+        value: bucket.data.id,
+        count: bucket.count,
+        label: bucket.data.label,
+        selected: props.availabilities.includes(bucket.data.id),
+      })) || [],
+    selectedValues: props.availabilities,
+  }),
 });
 
 const colorFilter = ({ props }: ImagesFilterProps): ColorFilter => {
@@ -311,17 +321,18 @@ const licensesFilter = ({
   type: 'checkbox',
   id: 'locations.license',
   label: 'Licenses',
-  options: filterOptionsWithNonAggregates(
-    images.aggregations?.license?.buckets.map(bucket => ({
-      id: bucket.data.id,
-      value: bucket.data.id,
-      count: bucket.count,
-      label: licenseLabels[bucket.data.id] || bucket.data.label,
-      selected: props['locations.license'].includes(bucket.data.id),
-    })) || [],
-    props['locations.license'],
-    true
-  ),
+  options: filterOptionsWithNonAggregates({
+    options:
+      images.aggregations?.license?.buckets.map(bucket => ({
+        id: bucket.data.id,
+        value: bucket.data.id,
+        count: bucket.count,
+        label: licenseLabels[bucket.data.id] || bucket.data.label,
+        selected: props['locations.license'].includes(bucket.data.id),
+      })) || [],
+    selectedValues: props['locations.license'],
+    showEmptyBuckets: true,
+  }),
 });
 
 const sourceGenresFilter = ({
@@ -331,16 +342,17 @@ const sourceGenresFilter = ({
   type: 'checkbox',
   id: 'source.genres.label',
   label: 'Types/Techniques',
-  options: filterOptionsWithNonAggregates(
-    images?.aggregations?.['source.genres.label']?.buckets.map(bucket => ({
-      id: toHtmlId(bucket.data.label),
-      value: quoteVal(bucket.data.label),
-      count: bucket.count,
-      label: bucket.data.label,
-      selected: props['source.genres.label'].includes(bucket.data.label),
-    })) || [],
-    props['source.genres.label'].map(quoteVal)
-  ),
+  options: filterOptionsWithNonAggregates({
+    options:
+      images?.aggregations?.['source.genres.label']?.buckets.map(bucket => ({
+        id: toHtmlId(bucket.data.label),
+        value: quoteVal(bucket.data.label),
+        count: bucket.count,
+        label: bucket.data.label,
+        selected: props['source.genres.label'].includes(bucket.data.label),
+      })) || [],
+    selectedValues: props['source.genres.label'].map(quoteVal),
+  }),
 });
 
 const sourceSubjectsFilter = ({
@@ -350,16 +362,17 @@ const sourceSubjectsFilter = ({
   type: 'checkbox',
   id: 'source.subjects.label',
   label: 'Subjects',
-  options: filterOptionsWithNonAggregates(
-    images?.aggregations?.['source.subjects.label']?.buckets.map(bucket => ({
-      id: toHtmlId(bucket.data.label),
-      value: quoteVal(bucket.data.label),
-      count: bucket.count,
-      label: bucket.data.label,
-      selected: props['source.subjects.label'].includes(bucket.data.label),
-    })) || [],
-    props['source.subjects.label'].map(quoteVal)
-  ),
+  options: filterOptionsWithNonAggregates({
+    options:
+      images?.aggregations?.['source.subjects.label']?.buckets.map(bucket => ({
+        id: toHtmlId(bucket.data.label),
+        value: quoteVal(bucket.data.label),
+        count: bucket.count,
+        label: bucket.data.label,
+        selected: props['source.subjects.label'].includes(bucket.data.label),
+      })) || [],
+    selectedValues: props['source.subjects.label'].map(quoteVal),
+  }),
 });
 
 const sourceContributorAgentsFilter = ({
@@ -369,20 +382,21 @@ const sourceContributorAgentsFilter = ({
   type: 'checkbox',
   id: 'source.contributors.agent.label',
   label: 'Contributors',
-  options: filterOptionsWithNonAggregates(
-    images?.aggregations?.['source.contributors.agent.label']?.buckets.map(
-      bucket => ({
-        id: toHtmlId(bucket.data.label),
-        value: quoteVal(bucket.data.label),
-        count: bucket.count,
-        label: bucket.data.label,
-        selected: props['source.contributors.agent.label'].includes(
-          bucket.data.label
-        ),
-      })
-    ) || [],
-    props['source.contributors.agent.label'].map(quoteVal)
-  ),
+  options: filterOptionsWithNonAggregates({
+    options:
+      images?.aggregations?.['source.contributors.agent.label']?.buckets.map(
+        bucket => ({
+          id: toHtmlId(bucket.data.label),
+          value: quoteVal(bucket.data.label),
+          count: bucket.count,
+          label: bucket.data.label,
+          selected: props['source.contributors.agent.label'].includes(
+            bucket.data.label
+          ),
+        })
+      ) || [],
+    selectedValues: props['source.contributors.agent.label'].map(quoteVal),
+  }),
 });
 
 const imagesFilters: (props: ImagesFilterProps) => Filter[] = props =>

--- a/common/services/catalogue/filters.ts
+++ b/common/services/catalogue/filters.ts
@@ -46,7 +46,7 @@ export type Filter = CheckboxFilter | DateRangeFilter | ColorFilter;
 type FilterOption = {
   id: string;
   value: string;
-  count: number;
+  count?: number;
   label: string;
   selected: boolean;
 };
@@ -77,7 +77,7 @@ function filterOptionsWithNonAggregates({
   showEmptyBuckets?: boolean;
 }): FilterOption[] {
   const aggregationValues = options.map(option => option.value);
-  const nonAggregateOptions = selectedValues
+  const nonAggregateOptions: FilterOption[] = selectedValues
     .map(value =>
       isString(value)
         ? {
@@ -90,15 +90,33 @@ function filterOptionsWithNonAggregates({
     .map(({ label, value }) => ({
       id: toHtmlId(value),
       value: value,
-      count: 0,
       label,
       selected: true,
     }));
 
   return nonAggregateOptions
     .concat(options)
-    .filter(option => showEmptyBuckets || option.count > 0 || option.selected);
+    .filter(
+      option =>
+        showEmptyBuckets ||
+        (option.count && option.count > 0) ||
+        option.selected
+    );
 }
+
+/** Creates the label for a filter in the GUI.
+ *
+ * Note: we intentionally omit the count when we have a filter whose
+ * count is unknown, which happens when we create a filter from a
+ * selected value.
+ */
+export const filterLabel = ({
+  label,
+  count,
+}: {
+  label: string;
+  count?: number;
+}): string => (count ? `${label} (${count})` : label);
 
 type WorksFilterProps = {
   works: CatalogueResultsList<Work>;

--- a/common/test/services/catalogue/filters.test.ts
+++ b/common/test/services/catalogue/filters.test.ts
@@ -49,12 +49,12 @@ describe('filter options', () => {
       works: worksAggregations,
       props: fromWorksQuery({
         // An aggregation we know isn't in the fixture response
-        'contributors.agent.label': '"Non existant"',
+        'contributors.agent.label': '"Non existent"',
       }),
     }).find(f => f.id === 'contributors.agent.label') as CheckboxFilter;
 
     expect(
-      filter.options.find(option => option.label === '"Non existant"')
+      filter.options.find(option => option.label === 'Non existent')
     ).toBeTruthy();
   });
 
@@ -62,10 +62,10 @@ describe('filter options', () => {
     const filter = imagesFilters({
       images: imagesAggregations,
       props: fromImagesQuery({
-        'locations.license': '"Non existant"',
+        'locations.license': '"Non existent"',
       }),
     }).find(f => f.id === 'locations.license') as CheckboxFilter;
 
-    expect(filter.options.filter(option => option.count === 0).length).toBe(7);
+    expect(filter.options.length).toBe(7);
   });
 });

--- a/common/views/components/ModalMoreFilters/ModalMoreFilters.tsx
+++ b/common/views/components/ModalMoreFilters/ModalMoreFilters.tsx
@@ -9,6 +9,7 @@ import ButtonSolid, { ButtonTypes } from '../ButtonSolid/ButtonSolid';
 import {
   Filter,
   CheckboxFilter as CheckboxFilterType,
+  filterLabel,
 } from '../../../services/catalogue/filters';
 import { AppContext } from '../AppContext/AppContext';
 import CheckboxRadio from '../CheckboxRadio/CheckboxRadio';
@@ -110,7 +111,7 @@ const CheckboxFilter = ({ f, changeHandler }: CheckboxFilterProps) => {
             <CheckboxRadio
               id={`desktop-${id}`}
               type="checkbox"
-              text={`${label} (${count})`}
+              text={filterLabel({ label, count })}
               value={value}
               name={f.id}
               checked={selected}

--- a/common/views/components/SearchFilters/SearchFiltersDesktop.tsx
+++ b/common/views/components/SearchFilters/SearchFiltersDesktop.tsx
@@ -18,6 +18,7 @@ import {
   CheckboxFilter as CheckboxFilterType,
   DateRangeFilter as DateRangeFilterType,
   ColorFilter as ColorFilterType,
+  filterLabel,
 } from '../../../services/catalogue/filters';
 import ModalMoreFilters from '../ModalMoreFilters/ModalMoreFilters';
 import { ResetActiveFilters } from './ResetActiveFilters';
@@ -56,7 +57,7 @@ const CheckboxFilter = ({ f, changeHandler }: CheckboxFilterProps) => {
               <CheckboxRadio
                 id={id}
                 type="checkbox"
-                text={`${label} (${count})`}
+                text={filterLabel({ label, count })}
                 value={value}
                 name={f.id}
                 checked={selected}

--- a/common/views/components/SearchFilters/SearchFiltersMobile.tsx
+++ b/common/views/components/SearchFilters/SearchFiltersMobile.tsx
@@ -127,7 +127,7 @@ const CheckboxFilter = ({ f, changeHandler }: CheckboxFilterProps) => {
               <CheckboxRadio
                 id={`mobile-${id}`}
                 type="checkbox"
-                text={`${label} (${count})`}
+                text={filterLabel({ label, count })}
                 value={value}
                 name={f.id}
                 checked={selected}

--- a/common/views/components/SearchFilters/SearchFiltersMobile.tsx
+++ b/common/views/components/SearchFilters/SearchFiltersMobile.tsx
@@ -20,6 +20,7 @@ import {
   CheckboxFilter as CheckboxFilterType,
   DateRangeFilter as DateRangeFilterType,
   ColorFilter as ColorFilterType,
+  filterLabel,
 } from '../../../services/catalogue/filters';
 import ButtonSolid, {
   ButtonTypes,


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/wellcomecollection.org/issues/8495, closes #8494 as superseded.

* Make the filter code easier to read
* Don't show quote marks around filters that need quoting; if we pass a label/value separately, we can still put the quoted value in the URL but not mess up the UI
* Don't show filters with 0 results, which makes no sense