### PR TITLE
Small visual changes to the search modal 

### DIFF
--- a/common/views/components/Modal/Modal.tsx
+++ b/common/views/components/Modal/Modal.tsx
@@ -167,7 +167,7 @@ const FiltersModal = styled(BaseModalWindow).attrs<BaseModalProps>({
 
 // TODO Is this still considered 'new'? rename otherwise
 const FiltersModalNew = styled(Space).attrs<BaseModalProps>({
-  v: { size: 's', properties: ['padding-top', 'padding-bottom'] },
+  v: { size: 's', properties: ['padding-top'] },
   className: 'shadow',
 })<BaseModalProps>`
   overflow: hidden;

--- a/common/views/components/ModalMoreFilters/ModalMoreFilters.tsx
+++ b/common/views/components/ModalMoreFilters/ModalMoreFilters.tsx
@@ -47,6 +47,9 @@ const ModalInner = styled(Space).attrs({
   flex-direction: column;
   min-width: 320px;
   max-width: 650px;
+  ${props => props.theme.media('medium')`
+    width: 500px;
+  `}
   ${props => props.theme.media('large')`
     width: 650px;
     top: 10px;

--- a/common/views/components/ModalMoreFilters/ModalMoreFilters.tsx
+++ b/common/views/components/ModalMoreFilters/ModalMoreFilters.tsx
@@ -47,9 +47,10 @@ const ModalInner = styled(Space).attrs({
   flex-direction: column;
   min-width: 320px;
   max-width: 650px;
-  ${props => props.theme.media('medium')`
-    width: 500px;
-  `}
+  ${props =>
+    props.theme.media('medium')(`
+    min-width: ${props.isNewStyle ? '500px' : '320px'};
+  `)}
   ${props => props.theme.media('large')`
     width: 650px;
     top: 10px;
@@ -57,7 +58,7 @@ const ModalInner = styled(Space).attrs({
   position: relative;
   top: ${props => (props.isNewStyle ? '0' : '15px')};
   overflow-y: auto;
-  max-height: 80vh;
+  max-height: ${props => (props.isNewStyle ? 'none' : '80vh')};
 `;
 
 // shared styles
@@ -78,24 +79,26 @@ const List = styled(PlainList)`
 
 const FiltersFooter = styled(Space).attrs({
   h: { size: 'l', properties: ['padding-left', 'padding-right'] },
-  v: { size: 'l', properties: ['padding-top', 'padding-bottom'] },
+  v: { size: 'm', properties: ['padding-top', 'padding-bottom'] },
 })<{ isNewStyle?: boolean }>`
   display: flex;
   align-items: center;
   justify-content: space-between;
   background-color: ${props => props.theme.color('white')};
   border-top: 1px solid ${props => props.theme.color('warmNeutral.400')};
-  position: ${props => (props.isNewStyle ? 'relative' : 'fixed')};
+  position: ${props => (props.isNewStyle ? 'sticky' : 'fixed')};
   bottom: 0;
   left: 0;
   right: 0;
-  height: 60px;
 `;
 
-const FiltersHeader = styled(Space).attrs({
+const FiltersHeader = styled(Space).attrs<{ isNewStyle?: boolean }>(props => ({
   h: { size: 'm', properties: ['padding-left', 'padding-right'] },
-  v: { size: 'm', properties: ['padding-top', 'padding-bottom'] },
-})<{ isNewStyle?: boolean }>`
+  v: {
+    size: props.isNewStyle ? 's' : 'm',
+    properties: ['padding-top', 'padding-bottom'],
+  },
+}))<{ isNewStyle?: boolean }>`
   position: ${props => (props.isNewStyle ? 'relative' : 'absolute')};
   background-color: ${props => props.theme.color('white')};
   border-bottom: 1px solid ${props => props.theme.color('warmNeutral.400')};

--- a/common/views/components/SearchFilters/SearchFiltersMobile.tsx
+++ b/common/views/components/SearchFilters/SearchFiltersMobile.tsx
@@ -310,35 +310,37 @@ const SearchFiltersMobile: FunctionComponent<SearchFiltersSharedProps> = ({
             </FiltersHeader>
 
             <FiltersBody>
-              {filters.map(f => {
-                return (
-                  <FilterSection key={f.id}>
-                    {f.type === 'checkbox' && (
-                      <CheckboxFilter
-                        f={f}
-                        changeHandler={changeHandler}
-                        form={searchFormId}
-                      />
-                    )}
+              {filters
+                .filter(f => !f.excludeFromMoreFilters)
+                .map(f => {
+                  return (
+                    <FilterSection key={f.id}>
+                      {f.type === 'checkbox' && (
+                        <CheckboxFilter
+                          f={f}
+                          changeHandler={changeHandler}
+                          form={searchFormId}
+                        />
+                      )}
 
-                    {f.type === 'dateRange' && (
-                      <DateRangeFilter
-                        f={f}
-                        changeHandler={changeHandler}
-                        form={searchFormId}
-                      />
-                    )}
+                      {f.type === 'dateRange' && (
+                        <DateRangeFilter
+                          f={f}
+                          changeHandler={changeHandler}
+                          form={searchFormId}
+                        />
+                      )}
 
-                    {f.type === 'color' && (
-                      <ColorFilter
-                        f={f}
-                        changeHandler={changeHandler}
-                        form={searchFormId}
-                      />
-                    )}
-                  </FilterSection>
-                );
-              })}
+                      {f.type === 'color' && (
+                        <ColorFilter
+                          f={f}
+                          changeHandler={changeHandler}
+                          form={searchFormId}
+                        />
+                      )}
+                    </FilterSection>
+                  );
+                })}
             </FiltersBody>
           </FiltersScrollable>
 


### PR DESCRIPTION
## Who is this for?
Design tweaks

## What is it doing for them?
- Removes "Series" as a filter option from the modal on mobile. This was already done on the desktop modal.
- Tweak modals' header and footer padding on desktop so they looks more centered and aligned.
- New style has extra `min-width` value as it looked strange without on certain queries that removed the need for two columns.

Before
<img width="917" alt="Screenshot 2023-01-30 at 14 26 01" src="https://user-images.githubusercontent.com/110461050/215526876-c27028f1-6470-4d25-9c5d-7c2178f82fba.png">

After
<img width="816" alt="Screenshot 2023-01-30 at 15 49 34" src="https://user-images.githubusercontent.com/110461050/215526923-3f19786c-4ef2-476c-b36a-39ae290ba1b0.png">

The current search modal looks about the same as it currently does, sans "Series" as a filter
<img width="906" alt="Screenshot 2023-01-30 at 14 26 55" src="https://user-images.githubusercontent.com/110461050/215527152-49c0244d-cc54-47c2-88ee-03bb41478eaa.png">
