### PR TITLE
Add non-breaking spaces so labels and values appear on the same line

### DIFF
--- a/catalogue/webapp/components/WorksSearchResult/WorksSearchResult.tsx
+++ b/catalogue/webapp/components/WorksSearchResult/WorksSearchResult.tsx
@@ -94,13 +94,13 @@ const WorkSearchResultV2: FunctionComponent<Props> = ({
 
               {archiveLabels?.reference && (
                 <WorkInformationItem>
-                  Reference:&nbsp;{archiveLabels && archiveLabels?.reference}
+                  Reference:&nbsp;{archiveLabels?.reference}
                 </WorkInformationItem>
               )}
             </WorkInformation>
             {archiveLabels?.partOf && (
               <WorkInformation>
-                Part of:&nbsp;{archiveLabels && archiveLabels?.partOf}
+                Part of:&nbsp;{archiveLabels?.partOf}
               </WorkInformation>
             )}
           </Details>

--- a/catalogue/webapp/components/WorksSearchResult/WorksSearchResult.tsx
+++ b/catalogue/webapp/components/WorksSearchResult/WorksSearchResult.tsx
@@ -88,19 +88,19 @@ const WorkSearchResultV2: FunctionComponent<Props> = ({
 
               {productionDates.length > 0 && (
                 <WorkInformationItem>
-                  Date: {productionDates[0]}
+                  Date:&nbsp;{productionDates[0]}
                 </WorkInformationItem>
               )}
 
               {archiveLabels?.reference && (
                 <WorkInformationItem>
-                  Reference: {archiveLabels && archiveLabels?.reference}
+                  Reference:&nbsp;{archiveLabels && archiveLabels?.reference}
                 </WorkInformationItem>
               )}
             </WorkInformation>
             {archiveLabels?.partOf && (
               <WorkInformation>
-                Part of: {archiveLabels && archiveLabels?.partOf}
+                Part of:&nbsp;{archiveLabels && archiveLabels?.partOf}
               </WorkInformation>
             )}
           </Details>


### PR DESCRIPTION
e.g. I spotted this on my phone:

![IMG_1859](https://user-images.githubusercontent.com/301220/197394828-9072666b-9831-402f-84db-09ffc5ee3295.PNG)
