### PR TITLE
Add text-and-image slice

### DIFF
--- a/prismic-model/src/parts/body.ts
+++ b/prismic-model/src/parts/body.ts
@@ -17,10 +17,15 @@ type SliceProps = {
   repeat?: Record<string, unknown>;
 };
 
-export function slice(label: string, { nonRepeat, repeat }: SliceProps) {
+export function slice(
+  label: string,
+  { nonRepeat, repeat }: SliceProps,
+  description?: string
+) {
   return {
     type: 'Slice',
     fieldset: label,
+    description,
     'non-repeat': nonRepeat,
     repeat,
   };

--- a/prismic-model/src/parts/visual-story-body.ts
+++ b/prismic-model/src/parts/visual-story-body.ts
@@ -1,4 +1,5 @@
 import body, { slice } from './body';
+import boolean from './boolean';
 import { documentLink } from './link';
 import { multiLineText, singleLineText } from './text';
 
@@ -45,6 +46,18 @@ export default {
           }),
         },
       },
+      textAndImage: slice('Text and image (side-by-side)', {
+        repeat: {
+          text: multiLineText('Text'),
+          image: {
+            type: 'Image',
+            config: {
+              label: 'Image',
+            },
+          },
+          isZoomable: boolean('Allow image to be zoomed to fill viewport?'),
+        },
+      }),
     },
   },
 };

--- a/prismic-model/src/parts/visual-story-body.ts
+++ b/prismic-model/src/parts/visual-story-body.ts
@@ -46,18 +46,22 @@ export default {
           }),
         },
       },
-      textAndImage: slice('Text and image (side-by-side)', {
-        repeat: {
-          text: multiLineText('Text'),
-          image: {
-            type: 'Image',
-            config: {
-              label: 'Image',
+      textAndImage: slice(
+        'Text and image',
+        {
+          repeat: {
+            text: multiLineText('Text'),
+            image: {
+              type: 'Image',
+              config: {
+                label: 'Image',
+              },
             },
+            isZoomable: boolean('Allow image to be zoomed to fill viewport?'),
           },
-          isZoomable: boolean('Allow image to be zoomed to fill viewport?'),
         },
-      }),
+        'Side-by-side'
+      ),
     },
   },
 };


### PR DESCRIPTION
## Who is this for?
Content editors

## What is it doing for them?
Adding a 'Text and image (side-by-side)' slice in the Visual Stories Content Type