### PR TITLE
Events & Exhibitions toggle

### DIFF
--- a/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
+++ b/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
@@ -20,7 +20,10 @@ const SearchBarContainer = styled(Space)`
   `}
 `;
 
-const SearchLayout: FunctionComponent = ({ children }) => {
+const SearchLayout: FunctionComponent<{ hasEventsExhibitions: boolean }> = ({
+  children,
+  hasEventsExhibitions,
+}) => {
   const router = useRouter();
 
   const currentSearchCategory =
@@ -62,22 +65,6 @@ const SearchLayout: FunctionComponent = ({ children }) => {
       case 'overview':
         setPageLayoutMetadata(defaultPageLayoutMetadata);
         break;
-      case 'exhibitions':
-        setPageLayoutMetadata({
-          ...basePageMetadata,
-          description: 'copy pending',
-          title: `${query ? `${query} | ` : ''}Exhibition Search`,
-          url: { pathname: '/search/exhibitions', query: query || {} },
-        });
-        break;
-      case 'events':
-        setPageLayoutMetadata({
-          ...basePageMetadata,
-          description: 'copy pending',
-          title: `${query ? `${query} | ` : ''}Events Search`,
-          url: { pathname: '/search/events', query: query || {} },
-        });
-        break;
       case 'stories':
         setPageLayoutMetadata({
           ...basePageMetadata,
@@ -100,6 +87,23 @@ const SearchLayout: FunctionComponent = ({ children }) => {
           description: 'copy pending',
           title: `${query ? `${query} | ` : ''}Catalogue Search`,
           url: { pathname: '/search/collections', query: query || {} },
+        });
+        break;
+      // In development
+      case 'exhibitions':
+        setPageLayoutMetadata({
+          ...basePageMetadata,
+          description: 'copy pending',
+          title: `${query ? `${query} | ` : ''}Exhibition Search`,
+          url: { pathname: '/search/exhibitions', query: query || {} },
+        });
+        break;
+      case 'events':
+        setPageLayoutMetadata({
+          ...basePageMetadata,
+          description: 'copy pending',
+          title: `${query ? `${query} | ` : ''}Events Search`,
+          url: { pathname: '/search/events', query: query || {} },
         });
         break;
 
@@ -166,16 +170,6 @@ const SearchLayout: FunctionComponent = ({ children }) => {
               name: 'Overview',
             },
             {
-              id: 'exhibitions',
-              url: getURL('/search/exhibitions'),
-              name: 'Exhibitions',
-            },
-            {
-              id: 'events',
-              url: getURL('/search/events'),
-              name: 'Events',
-            },
-            {
               id: 'stories',
               url: getURL('/search/stories'),
               name: 'Stories',
@@ -190,6 +184,20 @@ const SearchLayout: FunctionComponent = ({ children }) => {
               url: getURL('/search/works'),
               name: 'Catalogue',
             },
+            ...(hasEventsExhibitions
+              ? [
+                  {
+                    id: 'exhibitions',
+                    url: getURL('/search/exhibitions'),
+                    name: 'Exhibitions',
+                  },
+                  {
+                    id: 'events',
+                    url: getURL('/search/events'),
+                    name: 'Events',
+                  },
+                ]
+              : []),
           ]}
           currentSection={currentSearchCategory}
           hasDivider
@@ -201,8 +209,14 @@ const SearchLayout: FunctionComponent = ({ children }) => {
   );
 };
 
-export const getSearchLayout = (page: ReactElement): JSX.Element => (
-  <SearchLayout>{page}</SearchLayout>
-);
+export const getSearchLayout = (page: ReactElement): JSX.Element => {
+  const { searchPageEventsExhibitions } = page.props.serverData.toggles;
+
+  return (
+    <SearchLayout hasEventsExhibitions={searchPageEventsExhibitions}>
+      {page}
+    </SearchLayout>
+  );
+};
 
 export default SearchLayout;

--- a/catalogue/webapp/pages/search/events.tsx
+++ b/catalogue/webapp/pages/search/events.tsx
@@ -8,9 +8,9 @@ import { getSearchLayout } from '@weco/catalogue/components/SearchPageLayout/Sea
 import {
   getEvents,
   PrismicQueryProps,
-} from '../../services/prismic/fetch/events';
-import { Event } from '../../services/prismic/types/event';
-import { PrismicResultsList } from '../../services/prismic/types';
+} from '@weco/catalogue/services/prismic/fetch/events';
+import { Event } from '@weco/catalogue/services/prismic/types/event';
+import { PrismicResultsList } from '@weco/catalogue/services/prismic/types';
 import { Pageview } from '@weco/common/services/conversion/track';
 
 type Props = {
@@ -63,7 +63,10 @@ export const getServerSideProps: GetServerSideProps<
   const serverData = await getServerData(context);
   const query = context.query;
 
-  if (!serverData.toggles.searchPage) {
+  if (
+    !serverData.toggles.searchPage &&
+    !serverData.toggles.searchPageEventsExhibitions
+  ) {
     return { notFound: true };
   }
 

--- a/catalogue/webapp/pages/search/events.tsx
+++ b/catalogue/webapp/pages/search/events.tsx
@@ -64,8 +64,10 @@ export const getServerSideProps: GetServerSideProps<
   const query = context.query;
 
   if (
-    !serverData.toggles.searchPage &&
-    !serverData.toggles.searchPageEventsExhibitions
+    !(
+      serverData.toggles.searchPage &&
+      serverData.toggles.searchPageEventsExhibitions
+    )
   ) {
     return { notFound: true };
   }

--- a/catalogue/webapp/pages/search/exhibitions.tsx
+++ b/catalogue/webapp/pages/search/exhibitions.tsx
@@ -63,7 +63,10 @@ export const getServerSideProps: GetServerSideProps<
   const serverData = await getServerData(context);
   const query = context.query;
 
-  if (!serverData.toggles.searchPage) {
+  if (
+    !serverData.toggles.searchPage &&
+    !serverData.toggles.searchPageEventsExhibitions
+  ) {
     return { notFound: true };
   }
 

--- a/catalogue/webapp/pages/search/exhibitions.tsx
+++ b/catalogue/webapp/pages/search/exhibitions.tsx
@@ -64,8 +64,10 @@ export const getServerSideProps: GetServerSideProps<
   const query = context.query;
 
   if (
-    !serverData.toggles.searchPage &&
-    !serverData.toggles.searchPageEventsExhibitions
+    !(
+      serverData.toggles.searchPage &&
+      serverData.toggles.searchPageEventsExhibitions
+    )
   ) {
     return { notFound: true };
   }

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -66,8 +66,7 @@ const toggles = {
       id: 'searchPageEventsExhibitions',
       title: 'Search page: Events & Exhibitions',
       initialValue: false,
-      description:
-        "Events & Exhibitions will not go out at the same time as the rest of the new Search page, therefore we're adding another level of toggle within it to release them separately",
+      description: 'Include events and exhibitions on the new search page',
     },
   ] as const,
   tests: [] as ABTest[],

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -62,6 +62,13 @@ const toggles = {
       description:
         'New search page to help develop new components and functionalities',
     },
+    {
+      id: 'searchPageEventsExhibitions',
+      title: 'Search page: Events & Exhibitions',
+      initialValue: false,
+      description:
+        "Events & Exhibitions will not go out at the same time as the rest of the new Search page, therefore we're adding another level of toggle within it to release them separately",
+    },
   ] as const,
   tests: [] as ABTest[],
 };


### PR DESCRIPTION
## Who is this for?
Devs

## What is it doing for them?
Allows us to keep working on the Events & Exhibitions sections for the new Search hub, separately from the other sections that will go out first.

Also add them to the SubNavigation item if the toggle is enabled.

Closes #8917 