### PR TITLE
Remove origin from story URL

### DIFF
--- a/catalogue/webapp/services/prismic/transformers/index.ts
+++ b/catalogue/webapp/services/prismic/transformers/index.ts
@@ -37,7 +37,7 @@ export async function transformPrismicResponse(
         width: image.image?.dimensions?.width,
         height: image.image?.dimensions?.height,
       },
-      url: `https://wellcomecollection.org/${type}/${id}`,
+      url: `/${type}/${id}`,
       firstPublicationDate,
       contributors: allContributors,
       type,

--- a/catalogue/webapp/test/prismic/index.test.ts
+++ b/catalogue/webapp/test/prismic/index.test.ts
@@ -76,7 +76,7 @@ describe('transformPrismicResponse', () => {
         title: 'A cat in a hat',
         summary: 'A cat in a hat, a great story of an ace cat',
         id: 'X123456',
-        url: 'https://wellcomecollection.org/articles/X123456',
+        url: '/articles/X123456',
         firstPublicationDate: new Date('2022-09-08T09:29:27+0000'),
         contributors: ['Willow Wisp'],
         image: {


### PR DESCRIPTION
## Who is this for?
Local & staging instances

## What is it doing for them?
Noticed that they were always linking to production, might've been for when we couldn't run the apps concurrently but I don't think it's what we want anymore. I know of `linkResolver` and I might look into it more as part of my [`getCrop` alignment ](https://github.com/wellcomecollection/wellcomecollection.org/issues/9127)as well.