### PR TITLE
Tidy up some stuff in the Tasl component

### DIFF
--- a/common/views/components/Tasl/Tasl.tsx
+++ b/common/views/components/Tasl/Tasl.tsx
@@ -210,7 +210,7 @@ const Tasl: FunctionComponent<Props> = ({
   copyrightHolder,
   copyrightLink,
   idSuffix = '',
-}: Props) => {
+}) => {
   const { isEnhanced } = useContext(AppContext);
   const [isActive, setIsActive] = useState(false);
   function toggleWithAnalytics(event: MouseEvent<HTMLButtonElement>) {

--- a/common/views/components/Tasl/Tasl.tsx
+++ b/common/views/components/Tasl/Tasl.tsx
@@ -82,7 +82,7 @@ type MarkupProps = {
   idSuffix?: string;
 };
 
-function getMarkup({
+const Markup: FunctionComponent<MarkupProps> = ({
   title,
   author,
   sourceName,
@@ -90,7 +90,7 @@ function getMarkup({
   license,
   copyrightHolder,
   copyrightLink,
-}: MarkupProps) {
+}) => {
   return (
     <>
       {getTitleHtml(title, author, sourceLink)}
@@ -99,7 +99,7 @@ function getMarkup({
       {getLicenseHtml(license)}
     </>
   );
-}
+};
 
 function getTitleHtml(
   title?: string,
@@ -245,15 +245,15 @@ const Tasl: FunctionComponent<Props> = ({
           'is-hidden': isEnhanced && !isActive,
         })}
       >
-        {getMarkup({
-          title,
-          author,
-          sourceName,
-          sourceLink,
-          license,
-          copyrightHolder,
-          copyrightLink,
-        })}
+        <Markup
+          title={title}
+          author={author}
+          license={license}
+          sourceName={sourceName}
+          sourceLink={sourceLink}
+          copyrightHolder={copyrightHolder}
+          copyrightLink={copyrightLink}
+        />
       </InfoContainer>
     </StyledTasl>
   ) : null;

--- a/common/views/components/Tasl/Tasl.tsx
+++ b/common/views/components/Tasl/Tasl.tsx
@@ -71,7 +71,7 @@ const InfoContainer = styled(Space).attrs({
   padding-right: 36px;
 `;
 
-export type MarkUpProps = {
+export type MarkupProps = {
   title?: string;
   author?: string;
   sourceName?: string;
@@ -90,7 +90,7 @@ function getMarkup({
   license,
   copyrightHolder,
   copyrightLink,
-}: MarkUpProps) {
+}: MarkupProps) {
   return (
     <>
       {getTitleHtml(title, author, sourceLink)}
@@ -185,7 +185,7 @@ function getLicenseHtml(license?: string): ReactElement | undefined {
   );
 }
 
-export type Props = MarkUpProps & {
+export type Props = MarkupProps & {
   positionTop?: boolean;
 };
 

--- a/common/views/components/Tasl/Tasl.tsx
+++ b/common/views/components/Tasl/Tasl.tsx
@@ -71,7 +71,7 @@ const InfoContainer = styled(Space).attrs({
   padding-right: 36px;
 `;
 
-export type MarkupProps = {
+type MarkupProps = {
   title?: string;
   author?: string;
   sourceName?: string;

--- a/common/views/components/Tasl/Tasl.tsx
+++ b/common/views/components/Tasl/Tasl.tsx
@@ -82,31 +82,14 @@ type MarkupProps = {
   idSuffix?: string;
 };
 
-const Markup: FunctionComponent<MarkupProps> = ({
+type TitleProps = { title?: string; author?: string; sourceLink?: string };
+
+const Title: FunctionComponent<TitleProps> = ({
   title,
   author,
-  sourceName,
   sourceLink,
-  license,
-  copyrightHolder,
-  copyrightLink,
 }) => {
-  return (
-    <>
-      {getTitleHtml(title, author, sourceLink)}
-      {getSourceHtml(sourceName, sourceLink)}
-      {getCopyrightHtml(copyrightHolder, copyrightLink)}
-      {getLicenseHtml(license)}
-    </>
-  );
-};
-
-function getTitleHtml(
-  title?: string,
-  author?: string,
-  sourceLink?: string
-): ReactElement | undefined {
-  if (!title) return;
+  if (!title) return null;
 
   const byAuthor = author ? `, ${author}` : '';
 
@@ -130,13 +113,12 @@ function getTitleHtml(
       </>
     );
   }
-}
+};
 
-function getSourceHtml(
-  sourceName?: string,
-  sourceLink?: string
-): ReactElement | undefined {
-  if (!sourceName) return;
+type SourceProps = { sourceName?: string; sourceLink?: string };
+
+const Source: FunctionComponent<SourceProps> = ({ sourceName, sourceLink }) => {
+  if (!sourceName) return null;
 
   if (sourceLink) {
     return (
@@ -151,13 +133,18 @@ function getSourceHtml(
   } else {
     return <>Source: {sourceName}. </>;
   }
-}
+};
 
-function getCopyrightHtml(
-  copyrightHolder?: string,
-  copyrightLink?: string
-): ReactElement | undefined {
-  if (!copyrightHolder) return;
+type CopyrightProps = {
+  copyrightHolder?: string;
+  copyrightLink?: string;
+};
+
+const Copyright: FunctionComponent<CopyrightProps> = ({
+  copyrightHolder,
+  copyrightLink,
+}) => {
+  if (!copyrightHolder) return null;
 
   if (copyrightLink) {
     return (
@@ -168,12 +155,14 @@ function getCopyrightHtml(
   } else {
     return <>&copy; {copyrightHolder}. </>;
   }
-}
+};
 
-function getLicenseHtml(license?: string): ReactElement | undefined {
+type LicenseProps = { license?: string };
+
+const License: FunctionComponent<LicenseProps> = ({ license }) => {
   const licenseData = license && getPrismicLicenseData(license);
 
-  if (!licenseData) return;
+  if (!licenseData) return null;
 
   return (
     <>
@@ -183,7 +172,29 @@ function getLicenseHtml(license?: string): ReactElement | undefined {
       .
     </>
   );
-}
+};
+
+const Markup: FunctionComponent<MarkupProps> = ({
+  title,
+  author,
+  sourceName,
+  sourceLink,
+  license,
+  copyrightHolder,
+  copyrightLink,
+}) => {
+  return (
+    <>
+      <Title title={title} author={author} sourceLink={sourceLink} />
+      <Source sourceName={sourceName} sourceLink={sourceLink} />
+      <Copyright
+        copyrightHolder={copyrightHolder}
+        copyrightLink={copyrightLink}
+      />
+      <License license={license} />
+    </>
+  );
+};
 
 export type Props = MarkupProps & {
   positionTop?: boolean;

--- a/content/webapp/components/ImageWithTasl/ImageWithTasl.tsx
+++ b/content/webapp/components/ImageWithTasl/ImageWithTasl.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent, ReactElement } from 'react';
 import Tasl, {
-  MarkUpProps as TaslProps,
+  MarkupProps as TaslProps,
 } from '@weco/common/views/components/Tasl/Tasl';
 import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImage';
 import HeightRestrictedPrismicImage from '@weco/common/views/components/HeightRestrictedPrismicImage/HeightRestrictedPrismicImage';

--- a/content/webapp/components/ImageWithTasl/ImageWithTasl.tsx
+++ b/content/webapp/components/ImageWithTasl/ImageWithTasl.tsx
@@ -1,10 +1,10 @@
-import { FunctionComponent, ReactElement } from 'react';
-import Tasl, {
-  MarkupProps as TaslProps,
-} from '@weco/common/views/components/Tasl/Tasl';
+import { ComponentProps, FunctionComponent, ReactElement } from 'react';
+import Tasl from '@weco/common/views/components/Tasl/Tasl';
 import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImage';
 import HeightRestrictedPrismicImage from '@weco/common/views/components/HeightRestrictedPrismicImage/HeightRestrictedPrismicImage';
 import styled from 'styled-components';
+
+type TaslProps = ComponentProps<typeof Tasl>;
 
 const ImageWrapper = styled.div`
   position: relative;


### PR DESCRIPTION
It had a bunch of `getSomething()` functions which returned a `ReactElement | undefined`; our style everywhere else has been to use FunctionComponent for this sort of thing.

It's a fairly minimal change but makes it more stylistically consistent with our other code.

cf https://github.com/wellcomecollection/wellcomecollection.org/pull/9552