### PR TITLE
Replace leftover older colors

### DIFF
--- a/identity/webapp/src/frontend/MyAccount/MyAccount.style.ts
+++ b/identity/webapp/src/frontend/MyAccount/MyAccount.style.ts
@@ -71,7 +71,7 @@ const colours = {
   failure: css`
     background-color: rgba(224, 27, 47, 0.1);
     border: 1px solid rgba(224, 27, 47, 0.3);
-    color: #d1192c;
+    color: ${props => props.theme.color('validation.red')};
   `,
   info: css`
     background-color: rgba(255, 206, 60, 0.2);

--- a/identity/webapp/src/frontend/Registration/Registration.style.ts
+++ b/identity/webapp/src/frontend/Registration/Registration.style.ts
@@ -26,7 +26,7 @@ const AlertBox = styled.div.attrs({ role: 'alert', className: 'font-intr' })`
 
 export const ErrorAlert = styled(AlertBox)`
   background-color: rgba(224, 27, 47, 0.1);
-  color: #d1192c;
+  color: ${props => props.theme.color('validation.red')};
 `;
 
 export const SuccessMessage = styled(AlertBox)`
@@ -58,7 +58,7 @@ const FullWidthElementBase = css`
 export const InProgress = styled.div.attrs({ role: 'progressbar' })`
   ${FullWidthElementBase}
   border-radius: 6px;
-  background-color: #333;
+  background-color: ${props => props.theme.color('neutral.700')};
   color: white;
   user-select: none;
 `;

--- a/identity/webapp/src/frontend/components/Form.style.ts
+++ b/identity/webapp/src/frontend/components/Form.style.ts
@@ -18,8 +18,11 @@ export const TextInput = styled.input<{ invalid?: FieldError }>`
   height: 55px;
   margin: 0.333em 0;
   padding: 0.7em;
-  border: ${props =>
-    props.invalid ? 'solid 2px #d1192c' : 'solid 1px #8f8f8f'};
+  border: solid
+    ${props =>
+      props.invalid
+        ? `2px ${props.theme.color('validation.red')}`
+        : `1px ${props.theme.color('neutral.500')}`};
   border-radius: 6px;
 `;
 


### PR DESCRIPTION
## Who is this for?
New color scheme

## What is it doing for them?
As part of #384 I had a look through identity and replaced leftover colours that weren't called by `theme.color()` or were older ones. There's still a few special cases that aren't part of the scheme, but tbh I think it's fine for now. We could go with a bigger review once we get another designer in to help out.