### PR TITLE
Only show Volumes for multi-volume works

### DIFF
--- a/catalogue/webapp/components/IIIFViewer/ViewerSidebar.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerSidebar.tsx
@@ -243,11 +243,13 @@ const ViewerSidebar: FunctionComponent<Props> = ({ mainViewerRef }: Props) => {
             <ViewerStructures mainViewerRef={mainViewerRef} />
           </AccordionItem>
         )}
-        {parentManifest && parentManifest.items && (
-          <AccordionItem title="Volumes">
-            <MultipleManifestList />
-          </AccordionItem>
-        )}
+        {parentManifest &&
+          parentManifest.behavior?.[0] === 'multi-part' &&
+          parentManifest.items && (
+            <AccordionItem title="Volumes">
+              <MultipleManifestList />
+            </AccordionItem>
+          )}
       </Inner>
       {searchService && (
         <Inner>


### PR DESCRIPTION
Fixes #8815 

Currently any work that has a parent manifest containing items will display a 'Volumes' section in the viewer sidebar. This worked with IIIFv2, but seems like there's more hierarchy in IIIFv3 and the presence of a parent manifest doesn't necessarily mean that an item is part of a multi-part work. For that, there's a `multi-part` `SpecificationBehavior`.

__Before__
![image](https://user-images.githubusercontent.com/1394592/199545806-95c97cd5-4919-4230-8567-50598af45487.png)

__After__
![image](https://user-images.githubusercontent.com/1394592/199545966-2c7ce602-b550-4b79-9374-ebe62f16dd25.png)
