### PR TITLE
Use superjson serialize instead of stringify

### DIFF
--- a/content/webapp/pages/api/multi-content/index.ts
+++ b/content/webapp/pages/api/multi-content/index.ts
@@ -27,8 +27,6 @@ export default async (
 
   if (query) {
     const multiContent = transformQuery(query, transformMultiContent);
-
-    console.log(superjson.serialize(multiContent));
     return res.status(200).json(superjson.serialize(multiContent));
   }
 };


### PR DESCRIPTION
## Who is this for?
People who want press releases to display ([Slack thread](https://wellcome.slack.com/archives/C8X9YKM5X/p1678096963134169))

## What is it doing for them?
Making sure the json is good for the asyncSearchResults

This was working as we had it up until two weeks ago (as seen on waybackmachine). Perhaps the upgrade to Next13 broke our implementation. In any event, I think this is cleaner (doesn't require messing with the underlying types), and we should probably update our other api routes using superjson to use `serialize` instead of `stringify`. 