### PR TITLE
Wrap state changes in tests in act()

### DIFF
--- a/identity/webapp/src/frontend/MyAccount/ChangeEmail.test.tsx
+++ b/identity/webapp/src/frontend/MyAccount/ChangeEmail.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ChangeEmail } from './ChangeEmail';
 import { ChangeDetailsModalContentProps } from './ChangeDetailsModal';
@@ -20,7 +20,7 @@ const defaultProps: ChangeDetailsModalContentProps = {
 const renderComponent = (props: Partial<ChangeDetailsModalContentProps> = {}) =>
   render(
     <ThemeProvider theme={theme}>
-      <UserProvider forceEnable={true}>
+      <UserProvider>
         <ChangeEmail {...defaultProps} {...props} />
       </UserProvider>
     </ThemeProvider>
@@ -45,8 +45,10 @@ describe('ChangeEmail', () => {
   it('allows the user to enter an email address', async () => {
     renderComponent();
     const emailAddressInput = await screen.findByLabelText(/email address/i);
-    userEvent.clear(emailAddressInput);
-    userEvent.type(emailAddressInput, 'clarkkent@dailybugle.com');
+    await act(async () => {
+      userEvent.clear(emailAddressInput);
+      userEvent.type(emailAddressInput, 'clarkkent@dailybugle.com');
+    });
     await waitFor(() =>
       expect(emailAddressInput).toHaveValue('clarkkent@dailybugle.com')
     );
@@ -57,7 +59,9 @@ describe('ChangeEmail', () => {
     const confirmPasswordInput = await screen.findByLabelText(
       /confirm password/i
     );
-    userEvent.type(confirmPasswordInput, 'Superman1938');
+    await act(async () => {
+      userEvent.type(confirmPasswordInput, 'Superman1938');
+    });
     await waitFor(() =>
       expect(confirmPasswordInput).toHaveValue('Superman1938')
     );
@@ -67,15 +71,17 @@ describe('ChangeEmail', () => {
     const onComplete = jest.fn();
     renderComponent({ onComplete });
     const emailAddressInput = await screen.findByLabelText(/email address/i);
-    await userEvent.clear(emailAddressInput);
-    await userEvent.type(emailAddressInput, 'clarkkent@dailybugle.com');
-    await userEvent.type(
-      screen.getByLabelText(/confirm password/i),
-      'Superman1938'
-    );
-    await userEvent.click(
-      screen.getByRole('button', { name: /update email/i })
-    );
+    await act(async () => {
+      await userEvent.clear(emailAddressInput);
+      await userEvent.type(emailAddressInput, 'clarkkent@dailybugle.com');
+      await userEvent.type(
+        screen.getByLabelText(/confirm password/i),
+        'Superman1938'
+      );
+      await userEvent.click(
+        screen.getByRole('button', { name: /update email/i })
+      );
+    });
     await waitFor(() =>
       expect(onComplete).toBeCalledWith(
         expect.objectContaining({
@@ -89,18 +95,20 @@ describe('ChangeEmail', () => {
   it('resets when modal closes', async () => {
     const { rerender } = renderComponent();
     const emailAddressInput = await screen.findByLabelText(/email address/i);
-    userEvent.clear(emailAddressInput);
-    userEvent.type(emailAddressInput, 'clarkkent@dailybugle.com');
+    await act(async () => {
+      userEvent.clear(emailAddressInput);
+      userEvent.type(emailAddressInput, 'clarkkent@dailybugle.com');
+    });
     rerender(
       <ThemeProvider theme={theme}>
-        <UserProvider forceEnable={true}>
+        <UserProvider>
           <ChangeEmail {...defaultProps} isActive={false} />
         </UserProvider>
       </ThemeProvider>
     );
     rerender(
       <ThemeProvider theme={theme}>
-        <UserProvider forceEnable={true}>
+        <UserProvider>
           <ChangeEmail {...defaultProps} isActive={true} />
         </UserProvider>
       </ThemeProvider>
@@ -111,15 +119,22 @@ describe('ChangeEmail', () => {
   describe('shows an error on submission', () => {
     it('with an empty email field', async () => {
       renderComponent();
-      await userEvent.clear(await screen.findByLabelText(/email address/i));
+      const emailAddressInput = await screen.findByLabelText(/email address/i);
+
+      await act(async () => {
+        await userEvent.clear(emailAddressInput);
+      });
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-      await userEvent.type(
-        screen.getByLabelText(/confirm password/i),
-        'Superman1938'
-      );
-      await userEvent.click(
-        screen.getByRole('button', { name: /update email/i })
-      );
+
+      await act(async () => {
+        await userEvent.type(
+          screen.getByLabelText(/confirm password/i),
+          'Superman1938'
+        );
+        await userEvent.click(
+          screen.getByRole('button', { name: /update email/i })
+        );
+      });
       expect(await screen.findByRole('alert')).toHaveTextContent(
         /enter a valid email address/i
       );
@@ -129,15 +144,19 @@ describe('ChangeEmail', () => {
       renderComponent();
       const emailAddressInput = await screen.findByLabelText(/email address/i);
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-      await userEvent.clear(emailAddressInput);
-      await userEvent.type(emailAddressInput, 'clarkkent.com'); // no @
-      await userEvent.type(
-        screen.getByLabelText(/confirm password/i),
-        'Superman1938'
-      );
-      await userEvent.click(
-        screen.getByRole('button', { name: /update email/i })
-      );
+
+      await act(async () => {
+        await userEvent.clear(emailAddressInput);
+        await userEvent.type(emailAddressInput, 'clarkkent.com'); // no @
+        await userEvent.type(
+          screen.getByLabelText(/confirm password/i),
+          'Superman1938'
+        );
+        await userEvent.click(
+          screen.getByRole('button', { name: /update email/i })
+        );
+      });
+
       expect(await screen.findByRole('alert')).toHaveTextContent(
         /enter a valid email address/i
       );
@@ -147,15 +166,19 @@ describe('ChangeEmail', () => {
       renderComponent();
       const emailAddressInput = await screen.findByLabelText(/email address/i);
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-      await userEvent.clear(emailAddressInput);
-      await userEvent.type(emailAddressInput, 'clarkkent@dailybugle'); // no dot
-      await userEvent.type(
-        screen.getByLabelText(/confirm password/i),
-        'Superman1938'
-      );
-      await userEvent.click(
-        screen.getByRole('button', { name: /update email/i })
-      );
+
+      await act(async () => {
+        await userEvent.clear(emailAddressInput);
+        await userEvent.type(emailAddressInput, 'clarkkent@dailybugle'); // no dot
+        await userEvent.type(
+          screen.getByLabelText(/confirm password/i),
+          'Superman1938'
+        );
+        await userEvent.click(
+          screen.getByRole('button', { name: /update email/i })
+        );
+      });
+
       expect(await screen.findByRole('alert')).toHaveTextContent(
         /enter a valid email address/i
       );
@@ -164,15 +187,19 @@ describe('ChangeEmail', () => {
     it("when the email hasn't changed", async () => {
       renderComponent();
       const emailAddressInput = await screen.findByLabelText(/email address/i);
-      await userEvent.type(emailAddressInput, mockUser.email);
-      await userEvent.type(
-        await screen.findByLabelText(/confirm password/i),
-        'Superman1938'
-      );
-      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-      await userEvent.click(
-        screen.getByRole('button', { name: /update email/i })
-      );
+
+      await act(async () => {
+        await userEvent.type(emailAddressInput, mockUser.email);
+        await userEvent.type(
+          await screen.findByLabelText(/confirm password/i),
+          'Superman1938'
+        );
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+        await userEvent.click(
+          screen.getByRole('button', { name: /update email/i })
+        );
+      });
+
       expect(await screen.findByRole('alert')).toHaveTextContent(
         /you must enter a new email address to update your library account/i
       );
@@ -182,15 +209,19 @@ describe('ChangeEmail', () => {
       renderComponent();
       const emailAddressInput = await screen.findByLabelText(/email address/i);
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-      await userEvent.clear(emailAddressInput);
-      await userEvent.type(emailAddressInput, mockUser.email);
-      await userEvent.type(
-        screen.getByLabelText(/confirm password/i),
-        'Superman1938'
-      );
-      await userEvent.click(
-        screen.getByRole('button', { name: /update email/i })
-      );
+
+      await act(async () => {
+        await userEvent.clear(emailAddressInput);
+        await userEvent.type(emailAddressInput, mockUser.email);
+        await userEvent.type(
+          screen.getByLabelText(/confirm password/i),
+          'Superman1938'
+        );
+        await userEvent.click(
+          screen.getByRole('button', { name: /update email/i })
+        );
+      });
+
       expect(await screen.findByRole('alert')).toHaveTextContent(
         /you must enter a new email address to update your library account/i
       );
@@ -200,11 +231,15 @@ describe('ChangeEmail', () => {
       renderComponent();
       const emailAddressInput = await screen.findByLabelText(/email address/i);
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-      await userEvent.clear(emailAddressInput);
-      await userEvent.type(emailAddressInput, 'clarkkent@dailybugle.com');
-      await userEvent.click(
-        screen.getByRole('button', { name: /update email/i })
-      );
+
+      await act(async () => {
+        await userEvent.clear(emailAddressInput);
+        await userEvent.type(emailAddressInput, 'clarkkent@dailybugle.com');
+        await userEvent.click(
+          screen.getByRole('button', { name: /update email/i })
+        );
+      });
+
       expect(await screen.findByRole('alert')).toHaveTextContent(
         /enter your password/i
       );
@@ -221,15 +256,18 @@ describe('ChangeEmail', () => {
       renderComponent();
       const emailAddressInput = await screen.findByLabelText(/email address/i);
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-      await userEvent.clear(emailAddressInput);
-      await userEvent.type(emailAddressInput, 'clarkkent@dailybugle.com');
-      await userEvent.type(
-        screen.getByLabelText(/confirm password/i),
-        'Superman1938'
-      );
-      await userEvent.click(
-        screen.getByRole('button', { name: /update email/i })
-      );
+      await act(async () => {
+        await userEvent.clear(emailAddressInput);
+        await userEvent.type(emailAddressInput, 'clarkkent@dailybugle.com');
+        await userEvent.type(
+          screen.getByLabelText(/confirm password/i),
+          'Superman1938'
+        );
+        await userEvent.click(
+          screen.getByRole('button', { name: /update email/i })
+        );
+      });
+
       expect(await screen.findByRole('alert')).toHaveTextContent(
         /incorrect password/i
       );
@@ -244,15 +282,19 @@ describe('ChangeEmail', () => {
       renderComponent();
       const emailAddressInput = await screen.findByLabelText(/email address/i);
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-      await userEvent.clear(emailAddressInput);
-      await userEvent.type(emailAddressInput, 'clarkkent@dailybugle.com');
-      await userEvent.type(
-        screen.getByLabelText(/confirm password/i),
-        'Superman1938'
-      );
-      await userEvent.click(
-        screen.getByRole('button', { name: /update email/i })
-      );
+
+      await act(async () => {
+        await userEvent.clear(emailAddressInput);
+        await userEvent.type(emailAddressInput, 'clarkkent@dailybugle.com');
+        await userEvent.type(
+          screen.getByLabelText(/confirm password/i),
+          'Superman1938'
+        );
+        await userEvent.click(
+          screen.getByRole('button', { name: /update email/i })
+        );
+      });
+
       expect(await screen.findByRole('alert')).toHaveTextContent(
         /your account has been blocked/i
       );
@@ -267,15 +309,19 @@ describe('ChangeEmail', () => {
       renderComponent();
       const emailAddressInput = await screen.findByLabelText(/email address/i);
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-      await userEvent.clear(emailAddressInput);
-      await userEvent.type(emailAddressInput, 'clarkkent@dailybugle.com');
-      await userEvent.type(
-        screen.getByLabelText(/confirm password/i),
-        'Superman1938'
-      );
-      await userEvent.click(
-        screen.getByRole('button', { name: /update email/i })
-      );
+
+      await act(async () => {
+        await userEvent.clear(emailAddressInput);
+        await userEvent.type(emailAddressInput, 'clarkkent@dailybugle.com');
+        await userEvent.type(
+          screen.getByLabelText(/confirm password/i),
+          'Superman1938'
+        );
+        await userEvent.click(
+          screen.getByRole('button', { name: /update email/i })
+        );
+      });
+
       expect(await screen.findByRole('alert')).toHaveTextContent(
         /email address already in use/i
       );
@@ -290,15 +336,19 @@ describe('ChangeEmail', () => {
       renderComponent();
       const emailAddressInput = await screen.findByLabelText(/email address/i);
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-      await userEvent.clear(emailAddressInput);
-      await userEvent.type(emailAddressInput, 'clarkkent@dailybugle.com');
-      await userEvent.type(
-        screen.getByLabelText(/confirm password/i),
-        'Superman1938'
-      );
-      await userEvent.click(
-        screen.getByRole('button', { name: /update email/i })
-      );
+
+      await act(async () => {
+        await userEvent.clear(emailAddressInput);
+        await userEvent.type(emailAddressInput, 'clarkkent@dailybugle.com');
+        await userEvent.type(
+          screen.getByLabelText(/confirm password/i),
+          'Superman1938'
+        );
+        await userEvent.click(
+          screen.getByRole('button', { name: /update email/i })
+        );
+      });
+
       expect(await screen.findByRole('alert')).toHaveTextContent(
         /an unknown error occurred/i
       );

--- a/identity/webapp/src/frontend/MyAccount/ChangePassword.test.tsx
+++ b/identity/webapp/src/frontend/MyAccount/ChangePassword.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ChangePassword } from './ChangePassword';
 import { ThemeProvider } from 'styled-components';
@@ -33,14 +33,18 @@ describe('ChangePassword', () => {
   it('allows the user to enter their current password', async () => {
     renderComponent();
     const currentPasswordInput = screen.getByLabelText(/current password/i);
-    await userEvent.type(currentPasswordInput, 'hunter2');
+    await act(async () => {
+      await userEvent.type(currentPasswordInput, 'hunter2');
+    });
     expect(currentPasswordInput).toHaveValue('hunter2');
   });
 
   it('allows the user to enter a new password', async () => {
     renderComponent();
     const newPasswordInput = screen.getByLabelText(/^create new password/i);
-    await userEvent.type(newPasswordInput, 'hunter2');
+    await act(async () => {
+      await userEvent.type(newPasswordInput, 'hunter2');
+    });
     expect(newPasswordInput).toHaveValue('hunter2');
   });
 
@@ -49,25 +53,34 @@ describe('ChangePassword', () => {
     const confirmPasswordInput = screen.getByLabelText(
       /re-enter new password/i
     );
-    await userEvent.type(confirmPasswordInput, 'hunter2');
+    await act(async () => {
+      await userEvent.type(confirmPasswordInput, 'hunter2');
+    });
     expect(confirmPasswordInput).toHaveValue('hunter2');
   });
 
   it('submits a complete and valid form to the API', async () => {
     const onComplete = jest.fn();
     renderComponent({ onComplete });
-    await userEvent.type(screen.getByLabelText(/current password/i), 'hunter2');
-    await userEvent.type(
-      screen.getByLabelText(/^create new password/i),
-      'Superman1938'
-    );
-    await userEvent.type(
-      screen.getByLabelText(/re-enter new password/i),
-      'Superman1938'
-    );
-    await userEvent.click(
-      screen.getByRole('button', { name: /update password/i })
-    );
+
+    await act(async () => {
+      await userEvent.type(
+        screen.getByLabelText(/current password/i),
+        'hunter2'
+      );
+      await userEvent.type(
+        screen.getByLabelText(/^create new password/i),
+        'Superman1938'
+      );
+      await userEvent.type(
+        screen.getByLabelText(/re-enter new password/i),
+        'Superman1938'
+      );
+      await userEvent.click(
+        screen.getByRole('button', { name: /update password/i })
+      );
+    });
+
     await waitFor(() => expect(onComplete).toBeCalled());
   });
 
@@ -78,9 +91,13 @@ describe('ChangePassword', () => {
     const confirmPasswordInput = screen.getByLabelText(
       /re-enter new password/i
     );
-    userEvent.type(currentPasswordInput, 'hunter2');
-    userEvent.type(newPasswordInput, 'Superman1938');
-    userEvent.type(confirmPasswordInput, 'Superman1938');
+
+    await act(async () => {
+      userEvent.type(currentPasswordInput, 'hunter2');
+      userEvent.type(newPasswordInput, 'Superman1938');
+      userEvent.type(confirmPasswordInput, 'Superman1938');
+    });
+
     rerender(
       <ThemeProvider theme={theme}>
         <ChangePassword {...defaultProps} isActive={false} />
@@ -100,17 +117,21 @@ describe('ChangePassword', () => {
     it('with an empty current password field', async () => {
       renderComponent();
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-      await userEvent.type(
-        screen.getByLabelText(/^create new password/i),
-        'Superman1938'
-      );
-      await userEvent.type(
-        screen.getByLabelText(/re-enter new password/i),
-        'Superman1938'
-      );
-      await userEvent.click(
-        screen.getByRole('button', { name: /update password/i })
-      );
+
+      await act(async () => {
+        await userEvent.type(
+          screen.getByLabelText(/^create new password/i),
+          'Superman1938'
+        );
+        await userEvent.type(
+          screen.getByLabelText(/re-enter new password/i),
+          'Superman1938'
+        );
+        await userEvent.click(
+          screen.getByRole('button', { name: /update password/i })
+        );
+      });
+
       const nodes = await screen.findAllByRole('alert');
       expect(nodes[0]).toHaveTextContent(/enter your current password/i);
     });
@@ -118,17 +139,21 @@ describe('ChangePassword', () => {
     it('with an empty new password field', async () => {
       renderComponent();
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-      await userEvent.type(
-        screen.getByLabelText(/current password/i),
-        'hunter2'
-      );
-      await userEvent.type(
-        screen.getByLabelText(/re-enter new password/i),
-        'Superman1938'
-      );
-      await userEvent.click(
-        screen.getByRole('button', { name: /update password/i })
-      );
+
+      await act(async () => {
+        await userEvent.type(
+          screen.getByLabelText(/current password/i),
+          'hunter2'
+        );
+        await userEvent.type(
+          screen.getByLabelText(/re-enter new password/i),
+          'Superman1938'
+        );
+        await userEvent.click(
+          screen.getByRole('button', { name: /update password/i })
+        );
+      });
+
       expect(await screen.findByRole('alert')).toHaveTextContent(
         /enter your new password/i
       );
@@ -137,21 +162,25 @@ describe('ChangePassword', () => {
     it('with an invalid new password field', async () => {
       renderComponent();
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-      await userEvent.type(
-        screen.getByLabelText(/current password/i),
-        'hunter2'
-      );
-      await userEvent.type(
-        screen.getByLabelText(/^create new password/i),
-        'superman'
-      );
-      await userEvent.type(
-        screen.getByLabelText(/re-enter new password/i),
-        'Superman2021'
-      );
-      await userEvent.click(
-        screen.getByRole('button', { name: /update password/i })
-      );
+
+      await act(async () => {
+        await userEvent.type(
+          screen.getByLabelText(/current password/i),
+          'hunter2'
+        );
+        await userEvent.type(
+          screen.getByLabelText(/^create new password/i),
+          'superman'
+        );
+        await userEvent.type(
+          screen.getByLabelText(/re-enter new password/i),
+          'Superman2021'
+        );
+        await userEvent.click(
+          screen.getByRole('button', { name: /update password/i })
+        );
+      });
+
       expect(await screen.findByRole('alert')).toHaveTextContent(
         /enter a valid password/i
       );
@@ -160,17 +189,21 @@ describe('ChangePassword', () => {
     it('with an empty confirmation field', async () => {
       renderComponent();
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-      await userEvent.type(
-        screen.getByLabelText(/current password/i),
-        'hunter2'
-      );
-      await userEvent.type(
-        screen.getByLabelText(/^create new password/i),
-        'Superman1938'
-      );
-      await userEvent.click(
-        screen.getByRole('button', { name: /update password/i })
-      );
+
+      await act(async () => {
+        await userEvent.type(
+          screen.getByLabelText(/current password/i),
+          'hunter2'
+        );
+        await userEvent.type(
+          screen.getByLabelText(/^create new password/i),
+          'Superman1938'
+        );
+        await userEvent.click(
+          screen.getByRole('button', { name: /update password/i })
+        );
+      });
+
       expect(await screen.findByRole('alert')).toHaveTextContent(
         /confirm your new password/i
       );
@@ -179,21 +212,26 @@ describe('ChangePassword', () => {
     it('when the new password is too short', async () => {
       renderComponent();
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-      await userEvent.type(
-        screen.getByLabelText(/current password/i),
-        'hunter2'
-      );
-      await userEvent.type(
-        screen.getByLabelText(/^create new password/i),
-        'Supes1'
-      );
-      await userEvent.type(
-        screen.getByLabelText(/re-enter new password/i),
-        'Supes1'
-      );
-      await userEvent.click(
-        screen.getByRole('button', { name: /update password/i })
-      );
+
+      await act(async () => {
+        await userEvent.type(
+          screen.getByLabelText(/current password/i),
+          'hunter2'
+        );
+        await userEvent.type(
+          screen.getByLabelText(/^create new password/i),
+          'Supes1'
+        );
+        await userEvent.type(
+          screen.getByLabelText(/re-enter new password/i),
+          'Supes1'
+        );
+
+        await userEvent.click(
+          screen.getByRole('button', { name: /update password/i })
+        );
+      });
+
       expect(await screen.findByRole('alert')).toHaveTextContent(
         /enter a valid password/i
       );
@@ -202,21 +240,26 @@ describe('ChangePassword', () => {
     it('when the new password is missing a capital letter', async () => {
       renderComponent();
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-      await userEvent.type(
-        screen.getByLabelText(/current password/i),
-        'hunter2'
-      );
-      await userEvent.type(
-        screen.getByLabelText(/^create new password/i),
-        'superman1'
-      );
-      await userEvent.type(
-        screen.getByLabelText(/re-enter new password/i),
-        'superman1'
-      );
-      await userEvent.click(
-        screen.getByRole('button', { name: /update password/i })
-      );
+
+      await act(async () => {
+        await userEvent.type(
+          screen.getByLabelText(/current password/i),
+          'hunter2'
+        );
+        await userEvent.type(
+          screen.getByLabelText(/^create new password/i),
+          'superman1'
+        );
+        await userEvent.type(
+          screen.getByLabelText(/re-enter new password/i),
+          'superman1'
+        );
+
+        await userEvent.click(
+          screen.getByRole('button', { name: /update password/i })
+        );
+      });
+
       expect(await screen.findByRole('alert')).toHaveTextContent(
         /enter a valid password/i
       );
@@ -225,21 +268,26 @@ describe('ChangePassword', () => {
     it('when the new password is missing a small letter', async () => {
       renderComponent();
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-      await userEvent.type(
-        screen.getByLabelText(/current password/i),
-        'hunter2'
-      );
-      await userEvent.type(
-        screen.getByLabelText(/^create new password/i),
-        'SUPERMAN1'
-      );
-      await userEvent.type(
-        screen.getByLabelText(/re-enter new password/i),
-        'SUPERMAN1'
-      );
-      await userEvent.click(
-        screen.getByRole('button', { name: /update password/i })
-      );
+
+      await act(async () => {
+        await userEvent.type(
+          screen.getByLabelText(/current password/i),
+          'hunter2'
+        );
+        await userEvent.type(
+          screen.getByLabelText(/^create new password/i),
+          'SUPERMAN1'
+        );
+        await userEvent.type(
+          screen.getByLabelText(/re-enter new password/i),
+          'SUPERMAN1'
+        );
+
+        await userEvent.click(
+          screen.getByRole('button', { name: /update password/i })
+        );
+      });
+
       expect(await screen.findByRole('alert')).toHaveTextContent(
         /enter a valid password/i
       );
@@ -248,21 +296,26 @@ describe('ChangePassword', () => {
     it('when the new password is missing a number', async () => {
       renderComponent();
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-      await userEvent.type(
-        screen.getByLabelText(/current password/i),
-        'hunter2'
-      );
-      await userEvent.type(
-        screen.getByLabelText(/^create new password/i),
-        'Superman'
-      );
-      await userEvent.type(
-        screen.getByLabelText(/re-enter new password/i),
-        'Superman'
-      );
-      await userEvent.click(
-        screen.getByRole('button', { name: /update password/i })
-      );
+
+      await act(async () => {
+        await userEvent.type(
+          screen.getByLabelText(/current password/i),
+          'hunter2'
+        );
+        await userEvent.type(
+          screen.getByLabelText(/^create new password/i),
+          'Superman'
+        );
+        await userEvent.type(
+          screen.getByLabelText(/re-enter new password/i),
+          'Superman'
+        );
+
+        await userEvent.click(
+          screen.getByRole('button', { name: /update password/i })
+        );
+      });
+
       expect(await screen.findByRole('alert')).toHaveTextContent(
         /enter a valid password/i
       );
@@ -271,21 +324,26 @@ describe('ChangePassword', () => {
     it('when the new password does not match the confirmation', async () => {
       renderComponent();
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-      await userEvent.type(
-        screen.getByLabelText(/current password/i),
-        'hunter2'
-      );
-      await userEvent.type(
-        screen.getByLabelText(/^create new password/i),
-        'Superman1938'
-      );
-      await userEvent.type(
-        screen.getByLabelText(/re-enter new password/i),
-        'Superman2021'
-      );
-      await userEvent.click(
-        screen.getByRole('button', { name: /update password/i })
-      );
+
+      await act(async () => {
+        await userEvent.type(
+          screen.getByLabelText(/current password/i),
+          'hunter2'
+        );
+        await userEvent.type(
+          screen.getByLabelText(/^create new password/i),
+          'Superman1938'
+        );
+        await userEvent.type(
+          screen.getByLabelText(/re-enter new password/i),
+          'Superman2021'
+        );
+
+        await userEvent.click(
+          screen.getByRole('button', { name: /update password/i })
+        );
+      });
+
       expect(await screen.findByRole('alert')).toHaveTextContent(
         /passwords do not match/i
       );
@@ -301,21 +359,25 @@ describe('ChangePassword', () => {
       );
       renderComponent();
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-      await userEvent.type(
-        screen.getByLabelText(/current password/i),
-        'hunter2'
-      );
-      await userEvent.type(
-        screen.getByLabelText(/^create new password/i),
-        'Superman1938'
-      );
-      await userEvent.type(
-        screen.getByLabelText(/re-enter new password/i),
-        'Superman1938'
-      );
-      await userEvent.click(
-        screen.getByRole('button', { name: /update password/i })
-      );
+
+      await act(async () => {
+        await userEvent.type(
+          screen.getByLabelText(/current password/i),
+          'hunter2'
+        );
+        await userEvent.type(
+          screen.getByLabelText(/^create new password/i),
+          'Superman1938'
+        );
+        await userEvent.type(
+          screen.getByLabelText(/re-enter new password/i),
+          'Superman1938'
+        );
+        await userEvent.click(
+          screen.getByRole('button', { name: /update password/i })
+        );
+      });
+
       expect(await screen.findByRole('alert')).toHaveTextContent(
         /incorrect password/i
       );
@@ -330,21 +392,25 @@ describe('ChangePassword', () => {
       renderComponent();
 
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-      await userEvent.type(
-        screen.getByLabelText(/current password/i),
-        'hunter2'
-      );
-      await userEvent.type(
-        screen.getByLabelText(/^create new password/i),
-        'Superman1938'
-      );
-      await userEvent.type(
-        screen.getByLabelText(/re-enter new password/i),
-        'Superman1938'
-      );
-      await userEvent.click(
-        screen.getByRole('button', { name: /update password/i })
-      );
+
+      await act(async () => {
+        await userEvent.type(
+          screen.getByLabelText(/current password/i),
+          'hunter2'
+        );
+        await userEvent.type(
+          screen.getByLabelText(/^create new password/i),
+          'Superman1938'
+        );
+        await userEvent.type(
+          screen.getByLabelText(/re-enter new password/i),
+          'Superman1938'
+        );
+        await userEvent.click(
+          screen.getByRole('button', { name: /update password/i })
+        );
+      });
+
       expect(await screen.findByRole('alert')).toHaveTextContent(
         /your account has been blocked/i
       );
@@ -358,21 +424,25 @@ describe('ChangePassword', () => {
       );
       renderComponent();
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-      await userEvent.type(
-        screen.getByLabelText(/current password/i),
-        'hunter2'
-      );
-      await userEvent.type(
-        screen.getByLabelText(/^create new password/i),
-        'Superman1938'
-      );
-      await userEvent.type(
-        screen.getByLabelText(/re-enter new password/i),
-        'Superman1938'
-      );
-      await userEvent.click(
-        screen.getByRole('button', { name: /update password/i })
-      );
+
+      await act(async () => {
+        await userEvent.type(
+          screen.getByLabelText(/current password/i),
+          'hunter2'
+        );
+        await userEvent.type(
+          screen.getByLabelText(/^create new password/i),
+          'Superman1938'
+        );
+        await userEvent.type(
+          screen.getByLabelText(/re-enter new password/i),
+          'Superman1938'
+        );
+        await userEvent.click(
+          screen.getByRole('button', { name: /update password/i })
+        );
+      });
+
       expect(await screen.findByRole('alert')).toHaveTextContent(
         /password does not meet the policy/i
       );
@@ -386,21 +456,25 @@ describe('ChangePassword', () => {
       );
       renderComponent();
       expect(await screen.queryByRole('alert')).not.toBeInTheDocument();
-      await userEvent.type(
-        await screen.getByLabelText(/current password/i),
-        'hunter2'
-      );
-      await userEvent.type(
-        await screen.getByLabelText(/^create new password/i),
-        'Superman1938'
-      );
-      await userEvent.type(
-        await screen.getByLabelText(/re-enter new password/i),
-        'Superman1938'
-      );
-      await userEvent.click(
-        await screen.getByRole('button', { name: /update password/i })
-      );
+
+      await act(async () => {
+        await userEvent.type(
+          await screen.getByLabelText(/current password/i),
+          'hunter2'
+        );
+        await userEvent.type(
+          await screen.getByLabelText(/^create new password/i),
+          'Superman1938'
+        );
+        await userEvent.type(
+          await screen.getByLabelText(/re-enter new password/i),
+          'Superman1938'
+        );
+        await userEvent.click(
+          await screen.getByRole('button', { name: /update password/i })
+        );
+      });
+
       expect(await screen.findByRole('alert')).toHaveTextContent(
         'There is an issue with this library account password. To resolve this, please contact Library Enquiries (library@wellcomecollection.org).'
       );

--- a/identity/webapp/src/frontend/MyAccount/DeleteAccount.test.tsx
+++ b/identity/webapp/src/frontend/MyAccount/DeleteAccount.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { DeleteAccount } from './DeleteAccount';
 import { ThemeProvider } from 'styled-components';
@@ -33,33 +33,44 @@ describe('DeleteAccount', () => {
   it('allows the user to enter their password', async () => {
     renderComponent();
     const currentPasswordInput = screen.getByLabelText(/^password$/i);
-    await userEvent.type(currentPasswordInput, 'hunter2');
+    await act(async () => {
+      await userEvent.type(currentPasswordInput, 'hunter2');
+    });
     expect(currentPasswordInput).toHaveValue('hunter2');
   });
 
   it('allows the user to request account deletion after confirming their password', async () => {
     const onComplete = jest.fn();
     renderComponent({ onComplete });
-    await userEvent.type(screen.getByLabelText(/^password$/i), 'hunter2');
-    await userEvent.click(
-      screen.getByRole('button', { name: /yes, delete my account/i })
-    );
+    await act(async () => {
+      await userEvent.type(screen.getByLabelText(/^password$/i), 'hunter2');
+      await userEvent.click(
+        screen.getByRole('button', { name: /yes, delete my account/i })
+      );
+    });
     await waitFor(() => expect(onComplete).toBeCalled());
   });
 
   it('allows the user to cancel the operation', async () => {
     const onCancel = jest.fn();
     renderComponent({ onCancel });
+
     await userEvent.click(
-      screen.getByRole('link', { name: /no, go back to my account/i })
+      screen.getByRole('link', {
+        name: /no, go back to my account/i,
+      })
     );
+
     expect(onCancel).toHaveBeenCalled();
   });
 
   it('resets when modal closes', async () => {
     const { rerender } = renderComponent();
     const passwordInput = screen.getByLabelText(/^password$/i);
-    await userEvent.type(passwordInput, 'hunter2');
+    await act(async () => {
+      await userEvent.type(passwordInput, 'hunter2');
+    });
+
     rerender(
       <ThemeProvider theme={theme}>
         <DeleteAccount {...defaultProps} isActive={false} />
@@ -70,6 +81,7 @@ describe('DeleteAccount', () => {
         <DeleteAccount {...defaultProps} isActive={true} />
       </ThemeProvider>
     );
+
     expect(passwordInput).toHaveValue('');
   });
 
@@ -77,9 +89,13 @@ describe('DeleteAccount', () => {
     it('with an empty current password field', async () => {
       renderComponent();
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-      await userEvent.click(
-        screen.getByRole('button', { name: /yes, delete my account/i })
-      );
+
+      await act(async () => {
+        await userEvent.click(
+          screen.getByRole('button', { name: /yes, delete my account/i })
+        );
+      });
+
       expect(await screen.findByRole('alert')).toHaveTextContent(
         /enter your current password/i
       );
@@ -95,10 +111,14 @@ describe('DeleteAccount', () => {
       );
       renderComponent();
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-      await userEvent.type(screen.getByLabelText(/^password$/i), 'hunter2');
-      await userEvent.click(
-        screen.getByRole('button', { name: /yes, delete my account/i })
-      );
+
+      await act(async () => {
+        await userEvent.type(screen.getByLabelText(/^password$/i), 'hunter2');
+        await userEvent.click(
+          screen.getByRole('button', { name: /yes, delete my account/i })
+        );
+      });
+
       expect(await screen.findByRole('alert')).toHaveTextContent(
         /incorrect password/i
       );
@@ -112,10 +132,14 @@ describe('DeleteAccount', () => {
       );
       renderComponent();
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-      await userEvent.type(screen.getByLabelText(/^password$/i), 'hunter2');
-      await userEvent.click(
-        screen.getByRole('button', { name: /yes, delete my account/i })
-      );
+
+      await act(async () => {
+        await userEvent.type(screen.getByLabelText(/^password$/i), 'hunter2');
+        await userEvent.click(
+          screen.getByRole('button', { name: /yes, delete my account/i })
+        );
+      });
+
       expect(await screen.findByRole('alert')).toHaveTextContent(
         /your account has been blocked/i
       );
@@ -129,10 +153,14 @@ describe('DeleteAccount', () => {
       );
       renderComponent();
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-      await userEvent.type(screen.getByLabelText(/^password$/i), 'hunter2');
-      await userEvent.click(
-        screen.getByRole('button', { name: /yes, delete my account/i })
-      );
+
+      await act(async () => {
+        await userEvent.type(screen.getByLabelText(/^password$/i), 'hunter2');
+        await userEvent.click(
+          screen.getByRole('button', { name: /yes, delete my account/i })
+        );
+      });
+
       expect(await screen.findByRole('alert')).toHaveTextContent(
         /an unknown error occurred/i
       );

--- a/identity/webapp/src/frontend/MyAccount/MyAccount.test.tsx
+++ b/identity/webapp/src/frontend/MyAccount/MyAccount.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import AccountPage from '../../../pages';
 import {
   mockAuth0Profile,
@@ -46,7 +46,7 @@ jest.mock('next/router', () => require('next-router-mock'));
 const renderComponent = (user = mockAuth0Profile) =>
   render(
     <ThemeProvider theme={theme}>
-      <UserProvider forceEnable={true}>
+      <UserProvider>
         <AccountPage user={user} serverData={{} as ServerData} />
       </UserProvider>
     </ThemeProvider>
@@ -167,13 +167,18 @@ describe('MyAccount', () => {
     const changeEmailButton = await screen.findByRole('button', {
       name: /change email/i,
     });
-    await userEvent.click(changeEmailButton);
+    await act(async () => {
+      await userEvent.click(changeEmailButton);
+    });
 
     const emailInput = await screen.findByLabelText(/email address/i);
     const passwordConfirmInput = screen.getByLabelText(/confirm password/i);
-    await userEvent.clear(emailInput);
-    await userEvent.type(emailInput, 'clarkkent@dailybugle.com');
-    await userEvent.type(passwordConfirmInput, 'Superman1938');
+
+    await act(async () => {
+      await userEvent.clear(emailInput);
+      await userEvent.type(emailInput, 'clarkkent@dailybugle.com');
+      await userEvent.type(passwordConfirmInput, 'Superman1938');
+    });
 
     await waitFor(() => {
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
@@ -182,7 +187,9 @@ describe('MyAccount', () => {
     const updateEmailButton = screen.getByRole('button', {
       name: /update email/i,
     });
-    await userEvent.click(updateEmailButton);
+    await act(async () => {
+      await userEvent.click(updateEmailButton);
+    });
 
     expect(await screen.findByRole('alert')).toHaveTextContent(
       /email updated/i
@@ -195,16 +202,21 @@ describe('MyAccount', () => {
     const changePasswordButton = await screen.findByRole('button', {
       name: /Change password/,
     });
-    await userEvent.click(changePasswordButton);
+    await act(async () => {
+      await userEvent.click(changePasswordButton);
+    });
 
     const currentPasswordInput = screen.getByLabelText(/current password/i);
     const newPasswordInput = screen.getByLabelText(/^create new password/i);
     const confirmPasswordInput = screen.getByLabelText(
       /re-enter new password/i
     );
-    await userEvent.type(currentPasswordInput, 'hunter2');
-    await userEvent.type(newPasswordInput, 'Superman1938');
-    await userEvent.type(confirmPasswordInput, 'Superman1938');
+
+    await act(async () => {
+      await userEvent.type(currentPasswordInput, 'hunter2');
+      await userEvent.type(newPasswordInput, 'Superman1938');
+      await userEvent.type(confirmPasswordInput, 'Superman1938');
+    });
 
     await waitFor(() => {
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
@@ -213,7 +225,9 @@ describe('MyAccount', () => {
     const updatePasswordButton = screen.getByRole('button', {
       name: /update password/i,
     });
-    await userEvent.click(updatePasswordButton);
+    await act(async () => {
+      await userEvent.click(updatePasswordButton);
+    });
 
     expect(await screen.findByRole('alert')).toHaveTextContent(
       /password updated/i
@@ -230,14 +244,18 @@ describe('MyAccount', () => {
     const requestDeletionButton = await screen.findByRole('button', {
       name: /cancel your membership/i,
     });
-    await userEvent.click(requestDeletionButton);
+    await act(async () => {
+      await userEvent.click(requestDeletionButton);
+    });
 
     expect(
       await screen.findByRole('button', { name: /yes, delete my account/i })
     ).toBeInTheDocument();
 
     const closeButton = screen.getByRole('button', { name: /close/i });
-    await userEvent.click(closeButton);
+    await act(async () => {
+      await userEvent.click(closeButton);
+    });
 
     await waitFor(() => {
       expect(

--- a/identity/webapp/src/frontend/components/PasswordInput/PasswordInput.test.tsx
+++ b/identity/webapp/src/frontend/components/PasswordInput/PasswordInput.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { ThemeProvider } from 'styled-components';
 import theme from '@weco/common/views/themes/default';
 
@@ -42,7 +42,11 @@ describe('PasswordInput', () => {
   it('lets a user enter a password', async () => {
     renderComponent();
     const input = screen.getByLabelText(/^password$/i);
-    await userEvent.type(input, 'hunter2');
+
+    await act(async () => {
+      await userEvent.type(input, 'hunter2');
+    });
+
     expect(input).toHaveValue('hunter2');
   });
 
@@ -50,13 +54,19 @@ describe('PasswordInput', () => {
     renderComponent();
     const input = screen.getByLabelText(/^password$/i);
     expect(input).toHaveAttribute('type', 'password');
-    await userEvent.click(
-      screen.getByRole('button', { name: /show password/i })
-    );
+
+    await act(async () => {
+      await userEvent.click(
+        screen.getByRole('button', { name: /show password/i })
+      );
+    });
     expect(input).toHaveAttribute('type', 'text');
-    await userEvent.click(
-      screen.getByRole('button', { name: /hide password/i })
-    );
+
+    await act(async () => {
+      await userEvent.click(
+        screen.getByRole('button', { name: /hide password/i })
+      );
+    });
     expect(input).toHaveAttribute('type', 'password');
   });
 });


### PR DESCRIPTION
## Who is this for?
Devs and tests

## What is it doing for them?
Noticed `identity` tests[ were logging a lot of errors like](https://buildkite.com/wellcomecollection/wc-dot-org-build-plus-test/builds/11156#0187e751-c8e4-44dd-a4eb-9beea4d0e50b);

```
 Warning: An update to PasswordInput inside a test was not wrapped in act(...).

      When testing, code that causes React state updates should be wrapped into act(...):

      act(() => {
        /* fire events that update state */
      });
      /* assert on the output */

      This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
```

which 1) makes it hard to follow what's happening and 2) [wrapping in `act` ensures test behave closer to a browser](https://legacy.reactjs.org/docs/testing-recipes.html#act) when the state is being changed, so I went around tests and fixed it. It seems it could have to do with upgrading to React 18, although no other tests log this (but I think `identity` uses `render()` regularly, which might be why)


I'm aware there's an error left, which was there before and has to do with navigation not being allowed. The test passes and does it's job, but might want to look at it separately.

```
   Error: Not implemented: navigation (except hash changes)
        at module.exports (/Users/cantinr/Projects/wellcomecollection.org/node_modules/jsdom/lib/jsdom/browser/not-implemented.js:9:17)
        at navigateFetch (/Users/cantinr/Projects/wellcomecollection.org/node_modules/jsdom/lib/jsdom/living/window/navigation.js:77:3)
        at exports.navigate (/Users/cantinr/Projects/wellcomecollection.org/node_modules/jsdom/lib/jsdom/living/window/navigation.js:55:3)
        at Timeout._onTimeout (/Users/cantinr/Projects/wellcomecollection.org/node_modules/jsdom/lib/jsdom/living/nodes/HTMLHyperlinkElementUtils-impl.js:81:7)
        at listOnTimeout (node:internal/timers:559:17)
        at processTimers (node:internal/timers:502:7) {
      type: 'not implemented'
    }
```

Plus, it seems to make the tests run 16s faster 🤷‍♀️ 