### PR TITLE
Fix a bug in DateList on event pages

### DIFF
--- a/content/webapp/components/DateList/DateList.test.tsx
+++ b/content/webapp/components/DateList/DateList.test.tsx
@@ -1,0 +1,53 @@
+import {
+  renderWithTheme,
+  withMarkup,
+} from '@weco/common/test/fixtures/test-helpers';
+import * as dateUtils from '@weco/common/utils/dates';
+import DateList from '.';
+import { HasTimes } from '@weco/content/types/events';
+
+describe('DateList', () => {
+  it('doesn’t show anything if there aren’t any times', () => {
+    const { container } = renderWithTheme(<DateList event={{ times: [] }} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  const event: HasTimes = {
+    times: [
+      {
+        range: {
+          startDateTime: new Date('2001-01-01T01:01:01Z'),
+          endDateTime: new Date('2002-02-02T02:02:02Z'),
+        },
+        isFullyBooked: { inVenue: true, online: true },
+      },
+    ],
+  };
+
+  it('shows a “Full” indicator for an upcoming event if it’s fully booked', () => {
+    jest.spyOn(dateUtils, 'isPast').mockImplementation((date: Date) => {
+      return date < new Date('2000-01-01T00:00:00Z');
+    });
+
+    const { getByText } = renderWithTheme(<DateList event={event} />);
+    withMarkup(getByText, 'Full');
+  });
+
+  it('shows a “Past” indicator for a past event if it’s fully booked', () => {
+    jest.spyOn(dateUtils, 'isPast').mockImplementation((date: Date) => {
+      return date < new Date('2023-01-01T00:00:00Z');
+    });
+
+    const { getByText } = renderWithTheme(<DateList event={event} />);
+    withMarkup(getByText, 'Past');
+  });
+
+  it('shows a “Past” indicator for a past event, if it’s the same day but the event is over', () => {
+    jest.spyOn(dateUtils, 'isPast').mockImplementation((date: Date) => {
+      return date < new Date('2002-02-02T12:00:00Z');
+    });
+
+    const { getByText } = renderWithTheme(<DateList event={event} />);
+    withMarkup(getByText, 'Past');
+  });
+});

--- a/content/webapp/components/EventDateList/EventDateList.test.tsx
+++ b/content/webapp/components/EventDateList/EventDateList.test.tsx
@@ -3,12 +3,14 @@ import {
   withMarkup,
 } from '@weco/common/test/fixtures/test-helpers';
 import * as dateUtils from '@weco/common/utils/dates';
-import DateList from '.';
+import EventDateList from '.';
 import { HasTimes } from '@weco/content/types/events';
 
 describe('DateList', () => {
   it('doesn’t show anything if there aren’t any times', () => {
-    const { container } = renderWithTheme(<DateList event={{ times: [] }} />);
+    const { container } = renderWithTheme(
+      <EventDateList event={{ times: [] }} />
+    );
     expect(container.innerHTML).toBe('');
   });
 
@@ -29,7 +31,7 @@ describe('DateList', () => {
       return date < new Date('2000-01-01T00:00:00Z');
     });
 
-    const { getByText } = renderWithTheme(<DateList event={event} />);
+    const { getByText } = renderWithTheme(<EventDateList event={event} />);
     withMarkup(getByText, 'Full');
   });
 
@@ -38,7 +40,7 @@ describe('DateList', () => {
       return date < new Date('2023-01-01T00:00:00Z');
     });
 
-    const { getByText } = renderWithTheme(<DateList event={event} />);
+    const { getByText } = renderWithTheme(<EventDateList event={event} />);
     withMarkup(getByText, 'Past');
   });
 
@@ -47,7 +49,7 @@ describe('DateList', () => {
       return date < new Date('2002-02-02T12:00:00Z');
     });
 
-    const { getByText } = renderWithTheme(<DateList event={event} />);
+    const { getByText } = renderWithTheme(<EventDateList event={event} />);
     withMarkup(getByText, 'Past');
   });
 });

--- a/content/webapp/components/EventDateList/index.tsx
+++ b/content/webapp/components/EventDateList/index.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
 import DateRange from '@weco/common/views/components/DateRange/DateRange';
-import { Event } from '@weco/content/types/events';
+import { HasTimes } from '@weco/content/types/events';
 import EventStatus from '../EventStatus';
 import Space from '@weco/common/views/components/styled/Space';
 
@@ -24,7 +24,7 @@ const DateRangeWrapper = styled.div<{ isPast: boolean }>`
   flex: 1;
 `;
 
