### PR TITLE
Add a note if images are no-tzitzit because copyright

### DIFF
--- a/common/views/components/ApiToolbar/index.tsx
+++ b/common/views/components/ApiToolbar/index.tsx
@@ -49,8 +49,13 @@ export function setTzitzitParams({
 }): ApiToolbarLink | undefined {
   const licenceId = licence?.id.toUpperCase();
 
-  // We should not be using in copyright images in Stories
-  if (licenceId === 'INC') return;
+  // We should not be using in copyright images in Stories.
+  // TODO: Double check this is our policy with the Editorial team.
+  if (licenceId === 'INC')
+    return {
+      id: 'tzitzit',
+      label: '(no tzitzit, this image is in copyright)',
+    };
 
   const params = new URLSearchParams();
   params.set('title', title);


### PR DESCRIPTION
This will make it clearer what's going on, and avoid people thinking the tzitzit button is toggled off or broken for some other reason.

I think this was a decision made by devs at some point, and tzitzit itself doesn't support creating attribution strings for in-copyright images -- we may need to tweak this.

See https://wellcome.slack.com/archives/C8X9YKM5X/p1676638166994149