### PR TITLE
Look at the onlineIsFullyBooked field for "Fully booked"

### DIFF
--- a/content/webapp/pages/event.tsx
+++ b/content/webapp/pages/event.tsx
@@ -144,7 +144,7 @@ function DateList(event: Event) {
 
               {isDayPast(eventTime.range.endDateTime)
                 ? EventStatus({ text: 'Past', color: 'neutral.500' })
-                : eventTime.isFullyBooked
+                : eventTime.isFullyBooked && eventTime.onlineIsFullyBooked
                 ? EventStatus({ text: 'Full', color: 'validation.red' })
                 : null}
             </TimeWrapper>

--- a/content/webapp/services/prismic/events.test.ts
+++ b/content/webapp/services/prismic/events.test.ts
@@ -130,6 +130,24 @@ describe('upcomingDatesFullyBooked', () => {
     expect(result).toEqual(false);
   });
 
+  it('an event is not fully booked if online tickets are sold out but in-person tickets are available', () => {
+    const event = {
+      id: 'event-id',
+      times: [
+        {
+          range: {
+            startDateTime: new Date(3000, 3, 27, 15, 30, 0),
+            endDateTime: new Date(3000, 3, 27, 16, 30, 0),
+          },
+          isFullyBooked: false,
+          onlineIsFullyBooked: true,
+        },
+      ],
+    };
+    const result = upcomingDatesFullyBooked(event);
+    expect(result).toEqual(false);
+  });
+
   it('an event is not fully booked if there are no future dates', () => {
     const event = {
       id: 'event-id',

--- a/content/webapp/services/prismic/events.test.ts
+++ b/content/webapp/services/prismic/events.test.ts
@@ -60,7 +60,7 @@ describe('orderEventsByNextAvailableDate', () => {
 });
 
 describe('upcomingDatesFullyBooked', () => {
-  it('returns true if future dates are not available to book', () => {
+  it('an event is fully booked if future times are fully booked', () => {
     const event = {
       id: 'event-id',
       times: [
@@ -70,6 +70,7 @@ describe('upcomingDatesFullyBooked', () => {
             endDateTime: new Date(2000, 3, 25, 16, 30, 0),
           },
           isFullyBooked: false,
+          onlineIsFullyBooked: false,
         },
         {
           range: {
@@ -77,6 +78,7 @@ describe('upcomingDatesFullyBooked', () => {
             endDateTime: new Date(3000, 3, 27, 16, 30, 0),
           },
           isFullyBooked: true,
+          onlineIsFullyBooked: true,
         },
       ],
     };
@@ -84,7 +86,7 @@ describe('upcomingDatesFullyBooked', () => {
     expect(result).toEqual(true);
   });
 
-  it('returns false if future dates are available to book', () => {
+  it('an event is not fully booked if in-person tickets are still available', () => {
     const event = {
       id: 'event-id',
       times: [
@@ -94,6 +96,7 @@ describe('upcomingDatesFullyBooked', () => {
             endDateTime: new Date(2000, 3, 25, 16, 30, 0),
           },
           isFullyBooked: true,
+          onlineIsFullyBooked: true,
         },
         {
           range: {
@@ -101,6 +104,7 @@ describe('upcomingDatesFullyBooked', () => {
             endDateTime: new Date(3000, 3, 27, 16, 30, 0),
           },
           isFullyBooked: false,
+          onlineIsFullyBooked: true,
         },
       ],
     };
@@ -108,18 +112,28 @@ describe('upcomingDatesFullyBooked', () => {
     expect(result).toEqual(false);
   });
 
-  it('returns false if there are no future dates', () => {
+  it('an event is not fully booked if in-person tickets are sold out but online tickets are available', () => {
     const event = {
       id: 'event-id',
       times: [
         {
           range: {
-            startDateTime: new Date(2000, 3, 25, 15, 30, 0),
-            endDateTime: new Date(2000, 3, 25, 16, 30, 0),
+            startDateTime: new Date(3000, 3, 27, 15, 30, 0),
+            endDateTime: new Date(3000, 3, 27, 16, 30, 0),
           },
           isFullyBooked: true,
+          onlineIsFullyBooked: false,
         },
       ],
+    };
+    const result = upcomingDatesFullyBooked(event);
+    expect(result).toEqual(false);
+  });
+
+  it('an event is not fully booked if there are no future dates', () => {
+    const event = {
+      id: 'event-id',
+      times: [],
     };
     const result = upcomingDatesFullyBooked(event);
     expect(result).toEqual(false);

--- a/content/webapp/services/prismic/events.ts
+++ b/content/webapp/services/prismic/events.ts
@@ -209,9 +209,10 @@ export function upcomingDatesFullyBooked(event: HasTimes): boolean {
       ? event.times.filter(({ range }) => !isPast(range.endDateTime))
       : [];
   if (upcoming.length > 0) {
-    return upcoming.every(({ isFullyBooked }) => {
-      return isFullyBooked;
-    });
+    return upcoming.every(
+      ({ isFullyBooked, onlineIsFullyBooked }) =>
+        isFullyBooked && onlineIsFullyBooked
+    );
   } else {
     return false;
   }


### PR DESCRIPTION
An event time has two toggles to decide whether it's fully booked: one for in-person, and one for online.  We were only looking at the in-person toggle when deciding whether to show the "Fully booked" banner on the event; we should look at both.

I've had a quick look for other uses of `isFullyBooked`, but I can't see any other obvious instances of this mistake.

## Who is this for?

People looking at our events.

## What is it doing for them?

Not deterring them from an event they could still attend online.

See https://wellcome.slack.com/archives/C8X9YKM5X/p1669717891523899