### PR TITLE
Tweak how we calculate reading time on articles

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -51,7 +51,6 @@
     "react-ga": "^3.3.1",
     "react-popper": "^2.3.0",
     "react-transition-group": "^4.3.0",
-    "reading-time": "^1.5.0",
     "styled-components": "^5.3.8",
     "timezone-mock": "^1.3.6",
     "ts-jest": "29.1.0",

--- a/content/webapp/package.json
+++ b/content/webapp/package.json
@@ -31,6 +31,7 @@
     "nodemon": "^2.0.22",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "reading-time": "^1.5.0",
     "search-query-parser": "^1.3.0",
     "styled-components": "^5.3.8",
     "supertest": "^6.3.3",

--- a/content/webapp/services/prismic/transformers/articles.ts
+++ b/content/webapp/services/prismic/transformers/articles.ts
@@ -24,8 +24,8 @@ import { Format } from '../../../types/format';
 import { ArticleFormatId } from '@weco/common/data/content-format-ids';
 import { transformContributors } from './contributors';
 import { noAltTextBecausePromo } from './images';
-import readingTime from 'reading-time';
 import { MultiContentPrismicDocument } from '../types/multi-content';
+import { calculateReadingTime, showReadingTime } from 'utils/reading-time';
 
 function transformContentLink(document?: LinkField): MultiContent | undefined {
   if (!document) {
@@ -112,20 +112,6 @@ export function transformArticle(document: ArticlePrismicDocument): Article {
     ? (transformLabelType(data.format) as Format<ArticleFormatId>)
     : undefined;
 
-  // Calculating the full reading time of the article by getting all article text
-  function allArticleText(genericBody) {
-    return genericBody
-      .filter(genericBody => genericBody?.type === 'text')
-      .map(element => element.value)
-      .flat()
-      .map(element => element.text)
-      .join(' ');
-  }
-
-  const readingTimeInMinutes =
-    Math.round(readingTime(allArticleText(genericFields.body)).minutes) +
-    ' minutes';
-
   const series: Series[] = transformSingleLevelGroup(data.series, 'series').map(
     series => transformSeries(series as SeriesPrismicDocument)
   );
@@ -136,20 +122,6 @@ export function transformArticle(document: ArticlePrismicDocument): Article {
   ].filter(isNotUndefined);
 
   const contributors = transformContributors(document);
-  // This is getting a little unwieldy, as i am learning there
-  // are a few formats we consider to be 'articles' even if their Prismic 'format'
-  // doesn't return them as 'Article' e.g. Book extracts
-  // TODO: get definitive list of what we consider to be article and refactor the below function to account for that
-  const showReadingTime = format
-    ? Boolean(
-        format?.title === 'Article' ||
-          format?.title === 'Serial' ||
-          format?.title === 'Book extract' ||
-          format?.title === 'Long read' ||
-          format?.title === 'Photo story' ||
-          format?.title === 'Prose Poem'
-      )
-    : Boolean(labels[0]?.text === 'Serial' || labels[0]?.text === 'Article');
 
   return {
     ...genericFields,
@@ -158,7 +130,9 @@ export function transformArticle(document: ArticlePrismicDocument): Article {
     format,
     series,
     contributors,
-    readingTime: showReadingTime ? readingTimeInMinutes : undefined,
+    readingTime: showReadingTime(format, labels)
+      ? calculateReadingTime(genericFields.body)
+      : undefined,
     datePublished: new Date(datePublished),
     seasons: transformSingleLevelGroup(data.seasons, 'season').map(season =>
       transformSeason(season as SeasonPrismicDocument)

--- a/content/webapp/services/prismic/transformers/articles.ts
+++ b/content/webapp/services/prismic/transformers/articles.ts
@@ -25,7 +25,7 @@ import { ArticleFormatId } from '@weco/common/data/content-format-ids';
 import { transformContributors } from './contributors';
 import { noAltTextBecausePromo } from './images';
 import { MultiContentPrismicDocument } from '../types/multi-content';
-import { calculateReadingTime, showReadingTime } from 'utils/reading-time';
+import { calculateReadingTime, showReadingTime } from '@weco/content/utils/reading-time';
 
 function transformContentLink(document?: LinkField): MultiContent | undefined {
   if (!document) {

--- a/content/webapp/utils/reading-time.test.ts
+++ b/content/webapp/utils/reading-time.test.ts
@@ -1,0 +1,23 @@
+import { calculateReadingTime } from './reading-time';
+
+it('rounds up the reading time to the next minute', () => {
+  const result = calculateReadingTime([
+    {
+      value: [{ text: 'A very short sentence', spans: [], type: 'paragraph' }],
+      type: 'text',
+    },
+  ]);
+
+  expect(result).toBe('1 minute');
+});
+
+it('handles longer pieces', () => {
+  const result = calculateReadingTime(
+    [...Array(100)].map(() => ({
+      value: [{ text: 'A very short sentence', spans: [], type: 'paragraph' }],
+      type: 'text',
+    }))
+  );
+
+  expect(result).toBe('2 minutes');
+});

--- a/content/webapp/utils/reading-time.ts
+++ b/content/webapp/utils/reading-time.ts
@@ -4,6 +4,7 @@ import { asText } from '@weco/content/services/prismic/transformers';
 import { BodySlice } from '@weco/content/types/body';
 import { Format } from '@weco/content/types/format';
 import { Label } from '@weco/common/model/labels';
+import { pluralize } from '@weco/common/utils/grammar';
 
 // Calculating the full reading time of the article by getting all article text
 function allArticleText(genericBody: BodySlice[]) {
@@ -26,7 +27,7 @@ export function calculateReadingTime(body: BodySlice[]): string {
 
   const minutes = Math.ceil(readingTime(articleText).minutes);
 
-  return `${minutes} minute${minutes > 1 ? 's' : ''}`;
+  return pluralize(minutes, 'minute');
 }
 
 export function showReadingTime(

--- a/content/webapp/utils/reading-time.ts
+++ b/content/webapp/utils/reading-time.ts
@@ -1,0 +1,47 @@
+import readingTime from 'reading-time';
+import { asText } from '@weco/content/services/prismic/transformers';
+
+import { BodySlice } from '@weco/content/types/body';
+import { Format } from '@weco/content/types/format';
+import { Label } from '@weco/common/model/labels';
+
+// Calculating the full reading time of the article by getting all article text
+function allArticleText(genericBody: BodySlice[]) {
+  return genericBody
+    .map(slice => {
+      switch (slice.type) {
+        case 'text':
+          return asText(slice.value);
+        case 'quote':
+          return asText(slice.value.text);
+        default:
+          return '';
+      }
+    })
+    .join(' ');
+}
+
+export function calculateReadingTime(body: BodySlice[]): string {
+  const articleText = allArticleText(body);
+  return Math.ceil(readingTime(articleText).minutes) + ' minutes';
+}
+
+export function showReadingTime(
+  format: Format<string> | undefined,
+  labels: Label[]
+) {
+  // This is getting a little unwieldy, as i am learning there
+  // are a few formats we consider to be 'articles' even if their Prismic 'format'
+  // doesn't return them as 'Article' e.g. Book extracts
+  // TODO: get definitive list of what we consider to be article and refactor the below function to account for that
+  return format
+    ? Boolean(
+        format?.title === 'Article' ||
+          format?.title === 'Serial' ||
+          format?.title === 'Book extract' ||
+          format?.title === 'Long read' ||
+          format?.title === 'Photo story' ||
+          format?.title === 'Prose Poem'
+      )
+    : Boolean(labels[0]?.text === 'Serial' || labels[0]?.text === 'Article');
+}

--- a/content/webapp/utils/reading-time.ts
+++ b/content/webapp/utils/reading-time.ts
@@ -23,7 +23,10 @@ function allArticleText(genericBody: BodySlice[]) {
 
 export function calculateReadingTime(body: BodySlice[]): string {
   const articleText = allArticleText(body);
-  return Math.ceil(readingTime(articleText).minutes) + ' minutes';
+
+  const minutes = Math.ceil(readingTime(articleText).minutes);
+
+  return `${minutes} minute${minutes > 1 ? 's' : ''}`;
 }
 
 export function showReadingTime(


### PR DESCRIPTION
* Include quotes in the reading time calculate
* Round up the number of minutes, rather than to the nearest integer
* Move the code out into a separate file; add proper types