### PR TITLE
Remove some unused properties on the Icon component

### DIFF
--- a/common/views/components/ClearSearch/ClearSearch.tsx
+++ b/common/views/components/ClearSearch/ClearSearch.tsx
@@ -38,7 +38,7 @@ const ClearSearch: FunctionComponent<Props> = ({
       type="button"
       aria-label="clear"
     >
-      <Icon iconColor="black" icon={clear} title="Clear" />
+      <Icon iconColor="black" icon={clear} />
     </Button>
   );
 };

--- a/common/views/components/ClearSearch/ClearSearch.tsx
+++ b/common/views/components/ClearSearch/ClearSearch.tsx
@@ -26,7 +26,7 @@ const ClearSearch: FunctionComponent<Props> = ({
   setValue,
   gaEvent,
   right,
-}: Props) => {
+}) => {
   return (
     <Button
       style={right ? { right: `${right}px` } : undefined}

--- a/common/views/components/Icon/Icon.tsx
+++ b/common/views/components/Icon/Icon.tsx
@@ -57,7 +57,7 @@ const Icon: FunctionComponent<Props> = ({
   matchText,
   title,
   attrs = {},
-}: Props) => (
+}) => (
   <Wrapper
     rotate={rotate}
     iconColor={iconColor}

--- a/common/views/components/Icon/Icon.tsx
+++ b/common/views/components/Icon/Icon.tsx
@@ -46,7 +46,6 @@ type Props = {
   rotate?: number;
   iconColor?: PaletteColor;
   matchText?: boolean;
-  attrs?: { [key: string]: [string] };
 };
 
 const Icon: FunctionComponent<Props> = ({
@@ -54,10 +53,9 @@ const Icon: FunctionComponent<Props> = ({
   rotate,
   iconColor,
   matchText,
-  attrs = {},
 }) => (
   <Wrapper rotate={rotate} iconColor={iconColor} matchText={matchText}>
-    <svg className="icon__svg" aria-hidden="true" {...attrs}>
+    <svg className="icon__svg" aria-hidden="true">
       {/* This type guard is here just in case a string icon makes its way */}
       {/* in via Prismic etc - that shouldn't happen but better safe than sorry. */}
       {typeof icon === 'function' && icon({})}

--- a/common/views/components/Icon/Icon.tsx
+++ b/common/views/components/Icon/Icon.tsx
@@ -46,7 +46,6 @@ type Props = {
   rotate?: number;
   iconColor?: PaletteColor;
   matchText?: boolean;
-  title?: string;
   attrs?: { [key: string]: [string] };
 };
 
@@ -55,23 +54,10 @@ const Icon: FunctionComponent<Props> = ({
   rotate,
   iconColor,
   matchText,
-  title,
   attrs = {},
 }) => (
-  <Wrapper
-    rotate={rotate}
-    iconColor={iconColor}
-    matchText={matchText}
-    aria-hidden={title ? true : undefined}
-  >
-    <svg
-      className="icon__svg"
-      {...(title
-        ? { role: 'img', 'aria-labelledby': `icon-${title}-title` }
-        : { 'aria-hidden': true })}
-      {...attrs}
-    >
-      {title && <title id={`icon-${title}-title`}>{title}</title>}
+  <Wrapper rotate={rotate} iconColor={iconColor} matchText={matchText}>
+    <svg className="icon__svg" aria-hidden="true" {...attrs}>
       {/* This type guard is here just in case a string icon makes its way */}
       {/* in via Prismic etc - that shouldn't happen but better safe than sorry. */}
       {typeof icon === 'function' && icon({})}


### PR DESCRIPTION
This is a small optimisation spotted while working on https://github.com/wellcomecollection/wellcomecollection.org/pull/9293

The individual commit messages explain what's going on with `title` in particular.