### PR TITLE
Reset pagination on sort

### DIFF
--- a/catalogue/webapp/components/Sort/Sort.tsx
+++ b/catalogue/webapp/components/Sort/Sort.tsx
@@ -53,7 +53,11 @@ const Sort: FunctionComponent<Props> = ({
     const queryParams = { ...router.query, sortOrder, sort: sortType };
     const newQuery = propsToQuery(queryParams);
 
-    router.push({ pathname: router.pathname, query: newQuery });
+    // Reset pagination when we change the sort order
+    // as it's likely the user will want to start from page 1
+    const { page, ...rest } = newQuery;
+
+    router.push({ pathname: router.pathname, query: { ...rest } });
   }, [sortOrder, sortType]);
 
   return (


### PR DESCRIPTION
## Who is this for?
New sort component

## What is it doing for them?
- Removes `page=` from the query parameters when you change how you want to sort your results. This mimics the current search behaviour.
This was flagged in [new search feedback document](https://docs.google.com/document/d/1UHaHXMRSioQNesUMYUHdjlHRtAipDva_caCplhGpOxI/edit#) (functionality bugs n.2)