### PR TITLE
Dasherize TASL ids

### DIFF
--- a/common/views/components/Tasl/Tasl.tsx
+++ b/common/views/components/Tasl/Tasl.tsx
@@ -7,6 +7,7 @@ import Icon from '../Icon/Icon';
 import Space from '../styled/Space';
 import styled from 'styled-components';
 import { cross, information } from '@weco/common/icons';
+import { dasherizeShorten } from '@weco/common/utils/grammar';
 
 type StyledTaslProps = {
   positionAtTop: boolean;
@@ -204,13 +205,21 @@ const Tasl: FunctionComponent<Props> = ({
     setIsActive(!isActive);
   }
 
+  const id = title
+    ? dasherizeShorten(title)
+    : sourceName
+    ? dasherizeShorten(sourceName)
+    : copyrightHolder
+    ? dasherizeShorten(copyrightHolder)
+    : '';
+
   return [title, sourceName, copyrightHolder].some(_ => _) ? (
     <StyledTasl positionAtTop={positionTop} isEnhanced={isEnhanced}>
       <TaslButton
         onClick={toggleWithAnalytics}
         positionAtTop={positionTop}
         aria-expanded={isActive}
-        aria-controls={title || sourceName || copyrightHolder || ''}
+        aria-controls={id}
       >
         <TaslIcon isEnhanced={isEnhanced}>
           <Icon icon={isActive ? cross : information} iconColor="white" />
@@ -222,7 +231,7 @@ const Tasl: FunctionComponent<Props> = ({
         </TaslIcon>
       </TaslButton>
       <InfoContainer
-        id={title || sourceName || copyrightHolder || ''}
+        id={id}
         className={classNames({
           'is-hidden': isEnhanced && !isActive,
         })}

--- a/common/views/components/Tasl/Tasl.tsx
+++ b/common/views/components/Tasl/Tasl.tsx
@@ -73,6 +73,7 @@ export type MarkUpProps = {
   license?: string;
   copyrightHolder?: string;
   copyrightLink?: string;
+  idSuffix?: string;
 };
 
 function getMarkup({
@@ -191,6 +192,7 @@ const Tasl: FunctionComponent<Props> = ({
   license,
   copyrightHolder,
   copyrightLink,
+  idSuffix = '',
 }: Props) => {
   const { isEnhanced } = useContext(AppContext);
   const [isActive, setIsActive] = useState(false);
@@ -212,6 +214,7 @@ const Tasl: FunctionComponent<Props> = ({
     : copyrightHolder
     ? dasherizeShorten(copyrightHolder)
     : '';
+  const idWithSuffix = `${id}${idSuffix}`;
 
   return [title, sourceName, copyrightHolder].some(_ => _) ? (
     <StyledTasl positionAtTop={positionTop} isEnhanced={isEnhanced}>
@@ -219,7 +222,7 @@ const Tasl: FunctionComponent<Props> = ({
         onClick={toggleWithAnalytics}
         positionAtTop={positionTop}
         aria-expanded={isActive}
-        aria-controls={id}
+        aria-controls={idWithSuffix}
       >
         <TaslIcon isEnhanced={isEnhanced}>
           <Icon icon={isActive ? cross : information} iconColor="white" />
@@ -231,7 +234,7 @@ const Tasl: FunctionComponent<Props> = ({
         </TaslIcon>
       </TaslButton>
       <InfoContainer
-        id={id}
+        id={idWithSuffix}
         className={classNames({
           'is-hidden': isEnhanced && !isActive,
         })}

--- a/content/webapp/components/CaptionedImage/CaptionedImage.tsx
+++ b/content/webapp/components/CaptionedImage/CaptionedImage.tsx
@@ -4,6 +4,8 @@ import styled from 'styled-components';
 import { CaptionedImage as CaptionedImageType } from '@weco/common/model/captioned-image';
 import ImageWithTasl from '../ImageWithTasl/ImageWithTasl';
 import HeightRestrictedPrismicImage from '@weco/common/views/components/HeightRestrictedPrismicImage/HeightRestrictedPrismicImage';
+import { dasherizeShorten } from '@weco/common/utils/grammar';
+import * as prismicH from '@prismicio/helpers';
 
 type CaptionedImageFigureProps = {
   isBody?: boolean;
@@ -78,6 +80,7 @@ const CaptionedImage: FunctionComponent<CaptionedImageProps> = ({
   // and (2) what the correct default is.
   //
   // See https://wellcome.slack.com/archives/C8X9YKM5X/p1653466941113029
+
   return (
     <CaptionedImageFigure isBody={isBody}>
       <ImageContainerInner
@@ -86,7 +89,10 @@ const CaptionedImage: FunctionComponent<CaptionedImageProps> = ({
       >
         <ImageWithTasl
           Image={<HeightRestrictedPrismicImage image={image} quality="high" />}
-          tasl={image.tasl}
+          tasl={{
+            ...image.tasl,
+            idSuffix: dasherizeShorten(prismicH.asText(caption)),
+          }}
         />
         <Caption caption={caption} preCaptionNode={preCaptionNode} />
       </ImageContainerInner>

--- a/content/webapp/components/CaptionedImage/CaptionedImage.tsx
+++ b/content/webapp/components/CaptionedImage/CaptionedImage.tsx
@@ -5,7 +5,6 @@ import { CaptionedImage as CaptionedImageType } from '@weco/common/model/caption
 import ImageWithTasl from '../ImageWithTasl/ImageWithTasl';
 import HeightRestrictedPrismicImage from '@weco/common/views/components/HeightRestrictedPrismicImage/HeightRestrictedPrismicImage';
 import { dasherizeShorten } from '@weco/common/utils/grammar';
-import * as prismicH from '@prismicio/helpers';
 
 type CaptionedImageFigureProps = {
   isBody?: boolean;
@@ -91,7 +90,7 @@ const CaptionedImage: FunctionComponent<CaptionedImageProps> = ({
           Image={<HeightRestrictedPrismicImage image={image} quality="high" />}
           tasl={{
             ...image.tasl,
-            idSuffix: dasherizeShorten(prismicH.asText(caption)),
+            idSuffix: dasherizeShorten(image.contentUrl),
           }}
         />
         <Caption caption={caption} preCaptionNode={preCaptionNode} />


### PR DESCRIPTION
☝️ 

We were using strings with spaces for ids which isn't valid html.

**edit** ~~just seen that this won't be good enough because we also have multiple images on the same page with the same id (using the same title/source/copyright as the base).~~

**edit 2** ~~I've now dasherized the captions of `CaptionedImage`s and concatenated that onto the end of the dasherized title to ensure uniqueness.~~

**edit 3** At Ben's very sensible suggestion, I'm now using the guaranteed-to-be-unique image filename as the suffix.