### PR TITLE
Search page layout concept

### DIFF
--- a/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
+++ b/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
@@ -2,8 +2,9 @@ import { respondBetween, respondTo } from '@weco/common/views/themes/mixins';
 import CataloguePageLayout from 'components/CataloguePageLayout/CataloguePageLayout';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { FunctionComponent, ReactElement } from 'react';
+import { FunctionComponent, ReactElement, useEffect, useState } from 'react';
 import styled from 'styled-components';
+import { pageDescriptions } from '@weco/common/data/microcopy';
 
 const NavBar = styled.nav`
   overflow: scroll;
@@ -106,16 +107,78 @@ const SearchLayout: FunctionComponent = ({ children }) => {
     router.pathname === '/search'
       ? 'overview'
       : router.pathname.slice(router.pathname.lastIndexOf('/') + 1);
+
+  const basePageMetadata = {
+    openGraphType: 'website',
+    siteSection: 'collections',
+    jsonLd: { '@type': 'WebPage' },
+    hideNewsletterPromo: true,
+  } as const;
+
+  const defaultPageLayoutMetadata = {
+    ...basePageMetadata,
+    title: 'Search Page',
+    description: 'TBC',
+    url: { pathname: '/search', query: {} },
+  };
+
+  const [pageLayoutMetadata, setPageLayoutMetadata] = useState(
+    defaultPageLayoutMetadata
+  );
+  useEffect(() => {
+    const { query } = router.query;
+    switch (currentSearchCategory) {
+      case 'overview':
+        setPageLayoutMetadata(defaultPageLayoutMetadata);
+        break;
+      case 'exhibitions':
+        setPageLayoutMetadata({
+          ...basePageMetadata,
+          description: 'copy pending',
+          title: `${query ? `${query} | ` : ''}Exhibition Search`,
+          url: { pathname: '/search/exhibitions', query: router.query },
+        });
+        break;
+      case 'events':
+        setPageLayoutMetadata({
+          ...basePageMetadata,
+          description: 'copy pending',
+          title: `${query ? `${query} | ` : ''}Events Search`,
+          url: { pathname: '/search/events', query: router.query },
+        });
+        break;
+      case 'stories':
+        setPageLayoutMetadata({
+          ...basePageMetadata,
+          description: 'copy pending',
+          title: `${query ? `${query} | ` : ''}Stories Search`,
+          url: { pathname: '/search/stories', query: router.query },
+        });
+        break;
+      case 'images':
+        setPageLayoutMetadata({
+          ...basePageMetadata,
+          description: pageDescriptions.images,
+          title: `${query ? `${query} | ` : ''}Image Search`,
+          url: { pathname: '/search/images', query: router.query },
+        });
+        break;
+      case 'collections':
+        setPageLayoutMetadata({
+          ...basePageMetadata,
+          description: 'copy pending',
+          title: `${query ? `${query} | ` : ''}Collections Search`,
+          url: { pathname: '/search/collections', query: router.query },
+        });
+        break;
+
+      default:
+        break;
+    }
+  }, [currentSearchCategory]);
+
   return (
-    <CataloguePageLayout
-      title="Search Page"
-      description={'<TBC>'}
-      url={{ pathname: '/search', query: {} }}
-      openGraphType="website"
-      siteSection="collections"
-      jsonLd={{ '@type': 'WebPage' }}
-      hideNewsletterPromo={true}
-    >
+    <CataloguePageLayout {...pageLayoutMetadata}>
       <div className="container">
         <input placeholder="search..." type="search" />
         <NavBar aria-label="Search Categories">
@@ -135,10 +198,21 @@ const SearchLayout: FunctionComponent = ({ children }) => {
               <Link scroll={false} passHref href={'/search/exhibitions'}>
                 <NavLink
                   aria-current={
-                    currentSearchCategory === 'exhibition' ? 'page' : 'false'
+                    currentSearchCategory === 'exhibitions' ? 'page' : 'false'
                   }
                 >
-                  Exhibitions and Events
+                  Exhibitions
+                </NavLink>
+              </Link>
+            </NavItem>
+            <NavItem>
+              <Link scroll={false} passHref href={'/search/events'}>
+                <NavLink
+                  aria-current={
+                    currentSearchCategory === 'events' ? 'page' : 'false'
+                  }
+                >
+                  Events
                 </NavLink>
               </Link>
             </NavItem>

--- a/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
+++ b/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
@@ -1,0 +1,190 @@
+import { respondBetween, respondTo } from '@weco/common/views/themes/mixins';
+import CataloguePageLayout from 'components/CataloguePageLayout/CataloguePageLayout';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { FunctionComponent, ReactElement } from 'react';
+import styled from 'styled-components';
+
+const NavBar = styled.nav`
+  overflow: scroll;
+  border-bottom: 1px solid ${props => props.theme.color('warmNeutral.400')};
+  [aria-current='page'] {
+    &:after {
+      width: 100%;
+    }
+  }
+`;
+const NavList = styled.ul`
+  display: flex;
+  list-style: none;
+  list-style-position: inside;
+  padding-inline-start: 0;
+`;
+const NavItem = styled.li`
+  border-bottom: 1px solid ${props => props.theme.color('warmNeutral.400')};
+
+  // TODO: the vw units below are tightly coupled to the
+  // number of nav items and number of characters in them.
+  // This is a stop-gap ahead of nav design rework.
+
+  ${respondTo(
+    'headerMedium',
+    `
+    border-bottom: 0;
+    margin-right: calc(3vw - 20px);
+  `
+  )}
+
+  ${respondBetween(
+    'headerMedium',
+    'large',
+    `
+    font-size: 1.5vw;
+  `
+  )}
+
+  ${respondTo(
+    'xlarge',
+    `
+    margin-right: 1.4rem;
+  `
+  )}
+`;
+const NavLink = styled.a`
+  padding: 1.4rem 0.3rem;
+  display: inline-block;
+  text-decoration: none;
+  position: relative;
+  z-index: 1;
+  transition: color 400ms ease;
+  white-space: nowrap;
+
+  ${respondTo(
+    'headerMedium',
+    `
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+  `
+  )}
+
+  &:after {
+    content: '';
+    position: absolute;
+    bottom: 0.1rem;
+    height: 0.1rem;
+    left: 0;
+    width: 0;
+    background: ${props => props.theme.color('yellow')};
+    z-index: -1;
+    transition: width 200ms ease;
+
+    ${respondTo(
+      'headerMedium',
+      `
+      // bottom: 0.9rem;
+    `
+    )}
+  }
+
+  &:hover,
+  &:focus {
+    &:after {
+      width: 100%;
+
+      // Prevent iOS double-tap link issue
+      // https://css-tricks.com/annoying-mobile-double-tap-link-issue/
+      @media (pointer: coarse) {
+        width: 0;
+      }
+    }
+  }
+`;
+
+const SearchLayout: FunctionComponent = ({ children }) => {
+  const router = useRouter();
+  const currentSearchCategory =
+    router.pathname === '/search'
+      ? 'overview'
+      : router.pathname.slice(router.pathname.lastIndexOf('/') + 1);
+  return (
+    <CataloguePageLayout
+      title="Search Page"
+      description={'<TBC>'}
+      url={{ pathname: '/search', query: {} }}
+      openGraphType="website"
+      siteSection="collections"
+      jsonLd={{ '@type': 'WebPage' }}
+      hideNewsletterPromo={true}
+    >
+      <div className="container">
+        <input placeholder="search..." type="search" />
+        <NavBar aria-label="Search Categories">
+          <NavList>
+            <NavItem>
+              <Link scroll={false} passHref href={'/search'}>
+                <NavLink
+                  aria-current={
+                    currentSearchCategory === 'overview' ? 'page' : 'false'
+                  }
+                >
+                  Overview
+                </NavLink>
+              </Link>
+            </NavItem>
+            <NavItem>
+              <Link scroll={false} passHref href={'/search/exhibitions'}>
+                <NavLink
+                  aria-current={
+                    currentSearchCategory === 'exhibition' ? 'page' : 'false'
+                  }
+                >
+                  Exhibitions and Events
+                </NavLink>
+              </Link>
+            </NavItem>
+            <NavItem>
+              <Link scroll={false} passHref href={'/search/stories'}>
+                <NavLink
+                  aria-current={
+                    currentSearchCategory === 'stories' ? 'page' : 'false'
+                  }
+                >
+                  Stories
+                </NavLink>
+              </Link>
+            </NavItem>
+            <NavItem>
+              <Link scroll={false} passHref href={'/search/images'}>
+                <NavLink
+                  aria-current={
+                    currentSearchCategory === 'images' ? 'page' : 'false'
+                  }
+                >
+                  Images
+                </NavLink>
+              </Link>
+            </NavItem>
+            <NavItem>
+              <Link scroll={false} passHref href={'/search/collections'}>
+                <NavLink
+                  aria-current={
+                    currentSearchCategory === 'collections' ? 'page' : 'false'
+                  }
+                >
+                  Collections
+                </NavLink>
+              </Link>
+            </NavItem>
+          </NavList>
+        </NavBar>
+        <div>{children}</div>
+      </div>
+    </CataloguePageLayout>
+  );
+};
+
+export const getLayout = (page: ReactElement): JSX.Element => (
+  <SearchLayout>{page}</SearchLayout>
+);
+
+export default SearchLayout;

--- a/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
+++ b/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
@@ -7,7 +7,6 @@ import styled from 'styled-components';
 import { pageDescriptions } from '@weco/common/data/microcopy';
 
 const NavBar = styled.nav`
