### PR TITLE
Fix broken redirects on item pages

### DIFF
--- a/.buildkite/urls/expected_200_urls.txt
+++ b/.buildkite/urls/expected_200_urls.txt
@@ -76,3 +76,7 @@
 # This page won't serve anything especially useful, but we want to
 # make sure it won't throw a 500 error
 /articles?page=343
+
+# This is an item page which has been redirected; we want to make
+# sure it redirects to the correct location
+/works/m58dxy2s/items

--- a/catalogue/webapp/pages/item.tsx
+++ b/catalogue/webapp/pages/item.tsx
@@ -381,10 +381,19 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
 
     if (work.type === 'Error') {
       return appError(context, work.httpStatus, work.description);
-    } else if (work.type === 'Redirect') {
+    }
+
+    if (work.type === 'Redirect') {
+      // This ensures that any query parameters are preserved on redirect,
+      // e.g. if you have a link to /works/$oldId/items?canvas=10, then
+      // you'll go to /works/$newId/items?canvas=10
+      const destination = isNotUndefined(context.req.url)
+        ? context.req.url.replace(workId, work.redirectToId)
+        : `/works/${work.redirectToId}/items`;
+
       return {
         redirect: {
-          destination: work.redirectToId,
+          destination,
           permanent: work.status === 301,
         },
       };


### PR DESCRIPTION
Previously we were only replacing the final part of the URL, so `/works/$oldId/items` would be redirected to `/works/$oldId/$newId`.