### PR TITLE
Align buttons in search + sort copy

### DIFF
--- a/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
+++ b/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
@@ -214,7 +214,6 @@ const SearchLayout: FunctionComponent<{ hasEventsExhibitions: boolean }> = ({
           v={{ size: 'l', properties: ['margin-top', 'margin-bottom'] }}
         >
           <SearchBar
-            type={currentSearchCategory}
             placeholder={searchbarPlaceholderText[currentSearchCategory]}
           />
         </SearchBarContainer>

--- a/catalogue/webapp/pages/search/stories.tsx
+++ b/catalogue/webapp/pages/search/stories.tsx
@@ -76,8 +76,8 @@ export const SearchPage: NextPageWithLayout<Props> = ({
               <Sort
                 formId="searchPageForm"
                 options={[
-                  { value: 'alphabetical.asc', text: 'A -> Z' },
-                  { value: 'alphabetical.desc', text: 'Z -> A' },
+                  { value: 'alphabetical.asc', text: 'A-Z' },
+                  { value: 'alphabetical.desc', text: 'Z-A' },
                   { value: 'publication.dates.desc', text: 'Newest to oldest' },
                   { value: 'publication.dates.asc', text: 'Oldest to newest' },
                 ]}

--- a/common/views/components/ButtonSolidLink/ButtonSolidLink.tsx
+++ b/common/views/components/ButtonSolidLink/ButtonSolidLink.tsx
@@ -34,6 +34,7 @@ const ButtonSolidLink: FunctionComponent<ButtonSolidLinkProps> = ({
   hoverUnderline,
   ariaLabel,
   colors,
+  isNewStyle,
   isIconAfter,
 }: ButtonSolidLinkProps): ReactElement<ButtonSolidLinkProps> => {
   function handleClick(event) {
@@ -63,6 +64,7 @@ const ButtonSolidLink: FunctionComponent<ButtonSolidLinkProps> = ({
         ariaLabel={ariaLabel}
         colors={colors}
         hoverUnderline={hoverUnderline}
+        isNewStyle={isNewStyle}
       >
         <BaseButtonInner>
           {isIconAfter && (

--- a/common/views/components/SearchBar/SearchBar.tsx
+++ b/common/views/components/SearchBar/SearchBar.tsx
@@ -28,8 +28,7 @@ const SearchButtonWrapper = styled.div`
   flex: 0 1 auto;
 `;
 
-const SearchBar: FunctionComponent<{ type: string; placeholder: string }> = ({
-  type,
+const SearchBar: FunctionComponent<{ placeholder: string }> = ({
   placeholder,
 }) => {
   const { query } = useRouter();
@@ -69,7 +68,6 @@ const SearchBar: FunctionComponent<{ type: string; placeholder: string }> = ({
           size="large"
           form="searchPageForm"
           colors={themeValues.buttonColors.yellowYellowBlack}
-          isNewStyle
         />
       </SearchButtonWrapper>
     </Container>


### PR DESCRIPTION
## Who is this for?
new search

## What is it doing for them?
- I went to other way with #9061 . The `isNewStyle` styles haven't been officialised and should be part of a bigger design decision. As you also need a visual/non-colour-change related feedback that the button is being hovered on, I went with our decision to use underline as hover behaviour, making the Search button underline.
- Aligned copy in Sort dropdown to match the microcopy.

Closes #9061 