### PR TITLE
Segment toggles

### DIFF
--- a/common/services/conversion/track.ts
+++ b/common/services/conversion/track.ts
@@ -126,16 +126,13 @@ function trackSegmentEvent({
 
 function track(conversion: Conversion) {
   const debug = getCookie(cookies.analyticsDebug) === true;
-  const allCookies = getCookies();
-  const toggles: { [key: string]: string }[] = [];
+  const toggles = Object.entries(getCookies())
+    .map(([k, v]) => {
+      const isToggleCookie = k.match(/toggle_/);
 
-  for (const cookie in allCookies) {
-    const isToggleCookie = cookie.match(/toggle_/);
-
-    if (isToggleCookie) {
-      toggles.push({ [cookie]: allCookies[cookie] || 'false' });
-    }
-  }
+      return isToggleCookie && { [k]: v === 'true' };
+    })
+    .filter(Boolean);
 
   const sessionId = getSessionId();
   const session: Session = {

--- a/common/services/conversion/track.ts
+++ b/common/services/conversion/track.ts
@@ -126,6 +126,7 @@ function trackSegmentEvent({
 
 function track(conversion: Conversion) {
   const debug = getCookie(cookies.analyticsDebug) === true;
+  // We're not in React land here, so we can't use `useToggles`
   const toggles = getActiveToggles(getCookies());
   const sessionId = getSessionId();
   const session: Session = {

--- a/common/services/conversion/track.ts
+++ b/common/services/conversion/track.ts
@@ -3,7 +3,7 @@ import cookies from '@weco/common/data/cookies';
 import Router from 'next/router';
 import { ParsedUrlQuery } from 'querystring';
 import { v4 as uuidv4 } from 'uuid';
-
+import { getActiveToggles } from '@weco/common/utils/cookies';
 declare global {
   interface Window {
     // Segment.io requires `analytics: any;`
@@ -126,14 +126,7 @@ function trackSegmentEvent({
 
 function track(conversion: Conversion) {
   const debug = getCookie(cookies.analyticsDebug) === true;
-  const toggles = Object.entries(getCookies())
-    .map(([k, v]) => {
-      const isToggleCookie = k.match(/toggle_/);
-
-      return isToggleCookie && { [k]: v === 'true' };
-    })
-    .filter(Boolean);
-
+  const toggles = getActiveToggles(getCookies());
   const sessionId = getSessionId();
   const session: Session = {
     id: sessionId,

--- a/common/utils/cookies.ts
+++ b/common/utils/cookies.ts
@@ -1,0 +1,8 @@
+export function getActiveToggles(
+  cookies: Partial<{ [key: string]: string }>
+): string[] {
+  return Object.entries(cookies)
+    .filter(([k, v]) => k.startsWith('toggle_') && v === 'true')
+    .map(kv => kv[0].replace('toggle_', ''))
+    .sort();
+}

--- a/common/utils/cookies.ts
+++ b/common/utils/cookies.ts
@@ -1,3 +1,8 @@
+// You possibly/probably want `useToggles` instead of this. This function
+// returns an array of strings denoting which toggles a user has active. This
+// output is useful for display purposes (to show someone what they have turned
+// on) as well as for including alongside tracking data, in order to determine
+// e.g. what condition a user was in when performing a task on the site.
 export function getActiveToggles(
   cookies: Partial<{ [key: string]: string }>
 ): string[] {

--- a/common/views/components/ErrorPage/ErrorPage.tsx
+++ b/common/views/components/ErrorPage/ErrorPage.tsx
@@ -22,7 +22,7 @@ import PageLayout from '../PageLayout/PageLayout';
 import SpacingSection from '../SpacingSection/SpacingSection';
 import SpacingComponent from '../SpacingComponent/SpacingComponent';
 import Space from '../styled/Space';
-
+import { getActiveToggles } from '@weco/common/utils/cookies';
 const ToggleMessageBar = styled(Space).attrs({
   h: { size: 'm', properties: ['padding-left', 'padding-right'] },
   v: { size: 's', properties: ['padding-top', 'padding-bottom'] },
@@ -60,10 +60,7 @@ const TogglesMessage: FunctionComponent = () => {
   // useToggles() because we don't have access to the server data context
   // here -- we can't use getServerSideProps on an error page.
   // See https://nextjs.org/docs/messages/404-get-initial-props
-  const toggles = Object.entries(getCookies())
-    .filter(([k, v]) => k.startsWith('toggle_') && v === 'true')
-    .map(kv => kv[0].replace('toggle_', ''))
-    .sort();
+  const toggles = getActiveToggles(getCookies());
 
   return toggles.length > 0 ? (
     <Layout8>


### PR DESCRIPTION
Part of #8911 

This adds any `toggle_` cookies to what we `track` with segment, as part of the [`properties` object](https://segment.com/docs/connections/spec/track/#properties)

<img width="576" alt="Screenshot 2022-12-05 at 21 20 08" src="https://user-images.githubusercontent.com/1394592/205744979-a354b62a-41d5-41f9-a68a-bd3b03d60dd0.png">
