### PR TITLE
Remove the width-dependent no-margin classes

### DIFF
--- a/catalogue/webapp/components/ItemRequestModal/RequestDialog.tsx
+++ b/catalogue/webapp/components/ItemRequestModal/RequestDialog.tsx
@@ -59,6 +59,14 @@ const WorkTitle = styled.span`
   display: block;
 `;
 
+const PickupDeadline = styled.p.attrs({
+  className: font('intr', 6),
+})`
+  ${props => props.theme.media('large')`
+    margin: 0;
+  `}
+`;
+
 type RequestDialogProps = {
   work: Work;
   item: PhysicalItem;
@@ -136,10 +144,10 @@ const RequestDialog: FunctionComponent<RequestDialogProps> = ({
                 Select the date you would like to view this item in the library.
               </p>
             </Space>
-            <p className={`${font('intr', 6)} no-margin-l`}>
+            <PickupDeadline>
               Item requests need to be placed by 10am on the working day before
               your visit. Please bear in mind the library is closed on Sundays.
-            </p>
+            </PickupDeadline>
           </PickUpDateDescription>
           <PickUpDateInputWrapper>
             <RequestingDayPicker

--- a/common/views/themes/utility-classes.ts
+++ b/common/views/themes/utility-classes.ts
@@ -116,32 +116,6 @@ export const utilityClasses = css<GlobalStyleProps>`
     margin: 0 !important;
   }
 
-  .no-margin-s.no-margin-s {
-    ${props =>
-      props.theme.mediaBetween(
-        'small',
-        'medium'
-      )(`
-        margin: 0;
-    `)}
-  }
-
-  .no-margin-m.no-margin-m {
-    ${props =>
-      props.theme.mediaBetween(
-        'medium',
-        'large'
-      )(`
-        margin: 0;
-    `)}
-  }
-
-  .no-margin-l.no-margin-l {
-    ${props => props.theme.media('large')`
-      margin: 0;
-    `}
-  }
-
   .promo-link {
     height: 100%;
     color: ${props => props.theme.color('black')};

--- a/content/webapp/components/EventSchedule/EventScheduleItem.tsx
+++ b/content/webapp/components/EventSchedule/EventScheduleItem.tsx
@@ -81,7 +81,7 @@ const EventScheduleItem: FunctionComponent<Props> = ({
               );
             })}
         </EventTimesWrapper>
-        <div className={`${grid({ s: 12, m: 12, l: 9, xl: 10 })}`}>
+        <div className={grid({ s: 12, m: 12, l: 9, xl: 10 })}>
           <div>
             {event.primaryLabels.length > 0 && (
               <Space v={{ size: 's', properties: ['margin-bottom'] }}>

--- a/content/webapp/components/EventSchedule/EventScheduleItem.tsx
+++ b/content/webapp/components/EventSchedule/EventScheduleItem.tsx
@@ -51,8 +51,12 @@ const EventTimesWrapper = styled(Space).attrs({
     size: 'm',
     properties: ['margin-bottom'],
   },
-  className: `${grid({ s: 12, m: 12, l: 3, xl: 2 })} no-margin-l`,
-})``;
+  className: grid({ s: 12, m: 12, l: 3, xl: 2 }),
+})`
+  ${props => props.theme.media('large')`
+    margin: 0;
+  `}
+`;
 
 const EventScheduleItem: FunctionComponent<Props> = ({
   event,

--- a/content/webapp/components/EventSchedule/EventScheduleItem.tsx
+++ b/content/webapp/components/EventSchedule/EventScheduleItem.tsx
@@ -46,6 +46,14 @@ const EventContainer = styled(Space).attrs({
   background-color: ${props => props.theme.color('yellow')};
 `;
 
+const EventTimesWrapper = styled(Space).attrs({
+  v: {
+    size: 'm',
+    properties: ['margin-bottom'],
+  },
+  className: `${grid({ s: 12, m: 12, l: 3, xl: 2 })} no-margin-l`,
+})``;
+
 const EventScheduleItem: FunctionComponent<Props> = ({
   event,
   isNotLinked,
@@ -57,13 +65,7 @@ const EventScheduleItem: FunctionComponent<Props> = ({
   return (
     <GridWrapper>
       <div className="grid">
-        <Space
-          v={{
-            size: 'm',
-            properties: ['margin-bottom'],
-          }}
-          className={`${grid({ s: 12, m: 12, l: 3, xl: 2 })} no-margin-l`}
-        >
+        <EventTimesWrapper>
           {event.times &&
             event.times.map(t => {
               const startTimeString = t.range.startDateTime.toISOString();
@@ -78,7 +80,7 @@ const EventScheduleItem: FunctionComponent<Props> = ({
                 </h4>
               );
             })}
-        </Space>
+        </EventTimesWrapper>
         <div className={`${grid({ s: 12, m: 12, l: 9, xl: 10 })}`}>
           <div>
             {event.primaryLabels.length > 0 && (


### PR DESCRIPTION
Another snip at https://github.com/wellcomecollection/wellcomecollection.org/issues/8420

We were only using the `no-margin-l` variant, so there wasn't much to clean up.