### PR TITLE
Fix a bug where the "What's on" page is still showing October

### DIFF
--- a/common/utils/dates.ts
+++ b/common/utils/dates.ts
@@ -19,13 +19,11 @@ export function today(): Date {
 }
 
 export function isPast(date: Date): boolean {
-  const now = new Date();
-  return date < now;
+  return date < today();
 }
 
 export function isFuture(date: Date): boolean {
-  const now = new Date();
-  return date > now;
+  return date > today();
 }
 
 export function isSameMonth(date1: Date, date2: Date): boolean {

--- a/common/views/components/SpacingComponent/SpacingComponent.tsx
+++ b/common/views/components/SpacingComponent/SpacingComponent.tsx
@@ -1,7 +1,6 @@
-import type { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
-const SpacingComponentEl = styled.div.attrs({
+const SpacingComponent = styled.div.attrs({
   className: 'spacing-component',
 })`
   &:empty,
@@ -19,9 +18,5 @@ const SpacingComponentEl = styled.div.attrs({
       `)}
   }
 `;
-
-const SpacingComponent: FunctionComponent = ({ children }) => {
-  return <SpacingComponentEl>{children}</SpacingComponentEl>;
-};
 
 export default SpacingComponent;

--- a/content/webapp/components/EventsByMonth/group-event-utils.test.ts
+++ b/content/webapp/components/EventsByMonth/group-event-utils.test.ts
@@ -1,3 +1,4 @@
+import * as dateUtils from '@weco/common/utils/dates';
 import { getMonthsInDateRange, groupEventsByMonth } from './group-event-utils';
 
 describe('getMonthsInDateRange', () => {
@@ -35,7 +36,12 @@ describe('getMonthsInDateRange', () => {
 });
 
 describe('groupEventsByMonth', () => {
-  it('works', () => {
+  it('groups events correctly', () => {
+    const spyOnFuture = jest.spyOn(dateUtils, 'isFuture');
+    spyOnFuture.mockImplementation(
+      (d: Date) => d > new Date('2022-09-08T00:00:00Z')
+    );
+
     // This is based on the state of the "What's on" page on 8 September 2022
     const evShockingTreatment = {
       times: [
@@ -163,6 +169,74 @@ describe('groupEventsByMonth', () => {
       {
         month: { month: 'November', year: 2022 },
         events: [evHivAndAids],
+      },
+    ]);
+  });
+
+  it('skips months that have already passed', () => {
+    const spyOnFuture = jest.spyOn(dateUtils, 'isFuture');
+    spyOnFuture.mockImplementation(
+      (d: Date) => d > new Date('2022-11-02T00:00:00Z')
+    );
+
+    // This is based on the state of the "What's on" page on 2 November 2022
+
+    const evPhobiasAndManias = {
+      times: [
+        {
+          range: {
+            startDateTime: new Date('2022-11-10T19:00:00.000Z'),
+            endDateTime: new Date('2022-11-10T20:00:00.000Z'),
+          },
+        },
+      ],
+      title: 'Phobias and Manias with Kate Summerscale and Stephen Grosz',
+    };
+
+    const evWhatYouSee = {
+      times: [
+        {
+          range: {
+            startDateTime: new Date('2022-11-17T18:30:00.000Z'),
+            endDateTime: new Date('2022-11-19T15:00:00.000Z'),
+          },
+        },
+      ],
+      title: 'What You See / Don’t See When…',
+    };
+
+    const evHivAndAids = {
+      times: [
+        {
+          range: {
+            startDateTime: new Date('2022-10-18T09:30:00.000Z'),
+            endDateTime: new Date('2022-10-18T14:30:00.000Z'),
+          },
+        },
+        {
+          range: {
+            startDateTime: new Date('2022-11-08T10:30:00.000Z'),
+            endDateTime: new Date('2022-11-08T15:30:00.000Z'),
+          },
+        },
+        {
+          range: {
+            startDateTime: new Date('2022-11-30T10:30:00.000Z'),
+            endDateTime: new Date('2022-11-30T15:30:00.000Z'),
+          },
+        },
+      ],
+      title: 'HIV and AIDS',
+    };
+
+    const events = [evPhobiasAndManias, evWhatYouSee, evHivAndAids];
+
+    const groupedEvents = groupEventsByMonth(events);
+
+    expect(groupedEvents).toStrictEqual([
+      {
+        month: { month: 'November', year: 2022 },
+        events: [evHivAndAids, evPhobiasAndManias, evWhatYouSee],
       },
     ]);
   });

--- a/content/webapp/components/EventsByMonth/group-event-utils.ts
+++ b/content/webapp/components/EventsByMonth/group-event-utils.ts
@@ -1,5 +1,5 @@
 import { isNotUndefined } from '@weco/common/utils/array';
-import { getDatesBetween } from '@weco/common/utils/dates';
+import { getDatesBetween, isFuture } from '@weco/common/utils/dates';
 import { HasTimeRanges } from '../../types/events';
 
 export type YearMonth = {
@@ -84,11 +84,11 @@ function maxDate(dates: Date[]): Date {
 }
 
 function getEarliestStartTime({ times }: HasTimeRanges): Date {
-  return minDate(times.map(t => t.range.startDateTime));
+  return minDate(times.map(t => t.range.startDateTime).filter(isFuture));
 }
 
 function getLatestStartTime({ times }: HasTimeRanges): Date {
-  return maxDate(times.map(t => t.range.startDateTime));
+  return maxDate(times.map(t => t.range.startDateTime).filter(isFuture));
 }
 
 type GroupedEvent<T> = {


### PR DESCRIPTION
## Who is this for?

The temporal overlords of the universe.

## What is it doing for them?

Respecting their wisdom and authority.

<img width="700" alt="Screenshot 2022-11-02 at 12 01 46" src="https://user-images.githubusercontent.com/301220/199484830-c0bc0271-50c5-4e37-8778-01174394af63.png">
