### PR TITLE
Ensure ids for exhibition titles are unique

### DIFF
--- a/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
+++ b/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
@@ -228,7 +228,9 @@ const Stop: FunctionComponent<{
               }}
               v={{ size: 'l', properties: ['margin-bottom'] }}
             >
-              <StandaloneTitle id={dasherizeShorten(`${standaloneTitle}`)}>
+              <StandaloneTitle
+                id={`${dasherizeShorten(`${standaloneTitle}`)}-${index}`}
+              >
                 {standaloneTitle}
               </StandaloneTitle>
             </Space>
@@ -252,7 +254,7 @@ const Stop: FunctionComponent<{
               {!hasContext && title && (
                 <TombstoneTitle
                   level={tombstoneHeadingLevel}
-                  id={dasherizeShorten(`${title}`)}
+                  id={`${dasherizeShorten(`${title}`)}-${index}`}
                 >
                   {title}
                 </TombstoneTitle>
@@ -267,7 +269,7 @@ const Stop: FunctionComponent<{
                 <>
                   {title.length > 0 && (
                     <ContextTitle
-                      id={dasherizeShorten(title)}
+                      id={`${dasherizeShorten(`${title}`)}-c${index}`}
                       level={contextHeadingLevel}
                     >
                       {title}

--- a/content/webapp/services/prismic/transformers/exhibition-guides.ts
+++ b/content/webapp/services/prismic/transformers/exhibition-guides.ts
@@ -122,12 +122,12 @@ export function transformExhibitionGuide(
   const { data } = document;
 
   const components: ExhibitionGuideComponent[] = data.components?.map(
-    (component: ExhibitionGuideComponentPrismicDocument) => {
+    (component: ExhibitionGuideComponentPrismicDocument, index) => {
       const title = asTitle(component.title);
       const standaloneTitle = asTitle(component.standaloneTitle);
 
       const displayTitle = title || standaloneTitle;
-      const anchorId = dasherizeShorten(displayTitle);
+      const anchorId = `${dasherizeShorten(displayTitle)}-${index}`;
 
       return {
         number: component.number || undefined,


### PR DESCRIPTION
**Should not be deployed until Monday when the exhibition is closed.**

Fixes #8843

There are instances where the truncated titles, which we use for ids, aren't unique.  This is a problem for accessibility and because we use the ids to link directly to exhibition stops from QR codes.

This PR ensures all the ids on exhibition titles are unique by appending the stop index to the truncated title. 

E.g. before:

after: 
https://wellcomecollection.org/guides/exhibitions/Y2omihEAAKLNfLar/audio-with-descriptions#introduction
https://wellcomecollection.org/guides/exhibitions/Y2omihEAAKLNfLar/audio-with-descriptions#jim-naughten-talks-about
https://wellcomecollection.org/guides/exhibitions/Y2omihEAAKLNfLar/audio-with-descriptions#jim-naughten-talks-about
https://wellcomecollection.org/guides/exhibitions/Y2omihEAAKLNfLar/audio-with-descriptions#conservator-emma-duggan-talks
https://wellcomecollection.org/guides/exhibitions/Y2omihEAAKLNfLar/audio-with-descriptions#conservator-emma-duggan-talks

https://wellcomecollection.org/guides/exhibitions/Y2omihEAAKLNfLar/audio-with-descriptions#introduction-0
https://wellcomecollection.org/guides/exhibitions/Y2omihEAAKLNfLar/audio-with-descriptions#jim-naughten-talks-about-1
https://wellcomecollection.org/guides/exhibitions/Y2omihEAAKLNfLar/audio-with-descriptions#jim-naughten-talks-about-4
https://wellcomecollection.org/guides/exhibitions/Y2omihEAAKLNfLar/audio-with-descriptions#conservator-emma-duggan-talks-11
https://wellcomecollection.org/guides/exhibitions/Y2omihEAAKLNfLar/audio-with-descriptions#conservator-emma-duggan-talks-19

@davidpmccormick has kindly agreed to merge and deploy this on Monday (as I'm away), when the gallery is closed, so @dannybirchall can update the urls behind the QR codes.
