### PR TITLE
remove itemWorkLink from toggler

### DIFF
--- a/cache/edge_lambdas/src/toggler.ts
+++ b/cache/edge_lambdas/src/toggler.ts
@@ -19,14 +19,8 @@ type Test = {
 };
 
 // This is mutable for testing
-export let tests: Test[] = [
-  {
-    id: 'itemWorkLink',
-    title: 'Item page: Work page link',
-    range: [0, 50],
-    when: (): boolean => true,
-  },
-];
+export let tests: Test[] = [];
+
 export const setTests = function (newTests: Test[]): void {
   tests = newTests;
 };

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -72,16 +72,7 @@ const toggles = {
         'Adds tabbed navigation to the works page, for switching between work, item and related content',
     },
   ] as const,
-  tests: [
-    {
-      id: 'itemWorkLink',
-      title: 'Item page: Work page link',
-      range: [0, 50],
-      when: (request: CloudFrontRequest): boolean => {
-        return Boolean(request.uri.match(/^\/works\/\w*\/items/));
-      },
-    },
-  ] as ABTest[],
+  tests: [] as ABTest[],
 };
 
 export default toggles;


### PR DESCRIPTION
Relates to [tidying up after the a/b test](https://github.com/wellcomecollection/wellcomecollection.org/issues/9032#issuecomment-1413846268)

This stops us setting the cookie in the cloudfront edge lambda and removes the test from the [toggles dash](https://dash.wellcomecollection.org/toggles/index.html)