### PR TITLE
Remove isFilter styling workaround

### DIFF
--- a/common/views/components/DropdownButton/DropdownButton.tsx
+++ b/common/views/components/DropdownButton/DropdownButton.tsx
@@ -85,7 +85,6 @@ type Props = {
   isOnDark?: boolean;
   iconLeft?: IconSvg;
   isPill?: boolean;
-  isFilter?: boolean; // TODO This is a styling workaround for the /works & /images search, remove once we delete those pages.
   hasNoOptions?: boolean;
 };
 
@@ -97,7 +96,6 @@ const DropdownButton: FunctionComponent<Props> = ({
   id,
   iconLeft,
   isPill,
-  isFilter,
   hasNoOptions,
 }) => {
   const [isActive, setIsActive] = useState(false);
@@ -176,8 +174,6 @@ const DropdownButton: FunctionComponent<Props> = ({
           colors={
             isOnDark
               ? themeValues.buttonColors.whiteTransparentWhite
-              : isFilter
-              ? themeValues.buttonColors.whiteWhiteCharcoal
               : themeValues.buttonColors.marbleWhiteCharcoal
           }
         />

--- a/common/views/components/SearchFilters/SearchFilters.Desktop.CheckboxFilter.tsx
+++ b/common/views/components/SearchFilters/SearchFilters.Desktop.CheckboxFilter.tsx
@@ -24,7 +24,6 @@ const CheckboxFilter = ({
   return (
     <DropdownButton
       isPill={isNewStyle}
-      isFilter
       label={f.label}
       buttonType="inline"
       id={f.id}

--- a/common/views/components/SearchFilters/SearchFilters.Desktop.ColorFilter.tsx
+++ b/common/views/components/SearchFilters/SearchFilters.Desktop.ColorFilter.tsx
@@ -18,7 +18,6 @@ const DesktopColorFilter = ({
   return (
     <DropdownButton
       isPill={isNewStyle}
-      isFilter
       label="Colours"
       buttonType="inline"
       id="images.color"

--- a/common/views/components/SearchFilters/SearchFilters.Desktop.DateRangeFilter.tsx
+++ b/common/views/components/SearchFilters/SearchFilters.Desktop.DateRangeFilter.tsx
@@ -21,7 +21,6 @@ const DesktopDateRangeFilter = ({
     <Space className={font('intr', 5)}>
       <DropdownButton
         isPill={isNewStyle}
-        isFilter
         label={f.label}
         buttonType="inline"
         id={f.id}


### PR DESCRIPTION
## Who is this for?
Maintenance

## What is it doing for them?
This was a styling hack for the filters on `/works` and `/images`. Now these have been deleted, we can simplify this code.