### PR TITLE
Ensure we pass iiifImageLocation into IIIFViewer

### DIFF
--- a/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
@@ -48,6 +48,7 @@ type IIIFViewerProps = {
   canvasIndex: number;
   work: Work;
   image?: Image;
+  iiifImageLocation?: DigitalLocation;
   transformedManifest: TransformedManifest;
   manifestIndex?: number;
   handleImageError?: () => void;
@@ -205,6 +206,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
   canvasIndex,
   work,
   image,
+  iiifImageLocation,
   transformedManifest,
   manifestIndex,
   pageIndex,
@@ -236,7 +238,6 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
   const [searchResults, setSearchResults] = useState(results);
   const [isResizing, setIsResizing] = useState(false);
   const mainImageService = { '@id': currentCanvas?.imageServiceId };
-  const iiifImageLocation = image?.locations[0];
   const urlTemplate =
     iiifImageLocation && iiifImageTemplate(iiifImageLocation.url);
   const imageUrl = urlTemplate && urlTemplate({ size: '800,' });

--- a/catalogue/webapp/pages/works/[workId]/images.tsx
+++ b/catalogue/webapp/pages/works/[workId]/images.tsx
@@ -81,6 +81,7 @@ const ImagePage: FunctionComponent<Props> = ({
           pageIndex={0}
           canvasIndex={0}
           image={image}
+          iiifImageLocation={iiifImageLocation}
           work={work}
         />
       ) : (

--- a/catalogue/webapp/pages/works/[workId]/items.tsx
+++ b/catalogue/webapp/pages/works/[workId]/items.tsx
@@ -327,6 +327,7 @@ const ItemPage: NextPage<Props> = ({
             manifestIndex={manifestIndex}
             work={work}
             transformedManifest={transformedManifest}
+            iiifImageLocation={iiifImageLocation}
             handleImageError={() => {
               // If the image fails to load, we check to see if it's because the cookie is missing/no longer valid
               reloadAuthIframe(document, iframeId);


### PR DESCRIPTION
In 2d7612e we removed the `iiifImageLocation` prop, because we can derive it from the Image -- but we can only do this on the /images page.

When we're on the /items page, the Image is undefined so we can't get a IIIF image location inside the IIIFViewer component.  This means that anything which is a single image doesn't appear on the items page.

Passing the `iiifImageLocation` explicitly seems to fix these broken images; we should add a test to catch this, but I don't want to block fixing these pages behind that change.