### PR TITLE
Fix Spacing issue: missing comma on date range

### DIFF
--- a/common/views/components/DateRange/DateRange.tsx
+++ b/common/views/components/DateRange/DateRange.tsx
@@ -39,7 +39,7 @@ const DateRange: FunctionComponent<Props> = ({
   return isSameDay(start, end, 'London') ? (
     <>
       <HTMLDayDate date={start} />
-      {splitTime ? '' : ', '}
+      {!splitTime && ', '}
       <span className={splitTime ? 'block' : undefined}>
         <TimeRange start={start} end={end} />
       </span>

--- a/content/webapp/pages/event.tsx
+++ b/content/webapp/pages/event.tsx
@@ -265,7 +265,9 @@ const EventPage: NextPage<Props> = ({ event, jsonLd }: Props) => {
             }}
             className="flex flex--wrap"
           >
-            <EventDateRange event={event} />
+            <div className="inline">
+              <EventDateRange event={event} />
+            </div>
             <Space h={{ size: 's', properties: ['margin-left'] }}>
               {!event.isPast && <EventDatesLink id={event.id} />}
             </Space>


### PR DESCRIPTION
## Who is this for?
People who like correct grammar

## What is it doing for them?
Allows for space between comma and time in event (erased by flex)

Closes #8499 