### PR TITLE
Tidy up of headings on event series

### DIFF
--- a/content/webapp/pages/event-series/[eventSeriesId].tsx
+++ b/content/webapp/pages/event-series/[eventSeriesId].tsx
@@ -157,7 +157,7 @@ const EventSeriesPage: FunctionComponent<Props> = ({
         contributors={series.contributors}
       >
         {upcomingEvents.length > 0 ? (
-          <SearchResults items={upcomingEvents} title="What's next" />
+          <SearchResults items={upcomingEvents} title="Coming up" />
         ) : (
           <h2 className="h2">
             No events scheduled at the moment, check back soon…

--- a/content/webapp/pages/event-series/[eventSeriesId].tsx
+++ b/content/webapp/pages/event-series/[eventSeriesId].tsx
@@ -164,7 +164,7 @@ const EventSeriesPage: FunctionComponent<Props> = ({
 
         {pastEvents.length > 0 && (
           <Space v={{ size: 'xl', properties: ['margin-top'] }}>
-            <SearchResults items={pastEvents} title="What we've done before" />
+            <SearchResults items={pastEvents} title="Past events" />
           </Space>
         )}
       </ContentPage>

--- a/content/webapp/pages/event-series/[eventSeriesId].tsx
+++ b/content/webapp/pages/event-series/[eventSeriesId].tsx
@@ -159,9 +159,7 @@ const EventSeriesPage: FunctionComponent<Props> = ({
         {upcomingEvents.length > 0 ? (
           <SearchResults items={upcomingEvents} title="Coming up" />
         ) : (
-          <h2 className="h2">
-            No events scheduled at the moment, check back soon…
-          </h2>
+          <h2 className="h2">No upcoming events</h2>
         )}
 
         {pastEvents.length > 0 && (

--- a/content/webapp/utils/event-series.ts
+++ b/content/webapp/utils/event-series.ts
@@ -50,7 +50,7 @@ export function isUpcoming<T extends HasTimes>(event: T): boolean {
 
 // Returns all the upcoming events from a given list.
 //
-// This is used to populate the "What's next" list on event series pages.
+// This is used to populate the "Coming up" list on event series pages.
 //
 export function getUpcomingEvents<T extends HasTimes>(events: T[]): T[] {
   return events.filter(isUpcoming).sort((a, b) => {


### PR DESCRIPTION
## Who is this for?
Issue #9960
Users looking at our Event Series pages
For example, [Land Body Ecologies Festival](https://wellcomecollection.org/event-series/ZFt3UBQAAMFmEIya)

## What is it doing for them?
Using plainer language and making the text more scannable. 

| Current | Changed to | 
| ------------- | ------------- |
| What's next | Coming up  |
| No events scheduled at the moment, check back soon... | No upcoming events | 
| What we've done before | Past events | 

![Screenshot 2023-06-21 at 16 34 47](https://github.com/wellcomecollection/wellcomecollection.org/assets/81175151/f390a27e-d929-4163-a2b6-bca165716fd8)

![Screenshot 2023-06-21 at 16 35 26](https://github.com/wellcomecollection/wellcomecollection.org/assets/81175151/72c082e8-68a3-4a1a-b79b-8762ff76f1c5)
