### PR TITLE
Add cursor:pointer to all buttons (remove dup declarations)

### DIFF
--- a/catalogue/webapp/components/IIIFSearchWithin/IIIFSearchWithin.tsx
+++ b/catalogue/webapp/components/IIIFSearchWithin/IIIFSearchWithin.tsx
@@ -55,7 +55,6 @@ const ListItem = styled.li`
 const SearchResult = styled.button.attrs({
   className: font('intr', 6),
 })`
-  cursor: pointer;
   display: block;
   padding: ${props => `${props.theme.spacingUnit * 2}px 0`};
   color: ${props => props.theme.color('white')};

--- a/catalogue/webapp/components/IIIFViewer/ViewerStructures.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerStructures.tsx
@@ -37,10 +37,6 @@ const Item = styled(Space).attrs({
         background: ${props.theme.color('yellow')};
       }
     `}
-
-  button {
-    cursor: pointer;
-  }
 `;
 
 type Props = {

--- a/catalogue/webapp/components/PaletteColorPicker/PaletteColorPicker.tsx
+++ b/catalogue/webapp/components/PaletteColorPicker/PaletteColorPicker.tsx
@@ -91,7 +91,6 @@ const Swatch = styled.button.attrs((props: SwatchProps) => ({
   flex: 1 0 50%;
   line-height: normal;
   margin-bottom: 8px;
-  cursor: pointer;
   min-height: 32px;
   color: ${props =>
     props.theme.color('black')}; /* This avoids the default blue links on iOS */

--- a/common/views/components/Buttons/Control/Control.tsx
+++ b/common/views/components/Buttons/Control/Control.tsx
@@ -40,7 +40,6 @@ const Wrapper = styled.button.attrs<WrapperProps>(props => ({
   border-radius: 50%;
   padding: 0;
   transition: background ${props => props.theme.transitionProperties};
-  cursor: pointer;
   width: 46px;
   height: 46px;
 

--- a/common/views/components/CookieNotice/CookieNotice.tsx
+++ b/common/views/components/CookieNotice/CookieNotice.tsx
@@ -26,7 +26,6 @@ const CloseCookieNotice = styled.button`
   display: flex;
   align-items: center;
   margin-left: 1em;
-  cursor: pointer;
   background: none;
 `;
 

--- a/common/views/components/InfoBanner/InfoBanner.tsx
+++ b/common/views/components/InfoBanner/InfoBanner.tsx
@@ -45,7 +45,6 @@ const Copy = styled(Space).attrs({
 const CloseButton = styled.button`
   margin: 0;
   padding: 0;
-  cursor: pointer;
   color: ${props =>
     props.theme.color('black')}; /* This avoids the default blue links on iOS */
 `;

--- a/common/views/components/SearchTabs/SearchTabs.BaseTabs.tsx
+++ b/common/views/components/SearchTabs/SearchTabs.BaseTabs.tsx
@@ -28,7 +28,6 @@ const Tab = styled.button.attrs((props: TabProps) => ({
   'aria-controls': props.tabPanelId,
 }))<TabProps>`
   color: ${props => props.theme.color('black')};
-  cursor: pointer;
 
   &:focus {
     outline: 0;

--- a/common/views/components/VideoEmbed/VideoEmbed.tsx
+++ b/common/views/components/VideoEmbed/VideoEmbed.tsx
@@ -28,7 +28,6 @@ const VideoEmbedWrapper = styled.figure`
 `;
 
 const VideoTrigger = styled.button<{ hasFullSizePoster?: boolean }>`
-  cursor: pointer;
   position: absolute;
   padding-bottom: 56.25%; /* 16:9 */
   width: 100%;

--- a/common/views/themes/base/wellcome-normalize.ts
+++ b/common/views/themes/base/wellcome-normalize.ts
@@ -13,6 +13,7 @@ button {
   background: transparent;
   border: 0;
   text-align: left;
+  cursor: pointer;
 }
 
 fieldset {

--- a/content/webapp/components/TitledTextList/TitledTextList.tsx
+++ b/content/webapp/components/TitledTextList/TitledTextList.tsx
@@ -10,7 +10,6 @@ import * as prismic from '@prismicio/client';
 const HeadingLink = styled.a.attrs({
   className: font('intb', 4),
 })`
-  cursor: pointer;
   text-decoration: underline;
   color: ${props => props.theme.color('accent.green')};
 `;

--- a/dash/webapp/pages/toggles.tsx
+++ b/dash/webapp/pages/toggles.tsx
@@ -18,7 +18,6 @@ const Button = styled.button<{ opaque?: boolean }>`
   border-radius: 2px;
   padding: 6px 10px;
   transition: background 150ms ease;
-  cursor: pointer;
   margin-right: 18px;
 `;
 


### PR DESCRIPTION
Part of #9810 (zoom-in cursor on  IIIF images coming in separate PR)

## Who is this for?
People who want buttons to have a pointer cursor by default

## What is it doing for them?
Adding the property declaration to `button`s in `wellcome-normalize.ts` (and removing the now redundant declarations)