### PR TITLE
Comic series

### DIFF
--- a/content/webapp/pages/season.tsx
+++ b/content/webapp/pages/season.tsx
@@ -31,10 +31,7 @@ import {
   transformBook,
   transformBookToBookBasic,
 } from '../services/prismic/transformers/books';
-import {
-  transformEvent,
-  transformEventBasic,
-} from '../services/prismic/transformers/events';
+import { transformEventBasic } from '../services/prismic/transformers/events';
 import { transformExhibitionsQuery } from '../services/prismic/transformers/exhibitions';
 import { transformPage } from '../services/prismic/transformers/pages';
 import { transformProject } from '../services/prismic/transformers/projects';

--- a/content/webapp/pages/stories.tsx
+++ b/content/webapp/pages/stories.tsx
@@ -37,9 +37,11 @@ import { RichTextField } from '@prismicio/types';
 import { ArticleFormatIds } from '@weco/common/data/content-format-ids';
 import { fetchSeries } from '../services/prismic/fetch/series';
 import { transformSeries } from '../services/prismic/transformers/series';
+import { Series } from '../types/series';
 
 type Props = {
   articles: ArticleBasic[];
+  comicSeries: Series[];
   storiesLanding: StoriesLanding;
   jsonLd: JsonLdObj[];
 };
@@ -69,9 +71,8 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     });
 
     const comicSeriesPromise = fetchSeries(client, {
-      predicates: [`[at(my.series.seasons.season, "${id}")]`],
+      predicates: [`[at(my.series.format, "${ArticleFormatIds.Comic}")]`],
     });
-    // const comicSeriesPromise = fetchArticleSeries
 
     const storiesLandingPromise = fetchStoriesLanding(client);
 
@@ -85,8 +86,8 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     const articles = transformQuery(articlesQuery, transformArticle);
     const jsonLd = articles.results.map(articleLd);
     const basicArticles = articles.results.map(transformArticleToArticleBasic);
-    const series = transformQuery(comicSeriesQuery, transformSeries);
-    console.log({ series });
+    const comicSeries = transformQuery(comicSeriesQuery, transformSeries);
+    console.log(comicSeries.results);
 
     const storiesLanding =
       storiesLandingDoc &&
