### PR TITLE
Put commas in the right place for clip-path polygon

### DIFF
--- a/common/views/components/WobblyEdge/WobblyEdge.tsx
+++ b/common/views/components/WobblyEdge/WobblyEdge.tsx
@@ -93,7 +93,7 @@ const WobblyEdge: FunctionComponent<Props> = ({
   function makePolygonPoints(totalPoints: number, intensity: number): string {
     // Determine whether wobbly edge should be a mountain or a valley
     const first = isValley ? '0% 100%, 0% 0%,' : '0% 100%,';
-    const last = isValley ? ',100% 0%, 100% 100%' : ',100% 100%';
+    const last = isValley ? '100% 0%, 100% 100%' : '100% 100%';
     const innerPoints = [...Array(totalPoints)].reduce((acc, curr, index) => {
       const xMean = (100 / totalPoints) * index;
       const xShift = 100 / totalPoints / 2;
@@ -103,10 +103,10 @@ const WobblyEdge: FunctionComponent<Props> = ({
       const x = randomIntFromInterval(xMean - xShift, xMean + xShift - 1);
       const y = randomIntFromInterval(100 - intensity, 100);
 
-      return acc.concat(`${x}% ${y}%`);
+      return acc.concat(`${x}% ${y}%,`);
     }, []);
 
-    return `polygon(${first.concat(innerPoints.join(','), last)})`;
+    return `polygon(${first.concat(innerPoints.join(''), last)})`;
   }
 
   function updatePoints() {

--- a/common/views/themes/base/normalize.ts
+++ b/common/views/themes/base/normalize.ts
@@ -1,5 +1,5 @@
 export const normalize = `
-/*! normalize.css v5.0.0 | MIT License | github.com/necolas/normalize.css */
+/* normalize.css v5.0.0 | MIT License | github.com/necolas/normalize.css */
 
 /**
  * 1. Change the default font family in all browsers (opinionated).


### PR DESCRIPTION
## Who is this for?
Valid HTML fans

## What is it doing for them?
Making sure there are the right amount of commas in the `clip-path` declarations
