### PR TITLE
Re-set Turbosnap

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -19,5 +19,6 @@ jobs:
         uses: chromaui/action@v1
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          onlyChanged: true
           workingDir: cardigan
           buildScriptName: build

--- a/cardigan/package.json
+++ b/cardigan/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "start-storybook -s ./public -p 9001 -c .storybook",
     "build": "build-storybook -s ./public -c .storybook -o .dist",
-    "chromatic": "chromatic --forced-rebuild"
+    "chromatic": "chromatic --only-changed"
   },
   "devDependencies": {},
   "dependencies": {


### PR DESCRIPTION
## Who is this for?
Chromatic users

## What is it doing for them?
Re-sets Turbosnap, we don't want all snapshots to run if no modifications have been done.