### PR TITLE
Consolidate some uses of <div className="grid">

### DIFF
--- a/catalogue/webapp/components/SearchNoResults/SearchNoResults.tsx
+++ b/catalogue/webapp/components/SearchNoResults/SearchNoResults.tsx
@@ -1,8 +1,9 @@
 import Space from '@weco/common/views/components/styled/Space';
-import { font, grid } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import styled from 'styled-components';
 import { FunctionComponent } from 'react';
 import { PaletteColor } from '@weco/common/views/themes/config';
+import Layout from '@weco/common/views/components/Layout/Layout';
 
 type Props = {
   query: string;
@@ -28,19 +29,15 @@ const SearchNoResults: FunctionComponent<Props> = ({
 }: Props) => {
   return (
     <Space v={{ size: 'xl', properties: ['padding-top', 'padding-bottom'] }}>
-      <div className="container">
-        <div className="grid">
-          <div className={grid({ s: 12, m: 10, l: 8, xl: 8 })}>
-            <Copy textColor={textColor}>
-              We couldn&rsquo;t find anything that matched{' '}
-              <QuerySpan>{query}</QuerySpan>
-              {hasFilters && (
-                <> with the filters you have selected. Please try again.</>
-              )}
-            </Copy>
-          </div>
-        </div>
-      </div>
+      <Layout gridSizes={{ s: 12, m: 10, l: 8, xl: 8 }}>
+        <Copy textColor={textColor}>
+          We couldn&rsquo;t find anything that matched{' '}
+          <QuerySpan>{query}</QuerySpan>
+          {hasFilters && (
+            <> with the filters you have selected. Please try again.</>
+          )}
+        </Copy>
+      </Layout>
     </Space>
   );
 };

--- a/catalogue/webapp/components/SearchTitle/SearchTitle.tsx
+++ b/catalogue/webapp/components/SearchTitle/SearchTitle.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, ReactElement } from 'react';
+import { FunctionComponent } from 'react';
 import { grid, classNames } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 import { gridSize12 } from '@weco/common/views/components/Layout12/Layout12';
@@ -7,9 +7,7 @@ type Props = {
   isVisuallyHidden: boolean;
 };
 
