### PR TITLE
Skip showing empty contributors on a search story card

### DIFF
--- a/catalogue/webapp/services/prismic/transformers/index.ts
+++ b/catalogue/webapp/services/prismic/transformers/index.ts
@@ -5,6 +5,7 @@ import {
   Contributor,
 } from '../types';
 import { articleIdToLabel } from '../fetch';
+import { isNotUndefined } from '@weco/common/utils/array';
 
 export async function transformPrismicResponse(
   type: ContentType[],
@@ -18,13 +19,15 @@ export async function transformPrismicResponse(
     const summary = image.caption[0].text;
     const isArticle = type.includes('articles');
     // in some cases we don't have contributors
-    const allContributors = contributors?.map(contributor => {
-      const { contributor: contributorNode }: Contributor = contributor;
-      const hasContributor = contributor.contributor
-        ? contributorNode?.name
-        : '';
-      return hasContributor;
-    });
+    const allContributors = contributors
+      ?.map(contributor => {
+        const { contributor: contributorNode }: Contributor = contributor;
+        const hasContributor = contributor.contributor
+          ? contributorNode?.name
+          : undefined;
+        return hasContributor;
+      })
+      .filter(isNotUndefined);
 
     return {
       id,


### PR DESCRIPTION
The old code was causing us to show information on a story with a trailing pipe, e.g. '2 November 2017 | ', because the contributor information is a defined empty string. This patch will make `contributors` undefined if there aren't any, so we don't display the trailing pipe.

Normally I'd add a test for this, but since all this GraphQL code will be tossed when we get stories from Elasticsearch, I'm not so fussed.

Closes #8973

<img width="1293" alt="Screenshot 2022-12-09 at 13 23 51" src="https://user-images.githubusercontent.com/301220/206712192-0ccfd277-48ed-42dc-b9c9-5e2e47535ec0.png">
