### PR TITLE
Use pageDescription for comic strapline

### DIFF
--- a/common/data/microcopy.tsx
+++ b/common/data/microcopy.tsx
@@ -34,8 +34,8 @@ export const pageDescriptions = {
   whatsOn:
     'Discover all of the exhibitions, events and more on offer at Wellcome Collection, a free museum and library exploring health and human experience.',
   works: 'Search the Wellcome Collection catalogue',
-  comic: 'TODO: write words that make sense for comic series here',
-
+  comic:
+    'Explore new perspectives on bodies, brains and health with our guest comic artists.',
   search: {
     overview:
       'Search Wellcome Collection. Our stories, images and collections make connections and provoke new thinking about health and human experience.',
@@ -143,6 +143,3 @@ export const requestingDisabled =
 
 export const pastExhibitionsStrapline =
   'Take a look at our past exhibitions and installations.';
-
-export const comicsStrapline =
-  'Explore new perspectives on bodies, brains and health with our guest comic artists.';

--- a/content/webapp/pages/stories.tsx
+++ b/content/webapp/pages/stories.tsx
@@ -28,7 +28,7 @@ import {
   transformArticleToArticleBasic,
 } from '../services/prismic/transformers/articles';
 import { transformStoriesLanding } from '../services/prismic/transformers/stories-landing';
-import { pageDescriptions, comicsStrapline } from '@weco/common/data/microcopy';
+import { pageDescriptions } from '@weco/common/data/microcopy';
 import { StoriesLanding } from '../types/stories-landing';
 import { StoriesLandingPrismicDocument } from '../services/prismic/types/stories-landing';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
@@ -243,7 +243,7 @@ const StoriesPage: FunctionComponent<Props> = ({
 
           <SpacingComponent>
             <Layout12>
-              <p>{comicsStrapline}</p>
+              <p>{pageDescriptions.comic}</p>
             </Layout12>
           </SpacingComponent>
 


### PR DESCRIPTION
## Who is this for?
People who don't want a `TODO` on the frontend

## What is it doing for them?
Using the comic strapline text for the comic page description as well.

![image](https://user-images.githubusercontent.com/1394592/214559162-515b169f-a915-4135-9413-3678efb163b1.png)
