### PR TITLE
Reduce the amount of data we fetch on item pages

### DIFF
--- a/catalogue/webapp/pages/works/[workId]/items.tsx
+++ b/catalogue/webapp/pages/works/[workId]/items.tsx
@@ -370,6 +370,7 @@ export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
     const work = await getWork({
       id: workId,
       toggles: serverData.toggles,
+      include: ['items', 'languages', 'contributors'],
     });
 
     if (work.type === 'Error') {

--- a/catalogue/webapp/services/wellcome/catalogue/works.ts
+++ b/catalogue/webapp/services/wellcome/catalogue/works.ts
@@ -24,6 +24,7 @@ import {
 type GetWorkProps = {
   id: string;
   toggles: Toggles;
+  include?: string[];
 };
 
 const worksIncludes = ['production', 'contributors', 'partOf'];
@@ -125,6 +126,7 @@ type WorkResponse =
 export async function getWork({
   id,
   toggles,
+  include = workIncludes,
 }: GetWorkProps): Promise<WorkResponse> {
   if (!looksLikeCanonicalId(id)) {
     return notFound();
@@ -133,7 +135,7 @@ export async function getWork({
   const apiOptions = globalApiOptions(toggles);
 
   const params = {
-    include: workIncludes,
+    include,
   };
 
   const searchParams = new URLSearchParams(propsToQuery(params)).toString();


### PR DESCRIPTION
While testing some stuff for the new IIIF manifests, I noticed that we're loading a lot of work fields for the item page, even though only a handful of them are used.  These fields can be quite large, e.g. the page I'm testing has a large archive tree which is completely wasted.

Only fetching the fields we need should reduce the size of these pages.

I spotted this while looking at https://github.com/wellcomecollection/wellcomecollection.org/issues/9786; for that example it reduces the size of the initial page load by **40%**.