### PR TITLE
Remove cache control headers

### DIFF
--- a/catalogue/webapp/pages/api/works/[workId].tsx
+++ b/catalogue/webapp/pages/api/works/[workId].tsx
@@ -33,10 +33,6 @@ const WorksApi = async (
 
   res.setHeader('Content-Type', 'application/json');
   res.setHeader('Access-Control-Allow-Origin', '*');
-  res.setHeader(
-    'Cache-Control',
-    'private, no-cache, no-store, max-age=0, must-revalidate'
-  );
 
   if (response.type === 'Error') {
     res.status(response.httpStatus);

--- a/catalogue/webapp/pages/api/works/[workId].tsx
+++ b/catalogue/webapp/pages/api/works/[workId].tsx
@@ -33,6 +33,11 @@ const WorksApi = async (
 
   res.setHeader('Content-Type', 'application/json');
   res.setHeader('Access-Control-Allow-Origin', '*');
+  // we are forcing revalidation at all times because this is to do with ite availability, so it must be up to date
+  res.setHeader(
+    'Cache-Control',
+    'private, no-cache, no-store, max-age=0, must-revalidate'
+  );
 
   if (response.type === 'Error') {
     res.status(response.httpStatus);

--- a/catalogue/webapp/pages/api/works/[workId].tsx
+++ b/catalogue/webapp/pages/api/works/[workId].tsx
@@ -33,11 +33,6 @@ const WorksApi = async (
 
   res.setHeader('Content-Type', 'application/json');
   res.setHeader('Access-Control-Allow-Origin', '*');
-  // we are forcing revalidation at all times because this is to do with ite availability, so it must be up to date
-  res.setHeader(
-    'Cache-Control',
-    'private, no-cache, no-store, max-age=0, must-revalidate'
-  );
 
   if (response.type === 'Error') {
     res.status(response.httpStatus);

--- a/catalogue/webapp/pages/api/works/items/[workId].tsx
+++ b/catalogue/webapp/pages/api/works/items/[workId].tsx
@@ -80,6 +80,11 @@ const ItemsApi = async (
   });
   res.setHeader('Content-Type', 'application/json');
   res.setHeader('Access-Control-Allow-Origin', '*');
+  // we are forcing revalidation at all times because this is to do with ite availability, so it must be up to date
+  res.setHeader(
+    'Cache-Control',
+    'private, no-cache, no-store, max-age=0, must-revalidate'
+  );
 
   if (response.type === 'Error') {
     res.status(response.httpStatus);

--- a/catalogue/webapp/pages/api/works/items/[workId].tsx
+++ b/catalogue/webapp/pages/api/works/items/[workId].tsx
@@ -80,7 +80,7 @@ const ItemsApi = async (
   });
   res.setHeader('Content-Type', 'application/json');
   res.setHeader('Access-Control-Allow-Origin', '*');
-  // we are forcing revalidation at all times because this is to do with ite availability, so it must be up to date
+  // we are forcing revalidation at all times because this is to do with item availability, so it must be up to date
   res.setHeader(
     'Cache-Control',
     'private, no-cache, no-store, max-age=0, must-revalidate'

--- a/catalogue/webapp/pages/api/works/items/[workId].tsx
+++ b/catalogue/webapp/pages/api/works/items/[workId].tsx
@@ -80,10 +80,6 @@ const ItemsApi = async (
   });
   res.setHeader('Content-Type', 'application/json');
   res.setHeader('Access-Control-Allow-Origin', '*');
-  res.setHeader(
-    'Cache-Control',
-    'private, no-cache, no-store, max-age=0, must-revalidate'
-  );
 
   if (response.type === 'Error') {
     res.status(response.httpStatus);

--- a/catalogue/webapp/pages/concepts/[conceptId].tsx
+++ b/catalogue/webapp/pages/concepts/[conceptId].tsx
@@ -15,6 +15,7 @@ import { toLink as toImagesLink } from '@weco/catalogue/components/ImagesLink';
 import { toLink as toWorksLink } from '@weco/catalogue/components/WorksLink';
 import { pageDescriptionConcepts } from '@weco/common/data/microcopy';
 import { capitalize, formatNumber } from '@weco/common/utils/grammar';
+import { setCacheControl } from '@weco/common/utils/setCacheControl';
 
 // Components
 import BetaMessage from '@weco/common/views/components/BetaMessage/BetaMessage';
@@ -451,7 +452,7 @@ function createApiToolbarLinks(concept: ConceptType): ApiToolbarLink[] {
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
-  context.res.setHeader('Cache-Control', 'public');
+  setCacheControl(context.res);
   const serverData = await getServerData(context);
   const { conceptId } = context.query;
 

--- a/catalogue/webapp/pages/concepts/[conceptId].tsx
+++ b/catalogue/webapp/pages/concepts/[conceptId].tsx
@@ -451,6 +451,7 @@ function createApiToolbarLinks(concept: ConceptType): ApiToolbarLink[] {
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
+  context.res.setHeader('Cache-Control', 'public');
   const serverData = await getServerData(context);
   const { conceptId } = context.query;
 

--- a/catalogue/webapp/pages/search/images.tsx
+++ b/catalogue/webapp/pages/search/images.tsx
@@ -180,6 +180,7 @@ ImagesSearchPage.getLayout = getSearchLayout;
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
+  context.res.setHeader('Cache-Control', 'public');
   const serverData = await getServerData(context);
   const query = context.query;
   const params = fromQuery(query);

--- a/catalogue/webapp/pages/search/images.tsx
+++ b/catalogue/webapp/pages/search/images.tsx
@@ -28,6 +28,7 @@ import { getSearchLayout } from 'components/SearchPageLayout/SearchPageLayout';
 import { imagesFilters } from '@weco/catalogue/services/wellcome/catalogue/filters';
 import { hasFilters, linkResolver } from '@weco/common/utils/search';
 import { pluralize } from '@weco/common/utils/grammar';
+import { setCacheControl } from '@weco/common/utils/setCacheControl';
 
 // Types
 import {
@@ -180,7 +181,7 @@ ImagesSearchPage.getLayout = getSearchLayout;
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
-  context.res.setHeader('Cache-Control', 'public');
+  setCacheControl(context.res);
   const serverData = await getServerData(context);
   const query = context.query;
   const params = fromQuery(query);

--- a/catalogue/webapp/pages/search/index.tsx
+++ b/catalogue/webapp/pages/search/index.tsx
@@ -198,6 +198,7 @@ SearchPage.getLayout = getSearchLayout;
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
+  context.res.setHeader('Cache-Control', 'public');
   const serverData = await getServerData(context);
   const query = context.query;
   const params = fromQuery(query);

--- a/catalogue/webapp/pages/search/index.tsx
+++ b/catalogue/webapp/pages/search/index.tsx
@@ -37,6 +37,7 @@ import {
   ContentResultsList,
 } from '@weco/catalogue/services/wellcome/content/types';
 import { Content } from '@weco/catalogue/services/wellcome/content/types/api';
+import { setCacheControl } from '@weco/common/utils/setCacheControl';
 
 // Creating this version of fromQuery for the overview page only
 // No filters or pagination required.
@@ -198,7 +199,7 @@ SearchPage.getLayout = getSearchLayout;
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
-  context.res.setHeader('Cache-Control', 'public');
+  setCacheControl(context.res);
   const serverData = await getServerData(context);
   const query = context.query;
   const params = fromQuery(query);

--- a/catalogue/webapp/pages/search/stories.tsx
+++ b/catalogue/webapp/pages/search/stories.tsx
@@ -150,6 +150,7 @@ SearchPage.getLayout = getSearchLayout;
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
+  context.res.setHeader('Cache-Control', 'public');
   const serverData = await getServerData(context);
   const query = context.query;
   const defaultProps = serialiseProps({

--- a/catalogue/webapp/pages/search/stories.tsx
+++ b/catalogue/webapp/pages/search/stories.tsx
@@ -19,6 +19,7 @@ import { Pageview } from '@weco/common/services/conversion/track';
 import { pluralize } from '@weco/common/utils/grammar';
 import { getQueryPropertyValue } from '@weco/common/utils/search';
 import { getArticles } from '@weco/catalogue/services/wellcome/content/articles';
+import { setCacheControl } from '@weco/common/utils/setCacheControl';
 
 // Types
 import { Query } from '@weco/catalogue/types/search';
@@ -150,7 +151,7 @@ SearchPage.getLayout = getSearchLayout;
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
-  context.res.setHeader('Cache-Control', 'public');
+  setCacheControl(context.res);
   const serverData = await getServerData(context);
   const query = context.query;
   const defaultProps = serialiseProps({

--- a/catalogue/webapp/pages/search/works.tsx
+++ b/catalogue/webapp/pages/search/works.tsx
@@ -32,6 +32,7 @@ import convertUrlToString from '@weco/common/utils/convert-url-to-string';
 import { hasFilters, linkResolver } from '@weco/common/utils/search';
 import { AppErrorProps, appError } from '@weco/common/services/app';
 import { pluralize } from '@weco/common/utils/grammar';
+import { setCacheControl } from '@weco/common/utils/setCacheControl';
 
 // Types
 import {
@@ -214,7 +215,7 @@ CatalogueSearchPage.getLayout = getSearchLayout;
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
-  context.res.setHeader('Cache-Control', 'public');
+  setCacheControl(context.res);
   const serverData = await getServerData(context);
   const query = context.query;
   const params = fromQuery(query);

--- a/catalogue/webapp/pages/search/works.tsx
+++ b/catalogue/webapp/pages/search/works.tsx
@@ -214,6 +214,7 @@ CatalogueSearchPage.getLayout = getSearchLayout;
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
+  context.res.setHeader('Cache-Control', 'public');
   const serverData = await getServerData(context);
   const query = context.query;
   const params = fromQuery(query);

--- a/catalogue/webapp/pages/works/[workId]/download.tsx
+++ b/catalogue/webapp/pages/works/[workId]/download.tsx
@@ -25,6 +25,7 @@ import { getServerData } from '@weco/common/server-data';
 import { looksLikeCanonicalId } from '@weco/catalogue/services/wellcome/catalogue';
 import { fetchIIIFPresentationManifest } from '@weco/catalogue/services/iiif/fetch/manifest';
 import { transformManifest } from '@weco/catalogue/services/iiif/transformers/manifest';
+import { setCacheControl } from '@weco/common/utils/setCacheControl';
 
 type CreditProps = {
   workId: string;
@@ -171,7 +172,7 @@ const DownloadPage: NextPage<Props> = ({ transformedManifest, work }) => {
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
-  context.res.setHeader('Cache-Control', 'public');
+  setCacheControl(context.res);
   const serverData = await getServerData(context);
   const { workId } = context.query;
 

--- a/catalogue/webapp/pages/works/[workId]/download.tsx
+++ b/catalogue/webapp/pages/works/[workId]/download.tsx
@@ -168,50 +168,52 @@ const DownloadPage: NextPage<Props> = ({ transformedManifest, work }) => {
   );
 };
 
-export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
-  async context => {
-    const serverData = await getServerData(context);
-    const { workId } = context.query;
+export const getServerSideProps: GetServerSideProps<
+  Props | AppErrorProps
+> = async context => {
+  context.res.setHeader('Cache-Control', 'public');
+  const serverData = await getServerData(context);
+  const { workId } = context.query;
 
-    if (!looksLikeCanonicalId(workId)) {
-      return {
-        notFound: true,
-      };
-    }
-
-    const work = await getWork({
-      id: workId,
-      toggles: serverData.toggles,
-    });
-
-    if (work.type === 'Error') {
-      return appError(context, work.httpStatus, work.description);
-    } else if (work.type === 'Redirect') {
-      return {
-        redirect: {
-          destination: `/works/${work.redirectToId}/download`,
-          permanent: work.status === 301,
-        },
-      };
-    }
-
-    const manifestLocation = getDigitalLocationOfType(
-      work,
-      'iiif-presentation'
-    );
-    const iiifManifest =
-      manifestLocation &&
-      (await fetchIIIFPresentationManifest(manifestLocation.url, serverData.toggles));
-    const transformedManifest = iiifManifest && transformManifest(iiifManifest);
-
+  if (!looksLikeCanonicalId(workId)) {
     return {
-      props: serialiseProps({
-        serverData,
-        workId,
-        transformedManifest,
-        work,
-      }),
+      notFound: true,
     };
+  }
+
+  const work = await getWork({
+    id: workId,
+    toggles: serverData.toggles,
+  });
+
+  if (work.type === 'Error') {
+    return appError(context, work.httpStatus, work.description);
+  } else if (work.type === 'Redirect') {
+    return {
+      redirect: {
+        destination: `/works/${work.redirectToId}/download`,
+        permanent: work.status === 301,
+      },
+    };
+  }
+
+  const manifestLocation = getDigitalLocationOfType(work, 'iiif-presentation');
+  const iiifManifest =
+    manifestLocation &&
+    (await fetchIIIFPresentationManifest(
+      manifestLocation.url,
+      serverData.toggles
+    ));
+  const transformedManifest = iiifManifest && transformManifest(iiifManifest);
+
+  return {
+    props: serialiseProps({
+      serverData,
+      workId,
+      transformedManifest,
+      work,
+    }),
   };
+};
 
 export default DownloadPage;

--- a/catalogue/webapp/pages/works/[workId]/images.tsx
+++ b/catalogue/webapp/pages/works/[workId]/images.tsx
@@ -19,6 +19,7 @@ import {
   ApiToolbarLink,
   setTzitzitParams,
 } from '@weco/common/views/components/ApiToolbar';
+import { setCacheControl } from '@weco/common/utils/setCacheControl';
 
 function createTzitzitImageLink(
   work: Work,
@@ -100,7 +101,7 @@ const ImagePage: FunctionComponent<Props> = ({
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
-  context.res.setHeader('Cache-Control', 'public');
+  setCacheControl(context.res);
   const serverData = await getServerData(context);
   const { id, workId } = context.query;
 

--- a/catalogue/webapp/pages/works/[workId]/images.tsx
+++ b/catalogue/webapp/pages/works/[workId]/images.tsx
@@ -97,70 +97,72 @@ const ImagePage: FunctionComponent<Props> = ({
   );
 };
 
-export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
-  async context => {
-    const serverData = await getServerData(context);
-    const { id, workId } = context.query;
+export const getServerSideProps: GetServerSideProps<
+  Props | AppErrorProps
+> = async context => {
+  context.res.setHeader('Cache-Control', 'public');
+  const serverData = await getServerData(context);
+  const { id, workId } = context.query;
 
-    if (!looksLikeCanonicalId(id) || !looksLikeCanonicalId(workId)) {
+  if (!looksLikeCanonicalId(id) || !looksLikeCanonicalId(workId)) {
+    return { notFound: true };
+  }
+
+  const { url: catalogueApiUrl, image } = await getImage({
+    id,
+    toggles: serverData.toggles,
+  });
+
+  if (image.type === 'Error') {
+    if (image.httpStatus === 404) {
       return { notFound: true };
     }
+    return appError(context, image.httpStatus, image.description);
+  }
 
-    const { url: catalogueApiUrl, image } = await getImage({
-      id,
-      toggles: serverData.toggles,
-    });
+  // This is to avoid exposing a URL that has a valid `imageId` in it
+  // but not the correct `workId`, which would technically work,
+  // but the data on the page would be incorrect. e.g:
+  // image: { id: '1234567', image.source.id: 'abcdefg' }
+  // url: /works/gfedcba/images?id=1234567
+  if (image.source.id !== workId) {
+    return { notFound: true };
+  }
 
-    if (image.type === 'Error') {
-      if (image.httpStatus === 404) {
-        return { notFound: true };
-      }
-      return appError(context, image.httpStatus, image.description);
-    }
+  const work = await getWork({
+    id: workId,
+    toggles: serverData.toggles,
+  });
 
-    // This is to avoid exposing a URL that has a valid `imageId` in it
-    // but not the correct `workId`, which would technically work,
-    // but the data on the page would be incorrect. e.g:
-    // image: { id: '1234567', image.source.id: 'abcdefg' }
-    // url: /works/gfedcba/images?id=1234567
-    if (image.source.id !== workId) {
+  if (work.type === 'Error') {
+    if (work.httpStatus === 404) {
       return { notFound: true };
     }
-
-    const work = await getWork({
-      id: workId,
-      toggles: serverData.toggles,
-    });
-
-    if (work.type === 'Error') {
-      if (work.httpStatus === 404) {
-        return { notFound: true };
-      }
-      return appError(context, work.httpStatus, work.description);
-    } else if (work.type === 'Redirect') {
-      return {
-        redirect: {
-          destination: `/works/${work.redirectToId}`,
-          permanent: work.status === 301,
-        },
-      };
-    }
-
+    return appError(context, work.httpStatus, work.description);
+  } else if (work.type === 'Redirect') {
     return {
-      props: serialiseProps({
-        image,
-        // We know we'll get a catalogue API URL for a non-error response, but
-        // this isn't (currently) asserted by the type system.
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        catalogueApiUrl: catalogueApiUrl!,
-        work,
-        pageview: {
-          name: 'image',
-          properties: {},
-        },
-        serverData,
-      }),
+      redirect: {
+        destination: `/works/${work.redirectToId}`,
+        permanent: work.status === 301,
+      },
     };
+  }
+
+  return {
+    props: serialiseProps({
+      image,
+      // We know we'll get a catalogue API URL for a non-error response, but
+      // this isn't (currently) asserted by the type system.
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      catalogueApiUrl: catalogueApiUrl!,
+      work,
+      pageview: {
+        name: 'image',
+        properties: {},
+      },
+      serverData,
+    }),
   };
+};
 
 export default ImagePage;

--- a/catalogue/webapp/pages/works/[workId]/index.tsx
+++ b/catalogue/webapp/pages/works/[workId]/index.tsx
@@ -7,6 +7,7 @@ import { getServerData } from '@weco/common/server-data';
 import Work from '@weco/catalogue/components/Work/Work';
 import { getWork } from '@weco/catalogue/services/wellcome/catalogue/works';
 import { looksLikeCanonicalId } from '@weco/catalogue/services/wellcome/catalogue';
+import { setCacheControl } from '@weco/common/utils/setCacheControl';
 
 type Props = {
   work: WorkType;
@@ -23,7 +24,7 @@ export const WorkPage: NextPage<Props> = ({ work, apiUrl }) => {
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
-  context.res.setHeader('Cache-Control', 'public');
+  setCacheControl(context.res);
   const serverData = await getServerData(context);
   const { workId } = context.query;
 

--- a/catalogue/webapp/pages/works/[workId]/index.tsx
+++ b/catalogue/webapp/pages/works/[workId]/index.tsx
@@ -23,6 +23,7 @@ export const WorkPage: NextPage<Props> = ({ work, apiUrl }) => {
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
+  context.res.setHeader('Cache-Control', 'public');
   const serverData = await getServerData(context);
   const { workId } = context.query;
 

--- a/catalogue/webapp/pages/works/[workId]/items.tsx
+++ b/catalogue/webapp/pages/works/[workId]/items.tsx
@@ -338,146 +338,147 @@ const ItemPage: NextPage<Props> = ({
   );
 };
 
-export const getServerSideProps: GetServerSideProps<Props | AppErrorProps> =
-  async context => {
-    const serverData = await getServerData(context);
-    const {
-      workId,
-      page = 1,
-      canvas = 1,
-      manifest: manifestParam = 1,
-    } = fromQuery(context.query);
+export const getServerSideProps: GetServerSideProps<
+  Props | AppErrorProps
+> = async context => {
+  context.res.setHeader('Cache-Control', 'public');
+  const serverData = await getServerData(context);
+  const {
+    workId,
+    page = 1,
+    canvas = 1,
+    manifest: manifestParam = 1,
+  } = fromQuery(context.query);
 
-    if (!looksLikeCanonicalId(workId)) {
-      return { notFound: true };
-    }
+  if (!looksLikeCanonicalId(workId)) {
+    return { notFound: true };
+  }
 
-    const pageview: Pageview = {
-      name: 'item',
-      properties: {},
-    };
+  const pageview: Pageview = {
+    name: 'item',
+    properties: {},
+  };
 
-    const pageIndex = page - 1;
-    // Canvas and manifest params should be 0 indexed as they reference elements in an array
-    // We've chosen not to do this for some reason lost to time, but felt it better to stick
-    // to the same buggy implementation than have 2 implementations
+  const pageIndex = page - 1;
+  // Canvas and manifest params should be 0 indexed as they reference elements in an array
+  // We've chosen not to do this for some reason lost to time, but felt it better to stick
+  // to the same buggy implementation than have 2 implementations
 
-    // I imagine a fix for this could be having new parameters `m&c`
-    // and then redirecting to those once we have em fixed.
-    const canvasIndex = canvas - 1;
-    const manifestIndex = manifestParam - 1;
+  // I imagine a fix for this could be having new parameters `m&c`
+  // and then redirecting to those once we have em fixed.
+  const canvasIndex = canvas - 1;
+  const manifestIndex = manifestParam - 1;
 
-    const work = await getWork({
-      id: workId,
-      toggles: serverData.toggles,
-      include: ['items', 'languages', 'contributors', 'production'],
-    });
+  const work = await getWork({
+    id: workId,
+    toggles: serverData.toggles,
+    include: ['items', 'languages', 'contributors', 'production'],
+  });
 
-    if (work.type === 'Error') {
-      return appError(context, work.httpStatus, work.description);
-    }
+  if (work.type === 'Error') {
+    return appError(context, work.httpStatus, work.description);
+  }
 
-    if (work.type === 'Redirect') {
-      // This ensures that any query parameters are preserved on redirect,
-      // e.g. if you have a link to /works/$oldId/items?canvas=10, then
-      // you'll go to /works/$newId/items?canvas=10
-      const destination = isNotUndefined(context.req.url)
-        ? context.req.url.replace(workId, work.redirectToId)
-        : `/works/${work.redirectToId}/items`;
-
-      return {
-        redirect: {
-          destination,
-          permanent: work.status === 301,
-        },
-      };
-    }
-
-    const iiifImageLocation = getDigitalLocationOfType(work, 'iiif-image');
-    const iiifPresentationLocation = getDigitalLocationOfType(
-      work,
-      'iiif-presentation'
-    );
-    const iiifManifest =
-      iiifPresentationLocation &&
-      (await fetchIIIFPresentationManifest(
-        iiifPresentationLocation.url,
-        serverData.toggles
-      ));
-
-    const transformedManifest = iiifManifest && transformManifest(iiifManifest);
-
-    const { isCollectionManifest, manifests } = { ...transformedManifest };
-    // If the manifest is actually a Collection, .i.e. a manifest of manifests,
-    // then we get the first child manifest and use the data from that
-    // see: https://iiif.wellcomecollection.org/presentation/v2/b21293302
-    // from: https://wellcomecollection.org/works/f6qp7m32/items
-    async function getDisplayManifest(
-      transformedManifest: TransformedManifest,
-      manifestIndex: number
-    ): Promise<TransformedManifest> {
-      if (isCollectionManifest) {
-        const selectedCollectionManifestLocation =
-          manifests?.[manifestIndex]?.id;
-        const selectedCollectionManifest = selectedCollectionManifestLocation
-          ? await fetchIIIFPresentationManifest(
-              selectedCollectionManifestLocation,
-              serverData.toggles
-            )
-          : undefined;
-        const firstChildTransformedManifest =
-          selectedCollectionManifest &&
-          transformManifest(selectedCollectionManifest);
-        return firstChildTransformedManifest || transformedManifest;
-      } else {
-        return transformedManifest;
-      }
-    }
-
-    if (transformedManifest) {
-      const displayManifest = await getDisplayManifest(
-        transformedManifest,
-        manifestIndex
-      );
-      const { canvases } = displayManifest;
-      const currentCanvas = canvases[canvasIndex];
-      const canvasOcrText = await fetchCanvasOcr(currentCanvas);
-      const canvasOcr = transformCanvasOcr(canvasOcrText);
-
-      return {
-        props: serialiseProps({
-          transformedManifest: displayManifest,
-          manifestIndex,
-          pageIndex,
-          canvasIndex,
-          canvasOcr,
-          work,
-          currentCanvas,
-          iiifImageLocation,
-          pageview,
-          serverData,
-        }),
-      };
-    }
-
-    if (iiifImageLocation) {
-      return {
-        props: serialiseProps({
-          transformedManifest: createDefaultTransformedManifest(),
-          pageIndex,
-          canvasIndex,
-          work,
-          canvases: [],
-          iiifImageLocation,
-          pageview,
-          serverData,
-        }),
-      };
-    }
+  if (work.type === 'Redirect') {
+    // This ensures that any query parameters are preserved on redirect,
+    // e.g. if you have a link to /works/$oldId/items?canvas=10, then
+    // you'll go to /works/$newId/items?canvas=10
+    const destination = isNotUndefined(context.req.url)
+      ? context.req.url.replace(workId, work.redirectToId)
+      : `/works/${work.redirectToId}/items`;
 
     return {
-      notFound: true,
+      redirect: {
+        destination,
+        permanent: work.status === 301,
+      },
     };
+  }
+
+  const iiifImageLocation = getDigitalLocationOfType(work, 'iiif-image');
+  const iiifPresentationLocation = getDigitalLocationOfType(
+    work,
+    'iiif-presentation'
+  );
+  const iiifManifest =
+    iiifPresentationLocation &&
+    (await fetchIIIFPresentationManifest(
+      iiifPresentationLocation.url,
+      serverData.toggles
+    ));
+
+  const transformedManifest = iiifManifest && transformManifest(iiifManifest);
+
+  const { isCollectionManifest, manifests } = { ...transformedManifest };
+  // If the manifest is actually a Collection, .i.e. a manifest of manifests,
+  // then we get the first child manifest and use the data from that
+  // see: https://iiif.wellcomecollection.org/presentation/v2/b21293302
+  // from: https://wellcomecollection.org/works/f6qp7m32/items
+  async function getDisplayManifest(
+    transformedManifest: TransformedManifest,
+    manifestIndex: number
+  ): Promise<TransformedManifest> {
+    if (isCollectionManifest) {
+      const selectedCollectionManifestLocation = manifests?.[manifestIndex]?.id;
+      const selectedCollectionManifest = selectedCollectionManifestLocation
+        ? await fetchIIIFPresentationManifest(
+            selectedCollectionManifestLocation,
+            serverData.toggles
+          )
+        : undefined;
+      const firstChildTransformedManifest =
+        selectedCollectionManifest &&
+        transformManifest(selectedCollectionManifest);
+      return firstChildTransformedManifest || transformedManifest;
+    } else {
+      return transformedManifest;
+    }
+  }
+
+  if (transformedManifest) {
+    const displayManifest = await getDisplayManifest(
+      transformedManifest,
+      manifestIndex
+    );
+    const { canvases } = displayManifest;
+    const currentCanvas = canvases[canvasIndex];
+    const canvasOcrText = await fetchCanvasOcr(currentCanvas);
+    const canvasOcr = transformCanvasOcr(canvasOcrText);
+
+    return {
+      props: serialiseProps({
+        transformedManifest: displayManifest,
+        manifestIndex,
+        pageIndex,
+        canvasIndex,
+        canvasOcr,
+        work,
+        currentCanvas,
+        iiifImageLocation,
+        pageview,
+        serverData,
+      }),
+    };
+  }
+
+  if (iiifImageLocation) {
+    return {
+      props: serialiseProps({
+        transformedManifest: createDefaultTransformedManifest(),
+        pageIndex,
+        canvasIndex,
+        work,
+        canvases: [],
+        iiifImageLocation,
+        pageview,
+        serverData,
+      }),
+    };
+  }
+
+  return {
+    notFound: true,
   };
+};
 
 export default ItemPage;

--- a/catalogue/webapp/pages/works/[workId]/items.tsx
+++ b/catalogue/webapp/pages/works/[workId]/items.tsx
@@ -47,6 +47,7 @@ import {
   ApiToolbarLink,
   setTzitzitParams,
 } from '@weco/common/views/components/ApiToolbar';
+import { setCacheControl } from '@weco/common/utils/setCacheControl';
 
 const IframeAuthMessage = styled.iframe`
   display: none;
@@ -341,7 +342,7 @@ const ItemPage: NextPage<Props> = ({
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
-  context.res.setHeader('Cache-Control', 'public');
+  setCacheControl(context.res);
   const serverData = await getServerData(context);
   const {
     workId,

--- a/common/utils/setCacheControl.ts
+++ b/common/utils/setCacheControl.ts
@@ -4,6 +4,11 @@ export const setCacheControl = (res: ServerResponse) => {
   /**
    * Cloudfront should handle our caching, and the intention of this line is to
    * remove the caching that next adds on top of the request/responses.
+   *
+   * CloudFront behaviour:
+   * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html#w371aac17c17c25b9
+   * Our cache policies:
+   * https://github.com/wellcomecollection/wellcomecollection.org/blob/main/cache/modules/cloudfront_policies/cache_policies.tf
    */
   res.removeHeader('Cache-Control');
 };

--- a/common/utils/setCacheControl.ts
+++ b/common/utils/setCacheControl.ts
@@ -1,0 +1,5 @@
+import { ServerResponse } from 'http';
+
+export const setCacheControl = (res: ServerResponse) => {
+  res.setHeader('Cache-Control', 'public');
+};

--- a/common/utils/setCacheControl.ts
+++ b/common/utils/setCacheControl.ts
@@ -1,5 +1,9 @@
 import { ServerResponse } from 'http';
 
 export const setCacheControl = (res: ServerResponse) => {
-  res.setHeader('Cache-Control', 'public');
+  /**
+   * Cloudfront should handle our caching, and the intention of this line is to
+   * remove the caching that next adds on top of the request/responses.
+   */
+  res.removeHeader('Cache-Control');
 };

--- a/content/webapp/pages/articles/[articleId].tsx
+++ b/content/webapp/pages/articles/[articleId].tsx
@@ -67,6 +67,7 @@ function articleHasOutro(article: Article) {
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
+  context.res.setHeader('Cache-Control', 'public');
   const { articleId } = context.query;
   if (!looksLikePrismicId(articleId)) {
     return { notFound: true };

--- a/content/webapp/pages/articles/[articleId].tsx
+++ b/content/webapp/pages/articles/[articleId].tsx
@@ -39,6 +39,7 @@ import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 import styled from 'styled-components';
 import { Pageview } from '@weco/common/services/conversion/track';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
+import { setCacheControl } from '@weco/common/utils/setCacheControl';
 
 const ContentTypeWrapper = styled.div`
   display: flex;
@@ -67,7 +68,7 @@ function articleHasOutro(article: Article) {
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
-  context.res.setHeader('Cache-Control', 'public');
+  setCacheControl(context.res);
   const { articleId } = context.query;
   if (!looksLikePrismicId(articleId)) {
     return { notFound: true };

--- a/content/webapp/pages/articles/index.tsx
+++ b/content/webapp/pages/articles/index.tsx
@@ -19,6 +19,7 @@ import { getPage } from '@weco/content/utils/query-params';
 import { pageDescriptions } from '@weco/common/data/microcopy';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 import { ArticleBasic } from '@weco/content/types/articles';
+import { setCacheControl } from '@weco/common/utils/setCacheControl';
 
 type Props = {
   articles: PaginatedResults<ArticleBasic>;
@@ -28,7 +29,7 @@ type Props = {
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
-  context.res.setHeader('Cache-Control', 'public');
+  setCacheControl(context.res);
   const page = getPage(context.query);
 
   if (typeof page !== 'number') {

--- a/content/webapp/pages/articles/index.tsx
+++ b/content/webapp/pages/articles/index.tsx
@@ -28,6 +28,7 @@ type Props = {
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
+  context.res.setHeader('Cache-Control', 'public');
   const page = getPage(context.query);
 
   if (typeof page !== 'number') {

--- a/content/webapp/pages/books/[bookId].tsx
+++ b/content/webapp/pages/books/[bookId].tsx
@@ -22,6 +22,7 @@ import { looksLikePrismicId } from '@weco/common/services/prismic';
 import Layout8 from '@weco/common/views/components/Layout8/Layout8';
 import { Pageview } from '@weco/common/services/conversion/track';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
+import { setCacheControl } from '@weco/common/utils/setCacheControl';
 
 const MetadataWrapper = styled.div`
   border-top: 1px solid ${props => props.theme.color('neutral.300')};
@@ -87,7 +88,7 @@ type Props = {
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
-  context.res.setHeader('Cache-Control', 'public');
+  setCacheControl(context.res);
   const { bookId } = context.query;
   if (!looksLikePrismicId(bookId)) {
     return { notFound: true };

--- a/content/webapp/pages/books/[bookId].tsx
+++ b/content/webapp/pages/books/[bookId].tsx
@@ -87,6 +87,7 @@ type Props = {
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
+  context.res.setHeader('Cache-Control', 'public');
   const { bookId } = context.query;
   if (!looksLikePrismicId(bookId)) {
     return { notFound: true };

--- a/content/webapp/pages/books/index.tsx
+++ b/content/webapp/pages/books/index.tsx
@@ -25,6 +25,7 @@ type Props = {
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
+  context.res.setHeader('Cache-Control', 'public');
   const page = getPage(context.query);
   if (typeof page !== 'number') {
     return appError(context, 400, page.message);

--- a/content/webapp/pages/books/index.tsx
+++ b/content/webapp/pages/books/index.tsx
@@ -17,6 +17,7 @@ import { fetchBooks } from '@weco/content/services/prismic/fetch/books';
 import { BookBasic } from '@weco/content/types/books';
 import { getPage } from '@weco/content/utils/query-params';
 import { pageDescriptions } from '@weco/common/data/microcopy';
+import { setCacheControl } from '@weco/common/utils/setCacheControl';
 
 type Props = {
   books: PaginatedResults<BookBasic>;
@@ -25,7 +26,7 @@ type Props = {
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
-  context.res.setHeader('Cache-Control', 'public');
+  setCacheControl(context.res);
   const page = getPage(context.query);
   if (typeof page !== 'number') {
     return appError(context, 400, page.message);

--- a/content/webapp/pages/collections.tsx
+++ b/content/webapp/pages/collections.tsx
@@ -8,6 +8,7 @@ import * as page from './pages/[pageId]';
 export const getServerSideProps: GetServerSideProps<
   page.Props | AppErrorProps
 > = async context => {
+  context.res.setHeader('Cache-Control', 'public');
   return page.getServerSideProps({
     ...context,
     query: { pageId: prismicPageIds.collections },

--- a/content/webapp/pages/collections.tsx
+++ b/content/webapp/pages/collections.tsx
@@ -4,11 +4,12 @@ import CollectionsStaticContent from 'components/Body/CollectionsStaticContent';
 import { GetServerSideProps } from 'next';
 import { FunctionComponent } from 'react';
 import * as page from './pages/[pageId]';
+import { setCacheControl } from '@weco/common/utils/setCacheControl';
 
 export const getServerSideProps: GetServerSideProps<
   page.Props | AppErrorProps
 > = async context => {
-  context.res.setHeader('Cache-Control', 'public');
+  setCacheControl(context.res);
   return page.getServerSideProps({
     ...context,
     query: { pageId: prismicPageIds.collections },

--- a/content/webapp/pages/covid-welcome-back.tsx
+++ b/content/webapp/pages/covid-welcome-back.tsx
@@ -4,11 +4,12 @@ import { WeAreGoodToGo } from '@weco/common/views/components/CovidIcons/CovidIco
 import { GetServerSideProps } from 'next';
 import { FunctionComponent } from 'react';
 import * as page from './pages/[pageId]';
+import { setCacheControl } from '@weco/common/utils/setCacheControl';
 
 export const getServerSideProps: GetServerSideProps<
   page.Props | AppErrorProps
 > = async context => {
-  context.res.setHeader('Cache-Control', 'public');
+  setCacheControl(context.res);
   return page.getServerSideProps({
     ...context,
     query: { pageId: prismicPageIds.covidWelcomeBack },

--- a/content/webapp/pages/covid-welcome-back.tsx
+++ b/content/webapp/pages/covid-welcome-back.tsx
@@ -8,6 +8,7 @@ import * as page from './pages/[pageId]';
 export const getServerSideProps: GetServerSideProps<
   page.Props | AppErrorProps
 > = async context => {
+  context.res.setHeader('Cache-Control', 'public');
   return page.getServerSideProps({
     ...context,
     query: { pageId: prismicPageIds.covidWelcomeBack },

--- a/content/webapp/pages/event-series/[eventSeriesId].tsx
+++ b/content/webapp/pages/event-series/[eventSeriesId].tsx
@@ -29,6 +29,7 @@ import {
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 import { getUpcomingEvents } from '@weco/content/utils/event-series';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
+import { setCacheControl } from '@weco/common/utils/setCacheControl';
 
 type Props = {
   series: EventSeries;
@@ -58,7 +59,7 @@ function getPastEvents(
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
-  context.res.setHeader('Cache-Control', 'public');
+  setCacheControl(context.res);
   const serverData = await getServerData(context);
   const { eventSeriesId } = context.query;
 

--- a/content/webapp/pages/event-series/[eventSeriesId].tsx
+++ b/content/webapp/pages/event-series/[eventSeriesId].tsx
@@ -58,6 +58,7 @@ function getPastEvents(
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
+  context.res.setHeader('Cache-Control', 'public');
   const serverData = await getServerData(context);
   const { eventSeriesId } = context.query;
 

--- a/content/webapp/pages/events/[eventId].tsx
+++ b/content/webapp/pages/events/[eventId].tsx
@@ -63,6 +63,7 @@ import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 import { a11y } from '@weco/common/data/microcopy';
 import { Pageview } from '@weco/common/services/conversion/track';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
+import { setCacheControl } from '@weco/common/utils/setCacheControl';
 
 const DateWrapper = styled.div.attrs({
   className: 'body-text',
@@ -447,7 +448,7 @@ const EventPage: NextPage<Props> = ({ event, jsonLd }) => {
 };
 
 export const getServerSideProps: GetServerSideProps<Props> = async context => {
-  context.res.setHeader('Cache-Control', 'public');
+  setCacheControl(context.res);
   const serverData = await getServerData(context);
   const { eventId } = context.query;
 

--- a/content/webapp/pages/events/[eventId].tsx
+++ b/content/webapp/pages/events/[eventId].tsx
@@ -447,6 +447,7 @@ const EventPage: NextPage<Props> = ({ event, jsonLd }) => {
 };
 
 export const getServerSideProps: GetServerSideProps<Props> = async context => {
+  context.res.setHeader('Cache-Control', 'public');
   const serverData = await getServerData(context);
   const { eventId } = context.query;
 

--- a/content/webapp/pages/events/index.tsx
+++ b/content/webapp/pages/events/index.tsx
@@ -35,6 +35,7 @@ type Props = {
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
+  context.res.setHeader('Cache-Control', 'public');
   const page = getPage(context.query);
 
   if (typeof page !== 'number') {

--- a/content/webapp/pages/events/index.tsx
+++ b/content/webapp/pages/events/index.tsx
@@ -24,6 +24,7 @@ import { transformQuery } from '@weco/content/services/prismic/transformers/pagi
 import { pageDescriptions } from '@weco/common/data/microcopy';
 import { EventBasic } from '@weco/content/types/events';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
+import { setCacheControl } from '@weco/common/utils/setCacheControl';
 
 type Props = {
   title: string;
@@ -35,7 +36,7 @@ type Props = {
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
-  context.res.setHeader('Cache-Control', 'public');
+  setCacheControl(context.res);
   const page = getPage(context.query);
 
   if (typeof page !== 'number') {

--- a/content/webapp/pages/exhibitions/[exhibitionId].tsx
+++ b/content/webapp/pages/exhibitions/[exhibitionId].tsx
@@ -56,6 +56,7 @@ const ExhibitionPage: FunctionComponent<Props> = ({
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
+  context.res.setHeader('Cache-Control', 'public');
   const serverData = await getServerData(context);
   const { exhibitionId } = context.query;
 

--- a/content/webapp/pages/exhibitions/[exhibitionId].tsx
+++ b/content/webapp/pages/exhibitions/[exhibitionId].tsx
@@ -19,6 +19,7 @@ import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 import { Pageview } from '@weco/common/services/conversion/track';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
+import { setCacheControl } from '@weco/common/utils/setCacheControl';
 
 type Props = {
   exhibition: ExhibitionType;
@@ -56,7 +57,7 @@ const ExhibitionPage: FunctionComponent<Props> = ({
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
-  context.res.setHeader('Cache-Control', 'public');
+  setCacheControl(context.res);
   const serverData = await getServerData(context);
   const { exhibitionId } = context.query;
 

--- a/content/webapp/pages/exhibitions/index.tsx
+++ b/content/webapp/pages/exhibitions/index.tsx
@@ -28,6 +28,7 @@ import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/Pri
 import { headerBackgroundLs } from '@weco/common/utils/backgrounds';
 import { isFuture } from '@weco/common/utils/dates';
 import Pagination from '@weco/common/views/components/Pagination/Pagination';
+import { setCacheControl } from '@weco/common/utils/setCacheControl';
 
 type Props = {
   exhibitions: PaginatedResults<ExhibitionBasic>;
@@ -39,7 +40,7 @@ type Props = {
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
-  context.res.setHeader('Cache-Control', 'public');
+  setCacheControl(context.res);
   const serverData = await getServerData(context);
   const client = createClient(context);
 

--- a/content/webapp/pages/exhibitions/index.tsx
+++ b/content/webapp/pages/exhibitions/index.tsx
@@ -39,6 +39,7 @@ type Props = {
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
+  context.res.setHeader('Cache-Control', 'public');
   const serverData = await getServerData(context);
   const client = createClient(context);
 

--- a/content/webapp/pages/guides/exhibitions/[id]/[type].tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/[type].tsx
@@ -33,6 +33,7 @@ import ExhibitionGuideStops from '@weco/content/components/ExhibitionGuideStops/
 import { getTypeColor } from '@weco/content/components/ExhibitionCaptions/ExhibitionCaptions';
 import useHotjar from '@weco/common/hooks/useHotjar';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
+import { setCacheControl } from '@weco/common/utils/setCacheControl';
 
 const ButtonWrapper = styled(Space).attrs({
   v: { size: 's', properties: ['margin-bottom'] },
@@ -74,7 +75,7 @@ function getTypeTitle(type: ExhibitionGuideType): string {
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
-  context.res.setHeader('Cache-Control', 'public');
+  setCacheControl(context.res);
   const serverData = await getServerData(context);
   const { id, type, usingQRCode, userPreferenceSet, stopId } = context.query;
   const { res, req } = context;

--- a/content/webapp/pages/guides/exhibitions/[id]/[type].tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/[type].tsx
@@ -74,6 +74,7 @@ function getTypeTitle(type: ExhibitionGuideType): string {
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
+  context.res.setHeader('Cache-Control', 'public');
   const serverData = await getServerData(context);
   const { id, type, usingQRCode, userPreferenceSet, stopId } = context.query;
   const { res, req } = context;

--- a/content/webapp/pages/guides/exhibitions/[id]/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/index.tsx
@@ -30,6 +30,7 @@ import { exhibitionGuidesLinks } from '@weco/common/views/components/Header/Head
 import OtherExhibitionGuides from 'components/OtherExhibitionGuides/OtherExhibitionGuides';
 import ExhibitionGuideLinks from 'components/ExhibitionGuideLinks/ExhibitionGuideLinks';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
+import { setCacheControl } from '@weco/common/utils/setCacheControl';
 
 type Props = {
   exhibitionGuide: ExhibitionGuide;
@@ -40,7 +41,7 @@ type Props = {
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
-  context.res.setHeader('Cache-Control', 'public');
+  setCacheControl(context.res);
   const serverData = await getServerData(context);
   const { id } = context.query;
 

--- a/content/webapp/pages/guides/exhibitions/[id]/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/index.tsx
@@ -40,6 +40,7 @@ type Props = {
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
+  context.res.setHeader('Cache-Control', 'public');
   const serverData = await getServerData(context);
   const { id } = context.query;
 

--- a/content/webapp/pages/guides/exhibitions/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/index.tsx
@@ -29,6 +29,7 @@ type Props = {
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
+  context.res.setHeader('Cache-Control', 'public');
   const serverData = await getServerData(context);
   const page = getPage(context.query);
 

--- a/content/webapp/pages/guides/exhibitions/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/index.tsx
@@ -20,6 +20,7 @@ import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
 import LayoutPaginatedResults from '@weco/content/components/LayoutPaginatedResults/LayoutPaginatedResults';
 import { exhibitionGuidesLinks } from '@weco/common/views/components/Header/Header';
+import { setCacheControl } from '@weco/common/utils/setCacheControl';
 
 type Props = {
   exhibitionGuides: PaginatedResults<ExhibitionGuideBasic>;
@@ -29,7 +30,7 @@ type Props = {
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
-  context.res.setHeader('Cache-Control', 'public');
+  setCacheControl(context.res);
   const serverData = await getServerData(context);
   const page = getPage(context.query);
 

--- a/content/webapp/pages/homepage.tsx
+++ b/content/webapp/pages/homepage.tsx
@@ -45,6 +45,7 @@ import { BodySlice, isContentList, isStandfirst } from 'types/body';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 import Head from 'next/head';
+import { setCacheControl } from '@weco/common/utils/setCacheControl';
 
 const CreamBox = styled(Space).attrs({
   h: { size: 'l', properties: ['padding-left', 'padding-right'] },
@@ -74,7 +75,7 @@ const pageImage: ImageType = {
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
-  context.res.setHeader('Cache-Control', 'public');
+  setCacheControl(context.res);
   const serverData = await getServerData(context);
 
   const client = createClient(context);

--- a/content/webapp/pages/homepage.tsx
+++ b/content/webapp/pages/homepage.tsx
@@ -74,6 +74,7 @@ const pageImage: ImageType = {
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
+  context.res.setHeader('Cache-Control', 'public');
   const serverData = await getServerData(context);
 
   const client = createClient(context);

--- a/content/webapp/pages/newsletter.tsx
+++ b/content/webapp/pages/newsletter.tsx
@@ -10,6 +10,7 @@ import { getServerData } from '@weco/common/server-data';
 import { newsletterDescription } from '@weco/common/data/microcopy';
 import { landingHeaderBackgroundLs } from '@weco/common/utils/backgrounds';
 import Layout8 from '@weco/common/views/components/Layout8/Layout8';
+import { setCacheControl } from '@weco/common/utils/setCacheControl';
 
 type Props = {
   result?: string;
@@ -18,7 +19,7 @@ type Props = {
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
-  context.res.setHeader('Cache-Control', 'public');
+  setCacheControl(context.res);
   const serverData = await getServerData(context);
   const { result } = context.query;
 

--- a/content/webapp/pages/newsletter.tsx
+++ b/content/webapp/pages/newsletter.tsx
@@ -18,6 +18,7 @@ type Props = {
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
+  context.res.setHeader('Cache-Control', 'public');
   const serverData = await getServerData(context);
   const { result } = context.query;
 

--- a/content/webapp/pages/pages/[pageId].tsx
+++ b/content/webapp/pages/pages/[pageId].tsx
@@ -46,6 +46,7 @@ import { isNotUndefined } from '@weco/common/utils/type-guards';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 import { looksLikePrismicId } from '@weco/common/services/prismic';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
+import { setCacheControl } from '@weco/common/utils/setCacheControl';
 
 export type Props = {
   page: PageType;
@@ -117,7 +118,7 @@ function getFeaturedPictureWithTasl(
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
-  context.res.setHeader('Cache-Control', 'public');
+  setCacheControl(context.res);
   const serverData = await getServerData(context);
   const { pageId } = context.query;
 

--- a/content/webapp/pages/pages/[pageId].tsx
+++ b/content/webapp/pages/pages/[pageId].tsx
@@ -117,6 +117,7 @@ function getFeaturedPictureWithTasl(
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
+  context.res.setHeader('Cache-Control', 'public');
   const serverData = await getServerData(context);
   const { pageId } = context.query;
 

--- a/content/webapp/pages/seasons/[seasonId].tsx
+++ b/content/webapp/pages/seasons/[seasonId].tsx
@@ -113,6 +113,7 @@ const SeasonPage = ({
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
+  context.res.setHeader('Cache-Control', 'public');
   const { seasonId } = context.query;
   if (!looksLikePrismicId(seasonId)) {
     return { notFound: true };

--- a/content/webapp/pages/seasons/[seasonId].tsx
+++ b/content/webapp/pages/seasons/[seasonId].tsx
@@ -47,6 +47,7 @@ import { looksLikePrismicId } from '@weco/common/services/prismic';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 import * as prismic from '@prismicio/client';
+import { setCacheControl } from '@weco/common/utils/setCacheControl';
 
 type Props = {
   season: Season;
@@ -113,7 +114,7 @@ const SeasonPage = ({
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
-  context.res.setHeader('Cache-Control', 'public');
+  setCacheControl(context.res);
   const { seasonId } = context.query;
   if (!looksLikePrismicId(seasonId)) {
     return { notFound: true };

--- a/content/webapp/pages/series/[seriesId].tsx
+++ b/content/webapp/pages/series/[seriesId].tsx
@@ -59,6 +59,7 @@ type Props = {
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
+  context.res.setHeader('Cache-Control', 'public');
   const serverData = await getServerData(context);
 
   const { seriesId } = context.query;

--- a/content/webapp/pages/series/[seriesId].tsx
+++ b/content/webapp/pages/series/[seriesId].tsx
@@ -40,6 +40,7 @@ import { ArticleScheduleItem } from '@weco/content/types/article-schedule-items'
 import styled from 'styled-components';
 import ArticleCard from '@weco/content/components/ArticleCard/ArticleCard';
 import ArticleScheduleItemCard from '@weco/content/components/ArticleScheduleItemCard';
+import { setCacheControl } from '@weco/common/utils/setCacheControl';
 
 const SeriesItem = styled.div<{ isFirst: boolean }>`
   border-top: ${props =>
@@ -59,7 +60,7 @@ type Props = {
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
-  context.res.setHeader('Cache-Control', 'public');
+  setCacheControl(context.res);
   const serverData = await getServerData(context);
 
   const { seriesId } = context.query;

--- a/content/webapp/pages/stories/[contentType].tsx
+++ b/content/webapp/pages/stories/[contentType].tsx
@@ -22,6 +22,7 @@ import {
 import { ArticleFormatIds } from '@weco/common/data/content-format-ids';
 import * as prismic from '@prismicio/client';
 import { articleSeriesLd } from '@weco/content/services/prismic/transformers/json-ld';
+import { setCacheControl } from '@weco/common/utils/setCacheControl';
 
 const contentTypes = ['comic'] as const;
 type ContentType = (typeof contentTypes)[number];
@@ -56,7 +57,7 @@ function isContentType(x: any): x is ContentType {
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
-  context.res.setHeader('Cache-Control', 'public');
+  setCacheControl(context.res);
   const serverData = await getServerData(context);
 
   const page = getPage(context.query);

--- a/content/webapp/pages/stories/[contentType].tsx
+++ b/content/webapp/pages/stories/[contentType].tsx
@@ -56,6 +56,7 @@ function isContentType(x: any): x is ContentType {
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
+  context.res.setHeader('Cache-Control', 'public');
   const serverData = await getServerData(context);
 
   const page = getPage(context.query);

--- a/content/webapp/pages/stories/index.tsx
+++ b/content/webapp/pages/stories/index.tsx
@@ -67,6 +67,7 @@ const StoryPromoContainer = styled.div.attrs({
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
+  context.res.setHeader('Cache-Control', 'public');
   const serverData = await getServerData(context);
   const client = createClient(context);
   const articlesQueryPromise = fetchArticles(client, {

--- a/content/webapp/pages/stories/index.tsx
+++ b/content/webapp/pages/stories/index.tsx
@@ -38,6 +38,7 @@ import { transformSeriesToSeriesBasic } from '@weco/content/services/prismic/tra
 import { Series, SeriesBasic } from '@weco/content/types/series';
 import * as prismic from '@prismicio/client';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
+import { setCacheControl } from '@weco/common/utils/setCacheControl';
 
 type Props = {
   articles: ArticleBasic[];
@@ -67,7 +68,7 @@ const StoryPromoContainer = styled.div.attrs({
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
-  context.res.setHeader('Cache-Control', 'public');
+  setCacheControl(context.res);
   const serverData = await getServerData(context);
   const client = createClient(context);
   const articlesQueryPromise = fetchArticles(client, {

--- a/content/webapp/pages/visit-us.tsx
+++ b/content/webapp/pages/visit-us.tsx
@@ -8,6 +8,7 @@ import * as page from './pages/[pageId]';
 export const getServerSideProps: GetServerSideProps<
   page.Props | AppErrorProps
 > = async context => {
+  context.res.setHeader('Cache-Control', 'public');
   return page.getServerSideProps({
     ...context,
     query: { pageId: prismicPageIds.visitUs },

--- a/content/webapp/pages/visit-us.tsx
+++ b/content/webapp/pages/visit-us.tsx
@@ -4,11 +4,12 @@ import VisitUsStaticContent from '@weco/content/components/Body/VisitUsStaticCon
 import { GetServerSideProps } from 'next';
 import { FunctionComponent } from 'react';
 import * as page from './pages/[pageId]';
+import { setCacheControl } from '@weco/common/utils/setCacheControl';
 
 export const getServerSideProps: GetServerSideProps<
   page.Props | AppErrorProps
 > = async context => {
-  context.res.setHeader('Cache-Control', 'public');
+  setCacheControl(context.res);
   return page.getServerSideProps({
     ...context,
     query: { pageId: prismicPageIds.visitUs },

--- a/content/webapp/pages/whats-on.tsx
+++ b/content/webapp/pages/whats-on.tsx
@@ -309,6 +309,7 @@ const Header: FunctionComponent<HeaderProps> = ({
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
+  context.res.setHeader('Cache-Control', 'public');
   const serverData = await getServerData(context);
 
   const client = createClient(context);

--- a/content/webapp/pages/whats-on.tsx
+++ b/content/webapp/pages/whats-on.tsx
@@ -79,6 +79,7 @@ import {
 import { FacilityPromo as FacilityPromoType } from '@weco/content/types/facility-promo';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 import styled from 'styled-components';
+import { setCacheControl } from '@weco/common/utils/setCacheControl';
 
 const segmentedControlItems = [
   {
@@ -309,7 +310,7 @@ const Header: FunctionComponent<HeaderProps> = ({
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
-  context.res.setHeader('Cache-Control', 'public');
+  setCacheControl(context.res);
   const serverData = await getServerData(context);
 
   const client = createClient(context);


### PR DESCRIPTION
## Who is this for?
Platform, by making this change to the cache-control headers, we allow users to access cached resources, instead of forcing the platform to constantly repeat the same request multiple times and taking the service down

## What is it doing for them?
for now, removing all the no-cache responses, to be fine tuned at a later time, Amazon Cloudfront does have it's own cache control settings, so we will need to see what the behaviour ends up being.


note: as stated [here](https://nextjs.org/docs/pages/api-reference/next-config-js/headers#cache-control) you cannot set Cache-Control headers in the next.config file so I had to set it in all the pages files individually.