### PR TITLE
Search works tests

### DIFF
--- a/common/views/components/Pagination/Pagination.tsx
+++ b/common/views/components/Pagination/Pagination.tsx
@@ -112,7 +112,7 @@ export const Pagination: FunctionComponent<Props> = ({
 
   return (
     <Container
-      {...(!isHiddenMobile && { 'data-test-id': 'pagination' })} // This ensures that we only target the version of component that is also visible on mobile
+      {...(!isHiddenMobile && { 'data-testid': 'pagination' })} // This ensures that we only target the version of component that is also visible on mobile
       aria-label={ariaLabel}
       isHiddenMobile={isHiddenMobile}
     >

--- a/playwright/test/search-works.test.ts
+++ b/playwright/test/search-works.test.ts
@@ -45,16 +45,13 @@ const expectSearchParam = (
 const openDropdown = async (label: string, page: Page) => {
   console.info('openDropdown', label);
   if (isMobile(page)) {
+    await page.click(formatFilterMobileButton);
   } else {
     await page.click(`button :text("${label}")`);
   }
 };
 
 const selectCheckbox = async (label: string, page: Page) => {
-  if (isMobile(page)) {
-    await page.click(formatFilterMobileButton);
-  }
-
   await Promise.all([
     safeWaitForNavigation(page),
     page.click(`label :text("${label}")`),
@@ -205,15 +202,6 @@ test.describe(
       page,
       context,
     }) => {
-      // TODO: For some reason `"Filters"` isn't working on mobile.  The original
-      // purpose of this test was to check the logic behind the filters, not the UI.
-      // See https://wellcome.slack.com/archives/C8X9YKM5X/p1663763975934799
-      //
-      // Ideally we'd also be able to test mobile in this test, but it's not critical.
-      if (isMobile(page)) {
-        return;
-      }
-
       await newWorksSearch(context, page);
       await searchFor('brain', page);
       await openDropdown('Dates', page);
@@ -237,6 +225,10 @@ test.describe(
           .fill('2001'),
         safeWaitForNavigation(page),
       ]);
+
+      if (isMobile(page)) {
+        await page.click(`"Show results"`);
+      }
 
       expectSearchParam('production.dates.from', '1939', page);
       expectSearchParam('production.dates.to', '2001', page);

--- a/playwright/test/search-works.test.ts
+++ b/playwright/test/search-works.test.ts
@@ -1,8 +1,9 @@
+import { Page } from 'playwright';
+import { URLSearchParams } from 'url';
 import { test, expect } from '@playwright/test';
 import { isMobile, newWorksSearch } from './contexts';
-import { URLSearchParams } from 'url';
-import { Page } from 'playwright';
 import safeWaitForNavigation from './helpers/safeWaitForNavigation';
+import { formatFilterMobileButton } from './selectors/search';
 
 export const worksSearchForm = '#search-searchbar';
 export const searchFor = async (query: string, page: Page): Promise<void> => {
@@ -16,21 +17,29 @@ export const searchFor = async (query: string, page: Page): Promise<void> => {
 
 const expectSearchParam = (
   expectedKey: string,
-  expectedVal: string,
+  expectedVal: string | undefined,
   page: Page
 ) => {
   console.info('expectSearchParam', { expectedKey, expectedVal });
   const params = new URLSearchParams(page.url());
 
-  const foundMatchingParam = Array.from(params).find(
-    ([key, val]) => key === expectedKey && val === expectedVal
-  );
+  if (expectedVal) {
+    const foundMatchingParam = Array.from(params).find(
+      ([key, val]) => key === expectedKey && val === expectedVal
+    );
 
-  if (!foundMatchingParam) {
-    console.log(page.url());
+    if (!foundMatchingParam) {
+      console.log(page.url());
+    }
+
+    expect(foundMatchingParam).toBeTruthy();
+  } else {
+    const noMatchProps = !Array.from(params).find(
+      ([key]) => key === expectedKey
+    );
+
+    expect(noMatchProps).toBeTruthy();
   }
-
-  expect(foundMatchingParam).toBeTruthy();
 };
 
 const openDropdown = async (label: string, page: Page) => {
@@ -43,9 +52,7 @@ const openDropdown = async (label: string, page: Page) => {
 
 const selectCheckbox = async (label: string, page: Page) => {
   if (isMobile(page)) {
-    // TODO: Make this a user centric selector
-    // for some reason `"Filters"` isn't working.
-    await page.click(`[aria-controls="mobile-filters-modal"]`);
+    await page.click(formatFilterMobileButton);
   }
 
   await Promise.all([
@@ -60,13 +67,13 @@ const selectCheckbox = async (label: string, page: Page) => {
 };
 
 const navigateToNextPage = async (page: Page) => {
-  // data-test-id is only set on Pagination components that aren't hidden on mobile
+  // data-testid is only set on Pagination components that aren't hidden on mobile
   // in `common/views/components/Pagination/Pagination.tsx`
   await page.waitForTimeout(2000);
 
   await Promise.all([
     safeWaitForNavigation(page),
-    page.click('[data-test-id="pagination"] button'),
+    page.click('[data-testid="pagination"] button'),
   ]);
 };
 
@@ -237,6 +244,34 @@ test.describe(
       // This is a check that we have actually loaded some results from
       // the API, and the API hasn't just errored out.
       await navigateToResult(6, page);
+    });
+  }
+);
+
+test.describe(
+  'Scenario 7: The user is sorting by production dates in search',
+  () => {
+    test('Sort updates URL query and goes back to the first page', async ({
+      context,
+      page,
+    }) => {
+      await newWorksSearch(context, page);
+
+      const select = page.locator('select[name="sortOrder"]');
+      await select.selectOption({ index: 2 });
+
+      await safeWaitForNavigation(page);
+      await navigateToNextPage(page);
+
+      expectSearchParam('sortOrder', 'desc', page);
+      expectSearchParam('sort', 'production.dates', page);
+      expectSearchParam('page', '2', page);
+
+      await select.selectOption({ index: 1 });
+      await safeWaitForNavigation(page);
+
+      expectSearchParam('sortOrder', 'asc', page);
+      expectSearchParam('page', undefined, page);
     });
   }
 );


### PR DESCRIPTION
## Who is this for?
e2e tests

## What is it doing for them?
- Added a test to check Sorting dealt with the navigation correctly
- Fixed mobile tests for filters (older TODOs)
- Change `data-test-id` to `data-testid` because that's what Playwright and testing library support (see [PR convo here](https://github.com/wellcomecollection/wellcomecollection.org/pull/9393#discussion_r1126624648))