### PR TITLE
Add 'format: "custom"' to all our custom Prismic types

### DIFF
--- a/prismic-model/src/article-formats.ts
+++ b/prismic-model/src/article-formats.ts
@@ -7,6 +7,7 @@ const articleFormats: CustomType = {
   repeatable: true,
   status: true,
   json: label('Article format'),
+  format: 'custom',
 };
 
 export default articleFormats;

--- a/prismic-model/src/articles.ts
+++ b/prismic-model/src/articles.ts
@@ -69,6 +69,7 @@ const articles: CustomType = {
       },
     },
   },
+  format: 'custom',
 };
 
 export default articles;

--- a/prismic-model/src/audiences.ts
+++ b/prismic-model/src/audiences.ts
@@ -13,6 +13,7 @@ const audiences: CustomType = {
       description: singleLineText('Description'),
     },
   },
+  format: 'custom',
 };
 
 export default audiences;

--- a/prismic-model/src/background-textures.ts
+++ b/prismic-model/src/background-textures.ts
@@ -18,6 +18,7 @@ const backgroundTexture: CustomType = {
       },
     },
   },
+  format: 'custom',
 };
 
 export default backgroundTexture;

--- a/prismic-model/src/books.ts
+++ b/prismic-model/src/books.ts
@@ -19,7 +19,7 @@ const books: CustomType = {
     Book: {
       title,
       subtitle: singleLineText('Subtitle'),
-      body: body,
+      body,
       orderLink: webLink('Order link'),
       price: keyword('Price'),
       format: keyword('Format'),
@@ -54,6 +54,7 @@ const books: CustomType = {
       }),
     },
   },
+  format: 'custom',
 };
 
 export default books;

--- a/prismic-model/src/card.ts
+++ b/prismic-model/src/card.ts
@@ -20,6 +20,7 @@ const card: CustomType = {
       link: link('Link'),
     },
   },
+  format: 'custom',
 };
 
 export default card;

--- a/prismic-model/src/collection-venue.ts
+++ b/prismic-model/src/collection-venue.ts
@@ -126,6 +126,7 @@ const collectionVenue: CustomType = {
       },
     },
   },
+  format: 'custom',
 };
 
 export default collectionVenue;

--- a/prismic-model/src/editorial-contributor-roles.ts
+++ b/prismic-model/src/editorial-contributor-roles.ts
@@ -15,6 +15,7 @@ const editorialContributorRoles: CustomType = {
       describedBy: keyword('Word to describe output of the role'),
     },
   },
+  format: 'custom',
 };
 
 export default editorialContributorRoles;

--- a/prismic-model/src/event-formats.ts
+++ b/prismic-model/src/event-formats.ts
@@ -7,6 +7,7 @@ const eventFormats: CustomType = {
   repeatable: true,
   status: true,
   json: label('Event format'),
+  format: 'custom',
 };
 
 export default eventFormats;

--- a/prismic-model/src/event-policies.ts
+++ b/prismic-model/src/event-policies.ts
@@ -7,6 +7,7 @@ const eventPolicies: CustomType = {
   repeatable: true,
   status: true,
   json: label('Event policy'),
+  format: 'custom',
 };
 
 export default eventPolicies;

--- a/prismic-model/src/event-series.ts
+++ b/prismic-model/src/event-series.ts
@@ -27,6 +27,7 @@ const eventSeries: CustomType = {
       metadataDescription: singleLineText('Metadata description'),
     },
   },
+  format: 'custom',
 };
 
 export default eventSeries;

--- a/prismic-model/src/events.ts
+++ b/prismic-model/src/events.ts
@@ -110,6 +110,7 @@ const events: CustomType = {
       }),
     },
   },
+  format: 'custom',
 };
 
 export default events;

--- a/prismic-model/src/exhibition-formats.ts
+++ b/prismic-model/src/exhibition-formats.ts
@@ -7,6 +7,7 @@ const exhibitionFormats: CustomType = {
   repeatable: true,
   status: true,
   json: label('Exhibition format'),
+  format: 'custom',
 };
 
 export default exhibitionFormats;

--- a/prismic-model/src/exhibition-guides.ts
+++ b/prismic-model/src/exhibition-guides.ts
@@ -56,6 +56,7 @@ const exhibitionGuides: CustomType = {
       }),
     },
   },
+  format: 'custom',
 };
 
 export default exhibitionGuides;

--- a/prismic-model/src/exhibition-resources.ts
+++ b/prismic-model/src/exhibition-resources.ts
@@ -15,6 +15,7 @@ const exhibitionResources: CustomType = {
       icon: select('Icon type', { options: ['information', 'family'] }),
     },
   },
+  format: 'custom',
 };
 
 export default exhibitionResources;

--- a/prismic-model/src/exhibitions.ts
+++ b/prismic-model/src/exhibitions.ts
@@ -75,6 +75,7 @@ const exhibitions: CustomType = {
       }),
     },
   },
+  format: 'custom',
 };
 
 export default exhibitions;

--- a/prismic-model/src/global-alert.ts
+++ b/prismic-model/src/global-alert.ts
@@ -25,6 +25,7 @@ const globalAlert: CustomType = {
       ),
     },
   },
+  format: 'custom',
 };
 
 export default globalAlert;

--- a/prismic-model/src/guide-formats.ts
+++ b/prismic-model/src/guide-formats.ts
@@ -7,6 +7,7 @@ const guideFormat: CustomType = {
   repeatable: true,
   status: true,
   json: label('Guide format'),
+  format: 'custom',
 };
 
 export default guideFormat;

