### PR TITLE
Remove sass (@include)

### DIFF
--- a/common/views/themes/base/container.ts
+++ b/common/views/themes/base/container.ts
@@ -30,31 +30,13 @@ export const container = `
 
     &::-webkit-scrollbar {
       height: 18px;
-      background: ${themeValues.color('white')};
     }
 
     &::-webkit-scrollbar-thumb {
       border-radius: 0;
       border-style: solid;
-      border-color: ${themeValues.color('white')};
       border-width: 0 ${themeValues.containerPadding.small}px 12px;
       background: ${themeValues.color('neutral.400')};
-
-      @include respond-to('medium') {
-        border-left-width: ${themeValues.containerPadding.medium}px;
-        border-right-width: ${themeValues.gutter.medium}px;
-      }
-
-      @include respond-to('large') {
-        border-left-width: ${themeValues.containerPadding.large}px;
-        border-right-width: ${themeValues.gutter.large}px;
-      }
-
-      @include respond-to('xlarge') {
-        border-left-width: calc(((100vw - ${
-          themeValues.sizes.xlarge
-        }px) / 2) + ${themeValues.containerPadding.large}px);
-      }
     }
   `)}
 }


### PR DESCRIPTION
## Who is this for?
People who want valid html

## What is it doing for them?
Removing an `@include` rule that we forgot to remove in the port to styled-components.

Removing the includes alone left the scrollbar on a white background below the cards (not what we want). Taking out the `::-webkit-scrollbar` background and the `::-webkit-scrollbar-thumb` `border-color` gets us back to parity with the current styles.