### PR TITLE
Create a third environment for running our apps

### DIFF
--- a/cache/cloudfront_e2e.tf
+++ b/cache/cloudfront_e2e.tf
@@ -1,0 +1,49 @@
+module "e2e_cert" {
+  source = "github.com/wellcomecollection/terraform-aws-acm-certificate?ref=v1.0.0"
+
+  domain_name = "www-e2e.wellcomecollection.org"
+
+  subject_alternative_names = [
+    "content.www-e2e.wellcomecollection.org",
+    "works.www-e2e.wellcomecollection.org",
+    "identity.www-e2e.wellcomecollection.org"
+  ]
+
+  zone_id = "Z0902614YH73JBCZG1MA"
+
+  # The `aws.dns` provider should be a provider with permission to modify
+  # DNS records in the `zone_id` Hosted Zone.
+  providers = {
+    aws.dns = aws.dns
+  }
+}
+
+module "e2e_wc_org_cloudfront_distribution" {
+  source = "./modules/wc_org_cloudfront"
+
+  namespace = "e2e"
+  aliases = [
+    "www-e2e.wellcomecollection.org",
+    "content.www-e2e.wellcomecollection.org",
+    "works.www-e2e.wellcomecollection.org",
+    "identity.www-e2e.wellcomecollection.org"
+  ]
+
+  assets_origin = {
+    bucket_endpoint = data.terraform_remote_state.assets.outputs.bucket_domain_name
+    website_uri     = data.terraform_remote_state.assets.outputs.website_uri
+  }
+  load_balancer_dns = data.terraform_remote_state.experience.outputs.e2e["alb_dns_name"]
+
+  certificate_arn = module.e2e_cert.arn
+
+  lambda_arns = {
+    request  = aws_lambda_function.edge_lambda_request.qualified_arn
+    response = aws_lambda_function.edge_lambda_response.qualified_arn
+  }
+
+  cache_policies    = module.cloudfront_policies.cache_policies
+  request_policies  = module.cloudfront_policies.request_policies
+  response_policies = module.cloudfront_policies.response_policies
+  waf_ip_allowlist  = local.waf_ip_allowlist
+}

--- a/cache/cloudfront_e2e.tf
+++ b/cache/cloudfront_e2e.tf
@@ -9,7 +9,7 @@ module "e2e_cert" {
     "identity.www-e2e.wellcomecollection.org"
   ]
 
-  zone_id = "Z0902614YH73JBCZG1MA"
+  zone_id = data.aws_route53_zone.zone.id
 
   # The `aws.dns` provider should be a provider with permission to modify
   # DNS records in the `zone_id` Hosted Zone.

--- a/cache/dns.tf
+++ b/cache/dns.tf
@@ -1,6 +1,10 @@
 locals {
   cname_records = {
     "www-e2e.wellcomecollection.org" = module.e2e_wc_org_cloudfront_distribution.domain_name
+    "works.www-e2e.wellcomecollection.org" = module.e2e_wc_org_cloudfront_distribution.domain_name
+    "content.www-e2e.wellcomecollection.org" = module.e2e_wc_org_cloudfront_distribution.domain_name
+    "identity.www-e2e.wellcomecollection.org" = module.e2e_wc_org_cloudfront_distribution.domain_name
+
   }
 }
 

--- a/cache/dns.tf
+++ b/cache/dns.tf
@@ -1,0 +1,23 @@
+locals {
+  cname_records = {
+    "www-e2e.wellcomecollection.org" = module.e2e_wc_org_cloudfront_distribution.domain_name
+  }
+}
+
+data "aws_route53_zone" "zone" {
+  provider = aws.dns
+
+  name = "wellcomecollection.org."
+}
+
+resource "aws_route53_record" "cname" {
+  for_each = local.cname_records
+
+  zone_id = data.aws_route53_zone.zone.id
+  name    = each.key
+  type    = "CNAME"
+  records = [each.value]
+  ttl     = 60
+
+  provider = aws.dns
+}

--- a/cache/modules/wc_org_cloudfront/outputs.tf
+++ b/cache/modules/wc_org_cloudfront/outputs.tf
@@ -1,3 +1,7 @@
+output "domain_name" {
+  value = aws_cloudfront_distribution.wc_org.domain_name
+}
+
 output "distribution_id" {
   value = aws_cloudfront_distribution.wc_org.id
 }

