### PR TITLE
Toggle false should not be considered the same as undefined for test toggles

### DIFF
--- a/common/server-data/toggles.ts
+++ b/common/server-data/toggles.ts
@@ -46,14 +46,23 @@ export function getTogglesFromContext(
     }),
     {} as Toggles
   );
-  const tests = [...togglesResp.tests].reduce(
-    (acc, test) => ({
+  const tests = [...togglesResp.tests].reduce((acc, test) => {
+    function testToggleValue(Id: string): boolean | undefined {
+      const cookieValue = allCookies[`toggle_${Id}`];
+      switch (cookieValue) {
+        case 'true':
+          return true;
+        case 'false':
+          return false;
+        default:
+          return undefined;
+      }
+    }
+    return {
       ...acc,
-      [test.id]: allCookies[`toggle_${test.id}`] === 'true',
-    }),
-    {} as Toggles
-  );
-
+      [test.id]: testToggleValue(test.id),
+    };
+  }, {} as Toggles);
   return { ...toggles, ...tests };
 }
 

--- a/common/services/app/google-analytics.tsx
+++ b/common/services/app/google-analytics.tsx
@@ -34,7 +34,7 @@ export const Ga4DataLayer: FunctionComponent<Props> = ({ data }) => {
           return !togglesGaCanIgnore.includes(toggle);
         })
         .map(toggle => {
-          switch (data.toggles[toggle]) {
+          switch (data.toggles?.[toggle]) {
             case true:
               return toggle;
             case false:

--- a/common/services/app/google-analytics.tsx
+++ b/common/services/app/google-analytics.tsx
@@ -31,20 +31,26 @@ export const Ga4DataLayer: FunctionComponent<Props> = ({ data }) => {
   const toggles = data.toggles
     ? Object.keys(data.toggles)
         .filter(toggle => {
-          return (
-            Boolean(data.toggles?.[toggle]) &&
-            !togglesGaCanIgnore.includes(toggle)
-          );
+          return !togglesGaCanIgnore.includes(toggle);
+        })
+        .map(toggle => {
+          switch (data.toggles[toggle]) {
+            case true:
+              return toggle;
+            case false:
+              return `!${toggle}`;
+          }
         })
         .join(',')
     : null;
+
   return toggles ? (
     <script
       dangerouslySetInnerHTML={{
         __html: `
         window.dataLayer = window.dataLayer || [];
         window.dataLayer.push({
-          ${toggles ? `toggles: '${toggles}',` : ''}
+          toggles: '${toggles}'
         });
         `,
       }}

--- a/common/views/themes/default.ts
+++ b/common/views/themes/default.ts
@@ -97,7 +97,7 @@ const cls = {
 } as any as Classes & SizedClasses;
 
 export type GlobalStyleProps = {
-  toggles?: { [key: string]: boolean };
+  toggles?: { [key: string]: boolean | undefined };
   isFontsLoaded?: boolean;
 };
 

--- a/content/webapp/pages/stories/index.tsx
+++ b/content/webapp/pages/stories/index.tsx
@@ -44,7 +44,7 @@ type Props = {
   comicSeries: SeriesBasic[];
   storiesLanding: StoriesLanding;
   firstComicFromEachSeries: ArticleBasic[];
-  comicTest1: boolean;
+  comicTest1: boolean | undefined;
   jsonLd: JsonLdObj[];
 };
 

--- a/toggles/webapp/index.ts
+++ b/toggles/webapp/index.ts
@@ -12,4 +12,4 @@ export type TogglesResp = { toggles: PublishedToggle[]; tests: ABTest[] };
 
 // Don't be tempted to make the keys on this optional - keeping them
 // as required means we catch dead code left over from removed toggles
-export type Toggles = Record<ToggleId | TestId, boolean>;
+export type Toggles = Record<ToggleId | TestId, boolean | undefined>;


### PR DESCRIPTION
Relates to #9473

- This makes it possible to send a value of false for a test toggle to GA and Segment
  - The false value will now only be false if it is explicitly set to false
  - If the toggle is undefined no data will be sent

This also implements sending the data to GA, i'll open a new PR for sending the data with the segment tracking code
