### PR TITLE
Make captioned image captions multiline

### DIFF
--- a/common/views/components/Caption/Caption.tsx
+++ b/common/views/components/Caption/Caption.tsx
@@ -10,6 +10,10 @@ const CaptionText = styled(Space).attrs({
 })`
   text-align: left;
   border-left: 1px solid currentColor;
+
+  p:last-child {
+    margin-bottom: 0;
+  }
 `;
 
 const CaptionWrapper = styled.div`

--- a/common/views/components/Caption/Caption.tsx
+++ b/common/views/components/Caption/Caption.tsx
@@ -10,10 +10,6 @@ const CaptionText = styled(Space).attrs({
 })`
   text-align: left;
   border-left: 1px solid currentColor;
-
-  p {
-    display: inline;
-  }
 `;
 
 const CaptionWrapper = styled.div`

--- a/prismic-model/src/parts/captioned-image.ts
+++ b/prismic-model/src/parts/captioned-image.ts
@@ -6,7 +6,6 @@ export default function () {
   return {
     image: image('Image'),
     caption: multiLineText('Caption'),
-
     hasRoundedCorners: boolean('round image corners'),
   };
 }

--- a/prismic-model/src/parts/captioned-image.ts
+++ b/prismic-model/src/parts/captioned-image.ts
@@ -1,11 +1,12 @@
-import { singleLineText } from './text';
+import { multiLineText } from './text';
 import image from './image';
 import boolean from './boolean';
 
 export default function () {
   return {
     image: image('Image'),
-    caption: singleLineText('Caption'),
+    caption: multiLineText('Caption'),
+
     hasRoundedCorners: boolean('round image corners'),
   };
 }


### PR DESCRIPTION
## Who is this for?
Editors have been requesting this as they often have too much copy for captioned images and it makes it difficult to read when it's just in one paragraphs.

## What is it doing for them?
It's currently possible to create break-lines, but that's a hack, might as well make this officially multi-line!
I'll deploy the prismic model changes once this is approved and merged in.