### PR TITLE
[WIP] We always want London date comparisons, not UTC – make this explicit

### DIFF
--- a/catalogue/webapp/utils/dates.ts
+++ b/catalogue/webapp/utils/dates.ts
@@ -71,11 +71,7 @@ export function isLibraryOpen(
     return false;
   }
 
-  if (
-    exceptionalClosedDates.find(exception =>
-      isSameDay(date, exception, 'London')
-    )
-  ) {
+  if (exceptionalClosedDates.find(exception => isSameDay(date, exception))) {
     return false;
   }
 
@@ -243,10 +239,12 @@ export function isRequestableDate(params: {
   excludedDays: DayNumber[];
 }): boolean {
   const { date, startDate, endDate, excludedDates, excludedDays } = params;
-  const isExceptionalClosedDay = excludedDates.some(excluded =>
-    isSameDay(excluded, date, 'London')
-  );
-  const isRegularClosedDay = excludedDays.includes(date.getDay() as DayNumber);
+
+  const libraryOpen = isLibraryOpen(date, {
+    regularClosedDays: excludedDays,
+    exceptionalClosedDates: excludedDates,
+  });
+
   return (
     Boolean(
       // no start and end date
@@ -261,7 +259,6 @@ export function isRequestableDate(params: {
         // only end date
         (endDate && !startDate && isSameDayOrBefore(date, endDate))
     ) && // both start and end date
-    !isExceptionalClosedDay &&
-    !isRegularClosedDay
+    !libraryOpen
   );
 }

--- a/common/services/prismic/opening-times.ts
+++ b/common/services/prismic/opening-times.ts
@@ -261,7 +261,7 @@ export function getTodaysVenueHours(
   const exceptionalOpeningHours =
     venue.openingHours.exceptional &&
     venue.openingHours.exceptional.find(i =>
-      isSameDay(todaysDate, i.overrideDate, 'London')
+      isSameDay(todaysDate, i.overrideDate)
     );
   const regularOpeningHours =
     venue.openingHours.regular &&

--- a/common/utils/dates.test.ts
+++ b/common/utils/dates.test.ts
@@ -23,13 +23,21 @@ it('identifies dates in the future', () => {
 
 describe('isSameDay', () => {
   it('says a day is the same as itself', () => {
-    const day = new Date(2001, 1, 1, 1, 1, 1);
+    const day = new Date('2001-01-01T01:01:01Z');
     const result = isSameDay(day, day);
 
     expect(result).toEqual(true);
   });
 
-  describe('ComparisonMode', () => {
+  it('says two different days are different', () => {
+    const day1 = new Date('2001-01-01T01:01:01Z');
+    const day2 = new Date('2002-02-02T02:02:02Z');
+    const result = isSameDay(day1, day2);
+
+    expect(result).toEqual(false);
+  });
+
+  describe('it does London comparisons', () => {
     const september19Midnight = new Date(
       // = Sep 18 2022 23:00:00 UTC
       'Mon Sep 19 2022 00:00:00 GMT+0100 (British Summer Time)'
@@ -48,35 +56,15 @@ describe('isSameDay', () => {
     );
 
     it('says midnight {x} BST in London is on the same day as midday {x} BST using a comparison mode of "London"', () => {
-      const result = isSameDay(
-        september19Midnight,
-        september19Midday,
-        'London'
-      );
+      const result = isSameDay(september19Midnight, september19Midday);
       expect(result).toEqual(true);
     });
-
-    it('says midnight {x} BST in London is not on the same day as midday {x} BST using a comparison mode of "UTC"', () => {
-      const result = isSameDay(september19Midnight, september19Midday, 'UTC');
-      expect(result).toEqual(false);
-    });
-
     it('says 23:30 {x} BST in London is not on the same day as 00:30 {x+1} BST using a comparison mode of "London"', () => {
       const result = isSameDay(
         september18TwentyThreeThirty,
-        september19MidnightThirty,
-        'London'
+        september19MidnightThirty
       );
       expect(result).toEqual(false);
-    });
-
-    it('says 23:30 {x} BST in London is on the same day as 00:30 {x+1} BST using a comparison mode of "UTC"', () => {
-      const result = isSameDay(
-        september18TwentyThreeThirty,
-        september19MidnightThirty,
-        'UTC'
-      );
-      expect(result).toEqual(true);
     });
   });
 
@@ -151,47 +139,6 @@ describe('isSameDayOrBefore', () => {
 
     expect(isSameDayOrBefore(date1, date2)).toEqual(true);
     expect(isSameDayOrBefore(date2, date1)).toEqual(false);
-  });
-});
-
-describe('isSameMonth', () => {
-  it('says a day is the same as itself', () => {
-    const day = new Date(2001, 1, 1, 1, 1, 1);
-    const result = isSameMonth(day, day);
-
-    expect(result).toEqual(true);
-  });
-
-  it('says two times on the same day are the same', () => {
-    const result = isSameMonth(
-      new Date(2001, 1, 1, 1, 1, 1),
-      new Date(2001, 1, 1, 13, 24, 37)
-    );
-
-    expect(result).toEqual(true);
-  });
-
-  it('says two days in the same month are the same', () => {
-    const result = isSameMonth(
-      new Date(2001, 1, 1, 1, 1, 1),
-      new Date(2001, 1, 13, 4, 21, 53)
-    );
-
-    expect(result).toEqual(true);
-  });
-
-  each([
-    // same year/day, different month
-    [new Date(2001, 2, 1, 1, 1, 1), new Date(2001, 3, 1, 1, 1, 1)],
-
-    // same month of year, different year
-    [new Date(2001, 2, 1, 1, 1, 1), new Date(2005, 2, 1, 1, 1, 1)],
-
-    // completely different months
-    [new Date(2001, 2, 3, 1, 1, 1), new Date(2022, 5, 7, 19, 11, 13)],
-  ]).test('identifies %s and %s as different', (a, b) => {
-    const result = isSameMonth(a, b);
-    expect(result).toEqual(false);
   });
 });
 

--- a/common/utils/dates.ts
+++ b/common/utils/dates.ts
@@ -1,5 +1,5 @@
 import { DateRange } from '../model/date-range';
-import { formatDayDate } from './format-date';
+import { formatDate } from './format-date';
 
 // This is to allow us to mock values in tests, e.g.
 //
@@ -24,36 +24,14 @@ export function isFuture(date: Date): boolean {
   return date > now;
 }
 
-export function isSameMonth(date1: Date, date2: Date): boolean {
-  return (
-    date1.getUTCFullYear() === date2.getUTCFullYear() &&
-    date1.getUTCMonth() === date2.getUTCMonth()
-  );
-}
-
-type ComparisonMode = 'UTC' | 'London';
-
 /** Returns true if `date1` is on the same day as `date2`, false otherwise.
  *
- * Note: this function supports UTC or London comparisons.  We suspect we always
- * want London comparisons -- uses of this function should be examined and tested
- * to decide the correct behaviour, and updated as necessary.
- *
- * If we get to a point where every comparison uses London, we should delete the
- * mode argument and document that requirement explicitly.
+ * This compares the dates in London, not UTC.  See the tests for examples
+ * of edge cases where there are different UTC days but this function still
+ * returns true.
  */
-export function isSameDay(
-  date1: Date,
-  date2: Date,
-  mode: ComparisonMode = 'UTC'
-): boolean {
-  if (mode === 'UTC') {
-    return (
-      isSameMonth(date1, date2) && date1.getUTCDate() === date2.getUTCDate()
-    );
-  } else {
-    return formatDayDate(date1) === formatDayDate(date2);
-  }
+export function isSameDay(date1: Date, date2: Date): boolean {
+  return formatDate(date1) === formatDate(date2);
 }
 
 /** Returns true if `date1` is on the same day or before `date2`,
@@ -73,7 +51,7 @@ export function isSameDay(
  *
  */
 export function isSameDayOrBefore(date1: Date, date2: Date): boolean {
-  return isSameDay(date1, date2, 'London') || date1 <= date2;
+  return isSameDay(date1, date2) || date1 <= date2;
 }
 
 // Returns true if 'date' falls on a past day; false otherwise.

--- a/common/views/components/DateRange/DateRange.tsx
+++ b/common/views/components/DateRange/DateRange.tsx
@@ -36,7 +36,7 @@ const DateRange: FunctionComponent<Props> = ({
   end,
   splitTime,
 }: Props) => {
-  return isSameDay(start, end, 'London') ? (
+  return isSameDay(start, end) ? (
     <>
       <HTMLDayDate date={start} />
       {!splitTime && ', '}

--- a/content/webapp/components/StatusIndicator/StatusIndicator.tsx
+++ b/content/webapp/components/StatusIndicator/StatusIndicator.tsx
@@ -26,8 +26,8 @@ export function formatDateRangeWithMessage({
 }): { text: string; color: PaletteColor } {
   const sevenDaysTime = addDays(today(), 7);
 
-  const opensToday = isSameDay(start, today(), 'London');
-  const closesToday = isSameDay(end, today(), 'London');
+  const opensToday = isSameDay(start, today());
+  const closesToday = isSameDay(end, today());
   const closesInSevenDays = today() < end && end < sevenDaysTime;
 
   if (!opensToday && isFuture(start)) {

--- a/content/webapp/utils/event-series.test.ts
+++ b/content/webapp/utils/event-series.test.ts
@@ -39,6 +39,7 @@ describe('getUpcomingEvents', () => {
             endDateTime: new Date(2100, 3, 25, 16, 30, 0),
           },
           isFullyBooked: false,
+          onlineIsFullyBooked: false,
         },
       ],
     }));
@@ -59,6 +60,7 @@ describe('getUpcomingEvents', () => {
               endDateTime: new Date(2100, 3, 25, 17, 30),
             },
             isFullyBooked: false,
+            onlineIsFullyBooked: false,
           },
         ],
       },

--- a/content/webapp/utils/event-series.test.ts
+++ b/content/webapp/utils/event-series.test.ts
@@ -15,6 +15,7 @@ describe('getUpcomingEvents', () => {
             endDateTime: startDateTime,
           },
           isFullyBooked: false,
+          onlineIsFullyBooked: false,
         },
       ],
     }));


### PR DESCRIPTION
The remaining uses of `isSameDay()` were all for events or opening times, which are based in London. This means we can remove the UTC handling, and be clear that whenever we mean "isSameDay", we mean "in London".

Closes https://github.com/wellcomecollection/wellcomecollection.org/issues/7831

## Who is this for?

Devs.

## What is it doing for them?

Making it clear how our date comparison logic works, and more importantly how it's *meant* to work.