### PR TITLE
Make viewer chevrons flush to the right of sidebar

### DIFF
--- a/catalogue/webapp/components/IIIFViewer/ViewerSidebar.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerSidebar.tsx
@@ -57,7 +57,6 @@ const AccordionInner = styled(Space).attrs({
     }
 
     span {
-      width: 100%;
       display: flex;
       justify-content: space-between;
       align-items: center;


### PR DESCRIPTION
Not sure how/when this crept in. Fairly confident it wasn't there two years ago when this line was added.

__Before__
<img width="323" alt="image" src="https://user-images.githubusercontent.com/1394592/234552662-68809845-956a-4eed-b693-f84270f8c5d2.png">

__After__
<img width="325" alt="image" src="https://user-images.githubusercontent.com/1394592/234552478-11295452-d125-430c-b246-e0e2f8910fc4.png">
