### PR TITLE
Simplify the types we pass to the filters

### DIFF
--- a/catalogue/webapp/services/wellcome/catalogue/filters.ts
+++ b/catalogue/webapp/services/wellcome/catalogue/filters.ts
@@ -1,13 +1,9 @@
 import { palette } from '@weco/catalogue/components/PaletteColorPicker';
 import {
-  CatalogueResultsList,
-  Work,
-  Image,
+  ImageAggregations,
+  WorkAggregations,
 } from '@weco/catalogue/services/wellcome/catalogue/types';
-import {
-  Article,
-  ContentResultsList,
-} from '@weco/catalogue/services/wellcome/content/types/api';
+import { ArticleAggregations } from '@weco/catalogue/services/wellcome/content/types/api';
 import { quoteVal } from '@weco/common/utils/csv';
 import { toHtmlId } from '@weco/common/utils/string';
 import { ImagesProps } from '@weco/catalogue/components/ImagesLink';
@@ -127,17 +123,17 @@ export const filterLabel = ({
 }): string => (count ? `${label} (${formatNumber(count)})` : label);
 
 type WorksFilterProps = {
-  works: CatalogueResultsList<Work>;
+  works: { aggregations?: WorkAggregations };
   props: WorksProps;
 };
 
 type ImagesFilterProps = {
-  images: CatalogueResultsList<Image>;
+  images: { aggregations?: ImageAggregations };
   props: ImagesProps;
 };
 
 type StoriesFilterProps = {
-  stories: ContentResultsList<Article>;
+  stories: { aggregations?: ArticleAggregations };
   props: StoriesProps;
 };
 

--- a/catalogue/webapp/services/wellcome/catalogue/filters.ts
+++ b/catalogue/webapp/services/wellcome/catalogue/filters.ts
@@ -3,7 +3,7 @@ import {
   ImageAggregations,
   WorkAggregations,
 } from '@weco/catalogue/services/wellcome/catalogue/types';
-import { ArticleAggregations } from '@weco/catalogue/services/wellcome/content/types/api';
+import { ArticleAggregations } from '@weco/catalogue/services/wellcome/content/types';
 import { quoteVal } from '@weco/common/utils/csv';
 import { toHtmlId } from '@weco/common/utils/string';
 import { ImagesProps } from '@weco/catalogue/components/ImagesLink';

