### PR TITLE
Don't send error alerts for PHP endpoints

### DIFF
--- a/cache/send_slack_alert_for_5xx_errors.js
+++ b/cache/send_slack_alert_for_5xx_errors.js
@@ -333,6 +333,16 @@ function isInterestingError(hit) {
     return false;
   }
 
+  // Ignore any requests for PHP pages.
+  //
+  // This is usually somebody doing something malicious and hitting
+  // an ALB error, e.g. somebody hammering /wp-login.php with a bunch
+  // of random errors.  We don't have any PHP endpoints, so people trying
+  // to target PHP exploits are just noise.
+  if (hit.path.endsWith('.php')) {
+    return false;
+  }
+
   // This is a path we use for testing the 500 error page.
   if (hit.path === '/500') {
     return false;

--- a/cache/send_slack_alert_for_5xx_errors.js
+++ b/cache/send_slack_alert_for_5xx_errors.js
@@ -14,7 +14,7 @@
  * there were errors, but with no way to identify which app was the source of
  * the errors.  Now we know which app's logs we should be checking first.)
  *
- * It's written in vanilla JavaScript/Node because it's pretty simpler, and
+ * It's written in vanilla JavaScript/Node because it's pretty simple, and
  * it simplifies the process of deployment.
  *
  */


### PR DESCRIPTION
To reduce noise in the #wc-platform-alerts channel.