### PR TITLE
Remove property causing race condition(?)

### DIFF
--- a/common/views/components/Modal/Modal.tsx
+++ b/common/views/components/Modal/Modal.tsx
@@ -317,7 +317,6 @@ const Modal: FunctionComponent<Props> = ({
           in={isActive}
           classNames="fade"
           timeout={350}
-          unmountOnExit
           nodeRef={nodeRef}
         >
           <ModalWindow


### PR DESCRIPTION
## Who is this for?
Users using filters

## What is it doing for them?
- The theory is that this property was causing the search to refresh as the referenced component was unmounted, causing some sort of racing condition with the rendered query. It's not a property we absolutely need so it's simpler to remove it. 

([more info on the property here](https://reactcommunity.org/react-transition-group/transition#Transition-prop-unmountOnExit))
Fixes #9116 