### PR TITLE
Include default table header background

### DIFF
--- a/cardigan/stories/global/typography/typography.stories.tsx
+++ b/cardigan/stories/global/typography/typography.stories.tsx
@@ -77,14 +77,7 @@ const TypographyScaleSimple = () => {
   const firstRow = [['Font size unit', 'BP Large', 'BP Medium', 'BP Small']];
   const rowsWithHeadings = firstRow.concat(rowsWithScaleNumbers);
 
-  return (
-    <Table
-      caption={null}
-      hasRowHeaders={false}
-      rows={rowsWithHeadings}
-      plain={true}
-    />
-  );
+  return <Table caption={null} hasRowHeaders={false} rows={rowsWithHeadings} />;
 };
 
 const sizes = [0, 1, 2, 3, 4, 5, 6];


### PR DESCRIPTION
☝️ 

This is the table that displays in GitBook. Adding the column header at @DominiqueMarshall's request.

<img width="1051" alt="image" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/1394592/ec31d03e-a40d-48df-b1c3-931e5ec77cf8">
