### PR TITLE
Allow event-series in exhibitionOfs

### DIFF
--- a/content/webapp/services/prismic/transformers/exhibitions.ts
+++ b/content/webapp/services/prismic/transformers/exhibitions.ts
@@ -263,7 +263,10 @@ export const transformExhibitionRelatedContent = (
 
   return {
     exhibitionOfs: parsedContent.filter(
-      doc => doc.type === 'exhibitions' || doc.type === 'events'
+      doc =>
+        doc.type === 'exhibitions' ||
+        doc.type === 'events' ||
+        doc.type === 'event-series'
     ),
     exhibitionAbouts: parsedContent.filter(
       doc =>


### PR DESCRIPTION
## Who is this for?
Content team ([Slack thread](https://wellcome.slack.com/archives/C8X9YKM5X/p1688562645075639))

## What is it doing for them?
Letting them add `event-series` items to the 'About this exhibition' section of an exhibition page