### PR TITLE
Add some tests and commentary for getEarliestFutureDateRange

### DIFF
--- a/common/utils/dates.ts
+++ b/common/utils/dates.ts
@@ -14,21 +14,6 @@ export function today(): Date {
   return new Date();
 }
 
-export function getEarliestFutureDateRange(
-  dateRanges: DateRange[],
-  fromDate: Date | undefined = new Date()
-): DateRange | undefined {
-  const now = new Date();
-
-  return dateRanges
-    .sort((a, b) => (a.start > b.start ? 1 : -1))
-    .find(
-      ({ end }) =>
-        (isSameDay(end, fromDate) || end > fromDate) &&
-        (isSameDay(end, now) || end > now)
-    );
-}
-
 export function isPast(date: Date): boolean {
   const now = new Date();
   return date < now;

--- a/content/webapp/components/EventDateRange/EventDateRange.test.tsx
+++ b/content/webapp/components/EventDateRange/EventDateRange.test.tsx
@@ -1,0 +1,96 @@
+import * as dateUtils from '@weco/common/utils/dates';
+import { getEarliestFutureDateRange } from './EventDateRange';
+
+describe('getEarliestFutureDateRange', () => {
+  const spyOnToday = jest.spyOn(dateUtils, 'today');
+  spyOnToday.mockImplementation(() => new Date('2022-08-30'));
+
+  it('picks the single range available if it’s after now', () => {
+    const dateRanges = [
+      {
+        start: new Date('2022-10-06T19:00:00.000+0100'),
+        end: new Date('2022-10-06T19:30:00.000+0100'),
+      },
+    ];
+    const fromDate = new Date('2022-10-01T00:00:00.000+0100');
+
+    const result = getEarliestFutureDateRange(dateRanges, fromDate);
+    expect(result).toBe(dateRanges[0]);
+  });
+
+  it('skips the single range available if it’s in the past', () => {
+    const dateRanges = [
+      {
+        start: new Date('2002-10-06T19:00:00.000+0100'),
+        end: new Date('2002-10-06T19:30:00.000+0100'),
+      },
+    ];
+    const fromDate = new Date('2022-10-01T00:00:00.000+0100');
+
+    const result = getEarliestFutureDateRange(dateRanges, fromDate);
+    expect(result).toBeUndefined();
+  });
+
+  it('picks the earliest valid range, if multiple are available', () => {
+    // Note that the dateRanges argument is in descending order, to make sure
+    // we're sorting properly and not relying on the order that ranges are passed.
+    const earliestRange = {
+      start: new Date('2022-10-04T19:00:00.000+0100'),
+      end: new Date('2022-10-04T19:30:00.000+0100'),
+    };
+
+    const dateRanges = [
+      {
+        start: new Date('2022-10-06T19:00:00.000+0100'),
+        end: new Date('2022-10-06T19:30:00.000+0100'),
+      },
+      {
+        start: new Date('2022-10-05T19:00:00.000+0100'),
+        end: new Date('2022-10-05T19:30:00.000+0100'),
+      },
+      earliestRange,
+    ];
+    const fromDate = new Date('2022-10-01T00:00:00.000+0100');
+
+    const result = getEarliestFutureDateRange(dateRanges, fromDate);
+    expect(result).toBe(earliestRange);
+  });
+
+  it('filters based on the fromDate', () => {
+    const septemberEvent = {
+      start: new Date('2022-09-01T19:00:00.000+0100'),
+      end: new Date('2022-09-01T19:30:00.000+0100'),
+    };
+    const octoberEvent = {
+      start: new Date('2022-10-01T19:00:00.000+0100'),
+      end: new Date('2022-10-01T19:30:00.000+0100'),
+    };
+    const novemberEvent = {
+      start: new Date('2022-11-01T19:00:00.000+0100'),
+      end: new Date('2022-11-01T19:30:00.000+0100'),
+    };
+
+    const dateRanges = [septemberEvent, octoberEvent, novemberEvent];
+
+    const fromNow = getEarliestFutureDateRange(dateRanges);
+    expect(fromNow).toBe(septemberEvent);
+
+    const fromMidSept = getEarliestFutureDateRange(
+      dateRanges,
+      new Date('2022-09-15')
+    );
+    expect(fromMidSept).toBe(octoberEvent);
+
+    const fromMidOct = getEarliestFutureDateRange(
+      dateRanges,
+      new Date('2022-10-15')
+    );
+    expect(fromMidOct).toBe(novemberEvent);
+
+    const fromMidNov = getEarliestFutureDateRange(
+      dateRanges,
+      new Date('2022-11-15')
+    );
+    expect(fromMidNov).toBeUndefined();
+  });
+});

--- a/content/webapp/components/EventDateRange/EventDateRange.tsx
+++ b/content/webapp/components/EventDateRange/EventDateRange.tsx
@@ -1,5 +1,5 @@
 import { DateRange as DateRangeType } from '@weco/common/model/date-range';
-import { isSameDay } from '@weco/common/utils/dates';
+import { isSameDay, today } from '@weco/common/utils/dates';
 import DateRange from '@weco/common/views/components/DateRange/DateRange';
 import { FC } from 'react';
 import { HasTimeRanges } from '../../types/events';
@@ -38,9 +38,9 @@ type Props = {
  */
 export function getEarliestFutureDateRange(
   dateRanges: DateRangeType[],
-  fromDate: Date | undefined = new Date()
+  fromDate: Date | undefined = today()
 ): DateRangeType | undefined {
-  const now = new Date();
+  const now = today();
 
   return dateRanges
     .sort((a, b) => (a.start > b.start ? 1 : -1))

--- a/content/webapp/components/EventDateRange/EventDateRange.tsx
+++ b/content/webapp/components/EventDateRange/EventDateRange.tsx
@@ -25,7 +25,7 @@ type Props = {
  *
  * On the event page, we can display the full list of dates, but in certain contexts
  * (e.g. event promo cards, the event header) we can only show a single range.
- * This function choose which range to use.
+ * This function chooses a suitable snapshot of an event.
  *
  *    - If we're on the event page, we want to highlight the next time this event
  *      is happening.  If today is August, we'd show the event in September.

--- a/content/webapp/components/EventDateRange/EventDateRange.tsx
+++ b/content/webapp/components/EventDateRange/EventDateRange.tsx
@@ -1,4 +1,5 @@
-import { getEarliestFutureDateRange } from '@weco/common/utils/dates';
+import { DateRange as DateRangeType } from '@weco/common/model/date-range';
+import { isSameDay } from '@weco/common/utils/dates';
 import DateRange from '@weco/common/views/components/DateRange/DateRange';
 import { FC } from 'react';
 import { HasTimeRanges } from '../../types/events';
@@ -8,6 +9,47 @@ type Props = {
   splitTime?: boolean;
   fromDate?: Date;
 };
+
+/** Given a list of ranges, returns the first which ends on or after the given
+ * date.
+ *
+ * This is best explained with an example.  Suppose we have an event that repeats
+ * across three months: in September, October, and November.  Then it would have
+ * three date ranges:
+ *
+ *    [
+ *      { start: 1 Sept @ 9am, end: 1 Sept @ 10am },
+ *      { start: 1 Oct  @ 9am,  end: 1 Oct  @ 10am }
+ *      { start: 1 Nov  @ 9am,  end: 1 Nov  @ 10am }
+ *    ]
+ *
+ * On the event page, we can display the full list of dates, but in certain contexts
+ * (e.g. event promo cards, the event header) we can only show a single range.
+ * This function choose which range to use.
+ *
+ *    - If we're on the event page, we want to highlight the next time this event
+ *      is happening.  If today is August, we'd show the event in September.
+ *      If today is mid-September, we'd show the event in October.
+ *
+ *    - On the what's on page, we group events by month, so we show the first event
+ *      happening in each month.  If somebody is looking at the October tab, we show
+ *      the event in October.  If it's the November tab, it's the November event.
+ *
+ */
+export function getEarliestFutureDateRange(
+  dateRanges: DateRangeType[],
+  fromDate: Date | undefined = new Date()
+): DateRangeType | undefined {
+  const now = new Date();
+
+  return dateRanges
+    .sort((a, b) => (a.start > b.start ? 1 : -1))
+    .find(
+      ({ end }) =>
+        (isSameDay(end, fromDate) || end > fromDate) &&
+        (isSameDay(end, now) || end > now)
+    );
+}
 
 const EventDateRange: FC<Props> = ({ event, splitTime, fromDate }: Props) => {
   const dateRanges = event.times.map(({ range }) => ({


### PR DESCRIPTION
## Who is this for?

Devs and https://github.com/wellcomecollection/wellcomecollection.org/issues/7831

## What is it doing for them?

Explaining what this function is trying to do, and adding some tests so we're less likely to break it in future.

I've also moved it alongside the only component where it's used, so we don't try to use it in an unplanned scenario. The only change in this lift-and-shift is to replace `new Date()` with `today()`, so we can mock the current date in tests.