### PR TITLE
Cleanup search toggles

### DIFF
--- a/catalogue/webapp/pages/search/events.tsx
+++ b/catalogue/webapp/pages/search/events.tsx
@@ -62,12 +62,7 @@ export const getServerSideProps: GetServerSideProps<
   const serverData = await getServerData(context);
   const query = context.query;
 
-  if (
-    !(
-      serverData.toggles.searchPage &&
-      serverData.toggles.searchPageEventsExhibitions
-    )
-  ) {
+  if (!serverData.toggles.searchPageEventsExhibitions) {
     return { notFound: true };
   }
 

--- a/catalogue/webapp/pages/search/exhibitions.tsx
+++ b/catalogue/webapp/pages/search/exhibitions.tsx
@@ -62,12 +62,7 @@ export const getServerSideProps: GetServerSideProps<
   const serverData = await getServerData(context);
   const query = context.query;
 
-  if (
-    !(
-      serverData.toggles.searchPage &&
-      serverData.toggles.searchPageEventsExhibitions
-    )
-  ) {
+  if (!serverData.toggles.searchPageEventsExhibitions) {
     return { notFound: true };
   }
 

--- a/catalogue/webapp/pages/search/images.tsx
+++ b/catalogue/webapp/pages/search/images.tsx
@@ -191,11 +191,6 @@ ImagesSearchPage.getLayout = getSearchLayout;
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
     const serverData = await getServerData(context);
-
-    if (!serverData.toggles.searchPage) {
-      return { notFound: true };
-    }
-
     const query = context.query;
     const params = fromQuery(query);
 

--- a/catalogue/webapp/pages/search/index.tsx
+++ b/catalogue/webapp/pages/search/index.tsx
@@ -197,11 +197,6 @@ SearchPage.getLayout = getSearchLayout;
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
     const serverData = await getServerData(context);
-
-    if (!serverData.toggles.searchPage) {
-      return { notFound: true };
-    }
-
     const query = context.query;
     const params = fromQuery(query);
 

--- a/catalogue/webapp/pages/search/stories.tsx
+++ b/catalogue/webapp/pages/search/stories.tsx
@@ -122,13 +122,7 @@ export const getServerSideProps: GetServerSideProps<
   Record<string, unknown> | AppErrorProps
 > = async context => {
   const serverData = await getServerData(context);
-
-  if (!serverData.toggles.searchPage) {
-    return { notFound: true };
-  }
-
   const query = context.query;
-
   const defaultProps = removeUndefinedProps({
     serverData,
     storyResponseList: { totalResults: 0 },

--- a/catalogue/webapp/pages/search/works.tsx
+++ b/catalogue/webapp/pages/search/works.tsx
@@ -249,11 +249,6 @@ CatalogueSearchPage.getLayout = getSearchLayout;
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
     const serverData = await getServerData(context);
-
-    if (!serverData.toggles.searchPage) {
-      return { notFound: true };
-    }
-
     const query = context.query;
     const params = fromQuery(query);
 

--- a/common/services/conversion/track.ts
+++ b/common/services/conversion/track.ts
@@ -3,7 +3,7 @@ import cookies from '@weco/common/data/cookies';
 import Router from 'next/router';
 import { ParsedUrlQuery } from 'querystring';
 import { v4 as uuidv4 } from 'uuid';
-import { getActiveToggles } from '@weco/common/utils/cookies';
+import { dangerouslyGetEnabledToggles } from '@weco/common/utils/cookies';
 declare global {
   interface Window {
     // Segment.io requires `analytics: any;`
@@ -143,7 +143,7 @@ function trackSegmentEvent({
 function track(conversion: Conversion) {
   const debug = getCookie(cookies.analyticsDebug) === true;
   // We're not in React land here, so we can't use `useToggles`
-  const toggles = getActiveToggles(getCookies());
+  const toggles = dangerouslyGetEnabledToggles(getCookies());
   const sessionId = getSessionId();
   const session: Session = {
     id: sessionId,

--- a/common/utils/cookies.ts
+++ b/common/utils/cookies.ts
@@ -3,7 +3,7 @@
 // output is useful for display purposes (to show someone what they have turned
 // on) as well as for including alongside tracking data, in order to determine
 // e.g. what condition a user was in when performing a task on the site.
-export function getActiveToggles(
+export function dangerouslyGetEnabledToggles(
   cookies: Partial<{ [key: string]: string }>
 ): string[] {
   return Object.entries(cookies)

--- a/common/views/components/ErrorPage/ErrorPage.tsx
+++ b/common/views/components/ErrorPage/ErrorPage.tsx
@@ -22,7 +22,7 @@ import PageLayout from '../PageLayout/PageLayout';
 import SpacingSection from '../SpacingSection/SpacingSection';
 import SpacingComponent from '../SpacingComponent/SpacingComponent';
 import Space from '../styled/Space';
-import { getActiveToggles } from '@weco/common/utils/cookies';
+import { dangerouslyGetEnabledToggles } from '@weco/common/utils/cookies';
 const ToggleMessageBar = styled(Space).attrs({
   h: { size: 'm', properties: ['padding-left', 'padding-right'] },
   v: { size: 's', properties: ['padding-top', 'padding-bottom'] },
@@ -60,7 +60,7 @@ const TogglesMessage: FunctionComponent = () => {
   // useToggles() because we don't have access to the server data context
   // here -- we can't use getServerSideProps on an error page.
   // See https://nextjs.org/docs/messages/404-get-initial-props
-  const toggles = getActiveToggles(getCookies());
+  const toggles = dangerouslyGetEnabledToggles(getCookies());
 
   return toggles.length > 0 ? (
     <Layout8>

--- a/common/views/components/ErrorPage/ErrorPage.tsx
+++ b/common/views/components/ErrorPage/ErrorPage.tsx
@@ -39,7 +39,7 @@ const ToggleMessageBar = styled(Space).attrs({
 
 /** This shows the user a list of toggles they currently have enabled, e.g.
  *
- *      You have the following toggles enabled: apiToolbar, searchPage
+ *      You have the following toggles enabled: apiToolbar, stagingApi
  *
  * Sometimes toggles may cause errors on the site which aren't visible to
  * the public (e.g. the staging API toggle).

--- a/common/views/components/Header/Header.tsx
+++ b/common/views/components/Header/Header.tsx
@@ -1,13 +1,11 @@
 import { FunctionComponent, useEffect, useState } from 'react';
 import FocusTrap from 'focus-trap-react';
 import NextLink from 'next/link';
-import { getCookies } from 'cookies-next';
 
 import { font } from '@weco/common/utils/classnames';
 import WellcomeCollectionBlack from '@weco/common/icons/wellcome_collection_black';
 import { search, cross } from '@weco/common/icons';
 import Icon from '@weco/common/views/components/Icon/Icon';
-import { getActiveToggles } from '@weco/common/utils/cookies';
 import {
   Wrapper,
   GridCell,
@@ -26,6 +24,7 @@ import {
 import DesktopSignIn from './DesktopSignIn';
 import MobileSignIn from './MobileSignIn';
 import HeaderSearch from './HeaderSearch';
+import { useToggles } from '@weco/common/server-data/Context';
 
 export type NavLink = {
   href: string;
@@ -87,9 +86,7 @@ const Header: FunctionComponent<Props> = ({
 }) => {
   const [burgerMenuIsActive, setBurgerMenuIsActive] = useState(false);
   const [searchDropdownIsActive, setSearchDropdownIsActive] = useState(false);
-  const toggles = getActiveToggles(getCookies());
-
-  const isSearchToggleActive = toggles?.includes('globalSearchHeader');
+  const { globalSearchHeader } = useToggles();
 
   useEffect(() => {
     if (document && document.documentElement) {
@@ -131,7 +128,7 @@ const Header: FunctionComponent<Props> = ({
                   <span />
                 </BurgerTrigger>
               </Burger>
-              <HeaderBrand isSearchToggleActive={isSearchToggleActive}>
+              <HeaderBrand isSearchToggleActive={globalSearchHeader}>
                 <a href="/">
                   <WellcomeCollectionBlack />
                 </a>
@@ -161,7 +158,7 @@ const Header: FunctionComponent<Props> = ({
                 </HeaderNav>
 
                 <HeaderActions>
-                  {isSearchToggleActive && (
+                  {globalSearchHeader && (
                     <NextLink href="/search" passHref>
                       <SearchButton
                         text={

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -52,13 +52,6 @@ const toggles = {
         'Takes the comics out of the general set of stories, and moves them to their own page section, grouped by series.',
     },
     {
-      id: 'searchPage',
-      title: 'Search page',
-      initialValue: true,
-      description:
-        'New search page to help develop new components and functionalities',
-    },
-    {
       id: 'searchPageEventsExhibitions',
       title: 'Search page: Events & Exhibitions',
       initialValue: false,


### PR DESCRIPTION
## Who is this for?
Users who want to search + maintenance

## What is it doing for them?
- We were using the wrong function to check if the toggle was active. So
-- We changed that to use `useToggles()` as we should
-- Renamed the other function to signal we should think twice before using it
- Also cleaned up `searchPage` toggle as we probably won't completely hide it again (using redirect changes instead to "rollback")