### PR TITLE
Account for back-to-back Prismic text block spacing

### DIFF
--- a/common/views/components/styled/SpacingComponent.tsx
+++ b/common/views/components/styled/SpacingComponent.tsx
@@ -28,7 +28,9 @@ const SpacingComponent = styled.div.attrs({
     for this, we check if the two adjacent SpacingComponents contain
     .spaced-text, and if so, override the SpacingComponent spacing in favour of
     the .spaced-text spacing. Firefox currently (June 2023) doesn't support
-    :has(). Hopefully this will change soon.  */
+    :has(). Hopefully this will change soon
+    (https://connect.mozilla.org/t5/ideas/when-is-has-css-selector-going-to-be-fully-implemented-in/idi-p/23794/page/2#comments)
+    */
     &:has(.spaced-text) + &:has(.spaced-text) {
       margin-top: 0;
 

--- a/common/views/components/styled/SpacingComponent.tsx
+++ b/common/views/components/styled/SpacingComponent.tsx
@@ -29,11 +29,11 @@ const SpacingComponent = styled.div.attrs({
     .spaced-text, and if so, override the SpacingComponent spacing in favour of
     the .spaced-text spacing. Firefox currently (June 2023) doesn't support
     :has(). Hopefully this will change soon.  */
-    &:has(.spaced-text) + .spacing-component:has(.spaced-text) {
+    &:has(.spaced-text) + &:has(.spaced-text) {
       margin-top: 0;
 
       .spaced-text > *:first-child {
-        margin-top: 1.55em;
+        margin-top: ${props => props.theme.spacedTextTopMargin};
       }
     }
   }

--- a/common/views/components/styled/SpacingComponent.tsx
+++ b/common/views/components/styled/SpacingComponent.tsx
@@ -17,6 +17,26 @@ const SpacingComponent = styled.div.attrs({
         margin-top: ${props.theme.spaceAtBreakpoints.large.l}px;
       `)}
   }
+
+  @supports selector(:has(a)) {
+    /* The SpacingComponent spaces adjacent components vertically by an amount
+    of pixels. Elements within a single block of .spaced-text are spaced
+    vertically by an amount of ems. In Prismic, it is possible to create a new
+    component for each paragraph of text (instead of keeping it all in the same
+    block). This means that text elements could have slightly different amounts
+    of vertical spacing depending on how the content has been added. To account
+    for this, we check if the two adjacent SpacingComponents contain
+    .spaced-text, and if so, override the SpacingComponent spacing in favour of
+    the .spaced-text spacing. Firefox currently (June 2023) doesn't support
+    :has(). Hopefully this will change soon.  */
+    &:has(.spaced-text) + .spacing-component:has(.spaced-text) {
+      margin-top: 0;
+
+      .spaced-text > *:first-child {
+        margin-top: 1.55em;
+      }
+    }
+  }
 `;
 
 export default SpacingComponent;

--- a/common/views/themes/config.ts
+++ b/common/views/themes/config.ts
@@ -306,6 +306,7 @@ export const themeValues = {
     yellowYellowBlack,
     whiteWhiteCharcoal,
   },
+  spacedTextTopMargin: '1.55em',
 };
 
 export type Breakpoint = keyof typeof sizes;

--- a/common/views/themes/typography.ts
+++ b/common/views/themes/typography.ts
@@ -210,7 +210,7 @@ export const typography = css<GlobalStyleProps>`
     }
 
     * + * {
-      margin-top: 1.55em;
+      margin-top: ${themeValues.spacedTextTopMargin};
     }
 
     li + li {


### PR DESCRIPTION
## Who is this for?
People who want consistent spacing regardless of how the page has been built in Prismic

## What is it doing for them?
Checking if back-to-back text slices have been added and if so, using the spacing rules we created for text, rather than the spacing rules we created between components