### PR TITLE
Simplify Divider component

### DIFF
--- a/cardigan/stories/components/Divider/Divider.stories.mdx
+++ b/cardigan/stories/components/Divider/Divider.stories.mdx
@@ -17,8 +17,4 @@ import * as stories from './Divider.stories.tsx';
   <Story story={stories.stub} />
 </Canvas>
 
-<Canvas>
-  <Story story={stories.thick} />
-</Canvas>
-
 <ArgsTable />

--- a/cardigan/stories/components/Divider/Divider.stories.mdx
+++ b/cardigan/stories/components/Divider/Divider.stories.mdx
@@ -10,9 +10,15 @@ import * as stories from './Divider.stories.tsx';
 <Description>{Readme}</Description>
 
 <Canvas>
-  <Story story={stories.keyline} />
+  <Story story={stories.basic} />
+</Canvas>
+
+<Canvas>
   <Story story={stories.stub} />
-  <Story story={stories.thin} />
+</Canvas>
+
+<Canvas>
+  <Story story={stories.thick} />
 </Canvas>
 
 <ArgsTable />

--- a/cardigan/stories/components/Divider/Divider.stories.tsx
+++ b/cardigan/stories/components/Divider/Divider.stories.tsx
@@ -1,20 +1,51 @@
+import styled from 'styled-components';
 import Divider from '@weco/common/views/components/Divider/Divider';
 
