### PR TITLE
Prevent scrollbar being overlayed in Safari

### DIFF
--- a/catalogue/webapp/components/IIIFViewer/ImageViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ImageViewer.tsx
@@ -18,7 +18,7 @@ const ImageWrapper = styled.div`
   top: 0;
   left: 0;
   bottom: 0;
-  right: 0;
+  right: 20px;
   padding: 0;
   img {
     margin: auto;

--- a/catalogue/webapp/components/IIIFViewer/MainViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/MainViewer.tsx
@@ -59,7 +59,7 @@ const ThumbnailWrapper = styled.div<{ imageLoaded?: boolean }>`
   opacity: ${props => (props.imageLoaded ? 1 : 0)};
   transition: opacity 500ms ease;
   position: absolute;
-  width: 100%;
+  width: calc(100% - 20px);
   height: 100%;
   img {
     position: relative;


### PR DESCRIPTION
Fixes #6520
