### PR TITLE
Fix the underline hover colour of card links on dark backgrounds

### DIFF
--- a/content/webapp/components/Card/Card.tsx
+++ b/content/webapp/components/Card/Card.tsx
@@ -39,6 +39,11 @@ export const CardOuter = styled.a.attrs<{ className?: string }>(() => ({
   .card-theme.bg-dark & {
     color: ${props => props.theme.color('white')};
   }
+
+  .card-theme.bg-dark &:hover .promo-link__title,
+  .card-theme.bg-dark &:focus .promo-link__title {
+    text-decoration-color: ${props => props.theme.color('white')};
+  }
 `;
 
 export const CardPostBody = styled(Space).attrs({


### PR DESCRIPTION
Previously this hover was always black, even on a dark background, but the text was white -- now the hover is white to match.

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img width="1726" alt="Screenshot 2023-02-13 at 20 14 21" src="https://user-images.githubusercontent.com/301220/218566871-9faaf966-c113-4f85-a676-1fd665b787fd.png">
</td>
<td>
<img width="1726" alt="Screenshot 2023-02-13 at 20 23 57" src="https://user-images.githubusercontent.com/301220/218566884-e82b3bc9-d820-4146-bda6-b371671a86e4.png">
</td>
</tr>
</table>