### PR TITLE
Fixed the scrollbar always being present

### DIFF
--- a/common/views/components/SubNavigation/SubNavigation.styles.tsx
+++ b/common/views/components/SubNavigation/SubNavigation.styles.tsx
@@ -25,7 +25,7 @@ export const TabsContainer = styled.div`
   display: flex;
   list-style: none;
   padding: 0;
-  overflow-x: scroll;
+  overflow-x: auto;
   padding-left: ${props => props.theme.containerPadding.small}px;
 
   ${props => `

--- a/common/views/components/TabNav/TabNav.styles.tsx
+++ b/common/views/components/TabNav/TabNav.styles.tsx
@@ -27,7 +27,7 @@ export const TabsContainer = styled.div`
   list-style: none;
   padding: 0;
   margin: 0;
-  overflow-x: scroll;
+  overflow-x: auto;
   padding-left: ${props => props.theme.containerPadding.small}px;
 
   ${props => `


### PR DESCRIPTION
## Who is this for?
Those that are interacting with the new TabNav component

## What is it doing for them?
changing the scrollbar from always being present, to only being present if you require the scroll behaviour

closes #8874 