### PR TITLE
Revert "Add the concurrency group to _actually_ running the e2es"

### DIFF
--- a/.buildkite/scripts/trigger-e2e.sh
+++ b/.buildkite/scripts/trigger-e2e.sh
@@ -21,14 +21,6 @@ TRIGGER_STEP="steps:
       env:
         DEPLOYMENT_ENVIRONMENT: ${BUILDKITE_GITHUB_DEPLOYMENT_ENVIRONMENT}
         PLAYWRIGHT_BASE_URL: ${ENVIRONMENT_URL}
-
-    # This means that each set of e2e tests will run with one deployment.
-    #
-    # This avoids any issues with the deployment changing as the e2e tests
-    # are running, which we believe might be the source of some instability
-    # and flakiness -- stuff changing as the tests are running.
-    concurrency: 1
-    concurrency_group: "experience-deploy"
 "
 
 echo "$TRIGGER_STEP" | buildkite-agent pipeline upload


### PR DESCRIPTION
Reverts wellcomecollection/wellcomecollection.org#9875

This is breaking the builds; see https://buildkite.com/wellcomecollection/wc-dot-org-deployment/builds/2448#018870f9-4ac8-4ae3-b96d-66d76817aa06

> 422 Concurrency cannot be set for steps that trigger builds

I think it's the right idea, but wrong implementation.