### PR TITLE
Add the concurrency group to _actually_ running the e2es

### DIFF
--- a/.buildkite/scripts/trigger-e2e.sh
+++ b/.buildkite/scripts/trigger-e2e.sh
@@ -21,6 +21,14 @@ TRIGGER_STEP="steps:
       env:
         DEPLOYMENT_ENVIRONMENT: ${BUILDKITE_GITHUB_DEPLOYMENT_ENVIRONMENT}
         PLAYWRIGHT_BASE_URL: ${ENVIRONMENT_URL}
+
+    # This means that each set of e2e tests will run with one deployment.
+    #
+    # This avoids any issues with the deployment changing as the e2e tests
+    # are running, which we believe might be the source of some instability
+    # and flakiness -- stuff changing as the tests are running.
+    concurrency: 1
+    concurrency_group: "experience-deploy"
 "
 
 echo "$TRIGGER_STEP" | buildkite-agent pipeline upload


### PR DESCRIPTION
In my previous change, I added a concurrency group to the e2e trigger -- so the e2es wouldn't be triggered at the same time as a running deploy, but they could run at the same time as a deploy.  I think adding the concurrency group here should fix that.

These illustrations show what I think was happening; steps in the concurrency group are in yellow. Time moves down the page.

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img width="261" alt="Screenshot 2023-05-30 at 17 16 08" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/301220/02c54e8d-3ee1-4f06-bbc6-cbc2abac0e04">
</td>
<td>
<img width="266" alt="Screenshot 2023-05-30 at 17 16 11" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/301220/a257bee6-5656-4ddd-8669-96549d540bcd">
</td>
</tr>
</table>