### PR TITLE
formerFrequency and designation length should be optional chaining

### DIFF
--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -526,13 +526,13 @@ const WorkDetails: FunctionComponent<Props> = ({
             text={work.currentFrequency}
           />
         )}
-        {work.formerFrequency.length > 0 && (
+        {work.formerFrequency?.length > 0 && (
           <WorkDetailsText
             title="Former frequency"
             text={work.formerFrequency}
           />
         )}
-        {work.designation.length > 0 && (
+        {work.designation?.length > 0 && (
           <WorkDetailsText title="Designation" text={work.designation} />
         )}
         {work.physicalDescription && (


### PR DESCRIPTION
## Who is this for?
broken e2es

## What is it doing for them?
`formerFrequency` and `designation` are not always returned so we're making them optional in the chain of conditions.