### PR TITLE
return notFound if searchPage toggles not activated

### DIFF
--- a/catalogue/webapp/pages/search/catalogue.tsx
+++ b/catalogue/webapp/pages/search/catalogue.tsx
@@ -81,6 +81,11 @@ CatalogueSearchPage.getLayout = getSearchLayout;
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
     const serverData = await getServerData(context);
+
+    if (!serverData.toggles.searchPage) {
+      return { notFound: true };
+    }
+
     const props = fromQuery(context.query);
 
     const aggregations = [

--- a/catalogue/webapp/pages/search/images.tsx
+++ b/catalogue/webapp/pages/search/images.tsx
@@ -113,6 +113,11 @@ ImagesSearchPage.getLayout = getSearchLayout;
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
     const serverData = await getServerData(context);
+
+    if (!serverData.toggles.searchPage) {
+      return { notFound: true };
+    }
+
     const params = fromQuery(context.query);
     const aggregations = [
       'locations.license',


### PR DESCRIPTION
## Who is this for?
Us not wanting people to have access to search pages

## What is it doing for them?
Re-adds the toggle check in the serverSideProps, it was removed by accident in a prior PR.