### PR TITLE
Unify the list of URLs used in tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,200 +1,79 @@
-- label: ":docker: build common"
-  key: "build_common"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        build:
-          - common
-        image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
+  - label: "Update pa11y dashboard"
+    # if: build.env("BUILDKITE_GITHUB_DEPLOYMENT_ENVIRONMENT") == "prod"
+    plugins:
+      - wellcomecollection/aws-assume-role#v0.2.2:
+          role: "arn:aws:iam::130871440101:role/experience-ci"
+      - ecr#v2.1.1:
+          login: true
+      - docker-compose#v3.5.0:
+          run: pa11y
+          command: [ "yarn", "deploy" ]
+          env:
+            - AWS_ACCESS_KEY_ID
+            - AWS_SECRET_ACCESS_KEY
+            - AWS_SESSION_TOKEN
 
-- label: ":docker: build catalogue"
-  key: "build_catalogue"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        build:
-          - catalogue
-        image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
-
-- label: ":docker: build content"
-  key: "build_content"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        build:
-          - content
-        image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
-
-- label: ":docker: build edge_lambdas"
-  key: "build_edge_lambdas"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        build:
-          - edge_lambdas
-        image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
-
-- label: ":docker: build identity"
-  key: "build_identity"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        build:
-          - identity
-        image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
-
-- label: "diff prismic model"
-  branches: "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: prismic_model
-        env:
-          - CI
-        command: ["yarn", "diffCustomTypes"]
-
-- label: "test common"
-  depends_on: "build_common"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: common
-        command: ["yarn", "test"]
-
-- label: "test catalogue"
-  depends_on: "build_catalogue"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: catalogue
-        command: ["yarn", "test"]
-
-- label: "test content"
-  depends_on: "build_content"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: content
-        command: ["yarn", "test"]
-
-- label: "test identity"
-  depends_on: "build_identity"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: identity
-        command: ["yarn", "test"]
-
-- label: "test edge_lambdas"
-  depends_on: "build_edge_lambdas"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: edge_lambdas
-        command: ["yarn", "test"]
-
-- wait
-
-- label: "deploy catalogue (ecr image)"
-  branches: "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        push:
-          - catalogue:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/catalogue_webapp:ref.${BUILDKITE_COMMIT}
-          - catalogue:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/catalogue_webapp:latest
-
-- label: "deploy catalogue (bundle analysis)"
-  branches: "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: catalogue
-        command: [ "yarn", "deployBundleAnalysis" ]
-        env:
-          - AWS_ACCESS_KEY_ID
-          - AWS_SECRET_ACCESS_KEY
-          - AWS_SESSION_TOKEN
-
-- label: "deploy content (ecr image)"
-  branches: "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        push:
-          - content:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/content_webapp:ref.${BUILDKITE_COMMIT}
-          - content:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/content_webapp:latest
-
-- label: "deploy content (bundle analysis)"
-  branches: "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: content
-        command: [ "yarn", "deployBundleAnalysis" ]
-        env:
-          - AWS_ACCESS_KEY_ID
-          - AWS_SECRET_ACCESS_KEY
-          - AWS_SESSION_TOKEN
-
-- label: "deploy identity (ecr image)"
-  branches: "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        push:
-          - identity:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/identity_webapp:ref.${BUILDKITE_COMMIT}
-          - identity:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/identity_webapp:latest
-
-# - label: "deploy identity (bundle analysis)"
+# - label: ":docker: build common"
+#   key: "build_common"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         build:
+#           - common
+#         image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
+#
+# - label: ":docker: build catalogue"
+#   key: "build_catalogue"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         build:
+#           - catalogue
+#         image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
+#
+# - label: ":docker: build content"
+#   key: "build_content"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         build:
+#           - content
+#         image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
+#
+# - label: ":docker: build edge_lambdas"
+#   key: "build_edge_lambdas"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         build:
+#           - edge_lambdas
+#         image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
+#
+# - label: ":docker: build identity"
+#   key: "build_identity"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         build:
+#           - identity
+#         image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
+#
+# - label: "diff prismic model"
 #   branches: "main"
 #   plugins:
 #     - wellcomecollection/aws-assume-role#v0.2.2:
