### PR TITLE
Tidy up parameter names/iteration order in some date picker code

### DIFF
--- a/catalogue/webapp/components/CalendarSelect/CalendarSelect.tsx
+++ b/catalogue/webapp/components/CalendarSelect/CalendarSelect.tsx
@@ -12,8 +12,8 @@ import {
 } from '@weco/common/utils/format-date';
 
 type Props = {
-  min?: Date;
-  max?: Date;
+  startDate?: Date;
+  endDate?: Date;
   excludedDates: Date[];
   excludedDays: DayOfWeek[];
   chosenDate?: string;
@@ -45,16 +45,17 @@ function getAvailableDates(
 }
 
 const CalendarSelect: FunctionComponent<Props> = ({
-  min,
-  max,
+  startDate,
+  endDate,
   excludedDates,
   excludedDays,
   chosenDate,
   setChosenDate,
 }) => {
-  const canGetDates = min && max;
+  const canGetDates = startDate && endDate;
   const availableDates =
-    canGetDates && getAvailableDates(min, max, excludedDates, excludedDays);
+    canGetDates &&
+    getAvailableDates(startDate, endDate, excludedDates, excludedDays);
 
   return availableDates ? (
     <Select

--- a/catalogue/webapp/components/CalendarSelect/CalendarSelect.tsx
+++ b/catalogue/webapp/components/CalendarSelect/CalendarSelect.tsx
@@ -26,9 +26,7 @@ function getAvailableDates(
   excludedDates: Date[],
   excludedDays: DayOfWeek[]
 ): SelectOption[] {
-  const days = getDatesBetween({ startDate, endDate });
-
-  return days
+  return getDatesBetween({ startDate, endDate })
     .filter(date =>
       isRequestableDate({
         date,

--- a/catalogue/webapp/components/CalendarSelect/CalendarSelect.tsx
+++ b/catalogue/webapp/components/CalendarSelect/CalendarSelect.tsx
@@ -3,7 +3,6 @@ import Select, {
   SelectOption,
 } from '@weco/common/views/components/Select/Select';
 import { isRequestableDate } from '../../utils/dates';
-import { isTruthy } from '@weco/common/utils/array';
 import { getDatesBetween } from '@weco/common/utils/dates';
 import { dateAsValue } from '../ItemRequestModal/format-date';
 import {
@@ -30,21 +29,19 @@ function getAvailableDates(
   const days = getDatesBetween({ start: min, end: max });
 
   return days
-    .map(date => {
-      return (
-        isRequestableDate({
-          date,
-          startDate: min,
-          endDate: max,
-          excludedDates,
-          excludedDays,
-        }) && {
-          value: dateAsValue(date),
-          text: `${formatDayName(date)} ${formatDayMonth(date)}`,
-        }
-      );
-    })
-    .filter(isTruthy);
+    .filter(date =>
+      isRequestableDate({
+        date,
+        startDate: min,
+        endDate: max,
+        excludedDates,
+        excludedDays,
+      })
+    )
+    .map(date => ({
+      value: dateAsValue(date),
+      text: `${formatDayName(date)} ${formatDayMonth(date)}`,
+    }));
 }
 
 const CalendarSelect: FunctionComponent<Props> = ({

--- a/catalogue/webapp/components/CalendarSelect/CalendarSelect.tsx
+++ b/catalogue/webapp/components/CalendarSelect/CalendarSelect.tsx
@@ -52,9 +52,9 @@ const CalendarSelect: FunctionComponent<Props> = ({
   chosenDate,
   setChosenDate,
 }) => {
-  const canGetDates = startDate && endDate;
   const availableDates =
-    canGetDates &&
+    startDate &&
+    endDate &&
     getAvailableDates(startDate, endDate, excludedDates, excludedDays);
 
   return availableDates ? (

--- a/catalogue/webapp/components/CalendarSelect/CalendarSelect.tsx
+++ b/catalogue/webapp/components/CalendarSelect/CalendarSelect.tsx
@@ -26,7 +26,7 @@ function getAvailableDates(
   excludedDates: Date[],
   excludedDays: DayOfWeek[]
 ): SelectOption[] {
-  const days = getDatesBetween({ start: min, end: max });
+  const days = getDatesBetween({ startDate: min, endDate: max });
 
   return days
     .filter(date =>

--- a/catalogue/webapp/components/CalendarSelect/CalendarSelect.tsx
+++ b/catalogue/webapp/components/CalendarSelect/CalendarSelect.tsx
@@ -21,19 +21,19 @@ type Props = {
 };
 
 function getAvailableDates(
-  min: Date,
-  max: Date,
+  startDate: Date,
+  endDate: Date,
   excludedDates: Date[],
   excludedDays: DayOfWeek[]
 ): SelectOption[] {
-  const days = getDatesBetween({ startDate: min, endDate: max });
+  const days = getDatesBetween({ startDate, endDate });
 
   return days
     .filter(date =>
       isRequestableDate({
         date,
-        startDate: min,
-        endDate: max,
+        startDate,
+        endDate,
         excludedDates,
         excludedDays,
       })

--- a/catalogue/webapp/components/RequestingDayPicker/RequestingDayPicker.tsx
+++ b/catalogue/webapp/components/RequestingDayPicker/RequestingDayPicker.tsx
@@ -22,8 +22,8 @@ const RequestingDayPicker: FunctionComponent<Props> = ({
   return (
     <div style={{ position: 'relative' }}>
       <CalendarSelect
-        min={startDate}
-        max={endDate}
+        startDate={startDate}
+        endDate={endDate}
         excludedDates={exceptionalClosedDates}
         excludedDays={regularClosedDays}
         chosenDate={pickUpDate}

--- a/catalogue/webapp/utils/dates.ts
+++ b/catalogue/webapp/utils/dates.ts
@@ -118,7 +118,7 @@ export function includedRegularClosedDays(params: {
 }): number {
   const { startDate, endDate, regularClosedDays } = params;
 
-  const dayArray = getDatesBetween({ start: startDate, end: endDate }).map(d =>
+  const dayArray = getDatesBetween({ startDate, endDate }).map(d =>
     formatDayName(d)
   );
 

--- a/common/services/prismic/opening-times.ts
+++ b/common/services/prismic/opening-times.ts
@@ -161,12 +161,9 @@ export function completeDateRangeForExceptionalPeriods(
 ): ExceptionalPeriod[] {
   return exceptionalOpeningPeriods.map(period => {
     const startDate = period.dates[0];
-    const lastDate = period.dates[period.dates.length - 1];
+    const endDate = period.dates[period.dates.length - 1];
 
-    const completeDateArray = getDatesBetween({
-      start: startDate,
-      end: lastDate,
-    });
+    const completeDateArray = getDatesBetween({ startDate, endDate });
 
     return {
       type: period.type,

--- a/common/utils/array.ts
+++ b/common/utils/array.ts
@@ -2,10 +2,6 @@ export function isNotUndefined<T>(val: T | undefined): val is T {
   return typeof val !== 'undefined';
 }
 
-export function isTruthy<T>(val: T | false | null | undefined): val is T {
-  return typeof val !== 'undefined' && val !== false && val !== null;
-}
-
 export function isUndefined<T>(val: T | undefined): val is T {
   return typeof val === 'undefined';
 }

--- a/common/utils/dates.test.ts
+++ b/common/utils/dates.test.ts
@@ -265,8 +265,8 @@ describe('getNextWeekendDateRange', () => {
 describe('getDatesBetween', () => {
   it('finds the dates between two other dates', () => {
     const result = getDatesBetween({
-      start: new Date('2001-01-01T00:00:00Z'),
-      end: new Date('2001-01-04T00:00:00Z'),
+      startDate: new Date('2001-01-01T00:00:00Z'),
+      endDate: new Date('2001-01-04T00:00:00Z'),
     });
 
     expect(result).toStrictEqual([

--- a/common/utils/dates.ts
+++ b/common/utils/dates.ts
@@ -148,15 +148,15 @@ export function getNextWeekendDateRange(date: Date): DateRange {
  *
  */
 export function getDatesBetween({
-  start,
-  end,
+  startDate,
+  endDate,
 }: {
-  start: Date;
-  end: Date;
+  startDate: Date;
+  endDate: Date;
 }): Date[] {
   const dateArray: Date[] = [];
-  let currentDate = start;
-  while (currentDate <= end) {
+  let currentDate = startDate;
+  while (currentDate <= endDate) {
     dateArray.push(currentDate);
     currentDate = addDays(currentDate, 1);
   }

--- a/content/webapp/components/EventsByMonth/group-event-utils.test.ts
+++ b/content/webapp/components/EventsByMonth/group-event-utils.test.ts
@@ -4,16 +4,16 @@ import { getMonthsInDateRange, groupEventsByMonth } from './group-event-utils';
 describe('getMonthsInDateRange', () => {
   it('finds a single month', () => {
     const result = getMonthsInDateRange({
-      start: new Date('2001-01-01'),
-      end: new Date('2001-01-05'),
+      startDate: new Date('2001-01-01'),
+      endDate: new Date('2001-01-05'),
     });
     expect(result).toEqual([{ year: 2001, month: 'January' }]);
   });
 
   it('finds multiple months', () => {
     const result = getMonthsInDateRange({
-      start: new Date('2001-01-01'),
-      end: new Date('2001-03-06'),
+      startDate: new Date('2001-01-01'),
+      endDate: new Date('2001-03-06'),
     });
     expect(result).toEqual([
       { year: 2001, month: 'January' },
@@ -24,8 +24,8 @@ describe('getMonthsInDateRange', () => {
 
   it('finds months across a year boundary', () => {
     const result = getMonthsInDateRange({
-      start: new Date('2001-12-01'),
-      end: new Date('2002-02-07'),
+      startDate: new Date('2001-12-01'),
+      endDate: new Date('2002-02-07'),
     });
     expect(result).toEqual([
       { year: 2001, month: 'December' },

--- a/content/webapp/components/EventsByMonth/group-event-utils.ts
+++ b/content/webapp/components/EventsByMonth/group-event-utils.ts
@@ -40,20 +40,20 @@ const utcMonthNames = {
  *
  */
 export function getMonthsInDateRange({
-  start,
-  end,
+  startDate,
+  endDate,
 }: {
-  start: Date;
-  end: Date;
+  startDate: Date;
+  endDate: Date;
 }): YearMonth[] {
   console.assert(
-    start <= end,
-    `Asked to find months in date range start=${start}, end=${end}`
+    startDate <= endDate,
+    `Asked to find months in date range start=${startDate}, end=${endDate}`
   );
 
   const result: YearMonth[] = [];
 
-  getDatesBetween({ startDate: start, endDate: end }).forEach(d => {
+  getDatesBetween({ startDate, endDate }).forEach(d => {
     const m = {
       year: d.getUTCFullYear(),
       month: utcMonthNames[d.getUTCMonth()],
@@ -117,8 +117,8 @@ export function groupEventsByMonth<T extends HasTimeRanges>(
   // This gives us the list of months that will appear in the segmented control
   // on the "What's on" page
   const monthSpan = getMonthsInDateRange({
-    start: earliestStartTime,
-    end: latestStartTime,
+    startDate: earliestStartTime,
+    endDate: latestStartTime,
   });
 
   // For each month, work out (a) what events should be included and

--- a/content/webapp/components/EventsByMonth/group-event-utils.ts
+++ b/content/webapp/components/EventsByMonth/group-event-utils.ts
@@ -53,7 +53,7 @@ export function getMonthsInDateRange({
 
   const result: YearMonth[] = [];
 
-  getDatesBetween({ start, end }).forEach(d => {
+  getDatesBetween({ startDate: start, endDate: end }).forEach(d => {
     const m = {
       year: d.getUTCFullYear(),
       month: utcMonthNames[d.getUTCMonth()],

--- a/content/webapp/services/prismic/transformers/events.ts
+++ b/content/webapp/services/prismic/transformers/events.ts
@@ -445,8 +445,8 @@ export function transformEventBasicTimes(
   //
   // This tells us if the scheduled items are a continuous block.
   const daysInScheduleRange = getDatesBetween({
-    start: scheduleStart,
-    end: scheduleEnd,
+    startDate: scheduleStart,
+    endDate: scheduleEnd,
   });
 
   const everyDayHasSomething = daysInScheduleRange.every(d =>


### PR DESCRIPTION
Spotted on code read.

* Be consistent about `startDate`/`endDate` as parameter names in all this code
* [Simplify the map/filter in CalendarSelect](https://github.com/wellcomecollection/wellcomecollection.org/commit/45e670a8505c6bb472b81cb2cccdf0fcc2de6fd5) (see the commit message for longer explanation)