### PR TITLE
Fix BSL Titles

### DIFF
--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -177,6 +177,20 @@ function getTypeTitle(type: GuideType): string {
   }
 }
 
+// type titleOptions = {
+//   title?: string;
+//   standaloneTitle: string;
+//   number: number;
+// };
+
+function getTitle(stop: ExhibitionGuideComponent): string {
+  if (stop.title) {
+    return `${stop.number}. ${stop.title}`;
+  } else {
+    return `${stop.number}. ${stop.standaloneTitle}`;
+  }
+}
+
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
     const serverData = await getServerData(context);
@@ -309,22 +323,14 @@ const Stops: FC<StopsProps> = ({ stops, type }) => {
                 {type === 'audio-with-descriptions' &&
                   audioWithDescription?.url && (
                     <AudioPlayer
-                      title={
-                        stop.title
-                          ? `${number}. ${stop.title}`
-                          : `${number}. ${standaloneTitle}`
-                      }
+                      title={getTitle(stop)}
                       audioFile={audioWithDescription.url}
                     />
                   )}
                 {type === 'audio-without-descriptions' &&
                   audioWithoutDescription?.url && (
                     <AudioPlayer
-                      title={
-                        stop.title
-                          ? `${number}. ${stop.title}`
-                          : `${number}. ${standaloneTitle}`
-                      }
+                      title={getTitle(stop)}
                       audioFile={audioWithoutDescription.url}
                     />
                   )}
@@ -332,9 +338,7 @@ const Stops: FC<StopsProps> = ({ stops, type }) => {
                   <figure className="no-margin">
                     <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
                       <figcaption className={font('intb', 5)}>
-                        {stop.title
-                          ? `${number}. ${stop.title}`
-                          : `${number}. ${standaloneTitle}`}
+                        {getTitle(stop)}
                       </figcaption>
                     </Space>
                     <VideoEmbed embedUrl={bsl.embedUrl} />

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -329,7 +329,16 @@ const Stops: FC<StopsProps> = ({ stops, type }) => {
                     />
                   )}
                 {type === 'bsl' && bsl.embedUrl && (
-                  <VideoEmbed embedUrl={bsl.embedUrl} />
+                  <figure className="no-margin">
+                    <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
+                      <figcaption className={font('intb', 5)}>
+                        {stop.title
+                          ? `${number}. ${stop.title}`
+                          : `${number}. ${standaloneTitle}`}
+                      </figcaption>
+                    </Space>
+                    <VideoEmbed embedUrl={bsl.embedUrl} />
+                  </figure>
                 )}
               </Stop>
             ) : null; // We've decided to omit stops that don't have content for the selected type.

--- a/content/webapp/pages/exhibition-guide.tsx
+++ b/content/webapp/pages/exhibition-guide.tsx
@@ -177,12 +177,6 @@ function getTypeTitle(type: GuideType): string {
   }
 }
 
-// type titleOptions = {
-//   title?: string;
-//   standaloneTitle: string;
-//   number: number;
-// };
-
 function getTitle(stop: ExhibitionGuideComponent): string {
   if (stop.title) {
     return `${stop.number}. ${stop.title}`;


### PR DESCRIPTION
## Who is this for?

Any exhibition guide users and covers https://github.com/wellcomecollection/wellcomecollection.org/issues/8619

## What is it doing for them?

There will now be a number and title above BSL videos. I made a getTitles function to keep this a bit easier. 

After:
![Screenshot 2022-10-07 at 14 18 51](https://user-images.githubusercontent.com/16557524/194563637-90df3e96-d2d3-48cc-95d5-81a230e7c5f5.png)

