### PR TITLE
Rename Collection venue slice on UI

### DIFF
--- a/prismic-model/src/parts/body.ts
+++ b/prismic-model/src/parts/body.ts
@@ -100,7 +100,7 @@ export default {
           },
         },
       }),
-      collectionVenue: slice('Collection venue', {
+      collectionVenue: slice("Collection venue's hours", {
         nonRepeat: {
           content: documentLink('Content item', {
             linkedType: 'collection-venue',


### PR DESCRIPTION
## Who is this for?
Editorial and general confusion

## What is it doing for them?
There is a Collection Venue Content Type, and a Collection Venue Slice. Everytime we talk about them we get confused, so I'm opting for a name change on the UI; it makes it clearer and also makes its _purpose_ clearer. The ID remaining the same, this should be inconsequential. 