### PR TITLE
Remove .no-margin

### DIFF
--- a/cardigan/stories/components/PageHeader/PageHeader.stories.tsx
+++ b/cardigan/stories/components/PageHeader/PageHeader.stories.tsx
@@ -167,7 +167,7 @@ const ExhibitionContentTypeInfo = () => (
 );
 
 const BookContentTypeInfo = () => (
-  <p className={`${font('intb', 3)}`} style={{ marginBottom: 0 }}>
+  <p className={font('intb', 3)} style={{ marginBottom: 0 }}>
     Loneliness, Health & What Happens When We Find Connection
   </p>
 );

--- a/cardigan/stories/components/PageHeader/PageHeader.stories.tsx
+++ b/cardigan/stories/components/PageHeader/PageHeader.stories.tsx
@@ -50,7 +50,7 @@ const ContentTypeInfo = (
         v={{ size: 's', properties: ['margin-top'] }}
         className={font('intr', 6)}
       >
-        <p className="no-margin">
+        <p style={{ marginBottom: 0 }}>
           <span>By </span>
           <span className={font('intb', 6)}>Naomi Paxton</span>{' '}
           <Date>17 April 2019</Date>
@@ -167,7 +167,7 @@ const ExhibitionContentTypeInfo = () => (
 );
 
 const BookContentTypeInfo = () => (
-  <p className={`no-margin ${font('intb', 3)}`}>
+  <p className={`${font('intb', 3)}`} style={{ marginBottom: 0 }}>
     Loneliness, Health & What Happens When We Find Connection
   </p>
 );

--- a/cardigan/stories/global/typography/typography.stories.tsx
+++ b/cardigan/stories/global/typography/typography.stories.tsx
@@ -67,7 +67,10 @@ const Typography = ({ text }) => {
                   font-{font} font-size-{size}
                 </code>
               </FontName>
-              <p className={`no-margin font-size-${size} font-${font}`}>
+              <p
+                className={`font-size-${size} font-${font}`}
+                style={{ marginBottom: 0 }}
+              >
                 {text}
               </p>
             </Font>
@@ -101,7 +104,7 @@ const MiscTemplate = () => (
     <div>
       <h2>Body text link</h2>
       <div className="body-text">
-        <p className="no-margin">
+        <p style={{ marginBottom: 0 }}>
           There has even been a (failed){' '}
           <a href="https://www.nytimes.com/2015/10/15/us/court-rules-hot-yoga-isnt-entitled-to-copyright.html">
             attempt to copyright a yoga system
@@ -118,7 +121,7 @@ const MiscTemplate = () => (
     <div>
       <h2>Plain text link</h2>
       <div>
-        <p className="no-margin font-hnr4-s">
+        <p className="font-hnr4-s" style={{ marginBottom: 0 }}>
           Here is <a href="#">a link</a> in a block of non body text.
         </p>
       </div>

--- a/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
+++ b/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
@@ -58,9 +58,10 @@ const Metadata = styled.span`
 `;
 
 const ModalTitle = styled.h2.attrs({
-  className: `${font('intb', 3)} no-margin`,
+  className: `${font('intb', 3)}`,
 })`
   color: ${props => props.theme.color('black')};
+  margin-bottom: 0;
 `;
 
 const ImageWrapper = styled(Space).attrs({

--- a/catalogue/webapp/components/IIIFViewer/ViewerSidebar.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerSidebar.tsx
@@ -78,9 +78,13 @@ const Item = styled.div`
 `;
 
 const AccordionButton = styled.button.attrs({
-  className: 'plain-button no-margin',
+  className: 'plain-button',
 })`
   padding: 0;
+
+  h2 {
+    margin-bottom: 0;
+  }
 `;
 
 type AccordionItemProps = PropsWithChildren<{
@@ -98,7 +102,7 @@ const AccordionItem = ({ title, children, testId }: AccordionItemProps) => {
           aria-controls={toHtmlId(title)}
         >
           <span>
-            <h2 className={`${font('intb', 5)} no-margin`}>{title}</h2>
+            <h2 className={`${font('intb', 5)}`}>{title}</h2>
             <Icon
               icon={chevron}
               iconColor="white"

--- a/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
+++ b/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
@@ -147,7 +147,6 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
           </GalleryContainer>
         </PlainList>
       )}
-
       {(!isFullSupportBrowser || isSmallGallery) && (
         <ImageCardList data-test-id="image-search-results-container">
           {imagesWithDimensions.map((result: GalleryImageProps) => (
@@ -179,7 +178,6 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
           ))}
         </ImageCardList>
       )}
-
       <Modal
         id="expanded-image-dialog"
         isActive={isActive}

--- a/catalogue/webapp/components/ItemRequestModal/ErrorDialog.tsx
+++ b/catalogue/webapp/components/ItemRequestModal/ErrorDialog.tsx
@@ -17,7 +17,9 @@ const ErrorDialog: FunctionComponent<ErrorDialogProps> = ({
     <Header>
       <span className="h2">Request failed</span>
     </Header>
-    <p className="no-margin">{errorMessage || defaultRequestErrorMessage}</p>
+    <p style={{ marginBottom: 0 }}>
+      {errorMessage || defaultRequestErrorMessage}
+    </p>
     <CTAs>
       <ButtonSolid
         colors={themeValues.buttonColors.greenTransparentGreen}

--- a/catalogue/webapp/components/ItemRequestModal/RequestDialog.tsx
+++ b/catalogue/webapp/components/ItemRequestModal/RequestDialog.tsx
@@ -129,11 +129,11 @@ const RequestDialog: FunctionComponent<RequestDialogProps> = ({
           currentHoldRequests={currentHoldNumber}
         />
       </Header>
-      <p className={`${font('intb', 5)} no-margin`}>
+      <p className={`${font('intb', 5)}`} style={{ marginBottom: 0 }}>
         You are about to request the following item:
       </p>
       <Space v={{ size: 's', properties: ['margin-bottom'] }}>
-        <p className="no-margin">
+        <p style={{ marginBottom: 0 }}>
           {work.title && <WorkTitle>{work.title}</WorkTitle>}
           {item.title && <span>{item.title}</span>}
         </p>
@@ -143,7 +143,7 @@ const RequestDialog: FunctionComponent<RequestDialogProps> = ({
         <PickUpDate>
           <PickUpDateDescription>
             <Space v={{ size: 's', properties: ['margin-bottom'] }}>
-              <p className="no-margin">
+              <p style={{ marginBottom: 0 }}>
                 Select the date you would like to view this item in the library.
               </p>
             </Space>

--- a/catalogue/webapp/components/ItemRequestModal/RequestDialog.tsx
+++ b/catalogue/webapp/components/ItemRequestModal/RequestDialog.tsx
@@ -129,7 +129,7 @@ const RequestDialog: FunctionComponent<RequestDialogProps> = ({
           currentHoldRequests={currentHoldNumber}
         />
       </Header>
-      <p className={`${font('intb', 5)}`} style={{ marginBottom: 0 }}>
+      <p className={font('intb', 5)} style={{ marginBottom: 0 }}>
         You are about to request the following item:
       </p>
       <Space v={{ size: 's', properties: ['margin-bottom'] }}>

--- a/catalogue/webapp/components/ModalMoreFilters/index.tsx
+++ b/catalogue/webapp/components/ModalMoreFilters/index.tsx
@@ -107,6 +107,10 @@ const FiltersHeader = styled(Space).attrs({
   top: 0px;
   left: 0px;
   width: 100%;
+
+  > * {
+    margin-bottom: 0;
+  }
 `;
 
 type CheckboxFilterProps = {
@@ -232,7 +236,7 @@ const ModalMoreFilters: FunctionComponent<ModalMoreFiltersProps> = ({
         modalStyle="filters"
       >
         <FiltersHeader>
-          <h3 className="h3 no-margin">All filters</h3>
+          <h3 className="h3">All filters</h3>
         </FiltersHeader>
 
         <ModalInner>

--- a/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
+++ b/catalogue/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
@@ -61,8 +61,10 @@ const ButtonWrapper = styled.div<ButtonWrapperProps>`
 `;
 
 const DetailHeading = styled.h3.attrs({
-  className: `${font('intb', 5, { small: 3, medium: 3 })} no-margin`,
-})``;
+  className: `${font('intb', 5, { small: 3, medium: 3 })}`,
+})`
+  margin-bottom: 0;
+`;
 
 export type Props = {
   item: PhysicalItem;

--- a/catalogue/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.tsx
+++ b/catalogue/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.tsx
@@ -132,7 +132,7 @@ const VisuallySimilarImagesFromApi: FunctionComponent<Props> = ({
           </a>
         ))}
       </Wrapper>
-      <p className={`${font('intr', 6)} no-margin`}>
+      <p className={`${font('intr', 6)}`} style={{ marginBottom: 0 }}>
         We use machine learning to find images in our collection with similar
         shapes and features.
         <br />

--- a/catalogue/webapp/components/WorkDetails/OnlineResources.tsx
+++ b/catalogue/webapp/components/WorkDetails/OnlineResources.tsx
@@ -8,7 +8,7 @@ import styled from 'styled-components';
 import PlainList from '@weco/common/views/components/styled/PlainList';
 
 const ShowHideButton = styled.button.attrs({
-  className: `plain-button no-margin ${font('intr', 5)}`,
+  className: `plain-button ${font('intr', 5)}`,
 })`
   text-decoration: underline;
   padding: 0;

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -378,7 +378,10 @@ const WorkDetails: FunctionComponent<Props> = ({
                       properties: ['margin-top'],
                     }}
                   >
-                    <p className={`no-margin ${font('lr', 6)}`}>
+                    <p
+                      className={`${font('lr', 6)}`}
+                      style={{ marginBottom: 0 }}
+                    >
                       Contains:{' '}
                       {collectionManifestsCount > 0
                         ? `${collectionManifestsCount} ${

--- a/catalogue/webapp/components/WorkDetailsList/WorkDetailsList.tsx
+++ b/catalogue/webapp/components/WorkDetailsList/WorkDetailsList.tsx
@@ -4,15 +4,10 @@ import { FunctionComponent } from 'react';
 import Space from '@weco/common/views/components/styled/Space';
 import WorkDetailsProperty from '../WorkDetailsProperty/WorkDetailsProperty';
 
-const PlainList = styled(Space).attrs({
-  v: {
-    size: 'm',
-    properties: ['margin-bottom'],
-  },
-  className: 'no-margin',
-})`
+const PlainList = styled(Space)`
   list-style: none;
   padding: 0;
+  margin: 0;
 `;
 type Props = { title: string; list: string[] };
 

--- a/catalogue/webapp/components/WorkHeader/WorkHeader.tsx
+++ b/catalogue/webapp/components/WorkHeader/WorkHeader.tsx
@@ -112,7 +112,7 @@ const WorkHeader: FunctionComponent<Props> = ({ work }) => {
 
             {collectionManifestsCount > 0 && (
               <Space v={{ size: 'm', properties: ['margin-top'] }}>
-                <p className={`${font('intb', 5)} no-margin`}>
+                <p className={`${font('intb', 5)}`} style={{ marginBottom: 0 }}>
                   <Number
                     backgroundColor="yellow"
                     number={collectionManifestsCount}

--- a/common/views/components/ApiToolbar/index.tsx
+++ b/common/views/components/ApiToolbar/index.tsx
@@ -20,10 +20,11 @@ const ToolbarContainer = styled.div<{ mini: boolean }>`
 `;
 
 const LinkList = styled.ul.attrs({
-  className: 'no-margin font-size-5',
+  className: 'font-size-5',
 })`
   display: flex;
   list-style: none;
+  margin: 0;
 `;
 
 /** tzitzit is a tool used by the Digital Editorial team to create TASL

--- a/common/views/components/AudioPlayer/AudioPlayer.tsx
+++ b/common/views/components/AudioPlayer/AudioPlayer.tsx
@@ -31,6 +31,10 @@ const VolumeWrapper = styled.div`
   }
 `;
 
+const AudioPlayerWrapper = styled.figure`
+  margin: 0;
+`;
+
 const PlayPauseButton = styled.button.attrs<{ isPlaying: boolean }>(props => ({
   className: 'plain-button',
   ariaPressed: props.isPlaying,
@@ -414,7 +418,7 @@ export const AudioPlayer: FunctionComponent<AudioPlayerProps> = ({
   };
 
   return (
-    <figure className="no-margin">
+    <AudioPlayerWrapper>
       <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
         <figcaption className={font('intb', 5)} {...titleProps}>
           {title}
@@ -499,7 +503,7 @@ export const AudioPlayer: FunctionComponent<AudioPlayerProps> = ({
           instead.
         </p>
       </audio>
-    </figure>
+    </AudioPlayerWrapper>
   );
 };
 

--- a/common/views/components/BetaMessage/BetaMessage.tsx
+++ b/common/views/components/BetaMessage/BetaMessage.tsx
@@ -23,7 +23,7 @@ const BetaMessage: FunctionComponent<Props> = ({
     <Space h={{ size: 's', properties: ['margin-right'] }}>
       <Icon icon={underConstruction} />
     </Space>
-    <p className="no-margin">{message}</p>
+    <p style={{ marginBottom: 0 }}>{message}</p>
   </StyledBetaMessage>
 );
 

--- a/common/views/components/Header/Header.styles.ts
+++ b/common/views/components/Header/Header.styles.ts
@@ -160,7 +160,7 @@ export const HeaderNav = styled.nav<{ burgerMenuisActive: boolean }>`
 export const HeaderList = styled.ul`
   list-style: none;
   padding: 0;
-  margin-left: -0.3rem;
+  margin: 0;
 
   ${props => props.theme.media('headerMedium')`
   display: flex;

--- a/common/views/components/Header/Header.tsx
+++ b/common/views/components/Header/Header.tsx
@@ -155,7 +155,7 @@ const Header: FunctionComponent<Props> = ({
                   id="header-nav"
                   aria-labelledby="header-burger-trigger"
                 >
-                  <HeaderList className={`${font('wb', 5)} no-margin`}>
+                  <HeaderList className={`${font('wb', 5)}`}>
                     {(customNavLinks || links).map((link, i) => (
                       <HeaderItem key={i}>
                         <HeaderLink

--- a/common/views/components/LinkLabels/LinkLabels.tsx
+++ b/common/views/components/LinkLabels/LinkLabels.tsx
@@ -49,10 +49,11 @@ const PlainItemList = styled(PlainList).attrs({
 `;
 
 const ListWithHeading = styled.dl.attrs({
-  className: `no-margin ${font('intr', 5)}`,
+  className: `${font('intr', 5)}`,
 })`
   display: flex;
   flex-wrap: wrap;
+  margin: 0;
 `;
 
 const ListWithHeadingItem = styled(Space).attrs({
@@ -74,7 +75,7 @@ const LinkLabels: FunctionComponent<Props> = ({ items, heading, icon }) =>
         {heading}:
       </ListWithHeadingItem>
       {items.map(({ url, text }, i) => (
-        <dd key={`${url || text}-${i}`} className="no-margin">
+        <dd key={`${url || text}-${i}`} style={{ marginBottom: 0 }}>
           <ItemText url={url} addBorder={i !== 0}>
             {text}
           </ItemText>
@@ -84,7 +85,7 @@ const LinkLabels: FunctionComponent<Props> = ({ items, heading, icon }) =>
   ) : (
     <PlainItemList>
       {items.map(({ url, text }, i) => (
-        <li key={`${url || text}-${i}`} className="no-margin">
+        <li key={`${url || text}-${i}`} style={{ marginBottom: 0 }}>
           <ItemText url={url} addBorder={i !== 0}>
             {text}
           </ItemText>

--- a/common/views/components/LinkLabels/LinkLabels.tsx
+++ b/common/views/components/LinkLabels/LinkLabels.tsx
@@ -75,7 +75,7 @@ const LinkLabels: FunctionComponent<Props> = ({ items, heading, icon }) =>
         {heading}:
       </ListWithHeadingItem>
       {items.map(({ url, text }, i) => (
-        <dd key={`${url || text}-${i}`} style={{ marginBottom: 0 }}>
+        <dd key={`${url || text}-${i}`} style={{ margin: 0 }}>
           <ItemText url={url} addBorder={i !== 0}>
             {text}
           </ItemText>
@@ -85,7 +85,7 @@ const LinkLabels: FunctionComponent<Props> = ({ items, heading, icon }) =>
   ) : (
     <PlainItemList>
       {items.map(({ url, text }, i) => (
-        <li key={`${url || text}-${i}`} style={{ marginBottom: 0 }}>
+        <li key={`${url || text}-${i}`}>
           <ItemText url={url} addBorder={i !== 0}>
             {text}
           </ItemText>

--- a/common/views/components/NewsletterPromo/NewsletterPromo.tsx
+++ b/common/views/components/NewsletterPromo/NewsletterPromo.tsx
@@ -1,6 +1,6 @@
 import { useState, useContext, FunctionComponent } from 'react';
 import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
-import { font, classNames } from '../../../utils/classnames';
+import { font } from '../../../utils/classnames';
 import Space from '../styled/Space';
 import styled from 'styled-components';
 import TextInput from '../TextInput/TextInput';
@@ -155,15 +155,18 @@ const NewsletterPromo: FunctionComponent = () => {
               <BoxInner>
                 <CopyWrap>
                   <h2
-                    className={classNames({
-                      h2: true,
-                      'no-margin': !isSuccess,
-                    })}
+                    className="h2"
+                    style={{ marginBottom: !isSuccess ? 0 : undefined }}
                   >
                     {isSuccess ? 'Thank you for signing up!' : headingText}
                   </h2>
                   {!isSuccess && (
-                    <p className={`${font('intr', 5)} no-margin`}>{bodyText}</p>
+                    <p
+                      className={`${font('intr', 5)}`}
+                      style={{ marginBottom: 0 }}
+                    >
+                      {bodyText}
+                    </p>
                   )}
                   {isSuccess && (
                     <div className={`${font('intr', 5)} spaced-text`}>
@@ -219,7 +222,7 @@ const NewsletterPromo: FunctionComponent = () => {
                 )}
               </BoxInner>
               {!isSuccess && (
-                <p className={`${font('intr', 6)} no-margin`}>
+                <p className={`${font('intr', 6)}`} style={{ marginBottom: 0 }}>
                   <a href="/newsletter">All our newsletters</a>
                 </p>
               )}

--- a/common/views/components/SegmentedControl/SegmentedControl.tsx
+++ b/common/views/components/SegmentedControl/SegmentedControl.tsx
@@ -182,7 +182,7 @@ const MobileControlsModal = styled(Space).attrs({
 `;
 
 const Button = styled.button.attrs({
-  className: 'segmented-control__header plain-button no-margin',
+  className: 'segmented-control__header plain-button',
 })`
   padding: 0;
 `;

--- a/common/views/components/ToolbarSegmentedControl/ToolbarSegmentedControl.tsx
+++ b/common/views/components/ToolbarSegmentedControl/ToolbarSegmentedControl.tsx
@@ -24,7 +24,7 @@ const Item = styled.li<{ isActive: boolean }>`
 
 const Button = styled.button.attrs({
   type: 'button',
-  className: 'plain-button no-margin',
+  className: 'plain-button',
 })`
   display: flex;
   padding: 0;

--- a/common/views/components/VideoEmbed/VideoEmbed.tsx
+++ b/common/views/components/VideoEmbed/VideoEmbed.tsx
@@ -23,6 +23,10 @@ const YouTubePlay = () => (
   </svg>
 );
 
+const VideoEmbedWrapper = styled.figure`
+  margin: 0;
+`;
+
 const VideoTrigger = styled.button.attrs({
   className: 'plain-button',
 })<{ hasFullSizePoster?: boolean }>`
@@ -76,7 +80,7 @@ const VideoEmbed: FunctionComponent<Props> = ({
   }, []);
 
   return (
-    <figure className="no-margin">
+    <VideoEmbedWrapper>
       <IframeContainer>
         {isActive ? (
           <iframe
@@ -105,7 +109,7 @@ const VideoEmbed: FunctionComponent<Props> = ({
       </IframeContainer>
 
       {caption && <Caption caption={caption} />}
-    </figure>
+    </VideoEmbedWrapper>
   );
 };
 

--- a/common/views/themes/utility-classes.ts
+++ b/common/views/themes/utility-classes.ts
@@ -69,11 +69,6 @@ export const utilityClasses = css<GlobalStyleProps>`
     }
   }
 
-  // TODO See ticket for more information: https://github.com/wellcomecollection/wellcomecollection.org/issues/9556
-  .no-margin {
-    margin: 0 !important;
-  }
-
   // Only used in one component so move there and delete this.
   // Question the style itself, is it something we still want as input and buttons went fully square?
   .rounded-diagonal {

--- a/content/webapp/components/Body/VisitUsStaticContent.tsx
+++ b/content/webapp/components/Body/VisitUsStaticContent.tsx
@@ -21,7 +21,9 @@ const Container: FunctionComponent<PropsWithChildren> = ({ children }) => (
 const OpeningTimesWrapper = styled.div.attrs({
   className: font('intr', 5),
 })`
-  float; left;
+  h2 {
+    margin-bottom: 0;
+  }
 `;
 
 const VisitUsStaticContent: FunctionComponent = () => {
@@ -37,9 +39,7 @@ const VisitUsStaticContent: FunctionComponent = () => {
         <div className={`${grid({ s: 12, l: 5, xl: 5 })} ${font('intr', 4)}`}>
           <div style={{ display: 'flex' }}>
             <OpeningTimesWrapper>
-              <h2 className={`${font('intb', 5)} no-margin`}>
-                Today’s opening times
-              </h2>
+              <h2 className={`${font('intb', 5)}`}>Today’s opening times</h2>
               <OpeningTimes venues={venues} />
               <Space
                 v={{

--- a/content/webapp/components/EventCard/EventCard.tsx
+++ b/content/webapp/components/EventCard/EventCard.tsx
@@ -63,7 +63,9 @@ const EventCard: FunctionComponent<Props> = ({ event, xOfY }) => {
         </Space>
       </>
     ) : !event.isPast && event.times.length > 1 ? (
-      <p className={`${font('intb', 4)} no-margin`}>See all dates/times</p>
+      <p className={`${font('intb', 4)}`} style={{ marginBottom: 0 }}>
+        See all dates/times
+      </p>
     ) : undefined;
 
   return (

--- a/content/webapp/components/EventPromo/EventPromo.tsx
+++ b/content/webapp/components/EventPromo/EventPromo.tsx
@@ -191,7 +191,11 @@ const EventPromo: FunctionComponent<Props> = ({
       {event.series.length > 0 && (
         <CardPostBody>
           {event.series.map(series => (
-            <p key={series.title} className={`${font('intb', 6)} no-margin`}>
+            <p
+              key={series.title}
+              className={`${font('intb', 6)}`}
+              style={{ marginBottom: 0 }}
+            >
               <span className={font('intr', 6)}>Part of</span> {series.title}
             </p>
           ))}

--- a/content/webapp/components/EventSchedule/EventScheduleItem.tsx
+++ b/content/webapp/components/EventSchedule/EventScheduleItem.tsx
@@ -56,6 +56,10 @@ const EventTimesWrapper = styled(Space).attrs({
   ${props => props.theme.media('large')`
     margin: 0;
   `}
+
+  h4 {
+    margin-bottom: 0;
+  }
 `;
 
 const EventScheduleItem: FunctionComponent<Props> = ({
@@ -75,7 +79,7 @@ const EventScheduleItem: FunctionComponent<Props> = ({
             return (
               <h4
                 key={`${event.title} ${startTimeString}`}
-                className={`${font('intb', 5)} no-margin`}
+                className={`${font('intb', 5)}`}
               >
                 <HTMLTime date={t.range.startDateTime} />
                 {' – '}
@@ -125,7 +129,7 @@ const EventScheduleItem: FunctionComponent<Props> = ({
                   properties: ['margin-top', 'margin-bottom'],
                 }}
               >
-                <p className={`${font('intr', 5)} no-margin`}>
+                <p className={`${font('intr', 5)}`} style={{ marginBottom: 0 }}>
                   <a href={`/events/${event.id}`}>
                     Full event details
                     <span className="visually-hidden">

--- a/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.Stop.tsx
+++ b/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.Stop.tsx
@@ -21,13 +21,14 @@ const StandaloneTitle = styled(Space).attrs({
   as: 'h2',
   v: {
     size: 'm',
-    properties: ['padding-top', 'padding-bottom', 'margin-bottom'],
+    properties: ['padding-top', 'padding-bottom'],
   },
   h: { size: 'm', properties: ['padding-left', 'padding-right'] },
-  className: `${font('wb', 2)} no-margin`,
+  className: `${font('wb', 2)}`,
 })`
   display: inline-block;
   position: relative;
+  margin-bottom: 0;
 
   background: ${props =>
     props.theme.color(getTypeColor('captions-and-transcripts'))};

--- a/content/webapp/components/ExhibitionGuidePromo/ExhibitionGuidePromo.tsx
+++ b/content/webapp/components/ExhibitionGuidePromo/ExhibitionGuidePromo.tsx
@@ -63,7 +63,7 @@ const ExhibitionGuidePromo: FunctionComponent<Props> = ({
           </Space>
           {exhibitionGuide.promo?.caption && (
             <Space v={{ size: 's', properties: ['margin-top'] }}>
-              <p className={`${font('intr', 5)} no-margin`}>
+              <p className={`${font('intr', 5)}`} style={{ marginBottom: 0 }}>
                 {exhibitionGuide.promo.caption}
               </p>
             </Space>

--- a/content/webapp/components/ExhibitionGuideStops/ExhibitionGuideStops.tsx
+++ b/content/webapp/components/ExhibitionGuideStops/ExhibitionGuideStops.tsx
@@ -22,6 +22,10 @@ const Stop = styled(Space).attrs({
   height: 100%;
 `;
 
+const VideoPlayerWrapper = styled.figure`
+  margin: 0;
+`;
+
 type VideoPlayerProps = {
   title: string;
   videoUrl: string;
@@ -33,14 +37,14 @@ const VideoPlayer: FunctionComponent<VideoPlayerProps> = ({
   videoUrl,
   titleProps,
 }) => (
-  <figure className="no-margin">
+  <VideoPlayerWrapper>
     <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
       <figcaption className={font('intb', 5)} {...titleProps}>
         {title}
       </figcaption>
     </Space>
     <VideoEmbed embedUrl={videoUrl} />
-  </figure>
+  </VideoPlayerWrapper>
 );
 
 type Props = {

--- a/content/webapp/components/FeaturedCard/FeaturedCard.tsx
+++ b/content/webapp/components/FeaturedCard/FeaturedCard.tsx
@@ -119,7 +119,11 @@ const FeaturedCardArticleBody: FunctionComponent<FeaturedCardArticleBodyProps> =
         {article.series.length > 0 && (
           <Space v={{ size: 'l', properties: ['margin-top'] }}>
             {article.series.map(series => (
-              <p key={series.title} className={`${font('intb', 6)} no-margin`}>
+              <p
+                key={series.title}
+                className={`${font('intb', 6)}`}
+                style={{ marginBottom: 0 }}
+              >
                 <span className={font('intr', 6)}>Part of</span> {series.title}
               </p>
             ))}

--- a/content/webapp/components/ImageGallery/ImageGallery.tsx
+++ b/content/webapp/components/ImageGallery/ImageGallery.tsx
@@ -88,6 +88,10 @@ const GalleryTitle = styled(Space).attrs({
   className: 'flex--v-top',
 })`
   display: flex;
+
+  h2 {
+    margin-bottom: 0;
+  }
 `;
 
 const Gallery = styled.div.attrs({
@@ -342,7 +346,7 @@ const ImageGallery: FunctionComponent<{ id: number } & Props> = ({
             <Space as="span" h={{ size: 's', properties: ['margin-right'] }}>
               <Icon icon={gallery} />
             </Space>
-            <h2 id={`gallery-${id}`} className="h2 no-margin" ref={headingRef}>
+            <h2 id={`gallery-${id}`} className="h2" ref={headingRef}>
               {title || 'In pictures'}
             </h2>
           </GalleryTitle>

--- a/content/webapp/components/Quote/Quote.tsx
+++ b/content/webapp/components/Quote/Quote.tsx
@@ -11,6 +11,18 @@ export type Props = {
   isPullOrReview: boolean;
 };
 
+const Blockquote = styled.blockquote.attrs<{ isPullOrReview: boolean }>(
+  props => ({
+    className: classNames({
+      'quote--pull': props.isPullOrReview,
+      [font('intr', 2)]: props.isPullOrReview,
+      quote: true,
+    }),
+  })
+)<{ isPullOrReview: boolean }>`
+  margin: 0;
+`;
+
 const Cite = styled.cite.attrs({
   className: `quote__cite ${font('intr', 5)}`,
 })`
@@ -25,13 +37,7 @@ const Quote: FunctionComponent<Props> = ({
   isPullOrReview,
 }) => {
   return (
-    <blockquote
-      className={classNames({
-        'quote--pull': isPullOrReview,
-        [font('intr', 2)]: isPullOrReview,
-        'quote no-margin': true,
-      })}
-    >
+    <Blockquote isPullOrReview={isPullOrReview}>
       <Space
         v={citation ? { size: 'xs', properties: ['margin-bottom'] } : undefined}
       >
@@ -44,7 +50,7 @@ const Quote: FunctionComponent<Props> = ({
           </Cite>
         </footer>
       )}
-    </blockquote>
+    </Blockquote>
   );
 };
 

--- a/content/webapp/components/SearchResults/AsyncSearchResults.tsx
+++ b/content/webapp/components/SearchResults/AsyncSearchResults.tsx
@@ -31,7 +31,9 @@ class AsyncSearchResults extends Component<Props, State> {
           <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
             <div className="grid">
               <div className={grid({ s: 12 })}>
-                <h2 className="h2 no-margin">{this.props.title}</h2>
+                <h2 className="h2" style={{ marginBottom: 0 }}>
+                  {this.props.title}
+                </h2>
               </div>
             </div>
           </Space>

--- a/content/webapp/components/SeasonsHeader/SeasonsHeader.tsx
+++ b/content/webapp/components/SeasonsHeader/SeasonsHeader.tsx
@@ -24,9 +24,10 @@ const FeaturedMediaWrapper = styled.div`
 `;
 
 const TitleWrapper = styled.h1.attrs({
-  className: `no-margin ${font('wb', 1)}`,
+  className: `${font('wb', 1)}`,
 })`
   display: inline-block;
+  margin-bottom: 0;
 `;
 
 type Props = {

--- a/content/webapp/components/VenueClosedPeriods/VenueClosedPeriods.tsx
+++ b/content/webapp/components/VenueClosedPeriods/VenueClosedPeriods.tsx
@@ -23,7 +23,7 @@ const VenueClosedPeriods: FunctionComponent<Props> = ({ venue }) => {
     <div className="body-text">
       <h2>{getNameFromCollectionVenue(venue.id)} closures</h2>
       {venue.id === collectionVenueId.libraries.id && (
-        <p className="no-margin">
+        <p style={{ marginBottom: 0 }}>
           Planning a research visit? Our library is closed over bank holiday
           weekends and between Christmas Eve and New Year{`'`}s Day:
         </p>

--- a/content/webapp/pages/events/[eventId].tsx
+++ b/content/webapp/pages/events/[eventId].tsx
@@ -466,13 +466,13 @@ const EventPage: NextPage<Props> = ({ event, jsonLd }) => {
           {isNotUndefined(
             event.policies.find(p => p.id === eventPolicyIds.schoolBooking)
           ) ? (
-            <p className={`no-margin ${font('intr', 5)}`}>
+            <p className={`${font('intr', 5)}`} style={{ marginBottom: 0 }}>
               {a11y.defaultEventMessage}
             </p>
           ) : (
             <>
               <p className={font('intr', 5)}>{a11y.defaultEventMessage}</p>
-              <p className={`no-margin ${font('intr', 5)}`}>
+              <p className={`${font('intr', 5)}`} style={{ marginBottom: 0 }}>
                 <a
                   href={`https://wellcomecollection.org/pages/${prismicPageIds.bookingAndAttendingOurEvents}`}
                 >

--- a/content/webapp/pages/exhibitions/index.tsx
+++ b/content/webapp/pages/exhibitions/index.tsx
@@ -145,7 +145,7 @@ const ExhibitionsPage: FunctionComponent<Props> = props => {
               <SectionHeader title="Past Exhibitions" />
               <Layout12>
                 <Space v={{ size: 'm', properties: ['margin-top'] }}>
-                  <p className="no-margin">{pastExhibitionsStrapline}</p>
+                  <p style={{ marginBottom: 0 }}>{pastExhibitionsStrapline}</p>
                 </Space>
               </Layout12>
             </Space>

--- a/identity/webapp/src/frontend/MyAccount/ChangeEmail.tsx
+++ b/identity/webapp/src/frontend/MyAccount/ChangeEmail.tsx
@@ -90,8 +90,12 @@ export const ChangeEmail: React.FunctionComponent<ChangeDetailsModalContentProps
           <StatusAlert type="failure">{submissionErrorMessage}</StatusAlert>
         )}
         <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
-          <h3 className={`${font('intb', 5)} no-margin`}>Email</h3>
-          <p className={`${font('intr', 5)} no-margin`}>{user?.email}</p>
+          <h3 className={`${font('intb', 5)}`} style={{ marginBottom: 0 }}>
+            Email
+          </h3>
+          <p className={`${font('intr', 5)}`} style={{ marginBottom: 0 }}>
+            {user?.email}
+          </p>
         </Space>
         <form onSubmit={handleSubmit(onSubmit)}>
           <FieldMargin>

--- a/identity/webapp/src/frontend/Registration/RegistrationInformation.tsx
+++ b/identity/webapp/src/frontend/Registration/RegistrationInformation.tsx
@@ -14,7 +14,7 @@ const RegistrationInformation: FunctionComponent<Props> = ({ email }) => {
       <SectionHeading as="h1">Apply for a library membership</SectionHeading>
 
       <h2 className={font('intb', 4)}>Your details</h2>
-      <p className="no-margin">
+      <p style={{ marginBottom: 0 }}>
         Email address: <strong className={font('intb', 5)}>{email}</strong>
       </p>
       <Space

--- a/yarn.lock
+++ b/yarn.lock
@@ -3357,10 +3357,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@cfaester/enzyme-adapter-react-18@^0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@cfaester/enzyme-adapter-react-18/-/enzyme-adapter-react-18-0.6.0.tgz#38994075edc1a4d1cd12fc6818d8b7d74f6b765f"
-  integrity sha512-68pqLvXsH0OVr6vWYvjTybEAM4piLqpeIYR5wuPnFzjPGKy7oZdIjJAMwMoBCvvio1zMjyzBzj5dCbg4O2JQnA==
+"@cfaester/enzyme-adapter-react-18@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@cfaester/enzyme-adapter-react-18/-/enzyme-adapter-react-18-0.7.0.tgz#92d81903855ed542ab54d2241a787c1b95883d0a"
+  integrity sha512-24rdgq6ncwmuyHizvKpdPUSczx5PjIhSr+LfXH/q5/Y28WbNZB6iGIqQ2iSiXp41qs+lutRIQQgwRJIf/a1N9w==
   dependencies:
     enzyme-shallow-equal "^1.0.0"
     react-is "^18.0.0"


### PR DESCRIPTION
Closes #9556

The vast majority of cases it was being used was on `p` tags on which we wanted to remove the (default) bottom margin.

The idea of a `<PNoBottomMargin>` styled component felt like an unnecessary abstraction, and wouldn't reduce what gets sent down the wire (the likelihood is that a styled component would output more characters for its className than `style={{marginBottom: 0}}`).

The other instances largely made sense to be added as e.g. `margin: 0` to the pre-existing styled-component declaration.

The case for keeping `.no-margin` ultimately felt pretty shakey.

I added a couple of wrappers around `figure` elements which have a default set of margins set by `normalize.css`. I wondered if it would make more sense to override these higher up the cascade (e.g. add `figure { margin: 0; }` in `wellcome-normalize.ts`).

There were also a couple of instance where it looked like the original intention had been to override the `no-margin` class with some other margin, but the `!important` flag was winning. In these cases I chose to stick with what the current rendered style is, even though it may be at odds with the original intention.

__TODO:__
- [x] make sure there aren't any visual diffs from Chromatic (3 at the time of creating the PR)