@@ -202,73 +81,209 @@
 #     - ecr#v2.1.1:
 #         login: true
 #     - docker-compose#v3.5.0:
+#         run: prismic_model
+#         env:
+#           - CI
+#         command: ["yarn", "diffCustomTypes"]
+#
+# - label: "test common"
+#   depends_on: "build_common"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: common
+#         command: ["yarn", "test"]
+#
+# - label: "test catalogue"
+#   depends_on: "build_catalogue"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: catalogue
+#         command: ["yarn", "test"]
+#
+# - label: "test content"
+#   depends_on: "build_content"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: content
+#         command: ["yarn", "test"]
+#
+# - label: "test identity"
+#   depends_on: "build_identity"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
 #         run: identity
+#         command: ["yarn", "test"]
+#
+# - label: "test edge_lambdas"
+#   depends_on: "build_edge_lambdas"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: edge_lambdas
+#         command: ["yarn", "test"]
+#
+# - wait
+#
+# - label: "deploy catalogue (ecr image)"
+#   branches: "main"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         push:
+#           - catalogue:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/catalogue_webapp:ref.${BUILDKITE_COMMIT}
+#           - catalogue:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/catalogue_webapp:latest
+#
+# - label: "deploy catalogue (bundle analysis)"
+#   branches: "main"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: catalogue
 #         command: [ "yarn", "deployBundleAnalysis" ]
 #         env:
 #           - AWS_ACCESS_KEY_ID
 #           - AWS_SECRET_ACCESS_KEY
 #           - AWS_SESSION_TOKEN
-
-- label: "deploy dash"
-  branches: "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: dash
-        command: [ "yarn", "deploy" ]
-        env:
-          - AWS_ACCESS_KEY_ID
-          - AWS_SECRET_ACCESS_KEY
-          - AWS_SESSION_TOKEN
-
-- label: "deploy edge_lambdas"
-  branches: "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: edge_lambdas
-        command: [ "yarn", "deploy" ]
-        env:
-          - AWS_ACCESS_KEY_ID
-          - AWS_SECRET_ACCESS_KEY
-          - AWS_SESSION_TOKEN
-
-- label: "deploy updown"
-  branches: "main"
-  skip: "To avoid overriding manual work that is occuring"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: updown
-        command: [ "yarn", "checks" ]
-        env:
-          - AWS_ACCESS_KEY_ID
-          - AWS_SECRET_ACCESS_KEY
-          - AWS_SESSION_TOKEN
-
-- label: "deploy assets"
-  branches: "main"
-  commands: ./assets/deploy_assets.sh
-  agents:
-    queue: nano
-
-- wait
-
-- label: "Trigger stage deployment"
-  branches: "main"
-  plugins:
-    - wellcomecollection/github-deployments#v0.3.0:
-        assume_role: "arn:aws:iam::130871440101:role/experience-ci"
-        environment: stage
-        ref: "${BUILDKITE_COMMIT}"
-  agents:
-    queue: nano
+#
+# - label: "deploy content (ecr image)"
+#   branches: "main"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         push:
+#           - content:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/content_webapp:ref.${BUILDKITE_COMMIT}
+#           - content:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/content_webapp:latest
+#
+# - label: "deploy content (bundle analysis)"
+#   branches: "main"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: content
+#         command: [ "yarn", "deployBundleAnalysis" ]
+#         env:
+#           - AWS_ACCESS_KEY_ID
+#           - AWS_SECRET_ACCESS_KEY
+#           - AWS_SESSION_TOKEN
+#
+# - label: "deploy identity (ecr image)"
+#   branches: "main"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         push:
+#           - identity:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/identity_webapp:ref.${BUILDKITE_COMMIT}
+#           - identity:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/identity_webapp:latest
+#
+# # - label: "deploy identity (bundle analysis)"
+# #   branches: "main"
+# #   plugins:
+# #     - wellcomecollection/aws-assume-role#v0.2.2:
+# #         role: "arn:aws:iam::130871440101:role/experience-ci"
+# #     - ecr#v2.1.1:
+# #         login: true
+# #     - docker-compose#v3.5.0:
+# #         run: identity
+# #         command: [ "yarn", "deployBundleAnalysis" ]
+# #         env:
+# #           - AWS_ACCESS_KEY_ID
+# #           - AWS_SECRET_ACCESS_KEY
+# #           - AWS_SESSION_TOKEN
+#
+# - label: "deploy dash"
+#   branches: "main"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: dash
+#         command: [ "yarn", "deploy" ]
+#         env:
+#           - AWS_ACCESS_KEY_ID
+#           - AWS_SECRET_ACCESS_KEY
+#           - AWS_SESSION_TOKEN
+#
+# - label: "deploy edge_lambdas"
+#   branches: "main"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: edge_lambdas
+#         command: [ "yarn", "deploy" ]
+#         env:
+#           - AWS_ACCESS_KEY_ID
+#           - AWS_SECRET_ACCESS_KEY
+#           - AWS_SESSION_TOKEN
+#
+# - label: "deploy updown"
+#   branches: "main"
+#   skip: "To avoid overriding manual work that is occuring"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: updown
+#         command: [ "yarn", "checks" ]
+#         env:
+#           - AWS_ACCESS_KEY_ID
+#           - AWS_SECRET_ACCESS_KEY
+#           - AWS_SESSION_TOKEN
+#
+# - label: "deploy assets"
+#   branches: "main"
+#   commands: ./assets/deploy_assets.sh
+#   agents:
+#     queue: nano
+#
+# - wait
+#
+# - label: "Trigger stage deployment"
+#   branches: "main"
+#   plugins:
+#     - wellcomecollection/github-deployments#v0.3.0:
+#         assume_role: "arn:aws:iam::130871440101:role/experience-ci"
+#         environment: stage
+#         ref: "${BUILDKITE_COMMIT}"
+#   agents:
+#     queue: nano

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
   pa11y:
     build:
       context: .
