### PR TITLE
Reading time - changes based on feedback

### DIFF
--- a/content/webapp/pages/article.tsx
+++ b/content/webapp/pages/article.tsx
@@ -29,6 +29,7 @@ import { bodySquabblesSeries } from '@weco/common/data/hardcoded-ids';
 import { transformArticle } from '../services/prismic/transformers/articles';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 import { useToggles } from '@weco/common/server-data/Context';
+import styled from 'styled-components';
 
 type Props = {
   article: Article;
@@ -199,6 +200,13 @@ const ArticlePage: FC<Props> = ({ article, jsonLd }) => {
     />
   );
 
+  const ReadingTime = styled.span`
+    :before {
+      content: ' | ';
+      margin: 0 4px;
+    }
+  `;
+
   const ContentTypeInfo = (
     <Fragment>
       {article.standfirst && <PageHeaderStandfirst html={article.standfirst} />}
@@ -229,24 +237,11 @@ const ArticlePage: FC<Props> = ({ article, jsonLd }) => {
                 </Fragment>
               ))}
             {readingTime && article.readingTime ? (
-              <>
-                <span className={font('intr', 6)}>
-                  <span className={font('intr', 5)}>
-                    {' '}
-                    <Space
-                      as="span"
-                      h={{
-                        size: 's',
-                        properties: ['margin-right'],
-                      }}
-                    >
-                      |
-                    </Space>
-                  </span>{' '}
-                  Average reading time{' '}
-                  <span className={font('intb', 6)}>{article.readingTime}</span>
-                </span>
-              </>
+              <ReadingTime>
+                {' '}
+                Average reading time{' '}
+                <span className={font('intb', 6)}>{article.readingTime}</span>
+              </ReadingTime>
             ) : null}
             {article.contributors.length > 0 && ' '}
 

--- a/content/webapp/pages/article.tsx
+++ b/content/webapp/pages/article.tsx
@@ -228,10 +228,22 @@ const ArticlePage: FC<Props> = ({ article, jsonLd }) => {
                   </Space>
                 </Fragment>
               ))}
-            {readingTime && article.readingTime ? (
+            {!readingTime && article.readingTime ? (
               <>
                 <span className={font('intr', 6)}>
-                  <span className={font('intr', 5)}>| </span> reading time{' '}
+                  <span className={font('intr', 5)}>
+                    {' '}
+                    <Space
+                      as="span"
+                      h={{
+                        size: 's',
+                        properties: ['margin-right'],
+                      }}
+                    >
+                      |
+                    </Space>
+                  </span>{' '}
+                  Average reading time{' '}
                   <span className={font('intb', 6)}>{article.readingTime}</span>
                 </span>
               </>

--- a/content/webapp/pages/article.tsx
+++ b/content/webapp/pages/article.tsx
@@ -200,8 +200,8 @@ const ArticlePage: FC<Props> = ({ article, jsonLd }) => {
     />
   );
 
-  const ReadingTime = styled.span`
-    :before {
+  const ContentTypeInfoSection = styled.span`
+    &:not(:first-child):before {
       content: ' | ';
       margin: 0 4px;
     }
@@ -211,11 +211,12 @@ const ArticlePage: FC<Props> = ({ article, jsonLd }) => {
     <Fragment>
       {article.standfirst && <PageHeaderStandfirst html={article.standfirst} />}
       <div className="flex flex--h-baseline">
+
         <Space v={{ size: 's', properties: ['margin-top'] }}>
           <p className={`no-margin ${font('intr', 6)}`}>
             {article.contributors.length > 0 &&
               article.contributors.map(({ contributor, role }, i, arr) => (
-                <Fragment key={contributor.id}>
+                <ContentTypeInfoSection key={contributor.id}>
                   {role && role.describedBy && (
                     <span>
                       {i === 0
@@ -225,23 +226,13 @@ const ArticlePage: FC<Props> = ({ article, jsonLd }) => {
                     </span>
                   )}
                   <span className={font('intb', 6)}>{contributor.name}</span>
-                  <Space
-                    as="span"
-                    h={{
-                      size: 's',
-                      properties: ['margin-left', 'margin-right'],
-                    }}
-                  >
-                    {arr.length > 1 && i < arr.length - 1 && '|'}
-                  </Space>
-                </Fragment>
+                </ContentTypeInfoSection>
               ))}
             {readingTime && article.readingTime ? (
-              <ReadingTime>
-                {' '}
+              <ContentTypeInfoSection>
                 Average reading time{' '}
                 <span className={font('intb', 6)}>{article.readingTime}</span>
-              </ReadingTime>
+              </ContentTypeInfoSection>
             ) : null}
             {article.contributors.length > 0 && ' '}
 

--- a/content/webapp/pages/article.tsx
+++ b/content/webapp/pages/article.tsx
@@ -228,7 +228,7 @@ const ArticlePage: FC<Props> = ({ article, jsonLd }) => {
                   </Space>
                 </Fragment>
               ))}
-            {!readingTime && article.readingTime ? (
+            {readingTime && article.readingTime ? (
               <>
                 <span className={font('intr', 6)}>
                   <span className={font('intr', 5)}>

--- a/content/webapp/services/prismic/transformers/articles.ts
+++ b/content/webapp/services/prismic/transformers/articles.ts
@@ -118,7 +118,7 @@ export function transformArticle(document: ArticlePrismicDocument): Article {
 
   const readingTimeInMinutes =
     Math.round(readingTime(allArticleText(genericFields.body)).minutes) +
-    ' min';
+    ' minutes';
 
   const series: Series[] = transformSingleLevelGroup(data.series, 'series').map(
     series => transformSeries(series as SeriesPrismicDocument)


### PR DESCRIPTION

## Who is this for?

Anyone who reads articles

## What is it doing for them?

Increases space between `|` and reading time text. Uses the phrase 'Average reading time' to step away from being ableist in our terminology, and changes min to minutes. 