### PR TITLE
Search: Stories pagination

### DIFF
--- a/catalogue/webapp/pages/search/stories.tsx
+++ b/catalogue/webapp/pages/search/stories.tsx
@@ -13,7 +13,10 @@ import { font } from '@weco/common/utils/classnames';
 import { removeUndefinedProps } from '@weco/common/utils/json';
 import { AppErrorProps } from '@weco/common/services/app';
 import { getServerData } from '@weco/common/server-data';
-import { getStories } from '@weco/catalogue/services/prismic/fetch/articles';
+import {
+  getStories,
+  getStoriesByPage,
+} from '@weco/catalogue/services/prismic/fetch/articles';
 import { Story } from '@weco/catalogue/services/prismic/types/story';
 import {
   PrismicApiError,
@@ -168,7 +171,6 @@ export const SearchPage: NextPageWithLayout<Props> = ({
 
       {storyResponseList.totalResults > 0 && (
         <div className="container">
-          {/* TODO make pagination - cursor based pagination with graphql query */}
           <PaginationWrapper>
             {storyResponseList.totalResults > 0 && (
               <TotalResultsCopy>{`${storyResponseList.totalResults} result${
@@ -254,7 +256,6 @@ export const SearchPage: NextPageWithLayout<Props> = ({
             })}
           </main>
 
-          {/* TODO make pagination work... */}
           <BottomPaginationWrapper>
             <SearchPagination totalPages={storyResponseList.totalPages} />
           </BottomPaginationWrapper>
@@ -292,7 +293,8 @@ export const getServerSideProps: GetServerSideProps<
       props: defaultProps,
     };
   }
-
+  const pageQuery = Boolean(query.page);
+  console.log(pageQuery, 'do we have a page in the query');
   const storyResponseList: PrismicResultsList<Story> | PrismicApiError =
     await getStories({
       query,

--- a/catalogue/webapp/pages/search/stories.tsx
+++ b/catalogue/webapp/pages/search/stories.tsx
@@ -290,8 +290,7 @@ export const getServerSideProps: GetServerSideProps<
       props: defaultProps,
     };
   }
-  const pageQuery = Boolean(query.page);
-  console.log(pageQuery, 'do we have a page in the query');
+
   const storyResponseList: PrismicResultsList<Story> | PrismicApiError =
     await getStories({
       query,

--- a/catalogue/webapp/pages/search/stories.tsx
+++ b/catalogue/webapp/pages/search/stories.tsx
@@ -13,10 +13,7 @@ import { font } from '@weco/common/utils/classnames';
 import { removeUndefinedProps } from '@weco/common/utils/json';
 import { AppErrorProps } from '@weco/common/services/app';
 import { getServerData } from '@weco/common/server-data';
-import {
-  getStories,
-  getStoriesByPage,
-} from '@weco/catalogue/services/prismic/fetch/articles';
+import { getStories } from '@weco/catalogue/services/prismic/fetch/articles';
 import { Story } from '@weco/catalogue/services/prismic/types/story';
 import {
   PrismicApiError,

--- a/catalogue/webapp/services/prismic/fetch/articles.ts
+++ b/catalogue/webapp/services/prismic/fetch/articles.ts
@@ -105,14 +105,13 @@ export async function getStories({
         };
       });
       // We now get the first and nth cursor for first and nth page based on pageSize
-      const cursorsPaginated = (cursors, pagesize) =>
+      const cursorsPaginated = (cursors, pageSize) =>
         cursors
-          .filter(
-            (cursor, index) => index % pagesize === pagesize - 1 || index === 0
-          )
-          .map((e, index) => {
-            return { cursor: e.cursor, page: index + 1 };
-          });
+          .filter((cursor, cursorIndex) => {
+            const position = cursorIndex + 1;
+            return position % pageSize === 0;
+          })
+          .map((e, index) => ({ cursor: e.cursor, page: index + 1 }));
 
       return cursorsPaginated(getStoriesCursors, pageSize);
     };

--- a/catalogue/webapp/services/prismic/fetch/articles.ts
+++ b/catalogue/webapp/services/prismic/fetch/articles.ts
@@ -2,6 +2,74 @@ import { Story } from '../types/story';
 import { PrismicResultsList, PrismicApiError, Query } from '../types';
 import { prismicGraphQLClient, prismicApiError } from '.';
 import { transformPrismicResponse } from '../transformers';
+import { gql } from "graphql-request";
+
+export const storiesQuery = gql`
+  query getAllStories(
+    $queryString: String
+    $sortBy: SortArticlesy
+    $pageSize: Int
+    $cursor: String
+  ) {
+    allArticless(
+      fulltext: $queryString
+      sortBy: $sortBy
+      first: $pageSize
+      after: $cursor
+    ) {
+      totalCount
+      pageInfo {
+        hasNextPage
+        startCursor
+        endCursor
+        hasPreviousPage
+      }
+      edges {
+        cursor
+        node {
+          title
+          _meta {
+            id
+            firstPublicationDate
+          }
+          format {
+            __typename
+          }
+          format {
+            ... on ArticleFormats {
+              _meta {
+                id
+              }
+            }
+          }
+          contributors {
+            contributor {
+              ... on People {
+                name
+              }
+            }
+          }
+          body {
+            ... on ArticlesBodyStandfirst {
+              primary {
+                text
+              }
+            }
+          }
+          promo {
+            ... on ArticlesPromoEditorialimage {
+              primary {
+                image
+                link
+                caption
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
 
 export type PrismicQueryProps = {
   query: Query;

--- a/catalogue/webapp/services/prismic/fetch/articles.ts
+++ b/catalogue/webapp/services/prismic/fetch/articles.ts
@@ -88,14 +88,8 @@ export async function getStories({
   pageSize,
 }: PrismicQueryProps): Promise<PrismicResultsList<Story> | PrismicApiError> {
   try {
-    console.log('<<<<<<< WE ARE IN GET STORIES');
-
-    // TODO: clear up the types in the return objects
-    // TODO: clear up the types in the frontend page
-    // TODO: leave notes on why we are doing the cursor stuff
-
     // Create a map of all cursors to their respective page number by pageSize
-    // A cursor is a pointer to a node within the return list of results from a graphql query
+    // A cursor is a pointer to a node within the returned list of results from a graphql query
     const fetchAllCursors = async (
       type: string,
       query: Query,
@@ -119,7 +113,6 @@ export async function getStories({
             return { cursor: e.cursor, page: index + 1 };
           });
 
-      console.log(cursorsPaginated, 'cursorsPaginated');
       return cursorsPaginated(getStoriesCursors, pageSize);
     };
 
@@ -149,7 +142,6 @@ export async function getStories({
         pageSize,
         cursor
       );
-      console.log(query, 'what is the query in articles ts');
 
       const { allArticless } = await res;
       const { edges } = allArticless;
@@ -167,10 +159,9 @@ export async function getStories({
     };
 
     // To work with existing pagination component we paginate with query.page
-    // If there is no query.page, we will use the page number to get the relevant cursor
+    // If we have query.page, we will use current page number to get the relevant cursor
     if (query.page) {
       const cursor = await currentPageCursor('articles', query, pageSize);
-      console.log(cursor, 'do we have a cursor for this page');
       return fetchStories('articles', query, pageSize, cursor);
     }
     return fetchStories('articles', query, pageSize);

--- a/catalogue/webapp/services/prismic/fetch/articles.ts
+++ b/catalogue/webapp/services/prismic/fetch/articles.ts
@@ -9,25 +9,102 @@ export type PrismicQueryProps = {
   type?: string;
 };
 
+// This function will:
+// 1. Call the prismicGraphQLClient function with queryString from query and get nth number of stories by pageSize
+// Then, it will transform the above response into a list of stories in the format of ResultList
+// 2. If the query contains a page number, it will query the prismicGraphQLClient function with the cursor
+// and get the next nth number of stories by pageSize
 export async function getStories({
   query,
   pageSize,
 }: PrismicQueryProps): Promise<PrismicResultsList<Story> | PrismicApiError> {
   try {
-    const res = await prismicGraphQLClient('articles', query, pageSize);
-    const { allArticless } = await res;
-    const { edges } = allArticless;
-    const stories = await transformPrismicResponse(['articles'], edges);
+    console.log('<<<<<<< WE ARE IN GET STORIES');
 
-    return {
-      type: 'ResultList',
-      totalResults: allArticless.totalCount,
-      totalPages: Math.ceil(allArticless.totalCount / pageSize),
-      results: stories,
-      pageSize: pageSize,
-      prevPage: null,
-      nextPage: null,
+    // TODO: clear up the types in the return objects
+    // TODO: clear up the types in the frontend page
+    // TODO: leave notes on why we are doing the cursor stuff
+
+    // Create a map of all cursors to their respective page number by pageSize
+    // A cursor is a pointer to a node within the return list of results from a graphql query
+    const fetchAllCursors = async (
+      type: string,
+      query: Query,
+      pageSize: number
+    ) => {
+      const results = await prismicGraphQLClient(type, query, 100);
+      const { allArticless } = await results;
+      const { edges } = allArticless;
+      const getStoriesCursors = edges.map(edge => {
+        return {
+          cursor: edge.cursor,
+        };
+      });
+      // We now get the first and nth cursor for first and nth page based on pageSize
+      const cursorsPaginated = (cursors, pagesize) =>
+        cursors
+          .filter(
+            (cursor, index) => index % pagesize === pagesize - 1 || index === 0
+          )
+          .map((e, index) => {
+            return { cursor: e.cursor, page: index + 1 };
+          });
+
+      console.log(cursorsPaginated, 'cursorsPaginated');
+      return cursorsPaginated(getStoriesCursors, pageSize);
     };
+
+    // Get the relevant cursor for the page number
+    const currentPageCursor = async (
+      type: string,
+      query: Query,
+      pageSize: number
+    ) => {
+      const allCursors = await fetchAllCursors('articles', query, pageSize);
+      const currentPage = query.page ? query.page : 1;
+      const getCurrentPageCursor = allCursors.find(
+        cursor => cursor.page === parseFloat(String(currentPage))
+      );
+      return getCurrentPageCursor?.cursor;
+    };
+
+    const fetchStories = async (
+      type: string,
+      query: Query,
+      pageSize: number,
+      cursor?: string
+    ) => {
+      const res = await prismicGraphQLClient(
+        'articles',
+        query,
+        pageSize,
+        cursor
+      );
+      console.log(query, 'what is the query in articles ts');
+
+      const { allArticless } = await res;
+      const { edges } = allArticless;
+
+      const stories = await transformPrismicResponse(['articles'], edges);
+      return {
+        type: 'ResultList',
+        totalResults: allArticless.totalCount,
+        totalPages: Math.ceil(allArticless.totalCount / pageSize),
+        results: stories,
+        pageSize: pageSize,
+        prevPage: null,
+        nextPage: null,
+      };
+    };
+
+    // To work with existing pagination component we paginate with query.page
+    // If there is no query.page, we will use the page number to get the relevant cursor
+    if (query.page) {
+      const cursor = await currentPageCursor('articles', query, pageSize);
+      console.log(cursor, 'do we have a cursor for this page');
+      return fetchStories('articles', query, pageSize, cursor);
+    }
+    return fetchStories('articles', query, pageSize);
   } catch (error) {
     console.log(error);
     return prismicApiError();

--- a/catalogue/webapp/services/prismic/fetch/articles.ts
+++ b/catalogue/webapp/services/prismic/fetch/articles.ts
@@ -120,7 +120,7 @@ export async function getStories({
       const allCursors = await fetchAllCursors('articles', query, pageSize);
       const currentPage = query.page ? query.page : 1;
       const getCurrentPageCursor = allCursors.find(
-        cursor => cursor.page === parseFloat(String(currentPage))
+        cursor => cursor.page === currentPage
       );
       return getCurrentPageCursor?.cursor;
     };

--- a/catalogue/webapp/services/prismic/fetch/articles.ts
+++ b/catalogue/webapp/services/prismic/fetch/articles.ts
@@ -2,7 +2,7 @@ import { Story } from '../types/story';
 import { PrismicResultsList, PrismicApiError, Query } from '../types';
 import { prismicGraphQLClient, prismicApiError } from '.';
 import { transformPrismicResponse } from '../transformers';
-import { gql } from "graphql-request";
+import { gql } from 'graphql-request';
 
 export const storiesQuery = gql`
   query getAllStories(

--- a/catalogue/webapp/services/prismic/fetch/articles.ts
+++ b/catalogue/webapp/services/prismic/fetch/articles.ts
@@ -79,11 +79,6 @@ export type PrismicQueryProps = {
   type?: string;
 };
 
-// This function will:
-// 1. Call the prismicGraphQLClient function with queryString from query and get nth number of stories by pageSize
-// Then, it will transform the above response into a list of stories in the format of ResultList
-// 2. If the query contains a page number, it will query the prismicGraphQLClient function with the cursor
-// and get the next nth number of stories by pageSize
 export async function getStories({
   query,
   pageSize,
@@ -130,6 +125,10 @@ export async function getStories({
       return getCurrentPageCursor?.cursor;
     };
 
+    // Call the prismicGraphQLClient function with queryString from query and get nth number of stories by pageSize
+    // Then, it will transform the above response into a list of stories in the format of ResultList
+    // If the query contains a page number, it will query the prismicGraphQLClient function with the cursor
+    // and get the next nth number of stories by pageSize
     const fetchStories = async (
       type: string,
       query: Query,

--- a/catalogue/webapp/services/prismic/fetch/articles.ts
+++ b/catalogue/webapp/services/prismic/fetch/articles.ts
@@ -100,13 +100,16 @@ export async function getStories({
         };
       });
       // We now get the first and nth cursor for first and nth page based on pageSize
-      const cursorsPaginated = (cursors, pageSize) =>
+      const cursorsPaginated = (cursors, pageSize: number) =>
         cursors
           .filter((cursor, cursorIndex) => {
-            const position = cursorIndex + 1;
+            const position = cursorIndex - 1;
             return position % pageSize === 0;
           })
-          .map((e, index) => ({ cursor: e.cursor, page: index + 1 }));
+          .map((e, index) => ({
+            cursor: e.cursor,
+            page: (index + 1) as number,
+          }));
 
       return cursorsPaginated(getStoriesCursors, pageSize);
     };
@@ -119,8 +122,9 @@ export async function getStories({
     ) => {
       const allCursors = await fetchAllCursors('articles', query, pageSize);
       const currentPage = query.page ? query.page : 1;
+      console.log(typeof currentPage, typeof query.page);
       const getCurrentPageCursor = allCursors.find(
-        cursor => cursor.page === currentPage
+        cursor => cursor.page === parseFloat(String(currentPage))
       );
       return getCurrentPageCursor?.cursor;
     };
@@ -130,7 +134,7 @@ export async function getStories({
     // If the query contains a page number, it will query the prismicGraphQLClient function with the cursor
     // and get the next nth number of stories by pageSize
     const fetchStories = async (
-      // We use type here because we have a GraphQL query for each type, so we can use the type to determine which query to use
+      // We use type here because we have a GraphQL query for each type, so we can use the type to determine which query to us
       type: string,
       query: Query,
       pageSize: number,

--- a/catalogue/webapp/services/prismic/fetch/articles.ts
+++ b/catalogue/webapp/services/prismic/fetch/articles.ts
@@ -7,6 +7,7 @@ import { gql } from 'graphql-request';
 export const storiesQuery = gql`
   query getAllStories(
     $queryString: String
+    # I have changed the below type to work with the error message I get from Prismic graphql when I don't use it
     $sortBy: SortArticlesy
     $pageSize: Int
     $cursor: String

--- a/catalogue/webapp/services/prismic/fetch/articles.ts
+++ b/catalogue/webapp/services/prismic/fetch/articles.ts
@@ -130,6 +130,7 @@ export async function getStories({
     // If the query contains a page number, it will query the prismicGraphQLClient function with the cursor
     // and get the next nth number of stories by pageSize
     const fetchStories = async (
+      // We use type here because we have a GraphQL query for each type, so we can use the type to determine which query to use
       type: string,
       query: Query,
       pageSize: number,

--- a/catalogue/webapp/services/prismic/fetch/articles.ts
+++ b/catalogue/webapp/services/prismic/fetch/articles.ts
@@ -73,7 +73,7 @@ export async function getStories({
       query: Query,
       pageSize: number,
       cursor?: string
-    ) => {
+    ): Promise<PrismicResultsList<Story> | PrismicApiError> => {
       const res = await prismicGraphQLClient(
         'articles',
         query,

--- a/catalogue/webapp/services/prismic/fetch/articles.ts
+++ b/catalogue/webapp/services/prismic/fetch/articles.ts
@@ -123,7 +123,7 @@ export async function getStories({
     ) => {
       const allCursors = await fetchAllCursors('articles', query, pageSize);
       const currentPage = query.page ? query.page : 1;
-      console.log(typeof currentPage, typeof query.page);
+
       const getCurrentPageCursor = allCursors.find(
         cursor => cursor.page === parseFloat(String(currentPage))
       );
@@ -136,6 +136,7 @@ export async function getStories({
     // and get the next nth number of stories by pageSize
     const fetchStories = async (
       // We use type here because we have a GraphQL query for each type, so we can use the type to determine which query to us
+      // Type is used on events and exhibitions too, when they are updated/refactored we can remove 'type' from all three
       type: string,
       query: Query,
       pageSize: number,

--- a/catalogue/webapp/services/prismic/fetch/articles.ts
+++ b/catalogue/webapp/services/prismic/fetch/articles.ts
@@ -7,7 +7,8 @@ import { gql } from 'graphql-request';
 export const storiesQuery = gql`
   query getAllStories(
     $queryString: String
-    # I have changed the below type to work with the error message I get from Prismic graphql when I don't use it
+    # The below $sortBy type needs to be SortArticlesy, rather than String, or you will get the following error from Prismic GraphQl:
+    #  ClientError: Variable '$sortBy' of type 'String' used in position expecting type 'SortArticlesy'
     $sortBy: SortArticlesy
     $pageSize: Int
     $cursor: String

--- a/catalogue/webapp/services/prismic/fetch/events.ts
+++ b/catalogue/webapp/services/prismic/fetch/events.ts
@@ -7,7 +7,8 @@ import { gql } from 'graphql-request';
 export const eventsQuery = gql`
   query getAllEvents(
     $queryString: String
-    $sortBy: SortArticlesy
+    # I have changed the below type to work with the error message I get from Prismic graphql when I don't use it
+    $sortBy: SortEventsy
     $pageSize: Int
     $cursor: String
   ) {

--- a/catalogue/webapp/services/prismic/fetch/events.ts
+++ b/catalogue/webapp/services/prismic/fetch/events.ts
@@ -7,8 +7,9 @@ import { gql } from 'graphql-request';
 export const eventsQuery = gql`
   query getAllEvents(
     $queryString: String
-    # I have changed the below type to work with the error message I get from Prismic graphql when I don't use it
-    $sortBy: SortEventsy
+    # The below $sortBy type needs to be SortEventsy, rather than String, or you will get the following error from Prismic GraphQl:
+    #  ClientError: Variable '$sortBy' of type 'String' used in position expecting type 'SortEventsy'
+    $sortBy: String
     $pageSize: Int
     $cursor: String
   ) {

--- a/catalogue/webapp/services/prismic/fetch/events.ts
+++ b/catalogue/webapp/services/prismic/fetch/events.ts
@@ -2,6 +2,74 @@ import { PrismicResultsList, PrismicApiError, Query } from '../types';
 import { Event } from '../types/event';
 import { prismicGraphQLClient, prismicApiError } from '.';
 import { transformPrismicResponse } from '../transformers';
+import { gql } from "graphql-request";
+
+export const eventsQuery = gql`
+  query getAllEvents(
+    $queryString: String
+    $sortBy: SortArticlesy
+    $pageSize: Int
+    $cursor: String
+  ) {
+    allEventss(
+      fulltext: $queryString
+      sortBy: $sortBy
+      first: $pageSize
+      after: $cursor
+    ) {
+      totalCount
+      pageInfo {
+        hasNextPage
+        startCursor
+        endCursor
+        hasPreviousPage
+      }
+      edges {
+        cursor
+        node {
+          title
+          _meta {
+            id
+            firstPublicationDate
+          }
+          format {
+            __typename
+          }
+          format {
+            ... on EventFormats {
+              _meta {
+                id
+              }
+            }
+          }
+          contributors {
+            contributor {
+              ... on People {
+                name
+              }
+            }
+          }
+          body {
+            ... on EventsBodyStandfirst {
+              primary {
+                text
+              }
+            }
+          }
+          promo {
+            ... on EventsPromoEditorialimage {
+              primary {
+                image
+                link
+                caption
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
 
 export type PrismicQueryProps = {
   query: Query;

--- a/catalogue/webapp/services/prismic/fetch/events.ts
+++ b/catalogue/webapp/services/prismic/fetch/events.ts
@@ -2,7 +2,7 @@ import { PrismicResultsList, PrismicApiError, Query } from '../types';
 import { Event } from '../types/event';
 import { prismicGraphQLClient, prismicApiError } from '.';
 import { transformPrismicResponse } from '../transformers';
-import { gql } from "graphql-request";
+import { gql } from 'graphql-request';
 
 export const eventsQuery = gql`
   query getAllEvents(

--- a/catalogue/webapp/services/prismic/fetch/events.ts
+++ b/catalogue/webapp/services/prismic/fetch/events.ts
@@ -9,7 +9,7 @@ export const eventsQuery = gql`
     $queryString: String
     # The below $sortBy type needs to be SortEventsy, rather than String, or you will get the following error from Prismic GraphQl:
     #  ClientError: Variable '$sortBy' of type 'String' used in position expecting type 'SortEventsy'
-    $sortBy: String
+    $sortBy: SortEventsy
     $pageSize: Int
     $cursor: String
   ) {

--- a/catalogue/webapp/services/prismic/fetch/exhibitions.ts
+++ b/catalogue/webapp/services/prismic/fetch/exhibitions.ts
@@ -2,7 +2,7 @@ import { PrismicResultsList, PrismicApiError, Query } from '../types';
 import { Exhibition } from '../types/exhibition';
 import { prismicGraphQLClient, prismicApiError } from '.';
 import { transformPrismicResponse } from '../transformers';
-import { gql } from "graphql-request";
+import { gql } from 'graphql-request';
 
 export const exhibitionsQuery = gql`
   query getAllExhibitions(

--- a/catalogue/webapp/services/prismic/fetch/exhibitions.ts
+++ b/catalogue/webapp/services/prismic/fetch/exhibitions.ts
@@ -7,7 +7,8 @@ import { gql } from 'graphql-request';
 export const exhibitionsQuery = gql`
   query getAllExhibitions(
     $queryString: String
-    # I have changed the below type to work with the error message I get from Prismic graphql when I don't use it
+    # The below $sortBy type needs to be SortExhibitionsy, rather than String, or you will get the following error from Prismic GraphQl:
+    #   ClientError: Variable '$sortBy' of type 'String' used in position expecting type 'SortExhibitionsy'
     $sortBy: SortExhibitionsy
     $pageSize: Int
     $cursor: String

--- a/catalogue/webapp/services/prismic/fetch/exhibitions.ts
+++ b/catalogue/webapp/services/prismic/fetch/exhibitions.ts
@@ -7,11 +7,12 @@ import { gql } from 'graphql-request';
 export const exhibitionsQuery = gql`
   query getAllExhibitions(
     $queryString: String
-    $sortBy: SortArticlesy
+    # I have changed the below type to work with the error message I get from Prismic graphql when I don't use it
+    $sortBy: SortExhibitionsy
     $pageSize: Int
     $cursor: String
   ) {
-    allExhibitions(
+    allExhibitionss(
       fulltext: $queryString
       sortBy: $sortBy
       first: $pageSize

--- a/catalogue/webapp/services/prismic/fetch/exhibitions.ts
+++ b/catalogue/webapp/services/prismic/fetch/exhibitions.ts
@@ -2,6 +2,74 @@ import { PrismicResultsList, PrismicApiError, Query } from '../types';
 import { Exhibition } from '../types/exhibition';
 import { prismicGraphQLClient, prismicApiError } from '.';
 import { transformPrismicResponse } from '../transformers';
+import { gql } from "graphql-request";
+
+export const exhibitionsQuery = gql`
+  query getAllExhibitions(
+    $queryString: String
+    $sortBy: SortArticlesy
+    $pageSize: Int
+    $cursor: String
+  ) {
+    allExhibitions(
+      fulltext: $queryString
+      sortBy: $sortBy
+      first: $pageSize
+      after: $cursor
+    ) {
+      totalCount
+      pageInfo {
+        hasNextPage
+        startCursor
+        endCursor
+        hasPreviousPage
+      }
+      edges {
+        cursor
+        node {
+          title
+          _meta {
+            id
+            firstPublicationDate
+          }
+          format {
+            __typename
+          }
+          format {
+            ... on ExhibitionFormats {
+              _meta {
+                id
+              }
+            }
+          }
+          contributors {
+            contributor {
+              ... on People {
+                name
+              }
+            }
+          }
+          body {
+            ... on ExhibitionsBodyStandfirst {
+              primary {
+                text
+              }
+            }
+          }
+          promo {
+            ... on ExhibitionsPromoEditorialimage {
+              primary {
+                image
+                link
+                caption
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
 
 export type PrismicQueryProps = {
   query: Query;

--- a/catalogue/webapp/services/prismic/fetch/index.ts
+++ b/catalogue/webapp/services/prismic/fetch/index.ts
@@ -1,24 +1,14 @@
 import * as prismic from '@prismicio/client';
 import fetch from 'node-fetch';
-import { gql, GraphQLClient } from 'graphql-request';
-
+import { GraphQLClient } from 'graphql-request';
 import { PrismicApiError } from '../types';
-import { unCamelCase, capitalize } from '@weco/common/utils/grammar';
+import { unCamelCase } from '@weco/common/utils/grammar';
 import { ArticleFormatIds } from '@weco/common/data/content-format-ids';
 import { Query } from '@weco/catalogue/services/prismic/types';
 import { getPrismicSortValue } from '@weco/catalogue/utils/search';
 import { storiesQuery } from './articles';
 import { eventsQuery } from './events';
 import { exhibitionsQuery } from './exhibitions';
-
-export const typesToPrismicGraphQLSchemaTypes = {
-  // types to graphql query schema types,
-  events: 'allEventss',
-  exhibitions: 'allExhibitionss',
-  articles: 'allArticless',
-  series: 'allSeriess',
-  webcomics: 'allWebcomicss',
-};
 
 export const articleIdToLabel = (id: string): string => {
   const label = Object.keys(ArticleFormatIds).find(
@@ -28,147 +18,6 @@ export const articleIdToLabel = (id: string): string => {
   // TODO: Essay seems to indicate articles that are part of a series
   // More work to do here to make this label Serial with 'Part of' in the title
   return formattedLabel === 'Essay' ? 'Article' : formattedLabel;
-};
-
-export const prismicGraphQLQuery = (
-  type: string,
-  query: Query,
-  pageSize: number
-): string => {
-  // const { query: queryString, sort, sortOrder } = query;
-  // const sortBy = getPrismicSortValue({ sort, sortOrder });
-
-  // const query = gql`
-  //   query getMovie($title: String!) {
-  //     Movie(title: $title) {
-  //       releaseDate
-  //       actors {
-  //         name
-  //       }
-  //     }
-  //   }
-  // `
-  //
-  // const variables = {
-  //   title: 'Inception',
-  // }
-  // return gql`
-  //   query {
-  //     ${
-  //       typesToPrismicGraphQLSchemaTypes[type]
-  //       }(fulltext: "${queryString}" sortBy: ${sortBy} first: ${pageSize}) {
-  //     totalCount
-  //     pageInfo {
-  //       hasNextPage
-  //       startCursor
-  //       endCursor
-  //       hasPreviousPage
-  //     }
-  //       edges {
-  //         cursor
-  //         node {
-  //           title
-  //           _meta { id, firstPublicationDate }
-  //           format {
-  //             __typename
-  //           }
-  //           format {
-  //             ...on ArticleFormats {
-  //               _meta {
-  //                 id
-  //               }
-  //             }
-  //           }
-  //           contributors {
-  //             contributor {
-  //               ...on People {
-  //                 name
-  //               }
-  //             }
-  //           }
-  //           body {
-  //             ...on ${capitalize(type)}BodyStandfirst {
-  //               primary {
-  //                 text
-  //               }
-  //             }
-  //           }
-  //           promo {
-  //             ...on ${capitalize(type)}PromoEditorialimage {
-  //               primary {
-  //                 image
-  //                 link
-  //                 caption
-  //               }
-  //             }
-  //           }
-  //         }
-  //       }
-  //     }
-  //   }
-  // `;
-  const { query: queryString, sort, sortOrder } = query;
-  console.log(queryString, 'do we have this');
-  const sortBy = getPrismicSortValue({ sort, sortOrder });
-  const variables = { queryString: queryString?.toString(), sortBy, pageSize };
-  console.log(query, 'what is the query at this point');
-
-  return gql`
-    query {
-      ${
-        typesToPrismicGraphQLSchemaTypes[type]
-        // }(fulltext: "${queryString}" sortBy: ${sortBy} first: ${pageSize}) {
-      }(fulltext: $queryString sortBy: $sortBy first: $pageSize after: $cursor) {
-    totalCount
-    pageInfo {
-    hasNextPage
-    startCursor
-    endCursor
-    hasPreviousPage
-    }
-    edges {
-    cursor
-    node {
-    title
-    _meta { id, firstPublicationDate }
-    format {
-    __typename
-    }
-    format {
-    ...on ArticleFormats {
-    _meta {
-    id
-    }
-    }
-    }
-    contributors {
-    contributor {
-    ...on People {
-    name
-    }
-    }
-    }
-    body {
-    ...on ${capitalize(type)}BodyStandfirst {
-    primary {
-    text
-    }
-    }
-    }
-    promo {
-    ...on ${capitalize(type)}PromoEditorialimage {
-    primary {
-    image
-    link
-    caption
-    }
-    }
-    }
-    }
-    }
-    }
-    }
-  `;
 };
 
 const endpoint = prismic.getRepositoryEndpoint('wellcomecollection');
@@ -204,11 +53,10 @@ export async function prismicGraphQLClient(
     exhibitions: exhibitionsQuery,
   };
 
-  const graphQLQuery = (type: string) => {
-    console.log(type, 'what is the type');
+  const graphQLQueryByType = (type: string) => {
     return graphQLQueries[type];
   };
-  return graphqlClient.request(graphQLQuery(type), variables);
+  return graphqlClient.request(graphQLQueryByType(type), variables);
 }
 
 export const prismicApiError = (): PrismicApiError => ({

--- a/catalogue/webapp/services/prismic/fetch/index.ts
+++ b/catalogue/webapp/services/prismic/fetch/index.ts
@@ -51,10 +51,7 @@ export async function prismicGraphQLClient(
     exhibitions: exhibitionsQuery,
   };
 
-  const graphQLQueryByType = (type: string) => {
-    return graphQLQueries[type];
-  };
-  return graphqlClient.request(graphQLQueryByType(type), variables);
+  return graphqlClient.request(graphQLQueries[type], variables);
 }
 
 export const prismicApiError = (): PrismicApiError => ({

--- a/catalogue/webapp/services/prismic/fetch/index.ts
+++ b/catalogue/webapp/services/prismic/fetch/index.ts
@@ -23,8 +23,6 @@ export const articleIdToLabel = (id: string): string => {
 const endpoint = prismic.getRepositoryEndpoint('wellcomecollection');
 const client = prismic.createClient(endpoint, { fetch });
 
-// We need the below function to query with the variables like currentCursor
-// Once we can do that we can update where cursor is and pass through query
 export async function prismicGraphQLClient(
   type: string,
   query: Query,

--- a/catalogue/webapp/services/prismic/types/index.ts
+++ b/catalogue/webapp/services/prismic/types/index.ts
@@ -68,8 +68,8 @@ export type PrismicResultsList<Result> = {
   totalPages: number;
   results: Result[];
   pageSize: number;
-  prevPage: null;
-  nextPage: null;
+  prevPage: string | null;
+  nextPage: string | null;
 };
 
 export type PrismicNode = {

--- a/catalogue/webapp/services/prismic/types/index.ts
+++ b/catalogue/webapp/services/prismic/types/index.ts
@@ -68,8 +68,8 @@ export type PrismicResultsList<Result> = {
   totalPages: number;
   results: Result[];
   pageSize: number;
-  prevPage: string | null;
-  nextPage: string | null;
+  prevPage: null;
+  nextPage: null;
 };
 
 export type PrismicNode = {
@@ -120,4 +120,5 @@ export type Query = {
   query?: string;
   sortOrder?: string;
   sort?: string;
+  page?: number;
 };


### PR DESCRIPTION
## Who is this for?

Anyone searching for stories at `search/stories`.

This covers https://github.com/wellcomecollection/wellcomecollection.org/issues/8819. It also covers https://github.com/wellcomecollection/wellcomecollection.org/issues/8860 because I have made Prismic GraphQL query results work with the `SearchPagination` component, meaning we don't need to create another pagination component to work with Prismic results.

## What is it doing for them?
Users can paginate through `search/stories` results.

## Context for approach on cursor based pagination via GraphQL
Works and Images API responses both allow us to use previous and next pages to ensure that the `SearchPagination` component can be used to paginate through pages using the query parameters in the url e.g `https://wellcomecollection.org/search/stories?query=cats&page=2`. 

The Prismic GraphQL API response format is different, we don't get a url for the previous or next page. 
Prismic GraphQL results contain nodes that each will have a cursor `String` value. A node represents a story/event/exhibition result. I have taken the `pageSize` value (how many results we want in each page) and mapped the relevant starting cursor to the relevant page number. If the query params contain a page, we grab the corresponding cursor and pass this to the GraphQL query and get the next `pageSize` (6) results.  

The aim is to move Prismic data into our API, when we do this, we can make use of previous and next page urls from our API response, and not have to think too much about GraphQL cursor pagination again, phew. 
