### PR TITLE
Test the exhibition guides in pa11y

### DIFF
--- a/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
+++ b/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
@@ -248,7 +248,7 @@ const Stop: FunctionComponent<{
         >
           <div className="flex flex--wrap container">
             <Tombstone>
-              {!hasContext && (
+              {!hasContext && title && (
                 <TombstoneTitle
                   level={tombstoneHeadingLevel}
                   id={dasherizeShorten(`${title}`)}

--- a/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
+++ b/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
@@ -160,13 +160,14 @@ function calculateTombstoneHeadingLevel(titlesUsed) {
 }
 
 const Stop: FunctionComponent<{
+  index: number;
   stop: Stop;
   isFirstStop: boolean;
   titlesUsed: {
     standalone: boolean;
     context: boolean;
   };
-}> = ({ stop, isFirstStop, titlesUsed }) => {
+}> = ({ index, stop, isFirstStop, titlesUsed }) => {
   const {
     standaloneTitle,
     title,
@@ -294,7 +295,7 @@ const Stop: FunctionComponent<{
                   <TranscriptTitle level={audioTranscriptHeadingLevel}>
                     {stop.number ? `Stop ${stop.number}: ` : ''}Audio transcript
                   </TranscriptTitle>
-                  <div id="transcription-text">
+                  <div id={`transcription-text-${index}`}>
                     <PrismicHtmlBlock
                       html={transcriptionText as prismicT.RichTextField}
                     />
@@ -302,7 +303,7 @@ const Stop: FunctionComponent<{
                   {hasShowFullTranscriptionButton && (
                     <ButtonSolid
                       colors={themeValues.buttonColors.greenTransparentGreen}
-                      ariaControls="transcription-text"
+                      ariaControls={`transcription-text-${index}`}
                       ariaExpanded={isFullTranscription}
                       clickHandler={() => {
                         setIsFullTranscription(!isFullTranscription);
@@ -344,6 +345,7 @@ const ExhibitionCaptions: FunctionComponent<Props> = ({ stops }) => {
         return (
           <Stop
             key={index}
+            index={index}
             stop={stop}
             isFirstStop={index === 0}
             titlesUsed={titlesUsed}

--- a/pa11y/README.md
+++ b/pa11y/README.md
@@ -19,6 +19,10 @@ Alternatively, we re-run pa11y on every deployment to prod.
 
 The results are shown in a dashboard at <https://dash.wellcomecollection.org/pa11y>
 
-## Testing new pages
+## How we choose what pages to test
 
-To test a new page with pa11y, add to the list of URLs in `write-report.js`.
+We have to specify a list of URLs for pa11y to check – it doesn't crawl the site looking for content.
+
+We want it to test a representative sample – any time you create a new page type, add an example to pa11y.
+
+To add a new URL, add to the list in `write-report.js`.

--- a/pa11y/README.md
+++ b/pa11y/README.md
@@ -1,5 +1,24 @@
 # pa11y
 
-This is automated accessibility testing for wellcomecollection.org.
+pa11y is [an open-source tool][pa11y] for automated accessibility testing.
+We use it to detect accessibility issues on wellcomecollection.org.
 
-The results are shown as a dashboard at <https://dash.wellcomecollection.org/pa11y>.
+[pa11y]: https://pa11y.org/
+
+## Getting pa11y results
+
+You can get a new set of pa11y results by running:
+
+```console
+$ cd webapp
+$ yarn write-report
+$ AWS_PROFILE=experience-dev yarn deploy
+```
+
+Alternatively, we re-run pa11y on every deployment to prod.
+
+The results are shown in a dashboard at <https://dash.wellcomecollection.org/pa11y>
+
+## Testing new pages
+
+To test a new page with pa11y, add to the list of URLs in `write-report.js`.

--- a/pa11y/webapp/write-report.js
+++ b/pa11y/webapp/write-report.js
@@ -22,6 +22,11 @@ const urls = [
   'https://wellcomecollection.org/events/Wqkd1yUAAB8sW4By',
   'https://wellcomecollection.org/event-series/WlYT_SQAACcAWccj',
   'https://wellcomecollection.org/concepts/n4fvtc49',
+
+  // Exhibition guides.  We should test one example of each guide format.
+  'https://wellcomecollection.org/guides/exhibitions/YzwsAREAAHylrxau/audio-without-descriptions',
+  'https://wellcomecollection.org/guides/exhibitions/YzwsAREAAHylrxau/captions-and-transcripts',
+  'https://wellcomecollection.org/guides/exhibitions/YzwsAREAAHylrxau/bsl',
 ];
 
 const promises = urls.map(url =>


### PR DESCRIPTION
## Who is this for?

Devs.

## What is it doing for them?

Making sure we can see accessibility issues on exhibition guides. I've run it locally and uploaded the report to the pa11y dashboard; a bunch of stuff isn't working. 😬 

I've fixed the low-hanging fruit, but there's more stuff to fix I can't get to tonight.