### PR TITLE
This should return parsed JSON, not the literal string

### DIFF
--- a/content/webapp/services/prismic/fetch/index.ts
+++ b/content/webapp/services/prismic/fetch/index.ts
@@ -157,7 +157,7 @@ export function clientSideFetcher<TransformedDocument>(endpoint: string) {
       const response = await fetch(url);
 
       if (response.ok) {
-        const json = await response.text();
+        const json = await response.json();
         return deserialiseJsonDates(json);
       }
     },


### PR DESCRIPTION
We have failing e2e tests because when somebody calls this client-side fetcher, the component is being given the literal JSON string instead of the parsed JSON object – previously we passed the string into a superjson call, which would parse it into an object, but now we need to do that ourselves.