### PR TITLE
Add `position: absolute` to make the pagination button look right on iOS

### DIFF
--- a/common/views/components/Pagination/Pagination.tsx
+++ b/common/views/components/Pagination/Pagination.tsx
@@ -44,6 +44,13 @@ const ChevronWrapper = styled.button<{ prev?: boolean; hasDarkBg?: boolean }>`
   transition: background ${props => props.theme.transitionProperties};
   background-color: transparent;
 
+  // This is required to make the icon be the right size on iOS.  If this class
+  // has 'position: relative', then iOS will give it an incorrect height and
+  // it will appear super small.  Illegible!
+  .icon {
+    position: absolute;
+  }
+
   &[disabled] {
     pointer-events: none;
     color: ${props =>


### PR DESCRIPTION
The rough structure of this icon is:

```html
<ChevronWrapper>                  <!-- defined in Pagination.tsx -->
  <Wrapper className="icon">      <!-- defined in Icon.tsx -->
    <svg class="icon_svg">
      <svg xmlns="http://www.w3.org/2000/svg" …>
```

In the screenshots below, `ChevronWrapper` has a green background and `Wrapper className="icon"` has a yellow background.

Notice how, when `Wrapper className="icon"` has `position: relative`, iOS Safari doesn't size the element correctly relative to the parent, even though it sets explicit `width/height` styles. There are other examples on the web of people having issues with `position: relative` and iOS Safari, e.g. https://stackoverflow.com/q/15407636/1558022

![IMG_3073](https://user-images.githubusercontent.com/301220/219096495-b55d19ad-5f1a-4ee9-82e0-53cb317aa19b.PNG)

I looked at the `SelectContainer` component, which is using the same chevron icon for its dropdown arrow (but rotated through 90 degrees). And inside that component, you find we set `style: absolute` on `Wrapper className="icon"`.

https://github.com/wellcomecollection/wellcomecollection.org/blob/0e3571c541614619c505e665badcd659129582d0/common/views/components/SelectContainer/SelectContainer.tsx#L2

If we add that to `ChevronWrapper` in the pagination component, the button becomes the right size on iOS and is unaffected on other browsers:

![IMG_3074](https://user-images.githubusercontent.com/301220/219096449-083e0ef7-d5af-4114-997d-9fd2c743f676.PNG)

Closes https://github.com/wellcomecollection/wellcomecollection.org/issues/9039