### PR TITLE
make the sign in button description more descriptive

### DIFF
--- a/common/views/components/DropdownButton/DropdownButton.tsx
+++ b/common/views/components/DropdownButton/DropdownButton.tsx
@@ -82,7 +82,7 @@ const Popper = styled.div<{ isVisible: boolean }>`
 
 type Props = {
   id: string;
-  label: string;
+  label: ReactNode;
   ariaLabel?: string;
   buttonType?: 'outlined' | 'inline' | 'borderless';
   isOnDark?: boolean;

--- a/common/views/components/DropdownButton/DropdownButton.tsx
+++ b/common/views/components/DropdownButton/DropdownButton.tsx
@@ -82,7 +82,8 @@ const Popper = styled.div<{ isVisible: boolean }>`
 
 type Props = {
   id: string;
-  label: ReactNode;
+  label: string;
+  ariaLabel?: string;
   buttonType?: 'outlined' | 'inline' | 'borderless';
   isOnDark?: boolean;
   iconLeft?: IconSvg;
@@ -92,6 +93,7 @@ type Props = {
 
 const DropdownButton: FunctionComponent<PropsWithChildren<Props>> = ({
   label,
+  ariaLabel,
   children,
   buttonType = 'outlined',
   isOnDark,
@@ -159,6 +161,7 @@ const DropdownButton: FunctionComponent<PropsWithChildren<Props>> = ({
     icon: chevron,
     isIconAfter: true,
     text: label,
+    ariaLabel,
     type: ButtonTypes.button,
     ariaControls: id,
     ariaExpanded: isActive,
@@ -200,7 +203,7 @@ const DropdownButton: FunctionComponent<PropsWithChildren<Props>> = ({
           iconLeft={iconLeft}
           type="button"
           text={label}
-          aria-label={id}
+          aria-label={ariaLabel}
         />
       )}
       {isEnhanced && (

--- a/common/views/components/Header/DesktopSignIn.tsx
+++ b/common/views/components/Header/DesktopSignIn.tsx
@@ -47,6 +47,7 @@ const DesktopSignIn: FunctionComponent = () => {
       {state === 'signedout' && (
         <SignedOutWrapper>
           <DropdownButton
+            label=""
             ariaLabel="library account sign in"
             iconLeft={userIcon}
             id="signedin-dropdown"

--- a/common/views/components/Header/DesktopSignIn.tsx
+++ b/common/views/components/Header/DesktopSignIn.tsx
@@ -47,7 +47,7 @@ const DesktopSignIn: FunctionComponent = () => {
       {state === 'signedout' && (
         <SignedOutWrapper>
           <DropdownButton
-            label=""
+            ariaLabel="library account sign in"
             iconLeft={userIcon}
             id="signedin-dropdown"
             buttonType="borderless"


### PR DESCRIPTION
I noticed that the aria-label was being populated by the id prop and this didn't make any sense when being read out by a screen reader, so I've added a more descriptive ariaLabel prop
