### PR TITLE
Remove manual charset meta tag

### DIFF
--- a/common/views/pages/_document.tsx
+++ b/common/views/pages/_document.tsx
@@ -78,10 +78,6 @@ class WecoDoc extends Document<DocumentInitialPropsWithTogglesAndGa> {
     return (
       <Html lang="en" className="is-keyboard">
         <Head>
-          {/* W3C standard: The element containing the character encoding declaration
-          must be serialized completely within the first 1024 bytes of the document.
-          It has to be declared here as Next dynamically adds other elements to the Head */}
-          <meta charSet="utf-8" />
           {/* Adding toggles etc. to the datalayer so they are available to events in Google Tag Manager */}
           <Ga4DataLayer
             data={{


### PR DESCRIPTION
Fixes #9321

We [manually added a charset meta tag](https://github.com/wellcomecollection/wellcomecollection.org/pull/9105) to ensure it occurred in the first 1024 bytes of the document, in order to be valid html.

[Next.js now places this tag at the top of <Head /> itself](https://github.com/vercel/next.js/issues/26534#issuecomment-1031008721), so this is no longer necessary.

I've confirmed this works locally with the manual tag removed:
<img width="681" alt="Screenshot 2023-03-03 at 13 56 12" src="https://user-images.githubusercontent.com/6051896/222739928-5dd68d2b-b2de-4495-aee4-e19dd9cb37ce.png">
