### PR TITLE
Ensure numbers are formatted in Concept page

### DIFF
--- a/catalogue/webapp/pages/concept.tsx
+++ b/catalogue/webapp/pages/concept.tsx
@@ -14,6 +14,7 @@ import { getImages } from 'services/catalogue/images';
 import { toLink as toImagesLink } from '@weco/common/views/components/ImagesLink/ImagesLink';
 import { toLink as toWorksLink } from '@weco/common/views/components/WorksLink/WorksLink';
 import { pageDescriptionConcepts } from '@weco/common/data/microcopy';
+import { formatNumber } from '@weco/common/utils/grammar';
 
 // Components
 import CataloguePageLayout from 'components/CataloguePageLayout/CataloguePageLayout';
@@ -86,9 +87,17 @@ const ConceptWorksHeader = styled(Space).attrs({
     theme.color(hasWorksTabs ? 'warmNeutral.300' : 'white')};};
 `;
 
-const SeeMoreButton = ({ text, link }: { text: string; link: LinkProps }) => (
+const SeeMoreButton = ({
+  text,
+  link,
+  totalResults,
+}: {
+  text: string;
+  link: LinkProps;
+  totalResults: number;
+}) => (
   <MoreLink
-    name={text}
+    name={text + ` (${formatNumber(totalResults)})`}
     url={link}
     colors={theme.buttonColors.yellowYellowBlack}
     hoverUnderline
@@ -163,7 +172,9 @@ export const ConceptPage: NextPage<Props> = ({
                     text: (
                       <>
                         {`About this ${conceptResponse.type.toLowerCase()} `}
-                        <span className="is-hidden-s">{`(${imagesAbout.totalResults})`}</span>
+                        <span className="is-hidden-s">{`(${formatNumber(
+                          imagesAbout.totalResults
+                        )})`}</span>
                       </>
                     ),
                     selected: selectedImagesTab === 'images-about',
@@ -173,7 +184,9 @@ export const ConceptPage: NextPage<Props> = ({
                     text: (
                       <>
                         {`By this ${conceptResponse.type.toLowerCase()} `}
-                        <span className="is-hidden-s">{`(${imagesBy.totalResults})`}</span>
+                        <span className="is-hidden-s">{`(${formatNumber(
+                          imagesBy.totalResults
+                        )})`}</span>
                       </>
                     ),
                     selected: selectedImagesTab === 'images-by',
@@ -193,7 +206,8 @@ export const ConceptPage: NextPage<Props> = ({
                   <ImageEndpointSearchResults images={imagesAbout.results} />
                   <Space v={{ size: 'm', properties: ['margin-top'] }}>
                     <SeeMoreButton
-                      text={`All images (${imagesAbout.totalResults})`}
+                      text="All images"
+                      totalResults={imagesAbout.totalResults}
                       link={toImagesLink(
                         {
                           'source.subjects.label': [conceptResponse.label],
@@ -213,7 +227,8 @@ export const ConceptPage: NextPage<Props> = ({
                 >
                   <ImageEndpointSearchResults images={imagesBy.results} />
                   <SeeMoreButton
-                    text={`All images (${imagesBy.totalResults})`}
+                    text="All images"
+                    totalResults={imagesBy.totalResults}
                     link={toImagesLink(
                       {
                         'source.contributors.agent.label': [
@@ -246,7 +261,9 @@ export const ConceptPage: NextPage<Props> = ({
                       text: (
                         <>
                           {`About this ${conceptResponse.type.toLowerCase()} `}
-                          <span className="is-hidden-s">{`(${worksAbout.totalResults})`}</span>
+                          <span className="is-hidden-s">{`(${formatNumber(
+                            worksAbout.totalResults
+                          )})`}</span>
                         </>
                       ),
                       selected: selectedWorksTab === 'works-about',
@@ -256,7 +273,9 @@ export const ConceptPage: NextPage<Props> = ({
                       text: (
                         <>
                           {`By this ${conceptResponse.type.toLowerCase()} `}
-                          <span className="is-hidden-s">{`(${worksBy.totalResults})`}</span>
+                          <span className="is-hidden-s">{`(${formatNumber(
+                            worksBy.totalResults
+                          )})`}</span>
                         </>
                       ),
                       selected: selectedWorksTab === 'works-by',
@@ -286,7 +305,8 @@ export const ConceptPage: NextPage<Props> = ({
                   <WorksSearchResults works={worksAbout.results} />
                   <Space v={{ size: 'l', properties: ['padding-top'] }}>
                     <SeeMoreButton
-                      text={`All works (${worksAbout.totalResults})`}
+                      text="All works"
+                      totalResults={worksAbout.totalResults}
                       link={toWorksLink(
                         {
                           'subjects.label': [conceptResponse.label],
@@ -307,7 +327,8 @@ export const ConceptPage: NextPage<Props> = ({
                   <WorksSearchResults works={worksBy.results} />
                   <Space v={{ size: 'l', properties: ['padding-top'] }}>
                     <SeeMoreButton
-                      text={`All works (${worksBy.totalResults})`}
+                      text="All works"
+                      totalResults={worksBy.totalResults}
                       link={toWorksLink(
                         {
                           'contributors.agent.label': [conceptResponse.label],

--- a/catalogue/webapp/pages/concept.tsx
+++ b/catalogue/webapp/pages/concept.tsx
@@ -87,21 +87,30 @@ const ConceptWorksHeader = styled(Space).attrs({
     theme.color(hasWorksTabs ? 'warmNeutral.300' : 'white')};};
 `;
 
