### PR TITLE
[WIP] Run e2e tests on pull requests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,6 +3,8 @@
   plugins:
     - wellcomecollection/aws-assume-role#v0.2.2:
         role: "arn:aws:iam::130871440101:role/experience-ci"
+    - ecr#v2.1.1:
+        login: true
 
 # - label: ":docker: build common"
 #   key: "build_common"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,200 +1,66 @@
-- label: ":docker: build common"
-  key: "build_common"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        build:
-          - common
-        image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
 
-- label: ":docker: build catalogue"
-  key: "build_catalogue"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        build:
-          - catalogue
-        image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
 
-- label: ":docker: build content"
-  key: "build_content"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        build:
-          - content
-        image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
+# - label: ":docker: build common"
+#   key: "build_common"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         build:
+#           - common
+#         image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
 
-- label: ":docker: build edge_lambdas"
-  key: "build_edge_lambdas"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        build:
-          - edge_lambdas
-        image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
+# - label: ":docker: build catalogue"
+#   key: "build_catalogue"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         build:
+#           - catalogue
+#         image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
 
-- label: ":docker: build identity"
-  key: "build_identity"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        build:
-          - identity
-        image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
+# - label: ":docker: build content"
+#   key: "build_content"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         build:
+#           - content
+#         image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
 
-- label: "diff prismic model"
-  branches: "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: prismic_model
-        env:
-          - CI
-        command: ["yarn", "diffCustomTypes"]
+# - label: ":docker: build edge_lambdas"
+#   key: "build_edge_lambdas"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         build:
+#           - edge_lambdas
+#         image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
 
-- label: "test common"
-  depends_on: "build_common"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: common
-        command: ["yarn", "test"]
+# - label: ":docker: build identity"
+#   key: "build_identity"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         build:
+#           - identity
+#         image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
 
-- label: "test catalogue"
-  depends_on: "build_catalogue"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: catalogue
-        command: ["yarn", "test"]
-
-- label: "test content"
-  depends_on: "build_content"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: content
-        command: ["yarn", "test"]
-
-- label: "test identity"
-  depends_on: "build_identity"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: identity
-        command: ["yarn", "test"]
-
-- label: "test edge_lambdas"
-  depends_on: "build_edge_lambdas"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: edge_lambdas
-        command: ["yarn", "test"]
-
-- wait
-
-- label: "deploy catalogue (ecr image)"
-  branches: "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        push:
-          - catalogue:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/catalogue_webapp:ref.${BUILDKITE_COMMIT}
-          - catalogue:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/catalogue_webapp:latest
-
-- label: "deploy catalogue (bundle analysis)"
-  branches: "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: catalogue
-        command: [ "yarn", "deployBundleAnalysis" ]
-        env:
-          - AWS_ACCESS_KEY_ID
-          - AWS_SECRET_ACCESS_KEY
-          - AWS_SESSION_TOKEN
-
-- label: "deploy content (ecr image)"
-  branches: "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        push:
-          - content:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/content_webapp:ref.${BUILDKITE_COMMIT}
-          - content:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/content_webapp:latest
-
-- label: "deploy content (bundle analysis)"
-  branches: "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: content
-        command: [ "yarn", "deployBundleAnalysis" ]
-        env:
-          - AWS_ACCESS_KEY_ID
-          - AWS_SECRET_ACCESS_KEY
-          - AWS_SESSION_TOKEN
-
-- label: "deploy identity (ecr image)"
-  branches: "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        push:
-          - identity:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/identity_webapp:ref.${BUILDKITE_COMMIT}
-          - identity:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/identity_webapp:latest
-
-# - label: "deploy identity (bundle analysis)"
+# - label: "diff prismic model"
 #   branches: "main"
 #   plugins:
 #     - wellcomecollection/aws-assume-role#v0.2.2:
@@ -202,73 +68,209 @@
 #     - ecr#v2.1.1:
 #         login: true
 #     - docker-compose#v3.5.0:
