### PR TITLE
Suppress the T&Cs link if this is a Schools event

### DIFF
--- a/common/data/hardcoded-ids.ts
+++ b/common/data/hardcoded-ids.ts
@@ -49,6 +49,10 @@ export const prismicPageIds = {
   youth: 'Wuw2MSIAACtd3Ssg',
 };
 
+export const eventPolicyIds = {
+  schoolBooking: 'W4Vx5h4AACIAehqz',
+};
+
 export const getNameFromCollectionVenue = (id: string): string | undefined => {
   // check the keys and returns back name based on id
   for (const [key, value] of Object.entries(collectionVenueId)) {

--- a/content/webapp/pages/event.tsx
+++ b/content/webapp/pages/event.tsx
@@ -52,7 +52,10 @@ import {
   transformEvent,
 } from '../services/prismic/transformers/events';
 import { createClient } from '../services/prismic/fetch';
-import { prismicPageIds } from '@weco/common/data/hardcoded-ids';
+import {
+  eventPolicyIds,
+  prismicPageIds,
+} from '@weco/common/data/hardcoded-ids';
 import { headerBackgroundLs } from '@weco/common/utils/backgrounds';
 import { isDayPast, isPast } from '@weco/common/utils/dates';
 
@@ -450,14 +453,33 @@ const EventPage: NextPage<Props> = ({ event, jsonLd }) => {
               .filter(Boolean) as LabelField[]
           }
         >
-          <p className={font('intr', 5)}>{a11y.defaultEventMessage}</p>
-          <p className={`no-margin ${font('intr', 5)}`}>
-            <a
-              href={`https://wellcomecollection.org/pages/${prismicPageIds.bookingAndAttendingOurEvents}`}
-            >
-              Our event terms and conditions
-            </a>
-          </p>
+          {/* 
+            By default we show an 'event terms and conditions' link at the bottom
+            of the yellow box, but school events have their own T&Cs which are
+            managed separately, so we suppress the link.
+            
+            Later we might want to make this event configurable in Prismic, 
+
+            See https://wellcome.slack.com/archives/C8X9YKM5X/p1673523089747359
+          */}
+          {isNotUndefined(
+            event.policies.find(p => p.id === eventPolicyIds.schoolBooking)
+          ) ? (
+            <p className={`no-margin ${font('intr', 5)}`}>
+              {a11y.defaultEventMessage}
+            </p>
+          ) : (
+            <>
+              <p className={font('intr', 5)}>{a11y.defaultEventMessage}</p>
+              <p className={`no-margin ${font('intr', 5)}`}>
+                <a
+                  href={`https://wellcomecollection.org/pages/${prismicPageIds.bookingAndAttendingOurEvents}`}
+                >
+                  Our event terms and conditions
+                </a>
+              </p>
+            </>
+          )}
         </InfoBox>
         {/* We deliberately position the contributors below the schedule, so a
         reader can see all the events in a festival/multi-part event before they


### PR DESCRIPTION
For now I've hard-coded the ID of the one event policy which has its own T&Cs because it's a bit of a special-case.  We might want to make this configurable in Prismic later, but for now the use case is still a bit vague and ill-defined.

This is a small bit of complexity to hard-code in the front-end, and we can look at exposing it in Prismic if it gets more complicated -- when we'll know more about the use case.

Closes https://github.com/wellcomecollection/wellcomecollection.org/issues/9090