### PR TITLE
Ensure children are allowed elements within parents

### DIFF
--- a/common/views/components/CookieNotice/CookieNotice.tsx
+++ b/common/views/components/CookieNotice/CookieNotice.tsx
@@ -66,7 +66,6 @@ const CookieNotice: FunctionComponent<Props> = ({ source }) => {
             <div className="flex flex--v-center">
               <Icon icon={cookiesIcon} iconColor="white" />
               <Space
-                as="span"
                 h={{
                   size: 's',
                   properties: ['margin-left', 'margin-right'],

--- a/common/views/components/Icon/Icon.tsx
+++ b/common/views/components/Icon/Icon.tsx
@@ -9,7 +9,7 @@ type WrapperProps = {
   matchText?: boolean;
 };
 
-const Wrapper = styled.div.attrs({
+const Wrapper = styled.span.attrs({
   className: 'icon',
 })<WrapperProps>`
   display: inline-block;


### PR DESCRIPTION
## Who is this for?
Valid html-ers

## What is it doing for them?
- preventing `h2` from appearing inside a `span`
- preventing a `div` from appearing inside a `button`