### PR TITLE
Add more formats to the 'showReadingTime' function

### DIFF
--- a/content/webapp/services/prismic/transformers/articles.ts
+++ b/content/webapp/services/prismic/transformers/articles.ts
@@ -134,14 +134,17 @@ export function transformArticle(document: ArticlePrismicDocument): Article {
   // are a few formats we consider to be 'articles' even if their Prismic 'format'
   // doesn't return them as 'Article' e.g. Book extracts
   // TODO: get definitive list of what we consider to be article and refactor the below function to account for that
+  console.log(format, 'what is the format <<<<<');
   const showReadingTime = format
     ? Boolean(
         format?.title === 'Article' ||
           format?.title === 'Serial' ||
-          format?.title === 'Book extract'
+          format?.title === 'Book extract' ||
+          format?.title === 'Long read' ||
+          format?.title === 'Photo story' ||
+          format?.title === 'Prose Poem'
       )
     : Boolean(labels[0]?.text === 'Serial' || labels[0]?.text === 'Article');
-
 
   return {
     ...genericFields,

--- a/content/webapp/services/prismic/transformers/articles.ts
+++ b/content/webapp/services/prismic/transformers/articles.ts
@@ -134,7 +134,6 @@ export function transformArticle(document: ArticlePrismicDocument): Article {
   // are a few formats we consider to be 'articles' even if their Prismic 'format'
   // doesn't return them as 'Article' e.g. Book extracts
   // TODO: get definitive list of what we consider to be article and refactor the below function to account for that
-  console.log(format, 'what is the format <<<<<');
   const showReadingTime = format
     ? Boolean(
         format?.title === 'Article' ||


### PR DESCRIPTION
## Who is this for?
Editorial, and anyone reading articles https://github.com/wellcomecollection/wellcomecollection.org/issues/8601

## What is it doing for them?
Adding in photo story, long read and prose poem to the included readingTime for articles