### PR TITLE
Handle redirects when fetching works client-side

### DIFF
--- a/catalogue/webapp/services/catalogue/works.ts
+++ b/catalogue/webapp/services/catalogue/works.ts
@@ -182,8 +182,13 @@ export async function getWorkClientSide(workId: string): Promise<WorkResponse> {
     credentials: 'same-origin',
   });
 
-  const work: WorkResponse = await response.json();
-  return work;
+  const resp = await response.json();
+
+  if (resp.type === 'Redirect') {
+    return getWorkClientSide(resp.redirectToId);
+  } else {
+    return resp;
+  }
 }
 
 export async function getWorkItemsClientSide(


### PR DESCRIPTION
This fixes a bug where the image modal will hang if the source work for an image has been redirected.

This is the issue I reported in #wc-platform-feedback on Friday afternoon, see https://wellcome.slack.com/archives/C8X9YKM5X/p1670599613843669:

> I'm not quite sure what's going on, but if I click on the first result in https://wellcomecollection.org/images?query=V0017955, I just get the loading modal

The alternative fix is to remove the `/api/works` proxy and have clients call the catalogue API directly, and get the redirect that way, but that felt like a more invasive change for a small bug.

(The even better change would be to support states for images in the pipeline (https://github.com/wellcomecollection/platform/issues/5470) – I think this occurred because a METS work got linked over that Miro image, but the original Miro image won't be flushed until the next reindex.)