### PR TITLE
limit the toggle data we send to GA4

### DIFF
--- a/common/services/app/google-analytics.tsx
+++ b/common/services/app/google-analytics.tsx
@@ -27,13 +27,24 @@ export const Ga4DataLayer: FunctionComponent<Props> = ({ data }) => {
   const partOf = data.gaDimensions?.partOf?.length
     ? data.gaDimensions.partOf.join(',')
     : null;
+
+  // We send toggles as an event parameter to GA4 so we can determine the condition in which a particular event took place.
+  // GA4 now limits event parameter values to 100 characters: https://support.google.com/analytics/answer/9267744?hl=en,
+  // so instead of sending the whole toggles JSON blob we send a concatenated string of only the toggles that are turned on. We also remove toggles we know we don't care about.
+  const togglesToIgnore = ['stagingApi', 'apiToolbar', 'disableRequesting'];
+  const toggles = Object.keys(data.toggles)
+    .filter(toggle => {
+      return Boolean(data.toggles[toggle]) && !togglesToIgnore.includes(toggle);
+    })
+    .join('');
+
   return (
     <script
       dangerouslySetInnerHTML={{
         __html: `
         window.dataLayer = window.dataLayer || [];
         window.dataLayer.push({
-          'toggles': '${JSON.stringify(data.toggles)}',
+          'toggles': '${toggles}',
           ${partOf ? `'partOf': '${partOf}'` : ''}});`,
       }}
     />

--- a/common/services/app/google-analytics.tsx
+++ b/common/services/app/google-analytics.tsx
@@ -23,6 +23,8 @@ type Props = {
   };
 };
 
+const togglesGaCanIgnore = ['stagingApi', 'apiToolbar', 'disableRequesting'];
+
 export const Ga4DataLayer: FunctionComponent<Props> = ({ data }) => {
   const partOf = data.gaDimensions?.partOf?.length
     ? data.gaDimensions.partOf.join(',')
@@ -31,12 +33,14 @@ export const Ga4DataLayer: FunctionComponent<Props> = ({ data }) => {
   // We send toggles as an event parameter to GA4 so we can determine the condition in which a particular event took place.
   // GA4 now limits event parameter values to 100 characters: https://support.google.com/analytics/answer/9267744?hl=en,
   // so instead of sending the whole toggles JSON blob we send a concatenated string of only the toggles that are turned on. We also remove toggles we know we don't care about.
-  const togglesToIgnore = ['stagingApi', 'apiToolbar', 'disableRequesting'];
+
   const toggles = Object.keys(data.toggles)
     .filter(toggle => {
-      return Boolean(data.toggles[toggle]) && !togglesToIgnore.includes(toggle);
+      return (
+        Boolean(data.toggles[toggle]) && !togglesGaCanIgnore.includes(toggle)
+      );
     })
-    .join('');
+    .join(',');
 
   return (
     <script


### PR DESCRIPTION
Relates to #9224

We used to send the toggles JSON blob to Universal Analytics and I replicated this behaviour for GA4. However, It turns out [GA4 now limits event parameter values to 100 characters](https://support.google.com/analytics/answer/9267744?hl=en) and so the value is being truncated.

This PR changes the event parameter value to a concatenated string of only the toggles we care about, i.e. those we may want to use for A/B tests whose values are true.

N.B. There is a danger we may still end up sending strings that are too long, so I'm going to update the toggle deployment script to warn if this is the case.

This isn't ideal but I think it is a practical solution, as we should never have too many toggles operating at once and this will encourage us to remove outdated ones.
