### PR TITLE
Search overview (Front end)

### DIFF
--- a/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
+++ b/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
@@ -10,7 +10,7 @@ import styled from 'styled-components';
 
 import { convertImageUri } from '@weco/common/utils/convert-image-uri';
 import { hexToRgb } from '@weco/common/utils/convert-colors';
-import { Image, CatalogueResultsList } from '@weco/common/model/catalogue';
+import { Image } from '@weco/common/model/catalogue';
 import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
 
 import ExpandedImage from '../ExpandedImage/ExpandedImage';
@@ -20,7 +20,7 @@ import PlainList from '@weco/common/views/components/styled/PlainList';
 import Space from '@weco/common/views/components/styled/Space';
 
 type Props = {
-  images: CatalogueResultsList<Image>;
+  images: Image[];
   background?: string;
 };
 
@@ -75,23 +75,23 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
 
   // In the case that the modal changes the expanded image to
   // be one that isn't on this results page, this index will be -1
-  const expandedImagePosition = images.results.findIndex(
+  const expandedImagePosition = images.findIndex(
     img => expandedImage && img.id === expandedImage.id
   );
 
   // If there's only two images or less, display them differently (not worth loading the gallery + they display too large)
-  const isSmallGallery = images.results.length < 3;
+  const isSmallGallery = images.length < 3;
 
   // Loop through images to add data that Gallery needs in order to render
   const imagesWithDimensions: GalleryImageProps[] = useMemo(
     () =>
-      images.results.map(image => ({
+      images.map(image => ({
         ...image,
         src: convertImageUri(image.locations[0].url, 300),
         width: (image.aspectRatio || 1) * 100 + imageMargin,
         height: 100,
       })),
-    [images.results]
+    [images]
   );
 
   const imageRenderer = useCallback(galleryImage => {

--- a/catalogue/webapp/components/StoriesGrid/StoriesGrid.tsx
+++ b/catalogue/webapp/components/StoriesGrid/StoriesGrid.tsx
@@ -19,9 +19,9 @@ const StoriesContainer = styled.div<{ isDetailed?: boolean }>`
 
 const StoryWrapper = styled(Space).attrs<{
   isDetailed?: boolean;
-}>({
-  v: { size: 'xl', properties: ['padding-bottom'] },
-})<{ isDetailed?: boolean }>`
+}>(props => ({
+  v: { size: 'xl', properties: [props.isDetailed ? 'padding-bottom' : ''] },
+}))<{ isDetailed?: boolean }>`
   display: flex;
   flex-direction: ${props => (props.isDetailed ? 'row' : 'column')};
   align-items: flex-start;

--- a/catalogue/webapp/components/StoriesGrid/StoriesGrid.tsx
+++ b/catalogue/webapp/components/StoriesGrid/StoriesGrid.tsx
@@ -1,0 +1,223 @@
+import { FunctionComponent } from 'react';
+import styled from 'styled-components';
+
+import Space from '@weco/common/views/components/styled/Space';
+import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
+import { font } from '@weco/common/utils/classnames';
+import HTMLDate from '@weco/common/views/components/HTMLDate/HTMLDate';
+import { Story } from '@weco/catalogue/services/prismic/types/story';
+
+const StoriesContainer = styled.div<{ isDetailed?: boolean }>`
+  display: flex;
+  flex-direction: ${props => (props.isDetailed ? 'column' : 'row')};
+  flex-wrap: wrap;
+
+  ${props => props.theme.media('large')`
+      flex-wrap: nowrap;
+  `}
+`;
+
+const StoryWrapper = styled(Space).attrs<{
+  isDetailed?: boolean;
+}>({
+  v: { size: 'xl', properties: ['padding-bottom'] },
+})<{ isDetailed?: boolean }>`
+  display: flex;
+  flex-direction: ${props => (props.isDetailed ? 'row' : 'column')};
+  align-items: flex-start;
+
+  ${props =>
+    props.isDetailed
+      ? `flex-wrap: wrap;`
+      : `
+        margin-right: 20px; 
+        flex-basis: calc(50% - 10px);
+
+        &:nth-child(2n) {
+            margin-right: 0;
+        }
+    `};
+
+  text-decoration: none;
+
+  &:last-child {
+    padding-bottom: 0;
+  }
+
+  ${props =>
+    props.theme.media('medium')(`
+        flex-wrap: nowrap;
+  `)}
+
+  ${props =>
+    props.theme.media('large')(`
+    ${
+      props.isDetailed
+        ? ``
+        : `
+              margin-right: 30px; 
+              flex-basis: calc(25% - 20px);
+
+              &:nth-child(2n) {
+                  margin-right: 20px;
+              }
+
+              &:last-child {
+                  margin-right: 0;
+              }     
+          `
+    };
+    `)}
+`;
+
+const ImageWrapper = styled.div<{ isDetailed?: boolean }>`
+  position: relative;
+  flex: 1 1 auto;
+  margin-bottom: ${props => props.theme.spacingUnit * 2}px;
+
+  height: ${props => (props.isDetailed ? 'auto' : '160px')};
+  max-height: ${props => (props.isDetailed ? '250px' : '160px')};
+  width: ${props => (props.isDetailed ? 'auto' : '100%')};
+  max-width: 100%;
+
+  overflow: hidden;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  ${props =>
+    props.isDetailed
+      ? ``
+      : `
+        img {
+            object-fit: cover;
+            height: 100%;
+        }
+    `}
+
+  ${props =>
+    props.theme.media('medium')(`
+      max-height: 155px;
+      width: 100%;
+      
+      ${
+        props.isDetailed
+          ? `
+        flex: 1 0 40%;
+        margin-right: 1rem; 
+        max-width: 275px;
+      `
+          : ``
+      };
+      
+    `)}
+`;
+
+const Details = styled.div`
+  flex: 1 1 auto;
+
+  ${props => props.theme.media('medium')`
+      max-width: 820px;
+    `}
+`;
+
+const DesktopLabel = styled(Space).attrs({
+  v: { size: 's', properties: ['margin-bottom'] },
+})`
+  ${props => props.theme.media('medium', 'max-width')`
+      display:none;
+    `}
+`;
+
+const MobileLabel = styled(Space)`
+  position: absolute;
+  bottom: 0;
+  left: 0;
+
+  ${props => props.theme.media('medium')`
+      display: none;
+    `}
+`;
+
+const StoryInformation = styled(Space).attrs({
+  className: font('intr', 5),
+  v: { size: 'xs', properties: ['margin-bottom'] },
+})`
+  color: ${props => props.theme.color('neutral.600')};
+`;
+
+const StoryInformationItem = styled.span`
+  &:not(:first-child)::before {
+    content: ' | ';
+    margin: 0 4px;
+  }
+
+  span {
+    &:not(:first-child)::before {
+      content: ', ';
+    }
+  }
+`;
+
+type Props = {
+  stories: Story[];
+  isDetailed?: boolean;
+};
+
+const StoriesGrid: FunctionComponent<Props> = ({
+  stories,
+  isDetailed,
+}: Props) => {
+  return (
+    <StoriesContainer isDetailed={isDetailed}>
+      {stories.map(story => (
+        <StoryWrapper
+          key={story.id}
+          as="a"
+          href={story.url}
+          isDetailed={isDetailed}
+        >
+          <ImageWrapper isDetailed={isDetailed}>
+            <img src={story.image.url} alt="" />
+
+            {story.type && (
+              <MobileLabel>
+                <LabelsList labels={[story.label]} />
+              </MobileLabel>
+            )}
+          </ImageWrapper>
+          <Details>
+            {story.label && (
+              <DesktopLabel>
+                <LabelsList labels={[story.label]} />
+              </DesktopLabel>
+            )}
+            <h3 className={font('wb', 4)}>{story.title}</h3>
+            {isDetailed &&
+              (story.firstPublicationDate || !!story.contributors.length) && (
+                <StoryInformation>
+                  {story.firstPublicationDate && (
+                    <StoryInformationItem>
+                      <HTMLDate date={new Date(story.firstPublicationDate)} />
+                    </StoryInformationItem>
+                  )}
+                  {!!story.contributors.length && (
+                    <StoryInformationItem>
+                      {story.contributors.map(contributor => (
+                        <span key={contributor}>{contributor}</span>
+                      ))}
+                    </StoryInformationItem>
+                  )}
+                </StoryInformation>
+              )}
+            {story.summary && (
+              <p className={font('intr', 5)}>{story.summary}</p>
+            )}
+          </Details>
+        </StoryWrapper>
+      ))}
+    </StoriesContainer>
+  );
+};
+
+export default StoriesGrid;

--- a/catalogue/webapp/components/WorksSearchResults/WorksSearchResults.tsx
+++ b/catalogue/webapp/components/WorksSearchResults/WorksSearchResults.tsx
@@ -1,11 +1,11 @@
 import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 import WorksSearchResult from '../WorksSearchResult/WorksSearchResult';
-import { CatalogueResultsList, Work } from '@weco/common/model/catalogue';
+import { Work } from '@weco/common/model/catalogue';
 import PlainList from '@weco/common/views/components/styled/PlainList';
 
 type Props = {
-  works: CatalogueResultsList<Work>;
+  works: Work[];
 };
 
 const SearchResultUnorderedList = styled(PlainList)`
@@ -31,10 +31,10 @@ const SearchResultListItem = styled.li`
   }
 `;
 
-const WorkSearchResults: FunctionComponent<Props> = ({ works }: Props) => {
+const WorksSearchResults: FunctionComponent<Props> = ({ works }: Props) => {
   return (
     <SearchResultUnorderedList>
-      {works.results.map((result, i) => (
+      {works.map((result, i) => (
         <SearchResultListItem key={result.id}>
           <WorksSearchResult work={result} resultPosition={i} />
         </SearchResultListItem>
@@ -43,4 +43,4 @@ const WorkSearchResults: FunctionComponent<Props> = ({ works }: Props) => {
   );
 };
 
-export default WorkSearchResults;
+export default WorksSearchResults;

--- a/catalogue/webapp/pages/concept.tsx
+++ b/catalogue/webapp/pages/concept.tsx
@@ -198,7 +198,7 @@ export const ConceptPage: NextPage<Props> = ({
                   id="tabpanel-imagesAbout"
                   aria-labelledby="tab-imagesAbout"
                 >
-                  <ImageEndpointSearchResults images={imagesAbout} />
+                  <ImageEndpointSearchResults images={imagesAbout.results} />
                   <Space v={{ size: 'm', properties: ['margin-top'] }}>
                     <SeeMoreButton
                       text={`All images (${imagesAbout.totalResults})`}
@@ -219,7 +219,7 @@ export const ConceptPage: NextPage<Props> = ({
                   id="tabpanel-imagesBy"
                   aria-labelledby="tab-imagesBy"
                 >
-                  <ImageEndpointSearchResults images={imagesBy} />
+                  <ImageEndpointSearchResults images={imagesBy.results} />
                   <SeeMoreButton
                     text={`All images (${imagesBy.totalResults})`}
                     link={toImagesLink(
@@ -291,7 +291,7 @@ export const ConceptPage: NextPage<Props> = ({
                   id="tabpanel-worksAbout"
                   aria-labelledby="tab-worksAbout"
                 >
-                  <WorksSearchResults works={worksAbout} />
+                  <WorksSearchResults works={worksAbout.results} />
                   <Space v={{ size: 'l', properties: ['padding-top'] }}>
                     <SeeMoreButton
                       text={`All works (${worksAbout.totalResults})`}
@@ -312,7 +312,7 @@ export const ConceptPage: NextPage<Props> = ({
                   id="tabpanel-worksBy"
                   aria-labelledby="tab-worksBy"
                 >
-                  <WorksSearchResults works={worksBy} />
+                  <WorksSearchResults works={worksBy.results} />
                   <Space v={{ size: 'l', properties: ['padding-top'] }}>
                     <SeeMoreButton
                       text={`All works (${worksBy.totalResults})`}

--- a/catalogue/webapp/pages/images.tsx
+++ b/catalogue/webapp/pages/images.tsx
@@ -153,7 +153,7 @@ const Images: NextPage<Props> = ({
 
             <Space v={{ size: 'l', properties: ['padding-top'] }}>
               <div className="container">
-                <ImageEndpointSearchResults images={images} />
+                <ImageEndpointSearchResults images={images.results} />
               </div>
 
               <Space
@@ -189,7 +189,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     /**
      * This is here due to the noscript colour element
      * the value provided by the native element will
-     * include the # symbol.
+     * include the "#" symbol.
      */
     if (params.color) {
       params.color = params.color.replace('#', '');

--- a/catalogue/webapp/pages/search/images.tsx
+++ b/catalogue/webapp/pages/search/images.tsx
@@ -167,7 +167,7 @@ const ImagesSearchPage: NextPageWithLayout<Props> = ({
                 </PaginationWrapper>
 
                 <main>
-                  <ImageEndpointSearchResults images={images} />
+                  <ImageEndpointSearchResults images={images.results} />
                 </main>
 
                 <PaginationWrapper verticalSpacing="l" alignRight>
@@ -217,7 +217,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     /**
      * This is here due to the noscript colour element
      * the value provided by the native element will
-     * include the # symbol.
+     * include the "#" symbol.
      */
     if (params.color) {
       params.color = params.color.replace('#', '');

--- a/catalogue/webapp/pages/search/index.tsx
+++ b/catalogue/webapp/pages/search/index.tsx
@@ -3,14 +3,19 @@ import { getCookie } from 'cookies-next';
 import styled from 'styled-components';
 import { ParsedUrlQuery } from 'querystring';
 
+import Space from '@weco/common/views/components/styled/Space';
+import SearchNoResults from '@weco/catalogue/components/SearchNoResults/SearchNoResults';
+import StoriesGrid from '@weco/catalogue/components/StoriesGrid/StoriesGrid';
+import ImageEndpointSearchResults from '@weco/catalogue/components/ImageEndpointSearchResults/ImageEndpointSearchResults';
+import WorksSearchResults from '@weco/catalogue/components/WorksSearchResults/WorksSearchResults';
+import ButtonSolidLink from '@weco/common/views/components/ButtonSolidLink/ButtonSolidLink';
+import { arrow } from '@weco/common/icons';
+
+import { getSearchLayout } from '@weco/catalogue/components/SearchPageLayout/SearchPageLayout';
 import { removeUndefinedProps } from '@weco/common/utils/json';
 import { appError, AppErrorProps } from '@weco/common/services/app';
 import { getServerData } from '@weco/common/server-data';
-import Space from '@weco/common/views/components/styled/Space';
 import { NextPageWithLayout } from '@weco/common/views/pages/_app';
-import { getSearchLayout } from '@weco/catalogue/components/SearchPageLayout/SearchPageLayout';
-import SearchNoResults from '@weco/catalogue/components/SearchNoResults/SearchNoResults';
-import StoriesGrid from '@weco/catalogue/components/StoriesGrid/StoriesGrid';
 import { Pageview } from '@weco/common/services/conversion/track';
 import { getStories } from '@weco/catalogue/services/prismic/fetch/articles';
 import { Story } from '@weco/catalogue/services/prismic/types/story';
@@ -42,11 +47,22 @@ type Props = {
   pageview: Pageview;
 };
 
-const StorySection = styled(Space).attrs({
-  v: { size: 'l', properties: ['padding-top'] },
+const StoriesSection = styled(Space).attrs({
+  v: { size: 'xl', properties: ['padding-top', 'padding-bottom'] },
 })`
   background-color: ${props => props.theme.color('neutral.200')};
 `;
+
+const ImagesSection = styled(Space).attrs({
+  v: { size: 'xl', properties: ['padding-top', 'padding-bottom'] },
+})`
+  background-color: ${props => props.theme.color('black')};
+  color: ${props => props.theme.color('white')};
+`;
+
+const WorksSection = styled(Space).attrs({
+  v: { size: 'xl', properties: ['padding-top', 'padding-bottom'] },
+})``;
 
 const SectionTitle = ({ sectionName }: { sectionName: string }) => {
   return (
@@ -73,6 +89,36 @@ export const SearchPage: NextPageWithLayout<Props> = ({
     );
   }
 
+  const SeeMoreButton = ({
+    text,
+    pathname,
+  }: {
+    text: string;
+    pathname: string;
+  }) => (
+    <ButtonSolidLink
+      text={text}
+      link={{
+        href: {
+          pathname,
+          query: { query: queryString },
+        },
+        as: {
+          pathname,
+          query: { query: queryString },
+        },
+      }}
+      icon={arrow}
+      isIconAfter={true}
+      colors={{
+        border: 'yellow',
+        background: 'yellow',
+        text: 'black',
+      }}
+      hoverUnderline={true}
+    />
+  );
+
   return (
     <main>
       <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
@@ -83,52 +129,55 @@ export const SearchPage: NextPageWithLayout<Props> = ({
         ) : (
           <>
             {stories && (
-              <StorySection as="section">
+              <StoriesSection as="section">
                 <div className="container">
                   <SectionTitle sectionName="Stories" />
+
                   <StoriesGrid stories={stories} />
+
+                  <Space v={{ size: 'l', properties: ['padding-top'] }}>
+                    <SeeMoreButton
+                      text={`All stories`}
+                      pathname="/search/stories"
+                    />
+                  </Space>
                 </div>
-              </StorySection>
+              </StoriesSection>
             )}
 
             {images && (
-              <section>
+              <ImagesSection>
                 <div className="container">
                   <SectionTitle sectionName="Images" />
+
+                  <ImageEndpointSearchResults images={images} />
+
+                  <Space v={{ size: 'l', properties: ['padding-top'] }}>
+                    <SeeMoreButton
+                      text={`All images`}
+                      pathname="/search/images"
+                    />
+                  </Space>
                 </div>
-              </section>
+              </ImagesSection>
             )}
 
             {works && (
-              <section>
+              <WorksSection>
                 <div className="container">
-                  <SectionTitle sectionName="Works" />
+                  <SectionTitle sectionName="Catalogue" />
+
+                  <WorksSearchResults works={works} />
+
+                  <Space v={{ size: 'l', properties: ['padding-top'] }}>
+                    <SeeMoreButton
+                      text={`All catalogue`}
+                      pathname="/search/works"
+                    />
+                  </Space>
                 </div>
-              </section>
+              </WorksSection>
             )}
-
-            <div className="container">
-              <pre
-                style={{
-                  fontSize: '14px',
-                  overflow: 'hidden',
-                }}
-              >
-                {images && (
-                  <details>
-                    <summary>IMAGES</summary>
-                    {JSON.stringify(images, null, 1)}
-                  </details>
-                )}
-
-                {works && (
-                  <details>
-                    <summary>WORKS</summary>
-                    {JSON.stringify(works, null, 1)}
-                  </details>
-                )}
-              </pre>
-            </div>
           </>
         )}
       </Space>
@@ -182,7 +231,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
           ...params,
           _queryType: _worksQueryType,
         },
-        pageSize: 3,
+        pageSize: 5,
         toggles: serverData.toggles,
       });
       const works = getQueryResults('works', worksResults);
@@ -191,7 +240,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       const imagesResults = await getImages({
         params,
         toggles: serverData.toggles,
-        pageSize: 3,
+        pageSize: 10,
       });
       const images = getQueryResults('images', imagesResults);
 

--- a/catalogue/webapp/pages/search/index.tsx
+++ b/catalogue/webapp/pages/search/index.tsx
@@ -137,7 +137,7 @@ export const SearchPage: NextPageWithLayout<Props> = ({
 
                   <Space v={{ size: 'l', properties: ['padding-top'] }}>
                     <SeeMoreButton
-                      text={`All stories`}
+                      text="All stories"
                       pathname="/search/stories"
                     />
                   </Space>
@@ -154,7 +154,7 @@ export const SearchPage: NextPageWithLayout<Props> = ({
 
                   <Space v={{ size: 'l', properties: ['padding-top'] }}>
                     <SeeMoreButton
-                      text={`All images`}
+                      text="All images"
                       pathname="/search/images"
                     />
                   </Space>
@@ -170,10 +170,7 @@ export const SearchPage: NextPageWithLayout<Props> = ({
                   <WorksSearchResults works={works} />
 
                   <Space v={{ size: 'l', properties: ['padding-top'] }}>
-                    <SeeMoreButton
-                      text={`All catalogue`}
-                      pathname="/search/works"
-                    />
+                    <SeeMoreButton text="Catalogue" pathname="/search/works" />
                   </Space>
                 </div>
               </WorksSection>

--- a/catalogue/webapp/pages/search/index.tsx
+++ b/catalogue/webapp/pages/search/index.tsx
@@ -1,5 +1,6 @@
 import { GetServerSideProps } from 'next';
 import { getCookie } from 'cookies-next';
+import styled from 'styled-components';
 import { ParsedUrlQuery } from 'querystring';
 
 import { removeUndefinedProps } from '@weco/common/utils/json';
@@ -9,9 +10,11 @@ import Space from '@weco/common/views/components/styled/Space';
 import { NextPageWithLayout } from '@weco/common/views/pages/_app';
 import { getSearchLayout } from '@weco/catalogue/components/SearchPageLayout/SearchPageLayout';
 import SearchNoResults from '@weco/catalogue/components/SearchNoResults/SearchNoResults';
+import StoriesGrid from '@weco/catalogue/components/StoriesGrid/StoriesGrid';
 import { Pageview } from '@weco/common/services/conversion/track';
 import { getStories } from '@weco/catalogue/services/prismic/fetch/articles';
 import { Story } from '@weco/catalogue/services/prismic/types/story';
+import { font } from '@weco/common/utils/classnames';
 import { getWorks } from '@weco/catalogue/services/catalogue/works';
 import { Query } from '@weco/catalogue/types/search';
 import { getImages } from '@weco/catalogue/services/catalogue/images';
@@ -39,6 +42,20 @@ type Props = {
   pageview: Pageview;
 };
 
+const StorySection = styled(Space).attrs({
+  v: { size: 'l', properties: ['padding-top'] },
+})`
+  background-color: ${props => props.theme.color('neutral.200')};
+`;
+
+const SectionTitle = ({ sectionName }: { sectionName: string }) => {
+  return (
+    <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
+      <h3 className={font('intb', 2)}>{sectionName}</h3>
+    </Space>
+  );
+};
+
 export const SearchPage: NextPageWithLayout<Props> = ({
   works,
   images,
@@ -57,43 +74,65 @@ export const SearchPage: NextPageWithLayout<Props> = ({
   }
 
   return (
-    <div className="container">
-      <Space v={{ size: 'l', properties: ['margin-top', 'margin-bottom'] }}>
+    <main>
+      <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
         {!stories && !images && !works ? (
-          <SearchNoResults query={queryString} hasFilters={false} />
+          <div className="container">
+            <SearchNoResults query={queryString} hasFilters={false} />
+          </div>
         ) : (
-          <main>
-            <pre
-              style={{
-                fontSize: '14px',
-                overflow: 'hidden',
-              }}
-            >
-              {stories && (
-                <details>
-                  <summary>STORIES</summary>
-                  {JSON.stringify(stories, null, 1)}
-                </details>
-              )}
+          <>
+            {stories && (
+              <StorySection as="section">
+                <div className="container">
+                  <SectionTitle sectionName="Stories" />
+                  <StoriesGrid stories={stories} />
+                </div>
+              </StorySection>
+            )}
 
-              {images && (
-                <details>
-                  <summary>IMAGES</summary>
-                  {JSON.stringify(images, null, 1)}
-                </details>
-              )}
+            {images && (
+              <section>
+                <div className="container">
+                  <SectionTitle sectionName="Images" />
+                </div>
+              </section>
+            )}
 
-              {works && (
-                <details>
-                  <summary>WORKS</summary>
-                  {JSON.stringify(works, null, 1)}
-                </details>
-              )}
-            </pre>
-          </main>
+            {works && (
+              <section>
+                <div className="container">
+                  <SectionTitle sectionName="Works" />
+                </div>
+              </section>
+            )}
+
+            <div className="container">
+              <pre
+                style={{
+                  fontSize: '14px',
+                  overflow: 'hidden',
+                }}
+              >
+                {images && (
+                  <details>
+                    <summary>IMAGES</summary>
+                    {JSON.stringify(images, null, 1)}
+                  </details>
+                )}
+
+                {works && (
+                  <details>
+                    <summary>WORKS</summary>
+                    {JSON.stringify(works, null, 1)}
+                  </details>
+                )}
+              </pre>
+            </div>
+          </>
         )}
       </Space>
-    </div>
+    </main>
   );
 };
 
@@ -132,7 +171,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       // Stories
       const storiesResults = await getStories({
         query,
-        pageSize: 3,
+        pageSize: 4,
       });
       const stories = getQueryResults('stories', storiesResults);
 

--- a/catalogue/webapp/pages/search/stories.tsx
+++ b/catalogue/webapp/pages/search/stories.tsx
@@ -6,14 +6,12 @@ import Space from '@weco/common/views/components/styled/Space';
 import { getSearchLayout } from '@weco/catalogue/components/SearchPageLayout/SearchPageLayout';
 import Pagination from '@weco/common/views/components/Pagination/Pagination';
 import SearchNoResults from '@weco/catalogue/components/SearchNoResults/SearchNoResults';
-import HTMLDate from '@weco/common/views/components/HTMLDate/HTMLDate';
-import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
 import Sort from '@weco/catalogue/components/Sort/Sort';
 import PaginationWrapper from '@weco/common/views/components/styled/PaginationWrapper';
+import StoriesGrid from 'components/StoriesGrid/StoriesGrid';
 
 // Utils & Helpers
 import { NextPageWithLayout } from '@weco/common/views/pages/_app';
-import { font } from '@weco/common/utils/classnames';
 import { removeUndefinedProps } from '@weco/common/utils/json';
 import { AppErrorProps } from '@weco/common/services/app';
 import { getServerData } from '@weco/common/server-data';
@@ -48,95 +46,6 @@ const SortPaginationWrapper = styled.div`
     flex: 1 1 50%;
     justify-content: flex-end;
   `}
-`;
-
-const Container = styled(Space).attrs({
-  v: { size: 'xl', properties: ['padding-bottom'] },
-})`
-  &:last-child {
-    padding-bottom: 0;
-  }
-`;
-
-const StoryWrapper = styled.a`
-  display: flex;
-  align-items: flex-start;
-  flex-wrap: wrap;
-  text-decoration: none;
-
-  ${props => props.theme.media('medium')`
-    flex-wrap: nowrap;
-  `}
-`;
-
-const ImageWrapper = styled.div`
-  position: relative;
-  flex: 1 1 100%;
-  margin-bottom: ${props => props.theme.spacingUnit * 2}px;
-
-  max-height: 250px;
-  max-width: 100%;
-  width: auto;
-  height: auto;
-
-  overflow: hidden;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  ${props => props.theme.media('medium')`
-    flex: 1 0 40%;
-    margin-right: 1rem;
-    max-height: 155px;
-    max-width: 275px;
-    width: 100%;
-  `}
-`;
-
-const Details = styled.div`
-  flex: 1 1 100%;
-
-  ${props => props.theme.media('medium')`
-    max-width: 820px;
-  `}
-`;
-
-const DesktopLabel = styled(Space).attrs({
-  v: { size: 's', properties: ['margin-bottom'] },
-})`
-  ${props => props.theme.media('medium', 'max-width')`
-    display:none;
-  `}
-`;
-
-const MobileLabel = styled(Space)`
-  position: absolute;
-  bottom: 0;
-  left: 0;
-
-  ${props => props.theme.media('medium')`
-    display: none;
-  `}
-`;
-
-const StoryInformation = styled(Space).attrs({
-  className: font('intr', 5),
-  v: { size: 'xs', properties: ['margin-bottom'] },
-})`
-  color: ${props => props.theme.color('neutral.600')};
-`;
-
-const StoryInformationItem = styled.span`
-  &:not(:first-child)::before {
-    content: ' | ';
-    margin: 0 4px;
-  }
-
-  span {
-    &:not(:first-child)::before {
-      content: ', ';
-    }
-  }
 `;
 
 export const SearchPage: NextPageWithLayout<Props> = ({
@@ -193,53 +102,7 @@ export const SearchPage: NextPageWithLayout<Props> = ({
           </PaginationWrapper>
 
           <main>
-            {storyResponseList.results.map(story => {
-              return (
-                <Container key={story.id}>
-                  <StoryWrapper href={story.url}>
-                    <ImageWrapper>
-                      <img src={story.image.url} alt="" />
-
-                      {story.type && (
-                        <MobileLabel>
-                          <LabelsList labels={[story.label]} />
-                        </MobileLabel>
-                      )}
-                    </ImageWrapper>
-                    <Details>
-                      {story.label && (
-                        <DesktopLabel>
-                          <LabelsList labels={[story.label]} />
-                        </DesktopLabel>
-                      )}
-                      <h3 className={font('wb', 4)}>{story.title}</h3>
-                      {(story.firstPublicationDate ||
-                        !!story.contributors.length) && (
-                        <StoryInformation>
-                          {story.firstPublicationDate && (
-                            <StoryInformationItem>
-                              <HTMLDate
-                                date={new Date(story.firstPublicationDate)}
-                              />
-                            </StoryInformationItem>
-                          )}
-                          {!!story.contributors.length && (
-                            <StoryInformationItem>
-                              {story.contributors.map(contributor => (
-                                <span key={contributor}>{contributor}</span>
-                              ))}
-                            </StoryInformationItem>
-                          )}
-                        </StoryInformation>
-                      )}
-                      {story.summary && (
-                        <p className={font('intr', 5)}>{story.summary}</p>
-                      )}
-                    </Details>
-                  </StoryWrapper>
-                </Container>
-              );
-            })}
+            <StoriesGrid stories={storyResponseList.results} isDetailed />
           </main>
 
           <PaginationWrapper verticalSpacing="l" alignRight>

--- a/catalogue/webapp/pages/search/works.tsx
+++ b/catalogue/webapp/pages/search/works.tsx
@@ -198,7 +198,7 @@ export const CatalogueSearchPage: NextPageWithLayout<Props> = ({
                 </PaginationWrapper>
 
                 <main>
-                  <WorksSearchResults works={works} />
+                  <WorksSearchResults works={works.results} />
                 </main>
 
                 <PaginationWrapper verticalSpacing="l" alignRight>

--- a/catalogue/webapp/pages/works.tsx
+++ b/catalogue/webapp/pages/works.tsx
@@ -176,7 +176,7 @@ const Works: NextPage<Props> = ({ works, worksRouteProps }) => {
               style={{ opacity: loading ? 0 : 1 }}
             >
               <div className="container" role="main">
-                <WorksSearchResults works={works} />
+                <WorksSearchResults works={works.results} />
               </div>
 
               <Space


### PR DESCRIPTION
## Who is this for?
New search

## What is it doing for them?
- Integrates and styles the overview page.
- Create a StoryGrid component that we can use both in `/search` and `/search/stories` (just set `isDetailed` or not for the longer version with more information).
- Simplified what we send to `ImageEndpointSearchResults` and `WorksSearchResults` as only the list of results is required.

Closes #8741 