### PR TITLE
Work out most recent comic series from query for individual comics

### DIFF
--- a/content/webapp/pages/stories/index.tsx
+++ b/content/webapp/pages/stories/index.tsx
@@ -35,7 +35,7 @@ import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
 import { ArticleFormatIds } from '@weco/common/data/content-format-ids';
 import { transformSeriesToSeriesBasic } from '@weco/content/services/prismic/transformers/series';
-import { SeriesBasic } from '@weco/content/types/series';
+import { Series, SeriesBasic } from '@weco/content/types/series';
 import * as prismic from '@prismicio/client';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 
@@ -100,21 +100,15 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     // way we can be confident each of the three series that we have contains at
     // least one comic.
     const comics = transformQuery(comicsQuery, transformArticle);
-    const comicSeriesIds = new Set();
-    const comicSeriesSet = new Set();
 
-    comics.results.forEach(item => {
-      const id = item.series[0].id;
+    const comicSeriesIds = [
+      ...new Set(comics.results.map(item => item.series[0].id)),
+    ].slice(0, 3); // Set limits to unique values, of which we want the first three
 
-      if (comicSeriesSet.size === 3) return;
+    const comicSeries = comicSeriesIds.map(
+      id => comics.results.find(item => item.series[0].id === id)?.series[0]
+    ) as Series[];
 
-      if (!comicSeriesIds.has(id)) {
-        comicSeriesIds.add(id);
-        comicSeriesSet.add(item.series[0]);
-      }
-    });
-
-    const comicSeries = Array.from(comicSeriesSet);
     const basicComicSeries = comicSeries.map(transformSeriesToSeriesBasic);
 
     const jsonLd = articles.results.map(articleLd);

--- a/content/webapp/pages/stories/index.tsx
+++ b/content/webapp/pages/stories/index.tsx
@@ -34,11 +34,7 @@ import { StoriesLandingPrismicDocument } from '@weco/content/services/prismic/ty
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
 import { ArticleFormatIds } from '@weco/common/data/content-format-ids';
-import { fetchSeries } from '@weco/content/services/prismic/fetch/series';
-import {
-  transformSeries,
-  transformSeriesToSeriesBasic,
-} from '@weco/content/services/prismic/transformers/series';
+import { transformSeriesToSeriesBasic } from '@weco/content/services/prismic/transformers/series';
 import { SeriesBasic } from '@weco/content/types/series';
 import * as prismic from '@prismicio/client';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
@@ -80,35 +76,49 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
         : undefined,
     });
 
-    const storiesLandingPromise = fetchStoriesLanding(client);
-
-    const comicSeriesPromise = fetchSeries(client, {
+    const comicsQueryPromise = fetchArticles(client, {
+      pageSize: 100, // we need enough comics to make sure we have at least one from three different series
       predicates: prismic.predicate.at(
-        'my.series.format',
+        'my.articles.format',
         ArticleFormatIds.Comic
       ),
-      pageSize: 3,
-      orderings: {
-        field: 'document.first_publication_date',
-        direction: 'desc',
-      },
     });
 
-    const [articlesQuery, storiesLandingDoc, comicSeriesQuery] =
-      await Promise.all([
-        articlesQueryPromise,
-        storiesLandingPromise,
-        comicSeriesPromise,
-      ]);
+    const storiesLandingPromise = fetchStoriesLanding(client);
+
+    const [articlesQuery, storiesLandingDoc, comicsQuery] = await Promise.all([
+      articlesQueryPromise,
+      storiesLandingPromise,
+      comicsQueryPromise,
+    ]);
 
     const articles = transformQuery(articlesQuery, transformArticle);
+
+    // In order to avoid the case where we end up with an empty comic series,
+    // rather than querying for the series itself we query for the individual
+    // comics, then group them by series and stop once we've got to three. That
+    // way we can be confident each of the three series that we have contains at
+    // least one comic.
+    const comics = transformQuery(comicsQuery, transformArticle);
+    const comicSeriesIds = new Set();
+    const comicSeriesSet = new Set();
+
+    comics.results.forEach(item => {
+      const id = item.series[0].id;
+
+      if (comicSeriesSet.size === 3) return;
+
+      if (!comicSeriesIds.has(id)) {
+        comicSeriesIds.add(id);
+        comicSeriesSet.add(item.series[0]);
+      }
+    });
+
+    const comicSeries = Array.from(comicSeriesSet);
+    const basicComicSeries = comicSeries.map(transformSeriesToSeriesBasic);
+
     const jsonLd = articles.results.map(articleLd);
     const basicArticles = articles.results.map(transformArticleToArticleBasic);
-    const comicSeries = transformQuery(comicSeriesQuery, transformSeries);
-    const basicComicSeries = comicSeries.results.map(
-      transformSeriesToSeriesBasic
-    );
-
     const storiesLanding =
       storiesLandingDoc &&
       transformStoriesLanding(


### PR DESCRIPTION
☝️

We query for the 100 most recent comic articles, group them by series id and stop when we get three, then (since the comic series is attached to the comic article) we display the three most recent comic series _which are guaranteed to have at least one article_ on the stories landing page.

This removes the flakey requirement for the editorial team to add a `delist` tag to comic series when they don't yet contain any comics.

