### PR TITLE
Replace FC with FunctionComponent everywhere

### DIFF
--- a/catalogue/webapp/components/AudioList/AudioList.tsx
+++ b/catalogue/webapp/components/AudioList/AudioList.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import Space from '@weco/common/views/components/styled/Space';
 import AudioPlayer from '@weco/common/views/components/AudioPlayer/AudioPlayer';
 import DownloadLink from '@weco/common/views/components/DownloadLink/DownloadLink';
@@ -16,7 +16,7 @@ type Props = {
   workTitle: string;
 };
 
-const AudioList: FC<Props> = ({
+const AudioList: FunctionComponent<Props> = ({
   items,
   // thumbnail, TODO: add thumbnail once placeholders have been removed from manifests
   transcript,

--- a/catalogue/webapp/components/CalendarSelect/CalendarSelect.tsx
+++ b/catalogue/webapp/components/CalendarSelect/CalendarSelect.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import Select, {
   SelectOption,
 } from '@weco/common/views/components/Select/Select';
@@ -44,7 +44,7 @@ function getAvailableDates(
     .filter(isTruthy);
 }
 
-const Calendar: FC<Props> = ({
+const Calendar: FunctionComponent<Props> = ({
   min,
   max,
   excludedDates,

--- a/catalogue/webapp/components/IIIFImage/IIIFImage.tsx
+++ b/catalogue/webapp/components/IIIFImage/IIIFImage.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import Image, { ImageLoaderProps } from 'next/image';
 import styled from 'styled-components';
 
@@ -50,7 +50,7 @@ export type Props = {
   background?: string;
 };
 
-const IIIFImage: FC<Props> = ({
+const IIIFImage: FunctionComponent<Props> = ({
   image,
   sizes,
   onLoadingComplete,

--- a/catalogue/webapp/components/IIIFViewer/Padlock.tsx
+++ b/catalogue/webapp/components/IIIFViewer/Padlock.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 // TODO names and colours from theme
 const StyledPadlock = styled.div`
@@ -72,7 +72,7 @@ const StyledPadlock = styled.div`
   }
 `;
 
-const Padlock: FC = () => (
+const Padlock: FunctionComponent = () => (
   <StyledPadlock>
     <div></div>
   </StyledPadlock>

--- a/catalogue/webapp/components/ImageCard/ImageCard.tsx
+++ b/catalogue/webapp/components/ImageCard/ImageCard.tsx
@@ -1,4 +1,4 @@
-import { FC, SyntheticEvent, useContext } from 'react';
+import { FunctionComponent, SyntheticEvent, useContext } from 'react';
 import NextLink from 'next/link';
 import styled from 'styled-components';
 
@@ -29,7 +29,7 @@ const StyledLink = styled.a<{
   height: ${props => props.height}px;
 `;
 
-const ImageCard: FC<Props> = ({
+const ImageCard: FunctionComponent<Props> = ({
   id,
   workId,
   image,

--- a/catalogue/webapp/components/ItemRequestModal/ConfirmedDialog.tsx
+++ b/catalogue/webapp/components/ItemRequestModal/ConfirmedDialog.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import { CTAs, CurrentRequests, Header } from './common';
 import { allowedRequests } from '@weco/common/values/requests';
 import ButtonSolidLink from '@weco/common/views/components/ButtonSolidLink/ButtonSolidLink';
@@ -7,7 +7,9 @@ type ConfirmedDialogProps = {
   currentHoldNumber?: number;
 };
 
-const ConfirmedDialog: FC<ConfirmedDialogProps> = ({ currentHoldNumber }) => {
+const ConfirmedDialog: FunctionComponent<ConfirmedDialogProps> = ({
+  currentHoldNumber,
+}) => {
   return (
     <>
       <Header>

--- a/catalogue/webapp/components/ItemRequestModal/ErrorDialog.tsx
+++ b/catalogue/webapp/components/ItemRequestModal/ErrorDialog.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import { defaultRequestErrorMessage } from '@weco/common/data/microcopy';
 import ButtonSolid from '@weco/common/views/components/ButtonSolid/ButtonSolid';
 import { CTAs, Header } from './common';
@@ -9,7 +9,10 @@ type ErrorDialogProps = {
   errorMessage: string | undefined;
 };
 
-const ErrorDialog: FC<ErrorDialogProps> = ({ setIsActive, errorMessage }) => (
+const ErrorDialog: FunctionComponent<ErrorDialogProps> = ({
+  setIsActive,
+  errorMessage,
+}) => (
   <>
     <Header>
       <span className="h2">Request failed</span>

--- a/catalogue/webapp/components/ItemRequestModal/ItemRequestModal.tsx
+++ b/catalogue/webapp/components/ItemRequestModal/ItemRequestModal.tsx
@@ -1,4 +1,9 @@
-import { FC, useState, useEffect, MutableRefObject } from 'react';
+import {
+  FunctionComponent,
+  useState,
+  useEffect,
+  MutableRefObject,
+} from 'react';
 import Modal from '@weco/common/views/components/Modal/Modal';
 import {
   PhysicalItem,
@@ -23,7 +28,7 @@ type Props = {
 
 type RequestingState = 'initial' | 'requesting' | 'confirmed' | 'error';
 
-const ItemRequestModal: FC<Props> = ({
+const ItemRequestModal: FunctionComponent<Props> = ({
   item,
   work,
   setIsActive,

--- a/catalogue/webapp/components/ItemRequestModal/RequestDialog.tsx
+++ b/catalogue/webapp/components/ItemRequestModal/RequestDialog.tsx
@@ -1,4 +1,4 @@
-import { FC, FormEvent, useState } from 'react';
+import { FunctionComponent, FormEvent, useState } from 'react';
 import { useAvailableDates } from './useAvailableDates';
 import { isRequestableDate } from '../../utils/dates';
 import { trackEvent } from '@weco/common/utils/ga';
@@ -56,7 +56,7 @@ type RequestDialogProps = {
   currentHoldNumber?: number;
 };
 
-const RequestDialog: FC<RequestDialogProps> = ({
+const RequestDialog: FunctionComponent<RequestDialogProps> = ({
   work,
   item,
   confirmRequest,

--- a/catalogue/webapp/components/ItemRequestModal/common.tsx
+++ b/catalogue/webapp/components/ItemRequestModal/common.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import Space from '@weco/common/views/components/styled/Space';
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 
 export const CTAs = styled(Space).attrs({
   v: { size: 'l', properties: ['margin-top'] },
@@ -12,7 +12,7 @@ const CurrentRequestCount = styled(Space).attrs({
   border-left: 5px solid ${props => props.theme.color('yellow')};
 `;
 
-export const CurrentRequests: FC<{
+export const CurrentRequests: FunctionComponent<{
   allowedHoldRequests: number;
   currentHoldRequests?: number;
 }> = ({ allowedHoldRequests, currentHoldRequests }) =>

--- a/catalogue/webapp/components/LibraryMembersBar/LibraryMembersBar.tsx
+++ b/catalogue/webapp/components/LibraryMembersBar/LibraryMembersBar.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 import Space from '@weco/common/views/components/styled/Space';
 import Icon from '@weco/common/views/components/Icon/Icon';
@@ -24,7 +24,7 @@ const StyledComponent = styled(Space).attrs({
   }
 `;
 
-const SignInLink: FC = () => {
+const SignInLink: FunctionComponent = () => {
   const loginURL = useLoginURLWithReturnToCurrent();
   return (
     <>
@@ -54,7 +54,7 @@ const SignInLink: FC = () => {
 type ReloadProps = {
   reload: () => void;
 };
-const Reload: FC<ReloadProps> = ({ reload }) => {
+const Reload: FunctionComponent<ReloadProps> = ({ reload }) => {
   return (
     <>
       <span className={font('intb', 5)}>
@@ -78,7 +78,7 @@ const Reload: FC<ReloadProps> = ({ reload }) => {
   );
 };
 
-const LibraryMembersBar: FC = () => {
+const LibraryMembersBar: FunctionComponent = () => {
   const { state, reload } = useUser();
   const { disableRequesting } = useToggles();
   if (disableRequesting) {

--- a/catalogue/webapp/components/License/License.tsx
+++ b/catalogue/webapp/components/License/License.tsx
@@ -1,10 +1,10 @@
 import { LicenseData } from '@weco/common/utils/licenses';
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 type Props = {
   license: LicenseData;
 };
 
-const License: FC<Props> = ({ license }: Props) => {
+const License: FunctionComponent<Props> = ({ license }: Props) => {
   return (
     <>
       {license.description && `${license.description} `}

--- a/catalogue/webapp/components/RequestingDayPicker/RequestingDayPicker.tsx
+++ b/catalogue/webapp/components/RequestingDayPicker/RequestingDayPicker.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import { DayNumber } from '@weco/common/model/opening-hours';
 import CalendarSelect from '../CalendarSelect/CalendarSelect';
 
@@ -11,7 +11,7 @@ type Props = {
   setPickUpDate: (date: string) => void;
 };
 
-const RequestingDayPicker: FC<Props> = ({
+const RequestingDayPicker: FunctionComponent<Props> = ({
   startDate,
   endDate,
   exceptionalClosedDates,

--- a/catalogue/webapp/components/WorksSearchResult/WorksSearchResult.tsx
+++ b/catalogue/webapp/components/WorksSearchResult/WorksSearchResult.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 
 // Types
 import { Work } from '@weco/common/model/catalogue';
@@ -39,7 +39,10 @@ function isPdfThumbnail(thumbnail): boolean {
   return Boolean(thumbnail.url.match('.pdf/full'));
 }
 
-const WorkSearchResultV2: FC<Props> = ({ work, resultPosition }: Props) => {
+const WorkSearchResultV2: FunctionComponent<Props> = ({
+  work,
+  resultPosition,
+}: Props) => {
   const productionDates = getProductionDates(work);
   const archiveLabels = getArchiveLabels(work);
   const cardLabels = getCardLabels(work);

--- a/catalogue/webapp/components/WorksSearchResults/WorksSearchResults.tsx
+++ b/catalogue/webapp/components/WorksSearchResults/WorksSearchResults.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 import WorksSearchResult from '../WorksSearchResult/WorksSearchResult';
 import { CatalogueResultsList, Work } from '@weco/common/model/catalogue';
@@ -29,7 +29,7 @@ const SearchResultListItem = styled.li`
   }
 `;
 
-const WorkSearchResults: FC<Props> = ({ works }: Props) => {
+const WorkSearchResults: FunctionComponent<Props> = ({ works }: Props) => {
   return (
     <SearchResultUnorderedList>
       {works.results.map((result, i) => (

--- a/catalogue/webapp/views/search/searchHeader.tsx
+++ b/catalogue/webapp/views/search/searchHeader.tsx
@@ -1,4 +1,4 @@
-import { FC, Dispatch, SetStateAction } from 'react';
+import { FunctionComponent, Dispatch, SetStateAction } from 'react';
 import TabNav from '@weco/common/views/components/TabNav/TabNav';
 import Space from '@weco/common/views/components/styled/Space';
 
@@ -8,7 +8,10 @@ type Props = {
 };
 
 // TODO delete this once we figure out the routing strategy, might not be needed
-const SearchHeader: FC<Props> = ({ selectedTab, setSelectedTab }: Props) => {
+const SearchHeader: FunctionComponent<Props> = ({
+  selectedTab,
+  setSelectedTab,
+}: Props) => {
   return (
     <>
       <Space v={{ size: 'l', properties: ['margin-top', 'margin-bottom'] }}>

--- a/common/data/errors.tsx
+++ b/common/data/errors.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import { prismicPageIds } from './hardcoded-ids';
 import Layout8 from '../views/components/Layout8/Layout8';
 import Space from '../views/components/styled/Space';
@@ -8,7 +8,7 @@ export const errorMessages = {
   500: 'Internal Server Error',
 };
 
-export const DefaultErrorText: FC = () => (
+export const DefaultErrorText: FunctionComponent = () => (
   <Layout8>
     <Space
       className="body-text"
@@ -34,7 +34,7 @@ export const DefaultErrorText: FC = () => (
   </Layout8>
 );
 
-export const NotFoundErrorText: FC = () => (
+export const NotFoundErrorText: FunctionComponent = () => (
   <Layout8>
     <Space
       className="body-text"

--- a/common/icons/wellcome_collection_black.tsx
+++ b/common/icons/wellcome_collection_black.tsx
@@ -1,6 +1,6 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 
-const WellcomeCollectionBlack: FC = () => (
+const WellcomeCollectionBlack: FunctionComponent = () => (
   <svg
     width="128"
     height="42"

--- a/common/services/app/google-analytics.tsx
+++ b/common/services/app/google-analytics.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect } from 'react';
+import { FunctionComponent, useEffect } from 'react';
 import ReactGA from 'react-ga';
 import { Toggles } from '@weco/toggles';
 import Script from 'next/script';
@@ -18,7 +18,7 @@ const gaDimensionKeys = {
 
 // Don't use the next/script `Script` component for these as in
 // Next.js v11 it does not work when inside a `Head` component
-export const GoogleAnalyticsV4: FC = () => (
+export const GoogleAnalyticsV4: FunctionComponent = () => (
   <script
     id="google-analytics-v4"
     src={`https://www.googletagmanager.com/gtag/js?id=${GOOGLE_ANALYTICS_V4_ID}`}
@@ -26,7 +26,7 @@ export const GoogleAnalyticsV4: FC = () => (
   />
 );
 
-export const GoogleAnalyticsUA: FC = () => (
+export const GoogleAnalyticsUA: FunctionComponent = () => (
   <script
     id="google-analytics-ua"
     async={true}

--- a/common/views/components/ApiToolbar/ApiToolbar.tsx
+++ b/common/views/components/ApiToolbar/ApiToolbar.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState } from 'react';
+import { FunctionComponent, useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import styled from 'styled-components';
 import { ParsedUrlQuery } from 'querystring';
@@ -244,7 +244,7 @@ type Props = {
   extraLinks?: ApiToolbarLink[];
 };
 
-const ApiToolbar: FC<Props> = ({ extraLinks = [] }) => {
+const ApiToolbar: FunctionComponent<Props> = ({ extraLinks = [] }) => {
   const router = useRouter();
   const [links, setLinks] = useState<ApiToolbarLink[]>([]);
   const [mini, setMini] = useState<boolean>(false);

--- a/common/views/components/AppContext/AppContext.tsx
+++ b/common/views/components/AppContext/AppContext.tsx
@@ -4,7 +4,7 @@ import {
   useState,
   useEffect,
   ReactElement,
-  FC,
+  FunctionComponent,
   ReactNode,
 } from 'react';
 import theme, { Size } from '../../../views/themes/default';
@@ -46,7 +46,7 @@ function getWindowSize(): Size {
   }
 }
 
-export const AppContextProvider: FC<AppContextProviderProps> = ({
+export const AppContextProvider: FunctionComponent<AppContextProviderProps> = ({
   children,
 }: AppContextProviderProps): ReactElement<AppContextProviderProps> => {
   const [isEnhanced, setIsEnhanced] = useState(appContextDefaults.isEnhanced);

--- a/common/views/components/AudioPlayer/AudioPlayer.tsx
+++ b/common/views/components/AudioPlayer/AudioPlayer.tsx
@@ -2,7 +2,7 @@ import {
   useEffect,
   useRef,
   useState,
-  FC,
+  FunctionComponent,
   Ref,
   SyntheticEvent,
   useContext,
@@ -127,7 +127,7 @@ type PlayRateProps = {
   id: string;
 };
 
-const PlayRate: FC<PlayRateProps> = ({ audioPlayer, id }) => {
+const PlayRate: FunctionComponent<PlayRateProps> = ({ audioPlayer, id }) => {
   const { audioPlaybackRate, setAudioPlaybackRate } = useContext(AppContext);
   const speeds = [0.5, 1, 1.5, 2];
 
@@ -189,7 +189,7 @@ type VolumeProps = {
   id: string;
 };
 
-const Volume: FC<VolumeProps> = ({ audioPlayer, id }) => {
+const Volume: FunctionComponent<VolumeProps> = ({ audioPlayer, id }) => {
   const [volume, setVolume] = useState(audioPlayer.volume);
   const [isMuted, setIsMuted] = useState(audioPlayer.muted);
 
@@ -254,7 +254,7 @@ type ScrubberProps = {
   progressBarRef: Ref<HTMLInputElement>;
 };
 
-const Scrubber: FC<ScrubberProps> = ({
+const Scrubber: FunctionComponent<ScrubberProps> = ({
   startTime,
   duration,
   onChange,
@@ -290,7 +290,7 @@ export type AudioPlayerProps = {
   titleProps?: { role: string; 'aria-level': number };
 };
 
-export const AudioPlayer: FC<AudioPlayerProps> = ({
+export const AudioPlayer: FunctionComponent<AudioPlayerProps> = ({
   audioFile,
   title,
   idPrefix,

--- a/common/views/components/BorderlessClickable/BorderlessClickable.tsx
+++ b/common/views/components/BorderlessClickable/BorderlessClickable.tsx
@@ -1,6 +1,6 @@
 import {
   ComponentProps,
-  FC,
+  FunctionComponent,
   ReactNode,
   SyntheticEvent,
   forwardRef,
@@ -47,7 +47,7 @@ type Props = {
 };
 
 type BorderlessClickableProps = Props & { as: ClickableElement };
-const Button: FC<BorderlessClickableProps> = (
+const Button: FunctionComponent<BorderlessClickableProps> = (
   {
     as,
     icon,
@@ -104,7 +104,7 @@ const BorderlessClickable = forwardRef<
 >(Button);
 
 type BorderlessLinkProps = Props & ComponentProps<'a'>;
-const Link: FC<BorderlessLinkProps> = (
+const Link: FunctionComponent<BorderlessLinkProps> = (
   {
     icon,
     iconLeft,
@@ -136,7 +136,7 @@ type BorderlessButtonProps = Props &
     trackingEvent?: GaEvent;
     clickHandler?: (event: SyntheticEvent<HTMLButtonElement>) => void;
   };
-const ButtonOuter: FC<BorderlessButtonProps> = (
+const ButtonOuter: FunctionComponent<BorderlessButtonProps> = (
   {
     icon,
     iconLeft,

--- a/common/views/components/ButtonSolid/ButtonSolid.tsx
+++ b/common/views/components/ButtonSolid/ButtonSolid.tsx
@@ -1,4 +1,10 @@
-import { forwardRef, SyntheticEvent, ForwardedRef, FC, ReactNode } from 'react';
+import {
+  forwardRef,
+  SyntheticEvent,
+  ForwardedRef,
+  FunctionComponent,
+  ReactNode,
+} from 'react';
 import styled from 'styled-components';
 import { classNames, font } from '../../../utils/classnames';
 import { trackEvent, GaEvent } from '../../../utils/ga';
@@ -170,7 +176,7 @@ export const SolidButton = styled(BaseButton).attrs<SolidButtonProps>(
 `;
 
 // TODO move styles here - styled component
-const Button: FC<ButtonSolidProps> = (
+const Button: FunctionComponent<ButtonSolidProps> = (
   {
     icon,
     text,

--- a/common/views/components/Buttons/Control/Control.tsx
+++ b/common/views/components/Buttons/Control/Control.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, FC } from 'react';
+import { forwardRef, FunctionComponent } from 'react';
 import NextLink from 'next/link';
 import { LinkProps } from '../../../../model/link-props';
 import Icon from '../../Icon/Icon';
@@ -187,7 +187,7 @@ const InnerControl = ({ text, icon }: InnerControlProps) => (
 
 type Props = ButtonProps | AnchorProps;
 
-const BaseControl: FC<Props> = (
+const BaseControl: FunctionComponent<Props> = (
   {
     tabIndex,
     link,

--- a/common/views/components/Dot/Dot.tsx
+++ b/common/views/components/Dot/Dot.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import { PaletteColor } from '@weco/common/views/themes/config';
 
 const DotEl = styled.span.attrs({
@@ -17,5 +17,5 @@ type Props = {
   color: PaletteColor;
 };
 
-const Dot: FC<Props> = ({ color }) => <DotEl color={color} />;
+const Dot: FunctionComponent<Props> = ({ color }) => <DotEl color={color} />;
 export default Dot;

--- a/common/views/components/DropdownButton/DropdownButton.tsx
+++ b/common/views/components/DropdownButton/DropdownButton.tsx
@@ -1,5 +1,12 @@
 import { CSSTransition } from 'react-transition-group';
-import { useState, useRef, useEffect, useContext, FC, ReactNode } from 'react';
+import {
+  useState,
+  useRef,
+  useEffect,
+  useContext,
+  FunctionComponent,
+  ReactNode,
+} from 'react';
 import { usePopper } from 'react-popper';
 import styled from 'styled-components';
 import getFocusableElements from '../../../utils/get-focusable-elements';
@@ -79,7 +86,7 @@ type Props = {
   iconLeft?: IconSvg;
 };
 
-const DropdownButton: FC<Props> = ({
+const DropdownButton: FunctionComponent<Props> = ({
   label,
   children,
   buttonType = 'outlined',

--- a/common/views/components/Favicons/Favicons.tsx
+++ b/common/views/components/Favicons/Favicons.tsx
@@ -1,6 +1,6 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 
-const Favicons: FC = () => {
+const Favicons: FunctionComponent = () => {
   return (
     <>
       <link

--- a/common/views/components/FindUs/FindUs.tsx
+++ b/common/views/components/FindUs/FindUs.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 import {
   wellcomeCollectionGallery,
@@ -17,7 +17,7 @@ const PlainLink = styled.a.attrs({ className: 'plain-link' })`
   }
 `;
 
-const FindUs: FC = () => (
+const FindUs: FunctionComponent = () => (
   <>
     <Space v={{ size: 'm', properties: ['margin-bottom'] }} as="p">
       <PlainLink href={wellcomeCollectionAddress.addressMap}>

--- a/common/views/components/Footer/Footer.tsx
+++ b/common/views/components/Footer/Footer.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, FC } from 'react';
+import { useRef, useEffect, FunctionComponent } from 'react';
 import styled from 'styled-components';
 
 // Components
@@ -155,7 +155,7 @@ const BackToTopButton = styled.button.attrs({
 `;
 
 // Component
-const Footer: FC<Props> = ({ venues }: Props) => {
+const Footer: FunctionComponent<Props> = ({ venues }: Props) => {
   const footer = useRef<HTMLDivElement>(null);
 
   return (

--- a/common/views/components/Footer/FooterSocial.tsx
+++ b/common/views/components/Footer/FooterSocial.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 import {
   facebook,
@@ -84,7 +84,7 @@ const items: SocialItem[] = [
   },
 ];
 
-const FooterSocial: FC = () => (
+const FooterSocial: FunctionComponent = () => (
   <>
     {items.map(item => (
       <Cell key={item.title}>

--- a/common/views/components/Footer/FooterWellcomeLogo.tsx
+++ b/common/views/components/Footer/FooterWellcomeLogo.tsx
@@ -1,6 +1,6 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 
-const FooterWellcomeLogo: FC = () => (
+const FooterWellcomeLogo: FunctionComponent = () => (
   <svg
     width="128"
     height="42"

--- a/common/views/components/Header/DesktopSignIn.tsx
+++ b/common/views/components/Header/DesktopSignIn.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 import { font } from '../../../utils/classnames';
 import { useUser } from '../UserProvider/UserProvider';
@@ -21,7 +21,7 @@ const AccountA = styled(Space).attrs<AccountAProps>(props => ({
   }
 `;
 
-const DesktopSignIn: FC = () => {
+const DesktopSignIn: FunctionComponent = () => {
   const { state, user } = useUser();
 
   return state === 'initial' || state === 'loading' ? (

--- a/common/views/components/Header/Header.tsx
+++ b/common/views/components/Header/Header.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react';
+import { FunctionComponent, useState } from 'react';
 import styled from 'styled-components';
 import { font } from '../../../utils/classnames';
 import WellcomeCollectionBlack from '../../../icons/wellcome_collection_black';
@@ -343,7 +343,7 @@ const Container = styled.div.attrs({
   align-items: center;
 `;
 
-const Header: FC<Props> = ({
+const Header: FunctionComponent<Props> = ({
   siteSection,
   customNavLinks,
   showLibraryLogin = true,

--- a/common/views/components/Header/MobileSignIn.tsx
+++ b/common/views/components/Header/MobileSignIn.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 import { font } from '../../../utils/classnames';
 import { respondTo } from '../../themes/mixins';
@@ -47,7 +47,7 @@ const StyledComponent = styled.div.attrs({
   }
 `;
 
-const MobileSignIn: FC = () => {
+const MobileSignIn: FunctionComponent = () => {
   const { user } = useUser();
   return (
     <StyledComponent>

--- a/common/views/components/HeightRestrictedPrismicImage/HeightRestrictedPrismicImage.tsx
+++ b/common/views/components/HeightRestrictedPrismicImage/HeightRestrictedPrismicImage.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import Image from 'next/image';
 import styled from 'styled-components';
 import { ImageType } from '../../../model/image';
@@ -61,7 +61,7 @@ export function convertVerticalBreakpointSizesToSizes(
   });
 }
 
-const HeightRestrictedPrismicImage: FC<Props> = ({
+const HeightRestrictedPrismicImage: FunctionComponent<Props> = ({
   image,
   maxWidth,
   quality,

--- a/common/views/components/LabelsList/LabelsList.tsx
+++ b/common/views/components/LabelsList/LabelsList.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import { Label as LabelType, LabelColor } from '../../../model/labels';
 import Label from '../../components/Label/Label';
 import Space from '../styled/Space';
@@ -33,7 +33,7 @@ export type Props = {
   defaultLabelColor?: LabelColor;
 };
 
-const LabelsList: FC<Props> = ({
+const LabelsList: FunctionComponent<Props> = ({
   labels,
   defaultLabelColor = 'yellow',
 }: Props) => (

--- a/common/views/components/LoadingIndicator/LoadingIndicator.tsx
+++ b/common/views/components/LoadingIndicator/LoadingIndicator.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect } from 'react';
+import { FunctionComponent, useEffect } from 'react';
 import NProgress from 'nprogress';
 import Router from 'next/router';
 import styled from 'styled-components';
@@ -31,7 +31,7 @@ const LoadingIndicatorWrapper = styled.div.attrs({
   }
 `;
 
-const LoadingIndicator: FC = () => {
+const LoadingIndicator: FunctionComponent = () => {
   function handleRouteChangeStart() {
     NProgress.start();
   }

--- a/common/views/components/Message/Message.tsx
+++ b/common/views/components/Message/Message.tsx
@@ -1,7 +1,7 @@
 import { font } from '../../../utils/classnames';
 import Space from '../styled/Space';
 import styled from 'styled-components';
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 
 const Wrapper = styled(Space).attrs({
   v: {
@@ -19,5 +19,7 @@ type Props = {
   text: string;
 };
 
-const Message: FC<Props> = ({ text }) => <Wrapper>{text}</Wrapper>;
+const Message: FunctionComponent<Props> = ({ text }) => (
+  <Wrapper>{text}</Wrapper>
+);
 export default Message;

--- a/common/views/components/NewsletterPromo/NewsletterPromo.tsx
+++ b/common/views/components/NewsletterPromo/NewsletterPromo.tsx
@@ -1,4 +1,4 @@
-import { useState, useContext, FC } from 'react';
+import { useState, useContext, FunctionComponent } from 'react';
 import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
 import { font, classNames } from '../../../utils/classnames';
 import Space from '../styled/Space';
@@ -90,7 +90,7 @@ const CopyWrap = styled(Space).attrs({
   `}
 `;
 
-const NewsletterPromo: FC = () => {
+const NewsletterPromo: FunctionComponent = () => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSuccess, setIsSuccess] = useState(false);
   const [isSubmitError, setIsSubmitError] = useState(false);

--- a/common/views/components/NumberInput/NumberInput.tsx
+++ b/common/views/components/NumberInput/NumberInput.tsx
@@ -1,4 +1,4 @@
-import { ForwardedRef, forwardRef, FC } from 'react';
+import { ForwardedRef, forwardRef, FunctionComponent } from 'react';
 import styled from 'styled-components';
 import Space from '../styled/Space';
 
@@ -28,7 +28,7 @@ type Props = {
   label: string;
 } & JSX.IntrinsicElements['input'];
 
-const Input: FC<Props> = (
+const Input: FunctionComponent<Props> = (
   { label, ...inputProps }: Props,
   ref: ForwardedRef<HTMLInputElement>
 ) => (

--- a/common/views/components/OpeningTimes/OpeningTimes.tsx
+++ b/common/views/components/OpeningTimes/OpeningTimes.tsx
@@ -5,7 +5,7 @@ import {
   collectionVenueId,
   getNameFromCollectionVenue,
 } from '@weco/common/data/hardcoded-ids';
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
 type Props = {
@@ -29,7 +29,7 @@ const VenueName = styled.div`
   width: 90px;
 `;
 
-const OpeningTimes: FC<Props> = ({ venues }) => (
+const OpeningTimes: FunctionComponent<Props> = ({ venues }) => (
   <OpeningTimesList>
     {venues.map(venue => {
       const todaysHours = getTodaysVenueHours(venue);

--- a/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock.tsx
+++ b/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock.tsx
@@ -1,14 +1,17 @@
 import linkResolver from '@weco/common/services/prismic/link-resolver';
 import { JSXFunctionSerializer, PrismicRichText } from '@prismicio/react';
 import * as prismicT from '@prismicio/types';
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 
 type Props = {
   html: prismicT.RichTextField;
   htmlSerializer?: JSXFunctionSerializer;
 };
 
-const PrismicHtmlBlock: FC<Props> = ({ html, htmlSerializer }) => (
+const PrismicHtmlBlock: FunctionComponent<Props> = ({
+  html,
+  htmlSerializer,
+}) => (
   <PrismicRichText
     field={html}
     components={htmlSerializer}

--- a/common/views/components/PrismicImage/PrismicImage.tsx
+++ b/common/views/components/PrismicImage/PrismicImage.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import Image, { ImageLoaderProps } from 'next/image';
 import styled from 'styled-components';
 import { Breakpoint, sizes as breakpointSizes } from '../../themes/config';
@@ -96,7 +96,7 @@ export function createPrismicLoader(maxWidth: number, quality: ImageQuality) {
  * usurping UiImage which has reached a state where it is so bloated it is hard to refactor.
  * This is aimed solely at the Prismic image rendering for now.
  */
-const PrismicImage: FC<Props> = ({
+const PrismicImage: FunctionComponent<Props> = ({
   image,
   sizes,
   maxWidth,

--- a/common/views/components/SectionHeader/SectionHeader.tsx
+++ b/common/views/components/SectionHeader/SectionHeader.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import { grid, font } from '../../../utils/classnames';
 import Space from '../styled/Space';
 import styled from 'styled-components';
@@ -29,7 +29,7 @@ type Props = {
   title: string;
 };
 
-const SectionHeader: FC<Props> = ({ title }) => {
+const SectionHeader: FunctionComponent<Props> = ({ title }) => {
   return (
     <div className={`row ${font('wb', 2)}`}>
       <div className="container">

--- a/common/views/components/Select/Select.tsx
+++ b/common/views/components/Select/Select.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, FC } from 'react';
+import { ChangeEvent, FunctionComponent } from 'react';
 import SelectContainer from '../SelectContainer/SelectContainer';
 
 export type SelectOption = {
@@ -15,7 +15,7 @@ type Props = {
   onChange: (event: ChangeEvent<HTMLSelectElement>) => void;
 };
 
-const Select: FC<Props> = ({
+const Select: FunctionComponent<Props> = ({
   name,
   label,
   hideLabel,

--- a/common/views/components/SelectContainer/SelectContainer.tsx
+++ b/common/views/components/SelectContainer/SelectContainer.tsx
@@ -1,4 +1,4 @@
-import { useContext, ReactElement, FC } from 'react';
+import { useContext, ReactElement, FunctionComponent } from 'react';
 import { chevron } from '@weco/common/icons';
 import { AppContext } from '../AppContext/AppContext';
 import styled from 'styled-components';
@@ -62,7 +62,11 @@ type Props = {
   children: ReactElement<'select'>;
 };
 
-const SelectContainer: FC<Props> = ({ label, hideLabel, children }) => {
+const SelectContainer: FunctionComponent<Props> = ({
+  label,
+  hideLabel,
+  children,
+}) => {
   const { isKeyboard } = useContext(AppContext);
   const isFontsLoaded = useIsFontsLoaded();
 

--- a/common/views/components/SelectUncontrolled/SelectUncontrolled.tsx
+++ b/common/views/components/SelectUncontrolled/SelectUncontrolled.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import SelectContainer from '../SelectContainer/SelectContainer';
 
 type Props = {
@@ -11,7 +11,7 @@ type Props = {
   }[];
 };
 
-const SelectUncontrolled: FC<Props> = ({
+const SelectUncontrolled: FunctionComponent<Props> = ({
   name,
   label,
   options,

--- a/common/views/components/SpacingComponent/SpacingComponent.tsx
+++ b/common/views/components/SpacingComponent/SpacingComponent.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import type { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
 const SpacingComponentEl = styled.div.attrs({
@@ -20,7 +20,7 @@ const SpacingComponentEl = styled.div.attrs({
   }
 `;
 
-const SpacingComponent: FC = ({ children }) => {
+const SpacingComponent: FunctionComponent = ({ children }) => {
   return <SpacingComponentEl>{children}</SpacingComponentEl>;
 };
 

--- a/common/views/components/TabNav/TabNav.tsx
+++ b/common/views/components/TabNav/TabNav.tsx
@@ -1,5 +1,5 @@
 import {
-  FC,
+  FunctionComponent,
   useRef,
   Dispatch,
   SetStateAction,
@@ -25,7 +25,7 @@ type Props = {
   hasDivider?: boolean;
 };
 
-const TabNav: FC<Props> = ({
+const TabNav: FunctionComponent<Props> = ({
   id,
   items,
   selectedTab,

--- a/common/views/components/TextInput/TextInput.tsx
+++ b/common/views/components/TextInput/TextInput.tsx
@@ -1,4 +1,10 @@
-import { forwardRef, useContext, useState, RefObject, FC } from 'react';
+import {
+  forwardRef,
+  useContext,
+  useState,
+  RefObject,
+  FunctionComponent,
+} from 'react';
 import styled from 'styled-components';
 import Icon from '../Icon/Icon';
 import { AppContext } from '../AppContext/AppContext';
@@ -151,7 +157,7 @@ type Props = {
   ariaDescribedBy?: string;
 };
 
-const Input: FC<Props> = (
+const Input: FunctionComponent<Props> = (
   {
     label,
     type,

--- a/common/views/components/UserProvider/UserProvider.tsx
+++ b/common/views/components/UserProvider/UserProvider.tsx
@@ -1,4 +1,4 @@
-import { createContext, FC, useContext, useState } from 'react';
+import { createContext, FunctionComponent, useContext, useState } from 'react';
 import {
   auth0UserProfileToUserInfo,
   isFullAuth0Profile,
@@ -27,7 +27,7 @@ export function useUser(): Props {
   return contextState;
 }
 
-const UserProvider: FC = ({ children }) => {
+const UserProvider: FunctionComponent = ({ children }) => {
   const [user, setUser] = useState<UserInfo>();
   const [state, setState] = useState<State>('initial');
 

--- a/content/webapp/components/Body/GridFactory.tsx
+++ b/content/webapp/components/Body/GridFactory.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactElement } from 'react';
+import { FunctionComponent, ReactElement } from 'react';
 import { grid } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 
@@ -43,7 +43,10 @@ export const twoUpGridSizesMap: GridMap = {
   default: [s12m6l6xl6],
 };
 
-const GridFactory: FC<Props> = ({ items, overrideGridSizes }) => {
+const GridFactory: FunctionComponent<Props> = ({
+  items,
+  overrideGridSizes,
+}) => {
   const gridSizesMap = overrideGridSizes || {
     1: [{ s: 12, m: 12, l: 12, xl: 12 }],
     2: [

--- a/content/webapp/components/BookPromo/BookPromo.tsx
+++ b/content/webapp/components/BookPromo/BookPromo.tsx
@@ -4,7 +4,7 @@ import { BookBasic } from '../../types/books';
 import Space from '@weco/common/views/components/styled/Space';
 import styled from 'styled-components';
 import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import BookImage from '../../components/BookImage/BookImage';
 
 type LinkOrSpanSpaceAttrs = {
@@ -21,7 +21,7 @@ type Props = {
   book: BookBasic;
 };
 
-const BookPromo: FC<Props> = ({ book }) => {
+const BookPromo: FunctionComponent<Props> = ({ book }) => {
   const { id, title, subtitle, promo, cover } = book;
   return (
     <LinkOrSpanSpace

--- a/content/webapp/components/CaptionedImage/CaptionedImage.tsx
+++ b/content/webapp/components/CaptionedImage/CaptionedImage.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode } from 'react';
+import { FunctionComponent, ReactNode } from 'react';
 import Caption from '@weco/common/views/components/Caption/Caption';
 import styled from 'styled-components';
 import { CaptionedImage as CaptionedImageType } from '@weco/common/model/captioned-image';
@@ -62,7 +62,7 @@ type CaptionedImageProps = CaptionedImageType & {
   preCaptionNode?: ReactNode;
 };
 
-const CaptionedImage: FC<CaptionedImageProps> = ({
+const CaptionedImage: FunctionComponent<CaptionedImageProps> = ({
   caption,
   preCaptionNode,
   image,

--- a/content/webapp/components/Card/Card.tsx
+++ b/content/webapp/components/Card/Card.tsx
@@ -4,7 +4,7 @@ import { trackEvent } from '@weco/common/utils/ga';
 import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
 import Space from '@weco/common/views/components/styled/Space';
 import styled from 'styled-components';
-import { FC, FunctionComponent } from 'react';
+import { FunctionComponent, FunctionComponent } from 'react';
 import PartNumberIndicator from '../PartNumberIndicator/PartNumberIndicator';
 import { getCrop } from '@weco/common/model/image';
 import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImage';
@@ -106,7 +106,9 @@ const LabelsWrapper = styled.div`
   bottom: 0;
 `;
 
-export const CardLabels: FC<{ labels: LabelType[] }> = ({ labels }) => (
+export const CardLabels: FunctionComponent<{ labels: LabelType[] }> = ({
+  labels,
+}) => (
   <LabelsWrapper>
     <LabelsList labels={labels} />
   </LabelsWrapper>

--- a/content/webapp/components/CardGrid/DailyTourPromo.tsx
+++ b/content/webapp/components/CardGrid/DailyTourPromo.tsx
@@ -1,7 +1,7 @@
 import { Event } from '../../types/events';
 import { prismicPageIds } from '@weco/common/data/hardcoded-ids';
 import EventPromo from '../EventPromo/EventPromo';
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 
 const image = {
   contentUrl:
@@ -58,7 +58,7 @@ export const data: Event = {
   onlineHasEarlyRegistration: false,
 };
 
-const DailyTourPromo: FC = () => (
+const DailyTourPromo: FunctionComponent = () => (
   <EventPromo
     event={data}
     dateString={'Tuesday–Sunday'}

--- a/content/webapp/components/ComicPreviousNext/ComicPreviousNext.tsx
+++ b/content/webapp/components/ComicPreviousNext/ComicPreviousNext.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import { ArticleBasic } from '../../types/articles';
 import styled from 'styled-components';
 import Icon from '@weco/common/views/components/Icon/Icon';
@@ -102,7 +102,7 @@ export type Props = {
   next?: ArticleBasic;
 };
 
-const ComicPreviousNext: FC<Props> = ({ previous, next }) => {
+const ComicPreviousNext: FunctionComponent<Props> = ({ previous, next }) => {
   return (
     <Root>
       {previous && (

--- a/content/webapp/components/Contributors/Contributor.tsx
+++ b/content/webapp/components/Contributors/Contributor.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 import { font, grid } from '@weco/common/utils/classnames';
 import { Contributor as ContributorType } from '../../types/contributors';
@@ -12,7 +12,7 @@ const ContributorInfoWrapper = styled(Space)`
   color: ${props => props.theme.color('neutral.600')};
 `;
 
-const Contributor: FC<ContributorType> = ({
+const Contributor: FunctionComponent<ContributorType> = ({
   contributor,
   role,
   description,

--- a/content/webapp/components/DateAndStatusIndicator/DateAndStatusIndicator.tsx
+++ b/content/webapp/components/DateAndStatusIndicator/DateAndStatusIndicator.tsx
@@ -1,4 +1,4 @@
-import { FC, Fragment } from 'react';
+import { FunctionComponent, Fragment } from 'react';
 import DateRange from '@weco/common/views/components/DateRange/DateRange';
 import HTMLDate from '@weco/common/views/components/HTMLDate/HTMLDate';
 import StatusIndicator from '../../components/StatusIndicator/StatusIndicator';
@@ -9,7 +9,10 @@ type Props = {
   end?: Date;
 };
 
-const DateAndStatusIndicator: FC<Props> = ({ start, end }: Props) => (
+const DateAndStatusIndicator: FunctionComponent<Props> = ({
+  start,
+  end,
+}: Props) => (
   <Fragment>
     <Space v={{ size: 's', properties: ['margin-bottom'] }}>
       {end ? <DateRange start={start} end={end} /> : <HTMLDate date={start} />}

--- a/content/webapp/components/EventCard/EventCard.tsx
+++ b/content/webapp/components/EventCard/EventCard.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import { EventBasic } from '../../types/events';
 import CompactCard from '../CompactCard/CompactCard';
 import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImage';
@@ -14,7 +14,7 @@ type Props = {
   xOfY: { x: number; y: number };
 };
 
-const EventCard: FC<Props> = ({ event, xOfY }) => {
+const EventCard: FunctionComponent<Props> = ({ event, xOfY }) => {
   const DateRangeComponent = event.isPast ? undefined : (
     <EventDateRange event={event} />
   );

--- a/content/webapp/components/EventDateRange/EventDateRange.tsx
+++ b/content/webapp/components/EventDateRange/EventDateRange.tsx
@@ -1,7 +1,7 @@
 import { DateRange as DateRangeType } from '@weco/common/model/date-range';
 import { isSameDayOrBefore, today } from '@weco/common/utils/dates';
 import DateRange from '@weco/common/views/components/DateRange/DateRange';
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import { HasTimeRanges } from '../../types/events';
 
 type Props = {
@@ -50,7 +50,11 @@ export function getEarliestFutureDateRange(
     );
 }
 
-const EventDateRange: FC<Props> = ({ event, splitTime, fromDate }: Props) => {
+const EventDateRange: FunctionComponent<Props> = ({
+  event,
+  splitTime,
+  fromDate,
+}: Props) => {
   const dateRanges = event.times.map(({ range }) => ({
     start: range.startDateTime,
     end: range.endDateTime,

--- a/content/webapp/components/EventPromo/EventPromo.tsx
+++ b/content/webapp/components/EventPromo/EventPromo.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import { font } from '@weco/common/utils/classnames';
 import { trackEvent } from '@weco/common/utils/ga';
 import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
@@ -55,7 +55,7 @@ export function getLocationText(isOnline?: boolean, place?: Place[]): string {
   }`;
 }
 
-const EventPromo: FC<Props> = ({
+const EventPromo: FunctionComponent<Props> = ({
   event,
   position = 0,
   dateString,

--- a/content/webapp/components/EventSchedule/EventBookingButton.tsx
+++ b/content/webapp/components/EventSchedule/EventBookingButton.tsx
@@ -1,5 +1,5 @@
 import { Event } from '../../types/events';
-import { FC, Fragment } from 'react';
+import { FunctionComponent, Fragment } from 'react';
 import ButtonSolidLink from '@weco/common/views/components/ButtonSolidLink/ButtonSolidLink';
 import Message from '@weco/common/views/components/Message/Message';
 import { font } from '@weco/common/utils/classnames';
@@ -64,7 +64,7 @@ const EventBookingButtonLink = styled(Space).attrs<EventBookingButtonProps>(
   color: ${props => props.theme.color('neutral.700')};
 `;
 
-const EventBookingButton: FC<Props> = ({ event }: Props) => {
+const EventBookingButton: FunctionComponent<Props> = ({ event }: Props) => {
   const team = event.bookingEnquiryTeam;
 
   return (

--- a/content/webapp/components/EventSchedule/EventSchedule.tsx
+++ b/content/webapp/components/EventSchedule/EventSchedule.tsx
@@ -1,4 +1,4 @@
-import { Fragment, FC } from 'react';
+import { Fragment, FunctionComponent } from 'react';
 import type { EventSchedule as EventScheduleType } from '../../types/events';
 import EventScheduleItem from './EventScheduleItem';
 import { groupEventsByDay } from '../../services/prismic/events';
@@ -12,7 +12,7 @@ type Props = {
 // "Festival of Minds and Bodies" (XagmOxAAACIAo0v8), which is
 // a multi-day event with repeated schedule items.  Some of the items
 // span multiple days.
-const EventSchedule: FC<Props> = ({ schedule }) => {
+const EventSchedule: FunctionComponent<Props> = ({ schedule }) => {
   const events = schedule.map(({ event }) => event);
   const groupedEvents = groupEventsByDay(events);
   const isNotLinkedIds = schedule

--- a/content/webapp/components/EventSchedule/EventScheduleItem.tsx
+++ b/content/webapp/components/EventSchedule/EventScheduleItem.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import { grid, font } from '@weco/common/utils/classnames';
 import EventBookingButton from './EventBookingButton';
 import EventbriteButtons from '../EventbriteButtons/EventbriteButtons';
@@ -46,7 +46,10 @@ const EventContainer = styled(Space).attrs({
   background-color: ${props => props.theme.color('yellow')};
 `;
 
-const EventScheduleItem: FC<Props> = ({ event, isNotLinked }) => {
+const EventScheduleItem: FunctionComponent<Props> = ({
+  event,
+  isNotLinked,
+}) => {
   const waitForTicketSales =
     event.ticketSalesStart && !isPast(event.ticketSalesStart);
   const isHybridEvent = event.eventbriteId && event.onlineEventbriteId;

--- a/content/webapp/components/EventbriteButtons/EventbriteButtons.tsx
+++ b/content/webapp/components/EventbriteButtons/EventbriteButtons.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import { Event } from '../../types/events';
 import ButtonSolid from '@weco/common/views/components/ButtonSolid/ButtonSolid';
 import ButtonSolidLink from '@weco/common/views/components/ButtonSolidLink/ButtonSolidLink';
@@ -24,7 +24,7 @@ type Props = {
   event: Event;
 };
 
-const EventbriteButtons: FC<Props> = ({ event }) => {
+const EventbriteButtons: FunctionComponent<Props> = ({ event }) => {
   if (!event.eventbriteId && !event.onlineEventbriteId) return null;
   const isHybridEvent = event.eventbriteId && event.onlineEventbriteId;
   return (

--- a/content/webapp/components/Exhibition/Exhibition.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useState, useEffect, FC } from 'react';
+import { Fragment, useState, useEffect, FunctionComponent } from 'react';
 import { isPast, isFuture } from '@weco/common/utils/dates';
 import { formatDate } from '@weco/common/utils/format-date';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
@@ -203,7 +203,11 @@ type Props = {
   pages: PageType[];
 };
 
-const Exhibition: FC<Props> = ({ exhibition, jsonLd, pages }) => {
+const Exhibition: FunctionComponent<Props> = ({
+  exhibition,
+  jsonLd,
+  pages,
+}) => {
   type ExhibitionOf = (ExhibitionType | EventType)[];
 
   const [exhibitionOfs, setExhibitionOfs] = useState<ExhibitionOf>([]);

--- a/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
+++ b/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
@@ -1,4 +1,4 @@
-import { FC, useState, useContext, useEffect } from 'react';
+import { FunctionComponent, useState, useContext, useEffect } from 'react';
 import styled from 'styled-components';
 import Space from '@weco/common/views/components/styled/Space';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
@@ -159,7 +159,7 @@ function calculateTombstoneHeadingLevel(titlesUsed) {
   }
 }
 
-const Stop: FC<{
+const Stop: FunctionComponent<{
   stop: Stop;
   isFirstStop: boolean;
   titlesUsed: {
@@ -324,7 +324,7 @@ const Stop: FC<{
   );
 };
 
-const ExhibitionCaptions: FC<Props> = ({ stops }) => {
+const ExhibitionCaptions: FunctionComponent<Props> = ({ stops }) => {
   const titlesUsed = {
     standalone: false,
     context: false,

--- a/content/webapp/components/ExhibitionGuideLinks/ExhibitionGuideLinks.tsx
+++ b/content/webapp/components/ExhibitionGuideLinks/ExhibitionGuideLinks.tsx
@@ -1,5 +1,5 @@
 import { setCookie } from 'cookies-next';
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 import {
   britishSignLanguage,
@@ -38,7 +38,10 @@ function cookieHandler(key: string, data: string) {
   setCookie(key, data, options);
 }
 
-const ExhibitionGuideLinks: FC<Props> = ({ pathname, availableTypes }) => {
+const ExhibitionGuideLinks: FunctionComponent<Props> = ({
+  pathname,
+  availableTypes,
+}) => {
   return (
     <TypeList>
       {availableTypes.audioWithoutDescriptions && (

--- a/content/webapp/components/ExhibitionGuideLinks/TypeOption.tsx
+++ b/content/webapp/components/ExhibitionGuideLinks/TypeOption.tsx
@@ -1,4 +1,4 @@
-import { FC, SyntheticEvent } from 'react';
+import { FunctionComponent, SyntheticEvent } from 'react';
 import { IconSvg } from '@weco/common/icons/types';
 import { font } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
@@ -43,7 +43,14 @@ type Props = {
   onClick?: (event: SyntheticEvent<HTMLAnchorElement>) => void;
 };
 
-const TypeOption: FC<Props> = ({ url, title, text, color, icon, onClick }) => (
+const TypeOption: FunctionComponent<Props> = ({
+  url,
+  title,
+  text,
+  color,
+  icon,
+  onClick,
+}) => (
   <TypeItem>
     <TypeLink href={url} color={color} onClick={onClick}>
       <Space

--- a/content/webapp/components/ExhibitionGuideLinksPromo/ExhibitionGuideLinksPromo.tsx
+++ b/content/webapp/components/ExhibitionGuideLinksPromo/ExhibitionGuideLinksPromo.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import { font } from '@weco/common/utils/classnames';
 import { ExhibitionGuideBasic } from '../../types/exhibition-guides';
 import Space from '@weco/common/views/components/styled/Space';
@@ -34,7 +34,9 @@ type Props = {
 
 // We use this Promo for Exhibition Guides when we want to link to the individual types within a guide
 // and not just the guide itself
-const ExhibitionGuideLinksPromo: FC<Props> = ({ exhibitionGuide }) => {
+const ExhibitionGuideLinksPromo: FunctionComponent<Props> = ({
+  exhibitionGuide,
+}) => {
   const links: { url: string; text: string }[] = [];
   if (exhibitionGuide.availableTypes.audioWithoutDescriptions) {
     links.push({

--- a/content/webapp/components/ExhibitionGuidePromo/ExhibitionGuidePromo.tsx
+++ b/content/webapp/components/ExhibitionGuidePromo/ExhibitionGuidePromo.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import { font } from '@weco/common/utils/classnames';
 import { trackEvent } from '@weco/common/utils/ga';
 import { ExhibitionGuideBasic } from '../../types/exhibition-guides';
@@ -10,7 +10,9 @@ type Props = {
   exhibitionGuide: ExhibitionGuideBasic;
 };
 
-const ExhibitionGuidePromo: FC<Props> = ({ exhibitionGuide }) => {
+const ExhibitionGuidePromo: FunctionComponent<Props> = ({
+  exhibitionGuide,
+}) => {
   return (
     <CardOuter
       data-component="ExhibitionGuidePromo"

--- a/content/webapp/components/ExhibitionGuideStops/ExhibitionGuideStops.tsx
+++ b/content/webapp/components/ExhibitionGuideStops/ExhibitionGuideStops.tsx
@@ -2,7 +2,7 @@ import {
   ExhibitionGuideComponent,
   ExhibitionGuideType,
 } from '../../types/exhibition-guides';
-import { ReactElement, FC } from 'react';
+import { ReactElement, FunctionComponent } from 'react';
 import Space from '@weco/common/views/components/styled/Space';
 import ExhibitionCaptions from '../ExhibitionCaptions/ExhibitionCaptions';
 import styled from 'styled-components';
@@ -28,7 +28,11 @@ type VideoPlayerProps = {
   titleProps: { role: string; 'aria-level': number };
 };
 
-const VideoPlayer: FC<VideoPlayerProps> = ({ title, videoUrl, titleProps }) => (
+const VideoPlayer: FunctionComponent<VideoPlayerProps> = ({
+  title,
+  videoUrl,
+  titleProps,
+}) => (
   <figure className="no-margin">
     <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
       <figcaption className={font('intb', 5)} {...titleProps}>
@@ -45,7 +49,7 @@ type Props = {
   id?: number;
 };
 
-const Stops: FC<Props> = ({ stops, type }) => {
+const Stops: FunctionComponent<Props> = ({ stops, type }) => {
   return (
     <GridFactory
       overrideGridSizes={
@@ -78,7 +82,6 @@ const Stops: FC<Props> = ({ stops, type }) => {
               role: 'heading',
               'aria-level': 2,
             };
-
 
             return hasContentOfDesiredType ? (
               <Stop
@@ -123,7 +126,7 @@ const Stops: FC<Props> = ({ stops, type }) => {
   );
 };
 
-const ExhibitionGuideStops: FC<Props> = ({ stops, type }) => {
+const ExhibitionGuideStops: FunctionComponent<Props> = ({ stops, type }) => {
   const numberedStops = stops.filter(c => c.number);
   switch (type) {
     case 'bsl':

--- a/content/webapp/components/ExhibitionPromo/ExhibitionPromo.tsx
+++ b/content/webapp/components/ExhibitionPromo/ExhibitionPromo.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import { font } from '@weco/common/utils/classnames';
 import { trackEvent } from '@weco/common/utils/ga';
 import StatusIndicator from '../../components/StatusIndicator/StatusIndicator';
@@ -20,7 +20,10 @@ type Props = {
   position?: number;
 };
 
-const ExhibitionPromo: FC<Props> = ({ exhibition, position = 0 }) => {
+const ExhibitionPromo: FunctionComponent<Props> = ({
+  exhibition,
+  position = 0,
+}) => {
   const { start, end, statusOverride, isPermanent, hideStatus } = exhibition;
   const url = linkResolver(exhibition);
   const image = exhibition.promo?.image;

--- a/content/webapp/components/FacilityPromo/FacilityPromo.tsx
+++ b/content/webapp/components/FacilityPromo/FacilityPromo.tsx
@@ -5,7 +5,7 @@ import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImag
 import Space from '@weco/common/views/components/styled/Space';
 import { CardOuter, CardBody } from '../Card/Card';
 import { FacilityPromo as FacilityPromoType } from '../../types/facility-promo';
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
 const ImageWrapper = styled.div.attrs({
@@ -14,7 +14,7 @@ const ImageWrapper = styled.div.attrs({
   overflow: hidden;
 `;
 
-const FacilityPromo: FC<FacilityPromoType> = ({
+const FacilityPromo: FunctionComponent<FacilityPromoType> = ({
   id,
   url,
   title,

--- a/content/webapp/components/FeaturedText/FeaturedText.tsx
+++ b/content/webapp/components/FeaturedText/FeaturedText.tsx
@@ -2,14 +2,17 @@ import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/Pri
 import { font } from '@weco/common/utils/classnames';
 import { JSXFunctionSerializer } from '@prismicio/react';
 import * as prismicT from '@prismicio/types';
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 
 type Props = {
   html: prismicT.RichTextField;
   htmlSerializer?: JSXFunctionSerializer;
 };
 
-const FeaturedText: FC<Props> = ({ html, htmlSerializer }: Props) => (
+const FeaturedText: FunctionComponent<Props> = ({
+  html,
+  htmlSerializer,
+}: Props) => (
   <div className={`body-text ${font('intr', 4)}`}>
     <PrismicHtmlBlock html={html} htmlSerializer={htmlSerializer} />
   </div>

--- a/content/webapp/components/ImagePlaceholder/ImagePlaceholder.tsx
+++ b/content/webapp/components/ImagePlaceholder/ImagePlaceholder.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import type { ColorSelection } from '../../types/color-selections';
 import { transparentGif, repeatingLs } from '@weco/common/utils/backgrounds';
 import styled from 'styled-components';
@@ -24,7 +24,7 @@ type Props = {
   color?: ColorSelection;
 };
 
-const ImagePlaceholder: FC<Props> = ({ color }: Props) => (
+const ImagePlaceholder: FunctionComponent<Props> = ({ color }: Props) => (
   <Wrapper color={color || 'accent.purple'}>
     <img src={transparentGif} alt="" width="1" height="1" />
     <Pattern />

--- a/content/webapp/components/ImageWithTasl/ImageWithTasl.tsx
+++ b/content/webapp/components/ImageWithTasl/ImageWithTasl.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactElement } from 'react';
+import { FunctionComponent, ReactElement } from 'react';
 import Tasl, {
   MarkUpProps as TaslProps,
 } from '@weco/common/views/components/Tasl/Tasl';
@@ -17,7 +17,7 @@ type Props = {
   tasl?: TaslProps;
 };
 
-const ImageWithTasl: FC<Props> = ({ Image, tasl }) => (
+const ImageWithTasl: FunctionComponent<Props> = ({ Image, tasl }) => (
   <ImageWrapper>
     {Image}
     {tasl && <Tasl {...tasl} />}

--- a/content/webapp/components/InfoBox/InfoBox.tsx
+++ b/content/webapp/components/InfoBox/InfoBox.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode } from 'react';
+import React, { FunctionComponent, ReactNode } from 'react';
 import styled from 'styled-components';
 import { font } from '@weco/common/utils/classnames';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
@@ -31,7 +31,7 @@ const InfoIconWrapper = styled(Space).attrs({
   float: left;
 `;
 
-const InfoBox: FC<Props> = ({ title, items, children }) => {
+const InfoBox: FunctionComponent<Props> = ({ title, items, children }) => {
   return (
     <>
       <h2 className="h2">{title}</h2>

--- a/content/webapp/components/LayoutPaginatedResults/LayoutPaginatedResults.tsx
+++ b/content/webapp/components/LayoutPaginatedResults/LayoutPaginatedResults.tsx
@@ -11,7 +11,7 @@ import SpacingSection from '@weco/common/views/components/SpacingSection/Spacing
 import Space from '@weco/common/views/components/styled/Space';
 import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
 import { headerBackgroundLs } from '@weco/common/utils/backgrounds';
-import { FC, ReactElement } from 'react';
+import { FunctionComponent, ReactElement } from 'react';
 import CardGrid from '../CardGrid/CardGrid';
 import { BookBasic } from '../../types/books';
 import { Guide } from '../../types/guides';
@@ -49,7 +49,7 @@ const TotalPagesCopy = styled(Space).attrs({
   color: ${props => props.theme.color('neutral.600')};
 `;
 
-const LayoutPaginatedResults: FC<Props> = ({
+const LayoutPaginatedResults: FunctionComponent<Props> = ({
   title,
   description,
   paginatedResults,

--- a/content/webapp/components/NewsletterSignup/NewsletterSignup.tsx
+++ b/content/webapp/components/NewsletterSignup/NewsletterSignup.tsx
@@ -1,4 +1,4 @@
-import { SyntheticEvent, useState, useEffect, FC } from 'react';
+import { SyntheticEvent, useState, useEffect, FunctionComponent } from 'react';
 import TextInput from '@weco/common/views/components/TextInput/TextInput';
 import CheckboxRadio from '@weco/common/views/components/CheckboxRadio/CheckboxRadio';
 import { font } from '@weco/common/utils/classnames';
@@ -30,7 +30,7 @@ type Props = {
   isConfirmed?: boolean;
 };
 
-const NewsletterSignup: FC<Props> = ({
+const NewsletterSignup: FunctionComponent<Props> = ({
   isSuccess,
   isError,
   isConfirmed,

--- a/content/webapp/components/OtherExhibitionGuides/OtherExhibitionGuides.tsx
+++ b/content/webapp/components/OtherExhibitionGuides/OtherExhibitionGuides.tsx
@@ -1,7 +1,7 @@
 import Layout8 from '@weco/common/views/components/Layout8/Layout8';
 import Space from '@weco/common/views/components/styled/Space';
 import CardGrid from 'components/CardGrid/CardGrid';
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 import { ExhibitionGuideBasic } from 'types/exhibition-guides';
 
@@ -13,7 +13,9 @@ type Props = {
   otherExhibitionGuides: ExhibitionGuideBasic[];
 };
 
-const OtherExhibitionGuides: FC<Props> = ({ otherExhibitionGuides }) => (
+const OtherExhibitionGuides: FunctionComponent<Props> = ({
+  otherExhibitionGuides,
+}) => (
   <PromoContainer>
     <Space v={{ size: 'xl', properties: ['padding-top', 'padding-bottom'] }}>
       <Layout8 shift={false}>

--- a/content/webapp/components/Outro/Outro.tsx
+++ b/content/webapp/components/Outro/Outro.tsx
@@ -5,7 +5,7 @@ import CompactCard from '../CompactCard/CompactCard';
 import Divider from '@weco/common/views/components/Divider/Divider';
 import Space from '@weco/common/views/components/styled/Space';
 import linkResolver from '@weco/common/services/prismic/link-resolver';
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 
 type Props = {
   researchLinkText?: string;
@@ -16,7 +16,7 @@ type Props = {
   visitItem?: MultiContent;
 };
 
-const Outro: FC<Props> = ({
+const Outro: FunctionComponent<Props> = ({
   researchLinkText,
   researchItem,
   readLinkText,

--- a/content/webapp/components/Quote/Quote.tsx
+++ b/content/webapp/components/Quote/Quote.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import { font, classNames } from '@weco/common/utils/classnames';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
 import Space from '@weco/common/views/components/styled/Space';
@@ -19,7 +19,11 @@ const Cite = styled.cite.attrs({
   align-items: flex-end;
 `;
 
-const Quote: FC<Props> = ({ text, citation, isPullOrReview }) => {
+const Quote: FunctionComponent<Props> = ({
+  text,
+  citation,
+  isPullOrReview,
+}) => {
   return (
     <blockquote
       className={classNames({

--- a/content/webapp/components/SimpleCardGrid/SimpleCardGrid.tsx
+++ b/content/webapp/components/SimpleCardGrid/SimpleCardGrid.tsx
@@ -6,7 +6,7 @@ import Space from '@weco/common/views/components/styled/Space';
 import CssGridContainer from '@weco/common/views/components/styled/CssGridContainer';
 import FeaturedCard from '../FeaturedCard/FeaturedCard';
 import { getCrop } from '@weco/common/model/image';
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 
 type Props = {
   items: readonly CardType[];
@@ -64,7 +64,10 @@ const CardGridFeaturedCard = ({ item }: CardGridFeaturedCardProps) => {
   );
 };
 
-const CardGrid: FC<Props> = ({ items, isFeaturedFirst }: Props) => {
+const CardGrid: FunctionComponent<Props> = ({
+  items,
+  isFeaturedFirst,
+}: Props) => {
   const cards = items.filter(item => item.type === 'card');
   const threeCards = isFeaturedFirst ? cards.slice(1) : cards.slice(0, 3);
   const featuredCard = isFeaturedFirst ? cards[0] : cards[3];

--- a/content/webapp/components/StatusIndicator/StatusIndicator.tsx
+++ b/content/webapp/components/StatusIndicator/StatusIndicator.tsx
@@ -1,7 +1,7 @@
 import { font } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 import Dot from '@weco/common/views/components/Dot/Dot';
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import {
   addDays,
   isFuture,
@@ -41,7 +41,11 @@ export function formatDateRangeWithMessage({
   }
 }
 
-const StatusIndicator: FC<Props> = ({ start, end, statusOverride }: Props) => {
+const StatusIndicator: FunctionComponent<Props> = ({
+  start,
+  end,
+  statusOverride,
+}: Props) => {
   const { color, text } = statusOverride
     ? { color: 'neutral.500' as PaletteColor, text: statusOverride }
     : formatDateRangeWithMessage({ start, end });

--- a/content/webapp/components/ZoomedPrismicImage/ZoomedPrismicImage.tsx
+++ b/content/webapp/components/ZoomedPrismicImage/ZoomedPrismicImage.tsx
@@ -1,4 +1,10 @@
-import { FC, RefObject, useEffect, useState, useRef } from 'react';
+import {
+  FunctionComponent,
+  RefObject,
+  useEffect,
+  useState,
+  useRef,
+} from 'react';
 import styled from 'styled-components';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import { expand, cross } from '@weco/common/icons';
@@ -73,7 +79,9 @@ type ZoomedPrismicImageProps = {
   image: ImageType;
 };
 
-const ZoomedPrismicImage: FC<ZoomedPrismicImageProps> = ({ image }) => {
+const ZoomedPrismicImage: FunctionComponent<ZoomedPrismicImageProps> = ({
+  image,
+}) => {
   const [canShowZoom, setCanShowZoom] = useState(false);
   const [isLoaded, setIsLoaded] = useState(false);
   const [imageWidth, setImageWidth] = useState(0);

--- a/content/webapp/pages/article-series.tsx
+++ b/content/webapp/pages/article-series.tsx
@@ -1,5 +1,5 @@
 import { GetServerSideProps } from 'next';
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import PageHeaderStandfirst from '../components/PageHeaderStandfirst/PageHeaderStandfirst';
 import HeaderBackground from '@weco/common/views/components/HeaderBackground/HeaderBackground';
@@ -121,7 +121,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     };
   };
 
-const ArticleSeriesPage: FC<Props> = props => {
+const ArticleSeriesPage: FunctionComponent<Props> = props => {
   const { series, articles } = props;
   const breadcrumbs = {
     items: [

--- a/content/webapp/pages/article.tsx
+++ b/content/webapp/pages/article.tsx
@@ -1,5 +1,11 @@
 import { GetServerSideProps } from 'next';
-import { Fragment, FC, useState, useEffect, ReactElement } from 'react';
+import {
+  Fragment,
+  FunctionComponent,
+  useState,
+  useEffect,
+  ReactElement,
+} from 'react';
 import { Article, ArticleBasic } from '../types/articles';
 import { Series } from '../types/series';
 import { font } from '@weco/common/utils/classnames';
@@ -126,7 +132,7 @@ function getNextUp(
   }
 }
 
-const ArticlePage: FC<Props> = ({ article, jsonLd }) => {
+const ArticlePage: FunctionComponent<Props> = ({ article, jsonLd }) => {
   const [listOfSeries, setListOfSeries] = useState<ArticleSeriesList>();
 
   useEffect(() => {

--- a/content/webapp/pages/articles.tsx
+++ b/content/webapp/pages/articles.tsx
@@ -10,7 +10,7 @@ import {
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import LayoutPaginatedResults from '../components/LayoutPaginatedResults/LayoutPaginatedResults';
 import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import { GetServerSideProps } from 'next';
 import { appError, AppErrorProps } from '@weco/common/services/app';
 import { removeUndefinedProps } from '@weco/common/utils/json';
@@ -54,7 +54,10 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     };
   };
 
-const ArticlesPage: FC<Props> = ({ articles, jsonLd }: Props) => {
+const ArticlesPage: FunctionComponent<Props> = ({
+  articles,
+  jsonLd,
+}: Props) => {
   // `articles` could be empty if somebody paginates off the end of the list,
   // e.g. /articles?page=500
   const image = articles.results[0]?.image;

--- a/content/webapp/pages/collections.tsx
+++ b/content/webapp/pages/collections.tsx
@@ -2,7 +2,7 @@ import { prismicPageIds } from '@weco/common/data/hardcoded-ids';
 import { AppErrorProps } from '@weco/common/services/app';
 import CollectionsStaticContent from 'components/Body/CollectionsStaticContent';
 import { GetServerSideProps } from 'next';
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import * as page from './page';
 
 export const getServerSideProps: GetServerSideProps<
@@ -14,7 +14,7 @@ export const getServerSideProps: GetServerSideProps<
   });
 };
 
-const CollectionsPage: FC<page.Props> = (props: page.Props) => {
+const CollectionsPage: FunctionComponent<page.Props> = (props: page.Props) => {
   const staticContent = <CollectionsStaticContent />;
   return <page.Page {...props} staticContent={staticContent} />;
 };

--- a/content/webapp/pages/covid-welcome-back.tsx
+++ b/content/webapp/pages/covid-welcome-back.tsx
@@ -2,7 +2,7 @@ import { prismicPageIds } from '@weco/common/data/hardcoded-ids';
 import { AppErrorProps } from '@weco/common/services/app';
 import { WeAreGoodToGo } from '@weco/common/views/components/CovidIcons/CovidIcons';
 import { GetServerSideProps } from 'next';
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import * as page from './page';
 
 export const getServerSideProps: GetServerSideProps<
@@ -14,7 +14,7 @@ export const getServerSideProps: GetServerSideProps<
   });
 };
 
-const CovidWelcomeBack: FC<page.Props> = (props: page.Props) => {
+const CovidWelcomeBack: FunctionComponent<page.Props> = (props: page.Props) => {
   const postOutroContent = (
     <div style={{ width: '100px' }}>
       <WeAreGoodToGo />

--- a/content/webapp/pages/event-series.tsx
+++ b/content/webapp/pages/event-series.tsx
@@ -1,7 +1,7 @@
 import { GetServerSideProps } from 'next';
 import { EventSeries } from '../types/event-series';
 import { EventBasic } from '../types/events';
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import HeaderBackground from '@weco/common/views/components/HeaderBackground/HeaderBackground';
 import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
@@ -104,7 +104,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     }
   };
 
-const EventSeriesPage: FC<Props> = ({
+const EventSeriesPage: FunctionComponent<Props> = ({
   series,
   jsonLd,
   pastEvents,

--- a/content/webapp/pages/events.tsx
+++ b/content/webapp/pages/events.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import { orderEventsByNextAvailableDate } from '../services/prismic/events';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import LayoutPaginatedResults from '../components/LayoutPaginatedResults/LayoutPaginatedResults';
@@ -80,7 +80,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     }
   };
 
-const EventsPage: FC<Props> = props => {
+const EventsPage: FunctionComponent<Props> = props => {
   const { events, title, period, jsonLd } = props;
   const convertedPaginatedResults = {
     ...events,

--- a/content/webapp/pages/exhibition.tsx
+++ b/content/webapp/pages/exhibition.tsx
@@ -4,7 +4,7 @@ import { Exhibition as ExhibitionType } from '../types/exhibitions';
 import Installation from '../components/Installation/Installation';
 import { AppErrorProps } from '@weco/common/services/app';
 import { GaDimensions } from '@weco/common/services/app/google-analytics';
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import { GetServerSideProps } from 'next';
 import { removeUndefinedProps } from '@weco/common/utils/json';
 import { getServerData } from '@weco/common/server-data';
@@ -24,7 +24,11 @@ type Props = {
   gaDimensions: GaDimensions;
 };
 
-const ExhibitionPage: FC<Props> = ({ exhibition, pages, jsonLd }) =>
+const ExhibitionPage: FunctionComponent<Props> = ({
+  exhibition,
+  pages,
+  jsonLd,
+}) =>
   exhibition.format && exhibition.format.title === 'Installation' ? (
     <Installation installation={exhibition} jsonLd={jsonLd} />
   ) : (

--- a/content/webapp/pages/exhibitions.tsx
+++ b/content/webapp/pages/exhibitions.tsx
@@ -1,5 +1,5 @@
 import type { GetServerSideProps } from 'next';
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import { Period } from '../types/periods';
 import { PaginatedResults } from '@weco/common/services/prismic/types';
@@ -75,7 +75,7 @@ const PaginationWrapper = styled(Layout12)`
   text-align: right;
 `;
 
-const ExhibitionsPage: FC<Props> = props => {
+const ExhibitionsPage: FunctionComponent<Props> = props => {
   const { exhibitions, period, title, jsonLd } = props;
   const firstExhibition = exhibitions[0];
 

--- a/content/webapp/pages/homepage.tsx
+++ b/content/webapp/pages/homepage.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 import { font } from '@weco/common/utils/classnames';
 import SectionHeader from '@weco/common/views/components/SectionHeader/SectionHeader';
@@ -130,7 +130,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     }
   };
 
-const Homepage: FC<Props> = ({
+const Homepage: FunctionComponent<Props> = ({
   nextSevenDaysEvents,
   exhibitions,
   articles,

--- a/content/webapp/pages/newsletter.tsx
+++ b/content/webapp/pages/newsletter.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import NewsletterSignup from '../components/NewsletterSignup/NewsletterSignup';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
@@ -28,7 +28,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     };
   };
 
-const Newsletter: FC<Props> = ({ result }) => {
+const Newsletter: FunctionComponent<Props> = ({ result }) => {
   return (
     <PageLayout
       title="Sign up to our newsletter"

--- a/content/webapp/pages/page.tsx
+++ b/content/webapp/pages/page.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactElement } from 'react';
+import { FunctionComponent, ReactElement } from 'react';
 import PageLayout, {
   SiteSection,
 } from '@weco/common/views/components/PageLayout/PageLayout';
@@ -176,7 +176,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     }
   };
 
-export const Page: FC<Props> = ({
+export const Page: FunctionComponent<Props> = ({
   page,
   siblings,
   children,

--- a/content/webapp/pages/stories.tsx
+++ b/content/webapp/pages/stories.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import Layout12 from '@weco/common/views/components/Layout12/Layout12';
@@ -237,7 +237,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     }
   };
 
-const StoriesPage: FC<Props> = ({
+const StoriesPage: FunctionComponent<Props> = ({
   series,
   articles,
   featuredText,

--- a/content/webapp/pages/visit-us.tsx
+++ b/content/webapp/pages/visit-us.tsx
@@ -2,7 +2,7 @@ import { prismicPageIds } from '@weco/common/data/hardcoded-ids';
 import { AppErrorProps } from '@weco/common/services/app';
 import VisitUsStaticContent from 'components/Body/VisitUsStaticContent';
 import { GetServerSideProps } from 'next';
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import * as page from './page';
 
 export const getServerSideProps: GetServerSideProps<
@@ -14,7 +14,7 @@ export const getServerSideProps: GetServerSideProps<
   });
 };
 
-const VisitUs: FC<page.Props> = (props: page.Props) => {
+const VisitUs: FunctionComponent<page.Props> = (props: page.Props) => {
   const staticContent = <VisitUsStaticContent />;
 
   return <page.Page {...props} staticContent={staticContent}></page.Page>;

--- a/dash/webapp/components/Header.tsx
+++ b/dash/webapp/components/Header.tsx
@@ -1,9 +1,9 @@
 import Link from 'next/link';
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 
 type Props = { title: string };
 
-const Header: FC<Props> = ({ title }) => {
+const Header: FunctionComponent<Props> = ({ title }) => {
   return (
     <div
       style={{

--- a/dash/webapp/pages/index.tsx
+++ b/dash/webapp/pages/index.tsx
@@ -1,8 +1,8 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import Header from '../components/Header';
 const fontFamily = 'Gadget, sans-serif';
 
-const IndexPage: FC = () => {
+const IndexPage: FunctionComponent = () => {
   return (
     <div
       style={{

--- a/dash/webapp/pages/pa11y.tsx
+++ b/dash/webapp/pages/pa11y.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useState, useEffect, FC } from 'react';
+import { Fragment, useState, useEffect, FunctionComponent } from 'react';
 import styled from 'styled-components';
 import Header from '../components/Header';
 
@@ -34,7 +34,7 @@ const Issue = styled.div`
       : ''}
 `;
 
-const Index: FC = () => {
+const Index: FunctionComponent = () => {
   const [resultsList, setResultsList] = useState(null);
 
   useEffect(() => {

--- a/dash/webapp/pages/toggles.tsx
+++ b/dash/webapp/pages/toggles.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, FC } from 'react';
+import { useState, useEffect, useCallback, FunctionComponent } from 'react';
 import styled from 'styled-components';
 import getCookies from 'next-cookies';
 import Header from '../components/Header';
@@ -67,7 +67,7 @@ type AbTest = {
   description: string;
 };
 
-const IndexPage: FC = () => {
+const IndexPage: FunctionComponent = () => {
   const [toggleStates, setToggleStates] = useState<ToggleStates>({});
   const [toggles, setToggles] = useState<Toggle[]>([]);
   const [abTests, setAbTests] = useState<AbTest[]>([]);

--- a/identity/webapp/copy.tsx
+++ b/identity/webapp/copy.tsx
@@ -11,7 +11,7 @@
 
 import Divider from '@weco/common/views/components/Divider/Divider';
 import Space from '@weco/common/views/components/styled/Space';
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import { ExternalLink } from './src/frontend/Registration/Registration.style';
 import { SectionHeading } from './src/frontend/components/Layout.style';
 
@@ -19,36 +19,35 @@ type ValidatedSuccessTextProps = {
   isNewSignUp: boolean;
 };
 
-export const ValidatedSuccessText: FC<ValidatedSuccessTextProps> = ({
-  isNewSignUp,
-}: ValidatedSuccessTextProps) => (
-  <>
-    <SectionHeading as="h1">Email verified</SectionHeading>
-    <p>Thank you for verifying your email address.</p>
-    {isNewSignUp && (
-      <div data-test-id="new-sign-up">
-        <p>
-          You can now request up to 15 items from our closed stores in the
-          library.
-        </p>
-        <p>
-          To complete your membership and access subscription databases,
-          e-journals and e-books, you’ll need to bring a form of photo
-          identification (ID) and proof of your address to our admissions desk
-          when you visit. The identification we accept is detailed on our{' '}
-          <a href="https://wellcomecollection.org/pages/X_2eexEAACQAZLBi">
-            Library membership page
-          </a>
-          .
-        </p>
-      </div>
-    )}
-  </>
-);
+export const ValidatedSuccessText: FunctionComponent<ValidatedSuccessTextProps> =
+  ({ isNewSignUp }: ValidatedSuccessTextProps) => (
+    <>
+      <SectionHeading as="h1">Email verified</SectionHeading>
+      <p>Thank you for verifying your email address.</p>
+      {isNewSignUp && (
+        <div data-test-id="new-sign-up">
+          <p>
+            You can now request up to 15 items from our closed stores in the
+            library.
+          </p>
+          <p>
+            To complete your membership and access subscription databases,
+            e-journals and e-books, you’ll need to bring a form of photo
+            identification (ID) and proof of your address to our admissions desk
+            when you visit. The identification we accept is detailed on our{' '}
+            <a href="https://wellcomecollection.org/pages/X_2eexEAACQAZLBi">
+              Library membership page
+            </a>
+            .
+          </p>
+        </div>
+      )}
+    </>
+  );
 
-export const ValidatedFailedText: FC<{ message: string | string[] }> = ({
-  message,
-}) => (
+export const ValidatedFailedText: FunctionComponent<{
+  message: string | string[];
+}> = ({ message }) => (
   <>
     <SectionHeading as="h1">Failed to verify email</SectionHeading>
     <p>{message}</p>
@@ -59,7 +58,9 @@ export const ValidatedFailedText: FC<{ message: string | string[] }> = ({
   </>
 );
 
-export const ApplicationReceived: FC<{ email: string }> = ({ email }) => (
+export const ApplicationReceived: FunctionComponent<{ email: string }> = ({
+  email,
+}) => (
   <>
     <SectionHeading as="h1">Application received</SectionHeading>
     <div className="body-text">
@@ -123,7 +124,7 @@ export const collectionsResearchAgreementLabel = (
   </>
 );
 
-export const DeleteRequestedText: FC = () => (
+export const DeleteRequestedText: FunctionComponent = () => (
   <>
     <SectionHeading as="h1">Delete request received</SectionHeading>
 

--- a/identity/webapp/pages/index.tsx
+++ b/identity/webapp/pages/index.tsx
@@ -1,5 +1,5 @@
 import React, {
-  FC,
+  FunctionComponent,
   ComponentProps,
   useState,
   ComponentPropsWithoutRef,
@@ -66,14 +66,14 @@ type DetailListProps = {
   listItems: DetailProps[];
 };
 
-const Detail: FC<DetailProps> = ({ label, value }) => (
+const Detail: FunctionComponent<DetailProps> = ({ label, value }) => (
   <>
     <dt className={font('intb', 5)}>{label}</dt>
     <StyledDd className={font('intr', 5)}>{value}</StyledDd>
   </>
 );
 
-const DetailList: FC<DetailListProps> = ({ listItems }) => {
+const DetailList: FunctionComponent<DetailListProps> = ({ listItems }) => {
   return (
     <StyledDl>
       {listItems.map(item => (
@@ -83,7 +83,7 @@ const DetailList: FC<DetailListProps> = ({ listItems }) => {
   );
 };
 
-const TextButton: FC<ComponentPropsWithoutRef<'button'>> = ({
+const TextButton: FunctionComponent<ComponentPropsWithoutRef<'button'>> = ({
   children,
   ...props
 }) => (
@@ -101,7 +101,9 @@ const TextButton: FC<ComponentPropsWithoutRef<'button'>> = ({
   </button>
 );
 
-const RequestsFailed: FC<{ retry: () => void }> = ({ retry }) => (
+const RequestsFailed: FunctionComponent<{ retry: () => void }> = ({
+  retry,
+}) => (
   <p className={font('intr', 5)}>
     Something went wrong fetching your item requests.
     <TextButton
@@ -114,7 +116,7 @@ const RequestsFailed: FC<{ retry: () => void }> = ({ retry }) => (
   </p>
 );
 
-const AccountStatus: FC<ComponentProps<typeof StatusAlert>> = ({
+const AccountStatus: FunctionComponent<ComponentProps<typeof StatusAlert>> = ({
   type,
   children,
 }) => {

--- a/identity/webapp/src/frontend/MyAccount/ChangeDetailsModal.tsx
+++ b/identity/webapp/src/frontend/MyAccount/ChangeDetailsModal.tsx
@@ -20,45 +20,41 @@ type ChangeDetailsModalProps = {
   render: (props: ChangeDetailsModalContentProps) => ReactElement;
 };
 
-export const ChangeDetailsModal: React.FC<ChangeDetailsModalProps> = ({
-  id,
-  buttonText,
-  onComplete,
-  render,
-}) => {
-  const [isActive, setIsActive] = useState(false);
-  const [isModalLoading, setIsModalLoading] = useState(false);
-  const openButton = useRef(null);
+export const ChangeDetailsModal: React.FunctionComponent<ChangeDetailsModalProps> =
+  ({ id, buttonText, onComplete, render }) => {
+    const [isActive, setIsActive] = useState(false);
+    const [isModalLoading, setIsModalLoading] = useState(false);
+    const openButton = useRef(null);
 
-  const handleComplete = (newDetails?: UpdateUserSchema) => {
-    onComplete(newDetails);
-    setIsActive(false);
+    const handleComplete = (newDetails?: UpdateUserSchema) => {
+      onComplete(newDetails);
+      setIsActive(false);
+    };
+
+    const close = () => setIsActive(false);
+
+    return (
+      <>
+        <ButtonSolid
+          colors={themeValues.buttonColors.greenTransparentGreen}
+          text={buttonText}
+          clickHandler={() => setIsActive(true)}
+          ref={openButton}
+        />
+        <Modal
+          id={id}
+          isActive={isActive}
+          setIsActive={setIsActive}
+          openButtonRef={openButton}
+          removeCloseButton={isModalLoading}
+        >
+          {render({
+            onComplete: handleComplete,
+            onCancel: close,
+            isActive,
+            setIsModalLoading,
+          })}
+        </Modal>
+      </>
+    );
   };
-
-  const close = () => setIsActive(false);
-
-  return (
-    <>
-      <ButtonSolid
-        colors={themeValues.buttonColors.greenTransparentGreen}
-        text={buttonText}
-        clickHandler={() => setIsActive(true)}
-        ref={openButton}
-      />
-      <Modal
-        id={id}
-        isActive={isActive}
-        setIsActive={setIsActive}
-        openButtonRef={openButton}
-        removeCloseButton={isModalLoading}
-      >
-        {render({
-          onComplete: handleComplete,
-          onCancel: close,
-          isActive,
-          setIsModalLoading,
-        })}
-      </Modal>
-    </>
-  );
-};

--- a/identity/webapp/src/frontend/MyAccount/ChangeEmail.tsx
+++ b/identity/webapp/src/frontend/MyAccount/ChangeEmail.tsx
@@ -23,135 +23,132 @@ type ChangeEmailInputs = {
   password: string;
 };
 
-export const ChangeEmail: React.FC<ChangeDetailsModalContentProps> = ({
-  onComplete,
-  isActive,
-  setIsModalLoading,
-}) => {
-  const [initialEmail, setInitialEmail] = useState<string>('');
-  const { user, state: userState } = useUser();
-  const { updateUser, state: updateState, error } = useUpdateUser();
+export const ChangeEmail: React.FunctionComponent<ChangeDetailsModalContentProps> =
+  ({ onComplete, isActive, setIsModalLoading }) => {
+    const [initialEmail, setInitialEmail] = useState<string>('');
+    const { user, state: userState } = useUser();
+    const { updateUser, state: updateState, error } = useUpdateUser();
 
-  const { control, trigger, reset, formState, handleSubmit, setError } =
-    useForm<ChangeEmailInputs>({
-      defaultValues: { email: initialEmail, password: '' },
-    });
-  const [submissionErrorMessage, setSubmissionErrorMessage] = useState<
-    string | null
-  >(null);
+    const { control, trigger, reset, formState, handleSubmit, setError } =
+      useForm<ChangeEmailInputs>({
+        defaultValues: { email: initialEmail, password: '' },
+      });
+    const [submissionErrorMessage, setSubmissionErrorMessage] = useState<
+      string | null
+    >(null);
 
-  useEffect(() => {
-    setIsModalLoading(updateState === 'loading');
-  }, [updateState]);
+    useEffect(() => {
+      setIsModalLoading(updateState === 'loading');
+    }, [updateState]);
 
-  useEffect(() => {
-    reset({ password: '' });
-  }, [reset, isActive]);
+    useEffect(() => {
+      reset({ password: '' });
+    }, [reset, isActive]);
 
-  useEffect(() => {
-    switch (error) {
-      case UpdateUserError.EMAIL_ALREADY_EXISTS: {
-        setError('email', {
-          type: 'manual',
-          message: 'Email address already in use',
-        });
-        break;
+    useEffect(() => {
+      switch (error) {
+        case UpdateUserError.EMAIL_ALREADY_EXISTS: {
+          setError('email', {
+            type: 'manual',
+            message: 'Email address already in use',
+          });
+          break;
+        }
+        case UpdateUserError.INCORRECT_PASSWORD: {
+          setError('password', {
+            type: 'manual',
+            message: 'Incorrect password',
+          });
+          break;
+        }
+        case UpdateUserError.BRUTE_FORCE_BLOCKED: {
+          setSubmissionErrorMessage(
+            'Your account has been blocked after multiple consecutive login attempts'
+          );
+          break;
+        }
+        case UpdateUserError.UNKNOWN: {
+          setSubmissionErrorMessage('An unknown error occurred');
+          break;
+        }
       }
-      case UpdateUserError.INCORRECT_PASSWORD: {
-        setError('password', {
-          type: 'manual',
-          message: 'Incorrect password',
-        });
-        break;
-      }
-      case UpdateUserError.BRUTE_FORCE_BLOCKED: {
-        setSubmissionErrorMessage(
-          'Your account has been blocked after multiple consecutive login attempts'
-        );
-        break;
-      }
-      case UpdateUserError.UNKNOWN: {
-        setSubmissionErrorMessage('An unknown error occurred');
-        break;
-      }
+    }, [error, setError, formState.submitCount]);
+
+    if (userState === 'loading' || updateState === 'loading') {
+      return <Loading />;
     }
-  }, [error, setError, formState.submitCount]);
 
-  if (userState === 'loading' || updateState === 'loading') {
-    return <Loading />;
-  }
+    const onSubmit = (data: ChangeEmailInputs): void => {
+      setInitialEmail(data.email);
+      updateUser(data, onComplete);
+    };
 
-  const onSubmit = (data: ChangeEmailInputs): void => {
-    setInitialEmail(data.email);
-    updateUser(data, onComplete);
-  };
-
-  return (
-    <ModalContainer>
-      <ModalTitle>Change email</ModalTitle>
-      {submissionErrorMessage && (
-        <StatusAlert type="failure">{submissionErrorMessage}</StatusAlert>
-      )}
-      <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
-        <h3 className={`${font('intb', 5)} no-margin`}>Email</h3>
-        <p className={`${font('intr', 5)} no-margin`}>{user?.email}</p>
-      </Space>
-      <form onSubmit={handleSubmit(onSubmit)}>
-        <FieldMargin>
-          <Controller
-            name="email"
-            control={control}
-            defaultValue={initialEmail}
-            rules={{
-              required: 'Enter an email address',
-              pattern: {
-                value: validEmailPattern,
-                message: 'Enter a valid email address',
-              },
-              validate: {
-                hasChanged: newValue => {
-                  return (
-                    newValue !== user?.email ||
-                    'You must enter a new email address to update your library account'
-                  );
-                },
-              },
-            }}
-            render={({ onChange, value, name }, { invalid }) => (
-              <TextInput
-                required
-                id={name}
-                label="New email address"
-                value={value}
-                setValue={onChange}
-                isValid={!invalid}
-                setIsValid={() => trigger('email')}
-                showValidity={formState.isSubmitted}
-                errorMessage={formState.errors.email?.message}
-              />
-            )}
-          />
-        </FieldMargin>
-        <FieldMargin>
-          <PasswordInput
-            label="Confirm password"
-            id="change-email-confirm-password"
-            name="password"
-            control={control}
-            rules={{ required: 'Enter your password' }}
-          />
-          <ErrorMessage
-            errors={formState.errors}
-            name="password"
-            render={({ message }) => (
-              <TextInputErrorMessage>{message}</TextInputErrorMessage>
-            )}
-          />
-        </FieldMargin>
-        <Space v={{ size: 'l', properties: ['margin-top'] }}>
-          <ButtonSolid type={ButtonTypes.submit} text="Update email" />
+    return (
+      <ModalContainer>
+        <ModalTitle>Change email</ModalTitle>
+        {submissionErrorMessage && (
+          <StatusAlert type="failure">{submissionErrorMessage}</StatusAlert>
+        )}
+        <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
+          <h3 className={`${font('intb', 5)} no-margin`}>Email</h3>
+          <p className={`${font('intr', 5)} no-margin`}>{user?.email}</p>
         </Space>
-      </form>
-    </ModalContainer>
-  );
-};
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <FieldMargin>
+            <Controller
+              name="email"
+              control={control}
+              defaultValue={initialEmail}
+              rules={{
+                required: 'Enter an email address',
+                pattern: {
+                  value: validEmailPattern,
+                  message: 'Enter a valid email address',
+                },
+                validate: {
+                  hasChanged: newValue => {
+                    return (
+                      newValue !== user?.email ||
+                      'You must enter a new email address to update your library account'
+                    );
+                  },
+                },
+              }}
+              render={({ onChange, value, name }, { invalid }) => (
+                <TextInput
+                  required
+                  id={name}
+                  label="New email address"
+                  value={value}
+                  setValue={onChange}
+                  isValid={!invalid}
+                  setIsValid={() => trigger('email')}
+                  showValidity={formState.isSubmitted}
+                  errorMessage={formState.errors.email?.message}
+                />
+              )}
+            />
+          </FieldMargin>
+          <FieldMargin>
+            <PasswordInput
+              label="Confirm password"
+              id="change-email-confirm-password"
+              name="password"
+              control={control}
+              rules={{ required: 'Enter your password' }}
+            />
+            <ErrorMessage
+              errors={formState.errors}
+              name="password"
+              render={({ message }) => (
+                <TextInputErrorMessage>{message}</TextInputErrorMessage>
+              )}
+            />
+          </FieldMargin>
+          <Space v={{ size: 'l', properties: ['margin-top'] }}>
+            <ButtonSolid type={ButtonTypes.submit} text="Update email" />
+          </Space>
+        </form>
+      </ModalContainer>
+    );
+  };

--- a/identity/webapp/src/frontend/MyAccount/ChangePassword.tsx
+++ b/identity/webapp/src/frontend/MyAccount/ChangePassword.tsx
@@ -24,176 +24,176 @@ type ChangePasswordInputs = {
   confirmation: string;
 };
 
-export const ChangePassword: React.FC<ChangeDetailsModalContentProps> = ({
-  onComplete,
-  isActive,
-  setIsModalLoading,
-}) => {
-  const defaultValues: ChangePasswordInputs = useMemo(
-    () => ({
-      password: '',
-      newPassword: '',
-      confirmation: '',
-    }),
-    []
-  );
-  const { updatePassword, isLoading, error } = useUpdatePassword();
-  const {
-    control,
-    getValues,
-    setError,
-    formState,
-    handleSubmit,
-    trigger,
-    reset,
-  } = useForm<ChangePasswordInputs>({
-    defaultValues,
-  });
-  const [submissionErrorMessage, setSubmissionErrorMessage] = useState<
-    string | null
-  >(null);
+export const ChangePassword: React.FunctionComponent<ChangeDetailsModalContentProps> =
+  ({ onComplete, isActive, setIsModalLoading }) => {
+    const defaultValues: ChangePasswordInputs = useMemo(
+      () => ({
+        password: '',
+        newPassword: '',
+        confirmation: '',
+      }),
+      []
+    );
+    const { updatePassword, isLoading, error } = useUpdatePassword();
+    const {
+      control,
+      getValues,
+      setError,
+      formState,
+      handleSubmit,
+      trigger,
+      reset,
+    } = useForm<ChangePasswordInputs>({
+      defaultValues,
+    });
+    const [submissionErrorMessage, setSubmissionErrorMessage] = useState<
+      string | null
+    >(null);
 
-  useEffect(() => {
-    setIsModalLoading(isLoading);
-  }, [isLoading]);
+    useEffect(() => {
+      setIsModalLoading(isLoading);
+    }, [isLoading]);
 
-  const newPasswordInput = useWatch({ control, name: 'newPassword' }) as string;
-  const passwordRules = usePasswordRules(newPasswordInput);
+    const newPasswordInput = useWatch({
+      control,
+      name: 'newPassword',
+    }) as string;
+    const passwordRules = usePasswordRules(newPasswordInput);
 
-  useEffect(() => {
-    reset(defaultValues);
-  }, [reset, defaultValues, isActive]);
+    useEffect(() => {
+      reset(defaultValues);
+    }, [reset, defaultValues, isActive]);
 
-  useEffect(() => {
-    switch (error) {
-      case UpdatePasswordError.INCORRECT_PASSWORD: {
-        setError('password', {
-          type: 'manual',
-          message: 'Incorrect password',
-        });
-        break;
+    useEffect(() => {
+      switch (error) {
+        case UpdatePasswordError.INCORRECT_PASSWORD: {
+          setError('password', {
+            type: 'manual',
+            message: 'Incorrect password',
+          });
+          break;
+        }
+        case UpdatePasswordError.BRUTE_FORCE_BLOCKED: {
+          setSubmissionErrorMessage(
+            'Your account has been blocked after multiple consecutive login attempts'
+          );
+          break;
+        }
+        case UpdatePasswordError.DID_NOT_MEET_POLICY: {
+          setError('newPassword', {
+            type: 'manual',
+            message: 'Password does not meet the policy',
+          });
+          break;
+        }
+        case UpdatePasswordError.REPEATED_CHARACTERS: {
+          setError('newPassword', {
+            type: 'manual',
+            message:
+              "Repeating characters, such as aaaa, ababab, abcabc, won't be accepted as a password.",
+          });
+          break;
+        }
+        case UpdatePasswordError.UNKNOWN: {
+          setSubmissionErrorMessage(
+            'There is an issue with this library account password. To resolve this, please contact Library Enquiries (library@wellcomecollection.org).'
+          );
+          break;
+        }
       }
-      case UpdatePasswordError.BRUTE_FORCE_BLOCKED: {
-        setSubmissionErrorMessage(
-          'Your account has been blocked after multiple consecutive login attempts'
-        );
-        break;
-      }
-      case UpdatePasswordError.DID_NOT_MEET_POLICY: {
-        setError('newPassword', {
-          type: 'manual',
-          message: 'Password does not meet the policy',
-        });
-        break;
-      }
-      case UpdatePasswordError.REPEATED_CHARACTERS: {
-        setError('newPassword', {
-          type: 'manual',
-          message:
-            "Repeating characters, such as aaaa, ababab, abcabc, won't be accepted as a password.",
-        });
-        break;
-      }
-      case UpdatePasswordError.UNKNOWN: {
-        setSubmissionErrorMessage(
-          'There is an issue with this library account password. To resolve this, please contact Library Enquiries (library@wellcomecollection.org).'
-        );
-        break;
-      }
+    }, [error, setError, formState.submitCount]);
+
+    if (isLoading) {
+      return <Loading />;
     }
-  }, [error, setError, formState.submitCount]);
 
-  if (isLoading) {
-    return <Loading />;
-  }
-
-  return (
-    <ModalContainer>
-      <ModalTitle>Change password</ModalTitle>
-      {submissionErrorMessage && (
-        <StatusAlert type="failure">{submissionErrorMessage}</StatusAlert>
-      )}
-      <form
-        onSubmit={handleSubmit(data =>
-          updatePassword(
-            { password: data.password, newPassword: data.newPassword },
-            onComplete
-          )
+    return (
+      <ModalContainer>
+        <ModalTitle>Change password</ModalTitle>
+        {submissionErrorMessage && (
+          <StatusAlert type="failure">{submissionErrorMessage}</StatusAlert>
         )}
-      >
-        <FieldMargin>
-          <PasswordInput
-            label="Current password"
-            id="change-password-current"
-            name="password"
-            control={control}
-            rules={{ required: 'Enter your current password' }}
-          />
-          <ErrorMessage
-            errors={formState.errors}
-            name="password"
-            render={({ message }) => (
-              <TextInputErrorMessage>{message}</TextInputErrorMessage>
-            )}
-          />
-        </FieldMargin>
-        <FieldMargin>
-          <PasswordInput
-            label="Create new password"
-            id="change-password-new"
-            name="newPassword"
-            control={control}
-            rules={{
-              required: 'Enter your new password',
-              pattern: {
-                value: validPasswordPattern,
-                message: 'Enter a valid password',
-              },
-            }}
-          />
-          <ErrorMessage
-            errors={formState.errors}
-            name="newPassword"
-            render={({ message }) => (
-              <TextInputErrorMessage>{message}</TextInputErrorMessage>
-            )}
-          />
-        </FieldMargin>
-        <FieldMargin>
-          <PasswordInput
-            label="Re-enter new password"
-            id="change-password-confirm"
-            name="confirmation"
-            control={control}
-            rules={{
-              required: 'Confirm your new password',
-              validate: async value => {
-                const isNewPasswordValid = await trigger('newPassword');
-                if (isNewPasswordValid) {
-                  return (
-                    value === getValues('newPassword') ||
-                    'Passwords do not match'
-                  );
-                }
-                return true;
-              },
-            }}
-          />
-          <ErrorMessage
-            errors={formState.errors}
-            name="confirmation"
-            render={({ message }) => (
-              <TextInputErrorMessage>{message}</TextInputErrorMessage>
-            )}
-          />
-          <Space v={{ size: 's', properties: ['margin-top'] }}>
-            <PasswordRules {...passwordRules} />
+        <form
+          onSubmit={handleSubmit(data =>
+            updatePassword(
+              { password: data.password, newPassword: data.newPassword },
+              onComplete
+            )
+          )}
+        >
+          <FieldMargin>
+            <PasswordInput
+              label="Current password"
+              id="change-password-current"
+              name="password"
+              control={control}
+              rules={{ required: 'Enter your current password' }}
+            />
+            <ErrorMessage
+              errors={formState.errors}
+              name="password"
+              render={({ message }) => (
+                <TextInputErrorMessage>{message}</TextInputErrorMessage>
+              )}
+            />
+          </FieldMargin>
+          <FieldMargin>
+            <PasswordInput
+              label="Create new password"
+              id="change-password-new"
+              name="newPassword"
+              control={control}
+              rules={{
+                required: 'Enter your new password',
+                pattern: {
+                  value: validPasswordPattern,
+                  message: 'Enter a valid password',
+                },
+              }}
+            />
+            <ErrorMessage
+              errors={formState.errors}
+              name="newPassword"
+              render={({ message }) => (
+                <TextInputErrorMessage>{message}</TextInputErrorMessage>
+              )}
+            />
+          </FieldMargin>
+          <FieldMargin>
+            <PasswordInput
+              label="Re-enter new password"
+              id="change-password-confirm"
+              name="confirmation"
+              control={control}
+              rules={{
+                required: 'Confirm your new password',
+                validate: async value => {
+                  const isNewPasswordValid = await trigger('newPassword');
+                  if (isNewPasswordValid) {
+                    return (
+                      value === getValues('newPassword') ||
+                      'Passwords do not match'
+                    );
+                  }
+                  return true;
+                },
+              }}
+            />
+            <ErrorMessage
+              errors={formState.errors}
+              name="confirmation"
+              render={({ message }) => (
+                <TextInputErrorMessage>{message}</TextInputErrorMessage>
+              )}
+            />
+            <Space v={{ size: 's', properties: ['margin-top'] }}>
+              <PasswordRules {...passwordRules} />
+            </Space>
+          </FieldMargin>
+          <Space v={{ size: 'l', properties: ['margin-top'] }}>
+            <ButtonSolid type={ButtonTypes.submit} text="Update password" />
           </Space>
-        </FieldMargin>
-        <Space v={{ size: 'l', properties: ['margin-top'] }}>
-          <ButtonSolid type={ButtonTypes.submit} text="Update password" />
-        </Space>
-      </form>
-    </ModalContainer>
-  );
-};
+        </form>
+      </ModalContainer>
+    );
+  };

--- a/identity/webapp/src/frontend/MyAccount/DeleteAccount.tsx
+++ b/identity/webapp/src/frontend/MyAccount/DeleteAccount.tsx
@@ -27,112 +27,108 @@ type DeleteAccountInputs = {
   password: string;
 };
 
-export const DeleteAccount: React.FC<ChangeDetailsModalContentProps> = ({
-  onComplete,
-  onCancel,
-  isActive,
-  setIsModalLoading,
-}) => {
-  const defaultValues: DeleteAccountInputs = useMemo(
-    () => ({ password: '' }),
-    []
-  );
-  const { requestDelete, isLoading, isSuccess, error } = useRequestDelete();
-  const { control, formState, handleSubmit, setError, reset } =
-    useForm<DeleteAccountInputs>({
-      defaultValues,
-    });
-  const [submissionErrorMessage, setSubmissionErrorMessage] = useState<
-    string | null
-  >(null);
+export const DeleteAccount: React.FunctionComponent<ChangeDetailsModalContentProps> =
+  ({ onComplete, onCancel, isActive, setIsModalLoading }) => {
+    const defaultValues: DeleteAccountInputs = useMemo(
+      () => ({ password: '' }),
+      []
+    );
+    const { requestDelete, isLoading, isSuccess, error } = useRequestDelete();
+    const { control, formState, handleSubmit, setError, reset } =
+      useForm<DeleteAccountInputs>({
+        defaultValues,
+      });
+    const [submissionErrorMessage, setSubmissionErrorMessage] = useState<
+      string | null
+    >(null);
 
-  useEffect(() => {
-    reset(defaultValues);
-  }, [reset, defaultValues, isActive]);
+    useEffect(() => {
+      reset(defaultValues);
+    }, [reset, defaultValues, isActive]);
 
-  useEffect(() => {
-    if (isSuccess) {
-      onComplete();
+    useEffect(() => {
+      if (isSuccess) {
+        onComplete();
+      }
+    }, [isSuccess, onComplete]);
+
+    useEffect(() => {
+      setIsModalLoading(isLoading);
+    }, [isLoading]);
+
+    useEffect(() => {
+      switch (error) {
+        case RequestDeleteError.INCORRECT_PASSWORD: {
+          setError('password', {
+            type: 'manual',
+            message: 'Incorrect password',
+          });
+          break;
+        }
+        case RequestDeleteError.BRUTE_FORCE_BLOCKED: {
+          setSubmissionErrorMessage(
+            'Your account has been blocked after multiple consecutive login attempts'
+          );
+          break;
+        }
+        case RequestDeleteError.UNKNOWN: {
+          setSubmissionErrorMessage('An unknown error occurred');
+          break;
+        }
+      }
+    }, [error, setError, formState.submitCount]);
+
+    if (isLoading) {
+      return <Loading />;
     }
-  }, [isSuccess, onComplete]);
 
-  useEffect(() => {
-    setIsModalLoading(isLoading);
-  }, [isLoading]);
-
-  useEffect(() => {
-    switch (error) {
-      case RequestDeleteError.INCORRECT_PASSWORD: {
-        setError('password', {
-          type: 'manual',
-          message: 'Incorrect password',
-        });
-        break;
-      }
-      case RequestDeleteError.BRUTE_FORCE_BLOCKED: {
-        setSubmissionErrorMessage(
-          'Your account has been blocked after multiple consecutive login attempts'
-        );
-        break;
-      }
-      case RequestDeleteError.UNKNOWN: {
-        setSubmissionErrorMessage('An unknown error occurred');
-        break;
-      }
-    }
-  }, [error, setError, formState.submitCount]);
-
-  if (isLoading) {
-    return <Loading />;
-  }
-
-  return (
-    <ModalContainer>
-      <ModalTitle>Cancel library membership</ModalTitle>
-      {submissionErrorMessage && (
-        <StatusAlert type="failure">{submissionErrorMessage}</StatusAlert>
-      )}
-      <div className={font('intr', 5)}>
-        <p>
-          Are you sure you want to delete your account? Your account will be
-          closed and you won’t be able to request any items.
-        </p>
-        <p>
-          To permanently delete your library account and cancel your membership,
-          please enter your password to confirm.
-        </p>
-        <form onSubmit={handleSubmit(requestDelete)}>
-          <FieldMargin>
-            <PasswordInput
-              label="Password"
-              id="delete-account-confirm-password"
-              name="password"
-              control={control}
-              rules={{ required: 'Enter your current password' }}
-            />
-            <ErrorMessage
-              errors={formState.errors}
-              name="password"
-              render={({ message }) => (
-                <TextInputErrorMessage>{message}</TextInputErrorMessage>
-              )}
-            />
-          </FieldMargin>
-          <ButtonAlign>
-            <ButtonSolid
-              colors={themeValues.buttonColors.danger}
-              type={ButtonTypes.submit}
-              text="Yes, delete my account"
-            />
-            <ButtonSolidLink
-              colors={themeValues.buttonColors.greenTransparentGreen}
-              link="/account"
-              clickHandler={onCancel}
-              text="No, go back to my account"
-            />
-          </ButtonAlign>
-        </form>
-      </div>
-    </ModalContainer>
-  );
-};
+    return (
+      <ModalContainer>
+        <ModalTitle>Cancel library membership</ModalTitle>
+        {submissionErrorMessage && (
+          <StatusAlert type="failure">{submissionErrorMessage}</StatusAlert>
+        )}
+        <div className={font('intr', 5)}>
+          <p>
+            Are you sure you want to delete your account? Your account will be
+            closed and you won’t be able to request any items.
+          </p>
+          <p>
+            To permanently delete your library account and cancel your
+            membership, please enter your password to confirm.
+          </p>
+          <form onSubmit={handleSubmit(requestDelete)}>
+            <FieldMargin>
+              <PasswordInput
+                label="Password"
+                id="delete-account-confirm-password"
+                name="password"
+                control={control}
+                rules={{ required: 'Enter your current password' }}
+              />
+              <ErrorMessage
+                errors={formState.errors}
+                name="password"
+                render={({ message }) => (
+                  <TextInputErrorMessage>{message}</TextInputErrorMessage>
+                )}
+              />
+            </FieldMargin>
+            <ButtonAlign>
+              <ButtonSolid
+                colors={themeValues.buttonColors.danger}
+                type={ButtonTypes.submit}
+                text="Yes, delete my account"
+              />
+              <ButtonSolidLink
+                colors={themeValues.buttonColors.greenTransparentGreen}
+                link="/account"
+                clickHandler={onCancel}
+                text="No, go back to my account"
+              />
+            </ButtonAlign>
+          </form>
+        </div>
+      </ModalContainer>
+    );
+  };

--- a/identity/webapp/src/frontend/MyAccount/Loading.tsx
+++ b/identity/webapp/src/frontend/MyAccount/Loading.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import LL from '@weco/common/views/components/styled/LL';
 
-export const Loading: React.FC = () => (
+export const Loading: React.FunctionComponent = () => (
   <>
     <LL lighten={false} />
     <span className="visually-hidden" role="status" aria-label="loading">
@@ -17,7 +17,7 @@ const InlineWrapper = styled.div`
   position: relative;
 `;
 
-export const InlineLoading: React.FC = () => (
+export const InlineLoading: React.FunctionComponent = () => (
   <InlineWrapper>
     <LL small={true} lighten={true} />
     <span className="visually-hidden">Loading</span>

--- a/identity/webapp/src/frontend/MyAccount/UnverifiedEmail.tsx
+++ b/identity/webapp/src/frontend/MyAccount/UnverifiedEmail.tsx
@@ -1,7 +1,7 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import { UseSendVerificationEmail } from '../hooks/useSendVerificationEmail';
 
-export const UnverifiedEmail: FC<UseSendVerificationEmail> = ({
+export const UnverifiedEmail: FunctionComponent<UseSendVerificationEmail> = ({
   sendVerificationEmail,
   state,
 }) => {

--- a/identity/webapp/src/frontend/Registration/AccountCreated.tsx
+++ b/identity/webapp/src/frontend/Registration/AccountCreated.tsx
@@ -8,7 +8,7 @@ import Layout10 from '@weco/common/views/components/Layout10/Layout10';
 import Space from '@weco/common/views/components/styled/Space';
 import { info2 } from '@weco/common/icons';
 
-export const AccountCreated: React.FC = () => {
+export const AccountCreated: React.FunctionComponent = () => {
   return (
     <PageWrapper title="Account created">
       <Layout10>

--- a/identity/webapp/src/frontend/Registration/PasswordInput.tsx
+++ b/identity/webapp/src/frontend/Registration/PasswordInput.tsx
@@ -23,17 +23,18 @@ const VisibilityButton = styled(SolidButton).attrs(props => ({
 
 type PasswordInputProps = React.ComponentPropsWithRef<typeof WellcomeTextInput>;
 
-export const PasswordInput: React.FC<PasswordInputProps> = props => {
-  const [isVisible, setIsVisible] = useState(false);
+export const PasswordInput: React.FunctionComponent<PasswordInputProps> =
+  props => {
+    const [isVisible, setIsVisible] = useState(false);
 
-  const toggleIsVisible = () => setIsVisible(wasVisible => !wasVisible);
+    const toggleIsVisible = () => setIsVisible(wasVisible => !wasVisible);
 
-  return (
-    <PasswordInputContainer>
-      <WellcomeTextInput {...props} type={isVisible ? 'text' : 'password'} />
-      <VisibilityButton onClick={toggleIsVisible}>
-        <Icon icon={isVisible ? a11YVisual : eye} />
-      </VisibilityButton>
-    </PasswordInputContainer>
-  );
-};
+    return (
+      <PasswordInputContainer>
+        <WellcomeTextInput {...props} type={isVisible ? 'text' : 'password'} />
+        <VisibilityButton onClick={toggleIsVisible}>
+          <Icon icon={isVisible ? a11YVisual : eye} />
+        </VisibilityButton>
+      </PasswordInputContainer>
+    );
+  };

--- a/identity/webapp/src/frontend/Registration/RegistrationInformation.tsx
+++ b/identity/webapp/src/frontend/Registration/RegistrationInformation.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import Divider from '@weco/common/views/components/Divider/Divider';
 import { SectionHeading } from '../components/Layout.style';
 import { font } from '@weco/common/utils/classnames';
@@ -8,7 +8,7 @@ type Props = {
   email: string;
 };
 
-const RegistrationInformation: FC<Props> = ({ email }) => {
+const RegistrationInformation: FunctionComponent<Props> = ({ email }) => {
   return (
     <>
       <SectionHeading as="h1">Apply for a library membership</SectionHeading>

--- a/identity/webapp/src/frontend/components/CustomError.tsx
+++ b/identity/webapp/src/frontend/components/CustomError.tsx
@@ -1,10 +1,13 @@
-import { FC, PropsWithChildren } from 'react';
+import { FunctionComponent, PropsWithChildren } from 'react';
 import { SectionHeading } from './Layout.style';
 type Props = PropsWithChildren<{
   errorDescription: string;
 }>;
 
-const CustomError: FC<Props> = ({ errorDescription, children }) => {
+const CustomError: FunctionComponent<Props> = ({
+  errorDescription,
+  children,
+}) => {
   switch (errorDescription) {
     case 'user is blocked':
       return (

--- a/identity/webapp/src/frontend/components/Logo.tsx
+++ b/identity/webapp/src/frontend/components/Logo.tsx
@@ -5,7 +5,10 @@ type LogoProps = {
   height?: number;
 };
 
-export const Logo: React.FC<LogoProps> = ({ width = 128, height = 42 }) => {
+export const Logo: React.FunctionComponent<LogoProps> = ({
+  width = 128,
+  height = 42,
+}) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/identity/webapp/src/frontend/components/PageWrapper.tsx
+++ b/identity/webapp/src/frontend/components/PageWrapper.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import Head from 'next/head';
 import styled from 'styled-components';
 import Header from '@weco/common/views/components/Header/Header';
@@ -18,7 +18,7 @@ type Props = {
   title: string;
 };
 
-export const PageWrapper: FC<Props> = ({ title, children }) => {
+export const PageWrapper: FunctionComponent<Props> = ({ title, children }) => {
   return (
     <>
       <Head>

--- a/identity/webapp/src/frontend/components/PasswordInput/PasswordInput.tsx
+++ b/identity/webapp/src/frontend/components/PasswordInput/PasswordInput.tsx
@@ -14,47 +14,48 @@ export type PasswordInputProps = UseControllerOptions & {
   updateInput?: (value: string) => void;
 };
 
-export const PasswordInput: React.FC<PasswordInputProps> = props => {
-  const { updateInput } = props;
-  const [isVisible, setIsVisible] = useState(false);
-  const { field, meta } = useController(props);
-  const toggleVisibility = () =>
-    setIsVisible(currentlyVisible => !currentlyVisible);
+export const PasswordInput: React.FunctionComponent<PasswordInputProps> =
+  props => {
+    const { updateInput } = props;
+    const [isVisible, setIsVisible] = useState(false);
+    const { field, meta } = useController(props);
+    const toggleVisibility = () =>
+      setIsVisible(currentlyVisible => !currentlyVisible);
 
-  useEffect(() => {
-    if (!updateInput) return;
+    useEffect(() => {
+      if (!updateInput) return;
 
-    updateInput(field.value);
-  }, [field.value, updateInput]);
+      updateInput(field.value);
+    }, [field.value, updateInput]);
 
-  return (
-    <>
-      <TextInputWrap
-        hasErrorBorder={meta.invalid}
-        value={field.value}
-        big={false}
-      >
-        <TextInputLabel
-          htmlFor={props.id}
-          isEnhanced={true}
-          hasValue={!!field.value}
-        >
-          {props.label}
-        </TextInputLabel>
-        <TextInputInput
-          big={false}
+    return (
+      <>
+        <TextInputWrap
           hasErrorBorder={meta.invalid}
-          id={props.id || props.name}
-          type={isVisible ? 'text' : 'password'}
-          {...field}
-        />
-        <ShowPasswordButton
-          onClick={toggleVisibility}
-          aria-label={isVisible ? 'Hide password' : 'Show password'}
+          value={field.value}
+          big={false}
         >
-          <Icon icon={isVisible ? a11YVisual : eye} color="neutral.500" />
-        </ShowPasswordButton>
-      </TextInputWrap>
-    </>
-  );
-};
+          <TextInputLabel
+            htmlFor={props.id}
+            isEnhanced={true}
+            hasValue={!!field.value}
+          >
+            {props.label}
+          </TextInputLabel>
+          <TextInputInput
+            big={false}
+            hasErrorBorder={meta.invalid}
+            id={props.id || props.name}
+            type={isVisible ? 'text' : 'password'}
+            {...field}
+          />
+          <ShowPasswordButton
+            onClick={toggleVisibility}
+            aria-label={isVisible ? 'Hide password' : 'Show password'}
+          >
+            <Icon icon={isVisible ? a11YVisual : eye} color="neutral.500" />
+          </ShowPasswordButton>
+        </TextInputWrap>
+      </>
+    );
+  };

--- a/identity/webapp/src/frontend/components/PasswordInput/PasswordRules.tsx
+++ b/identity/webapp/src/frontend/components/PasswordInput/PasswordRules.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FunctionComponent } from 'react';
 import {
   RulesList,
   RulesListItem,
@@ -29,7 +29,7 @@ const RuleDot = styled.span<DotProps>`
   }
 `;
 
-const Dot: FC<DotProps> = ({ isValid }) => {
+const Dot: FunctionComponent<DotProps> = ({ isValid }) => {
   return (
     <Space h={{ size: 's', properties: ['margin-right'] }}>
       <RuleDot isValid={isValid}>
@@ -46,7 +46,7 @@ type Props = {
   hasNumbers: boolean;
 };
 
-export const PasswordRules: React.FC<Props> = ({
+export const PasswordRules: React.FunctionComponent<Props> = ({
   isAtLeast8Characters,
   hasLowercaseLetters,
   hasUppercaseLetters,

--- a/identity/webapp/src/frontend/test-utils.tsx
+++ b/identity/webapp/src/frontend/test-utils.tsx
@@ -3,7 +3,7 @@ import { render, RenderOptions, RenderResult } from '@testing-library/react';
 import { ThemeProvider } from 'styled-components';
 import theme from '@weco/common/views/themes/default';
 
-const AllTheProviders: React.FC = ({ children }) => {
+const AllTheProviders: React.FunctionComponent = ({ children }) => {
   return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
 };
 


### PR DESCRIPTION
There's no difference between them, but it's a persistent source of confusion for new developers, who wonder if there's some hidden system for choosing which one we should use in a given file.  (There isn't, but you can see why somebody might wonder!)

This should put an end to that confusion, by replacing FC everywhere with FunctionComponent.

To avoid a long bikeshed, I picked solely based on their use in the prior code:

```console
```
$ rg 'FC<' . | wc -l
     120

$ rg 'FunctionComponent<' . | wc -l
     161
```

🚲 🏠 