### PR TITLE
Extract ids from divs for audio and BSL guides

### DIFF
--- a/common/views/components/ApiToolbar/ApiToolbar.tsx
+++ b/common/views/components/ApiToolbar/ApiToolbar.tsx
@@ -124,23 +124,22 @@ function getAnchorLinkUrls() {
   const getAllHeadingIds = [...document.querySelectorAll('h2, h3, h4')].map(
     item => item.id
   );
-  // This function extracts divs that have an id within exhibition in the class name
-  // This is to allow us to grab ids from divs from audio and BSL guides in Exhibition Guides
-  const getDivIds = [...document.querySelectorAll('div[id]')].map(item => {
-    return item.className.match(/exhibition/g) ? item.id : null;
-  });
+  // This function extracts any apiToolbar id with the view to extracting the data-toolbar value
+  // This can be used across the codebase (where apiToolbar id is used) but at the moment is only used in audio & BSL guides
+  // Please note: an audio/BSL guide must contain and audio or video file or no id will exist and no link will be created
+  const getAudioBSLIds = document.querySelector('#apiToolbar');
+  const extractedAudioBSLAnchor =
+    getAudioBSLIds instanceof HTMLElement
+      ? `${document.URL}#${getAudioBSLIds.dataset.toolbar}`
+      : null;
   // Remove empty ids and then append them to the current url with # to
   // create the anchor link
   // e.g. weco.org/guides/exhibitions/YvUALRAAACMA2h8V/captions-and-transcripts#anchor-id
   const extractedHeadingIdValues = getAllHeadingIds
     .filter(Boolean)
     .map(id => `${document.URL}#${id}`);
-  const extractedIdsFromDivs = getDivIds
-    .filter(Boolean)
-    .map(id => `${document.URL}#${id}`);
-  // Make the list of urls csv friendly
   const csvAsSingleColumn =
-    extractedHeadingIdValues.join('\n') + extractedIdsFromDivs.join('\n');
+    extractedHeadingIdValues.join('\n') + extractedAudioBSLAnchor;
   // Push the list of urls to the clipboard
   if (navigator && navigator.clipboard && navigator.clipboard.writeText)
     return navigator.clipboard.writeText(csvAsSingleColumn).then(() => {

--- a/common/views/components/ApiToolbar/ApiToolbar.tsx
+++ b/common/views/components/ApiToolbar/ApiToolbar.tsx
@@ -135,14 +135,14 @@ function getAnchorLinkUrls() {
   // Remove empty ids and then append them to the current url with # to
   // create the anchor link
   // e.g. weco.org/guides/exhibitions/YvUALRAAACMA2h8V/captions-and-transcripts#anchor-id
-  const extractedHeadingIdValues = getAllHeadingIds
+  const extractedHeadingIdURLs = getAllHeadingIds
     .filter(Boolean)
     .map(id => `${document.URL}#${id}`);
-  const extractedAnchorValues = extractedAudioBSLAttributes
+  const extractedAudioBSLURLs = extractedAudioBSLAttributes
     .filter(Boolean)
     .map(id => `${document.URL}#${id}`);
   const csvAsSingleColumn =
-    extractedHeadingIdValues.join('\n') + extractedAnchorValues.join('\n');
+    extractedHeadingIdURLs.join('\n') + extractedAudioBSLURLs.join('\n');
   // Push the list of urls to the clipboard
   if (navigator && navigator.clipboard && navigator.clipboard.writeText)
     return navigator.clipboard.writeText(csvAsSingleColumn).then(() => {

--- a/common/views/components/ApiToolbar/ApiToolbar.tsx
+++ b/common/views/components/ApiToolbar/ApiToolbar.tsx
@@ -121,17 +121,26 @@ async function createTzitzitWorkLink(
 
 function getAnchorLinkUrls() {
   // This function currently only extracts the ids from h2, h3, and h4 tags
-  const getAllIds = [...document.querySelectorAll('h2, h3, h4')].map(
+  const getAllHeadingIds = [...document.querySelectorAll('h2, h3, h4')].map(
     item => item.id
   );
+  // This function extracts divs that have an id within exhibition in the class name
+  // This is to allow us to grab ids from divs from audio and BSL guides in Exhibition Guides
+  const getDivIds = [...document.querySelectorAll('div[id]')].map(item => {
+    return item.className.match(/exhibition/g) ? item.id : null;
+  });
   // Remove empty ids and then append them to the current url with # to
   // create the anchor link
   // e.g. weco.org/guides/exhibitions/YvUALRAAACMA2h8V/captions-and-transcripts#anchor-id
-  const extractedIdValues = getAllIds
+  const extractedHeadingIdValues = getAllHeadingIds
+    .filter(Boolean)
+    .map(id => `${document.URL}#${id}`);
+  const extractedIdsFromDivs = getDivIds
     .filter(Boolean)
     .map(id => `${document.URL}#${id}`);
   // Make the list of urls csv friendly
-  const csvAsSingleColumn = extractedIdValues.join('\n');
+  const csvAsSingleColumn =
+    extractedHeadingIdValues.join('\n') + extractedIdsFromDivs.join('\n');
   // Push the list of urls to the clipboard
   if (navigator && navigator.clipboard && navigator.clipboard.writeText)
     return navigator.clipboard.writeText(csvAsSingleColumn).then(() => {

--- a/common/views/components/ApiToolbar/ApiToolbar.tsx
+++ b/common/views/components/ApiToolbar/ApiToolbar.tsx
@@ -124,22 +124,25 @@ function getAnchorLinkUrls() {
   const getAllHeadingIds = [...document.querySelectorAll('h2, h3, h4')].map(
     item => item.id
   );
-  // This function extracts any apiToolbar id with the view to extracting the data-toolbar value
+  // This function extracts any apiToolbar ids with the view to extracting the data-toolbar values
   // This can be used across the codebase (where apiToolbar id is used) but at the moment is only used in audio & BSL guides
-  // Please note: an audio/BSL guide must contain and audio or video file or no id will exist and no link will be created
-  const getAudioBSLIds = document.querySelector('#apiToolbar');
-  const extractedAudioBSLAnchor =
-    getAudioBSLIds instanceof HTMLElement
-      ? `${document.URL}#${getAudioBSLIds.dataset.toolbar}`
-      : null;
+  // Please note: an audio/BSL guide must contain and audio or video file with an accompanying title or no id will exist
+  // and no link will be created
+  const extractedAudioBSLAttributes = [
+    ...document.querySelectorAll('#apiToolbar'),
+  ].map(el => el.getAttribute('data-toolbar-anchor'));
+
   // Remove empty ids and then append them to the current url with # to
   // create the anchor link
   // e.g. weco.org/guides/exhibitions/YvUALRAAACMA2h8V/captions-and-transcripts#anchor-id
   const extractedHeadingIdValues = getAllHeadingIds
     .filter(Boolean)
     .map(id => `${document.URL}#${id}`);
+  const extractedAnchorValues = extractedAudioBSLAttributes
+    .filter(Boolean)
+    .map(id => `${document.URL}#${id}`);
   const csvAsSingleColumn =
-    extractedHeadingIdValues.join('\n') + extractedAudioBSLAnchor;
+    extractedHeadingIdValues.join('\n') + extractedAnchorValues.join('\n');
   // Push the list of urls to the clipboard
   if (navigator && navigator.clipboard && navigator.clipboard.writeText)
     return navigator.clipboard.writeText(csvAsSingleColumn).then(() => {

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -296,7 +296,7 @@ const Stops: FC<StopsProps> = ({ stops, type }) => {
         return hasContentOfDesiredType ? (
           <Stop
             key={index}
-            id={'apiToolbar'}
+            id="apiToolbar"
             data-toolbar={dasherizeShorten(title)}
           >
             {type === 'audio-with-descriptions' &&

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -297,7 +297,7 @@ const Stops: FC<StopsProps> = ({ stops, type }) => {
           <Stop
             key={index}
             id="apiToolbar"
-            data-toolbar={dasherizeShorten(title)}
+            data-toolbar-anchor={dasherizeShorten(title)}
           >
             {type === 'audio-with-descriptions' &&
               audioWithDescription?.url && (

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -294,7 +294,11 @@ const Stops: FC<StopsProps> = ({ stops, type }) => {
             audioWithoutDescription?.url) ||
           (type === 'bsl' && bsl?.embedUrl);
         return hasContentOfDesiredType ? (
-          <Stop key={index} id={dasherizeShorten(title)}>
+          <Stop
+            key={index}
+            id={'apiToolbar'}
+            data-toolbar={dasherizeShorten(title)}
+          >
             {type === 'audio-with-descriptions' &&
               audioWithDescription?.url && (
                 <AudioPlayer


### PR DESCRIPTION
## Who is this for?

Anyone using the API Toolbar to extract anchor links for audio and BSL guides

## What is it doing for them?

We previously only selected ids from H2, H3 and H4. Audio and BSL guide ids are contained within divs. ~This change extracts ids from divs that have a class that contains 'exhibition', this is to ensure we grab the divs that are within an Exhibition Guide page. It will return the div ids for audio and BSL guides and create the links and push them to the clipboard.~

This change will grab the apiToolbar id and extract the data-toolbar value and create an anchor link and push them to to the clipboard.