### PR TITLE
Remove spaces from tel in href

### DIFF
--- a/common/views/components/FindUs/FindUs.tsx
+++ b/common/views/components/FindUs/FindUs.tsx
@@ -29,7 +29,7 @@ const FindUs: FunctionComponent = () => (
     </Space>
     <p>
       <PlainLink
-        href={`tel:${wellcomeCollectionGallery.telephone}`}
+        href={`tel:${wellcomeCollectionGallery.telephone.replace(/\s/g, '')}`}
         aria-label={createScreenreaderLabel(
           wellcomeCollectionGallery.displayTelephone
         )}


### PR DESCRIPTION
## Who is this for?
Valid HTML fans

## What is it doing for them?
Removing spaces from the telephone number in the `tel:` `href`