### PR TITLE
Tidy up the Download component; add a ConceptLink component; consolidate Segment values

### DIFF
--- a/catalogue/webapp/components/ConceptLink/index.tsx
+++ b/catalogue/webapp/components/ConceptLink/index.tsx
@@ -1,0 +1,39 @@
+import NextLink from 'next/link';
+import { FunctionComponent } from 'react';
+import { LinkFrom } from '@weco/common/utils/routes';
+import { LinkProps } from '@weco/common/model/link-props';
+import { ConceptLinkSource } from '@weco/common/data/segment-values';
+
+type ConceptLinkProps = { conceptId: string };
+
+function toLink(props: ConceptLinkProps, source: ConceptLinkSource): LinkProps {
+  return {
+    href: {
+      pathname: '/concepts/[conceptId]',
+      query: {
+        conceptId: props.conceptId,
+        source,
+      },
+    },
+    as: {
+      pathname: `/concepts/${props.conceptId}`,
+    },
+  };
+}
+
+type Props = LinkFrom<ConceptLinkProps> & { source: ConceptLinkSource };
+
+const ConceptLink: FunctionComponent<Props> = ({
+  children,
+  source,
+  ...props
+}) => {
+  return (
+    <NextLink {...toLink(props, source)} legacyBehavior>
+      {children}
+    </NextLink>
+  );
+};
+
+export default ConceptLink;
+export { toLink };

--- a/catalogue/webapp/components/ImageLink/index.tsx
+++ b/catalogue/webapp/components/ImageLink/index.tsx
@@ -10,9 +10,7 @@ import {
   stringCodec,
 } from '@weco/common/utils/routes';
 import { LinkProps } from '@weco/common/model/link-props';
