### PR TITLE
Add comma-separated numbers to the pagination component

### DIFF
--- a/common/utils/grammar.test.ts
+++ b/common/utils/grammar.test.ts
@@ -1,4 +1,15 @@
-import { pluralize } from './grammar';
+import { formatNumber, pluralize } from './grammar';
+
+describe('formatNumber', () => {
+  test.each([
+    { n: 1, output: '1' },
+    { n: 5, output: '5' },
+    { n: 100, output: '100' },
+    { n: 1156915, output: '1,156,915' },
+  ])('$n is formatted as $output', ({ n, output }) => {
+    expect(formatNumber(n)).toStrictEqual(output);
+  });
+});
 
 describe('pluralize', () => {
   test.each([

--- a/common/utils/grammar.ts
+++ b/common/utils/grammar.ts
@@ -32,6 +32,19 @@ export function dasherizeShorten(words: string): string {
     .replace(/\W/g, '-');
 }
 
+/** Formats a number with commas for readability, e.g.
+ *
+ *            1 =>         1
+ *           10 =>        10
+ *         1942 =>     1,942
+ *      1234567 => 1,234,567
+ */
+export function formatNumber(n: number): string {
+  const format = new Intl.NumberFormat('en-GB');
+
+  return format.format(n);
+}
+
 /** Formats a string to describe a list of results, e.g.
  *
  *      1 work
@@ -40,9 +53,7 @@ export function dasherizeShorten(words: string): string {
  *
  */
 export function pluralize(count: number, noun: string, suffix = 's'): string {
-  const format = new Intl.NumberFormat('en-GB');
-
-  return `${format.format(count)} ${noun}${count !== 1 ? suffix : ''}`;
+  return `${formatNumber(count)} ${noun}${count !== 1 ? suffix : ''}`;
 }
 
 export function unCamelCase(words: string): string {

--- a/common/views/components/Pagination/Pagination.test.tsx
+++ b/common/views/components/Pagination/Pagination.test.tsx
@@ -80,4 +80,14 @@ describe('Pagination', () => {
 
     expect(component.text().includes('Page 5 of 10')).toBe(true);
   });
+
+  it('does pretty formatting of large page counts', () => {
+    useRouter.mockImplementationOnce(() => ({ query: { page: '5' } }));
+
+    const component = mountWithTheme(
+      <Pagination totalPages={12345} ariaLabel="Results pagination" />
+    );
+
+    expect(component.text().includes('Page 5 of 12,345')).toBe(true);
+  });
 });

--- a/common/views/components/Pagination/Pagination.test.tsx
+++ b/common/views/components/Pagination/Pagination.test.tsx
@@ -70,4 +70,14 @@ describe('Pagination', () => {
         .includes('href="/works?page=4&amp;locations=available-online"')
     ).toBe(true);
   });
+
+  it('includes the total number of pages', () => {
+    useRouter.mockImplementationOnce(() => ({ query: { page: '5' } }));
+
+    const component = mountWithTheme(
+      <Pagination totalPages={10} ariaLabel="Results pagination" />
+    );
+
+    expect(component.text().includes('Page 5 of 10')).toBe(true);
+  });
 });

--- a/common/views/components/Pagination/Pagination.test.tsx
+++ b/common/views/components/Pagination/Pagination.test.tsx
@@ -25,6 +25,7 @@ describe('Pagination', () => {
     );
 
     expect(component.html().includes('Previous')).toBe(true);
+    expect(component.html().includes('href="/?page=4"')).toBe(true);
   });
 
   it('omits the "Next" button if we’re on the last page', () => {
@@ -45,5 +46,28 @@ describe('Pagination', () => {
     );
 
     expect(component.html().includes('Next')).toBe(true);
+    expect(component.html().includes('href="/?page=6"')).toBe(true);
+  });
+
+  it('includes the pathname and query parameters when linking to the next/previous pages', () => {
+    useRouter.mockImplementationOnce(() => ({
+      pathname: '/works',
+      query: { page: '5', locations: 'available-online' },
+    }));
+
+    const component = mountWithTheme(
+      <Pagination totalPages={10} ariaLabel="Results pagination" />
+    );
+
+    expect(
+      component
+        .html()
+        .includes('href="/works?page=6&amp;locations=available-online"')
+    ).toBe(true);
+    expect(
+      component
+        .html()
+        .includes('href="/works?page=4&amp;locations=available-online"')
+    ).toBe(true);
   });
 });

--- a/common/views/components/Pagination/Pagination.test.tsx
+++ b/common/views/components/Pagination/Pagination.test.tsx
@@ -1,0 +1,49 @@
+import { mountWithTheme } from '../../../test/fixtures/enzyme-helpers';
+import Pagination from './Pagination';
+
+// This approach to mocking useRouter() comes from a comment by Stephen Mason
+// on GitHub: https://github.com/vercel/next.js/issues/7479#issuecomment-520048773
+/* eslint-disable-next-line @typescript-eslint/no-var-requires */
+const useRouter = jest.spyOn(require('next/router'), 'useRouter');
+
+describe('Pagination', () => {
+  it('omits the "Previous" button if we’re on page 1', () => {
+    useRouter.mockImplementationOnce(() => ({ query: {} }));
+
+    const component = mountWithTheme(
+      <Pagination totalPages={10} ariaLabel="Results pagination" />
+    );
+
+    expect(component.html().includes('Previous')).toBe(false);
+  });
+
+  it('include the "Previous" button if we’re after page 1', () => {
+    useRouter.mockImplementationOnce(() => ({ query: { page: '5' } }));
+
+    const component = mountWithTheme(
+      <Pagination totalPages={10} ariaLabel="Results pagination" />
+    );
+
+    expect(component.html().includes('Previous')).toBe(true);
+  });
+
+  it('omits the "Next" button if we’re on the last page', () => {
+    useRouter.mockImplementationOnce(() => ({ query: { page: '10' } }));
+
+    const component = mountWithTheme(
+      <Pagination totalPages={10} ariaLabel="Results pagination" />
+    );
+
+    expect(component.html().includes('Next')).toBe(false);
+  });
+
+  it('includes the "Next" button if we’re not on the last page', () => {
+    useRouter.mockImplementationOnce(() => ({ query: { page: '5' } }));
+
+    const component = mountWithTheme(
+      <Pagination totalPages={10} ariaLabel="Results pagination" />
+    );
+
+    expect(component.html().includes('Next')).toBe(true);
+  });
+});

--- a/common/views/components/Pagination/Pagination.tsx
+++ b/common/views/components/Pagination/Pagination.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import { chevron } from '@weco/common/icons';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import { font } from '@weco/common/utils/classnames';
+import { formatNumber } from '@weco/common/utils/grammar';
 
 export type Props = {
   totalPages: number;
@@ -106,7 +107,7 @@ export const Pagination: FunctionComponent<Props> = ({
       )}
 
       <span>
-        Page <strong>{currentPage}</strong> of {totalPages}
+        Page <strong>{currentPage}</strong> of {formatNumber(totalPages)}
       </span>
 
       {showNext && (


### PR DESCRIPTION
Before/after:

<img width="446" alt="Screenshot 2023-01-27 at 09 05 31" src="https://user-images.githubusercontent.com/301220/215048665-32735b65-a448-4215-86ec-25698fdfb187.png">

A tiny little thing, but I noticed it while using the search and I think it makes the numbers more readable.

I also threw in a bunch of tests for the Pagination component which renders these buttons.