### PR TITLE
Stop the build from breaking

### DIFF
--- a/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
@@ -339,7 +339,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
       parentManifest.manifests.find((childManifest: CollectionManifest) => {
         return !transformedManifest
           ? false
-          : childManifest['@id'] === transformedManifest['@id'];
+          : childManifest['@id'] === transformedManifest.id;
       });
 
     matchingManifest && setCurrentManifestLabel(matchingManifest.label);

--- a/catalogue/webapp/services/iiif/transformers/manifest.ts
+++ b/catalogue/webapp/services/iiif/transformers/manifest.ts
@@ -24,6 +24,9 @@ export function transformManifest(
   const { manifestV2, manifestV3 } = { ...iiifManifests };
 
   // V2
+  // TODO Be aware when moving the id to v3 the id value changes, the id string will no longer contain /v2/
+  // This causes the matchingManifest not to be found in IIIFViewer
+  const id = manifestV2 ? manifestV2['@id']: '';
   const title = manifestV2 ? manifestV2.label : '';
   const canvases = manifestV2 ? getCanvases(manifestV2) : [];
   const canvasCount = canvases.length;
@@ -76,6 +79,7 @@ export function transformManifest(
   // TODO As we move over, further transform the props to exactly what we need
   return {
     // Taken from V2 manifest:
+    id,
     title,
     canvasCount,
     collectionManifestsCount,

--- a/catalogue/webapp/types/manifest.ts
+++ b/catalogue/webapp/types/manifest.ts
@@ -44,12 +44,14 @@ export type TransformedManifest = {
   searchService: Service2 | undefined;
   structures: IIIFStructure[];
   // Currently from iiif manifest v3:
+  id: string;
   audio: Audio | undefined;
   services: Service[];
 };
 
 export function createDefaultTransformedManifest(): TransformedManifest {
   return {
+    id: '',
     title: '',
     canvasCount: 0,
     collectionManifestsCount: 0,


### PR DESCRIPTION
The new transformer function wasn't returning the manifest id, which was stopping a label from displaying on works that were part of a collection.

The label is contained on the parent manifest and we needed the id to find it.
