### PR TITLE
Change sort CSS to align it more with the filters look

### DIFF
--- a/common/views/components/SelectContainer/SelectContainer.tsx
+++ b/common/views/components/SelectContainer/SelectContainer.tsx
@@ -22,8 +22,8 @@ const StyledSelect = styled.div.attrs({
   .icon {
     position: absolute;
     pointer-events: none;
-    top: 6px;
-    right: 6px;
+    ${props =>
+      props.isPill ? 'top: 4px; right: 10px;' : 'top: 6px; right: 6px;'};
   }
 
   select {
@@ -41,6 +41,7 @@ const StyledSelect = styled.div.attrs({
     color: ${props =>
       props.theme.color('black')}; // This avoids the default blue links on iOS
     width: 100%;
+    ${props => (props.isPill ? 'line-height: 1;' : '')}
 
     &::-ms-expand {
       display: none;


### PR DESCRIPTION
## Who is this for?
Design

## What is it doing for them?
Matches Sort and Filters' looks more closely

Before
![Screenshot 2023-02-15 at 11 44 44](https://user-images.githubusercontent.com/110461050/219018842-be0f2990-533c-4809-b7c0-5a74e1cf1f8b.png)


After
![Screenshot 2023-02-15 at 11 44 28](https://user-images.githubusercontent.com/110461050/219018827-13a075da-c432-4a0e-a157-77c99d60d677.png)
