### PR TITLE
Remove our dependency on next-transpile-modules

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -42,7 +42,6 @@
     "koa-compose": "^4.1.0",
     "lodash.debounce": "^4.0.8",
     "next": "^13.2.3",
-    "next-transpile-modules": "^10.0.0",
     "node-fetch": "^2.6.2",
     "nprogress": "^0.2.0",
     "react": "^18.2.0",

--- a/identity/webapp/package.json
+++ b/identity/webapp/package.json
@@ -36,7 +36,6 @@
     "koa-logger": "^3.2.1",
     "next": "^13.2.3",
     "next-router-mock": "^0.9.3",
-    "next-transpile-modules": "^8.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.43.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10468,14 +10468,6 @@ enhanced-resolve@^5.10.0:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
 
-enhanced-resolve@^5.7.0:
-  version "5.8.3"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz#6d552d465cce0423f5b3d718511ea53826a7b2f0"
-  integrity sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==
-  dependencies:
-    graceful-fs "^4.2.4"
-    tapable "^2.2.0"
-
 entities@2.2.0, entities@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
@@ -15437,21 +15429,6 @@ next-tick@1, next-tick@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.1.0.tgz#1836ee30ad56d67ef281b22bd199f709449b35eb"
   integrity sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==
-
-next-transpile-modules@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/next-transpile-modules/-/next-transpile-modules-10.0.0.tgz#7152880048835acb64d05fc7aa34910cbe7994da"
-  integrity sha512-FyeJ++Lm2Fq31gbThiRCrJlYpIY9QaI7A3TjuhQLzOix8ChQrvn5ny4MhfIthS5cy6+uK1AhDRvxVdW17y3Xdw==
-  dependencies:
-    enhanced-resolve "^5.10.0"
-
-next-transpile-modules@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/next-transpile-modules/-/next-transpile-modules-8.0.0.tgz#56375cdc25ae5d23a834195f277fc2737b26cb97"
-  integrity sha512-Q2f2yB0zMJ8KJbIYAeZoIxG6cSfVk813zr6B5HzsLMBVcJ3FaF8lKr7WG66n0KlHCwjLSmf/6EkgI6QQVWHrDw==
-  dependencies:
-    enhanced-resolve "^5.7.0"
-    escalade "^3.1.1"
 
 next@^13.2.3:
   version "13.2.3"


### PR DESCRIPTION
Quoting the [latest release of next-transpile-modules "The End"](https://github.com/martpie/next-transpile-modules/releases/tag/the-end):

> All features of next-transpile-modules are now natively integrated in Next.js 13.1: next-transpile-modules is now officially deprecated, and the repository will be archived soon.

We're already running Next.js 13.2, and we've already set up the `transpilePackages` setting suggested in the migration guide.

Closes #9704