### PR TITLE
set redirect for the global search from identity app

### DIFF
--- a/cache/edge_lambdas/src/redirector.test.ts
+++ b/cache/edge_lambdas/src/redirector.test.ts
@@ -116,6 +116,11 @@ describe('Query string redirects', () => {
       from: '/images?color=blue&hello=world',
       to: '/search/images?color=blue',
     },
+    {
+      description: 'global search redirect from identity app',
+      from: '/account/search?query=venice,',
+      to: '/search?query=venice,',
+    },
     // Extra testing cases
     {
       description: 'Only forward the specified forwardParams',

--- a/cache/edge_lambdas/src/redirects.ts
+++ b/cache/edge_lambdas/src/redirects.ts
@@ -315,4 +315,10 @@ export const queryRedirects: Record<string, QueryRedirect[]> = {
       ]),
     },
   ],
+  '/account/search': [
+    {
+      redirectPath: '/search',
+      forwardParams: new Set(['query']),
+    },
+  ],
 };

--- a/common/next/next.config.js
+++ b/common/next/next.config.js
@@ -48,15 +48,6 @@ const createConfig =
         }
         return [...rewriteEntries];
       },
-      async redirects() {
-        return [
-          {
-            source: `/account/search`,
-            destination: '/search',
-            permanent: true,
-          },
-        ];
-      },
       webpack: (config, { isServer, webpack }) => {
         config.plugins.push(
           new webpack.NormalModuleReplacementPlugin(

--- a/common/next/next.config.js
+++ b/common/next/next.config.js
@@ -48,6 +48,15 @@ const createConfig =
         }
         return [...rewriteEntries];
       },
+      async redirects() {
+        return [
+          {
+            source: `/account/search`,
+            destination: '/search',
+            permanent: true,
+          },
+        ];
+      },
       webpack: (config, { isServer, webpack }) => {
         config.plugins.push(
           new webpack.NormalModuleReplacementPlugin(


### PR DESCRIPTION
## Who is this for?
users of the app who wish to do a global search from the account pages

## What is it doing for them?
correctly redirects the user out of the sub route.
Note, this does not occur with the other apps because they do not use the subroutes in production.

https://github.com/wellcomecollection/platform/issues/5673