### PR TITLE
Only show tabbed nav on works with digitised items

### DIFF
--- a/catalogue/webapp/components/Work/Work.tsx
+++ b/catalogue/webapp/components/Work/Work.tsx
@@ -112,7 +112,6 @@ const Work: FunctionComponent<Props> = ({
   });
   const showTabbedNav =
     worksTabbedNav && (shouldShowItemLink || audio || video);
-  // end TODO pass these through to WorkDetails, no need to get again
   const imageUrl =
     iiifImageLocation && iiifImageLocation.url
       ? iiifImageTemplate(iiifImageLocation.url)({ size: `800,` })

--- a/catalogue/webapp/components/Work/Work.tsx
+++ b/catalogue/webapp/components/Work/Work.tsx
@@ -1,7 +1,14 @@
-import { Work as WorkType } from '@weco/common/model/catalogue';
+import { LinkProps } from 'next/link';
+import {
+  Work as WorkType,
+  DigitalLocation,
+} from '@weco/common/model/catalogue';
 import { useContext, FunctionComponent, ReactElement } from 'react';
 import { grid } from '@weco/common/utils/classnames';
-import { getDigitalLocationOfType } from '../../utils/works';
+import {
+  getDigitalLocationOfType,
+  getDigitalLocationInfo,
+} from '../../utils/works';
 import { removeIdiomaticTextTags } from '@weco/common/utils/string';
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
 import CataloguePageLayout from '../CataloguePageLayout/CataloguePageLayout';
@@ -19,6 +26,9 @@ import SearchContext from '@weco/common/views/components/SearchContext/SearchCon
 import IsArchiveContext from '../IsArchiveContext/IsArchiveContext';
 import WorkTabbedNav from '../WorkTabbedNav/WorkTabbedNav';
 import { useToggles } from '@weco/common/server-data/Context';
+import useTransformedManifest from '../../hooks/useTransformedManifest';
+import { toLink as itemLink } from '@weco/common/views/components/ItemLink/ItemLink';
+import { Audio, Video } from 'services/iiif/types/manifest/v3';
 
 const ArchiveDetailsContainer = styled.div`
   display: block;
@@ -44,6 +54,26 @@ export const Grid = styled.div.attrs({
   className: 'grid',
 })``;
 
+function showItemLink({
+  accessCondition,
+  itemUrl,
+  audio,
+  video,
+}: {
+  accessCondition: string | undefined;
+  itemUrl: LinkProps;
+  audio: Audio | undefined;
+  video: Video | undefined;
+}): boolean {
+  if (accessCondition === 'closed' || accessCondition === 'restricted') {
+    return false;
+  } else if (itemUrl && !((audio?.sounds || []).length > 0) && !video) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
 type Props = {
   work: WorkType;
 };
@@ -53,6 +83,7 @@ const Work: FunctionComponent<Props> = ({
 }: Props): ReactElement<Props> => {
   const { link: searchLink } = useContext(SearchContext);
   const { worksTabbedNav } = useToggles();
+  const transformedIIIFManifest = useTransformedManifest(work);
 
   const isArchive = !!(
     work.parts.length ||
@@ -60,7 +91,28 @@ const Work: FunctionComponent<Props> = ({
   );
 
   const iiifImageLocation = getDigitalLocationOfType(work, 'iiif-image');
+  const iiifPresentationLocation = getDigitalLocationOfType(
+    work,
+    'iiif-presentation'
+  );
 
+  // Determine digital location. If the work has a iiif-presentation location and a iiif-image location
+  // we use the former
+  const digitalLocation: DigitalLocation | undefined =
+    iiifPresentationLocation || iiifImageLocation;
+  const digitalLocationInfo =
+    digitalLocation && getDigitalLocationInfo(digitalLocation);
+  const itemUrl = itemLink({ workId: work.id }, 'work');
+  const { video, audio } = transformedIIIFManifest;
+  const shouldShowItemLink = showItemLink({
+    accessCondition: digitalLocationInfo?.accessCondition,
+    itemUrl,
+    audio,
+    video,
+  });
+  const showTabbedNav =
+    worksTabbedNav && (shouldShowItemLink || audio || video);
+  // end TODO pass these through to WorkDetails, no need to get again
   const imageUrl =
     iiifImageLocation && iiifImageLocation.url
       ? iiifImageTemplate(iiifImageLocation.url)({ size: `800,` })
@@ -139,7 +191,7 @@ const Work: FunctionComponent<Props> = ({
               <Grid>
                 <WorkHeader work={work} />
               </Grid>
-              {worksTabbedNav && (
+              {showTabbedNav && (
                 <WorkTabbedNav work={work} selected="catalogueDetails" />
               )}
             </Container>
@@ -149,7 +201,10 @@ const Work: FunctionComponent<Props> = ({
               <ArchiveDetailsContainer>
                 <ArchiveTree work={work} />
                 <WorkDetailsWrapper>
-                  <WorkDetails work={work} />
+                  <WorkDetails
+                    work={work}
+                    shouldShowItemLink={shouldShowItemLink}
+                  />
                 </WorkDetailsWrapper>
               </ArchiveDetailsContainer>
             </Container>
@@ -160,11 +215,11 @@ const Work: FunctionComponent<Props> = ({
               <Grid>
                 <WorkHeader work={work} />
               </Grid>
-              {worksTabbedNav && (
+              {showTabbedNav && (
                 <WorkTabbedNav work={work} selected="catalogueDetails" />
               )}
             </Container>
-            <WorkDetails work={work} />
+            <WorkDetails work={work} shouldShowItemLink={shouldShowItemLink} />
           </>
         )}
       </CataloguePageLayout>


### PR DESCRIPTION
This updates and renames the getItemLinkState function which due to #8955 only needs to return a boolean.
It also moves the logic into Work.tsx so it can also be used to wrap the tabbed nav and only show it when we have digitised items, as the 'view item' link wouldn't work. N.B. We may want to keep the 'catalogue details' tab for consistency, but if we come to that conclusion it will be an easy change.
