### PR TITLE
.plain-button refactor

### DIFF
--- a/cardigan/stories/components/Buttons/Buttons.stories.tsx
+++ b/cardigan/stories/components/Buttons/Buttons.stories.tsx
@@ -29,7 +29,7 @@ export const control = ControlTemplate.bind({});
 control.args = {
   text: 'something for screenreaders',
   icon: chevron,
-  extraClasses: 'control--light',
+  colorScheme: 'light',
 };
 control.storyName = 'Control';
 

--- a/catalogue/webapp/components/IIIFSearchWithin/IIIFSearchWithin.tsx
+++ b/catalogue/webapp/components/IIIFSearchWithin/IIIFSearchWithin.tsx
@@ -59,7 +59,6 @@ const SearchResult = styled.button.attrs({
   display: block;
   padding: ${props => `${props.theme.spacingUnit * 2}px 0`};
   color: ${props => props.theme.color('white')};
-  background: transparent;
   &:hover {
     background: ${props => props.theme.color('black')};
   }

--- a/catalogue/webapp/components/IIIFSearchWithin/IIIFSearchWithin.tsx
+++ b/catalogue/webapp/components/IIIFSearchWithin/IIIFSearchWithin.tsx
@@ -53,7 +53,7 @@ const ListItem = styled.li`
 `;
 
 const SearchResult = styled.button.attrs({
-  className: `${font('intr', 6)} plain-button`,
+  className: font('intr', 6),
 })`
   cursor: pointer;
   display: block;

--- a/catalogue/webapp/components/IIIFViewer/IIIFCanvasThumbnail.tsx
+++ b/catalogue/webapp/components/IIIFViewer/IIIFCanvasThumbnail.tsx
@@ -15,11 +15,7 @@ type ViewerThumbProps = {
 const IIIFViewerThumb = styled.button.attrs<ViewerThumbProps>(props => ({
   tabIndex: props.isFocusable ? 0 : -1,
 }))<ViewerThumbProps>`
-  appearance: none;
-  font-family: inherit;
-  letter-spacing: inherit;
   cursor: pointer;
-  border: 0;
   display: block;
   height: 100%;
   width: 300px;

--- a/catalogue/webapp/components/IIIFViewer/ViewerSidebar.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerSidebar.tsx
@@ -76,9 +76,7 @@ const Item = styled.div`
   }
 `;
 
-const AccordionButton = styled.button.attrs({
-  className: 'plain-button',
-})`
+const AccordionButton = styled.button`
   padding: 0;
 
   h2 {

--- a/catalogue/webapp/components/IIIFViewer/ViewerStructures.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerStructures.tsx
@@ -74,7 +74,6 @@ const ViewerStructuresPrototype: FunctionComponent<Props> = ({
           <Item key={i} isActive={activeIndex === canvasIndex}>
             <button
               data-gtm-trigger="contents_nav"
-              className="plain-button"
               type="button"
               onClick={() => {
                 mainViewerRef &&

--- a/catalogue/webapp/components/IIIFViewer/ViewerTopBar.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerTopBar.tsx
@@ -28,7 +28,6 @@ export const ShameButton = styled.button.attrs({
   text-decoration: none;
   text-align: center;
   transition: all ${props => props.theme.transitionProperties};
-  border: 0;
   white-space: nowrap;
   padding: 6px 12px;
   position: relative;

--- a/catalogue/webapp/components/PaletteColorPicker/PaletteColorPicker.tsx
+++ b/catalogue/webapp/components/PaletteColorPicker/PaletteColorPicker.tsx
@@ -83,7 +83,7 @@ type SwatchProps = {
 
 const Swatch = styled.button.attrs((props: SwatchProps) => ({
   type: 'button',
-  className: `plain-button ${font('intr', 5)}`,
+  className: font('intr', 5),
   'aria-pressed': !!props.ariaPressed,
 }))<SwatchProps>`
   position: relative;

--- a/catalogue/webapp/components/WorkDetails/ExplanatoryText.tsx
+++ b/catalogue/webapp/components/WorkDetails/ExplanatoryText.tsx
@@ -29,7 +29,7 @@ const IconContainer = styled.div<IconContainerProps>`
 `;
 
 const Control = styled.button.attrs({
-  className: `plain-button ${font('intb', 5)}`,
+  className: font('intb', 5),
 })`
   display: flex;
   align-items: center;

--- a/catalogue/webapp/components/WorkDetails/OnlineResources.tsx
+++ b/catalogue/webapp/components/WorkDetails/OnlineResources.tsx
@@ -8,7 +8,7 @@ import styled from 'styled-components';
 import PlainList from '@weco/common/views/components/styled/PlainList';
 
 const ShowHideButton = styled.button.attrs({
-  className: `plain-button ${font('intr', 5)}`,
+  className: font('intr', 5),
 })`
   text-decoration: underline;
   padding: 0;

--- a/common/views/components/ApiToolbar/index.tsx
+++ b/common/views/components/ApiToolbar/index.tsx
@@ -169,7 +169,6 @@ const ApiToolbar: FunctionComponent<Props> = ({ links = [] }) => {
         )}
       </div>
       <button
-        className="plain-button"
         type="button"
         onClick={() => {
           getAnchorLinkUrls();
@@ -180,7 +179,6 @@ const ApiToolbar: FunctionComponent<Props> = ({ links = [] }) => {
       </button>
 
       <button
-        className="plain-button"
         type="button"
         onClick={() => {
           setMini(!mini);

--- a/common/views/components/AudioPlayer/AudioPlayer.tsx
+++ b/common/views/components/AudioPlayer/AudioPlayer.tsx
@@ -37,7 +37,6 @@ const AudioPlayerWrapper = styled.figure`
 `;
 
 const PlayPauseButton = styled.button.attrs<{ isPlaying: boolean }>(props => ({
-  className: 'plain-button',
   ariaPressed: props.isPlaying,
 }))<{ isPlaying: boolean }>`
   padding: 0;
@@ -58,7 +57,6 @@ const PlayPauseInner = styled.div`
 `;
 
 const MuteUnmuteButton = styled.button.attrs<{ isMuted: boolean }>(props => ({
-  className: 'plain-button',
   ariaPressed: props.isMuted,
 }))`
   padding: 0;

--- a/common/views/components/ButtonSolid/ButtonSolid.tsx
+++ b/common/views/components/ButtonSolid/ButtonSolid.tsx
@@ -34,7 +34,6 @@ export const BaseButton = styled.button.attrs<BaseButtonProps>(props => ({
   text-align: center;
   transition: background ${props => props.theme.transitionProperties},
     border-color ${props => props.theme.transitionProperties};
-  border: 0;
   white-space: nowrap;
   cursor: pointer;
 

--- a/common/views/components/ClearSearch/ClearSearch.tsx
+++ b/common/views/components/ClearSearch/ClearSearch.tsx
@@ -4,9 +4,7 @@ import Icon from '../Icon/Icon';
 import { clear } from '@weco/common/icons';
 import styled from 'styled-components';
 
-const Button = styled.button.attrs({
-  className: 'plain-button',
-})`
+const Button = styled.button`
   position: absolute;
   line-height: 1;
   top: 50%;

--- a/common/views/components/CookieNotice/CookieNotice.tsx
+++ b/common/views/components/CookieNotice/CookieNotice.tsx
@@ -27,9 +27,7 @@ const CloseCookieNotice = styled.button`
   align-items: center;
   margin-left: 1em;
   cursor: pointer;
-  appearance: none;
   background: none;
-  border: 0;
 `;
 
 const CookieMessage = styled.div`

--- a/common/views/components/ExpandableList/ExpandableList.tsx
+++ b/common/views/components/ExpandableList/ExpandableList.tsx
@@ -10,7 +10,7 @@ import styled from 'styled-components';
 import PlainList from '@weco/common/views/components/styled/PlainList';
 
 const ShowHideButton = styled.button.attrs({
-  className: `plain-button ${font('intr', 5)}`,
+  className: font('intr', 5),
 })`
   margin: 0 !important;
   padding: 0;

--- a/common/views/components/Footer/index.tsx
+++ b/common/views/components/Footer/index.tsx
@@ -142,7 +142,7 @@ const FooterLicense = styled.p.attrs({ className: font('intr', 6) })`
 `;
 
 const BackToTopButton = styled.button.attrs({
-  className: 'is-hidden-s plain-button',
+  className: 'is-hidden-s',
 })`
   text-decoration: underline;
   color: ${props => props.theme.color('white')};

--- a/common/views/components/Iframe/Iframe.tsx
+++ b/common/views/components/Iframe/Iframe.tsx
@@ -81,7 +81,7 @@ export const IframeContainer = styled.div.attrs({
 `;
 
 const ButtonWrapper = styled.span.attrs({
-  className: 'trigger plain-button no-visible-focus',
+  className: 'trigger no-visible-focus',
 })`
   padding: 0;
 `;

--- a/common/views/components/InfoBanner/InfoBanner.tsx
+++ b/common/views/components/InfoBanner/InfoBanner.tsx
@@ -42,9 +42,7 @@ const Copy = styled(Space).attrs({
   align-self: center;
 `;
 
-const CloseButton = styled.button.attrs({
-  className: 'plain-button',
-})`
+const CloseButton = styled.button`
   margin: 0;
   padding: 0;
   cursor: pointer;

--- a/common/views/components/Pagination/Pagination.tsx
+++ b/common/views/components/Pagination/Pagination.tsx
@@ -45,7 +45,6 @@ const ChevronWrapper = styled.button<{ prev?: boolean; hasDarkBg?: boolean }>`
   margin: 0 0 0 1rem;
   cursor: pointer;
   transition: background ${props => props.theme.transitionProperties};
-  background-color: transparent;
 
   // This is required to make the icon be the right size on iOS.  If this class
   // has 'position: relative', then iOS will give it an incorrect height and

--- a/common/views/components/PopupDialog/PopupDialog.tsx
+++ b/common/views/components/PopupDialog/PopupDialog.tsx
@@ -107,9 +107,7 @@ const PopupDialogWindow = styled(Space).attrs({
   z-index: 3;
 `;
 
-const PopupDialogClose = styled.button.attrs({
-  className: 'plain-button',
-})`
+const PopupDialogClose = styled.button`
   margin: 0 !important;
   padding: 0;
 

--- a/common/views/components/PopupDialog/PopupDialog.tsx
+++ b/common/views/components/PopupDialog/PopupDialog.tsx
@@ -38,7 +38,7 @@ const PopupDialogOpen = styled(Space).attrs<PopupDialogOpenProps>(props => ({
     properties: ['padding-left', 'padding-right'],
     overrides: { small: 5, medium: 5, large: 5 },
   },
-  className: `${font('intb', 5)} plain-button`,
+  className: font('intb', 5),
 }))<PopupDialogOpenProps>`
   line-height: 1;
   display: inline-flex;

--- a/common/views/components/SearchTabs/SearchTabs.BaseTabs.tsx
+++ b/common/views/components/SearchTabs/SearchTabs.BaseTabs.tsx
@@ -22,7 +22,6 @@ type TabProps = {
 };
 
 const Tab = styled.button.attrs((props: TabProps) => ({
-  className: 'plain-button',
   role: 'tab',
   tabIndex: props.isActive ? 0 : -1,
   'aria-selected': props.isActive,

--- a/common/views/components/SegmentedControl/SegmentedControl.tsx
+++ b/common/views/components/SegmentedControl/SegmentedControl.tsx
@@ -145,9 +145,7 @@ const MobileControlsModal = styled(Space).attrs({
   bottom: 0;
 `;
 
-const Button = styled.button.attrs({
-  className: 'plain-button',
-})<{ isActive: boolean }>`
+const Button = styled.button<{ isActive: boolean }>`
   padding: 0;
   width: 100%;
 

--- a/common/views/components/TabNav/TabNav.styles.tsx
+++ b/common/views/components/TabNav/TabNav.styles.tsx
@@ -42,7 +42,7 @@ export const TabsContainer = styled.div`
 `;
 
 export const Tab = styled.button.attrs({
-  className: `plain-button ${font('intb', 5)}`,
+  className: font('intb', 5),
 })`
   margin: 0;
   padding: 0 1.5rem 0 0;

--- a/common/views/components/Tasl/Tasl.tsx
+++ b/common/views/components/Tasl/Tasl.tsx
@@ -30,9 +30,7 @@ type TaslButtonProps = {
   positionAtTop: boolean;
 };
 
-const TaslButton = styled.button.attrs({
-  className: 'plain-button',
-})<TaslButtonProps>`
+const TaslButton = styled.button<TaslButtonProps>`
   position: absolute;
   right: 0;
   top: ${props => (props.positionAtTop ? '2px' : 'auto')};

--- a/common/views/components/ToolbarSegmentedControl/ToolbarSegmentedControl.tsx
+++ b/common/views/components/ToolbarSegmentedControl/ToolbarSegmentedControl.tsx
@@ -24,7 +24,6 @@ const Item = styled.li<{ isActive: boolean }>`
 
 const Button = styled.button.attrs({
   type: 'button',
-  className: 'plain-button',
 })`
   display: flex;
   padding: 0;

--- a/common/views/components/VideoEmbed/VideoEmbed.tsx
+++ b/common/views/components/VideoEmbed/VideoEmbed.tsx
@@ -27,9 +27,7 @@ const VideoEmbedWrapper = styled.figure`
   margin: 0;
 `;
 
-const VideoTrigger = styled.button.attrs({
-  className: 'plain-button',
-})<{ hasFullSizePoster?: boolean }>`
+const VideoTrigger = styled.button<{ hasFullSizePoster?: boolean }>`
   cursor: pointer;
   position: absolute;
   padding-bottom: 56.25%; /* 16:9 */

--- a/common/views/themes/base/wellcome-normalize.ts
+++ b/common/views/themes/base/wellcome-normalize.ts
@@ -6,6 +6,15 @@ button {
   border-radius: 0;
 }
 
+button {
+  appearance: none;
+  font-family: inherit;
+  letter-spacing: inherit;
+  background: transparent;
+  border: 0;
+  text-align: left;
+}
+
 fieldset {
   border: 0;
   margin: 0;

--- a/common/views/themes/utility-classes.ts
+++ b/common/views/themes/utility-classes.ts
@@ -76,16 +76,6 @@ export const utilityClasses = css<GlobalStyleProps>`
     }
   }
 
-  // TODO See ticket for more information: https://github.com/wellcomecollection/wellcomecollection.org/issues/9541
-  .plain-button {
-    appearance: none;
-    font-family: inherit;
-    letter-spacing: inherit;
-    background: transparent;
-    border: 0;
-    text-align: left;
-  }
-
   // TODO See ticket for more information: https://github.com/wellcomecollection/wellcomecollection.org/issues/9558
   .no-visible-focus {
     &,

--- a/content/webapp/components/GifVideo/GifVideo.tsx
+++ b/content/webapp/components/GifVideo/GifVideo.tsx
@@ -21,9 +21,6 @@ const PlayPause = styled.button.attrs({
 })`
   margin: 0 !important;
   padding: 0;
-  background: transparent;
-  border: 0;
-  appearance: none;
   position: absolute;
   top: 6px;
   left: 6px;

--- a/content/webapp/components/GifVideo/GifVideo.tsx
+++ b/content/webapp/components/GifVideo/GifVideo.tsx
@@ -18,7 +18,6 @@ const Video = styled.video`
 
 const PlayPause = styled.button.attrs({
   'aria-label': 'play/pause button',
-  className: 'plain-button',
 })`
   margin: 0 !important;
   padding: 0;

--- a/content/webapp/components/ZoomedPrismicImage/ZoomedPrismicImage.tsx
+++ b/content/webapp/components/ZoomedPrismicImage/ZoomedPrismicImage.tsx
@@ -27,7 +27,6 @@ const ZoomButton = styled.button`
   display: flex;
   justify-content: center;
   align-items: center;
-  border: 0;
   padding: 0;
   margin: 0;
 


### PR DESCRIPTION
## Who is this for?
Maintenance

## What is it doing for them?
As part of removing utility classes, we decided `plain-button` was actually containing styles that should be set on all `buttons` in `wellcome-normalize`. This then
- Deletes the class
- Removes instances where it's used
- Remove duplicate styling properties.

Closes #9541 