### PR TITLE
Only show headings for former frequency/designation if they're populated

### DIFF
--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -526,13 +526,13 @@ const WorkDetails: FunctionComponent<Props> = ({
             text={work.currentFrequency}
           />
         )}
-        {work.formerFrequency && (
+        {work.formerFrequency.length > 0 && (
           <WorkDetailsText
             title="Former frequency"
             text={work.formerFrequency}
           />
         )}
-        {work.designation && (
+        {work.designation.length > 0 && (
           <WorkDetailsText title="Designation" text={work.designation} />
         )}
         {work.physicalDescription && (


### PR DESCRIPTION
I was mixing up Python (where an empty list of string is False) and JS (where an empty list of string is true), so when we got nothing back from the API, it would show a heading with nothing under it.

Closes https://github.com/wellcomecollection/platform/issues/5600