### PR TITLE
Properly sized images from the image grid

### DIFF
--- a/catalogue/webapp/components/IIIFImage/IIIFImage.tsx
+++ b/catalogue/webapp/components/IIIFImage/IIIFImage.tsx
@@ -44,7 +44,7 @@ export type Props = {
     naturalWidth: number;
     naturalHeight: number;
   }) => void;
-  layout: 'raw' | 'fill' | 'fixed';
+  layout: 'true-raw' | 'raw' | 'fill' | 'fixed';
   priority?: boolean;
   width?: number;
   background?: string;
@@ -66,12 +66,16 @@ const IIIFImage: FunctionComponent<Props> = ({
   // The Nextjs Image component has an experimental 'raw' layout feature
   // which will be rendered as a single image element with no wrappers, sizers or other responsive behavior.
   // We may be able to use this in future but, until then, render our own img element.
-  if (layout === 'raw') {
+  if (layout === 'raw' || layout === 'true-raw') {
     return (
       <img
-        src={iiifImageTemplate(image.contentUrl)({
-          size: `${width},`,
-        })}
+        src={
+          layout === 'true-raw'
+            ? image.contentUrl
+            : iiifImageTemplate(image.contentUrl)({
+                size: `${width},`,
+              })
+        }
         srcSet={''}
         sizes={sizesString}
         alt={image.alt || ''}

--- a/catalogue/webapp/components/ImageCard/ImageCard.tsx
+++ b/catalogue/webapp/components/ImageCard/ImageCard.tsx
@@ -13,7 +13,7 @@ type Props = {
   id: string;
   workId: string;
   image: ImageType;
-  layout: 'raw' | 'fill' | 'fixed';
+  layout: 'true-raw' | 'raw' | 'fill' | 'fixed';
   onClick: (event: SyntheticEvent<HTMLAnchorElement>) => void;
   background?: string;
 };
@@ -55,7 +55,17 @@ const ImageCard: FunctionComponent<Props> = ({
         width={image.width}
         height={image.height}
       >
-        <IIIFImage image={image} layout={layout} background={background} />
+        <IIIFImage
+          image={{
+            contentUrl: image.contentUrl,
+            width: 400,
+            height: 400,
+            alt: image.alt,
+          }}
+          width={300}
+          layout={layout}
+          background={background}
+        />
       </StyledLink>
     </NextLink>
   );

--- a/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
+++ b/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
@@ -173,7 +173,7 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
                       setIsActive(true);
                     }
                   }}
-                  layout="fill"
+                  layout="true-raw"
                 />
               </Space>
             </li>

--- a/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
+++ b/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
@@ -53,6 +53,19 @@ const ImageCardList = styled(PlainList)`
   flex-wrap: wrap;
 `;
 
+const AlbumRow = styled(PlainList)`
+  display: flex;
+  align-items: space-between;
+  margin-bottom: 0;
+`;
+
+const ImageFrame = styled.div`
+  display: block;
+  position: relative;
+  width: 100%;
+  height: 100%;
+`;
+
 const ImageEndpointSearchResults: FunctionComponent<Props> = ({
   images,
   background,
@@ -82,22 +95,9 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
     [images]
   );
 
-  const AlbumRow = styled(PlainList)`
-    display: flex;
-    align-items: space-between;
-    margin-bottom: 0;
-  `;
-
   const renderRowContainer: RenderRowContainer = ({ children }) => {
     return <AlbumRow>{children}</AlbumRow>;
   };
-
-  const ImageFrame = styled.div`
-    display: block;
-    position: relative;
-    width: 100%;
-    height: 100%;
-  `;
 
   const imageRenderer: FunctionComponent<RenderPhotoProps<GalleryImageProps>> =
     // these are values and props that are passed in by the PhotoAlbum component

--- a/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
+++ b/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
@@ -120,7 +120,7 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
                 setExpandedImage(photo);
                 setIsActive(true);
               }}
-              layout="fill"
+              layout="true-raw"
               background={
                 background ||
                 (rgbColor &&


### PR DESCRIPTION
## Who is this for?
Users of the image search

## What is it doing for them?
The previous implementation made the user download every possible size of an image, regardless of what space was available. This change fixes that.