### PR TITLE
Apply new version to get partOf in works redirect

### DIFF
--- a/cache/edge_lambdas/yarn.lock
+++ b/cache/edge_lambdas/yarn.lock
@@ -2356,6 +2356,11 @@ ts-jest@29.0.5:
     semver "7.x"
     yargs-parser "^21.0.1"
 
+type-detect@4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
+
 type-fest@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"

--- a/cache/locals.tf
+++ b/cache/locals.tf
@@ -3,8 +3,8 @@ data "aws_secretsmanager_secret_version" "slack_webhook" {
 }
 
 locals {
-  edge_lambda_request_version  = 116
-  edge_lambda_response_version = 116
+  edge_lambda_request_version  = 117
+  edge_lambda_response_version = 117
 
   wellcome_cdn_cert_arn = "arn:aws:acm:us-east-1:130871440101:certificate/bb840c52-56bb-4bf8-86f8-59e7deaf9c98"
 


### PR DESCRIPTION
## Who is this for?
Users with bookmarks

## What is it doing for them?
When fixing the missing `partOf.title` filter, I realised I hadn't listed it as a valid params in the `/works` to `/search/works` redirect, so here it now is. ([works in staging](https://www-stage.wellcomecollection.org/works?partOf.title=VLeBooks) now)