### PR TITLE
Revert to using color instead of newColor

### DIFF
--- a/cardigan/.storybook/preview.js
+++ b/cardigan/.storybook/preview.js
@@ -23,7 +23,7 @@ export const decorators = [
   },
 ];
 
-const themeColors = Object.entries(theme.newColors).map(([key, value]) => ({
+const themeColors = Object.entries(theme.colors).map(([key, value]) => ({
   name: key,
   value: value.base,
 }));

--- a/cardigan/stories/global/palette/palette.stories.tsx
+++ b/cardigan/stories/global/palette/palette.stories.tsx
@@ -50,7 +50,7 @@ const PaletteColor = styled.div<{ hasBorder: boolean }>`
   margin-right: 15px;
   border: 1px solid
     ${props =>
-      props.hasBorder ? props.theme.newColor('neutral.500') : 'transparent'};
+      props.hasBorder ? props.theme.color('neutral.500') : 'transparent'};
 
   &:before {
     content: '';
@@ -149,7 +149,7 @@ let objectColors: ColorsObject = {
   },
 };
 
-Object.entries(themeValues.newColors)
+Object.entries(themeValues.colors)
   .map(([key, value]) => {
     if (!key.includes('.')) {
       const rgb = hexToRgb(value);

--- a/cardigan/stories/global/spacing/spacing.stories.tsx
+++ b/cardigan/stories/global/spacing/spacing.stories.tsx
@@ -5,7 +5,7 @@ import SpacingSection from '@weco/common/views/components/SpacingSection/Spacing
 import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
 
 const ColorSection = styled.div<{ bgColor: string }>`
-  background-color: ${props => props.theme.newColor(props.bgColor)};
+  background-color: ${props => props.theme.color(props.bgColor)};
 `;
 
 export const Spacing: FunctionComponent = () => {

--- a/cardigan/stories/global/typography/typography.stories.tsx
+++ b/cardigan/stories/global/typography/typography.stories.tsx
@@ -6,13 +6,13 @@ import MoreLink from '@weco/common/views/components/MoreLink/MoreLink';
 
 const Font = styled.div`
   padding: 10px 0 25px;
-  border-bottom: 1px solid ${props => props.theme.newColor('neutral.500')};
+  border-bottom: 1px solid ${props => props.theme.color('neutral.500')};
 `;
 
 const FontName = styled.h2.attrs({
   className: font('intb', 6),
 })`
-  color: ${props => props.theme.newColor('accent.purple')};
+  color: ${props => props.theme.color('accent.purple')};
 `;
 
 const TypographyScale = ({ fontFamily }) => {

--- a/catalogue/webapp/components/ArchiveTree/ArchiveTree.tsx
+++ b/catalogue/webapp/components/ArchiveTree/ArchiveTree.tsx
@@ -23,7 +23,7 @@ import { chevron, tree } from '@weco/common/icons';
 import { trackEvent } from '@weco/common/utils/ga';
 
 const TreeContainer = styled.div`
-  border-right: 1px solid ${props => props.theme.newColor('warmNeutral.400')};
+  border-right: 1px solid ${props => props.theme.color('warmNeutral.400')};
 `;
 
 const instructions =
@@ -56,7 +56,7 @@ const Tree = styled.div<{ isEnhanced?: boolean }>`
       content: ${props => (props.isEnhanced ? `'${instructions}'` : null)};
       z-index: 2;
       top: 0;
-      background: ${props => props.theme.newColor('yellow')};
+      background: ${props => props.theme.color('yellow')};
       padding: ${props => `${props.theme.spacingUnit * 2}px`};
       margin: ${props => `${props.theme.spacingUnit}px`};
       border-radius: ${props => `${props.theme.borderRadiusUnit}px`};
@@ -90,7 +90,7 @@ const TreeItem = styled.li.attrs<TreeItemProps>(props => ({
   padding: 0;
   &:focus {
     outline: ${props =>
-      !props.hideFocus ? `2px solid ${props.theme.newColor('black')}` : 'none'};
+      !props.hideFocus ? `2px solid ${props.theme.color('black')}` : 'none'};
   }
 
   &.guideline::before,
@@ -101,7 +101,7 @@ const TreeItem = styled.li.attrs<TreeItemProps>(props => ({
   }
 
   &.guideline::before {
-    border-left: 1px solid ${props => props.theme.newColor('yellow')};
+    border-left: 1px solid ${props => props.theme.color('yellow')};
     width: 0;
     top: ${`${verticalGuidePosition}px`};
     left: ${`${controlWidth / 2}px`};
@@ -113,7 +113,7 @@ const TreeItem = styled.li.attrs<TreeItemProps>(props => ({
     width: 6px;
     height: 6px;
     border-radius: 50%;
-    background: ${props => props.theme.newColor('yellow')};
+    background: ${props => props.theme.color('yellow')};
     left: ${`${controlWidth / 2 - 3}px`};
     bottom: ${`${controlHeight / 2}px`};
   }
@@ -136,7 +136,7 @@ const TreeControl = styled.span<{ highlightCondition?: string }>`
     top: ${`${(controlHeight - circleHeight) / 2}px`};
     left: ${`${(controlWidth - circleWidth) / 2}px`};
     background: ${props =>
-      props.theme.newColor(
+      props.theme.color(
         props.highlightCondition === 'primary'
           ? 'yellow'
           : props.highlightCondition === 'secondary'
@@ -145,8 +145,8 @@ const TreeControl = styled.span<{ highlightCondition?: string }>`
       )};
     border: ${props =>
       props.highlightCondition === 'secondary'
-        ? `1px solid ${props.theme.newColor('yellow')}`
-        : `2px solid ${props.theme.newColor('white')}`};
+        ? `1px solid ${props.theme.color('yellow')}`
+        : `2px solid ${props.theme.color('white')}`};
     border-radius: 50%;
   }
   .icon {
@@ -168,9 +168,9 @@ const StyledLink = styled.a<StyledLinkProps>`
   display: inline-block;
   min-height: ${`${controlHeight}px`};
   line-height: 1;
-  color: ${props => props.theme.newColor('black')};
+  color: ${props => props.theme.color('black')};
   background: ${props =>
-    props.isCurrent ? props.theme.newColor('yellow') : 'transparent'};
+    props.isCurrent ? props.theme.color('yellow') : 'transparent'};
   cursor: pointer;
   margin-left: ${props =>
     props.hasControl ? `-${controlWidth / 2}px` : `${controlWidth / 2}px`};
@@ -198,7 +198,7 @@ const RefNumber = styled.span.attrs({
 })`
   line-height: 1;
   display: block;
-  color: ${props => props.theme.newColor('neutral.600')};
+  color: ${props => props.theme.color('neutral.600')};
   text-decoration: none;
 `;
 

--- a/catalogue/webapp/components/Calendar/CalendarStyles.tsx
+++ b/catalogue/webapp/components/Calendar/CalendarStyles.tsx
@@ -8,7 +8,7 @@ export const DatePicker = styled.div`
     border-style: none;
     background: transparent;
     cursor: pointer;
-    border: 1px solid ${props => props.theme.newColor('neutral.500')};
+    border: 1px solid ${props => props.theme.color('neutral.500')};
     :disabled {
       cursor: default;
     }
@@ -16,9 +16,9 @@ export const DatePicker = styled.div`
 `;
 
 export const Header = styled.div`
-  background-color: ${props => props.theme.newColor('white')};
+  background-color: ${props => props.theme.color('white')};
   display: flex;
-  color: ${props => props.theme.newColor('neutral.600')};
+  color: ${props => props.theme.color('neutral.600')};
 
   div {
     margin-left: auto;
@@ -28,14 +28,14 @@ export const Header = styled.div`
 export const Message = styled.p.attrs(() => ({
   className: font('intr', 6),
 }))`
-  background: ${props => props.theme.newColor('yellow')};
+  background: ${props => props.theme.color('yellow')};
   padding: ${props => `${props.theme.spacingUnit * 2}px`};
   margin: ${props => `${props.theme.spacingUnit}px`};
   border-radius: ${props => `${props.theme.borderRadiusUnit}px`};
 `;
 
 export const Table = styled.table`
-  color: ${props => props.theme.newColor('neutral.600')};
+  color: ${props => props.theme.color('neutral.600')};
 
   th,
   td {
@@ -58,20 +58,20 @@ export const Td = styled.td<TdProps>`
 
   &[aria-disabled='true'] {
     cursor: default;
-    color: ${props => props.theme.newColor('neutral.400')};
+    color: ${props => props.theme.color('neutral.400')};
   }
 
   &[tabindex='0']:focus {
-    background: ${props => props.theme.newColor('accent.green')};
-    color: ${props => props.theme.newColor('white')};
+    background: ${props => props.theme.color('accent.green')};
+    color: ${props => props.theme.color('white')};
     outline: 0;
     box-shadow: ${props =>
       props.isKeyboard ? props.theme.focusBoxShadow : 'none'};
   }
 
   &[aria-selected='true'] {
-    background: ${props => props.theme.newColor('yellow')};
-    color: ${props => props.theme.newColor('black')};
+    background: ${props => props.theme.color('yellow')};
+    color: ${props => props.theme.color('black')};
   }
 `;
 
@@ -88,5 +88,5 @@ export const CalendarButton = styled.button`
   line-height: 2em;
   border-radius: 50%;
   margin-left: 0.5em;
-  background: ${props => props.theme.newColor('neutral.500')};
+  background: ${props => props.theme.color('neutral.500')};
 `;

--- a/catalogue/webapp/components/Download/Download.tsx
+++ b/catalogue/webapp/components/Download/Download.tsx
@@ -16,7 +16,7 @@ export const DownloadOptions = styled.div.attrs(() => ({
   className: font('intb', 4),
 }))`
   white-space: normal;
-  color: ${props => props.theme.newColor('black')};
+  color: ${props => props.theme.color('black')};
 
   li + li {
     margin-top: ${props => `${props.theme.spacingUnit * 2}px`};

--- a/catalogue/webapp/components/DownloadLink/DownloadLink.tsx
+++ b/catalogue/webapp/components/DownloadLink/DownloadLink.tsx
@@ -12,8 +12,8 @@ const DownloadLinkStyle = styled.a.attrs({
 })`
   display: inline-block;
   white-space: nowrap;
-  background: ${props => props.theme.newColor('white')};
-  color: ${props => props.theme.newColor('accent.green')};
+  background: ${props => props.theme.color('white')};
+  color: ${props => props.theme.color('accent.green')};
   text-decoration: none;
   .icon__shape {
     fill: currentColor;

--- a/catalogue/webapp/components/IIIFImage/IIIFImage.tsx
+++ b/catalogue/webapp/components/IIIFImage/IIIFImage.tsx
@@ -16,7 +16,7 @@ import {
 const StyledImage = styled(Image).attrs({ className: 'font-neutral-700' })<{
   background: string;
 }>`
-  background-color: ${props => props.theme.newColor(props.background)};
+  background-color: ${props => props.theme.color(props.background)};
 `;
 
 const IIIFLoader = ({ src, width }: ImageLoaderProps) => {

--- a/catalogue/webapp/components/IIIFSearchWithin/IIIFSearchWithin.tsx
+++ b/catalogue/webapp/components/IIIFSearchWithin/IIIFSearchWithin.tsx
@@ -43,13 +43,13 @@ const ResultsHeader = styled(Space).attrs({
   as: 'h3',
   v: { size: 'm', properties: ['margin-top'] },
 })`
-  border-bottom: 1px solid ${props => props.theme.newColor('neutral.500')};
+  border-bottom: 1px solid ${props => props.theme.color('neutral.500')};
   padding-bottom: ${props => `${props.theme.spacingUnit}px`};
 `;
 
 const ListItem = styled.li`
   list-style: none;
-  border-bottom: 1px solid ${props => props.theme.newColor('neutral.500')};
+  border-bottom: 1px solid ${props => props.theme.color('neutral.500')};
 `;
 
 const SearchResult = styled.button.attrs({
@@ -58,10 +58,10 @@ const SearchResult = styled.button.attrs({
   cursor: pointer;
   display: block;
   padding: ${props => `${props.theme.spacingUnit * 2}px 0`};
-  color: ${props => props.theme.newColor('white')};
+  color: ${props => props.theme.color('white')};
   background: transparent;
   &:hover {
-    background: ${props => props.theme.newColor('black')};
+    background: ${props => props.theme.color('black')};
   }
 `;
 
@@ -70,7 +70,7 @@ const HitData = styled(Space).attrs({
   className: font('intb', 6),
 })`
   display: block;
-  background: ${props => props.theme.newColor('neutral.700')};
+  background: ${props => props.theme.color('neutral.700')};
   padding: ${props => `0 ${props.theme.spacingUnit}px`};
 `;
 

--- a/catalogue/webapp/components/IIIFViewer/GridViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/GridViewer.tsx
@@ -125,7 +125,7 @@ const GridViewerEl = styled.div<GridViewerElProps>`
   left: 0;
   bottom: 0;
   z-index: 1;
-  background: ${props => props.theme.newColor('black')};
+  background: ${props => props.theme.color('black')};
   transition: top 500ms ease;
 `;
 

--- a/catalogue/webapp/components/IIIFViewer/IIIFCanvasThumbnail.tsx
+++ b/catalogue/webapp/components/IIIFViewer/IIIFCanvasThumbnail.tsx
@@ -28,12 +28,12 @@ const IIIFViewerThumb = styled.button.attrs<ViewerThumbProps>(props => ({
   max-width: 90%;
   border-radius: 8px;
   background: ${props =>
-    props.theme.newColor(props.isActive ? 'neutral.700' : 'black')};
+    props.theme.color(props.isActive ? 'neutral.700' : 'black')};
   padding: 12px 16px;
   text-align: center;
   margin: auto;
   &:focus {
-    outline: ${props => `1px solid ${props.theme.newColor('yellow')}`};
+    outline: ${props => `1px solid ${props.theme.color('yellow')}`};
   }
 `;
 
@@ -72,7 +72,7 @@ const IIIFViewerThumbNumber = styled.span.attrs<ViewerThumbProps>(props => ({
   line-height: 1;
 
   ${props =>
-    !!props.isActive && `background-color: ${props.theme.newColor('yellow')};`}
+    !!props.isActive && `background-color: ${props.theme.color('yellow')};`}
 `;
 
 type IIIFCanvasThumbnailProps = {

--- a/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
@@ -118,11 +118,11 @@ const Sidebar = styled.div<{
 
   ${props => props.theme.media.medium`
     grid-area: desktop-main-start / left-edge / bottom-edge / desktop-sidebar-end;
-    border-right: 1px solid ${props.theme.newColor('black')};
+    border-right: 1px solid ${props.theme.color('black')};
   `}
 
-  background: ${props => props.theme.newColor('neutral.700')};
-  color: ${props => props.theme.newColor('white')};
+  background: ${props => props.theme.color('neutral.700')};
+  color: ${props => props.theme.color('white')};
   overflow: auto;
   z-index: 5;
 `;
@@ -130,7 +130,7 @@ const Sidebar = styled.div<{
 const Topbar = styled.div<{
   isDesktopSidebarActive: boolean;
 }>`
-  background: ${props => props.theme.newColor('neutral.700')};
+  background: ${props => props.theme.color('neutral.700')};
   grid-area: top-edge / left-edge / desktop-topbar-end / right-edge;
   z-index: 4; // TODO: this is to let downloads sit above sidebar on desktop but not have the topbar above the sidebar on mobile. If we move the downloads, this can be simplified
 
@@ -143,8 +143,8 @@ const Main = styled.div<{
   isResizing: boolean;
   isDesktopSidebarActive: boolean;
 }>`
-  background: ${props => props.theme.newColor('black')};
-  color: ${props => props.theme.newColor('white')};
+  background: ${props => props.theme.color('black')};
+  color: ${props => props.theme.color('white')};
   overflow: auto;
   position: relative;
 
@@ -185,7 +185,7 @@ const Thumbnails = styled.div<{
   isActive: boolean;
   isDesktopSidebarActive: boolean;
 }>`
-  background: ${props => props.theme.newColor('neutral.700')};
+  background: ${props => props.theme.color('neutral.700')};
   transform: translateY(${props => (props.isActive ? '0' : '100%')});
   transition: transform 250ms ease;
   z-index: 3;

--- a/catalogue/webapp/components/IIIFViewer/MainViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/MainViewer.tsx
@@ -39,7 +39,7 @@ type SearchTermHighlightProps = {
 };
 
 const SearchTermHighlight = styled.div<SearchTermHighlightProps>`
-  background: ${props => props.theme.newColor('accent.purple')};
+  background: ${props => props.theme.color('accent.purple')};
   opacity: 0.5;
   position: absolute;
   z-index: 1;
@@ -53,7 +53,7 @@ const MessageContainer = styled.div`
   min-width: 360px;
   max-width: 60%;
   margin: 0 auto;
-  border: 1px solid ${props => props.theme.newColor('neutral.600')};
+  border: 1px solid ${props => props.theme.color('neutral.600')};
   height: 80%;
   margin-top: 50%;
   transform: translateY(-50%);

--- a/catalogue/webapp/components/IIIFViewer/NoScriptViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/NoScriptViewer.tsx
@@ -22,12 +22,12 @@ const NoScriptViewerEl = styled.div`
   display: flex;
   flex-direction: row-reverse;
   height: calc(100vh - ${props => props.theme.navHeight}px);
-  background-color: ${props => props.theme.newColor('neutral.700')};
+  background-color: ${props => props.theme.color('neutral.700')};
 `;
 
 const NoScriptViewerMain = styled.div`
   position: relative;
-  color: ${props => props.theme.newColor('white')};
+  color: ${props => props.theme.color('white')};
   height: 100%;
   width: 75%;
 `;
@@ -58,7 +58,7 @@ const StaticThumbnailsContainer = styled.div`
   height: 100%;
   width: 25%;
   border-top: none;
-  border-right: 1px solid ${props => props.theme.newColor('neutral.600')};
+  border-right: 1px solid ${props => props.theme.color('neutral.600')};
 `;
 
 const ThumbnailLink = styled.a`

--- a/catalogue/webapp/components/IIIFViewer/Padlock.tsx
+++ b/catalogue/webapp/components/IIIFViewer/Padlock.tsx
@@ -24,7 +24,7 @@ const StyledPadlock = styled.div`
   &::after,
   > div::before,
   > div::after {
-    background-color: ${props => props.theme.newColor('black')};
+    background-color: ${props => props.theme.color('black')};
   }
 
   /* top bar */
@@ -33,7 +33,7 @@ const StyledPadlock = styled.div`
     height: 70%;
     left: 20%;
     border-radius: 40%;
-    background-color: ${props => props.theme.newColor('warmNeutral.400')};
+    background-color: ${props => props.theme.color('warmNeutral.400')};
   }
 
   &::after {
@@ -50,7 +50,7 @@ const StyledPadlock = styled.div`
     height: 62%;
     left: 10%;
     bottom: 0;
-    background-color: ${props => props.theme.newColor('yellow')};
+    background-color: ${props => props.theme.color('yellow')};
     border-radius: 15%;
     z-index: 1;
 

--- a/catalogue/webapp/components/IIIFViewer/ViewerBottomBar.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerBottomBar.tsx
@@ -13,8 +13,8 @@ import { expand, gridView, singlePage } from '@weco/common/icons';
 const BottomBar = styled.div`
   position: relative;
   z-index: 3;
-  background: ${props => props.theme.newColor('neutral.700')};
-  color: ${props => props.theme.newColor('white')};
+  background: ${props => props.theme.color('neutral.700')};
+  color: ${props => props.theme.color('white')};
   display: flex;
   justify-content: space-between;
 `;

--- a/catalogue/webapp/components/IIIFViewer/ViewerSidebar.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerSidebar.tsx
@@ -72,10 +72,10 @@ const AccordionInner = styled(Space).attrs({
 `;
 
 const Item = styled.div`
-  border-bottom: 1px solid ${props => props.theme.newColor('neutral.600')};
+  border-bottom: 1px solid ${props => props.theme.color('neutral.600')};
 
   &:first-child {
-    border-top: 1px solid ${props => props.theme.newColor('neutral.600')};
+    border-top: 1px solid ${props => props.theme.color('neutral.600')};
   }
 `;
 

--- a/catalogue/webapp/components/IIIFViewer/ViewerStructures.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerStructures.tsx
@@ -22,7 +22,7 @@ const ViewerStructuresPrototype: FunctionComponent<Props> = ({
     list-style: none;
     margin: 0 !important;
     padding: 0;
-    border-left: 1px solid ${props => props.theme.newColor('neutral.600')};
+    border-left: 1px solid ${props => props.theme.color('neutral.600')};
   `;
 
   const Item = styled(Space).attrs({
@@ -45,7 +45,7 @@ const ViewerStructuresPrototype: FunctionComponent<Props> = ({
           left: -1px;
           bottom: 0;
           width: 4px;
-          background: ${props.theme.newColor('yellow')};
+          background: ${props.theme.color('yellow')};
         }
       `}
 

--- a/catalogue/webapp/components/IIIFViewer/ViewerTopBar.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerTopBar.tsx
@@ -40,8 +40,8 @@ export const ShameButton = styled.button.attrs(() => ({
 
   &[disabled],
   &.disabled {
-    background: ${props => props.theme.newColor('neutral.600')};
-    border-color: ${props => props.theme.newColor('neutral.600')};
+    background: ${props => props.theme.color('neutral.600')};
+    border-color: ${props => props.theme.color('neutral.600')};
     cursor: not-allowed;
   }
 
@@ -70,7 +70,7 @@ export const ShameButton = styled.button.attrs(() => ({
     props.isDark &&
     `
     border: 2px solid transparent;
-    color: ${props.theme.newColor('white')};
+    color: ${props.theme.color('white')};
     background: transparent;
     outline: none;
     transition: all ${props.theme.transitionProperties};
@@ -84,21 +84,21 @@ export const ShameButton = styled.button.attrs(() => ({
     }
 
     &:not([disabled]):hover {
-      border: 2px solid ${props.theme.newColor('white')};
+      border: 2px solid ${props.theme.color('white')};
     }
   `}
 
   ${props =>
     !props.isDark &&
     `
-    background: ${props.theme.newColor('white')};
-    color: ${props.theme.newColor('accent.green')};
-    border: 1px solid ${props.theme.newColor('accent.green')};
+    background: ${props.theme.color('white')};
+    color: ${props.theme.color('accent.green')};
+    border: 1px solid ${props.theme.color('accent.green')};
 
     &:not([disabled]):hover,
     &:not([disabled]):focus {
-      background: ${props.theme.newColor('accent.green')};
-      color: ${props.theme.newColor('white')};
+      background: ${props.theme.color('accent.green')};
+      color: ${props.theme.color('white')};
     }
   `}
 `;
@@ -109,8 +109,8 @@ const TopBar = styled.div<{
 }>`
   position: relative;
   z-index: 3;
-  background: ${props => props.theme.newColor('neutral.700')};
-  color: ${props => props.theme.newColor('white')};
+  background: ${props => props.theme.color('neutral.700')};
+  color: ${props => props.theme.color('white')};
   justify-content: space-between;
   display: ${props => (props.isZooming ? 'none' : 'grid')};
   grid-template-columns: [left-edge] minmax(200px, 3fr) [desktop-sidebar-end main-start desktop-topbar-start] 9fr [right-edge];
@@ -154,7 +154,7 @@ const Sidebar = styled(Space).attrs({
   ${props =>
     !props.isZooming &&
     props.theme.media.medium`
-    border-right: 1px solid ${props => props.theme.newColor('black')};
+    border-right: 1px solid ${props => props.theme.color('black')};
   `}
 `;
 

--- a/catalogue/webapp/components/IIIFViewer/ZoomedImage.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ZoomedImage.tsx
@@ -18,7 +18,7 @@ const ZoomedImageContainer = styled.div`
   z-index: 5;
   width: 100%;
   height: 100%;
-  background: ${props => props.theme.newColor('black')};
+  background: ${props => props.theme.color('black')};
 `;
 
 const Controls = styled.div`

--- a/catalogue/webapp/components/ItemRequestModal/RequestDialog.tsx
+++ b/catalogue/webapp/components/ItemRequestModal/RequestDialog.tsx
@@ -21,8 +21,8 @@ const PickUpDate = styled(Space).attrs({
     properties: ['padding-top', 'padding-bottom'],
   },
 })`
-  border-top: 1px solid ${props => props.theme.newColor('neutral.300')};
-  border-bottom: 1px solid ${props => props.theme.newColor('neutral.300')};
+  border-top: 1px solid ${props => props.theme.color('neutral.300')};
+  border-bottom: 1px solid ${props => props.theme.color('neutral.300')};
 
   @media (min-width: 800px) {
     display: flex;

--- a/catalogue/webapp/components/ItemRequestModal/common.tsx
+++ b/catalogue/webapp/components/ItemRequestModal/common.tsx
@@ -9,7 +9,7 @@ export const CTAs = styled(Space).attrs({
 const CurrentRequestCount = styled(Space).attrs({
   h: { size: 's', properties: ['padding-left', 'margin-left'] },
 })`
-  border-left: 5px solid ${props => props.theme.newColor('yellow')};
+  border-left: 5px solid ${props => props.theme.color('yellow')};
 `;
 
 export const CurrentRequests: FC<{

--- a/catalogue/webapp/components/LibraryMembersBar/LibraryMembersBar.tsx
+++ b/catalogue/webapp/components/LibraryMembersBar/LibraryMembersBar.tsx
@@ -14,7 +14,7 @@ const StyledComponent = styled(Space).attrs({
   h: { size: 'm', properties: ['padding-left', 'padding-right'] },
   v: { size: 's', properties: ['padding-top', 'padding-bottom'] },
 })`
-  background: ${props => props.theme.newColor('accent.lightTurquoise')};
+  background: ${props => props.theme.color('accent.lightTurquoise')};
   display: flex;
   align-items: center;
   position: relative;

--- a/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
+++ b/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
@@ -33,7 +33,7 @@ const Wrapper = styled(Space).attrs({
   ${props =>
     props.underline &&
     `
-    border-bottom: 1px solid ${props.theme.newColor('warmNeutral.400')};
+    border-bottom: 1px solid ${props.theme.color('warmNeutral.400')};
   `}
 `;
 

--- a/catalogue/webapp/components/WorkDetails/ExplanatoryText.tsx
+++ b/catalogue/webapp/components/WorkDetails/ExplanatoryText.tsx
@@ -21,7 +21,7 @@ const IconContainer = styled.div<IconContainerProps>`
   height: 1em;
   border-radius: 50%;
   background: ${props =>
-    props.theme.newColor(props.open ? 'black' : 'accent.green')};
+    props.theme.color(props.open ? 'black' : 'accent.green')};
 
   .icon {
     transition: transform 300ms ease;

--- a/catalogue/webapp/components/WorksSearchResult/WorksSearchResult.tsx
+++ b/catalogue/webapp/components/WorksSearchResult/WorksSearchResult.tsx
@@ -24,7 +24,7 @@ type Props = {
 };
 
 const Wrapper = styled.div`
-  border-top: 1px solid ${props => props.theme.newColor('warmNeutral.400')};
+  border-top: 1px solid ${props => props.theme.color('warmNeutral.400')};
 `;
 
 const Container = styled.div`

--- a/catalogue/webapp/components/WorksSearchResult/WorksSearchResultV2.styles.tsx
+++ b/catalogue/webapp/components/WorksSearchResult/WorksSearchResultV2.styles.tsx
@@ -18,7 +18,7 @@ export const Preview = styled(Space)`
   max-width: 120px;
   margin-bottom: ${props => props.theme.spacingUnit * 2}px;
   margin-right: 1rem;
-  background-color: ${props => props.theme.newColor('black')};
+  background-color: ${props => props.theme.color('black')};
 
   ${props => props.theme.media.medium`
   margin-bottom: 0;
@@ -43,7 +43,7 @@ export const WorkInformation = styled(Space).attrs({
   className: font('intr', 5),
   v: { size: 'xs', properties: ['margin-bottom'] },
 })`
-  color: ${props => props.theme.newColor('neutral.600')};
+  color: ${props => props.theme.color('neutral.600')};
 `;
 
 export const WorkInformationItem = styled.span`

--- a/catalogue/webapp/components/WorksSearchResults/WorksSearchResultsV2.tsx
+++ b/catalogue/webapp/components/WorksSearchResults/WorksSearchResultsV2.tsx
@@ -10,7 +10,7 @@ type Props = {
 const SearchResultListItem = styled.li`
   flex-basis: 100%;
   max-width: 100%;
-  border-top: 1px solid ${props => props.theme.newColor('neutral.300')};
+  border-top: 1px solid ${props => props.theme.color('neutral.300')};
 
   &:first-child {
     border-top: 0;

--- a/catalogue/webapp/pages/concept.tsx
+++ b/catalogue/webapp/pages/concept.tsx
@@ -49,7 +49,7 @@ const leadingColor = 'yellow';
 const ConceptHero = styled(Space).attrs({
   v: { size: 'l', properties: ['padding-top', 'padding-bottom'] },
 })`
-  background-color: ${props => props.theme.newColor('lightYellow')};
+  background-color: ${props => props.theme.color('lightYellow')};
 `;
 
 const HeroTitle = styled.h1.attrs({ className: font('intb', 1) })`
@@ -58,7 +58,7 @@ const HeroTitle = styled.h1.attrs({ className: font('intb', 1) })`
 
 // TODO when LabelColor is refactored, maybe switch to using Label?
 const TypeLabel = styled.span.attrs({ className: font('intb', 6) })`
-  background-color: ${props => props.theme.newColor('warmNeutral.300')};
+  background-color: ${props => props.theme.color('warmNeutral.300')};
   padding: 5px;
 `;
 
@@ -69,10 +69,10 @@ const ConceptDescription = styled.section`
 const ConceptImages = styled(Space).attrs({
   v: { size: 'xl', properties: ['padding-top', 'padding-bottom'] },
 })`
-  background-color: ${props => props.theme.newColor('black')};
+  background-color: ${props => props.theme.color('black')};
 
   .sectionTitle {
-    color: ${props => props.theme.newColor('white')};
+    color: ${props => props.theme.color('white')};
   }
 `;
 
@@ -80,7 +80,7 @@ const ConceptWorksHeader = styled(Space).attrs({
   v: { size: 'xl', properties: ['padding-top'] },
 })<{ hasWorksTabs: boolean }>`
   background-color: ${({ hasWorksTabs, theme }) =>
-    theme.newColor(hasWorksTabs ? 'warmNeutral.300' : 'white')};};
+    theme.color(hasWorksTabs ? 'warmNeutral.300' : 'white')};};
 `;
 
 const SeeMoreButton = ({ text, link }: { text: string; link: LinkProps }) => (

--- a/common/views/components/ApiToolbar/ApiToolbar.tsx
+++ b/common/views/components/ApiToolbar/ApiToolbar.tsx
@@ -36,7 +36,7 @@ const includes = [
 ];
 
 const ToolbarContainer = styled.div`
-  background-color: ${props => props.theme.newColor('accent.purple')};
+  background-color: ${props => props.theme.color('accent.purple')};
   z-index: 100;
 `;
 

--- a/common/views/components/AudioPlayer/AudioPlayer.tsx
+++ b/common/views/components/AudioPlayer/AudioPlayer.tsx
@@ -43,7 +43,7 @@ const PlayPauseButton = styled.button.attrs<{ isPlaying: boolean }>(props => ({
 `;
 
 const PlayPauseInner = styled.div`
-  border: 2px solid ${props => props.theme.newColor('accent.green')};
+  border: 2px solid ${props => props.theme.color('accent.green')};
   border-radius: 50%;
   width: 40px;
   height: 40px;
@@ -108,7 +108,7 @@ const PlayRateLabel = styled.label<{ isActive: boolean }>`
   border-radius: 5px;
   text-align: center;
   background: ${props =>
-    props.isActive ? props.theme.newColor('yellow') : undefined}; ;
+    props.isActive ? props.theme.color('yellow') : undefined}; ;
 `;
 
 const formatVolume = (vol: number): string => {

--- a/common/views/components/BetaMessage/BetaMessage.tsx
+++ b/common/views/components/BetaMessage/BetaMessage.tsx
@@ -10,7 +10,7 @@ const StyledBetaMessage = styled.div.attrs(() => ({
 }))`
   display: flex;
   align-items: center;
-  border-left: ${props => `4px solid ${props.theme.newColor('accent.purple')}`};
+  border-left: ${props => `4px solid ${props.theme.color('accent.purple')}`};
   padding-left: ${props => props.theme.spacingUnit}px;
 `;
 

--- a/common/views/components/BorderlessClickable/BorderlessClickable.tsx
+++ b/common/views/components/BorderlessClickable/BorderlessClickable.tsx
@@ -24,17 +24,17 @@ type StyleProps = {
 
 export const BorderlessClickableStyle = styled(BaseButton)<StyleProps>`
   background: transparent;
-  color: ${props => props.theme.newColor('neutral.700')};
+  color: ${props => props.theme.color('neutral.700')};
   padding: 10px 8px;
 
   &:hover {
-    background: ${props => props.theme.newColor('neutral.300')};
+    background: ${props => props.theme.color('neutral.300')};
   }
 
   ${props =>
     props.isActive &&
     `
-    background: ${props.theme.newColor('neutral.300')};
+    background: ${props.theme.color('neutral.300')};
   `}
 `;
 

--- a/common/views/components/ButtonSolid/ButtonSolid.tsx
+++ b/common/views/components/ButtonSolid/ButtonSolid.tsx
@@ -5,16 +5,16 @@ import { trackEvent, GaEvent } from '../../../utils/ga';
 import Icon from '../Icon/Icon';
 import Space from '../styled/Space';
 import { IconSvg } from '@weco/common/icons';
-import { NewPaletteColor } from '@weco/common/views/themes/config';
+import { PaletteColor } from '@weco/common/views/themes/config';
 
 type BaseButtonProps = {
   href?: string;
 };
 
 export type ButtonColors = {
-  border: NewPaletteColor;
-  background: NewPaletteColor;
-  text: NewPaletteColor;
+  border: PaletteColor;
+  background: PaletteColor;
+  text: PaletteColor;
 };
 
 export const BaseButton = styled.button.attrs<BaseButtonProps>(props => ({
@@ -42,9 +42,9 @@ export const BaseButton = styled.button.attrs<BaseButtonProps>(props => ({
 
   &[disabled],
   &.disabled {
-    background: ${props => props.theme.newColor('neutral.600')};
-    border-color: ${props => props.theme.newColor('neutral.600')};
-    color: ${props => props.theme.newColor('white')};
+    background: ${props => props.theme.color('neutral.600')};
+    border-color: ${props => props.theme.color('neutral.600')};
+    color: ${props => props.theme.color('white')};
     cursor: not-allowed;
 
     &:hover {
@@ -157,16 +157,16 @@ export const SolidButton = styled(BaseButton).attrs<SolidButtonProps>(
   })
 )<SolidButtonProps>`
   background: ${props =>
-    props.theme.newColor(
+    props.theme.color(
       props?.colors?.background || props.theme.buttonColors.default.background
     )};
   color: ${props =>
-    props.theme.newColor(
+    props.theme.color(
       props?.colors?.text || props.theme.buttonColors.default.text
     )};
   border: 2px solid
     ${props =>
-      props.theme.newColor(
+      props.theme.color(
         props?.colors?.border || props.theme.buttonColors.default.border
       )};
 

--- a/common/views/components/Buttons/Control/Control.tsx
+++ b/common/views/components/Buttons/Control/Control.tsx
@@ -50,28 +50,28 @@ const Wrapper = styled.button.attrs<WrapperProps>(props => ({
   ${props =>
     props.colorScheme === 'light' &&
     `
-    background: ${props.theme.newColor('white')};
-    border: 2px solid ${props.theme.newColor('accent.green')};
+    background: ${props.theme.color('white')};
+    border: 2px solid ${props.theme.color('accent.green')};
 
     .icon__shape {
-      fill: ${props.theme.newColor('accent.green')};
+      fill: ${props.theme.color('accent.green')};
     }
 
     &:hover,
     &:focus {
-      background: ${props.theme.newColor('accent.green')};
+      background: ${props.theme.color('accent.green')};
 
       .icon__shape {
-        fill: ${props.theme.newColor('white')};
+        fill: ${props.theme.color('white')};
       }
     }
 
     &[disabled] {
       background: transparent;
-      border-color: ${props.theme.newColor('neutral.500')};
+      border-color: ${props.theme.color('neutral.500')};
 
       .icon__shape {
-        fill: ${props.theme.newColor('neutral.500')};
+        fill: ${props.theme.color('neutral.500')};
       }
     }
   `}
@@ -80,19 +80,19 @@ const Wrapper = styled.button.attrs<WrapperProps>(props => ({
     props.colorScheme === 'dark' &&
     `
     border: 0;
-    background: ${props.theme.newColor('accent.green')};
+    background: ${props.theme.color('accent.green')};
 
     .icon__shape {
-      fill: ${props.theme.newColor('white')};
+      fill: ${props.theme.color('white')};
     }
 
     &:hover,
     &:focus {
-      background: ${props.theme.newColor('black')};
+      background: ${props.theme.color('black')};
     }
 
     &[disabled] {
-      background: ${props.theme.newColor('neutral.500')};
+      background: ${props.theme.color('neutral.500')};
     }
   `}
 
@@ -104,21 +104,21 @@ const Wrapper = styled.button.attrs<WrapperProps>(props => ({
     background: #1f1f1f;
 
     .icon__shape {
-      fill: ${props.theme.newColor('white')};
+      fill: ${props.theme.color('white')};
       transition: all ${props.theme.transitionProperties};
     }
 
     &:hover,
     &:focus {
       .icon__shape {
-        fill: ${props.theme.newColor('yellow')};
+        fill: ${props.theme.color('yellow')};
       }
     }
 
 
     &[disabled] {
       .icon__shape {
-        fill: ${props.theme.newColor('neutral.400')};
+        fill: ${props.theme.color('neutral.400')};
       }
     }
   `}
@@ -126,25 +126,25 @@ const Wrapper = styled.button.attrs<WrapperProps>(props => ({
   ${props =>
     props.colorScheme === 'black-on-white' &&
     `
-    background: ${props.theme.newColor('white')};
+    background: ${props.theme.color('white')};
     border: none;
 
     .icon__shape {
-      fill: ${props.theme.newColor('neutral.700')};
+      fill: ${props.theme.color('neutral.700')};
     }
 
     &:hover,
     &:focus {
-      background: ${props.theme.newColor('yellow')};
+      background: ${props.theme.color('yellow')};
 
       .icon__shape {
-        fill: ${props.theme.newColor('neutral.700')};
+        fill: ${props.theme.color('neutral.700')};
       }
     }
 
     &[disabled] {
       .icon__shape {
-        fill: ${props.theme.newColor('neutral.600')};
+        fill: ${props.theme.color('neutral.600')};
       }
     }
   `}

--- a/common/views/components/CheckboxRadio/CheckboxRadio.tsx
+++ b/common/views/components/CheckboxRadio/CheckboxRadio.tsx
@@ -24,7 +24,7 @@ const CheckboxRadioBox = styled(CheckboxRadioBoxSpan)`
   position: relative;
   width: 1.3em;
   height: 1.3em;
-  border: 2px solid ${props => props.theme.newColor('warmNeutral.400')};
+  border: 2px solid ${props => props.theme.color('warmNeutral.400')};
   border-radius: ${props => (props.type === 'radio' ? '50%' : '0')};
 
   .icon {
@@ -45,7 +45,7 @@ const CheckboxRadioInput = styled.input.attrs(props => ({
   height: 1em;
 
   &:checked ~ ${CheckboxRadioBox} {
-    border-color: ${props => props.theme.newColor('black')};
+    border-color: ${props => props.theme.color('black')};
 
     .icon {
       opacity: 1;
@@ -53,14 +53,14 @@ const CheckboxRadioInput = styled.input.attrs(props => ({
   }
 
   &:hover ~ ${CheckboxRadioBox} {
-    border-color: ${props => props.theme.newColor('black')};
+    border-color: ${props => props.theme.color('black')};
   }
 
   .is-keyboard & {
     &:focus ~ ${CheckboxRadioBox} {
       outline: 0;
       box-shadow: ${props => props.theme.focusBoxShadow};
-      border-color: ${props => props.theme.newColor('black')};
+      border-color: ${props => props.theme.color('black')};
     }
   }
 `;

--- a/common/views/components/Contact/Contact.tsx
+++ b/common/views/components/Contact/Contact.tsx
@@ -7,7 +7,7 @@ const Wrapper = styled(Space).attrs({
   h: { size: 'm', properties: ['padding-left'] },
   className: 'body-text',
 })`
-  border-left: 5px solid ${props => props.theme.newColor('accent.turquoise')};
+  border-left: 5px solid ${props => props.theme.color('accent.turquoise')};
 `;
 
 export type Props = {

--- a/common/views/components/CookieNotice/CookieNotice.tsx
+++ b/common/views/components/CookieNotice/CookieNotice.tsx
@@ -12,15 +12,15 @@ const CookieNoticeStyle = styled.div.attrs({
   className: font('intb', 4),
 })`
   position: fixed;
-  background: ${props => props.theme.newColor('accent.blue')};
-  color: ${props => props.theme.newColor('white')};
+  background: ${props => props.theme.color('accent.blue')};
+  color: ${props => props.theme.color('white')};
   bottom: 0;
   left: 0;
   right: 0;
   z-index: 1000;
 
   .icon__shape {
-    fill: ${props => props.theme.newColor('white')};
+    fill: ${props => props.theme.color('white')};
   }
 `;
 

--- a/common/views/components/Divider/Divider.tsx
+++ b/common/views/components/Divider/Divider.tsx
@@ -1,9 +1,9 @@
 import { FunctionComponent, ReactElement } from 'react';
 import styled from 'styled-components';
-import { NewPaletteColor } from '@weco/common/views/themes/config';
+import { PaletteColor } from '@weco/common/views/themes/config';
 
 type Props = {
-  color: NewPaletteColor;
+  color: PaletteColor;
   isStub?: boolean;
   isKeyline?: boolean;
   isThin?: boolean;
@@ -16,7 +16,7 @@ const Rule = styled.hr<Props>`
   ${props =>
     props.color &&
     `
-    background-color: ${props.theme.newColor(props.color)};
+    background-color: ${props.theme.color(props.color)};
   `}
 
   ${props =>

--- a/common/views/components/DropdownButton/DropdownButton.tsx
+++ b/common/views/components/DropdownButton/DropdownButton.tsx
@@ -24,7 +24,7 @@ const Dropdown = styled(Space).attrs({
   h: { size: 'l', properties: ['padding-left', 'padding-right'] },
   className: 'rounded-corners shadow',
 })<DropdownProps>`
-  background-color: ${props => props.theme.newColor('white')};
+  background-color: ${props => props.theme.color('white')};
   margin-top: -2px;
   z-index: ${props => (props.isActive ? 2 : 1)};
   overflow: auto;

--- a/common/views/components/FindUs/FindUs.tsx
+++ b/common/views/components/FindUs/FindUs.tsx
@@ -26,7 +26,7 @@ const StyledFindUs = styled.div.attrs({
 
     &:hover,
     &:focus {
-      color: ${props => props.theme.newColor('accent.green')};
+      color: ${props => props.theme.color('accent.green')};
     }
   }
 `;

--- a/common/views/components/Footer/Footer.tsx
+++ b/common/views/components/Footer/Footer.tsx
@@ -16,7 +16,7 @@ const Wrapper = styled(Space).attrs({
   className: 'font-white',
 })`
   position: relative;
-  background-color: ${props => props.theme.newColor('black')};
+  background-color: ${props => props.theme.color('black')};
 `;
 
 const FooterNavWrapper = styled(Space).attrs({
@@ -25,8 +25,8 @@ const FooterNavWrapper = styled(Space).attrs({
     properties: ['padding-top', 'padding-bottom'],
   },
 })`
-  border-top: 1px solid ${props => props.theme.newColor('neutral.700')};
-  border-bottom: 1px solid ${props => props.theme.newColor('neutral.700')};
+  border-top: 1px solid ${props => props.theme.color('neutral.700')};
+  border-bottom: 1px solid ${props => props.theme.color('neutral.700')};
 `;
 
 const HygieneNav = styled(Space).attrs({
@@ -35,7 +35,7 @@ const HygieneNav = styled(Space).attrs({
 })`
   position: relative;
   flex: 1;
-  border-bottom: 1px solid ${props => props.theme.newColor('neutral.700')};
+  border-bottom: 1px solid ${props => props.theme.color('neutral.700')};
 `;
 
 const HygieneList = styled(Space).attrs({
@@ -47,7 +47,7 @@ const HygieneList = styled(Space).attrs({
   padding: 0;
   display: flex;
   justify-content: space-between;
-  border-top: 1px solid ${props => props.theme.newColor('neutral.700')};
+  border-top: 1px solid ${props => props.theme.color('neutral.700')};
 `;
 
 const FooterBottom = styled(Space).attrs({
@@ -57,7 +57,7 @@ const FooterBottom = styled(Space).attrs({
   flex-wrap: wrap;
   justify-content: space-between;
   align-items: flex-start;
-  border-top: 1px solid ${props => props.theme.newColor('neutral.700')};
+  border-top: 1px solid ${props => props.theme.color('neutral.700')};
 `;
 
 const NavBrand = styled.a`
@@ -85,13 +85,13 @@ const FooterStrap = styled(Space).attrs({
   display: flex;
   align-items: center;
   min-width: 220px;
-  border-bottom: 1px solid ${props => props.theme.newColor('neutral.700')};
+  border-bottom: 1px solid ${props => props.theme.color('neutral.700')};
   width: 100%;
 
   ${props => props.theme.media.medium`
     width: auto;
     border-bottom: 0;
-    border-right: 1px solid ${props.theme.newColor('neutral.700')};
+    border-right: 1px solid ${props.theme.color('neutral.700')};
     margin-right: 24px;
     padding-right: 24px;
   `}
@@ -121,11 +121,11 @@ const HygieneItem = styled.li.attrs({
     padding: 0.5em 0;
     display: block;
     text-decoration: none;
-    border-left: 1px solid ${props => props.theme.newColor('neutral.700')};
+    border-left: 1px solid ${props => props.theme.color('neutral.700')};
     transition: color 200ms ease;
 
     &:hover {
-      color: ${props => props.theme.newColor('accent.green')};
+      color: ${props => props.theme.color('accent.green')};
     }
 
     ${props => props.theme.media.xlarge`
@@ -139,7 +139,7 @@ const HygieneItem = styled.li.attrs({
       border-left: 0;
 
       ${props => props.theme.media.large`
-        border-left: 1px solid ${props => props.theme.newColor('neutral.700')};
+        border-left: 1px solid ${props => props.theme.color('neutral.700')};
         justify-content: center;
       `}
 
@@ -160,7 +160,7 @@ const HygieneItem = styled.li.attrs({
 
 const TopBorderBox = styled.div`
   @media (min-width: ${props => props.theme.sizes.large}px) {
-    border-top: 1px solid ${props => props.theme.newColor('neutral.700')};
+    border-top: 1px solid ${props => props.theme.color('neutral.700')};
     border-bottom: 0;
   }
 `;

--- a/common/views/components/Footer/FooterNav.tsx
+++ b/common/views/components/Footer/FooterNav.tsx
@@ -17,7 +17,7 @@ const NavLink = styled(Space).attrs({
   transition: color 200ms ease;
 
   &:hover {
-    color: ${props => props.theme.newColor('accent.green')};
+    color: ${props => props.theme.color('accent.green')};
   }
 `;
 

--- a/common/views/components/Footer/FooterSocial.tsx
+++ b/common/views/components/Footer/FooterSocial.tsx
@@ -60,7 +60,7 @@ const Link = styled(Space).attrs({
   as: 'a',
   className: font('intb', 6),
 })<LinkProps>`
-  color: ${props => props.theme.newColor('white')};
+  color: ${props => props.theme.color('white')};
   text-decoration: none;
   display: flex;
   align-items: center;
@@ -68,7 +68,7 @@ const Link = styled(Space).attrs({
 
   &:hover,
   &:focus {
-    color: ${props => props.theme.newColor('accent.green')};
+    color: ${props => props.theme.color('accent.green')};
   }
 `;
 

--- a/common/views/components/Header/Header.tsx
+++ b/common/views/components/Header/Header.tsx
@@ -29,8 +29,8 @@ const Wrapper = styled.div.attrs({
   align-items: center;
   position: relative;
   z-index: 6;
-  background-color: ${props => props.theme.newColor('white')};
-  border-bottom: 1px solid ${props => props.theme.newColor('warmNeutral.400')};
+  background-color: ${props => props.theme.color('white')};
+  border-bottom: 1px solid ${props => props.theme.color('warmNeutral.400')};
 
   ${props =>
     props.isBurgerOpen &&
@@ -73,7 +73,7 @@ const BurgerTrigger = styled.a<{ isActive: boolean }>`
     left: 0;
     right: 0;
     height: 2px;
-    background: ${props => props.theme.newColor('black')};
+    background: ${props => props.theme.color('black')};
     transition: transform 400ms ease;
     transform-origin: center center;
 
@@ -120,7 +120,7 @@ const HeaderBrand = styled.div`
       flex: 0 0 auto;
       margin-right: 1.5rem;
       padding-right: 1.5rem;
-      border-right: 1px solid ${props.theme.newColor('warmNeutral.400')};
+      border-right: 1px solid ${props.theme.color('warmNeutral.400')};
       width: auto;
       display: block;
     `
@@ -135,7 +135,7 @@ const HeaderBrand = styled.div`
 
 const HeaderNav = styled.nav<{ isActive: boolean }>`
   display: ${props => (props.isActive ? 'block' : 'none')};
-  background: ${props => props.theme.newColor('white')};
+  background: ${props => props.theme.color('white')};
   position: absolute;
   top: 100%;
   left: 0;
@@ -149,7 +149,7 @@ const HeaderNav = styled.nav<{ isActive: boolean }>`
       'small',
       'headerMedium',
       `
-      border-top: 1px solid ${props.theme.newColor('warmNeutral.400')};
+      border-top: 1px solid ${props.theme.color('warmNeutral.400')};
       height: calc(100vh - 84px);
       overflow: auto;
     `
@@ -190,7 +190,7 @@ const HeaderList = styled.ul`
 `;
 
 const HeaderItem = styled.li`
-  border-bottom: 1px solid ${props => props.theme.newColor('warmNeutral.400')};
+  border-bottom: 1px solid ${props => props.theme.color('warmNeutral.400')};
 
   // TODO: the vw units below are tightly coupled to the
   // number of nav items and number of characters in them.
@@ -243,7 +243,7 @@ const HeaderLink = styled.a<{ isActive: boolean }>`
     height: 0.6rem;
     left: 0;
     width: 0;
-    background: ${props => props.theme.newColor('yellow')};
+    background: ${props => props.theme.color('yellow')};
     z-index: -1;
     transition: width 200ms ease;
 

--- a/common/views/components/HeaderBackground/HeaderBackground.tsx
+++ b/common/views/components/HeaderBackground/HeaderBackground.tsx
@@ -19,7 +19,7 @@ const Background = styled.div<{ texture: string | null }>`
   overflow: hidden;
   z-index: -1;
 
-  background-color: ${props => props.theme.newColor('warmNeutral.300')};
+  background-color: ${props => props.theme.color('warmNeutral.300')};
   ${props =>
     props.texture &&
     `background-image: url(${props.texture});

--- a/common/views/components/HeightRestrictedPrismicImage/HeightRestrictedPrismicImage.tsx
+++ b/common/views/components/HeightRestrictedPrismicImage/HeightRestrictedPrismicImage.tsx
@@ -16,7 +16,7 @@ export type Props = {
 const PrismicImage = styled(Image).attrs({
   className: 'font-white',
 })`
-  background-color: ${props => props.theme.newColor('neutral.700')};
+  background-color: ${props => props.theme.color('neutral.700')};
 `;
 
 function determineSize(viewPortImageDifference): string {

--- a/common/views/components/Icon/Icon.tsx
+++ b/common/views/components/Icon/Icon.tsx
@@ -1,11 +1,11 @@
 import { FunctionComponent } from 'react';
 import styled from 'styled-components';
-import { NewPaletteColor } from '@weco/common/views/themes/config';
+import { PaletteColor } from '@weco/common/views/themes/config';
 import { IconSvg } from '@weco/common/icons';
 
 type WrapperProps = {
   rotate?: number;
-  color?: NewPaletteColor;
+  color?: PaletteColor;
   matchText?: boolean;
 };
 
@@ -37,11 +37,11 @@ const Wrapper = styled.div.attrs({
     props.color &&
     `
   .icon__shape {
-    fill: ${props.theme.newColor(props.color)};
+    fill: ${props.theme.color(props.color)};
   }
 
   .icon__stroke {
-    stroke: ${props.theme.newColor(props.color)};
+    stroke: ${props.theme.color(props.color)};
   }
 `}
 
@@ -55,7 +55,7 @@ const Wrapper = styled.div.attrs({
 type Props = {
   icon: IconSvg;
   rotate?: number;
-  color?: NewPaletteColor;
+  color?: PaletteColor;
   matchText?: boolean;
   title?: string;
   attrs?: { [key: string]: [string] };

--- a/common/views/components/InfoBanner/InfoBanner.tsx
+++ b/common/views/components/InfoBanner/InfoBanner.tsx
@@ -19,7 +19,7 @@ type Props = {
 const BannerContainer = styled(Space).attrs({
   v: { size: 'm', properties: ['padding-top', 'padding-bottom'] },
 })`
-  background-color: ${props => props.theme.newColor('yellow')};
+  background-color: ${props => props.theme.color('yellow')};
 `;
 
 const InfoBanner: FunctionComponent<Props> = ({

--- a/common/views/components/InfoBlock/InfoBlock.tsx
+++ b/common/views/components/InfoBlock/InfoBlock.tsx
@@ -10,7 +10,7 @@ import { themeValues } from '@weco/common/views/themes/config';
 const Wrapper = styled(Space).attrs({
   h: { size: 'l', properties: ['padding-left', 'padding-right'] },
 })`
-  border-left: 16px solid ${props => props.theme.newColor('yellow')};
+  border-left: 16px solid ${props => props.theme.color('yellow')};
 `;
 
 export type Props = {

--- a/common/views/components/Label/Label.tsx
+++ b/common/views/components/Label/Label.tsx
@@ -14,14 +14,14 @@ const LabelContainer = styled(Space).attrs({
 })<LabelContainerProps>`
   white-space: nowrap;
   line-height: 1;
-  color: ${props => props.theme.newColor(props.fontColor)};
-  background-color: ${props => props.theme.newColor(props.labelColor)};
+  color: ${props => props.theme.color(props.fontColor)};
+  background-color: ${props => props.theme.color(props.labelColor)};
 
   ${props => {
     if (props.labelColor === 'white' || props.labelColor === 'transparent') {
-      return `border: 1px solid ${props.theme.newColor('neutral.500')};`;
+      return `border: 1px solid ${props.theme.color('neutral.500')};`;
     } else {
-      return `border: 1px solid ${props.theme.newColor(props.labelColor)};`;
+      return `border: 1px solid ${props.theme.color(props.labelColor)};`;
     }
   }}
 `;

--- a/common/views/components/LinkLabels/LinkLabels.tsx
+++ b/common/views/components/LinkLabels/LinkLabels.tsx
@@ -36,7 +36,7 @@ const ItemText = styled(Space).attrs<LinkOrSpanSpaceAttrs>(props => ({
   ${props =>
     props.addBorder &&
     `
-    border-left: 1px solid ${props.theme.newColor('neutral.500')};
+    border-left: 1px solid ${props.theme.color('neutral.500')};
   `}
 `;
 

--- a/common/views/components/LoadingIndicator/LoadingIndicator.tsx
+++ b/common/views/components/LoadingIndicator/LoadingIndicator.tsx
@@ -10,7 +10,7 @@ const LoadingIndicatorWrapper = styled.div.attrs({
     pointer-events: none;
   }
   #nprogress .bar {
-    background: ${props => props.theme.newColor('yellow')};
+    background: ${props => props.theme.color('yellow')};
     position: fixed;
     z-index: 1031;
     top: 0;
@@ -24,8 +24,8 @@ const LoadingIndicatorWrapper = styled.div.attrs({
     right: 0px;
     width: 100px;
     height: 100%;
-    box-shadow: 0 0 10px ${props => props.theme.newColor('yellow')},
-      0 0 5px ${props => props.theme.newColor('yellow')};
+    box-shadow: 0 0 10px ${props => props.theme.color('yellow')},
+      0 0 5px ${props => props.theme.color('yellow')};
     opacity: 1;
     transform: rotate(3deg) translate(0px, -4px);
   }

--- a/common/views/components/Message/Message.tsx
+++ b/common/views/components/Message/Message.tsx
@@ -12,7 +12,7 @@ const Wrapper = styled(Space).attrs({
   className: font('intb', 5),
 })`
   display: inline-block;
-  border-left: 5px solid ${props => props.theme.newColor('yellow')};
+  border-left: 5px solid ${props => props.theme.color('yellow')};
 `;
 
 type Props = {

--- a/common/views/components/MessageBar/MessageBar.tsx
+++ b/common/views/components/MessageBar/MessageBar.tsx
@@ -7,7 +7,7 @@ const ColouredTag: FunctionComponent<SpaceComponentProps> = styled.span.attrs({
   className: `font-white ${font('intb', 6)}`,
 })<SpaceComponentProps>`
   display: inline-block;
-  background-color: ${props => props.theme.newColor('neutral.700')};
+  background-color: ${props => props.theme.color('neutral.700')};
   padding: 0.2em 0.5em;
   text-transform: uppercase;
   ${props =>

--- a/common/views/components/Modal/Modal.tsx
+++ b/common/views/components/Modal/Modal.tsx
@@ -59,14 +59,14 @@ const CloseButton = styled(Space).attrs<CloseButtonProps>({
   border-radius: 50%;
   appearance: none;
   background: rgba(0, 0, 0, 0.7);
-  color: ${props => props.theme.newColor('white')};
+  color: ${props => props.theme.color('white')};
   border: 0;
   outline: 0;
   z-index: 1;
 
   &:focus {
     ${props =>
-      !props.hideFocus && `border: 2px solid ${props.theme.newColor('black')}`}
+      !props.hideFocus && `border: 2px solid ${props.theme.color('black')}`}
   }
 
   .icon {
@@ -78,7 +78,7 @@ const CloseButton = styled(Space).attrs<CloseButtonProps>({
 
   ${props => props.theme.media.medium`
     background: none;
-    color: ${props => props.theme.newColor('neutral.600')};
+    color: ${props => props.theme.color('neutral.600')};
     position: absolute;
   `}
 `;
@@ -96,7 +96,7 @@ const BaseModalWindow = styled(Space).attrs<BaseModalProps>({
   position: fixed;
   overflow: auto;
   transition: opacity 350ms ease, transform 350ms ease;
-  background-color: ${props => props.theme.newColor('white')};
+  background-color: ${props => props.theme.color('white')};
 
   &,
   &.fade-exit-done {

--- a/common/views/components/ModalMoreFilters/ModalMoreFilters.tsx
+++ b/common/views/components/ModalMoreFilters/ModalMoreFilters.tsx
@@ -50,7 +50,7 @@ const FilterSection = styled(Space).attrs({
   h: { size: 'l', properties: ['padding-left', 'padding-right'] },
   v: { size: 'l', properties: ['padding-top', 'padding-bottom'] },
 })`
-  border-bottom: 1px solid ${props => props.theme.newColor('warmNeutral.400')};
+  border-bottom: 1px solid ${props => props.theme.color('warmNeutral.400')};
 `;
 
 const List = styled.ul`
@@ -71,8 +71,8 @@ const FiltersFooter = styled(Space).attrs({
   display: flex;
   align-items: center;
   justify-content: space-between;
-  background-color: ${props => props.theme.newColor('white')};
-  border-top: 1px solid ${props => props.theme.newColor('warmNeutral.400')};
+  background-color: ${props => props.theme.color('white')};
+  border-top: 1px solid ${props => props.theme.color('warmNeutral.400')};
   position: fixed;
   bottom: 0;
   left: 0;
@@ -85,7 +85,7 @@ const FiltersHeader = styled(Space).attrs({
   v: { size: 'm', properties: ['padding-top', 'padding-bottom'] },
 })`
   position: absolute;
-  border-bottom: 1px solid ${props => props.theme.newColor('warmNeutral.400')};
+  border-bottom: 1px solid ${props => props.theme.color('warmNeutral.400')};
   text-align: center;
   top: 0px;
   left: 0px;

--- a/common/views/components/NewsletterPromo/NewsletterPromo.tsx
+++ b/common/views/components/NewsletterPromo/NewsletterPromo.tsx
@@ -67,7 +67,7 @@ const YellowBox = styled(Space).attrs({
   v: { size: 'l', properties: ['padding-top', 'padding-bottom'] },
   'aria-live': 'polite',
 })`
-  border: 12px solid ${props => props.theme.newColor('yellow')};
+  border: 12px solid ${props => props.theme.color('yellow')};
 
   p {
     max-width: 600px;

--- a/common/views/components/Number/Number.tsx
+++ b/common/views/components/Number/Number.tsx
@@ -10,7 +10,7 @@ type Props = {
 
 const Wrapper = styled(Space)<{ color?: string }>`
   background-color: ${props =>
-    props.theme.newColor(props.color ? props.color : 'accent.purple')};
+    props.theme.color(props.color ? props.color : 'accent.purple')};
 
   transform: rotateZ(-6deg);
   width: 24px;

--- a/common/views/components/NumberInput/NumberInput.tsx
+++ b/common/views/components/NumberInput/NumberInput.tsx
@@ -6,7 +6,7 @@ const StyledInput = styled(Space).attrs({
   type: 'number',
 })`
   outline: none;
-  border: 1px solid ${props => props.theme.newColor('warmNeutral.400')};
+  border: 1px solid ${props => props.theme.color('warmNeutral.400')};
   padding: 12px;
   border-radius: 3px;
   appearance: none;
@@ -19,7 +19,7 @@ const StyledInput = styled(Space).attrs({
   }
 
   &:focus {
-    border: 2px solid ${props => props.theme.newColor('black')};
+    border: 2px solid ${props => props.theme.color('black')};
     padding: 11px;
   }
 `;

--- a/common/views/components/PageHeader/HighlightedHeading.tsx
+++ b/common/views/components/PageHeader/HighlightedHeading.tsx
@@ -4,7 +4,7 @@ import { FunctionComponent } from 'react';
 
 const Heading = styled(Space)`
   display: block;
-  background-color: ${props => props.theme.newColor('white')};
+  background-color: ${props => props.theme.color('white')};
 
   @supports (box-decoration-break: clone) {
     display: inline;

--- a/common/views/components/PageHeader/PageHeader.tsx
+++ b/common/views/components/PageHeader/PageHeader.tsx
@@ -27,7 +27,7 @@ import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper
 export const headerSpaceSize = 'l';
 const HeroPictureBackground = styled.div<{ bgColor: string }>`
   position: absolute;
-  background-color: ${props => props.theme.newColor(props.bgColor)};
+  background-color: ${props => props.theme.color(props.bgColor)};
   height: 50%;
   width: 100%;
   bottom: -${props => props.theme.spaceAtBreakpoints.small[headerSpaceSize]}px;

--- a/common/views/components/Placeholder/Placeholder.tsx
+++ b/common/views/components/Placeholder/Placeholder.tsx
@@ -10,7 +10,7 @@ type Props = {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const getGradient = (theme: any) => {
-  const bgColor = theme.newColors['neutral.300'];
+  const bgColor = theme.colors['neutral.300'];
   const highlightColor = 'rgba(255, 255, 255, 0.6)';
 
   // We make the background periodic so that it can be animated easily

--- a/common/views/components/PopupDialog/PopupDialog.tsx
+++ b/common/views/components/PopupDialog/PopupDialog.tsx
@@ -44,7 +44,7 @@ const PopupDialogOpen = styled(Space).attrs<PopupDialogOpenProps>(props => ({
   line-height: 1;
   display: inline-flex;
   align-items: center;
-  color: ${props => props.theme.newColor('accent.purple')};
+  color: ${props => props.theme.color('accent.purple')};
   position: fixed;
   transform: ${props =>
     props.isActive || !props.shouldStartAnimation
@@ -53,7 +53,7 @@ const PopupDialogOpen = styled(Space).attrs<PopupDialogOpenProps>(props => ({
   bottom: 20px;
   left: 20px;
   z-index: 3;
-  background: ${props => props.theme.newColor('white')};
+  background: ${props => props.theme.color('white')};
   opacity: ${props => (props.isActive || !props.shouldStartAnimation ? 0 : 1)};
   transition: opacity 500ms ease, filter 500ms ease, transform 500ms ease;
   transition-delay: ${props => (props.isActive ? '0ms' : '500ms')};
@@ -64,11 +64,11 @@ const PopupDialogOpen = styled(Space).attrs<PopupDialogOpenProps>(props => ({
   &:focus {
     outline: 0;
     border: 0;
-    color: ${props => props.theme.newColor('white')};
-    background: ${props => props.theme.newColor('accent.purple')};
+    color: ${props => props.theme.color('white')};
+    background: ${props => props.theme.color('accent.purple')};
 
     .icon__shape {
-      fill: ${props => props.theme.newColor('white')};
+      fill: ${props => props.theme.color('white')};
     }
   }
 `;
@@ -91,7 +91,7 @@ const PopupDialogWindow = styled(Space).attrs({
   },
   className: 'font-accent-purple',
 })<PopupDialogWindowProps>`
-  background-color: ${props => props.theme.newColor('white')};
+  background-color: ${props => props.theme.color('white')};
   border-radius: 20px 0 20px 0;
   box-shadow: 0 2px 60px 0 rgba(0, 0, 0, 0.7);
   opacity: ${props => (props.isActive ? 1 : 0)};
@@ -148,8 +148,8 @@ const PopupDialogCTA = styled(Space).attrs({
   className: `${font('intb', 5, { small: 3, medium: 3 })} rounded-corners`,
 })`
   display: inline-block;
-  background-color: ${props => props.theme.newColor('accent.purple')};
-  color: ${props => props.theme.newColor('white')};
+  background-color: ${props => props.theme.color('accent.purple')};
+  color: ${props => props.theme.color('white')};
   transition: all 500ms ease;
   border: 2px solid transparent;
   text-decoration: none;
@@ -157,9 +157,9 @@ const PopupDialogCTA = styled(Space).attrs({
   &:hover,
   &:focus {
     outline: 0;
-    color: ${props => props.theme.newColor('accent.purple')};
-    border-color: ${props => props.theme.newColor('accent.purple')};
-    background: ${props => props.theme.newColor('white')};
+    color: ${props => props.theme.color('accent.purple')};
+    border-color: ${props => props.theme.color('accent.purple')};
+    background: ${props => props.theme.color('white')};
   }
 `;
 

--- a/common/views/components/PrismicImage/PrismicImage.tsx
+++ b/common/views/components/PrismicImage/PrismicImage.tsx
@@ -5,7 +5,7 @@ import { Breakpoint, sizes as breakpointSizes } from '../../themes/config';
 import { ImageType } from '../../../model/image';
 
 const StyledImage = styled(Image).attrs({ className: 'font-white' })`
-  background-color: ${props => props.theme.newColor('neutral.700')};
+  background-color: ${props => props.theme.color('neutral.700')};
 `;
 
 export type BreakpointSizes = Partial<Record<Breakpoint, number>>;

--- a/common/views/components/SearchFilters/ResetActiveFilters.tsx
+++ b/common/views/components/SearchFilters/ResetActiveFilters.tsx
@@ -31,7 +31,7 @@ const Wrapper = styled(Space).attrs({
   h: { size: 'm', properties: ['padding-left', 'padding-right'] },
   className: 'tokens',
 })`
-  background-color: ${props => props.theme.newColor('white')};
+  background-color: ${props => props.theme.color('white')};
 `;
 
 type CancelFilterProps = {

--- a/common/views/components/SearchFilters/SearchFiltersDesktop.tsx
+++ b/common/views/components/SearchFilters/SearchFiltersDesktop.tsx
@@ -43,7 +43,7 @@ const Wrapper = styled(Space).attrs({
   },
 })`
   display: flex;
-  background-color: ${props => props.theme.newColor('warmNeutral.400')};
+  background-color: ${props => props.theme.color('warmNeutral.400')};
 `;
 
 const CheckboxFilter = ({ f, changeHandler }: CheckboxFilterProps) => {

--- a/common/views/components/SearchFilters/SearchFiltersMobile.tsx
+++ b/common/views/components/SearchFilters/SearchFiltersMobile.tsx
@@ -38,7 +38,7 @@ const PaletteColorPicker = dynamic(
 const SearchFiltersContainer = styled(Space).attrs({
   v: { size: 'm', properties: ['padding-top', 'padding-bottom'] },
 })`
-  background-color: ${props => props.theme.newColor('white')};
+  background-color: ${props => props.theme.color('white')};
 `;
 
 const ShameButtonWrap = styled(Space).attrs({
@@ -54,7 +54,7 @@ const FiltersHeader = styled(Space).attrs({
   h: { size: 'm', properties: ['padding-left', 'padding-right'] },
   v: { size: 'l', properties: ['padding-top', 'padding-bottom'] },
 })`
-  border-bottom: 1px solid ${props => props.theme.newColor('warmNeutral.400')};
+  border-bottom: 1px solid ${props => props.theme.color('warmNeutral.400')};
 `;
 
 const ActiveFilters = styled(Space).attrs({
@@ -66,7 +66,7 @@ const ActiveFilters = styled(Space).attrs({
   className: 'font-black rounded-corners',
 })`
   display: inline-block;
-  background-color: ${props => props.theme.newColor('yellow')};
+  background-color: ${props => props.theme.color('yellow')};
   text-align: center;
   min-width: 24px;
 `;
@@ -82,7 +82,7 @@ const FiltersBody = styled(Space).attrs({
 const FilterSection = styled(Space).attrs({
   v: { size: 'xl', properties: ['padding-top', 'padding-bottom'] },
 })`
-  border-bottom: 1px solid ${props => props.theme.newColor('warmNeutral.400')};
+  border-bottom: 1px solid ${props => props.theme.color('warmNeutral.400')};
 `;
 
 const FiltersScrollable = styled.div`
@@ -99,8 +99,8 @@ const FiltersFooter = styled(Space).attrs({
   display: flex;
   align-items: center;
   justify-content: space-between;
-  background-color: ${props => props.theme.newColor('white')};
-  border-top: 1px solid ${props => props.theme.newColor('warmNeutral.400')};
+  background-color: ${props => props.theme.color('white')};
+  border-top: 1px solid ${props => props.theme.color('warmNeutral.400')};
   position: fixed;
   bottom: 0;
   left: 0;

--- a/common/views/components/SearchForm/SearchForm.tsx
+++ b/common/views/components/SearchForm/SearchForm.tsx
@@ -58,7 +58,7 @@ const SearchButtonWrapper = styled.div`
 const SearchSortOrderWrapper = styled(Space).attrs({
   h: { size: 'm', properties: ['margin-right'] },
 })`
-  color: ${props => props.theme.newColor('black')};
+  color: ${props => props.theme.color('black')};
 `;
 
 type Props = {

--- a/common/views/components/SearchTabs/SearchTabs.tsx
+++ b/common/views/components/SearchTabs/SearchTabs.tsx
@@ -26,16 +26,16 @@ const Tab = styled(Space).attrs({
   className: font('intb', 5),
 })<TabProps>`
   display: inline-flex;
-  background: ${props => props.theme.newColor('white')};
+  background: ${props => props.theme.color('white')};
   border-width: 1px 1px 0 1px;
   border-style: solid;
-  border-color: ${props => props.theme.newColor('warmNeutral.400')};
+  border-color: ${props => props.theme.color('warmNeutral.400')};
 
   ${props =>
     props.isActive &&
     `
-    border-color: ${props.theme.newColor('warmNeutral.300')};
-    background: ${props.theme.newColor('warmNeutral.300')};
+    border-color: ${props.theme.color('warmNeutral.300')};
+    background: ${props.theme.color('warmNeutral.300')};
   `}
 
   ${props =>
@@ -54,7 +54,7 @@ const Tab = styled(Space).attrs({
 `;
 
 const TabPanel = styled(Space)`
-  background: ${props => props.theme.newColor('warmNeutral.300')};
+  background: ${props => props.theme.color('warmNeutral.300')};
 `;
 
 type Props = {

--- a/common/views/components/SectionHeader/SectionHeader.tsx
+++ b/common/views/components/SectionHeader/SectionHeader.tsx
@@ -7,7 +7,7 @@ const YellowBox = styled.div`
   display: inline-block;
   width: 60px;
   height: 18px;
-  background: ${props => props.theme.newColor('yellow')};
+  background: ${props => props.theme.color('yellow')};
 
   ${props => props.theme.media.medium`
     width: 58px;
@@ -21,7 +21,7 @@ const YellowBox = styled.div`
 
 const TitleWrapper = styled.span`
   .bg-neutral-700 & {
-    color: ${props => props.theme.newColor('white')};
+    color: ${props => props.theme.color('white')};
   }
 `;
 

--- a/common/views/components/SegmentedControl/SegmentedControl.tsx
+++ b/common/views/components/SegmentedControl/SegmentedControl.tsx
@@ -23,19 +23,19 @@ const DrawerItem = styled(Space).attrs({
   as: 'li',
   className: `${font('wb', 4)} segmented-control__drawer-item`,
 })<DrawerItemProps>`
-  border-bottom: 1px solid ${props => props.theme.newColor('neutral.300')};
+  border-bottom: 1px solid ${props => props.theme.color('neutral.300')};
 
   ${props =>
     props.isFirst &&
     `
-    border-top: 1px solid ${props.theme.newColor('neutral.300')};
+    border-top: 1px solid ${props.theme.color('neutral.300')};
   `}
 `;
 
 const List = styled.ul.attrs({
   className: 'segmented-control__list rounded-diagonal',
 })`
-  border: 1px solid ${props => props.theme.newColor('black')};
+  border: 1px solid ${props => props.theme.color('black')};
   margin: 0 !important;
   padding: 0;
   list-style: none;
@@ -51,7 +51,7 @@ const Item = styled.li.attrs({
 })<ItemProps>`
   display: flex;
   line-height: 1;
-  border-right: 1px solid ${props => props.theme.newColor('black')};
+  border-right: 1px solid ${props => props.theme.color('black')};
 
   ${props =>
     props.isLast &&
@@ -70,7 +70,7 @@ const ItemInner = styled.a.attrs<IsActiveProps>(props => ({
   display: block;
 
   background-color: ${props =>
-    props.theme.newColor(props.isActive ? 'black' : 'white')};
+    props.theme.color(props.isActive ? 'black' : 'white')};
 
   ${props =>
     props.theme.makeSpacePropertyValues(
@@ -90,7 +90,7 @@ const ItemInner = styled.a.attrs<IsActiveProps>(props => ({
   &:hover,
   &:focus {
     background: ${props =>
-      props.theme.newColor(props.isActive ? 'neutral.600' : 'warmNeutral.400')};
+      props.theme.color(props.isActive ? 'neutral.600' : 'warmNeutral.400')};
   }
 `;
 
@@ -182,14 +182,14 @@ const MobileControlsContainer = styled(Space).attrs({
     'segmented-control__button-text font-white rounded-diagonal',
 })`
   display: flex;
-  background-color: ${props => props.theme.newColor('black')};
+  background-color: ${props => props.theme.color('black')};
 `;
 
 const MobileControlsModal = styled(Space).attrs({
   h: { size: 'm', properties: ['padding-left', 'padding-right'] },
   className: 'segmented-control__body',
 })`
-  background-color: ${props => props.theme.newColor('white')};
+  background-color: ${props => props.theme.color('white')};
 `;
 
 type Props = {

--- a/common/views/components/SelectContainer/SelectContainer.tsx
+++ b/common/views/components/SelectContainer/SelectContainer.tsx
@@ -31,9 +31,9 @@ const StyledSelect = styled.div.attrs({
     font-weight: inherit;
     appearance: none;
     padding: 6px 36px 6px 12px;
-    border: 2px solid ${props => props.theme.newColor('warmNeutral.400')};
+    border: 2px solid ${props => props.theme.color('warmNeutral.400')};
     border-radius: ${props => props.theme.borderRadiusUnit}px;
-    background-color: ${props => props.theme.newColor('white')};
+    background-color: ${props => props.theme.color('white')};
     width: 100%;
 
     &::-ms-expand {

--- a/common/views/components/StackingTable/StackingTable.tsx
+++ b/common/views/components/StackingTable/StackingTable.tsx
@@ -47,7 +47,7 @@ type TrProps = {
 const StyledTr = styled(Space).attrs({
   as: 'tr',
 })<TrProps>`
-  border-bottom: 1px solid ${props => props.theme.newColor('warmNeutral.400')};
+  border-bottom: 1px solid ${props => props.theme.color('warmNeutral.400')};
 
   &:last-of-type {
     border: none;
@@ -76,7 +76,7 @@ const StyledTh = styled(Space).attrs<ThProps>(props => ({
   className: font('intb', 5),
 }))<ThProps>`
   background: ${props =>
-    props.plain ? 'transparent' : props.theme.newColor('warmNeutral.400')};
+    props.plain ? 'transparent' : props.theme.color('warmNeutral.400')};
   white-space: nowrap;
   text-align: left;
   vertical-align: top;

--- a/common/views/components/TabNav/TabNav.styles.tsx
+++ b/common/views/components/TabNav/TabNav.styles.tsx
@@ -42,7 +42,7 @@ export const NavItemInner = styled(Space).attrs<NavItemInnerProps>(props => {
   padding: 1em 0.3em;
   cursor: pointer;
   color: ${props =>
-    props.theme.newColor(
+    props.theme.color(
       props.isDarkMode
         ? props.selected
           ? 'white'
@@ -61,7 +61,7 @@ export const NavItemInner = styled(Space).attrs<NavItemInnerProps>(props => {
     left: 0;
     width: 0;
     background-color: ${props =>
-      props.theme.newColor(
+      props.theme.color(
         props.isDarkMode
           ? props.selected
             ? 'white'

--- a/common/views/components/TabNav/TabNav.tsx
+++ b/common/views/components/TabNav/TabNav.tsx
@@ -33,7 +33,7 @@ const NavItemInner: ComponentType<SpaceComponentProps> = styled(Space).attrs(
     height: 0.6rem;
     left: 0;
     width: 0;
-    background: ${props => props.theme.newColor('yellow')};
+    background: ${props => props.theme.color('yellow')};
     z-index: -1;
     transition: width 200ms ease;
   }

--- a/common/views/components/Table/Table.tsx
+++ b/common/views/components/Table/Table.tsx
@@ -113,7 +113,7 @@ const TableTr = styled.tr`
     border-bottom: ${props =>
       props.withBorder
         ? `1px dotted
-      ${props => props.theme.newColor('neutral.500')}`
+      ${props => props.theme.color('neutral.500')}`
         : 'none'};
   }
 
@@ -121,7 +121,7 @@ const TableTr = styled.tr`
     border-top: ${props =>
       props.withBorder
         ? `1px dotted
-      ${props => props.theme.newColor('neutral.500')}`
+      ${props => props.theme.color('neutral.500')}`
         : 'none'};
   }
 `;
@@ -133,7 +133,7 @@ const TableTh = styled(Space).attrs({
 })`
   font-weight: bold;
   background: ${props =>
-    props.plain ? 'transparent' : props.theme.newColor('warmNeutral.400')};
+    props.plain ? 'transparent' : props.theme.color('warmNeutral.400')};
   white-space: nowrap;
 
   ${TableTbody}.has-row-headers & {

--- a/common/views/components/Tasl/Tasl.tsx
+++ b/common/views/components/Tasl/Tasl.tsx
@@ -54,7 +54,7 @@ const TaslIcon = styled.span.attrs({
 `;
 
 const InfoContainer = styled(Space)`
-  background-color: ${props => props.theme.newColor('black')};
+  background-color: ${props => props.theme.color('black')};
   padding-right: 36px;
 `;
 

--- a/common/views/components/TextInput/TextInput.tsx
+++ b/common/views/components/TextInput/TextInput.tsx
@@ -12,7 +12,7 @@ type TextInputWrapProps = {
 export const TextInputWrap = styled.div<TextInputWrapProps>`
   display: flex;
   position: relative;
-  border: 1px solid ${props => props.theme.newColor('warmNeutral.400')};
+  border: 1px solid ${props => props.theme.color('warmNeutral.400')};
   border-radius: 6px;
   font-size: ${props => (props.big ? '20px' : '16px')};
 
@@ -31,7 +31,7 @@ export const TextInputWrap = styled.div<TextInputWrapProps>`
   ${props =>
     props.hasErrorBorder &&
     `
-    box-shadow: 0 0 0 1px ${props.theme.newColor('validation.red')};
+    box-shadow: 0 0 0 1px ${props.theme.color('validation.red')};
   `}
 `;
 
@@ -61,7 +61,7 @@ export const TextInputLabel = styled.label<TextInputLabelProps>`
   transition: top 125ms ease-in, font-size 125ms ease-in,
     transform 125ms ease-in;
   pointer-events: none;
-  color: ${props => props.theme.newColor('neutral.600')};
+  color: ${props => props.theme.color('neutral.600')};
 
   ${props =>
     (!props.isEnhanced || props.hasValue) &&
@@ -91,7 +91,7 @@ export const TextInputInput = styled.input.attrs(props => ({
 
   &:focus {
     outline: 0;
-    border-color: ${props => props.theme.newColor('accent.turquoise')};
+    border-color: ${props => props.theme.color('accent.turquoise')};
   }
 
   &:-ms-clear {
@@ -103,7 +103,7 @@ export const TextInputInput = styled.input.attrs(props => ({
     `
       &,
       &:focus {
-        border-color: ${props.theme.newColor('validation.red')};
+        border-color: ${props.theme.color('validation.red')};
       }
     `}
 `;
@@ -127,7 +127,7 @@ export const TextInputErrorMessage = styled.span.attrs({
   font-size: 14px;
   margin-top: 10px;
   padding-left: 15px;
-  color: ${props => props.theme.newColor('validation.red')};
+  color: ${props => props.theme.color('validation.red')};
 `;
 
 type Props = {

--- a/common/views/components/ToolbarSegmentedControl/ToolbarSegmentedControl.tsx
+++ b/common/views/components/ToolbarSegmentedControl/ToolbarSegmentedControl.tsx
@@ -9,7 +9,7 @@ const List = styled.ul.attrs({
   className:
     'no-margin no-padding plain-list flex-inline flex--v-center flex--h-center',
 })`
-  border: 2px solid ${props => props.theme.newColor('neutral.600')};
+  border: 2px solid ${props => props.theme.color('neutral.600')};
   border-radius: 5px;
 `;
 
@@ -17,7 +17,7 @@ const Item = styled.li<{ isActive: boolean }>`
   ${props =>
     props.isActive &&
     `
-    background: ${props.theme.newColor('neutral.600')};
+    background: ${props.theme.color('neutral.600')};
   `}
 `;
 
@@ -38,7 +38,7 @@ const ButtonInner = styled(Space).attrs({
   },
   className: `flex flex--v-center flex--h-center ${font('intb', 5)}`,
 })<{ isActive: boolean }>`
-  color: ${props => props.theme.newColor('white')};
+  color: ${props => props.theme.color('white')};
 `;
 
 type Props = {

--- a/common/views/components/WatchLabel/WatchLabel.tsx
+++ b/common/views/components/WatchLabel/WatchLabel.tsx
@@ -11,7 +11,7 @@ const WatchIconWrapper = styled.div`
   align-items: center;
   width: 36px;
   height: 36px;
-  background: ${props => props.theme.newColor('yellow')};
+  background: ${props => props.theme.color('yellow')};
   border-radius: 50%;
 
   .icon {
@@ -23,7 +23,7 @@ const WatchText = styled(Space).attrs({
   v: { size: 's', properties: ['margin-left'] },
   className: font('intr', 6),
 })`
-  color: ${props => props.theme.newColor('neutral.600')};
+  color: ${props => props.theme.color('neutral.600')};
 `;
 
 type Props = {

--- a/common/views/components/WobblyEdge/WobblyEdge.tsx
+++ b/common/views/components/WobblyEdge/WobblyEdge.tsx
@@ -45,7 +45,7 @@ const Edge = styled.div.attrs({
     }
   `}
 
-  background: ${props => props.theme.newColor(props.background)};
+  background: ${props => props.theme.color(props.background)};
 
   ${props =>
     props.isRotated &&

--- a/common/views/components/WobblyEdgedContainer/WobblyEdgedContainer.tsx
+++ b/common/views/components/WobblyEdgedContainer/WobblyEdgedContainer.tsx
@@ -10,7 +10,7 @@ const WobblyEdgeContainer = styled.div`
 
 const Wrapper = styled.div`
   position: relative;
-  background-color: ${props => props.theme.newColor('warmNeutral.300')};
+  background-color: ${props => props.theme.color('warmNeutral.300')};
 `;
 
 type Props = {

--- a/common/views/components/WobblyRow/WobblyRow.tsx
+++ b/common/views/components/WobblyRow/WobblyRow.tsx
@@ -12,7 +12,7 @@ const WobblyRowContainer = styled.div.attrs({
   className: 'font-white',
 })`
   position: relative;
-  background-color: ${props => props.theme.newColor('neutral.700')};
+  background-color: ${props => props.theme.color('neutral.700')};
 `;
 
 const WobblyRowPattern = styled.div`

--- a/common/views/components/styled/LL.tsx
+++ b/common/views/components/styled/LL.tsx
@@ -25,7 +25,7 @@ const LL = styled.div<LLProps>`
     bottom: 0;
     width: ${props => (props.small ? '10px' : '20px')};
     background: ${props =>
-      props.theme.newColor(props.lighten ? 'neutral.500' : 'black')};
+      props.theme.color(props.lighten ? 'neutral.500' : 'black')};
   }
 
   &:before {

--- a/common/views/themes/base/container.ts
+++ b/common/views/themes/base/container.ts
@@ -36,15 +36,15 @@ export const container = `
 
     &::-webkit-scrollbar {
       height: 18px;
-      background: ${themeValues.newColor('white')};
+      background: ${themeValues.color('white')};
     }
 
     &::-webkit-scrollbar-thumb {
       border-radius: 0;
       border-style: solid;
-      border-color: ${themeValues.newColor('white')};
+      border-color: ${themeValues.color('white')};
       border-width: 0 ${themeValues.containerPadding.small}px 12px;
-      background: ${themeValues.newColor('neutral.400')};
+      background: ${themeValues.color('neutral.400')};
 
       @include respond-to('medium') {
         border-left-width: ${themeValues.containerPadding.medium}px;

--- a/common/views/themes/base/row.ts
+++ b/common/views/themes/base/row.ts
@@ -14,7 +14,7 @@ export const row = `
   right: 0;
   height: 15%;
   transition: height 600ms ease;
-  background: ${themeValues.newColor('white')};
+  background: ${themeValues.color('white')};
 
   &:after {
     position: absolute;

--- a/common/views/themes/base/wellcome-normalize.ts
+++ b/common/views/themes/base/wellcome-normalize.ts
@@ -13,7 +13,7 @@ fieldset {
 }
 
 .openseadragon-canvas:focus {
-  border: 2px solid ${themeValues.newColor('yellow')}!important;
+  border: 2px solid ${themeValues.color('yellow')}!important;
   border-width: 2px 2px 0;
 }
 

--- a/common/views/themes/config.ts
+++ b/common/views/themes/config.ts
@@ -84,7 +84,7 @@ export const spacingUnits = {
 };
 
 // suggested new colors
-const newColors = {
+const colors = {
   // Core
   // Wrap in core? Looks better for lightYellow but worse for the others...
   white: '#ffffff',
@@ -123,12 +123,12 @@ const newColors = {
   'validation.green': '#0b7051',
 };
 
-const getNewColor = (name: NewPaletteColor): string => {
+const getColor = (name: PaletteColor): string => {
   // In some cases, these get passed in, see ButtonColors for example.
   // But better not to use it if possible.
   if (['currentColor', 'transparent', 'inherit'].includes(name)) return name;
 
-  return newColors[name];
+  return colors[name];
 };
 
 export const sizes = {
@@ -250,8 +250,8 @@ export const themeValues = {
   navHeight: 85,
   fontVerticalOffset: '0.15em',
   grid,
-  newColors,
-  newColor: getNewColor,
+  colors,
+  color: getColor,
   minCardHeight: 385,
   buttonColors: {
     default: defaultButtonColors,
@@ -266,8 +266,8 @@ export const themeValues = {
 
 export type Breakpoint = keyof typeof sizes;
 
-export type NewPaletteColor =
-  | keyof typeof newColors
+export type PaletteColor =
+  | keyof typeof colors
   | 'transparent'
   | 'inherit'
   | 'currentColor';

--- a/common/views/themes/typography.ts
+++ b/common/views/themes/typography.ts
@@ -122,7 +122,7 @@ export const typography = css<GlobalStyleProps>`
     ${fontFamilyMixin('intr', true)}
     ${fontSizeMixin(4)}
     line-height: 1.5;
-    color: ${themeValues.newColor('black')};
+    color: ${themeValues.color('black')};
     font-variant-ligatures: no-common-ligatures;
     -webkit-font-smoothing: antialiased;
     -moz-font-smoothing: antialiased;
@@ -189,7 +189,7 @@ export const typography = css<GlobalStyleProps>`
   }
 
   .more-link {
-    color: ${themeValues.newColor('accent.green')};
+    color: ${themeValues.color('accent.green')};
     text-decoration: none;
 
     &:hover,
@@ -245,7 +245,7 @@ export const typography = css<GlobalStyleProps>`
     }
 
     *::selection {
-      background: ${themeValues.newColor('accent.turquoise')}4d;
+      background: ${themeValues.color('accent.turquoise')}4d;
     }
 
     ul {
@@ -276,7 +276,7 @@ export const typography = css<GlobalStyleProps>`
       transition: color ${themeValues.transitionProperties};
 
       &:hover {
-        color: ${themeValues.newColor('accent.green')};
+        color: ${themeValues.color('accent.green')};
         text-decoration-color: transparent;
       }
     }
@@ -290,7 +290,7 @@ export const typography = css<GlobalStyleProps>`
   .drop-cap {
     ${fontFamilyMixin('wb', true)}
     font-size: 3em;
-    color: ${themeValues.newColor('black')};
+    color: ${themeValues.color('black')};
     float: left;
     line-height: 1em;
     padding-right: 0.1em;
@@ -299,7 +299,7 @@ export const typography = css<GlobalStyleProps>`
   }
 
   .quote {
-    border-left: 12px solid ${themeValues.newColor('warmNeutral.400')};
+    border-left: 12px solid ${themeValues.color('warmNeutral.400')};
     padding-left: 0.9em;
 
     p {
@@ -321,7 +321,7 @@ export const typography = css<GlobalStyleProps>`
       ${fontFamilyMixin('wb', true)}
       position: absolute;
       content: '“';
-      color: ${themeValues.newColor('accent.blue')};
+      color: ${themeValues.color('accent.blue')};
       left: -14px;
       top: 0.12em;
       font-size: 2em;

--- a/common/views/themes/utility-classes.ts
+++ b/common/views/themes/utility-classes.ts
@@ -4,7 +4,7 @@ import { GlobalStyleProps } from './default';
 import { respondTo, respondBetween, visuallyHidden } from './mixins';
 
 export const utilityClasses = css<GlobalStyleProps>`
-  ${Object.entries(themeValues.newColors)
+  ${Object.entries(themeValues.colors)
     .map(([key, value]) => {
       if (!key.includes('.')) {
         return `
@@ -296,12 +296,12 @@ export const utilityClasses = css<GlobalStyleProps>`
 
   .promo-link {
     height: 100%;
-    color: ${themeValues.newColor('black')};
+    color: ${themeValues.color('black')};
 
     &:hover .promo-link__title,
     &:focus .promo-link__title {
       text-decoration: underline;
-      text-decoration-color: ${themeValues.newColor('black')};
+      text-decoration-color: ${themeValues.color('black')};
     }
   }
 
@@ -386,7 +386,7 @@ export const utilityClasses = css<GlobalStyleProps>`
     &:focus {
       .card-link__title {
         text-decoration: underline;
-        text-decoration-color: ${themeValues.newColor('black')};
+        text-decoration-color: ${themeValues.color('black')};
       }
     }
   }
@@ -399,7 +399,7 @@ export const utilityClasses = css<GlobalStyleProps>`
   }
 
   noscript {
-    background: ${themeValues.newColor('white')};
-    color: ${themeValues.newColor('black')};
+    background: ${themeValues.color('white')};
+    color: ${themeValues.color('black')};
   }
 `;

--- a/content/webapp/components/BannerCard/BannerCard.tsx
+++ b/content/webapp/components/BannerCard/BannerCard.tsx
@@ -22,9 +22,9 @@ const CardOuter = styled.a<CardOuterProps>`
   flex-direction: column-reverse;
   overflow: hidden;
   text-decoration: none;
-  background: ${props => props.theme.newColor(props.background)};
+  background: ${props => props.theme.color(props.background)};
   color: ${props =>
-    props.theme.newColor(
+    props.theme.color(
       props.background === 'neutral.700' ? 'warmNeutral.300' : 'black'
     )};
 
@@ -41,7 +41,7 @@ const TextWrapper = styled.div<TextWrapperProps>`
   ${props => props.theme.media.large`
     flex-grow: 2;
     `};
-  border-left: 4px solid ${props => props.theme.newColor(props.highlightColor)};
+  border-left: 4px solid ${props => props.theme.color(props.highlightColor)};
 `;
 
 type ImageWrapperProps = {

--- a/content/webapp/components/Body/Body.tsx
+++ b/content/webapp/components/Body/Body.tsx
@@ -101,7 +101,7 @@ const Wrapper = styled(Space).attrs<{
   bg-${props.rowBackgroundColor}
     card-theme--${props.cardBackgroundColor}`, // Keeping bg-[color] class as some components below are styled based on this parent class.
 }))<{ rowBackgroundColor: string; cardBackgroundColor: string }>`
-  background-color: ${props => props.theme.newColor(props.rowBackgroundColor)};
+  background-color: ${props => props.theme.color(props.rowBackgroundColor)};
 `;
 
 const Body: FunctionComponent<Props> = ({

--- a/content/webapp/components/BookImage/BookImage.tsx
+++ b/content/webapp/components/BookImage/BookImage.tsx
@@ -9,7 +9,7 @@ import { ImageType } from '@weco/common/model/image';
 
 const BookPromoImageContainer = styled.div`
   position: relative;
-  background-color: ${props => props.theme.newColor('warmNeutral.300')};
+  background-color: ${props => props.theme.color('warmNeutral.300')};
   height: 0;
   padding-top: 100%;
   transform: rotate(-2deg);

--- a/content/webapp/components/Card/Card.tsx
+++ b/content/webapp/components/Card/Card.tsx
@@ -19,11 +19,11 @@ export const CardOuter = styled.a.attrs<{ className?: string }>(() => ({
   overflow: hidden;
   flex-direction: column;
 
-  background: ${props => props.theme.newColor('warmNeutral.300')};
+  background: ${props => props.theme.color('warmNeutral.300')};
   min-height: ${props => props.theme.minCardHeight}px;
 
   .card-theme.card-theme--white & {
-    background: ${props => props.theme.newColor('white')};
+    background: ${props => props.theme.color('white')};
   }
 
   .card-theme.card-theme--transparent & {
@@ -32,7 +32,7 @@ export const CardOuter = styled.a.attrs<{ className?: string }>(() => ({
   }
 
   .card-theme.bg-neutral-700 & {
-    color: ${props => props.theme.newColor('white')};
+    color: ${props => props.theme.color('white')};
   }
 `;
 

--- a/content/webapp/components/ContentPage/ContentPage.tsx
+++ b/content/webapp/components/ContentPage/ContentPage.tsx
@@ -60,13 +60,13 @@ const Wrapper = styled.div<{ isCreamy: boolean }>`
   overflow: auto;
   ${props =>
     props.isCreamy &&
-    `background-color: ${props.theme.newColor('warmNeutral.300')}`};
+    `background-color: ${props.theme.color('warmNeutral.300')}`};
 `;
 
 const ShameBorder = styled(Space).attrs({
   v: { size: 'l', properties: ['margin-top'] },
 })`
-  border-bottom: 1px solid ${props => props.theme.newColor('warmNeutral.400')};
+  border-bottom: 1px solid ${props => props.theme.color('warmNeutral.400')};
 `;
 // FIXME: obviously we can't carry on like this!
 const ShameWhatWeDoHack = () => (

--- a/content/webapp/components/EventSchedule/EventScheduleItem.tsx
+++ b/content/webapp/components/EventSchedule/EventScheduleItem.tsx
@@ -22,7 +22,7 @@ const GridWrapper = styled(Space).attrs({
     properties: ['margin-bottom', 'padding-bottom'],
   },
 })`
-  border-bottom: 1px solid ${props => props.theme.newColor('neutral.300')};
+  border-bottom: 1px solid ${props => props.theme.color('neutral.300')};
 `;
 
 const EventContainer = styled(Space).attrs({
@@ -42,7 +42,7 @@ const EventContainer = styled(Space).attrs({
   className: font('intb', 5),
 })`
   display: inline-block;
-  background-color: ${props => props.theme.newColor('yellow')};
+  background-color: ${props => props.theme.color('yellow')};
 `;
 
 const EventScheduleItem: FC<Props> = ({ event, isNotLinked }) => {

--- a/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
+++ b/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
@@ -43,7 +43,7 @@ const StandaloneTitle = styled(Space).attrs({
   position: relative;
 
   background: ${props =>
-    props.theme.newColor(getTypeColor('captions-and-transcripts'))};
+    props.theme.color(getTypeColor('captions-and-transcripts'))};
 `;
 
 const ContextTitle = styled(Space).attrs<{ level: number }>(props => ({
@@ -65,7 +65,7 @@ const ContextContainer = styled(Space).attrs<{ hasPadding: boolean }>(
       : null,
   })
 )<{ backgroundColor: string; hasPadding: boolean }>`
-  background: ${props => props.theme.newColor(props.backgroundColor)};
+  background: ${props => props.theme.color(props.backgroundColor)};
 `;
 
 const TombstoneTitle = styled(Space).attrs<{ level: number }>(props => ({
@@ -113,7 +113,7 @@ const Caption = styled(Space).attrs({
   className: `spaced-text ${font('intr', 5)}`,
   h: { size: 'm', properties: ['padding-left', 'padding-right'] },
 })`
-  border-left: 20px solid ${props => props.theme.newColor('yellow')};
+  border-left: 20px solid ${props => props.theme.color('yellow')};
 `;
 
 const PrismicImageWrapper = styled.div`
@@ -125,7 +125,7 @@ const Transcription = styled(Space).attrs({
   h: { size: 'm', properties: ['padding-left', 'padding-right'] },
   v: { size: 'l', properties: ['margin-top'] },
 })`
-  border-left: 20px solid ${props => props.theme.newColor('accent.lightBlue')};
+  border-left: 20px solid ${props => props.theme.color('accent.lightBlue')};
 `;
 
 type Stop = {

--- a/content/webapp/components/FeaturedCard/FeaturedCard.tsx
+++ b/content/webapp/components/FeaturedCard/FeaturedCard.tsx
@@ -218,7 +218,7 @@ const FeaturedCardCopy = styled(Space).attrs<{ color: string }>(props => ({
   className: classNames({ [`font-${props.color}`]: true }),
 }))<{ background: string }>`
   flex: 1;
-  background-color: ${props => props.theme.newColor(props.background)};
+  background-color: ${props => props.theme.color(props.background)};
 
   ${props => props.theme.media.large`
     margin-right: -${props => props.theme.gutter.large}px;
@@ -229,7 +229,7 @@ const FeaturedCardShim = styled.div.attrs<{ background: string }>({
   className: `is-hidden-s is-hidden-m ${grid({ s: 12, m: 11, l: 5, xl: 5 })}`,
 })<HasIsReversed & { background: string }>`
   position: relative;
-  background-color: ${props => props.theme.newColor(props.background)};
+  background-color: ${props => props.theme.color(props.background)};
   height: 21px;
   /* Prevent a white line appearing above the shim because of browser rounding errors */
   top: -1px;

--- a/content/webapp/components/GifVideo/GifVideo.tsx
+++ b/content/webapp/components/GifVideo/GifVideo.tsx
@@ -35,10 +35,10 @@ const Text = styled.span.attrs({
   className: font('lr', 5),
 })<{ isPlaying: boolean }>`
   display: block;
-  background: ${props => props.theme.newColor('neutral.700')};
+  background: ${props => props.theme.color('neutral.700')};
   padding: 6px;
   border-radius: ${props => props.theme.borderRadiusUnit}px;
-  color: ${props => props.theme.newColor('white')};
+  color: ${props => props.theme.color('white')};
 
   &:before {
     content: '${props => (props.isPlaying ? 'pause' : 'play')}';

--- a/content/webapp/components/ImageGallery/ImageGallery.tsx
+++ b/content/webapp/components/ImageGallery/ImageGallery.tsx
@@ -70,22 +70,22 @@ const Gallery = styled.div.attrs({
       display: inherit;
     }
 
-    color: ${props.theme.newColor('white')};
+    color: ${props.theme.color('white')};
     background: linear-gradient(
-      ${props.theme.newColor(props.pageBackground)} 100px,
-      ${props.theme.newColor('neutral.700')} 100px
+      ${props.theme.color(props.pageBackground)} 100px,
+      ${props.theme.color('neutral.700')} 100px
     );
 
     @media (min-width: ${props.theme.sizes.medium}px) {
       background: linear-gradient(
-        ${props.theme.newColor(props.pageBackground)} 200px,
-        ${props.theme.newColor('neutral.700')} 200px
+        ${props.theme.color(props.pageBackground)} 200px,
+        ${props.theme.color('neutral.700')} 200px
       );
 
       ${
         props.isStandalone &&
         `
-        background: ${props.theme.newColor('neutral.700')};
+        background: ${props.theme.color('neutral.700')};
       `
       }
     }
@@ -96,7 +96,7 @@ const Gallery = styled.div.attrs({
   ${props =>
     props.isStandalone &&
     `
-    background: ${props.theme.newColor('neutral.700')};
+    background: ${props.theme.color('neutral.700')};
 
     &:before {
       top: 0;

--- a/content/webapp/components/ImagePlaceholder/ImagePlaceholder.tsx
+++ b/content/webapp/components/ImagePlaceholder/ImagePlaceholder.tsx
@@ -7,7 +7,7 @@ const Wrapper = styled.div<{
   color: ColorSelection | undefined;
 }>`
   position: relative;
-  background: ${props => props.theme.newColor(props.color)};
+  background: ${props => props.theme.color(props.color)};
 `;
 
 const Pattern = styled.div`

--- a/content/webapp/components/InfoBox/InfoBox.tsx
+++ b/content/webapp/components/InfoBox/InfoBox.tsx
@@ -21,7 +21,7 @@ const InfoContainer = styled(Space).attrs({
   v: { size: 'l', properties: ['padding-top', 'padding-bottom'] },
   h: { size: 'l', properties: ['padding-left', 'padding-right'] },
 })`
-  background-color: ${props => props.theme.newColor('yellow')};
+  background-color: ${props => props.theme.color('yellow')};
 `;
 
 const InfoBox: FC<Props> = ({ title, items, children }) => {

--- a/content/webapp/components/NewsletterSignup/NewsletterSignup.tsx
+++ b/content/webapp/components/NewsletterSignup/NewsletterSignup.tsx
@@ -20,8 +20,8 @@ const ErrorBox = styled(Space).attrs({
   },
   h: { size: 'm', properties: ['padding-left', 'padding-right'] },
 })`
-  border: 1px solid ${props => props.theme.newColor('validation.red')};
-  color: ${props => props.theme.newColor('validation.red')};
+  border: 1px solid ${props => props.theme.color('validation.red')};
+  color: ${props => props.theme.color('validation.red')};
 `;
 
 type Props = {

--- a/content/webapp/components/OnThisPageAnchors/OnThisPageAnchors.tsx
+++ b/content/webapp/components/OnThisPageAnchors/OnThisPageAnchors.tsx
@@ -7,7 +7,7 @@ import { FunctionComponent, ReactElement } from 'react';
 const Anchor = styled.a.attrs(() => ({
   className: font('intb', 5),
 }))`
-  color: ${props => props.theme.newColor('accent.green')};
+  color: ${props => props.theme.color('accent.green')};
 `;
 
 type Props = {

--- a/content/webapp/components/SearchResults/SearchResults.tsx
+++ b/content/webapp/components/SearchResults/SearchResults.tsx
@@ -14,7 +14,7 @@ import { getCrop } from '@weco/common/model/image';
 import { Card } from '../../types/card';
 
 const Result = styled.div`
-  border-top: 1px solid ${props => props.theme.newColor('warmNeutral.400')};
+  border-top: 1px solid ${props => props.theme.color('warmNeutral.400')};
 `;
 
 export type Props = {

--- a/content/webapp/components/SeasonsHeader/SeasonsHeader.tsx
+++ b/content/webapp/components/SeasonsHeader/SeasonsHeader.tsx
@@ -12,11 +12,11 @@ import * as prismicT from '@prismicio/types';
 import DateRange from '@weco/common/views/components/DateRange/DateRange';
 
 const HeaderWrapper = styled.div`
-  background: ${props => props.theme.newColor('neutral.700')};
-  color: ${props => props.theme.newColor('white')};
+  background: ${props => props.theme.color('neutral.700')};
+  color: ${props => props.theme.color('white')};
 `;
 const TextWrapper = styled.div`
-  border-left: 1px solid ${props => props.theme.newColor('accent.salmon')};
+  border-left: 1px solid ${props => props.theme.color('accent.salmon')};
 `;
 
 type Props = {

--- a/content/webapp/components/TitledTextList/TitledTextList.tsx
+++ b/content/webapp/components/TitledTextList/TitledTextList.tsx
@@ -12,7 +12,7 @@ const HeadingLink = styled.a.attrs({
 })`
   cursor: pointer;
   text-decoration: underline;
-  color: ${props => props.theme.newColor('accent.green')};
+  color: ${props => props.theme.color('accent.green')};
 `;
 
 const TextContainer = styled.div`

--- a/content/webapp/components/VenueHours/VenueHours.tsx
+++ b/content/webapp/components/VenueHours/VenueHours.tsx
@@ -49,7 +49,7 @@ type JauntyBoxProps = {
 };
 const JauntyBox = styled(Space)<JauntyBoxProps>`
   display: inline-block;
-  background-color: ${props => props.theme.newColor('yellow')};
+  background-color: ${props => props.theme.color('yellow')};
   padding-left: 30px;
   padding-right: 42px;
   margin-left: -12px;

--- a/content/webapp/pages/book.tsx
+++ b/content/webapp/pages/book.tsx
@@ -21,7 +21,7 @@ import { looksLikePrismicId } from '@weco/common/services/prismic';
 import Layout8 from '@weco/common/views/components/Layout8/Layout8';
 
 const MetadataWrapper = styled.div`
-  border-top: 1px solid ${props => props.theme.newColor('neutral.300')};
+  border-top: 1px solid ${props => props.theme.color('neutral.300')};
 `;
 
 type Props = {

--- a/content/webapp/pages/event.tsx
+++ b/content/webapp/pages/event.tsx
@@ -67,13 +67,13 @@ const TimeWrapper = styled(Space).attrs({
 })`
   display: flex;
   justify-content: space-between;
-  border-top: 1px solid ${props => props.theme.newColor('warmNeutral.400')};
+  border-top: 1px solid ${props => props.theme.color('warmNeutral.400')};
 `;
 
 const DateWrapper = styled.div.attrs({
   className: 'body-text',
 })`
-  border-bottom: 1px solid ${props => props.theme.newColor('warmNeutral.400')};
+  border-bottom: 1px solid ${props => props.theme.color('warmNeutral.400')};
 `;
 
 type Props = {

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -54,14 +54,14 @@ import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/Pri
 import { dasherizeShorten } from '@weco/common/utils/grammar';
 
 const PromoContainer = styled.div`
-  background: ${props => props.theme.newColor('warmNeutral.300')};
+  background: ${props => props.theme.color('warmNeutral.300')};
 `;
 
 const Stop = styled(Space).attrs({
   v: { size: 'm', properties: ['padding-top', 'padding-bottom'] },
   h: { size: 'm', properties: ['padding-left', 'padding-right'] },
 })`
-  background: ${props => props.theme.newColor('warmNeutral.300')};
+  background: ${props => props.theme.color('warmNeutral.300')};
   height: 100%;
 `;
 
@@ -93,11 +93,11 @@ const TypeLink = styled.a`
   height: 100%;
   width: 100%;
   text-decoration: none;
-  background: ${props => props.theme.newColor(props.color)};
+  background: ${props => props.theme.color(props.color)};
 
   &:hover,
   &:focus {
-    background: ${props => props.theme.newColor('neutral.400')};
+    background: ${props => props.theme.color('neutral.400')};
   }
 `;
 
@@ -142,7 +142,7 @@ const Header = styled(Space).attrs({
     properties: ['padding-top', 'padding-bottom', 'margin-bottom'],
   },
 })`
-  background: ${props => props.theme.newColor(props.color)};
+  background: ${props => props.theme.color(props.color)};
 `;
 
 const typeNames = [

--- a/content/webapp/pages/homepage.tsx
+++ b/content/webapp/pages/homepage.tsx
@@ -50,7 +50,7 @@ const CreamBox = styled(Space).attrs({
   h: { size: 'l', properties: ['padding-left', 'padding-right'] },
   v: { size: 'l', properties: ['padding-top', 'padding-bottom'] },
 })`
-  background: ${props => props.theme.newColor('warmNeutral.300')};
+  background: ${props => props.theme.color('warmNeutral.300')};
 `;
 
 type Props = {

--- a/content/webapp/pages/stories.tsx
+++ b/content/webapp/pages/stories.tsx
@@ -72,18 +72,18 @@ type Props = {
 };
 
 const ArticlesContainer = styled.div`
-  background-color: ${props => props.theme.newColor('warmNeutral.300')};
+  background-color: ${props => props.theme.color('warmNeutral.300')};
 `;
 
 const StoryPromoContainer = styled.div.attrs({
   className: 'container container--scroll touch-scroll',
 })`
   &::-webkit-scrollbar {
-    background: ${props => props.theme.newColor('warmNeutral.300')};
+    background: ${props => props.theme.color('warmNeutral.300')};
   }
 
   &::-webkit-scrollbar-thumb {
-    border-color: ${props => props.theme.newColor('warmNeutral.300')};
+    border-color: ${props => props.theme.color('warmNeutral.300')};
   }
 `;
 

--- a/identity/webapp/src/frontend/MyAccount/MyAccount.style.ts
+++ b/identity/webapp/src/frontend/MyAccount/MyAccount.style.ts
@@ -4,7 +4,7 @@ import Space from '@weco/common/views/components/styled/Space';
 export const ProgressBar = styled(Space).attrs({
   v: { size: 'm', properties: ['margin-bottom'] },
 })`
-  background-color: ${props => props.theme.newColor('white')};
+  background-color: ${props => props.theme.color('white')};
   border-radius: 7px; /* (height of inner div) / 2 + padding */
   border: 2px solid black;
   width: 300px;
@@ -12,7 +12,7 @@ export const ProgressBar = styled(Space).attrs({
 `;
 
 export const ProgressIndicator = styled.div<{ percentage: number }>`
-  background-color: ${props => props.theme.newColor('black')};
+  background-color: ${props => props.theme.color('black')};
   width: ${props => `${props.percentage}%`};
   height: 10px;
 `;
@@ -66,7 +66,7 @@ const colours = {
   success: css`
     background-color: rgba(0, 120, 108, 0.1);
     border: 1px solid rgba(0, 120, 108, 0.3);
-    color: ${props => props.theme.newColor('black')};
+    color: ${props => props.theme.color('black')};
   `,
   failure: css`
     background-color: rgba(224, 27, 47, 0.1);
@@ -94,7 +94,7 @@ export const StatusAlert = styled(Space).attrs({
 `;
 
 export const Section = styled.section`
-  border-top: 1px solid ${props => props.theme.newColor('warmNeutral.400')};
+  border-top: 1px solid ${props => props.theme.color('warmNeutral.400')};
   display: grid;
   grid-template-columns: 1fr;
   grid-gap: 1em;

--- a/identity/webapp/src/frontend/Registration/Registration.style.ts
+++ b/identity/webapp/src/frontend/Registration/Registration.style.ts
@@ -31,14 +31,14 @@ export const ErrorAlert = styled(AlertBox)`
 
 export const SuccessMessage = styled(AlertBox)`
   background-color: rgba(0, 120, 108, 0.1);
-  color: ${props => props.theme.newColor('validation.green')};
+  color: ${props => props.theme.color('validation.green')};
 `;
 
 export const HighlightMessage = styled(Space).attrs({
   as: 'p',
   h: { size: 'm', properties: ['padding-left'] },
 })`
-  border-left: 13px solid ${props => props.theme.newColor('yellow')};
+  border-left: 13px solid ${props => props.theme.color('yellow')};
 `;
 
 export const Checkbox = styled(CheckboxRadio).attrs({ type: 'checkbox' })``;
@@ -83,7 +83,7 @@ export const Cancel = styled.button.attrs({
 export const YellowBorder = styled(Space).attrs({
   h: { size: 's', properties: ['padding-left'] },
 })`
-  border-left: 10px solid ${props => props.theme.newColor('yellow')};
+  border-left: 10px solid ${props => props.theme.color('yellow')};
 `;
 
 export const FullWidthButton = styled.div`

--- a/identity/webapp/src/frontend/components/Layout.style.ts
+++ b/identity/webapp/src/frontend/components/Layout.style.ts
@@ -6,7 +6,7 @@ export const Container = styled(Space).attrs({
   v: { size: 'xl', properties: ['margin-bottom'] },
 })`
   background-color: white;
-  border: 1px solid ${props => props.theme.newColor('warmNeutral.400')};
+  border: 1px solid ${props => props.theme.color('warmNeutral.400')};
   border-radius: 10px;
 `;
 
@@ -28,7 +28,7 @@ export const Wrapper = styled(Space).attrs<WrapperProps>(props => ({
 `;
 
 export const Header = styled(Space)`
-  background: ${props => props.theme.newColor('white')};
+  background: ${props => props.theme.color('white')};
 `;
 
 export const Title = styled.h1.attrs({ className: font('wb', 0) })``;

--- a/identity/webapp/src/frontend/components/PageWrapper.tsx
+++ b/identity/webapp/src/frontend/components/PageWrapper.tsx
@@ -8,7 +8,7 @@ import Favicons from '@weco/common/views/components/Favicons/Favicons';
 
 const Main = styled.div`
   @media (min-width: ${props => props.theme.sizes.medium}px) {
-    background: ${props => props.theme.newColor('warmNeutral.300')};
+    background: ${props => props.theme.color('warmNeutral.300')};
     min-height: calc(100vh - ${props => props.theme.navHeight}px);
   }
 `;

--- a/identity/webapp/src/frontend/components/PasswordInput/PasswordInput.style.ts
+++ b/identity/webapp/src/frontend/components/PasswordInput/PasswordInput.style.ts
@@ -14,7 +14,7 @@ export const RulesListWrapper = styled(Space).attrs({
   v: { size: 'm', properties: ['padding-top', 'padding-bottom'] },
   className: font('intr', 5),
 })`
-  border: 1px solid ${props => props.theme.newColor('neutral.300')};
+  border: 1px solid ${props => props.theme.color('neutral.300')};
   border-radius: ${props => props.theme.borderRadiusUnit}px;
 `;
 

--- a/identity/webapp/src/frontend/components/PasswordInput/PasswordRules.tsx
+++ b/identity/webapp/src/frontend/components/PasswordInput/PasswordRules.tsx
@@ -20,9 +20,9 @@ const RuleDot = styled.span<DotProps>`
   width: 1em;
   height: 1em;
   border-radius: 50%;
-  border: 1px solid ${props => props.theme.newColor('neutral.300')};
+  border: 1px solid ${props => props.theme.color('neutral.300')};
   background: ${props =>
-    props.theme.newColor(props.isValid ? 'accent.green' : 'white')};
+    props.theme.color(props.isValid ? 'accent.green' : 'white')};
 
   .icon {
     transform: scale(0.8);


### PR DESCRIPTION
## Who is this for?
Devs

## What is it doing for them?
`newColor` already doesn't make sense to use, it was quicker than expected to merge the work in and work out the kinks. Its use was to help figure out what other work might need updating but nothing was newly merged in, so I want to revert to using `color()`, `colors` and `PaletteColor`