### PR TITLE
Try putting an empty string here, does this make borders happy?

### DIFF
--- a/common/views/components/ButtonSolid/ButtonSolid.tsx
+++ b/common/views/components/ButtonSolid/ButtonSolid.tsx
@@ -187,7 +187,7 @@ export const SolidButton = styled(BaseButton).attrs<SolidButtonProps>(
       }`;
     } else {
       return `
-        ${props.isPill && 'border-radius: 24px;'}
+        ${props.isPill ? 'border-radius: 24px;' : ''}
         border: 2px solid
         ${props.theme.color(
           props?.colors?.border || props.theme.buttonColors.default.border


### PR DESCRIPTION
I think this fixes the issues with Chromatic on main, maybe? I think we were getting an `undefined` or `null` somewhere in there, looks better now: https://www.chromatic.com/component?appId=62f13cdbd0ff140768a8d87b&csfId=components-tagsgroup&buildNumber=1861&k=63a198b2d80c3ca5a33d8a99-1200-interactive-true&h=5&b=-3