-  overflow: scroll;
   border-bottom: 1px solid ${props => props.theme.color('warmNeutral.400')};
   [aria-current='page'] {
     &:after {
@@ -20,14 +19,10 @@ const NavList = styled.ul`
   list-style: none;
   list-style-position: inside;
   padding-inline-start: 0;
+  margin-block-start: 0;
+  margin-block-end: 0;
 `;
 const NavItem = styled.li`
-  border-bottom: 1px solid ${props => props.theme.color('warmNeutral.400')};
-
-  // TODO: the vw units below are tightly coupled to the
-  // number of nav items and number of characters in them.
-  // This is a stop-gap ahead of nav design rework.
-
   ${respondTo(
     'headerMedium',
     `
@@ -72,7 +67,7 @@ const NavLink = styled.a`
     content: '';
     position: absolute;
     bottom: 0.1rem;
-    height: 0.1rem;
+    height: 0.2rem;
     left: 0;
     width: 0;
     background: ${props => props.theme.color('yellow')};

--- a/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
+++ b/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
@@ -1,4 +1,3 @@
-import { respondBetween, respondTo } from '@weco/common/views/themes/mixins';
 import CataloguePageLayout from 'components/CataloguePageLayout/CataloguePageLayout';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
@@ -23,28 +22,8 @@ const NavList = styled.ul`
   margin-block-end: 0;
 `;
 const NavItem = styled.li`
-  ${respondTo(
-    'headerMedium',
-    `
-    border-bottom: 0;
-    margin-right: calc(3vw - 20px);
-  `
-  )}
-
-  ${respondBetween(
-    'headerMedium',
-    'large',
-    `
-    font-size: 1.5vw;
-  `
-  )}
-
-  ${respondTo(
-    'xlarge',
-    `
-    margin-right: 1.4rem;
-  `
-  )}
+  font-size: 1rem;
+  font-size: 16px;
 `;
 const NavLink = styled.a`
   padding: 1.4rem 0.3rem;
@@ -52,16 +31,7 @@ const NavLink = styled.a`
   text-decoration: none;
   position: relative;
   z-index: 1;
-  transition: color 400ms ease;
   white-space: nowrap;
-
-  ${respondTo(
-    'headerMedium',
-    `
-    padding-top: 1rem;
-    padding-bottom: 1rem;
-  `
-  )}
 
   &:after {
     content: '';
@@ -72,14 +42,7 @@ const NavLink = styled.a`
     width: 0;
     background: ${props => props.theme.color('yellow')};
     z-index: -1;
-    transition: width 200ms ease;
-
-    ${respondTo(
-      'headerMedium',
-      `
-      // bottom: 0.9rem;
-    `
-    )}
+    transition: width ${props => props.theme.transitionProperties};
   }
 
   &:hover,
@@ -176,10 +139,12 @@ const SearchLayout: FunctionComponent = ({ children }) => {
     <CataloguePageLayout {...pageLayoutMetadata}>
       <div className="container">
         <input placeholder="search..." type="search" />
-        <NavBar aria-label="Search Categories">
+      </div>
+      <NavBar aria-label="Search Categories">
+        <div className="container">
           <NavList>
             <NavItem>
-              <Link scroll={false} passHref href={'/search'}>
+              <Link scroll={false} passHref href="/search">
                 <NavLink
                   aria-current={
                     currentSearchCategory === 'overview' ? 'page' : 'false'
@@ -190,7 +155,7 @@ const SearchLayout: FunctionComponent = ({ children }) => {
               </Link>
             </NavItem>
             <NavItem>
-              <Link scroll={false} passHref href={'/search/exhibitions'}>
+              <Link scroll={false} passHref href="/search/exhibitions">
                 <NavLink
                   aria-current={
                     currentSearchCategory === 'exhibitions' ? 'page' : 'false'
@@ -201,7 +166,7 @@ const SearchLayout: FunctionComponent = ({ children }) => {
               </Link>
             </NavItem>
             <NavItem>
-              <Link scroll={false} passHref href={'/search/events'}>
+              <Link scroll={false} passHref href="/search/events">
                 <NavLink
                   aria-current={
                     currentSearchCategory === 'events' ? 'page' : 'false'
@@ -212,7 +177,7 @@ const SearchLayout: FunctionComponent = ({ children }) => {
               </Link>
             </NavItem>
             <NavItem>
-              <Link scroll={false} passHref href={'/search/stories'}>
+              <Link scroll={false} passHref href="/search/stories">
                 <NavLink
                   aria-current={
                     currentSearchCategory === 'stories' ? 'page' : 'false'
@@ -223,7 +188,7 @@ const SearchLayout: FunctionComponent = ({ children }) => {
               </Link>
             </NavItem>
             <NavItem>
-              <Link scroll={false} passHref href={'/search/images'}>
+              <Link scroll={false} passHref href="/search/images">
                 <NavLink
                   aria-current={
                     currentSearchCategory === 'images' ? 'page' : 'false'
@@ -234,7 +199,7 @@ const SearchLayout: FunctionComponent = ({ children }) => {
               </Link>
             </NavItem>
             <NavItem>
-              <Link scroll={false} passHref href={'/search/collections'}>
+              <Link scroll={false} passHref href="/search/collections">
                 <NavLink
                   aria-current={
                     currentSearchCategory === 'collections' ? 'page' : 'false'
@@ -245,14 +210,15 @@ const SearchLayout: FunctionComponent = ({ children }) => {
               </Link>
             </NavItem>
           </NavList>
-        </NavBar>
-        <div>{children}</div>
-      </div>
+        </div>
+      </NavBar>
+
+      {children}
     </CataloguePageLayout>
   );
 };
 
-export const getLayout = (page: ReactElement): JSX.Element => (
+export const getSearchLayout = (page: ReactElement): JSX.Element => (
   <SearchLayout>{page}</SearchLayout>
 );
 

--- a/catalogue/webapp/pages/search/collections.tsx
+++ b/catalogue/webapp/pages/search/collections.tsx
@@ -4,7 +4,7 @@ import { AppErrorProps } from '@weco/common/services/app';
 import { getServerData } from '@weco/common/server-data';
 import Space from '@weco/common/views/components/styled/Space';
 import { NextPageWithLayout } from '@weco/common/views/pages/_app';
-import { getLayout } from 'components/SearchPageLayout/SearchPageLayout';
+import { getSearchLayout } from 'components/SearchPageLayout/SearchPageLayout';
 
 export const CollectionsSearchPage: NextPageWithLayout = () => {
   return (
@@ -17,7 +17,7 @@ export const CollectionsSearchPage: NextPageWithLayout = () => {
   );
 };
 
-CollectionsSearchPage.getLayout = getLayout;
+CollectionsSearchPage.getLayout = getSearchLayout;
 
 export const getServerSideProps: GetServerSideProps<
   Record<string, unknown> | AppErrorProps

--- a/catalogue/webapp/pages/search/collections.tsx
+++ b/catalogue/webapp/pages/search/collections.tsx
@@ -1,0 +1,44 @@
+import { GetServerSideProps } from 'next';
+import { removeUndefinedProps } from '@weco/common/utils/json';
+import { AppErrorProps } from '@weco/common/services/app';
+import { getServerData } from '@weco/common/server-data';
+import Space from '@weco/common/views/components/styled/Space';
+import { NextPageWithLayout } from '@weco/common/views/pages/_app';
+import { getLayout } from 'components/SearchPageLayout/SearchPageLayout';
+
+export const SearchPage: NextPageWithLayout = () => {
+  return (
+    <>
+      <h1 className="visually-hidden">Search Page</h1>
+      <Space v={{ size: 'l', properties: ['margin-top', 'margin-bottom'] }}>
+        <div
+          role="tabpanel"
+          id="tabpanel-collectionsTab"
+          aria-labelledby="tab-collectionsTab"
+        >
+          Collections content
+        </div>
+      </Space>
+    </>
+  );
+};
+
+SearchPage.getLayout = getLayout;
+
+export const getServerSideProps: GetServerSideProps<
+  Record<string, unknown> | AppErrorProps
+> = async context => {
+  const serverData = await getServerData(context);
+
+  if (!serverData.toggles.searchPage) {
+    return { notFound: true };
+  }
+
+  return {
+    props: removeUndefinedProps({
+      serverData,
+    }),
+  };
+};
+
+export default SearchPage;

--- a/catalogue/webapp/pages/search/events.tsx
+++ b/catalogue/webapp/pages/search/events.tsx
@@ -4,7 +4,7 @@ import { AppErrorProps } from '@weco/common/services/app';
 import { getServerData } from '@weco/common/server-data';
 import Space from '@weco/common/views/components/styled/Space';
 import { NextPageWithLayout } from '@weco/common/views/pages/_app';
-import { getLayout } from 'components/SearchPageLayout/SearchPageLayout';
+import { getSearchLayout } from 'components/SearchPageLayout/SearchPageLayout';
 
 export const SearchPage: NextPageWithLayout = () => {
   return (
@@ -17,7 +17,7 @@ export const SearchPage: NextPageWithLayout = () => {
   );
 };
 
-SearchPage.getLayout = getLayout;
+SearchPage.getLayout = getSearchLayout;
 
 export const getServerSideProps: GetServerSideProps<
   Record<string, unknown> | AppErrorProps

--- a/catalogue/webapp/pages/search/events.tsx
+++ b/catalogue/webapp/pages/search/events.tsx
@@ -6,18 +6,18 @@ import Space from '@weco/common/views/components/styled/Space';
 import { NextPageWithLayout } from '@weco/common/views/pages/_app';
 import { getLayout } from 'components/SearchPageLayout/SearchPageLayout';
 
-export const CollectionsSearchPage: NextPageWithLayout = () => {
+export const SearchPage: NextPageWithLayout = () => {
   return (
     <>
-      <h1 className="visually-hidden">Collections Search Page</h1>
+      <h1 className="visually-hidden">Events Search Page</h1>
       <Space v={{ size: 'l', properties: ['margin-top', 'margin-bottom'] }}>
-        <div>Collections content</div>
+        <div>Events content</div>
       </Space>
     </>
   );
 };
 
-CollectionsSearchPage.getLayout = getLayout;
+SearchPage.getLayout = getLayout;
 
 export const getServerSideProps: GetServerSideProps<
   Record<string, unknown> | AppErrorProps
@@ -35,4 +35,4 @@ export const getServerSideProps: GetServerSideProps<
   };
 };
 
-export default CollectionsSearchPage;
+export default SearchPage;

--- a/catalogue/webapp/pages/search/exhibitions.tsx
+++ b/catalogue/webapp/pages/search/exhibitions.tsx
@@ -1,0 +1,44 @@
+import { GetServerSideProps } from 'next';
+import { removeUndefinedProps } from '@weco/common/utils/json';
+import { AppErrorProps } from '@weco/common/services/app';
+import { getServerData } from '@weco/common/server-data';
+import Space from '@weco/common/views/components/styled/Space';
+import { NextPageWithLayout } from '@weco/common/views/pages/_app';
+import { getLayout } from 'components/SearchPageLayout/SearchPageLayout';
+
+export const SearchPage: NextPageWithLayout = () => {
+  return (
+    <>
+      <h1 className="visually-hidden">Search Page</h1>
+      <Space v={{ size: 'l', properties: ['margin-top', 'margin-bottom'] }}>
+        <div
+          role="tabpanel"
+          id="tabpanel-exhibitionsTab"
+          aria-labelledby="tab-exhibitionsTab"
+        >
+          Exhibitions and events content
+        </div>
+      </Space>
+    </>
+  );
+};
+
+SearchPage.getLayout = getLayout;
+
+export const getServerSideProps: GetServerSideProps<
+  Record<string, unknown> | AppErrorProps
+> = async context => {
+  const serverData = await getServerData(context);
+
+  if (!serverData.toggles.searchPage) {
+    return { notFound: true };
+  }
+
+  return {
+    props: removeUndefinedProps({
+      serverData,
+    }),
+  };
+};
+
+export default SearchPage;

--- a/catalogue/webapp/pages/search/exhibitions.tsx
+++ b/catalogue/webapp/pages/search/exhibitions.tsx
@@ -9,15 +9,9 @@ import { getLayout } from 'components/SearchPageLayout/SearchPageLayout';
 export const SearchPage: NextPageWithLayout = () => {
   return (
     <>
-      <h1 className="visually-hidden">Search Page</h1>
+      <h1 className="visually-hidden">Exhibitions Search Page</h1>
       <Space v={{ size: 'l', properties: ['margin-top', 'margin-bottom'] }}>
-        <div
-          role="tabpanel"
-          id="tabpanel-exhibitionsTab"
-          aria-labelledby="tab-exhibitionsTab"
-        >
-          Exhibitions and events content
-        </div>
+        <div>Exhibitions and events content</div>
       </Space>
     </>
   );

--- a/catalogue/webapp/pages/search/exhibitions.tsx
+++ b/catalogue/webapp/pages/search/exhibitions.tsx
@@ -4,7 +4,7 @@ import { AppErrorProps } from '@weco/common/services/app';
 import { getServerData } from '@weco/common/server-data';
 import Space from '@weco/common/views/components/styled/Space';
 import { NextPageWithLayout } from '@weco/common/views/pages/_app';
-import { getLayout } from 'components/SearchPageLayout/SearchPageLayout';
+import { getSearchLayout } from 'components/SearchPageLayout/SearchPageLayout';
 
 export const SearchPage: NextPageWithLayout = () => {
   return (
@@ -17,7 +17,7 @@ export const SearchPage: NextPageWithLayout = () => {
   );
 };
 
-SearchPage.getLayout = getLayout;
+SearchPage.getLayout = getSearchLayout;
 
 export const getServerSideProps: GetServerSideProps<
   Record<string, unknown> | AppErrorProps

--- a/catalogue/webapp/pages/search/images.tsx
+++ b/catalogue/webapp/pages/search/images.tsx
@@ -24,10 +24,12 @@ import {
 import { imagesFilters } from '@weco/common/services/catalogue/filters';
 import { getServerData } from '@weco/common/server-data';
 import { pageDescriptions } from '@weco/common/data/microcopy';
+import { getLayout } from 'components/SearchPageLayout/SearchPageLayout';
 
 // Types
 import { CatalogueResultsList, Image } from '@weco/common/model/catalogue';
 import SearchHeader from 'views/search/searchHeader';
+import { NextPageWithLayout } from '@weco/common/views/pages/_app';
 
 type Props = {
   images?: CatalogueResultsList<Image>;
@@ -41,7 +43,7 @@ const Wrapper = styled(Space).attrs({
   background-color: ${props => props.theme.color('black')};
 `;
 
-const Images: NextPage<Props> = ({
+const Images: NextPageWithLayout<Props> = ({
   images,
   imagesRouteProps,
 }): ReactElement<Props> => {
@@ -160,6 +162,8 @@ const Images: NextPage<Props> = ({
     </>
   );
 };
+
+Images.getLayout = getLayout;
 
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {

--- a/catalogue/webapp/pages/search/images.tsx
+++ b/catalogue/webapp/pages/search/images.tsx
@@ -1,11 +1,10 @@
-import { useEffect, ReactElement, useContext, useState } from 'react';
-import { GetServerSideProps, NextPage } from 'next';
+import { useEffect, ReactElement, useContext } from 'react';
+import { GetServerSideProps } from 'next';
 import styled from 'styled-components';
 import Head from 'next/head';
 
 // Components
 import ImageEndpointSearchResults from '@weco/catalogue/components/ImageEndpointSearchResults/ImageEndpointSearchResults';
-import CataloguePageLayout from '@weco/catalogue/components/CataloguePageLayout/CataloguePageLayout';
 import Space from '@weco/common/views/components/styled/Space';
 import SearchNoResults from '@weco/catalogue/components/SearchNoResults/SearchNoResults';
 import SearchContext from '@weco/common/views/components/SearchContext/SearchContext';
@@ -21,14 +20,11 @@ import {
   ImagesProps,
   toLink,
 } from '@weco/common/views/components/ImagesLink/ImagesLink';
-import { imagesFilters } from '@weco/common/services/catalogue/filters';
 import { getServerData } from '@weco/common/server-data';
-import { pageDescriptions } from '@weco/common/data/microcopy';
 import { getLayout } from 'components/SearchPageLayout/SearchPageLayout';
 
 // Types
 import { CatalogueResultsList, Image } from '@weco/common/model/catalogue';
-import SearchHeader from 'views/search/searchHeader';
 import { NextPageWithLayout } from '@weco/common/views/pages/_app';
 
 type Props = {
@@ -43,34 +39,11 @@ const Wrapper = styled(Space).attrs({
   background-color: ${props => props.theme.color('black')};
 `;
 
-const Images: NextPageWithLayout<Props> = ({
+const ImagesSearchPage: NextPageWithLayout<Props> = ({
   images,
   imagesRouteProps,
 }): ReactElement<Props> => {
-  // const [isLoading, setIsLoading] = useState(false); // For pagination
   const { query, page, color: colorFilter } = imagesRouteProps;
-  const [selectedTab, setSelectedTab] = useState('images');
-
-  // For pagination
-  // useEffect(() => {
-  //   function routeChangeStart() {
-  //     setIsLoading(true);
-  //   }
-  //   function routeChangeComplete() {
-  //     setIsLoading(false);
-  //   }
-  //   Router.events.on('routeChangeStart', routeChangeStart);
-  //   Router.events.on('routeChangeComplete', routeChangeComplete);
-
-  //   return () => {
-  //     Router.events.off('routeChangeStart', routeChangeStart);
-  //     Router.events.off('routeChangeComplete', routeChangeComplete);
-  //   };
-  // }, []);
-
-  const filters = images
-    ? imagesFilters({ images, props: imagesRouteProps })
-    : [];
 
   const { setLink } = useContext(SearchContext);
   useEffect(() => {
@@ -100,70 +73,42 @@ const Images: NextPageWithLayout<Props> = ({
         )}
       </Head>
       {/* TODO review if this needs updating */}
-      <CataloguePageLayout
-        title={`${query ? `${query} | ` : ''}Image search`}
-        description={pageDescriptions.images}
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        url={toLink({ ...imagesRouteProps, source: 'canonical_link' }).as}
-        openGraphType="website"
-        jsonLd={{ '@type': 'WebPage' }}
-        siteSection="collections"
-        image={undefined}
-        apiToolbarLinks={
-          images
-            ? [
-                {
-                  id: 'catalogue-api-query',
-                  label: 'Catalogue API query',
-                  link: images._requestUrl,
-                },
-              ]
-            : []
-        }
-        hideNewsletterPromo={true}
-      >
-        <div className="container">
-          <SearchHeader
-            selectedTab={selectedTab}
-            setSelectedTab={setSelectedTab}
-          />
-          <Space
-            v={{ size: 'l', properties: ['padding-top', 'padding-bottom'] }}
-          >
-            <h2 style={{ marginBottom: 0 }}>Filters</h2>
-          </Space>
-        </div>
 
-        <Wrapper>
-          {images?.results && images.results.length > 0 && (
-            <div className="container">
-              <Space
-                v={{
-                  size: 'l',
-                  properties: ['padding-top', 'padding-bottom'],
-                }}
-                style={{ color: 'white' }}
-              >
-                <h2 style={{ marginBottom: 0 }}>Sort & Pagination</h2>
-              </Space>
-              <ImageEndpointSearchResults images={images} />
-            </div>
-          )}
-          {images?.results.length === 0 && (
-            <SearchNoResults
-              query={query}
-              hasFilters={!!colorFilter}
-              color="white"
-            />
-          )}
-        </Wrapper>
-      </CataloguePageLayout>
+      <h1 className="visually-hidden">Images Search Page</h1>
+      <div className="container">
+        <Space v={{ size: 'l', properties: ['padding-top', 'padding-bottom'] }}>
+          <h2 style={{ marginBottom: 0 }}>Filters</h2>
+        </Space>
+      </div>
+
+      <Wrapper>
+        {images?.results && images.results.length > 0 && (
+          <div className="container">
+            <Space
+              v={{
+                size: 'l',
+                properties: ['padding-top', 'padding-bottom'],
+              }}
+              style={{ color: 'white' }}
+            >
+              <h2 style={{ marginBottom: 0 }}>Sort & Pagination</h2>
+            </Space>
+            <ImageEndpointSearchResults images={images} />
+          </div>
+        )}
+        {images?.results.length === 0 && (
+          <SearchNoResults
+            query={query}
+            hasFilters={!!colorFilter}
+            color="white"
+          />
+        )}
+      </Wrapper>
     </>
   );
 };
 
-Images.getLayout = getLayout;
+ImagesSearchPage.getLayout = getLayout;
 
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
@@ -206,4 +151,4 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     };
   };
 
-export default Images;
+export default ImagesSearchPage;

--- a/catalogue/webapp/pages/search/images.tsx
+++ b/catalogue/webapp/pages/search/images.tsx
@@ -21,7 +21,7 @@ import {
   toLink,
 } from '@weco/common/views/components/ImagesLink/ImagesLink';
 import { getServerData } from '@weco/common/server-data';
-import { getLayout } from 'components/SearchPageLayout/SearchPageLayout';
+import { getSearchLayout } from 'components/SearchPageLayout/SearchPageLayout';
 
 // Types
 import { CatalogueResultsList, Image } from '@weco/common/model/catalogue';
@@ -108,7 +108,7 @@ const ImagesSearchPage: NextPageWithLayout<Props> = ({
   );
 };
 
-ImagesSearchPage.getLayout = getLayout;
+ImagesSearchPage.getLayout = getSearchLayout;
 
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {

--- a/catalogue/webapp/pages/search/index.tsx
+++ b/catalogue/webapp/pages/search/index.tsx
@@ -1,85 +1,23 @@
-import { useState } from 'react';
-import { GetServerSideProps, NextPage } from 'next';
-
-import CataloguePageLayout from 'components/CataloguePageLayout/CataloguePageLayout';
-import Space from '@weco/common/views/components/styled/Space';
-
+import { GetServerSideProps } from 'next';
 import { removeUndefinedProps } from '@weco/common/utils/json';
 import { AppErrorProps } from '@weco/common/services/app';
 import { getServerData } from '@weco/common/server-data';
-import SearchHeader from '@weco/catalogue/views/search/searchHeader';
+import Space from '@weco/common/views/components/styled/Space';
+import { NextPageWithLayout } from '@weco/common/views/pages/_app';
+import { getLayout } from 'components/SearchPageLayout/SearchPageLayout';
 
-export const SearchPage: NextPage = () => {
-  const [selectedTab, setSelectedTab] = useState('overview');
-
+export const SearchPage: NextPageWithLayout = () => {
   return (
-    // TODO review meta info here
-    <CataloguePageLayout
-      title="Search Page"
-      description={'<TBC>'}
-      url={{ pathname: '/search', query: {} }}
-      openGraphType="website"
-      siteSection="collections"
-      jsonLd={{ '@type': 'WebPage' }}
-      hideNewsletterPromo={true}
-    >
-      <div className="container">
-        <h1 className="visually-hidden">Search Page</h1>
-        <SearchHeader
-          selectedTab={selectedTab}
-          setSelectedTab={setSelectedTab}
-        />
-        <Space v={{ size: 'l', properties: ['margin-top', 'margin-bottom'] }}>
-          {selectedTab === 'overview' && (
-            <div
-              role="tabpanel"
-              id="tabpanel-overviewTab"
-              aria-labelledby="tab-overviewTab"
-            >
-              Overview content
-            </div>
-          )}
-          {selectedTab === 'exhibitions' && (
-            <div
-              role="tabpanel"
-              id="tabpanel-exhibitionsTab"
-              aria-labelledby="tab-exhibitionsTab"
-            >
-              Exhibitions and events content
-            </div>
-          )}
-          {selectedTab === 'stories' && (
-            <div
-              role="tabpanel"
-              id="tabpanel-storiesTab"
-              aria-labelledby="tab-storiesTab"
-            >
-              Stories content
-            </div>
-          )}
-          {selectedTab === 'images' && (
-            <div
-              role="tabpanel"
-              id="tabpanel-imagesTab"
-              aria-labelledby="tab-imagesTab"
-            >
-              Images content
-            </div>
-          )}
-          {selectedTab === 'collections' && (
-            <div
-              role="tabpanel"
-              id="tabpanel-collectionsTab"
-              aria-labelledby="tab-collectionsTab"
-            >
-              Collections content
-            </div>
-          )}
-        </Space>
-      </div>
-    </CataloguePageLayout>
+    <>
+      <h1 className="visually-hidden">Search Page Overview</h1>
+      <Space v={{ size: 'l', properties: ['margin-top', 'margin-bottom'] }}>
+        <div>Collections content</div>
+      </Space>
+    </>
   );
 };
+
+SearchPage.getLayout = getLayout;
 
 export const getServerSideProps: GetServerSideProps<
   Record<string, unknown> | AppErrorProps

--- a/catalogue/webapp/pages/search/index.tsx
+++ b/catalogue/webapp/pages/search/index.tsx
@@ -4,7 +4,7 @@ import { AppErrorProps } from '@weco/common/services/app';
 import { getServerData } from '@weco/common/server-data';
 import Space from '@weco/common/views/components/styled/Space';
 import { NextPageWithLayout } from '@weco/common/views/pages/_app';
-import { getLayout } from 'components/SearchPageLayout/SearchPageLayout';
+import { getSearchLayout } from 'components/SearchPageLayout/SearchPageLayout';
 
 export const SearchPage: NextPageWithLayout = () => {
   return (
@@ -17,7 +17,7 @@ export const SearchPage: NextPageWithLayout = () => {
   );
 };
 
-SearchPage.getLayout = getLayout;
+SearchPage.getLayout = getSearchLayout;
 
 export const getServerSideProps: GetServerSideProps<
   Record<string, unknown> | AppErrorProps

--- a/catalogue/webapp/pages/search/stories.tsx
+++ b/catalogue/webapp/pages/search/stories.tsx
@@ -9,15 +9,9 @@ import { getLayout } from 'components/SearchPageLayout/SearchPageLayout';
 export const SearchPage: NextPageWithLayout = () => {
   return (
     <>
-      <h1 className="visually-hidden">Search Page</h1>
+      <h1 className="visually-hidden">Stories Search Page</h1>
       <Space v={{ size: 'l', properties: ['margin-top', 'margin-bottom'] }}>
-        <div
-          role="tabpanel"
-          id="tabpanel-storiesTab"
-          aria-labelledby="tab-storiesTab"
-        >
-          Stories content
-        </div>
+        <div>Stories content</div>
       </Space>
     </>
   );

--- a/catalogue/webapp/pages/search/stories.tsx
+++ b/catalogue/webapp/pages/search/stories.tsx
@@ -4,7 +4,7 @@ import { AppErrorProps } from '@weco/common/services/app';
 import { getServerData } from '@weco/common/server-data';
 import Space from '@weco/common/views/components/styled/Space';
 import { NextPageWithLayout } from '@weco/common/views/pages/_app';
-import { getLayout } from 'components/SearchPageLayout/SearchPageLayout';
+import { getSearchLayout } from 'components/SearchPageLayout/SearchPageLayout';
 
 export const SearchPage: NextPageWithLayout = () => {
   return (
@@ -17,7 +17,7 @@ export const SearchPage: NextPageWithLayout = () => {
   );
 };
 
-SearchPage.getLayout = getLayout;
+SearchPage.getLayout = getSearchLayout;
 
 export const getServerSideProps: GetServerSideProps<
   Record<string, unknown> | AppErrorProps

--- a/catalogue/webapp/pages/search/stories.tsx
+++ b/catalogue/webapp/pages/search/stories.tsx
@@ -1,0 +1,44 @@
+import { GetServerSideProps } from 'next';
+import { removeUndefinedProps } from '@weco/common/utils/json';
+import { AppErrorProps } from '@weco/common/services/app';
+import { getServerData } from '@weco/common/server-data';
+import Space from '@weco/common/views/components/styled/Space';
+import { NextPageWithLayout } from '@weco/common/views/pages/_app';
+import { getLayout } from 'components/SearchPageLayout/SearchPageLayout';
+
+export const SearchPage: NextPageWithLayout = () => {
+  return (
+    <>
+      <h1 className="visually-hidden">Search Page</h1>
+      <Space v={{ size: 'l', properties: ['margin-top', 'margin-bottom'] }}>
+        <div
+          role="tabpanel"
+          id="tabpanel-storiesTab"
+          aria-labelledby="tab-storiesTab"
+        >
+          Stories content
+        </div>
+      </Space>
+    </>
+  );
+};
+
+SearchPage.getLayout = getLayout;
+
+export const getServerSideProps: GetServerSideProps<
+  Record<string, unknown> | AppErrorProps
+> = async context => {
+  const serverData = await getServerData(context);
+
+  if (!serverData.toggles.searchPage) {
+    return { notFound: true };
+  }
+
+  return {
+    props: removeUndefinedProps({
+      serverData,
+    }),
+  };
+};
+
+export default SearchPage;


### PR DESCRIPTION
closes issue #8689 
# What has been done
- search page structures added
- utilised the `getLayout` pattern to have a reusable layout, taking the responsibility away from the page, in regards to rendering content that is not relevant to it
- rebased and merged work to have a functioning `/search/images` page