### PR TITLE
Simplify the data we pass to concept pages

### DIFF
--- a/catalogue/webapp/pages/concepts/[conceptId].tsx
+++ b/catalogue/webapp/pages/concepts/[conceptId].tsx
@@ -46,28 +46,11 @@ import {
   getDisplayIdentifierType,
   queryParams,
 } from '@weco/catalogue/utils/concepts';
+import { emptyResultList } from '@weco/catalogue/services/wellcome';
 
-const emptyImageResults: CatalogueResultsList<ImageType> = {
-  type: 'ResultList',
-  pageSize: 10,
-  totalPages: 0,
-  totalResults: 0,
-  results: [],
-  nextPage: null,
-  prevPage: null,
-  _requestUrl: '',
-};
+const emptyImageResults: CatalogueResultsList<ImageType> = emptyResultList();
 
-const emptyWorkResults: CatalogueResultsList<WorkType> = {
-  type: 'ResultList',
-  pageSize: 10,
-  totalPages: 0,
-  totalResults: 0,
-  results: [],
-  nextPage: null,
-  prevPage: null,
-  _requestUrl: '',
-};
+const emptyWorkResults: CatalogueResultsList<WorkType> = emptyResultList();
 
 const tabOrder = ['by', 'in', 'about'];
 

--- a/catalogue/webapp/pages/search/index.tsx
+++ b/catalogue/webapp/pages/search/index.tsx
@@ -23,6 +23,7 @@ import { Image, Work } from '@weco/catalogue/services/wellcome/catalogue/types';
 import {
   getQueryResults,
   getQueryPropertyValue,
+  ReturnedResults,
 } from '@weco/common/utils/search';
 import {
   decodeQuery,
@@ -51,16 +52,11 @@ const fromQuery: (params: ParsedUrlQuery) => CodecMapProps = params => {
 };
 
 type Props = {
-  works?: ResultsProps<Work>;
-  images?: ResultsProps<Image>;
-  stories?: ResultsProps<Article>;
+  works?: ReturnedResults<Work>;
+  images?: ReturnedResults<Image>;
+  stories?: ReturnedResults<Article>;
   query: Query;
   pageview: Pageview;
-};
-
-type ResultsProps<T> = {
-  pageResults: T[];
-  totalResults: number;
 };
 
 type SeeMoreButtonProps = {

--- a/common/utils/search.ts
+++ b/common/utils/search.ts
@@ -17,7 +17,7 @@ type ApiError = {
   label: string;
 };
 
-type ReturnedResults<T> = {
+export type ReturnedResults<T> = {
   pageResults: T[];
   totalResults: number;
 };


### PR DESCRIPTION
This refactoring fell out of https://github.com/wellcomecollection/wellcomecollection.org/issues/8339 – I was mucking about with aggregations and it was a bit annoying to have to tell the concept page "here is the type of aggregation, even though you never use it".

As a bonus, the `getQueryResults` method we're using will drop a log if any of the API requests we make to populate the concept page fail.

(It does reduce the data we send to the page, but that's incidental and extremely slight – maybe a kilobyte or two at most. The big gains will come in the next PR.)