### PR TITLE
Reduce the amount of lag when a user types in a new term on the search page

### DIFF
--- a/catalogue/webapp/components/SearchPageLayout/SearchNavigation.tsx
+++ b/catalogue/webapp/components/SearchPageLayout/SearchNavigation.tsx
@@ -1,0 +1,159 @@
+import { useRouter } from 'next/router';
+import { FunctionComponent, useEffect, useState } from 'react';
+import styled from 'styled-components';
+
+import SearchBar from '@weco/common/views/components/SearchBar/SearchBar';
+import Space from '@weco/common/views/components/styled/Space';
+import SubNavigation from '@weco/common/views/components/SubNavigation/SubNavigation';
+
+import { formDataAsUrlQuery } from '@weco/common/utils/forms';
+import convertUrlToString from '@weco/common/utils/convert-url-to-string';
+import { trackGaEvent } from '@weco/common/utils/ga';
+import {
+  getUrlQueryFromSortValue,
+  getQueryPropertyValue,
+  linkResolver,
+} from '@weco/common/utils/search';
+import { capitalize } from '@weco/common/utils/grammar';
+import { searchPlaceholderText } from '@weco/common/data/microcopy';
+
+const SearchBarContainer = styled(Space)`
+  ${props => props.theme.media('medium', 'max-width')`
+    margin-bottom:0;
+  `}
+`;
+
+type SearchNavigationProps = {
+  currentSearchCategory: string;
+  currentQueryValue: string;
+};
+
+// Performance note: this component will be re-rendered every time a user
+// changes the text input field, and the search term they entered won't
+// appear until it finishes rendering.
+//
+// This component should be kept small, so these re-renders are fast,
+// and we don't introduce any lag into the user typing.
+//
+// (Historical note: previously this was inline in SearchPageLayout,
+// which introduced noticeable latency as we had to re-render most of the
+// page on every keystroke.  You really felt it!)
+const SearchNavigation: FunctionComponent<SearchNavigationProps> = ({
+  currentSearchCategory,
+  currentQueryValue: queryValue,
+}) => {
+  const router = useRouter();
+
+  // Variable naming note:
+  //
+  //    - `currentQueryValue` is whatever query was used to render
+  //      the currently-loaded search results
+  //    - `inputValue` is whatever the user has typed into the search
+  //      input field
+  //
+  const [inputValue, setInputValue] = useState(queryValue || '');
+
+  // This ensures that if somebody is on a search page, then does a search
+  // from the global nav, we'll update the text in the search box to match --
+  // replacing whatever they'd been searching for previously.
+  useEffect(() => {
+    setInputValue(queryValue);
+  }, [queryValue]);
+
+  const getURL = (pathname: string) => {
+    return convertUrlToString({
+      pathname,
+      // Note: we use `inputValue` instead of `currentQueryValue` because if
+      // a user clicks on a tab, we want to run a search with whatever is
+      // currently entered in the search input field.
+      query: { query: inputValue },
+    });
+  };
+
+  const updateUrl = (form: HTMLFormElement) => {
+    const formValues = formDataAsUrlQuery(form);
+
+    const sortOptionValue = getQueryPropertyValue(formValues.sortOrder);
+    const urlFormattedSort = sortOptionValue
+      ? getUrlQueryFromSortValue(sortOptionValue)
+      : undefined;
+
+    const link = linkResolver({
+      params: {
+        ...formValues,
+        ...(urlFormattedSort && {
+          sort: urlFormattedSort.sort,
+          sortOrder: urlFormattedSort.sortOrder,
+        }),
+      },
+      pathname: router.pathname,
+    });
+
+    return router.push(link.href, link.as);
+  };
+
+  return (
+    <>
+      <form
+        role="search"
+        id="search-page-form"
+        onSubmit={event => {
+          event.preventDefault();
+
+          trackGaEvent({
+            category: 'SearchForm',
+            action: 'submit search',
+            label: router.query.query as string,
+          });
+
+          updateUrl(event.currentTarget);
+        }}
+      >
+        <h1 className="visually-hidden">
+          ${capitalize(currentSearchCategory)} search
+        </h1>
+
+        <SearchBarContainer
+          v={{ size: 'l', properties: ['margin-top', 'margin-bottom'] }}
+        >
+          <SearchBar
+            inputValue={inputValue}
+            setInputValue={setInputValue}
+            placeholder={searchPlaceholderText[currentSearchCategory]}
+            form="search-page-form"
+            location="search"
+          />
+        </SearchBarContainer>
+      </form>
+      <SubNavigation
+        label="Search Categories"
+        items={[
+          {
+            id: 'overview',
+            url: getURL('/search'),
+            name: 'All',
+          },
+          {
+            id: 'stories',
+            url: getURL('/search/stories'),
+            name: 'Stories',
+          },
+          {
+            id: 'images',
+            url: getURL('/search/images'),
+            name: 'Images',
+          },
+          {
+            id: 'works',
+            url: getURL('/search/works'),
+            name: 'Catalogue',
+          },
+        ]}
+        currentSection={currentSearchCategory}
+        hasDivider
+      />
+    </>
+  );
+};
+
+export default SearchNavigation;

