### PR TITLE
Remove a couple of styled-components that only wrap a single class

### DIFF
--- a/catalogue/webapp/components/Work/Work.tsx
+++ b/catalogue/webapp/components/Work/Work.tsx
@@ -45,14 +45,6 @@ const WorkDetailsWrapper = styled(Space).attrs({
   flex: 1;
 `;
 
-export const Container = styled.div.attrs({
-  className: 'container',
-})``;
-
-export const Grid = styled.div.attrs({
-  className: 'grid',
-})``;
-
 function showItemLink({
   digitalLocation,
   accessCondition,
@@ -177,8 +169,8 @@ const Work: FunctionComponent<Props> = ({ work, apiUrl }) => {
         apiToolbarLinks={createApiToolbarLinks(work, apiUrl)}
         hideNewsletterPromo={true}
       >
-        <Container>
-          <Grid>
+        <div className="container">
+          <div className="grid">
             <Space
               v={{
                 size: 'l',
@@ -188,8 +180,8 @@ const Work: FunctionComponent<Props> = ({ work, apiUrl }) => {
             >
               <SearchForm searchCategory="works" location="page" />
             </Space>
-          </Grid>
-          <Grid>
+          </div>
+          <div className="grid">
             <Space
               v={{
                 size: 's',
@@ -199,13 +191,13 @@ const Work: FunctionComponent<Props> = ({ work, apiUrl }) => {
             >
               <BackToResults />
             </Space>
-          </Grid>
-        </Container>
+          </div>
+        </div>
 
         {isArchive ? (
           <>
-            <Container>
-              <Grid>
+            <div className="container">
+              <div className="grid">
                 <Space
                   v={{
                     size: 's',
@@ -215,18 +207,18 @@ const Work: FunctionComponent<Props> = ({ work, apiUrl }) => {
                 >
                   <ArchiveBreadcrumb work={work} />
                 </Space>
-              </Grid>
-            </Container>
-            <Container>
-              <Grid>
+              </div>
+            </div>
+            <div className="container">
+              <div className="grid">
                 <WorkHeader work={work} />
-              </Grid>
+              </div>
               {showTabbedNav && (
                 <WorkTabbedNav work={work} selected="catalogueDetails" />
               )}
-            </Container>
+            </div>
 
-            <Container>
+            <div className="container">
               <Divider />
               <ArchiveDetailsContainer>
                 <ArchiveTree work={work} />
@@ -237,18 +229,18 @@ const Work: FunctionComponent<Props> = ({ work, apiUrl }) => {
                   />
                 </WorkDetailsWrapper>
               </ArchiveDetailsContainer>
-            </Container>
+            </div>
           </>
         ) : (
           <>
-            <Container>
-              <Grid>
+            <div className="container">
+              <div className="grid">
                 <WorkHeader work={work} />
-              </Grid>
+              </div>
               {showTabbedNav && (
                 <WorkTabbedNav work={work} selected="catalogueDetails" />
               )}
-            </Container>
+            </div>
             <WorkDetails work={work} shouldShowItemLink={shouldShowItemLink} />
           </>
         )}

--- a/catalogue/webapp/pages/works/[workId]/items.tsx
+++ b/catalogue/webapp/pages/works/[workId]/items.tsx
@@ -38,7 +38,6 @@ import { transformCanvasOcr } from '@weco/catalogue/services/iiif/transformers/c
 import { TransformedManifest } from '@weco/catalogue/types/manifest';
 import WorkHeader from '@weco/catalogue/components/WorkHeader/WorkHeader';
 import WorkTabbedNav from '@weco/catalogue/components/WorkTabbedNav/WorkTabbedNav';
-import { Container, Grid } from '@weco/catalogue/components/Work/Work';
 import { useToggles } from '@weco/common/server-data/Context';
 import {
   ApiToolbarLink,
@@ -197,12 +196,12 @@ const ItemPage: NextPage<Props> = ({
 
       {worksTabbedNav && (
         <Space v={{ size: 'l', properties: ['margin-top'] }}>
-          <Container>
-            <Grid>
+          <div className="container">
+            <div className="grid">
               <WorkHeader work={work} />
-            </Grid>
+            </div>
             <WorkTabbedNav work={work} selected="imageViewer" />
-          </Container>
+          </div>
         </Space>
       )}
 
@@ -427,7 +426,8 @@ export const getServerSideProps: GetServerSideProps<
 
     return {
       props: serialiseProps({
-        compressedTransformedManifest: toCompressedTransformedManifest(displayManifest),
+        compressedTransformedManifest:
+          toCompressedTransformedManifest(displayManifest),
         canvasOcr,
         work,
         canvas,


### PR DESCRIPTION
This feels like a leftover from a different world where we took a different approach to styled-components; it's not consistent with how we use the `container`/`grid` classes anywhere else.