### PR TITLE
Fix the infinite loop on the items page

### DIFF
--- a/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
@@ -274,7 +274,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
       .filter(Boolean);
 
   useEffect(() => {
-    let timer;
+    let timer: NodeJS.Timeout;
     let previousActiveIndex;
 
     const mainAreaObserver = new ResizeObserver(([mainArea]) => {

--- a/common/services/catalogue/routes.ts
+++ b/common/services/catalogue/routes.ts
@@ -170,8 +170,8 @@ export const WorkRoute: NextRoute<WorkRouteProps> = {
     const { id } = params;
     return {
       href: {
-        pathname: '/work',
-        query: { id },
+        pathname: '/works/[workId]',
+        query: { workId: id },
       },
       as: {
         pathname: `/works/${id}`,
@@ -225,7 +225,7 @@ export const ItemRoute: NextRoute<ItemRouteProps> = {
     const { workId } = params;
     return {
       href: {
-        pathname: '/item',
+        pathname: '/works/[workId]/items',
         query: ItemRoute.toQuery(params),
       },
       as: {
@@ -258,7 +258,7 @@ export const ImageRoute: NextRoute<ImageRouteProps> = {
     const { workId } = params;
     return {
       href: {
-        pathname: '/image',
+        pathname: '/works/[workId]/images',
         query: ImageRoute.toQuery(params),
       },
       as: {

--- a/common/views/components/ImageLink/ImageLink.tsx
+++ b/common/views/components/ImageLink/ImageLink.tsx
@@ -63,7 +63,7 @@ function toLink(
 
 type Props = LinkFrom<ImageProps> & { source: ImagePropsSource };
 
-const WorksLink: FunctionComponent<Props> = ({
+const ImageLink: FunctionComponent<Props> = ({
   children,
   source,
   ...props
@@ -71,5 +71,5 @@ const WorksLink: FunctionComponent<Props> = ({
   return <NextLink {...toLink(props, source)}>{children}</NextLink>;
 };
 
-export default WorksLink;
+export default ImageLink;
 export { toLink, fromQuery, emptyImageProps };

--- a/common/views/components/ItemLink/ItemLink.tsx
+++ b/common/views/components/ItemLink/ItemLink.tsx
@@ -76,7 +76,7 @@ function toLink(
 
 type Props = LinkFrom<ItemProps> & { source: ItemPropsSource };
 
-const WorksLink: FunctionComponent<Props> = ({
+const ItemLink: FunctionComponent<Props> = ({
   children,
   source,
   ...props
@@ -84,5 +84,5 @@ const WorksLink: FunctionComponent<Props> = ({
   return <NextLink {...toLink(props, source)}>{children}</NextLink>;
 };
 
-export default WorksLink;
+export default ItemLink;
 export { toLink, fromQuery, emptyItemProps };

--- a/common/views/components/ItemLink/ItemLink.tsx
+++ b/common/views/components/ItemLink/ItemLink.tsx
@@ -55,7 +55,6 @@ function toLink(
   partialProps: Partial<ItemProps>,
   source: ItemPropsSource
 ): LinkProps {
-  const pathname = '/item';
   const props: ItemProps = {
     ...emptyItemProps,
     ...partialProps,
@@ -64,7 +63,7 @@ function toLink(
 
   return {
     href: {
-      pathname,
+      pathname: '/works/[workId]/items',
       query: { ...query, source },
     },
     as: {


### PR DESCRIPTION
I don't understand why this works, but making the internal routing more consistent is no bad thing and seems to fix the infinite redirect.

(I wonder if it was saying "go to /works/$workId/items?canvas=5", which I expect to be rendered by route `/item.tsx`, and because it was being rendered by `/works/[workId]/items.tsx` instead, it was going into a whole new page/loop)