### PR TITLE
[WIP] Split the period predicates for events and exhibitions

### DIFF
--- a/common/utils/dates.test.ts
+++ b/common/utils/dates.test.ts
@@ -12,6 +12,8 @@ import {
   minDate,
   maxDate,
   startOfWeek,
+  startOfDay,
+  endOfDay,
 } from './dates';
 
 it('identifies dates in the past', () => {
@@ -257,8 +259,8 @@ describe('getNextWeekendDateRange', () => {
   ])('the next weekend after $day is $weekend', ({ day, weekend }) => {
     const range = getNextWeekendDateRange(day);
 
-    expect(isSameDay(range.start, weekend.start)).toBeTruthy();
-    expect(isSameDay(range.end, weekend.end)).toBeTruthy();
+    expect(isSameDay(range.start, weekend.start, 'London')).toBeTruthy();
+    expect(isSameDay(range.end, weekend.end, 'London')).toBeTruthy();
   });
 });
 
@@ -341,4 +343,32 @@ describe('minDate and maxDate', () => {
       expect(maxDate(dates)).toBe(date3);
     }
   );
+});
+
+describe('startOfDay and endOfDay', () => {
+  const combinations = [
+    // when British Summer Time is in effect, and London is offset from UTC
+    {
+      d: new Date('2023-04-24'),
+      startDate: new Date('2023-04-23T23:00:00Z'),
+      endDate: new Date('2023-04-24T22:59:59Z'),
+    },
+    // when British Summer Time is not in effect, and London is on UTC
+    {
+      d: new Date('2023-11-24'),
+      startDate: new Date('2023-11-24T00:00:00Z'),
+      endDate: new Date('2023-11-24T23:59:59Z'),
+    },
+  ];
+
+  test.each(combinations)(
+    'the start of $d is $startDate',
+    ({ d, startDate }) => {
+      expect(startOfDay(d)).toStrictEqual(startDate);
+    }
+  );
+
+  test.each(combinations)('the end of $d is $endDate', ({ d, endDate }) => {
+    expect(endOfDay(d)).toStrictEqual(endDate);
+  });
 });

--- a/common/utils/dates.test.ts
+++ b/common/utils/dates.test.ts
@@ -260,6 +260,11 @@ describe('getNextWeekendDateRange', () => {
     const range = getNextWeekendDateRange(day);
 
     expect(isSameDay(range.start, weekend.start, 'London')).toBeTruthy();
+    console.log(
+      `@@AWLC range = ${JSON.stringify(range)}, weekend = ${JSON.stringify(
+        weekend
+      )}`
+    );
     expect(isSameDay(range.end, weekend.end, 'London')).toBeTruthy();
   });
 });

--- a/common/utils/dates.test.ts
+++ b/common/utils/dates.test.ts
@@ -356,13 +356,13 @@ describe('startOfDay and endOfDay', () => {
     {
       d: new Date('2023-04-24'),
       startDate: new Date('2023-04-23T23:00:00Z'),
-      endDate: new Date('2023-04-24T22:59:59Z'),
+      endDate: new Date('2023-04-24T22:59:59.999Z'),
     },
     // when British Summer Time is not in effect, and London is on UTC
     {
       d: new Date('2023-11-24'),
       startDate: new Date('2023-11-24T00:00:00Z'),
-      endDate: new Date('2023-11-24T23:59:59Z'),
+      endDate: new Date('2023-11-24T23:59:59.999Z'),
     },
   ];
 

--- a/common/utils/dates.test.ts
+++ b/common/utils/dates.test.ts
@@ -260,11 +260,6 @@ describe('getNextWeekendDateRange', () => {
     const range = getNextWeekendDateRange(day);
 
     expect(isSameDay(range.start, weekend.start, 'London')).toBeTruthy();
-    console.log(
-      `@@AWLC range = ${JSON.stringify(range)}, weekend = ${JSON.stringify(
-        weekend
-      )}`
-    );
     expect(isSameDay(range.end, weekend.end, 'London')).toBeTruthy();
   });
 });

--- a/common/utils/dates.ts
+++ b/common/utils/dates.ts
@@ -1,5 +1,5 @@
 import { DateRange } from '../model/date-range';
