### PR TITLE
remove spaced-text classes

### DIFF
--- a/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
+++ b/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
@@ -94,9 +94,7 @@ const Tombstone = styled(Space).attrs({
   }
 `;
 
-const CaptionTranscription = styled.div.attrs({
-  className: 'spaced-text',
-})`
+const CaptionTranscription = styled.div`
   flex-basis: 100%;
   max-width: 45em;
 
@@ -121,7 +119,6 @@ const PrismicImageWrapper = styled.div`
 `;
 
 const Transcription = styled(Space).attrs({
-  className: 'spaced-text',
   h: { size: 'm', properties: ['padding-left', 'padding-right'] },
   v: { size: 'l', properties: ['margin-top'] },
 })`

--- a/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
+++ b/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
@@ -219,7 +219,7 @@ const Stop: FC<{
           )}
           <div className="flex flex--wrap">
             <Tombstone />
-            {/* This empty Tombstone is needed for correct alignmennt of the standaloneTitle */}
+            {/* This empty Tombstone is needed for correct alignment of the standaloneTitle */}
             <Space
               h={{
                 size: 'm',


### PR DESCRIPTION
Fixes #8483

I've removed the spaced-text classes that were causing the space under the title to be applied. It doesn't seem to have affected anything else.

Before:
![Screenshot 2022-09-29 at 12 30 04](https://user-images.githubusercontent.com/6051896/193020722-3b53efab-e67f-42fa-8314-c275dccd106a.png)

After:
![Screenshot 2022-09-29 at 12 27 13](https://user-images.githubusercontent.com/6051896/193020711-7c3cb30b-2cae-4b11-a2be-c48f74108163.png)



