### PR TITLE
Have stories sort mimic works and current behaviour

### DIFF
--- a/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
+++ b/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
@@ -168,8 +168,9 @@ const SearchLayout: FunctionComponent<{ hasEventsExhibitions: boolean }> = ({
     const formValues = formDataAsUrlQuery(form);
 
     const sortOptionValue = getQueryPropertyValue(formValues.sortOrder);
-    const urlFormattedSort =
-      sortOptionValue && getUrlQueryFromSortValue(sortOptionValue);
+    const urlFormattedSort = sortOptionValue
+      ? getUrlQueryFromSortValue(sortOptionValue)
+      : undefined;
 
     const link = linkResolver({
       ...formValues,
@@ -178,6 +179,7 @@ const SearchLayout: FunctionComponent<{ hasEventsExhibitions: boolean }> = ({
         sortOrder: urlFormattedSort.sortOrder,
       }),
     });
+
     return router.push(link.href, link.as);
   };
 

--- a/catalogue/webapp/pages/search/stories.tsx
+++ b/catalogue/webapp/pages/search/stories.tsx
@@ -68,14 +68,15 @@ export const SearchPage: NextPageWithLayout<Props> = ({
               <Sort
                 formId="searchPageForm"
                 options={[
-                  { value: 'publication.dates.desc', text: 'Newest to oldest' },
+                  // Default value to be left empty as to not be reflected in URL query
+                  { value: '', text: 'Newest to oldest' },
                   { value: 'publication.dates.asc', text: 'Oldest to newest' },
                   { value: 'alphabetical.asc', text: 'A-Z' },
                   { value: 'alphabetical.desc', text: 'Z-A' },
                 ]}
                 jsLessOptions={{
                   sort: [
-                    { value: 'publication.dates', text: 'Publication dates' },
+                    { value: '', text: 'Publication dates' },
                     { value: 'alphabetical', text: 'Alphabetical' },
                   ],
                   sortOrder: [
@@ -147,6 +148,7 @@ export const getServerSideProps: GetServerSideProps<
   const pageNumber = page !== '1' && getQueryPropertyValue(page);
 
   // Setting a default order of descending publication date as default state
+  // as the Prismic default is last updated
   const storyResponseList: PrismicResultsList<Story> | PrismicApiError =
     await getStories({
       query: {

--- a/catalogue/webapp/pages/search/stories.tsx
+++ b/catalogue/webapp/pages/search/stories.tsx
@@ -148,7 +148,7 @@ export const getServerSideProps: GetServerSideProps<
   const pageNumber = page !== '1' && getQueryPropertyValue(page);
 
   // Setting a default order of descending publication date as default state
-  // as the Prismic default is last updated
+  // as the Prismic default is by "last updated"
   const storyResponseList: PrismicResultsList<Story> | PrismicApiError =
     await getStories({
       query: {

--- a/catalogue/webapp/pages/search/works.tsx
+++ b/catalogue/webapp/pages/search/works.tsx
@@ -161,6 +161,7 @@ export const CatalogueSearchPage: NextPageWithLayout<Props> = ({
                     <Sort
                       formId="searchPageForm"
                       options={[
+                        // Default value to be left empty so it's not added to the URL query
                         { value: '', text: 'Relevance' },
                         {
                           value: 'production.dates.asc',


### PR DESCRIPTION
## Who is this for?
New search

## What is it doing for them?
- Stories was adding the default sort values to the URL whenever a search was being done.
- Changed it to work like `/works` and `/search/works`, added a comment to explain. 