### PR TITLE
Make description a SliceProp

### DIFF
--- a/prismic-model/src/parts/body.ts
+++ b/prismic-model/src/parts/body.ts
@@ -15,12 +15,12 @@ import booleanDeprecated from './boolean-deprecated';
 type SliceProps = {
   nonRepeat?: Record<string, unknown>;
   repeat?: Record<string, unknown>;
+  description?: string;
 };
 
 export function slice(
   label: string,
-  { nonRepeat, repeat }: SliceProps,
-  description?: string
+  { nonRepeat, repeat, description }: SliceProps
 ) {
   return {
     type: 'Slice',

--- a/prismic-model/src/parts/visual-story-body.ts
+++ b/prismic-model/src/parts/visual-story-body.ts
@@ -46,22 +46,19 @@ export default {
           }),
         },
       },
-      textAndImage: slice(
-        'Text and image',
-        {
-          nonRepeat: {
-            text: multiLineText('Text'),
-            image: {
-              type: 'Image',
-              config: {
-                label: 'Image',
-              },
+      textAndImage: slice('Text and image', {
+        description: 'Side-by-side',
+        nonRepeat: {
+          text: multiLineText('Text'),
+          image: {
+            type: 'Image',
+            config: {
+              label: 'Image',
             },
-            isZoomable: boolean('Allow image to be zoomed to fill viewport?'),
           },
+          isZoomable: boolean('Allow image to be zoomed to fill viewport?'),
         },
-        'Side-by-side'
-      ),
+      }),
     },
   },
 };


### PR DESCRIPTION
## Who is this for?
Devs

## What is it doing for them?
Making a slice `description` a named prop instead of a third argument