### PR TITLE
Edited accessibility information in yellow box 

### DIFF
--- a/common/data/microcopy.tsx
+++ b/common/data/microcopy.tsx
@@ -75,7 +75,8 @@ export const a11y = {
   //
   defaultEventMessage: (
     <>
-      If you have any queries about accessibility, please email us at{' '}
+      For more information, please visit our <a href="/access">Accessibility</a>{' '}
+      page. If you have any queries about accessibility, please email us at{' '}
       <a href="mailto:access@wellcomecollection.org">
         access@wellcomecollection.org
       </a>{' '}

--- a/content/webapp/components/Exhibition/Exhibition.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.tsx
@@ -41,7 +41,6 @@ import * as prismicT from '@prismicio/types';
 import styled from 'styled-components';
 
 import { createScreenreaderLabel } from '@weco/common/utils/telephone-numbers';
-import Link from 'next/link';
 
 type ExhibitionItem = LabelField & {
   icon?: IconSvg;
@@ -291,11 +290,11 @@ const Exhibition: FunctionComponent<Props> = ({ exhibition, pages }) => {
         <InfoBox title="Visit us" items={getInfoItems(exhibition)}>
           <AccessibilityServices>
             For more information, please visit our{' '}
-            <Link href="/access">Accessibility</Link> page. If you have any
-            queries about accessibility, please email us at{' '}
-            <Link href="mailto:access@wellcomecollection.org">
+            <a href="/access">Accessibility</a> page. If you have any queries
+            about accessibility, please email us at{' '}
+            <a href="mailto:access@wellcomecollection.org">
               access@wellcomecollection.org
-            </Link>{' '}
+            </a>{' '}
             or call{' '}
             {/*
         This is to ensure phone numbers are read in a sensible way by

--- a/content/webapp/components/Exhibition/Exhibition.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.tsx
@@ -41,6 +41,7 @@ import * as prismicT from '@prismicio/types';
 import styled from 'styled-components';
 
 import { createScreenreaderLabel } from '@weco/common/utils/telephone-numbers';
+import Link from 'next/link';
 
 type ExhibitionItem = LabelField & {
   icon?: IconSvg;
@@ -290,11 +291,11 @@ const Exhibition: FunctionComponent<Props> = ({ exhibition, pages }) => {
         <InfoBox title="Visit us" items={getInfoItems(exhibition)}>
           <AccessibilityServices>
             For more information, please visit our{' '}
-            <a href="/access">Accessibility</a> page. If you have any queries
-            about accessibility, please email us at{' '}
-            <a href="mailto:access@wellcomecollection.org">
+            <Link href="/access">Accessibility</Link> page. If you have any
+            queries about accessibility, please email us at{' '}
+            <Link href="mailto:access@wellcomecollection.org">
               access@wellcomecollection.org
-            </a>{' '}
+            </Link>{' '}
             or call{' '}
             {/*
         This is to ensure phone numbers are read in a sensible way by

--- a/content/webapp/components/Exhibition/Exhibition.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.tsx
@@ -40,6 +40,8 @@ import { EventBasic } from '../../types/events';
 import * as prismicT from '@prismicio/types';
 import styled from 'styled-components';
 
+import { createScreenreaderLabel } from '@weco/common/utils/telephone-numbers';
+
 type ExhibitionItem = LabelField & {
   icon?: IconSvg;
 };
@@ -287,7 +289,21 @@ const Exhibition: FunctionComponent<Props> = ({ exhibition, pages }) => {
       {exhibition.end && !isPast(exhibition.end) && (
         <InfoBox title="Visit us" items={getInfoItems(exhibition)}>
           <AccessibilityServices>
-            <a href="/access">All our accessibility services</a>
+            For more information, please visit our{' '}
+            <a href="/access">Accessibility</a> page. If you have any queries
+            about accessibility, please email us at{' '}
+            <a href="mailto:access@wellcomecollection.org">
+              access@wellcomecollection.org
+            </a>{' '}
+            or call{' '}
+            {/*
+        This is to ensure phone numbers are read in a sensible way by
+        screen readers.
+      */}
+            <span className="visually-hidden">
+              {createScreenreaderLabel('020 7611 2222')}
+            </span>
+            <span aria-hidden="true">020&nbsp;7611&nbsp;2222.</span>
           </AccessibilityServices>
         </InfoBox>
       )}

--- a/content/webapp/components/Installation/Installation.tsx
+++ b/content/webapp/components/Installation/Installation.tsx
@@ -12,6 +12,7 @@ import Body from '../Body/Body';
 import ContentPage from '../ContentPage/ContentPage';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
 import { fetchExhibitExhibition } from '../../services/prismic/fetch/exhibitions';
+import { createScreenreaderLabel } from '@weco/common/utils/telephone-numbers';
 
 type Props = {
   installation: InstallationType;
@@ -87,7 +88,21 @@ const Installation: FunctionComponent<Props> = ({ installation }) => {
       {installation.end && !isPast(installation.end) && (
         <InfoBox title="Visit us" items={getInfoItems(installation)}>
           <AccessibilityServices>
-            <a href="/access">All our accessibility services</a>
+            For more information, please visit our{' '}
+            <a href="/access">Accessibility</a> page. If you have any queries
+            about accessibility, please email us at{' '}
+            <a href="mailto:access@wellcomecollection.org">
+              access@wellcomecollection.org
+            </a>{' '}
+            or call{' '}
+            {/*
+        This is to ensure phone numbers are read in a sensible way by
+        screen readers.
+      */}
+            <span className="visually-hidden">
+              {createScreenreaderLabel('020 7611 2222')}
+            </span>
+            <span aria-hidden="true">020&nbsp;7611&nbsp;2222.</span>
           </AccessibilityServices>
         </InfoBox>
       )}


### PR DESCRIPTION
## Who is this for?
Digital Editorial 
Users looking for Accessibility information on exhibition and events pages

## What is it doing for them?
For #9617 
A request was made for accessibility copy to be adjusted to be consistent across events, exhibitions, and installation pages within the yellow box . Users now see the same information across yellow boxes on accessibility 

Correct text displays on all exhibitions, events, and installations

To do this I:
- adjusted copy on both exhibitions, events, and installation yellow boxes
- imported the ```createScreenreaderLabel``` component into ```Exhibition.tsx``` and ```Installation.tsx``` to ensure the telephone number on the exhibitions page would also be read out correctly by screen readers
