### PR TITLE
Sorting guide components by stop numbers

### DIFF
--- a/content/webapp/services/prismic/transformers/exhibition-guides.ts
+++ b/content/webapp/services/prismic/transformers/exhibition-guides.ts
@@ -116,8 +116,8 @@ export function transformExhibitionGuide(
 ): ExhibitionGuide {
   const { data } = document;
 
-  const components: ExhibitionGuideComponent[] = data.components?.map(
-    component => {
+  const components: ExhibitionGuideComponent[] = data.components
+    ?.map(component => {
       return {
         number: component.number || '',
         title: (component.title && asText(component.title)) || '',
@@ -136,8 +136,10 @@ export function transformExhibitionGuide(
           ? transformYoutubeEmbed(component['bsl-video'])
           : {},
       };
-    }
-  );
+    })
+    .sort(({ number: aNumber }, { number: bNumber }) => {
+      return aNumber - bNumber;
+    });
 
   const introText = (data.introText && asRichText(data.introText)) || [];
   const promo =


### PR DESCRIPTION
## Who is this for?

Any editors filling the guide content, or anyone using guides. Covers https://github.com/wellcomecollection/wellcomecollection.org/issues/8620

## What is it doing for them?

Special thanks to @rcantin-w for rubber ducking and proving that the numbers were actually there! 
Orders the components by stop numbers

Before:
![Screenshot 2022-10-07 at 16 00 30](https://user-images.githubusercontent.com/16557524/194584763-eca1454b-7c6d-42a3-be3e-82c8152057d2.png)


After:
![Screenshot 2022-10-07 at 16 00 09](https://user-images.githubusercontent.com/16557524/194584733-956965a1-bf69-4b38-8f68-2e18853ec0ec.png)

