### PR TITLE
Add a white border to filters dropdown as their current one is invisible

### DIFF
--- a/common/views/components/DropdownButton/DropdownButton.tsx
+++ b/common/views/components/DropdownButton/DropdownButton.tsx
@@ -27,6 +27,7 @@ const DropdownWrapper = styled.div<{ hasNoOptions?: boolean }>`
     .icon__svg {
       width: 18px;
       left: 2px;
+      top: 1px;
     }
   `}
 `;
@@ -94,6 +95,7 @@ type Props = {
   isOnDark?: boolean;
   iconLeft?: IconSvg;
   isPill?: boolean;
+  isFilter?: boolean; // TODO This is a styling workaround for the /works & /images search, remove once we delete those pages.
   hasNoOptions?: boolean;
 };
 
@@ -105,6 +107,7 @@ const DropdownButton: FunctionComponent<Props> = ({
   id,
   iconLeft,
   isPill,
+  isFilter,
   hasNoOptions,
 }) => {
   const [isActive, setIsActive] = useState(false);
@@ -172,6 +175,7 @@ const DropdownButton: FunctionComponent<Props> = ({
     isPill,
     disabled: hasNoOptions,
   };
+
   return (
     <DropdownWrapper ref={dropdownWrapperRef} hasNoOptions={hasNoOptions}>
       {buttonType === 'inline' && (
@@ -182,6 +186,8 @@ const DropdownButton: FunctionComponent<Props> = ({
           colors={
             isOnDark
               ? themeValues.buttonColors.whiteTransparentWhite
+              : isFilter
+              ? themeValues.buttonColors.whiteWhiteCharcoal
               : themeValues.buttonColors.marbleWhiteCharcoal
           }
         />

--- a/common/views/components/SearchFilters/SearchFiltersDesktop.tsx
+++ b/common/views/components/SearchFilters/SearchFiltersDesktop.tsx
@@ -60,6 +60,7 @@ const CheckboxFilter = ({
   return (
     <DropdownButton
       isPill={isNewStyle}
+      isFilter
       label={f.label}
       buttonType="inline"
       id={f.id}
@@ -109,6 +110,7 @@ const DateRangeFilter = ({
     <Space className={font('intr', 5)}>
       <DropdownButton
         isPill={isNewStyle}
+        isFilter
         label={f.label}
         buttonType="inline"
         id={f.id}
@@ -169,6 +171,7 @@ const ColorFilter = ({
   return (
     <DropdownButton
       isPill={isNewStyle}
+      isFilter
       label="Colours"
       buttonType="inline"
       id="images.color"
@@ -494,7 +497,7 @@ const SearchFiltersDesktop: FunctionComponent<SearchFiltersSharedProps> = ({
                   >
                     {componentMounted && (
                       <ButtonSolid
-                        colors={themeValues.buttonColors.marbleWhiteCharcoal}
+                        colors={themeValues.buttonColors.whiteWhiteCharcoal}
                         hoverUnderline={true}
                         size="small"
                         type={ButtonTypes.button}

--- a/common/views/themes/config.ts
+++ b/common/views/themes/config.ts
@@ -202,6 +202,12 @@ const yellowYellowBlack: ButtonColors = {
   text: 'black',
 };
 
+const whiteWhiteCharcoal: ButtonColors = {
+  border: 'white',
+  background: 'white',
+  text: 'neutral.700', // legacy charcoal color
+};
+
 export type Size = keyof typeof sizes;
 const media =
   (sizeLabel: Size, minOrMaxWidth: 'min-width' | 'max-width' = 'min-width') =>
@@ -297,6 +303,7 @@ export const themeValues = {
     charcoalTransparentCharcoal,
     marbleWhiteCharcoal,
     yellowYellowBlack,
+    whiteWhiteCharcoal,
   },
 };
 


### PR DESCRIPTION
## Who is this for?
design

## What is it doing for them?
the current filters in `/works` have a border that is the same colour as their background. When some buttons become disabled, their change in border colour make them seem bigger. I've put in a temp workaround to change the default border to white (matching the new button design in which there is no visible border). 

Also[ adding the "cleaning up" TODO as part of the post-new search cleaning list.](https://github.com/wellcomecollection/wellcomecollection.org/issues/9034)