### PR TITLE
Don't rely on the user's locale to know what day it is

### DIFF
--- a/catalogue/webapp/components/CalendarSelect/CalendarSelect.tsx
+++ b/catalogue/webapp/components/CalendarSelect/CalendarSelect.tsx
@@ -2,18 +2,21 @@ import { FunctionComponent } from 'react';
 import Select, {
   SelectOption,
 } from '@weco/common/views/components/Select/Select';
-import { DayNumber } from '@weco/common/model/opening-hours';
 import { isRequestableDate } from '../../utils/dates';
 import { isTruthy } from '@weco/common/utils/array';
 import { getDatesBetween } from '@weco/common/utils/dates';
 import { dateAsValue } from '../ItemRequestModal/format-date';
-import { formatDayName, formatDayMonth } from '@weco/common/utils/format-date';
+import {
+  formatDayName,
+  formatDayMonth,
+  DayOfWeek,
+} from '@weco/common/utils/format-date';
 
 type Props = {
   min?: Date;
   max?: Date;
   excludedDates: Date[];
-  excludedDays: DayNumber[];
+  excludedDays: DayOfWeek[];
   chosenDate?: string;
   setChosenDate: (value: string) => void;
 };
@@ -22,7 +25,7 @@ function getAvailableDates(
   min: Date,
   max: Date,
   excludedDates: Date[],
-  excludedDays: DayNumber[]
+  excludedDays: DayOfWeek[]
 ): SelectOption[] {
   const days = getDatesBetween({ start: min, end: max });
 

--- a/catalogue/webapp/components/RequestingDayPicker/RequestingDayPicker.tsx
+++ b/catalogue/webapp/components/RequestingDayPicker/RequestingDayPicker.tsx
@@ -1,12 +1,12 @@
+import { DayOfWeek } from '@weco/common/utils/format-date';
 import { FunctionComponent } from 'react';
-import { DayNumber } from '@weco/common/model/opening-hours';
 import CalendarSelect from '../CalendarSelect/CalendarSelect';
 
 type Props = {
   startDate?: Date;
   endDate?: Date;
   exceptionalClosedDates: Date[];
-  regularClosedDays: DayNumber[];
+  regularClosedDays: DayOfWeek[];
   pickUpDate?: string;
   setPickUpDate: (date: string) => void;
 };

--- a/catalogue/webapp/package.json
+++ b/catalogue/webapp/package.json
@@ -44,6 +44,9 @@
     "graphql": "^16.6.0",
     "graphql-request": "^3.6.0"
   },
