### PR TITLE
Simplify the way we pass around Contributor data

### DIFF
--- a/cardigan/stories/components/Contributors/Contributors.stories.tsx
+++ b/cardigan/stories/components/Contributors/Contributors.stories.tsx
@@ -38,6 +38,5 @@ basic.args = {
       description: null,
     },
   ],
-  titleOverride: '',
 };
 basic.storyName = 'Contributors';

--- a/content/webapp/components/ContentPage/ContentPage.tsx
+++ b/content/webapp/components/ContentPage/ContentPage.tsx
@@ -117,7 +117,6 @@ const ContentPage = ({
   postOutroContent,
   seasons = [],
   contributors,
-  contributorTitle,
   hideContributors,
 }: Props): ReactElement => {
   // We don't want to add a spacing unit if there's nothing to render
@@ -173,10 +172,7 @@ const ContentPage = ({
           {!hideContributors && contributors && contributors.length > 0 && (
             <SpacingSection>
               <Layout8>
-                <Contributors
-                  contributors={contributors}
-                  titleOverride={contributorTitle}
-                />
+                <Contributors contributors={contributors} />
               </Layout8>
             </SpacingSection>
           )}

--- a/content/webapp/components/Contributors/Contributor.tsx
+++ b/content/webapp/components/Contributors/Contributor.tsx
@@ -7,6 +7,7 @@ import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/Pri
 import Space from '@weco/common/views/components/styled/Space';
 import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImage';
 import { getCrop } from '@weco/common/model/image';
+import { gridSize12 } from '@weco/common/views/components/Layout12/Layout12';
 
 const ContributorInfoWrapper = styled(Space)`
   color: ${props => props.theme.color('neutral.600')};
@@ -31,7 +32,7 @@ const Contributor: FunctionComponent<ContributorType> = ({
 
   return (
     <div className="grid">
-      <div className={`flex ${grid({ s: 12, m: 12, l: 12, xl: 12 })}`}>
+      <div className={`flex ${grid(gridSize12)}`}>
         <Space
           style={{ minWidth: '78px' }}
           h={{ size: 'm', properties: ['margin-right'] }}

--- a/content/webapp/components/Contributors/Contributor.tsx
+++ b/content/webapp/components/Contributors/Contributor.tsx
@@ -21,7 +21,7 @@ const Contributor: FunctionComponent<ContributorType> = ({
   contributor,
   role,
   description,
-}: ContributorType) => {
+}) => {
   const descriptionToRender = description || contributor.description;
 
   // Contributor images should always be square.

--- a/content/webapp/components/Contributors/Contributor.tsx
+++ b/content/webapp/components/Contributors/Contributor.tsx
@@ -20,10 +20,7 @@ const ContributorNameWrapper = styled.div`
 const Contributor: FunctionComponent<ContributorType> = ({
   contributor,
   role,
-  description,
 }) => {
-  const descriptionToRender = description || contributor.description;
-
   // Contributor images should always be square.
   //
   // We prefer the explicit square crop if it's available, but we can't rely on it --
@@ -113,7 +110,7 @@ const Contributor: FunctionComponent<ContributorType> = ({
             />
           )}
 
-          {descriptionToRender && (
+          {contributor.description && (
             <Space
               v={{
                 size: 's',
@@ -121,7 +118,7 @@ const Contributor: FunctionComponent<ContributorType> = ({
               }}
               className={`${font('intr', 5)} spaced-text`}
             >
-              <PrismicHtmlBlock html={descriptionToRender} />
+              <PrismicHtmlBlock html={contributor.description} />
             </Space>
           )}
         </div>

--- a/content/webapp/components/Contributors/Contributors.tsx
+++ b/content/webapp/components/Contributors/Contributors.tsx
@@ -52,7 +52,7 @@ const Contributors: FunctionComponent<Props> = ({
   titlePrefix = 'About the',
   contributors,
   titleOverride,
-}: Props) => {
+}) => {
   // The transformContributors() method will remove contributors that don't
   // have any visible fields.
   //

--- a/content/webapp/components/Contributors/Contributors.tsx
+++ b/content/webapp/components/Contributors/Contributors.tsx
@@ -7,7 +7,6 @@ import { Contributor as ContributorType } from '../../types/contributors';
 export type Props = {
   titlePrefix?: string;
   contributors: ContributorType[];
-  titleOverride?: string;
 };
 
 export function dedupeAndPluraliseRoles(roles: string[]): string[] {
@@ -51,7 +50,6 @@ export function getContributorsTitle(
 const Contributors: FunctionComponent<Props> = ({
   titlePrefix = 'About the',
   contributors,
-  titleOverride,
 }) => {
   // The transformContributors() method will remove contributors that don't
   // have any visible fields.
@@ -71,11 +69,7 @@ const Contributors: FunctionComponent<Props> = ({
 
   return (
     <Fragment>
-      <h2 className="h2">
-        {isNotUndefined(titleOverride)
-          ? titleOverride
-          : `${getContributorsTitle(roles, titlePrefix)}`}
-      </h2>
+      <h2 className="h2">{getContributorsTitle(roles, titlePrefix)}</h2>
 
       {contributors.map(({ contributor, role }) => (
         <Space

--- a/content/webapp/components/Contributors/Contributors.tsx
+++ b/content/webapp/components/Contributors/Contributors.tsx
@@ -30,10 +30,7 @@ export function dedupeAndPluraliseRoles(roles: string[]): string[] {
   return pluralised;
 }
 
-export function getContributorsTitle(
-  roles: string[],
-  titlePrefix = 'About the'
-): string {
+function getContributorsTitle(roles: string[], titlePrefix): string {
   const lowerCaseRoles = roles.map(role => role.toLowerCase());
 
   // This is basic, but makes sense

--- a/content/webapp/components/Contributors/Contributors.tsx
+++ b/content/webapp/components/Contributors/Contributors.tsx
@@ -77,7 +77,7 @@ const Contributors: FunctionComponent<Props> = ({
           : `${getContributorsTitle(roles, titlePrefix)}`}
       </h2>
 
-      {contributors.map(({ contributor, role, description }) => (
+      {contributors.map(({ contributor, role }) => (
         <Space
           v={{ size: 'l', properties: ['margin-bottom'] }}
           key={contributor.id}
@@ -89,7 +89,6 @@ const Contributors: FunctionComponent<Props> = ({
           <Contributor
             contributor={contributor}
             role={roles.length > 1 ? role : undefined}
-            description={description}
           />
         </Space>
       ))}

--- a/content/webapp/services/prismic/transformers/contributors.ts
+++ b/content/webapp/services/prismic/transformers/contributors.ts
@@ -90,13 +90,10 @@ export function transformContributors(
           }
         : undefined;
 
-      const description = asRichText(contributor.description);
-
       return agent
         ? {
             contributor: agent,
             role,
-            description,
           }
         : undefined;
     })

--- a/content/webapp/services/prismic/transformers/contributors.ts
+++ b/content/webapp/services/prismic/transformers/contributors.ts
@@ -13,7 +13,7 @@ import { Contributor, ContributorBasic } from '../../../types/contributors';
 import { isNotUndefined } from '@weco/common/utils/array';
 import { asRichText, asText } from '.';
 import { ImageType } from '@weco/common/model/image';
-import { Organisation, Person } from '../types/contributors';
+import { Organisation, Person, SameAsField } from '../types/contributors';
 import { transformImage } from '@weco/common/services/prismic/transformers/images';
 
 const defaultContributorImage: ImageType = {
@@ -54,7 +54,7 @@ export function transformContributorAgent(
       name: asText(agent.data.name),
       pronouns: asText(agent.data.pronouns),
       sameAs: (agent.data.sameAs ?? [])
-        .map(sameAs => {
+        .map((sameAs: SameAsField) => {
           const link = asText(sameAs.link);
           const title = asText(sameAs.title);
           return title && link ? { title, link } : undefined;
@@ -67,7 +67,7 @@ export function transformContributorAgent(
       type: agent.type,
       name: asText(agent.data.name),
       sameAs: (agent.data.sameAs ?? [])
-        .map(sameAs => {
+        .map((sameAs: SameAsField) => {
           const link = asText(sameAs.link);
           const title = asText(sameAs.title);
           return title && link ? { title, link } : undefined;

--- a/content/webapp/services/prismic/transformers/contributors.ts
+++ b/content/webapp/services/prismic/transformers/contributors.ts
@@ -41,6 +41,15 @@ function transformCommonFields(
     id: agent.id,
     description: asRichText(agent.data.description),
     image: transformImage(agent.data.image) || defaultContributorImage,
+    type: agent.type,
+    name: asText(agent.data.name),
+    sameAs: (agent.data.sameAs ?? [])
+      .map((sameAs: SameAsField) => {
+        const link = asText(sameAs.link);
+        const title = asText(sameAs.title);
+        return title && link ? { title, link } : undefined;
+      })
+      .filter(isNotUndefined),
   };
 }
 
@@ -50,29 +59,11 @@ export function transformContributorAgent(
   if (isFilledLinkToPersonField(agent)) {
     return {
       ...transformCommonFields(agent),
-      type: agent.type,
-      name: asText(agent.data.name),
       pronouns: asText(agent.data.pronouns),
-      sameAs: (agent.data.sameAs ?? [])
-        .map((sameAs: SameAsField) => {
-          const link = asText(sameAs.link);
-          const title = asText(sameAs.title);
-          return title && link ? { title, link } : undefined;
-        })
-        .filter(isNotUndefined),
     };
   } else if (isFilledLinkToOrganisationField(agent)) {
     return {
       ...transformCommonFields(agent),
-      type: agent.type,
-      name: asText(agent.data.name),
-      sameAs: (agent.data.sameAs ?? [])
-        .map((sameAs: SameAsField) => {
-          const link = asText(sameAs.link);
-          const title = asText(sameAs.title);
-          return title && link ? { title, link } : undefined;
-        })
-        .filter(isNotUndefined),
     };
   } else {
     return undefined;

--- a/content/webapp/services/prismic/types/contributors.ts
+++ b/content/webapp/services/prismic/types/contributors.ts
@@ -20,6 +20,11 @@ export type EditorialContributorRole = PrismicDocument<
   typeof editorialContributorRoleType
 >;
 
+export type SameAsField = {
+  link: KeyTextField;
+  title: RichTextField;
+};
+
 const personType = 'people';
 export type Person = PrismicDocument<
   {
@@ -27,10 +32,7 @@ export type Person = PrismicDocument<
     description: RichTextField;
     pronouns: KeyTextField;
     image: Image;
-    sameAs: GroupField<{
-      link: KeyTextField;
-      title: RichTextField;
-    }>;
+    sameAs: GroupField<SameAsField>;
   },
   typeof personType
 >;
@@ -41,10 +43,7 @@ export type Organisation = PrismicDocument<
     name: RichTextField;
     description: RichTextField;
     image: Image;
-    sameAs: GroupField<{
-      link: KeyTextField;
-      title: KeyTextField;
-    }>;
+    sameAs: GroupField<SameAsField>;
   },
   typeof organisationType
 >;

--- a/content/webapp/types/contributors.ts
+++ b/content/webapp/types/contributors.ts
@@ -34,7 +34,6 @@ type ContributorRole = {
 export type Contributor = {
   contributor: Person | Organisation;
   role?: ContributorRole;
-  description?: prismicT.RichTextField;
 };
 
 export type ContributorBasic = {


### PR DESCRIPTION
I was getting confused about why there are seemingly two sources of description:

* Contributor.description, and
* Contributor.contributor.description

but if you look at where this type is transformed from the Prismic model, you see they always contain the same value!  This implies two different bits of data when really they're the same, so I've removed one copy to avoid more confusion.

---

I also spotted that the ContentPage component has a `contributorTitle` property which is never used, so I removed that.

And while tugging on this thread, I cleaned up various other small bits along the way.