### PR TITLE
Remove plain-link utility class

### DIFF
--- a/catalogue/webapp/components/WorksSearchResult/WorksSearchResult.styles.tsx
+++ b/catalogue/webapp/components/WorksSearchResult/WorksSearchResult.styles.tsx
@@ -10,7 +10,7 @@ export const Container = styled.div`
 
 export const Wrapper = styled(Space).attrs({
   v: { size: 'l', properties: ['padding-top', 'padding-bottom'] },
-  className: 'plain-link card-link',
+  className: 'card-link',
 })`
   display: block;
 `;

--- a/common/views/components/FindUs/FindUs.tsx
+++ b/common/views/components/FindUs/FindUs.tsx
@@ -6,11 +6,19 @@ import {
 } from '@weco/common/data/organization';
 import Space from '@weco/common/views/components/styled/Space';
 import { prismicPageIds } from '@weco/common/data/hardcoded-ids';
-import { createScreenreaderLabel } from '../../../utils/telephone-numbers';
+import { createScreenreaderLabel } from '@weco/common/utils/telephone-numbers';
 import PlainList from '../styled/PlainList';
 
-const PlainLink = styled.a.attrs({ className: 'plain-link' })`
+const PlainLink = styled.a`
   transition: color 200ms ease;
+
+  // TODO change hover behaviour to match the rest of the website?
+  &,
+  &:link,
+  &:visited {
+    text-decoration: none;
+    border: none;
+  }
 
   &:hover,
   &:focus {

--- a/common/views/components/SegmentedControl/SegmentedControl.tsx
+++ b/common/views/components/SegmentedControl/SegmentedControl.tsx
@@ -34,6 +34,14 @@ const DrawerItem = styled(Space).attrs({
 })<DrawerItemProps>`
   border-bottom: 1px solid ${props => props.theme.color('neutral.300')};
 
