### PR TITLE
Add a script to find articles without useable promo images

### DIFF
--- a/prismic-model/lintPrismicData.ts
+++ b/prismic-model/lintPrismicData.ts
@@ -88,6 +88,25 @@ function detectNonHttpContributorLinks(doc: any): string[] {
   return [];
 }
 
+// Stories without a Promo image should be rare as they are considered required now
+// But older articles won't necessarily have them.
+//
+// We'll consider a default/fallbak option, but for now we want to find out which ones
+// are causing issue.
+function detectNonPromoImageStories(doc: any): string[] {
+  if (doc.type === 'articles') {
+    if (!doc.data.promo[0]) {
+      return ['This article has an empty promo'];
+    } else if (!doc.data.promo[0].primary?.image?.square) {
+      // getCrop won't work without square/ratioed layouts and therefore won't render an image
+      // on the front end.
+      return ['This article has no square layout'];
+    }
+  }
+
+  return [];
+}
+
 async function run() {
   const snapshotFile = await downloadPrismicSnapshot();
 
@@ -99,6 +118,7 @@ async function run() {
       ...detectEur01Safelinks(doc),
       ...detectBrokenInterpretationTypeLinks(doc),
       ...detectNonHttpContributorLinks(doc),
+      ...detectNonPromoImageStories(doc),
     ];
 
     totalErrors += errors.length;

--- a/prismic-model/lintPrismicData.ts
+++ b/prismic-model/lintPrismicData.ts
@@ -96,11 +96,13 @@ function detectNonHttpContributorLinks(doc: any): string[] {
 function detectNonPromoImageStories(doc: any): string[] {
   if (doc.type === 'articles') {
     if (!doc.data.promo[0]) {
-      return ['This article has an empty promo'];
+      return ['This article has no promo image, please add one.'];
     } else if (!doc.data.promo[0].primary?.image?.square) {
       // getCrop won't work without square/ratioed layouts and therefore won't render an image
       // on the front end.
-      return ['This article has no square layout'];
+      return [
+        "This article's promo image has no square layout, re-add the image and save it to fix.",
+      ];
     }
   }
 

--- a/prismic-model/lintPrismicData.ts
+++ b/prismic-model/lintPrismicData.ts
@@ -91,7 +91,7 @@ function detectNonHttpContributorLinks(doc: any): string[] {
 // Stories without a Promo image should be rare as they are considered required now
 // But older articles won't necessarily have them.
 //
-// We'll consider a default/fallbak option, but for now we want to find out which ones
+// We'll consider a default/fallback option, but for now we want to find out which ones
 // are causing issue.
 function detectNonPromoImageStories(doc: any): string[] {
   if (doc.type === 'articles') {


### PR DESCRIPTION
## Who is this for?
Editorial

## What is it doing for them?
Finds all Prismic articles that (1) don't have a promo image (2) don't have a promo image with a square layout

Closes #9191 