### PR TITLE
Make sure the StatusIndicator component uses London date comparisons, not UTC

### DIFF
--- a/common/utils/dates.ts
+++ b/common/utils/dates.ts
@@ -1,7 +1,15 @@
 import { DateRange } from '../model/date-range';
 import { formatDayDate } from './format-date';
 
-// This is just to allow us to mock values in tests
+// This is to allow us to mock values in tests, e.g.
+//
+//    import * as dateUtils from '@weco/common/utils/dates';
+//
+//    const spyOnToday = jest.spyOn(dateUtils, 'today');
+//    spyOnToday.mockImplementation(() =>
+//      new Date('2022-09-19T00:00:00Z')
+//    );
+//
 export function today(): Date {
   return new Date();
 }

--- a/content/webapp/components/StatusIndicator/StatusIndicator.test.tsx
+++ b/content/webapp/components/StatusIndicator/StatusIndicator.test.tsx
@@ -1,4 +1,5 @@
 import { formatDateRangeWithMessage } from './StatusIndicator';
+import * as dateUtils from '@weco/common/utils/dates';
 
 describe('formatDateRangeWithMessage', () => {
   it('formats a range that hasn’t started yet', () => {
@@ -58,7 +59,32 @@ describe('formatDateRangeWithMessage', () => {
       expect(result).toEqual({ text: 'Final week', color: 'accent.salmon' });
     });
 
+    it('says "Final week" if the last day is today in London, if not UTC', () => {
+      // These are the dates for the "In the Air" exhibition, as entered
+      // in Prismic.  The first day the public could see it was on
+      // Thursday 19 May, and the last day is Sunday 16 October.
+      //
+      // Somebody looking at the website on noon on Sunday should see it as
+      // still open.
+      const spyOnToday = jest.spyOn(dateUtils, 'today');
+      spyOnToday.mockImplementation(
+        () => new Date('2022-10-16T12:00:00.000+0100')
+      );
+
+      const inTheAir = {
+        start: new Date('2022-05-19T00:00:00.000+0100'),
+        end: new Date('2022-10-16T00:00:00.000+0100'),
+      };
+
+      const result = formatDateRangeWithMessage(inTheAir);
+
+      expect(result).toEqual({ text: 'Final week', color: 'accent.salmon' });
+    });
+
     it('says "Final week" if the last day is tomorrow', () => {
+      const spyOnToday = jest.spyOn(dateUtils, 'today');
+      spyOnToday.mockImplementation(() => new Date());
+
       const end = new Date();
       end.setDate(end.getDate() + 1);
       const tomorrow = new Date(end);

--- a/content/webapp/components/StatusIndicator/StatusIndicator.test.tsx
+++ b/content/webapp/components/StatusIndicator/StatusIndicator.test.tsx
@@ -47,7 +47,7 @@ describe('formatDateRangeWithMessage', () => {
     });
   });
 
-  describe('formats an event in its final week', () => {
+  describe('formats an event that is close to ending', () => {
     it('says "Final week" if the last day is today', () => {
       const today = new Date();
 
@@ -138,5 +138,30 @@ describe('formatDateRangeWithMessage', () => {
     });
 
     expect(result).toEqual({ text: 'Now on', color: 'validation.green' });
+  });
+
+  it('says "Coming soon" if the first day is today in UTC, but not in London', () => {
+    // These are the dates for the "In the Air" exhibition, as entered
+    // in Prismic.  The first day the public could see it was on
+    // Thursday 19 May, and the last day is Sunday 16 October.
+    //
+    // Somebody looking at the website on noon on Wednesday should see it
+    // as not yet open.
+    const wednesday = new Date('2022-05-18T12:00:00.000+0100');
+
+    const spyOnToday = jest.spyOn(dateUtils, 'today');
+    spyOnToday.mockImplementation(() => wednesday);
+
+    const spyOnIsFuture = jest.spyOn(dateUtils, 'isFuture');
+    spyOnIsFuture.mockImplementation(d => wednesday < d);
+
+    const inTheAir = {
+      start: new Date('2022-05-19T00:00:00.000+0100'),
+      end: new Date('2022-10-16T00:00:00.000+0100'),
+    };
+
+    const result = formatDateRangeWithMessage(inTheAir);
+
+    expect(result).toEqual({ text: 'Coming soon', color: 'neutral.500' });
   });
 });

--- a/content/webapp/components/StatusIndicator/StatusIndicator.tsx
+++ b/content/webapp/components/StatusIndicator/StatusIndicator.tsx
@@ -25,7 +25,7 @@ export function formatDateRangeWithMessage({
 }): { text: string; color: string } {
   const sevenDaysTime = addDays(today(), 7);
 
-  const opensToday = isSameDay(start, today());
+  const opensToday = isSameDay(start, today(), 'London');
   const closesToday = isSameDay(end, today(), 'London');
   const closesInSevenDays = today() < end && end < sevenDaysTime;
 

--- a/content/webapp/components/StatusIndicator/StatusIndicator.tsx
+++ b/content/webapp/components/StatusIndicator/StatusIndicator.tsx
@@ -7,7 +7,7 @@ import {
   isFuture,
   isPast,
   isSameDay,
-  today as getToday,
+  today,
 } from '@weco/common/utils/dates';
 
 type Props = {
@@ -23,13 +23,11 @@ export function formatDateRangeWithMessage({
   start: Date;
   end: Date;
 }): { text: string; color: string } {
-  const today = getToday();
+  const sevenDaysTime = addDays(today(), 7);
 
-  const sevenDaysTime = addDays(getToday(), 7);
-
-  const opensToday = isSameDay(start, today);
-  const closesToday = isSameDay(end, today);
-  const closesInSevenDays = today < end && end < sevenDaysTime;
+  const opensToday = isSameDay(start, today());
+  const closesToday = isSameDay(end, today());
+  const closesInSevenDays = today() < end && end < sevenDaysTime;
 
   if (!opensToday && isFuture(start)) {
     return { text: 'Coming soon', color: 'neutral.500' };

--- a/content/webapp/components/StatusIndicator/StatusIndicator.tsx
+++ b/content/webapp/components/StatusIndicator/StatusIndicator.tsx
@@ -26,7 +26,7 @@ export function formatDateRangeWithMessage({
   const sevenDaysTime = addDays(today(), 7);
 
   const opensToday = isSameDay(start, today());
-  const closesToday = isSameDay(end, today());
+  const closesToday = isSameDay(end, today(), 'London');
   const closesInSevenDays = today() < end && end < sevenDaysTime;
 
   if (!opensToday && isFuture(start)) {

--- a/content/webapp/components/StatusIndicator/StatusIndicator.tsx
+++ b/content/webapp/components/StatusIndicator/StatusIndicator.tsx
@@ -2,7 +2,13 @@ import { font } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 import Dot from '@weco/common/views/components/Dot/Dot';
 import { FC } from 'react';
-import { isFuture, isPast, isSameDay } from '@weco/common/utils/dates';
+import {
+  addDays,
+  isFuture,
+  isPast,
+  isSameDay,
+  today as getToday,
+} from '@weco/common/utils/dates';
 
 type Props = {
   start: Date;
@@ -17,17 +23,17 @@ export function formatDateRangeWithMessage({
   start: Date;
   end: Date;
 }): { text: string; color: string } {
-  const today = new Date();
+  const today = getToday();
 
-  const sevenDaysTime = new Date();
-  sevenDaysTime.setDate(sevenDaysTime.getDate() + 7);
+  const sevenDaysTime = addDays(getToday(), 7);
 
+  const opensToday = isSameDay(start, today);
   const closesToday = isSameDay(end, today);
   const closesInSevenDays = today < end && end < sevenDaysTime;
 
-  if (!isSameDay(today, start) && isFuture(start)) {
+  if (!opensToday && isFuture(start)) {
     return { text: 'Coming soon', color: 'neutral.500' };
-  } else if (!isSameDay(today, end) && isPast(end)) {
+  } else if (!closesToday && isPast(end)) {
     return { text: 'Past', color: 'neutral.500' };
   } else if (closesToday || closesInSevenDays) {
     return { text: 'Final week', color: 'accent.salmon' };


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/wellcomecollection.org/issues/8503; for https://github.com/wellcomecollection/wellcomecollection.org/issues/7831

## Who is this for?

People who like accurate dates.

## What is it doing for them?

Making sure the StatusIndicator component displays the correct date at the boundary of exhibitions – dates are entered in Prismic in a London timezone, not UTC, so we need to do those comparisons in London time when deciding if an exhibition is future/open/closed.