### PR TITLE
Remove unnecessary `ul` wrapper in Image grid

### DIFF
--- a/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
+++ b/catalogue/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
@@ -132,19 +132,17 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
   return (
     <>
       {isFullSupportBrowser && !isSmallGallery && (
-        <PlainList data-test-id="image-search-results-container">
-          <GalleryContainer>
-            <PhotoAlbum
-              photos={imagesWithDimensions}
-              renderPhoto={imageRenderer}
-              renderRowContainer={renderRowContainer}
-              layout="rows"
-              spacing={0}
-              padding={12}
-              targetRowHeight={200}
-            />
-          </GalleryContainer>
-        </PlainList>
+        <GalleryContainer data-test-id="image-search-results-container">
+          <PhotoAlbum
+            photos={imagesWithDimensions}
+            renderPhoto={imageRenderer}
+            renderRowContainer={renderRowContainer}
+            layout="rows"
+            spacing={0}
+            padding={12}
+            targetRowHeight={200}
+          />
+        </GalleryContainer>
       )}
       {(!isFullSupportBrowser || isSmallGallery) && (
         <ImageCardList data-test-id="image-search-results-container">

--- a/playwright/test/search-images.test.ts
+++ b/playwright/test/search-images.test.ts
@@ -26,7 +26,7 @@ const searchBarInput = `#search-searchbar`;
 const colourSelectorFilterDropDown = `button[aria-controls="images.color"]`;
 const colourSelector = `button[data-test-id="swatch-green"]`;
 const imageSearchResultsContainer =
-  'ul[data-test-id="image-search-results-container"]';
+  '[data-test-id="image-search-results-container"]';
 const imagesResultsListItem = `${imageSearchResultsContainer} li`;
 
 const fillActionSearchInput = async (

--- a/playwright/test/search.test.ts
+++ b/playwright/test/search.test.ts
@@ -46,7 +46,7 @@ async function gotoSearchResultPage(
 }
 
 const imageSearchResultsContainer =
-  'ul[data-test-id="image-search-results-container"]';
+  '[data-test-id="image-search-results-container"]';
 const imagesResultsListItem = `${imageSearchResultsContainer} li`;
 
 const subNavigationContainer = 'div[data-test-id="sub-nav-tab-container"]';


### PR DESCRIPTION
## Who is this for?
a11y, html semantics

## What is it doing for them?
The results were wrapped in a `ul` but its children were divs containing more `ul`s. It doesn't need to be a list at that level and was flagged by Lighthouse.