### PR TITLE
An event is past as soon as it's done, not the next day

### DIFF
--- a/common/utils/dates.ts
+++ b/common/utils/dates.ts
@@ -78,16 +78,6 @@ export function isSameDayOrBefore(date1: Date, date2: Date): boolean {
   return isSameDay(date1, date2, 'London') || date1 <= date2;
 }
 
-// Returns true if 'date' falls on a past day; false otherwise.
-export function isDayPast(date: Date): boolean {
-  const now = new Date();
-  if (isSameDay(date, now, 'UTC') || date > now) {
-    return false;
-  } else {
-    return true;
-  }
-}
-
 type LondonTZ = 'GMT' | 'BST';
 
 /** Returns the current timezone in London. */

--- a/content/webapp/services/prismic/events.test.ts
+++ b/content/webapp/services/prismic/events.test.ts
@@ -1,5 +1,7 @@
+import { HasTimes } from '@weco/content/types/events';
 import {
   groupEventsByDay,
+  isEventPast,
   orderEventsByNextAvailableDate,
   upcomingDatesFullyBooked,
 } from './events';
@@ -278,5 +280,56 @@ describe('groupEventsByDay', () => {
         ],
       },
     ]);
+  });
+});
+
+describe('isEventPast', () => {
+  const now = new Date('2011-01-01T12:00:00Z');
+
+  jest.spyOn(dateUtils, 'isPast').mockImplementation((d: Date) => d < now);
+
+  it('marks an event as past if every time is in the past', () => {
+    const event = {
+      times: [
+        {
+          range: {
+            startDateTime: new Date('2001-01-01T01:01:01Z'),
+            endDateTime: new Date('2001-01-01T02:02:02Z'),
+          },
+        },
+      ],
+    };
+
+    expect(isEventPast(event as HasTimes)).toBeTruthy();
+  });
+
+  it('marks an event as past if the last event finished earlier in the same day', () => {
+    const event = {
+      times: [
+        {
+          range: {
+            startDateTime: new Date('2001-01-01T01:01:01Z'),
+            endDateTime: new Date('2011-01-01T02:02:02Z'),
+          },
+        },
+      ],
+    };
+
+    expect(isEventPast(event as HasTimes)).toBeTruthy();
+  });
+
+  it('does not mark an event as past if the last event hasn’t finished yet', () => {
+    const event = {
+      times: [
+        {
+          range: {
+            startDateTime: new Date('2001-01-01T01:01:01Z'),
+            endDateTime: new Date('2033-03-03T03:03:03Z'),
+          },
+        },
+      ],
+    };
+
+    expect(isEventPast(event as HasTimes)).toBeFalsy();
   });
 });

--- a/content/webapp/services/prismic/events.ts
+++ b/content/webapp/services/prismic/events.ts
@@ -3,7 +3,6 @@ import {
   addDays,
   endOfDay,
   getNextWeekendDateRange,
-  isDayPast,
   isFuture,
   isPast,
   isSameDayOrBefore,
@@ -199,10 +198,7 @@ function getRanges({ start, end }: RangeProps, acc: Range[] = []): Range[] {
 }
 
 export function isEventPast({ times }: HasTimes): boolean {
-  const hasFutureEvents = times.some(
-    ({ range }) => !isDayPast(range.endDateTime)
-  );
-  return !hasFutureEvents;
+  return times.every(({ range }) => isPast(range.endDateTime));
 }
 
 export function upcomingDatesFullyBooked(event: HasTimes): boolean {


### PR DESCRIPTION
This changes the behaviour of `isEventPast` slightly, to avoid confusion on the same day as an event but after the event has finished.

This function is used on event schedule items to determine whether to show booking information below a scheduled event, e.g. "Just turn up" or a link to Eventbrite tickets.  But it wouldn't mark an event as past until the end of that day, meaning an event could still be showing "Just turn up" even after it's over!

e.g. an event finishes at 2pm, and somebody looks at the site at 3pm. Because `isEventPast` looks to see if the day of the event has passed, it says "false" and the page shows "Just turn up".  This is misleading! There's nothing to turn up to!

Now it marks events as past as soon as the event ends, avoiding the possibility of confusion.

(It also lets us ditch another use of UTC date comparisons!)

Here's an example of how this could go wrong, for the Lights Up on Milk event. At 4pm on the day of the event, even after the Lights Up session and AD tour are finished, we still tell people to turn up/offer ticket booking.

<img width="779" alt="Screenshot 2023-05-23 at 19 09 32" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/301220/902e0ec8-e49b-40c2-b65b-2c4972fc5d53">