--- a/cache/terraform.tf
+++ b/cache/terraform.tf
@@ -25,6 +25,25 @@ provider "aws" {
   }
 }
 
+provider "aws" {
+  region = "eu-west-1"
+  alias  = "dns"
+
+  assume_role {
+    role_arn = "arn:aws:iam::267269328833:role/wellcomecollection-assume_role_hosted_zone_update"
+  }
+
+  default_tags {
+    tags = {
+      TerraformConfigurationURL = "https://github.com/wellcomecollection/wellcomecollection.org/tree/main/cache"
+      Department                = "Digital Platform"
+      Division                  = "Culture and Society"
+      Use                       = "Front-end CloudFront distributions"
+    }
+  }
+}
+
+
 # Making the router state outputs available
 # e.g. ${data.terraform_remote_state.router.alb_dns_name}
 data "terraform_remote_state" "router" {

--- a/catalogue/terraform/locals.tf
+++ b/catalogue/terraform/locals.tf
@@ -21,7 +21,7 @@ locals {
     }
   )
 
-  e2e_app_image   = "${data.terraform_remote_state.experience_shared.outputs.catalogue_webapp_ecr_uri}:env.e2e"
+  e2e_app_image   = "${data.terraform_remote_state.experience_shared.outputs.buildkite_ecr_uri}:catalogue-env.e2e"
   stage_app_image = "${data.terraform_remote_state.experience_shared.outputs.catalogue_webapp_ecr_uri}:env.stage"
   prod_app_image  = "${data.terraform_remote_state.experience_shared.outputs.catalogue_webapp_ecr_uri}:env.prod"
 

--- a/catalogue/terraform/locals.tf
+++ b/catalogue/terraform/locals.tf
@@ -21,6 +21,7 @@ locals {
     }
   )
 
+  e2e_app_image   = "${data.terraform_remote_state.experience_shared.outputs.catalogue_webapp_ecr_uri}:env.e2e"
   stage_app_image = "${data.terraform_remote_state.experience_shared.outputs.catalogue_webapp_ecr_uri}:env.stage"
   prod_app_image  = "${data.terraform_remote_state.experience_shared.outputs.catalogue_webapp_ecr_uri}:env.prod"
 

--- a/catalogue/terraform/main.tf
+++ b/catalogue/terraform/main.tf
@@ -29,3 +29,22 @@ module "catalogue-stage" {
     aws = aws.stage
   }
 }
+
+
+// The service should be available at: "works.www-e2e.wellcomecollection.org/works"
+
+module "catalogue-e2e" {
+  source = "./stack"
+
+  container_image = local.e2e_app_image
+  nginx_image     = local.nginx_image
+  env_suffix      = "e2e"
+
+  environment = data.terraform_remote_state.experience_shared.outputs.e2e
+
+  subdomain = "works.www-e2e"
+
+  providers = {
+    aws = aws.stage
+  }
+}

