### PR TITLE
Colour filter console warning fix

### DIFF
--- a/common/views/components/PaletteColorPicker/PaletteColorPicker.tsx
+++ b/common/views/components/PaletteColorPicker/PaletteColorPicker.tsx
@@ -170,7 +170,7 @@ const PaletteColorPicker: FunctionComponent<Props> = ({
           form={form}
           type="color"
           name={name}
-          value={
+          defaultValue={
             color
               ? color[0] === '#' || color[0] === '%' // url encoded value for the hash symbol is '%23'
                 ? color


### PR DESCRIPTION
## Who is this for?
Devs

## What is it doing for them?
Fixes console warning:

```
Warning: You provided a `value` prop to a form field without an `onChange` handler. This will render a read-only field. If the field should be mutable use `defaultValue`. Otherwise, set either `onChange` or `readOnly`.
```