### PR TITLE
Add the new items route to the ALB routing

### DIFF
--- a/catalogue/terraform/stack/main.tf
+++ b/catalogue/terraform/stack/main.tf
@@ -161,6 +161,7 @@ locals {
     "/_next/data/*/image.json",
     "/_next/data/*/images.json",
     "/_next/data/*/item.json",
+    "/_next/data/*/items.json",
     "/_next/data/*/progress.json",
     "/_next/data/*/work.json",
     "/_next/data/*/works.json",


### PR DESCRIPTION
This prevents an infinite redirect on e.g. https://www-stage.wellcomecollection.org/works/re9cyhkt/items?canvas=5, in which Next.js can't load the getServerSideProps from items.json, and tries to reload the page.