+    a,
+    a:link,
+    a:visited {
+      text-decoration: none;
+      border: none;
+    }
+  }
+
   ${props =>
     props.isFirst &&
     `
@@ -75,13 +83,22 @@ const Item = styled.li.attrs({
 const ItemInner = styled.a.attrs<IsActiveProps>(props => ({
   className: classNames({
     'is-active': props.isActive,
-    'plain-link no-visible-focus': true,
+    'no-visible-focus': true,
   }),
 }))<IsActiveProps>`
   display: block;
   width: 100%;
   text-align: center;
   transition: background ${props => props.theme.transitionProperties};
+
+  text-decoration: none;
+  border: none;
+
+  &:link,
+  &:visited {
+    text-decoration: none;
+    border: none;
+  }
 
   color: ${props => props.theme.color(props.isActive ? 'white' : 'black')};
   background-color: ${props =>
@@ -238,12 +255,7 @@ const SegmentedControl: FunctionComponent<Props> = ({
             <PlainList>
               {items.map((item, i) => (
                 <DrawerItem isFirst={i === 0} key={item.id}>
-                  <a
-                    className="plain-link"
-                    style={{ display: 'block' }}
-                    onClick={e => onClick(e, item)}
-                    href={item.url}
-                  >
+                  <a onClick={e => onClick(e, item)} href={item.url}>
                     {item.text}
                   </a>
                 </DrawerItem>

--- a/common/views/themes/utility-classes.ts
+++ b/common/views/themes/utility-classes.ts
@@ -86,19 +86,6 @@ export const utilityClasses = css<GlobalStyleProps>`
     text-align: left;
   }
 
-  // TODO See ticket for more information: https://github.com/wellcomecollection/wellcomecollection.org/issues/9557
-  .plain-link,
-  .plain-link:link,
-  .plain-link:visited {
-    text-decoration: none;
-    border: none;
-
-    .body-text & {
-      text-decoration: none;
-      border: none;
-    }
-  }
-
   // TODO See ticket for more information: https://github.com/wellcomecollection/wellcomecollection.org/issues/9558
   .no-visible-focus {
     &,

--- a/content/webapp/components/BookPromo/BookPromo.tsx
+++ b/content/webapp/components/BookPromo/BookPromo.tsx
@@ -1,11 +1,11 @@
+import { FunctionComponent } from 'react';
+import styled from 'styled-components';
 import { font } from '@weco/common/utils/classnames';
 import { trackGaEvent } from '@weco/common/utils/ga';
-import { BookBasic } from '../../types/books';
+import { BookBasic } from '@weco/content/types/books';
 import Space from '@weco/common/views/components/styled/Space';
-import styled from 'styled-components';
 import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
-import { FunctionComponent } from 'react';
-import BookImage from '../../components/BookImage/BookImage';
+import BookImage from '@weco/content/components/BookImage/BookImage';
 
 type LinkSpaceAttrs = {
   url: string;
@@ -14,14 +14,18 @@ type LinkSpaceAttrs = {
 const LinkSpace = styled(Space).attrs<LinkSpaceAttrs>(props => ({
   as: 'a',
   href: props.url,
-  className: 'promo-link plain-link',
-  v: {
-    size: 'xl',
-    properties: ['padding-top'],
-  },
+  className: 'promo-link',
+  v: { size: 'xl', properties: ['padding-top'] },
   h: { size: 'm', properties: ['padding-left', 'padding-right'] },
 }))<LinkSpaceAttrs>`
   display: block;
+
+  &,
+  &:link,
+  &:visited {
+    text-decoration: none;
+    border: none;
+  }
 `;
 
 const Title = styled.h3.attrs({

--- a/content/webapp/components/Card/Card.tsx
+++ b/content/webapp/components/Card/Card.tsx
@@ -1,10 +1,10 @@
-import { Card as CardType } from '../../types/card';
+import { FunctionComponent } from 'react';
+import styled from 'styled-components';
+import { Card as CardType } from '@weco/content/types/card';
 import { font } from '@weco/common/utils/classnames';
 import { trackGaEvent } from '@weco/common/utils/ga';
 import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
 import Space from '@weco/common/views/components/styled/Space';
-import styled from 'styled-components';
-import { FunctionComponent } from 'react';
 import PartNumberIndicator from '../PartNumberIndicator/PartNumberIndicator';
 import { getCrop } from '@weco/common/model/image';
 import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImage';
@@ -20,7 +20,7 @@ type Props = {
 
 export const CardOuter = styled.a.attrs({
   'data-gtm-trigger': 'card_link',
-  className: 'plain-link promo-link',
+  className: 'promo-link',
 })`
   display: block; // IE
 
@@ -35,6 +35,13 @@ export const CardOuter = styled.a.attrs({
   background: ${props => props.theme.color('warmNeutral.300')};
   min-height: ${props => props.theme.minCardHeight}px;
   border-radius: ${props => props.theme.borderRadiusUnit}px;
+
+  &,
+  &:link,
+  &:visited {
+    text-decoration: none;
+    border: none;
+  }
 
   .card-theme.card-theme--white & {
     background: ${props => props.theme.color('white')};

--- a/content/webapp/components/FeaturedCard/FeaturedCard.tsx
+++ b/content/webapp/components/FeaturedCard/FeaturedCard.tsx
@@ -184,11 +184,18 @@ const FeaturedCardWrap = styled.div`
 
 type HasIsReversed = { isReversed: boolean };
 const FeaturedCardLink = styled.a.attrs({
-  className: 'grid promo-link plain-link',
+  className: 'grid promo-link',
   'data-gtm-trigger': 'featured_card_link',
 })<HasIsReversed>`
   justify-content: flex-end;
   flex-direction: ${props => (props.isReversed ? 'row-reverse' : 'row')};
+
+  &,
+  &:link,
+  &:visited {
+    text-decoration: none;
+    border: none;
+  }
 `;
 
 const FeaturedCardLeft = styled.div.attrs({


### PR DESCRIPTION
## Who is this for?
Maintenance

## What is it doing for them?
- Removes `.plain-link` utility class. The logic behind it (apart from "away with utility classes" ) is to aim to align OR expose discrepancies in link/hover behaviours. The current mindset is to have links in copy be underlined by default and have the underline disappear on hover. Most of these go a different way, but aren't considered copy text (e.g. Book Promo blocks)
- Everywhere where it was used that made sense I moved the styles within the component itself.
- I've addressed all instances in the ticket itself, not _fixing_ anything but might be a good one to show to someone helping us set up a design system? (@DominiqueMarshall @jennpb I could create a separate ticket with those instances if that's useful? )

For more details, ticket is:
Closes #9557 
