### PR TITLE
Readd missing pa11y commands, change neutral.600 slightly

### DIFF
--- a/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
+++ b/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
@@ -207,12 +207,12 @@ const ExpandedImage: FunctionComponent<Props> = ({
         </ImageWrapper>
       )}
       <InfoWrapper>
-        <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
-          <h2
-            className={`${font('intb', 3)} no-margin`}
-            dangerouslySetInnerHTML={{ __html: displayTitle }}
-          />
-          {displayContributor && (
+        {displayContributor && (
+          <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
+            <h2
+              className={`${font('intb', 3)} no-margin`}
+              dangerouslySetInnerHTML={{ __html: displayTitle }}
+            />
             <Space
               as="h3"
               v={{ size: 's', properties: ['margin-top'] }}
@@ -220,8 +220,8 @@ const ExpandedImage: FunctionComponent<Props> = ({
             >
               {displayContributor}
             </Space>
-          )}
-        </Space>
+          </Space>
+        )}
         {license && (
           <Space
             className={font('intr', 5)}

--- a/common/views/themes/config.ts
+++ b/common/views/themes/config.ts
@@ -110,7 +110,7 @@ const colors = {
   'neutral.300': '#e8e8e8', // lightness: 91 - matches warmNeutral.300
   'neutral.400': '#d9d9d9', // lightness: 85 - matches warmNeutral.400
   'neutral.500': '#8f8f8f', // lightness: 56
-  'neutral.600': '#6b6b6b', // lightness: 42
+  'neutral.600': '#6a6a6a', // suggested: lightness: 42
   'neutral.700': '#323232', // lightness: 20
 
   // Warm neutrals have equivalents in neutral (see lightness), but with a tinge of yellow to match the core colour.

--- a/pa11y/webapp/package.json
+++ b/pa11y/webapp/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@weco/pa11y",
   "scripts": {
+    "dev": "next",
+    "build": "next build",
+    "export": "next export",
     "write-report": "node write-report.js",
     "deploy": "node deploy.js"
   },


### PR DESCRIPTION
## Who is this for?
Devs

## What is it doing for them?
pa11y wasn't updating correctly since I'd removed some needed command lines in package.json. 

I'm also following the suggestion to tweak `neutral.600`:
So: `neutral.600` on `warmNeutral.200` annoyingly has a ratio of `4.497:1`, which gets flagged in pa11y as it wants `4.5:1`. The suggestion is to replace #6b6b6b with #6a6a6a, which I'm happy to go with since the goal is to use the `warmNeutrals` as background colours.
It's really, really close in looks; I suggest we amend if needed in the future, but as the luminosity stays the same as before (42%), I believe it still matches what we were trying to achieve.