+#         run: prismic_model
+#         env:
+#           - CI
+#         command: ["yarn", "diffCustomTypes"]
+
+# - label: "test common"
+#   depends_on: "build_common"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: common
+#         command: ["yarn", "test"]
+
+# - label: "test catalogue"
+#   depends_on: "build_catalogue"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: catalogue
+#         command: ["yarn", "test"]
+
+# - label: "test content"
+#   depends_on: "build_content"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: content
+#         command: ["yarn", "test"]
+
+# - label: "test identity"
+#   depends_on: "build_identity"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
 #         run: identity
+#         command: ["yarn", "test"]
+
+# - label: "test edge_lambdas"
+#   depends_on: "build_edge_lambdas"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: edge_lambdas
+#         command: ["yarn", "test"]
+
+# - wait
+
+# - label: "deploy catalogue (ecr image)"
+#   branches: "main"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         push:
+#           - catalogue:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/catalogue_webapp:ref.${BUILDKITE_COMMIT}
+#           - catalogue:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/catalogue_webapp:latest
+
+# - label: "deploy catalogue (bundle analysis)"
+#   branches: "main"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: catalogue
 #         command: [ "yarn", "deployBundleAnalysis" ]
 #         env:
 #           - AWS_ACCESS_KEY_ID
 #           - AWS_SECRET_ACCESS_KEY
 #           - AWS_SESSION_TOKEN
 
-- label: "deploy dash"
-  branches: "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: dash
-        command: [ "yarn", "deploy" ]
-        env:
-          - AWS_ACCESS_KEY_ID
-          - AWS_SECRET_ACCESS_KEY
-          - AWS_SESSION_TOKEN
+# - label: "deploy content (ecr image)"
+#   branches: "main"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         push:
+#           - content:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/content_webapp:ref.${BUILDKITE_COMMIT}
+#           - content:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/content_webapp:latest
 
-- label: "deploy edge_lambdas"
-  branches: "main"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: edge_lambdas
-        command: [ "yarn", "deploy" ]
-        env:
-          - AWS_ACCESS_KEY_ID
-          - AWS_SECRET_ACCESS_KEY
-          - AWS_SESSION_TOKEN
+# - label: "deploy content (bundle analysis)"
+#   branches: "main"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: content
+#         command: [ "yarn", "deployBundleAnalysis" ]
+#         env:
+#           - AWS_ACCESS_KEY_ID
+#           - AWS_SECRET_ACCESS_KEY
+#           - AWS_SESSION_TOKEN
 
-- label: "deploy updown"
-  branches: "main"
-  skip: "To avoid overriding manual work that is occuring"
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: "arn:aws:iam::130871440101:role/experience-ci"
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: updown
-        command: [ "yarn", "checks" ]
-        env:
-          - AWS_ACCESS_KEY_ID
-          - AWS_SECRET_ACCESS_KEY
-          - AWS_SESSION_TOKEN
+# - label: "deploy identity (ecr image)"
+#   branches: "main"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         push:
+#           - identity:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/identity_webapp:ref.${BUILDKITE_COMMIT}
+#           - identity:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/identity_webapp:latest
 
-- label: "deploy assets"
-  branches: "main"
-  commands: ./assets/deploy_assets.sh
-  agents:
-    queue: nano
+# # - label: "deploy identity (bundle analysis)"
+# #   branches: "main"
+# #   plugins:
+# #     - wellcomecollection/aws-assume-role#v0.2.2:
+# #         role: "arn:aws:iam::130871440101:role/experience-ci"
+# #     - ecr#v2.1.1:
+# #         login: true
+# #     - docker-compose#v3.5.0:
+# #         run: identity
+# #         command: [ "yarn", "deployBundleAnalysis" ]
+# #         env:
+# #           - AWS_ACCESS_KEY_ID
+# #           - AWS_SECRET_ACCESS_KEY
+# #           - AWS_SESSION_TOKEN
 
-- wait
+# - label: "deploy dash"
+#   branches: "main"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: dash
+#         command: [ "yarn", "deploy" ]
+#         env:
+#           - AWS_ACCESS_KEY_ID
+#           - AWS_SECRET_ACCESS_KEY
+#           - AWS_SESSION_TOKEN
 
