### PR TITLE
Fix a couple of paths in Next routing

### DIFF
--- a/catalogue/webapp/components/WorkTabbedNav/WorkTabbedNav.tsx
+++ b/catalogue/webapp/components/WorkTabbedNav/WorkTabbedNav.tsx
@@ -18,9 +18,9 @@ const WorkTabbedNav: FunctionComponent<Props> = ({ work, selected }) => {
           id: 'catalogueDetails',
           url: {
             href: {
-              pathname: '/work',
+              pathname: '/works/[workId]',
               query: {
-                id: work.id,
+                workId: work.id,
               },
             },
             as: {

--- a/common/views/components/ImageLink/ImageLink.tsx
+++ b/common/views/components/ImageLink/ImageLink.tsx
@@ -40,7 +40,6 @@ function toLink(
   partialProps: Partial<ImageProps>,
   source: ImagePropsSource
 ): LinkProps {
-  const pathname = '/image';
   const props: ImageProps = {
     ...emptyImageProps,
     ...partialProps,
@@ -49,8 +48,12 @@ function toLink(
 
   return {
     href: {
-      pathname,
-      query: { ...query, source },
+      pathname: `/works/[workId]/images`,
+      query: {
+        workId: props.workId,
+        ...query,
+        source,
+      },
     },
     as: {
       pathname: `/works/${props.workId}/images`,
@@ -68,7 +71,11 @@ const ImageLink: FunctionComponent<Props> = ({
   source,
   ...props
 }: Props) => {
-  return <NextLink {...toLink(props, source)} legacyBehavior>{children}</NextLink>;
+  return (
+    <NextLink {...toLink(props, source)} legacyBehavior>
+      {children}
+    </NextLink>
+  );
 };
 
 export default ImageLink;

--- a/common/views/components/WorkLink/WorkLink.tsx
+++ b/common/views/components/WorkLink/WorkLink.tsx
@@ -27,9 +27,9 @@ const WorkLink: FunctionComponent<PropsWithChildren<Props>> = ({
   return (
     <NextLink
       href={{
-        pathname: '/work',
+        pathname: '/works/[workId]',
         query: {
-          id,
+          workId: id,
           source,
           resultPosition,
         },
@@ -38,7 +38,8 @@ const WorkLink: FunctionComponent<PropsWithChildren<Props>> = ({
         pathname: `/works/${id}`,
       }}
       {...linkProps}
-      legacyBehavior>
+      legacyBehavior
+    >
       {children}
     </NextLink>
   );


### PR DESCRIPTION
These are leftovers from when we refactored our routing last week; among other things they're forcing clients to fetch the whole page again, which means the source is being dropped when navigating between pages.

Closes https://github.com/wellcomecollection/wellcomecollection.org/issues/9257; I've run locally and verified that (1) the `source` is being dropped before this fix and (2) we get proper client-side routing with `source` after this fix.