### PR TITLE
Improve the way multi-day events and "Lights Up" appear on the site

### DIFF
--- a/content/webapp/components/CardGrid/DailyTourPromo.tsx
+++ b/content/webapp/components/CardGrid/DailyTourPromo.tsx
@@ -27,7 +27,6 @@ const data: EventBasic = {
     image,
     link: `/pages/${prismicPageIds.dailyGuidedTours}`,
   },
-  scheduleLength: 0,
   isOnline: false,
   availableOnline: false,
   type: 'events',

--- a/content/webapp/components/EventPromo/EventPromo.tsx
+++ b/content/webapp/components/EventPromo/EventPromo.tsx
@@ -175,20 +175,8 @@ const EventPromo: FunctionComponent<Props> = ({
             </Space>
           )}
 
-          {!isPast && (
-            <>
-              {event.scheduleLength > 0 && (
-                <p className={`${font('intb', 5)} no-padding no-margin`}>
-                  {`${event.scheduleLength} ${
-                    event.scheduleLength > 1 ? 'events' : 'event'
-                  }`}
-                </p>
-              )}
-
-              {event.times.length > 1 && (
-                <p className={font('intb', 6)}>See all dates/times</p>
-              )}
-            </>
+          {!isPast && event.times.length > 1 && (
+            <p className={font('intb', 6)}>See all dates/times</p>
           )}
 
           {isPast && !event.availableOnline && (

--- a/content/webapp/components/EventsByMonth/group-event-utils.test.ts
+++ b/content/webapp/components/EventsByMonth/group-event-utils.test.ts
@@ -229,7 +229,13 @@ describe('groupEventsByMonth', () => {
       {
         range: {
           startDateTime: new Date('2022-11-03T16:00:00.000Z'),
-          endDateTime: new Date('2023-02-09T20:00:00.000Z'),
+          endDateTime: new Date('2022-11-03T20:00:00.000Z'),
+        },
+      },
+      {
+        range: {
+          startDateTime: new Date('2022-11-15T10:00:00.000Z'),
+          endDateTime: new Date('2022-11-15T14:00:00.000Z'),
         },
       },
     ],
@@ -275,7 +281,39 @@ describe('groupEventsByMonth', () => {
     expect(groupedEvents).toStrictEqual([
       {
         month: { month: 'November', year: 2022 },
-        events: [evLightsUp, evPhobiasAndManias, evWhatYouSee],
+        events: [evPhobiasAndManias, evLightsUp, evWhatYouSee],
+      },
+    ]);
+  });
+
+  it('puts multi-day events at the right order in the list', () => {
+    const spyOnFuture = jest.spyOn(dateUtils, 'isFuture');
+    spyOnFuture.mockImplementation(
+      (d: Date) => d > new Date('2022-11-09T00:00:00Z')
+    );
+
+    // Notice that on 9 November, the "HIV and AIDS" event has already
+    // had its first event in the month (on 8 Nov), and the event promo
+    // will be displaying the next event in the series (on 30 Nov).
+    //
+    // It should appear in the list based on that next date, not 8 Nov.
+    const events = [evHivAndAids, evPhobiasAndManias, evWhatYouSee];
+
+    const groupedEvents = groupEventsByMonth(events);
+
+    expect(groupedEvents).toStrictEqual([
+      {
+        month: { month: 'November', year: 2022 },
+        events: [
+          // 10 Nov
+          evPhobiasAndManias,
+
+          // 17 Nov – 19 Nov
+          evWhatYouSee,
+
+          // 30 Nov
+          evHivAndAids,
+        ],
       },
     ]);
   });

--- a/content/webapp/components/EventsByMonth/group-event-utils.ts
+++ b/content/webapp/components/EventsByMonth/group-event-utils.ts
@@ -134,9 +134,14 @@ export function groupEventsByMonth<T extends HasTimeRanges>(
         //    - what's the earliest time it starts in this month?
         //        => where should it appear in the order of events for this month?
         //
+        // Note that we may be partway through the month, so we need to sort based on
+        // the next future date -- this is what will appear on the card.
+        //
         const rangesInMonth = ev.times
           .map(t => t.range)
-          .filter(t => isInMonth(t.startDateTime, month));
+          .filter(
+            t => isInMonth(t.startDateTime, month) && isFuture(t.startDateTime)
+          );
 
         return rangesInMonth.length > 0
           ? {

--- a/content/webapp/services/prismic/fetch/events.ts
+++ b/content/webapp/services/prismic/fetch/events.ts
@@ -4,6 +4,7 @@ import {
   eventFormatFetchLinks,
   eventPolicyFetchLinks,
   EventPrismicDocument,
+  eventsFetchLinks,
   interpretationTypeFetchLinks,
   teamFetchLinks,
 } from '../types/events';
@@ -34,6 +35,7 @@ const fetchLinks = [
   ...teamFetchLinks,
   ...backgroundTexturesFetchLink,
   ...seasonsFetchLinks,
+  ...eventsFetchLinks,
 ];
 
 const eventsFetcher = fetcher<EventPrismicDocument>('events', fetchLinks);

--- a/content/webapp/services/prismic/transformers/events.test.ts
+++ b/content/webapp/services/prismic/transformers/events.test.ts
@@ -1,5 +1,9 @@
 import { groupEventsByDay } from '../../../services/prismic/events';
-import { getLastEndTime, getEventbriteId } from './events';
+import {
+  getLastEndTime,
+  getEventbriteId,
+  transformEventBasicTimes,
+} from './events';
 import { data as uiEventData } from '../../../components/CardGrid/DailyTourPromo';
 import { EventTime } from '../../../types/events';
 import { transformTimestamp } from '@weco/common/services/prismic/transformers';
@@ -112,5 +116,208 @@ describe('Events', () => {
     expect(getEventbriteId(embedUrl1)).toBe('test-event-1-tickets-5398972389');
     expect(getEventbriteId(embedUrl2)).toBe('5398972389');
     expect(getEventbriteId(embedUrl3)).toBeUndefined();
+  });
+});
+
+describe('transformEventBasicTimes', () => {
+  it('returns the event summary times for an event with no schedule', () => {
+    // This is based on https://wellcomecollection.org/events/Y1EkyhEAAA1CDSYH
+    //
+    // This is an event that occurred once, on a single evening.
+    const summaryTimes: EventTime[] = [
+      {
+        range: {
+          startDateTime: new Date('2022-11-25T19:00:00.000Z'),
+          endDateTime: new Date('2022-11-25T20:30:00.000Z'),
+        },
+        isFullyBooked: false,
+        onlineIsFullyBooked: false,
+      },
+    ];
+    const document: any = {
+      data: {
+        schedule: [{ event: { link_type: 'Document' }, isNotLinked: null }],
+      },
+    };
+
+    expect(transformEventBasicTimes(summaryTimes, document)).toBe(summaryTimes);
+  });
+
+  it('returns the event summary times for a multi-day festival', () => {
+    // This is based on https://wellcomecollection.org/events/XU1-9BMAACMAjCIb
+    //
+    // This is an event that ran over four days, with an individually scheduled item
+    // on each day.
+    const summaryTimes: EventTime[] = [
+      {
+        range: {
+          startDateTime: new Date('2019-10-16T23:00:00.000Z'),
+          endDateTime: new Date('2019-10-19T23:00:00.000Z'),
+        },
+        isFullyBooked: false,
+        onlineIsFullyBooked: false,
+      },
+    ];
+    const document: any = {
+      data: {
+        schedule: [
+          {
+            event: {
+              id: 'oct-17',
+              data: {
+                times: [
+                  {
+                    startDateTime: '2019-10-17T18:00:00+0000',
+                    endDateTime: '2019-10-17T19:30:00+0000',
+                  },
+                ],
+              },
+              link_type: 'Document',
+              isBroken: false,
+            },
+          },
+          {
+            event: {
+              id: 'oct-18',
+              data: {
+                times: [
+                  {
+                    startDateTime: '2019-10-18T14:00:00+0000',
+                    endDateTime: '2019-10-18T15:00:00+0000',
+                  },
+                ],
+              },
+              link_type: 'Document',
+              isBroken: false,
+            },
+          },
+          {
+            event: {
+              id: 'oct-20',
+              data: {
+                times: [
+                  {
+                    startDateTime: '2019-10-20T14:00:00+0000',
+                    endDateTime: '2019-10-20T15:00:00+0000',
+                  },
+                ],
+              },
+              link_type: 'Document',
+              isBroken: false,
+            },
+          },
+          {
+            event: {
+              id: 'oct-19',
+              data: {
+                times: [
+                  {
+                    startDateTime: '2019-10-19T13:00:00+0000',
+                    endDateTime: '2019-10-19T15:00:00+0000',
+                  },
+                ],
+              },
+              link_type: 'Document',
+              isBroken: false,
+            },
+          },
+        ],
+      },
+    };
+
+    expect(transformEventBasicTimes(summaryTimes, document)).toBe(summaryTimes);
+  });
+
+  it('uses the scheduled item times for a repeating event', () => {
+    // This is based on https://wellcomecollection.org/events/YzGDAxEAAM-gfxhj
+    //
+    // This is an event that was repeated on seven different days over four months.
+    const summaryTimes: EventTime[] = [
+      {
+        range: {
+          startDateTime: new Date('2022-11-03T16:00:00.000Z'),
+          endDateTime: new Date('2023-02-09T20:00:00.000Z'),
+        },
+        isFullyBooked: false,
+        onlineIsFullyBooked: false,
+      },
+    ];
+
+    const scheduleItemNov3 = {
+      startDateTime: '2022-11-03T16:00:00+0000',
+      endDateTime: '2022-11-03T20:00:00+0000',
+      isFullyBooked: null,
+      onlineIsFullyBooked: null,
+    };
+    const scheduleItemNov15 = {
+      startDateTime: '2022-11-15T10:00:00+0000',
+      endDateTime: '2022-11-15T14:00:00+0000',
+      isFullyBooked: null,
+      onlineIsFullyBooked: null,
+    };
+    const scheduleItemDec3 = {
+      startDateTime: '2022-12-03T14:00:00+0000',
+      endDateTime: '2022-12-03T18:00:00+0000',
+      isFullyBooked: null,
+      onlineIsFullyBooked: null,
+    };
+
+    const document: any = {
+      data: {
+        schedule: [
+          {
+            event: {
+              id: 'nov-3',
+              data: {
+                times: [scheduleItemNov3],
+              },
+              link_type: 'Document',
+              isBroken: false,
+            },
+          },
+          {
+            event: {
+              id: 'nov-15',
+              data: {
+                times: [scheduleItemNov15],
+              },
+              link_type: 'Document',
+              isBroken: false,
+            },
+          },
+          {
+            event: {
+              id: 'dec-3',
+              data: {
+                times: [scheduleItemDec3],
+              },
+              link_type: 'Document',
+              isBroken: false,
+            },
+          },
+        ],
+      },
+    };
+
+    expect(transformEventBasicTimes(summaryTimes, document)).toBe([
+      {
+        startDateTime: new Date('2022-11-03T16:00:00+0000'),
+        endDateTime: new Date('2022-11-03T20:00:00+0000'),
+        isFullyBooked: false,
+        onlineIsFullyBooked: false,
+      },
+      {
+        startDateTime: new Date('2022-11-15T10:00:00+0000'),
+        endDateTime: new Date('2022-11-15T14:00:00+0000'),
+        isFullyBooked: false,
+        onlineIsFullyBooked: false,
+      },
+      {
+        startDateTime: new Date('2022-12-03T14:00:00+0000'),
+        endDateTime: new Date('2022-12-03T18:00:00+0000'),
+        isFullyBooked: false,
+        onlineIsFullyBooked: false,
+      },
+    ]);
   });
 });

--- a/content/webapp/services/prismic/transformers/events.ts
+++ b/content/webapp/services/prismic/transformers/events.ts
@@ -293,9 +293,6 @@ export function transformEvent(
   const hasOnlineBooking =
     onlineEventbriteId || onlineThirdPartyBooking || onlineBookingEnquiryTeam;
 
-  // We want to display the scheduleLength on EventPromos,
-  // but don't want to make an extra API request to populate the schedule for every event in a list.
-  // We therefore return the scheduleLength property.
   return {
     type: 'events',
     ...genericFields,
@@ -489,12 +486,6 @@ export function transformEventBasic(
     cost,
   } = event;
 
-  const scheduleLength = isFilledLinkToDocumentWithData(
-    data.schedule.map(s => s.event)[0]
-  )
-    ? data.schedule.length
-    : 0;
-
   return {
     type,
     promo: promo && {
@@ -515,7 +506,6 @@ export function transformEventBasic(
     isOnline,
     locations: locations.map(({ title }) => ({ title })),
     availableOnline,
-    scheduleLength,
     series,
     cost,
   };

--- a/content/webapp/services/prismic/transformers/events.ts
+++ b/content/webapp/services/prismic/transformers/events.ts
@@ -22,7 +22,14 @@ import {
   LinkField,
   KeyTextField,
 } from '@prismicio/types';
-import { isPast, maxDate } from '@weco/common/utils/dates';
+import {
+  countDaysBetween,
+  getDatesBetween,
+  isPast,
+  isSameDay,
+  maxDate,
+  minDate,
+} from '@weco/common/utils/dates';
 import {
   asText,
   asTitle,
@@ -363,6 +370,97 @@ export function transformEvent(
   };
 }
 
+/** Get the event times for an EventBasic.
+ *
+ * This may be different to the times for the Event, because we use this field
+ * to manage how cards appear.
+ */
+export function transformEventBasicTimes(
+  summaryTimes: EventTime[],
+  document: EventPrismicDocument
+): EventTime[] {
+  // When the content team want to represent an event that repeats on multiple days
+  // (e.g. the Lights Up events that accompanied In Plain Sight), they create
+  // one parent event with all the event information, then individual events which
+  // are linked to it in the schedule field.  The `times` field on the parent event
+  // is a summary of the series.
+  //
+  // These individual events contain ticket booking information, details of times,
+  // and so on.
+  //
+  //                               +---> Event @ 1 January
+  //      parent event             |
+  //      times = 1 Jan – 3 Mar ---+---> Event @ 2 February
+  //                               |
+  //                               +---> Event @ 3 March
+  //
+  // In this case, we want the event cards on the What's On page to show the dates
+  // of the individual events.
+  //
+  // But they also use this approach for festival-like events, where there are multiple
+  // events happening over the same weekend (e.g. A Moon with a View).
+  //
+  //                               +---> Saturday event @ 12 – 2
+  //      parent event             |
+  //      times = Sat – Sun     ---+---> Saturday event @ 2 – 4
+  //                               |
+  //                               +---> Sunday event @ 3 – 5
+  //
+  // In this case, we want the event cards on the What's On page to show the summary.
+  //
+  // So we use the following rules:
+  //
+  //    1.  If an event has no schedule, the card uses the 'times' on the event
+  //    2.  If an event has a schedule, but the schedule items are all on a continuous block
+  //        of days (e.g. Fri/Sat/Sun), the card uses the summary 'times' on the event
+  //    3.  If an event has a schedule and the schedule items are scattered around,
+  //        the cards use the individual item times.
+  //
+  // These rules are likely incomplete, but they're directionally correct and fix a
+  // timely issue with the "Lights Up" event that spans multiple months.
+  //
+  const scheduleTimes = document.data.schedule.flatMap(s =>
+    isFilledLinkToDocumentWithData(s.event)
+      ? transformEventTimes(s.event.id, s.event.data.times || [])
+      : []
+  );
+
+  // Case 1: if the event has no schedule, use the 'times' on the event
+  if (scheduleTimes.length === 0) {
+    return summaryTimes;
+  }
+
+  // Now work out the span of the scheduled items.
+  //
+  // e.g. if the schedule is
+  //
+  //      item1 = { start: Sat @ 2pm, end: Sat @ 4pm }
+  //      item2 = { start: Sat @ 4pm, end: Sat @ 6pm }
+  //      item3 = { start: Sun @ 3pm, end: Sun @ 5pm }
+  //
+  // then `scheduleStart` is Sat @ 2pm and `scheduleEnd` is Sun @ 5pm.
+  const scheduleStart = minDate(scheduleTimes.map(s => s.range.startDateTime));
+  const scheduleEnd = maxDate(scheduleTimes.map(s => s.range.endDateTime));
+
+  // Then we work out how many days there are between the beginning and
+  // end of the schedule, and we check if something happens every day.
+  //
+  // This tells us if the scheduled items are a continuous block.
+  const daysInScheduleRange = getDatesBetween({
+    start: scheduleStart,
+    end: scheduleEnd,
+  });
+
+  const everyDayHasSomething = daysInScheduleRange.every(d =>
+    scheduleTimes.some(
+      s =>
+        isSameDay(d, s.range.startDateTime) || isSameDay(d, s.range.endDateTime)
+    )
+  );
+
+  return everyDayHasSomething ? summaryTimes : scheduleTimes;
+}
+
 /** Create a basic version of events suitable for JSON-LD and promos.
  *
  * Note: unlike our other types, this transforms the Prismic document directly,
@@ -408,7 +506,7 @@ export function transformEventBasic(
       },
     },
     id,
-    times,
+    times: transformEventBasicTimes(times, document),
     isPast,
     labels,
     primaryLabels,

--- a/content/webapp/types/events.ts
+++ b/content/webapp/types/events.ts
@@ -86,7 +86,6 @@ export type EventBasic = HasTimes & {
   isOnline: boolean;
   locations: PlaceBasic[];
   availableOnline: boolean;
-  scheduleLength: number;
   series: EventSeriesBasic[];
   cost?: string;
 };


### PR DESCRIPTION
For https://github.com/wellcomecollection/wellcomecollection.org/issues/8830

This follows a discussion we had at Access planning yesterday, with some additional tweaks based on implementation.

Changes:

* Events in the per-month view on What's On now sort based on their next future date, where previously they'd sort based on the first date anywhere in the month. Notice how HIV and AIDS has moved to the right place now.

* Event cards for events with a multi-day schedule now use the date of the next scheduled event, rather than the complete range. This only applies if there are gaps in the schedule:

    - if an event runs Fri/Sat/Sun, we'll show the "Fri – Sun" range
    - if an event runs 1 Jan/2 Feb/3 Mar, we'll show the individual dates
   

   Notice how "Lights Up" now shows the date of the next event (Tuesday), and there are tabs where you can see it appearing in future months also.

* Scheduled cards now show "See all dates/times", rather than "7 events" – we think this is clearer for users.

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td><img width="1100" alt="Screenshot 2022-11-10 at 14 10 41" src="https://user-images.githubusercontent.com/301220/201113787-74a18fda-814d-4d6d-ae74-be5c30195be8.png">
</td>
<td><img width="1108" alt="Screenshot 2022-11-10 at 14 10 12" src="https://user-images.githubusercontent.com/301220/201113681-abe64898-73c0-4193-bda0-d35f0939e500.png">
</td>
</tr>
</table>