-- label: "Trigger stage deployment"
-  branches: "main"
-  plugins:
-    - wellcomecollection/github-deployments#v0.3.0:
-        assume_role: "arn:aws:iam::130871440101:role/experience-ci"
-        environment: stage
-        ref: "${BUILDKITE_COMMIT}"
-  agents:
-    queue: nano
+# - label: "deploy edge_lambdas"
+#   branches: "main"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: edge_lambdas
+#         command: [ "yarn", "deploy" ]
+#         env:
+#           - AWS_ACCESS_KEY_ID
+#           - AWS_SECRET_ACCESS_KEY
+#           - AWS_SESSION_TOKEN
+
+# - label: "deploy updown"
+#   branches: "main"
+#   skip: "To avoid overriding manual work that is occuring"
+#   plugins:
+#     - wellcomecollection/aws-assume-role#v0.2.2:
+#         role: "arn:aws:iam::130871440101:role/experience-ci"
+#     - ecr#v2.1.1:
+#         login: true
+#     - docker-compose#v3.5.0:
+#         run: updown
+#         command: [ "yarn", "checks" ]
+#         env:
+#           - AWS_ACCESS_KEY_ID
+#           - AWS_SECRET_ACCESS_KEY
+#           - AWS_SESSION_TOKEN
+
+# - label: "deploy assets"
+#   branches: "main"
+#   commands: ./assets/deploy_assets.sh
+#   agents:
+#     queue: nano
+
+# - wait
+
+# - label: "Trigger stage deployment"
+#   branches: "main"
+#   plugins:
+#     - wellcomecollection/github-deployments#v0.3.0:
+#         assume_role: "arn:aws:iam::130871440101:role/experience-ci"
+#         environment: stage
+#         ref: "${BUILDKITE_COMMIT}"
+#   agents:
+#     queue: nano

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,6 +5,8 @@
         role: "arn:aws:iam::130871440101:role/experience-ci"
     - ecr#v2.1.1:
         login: true
+  agents:
+    queue: scala # High parallelism for expensive tests
 
 # - label: ":docker: build common"
 #   key: "build_common"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,4 +1,8 @@
-
+- label: "run e2e tests"
+  command: .buildkite/scripts/run_e2e_in_buildkite.sh
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: "arn:aws:iam::130871440101:role/experience-ci"
 
 # - label: ":docker: build common"
 #   key: "build_common"
@@ -15,8 +19,6 @@
 # - label: ":docker: build catalogue"
 #   key: "build_catalogue"
 #   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
 #     - ecr#v2.1.1:
 #         login: true
 #     - docker-compose#v3.5.0:

--- a/.buildkite/scripts/run_e2e_in_buildkite.sh
+++ b/.buildkite/scripts/run_e2e_in_buildkite.sh
@@ -36,4 +36,4 @@ done
 docker run \
   --env CI=true \
   --env PLAYWRIGHT_BASE_URL=http://localhost:3000 \
-  e2e yarn test
+  130871440101.dkr.ecr.eu-west-1.amazonaws.com/weco/playwright yarn test

--- a/.buildkite/scripts/run_e2e_in_buildkite.sh
+++ b/.buildkite/scripts/run_e2e_in_buildkite.sh
@@ -37,4 +37,4 @@ docker run --tty \
   --env CI=true \
   --env PLAYWRIGHT_BASE_URL=http://localhost:3000 \
   --network host \
-  130871440101.dkr.ecr.eu-west-1.amazonaws.com/weco/playwright:815c78ff9affb02d3c19ae8e0dc36cca2ee4aea2 yarn test
+  130871440101.dkr.ecr.eu-west-1.amazonaws.com/weco/playwright yarn test

--- a/.buildkite/scripts/run_e2e_in_buildkite.sh
+++ b/.buildkite/scripts/run_e2e_in_buildkite.sh
@@ -5,9 +5,12 @@ set -o nounset
 
 ROOT=$(git rev-parse --show-toplevel)
 
+CREDENTIALS=$(aws secretsmanager get-secret-value --secret-id=identity/stage/local_dev_client/credentials)
+
 docker run --rm \
   --volume "$ROOT:$ROOT" \
   --workdir "$ROOT" \
+  --env CREDENTIALS \
   --publish 3000:3000 \
     public.ecr.aws/docker/library/node:14-slim \
       ./run_all_e2e.sh

