### PR TITLE
Remove cardigan from ignore list

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -7,7 +7,6 @@ on:
       - '.buildkite/**'
       - 'assets/**'
       - 'cache/**'
-      - 'cardigan/**'
       - 'catalogue/terraform/**'
       - 'content/terraform/**'
       - 'docs/**'


### PR DESCRIPTION
## Who is this for?
Devs

## What is it doing for them?
When adding/modifying a story, Chromatic should build so we can see it. Currently only builds if we edit a component directly.