### PR TITLE
Add a Prismic lint to detect preview.wellcomecollection.org links

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -11,6 +11,7 @@ on:
       - 'identity/terraform/**'
       - 'infrastructure/**'
       - 'playwright/**'
+      - 'prismic-model/**'
 
 jobs:
   bundle_size_diff:

--- a/prismic-model/lintPrismicData.ts
+++ b/prismic-model/lintPrismicData.ts
@@ -40,6 +40,24 @@ function detectEur01Safelinks(doc: any): string[] {
   return [];
 }
 
+// Look for preview.wellcomecollection.org links.
+//
+// This is a very crude check; we could recurse further down into
+// the object to get more debugging information, but I hope this
+// is good enough for now.
+function detectPreviewLinks(doc: any): string[] {
+  if (
+    JSON.stringify(doc).indexOf('https://preview.wellcomecollection.org/') !==
+    -1
+  ) {
+    return [
+      'One of the links is a preview.wellcomecollection.org URL, which should be replaced with a link to the live site.',
+    ];
+  }
+
+  return [];
+}
+
 // Look for broken links to interpretation types on events.
 //
 // These manifest as small black squares (on promo cards) or small yellow
@@ -159,6 +177,7 @@ async function run() {
   for (const doc of getPrismicDocuments(snapshotFile)) {
     const errors = [
       ...detectEur01Safelinks(doc),
+      ...detectPreviewLinks(doc),
       ...detectBrokenInterpretationTypeLinks(doc),
       ...detectNonHttpContributorLinks(doc),
       ...detectNonPromoImageStories(doc),


### PR DESCRIPTION
The InfoSec team ran an automated security scan of the website this weekend, and part of the report includes a list of external links that weren't scanned (because it was scoped to wellcomecollection.org only).

I skimmed the list, and noticed a handful of preview.wellcomecollection.org links in there – looks like there are a few places where they've been copy/pasted into Prismic. Adding a lint to find them will allow us to clean them up.

(And may also cause preview.wc.org to drop down in Google, because it'll stop being linked from anywhere.)