### PR TITLE
Fix image titles in the expanded image modal

### DIFF
--- a/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
+++ b/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
@@ -207,21 +207,25 @@ const ExpandedImage: FunctionComponent<Props> = ({
         </ImageWrapper>
       )}
       <InfoWrapper>
-        <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
-          <h2
-            className={`${font('intb', 3)} no-margin`}
-            dangerouslySetInnerHTML={{ __html: displayTitle }}
-          />
-          {displayContributor && (
-            <Space
-              as="h3"
-              v={{ size: 's', properties: ['margin-top'] }}
-              className={font('intb', 5)}
-            >
-              {displayContributor}
-            </Space>
-          )}
-        </Space>
+        {(displayTitle || displayContributor) && (
+          <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
+            {displayTitle && (
+              <h2
+                className={`${font('intb', 3)} no-margin`}
+                dangerouslySetInnerHTML={{ __html: displayTitle }}
+              />
+            )}
+            {displayContributor && (
+              <Space
+                as="h3"
+                v={{ size: 's', properties: ['margin-top'] }}
+                className={font('intb', 5)}
+              >
+                {displayContributor}
+              </Space>
+            )}
+          </Space>
+        )}
         {license && (
           <Space
             className={font('intr', 5)}

--- a/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
+++ b/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
@@ -207,12 +207,12 @@ const ExpandedImage: FunctionComponent<Props> = ({
         </ImageWrapper>
       )}
       <InfoWrapper>
-        {displayContributor && (
-          <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
-            <h2
-              className={`${font('intb', 3)} no-margin`}
-              dangerouslySetInnerHTML={{ __html: displayTitle }}
-            />
+        <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
+          <h2
+            className={`${font('intb', 3)} no-margin`}
+            dangerouslySetInnerHTML={{ __html: displayTitle }}
+          />
+          {displayContributor && (
             <Space
               as="h3"
               v={{ size: 's', properties: ['margin-top'] }}
@@ -220,8 +220,8 @@ const ExpandedImage: FunctionComponent<Props> = ({
             >
               {displayContributor}
             </Space>
-          </Space>
-        )}
+          )}
+        </Space>
         {license && (
           <Space
             className={font('intr', 5)}

--- a/catalogue/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.tsx
+++ b/catalogue/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.tsx
@@ -36,7 +36,7 @@ const VisuallySimilarImagesFromApi: FunctionComponent<Props> = ({
 
   useEffect(() => {
     const fetchVisuallySimilarImages = async () => {
-      const fullImage = await getImage({
+      const { image: fullImage } = await getImage({
         id: originalId,
         toggles,
         include: ['visuallySimilar'],

--- a/catalogue/webapp/pages/image.tsx
+++ b/catalogue/webapp/pages/image.tsx
@@ -19,11 +19,16 @@ import { createDefaultTransformedManifest } from '../types/manifest';
 
 type Props = {
   image: Image;
+  catalogueApiUrl: string;
   sourceWork: Work;
   pageview: Pageview;
 };
 
-const ImagePage: FunctionComponent<Props> = ({ image, sourceWork }: Props) => {
+const ImagePage: FunctionComponent<Props> = ({
+  image,
+  sourceWork,
+  catalogueApiUrl,
+}) => {
   const title = sourceWork.title || '';
   const iiifImageLocation = image.locations[0];
 
@@ -55,6 +60,12 @@ const ImagePage: FunctionComponent<Props> = ({ image, sourceWork }: Props) => {
   const lang =
     (sourceWork.languages.length === 1 && sourceWork?.languages[0]?.id) || '';
 
+  const apiLink = {
+    id: 'json',
+    label: 'JSON',
+    link: catalogueApiUrl,
+  };
+
   return (
     <CataloguePageLayout
       title={title}
@@ -66,6 +77,7 @@ const ImagePage: FunctionComponent<Props> = ({ image, sourceWork }: Props) => {
       openGraphType="website"
       jsonLd={{ '@type': 'WebPage' }}
       siteSection="collections"
+      apiToolbarLinks={[apiLink]}
       hideNewsletterPromo={true}
       hideFooter={true}
       hideTopContent={true}
@@ -106,7 +118,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       return { notFound: true };
     }
 
-    const image = await getImage({
+    const { url: catalogueApiUrl, image } = await getImage({
       id,
       toggles: serverData.toggles,
     });
@@ -149,6 +161,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     return {
       props: removeUndefinedProps({
         image,
+        catalogueApiUrl: catalogueApiUrl!,
         sourceWork: work,
         pageview: {
           name: 'image',

--- a/catalogue/webapp/services/catalogue/images.ts
+++ b/catalogue/webapp/services/catalogue/images.ts
@@ -62,13 +62,18 @@ export async function getImages(
   return catalogueQuery('images', { ...props, params: extendedParams });
 }
 
+type ImageResponse = {
+  url?: string;
+  image: Image | CatalogueApiError;
+};
+
 export async function getImage({
   id,
   toggles,
   include = [],
-}: GetImageProps): Promise<Image | CatalogueApiError> {
+}: GetImageProps): Promise<ImageResponse> {
   if (!looksLikeCanonicalId(id)) {
-    return notFound();
+    return { image: notFound() };
   }
 
   const apiOptions = globalApiOptions(toggles);
@@ -86,12 +91,13 @@ export async function getImage({
   const res = await catalogueFetch(url);
 
   if (res.status === 404) {
-    return notFound();
+    return { image: notFound() };
   }
 
   try {
-    return await res.json();
+    const image = await res.json();
+    return { url, image };
   } catch (e) {
-    return catalogueApiError();
+    return { url, image: catalogueApiError() };
   }
 }


### PR DESCRIPTION
A recent refactor in ExpandedImage moved the conditional around and introduced what looks like a bug:

```diff
diff --git a/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx b/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
index 48ca44a89..51b990cf1 100644
--- a/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
+++ b/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
@@ -207,12 +207,12 @@ const ExpandedImage: FunctionComponent<Props> = ({
         </ImageWrapper>
       )}
       <InfoWrapper>
-        <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
-          <h2
-            className={`${font('intb', 3)} no-margin`}
-            dangerouslySetInnerHTML={{ __html: displayTitle }}
-          />
-          {displayContributor && (
+        {displayContributor && (
+          <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
+            <h2
+              className={`${font('intb', 3)} no-margin`}
+              dangerouslySetInnerHTML={{ __html: displayTitle }}
+            />
             <Space
               as="h3"
               v={{ size: 's', properties: ['margin-top'] }}
@@ -220,8 +220,8 @@ const ExpandedImage: FunctionComponent<Props> = ({
             >
               {displayContributor}
             </Space>
-          )}
-        </Space>
+          </Space>
+        )}
         {license && (
           <Space
             className={font('intr', 5)}
```

By moving the conditional on `displayContributor` up a level, we no longer display titles on images which don't have a displayContributor; this seems wrong.

This patch:

* Adds a couple of Playwright tests for title/contributor on the expanded image modal. These will catch a similar regression in future.
* Fix the ExpandedImage component so it displays titles if there are no contributors. I did consider testing this component directly, but you have to mock the `fetch()` that goes to the catalogue API, and that was more effort than I was willing to spend.
* Add a link to the images API from the API toolbar – I was initially wondering if maybe this was a data issue.