### PR TITLE
Always render PopupDialog in Cardigan

### DIFF
--- a/cardigan/stories/components/PopupDialog/PopupDialog.stories.tsx
+++ b/cardigan/stories/components/PopupDialog/PopupDialog.stories.tsx
@@ -1,22 +1,24 @@
 import PopupDialog from '@weco/common/views/components/PopupDialog/PopupDialog';
-import { emptyPopupDialog } from '@weco/common/services/prismic/documents';
 import Readme from '@weco/common/views/components/PopupDialog/README.md';
 import { ReadmeDecorator } from '@weco/cardigan/config/decorators';
 
-const Template = () => (
-  <ReadmeDecorator
-    WrappedComponent={PopupDialog}
-    args={{ document: emptyPopupDialog() }}
-    Readme={Readme}
-  />
+const Template = args => (
+  <ReadmeDecorator WrappedComponent={PopupDialog} args={args} Readme={Readme} />
 );
 export const basic = Template.bind({});
 basic.args = {
-  openButtonText: 'Got five minutes?',
-  linkText: 'Take the survey',
-  link: 'https://wellcomecollection.org/user-panel',
-  title: 'Help us improve our website',
-  dialogText:
-    'We’d like to know more about how you use Wellcome Collection’s website.',
+  document: {
+    data: {
+      openButtonText: 'Got five minutes?',
+      linkText: 'Take the survey',
+      link: {
+        link_type: 'Web',
+        url: 'https://wellcomecollection.org/user-panel',
+      },
+      title: 'Help us improve our website',
+      dialogText:
+        'We’d like to know more about how you use Wellcome Collection’s website.',
+    },
+  },
 };
 basic.storyName = 'PopupDialog';

--- a/common/views/components/PopupDialog/PopupDialog.tsx
+++ b/common/views/components/PopupDialog/PopupDialog.tsx
@@ -180,7 +180,15 @@ const PopupDialog: FunctionComponent<Props> = ({ document }: Props) => {
   const dialogWindowRef = useRef<HTMLDivElement>(null);
   const { isKeyboard } = useContext(AppContext);
 
+  function hasPersistentState() {
+    const cardiganHosts = ['localhost:9001', 'cardigan.wellcomecollection.org'];
+
+    return cardiganHosts.includes(window.location.host);
+  }
+
   function hidePopupDialog() {
+    if (hasPersistentState()) return;
+
     setCookie(cookies.popupDialog, 'true', {
       path: '/',
       expires: undefined,
@@ -190,7 +198,9 @@ const PopupDialog: FunctionComponent<Props> = ({ document }: Props) => {
   }
 
   useEffect(() => {
-    setShouldRender(!hasCookie(cookies.popupDialog));
+    setShouldRender(
+      hasPersistentState() ? true : !hasCookie(cookies.popupDialog)
+    );
 
     const timer = setTimeout(() => {
       setShouldStartAnimation(true);

--- a/common/views/components/PopupDialog/README.md
+++ b/common/views/components/PopupDialog/README.md
@@ -1,5 +1,7 @@
 ## Purpose
 A way to present a dialog box with a title, description and linked CTA.
 
+It shows up at the bottom-left of the page after a few seconds.
+
 
 [Edit this Readme on GitHub](https://github.com/wellcomecollection/wellcomecollection.org/edit/main/common/views/components/PopupDialog/README.md)


### PR DESCRIPTION
Fixes #9147 

## Who is this for?
People who want to see the PopupDialog in the design system

## What is it doing for them?
- Telling them where it'll appear in the page (in the README)
- Putting the data in the correct format so that text/links render
- Preventing it from being hidden when it is dismissed (as should happen on prod)

<img width="773" alt="image" src="https://user-images.githubusercontent.com/1394592/220614119-7cd6ee54-b9f1-41f3-8d75-e0ea9b0104f7.png">
