### PR TITLE
Remove the unused underline-on-hover class

### DIFF
--- a/common/views/themes/utility-classes.ts
+++ b/common/views/themes/utility-classes.ts
@@ -87,11 +87,6 @@ export const utilityClasses = css<GlobalStyleProps>`
     }
   }
 
-  .underline-on-hover:hover,
-  :link:hover .underline-on-hover {
-    text-decoration: underline;
-  }
-
   .no-visible-focus {
     &,
     &:focus {


### PR DESCRIPTION
This isn't used anywhere, so we can remove it.