### PR TITLE
Move charset again

### DIFF
--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -153,7 +153,6 @@ const PageLayoutComponent: FunctionComponent<Props> = ({
   return (
     <>
       <Head>
-        <meta charSet="utf-8" />
         <title>{fullTitle}</title>
         <meta name="description" content={description || ''} />
         <link rel="canonical" href={absoluteUrl} />

--- a/common/views/pages/_document.tsx
+++ b/common/views/pages/_document.tsx
@@ -64,6 +64,9 @@ class WecoDoc extends Document {
     return (
       <Html lang="en" className="is-keyboard">
         <Head>
+          {/* W3C standard: The element containing the character encoding declaration 
+          must be serialized completely within the first 1024 bytes of the document. 
+          It has to be declared here as Next dynamically adds other elements to the Head */}
           <meta charSet="utf-8" />
           <GoogleAnalyticsV4 />
           <GoogleAnalyticsUA />

--- a/common/views/pages/_document.tsx
+++ b/common/views/pages/_document.tsx
@@ -64,6 +64,7 @@ class WecoDoc extends Document {
     return (
       <Html lang="en" className="is-keyboard">
         <Head>
+          <meta charSet="utf-8" />
           <GoogleAnalyticsV4 />
           <GoogleAnalyticsUA />
           <script


### PR DESCRIPTION
## Who is this for?
People who like valid HTML who hadn't accounted for the fact that Next can add elements to the head at various places.

## What is it doing for them?
Moving the `charset` to the first place where the `<Head>` is being included in the DOM, above the GA scripts.