### PR TITLE
Use a vanilla bit of React state in SegmentedControl; fix events on What's On

### DIFF
--- a/common/views/components/SegmentedControl/SegmentedControl.tsx
+++ b/common/views/components/SegmentedControl/SegmentedControl.tsx
@@ -1,10 +1,4 @@
-import {
-  Fragment,
-  FunctionComponent,
-  useState,
-  useEffect,
-  useContext,
-} from 'react';
+import { Fragment, FunctionComponent, useState, useContext } from 'react';
 import { chevron, cross } from '@weco/common/icons';
 import { classNames, font } from '../../../utils/classnames';
 import Icon from '../Icon/Icon';
@@ -13,7 +7,6 @@ import PlainList from '../styled/PlainList';
 import Space from '../styled/Space';
 import styled from 'styled-components';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
-import { Period } from '@weco/content/types/periods';
 import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
 
 type IsActiveProps = {
@@ -156,8 +149,8 @@ const PlainLink = styled.a.attrs({
 type Props = {
   id: string;
   items: { id: string; text: string; url: string }[];
-  activeId?: string;
-  onActiveIdChange?: (id: string) => void;
+  activeId: string;
+  setActiveId: (id: string) => void;
   ariaCurrentText?: string;
 };
 
@@ -165,20 +158,11 @@ const SegmentedControl: FunctionComponent<Props> = ({
   id,
   items,
   activeId,
-  onActiveIdChange,
+  setActiveId,
   ariaCurrentText,
 }) => {
-  const [activeIdInternal, setActiveIdInternal] = useState<Period | undefined>(
-    activeId || items?.[0].id
-  );
   const { isEnhanced } = useContext(AppContext);
   const [isActive, setIsActive] = useState(false);
-
-  useEffect(() => {
-    if (onActiveIdChange) {
-      onActiveIdChange(id);
-    }
-  }, [activeIdInternal]);
 
   return (
     <div>
@@ -186,7 +170,7 @@ const SegmentedControl: FunctionComponent<Props> = ({
         <Drawer>
           <Button isActive={isActive}>
             {items
-              .filter(item => item.id === activeIdInternal)
+              .filter(item => item.id === activeId)
               .map(item => (
                 <Fragment key={item.id}>
                   {!isActive ? (
@@ -219,7 +203,7 @@ const SegmentedControl: FunctionComponent<Props> = ({
                         label: item.text,
                       });
 
-                      setActiveIdInternal(item.id);
+                      setActiveId(item.id);
                       setIsActive(false);
 
                       // Assume we want to
@@ -242,7 +226,7 @@ const SegmentedControl: FunctionComponent<Props> = ({
         {items.map((item, i) => (
           <Item key={item.id} isLast={i === items.length - 1}>
             <ItemInner
-              isActive={item.id === activeIdInternal}
+              isActive={item.id === activeId}
               onClick={e => {
                 const url = e.currentTarget.href;
                 const isHash = url.startsWith('#');
@@ -253,7 +237,7 @@ const SegmentedControl: FunctionComponent<Props> = ({
                   label: item.text,
                 });
 
-                setActiveIdInternal(item.id);
+                setActiveId(item.id);
 
                 // Assume we want to
                 if (isHash) {
@@ -263,7 +247,7 @@ const SegmentedControl: FunctionComponent<Props> = ({
               }}
               href={item.url}
               aria-current={
-                item.id === activeIdInternal
+                item.id === activeId
                   ? isNotUndefined(ariaCurrentText)
                   : undefined
               }

--- a/common/views/components/SegmentedControl/SegmentedControl.tsx
+++ b/common/views/components/SegmentedControl/SegmentedControl.tsx
@@ -149,9 +149,14 @@ const PlainLink = styled.a.attrs({
 type Props = {
   id: string;
   items: { id: string; text: string; url: string }[];
-  activeId: string;
-  setActiveId: (id: string) => void;
   ariaCurrentText?: string;
+  // Note: depending on the URLs passed in `items`, clicking on a segment may
+  // cause the user to navigate to a complete different page.
+  //
+  // In this case, the state is tracked by the URL, and there's no need for
+  // a setActiveId hook -- it will be updated by the re-render for the new URL.
+  activeId: string;
+  setActiveId?: (id: string) => void;
 };
 
 const SegmentedControl: FunctionComponent<Props> = ({
@@ -203,7 +208,7 @@ const SegmentedControl: FunctionComponent<Props> = ({
                         label: item.text,
                       });
 
-                      setActiveId(item.id);
+                      setActiveId && setActiveId(item.id);
                       setIsActive(false);
 
                       // Assume we want to
@@ -237,7 +242,7 @@ const SegmentedControl: FunctionComponent<Props> = ({
                   label: item.text,
                 });
 
-                setActiveId(item.id);
+                setActiveId && setActiveId(item.id);
 
                 // Assume we want to
                 if (isHash) {

--- a/content/webapp/components/EventsByMonth/EventsByMonth.tsx
+++ b/content/webapp/components/EventsByMonth/EventsByMonth.tsx
@@ -1,4 +1,4 @@
-import { Component } from 'react';
+import { FunctionComponent, useState } from 'react';
 import { classNames, cssGrid } from '@weco/common/utils/classnames';
 import SegmentedControl from '@weco/common/views/components/SegmentedControl/SegmentedControl';
 import { EventBasic } from '../../types/events';
@@ -13,82 +13,69 @@ type Props = {
   links?: Link[];
 };
 
-type State = {
-  activeId?: string;
-};
+const EventsByMonth: FunctionComponent<Props> = ({ events, links }) => {
+  const eventsInMonths = groupEventsByMonth(events);
 
-class EventsByMonth extends Component<Props, State> {
-  state = {
-    activeId: undefined,
-  };
+  // Order months correctly.  This returns the headings for each month,
+  // now in chronological order.
+  const groups = eventsInMonths.map(({ month, events }) => {
+    const id = `${month.month}-${month.year}`.toLowerCase();
 
-  render(): JSX.Element {
-    const { events, links } = this.props;
-    const { activeId } = this.state;
+    return {
+      id,
+      url: `#${id}`,
+      text: month.month,
+      month,
+      events,
+    };
+  });
 
-    const eventsInMonths = groupEventsByMonth(events);
+  const [activeId, setActiveId] = useState(groups[0].id);
 
-    // Order months correctly.  This returns the headings for each month,
-    // now in chronological order.
-    const groups = eventsInMonths.map(({ month, events }) => {
-      const id = `${month.month}-${month.year}`.toLowerCase();
-
-      return {
-        id,
-        url: `#${id}`,
-        text: month.month,
-        month,
-        events,
-      };
-    });
-
-    return (
-      <div>
-        <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
-          <CssGridContainer>
-            <div className="css-grid">
-              <div className={cssGrid({ s: 12, m: 12, l: 12, xl: 12 })}>
-                <SegmentedControl
-                  id="monthControls"
-                  activeId={groups[0]?.id}
-                  items={groups}
-                  onActiveIdChange={id => {
-                    this.setState({ activeId: id });
-                  }}
-                />
-              </div>
+  return (
+    <div>
+      <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
+        <CssGridContainer>
+          <div className="css-grid">
+            <div className={cssGrid({ s: 12, m: 12, l: 12, xl: 12 })}>
+              <SegmentedControl
+                id="monthControls"
+                activeId={activeId}
+                setActiveId={setActiveId}
+                items={groups}
+              />
             </div>
-          </CssGridContainer>
-        </Space>
-
-        {groups.map(g => (
-          <div
-            key={g.id}
-            className={cssGrid({ s: 12, m: 12, l: 12, xl: 12 })}
-            style={{
-              display: !activeId || activeId === g.id ? 'block' : 'none',
-            }}
-          >
-            <h2
-              className={classNames({
-                container: true,
-                'is-hidden': Boolean(activeId),
-              })}
-              id={g.id}
-            >
-              {g.month.month}
-            </h2>
-            <CardGrid
-              items={g.events}
-              itemsPerRow={3}
-              links={links}
-              fromDate={startOf(g.month)}
-            />
           </div>
-        ))}
-      </div>
-    );
-  }
-}
+        </CssGridContainer>
+      </Space>
+
+      {groups.map(g => (
+        <div
+          key={g.id}
+          className={cssGrid({ s: 12, m: 12, l: 12, xl: 12 })}
+          style={{
+            display: activeId === g.id ? 'block' : 'none',
+          }}
+        >
+          <h2
+            className={classNames({
+              container: true,
+              'is-hidden': Boolean(activeId),
+            })}
+            id={g.id}
+          >
+            {g.month.month}
+          </h2>
+          <CardGrid
+            items={g.events}
+            itemsPerRow={3}
+            links={links}
+            fromDate={startOf(g.month)}
+          />
+        </div>
+      ))}
+    </div>
+  );
+};
 
 export default EventsByMonth;

--- a/content/webapp/pages/guides/index.tsx
+++ b/content/webapp/pages/guides/index.tsx
@@ -1,5 +1,5 @@
 import { GetServerSideProps } from 'next';
-import { FunctionComponent } from 'react';
+import { FunctionComponent, useState } from 'react';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
 import LayoutPaginatedResults from '@weco/content/components/LayoutPaginatedResults/LayoutPaginatedResults';
@@ -47,11 +47,15 @@ const Filters: FunctionComponent<FiltersProps> = ({
     url: '/guides',
     text: 'All',
   });
+
+  const [activeId, setActiveId] = useState((currentId as string) || 'all');
+
   return (
     <Layout12>
       <SegmentedControl
         id="guidesFilter"
-        activeId={(currentId as string) || 'all'}
+        activeId={activeId}
+        setActiveId={setActiveId}
         items={items}
       />
     </Layout12>

--- a/content/webapp/pages/guides/index.tsx
+++ b/content/webapp/pages/guides/index.tsx
@@ -1,5 +1,5 @@
 import { GetServerSideProps } from 'next';
-import { FunctionComponent, useState } from 'react';
+import { FunctionComponent } from 'react';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
 import LayoutPaginatedResults from '@weco/content/components/LayoutPaginatedResults/LayoutPaginatedResults';
@@ -48,14 +48,11 @@ const Filters: FunctionComponent<FiltersProps> = ({
     text: 'All',
   });
 
-  const [activeId, setActiveId] = useState((currentId as string) || 'all');
-
   return (
     <Layout12>
       <SegmentedControl
         id="guidesFilter"
-        activeId={activeId}
-        setActiveId={setActiveId}
+        activeId={(currentId as string) || 'all'}
         items={items}
       />
     </Layout12>


### PR DESCRIPTION
This is another case of SegmentedControl (and EventsByMonth) being a bit of a weird component, and that hiding a bug.

Rather than using some React state with `useState()`, we were passing in a callback to fire whenever the state value was updated.  Something like:

```typescript
class EventsByMonth extends Component<Props, State> {
  state = {
    activeId: undefined,
  }

  render(): JSX.Element {
    ...
    <SegmentedControl
      id="monthControls"
      activeId={groups[0]?.id}
      onActiveIdChange={activeId => this.setState({ activeId })
    />
  ...
```

Inside SegmentedControl, it was using some regular React state with `useState`, and we had to call `onActiveIdChange` manually.  The intention was probably something like:

```typescript
const SegmentedControl = ({ id, activeId }) => {
  ...
  const [activeIdInternal, setActiveIdInternal] = useState(activeId);

  useEffect(() => {
    onActiveIdChange(activeIdInternal);
  }, [activeIdInternal]);
```

but what we were actually doing was:

```typescript
const SegmentedControl = ({ id, activeId }) => {
  ...

  useEffect(() => {
    onActiveIdChange(id);
  }, [activeIdInternal]);
```

This is the correct type, but the wrong value to pass here -- it means we were calling it with the `id` of the entire component, not the selected segment.  In the example above we were calling `onActiveIdChange("monthControls")` instead of `onActiveIdChange("may-2023")` or whatever.

**The practical upshot of this is that nothing would appear in a SegmentedControl, and none of the events are appearing on the What's On page right now.**

This `onActiveIdChange` is because we want changes in the SegmentedControl state to persist into the parent; the better approach is to move that state into the parent, and pass the getter/setter into SegmentedControl.

So now we have something more like:

```typescript
const EventsByMonth = ({ props }) => {
  ...
  const [activeId, setActiveId] = useState(groups[0]?.id);

  <SegmentedControl
    id="monthControls"
    activeId={activeId}
    setActiveId={setActiveId}
  />
  ...
```

and SegmentedControl is calling the `setActiveId` method from the parent, and doesn't have any of its own state.

This is more consistent with our other components, and I think easier to understand.

I had to convert EventsByMonth into a function component so I could use the `useState` React hook; the actual changes are fairly minor.

(I did try a version of this where I made the bugfix and the style changes separately, but I introduced a new bug where EventsByMonth was constantly re-rendering and the page slowed to a crawl, so I went back to this version.)

This fixes the [What's On events issue](https://wellcome.slack.com/archives/C8X9YKM5X/p1683218929603469) that Lalita has reported in Slack.