### PR TITLE
Add a dasherizeShorten function to shorten length of id anchor hashes

### DIFF
--- a/common/utils/grammar.ts
+++ b/common/utils/grammar.ts
@@ -20,3 +20,14 @@ export function camelize(title: string): string {
 export function dasherize(words: string): string {
   return words.trim().toLowerCase().replace(/\W/g, '-');
 }
+
+export function dasherizeShorten(words: string): string {
+  return words
+    .split(' ')
+    .slice(0, 4)
+    .join(' ')
+    .trim()
+    .toLowerCase()
+    .replace(/\W/g, '-');
+}
+

--- a/common/utils/grammar.ts
+++ b/common/utils/grammar.ts
@@ -23,13 +23,11 @@ export function dasherize(words: string): string {
 // Take a string, like Tombstone title, and return first four words, in lowercase, with dashes
 // An id from Exhibition Guide Tombstone title e.g. An eye surgeon operating on a man
 // becomes #an-eye-surgeon-operating
-export function dasherizeShorten(words: string): string[] {
+export function dasherizeShorten(words: string): string {
   return words
     .split(' ')
     .slice(0, 4)
     .join(' ')
-    .trim()
     .toLowerCase()
-    .replace(/\W/g, '-')
-    .split(/[.*:/()]/);
+    .replace(/\W/g, '-');
 }

--- a/common/utils/grammar.ts
+++ b/common/utils/grammar.ts
@@ -20,7 +20,9 @@ export function camelize(title: string): string {
 export function dasherize(words: string): string {
   return words.trim().toLowerCase().replace(/\W/g, '-');
 }
-
+// Take a string, like Tombstone title, and return first four words, in lowercase, with dashes
+// An id from Exhibition Guide Tombstone title e.g. An eye surgeon operating on a man
+// becomes #an-eye-surgeon-operating
 export function dasherizeShorten(words: string): string[] {
   return words
     .split(' ')

--- a/common/utils/grammar.ts
+++ b/common/utils/grammar.ts
@@ -21,13 +21,13 @@ export function dasherize(words: string): string {
   return words.trim().toLowerCase().replace(/\W/g, '-');
 }
 
-export function dasherizeShorten(words: string): string {
+export function dasherizeShorten(words: string): string[] {
   return words
     .split(' ')
     .slice(0, 4)
     .join(' ')
     .trim()
     .toLowerCase()
-    .replace(/\W/g, '-');
+    .replace(/\W/g, '-')
+    .split(/[.*:/()]/);
 }
-

--- a/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
+++ b/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
@@ -11,7 +11,7 @@ import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper
 import Divider from '@weco/common/views/components/Divider/Divider';
 import { font } from '@weco/common/utils/classnames';
 import { themeValues } from '@weco/common/views/themes/config';
-import { dasherize } from '@weco/common/utils/grammar';
+import { dasherizeShorten } from '@weco/common/utils/grammar';
 
 function getTypeColor(type: string): string {
   // importing this from exhibition-guide.tsx was causing a storybook build failure
@@ -233,7 +233,7 @@ const Stop: FC<{
               }}
               v={{ size: 'l', properties: ['margin-bottom'] }}
             >
-              <StandaloneTitle id={dasherize(`${standaloneTitle}`)}>
+              <StandaloneTitle id={dasherizeShorten(`${standaloneTitle}`)}>
                 {standaloneTitle}
               </StandaloneTitle>
             </Space>
@@ -258,7 +258,7 @@ const Stop: FC<{
               {!hasContext && (
                 <TombstoneTitle
                   level={tombstoneHeadingLevel}
-                  id={dasherize(`${title}`)}
+                  id={dasherizeShorten(`${title}`)}
                 >
                   {title}
                 </TombstoneTitle>
@@ -273,7 +273,7 @@ const Stop: FC<{
                 <>
                   {title.length > 0 && (
                     <ContextTitle
-                      id={dasherize(title)}
+                      id={dasherizeShorten(title)}
                       level={contextHeadingLevel}
                     >
                       {title}

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -51,7 +51,7 @@ import {
   speechToText,
 } from '@weco/common/icons';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
-import { dasherize } from '@weco/common/utils/grammar';
+import { dasherizeShorten } from '@weco/common/utils/grammar';
 
 const PromoContainer = styled.div`
   background: ${props => props.theme.color('cream')};
@@ -294,7 +294,7 @@ const Stops: FC<StopsProps> = ({ stops, type }) => {
             audioWithoutDescription?.url) ||
           (type === 'bsl' && bsl?.embedUrl);
         return hasContentOfDesiredType ? (
-          <Stop key={index} id={dasherize(title)}>
+          <Stop key={index} id={dasherizeShorten(title)}>
             {type === 'audio-with-descriptions' &&
               audioWithDescription?.url && (
                 <AudioPlayer
@@ -314,7 +314,7 @@ const Stops: FC<StopsProps> = ({ stops, type }) => {
             )}
           </Stop>
         ) : (
-          <Stop key={index} id={dasherize(title)}>
+          <Stop key={index} id={dasherizeShorten(title)}>
             <span className={font('intb', 5)}>
               {number}. {title}
             </span>


### PR DESCRIPTION
## Who is this for?

Anyone generating anchor links for h2, h3, h4 titles/stops/tombstones for Exhibition Guides. For https://github.com/wellcomecollection/wellcomecollection.org/issues/8463

## What is it doing for them?

We want to make sure we don't end up with really long `#hash` in an anchor link url. `dasherize` was helpful in generating a readable hash for the ids, but we wanted to shorten them as titles are potentially quite long. I've created a new function `dasherizeShorten`, so as not to break functionality of current `dasherize` function elsewhere, this will limit us to getting the first four full words for the id. The upshot is this _should_ make anchor links predictable and shorter. 
