### PR TITLE
Don’t show stops if they don’t have the necessary content

### DIFF
--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -320,13 +320,7 @@ const Stops: FC<StopsProps> = ({ stops, type }) => {
               <VideoEmbed embedUrl={bsl.embedUrl} />
             )}
           </Stop>
-        ) : (
-          <Stop key={index} id={dasherizeShorten(title)}>
-            <span className={font('intb', 5)}>
-              {number}. {title}
-            </span>
-          </Stop>
-        );
+        ) : null;
       })}
     />
   );
@@ -364,6 +358,7 @@ const ExhibitionLinks: FC<ExhibitionLinksProps> = ({ stops, pathname }) => {
   const hasCaptionsOrTranscripts = stops.some(
     stop => stop.caption.length > 0 || stop.transcription.length > 0
   );
+
   const hasAudioWithoutDescriptions = stops.some(
     stop => stop.audioWithoutDescription?.url
   );

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -323,7 +323,7 @@ const Stops: FC<StopsProps> = ({ stops, type }) => {
                   <VideoEmbed embedUrl={bsl.embedUrl} />
                 )}
               </Stop>
-            ) : null;
+            ) : null; // We've decided to omit stops that don't have content for the selected type.
           })
           .filter(Boolean) as ReactElement[]
       }

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -6,6 +6,7 @@ import {
 import { getCookie, hasCookie, setCookie, deleteCookie } from 'cookies-next';
 import { PaginatedResults } from '@weco/common/services/prismic/types';
 import * as prismicT from '@prismicio/types';
+import { ReactElement, FC, SyntheticEvent } from 'react';
 import { createClient } from '../services/prismic/fetch';
 import {
   fetchExhibitionGuide,
@@ -17,7 +18,6 @@ import {
 } from '../services/prismic/transformers/exhibition-guides';
 import { transformQuery } from '../services/prismic/transformers/paginated-results';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
-import { FC, SyntheticEvent } from 'react';
 import { IconSvg } from '@weco/common/icons/types';
 import { font } from '@weco/common/utils/classnames';
 import { removeUndefinedProps } from '@weco/common/utils/json';
@@ -283,45 +283,50 @@ const Stops: FC<StopsProps> = ({ stops, type }) => {
       overrideGridSizes={
         type === 'bsl' ? twoUpGridSizesMap : threeUpGridSizesMap
       }
-      items={stops.map((stop, index) => {
-        const {
-          number,
-          audioWithDescription,
-          audioWithoutDescription,
-          bsl,
-          title,
-        } = stop;
-        const hasContentOfDesiredType =
-          (type === 'audio-with-descriptions' && audioWithDescription?.url) ||
-          (type === 'audio-without-descriptions' &&
-            audioWithoutDescription?.url) ||
-          (type === 'bsl' && bsl?.embedUrl);
-        return hasContentOfDesiredType ? (
-          <Stop
-            key={index}
-            id="apiToolbar"
-            data-toolbar-anchor={dasherizeShorten(title)}
-          >
-            {type === 'audio-with-descriptions' &&
-              audioWithDescription?.url && (
-                <AudioPlayer
-                  title={`${number}. ${stop.title}`}
-                  audioFile={audioWithDescription.url}
-                />
-              )}
-            {type === 'audio-without-descriptions' &&
-              audioWithoutDescription?.url && (
-                <AudioPlayer
-                  title={`${number}. ${stop.title}`}
-                  audioFile={audioWithoutDescription.url}
-                />
-              )}
-            {type === 'bsl' && bsl.embedUrl && (
-              <VideoEmbed embedUrl={bsl.embedUrl} />
-            )}
-          </Stop>
-        ) : null;
-      })}
+      items={
+        stops
+          .map((stop, index) => {
+            const {
+              number,
+              audioWithDescription,
+              audioWithoutDescription,
+              bsl,
+              title,
+            } = stop;
+            const hasContentOfDesiredType =
+              (type === 'audio-with-descriptions' &&
+                audioWithDescription?.url) ||
+              (type === 'audio-without-descriptions' &&
+                audioWithoutDescription?.url) ||
+              (type === 'bsl' && bsl?.embedUrl);
+            return hasContentOfDesiredType ? (
+              <Stop
+                key={index}
+                id="apiToolbar"
+                data-toolbar-anchor={dasherizeShorten(title)}
+              >
+                {type === 'audio-with-descriptions' &&
+                  audioWithDescription?.url && (
+                    <AudioPlayer
+                      title={`${number}. ${stop.title}`}
+                      audioFile={audioWithDescription.url}
+                    />
+                  )}
+                {type === 'audio-without-descriptions' &&
+                  audioWithoutDescription?.url && (
+                    <AudioPlayer
+                      title={`${number}. ${stop.title}`}
+                      audioFile={audioWithoutDescription.url}
+                    />
+                  )}
+                {type === 'bsl' && bsl.embedUrl && (
+                  <VideoEmbed embedUrl={bsl.embedUrl} />
+                )}
+              </Stop>
+            ) : null;
+          })
+          .filter(Boolean) as ReactElement[]
+      }
     />
   );
 };


### PR DESCRIPTION
At the moment we show all stops for a guide, regardless of whether they have content necessary for the type being viewed.

The options are to 1) not show these stops 2) show these stops but inform the user there is no content for the stop.

After discussion with @DominiqueMarshall we've decided to implement option 1, but may revisit this at a later date.

Before:
![Screenshot 2022-09-29 at 12 35 49](https://user-images.githubusercontent.com/6051896/193041225-99e87859-422c-43fc-9c33-07ab89769ceb.png)

After:
![Screenshot 2022-09-29 at 14 09 48](https://user-images.githubusercontent.com/6051896/193041237-2514c404-e2e0-4ed4-8553-0cd001e953b8.png)

