### PR TITLE
Move vanity URLs to the 'data' directory

### DIFF
--- a/common/data/vanity-urls.ts
+++ b/common/data/vanity-urls.ts
@@ -1,0 +1,54 @@
+import { prismicPageIds } from './hardcoded-ids';
+
+type VanityUrl = {
+  url: string;
+  pageId: string;
+  template?: string;
+};
+
+export const vanityUrls: VanityUrl[] = [
+  {
+    url: '/about-us',
+    pageId: prismicPageIds.aboutUs,
+  },
+  {
+    url: '/access',
+    pageId: prismicPageIds.access,
+  },
+  {
+    url: '/covid-welcome-back',
+    pageId: prismicPageIds.covidWelcomeBack,
+  },
+  {
+    url: '/get-involved',
+    pageId: prismicPageIds.getInvolved,
+  },
+  {
+    url: '/opening-times',
+    pageId: prismicPageIds.openingTimes,
+  },
+  {
+    url: '/press',
+    pageId: prismicPageIds.press,
+  },
+  {
+    url: '/schools',
+    pageId: prismicPageIds.schools,
+  },
+  {
+    url: '/user-panel',
+    pageId: prismicPageIds.userPanel,
+  },
+  {
+    url: '/venue-hire',
+    pageId: prismicPageIds.venueHire,
+  },
+  {
+    url: '/what-we-do',
+    pageId: prismicPageIds.whatWeDo,
+  },
+  {
+    url: '/youth',
+    pageId: prismicPageIds.youth,
+  },
+];

--- a/common/data/vanity-urls.ts
+++ b/common/data/vanity-urls.ts
@@ -1,3 +1,18 @@
+/** This defines the vanity URLs for pages on wellcomecollection.org.
+ *
+ * This will have two effects for users:
+ *
+ *    1. If they visit the vanity URL, they'll be shown the content for that page.
+ *       e.g. if somebody visits /about-us, they'll be shown the Prismic page Wuw2MSIAACtd3Stq
+ *
+ *    2. If they visit the URL with an ID, they'll get a 301 Permanent Redirect
+ *       to the vanity URL.
+ *       e.g. if somebody visits /pages/Wuw2MSIAACtd3Stq, they'll be redirected to /about-us
+ *
+ *       This is to avoid splitting the Google juice for that page over two URLs.
+ *
+ */
+
 import { prismicPageIds } from './hardcoded-ids';
 
 type VanityUrl = {

--- a/content/webapp/app.ts
+++ b/content/webapp/app.ts
@@ -47,6 +47,18 @@ function pageVanityUrl(
   route(url, template, router, app, { id: pageId });
 }
 
+type VanityUrl = {
+  url: string;
+  pageId: string;
+};
+
+const vanityUrls: VanityUrl[] = [
+  {
+    url: '/what-we-do',
+    pageId: prismicPageIds.whatWeDo,
+  },
+];
+
 // A Prismic ID is an alphanumeric string, plus underscore and hyphen
 //
 // We filter out any requests for pages that obviously aren't Prismic IDs; we know
@@ -124,13 +136,16 @@ const appPromise = nextApp
     ); // :type(${guideType})
     route(`/guides/:id(${prismicId})`, '/page', router, nextApp);
 
+    vanityUrls.forEach(({ url, pageId }) =>
+      pageVanityUrl(router, nextApp, url, pageId)
+    );
+
     pageVanityUrl(
       router,
       nextApp,
       '/opening-times',
       prismicPageIds.openingTimes
     );
-    pageVanityUrl(router, nextApp, '/what-we-do', prismicPageIds.whatWeDo);
     pageVanityUrl(router, nextApp, '/press', prismicPageIds.press);
     pageVanityUrl(router, nextApp, '/venue-hire', prismicPageIds.venueHire);
     pageVanityUrl(router, nextApp, '/access', prismicPageIds.access);

--- a/content/webapp/app.ts
+++ b/content/webapp/app.ts
@@ -17,6 +17,7 @@ import { homepageId, prismicPageIds } from '@weco/common/data/hardcoded-ids';
 import { Periods } from './types/periods';
 import linkResolver from '@weco/common/services/prismic/link-resolver';
 import * as prismic from '@prismicio/client';
+import { vanityUrls } from '@weco/common/data/vanity-urls';
 
 const periodPaths = Object.values(Periods).join('|');
 
@@ -46,18 +47,6 @@ function pageVanityUrl(
 
   route(url, template, router, app, { id: pageId });
 }
-
-type VanityUrl = {
-  url: string;
-  pageId: string;
-};
-
-const vanityUrls: VanityUrl[] = [
-  {
-    url: '/what-we-do',
-    pageId: prismicPageIds.whatWeDo,
-  },
-];
 
 // A Prismic ID is an alphanumeric string, plus underscore and hyphen
 //
@@ -136,30 +125,9 @@ const appPromise = nextApp
     ); // :type(${guideType})
     route(`/guides/:id(${prismicId})`, '/page', router, nextApp);
 
-    vanityUrls.forEach(({ url, pageId }) =>
-      pageVanityUrl(router, nextApp, url, pageId)
+    vanityUrls.forEach(({ url, pageId, template = '/page' }) =>
+      pageVanityUrl(router, nextApp, url, pageId, template)
     );
-
-    pageVanityUrl(
-      router,
-      nextApp,
-      '/opening-times',
-      prismicPageIds.openingTimes
-    );
-    pageVanityUrl(router, nextApp, '/press', prismicPageIds.press);
-    pageVanityUrl(router, nextApp, '/venue-hire', prismicPageIds.venueHire);
-    pageVanityUrl(router, nextApp, '/access', prismicPageIds.access);
-    pageVanityUrl(router, nextApp, '/youth', prismicPageIds.youth);
-    pageVanityUrl(router, nextApp, '/schools', prismicPageIds.schools);
-    pageVanityUrl(
-      router,
-      nextApp,
-      '/covid-welcome-back',
-      prismicPageIds.covidWelcomeBack
-    );
-    pageVanityUrl(router, nextApp, '/about-us', prismicPageIds.aboutUs);
-    pageVanityUrl(router, nextApp, '/get-involved', prismicPageIds.getInvolved);
-    pageVanityUrl(router, nextApp, '/user-panel', prismicPageIds.userPanel);
 
     router.redirect(
       `/pages/${prismicPageIds.stories}`,


### PR DESCRIPTION
## Who is this for?

Devs and Editorial.

## What is it doing for them?

Moving the vanity URLs into the 'data' directory; this is the sort of thing that would be useful to review and manage outside the main application code.

This is a first step towards https://github.com/wellcomecollection/wellcomecollection.org/issues/8562