### PR TITLE
Add publication fields for serials to the work page

### DIFF
--- a/catalogue/webapp/components/ItemViewerContext/ItemViewerContext.tsx
+++ b/catalogue/webapp/components/ItemViewerContext/ItemViewerContext.tsx
@@ -84,6 +84,8 @@ const ItemViewerContext = createContext<Props>({
     production: [],
     languages: [],
     notes: [],
+    formerFrequency: [],
+    designation: [],
     parts: [],
     partOf: [],
     precededBy: [],

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -520,7 +520,21 @@ const WorkDetails: FunctionComponent<Props> = ({
             text={work.production.map(productionEvent => productionEvent.label)}
           />
         )}
-
+        {work.currentFrequency && (
+          <WorkDetailsText
+            title="Current frequency"
+            text={work.currentFrequency}
+          />
+        )}
+        {work.formerFrequency && (
+          <WorkDetailsText
+            title="Former frequency"
+            text={work.formerFrequency}
+          />
+        )}
+        {work.designation && (
+          <WorkDetailsText title="Designation" text={work.designation} />
+        )}
         {work.physicalDescription && (
           <WorkDetailsText
             title="Physical description"

--- a/catalogue/webapp/services/catalogue/works.ts
+++ b/catalogue/webapp/services/catalogue/works.ts
@@ -46,6 +46,8 @@ const workIncludes = [
   'contributors',
   'production',
   'notes',
+  'formerFrequency',
+  'designation',
   'parts',
   'partOf',
   'precededBy',

--- a/common/model/catalogue.ts
+++ b/common/model/catalogue.ts
@@ -16,6 +16,9 @@ export type Work = {
   thumbnail?: DigitalLocation;
   items?: Item<Location>[];
   production: Production[];
+  currentFrequency?: string;
+  formerFrequency: string[];
+  designation: string[];
   languages: Language[];
   edition?: string;
   notes: Note[];

--- a/common/test/fixtures/catalogueApi/work.ts
+++ b/common/test/fixtures/catalogueApi/work.ts
@@ -574,6 +574,8 @@ export const workWithPartOf: Work = {
   notes: [],
   languages: [],
   images: [],
+  formerFrequency: [],
+  designation: [],
   parts: [],
   partOf: [
     {
@@ -786,6 +788,8 @@ export const workWithMixedPartOf: Work = {
   precededBy: [],
   succeededBy: [],
   notes: [],
+  formerFrequency: [],
+  designation: [],
   parts: [],
   holdings: [],
   physicalDescription: '',

--- a/common/test/fixtures/catalogueApi/work.ts
+++ b/common/test/fixtures/catalogueApi/work.ts
@@ -354,6 +354,9 @@ export const workFixture: Work = {
       type: 'Note',
     },
   ],
+  currentFrequency: 'Published annually',
+  formerFrequency: ['Published bi-annually', 'Published semi-annually'],
+  designation: ['Issues 1–10', 'Issues 12–22'],
   images: [
     {
       id: 'y6v52b5g',
@@ -413,6 +416,8 @@ export const workWithLibrarySeriesPartOf: Work = {
   precededBy: [],
   succeededBy: [],
   notes: [],
+  formerFrequency: [],
+  designation: [],
   parts: [],
   holdings: [],
 };


### PR DESCRIPTION
These go between place of publication/creation and physical description, as per Jonathan's instructions on the original ticket.

Looking at the example work listed in the ticket:

<img width="469" alt="Screenshot 2023-01-10 at 13 55 36" src="https://user-images.githubusercontent.com/301220/211571546-f1009cf8-2d39-4f11-b8d5-7cdcceca9e41.png">


Closes https://github.com/wellcomecollection/platform/issues/5600