### PR TITLE
Consolidate on a single packaging for managing cookies

### DIFF
--- a/catalogue/webapp/components/CataloguePageLayout/CataloguePageLayout.tsx
+++ b/catalogue/webapp/components/CataloguePageLayout/CataloguePageLayout.tsx
@@ -5,6 +5,7 @@ import PageLayout, {
 } from '@weco/common/views/components/PageLayout/PageLayout';
 import InfoBanner from '@weco/common/views/components/InfoBanner/InfoBanner';
 import { wellcomeImagesRedirectBanner } from '@weco/common/data/microcopy';
+import cookies from '@weco/common/data/cookies';
 
 type Props = {
   hideTopContent?: boolean;
@@ -41,7 +42,7 @@ const CataloguePageLayout: FunctionComponent<Props> = ({
                   ],
                 },
               }}
-              cookieName="WC_wellcomeImagesRedirect"
+              cookieName={cookies.wellcomeImagesRedirect}
             />
           )}
         </>

--- a/catalogue/webapp/pages/works.tsx
+++ b/catalogue/webapp/pages/works.tsx
@@ -7,7 +7,7 @@ import CataloguePageLayout from '../components/CataloguePageLayout/CataloguePage
 import Paginator from '@weco/common/views/components/Paginator/Paginator';
 import Space from '@weco/common/views/components/styled/Space';
 import { getWorks } from '../services/catalogue/works';
-import cookies from 'next-cookies';
+import { getCookie } from 'cookies-next';
 import WorksSearchResults from '../components/WorksSearchResults/WorksSearchResults';
 import SearchTabs from '@weco/common/views/components/SearchTabs/SearchTabs';
 import SearchNoResults from '../components/SearchNoResults/SearchNoResults';
@@ -279,7 +279,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       'contributors.agent.label',
     ];
 
