### PR TITLE
Add some tests for formatting dates in different user locales

### DIFF
--- a/catalogue/webapp/package.json
+++ b/catalogue/webapp/package.json
@@ -44,9 +44,6 @@
     "graphql": "^16.6.0",
     "graphql-request": "^3.6.0"
   },
-  "devDependencies": {
-    "timezone-mock": "^1.3.6"
-  },
   "browserslist": [
     "last 2 versions",
     "iOS 8"

--- a/common/package.json
+++ b/common/package.json
@@ -57,12 +57,10 @@
     "reading-time": "^1.5.0",
     "styled-components": "^5.2.1",
     "superjson": "^1.9.1",
+    "timezone-mock": "^1.3.6",
     "ts-jest": "27.0.7",
     "url-template": "^2.0.8",
     "uuid": "^8.3.2",
     "webpack-bundle-analyzer": "^4.4.2"
-  },
-  "devDependencies": {
-    "timezone-mock": "^1.3.6"
   }
 }

--- a/common/package.json
+++ b/common/package.json
@@ -61,5 +61,8 @@
     "url-template": "^2.0.8",
     "uuid": "^8.3.2",
     "webpack-bundle-analyzer": "^4.4.2"
+  },
+  "devDependencies": {
+    "timezone-mock": "^1.3.6"
   }
 }


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/wellcomecollection.org/issues/9048

These tests confirm that the existing code is working: if you take your laptop to San Francisco or Singapore or São Paulo, all the formatting code will show the same dates, as they are in London, not in your locale.