### PR TITLE
Make search button same height as input

### DIFF
--- a/common/views/components/ButtonSolid/ButtonSolid.tsx
+++ b/common/views/components/ButtonSolid/ButtonSolid.tsx
@@ -104,7 +104,7 @@ export enum ButtonTypes {
   submit = 'submit',
 }
 
-type ButtonSize = 'small' | 'medium' | 'large';
+type ButtonSize = 'small' | 'medium';
 
 export type ButtonSolidBaseProps = {
   text: ReactNode;
@@ -148,8 +148,6 @@ const getPadding = (size: ButtonSize = 'medium') => {
       return '8px 12px';
     case 'medium':
       return '13px 20px';
-    case 'large':
-      return '21px 24px';
   }
 };
 

--- a/common/views/components/SearchBar/SearchBar.tsx
+++ b/common/views/components/SearchBar/SearchBar.tsx
@@ -19,7 +19,7 @@ import { AppContext } from '@weco/common/views/components/AppContext/AppContext'
 
 const Container = styled.div`
   display: flex;
-  align-items: center;
+  align-items: stretch;
 `;
 const SearchInputWrapper = styled.div`
   flex: 1 1 auto;
@@ -34,8 +34,11 @@ const SearchInputWrapper = styled.div`
 `;
 
 const SearchButtonWrapper = styled.div`
-  flex: 0 1 auto;
+  button {
+    height: 100%;
+  }
 `;
+
 type Props = {
   inputValue: string;
   setInputValue: Dispatch<SetStateAction<string>>;
@@ -89,7 +92,6 @@ const SearchBar: FunctionComponent<Props> = ({
         <ButtonSolid
           text="Search"
           type={ButtonTypes.submit}
-          size="large"
           form={form}
           colors={themeValues.buttonColors.yellowYellowBlack}
         />


### PR DESCRIPTION
Fixes #9638 

This was the only place we had the `size="large"` button, so I've removed `large` as an option altogether. Don't know if we want to make the remaining options 'small' and 'large' rather than 'small' and 'medium', but probably one for another PR if so.

I think we may be able to do something similar to this in the `NewsletterPromo` where the button is made bigger thanks to a `ShameButtonWrap`.