### PR TITLE
Fix global event listener toggle

### DIFF
--- a/common/views/components/Header/Header.tsx
+++ b/common/views/components/Header/Header.tsx
@@ -190,7 +190,7 @@ const Header: FunctionComponent<Props> = ({
 
         <HeaderSearch
           isActive={searchDropdownIsActive}
-          setIsActive={setSearchDropdownIsActive}
+          handleCloseModal={() => setSearchDropdownIsActive(false)}
         />
       </div>
     </FocusTrap>

--- a/common/views/components/Header/Header.tsx
+++ b/common/views/components/Header/Header.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, useEffect, useState } from 'react';
+import { FunctionComponent, useEffect, useRef, useState } from 'react';
 import FocusTrap from 'focus-trap-react';
 import NextLink from 'next/link';
 
@@ -87,6 +87,7 @@ const Header: FunctionComponent<Props> = ({
   const [burgerMenuIsActive, setBurgerMenuIsActive] = useState(false);
   const [searchDropdownIsActive, setSearchDropdownIsActive] = useState(false);
   const { globalSearchHeader } = useToggles();
+  const searchButtonRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     if (document && document.documentElement) {
@@ -177,6 +178,7 @@ const Header: FunctionComponent<Props> = ({
                             currentState => !currentState
                           );
                         }}
+                        ref={searchButtonRef}
                       />
                     </NextLink>
                   )}
@@ -191,6 +193,7 @@ const Header: FunctionComponent<Props> = ({
         <HeaderSearch
           isActive={searchDropdownIsActive}
           handleCloseModal={() => setSearchDropdownIsActive(false)}
+          searchButtonRef={searchButtonRef}
         />
       </div>
     </FocusTrap>

--- a/common/views/components/Header/HeaderSearch.tsx
+++ b/common/views/components/Header/HeaderSearch.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { useRouter } from 'next/router';
 import { classNames } from '@weco/common/utils/classnames';
@@ -30,37 +30,30 @@ const SearchBarWrapper = styled(Space).attrs({
 
 type Props = {
   isActive: boolean;
-  setIsActive: Dispatch<SetStateAction<boolean>>;
+  handleCloseModal: () => void;
 };
 
-const HeaderSearch = ({ isActive, setIsActive }: Props) => {
+const HeaderSearch = ({ isActive, handleCloseModal }: Props) => {
   const router = useRouter();
   const routerQuery = getQueryPropertyValue(router?.query?.query);
   const [inputValue, setInputValue] = useState(routerQuery || '');
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const handleClick = () => setIsActive(false);
-
   useEffect(() => {
-    setIsActive(false);
+    handleCloseModal();
     setInputValue('');
   }, [router?.pathname, router?.query]);
 
   useEffect(() => {
     if (isActive) {
       inputRef?.current?.focus();
-
-      document.addEventListener('click', handleClick);
-      return () => {
-        document.removeEventListener('click', handleClick);
-      };
     }
   }, [isActive]);
 
   useEffect(() => {
     function handleEscapeKey(event: KeyboardEvent) {
       if (event.code === 'Escape') {
-        setIsActive(false);
+        handleCloseModal();
       }
     }
 


### PR DESCRIPTION
## Who is this for?
everyone that is looking at the global search bar

## What is it doing for them?
explicitly looking at how event listeners have changed now.
it would appear that during the update, there will be a need to evaluate _how_ we toggle certain phases, the main issue that I saw with this, was that the button to cause the toggle was included in the elements that are valid for closing the toggle.

This was exposed in reacts anti-side effect change.


So the logic in the useEffect states, 
if the document is clicked (current element is excluded from calculations), check if the global search is currently displayed, then check to see if the button clicked was the toggle button, if so... ignore it (so that we don't have the toggle logic run twice, the toggle is controlled by the header), if anything else is clicked (once again, not the toggle button, that has it's logic controlled in another file, and not the component we are inside of...) close the modal.


this is different from, for example, the dropdown button component that we have, because the dropdown button itself is a trigger, and the menu that pops up, is the child of the button/wrapper element. and as such, the `onBlur` behaviour is much easier than here in the header search, where it has similar behaviour, but the two elements haven't got a parent/child relationship in the DOM

phew, what an adventure.