### PR TITLE
Reject queries which are non-JSON or non-strings

### DIFF
--- a/common/utils/array.ts
+++ b/common/utils/array.ts
@@ -14,6 +14,15 @@ export function isString(v: any): v is string {
   return typeof v === 'string';
 }
 
+export function isJson(v: string): boolean {
+  try {
+    JSON.parse(v);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
 export function stringFromStringOrStringArray(
   input: string | string[]
 ): string {

--- a/content/webapp/pages/api/exhibitions-related-content/index.ts
+++ b/content/webapp/pages/api/exhibitions-related-content/index.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { isString } from '@weco/common/utils/array';
+import { isJson, isString } from '@weco/common/utils/array';
 import { createClient } from '../../../services/prismic/fetch';
 import { fetchExhibitionRelatedContent } from '../../../services/prismic/fetch/exhibitions';
 import { transformExhibitionRelatedContent } from '../../../services/prismic/transformers/exhibitions';
@@ -14,11 +14,12 @@ export default async (
 ): Promise<void> => {
   const { params } = req.query;
 
-  if (!isString(params)) {
-    return res.status(400).json({ description: 'Missing params' });
+  // Reject anybody trying to send nonsense to the API
+  if (!isString(params) || !isJson(params)) {
+    return res.status(404).json({ notFound: true });
   }
 
-  const parsedParams: string[] = JSON.parse(params);
+  const parsedParams = JSON.parse(params);
   const client = createClient({ req });
 
   if (parsedParams.length === 0) {

--- a/content/webapp/pages/api/multi-content/index.ts
+++ b/content/webapp/pages/api/multi-content/index.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { isNotUndefined, isString } from '@weco/common/utils/array';
+import { isJson, isString } from '@weco/common/utils/array';
 import { createClient } from '../../../services/prismic/fetch';
 import {
   parseQuery,
@@ -16,17 +16,19 @@ export default async (
   res: NextApiResponse<string | NotFound>
 ): Promise<void> => {
   const { params } = req.query;
-  const parsedQuery = isString(params) ? parseQuery(params) : undefined;
 
-  if (isNotUndefined(parsedQuery)) {
-    const client = createClient({ req });
-    const query = await fetchMultiContent(client, parsedQuery);
-
-    if (query) {
-      const multiContent = transformQuery(query, transformMultiContent);
-      return res.status(200).json(superjson.stringify(multiContent));
-    }
+  // Reject anybody trying to send nonsense to the API
+  if (!isString(params) || !isJson(params)) {
+    return res.status(404).json({ notFound: true });
   }
 
-  return res.status(404).json({ notFound: true });
+  const parsedQuery = parseQuery(params);
+
+  const client = createClient({ req });
+  const query = await fetchMultiContent(client, parsedQuery);
+
+  if (query) {
+    const multiContent = transformQuery(query, transformMultiContent);
+    return res.status(200).json(superjson.stringify(multiContent));
+  }
 };


### PR DESCRIPTION
I could be persuaded to make this a 400, but honestly I just want to make the alerts shut up.

Note that because this is blowing up when we call `JSON.parse()`, this isn't affecting Prismic, just our alerts.