### PR TITLE
don’t attach gaUserId to iframe source

### DIFF
--- a/common/services/app/google-analytics.tsx
+++ b/common/services/app/google-analytics.tsx
@@ -71,19 +71,16 @@ export const GoogleTagManager: FunctionComponent = () => (
   />
 );
 
-export const GoogleTagManagerNoScript: FunctionComponent<{ gaUserId: string }> =
-  ({ gaUserId }) => (
-    <noscript>
-      <iframe
-        src={`https://www.googletagmanager.com/ns.html?id=GTM-53DFWQD&gaUserId=${encodeURIComponent(
-          gaUserId
-        )}`}
-        height="0"
-        width="0"
-        style={{ display: 'none', visibility: 'hidden' }}
-      ></iframe>
-    </noscript>
-  );
+export const GoogleTagManagerNoScript: FunctionComponent = () => (
+  <noscript>
+    <iframe
+      src="https://www.googletagmanager.com/ns.html?id=GTM-53DFWQD"
+      height="0"
+      width="0"
+      style={{ display: 'none', visibility: 'hidden' }}
+    ></iframe>
+  </noscript>
+);
 
 export const GoogleAnalyticsUA: FunctionComponent = () => (
   <script

--- a/common/views/pages/_document.tsx
+++ b/common/views/pages/_document.tsx
@@ -17,7 +17,6 @@ import {
   GoogleTagManagerNoScript,
   GaDimensions,
 } from '../../services/app/google-analytics';
-import { getCookie } from 'cookies-next';
 
 const {
   ANALYTICS_WRITE_KEY = '78Czn5jNSaMSVrBq2J9K4yJjWxh6fyRI',
@@ -40,13 +39,11 @@ function renderSegmentSnippet() {
 type DocumentInitialPropsWithTogglesAndGa = DocumentInitialProps & {
   toggles: Toggles;
   gaDimensions?: GaDimensions;
-  gaUserId?: string;
 };
 class WecoDoc extends Document<DocumentInitialPropsWithTogglesAndGa> {
   static async getInitialProps(
     ctx: DocumentContext
   ): Promise<DocumentInitialPropsWithTogglesAndGa> {
-    const gaUserId = getCookie('_ga', ctx) as string | undefined;
     const sheet = new ServerStyleSheet();
     let pageProps;
     const originalRenderPage = ctx.renderPage;
@@ -65,7 +62,6 @@ class WecoDoc extends Document<DocumentInitialPropsWithTogglesAndGa> {
         ...initialProps,
         toggles: pageProps.serverData?.toggles,
         gaDimensions: pageProps.gaDimensions,
-        gaUserId,
         styles: (
           <>
             {initialProps.styles}
@@ -95,7 +91,7 @@ class WecoDoc extends Document<DocumentInitialPropsWithTogglesAndGa> {
           />
         </Head>
         <body>
-          <GoogleTagManagerNoScript gaUserId={this.props.gaUserId || ''} />
+          <GoogleTagManagerNoScript />
           <div id="top">
             <Main />
           </div>


### PR DESCRIPTION
Undoing work that was done as part of #9417

We're not going to try and track non javascript users