### PR TITLE
Use an API key to fetch Prismic content

### DIFF
--- a/catalogue/terraform/stack/main.tf
+++ b/catalogue/terraform/stack/main.tf
@@ -40,7 +40,9 @@ module "catalogue-service-17092020" {
     APM_SECRET           = "elasticsearch/logging/apm_secret"
     items_api_key_prod   = "catalogue_api/items/prod/api_key"
     items_api_key_stage  = "catalogue_api/items/stage/api_key"
+
     PRISMIC_BEARER_TOKEN = "prismic-model/graphql/prismic_bearer_token"
+    PRISMIC_ACCESS_TOKEN = "prismic-model/prod/access-token"
   }
 
   vpc_id  = local.vpc_id

--- a/common/services/prismic/fetch/index.ts
+++ b/common/services/prismic/fetch/index.ts
@@ -1,9 +1,32 @@
 import fetch from 'node-fetch';
 import * as prismic from '@prismicio/client';
+import { isUndefined } from '../../../utils/array';
 
 export function createClient(): prismic.Client {
+  // We use an access token for Prismic in prod to avoid certain classes of
+  // intermittent error.  In particular, we'd see an occasional 500 response
+  // with an error from Prismic:
+  //
+  //      ForbiddenError: Access to this Ref requires an access token
+  //
+  // We have Prismic configured so that only our 'master' ref (i.e. latest) is
+  // available publicly.  Because this error is intermittent, it looks like maybe
+  // some sort of race condition where content is being published between our app
+  // getting the current master ref, and looking up content with that ref.
+  //
+  // Using authentication for Prismic requests should fix this error.
+  //
+  // See also: https://prismic.io/docs/access-token
+  // See also: https://github.com/wellcomecollection/wellcomecollection.org/issues/8309
+  //
+  const accessToken = process.env.PRISMIC_ACCESS_TOKEN;
+
+  if (isUndefined(accessToken) && process.env.NODE_ENV === 'production') {
+    console.warn('No access token specified for Prismic client');
+  }
+
   const endpoint = prismic.getEndpoint('wellcomecollection');
-  const client = prismic.createClient(endpoint, { fetch });
+  const client = prismic.createClient(endpoint, { fetch, accessToken });
 
   return client;
 }

--- a/content/terraform/stack/main.tf
+++ b/content/terraform/stack/main.tf
@@ -26,6 +26,8 @@ module "content-service-17092020" {
     APM_SECRET          = "elasticsearch/logging/apm_secret"
     dotdigital_username = "content/dotdigital/username"
     dotdigital_password = "content/dotdigital/password"
+
+    PRISMIC_ACCESS_TOKEN = "prismic-model/prod/access-token"
   }
 
   vpc_id  = local.vpc_id


### PR DESCRIPTION
This should stem the intermittent errors we've been seeing in https://github.com/wellcomecollection/wellcomecollection.org/issues/8309