### PR TITLE
Don't use <Script> inside the <Head>

### DIFF
--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -204,7 +204,7 @@ const PageLayoutComponent: FunctionComponent<Props> = ({
         <meta key="twitter:image" name="twitter:image" content={imageUrl} />
         <meta name="twitter:image:alt" content={imageAltText} />
         <meta httpEquiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-        <Script
+        <script
           src={`https://cdn.polyfill.io/v3/polyfill.js?version=${polyfillVersion}&features=${polyfillFeatures.join(
             ','
           )}`}
@@ -241,12 +241,12 @@ const PageLayoutComponent: FunctionComponent<Props> = ({
           href="https://i.wellcomecollection.org/assets/icons/safari-pinned-tab.svg"
           color="#000000"
         />
-        <Script
+        <script
           src="https://i.wellcomecollection.org/assets/libs/picturefill.min.js"
           async
         />
 
-        <Script
+        <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{
             __html: JSON.stringify(jsonLd),
@@ -261,7 +261,7 @@ const PageLayoutComponent: FunctionComponent<Props> = ({
             type="application/rss+xml"
           />
         )}
-        <Script
+        <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{
             __html: JSON.stringify(
@@ -269,7 +269,7 @@ const PageLayoutComponent: FunctionComponent<Props> = ({
             ),
           }}
         />
-        <Script
+        <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{
             __html: JSON.stringify(libraryLd(wellcomeLibraryWithHours)),


### PR DESCRIPTION
For some reason Next doesn't include these in the rendered <head>; changing them to a regular <script> like we do elsewhere (e.g. GA snippets) gets these rendering correctly.