### PR TITLE
Remove some old toggle-related code

### DIFF
--- a/content/webapp/pages/guides/exhibitions/[id]/[type].tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/[type].tsx
@@ -68,11 +68,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     const { id, type, usingQRCode, userPreferenceSet, stopId } = context.query;
     const { res, req } = context;
 
-    if (!looksLikePrismicId(id) || !serverData.toggles.exhibitionGuides) {
-      return { notFound: true };
-    }
-
-    if (!isValidType(type)) {
+    if (!looksLikePrismicId(id) || !isValidType(type)) {
       return { notFound: true };
     }
 

--- a/content/webapp/pages/guides/exhibitions/[id]/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/index.tsx
@@ -41,7 +41,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     const serverData = await getServerData(context);
     const { id } = context.query;
 
-    if (!looksLikePrismicId(id) || !serverData.toggles.exhibitionGuides) {
+    if (!looksLikePrismicId(id)) {
       return { notFound: true };
     }
 

--- a/content/webapp/pages/guides/exhibitions/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/index.tsx
@@ -31,10 +31,6 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     const serverData = await getServerData(context);
     const page = getPage(context.query);
 
-    if (!serverData.toggles.exhibitionGuides) {
-      return { notFound: true };
-    }
-
     if (typeof page !== 'number') {
       return appError(context, 400, page.message);
     }

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -49,13 +49,6 @@ const toggles = {
       description: 'View pages related to exhibition guides',
     },
     {
-      id: 'newStoriesLanding',
-      title: 'New stories landing page content',
-      initialValue: false,
-      description:
-        'Uses the new stories-landing type in Prismic to provide page content for /stories. Namely, the introductory text and featured books section (currently being populated from different places), and replaces the hard coded promoted series with a list of editor chosen articles and series.',
-    },
-    {
       id: 'searchPage',
       title: 'Search page',
       initialValue: false,


### PR DESCRIPTION
The first part of #8967.

* The stories landing toggle isn't used anywhere; we removed it from the display components in #8727
* The exhibition guides are now live for everyone; we can remove the conditional code

Once this is deployed, I'll follow up with a second PR to remove the exhibition guides toggle.