### PR TITLE
Move the "COVID welcome back" icons off the main page

### DIFF
--- a/common/data/vanity-urls.ts
+++ b/common/data/vanity-urls.ts
@@ -35,6 +35,7 @@ export const vanityUrls: VanityUrl[] = [
   {
     url: '/covid-welcome-back',
     pageId: prismicPageIds.covidWelcomeBack,
+    template: '/covid-welcome-back',
   },
   {
     url: '/get-involved',

--- a/content/webapp/pages/covid-welcome-back.tsx
+++ b/content/webapp/pages/covid-welcome-back.tsx
@@ -1,0 +1,27 @@
+import { prismicPageIds } from '@weco/common/data/hardcoded-ids';
+import { AppErrorProps } from '@weco/common/services/app';
+import { WeAreGoodToGo } from '@weco/common/views/components/CovidIcons/CovidIcons';
+import { GetServerSideProps } from 'next';
+import { FC } from 'react';
+import * as page from './page';
+
+export const getServerSideProps: GetServerSideProps<
+  page.Props | AppErrorProps
+> = async context => {
+  return page.getServerSideProps({
+    ...context,
+    query: { id: prismicPageIds.covidWelcomeBack },
+  });
+};
+
+const CovidWelcomeBack: FC<page.Props> = (props: page.Props) => {
+  const postOutroContent = (
+    <div style={{ width: '100px' }}>
+      <WeAreGoodToGo />
+    </div>
+  );
+
+  return <page.Page {...props} postOutroContent={postOutroContent} />;
+};
+
+export default CovidWelcomeBack;

--- a/content/webapp/pages/page.tsx
+++ b/content/webapp/pages/page.tsx
@@ -44,7 +44,6 @@ import { getCrop } from '@weco/common/model/image';
 import { isPicture, isVideoEmbed, BodySlice } from '../types/body';
 import { isNotUndefined } from '@weco/common/utils/array';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
-import { WeAreGoodToGo } from '@weco/common/views/components/CovidIcons/CovidIcons';
 
 export type Props = {
   page: PageType;
@@ -53,6 +52,7 @@ export type Props = {
   children: SiblingsGroup<PageType>;
   ordersInParents: OrderInParent[];
   staticContent: ReactElement | null;
+  postOutroContent: ReactElement | null;
   jsonLd: JsonLdObj;
   gaDimensions: GaDimensions;
 };
@@ -162,6 +162,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
           children,
           ordersInParents,
           staticContent: null,
+          postOutroContent: null,
           jsonLd,
           serverData,
           vanityUrl,
@@ -181,6 +182,7 @@ export const Page: FC<Props> = ({
   children,
   ordersInParents,
   staticContent,
+  postOutroContent,
   vanityUrl,
   jsonLd,
 }) => {
@@ -335,13 +337,6 @@ export const Page: FC<Props> = ({
   // in the page <head>; it means the canonical URL will match the links
   // we put elsewhere on the website, e.g. in the header.
   const pathname = vanityUrl || `/pages/${page.id}`;
-
-  const postOutroContent =
-    page.id === prismicPageIds.covidWelcomeBack ? (
-      <div style={{ width: '100px' }}>
-        <WeAreGoodToGo />
-      </div>
-    ) : null;
 
   return (
     <PageLayout


### PR DESCRIPTION
These icons are only loaded on a single page; better to move them out into a separate file, as we do for large content on "visit us" and "what's on" -- this cuts ~4% off the size of the initial bundle for all other pages.

## Who is this for?

Users.

## What is it doing for them?

Saving them a few bytes.