### PR TITLE
Disable filter dropdowns if no options are available

### DIFF
--- a/common/views/components/DropdownButton/DropdownButton.tsx
+++ b/common/views/components/DropdownButton/DropdownButton.tsx
@@ -85,6 +85,7 @@ type Props = {
   isOnDark?: boolean;
   iconLeft?: IconSvg;
   isPill?: boolean;
+  isDisabled?: boolean;
 };
 
 const DropdownButton: FunctionComponent<Props> = ({
@@ -95,6 +96,7 @@ const DropdownButton: FunctionComponent<Props> = ({
   id,
   iconLeft,
   isPill,
+  isDisabled,
 }) => {
   const [isActive, setIsActive] = useState(false);
   const [focusables, setFocusables] = useState<HTMLElement[]>([]);
@@ -159,6 +161,7 @@ const DropdownButton: FunctionComponent<Props> = ({
     ariaControls: id,
     ariaExpanded: isActive,
     isPill,
+    disabled: isDisabled,
   };
   return (
     <DropdownWrapper ref={dropdownWrapperRef}>

--- a/common/views/components/SearchFilters/SearchFiltersDesktop.tsx
+++ b/common/views/components/SearchFilters/SearchFiltersDesktop.tsx
@@ -38,6 +38,7 @@ type CheckboxFilterProps = {
   changeHandler: () => void;
   form?: string;
   isNewStyle?: boolean;
+  isDisabled?: boolean;
 };
 
 const Wrapper = styled(Space).attrs({
@@ -56,6 +57,7 @@ const CheckboxFilter = ({
   changeHandler,
   form,
   isNewStyle,
+  isDisabled,
 }: CheckboxFilterProps) => {
   return (
     <DropdownButton
@@ -63,6 +65,7 @@ const CheckboxFilter = ({
       label={f.label}
       buttonType="inline"
       id={f.id}
+      isDisabled={isDisabled}
     >
       <PlainList className={font('intr', 5)}>
         <ul className={`no-margin no-padding plain-list ${font('intr', 5)}`}>
@@ -216,9 +219,6 @@ const DynamicFilterArray = ({
 
   const filterClassname = 'superUniqueDropdownFilterButtonClass';
   const renderDynamicFilter = (f: Filter, i: number, arr: Filter[]) => {
-    if (f.type === 'checkbox' && f.options.length === 0) {
-      return <></>; // if there are no options, do not render the dropdown button
-    }
     return (
       <Space
         key={f.id}
@@ -238,6 +238,7 @@ const DynamicFilterArray = ({
             changeHandler={changeHandler}
             form={showMoreFiltersModal ? undefined : searchFormId}
             isNewStyle={isNewStyle}
+            isDisabled={!f.options.length}
           />
         )}
 
@@ -378,7 +379,7 @@ const SearchFiltersDesktop: FunctionComponent<SearchFiltersSharedProps> = ({
         <Space
           h={{
             size: 'm',
-            properties: !!isNewStyle
+            properties: isNewStyle
               ? ['padding-right']
               : ['padding-left', 'padding-right'],
           }}

--- a/common/views/components/SearchFilters/SearchFiltersDesktop.tsx
+++ b/common/views/components/SearchFilters/SearchFiltersDesktop.tsx
@@ -238,7 +238,7 @@ const DynamicFilterArray = ({
             changeHandler={changeHandler}
             form={showMoreFiltersModal ? undefined : searchFormId}
             isNewStyle={isNewStyle}
-            isDisabled={!f.options.length}
+            isDisabled={f.options.length === 0}
           />
         )}
 


### PR DESCRIPTION
## Who is this for?
New search - testing behaviour

## What is it doing for them?
Allows us to see if we prefer disabling dropdowns if no options are available VS hiding them completely.

You could test with something like `/search/works?query=musical&workType=c` or with a search term that returns nothing:

<img width="1298" alt="Screenshot 2023-01-12 at 14 20 34" src="https://user-images.githubusercontent.com/110461050/212093094-5f35365b-2639-4674-a005-ca453ee31664.png">

**Note:** This is just to start behaviour to start with, if we decide we'd like to go ahead with it, I'll style the disabled state differently. There is currently a design review for this component, so all those changes could be done at the same time.

Closes #9080 