### PR TITLE
Always backfill the opening-times, even if the date is other

### DIFF
--- a/common/services/prismic/opening-times.ts
+++ b/common/services/prismic/opening-times.ts
@@ -276,12 +276,7 @@ export function createExceptionalOpeningHoursDays(
           day => day.overrideDate && isSameDay(day.overrideDate, date)
         );
         const backfillDay = exceptionalFromRegular(venue, date, type);
-        if (type === 'other') {
-          // We don't backfill if its type is other - see https://github.com/wellcomecollection/wellcomecollection.org/pull/4437
-          return matchingDay;
-        } else {
-          return matchingDay || backfillDay;
-        }
+        return matchingDay || backfillDay;
       })
       .filter(isNotUndefined);
     return days;

--- a/common/test/services/prismic/opening-times.test.ts
+++ b/common/test/services/prismic/opening-times.test.ts
@@ -507,33 +507,6 @@ describe('opening-times', () => {
         ],
       ]);
     });
-
-    // We don't backfill if its type is other - see https://github.com/wellcomecollection/wellcomecollection.org/pull/4437
-    it("it doesn't return the regular hours if the override type is 'other'", () => {
-      const result = createExceptionalOpeningHoursDays(libraryVenue, [
-        {
-          type: 'Bank holiday',
-          dates: [new Date('2021-10-05')],
-        },
-        {
-          type: 'other',
-          dates: [new Date('2021-10-08')],
-        },
-      ]);
-
-      expect(result).toEqual([
-        [
-          {
-            overrideDate: new Date('2021-10-05'),
-            overrideType: 'Bank holiday',
-            opens: '10:00',
-            closes: '18:00',
-            isClosed: false,
-          },
-        ],
-        [],
-      ]);
-    });
   });
 
   describe('getUpcomingExceptionalOpeningHours', () => {


### PR DESCRIPTION
This reverses a decision in https://github.com/wellcomecollection/wellcomecollection.org/pull/4437

This makes it easier for visitors to get a complete sense of our dates, it behaves consistently with other opening times (e.g. bank holidays), and it avoids confusion about why each venue has different hours.

We can revisit this in future if it becomes a problem again (e.g. don't show unusual hours against a venue if has no unusual hours in the period), but let's deal with that when it arises, rather than try to build a complete solution now. This is enough for this weekend.

See https://wellcome.slack.com/archives/CUA669WHH/p1667561232988349