### PR TITLE
reinstate hidden tests

### DIFF
--- a/playwright/test/search-works.test.ts
+++ b/playwright/test/search-works.test.ts
@@ -128,7 +128,7 @@ test.describe('Scenario 1: The person is looking for an archive', () => {
     await navigateToResult(3, page);
   });
 
-  test.only('and the user can get back to their original search results', async ({
+  test('and the user can get back to their original search results', async ({
     page,
     context,
   }) => {


### PR DESCRIPTION
Currently, only one playwright test is being executed on main.  This reinstates the missing ones.