### PR TITLE
Add format to article-series in Prismic model

### DIFF
--- a/prismic-model/src/series.ts
+++ b/prismic-model/src/series.ts
@@ -19,6 +19,7 @@ const articleSeries: CustomType = {
   json: {
     'Story series': {
       title,
+      format: documentLink('Format', { linkedType: 'article-formats' }),
       color: select('Colour', {
         options: [
           'accent.green',


### PR DESCRIPTION
☝️ 

For #8399 we need to be able to query for multiple `series` that contain comics. Currently there isn't a way to determine what type of thing a `series` contains. Adding a `format` would allow editors to mark a series as containing comics and enable the right stuff to be queried.

Once this was complete, there would also be a task to add the comic format to existing comic series in Prismic.