### PR TITLE
Breaking story

### DIFF
--- a/catalogue/webapp/services/prismic/transformers/index.ts
+++ b/catalogue/webapp/services/prismic/transformers/index.ts
@@ -17,7 +17,7 @@ export async function transformPrismicResponse(
     const { node } = edge;
     const { title, contributors, promo, _meta, format } = node;
     const { id, firstPublicationDate } = _meta;
-    const { primary: image } = promo[0];
+    const image = promo?.[0]?.primary;
     const isArticle = type.includes('articles');
 
     // in some cases we don't have contributors
@@ -34,12 +34,12 @@ export async function transformPrismicResponse(
     return {
       id,
       title: title[0]?.text,
-      image: transformImage(image.image),
+      image: transformImage(image?.image),
       url: linkResolver({ id, type: type[0] }),
       firstPublicationDate,
       contributors: allContributors,
       type,
-      summary: image.caption[0].text,
+      summary: image?.caption[0].text,
       label:
         isArticle && format?._meta
           ? { text: articleIdToLabel(format._meta.id) }

--- a/catalogue/webapp/services/prismic/types/event.ts
+++ b/catalogue/webapp/services/prismic/types/event.ts
@@ -9,7 +9,7 @@ export type Event = {
   firstPublicationDate: Date;
   contributors: (string | undefined)[];
   type: ContentType[];
-  summary: string;
+  summary?: string;
   label: {
     text: string;
   };

--- a/catalogue/webapp/services/prismic/types/exhibition.ts
+++ b/catalogue/webapp/services/prismic/types/exhibition.ts
@@ -9,7 +9,7 @@ export type Exhibition = {
   firstPublicationDate: Date;
   contributors: (string | undefined)[];
   type: ContentType[];
-  summary: string;
+  summary?: string;
   label: {
     text: string;
   };

--- a/catalogue/webapp/services/prismic/types/story.ts
+++ b/catalogue/webapp/services/prismic/types/story.ts
@@ -9,7 +9,7 @@ export type Story = {
   firstPublicationDate: Date;
   contributors: (string | undefined)[];
   type: ContentType[];
-  summary: string;
+  summary?: string;
   label: {
     text: string;
   };


### PR DESCRIPTION
## Who is this for?
Users of story search

## What is it doing for them?
- Page was breaking when an article didn't have a promo image. We thought it always had one, but turns out it doesn't (see examples here https://wellcomecollection.org/series/WcpOjygAAJsLEXTc). I've taken the same treatment as the example page; no promo image, no replacement. This might be something we'd like to review down the line but for now this is a bug fix.

<img width="1167" alt="Screenshot 2023-01-31 at 09 42 25" src="https://user-images.githubusercontent.com/110461050/215724530-e06318bc-e39f-4ec3-819d-e155c2cd12e7.png">
<img width="1156" alt="Screenshot 2023-01-31 at 09 43 42" src="https://user-images.githubusercontent.com/110461050/215725578-475d02d8-19b5-4f75-8ade-5d179ab24982.png">

Note: Sometimes they do have an image, but no `richCrops` or `simpleCrops` information and therefore get ignored. We do want all our images to be of the same size so this avoids unequal grids. 