### PR TITLE
Focus visible

### DIFF
--- a/catalogue/webapp/components/ArchiveTree/ArchiveTree.tsx
+++ b/catalogue/webapp/components/ArchiveTree/ArchiveTree.tsx
@@ -79,7 +79,6 @@ const Tree = styled.div<{ isEnhanced?: boolean }>`
 type TreeItemProps = {
   isEnhanced?: boolean;
   showGuideline?: boolean;
-  hideFocus?: boolean;
 };
 
 const TreeItem = styled.li.attrs<TreeItemProps>(props => ({
@@ -88,9 +87,14 @@ const TreeItem = styled.li.attrs<TreeItemProps>(props => ({
   position: relative;
   list-style: ${props => (props.isEnhanced ? 'none' : 'disc')};
   padding: 0;
+
+  &:focus-visible,
   &:focus {
-    outline: ${props =>
-      !props.hideFocus ? `2px solid ${props.theme.color('black')}` : 'none'};
+    outline: 2px solid ${props => props.theme.color('black')};
+  }
+
+  :focus:not(:focus-visible) {
+    outline: none;
   }
 
   &.guideline::before,
@@ -161,7 +165,6 @@ const TreeControl = styled.span<{ highlightCondition?: string }>`
 type StyledLinkProps = {
   isCurrent?: boolean;
   hasControl?: boolean;
-  hideFocus?: boolean;
 };
 
 const StyledLink = styled.a<StyledLinkProps>`
@@ -184,9 +187,16 @@ const StyledLink = styled.a<StyledLinkProps>`
       : 0};
   padding-right: ${props => `${props.theme.spacingUnit * 2}px`};
   text-decoration: none;
+
+  &:focus-visible,
   &:focus {
-    outline: ${props => (!props.hideFocus ? 'auto' : 'none')};
+    outline: 'auto';
   }
