### PR TITLE
Licences to use UK spelling for UI

### DIFF
--- a/common/services/catalogue/filters.ts
+++ b/common/services/catalogue/filters.ts
@@ -349,7 +349,7 @@ const licensesFilter = ({
 }: ImagesFilterProps): CheckboxFilter => ({
   type: 'checkbox',
   id: 'locations.license',
-  label: 'Licenses',
+  label: 'Licences', // UK spelling for UI
   options: filterOptionsWithNonAggregates({
     options: images.aggregations?.license?.buckets.map(bucket => ({
       id: bucket.data.id,


### PR DESCRIPTION
## Who is this for?
British spelling!

## What is it doing for them?
- Changes "Licenses" to "Licences" on the UI as [flagged by Natalie](https://wellcome.slack.com/archives/C3TQSF63C/p1673432148251449?thread_ts=1673354994.931719&cid=C3TQSF63C). I remember having discussed this a few weeks back and making that change for the image modal, so doing this to align.

<img width="533" alt="Screenshot 2023-01-12 at 14 45 38" src="https://user-images.githubusercontent.com/110461050/212097190-96f56a5e-365e-41d7-a914-a0fdaf4f37b3.png">

<img width="1001" alt="Screenshot 2023-01-12 at 14 41 07" src="https://user-images.githubusercontent.com/110461050/212096977-93d66fa9-81b6-4c8a-a7a7-1c5d17ba12d6.png">

Closes #9067 
