### PR TITLE
Add API toolbar links for catalogue API queries in the new search

### DIFF
--- a/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
+++ b/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
@@ -264,19 +264,13 @@ const SearchLayout: FunctionComponent<{
   );
 };
 
-export const getSearchLayout = (page: ReactElement): JSX.Element => {
-  const { searchPageEventsExhibitions } = page.props.serverData.toggles;
-
-  console.log(page.props.apiToolbarLinks);
-
-  return (
-    <SearchLayout
-      hasEventsExhibitions={searchPageEventsExhibitions}
-      apiToolbarLinks={page.props.apiToolbarLinks}
-    >
-      {page}
-    </SearchLayout>
-  );
-};
+export const getSearchLayout = (page: ReactElement): JSX.Element => (
+  <SearchLayout
+    hasEventsExhibitions={page.props.serverData.toggles}
+    apiToolbarLinks={page.props.apiToolbarLinks}
+  >
+    {page}
+  </SearchLayout>
+);
 
 export default SearchLayout;

--- a/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
+++ b/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
@@ -68,7 +68,7 @@ const SearchLayout: FunctionComponent<{ hasEventsExhibitions: boolean }> = ({
   const [pageLayoutMetadata, setPageLayoutMetadata] =
     useState<PageLayoutMetadata>(basePageMetadata);
 
-  const getURL = pathname => {
+  const getURL = (pathname: string) => {
     return convertUrlToString({
       pathname,
       query: { query: queryString },

--- a/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
+++ b/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
@@ -17,6 +17,7 @@ import {
   linkResolver,
 } from '@weco/common/utils/search';
 import { capitalize } from '@weco/common/utils/grammar';
+import { ApiToolbarLink } from '@weco/common/views/components/ApiToolbar';
 
 const SearchBarContainer = styled(Space)`
   ${props => props.theme.media('medium', 'max-width')`
@@ -36,12 +37,13 @@ type PageLayoutMetadata = {
     pathname: string;
     query: Record<string, string | string[] | undefined>;
   };
+  apiToolbarLinks?: ApiToolbarLink[];
 };
 
-const SearchLayout: FunctionComponent<{ hasEventsExhibitions: boolean }> = ({
-  children,
-  hasEventsExhibitions,
-}) => {
+const SearchLayout: FunctionComponent<{
+  hasEventsExhibitions: boolean;
+  apiToolbarLinks: ApiToolbarLink[];
+}> = ({ children, hasEventsExhibitions, apiToolbarLinks }) => {
   const router = useRouter();
   const queryString = getQueryPropertyValue(router?.query?.query);
   const [inputValue, setInputValue] = useState(queryString || '');
@@ -52,6 +54,7 @@ const SearchLayout: FunctionComponent<{ hasEventsExhibitions: boolean }> = ({
       : router.pathname.slice(router.pathname.lastIndexOf('/') + 1);
 
   const basePageMetadata: PageLayoutMetadata = {
+    apiToolbarLinks,
     openGraphType: 'website',
     siteSection: null,
     jsonLd: { '@type': 'WebPage' },
@@ -264,8 +267,13 @@ const SearchLayout: FunctionComponent<{ hasEventsExhibitions: boolean }> = ({
 export const getSearchLayout = (page: ReactElement): JSX.Element => {
   const { searchPageEventsExhibitions } = page.props.serverData.toggles;
 
+  console.log(page.props.apiToolbarLinks);
+
   return (
-    <SearchLayout hasEventsExhibitions={searchPageEventsExhibitions}>
+    <SearchLayout
+      hasEventsExhibitions={searchPageEventsExhibitions}
+      apiToolbarLinks={page.props.apiToolbarLinks}
+    >
       {page}
     </SearchLayout>
   );

--- a/catalogue/webapp/pages/search/images.tsx
+++ b/catalogue/webapp/pages/search/images.tsx
@@ -33,12 +33,14 @@ import { pluralize } from '@weco/common/utils/grammar';
 import { CatalogueResultsList, Image } from '@weco/common/model/catalogue';
 import { NextPageWithLayout } from '@weco/common/views/pages/_app';
 import { Query } from '@weco/catalogue/types/search';
+import { ApiToolbarLink } from '@weco/common/views/components/ApiToolbar';
 
 type Props = {
   images: CatalogueResultsList<Image>;
   imagesRouteProps: ImagesProps;
   query: Query;
   pageview: Pageview;
+  apiToolbarLinks: ApiToolbarLink[];
 };
 
 const Wrapper = styled(Space).attrs<{ hasNoResults: boolean }>(props => ({
@@ -218,6 +220,13 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
           name: 'images',
           properties: { totalResults: images.totalResults },
         },
+        apiToolbarLinks: [
+          {
+            id: 'catalogue-api',
+            label: 'Catalogue API query',
+            link: images._requestUrl,
+          },
+        ],
       }),
     };
   };

--- a/catalogue/webapp/pages/search/works.tsx
+++ b/catalogue/webapp/pages/search/works.tsx
@@ -36,12 +36,14 @@ import { pluralize } from '@weco/common/utils/grammar';
 // Types
 import { CatalogueResultsList, Work } from '@weco/common/model/catalogue';
 import { Query } from '@weco/catalogue/types/search';
+import { ApiToolbarLink } from '@weco/common/views/components/ApiToolbar';
 
 type Props = {
   works: CatalogueResultsList<Work>;
   worksRouteProps: WorksRouteProps;
   query: Query;
   pageview: Pageview;
+  apiToolbarLinks: ApiToolbarLink[];
 };
 
 const SortPaginationWrapper = styled.div`
@@ -277,6 +279,13 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
           name: 'works',
           properties: { totalResults: works.totalResults },
         },
+        apiToolbarLinks: [
+          {
+            id: 'catalogue-api',
+            label: 'Catalogue API query',
+            link: works._requestUrl,
+          },
+        ],
       }),
     };
   };


### PR DESCRIPTION
This allows somebody to jump directly from a search page to the underlying catalogue API query, which is useful for debugging.

This is done with half an eye towards https://github.com/wellcomecollection/wellcomecollection.org/issues/8339 – I suspect some of our queries are passing unnecessary fields in the `include` parameter and getting more data than we need.