### PR TITLE
Add a vanity URL for colonial-roots statement

### DIFF
--- a/common/data/vanity-urls.ts
+++ b/common/data/vanity-urls.ts
@@ -66,4 +66,11 @@ export const vanityUrls: VanityUrl[] = [
     url: '/youth',
     pageId: prismicPageIds.youth,
   },
+  // This was added for the the printed gallery guide that will accompany
+  // the Grace Ndiritu exhibition.
+  // See https://wellcome.slack.com/archives/C8X9YKM5X/p1664363102626599
+  {
+    url: '/colonial-roots',
+    pageId: 'YLnsihAAACEAfsuu',
+  },
 ];


### PR DESCRIPTION
## Who is this for?

Visitors and https://github.com/wellcomecollection/wellcomecollection.org/issues/8562

## What is it doing for them?

Making a link they might be able to type in.