### PR TITLE
Change default sort for All

### DIFF
--- a/catalogue/webapp/pages/search/index.tsx
+++ b/catalogue/webapp/pages/search/index.tsx
@@ -241,21 +241,24 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
 
     try {
       // Stories
-      // We want the default order to be "descending publication date"
-      const storiesParams = {
-        ...query,
-        sort: getQueryPropertyValue(query.sort) || 'publication.dates',
-        sortOrder: getQueryPropertyValue(query.sortOrder) || 'desc',
-      };
+      // We want the default order to be "descending publication date" with the Prismic API
 
       const storiesResults = contentApi
         ? await getArticles({
-            params: storiesParams,
+            params: {
+              ...query,
+              sort: getQueryPropertyValue(query.sort),
+              sortOrder: getQueryPropertyValue(query.sortOrder),
+            },
             pageSize: 4,
             toggles: serverData.toggles,
           })
         : await getStories({
-            query: storiesParams,
+            query: {
+              ...query,
+              sort: getQueryPropertyValue(query.sort) || 'publication.dates',
+              sortOrder: getQueryPropertyValue(query.sortOrder) || 'desc',
+            },
             pageSize: 4,
           });
 


### PR DESCRIPTION
## Who is this for?
Content API results

## What is it doing for them?
Changes the default sort order on "All" search to be relevance.