### PR TITLE
Don't include 5xx errors from our e2e tests in our Slack alerts

### DIFF
--- a/cache/send_slack_alert_for_5xx_errors.js
+++ b/cache/send_slack_alert_for_5xx_errors.js
@@ -358,6 +358,14 @@ function isInterestingError(hit) {
     return false;
   }
 
+  // These are hits from the CloudFront distribution we use for end-to-end
+  // tests.  Any errors here are either opportunistic bots we don't care
+  // about, or a failure which will be surfaced elsewhere by the end-to-end
+  // test results.  We don't need to hear about them in Slack.
+  if (hit.host.includes('.www-e2e.')) {
+    return false;
+  }
+
   return true;
 }
 


### PR DESCRIPTION
For https://github.com/wellcomecollection/wellcomecollection.org/issues/9876