### PR TITLE
Tweak some of the event transformer code

### DIFF
--- a/content/webapp/__mocks__/events.ts
+++ b/content/webapp/__mocks__/events.ts
@@ -63,7 +63,6 @@ const baseEvent: Event = {
     image: image,
     link: `/pages/${prismicPageIds.dailyGuidedTours}`,
   },
-  scheduleLength: 0,
   seasons: [],
   isOnline: false,
   availableOnline: false,

--- a/content/webapp/components/CardGrid/DailyTourPromo.tsx
+++ b/content/webapp/components/CardGrid/DailyTourPromo.tsx
@@ -20,6 +20,7 @@ const data: EventBasic = {
   locations: [],
   cost: undefined,
   isPast: false,
+  labels: [],
   primaryLabels: [],
   secondaryLabels: [],
   promo: {

--- a/content/webapp/components/CardGrid/DailyTourPromo.tsx
+++ b/content/webapp/components/CardGrid/DailyTourPromo.tsx
@@ -1,4 +1,4 @@
-import { Event } from '../../types/events';
+import { EventBasic } from '../../types/events';
 import { prismicPageIds } from '@weco/common/data/hardcoded-ids';
 import EventPromo from '../EventPromo/EventPromo';
 import { FunctionComponent } from 'react';
@@ -12,36 +12,14 @@ const image = {
   crops: {},
 };
 
-export const data: Event = {
+const data: EventBasic = {
   id: 'tours',
   title: 'Daily Guided Tours and Discussions',
   times: [],
   series: [],
   locations: [],
-  bookingEnquiryTeam: undefined,
-  interpretations: [],
-  audiences: [],
-  policies: [],
-  bookingInformation: undefined,
   cost: undefined,
-  bookingType: undefined,
-  thirdPartyBooking: undefined,
-  isCompletelySoldOut: false,
   isPast: false,
-  isRelaxedPerformance: false,
-  format: {
-    id: 'WmYRpCQAACUAn-Ap',
-    title: 'Gallery tour',
-    description: undefined,
-  },
-  body: [],
-  image,
-  hasEarlyRegistration: false,
-  labels: [
-    {
-      text: 'Gallery tour',
-    },
-  ],
   primaryLabels: [],
   secondaryLabels: [],
   promo: {
@@ -49,13 +27,9 @@ export const data: Event = {
     link: `/pages/${prismicPageIds.dailyGuidedTours}`,
   },
   scheduleLength: 0,
-  seasons: [],
   isOnline: false,
   availableOnline: false,
-  contributors: [],
   type: 'events',
-  onlinePolicies: [],
-  onlineHasEarlyRegistration: false,
 };
 
 const DailyTourPromo: FunctionComponent = () => (

--- a/content/webapp/components/EventDateRange/EventDateRange.tsx
+++ b/content/webapp/components/EventDateRange/EventDateRange.tsx
@@ -19,8 +19,8 @@ type Props = {
  *
  *    [
  *      { start: 1 Sept @ 9am, end: 1 Sept @ 10am },
- *      { start: 1 Oct  @ 9am,  end: 1 Oct  @ 10am }
- *      { start: 1 Nov  @ 9am,  end: 1 Nov  @ 10am }
+ *      { start: 1 Oct  @ 9am, end: 1 Oct  @ 10am }
+ *      { start: 1 Nov  @ 9am, end: 1 Nov  @ 10am }
  *    ]
  *
  * On the event page, we can display the full list of dates, but in certain contexts

--- a/content/webapp/components/EventPromo/EventPromo.tsx
+++ b/content/webapp/components/EventPromo/EventPromo.tsx
@@ -136,25 +136,27 @@ const EventPromo: FunctionComponent<Props> = ({
           )}
 
           {!isPast && (
-            <p className={`${font('intr', 5)} no-padding no-margin`}>
-              <EventDateRange
-                event={event}
-                splitTime={true}
-                fromDate={fromDate}
-              />
-            </p>
-          )}
+            <>
+              <p className={`${font('intr', 5)} no-padding no-margin`}>
+                <EventDateRange
+                  event={event}
+                  splitTime={true}
+                  fromDate={fromDate}
+                />
+              </p>
 
-          {!isPast && dateString && (
-            <p className={`${font('intr', 5)} no-padding no-margin`}>
-              {dateString}
-            </p>
-          )}
+              {dateString && (
+                <p className={`${font('intr', 5)} no-padding no-margin`}>
+                  {dateString}
+                </p>
+              )}
 
-          {!isPast && timeString && (
-            <p className={`${font('intr', 5)} no-padding no-margin`}>
-              {timeString}
-            </p>
+              {timeString && (
+                <p className={`${font('intr', 5)} no-padding no-margin`}>
+                  {timeString}
+                </p>
+              )}
+            </>
           )}
 
           {upcomingDatesFullyBooked(event) && (
@@ -173,16 +175,20 @@ const EventPromo: FunctionComponent<Props> = ({
             </Space>
           )}
 
-          {!isPast && event.scheduleLength > 0 && (
-            <p className={`${font('intb', 5)} no-padding no-margin`}>
-              {`${event.scheduleLength} ${
-                event.scheduleLength > 1 ? 'events' : 'event'
-              }`}
-            </p>
-          )}
+          {!isPast && (
+            <>
+              {event.scheduleLength > 0 && (
+                <p className={`${font('intb', 5)} no-padding no-margin`}>
+                  {`${event.scheduleLength} ${
+                    event.scheduleLength > 1 ? 'events' : 'event'
+                  }`}
+                </p>
+              )}
 
-          {!isPast && event.times.length > 1 && (
-            <p className={font('intb', 6)}>See all dates/times</p>
+              {event.times.length > 1 && (
+                <p className={font('intb', 6)}>See all dates/times</p>
+              )}
+            </>
           )}
 
           {isPast && !event.availableOnline && (

--- a/content/webapp/components/Exhibition/Exhibition.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.tsx
@@ -37,7 +37,7 @@ import {
   ExhibitionAbout,
 } from '../../types/exhibitions';
 
-import { Event as EventType } from '../../types/events';
+import { EventBasic } from '../../types/events';
 import * as prismicT from '@prismicio/types';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 
@@ -208,7 +208,7 @@ const Exhibition: FunctionComponent<Props> = ({
   jsonLd,
   pages,
 }) => {
-  type ExhibitionOf = (ExhibitionType | EventType)[];
+  type ExhibitionOf = (ExhibitionType | EventBasic)[];
 
   const [exhibitionOfs, setExhibitionOfs] = useState<ExhibitionOf>([]);
   const [exhibitionAbouts, setExhibitionAbouts] = useState<ExhibitionAbout[]>(

--- a/content/webapp/components/FeaturedCard/FeaturedCard.tsx
+++ b/content/webapp/components/FeaturedCard/FeaturedCard.tsx
@@ -21,7 +21,7 @@ import linkResolver from '@weco/common/services/prismic/link-resolver';
 import { Page } from '../../types/pages';
 import { EventSeries } from '../../types/event-series';
 import { Book } from '../../types/books';
-import { Event } from '../../types/events';
+import { EventBasic } from '../../types/events';
 import { Guide } from '../../types/guides';
 import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImage';
 import { PaletteColor } from '@weco/common/views/themes/config';
@@ -67,7 +67,7 @@ export function convertItemToFeaturedCardProps(
     | Page
     | EventSeries
     | Book
-    | Event
+    | EventBasic
     | Guide
 ): PartialFeaturedCard {
   return {

--- a/content/webapp/pages/event-series.tsx
+++ b/content/webapp/pages/event-series.tsx
@@ -24,7 +24,7 @@ import { transformEventSeries } from '../services/prismic/transformers/event-ser
 import { transformQuery } from '../services/prismic/transformers/paginated-results';
 import {
   transformEvent,
-  transformEventToEventBasic,
+  transformEventBasic,
 } from '../services/prismic/transformers/events';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 import { getUpcomingEvents } from '../utils/event-series';
@@ -79,9 +79,9 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
 
     if (isNotUndefined(seriesDocument)) {
       const series = transformEventSeries(seriesDocument);
-      const fullEvents = transformQuery(eventsQuery, transformEvent).results;
 
-      const events = fullEvents.map(transformEventToEventBasic);
+      const fullEvents = transformQuery(eventsQuery, transformEvent).results;
+      const events = transformQuery(eventsQuery, transformEventBasic).results;
 
       const upcomingEvents = getUpcomingEvents(events);
       const upcomingEventsIds = new Set(upcomingEvents.map(event => event.id));

--- a/content/webapp/pages/events.tsx
+++ b/content/webapp/pages/events.tsx
@@ -16,7 +16,10 @@ import { eventLd } from '../services/prismic/transformers/json-ld';
 import { createClient } from '../services/prismic/fetch';
 import { fetchEvents } from '../services/prismic/fetch/events';
 import { getPage } from '../utils/query-params';
-import { transformEventBasic } from '../services/prismic/transformers/events';
+import {
+  transformEvent,
+  transformEventBasic,
+} from '../services/prismic/transformers/events';
 import { transformQuery } from '../services/prismic/transformers/paginated-results';
 import { pageDescriptions } from '@weco/common/data/microcopy';
 import { EventBasic } from '../types/events';
@@ -55,7 +58,8 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       availableOnline: availableOnline === 'true',
     });
 
-    const events = transformQuery(eventsQueryPromise, transformEventBasic);
+    const events = transformQuery(eventsQueryPromise, transformEvent);
+    const basicEvents = transformQuery(eventsQueryPromise, transformEventBasic);
 
     if (events) {
       const title = (period === 'past' ? 'Past e' : 'E') + 'vents';
@@ -64,7 +68,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
         props: removeUndefinedProps({
           events: {
             ...events,
-            results: events.results,
+            results: basicEvents.results,
           },
           title,
           period: period as Period,

--- a/content/webapp/pages/events.tsx
+++ b/content/webapp/pages/events.tsx
@@ -16,10 +16,7 @@ import { eventLd } from '../services/prismic/transformers/json-ld';
 import { createClient } from '../services/prismic/fetch';
 import { fetchEvents } from '../services/prismic/fetch/events';
 import { getPage } from '../utils/query-params';
-import {
-  transformEvent,
-  transformEventToEventBasic,
-} from '../services/prismic/transformers/events';
+import { transformEventBasic } from '../services/prismic/transformers/events';
 import { transformQuery } from '../services/prismic/transformers/paginated-results';
 import { pageDescriptions } from '@weco/common/data/microcopy';
 import { EventBasic } from '../types/events';
@@ -58,7 +55,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       availableOnline: availableOnline === 'true',
     });
 
-    const events = transformQuery(eventsQueryPromise, transformEvent);
+    const events = transformQuery(eventsQueryPromise, transformEventBasic);
 
     if (events) {
       const title = (period === 'past' ? 'Past e' : 'E') + 'vents';
@@ -67,7 +64,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
         props: removeUndefinedProps({
           events: {
             ...events,
-            results: events.results.map(transformEventToEventBasic),
+            results: events.results,
           },
           title,
           period: period as Period,

--- a/content/webapp/pages/homepage.tsx
+++ b/content/webapp/pages/homepage.tsx
@@ -37,7 +37,7 @@ import { transformPage } from '../services/prismic/transformers/pages';
 import { fetchEvents } from '../services/prismic/fetch/events';
 import {
   transformEvent,
-  transformEventToEventBasic,
+  transformEventBasic,
 } from '../services/prismic/transformers/events';
 import { pageDescriptions, homepageHeading } from '@weco/common/data/microcopy';
 import { fetchExhibitions } from '../services/prismic/fetch/exhibitions';
@@ -103,9 +103,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     const jsonLd = articles.results.map(articleLd);
     const basicArticles = articles.results.map(transformArticleToArticleBasic);
 
-    const events = transformQuery(eventsQuery, event =>
-      transformEventToEventBasic(transformEvent(event))
-    ).results;
+    const events = transformQuery(eventsQuery, transformEventBasic).results;
     const nextSevenDaysEvents = orderEventsByNextAvailableDate(
       filterEventsForNext7Days(events)
     );

--- a/content/webapp/pages/season.tsx
+++ b/content/webapp/pages/season.tsx
@@ -33,7 +33,7 @@ import {
 } from '../services/prismic/transformers/books';
 import {
   transformEvent,
-  transformEventToEventBasic,
+  transformEventBasic,
 } from '../services/prismic/transformers/events';
 import { transformExhibitionsQuery } from '../services/prismic/transformers/exhibitions';
 import { transformPage } from '../services/prismic/transformers/pages';
@@ -201,9 +201,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     const books = transformQuery(booksQuery, book =>
       transformBookToBookBasic(transformBook(book))
     );
-    const events = transformQuery(eventsQuery, event =>
-      transformEventToEventBasic(transformEvent(event))
-    );
+    const events = transformQuery(eventsQuery, transformEventBasic);
     const exhibitions = transformExhibitionsQuery(exhibitionsQuery);
 
     const pages = transformQuery(pagesQuery, transformPage);

--- a/content/webapp/pages/whats-on.tsx
+++ b/content/webapp/pages/whats-on.tsx
@@ -66,7 +66,7 @@ import { fetchEvents } from '../services/prismic/fetch/events';
 import { transformQuery } from '../services/prismic/transformers/paginated-results';
 import {
   transformEvent,
-  transformEventToEventBasic,
+  transformEventBasic,
 } from '../services/prismic/transformers/events';
 import { pageDescriptions } from '@weco/common/data/microcopy';
 import { fetchExhibitions } from '../services/prismic/fetch/exhibitions';
@@ -331,7 +331,12 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     const exhibitions = transformExhibitionsQuery(exhibitionsQuery).results;
     const availableOnlineEvents = transformQuery(
       availableOnlineEventsQuery,
-      event => transformEventToEventBasic(transformEvent(event))
+      transformEventBasic
+    ).results;
+
+    const basicEvents = transformQuery(
+      eventsQuery,
+      transformEventBasic
     ).results;
 
     if (period && events && exhibitions) {
@@ -344,7 +349,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
         props: removeUndefinedProps({
           period,
           exhibitions,
-          events: events.map(transformEventToEventBasic),
+          events: basicEvents,
           availableOnlineEvents,
           dateRange,
           jsonLd,

--- a/content/webapp/services/prismic/events.ts
+++ b/content/webapp/services/prismic/events.ts
@@ -10,7 +10,7 @@ import {
   minDate,
   startOfDay,
 } from '@weco/common/utils/dates';
-import { Event, EventBasic, HasTimes } from '../../types/events';
+import { Event, HasTimes } from '../../types/events';
 import { isNotUndefined } from '@weco/common/utils/array';
 
 function getNextDateInFuture(event: HasTimes): Date | undefined {
@@ -25,11 +25,11 @@ function getNextDateInFuture(event: HasTimes): Date | undefined {
   }
 }
 
-function filterEventsByTimeRange(
-  events: EventBasic[],
+function filterEventsByTimeRange<T extends HasTimes>(
+  events: T[],
   start: Date,
   end: Date
-): EventBasic[] {
+): T[] {
   return events.filter(event => {
     return event.times.find(time => {
       const eventStart = time.range.startDateTime;
@@ -44,21 +44,21 @@ function filterEventsByTimeRange(
   });
 }
 
-export function filterEventsForNext7Days(events: EventBasic[]): EventBasic[] {
+export function filterEventsForNext7Days<T extends HasTimes>(events: T[]): T[] {
   const startOfToday = startOfDay(new Date());
   const endOfNext7Days = endOfDay(addDays(new Date(), 7));
 
   return filterEventsByTimeRange(events, startOfToday, endOfNext7Days);
 }
 
-export function filterEventsForToday(events: EventBasic[]): EventBasic[] {
+export function filterEventsForToday<T extends HasTimes>(events: T[]): T[] {
   const startOfToday = startOfDay(new Date());
   const endOfToday = endOfDay(new Date());
 
   return filterEventsByTimeRange(events, startOfToday, endOfToday);
 }
 
-export function filterEventsForWeekend(events: EventBasic[]): EventBasic[] {
+export function filterEventsForWeekend<T extends HasTimes>(events: T[]): T[] {
   const { start, end } = getNextWeekendDateRange(new Date());
   return filterEventsByTimeRange(events, start, end);
 }
@@ -183,7 +183,7 @@ function getRanges({ start, end }: RangeProps, acc: Range[] = []): Range[] {
   }
 }
 
-export function isEventPast({ times }: Event): boolean {
+export function isEventPast({ times }: HasTimes): boolean {
   const hasFutureEvents = times.some(
     ({ range }) => !isDayPast(range.endDateTime)
   );

--- a/content/webapp/services/prismic/transformers/body.ts
+++ b/content/webapp/services/prismic/transformers/body.ts
@@ -54,7 +54,7 @@ import { transformGuide } from './guides';
 import { transformEventSeries } from './event-series';
 import { transformExhibition } from './exhibitions';
 import { transformArticle } from './articles';
-import { transformEvent } from './events';
+import { transformEventBasic } from './events';
 import { transformSeason } from './seasons';
 import { transformCard } from './card';
 
@@ -464,7 +464,7 @@ function transformContentListSlice(slice: ContentListSlice): BodySlice {
             case 'articles':
               return transformArticle(content);
             case 'events':
-              return transformEvent(content);
+              return transformEventBasic(content);
             case 'seasons':
               return transformSeason(content);
             case 'card':

--- a/content/webapp/services/prismic/transformers/events.ts
+++ b/content/webapp/services/prismic/transformers/events.ts
@@ -124,6 +124,7 @@ function transformThirdPartyBooking(
 }
 
 function transformEventTimes(
+  id: string,
   times: GroupField<EventTimePrismicDocument>
 ): EventTime[] {
   return times
@@ -140,7 +141,7 @@ function transformEventTimes(
           range.startDateTime > range.endDateTime
         ) {
           console.warn(
-            `Start time for event ${document.id} is after the end time; this is probably a bug in Prismic`
+            `Start time for event ${id} is after the end time; this is probably a bug in Prismic`
           );
         }
 
@@ -224,7 +225,7 @@ export function transformEvent(
     season => transformSeason(season as SeasonPrismicDocument)
   );
 
-  const times: EventTime[] = transformEventTimes(data.times || []);
+  const times: EventTime[] = transformEventTimes(document.id, data.times || []);
 
   const lastEndTime = getLastEndTime(times);
   const isRelaxedPerformance = data.isRelaxedPerformance === 'yes';

--- a/content/webapp/services/prismic/transformers/events.ts
+++ b/content/webapp/services/prismic/transformers/events.ts
@@ -380,13 +380,14 @@ export function transformEventBasic(
     id,
     times,
     isPast,
+    labels,
     primaryLabels,
+    secondaryLabels,
     title,
     isOnline,
     locations,
     availableOnline,
     series,
-    secondaryLabels,
     cost,
   } = event;
 
@@ -409,14 +410,15 @@ export function transformEventBasic(
     id,
     times,
     isPast,
+    labels,
     primaryLabels,
+    secondaryLabels,
     title,
     isOnline,
     locations: locations.map(({ title }) => ({ title })),
     availableOnline,
     scheduleLength,
     series,
-    secondaryLabels,
     cost,
   };
 }

--- a/content/webapp/services/prismic/transformers/events.ts
+++ b/content/webapp/services/prismic/transformers/events.ts
@@ -162,11 +162,6 @@ export function transformEvent(
   scheduleQuery?: Query<EventPrismicDocument>
 ): Event {
   const data = document.data;
-  const scheduleLength = isFilledLinkToDocumentWithData(
-    data.schedule.map(s => s.event)[0]
-  )
-    ? data.schedule.length
-    : 0;
   const genericFields = transformGenericFields(document);
   const eventSchedule =
     scheduleQuery && scheduleQuery.results
@@ -315,7 +310,6 @@ export function transformEvent(
     series,
     seasons,
     contributors,
-    scheduleLength,
     schedule,
     eventbriteId,
     isCompletelySoldOut:
@@ -376,6 +370,7 @@ export function transformEvent(
 export function transformEventBasic(
   document: EventPrismicDocument
 ): EventBasic {
+  const { data } = document;
   const event = transformEvent(document);
 
   const {
@@ -389,11 +384,16 @@ export function transformEventBasic(
     isOnline,
     locations,
     availableOnline,
-    scheduleLength,
     series,
     secondaryLabels,
     cost,
   } = event;
+
+  const scheduleLength = isFilledLinkToDocumentWithData(
+    data.schedule.map(s => s.event)[0]
+  )
+    ? data.schedule.length
+    : 0;
 
   return {
     type,

--- a/content/webapp/services/prismic/transformers/events.ts
+++ b/content/webapp/services/prismic/transformers/events.ts
@@ -368,9 +368,17 @@ export function transformEvent(
   };
 }
 
-export function transformEventToEventBasic(event: Event): EventBasic {
-  // returns what is required to render EventPromos and event JSON-LD
-  return (({
+/** Create a basic version of events suitable for JSON-LD and promos.
+ *
+ * Note: unlike our other types, this transforms the Prismic document directly,
+ * because EventBasic isn't a strict subset of Event.
+ */
+export function transformEventBasic(
+  document: EventPrismicDocument
+): EventBasic {
+  const event = transformEvent(document);
+
+  const {
     type,
     promo,
     id,
@@ -385,7 +393,9 @@ export function transformEventToEventBasic(event: Event): EventBasic {
     series,
     secondaryLabels,
     cost,
-  }) => ({
+  } = event;
+
+  return {
     type,
     promo: promo && {
       ...promo,
@@ -407,7 +417,7 @@ export function transformEventToEventBasic(event: Event): EventBasic {
     series,
     secondaryLabels,
     cost,
-  }))(event);
+  };
 }
 
 export const getScheduleIds = (

--- a/content/webapp/services/prismic/transformers/multi-content.ts
+++ b/content/webapp/services/prismic/transformers/multi-content.ts
@@ -7,7 +7,7 @@ import {
 import { transformArticle } from './articles';
 import { transformBook } from './books';
 import { transformEventSeries } from './event-series';
-import { transformEvent } from './events';
+import { transformEventBasic } from './events';
 import { transformExhibition } from './exhibitions';
 import { transformPage } from './pages';
 import { MultiContent } from '../../../types/multi-content';
@@ -67,7 +67,7 @@ export const transformMultiContent = (
     case 'books':
       return transformBook(document);
     case 'events':
-      return transformEvent(document);
+      return transformEventBasic(document);
     case 'articles':
     case 'webcomics':
       return transformArticle(document);

--- a/content/webapp/services/prismic/types/events.ts
+++ b/content/webapp/services/prismic/types/events.ts
@@ -102,7 +102,7 @@ export type WithEventFormat = {
   >;
 };
 
-export type EventTime = {
+export type EventTimePrismicDocument = {
   startDateTime: TimestampField;
   endDateTime: TimestampField;
   isFullyBooked: BooleanField;
@@ -120,7 +120,7 @@ export type EventPrismicDocument = PrismicDocument<
     }>;
     isOnline: BooleanField;
     availableOnline: BooleanField;
-    times: GroupField<EventTime>;
+    times: GroupField<EventTimePrismicDocument>;
     isRelaxedPerformance: SelectField<'yes'>;
     interpretations: GroupField<{
       interpretationType: RelationField<

--- a/content/webapp/types/body.ts
+++ b/content/webapp/types/body.ts
@@ -20,7 +20,7 @@ import { Venue } from '@weco/common/model/opening-hours';
 import { Page } from './pages';
 import { EventSeries } from './event-series';
 import { Book } from './books';
-import { Event } from './events';
+import { Event, EventBasic } from './events';
 import { Article } from './articles';
 import { Exhibition } from './exhibitions';
 import { Card } from './card';
@@ -46,7 +46,7 @@ type ContentList = {
     | Page
     | EventSeries
     | Book
-    | Event
+    | EventBasic
     | Article
     | Exhibition
     | Card

--- a/content/webapp/types/card.ts
+++ b/content/webapp/types/card.ts
@@ -1,6 +1,6 @@
 import { getCrop, ImageType } from '@weco/common/model/image';
 import { Format } from './format';
-import { Event } from './events';
+import { EventBasic } from './events';
 import { Article } from './articles';
 import { Season } from './seasons';
 import { Page, ParentPage } from './pages';
@@ -27,7 +27,7 @@ export type Card = {
 export function convertItemToCardProps(
   item:
     | Article
-    | Event
+    | EventBasic
     | Season
     | Page
     | Series
@@ -70,7 +70,7 @@ export function convertItemToCardProps(
             tasl: item.promo.image.tasl,
             simpleCrops: {
               '16:9': {
-                contentUrl: getCrop(item.image, '16:9')?.contentUrl || '',
+                contentUrl: getCrop(item.promo.image, '16:9')?.contentUrl || '',
                 width: 1600,
                 height: 900,
               },

--- a/content/webapp/types/events.ts
+++ b/content/webapp/types/events.ts
@@ -107,7 +107,6 @@ export type Event = GenericContentFields & {
   cost?: string;
   bookingType?: string;
   thirdPartyBooking?: ThirdPartyBooking;
-  scheduleLength: number;
   schedule?: EventSchedule;
   eventbriteId?: string;
   isCompletelySoldOut?: boolean;

--- a/content/webapp/types/events.ts
+++ b/content/webapp/types/events.ts
@@ -80,6 +80,7 @@ export type EventBasic = HasTimes & {
   title: string;
   promo?: ImagePromo | undefined;
   isPast: boolean;
+  labels: Label[];
   primaryLabels: Label[];
   secondaryLabels: Label[];
   isOnline: boolean;

--- a/content/webapp/types/exhibitions.ts
+++ b/content/webapp/types/exhibitions.ts
@@ -2,7 +2,7 @@ import { Article } from './articles';
 import { Series } from './series';
 import { Book } from './books';
 import { Contributor, ContributorBasic } from './contributors';
-import { Event } from './events';
+import { Event, EventBasic } from './events';
 import { Place } from './places';
 import { GenericContentFields } from './generic-content-fields';
 import { Resource } from './resource';
@@ -61,6 +61,6 @@ export type Exhibit = {
 export type ExhibitionAbout = Book | Article | Series;
 
 export type ExhibitionRelatedContent = {
-  exhibitionOfs: (Exhibition | Event)[];
+  exhibitionOfs: (Exhibition | EventBasic)[];
   exhibitionAbouts: ExhibitionAbout[];
 };


### PR DESCRIPTION
For https://github.com/wellcomecollection/wellcomecollection.org/issues/8830

The crux of that issue is that we don't have access to detailed schedule information on EventBasic, which is what we use to render those promo cards.

We could get that by modifying the fetch links (which #8850 is prep for), but we don't need to drag the entire schedule onto EventBasic – that's way too much data! So my plan is to have a mini-schedule on EventBasic – `EventTime[]` (times, is booked, is fully booked online) – which we then use to render the cards if it's a multi-day event. Hopefully this will be clearer when I actually implement it.

This PR is a no-op refactoring to the event transformer as prep work for this – in particular it diverges the `Event` and `EventBasic` types, which turns out to expose a bunch of places where we were implicitly relying on them to be similar.