### PR TITLE
Use serialize instead of stringify from superjson

### DIFF
--- a/content/webapp/pages/api/events/index.ts
+++ b/content/webapp/pages/api/events/index.ts
@@ -6,11 +6,9 @@ import { transformEventBasic } from '@weco/content/services/prismic/transformers
 import { transformQuery } from '@weco/content/services/prismic/transformers/paginated-results';
 import superjson from 'superjson';
 
-type NotFound = { notFound: true };
-
 export default async (
   req: NextApiRequest,
-  res: NextApiResponse<string | NotFound>
+  res: NextApiResponse
 ): Promise<void> => {
   const { params } = req.query;
 
@@ -26,6 +24,6 @@ export default async (
 
   if (query) {
     const events = transformQuery(query, transformEventBasic);
-    return res.status(200).json(superjson.stringify(events));
+    return res.status(200).json(superjson.serialize(events));
   }
 };

--- a/content/webapp/pages/api/exhibitions-related-content/index.ts
+++ b/content/webapp/pages/api/exhibitions-related-content/index.ts
@@ -5,12 +5,9 @@ import { fetchExhibitionRelatedContent } from '@weco/content/services/prismic/fe
 import { transformExhibitionRelatedContent } from '@weco/content/services/prismic/transformers/exhibitions';
 import superjson from 'superjson';
 
-type NotFound = { notFound: true };
-type UserError = { description: string };
-
 export default async (
   req: NextApiRequest,
-  res: NextApiResponse<string | NotFound | UserError>
+  res: NextApiResponse
 ): Promise<void> => {
   const { params } = req.query;
 
@@ -24,7 +21,7 @@ export default async (
 
   if (parsedParams.length === 0) {
     return res.status(200).json(
-      superjson.stringify({
+      superjson.serialize({
         exhibitionOfs: [],
         exhibitionAbouts: [],
       })
@@ -35,7 +32,7 @@ export default async (
 
   if (query) {
     const exhibitions = transformExhibitionRelatedContent(query);
-    return res.status(200).json(superjson.stringify(exhibitions));
+    return res.status(200).json(superjson.serialize(exhibitions));
   }
 
   return res.status(404).json({ notFound: true });

--- a/content/webapp/pages/api/exhibitions/index.ts
+++ b/content/webapp/pages/api/exhibitions/index.ts
@@ -5,11 +5,9 @@ import { fetchExhibitions } from '@weco/content/services/prismic/fetch/exhibitio
 import { transformExhibitionsQuery } from '@weco/content/services/prismic/transformers/exhibitions';
 import superjson from 'superjson';
 
-type NotFound = { notFound: true };
-
 export default async (
   req: NextApiRequest,
-  res: NextApiResponse<string | NotFound>
+  res: NextApiResponse
 ): Promise<void> => {
   const { params } = req.query;
 
@@ -25,6 +23,6 @@ export default async (
 
   if (query) {
     const exhibitions = transformExhibitionsQuery(query);
-    return res.status(200).json(superjson.stringify(exhibitions));
+    return res.status(200).json(superjson.serialize(exhibitions));
   }
 };


### PR DESCRIPTION
☝️ 

After #9391 because our current api route implementation using `superjson` (which enables serialization/deserialization of, among other things, `Dates`) has stopped working recently.