### PR TITLE
Add a simpler type scale table for embedding in GitBook

### DIFF
--- a/cardigan/.storybook/manager-head.html
+++ b/cardigan/.storybook/manager-head.html
@@ -10,3 +10,10 @@ m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 ga('create', 'UA-55614-23', 'auto');
 ga('send', 'pageview');
 </script>
+
+<style>
+  /* Don't show simple scale in sidebar – we're just embedding the story in GitBook */
+  #global-typography--scale-simple {
+    display: none;
+  }
+</style>

--- a/cardigan/stories/global/typography/typography.stories.mdx
+++ b/cardigan/stories/global/typography/typography.stories.mdx
@@ -12,6 +12,8 @@ Each of these sizes is responsive, being largest at the large breakpoint, becomi
 
   <Story story={stories.scale} />
 
+  <Story story={stories.scaleSimple} />
+
 ## Font families
 
 We use Wellcome Bold, Inter, and Lettera on the site.

--- a/cardigan/stories/global/typography/typography.stories.tsx
+++ b/cardigan/stories/global/typography/typography.stories.tsx
@@ -128,7 +128,7 @@ scale.args = {
   fontFamily: 'Wellcome Bold Web',
 };
 
-const scaleTemplateSimple = args => <TypographyScaleSimple {...args} />;
+const scaleTemplateSimple = () => <TypographyScaleSimple />;
 export const scaleSimple = scaleTemplateSimple.bind({});
 
 const MiscTemplate = () => (

--- a/cardigan/stories/global/typography/typography.stories.tsx
+++ b/cardigan/stories/global/typography/typography.stories.tsx
@@ -49,6 +49,44 @@ const TypographyScale = ({ fontFamily }) => {
   return <Table caption={null} hasRowHeaders={false} rows={rowsWithHeadings} />;
 };
 
+const TypographyScaleSimple = () => {
+  const transpose = matrix => {
+    const [row] = matrix;
+    return row.map((_, column) => matrix.map(row => row[column]));
+  };
+
+  const cols = Object.entries(fontSizesAtBreakpoints)
+    .map(entry => {
+      const value = entry[1];
+      return Object.entries(value).map((e, index) => {
+        const v = e[1];
+
+        return (
+          <span key={index}>
+            {v * 16} / {+(v * 16 * 1.5).toFixed(2)}
+          </span>
+        );
+      });
+    })
+    .reverse();
+
+  const rows = transpose(cols);
+  const rowsWithScaleNumbers = rows.map((row, index) => {
+    return [<span key={index}>{index}</span>, ...row];
+  });
+  const firstRow = [['Font size unit', 'BP Large', 'BP Medium', 'BP Small']];
+  const rowsWithHeadings = firstRow.concat(rowsWithScaleNumbers);
+
+  return (
+    <Table
+      caption={null}
+      hasRowHeaders={false}
+      rows={rowsWithHeadings}
+      plain={true}
+    />
+  );
+};
+
 const sizes = [0, 1, 2, 3, 4, 5, 6];
 const fontFamilies = ['intr', 'intb', 'wb', 'lr'];
 
@@ -89,6 +127,9 @@ export const scale = ScaleTemplate.bind({});
 scale.args = {
   fontFamily: 'Wellcome Bold Web',
 };
+
+const scaleTemplateSimple = args => <TypographyScaleSimple {...args} />;
+export const scaleSimple = scaleTemplateSimple.bind({});
 
 const MiscTemplate = () => (
   <div className="spaced-text">


### PR DESCRIPTION
☝️ 

<img width="870" alt="image" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/1394592/84836838-9d46-4c87-84ae-ff5429adc0b9">

This is to replace the [Type scale table currently in GitBook](https://app.gitbook.com/o/-LumfFcEMKx4gYXKAZTQ/s/SreoRFZHSJqTwnKOTN2h/foundations/design-tokens#type-scale) with contains out of date information. Using a story from Storybook should ensure it stays up to date.