### PR TITLE
Search: Only assign form ID if the modal is open

### DIFF
--- a/common/views/components/SearchFilters/SearchFiltersDesktop.tsx
+++ b/common/views/components/SearchFilters/SearchFiltersDesktop.tsx
@@ -208,11 +208,9 @@ const DynamicFilterArray = ({
     }
   };
   useEffect(() => {
-    if (isNewStyle) {
-      window.addEventListener('resize', updateWrapperWidth);
-      updateWrapperWidth();
-      return () => window.removeEventListener('resize', updateWrapperWidth);
-    }
+    window.addEventListener('resize', updateWrapperWidth);
+    updateWrapperWidth();
+    return () => window.removeEventListener('resize', updateWrapperWidth);
   }, []);
 
   const filterClassname = 'superUniqueDropdownFilterButtonClass';
@@ -224,7 +222,7 @@ const DynamicFilterArray = ({
         h={
           i + 1 !== arr.length
             ? {
-                size: isNewStyle ? 'm' : 's',
+                size: 'm',
                 properties: ['margin-right'],
               }
             : undefined
@@ -232,27 +230,27 @@ const DynamicFilterArray = ({
       >
         {f.type === 'checkbox' && (
           <CheckboxFilter
+            {...(!showMoreFiltersModal && { form: searchFormId })}
             f={f}
             changeHandler={changeHandler}
-            form={showMoreFiltersModal ? undefined : searchFormId}
             isNewStyle={isNewStyle}
           />
         )}
 
         {f.type === 'dateRange' && (
           <DateRangeFilter
+            {...(!showMoreFiltersModal && { form: searchFormId })}
             f={f}
             changeHandler={changeHandler}
-            form={showMoreFiltersModal ? undefined : searchFormId}
             isNewStyle={isNewStyle}
           />
         )}
 
         {f.type === 'color' && (
           <ColorFilter
+            {...(!showMoreFiltersModal && { form: searchFormId })}
             f={f}
             changeHandler={changeHandler}
-            form={showMoreFiltersModal ? undefined : searchFormId}
             isNewStyle={isNewStyle}
           />
         )}
@@ -412,6 +410,7 @@ const SearchFiltersDesktop: FunctionComponent<SearchFiltersSharedProps> = ({
                   />
                 )}
                 <ModalMoreFilters
+                  {...(showMoreFiltersModal && { form: searchFormId })}
                   query={query}
                   id="moreFilters"
                   isActive={showMoreFiltersModal}
@@ -420,7 +419,6 @@ const SearchFiltersDesktop: FunctionComponent<SearchFiltersSharedProps> = ({
                   changeHandler={changeHandler}
                   resetFilters={linkResolver({ query })}
                   filters={filters}
-                  form={searchFormId}
                   isNewStyle
                 />
               </>


### PR DESCRIPTION
## Who is this for?
New search

## What is it doing for them?
Debugging a [new search issue](https://github.com/wellcomecollection/wellcomecollection.org/pull/9121) brought to light another bug.

This was caused by the fact that in the new search, both the modal filters and the filters under the searchbar have the same id and are attached to the same form. 
There was logic in place that ensured that the form ID would not be assigned to the "desktop" filters if the modal was open, but not the other way around, which was the issue.
Because even when not displaying, the modal is rendered, which meant that fields were doubled, creating invalid URLs like `https://www-stage.wellcomecollection.org/search/works?query=human&workType=k&production.dates.from=%2C&production.dates.to=%2C`

Two empty date fields meant it was sending `[,]`  (`%2C` = `,` ) instead of being ignored as empty.

I've added that condition to the modal as well now, which made everything run again.