### PR TITLE
Consolidate the fetchLinks variables

### DIFF
--- a/content/webapp/pages/article-series.tsx
+++ b/content/webapp/pages/article-series.tsx
@@ -31,7 +31,6 @@ import {
 import { transformQuery } from 'services/prismic/transformers/paginated-results';
 import Space from '@weco/common/views/components/styled/Space';
 import Pagination from '@weco/common/views/components/Pagination/Pagination';
-import styled from 'styled-components';
 import { seasonsFetchLinks } from 'services/prismic/types';
 import { Pageview } from '@weco/common/services/conversion/track';
 

--- a/content/webapp/pages/article-series.tsx
+++ b/content/webapp/pages/article-series.tsx
@@ -7,7 +7,6 @@ import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
 import { getFeaturedMedia } from '../utils/page-header';
 import { Series } from '../types/series';
 import { ArticleBasic } from '../types/articles';
-import { seasonsFields } from '../services/prismic/fetch-links';
 import { headerBackgroundLs } from '@weco/common/utils/backgrounds';
 import { GaDimensions } from '@weco/common/services/app/google-analytics';
 import { appError, AppErrorProps } from '@weco/common/services/app';
@@ -32,6 +31,7 @@ import { transformQuery } from 'services/prismic/transformers/paginated-results'
 import Space from '@weco/common/views/components/styled/Space';
 import Pagination from '@weco/common/views/components/Pagination/Pagination';
 import styled from 'styled-components';
+import { seasonsFetchLinks } from 'services/prismic/types';
 
 type Props = {
   series: Series;
@@ -70,7 +70,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       predicates: [prismic.predicate.at(seriesField, id)],
       page,
       pageSize: 20,
-      fetchLinks: seasonsFields,
+      fetchLinks: seasonsFetchLinks,
     });
 
     // This can occasionally occur if somebody in the Editorial team is

--- a/content/webapp/services/prismic/fetch-links.ts
+++ b/content/webapp/services/prismic/fetch-links.ts
@@ -3,7 +3,6 @@ export const eventAccessOptionsFields = [
   'event-access-options.description',
   'event-access-options.description',
 ];
