### PR TITLE
When a catalogue API query fails, log the URL also

### DIFF
--- a/catalogue/webapp/pages/works.tsx
+++ b/catalogue/webapp/pages/works.tsx
@@ -288,9 +288,6 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     });
 
     if (works.type === 'Error') {
-      console.warn(
-        `Forwarding error from the works API: ${JSON.stringify(works)}`
-      );
       return appError(
         context,
         works.httpStatus,

--- a/catalogue/webapp/services/catalogue/index.ts
+++ b/catalogue/webapp/services/catalogue/index.ts
@@ -95,11 +95,19 @@ export async function catalogueQuery<Params, Result extends ResultType>(
     const res = await catalogueFetch(url);
     const json = await res.json();
 
+    if (json.type === 'Error') {
+      console.warn(
+        `Received error from catalogue API query ${url}: ` +
+          JSON.stringify(json)
+      );
+    }
+
     return {
       ...json,
       _requestUrl: url,
     };
   } catch (error) {
+    console.error(`Unable to fetch catalogue API URL ${url}`, error);
     return catalogueApiError();
   }
 }


### PR DESCRIPTION
To aid in future debugging. Unlike the previous patch, this will work for works as well as images.