### PR TITLE
add correct source for paginator links

### DIFF
--- a/catalogue/webapp/pages/search/images.tsx
+++ b/catalogue/webapp/pages/search/images.tsx
@@ -91,7 +91,7 @@ const ImagesSearchPage: NextPageWithLayout<Props> = ({
             href={convertUrlToString(
               toLink(
                 { ...imagesRouteProps, page: (imagesRouteProps.page || 1) - 1 },
-                'unknown'
+                'search/paginator'
               ).as
             )}
           />
@@ -102,7 +102,7 @@ const ImagesSearchPage: NextPageWithLayout<Props> = ({
             href={convertUrlToString(
               toLink(
                 { ...imagesRouteProps, page: imagesRouteProps.page + 1 },
-                'unknown'
+                'search/paginator'
               ).as
             )}
           />

--- a/catalogue/webapp/pages/search/works.tsx
+++ b/catalogue/webapp/pages/search/works.tsx
@@ -92,7 +92,7 @@ export const CatalogueSearchPage: NextPageWithLayout<Props> = ({
             href={convertUrlToString(
               toLink(
                 { ...worksRouteProps, page: (worksRouteProps.page || 1) - 1 },
-                'unknown'
+                'search/paginator'
               ).as
             )}
           />
@@ -103,7 +103,7 @@ export const CatalogueSearchPage: NextPageWithLayout<Props> = ({
             href={convertUrlToString(
               toLink(
                 { ...worksRouteProps, page: worksRouteProps.page + 1 },
-                'unknown'
+                'search/paginator'
               ).as
             )}
           />


### PR DESCRIPTION
We were sending a source of 'unknown' for pagination links on search results pages. Now we send a source of 'search/paginator'
