### PR TITLE
Fix the warning about an empty string in assetPrefix

### DIFF
--- a/common/next/next.config.js
+++ b/common/next/next.config.js
@@ -32,7 +32,7 @@ const createConfig =
       assetPrefix:
         isProd && prodSubdomain
           ? `https://${prodSubdomain}.wellcomecollection.org`
-          : '',
+          : undefined,
       publicRuntimeConfig: {
         apmConfig: apmConfig.client(`${options.applicationName}-webapp`),
       },


### PR DESCRIPTION
I see this warning every time I build, but I think this makes it happy.