### PR TITLE
Allow looking up canvas thumbnails for digitised PDFs

### DIFF
--- a/catalogue/webapp/test/fixtures/iiif/manifests/b28462270.ts
+++ b/catalogue/webapp/test/fixtures/iiif/manifests/b28462270.ts
@@ -1,0 +1,330 @@
+// Based on https://iiif-test.wellcomecollection.org/presentation/v3/b28462270
+// Retrieved 4 May 2023
+const manifest = {
+  '@context': [
+    'https://iiif-test.wellcomecollection.org/extensions/born-digital/context.json',
+    'http://iiif.io/api/presentation/3/context.json',
+  ],
+  id: 'https://iiif-test.wellcomecollection.org/presentation/b28462270',
+  type: 'Manifest',
+  label: {
+    en: [
+      'Digital humanities pedagogy : practices, principles and politics / edited by Brett D. Hirsch.',
+    ],
+  },
+  thumbnail: [
+    {
+      id: 'https://iiif-test.wellcomecollection.org/thumb/b28462270',
+      type: 'Image',
+      format: 'image/jpeg',
+    },
+  ],
+  homepage: [
+    {
+      id: 'https://wellcomecollection.org/works/qvgcmea3',
+      type: 'Text',
+      label: {
+        en: [
+          'Digital humanities pedagogy : practices, principles and politics / edited by Brett D. Hirsch.',
+        ],
+      },
+      format: 'text/html',
+      language: ['en'],
+    },
+  ],
+  metadata: [
+    {
+      label: {
+        en: ['Publication/creation'],
+      },
+      value: {
+        none: ['Cambridge : Open Book Publishers, [2012], Â©2012.'],
+      },
+    },
+    {
+      label: {
+        en: ['Physical description'],
+      },
+      value: {
+        en: ['1 online resource (448 pages) : illustrations.'],
+      },
+    },
+    {
+      label: {
+        en: ['Contributors'],
+      },
+      value: {
+        none: ['Hirsch, Brett D', 'Open Book Publishers'],
+      },
+    },
+    {
+      label: {
+        en: ['Notes'],
+      },
+      value: {
+        en: ['Available through Open Book Publishers.'],
+      },
+    },
+    {
+      label: {
+        en: ['Type/technique'],
+      },
+      value: {
+        en: ['Electronic books'],
+      },
+    },
+    {
+      label: {
+        en: ['Subjects'],
+      },
+      value: {
+        en: [
+          'Humanities - Computer network resources - Study and teaching (Higher)',
+          'Digital humanities - Study and teaching (Higher)',
+          'Humanities - Methodology - Study and teaching (Higher)',
+          'Humanities - Study and teaching (Higher)',
+          'Humanities - Technological innovations - Study and teaching (Higher)',
+        ],
+      },
+    },
+    {
+      label: {
+        en: ['Attribution and usage'],
+      },
+      value: {
+        en: [
+          'Wellcome Collection',
+          '<span>You have permission to make copies of this work under a <a target="_top" href="http: //creativecommons.org/licenses/by-nc-nd/4.0/">Creative Commons, Attribution, Non-commercial, No-derivatives license</a>. <br/><br/> Non-commercial use includes private study, academic research, teaching, and other activities that are not primarily intended for, or directed towards, commercial advantage or private monetary compensation. See the <a target="_top" href="http: //creativecommons.org/licenses/by-nc-nd/4.0/legalcode">Legal Code</a> for further information.<br/><br/>Image source should be attributed as specified in the full catalogue record. If no source is given the image should be attributed to Wellcome Collection.<br/><br/> Altering, adapting, modifying or translating the work is prohibited.</span>',
+        ],
+      },
+    },
+  ],
+  rights: 'http://creativecommons.org/licenses/by-nc-nd/4.0/',
+  provider: [
+    {
+      id: 'https://wellcomecollection.org',
+      type: 'Agent',
+      label: {
+        en: [
+          'Wellcome Collection',
+          '183 Euston Road',
+          'London NW1 2BE UK',
+          'T +44 (0)20 7611 8722',
+          'E library@wellcomecollection.org',
+          'https://wellcomecollection.org',
+        ],
+      },
+      homepage: [
+        {
+          id: 'https://wellcomecollection.org/works',
+          type: 'Text',
+          label: {
+            en: ['Explore our collections'],
+          },
+          format: 'text/html',
+        },
+      ],
+      logo: [
+        {
+          id: 'https://iiif-test.wellcomecollection.org/logos/wellcome-collection-black.png',
+          type: 'Image',
+          format: 'image/png',
+        },
+      ],
+    },
+  ],
+  seeAlso: [
+    {
+      id: 'https://api.wellcomecollection.org/catalogue/v2/works/qvgcmea3',
+      type: 'Dataset',
+      profile: 'https://api.wellcomecollection.org/catalogue/v2/context.json',
+      label: {
+        en: ['Wellcome Collection Catalogue API'],
+      },
+      format: 'application/json',
+    },
+  ],
+  services: [
+    {
+      id: 'https://iiif-test.wellcomecollection.org/presentation/b28462270#tracking',
+      type: 'Text',
+      profile: 'http://universalviewer.io/tracking-extensions-profile',
+      label: {
+        en: [
+          'Format: Monograph, Institution: n/a, Identifier: b28462270, Digicode: digobp, Collection code: n/a',
+        ],
+      },
+    },
+    {
+      id: 'https://iiif-test.wellcomecollection.org/presentation/b28462270#timestamp',
+      type: 'Text',
+      profile:
+        'https://github.com/wellcomecollection/iiif-builder/build-timestamp',
+      label: {
+        none: ['2023-04-26T12:59:00.3894750Z'],
+      },
+    },
+    {
+      id: 'https://iiif-test.wellcomecollection.org/presentation/b28462270#accesscontrolhints',
+      type: 'Text',
+      profile: 'http://wellcomelibrary.org/ld/iiif-ext/access-control-hints',
+      label: {
+        en: ['open'],
+      },
+      metadata: [
+        {
+          label: {
+            en: ['Open'],
+          },
+          value: {
+            none: ['1'],
+          },
+        },
+      ],
+    },
+  ],
+  items: [
+    {
+      id: 'https://iiif-test.wellcomecollection.org/presentation/b28462270/canvases/b28462270_DigitalHumanitiesPedagogy.pdf',
+      type: 'Canvas',
+      label: {
+        none: ['-'],
+      },
+      width: 1000,
+      height: 800,
+      thumbnail: [
+        {
+          id: 'https://iiif-test.wellcomecollection.org/extensions/born-digital/placeholder-thumb/fmt/20/application/pdf',
+          type: 'Image',
+          width: 101,
+          height: 151,
+          format: 'image/png',
+        },
+      ],
+      metadata: [
+        {
+          label: {
+            en: ['File format'],
+          },
+          value: {
+            none: ['Acrobat PDF 1.6 - Portable Document Format 1.6'],
+          },
+        },
+        {
+          label: {
+            en: ['File size'],
+          },
+          value: {
+            none: ['5.9 MB'],
+          },
+        },
+        {
+          label: {
+            en: ['Pronom key'],
+          },
+          value: {
+            none: ['fmt/20'],
+          },
+        },
+      ],
+      rendering: [
+        {
+          id: 'https://iiif-test.wellcomecollection.org/file/b28462270_DigitalHumanitiesPedagogy.pdf',
+          type: 'Text',
+          label: {
+            none: ['-'],
+          },
+          format: 'application/pdf',
+          behavior: ['original'],
+        },
+      ],
+      behavior: ['placeholder'],
+      items: [
+        {
+          id: 'https://iiif-test.wellcomecollection.org/presentation/b28462270/canvases/b28462270_DigitalHumanitiesPedagogy.pdf/painting',
+          type: 'AnnotationPage',
+          items: [
+            {
+              id: 'https://iiif-test.wellcomecollection.org/presentation/b28462270/canvases/b28462270_DigitalHumanitiesPedagogy.pdf/painting/anno',
+              type: 'Annotation',
+              motivation: 'painting',
+              body: {
+                id: 'https://iiif-test.wellcomecollection.org/extensions/born-digital/placeholder-canvas/fmt/20/application/pdf',
+                type: 'Image',
+                width: 1000,
+                height: 800,
+                format: 'image/png',
+              },
+              target:
+                'https://iiif-test.wellcomecollection.org/presentation/b28462270/canvases/b28462270_DigitalHumanitiesPedagogy.pdf',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  partOf: [
+    {
+      id: 'https://iiif-test.wellcomecollection.org/presentation/collections/contributors/d7fe2vs8',
+      type: 'Collection',
+      label: {
+        en: ['Contributor: Hirsch, Brett D'],
+      },
+    },
+    {
+      id: 'https://iiif-test.wellcomecollection.org/presentation/collections/contributors/he2bhwrf',
+      type: 'Collection',
+      label: {
+        en: ['Contributor: Open Book Publishers'],
+      },
+    },
+    {
+      id: 'https://iiif-test.wellcomecollection.org/presentation/collections/subjects/p5dgx97w',
+      type: 'Collection',
+      label: {
+        en: [
+          'Subject: Humanities - Computer network resources - Study and teaching (Higher)',
+        ],
+      },
+    },
+    {
+      id: 'https://iiif-test.wellcomecollection.org/presentation/collections/subjects/e9ghzxj3',
+      type: 'Collection',
+      label: {
+        en: ['Subject: Digital humanities - Study and teaching (Higher)'],
+      },
+    },
+    {
+      id: 'https://iiif-test.wellcomecollection.org/presentation/collections/subjects/tvb662ze',
+      type: 'Collection',
+      label: {
+        en: ['Subject: Humanities - Methodology - Study and teaching (Higher)'],
+      },
+    },
+    {
+      id: 'https://iiif-test.wellcomecollection.org/presentation/collections/subjects/p5dgx97w',
+      type: 'Collection',
+      label: {
+        en: ['Subject: Humanities - Study and teaching (Higher)'],
+      },
+    },
+    {
+      id: 'https://iiif-test.wellcomecollection.org/presentation/collections/subjects/p5dgx97w',
+      type: 'Collection',
+      label: {
+        en: [
+          'Subject: Humanities - Technological innovations - Study and teaching (Higher)',
+        ],
+      },
+    },
+    {
+      id: 'https://iiif-test.wellcomecollection.org/presentation/collections/genres/Electronic_books',
+      type: 'Collection',
+      label: {
+        en: ['Genre: Electronic books'],
+      },
+    },
+  ],
+};
+
+export default manifest;

--- a/catalogue/webapp/test/fixtures/iiif/manifests/index.ts
+++ b/catalogue/webapp/test/fixtures/iiif/manifests/index.ts
@@ -1,0 +1,7 @@
+import b2178081x from './b2178081x';
+import b3223756x from './b3223756x';
+import b16641097 from './b16641097';
+import b21506115 from './b21506115';
+import b28462270 from './b28462270';
+
+export { b2178081x, b3223756x, b16641097, b21506115, b28462270 };

--- a/catalogue/webapp/types/manifest.ts
+++ b/catalogue/webapp/types/manifest.ts
@@ -8,7 +8,7 @@ import {
 } from '@iiif/presentation-3';
 import { Audio, Video } from '../../webapp/services/iiif/types/manifest/v3';
 
-type ThumbnailImage = { url: string | undefined; width: number };
+export type ThumbnailImage = { url: string; width: number };
 
 export type TransformedCanvas = {
   id: string;

--- a/catalogue/webapp/utils/iiif/v3/canvas.test.ts
+++ b/catalogue/webapp/utils/iiif/v3/canvas.test.ts
@@ -1,6 +1,9 @@
 import { getThumbnailImage } from './canvas';
-import b21506115 from '@weco/catalogue/test/fixtures/iiif/manifests/b21506115';
-import b2178081x from '@weco/catalogue/test/fixtures/iiif/manifests/b2178081x';
+import {
+  b21506115,
+  b2178081x,
+  b28462270,
+} from '@weco/catalogue/test/fixtures/iiif/manifests';
 
 describe('getThumbnailImage', () => {
   it('if there’s no thumbnail on the canvas', () => {
@@ -21,6 +24,17 @@ describe('getThumbnailImage', () => {
     expect(getThumbnailImage(canvas2 as any)).toStrictEqual({
       url: 'https://iiif-test.wellcomecollection.org/thumbs/b2178081x_0002_0005.jp2/full/299%2C/0/default.jpg',
       width: 299,
+    });
+  });
+
+  it('finds a thumbnail image for a digitised PDF', () => {
+    // This is a PDF created with the new DLCS, which doesn't have an
+    // image service on PDF thumbnails.
+    // See https://github.com/wellcomecollection/wellcomecollection.org/issues/9727
+    const canvas = b28462270.items[0];
+    expect(getThumbnailImage(canvas as any)).toStrictEqual({
+      url: 'https://iiif-test.wellcomecollection.org/extensions/born-digital/placeholder-thumb/fmt/20/application/pdf',
+      width: 101,
     });
   });
 });

--- a/catalogue/webapp/utils/iiif/v3/canvas.ts
+++ b/catalogue/webapp/utils/iiif/v3/canvas.ts
@@ -1,10 +1,13 @@
 import { Canvas } from '@iiif/presentation-3';
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
 import { ThumbnailImage } from '@weco/catalogue/types/manifest';
+import { isNotUndefined } from '@weco/common/utils/type-guards';
 
 // Temporary type until iiif3 types are correct
 type Thumbnail = {
-  service: {
+  id: string;
+  width: number;
+  service?: {
     '@id': string;
     '@type': string;
     profile: string;
@@ -16,21 +19,43 @@ type Thumbnail = {
 
 export function getThumbnailImage(canvas: Canvas): ThumbnailImage | undefined {
   if (!canvas.thumbnail) return;
-  const thumbnail = canvas.thumbnail[0] as Thumbnail; // ContentResource which this should be, doesn't have a service property
-  const thumbnailService = Array.isArray(thumbnail.service)
-    ? thumbnail.service[0]
-    : thumbnail.service;
-  const urlTemplate = iiifImageTemplate(thumbnailService['@id']);
-  const preferredMinThumbnailHeight = 400;
-  const preferredThumbnail = thumbnailService?.sizes
-    ?.sort((a, b) => a.height - b.height)
-    .find(dimensions => dimensions.height >= preferredMinThumbnailHeight);
-  return (
-    urlTemplate && {
-      width: preferredThumbnail?.width || 30,
-      url: urlTemplate({
-        size: `${preferredThumbnail ? `${preferredThumbnail.width},` : 'max'}`,
-      }),
-    }
-  );
+
+  // The potential type here is extremely wide, but in practice we only
+  // see a couple of formats in our manifests:
+  //
+  //    - A thumbnail with an associated IIIF image service, which is used
+  //      for digitised books
+  //    - A thumbnail with type Image but no associated image service, which
+  //      is used for e.g. digitised PDFs
+  //
+  // We use our own type rather than trying to shoehorn this into the ContentResource
+  // type provided by the IIIF libraries.
+  //
+  // See the tests for examples of each of these.
+  const thumbnail = canvas.thumbnail[0] as Thumbnail;
+
+  if (isNotUndefined(thumbnail.service)) {
+    const thumbnailService = Array.isArray(thumbnail.service)
+      ? thumbnail.service[0]
+      : thumbnail.service;
+
+    const urlTemplate = iiifImageTemplate(thumbnailService['@id']);
+    const preferredMinThumbnailHeight = 400;
+    const preferredThumbnail = thumbnailService?.sizes
+      ?.sort((a, b) => a.height - b.height)
+      .find(dimensions => dimensions.height >= preferredMinThumbnailHeight);
+    return (
+      urlTemplate && {
+        width: preferredThumbnail?.width || 30,
+        url: urlTemplate({
+          size: preferredThumbnail ? `${preferredThumbnail.width},` : 'max',
+        }),
+      }
+    );
+  } else {
+    return {
+      width: thumbnail.width,
+      url: thumbnail.id,
+    };
+  }
 }

--- a/catalogue/webapp/utils/iiif/v3/canvas.ts
+++ b/catalogue/webapp/utils/iiif/v3/canvas.ts
@@ -44,14 +44,12 @@ export function getThumbnailImage(canvas: Canvas): ThumbnailImage | undefined {
     const preferredThumbnail = thumbnailService?.sizes
       ?.sort((a, b) => a.height - b.height)
       .find(dimensions => dimensions.height >= preferredMinThumbnailHeight);
-    return (
-      urlTemplate && {
-        width: preferredThumbnail?.width || 30,
-        url: urlTemplate({
-          size: preferredThumbnail ? `${preferredThumbnail.width},` : 'max',
-        }),
-      }
-    );
+    return {
+      width: preferredThumbnail?.width || 30,
+      url: urlTemplate({
+        size: preferredThumbnail ? `${preferredThumbnail.width},` : 'max',
+      }),
+    };
   } else {
     return {
       width: thumbnail.width,

--- a/catalogue/webapp/utils/iiif/v3/canvas.ts
+++ b/catalogue/webapp/utils/iiif/v3/canvas.ts
@@ -1,5 +1,6 @@
 import { Canvas } from '@iiif/presentation-3';
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
+import { ThumbnailImage } from '@weco/catalogue/types/manifest';
 
 // Temporary type until iiif3 types are correct
 type Thumbnail = {
@@ -13,12 +14,7 @@ type Thumbnail = {
   }[];
 };
 
-export function getThumbnailImage(canvas: Canvas):
-  | {
-      width: number;
-      url: string | undefined;
-    }
-  | undefined {
+export function getThumbnailImage(canvas: Canvas): ThumbnailImage | undefined {
   if (!canvas.thumbnail) return;
   const thumbnail = canvas.thumbnail[0] as Thumbnail; // ContentResource which this should be, doesn't have a service property
   const thumbnailService = Array.isArray(thumbnail.service)
@@ -29,12 +25,12 @@ export function getThumbnailImage(canvas: Canvas):
   const preferredThumbnail = thumbnailService?.sizes
     ?.sort((a, b) => a.height - b.height)
     .find(dimensions => dimensions.height >= preferredMinThumbnailHeight);
-  return {
-    width: preferredThumbnail?.width || 30,
-    url:
-      urlTemplate &&
-      urlTemplate({
+  return (
+    urlTemplate && {
+      width: preferredThumbnail?.width || 30,
+      url: urlTemplate({
         size: `${preferredThumbnail ? `${preferredThumbnail.width},` : 'max'}`,
       }),
-  };
+    }
+  );
 }


### PR DESCRIPTION
Follows #9728; for #9727.

Some context: there are two types of thumbnail in IIIF:

- a manifest thumbnail (for the whole thing, which we show on the works page)
- a canvas thumbnail (for an individual canvas, which we show on the grid viewer)

Before the DLCS upgrades:

- digitised images would have canvas thumbnails which were IIIF image services
- digitised PDFs wouldn't have any canvas thumbnails; they'd rely on the manifest thumbnail which was a picture of the first page. We were never showing PDFs in the grid viewer, so they didn't need thumbnails

We aren't showing PDFs in the grid viewer… yet… but they do now have thumbnails, as prep for born-digital. This thumbnail is just a static image, not a IIIF image, so they're throwing a client-side error. This patch updates `getThumbnailImage` to return this static image if it's all that's available.

This has no user-visible effect yet, but it suppresses a console warning and will be useful when we return to born-digital stuff later.