### PR TITLE
Include a title in the IframeAuthMessage for accessibility

### DIFF
--- a/catalogue/webapp/components/IIIFClickthrough/IIIFClickthrough.tsx
+++ b/catalogue/webapp/components/IIIFClickthrough/IIIFClickthrough.tsx
@@ -48,6 +48,7 @@ const IIIFClickthrough: FunctionComponent<Props> = ({
       {tokenService && origin && (
         <IframeAuthMessage
           id={iframeId}
+          title="IIIF Authentication iframe for cross-domain messaging"
           src={`${tokenService['@id']}?messageId=1&origin=${origin}`}
         />
       )}


### PR DESCRIPTION
☝️ 

Should fix `error: Iframe element requires a non-empty title attribute that identifies the frame.`

<img width="686" alt="image" src="https://user-images.githubusercontent.com/1394592/205041265-bcf5e76b-a804-40a7-a4c2-d1ad05b39f93.png">
