### PR TITLE
Printing lazy loading images

### DIFF
--- a/common/views/components/HeightRestrictedPrismicImage/HeightRestrictedPrismicImage.tsx
+++ b/common/views/components/HeightRestrictedPrismicImage/HeightRestrictedPrismicImage.tsx
@@ -11,6 +11,7 @@ export type Props = {
   image: ImageType;
   maxWidth?: number;
   quality: ImageQuality;
+  isPrinting?: boolean;
 };
 
 const PrismicImage = styled(Image)`
@@ -66,6 +67,7 @@ const HeightRestrictedPrismicImage: FunctionComponent<Props> = ({
   image,
   maxWidth,
   quality,
+  isPrinting,
 }) => {
   const vSizesString = convertVerticalBreakpointSizesToSizes(
     aspectRatios,
@@ -78,7 +80,19 @@ const HeightRestrictedPrismicImage: FunctionComponent<Props> = ({
     ? Math.min(maxWidth * 3, image.width)
     : image.width;
 
-  return (
+  return isPrinting ? (
+    <img
+      width={image.width}
+      height={image.height}
+      src={image.contentUrl}
+      alt={image.alt || ''}
+      sizes={`${vSizesString}, calc(100vw - 84px)`}
+      style={{
+        width: '100%',
+        height: 'auto',
+      }}
+    />
+  ) : (
     <PrismicImage
       width={image.width}
       height={image.height}

--- a/content/webapp/components/Body/Body.tsx
+++ b/content/webapp/components/Body/Body.tsx
@@ -106,6 +106,7 @@ type Props = {
   staticContent?: ReactElement | null;
   comicPreviousNext?: ComicPreviousNextProps;
   isShortFilm?: boolean;
+  isPrinting?: boolean;
 };
 
 type SectionTheme = {
@@ -145,6 +146,7 @@ const Body: FunctionComponent<Props> = ({
   staticContent = null,
   comicPreviousNext,
   isShortFilm = false,
+  isPrinting,
 }: Props) => {
   const filteredBody = body
     .filter(slice => !(slice.type === 'picture' && slice.weight === 'featured'))
@@ -408,6 +410,7 @@ const Body: FunctionComponent<Props> = ({
                 <SpacingComponent>
                   <ImageGallery
                     {...slice.value}
+                    isPrinting={isPrinting}
                     id={imageGalleryIdCount++}
                     comicPreviousNext={comicPreviousNext}
                   />

--- a/content/webapp/components/CaptionedImage/CaptionedImage.tsx
+++ b/content/webapp/components/CaptionedImage/CaptionedImage.tsx
@@ -61,6 +61,7 @@ const ImageContainerInner = styled.div<ImageContainerInnerProps>`
 type CaptionedImageProps = CaptionedImageType & {
   isBody?: boolean;
   preCaptionNode?: ReactNode;
+  isPrinting?: boolean;
 };
 
 const CaptionedImage: FunctionComponent<CaptionedImageProps> = ({
@@ -69,6 +70,7 @@ const CaptionedImage: FunctionComponent<CaptionedImageProps> = ({
   image,
   isBody,
   hasRoundedCorners,
+  isPrinting,
 }) => {
   // Note: the default quality here was originally 45, but this caused images to
   // appear very fuzzy on stories.
@@ -87,7 +89,13 @@ const CaptionedImage: FunctionComponent<CaptionedImageProps> = ({
         hasRoundedCorners={hasRoundedCorners}
       >
         <ImageWithTasl
-          Image={<HeightRestrictedPrismicImage image={image} quality="high" />}
+          Image={
+            <HeightRestrictedPrismicImage
+              isPrinting={isPrinting}
+              image={image}
+              quality="high"
+            />
+          }
           tasl={{
             ...image.tasl,
             idSuffix: dasherizeShorten(image.contentUrl),

--- a/content/webapp/components/ImageGallery/ImageGallery.tsx
+++ b/content/webapp/components/ImageGallery/ImageGallery.tsx
@@ -259,6 +259,7 @@ export type Props = {
   isStandalone: boolean;
   isFrames: boolean;
   comicPreviousNext?: ComicPreviousNextProps;
+  isPrinting?: boolean;
 };
 
 const ImageGallery: FunctionComponent<{ id: number } & Props> = ({
@@ -268,6 +269,7 @@ const ImageGallery: FunctionComponent<{ id: number } & Props> = ({
   isStandalone,
   isFrames,
   comicPreviousNext,
+  isPrinting,
 }) => {
   const [isActive, setIsActive] = useState(true);
   const openButtonRef = useRef<HTMLButtonElement>(null);
@@ -448,6 +450,7 @@ const ImageGallery: FunctionComponent<{ id: number } & Props> = ({
                 >
                   <CaptionedImage
                     image={captionedImage.image}
+                    isPrinting={isPrinting}
                     caption={captionedImage.caption}
                     hasRoundedCorners={captionedImage.hasRoundedCorners}
                     preCaptionNode={

--- a/content/webapp/pages/articles/[articleId].tsx
+++ b/content/webapp/pages/articles/[articleId].tsx
@@ -165,6 +165,7 @@ const HTMLDateWrapper = styled.span.attrs({ className: font('intr', 6) })`
 
 const ArticlePage: FunctionComponent<Props> = ({ article, jsonLd }) => {
   const [listOfSeries, setListOfSeries] = useState<ArticleSeriesList>();
+  const [isPrinting, setIsPrinting] = useState(false);
 
   useEffect(() => {
     async function setSeries() {
@@ -193,6 +194,21 @@ const ArticlePage: FunctionComponent<Props> = ({ article, jsonLd }) => {
     }
 
     setSeries();
+
+    function setIsPrintingTrue() {
+      setIsPrinting(true);
+    }
+    function setIsPrintingFalse() {
+      setIsPrinting(false);
+    }
+
+    window.addEventListener('beforeprint', setIsPrintingTrue);
+    window.addEventListener('afterprint', setIsPrintingFalse);
+
+    return () => {
+      window.removeEventListener('beforeprint', setIsPrintingTrue);
+      window.removeEventListener('afterprint', setIsPrintingFalse);
+    };
   }, []);
 
   const breadcrumbs = {
@@ -343,6 +359,7 @@ const ArticlePage: FunctionComponent<Props> = ({ article, jsonLd }) => {
             pageId={article.id}
             minWidth={isPodcast ? 10 : 8}
             isShortFilm={isShortFilmFormat}
+            isPrinting={isPrinting}
           />
         }
         RelatedContent={Siblings}


### PR DESCRIPTION
## Who is this for?
User who print and don't scroll beforehand

## What is it doing for them?
Whilst I was working on printing stylesheets and asking for feedback, [@alexwlchan pointed out](https://wellcome.slack.com/archives/CUA669WHH/p1683645879399799) that lazy loading images weren't rendering in print sheets if we weren't loading them by scrolling. I was able to replicate in Safari with [this 17 pages (when printing) article](https://wellcomecollection.org/articles/ZC2GqhQAABB9V0eV). 

As we're most likely to have a ton of images using lazy loading (as per our Image component) in Virtual Stories pages, we believes that was one to look into. Technically, it "work as expected" and some research showed there wasn't a simple solution. I tried removing the lazy loading from our Next images (with [`priority`](https://nextjs.org/docs/pages/api-reference/components/image#priority) or [`loading="eager"`](https://nextjs.org/docs/pages/api-reference/components/image#loading), but it still wasn't working. 

I think I found a workaround, in which we'll be using [`beforeprint` and `afterprint` events](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeprint_event) to change the component so it uses either Next's`Image` or the basic `img` element, depending on printing status. 

I'm suggesting this isn't done by default on ALL pages using these image components, but on a page type basis. 