### PR TITLE
add GA id to GTM iframe source

### DIFF
--- a/common/services/app/google-analytics.tsx
+++ b/common/services/app/google-analytics.tsx
@@ -70,16 +70,17 @@ export const GoogleTagManager: FunctionComponent = () => (
   />
 );
 
-export const GoogleTagManagerNoScript: FunctionComponent = () => (
-  <noscript>
-    <iframe
-      src="https://www.googletagmanager.com/ns.html?id=GTM-53DFWQD"
-      height="0"
-      width="0"
-      style={{ display: 'none', visibility: 'hidden' }}
-    ></iframe>
-  </noscript>
-);
+export const GoogleTagManagerNoScript: FunctionComponent<{ gaUserId: string }> =
+  ({ gaUserId }) => (
+    <noscript>
+      <iframe
+        src={`https://www.googletagmanager.com/ns.html?id=GTM-53DFWQD&gaUserId=${encodeURIComponent(gaUserId)}`}
+        height="0"
+        width="0"
+        style={{ display: 'none', visibility: 'hidden' }}
+      ></iframe>
+    </noscript>
+  );
 
 export const GoogleAnalyticsUA: FunctionComponent = () => (
   <script

--- a/common/views/pages/_document.tsx
+++ b/common/views/pages/_document.tsx
@@ -17,6 +17,7 @@ import {
   GoogleTagManagerNoScript,
   GaDimensions,
 } from '../../services/app/google-analytics';
+import { getCookie } from 'cookies-next';
 
 const {
   ANALYTICS_WRITE_KEY = '78Czn5jNSaMSVrBq2J9K4yJjWxh6fyRI',
@@ -44,6 +45,7 @@ class WecoDoc extends Document<DocumentInitialPropsWithTogglesAndGa> {
   static async getInitialProps(
     ctx: DocumentContext
   ): Promise<DocumentInitialPropsWithTogglesAndGa> {
+    const gaUserId = getCookie('_ga', ctx);
     const sheet = new ServerStyleSheet();
     let pageProps;
     const originalRenderPage = ctx.renderPage;
@@ -62,6 +64,7 @@ class WecoDoc extends Document<DocumentInitialPropsWithTogglesAndGa> {
         ...initialProps,
         toggles: pageProps.serverData?.toggles,
         gaDimensions: pageProps.gaDimensions,
+        gaUserId,
         styles: (
           <>
             {initialProps.styles}
@@ -92,7 +95,7 @@ class WecoDoc extends Document<DocumentInitialPropsWithTogglesAndGa> {
           />
         </Head>
         <body>
-          <GoogleTagManagerNoScript />
+          <GoogleTagManagerNoScript gaUserId={this.props.gaUserId || ''} />
           <div id="top">
             <Main />
           </div>

--- a/common/views/pages/_document.tsx
+++ b/common/views/pages/_document.tsx
@@ -40,12 +40,13 @@ function renderSegmentSnippet() {
 type DocumentInitialPropsWithTogglesAndGa = DocumentInitialProps & {
   toggles: Toggles;
   gaDimensions?: GaDimensions;
+  gaUserId?: string;
 };
 class WecoDoc extends Document<DocumentInitialPropsWithTogglesAndGa> {
   static async getInitialProps(
     ctx: DocumentContext
   ): Promise<DocumentInitialPropsWithTogglesAndGa> {
-    const gaUserId = getCookie('_ga', ctx);
+    const gaUserId = getCookie('_ga', ctx) as string | undefined;
     const sheet = new ServerStyleSheet();
     let pageProps;
     const originalRenderPage = ctx.renderPage;


### PR DESCRIPTION
Relates to #9417, where I'm setting up tracking pageviews for visitors without javascript.

This PR adds a key value pair containing the GA user Id (taken from the _ga cookie) to the iframe source in the Google Tag Manager code, which then can be accessed as a Datalayer variable in Google Tag Manager and means we can send it with the event to Google Analytics.

Without this every pageview event would be seen as a new session. 