### PR TITLE
Migrate away from a couple of deprecated Prismic types

### DIFF
--- a/common/services/prismic/types/index.ts
+++ b/common/services/prismic/types/index.ts
@@ -1,7 +1,7 @@
 import {
   PrismicDocument,
-  RelationField,
-  FilledLinkToDocumentField,
+  ContentRelationshipField,
+  FilledContentRelationshipField,
   FilledLinkToWebField,
   LinkField,
   AnyRegularField,
@@ -20,10 +20,10 @@ export type DataInterface = Record<
 >;
 /**
  * This allows us to get the DataInterface from PrismicDocuments when we
- * Need them for `RelationField`s e.g.
+ * Need them for `ContentRelationshipField`s e.g.
  * type Doc = PrismicDocument<{ title: RichTextField }>
  * type DataInterface = InferDataInterface<Doc> // { title: RichTextField }
- * RelationField<'formats', 'en-gb', DataInterface>
+ * ContentRelationshipField<'formats', 'en-gb', DataInterface>
  */
 export type InferDataInterface<T> = T extends PrismicDocument<
   infer DataInterface
@@ -43,14 +43,14 @@ export type PaginatedResults<T> = {
 
 // Guards
 export function isFilledLinkToDocument<T, L, D extends DataInterface>(
-  field: RelationField<T, L, D> | undefined
-): field is FilledLinkToDocumentField<T, L, D> {
+  field: ContentRelationshipField<T, L, D> | undefined
+): field is FilledContentRelationshipField<T, L, D> {
   return isNotUndefined(field) && 'id' in field && field.isBroken === false;
 }
 
 export function isFilledLinkToDocumentWithData<T, L, D extends DataInterface>(
-  field: RelationField<T, L, D> | undefined
-): field is FilledLinkToDocumentField<T, L, D> & { data: DataInterface } {
+  field: ContentRelationshipField<T, L, D> | undefined
+): field is FilledContentRelationshipField<T, L, D> & { data: DataInterface } {
   return isFilledLinkToDocument(field) && 'data' in field;
 }
 

--- a/content/webapp/services/prismic/transformers/body.ts
+++ b/content/webapp/services/prismic/transformers/body.ts
@@ -37,7 +37,11 @@ import {
   transformLink,
   transformTaslFromString,
 } from '@weco/common/services/prismic/transformers';
-import { LinkField, RelationField, RichTextField } from '@prismicio/types';
+import {
+  LinkField,
+  ContentRelationshipField,
+  RichTextField,
+} from '@prismicio/types';
 import { BodySlice, Weight } from '../../../types/body';
 import { transformCollectionVenue } from '@weco/common/services/prismic/transformers/collection-venues';
 import { transformPage } from './pages';
@@ -240,7 +244,7 @@ function transformTitledTextItem({
   title: RichTextField;
   text: RichTextField;
   link: LinkField;
-  label: RelationField<'labels'>;
+  label: ContentRelationshipField<'labels'>;
 }) {
   return {
     title: asTitle(title),

--- a/content/webapp/services/prismic/transformers/contributors.ts
+++ b/content/webapp/services/prismic/transformers/contributors.ts
@@ -1,4 +1,4 @@
-import { FilledLinkToDocumentField, PrismicDocument } from '@prismicio/types';
+import { FilledContentRelationshipField, PrismicDocument } from '@prismicio/types';
 import {
   WithContributors,
   isFilledLinkToOrganisationField,
@@ -26,12 +26,12 @@ const defaultContributorImage: ImageType = {
 
 function transformCommonFields(
   agent:
-    | (FilledLinkToDocumentField<
+    | (FilledContentRelationshipField<
         'people',
         'en-gb',
         InferDataInterface<Person>
       > & { data: Person })
-    | (FilledLinkToDocumentField<
+    | (FilledContentRelationshipField<
         'organisations',
         'en-gb',
         InferDataInterface<Organisation>

--- a/content/webapp/services/prismic/transformers/events.ts
+++ b/content/webapp/services/prismic/transformers/events.ts
@@ -18,7 +18,7 @@ import { isNotUndefined } from '@weco/common/utils/type-guards';
 import {
   GroupField,
   Query,
-  RelationField,
+  ContentRelationshipField,
   LinkField,
   KeyTextField,
 } from '@prismicio/types';
@@ -81,7 +81,7 @@ export function getLastEndTime(times: EventTime[]): Date | undefined {
 
 export function transformEventPolicyLabels(
   fragment: GroupField<{
-    policy: RelationField<
+    policy: ContentRelationshipField<
       'event-policy',
       'en-gb',
       InferDataInterface<EventPolicyPrismicDocument>
@@ -104,7 +104,7 @@ export function getEventbriteId(url: string): string | undefined {
 }
 
 function transformBookingEnquiryTeam(
-  team: RelationField<'teams', 'en-gb', InferDataInterface<PrismicTeam>>
+  team: ContentRelationshipField<'teams', 'en-gb', InferDataInterface<PrismicTeam>>
 ): Team | undefined {
   return isFilledLinkToDocumentWithData(team)
     ? {

--- a/content/webapp/services/prismic/transformers/index.ts
+++ b/content/webapp/services/prismic/transformers/index.ts
@@ -1,7 +1,7 @@
 import * as prismicH from '@prismicio/helpers';
 import {
   PrismicDocument,
-  FilledLinkToDocumentField,
+  FilledContentRelationshipField,
   KeyTextField,
   RichTextField,
 } from '@prismicio/types';
@@ -100,7 +100,7 @@ export function transformSingleLevelGroup(
 }
 
 export function transformLabelType(
-  format: FilledLinkToDocumentField<
+  format: FilledContentRelationshipField<
     'article-formats',
     'en-gb',
     InferDataInterface<ArticleFormat>

--- a/content/webapp/services/prismic/types/articles.ts
+++ b/content/webapp/services/prismic/types/articles.ts
@@ -4,7 +4,7 @@ import {
   TimestampField,
   PrismicDocument,
   GroupField,
-  RelationField,
+  ContentRelationshipField,
 } from '@prismicio/types';
 import { SeriesPrismicDocument } from './series';
 import {
@@ -19,7 +19,7 @@ import { InferDataInterface } from '@weco/common/services/prismic/types';
 
 type WithSeries = {
   series: GroupField<{
-    series: RelationField<
+    series: ContentRelationshipField<
       'series',
       'en-gb',
       InferDataInterface<SeriesPrismicDocument>

--- a/content/webapp/services/prismic/types/body.ts
+++ b/content/webapp/services/prismic/types/body.ts
@@ -10,7 +10,7 @@ import {
   ImageField,
   GeoPointField,
   EmbedField,
-  RelationField,
+  ContentRelationshipField,
 } from '@prismicio/types';
 import { isUndefined } from '@weco/common/utils/type-guards';
 import { Image } from '.';
@@ -98,7 +98,7 @@ export type Map = Slice<
 export type CollectionVenue = Slice<
   'collectionVenue',
   {
-    content: RelationField<'collection-venue'>;
+    content: ContentRelationshipField<'collection-venue'>;
     showClosingTimes: SelectField<'yes'>;
   }
 >;
@@ -106,7 +106,7 @@ export type CollectionVenue = Slice<
 export type Contact = Slice<
   'contact',
   {
-    content: RelationField<
+    content: ContentRelationshipField<
       'teams',
       'en-us',
       InferDataInterface<Partial<TeamPrismicDocument>>
@@ -158,7 +158,7 @@ export type TitledTextList = Slice<
     title: RichTextField;
     text: RichTextField;
     link: LinkField;
-    label: RelationField<'labels'>;
+    label: ContentRelationshipField<'labels'>;
   }
 >;
 
@@ -166,7 +166,7 @@ export type ContentList = Slice<
   'contentList',
   { title: RichTextField },
   {
-    content: RelationField<
+    content: ContentRelationshipField<
       | 'pages'
       | 'event-series'
       | 'books'

--- a/content/webapp/services/prismic/types/card.ts
+++ b/content/webapp/services/prismic/types/card.ts
@@ -3,7 +3,7 @@ import {
   RichTextField,
   NumberField,
   LinkField,
-  RelationField,
+  ContentRelationshipField,
 } from '@prismicio/types';
 import {
   Image,
@@ -25,13 +25,17 @@ const typeEnum = 'card';
 
 export type WithCardFormat = {
   format:
-    | RelationField<
+    | ContentRelationshipField<
         'article-formats',
         'en-gb',
         InferDataInterface<ArticleFormat>
       >
-    | RelationField<'event-formats', 'en-gb', InferDataInterface<EventFormat>>
-    | RelationField<'labels', 'en-gb', InferDataInterface<Label>>;
+    | ContentRelationshipField<
+        'event-formats',
+        'en-gb',
+        InferDataInterface<EventFormat>
+      >
+    | ContentRelationshipField<'labels', 'en-gb', InferDataInterface<Label>>;
 };
 
 export type CardPrismicDocument = PrismicDocument<

--- a/content/webapp/services/prismic/types/event-series.ts
+++ b/content/webapp/services/prismic/types/event-series.ts
@@ -1,11 +1,11 @@
-import { RelationField, PrismicDocument } from '@prismicio/types';
+import { ContentRelationshipField, PrismicDocument } from '@prismicio/types';
 import { BackgroundTexturesDocument } from './background-textures';
 import { CommonPrismicFields, WithContributors } from '.';
 import { InferDataInterface } from '@weco/common/services/prismic/types';
 
 export type EventSeriesPrismicDocument = PrismicDocument<
   {
-    backgroundTexture: RelationField<
+    backgroundTexture: ContentRelationshipField<
       'background-textures',
       'en-gb',
       InferDataInterface<BackgroundTexturesDocument>

--- a/content/webapp/services/prismic/types/events.ts
+++ b/content/webapp/services/prismic/types/events.ts
@@ -2,7 +2,7 @@ import {
   GroupField,
   TimestampField,
   PrismicDocument,
-  RelationField,
+  ContentRelationshipField,
   RichTextField,
   SelectField,
   BooleanField,
@@ -95,7 +95,7 @@ export const teamFetchLinks: FetchLinks<Team> = [
 ];
 
 export type WithEventFormat = {
-  format: RelationField<
+  format: ContentRelationshipField<
     'event-formats',
     'en-gb',
     InferDataInterface<EventFormat>
@@ -112,7 +112,7 @@ export type EventTimePrismicDocument = {
 export type EventPrismicDocument = PrismicDocument<
   {
     locations: GroupField<{
-      location: RelationField<
+      location: ContentRelationshipField<
         'place',
         'en-gb',
         InferDataInterface<PlacePrismicDocument>
@@ -123,7 +123,7 @@ export type EventPrismicDocument = PrismicDocument<
     times: GroupField<EventTimePrismicDocument>;
     isRelaxedPerformance: SelectField<'yes'>;
     interpretations: GroupField<{
-      interpretationType: RelationField<
+      interpretationType: ContentRelationshipField<
         'interpretation-types',
         'en-gb',
         InferDataInterface<InterpretationType>
@@ -132,14 +132,14 @@ export type EventPrismicDocument = PrismicDocument<
       extraInformation: RichTextField;
     }>;
     audiences: GroupField<{
-      audience: RelationField<
+      audience: ContentRelationshipField<
         'audiences',
         'en-gb',
         InferDataInterface<Audience>
       >;
     }>;
     ticketSalesStart: TimestampField;
-    bookingEnquiryTeam: RelationField<
+    bookingEnquiryTeam: ContentRelationshipField<
       'teams',
       'en-gb',
       InferDataInterface<Team>
@@ -149,7 +149,7 @@ export type EventPrismicDocument = PrismicDocument<
     thirdPartyBookingUrl: LinkField;
     bookingInformation: RichTextField;
     policies: GroupField<{
-      policy: RelationField<
+      policy: ContentRelationshipField<
         'event-policy',
         'en-gb',
         InferDataInterface<EventPolicy>
@@ -158,7 +158,7 @@ export type EventPrismicDocument = PrismicDocument<
     hasEarlyRegistration: SelectField<'yes'>;
     cost: KeyTextField;
     schedule: GroupField<{
-      event: RelationField<
+      event: ContentRelationshipField<
         'events',
         'en-gb',
         // We know this is an EventPrismicDocument, but the type checker gets
@@ -171,13 +171,13 @@ export type EventPrismicDocument = PrismicDocument<
       >;
       isNotLinked: SelectField<'yes'>;
     }>;
-    backgroundTexture: RelationField<
+    backgroundTexture: ContentRelationshipField<
       'background-textures',
       'en-gb',
       InferDataInterface<BackgroundTexturesDocument>
     >;
     onlineTicketSalesStart: TimestampField;
-    onlineBookingEnquiryTeam: RelationField<
+    onlineBookingEnquiryTeam: ContentRelationshipField<
       'teams',
       'en-gb',
       InferDataInterface<Team>
@@ -187,7 +187,7 @@ export type EventPrismicDocument = PrismicDocument<
     onlineThirdPartyBookingUrl: LinkField;
     onlineBookingInformation: RichTextField;
     onlinePolicies: GroupField<{
-      policy: RelationField<
+      policy: ContentRelationshipField<
         'event-policy',
         'en-gb',
         InferDataInterface<EventPolicy>

--- a/content/webapp/services/prismic/types/exhibition-guides.ts
+++ b/content/webapp/services/prismic/types/exhibition-guides.ts
@@ -1,7 +1,7 @@
 import {
   PrismicDocument,
   RichTextField,
-  RelationField,
+  ContentRelationshipField,
   GroupField,
   NumberField,
   LinkToMediaField,
@@ -29,7 +29,7 @@ export type ExhibitionGuideComponentPrismicDocument = {
 export type ExhibitionGuidePrismicDocument = PrismicDocument<{
   title: RichTextField;
   introText: RichTextField;
-  'related-exhibition': RelationField<
+  'related-exhibition': ContentRelationshipField<
     'exhibitions',
     'en-gb',
     InferDataInterface<ExhibitionPrismicDocument>

--- a/content/webapp/services/prismic/types/exhibitions.ts
+++ b/content/webapp/services/prismic/types/exhibitions.ts
@@ -2,7 +2,7 @@ import {
   GroupField,
   TimestampField,
   PrismicDocument,
-  RelationField,
+  ContentRelationshipField,
   RichTextField,
   SelectField,
 } from '@prismicio/types';
@@ -29,7 +29,7 @@ export type ExhibitionFormat = PrismicDocument<
 
 export type ExhibitionPrismicDocument = PrismicDocument<
   {
-    format: RelationField<
+    format: ContentRelationshipField<
       'exhibition-formats',
       'en-gb',
       InferDataInterface<ExhibitionFormat>
@@ -41,9 +41,9 @@ export type ExhibitionPrismicDocument = PrismicDocument<
     statusOverride: RichTextField;
     bslInfo: RichTextField;
     audioDescriptionInfo: RichTextField;
-    place: RelationField<'place'>;
+    place: ContentRelationshipField<'place'>;
     exhibits: GroupField<{
-      item: RelationField<
+      item: ContentRelationshipField<
         'exhibitions',
         'en-gb',
         // We know this is an ExhibitionPrismicDocument, but the type checker gets
@@ -56,13 +56,13 @@ export type ExhibitionPrismicDocument = PrismicDocument<
       >;
     }>;
     events: GroupField<{
-      item: RelationField<'events'>;
+      item: ContentRelationshipField<'events'>;
     }>;
     articles: GroupField<{
-      item: RelationField<'articles'>;
+      item: ContentRelationshipField<'articles'>;
     }>;
     resources: GroupField<{
-      item: RelationField<'resources'>;
+      item: ContentRelationshipField<'resources'>;
     }>;
   } & WithContributors &
     WithExhibitionParents &

--- a/content/webapp/services/prismic/types/guides.ts
+++ b/content/webapp/services/prismic/types/guides.ts
@@ -1,7 +1,7 @@
 import {
   TimestampField,
   PrismicDocument,
-  RelationField,
+  ContentRelationshipField,
   RichTextField,
   BooleanField,
 } from '@prismicio/types';
@@ -30,7 +30,7 @@ export const guideFormatsFetchLinks: FetchLinks<GuideFormatPrismicDocument> = [
 ];
 
 export type WithGuideFormat = {
-  format: RelationField<
+  format: ContentRelationshipField<
     'guide-formats',
     'en-gb',
     InferDataInterface<GuideFormatPrismicDocument>

--- a/content/webapp/services/prismic/types/index.ts
+++ b/content/webapp/services/prismic/types/index.ts
@@ -6,8 +6,8 @@ import {
   SliceZone,
   PrismicDocument,
   GroupField,
-  RelationField,
-  FilledLinkToDocumentField,
+  ContentRelationshipField,
+  FilledContentRelationshipField,
   NumberField,
   EmptyLinkField,
 } from '@prismicio/types';
@@ -107,7 +107,7 @@ export const commonPrismicFieldsFetchLinks = [
 
 export type WithEventSeries = {
   series: GroupField<{
-    series: RelationField<
+    series: ContentRelationshipField<
       'series',
       'en-gb',
       InferDataInterface<EventSeriesPrismicDocument>
@@ -122,7 +122,7 @@ export const eventSeriesFetchLinks: FetchLinks<EventSeriesPrismicDocument> = [
 
 export type WithSeasons = {
   seasons: GroupField<{
-    season: RelationField<
+    season: ContentRelationshipField<
       'seasons',
       'en-gb',
       InferDataInterface<SeasonPrismicDocument>
@@ -137,7 +137,7 @@ export const seasonsFetchLinks: FetchLinks<SeasonPrismicDocument> = [
 ];
 
 export type WithArticleFormat = {
-  format: RelationField<
+  format: ContentRelationshipField<
     'article-formats',
     'en-gb',
     InferDataInterface<ArticleFormat>
@@ -159,7 +159,7 @@ export const projectFormatsFetchLinks: FetchLinks<ProjectFormat> = [
 export type WithExhibitionParents = {
   parents: GroupField<{
     order: NumberField;
-    parent: RelationField<
+    parent: ContentRelationshipField<
       'exhibitions',
       // We know this is an ExhibitionPrismicDocument, but the type checker gets
       // unhappy about the circular reference:
@@ -180,8 +180,8 @@ export const exhibitionsFetchLinks: FetchLinks<ExhibitionPrismicDocument> = [
 
 type Contributor =
   | EmptyLinkField<'Document'>
-  | FilledLinkToDocumentField<'people', 'en-gb', InferDataInterface<Person>>
-  | FilledLinkToDocumentField<
+  | FilledContentRelationshipField<'people', 'en-gb', InferDataInterface<Person>>
+  | FilledContentRelationshipField<
       'organisations',
       'en-gb',
       InferDataInterface<Organisation>
@@ -190,7 +190,7 @@ type Contributor =
 export type WithContributors = {
   contributorsTitle: RichTextField;
   contributors: GroupField<{
-    role: RelationField<
+    role: ContentRelationshipField<
       'editorial-contributor-roles',
       'en-gb',
       InferDataInterface<EditorialContributorRole>
@@ -229,7 +229,7 @@ export const contributorFetchLinks = [
 // Guards
 export function isFilledLinkToPersonField(
   field: Contributor
-): field is FilledLinkToDocumentField<
+): field is FilledContentRelationshipField<
   'people',
   'en-gb',
   InferDataInterface<Person>
@@ -239,7 +239,7 @@ export function isFilledLinkToPersonField(
 
 export function isFilledLinkToOrganisationField(
   field: Contributor
-): field is FilledLinkToDocumentField<
+): field is FilledContentRelationshipField<
   'organisations',
   'en-gb',
   InferDataInterface<Organisation>

--- a/content/webapp/services/prismic/types/pages.ts
+++ b/content/webapp/services/prismic/types/pages.ts
@@ -1,7 +1,7 @@
 import {
   TimestampField,
   PrismicDocument,
-  RelationField,
+  ContentRelationshipField,
   RichTextField,
   BooleanField,
 } from '@prismicio/types';
@@ -29,7 +29,7 @@ export const pageFormatsFetchLinks: FetchLinks<PageFormat> = [
 ];
 
 export type WithPageFormat = {
-  format: RelationField<
+  format: ContentRelationshipField<
     'page-formats',
     'en-gb',
     InferDataInterface<PageFormat>

--- a/content/webapp/services/prismic/types/projects.ts
+++ b/content/webapp/services/prismic/types/projects.ts
@@ -1,7 +1,7 @@
 import {
   TimestampField,
   PrismicDocument,
-  RelationField,
+  ContentRelationshipField,
   RichTextField,
 } from '@prismicio/types';
 import {
@@ -23,7 +23,7 @@ type ProjectFormat = PrismicDocument<
 
 export type ProjectPrismicDocument = PrismicDocument<
   {
-    format: RelationField<
+    format: ContentRelationshipField<
       'project-formats',
       'en-gb',
       InferDataInterface<ProjectFormat>

--- a/content/webapp/services/prismic/types/stories-landing.ts
+++ b/content/webapp/services/prismic/types/stories-landing.ts
@@ -2,7 +2,7 @@ import {
   GroupField,
   RichTextField,
   PrismicDocument,
-  RelationField,
+  ContentRelationshipField,
 } from '@prismicio/types';
 import { BookPrismicDocument } from './books';
 import { ArticlePrismicDocument } from './articles';
@@ -14,7 +14,7 @@ export type StoriesLandingPrismicDocument = PrismicDocument<{
   storiesTitle: RichTextField;
   storiesDescription: RichTextField;
   stories: GroupField<{
-    story: RelationField<
+    story: ContentRelationshipField<
       'stories',
       'en-us',
       InferDataInterface<
@@ -25,7 +25,7 @@ export type StoriesLandingPrismicDocument = PrismicDocument<{
   booksTitle: RichTextField;
   booksDescription: RichTextField;
   books: GroupField<{
-    book: RelationField<
+    book: ContentRelationshipField<
       'book',
       'en-us',
       InferDataInterface<Partial<BookPrismicDocument>>


### PR DESCRIPTION
These were deprecated after @prismicio/types v0, and are removed in the upcoming v7 release.

See https://prismic.io/docs/prismicio-client-v7-migration-guide#migrate-from-removed-deprecated-apis

Part of https://github.com/wellcomecollection/wellcomecollection.org/issues/9797