### PR TITLE
Split the list of scheduled items into Events/Past Events

### DIFF
--- a/content/webapp/components/EventSchedule/EventSchedule.tsx
+++ b/content/webapp/components/EventSchedule/EventSchedule.tsx
@@ -1,8 +1,43 @@
 import { Fragment, FunctionComponent } from 'react';
-import type { EventSchedule as EventScheduleType } from '../../types/events';
+import type {
+  EventSchedule as EventScheduleType,
+  Event as EventType,
+} from '../../types/events';
 import EventScheduleItem from './EventScheduleItem';
-import { groupEventsByDay } from '../../services/prismic/events';
+import { EventsGroup, groupEventsByDay } from '../../services/prismic/events';
 import Space from '@weco/common/views/components/styled/Space';
+import { isPast } from '@weco/common/utils/dates';
+
+const EventScheduleList: FunctionComponent<{
+  groupedEvents: EventsGroup<EventType>[];
+  isNotLinkedIds: string[];
+}> = ({ groupedEvents, isNotLinkedIds }) => (
+  <>
+    {groupedEvents.map(
+      eventsGroup =>
+        eventsGroup.events.length > 0 && (
+          <Fragment key={eventsGroup.label}>
+            {groupedEvents.length > 1 && (
+              <Space
+                v={{ size: 'm', properties: ['margin-bottom'] }}
+                as="h3"
+                className="h3"
+              >
+                {eventsGroup.label}
+              </Space>
+            )}
+            {eventsGroup.events.map(event => (
+              <EventScheduleItem
+                key={event.id}
+                event={event}
+                isNotLinked={isNotLinkedIds.indexOf(event.id) > -1}
+              />
+            ))}
+          </Fragment>
+        )
+    )}
+  </>
+);
 
 type Props = {
   schedule: EventScheduleType;
@@ -19,31 +54,35 @@ const EventSchedule: FunctionComponent<Props> = ({ schedule }) => {
     .filter(({ isNotLinked }) => isNotLinked)
     .map(({ event }) => event.id);
 
+  // We split scheduled events into two headings: Events and Past Events.
+  //
+  // This is primarily for the benefit of long-running, repeating events
+  // like the Lights Up sessions for Milk.  There are lots of events in
+  // the schedule, but we want future/upcoming events to be prioritised
+  // on the page; readers shouldn't have to scroll past half a dozen past
+  // events to find the ticket link for the next event.
+  const pastEvents = groupedEvents.filter(group => isPast(group.end));
+  const futureEvents = groupedEvents.filter(group => !isPast(group.end));
+
   return (
     <>
-      <h2 className="h2">Events</h2>
-      {groupedEvents.map(
-        eventsGroup =>
-          eventsGroup.events.length > 0 && (
-            <Fragment key={eventsGroup.label}>
-              {groupedEvents.length > 1 && (
-                <Space
-                  v={{ size: 'm', properties: ['margin-bottom'] }}
-                  as="h3"
-                  className="h3"
-                >
-                  {eventsGroup.label}
-                </Space>
-              )}
-              {eventsGroup.events.map(event => (
-                <EventScheduleItem
-                  key={event.id}
-                  event={event}
-                  isNotLinked={isNotLinkedIds.indexOf(event.id) > -1}
-                />
-              ))}
-            </Fragment>
-          )
+      {futureEvents.length > 0 && (
+        <>
+          <h2 className="h2">Events</h2>
+          <EventScheduleList
+            groupedEvents={futureEvents}
+            isNotLinkedIds={isNotLinkedIds}
+          />
+        </>
+      )}
+      {pastEvents.length > 0 && (
+        <>
+          <h2 className="h2">Past events</h2>
+          <EventScheduleList
+            groupedEvents={pastEvents}
+            isNotLinkedIds={isNotLinkedIds}
+          />
+        </>
       )}
     </>
   );

--- a/content/webapp/components/EventSchedule/EventSchedule.tsx
+++ b/content/webapp/components/EventSchedule/EventSchedule.tsx
@@ -21,6 +21,7 @@ const EventSchedule: FunctionComponent<Props> = ({ schedule }) => {
 
   return (
     <>
+      <h2 className="h2">Events</h2>
       {groupedEvents.map(
         eventsGroup =>
           eventsGroup.events.length > 0 && (

--- a/content/webapp/components/EventSchedule/EventSchedule.tsx
+++ b/content/webapp/components/EventSchedule/EventSchedule.tsx
@@ -61,6 +61,8 @@ const EventSchedule: FunctionComponent<Props> = ({ schedule }) => {
   // the schedule, but we want future/upcoming events to be prioritised
   // on the page; readers shouldn't have to scroll past half a dozen past
   // events to find the ticket link for the next event.
+  //
+  // See e.g. https://wellcomecollection.org/events/ZCRYYRQAAB3ySUc2
   const pastEvents = groupedEvents.filter(group => isPast(group.end));
   const futureEvents = groupedEvents.filter(group => !isPast(group.end));
 

--- a/content/webapp/pages/events/[eventId].tsx
+++ b/content/webapp/pages/events/[eventId].tsx
@@ -269,10 +269,7 @@ const EventPage: NextPage<EventProps> = ({ event, jsonLd }) => {
           <EventDateList event={event} />
         </DateWrapper>
         {event.schedule && event.schedule.length > 0 && (
-          <>
-            <h2 className="h2">Events</h2>
-            <EventSchedule schedule={event.schedule} />
-          </>
+          <EventSchedule schedule={event.schedule} />
         )}
         {event.ticketSalesStart &&
           showTicketSalesStart(event.ticketSalesStart) && (

--- a/content/webapp/services/prismic/events.ts
+++ b/content/webapp/services/prismic/events.ts
@@ -90,7 +90,7 @@ export function orderEventsByNextAvailableDate<T extends HasTimes>(
     .map(({ event }) => event);
 }
 
-type EventsGroup<T> = {
+export type EventsGroup<T> = {
   label: string;
   start: Date;
   end: Date;


### PR DESCRIPTION
For https://github.com/wellcomecollection/wellcomecollection.org/issues/9949

There's a Slack discussion about this design, including screenshots: https://wellcome.slack.com/archives/CUA669WHH/p1687161340728489