### PR TITLE
Disable all filters on NoResult in search

### DIFF
--- a/catalogue/webapp/pages/search/images.tsx
+++ b/catalogue/webapp/pages/search/images.tsx
@@ -85,6 +85,8 @@ const ImagesSearchPage: NextPageWithLayout<Props> = ({
     return { href, as };
   };
 
+  const hasNoResults = images.totalResults === 0;
+
   return (
     <>
       <Head>
@@ -129,12 +131,13 @@ const ImagesSearchPage: NextPageWithLayout<Props> = ({
                 );
             }}
             filters={filters}
+            hasNoResults={hasNoResults}
             isNewStyle
           />
         </Space>
       </div>
 
-      {images.totalResults === 0 ? (
+      {hasNoResults ? (
         <SearchNoResults
           query={queryString}
           hasFilters={hasFilters({

--- a/catalogue/webapp/pages/search/works.tsx
+++ b/catalogue/webapp/pages/search/works.tsx
@@ -86,6 +86,8 @@ export const CatalogueSearchPage: NextPageWithLayout<Props> = ({
     return { href, as };
   };
 
+  const hasNoResults = works.totalResults === 0;
+
   return (
     <>
       <Head>
@@ -133,11 +135,12 @@ export const CatalogueSearchPage: NextPageWithLayout<Props> = ({
                 );
             }}
             filters={filters}
+            hasNoResults={hasNoResults}
             isNewStyle
           />
         </Space>
 
-        {works.totalResults === 0 ? (
+        {hasNoResults ? (
           <SearchNoResults
             query={queryString}
             hasFilters={hasFilters({

--- a/common/views/components/ModalMoreFilters/ModalMoreFilters.tsx
+++ b/common/views/components/ModalMoreFilters/ModalMoreFilters.tsx
@@ -30,6 +30,7 @@ type ModalMoreFiltersProps = {
   resetFilters: LinkProps;
   filters: Filter[];
   form?: string;
+  hasNoResults?: boolean;
   isNewStyle?: boolean;
 };
 
@@ -37,6 +38,7 @@ type MoreFiltersProps = {
   filters: Filter[];
   changeHandler: () => void;
   form?: string;
+  hasNoResults?: boolean;
   isNewStyle?: boolean;
 };
 
@@ -214,6 +216,7 @@ const MoreFilters: FunctionComponent<MoreFiltersProps> = ({
   changeHandler,
   filters,
   form,
+  hasNoResults,
   isNewStyle,
 }: MoreFiltersProps) => {
   return (
@@ -257,14 +260,15 @@ const MoreFilters: FunctionComponent<MoreFiltersProps> = ({
                       form={form}
                     />
                   )}
-                  {f.type === 'dateRange' && (
-                    <DateRangeFilter
-                      f={f}
-                      changeHandler={changeHandler}
-                      form={form}
-                    />
-                  )}
-                  {f.type === 'color' && (
+                  {f.type === 'dateRange' &&
+                    !(hasNoResults && !(f.from.value || f.to.value)) && (
+                      <DateRangeFilter
+                        f={f}
+                        changeHandler={changeHandler}
+                        form={form}
+                      />
+                    )}
+                  {f.type === 'color' && !(hasNoResults && !f.color) && (
                     <ColorFilter
                       f={f}
                       changeHandler={changeHandler}
@@ -289,6 +293,7 @@ const ModalMoreFilters: FunctionComponent<ModalMoreFiltersProps> = ({
   resetFilters,
   filters,
   form,
+  hasNoResults,
   isNewStyle,
 }: ModalMoreFiltersProps) => {
   const { isEnhanced } = useContext(AppContext);
@@ -321,6 +326,7 @@ const ModalMoreFilters: FunctionComponent<ModalMoreFiltersProps> = ({
               changeHandler={changeHandler}
               filters={filters}
               form={form}
+              hasNoResults={hasNoResults}
               isNewStyle={isNewStyle}
             />
           )}

--- a/common/views/components/ModalMoreFilters/ModalMoreFilters.tsx
+++ b/common/views/components/ModalMoreFilters/ModalMoreFilters.tsx
@@ -303,13 +303,12 @@ const ModalMoreFilters: FunctionComponent<ModalMoreFiltersProps> = ({
   return (
     <>
       <noscript>
-        <>
-          <MoreFilters
-            changeHandler={changeHandler}
-            filters={filters}
-            form={form}
-          />
-        </>
+        <MoreFilters
+          changeHandler={changeHandler}
+          filters={filters}
+          hasNoResults={hasNoResults}
+          form={form}
+        />
       </noscript>
       <Modal
         id={id}

--- a/common/views/components/ModalMoreFilters/ModalMoreFilters.tsx
+++ b/common/views/components/ModalMoreFilters/ModalMoreFilters.tsx
@@ -1,24 +1,26 @@
 import React, { FunctionComponent, RefObject, useContext } from 'react';
-import Modal from '../../components/Modal/Modal';
-import styled from 'styled-components';
-import Space from '../styled/Space';
-import { searchFilterCheckBox } from '../../../text/aria-labels';
 import NextLink from 'next/link';
-import ButtonSolid, { ButtonTypes } from '../ButtonSolid/ButtonSolid';
+import styled from 'styled-components';
+import Modal from '@weco/common/views/components/Modal/Modal';
+import Space from '@weco/common/views/components/styled/Space';
+import { searchFilterCheckBox } from '@weco/common/text/aria-labels';
+import ButtonSolid, {
+  ButtonTypes,
+} from '@weco/common/views/components/ButtonSolid/ButtonSolid';
 import {
   Filter,
   CheckboxFilter as CheckboxFilterType,
   DateRangeFilter as DateRangeFilterType,
   ColorFilter as ColorFilterType,
   filterLabel,
-} from '../../../services/catalogue/filters';
-import { AppContext } from '../AppContext/AppContext';
-import CheckboxRadio from '../CheckboxRadio/CheckboxRadio';
-import PlainList from '../styled/PlainList';
-import NumberInput from '../NumberInput/NumberInput';
-import { dateRegex } from '../SearchFilters/SearchFiltersDesktop';
+} from '@weco/common/services/catalogue/filters';
+import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
+import CheckboxRadio from '@weco/common/views/components/CheckboxRadio/CheckboxRadio';
+import PlainList from '@weco/common/views/components/styled/PlainList';
+import NumberInput from '@weco/common/views/components/NumberInput/NumberInput';
+import { dateRegex } from '@weco/common/views/components/SearchFilters/SearchFiltersDesktop';
 import { useControlledState } from '@weco/common/utils/useControlledState';
-import PaletteColorPicker from '../PaletteColorPicker/PaletteColorPicker';
+import PaletteColorPicker from '@weco/common/views/components/PaletteColorPicker/PaletteColorPicker';
 import { LinkProps } from '@weco/common/model/link-props';
 
 type ModalMoreFiltersProps = {

--- a/common/views/components/SearchFilters/SearchFilters.tsx
+++ b/common/views/components/SearchFilters/SearchFilters.tsx
@@ -13,6 +13,7 @@ type Props = {
   changeHandler: () => void;
   filters: Filter[];
   linkResolver: (params: ParsedUrlQuery) => LinkProps;
+  hasNoResults?: boolean;
   isNewStyle?: boolean;
 };
 
@@ -24,6 +25,7 @@ const SearchFilters: FunctionComponent<Props> = ({
   changeHandler,
   filters,
   linkResolver,
+  hasNoResults,
   isNewStyle,
 }: Props): ReactElement<Props> => {
   const { windowSize } = useContext(AppContext);
@@ -59,6 +61,7 @@ const SearchFilters: FunctionComponent<Props> = ({
     filters,
     linkResolver,
     activeFiltersCount,
+    hasNoResults,
     isNewStyle,
   };
 

--- a/common/views/components/SearchFilters/SearchFilters.tsx
+++ b/common/views/components/SearchFilters/SearchFilters.tsx
@@ -1,11 +1,13 @@
 import { FunctionComponent, ReactElement, useContext, useState } from 'react';
 import { ParsedUrlQuery } from 'querystring';
+
+import { LinkProps } from '@weco/common/model/link-props';
+import { Filter } from '@weco/common/services/catalogue/filters';
+import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
+import useIsomorphicLayoutEffect from '@weco/common/hooks/useIsomorphicLayoutEffect';
+
 import SearchFiltersDesktop from './SearchFiltersDesktop';
 import SearchFiltersMobile from './SearchFiltersMobile';
-import { LinkProps } from '../../../model/link-props';
-import { Filter } from '../../../services/catalogue/filters';
-import { AppContext } from '../AppContext/AppContext';
-import useIsomorphicLayoutEffect from '../../../hooks/useIsomorphicLayoutEffect';
 
 type Props = {
   query?: string;

--- a/common/views/components/SearchFilters/SearchFiltersDesktop.tsx
+++ b/common/views/components/SearchFilters/SearchFiltersDesktop.tsx
@@ -105,6 +105,7 @@ type DateRangeFilterProps = {
   f: DateRangeFilterType;
   changeHandler: () => void;
   form?: string;
+  hasNoOptions?: boolean;
   isNewStyle?: boolean;
 };
 
@@ -112,6 +113,7 @@ const DateRangeFilter = ({
   f,
   changeHandler,
   form,
+  hasNoOptions,
   isNewStyle,
 }: DateRangeFilterProps) => {
   const [from, setFrom] = useControlledState(f.from.value);
@@ -125,6 +127,7 @@ const DateRangeFilter = ({
         label={f.label}
         buttonType="inline"
         id={f.id}
+        hasNoOptions={hasNoOptions}
       >
         <>
           <Space as="span" h={{ size: 'm', properties: ['margin-right'] }}>
@@ -171,12 +174,14 @@ type ColorFilterProps = {
   f: ColorFilterType;
   changeHandler: () => void;
   form?: string;
+  hasNoOptions?: boolean;
   isNewStyle?: boolean;
 };
 const ColorFilter = ({
   f,
   changeHandler,
   form,
+  hasNoOptions,
   isNewStyle,
 }: ColorFilterProps) => {
   return (
@@ -186,6 +191,7 @@ const ColorFilter = ({
       label="Colours"
       buttonType="inline"
       id="images.color"
+      hasNoOptions={hasNoOptions}
     >
       <PaletteColorPicker
         name={f.id}
@@ -208,6 +214,7 @@ const DynamicFilterArray = ({
   searchFormId,
   filters,
   openMoreFiltersButtonRef,
+  hasNoResults,
 }) => {
   const router = useRouter();
   const [wrapperWidth, setWrapperWidth] = useState<number>(0);
@@ -257,6 +264,7 @@ const DynamicFilterArray = ({
             f={f}
             changeHandler={changeHandler}
             isNewStyle={isNewStyle}
+            hasNoOptions={hasNoResults && !(f.from.value || f.to.value)}
           />
         )}
 
@@ -266,6 +274,7 @@ const DynamicFilterArray = ({
             f={f}
             changeHandler={changeHandler}
             isNewStyle={isNewStyle}
+            hasNoOptions={hasNoResults && !f.color}
           />
         )}
       </Space>
@@ -377,6 +386,7 @@ const SearchFiltersDesktop: FunctionComponent<SearchFiltersSharedProps> = ({
   activeFiltersCount,
   searchFormId,
   isNewStyle,
+  hasNoResults,
 }: SearchFiltersSharedProps): ReactElement<SearchFiltersSharedProps> => {
   const [showMoreFiltersModal, setShowMoreFiltersModal] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
@@ -419,6 +429,7 @@ const SearchFiltersDesktop: FunctionComponent<SearchFiltersSharedProps> = ({
                     searchFormId={searchFormId}
                     filters={filters}
                     openMoreFiltersButtonRef={openMoreFiltersButtonRef}
+                    hasNoResults={hasNoResults}
                   />
                 )}
                 <ModalMoreFilters

--- a/common/views/components/SearchFilters/SearchFiltersDesktop.tsx
+++ b/common/views/components/SearchFilters/SearchFiltersDesktop.tsx
@@ -6,30 +6,33 @@ import React, {
   useState,
   useLayoutEffect,
 } from 'react';
+import { useRouter } from 'next/router';
 import styled from 'styled-components';
-import { font } from '../../../utils/classnames';
-import { useControlledState } from '../../../utils/useControlledState';
-import PlainList from '../styled/PlainList';
-import Space from '../styled/Space';
-import Icon from '../Icon/Icon';
+
+import { font } from '@weco/common/utils/classnames';
+import PlainList from '@weco/common/views/components/styled/PlainList';
+import Space from '@weco/common/views/components/styled/Space';
+import Icon from '@weco/common/views/components/Icon/Icon';
 import DropdownButton from '@weco/common/views/components/DropdownButton/DropdownButton';
-import NumberInput from '@weco/common/views/components/NumberInput/NumberInput';
 import CheckboxRadio from '@weco/common/views/components/CheckboxRadio/CheckboxRadio';
-import { SearchFiltersSharedProps } from '../SearchFilters/SearchFilters';
+import { useControlledState } from '@weco/common/utils/useControlledState';
+import { SearchFiltersSharedProps } from '@weco/common/views/components/SearchFilters/SearchFilters';
 import {
   CheckboxFilter as CheckboxFilterType,
   DateRangeFilter as DateRangeFilterType,
   ColorFilter as ColorFilterType,
   filterLabel,
   Filter,
-} from '../../../services/catalogue/filters';
-import ModalMoreFilters from '../ModalMoreFilters/ModalMoreFilters';
-import { ResetActiveFilters } from './ResetActiveFilters';
-import ButtonSolid, { ButtonTypes } from '../ButtonSolid/ButtonSolid';
+} from '@weco/common/services/catalogue/filters';
+import ModalMoreFilters from '@weco/common/views/components/ModalMoreFilters/ModalMoreFilters';
+import ButtonSolid, {
+  ButtonTypes,
+} from '@weco/common/views/components/ButtonSolid/ButtonSolid';
 import { filter } from '@weco/common/icons';
 import { themeValues } from '@weco/common/views/themes/config';
-import PaletteColorPicker from '../PaletteColorPicker/PaletteColorPicker';
-import { useRouter } from 'next/router';
+import PaletteColorPicker from '@weco/common/views/components/PaletteColorPicker/PaletteColorPicker';
+import NumberInput from '@weco/common/views/components/NumberInput/NumberInput';
+import { ResetActiveFilters } from './ResetActiveFilters';
 
 export const dateRegex = /^\d{4}$|^$/;
 

--- a/common/views/components/SearchFilters/SearchFiltersDesktop.tsx
+++ b/common/views/components/SearchFilters/SearchFiltersDesktop.tsx
@@ -441,6 +441,7 @@ const SearchFiltersDesktop: FunctionComponent<SearchFiltersSharedProps> = ({
                   changeHandler={changeHandler}
                   resetFilters={linkResolver({ query })}
                   filters={filters}
+                  hasNoResults={hasNoResults}
                   isNewStyle
                 />
               </>

--- a/common/views/components/SearchFilters/SearchFiltersMobile.tsx
+++ b/common/views/components/SearchFilters/SearchFiltersMobile.tsx
@@ -119,7 +119,6 @@ type CheckboxFilterProps = {
 const CheckboxFilter = ({ f, changeHandler, form }: CheckboxFilterProps) => {
   return (
     <>
-      <h3 className="h3">{f.label}</h3>
       <PlainList>
         {f.options.map(({ id, label, value, count, selected }) => {
           return (
@@ -158,7 +157,6 @@ const DateRangeFilter = ({ f, changeHandler, form }: DateRangeFilterProps) => {
 
   return (
     <>
-      <h3 className="h3">{f.label}</h3>
       <Space as="span" h={{ size: 'm', properties: ['margin-right'] }}>
         <NumberInput
           name={f.from.id}
@@ -219,6 +217,7 @@ const SearchFiltersMobile: FunctionComponent<SearchFiltersSharedProps> = ({
   filters,
   activeFiltersCount,
   searchFormId,
+  hasNoResults,
 }: SearchFiltersSharedProps): ReactElement<SearchFiltersSharedProps> => {
   const openFiltersButtonRef = useRef<HTMLButtonElement>(null);
   const closeFiltersButtonRef = useRef<HTMLDivElement>(null);
@@ -313,6 +312,9 @@ const SearchFiltersMobile: FunctionComponent<SearchFiltersSharedProps> = ({
               .map(f => {
                 return (
                   <FilterSection key={f.id}>
+                    <h3 className="h3">
+                      {f.type === 'color' ? 'Colours' : f.label}
+                    </h3>
                     {f.type === 'checkbox' && (
                       <CheckboxFilter
                         f={f}
@@ -321,15 +323,16 @@ const SearchFiltersMobile: FunctionComponent<SearchFiltersSharedProps> = ({
                       />
                     )}
 
-                    {f.type === 'dateRange' && (
-                      <DateRangeFilter
-                        f={f}
-                        changeHandler={changeHandler}
-                        form={searchFormId}
-                      />
-                    )}
+                    {f.type === 'dateRange' &&
+                      !(hasNoResults && !(f.from.value || f.to.value)) && (
+                        <DateRangeFilter
+                          f={f}
+                          changeHandler={changeHandler}
+                          form={searchFormId}
+                        />
+                      )}
 
-                    {f.type === 'color' && (
+                    {f.type === 'color' && !(hasNoResults && !f.color) && (
                       <ColorFilter
                         f={f}
                         changeHandler={changeHandler}

--- a/common/views/components/SearchFilters/SearchFiltersMobile.tsx
+++ b/common/views/components/SearchFilters/SearchFiltersMobile.tsx
@@ -4,33 +4,34 @@ import React, {
   FunctionComponent,
   ReactElement,
 } from 'react';
-import useSkipInitialEffect from '@weco/common/hooks/useSkipInitialEffect';
 import dynamic from 'next/dynamic';
-import getFocusableElements from '../../../utils/get-focusable-elements';
-import { useControlledState } from '../../../utils/useControlledState';
 import NextLink from 'next/link';
-import { toLink as worksLink } from '../WorksLink/WorksLink';
 import styled from 'styled-components';
-import PlainList from '../styled/PlainList';
-import Space from '../styled/Space';
-import Icon from '../Icon/Icon';
+
+import useSkipInitialEffect from '@weco/common/hooks/useSkipInitialEffect';
+import getFocusableElements from '@weco/common/utils/get-focusable-elements';
+import { useControlledState } from '@weco/common/utils/useControlledState';
+import { toLink as worksLink } from '@weco/common/views/components/WorksLink/WorksLink';
+import PlainList from '@weco/common/views/components/styled/PlainList';
+import Space from '@weco/common/views/components/styled/Space';
+import Icon from '@weco/common/views/components/Icon/Icon';
 import NumberInput from '@weco/common/views/components/NumberInput/NumberInput';
 import CheckboxRadio from '@weco/common/views/components/CheckboxRadio/CheckboxRadio';
-import { SearchFiltersSharedProps } from '../SearchFilters/SearchFilters';
+import { SearchFiltersSharedProps } from '@weco/common/views/components/SearchFilters/SearchFilters';
 import {
   CheckboxFilter as CheckboxFilterType,
   DateRangeFilter as DateRangeFilterType,
   ColorFilter as ColorFilterType,
   filterLabel,
-} from '../../../services/catalogue/filters';
+} from '@weco/common/services/catalogue/filters';
 import ButtonSolid, {
   ButtonTypes,
   SolidButton,
 } from '@weco/common/views/components/ButtonSolid/ButtonSolid';
-import { searchFilterCheckBox } from '../../../text/aria-labels';
-import { dateRegex } from './SearchFiltersDesktop';
+import { searchFilterCheckBox } from '@weco/common/text/aria-labels';
 import { filter } from '@weco/common/icons';
-import Modal from '../../components/Modal/Modal';
+import Modal from '@weco/common/views/components/Modal/Modal';
+import { dateRegex } from './SearchFiltersDesktop';
 
 const PaletteColorPicker = dynamic(
   import('../PaletteColorPicker/PaletteColorPicker')


### PR DESCRIPTION
## Who is this for?
New search

## What is it doing for them?
If there are no results, the Color and Date filters should also be disabled (unless one of them is in use)

- in Desktop filter button
- in Desktop modal
- in Mobile modal (not sure why there are two different ones to be honest - something to look into?)

I checked it worked for:
- New search on desktop with Javascript
- New search on desktop without Javascript
- New search on mobile with Javascript
- New search on mobile without Javascript
- New search's modal box with Javascript
- New search's modal box without Javascript (doesn't exist)

And I've checked it didn't affect functionalities in the current searches as well.

Part of #9236