### PR TITLE
Make the pa11y dashboard a bit easier to use

### DIFF
--- a/dash/webapp/pages/pa11y.tsx
+++ b/dash/webapp/pages/pa11y.tsx
@@ -5,13 +5,21 @@ import Header from '../components/Header';
 
 const fontFamily = 'Gadget, sans-serif';
 const Pre = styled.pre`
-  overflow: auto;
+  white-space: pre-wrap; /* css-3 */
+  white-space: -moz-pre-wrap; /* Mozilla, since 1999 */
+  white-space: -pre-wrap; /* Opera 4-6 */
+  white-space: -o-pre-wrap; /* Opera 7 */
+  word-wrap: break-word; /* Internet Explorer 5.5+ */
+
+  // This is the neutral.300 from the global palette
   background: #e8e8e8;
+
   margin: 6px 0;
+  padding: 6px;
 `;
 const Issue = styled.div<{ type: string }>`
   padding: 12px;
-  margin: 6px;
+  margin: 12px 0px;
   ${props =>
     props.type === 'error'
       ? `
@@ -33,6 +41,28 @@ const Issue = styled.div<{ type: string }>`
       background: rgba(92, 184, 191, 0.25);
     `
       : ''}
+
+  // This is the validation green from the global palette
+  ${props =>
+    props.type === 'success'
+      ? `
+          border: 1px solid rgba(11, 112, 81, 1);
+          background: rgba(11, 112, 81, 0.1);
+        `
+      : ''}
+`;
+
+const OriginalPageLink = styled.a`
+  color: #121212;
+
+  :hover {
+    text-decoration: none;
+  }
+`;
+
+const Description = styled.p`
+  margin-top: 0;
+  font-weight: bold;
 `;
 
 const Index: FC = () => {
@@ -43,6 +73,21 @@ const Index: FC = () => {
       .then(resp => resp.json())
       .then(json => setResultsList(json));
   }, []);
+
+  // This "score" is used to order the results, to make it easier to
+  // spot failures in the dashboard -- pages with lots of errors will
+  // appear at the top of the page.
+  const results = (resultsList['results'] || [])
+    .map(r => {
+      const errors = r.issues.filter(({ type }) => type === 'error');
+      const warnings = r.issues.filter(({ type }) => type === 'warning');
+      const notices = r.issues.filter(({ type }) => type === 'notice');
+
+      const score = 100 * errors.length + 10 * warnings.length + notices.length;
+
+      return { ...r, score, errors, warnings, notices };
+    })
+    .sort((a, b) => b.score - a.score);
 
   return (
     <>
@@ -63,80 +108,91 @@ const Index: FC = () => {
             }}
           >
             <main>
-              {resultsList['results'] &&
-                resultsList['results'].map(
-                  ({ documentTitle, pageUrl, issues }) => {
-                    const errorCount = issues.filter(
-                      issue => issue.type === 'error'
-                    ).length;
-                    const warningCount = issues.filter(
-                      issue => issue.type === 'warning'
-                    ).length;
-                    const noticeCount = issues.filter(
-                      issue => issue.type === 'notice'
-                    ).length;
-                    return (
-                      <section
-                        key={pageUrl}
-                        style={{
-                          marginTop: '18px',
-                          padding: '6px 0',
-                          borderTop: '1px solid #d9d6ce',
-                        }}
-                      >
-                        <h2
+              {results.map(
+                ({
+                  documentTitle,
+                  pageUrl,
+                  issues,
+                  errors,
+                  warnings,
+                  notices,
+                }) => {
+                  return (
+                    <section
+                      key={pageUrl}
+                      style={{
+                        marginTop: '18px',
+                        padding: '6px 0',
+                        borderTop: '1px solid #d9d6ce',
+                      }}
+                    >
+                      <OriginalPageLink href={pageUrl}>
+                        <h3
                           style={{
                             marginBottom: '6px',
                           }}
                         >
                           {documentTitle}
-                        </h2>
-                        <h3
-                          style={{
-                            fontWeight: 'normal',
-                            color: '#717171',
-                            fontSize: '14px',
-                            marginTop: 0,
-                          }}
-                        >
-                          {pageUrl}
                         </h3>
-                        <div
-                          style={{
-                            display: 'flex',
-                          }}
-                        >
-                          <Issue type="error">{errorCount}</Issue>
-                          <Issue type="warning">{warningCount}</Issue>
-                          <Issue type="notice">{noticeCount}</Issue>
-                        </div>
-                        {issues.map(issue => {
-                          return (
-                            <Issue type={issue.type} key={issue.selector}>
-                              <p>
-                                <b>
-                                  {issue.type}: {issue.message}
-                                </b>
-                              </p>
+                      </OriginalPageLink>
+                      <div
+                        style={{
+                          display: 'flex',
+                        }}
+                      >
+                        {issues.length === 0 ? (
+                          <Issue type="success">No issues reported</Issue>
+                        ) : (
+                          issues.length > 1 && (
+                            <>
+                              {errors.length > 0 && (
+                                <Issue type="error">
+                                  {errors.length} error
+                                  {errors.length !== 1 ? 's' : ''}
+                                </Issue>
+                              )}
+                              {warnings.length > 0 && (
+                                <Issue type="error">
+                                  {warnings.length} warning
+                                  {warnings.length !== 1 ? 's' : ''}
+                                </Issue>
+                              )}
+                              {notices.length > 0 && (
+                                <Issue type="error">
+                                  {notices.length} notice
+                                  {notices.length !== 1 ? 's' : ''}
+                                </Issue>
+                              )}
+                            </>
+                          )
+                        )}
+                      </div>
 
-                              <div>Context</div>
-                              <Pre>{issue.context}</Pre>
+                      {issues.map(issue => {
+                        return (
+                          <Issue type={issue.type} key={issue.selector}>
+                            <Description>
+                              {issue.type}: {issue.message}
+                            </Description>
 
-                              <div
-                                style={{
-                                  marginTop: '12px',
-                                }}
-                              >
-                                Selector
-                              </div>
-                              <Pre>{issue.selector}</Pre>
-                            </Issue>
-                          );
-                        })}
-                      </section>
-                    );
-                  }
-                )}
+                            <div>Context</div>
+                            <Pre>{issue.context}</Pre>
+
+                            <div
+                              style={{
+                                marginTop: '12px',
+                              }}
+                            >
+                              Selector
+                            </div>
+                            <Pre>{issue.selector}</Pre>
+                          </Issue>
+                        );
+                      })}
+                    </section>
+                  );
+                }
+              )}
             </main>
           </div>
         </div>


### PR DESCRIPTION
Now Raphaëlle has got the dashboard building again (see #8706), I can knock out a few ideas I've been sitting on.


*   Sort the results so any errors appear at the top of the list, to save having to scroll.
*   Make the page titles link to the page, which is more convenient than copy-pasting the URL.
*   Tidy up the error/warning/notice counts.  We only show the count if it's non-trivial (hidden if there are zero issues of this type; hidden if there's only a single issue), and we include a label to say "1 error" "2 warnings".  This is partly for colour-blind devs who can't distinguish the red/orange/blue, partly for new devs who don't know what the colours mean.
*   If there are no issues, say so in a pleasing green box rather than the 0/0/0.
*   Tweak padding and line wrap in the issue notices.

<table><tr><th>Before</th><th>After</th></tr><tr><td>
<img width="1003" alt="Screenshot 2022-10-20 at 16 21 18" src="https://user-images.githubusercontent.com/301220/196991164-3095517c-c476-49ed-b181-ac0fadc29347.png">
</td><td>
<img width="1003" alt="Screenshot 2022-10-20 at 16 21 09" src="https://user-images.githubusercontent.com/301220/196991159-f592678a-61f6-4908-b267-a928a66f9061.png">
</td></tr></table>