--- a/catalogue/terraform/stack/main.tf
+++ b/catalogue/terraform/stack/main.tf
@@ -28,7 +28,7 @@ module "catalogue-service-17092020" {
   #
   # We're increasing vCPU to 1 in prod to see if this is addressed
   cpu    = var.env_suffix == "prod" ? 1024 : 512
-  memory = 2048
+  memory = var.env_suffix == "prod" ? 2048 : 1024
 
   env_vars = {
     PROD_SUBDOMAIN  = var.subdomain
@@ -47,6 +47,8 @@ module "catalogue-service-17092020" {
 
   vpc_id  = local.vpc_id
   subnets = local.private_subnets
+
+  allow_scaling_to_zero = var.env_suffix != "prod"
 }
 
 locals {

--- a/content/terraform/locals.tf
+++ b/content/terraform/locals.tf
@@ -21,6 +21,8 @@ locals {
     }
   )
 
+
+  e2e_app_image   = "${data.terraform_remote_state.experience_shared.outputs.content_webapp_ecr_uri}:env.e2e"
   stage_app_image = "${data.terraform_remote_state.experience_shared.outputs.content_webapp_ecr_uri}:env.stage"
   prod_app_image  = "${data.terraform_remote_state.experience_shared.outputs.content_webapp_ecr_uri}:env.prod"
 

--- a/content/terraform/locals.tf
+++ b/content/terraform/locals.tf
@@ -22,7 +22,7 @@ locals {
   )
 
 
-  e2e_app_image   = "${data.terraform_remote_state.experience_shared.outputs.content_webapp_ecr_uri}:env.e2e"
+  e2e_app_image   = "${data.terraform_remote_state.experience_shared.outputs.buildkite_ecr_uri}:content-env.e2e"
   stage_app_image = "${data.terraform_remote_state.experience_shared.outputs.content_webapp_ecr_uri}:env.stage"
   prod_app_image  = "${data.terraform_remote_state.experience_shared.outputs.content_webapp_ecr_uri}:env.prod"
 

--- a/content/terraform/main.tf
+++ b/content/terraform/main.tf
@@ -29,3 +29,21 @@ module "content-stage" {
     aws = aws.stage
   }
 }
+
+// The service should be available at: "content.www-e2e.wellcomecollection.org"
+
+module "content-e2e" {
+  source = "./stack"
+
+  environment = data.terraform_remote_state.experience_shared.outputs.e2e
+
+  container_image = local.e2e_app_image
+  nginx_image     = local.nginx_image
+  env_suffix      = "e2e"
+
+  subdomain = "content.www-e2e"
+
+  providers = {
+    aws = aws.stage
+  }
+}

--- a/content/terraform/stack/main.tf
+++ b/content/terraform/stack/main.tf
@@ -11,6 +11,9 @@ module "content-service-17092020" {
   container_image = var.container_image
   container_port  = 3000
 
+  cpu    = var.env_suffix == "prod" ? 1024 : 512
+  memory = var.env_suffix == "prod" ? 2048 : 1024
+
   security_group_ids = [
     var.environment["interservice_security_group_id"],
     var.environment["service_egress_security_group_id"]
@@ -32,6 +35,8 @@ module "content-service-17092020" {
 
   vpc_id  = local.vpc_id
   subnets = local.private_subnets
+
+  allow_scaling_to_zero = var.env_suffix != "prod"
 }
 
 locals {

--- a/identity/terraform/locals.tf
+++ b/identity/terraform/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  e2e_app_image   = "${data.terraform_remote_state.experience_shared.outputs.identity_webapp_ecr_uri}:env.e2e"
+  e2e_app_image   = "${data.terraform_remote_state.experience_shared.outputs.buildkite_ecr_uri}:identity-env.e2e"
   stage_app_image = "${data.terraform_remote_state.experience_shared.outputs.identity_webapp_ecr_uri}:env.stage"
   prod_app_image  = "${data.terraform_remote_state.experience_shared.outputs.identity_webapp_ecr_uri}:env.prod"
 

--- a/identity/terraform/locals.tf
+++ b/identity/terraform/locals.tf
@@ -1,4 +1,5 @@
 locals {
+  e2e_app_image   = "${data.terraform_remote_state.experience_shared.outputs.identity_webapp_ecr_uri}:env.e2e"
   stage_app_image = "${data.terraform_remote_state.experience_shared.outputs.identity_webapp_ecr_uri}:env.stage"
   prod_app_image  = "${data.terraform_remote_state.experience_shared.outputs.identity_webapp_ecr_uri}:env.prod"
 

--- a/identity/terraform/main.tf
+++ b/identity/terraform/main.tf
@@ -41,3 +41,28 @@ module "identity-stage" {
     aws = aws.stage
   }
 }
+
+
+// The service should be available at: "https://identity.www-e2e.wellcomecollection.org"
+
+module "identity-e2e" {
+  source = "./stack"
+
+  container_image = local.e2e_app_image
+  nginx_image     = local.nginx_image
+  env_suffix      = "e2e"
+
+  environment = data.terraform_remote_state.experience_shared.outputs.e2e
+
+  env_vars = merge(
+    local.service_env["stage"]["env_vars"],
+    { SITE_BASE_URL = "https://www-e2e.wellcomecollection.org" }
+  )
+  secret_env_vars = local.service_env["stage"]["secret_env_vars"]
+
+  subdomain = "identity.www-e2e"
+
+  providers = {
+    aws = aws.stage
+  }
+}

--- a/identity/terraform/stack/main.tf
+++ b/identity/terraform/stack/main.tf
@@ -11,8 +11,8 @@ module "identity-service-18012021" {
   container_image = var.container_image
   container_port  = 3000
 
-  cpu    = 512
-  memory = 1024
+  cpu    = var.env_suffix == "prod" ? 512 : 256
+  memory = var.env_suffix == "prod" ? 1024 : 512
 
   security_group_ids = [
     var.environment["interservice_security_group_id"],
@@ -38,6 +38,8 @@ module "identity-service-18012021" {
 
   vpc_id  = local.vpc_id
   subnets = local.private_subnets
+
+  allow_scaling_to_zero = var.env_suffix != "prod"
 }
 
 locals {

--- a/infrastructure/experience/main.tf
+++ b/infrastructure/experience/main.tf
@@ -17,3 +17,13 @@ module "stage" {
   subnets  = local.public_subnets
   cert_arn = module.wellcomecollection_cert.arn
 }
+
+module "e2e" {
+  source = "./stack"
+
+  namespace = "e2e"
+
+  vpc_id   = local.vpc_id
+  subnets  = local.public_subnets
+  cert_arn = module.wellcomecollection_cert.arn
+}

--- a/infrastructure/experience/outputs.tf
+++ b/infrastructure/experience/outputs.tf
@@ -17,3 +17,7 @@ output "prod" {
 output "stage" {
   value = module.stage
 }
+
+output "e2e" {
+  value = module.e2e
+}

--- a/infrastructure/experience/outputs.tf
+++ b/infrastructure/experience/outputs.tf
@@ -1,3 +1,7 @@
+output "buildkite_ecr_uri" {
+  value = aws_ecr_repository.buildkite.repository_url
+}
+
 output "content_webapp_ecr_uri" {
   value = aws_ecr_repository.content_webapp.repository_url
 }

--- a/infrastructure/modules/service/main.tf
+++ b/infrastructure/modules/service/main.tf
@@ -98,4 +98,6 @@ module "service" {
   container_port = module.nginx_container.container_port
 
   propagate_tags = "SERVICE"
+
+  deployment_minimum_healthy_percent = var.allow_scaling_to_zero ? 0 : 100
 }

--- a/infrastructure/modules/service/variables.tf
+++ b/infrastructure/modules/service/variables.tf
@@ -62,3 +62,9 @@ variable "healthcheck_path" {}
 variable "use_fargate_spot" {
   default = false
 }
+
+variable "allow_scaling_to_zero" {
+  description = "Whether to allow this service to scale to zero (causing an outage) during deployments"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Follows #9880; part of #9876

## Intention

This creates a new version of the site which is available at https://www-e2e.wellcomecollection.org/ – an environment designed for use with our end-to-end tests. It has the same setup as stage/prod, including:

* ECS app configuration
* EC2 load balancers
* CloudFront and edge Lambdas

It's an environment that we can deploy stuff into quickly for testing, and have it mirror our real setup. The intention is eventually that we'll be able to deploy directly from PRs into this environment, and run end-to-end tests against it.

Nothing is deploying into this environment yet, so we can merge this before I go on leave, and nothing should break.

## Divergence from existing environments

* The stage/e2e environments get half the resources of the apps in our prod environment, and I'd be inclined to cut that event lower at some point. This is to avoid us increasing our bill by a third by adding this environment; it should be roughly cost-neutral.
* The e2e environment creates a DNS record that points `www-e2e.wc.org ~> CloudFront`. As far as I can tell, this has been configured by hand in the past, but really it should live in Terraform.
* The e2e (and now stage) environments allow scaling down to zero as soon as a deployment occurs, rather than doing the nice ECS blue-green behaviour where the old tasks aren't stopped until the new tasks are healthy. This is to make deployments into these environments a bit quicker, because they don't need 100% uptime.
* The e2e environment gets Docker images from the `uk.ac.wellcome/buildkite` repository, which is used to pass images between Buildkite steps – whereas the real apps get images from `uk.ac.wellcome/{content,catalogue,identity}_webapp`. The Buildkite repo isn't suitable for proper apps, because we purge old images pretty regularly, but for this environment of mostly short-lived apps it's not an issue.