### PR TITLE
Use image-search-results-container for small gallery image search results

### DIFF
--- a/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
+++ b/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
@@ -149,7 +149,10 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
       )}
 
       {(!isFullSupportBrowser || isSmallGallery) && (
-        <ImageCardList data-test-id="search-results-container" role="list">
+        <ImageCardList
+          data-test-id="image-search-results-container"
+          role="list"
+        >
           {imagesWithDimensions.map((result: GalleryImageProps) => (
             <li key={result.id} role="listitem">
               <Space


### PR DESCRIPTION
## Who is this for?
People who want tests to pass

## What is it doing for them?
Making the image search results always have the same `data-test-id` regardless of whether it counts as a 'small gallery' or not.