### PR TITLE
Remove an unnecessary use of lodash.clonedeep

### DIFF
--- a/catalogue/webapp/package.json
+++ b/catalogue/webapp/package.json
@@ -33,7 +33,6 @@
     "jest-environment-jsdom": "^29.5.0",
     "koa": "^2.5.0",
     "koa-router": "^7.4.0",
-    "lodash.clonedeep": "^4.5.0",
     "next": "^13.2.3",
     "nodemon": "^2.0.22",
     "openseadragon": "^4.0.0",

--- a/catalogue/webapp/utils/iiif/v3/index.ts
+++ b/catalogue/webapp/utils/iiif/v3/index.ts
@@ -21,7 +21,6 @@ import {
   TransformedCanvas,
   AuthClickThroughServiceWithPossibleServiceArray,
 } from '../../../types/manifest';
-import cloneDeep from 'lodash.clonedeep';
 import { getThumbnailImage } from './canvas';
 
 // The label we want to use to distinguish between parts of a multi-volume work
@@ -461,11 +460,7 @@ export function groupStructures(
   items: TransformedCanvas[],
   structures: Range[]
 ): Range[] {
-  // TODO: Do we actually need to clone the `structures` array here?
-  // It doesn't look like it's being mutated anywhere, so can't we just
-  // pass it directly to `reduce`?
-  const clonedStructures: Range[] = cloneDeep(structures);
-  return clonedStructures.reduce(
+  return structures.reduce(
     (acc, structure) => {
       if (!structure.items) return acc;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14582,11 +14582,6 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash.clonedeep@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
-  integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
-
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"


### PR DESCRIPTION
The only thing that's being modified in the reduce() loop is the accumulator `acc`; we don't need to clone the `structures` variable here, as it's an immutable array.