-const SeeMoreButton = ({
-  text,
-  link,
-  totalResults,
-}: {
+type SeeMoreButtonType = {
   text: string;
   link: LinkProps;
   totalResults: number;
-}) => (
+};
+
+const SeeMoreButton = ({ text, link, totalResults }: SeeMoreButtonType) => (
   <MoreLink
-    name={text + ` (${formatNumber(totalResults)})`}
+    name={`${text} (${formatNumber(totalResults)})`}
     url={link}
     colors={theme.buttonColors.yellowYellowBlack}
     hoverUnderline
   />
+);
+
+type TagLabelType = {
+  text: string;
+  totalResults: number;
+};
+
+const TabLabel = ({ text, totalResults }: TagLabelType) => (
+  <>
+    {text} <span className="is-hidden-s">({formatNumber(totalResults)})</span>
+  </>
 );
 
 export const ConceptPage: NextPage<Props> = ({
@@ -169,26 +178,18 @@ export const ConceptPage: NextPage<Props> = ({
                 items={[
                   {
                     id: 'images-about',
-                    text: (
-                      <>
-                        {`About this ${conceptResponse.type.toLowerCase()} `}
-                        <span className="is-hidden-s">{`(${formatNumber(
-                          imagesAbout.totalResults
-                        )})`}</span>
-                      </>
-                    ),
+                    text: TabLabel({
+                      text: `About this ${conceptResponse.type.toLowerCase()}`,
+                      totalResults: imagesAbout.totalResults,
+                    }),
                     selected: selectedImagesTab === 'images-about',
                   },
                   {
                     id: 'images-by',
-                    text: (
-                      <>
-                        {`By this ${conceptResponse.type.toLowerCase()} `}
-                        <span className="is-hidden-s">{`(${formatNumber(
-                          imagesBy.totalResults
-                        )})`}</span>
-                      </>
-                    ),
+                    text: TabLabel({
+                      text: `By this ${conceptResponse.type.toLowerCase()}`,
+                      totalResults: imagesBy.totalResults,
+                    }),
                     selected: selectedImagesTab === 'images-by',
                   },
                 ]}
@@ -258,26 +259,18 @@ export const ConceptPage: NextPage<Props> = ({
                   items={[
                     {
                       id: 'works-about',
-                      text: (
-                        <>
-                          {`About this ${conceptResponse.type.toLowerCase()} `}
-                          <span className="is-hidden-s">{`(${formatNumber(
-                            worksAbout.totalResults
-                          )})`}</span>
-                        </>
-                      ),
+                      text: TabLabel({
+                        text: `About this ${conceptResponse.type.toLowerCase()}`,
+                        totalResults: worksAbout.totalResults,
+                      }),
                       selected: selectedWorksTab === 'works-about',
                     },
                     {
                       id: 'works-by',
-                      text: (
-                        <>
-                          {`By this ${conceptResponse.type.toLowerCase()} `}
-                          <span className="is-hidden-s">{`(${formatNumber(
-                            worksBy.totalResults
-                          )})`}</span>
-                        </>
-                      ),
+                      text: TabLabel({
+                        text: `By this ${conceptResponse.type.toLowerCase()}`,
+                        totalResults: worksBy.totalResults,
+                      }),
                       selected: selectedWorksTab === 'works-by',
                     },
                   ]}


### PR DESCRIPTION
## Who is this for?
People who like readable numbers

## What is it doing for them?
Formats them in the concept page using the helper Alex created in https://github.com/wellcomecollection/wellcomecollection.org/pull/9169

<img width="486" alt="Screenshot 2023-01-30 at 14 22 20" src="https://user-images.githubusercontent.com/110461050/215503015-8a94bc1d-6087-486c-9aad-6f04fc703b87.png">
<img width="331" alt="Screenshot 2023-01-30 at 14 22 26" src="https://user-images.githubusercontent.com/110461050/215503025-5536c55a-93cd-43cb-868b-acaa7961f250.png">

