### PR TITLE
Continue migrating isSameDay() to use London-based comparisons

### DIFF
--- a/catalogue/webapp/components/Calendar/calendar-utils.ts
+++ b/catalogue/webapp/components/Calendar/calendar-utils.ts
@@ -106,8 +106,8 @@ export function firstDayOfWeek(date: Date, weeks: Date[][]): Date {
  * then this would return Sunday 11 September.
  *
  */
-export function lastDayOfWeek(date: Date, dates: Date[][]): Date {
-  const currentWeek = dates.find(week =>
+export function lastDayOfWeek(date: Date, weeks: Date[][]): Date {
+  const currentWeek = weeks.find(week =>
     week?.some(day => day && isSameDay(day, date, 'London'))
   );
   return (currentWeek && currentWeek[currentWeek.length - 1]) || date;

--- a/catalogue/webapp/components/Calendar/calendar-utils.ts
+++ b/catalogue/webapp/components/Calendar/calendar-utils.ts
@@ -62,8 +62,24 @@ export function getCalendarRows(date: Date): Date[][] {
   return groupIntoSize(rows, 7);
 }
 
-export function firstDayOfWeek(date: Date, dates: Date[][]): Date {
-  const currentWeek = dates.find(weekDates =>
+/** Given a list of weeks, return the first day of the week that
+ * contains the given date.
+ *
+ * e.g. if we're looking for 8 September 2022 in the weeks of September:
+ *
+ *      September 2022
+ *   Mo Tu We Th Fr Sa Su
+ * [           1  2  3  4 ]
+ * [  5  6  7  8  9 10 11 ] << currentWeek
+ * [ 12 13 14 15 16 17 18 ]
+ * [ 19 20 21 22 23 24 25 ]
+ * [ 26 27 28 29 30       ]
+ *
+ * then this would return Monday 5 September.
+ *
+ */
+export function firstDayOfWeek(date: Date, weeks: Date[][]): Date {
+  const currentWeek = weeks.find(weekDates =>
     weekDates?.some(weekDate => weekDate && isSameDay(weekDate, date))
   );
   return (currentWeek && currentWeek[0]) || date;

--- a/catalogue/webapp/components/Calendar/calendar-utils.ts
+++ b/catalogue/webapp/components/Calendar/calendar-utils.ts
@@ -38,6 +38,11 @@ export function countDaysInMonth(d: Date): number {
   return new Date(d.getFullYear(), d.getMonth() + 1, 0).getDate();
 }
 
+/** Returns a list of the dates in a month.
+ *
+ * For consistency, all these dates fall around the middle of each day,
+ * to avoid too much weirdness with boundary cases at the edge of London/UTC.
+ */
 export function getDatesInMonth(d: Date): Date[] {
   return getDatesBetween({
     start: new Date(d.getFullYear(), d.getMonth(), 1, 12, 0, 0),
@@ -80,14 +85,30 @@ export function getCalendarRows(date: Date): Date[][] {
  */
 export function firstDayOfWeek(date: Date, weeks: Date[][]): Date {
   const currentWeek = weeks.find(weekDates =>
-    weekDates?.some(weekDate => weekDate && isSameDay(weekDate, date))
+    weekDates?.some(weekDate => weekDate && isSameDay(weekDate, date, 'London'))
   );
   return (currentWeek && currentWeek[0]) || date;
 }
 
+/** Given a list of weeks, return the first day of the week that
+ * contains the given date.
+ *
+ * e.g. if we're looking for 8 September 2022 in the weeks of September:
+ *
+ *      September 2022
+ *   Mo Tu We Th Fr Sa Su
+ * [           1  2  3  4 ]
+ * [  5  6  7  8  9 10 11 ] << currentWeek
+ * [ 12 13 14 15 16 17 18 ]
+ * [ 19 20 21 22 23 24 25 ]
+ * [ 26 27 28 29 30       ]
+ *
+ * then this would return Sunday 11 September.
+ *
+ */
 export function lastDayOfWeek(date: Date, dates: Date[][]): Date {
   const currentWeek = dates.find(week =>
-    week?.some(day => day && isSameDay(day, date))
+    week?.some(day => day && isSameDay(day, date, 'London'))
   );
   return (currentWeek && currentWeek[currentWeek.length - 1]) || date;
 }


### PR DESCRIPTION
For https://github.com/wellcomecollection/wellcomecollection.org/issues/7831

The `firstDayOfWeek` function is only used in one place; it's used in the Calendar component when a user when somebody pressed `HOME` to jump to the start of a week. It's being passed a list of dates that comes from `getDatesInMonth()`, which deliberately creates times in the middle of the day, so London/UTC days will always eb the same.

This alone isn't particularly exciting, but it's another place we can convert `isSameDay()` to London-based comparisons.

A reminder: my suspicion is that _all_ same-day comparisons should be London, not UTC, and I'm gradually working through them to check each in turn.