### PR TITLE
Registration tweaks

### DIFF
--- a/identity/webapp/pages/api/registration.test.ts
+++ b/identity/webapp/pages/api/registration.test.ts
@@ -1,11 +1,11 @@
-import { getUserIdFromToken } from './registration';
+import { getDataFromToken } from './registration';
 
-describe('getUserIdFromToken', () => {
+describe('getDataFromToken', () => {
   it('rejects an invalid token', () => {
     const token = 'this_is.not_a.valid_jwt';
     const secret = '123';
 
-    expect(() => getUserIdFromToken(token, secret)).toThrow(
+    expect(() => getDataFromToken(token, secret)).toThrow(
       'Invalid session_token in decode'
     );
   });
@@ -17,37 +17,42 @@ describe('getUserIdFromToken', () => {
       'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ImhlbGxvIHdvcmxkIg.tJ6vz_pS3m2q1sfp1o5VBg0aDLM1-7PMK33SUx7fePQ';
     const secret = '123';
 
-    expect(() => getUserIdFromToken(token, secret)).toThrow(
+    expect(() => getDataFromToken(token, secret)).toThrow(
       'Cannot get user ID from a token with a string payload'
     );
   });
 
-  it('extracts the user ID from a payload', () => {
+  it('extracts the data from a payload', () => {
     // This token was created using https://jwt.io/ with the payload
     //
     //    {
-    //      "sub": "auth0|p1234567"
+    //      "sub": "auth0|p1234567",
+    //      "iss": "wellcome.test"
     //    }
     //
     const token =
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhdXRoMHxwMTIzNDU2NyJ9.3x0oPrTuo4dDe1hOKX_5ARksY26nDtd2P1w7gJm9R2I';
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhdXRoMHxwMTIzNDU2NyIsImlzcyI6IndlbGxjb21lLnRlc3QifQ.wlX8dLxzNlZZ0Lw4ga6rCCpw4L83Z261TKTJTsSdWTU';
     const secret = '123';
 
-    expect(getUserIdFromToken(token, secret)).toBe('1234567');
+    expect(getDataFromToken(token, secret)).toEqual({
+      userId: '1234567',
+      issuer: 'wellcome.test',
+    });
   });
 
   it('rejects a payload with a malformed user ID', () => {
     // This token was created using https://jwt.io/ with the payload
     //
     //    {
-    //      "sub": "not a real user ID"
+    //      "sub": "not a real user id",
+    //      "iss": "wellcome.test"
     //    }
     //
     const token =
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJub3QgYSByZWFsIHVzZXIgSUQifQ.H5ElnFhsN7gi7dEWejxg31ct6OrSxOAMYQUxMxqVmAc';
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJub3QgYSByZWFsIHVzZXIgaWQiLCJpc3MiOiJ3ZWxsY29tZS50ZXN0In0._a6xL2QwbkB367pjJhCWalosXKlz-AFuvOyctp5Jv78';
     const secret = '123';
 
-    expect(() => getUserIdFromToken(token, secret)).toThrow(
+    expect(() => getDataFromToken(token, secret)).toThrow(
       'Cannot get user ID from payload'
     );
   });
@@ -56,15 +61,32 @@ describe('getUserIdFromToken', () => {
     // This token was created using https://jwt.io/ with the payload
     //
     //    {
-    //      "sub": null
+    //      "sub": null,
+    //      "iss": "wellcome.test"
     //    }
     //
     const token =
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOm51bGx9.b9vr1ufzq2J4fhsmtyhSlezJNAIhCL8ZIgVnWV19WBs';
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOm51bGwsImlzcyI6IndlbGxjb21lLnRlc3QifQ.9urMyL3uXHyjn0j3Fjyi99vpaJEeHIJDzrBiEIKKW-I';
     const secret = '123';
 
-    expect(() => getUserIdFromToken(token, secret)).toThrow(
+    expect(() => getDataFromToken(token, secret)).toThrow(
       'Cannot get user ID from payload'
+    );
+  });
+
+  it('rejects a payload with a missing issuer', () => {
+    // This token was created using https://jwt.io/ with the payload
+    //
+    //    {
+    //      "sub": "auth0|p1234567",
+    //    }
+    //
+    const token =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhdXRoMHxwMTIzNDU2NyJ9.3x0oPrTuo4dDe1hOKX_5ARksY26nDtd2P1w7gJm9R2I';
+    const secret = '123';
+
+    expect(() => getDataFromToken(token, secret)).toThrow(
+      'Cannot get issuer from payload'
     );
   });
 });

--- a/identity/webapp/pages/registration.tsx
+++ b/identity/webapp/pages/registration.tsx
@@ -26,7 +26,7 @@ import ButtonSolid, {
   ButtonTypes,
 } from '@weco/common/views/components/ButtonSolid/ButtonSolid';
 import { getServerData } from '@weco/common/server-data';
-import { appError, AppErrorProps } from '@weco/common/services/app';
+import { AppErrorProps } from '@weco/common/services/app';
 import { removeUndefinedProps } from '@weco/common/utils/json';
 import { SimplifiedServerData } from '@weco/common/server-data/types';
 import {
@@ -67,7 +67,15 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     try {
       token = decodeToken(sessionToken, config.auth0.actionSecret);
     } catch (error) {
-      return appError(context, 400, 'Invalid session_token query parameter');
+      // There are non-nefarious reasons this might happen (eg expiry), so we redirect
+      // to login as logging in will give the user a new token.
+      console.error('Error decoding/validating session token', error);
+      return {
+        redirect: {
+          permanent: false,
+          destination: '/api/auth/login',
+        },
+      };
     }
 
     if (typeof token !== 'string') {


### PR DESCRIPTION
Not much to see here - realised that the token is already telling us where to redirect to, so we can use the issuer to construct the redirect URL rather than relying on our "own" information. Kinda twinned with https://github.com/wellcomecollection/identity/pull/393