### PR TITLE
Fix concept link

### DIFF
--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -657,7 +657,8 @@ const WorkDetails: FunctionComponent<Props> = ({
                     ),
                     linkAttributes: {
                       href: {
-                        pathname: `/concepts/${s.id}`,
+                        pathname: '/concept',
+                        query: { id: s.id },
                       },
                       as: {
                         pathname: `/concepts/${s.id}`,


### PR DESCRIPTION
As part of debugging #8961, I noticed the Next.js links to the concept pages were erroring. In prod this manifests as the client side navigation to the concept page not working. Instead the page ends up being fetched from the server.

This fixes that.
