### PR TITLE
Don't fetch subject/identifier data on work searches

### DIFF
--- a/catalogue/webapp/services/wellcome/catalogue/works.ts
+++ b/catalogue/webapp/services/wellcome/catalogue/works.ts
@@ -26,13 +26,7 @@ type GetWorkProps = {
   toggles: Toggles;
 };
 
-const worksIncludes = [
-  'identifiers',
-  'production',
-  'contributors',
-  'subjects',
-  'partOf',
-];
+const worksIncludes = ['production', 'contributors', 'partOf'];
 
 const workIncludes = [
   'identifiers',


### PR DESCRIPTION
We don't use either of these fields to render the work search results, and it has a notable impact on page weight – around 10% of the page size in some quick local testing!