### PR TITLE
Nojs footer

### DIFF
--- a/common/views/components/Header/Header.tsx
+++ b/common/views/components/Header/Header.tsx
@@ -123,6 +123,8 @@ const Header: FunctionComponent<Props> = ({
               <Burger>
                 <BurgerTrigger
                   burgerMenuisActive={burgerMenuIsActive}
+                  // We only add the link to the footer nav when javascript is not available
+                  // The footer nav is always available in that scenario, but not necessarily when javascript is enabled
                   href={isEnhanced ? '/' : '#footer-nav-1'}
                   id="header-burger-trigger"
                   aria-label="menu"

--- a/common/views/components/Header/Header.tsx
+++ b/common/views/components/Header/Header.tsx
@@ -1,4 +1,10 @@
-import { FunctionComponent, useEffect, useRef, useState } from 'react';
+import {
+  FunctionComponent,
+  useEffect,
+  useRef,
+  useState,
+  useContext,
+} from 'react';
 import FocusTrap from 'focus-trap-react';
 import NextLink from 'next/link';
 
@@ -24,6 +30,7 @@ import {
 import DesktopSignIn from './DesktopSignIn';
 import MobileSignIn from './MobileSignIn';
 import HeaderSearch from './HeaderSearch';
+import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
 
 export type NavLink = {
   href: string;
@@ -87,6 +94,7 @@ const Header: FunctionComponent<Props> = ({
   const [burgerMenuIsActive, setBurgerMenuIsActive] = useState(false);
   const [searchDropdownIsActive, setSearchDropdownIsActive] = useState(false);
   const searchButtonRef = useRef<HTMLButtonElement>(null);
+  const { isEnhanced } = useContext(AppContext);
 
   useEffect(() => {
     if (document && document.documentElement) {
@@ -115,7 +123,7 @@ const Header: FunctionComponent<Props> = ({
               <Burger>
                 <BurgerTrigger
                   burgerMenuisActive={burgerMenuIsActive}
-                  href="#footer-nav-1"
+                  href={isEnhanced ? '/' : '#footer-nav-1'}
                   id="header-burger-trigger"
                   aria-label="menu"
                   onClick={event => {

--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -334,6 +334,11 @@ const PageLayoutComponent: FunctionComponent<Props> = ({
             <NewsletterPromo />
           </Space>
         )}
+        {/* The no javascript version of the burger menu relies on the footer being present on the page,
+        as we then use an anchor link to take people to the navigation links in the footer.
+        Instead of completely removing the footer when we don't want it, we wrap it in a noscript tag,
+        so teh degraded experience still works.
+        */}
         <ConditionalWrapper
           condition={Boolean(hideFooter)}
           wrapper={children => <noscript>{children}</noscript>}

--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -26,6 +26,7 @@ import { getCrop, ImageType } from '@weco/common/model/image';
 import { convertImageUri } from '@weco/common/utils/convert-image-uri';
 import cookies from '@weco/common/data/cookies';
 import { isNotUndefined } from '@weco/common/utils/array';
+import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper/ConditionalWrapper';
 
 export type SiteSection =
   | 'collections'
@@ -333,7 +334,12 @@ const PageLayoutComponent: FunctionComponent<Props> = ({
             <NewsletterPromo />
           </Space>
         )}
-        {!hideFooter && <Footer venues={venues} />}
+        <ConditionalWrapper
+          condition={Boolean(hideFooter)}
+          wrapper={children => <noscript>{children}</noscript>}
+        >
+          <Footer venues={venues} />
+        </ConditionalWrapper>
       </div>
     </>
   );


### PR DESCRIPTION
Fixes #8717

The no javascript version of the burger menu relies on the footer being present on the page, as we then use an anchor link to take people to the navigation links in the footer.

This is a problem on certain pages where we remove the footer, e.g. exhibition guide and item pages.

Instead of removing the footer completely on these pages I've wrapped it in a noscript tag, so it is still available in the no javascript scenario.

I've also pointed the link to "/" instead of the footer nav, when javascript is available, to stop pa11y complaining that the named anchor doesn't exist.
