### PR TITLE
Filter exhibition guide links

### DIFF
--- a/content/webapp/components/ExhibitionGuideLinksPromo/ExhibitionGuideLinksPromo.tsx
+++ b/content/webapp/components/ExhibitionGuideLinksPromo/ExhibitionGuideLinksPromo.tsx
@@ -31,24 +31,31 @@ type Props = {
 // We use this Promo for Exhibition Guides when we want to link to the individual types within a guide
 // and not just the guide itself
 const ExhibitionGuideLinksPromo: FC<Props> = ({ exhibitionGuide }) => {
-  const links = [
-    {
+  const links: { url: string; text: string }[] = [];
+  if (exhibitionGuide.availableTypes.audioWithoutDescriptions) {
+    links.push({
       url: `/guides/exhibitions/${exhibitionGuide.id}/audio-without-descriptions`,
       text: 'Listen to audio guide, without audio description',
-    },
-    {
+    });
+  }
+  if (exhibitionGuide.availableTypes.audioWithDescriptions) {
+    links.push({
       url: `/guides/exhibitions/${exhibitionGuide.id}/audio-with-descriptions`,
       text: 'Listen to audio guide, with audio description',
-    },
-    {
+    });
+  }
+  if (exhibitionGuide.availableTypes.captionsOrTranscripts) {
+    links.push({
       url: `/guides/exhibitions/${exhibitionGuide.id}/captions-and-transcripts`,
       text: 'Read captions and transcriptions',
-    },
-    {
+    });
+  }
+  if (exhibitionGuide.availableTypes.BSLVideo) {
+    links.push({
       url: `/guides/exhibitions/${exhibitionGuide.id}/bsl`,
       text: 'Watch BSL videos',
-    },
-  ];
+    });
+  }
   return (
     <>
       <ExhibitionTitleLink href={`/guides/exhibitions/${exhibitionGuide.id}`}>

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -346,8 +346,13 @@ const ExhibitionStops: FC<StopsProps> = ({ stops, type }) => {
 };
 
 type ExhibitionLinksProps = {
-  stops: ExhibitionGuideComponent[];
   pathname: string;
+  availableTypes: {
+    BSLVideo: boolean;
+    captionsOrTranscripts: boolean;
+    audioWithoutDescriptions: boolean;
+    audioWithDescriptions: boolean;
+  };
 };
 
 function cookieHandler(key: string, data: string) {
@@ -356,24 +361,13 @@ function cookieHandler(key: string, data: string) {
   setCookie(key, data, options);
 }
 
-const ExhibitionLinks: FC<ExhibitionLinksProps> = ({ stops, pathname }) => {
-  const hasBSLVideo = stops.some(
-    stop => stop.bsl.embedUrl // it can't be undefined can it?
-  );
-  const hasCaptionsOrTranscripts = stops.some(
-    stop => stop.caption.length > 0 || stop.transcription.length > 0
-  );
-
-  const hasAudioWithoutDescriptions = stops.some(
-    stop => stop.audioWithoutDescription?.url
-  );
-  const hasAudioWithDescriptions = stops.some(
-    stop => stop.audioWithDescription?.url
-  );
-
+const ExhibitionLinks: FC<ExhibitionLinksProps> = ({
+  pathname,
+  availableTypes,
+}) => {
   return (
     <TypeList>
-      {hasAudioWithoutDescriptions && (
+      {availableTypes.audioWithoutDescriptions && (
         <TypeOption
           url={`/${pathname}/audio-without-descriptions`}
           title="Listen, without audio descriptions"
@@ -387,7 +381,7 @@ const ExhibitionLinks: FC<ExhibitionLinksProps> = ({ stops, pathname }) => {
           }}
         />
       )}
-      {hasAudioWithDescriptions && (
+      {availableTypes.audioWithDescriptions && (
         <TypeOption
           url={`/${pathname}/audio-with-descriptions`}
           title="Listen, with audio descriptions"
@@ -403,7 +397,7 @@ const ExhibitionLinks: FC<ExhibitionLinksProps> = ({ stops, pathname }) => {
           }}
         />
       )}
-      {hasCaptionsOrTranscripts && (
+      {availableTypes.captionsOrTranscripts && (
         <TypeOption
           url={`/${pathname}/captions-and-transcripts`}
           title="Read captions and transcripts"
@@ -419,7 +413,7 @@ const ExhibitionLinks: FC<ExhibitionLinksProps> = ({ stops, pathname }) => {
           }}
         />
       )}
-      {hasBSLVideo && (
+      {availableTypes.BSLVideo && (
         <TypeOption
           url={`/${pathname}/bsl`}
           title="Watch BSL videos"
@@ -493,7 +487,7 @@ const ExhibitionGuidePage: FC<Props> = props => {
             </Space>
             <Space v={{ size: 'l', properties: ['margin-top'] }}>
               <ExhibitionLinks
-                stops={exhibitionGuide.components}
+                availableTypes={exhibitionGuide.availableTypes}
                 pathname={pathname}
               />
             </Space>

--- a/content/webapp/services/prismic/transformers/exhibition-guides.ts
+++ b/content/webapp/services/prismic/transformers/exhibition-guides.ts
@@ -51,13 +51,11 @@ import { transformImagePromo } from './images';
 // const filterByGuide = components.filter(value => {
 //   return components[value].caption;
 // });
-//
-// TODO: Filters for guide types
 
 export function transformExhibitionGuideToExhibitionGuideBasic(
   exhibitionGuide: ExhibitionGuide
 ): ExhibitionGuideBasic {
-  // returns what is required to render StoryPromos and story JSON-LD
+  // returns what is required to render ExhibitionGuideLinkPromo
   return (({
     title,
     introText,
@@ -66,6 +64,7 @@ export function transformExhibitionGuideToExhibitionGuideBasic(
     image,
     promo,
     relatedExhibition,
+    availableTypes,
   }) => ({
     title,
     introText,
@@ -74,6 +73,7 @@ export function transformExhibitionGuideToExhibitionGuideBasic(
     image,
     promo,
     relatedExhibition,
+    availableTypes,
   }))(exhibitionGuide);
 }
 
@@ -151,6 +151,18 @@ export function transformExhibitionGuide(
     ? transformRelatedExhibition(data['related-exhibition'])
     : undefined;
 
+  const hasBSLVideo = components.some(component => component.bsl.embedUrl);
+  const hasCaptionsOrTranscripts = components.some(
+    component =>
+      component.caption.length > 0 || component.transcription.length > 0
+  );
+  const hasAudioWithoutDescriptions = components.some(
+    component => component.audioWithoutDescription?.url
+  );
+  const hasAudioWithDescriptions = components.some(
+    component => component.audioWithDescription?.url
+  );
+
   return {
     title: relatedExhibition?.title || '',
     introText,
@@ -159,5 +171,11 @@ export function transformExhibitionGuide(
     relatedExhibition,
     components,
     id: document.id,
+    availableTypes: {
+      BSLVideo: hasBSLVideo,
+      captionsOrTranscripts: hasCaptionsOrTranscripts,
+      audioWithoutDescriptions: hasAudioWithoutDescriptions,
+      audioWithDescriptions: hasAudioWithDescriptions,
+    },
   };
 }

--- a/content/webapp/types/exhibition-guides.ts
+++ b/content/webapp/types/exhibition-guides.ts
@@ -42,6 +42,12 @@ export type ExhibitionGuideBasic = {
   image?: ImageType;
   promo?: ImagePromo;
   relatedExhibition: Exhibit | undefined;
+  availableTypes: {
+    BSLVideo: boolean;
+    captionsOrTranscripts: boolean;
+    audioWithoutDescriptions: boolean;
+    audioWithDescriptions: boolean;
+  };
 };
 
 export type ExhibitionGuide = ExhibitionGuideBasic & {


### PR DESCRIPTION
This filters the type links (BSL, captions etc.) in the exhibition guide promos, so that they are only included if there is content of that type attached to the guide. See https://wellcome.slack.com/archives/CUA669WHH/p1664982249431029

Before:
<img width="1042" alt="Screenshot 2022-10-05 at 16 03 45" src="https://user-images.githubusercontent.com/6051896/194112539-c7b4e45f-7d9d-4535-93ee-60388a1e0509.png">

After: 
![Screenshot 2022-10-05 at 17 28 07](https://user-images.githubusercontent.com/6051896/194112658-8b143222-e52f-4713-8726-22e61e2d41ae.png)

