### PR TITLE
Don't show number of stops on C&T page type

### DIFF
--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -544,8 +544,11 @@ const ExhibitionGuidePage: FC<Props> = props => {
             <Layout10 isCentered={false}>
               {userPreferenceSet ? (
                 <p>
-                  This exhibition has {numberedStops.length} stops. You selected
-                  this type of guide previously, but you can also select{' '}
+                  {type !== 'captions-and-transcripts' && (
+                    <>This exhibition has {numberedStops.length} stops. </>
+                  )}
+                  You selected this type of guide previously, but you can also
+                  select{' '}
                   <a
                     href={`/guides/exhibitions/${exhibitionGuide.id}`}
                     onClick={() => {
@@ -556,7 +559,11 @@ const ExhibitionGuidePage: FC<Props> = props => {
                   </a>
                 </p>
               ) : (
-                <p>This exhibition has {numberedStops.length} stops.</p>
+                <>
+                  {type !== 'captions-and-transcripts' && (
+                    <p>This exhibition has {numberedStops.length} stops.</p>
+                  )}
+                </>
               )}
             </Layout10>
           </Space>


### PR DESCRIPTION
Fixes #8484 

__Before__
<img width="579" alt="image" src="https://user-images.githubusercontent.com/1394592/193013254-f116217d-edd7-46b7-bbf7-1a9dcb6c478b.png">

__After__
<img width="603" alt="Screenshot 2022-09-29 at 11 52 47" src="https://user-images.githubusercontent.com/1394592/193013292-aec5655c-00dc-40a7-b4d9-c2acb668be24.png">
