### PR TITLE
Defer creating the 'Request item' button/modal until we know we'll need it

### DIFF
--- a/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
+++ b/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
@@ -66,7 +66,6 @@ export type Props = {
   work: Work;
   accessDataIsStale: boolean;
   userHeldItems?: Set<string>;
-  encoreLink?: string;
   isLast: boolean;
 };
 

--- a/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
+++ b/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
@@ -146,23 +146,6 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
   const shelfmark = locationShelfmark || '';
 
   function createRows() {
-    const requestButton = (
-      <ButtonSolid
-        colors={themeValues.buttonColors.greenTransparentGreen}
-        disabled={userState !== 'signedin'}
-        ref={requestButtonRef}
-        text={'Request item'}
-        clickHandler={() => {
-          trackEvent({
-            category: 'requesting',
-            action: 'initiate_request',
-            label: `/works/${work.id}`,
-          });
-          setRequestModalIsActive(true);
-        }}
-      />
-    );
-
     const headingRow = [
       'Location',
       showAccessStatus ? 'Status' : ' ',
@@ -199,6 +182,23 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
     }
 
     if (showButton) {
+      const requestButton = (
+        <ButtonSolid
+          colors={themeValues.buttonColors.greenTransparentGreen}
+          disabled={userState !== 'signedin'}
+          ref={requestButtonRef}
+          text={'Request item'}
+          clickHandler={() => {
+            trackEvent({
+              category: 'requesting',
+              action: 'initiate_request',
+              label: `/works/${work.id}`,
+            });
+            setRequestModalIsActive(true);
+          }}
+        />
+      );
+
       dataRow.push(
         <ButtonWrapper styleChangeWidth={isArchive ? 980 : 620}>
           {requestButton}
@@ -213,15 +213,24 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
 
   return (
     <>
-      <ItemRequestModal
-        isActive={requestModalIsActive}
-        setIsActive={setRequestModalIsActive}
-        item={item}
-        work={work}
-        initialHoldNumber={userHeldItems?.size}
-        onSuccess={() => item.id && completedItemRequests.push(item.id)}
-        openButtonRef={requestButtonRef}
-      />
+      {/*
+        There are pages with hundreds of items, e.g. https://wellcomecollection.org/works/h4t88h83
+
+        There's a notable lag when we create instances of ItemRequestModal for
+        all these items, so if we're never going to show the button, don't bother
+        creating them.  This makes the page much snappier.
+       */}
+      {showButton && (
+        <ItemRequestModal
+          isActive={requestModalIsActive}
+          setIsActive={setRequestModalIsActive}
+          item={item}
+          work={work}
+          initialHoldNumber={userHeldItems?.size}
+          onSuccess={() => item.id && completedItemRequests.push(item.id)}
+          openButtonRef={requestButtonRef}
+        />
+      )}
       <Wrapper underline={!isLast}>
         {(title || itemNote) && (
           <Space v={{ size: 'm', properties: ['margin-bottom'] }}>


### PR DESCRIPTION
Running locally on a fairly powerful iMac, this takes the time to expand the list of 235 items in the original ticket from ~45 seconds to less than a second -- because they're all manual requests, so we never need to create this modal component.

It'll still be slow if all the items are orderable online.  Fixing that feels like it needs a more substantial refactor, possibly to only create a single instance of that component.

For https://github.com/wellcomecollection/wellcomecollection.org/issues/8539

## Who is this for?

Users.

## What is it doing for them?

Making items load faster.