### PR TITLE
Provide better logs when we forward a catalogue API error

### DIFF
--- a/catalogue/webapp/pages/works.tsx
+++ b/catalogue/webapp/pages/works.tsx
@@ -287,7 +287,14 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     });
 
     if (works.type === 'Error') {
-      return appError(context, works.httpStatus, works.description);
+      console.warn(
+        `Forwarding error from the works API: ${JSON.stringify(works)}`
+      );
+      return appError(
+        context,
+        works.httpStatus,
+        works.description || works.label
+      );
     }
 
     return {


### PR DESCRIPTION
* Log a warning in the console
* `description` is empty for 500 errors, so use the label instead