### PR TITLE
Make images display: block

### DIFF
--- a/common/views/components/HeightRestrictedPrismicImage/HeightRestrictedPrismicImage.tsx
+++ b/common/views/components/HeightRestrictedPrismicImage/HeightRestrictedPrismicImage.tsx
@@ -16,6 +16,7 @@ export type Props = {
 const PrismicImage = styled(Image)`
   color: ${props => props.theme.color('white')};
   background-color: ${props => props.theme.color('neutral.700')};
+  display: block;
 `;
 
 function determineSize(viewPortImageDifference: number): string {

--- a/common/views/components/PrismicImage/PrismicImage.tsx
+++ b/common/views/components/PrismicImage/PrismicImage.tsx
@@ -10,7 +10,7 @@ const StyledImage = styled(Image)<{ $desaturate: boolean }>`
   filter: ${props => (props.$desaturate ? 'saturate(0%)' : undefined)};
   width: 100%;
   height: auto;
-  margin-bottom: -7.7px;
+  display: block;
 `;
 
 export type BreakpointSizes = Partial<Record<Breakpoint, number>>;


### PR DESCRIPTION
## Who is this for?
People who want TASL info icons to line up in the right place

## What is it doing for them?
Amending the image positioning (and removing magic negative bottom margin)