### PR TITLE
Ignore errors from the GTM tracking pixel in our e2e tests

### DIFF
--- a/playwright/url-checker/ignore.ts
+++ b/playwright/url-checker/ignore.ts
@@ -23,13 +23,33 @@ export const ignoreErrorLog = (errorText: string): boolean => {
   if (errorText.includes('Failed to load resource')) {
     return true;
   }
-  
+
   // This is a hard-to-pin down issue which seems to be related to webfonts
   // being slow to load when the URL checker is run in CI - it seems to be logged from
   // https://github.com/wellcometrust/wellcomecollection.org/blob/9d9b2e96c82f4ea913c58df6c7daf27ff7eac9b4/common/hooks/useIsFontsLoaded.ts#L27
   if (errorText.startsWith('Error: 3000ms timeout exceeded')) {
     return true;
   }
-  
+
+  // This covers a class of errors like:
+  //
+  //      Request for an image resource at https://www.googletagmanager.com/a?[long query string] returned an unexpected mime type text/html
+  //
+  // I seems to happen at random, and get worse if you re-run the tests -- I suspect GTM
+  // is throttling requests that come from CI, and replacing a tracking pixel with
+  // an HTML error page.  This kinda makes sense -- CI is loading dozens of pages in
+  // parallel from a single IP address, which is very un-human-like behaviour.
+  //
+  // We can't do anything about GTM errors and we're not providing free uptime checking
+  // for Google, so let these through rather than failing our e2e tests.
+  if (
+    errorText.startsWith(
+      'Request for an image resource at https://www.googletagmanager.com/'
+    ) &&
+    errorText.endsWith('returned an unexpected mime type text/html')
+  ) {
+    return true;
+  }
+
   return false;
 };


### PR DESCRIPTION
Our e2e tests keep failing because we can't load GTM, and it goes away if you wait long enough -- I strongly suspect GTM is applying some rate limiting that's making the URL checker flaky.

## Who is this for?

Devs.

## What is it doing for them?

Making our e2e tests not flake.

🍨 