### PR TITLE
test suites for the new search pages

### DIFF
--- a/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
+++ b/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
@@ -133,7 +133,7 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
   return (
     <>
       {isFullSupportBrowser && !isSmallGallery && (
-        <PlainList data-test-id="search-results-container" role="list">
+        <PlainList data-test-id="image-search-results-container" role="list">
           <GalleryContainer>
             <PhotoAlbum
               photos={imagesWithDimensions}

--- a/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
+++ b/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
@@ -103,7 +103,7 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
     ({ photo, layout }) => {
       const rgbColor = hexToRgb(photo.averageColor || '');
       return (
-        <li style={{ padding: 12 }}>
+        <li data-test-id="image-search-result" style={{ padding: 12 }}>
           <ImageFrame>
             <ImageCard
               id={photo.id}
@@ -133,7 +133,7 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
   return (
     <>
       {isFullSupportBrowser && !isSmallGallery && (
-        <PlainList role="list">
+        <PlainList data-test-id="search-results-container" role="list">
           <GalleryContainer>
             <PhotoAlbum
               photos={imagesWithDimensions}
@@ -149,7 +149,7 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
       )}
 
       {(!isFullSupportBrowser || isSmallGallery) && (
-        <ImageCardList role="list">
+        <ImageCardList data-test-id="search-results-container" role="list">
           {imagesWithDimensions.map((result: GalleryImageProps) => (
             <li key={result.id} role="listitem">
               <Space

--- a/catalogue/webapp/components/SearchNoResults/SearchNoResults.tsx
+++ b/catalogue/webapp/components/SearchNoResults/SearchNoResults.tsx
@@ -33,7 +33,7 @@ const SearchNoResults: FunctionComponent<Props> = ({
     >
       <div className="grid">
         <div className={grid({ s: 12, m: 10, l: 8, xl: 8 })}>
-          <Copy textColor={textColor}>
+          <Copy data-test-id="search-no-results" textColor={textColor}>
             We couldn&rsquo;t find anything that matched{' '}
             {query ? <QuerySpan>{query}</QuerySpan> : 'your search'}
             {hasFilters ? ' with the filters you have selected.' : '.'} Please

--- a/catalogue/webapp/components/WorksSearchResults/WorksSearchResults.tsx
+++ b/catalogue/webapp/components/WorksSearchResults/WorksSearchResults.tsx
@@ -33,7 +33,7 @@ const SearchResultListItem = styled.li`
 
 const WorksSearchResults: FunctionComponent<Props> = ({ works }: Props) => {
   return (
-    <SearchResultUnorderedList data-test-id="search-results-container">
+    <SearchResultUnorderedList data-test-id="works-search-results-container">
       {works.map((result, i) => (
         <SearchResultListItem data-test-id="work-search-result" key={result.id}>
           <WorksSearchResult work={result} resultPosition={i} />

--- a/catalogue/webapp/components/WorksSearchResults/WorksSearchResults.tsx
+++ b/catalogue/webapp/components/WorksSearchResults/WorksSearchResults.tsx
@@ -33,9 +33,9 @@ const SearchResultListItem = styled.li`
 
 const WorksSearchResults: FunctionComponent<Props> = ({ works }: Props) => {
   return (
-    <SearchResultUnorderedList>
+    <SearchResultUnorderedList data-test-id="search-results-container">
       {works.map((result, i) => (
-        <SearchResultListItem key={result.id}>
+        <SearchResultListItem data-test-id="work-search-result" key={result.id}>
           <WorksSearchResult work={result} resultPosition={i} />
         </SearchResultListItem>
       ))}

--- a/common/views/components/SubNavigation/SubNavigation.tsx
+++ b/common/views/components/SubNavigation/SubNavigation.tsx
@@ -47,11 +47,11 @@ const SubNavigation: FunctionComponent<Props> = ({
 }: Props) => {
   return (
     <Wrapper aria-label={label}>
-      <TabsContainer>
+      <TabsContainer data-test-id="sub-nav-tab-container">
         {items.map(item => {
           const isSelected = currentSection === item.id;
           return (
-            <Tab key={item.id}>
+            <Tab data-test-id={item.id} key={item.id}>
               <Link
                 scroll={false}
                 passHref

--- a/playwright/test/contexts.ts
+++ b/playwright/test/contexts.ts
@@ -177,6 +177,14 @@ const worksSearch = async (
   await gotoWithoutCache(`${baseUrl}/works`, page);
 };
 
+const newWorksSearch = async (
+  context: BrowserContext,
+  page: Page
+): Promise<void> => {
+  await context.addCookies(requiredCookies);
+  await gotoWithoutCache(`${baseUrl}/search/works`, page);
+};
+
 const article = async (
   id: string,
   context: BrowserContext,
@@ -227,6 +235,7 @@ export {
   multiVolumeItem2,
   itemWithAltText,
   worksSearch,
+  newWorksSearch,
   itemWithSearchAndStructures,
   itemWithReferenceNumber,
   workWithPhysicalLocationOnly,

--- a/playwright/test/new-images-search.test.ts
+++ b/playwright/test/new-images-search.test.ts
@@ -1,0 +1,123 @@
+import { Page, test } from '@playwright/test';
+import { gotoWithoutCache, isMobile } from './contexts';
+import {
+  clickActionModalFilterButton,
+  clickActionCloseModalFilterButton,
+  clickActionClickSearchResultItem,
+} from './actions/search';
+
+import { clickActionClickViewExpandedImage } from './actions/images';
+
+import { elementIsVisible, fillInputAction } from './actions/common';
+import {
+  expectItemsIsVisible,
+  expectItemIsVisible,
+  expectUrlToMatch,
+} from './asserts/common';
+import {
+  mobileModalImageSearch,
+  modalexpandedImageViewMoreButton,
+} from './selectors/images';
+
+import { regexImageGalleryUrl } from './helpers/regex';
+import safeWaitForNavigation from './helpers/safeWaitForNavigation';
+import { baseUrl } from './helpers/urls';
+
+const imagesUrl = `${baseUrl}/search/images`;
+const searchBarInput = `#search-searchbar`;
+const colourSelectorFilterDropDown = `button[aria-controls="images.color"]`;
+const colourSelector = `button[data-test-id="swatch-green"]`;
+const searchResultsContainer = 'ul[data-test-id="search-results-container"]';
+const imagesResultsListItem = `${searchResultsContainer} li[data-test-id="image-search-result"]`;
+
+const fillActionSearchInput = async (
+  value: string,
+  page: Page
+): Promise<void> => {
+  const selector = `${searchBarInput}`;
+  await fillInputAction(selector, value, page);
+};
+const pressActionEnterSearchInput = async (page: Page): Promise<void> => {
+  const selector = `${searchBarInput}`;
+  await page.press(selector, 'Enter');
+};
+const clickActionColourDropDown = async (page: Page): Promise<void> => {
+  await page.click(colourSelectorFilterDropDown);
+};
+
+const selectColourInPicker = async (page: Page): Promise<void> => {
+  await Promise.all([safeWaitForNavigation(page), page.click(colourSelector)]);
+};
+
+async function gotoSearchResultPage(
+  { url, query }: { url: string; query: string },
+  page: Page
+): Promise<void> {
+  await gotoWithoutCache(url, page);
+  await fillActionSearchInput(query, page);
+  await Promise.all([
+    safeWaitForNavigation(page),
+    pressActionEnterSearchInput(page),
+  ]);
+}
+
+test.describe('Image search', () => {
+  test('Search by term, filter by colour, check results, view image details, view expanded image', async ({
+    page,
+  }) => {
+    const query = 'art of science';
+    await gotoSearchResultPage({ url: imagesUrl, query }, page);
+
+    if (isMobile(page)) {
+      await clickActionModalFilterButton(page);
+      await elementIsVisible(mobileModalImageSearch, page);
+      await selectColourInPicker(page);
+      await clickActionCloseModalFilterButton(page);
+    } else {
+      await clickActionColourDropDown(page);
+      await selectColourInPicker(page);
+      await clickActionColourDropDown(page);
+    }
+    await expectItemIsVisible(searchResultsContainer, page);
+    await expectItemsIsVisible(imagesResultsListItem, 1, page);
+    await clickActionClickSearchResultItem(1, page);
+    await expectItemIsVisible(modalexpandedImageViewMoreButton, page);
+
+    // Check we show visually similar images.  This could theoretically fail
+    // if the first result doesn't have any similar images, but if it fails
+    // it's much more likely we've broken something on the page.
+    await expectItemIsVisible('h3 >> text="Visually similar images"', page);
+
+    await Promise.all([
+      safeWaitForNavigation(page),
+      clickActionClickViewExpandedImage(page),
+    ]);
+    expectUrlToMatch(regexImageGalleryUrl, page);
+  });
+
+  test.describe('the expanded image modal', () => {
+    test('images without contributors still show a title', async ({ page }) => {
+      await gotoSearchResultPage({ url: imagesUrl, query: 'm2u74c63' }, page);
+
+      await clickActionClickSearchResultItem(1, page);
+      await expectItemIsVisible(
+        'h2 >> text="Fish. Watercolour drawing."',
+        page
+      );
+    });
+
+    test('images with contributors show both title and contributor', async ({
+      page,
+    }) => {
+      await gotoSearchResultPage({ url: imagesUrl, query: 'fcmwqd5u' }, page);
+
+      await clickActionClickSearchResultItem(1, page);
+      await expectItemIsVisible('h2 >> text="Dr. Darwin."', page);
+
+      await expectItemIsVisible(
+        'span >> text="Fortey, W. S. (William Samuel)"',
+        page
+      );
+    });
+  });
+});

--- a/playwright/test/new-images-search.test.ts
+++ b/playwright/test/new-images-search.test.ts
@@ -27,8 +27,9 @@ const imagesUrl = `${baseUrl}/search/images`;
 const searchBarInput = `#search-searchbar`;
 const colourSelectorFilterDropDown = `button[aria-controls="images.color"]`;
 const colourSelector = `button[data-test-id="swatch-green"]`;
-const searchResultsContainer = 'ul[data-test-id="search-results-container"]';
-const imagesResultsListItem = `${searchResultsContainer} li[data-test-id="image-search-result"]`;
+const imageSearchResultsContainer =
+  'ul[data-test-id="image-search-results-container"]';
+const imagesResultsListItem = `${imageSearchResultsContainer} li[data-test-id="image-search-result"]`;
 
 const fillActionSearchInput = async (
   value: string,
@@ -78,7 +79,7 @@ test.describe('Image search', () => {
       await selectColourInPicker(page);
       await clickActionColourDropDown(page);
     }
-    await expectItemIsVisible(searchResultsContainer, page);
+    await expectItemIsVisible(imageSearchResultsContainer, page);
     await expectItemsIsVisible(imagesResultsListItem, 1, page);
     await clickActionClickSearchResultItem(1, page);
     await expectItemIsVisible(modalexpandedImageViewMoreButton, page);

--- a/playwright/test/new-works-search.test.ts
+++ b/playwright/test/new-works-search.test.ts
@@ -1,0 +1,234 @@
+import { test, expect } from '@playwright/test';
+import { isMobile, newWorksSearch } from './contexts';
+import { URLSearchParams } from 'url';
+import { Page } from 'playwright';
+import safeWaitForNavigation from './helpers/safeWaitForNavigation';
+
+export const worksSearchForm = '#search-searchbar';
+export const searchFor = async (query: string, page: Page): Promise<void> => {
+  console.info('searchFor', query);
+  await page.fill(worksSearchForm, query);
+  await Promise.all([
+    page.press(worksSearchForm, 'Enter'),
+    safeWaitForNavigation(page),
+  ]);
+};
+
+const expectSearchParam = (
+  expectedKey: string,
+  expectedVal: string,
+  page: Page
+) => {
+  console.info('expectSearchParam', { expectedKey, expectedVal });
+  const params = new URLSearchParams(page.url());
+
+  const foundMatchingParam = Array.from(params).find(
+    ([key, val]) => key === expectedKey && val === expectedVal
+  );
+
+  if (!foundMatchingParam) {
+    console.log(page.url());
+  }
+
+  expect(foundMatchingParam).toBeTruthy();
+};
+
+const openDropdown = async (label: string, page: Page) => {
+  console.info('openDropdown', label);
+  if (isMobile(page)) {
+  } else {
+    await page.click(`button :text("${label}")`);
+  }
+};
+
+const selectCheckbox = async (label: string, page: Page) => {
+  if (isMobile(page)) {
+    // TODO: Make this a user centric selector
+    // for some reason `"Filters"` isn't working.
+    await page.click(`[aria-controls="mobile-filters-modal"]`);
+  }
+
+  await Promise.all([
+    safeWaitForNavigation(page),
+    page.click(`label :text("${label}")`),
+  ]);
+
+  if (isMobile(page)) {
+    await page.click(`"Show results"`);
+  }
+};
+
+const navigateToNextPage = async (page: Page) => {
+  // data-test-id is only set on Pagination components that aren't hidden on mobile
+  // in `common/views/components/Pagination/Pagination.tsx`
+  await Promise.all([
+    safeWaitForNavigation(page),
+    page.click('[data-test-id="pagination"] button'),
+  ]);
+};
+
+const navigateToResult = async (n = 1, page: Page) => {
+  const result = `main ul li:nth-of-type(${n}) a`;
+  const searchResultTitle = await page.textContent(`${result} h3`);
+
+  // For reasons I don't really understand, the safeWaitForNavigation will timeout…
+  // but only in the mobile tests.
+  //
+  // Since that helper is only a test convenience and isn't testing the behaviour of
+  // the site, I haven't investigated further -- this seems to make the tests happy.
+  if (isMobile(page)) {
+    await page.click(result);
+  } else {
+    await Promise.all([safeWaitForNavigation(page), page.click(result)]);
+  }
+
+  const title = await page.textContent('h1');
+  expect(title).toBe(searchResultTitle);
+};
+
+test.describe.configure({ mode: 'parallel' });
+
+test.describe('Scenario 1: The person is looking for an archive', () => {
+  test('the work should be browsable to from the search results', async ({
+    page,
+    context,
+  }) => {
+    await newWorksSearch(context, page);
+    await searchFor('Persian', page);
+    await openDropdown('Formats', page);
+    await selectCheckbox('Archives and manuscripts', page);
+    await navigateToNextPage(page);
+
+    expectSearchParam('workType', 'h', page);
+
+    await navigateToResult(3, page);
+  });
+});
+
+test.describe(
+  'Scenario 2: The person is searching for a work on open shelves',
+  () => {
+    test('the work should be browsable to from the search results', async ({
+      page,
+      context,
+    }) => {
+      await newWorksSearch(context, page);
+      await searchFor('eyes', page);
+      await openDropdown('Locations', page);
+      await selectCheckbox('Open shelves', page);
+      await navigateToNextPage(page);
+
+      expectSearchParam('availabilities', 'open-shelves', page);
+
+      await navigateToResult(6, page);
+    });
+  }
+);
+
+test.describe(
+  'Scenario 3: The person is searching for a work that is available online',
+  () => {
+    test('the work should be browsable to from the search results', async ({
+      page,
+      context,
+    }) => {
+      await newWorksSearch(context, page);
+      await searchFor('skin', page);
+      await openDropdown('Locations', page);
+      await selectCheckbox('Online', page);
+      await navigateToNextPage(page);
+
+      expectSearchParam('availabilities', 'online', page);
+
+      await navigateToResult(8, page);
+    });
+  }
+);
+
+test.describe(
+  'Scenario 4: The person is searching for a work from Wellcome Images',
+  () => {
+    test('the work should be browsable to from the search results', async ({
+      page,
+      context,
+    }) => {
+      await newWorksSearch(context, page);
+      await searchFor('skeleton', page);
+      await openDropdown('Formats', page);
+      await selectCheckbox('Digital images', page);
+      await navigateToNextPage(page);
+
+      expectSearchParam('workType', 'q', page);
+
+      await navigateToResult(1, page);
+    });
+  }
+);
+
+test.describe(
+  'Scenario 5: The person is searching for a work in closed stores',
+  () => {
+    test('the work should be browsable to from the search results', async ({
+      page,
+      context,
+    }) => {
+      await newWorksSearch(context, page);
+      await searchFor('brain', page);
+      await openDropdown('Locations', page);
+      await selectCheckbox('Closed stores', page);
+      await navigateToNextPage(page);
+
+      expectSearchParam('availabilities', 'closed-stores', page);
+
+      await navigateToResult(6, page);
+    });
+  }
+);
+
+test.describe(
+  'Scenario 6: The reader is searching for works from a particular year',
+  () => {
+    test('the work should be browsable to from the search results', async ({
+      page,
+      context,
+    }) => {
+      // TODO: For some reason `"Filters"` isn't working on mobile.  The original
+      // purpose of this test was to check the logic behind the filters, not the UI.
+      // See https://wellcome.slack.com/archives/C8X9YKM5X/p1663763975934799
+      //
+      // Ideally we'd also be able to test mobile in this test, but it's not critical.
+      if (isMobile(page)) {
+        return;
+      }
+
+      await newWorksSearch(context, page);
+      await searchFor('brain', page);
+      await openDropdown('Dates', page);
+
+      // Note: if you put both `page.locator(…).fill(…)` commands in a
+      // single Promise.all(), they can interfere in such a way that only
+      // one of them ends up in the final URL. :-/
+
+      await Promise.all([
+        page
+          .locator('input[form="searchPageForm"][name="production.dates.from"]')
+          .fill('1939'),
+        safeWaitForNavigation(page),
+      ]);
+
+      await Promise.all([
+        page
+          .locator('input[form="searchPageForm"][name="production.dates.to"]')
+          .fill('2001'),
+        safeWaitForNavigation(page),
+      ]);
+
+      expectSearchParam('production.dates.from', '1939', page);
+      expectSearchParam('production.dates.to', '2001', page);
+
+      // This is a check that we have actually loaded some results from
+      // the API, and the API hasn't just errored out.
+      await navigateToResult(6, page);
+    });
+  }
+);

--- a/playwright/test/search.test.ts
+++ b/playwright/test/search.test.ts
@@ -1,0 +1,115 @@
+import { Page, test, expect } from '@playwright/test';
+import { gotoWithoutCache, isMobile } from './contexts';
+import {
+  clickActionCloseModalFilterButton,
+  clickActionModalFilterButton,
+} from './actions/search';
+
+import { elementIsVisible, fillInputAction } from './actions/common';
+import { expectItemsIsVisible, expectItemIsVisible } from './asserts/common';
+import { mobileModalImageSearch } from './selectors/images';
+import safeWaitForNavigation from './helpers/safeWaitForNavigation';
+
+const baseUrl = process.env.PLAYWRIGHT_BASE_URL
+  ? process.env.PLAYWRIGHT_BASE_URL
+  : 'http://localhost:3000';
+
+const overviewUrl = `${baseUrl}/search`;
+const imagesUrl = `${baseUrl}/search/images`;
+
+const searchBarInput = `#search-searchbar`;
+const colourSelectorFilterDropDown = `button[aria-controls="images.color"]`;
+const colourSelector = `button[data-test-id="swatch-green"]`;
+
+const fillActionSearchInput = async (
+  value: string,
+  page: Page
+): Promise<void> => {
+  const selector = `${searchBarInput}`;
+  await fillInputAction(selector, value, page);
+};
+const pressActionEnterSearchInput = async (page: Page): Promise<void> => {
+  const selector = `${searchBarInput}`;
+  await page.press(selector, 'Enter');
+};
+const clickActionColourDropDown = async (page: Page): Promise<void> => {
+  await page.click(colourSelectorFilterDropDown);
+};
+
+const selectColourInPicker = async (page: Page): Promise<void> => {
+  await Promise.all([safeWaitForNavigation(page), page.click(colourSelector)]);
+};
+
+async function gotoSearchResultPage(
+  { url, query }: { url: string; query: string },
+  page: Page
+): Promise<void> {
+  await gotoWithoutCache(url, page);
+  await fillActionSearchInput(query, page);
+  await Promise.all([
+    safeWaitForNavigation(page),
+    pressActionEnterSearchInput(page),
+  ]);
+}
+
+const searchResultsContainer = 'ul[data-test-id="search-results-container"]';
+const imagesResultsListItem = `${searchResultsContainer} li[data-test-id="image-search-result"]`;
+
+const subNavigationContainer = 'div[data-test-id="sub-nav-tab-container"]';
+const catalogueSectionSelector = `${subNavigationContainer} div[data-test-id="works"]`;
+const searchNoResults = 'p[data-test-id="search-no-results"]';
+
+test.describe('New Search Page interactions', () => {
+  test('the query (but not the filters) are maintained when switching through tabs', async ({
+    page,
+  }) => {
+    const query = 'art of science';
+    await gotoSearchResultPage({ url: imagesUrl, query }, page);
+    await expectItemIsVisible(searchResultsContainer, page);
+    await expectItemsIsVisible(imagesResultsListItem, 1, page);
+
+    if (isMobile(page)) {
+      await clickActionModalFilterButton(page);
+      await elementIsVisible(mobileModalImageSearch, page);
+      await selectColourInPicker(page);
+      await clickActionCloseModalFilterButton(page);
+    } else {
+      await clickActionColourDropDown(page);
+      await selectColourInPicker(page);
+      await clickActionColourDropDown(page);
+    }
+
+    await page.click(catalogueSectionSelector);
+    await safeWaitForNavigation(page);
+
+    // check the url to ensure that no weird filters are added
+    expect(page.url()).toBe(`${baseUrl}/search/works?query=art%20of%20science`);
+  });
+  test('clicking on "All Stories" on the Overview page takes us to the correct page on click', async ({
+    page,
+  }) => {
+    const query = 'art of science';
+    await gotoSearchResultPage({ url: overviewUrl, query }, page);
+    await page.click('"All stories"');
+    await safeWaitForNavigation(page);
+    expect(page.url()).toBe(`${baseUrl}/search/stories?query=art+of+science`);
+  });
+  test('clicking on "All Images" on the Overview page takes us to the correct page on click', async ({
+    page,
+  }) => {
+    const query = 'art of science';
+    await gotoSearchResultPage({ url: overviewUrl, query }, page);
+    await page.click('"All images"');
+    await safeWaitForNavigation(page);
+    expect(page.url()).toBe(`${baseUrl}/search/images?query=art+of+science`);
+  });
+  test('the no results message shows if needed', async ({ page }) => {
+    const query = 'gisjdabasdf;o';
+    await gotoSearchResultPage({ url: imagesUrl, query }, page);
+    await safeWaitForNavigation(page);
+
+    expect(await page.innerText(searchNoResults)).toBe(
+      `We couldn’t find anything that matched ${query}. Please try again.`
+    );
+  });
+});

--- a/playwright/test/search.test.ts
+++ b/playwright/test/search.test.ts
@@ -52,8 +52,9 @@ async function gotoSearchResultPage(
   ]);
 }
 
-const searchResultsContainer = 'ul[data-test-id="search-results-container"]';
-const imagesResultsListItem = `${searchResultsContainer} li[data-test-id="image-search-result"]`;
+const imageSearchResultsContainer =
+  'ul[data-test-id="image-search-results-container"]';
+const imagesResultsListItem = `${imageSearchResultsContainer} li[data-test-id="image-search-result"]`;
 
 const subNavigationContainer = 'div[data-test-id="sub-nav-tab-container"]';
 const catalogueSectionSelector = `${subNavigationContainer} div[data-test-id="works"]`;
@@ -65,7 +66,7 @@ test.describe('New Search Page interactions', () => {
   }) => {
     const query = 'art of science';
     await gotoSearchResultPage({ url: imagesUrl, query }, page);
-    await expectItemIsVisible(searchResultsContainer, page);
+    await expectItemIsVisible(imageSearchResultsContainer, page);
     await expectItemsIsVisible(imagesResultsListItem, 1, page);
 
     if (isMobile(page)) {
@@ -106,8 +107,6 @@ test.describe('New Search Page interactions', () => {
   test('the no results message shows if needed', async ({ page }) => {
     const query = 'gisjdabasdf;o';
     await gotoSearchResultPage({ url: imagesUrl, query }, page);
-    await safeWaitForNavigation(page);
-
     expect(await page.innerText(searchNoResults)).toBe(
       `We couldn’t find anything that matched ${query}. Please try again.`
     );


### PR DESCRIPTION
- duplicated the existing searches for works/images and pointed them to the new search pages
- added a few more search use cases for the overview and also the cross section navigation behaviour
- added `data-test-id` attributes for elements that need to be selected for testing purposes

closes #9193 