### PR TITLE
Filter out HTTP 414 errors from logs

### DIFF
--- a/catalogue/webapp/services/catalogue/index.ts
+++ b/catalogue/webapp/services/catalogue/index.ts
@@ -95,7 +95,10 @@ export async function catalogueQuery<Params, Result extends ResultType>(
     const res = await catalogueFetch(url);
     const json = await res.json();
 
-    if (json.type === 'Error') {
+    // In general we want to know about errors from the catalogue API, but
+    // HTTP 414 URI Too Long isn't interesting -- it's usually a sign of an
+    // automated tool trying to inject malicious data, and thus can be ignored.
+    if (json.type === 'Error' && json.httpStatus !== 414) {
       console.warn(
         `Received error from catalogue API query ${url}: ` +
           JSON.stringify(json)


### PR DESCRIPTION
Otherwise the logs are filled with complete nonsense like:

> Received error from catalogue API query https://api.wellcomecollection.org/catalogue/v2/works?query=ddos%C3%83%C2%A7%C3%82%C2%BD%C3%A2%C2%80%C2%98%C3%83%C2%A9%C3%82%C2%A1%C3%82%C2%B5%C3%83%C2%A7%C3%82%C2%AB%C3%82%C2%AF%C3%83%C2%A5%C3%85%C2%BD%C3%A2%C2%80%C2%B9%C3%83%C2%A5%C3%85%C2%A0%C3%A2%C2%80%C2%BA%C3%83%C2%A6%C3%82%C2%B5%C3%A2%C2%80%C2%B9%C3%83%C2%A8%C3%82%C2%AF%C3%A2%C2%80%C2%A2%C3%83%C2%A3%C3%A2%C2%82%C2%AC%C3%82%C2%90%C3%83%C2%A7%C3%82%C2%BD%C3%A2%C2%80%C2%98%C3%83%C2%A7%C3%82%C2%AB%C3%A2%C2%84%C2%A2gpk3688.com%C3%83%C2%A3%C3%A2%C2%82%C2%AC%C3%A2%C2%80%C2%98%C3%83%C2%A3%C3%A2%C2%82%C2%AC%C3%82%C2%90cc%C3%83%C2%A6%C3%A2%C2%80%C2%9D%C3%82%C2%BB%C3%83%C2%A5%C3%A2%C2%80%C2%A1%C3%82%C2%BB%C3%83%C2%A6%C3%82%C2%BA%C3%82%C2%90%C3%83%C2%A7%C3%82%C2%A0%C3%82%C2%81%C3%83%C2%AF%C3%82%C2%BC%C3%85%C2%92%C3%83%C2%A6%C3%A2%C2%80%C2%B0%C3%A2%C2%80%C2%B9%C3%83%C2%A6%C3%85%C2%93%C3%82%C2%BAddos%C3%83%C2%A6%C3%A2%C2%80%C2%9D%C3%82%C2%BB%C3%83%C2%A5%C3%A2%C2%80%C2%A1%C3%82%C2%BB%C3%83%C2%A8%C3%82%C2%BD%C3%82%C2%AF%C3%83%C2%A4%C3%82%C2%BB%C3%82%C2%B6%C3%83%C2%AF%C3%82%C2%BC%C3%85%C2%92ddos%C3%83%C2%A6%C3%A2%C2%80%C2%9D%C3%82%C2%BB%C3%83%C2%A5%C3%A2%C2%80%C2%A1%C3%82%C2%BB%C3%83%C2%A6%C3%A2%C2%80%C2%B0%C3%A2%C2%80%C2%B9%C3%83%C2%A6%C3%85%C2%93%C3%82%C2%BA%C3%83%C2%A7%C3%A2%C2%80%C2%B0%C3%8B%C2%86app%C3%83%C2%A4%C3%82%C2%B8%C3%A2%C2%80%C2%B9%C3%83%C2%A8%C3%82%C2%BD%C3%82%C2%BD%C3%83%C2%AF%C3%82%C2%BC%C3%85%C2%92%C3%83%C2%A6%C3%A2%C2%80%C2%B0%C3%A2%C2%80%C2%B9%C3%83%C2%A6%C3%85%C2%93%C3%82%C2%BA%C3%83%C2%A7%C3%A2%C2%80%C2%B0%C3%8B%C2%86%C3%83%C2%A9%C3%82%C2%BB%C3%A2%C2%80%C2%98%C3%83%C2%A5%C3%82%C2%AE%C3%82%C2%A2%C3%83%C2%A5%C3%A2%C2%80%C2%A6%C3%82%C2%A5%C3%83%C2%A4%C3%82%C2%BE%C3%82%C2%B5%C3%83%C2%A8%C3%82%C2%BD%C3%82%C2%AF%C3%83%C2%A4%C3%82%C2%BB%C3%82%C2%B6%C3%83%C2%A4%C3%82%C2%B8%C3%A2%C2%80%C2%B9%C3%83%C2%A8%C3%82%C2%BD%C3%82%C2%BD%C3%83%C2%A3%C3%A2%C2%82%C2%AC%C3%85%C2%A0%C3%83%C2%A7%C3%82%C2%BD%C3%A2%C2%80%C2%98%C3%83%C2%A7%C3%82%C2%AB%C3%A2%C2%84%C2%A2gpk3688.com%C3%83%C2%A3%C3%A2%C2%82%C2%AC%C3%A2%C2%80%C2%B9ddos%C3%83%C2%A6%C3%A2%C2%80%C2%9D%C3%82%C2%BB%C3%83%C2%A5%C3%A2%C2%80%C2%A1%C3%82%C2%BB%C3%83%C2%A6%C3%8B%C2%9C%C3%82%C2%AF%C3%83%C2%A4%C3%82%C2%BB%C3%A2%C2%82%C2%AC%C3%83%C2%A4%C3%82%C2%B9%C3%8B%C2%86%C3%83%C2%A6%C3%A2%C2%80%C2%9E%C3%82%C2%8F%C3%83%C2%A6%C3%A2%C2%82%C2%AC%C3%82%C2%9D%C3%83%C2%A3%C3%A2%C2%82%C2%AC%C3%A2%C2%80%C2%98epidy&aggregations=workType%2Cavailabilities%2Cgenres.label%2Clanguages%2Csubjects.label%2Ccontributors.agent.label&include=identifiers%2Cproduction%2Ccontributors%2Csubjects%2CpartOf&pageSize=25: {"errorType":"http","httpStatus":414,"label":"URI Too Long","description":"URI length exceeds the configured limit of 2048 characters","type":"Error"}

which isn't helpful to anyone.