### PR TITLE
Run a CloudFront invalidation after pa11y deployments

### DIFF
--- a/pa11y/webapp/deploy.js
+++ b/pa11y/webapp/deploy.js
@@ -1,5 +1,5 @@
 const AWS = require('aws-sdk');
-const s3 = new AWS.S3({apiVersion: '2006-03-01'});
+const s3 = new AWS.S3({ apiVersion: '2006-03-01' });
 
 const fs = require('fs');
 
@@ -8,19 +8,16 @@ try {
 
   const params = {
     Body: data,
-    Bucket: "dash.wellcomecollection.org",
-    Key: "pa11y/report.json",
-    ACL: "public-read",
-    ContentType: "application/json"
+    Bucket: 'dash.wellcomecollection.org',
+    Key: 'pa11y/report.json',
+    ACL: 'public-read',
+    ContentType: 'application/json',
   };
 
-  s3.putObject(params, function(err, data) {
+  s3.putObject(params, function (err, data) {
     if (err) console.log(err, err.stack);
-    else     console.log("Finished uploading report.json");
+    else console.log('Finished uploading report.json');
   });
-
-} catch(e) {
+} catch (e) {
   console.log('Error:', e.stack);
 }
-
-

--- a/pa11y/webapp/deploy.js
+++ b/pa11y/webapp/deploy.js
@@ -1,5 +1,6 @@
 const AWS = require('aws-sdk');
 const s3 = new AWS.S3({ apiVersion: '2006-03-01' });
+const cloudfront = new AWS.CloudFront({ apiVersion: '2006-03-01' });
 
 const fs = require('fs');
 
@@ -18,6 +19,20 @@ try {
     if (err) console.log(err, err.stack);
     else console.log('Finished uploading report.json');
   });
+
+  cloudfront.createInvalidation(
+    {
+      DistributionId: 'EIOS79GG23UUY',
+      InvalidationBatch: {
+        Paths: { Items: ['/pa11y/report.json'], Quantity: 1 },
+        CallerReference: `Pa11yDeployInvalidationCallerReference${Date.now()}`,
+      },
+    },
+    function (err, data) {
+      if (err) console.log(err, err.stack);
+      else console.log('Flushed CloudFront cache for report.json');
+    }
+  );
 } catch (e) {
   console.log('Error:', e.stack);
 }

--- a/pa11y/webapp/deploy.js
+++ b/pa11y/webapp/deploy.js
@@ -1,6 +1,6 @@
 const AWS = require('aws-sdk');
 const s3 = new AWS.S3({ apiVersion: '2006-03-01' });
-const cloudfront = new AWS.CloudFront({ apiVersion: '2006-03-01' });
+const cloudfront = new AWS.CloudFront();
 
 const fs = require('fs');
 

--- a/pa11y/webapp/write-report.js
+++ b/pa11y/webapp/write-report.js
@@ -23,9 +23,13 @@ const urls = [
   'https://wellcomecollection.org/event-series/WlYT_SQAACcAWccj',
 ];
 
-const promises = urls.map(url => pa11y(url, {chromeLaunchConfig: {
-    args: ['--no-sandbox']
-}}));
+const promises = urls.map(url =>
+  pa11y(url, {
+    chromeLaunchConfig: {
+      args: ['--no-sandbox'],
+    },
+  })
+);
 
 Promise.all(promises).then(async results => {
   await mkdirp('./.dist');


### PR DESCRIPTION
## Who is this for?

Devs.

## What is it doing for them?

Raphaëlle and I noticed that the pa11y report is being cached by CloudFront, so results can be delayed after a deployment. This adds an invalidation after the report is uploaded to S3, so results should appear immediately. 