-const Template = args => <Divider {...args} />;
-export const keyline = Template.bind({});
-keyline.args = {
-  color: 'black',
-  isKeyline: true,
+const Container = styled.div<{ backgroundColor: 'white' | 'black' }>`
+  padding: 2rem 0;
+  ${props =>
+    props.backgroundColor &&
+    `background-color: ${props.theme.color(props.backgroundColor)}`};
+`;
+
+const Wrapper = styled.div`
+  margin: 0 2rem;
+`;
+
+const Template = args => {
+  const { backgroundColor, ...rest } = args;
+  return (
+    <Container backgroundColor={backgroundColor}>
+      <Wrapper>
+        <Divider {...rest} />
+      </Wrapper>
+    </Container>
+  );
+};
+
+export const basic = Template.bind({});
+basic.args = {
+  backgroundColor: 'white',
+  variant: 'default',
 };
 
 export const stub = Template.bind({});
 stub.args = {
   color: 'black',
-  isStub: true,
+  variant: 'stub',
+  backgroundColor: 'white',
 };
 
-export const thin = Template.bind({});
-thin.args = {
+export const thick = Template.bind({});
+thick.args = {
   color: 'black',
-  isThin: true,
+  variant: 'thick',
+  backgroundColor: 'white',
+};
+
+basic.argTypes = {
+  variant: {
+    control: { type: 'inline-radio' },
+    options: ['default', 'stub', 'thick'],
+  },
 };

--- a/cardigan/stories/components/Divider/Divider.stories.tsx
+++ b/cardigan/stories/components/Divider/Divider.stories.tsx
@@ -26,26 +26,18 @@ const Template = args => {
 export const basic = Template.bind({});
 basic.args = {
   backgroundColor: 'white',
-  variant: 'default',
 };
 
 export const stub = Template.bind({});
 stub.args = {
   color: 'black',
-  variant: 'stub',
-  backgroundColor: 'white',
-};
-
-export const thick = Template.bind({});
-thick.args = {
-  color: 'black',
-  variant: 'thick',
+  isStub: true,
   backgroundColor: 'white',
 };
 
 basic.argTypes = {
-  variant: {
-    control: { type: 'inline-radio' },
-    options: ['default', 'stub', 'thick'],
+  backgroundColor: {
+    control: { type: 'select' },
+    options: ['black', 'white'],
   },
 };

--- a/cardigan/stories/global/palette/palette.stories.tsx
+++ b/cardigan/stories/global/palette/palette.stories.tsx
@@ -136,7 +136,7 @@ export const Palette: FunctionComponent = () => (
   <>
     {Object.keys(paletteColors).map((category, i) => (
       <SectionWrapper key={category}>
-        {i !== 0 && <Divider color="black" isKeyline={true} />}
+        {i !== 0 && <Divider color="black" />}
         <SectionTitle>{paletteColors[category].label}</SectionTitle>
         <SectionDescription>
           {paletteColors[category].description}

--- a/catalogue/webapp/components/Download/Download.tsx
+++ b/catalogue/webapp/components/Download/Download.tsx
@@ -153,7 +153,7 @@ const Download: NextPage<Props> = ({
               {license && (
                 <>
                   <SpacingComponent>
-                    <Divider color="warmNeutral.400" isKeyline={true} />
+                    <Divider />
                   </SpacingComponent>
                   <SpacingComponent>
                     <div>

--- a/catalogue/webapp/components/Work/Work.tsx
+++ b/catalogue/webapp/components/Work/Work.tsx
@@ -140,7 +140,7 @@ const Work: FunctionComponent<Props> = ({
             </div>
 
             <div className="container">
-              <Divider color="warmNeutral.400" isKeyline={true} />
+              <Divider />
               <ArchiveDetailsContainer>
                 <ArchiveTree work={work} />
                 <Space

--- a/catalogue/webapp/components/WorkDetailsSection/WorkDetailsSection.tsx
+++ b/catalogue/webapp/components/WorkDetailsSection/WorkDetailsSection.tsx
@@ -19,7 +19,7 @@ const WorkDetailsSection: FunctionComponent<Props> = ({
     <>
       {!isArchive && (
         <>
-          <Divider color="warmNeutral.400" isKeyline={true} />
+          <Divider />
           <SpacingComponent />
         </>
       )}

--- a/common/views/components/Divider/Divider.tsx
+++ b/common/views/components/Divider/Divider.tsx
@@ -4,7 +4,7 @@ import { PaletteColor } from '@weco/common/views/themes/config';
 
 type Props = {
   color?: PaletteColor;
-  variant?: 'stub' | 'thick';
+  isStub?: boolean;
 };
 
 const Rule = styled.hr<Props>`
@@ -14,15 +14,12 @@ const Rule = styled.hr<Props>`
   ${props =>
     props.color && `background-color: ${props.theme.color(props.color)};`};
 
-  // Variants
-  ${props => props.variant === 'stub' && 'width: 60px; height: 5px;'}
-
-  ${props => props.variant === 'thick' && 'height: 2px;'}
+  ${props => props.isStub && 'width: 60px; height: 5px;'}
 `;
 
 const Divider: FunctionComponent<Props> = ({
   color = 'warmNeutral.400',
-  variant,
-}: Props): ReactElement => <Rule color={color} variant={variant} />;
+  isStub,
+}: Props): ReactElement => <Rule color={color} isStub={isStub} />;
 
 export default Divider;

--- a/common/views/components/Divider/Divider.tsx
+++ b/common/views/components/Divider/Divider.tsx
@@ -3,49 +3,26 @@ import styled from 'styled-components';
 import { PaletteColor } from '@weco/common/views/themes/config';
 
 type Props = {
-  color: PaletteColor;
-  isStub?: boolean;
-  isKeyline?: boolean;
-  isThin?: boolean;
+  color?: PaletteColor;
+  variant?: 'stub' | 'thick';
 };
 
 const Rule = styled.hr<Props>`
   text-align: left;
   border: 0;
-
+  height: 1px;
   ${props =>
-    props.color &&
-    `
-    background-color: ${props.theme.color(props.color)};
-  `}
+    props.color && `background-color: ${props.theme.color(props.color)};`};
 
-  ${props =>
-    props.isStub &&
-    `
-    width: 60px;
-    height: 5px;
-  `}
+  // Variants
+  ${props => props.variant === 'stub' && 'width: 60px; height: 5px;'}
 
-  ${props =>
-    props.isKeyline &&
-    `
-    height: 1px;
-  `}
-
-  ${props =>
-    props.isThin &&
-    `
-    height: 2px;
-  `}
+  ${props => props.variant === 'thick' && 'height: 2px;'}
 `;
 
 const Divider: FunctionComponent<Props> = ({
-  color,
-  isStub,
-  isKeyline,
-  isThin,
-}: Props): ReactElement => (
-  <Rule color={color} isStub={isStub} isKeyline={isKeyline} isThin={isThin} />
-);
+  color = 'warmNeutral.400',
+  variant,
+}: Props): ReactElement => <Rule color={color} variant={variant} />;
 
 export default Divider;

--- a/common/views/components/Divider/README.md
+++ b/common/views/components/Divider/README.md
@@ -1,5 +1,7 @@
 ## Purpose
 
-To provide a visual separation of page sections.
+To provide a visual separation of page sections. 
+
+It defaults to a `height` of `1px` and uses `warmNeutral.400` as a color. Both can be changed by using Divider props.
 
 [Edit this on GitHub](https://github.com/wellcomecollection/wellcomecollection.org/edit/main/common/views/components/Divider/README.md)

--- a/common/views/components/Footer/Footer.tsx
+++ b/common/views/components/Footer/Footer.tsx
@@ -190,7 +190,7 @@ const Footer: FC<Props> = ({ venues, hide = false }: Props) => {
           </InternalNavigationContainer>
 
           <FullWidthDivider>
-            <Divider color="neutral.700" isKeyline />
+            <Divider color="neutral.700" />
           </FullWidthDivider>
 
           <PoliciesContainer>

--- a/content/webapp/components/EventPromo/EventPromo.tsx
+++ b/content/webapp/components/EventPromo/EventPromo.tsx
@@ -206,7 +206,7 @@ const EventPromo: FC<Props> = ({
           h={{ size: 'm', properties: ['padding-left', 'padding-right'] }}
           v={{ size: 'm', properties: ['padding-bottom'] }}
         >
-          <Divider color="white" isKeyline={true} />
+          <Divider color="white" />
           <Space v={{ size: 's', properties: ['padding-top'] }}>
             <LabelsList
               labels={event.secondaryLabels}

--- a/content/webapp/components/LayoutPaginatedResults/LayoutPaginatedResults.tsx
+++ b/content/webapp/components/LayoutPaginatedResults/LayoutPaginatedResults.tsx
@@ -83,7 +83,7 @@ const LayoutPaginatedResults: FC<Props> = ({
             ? paginatedResults.totalResults
             : null}
         </Space>
-        <Divider color="warmNeutral.400" isKeyline={true} />
+        <Divider />
       </Layout12>
     )}
     {showFreeAdmissionMessage && (

--- a/content/webapp/components/Outro/Outro.tsx
+++ b/content/webapp/components/Outro/Outro.tsx
@@ -64,7 +64,7 @@ const Outro: FC<Props> = ({
 
   return (
     <div>
-      <Divider variant="stub" color="black" />
+      <Divider color="black" isStub />
       <Space
         v={{
           size: 'm',

--- a/content/webapp/components/Outro/Outro.tsx
+++ b/content/webapp/components/Outro/Outro.tsx
@@ -64,7 +64,7 @@ const Outro: FC<Props> = ({
 
   return (
     <div>
-      <Divider color="black" isStub={true} />
+      <Divider variant="stub" color="black" />
       <Space
         v={{
           size: 'm',

--- a/content/webapp/components/VenueHours/VenueHours.tsx
+++ b/content/webapp/components/VenueHours/VenueHours.tsx
@@ -112,7 +112,7 @@ const VenueHours: FunctionComponent<Props> = ({ venue, weight }) => {
         <>
           <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
             <span className="is-hidden-s">
-              <Divider color="warmNeutral.400" isKeyline={true} />
+              <Divider />
             </span>
           </Space>
           <VenueHoursImage v={{ size: 'm', properties: ['margin-bottom'] }}>

--- a/identity/webapp/copy.tsx
+++ b/identity/webapp/copy.tsx
@@ -86,7 +86,7 @@ export const ApplicationReceived: FC<{ email: string }> = ({ email }) => (
         .
       </p>
       <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
-        <Divider color="warmNeutral.400" isKeyline />
+        <Divider />
       </Space>
       <p>
         <strong>Didn’t receive an email?</strong>

--- a/identity/webapp/src/frontend/Registration/RegistrationInformation.tsx
+++ b/identity/webapp/src/frontend/Registration/RegistrationInformation.tsx
@@ -23,7 +23,7 @@ const RegistrationInformation: FC<Props> = ({ email }) => {
           properties: ['margin-top', 'margin-bottom'],
         }}
       >
-        <Divider color="warmNeutral.400" isKeyline />
+        <Divider />
       </Space>
     </>
   );


### PR DESCRIPTION
## Who is this for?
Devs, maintenance

## What is it doing for them?
Simplifies the Divider component, setting a default color and height. Prior to this change, you had to specify the type and color for the component to display properly, but it was using the same props 90% of the time.

I've also tweaked the story a little bit to explain. 

Closes #8630 