### PR TITLE
Remove support for legacy colours on article series

### DIFF
--- a/content/webapp/services/prismic/types/series.ts
+++ b/content/webapp/services/prismic/types/series.ts
@@ -17,21 +17,10 @@ import {
 
 const typeEnum = 'series';
 
-// TODO map legacy colours in Prismic to use new one
-// So we can clean this up eventually
 export type SeriesPrismicDocument = PrismicDocument<
   {
     color: SelectField<
-      | 'accent.blue'
-      | 'accent.salmon'
-      | 'accent.green'
-      | 'accent.purple'
-      | 'red'
-      | 'green'
-      | 'teal'
-      | 'purple'
-      | 'orange'
-      | 'turquoise'
+      'accent.blue' | 'accent.salmon' | 'accent.green' | 'accent.purple'
     >;
     schedule: GroupField<{
       title: RichTextField;

--- a/content/webapp/utils/colors.ts
+++ b/content/webapp/utils/colors.ts
@@ -1,20 +1,11 @@
 import { ColorSelection } from '../types/color-selections';
 
-// Purple, Treal, Red and Green used to be offered in Prismic as options
-// We should still support legacy stories so this function helps transform the colors
-// Into the new ones
 export const getSeriesColor = (
   prismicColor:
     | 'accent.blue'
     | 'accent.salmon'
     | 'accent.green'
     | 'accent.purple'
-    | 'red'
-    | 'green'
-    | 'teal'
-    | 'purple'
-    | 'orange'
-    | 'turquoise'
     | undefined
 ): ColorSelection => {
   switch (prismicColor) {
@@ -23,15 +14,6 @@ export const getSeriesColor = (
     case 'accent.green':
     case 'accent.purple':
       return prismicColor;
-    case 'teal':
-    case 'turquoise':
-      return 'accent.blue';
-    case 'red':
-    case 'orange':
-      return 'accent.salmon';
-    case 'green':
-      return 'accent.green';
-    case 'purple':
     default:
       return 'accent.purple';
   }


### PR DESCRIPTION
🧹 🧹 🧹 

Raphaëlle has fixed all these colours in Prismic, so we can delete the code for the legacy colour palette.

I remember her doing it, and I ran a quick tally of colours in the Prismic snapshot to double check:

```
  11 accent.purple
  14 accent.green
  16 accent.blue
  18 null
  19 accent.salmon
```