### PR TITLE
What's on: Remove extra grid container

### DIFF
--- a/content/webapp/pages/whats-on.tsx
+++ b/content/webapp/pages/whats-on.tsx
@@ -534,30 +534,20 @@ const WhatsOnPage: FunctionComponent<Props> = props => {
           </SpacingComponent>
           <SpacingComponent>
             <CssGridContainer>
-              <div className="css-grid">
-                <div
-                  className={
-                    'css-grid__scroll-container container--scroll touch-scroll' +
-                    ' ' +
-                    cssGrid({ s: 12, m: 12, l: 12, xl: 12 })
-                  }
-                >
-                  <div className="css-grid grid--scroll card-theme card-theme--transparent">
-                    {tryTheseTooPromos.concat(eatShopPromos).map(promo => (
-                      <div
-                        key={promo.id}
-                        className={cssGrid({
-                          s: 12,
-                          m: 6,
-                          l: 4,
-                          xl: 4,
-                        })}
-                      >
-                        <FacilityPromo {...promo} />
-                      </div>
-                    ))}
+              <div className="css-grid card-theme card-theme--transparent">
+                {tryTheseTooPromos.concat(eatShopPromos).map(promo => (
+                  <div
+                    key={promo.id}
+                    className={cssGrid({
+                      s: 12,
+                      m: 6,
+                      l: 4,
+                      xl: 4,
+                    })}
+                  >
+                    <FacilityPromo {...promo} />
                   </div>
-                </div>
+                ))}
               </div>
             </CssGridContainer>
           </SpacingComponent>


### PR DESCRIPTION
## Who is this for?
Design

## What is it doing for them?
Fixes missing margins in https://wellcomecollection.org/whats-on
There was an extra container that I'm not sure was useful, I cleaned up some classes - do let me know if these should stay in there, it just didn't look like it did to me.

Before
<img width="437" alt="Screenshot 2022-11-21 at 10 07 05" src="https://user-images.githubusercontent.com/110461050/203023116-74f33a81-8f08-4c59-bd95-5384feb79fd9.png">

After
<img width="416" alt="Screenshot 2022-11-21 at 10 08 21" src="https://user-images.githubusercontent.com/110461050/203023407-56e1efea-29d6-4ac9-a59c-5b67701f3829.png">