-      dockerfile: pa11y/webapp/Dockerfile
+      dockerfile: pa11y/Dockerfile
   updown:
     build:
       context: ./updown

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,8 @@ services:
       - AWS_PROFILE
   pa11y:
     build:
-      context: ./pa11y
+      context: .
+      dockerfile: pa11y/webapp/Dockerfile
   updown:
     build:
       context: ./updown

--- a/pa11y/Dockerfile
+++ b/pa11y/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/node:12-slim
+FROM public.ecr.aws/docker/library/node:16-slim
 
 VOLUME /dist
 

--- a/pa11y/Dockerfile
+++ b/pa11y/Dockerfile
@@ -9,9 +9,9 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
   libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
   libnss3
 
-WORKDIR /usr/src/app/webapp
+WORKDIR /usr/src/app/repo/pa11y/webapp
 
-ADD ./webapp /usr/src/app/webapp
+ADD . /usr/src/app/repo
 
 RUN yarn && \
     yarn write-report --no-sandbox && \

--- a/pa11y/webapp/deploy.js
+++ b/pa11y/webapp/deploy.js
@@ -16,8 +16,10 @@ try {
   };
 
   s3.putObject(params, function (err, data) {
-    if (err) console.log(err, err.stack);
-    else {
+    if (err) {
+      console.log(err, err.stack);
+      process.exit(1);
+    } else {
       console.log('Finished uploading report.json');
 
       cloudfront.createInvalidation(
@@ -29,8 +31,10 @@ try {
           },
         },
         function (err, data) {
-          if (err) console.log(err, err.stack);
-          else console.log('Flushed CloudFront cache for report.json');
+          if (err) {
+            console.log(err, err.stack);
+            process.exit(1);
+          } else console.log('Flushed CloudFront cache for report.json');
         }
       );
     }

--- a/pa11y/webapp/deploy.js
+++ b/pa11y/webapp/deploy.js
@@ -41,4 +41,5 @@ try {
   });
 } catch (e) {
   console.log('Error:', e.stack);
+  process.exit(1);
 }

