### PR TITLE
Add option to round image corners to model

### DIFF
--- a/prismic-model/src/parts/captioned-image.ts
+++ b/prismic-model/src/parts/captioned-image.ts
@@ -1,9 +1,11 @@
 import { singleLineText } from './structured-text';
 import image from './image';
+import boolean from './boolean';
 
 export default function () {
   return {
     image: image('Image'),
     caption: singleLineText({ label: 'Caption' }),
+    hasRoundedCorners: boolean('round image corners'),
   };
 }


### PR DESCRIPTION
## Who is this for?
Image editors

## What is it doing for them?
Preparing the model to allow them to round corners of an image programmatically (with css) rather than generating the image with rounded corners by hand.

An example of what is being done by hand currently:
<img width="242" alt="Screenshot 2022-09-29 at 14 18 42" src="https://user-images.githubusercontent.com/1394592/193050586-cbf76bed-4735-45ed-9355-faaba9a828fc.png">
from [this story](https://wellcomecollection.org/articles/YtgEcBEAACcA9ov3).

The latter approach will become problematic if/when the image doesn't appear on a cream background (or if the shade of the background changes).