### PR TITLE
Make sure all events by month display if there's no JS

### DIFF
--- a/common/views/components/SegmentedControl/SegmentedControl.tsx
+++ b/common/views/components/SegmentedControl/SegmentedControl.tsx
@@ -253,7 +253,7 @@ const SegmentedControl: FunctionComponent<Props> = ({
         {items.map((item, i) => (
           <Item key={item.id} isLast={i === items.length - 1}>
             <ItemInner
-              isActive={item.id === activeId}
+              isActive={isEnhanced && item.id === activeId}
               onClick={e => onClick(e, item)}
               href={item.url}
               aria-current={

--- a/content/webapp/components/EventsByMonth/EventsByMonth.tsx
+++ b/content/webapp/components/EventsByMonth/EventsByMonth.tsx
@@ -1,12 +1,19 @@
 import { FunctionComponent, useState, useEffect } from 'react';
-import { classNames, cssGrid } from '@weco/common/utils/classnames';
-import SegmentedControl from '@weco/common/views/components/SegmentedControl/SegmentedControl';
-import { EventBasic } from '../../types/events';
-import { Link } from '../../types/link';
-import Space from '@weco/common/views/components/styled/Space';
-import CssGridContainer from '@weco/common/views/components/styled/CssGridContainer';
-import CardGrid from '../CardGrid/CardGrid';
+
+// Helpers/Utils
+import { cssGrid, classNames } from '@weco/common/utils/classnames';
+import { gridSize12 } from '@weco/common/views/components/Layout12/Layout12';
 import { groupEventsByMonth, startOf } from './group-event-utils';
+
+// Components
+import CardGrid from '../CardGrid/CardGrid';
+import CssGridContainer from '@weco/common/views/components/styled/CssGridContainer';
+import SegmentedControl from '@weco/common/views/components/SegmentedControl/SegmentedControl';
+import Space from '@weco/common/views/components/styled/Space';
+
+// Types
+import { EventBasic } from '@weco/content/types/events';
+import { Link } from '@weco/content/types/link';
 
 type Props = {
   events: EventBasic[];
@@ -14,26 +21,29 @@ type Props = {
 };
 
 const EventsByMonth: FunctionComponent<Props> = ({ events, links }) => {
-  const eventsInMonths = groupEventsByMonth(events);
+  // Group the events into the per-month tabs that we render on the
+  // What's On page, e.g. a group for May, June, July, ...
+  const monthsWithEvents = groupEventsByMonth(events).map(
+    ({ month, events }) => {
+      const id = `${month.month}-${month.year}`.toLowerCase();
 
-  // Order months correctly.  This returns the headings for each month,
-  // now in chronological order.
-  const groups = eventsInMonths.map(({ month, events }) => {
-    const id = `${month.month}-${month.year}`.toLowerCase();
+      return {
+        id,
+        url: `#${id}`,
+        text: month.month,
+        month,
+        events,
+      };
+    }
+  );
 
-    return {
-      id,
-      url: `#${id}`,
-      text: month.month,
-      month,
-      events,
-    };
-  });
-
+  // We assume that there will always be some upcoming events scheduled,
+  // which means there will be at least one month in `monthsWithEvents`
+  // that has some events in it (as long as we have JS)
   const [activeId, setActiveId] = useState<string | undefined>();
 
   useEffect(() => {
-    setActiveId(groups[0].id);
+    setActiveId(monthsWithEvents[0].id);
   }, []);
 
   return (
@@ -41,40 +51,40 @@ const EventsByMonth: FunctionComponent<Props> = ({ events, links }) => {
       <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
         <CssGridContainer>
           <div className="css-grid">
-            <div className={cssGrid({ s: 12, m: 12, l: 12, xl: 12 })}>
+            <div className={cssGrid(gridSize12)}>
               <SegmentedControl
                 id="monthControls"
-                activeId={groups[0].id}
+                activeId={monthsWithEvents[0].id}
                 setActiveId={setActiveId}
-                items={groups}
+                items={monthsWithEvents}
               />
             </div>
           </div>
         </CssGridContainer>
       </Space>
 
-      {groups.map(g => (
+      {monthsWithEvents.map(({ id, month, events }) => (
         <div
-          key={g.id}
-          className={cssGrid({ s: 12, m: 12, l: 12, xl: 12 })}
-          style={{
-            display: !activeId || activeId === g.id ? 'block' : 'none',
-          }}
+          key={id}
+          className={classNames({
+            [cssGrid(gridSize12)]: true,
+            'is-hidden': Boolean(activeId) && activeId !== id,
+          })}
         >
           <h2
             className={classNames({
               container: true,
               'is-hidden': Boolean(activeId),
             })}
-            id={g.id}
+            id={id}
           >
-            {g.month.month}
+            {month.month}
           </h2>
           <CardGrid
-            items={g.events}
+            items={events}
             itemsPerRow={3}
             links={links}
-            fromDate={startOf(g.month)}
+            fromDate={startOf(month)}
           />
         </div>
       ))}

--- a/content/webapp/components/EventsByMonth/EventsByMonth.tsx
+++ b/content/webapp/components/EventsByMonth/EventsByMonth.tsx
@@ -54,7 +54,7 @@ const EventsByMonth: FunctionComponent<Props> = ({ events, links }) => {
             <div className={cssGrid(gridSize12)}>
               <SegmentedControl
                 id="monthControls"
-                activeId={activeId || monthsWithEvents[0].id}
+                activeId={monthsWithEvents[0].id}
                 setActiveId={setActiveId}
                 items={monthsWithEvents}
               />

--- a/content/webapp/components/EventsByMonth/EventsByMonth.tsx
+++ b/content/webapp/components/EventsByMonth/EventsByMonth.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, useState } from 'react';
+import { FunctionComponent, useState, useEffect } from 'react';
 import { classNames, cssGrid } from '@weco/common/utils/classnames';
 import SegmentedControl from '@weco/common/views/components/SegmentedControl/SegmentedControl';
 import { EventBasic } from '../../types/events';
@@ -30,7 +30,11 @@ const EventsByMonth: FunctionComponent<Props> = ({ events, links }) => {
     };
   });
 
-  const [activeId, setActiveId] = useState<string | undefined>(undefined);
+  const [activeId, setActiveId] = useState<string | undefined>();
+
+  useEffect(() => {
+    setActiveId(groups[0].id);
+  }, []);
 
   return (
     <div>
@@ -40,7 +44,7 @@ const EventsByMonth: FunctionComponent<Props> = ({ events, links }) => {
             <div className={cssGrid({ s: 12, m: 12, l: 12, xl: 12 })}>
               <SegmentedControl
                 id="monthControls"
-                activeId={groups[0]?.id}
+                activeId={groups[0].id}
                 setActiveId={setActiveId}
                 items={groups}
               />

--- a/content/webapp/components/EventsByMonth/EventsByMonth.tsx
+++ b/content/webapp/components/EventsByMonth/EventsByMonth.tsx
@@ -54,7 +54,7 @@ const EventsByMonth: FunctionComponent<Props> = ({ events, links }) => {
             <div className={cssGrid(gridSize12)}>
               <SegmentedControl
                 id="monthControls"
-                activeId={monthsWithEvents[0].id}
+                activeId={activeId || monthsWithEvents[0].id}
                 setActiveId={setActiveId}
                 items={monthsWithEvents}
               />

--- a/content/webapp/components/EventsByMonth/EventsByMonth.tsx
+++ b/content/webapp/components/EventsByMonth/EventsByMonth.tsx
@@ -1,19 +1,12 @@
 import { FunctionComponent, useState } from 'react';
-
-// Helpers/Utils
-import { cssGrid } from '@weco/common/utils/classnames';
-import { gridSize12 } from '@weco/common/views/components/Layout12/Layout12';
-import { groupEventsByMonth, startOf } from './group-event-utils';
-
-// Components
-import CardGrid from '../CardGrid/CardGrid';
-import CssGridContainer from '@weco/common/views/components/styled/CssGridContainer';
+import { classNames, cssGrid } from '@weco/common/utils/classnames';
 import SegmentedControl from '@weco/common/views/components/SegmentedControl/SegmentedControl';
+import { EventBasic } from '../../types/events';
+import { Link } from '../../types/link';
 import Space from '@weco/common/views/components/styled/Space';
-
-// Types
-import { EventBasic } from '@weco/content/types/events';
-import { Link } from '@weco/content/types/link';
+import CssGridContainer from '@weco/common/views/components/styled/CssGridContainer';
+import CardGrid from '../CardGrid/CardGrid';
+import { groupEventsByMonth, startOf } from './group-event-utils';
 
 type Props = {
   events: EventBasic[];
@@ -37,17 +30,17 @@ const EventsByMonth: FunctionComponent<Props> = ({ events, links }) => {
     };
   });
 
-  const [activeId, setActiveId] = useState(groups[0].id);
+  const [activeId, setActiveId] = useState<string | undefined>(undefined);
 
   return (
     <div>
       <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
         <CssGridContainer>
           <div className="css-grid">
-            <div className={cssGrid(gridSize12)}>
+            <div className={cssGrid({ s: 12, m: 12, l: 12, xl: 12 })}>
               <SegmentedControl
                 id="monthControls"
-                activeId={activeId}
+                activeId={groups[0]?.id}
                 setActiveId={setActiveId}
                 items={groups}
               />
@@ -56,25 +49,31 @@ const EventsByMonth: FunctionComponent<Props> = ({ events, links }) => {
         </CssGridContainer>
       </Space>
 
-      {groups
-        .filter(g => activeId === g.id)
-        .map(g => (
-          <div
-            key={g.id}
-            className={cssGrid(gridSize12)}
-            style={{ display: 'block' }}
+      {groups.map(g => (
+        <div
+          key={g.id}
+          className={cssGrid({ s: 12, m: 12, l: 12, xl: 12 })}
+          style={{
+            display: !activeId || activeId === g.id ? 'block' : 'none',
+          }}
+        >
+          <h2
+            className={classNames({
+              container: true,
+              'is-hidden': Boolean(activeId),
+            })}
+            id={g.id}
           >
-            <h2 className="container" id={g.id}>
-              {g.month.month}
-            </h2>
-            <CardGrid
-              items={g.events}
-              itemsPerRow={3}
-              links={links}
-              fromDate={startOf(g.month)}
-            />
-          </div>
-        ))}
+            {g.month.month}
+          </h2>
+          <CardGrid
+            items={g.events}
+            itemsPerRow={3}
+            links={links}
+            fromDate={startOf(g.month)}
+          />
+        </div>
+      ))}
     </div>
   );
 };


### PR DESCRIPTION
☝️ 

Should clear up the pa11y dashboard

This fell through the net when we were refactoring the SegmentedControl and EventsByMonth ([Slack](https://wellcome.slack.com/archives/CUA669WHH/p1683621408922809))