### PR TITLE
Automatically desaturate contributor images

### DIFF
--- a/common/views/components/PrismicImage/PrismicImage.tsx
+++ b/common/views/components/PrismicImage/PrismicImage.tsx
@@ -4,8 +4,11 @@ import styled from 'styled-components';
 import { Breakpoint, sizes as breakpointSizes } from '../../themes/config';
 import { ImageType } from '../../../model/image';
 
-const StyledImage = styled(Image).attrs({ className: 'font-white' })`
+const StyledImage = styled(Image).attrs({
+  className: 'font-white',
+})<{ desaturate?: boolean }>`
   background-color: ${props => props.theme.color('neutral.700')};
+  ${props => (props.desaturate ? 'filter: saturate(0%);' : '')}
 `;
 
 export type BreakpointSizes = Partial<Record<Breakpoint, number>>;
@@ -15,6 +18,7 @@ export type Props = {
   // The maximum width at which the image will be displayed
   maxWidth?: number;
   quality: 'low' | 'high';
+  desaturate?: boolean;
 };
 
 export function convertBreakpointSizesToSizes(
@@ -86,7 +90,13 @@ export function createPrismicLoader(maxWidth: number, quality: ImageQuality) {
  * usurping UiImage which has reached a state where it is so bloated it is hard to refactor.
  * This is aimed solely at the Prismic image rendering for now.
  */
-const PrismicImage: FC<Props> = ({ image, sizes, maxWidth, quality }) => {
+const PrismicImage: FC<Props> = ({
+  image,
+  sizes,
+  maxWidth,
+  quality,
+  desaturate = false,
+}) => {
   const sizesString = sizes
     ? convertBreakpointSizesToSizes(sizes).join(', ')
     : undefined;
@@ -106,6 +116,7 @@ const PrismicImage: FC<Props> = ({ image, sizes, maxWidth, quality }) => {
       src={image.contentUrl}
       alt={image.alt || ''}
       loader={createPrismicLoader(maxLoaderWidth, quality)}
+      desaturate={desaturate}
     />
   );
 };

--- a/content/webapp/components/Contributors/Contributor.tsx
+++ b/content/webapp/components/Contributors/Contributor.tsx
@@ -4,15 +4,8 @@ import LinkLabels from '@weco/common/views/components/LinkLabels/LinkLabels';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
 import Space from '@weco/common/views/components/styled/Space';
 import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImage';
-import { getCrop, ImageType } from '@weco/common/model/image';
+import { getCrop } from '@weco/common/model/image';
 import { FC } from 'react';
-
-const ContributorImage: FC<{ image: ImageType }> = ({ image }) => (
-  // Contributor images should always be in black-and-white.  Most of
-  // them are uploaded this way in Prismic, but we can additionally
-  // add a filter here to catch any that are missed.
-  <PrismicImage image={image} maxWidth={72} quality="low" desaturate={true} />
-);
 
 const Contributor: FC<ContributorType> = ({
   contributor,
@@ -51,13 +44,32 @@ const Contributor: FC<ContributorType> = ({
                   transform: 'rotateZ(6deg) scale(1.2)',
                 }}
               >
-                <ContributorImage image={contributorImage} />
+                {/*
+                  Contributor images should always be in black-and-white. Most
+                  of them are uploaded this way in Prismic, but we can
+                  additionally add a filter here to catch any that are missed.
+                */}
+                <PrismicImage
+                  image={contributorImage}
+                  maxWidth={72}
+                  quality="low"
+                  desaturate={true}
+                />
               </div>
             </div>
           )}
           {contributorImage && contributor.type === 'organisations' && (
             <div style={{ width: '72px' }}>
-              <ContributorImage image={contributorImage} />
+              {/*
+                For now don't desaturate organisation images, brands can be picky
+                about that sort of thing.
+              */}
+              <PrismicImage
+                image={contributorImage}
+                maxWidth={72}
+                quality="low"
+                desaturate={false}
+              />
             </div>
           )}
         </Space>

--- a/content/webapp/components/Contributors/Contributor.tsx
+++ b/content/webapp/components/Contributors/Contributor.tsx
@@ -4,8 +4,15 @@ import LinkLabels from '@weco/common/views/components/LinkLabels/LinkLabels';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
 import Space from '@weco/common/views/components/styled/Space';
 import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImage';
-import { getCrop } from '@weco/common/model/image';
+import { getCrop, ImageType } from '@weco/common/model/image';
 import { FC } from 'react';
+
+const ContributorImage: FC<{ image: ImageType }> = ({ image }) => (
+  // Contributor images should always be in black-and-white.  Most of
+  // them are uploaded this way in Prismic, but we can additionally
+  // add a filter here to catch any that are missed.
+  <PrismicImage image={image} maxWidth={72} quality="low" desaturate={true} />
+);
 
 const Contributor: FC<ContributorType> = ({
   contributor,
@@ -44,21 +51,13 @@ const Contributor: FC<ContributorType> = ({
                   transform: 'rotateZ(6deg) scale(1.2)',
                 }}
               >
-                <PrismicImage
-                  image={contributorImage}
-                  maxWidth={72}
-                  quality="low"
-                />
+                <ContributorImage image={contributorImage} />
               </div>
             </div>
           )}
           {contributorImage && contributor.type === 'organisations' && (
             <div style={{ width: '72px' }}>
-              <PrismicImage
-                image={contributorImage}
-                maxWidth={72}
-                quality="low"
-              />
+              <ContributorImage image={contributorImage} />
             </div>
           )}
         </Space>


### PR DESCRIPTION
## Who is this for?

Alice and the rest of Editorial.

## What is it doing for them?

Contributor images should always be black-and-white, but occasionally they're not, see https://wellcomecollection.org/events/YvTvQxAAACMA2dO4

This applies `filter: saturate(0%)` to desaturate any colourful contributor images that slip through.