### PR TITLE
Show short film 'PageHeader' in Cardigan

### DIFF
--- a/cardigan/stories/components/PageHeader/PageHeader.stories.mdx
+++ b/cardigan/stories/components/PageHeader/PageHeader.stories.mdx
@@ -27,4 +27,7 @@ import * as stories from './PageHeader.stories.tsx';
 ## Book
   <Story story={stories.book} />
 
+## ShortFilm
+  <Story story={stories.shortFilm} />
+
 <ArgsTable />

--- a/cardigan/stories/components/PageHeader/PageHeader.stories.tsx
+++ b/cardigan/stories/components/PageHeader/PageHeader.stories.tsx
@@ -10,8 +10,12 @@ import HeaderBackground from '@weco/common/views/components/HeaderBackground/Hea
 import { headerBackgroundLs } from '@weco/common/utils/backgrounds';
 import BookImage from '@weco/content/components/BookImage/BookImage';
 import PageHeaderReadme from '@weco/common/views/components/PageHeader/README.md';
+import ShortFilmPageHeaderReadme from '@weco/common/views/components/PageHeader/ShortFilm_README.md';
 import { ReadmeDecorator } from '@weco/cardigan/config/decorators';
 import { LicenseType } from '@weco/common/model/license';
+import Body from '@weco/content/components/Body/Body';
+import ContentPage from '@weco/content/components/ContentPage/ContentPage';
+import { videoEmbed } from '@weco/cardigan/stories/content';
 
 const Date = styled.span.attrs({ className: font('intr', 6) })`
   color: ${props => props.theme.color('neutral.600')};
@@ -224,6 +228,41 @@ article.args = {
   HeroPicture: <Picture images={articlePictureImages} isFull={true} />,
   ContentTypeInfo,
   isContentTypeInfoBeforeMedia: true,
+};
+
+const ContentPageTemplate = args => (
+  <ReadmeDecorator
+    WrappedComponent={ContentPage}
+    args={args}
+    Readme={ShortFilmPageHeaderReadme}
+  />
+);
+export const shortFilm = ContentPageTemplate.bind({});
+shortFilm.args = {
+  isCreamy: true,
+  Header: (
+    <PageHeader
+      isContentTypeInfoBeforeMedia={true}
+      ContentTypeInfo={ContentTypeInfo}
+      labels={{ labels: [{ text: 'Short film' }] }}
+      title="Audrey's archivist"
+      breadcrumbs={{
+        items: [{ text: 'Stories', url: '#' }],
+      }}
+    />
+  ),
+  Body: (
+    <Body
+      isShortFilm={true}
+      body={[
+        {
+          type: 'videoEmbed',
+          value: videoEmbed,
+        },
+      ]}
+      pageId="test"
+    />
+  ),
 };
 
 export const event = Template.bind({});

--- a/cardigan/stories/content.ts
+++ b/cardigan/stories/content.ts
@@ -317,7 +317,7 @@ const smallText = () => [
 ];
 
 export const videoEmbed = {
-  embedUrl: 'https://www.youtube.com/embed/VYOjWnS4cMY',
+  embedUrl: 'https://www.youtube.com/embed/l0A8-DmX0Z0?feature=oembed',
 };
 
 export const event: Event = {

--- a/common/views/components/PageHeader/ShortFilm_README.md
+++ b/common/views/components/PageHeader/ShortFilm_README.md
@@ -1,0 +1,9 @@
+## Purpose
+
+To create the impression the video embed from the body is included in the header area.
+
+When an article has the `short film` format applied:
+
+- The page header won't display a featured image
+- The first element in the `Body` will have a split-tone background colour – white at the top, and cream at the bottom
+- The `VideoEmbed` in the `Body` will span the full 12 columns of the grid.


### PR DESCRIPTION
## Who is this for?
People who want to see what the `short film` format will do to the page header and body area.

## What is it doing for them?
Adding a story in Cardigan within the `PageHeader` stories with an explanation of what's really happening.

<img width="1050" alt="image" src="https://user-images.githubusercontent.com/1394592/229796962-37ec6b21-5ada-4ace-b2dd-a9649fa4c0d9.png">
