### PR TITLE
Feature: Add the ability to copy anchor links on a page

### DIFF
--- a/common/views/components/ApiToolbar/ApiToolbar.tsx
+++ b/common/views/components/ApiToolbar/ApiToolbar.tsx
@@ -119,6 +119,18 @@ async function createTzitzitWorkLink(
   });
 }
 
+function getAnchorLinkUrls() {
+  const getAllIds = [...document.querySelectorAll('h2, h3, h4')].map(
+    item => item.id
+  );
+  const extractedIdValues = getAllIds.map(id => `${document.URL}#${id}`);
+  const allExtractedUrls = [...extractedIdValues];
+  const strings = JSON.stringify(allExtractedUrls);
+  if (navigator && navigator.clipboard && navigator.clipboard.writeText)
+    return navigator.clipboard.writeText(strings);
+  return 'The Clipboard API is not available.';
+}
+
 function getRouteProps(path: string) {
   switch (path) {
     case '/work':
@@ -258,6 +270,16 @@ const ApiToolbar: FunctionComponent = () => {
           </>
         )}
       </div>
+      <button
+        className="plain-button"
+        type="button"
+        onClick={() => {
+          getAnchorLinkUrls();
+        }}
+        style={{ padding: '10px' }}
+      >
+        <>⚓️</>
+      </button>
 
       <button
         className="plain-button"

--- a/common/views/components/ApiToolbar/ApiToolbar.tsx
+++ b/common/views/components/ApiToolbar/ApiToolbar.tsx
@@ -123,14 +123,16 @@ function getAnchorLinkUrls() {
   const getAllIds = [...document.querySelectorAll('h2, h3, h4')].map(
     item => item.id
   );
-  const extractedIdValues = getAllIds.map(id => `${document.URL}#${id}`);
+  const extractedIdValues = getAllIds
+    .filter(Boolean)
+    .map(id => `${document.URL}#${id}`);
   const csvAsSingleColumn = extractedIdValues.join('\n');
   if (navigator && navigator.clipboard && navigator.clipboard.writeText)
     return navigator.clipboard.writeText(csvAsSingleColumn).then(() => {
       alert('All anchor links on this page have been copied to clipboard!');
     });
   return alert(
-    'The Clipboard API is not available. No links have been copied.'
+    'The Clipboard API is not available. No anchor links have been copied.'
   );
 }
 

--- a/common/views/components/ApiToolbar/ApiToolbar.tsx
+++ b/common/views/components/ApiToolbar/ApiToolbar.tsx
@@ -124,11 +124,14 @@ function getAnchorLinkUrls() {
     item => item.id
   );
   const extractedIdValues = getAllIds.map(id => `${document.URL}#${id}`);
-  const allExtractedUrls = [...extractedIdValues];
-  const strings = JSON.stringify(allExtractedUrls);
+  const csvAsSingleColumn = extractedIdValues.join('\n');
   if (navigator && navigator.clipboard && navigator.clipboard.writeText)
-    return navigator.clipboard.writeText(strings);
-  return 'The Clipboard API is not available.';
+    return navigator.clipboard.writeText(csvAsSingleColumn).then(() => {
+      alert('All anchor links on this page have been copied to clipboard!');
+    });
+  return alert(
+    'The Clipboard API is not available. No links have been copied.'
+  );
 }
 
 function getRouteProps(path: string) {

--- a/common/views/components/ApiToolbar/ApiToolbar.tsx
+++ b/common/views/components/ApiToolbar/ApiToolbar.tsx
@@ -126,10 +126,13 @@ function getAnchorLinkUrls() {
   );
   // Remove empty ids and then append them to the current url with # to
   // create the anchor link
+  // e.g. weco.org/guides/exhibitions/YvUALRAAACMA2h8V/captions-and-transcripts#anchor-id
   const extractedIdValues = getAllIds
     .filter(Boolean)
     .map(id => `${document.URL}#${id}`);
+  // Make the list of urls csv friendly
   const csvAsSingleColumn = extractedIdValues.join('\n');
+  // Push the list of urls to the clipboard
   if (navigator && navigator.clipboard && navigator.clipboard.writeText)
     return navigator.clipboard.writeText(csvAsSingleColumn).then(() => {
       alert('All anchor links on this page have been copied to clipboard!');

--- a/common/views/components/ApiToolbar/ApiToolbar.tsx
+++ b/common/views/components/ApiToolbar/ApiToolbar.tsx
@@ -120,9 +120,12 @@ async function createTzitzitWorkLink(
 }
 
 function getAnchorLinkUrls() {
+  // This function currently only extracts the ids from h2, h3, and h4 tags
   const getAllIds = [...document.querySelectorAll('h2, h3, h4')].map(
     item => item.id
   );
+  // Remove empty ids and then append them to the current url with # to
+  // create the anchor link
   const extractedIdValues = getAllIds
     .filter(Boolean)
     .map(id => `${document.URL}#${id}`);


### PR DESCRIPTION
## Who is this for?

All editors who want to be able to copy any anchor links (`id=x`) on a page. Part of https://github.com/wellcomecollection/wellcomecollection.org/issues/8463


## What is it doing for them?
When the API Toolbar is active and you click ⚓️, any h2, h3 and h4 ids are extracted from page and appended to the current URL. A spreadsheet-friendly single-column list of these urls are copied to the clipboard, the editorial team can then paste this list of urls. 

![anchors2_opt](https://user-images.githubusercontent.com/16557524/191805848-49b83bdc-96c5-44de-86dd-7157bc431b94.gif)


~TODO~: 
- ~Trying to put this in a csv format so it pastes into a spreadsheet more easily~
- ~Some sanitising to be done to remove empty ids from the array of urls~