### PR TITLE
Add create_library_account trigger

### DIFF
--- a/identity/webapp/pages/registration.tsx
+++ b/identity/webapp/pages/registration.tsx
@@ -230,6 +230,7 @@ const RegistrationPage: NextPage<Props> = ({
                     <SpacingComponent>
                       <FullWidthButton>
                         <ButtonSolid
+                          dataGtmTrigger="create_library_account"
                           type={ButtonTypes.submit}
                           text="Create library account"
                         />


### PR DESCRIPTION
☝️ 

I'd previously thought this was all handled on Auth0 side and we'd need to fire a trigger when someone signing up arrived at a callback URL from Auth0, but because of the way we have to create the signup process at a URL we host ourselves (`/registration`), we can add the tracking to the 'Create library account' button, which is easier.