### PR TITLE
Windows dropdown pill styling fix for /images darkBg

### DIFF
--- a/common/views/components/SelectContainer/SelectContainer.tsx
+++ b/common/views/components/SelectContainer/SelectContainer.tsx
@@ -35,7 +35,8 @@ const StyledSelect = styled.div.attrs({
         props.theme.color(props.darkBg ? 'neutral.300' : 'neutral.600')};
     border-radius: ${props =>
       props.isPill ? 20 : props.theme.borderRadiusUnit}px;
-    background-color: ${props => props.theme.color('transparent')};
+    background-color: ${props =>
+      props.theme.color(props.darkBg ? 'black' : 'transparent')};
     color: ${props =>
       props.theme.color(
         props.darkBg ? 'white' : 'black'

--- a/common/views/components/SelectContainer/SelectContainer.tsx
+++ b/common/views/components/SelectContainer/SelectContainer.tsx
@@ -44,6 +44,12 @@ const StyledSelect = styled.div.attrs({
     width: 100%;
     ${props => (props.isPill ? 'line-height: 1;' : '')}
 
+    option {
+      background-color: ${props => props.theme.color('white')};
+      color: ${props => props.theme.color('black')};
+      /* This allows Windows users to see <Select> dropdown options on a darkBg theme */
+    }
+
     &::-ms-expand {
       display: none;
     }


### PR DESCRIPTION
## Who is this for?
Windows users of `/search/images`

for #10003 

## What is it doing for them?
I've inserted some styling for `<option>` within `SelectContainer>` that only affects Windows OS users, by enabling them to see the full dropdown menu when navigating `<Sort>` components within a `darkBg` container. 

I've also reverted the `background-color` value from only having `'transparent'` to also including `'black'` (it used to be `'white'` but this caused the pill to be white, which doesn't macth the `/images` theme to use in `darkBg` to match its theme more consistently, without (hopefully) introducing any errors from `'transparent'` only. 

This matches styling on Windows across `/stories` and `/works`. Again, does not affect other users across MacOS, iOS, or Android who all override dropdown styling. 

How this PR looks on Windows. 
![Screenshot 2023-07-04 at 16 44 44](https://github.com/wellcomecollection/wellcomecollection.org/assets/81175151/5f9d67e2-1cb8-4ef1-acc7-10a955f5de71)

---

Without overriding styling with `option {}`
![Screenshot 2023-07-04 at 16 32 58](https://github.com/wellcomecollection/wellcomecollection.org/assets/81175151/b1dbffab-6820-4cff-a343-2906a92de78e)


---

Currently looks like
![image](https://github.com/wellcomecollection/wellcomecollection.org/assets/81175151/73dd5343-769e-4c38-81b2-6b0f26bfc3f9)

