### PR TITLE
Fix search query bug and use MoreLink component

### DIFF
--- a/catalogue/webapp/pages/concept.tsx
+++ b/catalogue/webapp/pages/concept.tsx
@@ -1,3 +1,4 @@
+import styled from 'styled-components';
 import { useState } from 'react';
 import { GetServerSideProps, NextPage } from 'next';
 import Link, { LinkProps } from 'next/link';
@@ -16,7 +17,7 @@ import { pageDescriptionConcepts } from '@weco/common/data/microcopy';
 
 // Components
 import CataloguePageLayout from 'components/CataloguePageLayout/CataloguePageLayout';
-import ButtonSolidLink from '@weco/common/views/components/ButtonSolidLink/ButtonSolidLink';
+import MoreLink from '@weco/common/views/components/MoreLink/MoreLink';
 import WorksSearchResults from '../components/WorksSearchResults/WorksSearchResults';
 import ImageEndpointSearchResults from 'components/ImageEndpointSearchResults/ImageEndpointSearchResults';
 import BetaMessage from '@weco/common/views/components/BetaMessage/BetaMessage';
@@ -31,13 +32,12 @@ import {
 } from '@weco/common/model/catalogue';
 
 // Styles
-import styled from 'styled-components';
-import { arrowSmall } from '@weco/common/icons';
 import Space from '@weco/common/views/components/styled/Space';
 import TabNav from '@weco/common/views/components/TabNav/TabNav';
 import { font } from '@weco/common/utils/classnames';
 import { ApiToolbarLink } from '@weco/common/views/components/ApiToolbar/ApiToolbar';
 import { Pageview } from '@weco/common/services/conversion/track';
+import theme from '@weco/common/views/themes/default';
 
 type Props = {
   conceptResponse: ConceptType;
@@ -48,8 +48,6 @@ type Props = {
   apiToolbarLinks: ApiToolbarLink[];
   pageview: Pageview;
 };
-
-const leadingColor = 'yellow';
 
 const ConceptHero = styled(Space).attrs({
   v: { size: 'l', properties: ['padding-top', 'padding-bottom'] },
@@ -89,17 +87,11 @@ const ConceptWorksHeader = styled(Space).attrs({
 `;
 
 const SeeMoreButton = ({ text, link }: { text: string; link: LinkProps }) => (
-  <ButtonSolidLink
-    text={text}
-    link={link}
-    icon={arrowSmall}
-    isIconAfter={true}
-    colors={{
-      border: leadingColor,
-      background: leadingColor,
-      text: 'black',
-    }}
-    hoverUnderline={true}
+  <MoreLink
+    name={text}
+    url={link}
+    colors={theme.buttonColors.yellowYellowBlack}
+    hoverUnderline
   />
 );
 

--- a/catalogue/webapp/pages/search/index.tsx
+++ b/catalogue/webapp/pages/search/index.tsx
@@ -8,8 +8,7 @@ import SearchNoResults from '@weco/catalogue/components/SearchNoResults/SearchNo
 import StoriesGrid from '@weco/catalogue/components/StoriesGrid/StoriesGrid';
 import ImageEndpointSearchResults from '@weco/catalogue/components/ImageEndpointSearchResults/ImageEndpointSearchResults';
 import WorksSearchResults from '@weco/catalogue/components/WorksSearchResults/WorksSearchResults';
-import ButtonSolidLink from '@weco/common/views/components/ButtonSolidLink/ButtonSolidLink';
-import { arrowSmall } from '@weco/common/icons';
+import MoreLink from '@weco/common/views/components/MoreLink/MoreLink';
 
 import { getSearchLayout } from '@weco/catalogue/components/SearchPageLayout/SearchPageLayout';
 import { removeUndefinedProps } from '@weco/common/utils/json';
@@ -33,6 +32,7 @@ import {
   FromCodecMap,
   stringCodec,
 } from '@weco/common/utils/routes';
+import theme from '@weco/common/views/themes/default';
 
 // Creating this version of fromQuery for the overview page only
 // No filters or pagination required.
@@ -90,26 +90,16 @@ export const SearchPage: NextPageWithLayout<Props> = ({
     text: string;
     pathname: string;
   }) => (
-    <ButtonSolidLink
-      text={text}
-      link={{
+    <MoreLink
+      name={text}
+      url={{
         href: {
           pathname,
-          query: { query: queryString },
-        },
-        as: {
-          pathname,
-          query: { query: queryString },
+          query: { ...(queryString && { query: queryString }) },
         },
       }}
-      icon={arrowSmall}
-      isIconAfter={true}
-      colors={{
-        border: 'yellow',
-        background: 'yellow',
-        text: 'black',
-      }}
-      hoverUnderline={true}
+      colors={theme.buttonColors.yellowYellowBlack}
+      hoverUnderline
     />
   );
 

--- a/common/views/components/MoreLink/MoreLink.tsx
+++ b/common/views/components/MoreLink/MoreLink.tsx
@@ -1,18 +1,24 @@
 import { FunctionComponent, ReactElement } from 'react';
+import { LinkProps } from 'next/link';
 import { trackGaEvent, GaEvent } from '../../../utils/ga';
 import ButtonSolidLink from '../ButtonSolidLink/ButtonSolidLink';
 import { arrowSmall } from '@weco/common/icons';
 import { themeValues } from '@weco/common/views/themes/config';
+import { ButtonColors } from '../ButtonSolid/ButtonSolid';
 
 type Props = {
-  url: string;
+  url: string | LinkProps;
   name: string;
+  colors?: ButtonColors;
+  hoverUnderline?: boolean;
   trackingEvent?: GaEvent;
 };
 
 const MoreLink: FunctionComponent<Props> = ({
   url,
   name,
+  colors,
+  hoverUnderline,
   trackingEvent,
 }: Props): ReactElement<Props> => {
   function handleClick() {
@@ -27,12 +33,13 @@ const MoreLink: FunctionComponent<Props> = ({
 
   return (
     <ButtonSolidLink
-      colors={themeValues.buttonColors.charcoalTransparentCharcoal}
-      isIconAfter={true}
+      colors={colors || themeValues.buttonColors.charcoalTransparentCharcoal}
+      isIconAfter
       clickHandler={handleClick}
       text={name}
       link={url}
       icon={arrowSmall}
+      hoverUnderline={hoverUnderline}
     />
   );
 };


### PR DESCRIPTION
## Who is this for?
New search, devs

## What is it doing for them?
- Makes query optional so the "All images" button doesn't link to `/search/images?query=`
- Switch to using `MoreLink` component, which just came to my attention.
- I used it in concepts too so I made the switch there and got rid of `leadingColor` which was a leftover from when we thought Concepts would have different colour themes.