### PR TITLE
Send correct secondsPlayed with video engagement tracking

### DIFF
--- a/catalogue/webapp/components/VideoPlayer/VideoPlayer.tsx
+++ b/catalogue/webapp/components/VideoPlayer/VideoPlayer.tsx
@@ -1,6 +1,6 @@
 import Router from 'next/router';
 import { trackGaEvent } from '@weco/common/utils/ga';
-import { FunctionComponent, useEffect, useState } from 'react';
+import { FunctionComponent, useEffect, useState, useRef } from 'react';
 import useInterval from '@weco/common/hooks/useInterval';
 import MediaAnnotations from '../MediaAnnotations/MediaAnnotations';
 import { Video } from '../../services/iiif/types/manifest/v3';
@@ -15,13 +15,18 @@ const VideoPlayer: FunctionComponent<Props> = ({
   showDownloadOptions,
 }: Props) => {
   const [secondsPlayed, setSecondsPlayed] = useState(0);
+  const secondsPlayedRef = useRef(secondsPlayed);
   const [isPlaying, setIsPlaying] = useState(false);
+
+  useEffect(() => {
+    secondsPlayedRef.current = secondsPlayed;
+  }, [secondsPlayed]);
 
   function trackViewingTime() {
     trackGaEvent({
       category: 'Engagement',
       action: 'Amount of media played',
-      value: secondsPlayed,
+      value: secondsPlayedRef.current,
       nonInteraction: true,
       transport: 'beacon',
       label: 'Video',


### PR DESCRIPTION
I was looking to replicate our UA tracking with GA4 in the `VideoPlayer` component that is in use for works, without having to use Tag Manager – some long-lived tracking still feels like it maybe makes more sense to live in code, e.g. when sending along data that would otherwise need to be read from the DOM with a Tag Manager custom variable. This is debatable, and I guess we should decide for sure what, if any, events we want to continue to send from the codebase.

Seems like this would be the way to do it, using the `gtag` function that the analytics script attaches to the `window` (we'd have to decide on a format for the event names):

```
gtag('event', 'Engagement', {
  event_category: 'Video',
  seconds_played: secondsPlayedRef.current,
});
```

When looking at this, I realised that we're not sending the correct number of `secondsPlayed` ([it is always `0`](https://analytics.google.com/analytics/web/?authuser=1#/report/content-event-events/a55614w23273620p84264184/explorer-table.plotKeys=%5B%5D&_r.drilldown=analytics.eventCategory:Engagement,analytics.eventAction:Amount%20of%20media%20played,analytics.eventLabel:Video) because of the value being wrapped in a closure before it is sent).

This PR updates the UA implementation to send along the correct number of seconds. Then we can decide if we want to do this in GA4 after discussing.