### PR TITLE
Take invalid 'value' prop off TextInputWrap (div)

### DIFF
--- a/common/views/components/TextInput/TextInput.tsx
+++ b/common/views/components/TextInput/TextInput.tsx
@@ -4,7 +4,6 @@ import Icon from '@weco/common/views/components/Icon/Icon';
 import { check } from '@weco/common/icons';
 
 type TextInputWrapProps = {
-  value: string;
   hasErrorBorder: boolean;
   big?: boolean;
   darkBg?: boolean;
@@ -200,7 +199,6 @@ const Input: FunctionComponent<Props> = (
   return (
     <div>
       <TextInputWrap
-        value={value}
         hasErrorBorder={!!(!isValid && showValidity)}
         darkBg={darkBg}
         big={!!big}

--- a/identity/webapp/src/frontend/components/PasswordInput/PasswordInput.tsx
+++ b/identity/webapp/src/frontend/components/PasswordInput/PasswordInput.tsx
@@ -30,7 +30,7 @@ export const PasswordInput: React.FunctionComponent<PasswordInputProps> =
 
     return (
       <>
-        <TextInputWrap hasErrorBorder={meta.invalid} value={field.value}>
+        <TextInputWrap hasErrorBorder={meta.invalid}>
           <TextInputLabel
             htmlFor={props.id}
             isEnhanced={true}


### PR DESCRIPTION
☝️ 

We weren't using it as a prop in the styled-component and it is invalid to have `value` as an attribute on a div.