### PR TITLE
add link to v3 manifest on API toolbar

### DIFF
--- a/common/views/components/ApiToolbar/ApiToolbar.tsx
+++ b/common/views/components/ApiToolbar/ApiToolbar.tsx
@@ -184,24 +184,16 @@ function getRouteProps(path: string) {
           }, [] as Location[])
           ?.find(location => location.locationType.id.startsWith('iiif'));
 
-        const iiifV2Link = iiifItem &&
+        const iiifLink = iiifItem &&
           iiifItem.type === 'DigitalLocation' && {
-            id: 'iiifv2',
-            label: 'IIIF V2',
-            link: iiifItem.url,
-          };
-
-        const iiifV3Link = iiifItem &&
-          iiifItem.type === 'DigitalLocation' && {
-            id: 'iiifv3',
-            label: 'IIIF V3',
+            id: 'iiif',
+            label: 'IIIF',
             link: iiifItem.url.replace('/v2/', '/v3/'),
           };
 
         const links = [
           apiLink,
-          iiifV2Link,
-          iiifV3Link,
+          iiifLink,
           ...work.identifiers.map(id => ({
             id: id.value,
             label: id.identifierType.label,

--- a/common/views/components/ApiToolbar/ApiToolbar.tsx
+++ b/common/views/components/ApiToolbar/ApiToolbar.tsx
@@ -184,16 +184,24 @@ function getRouteProps(path: string) {
           }, [] as Location[])
           ?.find(location => location.locationType.id.startsWith('iiif'));
 
-        const iiifLink = iiifItem &&
+        const iiifV2Link = iiifItem &&
           iiifItem.type === 'DigitalLocation' && {
-            id: 'iiif',
-            label: 'IIIF',
+            id: 'iiifv2',
+            label: 'IIIF V2',
             link: iiifItem.url,
+          };
+
+        const iiifV3Link = iiifItem &&
+          iiifItem.type === 'DigitalLocation' && {
+            id: 'iiifv3',
+            label: 'IIIF V3',
+            link: iiifItem.url.replace('/v2/', '/v3/'),
           };
 
         const links = [
           apiLink,
-          iiifLink,
+          iiifV2Link,
+          iiifV3Link,
           ...work.identifiers.map(id => ({
             id: id.value,
             label: id.identifierType.label,


### PR DESCRIPTION
~Renames the iiif link on the api toolbar to iiif v2 and adds a iiif v3 link alongside it:~

Links to the iiif manifest version 3 from the toolbar instead of version 2
