### PR TITLE
Reduce the resources in the identity web app

### DIFF
--- a/identity/terraform/provider.tf
+++ b/identity/terraform/provider.tf
@@ -31,11 +31,6 @@ provider "aws" {
   default_tags {
     tags = local.default_prod_tags
   }
-
-  # Ignore deployment tags on services
-  ignore_tags {
-    keys = ["deployment:label"]
-  }
 }
 
 provider "aws" {
@@ -49,10 +44,5 @@ provider "aws" {
 
   default_tags {
     tags = local.default_stage_tags
-  }
-
-  # Ignore deployment tags on services
-  ignore_tags {
-    keys = ["deployment:label"]
   }
 }

--- a/identity/terraform/stack/main.tf
+++ b/identity/terraform/stack/main.tf
@@ -11,6 +11,9 @@ module "identity-service-18012021" {
   container_image = var.container_image
   container_port  = 3000
 
+  cpu    = 512
+  memory = 1024
+
   security_group_ids = [
     var.interservice_security_group_id,
     var.service_egress_security_group_id


### PR DESCRIPTION
I was poking around in the ECS console; it's massively over provisioned for the amount of traffic it gets.