### PR TITLE
Serve the right sized image on mobile

### DIFF
--- a/content/webapp/components/ImageGallery/ImageGallery.tsx
+++ b/content/webapp/components/ImageGallery/ImageGallery.tsx
@@ -36,12 +36,14 @@ function makeSizesForFrames(isThreeUp: boolean) {
     return `
         (min-width: ${sizes.medium}px) calc(80vw / 2),
         (min-width: ${sizes.large}px) calc(80vw / 3),
-        (min-width: ${sizes.xlarge}px) calc(${sizes.xlarge * 0.8}px / 3)
+        (min-width: ${sizes.xlarge}px) calc(${sizes.xlarge * 0.8}px / 3),
+        calc(100vw - 68px)
       `;
   } else {
     return `
       (min-width: ${sizes.medium}px) calc(80vw / 2),
-      (min-width: ${sizes.xlarge}px) calc(${sizes.xlarge * 0.8}px / 2)
+      (min-width: ${sizes.xlarge}px) calc(${sizes.xlarge * 0.8}px / 2),
+      calc(100vw - 68px)
     `;
   }
 }


### PR DESCRIPTION
## Who is this for?
People looking at comics on their phones

## What is it doing for them?
Serving them the appropriately sized image (previously missing from the recently-updated `sizes`.