### PR TITLE
Add preventScroll option to FocusLock to prevent scrolling in modal

### DIFF
--- a/catalogue/webapp/__mocks__/tabbable.js
+++ b/catalogue/webapp/__mocks__/tabbable.js
@@ -1,0 +1,15 @@
+const lib = jest.requireActual('tabbable');
+
+const tabbable = {
+  ...lib,
+  tabbable: (node, options) =>
+    lib.tabbable(node, { ...options, displayCheck: 'none' }),
+  focusable: (node, options) =>
+    lib.focusable(node, { ...options, displayCheck: 'none' }),
+  isFocusable: (node, options) =>
+    lib.isFocusable(node, { ...options, displayCheck: 'none' }),
+  isTabbable: (node, options) =>
+    lib.isTabbable(node, { ...options, displayCheck: 'none' }),
+};
+
+module.exports = tabbable;

--- a/common/__mocks__/tabbable.js
+++ b/common/__mocks__/tabbable.js
@@ -1,0 +1,15 @@
+const lib = jest.requireActual('tabbable');
+
+const tabbable = {
+  ...lib,
+  tabbable: (node, options) =>
+    lib.tabbable(node, { ...options, displayCheck: 'none' }),
+  focusable: (node, options) =>
+    lib.focusable(node, { ...options, displayCheck: 'none' }),
+  isFocusable: (node, options) =>
+    lib.isFocusable(node, { ...options, displayCheck: 'none' }),
+  isTabbable: (node, options) =>
+    lib.isTabbable(node, { ...options, displayCheck: 'none' }),
+};
+
+module.exports = tabbable;

--- a/common/package.json
+++ b/common/package.json
@@ -39,7 +39,7 @@
     "elastic-apm-node": "^3.21.1",
     "enzyme": "^3.11.0",
     "enzyme-to-json": "^3.4.4",
-    "focus-trap-react": "^8.9.2",
+    "focus-trap-react": "^10.0.2",
     "fontfaceobserver": "^2.0.13",
     "jest": "^27.3.1",
     "koa-compose": "^4.1.0",

