### PR TITLE
Fix the listing of events on the What's On and Past Event pages

### DIFF
--- a/content/webapp/components/EventsByMonth/group-event-utils.test.ts
+++ b/content/webapp/components/EventsByMonth/group-event-utils.test.ts
@@ -317,4 +317,25 @@ describe('groupEventsByMonth', () => {
       },
     ]);
   });
+
+  it.only('includes festivals that are midway through their run', () => {
+    const spyOnFuture = jest.spyOn(dateUtils, 'isFuture');
+    spyOnFuture.mockImplementation(
+      (d: Date) => d > new Date('2022-11-18T12:00:00Z')
+    );
+
+    // The "What You See" event is a three-day festival from 17–19 Nov
+    // with a single entry in the 'times' block; on 18 Nov it's on
+    // its second day, so we should make sure we still show it.
+    const events = [evWhatYouSee];
+
+    const groupedEvents = groupEventsByMonth(events);
+
+    expect(groupedEvents).toStrictEqual([
+      {
+        month: { month: 'November', year: 2022 },
+        events: [evWhatYouSee],
+      },
+    ]);
+  });
 });

--- a/content/webapp/components/EventsByMonth/group-event-utils.test.ts
+++ b/content/webapp/components/EventsByMonth/group-event-utils.test.ts
@@ -318,7 +318,7 @@ describe('groupEventsByMonth', () => {
     ]);
   });
 
