### PR TITLE
Only show 'back to search results' if you've arrived at the page from an internal search

### DIFF
--- a/cardigan/stories/components/BackToResults/BackToResults.stories.tsx
+++ b/cardigan/stories/components/BackToResults/BackToResults.stories.tsx
@@ -1,6 +1,7 @@
 import BackToResults from '@weco/common/views/components/BackToResults/BackToResults';
 import Readme from '@weco/common/views/components/BackToResults/README.md';
 import { ReadmeDecorator } from '@weco/cardigan/config/decorators';
+import SearchContext from '@weco/common/views/components/SearchContext/SearchContext';
 
 const nextLink = {
   href: {
@@ -19,15 +20,26 @@ const nextLink = {
   },
 };
 
+const WrappedBackToResults = () => (
+  <SearchContext.Provider
+    value={{
+      link: nextLink,
+      setLink: () => {
+        /* */
+      },
+    }}
+  >
+    <BackToResults />
+  </SearchContext.Provider>
+);
+
 const Template = args => (
   <ReadmeDecorator
-    WrappedComponent={BackToResults}
+    WrappedComponent={WrappedBackToResults}
     args={args}
     Readme={Readme}
   />
 );
 export const basic = Template.bind({});
-basic.args = {
-  nextLink,
-};
+
 basic.storyName = 'BackToResults';

--- a/common/views/components/BackToResults/BackToResults.tsx
+++ b/common/views/components/BackToResults/BackToResults.tsx
@@ -9,9 +9,10 @@ const BackToResults: FunctionComponent = () => {
   const query = link.href?.query?.query;
   const page = link.href?.query?.page;
 
-  return (
+  return query ? (
     <NextLink
       {...link}
+      data-gtm-trigger="back_to_search_results"
       onClick={() => {
         trackGaEvent({
           category: 'BackToResults',
@@ -23,7 +24,7 @@ const BackToResults: FunctionComponent = () => {
     >
       <span>{`Back to search${query ? ' results' : ''}`}</span>
     </NextLink>
-  );
+  ) : null;
 };
 
 export default BackToResults;

--- a/common/views/components/BackToResults/BackToResults.tsx
+++ b/common/views/components/BackToResults/BackToResults.tsx
@@ -22,7 +22,7 @@ const BackToResults: FunctionComponent = () => {
       }}
       className={font('intr', 5)}
     >
-      <span>{`Back to search${query ? ' results' : ''}`}</span>
+      <span>Back to search results</span>
     </NextLink>
   ) : null;
 };

--- a/common/views/components/BackToResults/BackToResults.tsx
+++ b/common/views/components/BackToResults/BackToResults.tsx
@@ -8,8 +8,11 @@ const BackToResults: FunctionComponent = () => {
   const { link } = useContext(SearchContext);
   const query = link.href?.query?.query;
   const page = link.href?.query?.page;
+  console.log({ link, query, page });
 
-  return query ? (
+  if (!query) return null;
+
+  return (
     <NextLink
       {...link}
       data-gtm-trigger="back_to_search_results"
@@ -24,7 +27,7 @@ const BackToResults: FunctionComponent = () => {
     >
       <span>Back to search results</span>
     </NextLink>
-  ) : null;
+  );
 };
 
 export default BackToResults;

--- a/common/views/components/BackToResults/BackToResults.tsx
+++ b/common/views/components/BackToResults/BackToResults.tsx
@@ -8,7 +8,6 @@ const BackToResults: FunctionComponent = () => {
   const { link } = useContext(SearchContext);
   const query = link.href?.query?.query;
   const page = link.href?.query?.page;
-  console.log({ link, query, page });
 
   if (!query) return null;
 


### PR DESCRIPTION
Fixes #9618 

Also adds a `back_to_search_restuls` trigger.
