### PR TITLE
Don't show "See all dates" if there are no more dates to see

### DIFF
--- a/content/webapp/components/EventDatesLink/EventDatesLink.tsx
+++ b/content/webapp/components/EventDatesLink/EventDatesLink.tsx
@@ -3,13 +3,21 @@ import { font } from '@weco/common/utils/classnames';
 import { trackEvent } from '@weco/common/utils/ga';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import { arrowSmall } from '@weco/common/icons';
+import styled from 'styled-components';
 
 type Props = {
   id: string;
 };
 
+const Wrapper = styled.a.attrs({
+  className: font('intb', 5),
+})`
+  display: inline-flex;
+  align-items: center;
+`;
+
 const EventDatesLink: FunctionComponent<Props> = ({ id }: Props) => (
-  <a
+  <Wrapper
     href="#dates"
     onClick={() => {
       trackEvent({
@@ -18,11 +26,10 @@ const EventDatesLink: FunctionComponent<Props> = ({ id }: Props) => (
         label: id,
       });
     }}
-    className={`flex-inline flex-v-center ${font('intb', 5)}`}
   >
     <Icon icon={arrowSmall} color="black" rotate={90} />
     <span>See all dates</span>
-  </a>
+  </Wrapper>
 );
 
 export default EventDatesLink;

--- a/content/webapp/components/EventDatesLink/EventDatesLink.tsx
+++ b/content/webapp/components/EventDatesLink/EventDatesLink.tsx
@@ -8,23 +8,21 @@ type Props = {
   id: string;
 };
 
-const EventDatesLink: FunctionComponent<Props> = ({ id }: Props) => {
-  return (
-    <a
-      href="#dates"
-      onClick={() => {
-        trackEvent({
-          category: 'EventDatesLink',
-          action: 'follow link',
-          label: id,
-        });
-      }}
-      className={`flex-inline flex-v-center ${font('intb', 5)}`}
-    >
-      <Icon icon={arrowSmall} color="black" rotate={90} />
-      <span>{`See all dates`}</span>
-    </a>
-  );
-};
+const EventDatesLink: FunctionComponent<Props> = ({ id }: Props) => (
+  <a
+    href="#dates"
+    onClick={() => {
+      trackEvent({
+        category: 'EventDatesLink',
+        action: 'follow link',
+        label: id,
+      });
+    }}
+    className={`flex-inline flex-v-center ${font('intb', 5)}`}
+  >
+    <Icon icon={arrowSmall} color="black" rotate={90} />
+    <span>See all dates</span>
+  </a>
+);
 
 export default EventDatesLink;

--- a/content/webapp/pages/event.tsx
+++ b/content/webapp/pages/event.tsx
@@ -270,8 +270,14 @@ const EventPage: NextPage<Props> = ({ event, jsonLd }: Props) => {
             <div className="inline">
               <EventDateRange event={event} />
             </div>
+            {/*
+              This 'All dates' link takes the user to the complete list of dates
+              further down the page, but if there's only one date we can skip it.
+             */}
             <Space h={{ size: 's', properties: ['margin-left'] }}>
-              {!event.isPast && <EventDatesLink id={event.id} />}
+              {!event.isPast && event.times.length > 1 && (
+                <EventDatesLink id={event.id} />
+              )}
             </Space>
           </Space>
           {event.isPast && EventStatus({ text: 'Past', color: 'neutral.500' })}


### PR DESCRIPTION
## Who is this for?

Readers.

## What is it doing for them?

Not implying the existence of extra events. e.g. when I saw this header last night, I thought it meant there were multiple instances of this event and the header was just showing me the first:

<img width="559" alt="Screenshot 2022-09-30 at 11 25 30" src="https://user-images.githubusercontent.com/301220/193250390-8ab54405-a652-44f1-bf76-c84a02450aba.png">

but no, there's just a single date:

<img width="927" alt="Screenshot 2022-09-30 at 11 25 59" src="https://user-images.githubusercontent.com/301220/193250463-227828f3-0eb9-4250-a1d5-6a71726b38b8.png">

This change means we no longer show "See all dates" on event pages that just have a single date.

This is similar to how we only show "See all dates" on event promo cards that have multiple dates:

<img width="844" alt="Screenshot 2022-09-30 at 11 26 17" src="https://user-images.githubusercontent.com/301220/193250623-ebe8b163-9a89-4ed8-abf8-3da2b93d0994.png">
