### PR TITLE
Use a single function for client-side fetching

### DIFF
--- a/content/webapp/services/prismic/fetch/exhibitions.ts
+++ b/content/webapp/services/prismic/fetch/exhibitions.ts
@@ -1,4 +1,9 @@
-import { clientSideFetcher, fetcher, GetServerSidePropsPrismicClient } from '.';
+import {
+  clientSideFetcher,
+  fetcher,
+  fetchFromClientSide,
+  GetServerSidePropsPrismicClient,
+} from '.';
 import {
   ExhibitionPrismicDocument,
   ExhibitionRelatedContentPrismicDocument,
@@ -36,7 +41,6 @@ import {
 } from '../types/events';
 import { seriesFetchLinks } from '../types/series';
 import { articlesFetchLinks } from '../types/articles';
-import { deserialiseDates as deserialiseJsonDates } from '@weco/common/utils/json';
 
 const fetchLinks = [
   ...exhibitionFormatsFetchLinks,
@@ -162,23 +166,8 @@ export const fetchExhibitionRelatedContent = async (
 export const fetchExhibitionRelatedContentClientSide = async (
   ids: string[]
 ): Promise<ExhibitionRelatedContent | undefined> => {
-  // If you add more parameters here, you have to update the corresponding cache behaviour
-  // in the CloudFront distribution, or you may get incorrect behaviour.
-  //
-  // e.g. at one point we forgot to include the "params" query in the cache key,
-  // so every article was showing the same set of related stories.
-  //
-  // See https://github.com/wellcomecollection/wellcomecollection.org/issues
-  const urlSearchParams = new URLSearchParams();
-  urlSearchParams.set('params', JSON.stringify(ids));
-
-  // If we have multiple content types, use the first one as the ID.
-  const url = `/api/exhibitions-related-content?${urlSearchParams.toString()}`;
-
-  const response = await fetch(url);
-
-  if (response.ok) {
-    const json = await response.text();
-    return deserialiseJsonDates(json);
-  }
+  return fetchFromClientSide<ExhibitionRelatedContent>({
+    endpoint: 'exhibitions-related-content',
+    params: ids,
+  });
 };


### PR DESCRIPTION
When I replaced response.text() with response.json() for the shared fetcher, I didn't realise exhibitions had its own fetcher.  It shouldn't; making it use the common one fixes the (hopefully final) e2e issue.