### PR TITLE
Update styles/logic for short film format articles

### DIFF
--- a/common/data/content-format-ids.ts
+++ b/common/data/content-format-ids.ts
@@ -5,6 +5,7 @@ export const ArticleFormatIds = {
   Podcast: 'XwRZ6hQAAG4K-bbt',
   BookExtract: 'W8CbPhEAAB8Nq4aG',
   LongRead: 'YxcjgREAACAAkjBg',
+  ShortFilm: 'ZBH6PRQAAIrrFirA',
 };
 
 export const PageFormatIds = {

--- a/content/webapp/components/Body/Body.tsx
+++ b/content/webapp/components/Body/Body.tsx
@@ -56,14 +56,14 @@ import { isNotUndefined } from '@weco/common/utils/type-guards';
 import SoundCloudEmbed from '../SoundCloudEmbed/SoundCloudEmbed';
 import * as prismicT from '@prismicio/types';
 import { Props as ComicPreviousNextProps } from '../ComicPreviousNext/ComicPreviousNext';
-import { PaletteColor } from '@weco/common/views/themes/config';
+import { PaletteColor, themeValues } from '@weco/common/views/themes/config';
 
 const Map = dynamic(import('../Map/Map'), {
   ssr: false,
 });
 
 type LayoutWidthProps = {
-  width: 8 | 10;
+  width: 8 | 10 | 12;
   children: ReactNode;
 };
 
@@ -72,6 +72,8 @@ const LayoutWidth: FunctionComponent<LayoutWidthProps> = ({
   children,
 }: LayoutWidthProps): ReactElement | null => {
   switch (true) {
+    case width === 12:
+      return <Layout12>{children}</Layout12>;
     case width === 10:
       return <Layout10>{children}</Layout10>;
     case width === 8:
@@ -92,6 +94,7 @@ type Props = {
   sectionLevelPage?: boolean;
   staticContent?: ReactElement | null;
   comicPreviousNext?: ComicPreviousNextProps;
+  isShortFilm?: boolean;
 };
 
 type SectionTheme = {
@@ -130,6 +133,7 @@ const Body: FunctionComponent<Props> = ({
   sectionLevelPage = false,
   staticContent = null,
   comicPreviousNext,
+  isShortFilm = false,
 }: Props) => {
   const filteredBody = body
     .filter(slice => !(slice.type === 'picture' && slice.weight === 'featured'))
@@ -288,7 +292,16 @@ const Body: FunctionComponent<Props> = ({
   };
 
   return (
-    <div className="basic-body">
+    <div
+      className="basic-body"
+      style={{
+        background: isShortFilm
+          ? `linear-gradient(180deg, ${themeValues.color(
+              'white'
+            )} 50%, transparent 50%)`
+          : undefined,
+      }}
+    >
       {filteredBody.length < 1 && (
         <AdditionalContent
           index={0}
@@ -445,7 +458,7 @@ const Body: FunctionComponent<Props> = ({
               )}
               {slice.type === 'videoEmbed' && (
                 <SpacingComponent>
-                  <LayoutWidth width={minWidth}>
+                  <LayoutWidth width={isShortFilm ? 12 : minWidth}>
                     <VideoEmbed {...slice.value} />
                   </LayoutWidth>
                 </SpacingComponent>

--- a/content/webapp/pages/articles/[articleId].tsx
+++ b/content/webapp/pages/articles/[articleId].tsx
@@ -276,6 +276,7 @@ const ArticlePage: FunctionComponent<Props> = ({ article, jsonLd }) => {
     : undefined;
   const isComicFormat = article.format?.id === ArticleFormatIds.Comic;
   const isInPicturesFormat = article.format?.id === ArticleFormatIds.InPictures;
+  const isShortFilmFormat = article.format?.id === ArticleFormatIds.ShortFilm;
   const isImageGallery = isInPicturesFormat || isComicFormat;
 
   const Header = (
@@ -285,9 +286,15 @@ const ArticlePage: FunctionComponent<Props> = ({ article, jsonLd }) => {
       title={article.title}
       ContentTypeInfo={ContentTypeInfo}
       FeaturedMedia={
-        isImageGallery || isPodcast ? undefined : maybeFeaturedMedia
+        isShortFilmFormat || isImageGallery || isPodcast
+          ? undefined
+          : maybeFeaturedMedia
       }
-      HeroPicture={isImageGallery || isPodcast ? undefined : maybeHeroPicture}
+      HeroPicture={
+        isShortFilmFormat || isImageGallery || isPodcast
+          ? undefined
+          : maybeHeroPicture
+      }
       heroImageBgColor={isImageGallery ? 'white' : 'warmNeutral.300'}
       TitleTopper={TitleTopper}
       isContentTypeInfoBeforeMedia={true}
@@ -334,6 +341,7 @@ const ArticlePage: FunctionComponent<Props> = ({ article, jsonLd }) => {
             isDropCapped={true}
             pageId={article.id}
             minWidth={isPodcast ? 10 : 8}
+            isShortFilm={isShortFilmFormat}
           />
         }
         RelatedContent={Siblings}


### PR DESCRIPTION
## Who is this for?
People who want to see short films in the Stories section of the site

## What is it doing for them?
Changing how the header and video embed slices render based on the presence of the 'short film' format.

![image](https://user-images.githubusercontent.com/1394592/229516055-ae086f6f-775e-4897-a3e2-02a0516717ac.png)
