### PR TITLE
Tweak padding on the right hand side of the dropdown button

### DIFF
--- a/common/views/components/ButtonSolid/ButtonSolid.tsx
+++ b/common/views/components/ButtonSolid/ButtonSolid.tsx
@@ -133,6 +133,8 @@ type SolidButtonProps = {
   size?: ButtonSize;
   hoverUnderline?: boolean;
   isPill?: boolean;
+  hasIcon?: boolean;
+  isIconAfter?: boolean;
 };
 
 // Default to medium button
@@ -171,7 +173,13 @@ export const SolidButton = styled(BaseButton).attrs<SolidButtonProps>(
       ? `
         border-radius: 20px;
         border: 1px solid ${props.theme.color('black')};
-        padding: 8px 16px;
+        padding: ${
+          props.hasIcon
+            ? `8px ${props.isIconAfter ? '8px' : '16px'} 8px ${
+                props.isIconAfter ? '16px' : '8px'
+              }`
+            : '8px 16px'
+        };
 
         &:hover {
           box-shadow: ${props.theme.focusBoxShadow};
@@ -233,6 +241,8 @@ const Button: FunctionComponent<ButtonSolidProps> = (
       ref={ref}
       form={form}
       isPill={isPill}
+      hasIcon={!!icon}
+      isIconAfter={isIconAfter}
     >
       <BaseButtonInner isInline={size === 'small'} isPill={isPill}>
         {isIconAfter && (


### PR DESCRIPTION
## Who is this for?
Ongoing search design

## What is it doing for them?
- Saves space by reducing padding on the right-hand side of the icon (or left side is `isIconAfter` is `false`) in the dropdown button + looks better


Before
![Screenshot 2023-01-26 at 13 52 29](https://user-images.githubusercontent.com/110461050/214852880-c9cc15fa-606e-497e-9b6b-1f1b16ef2651.png)


After
![Screenshot 2023-01-26 at 13 52 11](https://user-images.githubusercontent.com/110461050/214852805-061b2846-a1c0-47d8-ae3b-93887849578a.png)

This does cause the All Filters icon to be a bit snug, but we need to address the fact that our icons are not all the same size within their container, as a separate topic I'll bring up in the FE meeting

![Screenshot 2023-01-26 at 13 53 02](https://user-images.githubusercontent.com/110461050/214853637-8a858bf7-07f4-4d79-9dd1-3de3268aecdb.png)


![Screenshot 2023-01-26 at 13 35 45](https://user-images.githubusercontent.com/110461050/214853464-0761b3ab-68e1-41a6-a1fe-7af84ada48b2.png)
![Screenshot 2023-01-26 at 13 35 39](https://user-images.githubusercontent.com/110461050/214853462-0fca569d-59b9-463d-b6ae-f5d06b326a68.png)
