### PR TITLE
An event is upcoming if it hasn't finished yet

### DIFF
--- a/content/webapp/utils/event-series.test.ts
+++ b/content/webapp/utils/event-series.test.ts
@@ -23,6 +23,12 @@ function createEvent({
 }
 
 describe('isUpcoming', () => {
+  const mondayAt7am = new Date('2007-01-01T07:00:00Z');
+  const mondayAt9am = new Date('2007-01-01T09:00:00Z');
+  const mondayAt11am = new Date('2007-01-01T11:00:00Z');
+
+  const tuesdayAt7am = new Date('2007-01-02T07:00:00Z');
+
   it('an event which finished in the past is not upcoming', () => {
     const event = createEvent({
       startDateTime: new Date(2001, 1, 1, 1, 1, 1),
@@ -32,11 +38,7 @@ describe('isUpcoming', () => {
     expect(isUpcoming(event)).toBeFalsy();
   });
 
-  it('an event which started earlier today and finishes today is not upcoming', () => {
-    const mondayAt7am = new Date('2007-01-01T07:00:00Z');
-    const mondayAt9am = new Date('2007-01-01T09:00:00Z');
-    const mondayAt11am = new Date('2007-01-01T11:00:00Z');
-
+  it('an event which started earlier today and hasn’t finished yet is upcoming', () => {
     jest
       .spyOn(dateUtils, 'isFuture')
       .mockImplementation((d: Date) => d > mondayAt9am);
@@ -46,14 +48,23 @@ describe('isUpcoming', () => {
       endDateTime: mondayAt11am,
     });
 
+    expect(isUpcoming(event)).toBeTruthy();
+  });
+
+  it('an event which started earlier today and is already finished is past', () => {
+    jest
+      .spyOn(dateUtils, 'isFuture')
+      .mockImplementation((d: Date) => d > mondayAt11am);
+
+    const event = createEvent({
+      startDateTime: mondayAt7am,
+      endDateTime: mondayAt9am,
+    });
+
     expect(isUpcoming(event)).toBeFalsy();
   });
 
   it('an event which started earlier today and finishes tomorrow is upcoming', () => {
-    const mondayAt7am = new Date('2007-01-01T07:00:00Z');
-    const mondayAt9am = new Date('2007-01-01T09:00:00Z');
-    const tuesdayAt7am = new Date('2007-01-02T07:00:00Z');
-
     jest
       .spyOn(dateUtils, 'isFuture')
       .mockImplementation((d: Date) => d > mondayAt9am);

--- a/content/webapp/utils/event-series.ts
+++ b/content/webapp/utils/event-series.ts
@@ -7,45 +7,7 @@ import {
 import { HasTimes } from 'types/events';
 
 export function isUpcoming<T extends HasTimes>(event: T): boolean {
-  const startsInFuture = event.times.some(t => isFuture(t.range.startDateTime));
-
-  // This is to account for events that span multiple days.
-  //
-  // e.g. https://wellcomecollection.org/events/YjyVoREAACAAhUvk has two schedule items
-  // on different days:
-  //
-  //    - 22 April @ 15:00
-  //    - 28 April @ 15:00
-  //
-  // The "times" field in Prismic just says "22 Apr – 28 Apr", and only the schedule
-  // field on the event breaks it down in more detail -- which we don't have access to
-  // on the event series page.
-  //
-  // We only check the end date for multi-day events because we want to avoid listing
-  // an event as "upcoming" when it's already in progress (start is past, end is not).
-  // We may show an event as "upcoming" after the final event has finished on the final
-  // day, but it's unavoidable.
-  //
-  // Ideally we'd either have access to the detailed schedule, or break down the times
-  // field with more granularity.  Both of those are a non-trivial amount of work:
-  //
-  //    - The schedule isn't available on the event series page; it's fetched as
-  //      an async request with *another* Prismic query on event pages.
-  //    - The times are used for event cards and don't seem to support multiple entries
-  //      properly.  We want this event to show as "event @ 22 Apr – 28 Apr", but if you put
-  //      in multiple times the site shows "event @ 22 Apr 15:00" in certain places.
-  //      We could make this work properly, but it's more work than I want to do right now.
-  //
-  const earliestStartTime = minDate(
-    event.times.map(t => t.range.startDateTime)
-  );
-  const latestEndTime = maxDate(event.times.map(t => t.range.endDateTime));
-
-  const isMultiDayEvent = !isSameDay(earliestStartTime, latestEndTime, 'UTC');
-  const isUnfinished = isFuture(latestEndTime);
-  const endsOnAFutureDay = isMultiDayEvent && isUnfinished;
-
-  return startsInFuture || endsOnAFutureDay;
+  return event.times.some(t => isFuture(t.range.endDateTime));
 }
 
 // Returns all the upcoming events from a given list.


### PR DESCRIPTION
The naming here is a bit misleading -- we want upcoming or in-progress events to show under the 'Events' header, because if an event isn't upcoming it moves straight to 'Past events'.

This is causing issues for the Land Bodies Ecology Festival, which is already showing Day 1 under 'Past events' even though it's still happening today.

See Slack discussion: https://wellcome.slack.com/archives/C8X9YKM5X/p1687427559655459