### PR TITLE
Rename trackEvent functions to clarify where it's going

### DIFF
--- a/catalogue/webapp/components/ArchiveTree/ArchiveTree.tsx
+++ b/catalogue/webapp/components/ArchiveTree/ArchiveTree.tsx
@@ -20,7 +20,7 @@ import Modal from '@weco/common/views/components/Modal/Modal';
 import ButtonSolid from '@weco/common/views/components/ButtonSolid/ButtonSolid';
 import IsArchiveContext from '../IsArchiveContext/IsArchiveContext';
 import { chevron, tree } from '@weco/common/icons';
-import { trackEvent } from '@weco/common/utils/ga';
+import { trackGaEvent } from '@weco/common/utils/ga';
 
 const TreeContainer = styled.div`
   border-right: 1px solid ${props => props.theme.color('warmNeutral.400')};
@@ -648,7 +648,7 @@ const ListItem: FunctionComponent<ListItemProps> = ({
           <TreeControl
             highlightCondition={highlightCondition}
             onClick={() => {
-              trackEvent({
+              trackGaEvent({
                 category: 'ArchiveTree',
                 action: 'Chevron clicked',
                 label: item.work.id,
@@ -676,7 +676,7 @@ const ListItem: FunctionComponent<ListItemProps> = ({
             onClick={event => {
               event.stopPropagation();
               setShowArchiveTree(false);
-              trackEvent({
+              trackGaEvent({
                 category: 'ArchiveTree',
                 action: 'Link clicked',
                 label: item.work.id,

--- a/catalogue/webapp/components/CopyUrl/CopyUrl.tsx
+++ b/catalogue/webapp/components/CopyUrl/CopyUrl.tsx
@@ -5,7 +5,7 @@ import {
   ReactElement,
   FunctionComponent,
 } from 'react';
-import { trackEvent } from '@weco/common/utils/ga';
+import { trackGaEvent } from '@weco/common/utils/ga';
 import TextInput from '@weco/common/views/components/TextInput/TextInput';
 import Space from '@weco/common/views/components/styled/Space';
 import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
@@ -56,7 +56,7 @@ const CopyUrl: FunctionComponent<Props> = ({
     buttonRef.current && buttonRef.current.focus();
     textarea.remove();
 
-    trackEvent({
+    trackGaEvent({
       category: 'CopyUrl',
       action: 'copy url to clipboard',
       label: id,

--- a/catalogue/webapp/components/IIIFClickthrough/IIIFClickthrough.tsx
+++ b/catalogue/webapp/components/IIIFClickthrough/IIIFClickthrough.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent, ReactNode, useEffect, useState } from 'react';
 import { AuthClickThroughServiceWithPossibleServiceArray } from '../../../webapp/types/manifest';
 import { AuthAccessTokenService } from '@iiif/presentation-3';
 import { font } from '@weco/common/utils/classnames';
-import { trackEvent } from '@weco/common/utils/ga';
+import { trackGaEvent } from '@weco/common/utils/ga';
 import ButtonSolid from '@weco/common/views/components/ButtonSolid/ButtonSolid';
 import Space from '@weco/common/views/components/styled/Space';
 import styled from 'styled-components';
@@ -68,7 +68,7 @@ const IIIFClickthrough: FunctionComponent<Props> = ({
               <ButtonSolid
                 text="Show the content"
                 clickHandler={() => {
-                  trackEvent({
+                  trackGaEvent({
                     category: 'ButtonSolidLink',
                     action: 'follow link "Show the content"',
                     label: `workId: ${trackingId}`,

--- a/catalogue/webapp/components/IIIFViewer/NoScriptViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/NoScriptViewer.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import IIIFViewerImage from './IIIFViewerImage';
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
 import { imageSizes } from '@weco/common/utils/image-sizes';
-import { trackEvent } from '@weco/common/utils/ga';
+import { trackGaEvent } from '@weco/common/utils/ga';
 import Space from '@weco/common/views/components/styled/Space';
 import Rotator from '@weco/common/views/components/styled/Rotator';
 import Paginator, {
@@ -105,7 +105,7 @@ export const PaginatorButtons = (
                 text="Previous page"
                 tabIndex={isTabbable ? 0 : -1}
                 clickHandler={() => {
-                  trackEvent({
+                  trackGaEvent({
                     category: 'Control',
                     action: 'clicked work viewer previous page link',
                     label: `${workId} | page: ${currentPage}`,
@@ -127,7 +127,7 @@ export const PaginatorButtons = (
                 text="Next page"
                 tabIndex={isTabbable ? 0 : -1}
                 clickHandler={() => {
-                  trackEvent({
+                  trackGaEvent({
                     category: 'Control',
                     action: 'clicked work viewer next page link',
                     label: `${workId} | page: ${currentPage}`,

--- a/catalogue/webapp/components/IIIFViewer/ViewerBottomBar.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerBottomBar.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { trackEvent } from '@weco/common/utils/ga';
+import { trackGaEvent } from '@weco/common/utils/ga';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import Space from '@weco/common/views/components/styled/Space';
 import { FunctionComponent, useContext, RefObject } from 'react';
@@ -70,7 +70,7 @@ const ViewerBottomBar: FunctionComponent<Props> = ({ viewerRef }: Props) => {
                   icon: singlePage,
                   clickHandler() {
                     setGridVisible(false);
-                    trackEvent({
+                    trackGaEvent({
                       category: 'Control',
                       action: 'clicked work viewer Detail view button',
                       label: work.id,
@@ -83,7 +83,7 @@ const ViewerBottomBar: FunctionComponent<Props> = ({ viewerRef }: Props) => {
                   icon: gridView,
                   clickHandler() {
                     setGridVisible(true);
-                    trackEvent({
+                    trackGaEvent({
                       category: 'Control',
                       action: 'clicked work viewer Grid view button',
                       label: work.id,

--- a/catalogue/webapp/components/IIIFViewer/ViewerTopBar.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerTopBar.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { font } from '@weco/common/utils/classnames';
-import { trackEvent } from '@weco/common/utils/ga';
+import { trackGaEvent } from '@weco/common/utils/ga';
 import Download from '@weco/catalogue/components/Download/Download';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import Space from '@weco/common/views/components/styled/Space';
@@ -222,7 +222,7 @@ const ViewerTopBar: FunctionComponent<Props> = ({ viewerRef }: Props) => {
                 isDark
                 onClick={() => {
                   setIsDesktopSidebarActive(!isDesktopSidebarActive);
-                  trackEvent({
+                  trackGaEvent({
                     category: 'Control',
                     action: 'Toggle item viewer sidebar',
                     label: `${work.id}`,
@@ -264,7 +264,7 @@ const ViewerTopBar: FunctionComponent<Props> = ({ viewerRef }: Props) => {
                   icon: singlePage,
                   clickHandler() {
                     setGridVisible(false);
-                    trackEvent({
+                    trackGaEvent({
                       category: 'Control',
                       action: 'clicked work viewer Detail view button',
                       label: `${work.id}`,
@@ -277,7 +277,7 @@ const ViewerTopBar: FunctionComponent<Props> = ({ viewerRef }: Props) => {
                   icon: gridView,
                   clickHandler() {
                     setGridVisible(true);
-                    trackEvent({
+                    trackGaEvent({
                       category: 'Control',
                       action: 'clicked work viewer Grid view button',
                       label: `${work.id}`,

--- a/catalogue/webapp/components/IIIFViewer/ZoomedImage.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ZoomedImage.tsx
@@ -7,7 +7,7 @@ import {
   FunctionComponent,
 } from 'react';
 import styled from 'styled-components';
-import { trackEvent } from '@weco/common/utils/ga';
+import { trackGaEvent } from '@weco/common/utils/ga';
 import Control from '@weco/common/views/components/Buttons/Control/Control';
 import Space from '@weco/common/views/components/styled/Space';
 import ItemViewerContext from '../ItemViewerContext/ItemViewerContext';
@@ -113,7 +113,7 @@ const ZoomedImage: FunctionComponent = () => {
     if (viewer.isOpen()) {
       doZoomIn(viewer);
     }
-    trackEvent({
+    trackGaEvent({
       category: 'Control',
       action: 'zoom in ImageViewer',
       label: 'zoomedImage',
@@ -125,7 +125,7 @@ const ZoomedImage: FunctionComponent = () => {
     if (viewer.isOpen()) {
       doZoomOut(viewer);
     }
-    trackEvent({
+    trackGaEvent({
       category: 'Control',
       action: 'zoom out ImageViewer',
       label: 'zoomedImage',
@@ -135,7 +135,7 @@ const ZoomedImage: FunctionComponent = () => {
   function handleRotate(viewer) {
     if (!viewer) return;
     viewer.viewport.setRotation(viewer.viewport.getRotation() + 90);
-    trackEvent({
+    trackGaEvent({
       category: 'Control',
       action: 'rotate ImageViewer',
       label: 'zoomedImage',

--- a/catalogue/webapp/components/ImageCard/ImageCard.tsx
+++ b/catalogue/webapp/components/ImageCard/ImageCard.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent, SyntheticEvent, useContext } from 'react';
 import NextLink from 'next/link';
 import styled from 'styled-components';
 
-import { trackEvent } from '@weco/common/utils/ga';
+import { trackGaEvent } from '@weco/common/utils/ga';
 import { ImageType } from '@weco/common/model/image';
 
 import IIIFImage from '../IIIFImage/IIIFImage';
@@ -43,7 +43,7 @@ const ImageCard: FunctionComponent<Props> = ({
     <NextLink {...imageLink({ id, workId }, 'images_search_result')} passHref>
       <StyledLink
         onClick={event => {
-          trackEvent({
+          trackGaEvent({
             category: 'ImageCard',
             action: 'open ExpandedImage modal',
             label: id,

--- a/catalogue/webapp/components/ItemRequestModal/RequestDialog.tsx
+++ b/catalogue/webapp/components/ItemRequestModal/RequestDialog.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent, FormEvent, useState } from 'react';
 import { useAvailableDates } from './useAvailableDates';
 import { isRequestableDate } from '../../utils/dates';
-import { trackEvent } from '@weco/common/utils/ga';
+import { trackGaEvent } from '@weco/common/utils/ga';
 import { allowedRequests } from '@weco/common/values/requests';
 import { font } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
@@ -89,7 +89,7 @@ const RequestDialog: FunctionComponent<RequestDialogProps> = ({
         excludedDays: availableDates.closedDays,
       })
     ) {
-      trackEvent({
+      trackGaEvent({
         category: 'requesting',
         action: 'confirm_request',
         label: `/works/${work.id}`,

--- a/catalogue/webapp/components/LibraryMembersBar/LibraryMembersBar.tsx
+++ b/catalogue/webapp/components/LibraryMembersBar/LibraryMembersBar.tsx
@@ -6,7 +6,7 @@ import { useUser } from '@weco/common/views/components/UserProvider/UserProvider
 import { useLoginURLWithReturnToCurrent } from '@weco/common/utils/useLoginURLWithReturnToCurrent';
 import { font } from '@weco/common/utils/classnames';
 import { memberCard } from '@weco/common/icons';
-import { trackEvent } from '@weco/common/utils/ga';
+import { trackGaEvent } from '@weco/common/utils/ga';
 import { useToggles } from '@weco/common/server-data/Context';
 import { requestingDisabled } from '@weco/common/data/microcopy';
 
@@ -38,7 +38,7 @@ const SignInLink: FunctionComponent = () => {
         href={loginURL}
         className={font('intr', 5)}
         onClick={() => {
-          trackEvent({
+          trackGaEvent({
             category: 'library_account',
             action: 'login',
             label: window.location.pathname,

--- a/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
+++ b/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
@@ -23,7 +23,7 @@ import { itemIsRequestable } from '../../utils/requesting';
 import Placeholder from '@weco/common/views/components/Placeholder/Placeholder';
 import ButtonSolid from '@weco/common/views/components/ButtonSolid/ButtonSolid';
 import { sierraAccessMethodtoNewLabel } from '@weco/common/data/microcopy';
-import { trackEvent } from '@weco/common/utils/ga';
+import { trackGaEvent } from '@weco/common/utils/ga';
 import { useToggles } from '@weco/common/server-data/Context';
 import { themeValues } from '@weco/common/views/themes/config';
 
@@ -188,7 +188,7 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
           ref={requestButtonRef}
           text="Request item"
           clickHandler={() => {
-            trackEvent({
+            trackGaEvent({
               category: 'requesting',
               action: 'initiate_request',
               label: `/works/${work.id}`,

--- a/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
+++ b/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
@@ -10,7 +10,7 @@ import { pageDescriptions } from '@weco/common/data/microcopy';
 import { formDataAsUrlQuery } from '@weco/common/utils/forms';
 import SubNavigation from '@weco/common/views/components/SubNavigation/SubNavigation';
 import convertUrlToString from '@weco/common/utils/convert-url-to-string';
-import { trackEvent } from '@weco/common/utils/ga';
+import { trackGaEvent } from '@weco/common/utils/ga';
 import { removeEmptyProps } from '@weco/common/utils/json';
 import { getUrlQueryFromSortValue } from '@weco/catalogue/utils/search';
 import { capitalize } from '@weco/common/utils/grammar';
@@ -146,7 +146,7 @@ const SearchLayout: FunctionComponent<{ hasEventsExhibitions: boolean }> = ({
           onSubmit={event => {
             event.preventDefault();
 
-            trackEvent({
+            trackGaEvent({
               category: 'SearchForm',
               action: 'submit search',
               label: router.query.query as string,

--- a/catalogue/webapp/components/VideoPlayer/VideoPlayer.tsx
+++ b/catalogue/webapp/components/VideoPlayer/VideoPlayer.tsx
@@ -1,5 +1,5 @@
 import Router from 'next/router';
-import { trackEvent } from '@weco/common/utils/ga';
+import { trackGaEvent } from '@weco/common/utils/ga';
 import { FunctionComponent, useEffect, useState } from 'react';
 import useInterval from '@weco/common/hooks/useInterval';
 import MediaAnnotations from '../MediaAnnotations/MediaAnnotations';
@@ -18,7 +18,7 @@ const VideoPlayer: FunctionComponent<Props> = ({
   const [isPlaying, setIsPlaying] = useState(false);
 
   function trackViewingTime() {
-    trackEvent({
+    trackGaEvent({
       category: 'Engagement',
       action: 'Amount of media played',
       value: secondsPlayed,
@@ -34,7 +34,7 @@ const VideoPlayer: FunctionComponent<Props> = ({
     try {
       window.addEventListener('beforeunload', trackViewingTime);
     } catch (error) {
-      trackEvent({
+      trackGaEvent({
         category: 'Engagement',
         action: 'unable to track media playing time',
         nonInteraction: true,
@@ -61,7 +61,7 @@ const VideoPlayer: FunctionComponent<Props> = ({
       <video
         onPlay={() => {
           setIsPlaying(true);
-          trackEvent({
+          trackGaEvent({
             category: 'Video',
             action: 'play video',
             label: video.id,

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -28,7 +28,7 @@ import AudioList from '../AudioList/AudioList';
 import ButtonSolidLink from '@weco/common/views/components/ButtonSolidLink/ButtonSolidLink';
 import ExplanatoryText from './ExplanatoryText';
 import { toLink as itemLink } from '@weco/common/views/components/ItemLink/ItemLink';
-import { trackEvent } from '@weco/common/utils/ga';
+import { trackGaEvent } from '@weco/common/utils/ga';
 import PhysicalItems from '../PhysicalItems/PhysicalItems';
 import Layout12 from '@weco/common/views/components/Layout12/Layout12';
 import { DigitalLocation, Work } from '@weco/common/model/catalogue';
@@ -372,7 +372,7 @@ const WorkDetails: FunctionComponent<Props> = ({ work }: Props) => {
                           <NextLink href={itemUrl.href} as={itemUrl.as}>
                             <a
                               onClick={() =>
-                                trackEvent({
+                                trackGaEvent({
                                   category: 'WorkDetails',
                                   action: 'follow image link',
                                   label: work.id,

--- a/catalogue/webapp/pages/item.tsx
+++ b/catalogue/webapp/pages/item.tsx
@@ -17,7 +17,7 @@ import Space, {
 import Modal from '@weco/common/views/components/Modal/Modal';
 import ButtonSolid from '@weco/common/views/components/ButtonSolid/ButtonSolid';
 import { font } from '@weco/common/utils/classnames';
-import { trackEvent } from '@weco/common/utils/ga';
+import { trackGaEvent } from '@weco/common/utils/ga';
 import { removeUndefinedProps } from '@weco/common/utils/json';
 import { appError, AppErrorProps } from '@weco/common/services/app';
 import { Pageview } from '@weco/common/services/conversion/track';
@@ -270,7 +270,7 @@ const ItemPage: NextPage<Props> = ({
               <ButtonSolid
                 text="Show the content"
                 clickHandler={() => {
-                  trackEvent({
+                  trackGaEvent({
                     category: 'ButtonSolidLink',
                     action: 'follow link "Show the content"',
                     label: `workId: ${workId}`,
@@ -289,7 +289,7 @@ const ItemPage: NextPage<Props> = ({
           <WorkLink id={workId} source="item_auth_modal_back_to_work_link">
             <a
               onClick={() => {
-                trackEvent({
+                trackGaEvent({
                   category: 'ButtonSolidLink',
                   action: 'follow link to work page',
                   label: `workId: ${workId}`,

--- a/common/services/conversion/track.ts
+++ b/common/services/conversion/track.ts
@@ -93,7 +93,7 @@ function trackPageview(
 }
 
 type EventName = 'download';
-function trackEvent(
+function trackSegmentEvent(
   name: EventName,
   properties: { [key: string]: unknown }
 ): void {
@@ -132,4 +132,4 @@ function track(conversion: Conversion) {
   });
 }
 
-export { trackPageview, trackEvent };
+export { trackPageview, trackSegmentEvent };

--- a/common/utils/ga.ts
+++ b/common/utils/ga.ts
@@ -1,7 +1,7 @@
 import ReactGA, { EventArgs as GaEvent } from 'react-ga';
 
 // TODO this wrapper function is redundant but pervasive; consider getting rid of it
-export function trackEvent(gaEvent: GaEvent): void {
+export function trackGaEvent(gaEvent: GaEvent): void {
   ReactGA.event(gaEvent);
 }
 

--- a/common/views/components/AudioPlayer/AudioPlayer.tsx
+++ b/common/views/components/AudioPlayer/AudioPlayer.tsx
@@ -18,7 +18,7 @@ import {
 import Space from '@weco/common/views/components/styled/Space';
 import { font } from '@weco/common/utils/classnames';
 import styled from 'styled-components';
-import { trackEvent } from '@weco/common/utils/ga';
+import { trackGaEvent } from '@weco/common/utils/ga';
 import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
 
 const VolumeWrapper = styled.div`
