### PR TITLE
fix bundle size diff; Align types/react and fix error

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -25,7 +25,7 @@
     "@types/gtag.js": "^0.0.12",
     "@types/jest": "^27.0.2",
     "@types/lodash.debounce": "^4.0.6",
-    "@types/react": "^18.0.31",
+    "@types/react": "^18.0.35",
     "@types/styled-components": "^5.1.26",
     "@types/uuid": "^9.0.1",
     "@weco/toggles": "1.0.0",

--- a/common/views/components/StackingTable/StackingTable.tsx
+++ b/common/views/components/StackingTable/StackingTable.tsx
@@ -89,7 +89,7 @@ const StyledTh = styled(Space).attrs<ThProps>(props => ({
 type TdProps = {
   plain?: boolean;
   maxWidth?: number;
-  content?: string | ReactNode;
+  cellContent?: ReactNode;
   key?: number;
 };
 
@@ -122,14 +122,14 @@ const StyledTd = styled(Space).attrs<TdProps>(props => ({
     :before {
       display: block;
       white-space: nowrap;
-      content: ${props => (props.content ? `'${props.content}'` : '')};
+      content: ${props => (props.cellContent ? `'${props.cellContent}'` : '')};
       ${fontFamilyMixin('intb', true)}
     }
   }
 `;
 
 type Props = {
-  rows: (string | ReactNode)[][];
+  rows: ReactNode[][];
   plain?: boolean;
   maxWidth?: number;
   columnWidths?: (number | undefined)[];
@@ -162,16 +162,18 @@ const StackingTable: FunctionComponent<Props> = ({
       <tbody>
         {bodyRows.map((row, index) => (
           <StyledTr plain={plain} key={index}>
-            {row.map((data, index) => (
-              <StyledTd
-                key={index}
-                content={headerRow[index]}
-                plain={plain}
-                maxWidth={maxWidth}
-              >
-                {data}
-              </StyledTd>
-            ))}
+            {row.map((data, index) => {
+              return (
+                <StyledTd
+                  key={index}
+                  cellContent={headerRow[index]}
+                  plain={plain}
+                  maxWidth={maxWidth}
+                >
+                  {data}
+                </StyledTd>
+              );
+            })}
           </StyledTr>
         ))}
       </tbody>

--- a/dash/webapp/package.json
+++ b/dash/webapp/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.2.0",
-    "@types/react": "^18.0.31",
+    "@types/react": "^18.0.35",
     "@types/styled-components": "^5.1.26",
     "next": "^13.2.3",
     "next-cookies": "^1.0.4",

--- a/identity/webapp/package.json
+++ b/identity/webapp/package.json
@@ -62,7 +62,7 @@
     "@types/koa-logger": "^3.1.1",
     "@types/koa__router": "^8.0.2",
     "@types/node": "^18.15.11",
-    "@types/react": "18.0.31",
+    "@types/react": "18.0.35",
     "@typescript-eslint/eslint-plugin": "^5.54.1",
     "@typescript-eslint/parser": "^5.48.2",
     "babel-core": "^6.26.3",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "rimraf": "^4.4.1"
   },
   "resolutions": {
-    "@types/react": "18.0.31"
+    "@types/react": "18.0.35"
   },
   "private": true,
   "workspaces": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -5611,10 +5611,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@18.0.31", "@types/react@18.0.35", "@types/react@^18.0.31":
-  version "18.0.31"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.31.tgz#a69ef8dd7bfa849734d258c793a8fe343a338205"
-  integrity sha512-EEG67of7DsvRDU6BLLI0p+k1GojDLz9+lZsnCpCRTa/lOokvyPBvp8S5x+A24hME3yyQuIipcP70KJ6H7Qupww==
+"@types/react@*", "@types/react@18.0.35", "@types/react@^18.0.35":
+  version "18.0.35"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.35.tgz#192061cb1044fe01f2d3a94272cd35dd50502741"
+  integrity sha512-6Laome31HpetaIUGFWl1VQ3mdSImwxtFZ39rh059a1MNnKGqBpC88J6NJ8n/Is3Qx7CefDGLgf/KhN/sYCf7ag==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"


### PR DESCRIPTION
## Who is this for?
Devs

## What is it doing for them?
Upgraded types/react to `18.0.35` in one repo earlier and it seems to have caused some errors (maybe?) so tried aligning it across and fixing the error it flagged, which seems to work.