### PR TITLE
Fix the "back to search results" link

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -6,6 +6,9 @@ on:
       - 'assets/**'
       - 'cache/**'
       - 'cardigan/**'
+      - 'catalogue/terraform/**'
+      - 'content/terraform/**'
+      - 'identity/terraform/**'
       - 'infrastructure/**'
       - 'playwright/**'
 

--- a/catalogue/terraform/stack/main.tf
+++ b/catalogue/terraform/stack/main.tf
@@ -148,7 +148,7 @@ module "any_search_data_listener" {
   target_group_arn       = local.target_group_arn
 
   priority      = "206"
-  path_patterns = ["/_next/data/*/search/*.json"]
+  path_patterns = ["/_next/data/*/search/*.json", "/_next/data/*/works/*.json",]
 }
 
 locals {


### PR DESCRIPTION
Tentative fix for https://github.com/wellcomecollection/wellcomecollection.org/issues/9452, which involves modifying the load balancer config. I've also added an end-to-end test, so we'll catch this if we break it in future.

## Debugging process

Nobody could reproduce the issue locally, so I guess the problem was somewhere in the deployment infrastructure. As a quick reminder, here's what our stack looks like:

```mermaid
graph LR
    DNS["DNS records<br/>in Route 53"] --> CF[CloudFront distribution]
    CF --> ALB["EC2 Load Balancer (ALB)"]
    ALB --> ECS["ECS service<br/>(apps running in<br/>Docker containers)"]

    classDef interestingNode fill:#a2eeed,stroke:#1dbebb
    class DNS,CF,ALB,ECS interestingNode
```

The load balancers have their own DNS names: prod-1800364202.eu-west-1.elb.amazonaws.com and stage-228531489.eu-west-1.elb.amazonaws.com (but only accessible over HTTP).

I tested at the load balancer endpoint, and I was still seeing the issue – this told me that I could ignore DNS and CloudFront; this issue didn't involve them.

```mermaid
graph LR
    DNS["DNS records<br/>in Route 53"] --> CF[CloudFront distribution]
    CF --> ALB["EC2 Load Balancer (ALB)"]
    ALB --> ECS["ECS service<br/>(apps running in<br/>Docker containers)"]

    classDef interestingNode fill:#a2eeed,stroke:#1dbebb
    class ALB,ECS interestingNode

    classDef uninterestingNode fill:#e8e8e8,stroke:#d9d9d9,color:#8f8f8f
    class DNS,CF uninterestingNode
```

Then I looked at [the list of rules in the load balancer](https://eu-west-1.console.aws.amazon.com/ec2/home?region=eu-west-1#ELBListenerV2:loadBalancerArn=arn:aws:elasticloadbalancing:eu-west-1:130871440101:loadbalancer/app/prod/a4e6c20854a75a96;listenerPort=443;action=None;tab=Rules); the first rule says that any traffic for works.www.wellcomecollection.org should go to the catalogue app. So I tried going to works.wellcomecollection.org/search/works, and I got the correct behaviour – which confirms that there's no issue in the app code.

```mermaid
graph LR
    DNS["DNS records<br/>in Route 53"] --> CF[CloudFront distribution]
    CF --> ALB["EC2 Load Balancer (ALB)"]
    ALB --> ECS["ECS service<br/>(apps running in<br/>Docker containers)"]

    classDef interestingNode fill:#a2eeed,stroke:#1dbebb
    class ALB interestingNode

    classDef uninterestingNode fill:#e8e8e8,stroke:#d9d9d9,color:#8f8f8f
    class ECS,DNS,CF uninterestingNode
```

After that I had a bit of a fiddle with the load balancer rules in staging until I got it working.

## What next?

This is continued fallout from the way we restructured the routes in the catalogue app a couple of months back; trying to split the routes between the catalogue/content app remains tricky. I think this is further weight behind the argument that we should collapse the two apps into a single well-structured monolith.