### PR TITLE
bump typescript to 5.0.2 for webapps

### DIFF
--- a/catalogue/webapp/components/Work/Work.tsx
+++ b/catalogue/webapp/components/Work/Work.tsx
@@ -146,7 +146,7 @@ const Work: FunctionComponent<Props> = ({ work, apiUrl }) => {
   });
   const showTabbedNav =
     worksTabbedNav &&
-    (shouldShowItemLink || (audio?.sounds.length || []) > 0 || video);
+    (shouldShowItemLink || (audio?.sounds || []).length > 0 || video);
   // we want to experiment with showing the tabs for audio and video content
   // so we can't rely on shouldShowItemLink if we have that content
   const imageUrl =

--- a/catalogue/webapp/package.json
+++ b/catalogue/webapp/package.json
@@ -46,7 +46,7 @@
     "supertest": "^4.0.2",
     "ts-jest": "29.0.5",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.5"
+    "typescript": "^5.0.2"
   },
   "browserslist": [
     "last 2 versions",

--- a/common/package.json
+++ b/common/package.json
@@ -60,7 +60,7 @@
     "superjson": "^1.9.1",
     "timezone-mock": "^1.3.6",
     "ts-jest": "29.0.5",
-    "typescript": "^4.9.5",
+    "typescript": "^5.0.2",
     "url-template": "^2.0.8",
     "uuid": "^8.3.2",
     "webpack-bundle-analyzer": "^4.4.2"

--- a/content/webapp/package.json
+++ b/content/webapp/package.json
@@ -35,6 +35,6 @@
     "styled-components": "^5.3.8",
     "supertest": "^4.0.2",
     "ts-jest": "29.0.5",
-    "typescript": "^4.9.5"
+    "typescript": "^5.0.2"
   }
 }

--- a/identity/webapp/package.json
+++ b/identity/webapp/package.json
@@ -74,7 +74,7 @@
     "msw": "^0.27.0",
     "nodemon": "^2.0.15",
     "ts-jest": "29.0.5",
-    "typescript": "4.8.4",
+    "typescript": "5.0.2",
     "typescript-plugin-styled-components": "^1.4.4",
     "whatwg-fetch": "^3.6.2"
   }

--- a/playwright/yarn.lock
+++ b/playwright/yarn.lock
@@ -341,10 +341,10 @@ type-fest@^0.21.3:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
-typescript@^4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@^4.9.5:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19321,10 +19321,10 @@ typescript-plugin-styled-components@^1.4.4:
   resolved "https://registry.yarnpkg.com/typescript-plugin-styled-components/-/typescript-plugin-styled-components-1.6.0.tgz#6ee1d2b079490ad101055112fda1974d761f2e96"
   integrity sha512-cUCbOuY0iNr1JjPYC5MqCiABrfv2ouLift+7gi4vS0gBPQySUT006wHCjwzynMfU5LGMQaZqpssAgzRRjt30Ng==
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@5.0.2, typescript@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.2.tgz#891e1a90c5189d8506af64b9ef929fca99ba1ee5"
+  integrity sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==
 
 typescript@^4.4.4:
   version "4.9.4"


### PR DESCRIPTION
upgrade typescript to 5.0.2 while fixing the errors that would come from attempting to build catalogue