--- a/catalogue/webapp/services/wellcome/catalogue/fixtures/images-aggregations.ts
+++ b/catalogue/webapp/services/wellcome/catalogue/fixtures/images-aggregations.ts
@@ -1,16 +1,4 @@
-import {
-  CatalogueResultsList,
-  Image,
-} from '@weco/catalogue/services/wellcome/catalogue/types';
-
-const aggregations: CatalogueResultsList<Image> = {
-  type: 'ResultList',
-  pageSize: 10,
-  totalPages: 0,
-  totalResults: 0,
-  results: [],
-  nextPage: null,
-  prevPage: null,
+const aggregations = {
   aggregations: {
     license: {
       buckets: [
@@ -74,7 +62,6 @@ const aggregations: CatalogueResultsList<Image> = {
     },
     type: 'Aggregations',
   },
-  _requestUrl: 'https://api.wellcomecollection.org/catalogue/v2/images',
 };
 
 export default aggregations;

--- a/catalogue/webapp/services/wellcome/catalogue/fixtures/works-aggregations.ts
+++ b/catalogue/webapp/services/wellcome/catalogue/fixtures/works-aggregations.ts
@@ -1,16 +1,4 @@
-import {
-  CatalogueResultsList,
-  Work,
-} from '@weco/catalogue/services/wellcome/catalogue/types';
-
-const aggregations: CatalogueResultsList<Work> = {
-  type: 'ResultList',
-  pageSize: 10,
-  totalPages: 13771,
-  totalResults: 137701,
-  nextPage: null,
-  prevPage: null,
-  results: [],
+const aggregations = {
   aggregations: {
     workType: {
       buckets: [
@@ -2504,7 +2492,6 @@ const aggregations: CatalogueResultsList<Work> = {
     },
     type: 'Aggregations',
   },
-  _requestUrl: 'https://api.wellcomecollection.org/catalogue/v2/works',
 };
 
 export default aggregations;

--- a/catalogue/webapp/services/wellcome/catalogue/types/aggregations.ts
+++ b/catalogue/webapp/services/wellcome/catalogue/types/aggregations.ts
@@ -1,0 +1,24 @@
+import {
+  WellcomeAggregation,
+  UnidentifiedBucketData,
+} from '@weco/catalogue/services/wellcome';
+
+export type WorkAggregations = {
+  workType: WellcomeAggregation;
+  availabilities: WellcomeAggregation;
+  languages?: WellcomeAggregation;
+  'genres.label'?: WellcomeAggregation<UnidentifiedBucketData>;
+  'subjects.label'?: WellcomeAggregation<UnidentifiedBucketData>;
+  'contributors.agent.label'?: WellcomeAggregation<UnidentifiedBucketData>;
+  type: 'Aggregations';
+};
+
+export type ImageAggregations = {
+  license?: WellcomeAggregation;
+  'source.genres.label'?: WellcomeAggregation;
+  'source.subjects.label'?: WellcomeAggregation;
+  'source.contributors.agent.label'?: WellcomeAggregation;
+  type: 'Aggregations';
+};
+
+export type ConceptAggregations = null;

--- a/catalogue/webapp/services/wellcome/catalogue/types/index.ts
+++ b/catalogue/webapp/services/wellcome/catalogue/types/index.ts
@@ -12,15 +12,19 @@ import {
   CatalogueConceptsApiProps,
 } from './api';
 import {
-  UnidentifiedBucketData,
-  WellcomeAggregation,
-  WellcomeResultList,
-} from '../../index';
+  ConceptAggregations,
+  ImageAggregations,
+  WorkAggregations,
+} from './aggregations';
+import { WellcomeResultList } from '../../index';
 
 export type {
   CatalogueWorksApiProps,
   CatalogueImagesApiProps,
   CatalogueConceptsApiProps,
+  ConceptAggregations,
+  ImageAggregations,
+  WorkAggregations,
 };
 
 export type Work = {
@@ -214,26 +218,6 @@ export type Image = {
   visuallySimilar?: Image[];
   aspectRatio?: number;
 };
-
-type WorkAggregations = {
-  workType: WellcomeAggregation;
-  availabilities: WellcomeAggregation;
-  languages?: WellcomeAggregation;
-  'genres.label'?: WellcomeAggregation<UnidentifiedBucketData>;
-  'subjects.label'?: WellcomeAggregation<UnidentifiedBucketData>;
-  'contributors.agent.label'?: WellcomeAggregation<UnidentifiedBucketData>;
-  type: 'Aggregations';
-};
-
-type ImageAggregations = {
-  license?: WellcomeAggregation;
-  'source.genres.label'?: WellcomeAggregation;
-  'source.subjects.label'?: WellcomeAggregation;
-  'source.contributors.agent.label'?: WellcomeAggregation;
-  type: 'Aggregations';
-};
-
-type ConceptAggregations = null;
 
 export type ResultType = Work | Image | Concept;
 

--- a/catalogue/webapp/services/wellcome/content/types/api.ts
+++ b/catalogue/webapp/services/wellcome/content/types/api.ts
@@ -43,7 +43,7 @@ type Contributor = {
   };
 };
 
-type ArticleAggregations = {
+export type ArticleAggregations = {
   format: WellcomeAggregation;
   'contributors.contributor': WellcomeAggregation;
   type: 'Aggregations';

--- a/catalogue/webapp/services/wellcome/content/types/index.ts
+++ b/catalogue/webapp/services/wellcome/content/types/index.ts
@@ -1,4 +1,7 @@
 import { DigitalLocation, Contributor } from '@weco/common/model/catalogue';
+import { ArticleAggregations } from './api';
+
+export type { ArticleAggregations };
 
 // Response objects
 export type ContentApiError = {


### PR DESCRIPTION
We only need the aggregations to build the filters. Passing the full Catalogue/Content result list here is unnecessary, and creates a brittle type dependency – these filters can say what pieces they need, and that's it.

This is another bit of refactoring in advance of https://github.com/wellcomecollection/wellcomecollection.org/issues/8339.