### PR TITLE
Styled component to extend theme types

### DIFF
--- a/catalogue/webapp/types/styled-components.d.ts
+++ b/catalogue/webapp/types/styled-components.d.ts
@@ -1,0 +1,8 @@
+import theme from '@weco/common/views/themes/default';
+
+type ThemeInterface = typeof theme;
+
+declare module 'styled-components' {
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  interface DefaultTheme extends ThemeInterface {}
+}

--- a/common/types/styled-components.d.ts
+++ b/common/types/styled-components.d.ts
@@ -1,0 +1,8 @@
+import theme from '@weco/common/views/themes/default';
+
+type ThemeInterface = typeof theme;
+
+declare module 'styled-components' {
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  interface DefaultTheme extends ThemeInterface {}
+}

--- a/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
+++ b/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
@@ -13,7 +13,7 @@ import { font } from '@weco/common/utils/classnames';
 import { themeValues, PaletteColor } from '@weco/common/views/themes/config';
 import { dasherizeShorten } from '@weco/common/utils/grammar';
 
-function getTypeColor(type: string): string {
+function getTypeColor(type: string): PaletteColor {
   // importing this from exhibition-guide.tsx was causing a storybook build failure
   // need to investigate why, but am duplicating the function here for now
   // in order to get the exhibition guides work deployed

--- a/content/webapp/components/ImagePlaceholder/ImagePlaceholder.tsx
+++ b/content/webapp/components/ImagePlaceholder/ImagePlaceholder.tsx
@@ -4,7 +4,7 @@ import { transparentGif, repeatingLs } from '@weco/common/utils/backgrounds';
 import styled from 'styled-components';
 
 const Wrapper = styled.div<{
-  color: ColorSelection | undefined;
+  color: ColorSelection;
 }>`
   position: relative;
   background: ${props => props.theme.color(props.color)};
@@ -25,7 +25,7 @@ type Props = {
 };
 
 const ImagePlaceholder: FC<Props> = ({ color }: Props) => (
-  <Wrapper color={color}>
+  <Wrapper color={color || 'accent.purple'}>
     <img src={transparentGif} alt="" width="1" height="1" />
     <Pattern />
   </Wrapper>

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -43,7 +43,7 @@ import GridFactory, {
   threeUpGridSizesMap,
   twoUpGridSizesMap,
 } from '@weco/content/components/Body/GridFactory';
-import { themeValues } from '@weco/common/views/themes/config';
+import { themeValues, PaletteColor } from '@weco/common/views/themes/config';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import {
   britishSignLanguage,
@@ -88,7 +88,7 @@ const TypeItem = styled.li`
   `}
 `;
 
-const TypeLink = styled.a`
+const TypeLink = styled.a<{ color: PaletteColor }>`
   display: block;
   height: 100%;
   width: 100%;
@@ -141,7 +141,7 @@ const Header = styled(Space).attrs({
     size: 'xl',
     properties: ['padding-top', 'padding-bottom', 'margin-bottom'],
   },
-})`
+})<{ color: PaletteColor }>`
   background: ${props => props.theme.color(props.color)};
 `;
 
@@ -435,7 +435,7 @@ const ExhibitionLinks: FC<ExhibitionLinksProps> = ({ stops, pathname }) => {
   );
 };
 
-function getTypeColor(type?: GuideType): string {
+function getTypeColor(type?: GuideType): PaletteColor {
   switch (type) {
     case 'bsl':
       return 'accent.lightBlue';

--- a/content/webapp/types/styled-components.d.ts
+++ b/content/webapp/types/styled-components.d.ts
@@ -1,0 +1,8 @@
+import theme from '@weco/common/views/themes/default';
+
+type ThemeInterface = typeof theme;
+
+declare module 'styled-components' {
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  interface DefaultTheme extends ThemeInterface {}
+}

--- a/identity/webapp/types/styled-components.d.ts
+++ b/identity/webapp/types/styled-components.d.ts
@@ -1,0 +1,8 @@
+import theme from '@weco/common/views/themes/default';
+
+type ThemeInterface = typeof theme;
+
+declare module 'styled-components' {
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  interface DefaultTheme extends ThemeInterface {}
+}


### PR DESCRIPTION
## Who is this for?
Devs

## What is it doing for them?
Ensures the types in the theme are being checked. Solution based on this [SO suggestion](https://stackoverflow.com/questions/71074649/styled-components-w-typescript-missing-type-for-theme-variable). 

This brought to light a lot of errors on media queries so [`align-media-queries`](https://github.com/wellcomecollection/wellcomecollection.org/pull/8575) needs to be approved first.


<img width="1000" alt="Screenshot 2022-09-29 at 17 00 29" src="https://user-images.githubusercontent.com/110461050/193081231-ee932c3a-81de-436c-855d-44e45396d595.png">
<img width="979" alt="Screenshot 2022-09-29 at 17 00 55" src="https://user-images.githubusercontent.com/110461050/193081236-4e9e508e-dd84-4b08-a214-ce5a8a562480.png">


Related to #8566 