### PR TITLE
Small improvements to pa11y

### DIFF
--- a/.buildkite/urls/expected_200_urls.txt
+++ b/.buildkite/urls/expected_200_urls.txt
@@ -1,3 +1,8 @@
+# Note: if you add a URL to this list, make sure to also add it to the list
+# of URLs checked by pa11y.
+#
+# See pa11y/webapp/write-report.js
+
 # Some pages we can't let break!
 /
 /articles
@@ -9,6 +14,8 @@
 # Catalogue URLs
 /works
 /images
+/concepts/n4fvtc49
+
 # A book
 /works/efprdfhc
 # A digitised picture
@@ -39,7 +46,7 @@
 # This is an article with an event link in the "Try these next" section
 /articles/W_LXOxcAACwAxC5_
 
-# This is an example of every content type in Prismic (as of January 2022)
+# This is an example of every content type in Prismic (as of November 2022)
 /articles/YbNRQBEAACMAZfvG
 /books/YRpf9xEAADVQ33g6
 /event-series/XLWcIBEAAGC6wYZr
@@ -50,6 +57,11 @@
 /projects/YEIYwhAAACIANd6T
 /seasons/YEY3ZBAAACEASBjA
 /series/X8YMWBIAACUAhwAx
+
+# We should test one example of each exhibition guide format
+/guides/exhibitions/YzwsAREAAHylrxau/audio-without-descriptions
+/guides/exhibitions/YzwsAREAAHylrxau/captions-and-transcripts
+/guides/exhibitions/YzwsAREAAHylrxau/bsl
 
 # This is an article which is the 'webcomics' type underneath
 /articles/YbNRQBEAACMAZfvG

--- a/pa11y/Dockerfile
+++ b/pa11y/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/node:12-slim
+FROM public.ecr.aws/docker/library/node:14-slim
 
 VOLUME /dist
 

--- a/pa11y/webapp/deploy.js
+++ b/pa11y/webapp/deploy.js
@@ -16,8 +16,10 @@ try {
   };
 
   s3.putObject(params, function (err, data) {
-    if (err) console.log(err, err.stack);
-    else {
+    if (err) {
+      console.log(err, err.stack);
+      process.exit(1);
+    } else {
       console.log('Finished uploading report.json');
 
       cloudfront.createInvalidation(
@@ -37,4 +39,5 @@ try {
   });
 } catch (e) {
   console.log('Error:', e.stack);
+  process.exit(1);
 }

--- a/pa11y/webapp/write-report.js
+++ b/pa11y/webapp/write-report.js
@@ -5,29 +5,41 @@ const { promisify } = require('util');
 const writeFile = promisify(fs.writeFile);
 
 console.info('Pa11y: Starting report');
+
+const baseUrl = 'https://wellcomecollection.org';
+
+// Note: if you add a URL to this list, make sure to also add it to the list
+// of URLs checked by the URL checker.
+//
+// See .buildkite/urls/expected_200_urls.txt
+//
 const urls = [
-  'https://wellcomecollection.org',
-  'https://wellcomecollection.org/visit-us',
-  'https://wellcomecollection.org/whats-on',
-  'https://wellcomecollection.org/stories',
-  'https://wellcomecollection.org/articles/WyjHUicAACvGnmJI',
-  'https://wellcomecollection.org/articles/W8ivQRAAAJFijw1h',
-  'https://wellcomecollection.org/works',
-  'https://wellcomecollection.org/works?query=health',
-  'https://wellcomecollection.org/works/cjwep3ze?query=health&page=1',
-  'https://wellcomecollection.org/works/e7vav3ss/items?page=1&canvas=1&sierraId=b28136615&langCode=eng',
-  'https://wellcomecollection.org/what-we-do',
-  'https://wellcomecollection.org/series/WsSUrR8AAL3KGFPF',
-  'https://wellcomecollection.org/exhibitions/XOVfTREAAOJmx-Uw',
-  'https://wellcomecollection.org/events/Wqkd1yUAAB8sW4By',
-  'https://wellcomecollection.org/event-series/WlYT_SQAACcAWccj',
-  'https://wellcomecollection.org/concepts/n4fvtc49',
+  '/',
+  '/visit-us',
+  '/whats-on',
+  '/stories',
+  '/articles/WyjHUicAACvGnmJI',
+  '/articles/W8ivQRAAAJFijw1h',
+  '/works',
+  '/works?query=health',
+  '/works/cjwep3ze?query=health&page=1',
+  '/works/e7vav3ss/items?page=1&canvas=1&sierraId=b28136615&langCode=eng',
+  '/what-we-do',
+  '/series/WsSUrR8AAL3KGFPF',
+  '/exhibitions/XOVfTREAAOJmx-Uw',
+  '/events/Wqkd1yUAAB8sW4By',
+  '/event-series/WlYT_SQAACcAWccj',
+  '/concepts/n4fvtc49',
+
+  // This is a comic using the new (as of November 2022) approach to
+  // comic frames and navigation between issues.
+  '/articles/YzQT_BEAANURiuK9',
 
   // Exhibition guides.  We should test one example of each guide format.
-  'https://wellcomecollection.org/guides/exhibitions/YzwsAREAAHylrxau/audio-without-descriptions',
-  'https://wellcomecollection.org/guides/exhibitions/YzwsAREAAHylrxau/captions-and-transcripts',
-  'https://wellcomecollection.org/guides/exhibitions/YzwsAREAAHylrxau/bsl',
-];
+  '/guides/exhibitions/YzwsAREAAHylrxau/audio-without-descriptions',
+  '/guides/exhibitions/YzwsAREAAHylrxau/captions-and-transcripts',
+  '/guides/exhibitions/YzwsAREAAHylrxau/bsl',
+].map(u => `${baseUrl}${u}`);
 
 const promises = urls.map(url =>
   pa11y(url, {


### PR DESCRIPTION
This is some low-hanging fruit to improve pa11y after yesterday's retro.

* If the deployment failed (e.g. the report file doesn't exist), the pa11y job would still succeed in Buildkite! Don't do that.
* Bump to a newer version of Node.
* Add comments reminding people to cross-post new URLs between e2e tests and pa11y. Ideally they'd be the same, but that got a bit fiddly (see #8817) so I'm going to do this as a stopgap. I've also brought the two lists back into sync.
* I've added a `baseUrl` to the list of URLs in pa11y, so we could swap it out for another URL… eventually. 👀 