### PR TITLE
Check we're using the intended string as the label for multi-volume content

### DIFF
--- a/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
@@ -14,7 +14,7 @@ import {
   getDownloadOptionsFromImageUrl,
 } from '../../utils/works';
 import { getServiceId } from '../../utils/iiif/v2';
-import { getEnFromInternationalString } from '../../utils/iiif/v3';
+import { getMultiVolumeLabel } from '../../utils/iiif/v3';
 import ViewerSidebar from './ViewerSidebar';
 import MainViewer, { scrollViewer } from './MainViewer';
 import ViewerTopBar from './ViewerTopBar';
@@ -332,12 +332,9 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
           : canvas.id === transformedManifest.id;
       });
 
-    // The manifest label, as far as we can tell, exists exclusively at index 1
-    // of the manifest.label. This feels flakey, but as the information doesn't
-    // appear to exist elsewhere, it doesn't look like there's another option.
     const manifestLabel =
       matchingManifest?.label &&
-      getEnFromInternationalString(matchingManifest.label, 1);
+      getMultiVolumeLabel(matchingManifest.label, work?.title || '');
     manifestLabel && setCurrentManifestLabel(manifestLabel);
   }, [transformedManifest, parentManifest]);
 

--- a/catalogue/webapp/components/IIIFViewer/MultipleManifestList.tsx
+++ b/catalogue/webapp/components/IIIFViewer/MultipleManifestList.tsx
@@ -4,7 +4,7 @@ import NextLink from 'next/link';
 import { itemLink } from '@weco/common/services/catalogue/routes';
 import ItemViewerContext from '../ItemViewerContext/ItemViewerContext';
 import { volumesNavigationLabel } from '@weco/common/text/aria-labels';
-import { getEnFromInternationalString } from '../../utils/iiif/v3';
+import { getMultiVolumeLabel } from '../../utils/iiif/v3';
 
 const Anchor = styled.a<{ isManifestIndex: boolean }>`
   ${props => props.isManifestIndex && `color: ${props.theme.color('yellow')};`};
@@ -35,7 +35,7 @@ const MultipleManifestListPrototype: FunctionComponent = () => {
               aria-current={i === manifestIndex ? 'page' : undefined}
             >
               {(manifest?.label &&
-                getEnFromInternationalString(manifest.label, 1)) ||
+                getMultiVolumeLabel(manifest.label, work?.title || '')) ||
                 'Unknown'}
             </Anchor>
           </NextLink>

--- a/catalogue/webapp/test/utils/iiif.test.ts
+++ b/catalogue/webapp/test/utils/iiif.test.ts
@@ -1,6 +1,6 @@
 import { Manifest } from '@iiif/presentation-3';
 import { getCanvases, groupStructures } from '../../utils/iiif/v2';
-import { getAudio } from '../../utils/iiif/v3';
+import { getAudio, getMultiVolumeLabel } from '../../utils/iiif/v3';
 import manifest from '@weco/common/__mocks__/iiif-manifest';
 import {
   manifestWithAudioTitles,
@@ -112,6 +112,22 @@ describe('Group repetitive iiif structures', () => {
   it('groups iiifStructures with consecutive canvases and the same label', () => {
     const groupedStructures = groupStructures(canvases, structures);
     expect(groupedStructures).toEqual(correctResult);
+  });
+});
+
+describe('getMultiVolumeLabel', () => {
+  it('returns the appropriate label from an array', () => {
+    const label1 = getMultiVolumeLabel(
+      { en: ['Practica seu Lilium medicinae', 'Copy 1'] },
+      'Practica seu Lilium medicinae'
+    );
+    const label2 = getMultiVolumeLabel(
+      { en: ['Volume 1', 'The diary of Samuel Pepys'] },
+      'The diary of Samuel Pepys'
+    );
+
+    expect(label1).toEqual('Copy 1');
+    expect(label2).toEqual('Volume 1');
   });
 });
 

--- a/catalogue/webapp/utils/iiif/v3/index.ts
+++ b/catalogue/webapp/utils/iiif/v3/index.ts
@@ -13,6 +13,23 @@ import {
 import { isNotUndefined } from '@weco/common/utils/array';
 import { DownloadOption } from '../../../types/manifest';
 
+// The label we want to use to distinguish between parts of a multi-volume work
+// (e.g. 'Copy 1' or 'Volume 1') can currently exist in either the first or
+// second position of an array, with the item title appearing in the other
+// position. This is an interim check to give us the label we want, but ideally
+// it would be consistent in the manifest. It will eventually be the second
+// thing in the array, consistently, at which point this function will be
+// redundant.
+export function getMultiVolumeLabel(
+  internationalString: InternationalString,
+  itemTitle: string
+): string {
+  const stringAtIndex1 = getEnFromInternationalString(internationalString, 1);
+  const stringAtIndex0 = getEnFromInternationalString(internationalString, 0);
+
+  return stringAtIndex1 === itemTitle ? stringAtIndex0 : stringAtIndex1;
+}
+
 export function getEnFromInternationalString(
   internationalString: InternationalString,
   index = 0

--- a/playwright/test/contexts.ts
+++ b/playwright/test/contexts.ts
@@ -71,6 +71,14 @@ const multiVolumeItem = async (
   await gotoWithoutCache(`${baseUrl}/works/mg56yqa4/items`, page);
 };
 
+const multiVolumeItem2 = async (
+  context: BrowserContext,
+  page: Page
+): Promise<void> => {
+  await context.addCookies(requiredCookies);
+  await gotoWithoutCache(`${baseUrl}/works/ykqft4tw/items`, page);
+};
+
 const itemWithAltText = async (
   params: { canvasNumber?: number },
   context: BrowserContext,
@@ -216,6 +224,7 @@ const isMobile = (page: Page): boolean =>
 
 export {
   multiVolumeItem,
+  multiVolumeItem2,
   itemWithAltText,
   worksSearch,
   itemWithSearchAndStructures,

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -1,6 +1,7 @@
 import { test as base, expect } from '@playwright/test';
 import {
   multiVolumeItem,
+  multiVolumeItem2,
   itemWithSearchAndStructures,
   itemWithReferenceNumber,
   itemWithAltText,
@@ -253,6 +254,23 @@ test.describe('Scenario 6: Item has multiple volumes', () => {
 
       await page.waitForSelector(
         `css=[data-test-id=current-manifest] >> text="${nextManifestLinkLabel}"`
+      );
+    }
+  });
+
+  test('the multi-volume label should be appropriate', async ({
+    page,
+    context,
+  }) => {
+    if (!isMobile(page)) {
+      await multiVolumeItem(context, page);
+      await page.waitForSelector(
+        `css=[data-test-id=current-manifest] >> text="Copy 1"`
+      );
+
+      await multiVolumeItem2(context, page);
+      await page.waitForSelector(
+        `css=[data-test-id=current-manifest] >> text="Volume 1"`
       );
     }
   });


### PR DESCRIPTION
Fixes #8792 

__Before__
<img width="459" alt="image" src="https://user-images.githubusercontent.com/1394592/199236980-2696481e-e336-4300-8d7c-7cac83218bbd.png">

__After__
<img width="569" alt="image" src="https://user-images.githubusercontent.com/1394592/199236897-7a660705-df22-4211-b0bc-bd3f039b5cf4.png">

This will also be fixed at the manifest level in due course (the label will consistently appear _after_ the title in the array), at which point this can be refactored away.

TODO:
- [x] Tests (I'm thinking an e2e test for two works, one with the label at each of the two possible locations)