--- a/pa11y/webapp/write-report.js
+++ b/pa11y/webapp/write-report.js
@@ -4,41 +4,105 @@ const pa11y = require('pa11y');
 const { promisify } = require('util');
 const writeFile = promisify(fs.writeFile);
 
+const baseUrl = 'https://wellcomecollection.org';
+
+function runPa11yForUrls(urls) {
+  const promises = urls.map(url =>
+    pa11y(url, {
+      chromeLaunchConfig: {
+        args: ['--no-sandbox'],
+      },
+    })
+  );
+
+  Promise.all(promises).then(async results => {
+    await mkdirp('./.dist');
+    await writeFile('./.dist/report.json', JSON.stringify({ results }));
+    console.info('Reporting done!');
+  });
+}
+
 console.info('Pa11y: Starting report');
-const urls = [
-  'https://wellcomecollection.org',
-  'https://wellcomecollection.org/visit-us',
-  'https://wellcomecollection.org/whats-on',
-  'https://wellcomecollection.org/stories',
-  'https://wellcomecollection.org/articles/WyjHUicAACvGnmJI',
-  'https://wellcomecollection.org/articles/W8ivQRAAAJFijw1h',
-  'https://wellcomecollection.org/works',
-  'https://wellcomecollection.org/works?query=health',
-  'https://wellcomecollection.org/works/cjwep3ze?query=health&page=1',
-  'https://wellcomecollection.org/works/e7vav3ss/items?page=1&canvas=1&sierraId=b28136615&langCode=eng',
-  'https://wellcomecollection.org/what-we-do',
-  'https://wellcomecollection.org/series/WsSUrR8AAL3KGFPF',
-  'https://wellcomecollection.org/exhibitions/XOVfTREAAOJmx-Uw',
-  'https://wellcomecollection.org/events/Wqkd1yUAAB8sW4By',
-  'https://wellcomecollection.org/event-series/WlYT_SQAACcAWccj',
-  'https://wellcomecollection.org/concepts/n4fvtc49',
 
-  // Exhibition guides.  We should test one example of each guide format.
-  'https://wellcomecollection.org/guides/exhibitions/YzwsAREAAHylrxau/audio-without-descriptions',
-  'https://wellcomecollection.org/guides/exhibitions/YzwsAREAAHylrxau/captions-and-transcripts',
-  'https://wellcomecollection.org/guides/exhibitions/YzwsAREAAHylrxau/bsl',
-];
+fs.readFile('../../.buildkite/urls/expected_200_urls.txt', (err, fileData) => {
+  if (err) {
+    console.error('Cannot read list of expected URLs');
+    process.exit(1);
+  } else {
+    const urls = fileData
+      .toString('utf8')
+      .split('\n')
+      .filter(line => line.trim() !== '' && !line.startsWith('# '))
+      .map(u => `${baseUrl}${u}`);
 
-const promises = urls.map(url =>
-  pa11y(url, {
-    chromeLaunchConfig: {
-      args: ['--no-sandbox'],
-    },
-  })
-);
+    console.log(`Running pa11y for URLs: ${urls.join('\n')}`);
 
-Promise.all(promises).then(async results => {
-  await mkdirp('./.dist');
-  await writeFile('./.dist/report.json', JSON.stringify({ results }));
-  console.info('Reporting done!');
+    runPa11yForUrls(urls);
+  }
 });
+
+// console.log(urls);
+
+// const urls = [
+//   'https://wellcomecollection.org',
+//   'https://wellcomecollection.org/visit-us',
+//   'https://wellcomecollection.org/whats-on',
+//   'https://wellcomecollection.org/stories',
+//   'https://wellcomecollection.org/articles/WyjHUicAACvGnmJI',
+//   'https://wellcomecollection.org/articles/W8ivQRAAAJFijw1h',
+//   'https://wellcomecollection.org/works',
+//   'https://wellcomecollection.org/works?query=health',
+//   'https://wellcomecollection.org/works/cjwep3ze?query=health&page=1',
+//   'https://wellcomecollection.org/works/e7vav3ss/items?page=1&canvas=1&sierraId=b28136615&langCode=eng',
+//   'https://wellcomecollection.org/what-we-do',
+//   'https://wellcomecollection.org/series/WsSUrR8AAL3KGFPF',
+//   'https://wellcomecollection.org/exhibitions/XOVfTREAAOJmx-Uw',
+//   'https://wellcomecollection.org/events/Wqkd1yUAAB8sW4By',
+//   'https://wellcomecollection.org/event-series/WlYT_SQAACcAWccj',
+//   'https://wellcomecollection.org/concepts/n4fvtc49',
+//
+//   // Exhibition guides.  We should test one example of each guide format.
+//   'https://wellcomecollection.org/guides/exhibitions/YzwsAREAAHylrxau/audio-without-descriptions',
+//   'https://wellcomecollection.org/guides/exhibitions/YzwsAREAAHylrxau/captions-and-transcripts',
+//   'https://wellcomecollection.org/guides/exhibitions/YzwsAREAAHylrxau/bsl',
+// ];
+
+// =======
+// const urls = [
+//   'https://wellcomecollection.org',
+//   'https://wellcomecollection.org/visit-us',
+//   'https://wellcomecollection.org/whats-on',
+//   'https://wellcomecollection.org/stories',
+//   'https://wellcomecollection.org/articles/WyjHUicAACvGnmJI',
+//   'https://wellcomecollection.org/articles/W8ivQRAAAJFijw1h',
+//   'https://wellcomecollection.org/works',
+//   'https://wellcomecollection.org/works?query=health',
+//   'https://wellcomecollection.org/works/cjwep3ze?query=health&page=1',
+//   'https://wellcomecollection.org/works/e7vav3ss/items?page=1&canvas=1&sierraId=b28136615&langCode=eng',
+//   'https://wellcomecollection.org/what-we-do',
+//   'https://wellcomecollection.org/series/WsSUrR8AAL3KGFPF',
+//   'https://wellcomecollection.org/exhibitions/XOVfTREAAOJmx-Uw',
+//   'https://wellcomecollection.org/events/Wqkd1yUAAB8sW4By',
+//   'https://wellcomecollection.org/event-series/WlYT_SQAACcAWccj',
+//   'https://wellcomecollection.org/concepts/n4fvtc49',
+
+//   // Exhibition guides.  We should test one example of each guide format.
+//   'https://wellcomecollection.org/guides/exhibitions/YzwsAREAAHylrxau/audio-without-descriptions',
+//   'https://wellcomecollection.org/guides/exhibitions/YzwsAREAAHylrxau/captions-and-transcripts',
+//   'https://wellcomecollection.org/guides/exhibitions/YzwsAREAAHylrxau/bsl',
+// ];
+
+// const promises = urls.map(url =>
+//   pa11y(url, {
+//     chromeLaunchConfig: {
+//       args: ['--no-sandbox'],
+//     },
+//   })
+// );
+
+// Promise.all(promises).then(async results => {
+//   await mkdirp('./.dist');
+//   await writeFile('./.dist/report.json', JSON.stringify({ results }));
+//   console.info('Reporting done!');
+// });
+// >>>>>>> External Changes

--- a/pa11y/webapp/write-report.js
+++ b/pa11y/webapp/write-report.js
@@ -26,7 +26,7 @@ console.info('Pa11y: Starting report');
 
 fs.readFile('../../.buildkite/urls/expected_200_urls.txt', (err, fileData) => {
   if (err) {
-    console.error('Cannot read list of expected URLs');
+    console.error(`Cannot read list of expected URLs: ${err}`);
     process.exit(1);
   } else {
     const urls = fileData


### PR DESCRIPTION
## Who is this for?

Devs.

## What is it doing for them?

Combining the list of URLs used by pa11y and the URL checker, so we have a single canonical set of URLs which are checked in automated deploys.