### PR TITLE
Change selector for colorswatch tests

### DIFF
--- a/common/views/components/PaletteColorPicker/PaletteColorPicker.tsx
+++ b/common/views/components/PaletteColorPicker/PaletteColorPicker.tsx
@@ -165,6 +165,7 @@ const PaletteColorPicker: FunctionComponent<Props> = ({
         {palette.map(swatch => (
           <Swatch
             key={swatch.hexValue}
+            id={`swatch-${swatch.colorName.toLowerCase()}`}
             hexColor={swatch.hexValue}
             ariaPressed={colorState === swatch.hexValue}
             onClick={() => setColorState(swatch.hexValue)}

--- a/playwright/test/selectors/images.ts
+++ b/playwright/test/selectors/images.ts
@@ -4,7 +4,7 @@ import { mobileModal, searchResultsContainer } from './search';
 export const searchImagesForm =
   'form[aria-describedby="images-form-description"]';
 export const colourSelectorFilterDropDown = `${searchImagesForm} button[aria-controls="images.color"]`;
-export const colourSelector = 'button[color="8b572a"]';
+export const colourSelector = 'button[id="swatch-green"]';
 
 // results list
 export const imagesResultsListItem = `${searchResultsContainer} li[role="listitem"]`;


### PR DESCRIPTION
## Who is this for?
Failing E2Es

## What is it doing for them?
The selector was `color={hexValue}`, but we moved away from having `color` printed in the DOM. I added a unique ID alongside, and used that as a selector in the test instead.