### PR TITLE
Temporarily remove turbosnap

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -19,6 +19,5 @@ jobs:
         uses: chromaui/action@v1
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          onlyChanged: true
           workingDir: cardigan
           buildScriptName: build

--- a/cardigan/package.json
+++ b/cardigan/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "start-storybook -s ./public -p 9001 -c .storybook",
     "build": "build-storybook -s ./public -c .storybook -o .dist",
-    "chromatic": "chromatic --only-changed"
+    "chromatic": "chromatic"
   },
   "devDependencies": {},
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5611,7 +5611,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@18.0.31", "@types/react@18.0.33", "@types/react@^18.0.31":
+"@types/react@*", "@types/react@18.0.31", "@types/react@18.0.34", "@types/react@^18.0.31":
   version "18.0.31"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.31.tgz#a69ef8dd7bfa849734d258c793a8fe343a338205"
   integrity sha512-EEG67of7DsvRDU6BLLI0p+k1GojDLz9+lZsnCpCRTa/lOokvyPBvp8S5x+A24hME3yyQuIipcP70KJ6H7Qupww==
@@ -5722,10 +5722,10 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.6.tgz#250a7b16c3b91f672a24552ec64678eeb1d3a08d"
   integrity sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==
 
-"@types/uuid@^8.3.0":
-  version "8.3.1"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.1.tgz#1a32969cf8f0364b3d8c8af9cc3555b7805df14f"
-  integrity sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg==
+"@types/uuid@^9.0.1":
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.1.tgz#98586dc36aee8dacc98cc396dbca8d0429647aa6"
+  integrity sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==
 
 "@types/webpack-env@^1.16.0":
   version "1.16.3"
@@ -7183,7 +7183,7 @@ babel-plugin-react@^1.0.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-react/-/babel-plugin-react-1.0.0.tgz#29a959f9b06fc58a3af27bf58d16be2dc1031dff"
   integrity sha512-JuvvO25Cxgdqlg1QmHCt4EyvCB2EW5kQSEVLIDl6bIP0OS0TwnUFLMdNyOsxW0+mZOrL5p9ovSRTvWPq4ispkQ==
 
-"babel-plugin-styled-components@>= 1.12.0", babel-plugin-styled-components@^1.12.0:
+"babel-plugin-styled-components@>= 1.12.0":
   version "1.13.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.13.3.tgz#1f1cb3927d4afa1e324695c78f690900e3d075bc"
   integrity sha512-meGStRGv+VuKA/q0/jXxrPNWEm4LPfYIqxooDTdmh8kFsP/Ph7jJG5rUPwUPX3QHUvggwdbgdGpo88P/rRYsVw==
@@ -7202,6 +7202,17 @@ babel-plugin-styled-components@^2.0.7:
     "@babel/helper-module-imports" "^7.16.0"
     babel-plugin-syntax-jsx "^6.18.0"
     lodash "^4.17.11"
+    picomatch "^2.3.0"
+
+babel-plugin-styled-components@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-2.1.1.tgz#cd977cc0ff8410d5cbfdd142e42576e9c8794b87"
+  integrity sha512-c8lJlszObVQPguHkI+akXv8+Jgb9Ccujx0EetL7oIvwU100LxO6XAGe45qry37wUL40a5U9f23SYrivro2XKhA==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.16.0"
+    "@babel/helper-module-imports" "^7.16.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    lodash "^4.17.21"
     picomatch "^2.3.0"
 
 babel-plugin-superjson-next@^0.4.4:


### PR DESCRIPTION
## Who is this for?
Chromatic users

## What is it doing for them?
[Chromatic has been acting up on snapshots](https://wellcome.slack.com/archives/C3TQSF63C/p1681290481847349), we're hoping this will batch update them.
The `yarn.lock` update is, hopefully, extra insurance that it will get picked up.