--- a/.buildkite/scripts/run_e2e_in_buildkite.sh
+++ b/.buildkite/scripts/run_e2e_in_buildkite.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+
+ROOT=$(git rev-parse --show-toplevel)
+
+docker run --rm \
+  --volume "$ROOT:$ROOT" \
+  --workdir "$ROOT" \
+  --publish 3000:3000 \
+    public.ecr.aws/docker/library/node:14-slim
+      ./run_all_e2e.sh

--- a/.buildkite/scripts/run_e2e_in_buildkite.sh
+++ b/.buildkite/scripts/run_e2e_in_buildkite.sh
@@ -36,4 +36,4 @@ done
 docker run \
   --env CI=true \
   --env PLAYWRIGHT_BASE_URL=http://localhost:3000 \
-  130871440101.dkr.ecr.eu-west-1.amazonaws.com/weco/playwright yarn test
+  130871440101.dkr.ecr.eu-west-1.amazonaws.com/weco/playwright:815c78ff9affb02d3c19ae8e0dc36cca2ee4aea2 yarn test

--- a/.buildkite/scripts/run_e2e_in_buildkite.sh
+++ b/.buildkite/scripts/run_e2e_in_buildkite.sh
@@ -22,13 +22,18 @@ docker run --rm --detach \
 # Wait ~12 minutes for the containers to start, otherwise stop
 for i in {1..150}
 do
-  curl http://localhost:3000 && rc=$? || rc=$?
+  curl http://localhost:3000 >/dev/null 2>&1 && rc=$? || rc=$?
   if (( rc == 0 ))
   then
     echo "Docker container has started!"
     break
   else
-    echo "Docker container hasn't started, waiting 5 seconds..."
-    sleep 5
+    echo "Waiting another 15 seconds for Docker container..."
+    sleep 15
   fi
 done
+
+docker run \
+  --env CI=true \
+  --env PLAYWRIGHT_BASE_URL=http://localhost:3000 \
+  e2e yarn test

--- a/.buildkite/scripts/run_e2e_in_buildkite.sh
+++ b/.buildkite/scripts/run_e2e_in_buildkite.sh
@@ -36,4 +36,5 @@ done
 docker run \
   --env CI=true \
   --env PLAYWRIGHT_BASE_URL=http://localhost:3000 \
+  --network host \
   130871440101.dkr.ecr.eu-west-1.amazonaws.com/weco/playwright:815c78ff9affb02d3c19ae8e0dc36cca2ee4aea2 yarn test

--- a/.buildkite/scripts/run_e2e_in_buildkite.sh
+++ b/.buildkite/scripts/run_e2e_in_buildkite.sh
@@ -5,7 +5,10 @@ set -o nounset
 
 ROOT=$(git rev-parse --show-toplevel)
 
-CREDENTIALS=$(aws secretsmanager get-secret-value --secret-id=identity/stage/local_dev_client/credentials)
+CREDENTIALS=$(
+  aws secretsmanager get-secret-value \
+    --secret-id=identity/stage/local_dev_client/credentials
+)
 
 docker run --rm \
   --volume "$ROOT:$ROOT" \
@@ -14,3 +17,17 @@ docker run --rm \
   --publish 3000:3000 \
     public.ecr.aws/docker/library/node:14-slim \
       ./run_all_e2e.sh
+
+# Wait ~12 minutes for the containers to start, otherwise stop
+for i in {1..150}
+do
+  curl http://localhost:3000 && rc=$? || rc=$?
+  if (( rc == 0 ))
+  then
+    echo "Docker container has started!"
+    break
+  else
+    echo "Docker container hasn't started, waiting 5 seconds..."
+    sleep 5
+  fi
+done

--- a/.buildkite/scripts/run_e2e_in_buildkite.sh
+++ b/.buildkite/scripts/run_e2e_in_buildkite.sh
@@ -33,7 +33,7 @@ do
   fi
 done
 
-docker run \
+docker run --tty \
   --env CI=true \
   --env PLAYWRIGHT_BASE_URL=http://localhost:3000 \
   --network host \

--- a/.buildkite/scripts/run_e2e_in_buildkite.sh
+++ b/.buildkite/scripts/run_e2e_in_buildkite.sh
@@ -9,5 +9,5 @@ docker run --rm \
   --volume "$ROOT:$ROOT" \
   --workdir "$ROOT" \
   --publish 3000:3000 \
