### PR TITLE
Use commas when counting the number of results on a search page

### DIFF
--- a/common/utils/grammar.test.ts
+++ b/common/utils/grammar.test.ts
@@ -5,6 +5,7 @@ describe('pluralize', () => {
     { count: 1, noun: 'result', output: '1 result' },
     { count: 5, noun: 'image', output: '5 images' },
     { count: 100, noun: 'event', output: '100 events' },
+    { count: 1156915, noun: 'work', output: '1,156,915 works' },
   ])('$count × $noun is formatted as $output', ({ count, noun, output }) => {
     expect(pluralize(count, noun)).toStrictEqual(output);
   });

--- a/common/utils/grammar.test.ts
+++ b/common/utils/grammar.test.ts
@@ -1,0 +1,11 @@
+import { pluralize } from './grammar';
+
+describe('pluralize', () => {
+  test.each([
+    { count: 1, noun: 'result', output: '1 result' },
+    { count: 5, noun: 'image', output: '5 images' },
+    { count: 100, noun: 'event', output: '100 events' },
+  ])('$count × $noun is formatted as $output', ({ count, noun, output }) => {
+    expect(pluralize(count, noun)).toStrictEqual(output);
+  });
+});

--- a/common/utils/grammar.ts
+++ b/common/utils/grammar.ts
@@ -32,6 +32,13 @@ export function dasherizeShorten(words: string): string {
     .replace(/\W/g, '-');
 }
 
+/** Formats a string to describe a list of results, e.g.
+ *
+ *      1 work
+ *      5 images
+ *      100 events
+ *
+ */
 export function pluralize(count: number, noun: string, suffix = 's'): string {
   return `${count} ${noun}${count !== 1 ? suffix : ''}`;
 }

--- a/common/utils/grammar.ts
+++ b/common/utils/grammar.ts
@@ -40,7 +40,9 @@ export function dasherizeShorten(words: string): string {
  *
  */
 export function pluralize(count: number, noun: string, suffix = 's'): string {
-  return `${count} ${noun}${count !== 1 ? suffix : ''}`;
+  const format = new Intl.NumberFormat('en-GB');
+
+  return `${format.format(count)} ${noun}${count !== 1 ? suffix : ''}`;
 }
 
 export function unCamelCase(words: string): string {

--- a/common/views/components/ModalMoreFilters/ModalMoreFilters.tsx
+++ b/common/views/components/ModalMoreFilters/ModalMoreFilters.tsx
@@ -131,7 +131,7 @@ const MoreFilters: FunctionComponent<MoreFiltersProps> = ({
   changeHandler,
   filters,
   form,
-}: MoreFiltersProps) => {
+}) => {
   return (
     <>
       {filters


### PR DESCRIPTION
<table>
<tr>
<th>Before</th>
<td>1156915 results </td>
</tr>
<tr>
<th>After</th>
<td>1,156,915 results</td>
</tr>
</table>

This matches [the Wellcome style guide](https://app.gitbook.com/o/-LumfFcEMKx4gYXKAZTQ/s/18DwJCSD1tjue3OkGDPy/functional-digital-content-style-guide/wellcome-style-guide-april-2022-version) and is just a bit nicer to read imo.