### PR TITLE
Remove some unnecessary optional types

### DIFF
--- a/catalogue/webapp/pages/images.tsx
+++ b/catalogue/webapp/pages/images.tsx
@@ -31,7 +31,7 @@ import { Pageview } from '@weco/common/services/conversion/track';
 import { CatalogueResultsList, Image } from '@weco/common/model/catalogue';
 
 type Props = {
-  images?: CatalogueResultsList<Image>;
+  images: CatalogueResultsList<Image>;
   imagesRouteProps: ImagesProps;
   pageview: Pageview;
 };
@@ -55,9 +55,7 @@ const Images: NextPage<Props> = ({ images, imagesRouteProps }) => {
     };
   }, []);
 
-  const filters = images
-    ? imagesFilters({ images, props: imagesRouteProps })
-    : [];
+  const filters = imagesFilters({ images, props: imagesRouteProps });
 
   const { setLink } = useContext(SearchContext);
   useEffect(() => {
@@ -68,7 +66,7 @@ const Images: NextPage<Props> = ({ images, imagesRouteProps }) => {
   return (
     <>
       <Head>
-        {images?.prevPage && (
+        {images.prevPage && (
           <link
             rel="prev"
             href={convertUrlToString(
@@ -77,7 +75,7 @@ const Images: NextPage<Props> = ({ images, imagesRouteProps }) => {
             )}
           />
         )}
-        {images?.nextPage && (
+        {images.nextPage && (
           <link
             rel="next"
             href={convertUrlToString(
@@ -96,17 +94,13 @@ const Images: NextPage<Props> = ({ images, imagesRouteProps }) => {
         jsonLd={{ '@type': 'WebPage' }}
         siteSection="collections"
         image={undefined}
-        apiToolbarLinks={
-          images
-            ? [
-                {
-                  id: 'catalogue-api-query',
-                  label: 'Catalogue API query',
-                  link: images._requestUrl,
-                },
-              ]
-            : []
-        }
+        apiToolbarLinks={[
+          {
+            id: 'catalogue-api-query',
+            label: 'Catalogue API query',
+            link: images._requestUrl,
+          },
+        ]}
       >
         <Space v={{ size: 'l', properties: ['padding-bottom'] }}>
           <div className="container">
@@ -132,7 +126,7 @@ const Images: NextPage<Props> = ({ images, imagesRouteProps }) => {
           </div>
         </Space>
 
-        {images?.results && images.results.length > 0 && (
+        {images.results.length > 0 ? (
           <>
             <Space v={{ size: 'l', properties: ['padding-top'] }}>
               <div className="container">
@@ -168,9 +162,7 @@ const Images: NextPage<Props> = ({ images, imagesRouteProps }) => {
               </Space>
             </Space>
           </>
-        )}
-
-        {images?.results.length === 0 && (
+        ) : (
           <SearchNoResults query={query} hasFilters={!!color} />
         )}
       </CataloguePageLayout>
@@ -207,7 +199,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       pageSize: 30,
     });
 
-    if (images && images.type === 'Error') {
+    if (images.type === 'Error') {
       return appError(context, images.httpStatus, 'Images API error');
     }
 
@@ -218,11 +210,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
         imagesRouteProps: params,
         pageview: {
           name: 'images',
-          properties: images
-            ? {
-                totalResults: images.totalResults,
-              }
-            : {},
+          properties: images ? { totalResults: images.totalResults } : {},
         },
       }),
     };

--- a/catalogue/webapp/pages/images.tsx
+++ b/catalogue/webapp/pages/images.tsx
@@ -1,5 +1,5 @@
 import { GetServerSideProps, NextPage } from 'next';
-import { useEffect, useState, ReactElement, useContext } from 'react';
+import { useEffect, useState, useContext } from 'react';
 import Router from 'next/router';
 import Head from 'next/head';
 
@@ -36,10 +36,7 @@ type Props = {
   pageview: Pageview;
 };
 
-const Images: NextPage<Props> = ({
-  images,
-  imagesRouteProps,
-}): ReactElement<Props> => {
+const Images: NextPage<Props> = ({ images, imagesRouteProps }) => {
   const [isLoading, setIsLoading] = useState(false);
   const { query, page, color } = imagesRouteProps;
   useEffect(() => {

--- a/catalogue/webapp/pages/search/images.tsx
+++ b/catalogue/webapp/pages/search/images.tsx
@@ -1,5 +1,5 @@
 import { ParsedUrlQuery } from 'querystring';
-import { useEffect, ReactElement, useContext } from 'react';
+import { useEffect, useContext } from 'react';
 import { GetServerSideProps } from 'next';
 import styled from 'styled-components';
 import Head from 'next/head';
@@ -37,7 +37,7 @@ import { NextPageWithLayout } from '@weco/common/views/pages/_app';
 import { Query } from '@weco/catalogue/types/search';
 
 type Props = {
-  images?: CatalogueResultsList<Image>;
+  images: CatalogueResultsList<Image>;
   imagesRouteProps: ImagesProps;
   query: Query;
   pageview: Pageview;
@@ -54,7 +54,7 @@ const ImagesSearchPage: NextPageWithLayout<Props> = ({
   images,
   imagesRouteProps,
   query,
-}): ReactElement<Props> => {
+}) => {
   const { query: queryString } = query;
 
   const { setLink } = useContext(SearchContext);

--- a/catalogue/webapp/pages/search/images.tsx
+++ b/catalogue/webapp/pages/search/images.tsx
@@ -63,9 +63,7 @@ const ImagesSearchPage: NextPageWithLayout<Props> = ({
     setLink(link);
   }, [imagesRouteProps]);
 
-  const filters = images
-    ? imagesFilters({ images, props: imagesRouteProps })
-    : [];
+  const filters = imagesFilters({ images, props: imagesRouteProps });
 
   const linkResolver = params => {
     const queryWithSource = propsToQuery(params);
@@ -90,7 +88,7 @@ const ImagesSearchPage: NextPageWithLayout<Props> = ({
   return (
     <>
       <Head>
-        {images?.prevPage && (
+        {images.prevPage && (
           <link
             rel="prev"
             href={convertUrlToString(
@@ -101,7 +99,7 @@ const ImagesSearchPage: NextPageWithLayout<Props> = ({
             )}
           />
         )}
-        {images?.nextPage && (
+        {images.nextPage && (
           <link
             rel="next"
             href={convertUrlToString(
@@ -137,47 +135,43 @@ const ImagesSearchPage: NextPageWithLayout<Props> = ({
         />
       </Space>
 
-      {images && (
-        <>
-          {images?.totalResults === 0 ? (
-            <SearchNoResults
-              query={queryString}
-              hasFilters={hasFilters({
-                filters: filters.map(f => f.id),
-                queryParams: Object.keys(query).map(p => p),
-              })}
-            />
-          ) : (
-            <Wrapper>
-              <Space
-                className="container"
-                v={{ size: 'l', properties: ['padding-bottom'] }}
-              >
-                <PaginationWrapper verticalSpacing="l">
-                  <span>{pluralize(images.totalResults, 'result')}</span>
-                  <Pagination
-                    totalPages={images?.totalPages}
-                    ariaLabel="Image search pagination"
-                    hasDarkBg
-                    isHiddenMobile
-                  />
-                </PaginationWrapper>
+      {images.totalResults === 0 ? (
+        <SearchNoResults
+          query={queryString}
+          hasFilters={hasFilters({
+            filters: filters.map(f => f.id),
+            queryParams: Object.keys(query).map(p => p),
+          })}
+        />
+      ) : (
+        <Wrapper>
+          <Space
+            className="container"
+            v={{ size: 'l', properties: ['padding-bottom'] }}
+          >
+            <PaginationWrapper verticalSpacing="l">
+              <span>{pluralize(images.totalResults, 'result')}</span>
+              <Pagination
+                totalPages={images.totalPages}
+                ariaLabel="Image search pagination"
+                hasDarkBg
+                isHiddenMobile
+              />
+            </PaginationWrapper>
 
-                <main>
-                  <ImageEndpointSearchResults images={images.results} />
-                </main>
+            <main>
+              <ImageEndpointSearchResults images={images.results} />
+            </main>
 
-                <PaginationWrapper verticalSpacing="l" alignRight>
-                  <Pagination
-                    totalPages={images?.totalPages}
-                    ariaLabel="Image search pagination"
-                    hasDarkBg
-                  />
-                </PaginationWrapper>
-              </Space>
-            </Wrapper>
-          )}
-        </>
+            <PaginationWrapper verticalSpacing="l" alignRight>
+              <Pagination
+                totalPages={images.totalPages}
+                ariaLabel="Image search pagination"
+                hasDarkBg
+              />
+            </PaginationWrapper>
+          </Space>
+        </Wrapper>
       )}
     </>
   );
@@ -221,7 +215,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       pageSize: 30,
     });
 
-    if (images && images.type === 'Error') {
+    if (images.type === 'Error') {
       return appError(context, images.httpStatus, 'Images API error');
     }
 

--- a/catalogue/webapp/pages/search/works.tsx
+++ b/catalogue/webapp/pages/search/works.tsx
@@ -39,7 +39,7 @@ import { CatalogueResultsList, Work } from '@weco/common/model/catalogue';
 import { Query } from '@weco/catalogue/types/search';
 
 type Props = {
-  works?: CatalogueResultsList<Work>;
+  works: CatalogueResultsList<Work>;
   worksRouteProps: WorksRouteProps;
   query: Query;
   pageview: Pageview;
@@ -64,7 +64,7 @@ export const CatalogueSearchPage: NextPageWithLayout<Props> = ({
     setLink(link);
   }, [worksRouteProps]);
 
-  const filters = works ? worksFilters({ works, props: worksRouteProps }) : [];
+  const filters = worksFilters({ works, props: worksRouteProps });
 
   const linkResolver = params => {
     const queryWithSource = propsToQuery(params);
@@ -89,7 +89,7 @@ export const CatalogueSearchPage: NextPageWithLayout<Props> = ({
   return (
     <>
       <Head>
-        {works?.prevPage && (
+        {works.prevPage && (
           <link
             rel="prev"
             href={convertUrlToString(
@@ -100,7 +100,7 @@ export const CatalogueSearchPage: NextPageWithLayout<Props> = ({
             )}
           />
         )}
-        {works?.nextPage && (
+        {works.nextPage && (
           <link
             rel="next"
             href={convertUrlToString(
@@ -137,80 +137,76 @@ export const CatalogueSearchPage: NextPageWithLayout<Props> = ({
           />
         </Space>
 
-        {works && (
+        {works.totalResults === 0 ? (
+          <SearchNoResults
+            query={queryString}
+            hasFilters={hasFilters({
+              filters: [
+                ...filters.map(f => f.id),
+                // production.dates is one dropdown but two properties, so we're specifying them in their individual format
+                'production.dates.from',
+                'production.dates.to',
+              ],
+              queryParams: Object.keys(query).map(p => p),
+            })}
+          />
+        ) : (
           <>
-            {works.totalResults === 0 ? (
-              <SearchNoResults
-                query={queryString}
-                hasFilters={hasFilters({
-                  filters: [
-                    ...filters.map(f => f.id),
-                    // production.dates is one dropdown but two properties, so we're specifying them in their individual format
-                    'production.dates.from',
-                    'production.dates.to',
-                  ],
-                  queryParams: Object.keys(query).map(p => p),
-                })}
+            <PaginationWrapper verticalSpacing="l">
+              <span>{pluralize(works.totalResults, 'result')}</span>
+
+              <SortPaginationWrapper>
+                <Sort
+                  formId="searchPageForm"
+                  options={[
+                    // Default value to be left empty so it's not added to the URL query
+                    { value: '', text: 'Relevance' },
+                    {
+                      value: 'production.dates.asc',
+                      text: 'Oldest to newest',
+                    },
+                    {
+                      value: 'production.dates.desc',
+                      text: 'Newest to oldest',
+                    },
+                  ]}
+                  jsLessOptions={{
+                    sort: [
+                      { value: '', text: 'Relevance' },
+                      {
+                        value: 'production.dates',
+                        text: 'Production dates',
+                      },
+                    ],
+                    sortOrder: [
+                      { value: 'asc', text: 'Ascending' },
+                      { value: 'desc', text: 'Descending' },
+                    ],
+                  }}
+                  defaultValues={{
+                    sort: worksRouteProps.sort,
+                    sortOrder: worksRouteProps.sortOrder,
+                  }}
+                />
+
+                <Pagination
+                  totalPages={works.totalPages}
+                  ariaLabel="Catalogue search pagination"
+                  isHiddenMobile
+                />
+              </SortPaginationWrapper>
+            </PaginationWrapper>
+
+            <main>
+              <WorksSearchResults works={works.results} />
+            </main>
+
+            <PaginationWrapper verticalSpacing="l" alignRight>
+              <Pagination
+                totalPages={works.totalPages}
+                ariaLabel="Catalogue search pagination"
               />
-            ) : (
-              <>
-                <PaginationWrapper verticalSpacing="l">
-                  <span>{pluralize(works.totalResults, 'result')}</span>
-
-                  <SortPaginationWrapper>
-                    <Sort
-                      formId="searchPageForm"
-                      options={[
-                        // Default value to be left empty so it's not added to the URL query
-                        { value: '', text: 'Relevance' },
-                        {
-                          value: 'production.dates.asc',
-                          text: 'Oldest to newest',
-                        },
-                        {
-                          value: 'production.dates.desc',
-                          text: 'Newest to oldest',
-                        },
-                      ]}
-                      jsLessOptions={{
-                        sort: [
-                          { value: '', text: 'Relevance' },
-                          {
-                            value: 'production.dates',
-                            text: 'Production dates',
-                          },
-                        ],
-                        sortOrder: [
-                          { value: 'asc', text: 'Ascending' },
-                          { value: 'desc', text: 'Descending' },
-                        ],
-                      }}
-                      defaultValues={{
-                        sort: worksRouteProps.sort,
-                        sortOrder: worksRouteProps.sortOrder,
-                      }}
-                    />
-
-                    <Pagination
-                      totalPages={works?.totalPages}
-                      ariaLabel="Catalogue search pagination"
-                      isHiddenMobile
-                    />
-                  </SortPaginationWrapper>
-                </PaginationWrapper>
-
-                <main>
-                  <WorksSearchResults works={works.results} />
-                </main>
-
-                <PaginationWrapper verticalSpacing="l" alignRight>
-                  <Pagination
-                    totalPages={works?.totalPages}
-                    ariaLabel="Catalogue search pagination"
-                  />
-                </PaginationWrapper>
-              </>
-            )}
+            </PaginationWrapper>
           </>
         )}
       </Space>


### PR DESCRIPTION
On all these pages, we know we get a defined list of works/images as a result, so we can ditch all the optional types.

Spotted while reading other code for https://github.com/wellcomecollection/wellcomecollection.org/issues/9091