### PR TITLE
Build dash when we build the other Docker images in Buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -58,6 +58,18 @@
           - identity
         image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
 
+- label: ':docker: build dash'
+  branches: 'main'
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: 'arn:aws:iam::130871440101:role/experience-ci'
+    - ecr#v2.1.1:
+        login: true
+    - docker-compose#v3.5.0:
+        build:
+          - dash
+        image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
+
 - label: 'diff prismic model'
   branches: 'main'
   plugins:


### PR DESCRIPTION
Raphaëlle noticed that the 'deploy dash' is the longest deploy task in a build on main; almost 30s longer than any other deploy step.  Most of the time is spent in the "Building Docker Compose Service: dash" step, which includes the following line:

    No pre-built image found from a previous 'build' step for this
    service and config file. Building image...

I think the reason the other apps can deploy faster is because they already have prebuilt images; dash has no such luck.  Adding a step where we build dash at the same time as we build the other images should speed up this step.

For https://github.com/wellcomecollection/wellcomecollection.org/issues/9890