-const EventDateList: FunctionComponent<{ event: Event }> = ({ event }) => {
+const EventDateList: FunctionComponent<{ event: HasTimes }> = ({ event }) => {
   return (
     event.times && (
       <>

--- a/content/webapp/components/EventDateList/index.tsx
+++ b/content/webapp/components/EventDateList/index.tsx
@@ -26,29 +26,27 @@ const DateRangeWrapper = styled.div<{ isPast: boolean }>`
 
 const EventDateList: FunctionComponent<{ event: HasTimes }> = ({ event }) => {
   return (
-    event.times && (
-      <>
-        {event.times.map((eventTime, index) => {
-          return (
-            <TimeWrapper key={index}>
-              <DateRangeWrapper isPast={isDayPast(eventTime.range.endDateTime)}>
-                <DateRange
-                  start={eventTime.range.startDateTime}
-                  end={eventTime.range.endDateTime}
-                />
-              </DateRangeWrapper>
+    <>
+      {event.times.map((eventTime, index) => {
+        return (
+          <TimeWrapper key={index}>
+            <DateRangeWrapper isPast={isDayPast(eventTime.range.endDateTime)}>
+              <DateRange
+                start={eventTime.range.startDateTime}
+                end={eventTime.range.endDateTime}
+              />
+            </DateRangeWrapper>
 
-              {isDayPast(eventTime.range.endDateTime) ? (
-                <EventStatus text="Past" color="neutral.500" />
-              ) : eventTime.isFullyBooked.inVenue &&
-                eventTime.isFullyBooked.online ? (
-                <EventStatus text="Full" color="validation.red" />
-              ) : null}
-            </TimeWrapper>
-          );
-        })}
-      </>
-    )
+            {isDayPast(eventTime.range.endDateTime) ? (
+              <EventStatus text="Past" color="neutral.500" />
+            ) : eventTime.isFullyBooked.inVenue &&
+              eventTime.isFullyBooked.online ? (
+              <EventStatus text="Full" color="validation.red" />
+            ) : null}
+          </TimeWrapper>
+        );
+      })}
+    </>
   );
 };
 

--- a/content/webapp/components/EventDateList/index.tsx
+++ b/content/webapp/components/EventDateList/index.tsx
@@ -5,8 +5,7 @@ import DateRange from '@weco/common/views/components/DateRange/DateRange';
 import { HasTimes } from '@weco/content/types/events';
 import EventStatus from '../EventStatus';
 import Space from '@weco/common/views/components/styled/Space';
-
-import { isDayPast } from '@weco/common/utils/dates';
+import { isPast } from '@weco/common/utils/dates';
 
 const TimeWrapper = styled(Space).attrs({
   v: {
@@ -28,18 +27,16 @@ const EventDateList: FunctionComponent<{ event: HasTimes }> = ({ event }) => {
   return (
     <>
       {event.times.map((eventTime, index) => {
-        const isPast = isDayPast(eventTime.range.endDateTime);
-
         return (
           <TimeWrapper key={index}>
-            <DateRangeWrapper isPast={isPast}>
+            <DateRangeWrapper isPast={isPast(eventTime.range.endDateTime)}>
               <DateRange
                 start={eventTime.range.startDateTime}
                 end={eventTime.range.endDateTime}
               />
             </DateRangeWrapper>
 
-            {isPast ? (
+            {isPast(eventTime.range.endDateTime) ? (
               <EventStatus text="Past" color="neutral.500" />
             ) : eventTime.isFullyBooked.inVenue &&
               eventTime.isFullyBooked.online ? (

--- a/content/webapp/components/EventDateList/index.tsx
+++ b/content/webapp/components/EventDateList/index.tsx
@@ -28,16 +28,18 @@ const EventDateList: FunctionComponent<{ event: HasTimes }> = ({ event }) => {
   return (
     <>
       {event.times.map((eventTime, index) => {
+        const isPast = isDayPast(eventTime.range.endDateTime);
+
         return (
           <TimeWrapper key={index}>
-            <DateRangeWrapper isPast={isDayPast(eventTime.range.endDateTime)}>
+            <DateRangeWrapper isPast={isPast}>
               <DateRange
                 start={eventTime.range.startDateTime}
                 end={eventTime.range.endDateTime}
               />
             </DateRangeWrapper>
 
-            {isDayPast(eventTime.range.endDateTime) ? (
+            {isPast ? (
               <EventStatus text="Past" color="neutral.500" />
             ) : eventTime.isFullyBooked.inVenue &&
               eventTime.isFullyBooked.online ? (


### PR DESCRIPTION
Follows https://github.com/wellcomecollection/wellcomecollection.org/pull/9772

Currently when you have a schedule on a page, DateList uses `isDayPast` to determine whether to show "Past" for a scheduled item – this means that an event may continue to show as "Available" or "Full" even after it's finished, until the end of that day.

This patch changes it to use `isPast`, so as soon as the event finishes it will switch to showing "Past" in the schedule. I've also added a couple of tests for the component.