### PR TITLE
Ensure correct data is sent with page view tracking

### DIFF
--- a/common/services/conversion/track.ts
+++ b/common/services/conversion/track.ts
@@ -138,7 +138,7 @@ function track(conversion: Conversion) {
   localStorage.setItem(lastTrackedLocalStorageKey, Date.now().toString());
 
   if (debug) {
-    console.info({
+    console.info(eventGroup, {
       session,
       properties: { ...properties, toggles },
       ...restConversion,

--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -97,7 +97,8 @@ const WecoApp: FunctionComponent<WecoAppProps> = ({
   });
 
   useOnPageLoad(url => ReactGA.pageview(url));
-  useOnPageLoad(() => {
+
+  useEffect(() => {
     if (pageProps.pageview) {
       trackPageview({
         name: pageProps.pageview.name,
@@ -105,7 +106,11 @@ const WecoApp: FunctionComponent<WecoAppProps> = ({
         eventGroup: pageProps.pageview.eventGroup,
       });
     }
-  });
+  }, [pageProps.pageview]);
+  // pageProps.pageview is updated by getServerSideProps
+  // getServerSideProps is run when the page is requested directly
+  // or when requested client-side through next/link or next/router
+  // i.e. everything that we consider to be a page view
 
   usePrismicPreview(() => Boolean(document.cookie.match('isPreview=true')));
 


### PR DESCRIPTION
Fixes #8961

The correct page data was only being sent when the page was rendered from the server and not when client side routing was involved.

This was because the useEffect inside useOnPageLoad didn't have pageProps as a dependency and so, "...your code will reference stale values from previous renders" ([Conditionally firing an effect](https://reactjs.org/docs/hooks-reference.html#conditionally-firing-an-effect)).

Instead of using useOnPageLoad, I've moved the page tracking code into its own useEffect with pageProps.pageview as the dependency. This seems to fix the issue and satisfies the [criteria](https://github.com/wellcomecollection/wellcomecollection.org/issues/8961#issuecomment-1339176821) @jamieparkinson outlined.

N.B.   pageProps.pageview is updated by getServerSideProps which runs when the page is requested directly or when requested client-side through next/link or next/router. All of which I think we'd describe as a page view and therefore should be tracked.
