### PR TITLE
The DotEl component doesn't need wrapping in a FunctionComponent

### DIFF
--- a/common/views/components/TextWithDot/Dot.tsx
+++ b/common/views/components/TextWithDot/Dot.tsx
@@ -1,8 +1,7 @@
 import styled from 'styled-components';
-import { FunctionComponent } from 'react';
 import { PaletteColor } from '@weco/common/views/themes/config';
 
-const DotEl = styled.span.attrs({
+const Dot = styled.span.attrs({
   'aria-hidden': true,
 })<{ dotColor: PaletteColor }>`
   font-size: 0.7em;
@@ -13,11 +12,4 @@ const DotEl = styled.span.attrs({
   }
 `;
 
-type Props = {
-  dotColor: PaletteColor;
-};
-
-const Dot: FunctionComponent<Props> = ({ dotColor }) => (
-  <DotEl dotColor={dotColor} />
-);
 export default Dot;


### PR DESCRIPTION
tiny improvement I spotted