### PR TITLE
Add some tests for isSameDay => false in London time

### DIFF
--- a/common/utils/dates.test.ts
+++ b/common/utils/dates.test.ts
@@ -104,6 +104,26 @@ describe('isSameDay', () => {
     const result = isSameDay(a, b);
     expect(result).toEqual(false);
   });
+
+  each([
+    // same day of the week as returned by Date.getDay()
+    [new Date(2001, 2, 3, 1, 1, 1), new Date(2001, 2, 10, 1, 1, 1)],
+
+    // same year/month, different day
+    [new Date(2001, 2, 3, 1, 1, 1), new Date(2001, 2, 10, 1, 1, 1)],
+
+    // same year/day, different month
+    [new Date(2001, 2, 3, 1, 1, 1), new Date(2001, 10, 3, 1, 1, 1)],
+
+    // same month/day, different year
+    [new Date(2001, 2, 3, 1, 1, 1), new Date(2022, 2, 3, 1, 1, 1)],
+
+    // completely different days
+    [new Date(2001, 2, 3, 1, 1, 1), new Date(2022, 5, 7, 19, 11, 13)],
+  ]).test('identifies %s and %s as different (London time)', (a, b) => {
+    const result = isSameDay(a, b, 'London');
+    expect(result).toEqual(false);
+  });
 });
 
 describe('isSameDayOrBefore', () => {


### PR DESCRIPTION
This is copy-pasted from the tests for isSameDay with a UTC comparison, so pass unmodified.

(I was reading the implementation of isSameDay for London and briefly got confused and thought it had a bug; it doesn't, but we should be covering these test cases anyway.)