### PR TITLE
Switch to styled-components instead of one-line classes in RadioGroup

### DIFF
--- a/common/views/components/RadioGroup/RadioGroup.tsx
+++ b/common/views/components/RadioGroup/RadioGroup.tsx
@@ -3,7 +3,7 @@ import React, { FunctionComponent } from 'react';
 import CheckboxRadio from '../CheckboxRadio/CheckboxRadio';
 import Space from '../styled/Space';
 
-export type RadioGroupOption = {
+type RadioGroupOption = {
   value: string;
   id: string;
   label: string;

--- a/common/views/components/RadioGroup/RadioGroup.tsx
+++ b/common/views/components/RadioGroup/RadioGroup.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from 'react';
+import styled from 'styled-components';
 
 import CheckboxRadio from '../CheckboxRadio/CheckboxRadio';
 import Space from '../styled/Space';
@@ -8,6 +9,20 @@ type RadioGroupOption = {
   id: string;
   label: string;
 };
+
+type WrapperProps = { isLast: boolean };
+
+const CheckboxRadioWrapper = styled(Space).attrs<WrapperProps>(props => ({
+  v: {
+    size: 'm',
+    properties: ['padding-top', 'padding-bottom'],
+    overrides: { small: 3, medium: 3, large: 3 },
+  },
+  h: !props.isLast ? { size: 'm', properties: ['margin-right'] } : undefined,
+}))<WrapperProps>`
+  display: inline-flex;
+  justify-content: center;
+`;
 
 type Props = {
   name: string;
@@ -24,20 +39,7 @@ const RadioGroup: FunctionComponent<Props> = ({
 }) => (
   <div>
     {options.map(({ value, label, id }, index) => (
-      <Space
-        key={value}
-        v={{
-          size: 'm',
-          properties: ['padding-top', 'padding-bottom'],
-          overrides: { small: 3, medium: 3, large: 3 },
-        }}
-        h={
-          index !== options.length - 1
-            ? { size: 'm', properties: ['margin-right'] }
-            : undefined
-        }
-        className="flex-inline flex--h-center"
-      >
+      <CheckboxRadioWrapper key={value} isLast={index === options.length - 1}>
         <CheckboxRadio
           id={id}
           text={label}
@@ -47,7 +49,7 @@ const RadioGroup: FunctionComponent<Props> = ({
           checked={selected === value}
           onChange={() => onChange(value)}
         />
-      </Space>
+      </CheckboxRadioWrapper>
     ))}
   </div>
 );

--- a/common/views/components/RadioGroup/RadioGroup.tsx
+++ b/common/views/components/RadioGroup/RadioGroup.tsx
@@ -4,12 +4,6 @@ import styled from 'styled-components';
 import CheckboxRadio from '../CheckboxRadio/CheckboxRadio';
 import Space from '../styled/Space';
 
-type RadioGroupOption = {
-  value: string;
-  id: string;
-  label: string;
-};
-
 type WrapperProps = { isLast: boolean };
 
 const CheckboxRadioWrapper = styled(Space).attrs<WrapperProps>(props => ({
@@ -23,6 +17,12 @@ const CheckboxRadioWrapper = styled(Space).attrs<WrapperProps>(props => ({
   display: inline-flex;
   justify-content: center;
 `;
+
+type RadioGroupOption = {
+  value: string;
+  id: string;
+  label: string;
+};
 
 type Props = {
   name: string;


### PR DESCRIPTION
Continuing to chip away at https://github.com/wellcomecollection/wellcomecollection.org/issues/8420