### PR TITLE
Nojs viewer

### DIFF
--- a/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
@@ -5,7 +5,7 @@ import {
   useEffect,
   useContext,
 } from 'react';
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
 import { Manifest } from '@iiif/presentation-3';
 import { DigitalLocation } from '@weco/common/model/catalogue';
 import { Work } from '@weco/catalogue/services/wellcome/catalogue/types';
@@ -39,6 +39,26 @@ export function queryParamToArrayIndex(canvas: number): number {
 export function arrayIndexToQueryParam(canvasIndex: number): number {
   return canvasIndex + 1;
 }
+
+const show = keyframes`
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+`;
+// The <NoScriptViewer /> will display before the enhanced viewer takes it's place.
+// This is necessary for it to be available to visitors without javascript,
+// but would normally result in a large and noticeable change to the page which is jarring.
+// In order to prevent that, we wrap the <NoScriptViewer /> in a DelayVisibility styled component.
+// This delays the visibility of the <NoScriptViewer /> long enough
+// that the enhanced viewer will usually have replaced it, if javascript is available, and so it will never be seen.
+// The trade off is that if javascript isn't available there will be a slight delay before seeing the <NoScriptViewer />.
+const DelayVisibility = styled.div`
+  opacity: 0;
+  animation: 0.5s ${show} 2s forwards;
+`;
 
 type IIIFViewerProps = {
   work: Work;
@@ -369,11 +389,13 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
           </Thumbnails>
         </Grid>
       ) : (
-        <NoScriptViewer
-          imageUrl={imageUrl}
-          iiifImageLocation={iiifImageLocation}
-          canvasOcr={canvasOcr}
-        />
+        <DelayVisibility>
+          <NoScriptViewer
+            imageUrl={imageUrl}
+            iiifImageLocation={iiifImageLocation}
+            canvasOcr={canvasOcr}
+          />
+        </DelayVisibility>
       )}
     </ItemViewerContext.Provider>
   );

--- a/catalogue/webapp/pages/works/[workId]/items.tsx
+++ b/catalogue/webapp/pages/works/[workId]/items.tsx
@@ -101,7 +101,7 @@ const ItemPage: NextPage<Props> = ({
   const workId = work.id;
   const [origin, setOrigin] = useState<string>();
   const [showModal, setShowModal] = useState(false);
-  const [showViewer, setShowViewer] = useState(false);
+  const [showViewer, setShowViewer] = useState(true);
   const { worksTabbedNav } = useToggles();
   const {
     title,

--- a/catalogue/webapp/pages/works/[workId]/items.tsx
+++ b/catalogue/webapp/pages/works/[workId]/items.tsx
@@ -127,6 +127,13 @@ const ItemPage: NextPage<Props> = ({
     '@id': imageServiceId,
   };
 
+  // showViewer is true by default, so the noScriptViewer is available without javascript
+  // if javascript is available we set it to false and then determine whether the clickthrough modal is required
+  // before setting it to true
+  useEffect(() => {
+    setShowViewer(false);
+  }, []);
+
   useEffect(() => {
     setOrigin(`${window.location.protocol}//${window.location.hostname}`);
   }, []);


### PR DESCRIPTION
For #9380

Makes the NoScriptViewer available to use when javascript is disabled. Previously item pages would show no content in this scenario.

Before:
![Screenshot 2023-06-16 at 11 43 15](https://github.com/wellcomecollection/wellcomecollection.org/assets/6051896/655e8121-8d3c-48f3-9ca7-0f10b2be8422)

After:
![Screenshot 2023-06-16 at 11 43 34](https://github.com/wellcomecollection/wellcomecollection.org/assets/6051896/e2cc8431-5262-472f-b23e-266fe01619e0)

The NoScriptViewer allows for pagination through thumbnails and main images. However, at the moment
 it [can't cope with items that have a clickthrough service](https://github.com/wellcomecollection/wellcomecollection.org/issues/9428). In this case it will be unable to load the images:
![Screenshot 2023-06-16 at 11 38 30](https://github.com/wellcomecollection/wellcomecollection.org/assets/6051896/dc87bdae-ebc3-4516-8b8a-3e0f8c886976)

It also can't yet cope with multi volume items and will only display the first volume.