### PR TITLE
Rotate highlights

### DIFF
--- a/catalogue/webapp/components/IIIFViewer/MainViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/MainViewer.tsx
@@ -85,7 +85,7 @@ type ItemRendererProps = {
   };
 };
 
-function getHighlightStartPositions({
+function getOverlayTopLeft({
   imageContainerRect,
   imageRect,
   rotation,
@@ -188,7 +188,7 @@ function getPositionData({
       const y = coords ? Math.round(Number(coords[1]) * scale) : 0;
       const w = coords ? Math.round(Number(coords[2]) * scale) : 0;
       const h = coords ? Math.round(Number(coords[3]) * scale) : 0;
-      const { overlayTop, overlayLeft } = getHighlightStartPositions({
+      const { overlayTop, overlayLeft } = getOverlayTopLeft({
         imageContainerRect,
         imageRect,
         rotation: (matchingRotation?.rotation || 0) as RotationValue,

--- a/catalogue/webapp/components/IIIFViewer/MainViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/MainViewer.tsx
@@ -46,6 +46,8 @@ type SearchTermHighlightProps = {
   rotation: number;
 };
 
+type RotationValue = 0 | 90 | 180 | 270;
+
 const SearchTermHighlight = styled.div<SearchTermHighlightProps>`
   background: ${props => props.theme.color('accent.purple')};
   opacity: 0.5;
@@ -92,7 +94,7 @@ function getHighlightStartPositions({
 }: {
   imageContainerRect: DOMRect;
   imageRect: DOMRect;
-  rotation?: 0 | 90 | 180 | 270;
+  rotation: RotationValue;
   x: number;
   y: number;
 }): {
@@ -135,7 +137,7 @@ function getScale({
 }: {
   imageRect: DOMRect;
   currentCanvas: TransformedCanvas;
-  rotation: 0 | 90 | 180 | 270;
+  rotation: RotationValue;
 }): number {
   if (!rotation || rotation === 180) {
     return imageRect && currentCanvas.width
@@ -178,7 +180,7 @@ function getPositionData({
       const scale = getScale({
         imageRect,
         currentCanvas,
-        rotation: matchingRotation?.rotation,
+        rotation: (matchingRotation?.rotation || 0) as RotationValue,
       });
       const coordsMatch = resource.on.match(/(#xywh=)(.*)/);
       const coords = coordsMatch && coordsMatch[2].split(',');
@@ -189,7 +191,7 @@ function getPositionData({
       const { overlayTop, overlayLeft } = getHighlightStartPositions({
         imageContainerRect,
         imageRect,
-        rotation: matchingRotation?.rotation,
+        rotation: (matchingRotation?.rotation || 0) as RotationValue,
         x,
         y,
       });

--- a/catalogue/webapp/components/IIIFViewer/MainViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/MainViewer.tsx
@@ -17,7 +17,9 @@ import { convertIiifUriToInfoUri } from '@weco/catalogue/utils/convert-iiif-uri'
 import { missingAltTextMessage } from '@weco/catalogue/services/wellcome/catalogue/works';
 import { font } from '@weco/common/utils/classnames';
 import { SearchResults } from '@weco/catalogue/services/iiif/types/search/v3';
-import ItemViewerContext from '../ItemViewerContext/ItemViewerContext';
+import ItemViewerContext, {
+  RotatedImage,
+} from '../ItemViewerContext/ItemViewerContext';
 import ImageViewer from './ImageViewer';
 import { TransformedCanvas } from '@weco/catalogue/types/manifest';
 import { fetchCanvasOcr } from '@weco/catalogue/services/iiif/fetch/canvasOcr';
@@ -61,7 +63,7 @@ type ItemRendererProps = {
     scrollVelocity: number;
     canvases: TransformedCanvas[];
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    rotatedImages: any[];
+    rotatedImages: RotatedImage[];
     errorHandler?: () => void;
     restrictedService: AuthExternalService | undefined;
   };


### PR DESCRIPTION
Fixes #9815

Takes the image rotation into account, so that search term highlights are always in the correct place:
<img width="774" alt="Screenshot 2023-06-19 at 15 40 54" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/6051896/fe05b91e-2db2-4840-88c5-f52f50be0cf5">
<img width="1017" alt="Screenshot 2023-06-19 at 15 29 09" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/6051896/22e94792-5924-4e4c-ab44-f5688d1d813c">
<img width="1057" alt="Screenshot 2023-06-19 at 15 40 15" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/6051896/75c9721c-8fe7-478d-abe2-9bea4a5f6ac6">
<img width="787" alt="Screenshot 2023-06-19 at 15 40 36" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/6051896/528fc916-875c-4a13-b40c-df37f39c7c2a">
