### PR TITLE
Remove unused embeds from Prismic slice offer

### DIFF
--- a/content/webapp/components/SoundCloudEmbed/SoundCloudEmbed.tsx
+++ b/content/webapp/components/SoundCloudEmbed/SoundCloudEmbed.tsx
@@ -5,6 +5,10 @@ import styled from 'styled-components';
 
 const Figure = styled.figure`
   margin: 0;
+
+  iframe {
+    border: 0;
+  }
 `;
 
 export type Props = {
@@ -17,7 +21,6 @@ const SoundCloudEmbed: FunctionComponent<Props> = ({ embedUrl, caption }) => (
     <iframe
       width="100%"
       height="140"
-      frameBorder="no"
       title="soundcloud player"
       src={embedUrl}
     />

--- a/content/webapp/services/prismic/fetch/articles.ts
+++ b/content/webapp/services/prismic/fetch/articles.ts
@@ -136,12 +136,6 @@ export const graphQuery = `{
           caption
         }
       }
-      ...on youtubeVideoEmbed {
-        non-repeat {
-          embed
-          caption
-        }
-      }
       ...on discussion {
         non-repeat {
           title

--- a/content/webapp/services/prismic/fetch/articles.ts
+++ b/content/webapp/services/prismic/fetch/articles.ts
@@ -7,7 +7,7 @@ import {
 } from '.';
 import { ArticlePrismicDocument } from '../types/articles';
 import { ContentType } from '@weco/common/services/prismic/content-types';
-import { ArticleBasic } from '../../../types/articles';
+import { ArticleBasic } from '@weco/content/types/articles';
 import {
   articleFormatsFetchLinks,
   commonPrismicFieldsFetchLinks,
@@ -134,26 +134,6 @@ export const graphQuery = `{
         non-repeat {
           embed
           caption
-        }
-      }
-      ...on soundcloudEmbed {
-        non-repeat {
-          iframeSrc
-        }
-      }
-      ...on vimeoVideoEmbed {
-        non-repeat {
-          embed
-        }
-      }
-      ...on instagramEmbed {
-        non-repeat {
-          embed
-        }
-      }
-      ...on twitterEmbed {
-        non-repeat {
-          embed
         }
       }
       ...on youtubeVideoEmbed {

--- a/prismic-model/sliceAnalysis.ts
+++ b/prismic-model/sliceAnalysis.ts
@@ -78,8 +78,10 @@ async function main() {
     }
   }
 
-  console.info('=== Slice count ==');
-  Array.from(sliceCounter.entries())
+  const slicesArray = Array.from(sliceCounter.entries());
+
+  console.info(`=== Slice count (${slicesArray.length}) ==`);
+  slicesArray
     .sort((a, b) => a[1] - b[1])
     .forEach(entry =>
       console.info(`${String(entry[1]).padStart(6, ' ')}\t${entry[0]}`)

--- a/prismic-model/src/parts/article-body.ts
+++ b/prismic-model/src/parts/article-body.ts
@@ -41,20 +41,6 @@ export default {
           display: 'Standalone',
         },
       ],
-      youtubeVideoEmbed: [
-        {
-          name: 'featured',
-          display: 'Featured',
-        },
-        {
-          name: 'supporting',
-          display: 'Supporting',
-        },
-        {
-          name: 'standalone',
-          display: 'Standalone',
-        },
-      ],
       editorialImageGallery: [
         {
           name: 'standalone',
@@ -134,20 +120,6 @@ export default {
           embed: {
             type: 'Embed',
             fieldset: 'Embed',
-          },
-          caption: singleLineText('Caption', {
-            placeholder: 'Caption',
-            overrideTextOptions: ['hyperlink', 'em'],
-          }),
-        },
-      },
-      youtubeVideoEmbed: {
-        type: 'Slice',
-        fieldset: '[Deprecated] YouTube video (please use embed)',
-        'non-repeat': {
-          embed: {
-            type: 'Embed',
-            fieldset: 'YouTube embed',
           },
           caption: singleLineText('Caption', {
             placeholder: 'Caption',

--- a/prismic-model/src/parts/article-body.ts
+++ b/prismic-model/src/parts/article-body.ts
@@ -41,20 +41,6 @@ export default {
           display: 'Standalone',
         },
       ],
-      vimeoVideoEmbed: [
-        {
-          name: 'featured',
-          display: 'Featured',
-        },
-        {
-          name: 'supporting',
-          display: 'Supporting',
-        },
-        {
-          name: 'standalone',
-          display: 'Standalone',
-        },
-      ],
       youtubeVideoEmbed: [
         {
           name: 'featured',
@@ -153,48 +139,6 @@ export default {
             placeholder: 'Caption',
             overrideTextOptions: ['hyperlink', 'em'],
           }),
-        },
-      },
-      soundcloudEmbed: {
-        type: 'Slice',
-        fieldset: 'SoundCloud embed',
-        'non-repeat': {
-          iframeSrc: {
-            type: 'Text',
-            config: {
-              label: 'iframe src',
-            },
-          },
-        },
-      },
-      vimeoVideoEmbed: {
-        type: 'Slice',
-        fieldset: 'Vimeo video',
-        'non-repeat': {
-          embed: {
-            type: 'Embed',
-            fieldset: 'Vimeo embed',
-          },
-        },
-      },
-      instagramEmbed: {
-        type: 'Slice',
-        fieldset: 'Instagram embed',
-        'non-repeat': {
-          embed: {
-            type: 'Embed',
-            fieldset: 'Instagram embed',
-          },
-        },
-      },
-      twitterEmbed: {
-        type: 'Slice',
-        fieldset: 'Twitter embed',
-        'non-repeat': {
-          embed: {
-            type: 'Embed',
-            fieldset: 'Twitter embed',
-          },
         },
       },
       youtubeVideoEmbed: {

--- a/prismic-model/src/parts/body.ts
+++ b/prismic-model/src/parts/body.ts
@@ -87,7 +87,7 @@ export default {
       table: table(),
       embed: slice('Embed', {
         nonRepeat: {
-          embed: embed('Embed (Youtube, Vimeo etc)'),
+          embed: embed('Embed (Youtube, SoundCloud, etc)'),
           caption: singleLineText('Caption'),
         },
       }),


### PR DESCRIPTION
## Who is this for?
Maintenance

## What is it doing for them?
We have a few legacy slices that we can get rid of ([see analysis](https://docs.google.com/presentation/d/1RytMltnIDQ44BXEa8JR_2-hXslaLEogo49jopO3qLuY/edit#slide=id.g2501fc7a4df_0_0)). This brings it down from a total 27 to 22!

This PR deals with `vimeoVideoEmbed`, `instagramEmbed`, `twitterEmbed` and `soundcloudEmbed`.
[Danny has agreed to these four being removed](https://wellcome.slack.com/archives/C3N7J05TK/p1686302036964129) as there are no instance of them anywhere on the website.

They have all replaced by `Embed` a while ago (even though Vimeo doesn't seem styled nicely, it works). Currently, only YouTube and SoundCloud items are being rendered by `Embed`.

**Added later on** 
I've also removed `youtubeVideoEmbed` as it was labelled as Deprecated for a very long time. I've made sure all 21 instances now had an equivalent `Embed`. I can furnish the list if required.

Relates to #9917 
Closes #9924 

## Next step
I'd like confirmation on this:
I think I'll need to run `yarn deployType --id {vimeoVideoEmbed | instagramEmbed | twitterEmbed | soundcloudEmbed | youtubeVideoEmbed}` locally, once this gets merged to main, and that's it?