### PR TITLE
Use London time for startOf/endOfDay, not UTC

### DIFF
--- a/common/utils/dates.test.ts
+++ b/common/utils/dates.test.ts
@@ -12,7 +12,11 @@ import {
   minDate,
   maxDate,
   startOfWeek,
+  startOfDay,
+  endOfDay,
+  getLondonTimezone,
 } from './dates';
+import { formatDayDate } from './format-date';
 
 it('identifies dates in the past', () => {
   expect(isPast(new Date(2001, 1, 1, 1, 1, 1, 999))).toEqual(true);
@@ -257,8 +261,8 @@ describe('getNextWeekendDateRange', () => {
   ])('the next weekend after $day is $weekend', ({ day, weekend }) => {
     const range = getNextWeekendDateRange(day);
 
-    expect(isSameDay(range.start, weekend.start)).toBeTruthy();
-    expect(isSameDay(range.end, weekend.end)).toBeTruthy();
+    expect(isSameDay(range.start, weekend.start, 'London')).toBeTruthy();
+    expect(isSameDay(range.end, weekend.end, 'London')).toBeTruthy();
   });
 });
 
@@ -339,6 +343,69 @@ describe('minDate and maxDate', () => {
     `the max date from ${combinations} is ${date1}`,
     ({ dates }) => {
       expect(maxDate(dates)).toBe(date3);
+    }
+  );
+});
+
+describe('getLondonTimezone', () => {
+  test.each([
+    { d: new Date('2023-04-24'), tz: 'BST' },
+    { d: new Date('2023-11-24'), tz: 'GMT' },
+  ])(`in $d London is in $tz`, ({ d, tz }) => {
+    expect(getLondonTimezone(d)).toBe(tz);
+  });
+});
+
+describe('startOfDay and endOfDay', () => {
+  const combinations = [
+    // during British Summer Time, when London is offset from UTC
+    {
+      d: new Date('2023-04-24'),
+      startDate: new Date('2023-04-23T23:00:00.000Z'),
+      endDate: new Date('2023-04-24T22:59:59.999Z'),
+    },
+    {
+      d: new Date('2023-04-23T23:10:00Z'),
+      startDate: new Date('2023-04-23T23:00:00.000Z'),
+      endDate: new Date('2023-04-24T22:59:59.999Z'),
+    },
+    {
+      d: new Date('2023-04-24T22:40:00Z'),
+      startDate: new Date('2023-04-23T23:00:00.000Z'),
+      endDate: new Date('2023-04-24T22:59:59.999Z'),
+    },
+    // during British Winter Time, London is on UTC
+    {
+      d: new Date('2023-11-24'),
+      startDate: new Date('2023-11-24T00:00:00.000Z'),
+      endDate: new Date('2023-11-24T23:59:59.999Z'),
+    },
+  ];
+
+  test.each(combinations)(
+    'the start of $d is $startDate',
+    ({ d, startDate }) => {
+      expect(startOfDay(d)).toStrictEqual(startDate);
+    }
+  );
+
+  test.each(combinations)('the end of $d is $endDate', ({ d, endDate }) => {
+    expect(endOfDay(d)).toStrictEqual(endDate);
+  });
+
+  test.each(combinations)(
+    'the start/end of $d is the same day as d',
+    ({ d }) => {
+      expect(formatDayDate(d)).toBe(formatDayDate(startOfDay(d)));
+      expect(formatDayDate(d)).toBe(formatDayDate(endOfDay(d)));
+    }
+  );
+
+  test.each(combinations)(
+    'the start/end date functions are idempotent on $d',
+    ({ d }) => {
+      expect(startOfDay(startOfDay(d))).toStrictEqual(startOfDay(d));
+      expect(endOfDay(endOfDay(d))).toStrictEqual(endOfDay(d));
     }
   );
 });

--- a/common/utils/dates.ts
+++ b/common/utils/dates.ts
@@ -88,16 +88,58 @@ export function isDayPast(date: Date): boolean {
   }
 }
 
-// TODO: Does setting these to UTC 00:00:00 cause issues in London?
+type LondonTZ = 'GMT' | 'BST';
+
+/** Returns true if London is currently in BST (one-hour offset from UTC),
+ * false if it's in UTC.
+ */
+export function getLondonTimezone(d: Date): LondonTZ {
+  const s = d.toLocaleString('en-GB', {
+    hour: '2-digit',
+    timeZoneName: 'short',
+    timeZone: 'Europe/London',
+  });
+
+  if (s.endsWith(' BST')) {
+    return 'BST';
+  } else if (s.endsWith(' GMT')) {
+    return 'GMT';
+  } else {
+    throw new Error(`Unrecognised London timezone in ${s}`);
+  }
+}
+
+/** Returns the start of the day (midnight) in London. */
 export function startOfDay(d: Date): Date {
   const res = new Date(d);
-  res.setUTCHours(0, 0, 0, 0);
+
+  if (getLondonTimezone(d) === 'BST') {
+    if (res.getUTCHours() >= 23) {
+      res.setUTCHours(23, 0, 0, 0);
+    } else {
+      res.setUTCHours(-1, 0, 0, 0);
+    }
+  } else {
+    res.setUTCHours(0, 0, 0, 0);
+  }
+
   return res;
 }
 
+/** Returns the end of the day (a second before midnight) in London. */
 export function endOfDay(d: Date): Date {
   const res = new Date(d);
-  res.setUTCHours(23, 59, 59, 999);
+
+  if (getLondonTimezone(d) === 'BST') {
+    if (res.getUTCHours() >= 23) {
+      res.setDate(res.getDate() + 1);
+    }
+
+    res.setUTCHours(22, 59, 59, 999);
+  } else {
+    res.setUTCHours(23, 59, 59, 999);
+  }
+
   return res;
 }
 

--- a/content/webapp/services/prismic/events.test.ts
+++ b/content/webapp/services/prismic/events.test.ts
@@ -213,8 +213,8 @@ describe('groupEventsByDay', () => {
     expect(result).toStrictEqual([
       {
         label: 'Saturday 6 April 2019',
-        start: new Date('2019-04-06T00:00:00.000Z'),
-        end: new Date('2019-04-06T23:59:59.999Z'),
+        start: new Date('2019-04-05T23:00:00.000Z'),
+        end: new Date('2019-04-06T22:59:59.999Z'),
         events: [
           {
             id: 'XH6TQBAAAA0FGlrx',
@@ -246,8 +246,8 @@ describe('groupEventsByDay', () => {
       },
       {
         label: 'Sunday 7 April 2019',
-        start: new Date('2019-04-07T00:00:00.000Z'),
-        end: new Date('2019-04-07T23:59:59.999Z'),
+        start: new Date('2019-04-06T23:00:00.000Z'),
+        end: new Date('2019-04-07T22:59:59.999Z'),
         events: [
           {
             id: 'XHZeuhAAAHJe9sPp',
@@ -276,12 +276,6 @@ describe('groupEventsByDay', () => {
             ],
           },
         ],
-      },
-      {
-        label: 'Monday 8 April 2019',
-        start: new Date('2019-04-08T00:00:00.000Z'),
-        end: new Date('2019-04-08T23:59:59.999Z'),
-        events: [],
       },
     ]);
   });


### PR DESCRIPTION
Another piece spun out of #9666; follows #9669.

In most of the app, all of our datetime logic works in London time, not in UTC. These functions have been the exception for a while, and it manifests in strange ways – for example, that Monday with no events in the `groupEventsByDay` test. This should make it consistent with our other logic.