### PR TITLE
[DO NOT MERGE/REVIEW] Only pass around a small amount of information in the Work model

### DIFF
--- a/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
@@ -221,7 +221,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
   transformedManifest,
   canvasOcr,
   handleImageError,
-}: IIIFViewerProps) => {
+}) => {
   const router = useRouter();
   const {
     page = 1,

--- a/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
@@ -8,7 +8,7 @@ import {
 import styled, { keyframes } from 'styled-components';
 import { Manifest } from '@iiif/presentation-3';
 import { DigitalLocation } from '@weco/common/model/catalogue';
-import { Work } from '@weco/catalogue/services/wellcome/catalogue/types';
+import { WorkBasic } from '@weco/catalogue/services/wellcome/catalogue/types';
 import ViewerSidebar from './ViewerSidebar';
 import MainViewer from './MainViewer';
 import ViewerTopBar from './ViewerTopBar';
@@ -61,8 +61,9 @@ const DelayVisibility = styled.div`
 `;
 
 type IIIFViewerProps = {
-  work: Work;
-  iiifImageLocation: DigitalLocation | undefined;
+  work: WorkBasic;
+  iiifImageLocation?: DigitalLocation;
+  iiifPresentationLocation?: DigitalLocation;
   transformedManifest?: TransformedManifest;
   canvasOcr?: string;
   handleImageError?: () => void;
@@ -218,6 +219,7 @@ const Thumbnails = styled.div<{
 const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
   work,
   iiifImageLocation,
+  iiifPresentationLocation,
   transformedManifest,
   canvasOcr,
   handleImageError,
@@ -348,7 +350,10 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
             isActiveMobile={isMobileSidebarActive}
             isActiveDesktop={isDesktopSidebarActive}
           >
-            <ViewerSidebar iiifImageLocation={iiifImageLocation} />
+            <ViewerSidebar
+              iiifImageLocation={iiifImageLocation}
+              iiifPresentationLocation={iiifPresentationLocation}
+            />
           </Sidebar>
           <Topbar isDesktopSidebarActive={isDesktopSidebarActive}>
             <ViewerTopBar iiifImageLocation={iiifImageLocation} />

--- a/catalogue/webapp/components/IIIFViewer/ImageViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ImageViewer.tsx
@@ -98,7 +98,6 @@ const ImageViewer: FunctionComponent<ImageViewerProps> = ({
   );
 
   const rotation = matching ? matching.rotation : 0;
-  const lang = (work.languages.length === 1 && work.languages[0]?.id) || '';
 
   function updateImagePosition() {
     const imageRect = imageRef?.current?.getBoundingClientRect();
@@ -174,7 +173,7 @@ const ImageViewer: FunctionComponent<ImageViewerProps> = ({
         height={height}
         srcSet={imageSrcSet}
         sizes={`(min-width: 860px) 800px, calc(92.59vw + 22px)`}
-        lang={lang}
+        lang={work.languageId}
         alt={alt}
         clickHandler={() => {
           setShowZoomed(true);

--- a/catalogue/webapp/components/IIIFViewer/NoScriptViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/NoScriptViewer.tsx
@@ -155,7 +155,6 @@ const NoScriptViewer: FunctionComponent<NoScriptViewerProps> = ({
   canvasOcr,
 }: NoScriptViewerProps) => {
   const { work, query, transformedManifest } = useContext(ItemViewerContext);
-  const lang = (work.languages.length === 1 && work.languages[0].id) || '';
   const { canvases } = { ...transformedManifest };
   const currentCanvas = canvases?.[queryParamToArrayIndex(query.canvas)];
   const mainImageService = { '@id': currentCanvas?.imageServiceId };
@@ -211,7 +210,7 @@ const NoScriptViewer: FunctionComponent<NoScriptViewerProps> = ({
               src={imageUrl}
               srcSet={srcSet}
               sizes="(min-width: 860px) 800px, calc(92.59vw + 22px)"
-              lang={lang}
+              lang={work.languageId}
               alt={
                 (canvasOcr && canvasOcr.replace(/"/g, '')) ||
                 'no text alternative'
@@ -224,7 +223,7 @@ const NoScriptViewer: FunctionComponent<NoScriptViewerProps> = ({
               src={urlTemplate && urlTemplate({ size: '800,' })}
               srcSet={srcSet}
               sizes="(min-width: 860px) 800px, calc(92.59vw + 22px)"
-              lang={lang}
+              lang={work.languageId}
               alt={
                 (canvasOcr && canvasOcr.replace(/"/g, '')) ||
                 'no text alternative'

--- a/catalogue/webapp/components/IIIFViewer/ViewerSidebar.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerSidebar.tsx
@@ -13,10 +13,6 @@ import styled from 'styled-components';
 import Space from '@weco/common/views/components/styled/Space';
 import { classNames, font } from '@weco/common/utils/classnames';
 import LinkLabels from '@weco/common/views/components/LinkLabels/LinkLabels';
-import {
-  getProductionDates,
-  getDigitalLocationOfType,
-} from '@weco/catalogue/utils/works';
 import { getCatalogueLicenseData } from '@weco/common/utils/licenses';
 import ViewerStructures from './ViewerStructures';
 import ItemViewerContext from '../ItemViewerContext/ItemViewerContext';
@@ -123,25 +119,25 @@ const AccordionItem = ({ title, children, testId }: AccordionItemProps) => {
   );
 };
 
-const ViewerSidebar: FunctionComponent<{
+type ViewerSidebarProps = {
   iiifImageLocation?: DigitalLocation;
-}> = ({ iiifImageLocation }) => {
+  iiifPresentationLocation?: DigitalLocation;
+};
+
+const ViewerSidebar: FunctionComponent<ViewerSidebarProps> = ({
+  iiifImageLocation,
+  iiifPresentationLocation,
+}) => {
   const { work, transformedManifest, parentManifest } =
     useContext(ItemViewerContext);
   const [currentManifestLabel, setCurrentManifestLabel] = useState<
     string | undefined
   >();
   const { iiifCredit, structures, searchService } = { ...transformedManifest };
-  const productionDates = getProductionDates(work);
-  // Determine digital location
-  const imageLocation =
-    iiifImageLocation || getDigitalLocationOfType(work, 'iiif-image');
-  const iiifPresentationLocation = getDigitalLocationOfType(
-    work,
-    'iiif-presentation'
-  );
+  const { productionDates } = work;
+
   const digitalLocation: DigitalLocation | undefined =
-    iiifPresentationLocation || imageLocation;
+    iiifPresentationLocation || iiifImageLocation;
 
   const license =
     digitalLocation?.license &&
@@ -177,12 +173,12 @@ const ViewerSidebar: FunctionComponent<{
           <WorkTitle title={work.title} />
         </h1>
 
-        {work.contributors.length > 0 && (
+        {work.primaryContributorLabel && (
           <Space
             h={{ size: 'm', properties: ['margin-right'] }}
             data-test-id="work-contributors"
           >
-            <LinkLabels items={[{ text: work.contributors[0].agent.label }]} />
+            <LinkLabels items={[{ text: work.primaryContributorLabel }]} />
           </Space>
         )}
 

--- a/catalogue/webapp/components/IIIFViewer/ViewerTopBar.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerTopBar.tsx
@@ -216,9 +216,8 @@ const ViewerTopBar: FunctionComponent<{
   } = { ...transformedManifest };
   const currentCanvas = canvases?.[queryParamToArrayIndex(query.canvas)];
   const mainImageService = { '@id': currentCanvas?.imageServiceId };
-  const transformedIIIFImage = useTransformedIIIFImage(work);
-  const imageLocation =
-    iiifImageLocation || getDigitalLocationOfType(work, 'iiif-image');
+  const transformedIIIFImage = useTransformedIIIFImage(work, iiifImageLocation);
+
   // Works can have a DigitalLocation of type iiif-presentation and/or iiif-image.
   // For a iiif-presentation DigitalLocation we get the download options from the manifest to which it points.
   // For a iiif-image DigitalLocation we create the download options
@@ -229,9 +228,9 @@ const ViewerTopBar: FunctionComponent<{
   // Sometimes we render images for works that have neither a iiif-image or a iiif-presentation location type.
   // In this case we use the iiifImageLocation passed from the serverSideProps of the /images.tsx
 
-  const iiifImageDownloadOptions = imageLocation
+  const iiifImageDownloadOptions = iiifImageLocation
     ? getDownloadOptionsFromImageUrl({
-        url: imageLocation.url,
+        url: iiifImageLocation.url,
         width: transformedIIIFImage.width,
         height: transformedIIIFImage.height,
       })

--- a/catalogue/webapp/components/ItemViewerContext/ItemViewerContext.tsx
+++ b/catalogue/webapp/components/ItemViewerContext/ItemViewerContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, RefObject } from 'react';
-import { Work } from '@weco/catalogue/services/wellcome/catalogue/types';
+import { WorkBasic } from '@weco/catalogue/services/wellcome/catalogue/types';
 import { SearchResults } from '@weco/catalogue/services/iiif/types/search/v3';
 import { Manifest } from '@iiif/presentation-3';
 import { TransformedManifest } from '../../types/manifest';
@@ -17,7 +17,7 @@ export type Query = {
 type Props = {
   // DATA props:
   query: Query;
-  work: Work;
+  work: WorkBasic;
   transformedManifest: TransformedManifest | undefined;
   parentManifest: Manifest | undefined;
   searchResults: SearchResults;
@@ -67,34 +67,12 @@ const query = {
   shouldScrollToCanvas: true,
 };
 
-const work = {
-  type: 'Work',
+const work: WorkBasic = {
   id: '',
   title: '',
-  alternativeTitles: [],
-  physicalDescription: '',
-  workType: {
-    id: '',
-    label: '',
-    type: 'Format',
-  },
-  contributors: [],
-  identifiers: [],
-  subjects: [],
-  genres: [],
-  production: [],
-  languages: [],
-  notes: [],
-  formerFrequency: [],
-  designation: [],
-  parts: [],
-  partOf: [],
-  precededBy: [],
-  succeededBy: [],
-  availabilities: [],
-  availableOnline: false,
-  holdings: [],
-} as Work;
+  productionDates: [],
+  cardLabels: [],
+};
 
 const ItemViewerContext = createContext<Props>({
   // DATA props:

--- a/catalogue/webapp/components/Work/Work.tsx
+++ b/catalogue/webapp/components/Work/Work.tsx
@@ -230,7 +230,10 @@ const Work: FunctionComponent<Props> = ({ work, apiUrl }) => {
                 />
               </Grid>
               {showTabbedNav && (
-                <WorkTabbedNav work={work} selected="catalogueDetails" />
+                <WorkTabbedNav
+                  work={toWorkBasic(work)}
+                  selected="catalogueDetails"
+                />
               )}
             </Container>
 
@@ -257,7 +260,10 @@ const Work: FunctionComponent<Props> = ({ work, apiUrl }) => {
                 />
               </Grid>
               {showTabbedNav && (
-                <WorkTabbedNav work={work} selected="catalogueDetails" />
+                <WorkTabbedNav
+                  work={toWorkBasic(work)}
+                  selected="catalogueDetails"
+                />
               )}
             </Container>
             <WorkDetails work={work} shouldShowItemLink={shouldShowItemLink} />

--- a/catalogue/webapp/components/Work/Work.tsx
+++ b/catalogue/webapp/components/Work/Work.tsx
@@ -1,5 +1,8 @@
 import { FunctionComponent } from 'react';
-import { Work as WorkType } from '@weco/catalogue/services/wellcome/catalogue/types';
+import {
+  Work as WorkType,
+  toWorkBasic,
+} from '@weco/catalogue/services/wellcome/catalogue/types';
 import {
   Location as LocationType,
   DigitalLocation,
@@ -164,6 +167,8 @@ const Work: FunctionComponent<Props> = ({ work, apiUrl }) => {
       }
     : undefined;
 
+  const { collectionManifestsCount } = { ...transformedIIIFManifest };
+
   return (
     <IsArchiveContext.Provider value={isArchive}>
       <CataloguePageLayout
@@ -219,7 +224,10 @@ const Work: FunctionComponent<Props> = ({ work, apiUrl }) => {
             </Container>
             <Container>
               <Grid>
-                <WorkHeader work={work} />
+                <WorkHeader
+                  work={toWorkBasic(work)}
+                  collectionManifestsCount={collectionManifestsCount}
+                />
               </Grid>
               {showTabbedNav && (
                 <WorkTabbedNav work={work} selected="catalogueDetails" />
@@ -243,7 +251,10 @@ const Work: FunctionComponent<Props> = ({ work, apiUrl }) => {
           <>
             <Container>
               <Grid>
-                <WorkHeader work={work} />
+                <WorkHeader
+                  work={toWorkBasic(work)}
+                  collectionManifestsCount={collectionManifestsCount}
+                />
               </Grid>
               {showTabbedNav && (
                 <WorkTabbedNav work={work} selected="catalogueDetails" />

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -31,7 +31,10 @@ import { trackGaEvent } from '@weco/common/utils/ga';
 import PhysicalItems from '../PhysicalItems/PhysicalItems';
 import Layout10 from '@weco/common/views/components/Layout10/Layout10';
 import { DigitalLocation } from '@weco/common/model/catalogue';
-import { Work } from '@weco/catalogue/services/wellcome/catalogue/types';
+import {
+  Work,
+  toWorkBasic,
+} from '@weco/catalogue/services/wellcome/catalogue/types';
 import useTransformedManifest from '../../hooks/useTransformedManifest';
 import useTransformedIIIFImage from '../../hooks/useTransformedIIIFImage';
 import IIIFClickthrough from '../IIIFClickthrough/IIIFClickthrough';
@@ -58,7 +61,17 @@ const WorkDetails: FunctionComponent<Props> = ({
 }: Props) => {
   const isArchive = useContext(IsArchiveContext);
   const itemUrl = itemLink({ workId: work.id, source: 'work', props: {} });
-  const transformedIIIFImage = useTransformedIIIFImage(work);
+
+  const iiifImageLocation = getDigitalLocationOfType(work, 'iiif-image');
+  const iiifPresentationLocation = getDigitalLocationOfType(
+    work,
+    'iiif-presentation'
+  );
+
+  const transformedIIIFImage = useTransformedIIIFImage(
+    toWorkBasic(work),
+    iiifImageLocation
+  );
   const transformedIIIFManifest = useTransformedManifest(work);
   const {
     video,
@@ -71,12 +84,6 @@ const WorkDetails: FunctionComponent<Props> = ({
     clickThroughService,
     tokenService,
   } = { ...transformedIIIFManifest };
-
-  const iiifImageLocation = getDigitalLocationOfType(work, 'iiif-image');
-  const iiifPresentationLocation = getDigitalLocationOfType(
-    work,
-    'iiif-presentation'
-  );
 
   // Works can have a DigitalLocation of type iiif-presentation and/or iiif-image.
   // For a iiif-presentation DigitalLocation we get the download options from the manifest to which it points.

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.tsx
@@ -706,7 +706,7 @@ const WorkDetails: FunctionComponent<Props> = ({
           />
         )}
 
-        {work.languages.length > 0 && (
+        {work.languages && work.languages.length > 0 && (
           <WorkDetailsTags
             title="Languages"
             tags={work.languages.map(lang => {

--- a/catalogue/webapp/components/WorkHeader/WorkHeader.tsx
+++ b/catalogue/webapp/components/WorkHeader/WorkHeader.tsx
@@ -1,11 +1,6 @@
 import { FunctionComponent, useContext } from 'react';
-import { Work } from '@weco/catalogue/services/wellcome/catalogue/types';
+import { WorkBasic } from '@weco/catalogue/services/wellcome/catalogue/types';
 import { font, grid } from '@weco/common/utils/classnames';
-import {
-  getProductionDates,
-  getArchiveLabels,
-  getCardLabels,
-} from '../../utils/works';
 import SpacingComponent from '@weco/common/views/components/styled/SpacingComponent';
 import LinkLabels from '@weco/common/views/components/LinkLabels/LinkLabels';
 import Space from '@weco/common/views/components/styled/Space';
@@ -13,7 +8,6 @@ import Number from '@weco/common/views/components/Number/Number';
 import styled from 'styled-components';
 import WorkTitle from '../WorkTitle/WorkTitle';
 import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
-import useTransformedManifest from '../../hooks/useTransformedManifest';
 import Divider from '@weco/common/views/components/Divider/Divider';
 import IsArchiveContext from '../IsArchiveContext/IsArchiveContext';
 
@@ -29,20 +23,18 @@ const WorkTitleWrapper = styled.h1.attrs({ className: font('intb', 2) })`
 `;
 
 type Props = {
-  work: Work;
+  work: WorkBasic;
+  collectionManifestsCount: number | undefined;
 };
 
 const WorkHeader: FunctionComponent<Props> = ({ work }) => {
   const isArchive = useContext(IsArchiveContext);
-  const productionDates = getProductionDates(work);
-  const archiveLabels = getArchiveLabels(work);
-  const cardLabels = getCardLabels(work);
-  const manifestData = useTransformedManifest(work);
-  const { collectionManifestsCount } = { ...manifestData };
-
-  const primaryContributorLabel = work.contributors.find(
-    contributor => contributor.primary
-  )?.agent.label;
+  const {
+    productionDates,
+    archiveLabels,
+    cardLabels,
+    primaryContributorLabel,
+  } = work;
 
   return (
     <>
@@ -61,9 +53,7 @@ const WorkHeader: FunctionComponent<Props> = ({ work }) => {
               // We only send a lang if it's unambiguous -- better to send
               // no language than the wrong one.
               lang={
-                work?.languages?.length === 1
-                  ? work?.languages[0]?.id
-                  : undefined
+                work.languageIds.length === 1 ? work.languageIds[0] : undefined
               }
             >
               <WorkTitle title={work.title} />

--- a/catalogue/webapp/components/WorkHeader/WorkHeader.tsx
+++ b/catalogue/webapp/components/WorkHeader/WorkHeader.tsx
@@ -27,7 +27,10 @@ type Props = {
   collectionManifestsCount: number | undefined;
 };
 
-const WorkHeader: FunctionComponent<Props> = ({ work }) => {
+const WorkHeader: FunctionComponent<Props> = ({
+  work,
+  collectionManifestsCount,
+}) => {
   const isArchive = useContext(IsArchiveContext);
   const {
     productionDates,
@@ -50,11 +53,7 @@ const WorkHeader: FunctionComponent<Props> = ({ work }) => {
             <WorkTitleWrapper
               aria-live="polite"
               id="work-info"
-              // We only send a lang if it's unambiguous -- better to send
-              // no language than the wrong one.
-              lang={
-                work.languageIds.length === 1 ? work.languageIds[0] : undefined
-              }
+              lang={work.languageId}
             >
               <WorkTitle title={work.title} />
             </WorkTitleWrapper>

--- a/catalogue/webapp/components/WorkTabbedNav/WorkTabbedNav.tsx
+++ b/catalogue/webapp/components/WorkTabbedNav/WorkTabbedNav.tsx
@@ -1,11 +1,11 @@
-import { Work } from '@weco/catalogue/services/wellcome/catalogue/types';
+import { WorkBasic } from '@weco/catalogue/services/wellcome/catalogue/types';
 import { FunctionComponent } from 'react';
 import SubNavigation from '@weco/common/views/components/SubNavigation/SubNavigation';
 import { listView, eye } from '@weco/common/icons';
 import { toLink as itemLink } from '../ItemLink';
 
 type Props = {
-  work: Work;
+  work: WorkBasic;
   selected: 'catalogueDetails' | 'imageViewer';
 };
 const WorkTabbedNav: FunctionComponent<Props> = ({ work, selected }) => {

--- a/catalogue/webapp/components/WorksSearchResult/WorksSearchResult.tsx
+++ b/catalogue/webapp/components/WorksSearchResult/WorksSearchResult.tsx
@@ -2,14 +2,9 @@ import { FunctionComponent } from 'react';
 
 // Types
 import { DigitalLocation } from '@weco/common/model/catalogue';
-import { Work } from '@weco/catalogue/services/wellcome/catalogue/types';
+import { WorkBasic } from '@weco/catalogue/services/wellcome/catalogue/types';
 
 // Helpers/Utils
-import {
-  getArchiveLabels,
-  getProductionDates,
-  getCardLabels,
-} from '../../utils/works';
 import { convertIiifImageUri } from '@weco/common/utils/convert-image-uri';
 
 // Components
@@ -29,7 +24,7 @@ import {
 } from './WorksSearchResult.styles';
 
 type Props = {
-  work: Work;
+  work: WorkBasic;
   resultPosition: number;
 };
 
@@ -44,13 +39,12 @@ const WorkSearchResult: FunctionComponent<Props> = ({
   work,
   resultPosition,
 }) => {
-  const productionDates = getProductionDates(work);
-  const archiveLabels = getArchiveLabels(work);
-  const cardLabels = getCardLabels(work);
-
-  const primaryContributorLabel = work.contributors.find(
-    contributor => contributor.primary
-  )?.agent.label;
+  const {
+    productionDates,
+    archiveLabels,
+    cardLabels,
+    primaryContributorLabel,
+  } = work;
 
   return (
     <WorkLink

--- a/catalogue/webapp/components/WorksSearchResults/WorksSearchResults.tsx
+++ b/catalogue/webapp/components/WorksSearchResults/WorksSearchResults.tsx
@@ -1,7 +1,10 @@
 import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 import WorksSearchResult from '../WorksSearchResult/WorksSearchResult';
-import { Work } from '@weco/catalogue/services/wellcome/catalogue/types';
+import {
+  Work,
+  toWorkBasic,
+} from '@weco/catalogue/services/wellcome/catalogue/types';
 import PlainList from '@weco/common/views/components/styled/PlainList';
 
 type Props = {
@@ -36,7 +39,7 @@ const WorksSearchResults: FunctionComponent<Props> = ({ works }: Props) => {
     <SearchResultUnorderedList data-test-id="works-search-results-container">
       {works.map((result, i) => (
         <SearchResultListItem data-test-id="work-search-result" key={result.id}>
-          <WorksSearchResult work={result} resultPosition={i} />
+          <WorksSearchResult work={toWorkBasic(result)} resultPosition={i} />
         </SearchResultListItem>
       ))}
     </SearchResultUnorderedList>

--- a/catalogue/webapp/components/WorksSearchResults/WorksSearchResults.tsx
+++ b/catalogue/webapp/components/WorksSearchResults/WorksSearchResults.tsx
@@ -34,7 +34,7 @@ const SearchResultListItem = styled.li`
   }
 `;
 
-const WorksSearchResults: FunctionComponent<Props> = ({ works }: Props) => {
+const WorksSearchResults: FunctionComponent<Props> = ({ works }) => {
   return (
     <SearchResultUnorderedList data-test-id="works-search-results-container">
       {works.map((result, i) => (

--- a/catalogue/webapp/components/WorksSearchResults/WorksSearchResults.tsx
+++ b/catalogue/webapp/components/WorksSearchResults/WorksSearchResults.tsx
@@ -1,14 +1,11 @@
 import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 import WorksSearchResult from '../WorksSearchResult/WorksSearchResult';
-import {
-  Work,
-  toWorkBasic,
-} from '@weco/catalogue/services/wellcome/catalogue/types';
+import { WorkBasic } from '@weco/catalogue/services/wellcome/catalogue/types';
 import PlainList from '@weco/common/views/components/styled/PlainList';
 
 type Props = {
-  works: Work[];
+  works: WorkBasic[];
 };
 
 const SearchResultUnorderedList = styled(PlainList)`
@@ -39,7 +36,7 @@ const WorksSearchResults: FunctionComponent<Props> = ({ works }) => {
     <SearchResultUnorderedList data-test-id="works-search-results-container">
       {works.map((result, i) => (
         <SearchResultListItem data-test-id="work-search-result" key={result.id}>
-          <WorksSearchResult work={toWorkBasic(result)} resultPosition={i} />
+          <WorksSearchResult work={result} resultPosition={i} />
         </SearchResultListItem>
       ))}
     </SearchResultUnorderedList>

--- a/catalogue/webapp/pages/search/index.tsx
+++ b/catalogue/webapp/pages/search/index.tsx
@@ -19,7 +19,11 @@ import { font } from '@weco/common/utils/classnames';
 import { getWorks } from '@weco/catalogue/services/wellcome/catalogue/works';
 import { Query } from '@weco/catalogue/types/search';
 import { getImages } from '@weco/catalogue/services/wellcome/catalogue/images';
-import { Image, Work } from '@weco/catalogue/services/wellcome/catalogue/types';
+import {
+  Image,
+  toWorkBasic,
+  WorkBasic,
+} from '@weco/catalogue/services/wellcome/catalogue/types';
 import {
   getQueryResults,
   getQueryPropertyValue,
@@ -52,7 +56,7 @@ const fromQuery: (params: ParsedUrlQuery) => CodecMapProps = params => {
 };
 
 type Props = {
-  works?: ReturnedResults<Work>;
+  works?: ReturnedResults<WorkBasic>;
   images?: ReturnedResults<Image>;
   stories?: ReturnedResults<Article>;
   query: Query;
@@ -300,7 +304,9 @@ export const getServerSideProps: GetServerSideProps<
         ...defaultProps,
         ...(stories && stories.pageResults?.length && { stories }),
         ...(images?.pageResults.length && { images }),
-        ...(works?.pageResults.length && { works }),
+        works: works
+          ? { ...works, pageResults: works.pageResults.map(toWorkBasic) }
+          : undefined,
       },
     };
   } catch (error) {

--- a/catalogue/webapp/pages/search/works.tsx
+++ b/catalogue/webapp/pages/search/works.tsx
@@ -28,7 +28,10 @@ import { NextPageWithLayout } from '@weco/common/views/pages/_app';
 import { Pageview } from '@weco/common/services/conversion/track';
 import { getWorks } from '@weco/catalogue/services/wellcome/catalogue/works';
 import { worksFilters } from '@weco/catalogue/services/wellcome/catalogue/filters';
-import { emptyResultList } from '@weco/catalogue/services/wellcome';
+import {
+  emptyResultList,
+  WellcomeResultList,
+} from '@weco/catalogue/services/wellcome';
 import convertUrlToString from '@weco/common/utils/convert-url-to-string';
 import { hasFilters, linkResolver } from '@weco/common/utils/search';
 import { AppErrorProps, appError } from '@weco/common/services/app';
@@ -38,14 +41,15 @@ import { looksLikeSpam } from '@weco/catalogue/utils/spam-detector';
 
 // Types
 import {
-  CatalogueResultsList,
-  Work,
+  toWorkBasic,
+  WorkAggregations,
+  WorkBasic,
 } from '@weco/catalogue/services/wellcome/catalogue/types';
 import { Query } from '@weco/catalogue/types/search';
 import { ApiToolbarLink } from '@weco/common/views/components/ApiToolbar';
 
 type Props = {
-  works: CatalogueResultsList<Work>;
+  works: WellcomeResultList<WorkBasic, WorkAggregations>;
   worksRouteProps: WorksRouteProps;
   query: Query;
   pageview: Pageview;
@@ -282,7 +286,10 @@ export const getServerSideProps: GetServerSideProps<
   return {
     props: serialiseProps({
       ...defaultProps,
-      works,
+      works: {
+        ...works,
+        results: works.results.map(toWorkBasic),
+      },
       pageview: {
         name: 'works',
         properties: { totalResults: works.totalResults },

--- a/catalogue/webapp/pages/works/[workId]/images.tsx
+++ b/catalogue/webapp/pages/works/[workId]/images.tsx
@@ -1,7 +1,12 @@
 import { FunctionComponent } from 'react';
 import { GetServerSideProps } from 'next';
 import { appError, AppErrorProps } from '@weco/common/services/app';
-import { Work, Image } from '@weco/catalogue/services/wellcome/catalogue/types';
+import {
+  Work,
+  Image,
+  WorkBasic,
+  toWorkBasic,
+} from '@weco/catalogue/services/wellcome/catalogue/types';
 import CataloguePageLayout from '@weco/catalogue/components/CataloguePageLayout/CataloguePageLayout';
 import Layout12 from '@weco/common/views/components/Layout12/Layout12';
 import BetaMessage from '@weco/common/views/components/BetaMessage/BetaMessage';
@@ -34,24 +39,18 @@ function createTzitzitImageLink(
 
 type Props = {
   image: Image;
-  catalogueApiUrl: string;
-  work: Work;
+  apiToolbarLinks: (ApiToolbarLink | undefined)[];
+  work: WorkBasic;
   pageview: Pageview;
 };
 
 const ImagePage: FunctionComponent<Props> = ({
   image,
   work,
-  catalogueApiUrl,
+  apiToolbarLinks,
 }) => {
   const title = work.title || '';
   const iiifImageLocation = image.locations[0];
-
-  const apiLink = {
-    id: 'json',
-    label: 'JSON',
-    link: catalogueApiUrl,
-  };
 
   return (
     <CataloguePageLayout
@@ -64,7 +63,7 @@ const ImagePage: FunctionComponent<Props> = ({
       openGraphType="website"
       jsonLd={{ '@type': 'WebPage' }}
       siteSection="collections"
-      apiToolbarLinks={[apiLink, createTzitzitImageLink(work, image)]}
+      apiToolbarLinks={apiToolbarLinks}
       hideNewsletterPromo={true}
       hideFooter={true}
       hideTopContent={true}
@@ -141,8 +140,15 @@ export const getServerSideProps: GetServerSideProps<
       // We know we'll get a catalogue API URL for a non-error response, but
       // this isn't (currently) asserted by the type system.
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      catalogueApiUrl: catalogueApiUrl!,
-      work,
+      apiToolbarLinks: [
+        {
+          id: 'json',
+          label: 'JSON',
+          link: catalogueApiUrl!,
+        },
+        createTzitzitImageLink(work, image),
+      ],
+      work: toWorkBasic(work),
       pageview: {
         name: 'image',
         properties: {},

--- a/catalogue/webapp/pages/works/[workId]/items.tsx
+++ b/catalogue/webapp/pages/works/[workId]/items.tsx
@@ -208,7 +208,7 @@ const ItemPage: NextPage<Props> = ({
                 collectionManifestsCount={collectionManifestsCount}
               />
             </Grid>
-            <WorkTabbedNav work={work} selected="imageViewer" />
+            <WorkTabbedNav work={toWorkBasic(work)} selected="imageViewer" />
           </Container>
         </Space>
       )}

--- a/catalogue/webapp/pages/works/[workId]/items.tsx
+++ b/catalogue/webapp/pages/works/[workId]/items.tsx
@@ -6,6 +6,7 @@ import {
 } from '@weco/common/model/catalogue';
 import {
   Work,
+  WorkBasic,
   toWorkBasic,
 } from '@weco/catalogue/services/wellcome/catalogue/types';
 import { getDigitalLocationOfType } from '@weco/catalogue/utils/works';
@@ -92,12 +93,13 @@ function createTzitzitWorkLink(work: Work): ApiToolbarLink | undefined {
 
 type Props = {
   compressedTransformedManifest?: CompressedTransformedManifest;
-  work: Work;
+  work: WorkBasic;
   canvas: number;
   canvasOcr?: string;
   iiifImageLocation?: DigitalLocation;
   iiifPresentationLocation?: DigitalLocation;
   pageview: Pageview;
+  apiToolbarLinks: ApiToolbarLink[];
 };
 
 const ItemPage: NextPage<Props> = ({
@@ -106,6 +108,7 @@ const ItemPage: NextPage<Props> = ({
   canvasOcr,
   iiifImageLocation,
   canvas,
+  apiToolbarLinks,
 }) => {
   const transformedManifest =
     compressedTransformedManifest &&
@@ -188,7 +191,7 @@ const ItemPage: NextPage<Props> = ({
       openGraphType="website"
       jsonLd={{ '@type': 'WebPage' }}
       siteSection="collections"
-      apiToolbarLinks={[createTzitzitWorkLink(work)]}
+      apiToolbarLinks={apiToolbarLinks}
       hideNewsletterPromo={true}
       hideFooter={true}
       hideTopContent={true}
@@ -205,11 +208,11 @@ const ItemPage: NextPage<Props> = ({
           <Container>
             <Grid>
               <WorkHeader
-                work={toWorkBasic(work)}
+                work={work}
                 collectionManifestsCount={collectionManifestsCount}
               />
             </Grid>
-            <WorkTabbedNav work={toWorkBasic(work)} selected="imageViewer" />
+            <WorkTabbedNav work={work} selected="imageViewer" />
           </Container>
         </Space>
       )}
@@ -330,7 +333,7 @@ const ItemPage: NextPage<Props> = ({
       {showViewer &&
         ((mainImageService && currentCanvas) || iiifImageLocation) && (
           <IIIFViewer
-            work={toWorkBasic(work)}
+            work={work}
             transformedManifest={transformedManifest}
             canvasOcr={canvasOcr}
             iiifImageLocation={iiifImageLocation}
@@ -422,6 +425,8 @@ export const getServerSideProps: GetServerSideProps<
     }
   }
 
+  const apiToolbarLinks = [createTzitzitWorkLink(work)];
+
   if (transformedManifest) {
     const displayManifest = await getDisplayManifest(
       transformedManifest,
@@ -438,11 +443,12 @@ export const getServerSideProps: GetServerSideProps<
         compressedTransformedManifest:
           toCompressedTransformedManifest(displayManifest),
         canvasOcr,
-        work,
+        work: toWorkBasic(work),
         canvas,
         iiifImageLocation,
         iiifPresentationLocation,
         pageview,
+        apiToolbarLinks,
         serverData,
       }),
     };
@@ -452,12 +458,13 @@ export const getServerSideProps: GetServerSideProps<
     return {
       props: serialiseProps({
         compressedTransformedManifest: undefined,
-        work,
+        work: toWorkBasic(work),
         canvas,
         canvases: [],
         iiifImageLocation,
         iiifPresentationLocation,
         pageview,
+        apiToolbarLinks,
         serverData,
       }),
     };

--- a/catalogue/webapp/pages/works/[workId]/items.tsx
+++ b/catalogue/webapp/pages/works/[workId]/items.tsx
@@ -4,7 +4,10 @@ import {
   DigitalLocation,
   isDigitalLocation,
 } from '@weco/common/model/catalogue';
-import { Work } from '@weco/catalogue/services/wellcome/catalogue/types';
+import {
+  Work,
+  toWorkBasic,
+} from '@weco/catalogue/services/wellcome/catalogue/types';
 import { getDigitalLocationOfType } from '@weco/catalogue/utils/works';
 import { removeIdiomaticTextTags } from '@weco/common/utils/string';
 import { getWork } from '@weco/catalogue/services/wellcome/catalogue/works';
@@ -124,6 +127,7 @@ const ItemPage: NextPage<Props> = ({
     restrictedService,
     isTotallyRestricted,
     canvases,
+    collectionManifestsCount,
   } = { ...transformedManifest };
 
   const authService = clickThroughService || restrictedService;
@@ -199,7 +203,10 @@ const ItemPage: NextPage<Props> = ({
         <Space v={{ size: 'l', properties: ['margin-top'] }}>
           <Container>
             <Grid>
-              <WorkHeader work={work} />
+              <WorkHeader
+                work={toWorkBasic(work)}
+                collectionManifestsCount={collectionManifestsCount}
+              />
             </Grid>
             <WorkTabbedNav work={work} selected="imageViewer" />
           </Container>
@@ -427,7 +434,8 @@ export const getServerSideProps: GetServerSideProps<
 
     return {
       props: serialiseProps({
-        compressedTransformedManifest: toCompressedTransformedManifest(displayManifest),
+        compressedTransformedManifest:
+          toCompressedTransformedManifest(displayManifest),
         canvasOcr,
         work,
         canvas,

--- a/catalogue/webapp/pages/works/[workId]/items.tsx
+++ b/catalogue/webapp/pages/works/[workId]/items.tsx
@@ -99,7 +99,7 @@ type Props = {
   iiifImageLocation?: DigitalLocation;
   iiifPresentationLocation?: DigitalLocation;
   pageview: Pageview;
-  apiToolbarLinks: ApiToolbarLink[];
+  apiToolbarLinks: (ApiToolbarLink | undefined)[];
 };
 
 const ItemPage: NextPage<Props> = ({

--- a/catalogue/webapp/pages/works/[workId]/items.tsx
+++ b/catalogue/webapp/pages/works/[workId]/items.tsx
@@ -96,6 +96,7 @@ type Props = {
   canvas: number;
   canvasOcr?: string;
   iiifImageLocation?: DigitalLocation;
+  iiifPresentationLocation?: DigitalLocation;
   pageview: Pageview;
 };
 
@@ -329,7 +330,7 @@ const ItemPage: NextPage<Props> = ({
       {showViewer &&
         ((mainImageService && currentCanvas) || iiifImageLocation) && (
           <IIIFViewer
-            work={work}
+            work={toWorkBasic(work)}
             transformedManifest={transformedManifest}
             canvasOcr={canvasOcr}
             iiifImageLocation={iiifImageLocation}
@@ -440,6 +441,7 @@ export const getServerSideProps: GetServerSideProps<
         work,
         canvas,
         iiifImageLocation,
+        iiifPresentationLocation,
         pageview,
         serverData,
       }),
@@ -454,6 +456,7 @@ export const getServerSideProps: GetServerSideProps<
         canvas,
         canvases: [],
         iiifImageLocation,
+        iiifPresentationLocation,
         pageview,
         serverData,
       }),

--- a/catalogue/webapp/services/wellcome/catalogue/types/index.ts
+++ b/catalogue/webapp/services/wellcome/catalogue/types/index.ts
@@ -52,7 +52,7 @@ export type Work = {
   currentFrequency?: string;
   formerFrequency: string[];
   designation: string[];
-  languages: Language[];
+  languages?: Language[];
   edition?: string;
   notes: Note[];
   duration?: number;

--- a/catalogue/webapp/services/wellcome/catalogue/types/index.ts
+++ b/catalogue/webapp/services/wellcome/catalogue/types/index.ts
@@ -17,6 +17,7 @@ import {
   WorkAggregations,
 } from './aggregations';
 import { WellcomeResultList } from '../../index';
+import { WorkBasic, toWorkBasic } from './work';
 
 export type {
   CatalogueWorksApiProps,
@@ -25,7 +26,10 @@ export type {
   ConceptAggregations,
   ImageAggregations,
   WorkAggregations,
+  WorkBasic,
 };
+
+export { toWorkBasic };
 
 export type Work = {
   type: 'Work' | 'Collection' | 'Section' | 'Series';

--- a/catalogue/webapp/services/wellcome/catalogue/types/work.ts
+++ b/catalogue/webapp/services/wellcome/catalogue/types/work.ts
@@ -1,0 +1,35 @@
+import {
+  ArchiveLabels,
+  getArchiveLabels,
+  getCardLabels,
+  getProductionDates,
+} from '@weco/catalogue/utils/works';
+import { Work } from '.';
+import { Label } from '@weco/common/model/labels';
+import { DigitalLocation } from '@weco/common/model/catalogue';
+
+export type WorkBasic = {
+  id: string;
+  title: string;
+  thumbnail?: DigitalLocation;
+  productionDates: string[];
+  archiveLabels?: ArchiveLabels;
+  cardLabels: Label[];
+  primaryContributorLabel?: string;
+};
+
+export function toWorkBasic(work: Work): WorkBasic {
+  const { id, title, thumbnail } = work;
+
+  return {
+    id,
+    title,
+    thumbnail,
+    productionDates: getProductionDates(work),
+    archiveLabels: getArchiveLabels(work),
+    cardLabels: getCardLabels(work),
+    primaryContributorLabel: work.contributors.find(
+      contributor => contributor.primary
+    )?.agent.label,
+  };
+}

--- a/catalogue/webapp/services/wellcome/catalogue/types/work.ts
+++ b/catalogue/webapp/services/wellcome/catalogue/types/work.ts
@@ -27,7 +27,9 @@ export function toWorkBasic(work: Work): WorkBasic {
   // We only send a lang if it's unambiguous -- better to send
   // no language than the wrong one.
   const languageId =
-    work.languages.length === 1 ? work.languages[0].id : undefined;
+    work.languages && work.languages.length === 1
+      ? work.languages[0].id
+      : undefined;
 
   return {
     id,

--- a/catalogue/webapp/services/wellcome/catalogue/types/work.ts
+++ b/catalogue/webapp/services/wellcome/catalogue/types/work.ts
@@ -11,21 +11,28 @@ import { DigitalLocation } from '@weco/common/model/catalogue';
 export type WorkBasic = {
   id: string;
   title: string;
+  description?: string;
   thumbnail?: DigitalLocation;
   referenceNumber?: string;
   productionDates: string[];
   archiveLabels?: ArchiveLabels;
   cardLabels: Label[];
   primaryContributorLabel?: string;
-  languageIds: string[];
+  languageId?: string;
 };
 
 export function toWorkBasic(work: Work): WorkBasic {
-  const { id, title, thumbnail, referenceNumber } = work;
+  const { id, title, description, thumbnail, referenceNumber } = work;
+
+  // We only send a lang if it's unambiguous -- better to send
+  // no language than the wrong one.
+  const languageId =
+    work.languages.length === 1 ? work.languages[0].id : undefined;
 
   return {
     id,
     title,
+    description,
     thumbnail,
     referenceNumber,
     productionDates: getProductionDates(work),
@@ -34,6 +41,6 @@ export function toWorkBasic(work: Work): WorkBasic {
     primaryContributorLabel: work.contributors.find(
       contributor => contributor.primary
     )?.agent.label,
-    languageIds: work.languages.map(lang => lang.id),
+    languageId,
   };
 }

--- a/catalogue/webapp/services/wellcome/catalogue/types/work.ts
+++ b/catalogue/webapp/services/wellcome/catalogue/types/work.ts
@@ -12,24 +12,28 @@ export type WorkBasic = {
   id: string;
   title: string;
   thumbnail?: DigitalLocation;
+  referenceNumber?: string;
   productionDates: string[];
   archiveLabels?: ArchiveLabels;
   cardLabels: Label[];
   primaryContributorLabel?: string;
+  languageIds: string[];
 };
 
 export function toWorkBasic(work: Work): WorkBasic {
-  const { id, title, thumbnail } = work;
+  const { id, title, thumbnail, referenceNumber } = work;
 
   return {
     id,
     title,
     thumbnail,
+    referenceNumber,
     productionDates: getProductionDates(work),
     archiveLabels: getArchiveLabels(work),
     cardLabels: getCardLabels(work),
     primaryContributorLabel: work.contributors.find(
       contributor => contributor.primary
     )?.agent.label,
+    languageIds: work.languages.map(lang => lang.id),
   };
 }

--- a/catalogue/webapp/utils/works.ts
+++ b/catalogue/webapp/utils/works.ts
@@ -204,7 +204,7 @@ export function getItemIdentifiersWith(
   );
 }
 
-type ArchiveLabels = {
+export type ArchiveLabels = {
   reference: string;
   partOf?: string;
 };


### PR DESCRIPTION
There are several places where we pass around way more information about a Work than is required to render the page, in particular:

* the search results page
* the item page
* the image page

This patch introduces a new WorkBasic model which just contains the subset of fields we actually need, allowing us to simplify this code somewhat and reduce the amount of data we send in the Next props.

For https://github.com/wellcomecollection/wellcomecollection.org/issues/8339