### PR TITLE
Debug identity test

### DIFF
--- a/identity/webapp/src/frontend/MyAccount/ChangeEmail.test.tsx
+++ b/identity/webapp/src/frontend/MyAccount/ChangeEmail.test.tsx
@@ -138,7 +138,7 @@ describe('ChangeEmail', () => {
           screen.getByRole('button', { name: /update email/i })
         );
       });
-
+      console.log({ emailAddressInput });
       expect(await screen.findByRole('alert')).toHaveTextContent(
         /enter a valid email address/i
       );

--- a/identity/webapp/src/frontend/MyAccount/ChangeEmail.test.tsx
+++ b/identity/webapp/src/frontend/MyAccount/ChangeEmail.test.tsx
@@ -117,12 +117,16 @@ describe('ChangeEmail', () => {
   });
 
   describe('shows an error on submission', () => {
-    // TODO remove only before merging
+    // TODO remove ".only" before merging
     it.only('with an empty email field', async () => {
       renderComponent();
-      const emailAddressInput = await screen.findByLabelText(/email address/i);
+      const emailAddressInput = await screen.findByLabelText(
+        /new email address/i
+      );
 
       await act(async () => {
+        // this seems required to actually clear the input
+        // https://github.com/testing-library/user-event/discussions/970
         await userEvent.click(emailAddressInput);
         await userEvent.clear(emailAddressInput);
       });
@@ -138,7 +142,8 @@ describe('ChangeEmail', () => {
           screen.getByRole('button', { name: /update email/i })
         );
       });
-      console.log({ emailAddressInput });
+      const alert = await screen.findByRole('alert');
+      console.log({ alert });
       expect(await screen.findByRole('alert')).toHaveTextContent(
         /enter a valid email address/i
       );

--- a/identity/webapp/src/frontend/MyAccount/ChangeEmail.test.tsx
+++ b/identity/webapp/src/frontend/MyAccount/ChangeEmail.test.tsx
@@ -117,13 +117,16 @@ describe('ChangeEmail', () => {
   });
 
   describe('shows an error on submission', () => {
-    it('with an empty email field', async () => {
+    // TODO remove only before merging
+    it.only('with an empty email field', async () => {
       renderComponent();
       const emailAddressInput = await screen.findByLabelText(/email address/i);
 
       await act(async () => {
+        await userEvent.click(emailAddressInput);
         await userEvent.clear(emailAddressInput);
       });
+      expect(emailAddressInput).toHaveValue('');
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
 
       await act(async () => {
@@ -135,6 +138,7 @@ describe('ChangeEmail', () => {
           screen.getByRole('button', { name: /update email/i })
         );
       });
+
       expect(await screen.findByRole('alert')).toHaveTextContent(
         /enter a valid email address/i
       );


### PR DESCRIPTION
## Who is this for?
https://wellcome.slack.com/archives/C3TQSF63C/p1683627306387799
the `ChangeEmail` test has been failing intermittently for a few weeks, seems to have to do with it being wrapper in `act` as recommended, and therefore acting closer to a browser. I think it might also have to do with native validation stopping other alerts from showing.

## What is it doing for them?
As the behaviour seems different locally than in a PR's tests, I want to see what logs.