### PR TITLE
Bump the timeout on the CloudFront monitoring Lambda

### DIFF
--- a/cache/send_slack_alert_for_5xx_errors.tf
+++ b/cache/send_slack_alert_for_5xx_errors.tf
@@ -16,7 +16,9 @@ module "slack_alerts_for_5xx" {
   # but I don't see it defined there.  Is this topic defined in Terraform?
   alarm_topic_arn = "arn:aws:sns:us-east-1:130871440101:experience_lambda_error_alarm"
 
-  timeout = 30
+  # Note: we used to specify a 30 second timeout here, but occasionally
+  # the Lambda would error if there were lots of log events.
+  timeout = 300
 }
 
 resource "aws_lambda_permission" "allow_lambda" {


### PR DESCRIPTION
## Who is this for?

Anyone in the alerts channel.

## What is it doing for them?

Avoiding Lambda errors when there are too many CloudFront events to process in 30 seconds.

(Maybe? Guessing, but this can't hurt.)