### PR TITLE
Improve safari mobile reader content

### DIFF
--- a/content/webapp/components/ContentPage/ContentPage.tsx
+++ b/content/webapp/components/ContentPage/ContentPage.tsx
@@ -180,35 +180,36 @@ const ContentPage = ({
               </Layout8>
             </SpacingSection>
           )}
-
-          {RelatedContent.length > 0 && (
-            <SpacingSection>
-              {Children.map(RelatedContent, child => (
-                <Fragment>{child}</Fragment>
-              ))}
-            </SpacingSection>
-          )}
-
-          {outroProps && (
-            <SpacingSection>
-              <Layout8>
-                <Outro {...outroProps} />
-              </Layout8>
-            </SpacingSection>
-          )}
-
-          {postOutroContent && <Layout8>{postOutroContent}</Layout8>}
-
-          {seasons.length > 0 &&
-            seasons.map(season => (
-              <SpacingSection key={season.id}>
-                <Layout12>
-                  <BannerCard item={season} />
-                </Layout12>
-              </SpacingSection>
-            ))}
         </Wrapper>
       </article>
+      <Wrapper isCreamy={isCreamy}>
+        {RelatedContent.length > 0 && (
+          <SpacingSection>
+            {Children.map(RelatedContent, child => (
+              <Fragment>{child}</Fragment>
+            ))}
+          </SpacingSection>
+        )}
+
+        {outroProps && (
+          <SpacingSection>
+            <Layout8>
+              <Outro {...outroProps} />
+            </Layout8>
+          </SpacingSection>
+        )}
+
+        {postOutroContent && <Layout8>{postOutroContent}</Layout8>}
+
+        {seasons.length > 0 &&
+          seasons.map(season => (
+            <SpacingSection key={season.id}>
+              <Layout12>
+                <BannerCard item={season} />
+              </Layout12>
+            </SpacingSection>
+          ))}
+      </Wrapper>
     </PageBackgroundContext.Provider>
   );
 };


### PR DESCRIPTION
Closes #9026 (for now)

## Who is this for?
People who want more relevant content to display in mobile Safari reader view

## What is it doing for them?
Closing the `<article>` tag sooner, to exclude the (client-side-fetched) related content.

This appears to have the effect of including the desired content in reader view, although it also includes the blurb paragraph before any related content.

It seems Readability – the project reader view is based on – picks up on [certain classes](https://stackoverflow.com/a/15418461) to guess whether content is relevant or not. With this in mind, I tried adding e.g. `class="sidebar"` to the related content, but this only had the effect of prevent _any_ content from appearing in reader view altogether.

My only not-very-well-tested theory is that something in the client-side-fetching of content interferes with what reader view thinks is the relevant markup – perhaps a re-render?