### PR TITLE
Changes for gtm tree_link

### DIFF
--- a/catalogue/webapp/components/ArchiveTree/ArchiveTree.tsx
+++ b/catalogue/webapp/components/ArchiveTree/ArchiveTree.tsx
@@ -681,7 +681,7 @@ const ListItem: FunctionComponent<ListItemProps> = ({
             tabIndex={isEnhanced ? (isSelected ? 0 : -1) : 0}
             isCurrent={currentWorkId === item.work.id}
             ref={currentWorkId === item.work.id ? selected : undefined}
-            data-gtm-trigger="treeLink"
+            data-gtm-trigger="tree_link"
             data-gtm-data-tree-level={level}
             onClick={event => {
               event.stopPropagation();

--- a/catalogue/webapp/components/ArchiveTree/ArchiveTree.tsx
+++ b/catalogue/webapp/components/ArchiveTree/ArchiveTree.tsx
@@ -165,6 +165,8 @@ const TreeControl = styled.span<{ highlightCondition?: string }>`
 type StyledLinkProps = {
   isCurrent?: boolean;
   hasControl?: boolean;
+  'data-gtm-trigger': 'tree_link';
+  'data-gtm-data-tree-level': number;
 };
 
 const StyledLink = styled.a<StyledLinkProps>`

--- a/catalogue/webapp/components/ArchiveTree/ArchiveTree.tsx
+++ b/catalogue/webapp/components/ArchiveTree/ArchiveTree.tsx
@@ -681,6 +681,8 @@ const ListItem: FunctionComponent<ListItemProps> = ({
             tabIndex={isEnhanced ? (isSelected ? 0 : -1) : 0}
             isCurrent={currentWorkId === item.work.id}
             ref={currentWorkId === item.work.id ? selected : undefined}
+            data-gtm-trigger="treeLink"
+            data-gtm-data-tree-level={level}
             onClick={event => {
               event.stopPropagation();
               setShowArchiveTree(false);


### PR DESCRIPTION
Who is this for?
People who don't want to accidentally break tracking by e.g. changing a component or class name

What is it doing for them?
Adding data-gtm-trigger attribute hooks for long-lived GA4 events so their purpose is clear.


