### PR TITLE
Return No Result should Prismic return an error

### DIFF
--- a/catalogue/webapp/pages/search/stories.tsx
+++ b/catalogue/webapp/pages/search/stories.tsx
@@ -151,6 +151,29 @@ export const getServerSideProps: GetServerSideProps<
       pageSize: 6,
     });
 
+  if (storyResponseList.type === 'Error') {
+    // Prismic returns Internal Server Errors without much details for certain queries, such as query=t:"PP.PRE.D.1.1"
+    // As this is a temporary search tool until we replace it with our own API, we'll just return No Result should it happen
+    return {
+      props: removeUndefinedProps({
+        ...defaultProps,
+        storyResponseList: {
+          type: 'ResultList',
+          totalResults: 0,
+          totalPages: 0,
+          results: [],
+          pageSize: 6,
+        },
+        pageview: {
+          name: 'stories',
+          properties: {
+            totalResults: 0,
+          },
+        },
+      }),
+    };
+  }
+
   return {
     props: removeUndefinedProps({
       ...defaultProps,

--- a/catalogue/webapp/services/prismic/fetch/articles.ts
+++ b/catalogue/webapp/services/prismic/fetch/articles.ts
@@ -130,22 +130,26 @@ export async function getStories({
       pageSize: number,
       cursor?: string
     ): Promise<PrismicResultsList<Story> | PrismicApiError> => {
-      const res = await prismicGraphQLClient(query, pageSize, cursor);
+      try {
+        const res = await prismicGraphQLClient(query, pageSize, cursor);
+        const { allArticless } = await res;
+        const { edges } = allArticless;
 
-      const { allArticless } = await res;
-      const { edges } = allArticless;
+        const stories = await transformPrismicResponse(edges);
 
-      const stories = await transformPrismicResponse(edges);
-
-      return {
-        type: 'ResultList',
-        totalResults: allArticless.totalCount,
-        totalPages: Math.ceil(allArticless.totalCount / pageSize),
-        results: stories,
-        pageSize: pageSize,
-        prevPage: null,
-        nextPage: null,
-      };
+        return {
+          type: 'ResultList',
+          totalResults: allArticless.totalCount,
+          totalPages: Math.ceil(allArticless.totalCount / pageSize),
+          results: stories,
+          pageSize: pageSize,
+          prevPage: null,
+          nextPage: null,
+        };
+      } catch (error) {
+        console.log(error.response.errors);
+        return prismicApiError();
+      }
     };
 
     // To work with existing pagination component we paginate with query.page
@@ -156,7 +160,7 @@ export async function getStories({
     }
     return fetchStories(query, pageSize);
   } catch (error) {
-    console.log(error);
+    console.log({ error });
     return prismicApiError();
   }
 }

--- a/catalogue/webapp/services/prismic/fetch/articles.ts
+++ b/catalogue/webapp/services/prismic/fetch/articles.ts
@@ -160,7 +160,7 @@ export async function getStories({
     }
     return fetchStories(query, pageSize);
   } catch (error) {
-    console.log({ error });
+    console.log(error);
     return prismicApiError();
   }
 }


### PR DESCRIPTION
## Who is this for?
Users

## What is it doing for them?
We're getting errors on certain queries (like https://wellcomecollection.org/search?query=t%3A%22PP.PRE.D.1.1%09%22)
We aren't handling them much at all + Prismic are not giving us much detail as to what's wrong/how to change our query, just getting `Internal Server Error`. So until we use our own API, we'll just return no result should this happen.