### PR TITLE
Add some space around buttons on guide page header for small screens

### DIFF
--- a/content/webapp/pages/guides/exhibitions/[id]/[type].tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/[type].tsx
@@ -32,6 +32,13 @@ import cookies from '@weco/common/data/cookies';
 import ExhibitionGuideStops from '../../../../components/ExhibitionGuideStops/ExhibitionGuideStops';
 import { getTypeColor } from '../../../../components/ExhibitionCaptions/ExhibitionCaptions';
 
+const ButtonWrapper = styled(Space).attrs({
+  v: { size: 's', properties: ['margin-bottom'] },
+  h: { size: 's', properties: ['margin-right'] },
+})`
+  display: inline-block;
+`;
+
 const Header = styled(Space).attrs({
   v: {
     size: 'xl',
@@ -192,7 +199,7 @@ const ExhibitionGuidePage: FC<Props> = props => {
                 <p>{exhibitionGuide.relatedExhibition.description}</p>
               )
             )}
-            <Space as="span" h={{ size: 's', properties: ['margin-right'] }}>
+            <ButtonWrapper>
               <ButtonSolidLink
                 colors={themeValues.buttonColors.charcoalWhiteCharcoal}
                 text="Change guide type"
@@ -201,7 +208,7 @@ const ExhibitionGuidePage: FC<Props> = props => {
                   deleteCookie(cookies.exhibitionGuideType);
                 }}
               />
-            </Space>
+            </ButtonWrapper>
             <ButtonSolidLink
               colors={themeValues.buttonColors.charcoalWhiteCharcoal}
               text="Change exhibition"


### PR DESCRIPTION
☝️ 

**Before**
![Screenshot 2022-12-06 at 15 12 00](https://user-images.githubusercontent.com/1394592/205949937-7dd354f3-3867-4524-b8f8-8c3371ca0fe5.png)


**After**
![Screenshot 2022-12-06 at 15 10 53](https://user-images.githubusercontent.com/1394592/205949912-9b9674cd-2a37-4ba3-ac78-51c9f4249552.png)
