### PR TITLE
Fix No results message

### DIFF
--- a/catalogue/webapp/components/SearchNoResults/SearchNoResults.tsx
+++ b/catalogue/webapp/components/SearchNoResults/SearchNoResults.tsx
@@ -34,9 +34,8 @@ const SearchNoResults: FunctionComponent<Props> = ({
             <Copy textColor={textColor}>
               We couldn&rsquo;t find anything that matched{' '}
               <QuerySpan>{query}</QuerySpan>
-              {hasFilters && (
-                <> with the filters you have selected. Please try again.</>
-              )}
+              {hasFilters ? ' with the filters you have selected.' : '.'} Please
+              try again.
             </Copy>
           </div>
         </div>

--- a/catalogue/webapp/pages/search/works.tsx
+++ b/catalogue/webapp/pages/search/works.tsx
@@ -147,7 +147,12 @@ export const CatalogueSearchPage: NextPageWithLayout<Props> = ({
               <SearchNoResults
                 query={queryString}
                 hasFilters={hasFilters({
-                  filters: filters.map(f => f.id),
+                  filters: [
+                    ...filters.map(f => f.id),
+                    // production.dates is one dropdown but two properties, so we're specifying them in their individual format
+                    'production.dates.from',
+                    'production.dates.to',
+                  ],
                   queryParams: Object.keys(query).map(p => p),
                 })}
               />


### PR DESCRIPTION
## Who is this for?
Users using search

## What is it doing for them?
- The message had lost its "please try again" part when it didn't have filters, re-added that
- Made sure dates were considered "selected" filters for the message (currently ignored)

Notes: `/works` only looks at dates as a filter, and `/images` at color only, in order to display "with the filters you have selected". I'm unsure why, we've changed that in the new search. I haven't fixed it as part of this ticket as we'll remove these pages shortly. But they've at least retrieved the "please try again" part of the message.

Closes #9062 