### PR TITLE
use SiteSection type across platform and update it

### DIFF
--- a/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
+++ b/catalogue/webapp/components/SearchPageLayout/SearchPageLayout.tsx
@@ -14,10 +14,10 @@ import { pageDescriptions } from '@weco/common/data/microcopy';
 import { getQueryPropertyValue } from '@weco/common/utils/search';
 import { ApiToolbarLink } from '@weco/common/views/components/ApiToolbar';
 import SearchNavigation from './SearchNavigation';
+import { SiteSection } from '@weco/common/views/components/PageLayout/PageLayout';
 
 type PageLayoutMetadata = {
   openGraphType: 'website';
-  siteSection: null;
   jsonLd: { '@type': 'WebPage' };
   hideNewsletterPromo: true;
   excludeRoleMain: true;
@@ -27,6 +27,7 @@ type PageLayoutMetadata = {
     pathname: string;
     query: Record<string, string | string[] | undefined>;
   };
+  siteSection?: SiteSection;
   apiToolbarLinks?: ApiToolbarLink[];
 };
 
@@ -50,7 +51,6 @@ const SearchLayout: FunctionComponent<SearchLayoutProps> = ({
   const basePageMetadata: PageLayoutMetadata = {
     apiToolbarLinks,
     openGraphType: 'website',
-    siteSection: null, // We don't want search to display under any menu section
     jsonLd: { '@type': 'WebPage' },
     hideNewsletterPromo: true,
     excludeRoleMain: true,

--- a/common/views/components/ErrorPage/ErrorPage.tsx
+++ b/common/views/components/ErrorPage/ErrorPage.tsx
@@ -113,7 +113,6 @@ const ErrorPage: FunctionComponent<Props> = ({ statusCode = 500, title }) => {
       jsonLd={{ '@type': 'WebPage' }}
       openGraphType="website"
       hideNewsletterPromo={true}
-      siteSection={null}
     >
       <Space v={{ size: headerSpaceSize, properties: ['padding-bottom'] }}>
         <PageHeader

--- a/common/views/components/Header/Header.tsx
+++ b/common/views/components/Header/Header.tsx
@@ -33,6 +33,7 @@ import DesktopSignIn from './DesktopSignIn';
 import MobileSignIn from './MobileSignIn';
 import HeaderSearch from './HeaderSearch';
 import { searchPlaceholderText } from '@weco/common/data/microcopy';
+import { SiteSection } from '../PageLayout/PageLayout';
 
 const NoJSIconWrapper = styled.div`
   padding: 5px 8px 0;
@@ -42,11 +43,11 @@ const NoJSIconWrapper = styled.div`
 export type NavLink = {
   href: string;
   title: string;
-  siteSection?: string;
+  siteSection?: SiteSection;
 };
 
 type Props = {
-  siteSection: string | null;
+  siteSection: SiteSection | null;
   customNavLinks?: NavLink[];
   isMinimalHeader?: boolean;
 };

--- a/common/views/components/Header/Header.tsx
+++ b/common/views/components/Header/Header.tsx
@@ -47,7 +47,7 @@ export type NavLink = {
 };
 
 type Props = {
-  siteSection: SiteSection | null;
+  siteSection?: SiteSection;
   customNavLinks?: NavLink[];
   isMinimalHeader?: boolean;
 };

--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -59,7 +59,7 @@ export type Props = PropsWithChildren<{
   url: Url;
   jsonLd: JsonLdObj | JsonLdObj[];
   openGraphType: 'website' | 'article' | 'book' | 'profile' | 'video' | 'music';
-  siteSection: SiteSection | null;
+  siteSection?: SiteSection;
   image?: ImageType;
   rssUrl?: string;
   hideNewsletterPromo?: boolean;

--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -33,12 +33,14 @@ import { isNotUndefined } from '@weco/common/utils/type-guards';
 import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
 
 export type SiteSection =
-  | 'collections'
-  | 'what-we-do'
   | 'visit-us'
-  | 'stories'
   | 'whats-on'
-  | 'identity'
+  | 'stories'
+  | 'collections'
+  | 'get-involved'
+  | 'about-us'
+  | 'what-we-do' // TODO: to remove? Not in menu anymore
+  | 'identity' // TODO: is this used? No menu on login page
   | 'exhibition-guides';
 
 type HeaderProps = {

--- a/content/webapp/pages/index.tsx
+++ b/content/webapp/pages/index.tsx
@@ -189,7 +189,6 @@ const Homepage: FunctionComponent<Props> = ({
         url={{ pathname: '/' }}
         jsonLd={jsonLd}
         openGraphType="website"
-        siteSection={null}
         image={pageImage}
         apiToolbarLinks={[createPrismicLink(homepageId)]}
       >

--- a/content/webapp/pages/visual-stories/index.tsx
+++ b/content/webapp/pages/visual-stories/index.tsx
@@ -24,7 +24,6 @@ const VisualStory = () => {
       url={{ pathname: '/visual-stories' }}
       jsonLd={[]}
       openGraphType="website"
-      siteSection={null}
       hideNewsletterPromo={true}
     >
       <Space v={{ size: 'xl', properties: ['padding-bottom', 'padding-top'] }}>

--- a/content/webapp/pages/visual-stories/v1.tsx
+++ b/content/webapp/pages/visual-stories/v1.tsx
@@ -25,7 +25,6 @@ const VisualStoryV1 = () => {
       url={{ pathname: '/visual-stories/v1' }}
       jsonLd={[]}
       openGraphType="website"
-      siteSection={null}
       hideNewsletterPromo={true}
     >
       <Space v={{ size: 'xl', properties: ['padding-bottom', 'padding-top'] }}>

--- a/content/webapp/pages/visual-stories/v2.tsx
+++ b/content/webapp/pages/visual-stories/v2.tsx
@@ -25,7 +25,6 @@ const VisualStoryV2 = () => {
       url={{ pathname: '/visual-stories/v2' }}
       jsonLd={[]}
       openGraphType="website"
-      siteSection={null}
       hideNewsletterPromo={true}
     >
       <Space v={{ size: 'xl', properties: ['padding-bottom', 'padding-top'] }}>

--- a/content/webapp/services/prismic/transformers/guides.ts
+++ b/content/webapp/services/prismic/transformers/guides.ts
@@ -1,5 +1,5 @@
-import { Guide } from '../../../types/guides';
-import { Format } from '../../../types/format';
+import { Guide } from '@weco/content/types/guides';
+import { Format } from '@weco/content/types/format';
 import {
   GuidePrismicDocument,
   GuideFormatPrismicDocument,
@@ -8,6 +8,7 @@ import { asHtml, asTitle, transformFormat, transformGenericFields } from '.';
 import { links as headerLinks } from '@weco/common/views/components/Header/Header';
 import { transformOnThisPage } from './pages';
 import { transformTimestamp } from '@weco/common/services/prismic/transformers';
+import { SiteSection } from '@weco/common/views/components/PageLayout/PageLayout';
 
 export function transformGuide(document: GuidePrismicDocument): Guide {
   const { data } = document;
@@ -16,7 +17,9 @@ export function transformGuide(document: GuidePrismicDocument): Guide {
   // TODO (tagging): This is just for now, we will be implementing a proper site tagging
   // strategy for this later
   const siteSections = headerLinks.map(link => link.siteSection);
-  const siteSection = document.tags.find(tag => siteSections.includes(tag));
+  const siteSection = document.tags.find(tag =>
+    siteSections.includes(tag as SiteSection)
+  ) as SiteSection;
 
   const promo = genericFields.promo;
   return {

--- a/content/webapp/services/prismic/transformers/pages.ts
+++ b/content/webapp/services/prismic/transformers/pages.ts
@@ -17,6 +17,7 @@ import { SeasonPrismicDocument } from '../types/seasons';
 import { transformContributors } from './contributors';
 import { isNotUndefined, isUndefined } from '@weco/common/utils/type-guards';
 import { transformTimestamp } from '@weco/common/services/prismic/transformers';
+import { SiteSection } from '@weco/common/views/components/PageLayout/PageLayout';
 
 export function transformOnThisPage(body: Body): Link[] {
   return flattenDeep(
@@ -49,7 +50,9 @@ export function transformPage(document: PagePrismicDocument): Page {
   // TODO (tagging): This is just for now, we will be implementing a proper site tagging
   // strategy for this later
   const siteSections = headerLinks.map(link => link.siteSection);
-  const siteSection = document.tags.find(tag => siteSections.includes(tag));
+  const siteSection = document.tags.find(tag =>
+    siteSections.includes(tag as SiteSection)
+  ) as SiteSection;
 
   const promoField = genericFields.promo;
   const promo = promoField?.image ? promoField : undefined;

--- a/content/webapp/types/guides.ts
+++ b/content/webapp/types/guides.ts
@@ -1,12 +1,13 @@
 import { GenericContentFields } from './generic-content-fields';
 import { Link } from './link';
 import { Format } from './format';
+import { SiteSection } from '@weco/common/views/components/PageLayout/PageLayout';
 
 export type Guide = GenericContentFields & {
   type: 'guides';
   format?: Format;
   onThisPage: Link[];
   datePublished?: Date;
-  siteSection?: string;
+  siteSection?: SiteSection;
   showOnThisPage: boolean;
 };

--- a/content/webapp/types/pages.ts
+++ b/content/webapp/types/pages.ts
@@ -3,6 +3,7 @@ import { Link } from './link';
 import { Season } from './seasons';
 import { Format } from './format';
 import { Contributor } from './contributors';
+import { SiteSection } from '@weco/common/views/components/PageLayout/PageLayout';
 
 export type ParentPage = Page & {
   order: number;
@@ -16,7 +17,7 @@ export type Page = GenericContentFields & {
   parentPages: ParentPage[];
   onThisPage: Link[];
   datePublished?: Date;
-  siteSection?: string;
+  siteSection?: SiteSection;
   showOnThisPage: boolean;
   contributors: Contributor[];
 };


### PR DESCRIPTION
## Who is this for?
Maintenance

## What is it doing for them?
While working on #9987 I noticed that the `SiteSection` type [was out of date](https://wellcome.slack.com/archives/C3TQSF63C/p1688132628103479), so I added missing sections.

I haven't removed the ones I think are out of date as I'd like to do that as part of the audit instead, although I'll take opinions on `Identity` being one since it doesn't seem to ever be in any form of the main menu?

I've then applied the type across instead of string, which means in-existing sections will now be flagged as.