### PR TITLE
Improve the way unusual opening hours are presented

### DIFF
--- a/common/utils/dates.ts
+++ b/common/utils/dates.ts
@@ -10,6 +10,10 @@ import { formatDayDate } from './format-date';
 //      new Date('2022-09-19T00:00:00Z')
 //    );
 //
+// If you're doing local debugging, you can also override the return value
+// to make the site think it's a different date, e.g. to test opening times.
+// (Note: this may not affect all parts of the site.)
+//
 export function today(): Date {
   return new Date();
 }

--- a/content/webapp/components/VenueHours/VenueHours.test.tsx
+++ b/content/webapp/components/VenueHours/VenueHours.test.tsx
@@ -1,0 +1,210 @@
+import {
+  DifferentToRegularTime,
+  OverrideDay,
+  UnusualOpeningHours,
+} from './VenueHours';
+import {
+  ExceptionalOpeningHoursDay,
+  OpeningHoursDay,
+} from '@weco/common/model/opening-hours';
+import { shallow } from 'enzyme';
+
+const closedMonday: OpeningHoursDay = {
+  dayOfWeek: 'Monday',
+  opens: '00:00',
+  closes: '00:00',
+  isClosed: true,
+};
+
+const openMonday: OpeningHoursDay = {
+  dayOfWeek: 'Monday',
+  opens: '10:00',
+  closes: '18:00',
+  isClosed: false,
+};
+
+const openExceptionalMonday: ExceptionalOpeningHoursDay = {
+  overrideDate: new Date('2022-12-26T00:00:00.000Z'),
+  overrideType: 'Christmas and New Year',
+  opens: '10:00',
+  closes: '18:00',
+  isClosed: false,
+};
+
+const closedExceptionalMonday: ExceptionalOpeningHoursDay = {
+  overrideDate: new Date('2022-12-26T00:00:00.000Z'),
+  overrideType: 'Christmas and New Year',
+  opens: '00:00',
+  closes: '00:00',
+  isClosed: true,
+};
+
+describe('UnusualOpeningHours', () => {
+  describe('Case 1: the venue is closed, and would have been on a regular day', () => {
+    it('renders a regular “Closed” time if the venue was already closed this day', () => {
+      const component = shallow(
+        <UnusualOpeningHours
+          regular={closedMonday}
+          exceptional={closedExceptionalMonday}
+        />
+      );
+
+      expect(
+        component.matchesElement(
+          <>
+            <OverrideDay>Monday 26 December</OverrideDay>
+            Closed
+          </>
+        )
+      ).toBe(true);
+    });
+  });
+
+  describe('Case 2: the venue is closed, and wouldn’t be on a regular day', () => {
+    it('marks “Closed” as unusual if the venue isn’t usually closed this day', () => {
+      const component = shallow(
+        <UnusualOpeningHours
+          regular={openMonday}
+          exceptional={closedExceptionalMonday}
+        />
+      );
+
+      expect(
+        component.matchesElement(
+          <>
+            <OverrideDay>Monday 26 December</OverrideDay>{' '}
+            <DifferentToRegularTime>Closed</DifferentToRegularTime>
+          </>
+        )
+      ).toBe(true);
+    });
+  });
+
+  describe('Case 3: the venue is open, but would normally be closed', () => {
+    it('marks the opening times as unusual if the venue isn’t usually open', () => {
+      const component = shallow(
+        <UnusualOpeningHours
+          regular={closedMonday}
+          exceptional={openExceptionalMonday}
+        />
+      );
+
+      expect(
+        component.matchesElement(
+          <>
+            <OverrideDay>Monday 26 December</OverrideDay>{' '}
+            <DifferentToRegularTime>10:00 – 18:00</DifferentToRegularTime>
+          </>
+        )
+      ).toBe(true);
+    });
+  });
+
+  describe('Case 4: the venue is open', () => {
+    it('doesn’t mark the opening times as unusual if they match a regular day', () => {
+      const component = shallow(
+        <UnusualOpeningHours
+          regular={openMonday}
+          exceptional={openExceptionalMonday}
+        />
+      );
+
+      // This and subsequent tests are a bit fragile and weird; for some reason the
+      // matchesElement() approach I used in the other tests doesn't work here.
+      expect(component.debug()).toBe(`<Fragment>
+  <VenueHours__OverrideDay>
+    Monday
+     
+    26 December
+  </VenueHours__OverrideDay>
+   
+  10:00
+   – 
+  18:00
+</Fragment>`);
+
+      //   expect(
+      //     component.matchesElement(
+      //       <>
+      //         <OverrideDay>Monday 26 December</OverrideDay> {'10:00 – 18:00'}
+      //       </>
+      //     )
+      //   ).toBe(true);
+    });
+
+    it('marks a non-standard opening time as unusual', () => {
+      const component = shallow(
+        <UnusualOpeningHours
+          regular={openMonday}
+          exceptional={{ ...openExceptionalMonday, opens: '02:00' }}
+        />
+      );
+
+      expect(component.debug()).toBe(`<Fragment>
+  <VenueHours__OverrideDay>
+    Monday
+     
+    26 December
+  </VenueHours__OverrideDay>
+   
+  <VenueHours__DifferentToRegularTime>
+    02:00
+  </VenueHours__DifferentToRegularTime>
+   – 
+  18:00
+</Fragment>`);
+    });
+
+    it('marks a non-standard closing time as unusual', () => {
+      const component = shallow(
+        <UnusualOpeningHours
+          regular={openMonday}
+          exceptional={{ ...openExceptionalMonday, closes: '23:00' }}
+        />
+      );
+
+      expect(component.debug()).toBe(`<Fragment>
+  <VenueHours__OverrideDay>
+    Monday
+     
+    26 December
+  </VenueHours__OverrideDay>
+   
+  10:00
+   – 
+  <VenueHours__DifferentToRegularTime>
+    23:00
+  </VenueHours__DifferentToRegularTime>
+</Fragment>`);
+    });
+
+    it('marks non-standard opening/closing times as both unusual', () => {
+      const component = shallow(
+        <UnusualOpeningHours
+          regular={openMonday}
+          exceptional={{
+            ...openExceptionalMonday,
+            opens: '02:00',
+            closes: '23:00',
+          }}
+        />
+      );
+
+      expect(component.debug()).toBe(`<Fragment>
+  <VenueHours__OverrideDay>
+    Monday
+     
+    26 December
+  </VenueHours__OverrideDay>
+   
+  <VenueHours__DifferentToRegularTime>
+    02:00
+  </VenueHours__DifferentToRegularTime>
+   – 
+  <VenueHours__DifferentToRegularTime>
+    23:00
+  </VenueHours__DifferentToRegularTime>
+</Fragment>`);
+    });
+  });
+});


### PR DESCRIPTION
## Who is this for?

Site visitors.

## What is it doing for them?

Making it easier to see what our unusual opening hours are, and how they deviate from our regular hours.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td>
<img width="765" alt="Screenshot 2022-10-21 at 21 08 34" src="https://user-images.githubusercontent.com/301220/197280787-fbf83d38-60ee-4f3c-9ec6-c91c6e147d0d.png">
</td>
<td>
<img width="765" alt="Screenshot 2022-10-21 at 21 08 28" src="https://user-images.githubusercontent.com/301220/197280801-87949817-62d8-427b-911c-e500cc13c595.png">
</td></tr></table>

This was inspired by the way Chris Burns’ internal email about opening times was using red boxes/text to highlight deviations from our regular hours, and some other recent work to make all the opening times line up nicely.

Plus I’m giving away one of my tricks – I've added a comment explaining how I can make the site time travel.