### PR TITLE
Lower new search's filters' font size

### DIFF
--- a/common/views/components/SearchFilters/SearchFiltersDesktop.tsx
+++ b/common/views/components/SearchFilters/SearchFiltersDesktop.tsx
@@ -51,6 +51,15 @@ const Wrapper = styled(Space).attrs<{ isNewStyle?: boolean }>(props => ({
     props.isNewStyle ? 'unset' : props.theme.color('warmNeutral.400')};
 `;
 
+const FilterDropdownsContainer = styled(Space).attrs({
+  v: { size: 'm', properties: ['margin-bottom'] },
+  className: font('intr', 5),
+})<{ isComponentMounted?: boolean }>`
+  display: flex;
+  align-items: center;
+  ${props => !props.isComponentMounted && `flex-wrap: wrap;`}
+`;
+
 const CheckboxFilter = ({
   f,
   changeHandler,
@@ -67,24 +76,22 @@ const CheckboxFilter = ({
       hasNoOptions={f.options.length === 0}
     >
       <PlainList className={font('intr', 5)}>
-        <ul className={`no-margin no-padding plain-list ${font('intr', 5)}`}>
-          {f.options.map(({ id, label, value, count, selected }) => {
-            return (
-              <li key={`${f.id}-${id}`}>
-                <CheckboxRadio
-                  id={id}
-                  type="checkbox"
-                  text={filterLabel({ label, count })}
-                  value={value}
-                  name={f.id}
-                  checked={selected}
-                  onChange={changeHandler}
-                  form={form}
-                />
-              </li>
-            );
-          })}
-        </ul>
+        {f.options.map(({ id, label, value, count, selected }) => {
+          return (
+            <li key={`${f.id}-${id}`}>
+              <CheckboxRadio
+                id={id}
+                type="checkbox"
+                text={filterLabel({ label, count })}
+                value={value}
+                name={f.id}
+                checked={selected}
+                onChange={changeHandler}
+                form={form}
+              />
+            </li>
+          );
+        })}
       </PlainList>
     </DropdownButton>
   );
@@ -369,8 +376,8 @@ const SearchFiltersDesktop: FunctionComponent<SearchFiltersSharedProps> = ({
 }: SearchFiltersSharedProps): ReactElement<SearchFiltersSharedProps> => {
   const [showMoreFiltersModal, setShowMoreFiltersModal] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
-  const [componentMounted, setComponentMounted] = useState(false);
-  useEffect(() => setComponentMounted(true), []);
+  const [isComponentMounted, setIsComponentMounted] = useState(false);
+  useEffect(() => setIsComponentMounted(true), []);
   const openMoreFiltersButtonRef = useRef(null);
 
   const visibleFilters = filters.slice(0, nVisibleFilters);
@@ -388,15 +395,10 @@ const SearchFiltersDesktop: FunctionComponent<SearchFiltersSharedProps> = ({
           }}
           className="flex flex--h-space-between flex--v-center full-width flex--wrap"
         >
-          <Space
-            v={{ size: 'm', properties: ['margin-bottom'] }}
-            className={`flex flex--v-center flex--${
-              componentMounted ? 'no-' : ''
-            }wrap`}
-          >
+          <FilterDropdownsContainer isComponentMounted={isComponentMounted}>
             {isNewStyle && (
               <>
-                {componentMounted && (
+                {isComponentMounted && (
                   /**
                    * I had to extract this component so that useLayoutEffect
                    * didn't try to run before it could/cause syncing issues
@@ -486,13 +488,12 @@ const SearchFiltersDesktop: FunctionComponent<SearchFiltersSharedProps> = ({
 
                 {modalFilters.length > 0 && (
                   <Space
-                    className={font('intr', 5)}
                     h={{
                       size: isNewStyle ? 'm' : 's',
                       properties: ['margin-left'],
                     }}
                   >
-                    {componentMounted && (
+                    {isComponentMounted && (
                       <ButtonSolid
                         colors={themeValues.buttonColors.whiteWhiteCharcoal}
                         hoverUnderline={true}
@@ -520,7 +521,7 @@ const SearchFiltersDesktop: FunctionComponent<SearchFiltersSharedProps> = ({
                 )}
               </>
             )}
-          </Space>
+          </FilterDropdownsContainer>
         </Space>
       </Wrapper>
 


### PR DESCRIPTION
## Who is this for?
new search

## What is it doing for them?
- After discussing with Dom, lowering font-size in "More filters"
- Removing double `<ul>` (I think due to a conflicted merge in the past)
- Change var name to reflect it's boolean status.


Before
<img width="1052" alt="Screenshot 2023-01-23 at 16 35 38" src="https://user-images.githubusercontent.com/110461050/214106080-8503313d-33c8-474e-a7dc-52a39cdd9317.png">

After
<img width="1042" alt="Screenshot 2023-01-23 at 16 35 29" src="https://user-images.githubusercontent.com/110461050/214106070-1065102a-829b-40e3-8363-e0dae82e5c03.png">

