### PR TITLE
Only 4 (not 112) playback rate buttons per player

### DIFF
--- a/common/views/components/AudioPlayer/AudioPlayer.tsx
+++ b/common/views/components/AudioPlayer/AudioPlayer.tsx
@@ -90,10 +90,7 @@ const SecondRow = styled.div`
   grid-column: 1 / -1;
 `;
 
-const PlayRateRadio = styled.input.attrs({
-  type: 'radio',
-  name: 'playback-rate',
-})`
+const PlayRateRadio = styled.input`
   position: absolute;
   top: 0;
   right: 0;
@@ -169,6 +166,8 @@ const PlayRate: FC<PlayRateProps> = ({ audioPlayer, id }) => {
           isActive={audioPlaybackRate === speed}
         >
           <PlayRateRadio
+            type="radio"
+            name={`playback-rate-${id}`}
             id={`playrate-${speed}-${id}`}
             onClick={() => updatePlaybackRate(speed)}
           />


### PR DESCRIPTION
__Before__
<img width="1053" alt="image" src="https://user-images.githubusercontent.com/1394592/196164146-3d9ad000-8ae2-4fb8-8fad-8e8b1ea3e6e8.png">

__After__
<img width="1069" alt="image" src="https://user-images.githubusercontent.com/1394592/196163926-4d3afb81-fb42-4c64-838c-3d5fe0d786d2.png">
