### PR TITLE
Add accession number to identifiers section if present

### DIFF
--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -122,6 +122,16 @@ const WorkDetails: FunctionComponent<Props> = ({
   const issnIdentifiers = work.identifiers.filter(id => {
     return id.identifierType.id === 'issn';
   });
+
+  const accessionNumberIdentifiers = work.identifiers.filter(id => {
+    return id.identifierType.id === 'wellcome-accession-number';
+  });
+
+  const hasIdentifiers =
+    isbnIdentifiers.length > 0 ||
+    issnIdentifiers.length > 0 ||
+    accessionNumberIdentifiers.length > 0;
+
   const seriesPartOfs = work.partOf.filter(p => !p.id);
 
   const physicalItems = getItemsWithPhysicalLocation(work.items ?? []);
@@ -735,7 +745,7 @@ const WorkDetails: FunctionComponent<Props> = ({
         </div>
       </WorkDetailsSection>
 
-      {isbnIdentifiers.length > 0 && (
+      {hasIdentifiers && (
         <WorkDetailsSection headingText="Identifiers">
           {isbnIdentifiers.length > 0 && (
             <WorkDetailsList
@@ -747,6 +757,12 @@ const WorkDetails: FunctionComponent<Props> = ({
             <WorkDetailsList
               title="ISSN"
               list={issnIdentifiers.map(id => id.value)}
+            />
+          )}
+          {accessionNumberIdentifiers.length > 0 && (
+            <WorkDetailsList
+              title="Accession number"
+              list={accessionNumberIdentifiers.map(id => id.value)}
             />
           )}
         </WorkDetailsSection>


### PR DESCRIPTION
[Issue](https://github.com/wellcomecollection/wellcomecollection.org/issues/9899)

## Who is this for?
Archivists? 

## What is it doing for them?
Making the accession number visible on the work details page, so that the work's provenance details can be more easily provided to anyone who requests

![Screenshot 2023-06-05 at 16 52 28](https://github.com/wellcomecollection/wellcomecollection.org/assets/135110571/7f97a652-4d55-4970-aa8b-a9b654d6106a)
