### PR TITLE
Reordered tabs quickfix mobile

### DIFF
--- a/playwright/test/concept.test.ts
+++ b/playwright/test/concept.test.ts
@@ -2,7 +2,10 @@ import { test as base, expect } from '@playwright/test';
 import { concept } from './contexts';
 import { baseUrl } from './helpers/urls';
 import { makeDefaultToggleCookies } from './helpers/utils';
-import { imagesByThisPerson, worksByThisPerson } from './selectors/concepts';
+import {
+  imagesAboutThisPerson,
+  worksAboutThisPerson,
+} from './selectors/concepts';
 import { ConceptPage } from './pages/concept';
 const domain = new URL(baseUrl).host;
 
@@ -73,6 +76,7 @@ test.describe('concepts @conceptPage', () => {
     // I've deliberately picked a complicated ID with commas here, to make sure
     // we're quoting the link to a filtered search.
     await concept(conceptIds['Stephens, Joanna'], context, page);
+    await page.click(worksAboutThisPerson);
 
     // Note: the `link-reset` class is added by ButtonSolid, and is a way to
     // make sure we find the "All Works" link, and not a link to an individual work.
@@ -95,8 +99,6 @@ test.describe('concepts @conceptPage', () => {
     // I've deliberately picked a complicated ID with commas here, to make sure
     // we're quoting the link to a filtered search.
     await concept(conceptIds['Stephens, Joanna'], context, page);
-
-    await page.click(worksByThisPerson);
 
     // Note: the `link-reset` class is added by ButtonSolid, and is a way to
     // make sure we find the "All Works" link, and not a link to an individual work.
@@ -130,6 +132,7 @@ test.describe('concepts @conceptPage', () => {
     // we're quoting the link to a filtered search.
     await concept(conceptIds['Darwin, Charles, 1809-1882'], context, page);
 
+    await page.click(imagesAboutThisPerson);
     // Note: the `link-reset` class is added by ButtonSolid, and is a way to
     // make sure we find the "All Works" link, and not a link to an individual work.
     const aboutThisPerson = await page.waitForSelector(
@@ -151,8 +154,6 @@ test.describe('concepts @conceptPage', () => {
     // I've deliberately picked a complicated ID with commas here, to make sure
     // we're quoting the link to a filtered search.
     await concept(conceptIds['Darwin, Charles, 1809-1882'], context, page);
-
-    await page.click(imagesByThisPerson);
 
     // Note: the `link-reset` class is added by ButtonSolid, and is a way to
     // make sure we find the "All Works" link, and not a link to an individual work.

--- a/playwright/test/concept.test.ts
+++ b/playwright/test/concept.test.ts
@@ -178,17 +178,6 @@ test.describe('genres with works and images both about and using @conceptPage @g
     await expect(songsPage.worksInTab).toBeVisible();
   });
 
-  test('the "works using" panel should be visible by default', async ({
-    songsPage,
-  }) => {
-    await expect(
-      await songsPage.tabPanelFor(songsPage.worksInTab)
-    ).toBeVisible();
-    await expect(
-      await songsPage.tabPanelFor(songsPage.worksAboutTab)
-    ).not.toBeVisible();
-  });
-
   test('the "All works" link filters by the concept label', async ({
     songsPage,
   }) => {

--- a/playwright/test/selectors/concepts.ts
+++ b/playwright/test/selectors/concepts.ts
@@ -1,5 +1,3 @@
 export const worksAboutThisPerson = 'css=button#tab-worksAbout';
-export const worksAboutThisSubject = 'css=button#tab-worksAbout';
 
 export const imagesAboutThisPerson = 'css=button#tab-imagesAbout';
-export const imagesAboutThisSubject = 'css=button#tab-imagesAbout';

--- a/playwright/test/selectors/concepts.ts
+++ b/playwright/test/selectors/concepts.ts
@@ -1,5 +1,5 @@
-export const worksByThisPerson = 'css=button#tab-worksBy';
-export const worksByThisSubject = 'css=button#tab-worksBy';
+export const worksAboutThisPerson = 'css=button#tab-worksAbout';
+export const worksAboutThisSubject = 'css=button#tab-worksAbout';
 
-export const imagesByThisPerson = 'css=button#tab-imagesBy';
-export const imagesByThisSubject = 'css=button#tab-imagesBy';
+export const imagesAboutThisPerson = 'css=button#tab-imagesAbout';
+export const imagesAboutThisSubject = 'css=button#tab-imagesAbout';


### PR DESCRIPTION
Get rid of the new test that is failing on mobile.

I've eyeballed it using test:debug:mobile, and it is working as I expected, so I don't know why it's failing.

It's a new test that I added this morning because I thought it might be neat to ensure that the expected default tabs are shown at startup, but I think this is essentially covered by the All Works link tests anyway.