### PR TITLE
Don't 500 if somebody requests too many pages in an article series

### DIFF
--- a/.buildkite/urls/expected_404_urls.txt
+++ b/.buildkite/urls/expected_404_urls.txt
@@ -23,3 +23,6 @@
 
 # Guide formats that don't exist
 /guides?format=%not-a-prismic-id%
+
+# Requesting a page beyond the end of an article series 
+/series/W-XBJxEAAKmng1TG?page=500

--- a/content/webapp/pages/article-series.tsx
+++ b/content/webapp/pages/article-series.tsx
@@ -83,6 +83,23 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       return { notFound: true };
     }
 
+    // We've seen people trying to request a high-numbered page for a series,
+    // presumably by guessing at URLs, e.g. /series/W-XBJxEAAKmng1TG?page=500.
+    //
+    // The transformArticleSeries method expects to get a non-empty list of
+    // articles, so if this page doesn't have any articles, let's 404 here.
+    //
+    // Note: this is a debug rather than a warn because it's more likely to be
+    // somebody guessing about our URL scheme than somebody in Editorial looking
+    // at a yet-to-be-published series.
+    //
+    // Note: we may be able to remove this once we refactor transformArticleSeries,
+    // see https://github.com/wellcomecollection/wellcomecollection.org/issues/8516
+    if (articlesQuery.results_size === 0) {
+      console.debug(`Series ${id} doesn't have any articles on page ${page}`);
+      return { notFound: true };
+    }
+
     const { articles, series } = transformArticleSeries(id, articlesQuery);
 
     const paginatedArticles = transformQuery(articlesQuery, article =>


### PR DESCRIPTION
This was a bug that became possible in #7633, when we added pagination for article series.  The `transformArticleSeries()` method expects a non-empty list of articles; when we only got the first page, it was enough to check if the series is empty.  Now we can get higher pages, we need to additionally check if the selected page is empty.

## Who is this for?

Devs.

## What is it doing for them?

Fixing some alerts we got last night.