### PR TITLE
Search within refactor

### DIFF
--- a/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
+++ b/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
@@ -272,14 +272,12 @@ const ExpandedImage: FunctionComponent<Props> = ({
           trackingSource
         )
       : detailedWork &&
-        itemLink(
-          {
-            workId,
-            resultPosition,
-            ...(canvasDeeplink || {}),
-          },
-          trackingSource
-        );
+        workId &&
+        itemLink({
+          workId,
+          props: { resultPosition, ...(canvasDeeplink || {}) },
+          source: trackingSource,
+        });
 
   if (!detailedWork) {
     return (

--- a/catalogue/webapp/components/IIIFSearchWithin/IIIFSearchWithin.tsx
+++ b/catalogue/webapp/components/IIIFSearchWithin/IIIFSearchWithin.tsx
@@ -153,12 +153,23 @@ const IIIFSearchWithin: FunctionComponent = () => {
   return (
     <>
       <SearchForm
-        action="/"
+        action={router.asPath}
         onSubmit={event => {
           event.preventDefault();
-          getSearchResults();
+          const link = itemLink({
+            workId: work.id,
+            props: {
+              canvas: query.canvas,
+              manifest: query.manifest,
+              query: value,
+            },
+            source: 'search_within_submit',
+          });
+          router.replace(link.href, link.as);
         }}
       >
+        <input type="hidden" name="canvas" value={query.canvas} />
+        <input type="hidden" name="manifest" value={query.manifest} />
         <SearchInputWrapper>
           <TextInput
             id="searchWithin"

--- a/catalogue/webapp/components/IIIFSearchWithin/IIIFSearchWithin.tsx
+++ b/catalogue/webapp/components/IIIFSearchWithin/IIIFSearchWithin.tsx
@@ -134,8 +134,6 @@ const Hit: FunctionComponent<HitProps> = ({
 const IIIFSearchWithin: FunctionComponent = () => {
   const router = useRouter();
   const inputRef = useRef<HTMLInputElement>(null);
-  const [value, setValue] = useState('');
-  const [isLoading, setIsLoading] = useState(false);
   const {
     transformedManifest,
     searchResults,
@@ -144,7 +142,22 @@ const IIIFSearchWithin: FunctionComponent = () => {
     query,
     work,
   } = useContext(ItemViewerContext);
+  const [value, setValue] = useState(query.query);
+  const [isLoading, setIsLoading] = useState(false);
   const { searchService, canvases } = { ...transformedManifest };
+
+  function handleClearResults() {
+    const link = itemLink({
+      workId: work.id,
+      props: {
+        manifest: query.manifest,
+        canvas: query.canvas,
+      },
+      source: 'search_within_clear',
+    });
+    setSearchResults(results);
+    router.replace(link.href, link.as);
+  }
 
   async function getSearchResults() {
     if (searchService && query.query.length > 0) {
@@ -199,6 +212,7 @@ const IIIFSearchWithin: FunctionComponent = () => {
                 action: 'clear search',
                 label: 'item-search-within',
               }}
+              clickHandler={handleClearResults}
               setValue={setValue}
               right={10}
             />

--- a/catalogue/webapp/components/IIIFSearchWithin/IIIFSearchWithin.tsx
+++ b/catalogue/webapp/components/IIIFSearchWithin/IIIFSearchWithin.tsx
@@ -222,14 +222,15 @@ const IIIFSearchWithin: FunctionComponent = () => {
               <ListItem key={i}>
                 <SearchResult>
                   <NextLink
-                    {...itemLink(
-                      {
-                        workId: work.id,
-                        manifest: query.manifestParam,
+                    {...itemLink({
+                      workId: work.id,
+                      props: {
+                        manifest: query.manifest,
+                        query: query.query,
                         canvas: arrayIndexToQueryParam(index || 0),
                       },
-                      'search_within_result'
-                    )}
+                      source: 'search_within_result',
+                    })}
                     onClick={() => setIsMobileSidebarActive(false)}
                   >
                     <Hit

--- a/catalogue/webapp/components/IIIFSearchWithin/IIIFSearchWithin.tsx
+++ b/catalogue/webapp/components/IIIFSearchWithin/IIIFSearchWithin.tsx
@@ -137,15 +137,17 @@ const IIIFSearchWithin: FunctionComponent = () => {
   const { searchService, canvases } = { ...transformedManifest };
 
   async function getSearchResults() {
-    if (searchService) {
+    if (searchService && query.query.length > 0) {
       setIsLoading(true);
       try {
         const results = await (
-          await fetch(`${searchService['@id']}?q=${value}`)
+          await fetch(`${searchService['@id']}?q=${query.query}`)
         ).json();
         setIsLoading(false);
         setSearchResults(results);
       } catch (error) {}
+    } else {
+      setSearchResults(results);
     }
   }
   return (

--- a/catalogue/webapp/components/IIIFSearchWithin/IIIFSearchWithin.tsx
+++ b/catalogue/webapp/components/IIIFSearchWithin/IIIFSearchWithin.tsx
@@ -1,9 +1,18 @@
-import { useState, useContext, FunctionComponent, useRef } from 'react';
+import { useRouter } from 'next/router';
+import {
+  useState,
+  useContext,
+  useEffect,
+  FunctionComponent,
+  useRef,
+} from 'react';
 import TextInput from '@weco/common/views/components/TextInput/TextInput';
 import styled from 'styled-components';
 import { font } from '@weco/common/utils/classnames';
 import ButtonSolid from '@weco/common/views/components/ButtonSolid/ButtonSolid';
-import ItemViewerContext from '../ItemViewerContext/ItemViewerContext';
+import ItemViewerContext, {
+  results,
+} from '../ItemViewerContext/ItemViewerContext';
 import Space from '@weco/common/views/components/styled/Space';
 import LL from '@weco/common/views/components/styled/LL';
 import ClearSearch from '@weco/common/views/components/ClearSearch/ClearSearch';
@@ -123,6 +132,7 @@ const Hit: FunctionComponent<HitProps> = ({
 };
 
 const IIIFSearchWithin: FunctionComponent = () => {
+  const router = useRouter();
   const inputRef = useRef<HTMLInputElement>(null);
   const [value, setValue] = useState('');
   const [isLoading, setIsLoading] = useState(false);

--- a/catalogue/webapp/components/IIIFSearchWithin/IIIFSearchWithin.tsx
+++ b/catalogue/webapp/components/IIIFSearchWithin/IIIFSearchWithin.tsx
@@ -173,6 +173,11 @@ const IIIFSearchWithin: FunctionComponent = () => {
       setSearchResults(results);
     }
   }
+
+  useEffect(() => {
+    getSearchResults();
+  }, [query.query, query.manifest]);
+
   return (
     <>
       <SearchForm
@@ -229,7 +234,7 @@ const IIIFSearchWithin: FunctionComponent = () => {
       </SearchForm>
       <div aria-live="polite">
         {isLoading && <Loading />}
-        {searchResults.within.total !== null && (
+        {Boolean(searchResults.within.total !== null && query.query) && (
           <ResultsHeader data-test-id="results-header">
             {searchResults.within.total}{' '}
             {searchResults.within.total === 1 ? 'result' : 'results'}

--- a/catalogue/webapp/components/IIIFViewer/GridViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/GridViewer.tsx
@@ -84,17 +84,18 @@ const Cell = memo(({ columnIndex, rowIndex, style, data }: CellProps) => {
         currentCanvas && (
           <ThumbnailSpacer>
             <NextLink
-              {...itemLink(
-                {
-                  workId,
-                  manifest: query.manifestParam,
+              {...itemLink({
+                workId,
+                props: {
+                  manifest: query.manifest,
+                  query: query.query,
                   canvas: arrayIndexToQueryParam(canvasIndex),
                 },
-                'viewer/thumbnail'
-              )}
+                source: 'viewer/thumbnail',
+              })}
               passHref={true}
               aria-current={
-                canvasIndex === queryParamToArrayIndex(query.canvasParam)
+                canvasIndex === queryParamToArrayIndex(query.canvas)
               }
               onClick={() => {
                 setGridVisible(false);
@@ -102,9 +103,7 @@ const Cell = memo(({ columnIndex, rowIndex, style, data }: CellProps) => {
             >
               <IIIFCanvasThumbnail
                 canvas={currentCanvas}
-                isActive={
-                  canvasIndex === queryParamToArrayIndex(query.canvasParam)
-                }
+                isActive={canvasIndex === queryParamToArrayIndex(query.canvas)}
                 thumbNumber={arrayIndexToQueryParam(canvasIndex)}
                 isFocusable={gridVisible}
                 highlightImage={hasSearchResults}
@@ -160,10 +159,10 @@ const GridViewer: FunctionComponent = () => {
 
   useEffect(() => {
     const rowIndex = Math.floor(
-      queryParamToArrayIndex(query.canvasParam) / columnCount
+      queryParamToArrayIndex(query.canvas) / columnCount
     );
     grid.current?.scrollToItem({ align: 'start', rowIndex });
-  }, [query.canvasParam]);
+  }, [query.canvas]);
 
   useEffect(() => {
     // required to be set as we are setting the body to overflow hidden to stop multiple scrolls in view bug issue.

--- a/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
@@ -32,8 +32,8 @@ import { fromQuery } from '@weco/catalogue/components/ItemLink';
 
 // canvas and manifest params use 1-based indexing, but are used to access items in 0 indexed arrays,
 // so we need to convert it in various places
-export function queryParamToArrayIndex(canvasParam: number): number {
-  return canvasParam - 1;
+export function queryParamToArrayIndex(canvas: number): number {
+  return canvas - 1;
 }
 
 export function arrayIndexToQueryParam(canvasIndex: number): number {
@@ -204,10 +204,11 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
 }: IIIFViewerProps) => {
   const router = useRouter();
   const {
-    page: pageParam = 1,
-    canvas: canvasParam = 1,
-    manifest: manifestParam = 1,
+    page = 1,
+    canvas = 1,
+    manifest = 1,
     shouldScrollToCanvas = true,
+    query = '',
   } = fromQuery(router.query);
   const [gridVisible, setGridVisible] = useState(false);
   const [parentManifest, setParentManifest] = useState<Manifest | undefined>();
@@ -228,7 +229,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
   const imageUrl = urlTemplate && urlTemplate({ size: '800,' });
   const hasIiifImage = imageUrl && iiifImageLocation;
   const currentCanvas =
-    transformedManifest?.canvases[queryParamToArrayIndex(canvasParam)];
+    transformedManifest?.canvases[queryParamToArrayIndex(canvas)];
   const mainImageService = { '@id': currentCanvas?.imageServiceId };
   const hasImageService = mainImageService['@id'] && currentCanvas;
   const { parentManifestUrl } = { ...transformedManifest };
@@ -274,10 +275,11 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
       value={{
         // DATA props:
         query: {
-          pageParam,
-          canvasParam,
-          manifestParam,
+          page,
+          canvas,
+          manifest,
           shouldScrollToCanvas,
+          query,
         },
         work,
         transformedManifest,

--- a/catalogue/webapp/components/IIIFViewer/ImageViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ImageViewer.tsx
@@ -94,7 +94,7 @@ const ImageViewer: FunctionComponent<ImageViewerProps> = ({
       .join(',')
   );
   const matching = rotatedImages.find(
-    canvas => queryParamToArrayIndex(canvas.canvasParam) === index
+    canvas => queryParamToArrayIndex(canvas.canvas) === index
   );
 
   const rotation = matching ? matching.rotation : 0;
@@ -122,15 +122,16 @@ const ImageViewer: FunctionComponent<ImageViewerProps> = ({
   // we update the canvas param to match
   useSkipInitialEffect(() => {
     if (isOnScreen && transformedManifest) {
-      const link = itemLink(
-        {
-          workId: work.id,
-          manifest: query.manifestParam,
+      const link = itemLink({
+        workId: work.id,
+        props: {
+          manifest: query.manifest,
+          query: query.query,
           canvas: arrayIndexToQueryParam(index),
           shouldScrollToCanvas: false,
         },
-        'viewer/scroll'
-      );
+        source: 'viewer/scroll',
+      });
       Router.replace(link.href, link.as);
     }
   }, [isOnScreen]);

--- a/catalogue/webapp/components/IIIFViewer/ImageViewerControls.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ImageViewerControls.tsx
@@ -88,7 +88,7 @@ const ImageViewerControls: FunctionComponent = () => {
     setRotatedImages,
     setShowZoomed,
   } = useContext(ItemViewerContext);
-  const { canvasParam } = query;
+  const { canvas } = query;
 
   return (
     <ImageViewerControlsEl showControls={showControls}>
@@ -117,7 +117,7 @@ const ImageViewerControls: FunctionComponent = () => {
             setRotatedImages(
               updateRotatedImages({
                 rotatedImages,
-                canvasParam,
+                canvas,
               })
             );
           }}

--- a/catalogue/webapp/components/IIIFViewer/ImageViewerControls.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ImageViewerControls.tsx
@@ -53,7 +53,7 @@ function updateRotatedImages({
   canvasParam: number;
 }): RotatedImage[] {
   const matchingIndex = rotatedImages.findIndex(
-    rotation => rotation.canvasParam === canvasParam
+    rotation => rotation.canvas === canvasParam
   );
   if (matchingIndex >= 0) {
     return rotatedImages.map((rotatedImage, i) => {
@@ -62,7 +62,7 @@ function updateRotatedImages({
         const newRotationValue =
           currentRotationValue < 270 ? currentRotationValue + 90 : 0;
         return {
-          canvasParam: rotatedImage.canvasParam,
+          canvas: rotatedImage.canvas,
           rotation: newRotationValue,
         };
       } else {
@@ -73,7 +73,7 @@ function updateRotatedImages({
     return [
       ...rotatedImages,
       {
-        canvasParam,
+        canvas: canvasParam,
         rotation: 90,
       },
     ];
@@ -117,7 +117,7 @@ const ImageViewerControls: FunctionComponent = () => {
             setRotatedImages(
               updateRotatedImages({
                 rotatedImages,
-                canvas,
+                canvasParam: canvas,
               })
             );
           }}

--- a/catalogue/webapp/components/IIIFViewer/MainViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/MainViewer.tsx
@@ -283,12 +283,12 @@ ItemRenderer.displayName = 'ItemRenderer';
 
 function scrollViewer({
   currentCanvas,
-  canvasParam,
+  canvas,
   viewer,
   mainAreaWidth,
 }: {
   currentCanvas: TransformedCanvas | undefined;
-  canvasParam: number;
+  canvas: number;
   viewer: FixedSizeList | null;
   mainAreaWidth: number;
 }): void {
@@ -311,14 +311,14 @@ function scrollViewer({
         : 1;
     const renderedHeight = mainAreaWidth * ratio * 0.8; // TODO: 0.8 = 80% max-width image in container. Variable.
     const heightOfPreviousItems =
-      queryParamToArrayIndex(canvasParam) * (viewer?.props.itemSize || 0);
+      queryParamToArrayIndex(canvas) * (viewer?.props.itemSize || 0);
     const distanceToScroll =
       heightOfPreviousItems +
       ((viewer?.props.itemSize || 0) - renderedHeight) / 2;
     viewer?.scrollTo(distanceToScroll);
   } else {
     // 4. Otherwise, if it's portrait, we go to the start of the image
-    viewer?.scrollToItem(queryParamToArrayIndex(canvasParam), 'start');
+    viewer?.scrollToItem(queryParamToArrayIndex(canvas), 'start');
   }
 }
 
@@ -333,7 +333,7 @@ const MainViewer: FunctionComponent = () => {
     setShowControls,
     errorHandler,
   } = useContext(ItemViewerContext);
-  const { shouldScrollToCanvas, canvasParam } = query;
+  const { shouldScrollToCanvas, canvas } = query;
   const mainViewerRef = useRef<FixedSizeList>(null);
   const [newScrollOffset, setNewScrollOffset] = useState(0);
   const [firstRender, setFirstRender] = useState(true);
@@ -357,31 +357,31 @@ const MainViewer: FunctionComponent = () => {
     }, 500);
   }
 
-  // We display the canvas indicated by the canvasParam when the page first loads
+  // We display the canvas indicated by the canvas when the page first loads
   function handleOnItemsRendered() {
     let currentCanvas: TransformedCanvas | undefined;
     if (firstRenderRef.current) {
-      currentCanvas = canvases?.[queryParamToArrayIndex(canvasParam)];
+      currentCanvas = canvases?.[queryParamToArrayIndex(canvas)];
       const viewer = mainViewerRef?.current;
-      scrollViewer({ currentCanvas, canvasParam, viewer, mainAreaWidth });
+      scrollViewer({ currentCanvas, canvas, viewer, mainAreaWidth });
       setFirstRender(false);
       setShowControls(true);
     }
   }
 
-  // Scroll to the correct canvas  when the canvasParam changes.
-  // But we don't want this to happen if the canvasParam changes as a result of the viewer being scrolled,
+  // Scroll to the correct canvas  when the canvas changes.
+  // But we don't want this to happen if the canvas changes as a result of the viewer being scrolled,
   // so ItemLink href prop can include a shouldScrollToCanvas query param on the href object to prevent this.
   useEffect(() => {
     if (shouldScrollToCanvas) {
       scrollViewer({
-        currentCanvas: canvases?.[queryParamToArrayIndex(canvasParam)],
-        canvasParam,
+        currentCanvas: canvases?.[queryParamToArrayIndex(canvas)],
+        canvas,
         viewer: mainViewerRef?.current,
         mainAreaWidth,
       });
     }
-  }, [canvasParam]);
+  }, [canvas]);
 
   return (
     <div data-test-id="main-viewer">
@@ -397,7 +397,7 @@ const MainViewer: FunctionComponent = () => {
           rotatedImages,
           errorHandler,
           restrictedService,
-          canvasParam,
+          canvas,
         }}
         itemSize={mainAreaWidth}
         onItemsRendered={debounceHandleOnItemsRendered.current}

--- a/catalogue/webapp/components/IIIFViewer/MultipleManifestList.tsx
+++ b/catalogue/webapp/components/IIIFViewer/MultipleManifestList.tsx
@@ -21,24 +21,23 @@ const MultipleManifestListPrototype: FunctionComponent = () => {
         {parentManifest?.items.map((manifest, i) => (
           <li key={manifest.id}>
             <NextLink
-              {...itemLink(
-                {
-                  workId: work.id,
-                  manifest: i + 1,
+              {...itemLink({
+                workId: work.id,
+                props: {
                   canvas: 1,
+                  query: query.query,
+                  manifest: i + 1,
                 },
-                'manifests_navigation'
-              )}
+                source: 'manifests_navigation',
+              })}
               passHref={true}
               legacyBehavior
             >
               <Anchor
                 data-gtm-trigger="volumes_nav_link"
-                isManifestIndex={
-                  i === queryParamToArrayIndex(query.manifestParam)
-                }
+                isManifestIndex={i === queryParamToArrayIndex(query.manifest)}
                 aria-current={
-                  i === queryParamToArrayIndex(query.manifestParam)
+                  i === queryParamToArrayIndex(query.manifest)
                     ? 'page'
                     : undefined
                 }

--- a/catalogue/webapp/components/IIIFViewer/NoScriptViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/NoScriptViewer.tsx
@@ -157,13 +157,13 @@ const NoScriptViewer: FunctionComponent<NoScriptViewerProps> = ({
   const { work, query, transformedManifest } = useContext(ItemViewerContext);
   const lang = (work.languages.length === 1 && work.languages[0].id) || '';
   const { canvases } = { ...transformedManifest };
-  const currentCanvas = canvases?.[queryParamToArrayIndex(query.canvasParam)];
+  const currentCanvas = canvases?.[queryParamToArrayIndex(query.canvas)];
   const mainImageService = { '@id': currentCanvas?.imageServiceId };
-  const pageIndex = queryParamToArrayIndex(query.pageParam);
+  const pageIndex = queryParamToArrayIndex(query.page);
   const pageSize = 4;
   const navigationCanvases = canvases
     ? [...Array(pageSize)]
-        .map((_, i) => pageSize * queryParamToArrayIndex(query.pageParam) + i)
+        .map((_, i) => pageSize * queryParamToArrayIndex(query.page) + i)
         .map(i => canvases?.[i])
         .filter(Boolean)
     : [];
@@ -179,24 +179,23 @@ const NoScriptViewer: FunctionComponent<NoScriptViewerProps> = ({
       .join(',');
   const sharedPaginatorProps = {
     totalResults: canvases?.length || 1,
-    link: itemLink(
-      {
-        workId: work.id,
-        page: query.pageParam,
-        canvas: query.canvasParam,
-        manifest: query.manifestParam || undefined,
+    link: itemLink({
+      workId: work.id,
+      props: {
+        canvas: query.canvas,
+        page: query.page,
       },
-      'viewer/paginator'
-    ),
+      source: 'viewer/paginator',
+    }),
   };
   const mainPaginatorProps = {
-    currentPage: query.canvasParam,
+    currentPage: query.canvas,
     pageSize: 1,
     linkKey: 'canvas',
     ...sharedPaginatorProps,
   };
   const thumbsPaginatorProps = {
-    currentPage: query.pageParam,
+    currentPage: query.page,
     pageSize: 4,
     linkKey: 'page',
     ...sharedPaginatorProps,
@@ -252,14 +251,14 @@ const NoScriptViewer: FunctionComponent<NoScriptViewerProps> = ({
                   {...thumbsPaginatorProps}
                   render={() => (
                     <NextLink
-                      {...itemLink(
-                        {
-                          workId: work.id,
+                      {...itemLink({
+                        workId: work.id,
+                        props: {
+                          canvas: query.canvas,
                           page: arrayIndexToQueryParam(pageIndex),
-                          canvas: canvasParam,
                         },
-                        'viewer/paginator'
-                      )}
+                        source: 'viewer/paginator',
+                      })}
                       scroll={false}
                       replace
                       passHref
@@ -268,7 +267,7 @@ const NoScriptViewer: FunctionComponent<NoScriptViewerProps> = ({
                       <ThumbnailLink>
                         <IIIFCanvasThumbnail
                           canvas={canvas}
-                          isActive={canvasParam === query.canvasParam}
+                          isActive={canvasParam === query.canvas}
                           thumbNumber={canvasParam}
                         />
                       </ThumbnailLink>

--- a/catalogue/webapp/components/IIIFViewer/ViewerStructures.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerStructures.tsx
@@ -48,7 +48,7 @@ const Item = styled(Space).attrs({
 const ViewerStructuresPrototype: FunctionComponent = () => {
   const { transformedManifest, setIsMobileSidebarActive, query, work } =
     useContext(ItemViewerContext);
-  const { canvasParam, manifestParam } = query;
+  const { canvas } = query;
   const { structures, canvases } = { ...transformedManifest };
   const groupedStructures = groupStructures(canvases || [], structures || []);
 
@@ -67,19 +67,20 @@ const ViewerStructuresPrototype: FunctionComponent = () => {
         return (
           <Item
             key={i}
-            isActive={canvasParam === arrayIndexToQueryParam(canvasIndex)}
+            isActive={canvas === arrayIndexToQueryParam(canvasIndex)}
           >
             <NextLink
-              {...itemLink(
-                {
-                  workId: work.id,
-                  manifest: manifestParam,
+              {...itemLink({
+                workId: work.id,
+                props: {
+                  manifest: query.manifest,
+                  query: query.query,
                   canvas: arrayIndexToQueryParam(canvasIndex),
                 },
-                'contents_nav'
-              )}
+                source: 'contents_nav',
+              })}
               data-gtm-trigger="contents_nav"
-              aria-current={canvasParam === arrayIndexToQueryParam(canvasIndex)}
+              aria-current={canvas === arrayIndexToQueryParam(canvasIndex)}
               onClick={() => {
                 setIsMobileSidebarActive(false);
               }}

--- a/catalogue/webapp/components/IIIFViewer/ViewerTopBar.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerTopBar.tsx
@@ -205,13 +205,13 @@ const ViewerTopBar: FunctionComponent = () => {
     query,
     viewerRef,
   } = useContext(ItemViewerContext);
-  const { canvasParam } = query;
+  const { canvas } = query;
   const {
     canvases,
     downloadEnabled,
     downloadOptions: manifestDownloadOptions,
   } = { ...transformedManifest };
-  const currentCanvas = canvases?.[queryParamToArrayIndex(query.canvasParam)];
+  const currentCanvas = canvases?.[queryParamToArrayIndex(query.canvas)];
   const mainImageService = { '@id': currentCanvas?.imageServiceId };
   const transformedIIIFImage = useTransformedIIIFImage(work);
   const iiifImageLocation = getDigitalLocationOfType(work, 'iiif-image');
@@ -334,14 +334,14 @@ const ViewerTopBar: FunctionComponent = () => {
         <MiddleZone className="viewer-desktop">
           {canvases && canvases.length > 1 && !showZoomed && !isResizing && (
             <>
-              <span data-test-id="active-index">{`${canvasParam || 0}`}</span>
+              <span data-test-id="active-index">{`${canvas || 0}`}</span>
               {`/${canvases?.length || ''}`}{' '}
               {!(
-                canvases[queryParamToArrayIndex(canvasParam)]?.label?.trim() ===
+                canvases[queryParamToArrayIndex(canvas)]?.label?.trim() ===
                 '-'
               ) &&
                 `(page ${canvases[
-                  queryParamToArrayIndex(canvasParam)
+                  queryParamToArrayIndex(canvas)
                 ]?.label?.trim()})`}
             </>
           )}

--- a/catalogue/webapp/components/IIIFViewer/ZoomedImage.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ZoomedImage.tsx
@@ -52,7 +52,7 @@ const ZoomedImage: FunctionComponent<Props> = ({
   const { transformedManifest, query, setShowZoomed } =
     useContext(ItemViewerContext);
   const currentCanvas =
-    transformedManifest?.canvases[queryParamToArrayIndex(query.canvasParam)];
+    transformedManifest?.canvases[queryParamToArrayIndex(query.canvas)];
   const mainImageService = {
     '@id': currentCanvas?.imageServiceId || '',
   };

--- a/catalogue/webapp/components/ItemLink/index.tsx
+++ b/catalogue/webapp/components/ItemLink/index.tsx
@@ -12,7 +12,6 @@ import { ItemLinkSource } from '@weco/common/data/segment-values';
 import { removeUndefinedProps } from '@weco/common/utils/json';
 
 const emptyItemProps: ItemProps = {
-  workId: '',
   resultPosition: undefined,
   canvas: 1,
   manifest: 1,
@@ -21,7 +20,6 @@ const emptyItemProps: ItemProps = {
 };
 
 const codecMap = {
-  workId: stringCodec,
   resultPosition: maybeNumberCodec, // This used for tracking and tells us the position of the search result that linked to the item page. It doesn't get exposed in the url
   canvas: maybeNumberCodec,
   manifest: maybeNumberCodec,

--- a/catalogue/webapp/components/ItemLink/index.tsx
+++ b/catalogue/webapp/components/ItemLink/index.tsx
@@ -5,25 +5,27 @@ import {
   FromCodecMap,
   maybeNumberCodec,
   booleanCodec,
-  stringCodec,
+  maybeStringCodec,
 } from '@weco/common/utils/routes';
 import { LinkProps } from '@weco/common/model/link-props';
 import { ItemLinkSource } from '@weco/common/data/segment-values';
 import { removeUndefinedProps } from '@weco/common/utils/json';
 
 const emptyItemProps: ItemProps = {
-  resultPosition: undefined,
   canvas: 1,
   manifest: 1,
+  query: '',
   page: 1,
+  resultPosition: undefined,
   shouldScrollToCanvas: true,
 };
 
 const codecMap = {
-  resultPosition: maybeNumberCodec, // This used for tracking and tells us the position of the search result that linked to the item page. It doesn't get exposed in the url
   canvas: maybeNumberCodec,
   manifest: maybeNumberCodec,
+  query: maybeStringCodec,
   page: maybeNumberCodec, // This is only needed by the NoScriptViewer
+  resultPosition: maybeNumberCodec, // This used for tracking and tells us the position of the search result that linked to the item page. It doesn't get exposed in the url
   shouldScrollToCanvas: booleanCodec,
 };
 
@@ -37,24 +39,27 @@ const toQuery: (props: ItemProps) => ParsedUrlQuery = props => {
   return encodeQuery<ItemProps>(props, codecMap);
 };
 
-function toLink(
-  partialProps: Partial<ItemProps>,
-  source: ItemLinkSource
-): LinkProps {
-  const props: ItemProps = {
+type ToLinkProps = {
+  workId: string;
+  props: Partial<ItemProps>;
+  source: ItemLinkSource;
+};
+
+function toLink({ workId, props, source }: ToLinkProps): LinkProps {
+  const itemProps: ItemProps = {
     ...emptyItemProps,
-    ...partialProps,
+    ...props,
   };
-  const query = toQuery(props);
-  const { canvas, manifest, page } = query;
+  const urlQuery = toQuery(itemProps);
+  const { canvas, manifest, page, query } = urlQuery;
   return {
     href: {
       pathname: '/works/[workId]/items',
-      query: { ...query, source },
+      query: { ...urlQuery, source },
     },
     as: {
-      pathname: `/works/${props.workId}/items`,
-      query: removeUndefinedProps({ canvas, manifest, page }),
+      pathname: `/works/${workId}/items`,
+      query: removeUndefinedProps({ canvas, manifest, query, page }),
     },
   };
 }

--- a/catalogue/webapp/components/ItemLink/index.tsx
+++ b/catalogue/webapp/components/ItemLink/index.tsx
@@ -1,11 +1,8 @@
-import NextLink from 'next/link';
-import { FunctionComponent } from 'react';
 import { ParsedUrlQuery } from 'querystring';
 import {
   decodeQuery,
   encodeQuery,
   FromCodecMap,
-  LinkFrom,
   maybeNumberCodec,
   booleanCodec,
   stringCodec,
@@ -64,19 +61,4 @@ function toLink(
   };
 }
 
-type Props = LinkFrom<ItemProps> & { source: ItemLinkSource };
-
-const ItemLink: FunctionComponent<Props> = ({
-  children,
-  source,
-  ...props
-}: Props) => {
-  return (
-    <NextLink {...toLink(props, source)} legacyBehavior>
-      {children}
-    </NextLink>
-  );
-};
-
-export default ItemLink;
 export { toLink, fromQuery, emptyItemProps };

--- a/catalogue/webapp/components/ItemViewerContext/ItemViewerContext.tsx
+++ b/catalogue/webapp/components/ItemViewerContext/ItemViewerContext.tsx
@@ -11,6 +11,7 @@ export type Query = {
   canvasParam: number;
   manifestParam: number;
   shouldScrollToCanvas: boolean;
+  queryParam: string;
 };
 
 type Props = {
@@ -63,6 +64,7 @@ const query = {
   pageParam: 1,
   manifestParam: 1,
   shouldScrollToCanvas: true,
+  queryParam: '',
 };
 
 const work = {

--- a/catalogue/webapp/components/ItemViewerContext/ItemViewerContext.tsx
+++ b/catalogue/webapp/components/ItemViewerContext/ItemViewerContext.tsx
@@ -4,14 +4,14 @@ import { SearchResults } from '@weco/catalogue/services/iiif/types/search/v3';
 import { Manifest } from '@iiif/presentation-3';
 import { TransformedManifest } from '../../types/manifest';
 
-export type RotatedImage = { canvasParam: number; rotation: number };
+export type RotatedImage = { canvas: number; rotation: number };
 
 export type Query = {
-  pageParam: number;
-  canvasParam: number;
-  manifestParam: number;
+  canvas: number;
+  manifest: number;
+  query: string;
+  page: number;
   shouldScrollToCanvas: boolean;
-  queryParam: string;
 };
 
 type Props = {
@@ -60,11 +60,11 @@ export const results = {
 };
 
 const query = {
-  canvasParam: 1,
-  pageParam: 1,
-  manifestParam: 1,
+  canvas: 1,
+  manifest: 1,
+  query: '',
+  page: 1,
   shouldScrollToCanvas: true,
-  queryParam: '',
 };
 
 const work = {

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -58,7 +58,7 @@ const WorkDetails: FunctionComponent<Props> = ({
   shouldShowItemLink,
 }: Props) => {
   const isArchive = useContext(IsArchiveContext);
-  const itemUrl = itemLink({ workId: work.id }, 'work');
+  const itemUrl = itemLink({ workId: work.id, source: 'work', props: {} });
   const transformedIIIFImage = useTransformedIIIFImage(work);
   const transformedIIIFManifest = useTransformedManifest(work, useToggles());
   const {

--- a/catalogue/webapp/components/WorkTabbedNav/WorkTabbedNav.tsx
+++ b/catalogue/webapp/components/WorkTabbedNav/WorkTabbedNav.tsx
@@ -9,7 +9,7 @@ type Props = {
   selected: 'catalogueDetails' | 'imageViewer';
 };
 const WorkTabbedNav: FunctionComponent<Props> = ({ work, selected }) => {
-  const itemUrl = itemLink({ workId: work.id }, 'work');
+  const itemUrl = itemLink({ workId: work.id, source: 'work', props: {} });
   return (
     <SubNavigation
       label="Search Categories"

--- a/catalogue/webapp/pages/works/[workId]/download.tsx
+++ b/catalogue/webapp/pages/works/[workId]/download.tsx
@@ -169,52 +169,54 @@ const DownloadPage: NextPage<Props> = ({ transformedManifest, work }) => {
   );
 };
 
-export const getServerSideProps: GetServerSideProps<
-  Props | AppErrorProps
-> = async context => {
-  setCacheControl(context.res);
-  const serverData = await getServerData(context);
-  const { workId } = context.query;
+export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
+  async context => {
+    setCacheControl(context.res);
+    const serverData = await getServerData(context);
+    const { workId } = context.query;
 
-  if (!looksLikeCanonicalId(workId)) {
-    return {
-      notFound: true,
-    };
-  }
+    if (!looksLikeCanonicalId(workId)) {
+      return {
+        notFound: true,
+      };
+    }
 
-  const work = await getWork({
-    id: workId,
-    toggles: serverData.toggles,
-  });
+    const work = await getWork({
+      id: workId,
+      toggles: serverData.toggles,
+    });
 
-  if (work.type === 'Error') {
-    return appError(context, work.httpStatus, work.description);
-  } else if (work.type === 'Redirect') {
-    return {
-      redirect: {
-        destination: `/works/${work.redirectToId}/download`,
-        permanent: work.status === 301,
-      },
-    };
-  }
+    if (work.type === 'Error') {
+      return appError(context, work.httpStatus, work.description);
+    } else if (work.type === 'Redirect') {
+      return {
+        redirect: {
+          destination: `/works/${work.redirectToId}/download`,
+          permanent: work.status === 301,
+        },
+      };
+    }
 
-  const manifestLocation = getDigitalLocationOfType(work, 'iiif-presentation');
-  const iiifManifest =
-    manifestLocation &&
-    (await fetchIIIFPresentationManifest(
-      manifestLocation.url,
-      serverData.toggles
-    ));
-  const transformedManifest = iiifManifest && transformManifest(iiifManifest);
-
-  return {
-    props: serialiseProps({
-      serverData,
-      workId,
-      transformedManifest,
+    const manifestLocation = getDigitalLocationOfType(
       work,
-    }),
+      'iiif-presentation'
+    );
+    const iiifManifest =
+      manifestLocation &&
+      (await fetchIIIFPresentationManifest(
+        manifestLocation.url,
+        serverData.toggles
+      ));
+    const transformedManifest = iiifManifest && transformManifest(iiifManifest);
+
+    return {
+      props: serialiseProps({
+        serverData,
+        workId,
+        transformedManifest,
+        work,
+      }),
+    };
   };
-};
 
 export default DownloadPage;

--- a/catalogue/webapp/pages/works/[workId]/items.tsx
+++ b/catalogue/webapp/pages/works/[workId]/items.tsx
@@ -320,132 +320,133 @@ const ItemPage: NextPage<Props> = ({
   );
 };
 
-export const getServerSideProps: GetServerSideProps<
-  Props | AppErrorProps
-> = async context => {
-  setCacheControl(context.res);
-  const serverData = await getServerData(context);
-  const {
-    workId,
-    canvas: canvasParam = 1,
-    manifest: manifestParam = 1,
-  } = fromQuery(context.query);
+export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
+  async context => {
+    setCacheControl(context.res);
+    const serverData = await getServerData(context);
+    const {
+      workId,
+      canvas: canvasParam = 1,
+      manifest: manifestParam = 1,
+    } = fromQuery(context.query);
 
-  if (!looksLikeCanonicalId(workId)) {
-    return { notFound: true };
-  }
-
-  const pageview: Pageview = {
-    name: 'item',
-    properties: {},
-  };
-
-  const work = await getWork({
-    id: workId,
-    toggles: serverData.toggles,
-    include: ['items', 'languages', 'contributors', 'production'],
-  });
-
-  if (work.type === 'Error') {
-    return appError(context, work.httpStatus, work.description);
-  }
-
-  if (work.type === 'Redirect') {
-    // This ensures that any query parameters are preserved on redirect,
-    // e.g. if you have a link to /works/$oldId/items?canvas=10, then
-    // you'll go to /works/$newId/items?canvas=10
-    const destination = isNotUndefined(context.req.url)
-      ? context.req.url.replace(workId, work.redirectToId)
-      : `/works/${work.redirectToId}/items`;
-
-    return {
-      redirect: {
-        destination,
-        permanent: work.status === 301,
-      },
-    };
-  }
-
-  const iiifImageLocation = getDigitalLocationOfType(work, 'iiif-image');
-  const iiifPresentationLocation = getDigitalLocationOfType(
-    work,
-    'iiif-presentation'
-  );
-  const iiifManifest =
-    iiifPresentationLocation &&
-    (await fetchIIIFPresentationManifest(
-      iiifPresentationLocation.url,
-      serverData.toggles
-    ));
-
-  const transformedManifest = iiifManifest && transformManifest(iiifManifest);
-
-  const { isCollectionManifest, manifests } = { ...transformedManifest };
-  // If the manifest is actually a Collection, .i.e. a manifest of manifests,
-  // then we get the first child manifest and use the data from that
-  // see: https://iiif.wellcomecollection.org/presentation/v2/b21293302
-  // from: https://wellcomecollection.org/works/f6qp7m32/items
-  async function getDisplayManifest(
-    transformedManifest: TransformedManifest,
-    manifestIndex: number
-  ): Promise<TransformedManifest> {
-    if (isCollectionManifest) {
-      const selectedCollectionManifestLocation = manifests?.[manifestIndex]?.id;
-      const selectedCollectionManifest = selectedCollectionManifestLocation
-        ? await fetchIIIFPresentationManifest(
-            selectedCollectionManifestLocation,
-            serverData.toggles
-          )
-        : undefined;
-      const firstChildTransformedManifest =
-        selectedCollectionManifest &&
-        transformManifest(selectedCollectionManifest);
-      return firstChildTransformedManifest || transformedManifest;
-    } else {
-      return transformedManifest;
+    if (!looksLikeCanonicalId(workId)) {
+      return { notFound: true };
     }
-  }
 
-  if (transformedManifest) {
-    const displayManifest = await getDisplayManifest(
-      transformedManifest,
-      queryParamToArrayIndex(manifestParam)
+    const pageview: Pageview = {
+      name: 'item',
+      properties: {},
+    };
+
+    const work = await getWork({
+      id: workId,
+      toggles: serverData.toggles,
+      include: ['items', 'languages', 'contributors', 'production'],
+    });
+
+    if (work.type === 'Error') {
+      return appError(context, work.httpStatus, work.description);
+    }
+
+    if (work.type === 'Redirect') {
+      // This ensures that any query parameters are preserved on redirect,
+      // e.g. if you have a link to /works/$oldId/items?canvas=10, then
+      // you'll go to /works/$newId/items?canvas=10
+      const destination = isNotUndefined(context.req.url)
+        ? context.req.url.replace(workId, work.redirectToId)
+        : `/works/${work.redirectToId}/items`;
+
+      return {
+        redirect: {
+          destination,
+          permanent: work.status === 301,
+        },
+      };
+    }
+
+    const iiifImageLocation = getDigitalLocationOfType(work, 'iiif-image');
+    const iiifPresentationLocation = getDigitalLocationOfType(
+      work,
+      'iiif-presentation'
     );
-    const { canvases } = displayManifest;
-    const currentCanvas = canvases[queryParamToArrayIndex(canvasParam)];
-    const canvasOcrText = await fetchCanvasOcr(currentCanvas);
-    const canvasOcr = transformCanvasOcr(canvasOcrText);
+    const iiifManifest =
+      iiifPresentationLocation &&
+      (await fetchIIIFPresentationManifest(
+        iiifPresentationLocation.url,
+        serverData.toggles
+      ));
+
+    const transformedManifest = iiifManifest && transformManifest(iiifManifest);
+
+    const { isCollectionManifest, manifests } = { ...transformedManifest };
+    // If the manifest is actually a Collection, .i.e. a manifest of manifests,
+    // then we get the first child manifest and use the data from that
+    // see: https://iiif.wellcomecollection.org/presentation/v2/b21293302
+    // from: https://wellcomecollection.org/works/f6qp7m32/items
+    async function getDisplayManifest(
+      transformedManifest: TransformedManifest,
+      manifestIndex: number
+    ): Promise<TransformedManifest> {
+      if (isCollectionManifest) {
+        const selectedCollectionManifestLocation =
+          manifests?.[manifestIndex]?.id;
+        const selectedCollectionManifest = selectedCollectionManifestLocation
+          ? await fetchIIIFPresentationManifest(
+              selectedCollectionManifestLocation,
+              serverData.toggles
+            )
+          : undefined;
+        const firstChildTransformedManifest =
+          selectedCollectionManifest &&
+          transformManifest(selectedCollectionManifest);
+        return firstChildTransformedManifest || transformedManifest;
+      } else {
+        return transformedManifest;
+      }
+    }
+
+    if (transformedManifest) {
+      const displayManifest = await getDisplayManifest(
+        transformedManifest,
+        queryParamToArrayIndex(manifestParam)
+      );
+
+      const { canvases } = displayManifest;
+      const currentCanvas = canvases[queryParamToArrayIndex(canvasParam)];
+      const canvasOcrText = await fetchCanvasOcr(currentCanvas);
+      const canvasOcr = transformCanvasOcr(canvasOcrText);
+
+      return {
+        props: serialiseProps({
+          transformedManifest: displayManifest,
+          canvasOcr,
+          work,
+          canvasParam,
+          iiifImageLocation,
+          pageview,
+          serverData,
+        }),
+      };
+    }
+
+    if (iiifImageLocation) {
+      return {
+        props: serialiseProps({
+          transformedManifest: undefined,
+          work,
+          canvasParam,
+          canvases: [],
+          iiifImageLocation,
+          pageview,
+          serverData,
+        }),
+      };
+    }
 
     return {
-      props: serialiseProps({
-        transformedManifest: displayManifest,
-        canvasOcr,
-        work,
-        canvasParam,
-        iiifImageLocation,
-        pageview,
-        serverData,
-      }),
+      notFound: true,
     };
-  }
-
-  if (iiifImageLocation) {
-    return {
-      props: serialiseProps({
-        transformedManifest: undefined,
-        work,
-        canvasParam,
-        canvases: [],
-        iiifImageLocation,
-        pageview,
-        serverData,
-      }),
-    };
-  }
-
-  return {
-    notFound: true,
   };
-};
 
 export default ItemPage;

--- a/common/data/segment-values.ts
+++ b/common/data/segment-values.ts
@@ -55,8 +55,10 @@ export type ItemLinkSource =
   | 'viewer/scroll'
   | 'viewer/resize'
   | 'manifests_navigation'
-  | 'search_within_result'
-  | 'contents_nav';
+  | 'contents_nav'
+  | 'search_within_submit'
+  | 'search_within_clear'
+  | 'search_within_result';
 
 export type WorkLinkSource =
   | 'works_search_result'

--- a/common/views/components/ClearSearch/ClearSearch.tsx
+++ b/common/views/components/ClearSearch/ClearSearch.tsx
@@ -15,6 +15,7 @@ const Button = styled.button`
 type Props = {
   inputRef: RefObject<HTMLInputElement>;
   setValue: Dispatch<SetStateAction<string>>;
+  clickHandler?: () => void;
   gaEvent?: GaEvent;
   right?: number;
 };
@@ -24,6 +25,7 @@ const ClearSearch: FunctionComponent<Props> = ({
   setValue,
   gaEvent,
   right,
+  clickHandler,
 }: Props) => {
   return (
     <Button
@@ -31,6 +33,7 @@ const ClearSearch: FunctionComponent<Props> = ({
       onClick={() => {
         gaEvent && trackGaEvent(gaEvent);
         setValue('');
+        clickHandler && clickHandler();
         inputRef?.current?.focus();
       }}
       type="button"


### PR DESCRIPTION
Fixes #9650

There are quite a few file changes, but most of the magic happens in **IIIFSearchWithin.tsx** and **ItemLink/index.tsx**. The rest are the result of var name changes and a change to the parameters the the itemLink function accepts.

This PR changes the form in the IIIFSearchWithin component to update the item page url with the search query, rather than just holding it in state. This means searching within an item results in a page view, that will be tracked via Segment, with a source of 'search_within_submit':

<img width="800" alt="Screenshot 2023-05-19 at 10 53 39" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/6051896/32120061-cc37-4cbc-872f-e75206408325">


Other bonuses include:
- changing the volume now causes the search to be redone for the volume being viewed. Previously, if a user switched volumes after conducting a search, the old results would remain and the search result links wouldn't work.
- clearing the text input now also clears the search results.
- people can bookmark/share links with the search query included.
 