### PR TITLE
Add `is-hidden-print` utility class

### DIFF
--- a/common/views/components/Breadcrumb/Breadcrumb.tsx
+++ b/common/views/components/Breadcrumb/Breadcrumb.tsx
@@ -25,7 +25,7 @@ const Breadcrumb: FunctionComponent<BreadcrumbItems> = ({ items }) => {
   ];
 
   return (
-    <BreadcrumbWrapper>
+    <BreadcrumbWrapper className="is-hidden-print">
       {visibleItems.map(({ text, url, prefix }, i) => {
         const LinkOrSpanTag = url ? 'a' : 'span';
         return (

--- a/common/views/components/CookieNotice/CookieNotice.tsx
+++ b/common/views/components/CookieNotice/CookieNotice.tsx
@@ -11,7 +11,7 @@ import { trackGaEvent } from '@weco/common/utils/ga';
 import { addDays, today } from '../../../utils/dates';
 
 const CookieNoticeStyle = styled.div.attrs({
-  className: font('intb', 4),
+  className: `${font('intb', 4)} is-hidden-print`,
 })`
   position: fixed;
   background: ${props => props.theme.color('accent.blue')};

--- a/common/views/components/Footer/index.tsx
+++ b/common/views/components/Footer/index.tsx
@@ -20,7 +20,7 @@ type Props = {
 
 // Styles
 const Wrapper = styled(Space).attrs({
-  className: font('intr', 5),
+  className: `${font('intr', 5)} is-hidden-print`,
   v: { size: 'xl', properties: ['padding-top'] },
 })`
   position: relative;

--- a/common/views/components/Header/Header.tsx
+++ b/common/views/components/Header/Header.tsx
@@ -123,7 +123,7 @@ const Header: FunctionComponent<Props> = ({
       active={searchDropdownIsActive || burgerMenuIsActive}
       focusTrapOptions={{ preventScroll: true }}
     >
-      <div>
+      <div className="is-hidden-print">
         <Wrapper isBurgerOpen={burgerMenuIsActive}>
           <GridCell>
             <Container>

--- a/common/views/components/NewsletterPromo/NewsletterPromo.tsx
+++ b/common/views/components/NewsletterPromo/NewsletterPromo.tsx
@@ -1,13 +1,13 @@
 import { useState, useContext, FunctionComponent } from 'react';
 import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
-import { font } from '../../../utils/classnames';
+import { font } from '@weco/common/utils/classnames';
 import Space from '../styled/Space';
 import styled from 'styled-components';
 import TextInput from '../TextInput/TextInput';
-import { trackGaEvent } from '../../../utils/ga';
-import useValidation from '../../../hooks/useValidation';
+import { trackGaEvent } from '@weco/common/utils/ga';
+import useValidation from '@weco/common/hooks/useValidation';
 import ButtonSolid from '../ButtonSolid/ButtonSolid';
-import { newsletterAddressBook } from '../../../data/dotdigital';
+import { newsletterAddressBook } from '@weco/common/data/dotdigital';
 
 const FormElementWrapper = styled.div`
   display: flex;
@@ -151,7 +151,7 @@ const NewsletterPromo: FunctionComponent = () => {
   }
 
   return (
-    <div className="row">
+    <div className="is-hidden-print">
       <div className="container">
         <div style={{ display: 'flex', justifyContent: 'center' }}>
           <div>

--- a/common/views/components/PageHeader/PageHeader.tsx
+++ b/common/views/components/PageHeader/PageHeader.tsx
@@ -1,4 +1,5 @@
-import { font } from '../../../utils/classnames';
+import styled from 'styled-components';
+import { font } from '@weco/common/utils/classnames';
 import Breadcrumb from '../Breadcrumb/Breadcrumb';
 import LabelsList from '../LabelsList/LabelsList';
 import PrismicImage from '../PrismicImage/PrismicImage';
@@ -18,15 +19,33 @@ import {
   ComponentProps,
 } from 'react';
 import Space from '../styled/Space';
-import styled from 'styled-components';
 import { SectionPageHeader } from '@weco/common/views/components/styled/SectionPageHeader';
 import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper/ConditionalWrapper';
 import { PaletteColor } from '@weco/common/views/themes/config';
 
+const Container = styled.div<{
+  backgroundTexture?: string;
+}>`
+  position: relative;
+  background-image: ${props =>
+    props.backgroundTexture ? `url(${props.backgroundTexture})` : 'undefined'};
+  background-size: ${props =>
+    props.backgroundTexture ? 'cover' : 'undefined'};
+`;
+
+const Wrapper = styled(Space)`
+  @media print {
+    margin: 0;
+    padding: 0;
+  }
+`;
+
 // The `bottom` values here are coupled to the space
 // beneath the Header in ContentPage.tsx
 export const headerSpaceSize = 'l';
-const HeroPictureBackground = styled.div<{ bgColor: PaletteColor }>`
+const HeroPictureBackground = styled.div.attrs({
+  className: 'is-hidden-print',
+})<{ bgColor: PaletteColor }>`
   position: absolute;
   background-color: ${props => props.theme.color(props.bgColor)};
   height: 50%;
@@ -44,7 +63,9 @@ const HeroPictureBackground = styled.div<{ bgColor: PaletteColor }>`
     )}
 `;
 
-const HeroPictureContainer = styled.div`
+const HeroPictureContainer = styled.div.attrs({
+  className: 'is-hidden-print',
+})`
   max-width: 1450px;
   margin: 0 auto;
 
@@ -124,21 +145,12 @@ const PageHeader: FunctionComponent<Props> = ({
 
   return (
     <>
-      <div
-        className="row"
-        style={{
-          position: 'relative',
-          backgroundImage: backgroundTexture
-            ? `url(${backgroundTexture})`
-            : undefined,
-          backgroundSize: backgroundTexture ? 'cover' : undefined,
-        }}
-      >
+      <Container backgroundTexture={backgroundTexture}>
         {Background}
         <Layout
           gridSizes={sectionLevelPage ? gridSize12 : sectionLevelPageGridLayout}
         >
-          <Space
+          <Wrapper
             v={{
               size: 'l',
               properties:
@@ -183,7 +195,7 @@ const PageHeader: FunctionComponent<Props> = ({
             {amendedLabels && amendedLabels.labels.length > 0 && (
               <LabelsList {...amendedLabels} />
             )}
-          </Space>
+          </Wrapper>
         </Layout>
 
         {FeaturedMedia && (
@@ -203,7 +215,7 @@ const PageHeader: FunctionComponent<Props> = ({
             </HeroPictureContainer>
           </div>
         )}
-      </div>
+      </Container>
       {!hasMedia && !isContentTypeInfoBeforeMedia && !sectionLevelPage && (
         <WobblyEdge backgroundColor="white" />
       )}

--- a/common/views/components/Pagination/Pagination.tsx
+++ b/common/views/components/Pagination/Pagination.tsx
@@ -17,7 +17,9 @@ export type Props = {
   isLoading?: boolean;
 };
 
-const Container = styled.nav.attrs({ className: font('intr', 6) })<{
+const Container = styled.nav.attrs({
+  className: `${font('intr', 6)} is-hidden-print`,
+})<{
   isHiddenMobile?: boolean;
 }>`
   display: flex;

--- a/common/views/components/SearchBar/SearchBar.tsx
+++ b/common/views/components/SearchBar/SearchBar.tsx
@@ -62,7 +62,7 @@ const SearchBar: FunctionComponent<Props> = ({
   const defaultInputRef = useRef<HTMLInputElement>(null);
 
   return (
-    <Container>
+    <Container className="is-hidden-print">
       <SearchInputWrapper>
         <TextInput
           id={`${location}-searchbar`}

--- a/common/views/themes/utility-classes.ts
+++ b/common/views/themes/utility-classes.ts
@@ -43,6 +43,13 @@ export const utilityClasses = css<GlobalStyleProps>`
     `}
   }
 
+  // Only hides when printing
+  .is-hidden-print {
+    @media print {
+      display: none;
+    }
+  }
+
   // This removes the element from the flow, as well as its visibility
   .visually-hidden {
     border: 0;


### PR DESCRIPTION
## Who is this for?
Printer users/PDF makers

## What is it doing for them?
- Adds a `is-hidden-print` utility class, used on elements that should not appear in Print mode (e.g. the footer). 
- Applies it where I thought it useful - this is up for discussion and will be in various access chats as well.
- I removed some header margins and paddings as well as the title appeared very far from the rest of the content.

This is a WIP, so up for suggestions!