### PR TITLE
Make sure the 'X' in the global banner is black on iOS

### DIFF
--- a/common/views/components/InfoBanner/InfoBanner.tsx
+++ b/common/views/components/InfoBanner/InfoBanner.tsx
@@ -29,6 +29,8 @@ const CloseButton = styled.button.attrs({
   margin: 0;
   padding: 0;
   cursor: pointer;
+  color: ${props =>
+    props.theme.color('black')}; // This avoids the default blue links on iOS
 `;
 
 const InfoBanner: FunctionComponent<Props> = ({


### PR DESCRIPTION
<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img src="https://user-images.githubusercontent.com/301220/210338508-0901f4d4-cb72-4257-85c4-e9e7ad8c2d55.PNG" alt="The global alert banner with a blue X">
</td>
<td>
<img src="https://user-images.githubusercontent.com/301220/210338521-bdfc92fd-c52f-4f71-ba12-f8fac28ce03b.PNG" alt="The global alert banner with a black X">
</td>
</tr>
</table>