### PR TITLE
Improve font sizing and spacing in exhibition guides

### DIFF
--- a/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
+++ b/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
@@ -74,18 +74,18 @@ const TombstoneTitle = styled(Space).attrs<{ level: number }>(props => ({
 
 const Tombstone = styled(Space).attrs({
   className: font('intb', 4),
-  h: { size: 'm', properties: ['padding-right'] },
+  h: { size: 'l', properties: ['padding-right'] },
 })`
   flex-basis: 100%;
   margin-bottom: 1em;
 
   ${props => props.theme.media('medium')`
-    flex-basis: 45%;
+    flex-basis: 40%;
     margin-bottom: 0;
   `}
 
   ${props => props.theme.media('large')`
-    flex-basis: 35%;
+    flex-basis: 30%;
   `}
 
   p {
@@ -98,16 +98,16 @@ const CaptionTranscription = styled.div`
   max-width: 45em;
 
   ${props => props.theme.media('medium')`
-    flex-basis: 55%;
+    flex-basis: 60%;
   `}
 
   ${props => props.theme.media('large')`
-    flex-basis: 65%;
+    flex-basis: 70%;
   `}
 `;
 
 const Caption = styled(Space).attrs({
-  className: `spaced-text ${font('intr', 4)}`,
+  className: `spaced-text ${font('intr', 5)}`,
   h: { size: 'm', properties: ['padding-left', 'padding-right'] },
 })`
   border-left: 20px solid ${props => props.theme.color('lightYellow')};
@@ -255,7 +255,7 @@ const Stop: FC<{
                   {title}
                 </TombstoneTitle>
               )}
-              <div className={font('intb', 4)}>
+              <div className={font('intr', 4)}>
                 <PrismicHtmlBlock html={tombstone} />
               </div>
             </Tombstone>

--- a/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
+++ b/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
@@ -68,11 +68,12 @@ const ContextContainer = styled(Space).attrs<{ hasPadding: boolean }>(
 
 const TombstoneTitle = styled(Space).attrs<{ level: number }>(props => ({
   as: `h${props.level}`,
-  className: font('intb', 3),
+  className: font('wb', 2),
   v: { size: 's', properties: ['margin-bottom'] },
 }))<{ level: number }>``;
 
 const Tombstone = styled(Space).attrs({
+  className: font('intb', 4),
   h: { size: 'm', properties: ['padding-right'] },
 })`
   flex-basis: 100%;
@@ -254,7 +255,7 @@ const Stop: FC<{
                   {title}
                 </TombstoneTitle>
               )}
-              <div className={font('intr', 4)}>
+              <div className={font('intb', 4)}>
                 <PrismicHtmlBlock html={tombstone} />
               </div>
             </Tombstone>

--- a/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
+++ b/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
@@ -119,6 +119,7 @@ const PrismicImageWrapper = styled.div`
 `;
 
 const Transcription = styled(Space).attrs({
+  className: `spaced-text ${font('intr', 5)}`,
   h: { size: 'm', properties: ['padding-left', 'padding-right'] },
   v: { size: 'l', properties: ['margin-top'] },
 })`

--- a/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
+++ b/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
@@ -80,12 +80,12 @@ const Tombstone = styled(Space).attrs({
   margin-bottom: 1em;
 
   ${props => props.theme.media('medium')`
-    flex-basis: 40%;
+    flex-basis: 45%;
     margin-bottom: 0;
   `}
 
   ${props => props.theme.media('large')`
-    flex-basis: 25%;
+    flex-basis: 35%;
   `}
 
   p {
@@ -98,11 +98,11 @@ const CaptionTranscription = styled.div`
   max-width: 45em;
 
   ${props => props.theme.media('medium')`
-    flex-basis: 60%;
+    flex-basis: 55%;
   `}
 
   ${props => props.theme.media('large')`
-    flex-basis: 75%;
+    flex-basis: 65%;
   `}
 `;
 


### PR DESCRIPTION
## Who is this for?

All guide users, based on Dom flagging things don't look like the design https://github.com/wellcomecollection/wellcomecollection.org/issues/8616

## What is it doing for them?

It changes Tombstone Title to be wellcome bold font, as per design. It adjust the sizing of this title and implements inter bold on the Tombstone text. I've put my reasoning for the chosen font sizing below. I have also adjust the size of the Tombstone section, and spacing between Tombstone Title and the yellow border to be closer to the design.

I showed this to Dom, and so far so good, but I'll obviously get it into staging so Dom can have a look proper.

### Font sizing

I have [worked out](https://nekocalc.com/px-to-rem-converter) the closest rem match from [cardigan](https://cardigan.wellcomecollection.org/?path=/docs/global-typography--scale) to the designs in [Zeplin](https://app.zeplin.io/project/5aab926b4b6efde01259e959/screen/633a93328cdfb0307e4f2327). 

On Zeplin, Tombstone title is 24px -> 1.5rem -> 2 in cardigan typography scale
On Zeplin, text below Tombstone Title is 19px -> 1.188rem -> 4 in cardigan typography scale
On Zeplin, text to the right of yellow border is 16px -> 1rem -> 5 in cardigan typography scale 

Before
![Screenshot 2022-10-18 at 14 42 51](https://user-images.githubusercontent.com/16557524/196447536-94b2a729-2add-423b-afa3-477b5ce917e0.png)


After
![Screenshot 2022-10-18 at 14 44 06](https://user-images.githubusercontent.com/16557524/196447555-d00b3b6f-dd00-4e97-8546-3b8b13325b0f.png)

