### PR TITLE
A/B test stories landing comics

### DIFF
--- a/content/webapp/pages/stories/index.tsx
+++ b/content/webapp/pages/stories/index.tsx
@@ -43,6 +43,8 @@ type Props = {
   articles: ArticleBasic[];
   comicSeries: SeriesBasic[];
   storiesLanding: StoriesLanding;
+  firstComicFromEachSeries: ArticleBasic[];
+  storiesLandingComicTest1: boolean;
   jsonLd: JsonLdObj[];
 };
 
@@ -67,6 +69,8 @@ const StoryPromoContainer = styled.div.attrs({
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
     const serverData = await getServerData(context);
+    const storiesLandingComicTest1 =
+      serverData.toggles.storiesLandingComicTest1;
     const client = createClient(context);
     const articlesQueryPromise = fetchArticles(client, {
       predicates: prismic.predicate.not(
@@ -108,6 +112,10 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
       id => comics.results.find(item => item.series[0].id === id)?.series[0]
     ) as Series[];
 
+    const firstComicFromEachSeries = comicSeriesIds.map(id =>
+      comics.results.filter(item => item.series[0].id === id).at(-1)
+    ) as ArticleBasic[];
+
     const basicComicSeries = comicSeries.map(transformSeriesToSeriesBasic);
 
     const jsonLd = articles.results.map(articleLd);
@@ -123,6 +131,8 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
         props: removeUndefinedProps({
           articles: basicArticles,
           comicSeries: basicComicSeries,
+          firstComicFromEachSeries: firstComicFromEachSeries,
+          storiesLandingComicTest1,
           serverData,
           jsonLd,
           storiesLanding,
@@ -136,6 +146,8 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
 const StoriesPage: FunctionComponent<Props> = ({
   articles,
   comicSeries,
+  firstComicFromEachSeries,
+  storiesLandingComicTest1,
   jsonLd,
   storiesLanding,
 }) => {
@@ -243,7 +255,9 @@ const StoriesPage: FunctionComponent<Props> = ({
 
         <SpacingComponent>
           <CardGrid
-            items={comicSeries}
+            items={
+              storiesLandingComicTest1 ? firstComicFromEachSeries : comicSeries
+            }
             itemsPerRow={3}
             itemsHaveTransparentBackground={true}
             links={[{ text: 'More comics', url: '/stories/comic' }]}

--- a/content/webapp/pages/stories/index.tsx
+++ b/content/webapp/pages/stories/index.tsx
@@ -44,7 +44,7 @@ type Props = {
   comicSeries: SeriesBasic[];
   storiesLanding: StoriesLanding;
   firstComicFromEachSeries: ArticleBasic[];
-  storiesLandingComicTest1: boolean;
+  comicTest1: boolean;
   jsonLd: JsonLdObj[];
 };
 
@@ -69,8 +69,7 @@ const StoryPromoContainer = styled.div.attrs({
 export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
   async context => {
     const serverData = await getServerData(context);
-    const storiesLandingComicTest1 =
-      serverData.toggles.storiesLandingComicTest1;
+    const comicTest1 = serverData.toggles.comicTest1;
     const client = createClient(context);
     const articlesQueryPromise = fetchArticles(client, {
       predicates: prismic.predicate.not(
@@ -132,7 +131,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
           articles: basicArticles,
           comicSeries: basicComicSeries,
           firstComicFromEachSeries: firstComicFromEachSeries,
-          storiesLandingComicTest1,
+          comicTest1,
           serverData,
           jsonLd,
           storiesLanding,
@@ -147,7 +146,7 @@ const StoriesPage: FunctionComponent<Props> = ({
   articles,
   comicSeries,
   firstComicFromEachSeries,
-  storiesLandingComicTest1,
+  comicTest1,
   jsonLd,
   storiesLanding,
 }) => {
@@ -255,9 +254,7 @@ const StoriesPage: FunctionComponent<Props> = ({
 
         <SpacingComponent>
           <CardGrid
-            items={
-              storiesLandingComicTest1 ? firstComicFromEachSeries : comicSeries
-            }
+            items={comicTest1 ? firstComicFromEachSeries : comicSeries}
             itemsPerRow={3}
             itemsHaveTransparentBackground={true}
             links={[{ text: 'More comics', url: '/stories/comic' }]}

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -52,7 +52,15 @@ const toggles = {
         'Adds tabbed navigation to the works page, for switching between work, item and related content',
     },
   ] as const,
-  tests: [] as ABTest[],
+  tests: [
+    {
+      id: 'storiesLandingComicTest1',
+      title:
+        'A/B test linking to series pages or individual comics from last three series',
+      range: [50, 50],
+      when: () => true,
+    },
+  ] as ABTest[],
 };
 
 export default toggles;

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -54,7 +54,7 @@ const toggles = {
   ] as const,
   tests: [
     {
-      id: 'storiesLandingComicTest1',
+      id: 'comicTest1',
       title:
         'A/B test linking to series pages or individual comics from last three series',
       range: [0, 99],

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -57,7 +57,7 @@ const toggles = {
       id: 'storiesLandingComicTest1',
       title:
         'A/B test linking to series pages or individual comics from last three series',
-      range: [50, 50],
+      range: [0, 99],
       when: () => true,
     },
   ] as ABTest[],


### PR DESCRIPTION
Part of #9083

This is `A` (what we currently have) vs. `C` from [this comment on the ticket](https://github.com/wellcomecollection/wellcomecollection.org/issues/9083#issuecomment-1470242091) (which felt like the option with least problems to me).

Is 'total comics viewed' the right measure of success? On the one hand, it would seem to be slightly unfair on the `A` condition since it would require _first_ visiting a series landing page. On the other hand, perhaps that's a more appealing journey from the off?

Or if we don't think it's a fair test, do we need something more along the lines of 'more clicks on one of the three cards in the comics section on the stories landing page' as the measure?

@taceybadgerbrook and @jennpb do you have any opinions/thoughts about the above?