### PR TITLE
Remove the bundleAnalysis tasks from CI; don't install the awscli

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -140,7 +140,7 @@
 
 - wait
 
-- label: 'deploy catalogue (ecr image)'
+- label: 'deploy catalogue'
   branches: 'main'
   plugins:
     - wellcomecollection/aws-assume-role#v0.2.2:
@@ -152,22 +152,7 @@
           - catalogue:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/catalogue_webapp:ref.${BUILDKITE_COMMIT}
           - catalogue:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/catalogue_webapp:latest
 
-- label: 'deploy catalogue (bundle analysis)'
-  branches: 'main'
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: 'arn:aws:iam::130871440101:role/experience-ci'
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: catalogue
-        command: ['yarn', 'deployBundleAnalysis']
-        env:
-          - AWS_ACCESS_KEY_ID
-          - AWS_SECRET_ACCESS_KEY
-          - AWS_SESSION_TOKEN
-
-- label: 'deploy content (ecr image)'
+- label: 'deploy content'
   branches: 'main'
   plugins:
     - wellcomecollection/aws-assume-role#v0.2.2:
@@ -179,22 +164,7 @@
           - content:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/content_webapp:ref.${BUILDKITE_COMMIT}
           - content:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/content_webapp:latest
 
-- label: 'deploy content (bundle analysis)'
-  branches: 'main'
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: 'arn:aws:iam::130871440101:role/experience-ci'
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: content
-        command: ['yarn', 'deployBundleAnalysis']
-        env:
-          - AWS_ACCESS_KEY_ID
-          - AWS_SECRET_ACCESS_KEY
-          - AWS_SESSION_TOKEN
-
-- label: 'deploy identity (ecr image)'
+- label: 'deploy identity'
   branches: 'main'
   plugins:
     - wellcomecollection/aws-assume-role#v0.2.2:
@@ -205,21 +175,6 @@
         push:
           - identity:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/identity_webapp:ref.${BUILDKITE_COMMIT}
           - identity:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/identity_webapp:latest
-
-# - label: "deploy identity (bundle analysis)"
-#   branches: "main"
-#   plugins:
-#     - wellcomecollection/aws-assume-role#v0.2.2:
-#         role: "arn:aws:iam::130871440101:role/experience-ci"
-#     - ecr#v2.1.1:
-#         login: true
-#     - docker-compose#v3.5.0:
-#         run: identity
-#         command: [ "yarn", "deployBundleAnalysis" ]
-#         env:
-#           - AWS_ACCESS_KEY_ID
-#           - AWS_SECRET_ACCESS_KEY
-#           - AWS_SESSION_TOKEN
 
 - label: 'deploy dash'
   branches: 'main'

--- a/catalogue/Dockerfile
+++ b/catalogue/Dockerfile
@@ -1,8 +1,6 @@
 # This image should be built with the parent directory as context
 FROM public.ecr.aws/docker/library/node:16-slim
 
-RUN apt-get update && apt-get install -y awscli
-
 WORKDIR /app
 
 COPY package.json yarn.lock ./

--- a/catalogue/Dockerfile
+++ b/catalogue/Dockerfile
@@ -12,8 +12,6 @@ COPY catalogue/webapp/package.json ./
 RUN yarn --frozen-lockfile && yarn cache clean
 
 COPY catalogue/webapp .
-ENV BUILD_HASH=latest
-ENV BUNDLE_ANALYZE=both
 
 RUN yarn build && yarn cache clean
 

--- a/content/Dockerfile
+++ b/content/Dockerfile
@@ -1,8 +1,6 @@
 # This image should be built with the parent directory as context
 FROM public.ecr.aws/docker/library/node:16-slim
 
-RUN apt-get update && apt-get install -y awscli
-
 WORKDIR /app
 
 COPY package.json yarn.lock ./

--- a/content/Dockerfile
+++ b/content/Dockerfile
@@ -12,8 +12,6 @@ COPY content/webapp/package.json ./
 RUN yarn --frozen-lockfile && yarn cache clean
 
 COPY content/webapp .
-ENV BUILD_HASH=latest
-ENV BUNDLE_ANALYZE=both
 
 RUN yarn build && yarn cache clean
 

--- a/dash/webapp/pages/index.tsx
+++ b/dash/webapp/pages/index.tsx
@@ -75,16 +75,6 @@ const IndexPage: FunctionComponent = () => {
               </a>
             </li>
             <li>
-              <a href="https://dash.wellcomecollection.org/bundles/content.browser.latest.html">
-                Content app bundle size
-              </a>
-            </li>
-            <li>
-              <a href="https://dash.wellcomecollection.org/bundles/catalogue.browser.latest.html">
-                Catalogue app bundle size
-              </a>
-            </li>
-            <li>
               <a href="https://updown.io/2cep" rel="uptime">
                 Uptime: Homepage
               </a>

--- a/identity/Dockerfile
+++ b/identity/Dockerfile
@@ -1,8 +1,6 @@
 # This image should be built with the parent directory as context
 FROM public.ecr.aws/docker/library/node:16-slim
 
-RUN apt-get update && apt-get install -y awscli
-
 WORKDIR /app
 
 COPY package.json yarn.lock ./

--- a/identity/Dockerfile
+++ b/identity/Dockerfile
@@ -9,15 +9,11 @@ COPY toggles/webapp ./toggles/webapp
 
 WORKDIR identity/webapp
 COPY identity/webapp/package.json ./
-RUN yarn --frozen-lockfile && \
-    yarn cache clean
+RUN yarn --frozen-lockfile && yarn cache clean
 
 COPY identity/webapp .
-ENV BUILD_HASH=latest
-ENV BUNDLE_ANALYZE=both
 
-RUN yarn build && \
-    yarn cache clean
+RUN yarn build && yarn cache clean
 
 EXPOSE 3000
 CMD ["yarn", "start"]


### PR DESCRIPTION
I don't think we're actually using the output of these tasks (or somebody might have noticed that the dashboard links have been stale for ages), and I think we can get a decent speedup in CI by removing them.