### PR TITLE
Apply color at parent level

### DIFF
--- a/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
+++ b/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
@@ -38,6 +38,10 @@ type CanvasLink = {
   canvas: number;
 };
 
+const Container = styled.div`
+  color: ${props => props.theme.color('black')};
+`;
+
 const ImageInfoWrapper = styled.div`
   ${props => props.theme.media('large')`
     display: flex;
@@ -59,9 +63,8 @@ const Metadata = styled.span`
 `;
 
 const ModalTitle = styled.h2.attrs({
-  className: `${font('intb', 3)}`,
+  className: font('intb', 3),
 })`
-  color: ${props => props.theme.color('black')};
   margin-bottom: 0;
 `;
 
@@ -290,7 +293,7 @@ const ExpandedImage: FunctionComponent<Props> = ({
   const displayTitle = detailedWork?.title ?? '';
 
   return (
-    <>
+    <Container>
       <ImageInfoWrapper>
         {iiifImageLocation && expandedImageLink && (
           <ImageWrapper>
@@ -362,7 +365,7 @@ const ExpandedImage: FunctionComponent<Props> = ({
           onClickImage={setExpandedImage}
         />
       )}
-    </>
+    </Container>
   );
 };
 

--- a/catalogue/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.tsx
+++ b/catalogue/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.tsx
@@ -17,10 +17,6 @@ type Props = {
 
 type State = 'initial' | 'loading' | 'success' | 'failed';
 
-const Container = styled.div`
-  color: ${props => props.theme.color('black')};
-`;
-
 const Wrapper = styled(Space).attrs({
   v: { size: 's', properties: ['margin-bottom', 'margin-top'] },
 })`
@@ -91,7 +87,7 @@ const VisuallySimilarImagesFromApi: FunctionComponent<Props> = ({
     );
 
   return similarImages.length === 0 ? null : (
-    <Container>
+    <>
       <h3 className={font('wb', 5)}>Visually similar images</h3>
 
       <Wrapper>
@@ -135,7 +131,7 @@ const VisuallySimilarImagesFromApi: FunctionComponent<Props> = ({
         </a>{' '}
         if something doesn&rsquo;t look right.
       </p>
-    </Container>
+    </>
   );
 };
 export default VisuallySimilarImagesFromApi;


### PR DESCRIPTION
## Who is this for?
Users

## What is it doing for them?
Ensures the whole content shows up, currently the copy under the Visually Similar images is not visible. This is because the text appears in white as the Image Grid's _parent_ has that set as a style. I'm sure I've had to fix that in the past (both on the title and that copy) but maybe something reverted. Either way, I'm applying black to the whole Modal now.

<img width="1284" alt="Screenshot 2023-05-19 at 15 36 45" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/ec40eab5-6d5f-4dab-afd3-f9f7c79ff5be">

<img width="1079" alt="Screenshot 2023-05-19 at 16 00 44" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/d0221a2f-634b-4ac9-b578-10f30aea4877">
