### PR TITLE
Add LBE festival redirect

### DIFF
--- a/cache/edge_lambdas/src/redirects.ts
+++ b/cache/edge_lambdas/src/redirects.ts
@@ -198,6 +198,10 @@ const contentRedirects: Record<string, string> = {
   // of letters.
   // See https://wellcome.slack.com/archives/C3TQSF63C/p1668010459644169
   '/in-plain-sight': '/exhibitions/Yv95yBAAAILuCNv6',
+
+  // Requested by Content team
+  // See https://github.com/wellcomecollection/wellcomecollection.org/issues/9765
+  '/lbe-festival': '/event-series/ZFt3UBQAAMFmEIya',
 };
 
 /**


### PR DESCRIPTION
## Who is this for?
Content team

## What is it doing for them?
Redirects readable URL to the relevant page.

I'll prepare a separate PR for the application to production.

Related to #9765 