### PR TITLE
Fix the duplicate meta tags being written to the <head>

### DIFF
--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -155,7 +155,6 @@ const PageLayoutComponent: FunctionComponent<Props> = ({
   return (
     <>
       <Head>
-        <meta property="next:version" content="13" />
         <title>{fullTitle}</title>
         <meta name="description" content={description || ''} />
         <link rel="canonical" href={absoluteUrl} />

--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -156,7 +156,7 @@ const PageLayoutComponent: FunctionComponent<Props> = ({
     <>
       <Head>
         <title>{fullTitle}</title>
-        <meta name="description" content={description || ''} />
+        <meta name="description" content={description} />
         <link rel="canonical" href={absoluteUrl} />
         {/* meta elements need to be contained as direct children of the Head element, so don't componentise the following */}
         <meta property="og:site_name" content="Wellcome Collection" />

--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -203,11 +203,6 @@ const PageLayoutComponent: FunctionComponent<Props> = ({
         <meta key="twitter:image" name="twitter:image" content={imageUrl} />
         <meta name="twitter:image:alt" content={imageAltText} />
         <meta httpEquiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-        <script
-          src={`https://cdn.polyfill.io/v3/polyfill.js?version=${polyfillVersion}&features=${polyfillFeatures.join(
-            ','
-          )}`}
-        />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link
           rel="apple-touch-icon"
@@ -240,17 +235,6 @@ const PageLayoutComponent: FunctionComponent<Props> = ({
           href="https://i.wellcomecollection.org/assets/icons/safari-pinned-tab.svg"
           color="#000000"
         />
-        <script
-          src="https://i.wellcomecollection.org/assets/libs/picturefill.min.js"
-          async
-        />
-
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{
-            __html: JSON.stringify(jsonLd),
-          }}
-        />
 
         {rssUrl && (
           <link
@@ -260,21 +244,37 @@ const PageLayoutComponent: FunctionComponent<Props> = ({
             type="application/rss+xml"
           />
         )}
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{
-            __html: JSON.stringify(
-              museumLd(wellcomeCollectionGalleryWithHours)
-            ),
-          }}
-        />
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{
-            __html: JSON.stringify(libraryLd(wellcomeLibraryWithHours)),
-          }}
-        />
       </Head>
+
+      <Script
+        src={`https://cdn.polyfill.io/v3/polyfill.js?version=${polyfillVersion}&features=${polyfillFeatures.join(
+          ','
+        )}`}
+      />
+
+      <Script
+        src="https://i.wellcomecollection.org/assets/libs/picturefill.min.js"
+        async
+      />
+
+      <Script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(jsonLd),
+        }}
+      />
+      <Script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(museumLd(wellcomeCollectionGalleryWithHours)),
+        }}
+      />
+      <Script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(libraryLd(wellcomeLibraryWithHours)),
+        }}
+      />
 
       <div id="root">
         {apiToolbar && (


### PR DESCRIPTION
For some reason Next.js is putting duplicate `<meta>` tags in the `<head>` element, including the `charset`, `description` and `facebook-domain-verification` tags.

If I convert the `<script>` tags into `<Script>` and move them outside the `<Head>`, this seems to fix the issue. I'm not entirely sure why this works, but it does.

It does mean these scripts are now loading at the end of `<body>` instead of in the `<head>`, but this is still an improvement on the current situation where [they're not loading at all](https://github.com/wellcomecollection/wellcomecollection.org/pull/9640).