### PR TITLE
Fix and improve caching

### DIFF
--- a/cache/modules/cloudfront_policies/cache_policies.tf
+++ b/cache/modules/cloudfront_policies/cache_policies.tf
@@ -1,38 +1,3 @@
-resource "aws_cloudfront_cache_policy" "toggle_cookies_only" {
-  name    = "toggle-cookies-only"
-  comment = "Caches based on toggle cookies and nothing else"
-
-  min_ttl     = 0
-  default_ttl = local.one_hour
-  max_ttl     = local.one_day
-
-  parameters_in_cache_key_and_forwarded_to_origin {
-    // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-policy-compressed-objects
-    // This needs to be here as, despite what the AWS docs say, adding Accept-Encoding
-    // to the headers whitelist in a request policy fails with the grammatically questionable error:
-    //
-    //   The parameter Headers contains Accept-Encoding that is not allowed.
-    //
-    enable_accept_encoding_gzip = true
-
-    cookies_config {
-      cookie_behavior = "whitelist"
-
-      cookies {
-        items = local.toggles_cookies
-      }
-    }
-
-    headers_config {
-      header_behavior = "none"
-    }
-
-    query_strings_config {
-      query_string_behavior = "none"
-    }
-  }
-}
-
 resource "aws_cloudfront_cache_policy" "static_content" {
   name    = "static-content"
   comment = "Longer-lived cache for static content"

--- a/cache/modules/cloudfront_policies/locals.tf
+++ b/cache/modules/cloudfront_policies/locals.tf
@@ -1,7 +1,7 @@
 locals {
-  toggles_cookies = ["toggles", "toggle_*"]
+  toggles_cookies        = ["toggles", "toggle_*"]
   userpreference_cookies = ["WC_*"]
-  ga_cookies = ["_ga"]
+  ga_cookies             = ["_ga"]
 
   content_query_params = [
     "cachebust",
@@ -10,6 +10,7 @@ locals {
     "result",
     "toggle",
     "uri",
+    "format",
 
     # This is used to fetch articles client-side, e.g. related stories.
     # When it's missing, we may show the wrong stories as "read this next"

--- a/cache/modules/cloudfront_policies/outputs.tf
+++ b/cache/modules/cloudfront_policies/outputs.tf
@@ -1,7 +1,6 @@
 output "cache_policies" {
   value = {
     for policy in [
-      aws_cloudfront_cache_policy.toggle_cookies_only,
       aws_cloudfront_cache_policy.static_content,
       aws_cloudfront_cache_policy.weco_apps,
       aws_cloudfront_cache_policy.short_lived_toggles_only,

--- a/cache/modules/wc_org_cloudfront/distribution.tf
+++ b/cache/modules/wc_org_cloudfront/distribution.tf
@@ -185,7 +185,7 @@ resource "aws_cloudfront_distribution" "wc_org" {
     cached_methods         = local.stateless_methods
     viewer_protocol_policy = "redirect-to-https"
 
-    cache_policy_id            = var.cache_policies["toggle-cookies-only"]
+    cache_policy_id            = var.cache_policies["weco-apps"]
     origin_request_policy_id   = var.request_policies["host-query-and-toggles"]
     response_headers_policy_id = var.response_policies["weco-security"]
   }

--- a/catalogue/webapp/pages/concepts/[conceptId].tsx
+++ b/catalogue/webapp/pages/concepts/[conceptId].tsx
@@ -15,7 +15,7 @@ import { toLink as toImagesLink } from '@weco/catalogue/components/ImagesLink';
 import { toLink as toWorksLink } from '@weco/catalogue/components/WorksLink';
 import { pageDescriptionConcepts } from '@weco/common/data/microcopy';
 import { capitalize, formatNumber } from '@weco/common/utils/grammar';
-import { setCacheControl } from '@weco/common/utils/setCacheControl';
+import { cacheTTL, setCacheControl } from '@weco/common/utils/setCacheControl';
 
 // Components
 import BetaMessage from '@weco/common/views/components/BetaMessage/BetaMessage';
@@ -452,7 +452,7 @@ function createApiToolbarLinks(concept: ConceptType): ApiToolbarLink[] {
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
-  setCacheControl(context.res);
+  setCacheControl(context.res, cacheTTL.search);
   const serverData = await getServerData(context);
   const { conceptId } = context.query;
 

--- a/catalogue/webapp/pages/search/index.tsx
+++ b/catalogue/webapp/pages/search/index.tsx
@@ -37,7 +37,7 @@ import {
   ContentResultsList,
 } from '@weco/catalogue/services/wellcome/content/types/api';
 import { WellcomeApiError } from '@weco/catalogue/services/wellcome';
-import { setCacheControl } from '@weco/common/utils/setCacheControl';
+import { cacheTTL, setCacheControl } from '@weco/common/utils/setCacheControl';
 import { looksLikeSpam } from '@weco/catalogue/utils/spam-detector';
 
 // Creating this version of fromQuery for the overview page only
@@ -200,7 +200,7 @@ SearchPage.getLayout = getSearchLayout;
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
-  setCacheControl(context.res);
+  setCacheControl(context.res, cacheTTL.search);
   const serverData = await getServerData(context);
   const query = context.query;
   const params = fromQuery(query);

--- a/catalogue/webapp/pages/search/stories.tsx
+++ b/catalogue/webapp/pages/search/stories.tsx
@@ -24,7 +24,7 @@ import {
   linkResolver,
 } from '@weco/common/utils/search';
 import { getArticles } from '@weco/catalogue/services/wellcome/content/articles';
-import { setCacheControl } from '@weco/common/utils/setCacheControl';
+import { cacheTTL, setCacheControl } from '@weco/common/utils/setCacheControl';
 import { looksLikeSpam } from '@weco/catalogue/utils/spam-detector';
 
 // Types
@@ -204,7 +204,7 @@ SearchPage.getLayout = getSearchLayout;
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
-  setCacheControl(context.res);
+  setCacheControl(context.res, cacheTTL.search);
   const serverData = await getServerData(context);
   const query = context.query;
   const params = fromQuery(query);

--- a/catalogue/webapp/pages/search/works.tsx
+++ b/catalogue/webapp/pages/search/works.tsx
@@ -33,7 +33,7 @@ import convertUrlToString from '@weco/common/utils/convert-url-to-string';
 import { hasFilters, linkResolver } from '@weco/common/utils/search';
 import { AppErrorProps, appError } from '@weco/common/services/app';
 import { pluralize } from '@weco/common/utils/grammar';
-import { setCacheControl } from '@weco/common/utils/setCacheControl';
+import { cacheTTL, setCacheControl } from '@weco/common/utils/setCacheControl';
 import { looksLikeSpam } from '@weco/catalogue/utils/spam-detector';
 
 // Types
@@ -217,7 +217,7 @@ CatalogueSearchPage.getLayout = getSearchLayout;
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
-  setCacheControl(context.res);
+  setCacheControl(context.res, cacheTTL.search);
   const serverData = await getServerData(context);
   const query = context.query;
   const params = fromQuery(query);

--- a/common/utils/setCacheControl.ts
+++ b/common/utils/setCacheControl.ts
@@ -1,6 +1,15 @@
 import { ServerResponse } from 'http';
 
-export const setCacheControl = (res: ServerResponse) => {
+export const cacheTTL = {
+  default: 3600, // 1 hour
+  search: 300, // 5 minutes
+  events: 60, // 1 minute
+} as const;
+
+export const setCacheControl = (
+  res: ServerResponse,
+  ttl: (typeof cacheTTL)[keyof typeof cacheTTL] = cacheTTL.default
+) => {
   /**
    * Cloudfront should handle our caching, and the intention of this line is to
    * remove the caching that next adds on top of the request/responses.
@@ -10,5 +19,5 @@ export const setCacheControl = (res: ServerResponse) => {
    * Our cache policies:
    * https://github.com/wellcomecollection/wellcomecollection.org/blob/main/cache/modules/cloudfront_policies/cache_policies.tf
    */
-  res.setHeader('Cache-Control', 'max-age=3600');
+  res.setHeader('Cache-Control', `max-age=${ttl}`);
 };

--- a/content/webapp/pages/events/[eventId].tsx
+++ b/content/webapp/pages/events/[eventId].tsx
@@ -64,7 +64,7 @@ import { a11y } from '@weco/common/data/microcopy';
 import { Pageview } from '@weco/common/services/conversion/track';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 import { AppErrorProps } from '@weco/common/services/app';
-import { setCacheControl } from '@weco/common/utils/setCacheControl';
+import { cacheTTL, setCacheControl } from '@weco/common/utils/setCacheControl';
 
 const DateWrapper = styled.div.attrs({
   className: 'body-text',
@@ -456,7 +456,7 @@ const EventPage: NextPage<EventProps> = ({ event, jsonLd }) => {
 export const getServerSideProps: GetServerSideProps<
   EventProps | AppErrorProps
 > = async context => {
-  setCacheControl(context.res);
+  setCacheControl(context.res, cacheTTL.events);
   const serverData = await getServerData(context);
   const { eventId } = context.query;
 

--- a/content/webapp/pages/events/index.tsx
+++ b/content/webapp/pages/events/index.tsx
@@ -24,7 +24,7 @@ import { transformQuery } from '@weco/content/services/prismic/transformers/pagi
 import { pageDescriptions } from '@weco/common/data/microcopy';
 import { EventBasic } from '@weco/content/types/events';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
-import { setCacheControl } from '@weco/common/utils/setCacheControl';
+import { cacheTTL, setCacheControl } from '@weco/common/utils/setCacheControl';
 import { Period } from '@weco/common/types/periods';
 
 export type Props = {
@@ -37,7 +37,7 @@ export type Props = {
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
-  setCacheControl(context.res);
+  setCacheControl(context.res, cacheTTL.events);
   const page = getPage(context.query);
 
   if (typeof page !== 'number') {

--- a/content/webapp/pages/exhibitions/[exhibitionId].tsx
+++ b/content/webapp/pages/exhibitions/[exhibitionId].tsx
@@ -19,7 +19,7 @@ import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 import { Pageview } from '@weco/common/services/conversion/track';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
-import { setCacheControl } from '@weco/common/utils/setCacheControl';
+import { cacheTTL, setCacheControl } from '@weco/common/utils/setCacheControl';
 
 type ExhibitionProps = {
   exhibition: ExhibitionType;
@@ -62,7 +62,7 @@ const ExhibitionPage: FunctionComponent<ExhibitionProps> = ({
 export const getServerSideProps: GetServerSideProps<
   ExhibitionProps | AppErrorProps
 > = async context => {
-  setCacheControl(context.res);
+  setCacheControl(context.res, cacheTTL.events);
   const serverData = await getServerData(context);
   const { exhibitionId } = context.query;
 

--- a/content/webapp/pages/exhibitions/index.tsx
+++ b/content/webapp/pages/exhibitions/index.tsx
@@ -28,7 +28,7 @@ import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/Pri
 import { headerBackgroundLs } from '@weco/common/utils/backgrounds';
 import { isFuture } from '@weco/common/utils/dates';
 import Pagination from '@weco/common/views/components/Pagination/Pagination';
-import { setCacheControl } from '@weco/common/utils/setCacheControl';
+import { cacheTTL, setCacheControl } from '@weco/common/utils/setCacheControl';
 
 export type ExhibitionsProps = {
   exhibitions: PaginatedResults<ExhibitionBasic>;
@@ -40,7 +40,7 @@ export type ExhibitionsProps = {
 export const getServerSideProps: GetServerSideProps<
   ExhibitionsProps | AppErrorProps
 > = async context => {
-  setCacheControl(context.res);
+  setCacheControl(context.res, cacheTTL.events);
   const serverData = await getServerData(context);
   const client = createClient(context);
 

--- a/content/webapp/pages/whats-on/index.tsx
+++ b/content/webapp/pages/whats-on/index.tsx
@@ -82,7 +82,7 @@ import {
 import { FacilityPromo as FacilityPromoType } from '@weco/content/types/facility-promo';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 import styled from 'styled-components';
-import { setCacheControl } from '@weco/common/utils/setCacheControl';
+import { cacheTTL, setCacheControl } from '@weco/common/utils/setCacheControl';
 
 const segmentedControlItems: Item[] = [
   {
@@ -313,7 +313,7 @@ const Header: FunctionComponent<HeaderProps> = ({
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
-  setCacheControl(context.res);
+  setCacheControl(context.res, cacheTTL.events);
   const serverData = await getServerData(context);
 
   const client = createClient(context);


### PR DESCRIPTION
Getting caching to work exposed some underlying issues in how CloudFront was configured - the first change in this PR is to stop using the policy which caches only on toggles ie to make sure that cache keys include query parameters. This is already applied.

The next change is to add some overrides to cache TTL to specific routes: as per [the CloudFront docs](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html), we do these overrides in the app rather than configuring more granular cache policies, which I believe are intended to be broad-brush defaults.

I didn't put all that much thought into the values here - I thought search should be about 5 minutes to reflect changes to source data in a timely manner, and I thought events/exhibitions/etc should be 1 minute because of the real-world consequences involved with them being up-to-date; all of these are up for debate.