### PR TITLE
Add sliceType to SpacingComponent as class/data-slice

### DIFF
--- a/common/utils/grammar.ts
+++ b/common/utils/grammar.ts
@@ -68,6 +68,6 @@ export function pluralize(count: number, noun: string, suffix = 's'): string {
   return `${formatNumber(count)} ${noun}${count !== 1 ? suffix : ''}`;
 }
 
-export function unCamelCase(words: string): string {
-  return words.split(/(?=[A-Z])/).join(' ');
+export function camelToKebab(words: string): string {
+  return words.split(/(?=[A-Z])/).join('-');
 }

--- a/common/views/components/styled/SpacingComponent.tsx
+++ b/common/views/components/styled/SpacingComponent.tsx
@@ -1,8 +1,9 @@
 import styled from 'styled-components';
+import { dasherize } from 'utils/grammar';
 
 const SpacingComponent = styled.div.attrs<{ sliceType?: string }>(props => ({
   className: `spacing-component ${
-    props.sliceType ? `slice-type-${props.sliceType}` : ''
+    props.sliceType ? `slice-type-${dasherize(props.sliceType)}` : ''
   }`,
   'data-slice-type': props.sliceType,
 }))<{ sliceType?: string }>`

--- a/common/views/components/styled/SpacingComponent.tsx
+++ b/common/views/components/styled/SpacingComponent.tsx
@@ -1,11 +1,10 @@
 import styled from 'styled-components';
-import { camelToKebab } from 'utils/grammar';
+import { camelToKebab } from '@weco/common/utils/grammar';
 
 const SpacingComponent = styled.div.attrs<{ sliceType?: string }>(props => ({
   className: `spacing-component ${
     props.sliceType ? `slice-type-${camelToKebab(props.sliceType)}` : ''
   }`,
-  'data-slice-type': props.sliceType,
 }))<{ sliceType?: string }>`
   &:empty,
   & + .spacing-component {

--- a/common/views/components/styled/SpacingComponent.tsx
+++ b/common/views/components/styled/SpacingComponent.tsx
@@ -1,9 +1,9 @@
 import styled from 'styled-components';
-import { dasherize } from 'utils/grammar';
+import { camelToKebab } from 'utils/grammar';
 
 const SpacingComponent = styled.div.attrs<{ sliceType?: string }>(props => ({
   className: `spacing-component ${
-    props.sliceType ? `slice-type-${dasherize(props.sliceType)}` : ''
+    props.sliceType ? `slice-type-${camelToKebab(props.sliceType)}` : ''
   }`,
   'data-slice-type': props.sliceType,
 }))<{ sliceType?: string }>`

--- a/common/views/components/styled/SpacingComponent.tsx
+++ b/common/views/components/styled/SpacingComponent.tsx
@@ -1,7 +1,9 @@
 import styled from 'styled-components';
 
 const SpacingComponent = styled.div.attrs<{ sliceType?: string }>(props => ({
-  className: `spacing-component ${props.sliceType ? props.sliceType : ''}`,
+  className: `spacing-component ${
+    props.sliceType ? `slice-type-${props.sliceType}` : ''
+  }`,
   'data-slice-type': props.sliceType,
 }))<{ sliceType?: string }>`
   &:empty,
@@ -19,7 +21,7 @@ const SpacingComponent = styled.div.attrs<{ sliceType?: string }>(props => ({
       `)}
   }
 
-  &.text + &.text {
+  &.slice-type-text + &.slice-type-text {
     /* The SpacingComponent spaces adjacent components vertically by an amount
     of pixels. Elements within a single block of .spaced-text are spaced
     vertically by an amount of ems. In Prismic, it is possible to create a new

--- a/common/views/components/styled/SpacingComponent.tsx
+++ b/common/views/components/styled/SpacingComponent.tsx
@@ -1,8 +1,9 @@
 import styled from 'styled-components';
 
-const SpacingComponent = styled.div.attrs({
-  className: 'spacing-component',
-})`
+const SpacingComponent = styled.div.attrs<{ sliceType?: string }>(props => ({
+  className: 'spacing-component' + props.sliceType ? ` ${props.sliceType}` : '',
+  'data-slice-type': props.sliceType,
+}))<{ sliceType?: string }>`
   &:empty,
   & + .spacing-component {
     margin-top: ${props => props.theme.spaceAtBreakpoints.small.l}px;
@@ -18,7 +19,7 @@ const SpacingComponent = styled.div.attrs({
       `)}
   }
 
-  @supports selector(:has(a)) {
+  &.text + &.text {
     /* The SpacingComponent spaces adjacent components vertically by an amount
     of pixels. Elements within a single block of .spaced-text are spaced
     vertically by an amount of ems. In Prismic, it is possible to create a new
@@ -27,18 +28,12 @@ const SpacingComponent = styled.div.attrs({
     of vertical spacing depending on how the content has been added. To account
     for this, we check if the two adjacent SpacingComponents contain
     .spaced-text, and if so, override the SpacingComponent spacing in favour of
-    the .spaced-text spacing. Firefox currently (June 2023) doesn't support
-    :has(). Hopefully this will change soon
-    (https://connect.mozilla.org/t5/ideas/when-is-has-css-selector-going-to-be-fully-implemented-in/idi-p/23794/page/2#comments)
+    the .spaced-text spacing.
     */
+    margin-top: 0;
 
-    /* .body-text was added to ensure this only happened in Body slices */
-    &:has(.spaced-text.body-text) + &:has(.spaced-text.body-text) {
-      margin-top: 0;
-
-      .spaced-text.body-text > *:first-child {
-        margin-top: ${props => props.theme.spacedTextTopMargin};
-      }
+    .spaced-text > *:first-child {
+      margin-top: ${props => props.theme.spacedTextTopMargin};
     }
   }
 `;

--- a/common/views/components/styled/SpacingComponent.tsx
+++ b/common/views/components/styled/SpacingComponent.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 const SpacingComponent = styled.div.attrs<{ sliceType?: string }>(props => ({
-  className: 'spacing-component' + props.sliceType ? ` ${props.sliceType}` : '',
+  className: `spacing-component ${props.sliceType ? props.sliceType : ''}`,
   'data-slice-type': props.sliceType,
 }))<{ sliceType?: string }>`
   &:empty,

--- a/content/webapp/components/Body/Body.tsx
+++ b/content/webapp/components/Body/Body.tsx
@@ -346,7 +346,7 @@ const Body: FunctionComponent<Props> = ({
           ) && (
             <>
               {slice.type === 'text' && (
-                <SpacingComponent>
+                <SpacingComponent sliceType={slice.type}>
                   <LayoutWidth width={minWidth}>
                     <div className="body-text spaced-text">
                       {slice.weight !== 'featured' &&
@@ -384,28 +384,28 @@ const Body: FunctionComponent<Props> = ({
               {/* TODO: use one layout for all image weights if/when it's established
               that width isn't an adequate means to illustrate a difference */}
               {slice.type === 'picture' && slice.weight === 'default' && (
-                <SpacingComponent>
+                <SpacingComponent sliceType={slice.type}>
                   <Layout10>
                     <CaptionedImage {...slice.value} />
                   </Layout10>
                 </SpacingComponent>
               )}
               {slice.type === 'picture' && slice.weight === 'standalone' && (
-                <SpacingComponent>
+                <SpacingComponent sliceType={slice.type}>
                   <Layout12>
                     <CaptionedImage {...slice.value} />
                   </Layout12>
                 </SpacingComponent>
               )}
               {slice.type === 'picture' && slice.weight === 'supporting' && (
-                <SpacingComponent>
+                <SpacingComponent sliceType={slice.type}>
                   <LayoutWidth width={minWidth}>
                     <CaptionedImage {...slice.value} />
                   </LayoutWidth>
                 </SpacingComponent>
               )}
               {slice.type === 'imageGallery' && (
-                <SpacingComponent>
+                <SpacingComponent sliceType={slice.type}>
                   <ImageGallery
                     {...slice.value}
                     id={imageGalleryIdCount++}
@@ -414,21 +414,21 @@ const Body: FunctionComponent<Props> = ({
                 </SpacingComponent>
               )}
               {slice.type === 'quote' && (
-                <SpacingComponent>
+                <SpacingComponent sliceType={slice.type}>
                   <LayoutWidth width={minWidth}>
                     <Quote {...slice.value} />
                   </LayoutWidth>
                 </SpacingComponent>
               )}
               {slice.type === 'titledTextList' && (
-                <SpacingComponent>
+                <SpacingComponent sliceType={slice.type}>
                   <LayoutWidth width={minWidth}>
                     <TitledTextList {...slice.value} />
                   </LayoutWidth>
                 </SpacingComponent>
               )}
               {slice.type === 'contentList' && !isLanding && (
-                <SpacingComponent>
+                <SpacingComponent sliceType={slice.type}>
                   <LayoutWidth width={minWidth}>
                     {/* FIXME: this makes what-we-do contentLists synchronous, but it's hacky. */}
                     {pageId === prismicPageIds.whatWeDo ? (
@@ -452,14 +452,14 @@ const Body: FunctionComponent<Props> = ({
               )}
               {/* TODO: remove this slice type if we're not using it? */}
               {slice.type === 'searchResults' && (
-                <SpacingComponent>
+                <SpacingComponent sliceType={slice.type}>
                   <LayoutWidth width={minWidth}>
                     <AsyncSearchResults {...slice.value} />
                   </LayoutWidth>
                 </SpacingComponent>
               )}
               {slice.type === 'videoEmbed' && (
-                <SpacingComponent>
+                <SpacingComponent sliceType={slice.type}>
                   <LayoutWidth width={isShortFilm ? 12 : minWidth}>
                     <VideoEmbed
                       {...slice.value}
@@ -469,42 +469,42 @@ const Body: FunctionComponent<Props> = ({
                 </SpacingComponent>
               )}
               {slice.type === 'soundcloudEmbed' && (
-                <SpacingComponent>
+                <SpacingComponent sliceType={slice.type}>
                   <LayoutWidth width={minWidth}>
                     <SoundCloudEmbed {...slice.value} />
                   </LayoutWidth>
                 </SpacingComponent>
               )}
               {slice.type === 'map' && (
-                <SpacingComponent>
+                <SpacingComponent sliceType={slice.type}>
                   <LayoutWidth width={minWidth}>
                     <Map {...slice.value} />
                   </LayoutWidth>
                 </SpacingComponent>
               )}
               {slice.type === 'gifVideo' && (
-                <SpacingComponent>
+                <SpacingComponent sliceType={slice.type}>
                   <Layout10>
                     <GifVideo {...slice.value} />
                   </Layout10>
                 </SpacingComponent>
               )}
               {slice.type === 'iframe' && (
-                <SpacingComponent>
+                <SpacingComponent sliceType={slice.type}>
                   <Layout10>
                     <Iframe {...slice.value} />
                   </Layout10>
                 </SpacingComponent>
               )}
               {slice.type === 'contact' && (
-                <SpacingComponent>
+                <SpacingComponent sliceType={slice.type}>
                   <LayoutWidth width={minWidth}>
                     <Contact {...slice.value} />
                   </LayoutWidth>
                 </SpacingComponent>
               )}
               {slice.type === 'collectionVenue' && (
-                <SpacingComponent>
+                <SpacingComponent sliceType={slice.type}>
                   {slice.value.showClosingTimes ? (
                     <LayoutWidth width={minWidth}>
                       <VenueClosedPeriods venue={slice.value.content} />
@@ -541,21 +541,21 @@ const Body: FunctionComponent<Props> = ({
                 </SpacingComponent>
               )}
               {slice.type === 'table' && (
-                <SpacingComponent>
+                <SpacingComponent sliceType={slice.type}>
                   <LayoutWidth width={minWidth}>
                     <Table {...slice.value} />
                   </LayoutWidth>
                 </SpacingComponent>
               )}
               {slice.type === 'infoBlock' && (
-                <SpacingComponent>
+                <SpacingComponent sliceType={slice.type}>
                   <LayoutWidth width={minWidth}>
                     <InfoBlock {...slice.value} />
                   </LayoutWidth>
                 </SpacingComponent>
               )}
               {slice.type === 'discussion' && (
-                <SpacingComponent>
+                <SpacingComponent sliceType={slice.type}>
                   <WobblyEdgedContainer>
                     <Discussion
                       title={slice.value.title}
@@ -565,7 +565,7 @@ const Body: FunctionComponent<Props> = ({
                 </SpacingComponent>
               )}
               {slice.type === 'tagList' && (
-                <SpacingComponent>
+                <SpacingComponent sliceType={slice.type}>
                   <LayoutWidth width={minWidth}>
                     <TagsGroup {...slice.value} />
                   </LayoutWidth>
@@ -573,21 +573,21 @@ const Body: FunctionComponent<Props> = ({
               )}
               {/* deprecated */}
               {slice.type === 'deprecatedImageList' && (
-                <SpacingComponent>
+                <SpacingComponent sliceType={slice.type}>
                   <LayoutWidth width={minWidth}>
                     <DeprecatedImageList {...slice.value} />
                   </LayoutWidth>
                 </SpacingComponent>
               )}
               {slice.type === 'mediaObjectList' && (
-                <SpacingComponent>
+                <SpacingComponent sliceType={slice.type}>
                   <LayoutWidth width={minWidth}>
                     <MediaObjectList {...slice.value} />
                   </LayoutWidth>
                 </SpacingComponent>
               )}
               {slice.type === 'audioPlayer' && (
-                <SpacingComponent>
+                <SpacingComponent sliceType={slice.type}>
                   <LayoutWidth width={minWidth}>
                     <AudioPlayer {...slice.value} />
                   </LayoutWidth>


### PR DESCRIPTION
For #9918 

We currently don't have a good way of targeting neighbouring slices from Prismic and applying any specific styles at their intersection (for example, we might want to add dividing lines when two specific distinct components appear next to each other).

This PR adds a class and a data-slice attribute that exposes the slice type from Prismic onto the `SpacingComponent` (that wraps each slice). We can then override the `SpacingComponent` spacing where necessary and add any other intra-component styles.

This also means we don't need to use the `has()` selector anymore (which isn't yet supported in Firefox, and will never be supported in IE).
