### PR TITLE
Remove _queryType references

### DIFF
--- a/cache/modules/cloudfront_policies/cache_policies.tf
+++ b/cache/modules/cloudfront_policies/cache_policies.tf
@@ -89,7 +89,6 @@ resource "aws_cloudfront_cache_policy" "weco_apps" {
           distinct(
             concat(
               local.toggles_cookies,
-              local.works_cookies,
               local.userpreference_cookies,
               local.ga_cookies,
             )

--- a/cache/modules/cloudfront_policies/locals.tf
+++ b/cache/modules/cloudfront_policies/locals.tf
@@ -1,6 +1,5 @@
 locals {
   toggles_cookies = ["toggles", "toggle_*"]
-  works_cookies   = ["_queryType"]
   userpreference_cookies = ["WC_*"]
   ga_cookies = ["_ga"]
 
@@ -51,7 +50,6 @@ locals {
     "manifest",
 
     # All other parameters
-    "_queryType",
     "current",
     "items.locations.locationType",
     "source",

--- a/catalogue/webapp/pages/search/index.tsx
+++ b/catalogue/webapp/pages/search/index.tsx
@@ -1,5 +1,4 @@
 import { GetServerSideProps } from 'next';
-import { getCookie } from 'cookies-next';
 import styled from 'styled-components';
 import { ParsedUrlQuery } from 'querystring';
 
@@ -236,12 +235,8 @@ export const getServerSideProps: GetServerSideProps<
     });
 
     // Works
-    const _worksQueryType = getCookie('_queryType') as string | undefined;
     const worksResults = await getWorks({
-      params: {
-        ...params,
-        _queryType: _worksQueryType,
-      },
+      params,
       pageSize: 5,
       toggles: serverData.toggles,
     });
@@ -253,8 +248,8 @@ export const getServerSideProps: GetServerSideProps<
     // Images
     const imagesResults = await getImages({
       params,
-      toggles: serverData.toggles,
       pageSize: 10,
+      toggles: serverData.toggles,
     });
     const images = getQueryResults({
       categoryName: 'images',

--- a/catalogue/webapp/pages/search/works.tsx
+++ b/catalogue/webapp/pages/search/works.tsx
@@ -1,7 +1,6 @@
 import { useContext, useEffect } from 'react';
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';
-import { getCookie } from 'cookies-next';
 import styled from 'styled-components';
 
 // Components
@@ -228,11 +227,8 @@ export const getServerSideProps: GetServerSideProps<
     'contributors.agent.label',
   ];
 
-  const _queryType = getCookie('_queryType') as string | undefined;
-
   const worksApiProps = {
     ...params,
-    _queryType,
     aggregations,
   };
 

--- a/catalogue/webapp/services/wellcome/catalogue/types/api.ts
+++ b/catalogue/webapp/services/wellcome/catalogue/types/api.ts
@@ -32,7 +32,6 @@ export type CatalogueWorksApiProps = {
   subjects?: string[];
   'contributors.agent.label'?: string[];
   languages?: string[];
-  _queryType?: string;
   aggregations?: string[];
 };
 


### PR DESCRIPTION
## Who is this for?
Maintenance

## What is it doing for them?
See ticket for more details, @harrisonpim has confirmed this hasn't been used and isn't considered to be in the future. It's been copy/pasted in from the old search (and then questioned).

I'm not sure if anything needs applying in Terraform for the policy change and tried, but am not as comfortable making the Scala changes in `catalogue-api`, if anyone could assist? Happy to do it with some guidance. (@jamieparkinson / @alexwlchan / @paul-butcher )

Part of #9047 