### PR TITLE
Require an explicit comparison mode in isSameDay()

### DIFF
--- a/common/services/prismic/opening-times.ts
+++ b/common/services/prismic/opening-times.ts
@@ -55,7 +55,7 @@ export function getOverrideDatesForAllVenues(venues: Venue[]): OverrideDate[] {
     .sort((a, b) => Number(a.overrideDate) - Number(b.overrideDate))
     .reduce((result: OverrideDate[], thisOverride: OverrideDate) => {
       const isAlreadyInResult = result.some(t =>
-        isSameDay(t.overrideDate, thisOverride.overrideDate)
+        isSameDay(t.overrideDate, thisOverride.overrideDate, 'UTC')
       );
 
       if (!isAlreadyInResult) {
@@ -255,10 +255,10 @@ export function createExceptionalOpeningHoursDays(
     const days = sortedDates
       .map(date => {
         const matchingVenueGroup = groupedExceptionalDays.find(group =>
-          group.find(day => isSameDay(day.overrideDate, date))
+          group.find(day => isSameDay(day.overrideDate, date, 'UTC'))
         );
         const matchingDay = matchingVenueGroup?.find(day =>
-          isSameDay(day.overrideDate, date)
+          isSameDay(day.overrideDate, date, 'UTC')
         );
         const backfillDay = exceptionalFromRegular(venue, date, type);
         return matchingDay || backfillDay;
@@ -279,7 +279,7 @@ export function groupConsecutiveExceptionalDays(
 
       if (
         lastDayOfGroup &&
-        isSameDay(addDays(date.overrideDate, -1), lastDayOfGroup)
+        isSameDay(addDays(date.overrideDate, -1), lastDayOfGroup, 'UTC')
       ) {
         group.push(date);
       } else {

--- a/common/utils/dates.ts
+++ b/common/utils/dates.ts
@@ -47,7 +47,7 @@ type ComparisonMode = 'UTC' | 'London';
 export function isSameDay(
   date1: Date,
   date2: Date,
-  mode: ComparisonMode = 'UTC'
+  mode: ComparisonMode
 ): boolean {
   if (mode === 'UTC') {
     return (
@@ -81,7 +81,7 @@ export function isSameDayOrBefore(date1: Date, date2: Date): boolean {
 // Returns true if 'date' falls on a past day; false otherwise.
 export function isDayPast(date: Date): boolean {
   const now = new Date();
-  if (isSameDay(date, now) || date > now) {
+  if (isSameDay(date, now, 'UTC') || date > now) {
     return false;
   } else {
     return true;

--- a/content/webapp/services/prismic/transformers/events.ts
+++ b/content/webapp/services/prismic/transformers/events.ts
@@ -452,7 +452,8 @@ export function transformEventBasicTimes(
   const everyDayHasSomething = daysInScheduleRange.every(d =>
     scheduleTimes.some(
       s =>
-        isSameDay(d, s.range.startDateTime) || isSameDay(d, s.range.endDateTime)
+        isSameDay(d, s.range.startDateTime, 'UTC') ||
+        isSameDay(d, s.range.endDateTime, 'UTC')
     )
   );
 

--- a/content/webapp/utils/event-series.ts
+++ b/content/webapp/utils/event-series.ts
@@ -41,7 +41,7 @@ function isUpcoming<T extends HasTimes>(event: T): boolean {
   );
   const latestEndTime = maxDate(event.times.map(t => t.range.endDateTime));
 
-  const isMultiDayEvent = !isSameDay(earliestStartTime, latestEndTime);
+  const isMultiDayEvent = !isSameDay(earliestStartTime, latestEndTime, 'UTC');
   const isUnfinished = latestEndTime > new Date();
   const endsOnAFutureDay = isMultiDayEvent && isUnfinished;
 


### PR DESCRIPTION
This removes the default comparison mode from isSameDay.  I've updated all the calls that were relying on the default, so this doesn't change any behaviour, but it makes it easier to see where we're still using a UTC comparison of "same day".

I think eventually we should be doing London comparisons everywhere, but I'm not touching that right now – this is just making it more visible where we aren't using London-based logic.

Another bit of cleanup following https://github.com/wellcomecollection/wellcomecollection.org/issues/9666