### PR TITLE
Add a toggle for fetching manifests from iiif-test.wc.org

### DIFF
--- a/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
+++ b/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
@@ -25,6 +25,7 @@ import LL from '@weco/common/views/components/styled/LL';
 import { toLink as itemLink } from '../ItemLink';
 import { toLink as imageLink } from '../ImageLink';
 import { trackSegmentEvent } from '@weco/common/services/conversion/track';
+import { useToggles } from '@weco/common/server-data/Context';
 
 type Props = {
   image: ImageType | undefined;
@@ -188,6 +189,8 @@ const ExpandedImage: FunctionComponent<Props> = ({
     }
   }, [workId, currentImageId]);
 
+  const toggles = useToggles();
+
   useEffect(() => {
     // This downloads the IIIF manifest and tries to find the image in the canvases.
     // With upcoming work on IIIF identifiers, we should be able to provide the
@@ -199,7 +202,8 @@ const ExpandedImage: FunctionComponent<Props> = ({
     ) => {
       const imageLocationBase = imageUrl.replace('/info.json', '');
       const iiifManifest = await fetchIIIFPresentationManifest(
-        manifestLocation
+        manifestLocation,
+        toggles
       );
       const transformedManifest =
         iiifManifest && transformManifest(iiifManifest);

--- a/catalogue/webapp/components/Work/Work.tsx
+++ b/catalogue/webapp/components/Work/Work.tsx
@@ -116,7 +116,8 @@ type Props = {
 
 const Work: FunctionComponent<Props> = ({ work, apiUrl }) => {
   const { worksTabbedNav } = useToggles();
-  const transformedIIIFManifest = useTransformedManifest(work);
+  const toggles = useToggles();
+  const transformedIIIFManifest = useTransformedManifest(work, toggles);
 
   const isArchive = !!(
     work.parts.length ||

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -46,6 +46,7 @@ import {
 } from '../../utils/requesting';
 import { themeValues } from '@weco/common/views/themes/config';
 import { formatDuration } from '@weco/common/utils/format-date';
+import { useToggles } from '@weco/common/server-data/Context';
 
 type Props = {
   work: Work;
@@ -59,7 +60,7 @@ const WorkDetails: FunctionComponent<Props> = ({
   const isArchive = useContext(IsArchiveContext);
   const itemUrl = itemLink({ workId: work.id }, 'work');
   const transformedIIIFImage = useTransformedIIIFImage(work);
-  const transformedIIIFManifest = useTransformedManifest(work);
+  const transformedIIIFManifest = useTransformedManifest(work, useToggles());
   const {
     video,
     iiifCredit,

--- a/catalogue/webapp/components/WorkHeader/WorkHeader.tsx
+++ b/catalogue/webapp/components/WorkHeader/WorkHeader.tsx
@@ -16,6 +16,7 @@ import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
 import useTransformedManifest from '../../hooks/useTransformedManifest';
 import Divider from '@weco/common/views/components/Divider/Divider';
 import IsArchiveContext from '../IsArchiveContext/IsArchiveContext';
+import { useToggles } from '@weco/common/server-data/Context';
 
 const WorkHeaderContainer = styled.div`
   display: flex;
@@ -37,7 +38,7 @@ const WorkHeader: FunctionComponent<Props> = ({ work }) => {
   const productionDates = getProductionDates(work);
   const archiveLabels = getArchiveLabels(work);
   const cardLabels = getCardLabels(work);
-  const manifestData = useTransformedManifest(work);
+  const manifestData = useTransformedManifest(work, useToggles());
   const { collectionManifestsCount } = manifestData;
 
   const primaryContributorLabel = work.contributors.find(

--- a/catalogue/webapp/hooks/useTransformedManifest.ts
+++ b/catalogue/webapp/hooks/useTransformedManifest.ts
@@ -8,10 +8,14 @@ import {
   createDefaultTransformedManifest,
 } from '../types/manifest';
 import { getDigitalLocationOfType } from '../utils/works';
+import { Toggles } from '@weco/toggles';
 
 const manifestPromises: Map<string, Promise<Manifest | undefined>> = new Map();
 const cachedTransformedManifest: Map<string, TransformedManifest> = new Map();
-const useTransformedManifest = (work: Work): TransformedManifest => {
+const useTransformedManifest = (
+  work: Work,
+  toggles: Toggles
+): TransformedManifest => {
   const [transformedManifest, setTransformedManifest] =
     useState<TransformedManifest>(createDefaultTransformedManifest());
 
@@ -39,7 +43,7 @@ const useTransformedManifest = (work: Work): TransformedManifest => {
         if (!iiifPresentationLocation) return;
         manifestPromises.set(
           work.id,
-          fetchIIIFPresentationManifest(iiifPresentationLocation.url)
+          fetchIIIFPresentationManifest(iiifPresentationLocation.url, toggles)
         );
         const iiifManifest = await manifestPromises.get(work.id);
         iiifManifest && transformAndUpdate(iiifManifest, work.id);

--- a/catalogue/webapp/pages/works/[workId]/download.tsx
+++ b/catalogue/webapp/pages/works/[workId]/download.tsx
@@ -201,7 +201,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     );
     const iiifManifest =
       manifestLocation &&
-      (await fetchIIIFPresentationManifest(manifestLocation.url));
+      (await fetchIIIFPresentationManifest(manifestLocation.url, serverData.toggles));
     const transformedManifest = iiifManifest && transformManifest(iiifManifest);
 
     return {

--- a/catalogue/webapp/pages/works/[workId]/items.tsx
+++ b/catalogue/webapp/pages/works/[workId]/items.tsx
@@ -435,7 +435,10 @@ export const getServerSideProps: GetServerSideProps<
   );
   const iiifManifest =
     iiifPresentationLocation &&
-    (await fetchIIIFPresentationManifest(iiifPresentationLocation.url));
+    (await fetchIIIFPresentationManifest(
+      iiifPresentationLocation.url,
+      serverData.toggles
+    ));
 
   const transformedManifest = iiifManifest && transformManifest(iiifManifest);
 
@@ -452,7 +455,8 @@ export const getServerSideProps: GetServerSideProps<
       const selectedCollectionManifestLocation = manifests?.[manifestIndex]?.id;
       const selectedCollectionManifest = selectedCollectionManifestLocation
         ? await fetchIIIFPresentationManifest(
-            selectedCollectionManifestLocation
+            selectedCollectionManifestLocation,
+            serverData.toggles
           )
         : undefined;
       const firstChildTransformedManifest =

--- a/catalogue/webapp/services/iiif/fetch/manifest.ts
+++ b/catalogue/webapp/services/iiif/fetch/manifest.ts
@@ -1,4 +1,5 @@
 import { Manifest } from '@iiif/presentation-3';
+import { Toggles } from '@weco/toggles';
 
 async function getIIIFManifest(url: string): Promise<Manifest> {
   const resp = await fetch(url);
@@ -19,11 +20,20 @@ async function getIIIFManifest(url: string): Promise<Manifest> {
 }
 
 export async function fetchIIIFPresentationManifest(
-  location: string
+  location: string,
+  toggles: Toggles
 ): Promise<Manifest | undefined> {
   // TODO once we're using v3 everywhere,
   // we'll want the catalogue API to return v3, then we can stop doing the following
-  const v3Location = location.replace('/v2/', '/v3/');
+  const v3Location = toggles.useIIIFTest
+    ? location
+        .replace('/v2/', '/v3/')
+        .replace(
+          'iiif.wellcomecollection.org',
+          'iiif-test.wellcomecollection.org'
+        )
+    : location.replace('/v2/', '/v3/');
+
   const iiifManifest = await getIIIFManifest(v3Location);
 
   return iiifManifest;

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -51,6 +51,13 @@ const toggles = {
       description:
         'Adds tabbed navigation to the works page, for switching between work, item and related content',
     },
+    {
+      id: 'useIIIFTest',
+      title: 'Use iiif-test.wellcomecollection.org for IIIF URLs',
+      initialValue: false,
+      description:
+        'Fetch IIIF manifests from iiif-test.wellcomecollection.org for new DLCS testing.',
+    },
   ] as const,
   tests: [
     {


### PR DESCRIPTION
For https://github.com/wellcomecollection/wellcomecollection.org/issues/9690

This is a bit of a hack and won't work everywhere (e.g. in the URLs in the API toolbar), but I consider that a reasonable sacrifice – it'll all get backed out again soon.

This is one way in which I think the coupling of API model and front-end model is hurting us; I'd prefer to have two separate models and a transformation step in between (like we do for Prismic), and then I'd inject this change there, but that's too big a refactor for this temporary toggle. (And something we should discuss collectively first!)