-  it.only('includes festivals that are midway through their run', () => {
+  it('includes festivals that are midway through their run', () => {
     const spyOnFuture = jest.spyOn(dateUtils, 'isFuture');
     spyOnFuture.mockImplementation(
       (d: Date) => d > new Date('2022-11-18T12:00:00Z')

--- a/content/webapp/components/EventsByMonth/group-event-utils.ts
+++ b/content/webapp/components/EventsByMonth/group-event-utils.ts
@@ -128,7 +128,7 @@ export function groupEventsByMonth<T extends HasTimeRanges>(
       .map(ev => {
         // For each event, we ask:
         //
-        //    - does it have any start times in this month?
+        //    - does it have any start/end times in this month?
         //        => should it appear in the list of events for this month?
         //
         //    - what's the earliest time it starts in this month?
@@ -140,7 +140,10 @@ export function groupEventsByMonth<T extends HasTimeRanges>(
         const rangesInMonth = ev.times
           .map(t => t.range)
           .filter(
-            t => isInMonth(t.startDateTime, month) && isFuture(t.startDateTime)
+            t =>
+              (isInMonth(t.startDateTime, month) &&
+                isFuture(t.startDateTime)) ||
+              (isInMonth(t.endDateTime, month) && isFuture(t.endDateTime))
           );
 
         return rangesInMonth.length > 0

--- a/content/webapp/components/EventsByMonth/group-event-utils.ts
+++ b/content/webapp/components/EventsByMonth/group-event-utils.ts
@@ -47,7 +47,7 @@ export function getMonthsInDateRange({
   end: Date;
 }): YearMonth[] {
   console.assert(
-    start < end,
+    start <= end,
     `Asked to find months in date range start=${start}, end=${end}`
   );
 

--- a/content/webapp/services/prismic/events.test.ts
+++ b/content/webapp/services/prismic/events.test.ts
@@ -2,6 +2,7 @@ import {
   orderEventsByNextAvailableDate,
   upcomingDatesFullyBooked,
 } from './events';
+import * as dateUtils from '@weco/common/utils/dates';
 
 describe('orderEventsByNextAvailableDate', () => {
   it('returns events in the right order', () => {
@@ -33,6 +34,28 @@ describe('orderEventsByNextAvailableDate', () => {
 
     const result = orderEventsByNextAvailableDate([aprilEvent, marchEvent]);
     expect(result).toEqual([marchEvent, aprilEvent]);
+  });
+
+  it('includes multi-day festivals that are midway through their run', () => {
+    const evWhatYouSee = {
+      times: [
+        {
+          range: {
+            startDateTime: new Date('2022-11-17T18:30:00.000Z'),
+            endDateTime: new Date('2022-11-19T15:00:00.000Z'),
+          },
+        },
+      ],
+      title: 'What You See / Don’t See When…',
+    };
+
+    const spyOnFuture = jest.spyOn(dateUtils, 'isFuture');
+    spyOnFuture.mockImplementation(
+      (d: Date) => d > new Date('2022-11-18T12:00:00Z')
+    );
+
+    const result = orderEventsByNextAvailableDate([evWhatYouSee]);
+    expect(result).toEqual([evWhatYouSee]);
   });
 });
 

--- a/content/webapp/services/prismic/types/predicates.test.ts
+++ b/content/webapp/services/prismic/types/predicates.test.ts
@@ -1,0 +1,34 @@
+import { getPeriodPredicates } from './predicates';
+import * as dateUtils from '@weco/common/utils/dates';
+
+describe('getPeriodPredicates', () => {
+  it('uses the current time for current-and-coming-up', () => {
+    const spyOnToday = jest.spyOn(dateUtils, 'today');
+    spyOnToday.mockImplementation(() => new Date('2022-09-19T00:00:00Z'));
+
+    const result = getPeriodPredicates({
+      period: 'current-and-coming-up',
+      startField: 'example.events.startDateTime',
+      endField: 'example.events.endDateTime',
+    });
+
+    expect(result).toStrictEqual([
+      '[date.after(example.events.endDateTime, 1663545600000)]',
+    ]);
+  });
+
+  it('uses the current time for past', () => {
+    const spyOnToday = jest.spyOn(dateUtils, 'today');
+    spyOnToday.mockImplementation(() => new Date('2022-09-19T00:00:00Z'));
+
+    const result = getPeriodPredicates({
+      period: 'past',
+      startField: 'example.events.startDateTime',
+      endField: 'example.events.endDateTime',
+    });
+
+    expect(result).toStrictEqual([
+      '[date.before(example.events.endDateTime, 1663545600000)]',
+    ]);
+  });
+});

--- a/content/webapp/services/prismic/types/predicates.ts
+++ b/content/webapp/services/prismic/types/predicates.ts
@@ -22,13 +22,24 @@ export const getPeriodPredicates = ({
   const endOfToday = endOfDay(now);
 
   const weekendDateRange = getNextWeekendDateRange(now);
+
+  // The 'current-and-coming-up' and 'past' predicates should split
+  // events into two segments -- every event/exhibition should match
+  // exactly one of these.
+  //
+  // We use today() as the comparison value so events get removed from
+  // the What's On page as soon as they're done -- otherwise we get
+  // events appearing with a "Past" label in the event list.
+  if (period === 'current-and-coming-up') {
+    return [predicate.dateAfter(endField, today())];
+  }
+  if (period === 'past') {
+    return [predicate.dateBefore(endField, today())];
+  }
+
   const predicates =
     period === 'coming-up'
       ? [predicate.dateAfter(startField, endOfToday)]
-      : period === 'current-and-coming-up'
-      ? [predicate.dateAfter(endField, startOfToday)]
-      : period === 'past'
-      ? [predicate.dateBefore(endField, startOfToday)]
       : period === 'today'
       ? [
           predicate.dateBefore(startField, endOfToday),

--- a/content/webapp/services/prismic/types/predicates.ts
+++ b/content/webapp/services/prismic/types/predicates.ts
@@ -6,6 +6,7 @@ import {
   getNextWeekendDateRange,
   startOfDay,
   startOfWeek,
+  today,
 } from '@weco/common/utils/dates';
 import { Period } from '../../../types/periods';
 
@@ -15,12 +16,12 @@ export const getPeriodPredicates = ({
   startField,
   endField,
 }: Props): string[] => {
-  const today = new Date();
+  const now = today();
 
-  const startOfToday = startOfDay(today);
-  const endOfToday = endOfDay(today);
+  const startOfToday = startOfDay(now);
+  const endOfToday = endOfDay(now);
 
-  const weekendDateRange = getNextWeekendDateRange(today);
+  const weekendDateRange = getNextWeekendDateRange(now);
   const predicates =
     period === 'coming-up'
       ? [predicate.dateAfter(startField, endOfToday)]
@@ -40,12 +41,12 @@ export const getPeriodPredicates = ({
         ]
       : period === 'this-week'
       ? [
-          predicate.dateBefore(startField, endOfWeek(today)),
-          predicate.dateAfter(startField, startOfWeek(today)),
+          predicate.dateBefore(startField, endOfWeek(now)),
+          predicate.dateAfter(startField, startOfWeek(now)),
         ]
       : period === 'next-seven-days'
       ? [
-          predicate.dateBefore(startField, endOfDay(addDays(today, 6))),
+          predicate.dateBefore(startField, endOfDay(addDays(now, 6))),
           predicate.dateAfter(endField, startOfToday),
         ]
       : [];


### PR DESCRIPTION
This fixes a couple of bugs, some long-standing, some recently introduced:

* Last night's bug was caused by a mismatch between the What's On page and the Prismic event predicates.

   The What's On page expects to only display events that start sometime in the future (otherwise it would put the Past label on the card, which looks weird) – but the Prismic predicates were fetching any event that ended sometime that day.

    We had an event that ended at 7:30pm, which is why the outage lasted from 7:30 to midnight, when the predicate changed.

    The fix is to modify the predicate so it also fetches events that end sometime after **now**, not sometime the same day.

* We're in the middle of a multi-day festival from 17th to 19th, but it's not showing on the What's On page – it's being filtered out, because it doesn't have a future start date in any month.

    The fix is to modify the grouping logic so a month contains any events that start **or end** in that month.

Because of the broken multi-day festival, I'd like to deploy this as soon as it's merged.