### PR TITLE
Align stories, works and images and set an empty default state

### DIFF
--- a/catalogue/webapp/components/SearchNoResults/SearchNoResults.tsx
+++ b/catalogue/webapp/components/SearchNoResults/SearchNoResults.tsx
@@ -35,10 +35,7 @@ const SearchNoResults: FunctionComponent<Props> = ({
               We couldn&rsquo;t find anything that matched{' '}
               <QuerySpan>{query}</QuerySpan>
               {hasFilters && (
-                <>
-                  <span> with the filters you have selected</span>. Please try
-                  again.
-                </>
+                <> with the filters you have selected. Please try again.</>
               )}
             </Copy>
           </div>

--- a/catalogue/webapp/components/SearchNoResults/SearchNoResults.tsx
+++ b/catalogue/webapp/components/SearchNoResults/SearchNoResults.tsx
@@ -5,7 +5,7 @@ import { FunctionComponent } from 'react';
 import { PaletteColor } from '@weco/common/views/themes/config';
 
 type Props = {
-  query: string | undefined;
+  query: string;
   hasFilters: boolean;
   textColor?: PaletteColor;
 };
@@ -31,18 +31,16 @@ const SearchNoResults: FunctionComponent<Props> = ({
       <div className="container">
         <div className="grid">
           <div className={grid({ s: 12, m: 10, l: 8, xl: 8 })}>
-            {query && (
-              <Copy textColor={textColor}>
-                We couldn&rsquo;t find anything that matched{' '}
-                <QuerySpan>{query}</QuerySpan>
-                {hasFilters && (
-                  <>
-                    <span> with the filters you have selected</span>. Please try
-                    again.
-                  </>
-                )}
-              </Copy>
-            )}
+            <Copy textColor={textColor}>
+              We couldn&rsquo;t find anything that matched{' '}
+              <QuerySpan>{query}</QuerySpan>
+              {hasFilters && (
+                <>
+                  <span> with the filters you have selected</span>. Please try
+                  again.
+                </>
+              )}
+            </Copy>
           </div>
         </div>
       </div>

--- a/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
+++ b/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
@@ -151,6 +151,14 @@ const SearchLayout: FunctionComponent = ({ children }) => {
             return false;
           }}
         />
+        <h1 className="visually-hidden">
+          {/* Uppercases the first letter */}
+          {`${
+            currentSearchCategory[0].toUpperCase() +
+            currentSearchCategory.substring(1)
+          } search page`}
+        </h1>
+
         <SearchBarContainer
           v={{ size: 'l', properties: ['margin-top', 'margin-bottom'] }}
         >

--- a/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
+++ b/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
@@ -13,6 +13,7 @@ import convertUrlToString from '@weco/common/utils/convert-url-to-string';
 import { trackEvent } from '@weco/common/utils/ga';
 import { removeEmptyProps } from '@weco/common/utils/json';
 import { getUrlQueryFromSortValue } from '@weco/catalogue/utils/search';
+import { capitalize } from '@weco/common/utils/grammar';
 
 const SearchBarContainer = styled(Space)`
   ${props => props.theme.media('medium', 'max-width')`
@@ -152,11 +153,7 @@ const SearchLayout: FunctionComponent = ({ children }) => {
           }}
         />
         <h1 className="visually-hidden">
-          {/* Uppercases the first letter */}
-          {`${
-            currentSearchCategory[0].toUpperCase() +
-            currentSearchCategory.substring(1)
-          } search page`}
+          {`${capitalize(currentSearchCategory)} search page`}
         </h1>
 
         <SearchBarContainer

--- a/catalogue/webapp/pages/search/events.tsx
+++ b/catalogue/webapp/pages/search/events.tsx
@@ -8,9 +8,9 @@ import { getSearchLayout } from '@weco/catalogue/components/SearchPageLayout/Sea
 import {
   getEvents,
   PrismicQueryProps,
-} from '../../services/prismic/fetch/events';
-import { Event } from '../../services/prismic/types/event';
-import { PrismicResultsList } from '../../services/prismic/types';
+} from '@weco/catalogue/services/prismic/fetch/events';
+import { Event } from '@weco/catalogue/services/prismic/types/event';
+import { PrismicResultsList } from '@weco/catalogue/services/prismic/types';
 import { Pageview } from '@weco/common/services/conversion/track';
 
 type Props = {
@@ -23,7 +23,6 @@ export const SearchPage: NextPageWithLayout<Props> = ({
 }) => {
   return (
     <div className="container">
-      <h1 className="visually-hidden">Events Search Page</h1>
       <Space v={{ size: 'l', properties: ['margin-top', 'margin-bottom'] }}>
         <div>Events content</div>
       </Space>

--- a/catalogue/webapp/pages/search/exhibitions.tsx
+++ b/catalogue/webapp/pages/search/exhibitions.tsx
@@ -23,7 +23,6 @@ export const SearchPage: NextPageWithLayout<Props> = ({
 }) => {
   return (
     <div className="container">
-      <h1 className="visually-hidden">Exhibitions Search Page</h1>
       <Space v={{ size: 'l', properties: ['margin-top', 'margin-bottom'] }}>
         <div>Exhibition content</div>
       </Space>

--- a/catalogue/webapp/pages/search/images.tsx
+++ b/catalogue/webapp/pages/search/images.tsx
@@ -10,6 +10,7 @@ import Space from '@weco/common/views/components/styled/Space';
 import SearchNoResults from '@weco/catalogue/components/SearchNoResults/SearchNoResults';
 import SearchContext from '@weco/common/views/components/SearchContext/SearchContext';
 import SearchPagination from '@weco/common/views/components/SearchPagination/SearchPagination';
+import SearchFilters from '@weco/common/views/components/SearchFilters/SearchFilters';
 
 // Utils & Helpers
 import convertUrlToString from '@weco/common/utils/convert-url-to-string';
@@ -24,19 +25,20 @@ import {
 } from '@weco/common/views/components/ImagesLink/ImagesLink';
 import { getServerData } from '@weco/common/server-data';
 import { getSearchLayout } from 'components/SearchPageLayout/SearchPageLayout';
+import { imagesFilters } from '@weco/common/services/catalogue/filters';
+import { propsToQuery } from '@weco/common/utils/routes';
+import { hasFilters } from '@weco/catalogue/utils/search';
 
 // Types
 import { CatalogueResultsList, Image } from '@weco/common/model/catalogue';
 import { NextPageWithLayout } from '@weco/common/views/pages/_app';
 import { font } from '@weco/common/utils/classnames';
-
-import SearchFilters from '@weco/common/views/components/SearchFilters/SearchFilters';
-import { imagesFilters } from '@weco/common/services/catalogue/filters';
-import { propsToQuery } from '@weco/common/utils/routes';
+import { Query } from '@weco/catalogue/types/search';
 
 type Props = {
   images?: CatalogueResultsList<Image>;
   imagesRouteProps: ImagesProps;
+  query: Query;
   pageview: Pageview;
 };
 
@@ -63,8 +65,9 @@ const BottomPaginationWrapper = styled(PaginationWrapper)`
 const ImagesSearchPage: NextPageWithLayout<Props> = ({
   images,
   imagesRouteProps,
+  query,
 }): ReactElement<Props> => {
-  const { query, page, color: colorFilter } = imagesRouteProps;
+  const { query: queryString } = query;
 
   const { setLink } = useContext(SearchContext);
   useEffect(() => {
@@ -72,12 +75,22 @@ const ImagesSearchPage: NextPageWithLayout<Props> = ({
     setLink(link);
   }, [imagesRouteProps]);
 
+  // If there is no query, return an empty page
+  if (!queryString) {
+    return (
+      <Space
+        v={{ size: 'xl', properties: ['padding-top', 'padding-bottom'] }}
+      ></Space>
+    );
+  }
+
   const filters = images
     ? imagesFilters({ images, props: imagesRouteProps })
     : [];
 
   const linkResolver = params => {
     const queryWithSource = propsToQuery(params);
+    /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
     const { source = undefined, ...queryWithoutSource } = {
       ...queryWithSource,
     };
@@ -102,8 +115,10 @@ const ImagesSearchPage: NextPageWithLayout<Props> = ({
           <link
             rel="prev"
             href={convertUrlToString(
-              toLink({ ...imagesRouteProps, page: (page || 1) - 1 }, 'unknown')
-                .as
+              toLink(
+                { ...imagesRouteProps, page: (imagesRouteProps.page || 1) - 1 },
+                'unknown'
+              ).as
             )}
           />
         )}
@@ -111,17 +126,18 @@ const ImagesSearchPage: NextPageWithLayout<Props> = ({
           <link
             rel="next"
             href={convertUrlToString(
-              toLink({ ...imagesRouteProps, page: page + 1 }, 'unknown').as
+              toLink(
+                { ...imagesRouteProps, page: imagesRouteProps.page + 1 },
+                'unknown'
+              ).as
             )}
           />
         )}
       </Head>
-      {/* TODO review if this needs updating */}
 
-      <h1 className="visually-hidden">Images Search Page</h1>
       <div className="container">
         <SearchFilters
-          query={query}
+          query={queryString}
           linkResolver={linkResolver}
           searchFormId="searchPageForm"
           changeHandler={() => {
@@ -138,36 +154,38 @@ const ImagesSearchPage: NextPageWithLayout<Props> = ({
         />
       </div>
 
-      <Wrapper>
-        {images?.results && images.totalResults > 0 && (
-          <div className="container">
-            <PaginationWrapper>
-              {images.totalResults > 0 && (
-                <span>{`${images.totalResults} result${
-                  images.totalResults > 1 ? 's' : ''
-                }`}</span>
-              )}
-              <SearchPagination totalPages={images?.totalPages} darkBg />
-            </PaginationWrapper>
+      {images && (
+        <>
+          {images?.totalResults === 0 ? (
+            <SearchNoResults
+              query={queryString}
+              hasFilters={hasFilters({
+                filters: filters.map(f => f.id),
+                queryParams: Object.keys(query).map(p => p),
+              })}
+            />
+          ) : (
+            <Wrapper>
+              <div className="container">
+                <PaginationWrapper>
+                  <span>{`${images.totalResults} result${
+                    images.totalResults > 1 ? 's' : ''
+                  }`}</span>
+                  <SearchPagination totalPages={images?.totalPages} darkBg />
+                </PaginationWrapper>
 
-            <main>
-              <ImageEndpointSearchResults images={images} />
-            </main>
+                <main>
+                  <ImageEndpointSearchResults images={images} />
+                </main>
 
-            <BottomPaginationWrapper>
-              <SearchPagination totalPages={images?.totalPages} darkBg />
-            </BottomPaginationWrapper>
-          </div>
-        )}
-
-        {images?.totalResults === 0 && (
-          <SearchNoResults
-            query={query}
-            hasFilters={!!colorFilter}
-            textColor="white"
-          />
-        )}
-      </Wrapper>
+                <BottomPaginationWrapper>
+                  <SearchPagination totalPages={images?.totalPages} darkBg />
+                </BottomPaginationWrapper>
+              </div>
+            </Wrapper>
+          )}
+        </>
+      )}
     </>
   );
 };
@@ -177,12 +195,29 @@ ImagesSearchPage.getLayout = getSearchLayout;
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
     const serverData = await getServerData(context);
+    const query = context.query;
 
     if (!serverData.toggles.searchPage) {
       return { notFound: true };
     }
 
     const params = fromQuery(context.query);
+
+    // Stop here if no query has been entered
+    if (!params.query) {
+      return {
+        props: removeUndefinedProps({
+          imagesRouteProps: params,
+          serverData,
+          query,
+          pageview: {
+            name: 'images',
+            properties: { totalResults: 0 },
+          },
+        }),
+      };
+    }
+
     const aggregations = [
       'locations.license',
       'source.genres.label',
@@ -205,9 +240,10 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
 
     return {
       props: removeUndefinedProps({
-        serverData,
         images,
         imagesRouteProps: params,
+        serverData,
+        query,
         pageview: {
           name: 'images',
           properties: images

--- a/catalogue/webapp/pages/search/images.tsx
+++ b/catalogue/webapp/pages/search/images.tsx
@@ -28,11 +28,12 @@ import { getSearchLayout } from 'components/SearchPageLayout/SearchPageLayout';
 import { imagesFilters } from '@weco/common/services/catalogue/filters';
 import { propsToQuery } from '@weco/common/utils/routes';
 import { hasFilters } from '@weco/catalogue/utils/search';
+import { pluralize } from '@weco/common/utils/grammar';
+import { font } from '@weco/common/utils/classnames';
 
 // Types
 import { CatalogueResultsList, Image } from '@weco/common/model/catalogue';
 import { NextPageWithLayout } from '@weco/common/views/pages/_app';
-import { font } from '@weco/common/utils/classnames';
 import { Query } from '@weco/catalogue/types/search';
 
 type Props = {
@@ -168,9 +169,7 @@ const ImagesSearchPage: NextPageWithLayout<Props> = ({
             <Wrapper>
               <div className="container">
                 <PaginationWrapper>
-                  <span>{`${images.totalResults} result${
-                    images.totalResults > 1 ? 's' : ''
-                  }`}</span>
+                  <span>{pluralize(images.totalResults, 'result')}</span>
                   <SearchPagination totalPages={images?.totalPages} darkBg />
                 </PaginationWrapper>
 

--- a/catalogue/webapp/pages/search/index.tsx
+++ b/catalogue/webapp/pages/search/index.tsx
@@ -14,7 +14,6 @@ type Props = {
 export const SearchPage: NextPageWithLayout<Props> = () => {
   return (
     <div className="container">
-      <h1 className="visually-hidden">Overview Search Page</h1>
       <Space v={{ size: 'l', properties: ['margin-top', 'margin-bottom'] }}>
         <div>Overview</div>
       </Space>

--- a/catalogue/webapp/pages/search/stories.tsx
+++ b/catalogue/webapp/pages/search/stories.tsx
@@ -18,6 +18,7 @@ import { AppErrorProps } from '@weco/common/services/app';
 import { getServerData } from '@weco/common/server-data';
 import { getStories } from '@weco/catalogue/services/prismic/fetch/articles';
 import { Pageview } from '@weco/common/services/conversion/track';
+import { pluralize } from '@weco/common/utils/grammar';
 
 // Types
 import { Story } from '@weco/catalogue/services/prismic/types/story';
@@ -45,13 +46,6 @@ const PaginationWrapper = styled(Space).attrs({
   justify-content: space-between;
   align-items: center;
   flex-wrap: wrap;
-`;
-
-const TotalResultsCopy = styled.span`
-  ${props =>
-    props.theme.media('medium', 'max-width')`
-    flex: 1 1 50%;
-  `}
 `;
 
 const SortPaginationWrapper = styled.div`
@@ -181,9 +175,7 @@ export const SearchPage: NextPageWithLayout<Props> = ({
         <div className="container">
           {/* TODO make pagination - cursor based pagination with graphql query */}
           <PaginationWrapper>
-            <TotalResultsCopy>{`${storyResponseList.totalResults} result${
-              storyResponseList.totalResults > 1 ? 's' : ''
-            }`}</TotalResultsCopy>
+            <span>{pluralize(storyResponseList.totalResults, 'result')}</span>
 
             <SortPaginationWrapper>
               <Sort

--- a/catalogue/webapp/pages/search/stories.tsx
+++ b/catalogue/webapp/pages/search/stories.tsx
@@ -1,27 +1,31 @@
 import { GetServerSideProps } from 'next';
 import styled from 'styled-components';
 
+// Components
 import Space from '@weco/common/views/components/styled/Space';
 import { getSearchLayout } from '@weco/catalogue/components/SearchPageLayout/SearchPageLayout';
 import SearchPagination from '@weco/common/views/components/SearchPagination/SearchPagination';
 import SearchNoResults from '@weco/catalogue/components/SearchNoResults/SearchNoResults';
 import HTMLDate from '@weco/common/views/components/HTMLDate/HTMLDate';
 import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
+import Sort from '@weco/catalogue/components/Sort/Sort';
 
+// Utils & Helpers
 import { NextPageWithLayout } from '@weco/common/views/pages/_app';
 import { font } from '@weco/common/utils/classnames';
 import { removeUndefinedProps } from '@weco/common/utils/json';
 import { AppErrorProps } from '@weco/common/services/app';
 import { getServerData } from '@weco/common/server-data';
 import { getStories } from '@weco/catalogue/services/prismic/fetch/articles';
+import { Pageview } from '@weco/common/services/conversion/track';
+
+// Types
 import { Story } from '@weco/catalogue/services/prismic/types/story';
 import {
   PrismicApiError,
   PrismicResultsList,
-  Query,
 } from '@weco/catalogue/services/prismic/types';
-import { Pageview } from '@weco/common/services/conversion/track';
-import Sort from '@weco/catalogue/components/Sort/Sort';
+import { Query } from '@weco/catalogue/types/search';
 
 type Props = {
   storyResponseList: PrismicResultsList<Story>;
@@ -158,23 +162,28 @@ export const SearchPage: NextPageWithLayout<Props> = ({
   storyResponseList,
   query,
 }) => {
+  const { query: queryString } = query;
+
+  // If there is no query, return an empty page
+  if (!queryString) {
+    return (
+      <Space
+        v={{ size: 'xl', properties: ['padding-top', 'padding-bottom'] }}
+      ></Space>
+    );
+  }
+
   return (
     <Wrapper>
-      <h1 className="visually-hidden">Stories Search Page</h1>
-
-      {storyResponseList.totalResults === 0 && (
-        <SearchNoResults query={query.query} hasFilters={false} />
-      )}
-
-      {storyResponseList.totalResults > 0 && (
+      {storyResponseList.totalResults === 0 ? (
+        <SearchNoResults query={queryString} hasFilters={false} />
+      ) : (
         <div className="container">
           {/* TODO make pagination - cursor based pagination with graphql query */}
           <PaginationWrapper>
-            {storyResponseList.totalResults > 0 && (
-              <TotalResultsCopy>{`${storyResponseList.totalResults} result${
-                storyResponseList.totalResults > 1 ? 's' : ''
-              }`}</TotalResultsCopy>
-            )}
+            <TotalResultsCopy>{`${storyResponseList.totalResults} result${
+              storyResponseList.totalResults > 1 ? 's' : ''
+            }`}</TotalResultsCopy>
 
             <SortPaginationWrapper>
               <Sort

--- a/catalogue/webapp/pages/search/works.tsx
+++ b/catalogue/webapp/pages/search/works.tsx
@@ -32,6 +32,7 @@ import { propsToQuery } from '@weco/common/utils/routes';
 import convertUrlToString from '@weco/common/utils/convert-url-to-string';
 import { hasFilters } from '@weco/catalogue/utils/search';
 import { AppErrorProps, appError } from '@weco/common/services/app';
+import { pluralize } from '@weco/common/utils/grammar';
 
 // Types
 import { CatalogueResultsList, Work } from '@weco/common/model/catalogue';
@@ -168,9 +169,7 @@ export const CatalogueSearchPage: NextPageWithLayout<Props> = ({
             ) : (
               <>
                 <PaginationWrapper aria-label="Sort Search Results">
-                  <span>{`${works.totalResults} result${
-                    works.totalResults > 1 ? 's' : ''
-                  }`}</span>
+                  <span>{pluralize(works.totalResults, 'result')}</span>
 
                   <SortPaginationWrapper>
                     <Sort

--- a/catalogue/webapp/services/prismic/fetch/articles.ts
+++ b/catalogue/webapp/services/prismic/fetch/articles.ts
@@ -1,5 +1,6 @@
 import { Story } from '../types/story';
-import { PrismicResultsList, PrismicApiError, Query } from '../types';
+import { PrismicResultsList, PrismicApiError } from '../types';
+import { Query } from '@weco/catalogue/types/search';
 import { prismicGraphQLClient, prismicApiError } from '.';
 import { transformPrismicResponse } from '../transformers';
 

--- a/catalogue/webapp/services/prismic/fetch/events.ts
+++ b/catalogue/webapp/services/prismic/fetch/events.ts
@@ -1,4 +1,5 @@
-import { PrismicResultsList, PrismicApiError, Query } from '../types';
+import { PrismicResultsList, PrismicApiError } from '../types';
+import { Query } from '@weco/catalogue/types/search';
 import { Event } from '../types/event';
 import { prismicGraphQLClient, prismicApiError } from '.';
 import { transformPrismicResponse } from '../transformers';

--- a/catalogue/webapp/services/prismic/fetch/exhibitions.ts
+++ b/catalogue/webapp/services/prismic/fetch/exhibitions.ts
@@ -1,4 +1,5 @@
-import { PrismicResultsList, PrismicApiError, Query } from '../types';
+import { PrismicResultsList, PrismicApiError } from '../types';
+import { Query } from '@weco/catalogue/types/search';
 import { Exhibition } from '../types/exhibition';
 import { prismicGraphQLClient, prismicApiError } from '.';
 import { transformPrismicResponse } from '../transformers';

--- a/catalogue/webapp/services/prismic/fetch/index.ts
+++ b/catalogue/webapp/services/prismic/fetch/index.ts
@@ -5,7 +5,7 @@ import { gql, GraphQLClient } from 'graphql-request';
 import { PrismicApiError } from '../types';
 import { unCamelCase, capitalize } from '@weco/common/utils/grammar';
 import { ArticleFormatIds } from '@weco/common/data/content-format-ids';
-import { Query } from '@weco/catalogue/services/prismic/types';
+import { Query } from '@weco/catalogue/types/search';
 import { getPrismicSortValue } from '@weco/catalogue/utils/search';
 
 export const typesToPrismicGraphQLSchemaTypes = {

--- a/catalogue/webapp/services/prismic/types/index.ts
+++ b/catalogue/webapp/services/prismic/types/index.ts
@@ -115,9 +115,3 @@ export type PrismicResponse = {
 };
 
 export type TransformedResponse = Story | Event | Exhibition;
-
-export type Query = {
-  query?: string;
-  sortOrder?: string;
-  sort?: string;
-};

--- a/catalogue/webapp/types/search.ts
+++ b/catalogue/webapp/types/search.ts
@@ -1,0 +1,5 @@
+export type Query = {
+  query?: string;
+  sortOrder?: string;
+  sort?: string;
+};

--- a/catalogue/webapp/utils/search.ts
+++ b/catalogue/webapp/utils/search.ts
@@ -59,7 +59,8 @@ export const getPrismicSortValue = ({
 
 // FILTERS
 /**
- * Compare filter options to query parameters
+ * Compare filter options to query parameters,
+ * telling us if the user has applied any filters.
  * This is used for SearchNoResult's rendered copy
  * @param {string[]} filters - Available filter options
  * @param {string[]} queryParams - URL query parameters

--- a/catalogue/webapp/utils/search.ts
+++ b/catalogue/webapp/utils/search.ts
@@ -56,3 +56,20 @@ export const getPrismicSortValue = ({
   // this is currently what we set as default for Stories
   return 'title_ASC';
 };
+
+// FILTERS
+/**
+ * Compare filter options to query parameters
+ * This is used for SearchNoResult's rendered copy
+ * @param {string[]} filters - Available filter options
+ * @param {string[]} queryParams - URL query parameters
+ */
+export const hasFilters = ({
+  filters,
+  queryParams,
+}: {
+  filters: string[];
+  queryParams: string[];
+}): boolean => {
+  return !!filters.filter(element => queryParams.includes(element)).length;
+};

--- a/common/utils/grammar.ts
+++ b/common/utils/grammar.ts
@@ -32,6 +32,10 @@ export function dasherizeShorten(words: string): string {
     .replace(/\W/g, '-');
 }
 
+export function pluralize(count: number, noun: string, suffix = 's'): string {
+  return `${count} ${noun}${count !== 1 ? suffix : ''}`;
+}
+
 export function unCamelCase(words: string): string {
   return words.split(/(?=[A-Z])/).join(' ');
 }


### PR DESCRIPTION
## Who is this for?
Devs and new search

## What is it doing for them?
- Aligns all three search pages in terms of how to render different states
- Images and Works don't display default results when the query is empty anymore
- We don't use `SearchNoResults` anymore when the query is empty, it's solely for when a query returns no results again.
- `hasFilters` for `SearchNoResults` now looks at all filters (not sure why it was only looking at specific ones - maybe this change wasn't necessary?)
- Moved each pages' H1 to `SearchPageLayout`
- Added `<link rel="next/prev" ... />` to `/search/works`. Probably should be added to stories too but only did it quickly here as part of the alignment, I think the rest depends on Pagination for Prismic content working.

Closes #8862 , #8863 , #8864 
