### PR TITLE
Make gitbook specific section for spacing/typography

### DIFF
--- a/cardigan/.storybook/manager-head.html
+++ b/cardigan/.storybook/manager-head.html
@@ -12,8 +12,9 @@ ga('send', 'pageview');
 </script>
 
 <style>
-  /* Don't show simple scale in sidebar – we're just embedding the story in GitBook */
-  #global-typography--scale-simple {
+  /* Don't show story in the sidebar – we're just embedding it in GitBook */
+  #gitbook,
+  .sidebar-item[data-parent-id="gitbook"] {
     display: none;
   }
 </style>

--- a/cardigan/stories/global/spacing/gitbook.spacing.stories.mdx
+++ b/cardigan/stories/global/spacing/gitbook.spacing.stories.mdx
@@ -1,0 +1,6 @@
+import {Meta, Story} from '@storybook/addon-docs/blocks';
+import * as stories from './spacing.stories.tsx';
+
+<Meta title={`GitBook/Spacing`} />
+
+<Story story={stories.scale} />

--- a/cardigan/stories/global/spacing/spacing.stories.tsx
+++ b/cardigan/stories/global/spacing/spacing.stories.tsx
@@ -1,9 +1,54 @@
 import { FunctionComponent } from 'react';
 import styled from 'styled-components';
-
+import Table from '@weco/common/views/components/Table/Table';
 import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
 import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
-import { PaletteColor } from '@weco/common/views/themes/config';
+import { PaletteColor, themeValues } from '@weco/common/views/themes/config';
+
+const { spaceAtBreakpoints } = themeValues;
+
+const SpacingScale = () => {
+  const transpose = matrix => {
+    const [row] = matrix;
+    return row.map((_, column) => matrix.map(row => row[column])).reverse();
+  };
+
+  const cols = Object.entries(spaceAtBreakpoints)
+    .map(entry => {
+      const value = entry[1];
+      return Object.entries(value).map((e, index) => {
+        const v = e[1];
+
+        return <span key={index}>{v}</span>;
+      });
+    })
+    .reverse();
+
+  const rows = transpose(cols);
+  const rowsWithScaleColumn = rows.map((row, index) => {
+    return [
+      <span key={index}>
+        {
+          {
+            0: 'XL',
+            1: 'L',
+            2: 'M',
+            3: 'S',
+            4: 'XS',
+          }[index]
+        }
+      </span>,
+      ...row,
+    ];
+  });
+  const firstRow = [['Size', 'BP Large', 'BP Medium', 'BP Small']];
+  const rowsWithHeadings = firstRow.concat(rowsWithScaleColumn);
+
+  return <Table caption={null} hasRowHeaders={false} rows={rowsWithHeadings} />;
+};
+
+const ScaleTemplate = () => <SpacingScale />;
+export const scale = ScaleTemplate.bind({});
 
 const ColorSection = styled.div<{ bgColor: PaletteColor }>`
   background-color: ${props => props.theme.color(props.bgColor)};

--- a/cardigan/stories/global/typography/gitbook.typography.stories.mdx
+++ b/cardigan/stories/global/typography/gitbook.typography.stories.mdx
@@ -1,0 +1,6 @@
+import {Meta, Story} from '@storybook/addon-docs/blocks';
+import * as stories from './typography.stories.tsx';
+
+<Meta title={`GitBook/Typography`} />
+
+<Story story={stories.scaleSimple} />

--- a/cardigan/stories/global/typography/typography.stories.mdx
+++ b/cardigan/stories/global/typography/typography.stories.mdx
@@ -12,8 +12,6 @@ Each of these sizes is responsive, being largest at the large breakpoint, becomi
 
   <Story story={stories.scale} />
 
-  <Story story={stories.scaleSimple} />
-
 ## Font families
 
 We use Wellcome Bold, Inter, and Lettera on the site.


### PR DESCRIPTION
Closes #9807

Adding a spacing table for use in GitBook (to replace the static values there currently)

<img width="896" alt="image" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/1394592/728d73e5-95f4-4882-81da-31c629b54161">

Instead of hiding stories on an ad hoc basis, I figured it would make more sense to have a dedicated 'GitBook' section in Storybook that doesn't show up in the sidebar (but that we can still embed).

