### PR TITLE
Pa11y search changes

### DIFF
--- a/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
+++ b/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
@@ -213,19 +213,19 @@ const SearchLayout: FunctionComponent<{ hasEventsExhibitions: boolean }> = ({
             updateUrl(event.currentTarget);
             return false;
           }}
-        />
-        <h1 className="visually-hidden">
-          {`${capitalize(currentSearchCategory)} search page`}
-        </h1>
-
-        <SearchBarContainer
-          v={{ size: 'l', properties: ['margin-top', 'margin-bottom'] }}
         >
-          <SearchBar
-            placeholder={searchbarPlaceholderText[currentSearchCategory]}
-          />
-        </SearchBarContainer>
+          <h1 className="visually-hidden">
+            {`${capitalize(currentSearchCategory)} search page`}
+          </h1>
 
+          <SearchBarContainer
+            v={{ size: 'l', properties: ['margin-top', 'margin-bottom'] }}
+          >
+            <SearchBar
+              placeholder={searchbarPlaceholderText[currentSearchCategory]}
+            />
+          </SearchBarContainer>
+        </form>
         <SubNavigation
           label="Search Categories"
           items={[

--- a/common/views/components/PaletteColorPicker/PaletteColorPicker.tsx
+++ b/common/views/components/PaletteColorPicker/PaletteColorPicker.tsx
@@ -197,7 +197,7 @@ const PaletteColorPicker: FunctionComponent<Props> = ({
             {palette.map(swatch => (
               <Swatch
                 key={swatch.hexValue}
-                data-name={`swatch-${swatch.colorName.toLowerCase()}`}
+                data-test-id={`swatch-${swatch.colorName.toLowerCase()}`}
                 hexColor={swatch.hexValue}
                 ariaPressed={colorState === swatch.hexValue}
                 onClick={() => setColorState(swatch.hexValue)}

--- a/common/views/components/PaletteColorPicker/PaletteColorPicker.tsx
+++ b/common/views/components/PaletteColorPicker/PaletteColorPicker.tsx
@@ -197,7 +197,7 @@ const PaletteColorPicker: FunctionComponent<Props> = ({
             {palette.map(swatch => (
               <Swatch
                 key={swatch.hexValue}
-                id={`swatch-${swatch.colorName.toLowerCase()}`}
+                data-name={`swatch-${swatch.colorName.toLowerCase()}`}
                 hexColor={swatch.hexValue}
                 ariaPressed={colorState === swatch.hexValue}
                 onClick={() => setColorState(swatch.hexValue)}

--- a/common/views/components/SearchBar/SearchBar.tsx
+++ b/common/views/components/SearchBar/SearchBar.tsx
@@ -2,7 +2,9 @@ import { FunctionComponent, useRef, useState } from 'react';
 import styled from 'styled-components';
 
 import TextInput from '@weco/common/views/components/TextInput/TextInput';
-import ButtonSolid from '@weco/common/views/components/ButtonSolid/ButtonSolid';
+import ButtonSolid, {
+  ButtonTypes,
+} from '@weco/common/views/components/ButtonSolid/ButtonSolid';
 import { themeValues } from '@weco/common/views/themes/config';
 
 import { useRouter } from 'next/router';
@@ -65,6 +67,7 @@ const SearchBar: FunctionComponent<{ placeholder: string }> = ({
       <SearchButtonWrapper>
         <ButtonSolid
           text="Search"
+          type={ButtonTypes.submit}
           size="large"
           form="searchPageForm"
           colors={themeValues.buttonColors.yellowYellowBlack}

--- a/playwright/test/selectors/images.ts
+++ b/playwright/test/selectors/images.ts
@@ -4,7 +4,7 @@ import { mobileModal, searchResultsContainer } from './search';
 export const searchImagesForm =
   'form[aria-describedby="images-form-description"]';
 export const colourSelectorFilterDropDown = `${searchImagesForm} button[aria-controls="images.color"]`;
-export const colourSelector = 'button[data-name="swatch-green"]';
+export const colourSelector = 'button[data-test-id="swatch-green"]';
 
 // results list
 export const imagesResultsListItem = `${searchResultsContainer} li`;

--- a/playwright/test/selectors/images.ts
+++ b/playwright/test/selectors/images.ts
@@ -4,7 +4,7 @@ import { mobileModal, searchResultsContainer } from './search';
 export const searchImagesForm =
   'form[aria-describedby="images-form-description"]';
 export const colourSelectorFilterDropDown = `${searchImagesForm} button[aria-controls="images.color"]`;
-export const colourSelector = 'button[id="swatch-green"]';
+export const colourSelector = 'button[data-name="swatch-green"]';
 
 // results list
 export const imagesResultsListItem = `${searchResultsContainer} li`;


### PR DESCRIPTION
## Who is this for?
Users of AT

## What is it doing for them?
addressing the issues flagged in pa11y related to the new search page

- search page submit form button was not semantically a submit button, this was solved by both adding the type of submit to it, and also wrapping the search bar inside of the form element.
- the PaletteColourPicket was assigning each swatch button a unique ID, which got duplicated due to the colour swatch being present in both the filter bar and the filter modal. The ID had no apparent functional value, so I replaced it with `data-test-id` and updated the selector in the test files.

closes #9180 