### PR TITLE
Fix the flaky identity tests

### DIFF
--- a/identity/webapp/src/frontend/MyAccount/ChangeEmail.test.tsx
+++ b/identity/webapp/src/frontend/MyAccount/ChangeEmail.test.tsx
@@ -46,8 +46,8 @@ describe('ChangeEmail', () => {
     renderComponent();
     const emailAddressInput = await screen.findByLabelText(/email address/i);
     await act(async () => {
-      userEvent.clear(emailAddressInput);
-      userEvent.type(emailAddressInput, 'clarkkent@dailybugle.com');
+      await userEvent.clear(emailAddressInput);
+      await userEvent.type(emailAddressInput, 'clarkkent@dailybugle.com');
     });
     await waitFor(() =>
       expect(emailAddressInput).toHaveValue('clarkkent@dailybugle.com')
@@ -60,7 +60,7 @@ describe('ChangeEmail', () => {
       /confirm password/i
     );
     await act(async () => {
-      userEvent.type(confirmPasswordInput, 'Superman1938');
+      await userEvent.type(confirmPasswordInput, 'Superman1938');
     });
     await waitFor(() =>
       expect(confirmPasswordInput).toHaveValue('Superman1938')
@@ -96,8 +96,8 @@ describe('ChangeEmail', () => {
     const { rerender } = renderComponent();
     const emailAddressInput = await screen.findByLabelText(/email address/i);
     await act(async () => {
-      userEvent.clear(emailAddressInput);
-      userEvent.type(emailAddressInput, 'clarkkent@dailybugle.com');
+      await userEvent.clear(emailAddressInput);
+      await userEvent.type(emailAddressInput, 'clarkkent@dailybugle.com');
     });
     rerender(
       <ThemeProvider theme={theme}>

--- a/identity/webapp/src/frontend/MyAccount/ChangeEmail.test.tsx
+++ b/identity/webapp/src/frontend/MyAccount/ChangeEmail.test.tsx
@@ -59,9 +59,7 @@ describe('ChangeEmail', () => {
     const confirmPasswordInput = await screen.findByLabelText(
       /confirm password/i
     );
-    await act(async () => {
-      await userEvent.type(confirmPasswordInput, 'Superman1938');
-    });
+    await act(async () => userEvent.type(confirmPasswordInput, 'Superman1938'));
     await waitFor(() =>
       expect(confirmPasswordInput).toHaveValue('Superman1938')
     );
@@ -121,9 +119,7 @@ describe('ChangeEmail', () => {
       renderComponent();
       const emailAddressInput = await screen.findByLabelText(/email address/i);
 
-      await act(async () => {
-        await userEvent.clear(emailAddressInput);
-      });
+      await act(async () => userEvent.clear(emailAddressInput));
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
 
       await act(async () => {

--- a/identity/webapp/src/frontend/MyAccount/ChangeEmail.test.tsx
+++ b/identity/webapp/src/frontend/MyAccount/ChangeEmail.test.tsx
@@ -113,7 +113,7 @@ describe('ChangeEmail', () => {
         </UserProvider>
       </ThemeProvider>
     );
-    await expect(emailAddressInput).toHaveValue('');
+    expect(emailAddressInput).toHaveValue('');
   });
 
   describe('shows an error on submission', () => {

--- a/identity/webapp/src/frontend/MyAccount/ChangeEmail.test.tsx
+++ b/identity/webapp/src/frontend/MyAccount/ChangeEmail.test.tsx
@@ -135,9 +135,10 @@ describe('ChangeEmail', () => {
           screen.getByRole('button', { name: /update email/i })
         );
       });
-      expect(await screen.findByRole('alert')).toHaveTextContent(
-        /enter a valid email address/i
-      );
+
+      // Note: this is testing that the browser's native controls are rejecting
+      // the empty field, rather than our own alerts.
+      expect(emailAddressInput).toBeInvalid();
     });
 
     it('when the email is missing an @', async () => {

--- a/identity/webapp/src/frontend/MyAccount/ChangePassword.test.tsx
+++ b/identity/webapp/src/frontend/MyAccount/ChangePassword.test.tsx
@@ -33,18 +33,14 @@ describe('ChangePassword', () => {
   it('allows the user to enter their current password', async () => {
     renderComponent();
     const currentPasswordInput = screen.getByLabelText(/current password/i);
-    await act(async () => {
-      await userEvent.type(currentPasswordInput, 'hunter2');
-    });
+    await act(async () => userEvent.type(currentPasswordInput, 'hunter2'));
     expect(currentPasswordInput).toHaveValue('hunter2');
   });
 
   it('allows the user to enter a new password', async () => {
     renderComponent();
     const newPasswordInput = screen.getByLabelText(/^create new password/i);
-    await act(async () => {
-      await userEvent.type(newPasswordInput, 'hunter2');
-    });
+    await act(async () => userEvent.type(newPasswordInput, 'hunter2'));
     expect(newPasswordInput).toHaveValue('hunter2');
   });
 
@@ -53,9 +49,7 @@ describe('ChangePassword', () => {
     const confirmPasswordInput = screen.getByLabelText(
       /re-enter new password/i
     );
-    await act(async () => {
-      await userEvent.type(confirmPasswordInput, 'hunter2');
-    });
+    await act(async () => userEvent.type(confirmPasswordInput, 'hunter2'));
     expect(confirmPasswordInput).toHaveValue('hunter2');
   });
 

--- a/identity/webapp/src/frontend/MyAccount/ChangePassword.test.tsx
+++ b/identity/webapp/src/frontend/MyAccount/ChangePassword.test.tsx
@@ -93,9 +93,9 @@ describe('ChangePassword', () => {
     );
 
     await act(async () => {
-      userEvent.type(currentPasswordInput, 'hunter2');
-      userEvent.type(newPasswordInput, 'Superman1938');
-      userEvent.type(confirmPasswordInput, 'Superman1938');
+      await userEvent.type(currentPasswordInput, 'hunter2');
+      await userEvent.type(newPasswordInput, 'Superman1938');
+      await userEvent.type(confirmPasswordInput, 'Superman1938');
     });
 
     rerender(
@@ -455,23 +455,23 @@ describe('ChangePassword', () => {
         })
       );
       renderComponent();
-      expect(await screen.queryByRole('alert')).not.toBeInTheDocument();
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
 
       await act(async () => {
         await userEvent.type(
-          await screen.getByLabelText(/current password/i),
+          screen.getByLabelText(/current password/i),
           'hunter2'
         );
         await userEvent.type(
-          await screen.getByLabelText(/^create new password/i),
+          screen.getByLabelText(/^create new password/i),
           'Superman1938'
         );
         await userEvent.type(
-          await screen.getByLabelText(/re-enter new password/i),
+          screen.getByLabelText(/re-enter new password/i),
           'Superman1938'
         );
         await userEvent.click(
-          await screen.getByRole('button', { name: /update password/i })
+          screen.getByRole('button', { name: /update password/i })
         );
       });
 

--- a/identity/webapp/src/frontend/MyAccount/DeleteAccount.test.tsx
+++ b/identity/webapp/src/frontend/MyAccount/DeleteAccount.test.tsx
@@ -33,9 +33,7 @@ describe('DeleteAccount', () => {
   it('allows the user to enter their password', async () => {
     renderComponent();
     const currentPasswordInput = screen.getByLabelText(/^password$/i);
-    await act(async () => {
-      await userEvent.type(currentPasswordInput, 'hunter2');
-    });
+    await act(async () => userEvent.type(currentPasswordInput, 'hunter2'));
     expect(currentPasswordInput).toHaveValue('hunter2');
   });
 
@@ -67,9 +65,7 @@ describe('DeleteAccount', () => {
   it('resets when modal closes', async () => {
     const { rerender } = renderComponent();
     const passwordInput = screen.getByLabelText(/^password$/i);
-    await act(async () => {
-      await userEvent.type(passwordInput, 'hunter2');
-    });
+    await act(async () => userEvent.type(passwordInput, 'hunter2'));
 
     rerender(
       <ThemeProvider theme={theme}>
@@ -90,11 +86,11 @@ describe('DeleteAccount', () => {
       renderComponent();
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
 
-      await act(async () => {
-        await userEvent.click(
+      await act(async () =>
+        userEvent.click(
           screen.getByRole('button', { name: /yes, delete my account/i })
-        );
-      });
+        )
+      );
 
       expect(await screen.findByRole('alert')).toHaveTextContent(
         /enter your current password/i

--- a/identity/webapp/src/frontend/MyAccount/MyAccount.test.tsx
+++ b/identity/webapp/src/frontend/MyAccount/MyAccount.test.tsx
@@ -15,7 +15,7 @@ import UserProvider from '@weco/common/views/components/UserProvider/UserProvide
 // avoid rendering header SVG to help with debugging tests
 jest.mock('../components/PageWrapper', () => ({
   __esModule: true,
-  PageWrapper: ({ children }) => <>{children}</>, // eslint-disable-line react/display-name
+  PageWrapper: ({ children }) => <>{children}</>,
 }));
 
 jest.mock('@weco/common/server-data', () => ({
@@ -167,9 +167,7 @@ describe('MyAccount', () => {
     const changeEmailButton = await screen.findByRole('button', {
       name: /change email/i,
     });
-    await act(async () => {
-      await userEvent.click(changeEmailButton);
-    });
+    await act(async () => userEvent.click(changeEmailButton));
 
     const emailInput = await screen.findByLabelText(/email address/i);
     const passwordConfirmInput = screen.getByLabelText(/confirm password/i);
@@ -187,9 +185,7 @@ describe('MyAccount', () => {
     const updateEmailButton = screen.getByRole('button', {
       name: /update email/i,
     });
-    await act(async () => {
-      await userEvent.click(updateEmailButton);
-    });
+    await act(async () => userEvent.click(updateEmailButton));
 
     expect(await screen.findByRole('alert')).toHaveTextContent(
       /email updated/i
@@ -202,9 +198,7 @@ describe('MyAccount', () => {
     const changePasswordButton = await screen.findByRole('button', {
       name: /Change password/,
     });
-    await act(async () => {
-      await userEvent.click(changePasswordButton);
-    });
+    await act(async () => userEvent.click(changePasswordButton));
 
     const currentPasswordInput = screen.getByLabelText(/current password/i);
     const newPasswordInput = screen.getByLabelText(/^create new password/i);
@@ -225,9 +219,7 @@ describe('MyAccount', () => {
     const updatePasswordButton = screen.getByRole('button', {
       name: /update password/i,
     });
-    await act(async () => {
-      await userEvent.click(updatePasswordButton);
-    });
+    await act(async () => userEvent.click(updatePasswordButton));
 
     expect(await screen.findByRole('alert')).toHaveTextContent(
       /password updated/i
@@ -244,18 +236,14 @@ describe('MyAccount', () => {
     const requestDeletionButton = await screen.findByRole('button', {
       name: /cancel your membership/i,
     });
-    await act(async () => {
-      await userEvent.click(requestDeletionButton);
-    });
+    await act(async () => userEvent.click(requestDeletionButton));
 
     expect(
       await screen.findByRole('button', { name: /yes, delete my account/i })
     ).toBeInTheDocument();
 
     const closeButton = screen.getByRole('button', { name: /close/i });
-    await act(async () => {
-      await userEvent.click(closeButton);
-    });
+    await act(async () => userEvent.click(closeButton));
 
     await waitFor(() => {
       expect(


### PR DESCRIPTION
Tentatively closes https://github.com/wellcomecollection/wellcomecollection.org/pull/9764

The problem is in a test which checks the error message when somebody is trying to update their email address, and doesn't enter anything. The old test is asserting that we send a custom `<div role="alert">` with the error message `"Enter a valid email address"`. This test has become flaky recently, but I don't think the issue is a new one.

---

While running Raphaëlle's patch on my old and slow machine (🐌), I noticed an unusual behaviour – despite clearing the email address input field:

```typescript
await act(async () => {
  await userEvent.click(emailAddressInput);
  await userEvent.clear(emailAddressInput);
});
```

I was getting a failure on the assertion on the following line:

```typescript
expect(emailAddressInput).toHaveValue('');
```

It wasn't always the same text, but I was getting a handful of characters still in that field after it had been allegedly cleared.

I did some debugging, and discovered a test further up where some typing wasn't being `await`-ed properly:

```typescript
await act(async () => {
  userEvent.clear(emailAddressInput);
  userEvent.type(emailAddressInput, 'clarkkent@dailybugle.com');
});
```

Because we aren't `await`-ing those calls, I think it's possible for that typing to still be in progress after the `act()` completes – and even after this entire test case completes. That typing would then leak into the next test (which is the one failing intermittently).

Keystrokes leaking between tests would explain a lot of the weird behaviour we're seeing.

---

It also explains all the unusual behaviour described in the previous PR:

> The error message we should be looking for is "Enter an email address", not "Enter a valid email address", [as seen in the code of the page](https://github.com/wellcomecollection/wellcomecollection.org/blob/main/identity/webapp/src/frontend/MyAccount/ChangeEmail.tsx#L108).

There are two different error messages at play:

1. "Enter an email address" if the field is empty
2. "Enter a valid email address" if the field is non-empty but doesn't match our email regex

If the email address is really empty, we expect case (1), but the test is actually asserting the presence of (2).

My guess is that this test has _always_ been leaking inputs between tests, and the switch to `act()` has actually made it less leaky. Whoever wrote this test originally saw the "Enter a valid email address" error in the tests, because the field was getting stray keystrokes from other test cases, and asserted on that without realising they were meant to be looking for a slightly different error.

> That message never shows anyway as browsers' native validation catches it beforehand. I think it used to work because before being [wrapped in `act`](https://legacy.reactjs.org/docs/testing-recipes.html#act), it wasn't behaving as in a browser?

I think leaking is more likely, at which point we skip browser-native validation.

Now the field is being emptied correctly, I've changed the test to use the `.toBeInvalid()` assertion.

> It's strange because when running locally, if you run only that test, it errors. If you run them all, it passes.

It would error because if you run only that test, there's no state leaking, so you do get the browser-native validation. You need to run all the tests to get some leaky state and make the old, broken test pass.

> Apparently the clear action [doesn't work consistently](https://buildkite.com/wellcomecollection/wc-dot-org-build-plus-test/builds/11223#01880002-5521-45cb-815b-07509df972b1/160-225), https://github.com/testing-library/user-event/discussions/970 and it says doing a click on the input fixes it, which [it does seem to do](https://buildkite.com/wellcomecollection/wc-dot-org-build-plus-test/builds/11249#01880ad5-cf72-4283-b78e-d598975f609e/149-297).

I don't think it's the clear action at fault (and I wonder if other people are getting similarly bitten by leaky state).

> I'm not sure this is what should be tested or if the code should be refactored. I'm thinking we're happy with native validation and don't want to get rid of it just so we can test this use case?

We had a call to discuss this; we're going to test that the native validation is catching this rather than our custom alert.

---

This patch makes the following changes:

* Make sure everything inside an `act()` block is appropriately `await`-ed, so we don't get leaky state
* Check for browser-native validation when a user enters an empty email address, not our custom validation messages