### PR TITLE
Add a better error log for a 404'ing IIIF Manifest

### DIFF
--- a/catalogue/webapp/services/iiif/fetch/manifest.ts
+++ b/catalogue/webapp/services/iiif/fetch/manifest.ts
@@ -1,8 +1,20 @@
 import { Manifest } from '@iiif/presentation-3';
-import { fetchJson } from '@weco/common/utils/http';
 
 async function getIIIFManifest(url: string): Promise<Manifest> {
-  const manifest = await fetchJson(url);
+  const resp = await fetch(url);
+
+  if (resp.status === 404) {
+    const bnumber = url.match(/b[0-9]{7}[0-9x]/)?.[0];
+    const dashboardUrl = bnumber
+      ? `https://iiif.wellcomecollection.org/dash/Manifestation/${bnumber}`
+      : '';
+
+    throw new Error(
+      `Tried to retrieve IIIF Manifest at ${url}, but it's 404-ing. To fix, try running the "Rebuild IIIF" task in the iiif-builder dashboard. ${dashboardUrl}`
+    );
+  }
+
+  const manifest = await resp.json();
   return manifest;
 }
 


### PR DESCRIPTION
This presents as a 500 error to users, but to developers the error in the application logs wasn't especially clear either:

> FetchError: invalid json response body at https://iiif.wellcomecollection.org/presentation/v3/b2874584x reason: Unexpected token N in JSON at position 0

When you look at the IIIF response, it makes a bit more sense:

    No IIIF resource found for v3/b2874584x

For users this will still appear as a generic error, but now developers will get a better explanation of what's happening, including a link to the iiif-builder dashboard where they can fix the error.