### PR TITLE
Make the tests for event-series utils a bit more readable, add more test cases

### DIFF
--- a/content/webapp/utils/event-series.test.ts
+++ b/content/webapp/utils/event-series.test.ts
@@ -1,4 +1,71 @@
-import { getUpcomingEvents } from './event-series';
+import { HasTimes } from '@weco/content/types/events';
+import { getUpcomingEvents, isUpcoming } from './event-series';
+import * as dateUtils from '@weco/common/utils/dates';
+
+function createEvent({
+  startDateTime,
+  endDateTime,
+}: {
+  startDateTime: Date;
+  endDateTime: Date;
+}): HasTimes {
+  return {
+    times: [
+      {
+        range: {
+          startDateTime,
+          endDateTime,
+        },
+        isFullyBooked: { inVenue: false, online: false },
+      },
+    ],
+  };
+}
+
+describe('isUpcoming', () => {
+  it('an event which finished in the past is not upcoming', () => {
+    const event = createEvent({
+      startDateTime: new Date(2001, 1, 1, 1, 1, 1),
+      endDateTime: new Date(2002, 1, 1, 1, 1, 1),
+    });
+
+    expect(isUpcoming(event)).toBeFalsy();
+  });
+
+  it('an event which started earlier today and finishes today is not upcoming', () => {
+    const mondayAt7am = new Date('2007-01-01T07:00:00Z');
+    const mondayAt9am = new Date('2007-01-01T09:00:00Z');
+    const mondayAt11am = new Date('2007-01-01T11:00:00Z');
+
+    jest
+      .spyOn(dateUtils, 'isFuture')
+      .mockImplementation((d: Date) => d > mondayAt9am);
+
+    const event = createEvent({
+      startDateTime: mondayAt7am,
+      endDateTime: mondayAt11am,
+    });
+
+    expect(isUpcoming(event)).toBeFalsy();
+  });
+
+  it('an event which started earlier today and finishes tomorrow is upcoming', () => {
+    const mondayAt7am = new Date('2007-01-01T07:00:00Z');
+    const mondayAt9am = new Date('2007-01-01T09:00:00Z');
+    const tuesdayAt76am = new Date('2007-01-02T07:00:00Z');
+
+    jest
+      .spyOn(dateUtils, 'isFuture')
+      .mockImplementation((d: Date) => d > mondayAt9am);
+
+    const event = createEvent({
+      startDateTime: mondayAt7am,
+      endDateTime: tuesdayAt76am,
+    });
+
+    expect(isUpcoming(event)).toBeTruthy();
+  });
+});
 
 describe('getUpcomingEvents', () => {
   it('picks out events that start after today', () => {
@@ -8,15 +75,7 @@ describe('getUpcomingEvents', () => {
       { id: '2200', startDateTime: new Date(2200, 1, 1, 0, 0, 0) },
     ].map(({ id, startDateTime }) => ({
       id,
-      times: [
-        {
-          range: {
-            startDateTime,
-            endDateTime: startDateTime,
-          },
-          isFullyBooked: { inVenue: false, online: false },
-        },
-      ],
+      ...createEvent({ startDateTime, endDateTime: startDateTime }),
     }));
 
     const upcomingEvents = getUpcomingEvents(events);
@@ -28,6 +87,7 @@ describe('getUpcomingEvents', () => {
     const january = new Date(2100, 1, 1, 0, 0, 0);
     const february = new Date(2100, 2, 1, 0, 0, 0);
     const march = new Date(2100, 3, 1, 0, 0, 0);
+    const april = new Date(2100, 4, 1, 0, 0, 0);
 
     const events = [
       { id: 'jan', startDateTime: january },
@@ -35,15 +95,7 @@ describe('getUpcomingEvents', () => {
       { id: 'feb', startDateTime: february },
     ].map(({ id, startDateTime }) => ({
       id,
-      times: [
-        {
-          range: {
-            startDateTime,
-            endDateTime: new Date(2100, 3, 25, 16, 30, 0),
-          },
-          isFullyBooked: { inVenue: false, online: false },
-        },
-      ],
+      ...createEvent({ startDateTime, endDateTime: april }),
     }));
 
     const upcomingEvents = getUpcomingEvents(events);
@@ -58,15 +110,7 @@ describe('getUpcomingEvents', () => {
     const events = [
       {
         id: 'my-long-running-event',
-        times: [
-          {
-            range: {
-              startDateTime: pastDate,
-              endDateTime: futureDate,
-            },
-            isFullyBooked: { inVenue: false, online: false },
-          },
-        ],
+        ...createEvent({ startDateTime: pastDate, endDateTime: futureDate }),
       },
     ];
 

--- a/content/webapp/utils/event-series.test.ts
+++ b/content/webapp/utils/event-series.test.ts
@@ -52,7 +52,7 @@ describe('isUpcoming', () => {
   it('an event which started earlier today and finishes tomorrow is upcoming', () => {
     const mondayAt7am = new Date('2007-01-01T07:00:00Z');
     const mondayAt9am = new Date('2007-01-01T09:00:00Z');
-    const tuesdayAt76am = new Date('2007-01-02T07:00:00Z');
+    const tuesdayAt7am = new Date('2007-01-02T07:00:00Z');
 
     jest
       .spyOn(dateUtils, 'isFuture')

--- a/content/webapp/utils/event-series.test.ts
+++ b/content/webapp/utils/event-series.test.ts
@@ -25,10 +25,14 @@ describe('getUpcomingEvents', () => {
   });
 
   it('sorts upcoming events by their start date', () => {
+    const january = new Date(2100, 1, 1, 0, 0, 0);
+    const february = new Date(2100, 2, 1, 0, 0, 0);
+    const march = new Date(2100, 3, 1, 0, 0, 0);
+
     const events = [
-      { id: '1', startDateTime: new Date(2100, 1, 1, 0, 0, 0) },
-      { id: '3', startDateTime: new Date(2100, 3, 1, 0, 0, 0) },
-      { id: '2', startDateTime: new Date(2100, 2, 1, 0, 0, 0) },
+      { id: 'jan', startDateTime: january },
+      { id: 'mar', startDateTime: march },
+      { id: 'feb', startDateTime: february },
     ].map(({ id, startDateTime }) => ({
       id,
       times: [
@@ -44,18 +48,21 @@ describe('getUpcomingEvents', () => {
 
     const upcomingEvents = getUpcomingEvents(events);
 
-    expect(upcomingEvents.map(ev => ev.id)).toEqual(['1', '2', '3']);
+    expect(upcomingEvents.map(ev => ev.id)).toEqual(['jan', 'feb', 'mar']);
   });
 
   it('includes an event as upcoming if a multi-day event hasn’t finished yet', () => {
+    const pastDate = new Date(2001, 3, 25, 16, 30, 0);
+    const futureDate = new Date(2100, 3, 25, 17, 30);
+
     const events = [
       {
-        id: 'YjyVoREAACAAhUvk',
+        id: 'my-long-running-event',
         times: [
           {
             range: {
-              startDateTime: new Date(2001, 3, 25, 16, 30, 0),
-              endDateTime: new Date(2100, 3, 25, 17, 30),
+              startDateTime: pastDate,
+              endDateTime: futureDate,
             },
             isFullyBooked: { inVenue: false, online: false },
           },
@@ -65,6 +72,6 @@ describe('getUpcomingEvents', () => {
 
     const upcomingEvents = getUpcomingEvents(events);
 
-    expect(upcomingEvents.map(ev => ev.id)).toEqual(['YjyVoREAACAAhUvk']);
+    expect(upcomingEvents.map(ev => ev.id)).toEqual(['my-long-running-event']);
   });
 });

--- a/content/webapp/utils/event-series.test.ts
+++ b/content/webapp/utils/event-series.test.ts
@@ -60,7 +60,7 @@ describe('isUpcoming', () => {
 
     const event = createEvent({
       startDateTime: mondayAt7am,
-      endDateTime: tuesdayAt76am,
+      endDateTime: tuesdayAt7am,
     });
 
     expect(isUpcoming(event)).toBeTruthy();

--- a/content/webapp/utils/event-series.ts
+++ b/content/webapp/utils/event-series.ts
@@ -6,7 +6,7 @@ import {
 } from '@weco/common/utils/dates';
 import { HasTimes } from 'types/events';
 
-function isUpcoming<T extends HasTimes>(event: T): boolean {
+export function isUpcoming<T extends HasTimes>(event: T): boolean {
   const startsInFuture = event.times.some(t => isFuture(t.range.startDateTime));
 
   // This is to account for events that span multiple days.

--- a/content/webapp/utils/event-series.ts
+++ b/content/webapp/utils/event-series.ts
@@ -42,7 +42,7 @@ function isUpcoming<T extends HasTimes>(event: T): boolean {
   const latestEndTime = maxDate(event.times.map(t => t.range.endDateTime));
 
   const isMultiDayEvent = !isSameDay(earliestStartTime, latestEndTime, 'UTC');
-  const isUnfinished = latestEndTime > new Date();
+  const isUnfinished = isFuture(latestEndTime);
   const endsOnAFutureDay = isMultiDayEvent && isUnfinished;
 
   return startsInFuture || endsOnAFutureDay;


### PR DESCRIPTION
I was reading the event series code as part of https://github.com/wellcomecollection/wellcomecollection.org/issues/9874, and I was struggling to follow how it works (even though I think I wrote the current implementation!).

There are some subtleties in how `isUpcoming` work which aren't adequately covered in the tests, because we test it at a distance. I've tried to:

* Add a couple of tests for that function to show how it works by example
* Use named variables for the example dates so it's clearer what's expected (e.g. `mondayAt7am` / `mondayAt9am`)

There shouldn't be any changes to the actual behaviour, just more tests.