### PR TITLE
editorial team raised that book extracts are articles and should have a readingTime

### DIFF
--- a/content/webapp/services/prismic/transformers/articles.ts
+++ b/content/webapp/services/prismic/transformers/articles.ts
@@ -134,7 +134,7 @@ export function transformArticle(document: ArticlePrismicDocument): Article {
   // are a few formats we consider to be 'articles' even if their Prismic 'format'
   // doesn't return them as 'Article' e.g. Book extracts
   // TODO: get definitive list of what we consider to be article and refactor the below function to account for that
-  const isArticleOrSerialFormat = format
+  const showReadingTime = format
     ? Boolean(
         format?.title === 'Article' ||
           format?.title === 'Serial' ||
@@ -150,7 +150,7 @@ export function transformArticle(document: ArticlePrismicDocument): Article {
     format,
     series,
     contributors,
-    readingTime: isArticleOrSerialFormat ? readingTimeInMinutes : undefined,
+    readingTime: showReadingTime ? readingTimeInMinutes : undefined,
     datePublished: new Date(datePublished),
     seasons: transformSingleLevelGroup(data.seasons, 'season').map(season =>
       transformSeason(season as SeasonPrismicDocument)


### PR DESCRIPTION
## Who is this for?

Everyone who reads book extract articles. 
https://wellcome.slack.com/archives/C8X9YKM5X/p1664892831195689

## What is it doing for them?

The book article type is considered to be an article and will need a reading time. I've put a note to refactor this once I get a definitive list of what we consider to be an article, though explicitly don't call it that in `format`. 

After: 
<img width="1317" alt="Screenshot 2022-10-04 at 15 50 11" src="https://user-images.githubusercontent.com/16557524/193851812-c19e0092-90a7-43a6-84bc-c0280c9de879.png">


