### PR TITLE
changed hardcoded h2 on exhibitions page to 'Related stories'

### DIFF
--- a/content/webapp/components/Exhibition/Exhibition.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.tsx
@@ -292,7 +292,7 @@ const Exhibition: FunctionComponent<Props> = ({ exhibition, pages }) => {
         </InfoBox>
       )}
       {exhibitionAbouts.length > 0 && (
-        <SearchResults items={exhibitionAbouts} title="About this exhibition" />
+        <SearchResults items={exhibitionAbouts} title="Related stories" />
       )}
     </ContentPage>
   );


### PR DESCRIPTION
## Who is this for?
Exhibitions pages

## What is it doing for them?
For #9565
Changed hardcoded `h2` on Exhibition pages from "About this exhibition" to "Related stories" as requested by Digital Editorial