--- a/prismic-model/src/guides.ts
+++ b/prismic-model/src/guides.ts
@@ -30,6 +30,7 @@ const guides: CustomType = {
       metadataDescription: singleLineText('Metadata description'),
     },
   },
+  format: 'custom',
 };
 
 export default guides;

--- a/prismic-model/src/interpretation-types.ts
+++ b/prismic-model/src/interpretation-types.ts
@@ -19,6 +19,7 @@ const interpretationTypes: CustomType = {
       primaryDescription: multiLineText('Message if primary interpretation'),
     },
   },
+  format: 'custom',
 };
 
 export default interpretationTypes;

--- a/prismic-model/src/labels.ts
+++ b/prismic-model/src/labels.ts
@@ -7,6 +7,7 @@ const labels: CustomType = {
   repeatable: true,
   status: true,
   json: label('Label'),
+  format: 'custom',
 };
 
 export default labels;

--- a/prismic-model/src/organisations.ts
+++ b/prismic-model/src/organisations.ts
@@ -14,7 +14,7 @@ const organisations: CustomType = {
   json: {
     Organisation: {
       name: title,
-      description: description,
+      description,
       image: image('Image'),
       sameAs: list('Same as', {
         link: keyword('Link', {
@@ -26,6 +26,7 @@ const organisations: CustomType = {
       }),
     },
   },
+  format: 'custom',
 };
 
 export default organisations;

--- a/prismic-model/src/page-formats.ts
+++ b/prismic-model/src/page-formats.ts
@@ -7,6 +7,7 @@ const pageFormats: CustomType = {
   repeatable: true,
   status: true,
   json: label('Page format'),
+  format: 'custom',
 };
 
 export default pageFormats;

--- a/prismic-model/src/pages.ts
+++ b/prismic-model/src/pages.ts
@@ -49,6 +49,7 @@ const pages: CustomType = {
     },
     Contributors: contributorsWithTitle(),
   },
+  format: 'custom',
 };
 
 export default pages;

--- a/prismic-model/src/people.ts
+++ b/prismic-model/src/people.ts
@@ -13,7 +13,7 @@ const people: CustomType = {
   json: {
     Person: {
       name: keyword('Full name'),
-      description: description,
+      description,
       pronouns: keyword('Pronouns'),
       image: image('Image'),
       sameAs: list('Same as', {
@@ -26,6 +26,7 @@ const people: CustomType = {
       }),
     },
   },
+  format: 'custom',
 };
 
 export default people;

--- a/prismic-model/src/places.ts
+++ b/prismic-model/src/places.ts
@@ -20,6 +20,7 @@ const places: CustomType = {
       body,
     },
   },
+  format: 'custom',
 };
 
 export default places;

--- a/prismic-model/src/popup-dialog.ts
+++ b/prismic-model/src/popup-dialog.ts
@@ -19,6 +19,7 @@ const popupDialog: CustomType = {
       isShown: boolean('Is shown?', { defaultValue: false }),
     },
   },
+  format: 'custom',
 };
 
 export default popupDialog;

--- a/prismic-model/src/project-formats.ts
+++ b/prismic-model/src/project-formats.ts
@@ -7,6 +7,7 @@ const projectFormat: CustomType = {
   repeatable: true,
   status: true,
   json: label('Project format'),
+  format: 'custom',
 };
 
 export default projectFormat;

--- a/prismic-model/src/projects.ts
+++ b/prismic-model/src/projects.ts
@@ -37,6 +37,7 @@ const projects: CustomType = {
       metadataDescription: singleLineText('Metadata description'),
     },
   },
+  format: 'custom',
 };
 
 export default projects;

--- a/prismic-model/src/seasons.ts
+++ b/prismic-model/src/seasons.ts
@@ -20,6 +20,7 @@ const Season: CustomType = {
       promo,
     },
   },
+  format: 'custom',
 };
 
 export default Season;

--- a/prismic-model/src/series.ts
+++ b/prismic-model/src/series.ts
@@ -52,6 +52,7 @@ const articleSeries: CustomType = {
       }),
     },
   },
+  format: 'custom',
 };
 
 export default articleSeries;

--- a/prismic-model/src/stories-landing.ts
+++ b/prismic-model/src/stories-landing.ts
@@ -32,6 +32,7 @@ const featuredBooks: CustomType = {
       }),
     },
   },
+  format: 'custom',
 };
 
 export default featuredBooks;

--- a/prismic-model/src/teams.ts
+++ b/prismic-model/src/teams.ts
@@ -15,6 +15,7 @@ const teams = {
       url: keyword('URL'),
     },
   },
+  format: 'custom',
 };
 
 export default teams;

--- a/prismic-model/src/types/CustomType.ts
+++ b/prismic-model/src/types/CustomType.ts
@@ -4,4 +4,5 @@ export type CustomType = {
   repeatable: boolean;
   status: boolean;
   json: unknown;
+  format: 'custom';
 };

--- a/prismic-model/src/webcomic-series.ts
+++ b/prismic-model/src/webcomic-series.ts
@@ -24,6 +24,7 @@ const webcomicSeries: CustomType = {
       metadataDescription: singleLineText('Metadata description'),
     },
   },
+  format: 'custom',
 };
 
 export default webcomicSeries;

--- a/prismic-model/src/webcomics.ts
+++ b/prismic-model/src/webcomics.ts
@@ -46,6 +46,7 @@ const webcomics: CustomType = {
       },
     },
   },
+  format: 'custom',
 };
 
 export default webcomics;


### PR DESCRIPTION
The Prismic API has started returning this field in all its API responses; adding it to our models seems to make it happy.