### PR TITLE
Titled Text List slice changes

### DIFF
--- a/prismic-model/src/parts/body.ts
+++ b/prismic-model/src/parts/body.ts
@@ -138,14 +138,13 @@ export default {
           linkText: text('Button text'),
         },
       }),
-      titledTextList: slice('Titled text list', {
+      titledTextList: slice('Descriptive links list', {
         repeat: {
           title: heading('Title', { level: 3 }),
           text: multiLineText('Text', {
-            extraTextOptions: ['heading4', 'list-item'],
+            extraTextOptions: ['list-item'],
           }),
           link: link('Link'),
-          label: documentLink('tag', { linkedType: 'labels' }),
         },
       }),
       contentList: slice('(β) Content list', {

--- a/prismic-model/src/parts/body.ts
+++ b/prismic-model/src/parts/body.ts
@@ -141,9 +141,7 @@ export default {
       titledTextList: slice('Descriptive links list', {
         repeat: {
           title: heading('Title', { level: 3 }),
-          text: multiLineText('Text', {
-            extraTextOptions: ['list-item'],
-          }),
+          text: multiLineText('Text'),
           link: link('Link'),
         },
       }),

--- a/prismic-model/src/parts/body.ts
+++ b/prismic-model/src/parts/body.ts
@@ -147,7 +147,7 @@ export default {
           link: link('Link'),
         },
       }),
-      contentList: slice('(β) Content list', {
+      contentList: slice('Content list', {
         nonRepeat: {
           title,
         },
@@ -168,7 +168,7 @@ export default {
           }),
         },
       }),
-      searchResults: slice('(β) Search results', {
+      searchResults: slice('Search results', {
         nonRepeat: {
           title,
           query: text('Query'),


### PR DESCRIPTION
## Who is this for?
Maintenance, Editorial

## What is it doing for them?
Relates to #9993 
- Renames slice on UI for clarity of purpose
- Remove unused features from model
- Remove Sharp-S from some component names (we think it was to indicate they were in beta?)