### PR TITLE
Remove extra FocusTrap

### DIFF
--- a/common/views/components/SearchFilters/SearchFiltersMobile.tsx
+++ b/common/views/components/SearchFilters/SearchFiltersMobile.tsx
@@ -30,7 +30,6 @@ import ButtonSolid, {
 import { searchFilterCheckBox } from '../../../text/aria-labels';
 import { dateRegex } from './SearchFiltersDesktop';
 import { filter } from '@weco/common/icons';
-import FocusTrap from 'focus-trap-react';
 import Modal from '../../components/Modal/Modal';
 
 const PaletteColorPicker = dynamic(
@@ -296,76 +295,74 @@ const SearchFiltersMobile: FunctionComponent<SearchFiltersSharedProps> = ({
           )}
         </SolidButton>
       </ShameButtonWrap>
-      <FocusTrap active={isActive}>
-        <Modal
-          id="mobile-filters-modal"
-          isActive={isActive}
-          setIsActive={setIsActive}
-          openButtonRef={openFiltersButtonRef}
-          modalStyle="filters"
-        >
-          <FiltersScrollable>
-            <FiltersHeader>
-              <h2 className="h2">Filters</h2>
-            </FiltersHeader>
+      <Modal
+        id="mobile-filters-modal"
+        isActive={isActive}
+        setIsActive={setIsActive}
+        openButtonRef={openFiltersButtonRef}
+        modalStyle="filters"
+      >
+        <FiltersScrollable>
+          <FiltersHeader>
+            <h2 className="h2">Filters</h2>
+          </FiltersHeader>
 
-            <FiltersBody>
-              {filters
-                .filter(f => !f.excludeFromMoreFilters)
-                .map(f => {
-                  return (
-                    <FilterSection key={f.id}>
-                      {f.type === 'checkbox' && (
-                        <CheckboxFilter
-                          f={f}
-                          changeHandler={changeHandler}
-                          form={searchFormId}
-                        />
-                      )}
+          <FiltersBody>
+            {filters
+              .filter(f => !f.excludeFromMoreFilters)
+              .map(f => {
+                return (
+                  <FilterSection key={f.id}>
+                    {f.type === 'checkbox' && (
+                      <CheckboxFilter
+                        f={f}
+                        changeHandler={changeHandler}
+                        form={searchFormId}
+                      />
+                    )}
 
-                      {f.type === 'dateRange' && (
-                        <DateRangeFilter
-                          f={f}
-                          changeHandler={changeHandler}
-                          form={searchFormId}
-                        />
-                      )}
+                    {f.type === 'dateRange' && (
+                      <DateRangeFilter
+                        f={f}
+                        changeHandler={changeHandler}
+                        form={searchFormId}
+                      />
+                    )}
 
-                      {f.type === 'color' && (
-                        <ColorFilter
-                          f={f}
-                          changeHandler={changeHandler}
-                          form={searchFormId}
-                        />
-                      )}
-                    </FilterSection>
-                  );
-                })}
-            </FiltersBody>
-          </FiltersScrollable>
+                    {f.type === 'color' && (
+                      <ColorFilter
+                        f={f}
+                        changeHandler={changeHandler}
+                        form={searchFormId}
+                      />
+                    )}
+                  </FilterSection>
+                );
+              })}
+          </FiltersBody>
+        </FiltersScrollable>
 
-          <FiltersFooter>
-            <NextLink
-              passHref
-              {...worksLink(
-                {
-                  ...(query && { query }),
-                },
-                'cancel_filter/all'
-              )}
-            >
-              <a>Reset filters</a>
-            </NextLink>
+        <FiltersFooter>
+          <NextLink
+            passHref
+            {...worksLink(
+              {
+                ...(query && { query }),
+              },
+              'cancel_filter/all'
+            )}
+          >
+            <a>Reset filters</a>
+          </NextLink>
 
-            <ButtonSolid
-              ref={okFiltersButtonRef}
-              type={ButtonTypes.button}
-              clickHandler={handleOkFiltersButtonClick}
-              text="Show results"
-            />
-          </FiltersFooter>
-        </Modal>
-      </FocusTrap>
+          <ButtonSolid
+            ref={okFiltersButtonRef}
+            type={ButtonTypes.button}
+            clickHandler={handleOkFiltersButtonClick}
+            text="Show results"
+          />
+        </FiltersFooter>
+      </Modal>
     </SearchFiltersContainer>
   );
 };


### PR DESCRIPTION
## Who is this for?
maintenance

## What is it doing for them?
`<FocusTrap>` is already set in the [`<Modal>` component](https://github.com/wellcomecollection/wellcomecollection.org/blob/main/common/views/components/Modal/Modal.tsx#L305), so no need to wrap it in another one. It removes the console warning that brought this to attention (as it was conflicting with the first one's use of `ref`).

Closes #9181 