### PR TITLE
Add function comments to the opening-times code

### DIFF
--- a/common/services/prismic/opening-times.ts
+++ b/common/services/prismic/opening-times.ts
@@ -138,7 +138,22 @@ export function groupOverrideDates(dates: OverrideDate[]): ExceptionalPeriod[] {
     });
 }
 
-export function exceptionalOpeningPeriodsAllDates(
+/** Replace the dates on each exceptional period with a complete set of dates.
+ *
+ * e.g. if we had an exceptional period
+ *
+ *    type  = other
+ *    dates = 1 Jan, 2 Jan, 5 Jan
+ *
+ * the dates would be replaced with the complete range
+ *
+ *    type  = other
+ *    dates = 1 Jan, 2 Jan, 3 Jan, 4 Jan, 5 Jan
+ *
+ * Note: this function assumes the dates on each ExceptionalPeriod are already sorted.
+ *
+ */
+export function completeDateRangeForExceptionalPeriods(
   exceptionalOpeningPeriods: ExceptionalPeriod[]
 ): ExceptionalPeriod[] {
   return exceptionalOpeningPeriods.map(period => {

--- a/common/services/prismic/opening-times.ts
+++ b/common/services/prismic/opening-times.ts
@@ -62,9 +62,35 @@ export function getOverrideDatesForAllVenues(venues: Venue[]): OverrideDate[] {
     });
 }
 
-export function exceptionalOpeningPeriods(
-  dates: OverrideDate[]
-): ExceptionalPeriod[] {
+/** Groups the list of OverrideDates based on:
+ *
+ *    - whether they fall on dates that are within a week of each other
+ *    - whether they have the same override type
+ *
+ * The groups will be returned in chronological order of their first date.
+ *
+ * e.g. if we had a list of dates
+ *
+ *    1 Jan / bank holiday
+ *    2 Jan / bank holiday
+ *    3 Jan / late spectacular
+ *    4 Jan / late spectacular
+ *    5 Jan / bank holiday
+ *    6 Feb / other
+ *    7 Feb / bank holiday
+ *
+ * it would create four groups:
+ *
+ *    [1 Jan, 2 Jan, 5 Jan] / bank holiday
+ *    [3 Jan, 4 Jan]        / late spectacular
+ *    [6 Feb]               / other
+ *    [7 Feb]               / bank holiday
+ *
+ * Note: this function expects that there will be at most one `OverrideDate` for
+ * each calendar date.
+ *
+ */
+export function groupOverrideDates(dates: OverrideDate[]): ExceptionalPeriod[] {
   dates.sort((a, b) => Number(a.overrideDate) - Number(b.overrideDate));
 
   const groupedExceptionalPeriods: Record<OverrideType, OverrideDate[]> =

--- a/common/services/prismic/opening-times.ts
+++ b/common/services/prismic/opening-times.ts
@@ -18,6 +18,22 @@ import {
   today,
 } from '../../utils/dates';
 
+/** Returns a list of OverrideDate for which any venue has
+ * exceptional opening hours.
+ *
+ * e.g. if we had two venues
+ *
+ *    library.exceptionalOpeningHours = [1 Jan, 2 Jan, 3 Jan]
+ *    gallery.exceptionalOpeningHours = [3 Jan, 4 Jan, 5 Feb]
+ *
+ * then this would return
+ *
+ *    [1 Jan, 2 Jan, 3 Jan, 4 Jan, 5 Feb]
+ *
+ * Note: this assumes that two venues with an override on the same date will
+ * always have the same overrideType.
+ *
+ */
 export function exceptionalOpeningDates(venues: Venue[]): OverrideDate[] {
   return venues
     .flatMap(venue => {

--- a/common/services/prismic/opening-times.ts
+++ b/common/services/prismic/opening-times.ts
@@ -315,7 +315,7 @@ export function groupConsecutiveExceptionalDays(
  * This includes exceptional periods happening today, so that if somebody looks at
  * the site on an exceptional day, it highlights the exceptional hours.
  */
-export function getUpcomingExceptionalPeriods(
+export function getUpcomingExceptionalOpeningHours(
   openingHoursGroups: ExceptionalOpeningHoursGroup[]
 ): ExceptionalOpeningHoursGroup[] {
   return openingHoursGroups.filter(period =>

--- a/common/services/prismic/opening-times.ts
+++ b/common/services/prismic/opening-times.ts
@@ -34,7 +34,7 @@ import {
  * always have the same overrideType.
  *
  */
-export function exceptionalOpeningDates(venues: Venue[]): OverrideDate[] {
+export function getOverrideDatesForAllVenues(venues: Venue[]): OverrideDate[] {
   return venues
     .flatMap(venue => {
       if (venue.openingHours.exceptional) {

--- a/common/services/prismic/opening-times.ts
+++ b/common/services/prismic/opening-times.ts
@@ -18,12 +18,12 @@ import {
   today,
 } from '../../utils/dates';
 
-/** Returns a list of OverrideDate for which any venue has
- * exceptional opening hours.
+/** Returns a list of OverrideDate for which any venue has exceptional hours.
+ * The list will be sorted in chronological order.
  *
  * e.g. if we had two venues
  *
- *    library.exceptionalOpeningHours = [1 Jan, 2 Jan, 3 Jan]
+ *    library.exceptionalOpeningHours = [3 Jan, 2 Jan, 1 Jan]
  *    gallery.exceptionalOpeningHours = [3 Jan, 4 Jan, 5 Feb]
  *
  * then this would return

--- a/common/test/services/prismic/opening-times.test.ts
+++ b/common/test/services/prismic/opening-times.test.ts
@@ -1,6 +1,6 @@
 import {
   getOverrideDatesForAllVenues,
-  exceptionalOpeningPeriods,
+  groupOverrideDates,
   exceptionalOpeningPeriodsAllDates,
   getExceptionalVenueDays,
   groupExceptionalVenueDays,
@@ -122,9 +122,9 @@ describe('opening-times', () => {
     });
   });
 
-  describe('exceptionalOpeningPeriods: groups together override dates based on their proximity to each other and their override type, so we can display them together', () => {
+  describe('groupOverrideDates: groups together override dates based on their proximity to each other and their override type, so we can display them together', () => {
     it('groups together dates with the same overrideType, so that there is never more than 4 days between one date and the next', () => {
-      const result = exceptionalOpeningPeriods([
+      const result = groupOverrideDates([
         { overrideType: 'other', overrideDate: new Date('2020-01-01') },
         { overrideType: 'other', overrideDate: new Date('2020-01-03') },
         { overrideType: 'other', overrideDate: new Date('2020-01-06') },
@@ -151,7 +151,7 @@ describe('opening-times', () => {
     });
 
     it('puts OverrideDates with the same overrideDate but different overrideType into different groups', () => {
-      const result = exceptionalOpeningPeriods([
+      const result = groupOverrideDates([
         { overrideType: 'other', overrideDate: new Date('2020-01-02') },
         { overrideType: 'other', overrideDate: new Date('2020-01-04') },
         {
@@ -172,7 +172,7 @@ describe('opening-times', () => {
     });
 
     it('puts dates in chronological order within their groups', () => {
-      const result = exceptionalOpeningPeriods([
+      const result = groupOverrideDates([
         { overrideType: 'other', overrideDate: new Date('2020-01-04') },
         { overrideType: 'other', overrideDate: new Date('2020-01-07') },
         { overrideType: 'other', overrideDate: new Date('2020-01-02') },
@@ -190,7 +190,7 @@ describe('opening-times', () => {
     });
 
     it('puts Groups in chronological order based on their earliest date', () => {
-      const result = exceptionalOpeningPeriods([
+      const result = groupOverrideDates([
         {
           overrideType: 'Bank holiday',
           overrideDate: new Date('2021-01-05'),

--- a/common/test/services/prismic/opening-times.test.ts
+++ b/common/test/services/prismic/opening-times.test.ts
@@ -1,5 +1,5 @@
 import {
-  exceptionalOpeningDates,
+  getOverrideDatesForAllVenues,
   exceptionalOpeningPeriods,
   exceptionalOpeningPeriodsAllDates,
   getExceptionalVenueDays,
@@ -32,13 +32,15 @@ const libraryVenue = getVenueById(venues, 'WsuS_R8AACS1Nwlx');
 const galleriesVenue = getVenueById(venues, 'Wsttgx8AAJeSNmJ4');
 
 describe('opening-times', () => {
-  describe('exceptionalOpeningDates: returns unique dates on which exceptional opening hours occur, taken from all venues.', () => {
+  describe('getOverrideDatesForAllVenues: returns unique dates on which exceptional opening hours occur, taken from all venues.', () => {
     it('returns an empty array if no venues have dates with exceptional opening hours', () => {
-      const result = exceptionalOpeningDates(venuesWithoutExceptionalDates);
+      const result = getOverrideDatesForAllVenues(
+        venuesWithoutExceptionalDates
+      );
       expect(result).toEqual([]);
     });
     it('returns all dates that have exceptional opening hours for any venue', () => {
-      const result = exceptionalOpeningDates(venues);
+      const result = getOverrideDatesForAllVenues(venues);
       expect(result).toEqual([
         {
           overrideDate: new Date('2021-01-05'),
@@ -87,7 +89,7 @@ describe('opening-times', () => {
       ]);
     });
     it('does not include a date more than once', () => {
-      const result = exceptionalOpeningDates(venues);
+      const result = getOverrideDatesForAllVenues(venues);
       const uniqueDates = new Set(
         result.map(date => date.overrideDate?.toString())
       );

--- a/common/test/services/prismic/opening-times.test.ts
+++ b/common/test/services/prismic/opening-times.test.ts
@@ -1,7 +1,7 @@
 import {
   getOverrideDatesForAllVenues,
   groupOverrideDates,
-  exceptionalOpeningPeriodsAllDates,
+  completeDateRangeForExceptionalPeriods,
   getExceptionalVenueDays,
   groupExceptionalVenueDays,
   exceptionalFromRegular,
@@ -224,9 +224,9 @@ describe('opening-times', () => {
     });
   });
 
-  describe('exceptionalOpeningPeriodsAllDates: adds dates to the dates array of a period, so that they are consecutive from the first to last', () => {
+  describe('completeDateRangeForExceptionalPeriods: adds dates to the dates array of a period, so that they are consecutive from the first to last', () => {
     it('fills in missing dates', () => {
-      const result = exceptionalOpeningPeriodsAllDates([
+      const result = completeDateRangeForExceptionalPeriods([
         {
           type: 'Christmas and New Year',
           dates: [

--- a/common/test/services/prismic/opening-times.test.ts
+++ b/common/test/services/prismic/opening-times.test.ts
@@ -6,7 +6,7 @@ import {
   groupExceptionalVenueDays,
   exceptionalFromRegular,
   createExceptionalOpeningHoursDays,
-  getUpcomingExceptionalPeriods,
+  getUpcomingExceptionalOpeningHours,
   getVenueById,
   getTodaysVenueHours,
   groupConsecutiveExceptionalDays,
@@ -536,7 +536,7 @@ describe('opening-times', () => {
     });
   });
 
-  describe('getUpcomingExceptionalPeriods', () => {
+  describe('getUpcomingExceptionalOpeningHours', () => {
     const exceptionalPeriods: ExceptionalOpeningHoursDay[][] = [
       [
         {
@@ -592,7 +592,7 @@ describe('opening-times', () => {
       spyOnLondon.mockImplementation(() => {
         return new Date('2021-11-30');
       });
-      const result = getUpcomingExceptionalPeriods(exceptionalPeriods);
+      const result = getUpcomingExceptionalOpeningHours(exceptionalPeriods);
       expect(result).toEqual([]);
     });
 
@@ -602,7 +602,7 @@ describe('opening-times', () => {
       spyOnLondon.mockImplementation(() => {
         return new Date('2021-12-10');
       });
-      const result = getUpcomingExceptionalPeriods(exceptionalPeriods);
+      const result = getUpcomingExceptionalOpeningHours(exceptionalPeriods);
       expect(result).toEqual([
         [
           {
@@ -655,7 +655,7 @@ describe('opening-times', () => {
         return new Date('2022-09-19T00:00:00Z');
       });
 
-      const result = getUpcomingExceptionalPeriods(exceptionalPeriods);
+      const result = getUpcomingExceptionalOpeningHours(exceptionalPeriods);
       expect(result).toEqual(exceptionalPeriods);
     });
   });

--- a/common/test/services/prismic/opening-times.test.ts
+++ b/common/test/services/prismic/opening-times.test.ts
@@ -14,6 +14,7 @@ import {
 import { venues } from '../../../test/fixtures/components/venues';
 import {
   ExceptionalOpeningHoursDay,
+  OverrideType,
   Venue,
 } from '../../../model/opening-hours';
 import * as dateUtils from '../../../utils/dates';
@@ -28,8 +29,8 @@ const venuesWithoutExceptionalDates = venues.map(venue => {
   };
 });
 
-const libraryVenue = getVenueById(venues, 'WsuS_R8AACS1Nwlx');
-const galleriesVenue = getVenueById(venues, 'Wsttgx8AAJeSNmJ4');
+const libraryVenue = getVenueById(venues, 'WsuS_R8AACS1Nwlx')!;
+const galleriesVenue = getVenueById(venues, 'Wsttgx8AAJeSNmJ4')!;
 
 describe('opening-times', () => {
   describe('getOverrideDatesForAllVenues: returns unique dates on which exceptional opening hours occur, taken from all venues.', () => {
@@ -94,6 +95,30 @@ describe('opening-times', () => {
         result.map(date => date.overrideDate?.toString())
       );
       expect(result.length).toEqual(uniqueDates.size);
+    });
+    it('sorts the list of returned dates', () => {
+      const venue = {
+        ...libraryVenue,
+        openingHours: {
+          ...libraryVenue.openingHours,
+          exceptional: [
+            new Date('2003-03-03'),
+            new Date('2001-01-01'),
+            new Date('2002-02-02'),
+          ].map(overrideDate => ({
+            overrideDate,
+            overrideType: 'other' as OverrideType,
+            opens: '00:00',
+            closes: '00:00',
+          })),
+        },
+      };
+      const result = getOverrideDatesForAllVenues([venue]);
+      expect(result.map(d => d.overrideDate)).toEqual([
+        new Date('2001-01-01'),
+        new Date('2002-02-02'),
+        new Date('2003-03-03'),
+      ]);
     });
   });
 

--- a/common/test/services/prismic/opening-times.test.ts
+++ b/common/test/services/prismic/opening-times.test.ts
@@ -5,7 +5,7 @@ import {
   getExceptionalVenueDays,
   groupExceptionalVenueDays,
   exceptionalFromRegular,
-  backfillExceptionalVenueDays,
+  createExceptionalOpeningHoursDays,
   getUpcomingExceptionalPeriods,
   getVenueById,
   getTodaysVenueHours,
@@ -433,7 +433,7 @@ describe('opening-times', () => {
 
   describe("backfillExceptionalVenueDays: returns the venue's exceptional opening times for each date, and if there is no exceptional opening time for a specific date, then it uses the venue's regular opening times for that day.", () => {
     it('returns an exceptional override date type for each of the dates provided', () => {
-      const result = backfillExceptionalVenueDays(libraryVenue, [
+      const result = createExceptionalOpeningHoursDays(libraryVenue, [
         {
           type: 'Christmas and New Year',
           dates: [
@@ -510,7 +510,7 @@ describe('opening-times', () => {
 
     // We don't backfill if its type is other - see https://github.com/wellcomecollection/wellcomecollection.org/pull/4437
     it("it doesn't return the regular hours if the override type is 'other'", () => {
-      const result = backfillExceptionalVenueDays(libraryVenue, [
+      const result = createExceptionalOpeningHoursDays(libraryVenue, [
         {
           type: 'Bank holiday',
           dates: [new Date('2021-10-05')],

--- a/common/test/services/prismic/opening-times.test.ts
+++ b/common/test/services/prismic/opening-times.test.ts
@@ -245,7 +245,7 @@ describe('opening-times', () => {
 
   describe('getExceptionalVenueDays', () => {
     it('returns all exceptional override dates for a venue', () => {
-      const result = getExceptionalVenueDays(galleriesVenue!);
+      const result = getExceptionalVenueDays(galleriesVenue);
       expect(result).toEqual([
         {
           overrideDate: new Date('2022-01-01'),
@@ -416,7 +416,7 @@ describe('opening-times', () => {
   describe('exceptionalFromRegular', () => {
     it('returns an ExceptionalOpeningHoursDay type for a particular date and venue, generated from the regular hours of that venue.', () => {
       const result = exceptionalFromRegular(
-        libraryVenue!,
+        libraryVenue,
         new Date('2021-12-21'),
         'Bank holiday'
       );
@@ -433,7 +433,7 @@ describe('opening-times', () => {
 
   describe("backfillExceptionalVenueDays: returns the venue's exceptional opening times for each date, and if there is no exceptional opening time for a specific date, then it uses the venue's regular opening times for that day.", () => {
     it('returns an exceptional override date type for each of the dates provided', () => {
-      const result = backfillExceptionalVenueDays(libraryVenue!, [
+      const result = backfillExceptionalVenueDays(libraryVenue, [
         {
           type: 'Christmas and New Year',
           dates: [
@@ -510,7 +510,7 @@ describe('opening-times', () => {
 
     // We don't backfill if its type is other - see https://github.com/wellcomecollection/wellcomecollection.org/pull/4437
     it("it doesn't return the regular hours if the override type is 'other'", () => {
-      const result = backfillExceptionalVenueDays(libraryVenue!, [
+      const result = backfillExceptionalVenueDays(libraryVenue, [
         {
           type: 'Bank holiday',
           dates: [new Date('2021-10-05')],
@@ -675,7 +675,7 @@ describe('opening-times', () => {
         return new Date('2022-01-19T00:00:00Z');
       });
 
-      const result = getTodaysVenueHours(libraryVenue!);
+      const result = getTodaysVenueHours(libraryVenue);
 
       expect(result).toEqual({
         dayOfWeek: 'Wednesday',
@@ -692,7 +692,7 @@ describe('opening-times', () => {
         return new Date('2023-01-01T00:00:00Z');
       });
 
-      const result = getTodaysVenueHours(libraryVenue!);
+      const result = getTodaysVenueHours(libraryVenue);
       expect(result).toEqual({
         overrideDate: new Date('2023-01-01'),
         overrideType: 'Christmas and New Year',

--- a/content/webapp/components/VenueHours/VenueHours.tsx
+++ b/content/webapp/components/VenueHours/VenueHours.tsx
@@ -13,7 +13,7 @@ import {
   getUpcomingExceptionalPeriods,
   getOverrideDatesForAllVenues,
   groupOverrideDates,
-  exceptionalOpeningPeriodsAllDates,
+  completeDateRangeForExceptionalPeriods,
 } from '@weco/common/services/prismic/opening-times';
 import { transformCollectionVenues } from '@weco/common/services/prismic/transformers/collection-venues';
 import Space from '@weco/common/views/components/styled/Space';
@@ -94,10 +94,10 @@ const VenueHours: FunctionComponent<Props> = ({ venue, weight }) => {
   const venues = transformCollectionVenues(collectionVenues);
   const allOverrideDates = getOverrideDatesForAllVenues(venues);
   const exceptionalPeriods = groupOverrideDates(allOverrideDates);
-  const exceptionalPeriodsAllDates =
-    exceptionalOpeningPeriodsAllDates(exceptionalPeriods);
+  const completeExceptionalPeriods =
+    completeDateRangeForExceptionalPeriods(exceptionalPeriods);
   const backfilledExceptionalPeriods = venue
-    ? backfillExceptionalVenueDays(venue, exceptionalPeriodsAllDates)
+    ? backfillExceptionalVenueDays(venue, completeExceptionalPeriods)
     : [];
   const upcomingExceptionalPeriods =
     backfilledExceptionalPeriods &&

--- a/content/webapp/components/VenueHours/VenueHours.tsx
+++ b/content/webapp/components/VenueHours/VenueHours.tsx
@@ -10,7 +10,7 @@ import { getCrop } from '@weco/common/model/image';
 import { clock } from '@weco/common/icons';
 import {
   createExceptionalOpeningHoursDays,
-  getUpcomingExceptionalPeriods,
+  getUpcomingExceptionalOpeningHours,
   getOverrideDatesForAllVenues,
   groupOverrideDates,
   completeDateRangeForExceptionalPeriods,
@@ -102,7 +102,7 @@ const VenueHours: FunctionComponent<Props> = ({ venue, weight }) => {
 
   const upcomingExceptionalOpeningHours =
     exceptionalOpeningHours &&
-    getUpcomingExceptionalPeriods(exceptionalOpeningHours);
+    getUpcomingExceptionalOpeningHours(exceptionalOpeningHours);
 
   const isFeatured = weight === 'featured';
   return (
@@ -154,7 +154,7 @@ const VenueHours: FunctionComponent<Props> = ({ venue, weight }) => {
           )}
         </ul>
       </VenueHoursTimes>
-      {upcomingExceptionalPeriods.map((upcomingExceptionalPeriod, i) => {
+      {upcomingExceptionalOpeningHours.map((upcomingExceptionalPeriod, i) => {
         const firstOverride = upcomingExceptionalPeriod.find(
           date => date.overrideType
         );

--- a/content/webapp/components/VenueHours/VenueHours.tsx
+++ b/content/webapp/components/VenueHours/VenueHours.tsx
@@ -12,7 +12,7 @@ import {
   backfillExceptionalVenueDays,
   getUpcomingExceptionalPeriods,
   getOverrideDatesForAllVenues,
-  exceptionalOpeningPeriods,
+  groupOverrideDates,
   exceptionalOpeningPeriodsAllDates,
 } from '@weco/common/services/prismic/opening-times';
 import { transformCollectionVenues } from '@weco/common/services/prismic/transformers/collection-venues';
@@ -93,10 +93,9 @@ const VenueHours: FunctionComponent<Props> = ({ venue, weight }) => {
   const { collectionVenues } = usePrismicData();
   const venues = transformCollectionVenues(collectionVenues);
   const allOverrideDates = getOverrideDatesForAllVenues(venues);
-  const groupedExceptionalDates = exceptionalOpeningPeriods(allOverrideDates);
-  const exceptionalPeriodsAllDates = exceptionalOpeningPeriodsAllDates(
-    groupedExceptionalDates
-  );
+  const exceptionalPeriods = groupOverrideDates(allOverrideDates);
+  const exceptionalPeriodsAllDates =
+    exceptionalOpeningPeriodsAllDates(exceptionalPeriods);
   const backfilledExceptionalPeriods = venue
     ? backfillExceptionalVenueDays(venue, exceptionalPeriodsAllDates)
     : [];

--- a/content/webapp/components/VenueHours/VenueHours.tsx
+++ b/content/webapp/components/VenueHours/VenueHours.tsx
@@ -11,7 +11,7 @@ import { clock } from '@weco/common/icons';
 import {
   backfillExceptionalVenueDays,
   getUpcomingExceptionalPeriods,
-  exceptionalOpeningDates,
+  getOverrideDatesForAllVenues,
   exceptionalOpeningPeriods,
   exceptionalOpeningPeriodsAllDates,
 } from '@weco/common/services/prismic/opening-times';
@@ -92,9 +92,8 @@ type Props = {
 const VenueHours: FunctionComponent<Props> = ({ venue, weight }) => {
   const { collectionVenues } = usePrismicData();
   const venues = transformCollectionVenues(collectionVenues);
-  const allExceptionalDates = exceptionalOpeningDates(venues);
-  const groupedExceptionalDates =
-    exceptionalOpeningPeriods(allExceptionalDates);
+  const allOverrideDates = getOverrideDatesForAllVenues(venues);
+  const groupedExceptionalDates = exceptionalOpeningPeriods(allOverrideDates);
   const exceptionalPeriodsAllDates = exceptionalOpeningPeriodsAllDates(
     groupedExceptionalDates
   );

--- a/content/webapp/components/VenueHours/VenueHours.tsx
+++ b/content/webapp/components/VenueHours/VenueHours.tsx
@@ -9,7 +9,7 @@ import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImag
 import { getCrop } from '@weco/common/model/image';
 import { clock } from '@weco/common/icons';
 import {
-  backfillExceptionalVenueDays,
+  createExceptionalOpeningHoursDays,
   getUpcomingExceptionalPeriods,
   getOverrideDatesForAllVenues,
   groupOverrideDates,
@@ -96,12 +96,13 @@ const VenueHours: FunctionComponent<Props> = ({ venue, weight }) => {
   const exceptionalPeriods = groupOverrideDates(allOverrideDates);
   const completeExceptionalPeriods =
     completeDateRangeForExceptionalPeriods(exceptionalPeriods);
-  const backfilledExceptionalPeriods = venue
-    ? backfillExceptionalVenueDays(venue, completeExceptionalPeriods)
+  const exceptionalOpeningHours = venue
+    ? createExceptionalOpeningHoursDays(venue, completeExceptionalPeriods)
     : [];
-  const upcomingExceptionalPeriods =
-    backfilledExceptionalPeriods &&
-    getUpcomingExceptionalPeriods(backfilledExceptionalPeriods);
+
+  const upcomingExceptionalOpeningHours =
+    exceptionalOpeningHours &&
+    getUpcomingExceptionalPeriods(exceptionalOpeningHours);
 
   const isFeatured = weight === 'featured';
   return (


### PR DESCRIPTION
## Who is this for?

For me, other devs, and https://github.com/wellcomecollection/wellcomecollection.org/issues/7831

## What is it doing for them?

Adding some comments explaining how the individual functions for managing opening times are meant to work. This is among the gnarliest code we've got, and I find it pretty tricky to follow or even work out what it's doing. This is just adding comments and renaming functions, so the behaviour should be unchanged – but hopefully easier to read for the next person who comes along.