### PR TITLE
Group successes on the pa11y dashboard

### DIFF
--- a/dash/webapp/pages/pa11y.tsx
+++ b/dash/webapp/pages/pa11y.tsx
@@ -89,6 +89,9 @@ const Index: FunctionComponent = () => {
     })
     .sort((a, b) => b.score - a.score);
 
+  const successes = results.filter(({ score }) => score === 0);
+  const failures = results.filter(({ score }) => score > 0);
+
   return (
     <>
       <Head>
@@ -105,10 +108,11 @@ const Index: FunctionComponent = () => {
             style={{
               maxWidth: '600px',
               margin: '0 auto',
+              lineHeight: '1.3em',
             }}
           >
             <main>
-              {results.map(
+              {failures.map(
                 ({
                   documentTitle,
                   pageUrl,
@@ -132,41 +136,31 @@ const Index: FunctionComponent = () => {
                             marginBottom: '6px',
                           }}
                         >
-                          {documentTitle}
+                          {documentTitle.replace('| Wellcome Collection', '')}
                         </h3>
                       </OriginalPageLink>
-                      <div
-                        style={{
-                          display: 'flex',
-                        }}
-                      >
-                        {issues.length === 0 ? (
-                          <Issue type="success">No issues reported</Issue>
-                        ) : (
-                          issues.length > 1 && (
-                            <>
-                              {errors.length > 0 && (
-                                <Issue type="error">
-                                  {errors.length} error
-                                  {errors.length !== 1 ? 's' : ''}
-                                </Issue>
-                              )}
-                              {warnings.length > 0 && (
-                                <Issue type="error">
-                                  {warnings.length} warning
-                                  {warnings.length !== 1 ? 's' : ''}
-                                </Issue>
-                              )}
-                              {notices.length > 0 && (
-                                <Issue type="error">
-                                  {notices.length} notice
-                                  {notices.length !== 1 ? 's' : ''}
-                                </Issue>
-                              )}
-                            </>
-                          )
-                        )}
-                      </div>
+                      {issues.length > 1 && (
+                        <>
+                          {errors.length > 0 && (
+                            <Issue type="error">
+                              {errors.length} error
+                              {errors.length !== 1 ? 's' : ''}
+                            </Issue>
+                          )}
+                          {warnings.length > 0 && (
+                            <Issue type="error">
+                              {warnings.length} warning
+                              {warnings.length !== 1 ? 's' : ''}
+                            </Issue>
+                          )}
+                          {notices.length > 0 && (
+                            <Issue type="error">
+                              {notices.length} notice
+                              {notices.length !== 1 ? 's' : ''}
+                            </Issue>
+                          )}
+                        </>
+                      )}
 
                       {issues.map(issue => {
                         return (
@@ -192,6 +186,31 @@ const Index: FunctionComponent = () => {
                     </section>
                   );
                 }
+              )}
+
+              {successes.length > 0 && (
+                <section
+                  key="successes"
+                  style={{
+                    marginTop: '18px',
+                    padding: '6px 0',
+                    borderTop: '1px solid #d9d6ce',
+                  }}
+                >
+                  <Issue type="success">
+                    No issues reported on the following pages.
+                  </Issue>
+
+                  <ul>
+                    {successes.map(({ pageUrl, documentTitle }) => (
+                      <li key={pageUrl}>
+                        <OriginalPageLink href={pageUrl}>
+                          {documentTitle.replace('| Wellcome Collection', '')}
+                        </OriginalPageLink>
+                      </li>
+                    ))}
+                  </ul>
+                </section>
               )}
             </main>
           </div>


### PR DESCRIPTION
In the current version of the pa11y dashboard, you have to scroll through the whole list to check there are no issues – unless you know errors rise to the top, but that's not obvious.

This groups all the successes at the bottom of the page in a section titled "No issues reported on the following pages", so when everything is working it'll be super quick to review the dashboard. The whole thing is now visible without scrolling:

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img width="1306" alt="Screenshot 2022-10-23 at 21 29 23" src="https://user-images.githubusercontent.com/301220/197416805-f35a5cc4-f010-40a3-8348-2e6cf942c8c0.png">
</td>
<td>
<img width="1306" alt="Screenshot 2022-10-23 at 21 29 25" src="https://user-images.githubusercontent.com/301220/197416808-cce3cceb-b53e-40cc-8293-4350744bdbfe.png">
</td>
</tr>
</table>