### PR TITLE
Tidy up the analytics we send to Segment; lean on the type system more

### DIFF
--- a/catalogue/webapp/pages/images.tsx
+++ b/catalogue/webapp/pages/images.tsx
@@ -214,7 +214,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
         imagesRouteProps: params,
         pageview: {
           name: 'images',
-          properties: images ? { totalResults: images.totalResults } : {},
+          properties: { totalResults: images.totalResults },
         },
       }),
     };

--- a/catalogue/webapp/pages/search/images.tsx
+++ b/catalogue/webapp/pages/search/images.tsx
@@ -229,11 +229,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
         query,
         pageview: {
           name: 'images',
-          properties: images
-            ? {
-                totalResults: images.totalResults,
-              }
-            : {},
+          properties: { totalResults: images.totalResults },
         },
       }),
     };

--- a/catalogue/webapp/pages/search/index.tsx
+++ b/catalogue/webapp/pages/search/index.tsx
@@ -205,13 +205,15 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     const query = context.query;
     const params = fromQuery(query);
 
+    const pageview: Pageview = {
+      name: 'search',
+      properties: {},
+    };
+
     const defaultProps = removeUndefinedProps({
       serverData,
       query,
-      pageview: {
-        name: 'search',
-        properties: {},
-      },
+      pageview,
     });
 
     try {

--- a/catalogue/webapp/pages/search/works.tsx
+++ b/catalogue/webapp/pages/search/works.tsx
@@ -269,7 +269,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
         query,
         pageview: {
           name: 'works',
-          properties: works ? { totalResults: works.totalResults } : {},
+          properties: { totalResults: works.totalResults },
         },
       }),
     };

--- a/catalogue/webapp/pages/works.tsx
+++ b/catalogue/webapp/pages/works.tsx
@@ -249,7 +249,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
         serverData,
         pageview: {
           name: 'works',
-          properties: works ? { totalResults: works.totalResults } : {},
+          properties: { totalResults: works.totalResults },
         },
       }),
     };

--- a/catalogue/webapp/pages/works/[workId]/items.tsx
+++ b/catalogue/webapp/pages/works/[workId]/items.tsx
@@ -382,7 +382,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       return { notFound: true };
     }
 
-    const pageview = {
+    const pageview: Pageview = {
       name: 'item',
       properties: {},
     };

--- a/common/services/conversion/track.ts
+++ b/common/services/conversion/track.ts
@@ -15,7 +15,6 @@ declare global {
 
 type Page = {
   path: string;
-  pathname: string;
   name: string;
   query: ParsedUrlQuery;
 };
@@ -96,7 +95,6 @@ function trackPageview({
     eventGroup,
     page: {
       path: Router.asPath,
-      pathname: Router.pathname,
       name,
       query,
     },
@@ -116,7 +114,6 @@ function trackSegmentEvent({
     eventGroup,
     page: {
       path: Router.asPath,
-      pathname: Router.pathname,
       name: pageName,
       query: Router.query,
     },

--- a/common/services/conversion/track.ts
+++ b/common/services/conversion/track.ts
@@ -43,8 +43,27 @@ type EventProps = {
   eventGroup?: EventGroup;
 };
 
+// The pageview values are used for monthly/quarterly reporting.
+//
+// This type is an attempt to describe the expectations of those reporting tools;
+// to enforce our "analytics contract" in code.  It isn't set in stone, but it's
+// meant to flag to developers if they make unplanned or unexpected changes --
+// hopefully this will lead to more intentional changes.
+//
+// If you want to change this type, check with our digital analyst (currently Tacey)
+// before you do -- so the change can be coordinated with their reports.
 export type Pageview = {
-  name: string;
+  name:
+    | 'concept'
+    | 'event'
+    | 'exhibition'
+    | 'image'
+    | 'images'
+    | 'item'
+    | 'search'
+    | 'story'
+    | 'work'
+    | 'works';
   properties: Record<string, string[] | number[] | string | number | undefined>;
   eventGroup?: EventGroup;
 };


### PR DESCRIPTION
* I've removed `pathname` as a variable we send to Segment; it's an internal property of our codebase and not something we should be relying on. More detail in the commit message. Closes https://github.com/wellcomecollection/wellcomecollection.org/issues/9240
* I've added a type to check all our values of `pageview.name`, which encodes our analytics expectations in the type system. It's not perfect, but I think it will force us to be more intentional about the changes we make. Closes #9277.