### PR TITLE
Fix the routing for vanity URLs, e.g. /about-us

### DIFF
--- a/.buildkite/urls/expected_200_urls.txt
+++ b/.buildkite/urls/expected_200_urls.txt
@@ -89,3 +89,7 @@
 /search/stories?query=human
 /search/images?query=human
 /search/works?query=human
+
+# Vanity URLs in the content app
+/about-us
+/collections

--- a/content/webapp/app.ts
+++ b/content/webapp/app.ts
@@ -100,8 +100,8 @@ const appPromise = nextApp
 
     // We define the vanity URLs as soon as possible, so they can intercept
     // any routes defined further down, e.g. /pages/:id
-    vanityUrls.forEach(({ url, prismicId, template = '/pages/[pageId]' }) =>
-      pageVanityUrl(router, nextApp, url, prismicId, template)
+    vanityUrls.forEach(({ url, prismicId }) =>
+      pageVanityUrl(router, nextApp, url, prismicId, `/pages/${prismicId}`)
     );
 
     route(


### PR DESCRIPTION
tested locally, fixes one of the failing e2e tests