-    public.ecr.aws/docker/library/node:14-slim
+    public.ecr.aws/docker/library/node:14-slim \
       ./run_all_e2e.sh

--- a/.buildkite/scripts/run_e2e_in_buildkite.sh
+++ b/.buildkite/scripts/run_e2e_in_buildkite.sh
@@ -11,7 +11,7 @@ CREDENTIALS=$(
   jq -r .SecretString
 )
 
-docker run --rm --daemon \
+docker run --rm --detach \
   --volume "$ROOT:$ROOT" \
   --workdir "$ROOT" \
   --env CREDENTIALS \

--- a/.buildkite/scripts/run_e2e_in_buildkite.sh
+++ b/.buildkite/scripts/run_e2e_in_buildkite.sh
@@ -7,10 +7,11 @@ ROOT=$(git rev-parse --show-toplevel)
 
 CREDENTIALS=$(
   aws secretsmanager get-secret-value \
-    --secret-id=identity/stage/local_dev_client/credentials
+    --secret-id=identity/stage/local_dev_client/credentials |
+  jq -r .SecretString
 )
 
-docker run --rm \
+docker run --rm --daemon \
   --volume "$ROOT:$ROOT" \
   --workdir "$ROOT" \
   --env CREDENTIALS \

--- a/catalogue/webapp/next.config.js
+++ b/catalogue/webapp/next.config.js
@@ -4,7 +4,7 @@ const localConcurrentDevelopment =
   process.env.LOCAL_CONCURRENT_DEV_ENV === 'true';
 
 console.info(
-  'local concurrent development environment is set to:',
+  '(catalogue) local concurrent development environment is set to:',
   localConcurrentDevelopment
 );
 

--- a/content/webapp/next.config.js
+++ b/content/webapp/next.config.js
@@ -1,6 +1,6 @@
 const { createConfig } = require('@weco/common/next/next.config');
 
-const CATALOGUE_URL = 'http://localhost:3001/catalogue';
+const CATALOGUE_URL = 'http://localhost:3001/';
 const localConcurrentDevelopment =
   process.env.LOCAL_CONCURRENT_DEV_ENV === 'true';
 
