### PR TITLE
Add pagination buttons to article series

### DIFF
--- a/common/views/themes/utility-classes.ts
+++ b/common/views/themes/utility-classes.ts
@@ -155,10 +155,6 @@ export const utilityClasses = css<GlobalStyleProps>`
     text-decoration: underline;
   }
 
-  .text-align-right {
-    text-align: right;
-  }
-
   .text-align-center {
     text-align: center;
   }

--- a/content/webapp/components/LayoutPaginatedResults/LayoutPaginatedResults.tsx
+++ b/content/webapp/components/LayoutPaginatedResults/LayoutPaginatedResults.tsx
@@ -17,6 +17,7 @@ import { BookBasic } from '../../types/books';
 import { Guide } from '../../types/guides';
 import * as prismicT from '@prismicio/types';
 import { ExhibitionGuideBasic } from '../../types/exhibition-guides';
+import styled from 'styled-components';
 
 type PaginatedResultsTypes =
   | PaginatedResults<ExhibitionBasic>
@@ -34,6 +35,10 @@ type Props = {
   showFreeAdmissionMessage: boolean;
   children?: ReactElement;
 };
+
+const PaginationWrapper = styled(Layout12)`
+  text-align: right;
+`;
 
 const LayoutPaginatedResults: FC<Props> = ({
   title,
@@ -101,21 +106,19 @@ const LayoutPaginatedResults: FC<Props> = ({
 
     {paginatedResults.totalPages > 1 && (
       <Space v={{ size: 'm', properties: ['padding-top', 'padding-bottom'] }}>
-        <Layout12>
-          <div className="text-align-right">
-            <Pagination
-              paginatedResults={paginatedResults}
-              paginationRoot={{
-                href: {
-                  pathname: paginationRoot,
-                },
-                as: {
-                  pathname: paginationRoot,
-                },
-              }}
-            />
-          </div>
-        </Layout12>
+        <PaginationWrapper>
+          <Pagination
+            paginatedResults={paginatedResults}
+            paginationRoot={{
+              href: {
+                pathname: paginationRoot,
+              },
+              as: {
+                pathname: paginationRoot,
+              },
+            }}
+          />
+        </PaginationWrapper>
       </Space>
     )}
   </>

--- a/content/webapp/pages/article-series.tsx
+++ b/content/webapp/pages/article-series.tsx
@@ -143,11 +143,13 @@ const ArticleSeriesPage: FC<Props> = props => {
     />
   );
 
+  const paginationRoot = `/series/${series.id}`;
+
   return (
     <PageLayout
       title={series.title}
       description={series.metadataDescription || series.promo?.caption || ''}
-      url={{ pathname: `/series/${series.id}` }}
+      url={{ pathname: paginationRoot }}
       jsonLd={{ '@type': 'WebPage' }}
       siteSection={'stories'}
       openGraphType={'website'}
@@ -167,31 +169,15 @@ const ArticleSeriesPage: FC<Props> = props => {
           >
             <div className="text-align-right">
               <Pagination
-                totalResults={articles.totalResults}
-                currentPage={articles.currentPage}
-                totalPages={articles.totalPages}
-                prevPage={
-                  articles.currentPage > 1
-                    ? articles.currentPage - 1
-                    : undefined
-                }
-                nextPage={
-                  articles.currentPage < articles.totalPages
-                    ? articles.currentPage + 1
-                    : undefined
-                }
-                prevQueryString={
-                  `/series/${series.id}` +
-                  (articles.currentPage > 1
-                    ? `?page=${articles.currentPage - 1}`
-                    : '')
-                }
-                nextQueryString={
-                  `/series/${series.id}` +
-                  (articles.currentPage < articles.totalPages
-                    ? `?page=${articles.currentPage + 1}`
-                    : '')
-                }
+                paginatedResults={articles}
+                paginationRoot={{
+                  href: {
+                    pathname: paginationRoot,
+                  },
+                  as: {
+                    pathname: paginationRoot,
+                  },
+                }}
               />
             </div>
           </Space>

--- a/content/webapp/pages/article-series.tsx
+++ b/content/webapp/pages/article-series.tsx
@@ -34,7 +34,6 @@ import {
 import { transformQuery } from 'services/prismic/transformers/paginated-results';
 import Space from '@weco/common/views/components/styled/Space';
 import Pagination from '@weco/common/views/components/Pagination/Pagination';
-import Layout10 from '@weco/common/views/components/Layout10/Layout10';
 
 type Props = {
   series: Series;
@@ -166,37 +165,35 @@ const ArticleSeriesPage: FC<Props> = props => {
           <Space
             v={{ size: 'm', properties: ['padding-top', 'padding-bottom'] }}
           >
-            <Layout10>
-              <div className="text-align-right">
-                <Pagination
-                  totalResults={articles.totalResults}
-                  currentPage={articles.currentPage}
-                  totalPages={articles.totalPages}
-                  prevPage={
-                    articles.currentPage > 1
-                      ? articles.currentPage - 1
-                      : undefined
-                  }
-                  nextPage={
-                    articles.currentPage < articles.totalPages
-                      ? articles.currentPage + 1
-                      : undefined
-                  }
-                  prevQueryString={
-                    `/series/${series.id}` +
-                    (articles.currentPage > 1
-                      ? `?page=${articles.currentPage - 1}`
-                      : '')
-                  }
-                  nextQueryString={
-                    `/series/${series.id}` +
-                    (articles.currentPage < articles.totalPages
-                      ? `?page=${articles.currentPage + 1}`
-                      : '')
-                  }
-                />
-              </div>
-            </Layout10>
+            <div className="text-align-right">
+              <Pagination
+                totalResults={articles.totalResults}
+                currentPage={articles.currentPage}
+                totalPages={articles.totalPages}
+                prevPage={
+                  articles.currentPage > 1
+                    ? articles.currentPage - 1
+                    : undefined
+                }
+                nextPage={
+                  articles.currentPage < articles.totalPages
+                    ? articles.currentPage + 1
+                    : undefined
+                }
+                prevQueryString={
+                  `/series/${series.id}` +
+                  (articles.currentPage > 1
+                    ? `?page=${articles.currentPage - 1}`
+                    : '')
+                }
+                nextQueryString={
+                  `/series/${series.id}` +
+                  (articles.currentPage < articles.totalPages
+                    ? `?page=${articles.currentPage + 1}`
+                    : '')
+                }
+              />
+            </div>
           </Space>
         )}
       </ContentPage>

--- a/content/webapp/pages/article-series.tsx
+++ b/content/webapp/pages/article-series.tsx
@@ -34,6 +34,7 @@ import {
 import { transformQuery } from 'services/prismic/transformers/paginated-results';
 import Space from '@weco/common/views/components/styled/Space';
 import Pagination from '@weco/common/views/components/Pagination/Pagination';
+import styled from 'styled-components';
 
 type Props = {
   series: Series;
@@ -145,6 +146,12 @@ const ArticleSeriesPage: FC<Props> = props => {
 
   const paginationRoot = `/series/${series.id}`;
 
+  const PaginationWrapper = styled(Space).attrs({
+    v: { size: 'm', properties: ['padding-top', 'padding-bottom'] },
+  })`
+    text-align: right;
+  `;
+
   return (
     <PageLayout
       title={series.title}
@@ -164,23 +171,19 @@ const ArticleSeriesPage: FC<Props> = props => {
       >
         <SearchResults items={series.items} showPosition={true} />
         {articles.totalPages > 1 && (
-          <Space
-            v={{ size: 'm', properties: ['padding-top', 'padding-bottom'] }}
-          >
-            <div className="text-align-right">
-              <Pagination
-                paginatedResults={articles}
-                paginationRoot={{
-                  href: {
-                    pathname: paginationRoot,
-                  },
-                  as: {
-                    pathname: paginationRoot,
-                  },
-                }}
-              />
-            </div>
-          </Space>
+          <PaginationWrapper>
+            <Pagination
+              paginatedResults={articles}
+              paginationRoot={{
+                href: {
+                  pathname: paginationRoot,
+                },
+                as: {
+                  pathname: paginationRoot,
+                },
+              }}
+            />
+          </PaginationWrapper>
         )}
       </ContentPage>
     </PageLayout>

--- a/content/webapp/pages/exhibitions.tsx
+++ b/content/webapp/pages/exhibitions.tsx
@@ -27,6 +27,7 @@ import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/Pri
 import { headerBackgroundLs } from '@weco/common/utils/backgrounds';
 import Pagination from '@weco/common/views/components/Pagination/Pagination';
 import { isFuture } from '@weco/common/utils/dates';
+import styled from 'styled-components';
 
 type Props = {
   exhibitions: PaginatedResults<ExhibitionBasic>;
@@ -69,6 +70,10 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       return { notFound: true };
     }
   };
+
+const PaginationWrapper = styled(Layout12)`
+  text-align: right;
+`;
 
 const ExhibitionsPage: FC<Props> = props => {
   const { exhibitions, period, title, jsonLd } = props;
@@ -156,21 +161,19 @@ const ExhibitionsPage: FC<Props> = props => {
               itemsPerRow={3}
             />
             {exhibitions.totalPages > 1 && (
-              <Layout12>
-                <div className="text-align-right">
-                  <Pagination
-                    paginatedResults={exhibitions}
-                    paginationRoot={{
-                      href: {
-                        pathname: paginationRoot,
-                      },
-                      as: {
-                        pathname: paginationRoot,
-                      },
-                    }}
-                  />
-                </div>
-              </Layout12>
+              <PaginationWrapper>
+                <Pagination
+                  paginatedResults={exhibitions}
+                  paginationRoot={{
+                    href: {
+                      pathname: paginationRoot,
+                    },
+                    as: {
+                      pathname: paginationRoot,
+                    },
+                  }}
+                />
+              </PaginationWrapper>
             )}
           </SpacingSection>
         </>


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/wellcomecollection.org/issues/7633

## Who is this for?

Our most dedicated and devoted readers!

## What is it doing for them?

Allowing them to read every article in especially long series, e.g. Body Squabbles https://wellcomecollection.org/series/WleP3iQAACUAYEoN

I modelled it on the articles page, sticking two pagination buttons at the bottom of the list:

<img width="1126" alt="Screenshot 2022-10-05 at 12 09 58" src="https://user-images.githubusercontent.com/301220/194047335-47fa657d-8815-4e07-8412-8f65f08dddf3.png">

I considered putting an indicator of total count somewhere on the page, e.g. "1 – 20 of 120", but I couldn't find a good place to put it and this doesn't seem worth our currently limited design resource. It closes a functional gap; if it needs improving we can come back and give it more time later.