### PR TITLE
Remove altImageSearch toggle

### DIFF
--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -75,13 +75,6 @@ const toggles = {
       description:
         'New search page to help develop new components and functionalities',
     },
-    {
-      id: 'altImageSearch',
-      title: 'Alternative Image Search page',
-      initialValue: false,
-      description:
-        'Displays the "in progress" image search page in its new look',
-    },
   ] as const,
   tests: [] as ABTest[],
 };


### PR DESCRIPTION
## Who is this for?
Maintenance

## What is it doing for them?
After a chat with Jonathan we came to the conclusion that starting to build the new image search within `/images` wouldn't make sense, everything is too interconnected, so we'll build it behind the Search toggle instead.