### PR TITLE
Works tabs toggle

### DIFF
--- a/catalogue/webapp/components/Work/Work.tsx
+++ b/catalogue/webapp/components/Work/Work.tsx
@@ -17,6 +17,8 @@ import Divider from '@weco/common/views/components/Divider/Divider';
 import styled from 'styled-components';
 import SearchContext from '@weco/common/views/components/SearchContext/SearchContext';
 import IsArchiveContext from '../IsArchiveContext/IsArchiveContext';
+import WorkTabbedNav from '../WorkTabbedNav/WorkTabbedNav';
+import { useToggles } from '@weco/common/server-data/Context';
 
 const ArchiveDetailsContainer = styled.div`
   display: block;
@@ -34,11 +36,11 @@ const WorkDetailsWrapper = styled(Space).attrs({
   flex: 1;
 `;
 
-const Container = styled.div.attrs({
+export const Container = styled.div.attrs({
   className: 'container',
 })``;
 
-const Grid = styled.div.attrs({
+export const Grid = styled.div.attrs({
   className: 'grid',
 })``;
 
@@ -50,6 +52,7 @@ const Work: FunctionComponent<Props> = ({
   work,
 }: Props): ReactElement<Props> => {
   const { link: searchLink } = useContext(SearchContext);
+  const { worksTabbedNav } = useToggles();
 
   const isArchive = !!(
     work.parts.length ||
@@ -136,6 +139,9 @@ const Work: FunctionComponent<Props> = ({
               <Grid>
                 <WorkHeader work={work} />
               </Grid>
+              {worksTabbedNav && (
+                <WorkTabbedNav work={work} selected="catalogueDetails" />
+              )}
             </Container>
 
             <Container>
@@ -154,6 +160,9 @@ const Work: FunctionComponent<Props> = ({
               <Grid>
                 <WorkHeader work={work} />
               </Grid>
+              {worksTabbedNav && (
+                <WorkTabbedNav work={work} selected="catalogueDetails" />
+              )}
             </Container>
             <WorkDetails work={work} />
           </>

--- a/catalogue/webapp/components/WorkTabbedNav/WorkTabbedNav.tsx
+++ b/catalogue/webapp/components/WorkTabbedNav/WorkTabbedNav.tsx
@@ -1,0 +1,47 @@
+import { Work } from '@weco/common/model/catalogue';
+import { FunctionComponent } from 'react';
+import SubNavigation from '@weco/common/views/components/SubNavigation/SubNavigation';
+import { listView, eye } from '@weco/common/icons';
+import { toLink as itemLink } from '@weco/common/views/components/ItemLink/ItemLink';
+
+type Props = {
+  work: Work;
+  selected: string;
+};
+const WorkTabbedNav: FunctionComponent<Props> = ({ work, selected }) => {
+  const itemUrl = itemLink({ workId: work.id }, 'work');
+  return (
+    <SubNavigation
+      label="Search Categories"
+      items={[
+        {
+          id: 'catalogueDetails',
+          url: {
+            href: {
+              pathname: '/work',
+              query: {
+                id: work.id,
+              },
+            },
+            as: {
+              pathname: `/works/${work.id}`,
+            },
+          },
+          name: 'Catalogue details',
+          icon: listView,
+        },
+        {
+          id: 'imageViewer',
+          url: itemUrl, // TODO typing to also accept an object
+          name: 'Image viewer',
+          icon: eye,
+        },
+      ]}
+      currentSection={selected}
+      hasDivider
+      variant="yellow"
+    />
+  );
+};
+
+export default WorkTabbedNav;

--- a/catalogue/webapp/components/WorkTabbedNav/WorkTabbedNav.tsx
+++ b/catalogue/webapp/components/WorkTabbedNav/WorkTabbedNav.tsx
@@ -32,7 +32,7 @@ const WorkTabbedNav: FunctionComponent<Props> = ({ work, selected }) => {
         },
         {
           id: 'imageViewer',
-          url: itemUrl, // TODO typing to also accept an object
+          url: itemUrl,
           name: 'Image viewer',
           icon: eye,
         },

--- a/catalogue/webapp/components/WorkTabbedNav/WorkTabbedNav.tsx
+++ b/catalogue/webapp/components/WorkTabbedNav/WorkTabbedNav.tsx
@@ -6,7 +6,7 @@ import { toLink as itemLink } from '@weco/common/views/components/ItemLink/ItemL
 
 type Props = {
   work: Work;
-  selected: string;
+  selected:'catalogueDetails' | imageViewer';
 };
 const WorkTabbedNav: FunctionComponent<Props> = ({ work, selected }) => {
   const itemUrl = itemLink({ workId: work.id }, 'work');

--- a/catalogue/webapp/components/WorkTabbedNav/WorkTabbedNav.tsx
+++ b/catalogue/webapp/components/WorkTabbedNav/WorkTabbedNav.tsx
@@ -6,7 +6,7 @@ import { toLink as itemLink } from '@weco/common/views/components/ItemLink/ItemL
 
 type Props = {
   work: Work;
-  selected:'catalogueDetails' | imageViewer';
+  selected: 'catalogueDetails' | 'imageViewer';
 };
 const WorkTabbedNav: FunctionComponent<Props> = ({ work, selected }) => {
   const itemUrl = itemLink({ workId: work.id }, 'work');

--- a/catalogue/webapp/pages/item.tsx
+++ b/catalogue/webapp/pages/item.tsx
@@ -40,6 +40,10 @@ import {
   TransformedManifest,
   createDefaultTransformedManifest,
 } from '../types/manifest';
+import WorkHeader from '../components/WorkHeader/WorkHeader';
+import WorkTabbedNav from '../components/WorkTabbedNav/WorkTabbedNav';
+import { Container, Grid } from '../components/Work/Work';
+import { useToggles } from '@weco/common/server-data/Context';
 
 const IframeAuthMessage = styled.iframe`
   display: none;
@@ -93,7 +97,7 @@ const ItemPage: NextPage<Props> = ({
   const [origin, setOrigin] = useState<string>();
   const [showModal, setShowModal] = useState(false);
   const [showViewer, setShowViewer] = useState(false);
-
+  const { worksTabbedNav } = useToggles();
   const {
     title,
     downloadEnabled,
@@ -196,6 +200,18 @@ const ItemPage: NextPage<Props> = ({
           src={`${tokenService['@id']}?messageId=1&origin=${origin}`}
         />
       )}
+
+      {worksTabbedNav && (
+        <Space v={{ size: 'l', properties: ['margin-top'] }}>
+          <Container>
+            <Grid>
+              <WorkHeader work={work} />
+            </Grid>
+            <WorkTabbedNav work={work} selected="imageViewer" />
+          </Container>
+        </Space>
+      )}
+
       {isNotUndefined(audio) && audio?.sounds?.length > 0 && (
         <Space v={{ size: 'l', properties: ['margin-top', 'margin-bottom'] }}>
           <Layout12>

--- a/common/views/components/SubNavigation/SubNavigation.tsx
+++ b/common/views/components/SubNavigation/SubNavigation.tsx
@@ -1,5 +1,5 @@
 import { FunctionComponent } from 'react';
-import { IconSvg } from '../../../icons';
+import Link, { LinkProps } from 'next/link';
 import {
   Wrapper,
   TabsContainer,
@@ -7,9 +7,9 @@ import {
   NavItemInner,
 } from './SubNavigation.styles';
 import Divider from '../Divider/Divider';
-import Icon from '../Icon/Icon';
 import Space from '../styled/Space';
-import Link from 'next/link';
+import Icon from '../Icon/Icon';
+import { IconSvg } from '../../../icons';
 import styled from 'styled-components';
 
 const IconWrapper = styled.span`
@@ -21,7 +21,7 @@ const IconWrapper = styled.span`
 type SelectableTextLink = {
   name: string;
   id: string;
-  url: string;
+  url: string | LinkProps;
   icon?: IconSvg;
 };
 
@@ -51,7 +51,7 @@ const SubNavigation: FunctionComponent<Props> = ({
                 scroll={false}
                 passHref
                 href={typeof item.url === 'string' ? item.url : item.url.href}
-                as={item.url.as}
+                as={typeof item.url === 'string' ? undefined : item.url.as}
               >
                 <NavItemInner
                   variant={variant}

--- a/common/views/components/SubNavigation/SubNavigation.tsx
+++ b/common/views/components/SubNavigation/SubNavigation.tsx
@@ -1,17 +1,28 @@
 import { FunctionComponent } from 'react';
+import { IconSvg } from '../../../icons';
 import {
   Wrapper,
   TabsContainer,
   Tab,
   NavItemInner,
 } from './SubNavigation.styles';
-import Divider from '@weco/common/views/components/Divider/Divider';
+import Divider from '../Divider/Divider';
+import Icon from '../Icon/Icon';
+import Space from '../styled/Space';
 import Link from 'next/link';
+import styled from 'styled-components';
+
+const IconWrapper = styled.span`
+  div {
+    top: 6px;
+  }
+`;
 
 type SelectableTextLink = {
   name: string;
   id: string;
   url: string;
+  icon?: IconSvg;
 };
 
 type Props = {
@@ -36,7 +47,12 @@ const SubNavigation: FunctionComponent<Props> = ({
           const isSelected = currentSection === item.id;
           return (
             <Tab key={item.id}>
-              <Link scroll={false} passHref href={item.url}>
+              <Link
+                scroll={false}
+                passHref
+                href={typeof item.url === 'string' ? item.url : item.url.href}
+                as={item.url.as}
+              >
                 <NavItemInner
                   variant={variant}
                   selected={isSelected}
@@ -51,6 +67,16 @@ const SubNavigation: FunctionComponent<Props> = ({
                     }
                   }}
                 >
+                  {item.icon && (
+                    <Space
+                      as="span"
+                      h={{ size: 's', properties: ['margin-right'] }}
+                    >
+                      <IconWrapper>
+                        <Icon icon={item.icon} />
+                      </IconWrapper>
+                    </Space>
+                  )}
                   {item.name}
                 </NavItemInner>
               </Link>

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -68,6 +68,13 @@ const toggles = {
       initialValue: false,
       description: 'Include events and exhibitions on the new search page',
     },
+    {
+      id: 'worksTabbedNav',
+      title: 'Works page: Tabbed navigation',
+      initialValue: false,
+      description:
+        'Adds tabbed navigation to the works page, for switching between work, item and related content',
+    },
   ] as const,
   tests: [] as ABTest[],
 };


### PR DESCRIPTION
Relates to #8910 and fixes #8909

- Adds tabbed navigation to the works page and item page behind a toggle.
- This will allow us to explore if/how this should work - e.g. what should happen in the case of audio/video.
- In combination with #8958, we'll be able to check @taceybadgerbrook can track what she needs and will be able to change the toggle to function as an A/B test when required

Work page:
![Screenshot 2022-12-05 at 16 17 55](https://user-images.githubusercontent.com/6051896/205901694-147bad50-2041-4574-bd57-e8eebe0c2a28.png)

Item page:
![Screenshot 2022-12-05 at 16 16 54](https://user-images.githubusercontent.com/6051896/205901715-0e6e98d1-a655-47a1-a8a0-9ab484b4313c.png)
