### PR TITLE
Make storiesLandingComics toggle default to true

### DIFF
--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -47,7 +47,7 @@ const toggles = {
     {
       id: 'storiesLandingComics',
       title: 'Rearranging comics on the stories landing page',
-      initialValue: false,
+      initialValue: true,
       description:
         'Takes the comics out of the general set of stories, and moves them to their own page section, grouped by series.',
     },


### PR DESCRIPTION
This will turn on the comic section on the stories landing page for everyone who hasn't already opted in.