### PR TITLE
Fix our handling of IIIF videos without a "Choice" in the body

### DIFF
--- a/catalogue/webapp/test/fixtures/iiif/manifests/b16641097.ts
+++ b/catalogue/webapp/test/fixtures/iiif/manifests/b16641097.ts
@@ -1,0 +1,293 @@
+// This is based on https://iiif-test.wellcomecollection.org/presentation/b16641097
+// as retrieved 3 May 2023
+const manifest = {
+  '@context': 'http://iiif.io/api/presentation/3/context.json',
+  id: 'https://iiif-test.wellcomecollection.org/presentation/b16641097',
+  type: 'Manifest',
+  label: {
+    en: ['Gestation of ovum.'],
+  },
+  summary: {
+    en: [
+      '&lt;p&gt;A time lapse study showing the relative sliding movements of the cells during early stages of embryonic development, and the development and fusion of the medullary plates. Time lapse studies of axolotl ovum and the rotation of the embryo during later stages of development are shown.  2 segments.&lt;/p&gt;',
+    ],
+  },
+  homepage: [
+    {
+      id: 'https://wellcomecollection.org/works/qbukhq7m',
+      type: 'Text',
+      label: {
+        en: ['Gestation of ovum.'],
+      },
+      format: 'text/html',
+      language: ['en'],
+    },
+  ],
+  metadata: [
+    {
+      label: {
+        en: ['Description'],
+      },
+      value: {
+        en: [
+          '&lt;p&gt;A time lapse study showing the relative sliding movements of the cells during early stages of embryonic development, and the development and fusion of the medullary plates. Time lapse studies of axolotl ovum and the rotation of the embryo during later stages of development are shown.  2 segments.&lt;/p&gt;',
+        ],
+      },
+    },
+    {
+      label: {
+        en: ['Publication/creation'],
+      },
+      value: {
+        none: ['Germany : [s.n], 1924.'],
+      },
+    },
+    {
+      label: {
+        en: ['Physical description'],
+      },
+      value: {
+        en: ['1 encoded moving image (9 min.) : silent, black and white'],
+      },
+    },
+    {
+      label: {
+        en: ['Copyright note'],
+      },
+      value: {
+        en: ['British Medical Association 1924'],
+      },
+    },
+    {
+      label: {
+        en: ['Creator/production credits'],
+      },
+      value: {
+        en: ['Prof. Kopsch and Berlin University'],
+      },
+    },
+    {
+      label: {
+        en: ['Subjects'],
+      },
+      value: {
+        en: [
+          'Obstetrics',
+          'Embryology',
+          'Embryonic and Fetal Development',
+          'Friedrich-Wilhelms-UniversitÃ¤t Berlin',
+        ],
+      },
+    },
+    {
+      label: {
+        en: ['Attribution and usage'],
+      },
+      value: {
+        en: [
+          'Wellcome Collection',
+          '&lt;span&gt;You have permission to make copies of this work under a &lt;a target="_top" href="http://creativecommons.org/licenses/by-nc/4.0/";&gt;Creative Commons, Attribution, Non-commercial license&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Non-commercial use includes private study, academic research, teaching, and other activities that are not primarily intended for, or directed towards, commercial advantage or private monetary compensation. See the &lt;a target="_top" href="http://creativecommons.org/licenses/by-nc/4.0/legalcode";&gt;Legal Code&lt;/a&gt; for further information.&lt;br/&gt;&lt;br/&gt;Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Collection.&lt;/span&gt;',
+        ],
+      },
+    },
+  ],
+  rights: 'http://creativecommons.org/licenses/by-nc/4.0/',
+  provider: [
+    {
+      id: 'https://wellcomecollection.org',
+      type: 'Agent',
+      label: {
+        en: [
+          'Wellcome Collection',
+          '183 Euston Road',
+          'London NW1 2BE UK',
+          'T +44 (0)20 7611 8722',
+          'E library@wellcomecollection.org',
+          'https://wellcomecollection.org',
+        ],
+      },
+      homepage: [
+        {
+          id: 'https://wellcomecollection.org/works',
+          type: 'Text',
+          label: {
+            en: ['Explore our collections'],
+          },
+          format: 'text/html',
+        },
+      ],
+      logo: [
+        {
+          id: 'https://iiif-test.wellcomecollection.org/logos/wellcome-collection-black.png',
+          type: 'Image',
+          format: 'image/png',
+        },
+      ],
+    },
+  ],
+  seeAlso: [
+    {
+      id: 'https://api.wellcomecollection.org/catalogue/v2/works/qbukhq7m',
+      type: 'Dataset',
+      profile: 'https://api.wellcomecollection.org/catalogue/v2/context.json',
+      label: {
+        en: ['Wellcome Collection Catalogue API'],
+      },
+      format: 'application/json',
+    },
+  ],
+  services: [
+    {
+      id: 'https://iiif-test.wellcomecollection.org/presentation/b16641097#tracking',
+      type: 'Text',
+      profile: 'http://universalviewer.io/tracking-extensions-profile',
+      label: {
+        en: [
+          'Format: Video, Institution: n/a, Identifier: b16641097, Digicode: digfilm, Collection code: n/a',
+        ],
+      },
+    },
+    {
+      id: 'https://iiif-test.wellcomecollection.org/presentation/b16641097#timestamp',
+      type: 'Text',
+      profile:
+        'https://github.com/wellcomecollection/iiif-builder/build-timestamp',
+      label: {
+        none: ['2023-04-26T12:58:58.9397379Z'],
+      },
+    },
+    {
+      id: 'https://iiif-test.wellcomecollection.org/presentation/b16641097#accesscontrolhints',
+      type: 'Text',
+      profile: 'http://wellcomelibrary.org/ld/iiif-ext/access-control-hints',
+      label: {
+        en: ['open'],
+      },
+      metadata: [
+        {
+          label: {
+            en: ['Open'],
+          },
+          value: {
+            none: ['1'],
+          },
+        },
+      ],
+    },
+  ],
+  placeholderCanvas: {
+    id: 'https://iiif-test.wellcomecollection.org/presentation/b16641097/canvases/poster-b16641097_0055-0000-3655-0000-0-0000-0000-0.mpg',
+    type: 'Canvas',
+    label: {
+      en: ['Poster Image Canvas'],
+    },
+    width: 600,
+    height: 400,
+    items: [
+      {
+        id: 'https://iiif-test.wellcomecollection.org/presentation/b16641097/canvases/poster-b16641097_0055-0000-3655-0000-0-0000-0000-0.mpg/painting',
+        type: 'AnnotationPage',
+        items: [
+          {
+            id: 'https://iiif-test.wellcomecollection.org/presentation/b16641097/canvases/poster-b16641097_0055-0000-3655-0000-0-0000-0000-0.mpg/painting/anno',
+            type: 'Annotation',
+            motivation: 'painting',
+            body: {
+              id: 'https://iiif-test.wellcomecollection.org/thumb/b16641097',
+              type: 'Image',
+              label: {
+                en: ['Poster Image'],
+              },
+              format: 'image/jpeg',
+            },
+            target:
+              'https://iiif-test.wellcomecollection.org/presentation/b16641097/canvases/poster-b16641097_0055-0000-3655-0000-0-0000-0000-0.mpg/painting',
+          },
+        ],
+      },
+    ],
+  },
+  items: [
+    {
+      id: 'https://iiif-test.wellcomecollection.org/presentation/b16641097/canvases/b16641097_0055-0000-3655-0000-0-0000-0000-0.mpg',
+      type: 'Canvas',
+      label: {
+        none: ['-'],
+      },
+      width: 999,
+      height: 999,
+      duration: 1061,
+      rendering: [
+        {
+          width: 720,
+          height: 720,
+          duration: 1061,
+          id: 'https://iiif-test.wellcomecollection.org/av/b16641097_0055-0000-3655-0000-0-0000-0000-0.mpg/full/full/max/max/0/default.mp4',
+          type: 'Video',
+          label: {
+            en: ['Video file, size: 720 x 720'],
+          },
+          format: 'video/mp4',
+        },
+      ],
+      items: [
+        {
+          id: 'https://iiif-test.wellcomecollection.org/presentation/b16641097/canvases/b16641097_0055-0000-3655-0000-0-0000-0000-0.mpg/painting',
+          type: 'AnnotationPage',
+          items: [
+            {
+              id: 'https://iiif-test.wellcomecollection.org/presentation/b16641097/canvases/b16641097_0055-0000-3655-0000-0-0000-0000-0.mpg/painting/anno',
+              type: 'Annotation',
+              motivation: 'painting',
+              body: {
+                width: 720,
+                height: 720,
+                duration: 1061,
+                id: 'https://iiif-test.wellcomecollection.org/av/b16641097_0055-0000-3655-0000-0-0000-0000-0.mpg/full/full/max/max/0/default.mp4',
+                type: 'Video',
+                label: {
+                  en: ['Video file, size: 720 x 720'],
+                },
+                format: 'video/mp4',
+              },
+              target:
+                'https://iiif-test.wellcomecollection.org/presentation/b16641097/canvases/b16641097_0055-0000-3655-0000-0-0000-0000-0.mpg',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  partOf: [
+    {
+      id: 'https://iiif-test.wellcomecollection.org/presentation/collections/subjects/zntjhxwq',
+      type: 'Collection',
+      label: {
+        en: ['Subject: Obstetrics'],
+      },
+    },
+    {
+      id: 'https://iiif-test.wellcomecollection.org/presentation/collections/subjects/tszj8pne',
+      type: 'Collection',
+      label: {
+        en: ['Subject: Embryology'],
+      },
+    },
+    {
+      id: 'https://iiif-test.wellcomecollection.org/presentation/collections/subjects/h5zvgnb3',
+      type: 'Collection',
+      label: {
+        en: ['Subject: Embryonic and Fetal Development'],
+      },
+    },
+    {
+      id: 'https://iiif-test.wellcomecollection.org/presentation/collections/subjects/q3cjsazk',
+      type: 'Collection',
+      label: {
+        en: ['Subject: Friedrich-Wilhelms-UniversitÃ¤t Berlin'],
+      },
+    },
+  ],
+};
+
+export default manifest;

--- a/catalogue/webapp/test/fixtures/iiif/manifests/b3223756x.ts
+++ b/catalogue/webapp/test/fixtures/iiif/manifests/b3223756x.ts
@@ -1,0 +1,361 @@
+// This is based on https://iiif-test.wellcomecollection.org/presentation/v3/b3223756x
+// as retrieved 4 May 2023
+const manifest = {
+  '@context': 'http://iiif.io/api/presentation/3/context.json',
+  id: 'https://iiif-test.wellcomecollection.org/presentation/b3223756x',
+  type: 'Manifest',
+  label: {
+    en: ['Animated slides on the duplicity of vision.'],
+  },
+  summary: {
+    en: [
+      '&lt;p&gt;Animated slides with voiceover showing the function of the Fovea. &lt;/p&gt;',
+    ],
+  },
+  homepage: [
+    {
+      id: 'https://wellcomecollection.org/works/r2whysjp',
+      type: 'Text',
+      label: {
+        en: ['Animated slides on the duplicity of vision.'],
+      },
+      format: 'text/html',
+      language: ['en'],
+    },
+  ],
+  metadata: [
+    {
+      label: {
+        en: ['Description'],
+      },
+      value: {
+        en: [
+          '&lt;p&gt;Animated slides with voiceover showing the function of the Fovea. &lt;/p&gt;',
+        ],
+      },
+    },
+    {
+      label: {
+        en: ['Publication/creation'],
+      },
+      value: {
+        none: ['England, c.1960.'],
+      },
+    },
+    {
+      label: {
+        en: ['Physical description'],
+      },
+      value: {
+        en: ['1 encoded moving image (05 min.)'],
+      },
+    },
+    {
+      label: {
+        en: ['Contributors'],
+      },
+      value: {
+        none: ['Institute of Ophthalmology.'],
+      },
+    },
+    {
+      label: {
+        en: ['Copyright note'],
+      },
+      value: {
+        en: ['Institute of Ophthalmology.'],
+      },
+    },
+    {
+      label: {
+        en: ['Notes'],
+      },
+      value: {
+        en: [
+          'The sound reel forms part of a group of films donated to the Wellcome Trust in 2006 by The British Medical Association.',
+          "The picture only reel was 1 of 58 films which formed part of an additional accession in 2015 to a group of films donated to the Wellcome Trust in 2006 by The British Medical Association. The material originates from the Institute of Ophthalmology and it isn't clear when they arrived at the BMA.",
+        ],
+      },
+    },
+    {
+      label: {
+        en: ['Creator/production credits'],
+      },
+      value: {
+        en: ['R. A. Weale.'],
+      },
+    },
+    {
+      label: {
+        en: ['Subjects'],
+      },
+      value: {
+        en: [
+          'Ophthalmology',
+          'Vision, Ocular',
+          'Eye',
+          'Eye Diseases',
+          'Eye Manifestations',
+          'Nystagmus, Pathologic',
+        ],
+      },
+    },
+    {
+      label: {
+        en: ['Attribution and usage'],
+      },
+      value: {
+        en: [
+          'Wellcome Collection',
+          '&lt;span&gt;Conditions of use: it is possible this item is protected by copyright and/or related rights. You are free to use this item in any way that is permitted by the copyright and related rights legislation that applies to your use. For other uses you need to obtain permission from the rights-holder(s).&lt;/span&gt;',
+        ],
+      },
+    },
+  ],
+  provider: [
+    {
+      id: 'https://wellcomecollection.org',
+      type: 'Agent',
+      label: {
+        en: [
+          'Wellcome Collection',
+          '183 Euston Road',
+          'London NW1 2BE UK',
+          'T +44 (0)20 7611 8722',
+          'E library@wellcomecollection.org',
+          'https://wellcomecollection.org',
+        ],
+      },
+      homepage: [
+        {
+          id: 'https://wellcomecollection.org/works',
+          type: 'Text',
+          label: {
+            en: ['Explore our collections'],
+          },
+          format: 'text/html',
+        },
+      ],
+      logo: [
+        {
+          id: 'https://iiif-test.wellcomecollection.org/logos/wellcome-collection-black.png',
+          type: 'Image',
+          format: 'image/png',
+        },
+      ],
+    },
+  ],
+  seeAlso: [
+    {
+      id: 'https://api.wellcomecollection.org/catalogue/v2/works/r2whysjp',
+      type: 'Dataset',
+      profile: 'https://api.wellcomecollection.org/catalogue/v2/context.json',
+      label: {
+        en: ['Wellcome Collection Catalogue API'],
+      },
+      format: 'application/json',
+    },
+  ],
+  services: [
+    {
+      id: 'https://iiif-test.wellcomecollection.org/presentation/b3223756x#tracking',
+      type: 'Text',
+      profile: 'http://universalviewer.io/tracking-extensions-profile',
+      label: {
+        en: [
+          'Format: Video, Institution: n/a, Identifier: b3223756x, Digicode: digfilm, Collection code: n/a',
+        ],
+      },
+    },
+    {
+      id: 'https://iiif-test.wellcomecollection.org/presentation/b3223756x#timestamp',
+      type: 'Text',
+      profile:
+        'https://github.com/wellcomecollection/iiif-builder/build-timestamp',
+      label: {
+        none: ['2023-05-03T16:48:12.4591750Z'],
+      },
+    },
+    {
+      id: 'https://iiif-test.wellcomecollection.org/presentation/b3223756x#accesscontrolhints',
+      type: 'Text',
+      profile: 'http://wellcomelibrary.org/ld/iiif-ext/access-control-hints',
+      label: {
+        en: ['open'],
+      },
+      metadata: [
+        {
+          label: {
+            en: ['Open'],
+          },
+          value: {
+            none: ['1'],
+          },
+        },
+      ],
+    },
+  ],
+  placeholderCanvas: {
+    id: 'https://iiif-test.wellcomecollection.org/presentation/b3223756x/canvases/poster-b3223756x_0002.mp4',
+    type: 'Canvas',
+    label: {
+      en: ['Poster Image Canvas'],
+    },
+    width: 600,
+    height: 400,
+    items: [
+      {
+        id: 'https://iiif-test.wellcomecollection.org/presentation/b3223756x/canvases/poster-b3223756x_0002.mp4/painting',
+        type: 'AnnotationPage',
+        items: [
+          {
+            id: 'https://iiif-test.wellcomecollection.org/presentation/b3223756x/canvases/poster-b3223756x_0002.mp4/painting/anno',
+            type: 'Annotation',
+            motivation: 'painting',
+            body: {
+              id: 'https://iiif-test.wellcomecollection.org/thumb/b3223756x',
+              type: 'Image',
+              label: {
+                en: ['Poster Image'],
+              },
+              format: 'image/jpeg',
+            },
+            target:
+              'https://iiif-test.wellcomecollection.org/presentation/b3223756x/canvases/poster-b3223756x_0002.mp4/painting',
+          },
+        ],
+      },
+    ],
+  },
+  items: [
+    {
+      id: 'https://iiif-test.wellcomecollection.org/presentation/b3223756x/canvases/b3223756x_0002.mp4',
+      type: 'Canvas',
+      label: {
+        none: ['-'],
+      },
+      width: 2048,
+      height: 1536,
+      duration: 239.875,
+      rendering: [
+        {
+          width: 960,
+          height: 720,
+          duration: 239.875,
+          id: 'https://iiif-test.wellcomecollection.org/av/b3223756x_0002.mp4/full/full/max/max/0/default.mp4',
+          type: 'Video',
+          label: {
+            en: ['Video file, size: 960 x 720'],
+          },
+          format: 'video/mp4',
+        },
+        {
+          width: 2048,
+          height: 1536,
+          duration: 239.875,
+          id: 'https://iiif-test.wellcomecollection.org/file/b3223756x_0002.mp4',
+          type: 'Video',
+          label: {
+            en: ['Video file, size: 2048 x 1536'],
+          },
+          format: 'video/mp4',
+        },
+      ],
+      items: [
+        {
+          id: 'https://iiif-test.wellcomecollection.org/presentation/b3223756x/canvases/b3223756x_0002.mp4/painting',
+          type: 'AnnotationPage',
+          items: [
+            {
+              id: 'https://iiif-test.wellcomecollection.org/presentation/b3223756x/canvases/b3223756x_0002.mp4/painting/anno',
+              type: 'Annotation',
+              motivation: 'painting',
+              body: {
+                type: 'Choice',
+                items: [
+                  {
+                    width: 960,
+                    height: 720,
+                    duration: 239.875,
+                    id: 'https://iiif-test.wellcomecollection.org/av/b3223756x_0002.mp4/full/full/max/max/0/default.mp4',
+                    type: 'Video',
+                    label: {
+                      en: ['Video file, size: 960 x 720'],
+                    },
+                    format: 'video/mp4',
+                  },
+                  {
+                    width: 2048,
+                    height: 1536,
+                    duration: 239.875,
+                    id: 'https://iiif-test.wellcomecollection.org/file/b3223756x_0002.mp4',
+                    type: 'Video',
+                    label: {
+                      en: ['Video file, size: 2048 x 1536'],
+                    },
+                    format: 'video/mp4',
+                  },
+                ],
+              },
+              target:
+                'https://iiif-test.wellcomecollection.org/presentation/b3223756x/canvases/b3223756x_0002.mp4',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  partOf: [
+    {
+      id: 'https://iiif-test.wellcomecollection.org/presentation/collections/contributors/f2skecp7',
+      type: 'Collection',
+      label: {
+        en: ['Contributor: Institute of Ophthalmology.'],
+      },
+    },
+    {
+      id: 'https://iiif-test.wellcomecollection.org/presentation/collections/subjects/yykpte9u',
+      type: 'Collection',
+      label: {
+        en: ['Subject: Ophthalmology'],
+      },
+    },
+    {
+      id: 'https://iiif-test.wellcomecollection.org/presentation/collections/subjects/fc3sth5p',
+      type: 'Collection',
+      label: {
+        en: ['Subject: Vision, Ocular'],
+      },
+    },
+    {
+      id: 'https://iiif-test.wellcomecollection.org/presentation/collections/subjects/nfv4y9gy',
+      type: 'Collection',
+      label: {
+        en: ['Subject: Eye'],
+      },
+    },
+    {
+      id: 'https://iiif-test.wellcomecollection.org/presentation/collections/subjects/msp96ntw',
+      type: 'Collection',
+      label: {
+        en: ['Subject: Eye Diseases'],
+      },
+    },
+    {
+      id: 'https://iiif-test.wellcomecollection.org/presentation/collections/subjects/brz3964g',
+      type: 'Collection',
+      label: {
+        en: ['Subject: Eye Manifestations'],
+      },
+    },
+    {
+      id: 'https://iiif-test.wellcomecollection.org/presentation/collections/subjects/qpeyyytg',
+      type: 'Collection',
+      label: {
+        en: ['Subject: Nystagmus, Pathologic'],
+      },
+    },
+  ],
+};
+
+export default manifest;

--- a/catalogue/webapp/test/utils/iiif.test.ts
+++ b/catalogue/webapp/test/utils/iiif.test.ts
@@ -170,6 +170,251 @@ describe('Group repetitive iiif structures', () => {
 });
 
 describe('getVideo', () => {
+  it('gets a video with a single "Video" in the body', () => {
+    // This is based on https://iiif-test.wellcomecollection.org/presentation/b16641097
+    // as retrieved 3 May 2023
+    const manifest = {
+      '@context': 'http://iiif.io/api/presentation/3/context.json',
+      id: 'https://iiif-test.wellcomecollection.org/presentation/b16641097',
+      type: 'Manifest',
+      placeholderCanvas: {
+        id: 'https://iiif-test.wellcomecollection.org/presentation/b16641097/canvases/poster-b16641097_0055-0000-3655-0000-0-0000-0000-0.mpg',
+        type: 'Canvas',
+        label: {
+          en: ['Poster Image Canvas'],
+        },
+        width: 600,
+        height: 400,
+        items: [
+          {
+            id: 'https://iiif-test.wellcomecollection.org/presentation/b16641097/canvases/poster-b16641097_0055-0000-3655-0000-0-0000-0000-0.mpg/painting',
+            type: 'AnnotationPage',
+            items: [
+              {
+                id: 'https://iiif-test.wellcomecollection.org/presentation/b16641097/canvases/poster-b16641097_0055-0000-3655-0000-0-0000-0000-0.mpg/painting/anno',
+                type: 'Annotation',
+                motivation: 'painting',
+                body: {
+                  id: 'https://iiif-test.wellcomecollection.org/thumb/b16641097',
+                  type: 'Image',
+                  label: {
+                    en: ['Poster Image'],
+                  },
+                  format: 'image/jpeg',
+                },
+                target:
+                  'https://iiif-test.wellcomecollection.org/presentation/b16641097/canvases/poster-b16641097_0055-0000-3655-0000-0-0000-0000-0.mpg/painting',
+              },
+            ],
+          },
+        ],
+      },
+      items: [
+        {
+          id: 'https://iiif-test.wellcomecollection.org/presentation/b16641097/canvases/b16641097_0055-0000-3655-0000-0-0000-0000-0.mpg',
+          type: 'Canvas',
+          label: {
+            none: ['-'],
+          },
+          width: 999,
+          height: 999,
+          duration: 1061,
+          rendering: [
+            {
+              width: 720,
+              height: 720,
+              duration: 1061,
+              id: 'https://iiif-test.wellcomecollection.org/av/b16641097_0055-0000-3655-0000-0-0000-0000-0.mpg/full/full/max/max/0/default.mp4',
+              type: 'Video',
+              label: {
+                en: ['Video file, size: 720 x 720'],
+              },
+              format: 'video/mp4',
+            },
+          ],
+          items: [
+            {
+              id: 'https://iiif-test.wellcomecollection.org/presentation/b16641097/canvases/b16641097_0055-0000-3655-0000-0-0000-0000-0.mpg/painting',
+              type: 'AnnotationPage',
+              items: [
+                {
+                  id: 'https://iiif-test.wellcomecollection.org/presentation/b16641097/canvases/b16641097_0055-0000-3655-0000-0-0000-0000-0.mpg/painting/anno',
+                  type: 'Annotation',
+                  motivation: 'painting',
+                  body: {
+                    width: 720,
+                    height: 720,
+                    duration: 1061,
+                    id: 'https://iiif-test.wellcomecollection.org/av/b16641097_0055-0000-3655-0000-0-0000-0000-0.mpg/full/full/max/max/0/default.mp4',
+                    type: 'Video',
+                    label: {
+                      en: ['Video file, size: 720 x 720'],
+                    },
+                    format: 'video/mp4',
+                  },
+                  target:
+                    'https://iiif-test.wellcomecollection.org/presentation/b16641097/canvases/b16641097_0055-0000-3655-0000-0-0000-0000-0.mpg',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const video = getVideo(manifest as any);
+
+    expect(video).toStrictEqual({
+      width: 720,
+      height: 720,
+      duration: 1061,
+      id: 'https://iiif-test.wellcomecollection.org/av/b16641097_0055-0000-3655-0000-0-0000-0000-0.mpg/full/full/max/max/0/default.mp4',
+      type: 'Video',
+      label: {
+        en: ['Video file, size: 720 x 720'],
+      },
+      format: 'video/mp4',
+      thumbnail: 'https://iiif-test.wellcomecollection.org/thumb/b16641097',
+      annotations: undefined,
+    });
+  });
+
+  it('gets a video with multiple items as a "Choice" in the body', () => {
+    // This is based on https://iiif-test.wellcomecollection.org/presentation/v3/b3223756x
+    // as retrieved 4 May 2023
+    const manifest = {
+      '@context': 'http://iiif.io/api/presentation/3/context.json',
+      id: 'https://iiif-test.wellcomecollection.org/presentation/b3223756x',
+      type: 'Manifest',
+      placeholderCanvas: {
+        id: 'https://iiif-test.wellcomecollection.org/presentation/b3223756x/canvases/poster-b3223756x_0002.mp4',
+        type: 'Canvas',
+        label: {
+          en: ['Poster Image Canvas'],
+        },
+        width: 600,
+        height: 400,
+        items: [
+          {
+            id: 'https://iiif-test.wellcomecollection.org/presentation/b3223756x/canvases/poster-b3223756x_0002.mp4/painting',
+            type: 'AnnotationPage',
+            items: [
+              {
+                id: 'https://iiif-test.wellcomecollection.org/presentation/b3223756x/canvases/poster-b3223756x_0002.mp4/painting/anno',
+                type: 'Annotation',
+                motivation: 'painting',
+                body: {
+                  id: 'https://iiif-test.wellcomecollection.org/thumb/b3223756x',
+                  type: 'Image',
+                  label: {
+                    en: ['Poster Image'],
+                  },
+                  format: 'image/jpeg',
+                },
+                target:
+                  'https://iiif-test.wellcomecollection.org/presentation/b3223756x/canvases/poster-b3223756x_0002.mp4/painting',
+              },
+            ],
+          },
+        ],
+      },
+      items: [
+        {
+          id: 'https://iiif-test.wellcomecollection.org/presentation/b3223756x/canvases/b3223756x_0002.mp4',
+          type: 'Canvas',
+          label: {
+            none: ['-'],
+          },
+          width: 2048,
+          height: 1536,
+          duration: 239.875,
+          rendering: [
+            {
+              width: 960,
+              height: 720,
+              duration: 239.875,
+              id: 'https://iiif-test.wellcomecollection.org/av/b3223756x_0002.mp4/full/full/max/max/0/default.mp4',
+              type: 'Video',
+              label: {
+                en: ['Video file, size: 960 x 720'],
+              },
+              format: 'video/mp4',
+            },
+            {
+              width: 2048,
+              height: 1536,
+              duration: 239.875,
+              id: 'https://iiif-test.wellcomecollection.org/file/b3223756x_0002.mp4',
+              type: 'Video',
+              label: {
+                en: ['Video file, size: 2048 x 1536'],
+              },
+              format: 'video/mp4',
+            },
+          ],
+          items: [
+            {
+              id: 'https://iiif-test.wellcomecollection.org/presentation/b3223756x/canvases/b3223756x_0002.mp4/painting',
+              type: 'AnnotationPage',
+              items: [
+                {
+                  id: 'https://iiif-test.wellcomecollection.org/presentation/b3223756x/canvases/b3223756x_0002.mp4/painting/anno',
+                  type: 'Annotation',
+                  motivation: 'painting',
+                  body: {
+                    type: 'Choice',
+                    items: [
+                      {
+                        width: 960,
+                        height: 720,
+                        duration: 239.875,
+                        id: 'https://iiif-test.wellcomecollection.org/av/b3223756x_0002.mp4/full/full/max/max/0/default.mp4',
+                        type: 'Video',
+                        label: {
+                          en: ['Video file, size: 960 x 720'],
+                        },
+                        format: 'video/mp4',
+                      },
+                      {
+                        width: 2048,
+                        height: 1536,
+                        duration: 239.875,
+                        id: 'https://iiif-test.wellcomecollection.org/file/b3223756x_0002.mp4',
+                        type: 'Video',
+                        label: {
+                          en: ['Video file, size: 2048 x 1536'],
+                        },
+                        format: 'video/mp4',
+                      },
+                    ],
+                  },
+                  target:
+                    'https://iiif-test.wellcomecollection.org/presentation/b3223756x/canvases/b3223756x_0002.mp4',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const video = getVideo(manifest as any);
+
+    expect(video).toStrictEqual({
+      width: 960,
+      height: 720,
+      duration: 239.875,
+      id: 'https://iiif-test.wellcomecollection.org/av/b3223756x_0002.mp4/full/full/max/max/0/default.mp4',
+      type: 'Video',
+      label: {
+        en: ['Video file, size: 960 x 720'],
+      },
+      format: 'video/mp4',
+      thumbnail: 'https://iiif-test.wellcomecollection.org/thumb/b3223756x',
+      annotations: undefined,
+    });
+  });
+
   it('returns a Video type from a manifest', () => {
     const video = {
       width: 720,

--- a/catalogue/webapp/test/utils/iiif.test.ts
+++ b/catalogue/webapp/test/utils/iiif.test.ts
@@ -19,6 +19,9 @@ import {
   clickThroughService,
 } from '@weco/common/__mocks__/iiif-manifest-v3';
 
+import b16641097 from '@weco/catalogue/test/fixtures/iiif/manifests/b16641097';
+import b3223756x from '@weco/catalogue/test/fixtures/iiif/manifests/b3223756x';
+
 const canvases = getTransformedCanvases(manifest as Manifest);
 const structures = [
   {
@@ -171,98 +174,7 @@ describe('Group repetitive iiif structures', () => {
 
 describe('getVideo', () => {
   it('gets a video with a single "Video" in the body', () => {
-    // This is based on https://iiif-test.wellcomecollection.org/presentation/b16641097
-    // as retrieved 3 May 2023
-    const manifest = {
-      '@context': 'http://iiif.io/api/presentation/3/context.json',
-      id: 'https://iiif-test.wellcomecollection.org/presentation/b16641097',
-      type: 'Manifest',
-      placeholderCanvas: {
-        id: 'https://iiif-test.wellcomecollection.org/presentation/b16641097/canvases/poster-b16641097_0055-0000-3655-0000-0-0000-0000-0.mpg',
-        type: 'Canvas',
-        label: {
-          en: ['Poster Image Canvas'],
-        },
-        width: 600,
-        height: 400,
-        items: [
-          {
-            id: 'https://iiif-test.wellcomecollection.org/presentation/b16641097/canvases/poster-b16641097_0055-0000-3655-0000-0-0000-0000-0.mpg/painting',
-            type: 'AnnotationPage',
-            items: [
-              {
-                id: 'https://iiif-test.wellcomecollection.org/presentation/b16641097/canvases/poster-b16641097_0055-0000-3655-0000-0-0000-0000-0.mpg/painting/anno',
-                type: 'Annotation',
-                motivation: 'painting',
-                body: {
-                  id: 'https://iiif-test.wellcomecollection.org/thumb/b16641097',
-                  type: 'Image',
-                  label: {
-                    en: ['Poster Image'],
-                  },
-                  format: 'image/jpeg',
-                },
-                target:
-                  'https://iiif-test.wellcomecollection.org/presentation/b16641097/canvases/poster-b16641097_0055-0000-3655-0000-0-0000-0000-0.mpg/painting',
-              },
-            ],
-          },
-        ],
-      },
-      items: [
-        {
-          id: 'https://iiif-test.wellcomecollection.org/presentation/b16641097/canvases/b16641097_0055-0000-3655-0000-0-0000-0000-0.mpg',
-          type: 'Canvas',
-          label: {
-            none: ['-'],
-          },
-          width: 999,
-          height: 999,
-          duration: 1061,
-          rendering: [
-            {
-              width: 720,
-              height: 720,
-              duration: 1061,
-              id: 'https://iiif-test.wellcomecollection.org/av/b16641097_0055-0000-3655-0000-0-0000-0000-0.mpg/full/full/max/max/0/default.mp4',
-              type: 'Video',
-              label: {
-                en: ['Video file, size: 720 x 720'],
-              },
-              format: 'video/mp4',
-            },
-          ],
-          items: [
-            {
-              id: 'https://iiif-test.wellcomecollection.org/presentation/b16641097/canvases/b16641097_0055-0000-3655-0000-0-0000-0000-0.mpg/painting',
-              type: 'AnnotationPage',
-              items: [
-                {
-                  id: 'https://iiif-test.wellcomecollection.org/presentation/b16641097/canvases/b16641097_0055-0000-3655-0000-0-0000-0000-0.mpg/painting/anno',
-                  type: 'Annotation',
-                  motivation: 'painting',
-                  body: {
-                    width: 720,
-                    height: 720,
-                    duration: 1061,
-                    id: 'https://iiif-test.wellcomecollection.org/av/b16641097_0055-0000-3655-0000-0-0000-0000-0.mpg/full/full/max/max/0/default.mp4',
-                    type: 'Video',
-                    label: {
-                      en: ['Video file, size: 720 x 720'],
-                    },
-                    format: 'video/mp4',
-                  },
-                  target:
-                    'https://iiif-test.wellcomecollection.org/presentation/b16641097/canvases/b16641097_0055-0000-3655-0000-0-0000-0000-0.mpg',
-                },
-              ],
-            },
-          ],
-        },
-      ],
-    };
-
-    const video = getVideo(manifest as any);
+    const video = getVideo(b16641097 as any);
 
     expect(video).toStrictEqual({
       width: 720,
@@ -280,125 +192,7 @@ describe('getVideo', () => {
   });
 
   it('gets a video with multiple items as a "Choice" in the body', () => {
-    // This is based on https://iiif-test.wellcomecollection.org/presentation/v3/b3223756x
-    // as retrieved 4 May 2023
-    const manifest = {
-      '@context': 'http://iiif.io/api/presentation/3/context.json',
-      id: 'https://iiif-test.wellcomecollection.org/presentation/b3223756x',
-      type: 'Manifest',
-      placeholderCanvas: {
-        id: 'https://iiif-test.wellcomecollection.org/presentation/b3223756x/canvases/poster-b3223756x_0002.mp4',
-        type: 'Canvas',
-        label: {
-          en: ['Poster Image Canvas'],
-        },
-        width: 600,
-        height: 400,
-        items: [
-          {
-            id: 'https://iiif-test.wellcomecollection.org/presentation/b3223756x/canvases/poster-b3223756x_0002.mp4/painting',
-            type: 'AnnotationPage',
-            items: [
-              {
-                id: 'https://iiif-test.wellcomecollection.org/presentation/b3223756x/canvases/poster-b3223756x_0002.mp4/painting/anno',
-                type: 'Annotation',
-                motivation: 'painting',
-                body: {
-                  id: 'https://iiif-test.wellcomecollection.org/thumb/b3223756x',
-                  type: 'Image',
-                  label: {
-                    en: ['Poster Image'],
-                  },
-                  format: 'image/jpeg',
-                },
-                target:
-                  'https://iiif-test.wellcomecollection.org/presentation/b3223756x/canvases/poster-b3223756x_0002.mp4/painting',
-              },
-            ],
-          },
-        ],
-      },
-      items: [
-        {
-          id: 'https://iiif-test.wellcomecollection.org/presentation/b3223756x/canvases/b3223756x_0002.mp4',
-          type: 'Canvas',
-          label: {
-            none: ['-'],
-          },
-          width: 2048,
-          height: 1536,
-          duration: 239.875,
-          rendering: [
-            {
-              width: 960,
-              height: 720,
-              duration: 239.875,
-              id: 'https://iiif-test.wellcomecollection.org/av/b3223756x_0002.mp4/full/full/max/max/0/default.mp4',
-              type: 'Video',
-              label: {
-                en: ['Video file, size: 960 x 720'],
-              },
-              format: 'video/mp4',
-            },
-            {
-              width: 2048,
-              height: 1536,
-              duration: 239.875,
-              id: 'https://iiif-test.wellcomecollection.org/file/b3223756x_0002.mp4',
-              type: 'Video',
-              label: {
-                en: ['Video file, size: 2048 x 1536'],
-              },
-              format: 'video/mp4',
-            },
-          ],
-          items: [
-            {
-              id: 'https://iiif-test.wellcomecollection.org/presentation/b3223756x/canvases/b3223756x_0002.mp4/painting',
-              type: 'AnnotationPage',
-              items: [
-                {
-                  id: 'https://iiif-test.wellcomecollection.org/presentation/b3223756x/canvases/b3223756x_0002.mp4/painting/anno',
-                  type: 'Annotation',
-                  motivation: 'painting',
-                  body: {
-                    type: 'Choice',
-                    items: [
-                      {
-                        width: 960,
-                        height: 720,
-                        duration: 239.875,
-                        id: 'https://iiif-test.wellcomecollection.org/av/b3223756x_0002.mp4/full/full/max/max/0/default.mp4',
-                        type: 'Video',
-                        label: {
-                          en: ['Video file, size: 960 x 720'],
-                        },
-                        format: 'video/mp4',
-                      },
-                      {
-                        width: 2048,
-                        height: 1536,
-                        duration: 239.875,
-                        id: 'https://iiif-test.wellcomecollection.org/file/b3223756x_0002.mp4',
-                        type: 'Video',
-                        label: {
-                          en: ['Video file, size: 2048 x 1536'],
-                        },
-                        format: 'video/mp4',
-                      },
-                    ],
-                  },
-                  target:
-                    'https://iiif-test.wellcomecollection.org/presentation/b3223756x/canvases/b3223756x_0002.mp4',
-                },
-              ],
-            },
-          ],
-        },
-      ],
-    };
-
-    const video = getVideo(manifest as any);
+    const video = getVideo(b3223756x as any);
 
     expect(video).toStrictEqual({
       width: 960,

--- a/catalogue/webapp/utils/iiif/v3/index.ts
+++ b/catalogue/webapp/utils/iiif/v3/index.ts
@@ -338,10 +338,22 @@ function getExternalWebResourceBody(
 }
 
 export function getVideo(manifest: Manifest): Video | undefined {
-  const videoChoiceBody = getChoiceBody(
-    manifest.items?.[0]?.items?.[0]?.items?.[0]?.body
-  );
-  const maybeVideo = getExternalWebResourceBody(videoChoiceBody?.items?.[0]);
+  const body = manifest.items?.[0]?.items?.[0]?.items?.[0]?.body;
+
+  const videoChoiceBody = getChoiceBody(body);
+
+  // A video can appear in the "body" in two ways:
+  //
+  //    - As a ChoiceBody with multiple items, for example if the video is
+  //      available in multiple formats or resolutions.
+  //    - As an ExternalWebResource with type "Video", if the video is only
+  //      available in a single format/resolution.
+  //
+  // See the test cases for this function for examples of both.
+  const maybeVideo = videoChoiceBody
+    ? getExternalWebResourceBody(videoChoiceBody.items?.[0])
+    : getExternalWebResourceBody(body);
+
   const thumbnailImageResourceBody = getExternalWebResourceBody(
     manifest.placeholderCanvas?.items?.[0]?.items?.[0]?.body
   );


### PR DESCRIPTION
This is one of the changes with the new IIIF manifests from DLCS: previously every video would have a "Choice" in the body, because DLCS was offering both MP4 and WebM options.

It now only offers MP4, so some videos no longer have a "Choice" -- the only option is the single MP4.  But we can't remove the "Choice" handling entirely, because some videos still have a "Choice", e.g. for multiple resolutions.

Closes https://github.com/wellcomecollection/wellcomecollection.org/issues/9724