### PR TITLE
Don't fail as badly if there's an unexpected error during search

### DIFF
--- a/catalogue/webapp/pages/search/index.tsx
+++ b/catalogue/webapp/pages/search/index.tsx
@@ -256,7 +256,8 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
         },
       };
     } catch (error) {
-      return appError(context, error.httpStatus, 'Search results error');
+      console.error(error);
+      return appError(context, 500, 'Search results error');
     }
   };
 


### PR DESCRIPTION
Yesterday we were getting errors from this page in both prod and stage, which occur consistently:

https://wellcomecollection.org/search?query=drinks

This appeared to users as a completely broken page, not just our regular 500:

<img width="1032" alt="Screenshot 2023-02-06 at 16 28 20" src="https://user-images.githubusercontent.com/301220/217200978-a1da0b2e-b9ac-4321-84f0-ba10483b1610.png">

The app logs had the following error:

```
RangeError [ERR_HTTP_INVALID_STATUS_CODE]: Invalid status code: undefined
```

which gave me a clue that maybe we were going down an error path which doesn't have an HTTP status code, like here: https://github.com/wellcomecollection/wellcomecollection.org/blob/b2bd4fc575abde6550338254d748a9042a570188/catalogue/webapp/pages/search/index.tsx#L259

This PR adds some logging to that branch, which I deployed to stage so we can work out what's going on. It does fail, with the following error:

> Error: Internal server error: {"response":{"data":null,"errors":[{"message":"Internal server error","path":["allArticless"],"locations":[{"line":1,"column":99}]}],"status":200,"headers":{}},"request":{"query":"\n query getAllStories(\n $queryString: String\n # The below $sortBy type needs to be SortArticlesy, rather than String, or you will get the following error from Prismic GraphQl:\n # ClientError: Variable '$sortBy' of type 'String' used in position expecting type 'SortArticlesy'\n $sortBy: SortArticlesy\n $pageSize: Int\n $cursor: String\n ) {\n allArticless(\n fulltext: $queryString\n sortBy: $sortBy\n first: $pageSize\n after: $cursor\n ) {\n totalCount\n pageInfo {\n hasNextPage\n startCursor\n endCursor\n hasPreviousPage\n }\n edges {\n cursor\n node {\n title\n _meta {\n id\n firstPublicationDate\n }\n format {\n __typename\n }\n format {\n ... on ArticleFormats {\n _meta {\n id\n }\n }\n }\n contributors {\n contributor {\n ... on People {\n name\n }\n }\n }\n body {\n ... on ArticlesBodyStandfirst {\n primary {\n text\n }\n }\n }\n promo {\n ... on ArticlesPromoEditorialimage {\n primary {\n image\n link\n caption\n }\n }\n }\n }\n }\n }\n }\n","variables":{"queryString":"drinks","sortBy":"meta_firstPublicationDate_DESC","pageSize":4}}}

However, the error seems to have resolved itself without us doing anything. 🤷‍♀️ 

I've updated this PR to improve the logging in this area of the code permanently, and avoid failing in quite such a spectacular way. Unfortunately I don't think we can do more unless we can reproduce that Prismic issue.

We could consider refactoring this code into separate `try … catch` blocks for each search type, so you'd still get some work/image results even if stories fails, but that's a bigger change.