### PR TITLE
Include a link to application logs in the Slack alerts

### DIFF
--- a/cache/locals.tf
+++ b/cache/locals.tf
@@ -3,8 +3,8 @@ data "aws_secretsmanager_secret_version" "slack_webhook" {
 }
 
 locals {
-  edge_lambda_request_version  = 101
-  edge_lambda_response_version = 102
+  edge_lambda_request_version  = 106
+  edge_lambda_response_version = 106
 
   wellcome_cdn_cert_arn = "arn:aws:acm:us-east-1:130871440101:certificate/bb840c52-56bb-4bf8-86f8-59e7deaf9c98"
 

--- a/cache/send_slack_alert_for_5xx_errors.js
+++ b/cache/send_slack_alert_for_5xx_errors.js
@@ -119,7 +119,7 @@ async function sendSlackMessage(bucket, key, serverErrors, hits) {
 
   // This creates a Markdown-formatted message like:
   //
-  //    5 errors / 5K requests / <https://us-east-1…|logs in S3>
+  //    5 errors / 5K requests / <https://us-east-1…|CloudFront logs>
   //    ```
   //    https://example.org/badness
   //    https://example.org/more-badness
@@ -140,7 +140,7 @@ async function sendSlackMessage(bucket, key, serverErrors, hits) {
   }`;
 
   const message =
-    `${errorCount} / ${requestCount} / <${url}|logs in S3>\n` +
+    `${errorCount} / ${requestCount} / <${url}|CloudFront logs>\n` +
     '```\n' +
     lines.join('\n') +
     '\n```';


### PR DESCRIPTION
While debugging with Raphaëlle this morning, she said that her first point of debugging would be to click the prominent link 'see logs' in the Slack alert – even though that takes you to the raw CloudFront log file, which isn't very useful!

That link was originally meant to help debug the alert, but it's misleading and poor alert design.  It should be taking you somewhere useful!

This patch improves the alert by adding a link to a canned Kibana logging search for the front-end apps, which should contain more useful context. This canned search:

*   pre-filters to the front-end apps
*   adds a query that excludes a lot of logs that aren't interesting for debugging, e.g. 200 responses and the health checker

This is the first log in the alert, so people can debug app errors more quickly.

Example:

<img width="732" alt="Screenshot 2022-11-18 at 16 18 17" src="https://user-images.githubusercontent.com/301220/202751541-371baa56-22c1-4903-acd1-c97ef578bbc4.png">
