### PR TITLE
Remove the old iiif-test.wc.org toggle

### DIFF
--- a/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
+++ b/catalogue/webapp/components/ExpandedImage/ExpandedImage.tsx
@@ -25,7 +25,6 @@ import LL from '@weco/common/views/components/styled/LL';
 import { toLink as itemLink } from '../ItemLink';
 import { toLink as imageLink } from '../ImageLink';
 import { trackSegmentEvent } from '@weco/common/services/conversion/track';
-import { useToggles } from '@weco/common/server-data/Context';
 
 type Props = {
   image: ImageType | undefined;
@@ -193,8 +192,6 @@ const ExpandedImage: FunctionComponent<Props> = ({
     }
   }, [workId, currentImageId]);
 
-  const toggles = useToggles();
-
   useEffect(() => {
     // This downloads the IIIF manifest and tries to find the image in the canvases.
     // With upcoming work on IIIF identifiers, we should be able to provide the
@@ -206,8 +203,7 @@ const ExpandedImage: FunctionComponent<Props> = ({
     ) => {
       const imageLocationBase = imageUrl.replace('/info.json', '');
       const iiifManifest = await fetchIIIFPresentationManifest(
-        manifestLocation,
-        toggles
+        manifestLocation
       );
       const transformedManifest =
         iiifManifest && transformManifest(iiifManifest);

--- a/catalogue/webapp/components/Work/Work.tsx
+++ b/catalogue/webapp/components/Work/Work.tsx
@@ -116,8 +116,7 @@ type Props = {
 
 const Work: FunctionComponent<Props> = ({ work, apiUrl }) => {
   const { worksTabbedNav } = useToggles();
-  const toggles = useToggles();
-  const transformedIIIFManifest = useTransformedManifest(work, toggles);
+  const transformedIIIFManifest = useTransformedManifest(work);
 
   const isArchive = !!(
     work.parts.length ||

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -46,7 +46,6 @@ import {
 } from '../../utils/requesting';
 import { themeValues } from '@weco/common/views/themes/config';
 import { formatDuration } from '@weco/common/utils/format-date';
-import { useToggles } from '@weco/common/server-data/Context';
 
 type Props = {
   work: Work;
@@ -60,7 +59,7 @@ const WorkDetails: FunctionComponent<Props> = ({
   const isArchive = useContext(IsArchiveContext);
   const itemUrl = itemLink({ workId: work.id, source: 'work', props: {} });
   const transformedIIIFImage = useTransformedIIIFImage(work);
-  const transformedIIIFManifest = useTransformedManifest(work, useToggles());
+  const transformedIIIFManifest = useTransformedManifest(work);
   const {
     video,
     iiifCredit,

--- a/catalogue/webapp/components/WorkHeader/WorkHeader.tsx
+++ b/catalogue/webapp/components/WorkHeader/WorkHeader.tsx
@@ -16,7 +16,6 @@ import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
 import useTransformedManifest from '../../hooks/useTransformedManifest';
 import Divider from '@weco/common/views/components/Divider/Divider';
 import IsArchiveContext from '../IsArchiveContext/IsArchiveContext';
-import { useToggles } from '@weco/common/server-data/Context';
 
 const WorkHeaderContainer = styled.div`
   display: flex;
@@ -38,7 +37,7 @@ const WorkHeader: FunctionComponent<Props> = ({ work }) => {
   const productionDates = getProductionDates(work);
   const archiveLabels = getArchiveLabels(work);
   const cardLabels = getCardLabels(work);
-  const manifestData = useTransformedManifest(work, useToggles());
+  const manifestData = useTransformedManifest(work);
   const { collectionManifestsCount } = { ...manifestData };
 
   const primaryContributorLabel = work.contributors.find(

--- a/catalogue/webapp/hooks/useTransformedManifest.ts
+++ b/catalogue/webapp/hooks/useTransformedManifest.ts
@@ -5,13 +5,11 @@ import { transformManifest } from '../services/iiif/transformers/manifest';
 import { fetchIIIFPresentationManifest } from '../services/iiif/fetch/manifest';
 import { TransformedManifest } from '../types/manifest';
 import { getDigitalLocationOfType } from '../utils/works';
-import { Toggles } from '@weco/toggles';
 
 const manifestPromises: Map<string, Promise<Manifest | undefined>> = new Map();
 const cachedTransformedManifest: Map<string, TransformedManifest> = new Map();
 const useTransformedManifest = (
-  work: Work,
-  toggles: Toggles
+  work: Work
 ): TransformedManifest | undefined => {
   const [transformedManifest, setTransformedManifest] = useState<
     TransformedManifest | undefined
@@ -41,7 +39,7 @@ const useTransformedManifest = (
         if (!iiifPresentationLocation) return;
         manifestPromises.set(
           work.id,
-          fetchIIIFPresentationManifest(iiifPresentationLocation.url, toggles)
+          fetchIIIFPresentationManifest(iiifPresentationLocation.url)
         );
         const iiifManifest = await manifestPromises.get(work.id);
         iiifManifest && transformAndUpdate(iiifManifest, work.id);

--- a/catalogue/webapp/pages/works/[workId]/download.tsx
+++ b/catalogue/webapp/pages/works/[workId]/download.tsx
@@ -201,10 +201,7 @@ export const getServerSideProps: GetServerSideProps<
   const manifestLocation = getDigitalLocationOfType(work, 'iiif-presentation');
   const iiifManifest =
     manifestLocation &&
-    (await fetchIIIFPresentationManifest(
-      manifestLocation.url,
-      serverData.toggles
-    ));
+    (await fetchIIIFPresentationManifest(manifestLocation.url));
   const transformedManifest = iiifManifest && transformManifest(iiifManifest);
 
   return {

--- a/catalogue/webapp/pages/works/[workId]/items.tsx
+++ b/catalogue/webapp/pages/works/[workId]/items.tsx
@@ -376,10 +376,7 @@ export const getServerSideProps: GetServerSideProps<
   );
   const iiifManifest =
     iiifPresentationLocation &&
-    (await fetchIIIFPresentationManifest(
-      iiifPresentationLocation.url,
-      serverData.toggles
-    ));
+    (await fetchIIIFPresentationManifest(iiifPresentationLocation.url));
 
   const transformedManifest = iiifManifest && transformManifest(iiifManifest);
 
@@ -396,8 +393,7 @@ export const getServerSideProps: GetServerSideProps<
       const selectedCollectionManifestLocation = manifests?.[manifestIndex]?.id;
       const selectedCollectionManifest = selectedCollectionManifestLocation
         ? await fetchIIIFPresentationManifest(
-            selectedCollectionManifestLocation,
-            serverData.toggles
+            selectedCollectionManifestLocation
           )
         : undefined;
       const firstChildTransformedManifest =

--- a/catalogue/webapp/services/iiif/fetch/manifest.ts
+++ b/catalogue/webapp/services/iiif/fetch/manifest.ts
@@ -1,5 +1,4 @@
 import { Manifest } from '@iiif/presentation-3';
-import { Toggles } from '@weco/toggles';
 
 async function getIIIFManifest(url: string): Promise<Manifest> {
   const resp = await fetch(url);
@@ -20,19 +19,11 @@ async function getIIIFManifest(url: string): Promise<Manifest> {
 }
 
 export async function fetchIIIFPresentationManifest(
-  location: string,
-  toggles: Toggles
+  location: string
 ): Promise<Manifest | undefined> {
   // TODO once we're using v3 everywhere,
   // we'll want the catalogue API to return v3, then we can stop doing the following
-  const v3Location = toggles.useIIIFTest
-    ? location
-        .replace('/v2/', '/v3/')
-        .replace(
-          'iiif.wellcomecollection.org',
-          'iiif-test.wellcomecollection.org'
-        )
-    : location.replace('/v2/', '/v3/');
+  const v3Location = location.replace('/v2/', '/v3/');
 
   const iiifManifest = await getIIIFManifest(v3Location);
 

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -57,14 +57,6 @@ const toggles = {
       type: 'experimental',
     },
     {
-      id: 'useIIIFTest',
-      title: 'Use iiif-test.wellcomecollection.org for IIIF URLs',
-      initialValue: false,
-      description:
-        'Fetch IIIF manifests from iiif-test.wellcomecollection.org for new DLCS testing.',
-      type: 'experimental',
-    },
-    {
       id: 'visualStories',
       title: 'Visual Stories Prototype',
       initialValue: false,


### PR DESCRIPTION
This is for #9723 – we no longer need this toggle because the DLCS upgrade is done, and it seems to be causing errors for a few users who still have the toggle enabled. Removing it should fix these issues.