### PR TITLE
Add rounded corner styles to captioned images

### DIFF
--- a/common/model/captioned-image.ts
+++ b/common/model/captioned-image.ts
@@ -4,4 +4,5 @@ import * as prismicT from '@prismicio/types';
 export type CaptionedImage = {
   caption: prismicT.RichTextField;
   image: ImageType;
+  hasRoundedCorners: boolean;
 };

--- a/content/webapp/components/CaptionedImage/CaptionedImage.tsx
+++ b/content/webapp/components/CaptionedImage/CaptionedImage.tsx
@@ -29,6 +29,7 @@ const CaptionedImageFigure = styled.div<CaptionedImageProps>`
 
 type ImageContainerInnerProps = {
   aspectRatio: number;
+  hasRoundedCorners: boolean;
 };
 
 const ImageContainerInner = styled.div<ImageContainerInnerProps>`
@@ -36,6 +37,16 @@ const ImageContainerInner = styled.div<ImageContainerInnerProps>`
   max-height: 80vh;
   aspect-ratio: ${props => props.aspectRatio};
   margin: 0 auto;
+
+  ${props =>
+    props.hasRoundedCorners &&
+    `
+    > div {
+      border-radius:  clamp(10px, 2vw, 26px);
+      overflow: hidden;
+    }
+  `}
+
   @supports not (aspect-ratio: auto) {
     max-width: 90%;
     ${props => props.theme.media.large`
@@ -54,6 +65,7 @@ const CaptionedImage: FC<UiCaptionedImageProps> = ({
   preCaptionNode,
   image,
   isBody,
+  hasRoundedCorners,
 }) => {
   // Note: the default quality here was originally 45, but this caused images to
   // appear very fuzzy on stories.
@@ -66,7 +78,10 @@ const CaptionedImage: FC<UiCaptionedImageProps> = ({
   // See https://wellcome.slack.com/archives/C8X9YKM5X/p1653466941113029
   return (
     <CaptionedImageFigure isBody={isBody}>
-      <ImageContainerInner aspectRatio={image.width / image.height}>
+      <ImageContainerInner
+        aspectRatio={image.width / image.height}
+        hasRoundedCorners={hasRoundedCorners}
+      >
         <ImageWithTasl
           Image={<HeightRestrictedPrismicImage image={image} quality="high" />}
           tasl={image.tasl}

--- a/content/webapp/components/ImageGallery/ImageGallery.tsx
+++ b/content/webapp/components/ImageGallery/ImageGallery.tsx
@@ -369,6 +369,7 @@ const ImageGallery: FunctionComponent<{ id: number } & Props> = ({
                 <CaptionedImage
                   image={captionedImage.image}
                   caption={captionedImage.caption}
+                  hasRoundedCorners={captionedImage.hasRoundedCorners}
                   preCaptionNode={
                     items.length > 1 ? (
                       <Space

--- a/content/webapp/services/prismic/transformers/images.ts
+++ b/content/webapp/services/prismic/transformers/images.ts
@@ -19,7 +19,7 @@ export const placeHolderImage: ImageType = {
 };
 
 export function transformCaptionedImage(
-  frag: { image: Image; caption: RichTextField },
+  frag: { image: Image; caption: RichTextField; hasRoundedCorners: boolean },
   crop?: Crop
 ): CaptionedImage {
   if (isEmptyObj(frag.image)) {
@@ -32,6 +32,7 @@ export function transformCaptionedImage(
           spans: [],
         },
       ],
+      hasRoundedCorners: false,
     };
   }
 
@@ -39,6 +40,7 @@ export function transformCaptionedImage(
   return {
     image: transformImage(image) || placeHolderImage,
     caption: asRichText(frag.caption) || [],
+    hasRoundedCorners: frag.hasRoundedCorners,
   };
 }
 
@@ -49,7 +51,10 @@ export function transformPromoToCaptionedImage(
   // We could do more complicated checking here, but this is what we always use.
   if (frag.length > 0) {
     const promo = frag[0]!;
-    return transformCaptionedImage(promo.primary, crop);
+    return transformCaptionedImage(
+      { ...promo.primary, hasRoundedCorners: false },
+      crop
+    );
   } else {
     return undefined;
   }

--- a/content/webapp/services/prismic/transformers/images.ts
+++ b/content/webapp/services/prismic/transformers/images.ts
@@ -19,7 +19,7 @@ export const placeHolderImage: ImageType = {
 };
 
 export function transformCaptionedImage(
-  frag: { image: Image; caption: RichTextField; hasRoundedCorners: boolean },
+  frag: { image: Image; caption: RichTextField; hasRoundedCorners?: boolean },
   crop?: Crop
 ): CaptionedImage {
   if (isEmptyObj(frag.image)) {
@@ -40,7 +40,7 @@ export function transformCaptionedImage(
   return {
     image: transformImage(image) || placeHolderImage,
     caption: asRichText(frag.caption) || [],
-    hasRoundedCorners: frag.hasRoundedCorners,
+    hasRoundedCorners: Boolean(frag.hasRoundedCorners),
   };
 }
 
@@ -51,10 +51,7 @@ export function transformPromoToCaptionedImage(
   // We could do more complicated checking here, but this is what we always use.
   if (frag.length > 0) {
     const promo = frag[0]!;
-    return transformCaptionedImage(
-      { ...promo.primary, hasRoundedCorners: false },
-      crop
-    );
+    return transformCaptionedImage(promo.primary, crop);
   } else {
     return undefined;
   }


### PR DESCRIPTION
## Who is this for?
Image editors

## What is it doing for them?
Makes the Prismic toggle for rounding corners work on the front end.

__Prismic__
![Screenshot 2022-09-29 at 15 50 15](https://user-images.githubusercontent.com/1394592/193064769-cc0205ba-b5ba-4615-9014-66ad67edc118.png)

__Website
![Screenshot 2022-09-29 at 15 42 16](https://user-images.githubusercontent.com/1394592/193064889-e78370ce-0570-4f2f-9962-acf19c0c9289.png)
__
