### PR TITLE
Line up the hours in the opening

### DIFF
--- a/common/views/components/OpeningTimes/OpeningTimes.test.tsx
+++ b/common/views/components/OpeningTimes/OpeningTimes.test.tsx
@@ -5,6 +5,7 @@ import {
 } from '../../../test/fixtures/enzyme-helpers';
 import { venues } from '../../../test/fixtures/components/venues';
 import * as serviceOpeningTimes from '@weco/common/services/prismic/opening-times';
+import { shopVenue } from '../../../test/fixtures/components/shop-venue';
 
 describe('OpeningTimes', () => {
   const spyOnGetTodaysVenueHours = jest.spyOn(
@@ -63,7 +64,8 @@ describe('OpeningTimes', () => {
         isClosed: true,
       };
     });
-    const component = shallowWithTheme(<OpeningTimes venues={venues} />);
-    expect(component.html().match('Shop closed')).toBeTruthy();
+    const component = shallowWithTheme(<OpeningTimes venues={[shopVenue]} />);
+    expect(component.html().includes('Shop')).toBeTruthy();
+    expect(component.html().includes('closed')).toBeTruthy();
   });
 });

--- a/common/views/components/OpeningTimes/OpeningTimes.tsx
+++ b/common/views/components/OpeningTimes/OpeningTimes.tsx
@@ -23,7 +23,7 @@ const OpeningTimesList = styled.ul.attrs({
 // This is chosen to be wider than any of the venue names, but not so wide as
 // to leave lots of space between the name and the opening hours.
 //
-// The choice of '90px' is somewhat arbitrary, just based on what looked okay locally.
+// The exact value is somewhat arbitrary, based on what looked okay locally.
 const VenueName = styled.div`
   display: inline-block;
   width: 90px;

--- a/common/views/components/OpeningTimes/OpeningTimes.tsx
+++ b/common/views/components/OpeningTimes/OpeningTimes.tsx
@@ -20,6 +20,15 @@ const OpeningTimesList = styled.ul.attrs({
   margin: 0;
 `;
 
+// This is chosen to be wider than any of the venue names, but not so wide as
+// to leave lots of space between the name and the opening hours.
+//
+// The choice of '90px' is somewhat arbitrary, just based on what looked okay locally.
+const VenueName = styled.div`
+  display: inline-block;
+  width: 90px;
+`;
+
 const OpeningTimes: FC<Props> = ({ venues }) => (
   <OpeningTimesList>
     {venues.map(venue => {
@@ -34,9 +43,11 @@ const OpeningTimes: FC<Props> = ({ venues }) => (
             as="li"
             key={venue.id}
           >
-            {venue.id === collectionVenueId.restaurant.id
-              ? 'Kitchen '
-              : `${getNameFromCollectionVenue(venue.id)} `}
+            <VenueName>
+              {venue.id === collectionVenueId.restaurant.id
+                ? 'Kitchen '
+                : `${getNameFromCollectionVenue(venue.id)} `}
+            </VenueName>
             {todaysHours.isClosed ? (
               'closed'
             ) : (

--- a/common/views/components/OpeningTimes/OpeningTimes.tsx
+++ b/common/views/components/OpeningTimes/OpeningTimes.tsx
@@ -6,13 +6,22 @@ import {
   getNameFromCollectionVenue,
 } from '@weco/common/data/hardcoded-ids';
 import { FC } from 'react';
+import styled from 'styled-components';
 
 type Props = {
   venues: Venue[];
 };
 
+const OpeningTimesList = styled.ul.attrs({
+  'data-chromatic': 'ignore',
+})`
+  list-style: none;
+  padding: 0;
+  margin: 0;
+`;
+
 const OpeningTimes: FC<Props> = ({ venues }) => (
-  <ul className="plain-list no-padding no-margin" data-chromatic="ignore">
+  <OpeningTimesList>
     {venues.map(venue => {
       const todaysHours = getTodaysVenueHours(venue);
       return (
@@ -41,6 +50,6 @@ const OpeningTimes: FC<Props> = ({ venues }) => (
         )
       );
     })}
-  </ul>
+  </OpeningTimesList>
 );
 export default OpeningTimes;

--- a/content/webapp/components/VenueHours/VenueHours.tsx
+++ b/content/webapp/components/VenueHours/VenueHours.tsx
@@ -70,6 +70,16 @@ const JauntyBox = styled(Space)<JauntyBoxProps>`
 
 const randomPx = () => `${Math.floor(Math.random() * 20)}px`;
 
+// This is chosen to be wider than the names of days of the week
+// (in particular 'Wednesday'), but not so wide as to leave lots
+// of space between the name and the opening hours.
+//
+// The exact value is somewhat arbitrary, based on what looked okay locally.
+const DayOfWeek = styled.div`
+  display: inline-block;
+  width: 100px;
+`;
+
 type Props = {
   venue: Venue;
   weight: Weight;
@@ -134,7 +144,8 @@ const VenueHours: FunctionComponent<Props> = ({ venue, weight }) => {
           {venue?.openingHours.regular.map(
             ({ dayOfWeek, opens, closes, isClosed }) => (
               <li key={dayOfWeek}>
-                {dayOfWeek} {isClosed ? 'Closed' : `${opens} – ${closes}`}
+                <DayOfWeek>{dayOfWeek}</DayOfWeek>{' '}
+                {isClosed ? 'Closed' : `${opens} – ${closes}`}
               </li>
             )
           )}


### PR DESCRIPTION
Pop quiz! What day are we open late?

<table><tr><td>
<img width="381" alt="Screenshot 2022-09-29 at 12 43 46" src="https://user-images.githubusercontent.com/301220/193023110-6ff9a780-8150-41fd-adfd-ff8d99577d2a.png"></td><td>
<img width="389" alt="Screenshot 2022-09-29 at 12 43 38" src="https://user-images.githubusercontent.com/301220/193023135-999a355e-6ffd-4197-be2f-9bd557a4e37c.png"></td></tr>
<tr><td>
<img width="434" alt="Screenshot 2022-09-29 at 12 40 37" src="https://user-images.githubusercontent.com/301220/193023285-2da9e015-fc35-4869-a64d-1c37d0c096c5.png"></td><td>
<img width="434" alt="Screenshot 2022-09-29 at 12 41 23" src="https://user-images.githubusercontent.com/301220/193023295-b4e4787b-5ded-4d8d-859b-d8b50bf0ec39.png"></td></tr>
<tr><td>Before</td><td>After</td></tr></table>

While looking at the opening times for next week's rail strikes, I finally decided to fix a bugbear I’ve had for a while – we don't line up our opening times, which makes it hard to compare across days. Before it was a hard-to-read mess, now I can see that Thursdays are late opening and everything closes at the same time today.

Follows #8571.