### PR TITLE
updating tf to add _ga cookie

### DIFF
--- a/cache/modules/cloudfront_policies/cache_policies.tf
+++ b/cache/modules/cloudfront_policies/cache_policies.tf
@@ -91,6 +91,7 @@ resource "aws_cloudfront_cache_policy" "weco_apps" {
               local.toggles_cookies,
               local.works_cookies,
               local.userpreference_cookies,
+              local.ga_cookies,
             )
           )
         )

--- a/cache/modules/cloudfront_policies/locals.tf
+++ b/cache/modules/cloudfront_policies/locals.tf
@@ -2,6 +2,7 @@ locals {
   toggles_cookies = ["toggles", "toggle_*"]
   works_cookies   = ["_queryType"]
   userpreference_cookies = ["WC_*"]
+  ga_cookies = ["_ga"]
 
   content_query_params = [
     "cachebust",

--- a/cache/modules/cloudfront_policies/request_policies.tf
+++ b/cache/modules/cloudfront_policies/request_policies.tf
@@ -14,6 +14,7 @@ resource "aws_cloudfront_origin_request_policy" "host_query_and_toggles" {
           concat(
             local.toggles_cookies,
             local.userpreference_cookies,
+            local.ga_cookies,
           )
         )
     }


### PR DESCRIPTION
Relates to #9430 

Makes the _ga identity cookie available on the server for use with no script tracking