### PR TITLE
Match on auth URLs from iiif-test.wc.org

### DIFF
--- a/catalogue/webapp/utils/iiif/v3/index.ts
+++ b/catalogue/webapp/utils/iiif/v3/index.ts
@@ -374,13 +374,17 @@ export function getClickThroughService(
   ) as AuthClickThroughServiceWithPossibleServiceArray | undefined;
 }
 
-const restrictedAuthServiceUrl =
-  'https://iiif.wellcomecollection.org/auth/restrictedlogin';
+const restrictedAuthServiceUrls = [
+  'https://iiif.wellcomecollection.org/auth/restrictedlogin',
+  'https://iiif-test.wellcomecollection.org/auth/restrictedlogin',
+];
 
 function isImageRestricted(canvas: Canvas): boolean {
   const imageService = getImageService(canvas);
   const imageAuthCookieService = getImageAuthCookieService(imageService);
-  return imageAuthCookieService?.['@id'] === restrictedAuthServiceUrl;
+  return restrictedAuthServiceUrls.some(
+    url => imageAuthCookieService?.['@id'] === url
+  );
 }
 
 export function getRestrictedLoginService(
@@ -388,7 +392,7 @@ export function getRestrictedLoginService(
 ): AuthExternalService | undefined {
   return manifest.services?.find(service => {
     const typedService = service as AuthExternalService;
-    return typedService['@id'] === restrictedAuthServiceUrl;
+    return restrictedAuthServiceUrls.some(url => typedService['@id'] === url);
   }) as AuthExternalService;
 }
 


### PR DESCRIPTION
This is somewhat speculative fix for https://github.com/wellcomecollection/wellcomecollection.org/issues/9786

The auth URLs in the new manifests have iiif-test.wc.org as their hostname, so they're not being matched properly here. In the long term, I think we should probably find a less fragile way to do this, but in the meantime I think this will get things working correctly again.