### PR TITLE
Amend next links

### DIFF
--- a/catalogue/webapp/components/IIIFSearchWithin/IIIFSearchWithin.tsx
+++ b/catalogue/webapp/components/IIIFSearchWithin/IIIFSearchWithin.tsx
@@ -264,6 +264,7 @@ const IIIFSearchWithin: FunctionComponent = () => {
               <ListItem key={i}>
                 <SearchResult>
                   <NextLink
+                    replace={true}
                     {...itemLink({
                       workId: work.id,
                       props: {

--- a/catalogue/webapp/components/IIIFViewer/GridViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/GridViewer.tsx
@@ -84,6 +84,7 @@ const Cell = memo(({ columnIndex, rowIndex, style, data }: CellProps) => {
         currentCanvas && (
           <ThumbnailSpacer>
             <NextLink
+              replace={true}
               {...itemLink({
                 workId,
                 props: {

--- a/catalogue/webapp/components/IIIFViewer/MultipleManifestList.tsx
+++ b/catalogue/webapp/components/IIIFViewer/MultipleManifestList.tsx
@@ -21,6 +21,7 @@ const MultipleManifestListPrototype: FunctionComponent = () => {
         {parentManifest?.items.map((manifest, i) => (
           <li key={manifest.id}>
             <NextLink
+              replace={true}
               {...itemLink({
                 workId: work.id,
                 props: {

--- a/catalogue/webapp/components/IIIFViewer/ViewerStructures.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerStructures.tsx
@@ -70,6 +70,7 @@ const ViewerStructuresPrototype: FunctionComponent = () => {
             isActive={canvas === arrayIndexToQueryParam(canvasIndex)}
           >
             <NextLink
+              replace={true}
               {...itemLink({
                 workId: work.id,
                 props: {


### PR DESCRIPTION
The next/links should replace the current history state instead of adding a new URL into the browser’s history stack.

The expected behaviour when using the browser back button is to go to the previous page, not the previous state of the viewer on the item page.
