### PR TITLE
Remove no-visible-focus class

### DIFF
--- a/common/views/components/Iframe/Iframe.tsx
+++ b/common/views/components/Iframe/Iframe.tsx
@@ -1,11 +1,11 @@
-import { Component, Fragment, createRef, ReactElement } from 'react';
+import { Component, createRef, ReactElement } from 'react';
+import styled from 'styled-components';
 import { trackGaEvent } from '@weco/common/utils/ga';
 import PrismicImage from '../PrismicImage/PrismicImage';
 import Control from '@weco/common/views/components/Buttons/Control/Control';
 import ButtonSolid from '@weco/common/views/components/ButtonSolid/ButtonSolid';
 import { cross } from '@weco/common/icons';
 import { ImageType } from '@weco/common/model/image';
-import styled from 'styled-components';
 
 export const IframeContainer = styled.div.attrs({
   'data-chromatic': 'ignore',
@@ -81,7 +81,7 @@ export const IframeContainer = styled.div.attrs({
 `;
 
 const ButtonWrapper = styled.span.attrs({
-  className: 'trigger no-visible-focus',
+  className: 'trigger',
 })`
   padding: 0;
 `;
@@ -126,7 +126,7 @@ class Iframe extends Component<Props, State> {
     return (
       <IframeContainer>
         {image.contentUrl && (
-          <Fragment>
+          <>
             {!this.state.iframeShowing && (
               <ButtonWrapper onClick={this.toggleIframeDisplay}>
                 <span className="overlay" />
@@ -154,7 +154,7 @@ class Iframe extends Component<Props, State> {
                 extraClasses="close"
               />
             )}
-          </Fragment>
+          </>
         )}
         {this.state.iframeShowing && (
           <iframe

--- a/common/views/components/SegmentedControl/SegmentedControl.tsx
+++ b/common/views/components/SegmentedControl/SegmentedControl.tsx
@@ -83,7 +83,6 @@ const Item = styled.li.attrs({
 const ItemInner = styled.a.attrs<IsActiveProps>(props => ({
   className: classNames({
     'is-active': props.isActive,
-    'no-visible-focus': true,
   }),
 }))<IsActiveProps>`
   display: block;

--- a/common/views/themes/utility-classes.ts
+++ b/common/views/themes/utility-classes.ts
@@ -76,14 +76,6 @@ export const utilityClasses = css<GlobalStyleProps>`
     }
   }
 
-  // TODO See ticket for more information: https://github.com/wellcomecollection/wellcomecollection.org/issues/9558
-  .no-visible-focus {
-    &,
-    &:focus {
-      outline: 0;
-    }
-  }
-
   // TODO See ticket for more information: https://github.com/wellcomecollection/wellcomecollection.org/issues/9561
   .promo-link {
     height: 100%;


### PR DESCRIPTION
## Who is this for?
Maintenance

## What is it doing for them?
In line with removal of utility classes. This one felt pretty anti-a11y to us from the get go and we thought we should analyze what it was used for.. Turns out I couldn't see any difference. In the `IFrame` one, the span isn't focusable..? As for the `SegmentedControl`, the exact same styles are already set on the `a` element further up the tree. So this class wasn't doing anything and I'm just removing it.

Closes #9558 