### PR TITLE
Make Cookie notice closing icon white

### DIFF
--- a/common/views/components/CookieNotice/CookieNotice.tsx
+++ b/common/views/components/CookieNotice/CookieNotice.tsx
@@ -79,7 +79,7 @@ const CookieNotice: FunctionComponent<Props> = ({ source }) => {
               </a>
             </div>
             <CloseCookieNotice onClick={hideCookieNotice}>
-              <Icon icon={clear} />
+              <Icon icon={clear} color="white" />
               <span className="visually-hidden">Close cookie notification</span>
             </CloseCookieNotice>
           </div>


### PR DESCRIPTION
## Who is this for?
users 

## What is it doing for them?
Makes the closing icon more visible

<img width="1081" alt="Screenshot 2022-10-17 at 10 13 52" src="https://user-images.githubusercontent.com/110461050/196138779-57e4707f-54c1-45a8-9707-6f191da31270.png">
