### PR TITLE
prevent hydration error

### DIFF
--- a/common/views/components/ErrorPage/ErrorPage.tsx
+++ b/common/views/components/ErrorPage/ErrorPage.tsx
@@ -1,4 +1,4 @@
-import { Fragment, FunctionComponent } from 'react';
+import { Fragment, FunctionComponent, useState, useEffect } from 'react';
 
 // Helpers/Utils
 import { isNotUndefined } from '../../../utils/array';
@@ -60,7 +60,11 @@ const TogglesMessage: FunctionComponent = () => {
   // useToggles() because we don't have access to the server data context
   // here -- we can't use getServerSideProps on an error page.
   // See https://nextjs.org/docs/messages/404-get-initial-props
-  const toggles = dangerouslyGetEnabledToggles(getCookies());
+  const [toggles, setToggles] = useState<string[]>([]);
+
+  useEffect(() => {
+    setToggles(dangerouslyGetEnabledToggles(getCookies()));
+  }, []);
 
   return toggles.length > 0 ? (
     <Layout8>


### PR DESCRIPTION
## Who is this for?

People who don't want to see errors on the 404 page

## What is it doing for them?

Stopping this from happening:
<img width="846" alt="Screenshot 2023-03-02 at 17 26 01" src="https://user-images.githubusercontent.com/6051896/222505616-f07b3243-ec84-4cac-8dbf-067aa483d5be.png">

