### PR TITLE
Desaturate img

### DIFF
--- a/common/views/components/PrismicImage/PrismicImage.tsx
+++ b/common/views/components/PrismicImage/PrismicImage.tsx
@@ -10,11 +10,9 @@ import { ImageType } from '../../../model/image';
 // Since this wrapper is only used in this file, we use the slightly clunkier
 // 1 = true / 0 = false to silence the warning.
 const StyledImage = styled(Image)<{ desaturate: 1 | 0 }>`
-  ${props => `
-    color: ${props.theme.color('white')};
-    background-color: ${props.theme.color('neutral.700')};
-    `}
-  ${props => props.desaturate === 1 && 'filter: saturate(0%);'};
+  color: ${props => props.theme.color('white')};
+  background-color: ${props => props.theme.color('neutral.700')};
+  filter: ${props => (props.desaturate ? 'saturate(0%)' : undefined)};
 `;
 
 export type BreakpointSizes = Partial<Record<Breakpoint, number>>;

--- a/common/views/components/PrismicImage/PrismicImage.tsx
+++ b/common/views/components/PrismicImage/PrismicImage.tsx
@@ -4,10 +4,10 @@ import styled from 'styled-components';
 import { Breakpoint, sizes as breakpointSizes } from '../../themes/config';
 import { ImageType } from '../../../model/image';
 
-const StyledImage = styled(Image)<{ desaturate: boolean }>`
+const StyledImage = styled(Image)<{ $desaturate: boolean }>`
   color: ${props => props.theme.color('white')};
   background-color: ${props => props.theme.color('neutral.700')};
-  filter: ${props => (props.desaturate ? 'saturate(0%)' : undefined)};
+  filter: ${props => (props.$desaturate ? 'saturate(0%)' : undefined)};
 `;
 
 export type BreakpointSizes = Partial<Record<Breakpoint, number>>;
@@ -117,7 +117,7 @@ const PrismicImage: FunctionComponent<Props> = ({
       src={image.contentUrl}
       alt={image.alt || ''}
       loader={createPrismicLoader(maxLoaderWidth, quality)}
-      desaturate={desaturate}
+      $desaturate={desaturate}
     />
   );
 };

--- a/common/views/components/PrismicImage/PrismicImage.tsx
+++ b/common/views/components/PrismicImage/PrismicImage.tsx
@@ -4,12 +4,7 @@ import styled from 'styled-components';
 import { Breakpoint, sizes as breakpointSizes } from '../../themes/config';
 import { ImageType } from '../../../model/image';
 
-// Note: for some reason passing a boolean to desaturate causes a warning;
-// see the commit message for the full stack trace.
-//
-// Since this wrapper is only used in this file, we use the slightly clunkier
-// 1 = true / 0 = false to silence the warning.
-const StyledImage = styled(Image)<{ desaturate: 1 | 0 }>`
+const StyledImage = styled(Image)<{ desaturate: boolean }>`
   color: ${props => props.theme.color('white')};
   background-color: ${props => props.theme.color('neutral.700')};
   filter: ${props => (props.desaturate ? 'saturate(0%)' : undefined)};
@@ -122,7 +117,7 @@ const PrismicImage: FunctionComponent<Props> = ({
       src={image.contentUrl}
       alt={image.alt || ''}
       loader={createPrismicLoader(maxLoaderWidth, quality)}
-      desaturate={desaturate ? 1 : 0}
+      desaturate={desaturate}
     />
   );
 };


### PR DESCRIPTION
## Who is this for?
Valid html-ers

## What is it doing for them?
Preventing `desaturate="1"` appearing in the rendered `img` markup.

I'm not too sure why this rejig works, but it does (and gets rid of the need to juggle between `boolean` and `1`| `0` for the prop.