### PR TITLE
Use useRouter pathname instead of depending on state

### DIFF
--- a/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
+++ b/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
@@ -54,7 +54,7 @@ const SearchLayout: FunctionComponent<{ apiToolbarLinks: ApiToolbarLink[] }> =
     const basePageMetadata: PageLayoutMetadata = {
       apiToolbarLinks,
       openGraphType: 'website',
-      siteSection: null,
+      siteSection: null, // We don't want search to display under any menu section
       jsonLd: { '@type': 'WebPage' },
       hideNewsletterPromo: true,
       excludeRoleMain: true,
@@ -78,7 +78,7 @@ const SearchLayout: FunctionComponent<{ apiToolbarLinks: ApiToolbarLink[] }> =
 
     useEffect(() => {
       const queryStringTitle = queryString ? `${queryString} | ` : '';
-      setInputValue(queryString || ''); // This accounts for queries done from these pages from the global search
+      setInputValue(queryString || ''); // This accounts for queries done on these pages, but from the global search
 
       switch (currentSearchCategory) {
         case 'overview':
@@ -149,7 +149,7 @@ const SearchLayout: FunctionComponent<{ apiToolbarLinks: ApiToolbarLink[] }> =
             sortOrder: urlFormattedSort.sortOrder,
           }),
         },
-        pathname: pageLayoutMetadata.url.pathname,
+        pathname: router.pathname,
       });
 
       return router.push(link.href, link.as);


### PR DESCRIPTION
## Who is this for?
Everyone ⭐ 

## What is it doing for them?
React strict mode flagged a race condition/use effect issue with the navigation (only locally, [read more here](https://wellcome.slack.com/archives/C3TQSF63C/p1678274886701909?thread_ts=1678272840.419089&cid=C3TQSF63C)). `pageLayoutMetadata` gets updated at the same time as `updateUrl` is fired, so it was sending in the previous URL value. 
I don't think we need to use the URL set by the state as `updateUrl` is only used on `onSubmit`, which will always be on the current page, so I changed it to use `router.pathname` instead, which fixes the issue.