-const SearchTitle: FunctionComponent<Props> = ({
-  isVisuallyHidden,
-}): ReactElement => {
+const SearchTitle: FunctionComponent<Props> = ({ isVisuallyHidden }) => {
   return (
     <div
       className={classNames({

--- a/catalogue/webapp/components/SearchTitle/SearchTitle.tsx
+++ b/catalogue/webapp/components/SearchTitle/SearchTitle.tsx
@@ -1,6 +1,7 @@
 import { FunctionComponent, ReactElement } from 'react';
 import { grid, classNames } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
+import { gridSize12 } from '@weco/common/views/components/Layout12/Layout12';
 
 type Props = {
   isVisuallyHidden: boolean;
@@ -16,7 +17,7 @@ const SearchTitle: FunctionComponent<Props> = ({
         'visually-hidden': isVisuallyHidden,
       })}
     >
-      <div className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>
+      <div className={grid(gridSize12)}>
         <Space
           v={{
             size: 'm',

--- a/catalogue/webapp/components/Work/Work.tsx
+++ b/catalogue/webapp/components/Work/Work.tsx
@@ -2,7 +2,7 @@ import {
   Work as WorkType,
   DigitalLocation,
 } from '@weco/common/model/catalogue';
-import { useContext, FunctionComponent, ReactElement } from 'react';
+import { useContext, FunctionComponent } from 'react';
 import { grid } from '@weco/common/utils/classnames';
 import {
   getDigitalLocationOfType,
@@ -77,9 +77,7 @@ type Props = {
   work: WorkType;
 };
 
-const Work: FunctionComponent<Props> = ({
-  work,
-}: Props): ReactElement<Props> => {
+const Work: FunctionComponent<Props> = ({ work }) => {
   const { link: searchLink } = useContext(SearchContext);
   const { worksTabbedNav } = useToggles();
   const transformedIIIFManifest = useTransformedManifest(work);

--- a/catalogue/webapp/components/Work/Work.tsx
+++ b/catalogue/webapp/components/Work/Work.tsx
@@ -27,6 +27,7 @@ import WorkTabbedNav from '../WorkTabbedNav/WorkTabbedNav';
 import { useToggles } from '@weco/common/server-data/Context';
 import useTransformedManifest from '../../hooks/useTransformedManifest';
 import { Audio, Video } from 'services/iiif/types/manifest/v3';
+import { gridSize12 } from '@weco/common/views/components/Layout12/Layout12';
 
 const ArchiveDetailsContainer = styled.div`
   display: block;
@@ -143,7 +144,7 @@ const Work: FunctionComponent<Props> = ({
       >
         <Container>
           <Grid>
-            <div className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>
+            <div className={grid(gridSize12)}>
               <Space v={{ size: 'l', properties: ['margin-top'] }}>
                 <SearchTabs
                   query={searchLink.as.query?.query?.toString() || ''}

--- a/catalogue/webapp/pages/images.tsx
+++ b/catalogue/webapp/pages/images.tsx
@@ -17,8 +17,8 @@ import {
 } from '@weco/common/views/components/ImagesLink/ImagesLink';
 import SearchContext from '@weco/common/views/components/SearchContext/SearchContext';
 import PaginationWrapper from '@weco/common/views/components/styled/PaginationWrapper';
+import Grid from '@weco/common/views/components/styled/Grid';
 
-import { grid } from '@weco/common/utils/classnames';
 import convertUrlToString from '@weco/common/utils/convert-url-to-string';
 import { getImages } from '@weco/catalogue/services/catalogue/images';
 import { imagesFilters } from '@weco/common/services/catalogue/filters';
@@ -115,23 +115,21 @@ const Images: NextPage<Props> = ({
           <div className="container">
             <SearchTitle isVisuallyHidden={Boolean(images)} />
 
-            <div className="grid">
-              <div className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>
-                <Space v={{ size: 'l', properties: ['margin-top'] }}>
-                  <SearchTabs
-                    query={imagesRouteProps.query}
-                    sort={undefined}
-                    sortOrder={undefined}
-                    shouldShowDescription={query === ''}
-                    activeTabIndex={1}
-                    shouldShowFilters={true}
-                    showSortBy={Boolean(images)}
-                    imagesFilters={filters}
-                    worksFilters={[]}
-                  />
-                </Space>
-              </div>
-            </div>
+            <Grid sizes={{ s: 12, m: 12, l: 12, xl: 12 }}>
+              <Space v={{ size: 'l', properties: ['margin-top'] }}>
+                <SearchTabs
+                  query={imagesRouteProps.query}
+                  sort={undefined}
+                  sortOrder={undefined}
+                  shouldShowDescription={query === ''}
+                  activeTabIndex={1}
+                  shouldShowFilters={true}
+                  showSortBy={Boolean(images)}
+                  imagesFilters={filters}
+                  worksFilters={[]}
+                />
+              </Space>
+            </Grid>
           </div>
         </Space>
 
@@ -189,7 +187,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     /**
      * This is here due to the noscript colour element
      * the value provided by the native element will
-     * include the # symbol.
+     * include the # symbol.
      */
     if (params.color) {
       params.color = params.color.replace('#', '');

--- a/catalogue/webapp/pages/works.tsx
+++ b/catalogue/webapp/pages/works.tsx
@@ -5,7 +5,6 @@ import Head from 'next/head';
 import styled from 'styled-components';
 import { getCookie } from 'cookies-next';
 
-import { grid } from '@weco/common/utils/classnames';
 import convertUrlToString from '@weco/common/utils/convert-url-to-string';
 import CataloguePageLayout from '@weco/catalogue/components/CataloguePageLayout/CataloguePageLayout';
 import Space from '@weco/common/views/components/styled/Space';
@@ -30,6 +29,7 @@ import { CatalogueResultsList, Work } from '@weco/common/model/catalogue';
 import { pageDescriptions } from '@weco/common/data/microcopy';
 import Pagination from '@weco/common/views/components/Pagination/Pagination';
 import { pluralize } from '@weco/common/utils/grammar';
+import Grid from '@weco/common/views/components/styled/Grid';
 
 type Props = {
   works: CatalogueResultsList<Work>;
@@ -131,22 +131,20 @@ const Works: NextPage<Props> = ({ works, worksRouteProps }) => {
             have Google use it as the link text in sitelinks
             https://github.com/wellcomecollection/wellcomecollection.org/issues/7297 */}
             <SearchTitle isVisuallyHidden={Boolean(works) && !isWorksLanding} />
-            <div className="grid">
-              <div className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>
-                <Space v={{ size: 'l', properties: ['margin-top'] }}>
-                  <SearchTabs
-                    query={worksRouteProps.query}
-                    sort={worksRouteProps.sort}
-                    sortOrder={worksRouteProps.sortOrder}
-                    worksFilters={filters}
-                    imagesFilters={[]}
-                    shouldShowDescription={query === ''}
-                    shouldShowFilters={true}
-                    showSortBy={Boolean(works)}
-                  />
-                </Space>
-              </div>
-            </div>
+            <Grid sizes={{ s: 12, m: 12, l: 12, xl: 12 }}>
+              <Space v={{ size: 'l', properties: ['margin-top'] }}>
+                <SearchTabs
+                  query={worksRouteProps.query}
+                  sort={worksRouteProps.sort}
+                  sortOrder={worksRouteProps.sortOrder}
+                  worksFilters={filters}
+                  imagesFilters={[]}
+                  shouldShowDescription={query === ''}
+                  shouldShowFilters={true}
+                  showSortBy={Boolean(works)}
+                />
+              </Space>
+            </Grid>
           </div>
         </Space>
 

--- a/common/views/components/InfoBanner/InfoBanner.tsx
+++ b/common/views/components/InfoBanner/InfoBanner.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent, useEffect, useState } from 'react';
 import cookies from '@weco/common/data/cookies';
 import { getCookie, setCookie } from 'cookies-next';
-import { grid, font } from '../../../utils/classnames';
+import { font } from '../../../utils/classnames';
 import Icon from '../Icon/Icon';
 import PrismicHtmlBlock from '../PrismicHtmlBlock/PrismicHtmlBlock';
 import Space from '../styled/Space';
@@ -10,6 +10,7 @@ import { cross, information } from '../../../icons';
 import { GlobalAlertPrismicDocument } from '../../../services/prismic/documents';
 import { InferDataInterface } from '../../../services/prismic/types';
 import styled from 'styled-components';
+import Layout12 from '../Layout12/Layout12';
 
 type Props = {
   cookieName: string;
@@ -76,40 +77,33 @@ const InfoBanner: FunctionComponent<Props> = ({
 
   return isVisible ? (
     <BannerContainer role="region" aria-labelledby="note" id="notification">
-      <div className="container">
-        <div className="grid">
-          <div className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>
-            <div className={`flex flex--h-space-between ${font('intr', 5)}`}>
-              <div>
-                <span className="flex">
-                  <Space
-                    h={{ size: 'm', properties: ['margin-right'] }}
-                    v={{ size: 'xs', properties: ['margin-top'] }}
-                    className="flex"
-                  >
-                    <Icon icon={information} />
-                    <span className="visually-hidden" id="note">
-                      Notification
-                    </span>
-                  </Space>
-                  <div className="body-text spaced-text">
-                    <PrismicHtmlBlock html={text} />
-                  </div>
+      <Layout12>
+        <div className={`flex flex--h-space-between ${font('intr', 5)}`}>
+          <div>
+            <span className="flex">
+              <Space
+                h={{ size: 'm', properties: ['margin-right'] }}
+                v={{ size: 'xs', properties: ['margin-top'] }}
+                className="flex"
+              >
+                <Icon icon={information} />
+                <span className="visually-hidden" id="note">
+                  Notification
                 </span>
-              </div>
-              <Space v={{ size: 'xs', properties: ['margin-top'] }}>
-                <CloseButton
-                  onClick={hideInfoBanner}
-                  aria-controls="notification"
-                >
-                  <Icon icon={cross} title="Close notification" />
-                  <span className="visually-hidden">close notification</span>
-                </CloseButton>
               </Space>
-            </div>
+              <div className="body-text spaced-text">
+                <PrismicHtmlBlock html={text} />
+              </div>
+            </span>
           </div>
+          <Space v={{ size: 'xs', properties: ['margin-top'] }}>
+            <CloseButton onClick={hideInfoBanner} aria-controls="notification">
+              <Icon icon={cross} title="Close notification" />
+              <span className="visually-hidden">close notification</span>
+            </CloseButton>
+          </Space>
         </div>
-      </div>
+      </Layout12>
     </BannerContainer>
   ) : null;
 };

--- a/common/views/components/Label/Label.tsx
+++ b/common/views/components/Label/Label.tsx
@@ -35,7 +35,7 @@ export type Props = {
 const Label: FunctionComponent<Props> = ({
   label,
   defaultLabelColor = 'yellow',
-}: Props) => {
+}) => {
   return (
     <LabelContainer
       v={{

--- a/common/views/components/LabelsList/LabelsList.tsx
+++ b/common/views/components/LabelsList/LabelsList.tsx
@@ -36,7 +36,7 @@ export type Props = {
 const LabelsList: FunctionComponent<Props> = ({
   labels,
   defaultLabelColor = 'yellow',
-}: Props) => (
+}) => (
   <List as="ul">
     {labels.filter(Boolean).map((label, i) => (
       <ListItem as="li" key={`${label.text}-${i}`}>

--- a/common/views/components/Layout/Layout.tsx
+++ b/common/views/components/Layout/Layout.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, FunctionComponent } from 'react';
-import { grid, SizeMap } from '../../../utils/classnames';
+import { SizeMap } from '../../../utils/classnames';
+import Grid from '../styled/Grid';
 
 type Props = {
   gridSizes: SizeMap;
@@ -8,9 +9,7 @@ type Props = {
 
 const Layout: FunctionComponent<Props> = ({ gridSizes, children }: Props) => (
   <div className="container">
-    <div className="grid">
-      <div className={grid(gridSizes)}>{children}</div>
-    </div>
+    <Grid sizes={gridSizes}>{children}</Grid>
   </div>
 );
 export default Layout;

--- a/common/views/components/SectionHeader/SectionHeader.tsx
+++ b/common/views/components/SectionHeader/SectionHeader.tsx
@@ -1,7 +1,8 @@
 import { FunctionComponent } from 'react';
-import { grid, font } from '../../../utils/classnames';
+import { font } from '../../../utils/classnames';
 import Space from '../styled/Space';
 import styled from 'styled-components';
+import Layout12 from '../Layout12/Layout12';
 
 const YellowBox = styled.div`
   display: inline-block;
@@ -38,16 +39,12 @@ type Props = {
 const SectionHeader: FunctionComponent<Props> = ({ title }) => {
   return (
     <div className={`row ${font('wb', 2)}`}>
-      <div className="container">
-        <div className="grid">
-          <div className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>
-            <YellowBox />
-            <TitleWrapper as="h2">
-              <Title>{title}</Title>
-            </TitleWrapper>
-          </div>
-        </div>
-      </div>
+      <Layout12>
+        <YellowBox />
+        <TitleWrapper as="h2">
+          <Title>{title}</Title>
+        </TitleWrapper>
+      </Layout12>
     </div>
   );
 };

--- a/common/views/components/WobblyRow/WobblyRow.tsx
+++ b/common/views/components/WobblyRow/WobblyRow.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { grid } from '../../../utils/classnames';
 import WobblyEdge from '../WobblyEdge/WobblyEdge';
 import { repeatingLsBlack } from '../../../utils/backgrounds';
+import { gridSize12 } from '../Layout12/Layout12';
 
 type Props = {
   children: ReactNode;
@@ -33,7 +34,7 @@ const WobblyRow: FunctionComponent<Props> = ({ children }: Props) => (
     <div className="container">
       <div className="grid" style={{ marginTop: '50px' }}>
         <div
-          className={grid({ s: 12, m: 12, l: 12, xl: 12 })}
+          className={grid(gridSize12)}
           style={{ marginTop: '-50px', position: 'relative' }}
         >
           {children}

--- a/common/views/components/styled/Grid.tsx
+++ b/common/views/components/styled/Grid.tsx
@@ -1,0 +1,15 @@
+import { FunctionComponent, ReactNode } from 'react';
+import { grid, SizeMap } from '../../../utils/classnames';
+
+type GridProps = {
+  sizes: SizeMap;
+  children: ReactNode;
+};
+
+const Grid: FunctionComponent<GridProps> = ({ sizes, children }) => (
+  <div className="grid">
+    <div className={grid(sizes)}>{children}</div>
+  </div>
+);
+
+export default Grid;

--- a/content/webapp/components/Contributors/Contributor.tsx
+++ b/content/webapp/components/Contributors/Contributor.tsx
@@ -7,6 +7,7 @@ import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/Pri
 import Space from '@weco/common/views/components/styled/Space';
 import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImage';
 import { getCrop } from '@weco/common/model/image';
+import { gridSize12 } from '@weco/common/views/components/Layout12/Layout12';
 
 const ContributorInfoWrapper = styled(Space)`
   color: ${props => props.theme.color('neutral.600')};
@@ -34,7 +35,7 @@ const Contributor: FunctionComponent<ContributorType> = ({
 
   return (
     <div className="grid">
-      <div className={`flex ${grid({ s: 12, m: 12, l: 12, xl: 12 })}`}>
+      <div className={`flex ${grid(gridSize12)}`}>
         <Space
           style={{ minWidth: '78px' }}
           h={{ size: 'm', properties: ['margin-right'] }}

--- a/content/webapp/components/Contributors/Contributor.tsx
+++ b/content/webapp/components/Contributors/Contributor.tsx
@@ -22,7 +22,7 @@ const Contributor: FunctionComponent<ContributorType> = ({
   contributor,
   role,
   description,
-}: ContributorType) => {
+}) => {
   const descriptionToRender = description || contributor.description;
 
   // Contributor images should always be square.

--- a/content/webapp/components/MediaObject/MediaObject.tsx
+++ b/content/webapp/components/MediaObject/MediaObject.tsx
@@ -8,6 +8,7 @@ import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/Pri
 import styled from 'styled-components';
 import { grid, font } from '@weco/common/utils/classnames';
 import * as prismicT from '@prismicio/types';
+import { gridSize12 } from '@weco/common/views/components/Layout12/Layout12';
 
 export type Props = {
   title: string;
@@ -19,29 +20,17 @@ type ImageWrapperProp = {
   hasImage: boolean;
 };
 
-const grid12 = grid({ s: 12, m: 12, l: 12, xl: 12 });
+const ImageWrapper = styled.div.attrs<ImageWrapperProp>(props => ({
+  className: props.hasImage
+    ? grid({ s: 2, m: 2, l: 2, xl: 2 })
+    : grid(gridSize12),
+}))<ImageWrapperProp>``;
 
-const ImageWrapper = styled.div.attrs<ImageWrapperProp>(props => {
-  if (props.hasImage) {
-    return {
-      className: grid({ s: 2, m: 2, l: 2, xl: 2 }),
-    };
-  }
-  return {
-    className: grid12,
-  };
-})<ImageWrapperProp>``;
-
-const TextWrapper = styled.div.attrs<HasImageProps>(props => {
-  if (props.hasImage) {
-    return {
-      className: grid({ s: 10, m: 10, l: 10, xl: 10 }),
-    };
-  }
-  return {
-    className: grid12,
-  };
-})<HasImageProps>``;
+const TextWrapper = styled.div.attrs<HasImageProps>(props => ({
+  className: props.hasImage
+    ? grid({ s: 10, m: 10, l: 10, xl: 10 })
+    : grid(gridSize12),
+}))<HasImageProps>``;
 
 const TitleWrapper = styled.div.attrs({
   className: `card-link__title ${font('wb', 4)}`,

--- a/content/webapp/components/MediaObject/MediaObject.tsx
+++ b/content/webapp/components/MediaObject/MediaObject.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, ReactElement } from 'react';
+import { FunctionComponent } from 'react';
 import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImage';
 import MediaObjectBase, {
   HasImageProps,
@@ -40,7 +40,7 @@ export const MediaObject: FunctionComponent<Props> = ({
   title,
   text,
   image,
-}: Props): ReactElement<Props> => {
+}) => {
   const squareImage = getCrop(image, 'square');
   const ImageComponent = squareImage && (
     <PrismicImage

--- a/content/webapp/components/MediaObjectBase/MediaObjectBase.test.tsx
+++ b/content/webapp/components/MediaObjectBase/MediaObjectBase.test.tsx
@@ -24,27 +24,13 @@ const grid9 = grid({ s: 9, m: 9, l: 9, xl: 9 });
 const grid10 = grid({ s: 10, m: 10, l: 10, xl: 10 });
 const grid12 = grid({ s: 12, m: 12, l: 12, xl: 12 });
 
-const ImageWrapper = styled.div.attrs<HasImageProps>(props => {
-  if (props.hasImage) {
-    return {
-      className: grid2,
-    };
-  }
-  return {
-    className: grid12,
-  };
-})<HasImageProps>``;
+const ImageWrapper = styled.div.attrs<HasImageProps>(props => ({
+  className: props.hasImage ? grid2 : grid12,
+}))<HasImageProps>``;
 
-const TextWrapper = styled.div.attrs<HasImageProps>(props => {
-  if (props.hasImage) {
-    return {
-      className: grid10,
-    };
-  }
-  return {
-    className: grid12,
-  };
-})<HasImageProps>``;
+const TextWrapper = styled.div.attrs<HasImageProps>(props => ({
+  className: props.hasImage ? grid10 : grid12,
+}))<HasImageProps>``;
 
 const TitleWrapper = styled.div.attrs({
   className: `card-link__title ${font('wb', 4)}`,

--- a/content/webapp/components/MediaObjectBase/MediaObjectBase.tsx
+++ b/content/webapp/components/MediaObjectBase/MediaObjectBase.tsx
@@ -96,7 +96,7 @@ const MediaObjectBase: FunctionComponent<Props> = ({
   OverrideTitleWrapper,
   onClick,
   postTitleChildren,
-}: Props): ReactElement<Props> => {
+}) => {
   const { x, y } = xOfY || {};
   const ImageWrapper = OverrideImageWrapper || BaseImageWrapper;
   const TextWrapper = OverrideTextWrapper || BaseTextWrapper;

--- a/content/webapp/components/MediaObjectBase/MediaObjectBase.tsx
+++ b/content/webapp/components/MediaObjectBase/MediaObjectBase.tsx
@@ -18,6 +18,7 @@ import Space, {
 } from '@weco/common/views/components/styled/Space';
 import { Label } from '@weco/common/model/labels';
 import styled from 'styled-components';
+import { gridSize12 } from '@weco/common/views/components/Layout12/Layout12';
 
 type Props = {
   url?: string;
@@ -60,16 +61,11 @@ export type HasImageProps = {
 };
 
 // Ability to add custom prop types in TS and styled components
-const BaseTextWrapper = styled.div.attrs<HasImageProps>(props => {
-  if (props.hasImage) {
-    return {
-      className: grid({ s: 9, m: 9, l: 9, xl: 9 }),
-    };
-  }
-  return {
-    className: grid({ s: 12, m: 12, l: 12, xl: 12 }),
-  };
-})<HasImageProps>``;
+const BaseTextWrapper = styled.div.attrs<HasImageProps>(props => ({
+  className: props.hasImage
+    ? grid({ s: 9, m: 9, l: 9, xl: 9 })
+    : grid(gridSize12),
+}))<HasImageProps>``;
 
 type LinkOrDivSpaceAttrs = {
   url?: string;

--- a/content/webapp/components/MediaObjectList/MediaObjectList.tsx
+++ b/content/webapp/components/MediaObjectList/MediaObjectList.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, ReactElement } from 'react';
+import { FunctionComponent } from 'react';
 import MediaObject, {
   Props as MediaObjectProps,
 } from '../MediaObject/MediaObject';
@@ -7,16 +7,12 @@ export type Props = {
   items: MediaObjectProps[];
 };
 
-const MediaObjectList: FunctionComponent<Props> = ({
-  items,
-}: Props): ReactElement<Props> => {
-  return (
-    <div className="body-text">
-      {items.map((mediaObject, index) => {
-        return <MediaObject {...mediaObject} key={index} />;
-      })}
-    </div>
-  );
-};
+const MediaObjectList: FunctionComponent<Props> = ({ items }) => (
+  <div className="body-text">
+    {items.map((mediaObject, index) => {
+      return <MediaObject {...mediaObject} key={index} />;
+    })}
+  </div>
+);
 
 export default MediaObjectList;

--- a/content/webapp/components/SearchResults/AsyncSearchResults.tsx
+++ b/content/webapp/components/SearchResults/AsyncSearchResults.tsx
@@ -1,9 +1,9 @@
 import { Component, Fragment, ReactElement } from 'react';
 import SearchResults from './SearchResults';
-import { grid } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 import { fetchMultiContentClientSide } from '../../services/prismic/fetch/multi-content';
 import { MultiContent } from '../../types/multi-content';
+import Grid from '@weco/common/views/components/styled/Grid';
 
 export type Props = {
   title?: string;
@@ -29,11 +29,9 @@ class AsyncSearchResults extends Component<Props, State> {
       <Fragment>
         {this.props.title && (
           <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
-            <div className="grid">
-              <div className={grid({ s: 12 })}>
-                <h2 className="h2 no-margin">{this.props.title}</h2>
-              </div>
-            </div>
+            <Grid sizes={{ s: 12 }}>
+              <h2 className="h2 no-margin">{this.props.title}</h2>
+            </Grid>
           </Space>
         )}
 

--- a/content/webapp/components/SearchResults/SearchResults.tsx
+++ b/content/webapp/components/SearchResults/SearchResults.tsx
@@ -1,7 +1,6 @@
 import { Fragment, FunctionComponent } from 'react';
 import styled from 'styled-components';
 import { MultiContent } from '../../types/multi-content';
-import { grid } from '@weco/common/utils/classnames';
 import { formatDate } from '@weco/common/utils/format-date';
 import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImage';
 import CompactCard from '../CompactCard/CompactCard';
@@ -12,6 +11,7 @@ import ArticleCard from '../ArticleCard/ArticleCard';
 import { ArticleScheduleItem } from '../../types/article-schedule-items';
 import { getCrop } from '@weco/common/model/image';
 import { Card } from '../../types/card';
+import Grid from '@weco/common/views/components/styled/Grid';
 
 const Result = styled.div`
   border-top: 1px solid ${props => props.theme.color('warmNeutral.400')};
@@ -35,11 +35,9 @@ const SearchResults: FunctionComponent<Props> = ({
       <Space
         v={!summary ? { size: 'l', properties: ['margin-bottom'] } : undefined}
       >
-        <div className="grid">
-          <div className={grid({ s: 12 })}>
-            <h2 className="h2">{title}</h2>
-          </div>
-        </div>
+        <Grid sizes={{ s: 12 }}>
+          <h2 className="h2">{title}</h2>
+        </Grid>
       </Space>
     )}
     {summary && (
@@ -67,6 +65,7 @@ const SearchResults: FunctionComponent<Props> = ({
                         // title of the item in the list.
                         //
                         // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
+                        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                         ...getCrop(item.image, 'square')!,
                         alt: '',
                       }}
@@ -100,6 +99,7 @@ const SearchResults: FunctionComponent<Props> = ({
                         // title of the item in the list.
                         //
                         // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
+                        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                         ...getCrop(item.image, 'square')!,
                         alt: '',
                       }}
@@ -133,6 +133,7 @@ const SearchResults: FunctionComponent<Props> = ({
                         // title of the item in the list.
                         //
                         // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
+                        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                         ...getCrop(item.cover, 'square')!,
                         alt: '',
                       }}
@@ -173,6 +174,7 @@ const SearchResults: FunctionComponent<Props> = ({
                         // title of the item in the list.
                         //
                         // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
+                        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                         ...getCrop(item.image, 'square')!,
                         alt: '',
                       }}
@@ -228,6 +230,7 @@ const SearchResults: FunctionComponent<Props> = ({
                         // title of the item in the list.
                         //
                         // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
+                        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                         ...getCrop(item.promo?.image, 'square')!,
                         alt: '',
                       }}

--- a/content/webapp/pages/newsletter.tsx
+++ b/content/webapp/pages/newsletter.tsx
@@ -2,7 +2,6 @@ import { FunctionComponent } from 'react';
 import NewsletterSignup from '../components/NewsletterSignup/NewsletterSignup';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
-import { grid } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 import { GetServerSideProps } from 'next';
 import { AppErrorProps } from '@weco/common/services/app';
@@ -10,6 +9,7 @@ import { removeUndefinedProps } from '@weco/common/utils/json';
 import { getServerData } from '@weco/common/server-data';
 import { newsletterDescription } from '@weco/common/data/microcopy';
 import { landingHeaderBackgroundLs } from '@weco/common/utils/backgrounds';
+import Layout8 from '@weco/common/views/components/Layout8/Layout8';
 
 type Props = {
   result?: string;
@@ -61,27 +61,13 @@ const Newsletter: FunctionComponent<Props> = ({ result }) => {
           }}
           className="row"
         >
-          <div className="container">
-            <div className="grid">
-              <div
-                className={grid({
-                  s: 12,
-                  m: 10,
-                  shiftM: 1,
-                  l: 8,
-                  shiftL: 2,
-                  xl: 8,
-                  shiftXL: 2,
-                })}
-              >
-                <NewsletterSignup
-                  isSuccess={result === 'success'}
-                  isError={result === 'error'}
-                  isConfirmed={result === 'confirmed'}
-                />
-              </div>
-            </div>
-          </div>
+          <Layout8>
+            <NewsletterSignup
+              isSuccess={result === 'success'}
+              isError={result === 'error'}
+              isConfirmed={result === 'confirmed'}
+            />
+          </Layout8>
         </Space>
       </Space>
     </PageLayout>

--- a/content/webapp/pages/whats-on.tsx
+++ b/content/webapp/pages/whats-on.tsx
@@ -25,7 +25,9 @@ import EventsByMonth from '../components/EventsByMonth/EventsByMonth';
 import SectionHeader from '@weco/common/views/components/SectionHeader/SectionHeader';
 import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
 import Icon from '@weco/common/views/components/Icon/Icon';
-import Layout12 from '@weco/common/views/components/Layout12/Layout12';
+import Layout12, {
+  gridSize12,
+} from '@weco/common/views/components/Layout12/Layout12';
 import FacilityPromo from '../components/FacilityPromo/FacilityPromo';
 import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
 import Space from '@weco/common/views/components/styled/Space';
@@ -206,7 +208,7 @@ const Header: FunctionComponent<HeaderProps> = ({
     >
       <div className="container">
         <div className="grid">
-          <div className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>
+          <div className={grid(gridSize12)}>
             <div className="flex flex--v-center flex--h-space-between flex--wrap">
               <SectionPageHeader sectionLevelPage={true}>
                 What’s on


### PR DESCRIPTION
There's a pretty common pattern:

    <div className="grid">
      <div className={grid({ … })}>

This collapses a few instances into a new Grid component, and in other cases replaces it with the existing Layout components (where appropriate).

A little code tidy spotted on code read.