### PR TITLE
Search; Rename Overview to All and remove from under Collections

### DIFF
--- a/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
+++ b/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
@@ -27,7 +27,7 @@ const SearchBarContainer = styled(Space)`
 
 type PageLayoutMetadata = {
   openGraphType: 'website';
-  siteSection: 'collections';
+  siteSection: null;
   jsonLd: { '@type': 'WebPage' };
   hideNewsletterPromo: true;
   excludeRoleMain: true;
@@ -53,7 +53,7 @@ const SearchLayout: FunctionComponent<{ hasEventsExhibitions: boolean }> = ({
 
   const basePageMetadata: PageLayoutMetadata = {
     openGraphType: 'website',
-    siteSection: 'collections',
+    siteSection: null,
     jsonLd: { '@type': 'WebPage' },
     hideNewsletterPromo: true,
     excludeRoleMain: true,
@@ -232,7 +232,7 @@ const SearchLayout: FunctionComponent<{ hasEventsExhibitions: boolean }> = ({
             {
               id: 'overview',
               url: getURL('/search'),
-              name: 'Overview',
+              name: 'All',
             },
             {
               id: 'stories',


### PR DESCRIPTION
## Who is this for?
new search

## What is it doing for them?
- Renames Overview to All but in the UI only. I find it's clearer to keep it as `overview` in the codebase for other purposes
- Removes it from under the Collection section


Part of #9236 