@@ -136,7 +136,7 @@ const PlayRate: FunctionComponent<PlayRateProps> = ({ audioPlayer, id }) => {
   }, [audioPlaybackRate]);
 
   function updatePlaybackRate(speed: number) {
-    trackEvent({
+    trackGaEvent({
       category: 'Audio',
       action: `set speed to ${speed}x`,
       label: id,
@@ -209,7 +209,7 @@ const Volume: FunctionComponent<VolumeProps> = ({ audioPlayer, id }) => {
   };
 
   const onVolumeButtonClick = () => {
-    trackEvent({
+    trackGaEvent({
       category: 'Audio',
       action: `${isMuted ? 'unmute' : 'mute'} audio`,
       label: id,
@@ -347,14 +347,14 @@ export const AudioPlayer: FunctionComponent<AudioPlayerProps> = ({
     setIsPlaying(!prevValue);
 
     if (prevValue) {
-      trackEvent({
+      trackGaEvent({
         category: 'Audio',
         action: 'pause audio',
         label: id,
       });
       audioPlayerRef.current.pause();
     } else {
-      trackEvent({
+      trackGaEvent({
         category: 'Audio',
         action: 'play audio',
         label: id,

--- a/common/views/components/BackToResults/BackToResults.tsx
+++ b/common/views/components/BackToResults/BackToResults.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent, useContext } from 'react';
 import NextLink from 'next/link';
 import { font } from '../../../utils/classnames';
-import { trackEvent } from '../../../utils/ga';
+import { trackGaEvent } from '../../../utils/ga';
 import SearchContext from '../SearchContext/SearchContext';
 
 const BackToResults: FunctionComponent = () => {
@@ -13,7 +13,7 @@ const BackToResults: FunctionComponent = () => {
     <NextLink {...link}>
       <a
         onClick={() => {
-          trackEvent({
+          trackGaEvent({
             category: 'BackToResults',
             action: 'follow link',
             label: `${query} | page: ${page || 1}`,

--- a/common/views/components/BorderlessClickable/BorderlessClickable.tsx
+++ b/common/views/components/BorderlessClickable/BorderlessClickable.tsx
@@ -13,7 +13,7 @@ import {
 } from '../ButtonSolid/ButtonSolid';
 import Icon from '../Icon/Icon';
 import { classNames, font } from '../../../utils/classnames';
-import { GaEvent, trackEvent } from '../../../utils/ga';
+import { GaEvent, trackGaEvent } from '../../../utils/ga';
 import { IconSvg } from '@weco/common/icons';
 
 type ClickableElement = 'a' | 'button';
@@ -151,7 +151,7 @@ const ButtonOuter: FunctionComponent<BorderlessButtonProps> = (
 ) => {
   function onClick(event) {
     clickHandler && clickHandler(event);
-    trackingEvent && trackEvent(trackingEvent);
+    trackingEvent && trackGaEvent(trackingEvent);
   }
 
   return (

--- a/common/views/components/ButtonSolid/ButtonSolid.tsx
+++ b/common/views/components/ButtonSolid/ButtonSolid.tsx
@@ -7,7 +7,7 @@ import {
 } from 'react';
 import styled from 'styled-components';
 import { classNames, font } from '../../../utils/classnames';
-import { trackEvent, GaEvent } from '../../../utils/ga';
+import { trackGaEvent, GaEvent } from '../../../utils/ga';
 import Icon from '../Icon/Icon';
 import Space from '../styled/Space';
 import { IconSvg } from '@weco/common/icons';
@@ -222,7 +222,7 @@ const Button: FunctionComponent<ButtonSolidProps> = (
 ) => {
   function handleClick(event) {
     clickHandler && clickHandler(event);
-    trackingEvent && trackEvent(trackingEvent);
+    trackingEvent && trackGaEvent(trackingEvent);
   }
 
   return (

--- a/common/views/components/ButtonSolidLink/ButtonSolidLink.tsx
+++ b/common/views/components/ButtonSolidLink/ButtonSolidLink.tsx
@@ -7,7 +7,7 @@ import {
   SolidButton,
   ButtonSolidBaseProps,
 } from '../ButtonSolid/ButtonSolid';
-import { trackEvent } from '@weco/common/utils/ga';
+import { trackGaEvent } from '@weco/common/utils/ga';
 import Icon from '../Icon/Icon';
 import ConditionalWrapper from '../ConditionalWrapper/ConditionalWrapper';
 
@@ -38,7 +38,7 @@ const ButtonSolidLink: FunctionComponent<ButtonSolidLinkProps> = ({
 }: ButtonSolidLinkProps): ReactElement<ButtonSolidLinkProps> => {
   function handleClick(event) {
     clickHandler && clickHandler(event);
-    trackingEvent && trackEvent(trackingEvent);
+    trackingEvent && trackGaEvent(trackingEvent);
   }
 
   const isNextLink = typeof link === 'object';

--- a/common/views/components/Buttons/Control/Control.tsx
+++ b/common/views/components/Buttons/Control/Control.tsx
@@ -2,7 +2,7 @@ import { forwardRef, FunctionComponent } from 'react';
 import NextLink from 'next/link';
 import { LinkProps } from '../../../../model/link-props';
 import Icon from '../../Icon/Icon';
-import { GaEvent, trackEvent } from '../../../../utils/ga';
+import { GaEvent, trackGaEvent } from '../../../../utils/ga';
 import styled from 'styled-components';
 import { IconSvg } from '@weco/common/icons';
 
@@ -222,7 +222,7 @@ const BaseControl: FunctionComponent<Props> = (
 
   function handleClick(event) {
     if (trackingEvent) {
-      trackEvent(trackingEvent);
+      trackGaEvent(trackingEvent);
     }
 
     if (clickHandler) {

--- a/common/views/components/ClearSearch/ClearSearch.tsx
+++ b/common/views/components/ClearSearch/ClearSearch.tsx
@@ -1,5 +1,5 @@
 import { FunctionComponent, RefObject, Dispatch, SetStateAction } from 'react';
-import { trackEvent, GaEvent } from '../../../utils/ga';
+import { trackGaEvent, GaEvent } from '../../../utils/ga';
 import Icon from '../Icon/Icon';
 import { clear } from '@weco/common/icons';
 import styled from 'styled-components';
@@ -31,7 +31,7 @@ const ClearSearch: FunctionComponent<Props> = ({
     <Button
       style={right ? { right: `${right}px` } : undefined}
       onClick={() => {
-        gaEvent && trackEvent(gaEvent);
+        gaEvent && trackGaEvent(gaEvent);
         setValue('');
         inputRef?.current?.focus();
       }}

--- a/common/views/components/CookieNotice/CookieNotice.tsx
+++ b/common/views/components/CookieNotice/CookieNotice.tsx
@@ -7,7 +7,7 @@ import Icon from '@weco/common/views/components/Icon/Icon';
 import Space from '@weco/common/views/components/styled/Space';
 import Layout12 from '@weco/common/views/components/Layout12/Layout12';
 import { clear, cookies as cookiesIcon } from '@weco/common/icons';
-import { trackEvent } from '@weco/common/utils/ga';
+import { trackGaEvent } from '@weco/common/utils/ga';
 import { addDays, today } from '../../../utils/dates';
 
 const CookieNoticeStyle = styled.div.attrs({
@@ -45,7 +45,7 @@ const CookieNotice: FunctionComponent<Props> = ({ source }) => {
       expires: addDays(today(), 30),
     });
 
-    trackEvent({
+    trackGaEvent({
       category: 'CookieNotice',
       action: 'click close cookie notice button',
       label: source,

--- a/common/views/components/DownloadLink/DownloadLink.tsx
+++ b/common/views/components/DownloadLink/DownloadLink.tsx
@@ -1,10 +1,10 @@
-import { trackEvent as trackGaEvent, GaEvent } from '@weco/common/utils/ga';
+import { trackGaEvent, GaEvent } from '@weco/common/utils/ga';
 import styled from 'styled-components';
 import { font } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import Space from '@weco/common/views/components/styled/Space';
 import { FunctionComponent, ReactNode } from 'react';
-import { trackEvent } from '@weco/common/services/conversion/track';
+import { trackSegmentEvent } from '@weco/common/services/conversion/track';
 import { download } from '@weco/common/icons';
 
 const DownloadLinkStyle = styled.a.attrs({
@@ -91,7 +91,7 @@ const DownloadLink: FunctionComponent<Props> = ({
       rel="noopener noreferrer"
       href={href}
       onClick={() => {
-        trackEvent('download', { width, mimeType, tags: trackingTags });
+        trackSegmentEvent('download', { width, mimeType, tags: trackingTags });
         trackingEvent && trackGaEvent(trackingEvent);
       }}
     >

--- a/common/views/components/Header/DesktopSignIn.tsx
+++ b/common/views/components/Header/DesktopSignIn.tsx
@@ -6,7 +6,7 @@ import DropdownButton from '../DropdownButton/DropdownButton';
 import Space from '../styled/Space';
 import { BorderlessLink } from '../BorderlessClickable/BorderlessClickable';
 import { user as userIcon } from '../../../icons';
-import { trackEvent } from '../../../utils/ga';
+import { trackGaEvent } from '../../../utils/ga';
 
 type AccountAProps = {
   last?: true;
@@ -43,7 +43,7 @@ const DesktopSignIn: FunctionComponent = () => {
               text={<span className={font('intr', 6)}>Library sign in</span>}
               href="/account/api/auth/login"
               onClick={() => {
-                trackEvent({
+                trackGaEvent({
                   category: 'library_account',
                   action: 'login',
                   label: window.location.pathname,
@@ -88,7 +88,7 @@ const DesktopSignIn: FunctionComponent = () => {
               <AccountA
                 as="a"
                 onClick={() => {
-                  trackEvent({
+                  trackGaEvent({
                     category: 'library_account',
                     action: 'view',
                     label: window.location.pathname,

--- a/common/views/components/Header/MobileSignIn.tsx
+++ b/common/views/components/Header/MobileSignIn.tsx
@@ -5,7 +5,7 @@ import Space from '../styled/Space';
 import Icon from '../Icon/Icon';
 import { useUser } from '../UserProvider/UserProvider';
 import { user as userIcon } from '@weco/common/icons';
-import { trackEvent } from '@weco/common/utils/ga';
+import { trackGaEvent } from '@weco/common/utils/ga';
 
 const StyledComponent = styled.div.attrs({
   className: font('intr', 5),
@@ -57,7 +57,7 @@ const MobileSignIn: FunctionComponent = () => {
         <a
           href="/account/api/auth/login"
           onClick={() => {
-            trackEvent({
+            trackGaEvent({
               category: 'library_account',
               action: 'login',
               label: window.location.pathname,
@@ -72,7 +72,7 @@ const MobileSignIn: FunctionComponent = () => {
           <a
             href="/account"
             onClick={() => {
-              trackEvent({
+              trackGaEvent({
                 category: 'library_account',
                 action: 'view',
                 label: window.location.pathname,

--- a/common/views/components/Iframe/Iframe.tsx
+++ b/common/views/components/Iframe/Iframe.tsx
@@ -1,5 +1,5 @@
 import { Component, Fragment, createRef, ReactElement } from 'react';
-import { trackEvent } from '@weco/common/utils/ga';
+import { trackGaEvent } from '@weco/common/utils/ga';
 import PrismicImage from '../PrismicImage/PrismicImage';
 import Control from '@weco/common/views/components/Buttons/Control/Control';
 import ButtonSolid from '@weco/common/views/components/ButtonSolid/ButtonSolid';
@@ -98,7 +98,7 @@ class Iframe extends Component<Props, State> {
 
   toggleIframeDisplay = (): void => {
     if (!this.state.iframeShowing) {
-      trackEvent({
+      trackGaEvent({
         category: 'Iframe',
         action: 'launch iframe',
         label: this.props.src,

--- a/common/views/components/MoreLink/MoreLink.tsx
+++ b/common/views/components/MoreLink/MoreLink.tsx
@@ -1,5 +1,5 @@
 import { FunctionComponent, ReactElement } from 'react';
-import { trackEvent, GaEvent } from '../../../utils/ga';
+import { trackGaEvent, GaEvent } from '../../../utils/ga';
 import ButtonSolidLink from '../ButtonSolidLink/ButtonSolidLink';
 import { arrowSmall } from '@weco/common/icons';
 import { themeValues } from '@weco/common/views/themes/config';
@@ -17,7 +17,7 @@ const MoreLink: FunctionComponent<Props> = ({
 }: Props): ReactElement<Props> => {
   function handleClick() {
     if (trackingEvent) {
-      trackEvent({
+      trackGaEvent({
         category: 'MoreLink',
         action: 'follow link',
         label: `${url} | text: ${name}`,

--- a/common/views/components/NewsletterPromo/NewsletterPromo.tsx
+++ b/common/views/components/NewsletterPromo/NewsletterPromo.tsx
@@ -4,7 +4,7 @@ import { font, classNames } from '../../../utils/classnames';
 import Space from '../styled/Space';
 import styled from 'styled-components';
 import TextInput from '../TextInput/TextInput';
-import { trackEvent } from '../../../utils/ga';
+import { trackGaEvent } from '../../../utils/ga';
 import useValidation from '../../../hooks/useValidation';
 import ButtonSolid from '../ButtonSolid/ButtonSolid';
 import { newsletterAddressBook } from '../../../data/dotdigital';
@@ -136,7 +136,7 @@ const NewsletterPromo: FunctionComponent = () => {
     switch (result) {
       case 'ok':
         setIsSuccess(true);
-        trackEvent({ category: 'NewsletterPromo', action: 'submit email' });
+        trackGaEvent({ category: 'NewsletterPromo', action: 'submit email' });
         break;
       case 'error':
         setIsSubmitError(true);

--- a/common/views/components/PopupDialog/PopupDialog.tsx
+++ b/common/views/components/PopupDialog/PopupDialog.tsx
@@ -13,7 +13,7 @@ import Icon from '../Icon/Icon';
 import Space from '../styled/Space';
 import { font } from '../../../utils/classnames';
 import getFocusableElements from '../../../utils/get-focusable-elements';
-import { trackEvent } from '../../../utils/ga';
+import { trackGaEvent } from '../../../utils/ga';
 import { AppContext } from '../AppContext/AppContext';
 import { PopupDialogPrismicDocument } from '../../../services/prismic/documents';
 import PrismicHtmlBlock from '../PrismicHtmlBlock/PrismicHtmlBlock';
@@ -223,7 +223,7 @@ const PopupDialog: FunctionComponent<Props> = ({ document }: Props) => {
     ) {
       setIsActive(false);
       openDialogRef && openDialogRef.current && openDialogRef.current.focus();
-      trackEvent({
+      trackGaEvent({
         category: 'PopupDialog',
         action: 'close dialog',
       });
@@ -234,7 +234,7 @@ const PopupDialog: FunctionComponent<Props> = ({ document }: Props) => {
     if (event.keyCode === 27 && isActiveRef.current) {
       setIsActive(false);
       openDialogRef && openDialogRef.current && openDialogRef.current.focus();
-      trackEvent({
+      trackGaEvent({
         category: 'PopupDialog',
         action: 'close dialog',
       });
@@ -283,7 +283,7 @@ const PopupDialog: FunctionComponent<Props> = ({ document }: Props) => {
             closeDialogRef.current &&
             closeDialogRef.current.focus();
 
-          trackEvent({
+          trackGaEvent({
             category: 'PopupDialog',
             action: 'open dialog',
           });
@@ -314,7 +314,7 @@ const PopupDialog: FunctionComponent<Props> = ({ document }: Props) => {
               openDialogRef.current &&
               openDialogRef.current.focus();
 
-            trackEvent({
+            trackGaEvent({
               category: 'PopupDialog',
               action: 'close dialog',
             });

--- a/common/views/components/SearchForm/SearchForm.tsx
+++ b/common/views/components/SearchForm/SearchForm.tsx
@@ -11,7 +11,7 @@ import Router from 'next/router';
 import styled from 'styled-components';
 import TextInput from '../TextInput/TextInput';
 import ButtonSolid from '../ButtonSolid/ButtonSolid';
-import { trackEvent } from '../../../utils/ga';
+import { trackGaEvent } from '../../../utils/ga';
 import SearchFilters from '../SearchFilters/SearchFilters';
 import Select from '../Select/Select';
 import Space from '../styled/Space';
@@ -166,7 +166,7 @@ const SearchForm = forwardRef(
         onSubmit={event => {
           event.preventDefault();
 
-          trackEvent({
+          trackGaEvent({
             category: 'SearchForm',
             action: 'submit search',
             label: query,

--- a/common/views/components/SearchTabs/SearchTabs.tsx
+++ b/common/views/components/SearchTabs/SearchTabs.tsx
@@ -6,7 +6,7 @@ import Space from '../styled/Space';
 import { useContext, FunctionComponent, ReactElement, useRef } from 'react';
 import { AppContext } from '../AppContext/AppContext';
 import SearchForm from '@weco/common/views/components/SearchForm/SearchForm';
-import { trackEvent } from '@weco/common/utils/ga';
+import { trackGaEvent } from '@weco/common/utils/ga';
 import NextLink from 'next/link';
 import { removeEmptyProps } from '../../../utils/json';
 import ConditionalWrapper from '../ConditionalWrapper/ConditionalWrapper';
@@ -273,7 +273,7 @@ const SearchTabs: FunctionComponent<Props> = ({
     } else {
       searchWorksFormRef?.current?.submit();
     }
-    trackEvent({
+    trackGaEvent({
       category: 'SearchTabs',
       action: 'click tab',
       label: `${id}`,

--- a/common/views/components/SegmentedControl/SegmentedControl.tsx
+++ b/common/views/components/SegmentedControl/SegmentedControl.tsx
@@ -2,7 +2,7 @@ import { Component, Fragment, ReactElement } from 'react';
 import { chevron, cross } from '@weco/common/icons';
 import { classNames, font } from '../../../utils/classnames';
 import Icon from '../Icon/Icon';
-import { trackEvent } from '../../../utils/ga';
+import { trackGaEvent } from '../../../utils/ga';
 import Space from '../styled/Space';
 import styled from 'styled-components';
 import { isNotUndefined } from '../../../utils/array';
@@ -262,7 +262,7 @@ class SegmentedControl extends Component<Props, State> {
                       const url = e.currentTarget.href;
                       const isHash = url.startsWith('#');
 
-                      trackEvent({
+                      trackGaEvent({
                         category: 'SegmentedControl',
                         action: 'select segment',
                         label: item.text,
@@ -298,7 +298,7 @@ class SegmentedControl extends Component<Props, State> {
                   const url = e.currentTarget.href;
                   const isHash = url.startsWith('#');
 
-                  trackEvent({
+                  trackGaEvent({
                     category: 'SegmentedControl',
                     action: 'select segment',
                     label: item.text,

--- a/common/views/components/TabNav/TabNav.tsx
+++ b/common/views/components/TabNav/TabNav.tsx
@@ -6,7 +6,7 @@ import {
   ReactNode,
   KeyboardEvent,
 } from 'react';
-import { trackEvent } from '@weco/common/utils/ga';
+import { trackGaEvent } from '@weco/common/utils/ga';
 import { Wrapper, TabsContainer, Tab, NavItemInner } from './TabNav.styles';
 import Divider from '@weco/common/views/components/Divider/Divider';
 
@@ -45,7 +45,7 @@ const TabNav: FunctionComponent<Props> = ({
   }
 
   const sendEvent = (id: string) => {
-    trackEvent({
+    trackGaEvent({
       category: 'TabNav',
       action: 'Tab clicked',
       label: id,

--- a/common/views/components/Tasl/Tasl.tsx
+++ b/common/views/components/Tasl/Tasl.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent, ReactElement, useContext, useState } from 'react';
 import { font, classNames } from '../../../utils/classnames';
 import { getPrismicLicenseData } from '../../../utils/licenses';
-import { trackEvent } from '../../../utils/ga';
+import { trackGaEvent } from '../../../utils/ga';
 import { AppContext } from '../../components/AppContext/AppContext';
 import Icon from '../Icon/Icon';
 import Space from '../styled/Space';
@@ -195,7 +195,7 @@ const Tasl: FunctionComponent<Props> = ({
   const [isActive, setIsActive] = useState(false);
   function toggleWithAnalytics(event) {
     event.preventDefault();
-    trackEvent({
+    trackGaEvent({
       category: 'Tasl',
       action: isActive ? 'closed' : 'opened',
       label: title || 'no title',

--- a/content/webapp/components/BannerCard/BannerCard.tsx
+++ b/content/webapp/components/BannerCard/BannerCard.tsx
@@ -1,6 +1,6 @@
 import { font } from '@weco/common/utils/classnames';
 import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
-import { trackEvent } from '@weco/common/utils/ga';
+import { trackGaEvent } from '@weco/common/utils/ga';
 import { FunctionComponent } from 'react';
 import { Season } from '../../types/seasons';
 import styled from 'styled-components';
@@ -129,7 +129,7 @@ const BannerCard: FunctionComponent<Props> = ({
       href={link}
       background={background}
       onClick={() => {
-        trackEvent({
+        trackGaEvent({
           category: 'BannerCard',
           action: 'follow link',
           label: `${title || ''}`,

--- a/content/webapp/components/BookPromo/BookPromo.tsx
+++ b/content/webapp/components/BookPromo/BookPromo.tsx
@@ -1,5 +1,5 @@
 import { font } from '@weco/common/utils/classnames';
-import { trackEvent } from '@weco/common/utils/ga';
+import { trackGaEvent } from '@weco/common/utils/ga';
 import { BookBasic } from '../../types/books';
 import Space from '@weco/common/views/components/styled/Space';
 import styled from 'styled-components';
@@ -33,7 +33,7 @@ const BookPromo: FunctionComponent<Props> = ({ book }) => {
       url={`/books/${id}`}
       className="block promo-link plain-link"
       onClick={() => {
-        trackEvent({
+        trackGaEvent({
           category: 'BookPromo',
           action: 'follow link',
           label: title,

--- a/content/webapp/components/Card/Card.tsx
+++ b/content/webapp/components/Card/Card.tsx
@@ -1,6 +1,6 @@
 import { Card as CardType } from '../../types/card';
 import { font } from '@weco/common/utils/classnames';
-import { trackEvent } from '@weco/common/utils/ga';
+import { trackGaEvent } from '@weco/common/utils/ga';
 import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
 import Space from '@weco/common/views/components/styled/Space';
 import styled from 'styled-components';
@@ -121,7 +121,7 @@ const Card: FunctionComponent<Props> = ({ item }: Props) => {
     <CardOuter
       href={item.link}
       onClick={() => {
-        trackEvent({
+        trackGaEvent({
           category: 'Card',
           action: 'follow link',
           label: `${item.title || ''}`,

--- a/content/webapp/components/CompactCard/CompactCard.test.tsx
+++ b/content/webapp/components/CompactCard/CompactCard.test.tsx
@@ -29,8 +29,8 @@ describe('CompactCard', () => {
     />
   );
 
-  it('should expect ga trackEvent tobe called ', () => {
-    const spyOnTrackEvent = jest.spyOn(ga, 'trackEvent');
+  it('should expect trackGaEvent to be called ', () => {
+    const spyOnTrackEvent = jest.spyOn(ga, 'trackGaEvent');
     componentWithImage.simulate('click');
     expect(spyOnTrackEvent).toBeCalled();
     expect(spyOnTrackEvent).toHaveBeenCalledTimes(1);

--- a/content/webapp/components/CompactCard/CompactCard.tsx
+++ b/content/webapp/components/CompactCard/CompactCard.tsx
@@ -4,7 +4,7 @@ import {
   ReactElement,
   ReactNode,
 } from 'react';
-import { trackEvent } from '@weco/common/utils/ga';
+import { trackGaEvent } from '@weco/common/utils/ga';
 import DateRange from '@weco/common/views/components/DateRange/DateRange';
 import EventDateRange from '../EventDateRange/EventDateRange';
 import StatusIndicator from '../StatusIndicator/StatusIndicator';
@@ -82,7 +82,7 @@ const CompactCard: FunctionComponent<Props> = ({
       OverrideTextWrapper={OverrideTextWrapper}
       OverrideTitleWrapper={OverrideTitleWrapper}
       onClick={(): void => {
-        trackEvent({
+        trackGaEvent({
           category: 'CompactCard',
           action: 'follow link',
           label: title,

--- a/content/webapp/components/EventDatesLink/EventDatesLink.tsx
+++ b/content/webapp/components/EventDatesLink/EventDatesLink.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent } from 'react';
 import { font } from '@weco/common/utils/classnames';
-import { trackEvent } from '@weco/common/utils/ga';
+import { trackGaEvent } from '@weco/common/utils/ga';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import { arrowSmall } from '@weco/common/icons';
 import styled from 'styled-components';
@@ -20,7 +20,7 @@ const EventDatesLink: FunctionComponent<Props> = ({ id }: Props) => (
   <Wrapper
     href="#dates"
     onClick={() => {
-      trackEvent({
+      trackGaEvent({
         category: 'EventDatesLink',
         action: 'follow link',
         label: id,

--- a/content/webapp/components/EventPromo/EventPromo.tsx
+++ b/content/webapp/components/EventPromo/EventPromo.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent } from 'react';
 import { font } from '@weco/common/utils/classnames';
-import { trackEvent } from '@weco/common/utils/ga';
+import { trackGaEvent } from '@weco/common/utils/ga';
 import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
 import Dot from '@weco/common/views/components/Dot/Dot';
 import EventDateRange from '../EventDateRange/EventDateRange';
@@ -72,7 +72,7 @@ const EventPromo: FunctionComponent<Props> = ({
       data-component-state={JSON.stringify({ position: position })}
       href={(event.promo && event.promo.link) || `/events/${event.id}`}
       onClick={() => {
-        trackEvent({
+        trackGaEvent({
           category: 'EventPromo',
           action: 'follow link',
           label: `${event.id} | position: ${position}`,

--- a/content/webapp/components/ExhibitionGuidePromo/ExhibitionGuidePromo.tsx
+++ b/content/webapp/components/ExhibitionGuidePromo/ExhibitionGuidePromo.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent } from 'react';
 import { font } from '@weco/common/utils/classnames';
-import { trackEvent } from '@weco/common/utils/ga';
+import { trackGaEvent } from '@weco/common/utils/ga';
 import { ExhibitionGuideBasic } from '../../types/exhibition-guides';
 import Space from '@weco/common/views/components/styled/Space';
 import { CardOuter, CardBody, CardImageWrapper } from '../Card/Card';
@@ -21,7 +21,7 @@ const ExhibitionGuidePromo: FunctionComponent<Props> = ({
         `/guides/exhibitions/${exhibitionGuide.id}`
       }
       onClick={() => {
-        trackEvent({
+        trackGaEvent({
           category: 'ExhibitionGuide',
           action: 'follow link',
           label: `${exhibitionGuide.id}`,

--- a/content/webapp/components/ExhibitionPromo/ExhibitionPromo.tsx
+++ b/content/webapp/components/ExhibitionPromo/ExhibitionPromo.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent } from 'react';
 import { font } from '@weco/common/utils/classnames';
-import { trackEvent } from '@weco/common/utils/ga';
+import { trackGaEvent } from '@weco/common/utils/ga';
 import StatusIndicator from '../../components/StatusIndicator/StatusIndicator';
 import Space from '@weco/common/views/components/styled/Space';
 import {
@@ -39,7 +39,7 @@ const ExhibitionPromo: FunctionComponent<Props> = ({
       id={exhibition.id}
       href={url}
       onClick={() => {
-        trackEvent({
+        trackGaEvent({
           category: 'ExhibitionPromo',
           action: 'follow link',
           label: `${exhibition.id} | position: ${position}`,

--- a/content/webapp/components/FacilityPromo/FacilityPromo.tsx
+++ b/content/webapp/components/FacilityPromo/FacilityPromo.tsx
@@ -1,5 +1,5 @@
 import { font } from '@weco/common/utils/classnames';
-import { trackEvent } from '@weco/common/utils/ga';
+import { trackGaEvent } from '@weco/common/utils/ga';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImage';
 import Space from '@weco/common/views/components/styled/Space';
@@ -30,7 +30,7 @@ const FacilityPromo: FunctionComponent<FacilityPromoType> = ({
     <CardOuter
       data-component="FacilityPromo"
       onClick={() => {
-        trackEvent({
+        trackGaEvent({
           category: 'FacilityPromo',
           action: 'follow link',
           label: title,

--- a/content/webapp/components/FeaturedCard/FeaturedCard.tsx
+++ b/content/webapp/components/FeaturedCard/FeaturedCard.tsx
@@ -16,7 +16,7 @@ import { grid, font } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
 import StatusIndicator from '../StatusIndicator/StatusIndicator';
-import { trackEvent } from '@weco/common/utils/ga';
+import { trackGaEvent } from '@weco/common/utils/ga';
 import linkResolver from '@weco/common/services/prismic/link-resolver';
 import { Page } from '../../types/pages';
 import { EventSeries } from '../../types/event-series';
@@ -254,7 +254,7 @@ const FeaturedCard: FunctionComponent<Props> = ({
         href={link.url}
         isReversed={isReversed}
         onClick={() => {
-          trackEvent({
+          trackGaEvent({
             category: 'FeaturedCard',
             action: 'follow link',
             label: `${id}`,

--- a/content/webapp/components/GifVideo/GifVideo.tsx
+++ b/content/webapp/components/GifVideo/GifVideo.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent, useState, useEffect, useRef } from 'react';
 import debounce from 'lodash.debounce';
 import throttle from 'lodash.throttle';
 import { font } from '@weco/common/utils/classnames';
-import { trackEvent } from '@weco/common/utils/ga';
+import { trackGaEvent } from '@weco/common/utils/ga';
 import Tasl from '@weco/common/views/components/Tasl/Tasl';
 import Caption from '@weco/common/views/components/Caption/Caption';
 import { Tasl as TaslType } from '@weco/common/model/tasl';
@@ -138,7 +138,7 @@ const GifVideo: FunctionComponent<Props> = ({
         pauseVideo(video);
       }
     }
-    trackEvent({
+    trackGaEvent({
       category: 'GifVideo',
       action: isPlaying ? 'pause video' : 'play video',
       label: videoUrl,

--- a/content/webapp/components/ImageGallery/ImageGallery.tsx
+++ b/content/webapp/components/ImageGallery/ImageGallery.tsx
@@ -9,7 +9,7 @@ import styled from 'styled-components';
 import { font, classNames } from '@weco/common/utils/classnames';
 import { CaptionedImage as CaptionedImageProps } from '@weco/common/model/captioned-image';
 import { repeatingLsBlack } from '@weco/common/utils/backgrounds';
-import { trackEvent } from '@weco/common/utils/ga';
+import { trackGaEvent } from '@weco/common/utils/ga';
 import CaptionedImage from '../CaptionedImage/CaptionedImage';
 import WobblyEdge from '@weco/common/views/components/WobblyEdge/WobblyEdge';
 import ButtonSolid from '@weco/common/views/components/ButtonSolid/ButtonSolid';
@@ -250,7 +250,7 @@ const ImageGallery: FunctionComponent<{ id: number } & Props> = ({
         headingRef.current.scrollIntoView();
       }
 
-      trackEvent({
+      trackGaEvent({
         category: 'Control',
         action: 'close ImageGallery',
         label: id.toString(),
@@ -263,7 +263,7 @@ const ImageGallery: FunctionComponent<{ id: number } & Props> = ({
   }
 
   function showAllImages(isButton?: boolean) {
-    trackEvent({
+    trackGaEvent({
       category: `${isButton ? 'Button' : 'CaptionedImage'}`,
       action: 'open ImageGallery',
       label: id.toString(),

--- a/content/webapp/components/Outro/Outro.tsx
+++ b/content/webapp/components/Outro/Outro.tsx
@@ -1,6 +1,6 @@
 import { MultiContent } from '../../types/multi-content';
 import { isNotUndefined } from '@weco/common/utils/array';
-import { trackEvent } from '@weco/common/utils/ga';
+import { trackGaEvent } from '@weco/common/utils/ga';
 import CompactCard from '../CompactCard/CompactCard';
 import Divider from '@weco/common/views/components/Divider/Divider';
 import Space from '@weco/common/views/components/styled/Space';
@@ -86,7 +86,7 @@ const Outro: FunctionComponent<Props> = ({
               <li
                 key={item.id}
                 onClick={() => {
-                  trackEvent({
+                  trackGaEvent({
                     category: 'Outro',
                     action: `follow ${type} link`,
                     label: item.id,

--- a/content/webapp/components/StoryPromo/StoryPromo.tsx
+++ b/content/webapp/components/StoryPromo/StoryPromo.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent } from 'react';
 import { font } from '@weco/common/utils/classnames';
-import { trackEvent } from '@weco/common/utils/ga';
+import { trackGaEvent } from '@weco/common/utils/ga';
 import PartNumberIndicator from '../PartNumberIndicator/PartNumberIndicator';
 import Space from '@weco/common/views/components/styled/Space';
 import {
@@ -74,7 +74,7 @@ const StoryPromo: FunctionComponent<Props> = ({
   return (
     <CardOuter
       onClick={() => {
-        trackEvent({
+        trackGaEvent({
           category: 'StoryPromo',
           action: 'follow link',
           label: `${article.id} | position: ${position}`,

--- a/content/webapp/components/ZoomedPrismicImage/ZoomedPrismicImage.tsx
+++ b/content/webapp/components/ZoomedPrismicImage/ZoomedPrismicImage.tsx
@@ -12,7 +12,7 @@ import { ImageType } from '@weco/common/model/image';
 import LL from '@weco/common/views/components/styled/LL';
 import Image from 'next/image';
 import { createPrismicLoader } from '@weco/common/views/components/PrismicImage/PrismicImage';
-import { trackEvent } from '@weco/common/utils/ga';
+import { trackGaEvent } from '@weco/common/utils/ga';
 
 const ZoomButton = styled.button`
   position: absolute;
@@ -93,7 +93,7 @@ const ZoomedPrismicImage: FunctionComponent<ZoomedPrismicImageProps> = ({
     const viewportWidth = document.documentElement.clientWidth;
     setImageWidth(viewportWidth);
     setIsZoom(true);
-    trackEvent({
+    trackGaEvent({
       category: 'ZoomedPrismicImage',
       action: 'Zoom in clicked',
       label: image.contentUrl,


### PR DESCRIPTION
## Who is this for?
Devs

## What is it doing for them?
We had two functions called `trackEvent`, one for GA, one for Segment.
Clarifies which `trackEvent` function we're using; as we'll be using `trackSegmentEvent` more moving forward, we need to differentiate it easily from `trackGaEvent`.