### PR TITLE
Remove double license in package.json

### DIFF
--- a/prismic-model/package.json
+++ b/prismic-model/package.json
@@ -10,7 +10,6 @@
     "lintPrismicData": "ts-node lintPrismicData",
     "tryAllContentPages": "ts-node tryAllContentPages"
   },
-  "license": "MIT",
   "dependencies": {
     "@aws-sdk/client-cloudfront": "^3.40.0",
     "@aws-sdk/client-secrets-manager": "^3.40.0",


### PR DESCRIPTION
## Who is this for?
maintenance

## What is it doing for them?
Just noticed (linting error) license was declared twice (on line 4 as well)