-export const audiencesFields = ['audiences.title'];
 export const exhibitionResourcesFields = [
   'exhibition-resources.title',
   'exhibition-resources.description',

--- a/content/webapp/services/prismic/fetch-links.ts
+++ b/content/webapp/services/prismic/fetch-links.ts
@@ -4,10 +4,6 @@ export const eventAccessOptionsFields = [
   'event-access-options.description',
 ];
 export const audiencesFields = ['audiences.title'];
-export const eventPoliciesFields = [
-  'event-policies.title',
-  'event-policies.description',
-];
 export const exhibitionResourcesFields = [
   'exhibition-resources.title',
   'exhibition-resources.description',

--- a/content/webapp/services/prismic/fetch-links.ts
+++ b/content/webapp/services/prismic/fetch-links.ts
@@ -8,12 +8,4 @@ export const exhibitionResourcesFields = [
   'exhibition-resources.description',
   'exhibition-resources.icon',
 ];
-export const pagesFormatsFields = [
-  'page-formats.title',
-  'page-formats.description',
-  'guide-formats.title',
-  'guide-formats.description',
-  'project-formats.title',
-  'project-formats.description',
-];
 export const labelsFields = ['labels.title', 'labels.description'];

--- a/content/webapp/services/prismic/fetch-links.ts
+++ b/content/webapp/services/prismic/fetch-links.ts
@@ -8,7 +8,6 @@ export const exhibitionResourcesFields = [
   'exhibition-resources.description',
   'exhibition-resources.icon',
 ];
-export const articleSeriesFields = ['series.title'];
 export const articlesFields = ['articles.title'];
 export const cardsFields = [
   'card.title',

--- a/content/webapp/services/prismic/fetch-links.ts
+++ b/content/webapp/services/prismic/fetch-links.ts
@@ -1,4 +1,3 @@
-export const pagesFields = ['pages.title', 'pages.promo'];
 export const collectionVenuesFields = [
   'collection-venue.title',
   'collection-venue.image',

--- a/content/webapp/services/prismic/fetch-links.ts
+++ b/content/webapp/services/prismic/fetch-links.ts
@@ -8,13 +8,6 @@ export const exhibitionResourcesFields = [
   'exhibition-resources.description',
   'exhibition-resources.icon',
 ];
-export const cardsFields = [
-  'card.title',
-  'card.format',
-  'card.description',
-  'card.image',
-  'card.link',
-];
 export const pagesFormatsFields = [
   'page-formats.title',
   'page-formats.description',

--- a/content/webapp/services/prismic/fetch-links.ts
+++ b/content/webapp/services/prismic/fetch-links.ts
@@ -17,4 +17,3 @@ export const pagesFormatsFields = [
   'project-formats.description',
 ];
 export const labelsFields = ['labels.title', 'labels.description'];
-export const guidesFields = ['guides.title', 'guides.promo'];

--- a/content/webapp/services/prismic/fetch-links.ts
+++ b/content/webapp/services/prismic/fetch-links.ts
@@ -1,8 +1,3 @@
-export const exhibitionFields = [
-  'exhibition-formats.title',
-  'exhibitions.title',
-  'exhibitions.format',
-];
 export const bookFields = ['books.title'];
 export const eventAccessOptionsFields = [
   'event-access-options.title',

--- a/content/webapp/services/prismic/fetch-links.ts
+++ b/content/webapp/services/prismic/fetch-links.ts
@@ -1,9 +1,3 @@
-export const eventSeriesFields = [
-  'event-series.title',
-  'event-series.description',
-  'event-series.backgroundTexture',
-  'event-series.promo',
-];
 export const exhibitionFields = [
   'exhibition-formats.title',
   'exhibitions.title',

--- a/content/webapp/services/prismic/fetch-links.ts
+++ b/content/webapp/services/prismic/fetch-links.ts
@@ -3,12 +3,6 @@ export const eventAccessOptionsFields = [
   'event-access-options.description',
   'event-access-options.description',
 ];
-export const interpretationTypesFields = [
-  'interpretation-types.title',
-  'interpretation-types.abbreviation',
-  'interpretation-types.description',
-  'interpretation-types.primaryDescription',
-];
 export const audiencesFields = ['audiences.title'];
 export const eventPoliciesFields = [
   'event-policies.title',

--- a/content/webapp/services/prismic/fetch-links.ts
+++ b/content/webapp/services/prismic/fetch-links.ts
@@ -53,10 +53,6 @@ export const exhibitionResourcesFields = [
   'exhibition-resources.icon',
 ];
 export const articleSeriesFields = ['series.title'];
-export const articleFormatsFields = [
-  'article-formats.title',
-  'article-formats.description',
-];
 export const articlesFields = ['articles.title'];
 export const eventsFields = [
   'events.title',

--- a/content/webapp/services/prismic/fetch-links.ts
+++ b/content/webapp/services/prismic/fetch-links.ts
@@ -10,14 +10,6 @@ export const exhibitionResourcesFields = [
 ];
 export const articleSeriesFields = ['series.title'];
 export const articlesFields = ['articles.title'];
-export const eventsFields = [
-  'events.title',
-  'events.schedule',
-  'events.interpretations',
-  'events.audiences',
-  'events.series',
-  'events.times',
-];
 export const cardsFields = [
   'card.title',
   'card.format',

--- a/content/webapp/services/prismic/fetch-links.ts
+++ b/content/webapp/services/prismic/fetch-links.ts
@@ -1,9 +1,3 @@
-export const placesFields = [
-  'places.title',
-  'places.level',
-  'places.capacity',
-  'places.locationInformation',
-];
 export const pagesFields = ['pages.title', 'pages.promo'];
 export const collectionVenuesFields = [
   'collection-venue.title',

--- a/content/webapp/services/prismic/fetch-links.ts
+++ b/content/webapp/services/prismic/fetch-links.ts
@@ -1,10 +1,3 @@
-export const organisationsFields = [
-  'organisations.name',
-  'organisations.image',
-  'organisations.url',
-  'organisations.description',
-  'organisations.sameAs',
-];
 export const placesFields = [
   'places.title',
   'places.level',

--- a/content/webapp/services/prismic/fetch-links.ts
+++ b/content/webapp/services/prismic/fetch-links.ts
@@ -1,4 +1,3 @@
-export const contributorsFields = ['editorial-contributor-roles.title'];
 export const organisationsFields = [
   'organisations.name',
   'organisations.image',

--- a/content/webapp/services/prismic/fetch-links.ts
+++ b/content/webapp/services/prismic/fetch-links.ts
@@ -27,10 +27,6 @@ export const exhibitionFields = [
   'exhibitions.format',
 ];
 export const bookFields = ['books.title'];
-export const eventFormatsFields = [
-  'event-formats.title',
-  'event-formats.description',
-];
 export const eventAccessOptionsFields = [
   'event-access-options.title',
   'event-access-options.description',

--- a/content/webapp/services/prismic/fetch-links.ts
+++ b/content/webapp/services/prismic/fetch-links.ts
@@ -42,13 +42,6 @@ export const interpretationTypesFields = [
   'interpretation-types.description',
   'interpretation-types.primaryDescription',
 ];
-export const teamsFields = [
-  'teams.title',
-  'teams.subtitle',
-  'teams.email',
-  'teams.phone',
-  'teams.url',
-];
 export const audiencesFields = ['audiences.title'];
 export const eventPoliciesFields = [
   'event-policies.title',

--- a/content/webapp/services/prismic/fetch-links.ts
+++ b/content/webapp/services/prismic/fetch-links.ts
@@ -1,19 +1,3 @@
-export const collectionVenuesFields = [
-  'collection-venue.title',
-  'collection-venue.image',
-  'collection-venue.link',
-  'collection-venue.linkText',
-  'collection-venue.order',
-  'collection-venue.monday',
-  'collection-venue.tuesday',
-  'collection-venue.wednesday',
-  'collection-venue.thursday',
-  'collection-venue.friday',
-  'collection-venue.saturday',
-  'collection-venue.sunday',
-  'collection-venue.modifiedDayOpeningTimes',
-];
-
 export const eventSeriesFields = [
   'event-series.title',
   'event-series.description',

--- a/content/webapp/services/prismic/fetch-links.ts
+++ b/content/webapp/services/prismic/fetch-links.ts
@@ -1,10 +1,3 @@
-export const peopleFields = [
-  'people.name',
-  'people.image',
-  'people.description',
-  'people.pronouns',
-  'people.sameAs',
-];
 export const contributorsFields = ['editorial-contributor-roles.title'];
 export const organisationsFields = [
   'organisations.name',

--- a/content/webapp/services/prismic/fetch-links.ts
+++ b/content/webapp/services/prismic/fetch-links.ts
@@ -1,3 +1,20 @@
+// Note: I'm not sure what these fetch links do, because it's unclear
+// what part of our Prismic types they refer to -- e.g. there's no field
+// called 'exhibition-resources', only 'resources'.
+//
+// To work out what they do, it would be useful to:
+//
+//    1. Find the Prismic fetchers where we use these fetch fields
+//    2. Find the ID of every document that might be affected
+//    3. Fetch each of those documents, with and without these fetch fields
+//    4. Compare the responses for any difference
+//
+// If all the responses are the same, these aren't do anything and we can remove
+// them.  If the responses are different, that gives us a clue as to what these
+// are doing, and we can match them up to the associated Prismic types.
+//
+// (But I don't have time to do that right now.)
+
 export const eventAccessOptionsFields = [
   'event-access-options.title',
   'event-access-options.description',

--- a/content/webapp/services/prismic/fetch-links.ts
+++ b/content/webapp/services/prismic/fetch-links.ts
@@ -8,7 +8,6 @@ export const exhibitionResourcesFields = [
   'exhibition-resources.description',
   'exhibition-resources.icon',
 ];
-export const articlesFields = ['articles.title'];
 export const cardsFields = [
   'card.title',
   'card.format',

--- a/content/webapp/services/prismic/fetch-links.ts
+++ b/content/webapp/services/prismic/fetch-links.ts
@@ -1,4 +1,3 @@
-export const bookFields = ['books.title'];
 export const eventAccessOptionsFields = [
   'event-access-options.title',
   'event-access-options.description',

--- a/content/webapp/services/prismic/fetch-links.ts
+++ b/content/webapp/services/prismic/fetch-links.ts
@@ -19,12 +19,6 @@ export const eventsFields = [
   'events.series',
   'events.times',
 ];
-export const seasonsFields = [
-  'seasons.title',
-  'seasons.start',
-  'seasons.end',
-  'seasons.promo',
-];
 export const cardsFields = [
   'card.title',
   'card.format',

--- a/content/webapp/services/prismic/fetch/events.ts
+++ b/content/webapp/services/prismic/fetch/events.ts
@@ -18,7 +18,7 @@ import {
   exhibitionsFetchLinks,
   seasonsFetchLinks,
 } from '../types';
-import { placesFetchLink } from '../types/places';
+import { placesFetchLinks } from '../types/places';
 import { backgroundTexturesFetchLink } from '../types/background-textures';
 
 const fetchLinks = [
@@ -30,7 +30,7 @@ const fetchLinks = [
   ...interpretationTypeFetchLinks,
   ...audienceFetchLinks,
   ...eventPolicyFetchLink,
-  ...placesFetchLink,
+  ...placesFetchLinks,
   ...teamFetchLinks,
   ...backgroundTexturesFetchLink,
   ...seasonsFetchLinks,

--- a/content/webapp/services/prismic/fetch/events.ts
+++ b/content/webapp/services/prismic/fetch/events.ts
@@ -1,7 +1,7 @@
 import { clientSideFetcher, fetcher, GetServerSidePropsPrismicClient } from '.';
 import {
   audienceFetchLinks,
-  eventFormatFetchLink,
+  eventFormatFetchLinks,
   eventPolicyFetchLink,
   EventPrismicDocument,
   interpretationTypeFetchLinks,
@@ -26,7 +26,7 @@ const fetchLinks = [
   ...contributorFetchLinks,
   ...eventSeriesFetchLink,
   ...exhibitionsFetchLinks,
-  ...eventFormatFetchLink,
+  ...eventFormatFetchLinks,
   ...interpretationTypeFetchLinks,
   ...audienceFetchLinks,
   ...eventPolicyFetchLink,

--- a/content/webapp/services/prismic/fetch/events.ts
+++ b/content/webapp/services/prismic/fetch/events.ts
@@ -2,7 +2,7 @@ import { clientSideFetcher, fetcher, GetServerSidePropsPrismicClient } from '.';
 import {
   audienceFetchLinks,
   eventFormatFetchLinks,
-  eventPolicyFetchLink,
+  eventPolicyFetchLinks,
   EventPrismicDocument,
   interpretationTypeFetchLinks,
   teamFetchLinks,
@@ -29,7 +29,7 @@ const fetchLinks = [
   ...eventFormatFetchLinks,
   ...interpretationTypeFetchLinks,
   ...audienceFetchLinks,
-  ...eventPolicyFetchLink,
+  ...eventPolicyFetchLinks,
   ...placesFetchLinks,
   ...teamFetchLinks,
   ...backgroundTexturesFetchLink,

--- a/content/webapp/services/prismic/fetch/events.ts
+++ b/content/webapp/services/prismic/fetch/events.ts
@@ -14,7 +14,7 @@ import { Event } from '../../../types/events';
 import {
   commonPrismicFieldsFetchLinks,
   contributorFetchLinks,
-  eventSeriesFetchLink,
+  eventSeriesFetchLinks,
   exhibitionsFetchLinks,
   seasonsFetchLinks,
 } from '../types';
@@ -24,7 +24,7 @@ import { backgroundTexturesFetchLink } from '../types/background-textures';
 const fetchLinks = [
   ...commonPrismicFieldsFetchLinks,
   ...contributorFetchLinks,
-  ...eventSeriesFetchLink,
+  ...eventSeriesFetchLinks,
   ...exhibitionsFetchLinks,
   ...eventFormatFetchLinks,
   ...interpretationTypeFetchLinks,

--- a/content/webapp/services/prismic/fetch/exhibitions.ts
+++ b/content/webapp/services/prismic/fetch/exhibitions.ts
@@ -16,7 +16,6 @@ import {
   interpretationTypesFields,
   audiencesFields,
   eventSeriesFields,
-  organisationsFields,
   eventPoliciesFields,
   articleSeriesFields,
   articleFormatsFields,
@@ -32,13 +31,11 @@ import {
   ExhibitionRelatedContent,
 } from '../../../types/exhibitions';
 import superjson from 'superjson';
-import { contributionRoleFetchLinks, personFetchLinks } from '../types';
+import { contributorFetchLinks } from '../types';
 
 const fetchLinks = [
-  ...personFetchLinks,
   ...exhibitionFields,
-  ...organisationsFields,
-  ...contributorsFields,
+  ...contributorFetchLinks,
   ...placesFields,
   ...exhibitionResourcesFields,
   ...eventSeriesFields,
@@ -141,9 +138,7 @@ export const fetchExhibitionRelatedContent = async (
     ...placesFields,
     ...interpretationTypesFields,
     ...audiencesFields,
-    ...organisationsFields,
-    ...personFetchLinks,
-    ...contributionRoleFetchLinks,
+    ...contributorFetchLinks,
     ...eventSeriesFields,
     ...eventPoliciesFields,
     ...articleSeriesFields,

--- a/content/webapp/services/prismic/fetch/exhibitions.ts
+++ b/content/webapp/services/prismic/fetch/exhibitions.ts
@@ -12,7 +12,6 @@ import {
   articleSeriesFields,
   articlesFields,
   exhibitionResourcesFields,
-  eventsFields,
 } from '../fetch-links';
 import { Period } from '../../../types/periods';
 import { getPeriodPredicates } from '../types/predicates';
@@ -35,6 +34,7 @@ import {
   audienceFetchLinks,
   eventFormatFetchLinks,
   eventPolicyFetchLinks,
+  eventsFetchLinks,
   interpretationTypeFetchLinks,
 } from '../types/events';
 
@@ -46,7 +46,7 @@ const fetchLinks = [
   ...exhibitionResourcesFields,
   ...eventSeriesFetchLinks,
   ...articlesFields,
-  ...eventsFields,
+  ...eventsFetchLinks,
   ...seasonsFetchLinks,
 ];
 

--- a/content/webapp/services/prismic/fetch/exhibitions.ts
+++ b/content/webapp/services/prismic/fetch/exhibitions.ts
@@ -9,7 +9,6 @@ import * as prismic from '@prismicio/client';
 import { PagePrismicDocument } from '../types/pages';
 import {
   eventAccessOptionsFields,
-  interpretationTypesFields,
   audiencesFields,
   eventPoliciesFields,
   articleSeriesFields,
@@ -34,7 +33,10 @@ import {
 } from '../types';
 import { placesFetchLinks } from '../types/places';
 import { teamsFetchLinks } from '../types/teams';
-import { eventFormatFetchLinks } from '../types/events';
+import {
+  eventFormatFetchLinks,
+  interpretationTypeFetchLinks,
+} from '../types/events';
 
 const fetchLinks = [
   ...exhibitionFormatsFetchLinks,
@@ -140,7 +142,7 @@ export const fetchExhibitionRelatedContent = async (
     ...teamsFetchLinks,
     ...eventFormatFetchLinks,
     ...placesFetchLinks,
-    ...interpretationTypesFields,
+    ...interpretationTypeFetchLinks,
     ...audiencesFields,
     ...contributorFetchLinks,
     ...eventSeriesFetchLinks,

--- a/content/webapp/services/prismic/fetch/exhibitions.ts
+++ b/content/webapp/services/prismic/fetch/exhibitions.ts
@@ -12,7 +12,6 @@ import {
   eventAccessOptionsFields,
   teamsFields,
   eventFormatsFields,
-  placesFields,
   interpretationTypesFields,
   audiencesFields,
   eventSeriesFields,
@@ -32,11 +31,12 @@ import {
 } from '../../../types/exhibitions';
 import superjson from 'superjson';
 import { contributorFetchLinks } from '../types';
+import { placesFetchLinks } from '../types/places';
 
 const fetchLinks = [
   ...exhibitionFields,
   ...contributorFetchLinks,
-  ...placesFields,
+  ...placesFetchLinks,
   ...exhibitionResourcesFields,
   ...eventSeriesFields,
   ...articlesFields,
@@ -135,7 +135,7 @@ export const fetchExhibitionRelatedContent = async (
     ...eventAccessOptionsFields,
     ...teamsFields,
     ...eventFormatsFields,
-    ...placesFields,
+    ...placesFetchLinks,
     ...interpretationTypesFields,
     ...audiencesFields,
     ...contributorFetchLinks,

--- a/content/webapp/services/prismic/fetch/exhibitions.ts
+++ b/content/webapp/services/prismic/fetch/exhibitions.ts
@@ -8,7 +8,6 @@ import { fetchPages } from './pages';
 import * as prismic from '@prismicio/client';
 import { PagePrismicDocument } from '../types/pages';
 import {
-  exhibitionFields,
   eventAccessOptionsFields,
   interpretationTypesFields,
   audiencesFields,
@@ -30,13 +29,16 @@ import {
   articleFormatsFetchLinks,
   contributorFetchLinks,
   eventSeriesFetchLinks,
+  exhibitionFormatsFetchLinks,
+  exhibitionsFetchLinks,
 } from '../types';
 import { placesFetchLinks } from '../types/places';
 import { teamsFetchLinks } from '../types/teams';
 import { eventFormatFetchLinks } from '../types/events';
 
 const fetchLinks = [
-  ...exhibitionFields,
+  ...exhibitionFormatsFetchLinks,
+  ...exhibitionsFetchLinks,
   ...contributorFetchLinks,
   ...placesFetchLinks,
   ...exhibitionResourcesFields,
@@ -145,7 +147,8 @@ export const fetchExhibitionRelatedContent = async (
     ...eventPoliciesFields,
     ...articleSeriesFields,
     ...articleFormatsFetchLinks,
-    ...exhibitionFields,
+    ...exhibitionFormatsFetchLinks,
+    ...exhibitionsFetchLinks,
     ...articlesFields,
   ];
 

--- a/content/webapp/services/prismic/fetch/exhibitions.ts
+++ b/content/webapp/services/prismic/fetch/exhibitions.ts
@@ -17,7 +17,6 @@ import {
   audiencesFields,
   eventSeriesFields,
   organisationsFields,
-  peopleFields,
   contributorsFields,
   eventPoliciesFields,
   articleSeriesFields,
@@ -34,9 +33,10 @@ import {
   ExhibitionRelatedContent,
 } from '../../../types/exhibitions';
 import superjson from 'superjson';
+import { personFetchLinks } from '../types';
 
 const fetchLinks = [
-  ...peopleFields,
+  ...personFetchLinks,
   ...exhibitionFields,
   ...organisationsFields,
   ...contributorsFields,
@@ -143,7 +143,7 @@ export const fetchExhibitionRelatedContent = async (
     ...interpretationTypesFields,
     ...audiencesFields,
     ...organisationsFields,
-    ...peopleFields,
+    ...personFetchLinks,
     ...contributorsFields,
     ...eventSeriesFields,
     ...eventPoliciesFields,

--- a/content/webapp/services/prismic/fetch/exhibitions.ts
+++ b/content/webapp/services/prismic/fetch/exhibitions.ts
@@ -14,7 +14,6 @@ import {
   articlesFields,
   exhibitionResourcesFields,
   eventsFields,
-  seasonsFields,
 } from '../fetch-links';
 import { Period } from '../../../types/periods';
 import { getPeriodPredicates } from '../types/predicates';
@@ -29,6 +28,7 @@ import {
   eventSeriesFetchLinks,
   exhibitionFormatsFetchLinks,
   exhibitionsFetchLinks,
+  seasonsFetchLinks,
 } from '../types';
 import { placesFetchLinks } from '../types/places';
 import { teamsFetchLinks } from '../types/teams';
@@ -47,7 +47,7 @@ const fetchLinks = [
   ...eventSeriesFetchLinks,
   ...articlesFields,
   ...eventsFields,
-  ...seasonsFields,
+  ...seasonsFetchLinks,
 ];
 
 const exhibitionsFetcher = fetcher<ExhibitionPrismicDocument>(

--- a/content/webapp/services/prismic/fetch/exhibitions.ts
+++ b/content/webapp/services/prismic/fetch/exhibitions.ts
@@ -10,7 +10,6 @@ import { PagePrismicDocument } from '../types/pages';
 import {
   exhibitionFields,
   eventAccessOptionsFields,
-  eventFormatsFields,
   interpretationTypesFields,
   audiencesFields,
   eventSeriesFields,
@@ -31,6 +30,7 @@ import superjson from 'superjson';
 import { articleFormatsFetchLinks, contributorFetchLinks } from '../types';
 import { placesFetchLinks } from '../types/places';
 import { teamsFetchLinks } from '../types/teams';
+import { eventFormatFetchLinks } from '../types/events';
 
 const fetchLinks = [
   ...exhibitionFields,
@@ -133,7 +133,7 @@ export const fetchExhibitionRelatedContent = async (
   const fetchLinks = [
     ...eventAccessOptionsFields,
     ...teamsFetchLinks,
-    ...eventFormatsFields,
+    ...eventFormatFetchLinks,
     ...placesFetchLinks,
     ...interpretationTypesFields,
     ...audiencesFields,

--- a/content/webapp/services/prismic/fetch/exhibitions.ts
+++ b/content/webapp/services/prismic/fetch/exhibitions.ts
@@ -10,7 +10,6 @@ import { PagePrismicDocument } from '../types/pages';
 import {
   eventAccessOptionsFields,
   audiencesFields,
-  eventPoliciesFields,
   articleSeriesFields,
   articlesFields,
   exhibitionResourcesFields,
@@ -35,6 +34,7 @@ import { placesFetchLinks } from '../types/places';
 import { teamsFetchLinks } from '../types/teams';
 import {
   eventFormatFetchLinks,
+  eventPolicyFetchLinks,
   interpretationTypeFetchLinks,
 } from '../types/events';
 
@@ -146,7 +146,7 @@ export const fetchExhibitionRelatedContent = async (
     ...audiencesFields,
     ...contributorFetchLinks,
     ...eventSeriesFetchLinks,
-    ...eventPoliciesFields,
+    ...eventPolicyFetchLinks,
     ...articleSeriesFields,
     ...articleFormatsFetchLinks,
     ...exhibitionFormatsFetchLinks,

--- a/content/webapp/services/prismic/fetch/exhibitions.ts
+++ b/content/webapp/services/prismic/fetch/exhibitions.ts
@@ -12,7 +12,6 @@ import {
   eventAccessOptionsFields,
   interpretationTypesFields,
   audiencesFields,
-  eventSeriesFields,
   eventPoliciesFields,
   articleSeriesFields,
   articlesFields,
@@ -27,7 +26,11 @@ import {
   ExhibitionRelatedContent,
 } from '../../../types/exhibitions';
 import superjson from 'superjson';
-import { articleFormatsFetchLinks, contributorFetchLinks } from '../types';
+import {
+  articleFormatsFetchLinks,
+  contributorFetchLinks,
+  eventSeriesFetchLinks,
+} from '../types';
 import { placesFetchLinks } from '../types/places';
 import { teamsFetchLinks } from '../types/teams';
 import { eventFormatFetchLinks } from '../types/events';
@@ -37,7 +40,7 @@ const fetchLinks = [
   ...contributorFetchLinks,
   ...placesFetchLinks,
   ...exhibitionResourcesFields,
-  ...eventSeriesFields,
+  ...eventSeriesFetchLinks,
   ...articlesFields,
   ...eventsFields,
   ...seasonsFields,
@@ -138,7 +141,7 @@ export const fetchExhibitionRelatedContent = async (
     ...interpretationTypesFields,
     ...audiencesFields,
     ...contributorFetchLinks,
-    ...eventSeriesFields,
+    ...eventSeriesFetchLinks,
     ...eventPoliciesFields,
     ...articleSeriesFields,
     ...articleFormatsFetchLinks,

--- a/content/webapp/services/prismic/fetch/exhibitions.ts
+++ b/content/webapp/services/prismic/fetch/exhibitions.ts
@@ -10,7 +10,6 @@ import { PagePrismicDocument } from '../types/pages';
 import {
   exhibitionFields,
   eventAccessOptionsFields,
-  teamsFields,
   eventFormatsFields,
   interpretationTypesFields,
   audiencesFields,
@@ -32,6 +31,7 @@ import {
 import superjson from 'superjson';
 import { contributorFetchLinks } from '../types';
 import { placesFetchLinks } from '../types/places';
+import { teamsFetchLinks } from '../types/teams';
 
 const fetchLinks = [
   ...exhibitionFields,
@@ -133,7 +133,7 @@ export const fetchExhibitionRelatedContent = async (
 ): Promise<Query<ExhibitionRelatedContentPrismicDocument>> => {
   const fetchLinks = [
     ...eventAccessOptionsFields,
-    ...teamsFields,
+    ...teamsFetchLinks,
     ...eventFormatsFields,
     ...placesFetchLinks,
     ...interpretationTypesFields,

--- a/content/webapp/services/prismic/fetch/exhibitions.ts
+++ b/content/webapp/services/prismic/fetch/exhibitions.ts
@@ -16,7 +16,6 @@ import {
   eventSeriesFields,
   eventPoliciesFields,
   articleSeriesFields,
-  articleFormatsFields,
   articlesFields,
   exhibitionResourcesFields,
   eventsFields,
@@ -29,7 +28,7 @@ import {
   ExhibitionRelatedContent,
 } from '../../../types/exhibitions';
 import superjson from 'superjson';
-import { contributorFetchLinks } from '../types';
+import { articleFormatsFetchLinks, contributorFetchLinks } from '../types';
 import { placesFetchLinks } from '../types/places';
 import { teamsFetchLinks } from '../types/teams';
 
@@ -142,7 +141,7 @@ export const fetchExhibitionRelatedContent = async (
     ...eventSeriesFields,
     ...eventPoliciesFields,
     ...articleSeriesFields,
-    ...articleFormatsFields,
+    ...articleFormatsFetchLinks,
     ...exhibitionFields,
     ...articlesFields,
   ];

--- a/content/webapp/services/prismic/fetch/exhibitions.ts
+++ b/content/webapp/services/prismic/fetch/exhibitions.ts
@@ -9,7 +9,6 @@ import * as prismic from '@prismicio/client';
 import { PagePrismicDocument } from '../types/pages';
 import {
   eventAccessOptionsFields,
-  articleSeriesFields,
   articlesFields,
   exhibitionResourcesFields,
 } from '../fetch-links';
@@ -37,6 +36,7 @@ import {
   eventsFetchLinks,
   interpretationTypeFetchLinks,
 } from '../types/events';
+import { seriesFetchLinks } from '../types/series';
 
 const fetchLinks = [
   ...exhibitionFormatsFetchLinks,
@@ -147,7 +147,7 @@ export const fetchExhibitionRelatedContent = async (
     ...contributorFetchLinks,
     ...eventSeriesFetchLinks,
     ...eventPolicyFetchLinks,
-    ...articleSeriesFields,
+    ...seriesFetchLinks,
     ...articleFormatsFetchLinks,
     ...exhibitionFormatsFetchLinks,
     ...exhibitionsFetchLinks,

--- a/content/webapp/services/prismic/fetch/exhibitions.ts
+++ b/content/webapp/services/prismic/fetch/exhibitions.ts
@@ -9,7 +9,6 @@ import * as prismic from '@prismicio/client';
 import { PagePrismicDocument } from '../types/pages';
 import {
   eventAccessOptionsFields,
-  articlesFields,
   exhibitionResourcesFields,
 } from '../fetch-links';
 import { Period } from '../../../types/periods';
@@ -37,6 +36,7 @@ import {
   interpretationTypeFetchLinks,
 } from '../types/events';
 import { seriesFetchLinks } from '../types/series';
+import { articlesFetchLinks } from '../types/articles';
 
 const fetchLinks = [
   ...exhibitionFormatsFetchLinks,
@@ -45,7 +45,7 @@ const fetchLinks = [
   ...placesFetchLinks,
   ...exhibitionResourcesFields,
   ...eventSeriesFetchLinks,
-  ...articlesFields,
+  ...articlesFetchLinks,
   ...eventsFetchLinks,
   ...seasonsFetchLinks,
 ];
@@ -151,7 +151,7 @@ export const fetchExhibitionRelatedContent = async (
     ...articleFormatsFetchLinks,
     ...exhibitionFormatsFetchLinks,
     ...exhibitionsFetchLinks,
-    ...articlesFields,
+    ...articlesFetchLinks,
   ];
 
   return client.getByIDs<ExhibitionRelatedContentPrismicDocument>(ids, {

--- a/content/webapp/services/prismic/fetch/exhibitions.ts
+++ b/content/webapp/services/prismic/fetch/exhibitions.ts
@@ -17,7 +17,6 @@ import {
   audiencesFields,
   eventSeriesFields,
   organisationsFields,
-  contributorsFields,
   eventPoliciesFields,
   articleSeriesFields,
   articleFormatsFields,
@@ -33,7 +32,7 @@ import {
   ExhibitionRelatedContent,
 } from '../../../types/exhibitions';
 import superjson from 'superjson';
-import { personFetchLinks } from '../types';
+import { contributionRoleFetchLinks, personFetchLinks } from '../types';
 
 const fetchLinks = [
   ...personFetchLinks,
@@ -144,7 +143,7 @@ export const fetchExhibitionRelatedContent = async (
     ...audiencesFields,
     ...organisationsFields,
     ...personFetchLinks,
-    ...contributorsFields,
+    ...contributionRoleFetchLinks,
     ...eventSeriesFields,
     ...eventPoliciesFields,
     ...articleSeriesFields,

--- a/content/webapp/services/prismic/fetch/exhibitions.ts
+++ b/content/webapp/services/prismic/fetch/exhibitions.ts
@@ -9,7 +9,6 @@ import * as prismic from '@prismicio/client';
 import { PagePrismicDocument } from '../types/pages';
 import {
   eventAccessOptionsFields,
-  audiencesFields,
   articleSeriesFields,
   articlesFields,
   exhibitionResourcesFields,
@@ -33,6 +32,7 @@ import {
 import { placesFetchLinks } from '../types/places';
 import { teamsFetchLinks } from '../types/teams';
 import {
+  audienceFetchLinks,
   eventFormatFetchLinks,
   eventPolicyFetchLinks,
   interpretationTypeFetchLinks,
@@ -143,7 +143,7 @@ export const fetchExhibitionRelatedContent = async (
     ...eventFormatFetchLinks,
     ...placesFetchLinks,
     ...interpretationTypeFetchLinks,
-    ...audiencesFields,
+    ...audienceFetchLinks,
     ...contributorFetchLinks,
     ...eventSeriesFetchLinks,
     ...eventPolicyFetchLinks,

--- a/content/webapp/services/prismic/fetch/multi-content.ts
+++ b/content/webapp/services/prismic/fetch/multi-content.ts
@@ -11,13 +11,16 @@ import {
   eventPoliciesFields,
   audiencesFields,
   articleSeriesFields,
-  exhibitionFields,
   articlesFields,
 } from '../fetch-links';
 import { PaginatedResults } from '@weco/common/services/prismic/types';
 import { MultiContent } from '../../../types/multi-content';
 import superjson from 'superjson';
-import { contributorFetchLinks } from '../types';
+import {
+  contributorFetchLinks,
+  exhibitionFormatsFetchLinks,
+  exhibitionsFetchLinks,
+} from '../types';
 import { placesFetchLinks } from '../types/places';
 import { teamsFetchLinks } from '../types/teams';
 import { eventFormatFetchLinks } from '../types/events';
@@ -70,7 +73,8 @@ export const fetchMultiContent = async (
       ...eventPoliciesFields,
       ...audiencesFields,
       ...articleSeriesFields,
-      ...exhibitionFields,
+      ...exhibitionFormatsFetchLinks,
+      ...exhibitionsFetchLinks,
       ...contributorFetchLinks,
       ...teamsFetchLinks,
       ...articlesFields,

--- a/content/webapp/services/prismic/fetch/multi-content.ts
+++ b/content/webapp/services/prismic/fetch/multi-content.ts
@@ -6,7 +6,6 @@ import {
   StructuredSearchQuery,
 } from '../types/multi-content';
 import * as prismic from '@prismicio/client';
-import { articlesFields } from '../fetch-links';
 import { PaginatedResults } from '@weco/common/services/prismic/types';
 import { MultiContent } from '../../../types/multi-content';
 import superjson from 'superjson';
@@ -25,6 +24,7 @@ import {
 } from '../types/events';
 import { pagesFetchLinks } from '../types/pages';
 import { seriesFetchLinks } from '../types/series';
+import { articlesFetchLinks } from '../types/articles';
 
 export const fetchMultiContent = async (
   { client }: GetServerSidePropsPrismicClient,
@@ -77,7 +77,7 @@ export const fetchMultiContent = async (
       ...exhibitionsFetchLinks,
       ...contributorFetchLinks,
       ...teamsFetchLinks,
-      ...articlesFields,
+      ...articlesFetchLinks,
     ],
     predicates,
     pageSize: pageSize || 100,

--- a/content/webapp/services/prismic/fetch/multi-content.ts
+++ b/content/webapp/services/prismic/fetch/multi-content.ts
@@ -9,7 +9,6 @@ import * as prismic from '@prismicio/client';
 import {
   pagesFields,
   interpretationTypesFields,
-  placesFields,
   eventFormatsFields,
   eventPoliciesFields,
   audiencesFields,
@@ -22,6 +21,7 @@ import { PaginatedResults } from '@weco/common/services/prismic/types';
 import { MultiContent } from '../../../types/multi-content';
 import superjson from 'superjson';
 import { contributorFetchLinks } from '../types';
+import { placesFetchLinks } from '../types/places';
 
 export const fetchMultiContent = async (
   { client }: GetServerSidePropsPrismicClient,
@@ -65,7 +65,7 @@ export const fetchMultiContent = async (
     fetchLinks: [
       ...pagesFields,
       ...interpretationTypesFields,
-      ...placesFields,
+      ...placesFetchLinks,
       ...eventFormatsFields,
       ...eventPoliciesFields,
       ...audiencesFields,

--- a/content/webapp/services/prismic/fetch/multi-content.ts
+++ b/content/webapp/services/prismic/fetch/multi-content.ts
@@ -14,7 +14,6 @@ import {
   audiencesFields,
   articleSeriesFields,
   exhibitionFields,
-  teamsFields,
   articlesFields,
 } from '../fetch-links';
 import { PaginatedResults } from '@weco/common/services/prismic/types';
@@ -22,6 +21,7 @@ import { MultiContent } from '../../../types/multi-content';
 import superjson from 'superjson';
 import { contributorFetchLinks } from '../types';
 import { placesFetchLinks } from '../types/places';
+import { teamsFetchLinks } from '../types/teams';
 
 export const fetchMultiContent = async (
   { client }: GetServerSidePropsPrismicClient,
@@ -72,7 +72,7 @@ export const fetchMultiContent = async (
       ...articleSeriesFields,
       ...exhibitionFields,
       ...contributorFetchLinks,
-      ...teamsFields,
+      ...teamsFetchLinks,
       ...articlesFields,
     ],
     predicates,

--- a/content/webapp/services/prismic/fetch/multi-content.ts
+++ b/content/webapp/services/prismic/fetch/multi-content.ts
@@ -6,11 +6,7 @@ import {
   StructuredSearchQuery,
 } from '../types/multi-content';
 import * as prismic from '@prismicio/client';
-import {
-  audiencesFields,
-  articleSeriesFields,
-  articlesFields,
-} from '../fetch-links';
+import { articleSeriesFields, articlesFields } from '../fetch-links';
 import { PaginatedResults } from '@weco/common/services/prismic/types';
 import { MultiContent } from '../../../types/multi-content';
 import superjson from 'superjson';
@@ -22,6 +18,7 @@ import {
 import { placesFetchLinks } from '../types/places';
 import { teamsFetchLinks } from '../types/teams';
 import {
+  audienceFetchLinks,
   eventFormatFetchLinks,
   eventPolicyFetchLinks,
   interpretationTypeFetchLinks,
@@ -73,7 +70,7 @@ export const fetchMultiContent = async (
       ...placesFetchLinks,
       ...eventFormatFetchLinks,
       ...eventPolicyFetchLinks,
-      ...audiencesFields,
+      ...audienceFetchLinks,
       ...articleSeriesFields,
       ...exhibitionFormatsFetchLinks,
       ...exhibitionsFetchLinks,

--- a/content/webapp/services/prismic/fetch/multi-content.ts
+++ b/content/webapp/services/prismic/fetch/multi-content.ts
@@ -7,7 +7,6 @@ import {
 } from '../types/multi-content';
 import * as prismic from '@prismicio/client';
 import {
-  eventPoliciesFields,
   audiencesFields,
   articleSeriesFields,
   articlesFields,
@@ -24,6 +23,7 @@ import { placesFetchLinks } from '../types/places';
 import { teamsFetchLinks } from '../types/teams';
 import {
   eventFormatFetchLinks,
+  eventPolicyFetchLinks,
   interpretationTypeFetchLinks,
 } from '../types/events';
 import { pagesFetchLinks } from '../types/pages';
@@ -72,7 +72,7 @@ export const fetchMultiContent = async (
       ...interpretationTypeFetchLinks,
       ...placesFetchLinks,
       ...eventFormatFetchLinks,
-      ...eventPoliciesFields,
+      ...eventPolicyFetchLinks,
       ...audiencesFields,
       ...articleSeriesFields,
       ...exhibitionFormatsFetchLinks,

--- a/content/webapp/services/prismic/fetch/multi-content.ts
+++ b/content/webapp/services/prismic/fetch/multi-content.ts
@@ -6,7 +6,7 @@ import {
   StructuredSearchQuery,
 } from '../types/multi-content';
 import * as prismic from '@prismicio/client';
-import { articleSeriesFields, articlesFields } from '../fetch-links';
+import { articlesFields } from '../fetch-links';
 import { PaginatedResults } from '@weco/common/services/prismic/types';
 import { MultiContent } from '../../../types/multi-content';
 import superjson from 'superjson';
@@ -24,6 +24,7 @@ import {
   interpretationTypeFetchLinks,
 } from '../types/events';
 import { pagesFetchLinks } from '../types/pages';
+import { seriesFetchLinks } from '../types/series';
 
 export const fetchMultiContent = async (
   { client }: GetServerSidePropsPrismicClient,
@@ -71,7 +72,7 @@ export const fetchMultiContent = async (
       ...eventFormatFetchLinks,
       ...eventPolicyFetchLinks,
       ...audienceFetchLinks,
-      ...articleSeriesFields,
+      ...seriesFetchLinks,
       ...exhibitionFormatsFetchLinks,
       ...exhibitionsFetchLinks,
       ...contributorFetchLinks,

--- a/content/webapp/services/prismic/fetch/multi-content.ts
+++ b/content/webapp/services/prismic/fetch/multi-content.ts
@@ -7,7 +7,6 @@ import {
 } from '../types/multi-content';
 import * as prismic from '@prismicio/client';
 import {
-  pagesFields,
   interpretationTypesFields,
   eventPoliciesFields,
   audiencesFields,
@@ -22,6 +21,7 @@ import { contributorFetchLinks } from '../types';
 import { placesFetchLinks } from '../types/places';
 import { teamsFetchLinks } from '../types/teams';
 import { eventFormatFetchLinks } from '../types/events';
+import { pagesFetchLinks } from '../types/pages';
 
 export const fetchMultiContent = async (
   { client }: GetServerSidePropsPrismicClient,
@@ -63,7 +63,7 @@ export const fetchMultiContent = async (
 
   return client.get<MultiContentPrismicDocument>({
     fetchLinks: [
-      ...pagesFields,
+      ...pagesFetchLinks,
       ...interpretationTypesFields,
       ...placesFetchLinks,
       ...eventFormatFetchLinks,

--- a/content/webapp/services/prismic/fetch/multi-content.ts
+++ b/content/webapp/services/prismic/fetch/multi-content.ts
@@ -9,7 +9,6 @@ import * as prismic from '@prismicio/client';
 import {
   pagesFields,
   interpretationTypesFields,
-  eventFormatsFields,
   eventPoliciesFields,
   audiencesFields,
   articleSeriesFields,
@@ -22,6 +21,7 @@ import superjson from 'superjson';
 import { contributorFetchLinks } from '../types';
 import { placesFetchLinks } from '../types/places';
 import { teamsFetchLinks } from '../types/teams';
+import { eventFormatFetchLinks } from '../types/events';
 
 export const fetchMultiContent = async (
   { client }: GetServerSidePropsPrismicClient,
@@ -66,7 +66,7 @@ export const fetchMultiContent = async (
       ...pagesFields,
       ...interpretationTypesFields,
       ...placesFetchLinks,
-      ...eventFormatsFields,
+      ...eventFormatFetchLinks,
       ...eventPoliciesFields,
       ...audiencesFields,
       ...articleSeriesFields,

--- a/content/webapp/services/prismic/fetch/multi-content.ts
+++ b/content/webapp/services/prismic/fetch/multi-content.ts
@@ -7,7 +7,6 @@ import {
 } from '../types/multi-content';
 import * as prismic from '@prismicio/client';
 import {
-  interpretationTypesFields,
   eventPoliciesFields,
   audiencesFields,
   articleSeriesFields,
@@ -23,7 +22,10 @@ import {
 } from '../types';
 import { placesFetchLinks } from '../types/places';
 import { teamsFetchLinks } from '../types/teams';
-import { eventFormatFetchLinks } from '../types/events';
+import {
+  eventFormatFetchLinks,
+  interpretationTypeFetchLinks,
+} from '../types/events';
 import { pagesFetchLinks } from '../types/pages';
 
 export const fetchMultiContent = async (
@@ -67,7 +69,7 @@ export const fetchMultiContent = async (
   return client.get<MultiContentPrismicDocument>({
     fetchLinks: [
       ...pagesFetchLinks,
-      ...interpretationTypesFields,
+      ...interpretationTypeFetchLinks,
       ...placesFetchLinks,
       ...eventFormatFetchLinks,
       ...eventPoliciesFields,

--- a/content/webapp/services/prismic/fetch/multi-content.ts
+++ b/content/webapp/services/prismic/fetch/multi-content.ts
@@ -15,14 +15,13 @@ import {
   audiencesFields,
   articleSeriesFields,
   exhibitionFields,
-  organisationsFields,
   teamsFields,
   articlesFields,
 } from '../fetch-links';
 import { PaginatedResults } from '@weco/common/services/prismic/types';
 import { MultiContent } from '../../../types/multi-content';
 import superjson from 'superjson';
-import { contributionRoleFetchLinks, personFetchLinks } from '../types';
+import { contributorFetchLinks } from '../types';
 
 export const fetchMultiContent = async (
   { client }: GetServerSidePropsPrismicClient,
@@ -72,9 +71,7 @@ export const fetchMultiContent = async (
       ...audiencesFields,
       ...articleSeriesFields,
       ...exhibitionFields,
-      ...personFetchLinks,
-      ...organisationsFields,
-      ...contributionRoleFetchLinks,
+      ...contributorFetchLinks,
       ...teamsFields,
       ...articlesFields,
     ],

--- a/content/webapp/services/prismic/fetch/multi-content.ts
+++ b/content/webapp/services/prismic/fetch/multi-content.ts
@@ -16,14 +16,13 @@ import {
   articleSeriesFields,
   exhibitionFields,
   organisationsFields,
-  contributorsFields,
   teamsFields,
   articlesFields,
 } from '../fetch-links';
 import { PaginatedResults } from '@weco/common/services/prismic/types';
 import { MultiContent } from '../../../types/multi-content';
 import superjson from 'superjson';
-import { personFetchLinks } from '../types';
+import { contributionRoleFetchLinks, personFetchLinks } from '../types';
 
 export const fetchMultiContent = async (
   { client }: GetServerSidePropsPrismicClient,
@@ -75,7 +74,7 @@ export const fetchMultiContent = async (
       ...exhibitionFields,
       ...personFetchLinks,
       ...organisationsFields,
-      ...contributorsFields,
+      ...contributionRoleFetchLinks,
       ...teamsFields,
       ...articlesFields,
     ],

--- a/content/webapp/services/prismic/fetch/multi-content.ts
+++ b/content/webapp/services/prismic/fetch/multi-content.ts
@@ -15,7 +15,6 @@ import {
   audiencesFields,
   articleSeriesFields,
   exhibitionFields,
-  peopleFields,
   organisationsFields,
   contributorsFields,
   teamsFields,
@@ -24,6 +23,7 @@ import {
 import { PaginatedResults } from '@weco/common/services/prismic/types';
 import { MultiContent } from '../../../types/multi-content';
 import superjson from 'superjson';
+import { personFetchLinks } from '../types';
 
 export const fetchMultiContent = async (
   { client }: GetServerSidePropsPrismicClient,
@@ -73,7 +73,7 @@ export const fetchMultiContent = async (
       ...audiencesFields,
       ...articleSeriesFields,
       ...exhibitionFields,
-      ...peopleFields,
+      ...personFetchLinks,
       ...organisationsFields,
       ...contributorsFields,
       ...teamsFields,

--- a/content/webapp/services/prismic/fetch/pages.ts
+++ b/content/webapp/services/prismic/fetch/pages.ts
@@ -1,7 +1,11 @@
 import * as prismic from '@prismicio/client';
 import { fetcher, GetServerSidePropsPrismicClient } from '.';
-import { PagePrismicDocument, pagesFetchLinks } from '../types/pages';
-import { labelsFields, pagesFormatsFields } from '../fetch-links';
+import {
+  pageFormatsFetchLinks,
+  PagePrismicDocument,
+  pagesFetchLinks,
+} from '../types/pages';
+import { labelsFields } from '../fetch-links';
 import { Page } from '../../../types/pages';
 import { SiblingsGroup } from '../../../types/siblings-group';
 import {
@@ -10,6 +14,7 @@ import {
   eventSeriesFetchLinks,
   exhibitionFormatsFetchLinks,
   exhibitionsFetchLinks,
+  projectFormatsFetchLinks,
   seasonsFetchLinks,
 } from '../types';
 import { teamsFetchLinks } from '../types/teams';
@@ -18,7 +23,7 @@ import { collectionVenuesFetchLinks } from '../types/collection-venues';
 import { bookFetchLinks } from '../types/books';
 import { seriesFetchLinks } from '../types/series';
 import { cardFetchLinks } from '../types/card';
-import { guideFetchLinks } from '../types/guides';
+import { guideFetchLinks, guideFormatsFetchLinks } from '../types/guides';
 
 export const fetchLinks = [
   ...pagesFetchLinks,
@@ -36,7 +41,9 @@ export const fetchLinks = [
   ...seasonsFetchLinks,
   ...contributorFetchLinks,
   ...bookFetchLinks,
-  ...pagesFormatsFields,
+  ...pageFormatsFetchLinks,
+  ...guideFormatsFetchLinks,
+  ...projectFormatsFetchLinks,
   ...guideFetchLinks,
 ];
 

--- a/content/webapp/services/prismic/fetch/pages.ts
+++ b/content/webapp/services/prismic/fetch/pages.ts
@@ -15,13 +15,13 @@ import {
   labelsFields,
   seasonsFields,
   contributorsFields,
-  peopleFields,
   bookFields,
   pagesFormatsFields,
   guidesFields,
 } from '../fetch-links';
 import { Page } from '../../../types/pages';
 import { SiblingsGroup } from '../../../types/siblings-group';
+import { personFetchLinks } from '../types';
 
 export const fetchLinks = [
   ...pagesFields,
@@ -37,7 +37,7 @@ export const fetchLinks = [
   ...labelsFields,
   ...seasonsFields,
   ...contributorsFields,
-  ...peopleFields,
+  ...personFetchLinks,
   ...bookFields,
   ...pagesFormatsFields,
   ...guidesFields,

--- a/content/webapp/services/prismic/fetch/pages.ts
+++ b/content/webapp/services/prismic/fetch/pages.ts
@@ -3,7 +3,6 @@ import { fetcher, GetServerSidePropsPrismicClient } from '.';
 import { PagePrismicDocument, pagesFetchLinks } from '../types/pages';
 import {
   articleSeriesFields,
-  eventSeriesFields,
   exhibitionFields,
   eventsFields,
   cardsFields,
@@ -15,7 +14,11 @@ import {
 } from '../fetch-links';
 import { Page } from '../../../types/pages';
 import { SiblingsGroup } from '../../../types/siblings-group';
-import { articleFormatsFetchLinks, contributorFetchLinks } from '../types';
+import {
+  articleFormatsFetchLinks,
+  contributorFetchLinks,
+  eventSeriesFetchLinks,
+} from '../types';
 import { teamsFetchLinks } from '../types/teams';
 import { eventFormatFetchLinks } from '../types/events';
 import { collectionVenuesFetchLinks } from '../types/collection-venues';
@@ -23,7 +26,7 @@ import { collectionVenuesFetchLinks } from '../types/collection-venues';
 export const fetchLinks = [
   ...pagesFetchLinks,
   ...articleSeriesFields,
-  ...eventSeriesFields,
+  ...eventSeriesFetchLinks,
   ...collectionVenuesFetchLinks,
   ...exhibitionFields,
   ...teamsFetchLinks,

--- a/content/webapp/services/prismic/fetch/pages.ts
+++ b/content/webapp/services/prismic/fetch/pages.ts
@@ -7,7 +7,6 @@ import {
   collectionVenuesFields,
   eventSeriesFields,
   exhibitionFields,
-  teamsFields,
   eventsFields,
   cardsFields,
   eventFormatsFields,
@@ -21,6 +20,7 @@ import {
 import { Page } from '../../../types/pages';
 import { SiblingsGroup } from '../../../types/siblings-group';
 import { contributorFetchLinks } from '../types';
+import { teamsFetchLinks } from '../types/teams';
 
 export const fetchLinks = [
   ...pagesFields,
@@ -28,7 +28,7 @@ export const fetchLinks = [
   ...eventSeriesFields,
   ...collectionVenuesFields,
   ...exhibitionFields,
-  ...teamsFields,
+  ...teamsFetchLinks,
   ...eventsFields,
   ...cardsFields,
   ...eventFormatsFields,

--- a/content/webapp/services/prismic/fetch/pages.ts
+++ b/content/webapp/services/prismic/fetch/pages.ts
@@ -20,7 +20,7 @@ import {
 } from '../fetch-links';
 import { Page } from '../../../types/pages';
 import { SiblingsGroup } from '../../../types/siblings-group';
-import { contributionRoleFetchLinks, personFetchLinks } from '../types';
+import { contributorFetchLinks } from '../types';
 
 export const fetchLinks = [
   ...pagesFields,
@@ -35,8 +35,7 @@ export const fetchLinks = [
   ...articleFormatsFields,
   ...labelsFields,
   ...seasonsFields,
-  ...contributionRoleFetchLinks,
-  ...personFetchLinks,
+  ...contributorFetchLinks,
   ...bookFields,
   ...pagesFormatsFields,
   ...guidesFields,

--- a/content/webapp/services/prismic/fetch/pages.ts
+++ b/content/webapp/services/prismic/fetch/pages.ts
@@ -7,7 +7,6 @@ import {
   cardsFields,
   labelsFields,
   seasonsFields,
-  bookFields,
   pagesFormatsFields,
   guidesFields,
 } from '../fetch-links';
@@ -23,6 +22,7 @@ import {
 import { teamsFetchLinks } from '../types/teams';
 import { eventFormatFetchLinks } from '../types/events';
 import { collectionVenuesFetchLinks } from '../types/collection-venues';
+import { bookFetchLinks } from '../types/books';
 
 export const fetchLinks = [
   ...pagesFetchLinks,
@@ -39,7 +39,7 @@ export const fetchLinks = [
   ...labelsFields,
   ...seasonsFields,
   ...contributorFetchLinks,
-  ...bookFields,
+  ...bookFetchLinks,
   ...pagesFormatsFields,
   ...guidesFields,
 ];

--- a/content/webapp/services/prismic/fetch/pages.ts
+++ b/content/webapp/services/prismic/fetch/pages.ts
@@ -14,14 +14,13 @@ import {
   articleFormatsFields,
   labelsFields,
   seasonsFields,
-  contributorsFields,
   bookFields,
   pagesFormatsFields,
   guidesFields,
 } from '../fetch-links';
 import { Page } from '../../../types/pages';
 import { SiblingsGroup } from '../../../types/siblings-group';
-import { personFetchLinks } from '../types';
+import { contributionRoleFetchLinks, personFetchLinks } from '../types';
 
 export const fetchLinks = [
   ...pagesFields,
@@ -36,7 +35,7 @@ export const fetchLinks = [
   ...articleFormatsFields,
   ...labelsFields,
   ...seasonsFields,
-  ...contributorsFields,
+  ...contributionRoleFetchLinks,
   ...personFetchLinks,
   ...bookFields,
   ...pagesFormatsFields,

--- a/content/webapp/services/prismic/fetch/pages.ts
+++ b/content/webapp/services/prismic/fetch/pages.ts
@@ -6,7 +6,6 @@ import {
   eventsFields,
   cardsFields,
   labelsFields,
-  seasonsFields,
   pagesFormatsFields,
   guidesFields,
 } from '../fetch-links';
@@ -18,6 +17,7 @@ import {
   eventSeriesFetchLinks,
   exhibitionFormatsFetchLinks,
   exhibitionsFetchLinks,
+  seasonsFetchLinks,
 } from '../types';
 import { teamsFetchLinks } from '../types/teams';
 import { eventFormatFetchLinks } from '../types/events';
@@ -37,7 +37,7 @@ export const fetchLinks = [
   ...eventFormatFetchLinks,
   ...articleFormatsFetchLinks,
   ...labelsFields,
-  ...seasonsFields,
+  ...seasonsFetchLinks,
   ...contributorFetchLinks,
   ...bookFetchLinks,
   ...pagesFormatsFields,

--- a/content/webapp/services/prismic/fetch/pages.ts
+++ b/content/webapp/services/prismic/fetch/pages.ts
@@ -3,7 +3,6 @@ import { fetcher, GetServerSidePropsPrismicClient } from '.';
 import { PagePrismicDocument, pagesFetchLinks } from '../types/pages';
 import {
   articleSeriesFields,
-  exhibitionFields,
   eventsFields,
   cardsFields,
   labelsFields,
@@ -18,6 +17,8 @@ import {
   articleFormatsFetchLinks,
   contributorFetchLinks,
   eventSeriesFetchLinks,
+  exhibitionFormatsFetchLinks,
+  exhibitionsFetchLinks,
 } from '../types';
 import { teamsFetchLinks } from '../types/teams';
 import { eventFormatFetchLinks } from '../types/events';
@@ -28,7 +29,8 @@ export const fetchLinks = [
   ...articleSeriesFields,
   ...eventSeriesFetchLinks,
   ...collectionVenuesFetchLinks,
-  ...exhibitionFields,
+  ...exhibitionFormatsFetchLinks,
+  ...exhibitionsFetchLinks,
   ...teamsFetchLinks,
   ...eventsFields,
   ...cardsFields,

--- a/content/webapp/services/prismic/fetch/pages.ts
+++ b/content/webapp/services/prismic/fetch/pages.ts
@@ -9,7 +9,6 @@ import {
   exhibitionFields,
   eventsFields,
   cardsFields,
-  eventFormatsFields,
   labelsFields,
   seasonsFields,
   bookFields,
@@ -20,6 +19,7 @@ import { Page } from '../../../types/pages';
 import { SiblingsGroup } from '../../../types/siblings-group';
 import { articleFormatsFetchLinks, contributorFetchLinks } from '../types';
 import { teamsFetchLinks } from '../types/teams';
+import { eventFormatFetchLinks } from '../types/events';
 
 export const fetchLinks = [
   ...pagesFields,
@@ -30,7 +30,7 @@ export const fetchLinks = [
   ...teamsFetchLinks,
   ...eventsFields,
   ...cardsFields,
-  ...eventFormatsFields,
+  ...eventFormatFetchLinks,
   ...articleFormatsFetchLinks,
   ...labelsFields,
   ...seasonsFields,

--- a/content/webapp/services/prismic/fetch/pages.ts
+++ b/content/webapp/services/prismic/fetch/pages.ts
@@ -1,9 +1,8 @@
 import * as prismic from '@prismicio/client';
 import { fetcher, GetServerSidePropsPrismicClient } from '.';
-import { PagePrismicDocument } from '../types/pages';
+import { PagePrismicDocument, pagesFetchLinks } from '../types/pages';
 import {
   articleSeriesFields,
-  pagesFields,
   collectionVenuesFields,
   eventSeriesFields,
   exhibitionFields,
@@ -22,7 +21,7 @@ import { teamsFetchLinks } from '../types/teams';
 import { eventFormatFetchLinks } from '../types/events';
 
 export const fetchLinks = [
-  ...pagesFields,
+  ...pagesFetchLinks,
   ...articleSeriesFields,
   ...eventSeriesFields,
   ...collectionVenuesFields,

--- a/content/webapp/services/prismic/fetch/pages.ts
+++ b/content/webapp/services/prismic/fetch/pages.ts
@@ -1,12 +1,7 @@
 import * as prismic from '@prismicio/client';
 import { fetcher, GetServerSidePropsPrismicClient } from '.';
 import { PagePrismicDocument, pagesFetchLinks } from '../types/pages';
-import {
-  cardsFields,
-  labelsFields,
-  pagesFormatsFields,
-  guidesFields,
-} from '../fetch-links';
+import { labelsFields, pagesFormatsFields, guidesFields } from '../fetch-links';
 import { Page } from '../../../types/pages';
 import { SiblingsGroup } from '../../../types/siblings-group';
 import {
@@ -22,6 +17,7 @@ import { eventFormatFetchLinks, eventsFetchLinks } from '../types/events';
 import { collectionVenuesFetchLinks } from '../types/collection-venues';
 import { bookFetchLinks } from '../types/books';
 import { seriesFetchLinks } from '../types/series';
+import { cardFetchLinks } from '../types/card';
 
 export const fetchLinks = [
   ...pagesFetchLinks,
@@ -32,7 +28,7 @@ export const fetchLinks = [
   ...exhibitionsFetchLinks,
   ...teamsFetchLinks,
   ...eventsFetchLinks,
-  ...cardsFields,
+  ...cardFetchLinks,
   ...eventFormatFetchLinks,
   ...articleFormatsFetchLinks,
   ...labelsFields,

--- a/content/webapp/services/prismic/fetch/pages.ts
+++ b/content/webapp/services/prismic/fetch/pages.ts
@@ -1,7 +1,7 @@
 import * as prismic from '@prismicio/client';
 import { fetcher, GetServerSidePropsPrismicClient } from '.';
 import { PagePrismicDocument, pagesFetchLinks } from '../types/pages';
-import { labelsFields, pagesFormatsFields, guidesFields } from '../fetch-links';
+import { labelsFields, pagesFormatsFields } from '../fetch-links';
 import { Page } from '../../../types/pages';
 import { SiblingsGroup } from '../../../types/siblings-group';
 import {
@@ -18,6 +18,7 @@ import { collectionVenuesFetchLinks } from '../types/collection-venues';
 import { bookFetchLinks } from '../types/books';
 import { seriesFetchLinks } from '../types/series';
 import { cardFetchLinks } from '../types/card';
+import { guideFetchLinks } from '../types/guides';
 
 export const fetchLinks = [
   ...pagesFetchLinks,
@@ -36,7 +37,7 @@ export const fetchLinks = [
   ...contributorFetchLinks,
   ...bookFetchLinks,
   ...pagesFormatsFields,
-  ...guidesFields,
+  ...guideFetchLinks,
 ];
 
 /** Although these are three different document types in Prismic, they all get

--- a/content/webapp/services/prismic/fetch/pages.ts
+++ b/content/webapp/services/prismic/fetch/pages.ts
@@ -10,7 +10,6 @@ import {
   eventsFields,
   cardsFields,
   eventFormatsFields,
-  articleFormatsFields,
   labelsFields,
   seasonsFields,
   bookFields,
@@ -19,7 +18,7 @@ import {
 } from '../fetch-links';
 import { Page } from '../../../types/pages';
 import { SiblingsGroup } from '../../../types/siblings-group';
-import { contributorFetchLinks } from '../types';
+import { articleFormatsFetchLinks, contributorFetchLinks } from '../types';
 import { teamsFetchLinks } from '../types/teams';
 
 export const fetchLinks = [
@@ -32,7 +31,7 @@ export const fetchLinks = [
   ...eventsFields,
   ...cardsFields,
   ...eventFormatsFields,
-  ...articleFormatsFields,
+  ...articleFormatsFetchLinks,
   ...labelsFields,
   ...seasonsFields,
   ...contributorFetchLinks,

--- a/content/webapp/services/prismic/fetch/pages.ts
+++ b/content/webapp/services/prismic/fetch/pages.ts
@@ -3,7 +3,6 @@ import { fetcher, GetServerSidePropsPrismicClient } from '.';
 import { PagePrismicDocument, pagesFetchLinks } from '../types/pages';
 import {
   articleSeriesFields,
-  eventsFields,
   cardsFields,
   labelsFields,
   pagesFormatsFields,
@@ -20,7 +19,7 @@ import {
   seasonsFetchLinks,
 } from '../types';
 import { teamsFetchLinks } from '../types/teams';
-import { eventFormatFetchLinks } from '../types/events';
+import { eventFormatFetchLinks, eventsFetchLinks } from '../types/events';
 import { collectionVenuesFetchLinks } from '../types/collection-venues';
 import { bookFetchLinks } from '../types/books';
 
@@ -32,7 +31,7 @@ export const fetchLinks = [
   ...exhibitionFormatsFetchLinks,
   ...exhibitionsFetchLinks,
   ...teamsFetchLinks,
-  ...eventsFields,
+  ...eventsFetchLinks,
   ...cardsFields,
   ...eventFormatFetchLinks,
   ...articleFormatsFetchLinks,

--- a/content/webapp/services/prismic/fetch/pages.ts
+++ b/content/webapp/services/prismic/fetch/pages.ts
@@ -2,7 +2,6 @@ import * as prismic from '@prismicio/client';
 import { fetcher, GetServerSidePropsPrismicClient } from '.';
 import { PagePrismicDocument, pagesFetchLinks } from '../types/pages';
 import {
-  articleSeriesFields,
   cardsFields,
   labelsFields,
   pagesFormatsFields,
@@ -22,10 +21,11 @@ import { teamsFetchLinks } from '../types/teams';
 import { eventFormatFetchLinks, eventsFetchLinks } from '../types/events';
 import { collectionVenuesFetchLinks } from '../types/collection-venues';
 import { bookFetchLinks } from '../types/books';
+import { seriesFetchLinks } from '../types/series';
 
 export const fetchLinks = [
   ...pagesFetchLinks,
-  ...articleSeriesFields,
+  ...seriesFetchLinks,
   ...eventSeriesFetchLinks,
   ...collectionVenuesFetchLinks,
   ...exhibitionFormatsFetchLinks,

--- a/content/webapp/services/prismic/fetch/pages.ts
+++ b/content/webapp/services/prismic/fetch/pages.ts
@@ -3,7 +3,6 @@ import { fetcher, GetServerSidePropsPrismicClient } from '.';
 import { PagePrismicDocument, pagesFetchLinks } from '../types/pages';
 import {
   articleSeriesFields,
-  collectionVenuesFields,
   eventSeriesFields,
   exhibitionFields,
   eventsFields,
@@ -19,12 +18,13 @@ import { SiblingsGroup } from '../../../types/siblings-group';
 import { articleFormatsFetchLinks, contributorFetchLinks } from '../types';
 import { teamsFetchLinks } from '../types/teams';
 import { eventFormatFetchLinks } from '../types/events';
+import { collectionVenuesFetchLinks } from '../types/collection-venues';
 
 export const fetchLinks = [
   ...pagesFetchLinks,
   ...articleSeriesFields,
   ...eventSeriesFields,
-  ...collectionVenuesFields,
+  ...collectionVenuesFetchLinks,
   ...exhibitionFields,
   ...teamsFetchLinks,
   ...eventsFields,

--- a/content/webapp/services/prismic/types/articles.ts
+++ b/content/webapp/services/prismic/types/articles.ts
@@ -13,6 +13,7 @@ import {
   WithExhibitionParents,
   WithSeasons,
   WithContributors,
+  FetchLinks,
 } from '.';
 import { InferDataInterface } from '@weco/common/services/prismic/types';
 
@@ -43,3 +44,7 @@ export type ArticlePrismicDocument = PrismicDocument<
     CommonPrismicFields,
   'articles' | 'webcomics'
 >;
+
+export const articlesFetchLinks: FetchLinks<ArticlePrismicDocument> = [
+  'articles.title',
+];

--- a/content/webapp/services/prismic/types/books.ts
+++ b/content/webapp/services/prismic/types/books.ts
@@ -8,6 +8,7 @@ import {
 } from '@prismicio/types';
 import {
   CommonPrismicFields,
+  FetchLinks,
   WithContributors,
   WithExhibitionParents,
   WithSeasons,
@@ -32,3 +33,5 @@ export type BookPrismicDocument = PrismicDocument<
     CommonPrismicFields,
   'books'
 >;
+
+export const bookFetchLinks: FetchLinks<BookPrismicDocument> = ['books.title'];

--- a/content/webapp/services/prismic/types/card.ts
+++ b/content/webapp/services/prismic/types/card.ts
@@ -11,6 +11,7 @@ import {
   WithContributors,
   WithExhibitionParents,
   WithSeasons,
+  FetchLinks,
 } from '.';
 import { InferDataInterface } from '@weco/common/services/prismic/types';
 import { EventFormat } from './events';
@@ -47,3 +48,11 @@ export type CardPrismicDocument = PrismicDocument<
     CommonPrismicFields,
   typeof typeEnum
 >;
+
+export const cardFetchLinks: FetchLinks<CardPrismicDocument> = [
+  'card.title',
+  'card.format',
+  'card.description',
+  'card.image',
+  'card.link',
+];

--- a/content/webapp/services/prismic/types/collection-venues.ts
+++ b/content/webapp/services/prismic/types/collection-venues.ts
@@ -1,0 +1,19 @@
+import { CollectionVenuePrismicDocument } from '@weco/common/services/prismic/documents';
+import { FetchLinks } from '.';
+
+export const collectionVenuesFetchLinks: FetchLinks<CollectionVenuePrismicDocument> =
+  [
+    'collection-venue.title',
+    'collection-venue.image',
+    'collection-venue.link',
+    'collection-venue.linkText',
+    'collection-venue.order',
+    'collection-venue.monday',
+    'collection-venue.tuesday',
+    'collection-venue.wednesday',
+    'collection-venue.thursday',
+    'collection-venue.friday',
+    'collection-venue.saturday',
+    'collection-venue.sunday',
+    'collection-venue.modifiedDayOpeningTimes',
+  ];

--- a/content/webapp/services/prismic/types/events.ts
+++ b/content/webapp/services/prismic/types/events.ts
@@ -71,7 +71,7 @@ export type EventPolicy = PrismicDocument<
   },
   'event-policies'
 >;
-export const eventPolicyFetchLink: FetchLinks<EventPolicy> = [
+export const eventPolicyFetchLinks: FetchLinks<EventPolicy> = [
   'event-policies.title',
   'event-policies.description',
 ];

--- a/content/webapp/services/prismic/types/events.ts
+++ b/content/webapp/services/prismic/types/events.ts
@@ -31,7 +31,7 @@ export type EventFormat = PrismicDocument<
   },
   'event-formats'
 >;
-export const eventFormatFetchLink: FetchLinks<EventFormat> = [
+export const eventFormatFetchLinks: FetchLinks<EventFormat> = [
   'event-formats.title',
   'event-formats.description',
 ];

--- a/content/webapp/services/prismic/types/events.ts
+++ b/content/webapp/services/prismic/types/events.ts
@@ -205,6 +205,7 @@ export type EventPrismicDocument = PrismicDocument<
 >;
 
 export const eventsFetchLinks: FetchLinks<EventPrismicDocument> = [
+  'events.title',
   'events.audiences',
   'events.schedule',
   'events.interpretations',

--- a/content/webapp/services/prismic/types/guides.ts
+++ b/content/webapp/services/prismic/types/guides.ts
@@ -24,6 +24,11 @@ export type GuideFormatPrismicDocument = PrismicDocument<
   'guide-formats'
 >;
 
+export const guideFormatsFetchLinks: FetchLinks<GuideFormatPrismicDocument> = [
+  'guide-formats.title',
+  'guide-formats.description',
+];
+
 export type WithGuideFormat = {
   format: RelationField<
     'guide-formats',

--- a/content/webapp/services/prismic/types/guides.ts
+++ b/content/webapp/services/prismic/types/guides.ts
@@ -7,6 +7,7 @@ import {
 } from '@prismicio/types';
 import {
   CommonPrismicFields,
+  FetchLinks,
   WithContributors,
   WithExhibitionParents,
   WithSeasons,
@@ -43,3 +44,8 @@ export type GuidePrismicDocument = PrismicDocument<
     CommonPrismicFields,
   typeof typeEnum
 >;
+
+export const guideFetchLinks: FetchLinks<GuidePrismicDocument> = [
+  'guides.title',
+  'guides.promo',
+];

--- a/content/webapp/services/prismic/types/index.ts
+++ b/content/webapp/services/prismic/types/index.ts
@@ -114,8 +114,9 @@ export type WithEventSeries = {
     >;
   }>;
 };
-export const eventSeriesFetchLink: FetchLinks<EventSeriesPrismicDocument> = [
+export const eventSeriesFetchLinks: FetchLinks<EventSeriesPrismicDocument> = [
   'event-series.title',
+  'event-series.backgroundTexture',
   'event-series.promo',
 ];
 

--- a/content/webapp/services/prismic/types/index.ts
+++ b/content/webapp/services/prismic/types/index.ts
@@ -173,6 +173,7 @@ export const exhibitionsFetchLinks: FetchLinks<ExhibitionPrismicDocument> = [
   'exhibitions.title',
   'exhibitions.promo',
   'exhibitions.shortTitle',
+  'exhibitions.format',
 ];
 
 type Contributor =

--- a/content/webapp/services/prismic/types/index.ts
+++ b/content/webapp/services/prismic/types/index.ts
@@ -131,6 +131,8 @@ export type WithSeasons = {
 };
 export const seasonsFetchLinks: FetchLinks<SeasonPrismicDocument> = [
   'seasons.title',
+  'seasons.start',
+  'seasons.end',
   'seasons.promo',
 ];
 

--- a/content/webapp/services/prismic/types/index.ts
+++ b/content/webapp/services/prismic/types/index.ts
@@ -196,6 +196,14 @@ export type WithContributors = {
   }>;
 };
 
+export const personFetchLinks: FetchLinks<Person> = [
+  'people.name',
+  'people.description',
+  'people.pronouns',
+  'people.image',
+  'people.sameAs',
+];
+
 type ContributorFetchLink = (
   | FetchLinks<EditorialContributorRole>[number]
   | FetchLinks<Person>[number]
@@ -204,11 +212,7 @@ type ContributorFetchLink = (
 export const contributorFetchLinks: ContributorFetchLink = [
   'editorial-contributor-roles.title',
   'editorial-contributor-roles.describedBy',
-  'people.name',
-  'people.description',
-  'people.pronouns',
-  'people.image',
-  'people.sameAs',
+  ...personFetchLinks,
   'organisations.name',
   'organisations.description',
   'organisations.image',

--- a/content/webapp/services/prismic/types/index.ts
+++ b/content/webapp/services/prismic/types/index.ts
@@ -196,13 +196,12 @@ export type WithContributors = {
   }>;
 };
 
-export const contributionRoleFetchLinks: FetchLinks<EditorialContributorRole> =
-  [
-    'editorial-contributor-roles.title',
-    'editorial-contributor-roles.describedBy',
-  ];
+const contributionRoleFetchLinks: FetchLinks<EditorialContributorRole> = [
+  'editorial-contributor-roles.title',
+  'editorial-contributor-roles.describedBy',
+];
 
-export const personFetchLinks: FetchLinks<Person> = [
+const personFetchLinks: FetchLinks<Person> = [
   'people.name',
   'people.description',
   'people.pronouns',
@@ -210,18 +209,17 @@ export const personFetchLinks: FetchLinks<Person> = [
   'people.sameAs',
 ];
 
-type ContributorFetchLink = (
-  | FetchLinks<EditorialContributorRole>[number]
-  | FetchLinks<Person>[number]
-  | FetchLinks<Organisation>[number]
-)[];
-export const contributorFetchLinks: ContributorFetchLink = [
-  ...contributionRoleFetchLinks,
-  ...personFetchLinks,
+const organisationFetchLinks: FetchLinks<Organisation> = [
   'organisations.name',
   'organisations.description',
   'organisations.image',
   'organisations.sameAs',
+];
+
+export const contributorFetchLinks = [
+  ...contributionRoleFetchLinks,
+  ...personFetchLinks,
+  ...organisationFetchLinks,
 ];
 
 // Guards

--- a/content/webapp/services/prismic/types/index.ts
+++ b/content/webapp/services/prismic/types/index.ts
@@ -196,6 +196,12 @@ export type WithContributors = {
   }>;
 };
 
+export const contributionRoleFetchLinks: FetchLinks<EditorialContributorRole> =
+  [
+    'editorial-contributor-roles.title',
+    'editorial-contributor-roles.describedBy',
+  ];
+
 export const personFetchLinks: FetchLinks<Person> = [
   'people.name',
   'people.description',
@@ -210,8 +216,7 @@ type ContributorFetchLink = (
   | FetchLinks<Organisation>[number]
 )[];
 export const contributorFetchLinks: ContributorFetchLink = [
-  'editorial-contributor-roles.title',
-  'editorial-contributor-roles.describedBy',
+  ...contributionRoleFetchLinks,
   ...personFetchLinks,
   'organisations.name',
   'organisations.description',

--- a/content/webapp/services/prismic/types/pages.ts
+++ b/content/webapp/services/prismic/types/pages.ts
@@ -7,6 +7,7 @@ import {
 } from '@prismicio/types';
 import {
   CommonPrismicFields,
+  FetchLinks,
   WithContributors,
   WithExhibitionParents,
   WithSeasons,
@@ -43,3 +44,8 @@ export type PagePrismicDocument = PrismicDocument<
     CommonPrismicFields,
   typeof typeEnum
 >;
+
+export const pagesFetchLinks: FetchLinks<PagePrismicDocument> = [
+  'pages.title',
+  'pages.promo',
+];

--- a/content/webapp/services/prismic/types/pages.ts
+++ b/content/webapp/services/prismic/types/pages.ts
@@ -23,6 +23,11 @@ type PageFormat = PrismicDocument<
   'page-formats'
 >;
 
+export const pageFormatsFetchLinks: FetchLinks<PageFormat> = [
+  'page-formats.title',
+  'page-formats.description',
+];
+
 export type WithPageFormat = {
   format: RelationField<
     'page-formats',

--- a/content/webapp/services/prismic/types/places.ts
+++ b/content/webapp/services/prismic/types/places.ts
@@ -19,7 +19,7 @@ export type PlacePrismicDocument = PrismicDocument<
   'places'
 >;
 
-export const placesFetchLink: FetchLinks<PlacePrismicDocument> = [
+export const placesFetchLinks: FetchLinks<PlacePrismicDocument> = [
   'places.title',
   'places.geolocation',
   'places.level',

--- a/content/webapp/services/prismic/types/project-format.ts
+++ b/content/webapp/services/prismic/types/project-format.ts
@@ -10,5 +10,4 @@ export type ProjectFormat = PrismicDocument<
 
 export const projectFormatsFetchLinks: FetchLinks<ProjectFormat> = [
   'project-formats.title',
-  'project-formats.description',
 ];

--- a/content/webapp/services/prismic/types/project-format.ts
+++ b/content/webapp/services/prismic/types/project-format.ts
@@ -1,4 +1,5 @@
 import { RichTextField, PrismicDocument } from '@prismicio/types';
+import { FetchLinks } from '.';
 
 export type ProjectFormat = PrismicDocument<
   {
@@ -6,3 +7,8 @@ export type ProjectFormat = PrismicDocument<
   },
   'project-formats'
 >;
+
+export const projectFormatsFetchLinks: FetchLinks<ProjectFormat> = [
+  'project-formats.title',
+  'project-formats.description',
+];

--- a/content/webapp/services/prismic/types/teams.ts
+++ b/content/webapp/services/prismic/types/teams.ts
@@ -1,5 +1,5 @@
 import { KeyTextField, RichTextField, PrismicDocument } from '@prismicio/types';
-import { CommonPrismicFields } from '.';
+import { CommonPrismicFields, FetchLinks } from '.';
 
 export type TeamPrismicDocument = PrismicDocument<
   {
@@ -11,3 +11,11 @@ export type TeamPrismicDocument = PrismicDocument<
   } & CommonPrismicFields,
   'teams'
 >;
+
+export const teamsFetchLinks: FetchLinks<TeamPrismicDocument> = [
+  'teams.title',
+  'teams.subtitle',
+  'teams.email',
+  'teams.phone',
+  'teams.url',
+];


### PR DESCRIPTION
For https://github.com/wellcomecollection/wellcomecollection.org/issues/8846

In most cases these variables are either like-for-like, or the new variable is a strict superset of the fields in the old variable. There are a couple I couldn't work out, and I've added a comment.

Mostly this is meant to reduce confusion about where these come from, because there's now only one source (and variable naming convention) for fetch links.