### PR TITLE
Specify color for image modal title

### DIFF
--- a/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
+++ b/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
@@ -54,6 +54,12 @@ const Metadata = styled.span`
   }
 `;
 
+const ModalTitle = styled.h2.attrs({
+  className: `${font('intb', 3)} no-margin`,
+})`
+  color: ${props => props.theme.color('black')};
+`;
+
 const ImageWrapper = styled(Space).attrs({
   v: { size: 'l', properties: ['margin-bottom'] },
 })`
@@ -294,8 +300,7 @@ const ExpandedImage: FunctionComponent<Props> = ({
           {(displayTitle || displayContributor || license) && (
             <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
               {displayTitle && (
-                <h2
-                  className={`${font('intb', 3)} no-margin`}
+                <ModalTitle
                   dangerouslySetInnerHTML={{ __html: displayTitle }}
                 />
               )}


### PR DESCRIPTION
## Who is this for?
Everyone

## What is it doing for them?
There's an issue in the CSS compiler and the title colour was overwritten. This makes it black - and readable - again.

Closes #9065 