### PR TITLE
Clear cachedSteps after an a/v complete event

### DIFF
--- a/common/hooks/useAVTracking.ts
+++ b/common/hooks/useAVTracking.ts
@@ -37,8 +37,7 @@ export const useAVTracking = (avType: 'audio' | 'video') => {
   function trackEnded(event: SyntheticEvent<HTMLMediaElement, Event>) {
     gtag('event', `${avType}_complete`, getParams(event));
     setDidStart(false);
-    cachedSteps.clear();
-    setCachedSteps(cachedSteps);
+    setCachedSteps(new Set());
   }
 
   function trackTimeUpdate(event: SyntheticEvent<HTMLMediaElement, Event>) {

--- a/common/hooks/useAVTracking.ts
+++ b/common/hooks/useAVTracking.ts
@@ -37,6 +37,8 @@ export const useAVTracking = (avType: 'audio' | 'video') => {
   function trackEnded(event: SyntheticEvent<HTMLMediaElement, Event>) {
     gtag('event', `${avType}_complete`, getParams(event));
     setDidStart(false);
+    cachedSteps.clear();
+    setCachedSteps(cachedSteps);
   }
 
   function trackTimeUpdate(event: SyntheticEvent<HTMLMediaElement, Event>) {


### PR DESCRIPTION
☝️ 

When the `audio_` and `video_progress` events fire, it adds the percent progressed to a cache and these progress events won't fire again even if you scrub back in the video and pass the same percentage threshold again. But currently we don't reset this cache when you get to the end of a piece of audio or video (and this is out of step with how the built in video events work).

This PR resets the cache when the `complete` event fires.
