### PR TITLE
Work link

### DIFF
--- a/catalogue/webapp/components/IIIFViewer/ViewerSidebar.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerSidebar.tsx
@@ -152,7 +152,7 @@ const ViewerSidebar: FunctionComponent<Props> = ({ mainViewerRef }: Props) => {
               v={{ size: 'xl', properties: ['margin-top', 'margin-bottom'] }}
             >
               <WorkLink id={work.id} source="button_back_link" passHref>
-                <WorkLinkAnchor className={`${font('intr', 5)}`}>
+                <WorkLinkAnchor className={font('intr', 5)}>
                   More about this item
                 </WorkLinkAnchor>
               </WorkLink>

--- a/catalogue/webapp/components/IIIFViewer/ViewerSidebar.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerSidebar.tsx
@@ -26,6 +26,8 @@ import IIIFSearchWithin from '../IIIFSearchWithin/IIIFSearchWithin';
 import WorkTitle from '../WorkTitle/WorkTitle';
 import { toHtmlId } from '@weco/common/utils/string';
 import { arrow, chevron } from '@weco/common/icons';
+import { WorkLinkAnchor } from './ViewerTopBar';
+import { useToggles } from '@weco/common/server-data/Context';
 
 const Inner = styled(Space).attrs({
   h: { size: 'm', properties: ['padding-left', 'padding-right'] },
@@ -121,6 +123,7 @@ type Props = {
 };
 
 const ViewerSidebar: FunctionComponent<Props> = ({ mainViewerRef }: Props) => {
+  const { itemWorkLink } = useToggles();
   const { work, transformedManifest, parentManifest, currentManifestLabel } =
     useContext(ItemViewerContext);
   const { iiifCredit, structures, searchService } = transformedManifest;
@@ -143,6 +146,20 @@ const ViewerSidebar: FunctionComponent<Props> = ({ mainViewerRef }: Props) => {
   return (
     <>
       <Inner className={font('intb', 5)}>
+        {itemWorkLink && (
+          <div className="viewer-mobile">
+            <Space
+              v={{ size: 'xl', properties: ['margin-top', 'margin-bottom'] }}
+            >
+              <WorkLink id={work.id} source="button_back_link" passHref>
+                <WorkLinkAnchor className={`${font('intr', 5)}`}>
+                  More about this item
+                </WorkLinkAnchor>
+              </WorkLink>
+            </Space>
+          </div>
+        )}
+
         {currentManifestLabel && (
           <span data-test-id="current-manifest" className={font('intr', 5)}>
             {currentManifestLabel}
@@ -195,19 +212,21 @@ const ViewerSidebar: FunctionComponent<Props> = ({ mainViewerRef }: Props) => {
           </div>
         )}
 
-        <Space v={{ size: 'm', properties: ['margin-top'] }}>
-          <WorkLink id={work.id} source="viewer_back_link">
-            <a className={`${font('intr', 5)} flex flex--v-center`}>
-              Catalogue details
-              <Space
-                h={{ size: 's', properties: ['margin-left'] }}
-                className="flex flex--v-center"
-              >
-                <Icon icon={arrow} matchText={true} iconColor="white" />
-              </Space>
-            </a>
-          </WorkLink>
-        </Space>
+        {!itemWorkLink && (
+          <Space v={{ size: 'm', properties: ['margin-top'] }}>
+            <WorkLink id={work.id} source="viewer_back_link">
+              <a className={`${font('intr', 5)} flex flex--v-center`}>
+                Catalogue details
+                <Space
+                  h={{ size: 's', properties: ['margin-left'] }}
+                  className="flex flex--v-center"
+                >
+                  <Icon icon={arrow} matchText={true} iconColor="white" />
+                </Space>
+              </a>
+            </WorkLink>
+          </Space>
+        )}
       </Inner>
       <Inner>
         <AccordionItem title="Licence and credit" testId="license-and-credit">

--- a/catalogue/webapp/components/IIIFViewer/ViewerTopBar.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerTopBar.tsx
@@ -16,6 +16,22 @@ import {
   gridView,
   singlePage,
 } from '@weco/common/icons';
+import { useToggles } from '@weco/common/server-data/Context';
+import WorkLink from '@weco/common/views/components/WorkLink/WorkLink';
+
+export const WorkLinkAnchor = styled.a`
+  line-height: 1;
+  padding: 8px 12px;
+  background: transparent;
+  color: ${props => props.theme.color('white')};
+  border: 2px solid ${props => props.theme.color('white')};
+  text-decoration: none;
+  cursor: pointer;
+  &:hover,
+  &:focus {
+    text-decoration: underline;
+  }
+`;
 
 // TODO: update this with a more considered button from our system
 export const ShameButton = styled.button.attrs(() => ({
@@ -131,17 +147,19 @@ const TopBar = styled.div<{
 
 const Sidebar = styled(Space).attrs({
   v: { size: 's', properties: ['padding-top', 'padding-bottom'] },
-  h: { size: 's', properties: ['padding-left', 'padding-right'] },
-})<{ isZooming: boolean }>`
+  h: { size: 'm', properties: ['padding-left', 'padding-right'] },
+})<{ isZooming: boolean; itemWorkLink: boolean }>`
   grid-column-start: left-edge;
   grid-column-end: desktop-sidebar-end;
   display: flex;
-  justify-content: flex-start;
+  justify-content: ${props =>
+    props.itemWorkLink ? 'space-between' : 'flex-start'};
   align-items: center;
 
-  ${props => props.theme.media('medium')`
-    justify-content: flex-end;
-  `}
+  ${props =>
+    props.theme.media('medium')(`
+    justify-content: ${props.itemWorkLink ? 'space-between' : 'flex-end'};
+  `)}
 
   ${props =>
     !props.isZooming &&
@@ -206,16 +224,26 @@ const ViewerTopBar: FunctionComponent<Props> = ({ viewerRef }: Props) => {
     isResizing,
     transformedManifest,
   } = useContext(ItemViewerContext);
+  const { itemWorkLink } = useToggles();
   const { canvases } = transformedManifest;
   return (
     <TopBar
       isZooming={showZoomed}
       isDesktopSidebarActive={isDesktopSidebarActive}
     >
-      {isEnhanced && (
-        <Sidebar isZooming={showZoomed}>
-          {!showZoomed && (
-            <>
+      <Sidebar isZooming={showZoomed} itemWorkLink={itemWorkLink}>
+        {itemWorkLink && (
+          <div className="viewer-desktop">
+            <WorkLink id={work.id} source="button_back_link" passHref>
+              <WorkLinkAnchor className={`${font('intr', 5)}`}>
+                More about this item
+              </WorkLinkAnchor>
+            </WorkLink>
+          </div>
+        )}
+        {isEnhanced && !showZoomed && (
+          <>
+            {!itemWorkLink && (
               <ShameButton
                 data-test-id="toggle-info-desktop"
                 className="viewer-desktop"
@@ -238,20 +266,20 @@ const ViewerTopBar: FunctionComponent<Props> = ({ viewerRef }: Props) => {
                   {isDesktopSidebarActive ? 'Hide info' : 'Show info'}
                 </span>
               </ShameButton>
-              <ShameButton
-                data-test-id="toggle-info-mobile"
-                className="viewer-mobile"
-                isDark
-                onClick={() => {
-                  setIsMobileSidebarActive(!isMobileSidebarActive);
-                }}
-              >
-                {isMobileSidebarActive ? 'Hide info' : 'Show info'}
-              </ShameButton>
-            </>
-          )}
-        </Sidebar>
-      )}
+            )}
+            <ShameButton
+              data-test-id="toggle-info-mobile"
+              className="viewer-mobile"
+              isDark
+              onClick={() => {
+                setIsMobileSidebarActive(!isMobileSidebarActive);
+              }}
+            >
+              {isMobileSidebarActive ? 'Hide info' : 'Show info'}
+            </ShameButton>
+          </>
+        )}
+      </Sidebar>
       <Main>
         <LeftZone className="viewer-desktop">
           {!showZoomed && canvases && canvases.length > 1 && (

--- a/catalogue/webapp/components/IIIFViewer/ViewerTopBar.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerTopBar.tsx
@@ -235,7 +235,7 @@ const ViewerTopBar: FunctionComponent<Props> = ({ viewerRef }: Props) => {
         {itemWorkLink && (
           <div className="viewer-desktop">
             <WorkLink id={work.id} source="button_back_link" passHref>
-              <WorkLinkAnchor className={`${font('intr', 5)}`}>
+              <WorkLinkAnchor className={font('intr', 5)}>
                 More about this item
               </WorkLinkAnchor>
             </WorkLink>

--- a/common/views/components/WorkLink/WorkLink.tsx
+++ b/common/views/components/WorkLink/WorkLink.tsx
@@ -7,7 +7,8 @@ type WorkLinkSource =
   | 'item_auth_modal_back_to_work_link'
   | 'archive_tree'
   | 'viewer_back_link'
-  | 'viewer_credit';
+  | 'viewer_credit'
+  | 'button_back_link';
 
 // We remove `href` and `as` because we contruct those ourselves
 // in the component.

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -73,7 +73,7 @@ const toggles = {
       id: 'itemWorkLink',
       title: 'Item page: Work page link',
       initialValue: false,
-      description: 'Repositiions and changes the style of the work page link',
+      description: 'Tries an alternative style for the link from the item page to the corresponding work',
     },
   ] as const,
   tests: [] as ABTest[],

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -69,6 +69,12 @@ const toggles = {
       description:
         'Adds tabbed navigation to the works page, for switching between work, item and related content',
     },
+    {
+      id: 'itemWorkLink',
+      title: 'Item page: Work page link',
+      initialValue: false,
+      description: 'Repositiions and changes the style of the work page link',
+    },
   ] as const,
   tests: [] as ABTest[],
 };


### PR DESCRIPTION
Relates to #8907

Implements the changes related to repositioning and restyling the catalogue link on the item page behind a toggle. The toggle will eventually be used to split traffic into one of two conditions.

<img width="735" alt="Screenshot 2022-12-16 at 13 51 25" src="https://user-images.githubusercontent.com/6051896/208127505-f77074ca-3935-4f33-83f9-084659928b77.png">

<img width="502" alt="Screenshot 2022-12-16 at 13 51 55" src="https://user-images.githubusercontent.com/6051896/208127251-32b1eefe-4075-4e44-a425-e9ce88829ae0.png">

N.B there were other styling differences in the Zeplin files, such as background colours, button styles, keylines, which I've ignored as they seem like more general changes to the viewer and not required for the A/B test.

Re the A/B test: we want to test the hypotheses that for everyone that lands on an item page, more people in condition B will click the work page link. We send the toggle data with every page view to Segment, so it's possible to determine how many people over a given period viewed an item page in each condition. We also send a source as a query parameter on the url when the link is clicked.  This is currently 'viewer_back_link' for condition A and, as requested by @taceybadgerbrook, will be 'button_back_link' for condition B. So we will be able to determine over the same period how many times the link was clicked in each condition.


