### PR TITLE
Remove repetitive Tabs reference

### DIFF
--- a/common/views/components/TabNav/TabNav.tsx
+++ b/common/views/components/TabNav/TabNav.tsx
@@ -113,11 +113,7 @@ const TabNav: FunctionComponent<Props> = ({
 
   return (
     <Wrapper>
-      <TabsContainer
-        role="tablist"
-        ref={tabListRef}
-        aria-label={`Tabs for ${id}`}
-      >
+      <TabsContainer role="tablist" ref={tabListRef} aria-label={id}>
         {items.map(item => (
           <Tab
             key={item.id}

--- a/playwright/test/pages/concept.ts
+++ b/playwright/test/pages/concept.ts
@@ -32,10 +32,10 @@ export class ConceptPage {
     this.allWorksLink = this.allRecordsLink('works');
     this.allImagesLink = this.allRecordsLink('images');
     this.worksTabGroup = page.getByRole('tablist', {
-      name: 'Tabs for works',
+      name: 'works',
     });
     this.imagesTabGroup = page.getByRole('tablist', {
-      name: 'Tabs for images',
+      name: 'images',
     });
     this.worksAboutTab = this.tab(
       this.worksTabGroup,


### PR DESCRIPTION
## Who is this for?
Accessibility

## What is it doing for them?
This was flagged as repetitive (the `role` being `tablist/tab` already, the user _knows_ it's a tab) in the 2021 a11y report for the old search tabs. As we copy/pasted that in the new `TabNav` component, I'm changing it there.

Closes #8918