### PR TITLE
Include transformedManifest as a dep for the currentManifestLabel

### DIFF
--- a/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
@@ -339,7 +339,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
       matchingManifest?.label &&
       getEnFromInternationalString(matchingManifest.label, 1);
     manifestLabel && setCurrentManifestLabel(manifestLabel);
-  }, [parentManifest]);
+  }, [transformedManifest]);
 
   const iiifPresentationLocation = getDigitalLocationOfType(
     work,


### PR DESCRIPTION
Fixing broken e2e tests. Without this dependency, the `currentManifestLabel` will stick on whatever is rendered first, rather than updating when a user navigates to a different volume.