### PR TITLE
Accessibility fixes on the audio player

### DIFF
--- a/common/views/components/AudioPlayer/AudioPlayer.tsx
+++ b/common/views/components/AudioPlayer/AudioPlayer.tsx
@@ -416,7 +416,26 @@ export const AudioPlayer: FC<AudioPlayerProps> = ({
 
       <AudioPlayerGrid>
         <PlayPauseButton onClick={onTogglePlay} isPlaying={isPlaying}>
-          <PlayPauseInner>
+          <PlayPauseInner
+            // We declare the ARIA data on this wrapper rather than relying on the icon label
+            // to avoid a weird behaviour IOS screen reader.
+            //
+            // In particular, some combination of the icon-swapping means that selecting
+            // the button is read as:
+            //
+            //    Button, play
+            //    (user taps button)
+            //    Play, pause
+            //
+            // With these attributes, it's now read as:
+            //
+            //    Play, button
+            //    (user taps button)
+            //    Pause
+            //
+            aria-label={isPlaying ? 'Pause' : 'Play'}
+            role="button"
+          >
             <Icon color="accent.green" icon={isPlaying ? pause : play} />
           </PlayPauseInner>
         </PlayPauseButton>

--- a/common/views/components/AudioPlayer/AudioPlayer.tsx
+++ b/common/views/components/AudioPlayer/AudioPlayer.tsx
@@ -169,21 +169,30 @@ const PlayRate: FC<PlayRateProps> = ({ audioPlayer, id }) => {
       role="radiogroup"
     >
       <span className="visually-hidden">playback rate:</span>
-      {speeds.map(speed => (
-        <PlayRateLabel
-          key={speed}
-          htmlFor={`playrate-${speed}-${id}`}
-          isActive={audioPlaybackRate === speed}
-        >
-          <PlayRateRadio
-            id={`playrate-${speed}-${id}`}
-            onClick={() => updatePlaybackRate(speed)}
-            name={`playrate-${id}`}
-          />
-          {speed}
-          <span aria-hidden="true">x</span>
-        </PlayRateLabel>
-      ))}
+      {speeds.map(speed => {
+        // We construct this string here rather than directly in the component so these
+        // become a single element on the page.
+        //
+        // If we had them directly in the component, the iOS screen reader would read
+        // the two parts separately,
+        // e.g. "one point five (pause) ex" rather than "one point five ex".
+        const label = `${speed}x`;
+
+        return (
+          <PlayRateLabel
+            key={speed}
+            htmlFor={`playrate-${speed}-${id}`}
+            isActive={audioPlaybackRate === speed}
+          >
+            <PlayRateRadio
+              id={`playrate-${speed}-${id}`}
+              onClick={() => updatePlaybackRate(speed)}
+              name={`playrate-${id}`}
+            />
+            {label}
+          </PlayRateLabel>
+        );
+      })}
     </PlayRateWrapper>
   );
 };

--- a/common/views/components/AudioPlayer/AudioPlayer.tsx
+++ b/common/views/components/AudioPlayer/AudioPlayer.tsx
@@ -418,7 +418,7 @@ export const AudioPlayer: FC<AudioPlayerProps> = ({
         <PlayPauseButton onClick={onTogglePlay} isPlaying={isPlaying}>
           <PlayPauseInner
             // We declare the ARIA data on this wrapper rather than relying on the icon label
-            // to avoid a weird behaviour IOS screen reader.
+            // to avoid a weird behaviour in the iOS screen reader.
             //
             // In particular, some combination of the icon-swapping means that selecting
             // the button is read as:

--- a/common/views/components/AudioPlayer/AudioPlayer.tsx
+++ b/common/views/components/AudioPlayer/AudioPlayer.tsx
@@ -168,6 +168,7 @@ const PlayRate: FC<PlayRateProps> = ({ audioPlayer, id }) => {
       // e.g. a screen reader will say "1 of 4" instead of "1 of 112" on an exhibition guide.
       role="radiogroup"
     >
+      <span className="visually-hidden">playback rate:</span>
       {speeds.map(speed => (
         <PlayRateLabel
           key={speed}
@@ -179,7 +180,6 @@ const PlayRate: FC<PlayRateProps> = ({ audioPlayer, id }) => {
             onClick={() => updatePlaybackRate(speed)}
             name={`playrate-${id}`}
           />
-          <span className="visually-hidden">playback rate:</span>
           {speed}
           <span aria-hidden="true">x</span>
         </PlayRateLabel>

--- a/common/views/components/AudioPlayer/AudioPlayer.tsx
+++ b/common/views/components/AudioPlayer/AudioPlayer.tsx
@@ -92,7 +92,6 @@ const SecondRow = styled.div`
 
 const PlayRateRadio = styled.input.attrs({
   type: 'radio',
-  name: 'playback-rate',
 })`
   position: absolute;
   top: 0;
@@ -161,7 +160,14 @@ const PlayRate: FC<PlayRateProps> = ({ audioPlayer, id }) => {
   }
 
   return (
-    <PlayRateWrapper>
+    <PlayRateWrapper
+      // This ARIA role -- combined with the shared `name` on the individual buttons --
+      // tells screen readers that these radio buttons are part of a single group, and
+      // separate from the other buttons on the page.
+      //
+      // e.g. a screen reader will say "1 of 4" instead of "1 of 112" on an exhibition guide.
+      role="radiogroup"
+    >
       {speeds.map(speed => (
         <PlayRateLabel
           key={speed}
@@ -171,6 +177,7 @@ const PlayRate: FC<PlayRateProps> = ({ audioPlayer, id }) => {
           <PlayRateRadio
             id={`playrate-${speed}-${id}`}
             onClick={() => updatePlaybackRate(speed)}
+            name={`playrate-${id}`}
           />
           <span className="visually-hidden">playback rate:</span>
           {speed}


### PR DESCRIPTION
## Who is this for?

Screen reader users.

## What is it doing for them?

Making the audio player experience a bit less awkward.

* Playback rate buttons are now read as "1 of 4", not "1 of however many on the page"
* We only say "playback rate" once, and we include the "x"
* We don't double up the playback rate as you skip through it
* Fix some weird behaviour on the play/pause button

Screen recordings below.

<table><tr><th>Before</th><th>After</th></tr>
<tr><td><video src="https://user-images.githubusercontent.com/301220/196169282-e457acde-42fb-4cb2-afea-a391947e110b.mp4"></td><td>
<video src="https://user-images.githubusercontent.com/301220/196169090-2e70b8e7-e982-47c2-b3ab-a9b2d987cc74.mp4"></td></tr></table>