### PR TITLE
Ensure filters wrap in current search

### DIFF
--- a/.buildkite/urls/expected_200_urls.txt
+++ b/.buildkite/urls/expected_200_urls.txt
@@ -80,3 +80,9 @@
 # This is an item page which has been redirected; we want to make
 # sure it redirects to the correct location
 /works/m58dxy2s/items
+
+# These are search pages
+/search?query=human
+/search/stories?query=human
+/search/images?query=human
+/search/works?query=human

--- a/common/views/components/SearchFilters/SearchFiltersDesktop.tsx
+++ b/common/views/components/SearchFilters/SearchFiltersDesktop.tsx
@@ -54,10 +54,14 @@ const Wrapper = styled(Space).attrs<{ isNewStyle?: boolean }>(props => ({
 const FilterDropdownsContainer = styled(Space).attrs({
   v: { size: 'm', properties: ['margin-bottom'] },
   className: font('intr', 5),
-})<{ isComponentMounted?: boolean }>`
+})<{ isComponentMounted?: boolean; isNewStyle?: boolean }>`
   display: flex;
-  align-items: center;
-  ${props => !props.isComponentMounted && `flex-wrap: wrap;`}
+  align-items: ${props => (props.isNewStyle ? 'center' : 'stretch')};
+
+  // Wrap if old style or if new style without Javascript
+  ${props =>
+    (!props.isNewStyle || (props.isNewStyle && !props.isComponentMounted)) &&
+    `flex-wrap: wrap;`}
 `;
 
 const CheckboxFilter = ({
@@ -395,7 +399,10 @@ const SearchFiltersDesktop: FunctionComponent<SearchFiltersSharedProps> = ({
           }}
           className="flex flex--h-space-between flex--v-center full-width flex--wrap"
         >
-          <FilterDropdownsContainer isComponentMounted={isComponentMounted}>
+          <FilterDropdownsContainer
+            isNewStyle={isNewStyle}
+            isComponentMounted={isComponentMounted}
+          >
             {isNewStyle && (
               <>
                 {isComponentMounted && (
@@ -449,12 +456,10 @@ const SearchFiltersDesktop: FunctionComponent<SearchFiltersSharedProps> = ({
                       key={f.id}
                       h={
                         i + 1 !== arr.length
-                          ? {
-                              size: isNewStyle ? 'm' : 's',
-                              properties: ['margin-right'],
-                            }
+                          ? { size: 's', properties: ['margin-right'] }
                           : undefined
                       }
+                      v={{ size: 'xs', properties: ['margin-bottom'] }}
                     >
                       {f.type === 'checkbox' && (
                         <CheckboxFilter
@@ -487,12 +492,7 @@ const SearchFiltersDesktop: FunctionComponent<SearchFiltersSharedProps> = ({
                 })}
 
                 {modalFilters.length > 0 && (
-                  <Space
-                    h={{
-                      size: isNewStyle ? 'm' : 's',
-                      properties: ['margin-left'],
-                    }}
-                  >
+                  <Space h={{ size: 's', properties: ['margin-left'] }}>
                     {isComponentMounted && (
                       <ButtonSolid
                         colors={themeValues.buttonColors.whiteWhiteCharcoal}

--- a/pa11y/webapp/write-report.js
+++ b/pa11y/webapp/write-report.js
@@ -44,6 +44,12 @@ const urls = [
   '/guides/exhibitions/YzwsAREAAHylrxau/audio-without-descriptions',
   '/guides/exhibitions/YzwsAREAAHylrxau/captions-and-transcripts',
   '/guides/exhibitions/YzwsAREAAHylrxau/bsl',
+
+  // These are the new search pages
+  '/search?query=human',
+  '/search/stories?query=human',
+  '/search/images?query=human',
+  '/search/works?query=human',
 ].map(u => `${baseUrl}${u}`);
 
 const promises = urls.map(url =>


### PR DESCRIPTION
## Who is this for?
Users

## What is it doing for them?
The filters weren't wrapping on the current search, creating a horizontal scroll on smaller screens. This ensures that it does wrap the way it used to, and cleans up some conditions.

<img width="594" alt="Screenshot 2023-01-30 at 14 37 34" src="https://user-images.githubusercontent.com/110461050/215516924-a952630b-890a-4a0b-b8e4-0635af9e8a8d.png">
<img width="589" alt="Screenshot 2023-01-30 at 15 16 32" src="https://user-images.githubusercontent.com/110461050/215516983-38111419-e73c-443d-95fd-8e43b7d28d70.png">


It's getting quite complex in there because we have two versions of filters running at the same time, we'll be cleaning up all of this as soon as `/works` and `/images` are deleted.
