### PR TITLE
Remove a bunch of utility classes that we aren't using

### DIFF
--- a/common/views/themes/mixins.ts
+++ b/common/views/themes/mixins.ts
@@ -30,17 +30,6 @@ export const visuallyHidden = `
   white-space: nowrap;
 `;
 
-export const clearfix = `
-  &:before,
-  &:after {
-    content: '';
-    display: table;
-  }
-
-  &:after {
-    clear: both;
-}`;
-
 export function gridCells(columns: number, key: ColumnKey): string {
   return [...Array(columns).keys()]
     .map(c => {

--- a/common/views/themes/utility-classes.ts
+++ b/common/views/themes/utility-classes.ts
@@ -1,7 +1,7 @@
 import { themeValues } from './config';
 import { css } from 'styled-components';
 import { GlobalStyleProps } from './default';
-import { respondTo, respondBetween, visuallyHidden, clearfix } from './mixins';
+import { respondTo, respondBetween, visuallyHidden } from './mixins';
 
 export const utilityClasses = css<GlobalStyleProps>`
   ${Object.entries(themeValues.colors)
@@ -19,10 +19,6 @@ export const utilityClasses = css<GlobalStyleProps>`
 
   .transition-bg {
     transition: background ${themeValues.transitionProperties};
-  }
-
-  .caps {
-    text-transform: uppercase;
   }
 
   .is-hidden {
@@ -89,15 +85,6 @@ export const utilityClasses = css<GlobalStyleProps>`
     display: flex;
   }
 
-  .flex-l-up {
-    ${respondTo(
-      'large',
-      `
-    display: flex;
-  `
-    )}
-  }
-
   .flex--column {
     flex-direction: column;
   }
@@ -144,14 +131,6 @@ export const utilityClasses = css<GlobalStyleProps>`
 
   .pointer {
     cursor: pointer;
-  }
-
-  .pointer-events-none {
-    pointer-events: none;
-  }
-
-  .pointer-events-all {
-    pointer-events: all;
   }
 
   .plain-button {
@@ -232,83 +211,9 @@ export const utilityClasses = css<GlobalStyleProps>`
     float: left;
   }
 
-  .rotate-r-8 {
-    transform: rotate(8deg);
-  }
-
   .h-center {
     margin-left: auto;
     margin-right: auto;
-  }
-
-  .text--truncate {
-    max-height: 80px;
-    overflow: hidden;
-
-    &:after {
-      position: absolute;
-      top: 45px;
-      content: '';
-      display: block;
-      width: 100%;
-      height: 35px;
-      background: linear-gradient(
-        rgba(255, 255, 255, 0.001),
-        ${themeValues.color('white')}
-      ); // Safari doesn't like transparent (shows as grey), so giving a value very close to transparent.
-    }
-  }
-
-  .flush-container-left {
-    position: absolute;
-    left: ${themeValues.containerPadding.small}px;
-
-    ${respondTo(
-      'medium',
-      `
-    left: ${themeValues.containerPadding.medium}px;
-  `
-    )}
-
-    ${respondTo(
-      'large',
-      `
-    left: ${themeValues.containerPadding.large}px;
-  `
-    )}
-
-  ${respondTo(
-      'xlarge',
-      `
-    left: calc(((100vw - ${themeValues.sizes.xlarge}px) / 2) + ${themeValues.containerPadding.xlarge}px)
-  `
-    )}
-  }
-
-  .flush-container-right {
-    position: absolute;
-    right: ${themeValues.containerPadding.small}px;
-
-    ${respondTo(
-      'medium',
-      `
-    right: ${themeValues.containerPadding.medium}px;
-  `
-    )}
-
-    ${respondTo(
-      'large',
-      `
-    right: ${themeValues.containerPadding.large}px;
-  `
-    )}
-
-  ${respondTo(
-      'xlarge',
-      `
-    right: calc(((100vw - ${themeValues.sizes.xlarge}px) / 2) + ${themeValues.containerPadding.xlarge}px)
-  `
-    )}
   }
 
   .no-margin {
@@ -377,15 +282,6 @@ export const utilityClasses = css<GlobalStyleProps>`
     )}
   }
 
-  .margin-h-auto {
-    margin-left: auto;
-    margin-right: auto;
-  }
-
-  .margin-top-auto {
-    margin-top: auto;
-  }
-
   .promo-link {
     height: 100%;
     color: ${themeValues.color('black')};
@@ -439,22 +335,6 @@ export const utilityClasses = css<GlobalStyleProps>`
     height: 100%;
   }
 
-  .full-max-width {
-    max-width: 100%;
-  }
-
-  // Images
-  .width-inherit {
-    width: inherit;
-  }
-
-  .image-max-height-restricted {
-    max-height: 90vh;
-    max-width: 100%;
-    width: auto;
-    margin: 0 auto;
-  }
-
   // For when we get HTML out of systems like Prismic
   .first-para-no-margin p:first-of-type {
     margin: 0;
@@ -478,34 +358,12 @@ export const utilityClasses = css<GlobalStyleProps>`
     }
   }
 
-  .opacity-0 {
-    opacity: 0;
-  }
-
   .hidden {
     visibility: hidden;
   }
 
   .overflow-hidden {
     overflow: hidden;
-  }
-
-  .cursor-zoom-in {
-    cursor: zoom-in;
-  }
-
-  // Used mainly for images
-  .max-height-70vh {
-    max-height: 70vh;
-  }
-
-  .width-auto {
-    width: auto;
-    max-width: 100%;
-  }
-
-  .clearfix {
-    ${clearfix}
   }
 
   // TODO: use this for e.g. Promo hover behaviour too


### PR DESCRIPTION
## Who is this for?

Devs.

## What is it doing for them?

Keeping the codebase clean by removing some unused classes. I searched the codebase for all these classes; if they weren't used I removed them. Most of them are pretty simple and would fall under the axe of #8420 anyway.

(I’m trying to work out how something works on the Stories homepage, so I’ve been reading the rendered CSS. I spotted some unused classes as part of that. :D)