### PR TITLE
Tweak components to have AA contrast

### DIFF
--- a/common/views/components/MoreLink/MoreLink.tsx
+++ b/common/views/components/MoreLink/MoreLink.tsx
@@ -27,7 +27,7 @@ const MoreLink: FunctionComponent<Props> = ({
 
   return (
     <ButtonSolidLink
-      colors={themeValues.buttonColors.greenTransparentGreen}
+      colors={themeValues.buttonColors.charcoalTransparentCharcoal}
       isIconAfter={true}
       clickHandler={handleClick}
       text={name}

--- a/common/views/components/Number/Number.tsx
+++ b/common/views/components/Number/Number.tsx
@@ -31,7 +31,11 @@ const Number: FunctionComponent<Props> = ({
     color={color}
   >
     <span
-      className={color === 'yellow' ? 'font-black' : 'font-white'}
+      className={
+        color === 'yellow' || color === 'accent.salmon'
+          ? 'font-black'
+          : 'font-white'
+      }
       style={{ transform: 'rotateZ(6deg) scale(1.2)' }}
     >
       {number}

--- a/common/views/components/SectionHeader/SectionHeader.tsx
+++ b/common/views/components/SectionHeader/SectionHeader.tsx
@@ -20,7 +20,7 @@ const YellowBox = styled.div`
 `;
 
 const TitleWrapper = styled.span`
-  .bg-neutral-700 & {
+  .bg-dark & {
     color: ${props => props.theme.color('white')};
   }
 `;

--- a/common/views/components/WatchLabel/WatchLabel.tsx
+++ b/common/views/components/WatchLabel/WatchLabel.tsx
@@ -23,7 +23,7 @@ const WatchText = styled(Space).attrs({
   v: { size: 's', properties: ['margin-left'] },
   className: font('intr', 6),
 })`
-  color: ${props => props.theme.color('neutral.600')};
+  color: ${props => props.theme.color('neutral.700')};
 `;
 
 type Props = {

--- a/common/views/themes/config.ts
+++ b/common/views/themes/config.ts
@@ -181,6 +181,12 @@ const pumiceTransparentCharcoal: ButtonColors = {
   text: 'neutral.700', // legacy charcoal color
 };
 
+const charcoalTransparentCharcoal: ButtonColors = {
+  border: 'neutral.700', // legacy charcoal color
+  background: 'transparent',
+  text: 'neutral.700', // legacy charcoal color
+};
+
 const marbleWhiteCharcoal: ButtonColors = {
   border: 'neutral.400', // legacy pumice color
   background: 'white',
@@ -260,6 +266,7 @@ export const themeValues = {
     greenTransparentGreen,
     whiteTransparentWhite,
     pumiceTransparentCharcoal,
+    charcoalTransparentCharcoal,
     marbleWhiteCharcoal,
   },
 };

--- a/content/webapp/components/Body/Body.tsx
+++ b/content/webapp/components/Body/Body.tsx
@@ -6,7 +6,7 @@ import React, {
   Fragment,
 } from 'react';
 import styled from 'styled-components';
-import { font } from '@weco/common/utils/classnames';
+import { classNames, font } from '@weco/common/utils/classnames';
 import { Link } from '../../types/link';
 import {
   defaultSerializer,
@@ -97,9 +97,14 @@ const Wrapper = styled(Space).attrs<{
   rowBackgroundColor: string;
   cardBackgroundColor: string;
 }>(props => ({
-  className: `row card-theme
-  bg-${props.rowBackgroundColor}
-    card-theme--${props.cardBackgroundColor}`, // Keeping bg-[color] class as some components below are styled based on this parent class.
+  className: classNames({
+    'row card-theme': true,
+    'bg-dark': props.rowBackgroundColor === 'neutral.700',
+    [`card-theme--${props.cardBackgroundColor}`]: [
+      'white',
+      'transparent',
+    ].includes(props.cardBackgroundColor),
+  }),
 }))<{ rowBackgroundColor: string; cardBackgroundColor: string }>`
   background-color: ${props => props.theme.color(props.rowBackgroundColor)};
 `;

--- a/content/webapp/components/Card/Card.tsx
+++ b/content/webapp/components/Card/Card.tsx
@@ -31,7 +31,7 @@ export const CardOuter = styled.a.attrs<{ className?: string }>(() => ({
     min-height: auto;
   }
 
-  .card-theme.bg-neutral-700 & {
+  .card-theme.bg-dark & {
     color: ${props => props.theme.color('white')};
   }
 `;


### PR DESCRIPTION
## Who is this for?
A11y

## What is it doing for them?
Makes things readable, some of these are, to me, temp fixes (see new buttons colours, we should maybe check if a different green or a different beige background could be best as they don't fit the ratio and are probably common occurrences), so I'll make notes in finding longer term solutions. 