### PR TITLE
Fix a React warning about duplicate keys in the breadcrumb

### DIFF
--- a/common/views/components/Breadcrumb/Breadcrumb.tsx
+++ b/common/views/components/Breadcrumb/Breadcrumb.tsx
@@ -29,7 +29,10 @@ const Breadcrumb: FunctionComponent<BreadcrumbItems> = ({ items }) => {
       {visibleItems.map(({ text, url, prefix }, i) => {
         const LinkOrSpanTag = url ? 'a' : 'span';
         return (
-          <ItemWrapper key={text} as={prefix ? 'b' : 'span'}>
+          <ItemWrapper
+            key={prefix ? `${prefix}-${text}` : text}
+            as={prefix ? 'b' : 'span'}
+          >
             {i > 0 && (
               <Space
                 as="span"


### PR DESCRIPTION
On the Press page, there's a warning about duplicate keys, because the breadcrumb goes:

    Home | About us | (Part of) About us

and so we have two breadcrumb entries with a key `About us`.

Arguably this points to a data issue, but in the meantime we can make React happy by including the prefix in this key to distinguish them.