### PR TITLE
Make segment tracking allow for different indexes and track VSI

### DIFF
--- a/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
+++ b/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useState, FunctionComponent } from 'react';
+import React, { useEffect, useState, FunctionComponent } from 'react';
 import styled from 'styled-components';
 import NextLink from 'next/link';
 import { font } from '@weco/common/utils/classnames';
 import {
   getDigitalLocationOfType,
   sierraIdFromPresentationManifestUrl,
+  getProductionDates,
 } from '@weco/catalogue/utils/works';
 import { getCatalogueLicenseData } from '@weco/common/utils/licenses';
 import { Image as ImageType, Work } from '@weco/common/model/catalogue';
@@ -21,12 +22,13 @@ import IIIFImage from '@weco/catalogue/components/IIIFImage/IIIFImage';
 import LL from '@weco/common/views/components/styled/LL';
 import { toLink as itemLink } from '@weco/common/views/components/ItemLink/ItemLink';
 import { toLink as imageLink } from '@weco/common/views/components/ImageLink/ImageLink';
-import { getProductionDates } from '../../utils/works';
+import { trackSegmentEvent } from '@weco/common/services/conversion/track';
 
 type Props = {
   image: ImageType | undefined;
   setExpandedImage: (image?: ImageType) => void;
   resultPosition: number;
+  isActive: boolean;
 };
 
 type CanvasLink = {
@@ -112,6 +114,7 @@ const ExpandedImage: FunctionComponent<Props> = ({
   image,
   setExpandedImage,
   resultPosition,
+  isActive,
 }: Props) => {
   const [detailedWork, setDetailedWork] = useState<Work | undefined>();
   const [canvasDeeplink, setCanvasDeeplink] = useState<
@@ -120,6 +123,37 @@ const ExpandedImage: FunctionComponent<Props> = ({
   const [currentImageId, setCurrentImageId] = useState<string | undefined>();
 
   const workId = image?.source.id;
+
+  useEffect(() => {
+    if (workId) {
+      // Send reporting events
+      if (!isActive) {
+        trackSegmentEvent({
+          name: 'Close image modal',
+          eventGroup: 'similarity',
+          properties: {
+            imageId: image?.id,
+          },
+        });
+      } else {
+        trackSegmentEvent({
+          name: 'Open image modal',
+          eventGroup: 'similarity',
+          properties: {
+            imageId: image?.id,
+          },
+        });
+
+        trackSegmentEvent({
+          name: 'Open image modal',
+          eventGroup: 'conversion',
+          properties: {
+            imageId: image?.id,
+          },
+        });
+      }
+    }
+  }, [isActive]);
 
   useEffect(() => {
     if (workId && workId !== currentImageId) {

--- a/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
+++ b/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, FunctionComponent } from 'react';
+import { useEffect, useState, FunctionComponent } from 'react';
 import styled from 'styled-components';
 import NextLink from 'next/link';
 import { font } from '@weco/common/utils/classnames';
@@ -125,6 +125,8 @@ const ExpandedImage: FunctionComponent<Props> = ({
   const workId = image?.source.id;
 
   useEffect(() => {
+    // We want this fired only if there is a workId (not on initial load),
+    // but not everytime it changes, so excluding it from dependency array
     if (workId) {
       // Send reporting events
       if (!isActive) {

--- a/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
+++ b/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
@@ -178,6 +178,7 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
         <ExpandedImage
           resultPosition={expandedImagePosition}
           image={expandedImage}
+          isActive={isActive}
           setExpandedImage={setExpandedImage}
         />
       </Modal>

--- a/catalogue/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.tsx
+++ b/catalogue/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.tsx
@@ -8,6 +8,7 @@ import Space from '@weco/common/views/components/styled/Space';
 import { useToggles } from '@weco/common/server-data/Context';
 import IIIFImage from '@weco/catalogue/components/IIIFImage/IIIFImage';
 import LL from '@weco/common/views/components/styled/LL';
+import { trackSegmentEvent } from '@weco/common/services/conversion/track';
 
 type Props = {
   originalId: string;
@@ -95,7 +96,23 @@ const VisuallySimilarImagesFromApi: FunctionComponent<Props> = ({
 
       <Wrapper>
         {similarImages.map(related => (
-          <a key={related.id} onClick={() => onClickImage(related)} href="#">
+          <a
+            key={related.id}
+            onClick={() => {
+              onClickImage(related);
+
+              trackSegmentEvent({
+                name: 'Click visually similar image',
+                eventGroup: 'similarity',
+                properties: {
+                  sourceImageId: originalId,
+                  imageId: related?.id,
+                  siblingImageIds: similarImages.map(s => s.id),
+                },
+              });
+            }}
+            href="#"
+          >
             <IIIFImage
               layout="raw"
               image={{

--- a/common/services/conversion/track.ts
+++ b/common/services/conversion/track.ts
@@ -38,6 +38,12 @@ type Session = {
   timeout: number;
 };
 
+type EventProps = {
+  name: string;
+  properties: { [key: string]: unknown };
+  eventGroup?: EventGroup;
+};
+
 export type Pageview = {
   name: string;
   properties: Record<string, string[] | number[] | string | number | undefined>;
@@ -78,11 +84,7 @@ function trackPageview({
   name,
   properties,
   eventGroup = 'conversion',
-}: {
-  name: string;
-  properties: { [key: string]: unknown };
-  eventGroup?: EventGroup;
-}): void {
+}: EventProps): void {
   // Source is passed in the querystring in the app, but not the client.
   // e.g. /common/views/component/WorkLink/WorkLink.tsx
   const { source, ...query } = Router.query;
@@ -108,11 +110,7 @@ function trackSegmentEvent({
   name,
   properties,
   eventGroup = 'conversion',
-}: {
-  name: string;
-  properties: { [key: string]: unknown };
-  eventGroup?: EventGroup;
-}): void {
+}: EventProps): void {
   track({
     type: 'event',
     eventGroup,

--- a/common/services/conversion/track.ts
+++ b/common/services/conversion/track.ts
@@ -6,6 +6,9 @@ import { v4 as uuidv4 } from 'uuid';
 
 declare global {
   interface Window {
+    // Segment.io requires `analytics: any;`
+    // https://ashokraju.medium.com/using-segment-io-analytics-js-with-single-page-react-typescript-app-a8c12b4816c4
+    // eslint-disable-next-line
     analytics: any;
   }
 }
@@ -74,7 +77,7 @@ let pageName: string;
 function trackPageview({
   name,
   properties,
-  eventGroup,
+  eventGroup = 'conversion',
 }: {
   name: string;
   properties: { [key: string]: unknown };
@@ -88,7 +91,7 @@ function trackPageview({
   const conversion: Conversion = {
     type: 'pageview',
     source: source?.toString() || 'unknown',
-    eventGroup: eventGroup || 'conversion',
+    eventGroup,
     page: {
       path: Router.asPath,
       pathname: Router.pathname,
@@ -104,7 +107,7 @@ function trackPageview({
 function trackSegmentEvent({
   name,
   properties,
-  eventGroup,
+  eventGroup = 'conversion',
 }: {
   name: string;
   properties: { [key: string]: unknown };
@@ -112,7 +115,7 @@ function trackSegmentEvent({
 }): void {
   track({
     type: 'event',
-    eventGroup: eventGroup || 'conversion',
+    eventGroup,
     page: {
       path: Router.asPath,
       pathname: Router.pathname,

--- a/common/views/components/DownloadLink/DownloadLink.tsx
+++ b/common/views/components/DownloadLink/DownloadLink.tsx
@@ -91,7 +91,10 @@ const DownloadLink: FunctionComponent<Props> = ({
       rel="noopener noreferrer"
       href={href}
       onClick={() => {
-        trackSegmentEvent('download', { width, mimeType, tags: trackingTags });
+        trackSegmentEvent({
+          name: 'download',
+          properties: { width, mimeType, tags: trackingTags },
+        });
         trackingEvent && trackGaEvent(trackingEvent);
       }}
     >

--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -99,7 +99,11 @@ const WecoApp: FunctionComponent<WecoAppProps> = ({
   useOnPageLoad(url => ReactGA.pageview(url));
   useOnPageLoad(() => {
     if (pageProps.pageview) {
-      trackPageview(pageProps.pageview.name, pageProps.pageview.properties);
+      trackPageview({
+        name: pageProps.pageview.name,
+        properties: pageProps.pageview.properties,
+        eventGroup: pageProps.pageview.eventGroup,
+      });
     }
   });
 


### PR DESCRIPTION
## Who is this for?
Reporting

## What is it doing for them?
- Makes `trackSegmentEvent` more flexible, allowing for `similary` OR `conversion` index.
- Tracks VSI journey (open modal/click on VSI/close modal).

Relates to #8841 and #8885 