### PR TITLE
Update casing of reading time in articles (small pr)

### DIFF
--- a/content/webapp/pages/article.tsx
+++ b/content/webapp/pages/article.tsx
@@ -239,7 +239,7 @@ const ArticlePage: FunctionComponent<Props> = ({ article, jsonLd }) => {
               ))}
             {article.readingTime ? (
               <ContentTypeInfoSection>
-                Average reading time{' '}
+                average reading time{' '}
                 <span className={font('intb', 6)}>{article.readingTime}</span>
               </ContentTypeInfoSection>
             ) : null}


### PR DESCRIPTION
## Who is this for?

Anyone reading articles

## What is it doing for them?

I had put 'average reading time' as uppercase, as there will be contributor and/or artist details before the reading time, this should be lowercase to match. 