### PR TITLE
Try adding a concurrency group to the e2e tests

### DIFF
--- a/.buildkite/pipeline.deployment.yml
+++ b/.buildkite/pipeline.deployment.yml
@@ -29,6 +29,14 @@ steps:
     agents:
       queue: nano
 
+    # This means that each set of e2e tests will run with one deployment.
+    #
+    # This avoids any issues with the deployment changing as the e2e tests
+    # are running, which we believe might be the source of some instability
+    # and flakiness -- stuff changing as the tests are running.
+    concurrency: 1
+    concurrency_group: "experience-deploy"
+
     soft_fail:
       - exit_status: 1
 


### PR DESCRIPTION
I've added this to the task that triggers the e2es rather than the e2es themselves because:

* it keeps everything in one file
* we still want the different flavours of e2e to run concurrently, but I was too lazy to work out how concurrency gates work https://buildkite.com/docs/pipelines/controlling-concurrency

Potentially we could still get flakiness if something else triggers an e2e test mid-deployment (e.g. an API deployment), but let's cross that bridge when we come to it.