### PR TITLE
Retry the URL checker in the e2e tests

### DIFF
--- a/.buildkite/pipeline.e2e-universal.yml
+++ b/.buildkite/pipeline.e2e-universal.yml
@@ -22,6 +22,8 @@ steps:
           volumes:
             - "./.buildkite/urls:/usr/src/app/webapp/playwright/urls"
           command: ["bash", "check_urls.sh"]
+    retry:
+      automatic: true
 
   - label: "e2e test:desktop [$DEPLOYMENT_ENVIRONMENT]"
     plugins:


### PR DESCRIPTION
This isn't great, tests shouldn't be flaky, but it's what we're already doing and hopefully means "the tests are failing" is a bit more of a signal.