### PR TITLE
Stories toggle; Check if either queries have a result

### DIFF
--- a/catalogue/webapp/pages/search/index.tsx
+++ b/catalogue/webapp/pages/search/index.tsx
@@ -132,7 +132,7 @@ export const SearchPage: NextPageWithLayout<Props> = ({
   return (
     <main>
       <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
-        {!stories && !images && !works ? (
+        {!returnedStories && !images && !works ? (
           <div className="container">
             <SearchNoResults query={queryString} />
           </div>


### PR DESCRIPTION
## Who is this for?
Search

## What is it doing for them?
Currently on `/search`, we just get a "no result" if Prismic API returns no result, even if you're actually pointing to the Content API. Prismic API will always return no result if that's the case, so that needed changing.

This doesn't happen in `/search/stories`