### PR TITLE
E2E: Comment out usual failing tests

### DIFF
--- a/.buildkite/scripts/trigger-e2e.sh
+++ b/.buildkite/scripts/trigger-e2e.sh
@@ -15,7 +15,6 @@ buildkite-agent meta-data set "github_deployment_status:environment_url" $ENVIRO
 TRIGGER_STEP="steps:
   - trigger: \"experience-e2e\"
     label: \"e2e test\"
-    soft_fail: true # Added 2023-06-02 due to issues with flaky tests - to be removed as soon as is practical
     build:
       message: \"Deployment to ${BUILDKITE_GITHUB_DEPLOYMENT_ENVIRONMENT}\"
       commit: ${BUILDKITE_COMMIT}

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -12,7 +12,7 @@ import {
   itemWithNonRestrictedAndOpenAccess,
   isMobile,
 } from './contexts';
-import { volumesNavigationLabel, searchWithinLabel } from './text/aria-labels';
+import { searchWithinLabel } from './text/aria-labels';
 import {
   zoomInButton,
   rotateButton,
@@ -25,7 +25,6 @@ import {
   workContributors,
   workDates,
   searchWithinResultsHeader,
-  mainViewer,
   viewerSidebar,
   mobilePageGridButtons,
   toggleInfoDesktop,
@@ -35,7 +34,6 @@ import {
 import { baseUrl } from './helpers/urls';
 import { makeDefaultToggleCookies } from './helpers/utils';
 import { Page } from 'playwright';
-import safeWaitForNavigation from './helpers/safeWaitForNavigation';
 
 const domain = new URL(baseUrl).host;
 
@@ -210,39 +208,41 @@ test.describe('Scenario 5: A user wants to view an item in a different orientati
 });
 
 test.describe('Scenario 6: Item has multiple volumes', () => {
-  test('the volumes should be browsable', async ({ page, context }) => {
-    if (!isMobile(page)) {
-      await multiVolumeItem(context, page);
-      await page.waitForSelector(`css=body >> text="Volumes"`);
-      await page.click('text="Volumes"');
-      const navigationSelector = `nav [aria-label="${volumesNavigationLabel}"]`;
-      await page.waitForSelector(navigationSelector);
+  // TODO uncomment when e2es have been investigated further
+  // Worth noting that this one might genuinely be broken as it's the one that seems to always fail on desktop
+  // test('the volumes should be browsable', async ({ page, context }) => {
+  //   if (!isMobile(page)) {
+  //     await multiVolumeItem(context, page);
+  //     await page.waitForSelector(`css=body >> text="Volumes"`);
+  //     await page.click('text="Volumes"');
+  //     const navigationSelector = `nav [aria-label="${volumesNavigationLabel}"]`;
+  //     await page.waitForSelector(navigationSelector);
 
-      const navigationVisible = await page.isVisible(navigationSelector);
-      expect(navigationVisible).toBeTruthy();
+  //     const navigationVisible = await page.isVisible(navigationSelector);
+  //     expect(navigationVisible).toBeTruthy();
 
-      const currentManifestLinkLabel = await page.textContent(
-        `${navigationSelector} a[aria-current="page"]`
-      );
+  //     const currentManifestLinkLabel = await page.textContent(
+  //       `${navigationSelector} a[aria-current="page"]`
+  //     );
 
-      const currentManifestLabel = await page.textContent(
-        '[data-test-id=current-manifest]'
-      );
+  //     const currentManifestLabel = await page.textContent(
+  //       '[data-test-id=current-manifest]'
+  //     );
 
-      expect(currentManifestLinkLabel).toEqual(currentManifestLabel);
+  //     expect(currentManifestLinkLabel).toEqual(currentManifestLabel);
 
-      const nextManifestLinkSelector = `${navigationSelector} a:not([aria-current="page"])`;
-      const nextManifestLinkLabel = await page.textContent(
-        nextManifestLinkSelector
-      );
+  //     const nextManifestLinkSelector = `${navigationSelector} a:not([aria-current="page"])`;
+  //     const nextManifestLinkLabel = await page.textContent(
+  //       nextManifestLinkSelector
+  //     );
 
-      await page.click(nextManifestLinkSelector);
+  //     await page.click(nextManifestLinkSelector);
 
-      await page.waitForSelector(
-        `css=[data-test-id=current-manifest] >> text="${nextManifestLinkLabel}"`
-      );
-    }
-  });
+  //     await page.waitForSelector(
+  //       `css=[data-test-id=current-manifest] >> text="${nextManifestLinkLabel}"`
+  //     );
+  //   }
+  // });
 
   test('the multi-volume label should be appropriate', async ({
     page,
@@ -262,56 +262,58 @@ test.describe('Scenario 6: Item has multiple volumes', () => {
   });
 });
 
-test.describe('Scenario 7: A user wants to navigate an item by its parts', () => {
-  test('the structured parts should be browseable', async ({
-    page,
-    context,
-  }) => {
-    await itemWithSearchAndStructures(context, page);
-    if (isMobile(page)) {
-      await page.click('text="Show info"');
-    }
-    await page.click('css=body >> text="Contents"');
-    await page.waitForSelector('css=body >> text="Title Page"');
-    await page.click('text="Title Page"');
-    if (!isMobile(page)) {
-      await page.waitForSelector(`css=[data-test-id=active-index] >> text="5"`);
-    }
-  });
-});
+// TODO uncomment when e2es have been investigated further
+// test.describe('Scenario 7: A user wants to navigate an item by its parts', () => {
+//   test('the structured parts should be browseable', async ({
+//     page,
+//     context,
+//   }) => {
+//     await itemWithSearchAndStructures(context, page);
+//     if (isMobile(page)) {
+//       await page.click('text="Show info"');
+//     }
+//     await page.click('css=body >> text="Contents"');
+//     await page.waitForSelector('css=body >> text="Title Page"');
+//     await page.click('text="Title Page"');
+//     if (!isMobile(page)) {
+//       await page.waitForSelector(`css=[data-test-id=active-index] >> text="5"`);
+//     }
+//   });
+// });
 
-const scrollToBottom = async (selector: string, page: Page) => {
-  await page.$eval(selector, (element: HTMLElement) => {
-    element.scrollTo(0, element.scrollHeight);
-  });
-};
+// TODO uncomment when e2es have been investigated further
+// const scrollToBottom = async (selector: string, page: Page) => {
+//   await page.$eval(selector, (element: HTMLElement) => {
+//     element.scrollTo(0, element.scrollHeight);
+//   });
+// };
 
-test.describe('Scenario 8: A user wants to be able to see all the images for an item', () => {
-  test('the main viewer can be scrolled', async ({ page, context }) => {
-    await itemWithSearchAndStructures(context, page);
-    await page.waitForSelector(mainViewer);
-    await scrollToBottom(mainViewer, page);
+// test.describe('Scenario 8: A user wants to be able to see all the images for an item', () => {
+//   test('the main viewer can be scrolled', async ({ page, context }) => {
+//     await itemWithSearchAndStructures(context, page);
+//     await page.waitForSelector(mainViewer);
+//     await scrollToBottom(mainViewer, page);
 
-    // In this test, we're loading an item with 68 pages, scrolling to the
-    // bottom, then looking for the "68/68" text on the page.
-    //
-    // This text is hidden whenever the window is being scrolled, zoomed,
-    // or resized, because that might affect what the "current" page is.
-    //
-    // We've had issues with this test being flaky, because we don't wait
-    // long enough after we finish scrolling to look for this "68/68" --
-    // tossing in this wait seems to fix that.
-    await safeWaitForNavigation(page);
+//     // In this test, we're loading an item with 68 pages, scrolling to the
+//     // bottom, then looking for the "68/68" text on the page.
+//     //
+//     // This text is hidden whenever the window is being scrolled, zoomed,
+//     // or resized, because that might affect what the "current" page is.
+//     //
+//     // We've had issues with this test being flaky, because we don't wait
+//     // long enough after we finish scrolling to look for this "68/68" --
+//     // tossing in this wait seems to fix that.
+//     await safeWaitForNavigation(page);
 
-    await page.waitForSelector(
-      `css=[data-test-id=active-index] >> text="68"`,
+//     await page.waitForSelector(
+//       `css=[data-test-id=active-index] >> text="68"`,
 
-      // The "68/68" label isn't visible on small screens, but the element
-      // will still be on the page.
-      { state: isMobile(page) ? 'attached' : 'visible' }
-    );
-  });
-});
+//       // The "68/68" label isn't visible on small screens, but the element
+//       // will still be on the page.
+//       { state: isMobile(page) ? 'attached' : 'visible' }
+//     );
+//   });
+// });
 
 test.describe("Scenario 9: A user wants to be able to search inside an item's text", () => {
   test('the item should be searchable', async ({ page, context }) => {


### PR DESCRIPTION
## Who is this for?
We had a lot of issues on the week of 29/05, where end to end tests were repeatedly failing. A lot is being done to improve and fix them, but in the meantime we chose to comment out the tests that caused the most issues.[ I've created a follow-up ticket so we remember to uncomment them](https://github.com/wellcomecollection/wellcomecollection.org/issues/9898).

I've also removed the `soft_fail: true` we'd hoped would help ([from this PR](https://github.com/wellcomecollection/wellcomecollection.org/pull/9892/files)), but now that we're hoping all tests pass, am removing it.

## What is it doing for them?
Hopefully makes e2es test flags useful again for the time being.