### PR TITLE
Center digitised preview

### DIFF
--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -44,6 +44,12 @@ import {
 } from '../../utils/requesting';
 import { themeValues } from '@weco/common/views/themes/config';
 import { formatDuration } from '@weco/common/utils/format-date';
+import styled from 'styled-components';
+
+const DigitisedPreview = styled.div`
+  display: flex;
+  justify-content: center;
+`;
 
 type Props = {
   work: Work;
@@ -258,7 +264,7 @@ const WorkDetails: FunctionComponent<Props> = ({
   const renderContent = () => (
     <>
       {showAvailableOnlineSection && (
-        <WorkDetailsSection headingText="Available online">
+        <>
           <ConditionalWrapper
             condition={Boolean(tokenService && !shouldShowItemLink)}
             wrapper={children =>
@@ -299,119 +305,108 @@ const WorkDetails: FunctionComponent<Props> = ({
             )}
 
             {shouldShowItemLink && (
-              <>
-                {work.thumbnail && (
-                  <Space
-                    v={{
-                      size: 's',
-                      properties: ['margin-bottom'],
-                    }}
-                  >
-                    <ConditionalWrapper
-                      condition={Boolean(itemUrl)}
-                      wrapper={children =>
-                        itemUrl && (
-                          <NextLink
-                            href={itemUrl.href}
-                            as={itemUrl.as}
-                            onClick={() =>
-                              trackGaEvent({
-                                category: 'WorkDetails',
-                                action: 'follow image link',
-                                label: work.id,
-                              })
-                            }
-                          >
-                            {children}
-                          </NextLink>
-                        )
-                      }
-                    >
-                      <img
-                        style={{
-                          width: 'auto',
-                          height: 'auto',
-                        }}
-                        alt={`view ${work.title}`}
-                        src={work.thumbnail.url}
-                      />
-                    </ConditionalWrapper>
-                  </Space>
-                )}
-
-                {/* Note: there is no class flex-h-center, but there is flex--h-center
-                    Is that what's meant here? */}
-                <div className="flex flex-h-center">
-                  {itemUrl && (
+              <DigitisedPreview>
+                <div>
+                  {work.thumbnail && (
                     <Space
-                      as="span"
-                      h={{
-                        size: 'm',
-                        properties: ['margin-right'],
+                      v={{
+                        size: 's',
+                        properties: ['margin-bottom'],
                       }}
                     >
-                      <ButtonSolidLink
-                        icon={eye}
-                        text="View"
-                        trackingEvent={{
-                          category: 'WorkDetails',
-                          action: 'follow view link',
-                          label: itemUrl?.href?.query?.workId?.toString(),
-                        }}
-                        link={{ ...itemUrl }}
-                      />
+                      <ConditionalWrapper
+                        condition={Boolean(itemUrl)}
+                        wrapper={children =>
+                          itemUrl && (
+                            <NextLink
+                              href={itemUrl.href}
+                              as={itemUrl.as}
+                              onClick={() =>
+                                trackGaEvent({
+                                  category: 'WorkDetails',
+                                  action: 'follow image link',
+                                  label: work.id,
+                                })
+                              }
+                            >
+                              {children}
+                            </NextLink>
+                          )
+                        }
+                      >
+                        <img
+                          style={{
+                            width: 'auto',
+                            height: 'auto',
+                          }}
+                          alt={`view ${work.title}`}
+                          src={work.thumbnail.url}
+                        />
+                      </ConditionalWrapper>
                     </Space>
                   )}
+                  {/* Note: there is no class flex-h-center, but there is flex--h-center
+                    Is that what's meant here? */}
+                  <div className="flex flex-h-center">
+                    {itemUrl && (
+                      <Space
+                        as="span"
+                        h={{
+                          size: 'm',
+                          properties: ['margin-right'],
+                        }}
+                      >
+                        <ButtonSolidLink
+                          icon={eye}
+                          text="View"
+                          trackingEvent={{
+                            category: 'WorkDetails',
+                            action: 'follow view link',
+                            label: itemUrl?.href?.query?.workId?.toString(),
+                          }}
+                          link={{ ...itemUrl }}
+                        />
+                      </Space>
+                    )}
 
-                  {showDownloadOptions && (
-                    <Download
-                      ariaControlsId="itemDownloads"
-                      workId={work.id}
-                      downloadOptions={downloadOptions}
-                    />
+                    {showDownloadOptions && (
+                      <Download
+                        ariaControlsId="itemDownloads"
+                        workId={work.id}
+                        downloadOptions={downloadOptions}
+                      />
+                    )}
+                  </div>
+                  {(collectionManifestsCount > 0 || canvasCount > 0) && (
+                    <Space
+                      v={{
+                        size: 'm',
+                        properties: ['margin-top'],
+                      }}
+                    >
+                      <p className={`no-margin ${font('lr', 6)}`}>
+                        Contains:{' '}
+                        {collectionManifestsCount > 0
+                          ? `${collectionManifestsCount} ${
+                              collectionManifestsCount === 1
+                                ? 'volume'
+                                : 'volumes'
+                            }`
+                          : canvasCount > 0
+                          ? `${canvasCount} ${
+                              canvasCount === 1 ? 'image' : 'images'
+                            }`
+                          : ''}
+                      </p>
+                    </Space>
                   )}
                 </div>
-                {(collectionManifestsCount > 0 || canvasCount > 0) && (
-                  <Space
-                    v={{
-                      size: 'm',
-                      properties: ['margin-top'],
-                    }}
-                  >
-                    <p className={`no-margin ${font('lr', 6)}`}>
-                      Contains:{' '}
-                      {collectionManifestsCount > 0
-                        ? `${collectionManifestsCount} ${
-                            collectionManifestsCount === 1
-                              ? 'volume'
-                              : 'volumes'
-                          }`
-                        : canvasCount > 0
-                        ? `${canvasCount} ${
-                            canvasCount === 1 ? 'image' : 'images'
-                          }`
-                        : ''}
-                    </p>
-                  </Space>
-                )}
-              </>
+              </DigitisedPreview>
             )}
           </ConditionalWrapper>
-
-          {digitalLocationInfo?.license && (
-            <>
-              <Space
-                v={{
-                  size: 'l',
-                  properties: ['margin-top'],
-                }}
-              >
-                <WorkDetailsText
-                  title="Licence"
-                  text={[digitalLocationInfo.license.label]}
-                />
-              </Space>
-              {digitalLocation?.accessConditions[0]?.terms && (
+          <WorkDetailsSection headingText="Available online">
+            {digitalLocationInfo?.license && (
+              <>
                 <Space
                   v={{
                     size: 'l',
@@ -419,59 +414,74 @@ const WorkDetails: FunctionComponent<Props> = ({
                   }}
                 >
                   <WorkDetailsText
-                    title="Access conditions"
-                    noSpacing={true}
-                    text={digitalLocation?.accessConditions[0]?.terms}
+                    title="Licence"
+                    text={[digitalLocationInfo.license.label]}
                   />
                 </Space>
-              )}
-              <Space
-                v={{
-                  size: 'l',
-                  properties: ['margin-top'],
-                }}
-              >
-                <ExplanatoryText
-                  id="licenseDetail"
-                  controlText="Can I use this?"
-                >
-                  <>
-                    {digitalLocationInfo.license.humanReadableText && (
-                      <WorkDetailsText
-                        contents={digitalLocationInfo.license.humanReadableText}
-                      />
-                    )}
+                {digitalLocation?.accessConditions[0]?.terms && (
+                  <Space
+                    v={{
+                      size: 'l',
+                      properties: ['margin-top'],
+                    }}
+                  >
                     <WorkDetailsText
-                      contents={
-                        <>
-                          Credit: {work.title.replace(/\.$/g, '')}.
-                          {credit && (
-                            <>
-                              {' '}
-                              <a
-                                href={`https://wellcomecollection.org/works/${work.id}`}
-                              >
-                                {credit}
-                              </a>
-                              .
-                            </>
-                          )}{' '}
-                          {digitalLocationInfo.license.url ? (
-                            <a href={digitalLocationInfo.license.url}>
-                              {digitalLocationInfo.license.label}
-                            </a>
-                          ) : (
-                            digitalLocationInfo.license.label
-                          )}
-                        </>
-                      }
+                      title="Access conditions"
+                      noSpacing={true}
+                      text={digitalLocation?.accessConditions[0]?.terms}
                     />
-                  </>
-                </ExplanatoryText>
-              </Space>
-            </>
-          )}
-        </WorkDetailsSection>
+                  </Space>
+                )}
+                <Space
+                  v={{
+                    size: 'l',
+                    properties: ['margin-top'],
+                  }}
+                >
+                  <ExplanatoryText
+                    id="licenseDetail"
+                    controlText="Can I use this?"
+                  >
+                    <>
+                      {digitalLocationInfo.license.humanReadableText && (
+                        <WorkDetailsText
+                          contents={
+                            digitalLocationInfo.license.humanReadableText
+                          }
+                        />
+                      )}
+                      <WorkDetailsText
+                        contents={
+                          <>
+                            Credit: {work.title.replace(/\.$/g, '')}.
+                            {credit && (
+                              <>
+                                {' '}
+                                <a
+                                  href={`https://wellcomecollection.org/works/${work.id}`}
+                                >
+                                  {credit}
+                                </a>
+                                .
+                              </>
+                            )}{' '}
+                            {digitalLocationInfo.license.url ? (
+                              <a href={digitalLocationInfo.license.url}>
+                                {digitalLocationInfo.license.label}
+                              </a>
+                            ) : (
+                              digitalLocationInfo.license.label
+                            )}
+                          </>
+                        }
+                      />
+                    </>
+                  </ExplanatoryText>
+                </Space>
+              </>
+            )}
+          </WorkDetailsSection>
+        </>
       )}
 
       <OnlineResources work={work} />

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -28,7 +28,7 @@ import ExplanatoryText from './ExplanatoryText';
 import { toLink as itemLink } from '@weco/common/views/components/ItemLink/ItemLink';
 import { trackGaEvent } from '@weco/common/utils/ga';
 import PhysicalItems from '../PhysicalItems/PhysicalItems';
-import Layout12 from '@weco/common/views/components/Layout12/Layout12';
+import Layout10 from '@weco/common/views/components/Layout10/Layout10';
 import { DigitalLocation, Work } from '@weco/common/model/catalogue';
 import useTransformedManifest from '../../hooks/useTransformedManifest';
 import useTransformedIIIFImage from '../../hooks/useTransformedIIIFImage';
@@ -739,7 +739,7 @@ const WorkDetails: FunctionComponent<Props> = ({
       {renderContent()}
     </Space>
   ) : (
-    <Layout12>{renderContent()}</Layout12>
+    <Layout10>{renderContent()}</Layout10>
   );
 };
 

--- a/catalogue/webapp/components/WorkDetailsSection/WorkDetailsSection.tsx
+++ b/catalogue/webapp/components/WorkDetailsSection/WorkDetailsSection.tsx
@@ -1,13 +1,28 @@
-import Divider from '@weco/common/views/components/Divider/Divider';
-import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
 import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
-import { classNames, grid, font } from '@weco/common/utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import { FunctionComponent, PropsWithChildren, useContext } from 'react';
+import styled from 'styled-components';
+import Space from '@weco/common/views/components/styled/Space';
 import IsArchiveContext from '../IsArchiveContext/IsArchiveContext';
 
 type Props = PropsWithChildren<{
   headingText?: string;
 }>;
+
+const SectionWithDivider = styled(Space).attrs({
+  v: { size: 'l', properties: ['padding-top'] },
+})<{ isArchive: boolean }>`
+  ${props =>
+    props.isArchive &&
+    `
+    &:nth-child(1) {
+      padding-top: 0;
+    }
+  `}
+  & + & {
+    border-top: 1px solid ${props => props.theme.color('neutral.400')};
+  }
+`;
 
 const WorkDetailsSection: FunctionComponent<Props> = ({
   headingText,
@@ -16,51 +31,17 @@ const WorkDetailsSection: FunctionComponent<Props> = ({
   const isArchive = useContext(IsArchiveContext);
 
   return (
-    <>
-      {!isArchive && (
-        <>
-          <Divider />
-          <SpacingComponent />
-        </>
-      )}
+    <SectionWithDivider isArchive={isArchive}>
       <SpacingSection>
-        <div
-          className={classNames({
-            grid: !isArchive,
-          })}
-        >
-          <div
-            className={classNames({
-              [grid({
-                s: 12,
-                m: 12,
-                l: 4,
-                xl: 4,
-              })]: !isArchive,
-            })}
-          >
-            {headingText && (
-              <h2 className={`${font('wb', 4)} work-details-heading`}>
-                {headingText}
-              </h2>
-            )}
-          </div>
+        {headingText && (
+          <h2 className={`${font('wb', 4)} work-details-heading`}>
+            {headingText}
+          </h2>
+        )}
 
-          <div
-            className={classNames({
-              [grid({
-                s: 12,
-                m: 12,
-                l: 8,
-                xl: 7,
-              })]: !isArchive,
-            })}
-          >
-            {children}
-          </div>
-        </div>
+        {children}
       </SpacingSection>
-    </>
+    </SectionWithDivider>
   );
 };
 

--- a/catalogue/webapp/components/WorkDetailsText/WorkDetailsText.tsx
+++ b/catalogue/webapp/components/WorkDetailsText/WorkDetailsText.tsx
@@ -1,6 +1,13 @@
 import WorkDetailsProperty from '../WorkDetailsProperty/WorkDetailsProperty';
 import { FunctionComponent, ReactElement } from 'react';
 import { isString } from '@weco/common/utils/array';
+import styled from 'styled-components';
+
+const LimitWidth = styled.div.attrs({
+  className: 'spaced-text',
+})`
+  max-width: 45em;
+`;
 
 type BaseProps = {
   title?: string;
@@ -37,7 +44,7 @@ const WorkDetailsText: FunctionComponent<Props> = props => {
       inlineHeading={inlineHeading}
       noSpacing={noSpacing}
     >
-      <div className="spaced-text">
+      <LimitWidth>
         {'contents' in props && props.contents}
         {'text' in props &&
           (isString(props.text) ? (
@@ -53,7 +60,7 @@ const WorkDetailsText: FunctionComponent<Props> = props => {
               <div key={i} dangerouslySetInnerHTML={{ __html: para }} />
             ))
           ))}
-      </div>
+      </LimitWidth>
     </WorkDetailsProperty>
   );
 };

--- a/catalogue/webapp/components/WorkHeader/WorkHeader.tsx
+++ b/catalogue/webapp/components/WorkHeader/WorkHeader.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent } from 'react';
+import { FunctionComponent, useContext } from 'react';
 import { Work } from '@weco/common/model/catalogue';
 import { font, grid } from '@weco/common/utils/classnames';
 import {
@@ -14,6 +14,8 @@ import styled from 'styled-components';
 import WorkTitle from '../WorkTitle/WorkTitle';
 import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
 import useTransformedManifest from '../../hooks/useTransformedManifest';
+import Divider from '@weco/common/views/components/Divider/Divider';
+import IsArchiveContext from '../IsArchiveContext/IsArchiveContext';
 
 const WorkHeaderContainer = styled.div`
   display: flex;
@@ -31,6 +33,7 @@ type Props = {
 };
 
 const WorkHeader: FunctionComponent<Props> = ({ work }) => {
+  const isArchive = useContext(IsArchiveContext);
   const productionDates = getProductionDates(work);
   const archiveLabels = getArchiveLabels(work);
   const cardLabels = getCardLabels(work);
@@ -42,78 +45,98 @@ const WorkHeader: FunctionComponent<Props> = ({ work }) => {
   )?.agent.label;
 
   return (
-    <WorkHeaderContainer>
-      <Space
-        v={{
-          size: 'm',
-          properties: ['margin-bottom'],
-        }}
-        className={grid({ s: 12, m: 12, l: 10, xl: 10 })}
-      >
-        <SpacingComponent>
-          <WorkTitleWrapper
-            aria-live="polite"
-            id="work-info"
-            // We only send a lang if it's unambiguous -- better to send
-            // no language than the wrong one.
-            lang={
-              work?.languages?.length === 1 ? work?.languages[0]?.id : undefined
-            }
-          >
-            <WorkTitle title={work.title} />
-          </WorkTitleWrapper>
+    <>
+      <WorkHeaderContainer>
+        <Space
+          v={{
+            size: 'm',
+            properties: ['margin-bottom'],
+          }}
+          className={grid({ s: 12, m: 12, l: 10, xl: 10 })}
+        >
+          <SpacingComponent>
+            <WorkTitleWrapper
+              aria-live="polite"
+              id="work-info"
+              // We only send a lang if it's unambiguous -- better to send
+              // no language than the wrong one.
+              lang={
+                work?.languages?.length === 1
+                  ? work?.languages[0]?.id
+                  : undefined
+              }
+            >
+              <WorkTitle title={work.title} />
+            </WorkTitleWrapper>
 
-          {primaryContributorLabel && (
-            <Space h={{ size: 'm', properties: ['margin-right'] }}>
-              <LinkLabels items={[{ text: primaryContributorLabel }]} />
+            {primaryContributorLabel && (
+              <Space h={{ size: 'm', properties: ['margin-right'] }}>
+                <LinkLabels items={[{ text: primaryContributorLabel }]} />
+              </Space>
+            )}
+
+            {productionDates.length > 0 && (
+              <LinkLabels
+                heading="Date"
+                items={[{ text: productionDates[0] }]}
+              />
+            )}
+
+            {work.referenceNumber && (
+              <LinkLabels
+                heading="Reference"
+                items={[{ text: work.referenceNumber }]}
+              />
+            )}
+
+            {archiveLabels?.partOf && (
+              <LinkLabels
+                heading="Part of"
+                items={[{ text: archiveLabels.partOf }]}
+              />
+            )}
+
+            <Space
+              v={{
+                size: 'm',
+                properties: ['margin-top'],
+              }}
+            >
+              <LabelsList
+                labels={cardLabels}
+                defaultLabelColor="warmNeutral.300"
+              />
             </Space>
-          )}
 
-          {productionDates.length > 0 && (
-            <LinkLabels heading="Date" items={[{ text: productionDates[0] }]} />
-          )}
-
-          {work.referenceNumber && (
-            <LinkLabels
-              heading="Reference"
-              items={[{ text: work.referenceNumber }]}
-            />
-          )}
-
-          {archiveLabels?.partOf && (
-            <LinkLabels
-              heading="Part of"
-              items={[{ text: archiveLabels.partOf }]}
-            />
-          )}
-
+            {collectionManifestsCount > 0 && (
+              <Space v={{ size: 'm', properties: ['margin-top'] }}>
+                <p className={`${font('intb', 5)} no-margin`}>
+                  <Number
+                    backgroundColor="yellow"
+                    number={collectionManifestsCount}
+                  />
+                  {collectionManifestsCount === 1 ? ' volume ' : ' volumes '}
+                  online
+                </p>
+              </Space>
+            )}
+          </SpacingComponent>
+        </Space>
+      </WorkHeaderContainer>
+      {!isArchive && (
+        <WorkHeaderContainer>
           <Space
             v={{
               size: 'm',
-              properties: ['margin-top'],
+              properties: ['margin-bottom'],
             }}
+            className={grid({ s: 12, m: 12, l: 12, xl: 12 })}
           >
-            <LabelsList
-              labels={cardLabels}
-              defaultLabelColor="warmNeutral.300"
-            />
+            <Divider lineColor="neutral.400" />
           </Space>
-
-          {collectionManifestsCount > 0 && (
-            <Space v={{ size: 'm', properties: ['margin-top'] }}>
-              <p className={`${font('intb', 5)} no-margin`}>
-                <Number
-                  backgroundColor="yellow"
-                  number={collectionManifestsCount}
-                />
-                {collectionManifestsCount === 1 ? ' volume ' : ' volumes '}
-                online
-              </p>
-            </Space>
-          )}
-        </SpacingComponent>
-      </Space>
-    </WorkHeaderContainer>
+        </WorkHeaderContainer>
+      )}
+    </>
   );
 };
 export default WorkHeader;


### PR DESCRIPTION
☝️ 

Part of #9373 broken out from #9377

This takes the digitised preview out of the work details section it lives in currently (so that it isn't headed by 'Available online') as per [this Zeplin screen](https://app.zeplin.io/project/5aab926b4b6efde01259e959/screen/63fc84c63d2cb70eb11654b6)

<img width="1206" alt="image" src="https://user-images.githubusercontent.com/1394592/223414947-6171db72-8de7-465f-90d0-08d1cbaa4818.png">
