### PR TITLE
Move the first-para-no-margin class to styled-components

### DIFF
--- a/common/views/themes/utility-classes.ts
+++ b/common/views/themes/utility-classes.ts
@@ -138,11 +138,6 @@ export const utilityClasses = css<GlobalStyleProps>`
     width: 100%;
   }
 
-  // For when we get HTML out of systems like Prismic
-  .first-para-no-margin p:first-of-type {
-    margin: 0;
-  }
-
   // This removes the element from the flow, as well as it's visibility
   .visually-hidden {
     border: 0;

--- a/content/webapp/components/PageHeaderStandfirst/PageHeaderStandfirst.tsx
+++ b/content/webapp/components/PageHeaderStandfirst/PageHeaderStandfirst.tsx
@@ -2,21 +2,28 @@ import { FunctionComponent } from 'react';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
 import Space from '@weco/common/views/components/styled/Space';
 import * as prismicT from '@prismicio/types';
+import styled from 'styled-components';
+
+const Wrapper = styled(Space).attrs({
+  v: {
+    size: 's',
+    properties: ['margin-top'],
+  },
+  className: 'body-text',
+})`
+  p:first-of-type {
+    margin: 0;
+  }
+`;
 
 type Props = {
   html: prismicT.RichTextField;
 };
 
 const PageHeaderStandfirst: FunctionComponent<Props> = ({ html }: Props) => (
-  <Space
-    v={{
-      size: 's',
-      properties: ['margin-top'],
-    }}
-    className="body-text first-para-no-margin"
-  >
+  <Wrapper>
     <PrismicHtmlBlock html={html} />
-  </Space>
+  </Wrapper>
 );
 
 export default PageHeaderStandfirst;


### PR DESCRIPTION
*   It's only used in one place; it shouldn't live in the global styles
*   Extract the styles here into a styled-component, because we can't
    declare styles on a child element in the inline `style` attribute.

Chips away at https://github.com/wellcomecollection/wellcomecollection.org/issues/8420