### PR TITLE
Overview page should set link to search context

### DIFF
--- a/catalogue/webapp/pages/search/index.tsx
+++ b/catalogue/webapp/pages/search/index.tsx
@@ -39,6 +39,8 @@ import {
 import { WellcomeApiError } from '@weco/catalogue/services/wellcome';
 import { setCacheControl } from '@weco/common/utils/setCacheControl';
 import { looksLikeSpam } from '@weco/catalogue/utils/spam-detector';
+import SearchContext from '@weco/common/views/components/SearchContext/SearchContext';
+import { useContext, useEffect } from 'react';
 
 // Creating this version of fromQuery for the overview page only
 // No filters or pagination required.
@@ -99,6 +101,22 @@ export const SearchPage: NextPageWithLayout<Props> = ({
   query,
 }) => {
   const { query: queryString } = query;
+  const { setLink } = useContext(SearchContext);
+
+  useEffect(() => {
+    const pathname = '/search';
+    const link = {
+      href: {
+        pathname,
+        query,
+      },
+      as: {
+        pathname,
+        query,
+      },
+    };
+    setLink(link);
+  }, [query]);
 
   const SeeMoreButton = ({
     text,

--- a/common/views/components/BackToResults/BackToResults.tsx
+++ b/common/views/components/BackToResults/BackToResults.tsx
@@ -6,7 +6,8 @@ import SearchContext from '../SearchContext/SearchContext';
 
 const BackToResults: FunctionComponent = () => {
   const { link } = useContext(SearchContext);
-  const query = link.href?.query?.query;
+  const query = link.href?.query;
+  const queryString = link.href?.query?.query;
   const page = link.href?.query?.page;
 
   if (!query) return null;
@@ -19,7 +20,7 @@ const BackToResults: FunctionComponent = () => {
         trackGaEvent({
           category: 'BackToResults',
           action: 'follow link',
-          label: `${query} | page: ${page || 1}`,
+          label: `${queryString || ''} | page: ${page || 1}`,
         });
       }}
       className={font('intr', 5)}


### PR DESCRIPTION
## Who is this for?
Users of the overview page when searching should be able to return back to the search page when they click on a work.

now, the question is if I should expand this logic and feature to stories pages?

## What is it doing for them?
simply ensuring the search result page (Overview) updates the SearchContext was enough for the stories page to acknowledge that there was a search happening.