### PR TITLE
Sorting to image search, with options "Relevance", "Oldest to newest", "Newest to oldest"

### DIFF
--- a/cache/modules/cloudfront_policies/locals.tf
+++ b/cache/modules/cloudfront_policies/locals.tf
@@ -62,6 +62,8 @@ locals {
     # From /images -> /search/images.
     # This matches the order in redirects.ts
     "query",
+    "sort",
+    "sortOrder",
     "color",
     "locations.license",
     "source.genres.label",

--- a/catalogue/webapp/components/ImagesLink/index.tsx
+++ b/catalogue/webapp/components/ImagesLink/index.tsx
@@ -28,6 +28,8 @@ const emptyImagesProps: ImagesProps = {
   'source.subjects.label': [],
   'source.contributors.agent.label': [],
   color: undefined,
+  sort: undefined,
+  sortOrder: undefined,
 };
 
 const codecMap = {
@@ -41,6 +43,8 @@ const codecMap = {
   'source.subjects.label': quotedCsvCodec,
   'source.contributors.agent.label': quotedCsvCodec,
   color: maybeStringCodec,
+  sort: maybeStringCodec,
+  sortOrder: maybeStringCodec,
 };
 
 const fromQuery: (params: ParsedUrlQuery) => ImagesProps = params => {

--- a/catalogue/webapp/components/Sort/Sort.tsx
+++ b/catalogue/webapp/components/Sort/Sort.tsx
@@ -28,6 +28,7 @@ type Props = {
   options: Option[];
   jsLessOptions: JsLessOptions;
   defaultValues?: DefaultSortValuesType;
+  darkBg?: boolean;
 };
 
 type JsLessOptions = {
@@ -45,6 +46,7 @@ const Sort: FunctionComponent<Props> = ({
   options,
   jsLessOptions,
   defaultValues,
+  darkBg,
 }) => {
   const router = useRouter();
   const { isEnhanced } = useContext(AppContext);
@@ -123,6 +125,7 @@ const Sort: FunctionComponent<Props> = ({
           options={options}
           isPill
           hideLabel
+          darkBg={darkBg}
         />
       )}
     </Wrapper>

--- a/catalogue/webapp/pages/search/images.tsx
+++ b/catalogue/webapp/pages/search/images.tsx
@@ -62,6 +62,12 @@ const Wrapper = styled(Space).attrs<{ hasNoResults: boolean }>(props => ({
         `}
 `;
 
+const SortPaginationWrapper = styled.div`
+  display: flex;
+  align-items;
+  flex-wrap: wrap;
+`;
+
 const ImagesSearchPage: NextPageWithLayout<Props> = ({
   images,
   imagesRouteProps,
@@ -167,6 +173,33 @@ const ImagesSearchPage: NextPageWithLayout<Props> = ({
             <>
               <PaginationWrapper verticalSpacing="l">
                 <span>{pluralize(images.totalResults, 'result')}</span>
+
+                <SortPaginationWrapper>
+                  <Sort
+                    formId="search-page-form"
+                    options={sortOptions}
+                    jsLessOptions={{
+                      sort: [
+                        {
+                          value: '',
+                          text: 'Relevance',
+                        },
+                        {
+                          value: 'source.production.dates',
+                          text: 'Production dates',
+                        },
+                      ],
+                      sortOrder: [
+                        { value: 'asc', text: 'Ascending' },
+                        { value: 'desc', text: 'Descending' },
+                      ],
+                    }}
+                    defaultValues={{
+                      sort: query.sort,
+                      sortOrder: query.sortOrder,
+                    }}
+                  />
+                </SortPaginationWrapper>
                 <Pagination
                   totalPages={images.totalPages}
                   ariaLabel="Image search pagination"

--- a/catalogue/webapp/pages/search/images.tsx
+++ b/catalogue/webapp/pages/search/images.tsx
@@ -199,13 +199,14 @@ const ImagesSearchPage: NextPageWithLayout<Props> = ({
                       sortOrder: query.sortOrder,
                     }}
                   />
+
+                  <Pagination
+                    totalPages={images.totalPages}
+                    ariaLabel="Image search pagination"
+                    hasDarkBg
+                    isHiddenMobile
+                  />
                 </SortPaginationWrapper>
-                <Pagination
-                  totalPages={images.totalPages}
-                  ariaLabel="Image search pagination"
-                  hasDarkBg
-                  isHiddenMobile
-                />
               </PaginationWrapper>
 
               <main>

--- a/catalogue/webapp/pages/search/images.tsx
+++ b/catalogue/webapp/pages/search/images.tsx
@@ -195,8 +195,8 @@ const ImagesSearchPage: NextPageWithLayout<Props> = ({
                       ],
                     }}
                     defaultValues={{
-                      sort: query.sort,
-                      sortOrder: query.sortOrder,
+                      sort: imagesRouteProps.sort,
+                      sortOrder: imagesRouteProps.sortOrder,
                     }}
                   />
 

--- a/catalogue/webapp/pages/search/images.tsx
+++ b/catalogue/webapp/pages/search/images.tsx
@@ -64,7 +64,7 @@ const Wrapper = styled(Space).attrs<{ hasNoResults: boolean }>(props => ({
 
 const SortPaginationWrapper = styled.div`
   display: flex;
-  align-items;
+  align-items: center;
   flex-wrap: wrap;
 `;
 

--- a/catalogue/webapp/pages/search/images.tsx
+++ b/catalogue/webapp/pages/search/images.tsx
@@ -198,6 +198,7 @@ const ImagesSearchPage: NextPageWithLayout<Props> = ({
                       sort: imagesRouteProps.sort,
                       sortOrder: imagesRouteProps.sortOrder,
                     }}
+                    darkBg
                   />
 
                   <Pagination

--- a/catalogue/webapp/pages/search/images.tsx
+++ b/catalogue/webapp/pages/search/images.tsx
@@ -11,6 +11,7 @@ import SearchContext from '@weco/common/views/components/SearchContext/SearchCon
 import Pagination from '@weco/common/views/components/Pagination/Pagination';
 import SearchFilters from '@weco/catalogue/components/SearchFilters';
 import PaginationWrapper from '@weco/common/views/components/styled/PaginationWrapper';
+import Sort from '@weco/catalogue/components/Sort/Sort';
 
 // Utils & Helpers
 import convertUrlToString from '@weco/common/utils/convert-url-to-string';
@@ -81,6 +82,21 @@ const ImagesSearchPage: NextPageWithLayout<Props> = ({
     filters: filters.map(f => f.id),
     queryParams: Object.keys(query),
   });
+
+  const sortOptions = [
+    {
+      value: '',
+      text: 'Relevance',
+    },
+    {
+      value: 'source.production.dates.asc',
+      text: 'Oldest to newest',
+    },
+    {
+      value: 'source.production.dates.desc',
+      text: 'Newest to oldest',
+    },
+  ];
 
   return (
     <>

--- a/common/views/components/Select/Select.tsx
+++ b/common/views/components/Select/Select.tsx
@@ -15,6 +15,7 @@ type Props = {
   onChange: (event: ChangeEvent<HTMLSelectElement>) => void;
   isPill?: boolean;
   form?: string;
+  darkBg?: boolean;
 };
 
 const Select: FunctionComponent<Props> = ({
@@ -26,9 +27,15 @@ const Select: FunctionComponent<Props> = ({
   onChange,
   isPill,
   form,
+  darkBg,
 }) => {
   return (
-    <SelectContainer label={label} hideLabel={hideLabel} isPill={isPill}>
+    <SelectContainer
+      label={label}
+      hideLabel={hideLabel}
+      isPill={isPill}
+      darkBg={darkBg}
+    >
       <select name={name} onChange={onChange} value={value} form={form}>
         {options.map(option => {
           return (

--- a/common/views/components/SelectContainer/SelectContainer.tsx
+++ b/common/views/components/SelectContainer/SelectContainer.tsx
@@ -30,14 +30,15 @@ const StyledSelect = styled.div.attrs({
     font-weight: inherit;
     appearance: none;
     padding: 8px 42px 8px 16px;
-    border: 1px solid ${props => props.theme.color('neutral.600')};
+    border: 1px solid
+      ${props =>
+        props.theme.color(props.darkBg ? 'neutral.300' : 'neutral.600')};
     border-radius: ${props =>
       props.isPill ? 20 : props.theme.borderRadiusUnit}px;
-    background-color: ${props =>
-      props.theme.color(props.darkBg ? 'white' : 'transparent')};
+    background-color: ${props => props.theme.color('transparent')};
     color: ${props =>
       props.theme.color(
-        'black'
+        props.darkBg ? 'white' : 'black'
       )}; /* This avoids the default blue links on iOS */
     width: 100%;
     ${props => (props.isPill ? 'line-height: 1;' : '')}


### PR DESCRIPTION
## Who is this for?
Image foragers, seeking to chronologically sort their search

Part of [#5668](https://github.com/wellcomecollection/platform/issues/5668)

## What is it doing for them?
Add sorting to image search, with the options "Relevance", "Oldest to newest", "Newest to oldest".

Sorting drop down matches existing `/stories` and `/works` with transparent pill. Screenshots below.

![Full view](https://github.com/wellcomecollection/wellcomecollection.org/assets/81175151/a6fb392e-0c13-466d-a3c3-f395bbaf0020)

![Dropdown options](https://github.com/wellcomecollection/wellcomecollection.org/assets/81175151/6b87d9f0-7412-4f23-9a9c-f82e3c4558c6)

![Oldest to newest sort](https://github.com/wellcomecollection/wellcomecollection.org/assets/81175151/239c47ce-dca1-408b-80e8-d6ef94ab3ec5)

![Newest to oldest sort selected highlight](https://github.com/wellcomecollection/wellcomecollection.org/assets/81175151/8503af3a-d523-40ac-a655-3ed6eb01229c)

![Mobile](https://github.com/wellcomecollection/wellcomecollection.org/assets/81175151/4806dcaf-17c7-4293-b14c-5d1b3dd4bbd7)
