### PR TITLE
Metatitle to change on query change

### DIFF
--- a/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
+++ b/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
@@ -44,72 +44,78 @@ const SearchLayout: FunctionComponent<{ hasEventsExhibitions: boolean }> = ({
   hasEventsExhibitions,
 }) => {
   const router = useRouter();
+  const { query: queryString } = router.query;
 
   const currentSearchCategory =
     router.pathname === '/search'
       ? 'overview'
       : router.pathname.slice(router.pathname.lastIndexOf('/') + 1);
 
-  const basePageMetadata = {
+  const basePageMetadata: PageLayoutMetadata = {
     openGraphType: 'website',
     siteSection: 'collections',
     jsonLd: { '@type': 'WebPage' },
     hideNewsletterPromo: true,
     excludeRoleMain: true,
-  } as const;
-
-  const defaultPageLayoutMetadata: PageLayoutMetadata = {
-    ...basePageMetadata,
-    title: 'Search',
+    title: `${queryString ? `${queryString} | ` : ''}Search`,
     description: pageDescriptions.search.overview,
-    url: { pathname: '/search', query: {} },
+    url: {
+      pathname: '/search',
+      query: queryString ? { query: queryString } : {},
+    },
   };
 
   const [pageLayoutMetadata, setPageLayoutMetadata] =
-    useState<PageLayoutMetadata>(defaultPageLayoutMetadata);
+    useState<PageLayoutMetadata>(basePageMetadata);
 
   const getURL = pathname => {
-    const query = { query: router.query.query };
     return convertUrlToString({
       pathname,
-      query,
+      query: { query: queryString },
     });
   };
 
   useEffect(() => {
-    const { query } = router.query;
+    const queryStringTitle = queryString ? `${queryString} | ` : '';
 
     switch (currentSearchCategory) {
       case 'overview':
         setPageLayoutMetadata({
           ...basePageMetadata,
-          description: pageDescriptions.search.overview,
-          title: `${query ? `${query} | ` : ''}Search`,
-          url: { pathname: '/search', query: { query } || {} },
+          title: `${queryStringTitle}Search`,
         });
         break;
       case 'stories':
         setPageLayoutMetadata({
           ...basePageMetadata,
           description: pageDescriptions.search.stories,
-          title: `${query ? `${query} | ` : ''}Stories search`,
-          url: { pathname: '/search/stories', query: { query } || {} },
+          title: `${queryStringTitle}Stories search`,
+          url: {
+            ...basePageMetadata.url,
+            pathname: '/search/stories',
+          },
         });
         break;
       case 'images':
         setPageLayoutMetadata({
           ...basePageMetadata,
           description: pageDescriptions.search.images,
-          title: `${query ? `${query} | ` : ''}Image search`,
-          url: { pathname: '/search/images', query: { query } || {} },
+          title: `${queryStringTitle}Image search`,
+          url: {
+            ...basePageMetadata.url,
+            pathname: '/search/images',
+          },
         });
         break;
       case 'works':
         setPageLayoutMetadata({
           ...basePageMetadata,
           description: pageDescriptions.search.works,
-          title: `${query ? `${query} | ` : ''}Catalogue search`,
-          url: { pathname: '/search/works', query: { query } || {} },
+          title: `${queryStringTitle}Catalogue search`,
+          url: {
+            ...basePageMetadata.url,
+            pathname: '/search/works',
+          },
         });
         break;
       // In development
@@ -117,23 +123,29 @@ const SearchLayout: FunctionComponent<{ hasEventsExhibitions: boolean }> = ({
         setPageLayoutMetadata({
           ...basePageMetadata,
           description: pageDescriptions.search.exhibitions,
-          title: `${query ? `${query} | ` : ''}Exhibition Search`,
-          url: { pathname: '/search/exhibitions', query: { query } || {} },
+          title: `${queryStringTitle}Exhibition Search`,
+          url: {
+            ...basePageMetadata.url,
+            pathname: '/search/exhibitions',
+          },
         });
         break;
       case 'events':
         setPageLayoutMetadata({
           ...basePageMetadata,
           description: pageDescriptions.search.events,
-          title: `${query ? `${query} | ` : ''}Events Search`,
-          url: { pathname: '/search/events', query: { query } || {} },
+          title: `${queryStringTitle}Events Search`,
+          url: {
+            ...basePageMetadata.url,
+            pathname: '/search/events',
+          },
         });
         break;
 
       default:
         break;
     }
-  }, [currentSearchCategory]);
+  }, [currentSearchCategory, queryString]);
 
   const searchbarPlaceholderText = {
     overview: 'Search Wellcome Collection',


### PR DESCRIPTION
## Who is this for?
new search metadata

## What is it doing for them?
Updates the meta title on query change. (Fix was just to add it as a dependency in `useEffect` but I've also tried to re-use more code within this PR) 