### PR TITLE
Spacing for Body slices only

### DIFF
--- a/common/views/components/styled/SpacingComponent.tsx
+++ b/common/views/components/styled/SpacingComponent.tsx
@@ -31,10 +31,12 @@ const SpacingComponent = styled.div.attrs({
     :has(). Hopefully this will change soon
     (https://connect.mozilla.org/t5/ideas/when-is-has-css-selector-going-to-be-fully-implemented-in/idi-p/23794/page/2#comments)
     */
-    &:has(.spaced-text) + &:has(.spaced-text) {
+
+    /* .body-text was added to ensure this only happened in Body slices */
+    &:has(.spaced-text.body-text) + &:has(.spaced-text.body-text) {
       margin-top: 0;
 
-      .spaced-text > *:first-child {
+      .spaced-text.body-text > *:first-child {
         margin-top: ${props => props.theme.spacedTextTopMargin};
       }
     }


### PR DESCRIPTION
## Who is this for?
Website design/users

## What is it doing for them?
To account for Content's new way of creating paragraph blocks (one Text per paragraph), [a little `has()` magic was done](https://github.com/wellcomecollection/wellcomecollection.org/commit/d68500fce9825d05f8ee1a00f5ed6264c6dd5661), which fixed it. It didn't account for other pages that also used `spacing-component` with `spaced-text`, such as works, which meant that the margins were a bit out of whack. 

<img width="494" alt="Screenshot 2023-06-08 at 09 44 51" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/16599878-bd40-4f89-be5a-5a29e5c93cf8">



I believe this fix does what we want, as we only want pages created with Prismic to have that styling, where `.body-text` is used in conjunction with `.spaced-text`. Need to ensure the logic is sound with the review, though. Maybe we actually want to add a class to specifically target this instead?

[See Slack convo](https://wellcome.slack.com/archives/C8X9YKM5X/p1686157725553589)