### PR TITLE
Hide Events/Exh from Search tabs

### DIFF
--- a/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
+++ b/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
@@ -266,7 +266,7 @@ const SearchLayout: FunctionComponent<{
 
 export const getSearchLayout = (page: ReactElement): JSX.Element => (
   <SearchLayout
-    hasEventsExhibitions={page.props.serverData.toggles}
+    hasEventsExhibitions={page.props.serverData.toggles.hasEventsExhibitions}
     apiToolbarLinks={page.props.apiToolbarLinks}
   >
     {page}


### PR DESCRIPTION
## Who is this for?
Users 

## What is it doing for them?
- Checks for the toggle specifically and send to the tabs component to determine what to display.