### PR TITLE
 use title if we have it for a stop, otherwise use standalone title

### DIFF
--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -292,6 +292,7 @@ const Stops: FC<StopsProps> = ({ stops, type }) => {
               audioWithoutDescription,
               bsl,
               title,
+              standaloneTitle,
             } = stop;
             const hasContentOfDesiredType =
               (type === 'audio-with-descriptions' &&
@@ -308,14 +309,22 @@ const Stops: FC<StopsProps> = ({ stops, type }) => {
                 {type === 'audio-with-descriptions' &&
                   audioWithDescription?.url && (
                     <AudioPlayer
-                      title={`${number}. ${stop.title}`}
+                      title={
+                        stop.title
+                          ? `${number}. ${stop.title}`
+                          : `${number}. ${standaloneTitle}`
+                      }
                       audioFile={audioWithDescription.url}
                     />
                   )}
                 {type === 'audio-without-descriptions' &&
                   audioWithoutDescription?.url && (
                     <AudioPlayer
-                      title={`${number}. ${stop.title}`}
+                      title={
+                        stop.title
+                          ? `${number}. ${stop.title}`
+                          : `${number}. ${standaloneTitle}`
+                      }
                       audioFile={audioWithoutDescription.url}
                     />
                   )}


### PR DESCRIPTION

## Who is this for?

Users of exhibition guides and hopefully covers bug flagged by Danny and Alice 
https://github.com/wellcomecollection/wellcomecollection.org/issues/8485

## What is it doing for them?
Making use of the title if we have it, otherwise using the standalone title. I think this gives us the behaviour we want, but I'll check with Alice and Danny.

Before:
<img width="1317" alt="Screenshot 2022-10-06 at 09 36 02" src="https://user-images.githubusercontent.com/16557524/194264216-f81d9716-1e23-4e48-8c93-1a8480acd0d5.png">


After: 
<img width="1317" alt="Screenshot 2022-10-06 at 09 35 34" src="https://user-images.githubusercontent.com/16557524/194264185-4919a961-982a-467d-948d-c4c2431f5305.png">

