### PR TITLE
add new search URLs to pa11y

### DIFF
--- a/.buildkite/urls/expected_200_urls.txt
+++ b/.buildkite/urls/expected_200_urls.txt
@@ -80,3 +80,9 @@
 # This is an item page which has been redirected; we want to make
 # sure it redirects to the correct location
 /works/m58dxy2s/items
+
+# These are search pages
+/search?query=human
+/search/stories?query=human
+/search/images?query=human
+/search/works?query=human

--- a/pa11y/webapp/write-report.js
+++ b/pa11y/webapp/write-report.js
@@ -44,6 +44,12 @@ const urls = [
   '/guides/exhibitions/YzwsAREAAHylrxau/audio-without-descriptions',
   '/guides/exhibitions/YzwsAREAAHylrxau/captions-and-transcripts',
   '/guides/exhibitions/YzwsAREAAHylrxau/bsl',
+
+  // These are the new search pages
+  '/search?query=human',
+  '/search/stories?query=human',
+  '/search/images?query=human',
+  '/search/works?query=human',
 ].map(u => `${baseUrl}${u}`);
 
 const promises = urls.map(url =>


### PR DESCRIPTION
## Who is this for?
Automation testing

## What is it doing for them?
adding the newly created pages to the list of URLs that Pa11y will check.

closes #9053 

**please do not merge until the toggle for the new search page is defaulted to true**