### PR TITLE
Only run the useItemState hook on initial render

### DIFF
--- a/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
+++ b/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx
@@ -55,7 +55,7 @@ const useItemsState = (
 
   useEffect(() => {
     setItemsState(getItemsState(items));
-  }, [items]);
+  }, []);
 
   return [itemsState, setItemsState];
 };


### PR DESCRIPTION
Fixes #9400

We can get in a race condition between the useItemsState hook and the useAbortSignalEffect hook, which meant sometimes the itemsState could be reset to 'stale' after it had been set to 'up-to-date' and this would prevent the status and access from displaying.

As far as I can reason, we only need to run the useItemState hook on first render and removing items from the dependency array fixes the issue.