@@ -98,6 +99,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       return {
         props: removeUndefinedProps({
           articles: basicArticles,
+          comicSeries: comicSeries.results, // TODO: these probably need to be more basic, like basicArticles
           serverData,
           jsonLd,
           storiesLanding,
@@ -110,6 +112,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
 
 const StoriesPage: FunctionComponent<Props> = ({
   articles,
+  comicSeries,
   jsonLd,
   storiesLanding,
 }) => {
@@ -208,6 +211,27 @@ const StoriesPage: FunctionComponent<Props> = ({
             items={storiesLanding.stories}
             itemsPerRow={3}
             links={[{ text: 'More stories', url: '/articles' }]}
+          />
+        </SpacingComponent>
+      </SpacingSection>
+
+      <SpacingSection>
+        <SpacingComponent>
+          {/* TODO: add to storiesLandingDoc */}
+          <SectionHeader title={'Comics'} />
+        </SpacingComponent>
+
+        <SpacingComponent>
+          <Layout12>
+            <p>Intro text about comic series</p>
+          </Layout12>
+        </SpacingComponent>
+
+        <SpacingComponent>
+          <CardGrid
+            items={comicSeries}
+            itemsPerRow={3}
+            itemsHaveTransparentBackground={true}
           />
         </SpacingComponent>
       </SpacingSection>

--- a/content/webapp/pages/stories.tsx
+++ b/content/webapp/pages/stories.tsx
@@ -35,6 +35,8 @@ import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
 import { RichTextField } from '@prismicio/types';
 import { ArticleFormatIds } from '@weco/common/data/content-format-ids';
+import { fetchSeries } from '../services/prismic/fetch/series';
+import { transformSeries } from '../services/prismic/transformers/series';
 
 type Props = {
   articles: ArticleBasic[];
@@ -66,16 +68,25 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       predicates: [`[not(my.articles.format, "${ArticleFormatIds.Comic}")]`],
     });
 
+    const comicSeriesPromise = fetchSeries(client, {
+      predicates: [`[at(my.series.seasons.season, "${id}")]`],
+    });
+    // const comicSeriesPromise = fetchArticleSeries
+
     const storiesLandingPromise = fetchStoriesLanding(client);
 
-    const [articlesQuery, storiesLandingDoc] = await Promise.all([
-      articlesQueryPromise,
-      storiesLandingPromise,
-    ]);
+    const [articlesQuery, storiesLandingDoc, comicSeriesQuery] =
+      await Promise.all([
+        articlesQueryPromise,
+        storiesLandingPromise,
+        comicSeriesPromise,
+      ]);
 
     const articles = transformQuery(articlesQuery, transformArticle);
     const jsonLd = articles.results.map(articleLd);
     const basicArticles = articles.results.map(transformArticleToArticleBasic);
+    const series = transformQuery(comicSeriesQuery, transformSeries);
+    console.log({ series });
 
     const storiesLanding =
       storiesLandingDoc &&

--- a/content/webapp/pages/stories.tsx
+++ b/content/webapp/pages/stories.tsx
@@ -34,6 +34,7 @@ import { StoriesLandingPrismicDocument } from '../services/prismic/types/stories
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
 import { RichTextField } from '@prismicio/types';
+import { ArticleFormatIds } from '@weco/common/data/content-format-ids';
 
 type Props = {
   articles: ArticleBasic[];
@@ -61,8 +62,9 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
     const serverData = await getServerData(context);
     const client = createClient(context);
-
-    const articlesQueryPromise = fetchArticles(client);
+    const articlesQueryPromise = fetchArticles(client, {
+      predicates: [`[not(my.articles.format, "${ArticleFormatIds.Comic}")]`],
+    });
 
     const storiesLandingPromise = fetchStoriesLanding(client);
 

--- a/content/webapp/services/prismic/fetch/series.ts
+++ b/content/webapp/services/prismic/fetch/series.ts
@@ -4,12 +4,13 @@ import {
   contributorFetchLinks,
   seasonsFetchLinks,
 } from '../types';
-import { SeriesPrismicDocument } from '../types/series';
+import { SeriesPrismicDocument, seriesFetchLinks } from '../types/series';
 
 const fetchLinks = [
   ...commonPrismicFieldsFetchLinks,
   ...contributorFetchLinks,
   ...seasonsFetchLinks,
+  ...seriesFetchLinks,
 ];
 
 const seriesFetcher = fetcher<SeriesPrismicDocument>('series', fetchLinks);

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -49,11 +49,11 @@ const toggles = {
       description: 'View pages related to exhibition guides',
     },
     {
-      id: 'newStoriesLanding',
-      title: 'New stories landing page content',
+      id: 'storiesLandingComics',
+      title: 'Rearranging comics on the stories landing page',
       initialValue: false,
       description:
-        'Uses the new stories-landing type in Prismic to provide page content for /stories. Namely, the introductory text and featured books section (currently being populated from different places), and replaces the hard coded promoted series with a list of editor chosen articles and series.',
+        'Takes the comics out of the general set of stories, and moves them to their own page section, grouped by series.',
     },
     {
       id: 'searchPage',


### PR DESCRIPTION
Part of #8399 

- Takes the comics out of the overall stories list on the stories landing page
- Adds a 'Comics' section grouping the three most recent comic series into cards that link to that series's index
- Puts this behind a toggle `storiesLandingComics`

**TODO:**
- [ ] Create/use basic series type that has just enough data to render the cards (fetching all data currently)
- [ ] Add a 'View all' button beneath the latest three comic series that links to a comic series index page
- [ ] Make the above comic series index page