### PR TITLE
Change title font to Inter

### DIFF
--- a/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
+++ b/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
@@ -72,7 +72,7 @@ const ContextContainer = styled(Space).attrs<{ hasPadding: boolean }>(
 
 const TombstoneTitle = styled(Space).attrs<{ level: number }>(props => ({
   as: `h${props.level}`,
-  className: font('wb', 3),
+  className: font('intb', 3),
   v: { size: 's', properties: ['margin-bottom'] },
 }))<{ level: number }>``;
 
@@ -288,11 +288,7 @@ const Stop: FC<{
                   {image?.contentUrl && (
                     <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
                       <PrismicImageWrapper>
-                        <PrismicImage
-                          image={image}
-                          sizes={{}}
-                          quality="low"
-                        />
+                        <PrismicImage image={image} sizes={{}} quality="low" />
                       </PrismicImageWrapper>
                     </Space>
                   )}


### PR DESCRIPTION
Fixes #8482 

As discussed in the issue, this changes the font used for the Tombstone title to Inter, which has support for more glyphs

Before:
![Screenshot 2022-09-26 at 15 57 07](https://user-images.githubusercontent.com/6051896/192310693-8fb50d65-969a-46ea-a088-f56228eb6d7e.png)

After:

![Screenshot 2022-09-26 at 16 01 10](https://user-images.githubusercontent.com/6051896/192311715-dce5f4c8-eb10-417a-82b4-43ef03921d48.png)