+
+  :focus:not(:focus-visible) {
+    outline: none;
+  }
+
   &:focus,
   &:hover {
     text-decoration: underline;
@@ -490,7 +500,7 @@ const ListItem: FunctionComponent<ListItemProps> = ({
   setShowArchiveTree,
   archiveAncestorArray,
 }: ListItemProps) => {
-  const { isKeyboard, isEnhanced } = useContext(AppContext);
+  const { isEnhanced } = useContext(AppContext);
   const isEndNode = item.children && item.children.length === 0;
   const isSelected =
     (tabbableId && tabbableId === item.work.id) ||
@@ -528,7 +538,6 @@ const ListItem: FunctionComponent<ListItemProps> = ({
   }
   return (
     <TreeItem
-      hideFocus={!isKeyboard}
       isEnhanced={isEnhanced}
       showGuideline={isEnhanced && hasControl && item.openStatus && level > 1}
       id={item.work.id}
@@ -669,7 +678,6 @@ const ListItem: FunctionComponent<ListItemProps> = ({
               [font('intb', 6)]: level === 1,
               [font('intr', 6)]: level > 1,
             })}
-            hideFocus={!isKeyboard}
             tabIndex={isEnhanced ? (isSelected ? 0 : -1) : 0}
             isCurrent={currentWorkId === item.work.id}
             ref={currentWorkId === item.work.id ? selected : undefined}

--- a/catalogue/webapp/components/WorkDetails/ExplanatoryText.tsx
+++ b/catalogue/webapp/components/WorkDetails/ExplanatoryText.tsx
@@ -28,21 +28,22 @@ const IconContainer = styled.div<IconContainerProps>`
   }
 `;
 
-type ControlProps = {
-  hideFocus: boolean;
-};
-
-/* eslint-disable @typescript-eslint/no-unused-vars */
-const Control = styled.button.attrs(props => ({
+const Control = styled.button.attrs({
   className: `plain-button ${font('intb', 5)}`,
-}))<ControlProps>`
+})`
   display: flex;
   align-items: center;
 
   cursor: pointer;
   padding: 0;
+
+  &:focus-visible,
   &:focus {
-    outline: ${props => (!props.hideFocus ? 'intial' : 'none')};
+    outline: 'initial';
+  }
+
+  :focus:not(:focus-visible) {
+    outline: none;
   }
 `;
 
@@ -69,7 +70,7 @@ const ExplanatoryText: FunctionComponent<Props> = ({
   controlText,
   children,
 }: Props) => {
-  const { isEnhanced, isKeyboard } = useContext(AppContext);
+  const { isEnhanced } = useContext(AppContext);
   const [showContent, setShowContent] = useState(true);
   useEffect(() => {
     setShowContent(false);
@@ -83,7 +84,6 @@ const ExplanatoryText: FunctionComponent<Props> = ({
           onClick={() => {
             setShowContent(!showContent);
           }}
-          hideFocus={!isKeyboard}
         >
           <Space as="span" h={{ size: 's', properties: ['margin-right'] }}>
             <IconContainer open={showContent}>

--- a/common/views/components/AppContext/AppContext.tsx
+++ b/common/views/components/AppContext/AppContext.tsx
@@ -12,7 +12,6 @@ import { Size } from '@weco/common/views/themes/config';
 
 type AppContextProps = {
   isEnhanced: boolean;
-  isKeyboard: boolean;
   isFullSupportBrowser: boolean;
   windowSize: Size;
   audioPlaybackRate: number;
@@ -21,7 +20,6 @@ type AppContextProps = {
 
 const appContextDefaults = {
   isEnhanced: false,
-  isKeyboard: true,
   isFullSupportBrowser: false,
   windowSize: 'small' as Size,
   audioPlaybackRate: 1,
@@ -51,7 +49,6 @@ export const AppContextProvider: FunctionComponent<AppContextProviderProps> = ({
   children,
 }: AppContextProviderProps): ReactElement<AppContextProviderProps> => {
   const [isEnhanced, setIsEnhanced] = useState(appContextDefaults.isEnhanced);
-  const [isKeyboard, setIsKeyboard] = useState(appContextDefaults.isKeyboard);
   const [isFullSupportBrowser, setIsFullSupportBrowser] = useState(
     appContextDefaults.isFullSupportBrowser
   );
@@ -86,35 +83,12 @@ export const AppContextProvider: FunctionComponent<AppContextProviderProps> = ({
     // The presence of IntersectionObserver is a useful proxy for browsers that we
     // want to support in full: https://caniuse.com/intersectionobserver
     setIsFullSupportBrowser('IntersectionObserver' in window);
-
-    document.addEventListener('mousedown', setIsKeyboardFalse);
-    document.addEventListener('keydown', setIsKeyboardTrue);
-
-    return () => {
-      document.removeEventListener('mousedown', setIsKeyboardFalse);
-      document.removeEventListener('keydown', setIsKeyboardTrue);
-    };
   }, []);
-
-  function setIsKeyboardFalse() {
-    document &&
-      document.documentElement &&
-      document.documentElement.classList.remove('is-keyboard');
-    setIsKeyboard(false);
-  }
-
-  function setIsKeyboardTrue() {
-    document &&
-      document.documentElement &&
-      document.documentElement.classList.add('is-keyboard');
-    setIsKeyboard(true);
-  }
 
   return (
     <AppContext.Provider
       value={{
         isEnhanced,
-        isKeyboard,
         isFullSupportBrowser,
         windowSize,
         audioPlaybackRate,

--- a/common/views/components/ButtonSolid/ButtonSolid.tsx
+++ b/common/views/components/ButtonSolid/ButtonSolid.tsx
@@ -38,12 +38,14 @@ export const BaseButton = styled.button.attrs<BaseButtonProps>(props => ({
   white-space: nowrap;
   cursor: pointer;
 
+  &:focus-visible,
   &:focus {
+    box-shadow: ${props => props.theme.focusBoxShadow};
     outline: 0;
+  }
 
-    .is-keyboard & {
-      box-shadow: ${props => props.theme.focusBoxShadow};
-    }
+  :focus:not(:focus-visible) {
+    box-shadow: none;
   }
 
   &[disabled],
@@ -160,7 +162,7 @@ export const SolidButton = styled(BaseButton).attrs<SolidButtonProps>(
 )<SolidButtonProps>`
   padding: ${props => getPadding(props.size)};
   ${props => `
-    background: 
+    background:
       ${props.theme.color(
         props?.colors?.background || props.theme.buttonColors.default.background
       )};

--- a/common/views/components/CheckboxRadio/CheckboxRadio.tsx
+++ b/common/views/components/CheckboxRadio/CheckboxRadio.tsx
@@ -56,12 +56,13 @@ const CheckboxRadioInput = styled.input.attrs(props => ({
     border-color: ${props => props.theme.color('black')};
   }
 
-  .is-keyboard & {
-    &:focus ~ ${CheckboxRadioBox} {
-      outline: 0;
-      box-shadow: ${props => props.theme.focusBoxShadow};
-      border-color: ${props => props.theme.color('black')};
-    }
+  &:focus-visible ~ ${CheckboxRadioBox}, &:focus ~ ${CheckboxRadioBox} {
+    box-shadow: ${props => props.theme.focusBoxShadow};
+    outline: 0;
+  }
+
+  &:focus ~ ${CheckboxRadioBox}:not(:focus-visible ~ ${CheckboxRadioBox}) {
+    box-shadow: none;
   }
 `;
 

--- a/common/views/components/Modal/Modal.tsx
+++ b/common/views/components/Modal/Modal.tsx
@@ -2,7 +2,6 @@ import {
   ReactNode,
   useEffect,
   useRef,
-  useContext,
   FunctionComponent,
   RefObject,
   MutableRefObject,
@@ -10,14 +9,9 @@ import {
 import styled from 'styled-components';
 import Space from '../styled/Space';
 import Icon from '../Icon/Icon';
-import { AppContext } from '../AppContext/AppContext';
 import { CSSTransition } from 'react-transition-group';
 import { cross } from '@weco/common/icons';
 import FocusTrap from 'focus-trap-react';
-
-type CloseButtonProps = {
-  hideFocus: boolean;
-};
 
 type BaseModalProps = {
   width?: string | null;
@@ -49,12 +43,12 @@ const Overlay = styled.div`
   `}
 `;
 
-const CloseButton = styled(Space).attrs<CloseButtonProps>({
+const CloseButton = styled(Space).attrs({
   as: 'button',
   type: 'button',
   v: { size: 'm', properties: ['top'] },
   h: { size: 'm', properties: ['left'] },
-})<CloseButtonProps>`
+})`
   position: fixed;
   width: 28px;
   height: 28px;
@@ -66,9 +60,13 @@ const CloseButton = styled(Space).attrs<CloseButtonProps>({
   outline: 0;
   z-index: 1;
 
+  &:focus-visible,
   &:focus {
-    ${props =>
-      !props.hideFocus && `border: 2px solid ${props.theme.color('black')}`}
+    outline: border: 2px solid ${props => props.theme.color('black')};
+  }
+
+  :focus:not(:focus-visible) {
+    outline: none;
   }
 
   .icon {
@@ -200,7 +198,6 @@ const Modal: FunctionComponent<Props> = ({
   modalStyle,
 }: Props) => {
   const closeButtonRef: RefObject<HTMLInputElement> = useRef(null);
-  const { isKeyboard } = useContext(AppContext);
   const ModalWindow = determineModal(modalStyle);
   const initialLoad = useRef(true);
   const nodeRef = useRef(null);
@@ -273,7 +270,6 @@ const Modal: FunctionComponent<Props> = ({
                 onClick={() => {
                   setIsActive(false);
                 }}
-                hideFocus={!isKeyboard}
               >
                 <span className="visually-hidden">Close modal window</span>
                 <Icon icon={cross} />

--- a/common/views/components/PopupDialog/PopupDialog.tsx
+++ b/common/views/components/PopupDialog/PopupDialog.tsx
@@ -3,7 +3,6 @@ import {
   useState,
   useRef,
   useEffect,
-  useContext,
   KeyboardEvent as ReactKeyboardEvent,
 } from 'react';
 import styled from 'styled-components';
@@ -14,7 +13,6 @@ import Space from '../styled/Space';
 import { font } from '../../../utils/classnames';
 import getFocusableElements from '../../../utils/get-focusable-elements';
 import { trackGaEvent } from '../../../utils/ga';
-import { AppContext } from '../AppContext/AppContext';
 import { PopupDialogPrismicDocument } from '../../../services/prismic/documents';
 import PrismicHtmlBlock from '../PrismicHtmlBlock/PrismicHtmlBlock';
 import { chat, clear } from '../../../icons';
@@ -111,7 +109,7 @@ const PopupDialogWindow = styled(Space).attrs({
 
 const PopupDialogClose = styled.button.attrs({
   className: 'plain-button',
-})<{ isKeyboard: boolean }>`
+})`
   margin: 0 !important;
   padding: 0;
 
@@ -123,14 +121,14 @@ const PopupDialogClose = styled.button.attrs({
   top: 10px;
   right: 10px;
 
+  &:focus-visible,
   &:focus {
+    box-shadow: ${props => props.theme.focusBoxShadow};
     outline: 0;
+  }
 
-    ${props =>
-      props.isKeyboard &&
-      `
-      box-shadow: ${props.theme.focusBoxShadow};
-    `}
+  :focus:not(:focus-visible) {
+    box-shadow: none;
   }
 `;
 
@@ -179,7 +177,6 @@ const PopupDialog: FunctionComponent<Props> = ({ document }: Props) => {
   const closeDialogRef = useRef<HTMLButtonElement>(null);
   const ctaRef = useRef<HTMLAnchorElement>(null);
   const dialogWindowRef = useRef<HTMLDivElement>(null);
-  const { isKeyboard } = useContext(AppContext);
 
   function hasPersistentState() {
     const cardiganHosts = ['localhost:9001', 'cardigan.wellcomecollection.org'];
@@ -313,7 +310,6 @@ const PopupDialog: FunctionComponent<Props> = ({ document }: Props) => {
       </PopupDialogOpen>
       <PopupDialogWindow ref={dialogWindowRef} isActive={isActive}>
         <PopupDialogClose
-          isKeyboard={isKeyboard}
           title="close dialog"
           ref={closeDialogRef}
           tabIndex={isActive ? 0 : -1}

--- a/common/views/components/SearchTabs/SearchTabs.BaseTabs.tsx
+++ b/common/views/components/SearchTabs/SearchTabs.BaseTabs.tsx
@@ -30,9 +30,19 @@ const Tab = styled.button.attrs((props: TabProps) => ({
 }))<TabProps>`
   color: ${props => props.theme.color('black')};
   cursor: pointer;
+
   &:focus {
     outline: 0;
   }
+
+  &[aria-selected='true']:focus-visible,
+  &:focus-visible + [aria-selected='true'] {
+    box-shadow: ${props => props.theme.focusBoxShadow};
+    position: relative;
+    z-index: 1;
+    outline: 0;
+  }
+
   padding: 0;
   width: 50%;
   ${props => props.theme.media('medium')`

--- a/common/views/components/SearchTabs/SearchTabs.tsx
+++ b/common/views/components/SearchTabs/SearchTabs.tsx
@@ -16,7 +16,6 @@ type TabProps = {
   isLast: boolean;
   isActive: boolean;
   isFocused: boolean;
-  isKeyboard: boolean;
 };
 const Tab = styled(Space).attrs({
   as: 'span',
@@ -35,14 +34,6 @@ const Tab = styled(Space).attrs({
     `
     border-color: ${props.theme.color('warmNeutral.300')};
     background: ${props.theme.color('warmNeutral.300')};
-  `}
-
-  ${props =>
-    props.isFocused &&
-    `
-    box-shadow: ${props.isKeyboard ? props.theme.focusBoxShadow : null};
-    position: relative;
-    z-index: 1;
   `}
 
   width: 100%;
@@ -65,7 +56,7 @@ const SearchTabs: FunctionComponent<Props> = ({
   query,
   activeTabIndex,
 }: Props): ReactElement<Props> => {
-  const { isKeyboard, isEnhanced } = useContext(AppContext);
+  const { isEnhanced } = useContext(AppContext);
   const searchImagesFormRef = useRef<HTMLFormElement>();
   const searchWorksFormRef = useRef<HTMLFormElement>();
 
@@ -99,12 +90,7 @@ const SearchTabs: FunctionComponent<Props> = ({
               </NextLink>
             )}
           >
-            <Tab
-              isActive={true}
-              isFocused={isFocused}
-              isKeyboard={isKeyboard}
-              isLast={false}
-            >
+            <Tab isActive={true} isFocused={isFocused} isLast={false}>
               Library catalogue
             </Tab>
           </ConditionalWrapper>
@@ -179,12 +165,7 @@ const SearchTabs: FunctionComponent<Props> = ({
               </NextLink>
             )}
           >
-            <Tab
-              isActive={false}
-              isFocused={isFocused}
-              isKeyboard={isKeyboard}
-              isLast={true}
-            >
+            <Tab isActive={false} isFocused={isFocused} isLast={true}>
               Images
             </Tab>
           </ConditionalWrapper>

--- a/common/views/components/SelectContainer/SelectContainer.tsx
+++ b/common/views/components/SelectContainer/SelectContainer.tsx
@@ -1,6 +1,5 @@
-import { useContext, ReactElement, FunctionComponent } from 'react';
+import { ReactElement, FunctionComponent } from 'react';
 import { chevron } from '@weco/common/icons';
-import { AppContext } from '../AppContext/AppContext';
 import styled from 'styled-components';
 import Space from '../styled/Space';
 import Icon from '../Icon/Icon';
@@ -8,7 +7,6 @@ import { classNames, font } from '../../../utils/classnames';
 import useIsFontsLoaded from '@weco/common/hooks/useIsFontsLoaded';
 
 type StyledSelectProps = {
-  isKeyboard: boolean;
   isFontsLoaded: boolean;
   isPill?: boolean;
   darkBg?: boolean;
@@ -51,14 +49,14 @@ const StyledSelect = styled.div.attrs({
       box-shadow: ${props => props.theme.focusBoxShadow};
     }
 
+    &:focus-visible,
     &:focus {
+      box-shadow: ${props => props.theme.focusBoxShadow};
       outline: 0;
+    }
 
-      ${props =>
-        props.isKeyboard &&
-        `
-        box-shadow: ${props.theme.focusBoxShadow};
-      `}
+    :focus:not(:focus-visible) {
+      box-shadow: none;
     }
   }
 `;
@@ -94,16 +92,10 @@ const SelectContainer: FunctionComponent<Props> = ({
   isPill,
   darkBg,
 }) => {
-  const { isKeyboard } = useContext(AppContext);
   const isFontsLoaded = useIsFontsLoaded();
 
   return (
-    <StyledSelect
-      isKeyboard={isKeyboard}
-      isFontsLoaded={isFontsLoaded}
-      isPill={isPill}
-      darkBg={darkBg}
-    >
+    <StyledSelect isFontsLoaded={isFontsLoaded} isPill={isPill} darkBg={darkBg}>
       <Label>
         <LabelContent hideLabel={hideLabel}>{label}</LabelContent>
         {children}

--- a/common/views/pages/_document.tsx
+++ b/common/views/pages/_document.tsx
@@ -80,7 +80,7 @@ class WecoDoc extends Document<DocumentInitialPropsWithTogglesAndGa> {
 
   render(): ReactElement<DocumentInitialProps> {
     return (
-      <Html lang="en" className="is-keyboard">
+      <Html lang="en">
         <Head>
           {/* Adding toggles etc. to the datalayer so they are available to events in Google Tag Manager */}
           <Ga4DataLayer

--- a/common/views/themes/typography.ts
+++ b/common/views/themes/typography.ts
@@ -167,11 +167,14 @@ export const typography = css<GlobalStyleProps>`
       text-decoration: none;
     }
 
-    .is-keyboard & {
-      &:focus {
-        outline: 0;
-        box-shadow: ${themeValues.focusBoxShadow};
-      }
+    &:focus-visible,
+    &:focus {
+      box-shadow: ${props => props.theme.focusBoxShadow};
+      outline: 0;
+    }
+
+    :focus:not(:focus-visible) {
+      box-shadow: none;
     }
   }
 


### PR DESCRIPTION
We are currently using JS to determine whether you're using a keyboard and applying visual focus styles accordingly.

`:focus-visible` is [well supported](https://caniuse.com/?search=focus-visible) and means we can achieve the same results without JS.

Explainer: [When is :focus-visible visible](https://bitsofco.de/when-is-focus-visible-visible/)