### PR TITLE
Improve a few aspects of the sameAs field on contributors

### DIFF
--- a/content/webapp/services/prismic/transformers/contributors.ts
+++ b/content/webapp/services/prismic/transformers/contributors.ts
@@ -48,6 +48,12 @@ function transformCommonFields(
         const link = asText(sameAs.link);
         const title = asText(sameAs.title);
 
+        if ((title || link) && !(title && link)) {
+          console.warn(
+            `Only one of title and link are specified in sameAs on ${agent.id}; both must be provided`
+          );
+        }
+
         return title && link ? { title, link } : undefined;
       })
       .filter(isNotUndefined),

--- a/content/webapp/services/prismic/transformers/contributors.ts
+++ b/content/webapp/services/prismic/transformers/contributors.ts
@@ -41,6 +41,16 @@ function transformCommonFields(
     id: agent.id,
     description: asRichText(agent.data.description),
     image: transformImage(agent.data.image) || defaultContributorImage,
+    type: agent.type,
+    name: asText(agent.data.name),
+    sameAs: (agent.data.sameAs ?? [])
+      .map(sameAs => {
+        const link = asText(sameAs.link);
+        const title = asText(sameAs.title);
+
+        return title && link ? { title, link } : undefined;
+      })
+      .filter(isNotUndefined),
   };
 }
 
@@ -50,30 +60,10 @@ export function transformContributorAgent(
   if (isFilledLinkToPersonField(agent)) {
     return {
       ...transformCommonFields(agent),
-      type: agent.type,
-      name: asText(agent.data.name),
       pronouns: asText(agent.data.pronouns),
-      sameAs: (agent.data.sameAs ?? [])
-        .map(sameAs => {
-          const link = asText(sameAs.link);
-          const title = asText(sameAs.title);
-          return title && link ? { title, link } : undefined;
-        })
-        .filter(isNotUndefined),
     };
   } else if (isFilledLinkToOrganisationField(agent)) {
-    return {
-      ...transformCommonFields(agent),
-      type: agent.type,
-      name: asText(agent.data.name),
-      sameAs: (agent.data.sameAs ?? [])
-        .map(sameAs => {
-          const link = asText(sameAs.link);
-          const title = asText(sameAs.title);
-          return title && link ? { title, link } : undefined;
-        })
-        .filter(isNotUndefined),
-    };
+    return transformCommonFields(agent);
   } else {
     return undefined;
   }

--- a/prismic-model/src/organisations.ts
+++ b/prismic-model/src/organisations.ts
@@ -22,15 +22,6 @@ const organisations: CustomType = {
         }),
         title: singleLineText('Title', {
           placeholder: 'The official website of Organisation (required)',
-          // Note: the `heading1` is for back-compatibility with an older version of the
-          // Prismic custom type; we should aim to remove it.
-          overrideTextOptions: [
-            'paragraph',
-            'hyperlink',
-            'strong',
-            'em',
-            'heading1',
-          ],
         }),
       }),
     },

--- a/prismic-model/src/organisations.ts
+++ b/prismic-model/src/organisations.ts
@@ -3,8 +3,8 @@ import description from './parts/description';
 import image from './parts/image';
 import list from './parts/list';
 import title from './parts/title';
-import heading from './parts/heading';
 import { CustomType } from './types/CustomType';
+import { singleLineText } from './parts/text';
 
 const organisations: CustomType = {
   id: 'organisations',
@@ -17,8 +17,21 @@ const organisations: CustomType = {
       description: description,
       image: image('Image'),
       sameAs: list('Same as', {
-        link: keyword('Link'),
-        title: heading('Title (override)'),
+        link: keyword('Link', {
+          placeholder: 'https://example.com/organisation (required)',
+        }),
+        title: singleLineText('Title', {
+          placeholder: 'The official website of Organisation (required)',
+          // Note: the `heading1` is for back-compatibility with an older version of the
+          // Prismic custom type; we should aim to remove it.
+          overrideTextOptions: [
+            'paragraph',
+            'hyperlink',
+            'strong',
+            'em',
+            'heading1',
+          ],
+        }),
       }),
     },
   },

--- a/prismic-model/src/people.ts
+++ b/prismic-model/src/people.ts
@@ -17,8 +17,12 @@ const people: CustomType = {
       pronouns: keyword('Pronouns'),
       image: image('Image'),
       sameAs: list('Same as', {
-        link: keyword('Link'),
-        title: singleLineText('Link text'),
+        link: keyword('Link', {
+          placeholder: 'https://example.com/person (required)',
+        }),
+        title: singleLineText('Link text', {
+          placeholder: 'The personal website of Person (required)',
+        }),
       }),
     },
   },


### PR DESCRIPTION
The contributor model in Prismic has a `sameAs` field which is used to link to the contributor elsewhere on the web, e.g. a person's social media or an organisation's website. The `sameAs` object has two fields: `link` and `title`. We need both of them to display the link on the page.

We had an [issue earlier today](https://wellcome.slack.com/archives/C8X9YKM5X/p1681723088499609) where a link to an organisation's website was being hidden, because it wasn't obvious that we need both of them in the Prismic editing interface.

This PR addresses this issue in three ways:

* The title on the Organisation model was labelled as "Title (override)" in the Prismic UI, which implies it's optional. I've renamed it to "Title" and added placeholders with examples of usage, which include "(required)" as a clue to editors that they need to fill in this field.

* The code which transforms contributors will now warn if it's discarding a `sameAs` field because one of the `link`/`title` fields is missing, to make this easier to spot next time.

* There's a new Prismic lint which will highlight any existing contributors which have links that aren't displaying because one of these fields are missing, so we can backfill any historical links which aren't displaying.