### PR TITLE
Cardigan Contributors: Fix missing heading

### DIFF
--- a/cardigan/stories/components/Contributors/Contributors.stories.tsx
+++ b/cardigan/stories/components/Contributors/Contributors.stories.tsx
@@ -38,6 +38,5 @@ basic.args = {
       description: null,
     },
   ],
-  titleOverride: '',
 };
 basic.storyName = 'Contributors';

--- a/content/webapp/components/Contributors/Contributors.tsx
+++ b/content/webapp/components/Contributors/Contributors.tsx
@@ -1,4 +1,4 @@
-import { Fragment, FunctionComponent } from 'react';
+import { FunctionComponent } from 'react';
 import { isNotUndefined } from '@weco/common/utils/array';
 import Space from '@weco/common/views/components/styled/Space';
 import Contributor from './Contributor';
@@ -70,11 +70,11 @@ const Contributors: FunctionComponent<Props> = ({
   );
 
   return (
-    <Fragment>
+    <>
       <h2 className="h2">
         {isNotUndefined(titleOverride)
           ? titleOverride
-          : `${getContributorsTitle(roles, titlePrefix)}`}
+          : getContributorsTitle(roles, titlePrefix)}
       </h2>
 
       {contributors.map(({ contributor, role, description }) => (
@@ -93,7 +93,7 @@ const Contributors: FunctionComponent<Props> = ({
           />
         </Space>
       ))}
-    </Fragment>
+    </>
   );
 };
 


### PR DESCRIPTION
## Who is this for?
Cardigan

## What is it doing for them?
Had an a11y flag where the heading was displaying as empty. The `isNotUndefined` check means an empty string is true (only checks for `undefined`), so I just removed that prop from the story completely. 


<img width="440" alt="Screenshot 2023-03-07 at 13 48 07" src="https://user-images.githubusercontent.com/110461050/223443295-833697c1-fbe7-40bf-beac-b155c547c19a.png">


It does mean that an empty string (`''`) will display an empty h2 though, but as it seems to [have been done on purpose](https://github.com/wellcomecollection/wellcomecollection.org/commit/a3030801f13dadaafda379be81fbb877c116e185) ([PR](https://github.com/wellcomecollection/wellcomecollection.org/pull/8834)), I wonder if there is more to consider? Should we change the check to be something like;

```
 {Boolean(titleOverride)
          ? titleOverride
          : getContributorsTitle(roles, titlePrefix)}
```
