### PR TITLE
Allow social icons to wrap when zoomed in

### DIFF
--- a/common/views/components/Footer/Footer.tsx
+++ b/common/views/components/Footer/Footer.tsx
@@ -101,6 +101,7 @@ const PoliciesContainer = styled(Space)`
 
 const SocialsContainer = styled(Space)`
   display: flex;
+  flex-wrap: wrap;
   justify-content: space-between;
   align-items: center;
   align-self: flex-start;


### PR DESCRIPTION
Fixes #9027 

## Who is this for?
People who want to be able to read zoomed content on their phone

## What is it doing for them?
Allowing the social icons in the footer to wrap if needed, preventing a horizontal scrollbar from being added (which was shunting text off the screen to the left).

