### PR TITLE
Fix E2Es: Use id for tests in pagination

### DIFF
--- a/common/views/components/Pagination/Pagination.tsx
+++ b/common/views/components/Pagination/Pagination.tsx
@@ -86,7 +86,11 @@ export const Pagination: FunctionComponent<Props> = ({
   const showNext = currentPage < totalPages;
 
   return (
-    <Container aria-label={ariaLabel} isHiddenMobile={isHiddenMobile}>
+    <Container
+      id="pagination"
+      aria-label={ariaLabel}
+      isHiddenMobile={isHiddenMobile}
+    >
       {showPrev && (
         <Link
           passHref

--- a/playwright/test/works-search.test.ts
+++ b/playwright/test/works-search.test.ts
@@ -66,7 +66,7 @@ const navigateToNextPage = async (page: Page) => {
   await Promise.all([
     safeWaitForNavigation(page),
     page.click(
-      `[aria-label="pagination"]${
+      `[id="pagination"]${
         isMobile(page) ? ':not(.is-hidden-s)' : ''
       }:nth-of-type(1) a`
     ),


### PR DESCRIPTION
## Who is this for?
e2es failing

## What is it doing for them?
It was looking for `aria-label="pagination"` to navigate, but these might now differ based on which page they are in, so I added a static ID instead and am using that as a selector.