### PR TITLE
Make TextAndImageOrIcons take a single item

### DIFF
--- a/cardigan/stories/components/TextAndImageOrIcons/TextAndImageOrIcons.stories.tsx
+++ b/cardigan/stories/components/TextAndImageOrIcons/TextAndImageOrIcons.stories.tsx
@@ -15,30 +15,21 @@ const Template = args => (
 
 export const icons = Template.bind({});
 icons.args = {
-  items: [
-    {
-      type: 'icons',
-      icons: mockIcons,
-      text: smallText(),
-    },
-    {
-      type: 'icons',
-      icons: mockIcons.slice(2, 4),
-      text: smallText(),
-    },
-  ],
+  item: {
+    type: 'icons',
+    icons: mockIcons,
+    text: smallText(),
+  },
 };
 icons.storyName = 'TextAndIcons';
 
 export const image = Template.bind({});
 image.args = {
-  items: [
-    {
-      type: 'image',
-      image: mockImage,
-      isZoomable: true,
-      text: smallText(),
-    },
-  ],
+  item: {
+    type: 'image',
+    image: mockImage,
+    isZoomable: true,
+    text: smallText(),
+  },
 };
 image.storyName = 'TextAndImage';

--- a/content/webapp/components/TextAndImageOrIcons/TextAndImageOrIcons.tsx
+++ b/content/webapp/components/TextAndImageOrIcons/TextAndImageOrIcons.tsx
@@ -73,44 +73,42 @@ type Item = {
 );
 
 type Props = {
-  items: Item[];
+  item: Item;
 };
 
-const TextAndImageOrIcons: FunctionComponent<Props> = ({ items }) => {
+const TextAndImageOrIcons: FunctionComponent<Props> = ({ item }) => {
   return (
     <>
-      {items.map((item, index) => (
-        <DividingLine key={index}>
-          <MediaAndTextWrap>
-            {item.type === 'icons' && (
-              <ImageOrIcons isIcons={true}>
-                {item.icons.map((icon, index) => {
-                  return (
-                    <div key={index}>
-                      <PrismicImage image={icon} quality="low" maxWidth={100} />
-                    </div>
-                  );
-                })}
-              </ImageOrIcons>
-            )}
+      <DividingLine>
+        <MediaAndTextWrap>
+          {item.type === 'icons' && (
+            <ImageOrIcons isIcons={true}>
+              {item.icons.map((icon, index) => {
+                return (
+                  <div key={index}>
+                    <PrismicImage image={icon} quality="low" maxWidth={100} />
+                  </div>
+                );
+              })}
+            </ImageOrIcons>
+          )}
 
-            {item.type === 'image' && (
-              <ImageOrIcons isPortrait={item.image.width < item.image.height}>
-                <CaptionedImage
-                  image={item.image}
-                  caption={[]}
-                  hasRoundedCorners={false}
-                  isZoomable={item.isZoomable}
-                />
-              </ImageOrIcons>
-            )}
+          {item.type === 'image' && (
+            <ImageOrIcons isPortrait={item.image.width < item.image.height}>
+              <CaptionedImage
+                image={item.image}
+                caption={[]}
+                hasRoundedCorners={false}
+                isZoomable={item.isZoomable}
+              />
+            </ImageOrIcons>
+          )}
 
-            <Text>
-              <PrismicHtmlBlock html={item.text} />
-            </Text>
-          </MediaAndTextWrap>
-        </DividingLine>
-      ))}
+          <Text>
+            <PrismicHtmlBlock html={item.text} />
+          </Text>
+        </MediaAndTextWrap>
+      </DividingLine>
     </>
   );
 };


### PR DESCRIPTION
After #10011 (and #10014) the component that handles the text-and-image/text-and-icons slices no longer takes an array of items, but a single item only.