### PR TITLE
Add a missing type to handleClick

### DIFF
--- a/common/views/components/ButtonSolid/ButtonSolid.tsx
+++ b/common/views/components/ButtonSolid/ButtonSolid.tsx
@@ -228,7 +228,7 @@ const Button: ForwardRefRenderFunction<HTMLButtonElement, ButtonSolidProps> = (
   }: ButtonSolidProps,
   ref: ForwardedRef<HTMLButtonElement>
 ) => {
-  function handleClick(event) {
+  function handleClick(event: SyntheticEvent<HTMLButtonElement>) {
     clickHandler && clickHandler(event);
     trackingEvent && trackGaEvent(trackingEvent);
   }


### PR DESCRIPTION
I was poking around in here yesterday while doing some React profiling, and VSCode was whinging that `event` is untyped.