### PR TITLE
ensured that the API was getting a 4 digit year

### DIFF
--- a/catalogue/webapp/services/catalogue/works.ts
+++ b/catalogue/webapp/services/catalogue/works.ts
@@ -78,10 +78,14 @@ function toIsoDateString(
 ): string | undefined {
   if (s) {
     try {
+      const pad = (value: string): string => {
+        if (value.length === 4) return value;
+        return pad(`0${value}`);
+      };
       const d = new Date(s);
-      return range === 'from'
-        ? `${d.getUTCFullYear()}-01-01`
-        : `${d.getUTCFullYear()}-12-31`;
+      let year = d.getUTCFullYear().toString();
+
+      return range === 'from' ? `${pad(year)}-01-01` : `${pad(year)}-12-31`;
     } catch (e) {
       return undefined;
     }


### PR DESCRIPTION
## Who is this for?
People that wish to search for works older than the year 1000

## What is it doing for them?
allows for the front end to make requests for works dated from the first century
note: this does not currently cover content that is BC