### PR TITLE
Fix mobile e2es for Works searches

### DIFF
--- a/playwright/test/new-works-search.test.ts
+++ b/playwright/test/new-works-search.test.ts
@@ -78,6 +78,7 @@ const navigateToResult = async (n = 1, page: Page) => {
   // the site, I haven't investigated further -- this seems to make the tests happy.
   if (isMobile(page)) {
     await page.click(result);
+    await safeWaitForNavigation(page);
   } else {
     await Promise.all([safeWaitForNavigation(page), page.click(result)]);
   }

--- a/playwright/test/works-search.test.ts
+++ b/playwright/test/works-search.test.ts
@@ -78,6 +78,7 @@ const navigateToResult = async (n = 1, page: Page) => {
   // the site, I haven't investigated further -- this seems to make the tests happy.
   if (isMobile(page)) {
     await page.click(result);
+    await safeWaitForNavigation(page);
   } else {
     await Promise.all([safeWaitForNavigation(page), page.click(result)]);
   }


### PR DESCRIPTION
## Who is this for?
[Broken mobile e2es](https://buildkite.com/wellcomecollection/wc-dot-org-end-to-end-tests/builds/2384#018650ec-e306-4d26-8bdd-cbbe704a7849)

## What is it doing for them?
Waits for navigation before reading the page title on mobile. It was happening too fast and was reading the search page title instead.

I don't think this breaks the bugfix that was put in two weeks ago, as we wait for navigation at a different step than on desktop.