### PR TITLE
Move results to page content, change works url

### DIFF
--- a/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
+++ b/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
@@ -109,32 +109,32 @@ const SearchLayout: FunctionComponent = ({ children }) => {
             {
               id: 'overview',
               url: getURL('/search'),
-              name: 'Overview (1032)',
+              name: 'Overview',
             },
             {
               id: 'exhibitions',
               url: getURL('/search/exhibitions'),
-              name: 'Exhibitions (1032)',
+              name: 'Exhibitions',
             },
             {
               id: 'events',
               url: getURL('/search/events'),
-              name: 'Events (1032)',
+              name: 'Events',
             },
             {
               id: 'stories',
               url: getURL('/search/stories'),
-              name: 'Stories (1032)',
+              name: 'Stories',
             },
             {
               id: 'images',
               url: getURL('/search/images'),
-              name: 'Images (1032)',
+              name: 'Images',
             },
             {
-              id: 'catalogue',
-              url: getURL('/search/catalogue'),
-              name: 'Catalogue (1032)',
+              id: 'works',
+              url: getURL('/search/works'),
+              name: 'Catalogue',
             },
           ]}
           currentSection={currentSearchCategory}

--- a/catalogue/webapp/pages/search/images.tsx
+++ b/catalogue/webapp/pages/search/images.tsx
@@ -40,9 +40,10 @@ const Wrapper = styled(Space).attrs({
   background-color: ${props => props.theme.color('black')};
 `;
 
-const PaginationWrapper = styled.div`
+const ResultsPaginationWrapper = styled.div`
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
+  align-items: center;
 `;
 
 const ImagesSearchPage: NextPageWithLayout<Props> = ({
@@ -56,6 +57,8 @@ const ImagesSearchPage: NextPageWithLayout<Props> = ({
     const link = toLink({ ...imagesRouteProps }, 'images_search_context');
     setLink(link);
   }, [imagesRouteProps]);
+
+  const showSort = true;
 
   return (
     <>
@@ -84,6 +87,7 @@ const ImagesSearchPage: NextPageWithLayout<Props> = ({
       <div className="container">
         <Space v={{ size: 'l', properties: ['padding-top', 'padding-bottom'] }}>
           <h2 style={{ marginBottom: 0 }}>Filters</h2>
+          {showSort && <div>Sort Component?</div>}
         </Space>
       </div>
 
@@ -97,9 +101,12 @@ const ImagesSearchPage: NextPageWithLayout<Props> = ({
               }}
               style={{ color: 'white' }}
             >
-              <PaginationWrapper>
+              <ResultsPaginationWrapper>
+                {images.totalResults > 0 && (
+                  <div>{images.totalResults} results</div>
+                )}
                 <SearchPagination totalPages={images?.totalPages} darkBg />
-              </PaginationWrapper>
+              </ResultsPaginationWrapper>
             </Space>
             <ImageEndpointSearchResults images={images} />
           </div>

--- a/catalogue/webapp/pages/search/works.tsx
+++ b/catalogue/webapp/pages/search/works.tsx
@@ -27,10 +27,10 @@ type Props = {
   pageview: Pageview;
 };
 
-const SortPaginationWrapper = styled.div<{ showSort?: boolean }>`
+const ResultsPaginationWrapper = styled.div`
   display: flex;
-  justify-content: ${({ showSort }) =>
-    showSort ? 'space-between' : 'flex-end'};
+  justify-content: space-between;
+  align-items: center;
 `;
 
 export const CatalogueSearchPage: NextPageWithLayout<Props> = ({
@@ -51,12 +51,15 @@ export const CatalogueSearchPage: NextPageWithLayout<Props> = ({
 
   const showSort = true;
 
+  if (works.totalResults === 0) return <p>nothing</p>;
+
   return (
     <>
       <h1 className="visually-hidden">Works Search Page</h1>
       <div className="container">
         <Space v={{ size: 'l', properties: ['padding-top', 'padding-bottom'] }}>
           <h2 style={{ marginBottom: 0 }}>Filters</h2>
+          {showSort && <div>Sort Component?</div>}
         </Space>
       </div>
 
@@ -68,10 +71,12 @@ export const CatalogueSearchPage: NextPageWithLayout<Props> = ({
               properties: ['padding-top', 'padding-bottom'],
             }}
           >
-            <SortPaginationWrapper showSort={showSort}>
-              {showSort && <div>Sort Component</div>}
+            <ResultsPaginationWrapper>
+              {works.totalResults > 0 && (
+                <div>{works.totalResults} results</div>
+              )}
               <SearchPagination totalPages={works?.totalPages} />
-            </SortPaginationWrapper>
+            </ResultsPaginationWrapper>
           </Space>
           <Space v={{ size: 'l', properties: ['padding-top'] }}>
             <WorksSearchResults works={works} />
@@ -111,7 +116,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     ];
 
     const _queryType = getCookie('_queryType') as string | undefined;
-
+    console.log(props);
     const worksApiProps = {
       ...props,
       _queryType,

--- a/catalogue/webapp/pages/search/works.tsx
+++ b/catalogue/webapp/pages/search/works.tsx
@@ -116,7 +116,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     ];
 
     const _queryType = getCookie('_queryType') as string | undefined;
-    console.log(props);
+
     const worksApiProps = {
       ...props,
       _queryType,


### PR DESCRIPTION
## Who is this for?
New search page 

## What is it doing for them?
As discussed, moving # results to the page content itself
Change Catalogue's URL back ("Catalogue" is label, `works` is URL)