-
-const imagePropsSources = ['images_search_result', 'viewer/paginator'] as const;
-type ImagePropsSource = (typeof imagePropsSources)[number];
+import { ImageLinkSource } from '@weco/common/data/segment-sources';
 
 const emptyImageProps: ImageProps = {
   id: '',
@@ -38,7 +36,7 @@ const toQuery: (props: ImageProps) => ParsedUrlQuery = props => {
 
 function toLink(
   partialProps: Partial<ImageProps>,
-  source: ImagePropsSource
+  source: ImageLinkSource
 ): LinkProps {
   const props: ImageProps = {
     ...emptyImageProps,
@@ -64,7 +62,7 @@ function toLink(
   };
 }
 
-type Props = LinkFrom<ImageProps> & { source: ImagePropsSource };
+type Props = LinkFrom<ImageProps> & { source: ImageLinkSource };
 
 const ImageLink: FunctionComponent<Props> = ({
   children,

--- a/catalogue/webapp/components/ImageLink/index.tsx
+++ b/catalogue/webapp/components/ImageLink/index.tsx
@@ -10,7 +10,7 @@ import {
   stringCodec,
 } from '@weco/common/utils/routes';
 import { LinkProps } from '@weco/common/model/link-props';
-import { ImageLinkSource } from '@weco/common/data/segment-sources';
+import { ImageLinkSource } from '@weco/common/data/segment-values';
 
 const emptyImageProps: ImageProps = {
   id: '',
@@ -46,7 +46,7 @@ function toLink(
 
   return {
     href: {
-      pathname: `/works/[workId]/images`,
+      pathname: '/works/[workId]/images',
       query: {
         workId: props.workId,
         ...query,

--- a/catalogue/webapp/components/ImagesLink/index.tsx
+++ b/catalogue/webapp/components/ImagesLink/index.tsx
@@ -13,17 +13,7 @@ import {
   decodeQuery,
   quotedCsvCodec,
 } from '@weco/common/utils/routes';
-
-const imagesPropsSources = [
-  'search/paginator',
-  'canonical_link',
-  'concept/images_about',
-  'concept/images_by',
-  'images_search_context',
-  'work_details/images',
-  'unknown',
-] as const;
-type ImagesPropsSource = (typeof imagesPropsSources)[number];
+import { ImagesLinkSource } from '@weco/common/data/segment-sources';
 
 export type ImagesProps = FromCodecMap<typeof codecMap>;
 
@@ -57,7 +47,7 @@ const toQuery: (props: ImagesProps) => ParsedUrlQuery = props => {
 
 function toLink(
   partialProps: Partial<ImagesProps>,
-  source: ImagesPropsSource
+  source: ImagesLinkSource
 ): LinkProps {
   const pathname = '/search/images';
   const props: ImagesProps = {
@@ -78,7 +68,7 @@ function toLink(
   };
 }
 
-type Props = LinkFrom<ImagesProps> & { source: ImagesPropsSource };
+type Props = LinkFrom<ImagesProps> & { source: ImagesLinkSource };
 const ImagesLink: FunctionComponent<Props> = ({
   children,
   source,

--- a/catalogue/webapp/components/ImagesLink/index.tsx
+++ b/catalogue/webapp/components/ImagesLink/index.tsx
@@ -13,7 +13,7 @@ import {
   decodeQuery,
   quotedCsvCodec,
 } from '@weco/common/utils/routes';
-import { ImagesLinkSource } from '@weco/common/data/segment-sources';
+import { ImagesLinkSource } from '@weco/common/data/segment-values';
 
 export type ImagesProps = FromCodecMap<typeof codecMap>;
 

--- a/catalogue/webapp/components/ItemLink/index.tsx
+++ b/catalogue/webapp/components/ItemLink/index.tsx
@@ -11,7 +11,7 @@ import {
   stringCodec,
 } from '@weco/common/utils/routes';
 import { LinkProps } from '@weco/common/model/link-props';
-import { ItemLinkSource } from '@weco/common/data/segment-sources';
+import { ItemLinkSource } from '@weco/common/data/segment-values';
 
 const emptyItemProps: ItemProps = {
   workId: '',

--- a/catalogue/webapp/components/ItemLink/index.tsx
+++ b/catalogue/webapp/components/ItemLink/index.tsx
@@ -11,15 +11,7 @@ import {
   stringCodec,
 } from '@weco/common/utils/routes';
 import { LinkProps } from '@weco/common/model/link-props';
-
-const itemPropsSources = [
-  'work',
-  'images_search_result',
-  'viewer/paginator',
-  'manifests_navigation',
-  'search_within_result',
-] as const;
-type ItemPropsSource = (typeof itemPropsSources)[number];
+import { ItemLinkSource } from '@weco/common/data/segment-sources';
 
 const emptyItemProps: ItemProps = {
   workId: '',
@@ -53,7 +45,7 @@ const toQuery: (props: ItemProps) => ParsedUrlQuery = props => {
 
 function toLink(
   partialProps: Partial<ItemProps>,
-  source: ItemPropsSource
+  source: ItemLinkSource
 ): LinkProps {
   const props: ItemProps = {
     ...emptyItemProps,
@@ -73,7 +65,7 @@ function toLink(
   };
 }
 
-type Props = LinkFrom<ItemProps> & { source: ItemPropsSource };
+type Props = LinkFrom<ItemProps> & { source: ItemLinkSource };
 
 const ItemLink: FunctionComponent<Props> = ({
   children,

--- a/catalogue/webapp/components/Work/Work.tsx
+++ b/catalogue/webapp/components/Work/Work.tsx
@@ -169,7 +169,7 @@ const Work: FunctionComponent<Props> = ({ work, apiUrl }) => {
       <CataloguePageLayout
         title={title}
         description={work.description || title}
-        url={{ pathname: `/works/${work.id}`, query: {} }}
+        url={{ pathname: `/works/${work.id}` }}
         openGraphType="website"
         jsonLd={workLd(work)}
         siteSection="collections"

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -26,6 +26,7 @@ import AudioList from '../AudioList/AudioList';
 import ButtonSolidLink from '@weco/common/views/components/ButtonSolidLink/ButtonSolidLink';
 import ExplanatoryText from './ExplanatoryText';
 import { toLink as itemLink } from '../ItemLink';
+import { toLink as conceptLink } from '../ConceptLink';
 import { trackGaEvent } from '@weco/common/utils/ga';
 import PhysicalItems from '../PhysicalItems/PhysicalItems';
 import Layout10 from '@weco/common/views/components/Layout10/Layout10';
@@ -588,14 +589,10 @@ const WorkDetails: FunctionComponent<Props> = ({
               return contributor.agent.id
                 ? {
                     textParts,
-                    linkAttributes: {
-                      href: {
-                        pathname: `/concepts/${contributor.agent.id}`,
-                      },
-                      as: {
-                        pathname: `/concepts/${contributor.agent.id}`,
-                      },
-                    },
+                    linkAttributes: conceptLink(
+                      { conceptId: contributor.agent.id },
+                      'work_details/contributors'
+                    ),
                   }
                 : {
                     textParts,
@@ -682,15 +679,10 @@ const WorkDetails: FunctionComponent<Props> = ({
                     textParts: [s.concepts[0].label].concat(
                       s.concepts.slice(1).map(c => c.label)
                     ),
-                    linkAttributes: {
-                      href: {
-                        pathname: '/concept',
-                        query: { id: s.id },
-                      },
-                      as: {
-                        pathname: `/concepts/${s.id}`,
-                      },
-                    },
+                    linkAttributes: conceptLink(
+                      { conceptId: s.id },
+                      'work_details/subjects'
+                    ),
                   }
                 : {
                     textParts: s.concepts.map(c => c.label),

--- a/catalogue/webapp/components/WorkLink/index.tsx
+++ b/catalogue/webapp/components/WorkLink/index.tsx
@@ -1,6 +1,6 @@
 import NextLink, { LinkProps } from 'next/link';
 import { FunctionComponent, PropsWithChildren } from 'react';
-import { WorkLinkSource } from '@weco/common/data/segment-sources';
+import { WorkLinkSource } from '@weco/common/data/segment-values';
 
 // We remove `href` and `as` because we contruct those ourselves
 // in the component.

--- a/catalogue/webapp/components/WorkLink/index.tsx
+++ b/catalogue/webapp/components/WorkLink/index.tsx
@@ -1,14 +1,6 @@
 import NextLink, { LinkProps } from 'next/link';
 import { FunctionComponent, PropsWithChildren } from 'react';
-
-type WorkLinkSource =
-  | 'works_search_result'
-  | 'images_search_result'
-  | 'item_auth_modal_back_to_work_link'
-  | 'archive_tree'
-  | 'viewer_back_link'
-  | 'viewer_credit'
-  | 'download_credit';
+import { WorkLinkSource } from '@weco/common/data/segment-sources';
 
 // We remove `href` and `as` because we contruct those ourselves
 // in the component.

--- a/catalogue/webapp/components/WorkLink/index.tsx
+++ b/catalogue/webapp/components/WorkLink/index.tsx
@@ -7,7 +7,8 @@ type WorkLinkSource =
   | 'item_auth_modal_back_to_work_link'
   | 'archive_tree'
   | 'viewer_back_link'
-  | 'viewer_credit';
+  | 'viewer_credit'
+  | 'download_credit';
 
 // We remove `href` and `as` because we contruct those ourselves
 // in the component.

--- a/catalogue/webapp/components/WorksLink/index.tsx
+++ b/catalogue/webapp/components/WorksLink/index.tsx
@@ -13,7 +13,7 @@ import {
   decodeQuery,
   encodeQuery,
 } from '@weco/common/utils/routes';
-import { WorksLinkSource } from '@weco/common/data/segment-sources';
+import { WorksLinkSource } from '@weco/common/data/segment-values';
 
 const emptyWorksProps: WorksProps = {
   query: '',

--- a/catalogue/webapp/components/WorksLink/index.tsx
+++ b/catalogue/webapp/components/WorksLink/index.tsx
@@ -13,26 +13,7 @@ import {
   decodeQuery,
   encodeQuery,
 } from '@weco/common/utils/routes';
-import { Prefix } from '@weco/common/utils/utility-types';
-
-const worksPropsSources = [
-  'search_form',
-  'canonical_link',
-  'meta_link',
-  'search/paginator',
-  'concept/works_about',
-  'concept/works_by',
-  'works_search_context',
-  'work_details/contributors',
-  'work_details/genres',
-  'work_details/subjects',
-  'work_details/partOf',
-] as const;
-
-type WorksPropsSource =
-  | (typeof worksPropsSources)[number]
-  | Prefix<'cancel_filter/'>
-  | 'unknown';
+import { WorksLinkSource } from '@weco/common/data/segment-sources';
 
 const emptyWorksProps: WorksProps = {
   query: '',
@@ -80,7 +61,7 @@ const toQuery: (props: WorksProps) => ParsedUrlQuery = props => {
 
 function toLink(
   partialProps: Partial<WorksProps>,
-  source: WorksPropsSource
+  source: WorksLinkSource
 ): LinkProps {
   const pathname = '/search/works';
   const props: WorksProps = {
@@ -101,7 +82,7 @@ function toLink(
   };
 }
 
-type Props = LinkFrom<WorksProps> & { source: WorksPropsSource };
+type Props = LinkFrom<WorksProps> & { source: WorksLinkSource };
 const WorksLink: FunctionComponent<Props> = ({
   children,
   source,

--- a/catalogue/webapp/pages/works/[workId]/download.tsx
+++ b/catalogue/webapp/pages/works/[workId]/download.tsx
@@ -25,7 +25,6 @@ import { getServerData } from '@weco/common/server-data';
 import { looksLikeCanonicalId } from '@weco/catalogue/services/wellcome/catalogue';
 import { fetchIIIFPresentationManifest } from '@weco/catalogue/services/iiif/fetch/manifest';
 import { transformManifest } from '@weco/catalogue/services/iiif/transformers/manifest';
-import WorkLink from '@weco/catalogue/components/WorkLink';
 
 type CreditProps = {
   workId: string;
@@ -45,10 +44,7 @@ const Credit: FunctionComponent<CreditProps> = ({
   const linkCredit = credit && (
     <>
       Credit:{' '}
-      <WorkLink id={workId} source="download_credit">
-        {credit}
-      </WorkLink>
-      .
+      <a href={`https://wellcomecollection.org/works/${workId}`}>{credit}</a>.
     </>
   );
 

--- a/common/data/segment-sources.ts
+++ b/common/data/segment-sources.ts
@@ -1,0 +1,43 @@
+import { Prefix } from '@weco/common/utils/utility-types';
+
+export type ImageLinkSource = 'images_search_result' | 'viewer/paginator';
+
+export type ImagesLinkSource =
+  | 'search/paginator'
+  | 'canonical_link'
+  | 'concept/images_about'
+  | 'concept/images_by'
+  | 'images_search_context'
+  | 'work_details/images'
+  | 'unknown';
+
+export type ItemLinkSource =
+  | 'work'
+  | 'images_search_result'
+  | 'viewer/paginator'
+  | 'manifests_navigation'
+  | 'search_within_result';
+
+export type WorkLinkSource =
+  | 'works_search_result'
+  | 'images_search_result'
+  | 'item_auth_modal_back_to_work_link'
+  | 'archive_tree'
+  | 'viewer_back_link'
+  | 'viewer_credit'
+  | 'download_credit';
+
+export type WorksLinkSource =
+  | 'search_form'
+  | 'canonical_link'
+  | 'meta_link'
+  | 'search/paginator'
+  | 'concept/works_about'
+  | 'concept/works_by'
+  | 'works_search_context'
+  | 'work_details/contributors'
+  | 'work_details/genres'
+  | 'work_details/subjects'
+  | 'work_details/partOf'
+  | Prefix<'cancel_filter/'>
+  | 'unknown';

--- a/common/data/segment-values.ts
+++ b/common/data/segment-values.ts
@@ -1,5 +1,30 @@
 import { Prefix } from '@weco/common/utils/utility-types';
 
+// The pageview values are used for monthly/quarterly reporting.
+//
+// This type is an attempt to describe the expectations of those reporting tools;
+// to enforce our "analytics contract" in code.  It isn't set in stone, but it's
+// meant to flag to developers if they make unplanned or unexpected changes --
+// hopefully this will lead to more intentional changes.
+//
+// If you want to change this type, check with our digital analyst (currently Tacey)
+// before you do -- so the change can be coordinated with their reports.
+export type PageviewName =
+  | 'concept'
+  | 'event'
+  | 'exhibition'
+  | 'image'
+  | 'images'
+  | 'item'
+  | 'search'
+  | 'story'
+  | 'work'
+  | 'works';
+
+export type ConceptLinkSource =
+  | 'work_details/contributors'
+  | 'work_details/subjects';
+
 export type ImageLinkSource = 'images_search_result' | 'viewer/paginator';
 
 export type ImagesLinkSource =

--- a/common/data/segment-values.ts
+++ b/common/data/segment-values.ts
@@ -1,14 +1,22 @@
+/** This contains a list of values which are sent to Segment.
+ *
+ * == What it's used for ==
+ *
+ * These are used to analyse behaviour on the site, e.g. we use the 'source'
+ * parameter on links to track where somebody clicked from, so we can see
+ * how many people landed on concept pages from contributors/subjects/genres/etc.
+ *
+ * These types are an attempt to describe the expectations of those reporting tools;
+ * to enforce our "analytics contract" in code.  It isn't set in stone, but it's
+ * meant to flag to developers if they make unplanned or unexpected changes --
+ * hopefully this will lead to fewer unintentional changes.
+ *
+ * If you want to change this type, check with our digital analyst (currently Tacey)
+ * before you do -- so the change can be coordinated with their reports.
+ */
+
 import { Prefix } from '@weco/common/utils/utility-types';
 
-// The pageview values are used for monthly/quarterly reporting.
-//
-// This type is an attempt to describe the expectations of those reporting tools;
-// to enforce our "analytics contract" in code.  It isn't set in stone, but it's
-// meant to flag to developers if they make unplanned or unexpected changes --
-// hopefully this will lead to more intentional changes.
-//
-// If you want to change this type, check with our digital analyst (currently Tacey)
-// before you do -- so the change can be coordinated with their reports.
 export type PageviewName =
   | 'concept'
   | 'event'

--- a/common/data/segment-values.ts
+++ b/common/data/segment-values.ts
@@ -57,8 +57,7 @@ export type WorkLinkSource =
   | 'item_auth_modal_back_to_work_link'
   | 'archive_tree'
   | 'viewer_back_link'
-  | 'viewer_credit'
-  | 'download_credit';
+  | 'viewer_credit';
 
 export type WorksLinkSource =
   | 'search_form'

--- a/common/services/conversion/track.ts
+++ b/common/services/conversion/track.ts
@@ -3,7 +3,7 @@ import cookies from '@weco/common/data/cookies';
 import Router from 'next/router';
 import { ParsedUrlQuery } from 'querystring';
 import { v4 as uuidv4 } from 'uuid';
-import { PageviewName } from 'data/segment-values';
+import { PageviewName } from '@weco/common/data/segment-values';
 declare global {
   interface Window {
     // Segment.io requires `analytics: any;`

--- a/common/services/conversion/track.ts
+++ b/common/services/conversion/track.ts
@@ -3,12 +3,14 @@ import cookies from '@weco/common/data/cookies';
 import Router from 'next/router';
 import { ParsedUrlQuery } from 'querystring';
 import { v4 as uuidv4 } from 'uuid';
+import { PageviewName } from 'data/segment-values';
 declare global {
   interface Window {
     // Segment.io requires `analytics: any;`
     // https://ashokraju.medium.com/using-segment-io-analytics-js-with-single-page-react-typescript-app-a8c12b4816c4
     // eslint-disable-next-line
     analytics: any;
+    // eslint-disable-next-line
     dataLayer: Record<string, any>[] | undefined;
   }
 }
@@ -43,27 +45,8 @@ type EventProps = {
   eventGroup?: EventGroup;
 };
 
-// The pageview values are used for monthly/quarterly reporting.
-//
-// This type is an attempt to describe the expectations of those reporting tools;
-// to enforce our "analytics contract" in code.  It isn't set in stone, but it's
-// meant to flag to developers if they make unplanned or unexpected changes --
-// hopefully this will lead to more intentional changes.
-//
-// If you want to change this type, check with our digital analyst (currently Tacey)
-// before you do -- so the change can be coordinated with their reports.
 export type Pageview = {
-  name:
-    | 'concept'
-    | 'event'
-    | 'exhibition'
-    | 'image'
-    | 'images'
-    | 'item'
-    | 'search'
-    | 'story'
-    | 'work'
-    | 'works';
+  name: PageviewName;
   properties: Record<string, string[] | number[] | string | number | undefined>;
   eventGroup?: EventGroup;
 };


### PR DESCRIPTION
We have several different components for creating links, which require a `source` parameter (e.g. WorkLink, ItemLink, ImagesLink). This `source` parameter is used for tracking in Segment, and we use the type system to enforce that this parameter only comes from a fixed list of values. However, these types are spread across multiple files.

This patch makes a few changes to make this easier to manage:

* The types are now defined in a single file `segment-values.ts`. This is a similar approach to what we've done with e.g. microcopy – it pulls all these magic strings into one place, so they can be reviewed and discussed as a single entity.
* There's a new ConceptLink component for tracking clicks to concept pages – we think, for example, that genre pages will be pretty popular, and this lays the groundwork to track whether they get more clicks than subjects/contributors.
* It applies a consistent approach to defining these types, which had become a bit fragmented.

It might be useful to review the list of link sources and prune ones which are no longer used, but I didn't want to touch that in this patch.

Closes https://github.com/wellcomecollection/wellcomecollection.org/issues/9689