@@ -11,12 +11,16 @@ const rewriteEntries = localConcurrentDevelopment
         destination: `/:path*`,
       },
       {
+        source: '/catalogue/_next/:path*',
+        destination: `${CATALOGUE_URL}/catalogue/_next/:path*`,
+      },
+      {
         source: '/catalogue/:path*',
         destination: `${CATALOGUE_URL}/:path*`,
       },
       {
-        source: '/concept',
-        destination: `${CATALOGUE_URL}/concept`,
+        source: '/concepts/:path*',
+        destination: `${CATALOGUE_URL}/concepts/:path*`,
       },
       {
         source: '/download',
@@ -41,6 +45,10 @@ const rewriteEntries = localConcurrentDevelopment
       {
         source: '/works',
         destination: `${CATALOGUE_URL}/works`,
+      },
+      {
+        source: '/works/:path*',
+        destination: `${CATALOGUE_URL}/works/:path*`,
       },
       {
         source: '/item',

--- a/content/webapp/next.config.js
+++ b/content/webapp/next.config.js
@@ -4,6 +4,11 @@ const CATALOGUE_URL = 'http://localhost:3001/';
 const localConcurrentDevelopment =
   process.env.LOCAL_CONCURRENT_DEV_ENV === 'true';
 
+console.info(
+  '(content) local concurrent development environment is set to:',
+  localConcurrentDevelopment
+);
+
 const rewriteEntries = localConcurrentDevelopment
   ? [
       {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,13 @@ services:
   updown:
     build:
       context: ./updown
+  run-concurrently:
+    image: public.ecr.aws/docker/library/node:14-slim
+    volumes:
+      - ~/.aws:/root/.aws
+      - .:/repo
+    working_dir: /repo
+    command: ./run_all_e2e.sh
   e2e:
     image: "130871440101.dkr.ecr.eu-west-1.amazonaws.com/weco/playwright:latest"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,13 +38,6 @@ services:
   updown:
     build:
       context: ./updown
-  run-concurrently:
-    image: public.ecr.aws/docker/library/node:14-slim
-    volumes:
-      - ~/.aws:/root/.aws
-      - .:/repo
-    working_dir: /repo
-    command: ./run_all_e2e.sh
   e2e:
     image: "130871440101.dkr.ecr.eu-west-1.amazonaws.com/weco/playwright:latest"
     volumes:

--- a/identity/webapp/package.json
+++ b/identity/webapp/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "start": "NODE_ENV=production ts-node-transpile-only -r tsconfig-paths/register src/index.ts",
     "start:dev": "CREDENTIALS=$(AWS_PROFILE=identity-dev aws secretsmanager get-secret-value --secret-id=identity/stage/local_dev_client/credentials) NODE_ENV=development nodemon --ignore './src/frontend/' src/index.ts",
+    "start:ci": "NODE_ENV=development nodemon --ignore './src/frontend/' src/index.ts",
     "watch:client": "yarn build:frontend --watch",
     "build": "NODE_ENV=production && yarn build:next",
     "build:next": "next build",

--- a/identity/webapp/package.json
+++ b/identity/webapp/package.json
@@ -11,7 +11,6 @@
   "scripts": {
     "start": "NODE_ENV=production ts-node-transpile-only -r tsconfig-paths/register src/index.ts",
     "start:dev": "CREDENTIALS=$(AWS_PROFILE=identity-dev aws secretsmanager get-secret-value --secret-id=identity/stage/local_dev_client/credentials) NODE_ENV=development nodemon --ignore './src/frontend/' src/index.ts",
-    "start:ci": "CREDENTIALS=$(aws secretsmanager get-secret-value --secret-id=identity/stage/local_dev_client/credentials) NODE_ENV=development nodemon --ignore './src/frontend/' src/index.ts",
     "watch:client": "yarn build:frontend --watch",
     "build": "NODE_ENV=production && yarn build:next",
     "build:next": "next build",

--- a/identity/webapp/package.json
+++ b/identity/webapp/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "start": "NODE_ENV=production ts-node-transpile-only -r tsconfig-paths/register src/index.ts",
     "start:dev": "CREDENTIALS=$(AWS_PROFILE=identity-dev aws secretsmanager get-secret-value --secret-id=identity/stage/local_dev_client/credentials) NODE_ENV=development nodemon --ignore './src/frontend/' src/index.ts",
+    "start:ci": "CREDENTIALS=$(aws secretsmanager get-secret-value --secret-id=identity/stage/local_dev_client/credentials) NODE_ENV=development nodemon --ignore './src/frontend/' src/index.ts",
     "watch:client": "yarn build:frontend --watch",
     "build": "NODE_ENV=production && yarn build:next",
     "build:next": "next build",

--- a/playwright/package.json
+++ b/playwright/package.json
@@ -2,7 +2,7 @@
   "name": "@weco/e2e-tests",
   "license": "MIT",
   "scripts": {
-    "test": "playwright test",
+    "test": "playwright test --workers=1",
     "test:mobile": "NODE_ENV=test platform=mobile yarn test",
     "test:debug:mobile": "NODE_ENV=test debug=true platform=mobile yarn test",
     "test:debug": "NODE_ENV=test debug=true yarn test",

--- a/run_all_e2e.sh
+++ b/run_all_e2e.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+
+yarn
+echo "done with yarn"
+yarn run-concurrently

--- a/scripts/run-concurrently.sh
+++ b/scripts/run-concurrently.sh
@@ -1,18 +1,25 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-echo Starting the applications
+set -o errexit
+set -o nounset
+
+echo "Starting the applications"
 
 target=true
 
-PORT=3002 LOCAL_CONCURRENT_DEV_ENV=$target IDENTITY_HOST=http://localhost:3002 yarn identity &
-P1=$!
+pushd identity/webapp
+    PORT=3002 LOCAL_CONCURRENT_DEV_ENV=$target IDENTITY_HOST=http://localhost:3002 yarn start:dev &
+    PROC_IDENTIFY=$!
+popd
+
 PORT=3001 LOCAL_CONCURRENT_DEV_ENV=$target IDENTITY_HOST=http://localhost:3002 yarn catalogue &
-P2=$!
+PROC_CATALOGUE=$!
+
 PORT=3000 LOCAL_CONCURRENT_DEV_ENV=$target IDENTITY_HOST=http://localhost:3002 yarn content &
-P3=$!
+PROC_CONTENT=$!
 
 # saves the process IDs into the variables above.
 # passed them in to the array on wait, when you kill wait, you also kill the processes passed in
 
-echo process IDs: $P1 $P2 $P3
-wait $P1 $P2 $P3
+echo process IDs: identity=$PROC_IDENTIFY catalogue=$PROC_CATALOGUE content=$PROC_CONTENT
+wait $PROC_IDENTIFY $PROC_CATALOGUE $PROC_CONTENT

--- a/scripts/run-concurrently.sh
+++ b/scripts/run-concurrently.sh
@@ -13,7 +13,7 @@ pushd identity/webapp
         PORT=3002 LOCAL_CONCURRENT_DEV_ENV=$target IDENTITY_HOST=http://localhost:3002 yarn start:dev &
         PROC_IDENTIFY=$!
     else
-        PORT=3002 LOCAL_CONCURRENT_DEV_ENV=$target IDENTITY_HOST=http://localhost:3002 yarn start:ci &
+        PORT=3002 LOCAL_CONCURRENT_DEV_ENV=$target IDENTITY_HOST=http://localhost:3002 yarn start &
         PROC_IDENTIFY=$!
     fi
 popd

--- a/scripts/run-concurrently.sh
+++ b/scripts/run-concurrently.sh
@@ -8,8 +8,14 @@ echo "Starting the applications"
 target=true
 
 pushd identity/webapp
-    PORT=3002 LOCAL_CONCURRENT_DEV_ENV=$target IDENTITY_HOST=http://localhost:3002 yarn start:dev &
-    PROC_IDENTIFY=$!
+    if [[ "${CI:-}" == "true" ]]
+    then
+        PORT=3002 LOCAL_CONCURRENT_DEV_ENV=$target IDENTITY_HOST=http://localhost:3002 yarn start:dev &
+        PROC_IDENTIFY=$!
+    else
+        PORT=3002 LOCAL_CONCURRENT_DEV_ENV=$target IDENTITY_HOST=http://localhost:3002 yarn start:ci &
+        PROC_IDENTIFY=$!
+    fi
 popd
 
 PORT=3001 LOCAL_CONCURRENT_DEV_ENV=$target IDENTITY_HOST=http://localhost:3002 yarn catalogue &

--- a/scripts/run-concurrently.sh
+++ b/scripts/run-concurrently.sh
@@ -13,7 +13,7 @@ pushd identity/webapp
         PORT=3002 LOCAL_CONCURRENT_DEV_ENV=$target IDENTITY_HOST=http://localhost:3002 yarn start:dev &
         PROC_IDENTIFY=$!
     else
-        PORT=3002 LOCAL_CONCURRENT_DEV_ENV=$target IDENTITY_HOST=http://localhost:3002 yarn start &
+        PORT=3002 LOCAL_CONCURRENT_DEV_ENV=$target IDENTITY_HOST=http://localhost:3002 yarn start:ci &
         PROC_IDENTIFY=$!
     fi
 popd


### PR DESCRIPTION
This is some initial work towards https://github.com/wellcomecollection/wellcomecollection.org/issues/9091

This isn't ready to merge.

* ✅ The containers all start correctly, both locally and in CI
* ✅ The e2e tests run against the local setup
* ❌ The e2e tests don't pass, and they're actually quite flaky – the set of failures is inconsistent between consecutive runs

## Routing issues

To help us split requests for the JavaScript bundle (e.g. `/_next/static/chunks/main.js`) we add a [base path](https://nextjs.org/docs/api-reference/next.config.js/basepath) in the catalogue app settings (so that becomes `/catalogue/_next/static/chunks/main.js`). But this seems to be applied inconsistently, for example:

* Both `/works` and `/catalogue/works` load correctly
* But `/images` is a 404, you want `/catalogue/images`
* And `/api/works/items/ffd3zeq3` is a 404, but `/catalogue/api/works/items/ffd3zeq3` works

I could get it working by playing whack-a-mole with those URLs, but it feels like we should get our routing to behave consistently before we write a bunch of new rewrite/redirection logic on top of it.