### PR TITLE
Tweak how we check for "is in final week"

### DIFF
--- a/content/webapp/components/StatusIndicator/StatusIndicator.tsx
+++ b/content/webapp/components/StatusIndicator/StatusIndicator.tsx
@@ -7,6 +7,7 @@ import {
   isFuture,
   isPast,
   isSameDay,
+  isSameDayOrBefore,
   today,
 } from '@weco/common/utils/dates';
 import { PaletteColor } from '@weco/common/views/themes/config';
@@ -24,17 +25,16 @@ export function formatDateRangeWithMessage({
   start: Date;
   end: Date;
 }): { text: string; color: PaletteColor } {
-  const sevenDaysTime = addDays(today(), 7);
+  const closesInThisWeek = isSameDayOrBefore(end, addDays(today(), 6));
 
   const opensToday = isSameDay(start, today(), 'London');
   const closesToday = isSameDay(end, today(), 'London');
-  const closesInSevenDays = today() < end && end < sevenDaysTime;
 
   if (!opensToday && isFuture(start)) {
     return { text: 'Coming soon', color: 'neutral.500' };
   } else if (!closesToday && isPast(end)) {
     return { text: 'Past', color: 'neutral.500' };
-  } else if (closesToday || closesInSevenDays) {
+  } else if (closesInThisWeek) {
     return { text: 'Final week', color: 'accent.salmon' };
   } else {
     return { text: 'Now on', color: 'validation.green' };


### PR DESCRIPTION
This makes the function behave more like we'd expect, and also fixes a flaky test.

Previously the function compared exact timestamps, e.g.

    Mo Tu We Th Fr Sa Su Mo
    ^ now
                         ^end date @ 5pm

The function would show "Final week" after we passed the time of the end date, e.g. on Monday at 4:59 it would say "Now on" and at 5:01 it would switch to "Final week".  Now it switches at midnight on Tuesday.

By doing per-day comparisons instead of looking at the exact h/m/s, we reduce the risk of a flaky test that can fail when we call `today()` a second apart, and get two slightly different timestamps.