--- a/common/views/components/Modal/Modal.tsx
+++ b/common/views/components/Modal/Modal.tsx
@@ -302,7 +302,7 @@ const Modal: FunctionComponent<Props> = ({
   }, [isActive]);
 
   return (
-    <FocusTrap active={isActive}>
+    <FocusTrap active={isActive} focusTrapOptions={{ preventScroll: true }}>
       <div>
         {isActive && showOverlay && (
           <Overlay

--- a/identity/webapp/__mocks__/tabbable.js
+++ b/identity/webapp/__mocks__/tabbable.js
@@ -1,0 +1,15 @@
+const lib = jest.requireActual('tabbable');
+
+const tabbable = {
+  ...lib,
+  tabbable: (node, options) =>
+    lib.tabbable(node, { ...options, displayCheck: 'none' }),
+  focusable: (node, options) =>
+    lib.focusable(node, { ...options, displayCheck: 'none' }),
+  isFocusable: (node, options) =>
+    lib.isFocusable(node, { ...options, displayCheck: 'none' }),
+  isTabbable: (node, options) =>
+    lib.isTabbable(node, { ...options, displayCheck: 'none' }),
+};
+
+module.exports = tabbable;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10820,19 +10820,20 @@ fn-name@~2.0.1:
   resolved "https://registry.yarnpkg.com/fn-name/-/fn-name-2.0.1.tgz#5214d7537a4d06a4a301c0cc262feb84188002e7"
   integrity sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=
 
-focus-trap-react@^8.9.2:
-  version "8.9.2"
-  resolved "https://registry.yarnpkg.com/focus-trap-react/-/focus-trap-react-8.9.2.tgz#af19c6d65bedeba925859d7ec51c41d8d2c30855"
-  integrity sha512-m6TQQHLcqkisc6Qq92q1yYzzOaxo34Szh5FQOXzky7028PXFEhuUxScTbT7EG9qL0QG7B+oR2ZbxyU0lK4kIwQ==
+focus-trap-react@^10.0.2:
+  version "10.0.2"
+  resolved "https://registry.yarnpkg.com/focus-trap-react/-/focus-trap-react-10.0.2.tgz#eed4ce5b508bf3a0ce2ce63151c5c0f34a8f8529"
+  integrity sha512-MnN2cmdgpY7NY74ePOio4kbO5A3ILhrg1g5OGbgIQjcWEv1hhcbh6e98K0a+df88hNbE+4i9r8ji9aQnHou6GA==
   dependencies:
-    focus-trap "^6.7.3"
+    focus-trap "^7.2.0"
+    tabbable "^6.0.1"
 
-focus-trap@^6.7.3:
-  version "6.7.3"
-  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.7.3.tgz#b5dc195b49c90001f08a63134471d1e6dd381ddd"
-  integrity sha512-8xCEKndV4KrseGhFKKKmczVA14yx1/hnmFICPOjcFjToxCJYj/NHH43tPc3YE/PLnLRNZoFug0EcWkGQde/miQ==
+focus-trap@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-7.2.0.tgz#25af61b5635d3c18cd2fd176087db7b60be72c6b"
+  integrity sha512-v4wY6HDDYvzkBy4735kW5BUEuw6Yz9ABqMYLuTNbzAFPcBOGiGHwwcNVMvUz4G0kgSYh13wa/7TG3XwTeT4O/A==
   dependencies:
-    tabbable "^5.2.1"
+    tabbable "^6.0.1"
 
 follow-redirects@^1.14.4:
   version "1.14.5"
@@ -18150,10 +18151,10 @@ synchronous-promise@^2.0.6:
   resolved "https://registry.yarnpkg.com/synchronous-promise/-/synchronous-promise-2.0.15.tgz#07ca1822b9de0001f5ff73595f3d08c4f720eb8e"
   integrity sha512-k8uzYIkIVwmT+TcglpdN50pS2y1BDcUnBPK9iJeGu0Pl1lOI8pD6wtzgw91Pjpe+RxtTncw32tLxs/R0yNL2Mg==
 
-tabbable@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.2.1.tgz#e3fda7367ddbb172dcda9f871c0fdb36d1c4cd9c"
-  integrity sha512-40pEZ2mhjaZzK0BnI+QGNjJO8UYx9pP5v7BGe17SORTO0OEuuaAwQTkAp8whcZvqon44wKFOikD+Al11K3JICQ==
+tabbable@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.0.1.tgz#427a09b13c83ae41eed3e88abb76a4af28bde1a6"
+  integrity sha512-SYJSIgeyXW7EuX1ytdneO5e8jip42oHWg9xl/o3oTYhmXusZVgiA+VlPvjIN+kHii9v90AmzTZEBcsEvuAY+TA==
 
 table@^6.0.9:
   version "6.7.3"


### PR DESCRIPTION
## Who is this for?
Filtering users

## What is it doing for them?
There's a bug currently that sometimes makes the filtering experience frustrating in that it doesn't select the filter that was clicked and scrolls back to the previously selected one. This seems to happen to filters who are below the "scroll line" and the theory is this `FocusLock` doesn't recognise them as part of the focusable zone.

I've updated the package we used from v8 -> v10 and added the `preventScroll` [option](https://github.com/focus-trap/focus-trap-react#focustrapoptions), which seems to fix it, I tried to replicate it as much as possible and it looks alright.

⚠️ to fix the tests, I've added config files to `__mocks__` folders based on the [recommendations in the package instructions](https://github.com/focus-trap/tabbable#testing-in-jsdom). Being new-ish to jest, do let me know if there's a better way/if this is against our ways of coding (it _is_ annoyingly repetitive)

https://user-images.githubusercontent.com/110461050/214096836-93987ac7-bb4e-4ef7-b430-8e09821e1230.mov

