### PR TITLE
Simplify and tidy up the way we render article series

### DIFF
--- a/common/views/components/WatchLabel/WatchLabel.tsx
+++ b/common/views/components/WatchLabel/WatchLabel.tsx
@@ -27,7 +27,7 @@ const WatchText = styled(Space).attrs({
 `;
 
 type Props = {
-  text?: string | ReactElement;
+  text: string | ReactElement;
 };
 
 const WatchLabel: FunctionComponent<Props> = ({ text }: Props) => (
@@ -35,7 +35,7 @@ const WatchLabel: FunctionComponent<Props> = ({ text }: Props) => (
     <WatchIconWrapper>
       <Icon icon={play} matchText={true} />
     </WatchIconWrapper>
-    {text && <WatchText>{text}</WatchText>}
+    <WatchText>{text}</WatchText>
   </div>
 );
 export default WatchLabel;

--- a/content/webapp/components/ArticleCard/ArticleCard.tsx
+++ b/content/webapp/components/ArticleCard/ArticleCard.tsx
@@ -28,7 +28,7 @@ const ArticleCard: FunctionComponent<Props> = ({
   const image = getCrop(article.image, 'square');
 
   const seriesWithSchedule = article.series.find(
-    series => (series.schedule ?? []).length > 0
+    series => series.schedule.length > 0
   );
 
   const indexInSeriesSchedule = article.promo?.caption

--- a/content/webapp/components/ArticleCard/ArticleCard.tsx
+++ b/content/webapp/components/ArticleCard/ArticleCard.tsx
@@ -50,7 +50,7 @@ const ArticleCard: FunctionComponent<Props> = ({
       secondaryLabels={[]}
       description={!isPodcast ? article.promo?.caption ?? undefined : undefined}
       Image={
-        (image && (
+        image && (
           <PrismicImage
             // We intentionally omit the alt text on promos, so screen reader
             // users don't have to listen to the alt text before hearing the
@@ -66,8 +66,7 @@ const ArticleCard: FunctionComponent<Props> = ({
             }}
             quality="low"
           />
-        )) ||
-        undefined
+        )
       }
       xOfY={xOfY}
       postTitleChildren={

--- a/content/webapp/components/ArticleCard/ArticleCard.tsx
+++ b/content/webapp/components/ArticleCard/ArticleCard.tsx
@@ -6,7 +6,7 @@ import Space from '@weco/common/views/components/styled/Space';
 import WatchLabel from '@weco/common/views/components/WatchLabel/WatchLabel';
 import { isNotUndefined, isUndefined } from '@weco/common/utils/array';
 import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImage';
-import { ArticleBasic } from '../../types/articles';
+import { ArticleBasic, getArticleColor } from '../../types/articles';
 import linkResolver from '@weco/common/services/prismic/link-resolver';
 import { getCrop } from '@weco/common/model/image';
 import { getPartNumberInSeries } from '@weco/content/types/articles';
@@ -28,13 +28,7 @@ const ArticleCard: FunctionComponent<Props> = ({
   const url = linkResolver(article);
   const image = getCrop(article.image, 'square');
 
-  const seriesWithSchedule = article.series.find(
-    series => series.schedule.length > 0
-  );
-
-  const seriesColor = seriesWithSchedule?.color ?? undefined;
-
-  const isSerial = Boolean(seriesWithSchedule);
+  const isSerial = article.series.some(series => series.schedule.length > 0);
   const isPodcast = article.format?.id === ArticleFormatIds.Podcast;
 
   const labels = [article.format?.title, isSerial ? 'Serial' : undefined]
@@ -51,7 +45,7 @@ const ArticleCard: FunctionComponent<Props> = ({
       title={article.title}
       partNumber={partNumber}
       partDescription={isPodcast ? 'Episode' : 'Part'}
-      partNumberColor={seriesColor}
+      partNumberColor={getArticleColor(article)}
       primaryLabels={!isPodcast && isUndefined(partNumber) ? labels : []}
       secondaryLabels={[]}
       description={!isPodcast ? article.promo?.caption ?? undefined : undefined}

--- a/content/webapp/components/ArticleCard/ArticleCard.tsx
+++ b/content/webapp/components/ArticleCard/ArticleCard.tsx
@@ -4,11 +4,12 @@ import { ArticleFormatIds } from '@weco/common/data/content-format-ids';
 import HTMLDate from '@weco/common/views/components/HTMLDate/HTMLDate';
 import Space from '@weco/common/views/components/styled/Space';
 import WatchLabel from '@weco/common/views/components/WatchLabel/WatchLabel';
-import { isNotUndefined } from '@weco/common/utils/array';
+import { isNotUndefined, isUndefined } from '@weco/common/utils/array';
 import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImage';
 import { ArticleBasic } from '../../types/articles';
 import linkResolver from '@weco/common/services/prismic/link-resolver';
 import { getCrop } from '@weco/common/model/image';
+import { getPartNumberInSeries } from '@weco/content/types/articles';
 
 type Props = {
   article: ArticleBasic;
@@ -31,18 +32,7 @@ const ArticleCard: FunctionComponent<Props> = ({
     series => series.schedule.length > 0
   );
 
-  const indexInSeriesSchedule = article.promo?.caption
-    ? seriesWithSchedule?.schedule
-        ?.map(scheduleItem => scheduleItem.title)
-        .indexOf(article.promo?.caption)
-    : undefined;
-
   const seriesColor = seriesWithSchedule?.color ?? undefined;
-
-  const positionInSeriesSchedule =
-    isNotUndefined(indexInSeriesSchedule) && indexInSeriesSchedule !== -1
-      ? indexInSeriesSchedule + 1
-      : undefined;
 
   const isSerial = Boolean(seriesWithSchedule);
   const isPodcast = article.format?.id === ArticleFormatIds.Podcast;
@@ -53,14 +43,16 @@ const ArticleCard: FunctionComponent<Props> = ({
 
   const publicationDate = article.datePublished;
 
+  const partNumber = showPosition ? getPartNumberInSeries(article) : undefined;
+
   return (
     <CompactCard
       url={url}
       title={article.title}
-      partNumber={showPosition ? positionInSeriesSchedule : undefined}
+      partNumber={partNumber}
       partDescription={isPodcast ? 'Episode' : 'Part'}
       partNumberColor={seriesColor}
-      primaryLabels={!isPodcast ? labels : []}
+      primaryLabels={!isPodcast && isUndefined(partNumber) ? labels : []}
       secondaryLabels={[]}
       description={!isPodcast ? article.promo?.caption ?? undefined : undefined}
       Image={

--- a/content/webapp/components/ArticleCard/ArticleCard.tsx
+++ b/content/webapp/components/ArticleCard/ArticleCard.tsx
@@ -24,7 +24,7 @@ const ArticleCard: FunctionComponent<Props> = ({
   article,
   showPosition,
   xOfY,
-}: Props) => {
+}) => {
   const url = linkResolver(article);
   const image = getCrop(article.image, 'square');
 

--- a/content/webapp/components/ArticleScheduleItemCard/index.tsx
+++ b/content/webapp/components/ArticleScheduleItemCard/index.tsx
@@ -1,0 +1,30 @@
+import { ArticleScheduleItem } from '@weco/content/types/article-schedule-items';
+import CompactCard from '../CompactCard/CompactCard';
+import { FunctionComponent } from 'react';
+import { formatDate } from '@weco/common/utils/format-date';
+import ImagePlaceholder from '../ImagePlaceholder/ImagePlaceholder';
+
+type Props = {
+  item: ArticleScheduleItem;
+  xOfY: { x: number; y: number };
+};
+
+const ArticleScheduleItemCard: FunctionComponent<Props> = ({ item, xOfY }) => (
+  <CompactCard
+    title={item.title}
+    partNumber={item.partNumber}
+    partNumberColor={item.color}
+    primaryLabels={
+      /* We don't show a label on items that haven't been published yet, because
+       * we don't know whether they're a story, comic, etc.
+       * See https://github.com/wellcomecollection/wellcomecollection.org/pull/7568 */
+      []
+    }
+    secondaryLabels={[]}
+    description={`Available ${formatDate(item.publishDate)}`}
+    Image={<ImagePlaceholder backgroundColor={item.color} />}
+    xOfY={xOfY}
+  />
+);
+
+export default ArticleScheduleItemCard;

--- a/content/webapp/components/FeaturedCard/FeaturedCard.tsx
+++ b/content/webapp/components/FeaturedCard/FeaturedCard.tsx
@@ -4,8 +4,8 @@ import { ImageType } from '@weco/common/model/image';
 import { ExhibitionBasic } from '../../types/exhibitions';
 import {
   ArticleBasic,
-  getPositionInSeries,
   getArticleColor,
+  getPartNumberInSeries,
 } from '../../types/articles';
 import { Season } from '../../types/seasons';
 import { Card } from '../../types/card';
@@ -102,13 +102,13 @@ type FeaturedCardArticleBodyProps = {
 // TODO: make this e.g. just `CardArticleBody` and work it back into the existing promos/cards
 const FeaturedCardArticleBody: FunctionComponent<FeaturedCardArticleBodyProps> =
   ({ article }) => {
-    const positionInSeries = getPositionInSeries(article);
+    const partNumber = getPartNumberInSeries(article);
     const seriesColor = getArticleColor(article);
     return (
       <>
-        {positionInSeries && (
+        {partNumber && (
           <PartNumberIndicator
-            number={positionInSeries}
+            number={partNumber}
             backgroundColor={seriesColor}
           />
         )}

--- a/content/webapp/components/ImagePlaceholder/ImagePlaceholder.tsx
+++ b/content/webapp/components/ImagePlaceholder/ImagePlaceholder.tsx
@@ -12,7 +12,7 @@ const Wrapper = styled.div<{
 
 const Pattern = styled.div`
   position: absolute;
-  background-image: ${`url('${repeatingLs}')`};
+  background-image: url('${repeatingLs}');
   background-size: cover;
   width: 100%;
   height: 100%;

--- a/content/webapp/components/ImagePlaceholder/ImagePlaceholder.tsx
+++ b/content/webapp/components/ImagePlaceholder/ImagePlaceholder.tsx
@@ -24,9 +24,7 @@ type Props = {
   backgroundColor?: ColorSelection;
 };
 
-const ImagePlaceholder: FunctionComponent<Props> = ({
-  backgroundColor,
-}: Props) => (
+const ImagePlaceholder: FunctionComponent<Props> = ({ backgroundColor }) => (
   <Wrapper backgroundColor={backgroundColor || 'accent.purple'}>
     <img src={transparentGif} alt="" width="1" height="1" />
     <Pattern />

--- a/content/webapp/components/MediaObjectBase/MediaObjectBase.tsx
+++ b/content/webapp/components/MediaObjectBase/MediaObjectBase.tsx
@@ -47,10 +47,7 @@ const BaseImageWrapper = styled.div.attrs({
 })``;
 
 const BaseTitleWrapper = styled.div.attrs({
-  className: classNames({
-    'card-link__title': true,
-    [font('wb', 3)]: true,
-  }),
+  className: `card-link__title ${font('wb', 3)}`,
 })``;
 
 export type HasImageProps = {

--- a/content/webapp/components/SearchResults/SearchResults.tsx
+++ b/content/webapp/components/SearchResults/SearchResults.tsx
@@ -86,7 +86,7 @@ const SearchResults: FunctionComponent<Props> = ({
             {item.type === 'event-series' && (
               <CompactCard
                 url={`/event-series/${item.id}`}
-                title={item.title || ''}
+                title={item.title}
                 primaryLabels={item.labels}
                 secondaryLabels={[]}
                 description={item.promo && item.promo.caption}
@@ -119,7 +119,7 @@ const SearchResults: FunctionComponent<Props> = ({
             {item.type === 'books' && (
               <CompactCard
                 url={`/books/${item.id}`}
-                title={item.title || ''}
+                title={item.title}
                 primaryLabels={item.labels}
                 secondaryLabels={[]}
                 description={item.promo && item.promo.caption}

--- a/content/webapp/components/SearchResults/SearchResults.tsx
+++ b/content/webapp/components/SearchResults/SearchResults.tsx
@@ -2,14 +2,11 @@ import { Fragment, FunctionComponent } from 'react';
 import styled from 'styled-components';
 import { MultiContent } from '../../types/multi-content';
 import { grid } from '@weco/common/utils/classnames';
-import { formatDate } from '@weco/common/utils/format-date';
 import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImage';
 import CompactCard from '../CompactCard/CompactCard';
 import EventCard from '../EventCard/EventCard';
-import ImagePlaceholder from '../ImagePlaceholder/ImagePlaceholder';
 import Space from '@weco/common/views/components/styled/Space';
 import ArticleCard from '../ArticleCard/ArticleCard';
-import { ArticleScheduleItem } from '../../types/article-schedule-items';
 import { getCrop } from '@weco/common/model/image';
 import { Card } from '../../types/card';
 
@@ -20,7 +17,7 @@ const Result = styled.div`
 export type Props = {
   title?: string;
   summary?: string;
-  items: readonly (MultiContent | ArticleScheduleItem | Card)[];
+  items: readonly (MultiContent | Card)[];
   showPosition?: boolean;
 };
 
@@ -189,23 +186,6 @@ const SearchResults: FunctionComponent<Props> = ({
                     />
                   )
                 }
-                xOfY={{ x: index + 1, y: items.length }}
-              />
-            )}
-            {item.type === 'article-schedule-items' && (
-              <CompactCard
-                title={item.title || ''}
-                partNumber={item.partNumber}
-                partNumberColor={item.color}
-                primaryLabels={
-                  /* We don't show a label on items that haven't been published yet, because
-                   * we don't know whether they're a story, comic, etc.
-                   * See https://github.com/wellcomecollection/wellcomecollection.org/pull/7568 */
-                  []
-                }
-                secondaryLabels={[]}
-                description={`Available ${formatDate(item.publishDate)}`}
-                Image={<ImagePlaceholder backgroundColor={item.color} />}
                 xOfY={{ x: index + 1, y: items.length }}
               />
             )}

--- a/content/webapp/components/SeriesNavigation/SeriesNavigation.tsx
+++ b/content/webapp/components/SeriesNavigation/SeriesNavigation.tsx
@@ -4,13 +4,12 @@ import SpacingComponent from '@weco/common/views/components/SpacingComponent/Spa
 import Layout8 from '@weco/common/views/components/Layout8/Layout8';
 import { Series } from '../../types/series';
 import { ArticleBasic } from '../../types/articles';
-import { ArticleScheduleItem } from '../../types/article-schedule-items';
 import Space from '@weco/common/views/components/styled/Space';
 import SearchResults from '../SearchResults/SearchResults';
 
 type Props = {
   series: Series;
-  items: readonly (ArticleBasic | ArticleScheduleItem)[];
+  items: ArticleBasic[];
   isPodcast: boolean;
 };
 

--- a/content/webapp/components/StoryPromo/StoryPromo.tsx
+++ b/content/webapp/components/StoryPromo/StoryPromo.tsx
@@ -11,7 +11,11 @@ import {
   CardImageWrapper,
 } from '../Card/Card';
 import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImage';
-import { ArticleBasic } from '../../types/articles';
+import {
+  ArticleBasic,
+  getArticleColor,
+  getPartNumberInSeries,
+} from '../../types/articles';
 import { isNotUndefined } from '@weco/common/utils/array';
 import linkResolver from '@weco/common/services/prismic/link-resolver';
 import styled from 'styled-components';
@@ -46,26 +50,11 @@ const StoryPromo: FunctionComponent<Props> = ({
   const image = article.promo?.image;
   const url = linkResolver(article);
 
-  // This is a bit of nastiness as we can't access the articles within a series i.e.
-  // `thisArticle.series.schedule.articles.map(article => article.id === thisArticle.id)`
-  // So this only works on series that have a schedule, and a schedule where the titles
-  // match exactly with the schedule items. This wouldn't work with any series.
-  const seriesWithSchedule = article.series.find(series =>
-    (series.schedule ?? []).find(schedule => schedule.publishDate)
-  );
+  const seriesColor = getArticleColor(article);
 
-  const seriesColor = seriesWithSchedule?.color ?? undefined;
+  const partNumber = getPartNumberInSeries(article);
 
-  const seriesTitles =
-    seriesWithSchedule?.schedule?.map(scheduleItem => scheduleItem.title) || [];
-  const indexInSeriesSchedule = seriesTitles.indexOf(article.title);
-
-  const positionInSeriesSchedule =
-    isNotUndefined(indexInSeriesSchedule) && indexInSeriesSchedule !== -1
-      ? indexInSeriesSchedule + 1
-      : undefined;
-
-  const isSerial = Boolean(seriesWithSchedule);
+  const isSerial = article.series.some(series => series.schedule.length > 0);
 
   const labels = [article.format?.title, isSerial ? 'Serial' : undefined]
     .filter(isNotUndefined)
@@ -106,9 +95,9 @@ const StoryPromo: FunctionComponent<Props> = ({
 
       <CardBody>
         <div>
-          {positionInSeriesSchedule && (
+          {partNumber && (
             <PartNumberIndicator
-              number={positionInSeriesSchedule}
+              number={partNumber}
               backgroundColor={seriesColor}
             />
           )}

--- a/content/webapp/components/StoryPromo/StoryPromo.tsx
+++ b/content/webapp/components/StoryPromo/StoryPromo.tsx
@@ -34,9 +34,7 @@ const PartOf = styled.div.attrs({
 `;
 
 type Props = {
-  article: ArticleBasic & {
-    series: { id: string; title: string }[];
-  };
+  article: ArticleBasic;
   position: number;
   hidePromoText?: boolean;
   sizesQueries?: string;

--- a/content/webapp/components/StoryPromo/StoryPromo.tsx
+++ b/content/webapp/components/StoryPromo/StoryPromo.tsx
@@ -44,7 +44,7 @@ const StoryPromo: FunctionComponent<Props> = ({
   article,
   position,
   hidePromoText = false,
-}: Props) => {
+}) => {
   const image = article.promo?.image;
   const url = linkResolver(article);
 

--- a/content/webapp/pages/articles/[articleId].tsx
+++ b/content/webapp/pages/articles/[articleId].tsx
@@ -6,7 +6,11 @@ import {
   useEffect,
   ReactElement,
 } from 'react';
-import { Article, ArticleBasic } from '@weco/content/types/articles';
+import {
+  Article,
+  ArticleBasic,
+  getPartNumberInSeries,
+} from '@weco/content/types/articles';
 import { Series } from '@weco/content/types/series';
 import { font } from '@weco/common/utils/classnames';
 import { capitalize } from '@weco/common/utils/grammar';
@@ -206,9 +210,7 @@ const ArticlePage: FunctionComponent<Props> = ({ article, jsonLd }) => {
 
   // Check if the article is in a serial, and where
   const serial = article.series.find(series => series.schedule.length > 0);
-  const titlesInSerial = serial && serial.schedule.map(item => item.title);
-  const positionInSerial =
-    titlesInSerial && titlesInSerial.indexOf(article.title) + 1;
+  const positionInSerial = getPartNumberInSeries(article);
 
   // We can abstract this out as a component if we see it elsewhere.
   // Not too confident it's going to be used like this for long.

--- a/content/webapp/pages/articles/[articleId].tsx
+++ b/content/webapp/pages/articles/[articleId].tsx
@@ -210,13 +210,13 @@ const ArticlePage: FunctionComponent<Props> = ({ article, jsonLd }) => {
 
   // Check if the article is in a serial, and where
   const serial = article.series.find(series => series.schedule.length > 0);
-  const positionInSerial = getPartNumberInSeries(article);
+  const partNumber = getPartNumberInSeries(article);
 
   // We can abstract this out as a component if we see it elsewhere.
   // Not too confident it's going to be used like this for long.
-  const TitleTopper = serial && positionInSerial && (
+  const TitleTopper = serial && partNumber && (
     <PartNumberIndicator
-      number={positionInSerial}
+      number={partNumber}
       backgroundColor={serial.color}
       description={isPodcast ? 'Episode' : 'Part'}
     />
@@ -298,7 +298,7 @@ const ArticlePage: FunctionComponent<Props> = ({ article, jsonLd }) => {
 
   const Siblings = listOfSeries
     ?.map(({ series, articles }) => {
-      return getNextUp(series, articles, article, positionInSerial, isPodcast);
+      return getNextUp(series, articles, article, partNumber, isPodcast);
     })
     .filter(Boolean);
 

--- a/content/webapp/pages/articles/[articleId].tsx
+++ b/content/webapp/pages/articles/[articleId].tsx
@@ -204,8 +204,7 @@ const ArticlePage: FunctionComponent<Props> = ({ article, jsonLd }) => {
     ],
   };
 
-  const isPodcast =
-    (article.format && article.format.id === ArticleFormatIds.Podcast) || false;
+  const isPodcast = article.format?.id === ArticleFormatIds.Podcast;
 
   // Check if the article is in a serial, and where
   const serial = article.series.find(series => series.schedule.length > 0);

--- a/content/webapp/pages/articles/[articleId].tsx
+++ b/content/webapp/pages/articles/[articleId].tsx
@@ -131,7 +131,6 @@ function getNextUp(
 
     return nextUp ? (
       <SeriesNavigation
-        key={series.id}
         series={series}
         items={[nextUp]}
         isPodcast={isPodcast}

--- a/content/webapp/pages/series/[seriesId].tsx
+++ b/content/webapp/pages/series/[seriesId].tsx
@@ -137,9 +137,10 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
         series,
         articles: {
           ...articles,
-          results: sortSeriesItems({ series, articles: articles.results }).map(
-            transformArticleToArticleBasic
-          ),
+          results: sortSeriesItems({
+            series,
+            articles: articles.results.map(transformArticleToArticleBasic),
+          }),
         },
         scheduledItems,
         serverData,

--- a/content/webapp/pages/series/[seriesId].tsx
+++ b/content/webapp/pages/series/[seriesId].tsx
@@ -34,10 +34,12 @@ import Pagination from '@weco/common/views/components/Pagination/Pagination';
 import { seasonsFetchLinks } from '@weco/content/services/prismic/types';
 import { Pageview } from '@weco/common/services/conversion/track';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
+import { ArticleScheduleItem } from '@weco/content/types/article-schedule-items';
 
 type Props = {
   series: Series;
   articles: PaginatedResults<ArticleBasic>;
+  scheduledItems: ArticleScheduleItem[];
   gaDimensions: GaDimensions;
   pageview: Pageview;
 };
@@ -121,6 +123,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
           ...paginatedArticles,
           articles,
         },
+        scheduledItems: [],
         serverData,
         gaDimensions: {
           partOf: series.seasons.map(season => season.id),

--- a/content/webapp/services/prismic/transformers/article-series.test.ts
+++ b/content/webapp/services/prismic/transformers/article-series.test.ts
@@ -1,0 +1,99 @@
+import { SeriesBasic } from '@weco/content/types/series';
+import { ArticleBasic } from '@weco/content/types/articles';
+import { sortSeriesItems } from './article-series';
+
+describe('sortSeriesItems', () => {
+  it('puts articles in a serial in part number order', () => {
+    // Here Prismic has returned the articles in descending date of publication;
+    // we want to sort them into serial part number order.
+
+    const series: SeriesBasic = {
+      id: 'YxnFmxEAAHzJngrE',
+      title: 'The Hidden Side of Violence',
+      labels: [{ text: 'Serial' }],
+      type: 'series',
+      schedule: [
+        {
+          type: 'article-schedule-items',
+          id: 'YxnFmxEAAHzJngrE_1',
+          title: 'Are people born violent?',
+          publishDate: new Date('2022-09-29T09:00:00.000Z'),
+          partNumber: 2,
+        },
+        {
+          type: 'article-schedule-items',
+          id: 'YxnFmxEAAHzJngrE_0',
+          title: 'What is violence?',
+          publishDate: new Date('2022-09-22T09:00:00.000Z'),
+          partNumber: 1,
+        },
+        {
+          type: 'article-schedule-items',
+          id: 'YxnFmxEAAHzJngrE_3',
+          title: 'Why do victims become violent?',
+          publishDate: new Date('2022-10-13T09:00:00.000Z'),
+          partNumber: 4,
+        },
+        {
+          type: 'article-schedule-items',
+          id: 'YxnFmxEAAHzJngrE_2',
+          title: 'Where does violence come from?',
+          publishDate: new Date('2022-10-06T09:00:00.000Z'),
+          partNumber: 3,
+        },
+        {
+          type: 'article-schedule-items',
+          id: 'YxnFmxEAAHzJngrE_5',
+          title: 'How can we prevent violence?',
+          publishDate: new Date('2022-10-27T09:00:00.000Z'),
+          partNumber: 6,
+        },
+        {
+          type: 'article-schedule-items',
+          id: 'YxnFmxEAAHzJngrE_4',
+          title: 'What is structural violence?',
+          publishDate: new Date('2022-10-20T09:00:00.000Z'),
+          partNumber: 5,
+        },
+      ],
+      color: 'accent.salmon',
+    };
+
+    const articles: ArticleBasic[] = [
+      {
+        type: 'articles',
+        id: 'Y0-8rxEAAA1CBr3a',
+        title: 'How can we prevent violence?',
+        series: [],
+        datePublished: new Date('2022-10-27T09:00:00.000Z'),
+        labels: [{ text: 'Serial' }],
+      },
+      {
+        type: 'articles',
+        id: 'Y0Uv0REAAImM14IP',
+        series: [],
+        title: 'What is structural violence?',
+        datePublished: new Date('2022-10-20T09:00:00.000Z'),
+        labels: [{ text: 'Serial' }],
+      },
+      {
+        type: 'articles',
+        id: 'Yz1IdhEAABfUtA8u',
+        series: [],
+        title: 'Why do victims become violent?',
+        datePublished: new Date('2022-10-13T09:00:01.000Z'),
+        labels: [{ text: 'Serial' }],
+      },
+    ];
+
+    const sortedTitles = sortSeriesItems({ series, articles }).map(
+      article => article.title
+    );
+
+    expect(sortedTitles).toStrictEqual([
+      'Why do victims become violent?',
+      'What is structural violence?',
+      'How can we prevent violence?',
+    ]);
+  });
+});

--- a/content/webapp/services/prismic/transformers/article-series.ts
+++ b/content/webapp/services/prismic/transformers/article-series.ts
@@ -1,6 +1,11 @@
-import { SeriesBasic } from '@weco/content/types/series';
-import { ArticleBasic } from '@weco/content/types/articles';
+import { Series } from '@weco/content/types/series';
+import { Article } from '@weco/content/types/articles';
 import { ArticleScheduleItem } from '@weco/content/types/article-schedule-items';
+
+type ArticleSeriesProps = {
+  series: Series;
+  articles: Article[];
+};
 
 /** Get a list of all the scheduled items in this series that haven't
  * been published yet.
@@ -13,10 +18,7 @@ import { ArticleScheduleItem } from '@weco/content/types/article-schedule-items'
 export function getScheduledItems({
   series,
   articles,
-}: {
-  series: SeriesBasic;
-  articles: ArticleBasic[];
-}): ArticleScheduleItem[] {
+}: ArticleSeriesProps): ArticleScheduleItem[] {
   // Get a list of titles that have already been published in this series.
   //
   // This may cause issues with extremely long serials, if a single page
@@ -26,4 +28,31 @@ export function getScheduledItems({
   const publishedTitles = articles.map(art => art.title);
 
   return series.schedule.filter(item => !publishedTitles.includes(item.title));
+}
+
+/** Given a list of articles in a series, put them in the right order.
+ *
+ *    - If this is part of a serial (e.g. Finding Audrey Amiss), then they go
+ *      in ascending schedule order -- from earliest published to latest published.
+ *
+ *    - If this is part of an ongoing series (e.g. Inside Our Collections), then they
+ *      go in descending publication order.
+ *
+ */
+export function sortSeriesItems({
+  series,
+  articles,
+}: ArticleSeriesProps): Article[] {
+  if (series.schedule.length > 0) {
+    const scheduleTitles = series.schedule.map(item => item.title);
+
+    return articles.sort(
+      (a, b) =>
+        scheduleTitles.indexOf(a.title) - scheduleTitles.indexOf(b.title)
+    );
+  } else {
+    return articles.sort(
+      (a, b) => a.datePublished.valueOf() - b.datePublished.valueOf()
+    );
+  }
 }

--- a/content/webapp/services/prismic/transformers/article-series.ts
+++ b/content/webapp/services/prismic/transformers/article-series.ts
@@ -1,10 +1,10 @@
-import { Series } from '@weco/content/types/series';
-import { Article } from '@weco/content/types/articles';
+import { SeriesBasic } from '@weco/content/types/series';
+import { ArticleBasic } from '@weco/content/types/articles';
 import { ArticleScheduleItem } from '@weco/content/types/article-schedule-items';
 
 type ArticleSeriesProps = {
-  series: Series;
-  articles: Article[];
+  series: SeriesBasic;
+  articles: ArticleBasic[];
 };
 
 /** Get a list of all the scheduled items in this series that haven't
@@ -42,9 +42,11 @@ export function getScheduledItems({
 export function sortSeriesItems({
   series,
   articles,
-}: ArticleSeriesProps): Article[] {
+}: ArticleSeriesProps): ArticleBasic[] {
   if (series.schedule.length > 0) {
-    const scheduleTitles = series.schedule.map(item => item.title);
+    const scheduleTitles = series.schedule
+      .sort((a, b) => a.partNumber - b.partNumber)
+      .map(item => item.title);
 
     return articles.sort(
       (a, b) =>

--- a/content/webapp/types/articles.test.ts
+++ b/content/webapp/types/articles.test.ts
@@ -1,0 +1,68 @@
+import { ArticleBasic } from '@weco/content/types/articles';
+import { getPartNumberInSeries } from './articles';
+
+describe('getPartNumberInSeries', () => {
+  it('finds the part number, if available', () => {
+    const article: ArticleBasic = {
+      type: 'articles',
+      id: 'Y_iu0RQAACYAwp8A',
+      series: [
+        {
+          id: 'Y_OGkRQAACgAq4ui',
+          type: 'series',
+          title: 'Finding Audrey Amiss',
+          labels: [{ text: 'Serial' }],
+          color: 'accent.green',
+          schedule: [
+            {
+              type: 'article-schedule-items',
+              id: 'Y_OGkRQAACgAq4ui_0',
+              title: 'Who was Audrey Amiss?',
+              publishDate: new Date('2023-03-02T00:00:00.000Z'),
+              partNumber: 1,
+            },
+            {
+              type: 'article-schedule-items',
+              id: 'Y_OGkRQAACgAq4ui_1',
+              title: 'Cataloguing Audrey',
+              publishDate: new Date('2023-03-09T00:00:00.000Z'),
+              partNumber: 2,
+            },
+          ],
+        },
+      ],
+      title: 'Cataloguing Audrey',
+      datePublished: new Date('2023-03-09T14:00:01.000Z'),
+      labels: [{ text: 'Serial' }],
+    };
+
+    const partNumber = getPartNumberInSeries(article);
+
+    expect(partNumber).toBe(2);
+  });
+
+  it('returns undefined if there is no part number', () => {
+    const article: ArticleBasic = {
+      type: 'articles',
+      id: 'Y-0A1hQAACUAjrjg',
+      series: [
+        {
+          id: 'WsSUrR8AAL3KGFPF',
+          type: 'series',
+          title: 'Inside Our Collections',
+          labels: [{ text: 'Series' }],
+          color: 'accent.blue',
+          schedule: [],
+        },
+      ],
+      title: 'Stones for healing',
+      format: { id: 'W5uKaCQAACkA3C0T', title: 'In pictures' },
+      datePublished: new Date('2023-02-21T10:00:01.000Z'),
+      labels: [{ text: 'In pictures' }],
+    };
+
+    const partNumber = getPartNumberInSeries(article);
+
+    expect(partNumber).toBeUndefined();
+  });
+});

--- a/content/webapp/types/articles.ts
+++ b/content/webapp/types/articles.ts
@@ -53,6 +53,19 @@ export function getPositionInSeries(article: ArticleBasic): number | undefined {
   }
 }
 
+/** Given an article in a serial, return its part number.
+ *
+ * e.g. "Cataloguing Audrey" is the second article in the "Finding Audrey Amiss" serial,
+ * so it has a part number of 2.
+ */
+export function getPartNumberInSeries(
+  article: ArticleBasic
+): number | undefined {
+  return article.series
+    .flatMap(series => series.schedule)
+    .find(scheduleItem => scheduleItem.title === article.title)?.partNumber;
+}
+
 export function getArticleColor(article: ArticleBasic): ColorSelection {
   return (
     article.series.map(series => series.color).find(Boolean) || 'accent.purple'

--- a/content/webapp/types/articles.ts
+++ b/content/webapp/types/articles.ts
@@ -42,17 +42,6 @@ export type Article = GenericContentFields & {
   contributors: Contributor[];
 };
 
-export function getPositionInSeries(article: ArticleBasic): number | undefined {
-  const serialisedSeries = article.series.find(
-    series => series.schedule.length > 0
-  );
-  if (serialisedSeries) {
-    const titles = serialisedSeries.schedule.map(item => item.title);
-    const index = titles.indexOf(article.title);
-    return index > -1 ? index + 1 : undefined;
-  }
-}
-
 /** Given an article in a serial, return its part number.
  *
  * e.g. "Cataloguing Audrey" is the second article in the "Finding Audrey Amiss" serial,


### PR DESCRIPTION
This makes a couple of changes to the way we handle article series pages, e.g. https://wellcomecollection.org/series/Y_OGkRQAACgAq4ui

* It removes the confusing `transformArticleSeries`, which was both difficult to follow and had a misleading return type – it claimed to return `ArticleBasic[]`, but actually it returned `(ArticleBasic | ArticleScheduleItem)[]`.

   Instead, we now construct two lists inside the getServerSideProps for article series pages:

    ```typescript
    articles: ArticleBasic[];
    scheduledItems: ArticleScheduleItem[];
    ```

    This means we can simplify how we render them on the page – we display all the articles, then all the scheduled items.

    It also makes some of our assumptions about how these pages behave explicit – for example, Prismic returns articles in descending publication order (newest articles first), but on serials we want the opposite behaviour. This was happening in the old `transformArticleSeries` method, but it wasn't obvious that this was happening – there's now a new `sortSeriesItems` to be clear about what the intended behaviour here is.

* The scheduled items are rendered by a new ArticleScheduleItemCard component, which I've extracted from SearchResults – that component was being used for several different purposes and felt a bit overloaded, but now we don't have to use it for article series pages.

* We had ~two~ three different implementations for working out the part number of an article within a serial (one on the individual articles, one on the series page, one for featured cards) – and they were overcomplicated. I've created a single function which is tested, and I'm using it in both places.

   A nice side effect of this is that already-published articles now retain their part numbers on series pages, e.g.:

     <img width="1149" alt="Screenshot 2023-03-10 at 19 34 35" src="https://user-images.githubusercontent.com/301220/224411267-f70b62f4-7160-4eb2-b415-309f6c81802e.png">

    (Notice also that we lose the vertical line at the top of the results)


Closes https://github.com/wellcomecollection/wellcomecollection.org/issues/8516