### PR TITLE
Remove unused css

### DIFF
--- a/catalogue/webapp/components/IIIFImage/IIIFImage.tsx
+++ b/catalogue/webapp/components/IIIFImage/IIIFImage.tsx
@@ -16,8 +16,6 @@ import {
 const StyledImage = styled(Image)<{ background: string }>`
   background-color: ${props => props.background};
   color: ${props => props.theme.color('neutral.700')};
-  maxwidth: 100%;
-  height: auto;
 `;
 
 const StyledImageContainer = styled.div<{


### PR DESCRIPTION
## Who is this for?
maintenance

## What is it doing for them?
Noticed a typo in `maxwidth` and while fixing, I noticed it didn't seem required. It was added [here to account for changes to Next Image](https://github.com/wellcomecollection/wellcomecollection.org/pull/9280/files#diff-eaffb8859af039e0029ba83905edfb31490e0f82267388453ccc5115f131dd9fR19), but `img` has `height: auto` already so that was a double. I tested in the image gallery and it didn't seem like required styling, so am removing.