### PR TITLE
Highlight any selected toggles when you hit an error

### DIFF
--- a/common/views/components/ErrorPage/ErrorPage.tsx
+++ b/common/views/components/ErrorPage/ErrorPage.tsx
@@ -1,16 +1,91 @@
 import { FunctionComponent } from 'react';
-import { headerBackgroundLs } from '../../../utils/backgrounds';
-import PageHeader, { headerSpaceSize } from '../PageHeader/PageHeader';
-import PageLayout from '../PageLayout/PageLayout';
-import SpacingSection from '../SpacingSection/SpacingSection';
-import SpacingComponent from '../SpacingComponent/SpacingComponent';
-import Space from '../styled/Space';
+
+// Helpers/Utils
 import { isNotUndefined } from '../../../utils/array';
+import { getCookies } from 'cookies-next';
+import styled from 'styled-components';
+
+// Hard-coded values
 import {
   DefaultErrorText,
   NotFoundErrorText,
   errorMessages,
 } from '../../../data/errors';
+import { headerBackgroundLs } from '../../../utils/backgrounds';
+import { underConstruction } from '../../../icons';
+
+// Components
+import Icon from '../Icon/Icon';
+import Layout8 from '../Layout8/Layout8';
+import PageHeader, { headerSpaceSize } from '../PageHeader/PageHeader';
+import PageLayout from '../PageLayout/PageLayout';
+import SpacingSection from '../SpacingSection/SpacingSection';
+import SpacingComponent from '../SpacingComponent/SpacingComponent';
+import Space from '../styled/Space';
+
+const ToggleMessageBar = styled(Space).attrs({
+  h: { size: 'm', properties: ['padding-left', 'padding-right'] },
+  v: { size: 's', properties: ['padding-top', 'padding-bottom'] },
+})`
+  background: ${props => props.theme.color('yellow')};
+  display: flex;
+  align-items: center;
+  position: relative;
+
+  .icon {
+    transform: translateY(0.1em);
+  }
+`;
+
+/** This shows the user a list of toggles they currently have enabled, e.g.
+ *
+ *      You have the following toggles enabled: apiToolbar, searchPage
+ *
+ * Sometimes toggles may cause errors on the site which aren't visible to
+ * the public (e.g. the staging API toggle).
+ *
+ * Staff send us screenshots to show us the site is broken, and it may not
+ * be immediately obvious why we can't reproduce the error.  This gives us
+ * more information to help debug errors quickly.
+ *
+ * The only people who should have toggles enabled are Wellcome staff, and
+ * this message only shows if you've enabled at least one toggle, so this
+ * won't going to cause confusing messages to be shown to the public.
+ *
+ * We add a brightly coloured background to emphasise this isn't part of the
+ * regular error page.
+ */
+const TogglesMessage: FunctionComponent = () => {
+  // Note: we use this slightly non-standard construction rather than
+  // useToggles() because we don't have access to the server data context
+  // here -- we can't use getServerSideProps on an error page.
+  // See https://nextjs.org/docs/messages/404-get-initial-props
+  const toggles = Object.entries(getCookies())
+    .filter(([k, v]) => k.startsWith('toggle_') && v === 'true')
+    .map(kv => kv[0].replaceAll('toggle_', ''))
+    .sort();
+
+  return toggles.length > 0 ? (
+    <Layout8>
+      <ToggleMessageBar>
+        <Space h={{ size: 's', properties: ['margin-right'] }}>
+          <Icon icon={underConstruction} />
+        </Space>
+        <Space h={{ size: 's', properties: ['margin-right'] }}>
+          You have the following{' '}
+          <a href="https://dash.wellcomecollection.org/toggles">toggles</a>{' '}
+          enabled:{' '}
+          {toggles.map((t, i) => (
+            <>
+              <strong key={t}>{t}</strong>
+              {i !== toggles.length - 1 && <>, </>}
+            </>
+          ))}
+        </Space>
+      </ToggleMessageBar>
+    </Layout8>
+  ) : null;
+};
 
 type Props = {
   statusCode?: number;
@@ -45,6 +120,7 @@ const ErrorPage: FunctionComponent<Props> = ({ statusCode = 500, title }) => {
         <SpacingSection>
           <SpacingComponent>
             {statusCode === 404 ? <NotFoundErrorText /> : <DefaultErrorText />}
+            <TogglesMessage />
           </SpacingComponent>
         </SpacingSection>
       </Space>

--- a/common/views/components/ErrorPage/ErrorPage.tsx
+++ b/common/views/components/ErrorPage/ErrorPage.tsx
@@ -17,10 +17,7 @@ type Props = {
   title?: string;
 };
 
-const ErrorPage: FunctionComponent<Props> = ({
-  statusCode = 500,
-  title,
-}: Props) => {
+const ErrorPage: FunctionComponent<Props> = ({ statusCode = 500, title }) => {
   const errorMessage = isNotUndefined(title)
     ? title
     : statusCode in errorMessages

--- a/common/views/components/ErrorPage/ErrorPage.tsx
+++ b/common/views/components/ErrorPage/ErrorPage.tsx
@@ -62,7 +62,7 @@ const TogglesMessage: FunctionComponent = () => {
   // See https://nextjs.org/docs/messages/404-get-initial-props
   const toggles = Object.entries(getCookies())
     .filter(([k, v]) => k.startsWith('toggle_') && v === 'true')
-    .map(kv => kv[0].replaceAll('toggle_', ''))
+    .map(kv => kv[0].replace('toggle_', ''))
     .sort();
 
   return toggles.length > 0 ? (


### PR DESCRIPTION
## Who is this for?

Devs/staff.

## What is it doing for them?

Making it easier to debug issues caused by an experimental toggle. If you have toggles enabled, you now get a yellow bar telling you about them on any error pages:

<img width="918" alt="Screenshot 2022-12-05 at 15 37 59" src="https://user-images.githubusercontent.com/301220/205678261-589d5c77-8b2b-4171-a63b-0ed26ad156de.png">

If a member of staff sends that screenshot to devs (which they often do), it makes it easier for us to reproduce the error and we don't have to remember to ask about toggles.

The main use case for this is the **stagingApi** toggle, because the staging catalogue API doesn't have the same uptime guarantees as the prod API – it's been broken recently, and we've had several confused staff asking why the collections search isn't working.