### PR TITLE
Add index in key name as a temporary fix

### DIFF
--- a/common/views/components/ModalMoreFilters/ModalMoreFilters.tsx
+++ b/common/views/components/ModalMoreFilters/ModalMoreFilters.tsx
@@ -116,13 +116,16 @@ type CheckboxFilterProps = {
 const CheckboxFilter = ({ f, changeHandler, form }: CheckboxFilterProps) => {
   return (
     <List>
-      {f.options.map(({ id, label, value, count, selected }) => {
+      {f.options.map(({ id, label, value, count, selected }, i) => {
         return (
           <Space
             as="li"
             v={{ size: 'm', properties: ['margin-bottom'] }}
             h={{ size: 'l', properties: ['margin-right'] }}
-            key={`desktop-${id}`}
+            // TODO remove index from key once we resolve the doubled IDs issue
+            // (https://github.com/wellcomecollection/wellcomecollection.org/issues/9109)
+            // as we now sometimes get "Warning: Encountered two children with the same key" console errors
+            key={`desktop-${f.id}-${i}`}
           >
             <CheckboxRadio
               id={`desktop-${id}`}
@@ -154,8 +157,11 @@ const MoreFilters: FunctionComponent<MoreFiltersProps> = ({
       {!isNewStyle &&
         filters
           .filter(f => f.excludeFromMoreFilters)
-          .map(f => (
-            <div key={f.id} style={{ display: 'none' }}>
+          .map((f, i) => (
+            // TODO remove index from key once we resolve the doubled IDs issue
+            // (https://github.com/wellcomecollection/wellcomecollection.org/issues/9109)
+            // as we now sometimes get "Warning: Encountered two children with the same key" console errors
+            <div key={`${f.id}-${i}`} style={{ display: 'none' }}>
               {f.type === 'checkbox' && (
                 <CheckboxFilter
                   f={f}
@@ -182,8 +188,11 @@ const MoreFilters: FunctionComponent<MoreFiltersProps> = ({
           ))}
       {filters
         .filter(f => !f.excludeFromMoreFilters)
-        .map(f => (
-          <FilterSection key={f.id}>
+        .map((f, i) => (
+          // TODO remove index from key once we resolve the doubled IDs issue
+          // (https://github.com/wellcomecollection/wellcomecollection.org/issues/9109)
+          // as we now sometimes get "Warning: Encountered two children with the same key" console errors
+          <FilterSection key={`${f.id}-${i}`}>
             <h3 className="h3">{f.type === 'color' ? 'Colours' : f.label}</h3>
             <Space as="span" h={{ size: 'm', properties: ['margin-right'] }}>
               <PlainList as="div">

--- a/common/views/components/SearchFilters/SearchFiltersDesktop.tsx
+++ b/common/views/components/SearchFilters/SearchFiltersDesktop.tsx
@@ -84,9 +84,12 @@ const CheckboxFilter = ({
       hasNoOptions={f.options.length === 0}
     >
       <PlainList className={font('intr', 5)}>
-        {f.options.map(({ id, label, value, count, selected }) => {
+        {f.options.map(({ id, label, value, count, selected }, i) => {
           return (
-            <li key={`${f.id}-${id}`}>
+            // TODO remove index from key once we resolve the doubled IDs issue
+            // (https://github.com/wellcomecollection/wellcomecollection.org/issues/9109)
+            // as we now sometimes get "Warning: Encountered two children with the same key" console errors
+            <li key={`${id}-${i}`}>
               <CheckboxRadio
                 id={id}
                 type="checkbox"
@@ -198,8 +201,11 @@ const DynamicFilterArray = ({
   const filterClassname = 'superUniqueDropdownFilterButtonClass';
   const renderDynamicFilter = (f: Filter, i: number, arr: Filter[]) => {
     return (
+      // TODO remove index from key once we resolve the doubled IDs issue
+      // (https://github.com/wellcomecollection/wellcomecollection.org/issues/9109)
+      // as we now sometimes get "Warning: Encountered two children with the same key" console errors
       <Space
-        key={f.id}
+        key={`${f.id}-${i}`}
         className={filterClassname}
         h={
           i + 1 !== arr.length
@@ -428,7 +434,10 @@ const SearchFiltersDesktop: FunctionComponent<SearchFiltersSharedProps> = ({
                 {visibleFilters.map((f, i, arr) => {
                   return (
                     <Space
-                      key={f.id}
+                      // TODO remove index from key once we resolve the doubled IDs issue
+                      // (https://github.com/wellcomecollection/wellcomecollection.org/issues/9109)
+                      // as we now sometimes get "Warning: Encountered two children with the same key" console errors
+                      key={`${f.id}-${i}`}
                       h={
                         i + 1 !== arr.length
                           ? { size: 's', properties: ['margin-right'] }

--- a/common/views/components/SearchFilters/SearchFiltersMobile.tsx
+++ b/common/views/components/SearchFilters/SearchFiltersMobile.tsx
@@ -112,12 +112,15 @@ const CheckboxFilter = ({ f, changeHandler, form }: CheckboxFilterProps) => {
   return (
     <>
       <PlainList>
-        {f.options.map(({ id, label, value, count, selected }) => {
+        {f.options.map(({ id, label, value, count, selected }, i) => {
           return (
             <Space
               as="li"
               v={{ size: 'l', properties: ['margin-bottom'] }}
-              key={`mobile-${id}`}
+              // TODO remove index from key once we resolve the doubled IDs issue
+              // (https://github.com/wellcomecollection/wellcomecollection.org/issues/9109)
+              // as we now sometimes get "Warning: Encountered two children with the same key" console errors
+              key={`mobile-${id}-${i}`}
             >
               <CheckboxRadio
                 id={`mobile-${id}`}
@@ -237,9 +240,12 @@ const SearchFiltersMobile: FunctionComponent<SearchFiltersSharedProps> = ({
           <FiltersBody>
             {filters
               .filter(f => !f.excludeFromMoreFilters)
-              .map(f => {
+              .map((f, i) => {
                 return (
-                  <FilterSection key={f.id}>
+                  // TODO remove index from key once we resolve the doubled IDs issue
+                  // (https://github.com/wellcomecollection/wellcomecollection.org/issues/9109)
+                  // as we now sometimes get "Warning: Encountered two children with the same key" console errors
+                  <FilterSection key={`${f.id}-${i}`}>
                     <h3 className="h3">
                       {f.type === 'color' ? 'Colours' : f.label}
                     </h3>


### PR DESCRIPTION
## Who is this for?
Devs and general good react behaviour

## What is it doing for them?
Because of "[the Glasgow problem](https://github.com/wellcomecollection/wellcomecollection.org/issues/9109)", some keys in rendered arrays were being repeated, making for bad practice in React. We decided to go with adding in the index (which is [a last resort solution](https://reactjs.org/docs/lists-and-keys.html#keys)), but left TODOs to remove them when #9109 is fixed.

I find this also outlines how repetitive our components are, which is something I hope we can streamline once we delete the old search for good.