-    const _queryType = cookies(context)._queryType;
+    const _queryType = getCookie('_queryType') as string | undefined;
 
     const worksApiProps = {
       ...props,

--- a/common/data/cookies.ts
+++ b/common/data/cookies.ts
@@ -26,6 +26,12 @@ const cookies = {
 
   // Records whether a user has dismissed our cookie banner.
   cookiesAccepted: 'WC_cookiesAccepted',
+
+  // Remembers whether somebody is using the "mini" version of the API toolbar.
+  apiToolbarMini: 'WC_apiToolbarMini',
+
+  // Causes Segment session info to be logged to the dev console.
+  analyticsDebug: 'WC_analyticsDebug',
 };
 
 export default cookies;

--- a/common/data/cookies.ts
+++ b/common/data/cookies.ts
@@ -12,6 +12,10 @@ const cookies = {
   // the next time they open the guide we'll take them to BSL without
   // asking them to pick again.
   exhibitionGuideType: 'WC_userPreferenceGuideType',
+
+  // This is the cookie used in the popup dialog to remember when somebody
+  // has closed the dialog.
+  popupDialog: 'WC_PopupDialog',
 };
 
 export default cookies;

--- a/common/data/cookies.ts
+++ b/common/data/cookies.ts
@@ -23,6 +23,9 @@ const cookies = {
   // This remmebers when somebody has dismissed the banner you get when
   // you've been redirected from Wellcome Images.
   wellcomeImagesRedirect: 'WC_wellcomeImagesRedirect',
+
+  // Records whether a user has dismissed our cookie banner.
+  cookiesAccepted: 'WC_cookiesAccepted',
 };
 
 export default cookies;

--- a/common/data/cookies.ts
+++ b/common/data/cookies.ts
@@ -16,6 +16,13 @@ const cookies = {
   // This is the cookie used in the popup dialog to remember when somebody
   // has closed the dialog.
   popupDialog: 'WC_PopupDialog',
+
+  // This remembers when somebody has dismissed the global info banner.
+  globalAlert: 'WC_globalAlert',
+
+  // This remmebers when somebody has dismissed the banner you get when
+  // you've been redirected from Wellcome Images.
+  wellcomeImagesRedirect: 'WC_wellcomeImagesRedirect',
 };
 
 export default cookies;

--- a/common/package.json
+++ b/common/package.json
@@ -44,7 +44,6 @@
     "koa-compose": "^4.1.0",
     "lodash.debounce": "^4.0.8",
     "next": "^11.1.2",
-    "next-cookies": "^2.0.3",
     "next-transpile-modules": "^8.0.0",
     "node-fetch": "^2.6.2",
     "nprogress": "^0.2.0",

--- a/common/package.json
+++ b/common/package.json
@@ -35,6 +35,7 @@
     "babel-jest": "^27.3.1",
     "babel-plugin-styled-components": "^1.9.4",
     "babel-plugin-superjson-next": "^0.4.4",
+    "cookies-next": "^2.1.1",
     "elastic-apm-node": "^3.21.1",
     "enzyme": "^3.11.0",
     "enzyme-to-json": "^3.4.4",

--- a/common/package.json
+++ b/common/package.json
@@ -35,7 +35,6 @@
     "babel-jest": "^27.3.1",
     "babel-plugin-styled-components": "^1.9.4",
     "babel-plugin-superjson-next": "^0.4.4",
-    "cookie-cutter": "^0.2.0",
     "elastic-apm-node": "^3.21.1",
     "enzyme": "^3.11.0",
     "enzyme-to-json": "^3.4.4",

--- a/common/server-data/toggles.ts
+++ b/common/server-data/toggles.ts
@@ -1,7 +1,7 @@
 import { getCookies } from 'cookies-next';
 import { Toggles, TogglesResp } from '@weco/toggles';
 import { Handler } from './';
-import { NextApiRequest, NextApiResponse } from 'next';
+import { IncomingMessage } from 'http';
 
 const defaultValue = { toggles: [], tests: [] };
 
@@ -18,7 +18,13 @@ const togglesHandler: Handler<TogglesResp, TogglesResp> = {
   fetch: fetchToggles,
 };
 
-type Context = { req: NextApiRequest; res: NextApiResponse };
+type Context = {
+  req: IncomingMessage & {
+    cookies: {
+      [key: string]: string;
+    };
+  };
+};
 
 /**
  * normally parsing like this should happen in `_app.parseServerDataToAppData`

--- a/common/server-data/toggles.ts
+++ b/common/server-data/toggles.ts
@@ -1,7 +1,7 @@
 import { getCookies } from 'cookies-next';
 import { Toggles, TogglesResp } from '@weco/toggles';
 import { Handler } from './';
-import { GetServerSidePropsContext } from 'next';
+import { NextApiRequest, NextApiResponse } from 'next';
 
 const defaultValue = { toggles: [], tests: [] };
 
@@ -18,6 +18,8 @@ const togglesHandler: Handler<TogglesResp, TogglesResp> = {
   fetch: fetchToggles,
 };
 
+type Context = { req: NextApiRequest; res: NextApiResponse };
+
 /**
  * normally parsing like this should happen in `_app.parseServerDataToAppData`
  * but we need the `req` from the `context` for cookies which we don't
@@ -25,7 +27,7 @@ const togglesHandler: Handler<TogglesResp, TogglesResp> = {
  */
 export function getTogglesFromContext(
   togglesResp: TogglesResp,
-  context: GetServerSidePropsContext
+  context: Context
 ): Toggles {
   const allCookies = getCookies(context);
   const toggles = [...togglesResp.toggles].reduce(

--- a/common/server-data/toggles.ts
+++ b/common/server-data/toggles.ts
@@ -1,6 +1,7 @@
-import cookies from 'next-cookies';
+import { getCookies } from 'cookies-next';
 import { Toggles, TogglesResp } from '@weco/toggles';
 import { Handler } from './';
+import { GetServerSidePropsContext } from 'next';
 
 const defaultValue = { toggles: [], tests: [] };
 
@@ -22,12 +23,11 @@ const togglesHandler: Handler<TogglesResp, TogglesResp> = {
  * but we need the `req` from the `context` for cookies which we don't
  * have in `_app` - so it lives here
  */
-type CookiesContext = Parameters<typeof cookies>[0];
 export function getTogglesFromContext(
   togglesResp: TogglesResp,
-  context: CookiesContext
+  context: GetServerSidePropsContext
 ): Toggles {
-  const allCookies = cookies(context);
+  const allCookies = getCookies(context);
   const toggles = [...togglesResp.toggles].reduce(
     (acc, toggle) => ({
       ...acc,

--- a/common/services/conversion/track.ts
+++ b/common/services/conversion/track.ts
@@ -1,4 +1,5 @@
-import cookies from 'next-cookies';
+import { getCookie } from 'cookies-next';
+import cookies from '@weco/common/data/cookies';
 import Router from 'next/router';
 import { ParsedUrlQuery } from 'querystring';
 import { v4 as uuidv4 } from 'uuid';
@@ -109,7 +110,7 @@ function trackEvent(
 }
 
 function track(conversion: Conversion) {
-  const debug = Boolean(cookies({}).analytics_debug);
+  const debug = getCookie(cookies.analyticsDebug) === true;
   const sessionId = getSessionId();
   const session: Session = {
     id: sessionId,

--- a/common/views/components/ApiToolbar/ApiToolbar.tsx
+++ b/common/views/components/ApiToolbar/ApiToolbar.tsx
@@ -2,7 +2,8 @@ import { FC, useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import styled from 'styled-components';
 import { ParsedUrlQuery } from 'querystring';
-import cookies from 'next-cookies';
+import cookies from '@weco/common/data/cookies';
+import { getCookie, setCookie } from 'cookies-next';
 import useIsomorphicLayoutEffect from '../../../hooks/useIsomorphicLayoutEffect';
 import {
   Work,
@@ -241,13 +242,12 @@ type Props = {
 };
 
 const ApiToolbar: FC<Props> = ({ extraLinks = [] }) => {
-  const cookieName = 'apiToolbarMini';
   const router = useRouter();
   const [links, setLinks] = useState<ApiToolbarLink[]>([]);
   const [mini, setMini] = useState<boolean>(false);
 
   useIsomorphicLayoutEffect(() => {
-    setMini(cookies({})[cookieName] === 'true');
+    setMini(getCookie(cookies.apiToolbarMini) === true);
   }, []);
 
   useEffect(() => {
@@ -313,7 +313,7 @@ const ApiToolbar: FC<Props> = ({ extraLinks = [] }) => {
         type="button"
         onClick={() => {
           setMini(!mini);
-          document.cookie = `${cookieName}=${!mini}; path=/`;
+          setCookie(cookies.apiToolbarMini, !mini, { path: '/' });
         }}
         style={{ padding: '10px' }}
       >

--- a/common/views/components/CookieNotice/CookieNotice.tsx
+++ b/common/views/components/CookieNotice/CookieNotice.tsx
@@ -1,12 +1,14 @@
 import styled from 'styled-components';
-import cookie from 'cookie-cutter';
+import cookies from '@weco/common/data/cookies';
+import { hasCookie, setCookie } from 'cookies-next';
 import { font } from '@weco/common/utils/classnames';
 import { useState, useEffect, FunctionComponent } from 'react';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import Space from '@weco/common/views/components/styled/Space';
 import Layout12 from '@weco/common/views/components/Layout12/Layout12';
-import { clear, cookies } from '@weco/common/icons';
+import { clear, cookies as cookiesIcon } from '@weco/common/icons';
 import { trackEvent } from '@weco/common/utils/ga';
+import { addDays, today } from '../../../utils/dates';
 
 const CookieNoticeStyle = styled.div.attrs({
   className: font('intb', 4),
@@ -42,10 +44,10 @@ const CookieNotice: FunctionComponent<Props> = ({ source }) => {
   const [shouldRender, setShouldRender] = useState(true);
   function hideCookieNotice() {
     // Remember that the user has accepted cookies for the next month.
-    const expires = new Date();
-    expires.setDate(new Date().getDate() + 30);
-
-    cookie.set('WC_cookiesAccepted', 'true', { path: '/', expires });
+    setCookie(cookies.cookiesAccepted, 'true', {
+      path: '/',
+      expires: addDays(today(), 30),
+    });
 
     trackEvent({
       category: 'CookieNotice',
@@ -57,7 +59,7 @@ const CookieNotice: FunctionComponent<Props> = ({ source }) => {
   }
 
   useEffect(() => {
-    setShouldRender(!cookie.get('WC_cookiesAccepted'));
+    setShouldRender(!hasCookie(cookies.cookiesAccepted));
   }, []);
 
   return shouldRender ? (
@@ -66,7 +68,7 @@ const CookieNotice: FunctionComponent<Props> = ({ source }) => {
         <Space v={{ size: 'l', properties: ['margin-top', 'margin-bottom'] }}>
           <div className="flex flex--h-space-between">
             <div className="flex flex--v-center">
-              <Icon icon={cookies} />
+              <Icon icon={cookiesIcon} />
               <Space
                 as="span"
                 h={{

--- a/common/views/components/InfoBanner/InfoBanner.tsx
+++ b/common/views/components/InfoBanner/InfoBanner.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent, useEffect, useState } from 'react';
-import cookie from 'cookie-cutter';
+import cookies from '@weco/common/data/cookies';
+import { getCookie, setCookie } from 'cookies-next';
 import { grid, font } from '../../../utils/classnames';
 import Icon from '../Icon/Icon';
 import PrismicHtmlBlock from '../PrismicHtmlBlock/PrismicHtmlBlock';
@@ -11,7 +12,7 @@ import { InferDataInterface } from '../../../services/prismic/types';
 import styled from 'styled-components';
 
 type Props = {
-  cookieName?: string;
+  cookieName: string;
   document: { data: InferDataInterface<GlobalAlertPrismicDocument> };
   onVisibilityChange?: (isVisible: boolean) => void;
 };
@@ -42,13 +43,15 @@ const InfoBanner: FunctionComponent<Props> = ({
   const [isVisible, setIsVisible] = useState<boolean>(defaultValue);
   const prevIsVisible = usePrevious(defaultValue);
   const hideInfoBanner = () => {
-    const singleSessionCookies = ['WC_globalAlert'];
+    const singleSessionCookies = [cookies.globalAlert];
     const isSingleSessionCookie =
       cookieName && singleSessionCookies.indexOf(cookieName) > -1;
 
-    cookie.set(cookieName, 'true', {
+    setCookie(cookieName, 'true', {
       path: '/',
-      expires: isSingleSessionCookie ? null : 'Fri, 31 Dec 2036 23:59:59 GMT',
+      expires: isSingleSessionCookie
+        ? undefined
+        : new Date('2036-12-31T23:59:59Z'),
     });
 
     setIsVisible(false);
@@ -62,7 +65,7 @@ const InfoBanner: FunctionComponent<Props> = ({
   }, [isVisible]);
 
   useEffect(() => {
-    const isAccepted = cookie.get(cookieName);
+    const isAccepted = getCookie(cookieName);
 
     if (!isAccepted) {
       setIsVisible(true);

--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -23,6 +23,7 @@ import { usePrismicData, useToggles } from '../../../server-data/Context';
 import { defaultPageTitle } from '@weco/common/data/microcopy';
 import { getCrop, ImageType } from '@weco/common/model/image';
 import { convertImageUri } from '@weco/common/utils/convert-image-uri';
+import cookies from '@weco/common/data/cookies';
 
 export type SiteSection =
   | 'collections'
@@ -263,7 +264,7 @@ const PageLayoutComponent: FunctionComponent<Props> = ({
             urlString.match(new RegExp(globalAlert.data.routeRegex))) && (
             <InfoBanner
               document={globalAlert}
-              cookieName="WC_globalAlert"
+              cookieName={cookies.globalAlert}
               onVisibilityChange={isVisible => {
                 globalInfoBar.setIsVisible(isVisible);
               }}

--- a/common/views/components/PopupDialog/PopupDialog.tsx
+++ b/common/views/components/PopupDialog/PopupDialog.tsx
@@ -7,7 +7,8 @@ import {
   KeyboardEvent as ReactKeyboardEvent,
 } from 'react';
 import styled from 'styled-components';
-import cookie from 'cookie-cutter';
+import { hasCookie, setCookie } from 'cookies-next';
+import cookies from '@weco/common/data/cookies';
 import Icon from '../Icon/Icon';
 import Space from '../styled/Space';
 import { font } from '../../../utils/classnames';
@@ -180,16 +181,16 @@ const PopupDialog: FunctionComponent<Props> = ({ document }: Props) => {
   const { isKeyboard } = useContext(AppContext);
 
   function hidePopupDialog() {
-    cookie.set('WC_PopupDialog', 'true', {
+    setCookie(cookies.popupDialog, 'true', {
       path: '/',
-      expires: null,
+      expires: undefined,
     });
 
     setShouldRender(false);
   }
 
   useEffect(() => {
-    setShouldRender(!cookie.get('WC_PopupDialog'));
+    setShouldRender(!hasCookie(cookies.popupDialog));
 
     const timer = setTimeout(() => {
       setShouldStartAnimation(true);

--- a/content/webapp/package.json
+++ b/content/webapp/package.json
@@ -17,7 +17,6 @@
     "@types/styled-components": "^5.1.15",
     "@types/supertest": "^2.0.11",
     "@weco/common": "1.0.0",
-    "cookies-next": "^2.1.1",
     "google-maps": "^3.3.0",
     "jest": "^27.3.1",
     "koa": "^2.5.0",

--- a/content/webapp/pages/guides/exhibitions/[id]/[type].tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/[type].tsx
@@ -3,7 +3,7 @@ import {
   ExhibitionGuideType,
   isValidType,
 } from '../../../../types/exhibition-guides';
-import { setCookie, deleteCookie, getCookie } from 'cookies-next';
+import { deleteCookie, getCookie } from 'cookies-next';
 import * as prismicT from '@prismicio/types';
 import { FC } from 'react';
 import { createClient } from '../../../../services/prismic/fetch';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4108,11 +4108,6 @@
   resolved "https://registry.yarnpkg.com/@types/content-disposition/-/content-disposition-0.5.4.tgz#de48cf01c79c9f1560bcfd8ae43217ab028657f8"
   integrity sha512-0mPF08jn9zYI0n0Q/Pnz7C4kThdSt+6LD4amsrYDDpgBfrVWa3TcCOxKX1zkGgYniGagRv8heN2cbh+CAn+uuQ==
 
-"@types/cookie@^0.3.3":
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.3.3.tgz#85bc74ba782fb7aa3a514d11767832b0e3bc6803"
-  integrity sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==
-
 "@types/cookie@^0.4.0", "@types/cookie@^0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.1.tgz#bfd02c1f2224567676c1545199f87c3a861d878d"
@@ -12849,13 +12844,6 @@ nested-error-stacks@^2.0.0, nested-error-stacks@^2.1.0:
   resolved "https://registry.yarnpkg.com/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz#0fbdcf3e13fe4994781280524f8b96b0cdff9c61"
   integrity sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==
 
-next-cookies@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/next-cookies/-/next-cookies-2.0.3.tgz#5a3eabcb6afa9b4d4ade69dfaaad749d16cd4a9a"
-  integrity sha512-YVCQzwZx+sz+KqLO4y9niHH9jjz6jajlEQbAKfsYVT6DOfngb/0k5l6vFK4rmpExVug96pGag8OBsdSRL9FZhQ==
-  dependencies:
-    universal-cookie "^4.0.2"
-
 next-line@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/next-line/-/next-line-1.1.0.tgz#fcae57853052b6a9bae8208e40dd7d3c2d304603"
@@ -16857,14 +16845,6 @@ unist-util-visit@2.0.3, unist-util-visit@^2.0.0:
     "@types/unist" "^2.0.0"
     unist-util-is "^4.0.0"
     unist-util-visit-parents "^3.0.0"
-
-universal-cookie@^4.0.2:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/universal-cookie/-/universal-cookie-4.0.4.tgz#06e8b3625bf9af049569ef97109b4bb226ad798d"
-  integrity sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==
-  dependencies:
-    "@types/cookie" "^0.3.3"
-    cookie "^0.4.0"
 
 universalify@^0.1.2:
   version "0.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7178,11 +7178,6 @@ convert-source-map@^1.4.0, convert-source-map@^1.5.0, convert-source-map@^1.5.1,
   dependencies:
     safe-buffer "~5.1.1"
 
-cookie-cutter@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/cookie-cutter/-/cookie-cutter-0.2.0.tgz#5988f598b68c060a00ec8524ad6e6aa193e72244"
-  integrity sha1-WYj1mLaMBgoA7IUkrW5qoZPnIkQ=
-
 cookie-signature@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/wellcomecollection.org/issues/8656

## Who is this for?

Devs.

## What is it doing for them?

Rationalising our cookie management on a single library (`cookies-next`). I've tested all these interactions and they're still working correctly.

The dashboard is still using `next-cookies`, but it's a standalone app stuck on Node.js 12 and it's not compiling properly, so I'm going to defer sorting that out until we dive in and do some other work on the dashboard to bring it up-to-date.