### PR TITLE
Display bottom pagination for works in mobile

### DIFF
--- a/catalogue/webapp/pages/works.tsx
+++ b/catalogue/webapp/pages/works.tsx
@@ -180,7 +180,6 @@ const Works: NextPage<Props> = ({ works, worksRouteProps }) => {
                     <Pagination
                       totalPages={works.totalPages}
                       ariaLabel="Catalogue search pagination"
-                      isHiddenMobile
                     />
                   </PaginationWrapper>
                 </div>

--- a/playwright/test/works-search.test.ts
+++ b/playwright/test/works-search.test.ts
@@ -63,7 +63,7 @@ const navigateToNextPage = async (page: Page) => {
   // in `common/views/components/Pagination/Pagination.tsx`
   await Promise.all([
     safeWaitForNavigation(page),
-    page.click(`[data-test-id="pagination"] button`),
+    page.click('[data-test-id="pagination"] button'),
   ]);
 };
 


### PR DESCRIPTION
## Who is this for?
devs in 🙏 fixing e2es 🙏  AND users wanting to use pagination on `/works` 😱 

## What is it doing for them?
So, YAY for tests! Both pagination components were hidden on mobile on `/works`, so we would've had zero pagination on mobile.  I've gone through everywhere other pages and they ALL now have at least one pagination component on mobile, it was only missing in this file, which is the one that was tested.

I'll add "Test more for pagination" to my January to do list. Thanks all for your patience with this one..!