### PR TITLE
Replace a bunch of explicit children properties with PropsWithChildren

### DIFF
--- a/cardigan/config/decorators.tsx
+++ b/cardigan/config/decorators.tsx
@@ -1,13 +1,12 @@
-import { ReactNode, ComponentType, FunctionComponent } from 'react';
+import { ComponentType, FunctionComponent, PropsWithChildren } from 'react';
 import { ThemeProvider } from 'styled-components';
 import theme, { GlobalStyle } from '@weco/common/views/themes/default';
 import { AppContextProvider } from '@weco/common/views/components/AppContext/AppContext';
 import Space from '@weco/common/views/components/styled/Space';
 
-type Props = {
-  children: ReactNode;
-};
-export const ContextDecorator: FunctionComponent<Props> = ({ children }) => {
+export const ContextDecorator: FunctionComponent<PropsWithChildren> = ({
+  children,
+}) => {
   return (
     <ThemeProvider theme={theme}>
       <GlobalStyle isFontsLoaded={true} />
@@ -56,12 +55,12 @@ const ReadMeInfo = ({ Readme }: { Readme: ComponentType }) => {
   );
 };
 
-type ReadmeDecoratorProps = {
+type ReadmeDecoratorProps = PropsWithChildren<{
   WrappedComponent: ComponentType;
   args: Record<string, unknown>;
   Readme: ComponentType;
   order?: 'componentFirst' | 'readmeFirst';
-};
+}>;
 
 export const ReadmeDecorator: FunctionComponent<ReadmeDecoratorProps> = ({
   WrappedComponent,

--- a/catalogue/webapp/components/ArchiveBreadcrumb/ArchiveBreadcrumb.tsx
+++ b/catalogue/webapp/components/ArchiveBreadcrumb/ArchiveBreadcrumb.tsx
@@ -4,7 +4,7 @@ import DropdownButton from '@weco/common/views/components/DropdownButton/Dropdow
 import Icon from '@weco/common/views/components/Icon/Icon';
 import WorkTitle from '../WorkTitle/WorkTitle';
 import { getArchiveAncestorArray } from '../../utils/works';
-import { FunctionComponent, ReactNode, useContext } from 'react';
+import { FunctionComponent, PropsWithChildren, useContext } from 'react';
 import WorkLink from '../WorkLink';
 import IsArchiveContext from '../IsArchiveContext/IsArchiveContext';
 import { archive, folder } from '@weco/common/icons';
@@ -75,14 +75,13 @@ const ArchiveBreadcrumbNav = styled.nav`
   }
 `;
 
-type ArchiveWorkLinkProps = {
+type ArchiveWorkLinkProps = PropsWithChildren<{
   id: string;
-  children: ReactNode;
-};
+}>;
 const ArchiveWorkLink: FunctionComponent<ArchiveWorkLinkProps> = ({
   id,
   children,
-}: ArchiveWorkLinkProps) => {
+}) => {
   return (
     <WorkLink id={id} source="archive_tree">
       {children}
@@ -94,7 +93,7 @@ type Props = {
   work: Work;
 };
 
-const ArchiveBreadcrumb: FunctionComponent<Props> = ({ work }: Props) => {
+const ArchiveBreadcrumb: FunctionComponent<Props> = ({ work }) => {
   const archiveAncestorArray = getArchiveAncestorArray(work);
   const firstCrumb = archiveAncestorArray[0];
   const middleCrumbs =

--- a/catalogue/webapp/components/IIIFClickthrough/IIIFClickthrough.tsx
+++ b/catalogue/webapp/components/IIIFClickthrough/IIIFClickthrough.tsx
@@ -1,4 +1,9 @@
-import { FunctionComponent, ReactNode, useEffect, useState } from 'react';
+import {
+  FunctionComponent,
+  PropsWithChildren,
+  useEffect,
+  useState,
+} from 'react';
 import { AuthClickThroughServiceWithPossibleServiceArray } from '../../../webapp/types/manifest';
 import { AuthAccessTokenService } from '@iiif/presentation-3';
 import { font } from '@weco/common/utils/classnames';
@@ -20,21 +25,20 @@ function reloadAuthIframe(document: Document, id: string) {
   authMessageIframe.src = authMessageIframe.src;
 }
 
-type Props = {
+type Props = PropsWithChildren<{
   clickThroughService:
     | AuthClickThroughServiceWithPossibleServiceArray
     | undefined;
   tokenService: AuthAccessTokenService | undefined;
   trackingId: string;
-  children: ReactNode;
-};
+}>;
 
 const IIIFClickthrough: FunctionComponent<Props> = ({
   clickThroughService,
   tokenService,
   trackingId,
   children,
-}: Props) => {
+}) => {
   const [origin, setOrigin] = useState<string>();
   const showClickthroughMessage = useShowClickthrough(
     clickThroughService,

--- a/catalogue/webapp/components/IIIFViewer/ViewerSidebar.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerSidebar.tsx
@@ -83,15 +83,13 @@ const AccordionButton = styled.button.attrs({
   padding: 0;
 `;
 
-const AccordionItem = ({
-  title,
-  children,
-  testId,
-}: {
+type AccordionItemProps = {
   title: string;
   children: ReactNode;
   testId?: string;
-}) => {
+};
+
+const AccordionItem = ({ title, children, testId }: AccordionItemProps) => {
   const [isActive, setIsActive] = useState(false);
   return (
     <Item data-test-id={testId}>

--- a/catalogue/webapp/components/IIIFViewer/ViewerSidebar.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerSidebar.tsx
@@ -3,7 +3,7 @@ import {
   useState,
   useContext,
   RefObject,
-  ReactNode,
+  PropsWithChildren,
 } from 'react';
 import NextLink from 'next/link';
 import WorkLink from '../WorkLink';
@@ -83,11 +83,10 @@ const AccordionButton = styled.button.attrs({
   padding: 0;
 `;
 
-type AccordionItemProps = {
+type AccordionItemProps = PropsWithChildren<{
   title: string;
-  children: ReactNode;
   testId?: string;
-};
+}>;
 
 const AccordionItem = ({ title, children, testId }: AccordionItemProps) => {
   const [isActive, setIsActive] = useState(false);

--- a/catalogue/webapp/components/WorkDetails/ExplanatoryText.tsx
+++ b/catalogue/webapp/components/WorkDetails/ExplanatoryText.tsx
@@ -5,6 +5,7 @@ import {
   useContext,
   FunctionComponent,
   ReactElement,
+  PropsWithChildren,
 } from 'react';
 import styled from 'styled-components';
 import { plus } from '@weco/common/icons';
@@ -59,17 +60,16 @@ const Content = styled.div<ContentProps>`
   display: ${props => (props.hidden ? 'none' : 'block')};
 `;
 
-type Props = {
+type Props = PropsWithChildren<{
   id: string;
   controlText: string;
-  children: ReactElement;
-};
+}>;
 
 const ExplanatoryText: FunctionComponent<Props> = ({
   id,
   controlText,
   children,
-}: Props) => {
+}) => {
   const { isEnhanced } = useContext(AppContext);
   const [showContent, setShowContent] = useState(true);
   useEffect(() => {

--- a/common/views/components/AppContext/AppContext.tsx
+++ b/common/views/components/AppContext/AppContext.tsx
@@ -3,9 +3,8 @@ import {
   createContext,
   useState,
   useEffect,
-  ReactElement,
   FunctionComponent,
-  ReactNode,
+  PropsWithChildren,
 } from 'react';
 import theme from '@weco/common/views/themes/default';
 import { Size } from '@weco/common/views/themes/config';
@@ -28,10 +27,6 @@ const appContextDefaults = {
 
 export const AppContext = createContext<AppContextProps>(appContextDefaults);
 
-type AppContextProviderProps = {
-  children: ReactNode;
-};
-
 function getWindowSize(): Size {
   switch (true) {
     case window.innerWidth < theme.sizes.medium:
@@ -45,9 +40,9 @@ function getWindowSize(): Size {
   }
 }
 
-export const AppContextProvider: FunctionComponent<AppContextProviderProps> = ({
+export const AppContextProvider: FunctionComponent<PropsWithChildren> = ({
   children,
-}: AppContextProviderProps): ReactElement<AppContextProviderProps> => {
+}) => {
   const [isEnhanced, setIsEnhanced] = useState(appContextDefaults.isEnhanced);
   const [isFullSupportBrowser, setIsFullSupportBrowser] = useState(
     appContextDefaults.isFullSupportBrowser

--- a/common/views/components/GlobalInfoBarContext/GlobalInfoBarContext.tsx
+++ b/common/views/components/GlobalInfoBarContext/GlobalInfoBarContext.tsx
@@ -1,8 +1,10 @@
-import { createContext, FunctionComponent, ReactNode, useState } from 'react';
+import {
+  createContext,
+  FunctionComponent,
+  PropsWithChildren,
+  useState,
+} from 'react';
 
-type Props = {
-  children: ReactNode;
-};
 type ContextProps = {
   isVisible: boolean;
   setIsVisible: (isVisible: boolean) => void;
@@ -13,9 +15,9 @@ const GlobalInfoBarContext = createContext<ContextProps>({
     // noop
   },
 });
-const GlobalInfoBarContextProvider: FunctionComponent<Props> = ({
+const GlobalInfoBarContextProvider: FunctionComponent<PropsWithChildren> = ({
   children,
-}: Props) => {
+}) => {
   const [isVisible, setIsVisible] = useState(false);
   return (
     <GlobalInfoBarContext.Provider

--- a/common/views/components/Layout/Layout.tsx
+++ b/common/views/components/Layout/Layout.tsx
@@ -1,12 +1,11 @@
-import { ReactNode, FunctionComponent } from 'react';
+import { FunctionComponent, PropsWithChildren } from 'react';
 import { grid, SizeMap } from '../../../utils/classnames';
 
-type Props = {
+type Props = PropsWithChildren<{
   gridSizes: SizeMap;
-  children: ReactNode;
-};
+}>;
 
-const Layout: FunctionComponent<Props> = ({ gridSizes, children }: Props) => (
+const Layout: FunctionComponent<Props> = ({ gridSizes, children }) => (
   <div className="container">
     <div className="grid">
       <div className={grid(gridSizes)}>{children}</div>

--- a/common/views/components/Layout10/Layout10.tsx
+++ b/common/views/components/Layout10/Layout10.tsx
@@ -1,10 +1,9 @@
-import { ReactNode, FunctionComponent } from 'react';
+import { FunctionComponent, PropsWithChildren } from 'react';
 import Layout from '../Layout/Layout';
 
-type Props = {
+type Props = PropsWithChildren<{
   isCentered?: boolean;
-  children: ReactNode;
-};
+}>;
 
 const Layout10: FunctionComponent<Props> = ({
   children,

--- a/common/views/components/Layout12/Layout12.tsx
+++ b/common/views/components/Layout12/Layout12.tsx
@@ -1,12 +1,8 @@
-import { ReactNode, FunctionComponent } from 'react';
+import { FunctionComponent, PropsWithChildren } from 'react';
 import Layout from '../Layout/Layout';
 
-type Props = {
-  children: ReactNode;
-};
-
 export const gridSize12 = { s: 12, m: 12, l: 12, xl: 12 };
-const Layout12: FunctionComponent<Props> = ({ children }) => (
+const Layout12: FunctionComponent<PropsWithChildren> = ({ children }) => (
   <Layout gridSizes={gridSize12}>{children}</Layout>
 );
 

--- a/common/views/components/Layout6/Layout6.tsx
+++ b/common/views/components/Layout6/Layout6.tsx
@@ -1,11 +1,7 @@
-import { ReactNode, FunctionComponent } from 'react';
+import { FunctionComponent, PropsWithChildren } from 'react';
 import Layout from '../Layout/Layout';
 
-type Props = {
-  children: ReactNode;
-};
-
-const Layout6: FunctionComponent<Props> = ({ children }: Props) => (
+const Layout6: FunctionComponent<PropsWithChildren> = ({ children }) => (
   <Layout
     gridSizes={{
       s: 12,

--- a/common/views/components/Layout8/Layout8.tsx
+++ b/common/views/components/Layout8/Layout8.tsx
@@ -1,10 +1,9 @@
-import { ReactNode, FunctionComponent } from 'react';
+import { FunctionComponent, PropsWithChildren } from 'react';
 import Layout from '../Layout/Layout';
 
-type Props = {
-  children: ReactNode;
+type Props = PropsWithChildren<{
   shift?: boolean;
-};
+}>;
 
 const Layout8: FunctionComponent<Props> = ({ children, shift = true }) => (
   <Layout

--- a/common/views/components/MessageBar/MessageBar.tsx
+++ b/common/views/components/MessageBar/MessageBar.tsx
@@ -1,11 +1,13 @@
-import { ReactNode, FunctionComponent } from 'react';
+import { FunctionComponent, PropsWithChildren } from 'react';
 import styled from 'styled-components';
 import { font } from '../../../utils/classnames';
 import Space, { SpaceComponentProps } from '../styled/Space';
 
-const ColouredTag: FunctionComponent<SpaceComponentProps> = styled.span.attrs({
+type ColouredTagProps = PropsWithChildren<SpaceComponentProps>;
+
+const ColouredTag: FunctionComponent<ColouredTagProps> = styled.span.attrs({
   className: font('intb', 6),
-})<SpaceComponentProps>`
+})<ColouredTagProps>`
   display: inline-block;
   color: ${props => props.theme.color('white')};
   background-color: ${props => props.theme.color('neutral.700')};
@@ -14,12 +16,11 @@ const ColouredTag: FunctionComponent<SpaceComponentProps> = styled.span.attrs({
   ${props => props.theme.makeSpacePropertyValues('s', ['margin-right'])}
 `;
 
-type Props = {
+type Props = PropsWithChildren<{
   tagText?: string;
-  children: ReactNode;
-};
+}>;
 
-const MessageBar: FunctionComponent<Props> = ({ tagText, children }: Props) => (
+const MessageBar: FunctionComponent<Props> = ({ tagText, children }) => (
   <Space
     v={{
       size: 'm',

--- a/common/views/components/Modal/Modal.tsx
+++ b/common/views/components/Modal/Modal.tsx
@@ -5,6 +5,7 @@ import {
   FunctionComponent,
   RefObject,
   MutableRefObject,
+  PropsWithChildren,
 } from 'react';
 import styled from 'styled-components';
 import Space from '../styled/Space';
@@ -18,8 +19,7 @@ type BaseModalProps = {
   maxWidth?: string;
 };
 
-type Props = {
-  children: ReactNode;
+type Props = PropsWithChildren<{
   isActive: boolean;
   setIsActive: (value: boolean) => void;
   width?: string | null;
@@ -29,7 +29,7 @@ type Props = {
   removeCloseButton?: boolean;
   showOverlay?: boolean;
   modalStyle?: 'filters' | 'calendar';
-};
+}>;
 const Overlay = styled.div`
   z-index: 1000;
   position: fixed;

--- a/common/views/components/OutboundLinkTracker/OutboundLinkTracker.tsx
+++ b/common/views/components/OutboundLinkTracker/OutboundLinkTracker.tsx
@@ -1,12 +1,10 @@
-import React, { FunctionComponent, ReactNode, useEffect } from 'react';
+import React, { FunctionComponent, PropsWithChildren, useEffect } from 'react';
 import ReactGA from 'react-ga';
 import { isExternal } from '../../../utils/domain';
 
-type Props = {
-  children: ReactNode;
-};
-
-const OutboundLinkTracker: FunctionComponent<Props> = ({ children }: Props) => {
+const OutboundLinkTracker: FunctionComponent<PropsWithChildren> = ({
+  children,
+}) => {
   function handleClick(event: MouseEvent) {
     if (event.target instanceof HTMLAnchorElement) {
       const url = event.target.href;

--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, FunctionComponent, ReactNode } from 'react';
+import React, { useContext, FunctionComponent, PropsWithChildren } from 'react';
 import { Url } from '../../../model/link-props';
 import { JsonLdObj } from '../JsonLd/JsonLd';
 import Head from 'next/head';
@@ -47,7 +47,7 @@ type SkipToContentLink = {
   label: string;
 };
 
-export type Props = {
+export type Props = PropsWithChildren<{
   title: string;
   description: string;
   url: Url;
@@ -56,14 +56,13 @@ export type Props = {
   siteSection: SiteSection | null;
   image?: ImageType;
   rssUrl?: string;
-  children: ReactNode;
   hideNewsletterPromo?: boolean;
   hideFooter?: boolean;
   excludeRoleMain?: boolean;
   headerProps?: HeaderProps;
   apiToolbarLinks?: (ApiToolbarLink | undefined)[];
   skipToContentLinks?: SkipToContentLink[];
-};
+}>;
 
 const PageLayoutComponent: FunctionComponent<Props> = ({
   title,

--- a/common/views/components/SpacingSection/SpacingSection.tsx
+++ b/common/views/components/SpacingSection/SpacingSection.tsx
@@ -1,11 +1,7 @@
-import { FunctionComponent, ReactNode } from 'react';
+import { FunctionComponent, PropsWithChildren } from 'react';
 import Space from '../styled/Space';
 
-type Props = {
-  children: ReactNode;
-};
-
-const SpacingSection: FunctionComponent<Props> = ({ children }) => {
+const SpacingSection: FunctionComponent<PropsWithChildren> = ({ children }) => {
   return (
     <Space v={{ size: 'xl', properties: ['margin-bottom'] }}>{children}</Space>
   );

--- a/common/views/components/WobblyBottom/WobblyBottom.tsx
+++ b/common/views/components/WobblyBottom/WobblyBottom.tsx
@@ -1,4 +1,4 @@
-import { Fragment, FunctionComponent, ReactNode } from 'react';
+import { FunctionComponent, ReactNode } from 'react';
 import WobblyEdge from '../WobblyEdge/WobblyEdge';
 import styled from 'styled-components';
 
@@ -16,10 +16,8 @@ const WobblyBottom: FunctionComponent<Props> = ({
   children,
 }: Props) => (
   <Wrapper>
-    <Fragment>
-      {children}
-      <WobblyEdge backgroundColor={backgroundColor} />
-    </Fragment>
+    {children}
+    <WobblyEdge backgroundColor={backgroundColor} />
   </Wrapper>
 );
 export default WobblyBottom;

--- a/common/views/components/WobblyBottom/WobblyBottom.tsx
+++ b/common/views/components/WobblyBottom/WobblyBottom.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, ReactNode } from 'react';
+import { FunctionComponent, PropsWithChildren } from 'react';
 import WobblyEdge from '../WobblyEdge/WobblyEdge';
 import styled from 'styled-components';
 
@@ -6,15 +6,14 @@ const Wrapper = styled.div`
   position: relative;
 `;
 
-type Props = {
+type Props = PropsWithChildren<{
   backgroundColor: 'warmNeutral.300' | 'white';
-  children: ReactNode;
-};
+}>;
 
 const WobblyBottom: FunctionComponent<Props> = ({
   backgroundColor,
   children,
-}: Props) => (
+}) => (
   <Wrapper>
     {children}
     <WobblyEdge backgroundColor={backgroundColor} />

--- a/common/views/components/WobblyEdgedContainer/WobblyEdgedContainer.tsx
+++ b/common/views/components/WobblyEdgedContainer/WobblyEdgedContainer.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, ReactNode } from 'react';
+import { FunctionComponent, PropsWithChildren } from 'react';
 import styled from 'styled-components';
 import WobblyEdge from '../WobblyEdge/WobblyEdge';
 import Layout8 from '../Layout8/Layout8';
@@ -13,13 +13,9 @@ const Wrapper = styled.div`
   background-color: ${props => props.theme.color('warmNeutral.300')};
 `;
 
-type Props = {
-  children: ReactNode;
-};
-
-const WobblyEdgedContainer: FunctionComponent<Props> = ({
+const WobblyEdgedContainer: FunctionComponent<PropsWithChildren> = ({
   children,
-}: Props) => {
+}) => {
   return (
     <Wrapper>
       <WobblyEdgeContainer>

--- a/common/views/components/WobblyRow/WobblyRow.tsx
+++ b/common/views/components/WobblyRow/WobblyRow.tsx
@@ -1,12 +1,8 @@
-import { FunctionComponent, ReactNode } from 'react';
+import { FunctionComponent, PropsWithChildren } from 'react';
 import styled from 'styled-components';
 import { grid } from '../../../utils/classnames';
 import WobblyEdge from '../WobblyEdge/WobblyEdge';
 import { repeatingLsBlack } from '../../../utils/backgrounds';
-
-type Props = {
-  children: ReactNode;
-};
 
 const WobblyRowContainer = styled.div`
   position: relative;
@@ -27,7 +23,7 @@ const WobblyRowPattern = styled.div`
   height: 100%;
 `;
 
-const WobblyRow: FunctionComponent<Props> = ({ children }: Props) => (
+const WobblyRow: FunctionComponent<PropsWithChildren> = ({ children }) => (
   <WobblyRowContainer>
     <WobblyRowPattern />
     <div className="container">

--- a/content/webapp/components/Body/Body.tsx
+++ b/content/webapp/components/Body/Body.tsx
@@ -1,9 +1,9 @@
 import dynamic from 'next/dynamic';
 import React, {
-  ReactNode,
   ReactElement,
   FunctionComponent,
   Fragment,
+  PropsWithChildren,
 } from 'react';
 import styled from 'styled-components';
 import { classNames, font } from '@weco/common/utils/classnames';
@@ -62,15 +62,14 @@ const Map = dynamic(import('../Map/Map'), {
   ssr: false,
 });
 
-type LayoutWidthProps = {
+type LayoutWidthProps = PropsWithChildren<{
   width: 8 | 10;
-  children: ReactNode;
-};
+}>;
 
 const LayoutWidth: FunctionComponent<LayoutWidthProps> = ({
   width,
   children,
-}: LayoutWidthProps): ReactElement | null => {
+}): ReactElement | null => {
   switch (true) {
     case width === 10:
       return <Layout10>{children}</Layout10>;

--- a/content/webapp/components/Body/VisitUsStaticContent.tsx
+++ b/content/webapp/components/Body/VisitUsStaticContent.tsx
@@ -17,9 +17,7 @@ type ContainerProps = {
 const Container: FunctionComponent<ContainerProps> = ({ children }) => (
   <SpacingSection>
     <SpacingComponent>
-      <div>
-        <Layout12>{children}</Layout12>
-      </div>
+      <Layout12>{children}</Layout12>
     </SpacingComponent>
   </SpacingSection>
 );

--- a/content/webapp/components/Body/VisitUsStaticContent.tsx
+++ b/content/webapp/components/Body/VisitUsStaticContent.tsx
@@ -44,7 +44,7 @@ const VisitUsStaticContent: FunctionComponent = () => {
               <h2 className={`${font('intb', 5)} no-margin`}>
                 Today’s opening times
               </h2>
-              {venues && <OpeningTimes venues={venues} />}
+              <OpeningTimes venues={venues} />
               <Space
                 v={{
                   size: 's',

--- a/content/webapp/components/Body/VisitUsStaticContent.tsx
+++ b/content/webapp/components/Body/VisitUsStaticContent.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, ReactNode } from 'react';
+import { FunctionComponent, PropsWithChildren } from 'react';
 import { font, grid } from '@weco/common/utils/classnames';
 import FindUs from '@weco/common/views/components/FindUs/FindUs';
 import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
@@ -10,11 +10,7 @@ import { usePrismicData } from '@weco/common/server-data/Context';
 import { transformCollectionVenues } from '@weco/common/services/prismic/transformers/collection-venues';
 import styled from 'styled-components';
 
-type ContainerProps = {
-  children: ReactNode;
-};
-
-const Container: FunctionComponent<ContainerProps> = ({ children }) => (
+const Container: FunctionComponent<PropsWithChildren> = ({ children }) => (
   <SpacingSection>
     <SpacingComponent>
       <Layout12>{children}</Layout12>

--- a/content/webapp/components/Contributors/Contributor.tsx
+++ b/content/webapp/components/Contributors/Contributor.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, ReactNode } from 'react';
+import { FunctionComponent, PropsWithChildren } from 'react';
 import styled from 'styled-components';
 import { font, grid } from '@weco/common/utils/classnames';
 import { Contributor as ContributorType } from '../../types/contributors';
@@ -23,9 +23,7 @@ const ContributorNameWrapper = styled.div`
   align-items: baseline;
 `;
 
-const PeopleImage: FunctionComponent<{ children: ReactNode }> = ({
-  children,
-}) => (
+const PeopleImage: FunctionComponent<PropsWithChildren> = ({ children }) => (
   <div
     style={{
       width: 72,

--- a/content/webapp/components/InfoBox/InfoBox.tsx
+++ b/content/webapp/components/InfoBox/InfoBox.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, ReactNode } from 'react';
+import React, { FunctionComponent, PropsWithChildren } from 'react';
 import styled from 'styled-components';
 import { font } from '@weco/common/utils/classnames';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
@@ -11,11 +11,10 @@ type InfoBoxItem = LabelField & {
   icon?: IconSvg;
 };
 
-type Props = {
+type Props = PropsWithChildren<{
   title: string;
   items: InfoBoxItem[];
-  children: ReactNode;
-};
+}>;
 
 const InfoContainer = styled(Space).attrs({
   v: { size: 'l', properties: ['padding-top', 'padding-bottom'] },


### PR DESCRIPTION
This is a convention we established when we had to add explicit children to all our types during the Next 13 upgrade; this backfills the change to all our components where we already had explicit children.

Closes https://github.com/wellcomecollection/wellcomecollection.org/issues/9437