### PR TITLE
Add some concepts information to the API toolbar

### DIFF
--- a/catalogue/webapp/pages/concept.tsx
+++ b/catalogue/webapp/pages/concept.tsx
@@ -400,6 +400,17 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       toggles: serverData.toggles,
     });
 
+    if (conceptResponse.type === 'Error') {
+      if (conceptResponse.httpStatus === 404) {
+        return { notFound: true };
+      }
+      return appError(
+        context,
+        conceptResponse.httpStatus,
+        conceptResponse.description
+      );
+    }
+
     const worksAboutPromise = getWorks({
       params: { 'subjects.label': [conceptResponse.label] },
       toggles: serverData.toggles,
@@ -435,17 +446,6 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       imagesAboutPromise,
       imagesByPromise,
     ]);
-
-    if (conceptResponse.type === 'Error') {
-      if (conceptResponse.httpStatus === 404) {
-        return { notFound: true };
-      }
-      return appError(
-        context,
-        conceptResponse.httpStatus,
-        conceptResponse.description
-      );
-    }
 
     const worksAbout =
       worksAboutResponse.type === 'Error' ? undefined : worksAboutResponse;

--- a/catalogue/webapp/pages/concept.tsx
+++ b/catalogue/webapp/pages/concept.tsx
@@ -25,6 +25,7 @@ import BetaMessage from '@weco/common/views/components/BetaMessage/BetaMessage';
 import {
   CatalogueResultsList,
   Concept as ConceptType,
+  IdentifierType,
   Image as ImageType,
   Work as WorkType,
 } from '@weco/common/model/catalogue';
@@ -35,6 +36,7 @@ import { arrow } from '@weco/common/icons';
 import Space from '@weco/common/views/components/styled/Space';
 import TabNavV2 from '@weco/common/views/components/TabNav/TabNavV2';
 import { font } from '@weco/common/utils/classnames';
+import { ApiToolbarLink } from '@weco/common/views/components/ApiToolbar/ApiToolbar';
 
 type Props = {
   conceptResponse: ConceptType;
@@ -42,6 +44,7 @@ type Props = {
   worksBy: CatalogueResultsList<WorkType> | undefined;
   imagesAbout: CatalogueResultsList<ImageType> | undefined;
   imagesBy: CatalogueResultsList<ImageType> | undefined;
+  apiToolbarLinks: ApiToolbarLink[];
 };
 
 const leadingColor = 'yellow';
@@ -104,6 +107,7 @@ export const ConceptPage: NextPage<Props> = ({
   worksBy,
   imagesAbout,
   imagesBy,
+  apiToolbarLinks,
 }) => {
   const [selectedWorksTab, setSelectedWorksTab] = useState('works-about');
   const [selectedImagesTab, setSelectedImagesTab] = useState('images-about');
@@ -122,6 +126,7 @@ export const ConceptPage: NextPage<Props> = ({
       siteSection="collections"
       jsonLd={{ '@type': 'WebPage' }}
       hideNewsletterPromo={true}
+      apiToolbarLinks={apiToolbarLinks}
     >
       <ConceptHero>
         <div className="container">
@@ -335,6 +340,44 @@ export const ConceptPage: NextPage<Props> = ({
   );
 };
 
+function getDisplayIdentifierType(identifierType: IdentifierType): string {
+  switch (identifierType.id) {
+    case 'lc-names':
+      return 'LC Names';
+    case 'lc-subjects':
+      return 'LCSH';
+    case 'nlm-mesh':
+      return 'MeSH';
+    default:
+      return identifierType.label;
+  }
+}
+
+function createApiToolbarLinks(concept: ConceptType): ApiToolbarLink[] {
+  const apiUrl = `https://api.wellcomecollection.org/catalogue/v2/concepts/${concept.id}`;
+
+  const apiLink = {
+    id: 'json',
+    label: 'JSON',
+    link: apiUrl,
+  };
+
+  const identifiers = (concept.identifiers || []).map(id =>
+    id.identifierType.id === 'label-derived'
+      ? {
+          id: id.value,
+          label: 'Label-derived identifier',
+        }
+      : {
+          id: id.value,
+          label: getDisplayIdentifierType(id.identifierType),
+          value: id.value,
+        }
+  );
+
+  return [apiLink, ...identifiers];
+}
+
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
     const serverData = await getServerData(context);
@@ -413,6 +456,8 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     const imagesBy =
       imagesByResponse.type === 'Error' ? undefined : imagesByResponse;
 
+    const apiToolbarLinks = createApiToolbarLinks(conceptResponse);
+
     return {
       props: removeUndefinedProps({
         conceptResponse,
@@ -420,6 +465,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
         worksBy,
         imagesAbout,
         imagesBy,
+        apiToolbarLinks,
         serverData,
       }),
     };

--- a/common/model/catalogue.ts
+++ b/common/model/catalogue.ts
@@ -68,7 +68,7 @@ type Period = {
   type: 'Period';
 };
 
-type IdentifierType = {
+export type IdentifierType = {
   id: string;
   label: string;
   type: 'IdentifierType';

--- a/common/views/components/ApiToolbar/ApiToolbar.tsx
+++ b/common/views/components/ApiToolbar/ApiToolbar.tsx
@@ -201,6 +201,22 @@ function getRouteProps(path: string) {
 
         return tzitzitLink ? [tzitzitLink] : [];
       };
+
+    case '/concept':
+      return async (query: ParsedUrlQuery): Promise<ApiToolbarLink[]> => {
+        const { id } = query;
+
+        const apiUrl = `https://api.wellcomecollection.org/catalogue/v2/concepts/${id}`;
+
+        const apiLink = {
+          id: 'json',
+          label: 'JSON',
+          link: apiUrl,
+        };
+
+        return [apiLink];
+      };
+
     case '/item':
       return async (query: ParsedUrlQuery): Promise<ApiToolbarLink[]> => {
         const { workId } = query;

--- a/common/views/components/ApiToolbar/ApiToolbar.tsx
+++ b/common/views/components/ApiToolbar/ApiToolbar.tsx
@@ -202,21 +202,6 @@ function getRouteProps(path: string) {
         return tzitzitLink ? [tzitzitLink] : [];
       };
 
-    case '/concept':
-      return async (query: ParsedUrlQuery): Promise<ApiToolbarLink[]> => {
-        const { id } = query;
-
-        const apiUrl = `https://api.wellcomecollection.org/catalogue/v2/concepts/${id}`;
-
-        const apiLink = {
-          id: 'json',
-          label: 'JSON',
-          link: apiUrl,
-        };
-
-        return [apiLink];
-      };
-
     case '/item':
       return async (query: ParsedUrlQuery): Promise<ApiToolbarLink[]> => {
         const { workId } = query;


### PR DESCRIPTION
## Who is this for?

Me

## What is it doing for them?

Making it easier for us to follow what's happening on the concepts pages. In particular, I now get:

* A link to the concepts API JSON
* A list of identifiers on the concept

Because it's hard to follow discussions about the source of the concepts data when I can't see where the data is coming from.

<img width="931" alt="Screenshot 2022-09-27 at 19 17 03" src="https://user-images.githubusercontent.com/301220/192605070-8b3d5aef-36ad-42a2-aaae-bee4ff075065.png">

## Implementation note

This continues a pattern I started in #8491, where individual pages know what their API toolbar links should be, rather than having the API toolbar hold all that context, and potentially have to refetch data that's already available on the page.

e.g. we already know what the concept data is, so we reuse that to build the toolbar rather than querying the concepts API a second time.

This is slightly more efficient and avoids bloating the API toolbar code.