### PR TITLE
Reduce the data we fetch on the Stories landing page

### DIFF
--- a/content/webapp/components/SearchResults/SearchResults.tsx
+++ b/content/webapp/components/SearchResults/SearchResults.tsx
@@ -53,7 +53,7 @@ const SearchResults: FunctionComponent<Props> = ({
             {item.type === 'pages' && (
               <CompactCard
                 url={`/pages/${item.id}`}
-                title={item.title || ''}
+                title={item.title}
                 primaryLabels={[]}
                 secondaryLabels={[]}
                 description={item.promo?.caption || item.metadataDescription}
@@ -86,7 +86,7 @@ const SearchResults: FunctionComponent<Props> = ({
             {item.type === 'event-series' && (
               <CompactCard
                 url={`/event-series/${item.id}`}
-                title={item.title || ''}
+                title={item.title}
                 primaryLabels={item.labels}
                 secondaryLabels={[]}
                 description={item.promo && item.promo.caption}
@@ -119,7 +119,7 @@ const SearchResults: FunctionComponent<Props> = ({
             {item.type === 'books' && (
               <CompactCard
                 url={`/books/${item.id}`}
-                title={item.title || ''}
+                title={item.title}
                 primaryLabels={item.labels}
                 secondaryLabels={[]}
                 description={item.promo && item.promo.caption}
@@ -159,7 +159,7 @@ const SearchResults: FunctionComponent<Props> = ({
             {item.type === 'series' && (
               <CompactCard
                 url={`/series/${item.id}`}
-                title={item.title || ''}
+                title={item.title}
                 primaryLabels={item.labels}
                 secondaryLabels={[]}
                 description={item.promo && item.promo.caption}
@@ -191,7 +191,7 @@ const SearchResults: FunctionComponent<Props> = ({
             )}
             {item.type === 'article-schedule-items' && (
               <CompactCard
-                title={item.title || ''}
+                title={item.title}
                 partNumber={item.partNumber}
                 partNumberColor={item.color}
                 primaryLabels={

--- a/content/webapp/components/SearchResults/SearchResults.tsx
+++ b/content/webapp/components/SearchResults/SearchResults.tsx
@@ -1,4 +1,4 @@
-import { Fragment, FunctionComponent } from 'react';
+import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 import { MultiContent } from '../../types/multi-content';
 import { grid } from '@weco/common/utils/classnames';
@@ -30,7 +30,7 @@ const SearchResults: FunctionComponent<Props> = ({
   summary,
   showPosition = false,
 }) => (
-  <Fragment>
+  <>
     {title && (
       <Space
         v={!summary ? { size: 'l', properties: ['margin-bottom'] } : undefined}
@@ -247,7 +247,7 @@ const SearchResults: FunctionComponent<Props> = ({
           </Result>
         )
     )}
-  </Fragment>
+  </>
 );
 
 export default SearchResults;

--- a/content/webapp/pages/stories.tsx
+++ b/content/webapp/pages/stories.tsx
@@ -76,6 +76,9 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       predicates: storiesLandingComics
         ? prismic.predicate.not('my.articles.format', ArticleFormatIds.Comic)
         : undefined,
+      // We only display 11 articles on the stories homepage: 5 at the top of
+      // the page, then another 6 as "you might have missed".
+      pageSize: 11,
     });
 
     const storiesLandingPromise = fetchStoriesLanding(client);

--- a/content/webapp/services/prismic/transformers/series.ts
+++ b/content/webapp/services/prismic/transformers/series.ts
@@ -8,6 +8,7 @@ import { isNotUndefined } from '@weco/common/utils/array';
 import { transformContributors } from './contributors';
 import { transformTimestamp } from '@weco/common/services/prismic/transformers';
 import { getSeriesColor } from '../../../utils/colors';
+import { noAltTextBecausePromo } from './images';
 
 export function transformSeries(document: SeriesPrismicDocument): Series {
   const { data } = document;
@@ -52,14 +53,25 @@ export function transformSeries(document: SeriesPrismicDocument): Series {
 }
 
 export function transformSeriesToSeriesBasic(series: Series): SeriesBasic {
-  return (({ id, type, title, labels, color, schedule, promo, image }) => ({
+  const { id, type, title, labels, color, schedule, promo, image } = series;
+
+  return {
     id,
     type,
     title,
     labels,
     color,
     schedule,
-    promo,
-    image,
-  }))(series);
+    promo: promo && {
+      ...promo,
+      image: promo.image && {
+        ...promo.image,
+        ...noAltTextBecausePromo,
+      },
+    },
+    image: image && {
+      ...image,
+      ...noAltTextBecausePromo,
+    },
+  };
 }


### PR DESCRIPTION
This cuts the size of the initial HTML load for the Stories landing page:

<table>
<tr>
<th>Before</th>
<td>345.19 kB</td>
</tr>
<tr>
<th>After</th>
<td>289.79 kB (&minus;16%)</td>
</tr>
</table>

with two changes:

* Discard the alt text on the SeriesBasic type; we don't use it for promos
* Only fetch the 11 articles from Prismic that we're going to show, not 20.