### PR TITLE
Change id to always select pagination visible on mobile too

### DIFF
--- a/common/views/components/Pagination/Pagination.tsx
+++ b/common/views/components/Pagination/Pagination.tsx
@@ -87,7 +87,7 @@ export const Pagination: FunctionComponent<Props> = ({
 
   return (
     <Container
-      id="pagination"
+      id={isHiddenMobile ? 'desktop-pagination' : 'pagination'}
       aria-label={ariaLabel}
       isHiddenMobile={isHiddenMobile}
     >

--- a/common/views/components/Pagination/Pagination.tsx
+++ b/common/views/components/Pagination/Pagination.tsx
@@ -87,7 +87,7 @@ export const Pagination: FunctionComponent<Props> = ({
 
   return (
     <Container
-      id={isHiddenMobile ? 'desktop-pagination' : 'pagination'}
+      {...(!isHiddenMobile && { 'data-test-id': 'pagination' })} // This ensures that we only target the version of component that is also visible on mobile
       aria-label={ariaLabel}
       isHiddenMobile={isHiddenMobile}
     >

--- a/content/webapp/components/LayoutPaginatedResults/LayoutPaginatedResults.tsx
+++ b/content/webapp/components/LayoutPaginatedResults/LayoutPaginatedResults.tsx
@@ -81,7 +81,7 @@ const LayoutPaginatedResults: FunctionComponent<Props> = ({
 
     {paginatedResults.totalPages > 1 && (
       <Layout12>
-        <PaginationWrapper verticalSpacing="l">
+        <PaginationWrapper verticalSpacing="l" alignRight>
           <Pagination
             totalPages={paginatedResults.totalPages}
             ariaLabel="Results pagination"

--- a/playwright/test/works-search.test.ts
+++ b/playwright/test/works-search.test.ts
@@ -65,11 +65,7 @@ const navigateToNextPage = async (page: Page) => {
   // another hack
   await Promise.all([
     safeWaitForNavigation(page),
-    page.click(
-      `[id="pagination"]${
-        isMobile(page) ? ':not(.is-hidden-s)' : ''
-      }:nth-of-type(1) a`
-    ),
+    page.click(`[id="pagination"]:nth-of-type(1) button`),
   ]);
 };
 

--- a/playwright/test/works-search.test.ts
+++ b/playwright/test/works-search.test.ts
@@ -59,13 +59,11 @@ const selectCheckbox = async (label: string, page: Page) => {
 };
 
 const navigateToNextPage = async (page: Page) => {
-  // Not a massive fan of this selector, as it isn't very user-centric,
-  // but the selector `Next (page 2)` doesn't work as it's `visually-hidden`
-  // we also use nth-of-type as the bottom navigation is the one ued on mobile
-  // another hack
+  // data-test-id is only set on Pagination components that aren't hidden on mobile
+  // in `common/views/components/Pagination/Pagination.tsx`
   await Promise.all([
     safeWaitForNavigation(page),
-    page.click(`[id="pagination"]:nth-of-type(1) button`),
+    page.click(`[data-test-id="pagination"] button`),
   ]);
 };
 


### PR DESCRIPTION
## Who is this for?
broken e2es

## What is it doing for them?
The previous PR fixed only part of the problem, we need to change the ID to match the pagination that's visible on mobile.

Also noticed a missing prop for alignment so added it in.