### PR TITLE
Fix the API toolbar links

### DIFF
--- a/catalogue/webapp/components/Work/Work.tsx
+++ b/catalogue/webapp/components/Work/Work.tsx
@@ -3,7 +3,7 @@ import {
   Location as LocationType,
   DigitalLocation,
 } from '@weco/common/model/catalogue';
-import { useContext, FunctionComponent, ReactElement } from 'react';
+import { useContext, FunctionComponent } from 'react';
 import { grid } from '@weco/common/utils/classnames';
 import {
   getDigitalLocationOfType,
@@ -115,10 +115,7 @@ type Props = {
   apiUrl: string;
 };
 
-const Work: FunctionComponent<Props> = ({
-  work,
-  apiUrl,
-}: Props): ReactElement<Props> => {
+const Work: FunctionComponent<Props> = ({ work, apiUrl }) => {
   const { link: searchLink } = useContext(SearchContext);
   const { worksTabbedNav } = useToggles();
   const transformedIIIFManifest = useTransformedManifest(work);

--- a/catalogue/webapp/pages/concepts/[conceptId].tsx
+++ b/catalogue/webapp/pages/concepts/[conceptId].tsx
@@ -36,7 +36,7 @@ import {
 import Space from '@weco/common/views/components/styled/Space';
 import TabNav from '@weco/common/views/components/TabNav/TabNav';
 import { font } from '@weco/common/utils/classnames';
-import { ApiToolbarLink } from '@weco/common/views/components/ApiToolbar/ApiToolbar';
+import { ApiToolbarLink } from '@weco/common/views/components/ApiToolbar';
 import { Pageview } from '@weco/common/services/conversion/track';
 import theme from '@weco/common/views/themes/default';
 

--- a/catalogue/webapp/pages/works/[workId]/images.tsx
+++ b/catalogue/webapp/pages/works/[workId]/images.tsx
@@ -16,6 +16,22 @@ import { unavailableImageMessage } from '@weco/common/data/microcopy';
 import { Pageview } from '@weco/common/services/conversion/track';
 import { looksLikeCanonicalId } from '@weco/catalogue/services/catalogue';
 import { createDefaultTransformedManifest } from '@weco/catalogue/types/manifest';
+import {
+  ApiToolbarLink,
+  setTzitzitParams,
+} from '@weco/common/views/components/ApiToolbar';
+
+function createTzitzitImageLink(
+  work: Work,
+  image: Image
+): ApiToolbarLink | undefined {
+  return setTzitzitParams({
+    title: image.source.title,
+    sourceLink: `/works/${work.id}/images`,
+    licence: image.locations[0].license,
+    contributors: image.source.contributors,
+  });
+}
 
 type Props = {
   image: Image;
@@ -77,7 +93,7 @@ const ImagePage: FunctionComponent<Props> = ({
       openGraphType="website"
       jsonLd={{ '@type': 'WebPage' }}
       siteSection="collections"
-      apiToolbarLinks={[apiLink]}
+      apiToolbarLinks={[apiLink, createTzitzitImageLink(sourceWork, image)]}
       hideNewsletterPromo={true}
       hideFooter={true}
       hideTopContent={true}

--- a/catalogue/webapp/pages/works/[workId]/index.tsx
+++ b/catalogue/webapp/pages/works/[workId]/index.tsx
@@ -9,14 +9,15 @@ import { getWork } from '@weco/catalogue/services/catalogue/works';
 import { looksLikeCanonicalId } from '@weco/catalogue/services/catalogue';
 
 type Props = {
-  workResponse: WorkType;
+  work: WorkType;
+  apiUrl: string;
   pageview: Pageview;
 };
 
-export const WorkPage: NextPage<Props> = ({ workResponse }) => {
+export const WorkPage: NextPage<Props> = ({ work, apiUrl }) => {
   // TODO: remove the <Work> component and move the JSX in here.
   // It was abstracted as we did error handling in the page, and it made it a little clearer.
-  return <Work work={workResponse} />;
+  return <Work work={work} apiUrl={apiUrl} />;
 };
 
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
@@ -53,9 +54,12 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       );
     }
 
+    const { url, ...work } = workResponse;
+
     return {
       props: removeUndefinedProps({
-        workResponse,
+        work,
+        apiUrl: url,
         serverData,
         pageview: {
           name: 'work',

--- a/catalogue/webapp/pages/works/[workId]/items.tsx
+++ b/catalogue/webapp/pages/works/[workId]/items.tsx
@@ -44,6 +44,10 @@ import WorkHeader from '@weco/catalogue/components/WorkHeader/WorkHeader';
 import WorkTabbedNav from '@weco/catalogue/components/WorkTabbedNav/WorkTabbedNav';
 import { Container, Grid } from '@weco/catalogue/components/Work/Work';
 import { useToggles } from '@weco/common/server-data/Context';
+import {
+  ApiToolbarLink,
+  setTzitzitParams,
+} from '@weco/common/views/components/ApiToolbar';
 
 const IframeAuthMessage = styled.iframe`
   display: none;
@@ -65,6 +69,25 @@ function reloadAuthIframe(document, id: string) {
   // assigning the iframe src to itself reloads the iframe and refires the window.message event
   // eslint-disable-next-line no-self-assign
   if (authMessageIframe) authMessageIframe.src = authMessageIframe.src;
+}
+
+function createTzitzitWorkLink(work: Work): ApiToolbarLink | undefined {
+  // Look at digital item locations only
+  const digitalLocation = work.items
+    ?.map(item =>
+      item.locations.find(location => location.type === 'DigitalLocation')
+    )
+    .find(i => i);
+
+  return setTzitzitParams({
+    title: work.title,
+    sourceLink: `/works/${work.id}/items`,
+    licence:
+      digitalLocation?.type === 'DigitalLocation'
+        ? digitalLocation.license
+        : undefined,
+    contributors: work.contributors,
+  });
 }
 
 type Props = {
@@ -190,6 +213,7 @@ const ItemPage: NextPage<Props> = ({
       openGraphType="website"
       jsonLd={{ '@type': 'WebPage' }}
       siteSection="collections"
+      apiToolbarLinks={[createTzitzitWorkLink(work)]}
       hideNewsletterPromo={true}
       hideFooter={true}
       hideTopContent={true}

--- a/catalogue/webapp/pages/works/[workId]/items.tsx
+++ b/catalogue/webapp/pages/works/[workId]/items.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useState } from 'react';
 import { GetServerSideProps, NextPage } from 'next';
-import { DigitalLocation, Work } from '@weco/common/model/catalogue';
+import {
+  DigitalLocation,
+  isDigitalLocation,
+  Work,
+} from '@weco/common/model/catalogue';
 import { Audio, Video } from '@weco/catalogue/services/iiif/types/manifest/v3';
 import { getDigitalLocationOfType } from '@weco/catalogue/utils/works';
 import { removeIdiomaticTextTags } from '@weco/common/utils/string';
@@ -73,19 +77,14 @@ function reloadAuthIframe(document, id: string) {
 
 function createTzitzitWorkLink(work: Work): ApiToolbarLink | undefined {
   // Look at digital item locations only
-  const digitalLocation = work.items
-    ?.map(item =>
-      item.locations.find(location => location.type === 'DigitalLocation')
-    )
+  const digitalLocation: DigitalLocation | undefined = work.items
+    ?.map(item => item.locations.find(isDigitalLocation))
     .find(i => i);
 
   return setTzitzitParams({
     title: work.title,
     sourceLink: `/works/${work.id}/items`,
-    licence:
-      digitalLocation?.type === 'DigitalLocation'
-        ? digitalLocation.license
-        : undefined,
+    licence: digitalLocation?.license,
     contributors: work.contributors,
   });
 }

--- a/catalogue/webapp/services/catalogue/works.ts
+++ b/catalogue/webapp/services/catalogue/works.ts
@@ -79,7 +79,7 @@ function toIsoDateString(
   if (s) {
     try {
       const d = new Date(s);
-      let year = d.getUTCFullYear().toString().padStart(4, '0');
+      const year = d.getUTCFullYear().toString().padStart(4, '0');
 
       return range === 'from' ? `${year}-01-01` : `${year}-12-31`;
     } catch (e) {
@@ -126,7 +126,10 @@ export async function getWorks(
   });
 }
 
-type WorkResponse = Work | CatalogueApiError | CatalogueApiRedirect;
+type WorkResponse =
+  | (Work & { url: string })
+  | CatalogueApiError
+  | CatalogueApiRedirect;
 
 export async function getWork({
   id,
@@ -171,7 +174,8 @@ export async function getWork({
   }
 
   try {
-    return await res.json();
+    const work = await res.json();
+    return { ...work, url };
   } catch (e) {
     return catalogueApiError();
   }

--- a/common/model/catalogue.ts
+++ b/common/model/catalogue.ts
@@ -145,6 +145,12 @@ export type DigitalLocation = {
   type: 'DigitalLocation';
 };
 
+export function isDigitalLocation(
+  location: Location
+): location is DigitalLocation {
+  return location.type === 'DigitalLocation';
+}
+
 export type PhysicalLocation = {
   locationType: LocationType;
   label: string;

--- a/common/views/components/ApiToolbar/index.tsx
+++ b/common/views/components/ApiToolbar/index.tsx
@@ -5,13 +5,7 @@ import { ParsedUrlQuery } from 'querystring';
 import cookies from '@weco/common/data/cookies';
 import { getCookie, setCookie } from 'cookies-next';
 import useIsomorphicLayoutEffect from '../../../hooks/useIsomorphicLayoutEffect';
-import {
-  Work,
-  Location,
-  Image,
-  Contributor,
-  License,
-} from '../../../model/catalogue';
+import { Work, Location, Contributor, License } from '../../../model/catalogue';
 
 export type ApiToolbarLink = {
   id: string;
@@ -88,20 +82,6 @@ export function setTzitzitParams({
     label: 'tzitzit',
     link: `https://s3-eu-west-1.amazonaws.com/tzitzit.wellcomecollection.org/index.html?${params.toString()}`,
   };
-}
-
-async function createTzitzitImageLink(
-  imageId: string
-): Promise<ApiToolbarLink | undefined> {
-  const apiUrl = `https://api.wellcomecollection.org/catalogue/v2/images/${imageId}?include=source.contributors`;
-  const image: Image = await fetch(apiUrl).then(res => res.json());
-
-  return setTzitzitParams({
-    title: image.source.title,
-    sourceLink: window.location.toString(),
-    licence: image.locations[0].license,
-    contributors: image.source.contributors,
-  });
 }
 
 export function createPrismicLink(prismicId: string): ApiToolbarLink {
@@ -185,15 +165,6 @@ function getRouteProps(path: string) {
         ].filter(Boolean) as ApiToolbarLink[];
 
         return links;
-      };
-
-    case '/image':
-      return async (query: ParsedUrlQuery): Promise<ApiToolbarLink[]> => {
-        const { id } = query;
-
-        const tzitzitLink = await createTzitzitImageLink(id as string);
-
-        return tzitzitLink ? [tzitzitLink] : [];
       };
     default:
       return async (query: ParsedUrlQuery): Promise<ApiToolbarLink[]> => {

--- a/common/views/components/ApiToolbar/index.tsx
+++ b/common/views/components/ApiToolbar/index.tsx
@@ -12,7 +12,6 @@ import {
   Contributor,
   License,
 } from '../../../model/catalogue';
-import { looksLikePrismicId } from '../../../services/prismic';
 
 export type ApiToolbarLink = {
   id: string;
@@ -129,6 +128,14 @@ async function createTzitzitWorkLink(
   });
 }
 
+export function createPrismicLink(prismicId: string): ApiToolbarLink {
+  return {
+    id: 'prismic',
+    label: 'Edit in Prismic',
+    link: `https://wellcomecollection.prismic.io/documents~b=working&c=published&l=en-gb/${prismicId}/`,
+  };
+}
+
 function getAnchorLinkUrls() {
   // This function currently only extracts the ids from h2, h3, and h4 tags
   const getAllHeadingIds = [...document.querySelectorAll('h2, h3, h4')].map(
@@ -223,26 +230,8 @@ function getRouteProps(path: string) {
       };
     default:
       return async (query: ParsedUrlQuery): Promise<ApiToolbarLink[]> => {
-        const { id } = query;
-
-        // On some Prismic pages, the ID will be in the query data, e.g. /events/YeViLhAAAJMQM7IY
-        // will have the query {"id": "YeViLhAAAJMQM7IY"}
-        //
-        // If it looks like a Prismic ID, we can guess how to get to the page in Prismic.
-        // This isn't perfect -- there may be cases where the link doesn't work (e.g. if it's
-        // not actually a Prismic ID, or the page is unpublished) -- but hopefully something
-        // that works 95% of the time is still useful.
-        if (looksLikePrismicId(id)) {
-          const prismicLink = {
-            id: 'prismic',
-            label: 'Prismic',
-            link: `https://wellcomecollection.prismic.io/documents~b=working&c=published&l=en-gb/${id}/`,
-          };
-
-          return [prismicLink];
-        } else {
-          return [];
-        }
+        console.debug(`query = ${query}`);
+        return [];
       };
   }
 }

--- a/common/views/components/ApiToolbar/index.tsx
+++ b/common/views/components/ApiToolbar/index.tsx
@@ -59,7 +59,7 @@ const LinkList = styled.ul.attrs({
  *
  */
 
-function setTzitzitParams({
+export function setTzitzitParams({
   title,
   sourceLink,
   licence,
@@ -101,30 +101,6 @@ async function createTzitzitImageLink(
     sourceLink: window.location.toString(),
     licence: image.locations[0].license,
     contributors: image.source.contributors,
-  });
-}
-
-async function createTzitzitWorkLink(
-  workId: string
-): Promise<ApiToolbarLink | undefined> {
-  const apiUrl = `https://api.wellcomecollection.org/catalogue/v2/works/${workId}?include=items,contributors`;
-  const work: Work = await fetch(apiUrl).then(res => res.json());
-
-  // Look at digital item locations only
-  const digitalLocation = work.items
-    ?.map(item =>
-      item.locations.find(location => location.type === 'DigitalLocation')
-    )
-    .find(i => i);
-
-  return setTzitzitParams({
-    title: work.title,
-    sourceLink: window.location.toString(),
-    licence:
-      digitalLocation?.type === 'DigitalLocation'
-        ? digitalLocation.license
-        : undefined,
-    contributors: work.contributors,
   });
 }
 
@@ -216,15 +192,6 @@ function getRouteProps(path: string) {
         const { id } = query;
 
         const tzitzitLink = await createTzitzitImageLink(id as string);
-
-        return tzitzitLink ? [tzitzitLink] : [];
-      };
-
-    case '/item':
-      return async (query: ParsedUrlQuery): Promise<ApiToolbarLink[]> => {
-        const { workId } = query;
-
-        const tzitzitLink = await createTzitzitWorkLink(workId as string);
 
         return tzitzitLink ? [tzitzitLink] : [];
       };

--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -18,7 +18,7 @@ import { wellcomeCollectionGallery } from '../../../data/organization';
 import GlobalInfoBarContext, {
   GlobalInfoBarContextProvider,
 } from '../GlobalInfoBarContext/GlobalInfoBarContext';
-import ApiToolbar, { ApiToolbarLink } from '../ApiToolbar/ApiToolbar';
+import ApiToolbar, { ApiToolbarLink } from '../ApiToolbar';
 import { usePrismicData, useToggles } from '../../../server-data/Context';
 import { defaultPageTitle } from '@weco/common/data/microcopy';
 import { getCrop, ImageType } from '@weco/common/model/image';

--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -277,7 +277,7 @@ const PageLayoutComponent: FunctionComponent<Props> = ({
 
       <div id="root">
         {apiToolbar && (
-          <ApiToolbar extraLinks={apiToolbarLinks.filter(isNotUndefined)} />
+          <ApiToolbar links={apiToolbarLinks.filter(isNotUndefined)} />
         )}
         <CookieNotice source={url.pathname || ''} />
 

--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -24,6 +24,7 @@ import { defaultPageTitle } from '@weco/common/data/microcopy';
 import { getCrop, ImageType } from '@weco/common/model/image';
 import { convertImageUri } from '@weco/common/utils/convert-image-uri';
 import cookies from '@weco/common/data/cookies';
+import { isNotUndefined } from '@weco/common/utils/array';
 
 export type SiteSection =
   | 'collections'
@@ -58,7 +59,7 @@ export type Props = {
   hideFooter?: boolean;
   excludeRoleMain?: boolean;
   headerProps?: HeaderProps;
-  apiToolbarLinks?: ApiToolbarLink[];
+  apiToolbarLinks?: (ApiToolbarLink | undefined)[];
   skipToContentLinks?: SkipToContentLink[];
 };
 
@@ -275,7 +276,9 @@ const PageLayoutComponent: FunctionComponent<Props> = ({
       </Head>
 
       <div id="root">
-        {apiToolbar && <ApiToolbar extraLinks={apiToolbarLinks} />}
+        {apiToolbar && (
+          <ApiToolbar extraLinks={apiToolbarLinks.filter(isNotUndefined)} />
+        )}
         <CookieNotice source={url.pathname || ''} />
 
         {skipToContentLinks.map(({ anchorId, label }) => (

--- a/content/webapp/components/Exhibition/Exhibition.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.tsx
@@ -40,6 +40,7 @@ import {
 import { EventBasic } from '../../types/events';
 import * as prismicT from '@prismicio/types';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
+import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 
 type ExhibitionItem = LabelField & {
   icon?: IconSvg;
@@ -289,6 +290,7 @@ const Exhibition: FunctionComponent<Props> = ({
       openGraphType="website"
       siteSection="whats-on"
       image={exhibition.image}
+      apiToolbarLinks={[createPrismicLink(exhibition.id)]}
     >
       <ContentPage
         id={exhibition.id}

--- a/content/webapp/components/Installation/Installation.tsx
+++ b/content/webapp/components/Installation/Installation.tsx
@@ -15,6 +15,7 @@ import ContentPage from '../ContentPage/ContentPage';
 import { isNotUndefined } from '@weco/common/utils/array';
 import { fetchExhibitExhibition } from '../../services/prismic/fetch/exhibitions';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
+import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 
 type Props = {
   installation: InstallationType;
@@ -94,6 +95,7 @@ const Installation: FunctionComponent<Props> = ({
       openGraphType="website"
       siteSection="whats-on"
       image={installation.image}
+      apiToolbarLinks={[createPrismicLink(installation.id)]}
     >
       <ContentPage
         id={installation.id}

--- a/content/webapp/pages/articles/[articleId].tsx
+++ b/content/webapp/pages/articles/[articleId].tsx
@@ -40,6 +40,7 @@ import { transformArticle } from '@weco/content/services/prismic/transformers/ar
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 import styled from 'styled-components';
 import { Pageview } from '@weco/common/services/conversion/track';
+import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 
 const ContentTypeWrapper = styled.div`
   display: flex;
@@ -319,6 +320,7 @@ const ArticlePage: FunctionComponent<Props> = ({ article, jsonLd }) => {
       openGraphType="article"
       siteSection="stories"
       image={article.image}
+      apiToolbarLinks={[createPrismicLink(article.id)]}
     >
       <ContentPage
         id={article.id}

--- a/content/webapp/pages/books/[bookId].tsx
+++ b/content/webapp/pages/books/[bookId].tsx
@@ -21,6 +21,7 @@ import { Book } from '@weco/content/types/books';
 import { looksLikePrismicId } from '@weco/common/services/prismic';
 import Layout8 from '@weco/common/views/components/Layout8/Layout8';
 import { Pageview } from '@weco/common/services/conversion/track';
+import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 
 const MetadataWrapper = styled.div`
   border-top: 1px solid ${props => props.theme.color('neutral.300')};
@@ -161,6 +162,7 @@ const BookPage: FunctionComponent<Props> = props => {
       openGraphType="book"
       siteSection="stories"
       image={book.image}
+      apiToolbarLinks={[createPrismicLink(book.id)]}
     >
       <ContentPage
         id={book.id}

--- a/content/webapp/pages/event-series/[eventSeriesId].tsx
+++ b/content/webapp/pages/event-series/[eventSeriesId].tsx
@@ -28,6 +28,7 @@ import {
 } from '@weco/content/services/prismic/transformers/events';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 import { getUpcomingEvents } from '@weco/content/utils/event-series';
+import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 
 type Props = {
   series: EventSeries;
@@ -146,6 +147,7 @@ const EventSeriesPage: FunctionComponent<Props> = ({
       openGraphType="website"
       siteSection="whats-on"
       image={series.image}
+      apiToolbarLinks={[createPrismicLink(series.id)]}
     >
       <ContentPage
         id={series.id}

--- a/content/webapp/pages/events/[eventId].tsx
+++ b/content/webapp/pages/events/[eventId].tsx
@@ -64,6 +64,7 @@ import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 import { PaletteColor } from '@weco/common/views/themes/config';
 import { a11y } from '@weco/common/data/microcopy';
 import { Pageview } from '@weco/common/services/conversion/track';
+import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 
 const TimeWrapper = styled(Space).attrs({
   v: {
@@ -306,6 +307,7 @@ const EventPage: NextPage<Props> = ({ event, jsonLd }) => {
       openGraphType="website"
       siteSection="whats-on"
       image={event.image}
+      apiToolbarLinks={[createPrismicLink(event.id)]}
     >
       <ContentPage
         id={event.id}

--- a/content/webapp/pages/guides/exhibitions/[id]/[type].tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/[type].tsx
@@ -32,6 +32,7 @@ import cookies from '@weco/common/data/cookies';
 import ExhibitionGuideStops from '@weco/content/components/ExhibitionGuideStops/ExhibitionGuideStops';
 import { getTypeColor } from '@weco/content/components/ExhibitionCaptions/ExhibitionCaptions';
 import useHotjar from '@weco/common/hooks/useHotjar';
+import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 
 const ButtonWrapper = styled(Space).attrs({
   v: { size: 's', properties: ['margin-bottom'] },
@@ -181,6 +182,7 @@ const ExhibitionGuidePage: FC<Props> = props => {
       }}
       hideNewsletterPromo={true}
       hideFooter={true}
+      apiToolbarLinks={[createPrismicLink(exhibitionGuide.id)]}
       skipToContentLinks={skipToContentLinks}
     >
       <Header backgroundColor={typeColor}>

--- a/content/webapp/pages/guides/exhibitions/[id]/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/index.tsx
@@ -29,6 +29,7 @@ import { AppErrorProps } from '@weco/common/services/app';
 import { exhibitionGuidesLinks } from '@weco/common/views/components/Header/Header';
 import OtherExhibitionGuides from 'components/OtherExhibitionGuides/OtherExhibitionGuides';
 import ExhibitionGuideLinks from 'components/ExhibitionGuideLinks/ExhibitionGuideLinks';
+import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 
 type Props = {
   exhibitionGuide: ExhibitionGuide;
@@ -112,6 +113,7 @@ const ExhibitionGuidePage: FC<Props> = ({
         customNavLinks: exhibitionGuidesLinks,
         showLibraryLogin: false,
       }}
+      apiToolbarLinks={[createPrismicLink(exhibitionGuide.id)]}
       hideNewsletterPromo={true}
       hideFooter={true}
     >

--- a/content/webapp/pages/pages/[pageId].tsx
+++ b/content/webapp/pages/pages/[pageId].tsx
@@ -45,6 +45,7 @@ import { isPicture, isVideoEmbed, BodySlice } from '@weco/content/types/body';
 import { isNotUndefined } from '@weco/common/utils/array';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 import { looksLikePrismicId } from '@weco/common/services/prismic';
+import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 
 export type Props = {
   page: PageType;
@@ -355,6 +356,7 @@ export const Page: FunctionComponent<Props> = ({
       openGraphType="website"
       siteSection={page?.siteSection as SiteSection}
       image={page.image}
+      apiToolbarLinks={[createPrismicLink(page.id)]}
     >
       <ContentPage
         id={page.id}

--- a/content/webapp/pages/seasons/[seasonId].tsx
+++ b/content/webapp/pages/seasons/[seasonId].tsx
@@ -47,6 +47,7 @@ import { Series } from '@weco/content/types/series';
 import { looksLikePrismicId } from '@weco/common/services/prismic';
 import { getCrop } from '@weco/common/model/image';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
+import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 
 type Props = {
   season: Season;
@@ -116,6 +117,7 @@ const SeasonPage = ({
       siteSection="whats-on"
       openGraphType="website"
       image={season.image}
+      apiToolbarLinks={[createPrismicLink(season.id)]}
     >
       <ContentPage
         id={season.id}

--- a/content/webapp/pages/series/[seriesId].tsx
+++ b/content/webapp/pages/series/[seriesId].tsx
@@ -33,6 +33,7 @@ import { transformQuery } from '@weco/content/services/prismic/transformers/pagi
 import Pagination from '@weco/common/views/components/Pagination/Pagination';
 import { seasonsFetchLinks } from '@weco/content/services/prismic/types';
 import { Pageview } from '@weco/common/services/conversion/track';
+import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 
 type Props = {
   series: Series;
@@ -180,6 +181,7 @@ const ArticleSeriesPage: FunctionComponent<Props> = props => {
       siteSection="stories"
       openGraphType="website"
       image={series.image}
+      apiToolbarLinks={[createPrismicLink(series.id)]}
     >
       <ContentPage
         id={series.id}

--- a/content/webapp/pages/stories/index.tsx
+++ b/content/webapp/pages/stories/index.tsx
@@ -41,6 +41,7 @@ import {
 } from '@weco/content/services/prismic/transformers/series';
 import { SeriesBasic } from '@weco/content/types/series';
 import * as prismic from '@prismicio/client';
+import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 
 type Props = {
   articles: ArticleBasic[];
@@ -148,13 +149,7 @@ const StoriesPage: FunctionComponent<Props> = ({
       siteSection="stories"
       image={firstArticle && firstArticle.image}
       rssUrl="https://rss.wellcomecollection.org/stories"
-      apiToolbarLinks={[
-        {
-          id: 'prismic',
-          label: 'Prismic',
-          link: `https://wellcomecollection.prismic.io/documents~b=working&c=published&l=en-gb/${storiesLanding.id}/`,
-        },
-      ]}
+      apiToolbarLinks={[createPrismicLink(storiesLanding.id)]}
     >
       <PageHeader
         breadcrumbs={{ items: [] }}

--- a/content/webapp/pages/whats-on.tsx
+++ b/content/webapp/pages/whats-on.tsx
@@ -77,6 +77,7 @@ import {
   getTryTheseTooPromos,
 } from '@weco/content/services/prismic/transformers/whats-on';
 import { FacilityPromo as FacilityPromoType } from '@weco/content/types/facility-promo';
+import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 
 const segmentedControlItems = [
   {
@@ -413,13 +414,7 @@ const WhatsOnPage: FunctionComponent<Props> = props => {
       openGraphType="website"
       siteSection="whats-on"
       image={firstExhibition && firstExhibition.promo?.image}
-      apiToolbarLinks={[
-        {
-          id: 'prismic',
-          label: 'Prismic',
-          link: `https://wellcomecollection.prismic.io/documents~b=working&c=published&l=en-gb/${prismicPageIds.whatsOn}/`,
-        },
-      ]}
+      apiToolbarLinks={[createPrismicLink(prismicPageIds.whatsOn)]}
     >
       <>
         <Header


### PR DESCRIPTION
The API toolbar links all broke after we switched to absolute routing, because the API toolbar had a bunch of implicit knowledge of how the routes work; now every page gives the API toolbar a list of links to display – this should be less brittle.

Other benefits:

* On the work/image/item pages, we can pass the API response we've already received – the browser doesn't need to make a second request to get that information again
* When we link to the catalogue API URL for works/images, we can use the exact URL that was used to render the page (which doesn't always match what the API toolbar was using)
* The API toolbar should be smaller overall, because e.g. stories aren't getting the API toolbar code for works pages

Closes https://github.com/wellcomecollection/platform/issues/5657