### PR TITLE
don’t display license/credit info in download modal

### DIFF
--- a/catalogue/webapp/components/Download/Download.tsx
+++ b/catalogue/webapp/components/Download/Download.tsx
@@ -1,7 +1,6 @@
 import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
 import { DownloadOption } from '../../types/manifest';
-import { LicenseData } from '@weco/common/utils/licenses';
-import { ReactElement, useContext, useRef } from 'react';
+import { useContext, useRef } from 'react';
 import styled from 'styled-components';
 import { font, classNames } from '@weco/common/utils/classnames';
 import DownloadLink, {
@@ -38,39 +37,6 @@ function getFormatString(format: string): DownloadFormat | undefined {
     default:
       return undefined;
   }
-}
-
-export function getCredit(
-  workId: string,
-  title: string,
-  iiifImageLocationCredit: string | undefined,
-  license: LicenseData
-): ReactElement {
-  const titleCredit = title.replace(/\.$/g, '');
-
-  const linkCredit = iiifImageLocationCredit ? (
-    <>
-      Credit:{' '}
-      <a href={`https://wellcomecollection.org/works/${workId}`}>
-        {iiifImageLocationCredit}
-      </a>
-      .
-    </>
-  ) : null;
-
-  const licenseCredit: ReactElement = license.url ? (
-    <a href={license.url}>{license.label}</a>
-  ) : (
-    <>{license.label}</>
-  );
-
-  return (
-    <>
-      <div key="0">
-        {titleCredit}. {linkCredit} {licenseCredit}
-      </div>
-    </>
-  );
 }
 
 type Props = {

--- a/catalogue/webapp/components/Download/Download.tsx
+++ b/catalogue/webapp/components/Download/Download.tsx
@@ -43,8 +43,6 @@ type Props = {
   ariaControlsId: string;
   workId: string;
   downloadOptions: DownloadOption[];
-  title?: string;
-  iiifImageLocationCredit?: string;
   useDarkControl?: boolean;
   isInline?: boolean;
 };

--- a/catalogue/webapp/components/Download/Download.tsx
+++ b/catalogue/webapp/components/Download/Download.tsx
@@ -7,9 +7,7 @@ import { font, classNames } from '@weco/common/utils/classnames';
 import DownloadLink, {
   DownloadFormat,
 } from '@weco/common/views/components/DownloadLink/DownloadLink';
-import Divider from '@weco/common/views/components/Divider/Divider';
 import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
-import WorkDetailsText from '../WorkDetailsText/WorkDetailsText';
 import DropdownButton from '@weco/common/views/components/DropdownButton/DropdownButton';
 import { NextPage } from 'next';
 import PlainList from '@weco/common/views/components/styled/PlainList';
@@ -80,7 +78,6 @@ type Props = {
   workId: string;
   downloadOptions: DownloadOption[];
   title?: string;
-  license?: LicenseData;
   iiifImageLocationCredit?: string;
   useDarkControl?: boolean;
   isInline?: boolean;
@@ -88,11 +85,8 @@ type Props = {
 
 const Download: NextPage<Props> = ({
   ariaControlsId,
-  title = '',
   workId,
   downloadOptions,
-  license,
-  iiifImageLocationCredit,
   useDarkControl = false,
   isInline = false,
 }: Props) => {
@@ -150,32 +144,6 @@ const Download: NextPage<Props> = ({
                   })}
                 </PlainList>
               </SpacingComponent>
-              {license && (
-                <>
-                  <SpacingComponent>
-                    <Divider />
-                  </SpacingComponent>
-                  <SpacingComponent>
-                    <div>
-                      {license.humanReadableText && (
-                        <WorkDetailsText
-                          title="Licence information"
-                          contents={license.humanReadableText}
-                        />
-                      )}
-                      <WorkDetailsText
-                        title="Credit"
-                        contents={getCredit(
-                          workId,
-                          title,
-                          iiifImageLocationCredit,
-                          license
-                        )}
-                      />
-                    </div>
-                  </SpacingComponent>
-                </>
-              )}
             </DownloadOptions>
           </DropdownButton>
         </>

--- a/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
@@ -446,7 +446,6 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
         activeIndex,
         gridVisible,
         currentManifestLabel,
-        licenseInfo,
         iiifImageLocationCredit,
         downloadOptions: downloadEnabled ? downloadOptions : [],
         parentManifest,

--- a/catalogue/webapp/components/IIIFViewer/ViewerTopBar.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerTopBar.tsx
@@ -213,7 +213,6 @@ const ViewerTopBar: FunctionComponent<Props> = ({ viewerRef }: Props) => {
     setGridVisible,
     work,
     activeIndex,
-    licenseInfo,
     iiifImageLocationCredit,
     downloadOptions,
     setIsMobileSidebarActive,

--- a/catalogue/webapp/components/IIIFViewer/ViewerTopBar.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerTopBar.tsx
@@ -338,7 +338,6 @@ const ViewerTopBar: FunctionComponent<Props> = ({ viewerRef }: Props) => {
                     ariaControlsId="itemDownloads"
                     title={work.title}
                     workId={work.id}
-                    license={licenseInfo}
                     iiifImageLocationCredit={iiifImageLocationCredit}
                     downloadOptions={downloadOptions}
                     useDarkControl={true}

--- a/catalogue/webapp/components/IIIFViewer/ViewerTopBar.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerTopBar.tsx
@@ -335,7 +335,6 @@ const ViewerTopBar: FunctionComponent<Props> = ({ viewerRef }: Props) => {
                 <Space h={{ size: 's', properties: ['margin-right'] }}>
                   <Download
                     ariaControlsId="itemDownloads"
-                    title={work.title}
                     workId={work.id}
                     iiifImageLocationCredit={iiifImageLocationCredit}
                     downloadOptions={downloadOptions}

--- a/catalogue/webapp/components/IIIFViewer/ViewerTopBar.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerTopBar.tsx
@@ -213,7 +213,6 @@ const ViewerTopBar: FunctionComponent<Props> = ({ viewerRef }: Props) => {
     setGridVisible,
     work,
     activeIndex,
-    iiifImageLocationCredit,
     downloadOptions,
     setIsMobileSidebarActive,
     setIsDesktopSidebarActive,
@@ -336,7 +335,6 @@ const ViewerTopBar: FunctionComponent<Props> = ({ viewerRef }: Props) => {
                   <Download
                     ariaControlsId="itemDownloads"
                     workId={work.id}
-                    iiifImageLocationCredit={iiifImageLocationCredit}
                     downloadOptions={downloadOptions}
                     useDarkControl={true}
                     isInline={true}

--- a/catalogue/webapp/components/ItemViewerContext/ItemViewerContext.tsx
+++ b/catalogue/webapp/components/ItemViewerContext/ItemViewerContext.tsx
@@ -7,7 +7,6 @@ import {
   TransformedManifest,
   createDefaultTransformedManifest,
 } from '../../types/manifest';
-import { LicenseData } from '@weco/common/utils/licenses';
 import { UrlTemplate } from 'url-template';
 
 export type RotatedImage = { canvasIndex: number; rotation: number };
@@ -22,7 +21,6 @@ type Props = {
   gridVisible: boolean;
   setGridVisible: (v: boolean) => void;
   currentManifestLabel?: string;
-  licenseInfo?: LicenseData;
   iiifImageLocationCredit: string | undefined;
   downloadOptions: DownloadOption[]; // This can be downloads from a manifest or created from a iiif-image location
   parentManifest: Manifest | undefined;
@@ -100,7 +98,6 @@ const ItemViewerContext = createContext<Props>({
   canvasIndex: 0,
   gridVisible: false,
   currentManifestLabel: undefined,
-  licenseInfo: undefined,
   iiifImageLocationCredit: '',
   downloadOptions: [],
   parentManifest: undefined,

--- a/catalogue/webapp/pages/download.tsx
+++ b/catalogue/webapp/pages/download.tsx
@@ -1,17 +1,19 @@
+import { ReactElement } from 'react';
 import { Work } from '@weco/common/model/catalogue';
 import { font } from '@weco/common/utils/classnames';
 import {
   getDownloadOptionsFromImageUrl,
   getDigitalLocationOfType,
 } from '../utils/works';
-import { getCatalogueLicenseData } from '@weco/common/utils/licenses';
+import {
+  getCatalogueLicenseData,
+  LicenseData,
+} from '@weco/common/utils/licenses';
 import { TransformedManifest } from '../types/manifest';
 import { getWork } from '../services/catalogue/works';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import Layout8 from '@weco/common/views/components/Layout8/Layout8';
-import Download, {
-  getCredit,
-} from '@weco/catalogue/components/Download/Download';
+import Download from '@weco/catalogue/components/Download/Download';
 import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
 import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
 import Space from '@weco/common/views/components/styled/Space';
@@ -23,6 +25,39 @@ import { getServerData } from '@weco/common/server-data';
 import { looksLikeCanonicalId } from 'services/catalogue';
 import { fetchIIIFPresentationManifest } from '../services/iiif/fetch/manifest';
 import { transformManifest } from '../services/iiif/transformers/manifest';
+
+function getCredit(
+  workId: string,
+  title: string,
+  iiifImageLocationCredit: string | undefined,
+  license: LicenseData
+): ReactElement {
+  const titleCredit = title.replace(/\.$/g, '');
+
+  const linkCredit = iiifImageLocationCredit ? (
+    <>
+      Credit:{' '}
+      <a href={`https://wellcomecollection.org/works/${workId}`}>
+        {iiifImageLocationCredit}
+      </a>
+      .
+    </>
+  ) : null;
+
+  const licenseCredit: ReactElement = license.url ? (
+    <a href={license.url}>{license.label}</a>
+  ) : (
+    <>{license.label}</>
+  );
+
+  return (
+    <>
+      <div key="0">
+        {titleCredit}. {linkCredit} {licenseCredit}
+      </div>
+    </>
+  );
+}
 
 type Props = {
   workId: string;

--- a/catalogue/webapp/pages/download.tsx
+++ b/catalogue/webapp/pages/download.tsx
@@ -51,11 +51,9 @@ function getCredit(
   );
 
   return (
-    <>
-      <div key="0">
-        {titleCredit}. {linkCredit} {licenseCredit}
-      </div>
-    </>
+    <div key="0">
+      {titleCredit}. {linkCredit} {licenseCredit}
+    </div>
   );
 }
 


### PR DESCRIPTION
Relates to #8907

Removes the license and credit information from the Downloads modal, [as discussed in 8907](https://github.com/wellcomecollection/wellcomecollection.org/issues/8907#issuecomment-1369662239)

Before:
![Screenshot 2023-01-03 at 11 59 18](https://user-images.githubusercontent.com/6051896/210353530-1709d008-314a-4f77-ba9b-1d6349e6e0fc.png)

After:
![Screenshot 2023-01-03 at 11 58 50](https://user-images.githubusercontent.com/6051896/210353586-af979268-aeb8-4b61-be6e-164ef65a1082.png)