--- a/common/data/microcopy.tsx
+++ b/common/data/microcopy.tsx
@@ -139,3 +139,12 @@ export const requestingDisabled =
 
 export const pastExhibitionsStrapline =
   'Take a look at our past exhibitions and installations.';
+
+// This is the placeholder terms used in the search box, both for the
+// search in the global nav and on the categories in wc.org/search
+export const searchPlaceholderText = {
+  overview: 'Search our stories, images and catalogue',
+  stories: 'Search for stories',
+  images: 'Search for images',
+  works: 'Search the catalogue',
+};

--- a/common/views/components/Header/Header.tsx
+++ b/common/views/components/Header/Header.tsx
@@ -32,6 +32,7 @@ import {
 import DesktopSignIn from './DesktopSignIn';
 import MobileSignIn from './MobileSignIn';
 import HeaderSearch from './HeaderSearch';
+import { searchPlaceholderText } from '@weco/common/data/microcopy';
 
 const NoJSIconWrapper = styled.div`
   padding: 5px 8px 0;
@@ -183,7 +184,7 @@ const Header: FunctionComponent<Props> = ({
                               icon={searchDropdownIsActive ? cross : search}
                             />
                             <span className="visually-hidden">
-                              Search our stories, images and catalogue
+                              {searchPlaceholderText.overview}
                             </span>
                           </NoJSIconWrapper>
                         </NextLink>


### PR DESCRIPTION
On [the current search pages](https://wellcomecollection.org/search), there's a pretty substantial lag whenever you type in a search term, and you can see the local CPU spike as well.  That's on my dev spec MacBook, so it's probably much worse on other hardware.

I noticed that we're re-rendering the entire SearchPageLayout component every time the user changes the text input for the search – looking in the React dev tools, I think it's because the input value is a state hook on that component:

    const [inputValue, setInputValue] = useState(…);

Every keystroke they type updates this state, which forces a re-render of that component – which is pretty much the entire page.  Although it's only ~90ms to render, that gets backed up quickly and causes the lag.

This patch moves that state into a new component, SearchNavigation. It still gets re-rendered on every keystroke, but it's much smaller, so the performance impact is negligible.  It requires a bit of fiddling to get search working from the global nav, and maybe it's not perfect, but it seems to work.

I ran the following test cases locally:

1. Go to the search overview http://localhost:3000/search Type in the query "fish" and click "search".  Check I'm taken to a page with:

   - search results for fish
   - the word "fish" in the search form
   - a query parameter "fish" in the URL.

2. Now add the word "custard" to the search input, so the search form says "fish custard".  Click the "Catalogue" tab.  Check I'm taken to a page with:

   - search results for fish custard
   - the phrase "fish custard" in the search form
   - a query parameter "fish custard" in the URL

3. Now click the search icon in the global nav, enter "fish cream", and click search.  Check I'm taken to an overview search page with:

   - search results for fish cream
   - the phrase "fish cream" in the search form
   - a query parameter "fish cream" in the URL