### PR TITLE
Lower threshold and add it to PageHeader Article

### DIFF
--- a/cardigan/stories/components/BookPromo/BookPromo.stories.tsx
+++ b/cardigan/stories/components/BookPromo/BookPromo.stories.tsx
@@ -19,5 +19,5 @@ basic.args = {
 basic.storyName = 'BookPromo';
 basic.parameters = {
   gridSizes: { s: 12, m: 6, l: 4, xl: 4 },
-  diffThreshold: 0.2,
+  diffThreshold: 0.1,
 };

--- a/cardigan/stories/components/Cards/Cards.stories.tsx
+++ b/cardigan/stories/components/Cards/Cards.stories.tsx
@@ -39,7 +39,7 @@ compactCard.storyName = 'CompactCard';
 compactCard.parameters = {
   gridSizes: { s: 12, m: 10, l: 8, xl: 8 },
   // Sets a delay for the component's stories
-  chromatic: { diffThreshold: 0.2 },
+  chromatic: { diffThreshold: 0.1 },
 };
 
 const BannerCardTemplate = args => <BannerCard {...args} />;
@@ -50,7 +50,7 @@ bannerCard.args = {
 bannerCard.storyName = 'BannerCard';
 bannerCard.parameters = {
   // Sets a delay for the component's stories
-  chromatic: { diffThreshold: 0.2 },
+  chromatic: { diffThreshold: 0.1 },
 };
 
 const FeaturedCardTemplate = args => {
@@ -88,7 +88,7 @@ featuredCard.args = {
 featuredCard.storyName = 'FeaturedCard';
 featuredCard.parameters = {
   // Sets a delay for the component's stories
-  chromatic: { diffThreshold: 0.2 },
+  chromatic: { diffThreshold: 0.1 },
 };
 
 const EventPromoTemplate = args => <EventPromo {...args} />;
@@ -100,7 +100,7 @@ eventPromo.args = {
 eventPromo.parameters = {
   gridSizes: { s: 12, m: 6, l: 4, xl: 4 },
   // Sets a delay for the component's stories
-  chromatic: { diffThreshold: 0.2 },
+  chromatic: { diffThreshold: 0.1 },
 };
 eventPromo.storyName = 'EventPromo';
 
@@ -110,7 +110,7 @@ exhibitionPromo.args = { exhibition: exhibitionBasic };
 exhibitionPromo.parameters = {
   gridSizes: { s: 12, m: 6, l: 4, xl: 4 },
   // Sets a delay for the component's stories
-  chromatic: { diffThreshold: 0.2 },
+  chromatic: { diffThreshold: 0.1 },
 };
 exhibitionPromo.storyName = 'ExhibitionPromo';
 
@@ -123,6 +123,6 @@ storyPromo.args = {
 storyPromo.parameters = {
   gridSizes: { s: 12, m: 6, l: 4, xl: 4 },
   // Sets a delay for the component's stories
-  chromatic: { diffThreshold: 0.2 },
+  chromatic: { diffThreshold: 0.1 },
 };
 storyPromo.storyName = 'StoryPromo';

--- a/cardigan/stories/components/PageHeader/PageHeader.stories.tsx
+++ b/cardigan/stories/components/PageHeader/PageHeader.stories.tsx
@@ -230,6 +230,9 @@ article.args = {
   ContentTypeInfo,
   isContentTypeInfoBeforeMedia: true,
 };
+article.parameters = {
+  diffThreshold: 0.1,
+};
 
 const ContentPageTemplate = args => (
   <ReadmeDecorator


### PR DESCRIPTION
## Who is this for?
Chromatic

## What is it doing for them?
Lowers the difference threshold to `0.1` as Chromatic support said it seemed sufficient based on their tests.
Adding it to PageHeader: Article as it's come up often as being different.

Our decided strategy for now is to apply that threshold (basic one being at `0.063`) when similar "differences" come up. Only happens on images that never change, so I believe it's still a Chromatic issue but could also have to do with the way we compress images.

If the lowering of it makes them detect a difference again, we can bring it back to `0.2` as that still detected 4px wide differences, which already has more value.