### PR TITLE
Introduce a WorkBasic type

### DIFF
--- a/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
+++ b/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
@@ -10,7 +10,11 @@ import styled from 'styled-components';
 
 import { convertImageUri } from '@weco/common/utils/convert-image-uri';
 import { hexToRgb } from '@weco/common/utils/convert-colors';
-import { Image, CatalogueResultsList } from '@weco/common/model/catalogue';
+import {
+  Image,
+  CatalogueResultsList,
+  ImageAggregations,
+} from '@weco/common/model/catalogue';
 import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
 
 import ExpandedImage from '../ExpandedImage/ExpandedImage';
@@ -19,7 +23,7 @@ import Modal from '@weco/common/views/components/Modal/Modal';
 import Space from '@weco/common/views/components/styled/Space';
 
 type Props = {
-  images: CatalogueResultsList<Image>;
+  images: CatalogueResultsList<Image, ImageAggregations>;
   background?: string;
 };
 

--- a/catalogue/webapp/components/WorkHeader/WorkHeader.tsx
+++ b/catalogue/webapp/components/WorkHeader/WorkHeader.tsx
@@ -30,7 +30,7 @@ const WorkHeader: FunctionComponent<Props> = ({
 }: Props): ReactElement<Props> => {
   const productionDates = getProductionDates(work);
   const archiveLabels = getArchiveLabels(work);
-  const cardLabels = getCardLabels(work);
+  const cardLabels = getCardLabels(work.workType, work.availabilities || []);
   const manifestData = useTransformedManifest(work);
   const { collectionManifestsCount } = manifestData;
 

--- a/catalogue/webapp/components/WorksSearchResult/WorksSearchResult.tsx
+++ b/catalogue/webapp/components/WorksSearchResult/WorksSearchResult.tsx
@@ -1,14 +1,7 @@
 import { FunctionComponent } from 'react';
-
-// Types
-import { Work } from '@weco/common/model/catalogue';
+import { WorkBasic } from 'services/catalogue/types/works';
 
 // Helpers/Utils
-import {
-  getArchiveLabels,
-  getProductionDates,
-  getCardLabels,
-} from '../../utils/works';
 import { convertIiifImageUri } from '@weco/common/utils/convert-image-uri';
 
 // Components
@@ -26,30 +19,25 @@ import {
   WorkInformationItem,
   WorkTitleHeading,
 } from './WorksSearchResult.styles';
+import { getCardLabels } from 'utils/works';
 
 type Props = {
-  work: Work;
+  work: WorkBasic;
   resultPosition: number;
 };
 
 // TODO: remove, hack to handle the fact that we are pulling through PDF thumbnails.
 // These will be removed from the API at some stage.
-function isPdfThumbnail(thumbnail): boolean {
+function isPdfThumbnail(thumbnailUrl: string): boolean {
   // e.g. https://dlcs.io/iiif-img/wellcome/5/b28820769_WG_2006_PAAG-implementing-persistent-identifiers_EN.pdf/full/!200,200/0/default.jpg
-  return Boolean(thumbnail.url.match('.pdf/full'));
+  return Boolean(thumbnailUrl.match('.pdf/full'));
 }
 
 const WorkSearchResultV2: FunctionComponent<Props> = ({
   work,
   resultPosition,
 }: Props) => {
-  const productionDates = getProductionDates(work);
-  const archiveLabels = getArchiveLabels(work);
-  const cardLabels = getCardLabels(work);
-
-  const primaryContributorLabel = work.contributors.find(
-    contributor => contributor.primary
-  )?.agent.label;
+  const cardLabels = getCardLabels(work.workType, work.availabilities);
 
   return (
     <WorkLink
@@ -60,11 +48,11 @@ const WorkSearchResultV2: FunctionComponent<Props> = ({
     >
       <Wrapper as="a">
         <Container>
-          {work.thumbnail && !isPdfThumbnail(work.thumbnail) && (
+          {work.thumbnailUrl && !isPdfThumbnail(work.thumbnailUrl) && (
             <Preview>
               <PreviewImage
                 alt={`view ${work.title}`}
-                src={convertIiifImageUri(work.thumbnail.url, 120)}
+                src={convertIiifImageUri(work.thumbnailUrl, 120)}
               />
             </Preview>
           )}
@@ -80,28 +68,26 @@ const WorkSearchResultV2: FunctionComponent<Props> = ({
             </WorkTitleHeading>
 
             <WorkInformation>
-              {primaryContributorLabel && (
+              {work.primaryContributors.length > 0 && (
                 <WorkInformationItem>
-                  {primaryContributorLabel}
+                  {work.primaryContributors[0].label}
                 </WorkInformationItem>
               )}
 
-              {productionDates.length > 0 && (
+              {work.productionDates.length > 0 && (
                 <WorkInformationItem>
-                  Date:&nbsp;{productionDates[0]}
+                  Date:&nbsp;{work.productionDates[0]}
                 </WorkInformationItem>
               )}
 
-              {archiveLabels?.reference && (
+              {work.reference && (
                 <WorkInformationItem>
-                  Reference:&nbsp;{archiveLabels?.reference}
+                  Reference:&nbsp;{work.reference}
                 </WorkInformationItem>
               )}
             </WorkInformation>
-            {archiveLabels?.partOf && (
-              <WorkInformation>
-                Part of:&nbsp;{archiveLabels?.partOf}
-              </WorkInformation>
+            {work.partOf && (
+              <WorkInformation>Part of:&nbsp;{work.partOf}</WorkInformation>
             )}
           </Details>
         </Container>

--- a/catalogue/webapp/components/WorksSearchResults/WorksSearchResults.tsx
+++ b/catalogue/webapp/components/WorksSearchResults/WorksSearchResults.tsx
@@ -1,10 +1,14 @@
 import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 import WorksSearchResult from '../WorksSearchResult/WorksSearchResult';
-import { CatalogueResultsList, Work } from '@weco/common/model/catalogue';
+import {
+  CatalogueResultsList,
+  WorkAggregations,
+} from '@weco/common/model/catalogue';
+import { WorkBasic } from '../../services/catalogue/types/works';
 
 type Props = {
-  works: CatalogueResultsList<Work>;
+  works: CatalogueResultsList<WorkBasic, WorkAggregations>;
 };
 
 const SearchResultUnorderedList = styled.ul`

--- a/catalogue/webapp/pages/concept.tsx
+++ b/catalogue/webapp/pages/concept.tsx
@@ -27,7 +27,8 @@ import {
   Concept as ConceptType,
   IdentifierType,
   Image as ImageType,
-  Work as WorkType,
+  ImageAggregations,
+  WorkAggregations,
 } from '@weco/common/model/catalogue';
 
 // Styles
@@ -37,13 +38,15 @@ import Space from '@weco/common/views/components/styled/Space';
 import TabNav from '@weco/common/views/components/TabNav/TabNav';
 import { font } from '@weco/common/utils/classnames';
 import { ApiToolbarLink } from '@weco/common/views/components/ApiToolbar/ApiToolbar';
+import { transformWorkToWorkBasic } from '../services/catalogue/transformers/works';
+import { WorkBasic } from '../services/catalogue/types/works';
 
 type Props = {
   conceptResponse: ConceptType;
-  worksAbout: CatalogueResultsList<WorkType> | undefined;
-  worksBy: CatalogueResultsList<WorkType> | undefined;
-  imagesAbout: CatalogueResultsList<ImageType> | undefined;
-  imagesBy: CatalogueResultsList<ImageType> | undefined;
+  worksAbout: CatalogueResultsList<WorkBasic, WorkAggregations> | undefined;
+  worksBy: CatalogueResultsList<WorkBasic, WorkAggregations> | undefined;
+  imagesAbout: CatalogueResultsList<ImageType, ImageAggregations> | undefined;
+  imagesBy: CatalogueResultsList<ImageType, ImageAggregations> | undefined;
   apiToolbarLinks: ApiToolbarLink[];
 };
 
@@ -432,9 +435,19 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     ]);
 
     const worksAbout =
-      worksAboutResponse.type === 'Error' ? undefined : worksAboutResponse;
+      worksAboutResponse.type === 'Error'
+        ? undefined
+        : {
+            ...worksAboutResponse,
+            results: worksAboutResponse.results.map(transformWorkToWorkBasic),
+          };
     const worksBy =
-      worksByResponse.type === 'Error' ? undefined : worksByResponse;
+      worksByResponse.type === 'Error'
+        ? undefined
+        : {
+            ...worksByResponse,
+            results: worksByResponse.results.map(transformWorkToWorkBasic),
+          };
     const imagesAbout =
       imagesAboutResponse.type === 'Error' ? undefined : imagesAboutResponse;
     const imagesBy =

--- a/catalogue/webapp/pages/images.tsx
+++ b/catalogue/webapp/pages/images.tsx
@@ -2,7 +2,11 @@ import { GetServerSideProps, NextPage } from 'next';
 import { useEffect, useState, ReactElement, useContext } from 'react';
 import Router from 'next/router';
 import Head from 'next/head';
-import { CatalogueResultsList, Image } from '@weco/common/model/catalogue';
+import {
+  CatalogueResultsList,
+  Image,
+  ImageAggregations,
+} from '@weco/common/model/catalogue';
 import { grid } from '@weco/common/utils/classnames';
 import convertUrlToString from '@weco/common/utils/convert-url-to-string';
 import CataloguePageLayout from '../components/CataloguePageLayout/CataloguePageLayout';
@@ -28,7 +32,7 @@ import { pageDescriptions } from '@weco/common/data/microcopy';
 import styled from 'styled-components';
 
 type Props = {
-  images?: CatalogueResultsList<Image>;
+  images?: CatalogueResultsList<Image, ImageAggregations>;
   imagesRouteProps: ImagesProps;
   pageview: Pageview;
 };
@@ -36,7 +40,7 @@ type Props = {
 type ImagesPaginationProps = {
   query?: string;
   page: number;
-  results: CatalogueResultsList<Image>;
+  results: CatalogueResultsList<Image, ImageAggregations>;
   imagesRouteProps: ImagesProps;
   hideMobilePagination?: boolean;
   hideMobileTotalResults?: boolean;

--- a/catalogue/webapp/pages/search/images.tsx
+++ b/catalogue/webapp/pages/search/images.tsx
@@ -24,11 +24,15 @@ import { getServerData } from '@weco/common/server-data';
 import { getSearchLayout } from 'components/SearchPageLayout/SearchPageLayout';
 
 // Types
-import { CatalogueResultsList, Image } from '@weco/common/model/catalogue';
+import {
+  CatalogueResultsList,
+  Image,
+  ImageAggregations,
+} from '@weco/common/model/catalogue';
 import { NextPageWithLayout } from '@weco/common/views/pages/_app';
 
 type Props = {
-  images?: CatalogueResultsList<Image>;
+  images?: CatalogueResultsList<Image, ImageAggregations>;
   imagesRouteProps: ImagesProps;
   pageview: Pageview;
 };

--- a/catalogue/webapp/services/catalogue/concepts.ts
+++ b/catalogue/webapp/services/catalogue/concepts.ts
@@ -52,6 +52,6 @@ export async function getConcept({
 
 export async function getConcepts(
   props: QueryProps<CatalogueConceptsApiProps>
-): Promise<CatalogueResultsList<Concept> | CatalogueApiError> {
+): Promise<CatalogueResultsList<Concept, null> | CatalogueApiError> {
   return catalogueQuery('concepts', props);
 }

--- a/catalogue/webapp/services/catalogue/images.ts
+++ b/catalogue/webapp/services/catalogue/images.ts
@@ -2,6 +2,7 @@ import {
   CatalogueApiError,
   CatalogueResultsList,
   Image,
+  ImageAggregations,
 } from '@weco/common/model/catalogue';
 import { CatalogueImagesApiProps } from '@weco/common/services/catalogue/api';
 import {
@@ -46,7 +47,7 @@ type GetImageProps = {
  */
 export async function getImages(
   props: QueryProps<CatalogueImagesApiProps>
-): Promise<CatalogueResultsList<Image> | CatalogueApiError> {
+): Promise<CatalogueResultsList<Image, ImageAggregations> | CatalogueApiError> {
   const params: ImagesProps = {
     ...emptyImagesProps,
     ...props.params,

--- a/catalogue/webapp/services/catalogue/index.ts
+++ b/catalogue/webapp/services/catalogue/index.ts
@@ -74,10 +74,10 @@ export type QueryProps<Params> = {
   toggles: Toggles;
 };
 
-export async function catalogueQuery<Params, Result extends ResultType>(
+export async function catalogueQuery<Params, Result, Aggregations>(
   endpoint: string,
   { params, toggles, pageSize }: QueryProps<Params>
-): Promise<CatalogueResultsList<Result> | CatalogueApiError> {
+): Promise<CatalogueResultsList<Result, Aggregations> | CatalogueApiError> {
   const apiOptions = globalApiOptions(toggles);
 
   const extendedParams = {

--- a/catalogue/webapp/services/catalogue/transformers/works.ts
+++ b/catalogue/webapp/services/catalogue/transformers/works.ts
@@ -1,0 +1,21 @@
+import { Work } from '@weco/common/model/catalogue';
+import { getArchiveLabels, getProductionDates } from 'utils/works';
+import { WorkBasic } from '@weco/common/services/catalogue/types/works';
+
+export function transformWorkToWorkBasic(work: Work): WorkBasic {
+  const archiveLabels = getArchiveLabels(work);
+
+  return {
+    id: work.id,
+    title: work.title,
+    reference: archiveLabels?.reference,
+    productionDates: getProductionDates(work),
+    thumbnailUrl: work.thumbnail?.url,
+    partOf: archiveLabels?.partOf,
+    workType: { label: work.workType.label },
+    availabilities: (work.availabilities || []).map(({ id }) => ({ id })),
+    primaryContributors: work.contributors
+      .filter(c => c.primary === true)
+      .map(({ agent }) => ({ label: agent.label })),
+  };
+}

--- a/catalogue/webapp/services/catalogue/types/works.ts
+++ b/catalogue/webapp/services/catalogue/types/works.ts
@@ -1,0 +1,11 @@
+export type WorkBasic = {
+  id: string;
+  title: string;
+  reference: string | undefined;
+  productionDates: string[];
+  thumbnailUrl: string | undefined;
+  partOf: string | undefined;
+  workType: { label: string };
+  availabilities: { id: string }[];
+  primaryContributors: { label: string }[];
+};

--- a/catalogue/webapp/services/catalogue/works.ts
+++ b/catalogue/webapp/services/catalogue/works.ts
@@ -4,6 +4,7 @@ import {
   CatalogueResultsList,
   ItemsList,
   Work,
+  WorkAggregations,
 } from '@weco/common/model/catalogue';
 import { IIIFCanvas } from '../../services/iiif/types/manifest/v2';
 import { CatalogueWorksApiProps } from '@weco/common/services/catalogue/api';
@@ -98,7 +99,7 @@ function toIsoDateString(
  */
 export async function getWorks(
   props: QueryProps<CatalogueWorksApiProps>
-): Promise<CatalogueResultsList<Work> | CatalogueApiError> {
+): Promise<CatalogueResultsList<Work, WorkAggregations> | CatalogueApiError> {
   const params: WorksProps = {
     ...emptyWorksProps,
     ...props.params,

--- a/catalogue/webapp/utils/works.ts
+++ b/catalogue/webapp/utils/works.ts
@@ -243,8 +243,8 @@ type ArchiveLabels = {
   partOf?: string;
 };
 
-export const isAvailableOnline = (work: Work): boolean =>
-  (work.availabilities ?? []).some(({ id }) => id === 'online');
+const isAvailableOnline = (availabilities: { id: string }[]): boolean =>
+  (availabilities ?? []).some(({ id }) => id === 'online');
 
 const getArchiveRoot = (work: RelatedWork): RelatedWork =>
   work?.partOf?.[0] ? getArchiveRoot(work.partOf[0]) : work;
@@ -260,9 +260,12 @@ export const getArchiveLabels = (work: Work): ArchiveLabels | undefined => {
   return undefined;
 };
 
-export const getCardLabels = (work: Work): Label[] => {
-  const cardLabels = [{ text: work.workType.label }];
-  if (isAvailableOnline(work)) {
+export const getCardLabels = (
+  workType: { label: string },
+  availabilities: { id: string }[]
+): Label[] => {
+  const cardLabels = [{ text: workType.label }];
+  if (isAvailableOnline(availabilities)) {
     return [...cardLabels, { text: 'Online', labelColor: 'white' }];
   } else {
     return cardLabels;

--- a/common/model/catalogue.ts
+++ b/common/model/catalogue.ts
@@ -328,11 +328,9 @@ export type ImageAggregations = {
   type: 'Aggregations';
 };
 
-type ConceptAggregations = null;
-
 export type ResultType = Work | Image | Concept;
 
-export type CatalogueResultsList<Result extends ResultType> = {
+export type CatalogueResultsList<Result, Aggregation> = {
   type: 'ResultList';
   totalResults: number;
   totalPages: number;
@@ -340,13 +338,7 @@ export type CatalogueResultsList<Result extends ResultType> = {
   pageSize: number;
   prevPage: string | null;
   nextPage: string | null;
-  aggregations?: Result extends Work
-    ? WorkAggregations
-    : Result extends Image
-    ? ImageAggregations
-    : Result extends Concept
-    ? ConceptAggregations
-    : null;
+  aggregations?: Aggregation;
 
   // We include the URL used to fetch data from the catalogue API for
   // debugging purposes.

--- a/common/services/catalogue/filters.ts
+++ b/common/services/catalogue/filters.ts
@@ -1,5 +1,5 @@
 import { palette } from '../../views/components/PaletteColorPicker/PaletteColorPicker';
-import { CatalogueResultsList, Work, Image } from '../../model/catalogue';
+import { WorkAggregations, ImageAggregations } from '../../model/catalogue';
 import { quoteVal } from '../../utils/csv';
 import { toHtmlId } from '../../utils/string';
 import { ImagesProps } from '../../views/components/ImagesLink/ImagesLink';
@@ -114,12 +114,12 @@ export const filterLabel = ({
 }): string => (count ? `${label} (${count})` : label);
 
 type WorksFilterProps = {
-  works: CatalogueResultsList<Work>;
+  works: { aggregations?: WorkAggregations };
   props: WorksProps;
 };
 
 type ImagesFilterProps = {
-  images: CatalogueResultsList<Image>;
+  images: { aggregations?: ImageAggregations };
   props: ImagesProps;
 };
 

--- a/common/services/catalogue/types/works.ts
+++ b/common/services/catalogue/types/works.ts
@@ -1,0 +1,11 @@
+export type WorkBasic = {
+  id: string;
+  title: string;
+  reference: string | undefined;
+  productionDates: string[];
+  thumbnailUrl: string | undefined;
+  partOf: string | undefined;
+  workType: { label: string };
+  availabilities: { id: string }[];
+  primaryContributors: { label: string }[];
+};


### PR DESCRIPTION
Previously we'd proxy the entire catalogue API result when showing a list of works, which is very inefficient -- we use a tiny subset of the data, and load a lot of works.

In the same style as the Prismic code in the content app, this introduces a WorkBasic type that just contains the minimal set of fields to show a search result, and throws away everything else.

<table>
<tr>
<th></th>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>/works</td>
<td>541.84 kB</td>
<td>485.31 kB (&minus;10%)</td>
</tr>
<tr>
<td>/concept/v3m7uhy9</td>
<td>223.73 kB</td>
<td>187.92 kB (&minus;16%)</td>
</tr>
</table>

It also continues the gradual adoption of the fetch/transform/types pattern which we already have for Prismic and which Gareth has been adding for IIIF.

## Who is this for?

Users.

## What is it doing for them?

Making pages load faster.

This closes https://github.com/wellcomecollection/wellcomecollection.org/issues/8339; I picked it off because I had ten minutes before a meeting and prod Archivematica is a bit borked, waiting for D&T to sort it out.