### PR TITLE
Remove unused id causing duplicate a11y issues

### DIFF
--- a/common/views/components/Footer/FooterNav.tsx
+++ b/common/views/components/Footer/FooterNav.tsx
@@ -95,9 +95,9 @@ const FooterNav = ({
       aria-label="Footer navigation"
       isInline={isInline}
     >
-      {itemsList.map((link, i) => (
+      {itemsList.map(link => (
         <li key={link.title}>
-          <NavLinkElement id={`footer-nav-${i}`} as="a" href={link.href}>
+          <NavLinkElement as="a" href={link.href}>
             {link.title}
           </NavLinkElement>
         </li>


### PR DESCRIPTION
## Who is this for?
a11y

## What is it doing for them?
Removes duplicate IDs in footer navigation, these weren't useful names either so I removed them. 