### PR TITLE
Improve the tabular output of sliceAnalysis

### DIFF
--- a/prismic-model/sliceAnalysis.ts
+++ b/prismic-model/sliceAnalysis.ts
@@ -77,10 +77,15 @@ async function main() {
       }
     }
   }
-  console.info(
-    'Slice count',
-    Array.from(sliceCounter.entries()).sort((a, b) => a[1] - b[1])
-  );
+
+  console.info('=== Slice count ==');
+  Array.from(sliceCounter.entries())
+    .sort((a, b) => a[1] - b[1])
+    .forEach(entry =>
+      console.info(`${String(entry[1]).padStart(6, ' ')}\t${entry[0]}`)
+    );
+  console.info('');
+
   console.info(matches);
   console.info(`found ${matches.length}`);
 }


### PR DESCRIPTION
Before:

```
Slice count [
  [ 'infoBlock', 104 ],
  [ 'quote', 171 ],
  [ 'embed', 205 ],
  ...
```

After:

```
=== Slice count ==
 ...
 104	infoBlock
 171	quote
 205	embed
```

## Who is this for?

Devs.

## What is it doing for them?

Making the slice analysis tool easier to use.