### PR TITLE
Simplify the image list item selector

### DIFF
--- a/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
+++ b/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
@@ -103,7 +103,7 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
     ({ photo, layout }) => {
       const rgbColor = hexToRgb(photo.averageColor || '');
       return (
-        <li data-test-id="image-search-result" style={{ padding: 12 }}>
+        <li style={{ padding: 12 }}>
           <ImageFrame>
             <ImageCard
               id={photo.id}

--- a/playwright/test/new-images-search.test.ts
+++ b/playwright/test/new-images-search.test.ts
@@ -27,7 +27,7 @@ const colourSelectorFilterDropDown = `button[aria-controls="images.color"]`;
 const colourSelector = `button[data-test-id="swatch-green"]`;
 const imageSearchResultsContainer =
   'ul[data-test-id="image-search-results-container"]';
-const imagesResultsListItem = `${imageSearchResultsContainer} li[data-test-id="image-search-result"]`;
+const imagesResultsListItem = `${imageSearchResultsContainer} li`;
 
 const fillActionSearchInput = async (
   value: string,

--- a/playwright/test/search.test.ts
+++ b/playwright/test/search.test.ts
@@ -47,7 +47,7 @@ async function gotoSearchResultPage(
 
 const imageSearchResultsContainer =
   'ul[data-test-id="image-search-results-container"]';
-const imagesResultsListItem = `${imageSearchResultsContainer} li[data-test-id="image-search-result"]`;
+const imagesResultsListItem = `${imageSearchResultsContainer} li`;
 
 const subNavigationContainer = 'div[data-test-id="sub-nav-tab-container"]';
 const catalogueSectionSelector = `${subNavigationContainer} div[data-test-id="works"]`;


### PR DESCRIPTION
☝️ 

Since we're already inside a `data-test-id="image-search-container"`, the list-items are going to be images (so don't require further `data-test-id`s themselves. 