### PR TITLE
WIP: Use PrismicImage in StoriesGrid

### DIFF
--- a/catalogue/webapp/components/StoriesGrid/StoriesGrid.tsx
+++ b/catalogue/webapp/components/StoriesGrid/StoriesGrid.tsx
@@ -6,6 +6,9 @@ import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
 import { font } from '@weco/common/utils/classnames';
 import HTMLDate from '@weco/common/views/components/HTMLDate/HTMLDate';
 import { Story } from '@weco/catalogue/services/prismic/types/story';
+import PrismicImage, {
+  BreakpointSizes,
+} from '@weco/common/views/components/PrismicImage/PrismicImage';
 
 const StoriesContainer = styled.div<{ isDetailed?: boolean }>`
   display: flex;
@@ -42,6 +45,12 @@ const StoryWrapper = styled(Space).attrs<{
 
   &:last-child {
     padding-bottom: 0;
+  }
+
+  &:hover {
+    h3 {
+      text-decoration: underline;
+    }
   }
 
   ${props =>
@@ -85,15 +94,20 @@ const ImageWrapper = styled.div<{ isDetailed?: boolean }>`
   justify-content: center;
   align-items: center;
 
-  ${props =>
-    props.isDetailed
-      ? ``
-      : `
-        img {
-            object-fit: cover;
-            height: 100%;
-        }
-    `}
+  & > div {
+    height: 100%;
+    width: 100%;
+
+    ${props =>
+      props.isDetailed
+        ? ``
+        : `
+          img {
+              object-fit: cover;
+              height: 100%;
+          }
+      `}
+  }
 
   ${props =>
     props.theme.media('medium')(`
@@ -159,13 +173,21 @@ const StoryInformationItem = styled.span`
   }
 `;
 
+type ImageConfigProps = {
+  width: number;
+  height: number;
+  sizes?: BreakpointSizes;
+};
+
 type Props = {
   stories: Story[];
   isDetailed?: boolean;
+  imagesSize: ImageConfigProps;
 };
 
 const StoriesGrid: FunctionComponent<Props> = ({
   stories,
+  imagesSize,
   isDetailed,
 }: Props) => {
   return (
@@ -178,7 +200,14 @@ const StoriesGrid: FunctionComponent<Props> = ({
           isDetailed={isDetailed}
         >
           <ImageWrapper isDetailed={isDetailed}>
-            <img src={story.image.url} alt="" />
+            <PrismicImage
+              image={{
+                contentUrl: story.image.url,
+                alt: '',
+                ...imagesSize,
+              }}
+              quality="low"
+            />
 
             {story.type && (
               <MobileLabel>

--- a/catalogue/webapp/components/StoriesGrid/StoriesGrid.tsx
+++ b/catalogue/webapp/components/StoriesGrid/StoriesGrid.tsx
@@ -9,7 +9,6 @@ import { Story } from '@weco/catalogue/services/prismic/types/story';
 import PrismicImage, {
   BreakpointSizes,
 } from '@weco/common/views/components/PrismicImage/PrismicImage';
-import { ImageDimensions } from '@weco/common/model/image';
 
 const StoriesContainer = styled.div<{ isDetailed?: boolean }>`
   display: flex;
@@ -176,14 +175,12 @@ const StoryInformationItem = styled.span`
 
 type Props = {
   stories: Story[];
-  defaultImageSize: ImageDimensions;
   dynamicImageSizes?: BreakpointSizes;
   isDetailed?: boolean;
 };
 
 const StoriesGrid: FunctionComponent<Props> = ({
   stories,
-  defaultImageSize,
   dynamicImageSizes,
   isDetailed,
 }: Props) => {
@@ -201,7 +198,8 @@ const StoriesGrid: FunctionComponent<Props> = ({
               image={{
                 contentUrl: story.image.url,
                 alt: '',
-                ...defaultImageSize,
+                width: story.image.width,
+                height: story.image.height,
               }}
               sizes={dynamicImageSizes}
               quality="low"

--- a/catalogue/webapp/components/StoriesGrid/StoriesGrid.tsx
+++ b/catalogue/webapp/components/StoriesGrid/StoriesGrid.tsx
@@ -9,6 +9,7 @@ import { Story } from '@weco/catalogue/services/prismic/types/story';
 import PrismicImage, {
   BreakpointSizes,
 } from '@weco/common/views/components/PrismicImage/PrismicImage';
+import { ImageDimensions } from '@weco/common/model/image';
 
 const StoriesContainer = styled.div<{ isDetailed?: boolean }>`
   display: flex;
@@ -173,21 +174,17 @@ const StoryInformationItem = styled.span`
   }
 `;
 
-type ImageConfigProps = {
-  width: number;
-  height: number;
-  sizes?: BreakpointSizes;
-};
-
 type Props = {
   stories: Story[];
+  defaultImageSize: ImageDimensions;
+  dynamicImageSizes?: BreakpointSizes;
   isDetailed?: boolean;
-  imagesSize: ImageConfigProps;
 };
 
 const StoriesGrid: FunctionComponent<Props> = ({
   stories,
-  imagesSize,
+  defaultImageSize,
+  dynamicImageSizes,
   isDetailed,
 }: Props) => {
   return (
@@ -204,8 +201,9 @@ const StoriesGrid: FunctionComponent<Props> = ({
               image={{
                 contentUrl: story.image.url,
                 alt: '',
-                ...imagesSize,
+                ...defaultImageSize,
               }}
+              sizes={dynamicImageSizes}
               quality="low"
             />
 

--- a/catalogue/webapp/pages/search/index.tsx
+++ b/catalogue/webapp/pages/search/index.tsx
@@ -133,7 +133,13 @@ export const SearchPage: NextPageWithLayout<Props> = ({
                 <div className="container">
                   <SectionTitle sectionName="Stories" />
 
-                  <StoriesGrid stories={stories} />
+                  <StoriesGrid
+                    stories={stories}
+                    imagesSize={{
+                      width: 300,
+                      height: 200,
+                    }}
+                  />
 
                   <Space v={{ size: 'l', properties: ['padding-top'] }}>
                     <SeeMoreButton
@@ -199,7 +205,6 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       serverData,
       query,
 
-      // TODO Harrison to explore what properties we'd want here
       pageview: {
         name: 'search',
         properties: {},

--- a/catalogue/webapp/pages/search/index.tsx
+++ b/catalogue/webapp/pages/search/index.tsx
@@ -135,9 +135,15 @@ export const SearchPage: NextPageWithLayout<Props> = ({
 
                   <StoriesGrid
                     stories={stories}
-                    imagesSize={{
-                      width: 300,
-                      height: 200,
+                    defaultImageSize={{
+                      width: 400,
+                      height: 300,
+                    }}
+                    dynamicImageSizes={{
+                      xlarge: 1 / 5,
+                      large: 1 / 4,
+                      medium: 1 / 2,
+                      small: 1 / 2,
                     }}
                   />
 

--- a/catalogue/webapp/pages/search/index.tsx
+++ b/catalogue/webapp/pages/search/index.tsx
@@ -135,13 +135,9 @@ export const SearchPage: NextPageWithLayout<Props> = ({
 
                   <StoriesGrid
                     stories={stories}
-                    defaultImageSize={{
-                      width: 400,
-                      height: 300,
-                    }}
                     dynamicImageSizes={{
                       xlarge: 1 / 5,
-                      large: 1 / 4,
+                      large: 1 / 5,
                       medium: 1 / 2,
                       small: 1 / 2,
                     }}

--- a/catalogue/webapp/pages/search/stories.tsx
+++ b/catalogue/webapp/pages/search/stories.tsx
@@ -103,13 +103,18 @@ export const SearchPage: NextPageWithLayout<Props> = ({
 
           <main>
             <StoriesGrid
+              isDetailed
               stories={storyResponseList.results}
-              imagesSize={{
+              defaultImageSize={{
                 width: 600,
                 height: 400,
-                sizes: { xlarge: 1 / 6, large: 1 / 6, medium: 1, small: 1 },
               }}
-              isDetailed
+              dynamicImageSizes={{
+                xlarge: 1 / 6,
+                large: 1 / 6,
+                medium: 1,
+                small: 1,
+              }}
             />
           </main>
 

--- a/catalogue/webapp/pages/search/stories.tsx
+++ b/catalogue/webapp/pages/search/stories.tsx
@@ -102,7 +102,15 @@ export const SearchPage: NextPageWithLayout<Props> = ({
           </PaginationWrapper>
 
           <main>
-            <StoriesGrid stories={storyResponseList.results} isDetailed />
+            <StoriesGrid
+              stories={storyResponseList.results}
+              imagesSize={{
+                width: 600,
+                height: 400,
+                sizes: { xlarge: 1 / 6, large: 1 / 6, medium: 1, small: 1 },
+              }}
+              isDetailed
+            />
           </main>
 
           <PaginationWrapper verticalSpacing="l" alignRight>

--- a/catalogue/webapp/pages/search/stories.tsx
+++ b/catalogue/webapp/pages/search/stories.tsx
@@ -105,14 +105,10 @@ export const SearchPage: NextPageWithLayout<Props> = ({
             <StoriesGrid
               isDetailed
               stories={storyResponseList.results}
-              defaultImageSize={{
-                width: 600,
-                height: 400,
-              }}
               dynamicImageSizes={{
-                xlarge: 1 / 6,
-                large: 1 / 6,
-                medium: 1,
+                xlarge: 1 / 5,
+                large: 1 / 5,
+                medium: 1 / 5,
                 small: 1,
               }}
             />

--- a/catalogue/webapp/services/prismic/transformers/index.ts
+++ b/catalogue/webapp/services/prismic/transformers/index.ts
@@ -34,6 +34,8 @@ export async function transformPrismicResponse(
       title: title[0]?.text,
       image: {
         url: image.image?.url,
+        width: image.image?.dimensions?.width,
+        height: image.image?.dimensions?.height,
       },
       url: `https://wellcomecollection.org/${type}/${id}`,
       firstPublicationDate,

--- a/catalogue/webapp/services/prismic/types/event.ts
+++ b/catalogue/webapp/services/prismic/types/event.ts
@@ -6,6 +6,8 @@ export type Event = {
   title: Title;
   image: {
     url: string;
+    width: number;
+    height: number;
   };
   url: string;
   firstPublicationDate: Date;

--- a/catalogue/webapp/services/prismic/types/exhibition.ts
+++ b/catalogue/webapp/services/prismic/types/exhibition.ts
@@ -6,6 +6,8 @@ export type Exhibition = {
   title: Title;
   image: {
     url: string;
+    width: number;
+    height: number;
   };
   url: string;
   firstPublicationDate: Date;

--- a/catalogue/webapp/services/prismic/types/index.ts
+++ b/catalogue/webapp/services/prismic/types/index.ts
@@ -1,6 +1,7 @@
 import { Story } from './story';
 import { Event } from './event';
 import { Exhibition } from './exhibition';
+import { ImageDimensions } from '@weco/common/model/image';
 
 const contentTypes = [
   'articles',
@@ -39,6 +40,7 @@ export type Standfirst = {
 
 export type Image = {
   url: string;
+  dimensions: ImageDimensions;
 };
 
 export type Promo = {

--- a/catalogue/webapp/services/prismic/types/story.ts
+++ b/catalogue/webapp/services/prismic/types/story.ts
@@ -6,6 +6,8 @@ export type Story = {
   title: Title;
   image: {
     url: string;
+    width: number;
+    height: number;
   };
   url: string;
   firstPublicationDate: Date;

--- a/catalogue/webapp/test/prismic/index.test.ts
+++ b/catalogue/webapp/test/prismic/index.test.ts
@@ -78,6 +78,8 @@ describe('transformPrismicResponse', () => {
         contributors: ['Willow Wisp'],
         image: {
           url: 'https://images.prismic.io/wellcomecollection/8b6b4b4e-4f1c-4f9e-8c1a-1b0c2b0e8b1a_The+cat+in+the+hat.jpg?auto=compress,format&rect=0,0,2000,2000&w=2000&h=2000',
+          width: 4000,
+          height: 2644,
         },
         label: { text: 'Article' },
         type: ['articles'],

--- a/common/model/image.ts
+++ b/common/model/image.ts
@@ -2,7 +2,7 @@ import { Tasl } from './tasl';
 
 export type Crop = '32:15' | '16:9' | 'square';
 
-type ImageDimensions = {
+export type ImageDimensions = {
   width: number;
   height: number;
 };


### PR DESCRIPTION
## Who is this for?
New search/faster results

## What is it doing for them?
- Uses `PrismicImage`, which ensures we only load the size of image we actually need.
- Modifies hover behaviour to match `/articles`'s

Closes #9059 