### PR TITLE
Draft: Activate turbosnap/no changes

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -13,5 +13,6 @@ jobs:
         uses: chromaui/action@v1
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          onlyChanged: true
           workingDir: cardigan
           buildScriptName: build

--- a/cardigan/package.json
+++ b/cardigan/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "start-storybook -s ./public -p 9001 -c .storybook",
     "build": "build-storybook -s ./public -c .storybook -o .dist",
-    "chromatic": "chromatic"
+    "chromatic": "chromatic --only-changed"
   },
   "devDependencies": {},
   "dependencies": {


### PR DESCRIPTION
## Who is this for?
Us maybe having less builds/a lower allowance of snapshots

## What is it doing for them?
https://www.chromatic.com/docs/turbosnap
It's meant to only build when files have changes, instead of every time, which might be valuable cost-wise.