### PR TITLE
Extract a couple of components from the event page

### DIFF
--- a/common/utils/dates.ts
+++ b/common/utils/dates.ts
@@ -90,9 +90,7 @@ export function isDayPast(date: Date): boolean {
 
 type LondonTZ = 'GMT' | 'BST';
 
-/** Returns true if London is currently in BST (one-hour offset from UTC),
- * false if it's in UTC.
- */
+/** Returns the current timezone in London. */
 export function getLondonTimezone(d: Date): LondonTZ {
   const s = d.toLocaleString('en-GB', {
     hour: '2-digit',

--- a/content/webapp/components/DateList/index.tsx
+++ b/content/webapp/components/DateList/index.tsx
@@ -1,0 +1,55 @@
+import { FunctionComponent } from 'react';
+import styled from 'styled-components';
+
+import DateRange from '@weco/common/views/components/DateRange/DateRange';
+import { Event } from '@weco/content/types/events';
+import EventStatus from '../EventStatus';
+import Space from '@weco/common/views/components/styled/Space';
+
+import { isDayPast } from '@weco/common/utils/dates';
+
+const TimeWrapper = styled(Space).attrs({
+  v: {
+    size: 'm',
+    properties: ['padding-top', 'padding-bottom'],
+  },
+})`
+  display: flex;
+  justify-content: space-between;
+  border-top: 1px solid ${props => props.theme.color('warmNeutral.400')};
+`;
+
+const DateRangeWrapper = styled.div<{ isPast: boolean }>`
+  ${props => props.isPast && `color: ${props.theme.color('neutral.600')};`};
+  flex: 1;
+`;
+
+const DateList: FunctionComponent<{ event: Event }> = ({ event }) => {
+  return (
+    event.times && (
+      <>
+        {event.times.map((eventTime, index) => {
+          return (
+            <TimeWrapper key={index}>
+              <DateRangeWrapper isPast={isDayPast(eventTime.range.endDateTime)}>
+                <DateRange
+                  start={eventTime.range.startDateTime}
+                  end={eventTime.range.endDateTime}
+                />
+              </DateRangeWrapper>
+
+              {isDayPast(eventTime.range.endDateTime) ? (
+                <EventStatus text="Past" color="neutral.500" />
+              ) : eventTime.isFullyBooked.inVenue &&
+                eventTime.isFullyBooked.online ? (
+                <EventStatus text="Full" color="validation.red" />
+              ) : null}
+            </TimeWrapper>
+          );
+        })}
+      </>
+    )
+  );
+};
+
+export default DateList;

--- a/content/webapp/components/EventDateList/index.tsx
+++ b/content/webapp/components/EventDateList/index.tsx
@@ -24,7 +24,7 @@ const DateRangeWrapper = styled.div<{ isPast: boolean }>`
   flex: 1;
 `;
 
-const DateList: FunctionComponent<{ event: Event }> = ({ event }) => {
+const EventDateList: FunctionComponent<{ event: Event }> = ({ event }) => {
   return (
     event.times && (
       <>
@@ -52,4 +52,4 @@ const DateList: FunctionComponent<{ event: Event }> = ({ event }) => {
   );
 };
 
-export default DateList;
+export default EventDateList;

--- a/content/webapp/components/EventStatus/index.tsx
+++ b/content/webapp/components/EventStatus/index.tsx
@@ -1,0 +1,19 @@
+import { FunctionComponent } from 'react';
+import { font } from '@weco/common/utils/classnames';
+import TextWithDot from '@weco/common/views/components/TextWithDot';
+import { PaletteColor } from '@weco/common/views/themes/config';
+
+type EventStatusProps = {
+  text: string;
+  color: PaletteColor;
+};
+
+const EventStatus: FunctionComponent<EventStatusProps> = ({ text, color }) => {
+  return (
+    <div style={{ display: 'flex' }}>
+      <TextWithDot className={font('intb', 5)} dotColor={color} text={text} />
+    </div>
+  );
+};
+
+export default EventStatus;

--- a/content/webapp/pages/events/[eventId].tsx
+++ b/content/webapp/pages/events/[eventId].tsx
@@ -1,16 +1,14 @@
 import NextLink from 'next/link';
-import { FunctionComponent, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import * as prismic from '@prismicio/client';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import EventSchedule from '@weco/content/components/EventSchedule/EventSchedule';
-import TextWithDot from '@weco/common/views/components/TextWithDot';
 import ButtonSolid from '@weco/common/views/components/ButtonSolid/ButtonSolid';
 import ButtonSolidLink from '@weco/common/views/components/ButtonSolidLink/ButtonSolidLink';
 import EventbriteButtons from '@weco/content/components/EventbriteButtons/EventbriteButtons';
 import Message from '@weco/common/views/components/Message/Message';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
 import InfoBox from '@weco/content/components/InfoBox/InfoBox';
-import DateRange from '@weco/common/views/components/DateRange/DateRange';
 import { font } from '@weco/common/utils/classnames';
 import { camelize } from '@weco/common/utils/grammar';
 import { formatDayDate, formatTime } from '@weco/common/utils/format-date';
@@ -57,25 +55,15 @@ import {
   prismicPageIds,
 } from '@weco/common/data/hardcoded-ids';
 import { headerBackgroundLs } from '@weco/common/utils/backgrounds';
-import { isDayPast, isPast } from '@weco/common/utils/dates';
+import { isPast } from '@weco/common/utils/dates';
+import DateList from '@weco/content/components/DateList';
+import EventStatus from '@weco/content/components/EventStatus';
 
 import * as prismicT from '@prismicio/types';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
-import { PaletteColor } from '@weco/common/views/themes/config';
 import { a11y } from '@weco/common/data/microcopy';
 import { Pageview } from '@weco/common/services/conversion/track';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
-
-const TimeWrapper = styled(Space).attrs({
-  v: {
-    size: 'm',
-    properties: ['padding-top', 'padding-bottom'],
-  },
-})`
-  display: flex;
-  justify-content: space-between;
-  border-top: 1px solid ${props => props.theme.color('warmNeutral.400')};
-`;
 
 const DateWrapper = styled.div.attrs({
   className: 'body-text',
@@ -98,58 +86,11 @@ const EmailTeamCopy = styled(Space).attrs({
   color: ${props => props.theme.color('neutral.700')};
 `;
 
-const DateRangeWrapper = styled.div<{ isPast: boolean }>`
-  ${props => props.isPast && `color: ${props.theme.color('neutral.600')};`};
-  flex: 1;
-`;
-
 type Props = {
   event: Event;
   jsonLd: JsonLdObj[];
   gaDimensions: GaDimensions;
   pageview: Pageview;
-};
-
-// TODO: Probably use the StatusIndicator?
-type EventStatusProps = {
-  text: string;
-  color: PaletteColor;
-};
-
-const EventStatus: FunctionComponent<EventStatusProps> = ({ text, color }) => {
-  return (
-    <div style={{ display: 'flex' }}>
-      <TextWithDot className={font('intb', 5)} dotColor={color} text={text} />
-    </div>
-  );
-};
-
-const DateList: FunctionComponent<{ event: Event }> = ({ event }) => {
-  return (
-    event.times && (
-      <>
-        {event.times.map((eventTime, index) => {
-          return (
-            <TimeWrapper key={index}>
-              <DateRangeWrapper isPast={isDayPast(eventTime.range.endDateTime)}>
-                <DateRange
-                  start={eventTime.range.startDateTime}
-                  end={eventTime.range.endDateTime}
-                />
-              </DateRangeWrapper>
-
-              {isDayPast(eventTime.range.endDateTime) ? (
-                <EventStatus text="Past" color="neutral.500" />
-              ) : eventTime.isFullyBooked.inVenue &&
-                eventTime.isFullyBooked.online ? (
-                <EventStatus text="Full" color="validation.red" />
-              ) : null}
-            </TimeWrapper>
-          );
-        })}
-      </>
-    )
-  );
 };
 
 function showTicketSalesStart(dateTime: Date | undefined) {

--- a/content/webapp/pages/events/[eventId].tsx
+++ b/content/webapp/pages/events/[eventId].tsx
@@ -56,7 +56,7 @@ import {
 } from '@weco/common/data/hardcoded-ids';
 import { headerBackgroundLs } from '@weco/common/utils/backgrounds';
 import { isPast } from '@weco/common/utils/dates';
-import DateList from '@weco/content/components/DateList';
+import EventDateList from '@weco/content/components/EventDateList';
 import EventStatus from '@weco/content/components/EventStatus';
 
 import * as prismicT from '@prismicio/types';
@@ -260,7 +260,7 @@ const EventPage: NextPage<Props> = ({ event, jsonLd }) => {
       >
         <DateWrapper>
           <h2 id="dates">Dates</h2>
-          <DateList event={event} />
+          <EventDateList event={event} />
         </DateWrapper>
         {event.schedule && event.schedule.length > 0 && (
           <>

--- a/content/webapp/pages/events/[eventId].tsx
+++ b/content/webapp/pages/events/[eventId].tsx
@@ -228,9 +228,10 @@ const EventPage: NextPage<Props> = ({ event, jsonLd }) => {
               )}
             </Space>
           </Space>
-          {event.isPast && EventStatus({ text: 'Past', color: 'neutral.500' })}
-          {upcomingDatesFullyBooked(event) &&
-            EventStatus({ text: 'Fully booked', color: 'validation.red' })}
+          {event.isPast && <EventStatus text="Past" color="neutral.500" />}
+          {upcomingDatesFullyBooked(event) && (
+            <EventStatus text="Fully booked" color="validation.red" />
+          )}
         </>
       }
       isFree={!event.cost} // TODO or no online cost


### PR DESCRIPTION
The `[eventId].tsx` file is on the large side; this extracts the DateList and EventStatus components as-is into separate files.

The specific motivation for this is that I've spotted a (small) bug in the DateList component: events will still appear as "Full" even after they're finished, for example tomorrow's event:

<img width="780" alt="Screenshot 2023-05-15 at 09 41 44" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/301220/98abb364-859d-4a57-a575-1c4e15198742">

We're using `isDayPast(endOfEvent)` when I think we want `isPast(endOfEvent)`.

This patch **doesn't** contain a fix for this bug, it just extracts the components into standalone files. I wanted them in the `components` folder so they'd be easier to test, but it's tricky to review any changes to the components at the same time as moving them. This patch leaves them as-is, and I'll do a separate patch for the bugfix.