### PR TITLE
Realign button and search fields in older components

### DIFF
--- a/cardigan/stories/components/TextInput/TextInput.stories.tsx
+++ b/cardigan/stories/components/TextInput/TextInput.stories.tsx
@@ -12,7 +12,7 @@ const Template = () => {
       type="email"
       name="email"
       label="Your email address"
-      errorMessage={'Enter a valid email address.'}
+      errorMessage="Enter a valid email address."
       value={value}
       setValue={setValue}
       {...useValidation()}

--- a/catalogue/webapp/components/IIIFSearchWithin/IIIFSearchWithin.tsx
+++ b/catalogue/webapp/components/IIIFSearchWithin/IIIFSearchWithin.tsx
@@ -22,20 +22,20 @@ type Props = {
 
 const SearchForm = styled.form`
   position: relative;
+  display: flex;
 `;
 
 const SearchInputWrapper = styled.div`
   position: relative;
-  input {
-    padding-right: 70px;
-  }
+  flex: 1 1 auto;
 `;
 
 const SearchButtonWrapper = styled.div`
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  right: 4px;
+  margin-left: 4px;
+
+  button {
+    height: 100%;
+  }
 `;
 
 const ResultsHeader = styled(Space).attrs({
@@ -141,18 +141,19 @@ const IIIFSearchWithin: FunctionComponent<Props> = ({
                 label: 'item-search-within',
               }}
               setValue={setValue}
-              right={68}
+              right={10}
             />
           )}
-          <SearchButtonWrapper>
-            <ButtonSolid
-              size="medium"
-              icon={search}
-              text="search"
-              isTextHidden={true}
-            />
-          </SearchButtonWrapper>
         </SearchInputWrapper>
+        <SearchButtonWrapper>
+          <ButtonSolid
+            size="medium"
+            icon={search}
+            text="search"
+            isTextHidden={true}
+            isNewStyle
+          />
+        </SearchButtonWrapper>
       </SearchForm>
       <div aria-live="polite">
         {isLoading && <Loading />}

--- a/catalogue/webapp/components/IIIFSearchWithin/IIIFSearchWithin.tsx
+++ b/catalogue/webapp/components/IIIFSearchWithin/IIIFSearchWithin.tsx
@@ -15,6 +15,7 @@ import Space from '@weco/common/views/components/styled/Space';
 import LL from '@weco/common/views/components/styled/LL';
 import ClearSearch from '@weco/common/views/components/ClearSearch/ClearSearch';
 import { search } from '@weco/common/icons';
+import { themeValues } from '@weco/common/views/themes/config';
 
 type Props = {
   mainViewerRef: RefObject<FixedSizeList>;
@@ -131,6 +132,7 @@ const IIIFSearchWithin: FunctionComponent<Props> = ({
             setValue={setValue}
             required={true}
             ref={inputRef}
+            darkBg
           />
           {value !== '' && (
             <ClearSearch
@@ -147,10 +149,10 @@ const IIIFSearchWithin: FunctionComponent<Props> = ({
         </SearchInputWrapper>
         <SearchButtonWrapper>
           <ButtonSolid
-            size="medium"
             icon={search}
             text="search"
             isTextHidden={true}
+            colors={themeValues.buttonColors.yellowYellowBlack}
             isNewStyle
           />
         </SearchButtonWrapper>

--- a/common/views/components/SearchForm/SearchForm.tsx
+++ b/common/views/components/SearchForm/SearchForm.tsx
@@ -30,7 +30,7 @@ import { formDataAsUrlQuery } from '../../../utils/forms';
 
 const SearchInputWrapper = styled.div`
   position: relative;
-  font-size: 20px;
+  flex: 1 1 auto;
 
   .search-query {
     height: ${props => 10 * props.theme.spacingUnit}px;
@@ -38,21 +38,10 @@ const SearchInputWrapper = styled.div`
 `;
 
 const SearchButtonWrapper = styled.div`
-  position: absolute;
-  top: ${props => props.theme.spacingUnits['3'] + 7}px;
-  right: ${props => props.theme.spacingUnits['5'] + 6}px;
-
-  ${props =>
-    props.theme.media('medium')(`
-      top: ${props.theme.spacingUnits['4'] + 7}px;
-      right: ${props.theme.spacingUnits['6'] + 6}px;
-    `)}
-
-  ${props =>
-    props.theme.media('large')(`
-      top: ${props.theme.spacingUnits['5'] + 7}px;
-      right: ${props.theme.spacingUnits['8'] + 6}px;
-    `)}
+  margin-left: 4px;
+  button {
+    height: 100%;
+  }
 `;
 
 const SearchSortOrderWrapper = styled(Space).attrs({
@@ -181,7 +170,7 @@ const SearchForm = forwardRef(
         }}
       >
         <Space
-          h={{ size: 'l', properties: ['padding-left', 'padding-right'] }}
+          h={{ size: 'm', properties: ['padding-left', 'padding-right'] }}
           v={{ size: 'm', properties: ['padding-top', 'padding-bottom'] }}
         >
           <SearchInputWrapper>
@@ -209,10 +198,13 @@ const SearchForm = forwardRef(
                   action: 'clear search',
                   label: 'works-search',
                 }}
-                right={102}
+                right={10}
               />
             )}
           </SearchInputWrapper>
+          <SearchButtonWrapper>
+            <ButtonSolid text="Search" size="medium" />
+          </SearchButtonWrapper>
         </Space>
         {shouldShowFilters && (
           <SearchFilters
@@ -231,18 +223,9 @@ const SearchForm = forwardRef(
                 label="Sort by:"
                 value={portalSortOrder || ''}
                 options={[
-                  {
-                    value: '',
-                    text: 'Relevance',
-                  },
-                  {
-                    value: 'asc',
-                    text: 'Oldest to newest',
-                  },
-                  {
-                    value: 'desc',
-                    text: 'Newest to oldest',
-                  },
+                  { value: '', text: 'Relevance' },
+                  { value: 'asc', text: 'Oldest to newest' },
+                  { value: 'desc', text: 'Newest to oldest' },
                 ]}
                 onChange={event => {
                   setPortalSortOrder(event.currentTarget.value);
@@ -260,14 +243,8 @@ const SearchForm = forwardRef(
                   label="Sort by"
                   defaultValue={sort || ''}
                   options={[
-                    {
-                      value: '',
-                      text: 'Relevance',
-                    },
-                    {
-                      value: 'production.dates',
-                      text: 'Production dates',
-                    },
+                    { value: '', text: 'Relevance' },
+                    { value: 'production.dates', text: 'Production dates' },
                   ]}
                 />
               </Space>
@@ -276,22 +253,13 @@ const SearchForm = forwardRef(
                 label="Sort order"
                 defaultValue={sortOrder || ''}
                 options={[
-                  {
-                    value: 'asc',
-                    text: 'Ascending',
-                  },
-                  {
-                    value: 'desc',
-                    text: 'Descending',
-                  },
+                  { value: 'asc', text: 'Ascending' },
+                  { value: 'desc', text: 'Descending' },
                 ]}
               />
             </>
           )}
         </noscript>
-        <SearchButtonWrapper>
-          <ButtonSolid text="Search" size="medium" />
-        </SearchButtonWrapper>
       </form>
     );
   }

--- a/common/views/components/SearchForm/SearchForm.tsx
+++ b/common/views/components/SearchForm/SearchForm.tsx
@@ -28,6 +28,13 @@ import { LinkProps } from '../../../model/link-props';
 import { Filter } from '../../../services/catalogue/filters';
 import { formDataAsUrlQuery } from '../../../utils/forms';
 
+const Wrapper = styled(Space).attrs({
+  h: { size: 'm', properties: ['padding-left', 'padding-right'] },
+  v: { size: 'm', properties: ['padding-top', 'padding-bottom'] },
+})`
+  display: flex;
+`;
+
 const SearchInputWrapper = styled.div`
   position: relative;
   flex: 1 1 auto;
@@ -169,10 +176,7 @@ const SearchForm = forwardRef(
           return false;
         }}
       >
-        <Space
-          h={{ size: 'm', properties: ['padding-left', 'padding-right'] }}
-          v={{ size: 'm', properties: ['padding-top', 'padding-bottom'] }}
-        >
+        <Wrapper>
           <SearchInputWrapper>
             <TextInput
               id={`${isImageSearch ? 'images' : 'works'}-search-input`}
@@ -203,9 +207,9 @@ const SearchForm = forwardRef(
             )}
           </SearchInputWrapper>
           <SearchButtonWrapper>
-            <ButtonSolid text="Search" size="medium" />
+            <ButtonSolid text="Search" />
           </SearchButtonWrapper>
-        </Space>
+        </Wrapper>
         {shouldShowFilters && (
           <SearchFilters
             query={query}

--- a/common/views/components/TextInput/TextInput.tsx
+++ b/common/views/components/TextInput/TextInput.tsx
@@ -5,13 +5,15 @@ import { check } from '@weco/common/icons';
 
 type TextInputWrapProps = {
   value: string;
-  big: boolean;
   hasErrorBorder: boolean;
+  big?: boolean;
+  darkBg?: boolean;
 };
 export const TextInputWrap = styled.div<TextInputWrapProps>`
   display: flex;
   position: relative;
-  border: 2px solid ${props => props.theme.color('neutral.600')};
+  border: 2px solid
+    ${props => props.theme.color(props.darkBg ? 'white' : 'neutral.600')};
   font-size: ${props => (props.big ? '20px' : '16px')};
 
   &:focus-within {
@@ -74,7 +76,6 @@ export const TextInputLabel = styled.label<TextInputLabelProps>`
 
 type TextInputInputProps = {
   hasErrorBorder: boolean;
-  big: boolean;
 };
 export const TextInputInput = styled.input.attrs(props => ({
   type: props.type || 'text',
@@ -85,11 +86,6 @@ export const TextInputInput = styled.input.attrs(props => ({
   height: 100%;
   font-size: inherit;
   width: 100%;
-
-  ${props =>
-    props.theme.media('large')(`
-      padding: ${props.big ? '17px 130px 17px 15px' : '17px 40px 17px 15px'};
-    `)}
 
   &:focus {
     outline: 0;
@@ -152,6 +148,7 @@ type Props = {
   ariaLabel?: string;
   ariaDescribedBy?: string;
   form?: string;
+  darkBg?: boolean;
 };
 
 const Input: FunctionComponent<Props> = (
@@ -171,10 +168,11 @@ const Input: FunctionComponent<Props> = (
     showValidity,
     setShowValidity,
     autoFocus,
-    big,
     ariaLabel,
     ariaDescribedBy,
     form,
+    big,
+    darkBg,
   }: Props,
   ref: RefObject<HTMLInputElement>
 ) => {
@@ -204,6 +202,7 @@ const Input: FunctionComponent<Props> = (
       <TextInputWrap
         value={value}
         hasErrorBorder={!!(!isValid && showValidity)}
+        darkBg={darkBg}
         big={!!big}
       >
         <label className="visually-hidden" htmlFor={id}>
@@ -226,7 +225,6 @@ const Input: FunctionComponent<Props> = (
           aria-describedby={ariaDescribedBy}
           aria-invalid={!!(!isValid && showValidity)}
           aria-errormessage={errorMessage && `${id}-errormessage`}
-          big={!!big}
           form={form}
         />
         {isValid && showValidity && (

--- a/common/views/components/TextInput/TextInput.tsx
+++ b/common/views/components/TextInput/TextInput.tsx
@@ -79,13 +79,17 @@ type TextInputInputProps = {
 export const TextInputInput = styled.input.attrs(props => ({
   type: props.type || 'text',
 }))<TextInputInputProps>`
-  padding: ${props =>
-    props.big ? '17px 130px 17px 15px' : '17px 40px 17px 15px'};
+  padding: 17px 35px 17px 15px;
   appearance: none;
   border: 0;
   height: 100%;
   font-size: inherit;
   width: 100%;
+
+  ${props =>
+    props.theme.media('large')(`
+      padding: ${props.big ? '17px 130px 17px 15px' : '17px 40px 17px 15px'};
+    `)}
 
   &:focus {
     outline: 0;

--- a/identity/webapp/src/frontend/components/PasswordInput/PasswordInput.tsx
+++ b/identity/webapp/src/frontend/components/PasswordInput/PasswordInput.tsx
@@ -30,11 +30,7 @@ export const PasswordInput: React.FunctionComponent<PasswordInputProps> =
 
     return (
       <>
-        <TextInputWrap
-          hasErrorBorder={meta.invalid}
-          value={field.value}
-          big={false}
-        >
+        <TextInputWrap hasErrorBorder={meta.invalid} value={field.value}>
           <TextInputLabel
             htmlFor={props.id}
             isEnhanced={true}
@@ -43,7 +39,6 @@ export const PasswordInput: React.FunctionComponent<PasswordInputProps> =
             {props.label}
           </TextInputLabel>
           <TextInputInput
-            big={false}
             hasErrorBorder={meta.invalid}
             id={props.id || props.name}
             type={isVisible ? 'text' : 'password'}


### PR DESCRIPTION
## Who is this for?
Designs

## What is it doing for them?
After tweaking the search input in https://github.com/wellcomecollection/wellcomecollection.org/issues/8820, I noticed the clear input button is too close to the search button, so we should change the alignment a little bit so it looks better. 

But I decided to refactor those further as it opened a can of worms (padding, font-size). I removed the buttons from within the input in the cases I could find. Please let me know if I may have missed some (**particularly as I'm struggling to run identity pages locally**)

Before
<img width="1232" alt="Screenshot 2022-11-16 at 10 59 13" src="https://user-images.githubusercontent.com/110461050/202163033-85843859-fe8a-4f59-b461-8733abd7bb11.png">

After
<img width="1181" alt="Screenshot 2022-11-16 at 11 45 19" src="https://user-images.githubusercontent.com/110461050/202172275-2f2735f7-016e-4d51-a6f7-5dd075d2cdfa.png">


Before
<img width="306" alt="Screenshot 2022-11-16 at 10 57 32" src="https://user-images.githubusercontent.com/110461050/202162690-bbfe1c47-4a65-411c-a8e0-fd6e381b8640.png">

After
<img width="311" alt="Screenshot 2022-11-16 at 10 58 40" src="https://user-images.githubusercontent.com/110461050/202162905-20750976-4ce7-4c0e-a491-12fb74f46af0.png">

Closes #8878 
