### PR TITLE
refactor NextLink button implementation

### DIFF
--- a/catalogue/webapp/components/WorkLink/index.tsx
+++ b/catalogue/webapp/components/WorkLink/index.tsx
@@ -39,7 +39,6 @@ const WorkLink: FunctionComponent<Props> = ({
         pathname: `/works/${id}`,
       }}
       {...linkProps}
-      legacyBehavior
     >
       {children}
     </NextLink>

--- a/catalogue/webapp/components/WorkLink/index.tsx
+++ b/catalogue/webapp/components/WorkLink/index.tsx
@@ -35,6 +35,7 @@ const WorkLink: FunctionComponent<Props> = ({
           resultPosition,
         },
       }}
+      className="plain-link card-link"
       as={{
         pathname: `/works/${id}`,
       }}

--- a/catalogue/webapp/components/WorksSearchResult/WorksSearchResult.styles.tsx
+++ b/catalogue/webapp/components/WorksSearchResult/WorksSearchResult.styles.tsx
@@ -13,7 +13,6 @@ export const Wrapper = styled(Space).attrs<{ index: number }>(props => ({
     size: 'l',
     properties: [props.index !== 0 && 'padding-top', 'padding-bottom'],
   },
-  className: 'plain-link card-link',
 }))<{ index: number }>`
   display: block;
 `;

--- a/catalogue/webapp/components/WorksSearchResult/WorksSearchResult.styles.tsx
+++ b/catalogue/webapp/components/WorksSearchResult/WorksSearchResult.styles.tsx
@@ -8,12 +8,17 @@ export const Container = styled.div`
   `}
 `;
 
-export const Wrapper = styled(Space).attrs<{ index: number }>(props => ({
-  v: {
-    size: 'l',
-    properties: [props.index !== 0 && 'padding-top', 'padding-bottom'],
-  },
-}))<{ index: number }>`
+export const Wrapper = styled(Space).attrs<{ index: number; isLast: boolean }>(
+  props => ({
+    v: {
+      size: 'l',
+      properties: [
+        props.index !== 0 && 'padding-top',
+        !props.isLast && 'padding-bottom',
+      ],
+    },
+  })
+)<{ index: number; isLast: boolean }>`
   display: block;
 `;
 

--- a/catalogue/webapp/components/WorksSearchResult/WorksSearchResult.styles.tsx
+++ b/catalogue/webapp/components/WorksSearchResult/WorksSearchResult.styles.tsx
@@ -8,10 +8,13 @@ export const Container = styled.div`
   `}
 `;
 
-export const Wrapper = styled(Space).attrs({
-  v: { size: 'l', properties: ['padding-top', 'padding-bottom'] },
+export const Wrapper = styled(Space).attrs<{ index: number }>(props => ({
+  v: {
+    size: 'l',
+    properties: [props.index !== 0 && 'padding-top', 'padding-bottom'],
+  },
   className: 'plain-link card-link',
-})`
+}))<{ index: number }>`
   display: block;
 `;
 

--- a/catalogue/webapp/components/WorksSearchResult/WorksSearchResult.tsx
+++ b/catalogue/webapp/components/WorksSearchResult/WorksSearchResult.tsx
@@ -31,6 +31,7 @@ import {
 type Props = {
   work: Work;
   resultPosition: number;
+  isLast: boolean;
 };
 
 // TODO: remove, hack to handle the fact that we are pulling through PDF thumbnails.
@@ -43,6 +44,7 @@ function isPdfThumbnail(thumbnail: DigitalLocation): boolean {
 const WorkSearchResult: FunctionComponent<Props> = ({
   work,
   resultPosition,
+  isLast,
 }) => {
   const productionDates = getProductionDates(work);
   const archiveLabels = getArchiveLabels(work);
@@ -58,7 +60,7 @@ const WorkSearchResult: FunctionComponent<Props> = ({
       resultPosition={resultPosition}
       source="works_search_result"
     >
-      <Wrapper index={resultPosition}>
+      <Wrapper index={resultPosition} isLast={isLast}>
         <Container>
           {work.thumbnail && !isPdfThumbnail(work.thumbnail) && (
             <Preview>

--- a/catalogue/webapp/components/WorksSearchResult/WorksSearchResult.tsx
+++ b/catalogue/webapp/components/WorksSearchResult/WorksSearchResult.tsx
@@ -57,9 +57,8 @@ const WorkSearchResult: FunctionComponent<Props> = ({
       id={work.id}
       resultPosition={resultPosition}
       source="works_search_result"
-      passHref
     >
-      <Wrapper as="a">
+      <Wrapper index={resultPosition}>
         <Container>
           {work.thumbnail && !isPdfThumbnail(work.thumbnail) && (
             <Preview>

--- a/catalogue/webapp/components/WorksSearchResults/WorksSearchResults.tsx
+++ b/catalogue/webapp/components/WorksSearchResults/WorksSearchResults.tsx
@@ -17,6 +17,9 @@ const SearchResultListItem = styled.li`
   flex-basis: 100%;
   max-width: 100%;
   border-top: 1px solid ${props => props.theme.color('neutral.300')};
+  &:first-child {
+    border-top: 0;
+  }
 `;
 
 const WorksSearchResults: FunctionComponent<Props> = ({ works }: Props) => {

--- a/catalogue/webapp/components/WorksSearchResults/WorksSearchResults.tsx
+++ b/catalogue/webapp/components/WorksSearchResults/WorksSearchResults.tsx
@@ -17,18 +17,6 @@ const SearchResultListItem = styled.li`
   flex-basis: 100%;
   max-width: 100%;
   border-top: 1px solid ${props => props.theme.color('neutral.300')};
-
-  &:first-child {
-    border-top: 0;
-
-    & > a {
-      padding-top: 0;
-    }
-  }
-
-  &:last-child a {
-    padding-bottom: 0;
-  }
 `;
 
 const WorksSearchResults: FunctionComponent<Props> = ({ works }: Props) => {
@@ -36,7 +24,11 @@ const WorksSearchResults: FunctionComponent<Props> = ({ works }: Props) => {
     <SearchResultUnorderedList data-test-id="works-search-results-container">
       {works.map((result, i) => (
         <SearchResultListItem data-test-id="work-search-result" key={result.id}>
-          <WorksSearchResult work={result} resultPosition={i} />
+          <WorksSearchResult
+            work={result}
+            resultPosition={i}
+            isLast={works.length - 1 === i}
+          />
         </SearchResultListItem>
       ))}
     </SearchResultUnorderedList>


### PR DESCRIPTION
## Who is this for?
Users of the site

## What is it doing for them?
It would appear that, in production environments, clicking on a works search result causes a href navigation as opposed to the SPA navigation that is expected, this causes the `React Context` to be reset... very odd.

I've updated the `next/link` component implementation to use the new `next 13` api, hoping that this solves it, but there may be something funny going on besides this.

please note: this issue **_only_** applies to production environments, this behaviour is not seen locally

closes #9452 