### PR TITLE
set dropdown children to tabIndex -1 on mount

### DIFF
--- a/common/views/components/DropdownButton/DropdownButton.tsx
+++ b/common/views/components/DropdownButton/DropdownButton.tsx
@@ -142,15 +142,9 @@ const DropdownButton: FunctionComponent<PropsWithChildren<Props>> = ({
   });
 
   useEffect(() => {
-    if (dropdownRef && dropdownRef.current) {
-      const focusableElements = getFocusableElements(
-        dropdownRef.current
-      ) as HTMLElement[];
-      setFocusables(focusableElements);
-      focusableElements.forEach(focusable =>
-        focusable.setAttribute('tabIndex', '-1')
-      );
-    }
+    dropdownRef &&
+      dropdownRef.current &&
+      setFocusables(getFocusableElements(dropdownRef.current));
   }, [children]);
 
   useEffect(() => {
@@ -159,7 +153,7 @@ const DropdownButton: FunctionComponent<PropsWithChildren<Props>> = ({
     } else {
       focusables.forEach(focusable => focusable.setAttribute('tabIndex', '-1'));
     }
-  }, [isActive, children]);
+  }, [isActive, children, focusables]);
 
   const buttonProps = {
     isActive,

--- a/common/views/components/DropdownButton/DropdownButton.tsx
+++ b/common/views/components/DropdownButton/DropdownButton.tsx
@@ -142,9 +142,15 @@ const DropdownButton: FunctionComponent<PropsWithChildren<Props>> = ({
   });
 
   useEffect(() => {
-    dropdownRef &&
-      dropdownRef.current &&
-      setFocusables(getFocusableElements(dropdownRef.current));
+    if (dropdownRef && dropdownRef.current) {
+      const focusableElements = getFocusableElements(
+        dropdownRef.current
+      ) as HTMLElement[];
+      setFocusables(focusableElements);
+      focusableElements.forEach(focusable =>
+        focusable.setAttribute('tabIndex', '-1')
+      );
+    }
   }, [children]);
 
   useEffect(() => {


### PR DESCRIPTION
## Who is this for?
an extra consideration. The previous work sorted it out on the initial load.
But did not run when the children elements got updated, even though `focusables` list gets updated. 

## What is it doing for them?
