### PR TITLE
Add colour table for gitbook

### DIFF
--- a/cardigan/stories/global/palette/gitbook.palette.stories.mdx
+++ b/cardigan/stories/global/palette/gitbook.palette.stories.mdx
@@ -1,0 +1,6 @@
+import {Meta, Story} from '@storybook/addon-docs/blocks';
+import * as stories from './palette.stories.tsx';
+
+<Meta title={`GitBook/Palette`} />
+
+<Story story={stories.gitbookPalette} />

--- a/cardigan/stories/global/palette/palette.stories.tsx
+++ b/cardigan/stories/global/palette/palette.stories.tsx
@@ -3,6 +3,7 @@ import { themeValues } from '@weco/common/views/themes/config';
 import styled from 'styled-components';
 import { font } from '@weco/common/utils/classnames';
 import Divider from '@weco/common/views/components/Divider/Divider';
+import Table from '@weco/common/views/components/Table/Table';
 import {
   RGB,
   HSL,
@@ -133,6 +134,46 @@ Object.entries(themeValues.colors)
     }
   })
   .filter(Boolean);
+
+const Swatch = ({ hex }) => {
+  return (
+    <div
+      style={{
+        width: '40px',
+        height: '40px',
+        borderRadius: '50%',
+        backgroundColor: hex,
+        border: hex === '#ffffff' ? '1px solid #ddd' : undefined,
+      }}
+    />
+  );
+};
+
+const GitbookPalette = () => {
+  function getNameAndType(key: string): [string, string] {
+    if (!key.includes('.')) return [key, 'core'];
+
+    return [key.slice(key.indexOf('.') + 1), key.slice(0, key.indexOf('.'))];
+  }
+
+  const headings = ['Name', 'Type', 'Hex', 'Swatch'];
+
+  const gitbookColorRows = Object.keys(themeValues.colors).map(key => {
+    const hex = themeValues.colors[key];
+    const nameAndType = getNameAndType(key);
+    return [
+      nameAndType[0],
+      nameAndType[1],
+      hex,
+      <Swatch key={key} hex={hex} />,
+    ];
+  });
+
+  return <Table rows={[headings, ...gitbookColorRows]} />;
+};
+
+const GitbookPaletteTemplate = () => <GitbookPalette />;
+export const gitbookPalette = GitbookPaletteTemplate.bind({});
 
 export const Palette: FunctionComponent = () => (
   <>


### PR DESCRIPTION
Closes #9808

A table in Storybook to embed in Gitbook to replace [the static one](https://app.gitbook.com/o/-LumfFcEMKx4gYXKAZTQ/s/SreoRFZHSJqTwnKOTN2h/foundations/design-tokens#3.-colour) that is out of date.

<img width="717" alt="image" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/1394592/817128ac-52d1-43b3-ad00-dee6786b7507">
