### PR TITLE
Remove nowrap

### DIFF
--- a/common/views/components/DownloadLink/DownloadLink.tsx
+++ b/common/views/components/DownloadLink/DownloadLink.tsx
@@ -27,7 +27,6 @@ const DownloadLinkStyle = styled.a.attrs({
 
 const DownloadLinkUnStyled = styled.a`
   position: relative;
-  white-space: nowrap;
 `;
 
 const Format = styled(Space).attrs({


### PR DESCRIPTION
## Who is this for?
Mobile users

## What is it doing for them?
Ensures the page isn't horizontally scrollable when the `DownloadLink` is a long one (see ticket).
That style is only applied when there is no `linkText` passed to the component, which only happens in HTMLSerializer so I think it should look ok everywhere.

Closes #9789 