### PR TITLE
Languages on work pages are buttons leading to language filtered search

### DIFF
--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -663,9 +663,19 @@ const WorkDetails: FunctionComponent<Props> = ({
         )}
 
         {work.languages.length > 0 && (
-          <WorkDetailsList
-            title="Languages"
-            list={work.languages.map(lang => lang.label)}
+          <WorkDetailsTags
+            title="Languages workslink"
+            tags={work.languages.map(lang => {
+              return {
+                textParts: [lang.label],
+                linkAttributes: worksLink(
+                  {
+                    languages: [lang.id],
+                  },
+                  'work_details/languages'
+                ),
+              };
+            })}
           />
         )}
       </WorkDetailsSection>

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -664,7 +664,7 @@ const WorkDetails: FunctionComponent<Props> = ({
 
         {work.languages.length > 0 && (
           <WorkDetailsTags
-            title="Languages workslink"
+            title="Languages"
             tags={work.languages.map(lang => {
               return {
                 textParts: [lang.label],

--- a/catalogue/webapp/components/WorksLink/index.tsx
+++ b/catalogue/webapp/components/WorksLink/index.tsx
@@ -27,10 +27,11 @@ const worksPropsSources = [
   'work_details/genres',
   'work_details/subjects',
   'work_details/partOf',
+  'work_details/languages',
 ] as const;
 
 type WorksPropsSource =
-  | (typeof worksPropsSources)[number]
+  | typeof worksPropsSources[number]
   | Prefix<'cancel_filter/'>
   | 'unknown';
 

--- a/catalogue/webapp/services/wellcome/catalogue/types/index.ts
+++ b/catalogue/webapp/services/wellcome/catalogue/types/index.ts
@@ -165,7 +165,7 @@ type Production = {
 };
 
 type Language = {
-  id?: string;
+  id: string;
   label: string;
   type: 'Language';
 };

--- a/common/data/segment-values.ts
+++ b/common/data/segment-values.ts
@@ -71,5 +71,6 @@ export type WorksLinkSource =
   | 'work_details/genres'
   | 'work_details/subjects'
   | 'work_details/partOf'
+  | 'work_details/languages'
   | Prefix<'cancel_filter/'>
   | 'unknown';


### PR DESCRIPTION
## Who is this for?
Users looking to explore language-related searches from individual works pages. 

## What is it doing for them?
It allows them to make a filtered language search directly from the listed languages on the works page, as they can currently do with Type/Technique, Series, and Contributors.

--

for #9651 

On individual works pages, languages are a list of buttons/links that take you to a filtered language search. 

Languages was previously listed with ```<WorkDetailsList>``` (not <...Text> as mentioned in commit a3a2781 and now uses the ```<WorkDetailsTags>``` component to display buttons - comparison here:

![Screenshot 2023-04-27 at 14 33 20](https://user-images.githubusercontent.com/81175151/234879538-f06680ef-7b1d-44b0-be86-cc19a2ec746a.png)

To avoid the error  _"Type 'undefined' is not assignable to type 'string'"_. after first PR/failed buildkite checks, i adjusted the Language type in ```types > index.ts```

```typescript
type Language = {
  id: string;
  label: string;
  type: 'Language';
};
```

```id:```  adjusted from  ```id?:``` - my inexperience with the codebase and TS in general means I may be missing consequences beyond my checks in asking the ```lang.id``` to be strictly a string? 

Additionally, ```/languages``` was added to ```WorksLinkSource``` to avoid further errors of incompatibility there. 