### PR TITLE
Add a hard-coded message about event access

### DIFF
--- a/content/webapp/pages/event.tsx
+++ b/content/webapp/pages/event.tsx
@@ -461,6 +461,24 @@ const EventPage: NextPage<Props> = ({ event, jsonLd }: Props) => {
               .filter(Boolean) as LabelField[]
           }
         >
+          {/*
+            This message is hard-coded as part of the yellow box rather than specified
+            on the individual access notices for two reasons:
+
+              1.  So we don't repeat it if we have lots of access information on an event
+                  See https://wellcome.slack.com/archives/CUA669WHH/p1664808905110529
+
+              2.  So we always have it on events that don't have any access information, when
+                  it's arguably most important.
+
+           */}
+          <p className={font('intr', 5)}>
+            If you have any queries about accessibility, please email us at{' '}
+            <a href="mailto:access@wellcomecollection.org">
+              access@wellcomecollection.org
+            </a>{' '}
+            or call 020 7611 2222.
+          </p>
           <p className={`no-margin ${font('intr', 5)}`}>
             <a
               href={`https://wellcomecollection.org/pages/${prismicPageIds.bookingAndAttendingOurEvents}`}


### PR DESCRIPTION
## Who is this for?

Users.

## What is it doing for them?

* Saving them from reading N copies of a slightly different "contact us if you have questions about access" message on long events
* Ensuring we always point to "ask us about access" even if we've not specified anything explicitly

Note: this will need the Editorial team to remove the hard-coded text from all of the event descriptions.

<table>
<tr><td>Before</td><td>After</td></tr>
<tr><td>
<img width="443" alt="Screenshot 2022-10-03 at 16 24 27" src="https://user-images.githubusercontent.com/301220/193615617-0bd093a9-d25c-403e-a853-d2d522ead553.png">
</td><td><img width="434" alt="Screenshot 2022-10-03 at 16 24 19" src="https://user-images.githubusercontent.com/301220/193615644-960e17c2-0256-462b-b040-fe696d71f38b.png"></td></tr></table>