### PR TITLE
don’t run tests in parallel

### DIFF
--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -55,8 +55,6 @@ const test = base.extend({
   },
 });
 
-test.describe.configure({ mode: 'parallel' });
-
 test.describe('Scenario 1: A user wants a large-scale view of an item', () => {
   test('the images are scalable', async ({ page, context }) => {
     await multiVolumeItem(context, page);


### PR DESCRIPTION
No idea if this will fix anything, but worth a punt.
Getting rid of this makes the test pass locally every time. With it they are flakey.

N.B. It will make the tests a bit slower to run.