### PR TITLE
Implement a basic spam detection heuristic

### DIFF
--- a/cache/edge_lambdas/src/origin.ts
+++ b/cache/edge_lambdas/src/origin.ts
@@ -4,8 +4,11 @@ import {
   CloudFrontRequestHandler,
   CloudFrontResponseHandler,
 } from 'aws-lambda';
+import { getRejection } from './rejection';
 
 export const request: CloudFrontRequestHandler = (event, context, callback) => {
+  getRejection(event);
+
   const redirectResponse = getRedirect(event);
   if (redirectResponse) {
     callback(null, redirectResponse);

--- a/cache/edge_lambdas/src/origin.ts
+++ b/cache/edge_lambdas/src/origin.ts
@@ -7,7 +7,11 @@ import {
 import { getRejection } from './rejection';
 
 export const request: CloudFrontRequestHandler = (event, context, callback) => {
-  getRejection(event);
+  const rejectResponse = getRejection(event);
+  if (rejectResponse) {
+    callback(null, rejectResponse);
+    return;
+  }
 
   const redirectResponse = getRedirect(event);
   if (redirectResponse) {

--- a/cache/edge_lambdas/src/redirector.ts
+++ b/cache/edge_lambdas/src/redirector.ts
@@ -2,7 +2,7 @@ import { CloudFrontRequestEvent, CloudFrontResponse } from 'aws-lambda';
 import { URLSearchParams } from 'url';
 import { literalRedirects, queryRedirects } from './redirects';
 
-const redirect301 = (host: string, path: string) => ({
+export const redirect301 = (host: string, path: string) => ({
   status: '301',
   statusDescription: 'Found',
   headers: {

--- a/cache/edge_lambdas/src/rejection.test.ts
+++ b/cache/edge_lambdas/src/rejection.test.ts
@@ -48,7 +48,6 @@ describe('requests that probably aren’t spam', () => {
 
 describe('requests that probably are spam', () => {
   test.each([
-    { request: { querystring: 'token=oukyuiw07&query=如何利用电' } },
     { request: { querystring: 'ID=6xnq75u6n&query=找黑客' } },
     {
       request: {

--- a/cache/edge_lambdas/src/rejection.test.ts
+++ b/cache/edge_lambdas/src/rejection.test.ts
@@ -48,7 +48,6 @@ describe('requests that probably aren’t spam', () => {
 
 describe('requests that probably are spam', () => {
   test.each([
-    { request: { querystring: 'ID=6xnq75u6n&query=找黑客' } },
     {
       request: {
         querystring: 'query=free+to+play+casino',

--- a/cache/edge_lambdas/src/rejection.test.ts
+++ b/cache/edge_lambdas/src/rejection.test.ts
@@ -1,0 +1,100 @@
+import { CloudFrontRequestEvent } from 'aws-lambda';
+import { looksLikeSpam } from './rejection';
+
+describe('requests that probably aren’t spam', () => {
+  test.each([
+    { request: { uri: '/whats-on', querystring: '' } },
+    { request: { uri: '/articles/YFS1qRAAACgAF3A3', querystring: '' } },
+    {
+      request: {
+        querystring: 'query=history+of+play',
+        headers: {
+          'user-agent': [{ key: 'User-Agent', value: 'Chrome/103.0.5060.134' }],
+        },
+      },
+    },
+    {
+      request: {
+        querystring: 'query=生殖健康问题+Reproductive+health+matters',
+      },
+    },
+    { request: { querystring: 'query=fish&page=2&workType=a' } },
+  ])(`$request`, ({ request }) => {
+    const event: CloudFrontRequestEvent = {
+      Records: [
+        {
+          cf: {
+            config: {
+              distributionId: 'EXAMPLE',
+              distributionDomainName: '',
+              requestId: '',
+              eventType: 'origin-request',
+            },
+            request: {
+              uri: '/search',
+              method: 'GET',
+              clientIp: '2001:cdba::3257:9652',
+              headers: {},
+              ...request,
+            },
+          },
+        },
+      ],
+    };
+
+    expect(looksLikeSpam(event)).toBeFalsy();
+  });
+});
+
+describe('requests that probably are spam', () => {
+  test.each([
+    { request: { querystring: 'token=oukyuiw07&query=如何利用电' } },
+    { request: { querystring: 'ID=6xnq75u6n&query=找黑客' } },
+    {
+      request: {
+        querystring: 'query=free+to+play+casino',
+        headers: {
+          'user-agent': [{ key: 'User-Agent', value: 'bingbot/2.0;' }],
+        },
+      },
+    },
+    {
+      request: {
+        querystring: 'query=来我们这里免费玩赌场游戏',
+        headers: {
+          'user-agent': [{ key: 'User-Agent', value: 'Googlebot/2.1;' }],
+        },
+      },
+    },
+    {
+      request: {
+        querystring:
+          'query=不用认真来找我们免费玩赌场游戏sketchy.xyz我们拥有所有最好的骗局和垃圾邮件我们非常值得信赖您可以完全关闭病毒检查程序',
+      },
+    },
+  ])(`$request`, ({ request }) => {
+    const event: CloudFrontRequestEvent = {
+      Records: [
+        {
+          cf: {
+            config: {
+              distributionId: 'EXAMPLE',
+              distributionDomainName: '',
+              requestId: '',
+              eventType: 'origin-request',
+            },
+            request: {
+              uri: '/search',
+              method: 'GET',
+              clientIp: '2001:cdba::3257:9652',
+              headers: {},
+              ...request,
+            },
+          },
+        },
+      ],
+    };
+
+    expect(looksLikeSpam(event)).toBeTruthy();
+  });
+});

--- a/cache/edge_lambdas/src/rejection.ts
+++ b/cache/edge_lambdas/src/rejection.ts
@@ -30,7 +30,7 @@ export const getRejection = (
         : 'wellcomecollection.org';
 
     const params = new URLSearchParams();
-    params.set('originalUrl', request.uri);
+    params.set('originalUrl', `${request.uri}?${request.querystring}`);
 
     return redirect301(host, `/404?${params}`);
   }

--- a/cache/edge_lambdas/src/rejection.ts
+++ b/cache/edge_lambdas/src/rejection.ts
@@ -1,4 +1,13 @@
 import { CloudFrontRequestEvent, CloudFrontResponse } from 'aws-lambda';
+import { redirect301 } from './redirector';
+
+const countChineseCharacters = (s: string) => {
+  const chineseCharCount = s
+    .split('')
+    .map(c => c.charCodeAt(0))
+    .filter(code => code >= 13312 && code <= 64255).length;
+  return chineseCharCount / s.length;
+};
 
 export const getRejection = (
   event: CloudFrontRequestEvent
@@ -8,6 +17,23 @@ export const getRejection = (
 
   const requestParams = new URLSearchParams(request.querystring);
   const query = requestParams.getAll('query').join(' ');
+
+  if (query.length >= 100 && countChineseCharacters(query) > 0.5) {
+    const hostHeader = cf.request.headers.host;
+    const requestHost =
+      hostHeader && hostHeader.length > 0 ? hostHeader[0].value : undefined;
+
+    const host =
+      requestHost &&
+      requestHost.indexOf('www-stage.wellcomecollection.org') !== -1
+        ? 'www-stage.wellcomecollection.org'
+        : 'wellcomecollection.org';
+
+    const params = new URLSearchParams();
+    params.set('originalUrl', request.uri);
+
+    return redirect301(host, `/404?${params}`);
+  }
 
   console.log(query);
 

--- a/cache/edge_lambdas/src/rejection.ts
+++ b/cache/edge_lambdas/src/rejection.ts
@@ -1,0 +1,15 @@
+import { CloudFrontRequestEvent, CloudFrontResponse } from 'aws-lambda';
+
+export const getRejection = (
+  event: CloudFrontRequestEvent
+): CloudFrontResponse | undefined => {
+  const cf = event.Records[0].cf;
+  const request = cf.request;
+
+  const requestParams = new URLSearchParams(request.querystring);
+  const query = requestParams.getAll('query').join(' ');
+
+  console.log(query);
+
+  return undefined;
+};

--- a/cache/edge_lambdas/src/rejection.ts
+++ b/cache/edge_lambdas/src/rejection.ts
@@ -110,22 +110,13 @@ export const looksLikeSpam = (event: CloudFrontRequestEvent): boolean => {
   //
   // In my analysis, this flagged ~41% of all search traffic.
   const spamKeywords = [
-    'cash',
     'casino',
     'chatgpt',
     'crypto',
     'ddos',
-    'free',
-    'fun',
-    'game',
-    'give away',
-    'give-away',
-    'giveaway',
-    'play',
     'poker',
     'telegram',
     'whatsapp',
-    'win',
     '➡️',
     '☀️',
     '⏩',
@@ -139,25 +130,13 @@ export const looksLikeSpam = (event: CloudFrontRequestEvent): boolean => {
     '⭐',
     '👈',
     '👉',
+    '㊙️',
   ];
 
   if (
     isBotRequest(request) &&
     spamKeywords.some(kw => query.toLowerCase().includes(kw))
   ) {
-    return true;
-  }
-
-  // Look for query parameters that we don't use.
-  //
-  // I noticed that a lot of search requests include query parameters that we don't
-  // define in our apps, and with values that aren't meaningful.  If one of these are
-  // present, it suggests you're probably not a real person.
-  //
-  // In my analysis, this flagged ~4% of all search traffic.
-  const unrecognisedParams = ['ID', 'news', 'action', 'cat', 'token', 'type'];
-
-  if (unrecognisedParams.some(name => requestParams.get(name) !== null)) {
     return true;
   }
 

--- a/cache/edge_lambdas/src/rejection.ts
+++ b/cache/edge_lambdas/src/rejection.ts
@@ -185,6 +185,7 @@ export const looksLikeSpam = (event: CloudFrontRequestEvent): boolean => {
           //
           //    U+3299 Circled Ideograph Secret
           //    U+FE0F Variation Selector-16 (which triggers Unicode)
+          //
           code === 0x3299 ||
           code === 0xfe0f
       ).length;

--- a/cache/edge_lambdas/src/rejection.ts
+++ b/cache/edge_lambdas/src/rejection.ts
@@ -1,4 +1,47 @@
-import { CloudFrontRequestEvent, CloudFrontResponse } from 'aws-lambda';
+/** This implements some basic spam-detection heuristics.
+ *
+ * We see a lot of spam on the search page -- people stuffing in nonsense queries,
+ * or links to spam sites (casinos, scams, porn, etc).  We want to reject these as
+ * quickly as possible; to avoid them gumming up our analytics and putting unnecessary
+ * load on our back-end search systems.
+ *
+ * The heuristics were chosen with the following principles/assumptions:
+ *
+ *    - We're trying to cut the spam, not stop it entirely.
+ *
+ *      It's enough to have some simple heuristics that stop the worst of the traffic.
+ *      We assume we're dealing with automated spam bots, not dealing with somebody
+ *      who's targeting us specifically.  (If we are, we should start by making these
+ *      rules private!)
+ *
+ *    - We should never impact legitimate users.  It's better to serve a request to
+ *      a spam bot than break the site for a real person.
+ *
+ *    - These checks should be fast; we don't want to slow down the site for real users
+ *      with overly expensive spam checks.
+ *
+ * == How these heuristics were developed ==
+ *
+ * I downloaded the CloudFront logs for a 2-week-long period, and looked at any request
+ * that had a `query` parameter (which is where a lot of the spam comes in).
+ *
+ * Then I wrote a script that would try a candidate heuristic over these requests,
+ * and report:
+ *
+ *    - the total number of requests that were accepted/rejected
+ *    - the average time taken to process each request
+ *    - a random sample of accepted/rejected requests
+ *
+ * I ran this multiple times to refine the heuristic, until a good number of the sample
+ * of accepted requests looked like bona-fide traffic.
+ *
+ */
+
+import {
+  CloudFrontRequest,
+  CloudFrontRequestEvent,
+  CloudFrontResponse,
+} from 'aws-lambda';
 import { redirect301 } from './redirector';
 
 const countChineseCharacters = (s: string) => {
@@ -9,33 +52,144 @@ const countChineseCharacters = (s: string) => {
   return chineseCharCount / s.length;
 };
 
-export const getRejection = (
-  event: CloudFrontRequestEvent
-): CloudFrontResponse | undefined => {
+// Returns true if this request looks like a bot.
+//
+// A lot of spam requests will spoof their User-Agent header to look like a popular
+// web crawler, e.g. Googlebot or Bingbot.  Because a person would never spoof their
+// User-Agent this way, we can use this as an excuse to apply more stringent checks.
+const isBotRequest = (request: CloudFrontRequest): boolean => {
+  const userAgent = request.headers['user-agent']?.[0]?.value || '';
+
+  return (
+    userAgent.toLowerCase().includes('bot') ||
+    userAgent.toLowerCase().includes('search.yahoo')
+  );
+};
+
+// 253,376 requests rejected
+// 6,688,393 requests accepted
+
+export const looksLikeSpam = (event: CloudFrontRequestEvent): boolean => {
   const cf = event.Records[0].cf;
   const request = cf.request;
 
   const requestParams = new URLSearchParams(request.querystring);
   const query = requestParams.getAll('query').join(' ');
 
-  if (query.length >= 100 && countChineseCharacters(query) > 0.5) {
-    const hostHeader = cf.request.headers.host;
-    const requestHost =
-      hostHeader && hostHeader.length > 0 ? hostHeader[0].value : undefined;
-
-    const host =
-      requestHost &&
-      requestHost.indexOf('www-stage.wellcomecollection.org') !== -1
-        ? 'www-stage.wellcomecollection.org'
-        : 'wellcomecollection.org';
-
-    const params = new URLSearchParams();
-    params.set('originalUrl', `${request.uri}?${request.querystring}`);
-
-    return redirect301(host, `/404?${params}`);
+  // Look for the `query` URL parameter.
+  //
+  // The majority of our spam comes from people plugging in values to the
+  // search form and stuffing bogus values into the query parameter.
+  // If there isn't a query parameter on this request, it's probably not spam.
+  if (query === '') {
+    return false;
   }
 
-  console.log(query);
+  // Look for spammy keywords and emoji.
+  //
+  // We can't solely rely on the presence of these words/characters to indicate spam,
+  // but they're a clue -- usually accompanied by long strings of Chinese characters
+  // and a URL to a sketchy-looking site.
+  //
+  // To avoid penalising real users, we only treat this text as spam if the user
+  // has self-identified as a bot/crawler in their User-Agent header.
+  //
+  // In my analysis, this flagged ~41% of all search traffic.
+  const spamKeywords = [
+    'cash',
+    'casino',
+    'chatgpt',
+    'crypto',
+    'ddos',
+    'free',
+    'fun',
+    'game',
+    'give away',
+    'give-away',
+    'giveaway',
+    'play',
+    'poker',
+    'whatsapp',
+    'win',
+    '➡️',
+    '☀️',
+    '⏩',
+    '⛔',
+    '⚽',
+    '✅',
+    '🐯',
+    '🍀',
+    '㊙',
+    '✔️',
+    '⭐',
+    '👈',
+    '👉',
+  ];
 
+  if (
+    isBotRequest(request) &&
+    spamKeywords.some(kw => query.toLowerCase().includes(kw))
+  ) {
+    return true;
+  }
+
+  // Look for query parameters that we don't use.
+  //
+  // I noticed that a lot of search requests include query parameters that we don't
+  // define in our apps, and with values that aren't meaningful.  If one of these are
+  // present, it suggests you're probably not a real person.
+  //
+  // In my analysis, this flagged ~4% of all search traffic.
+  const unrecognisedParams = ['ID', 'news', 'action', 'cat', 'token', 'type'];
+
+  if (unrecognisedParams.some(name => requestParams.get(name) !== null)) {
+    return true;
+  }
+
+  // Count Chinese characters in the query string.
+  //
+  // A lot of our spam queries feature a long string of Chinese, with links to
+  // sketchy-looking sites mixed in the middle.  This is a clue!
+  //
+  // But we can't reject all queries with Chinese characters, because we have
+  // some Chinese in the catalogue that real people might be searching for.
+  // It's rare and isn't on many works, but it does occur in a few records
+  // e.g. https://wellcomecollection.org/works/grgcnqwf
+  //
+  // So we implement this check as follows:
+  //
+  //    - Pick a threshold for most Chinese characters allowed in a query.
+  //    - Count the number of Chinese characters in the query.
+  //    - If it's higher than the threshold, mark the request as spam.
+  //
+  // The threshold is significantly lower for users that self-identify as bots
+  // in their User-Agent header.
+  //
+  // Implementation note: this check is somewhat expensive, so we skip running it
+  // if the query is too short to exceed the threshold.
+  //
+  // In my analysis, this flagged ~70% of all search traffic.
+  const maxChineseCharsAllowed = isBotRequest(request) ? 10 : 30;
+
+  if (query.length >= maxChineseCharsAllowed) {
+    const chineseCharacterCount = query
+      .split('')
+      .map(c => c.charCodeAt(0))
+      .filter(
+        code =>
+          (code >= 12353 && code <= 12446) || (code >= 13312 && code <= 64255)
+      ).length;
+
+    if (chineseCharacterCount >= maxChineseCharsAllowed) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+export const getRejection = (
+  event: CloudFrontRequestEvent
+): CloudFrontResponse | undefined => {
   return undefined;
 };

--- a/cache/edge_lambdas/src/rejection.ts
+++ b/cache/edge_lambdas/src/rejection.ts
@@ -100,6 +100,7 @@ export const looksLikeSpam = (event: CloudFrontRequestEvent): boolean => {
     'giveaway',
     'play',
     'poker',
+    'telegram',
     'whatsapp',
     'win',
     '➡️',

--- a/cache/edge_lambdas/src/rejection.ts
+++ b/cache/edge_lambdas/src/rejection.ts
@@ -42,15 +42,6 @@ import {
   CloudFrontRequestEvent,
   CloudFrontResponse,
 } from 'aws-lambda';
-import { redirect301 } from './redirector';
-
-const countChineseCharacters = (s: string) => {
-  const chineseCharCount = s
-    .split('')
-    .map(c => c.charCodeAt(0))
-    .filter(code => code >= 13312 && code <= 64255).length;
-  return chineseCharCount / s.length;
-};
 
 // Returns true if this request looks like a bot.
 //


### PR DESCRIPTION
This implements a basic spam detection heuristic for our search traffic. The comments in the code explain the rules in more detail, but the tl;dr is:

* 🚮 if you're using a query parameter we obviously don't use
* 🚮 if you claim to be a bot and then use spammy keywords like "crypto" or "casino"
* 🚮 if there are a suspiciously high number of Chinese chars in your query (higher threshold for people than bots)

Combined, these three measures would filter our ~75% of the search traffic from the last fortnight. 

This PR just implements the heuristic as a pure function; it doesn't wire it up to anything yet – I’ll handle that in a separate patch.