### PR TITLE
Conditionally show available online section

### DIFF
--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -163,7 +163,8 @@ const WorkDetails: FunctionComponent<Props> = ({
   const holdings = getHoldings(work);
 
   const showAvailableOnlineSection =
-    digitalLocation && (shouldShowItemLink || audio || video);
+    digitalLocation &&
+    (shouldShowItemLink || (audio?.sounds || []).length > 0 || video);
 
   const renderWhereToFindIt = () => {
     return (


### PR DESCRIPTION
We should be conditionally showing the available online section, but the check for audio was always returning true.

At some point the value of audio changed so we now need to check the length of the sounds property it contains.
