### PR TITLE
Remove variants in subnavigation

### DIFF
--- a/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
+++ b/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
@@ -215,7 +215,6 @@ const SearchLayout: FunctionComponent<{ apiToolbarLinks: ApiToolbarLink[] }> =
             ]}
             currentSection={currentSearchCategory}
             hasDivider
-            variant="yellow"
           />
         </div>
         {children}

--- a/catalogue/webapp/components/WorkTabbedNav/WorkTabbedNav.tsx
+++ b/catalogue/webapp/components/WorkTabbedNav/WorkTabbedNav.tsx
@@ -39,7 +39,6 @@ const WorkTabbedNav: FunctionComponent<Props> = ({ work, selected }) => {
       ]}
       currentSection={selected}
       hasDivider
-      variant="yellow"
     />
   );
 };

--- a/common/views/components/SubNavigation/SubNavigation.styles.tsx
+++ b/common/views/components/SubNavigation/SubNavigation.styles.tsx
@@ -54,7 +54,6 @@ export const Tab = styled.div.attrs({
 
 type NavItemInnerProps = {
   selected: boolean;
-  variant?: 'yellow' | 'white';
 };
 export const NavItemInner = styled.a.attrs<NavItemInnerProps>(props => {
   return {
@@ -66,15 +65,7 @@ export const NavItemInner = styled.a.attrs<NavItemInnerProps>(props => {
   padding: 0 10px 24px; // Deliberately offset from the left-hand side to make the buttons bigger for a11y
   cursor: pointer;
   color: ${props =>
-    props.theme.color(
-      props.variant === 'white'
-        ? props.selected
-          ? 'white'
-          : 'warmNeutral.400'
-        : props.selected
-        ? 'black'
-        : 'neutral.600'
-    )};
+    props.theme.color(props.selected ? 'black' : 'neutral.600')};
   text-decoration: none;
   transition: all ${props => props.theme.transitionProperties};
 
@@ -86,19 +77,7 @@ export const NavItemInner = styled.a.attrs<NavItemInnerProps>(props => {
     left: 0;
     width: 0;
     background-color: ${props =>
-      props.theme.color(
-        props.selected
-          ? props.variant === 'white'
-            ? 'white'
-            : props.variant === 'yellow'
-            ? 'yellow'
-            : 'black'
-          : props.variant === 'white'
-          ? 'warmNeutral.400'
-          : props.variant === 'yellow'
-          ? 'lightYellow'
-          : 'neutral.600'
-      )};
+      props.theme.color(props.selected ? 'yellow' : 'lightYellow')};
     z-index: -1;
     transition: width 200ms ease;
   }

--- a/common/views/components/SubNavigation/SubNavigation.tsx
+++ b/common/views/components/SubNavigation/SubNavigation.tsx
@@ -28,7 +28,6 @@ type Props = {
   label: string;
   items: SelectableTextLink[];
   currentSection: string;
-  variant?: 'yellow' | 'white';
   hasDivider?: boolean;
 };
 
@@ -41,7 +40,6 @@ const TabNavBottomBorder = styled.div`
 const SubNavigation: FunctionComponent<Props> = ({
   label,
   items,
-  variant,
   currentSection,
   hasDivider,
 }: Props) => {
@@ -60,7 +58,6 @@ const SubNavigation: FunctionComponent<Props> = ({
                 legacyBehavior
               >
                 <NavItemInner
-                  variant={variant}
                   selected={isSelected}
                   aria-current={isSelected ? 'page' : 'false'}
                   onClick={e => {


### PR DESCRIPTION
## Who is this for?
Maintenance

## What is it doing for them?
Color variants were leftovers from `TabNav`, which looks really similar but does need other colours ([see concept images section](https://wellcomecollection.org/concepts/n4fvtc49)). `SubNavigation` in itself only ever uses yellow, there is no plan (AFAIK) to use something else, so a bit of a cleanup.