### PR TITLE
Remove concept toggle

### DIFF
--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -53,7 +53,6 @@ import {
   itemIsRequestable,
   itemIsTemporarilyUnavailable,
 } from '../../utils/requesting';
-import { useToggles } from '@weco/common/server-data/Context';
 import { themeValues } from '@weco/common/views/themes/config';
 import { formatDuration } from '@weco/common/utils/format-date';
 
@@ -318,8 +317,6 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
       </>
     );
   };
-
-  const toggles = useToggles();
 
   const renderContent = () => (
     <>
@@ -653,11 +650,8 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
               /*
               If this is an identified contributor, link to the concepts prototype
               page instead.
-
-              The prototype page will only display if you have the toggle enabled,
-              so don't link there if you don't have the toggle.
               */
-              return toggles.conceptsPages && contributor.agent.id
+              return contributor.agent.id
                 ? {
                     textParts,
                     linkAttributes: {
@@ -748,11 +742,8 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
               /*
               If this is an identified subject, link to the concepts prototype
               page instead.
-
-              The prototype page will only display if you have the toggle enabled,
-              so don't display it if you don't have the toggle.
               */
-              return toggles.conceptsPages && s.id
+              return s.id
                 ? {
                     textParts: [s.concepts[0].label].concat(
                       s.concepts.slice(1).map(c => c.label)

--- a/catalogue/webapp/pages/concept.tsx
+++ b/catalogue/webapp/pages/concept.tsx
@@ -377,14 +377,6 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     const serverData = await getServerData(context);
     const { id } = context.query;
 
-    // Note: These pages don't need to be behind a toggle, but I'm putting them here
-    // as a way to test the concepts toggle.
-    //
-    // We will want a toggle in place for linking to concepts from works pages.
-    if (!serverData.toggles.conceptsPages) {
-      return { notFound: true };
-    }
-
     if (!looksLikeCanonicalId(id)) {
       return { notFound: true };
     }

--- a/playwright/test/concept.test.ts
+++ b/playwright/test/concept.test.ts
@@ -8,18 +8,10 @@ const domain = new URL(baseUrl).host;
 
 const test = base.extend({
   context: async ({ context }, use) => {
-    const defaultToggleCookies = await makeDefaultToggleCookies(domain);
-
-    // This adds the conceptsPages toggle so the e2e tests can see the concept pages,
-    // but once they're out from behind a toggle we can remove this.
+    const defaultToggleAndTestCookies = await makeDefaultToggleCookies(domain);
     await context.addCookies([
-      {
-        name: 'toggle_conceptsPages',
-        value: 'true',
-        domain,
-        path: '/',
-      },
-      ...defaultToggleCookies.filter(c => c.name !== 'toggle_conceptsPages'),
+      { name: 'WC_cookiesAccepted', value: 'true', domain: domain, path: '/' },
+      ...defaultToggleAndTestCookies,
     ]);
 
     await use(context);

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -43,13 +43,6 @@ const toggles = {
       description: 'A toolbar to help us navigate the secret depths of the API',
     },
     {
-      id: 'conceptsPages',
-      title: 'Concepts pages',
-      initialValue: false,
-      description:
-        'View pages for concepts (subjects and people) and link to them from works pages',
-    },
-    {
       id: 'exhibitionGuides',
       title: 'Exhibition guides',
       initialValue: false,


### PR DESCRIPTION
## Who is this for?
Devs/Clean code likers

## What is it doing for them?
Removing traces of the ConceptPages toggle as we don't think we'll need it moving forward.