### PR TITLE
Make work.workType optional

### DIFF
--- a/catalogue/webapp/components/WorkHeader/WorkHeader.tsx
+++ b/catalogue/webapp/components/WorkHeader/WorkHeader.tsx
@@ -96,17 +96,19 @@ const WorkHeader: FunctionComponent<Props> = ({ work }) => {
               />
             )}
 
-            <Space
-              v={{
-                size: 'm',
-                properties: ['margin-top'],
-              }}
-            >
-              <LabelsList
-                labels={cardLabels}
-                defaultLabelColor="warmNeutral.300"
-              />
-            </Space>
+            {cardLabels && (
+              <Space
+                v={{
+                  size: 'm',
+                  properties: ['margin-top'],
+                }}
+              >
+                <LabelsList
+                  labels={cardLabels}
+                  defaultLabelColor="warmNeutral.300"
+                />
+              </Space>
+            )}
 
             {collectionManifestsCount > 0 && (
               <Space v={{ size: 'm', properties: ['margin-top'] }}>

--- a/catalogue/webapp/components/WorksSearchResult/WorksSearchResult.tsx
+++ b/catalogue/webapp/components/WorksSearchResult/WorksSearchResult.tsx
@@ -70,12 +70,14 @@ const WorkSearchResult: FunctionComponent<Props> = ({
             </Preview>
           )}
           <Details>
-            <Space v={{ size: 's', properties: ['margin-bottom'] }}>
-              <LabelsList
-                labels={cardLabels}
-                defaultLabelColor="warmNeutral.300"
-              />
-            </Space>
+            {cardLabels && (
+              <Space v={{ size: 's', properties: ['margin-bottom'] }}>
+                <LabelsList
+                  labels={cardLabels}
+                  defaultLabelColor="warmNeutral.300"
+                />
+              </Space>
+            )}
             <WorkTitleHeading>
               <WorkTitle title={work.title} />
             </WorkTitleHeading>

--- a/catalogue/webapp/pages/works/[workId]/index.tsx
+++ b/catalogue/webapp/pages/works/[workId]/index.tsx
@@ -66,7 +66,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
           // we shouldn't overload this
           // these metrics allow us to report back on breadth of collection accessed
           properties: {
-            workType: workResponse.workType.id,
+            workType: workResponse.workType?.id,
             identifiers: workResponse.identifiers.map(id => id.value),
             identifierTypes: workResponse.identifiers.map(
               id => id.identifierType.id

--- a/catalogue/webapp/services/catalogue/types/index.ts
+++ b/catalogue/webapp/services/catalogue/types/index.ts
@@ -26,7 +26,7 @@ export type Work = {
   referenceNumber?: string;
   description?: string;
   physicalDescription: string;
-  workType: WorkType;
+  workType?: WorkType;
   lettering?: string;
   createdDate?: Period;
   contributors: Contributor[];

--- a/catalogue/webapp/utils/works.ts
+++ b/catalogue/webapp/utils/works.ts
@@ -74,26 +74,6 @@ export function getDownloadOptionsFromImageUrl(
   }
 }
 
-const workTypeIcons = {
-  '3dobjects': 'threeD',
-  ebooks: 'book',
-  books: 'book',
-  audio: 'audio',
-  'digital images': 'digitalImage',
-  journals: 'journal',
-  maps: 'map',
-  music: 'music',
-  sound: 'music',
-  pictures: 'picture',
-  'archives and manuscripts': 'archive',
-  ephemera: 'threeD',
-  evideos: 'video',
-  websites: 'website',
-};
-export function getWorkTypeIcon(work: Work): string | undefined {
-  return workTypeIcons[work.workType.label.toLowerCase()];
-}
-
 type StacksItemStatus = {
   id: string;
   label: string;
@@ -246,12 +226,14 @@ export const getArchiveLabels = (work: Work): ArchiveLabels | undefined => {
   return undefined;
 };
 
-export const getCardLabels = (work: Work): Label[] => {
-  const cardLabels = [{ text: work.workType.label }];
-  if (isAvailableOnline(work)) {
-    return [...cardLabels, { text: 'Online', labelColor: 'white' }];
-  } else {
-    return cardLabels;
+export const getCardLabels = (work: Work): Label[] | undefined => {
+  if (work.workType) {
+    const cardLabels = [{ text: work.workType.label }];
+    if (isAvailableOnline(work)) {
+      return [...cardLabels, { text: 'Online', labelColor: 'white' }];
+    } else {
+      return cardLabels;
+    }
   }
 };
 


### PR DESCRIPTION
## Who is this for?
Bug with works causing search and work page to error
[Slack alert](https://wellcome.slack.com/archives/CQ720BG02/p1679590032417649)
[Slack investigation thread](https://wellcome.slack.com/archives/CQ720BG02/p1679590105902349)

## What is it doing for them?
`workType` was typed as a required field in the API response when[ it is typed as optional on their side](https://wellcome.slack.com/archives/CQ720BG02/p1679656658549799?thread_ts=1679590105.902349&cid=CQ720BG02). This makes it optional on the FE as well.
I've deleted `getWorkTypeIcon` as I couldn't find it in use anywhere.