### PR TITLE
Don't show exhibitions twice on the homepage

### DIFF
--- a/content/webapp/services/prismic/transformers/card.ts
+++ b/content/webapp/services/prismic/transformers/card.ts
@@ -3,11 +3,14 @@ import { transformImage } from '@weco/common/services/prismic/transformers/image
 import { Card } from '../../../types/card';
 import { asText, asTitle, transformFormat } from '.';
 import { transformLink } from '@weco/common/services/prismic/transformers';
+import { isFilledLinkToDocument } from '@weco/common/services/prismic/types';
+
 export function transformCard(document: CardPrismicDocument): Card {
   const { title, description, image, link } = document.data;
 
   return {
     type: 'card',
+    id: isFilledLinkToDocument(link) ? link.id : undefined,
     title: asTitle(title),
     format: transformFormat(document),
     description: asText(description),

--- a/content/webapp/types/card.ts
+++ b/content/webapp/types/card.ts
@@ -15,6 +15,7 @@ import { ExhibitionGuide, ExhibitionGuideBasic } from './exhibition-guides';
 
 export type Card = {
   type: 'card';
+  id?: string;
   format?: Format;
   title?: string;
   description?: string;


### PR DESCRIPTION
Danny has pointed out that "In Plain Sight" is appearing twice on the homepage -- once as the top item in the header, once in the list of current exhibitions and events.

This PR adds a filter so if we're featuring an event/exhibition in the top spot, it won't appear again in the list.

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img width="686" alt="Screenshot 2022-10-26 at 18 00 06" src="https://user-images.githubusercontent.com/301220/198089101-78d75f84-55f3-4c1a-83f0-cdc12f5368d8.png">
</td>
<td>
<img width="686" alt="Screenshot 2022-10-26 at 18 00 54" src="https://user-images.githubusercontent.com/301220/198089135-d76896f6-9ddc-4ad4-ad24-b3cc5af143d5.png">
</td>
</tr>
</table>