### PR TITLE
Make text-and-image non-repeat

### DIFF
--- a/prismic-model/src/parts/visual-story-body.ts
+++ b/prismic-model/src/parts/visual-story-body.ts
@@ -49,7 +49,7 @@ export default {
       textAndImage: slice(
         'Text and image',
         {
-          repeat: {
+          nonRepeat: {
             text: multiLineText('Text'),
             image: {
               type: 'Image',


### PR DESCRIPTION
## Who is this for?
Content editors

## What is it doing for them?
Making the text-and-image non-repeating so that it will be consistent with the upcoming text-and-icons slice (on account of Prismic not being able to handle nested repeating fields in a straightforward way).

We don't need content to be grouped in e.g. a `ul`, and we have already solved the problem of adding dividing lines between back-to-back slices of a certain type, so this should be ok from the front end's perspective.