-import { formatDayDate } from './format-date';
+import { formatDayDate, formatIso8601Date } from './format-date';
 
 // This is to allow us to mock values in tests, e.g.
 //
@@ -88,17 +88,16 @@ export function isDayPast(date: Date): boolean {
   }
 }
 
-// TODO: Does setting these to UTC 00:00:00 cause issues in London?
+/** Return the start (midnight) and end (23:59:59) of the given date.
+ *
+ * This is the start/end of the day in London, not UTC.
+ */
 export function startOfDay(d: Date): Date {
-  const res = new Date(d);
-  res.setUTCHours(0, 0, 0, 0);
-  return res;
+  return new Date(`${formatIso8601Date(d)} 00:00:00 (London)`);
 }
 
 export function endOfDay(d: Date): Date {
-  const res = new Date(d);
-  res.setUTCHours(23, 59, 59, 999);
-  return res;
+  return new Date(`${formatIso8601Date(d)} 23:59:59 (London)`);
 }
 
 export function addDays(d: Date, days: number): Date {

--- a/common/utils/dates.ts
+++ b/common/utils/dates.ts
@@ -1,5 +1,5 @@
 import { DateRange } from '../model/date-range';
-import { formatDayDate, formatIso8601Date } from './format-date';
+import { formatDayDate, formatLondon } from './format-date';
 
 // This is to allow us to mock values in tests, e.g.
 //
@@ -93,11 +93,37 @@ export function isDayPast(date: Date): boolean {
  * This is the start/end of the day in London, not UTC.
  */
 export function startOfDay(d: Date): Date {
-  return new Date(`${formatIso8601Date(d)} 00:00:00 (London)`);
+  const currentTz = formatLondon(d, {
+    hour: '2-digit',
+    timeZoneName: 'short',
+  }).split(' ')[1];
+
+  if (currentTz === 'BST') {
+    const res = new Date(d);
+    res.setUTCHours(-1, 0, 0, 0);
+    return res;
+  } else {
+    const res = new Date(d);
+    res.setUTCHours(0, 0, 0, 0);
+    return res;
+  }
 }
 
 export function endOfDay(d: Date): Date {
-  return new Date(`${formatIso8601Date(d)} 23:59:59 (London)`);
+  const currentTz = formatLondon(d, {
+    hour: '2-digit',
+    timeZoneName: 'short',
+  }).split(' ')[1];
+
+  if (currentTz === 'BST') {
+    const res = new Date(d);
+    res.setUTCHours(22, 59, 59, 999);
+    return res;
+  } else {
+    const res = new Date(d);
+    res.setUTCHours(23, 59, 59, 999);
+    return res;
+  }
 }
 
 export function addDays(d: Date, days: number): Date {

--- a/common/utils/format-date.test.ts
+++ b/common/utils/format-date.test.ts
@@ -6,6 +6,7 @@ import {
   formatDuration,
   formatTime,
   formatYear,
+  formatIso8601Date,
 } from './format-date';
 import timezoneMock from 'timezone-mock';
 
@@ -82,6 +83,18 @@ describe('formatDuration', () => {
     '$seconds seconds is formatted as $formattedDuration',
     ({ seconds, formattedDuration }) => {
       expect(formatDuration(seconds)).toStrictEqual(formattedDuration);
+    }
+  );
+});
+
+describe('formatIso8601Date', () => {
+  test.each([
+    { date: new Date('1 February 2003'), formattedDate: '2003-02-01' },
+    { date: new Date('17 December 2021'), formattedDate: '2021-12-17' },
+  ])(
+    '$date seconds is formatted as $formattedDate',
+    ({ date, formattedDate }) => {
+      expect(formatIso8601Date(date)).toStrictEqual(formattedDate);
     }
   );
 });

--- a/common/utils/format-date.ts
+++ b/common/utils/format-date.ts
@@ -1,4 +1,7 @@
-function formatLondon(date: Date, options: Intl.DateTimeFormatOptions): string {
+export function formatLondon(
+  date: Date,
+  options: Intl.DateTimeFormatOptions
+): string {
   return date.toLocaleString('en-GB', {
     ...options,
     timeZone: 'Europe/London',

--- a/common/utils/format-date.ts
+++ b/common/utils/format-date.ts
@@ -71,9 +71,22 @@ export function formatDuration(seconds: number): string {
     `${hours ** secondsPerHour + minutes * secondsPerMinute} != ${seconds}`
   );
 
-  const HH = String(hours).padStart(2, '0');
-  const MM = String(minutes).padStart(2, '0');
-  const SS = String(remainingSeconds).padStart(2, '0');
+  const HH = hours.toString().padStart(2, '0');
+  const MM = minutes.toString().padStart(2, '0');
+  const SS = remainingSeconds.toString().padStart(2, '0');
 
   return `${HH}:${MM}:${SS}`;
+}
+
+/** Formats a date as an ISO-8601 date, e.g. '1 February 2003' is '2003-02-01' */
+export function formatIso8601Date(date: Date): string {
+  const year = formatLondon(date, { year: 'numeric' });
+  const month = formatLondon(date, { month: 'numeric' })
+    .toString()
+    .padStart(2, '0');
+  const day = formatLondon(date, { day: 'numeric' })
+    .toString()
+    .padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
 }

--- a/common/utils/format-date.ts
+++ b/common/utils/format-date.ts
@@ -41,7 +41,7 @@ export function formatDate(date: Date): string {
 /** Formats a date as the HH:MM time, using a 24-hour clock, e.g. '09:00' or '13:30' */
 export function formatTime(date: Date): string {
   const hours = formatLondon(date, { hour: '2-digit', hourCycle: 'h23' });
-  const minutes = formatLondon(date, { minute: '2-digit' });
+  const minutes = formatLondon(date, { minute: '2-digit' }).padStart(2, '0');
 
   return `${hours}:${minutes}`;
 }
@@ -84,8 +84,12 @@ export function formatDuration(seconds: number): string {
 /** Formats a date as an ISO-8601 date, e.g. '1 February 2003' is '2003-02-01' */
 export function formatIso8601Date(date: Date): string {
   const year = formatLondon(date, { year: 'numeric' });
-  const month = formatLondon(date, { month: '2-digit' });
-  const day = formatLondon(date, { day: '2-digit' });
+  const month = formatLondon(date, { month: 'numeric' })
+    .toString()
+    .padStart(2, '0');
+  const day = formatLondon(date, { day: 'numeric' })
+    .toString()
+    .padStart(2, '0');
 
   return `${year}-${month}-${day}`;
 }

--- a/common/utils/format-date.ts
+++ b/common/utils/format-date.ts
@@ -41,7 +41,7 @@ export function formatDate(date: Date): string {
 /** Formats a date as the HH:MM time, using a 24-hour clock, e.g. '09:00' or '13:30' */
 export function formatTime(date: Date): string {
   const hours = formatLondon(date, { hour: '2-digit', hourCycle: 'h23' });
-  const minutes = formatLondon(date, { minute: '2-digit' }).padStart(2, '0');
+  const minutes = formatLondon(date, { minute: '2-digit' });
 
   return `${hours}:${minutes}`;
 }
@@ -84,12 +84,8 @@ export function formatDuration(seconds: number): string {
 /** Formats a date as an ISO-8601 date, e.g. '1 February 2003' is '2003-02-01' */
 export function formatIso8601Date(date: Date): string {
   const year = formatLondon(date, { year: 'numeric' });
-  const month = formatLondon(date, { month: 'numeric' })
-    .toString()
-    .padStart(2, '0');
-  const day = formatLondon(date, { day: 'numeric' })
-    .toString()
-    .padStart(2, '0');
+  const month = formatLondon(date, { month: '2-digit' });
+  const day = formatLondon(date, { day: '2-digit' });
 
   return `${year}-${month}-${day}`;
 }

--- a/content/webapp/services/prismic/fetch/events.ts
+++ b/content/webapp/services/prismic/fetch/events.ts
@@ -9,7 +9,7 @@ import {
   teamFetchLinks,
 } from '../types/events';
 import { Query } from '@prismicio/types';
-import { getPeriodPredicates } from '../types/predicates';
+import { getEventPredicates } from '../types/predicates';
 import * as prismic from '@prismicio/client';
 import { EventBasic } from '../../../types/events';
 import {
@@ -159,7 +159,7 @@ export const fetchEvents = (
       : [];
 
   const dateRangePredicates = period
-    ? getPeriodPredicates({ period, startField, endField })
+    ? getEventPredicates({ period, startField, endField })
     : [];
 
   // NOTE: Ideally we'd use the Prismic DSL to construct these predicates rather

--- a/content/webapp/services/prismic/fetch/exhibitions.ts
+++ b/content/webapp/services/prismic/fetch/exhibitions.ts
@@ -12,7 +12,7 @@ import {
   exhibitionResourcesFields,
 } from '../fetch-links';
 import { Period } from '../../../types/periods';
-import { getPeriodPredicates } from '../types/predicates';
+import { getExhibitionPeriodPredicates } from '../types/predicates';
 import {
   Exhibition,
   ExhibitionRelatedContent,
@@ -106,7 +106,7 @@ export const fetchExhibitions = (
   ];
 
   const periodPredicates = period
-    ? getPeriodPredicates({ period, startField, endField })
+    ? getExhibitionPeriodPredicates({ period, startField, endField })
     : [];
 
   return exhibitionsFetcher.getByType(client, {

--- a/content/webapp/services/prismic/types/predicates.test.ts
+++ b/content/webapp/services/prismic/types/predicates.test.ts
@@ -1,4 +1,8 @@
-import { getPeriodPredicates } from './predicates';
+import { Period } from '@weco/content/types/periods';
+import {
+  getExhibitionPeriodPredicates,
+  getEventPredicates,
+} from './predicates';
 import * as dateUtils from '@weco/common/utils/dates';
 
 describe('getPeriodPredicates', () => {
@@ -6,7 +10,7 @@ describe('getPeriodPredicates', () => {
     const spyOnToday = jest.spyOn(dateUtils, 'today');
     spyOnToday.mockImplementation(() => new Date('2022-09-19T00:00:00Z'));
 
-    const result = getPeriodPredicates({
+    const result = getEventPredicates({
       period: 'current-and-coming-up',
       startField: 'example.events.startDateTime',
       endField: 'example.events.endDateTime',
@@ -21,7 +25,7 @@ describe('getPeriodPredicates', () => {
     const spyOnToday = jest.spyOn(dateUtils, 'today');
     spyOnToday.mockImplementation(() => new Date('2022-09-19T00:00:00Z'));
 
-    const result = getPeriodPredicates({
+    const result = getEventPredicates({
       period: 'past',
       startField: 'example.events.startDateTime',
       endField: 'example.events.endDateTime',
@@ -31,4 +35,69 @@ describe('getPeriodPredicates', () => {
       '[date.before(example.events.endDateTime, 1663545600000)]',
     ]);
   });
+});
+
+describe('getExhibitionPeriodPredicates', () => {
+  test.each([
+    {
+      period: 'current-and-coming-up',
+      expectedPredicates: [
+        '[date.after(example.exhibitions.endDateTime, "2023-04-23")]',
+      ],
+    },
+    {
+      period: 'past',
+      expectedPredicates: [
+        '[date.before(example.exhibitions.endDateTime, "2023-04-24")]',
+      ],
+    },
+    {
+      period: 'coming-up',
+      expectedPredicates: [
+        '[date.after(example.exhibitions.startDateTime, "2023-04-24")]',
+      ],
+    },
+    {
+      period: 'today',
+      expectedPredicates: [
+        '[date.before(example.exhibitions.startDateTime, "2023-04-25")]',
+        '[date.after(example.exhibitions.endDateTime, "2023-04-23")]',
+      ],
+    },
+    {
+      period: 'this-weekend',
+      expectedPredicates: [
+        '[date.before(example.exhibitions.startDateTime, "2023-05-01")]',
+        '[date.after(example.exhibitions.endDateTime, "2023-04-27")]',
+      ],
+    },
+    {
+      period: 'this-week',
+      expectedPredicates: [
+        '[date.before(example.exhibitions.startDateTime, "2023-04-30")]',
+        '[date.after(example.exhibitions.endDateTime, "2023-04-22")]',
+      ],
+    },
+    {
+      period: 'next-seven-days',
+      expectedPredicates: [
+        '[date.before(example.exhibitions.startDateTime, "2023-05-01")]',
+        '[date.after(example.exhibitions.endDateTime, "2023-04-23")]',
+      ],
+    },
+  ])(
+    'the exhibition period predicate for `$period` is $expectedPredicates',
+    ({ period, expectedPredicates }) => {
+      const spyOnToday = jest.spyOn(dateUtils, 'today');
+      spyOnToday.mockImplementation(() => new Date('2023-04-24T12:00:00Z'));
+
+      const result = getExhibitionPeriodPredicates({
+        period: period as Period,
+        startField: 'example.exhibitions.startDateTime',
+        endField: 'example.exhibitions.endDateTime',
+      });
+
+      expect(result).toStrictEqual(expectedPredicates);
+    }
+  );
 });

--- a/content/webapp/services/prismic/types/predicates.ts
+++ b/content/webapp/services/prismic/types/predicates.ts
@@ -9,9 +9,10 @@ import {
   today,
 } from '@weco/common/utils/dates';
 import { Period } from '../../../types/periods';
+import { formatIso8601Date } from '@weco/common/utils/format-date';
 
 type Props = { period?: Period; startField: string; endField: string };
-export const getPeriodPredicates = ({
+export const getEventPredicates = ({
   period,
   startField,
   endField,
@@ -63,6 +64,91 @@ export const getPeriodPredicates = ({
       : [];
 
   return predicates;
+};
+
+export const getExhibitionPeriodPredicates = ({
+  period,
+  startField,
+  endField,
+}: Props): string[] => {
+  // This function relies heavily on Prismic's date predicates, which are
+  // described in the API documentation here:
+  // https://prismic.io/docs/rest-api-technical-reference#date-predicates
+  //
+  // Note in particular this line:
+  //
+  //      The "after" and "before" predicates will not include a date or time
+  //      equal to the given value.
+  //
+
+  const now = today();
+
+  const yesterday = addDays(today(), -1);
+  const tomorrow = addDays(today(), 1);
+
+  const weekendDateRange = getNextWeekendDateRange(now);
+
+  switch (period) {
+    case 'current-and-coming-up':
+      // yesterday < endDate and yesterday != endDate
+      return [predicate.dateAfter(endField, formatIso8601Date(yesterday))];
+
+    case 'past':
+      // endDate < today and endDate != today
+      return [predicate.dateBefore(endField, formatIso8601Date(today()))];
+
+    case 'coming-up':
+      // today < startDate and today != startDate
+      return [predicate.dateAfter(startField, formatIso8601Date(today()))];
+
+    case 'today':
+      return [
+        // startDate < tomorrow and startDate != tomorrow
+        predicate.dateBefore(startField, formatIso8601Date(tomorrow)),
+
+        // yesterday < endDate and yesterday != endDate
+        predicate.dateAfter(endField, formatIso8601Date(yesterday)),
+      ];
+
+    case 'this-weekend':
+      return [
+        predicate.dateBefore(
+          startField,
+          formatIso8601Date(addDays(weekendDateRange.end, 1))
+        ),
+        predicate.dateAfter(
+          endField,
+          formatIso8601Date(addDays(weekendDateRange.start, -1))
+        ),
+      ];
+
+    case 'this-week':
+      return [
+        predicate.dateBefore(
+          startField,
+          formatIso8601Date(addDays(endOfWeek(now), 1))
+        ),
+        predicate.dateAfter(
+          endField,
+          formatIso8601Date(addDays(startOfWeek(now), -1))
+        ),
+      ];
+
+    case 'next-seven-days':
+      return [
+        predicate.dateBefore(
+          startField,
+          formatIso8601Date(addDays(today(), 7))
+        ),
+        predicate.dateAfter(endField, formatIso8601Date(yesterday)),
+      ];
+
+    // This branch should be unreachable by the types on Period, but we include
+    // it for safety and so that TypeScript is happy with the return type.
+    default:
+      console.warn(`Got unrecognised period: ${period}`);
+      return [];
+  }
 };
 
 export const isOnlinePredicate = predicate.at('my.events.isOnline', 'true');


### PR DESCRIPTION
Tentatively fixes https://github.com/wellcomecollection/wellcomecollection.org/issues/9666

I went digging on this, and I realised (1) why the bug had occurred and (2) why we've only just noticed it.

The problem is how we're querying data from Prismic. In particular, we have a function `getPeriodPredicates` which constructs a filter in the Prismic DSL for the requested period of time. For example, if you wanted to find all exhibitions that have happened in the past, you'd do something like:

```
> getPeriodPredicates('past')
'[date.before(example.exhibitions.endDateTime, "2023-04-24")]'
```

We've been using this function for both events and exhibitions, and this was a mistake. The two types behave slightly differently, and we want to query them accordingly – in particular when using the `current-and-upcoming` predicate.

* Events have an exact date and time, and as soon as the event finishes we want to move it out of "current and coming up".
* Exhibitions only have a date, and their end date is tagged as midnight on the morning of their final day, e.g. OIS ended on Sunday, so it was tagged as `Sunday 23-04-2023 00:00:00`. We want to leave the exhibition in "current and coming up" until the end of the day.

Here's an illustration to show what I mean:

<img width="874" alt="Screenshot 2023-04-24 at 12 40 12" src="https://user-images.githubusercontent.com/301220/233985896-f4d30f02-799d-42a6-846a-f5f17e2b6cf8.png">

For a long time, this function used the behaviour required by exhibitions, meaning events would stay on the "current and coming up" page until the end of the day.

This broke in November, when we had a multi-part event (a festival). When there are multi-part events, we work out when the next part of the event is occurring, and display that on the event card. Because we were trying to render an event card for an event that it already finished, the site crashed and we had a multi-hour outage. We change the behaviour in #8894, so now events disappear from the What's On page as soon as they're done…

…and so do exhibitions. But we've only closed two exhibitions since we merged that patch, and we didn't catch the fact that it would affect exhibitions also. This is why we've only just caught the bug – the Editorial team haven't changed the way events are modelled in Prismic, but our query behaviour changed.

This patch splits the function, so now we have `getEventPeriodPredicates` and `getExhibitionPeriodPredicates`. They behave in slightly different ways, to accommodate the different types. I've also added tests for the latter, and checked the Prismic documentation quite carefully – these predicates are tricky!

To check this works correctly, I changed the site's clock while running locally and checked it at various times:

<table>
<tr><td>Sunday 10th September – last day of Milk<br/>Milk still on What’s On page</td><td>Monday 11th September – day after Milk closes<br/>Milk no longer on What’s On page</td>
</tr>
<tr><td>
<img width="1275" alt="Screenshot 2023-04-24 at 12 24 09" src="https://user-images.githubusercontent.com/301220/233986788-e8ed5b3e-a54b-4c11-bd64-6dc4d417b731.png">
</td><td><img width="1275" alt="Screenshot 2023-04-24 at 12 24 18" src="https://user-images.githubusercontent.com/301220/233986763-9281f555-f370-42ad-a5e5-b2439933214e.png">
</td></tr></table>

<table>
<tr><td>Sunday 23rd April – last day of TAoaU<br/> TAoaU still on What’s On page</td><td>Monday 24th April closes<br/> TAoaU no longer on What’s On page</td>
</tr>
<tr><td>
<img width="1275" alt="Screenshot 2023-04-24 at 12 23 12" src="https://user-images.githubusercontent.com/301220/233986737-78abdfca-f4ed-44a9-a86e-638eeb50534f.png">

</td><td><img width="1275" alt="Screenshot 2023-04-24 at 11 10 51" src="https://user-images.githubusercontent.com/301220/233986746-66149374-5254-4bb4-992c-06e291d4cc51.png">

</td></tr></table>



## Other changes

Because the Prismic exhibition predicates are all at day-level granularity, I changed them to use YYYY-MM-DD style dates. This is supported by Prismic and way easier to debug.

I also had to change the `startOfDay()` and `endOfDay()` functions to be London-specific rather than UTC, which was causing an off-by-one error in the hours. These functions are properly tested now as well.