### PR TITLE
Add a "concurrency gate" around front-end deployments

### DIFF
--- a/.buildkite/pipeline.deployment.yml
+++ b/.buildkite/pipeline.deployment.yml
@@ -78,7 +78,7 @@ steps:
     agents:
       queue: nano
 
-  - block: ":rocket: Trigger prod deployment"
+  - block: ":rocket: Allow prod deployment?"
     if: build.env("BUILDKITE_GITHUB_DEPLOYMENT_ENVIRONMENT") == "stage"
     prompt: "Have you checked the change and main landing pages on staging?"
 

--- a/.buildkite/pipeline.deployment.yml
+++ b/.buildkite/pipeline.deployment.yml
@@ -1,9 +1,33 @@
 steps:
   - label: "Deploy to $BUILDKITE_GITHUB_DEPLOYMENT_ENVIRONMENT"
     if: build.env("BUILDKITE_GITHUB_DEPLOYMENT_TASK") == "deploy:weco"
+
+    # These three lines create a "lock" around this pipeline.
+    #
+    # This means that once a deployment starts to an environment,
+    # no other builds will deploy to that environment until this
+    # deployment is complete and has run the end-to-end tests.
+    #
+    # == How it works ==
+    #
+    # This uses the "concurrency gate" pattern described in the Buildkite blog
+    # here: https://buildkite.com/blog/concurrency-gates
+    #
+    # Once this job starts running, this build has to either:
+    #
+    #   1)  fail, or
+    #   2)  complete all the other tasks in this concurrency group -- which is
+    #       just the "Complete!" task at the end of the pipeline
+    #
+    # before any other build is allowed to run tasks in this concurrency group.
+    # This means no other build can start a new deployment until this deployment
+    # is complete.
+    #
+    # Note: we have separate concurrency groups for stage/prod, because it's okay
+    # to deploy to them both simultaneously.
+    concurrency_group: "front-end-deployment-${BUILDKITE_GITHUB_DEPLOYMENT_ENVIRONMENT}-gate"
     concurrency: 1
-    concurrency_group: "experience-deploy"
-    command: ".buildkite/scripts/deploy_all_apps.sh"
+    key: start-deployment
 
     plugins:
       - wellcomecollection/aws-assume-role#v0.2.2:
@@ -19,14 +43,6 @@ steps:
     command: ".buildkite/scripts/trigger-e2e.sh"
     agents:
       queue: nano
-
-    # This means that each set of e2e tests will run with one deployment.
-    #
-    # This avoids any issues with the deployment changing as the e2e tests
-    # are running, which we believe might be the source of some instability
-    # and flakiness -- stuff changing as the tests are running.
-    concurrency: 1
-    concurrency_group: "experience-deploy"
 
     soft_fail:
       - exit_status: 1
@@ -45,6 +61,21 @@ steps:
             - AWS_ACCESS_KEY_ID
             - AWS_SECRET_ACCESS_KEY
             - AWS_SESSION_TOKEN
+
+  - wait
+
+  - label: "Complete ${BUILDKITE_GITHUB_DEPLOYMENT_ENVIRONMENT} deployment"
+    command: echo "Stage ${BUILDKITE_GITHUB_DEPLOYMENT_ENVIRONMENT} complete!"
+
+    # This is the second half of the concurrency gate that "locks" the deployment.
+    #
+    # When this step completes, it "unlocks" the deployment and allows other
+    # deployments to stage to begin.
+    concurrency_group: "front-end-deployment-${BUILDKITE_GITHUB_DEPLOYMENT_ENVIRONMENT}-gate"
+    concurrency: 1
+
+    agents:
+      queue: nano
 
   - block: ":rocket: Trigger prod deployment"
     if: build.env("BUILDKITE_GITHUB_DEPLOYMENT_ENVIRONMENT") == "stage"

--- a/.buildkite/pipeline.deployment.yml
+++ b/.buildkite/pipeline.deployment.yml
@@ -28,7 +28,6 @@ steps:
     # to deploy to them both simultaneously.
     concurrency_group: "front-end-deployment-${BUILDKITE_GITHUB_DEPLOYMENT_ENVIRONMENT}-gate"
     concurrency: 1
-    key: start-deployment
 
     plugins:
       - wellcomecollection/aws-assume-role#v0.2.2:
@@ -66,12 +65,15 @@ steps:
   - wait
 
   - label: "Complete ${BUILDKITE_GITHUB_DEPLOYMENT_ENVIRONMENT} deployment"