+  "devDependencies": {
+    "timezone-mock": "^1.3.6"
+  },
   "browserslist": [
     "last 2 versions",
     "iOS 8"

--- a/catalogue/webapp/test/utils/dates.test.ts
+++ b/catalogue/webapp/test/utils/dates.test.ts
@@ -132,7 +132,7 @@ describe('findClosedDays', () => {
 describe('determineNextAvailableDate', () => {
   it('adds a single day to the current date, if the time is before 10am', () => {
     const result = determineNextAvailableDate(new Date('2021-12-9 09:00'), {
-      regularClosedDays: [0],
+      regularClosedDays: ['Sunday'],
       exceptionalClosedDates: [],
     });
     expect(result).toEqual(new Date('2021-12-10 09:00'));
@@ -140,7 +140,7 @@ describe('determineNextAvailableDate', () => {
 
   it('adds 2 days to the current date, if the time is after 10am', () => {
     const result = determineNextAvailableDate(new Date('2021-12-9 11:00'), {
-      regularClosedDays: [0],
+      regularClosedDays: ['Sunday'],
       exceptionalClosedDates: [],
     });
     expect(result).toEqual(new Date('2021-12-11 11:00'));
@@ -203,7 +203,7 @@ describe('determineNextAvailableDate', () => {
     '$description: an item ordered at $requestMade can be retrieved on $firstVisits',
     ({ requestMade, firstVisits }) => {
       const result = determineNextAvailableDate(requestMade, {
-        regularClosedDays: [0], // Sunday
+        regularClosedDays: ['Sunday'],
         exceptionalClosedDates: [],
       });
       expect(result).toEqual(firstVisits);
@@ -212,7 +212,15 @@ describe('determineNextAvailableDate', () => {
 
   it("doesn't return a date if there are no regular days that are open", () => {
     const result = determineNextAvailableDate(new Date(), {
-      regularClosedDays: [0, 1, 2, 3, 4, 5, 6],
+      regularClosedDays: [
+        'Sunday',
+        'Monday',
+        'Tuesday',
+        'Wednesday',
+        'Thursday',
+        'Friday',
+        'Saturday',
+      ],
       exceptionalClosedDates: [],
     });
     expect(result).toBeUndefined();
@@ -224,7 +232,7 @@ describe('determineNextAvailableDate', () => {
     const date1 = new Date('2021-12-09T10:30:00+0100');
 
     const result1 = determineNextAvailableDate(date1, {
-      regularClosedDays: [0],
+      regularClosedDays: ['Sunday'],
       exceptionalClosedDates: [],
     });
     expect(result1).toEqual(new Date('2021-12-10T09:30:00Z'));
@@ -234,7 +242,7 @@ describe('determineNextAvailableDate', () => {
     const date2 = new Date('2021-12-09T11:30:00+0100');
 
     const result2 = determineNextAvailableDate(date2, {
-      regularClosedDays: [0],
+      regularClosedDays: ['Sunday'],
       exceptionalClosedDates: [],
     });
     expect(result2).toEqual(new Date('2021-12-11T10:30:00Z'));
@@ -243,14 +251,14 @@ describe('determineNextAvailableDate', () => {
     // and UTC are different.
     const date3 = new Date('2022-09-06T10:30:00+0200');
     const result3 = determineNextAvailableDate(date3, {
-      regularClosedDays: [0],
+      regularClosedDays: ['Sunday'],
       exceptionalClosedDates: [],
     });
     expect(result3).toEqual(new Date('2022-09-07T09:30:00+0100'));
 
     const date4 = new Date('2022-09-06T11:30:00+0200');
     const result4 = determineNextAvailableDate(date4, {
-      regularClosedDays: [0],
+      regularClosedDays: ['Sunday'],
       exceptionalClosedDates: [],
     });
     expect(result4).toEqual(new Date('2022-09-08T10:30:00+0100'));
@@ -265,7 +273,7 @@ describe('determineNextAvailableDate', () => {
     const result = determineNextAvailableDate(
       new Date('2022-09-16T18:00:00+0100'), // Friday evening
       {
-        regularClosedDays: [0], //
+        regularClosedDays: ['Sunday'], //
         exceptionalClosedDates: [stateFuneral],
       }
     );
@@ -284,7 +292,7 @@ describe('determineNextAvailableDate', () => {
     const result = determineNextAvailableDate(
       new Date('2021-12-10T12:00:00Z'), // Friday
       {
-        regularClosedDays: [0], // Sunday
+        regularClosedDays: ['Sunday'],
         exceptionalClosedDates: [exceptionalClosure],
       }
     );
@@ -301,10 +309,11 @@ describe('determineNextAvailableDate', () => {
 
 describe('filterExceptionalClosedDates', () => {
   it('removes any date that is a regular closed day', () => {
-    const result = filterExceptionalClosedDates(
-      exceptionalClosedDates,
-      [0, 1, 3]
-    );
+    const result = filterExceptionalClosedDates(exceptionalClosedDates, [
+      'Sunday',
+      'Monday',
+      'Wednesday',
+    ]);
 
     expect(result).toEqual([
       new Date('2019-12-03'),
@@ -323,7 +332,7 @@ describe('includedRegularClosedDays', () => {
     const result = includedRegularClosedDays({
       startDate: new Date('2020-01-03'),
       endDate: new Date('2020-01-16'),
-      regularClosedDays: [0, 1, 4],
+      regularClosedDays: ['Sunday', 'Monday', 'Thursday'],
     });
 
     // This is the date range:
@@ -334,7 +343,6 @@ describe('includedRegularClosedDays', () => {
     //      5  6  7  8  9 10 11
     //     12 13 14 15 16
     //
-    // Of these, we're counting Sunday (0), Monday (1) and Thursday (4).
     expect(result).toEqual(6);
   });
 });
@@ -375,7 +383,7 @@ describe('extendEndDate: Determines the end date to use, so that there are alway
       startDate: new Date('2021-11-03'),
       endDate: new Date('2021-11-16'),
       exceptionalClosedDates,
-      regularClosedDays: [0],
+      regularClosedDays: ['Sunday'],
     });
 
     expect(result).toEqual(new Date('2021-11-16'));
@@ -397,7 +405,7 @@ describe('extendEndDate: Determines the end date to use, so that there are alway
       startDate: new Date('2019-12-28'),
       endDate: new Date('2020-01-10'),
       exceptionalClosedDates,
-      regularClosedDays: [0],
+      regularClosedDays: ['Sunday'],
     });
 
     expect(result).toEqual(new Date('2020-01-16'));
@@ -419,7 +427,7 @@ describe('extendEndDate: Determines the end date to use, so that there are alway
       startDate: new Date('2020-01-03'),
       endDate: new Date('2020-01-16'),
       exceptionalClosedDates,
-      regularClosedDays: [0],
+      regularClosedDays: ['Sunday'],
     });
 
     expect(result).toEqual(new Date('2020-01-24'));
@@ -430,7 +438,7 @@ describe('extendEndDate: Determines the end date to use, so that there are alway
       startDate: new Date('2019-12-24'),
       endDate: new Date('2019-12-31'),
       exceptionalClosedDates,
-      regularClosedDays: [2],
+      regularClosedDays: ['Tuesday'],
     });
 
     expect(result).toEqual(new Date('2019-12-31'));
@@ -440,7 +448,7 @@ describe('extendEndDate: Determines the end date to use, so that there are alway
     const result = extendEndDate({
       endDate: new Date('2020-01-10'),
       exceptionalClosedDates: exceptionalClosedDates,
-      regularClosedDays: [0],
+      regularClosedDays: ['Sunday'],
     });
 
     expect(result).toBeUndefined();
@@ -450,7 +458,7 @@ describe('extendEndDate: Determines the end date to use, so that there are alway
     const result = extendEndDate({
       startDate: new Date('2019-12-24'),
       exceptionalClosedDates,
-      regularClosedDays: [0],
+      regularClosedDays: ['Sunday'],
     });
 
     expect(result).toBeUndefined();
@@ -486,7 +494,7 @@ describe("isRequestableDate: checks the date falls between 2 specified dates and
       startDate: new Date('2019-12-17'),
       endDate: new Date('2019-12-31'),
       excludedDates: [],
-      excludedDays: [2], // Tuesday
+      excludedDays: ['Tuesday'],
     });
     expect(result).toEqual(false);
   });
@@ -573,7 +581,7 @@ describe('isLibraryOpen: determines whether the library is open on a given day',
     },
   ])('The library is $state on $dayOfWeek', ({ state, date }) => {
     const result = isLibraryOpen(date, {
-      regularClosedDays: [0],
+      regularClosedDays: ['Sunday'],
       exceptionalClosedDates,
     });
 
@@ -630,7 +638,7 @@ describe('works correctly with a non-London timezone', () => {
 
     const userDate = new Date('2023-01-06T18:00:00-0800');
     const result = determineNextAvailableDate(userDate, {
-      regularClosedDays: [0],
+      regularClosedDays: ['Sunday'],
       exceptionalClosedDates: [],
     });
     expect(result).toEqual(new Date('2023-01-09T02:00:00Z'));
@@ -641,14 +649,14 @@ describe('works correctly with a non-London timezone', () => {
   it('isLibraryOpen: when the request is made on a different day in $timezone and in London', () => {
     const date1 = new Date('2023-01-07T18:00:00-0800'); // Saturday in US, Sunday in London
     const result1 = isLibraryOpen(date1, {
-      regularClosedDays: [0],
+      regularClosedDays: ['Sunday'],
       exceptionalClosedDates: [],
     });
     expect(result1).toBeFalsy();
 
     const date2 = new Date('2023-01-08T18:00:00-0800'); // Sunday in US, Monday in London
     const result2 = isLibraryOpen(date2, {
-      regularClosedDays: [0],
+      regularClosedDays: ['Sunday'],
       exceptionalClosedDates: [],
     });
     expect(result2).toBeTruthy();

--- a/catalogue/webapp/test/utils/dates.test.ts
+++ b/catalogue/webapp/test/utils/dates.test.ts
@@ -4,15 +4,9 @@ import {
   includedRegularClosedDays,
   groupExceptionalClosedDates,
   extendEndDate,
-  findClosedDays,
   isRequestableDate,
   isLibraryOpen,
 } from '../../utils/dates';
-import {
-  OverrideType,
-  OpeningHoursDay,
-  ExceptionalOpeningHoursDay,
-} from '@weco/common/model/opening-hours';
 import timezoneMock from 'timezone-mock';
 
 const exceptionalClosedDates = [
@@ -30,104 +24,6 @@ const exceptionalClosedDates = [
   new Date('2020-01-20'),
   new Date('2020-01-22'),
 ];
-
-const regularOpeningHours: OpeningHoursDay[] = [
-  {
-    dayOfWeek: 'Monday',
-    opens: '10:00',
-    closes: '18:00',
-    isClosed: false,
-  },
-  {
-    dayOfWeek: 'Tuesday',
-    opens: '10:00',
-    closes: '18:00',
-    isClosed: false,
-  },
-  {
-    dayOfWeek: 'Wednesday',
-    opens: '10:00',
-    closes: '18:00',
-    isClosed: false,
-  },
-  {
-    dayOfWeek: 'Thursday',
-    opens: '10:00',
-    closes: '18:00',
-    isClosed: false,
-  },
-  {
-    dayOfWeek: 'Friday',
-    opens: '10:00',
-    closes: '18:00',
-    isClosed: false,
-  },
-  {
-    dayOfWeek: 'Saturday',
-    opens: '10:00',
-    closes: '16:00',
-    isClosed: false,
-  },
-  {
-    dayOfWeek: 'Sunday',
-    opens: '00:00',
-    closes: '00:00',
-    isClosed: true,
-  },
-];
-
-const exceptionalOpeningHours: ExceptionalOpeningHoursDay[] = [
-  {
-    overrideDate: new Date('2021-12-25T00:00:00.000Z'),
-    overrideType: 'Christmas and New Year' as OverrideType,
-    opens: '00:00',
-    closes: '00:00',
-    isClosed: true,
-  },
-  {
-    overrideDate: new Date('2021-12-26T00:00:00.000Z'),
-    overrideType: 'Christmas and New Year' as OverrideType,
-    opens: '12:00',
-    closes: '14:00',
-    isClosed: false,
-  },
-  {
-    overrideDate: new Date('2021-12-27T00:00:00.000Z'),
-    overrideType: 'Christmas and New Year' as OverrideType,
-    opens: '00:00',
-    closes: '00:00',
-    isClosed: true,
-  },
-];
-
-describe('findClosedDays', () => {
-  it('filters out any non closed days from regular opening hours', () => {
-    const result = findClosedDays(regularOpeningHours);
-    expect(result).toEqual([
-      { dayOfWeek: 'Sunday', opens: '00:00', closes: '00:00', isClosed: true },
-    ]);
-  });
-
-  it('filters out any non closed days from exceptional opening hours', () => {
-    const result = findClosedDays(exceptionalOpeningHours);
-    expect(result).toEqual([
-      {
-        overrideDate: new Date('2021-12-25T00:00:00.000Z'),
-        overrideType: 'Christmas and New Year',
-        opens: '00:00',
-        closes: '00:00',
-        isClosed: true,
-      },
-      {
-        overrideDate: new Date('2021-12-27T00:00:00.000Z'),
-        overrideType: 'Christmas and New Year',
-        opens: '00:00',
-        closes: '00:00',
-        isClosed: true,
-      },
-    ]);
-  });
-});
 
 describe('determineNextAvailableDate', () => {
   it('adds a single day to the current date, if the time is before 10am', () => {

--- a/catalogue/webapp/utils/dates.ts
+++ b/catalogue/webapp/utils/dates.ts
@@ -1,64 +1,13 @@
 import {
-  OpeningHoursDay,
-  DayNumber,
-  ExceptionalOpeningHoursDay,
-} from '@weco/common/model/opening-hours';
-import {
   addDays,
   getDatesBetween,
   isSameDay,
   isSameDayOrBefore,
 } from '@weco/common/utils/dates';
-import { DayOfWeek } from '@weco/common/utils/format-date';
-
-export function findClosedDays(
-  days: (OpeningHoursDay | ExceptionalOpeningHoursDay)[]
-): (OpeningHoursDay | ExceptionalOpeningHoursDay)[] {
-  return days.filter(day => day.isClosed);
-}
-
-export function convertOpeningHoursDayToDayNumber(
-  day: OpeningHoursDay
-): DayNumber {
-  switch (day.dayOfWeek) {
-    case 'Monday':
-      return 1;
-    case 'Tuesday':
-      return 2;
-    case 'Wednesday':
-      return 3;
-    case 'Thursday':
-      return 4;
-    case 'Friday':
-      return 5;
-    case 'Saturday':
-      return 6;
-    case 'Sunday':
-      return 0;
-  }
-}
-
-export function convertDayNumberToDay(dayNumber: DayNumber): DayOfWeek {
-  switch (dayNumber) {
-    case 1:
-      return 'Monday';
-    case 2:
-      return 'Tuesday';
-    case 3:
-      return 'Wednesday';
-    case 4:
-      return 'Thursday';
-    case 5:
-      return 'Friday';
-    case 6:
-      return 'Saturday';
-    case 0:
-      return 'Sunday';
-  }
-}
+import { DayOfWeek, formatDayName } from '@weco/common/utils/format-date';
 
 type ClosedDates = {
-  regularClosedDays: DayNumber[];
+  regularClosedDays: DayOfWeek[];
   exceptionalClosedDates: Date[];
 };
 
@@ -67,7 +16,7 @@ export function isLibraryOpen(
   date: Date,
   { regularClosedDays, exceptionalClosedDates }: ClosedDates
 ): boolean {
-  if (regularClosedDays.includes(date.getDay() as DayNumber)) {
+  if (regularClosedDays.includes(formatDayName(date))) {
     return false;
   }
 
@@ -155,22 +104,22 @@ export function groupExceptionalClosedDates(params: {
 
 export function filterExceptionalClosedDates(
   exceptionalClosedDates: Date[],
-  regularClosedDays: DayNumber[]
+  regularClosedDays: DayOfWeek[]
 ): Date[] {
   return exceptionalClosedDates.filter(date => {
-    return regularClosedDays.every(day => day !== date.getDay());
+    return regularClosedDays.every(day => day !== formatDayName(date));
   });
 }
 
 export function includedRegularClosedDays(params: {
   startDate: Date;
   endDate: Date;
-  regularClosedDays: number[];
+  regularClosedDays: DayOfWeek[];
 }): number {
   const { startDate, endDate, regularClosedDays } = params;
 
   const dayArray = getDatesBetween({ start: startDate, end: endDate }).map(d =>
-    d.getDay()
+    formatDayName(d)
   );
 
   const includedRegularClosedDays = dayArray.filter(day =>
@@ -183,7 +132,7 @@ export function extendEndDate(params: {
   startDate?: Date;
   endDate?: Date;
   exceptionalClosedDates: Date[];
-  regularClosedDays: DayNumber[];
+  regularClosedDays: DayOfWeek[];
 }): Date | undefined {
   const { startDate, endDate, exceptionalClosedDates, regularClosedDays } =
     params;
@@ -240,13 +189,13 @@ export function isRequestableDate(params: {
   startDate?: Date;
   endDate?: Date;
   excludedDates: Date[];
-  excludedDays: DayNumber[];
+  excludedDays: DayOfWeek[];
 }): boolean {
   const { date, startDate, endDate, excludedDates, excludedDays } = params;
   const isExceptionalClosedDay = excludedDates.some(excluded =>
     isSameDay(excluded, date, 'London')
   );
-  const isRegularClosedDay = excludedDays.includes(date.getDay() as DayNumber);
+  const isRegularClosedDay = excludedDays.includes(formatDayName(date));
   return (
     Boolean(
       // no start and end date

--- a/common/model/opening-hours.ts
+++ b/common/model/opening-hours.ts
@@ -1,8 +1,6 @@
 import { DayOfWeek } from '../utils/format-date';
 import { ImageType } from './image';
 
-export type DayNumber = 0 | 1 | 2 | 3 | 4 | 5 | 6;
-
 export type OverrideType =
   | 'Bank holiday'
   | 'Easter'

--- a/yarn.lock
+++ b/yarn.lock
@@ -18345,6 +18345,11 @@ timers-ext@^0.1.7:
     es5-ext "~0.10.46"
     next-tick "1"
 
+timezone-mock@^1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/timezone-mock/-/timezone-mock-1.3.6.tgz#44e4c5aeb57e6c07ae630a05c528fc4d9aab86f4"
+  integrity sha512-YcloWmZfLD9Li5m2VcobkCDNVaLMx8ohAb/97l/wYS3m+0TIEK5PFNMZZfRcusc6sFjIfxu8qcJT0CNnOdpqmg==
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"


### PR DESCRIPTION
Follows https://github.com/wellcomecollection/wellcomecollection.org/pull/9043, fixes #9042

The bug occurs inside `isLibraryOpen()`, where we want to check if the library is open on a day of the week (given the regular opening hours).

We were calling `Date.getDay()` and comparing that to the regular opening days, but that function is locale-sensitive, and returns the day **in the user's timezone**, not in London. This causes issues when they're not the same.

This patch replaces it with `formatDayName()`, which works independently of the user's timezone.  It also allows us to pass around named days of the week, rather than day numbers, which imo is a bit clearer.
