### PR TITLE
Improvements to the breadcrumb

### DIFF
--- a/common/views/components/Breadcrumb/Breadcrumb.tsx
+++ b/common/views/components/Breadcrumb/Breadcrumb.tsx
@@ -5,25 +5,28 @@ import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 import { BreadcrumbItems } from '../../../model/breadcrumbs';
 
+const BreadcrumbWrapper = styled.div`
+  display: flex;
+`;
+
 const ItemWrapper = styled(Space).attrs({
   className: font('intr', 6),
 })``;
 
-const EmptyFiller = styled.span.attrs({
-  className: `${font('intr', 6)} empty-filler`,
-})`
-  line-height: 1;
+const Breadcrumb: FunctionComponent<BreadcrumbItems> = ({ items }) => {
+  // We prepend a 'Home' breadcrumb at the start of every chain, so every page
+  // will always have a visible breadcrumb.
+  const visibleItems = [
+    {
+      text: 'Home',
+      url: '/',
+    },
+    ...items.filter(({ isHidden }) => !isHidden),
+  ];
 
-  :before {
-    content: '\\200b';
-  }
-`;
-
-const Breadcrumb: FunctionComponent<BreadcrumbItems> = ({ items }) => (
-  <div className="flex">
-    {items
-      .filter(({ isHidden }) => !isHidden)
-      .map(({ text, url, prefix }, i) => {
+  return (
+    <BreadcrumbWrapper>
+      {visibleItems.map(({ text, url, prefix }, i) => {
         const LinkOrSpanTag = url ? 'a' : 'span';
         return (
           <ItemWrapper key={text} as={prefix ? 'b' : 'span'}>
@@ -47,16 +50,14 @@ const Breadcrumb: FunctionComponent<BreadcrumbItems> = ({ items }) => (
           </ItemWrapper>
         );
       })}
-    {/* We do this so that the page doesn't bounce around if we don't have any breadcrumbs */}
-    {items.length === 0 && <EmptyFiller />}
-    {items.length > 0 && (
+      {/* Because we always insert a 'Home' breadcrumb, we know it will be non-empty. */}
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{
           __html: JSON.stringify(breadcrumbsLd({ items })),
         }}
       />
-    )}
-  </div>
-);
+    </BreadcrumbWrapper>
+  );
+};
 export default Breadcrumb;

--- a/common/views/components/Breadcrumb/Breadcrumb.tsx
+++ b/common/views/components/Breadcrumb/Breadcrumb.tsx
@@ -34,6 +34,7 @@ const Breadcrumb: FunctionComponent<BreadcrumbItems> = ({ items }) => {
               <Space
                 as="span"
                 h={{ size: 's', properties: ['margin-left', 'margin-right'] }}
+                aria-hidden="true"
               >
                 |
               </Space>

--- a/common/views/components/PageHeader/PageHeader.tsx
+++ b/common/views/components/PageHeader/PageHeader.tsx
@@ -111,7 +111,7 @@ const PageHeader: FunctionComponent<Props> = ({
   asyncBreadcrumbsRoute,
   TitleTopper,
   sectionLevelPage,
-}: Props) => {
+}) => {
   const Heading =
     highlightHeading && !sectionLevelPage ? (
       <HighlightedHeading text={title} />

--- a/common/views/components/PageHeader/PageHeader.tsx
+++ b/common/views/components/PageHeader/PageHeader.tsx
@@ -84,7 +84,6 @@ type Props = {
   heroImageBgColor?: 'warmNeutral.300' | 'white';
   backgroundTexture?: string;
   highlightHeading?: boolean;
-  asyncBreadcrumbsRoute?: string;
   isContentTypeInfoBeforeMedia?: boolean;
   sectionLevelPage?: boolean;
   // TODO: Don't overload this, it's just for putting things in till
@@ -108,7 +107,6 @@ const PageHeader: FunctionComponent<Props> = ({
   heroImageBgColor = 'white',
   backgroundTexture,
   highlightHeading,
-  asyncBreadcrumbsRoute,
   TitleTopper,
   sectionLevelPage,
 }) => {
@@ -159,23 +157,7 @@ const PageHeader: FunctionComponent<Props> = ({
                 }}
               >
                 {breadcrumbs.items.length > 0 ? (
-                  <div
-                    data-component={
-                      asyncBreadcrumbsRoute ? 'AsyncBreadcrumb' : undefined
-                    }
-                    className={
-                      asyncBreadcrumbsRoute
-                        ? 'breadcrumb-placeholder'
-                        : undefined
-                    }
-                    data-endpoint={asyncBreadcrumbsRoute || undefined}
-                    data-prefix-endpoint={
-                      asyncBreadcrumbsRoute ? 'false' : undefined
-                    }
-                    data-modifiers={asyncBreadcrumbsRoute ? '' : undefined}
-                  >
-                    <Breadcrumb {...breadcrumbs} />
-                  </div>
+                  <Breadcrumb {...breadcrumbs} />
                 ) : (
                   <span className={`${font('intr', 5)} flex`}>&nbsp;</span>
                 )}

--- a/common/views/components/PageHeader/PageHeader.tsx
+++ b/common/views/components/PageHeader/PageHeader.tsx
@@ -156,11 +156,7 @@ const PageHeader: FunctionComponent<Props> = ({
                   overrides: { large: 4 },
                 }}
               >
-                {breadcrumbs.items.length > 0 ? (
-                  <Breadcrumb {...breadcrumbs} />
-                ) : (
-                  <span className={`${font('intr', 5)} flex`}>&nbsp;</span>
-                )}
+                <Breadcrumb {...breadcrumbs} />
               </Space>
             )}
             <ConditionalWrapper

--- a/content/webapp/components/LayoutPaginatedResults/LayoutPaginatedResults.tsx
+++ b/content/webapp/components/LayoutPaginatedResults/LayoutPaginatedResults.tsx
@@ -1,5 +1,4 @@
 import { FunctionComponent, ReactElement } from 'react';
-import * as prismicT from '@prismicio/types';
 import Layout12 from '@weco/common/views/components/Layout12/Layout12';
 import Divider from '@weco/common/views/components/Divider/Divider';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
@@ -30,7 +29,7 @@ type PaginatedResultsTypes =
 
 type Props = {
   title: string;
-  description?: prismicT.RichTextField;
+  description?: string;
   paginatedResults: PaginatedResultsTypes;
   children?: ReactElement;
 };
@@ -46,7 +45,19 @@ const LayoutPaginatedResults: FunctionComponent<Props> = ({
       breadcrumbs={{ items: [] }}
       labels={undefined}
       title={title}
-      ContentTypeInfo={description && <PrismicHtmlBlock html={description} />}
+      ContentTypeInfo={
+        description && (
+          <PrismicHtmlBlock
+            html={[
+              {
+                type: 'paragraph',
+                text: description,
+                spans: [],
+              },
+            ]}
+          />
+        )
+      }
       backgroundTexture={headerBackgroundLs}
       highlightHeading={true}
       isContentTypeInfoBeforeMedia={false}

--- a/content/webapp/pages/article-series-many.tsx
+++ b/content/webapp/pages/article-series-many.tsx
@@ -130,13 +130,7 @@ const ArticleSeriesManyPage: FunctionComponent<Props> = ({
         <SpacingSection>
           <LayoutPaginatedResults
             title={title}
-            description={[
-              {
-                type: 'paragraph',
-                text: pageDescriptions[contentType],
-                spans: [],
-              },
-            ]}
+            description={pageDescriptions[contentType]}
             paginatedResults={series}
           />
         </SpacingSection>

--- a/content/webapp/pages/articles.tsx
+++ b/content/webapp/pages/articles.tsx
@@ -75,13 +75,7 @@ const ArticlesPage: FunctionComponent<Props> = ({
       <SpacingSection>
         <LayoutPaginatedResults
           title="Stories"
-          description={[
-            {
-              type: 'paragraph',
-              text: pageDescriptions.articles,
-              spans: [],
-            },
-          ]}
+          description={pageDescriptions.articles}
           paginatedResults={articles}
         />
       </SpacingSection>

--- a/content/webapp/pages/books.tsx
+++ b/content/webapp/pages/books.tsx
@@ -68,13 +68,7 @@ const BooksPage: FunctionComponent<Props> = props => {
       <SpacingSection>
         <LayoutPaginatedResults
           title="Books"
-          description={[
-            {
-              type: 'paragraph',
-              text: pageDescriptions.books,
-              spans: [],
-            },
-          ]}
+          description={pageDescriptions.books}
           paginatedResults={books}
         />
       </SpacingSection>

--- a/content/webapp/pages/event.tsx
+++ b/content/webapp/pages/event.tsx
@@ -267,7 +267,6 @@ const EventPage: NextPage<Props> = ({ event, jsonLd }: Props) => {
 
   const Header = (
     <PageHeader
-      asyncBreadcrumbsRoute={`/events/${event.id}/scheduled-in`}
       breadcrumbs={breadcrumbs}
       labels={labels}
       title={event.title}

--- a/content/webapp/pages/events.tsx
+++ b/content/webapp/pages/events.tsx
@@ -104,13 +104,7 @@ const EventsPage: FunctionComponent<Props> = props => {
       <SpacingSection>
         <LayoutPaginatedResults
           title={title}
-          description={[
-            {
-              type: 'paragraph',
-              text: pageDescriptions.events,
-              spans: [],
-            },
-          ]}
+          description={pageDescriptions.events}
           paginatedResults={convertedPaginatedResults}
         />
         {period === 'current-and-coming-up' && (

--- a/content/webapp/pages/guides.tsx
+++ b/content/webapp/pages/guides.tsx
@@ -81,13 +81,7 @@ const GuidePage: FunctionComponent<Props> = ({
       <SpacingSection>
         <LayoutPaginatedResults
           title={displayTitle}
-          description={[
-            {
-              type: 'paragraph',
-              text: pageDescriptions.guides,
-              spans: [],
-            },
-          ]}
+          description={pageDescriptions.guides}
           paginatedResults={guides}
         >
           <Filters currentId={formatId} guideFormats={guideFormats} />

--- a/content/webapp/pages/page.tsx
+++ b/content/webapp/pages/page.tsx
@@ -236,14 +236,18 @@ export const Page: FunctionComponent<Props> = ({
   }
 
   // TODO: This is not the way to do site sections
-  const sectionItem = page.siteSection
-    ? [
-        {
-          text: getBreadcrumbText(page.siteSection),
-          url: page.siteSection ? `/${page.siteSection}` : '',
-        },
-      ]
-    : [];
+  // Note: the 'About Us' page is a bit unusual, because it's the only top-level
+  // item in the site header which shows a breadcrumb, so we need to avoid
+  // triplicating it in the breadcrumb/header/page title.
+  const sectionItem =
+    page.id !== prismicPageIds.aboutUs && page.siteSection
+      ? [
+          {
+            text: getBreadcrumbText(page.siteSection),
+            url: page.siteSection ? `/${page.siteSection}` : '',
+          },
+        ]
+      : [];
 
   const breadcrumbs = {
     items: [


### PR DESCRIPTION
For https://github.com/wellcomecollection/wellcomecollection.org/issues/8771

* We always have 'Home' as the first entry in the breadcrumb, which fixes accessibility issues around an empty div
* Screen readers will now skip the vertical lines when reading the breadcrumb
* Remove some old code that's no longer used