### PR TITLE
removing keyline

### DIFF
--- a/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
+++ b/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
@@ -51,6 +51,7 @@ const ContextTitle = styled(Space).attrs<{ level: number }>(props => ({
   className: font('wb', 3),
   v: { size: 'm', properties: ['margin-bottom'] },
 }))<{ level: number }>``;
+console.log(ContextTitle, 'this is the output of the styling');
 
 const TranscriptTitle = styled(Space).attrs<{ level: number }>(props => ({
   as: `h${props.level}`,
@@ -214,7 +215,7 @@ const Stop: FC<{
                 properties: ['margin-bottom'],
               }}
             >
-              <Divider color="warmNeutral.400" isKeyline={true} />
+              <Divider color="warmNeutral.400" isKeyline={false} />
             </Space>
           )}
           <div className="flex flex--wrap">

--- a/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
+++ b/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
@@ -8,7 +8,6 @@ import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImag
 import ButtonSolid from '@weco/common/views/components/ButtonSolid/ButtonSolid';
 import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
 import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper/ConditionalWrapper';
-import Divider from '@weco/common/views/components/Divider/Divider';
 import { font } from '@weco/common/utils/classnames';
 import { themeValues, PaletteColor } from '@weco/common/views/themes/config';
 import { dasherizeShorten } from '@weco/common/utils/grammar';
@@ -214,7 +213,6 @@ const Stop: FC<{
                 properties: ['margin-bottom'],
               }}
             >
-              <Divider color="warmNeutral.400" />
             </Space>
           )}
           <div className="flex flex--wrap">

--- a/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
+++ b/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
@@ -51,7 +51,6 @@ const ContextTitle = styled(Space).attrs<{ level: number }>(props => ({
   className: font('wb', 3),
   v: { size: 'm', properties: ['margin-bottom'] },
 }))<{ level: number }>``;
-console.log(ContextTitle, 'this is the output of the styling');
 
 const TranscriptTitle = styled(Space).attrs<{ level: number }>(props => ({
   as: `h${props.level}`,

--- a/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
+++ b/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
@@ -214,7 +214,7 @@ const Stop: FC<{
                 properties: ['margin-bottom'],
               }}
             >
-              <Divider color="warmNeutral.400" isKeyline={false} />
+              <Divider color="warmNeutral.400" />
             </Space>
           )}
           <div className="flex flex--wrap">


### PR DESCRIPTION
## Who is this for?

Users of the exhibition guides, for https://github.com/wellcomecollection/wellcomecollection.org/issues/8481

## What is it doing for them?

@alicerichmond has flagged that the grey lines are not part of the design. They were visible in firefox but I could also see them in chrome.

Before:
<img width="1317" alt="Screenshot 2022-10-04 at 10 05 33" src="https://user-images.githubusercontent.com/16557524/193780905-54770dcb-e185-4453-8c16-c40b5426ca20.png">

After:
<img width="1317" alt="Screenshot 2022-10-04 at 10 05 52" src="https://user-images.githubusercontent.com/16557524/193780929-0d960a91-9659-4135-8263-0273a3d39cda.png">
