### PR TITLE
Set color for tab buttons

### DIFF
--- a/common/views/components/BaseTabs/BaseTabs.tsx
+++ b/common/views/components/BaseTabs/BaseTabs.tsx
@@ -28,6 +28,7 @@ const Tab = styled.button.attrs((props: TabProps) => ({
   'aria-selected': props.isActive,
   'aria-controls': props.tabPanelId,
 }))<TabProps>`
+  color: ${props => props.theme.color('black')};
   cursor: pointer;
   &:focus {
     outline: 0;


### PR DESCRIPTION
The tabs at `/works` have blue text on iOS (default since version 15 apparently). Setting a specific palette colour so that it renders the same on all browsers.

__Before__
<img width="361" alt="image" src="https://user-images.githubusercontent.com/1394592/195610009-8e8d15af-c2e6-4062-9722-d8249bca497b.png">

__After__
<img width="361" alt="image" src="https://user-images.githubusercontent.com/1394592/195609956-de4779c0-bbe5-4335-a7b4-1a304f7d3766.png">
