### PR TITLE
Reduce some repetition in the prismic-model scripts

### DIFF
--- a/prismic-model/downloadSnapshot.ts
+++ b/prismic-model/downloadSnapshot.ts
@@ -25,6 +25,20 @@ async function getPrismicApiRefById(id: string): Promise<string> {
   return json.refs.find(r => r.id === id).ref;
 }
 
+/** Returns a list of all the Prismic documents in a given snapshot directory. */
+export function getPrismicDocuments(snapshotDir: string): any[] {
+  const documents: any[] = [];
+
+  fs.readdirSync(snapshotDir).forEach(file => {
+    const data = fs.readFileSync(`${snapshotDir}/${file}`);
+    const json: { results: any[] } = JSON.parse(data.toString());
+
+    documents.push(...json.results);
+  });
+
+  return documents;
+}
+
 type ApiResponse = {
   pageNumber: number;
   json: any;

--- a/prismic-model/lintPrismicData.ts
+++ b/prismic-model/lintPrismicData.ts
@@ -7,24 +7,12 @@
  * See https://prismic.io/blog/required-fields
  */
 
-import fs from 'fs';
 import chalk from 'chalk';
 import { error } from './console';
-import { downloadPrismicSnapshot } from './downloadSnapshot';
-
-/** Returns a list of all the Prismic documents in a given snapshot directory. */
-function getPrismicDocuments(snapshotDir: string): any[] {
-  const documents: any[] = [];
-
-  fs.readdirSync(snapshotDir).forEach(file => {
-    const data = fs.readFileSync(`${snapshotDir}/${file}`);
-    const json: { results: any[] } = JSON.parse(data.toString());
-
-    documents.push(...json.results);
-  });
-
-  return documents;
-}
+import {
+  downloadPrismicSnapshot,
+  getPrismicDocuments,
+} from './downloadSnapshot';
 
 // Look for eur01 safelinks.  These occur when somebody has copied
 // a URL directly from Outlook and isn't using the original URL.

--- a/prismic-model/tryAllContentPages.ts
+++ b/prismic-model/tryAllContentPages.ts
@@ -9,8 +9,10 @@
  */
 
 import { error } from './console';
-import { downloadPrismicSnapshot } from './downloadSnapshot';
-import fs from 'fs';
+import {
+  downloadPrismicSnapshot,
+  getPrismicDocuments,
+} from './downloadSnapshot';
 import fetch from 'node-fetch';
 import tqdm from 'tqdm';
 
@@ -18,20 +20,6 @@ type PrismicDocument = {
   id: string;
   type: string;
 };
-
-/** Returns a list of all the Prismic documents in a given snapshot directory. */
-function getPrismicDocuments(snapshotDir: string): PrismicDocument[] {
-  const documents: PrismicDocument[] = [];
-
-  fs.readdirSync(snapshotDir).forEach(file => {
-    const data = fs.readFileSync(`${snapshotDir}/${file}`);
-    const json: { results: PrismicDocument[] } = JSON.parse(data.toString());
-
-    documents.push(...json.results);
-  });
-
-  return documents;
-}
 
 // Prismic content types that have documents, but are only visible when they're linked
 // from other types -- they aren't individually addressable.


### PR DESCRIPTION
## Who is this for?

Devs.

## What is it doing for them?

Making this code easier to manage, and faster. Now `sliceAnalysis` will download a snapshot from Prismic once, then future analysis is on the locally cached copy until something changes in Prismic.