### PR TITLE
Fix the API toolbar tzitzit links; add some Playwright tests

### DIFF
--- a/catalogue/webapp/pages/works/[workId]/images.tsx
+++ b/catalogue/webapp/pages/works/[workId]/images.tsx
@@ -27,9 +27,9 @@ function createTzitzitImageLink(
 ): ApiToolbarLink | undefined {
   return setTzitzitParams({
     title: image.source.title,
-    sourceLink: `/works/${work.id}/images`,
+    sourceLink: `https://wellcomecollection.org/works/${work.id}/images?id=${image.id}`,
     licence: image.locations[0].license,
-    contributors: image.source.contributors,
+    contributors: work.contributors,
   });
 }
 

--- a/catalogue/webapp/pages/works/[workId]/items.tsx
+++ b/catalogue/webapp/pages/works/[workId]/items.tsx
@@ -81,7 +81,7 @@ function createTzitzitWorkLink(work: Work): ApiToolbarLink | undefined {
 
   return setTzitzitParams({
     title: work.title,
-    sourceLink: `/works/${work.id}/items`,
+    sourceLink: `https://wellcomecollection.org/works/${work.id}/items`,
     licence: digitalLocation?.license,
     contributors: work.contributors,
   });

--- a/playwright/test/api-toolbar.test.ts
+++ b/playwright/test/api-toolbar.test.ts
@@ -1,0 +1,52 @@
+import { test as base, expect } from '@playwright/test';
+import { gotoWithoutCache } from './contexts';
+import { baseUrl } from './helpers/urls';
+
+const domain = new URL(baseUrl).host;
+
+const test = base.extend({
+  context: async ({ context }, use) => {
+    await context.addCookies([
+      { name: 'toggle_apiToolbar', value: 'true', domain, path: '/' },
+    ]);
+
+    await use(context);
+  },
+});
+
+test.describe('tzitzit links', () => {
+  test('does not create a tzitzit link for images in copyright', async ({
+    page,
+  }) => {
+    await gotoWithoutCache(`${baseUrl}/works/fedcvz22/items`, page);
+
+    await page.waitForSelector(
+      'li >> text="(no tzitzit, this image is in copyright)"'
+    );
+  });
+
+  test('creates a tzitzit link for item pages', async ({ page }) => {
+    await gotoWithoutCache(`${baseUrl}/works/ccg335hm/items`, page);
+
+    const anchor = await page.waitForSelector('a >> text="tzitzit"');
+    const url = await anchor.getAttribute('href');
+
+    expect(url).toBe(
+      'https://s3-eu-west-1.amazonaws.com/tzitzit.wellcomecollection.org/index.html?title=Fish+schizophrene.&sourceName=Wellcome+Collection&sourceLink=https%3A%2F%2Fwellcomecollection.org%2Fworks%2Fccg335hm%2Fitems&author=Charnley%2C+Bryan%2C+1949-1991'
+    );
+  });
+
+  test('creates a tzitzit link for image pages', async ({ page }) => {
+    await gotoWithoutCache(
+      `${baseUrl}/works/ccg335hm/images?id=srfsqn7t`,
+      page
+    );
+
+    const anchor = await page.waitForSelector('a >> text="tzitzit"');
+    const url = await anchor.getAttribute('href');
+
+    expect(url).toBe(
+      'https://s3-eu-west-1.amazonaws.com/tzitzit.wellcomecollection.org/index.html?title=Fish+schizophrene.&sourceName=Wellcome+Collection&sourceLink=https%3A%2F%2Fwellcomecollection.org%2Fworks%2Fccg335hm%2Fimages%3Fid%3Dsrfsqn7t&licence=CC-BY-NC&author=Charnley%2C+Bryan%2C+1949-1991'
+    );
+  });
+});

--- a/playwright/test/contexts.ts
+++ b/playwright/test/contexts.ts
@@ -6,7 +6,14 @@ export const gotoWithoutCache = async (
   url: string,
   page: Page
 ): Promise<void> => {
-  const requestUrl = `${url}?cachebust=${Date.now()}`;
+  // Check if the URL already has query parameters before adding a cachebust.
+  // We could make this more robust (e.g. checking for fragments), but this is
+  // good enough for now.
+  const requestUrl =
+    url.indexOf('?') === -1
+      ? `${url}?cachebust=${Date.now()}`
+      : `${url}&cachebust=${Date.now()}`;
+
   /*
    * What's going on here?
    * @jamieparkinson 23/06/2022


### PR DESCRIPTION
*   The API toolbar link on /images was linking to /works/[workId]/images,
    but it should be /works/[workId]/images?id=[imageId]
*   Ensure we can test image URLs in Playwright, in particular when we
    add the cachebust parameter
*   Pass the proper contributors to tzitzit URLs on images

Closes https://github.com/wellcomecollection/wellcomecollection.org/issues/9345