### PR TITLE
Make sure we render newlines in the lettering field (and other fields)

### DIFF
--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -627,7 +627,10 @@ const WorkDetails: FunctionComponent<Props> = ({
           e.g. Patient <...>, sup<erior> mesenteric a<rtery>
           */}
         {work.lettering && (
-          <WorkDetailsText title="Lettering" text={work.lettering} />
+          <WorkDetailsText
+            title="Lettering"
+            text={work.lettering.split('\n\n')}
+          />
         )}
 
         {work.edition && (

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -627,10 +627,7 @@ const WorkDetails: FunctionComponent<Props> = ({
           e.g. Patient <...>, sup<erior> mesenteric a<rtery>
           */}
         {work.lettering && (
-          <WorkDetailsText
-            title="Lettering"
-            text={work.lettering.split('\n\n')}
-          />
+          <WorkDetailsText title="Lettering" text={work.lettering} />
         )}
 
         {work.edition && (

--- a/catalogue/webapp/components/WorkDetailsText/WorkDetailsText.tsx
+++ b/catalogue/webapp/components/WorkDetailsText/WorkDetailsText.tsx
@@ -9,13 +9,18 @@ const LimitWidth = styled.div.attrs({
   className: 'spaced-text',
 })`
   max-width: 45em;
+
+  /* This keeps the changes needed for letters spaced together, but
+   * should remove any consideration for symbols. So no more -> turning
+   * into an arrow, which can be an issue e.g. for year ranges <1800->
+   **/
   font-variant-ligatures: no-contextual;
+
+  /* This ensures any newlines in the API data are rendered on the page,
+   * e.g. lettering with newlines on https://wellcomecollection.org/works/cphumehx
+   **/
+  white-space: break-spaces;
 `;
-/**
- * [font-variant-ligatures: no-contextual] is supposed to maintain the
- * changes needed for letters spaced together, but should remove any
- * consideration for symbols. So no more -> turning into an arrow
- * */
 
 type TextProps = BaseProps & {
   text: string | string[];


### PR DESCRIPTION
The API sometimes returns data with newlines in the data, but whitespace isn't typically significant in HTML.

This fixes the work details so any newlines from the API data will be preserved.