### PR TITLE
Add `deployTypes` script for all types at the same time

### DIFF
--- a/prismic-model/deployType.ts
+++ b/prismic-model/deployType.ts
@@ -106,7 +106,10 @@ async function run() {
   );
 
   if (response.status === 204) {
-    success(`Updated ${id} successfully`);
+    success(
+      `Updated ${id} successfully.
+      To ensure Prismic uses this new model, go make a small change to a page and publish it. e.g. https://wellcomecollection.prismic.io/documents~k=pages&w=test&b=working&c=unclassified&l=en-gb/YB3RoRIAACQATXTn/`
+    );
 
     await checkForOtherDiffs(credentials);
   } else {

--- a/prismic-model/deployTypes.ts
+++ b/prismic-model/deployTypes.ts
@@ -1,0 +1,126 @@
+import fetch from 'node-fetch';
+import { getCreds } from '@weco/ts-aws';
+import prompts from 'prompts';
+import { error, success, warn } from './console';
+import { removeUndefinedProps, printDelta } from './utils';
+import { diffString } from 'json-diff';
+import { getContentTypes, getCustomType, getLocalType } from './utils/prismic';
+
+async function promptDiff({ id, localType, delta }) {
+  printDelta(localType.id, delta);
+  const { confirm } = await prompts({
+    type: 'confirm',
+    name: 'confirm',
+    message: 'Happy with the diff?',
+    initial: true,
+  });
+
+  if (!confirm) {
+    warn('Unhappy with the diff');
+    return false;
+  }
+
+  const response = await fetch(
+    `https://customtypes.prismic.io/customtypes/update`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${process.env.PRISMIC_BEARER_TOKEN}`,
+        repository: 'wellcomecollection',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(localType),
+    }
+  );
+  if (response.status === 204) {
+    success(`Updated ${id} successfully`);
+    return true;
+  } else {
+    console.error(response);
+    error(`Failed updating ${id}`);
+    return true;
+  }
+}
+
+async function run() {
+  const credentials = await getCreds('experience', 'developer');
+  const contentTypes = await getContentTypes(credentials);
+  const noDiff = [];
+  const hasDiff = [];
+
+  await Promise.all(
+    contentTypes.map(async ({ id }) => {
+      const remoteType = await getCustomType(credentials, id);
+
+      if (typeof remoteType === 'undefined') {
+        error(
+          `Prismic does not know about a custom type '${id}'. Something has gone wrong.`
+        );
+        return;
+      }
+
+      const localType = await getLocalType(id);
+      if (typeof remoteType === 'undefined') {
+        error(`Cannot load local type '${id}'. Something has gone wrong.`);
+        return;
+      }
+
+      const delta = diffString(remoteType, removeUndefinedProps(localType)); // we'll never get undefined props from Prismic, so we don't want them locally
+
+      if (delta.length === 0) {
+        noDiff.push(id);
+      } else {
+        hasDiff.push({ id, localType, delta });
+      }
+    })
+  );
+
+  if (noDiff.length > 0) {
+    success(
+      `Remote type${noDiff.length === 1 ? '' : 's'} "${noDiff.join(
+        ', '
+      )}" match${noDiff.length === 1 ? 'es' : ''} local model${
+        noDiff.length === 1 ? '' : 's'
+      }; nothing to do.`
+    );
+  }
+
+  if (hasDiff.length > 0) {
+    const nonUpdatedTypes = [];
+    const updatedTypes = [];
+
+    warn(
+      `You'll be asked to confirm changes to: ${hasDiff
+        .map(t => t.id)
+        .join(', ')}.`
+    );
+
+    for (let i = 0; i < hasDiff.length; i++) {
+      const type = hasDiff[i];
+      const updated = await promptDiff({
+        id: type.id,
+        localType: type.localType,
+        delta: type.delta,
+      });
+
+      if (!updated) {
+        nonUpdatedTypes.push(type.id);
+      } else {
+        updatedTypes.push(type.id);
+      }
+    }
+
+    if (nonUpdatedTypes.length > 0)
+      warn(`You chose not to update ${nonUpdatedTypes.join(', ')}.`);
+    if (updatedTypes.length > 0)
+      warn(
+        `You've updated some types (${updatedTypes.join(
+          ', '
+        )}). To ensure Prismic uses this new model, go make a small change to a page and publish it. e.g. https://wellcomecollection.prismic.io/documents~k=pages&w=test&b=working&c=unclassified&l=en-gb/YB3RoRIAACQATXTn/`
+      );
+  }
+}
+
+run();
+
+export {};

--- a/prismic-model/package.json
+++ b/prismic-model/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "sliceAnalysis": "ts-node sliceAnalysis",
     "deployType": "ts-node deployType",
+    "deployTypes": "ts-node deployTypes",
     "diffCustomTypes": "ts-node diffCustomTypes",
     "downloadSnapshot": "ts-node downloadSnapshot",
     "lintPrismicData": "ts-node lintPrismicData",


### PR DESCRIPTION
## Who is this for?
Devs who play with Prismic models
Relates to #9953 

## What is it doing for them?
1. Allows for all types to be run through at the same time instead of having to manually do them one by one
2. Adds a prompt when an update happens to encourage the dev to go save a doc in Prismic, as that's needed to have the changes be taken into account.

Looks like this if two types have a change, user gets asked to approve one at a time:
<img width="1188" alt="Screenshot 2023-06-19 at 15 07 41" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/17b91791-0f8f-4e23-a581-7fa3114a9ac1">

When only some get approved and others not:
<img width="1064" alt="Screenshot 2023-06-19 at 15 24 47" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/0a8abe1a-2d55-496d-a919-3f648dc5e8a8">


Individual updates still work but user gets prompted:
<img width="727" alt="Screenshot 2023-06-19 at 15 15 31" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/7bc195d0-a9ac-4531-9ce4-d11cf6043000">

