### PR TITLE
Apply object-fit for Safari

### DIFF
--- a/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
+++ b/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
@@ -82,6 +82,8 @@ const ImageLink = styled.a`
   img {
     max-width: calc(100% - 20px);
     max-height: 100%;
+    // Safari doesn't respond to max-height/width like the other browsers, we need this to ensure it's not warped.
+    object-fit: contain;
   }
 
   ${props => props.theme.media('large')`

--- a/catalogue/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.tsx
+++ b/catalogue/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.tsx
@@ -40,6 +40,8 @@ const Wrapper = styled(Space).attrs({
     margin-right: 10px;
     width: auto;
     max-height: 120px;
+    // Safari doesn't respond to max-height/width like the other browsers, we need this to ensure it's not warped.
+    object-fit: contain;
 
     ${props => props.theme.media('large')`
       max-width: 150px;


### PR DESCRIPTION
## Who is this for?
Safari users

## What is it doing for them?
A few of us looked into it and it was a discovery in "[Safari likes to read into max-width/height auto its own way](https://stackoverflow.com/questions/10760243/safari-image-size-auto-height-css)". There might be a better fix but because we have such diverse aspect ratios in our images, this code was to allow for all of them to display nicely in the expanded model. In the meantime, this is the fix I'm suggesting. It's not perfect in Safari (there's a lot of spacing as the parent still adopts a square shape), but at least the image is true to its ratio.

I also found that the main image in the modal would be warped on mobile, so fixed it there too.


Before
<img width="945" alt="Screenshot 2022-11-22 at 17 03 40" src="https://user-images.githubusercontent.com/110461050/203510239-13cc7117-4537-495c-ace0-b0824e2a2f5b.png">

After
<img width="895" alt="Screenshot 2022-11-22 at 17 03 31" src="https://user-images.githubusercontent.com/110461050/203510258-fa0901ef-afdf-4084-9e2e-a2f6dbc3dbce.png">

--------

Before
<img width="582" alt="Screenshot 2022-11-23 at 09 21 30" src="https://user-images.githubusercontent.com/110461050/203510581-396ca970-87de-46e3-bccc-e56c54951229.png">

After
<img width="580" alt="Screenshot 2022-11-23 at 09 21 07" src="https://user-images.githubusercontent.com/110461050/203510633-3aaef330-47e1-43db-8028-27d3720452b8.png">

Closes #8896 