### PR TITLE
Add the "Audio described" icon to the audio exhibition guides

### DIFF
--- a/content/webapp/components/ExhibitionGuideLinks/ExhibitionGuideLinks.tsx
+++ b/content/webapp/components/ExhibitionGuideLinks/ExhibitionGuideLinks.tsx
@@ -48,6 +48,7 @@ const ExhibitionGuideLinks: FunctionComponent<Props> = ({
           title="Listen to audio"
           text="Find out more about the exhibition with short audio tracks."
           backgroundColor="accent.lightSalmon"
+          icon={audioDescribed}
           onClick={() => {
             cookieHandler(
               cookies.exhibitionGuideType,


### PR DESCRIPTION
Previously we were only adding the AD symbol on "Listen to audio w/wayfinding", but we want it on "Listen to audio" as well.

See screenshots in https://wellcome.slack.com/archives/C8X9YKM5X/p1675419084995139