### PR TITLE
Fix: adjust font size for transcriptions to make them the same as captions

### DIFF
--- a/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
+++ b/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
@@ -121,7 +121,7 @@ const PrismicImageWrapper = styled.div`
 `;
 
 const Transcription = styled(Space).attrs({
-  className: 'spaced-text',
+  className: `spaced-text ${font('intr', 5)}`,
   h: { size: 'm', properties: ['padding-left', 'padding-right'] },
   v: { size: 'l', properties: ['margin-top'] },
 })`

--- a/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
+++ b/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
@@ -110,7 +110,7 @@ const CaptionTranscription = styled.div.attrs({
 `;
 
 const Caption = styled(Space).attrs({
-  className: `spaced-text ${font('intr', 5)}`,
+  className: `spaced-text ${font('intr', 4)}`,
   h: { size: 'm', properties: ['padding-left', 'padding-right'] },
 })`
   border-left: 20px solid ${props => props.theme.newColor('yellow')};
@@ -121,7 +121,7 @@ const PrismicImageWrapper = styled.div`
 `;
 
 const Transcription = styled(Space).attrs({
-  className: `spaced-text ${font('intr', 5)}`,
+  className: 'spaced-text',
   h: { size: 'm', properties: ['padding-left', 'padding-right'] },
   v: { size: 'l', properties: ['margin-top'] },
 })`


### PR DESCRIPTION
## Who is this for?

All exhibition guide users. For https://github.com/wellcomecollection/wellcomecollection.org/issues/8480

## What is it doing for them?

Changing font size to make sure transcripts and captions have the same font size on desktop and mobile. 

before:
![Screenshot 2022-09-27 at 13 59 30](https://user-images.githubusercontent.com/16557524/192533190-200b3944-8510-492d-9e35-a43a0fd4f804.png)

after: 
![Screenshot 2022-09-27 at 13 59 41](https://user-images.githubusercontent.com/16557524/192533136-bb3055fd-efc5-4fef-b55c-9da0b54279be.png)

