### PR TITLE
Only fetch an EventBasic for client-side events

### DIFF
--- a/content/webapp/pages/api/events/index.ts
+++ b/content/webapp/pages/api/events/index.ts
@@ -2,7 +2,7 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import { isJson, isString } from '@weco/common/utils/array';
 import { createClient } from '../../../services/prismic/fetch';
 import { fetchEvents } from '../../../services/prismic/fetch/events';
-import { transformEvent } from '../../../services/prismic/transformers/events';
+import { transformEventBasic } from '../../../services/prismic/transformers/events';
 import { transformQuery } from '../../../services/prismic/transformers/paginated-results';
 import superjson from 'superjson';
 
@@ -25,7 +25,7 @@ export default async (
   const query = await fetchEvents(client, parsedParams);
 
   if (query) {
-    const events = transformQuery(query, transformEvent);
+    const events = transformQuery(query, transformEventBasic);
     return res.status(200).json(superjson.stringify(events));
   }
 };

--- a/content/webapp/pages/event.tsx
+++ b/content/webapp/pages/event.tsx
@@ -18,7 +18,7 @@ import EventDateRange from '../components/EventDateRange/EventDateRange';
 import HeaderBackground from '@weco/common/views/components/HeaderBackground/HeaderBackground';
 import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
 import { getFeaturedMedia } from '../utils/page-header';
-import { Event, Interpretation } from '../types/events';
+import { Event, EventBasic, Interpretation } from '../types/events';
 import { upcomingDatesFullyBooked } from '../services/prismic/events';
 import EventDatesLink from '../components/EventDatesLink/EventDatesLink';
 import Space from '@weco/common/views/components/styled/Space';
@@ -185,10 +185,16 @@ const eventInterpretationIcons: Record<string, IconSvg> = {
 };
 
 const EventPage: NextPage<Props> = ({ event, jsonLd }) => {
-  const [scheduledIn, setScheduledIn] = useState<Event>();
+  const [scheduledIn, setScheduledIn] = useState<EventBasic>();
+
+  // This is used to populate the 'Part of' in the breadcrumb trail.
+  //
+  // Here's an example of a page which uses it:
+  // https://wellcomecollection.org/events/W3K54ykAACcAEIGL
   const getScheduledIn = async () => {
     const scheduledInQuery = await fetchEventsClientSide({
       predicates: [prismic.predicate.at('my.events.schedule.event', event.id)],
+      pageSize: 1,
     });
 
     if (

--- a/content/webapp/services/prismic/fetch/events.ts
+++ b/content/webapp/services/prismic/fetch/events.ts
@@ -11,7 +11,7 @@ import {
 import { Query } from '@prismicio/types';
 import { getPeriodPredicates } from '../types/predicates';
 import * as prismic from '@prismicio/client';
-import { Event } from '../../../types/events';
+import { EventBasic } from '../../../types/events';
 import {
   commonPrismicFieldsFetchLinks,
   contributorFetchLinks,
@@ -191,14 +191,7 @@ export const fetchEvents = (
   });
 };
 
-// TODO: I suspect any page that uses this fetcher to get a non-empty
-// list of results will throw a client-side error, because these events
-// will have strings as dates instead of the JavaScript Date type.
-//
-// See a similar comment on the client-side fetcher in multi-content.ts.
-//
-// AFAICT, there aren't any events that call this fetcher right now and
-// return a non-empty list of results, so it's hard to test this -- but
-// be aware that bug is potentially lurking out there.
+// See also: the API route /api/events, which returns the data used
+// by this fetcher.
 export const fetchEventsClientSide =
-  clientSideFetcher<Event>('events').getByTypeClientSide;
+  clientSideFetcher<EventBasic>('events').getByTypeClientSide;


### PR DESCRIPTION
We want exactly two fields here: an id and title.  We don't need to fetch a full event, or more than one; fetching a single EventBasic will make a (small) reduction in the amount of data here.

Also, I can never remember what example to look at to debug this code, so add an example link.

Another tidy while reading code for https://github.com/wellcomecollection/wellcomecollection.org/issues/9090