### PR TITLE
Allow for undefined promo captions

### DIFF
--- a/catalogue/webapp/services/prismic/transformers/index.ts
+++ b/catalogue/webapp/services/prismic/transformers/index.ts
@@ -39,7 +39,7 @@ export async function transformPrismicResponse(
       firstPublicationDate,
       contributors: allContributors,
       type,
-      summary: image?.caption[0].text,
+      summary: image?.caption ? image.caption[0].text : undefined,
       label:
         isArticle && format?._meta
           ? { text: articleIdToLabel(format._meta.id) }

--- a/catalogue/webapp/services/prismic/transformers/index.ts
+++ b/catalogue/webapp/services/prismic/transformers/index.ts
@@ -39,7 +39,7 @@ export async function transformPrismicResponse(
       firstPublicationDate,
       contributors: allContributors,
       type,
-      summary: image?.caption ? image.caption[0].text : undefined,
+      summary: image.caption?.[0].text,
       label:
         isArticle && format?._meta
           ? { text: articleIdToLabel(format._meta.id) }


### PR DESCRIPTION
## Who is this for?
Search

## What is it doing for them?
Doesn't break the page when people find a result that doesn't have a promo caption.

This follows the model currently in use in `/stories`


Closes #9346 