### PR TITLE
Tweak InfoBanner CSS and simplify component

### DIFF
--- a/common/views/components/InfoBanner/InfoBanner.tsx
+++ b/common/views/components/InfoBanner/InfoBanner.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent, useEffect, useState } from 'react';
 import cookies from '@weco/common/data/cookies';
 import { getCookie, setCookie } from 'cookies-next';
-import { grid, font } from '../../../utils/classnames';
+import { font } from '../../../utils/classnames';
 import Icon from '../Icon/Icon';
 import PrismicHtmlBlock from '../PrismicHtmlBlock/PrismicHtmlBlock';
 import Space from '../styled/Space';
@@ -19,8 +19,27 @@ type Props = {
 
 const BannerContainer = styled(Space).attrs({
   v: { size: 'm', properties: ['padding-top', 'padding-bottom'] },
+  className: font('intr', 5),
 })`
   background-color: ${props => props.theme.color('yellow')};
+`;
+
+const BannerWrapper = styled.div.attrs({
+  className: 'container',
+})`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const CopyContainer = styled.div`
+  display: flex;
+`;
+
+const Copy = styled(Space).attrs({
+  h: { size: 'm', properties: ['margin-right'] },
+  className: 'body-text spaced-text',
+})`
+  align-self: center;
 `;
 
 const CloseButton = styled.button.attrs({
@@ -76,40 +95,28 @@ const InfoBanner: FunctionComponent<Props> = ({
 
   return isVisible ? (
     <BannerContainer role="region" aria-labelledby="note" id="notification">
-      <div className="container">
-        <div className="grid">
-          <div className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>
-            <div className={`flex flex--h-space-between ${font('intr', 5)}`}>
-              <div>
-                <span className="flex">
-                  <Space
-                    h={{ size: 'm', properties: ['margin-right'] }}
-                    v={{ size: 'xs', properties: ['margin-top'] }}
-                    className="flex"
-                  >
-                    <Icon icon={information} />
-                    <span className="visually-hidden" id="note">
-                      Notification
-                    </span>
-                  </Space>
-                  <div className="body-text spaced-text">
-                    <PrismicHtmlBlock html={text} />
-                  </div>
-                </span>
-              </div>
-              <Space v={{ size: 'xs', properties: ['margin-top'] }}>
-                <CloseButton
-                  onClick={hideInfoBanner}
-                  aria-controls="notification"
-                >
-                  <Icon icon={cross} title="Close notification" />
-                  <span className="visually-hidden">close notification</span>
-                </CloseButton>
-              </Space>
-            </div>
-          </div>
-        </div>
-      </div>
+      <BannerWrapper>
+        <CopyContainer>
+          <Space
+            h={{ size: 'm', properties: ['margin-right'] }}
+            v={{ size: 'xs', properties: ['margin-top'] }}
+          >
+            <Icon icon={information} />
+            <span className="visually-hidden" id="note">
+              Notification
+            </span>
+          </Space>
+          <Copy>
+            <PrismicHtmlBlock html={text} />
+          </Copy>
+        </CopyContainer>
+        <Space v={{ size: 'xs', properties: ['margin-top'] }}>
+          <CloseButton onClick={hideInfoBanner} aria-controls="notification">
+            <Icon icon={cross} title="Close notification" />
+            <span className="visually-hidden">close notification</span>
+          </CloseButton>
+        </Space>
+      </BannerWrapper>
     </BannerContainer>
   ) : null;
 };


### PR DESCRIPTION
## Who is this for?
Me 😄 devs for simplified component

## What is it doing for them?
I noticed the alignment was a bit off on desktop, especially when the copy is only one line. So thought I'd take a quick look! Also simplified the code a little. It doesn't change too much visually, but adding mobile screenshots to prove it.

---

**Before:**

<img width="1313" alt="Screenshot 2023-01-04 at 11 52 15" src="https://user-images.githubusercontent.com/110461050/210552553-6a45783f-f59c-4e46-8386-d9071424462f.png">
<img width="387" alt="Screenshot 2023-01-04 at 11 52 24" src="https://user-images.githubusercontent.com/110461050/210552559-a135ac37-ffa1-4c28-bb0b-1aaef54a7717.png">

---

**After:**

<img width="1316" alt="Screenshot 2023-01-04 at 12 06 22" src="https://user-images.githubusercontent.com/110461050/210552621-a81e13e9-509e-429f-b535-bf6ce174d969.png">
<img width="380" alt="Screenshot 2023-01-04 at 12 06 29" src="https://user-images.githubusercontent.com/110461050/210552625-423b3f0f-5980-4b4b-bf8d-df0295772bb4.png">