-    command: echo "Stage ${BUILDKITE_GITHUB_DEPLOYMENT_ENVIRONMENT} complete!"
+    command: echo "${BUILDKITE_GITHUB_DEPLOYMENT_ENVIRONMENT} complete!"
 
-    # This is the second half of the concurrency gate that "locks" the deployment.
+    # This is the second half of the concurrency gate described above.
+    #
+    # Buildkite won't let any other pipelines run in this concurrency group until
+    # this step has run (or the entire deployment has failed).
     #
     # When this step completes, it "unlocks" the deployment and allows other
-    # deployments to stage to begin.
+    # deployments to begin.
     concurrency_group: "front-end-deployment-${BUILDKITE_GITHUB_DEPLOYMENT_ENVIRONMENT}-gate"
     concurrency: 1
 

--- a/.buildkite/pipeline.deployment.yml
+++ b/.buildkite/pipeline.deployment.yml
@@ -3,16 +3,7 @@ steps:
     if: build.env("BUILDKITE_GITHUB_DEPLOYMENT_TASK") == "deploy:weco"
     concurrency: 1
     concurrency_group: "experience-deploy"
-    command: |
-      ENV_TAG="env.$BUILDKITE_GITHUB_DEPLOYMENT_ENVIRONMENT" .buildkite/scripts/update_ecr_image_tag.sh \
-        uk.ac.wellcome/content_webapp \
-        uk.ac.wellcome/catalogue_webapp \
-        uk.ac.wellcome/identity_webapp
-
-      CLUSTER="experience-frontend-$BUILDKITE_GITHUB_DEPLOYMENT_ENVIRONMENT" .buildkite/scripts/deploy_ecs_services.sh \
-        "content-17092020-$BUILDKITE_GITHUB_DEPLOYMENT_ENVIRONMENT" \
-        "catalogue-17092020-$BUILDKITE_GITHUB_DEPLOYMENT_ENVIRONMENT" \
-        "identity-18012021-$BUILDKITE_GITHUB_DEPLOYMENT_ENVIRONMENT"
+    command: ".buildkite/scripts/deploy_all_apps.sh"
 
     plugins:
       - wellcomecollection/aws-assume-role#v0.2.2:

--- a/.buildkite/pipeline.deployment.yml
+++ b/.buildkite/pipeline.deployment.yml
@@ -1,6 +1,7 @@
 steps:
   - label: "Deploy to $BUILDKITE_GITHUB_DEPLOYMENT_ENVIRONMENT"
     if: build.env("BUILDKITE_GITHUB_DEPLOYMENT_TASK") == "deploy:weco"
+    command: ".buildkite/scripts/deploy_all_apps.sh"
 
     # These three lines create a "lock" around this pipeline.
     #

--- a/.buildkite/scripts/deploy_all_apps.sh
+++ b/.buildkite/scripts/deploy_all_apps.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+
+ENV_TAG="env.$BUILDKITE_GITHUB_DEPLOYMENT_ENVIRONMENT" .buildkite/scripts/update_ecr_image_tag.sh \
+  uk.ac.wellcome/content_webapp \
+  uk.ac.wellcome/catalogue_webapp \
+  uk.ac.wellcome/identity_webapp
+
+CLUSTER="experience-frontend-$BUILDKITE_GITHUB_DEPLOYMENT_ENVIRONMENT" .buildkite/scripts/deploy_ecs_services.sh \
+  "content-17092020-$BUILDKITE_GITHUB_DEPLOYMENT_ENVIRONMENT" \
+  "catalogue-17092020-$BUILDKITE_GITHUB_DEPLOYMENT_ENVIRONMENT" \
+  "identity-18012021-$BUILDKITE_GITHUB_DEPLOYMENT_ENVIRONMENT"


### PR DESCRIPTION
It took me a while to wrap my head around this, but I think I get it now.

This implements the "concurrency gate" pattern described in Buildkite's support blog here: https://buildkite.com/blog/concurrency-gates

I'm not going to explain it in the PR description, because there's a comment in the Buildkite YAML and that's the thing we'll have to follow in six months time when we're scratching our heads at this code. If I need to clarify stuff, I'll update that comment rather than this description.

This is an offshoot of the work to get e2es running on pull requests: https://github.com/wellcomecollection/wellcomecollection.org/issues/9876