### PR TITLE
Volumes copies

### DIFF
--- a/catalogue/webapp/components/IIIFViewer/MultipleManifestList.tsx
+++ b/catalogue/webapp/components/IIIFViewer/MultipleManifestList.tsx
@@ -3,7 +3,10 @@ import NextLink from 'next/link';
 import { toLink as itemLink } from '../ItemLink';
 import ItemViewerContext from '../ItemViewerContext/ItemViewerContext';
 import { volumesNavigationLabel } from '@weco/common/text/aria-labels';
-import { getMultiVolumeLabel } from '@weco/catalogue/utils/iiif/v3';
+import {
+  getMultiVolumeLabel,
+  getCollectionManifests,
+} from '@weco/catalogue/utils/iiif/v3';
 import { queryParamToArrayIndex } from '@weco/catalogue/components/IIIFViewer/IIIFViewer';
 import {
   List,
@@ -13,10 +16,13 @@ import {
 const MultipleManifestListPrototype: FunctionComponent = () => {
   const { parentManifest, work, query, setIsMobileSidebarActive } =
     useContext(ItemViewerContext);
+  const manifests = parentManifest
+    ? getCollectionManifests(parentManifest)
+    : [];
   return (
     <nav>
       <List aria-label={volumesNavigationLabel}>
-        {parentManifest?.items.map((manifest, i) => (
+        {manifests.map((manifest, i) => (
           <Item
             key={manifest.id}
             isActive={i === queryParamToArrayIndex(query.manifest)}

--- a/catalogue/webapp/components/IIIFViewer/ViewerSidebar.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerSidebar.tsx
@@ -25,7 +25,10 @@ import IIIFSearchWithin from '../IIIFSearchWithin/IIIFSearchWithin';
 import WorkTitle from '../WorkTitle/WorkTitle';
 import { toHtmlId } from '@weco/common/utils/string';
 import { arrow, chevron } from '@weco/common/icons';
-import { getMultiVolumeLabel } from '@weco/catalogue/utils/iiif/v3';
+import {
+  getMultiVolumeLabel,
+  getCollectionManifests,
+} from '@weco/catalogue/utils/iiif/v3';
 
 const Inner = styled(Space).attrs({
   h: { size: 'm', properties: ['padding-left', 'padding-right'] },
@@ -147,13 +150,14 @@ const ViewerSidebar: FunctionComponent<{
   const credit = (digitalLocation && digitalLocation.credit) || iiifCredit;
 
   useEffect(() => {
-    const matchingManifest =
-      parentManifest?.items &&
-      parentManifest.items.find(canvas => {
-        return !transformedManifest
-          ? false
-          : canvas.id === transformedManifest.id;
-      });
+    const manifests = parentManifest
+      ? getCollectionManifests(parentManifest)
+      : [];
+    const matchingManifest = manifests.find(canvas => {
+      return !transformedManifest
+        ? false
+        : canvas.id === transformedManifest.id;
+    });
 
     const manifestLabel =
       matchingManifest?.label &&

--- a/catalogue/webapp/services/iiif/transformers/manifest.ts
+++ b/catalogue/webapp/services/iiif/transformers/manifest.ts
@@ -15,6 +15,7 @@ import {
   hasPdfDownload,
   getClickThroughService,
   getTokenService,
+  getCollectionManifests,
   checkModalRequired,
   checkIsTotallyRestricted,
 } from '../../../utils/iiif/v3';
@@ -29,7 +30,7 @@ export function transformManifest(manifestV3: Manifest): TransformedManifest {
   const pdf = getPdf(manifestV3);
   const id = manifestV3.id || '';
   const parentManifestUrl = manifestV3.partOf?.[0].id;
-  const manifests = manifestV3.items.filter(c => c.type === 'Manifest') || [];
+  const manifests = getCollectionManifests(manifestV3);
   const collectionManifestsCount = manifests.length;
   const transformedCanvases = getTransformedCanvases(manifestV3);
   const canvasCount = transformedCanvases.length;
@@ -54,7 +55,6 @@ export function transformManifest(manifestV3: Manifest): TransformedManifest {
   const structures = manifestV3.structures || [];
   const isCollectionManifest = manifestV3.type === 'Collection';
   const downloadEnabled = hasPdfDownload(manifestV3);
-
   return {
     id,
     firstCollectionManifestLocation,

--- a/catalogue/webapp/utils/iiif/v3/index.ts
+++ b/catalogue/webapp/utils/iiif/v3/index.ts
@@ -1,5 +1,6 @@
 import { Audio, Video } from '../../../services/iiif/types/manifest/v3';
 import {
+  AnnotationPage,
   AnnotationBody,
   ChoiceBody,
   ContentResource,
@@ -515,8 +516,12 @@ export function getCollectionManifests(manifest: Manifest) {
   const collections = manifest.items.filter(c => c.type === 'Collection') || [];
   const collectionManifests = collections
     .map(collection => {
-      return collection.items?.filter(c => c.type === 'Manifest') || [];
+      return (
+        collection.items?.filter(
+          c => c.type === ('Manifest' as AnnotationPage & { type: 'Manifest' })
+        ) || []
+      );
     })
     .flat();
-  return [...firstLevelManifests, ...collectionManifests];
+  return [...firstLevelManifests, ...collectionManifests] as Canvas[];
 }

--- a/catalogue/webapp/utils/iiif/v3/index.ts
+++ b/catalogue/webapp/utils/iiif/v3/index.ts
@@ -508,3 +508,15 @@ export function groupStructures(
     }
   ).groupedArray;
 }
+
+export function getCollectionManifests(manifest: Manifest) {
+  const firstLevelManifests =
+    manifest.items.filter(c => c.type === 'Manifest') || [];
+  const collections = manifest.items.filter(c => c.type === 'Collection') || [];
+  const collectionManifests = collections
+    .map(collection => {
+      return collection.items?.filter(c => c.type === 'Manifest') || [];
+    })
+    .flat();
+  return [...firstLevelManifests, ...collectionManifests];
+}


### PR DESCRIPTION
For #9901

The structure of this [multi volume work](https://wellcomecollection.org/works/z9gxzppu/items?manifest=4) is slightly different to others we have encountered.

Instead of the manifest (type: 'Collection') having an array of items type: Manifest, it had an array of items which were also type: 'Collection'. These Collections then contained arrays of items of type: Manifest.

We only ever looked for manifests on the initial items array, so never found the nested manifest items.

I don't know whether we need to present this additional structure in the UI, but for now I have included all the manifests together under the volumes section:

<img width="325" alt="Screenshot 2023-06-09 at 17 22 40" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/6051896/04e05800-5fdd-4a63-855a-94bc28671a09">

This also fixes the volume count being displayed on the work page.

Before:
<img width="375" alt="Screenshot 2023-06-09 at 16 43 32" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/6051896/4df2ab68-6f0f-45ed-9a1a-1e84fee1a125">

After:
 
<img width="427" alt="Screenshot 2023-06-09 at 16 43 12" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/6051896/8c8b5a12-109c-4981-ae4a-36516bda9e83">
