### PR TITLE
Simplify the data we pass into the IIIF components

### DIFF
--- a/catalogue/webapp/components/IIIFSearchWithin/IIIFSearchWithin.tsx
+++ b/catalogue/webapp/components/IIIFSearchWithin/IIIFSearchWithin.tsx
@@ -20,7 +20,7 @@ import { search } from '@weco/common/icons';
 import { themeValues } from '@weco/common/views/themes/config';
 import { toLink as itemLink } from '@weco/catalogue/components/ItemLink';
 import NextLink from 'next/link';
-import { arrayIndexToQueryParam } from '@weco/catalogue/components/IIIFViewer/IIIFViewer';
+import { arrayIndexToQueryParam } from '@weco/catalogue/components/IIIFViewer';
 import { SearchResults } from '@weco/catalogue/services/iiif/types/search/v3';
 import { TransformedCanvas } from '@weco/catalogue/types/manifest';
 

--- a/catalogue/webapp/components/IIIFViewer/GridViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/GridViewer.tsx
@@ -22,10 +22,7 @@ import { AppContext } from '@weco/common/views/components/AppContext/AppContext'
 import { TransformedCanvas } from '@weco/catalogue/types/manifest';
 import NextLink from 'next/link';
 import { toLink as itemLink } from '@weco/catalogue/components/ItemLink';
-import {
-  arrayIndexToQueryParam,
-  queryParamToArrayIndex,
-} from '@weco/catalogue/components/IIIFViewer/IIIFViewer';
+import { arrayIndexToQueryParam, queryParamToArrayIndex } from '.';
 
 const ThumbnailSpacer = styled(Space).attrs({
   v: { size: 's', properties: ['padding-top', 'padding-bottom'] },

--- a/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
@@ -29,6 +29,7 @@ import NoScriptViewer from './NoScriptViewer';
 import { fetchJson } from '@weco/common/utils/http';
 import { TransformedManifest } from '@weco/catalogue/types/manifest';
 import { fromQuery } from '@weco/catalogue/components/ItemLink';
+import { OptionalToUndefined } from '@weco/common/utils/utility-types';
 
 // canvas and manifest params use 1-based indexing, but are used to access items in 0 indexed arrays,
 // so we need to convert it in various places
@@ -60,13 +61,14 @@ const DelayVisibility = styled.div`
   animation: 0.5s ${show} 2s forwards;
 `;
 
-type IIIFViewerProps = {
+type IIIFViewerProps = OptionalToUndefined<{
   work: Work;
-  iiifImageLocation: DigitalLocation | undefined;
+  iiifImageLocation?: DigitalLocation;
+  iiifPresentationLocation?: DigitalLocation;
   transformedManifest?: TransformedManifest;
   canvasOcr?: string;
   handleImageError?: () => void;
-};
+}>;
 
 const LoadingComponent = () => (
   <div
@@ -218,6 +220,7 @@ const Thumbnails = styled.div<{
 const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
   work,
   iiifImageLocation,
+  iiifPresentationLocation,
   transformedManifest,
   canvasOcr,
   handleImageError,
@@ -348,7 +351,10 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
             isActiveMobile={isMobileSidebarActive}
             isActiveDesktop={isDesktopSidebarActive}
           >
-            <ViewerSidebar iiifImageLocation={iiifImageLocation} />
+            <ViewerSidebar
+              iiifImageLocation={iiifImageLocation}
+              iiifPresentationLocation={iiifPresentationLocation}
+            />
           </Sidebar>
           <Topbar isDesktopSidebarActive={isDesktopSidebarActive}>
             <ViewerTopBar iiifImageLocation={iiifImageLocation} />

--- a/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
@@ -29,7 +29,6 @@ import NoScriptViewer from './NoScriptViewer';
 import { fetchJson } from '@weco/common/utils/http';
 import { TransformedManifest } from '@weco/catalogue/types/manifest';
 import { fromQuery } from '@weco/catalogue/components/ItemLink';
-import { OptionalToUndefined } from '@weco/common/utils/utility-types';
 
 // canvas and manifest params use 1-based indexing, but are used to access items in 0 indexed arrays,
 // so we need to convert it in various places
@@ -61,14 +60,14 @@ const DelayVisibility = styled.div`
   animation: 0.5s ${show} 2s forwards;
 `;
 
-type IIIFViewerProps = OptionalToUndefined<{
+type IIIFViewerProps = {
   work: Work;
   iiifImageLocation?: DigitalLocation;
   iiifPresentationLocation?: DigitalLocation;
   transformedManifest?: TransformedManifest;
   canvasOcr?: string;
   handleImageError?: () => void;
-}>;
+};
 
 const LoadingComponent = () => (
   <div

--- a/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
@@ -29,16 +29,7 @@ import NoScriptViewer from './NoScriptViewer';
 import { fetchJson } from '@weco/common/utils/http';
 import { TransformedManifest } from '@weco/catalogue/types/manifest';
 import { fromQuery } from '@weco/catalogue/components/ItemLink';
-
-// canvas and manifest params use 1-based indexing, but are used to access items in 0 indexed arrays,
-// so we need to convert it in various places
-export function queryParamToArrayIndex(canvas: number): number {
-  return canvas - 1;
-}
-
-export function arrayIndexToQueryParam(canvasIndex: number): number {
-  return canvasIndex + 1;
-}
+import { queryParamToArrayIndex } from '.';
 
 const show = keyframes`
   from {

--- a/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
@@ -221,7 +221,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
   transformedManifest,
   canvasOcr,
   handleImageError,
-}: IIIFViewerProps) => {
+}) => {
   const router = useRouter();
   const {
     page = 1,

--- a/catalogue/webapp/components/IIIFViewer/ImageViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ImageViewer.tsx
@@ -14,10 +14,7 @@ import ItemViewerContext from '../ItemViewerContext/ItemViewerContext';
 import Router from 'next/router';
 import { toLink as itemLink } from '@weco/catalogue/components/ItemLink';
 import useSkipInitialEffect from '@weco/common/hooks/useSkipInitialEffect';
-import {
-  arrayIndexToQueryParam,
-  queryParamToArrayIndex,
-} from '@weco/catalogue/components/IIIFViewer/IIIFViewer';
+import { arrayIndexToQueryParam, queryParamToArrayIndex } from '.';
 
 const ImageWrapper = styled.div`
   position: absolute;

--- a/catalogue/webapp/components/IIIFViewer/ImageViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ImageViewer.tsx
@@ -64,7 +64,7 @@ const ImageViewer: FunctionComponent<ImageViewerProps> = ({
   index,
   setImageRect,
   setImageContainerRect,
-}: ImageViewerProps) => {
+}) => {
   const {
     work,
     errorHandler,

--- a/catalogue/webapp/components/IIIFViewer/MainViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/MainViewer.tsx
@@ -25,7 +25,7 @@ import { TransformedCanvas } from '@weco/catalogue/types/manifest';
 import { fetchCanvasOcr } from '@weco/catalogue/services/iiif/fetch/canvasOcr';
 import { transformCanvasOcr } from '@weco/catalogue/services/iiif/transformers/canvasOcr';
 import { AuthExternalService } from '@iiif/presentation-3';
-import { queryParamToArrayIndex } from './IIIFViewer';
+import { queryParamToArrayIndex } from '.';
 
 type OverlayPositionData = {
   canvasNumber: number;

--- a/catalogue/webapp/components/IIIFViewer/MultipleManifestList.tsx
+++ b/catalogue/webapp/components/IIIFViewer/MultipleManifestList.tsx
@@ -7,7 +7,7 @@ import {
   getMultiVolumeLabel,
   getCollectionManifests,
 } from '@weco/catalogue/utils/iiif/v3';
-import { queryParamToArrayIndex } from '@weco/catalogue/components/IIIFViewer/IIIFViewer';
+import { queryParamToArrayIndex } from '.';
 import {
   List,
   Item,

--- a/catalogue/webapp/components/IIIFViewer/NoScriptViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/NoScriptViewer.tsx
@@ -19,6 +19,7 @@ import {
   arrayIndexToQueryParam,
   queryParamToArrayIndex,
 } from '@weco/catalogue/components/IIIFViewer/IIIFViewer';
+import { OptionalToUndefined } from '@weco/common/utils/utility-types';
 
 const NoScriptViewerEl = styled.div`
   display: flex;
@@ -143,17 +144,17 @@ const PaginatorButtons = (
 };
 /* eslint-enable react/display-name */
 
-type NoScriptViewerProps = {
+type NoScriptViewerProps = OptionalToUndefined<{
   imageUrl?: string;
   iiifImageLocation?: { url: string };
   canvasOcr?: string;
-};
+}>;
 
 const NoScriptViewer: FunctionComponent<NoScriptViewerProps> = ({
   imageUrl,
   iiifImageLocation,
   canvasOcr,
-}: NoScriptViewerProps) => {
+}) => {
   const { work, query, transformedManifest } = useContext(ItemViewerContext);
   const lang = (work.languages.length === 1 && work.languages[0].id) || '';
   const { canvases } = { ...transformedManifest };

--- a/catalogue/webapp/components/IIIFViewer/NoScriptViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/NoScriptViewer.tsx
@@ -15,10 +15,7 @@ import { FunctionComponent, useContext } from 'react';
 import { toLink as itemLink } from '@weco/catalogue/components/ItemLink';
 import { arrow } from '@weco/common/icons';
 import ItemViewerContext from '../ItemViewerContext/ItemViewerContext';
-import {
-  arrayIndexToQueryParam,
-  queryParamToArrayIndex,
-} from '@weco/catalogue/components/IIIFViewer/IIIFViewer';
+import { arrayIndexToQueryParam, queryParamToArrayIndex } from '.';
 import { OptionalToUndefined } from '@weco/common/utils/utility-types';
 
 const NoScriptViewerEl = styled.div`

--- a/catalogue/webapp/components/IIIFViewer/ViewerSidebar.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerSidebar.tsx
@@ -121,12 +121,12 @@ const AccordionItem = ({ title, children, testId }: AccordionItemProps) => {
   );
 };
 
-type Props = OptionalToUndefined<{
+type ViewerSidebarProps = OptionalToUndefined<{
   iiifImageLocation?: DigitalLocation;
   iiifPresentationLocation?: DigitalLocation;
 }>;
 
-const ViewerSidebar: FunctionComponent<Props> = ({
+const ViewerSidebar: FunctionComponent<ViewerSidebarProps> = ({
   iiifImageLocation,
   iiifPresentationLocation,
 }) => {

--- a/catalogue/webapp/components/IIIFViewer/ViewerSidebar.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerSidebar.tsx
@@ -29,6 +29,7 @@ import {
   getMultiVolumeLabel,
   getCollectionManifests,
 } from '@weco/catalogue/utils/iiif/v3';
+import { OptionalToUndefined } from '@weco/common/utils/utility-types';
 
 const Inner = styled(Space).attrs({
   h: { size: 'm', properties: ['padding-left', 'padding-right'] },
@@ -123,9 +124,11 @@ const AccordionItem = ({ title, children, testId }: AccordionItemProps) => {
   );
 };
 
-const ViewerSidebar: FunctionComponent<{
+type Props = OptionalToUndefined<{
   iiifImageLocation?: DigitalLocation;
-}> = ({ iiifImageLocation }) => {
+}>;
+
+const ViewerSidebar: FunctionComponent<Props> = ({ iiifImageLocation }) => {
   const { work, transformedManifest, parentManifest } =
     useContext(ItemViewerContext);
   const [currentManifestLabel, setCurrentManifestLabel] = useState<
@@ -134,14 +137,12 @@ const ViewerSidebar: FunctionComponent<{
   const { iiifCredit, structures, searchService } = { ...transformedManifest };
   const productionDates = getProductionDates(work);
   // Determine digital location
-  const imageLocation =
-    iiifImageLocation || getDigitalLocationOfType(work, 'iiif-image');
   const iiifPresentationLocation = getDigitalLocationOfType(
     work,
     'iiif-presentation'
   );
   const digitalLocation: DigitalLocation | undefined =
-    iiifPresentationLocation || imageLocation;
+    iiifPresentationLocation || iiifImageLocation;
 
   const license =
     digitalLocation?.license &&

--- a/catalogue/webapp/components/IIIFViewer/ViewerSidebar.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerSidebar.tsx
@@ -13,10 +13,7 @@ import styled from 'styled-components';
 import Space from '@weco/common/views/components/styled/Space';
 import { classNames, font } from '@weco/common/utils/classnames';
 import LinkLabels from '@weco/common/views/components/LinkLabels/LinkLabels';
-import {
-  getProductionDates,
-  getDigitalLocationOfType,
-} from '@weco/catalogue/utils/works';
+import { getProductionDates } from '@weco/catalogue/utils/works';
 import { getCatalogueLicenseData } from '@weco/common/utils/licenses';
 import ViewerStructures from './ViewerStructures';
 import ItemViewerContext from '../ItemViewerContext/ItemViewerContext';
@@ -126,9 +123,13 @@ const AccordionItem = ({ title, children, testId }: AccordionItemProps) => {
 
 type Props = OptionalToUndefined<{
   iiifImageLocation?: DigitalLocation;
+  iiifPresentationLocation?: DigitalLocation;
 }>;
 
-const ViewerSidebar: FunctionComponent<Props> = ({ iiifImageLocation }) => {
+const ViewerSidebar: FunctionComponent<Props> = ({
+  iiifImageLocation,
+  iiifPresentationLocation,
+}) => {
   const { work, transformedManifest, parentManifest } =
     useContext(ItemViewerContext);
   const [currentManifestLabel, setCurrentManifestLabel] = useState<
@@ -136,11 +137,7 @@ const ViewerSidebar: FunctionComponent<Props> = ({ iiifImageLocation }) => {
   >();
   const { iiifCredit, structures, searchService } = { ...transformedManifest };
   const productionDates = getProductionDates(work);
-  // Determine digital location
-  const iiifPresentationLocation = getDigitalLocationOfType(
-    work,
-    'iiif-presentation'
-  );
+
   const digitalLocation: DigitalLocation | undefined =
     iiifPresentationLocation || iiifImageLocation;
 

--- a/catalogue/webapp/components/IIIFViewer/ViewerStructures.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerStructures.tsx
@@ -10,7 +10,7 @@ import {
 import PlainList from '@weco/common/views/components/styled/PlainList';
 import { toLink as itemLink } from '@weco/catalogue/components/ItemLink';
 import NextLink from 'next/link';
-import { arrayIndexToQueryParam } from '@weco/catalogue/components/IIIFViewer/IIIFViewer';
+import { arrayIndexToQueryParam } from '.';
 
 export const List = styled(PlainList)`
   border-left: 1px solid ${props => props.theme.color('neutral.600')};

--- a/catalogue/webapp/components/IIIFViewer/ViewerTopBar.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerTopBar.tsx
@@ -189,9 +189,11 @@ const RightZone = styled.div`
   align-items: center;
 `;
 
-const ViewerTopBar: FunctionComponent<{
+type Props = {
   iiifImageLocation?: DigitalLocation;
-}> = ({ iiifImageLocation }) => {
+};
+
+const ViewerTopBar: FunctionComponent<Props> = ({ iiifImageLocation }) => {
   const { isEnhanced } = useContext(AppContext);
   const isFullscreenEnabled = useIsFullscreenEnabled();
   const {

--- a/catalogue/webapp/components/IIIFViewer/ViewerTopBar.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerTopBar.tsx
@@ -20,11 +20,9 @@ import {
   singlePage,
 } from '@weco/common/icons';
 import { queryParamToArrayIndex } from './IIIFViewer';
-import {
-  getDownloadOptionsFromImageUrl,
-  getDigitalLocationOfType,
-} from '@weco/catalogue/utils/works';
+import { getDownloadOptionsFromImageUrl } from '@weco/catalogue/utils/works';
 import useTransformedIIIFImage from '@weco/catalogue/hooks/useTransformedIIIFImage';
+import { OptionalToUndefined } from '@weco/common/utils/utility-types';
 
 // TODO: update this with a more considered button from our system
 export const ShameButton = styled.button.attrs({
@@ -189,9 +187,9 @@ const RightZone = styled.div`
   align-items: center;
 `;
 
-type Props = {
+type Props = OptionalToUndefined<{
   iiifImageLocation?: DigitalLocation;
-};
+}>;
 
 const ViewerTopBar: FunctionComponent<Props> = ({ iiifImageLocation }) => {
   const { isEnhanced } = useContext(AppContext);
@@ -219,8 +217,7 @@ const ViewerTopBar: FunctionComponent<Props> = ({ iiifImageLocation }) => {
   const currentCanvas = canvases?.[queryParamToArrayIndex(query.canvas)];
   const mainImageService = { '@id': currentCanvas?.imageServiceId };
   const transformedIIIFImage = useTransformedIIIFImage(work);
-  const imageLocation =
-    iiifImageLocation || getDigitalLocationOfType(work, 'iiif-image');
+
   // Works can have a DigitalLocation of type iiif-presentation and/or iiif-image.
   // For a iiif-presentation DigitalLocation we get the download options from the manifest to which it points.
   // For a iiif-image DigitalLocation we create the download options
@@ -231,9 +228,9 @@ const ViewerTopBar: FunctionComponent<Props> = ({ iiifImageLocation }) => {
   // Sometimes we render images for works that have neither a iiif-image or a iiif-presentation location type.
   // In this case we use the iiifImageLocation passed from the serverSideProps of the /images.tsx
 
-  const iiifImageDownloadOptions = imageLocation
+  const iiifImageDownloadOptions = iiifImageLocation
     ? getDownloadOptionsFromImageUrl({
-        url: imageLocation.url,
+        url: iiifImageLocation.url,
         width: transformedIIIFImage.width,
         height: transformedIIIFImage.height,
       })

--- a/catalogue/webapp/components/IIIFViewer/ViewerTopBar.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerTopBar.tsx
@@ -19,7 +19,7 @@ import {
   gridView,
   singlePage,
 } from '@weco/common/icons';
-import { queryParamToArrayIndex } from './IIIFViewer';
+import { queryParamToArrayIndex } from '.';
 import { getDownloadOptionsFromImageUrl } from '@weco/catalogue/utils/works';
 import useTransformedIIIFImage from '@weco/catalogue/hooks/useTransformedIIIFImage';
 import { OptionalToUndefined } from '@weco/common/utils/utility-types';

--- a/catalogue/webapp/components/IIIFViewer/ViewerTopBar.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerTopBar.tsx
@@ -187,11 +187,13 @@ const RightZone = styled.div`
   align-items: center;
 `;
 
-type Props = OptionalToUndefined<{
+type ViewerTopBarProps = OptionalToUndefined<{
   iiifImageLocation?: DigitalLocation;
 }>;
 
-const ViewerTopBar: FunctionComponent<Props> = ({ iiifImageLocation }) => {
+const ViewerTopBar: FunctionComponent<ViewerTopBarProps> = ({
+  iiifImageLocation,
+}) => {
   const { isEnhanced } = useContext(AppContext);
   const isFullscreenEnabled = useIsFullscreenEnabled();
   const {

--- a/catalogue/webapp/components/IIIFViewer/ZoomedImage.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ZoomedImage.tsx
@@ -15,6 +15,7 @@ import ItemViewerContext from '../ItemViewerContext/ItemViewerContext';
 import { cross, minus, plus, rotateRight } from '@weco/common/icons';
 import { convertIiifUriToInfoUri } from '@weco/catalogue/utils/convert-iiif-uri';
 import { queryParamToArrayIndex } from '@weco/catalogue/components/IIIFViewer/IIIFViewer';
+import { OptionalToUndefined } from '@weco/common/utils/utility-types';
 
 const ZoomedImageContainer = styled.div`
   position: relative;
@@ -42,9 +43,9 @@ const ErrorMessage = () => (
   </div>
 );
 
-type Props = {
-  iiifImageLocation: DigitalLocation | undefined;
-};
+type Props = OptionalToUndefined<{
+  iiifImageLocation?: DigitalLocation;
+}>;
 
 const ZoomedImage: FunctionComponent<Props> = ({ iiifImageLocation }) => {
   const { transformedManifest, query, setShowZoomed } =

--- a/catalogue/webapp/components/IIIFViewer/ZoomedImage.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ZoomedImage.tsx
@@ -46,9 +46,7 @@ type Props = {
   iiifImageLocation: DigitalLocation | undefined;
 };
 
-const ZoomedImage: FunctionComponent<Props> = ({
-  iiifImageLocation,
-}: Props) => {
+const ZoomedImage: FunctionComponent<Props> = ({ iiifImageLocation }) => {
   const { transformedManifest, query, setShowZoomed } =
     useContext(ItemViewerContext);
   const currentCanvas =

--- a/catalogue/webapp/components/IIIFViewer/ZoomedImage.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ZoomedImage.tsx
@@ -14,7 +14,7 @@ import Space from '@weco/common/views/components/styled/Space';
 import ItemViewerContext from '../ItemViewerContext/ItemViewerContext';
 import { cross, minus, plus, rotateRight } from '@weco/common/icons';
 import { convertIiifUriToInfoUri } from '@weco/catalogue/utils/convert-iiif-uri';
-import { queryParamToArrayIndex } from '@weco/catalogue/components/IIIFViewer/IIIFViewer';
+import { queryParamToArrayIndex } from '.';
 import { OptionalToUndefined } from '@weco/common/utils/utility-types';
 
 const ZoomedImageContainer = styled.div`

--- a/catalogue/webapp/components/IIIFViewer/ZoomedImage.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ZoomedImage.tsx
@@ -63,7 +63,7 @@ const ZoomedImage: FunctionComponent<Props> = ({ iiifImageLocation }) => {
   const firstControl = useRef<HTMLButtonElement>(null);
   const lastControl = useRef<HTMLButtonElement>(null);
   const zoomedImage = useRef<HTMLDivElement>(null);
-  function setupViewer(imageInfoSrc, viewerId) {
+  function setupViewer(imageInfoSrc: string, viewerId: string) {
     fetch(imageInfoSrc)
       .then(response => response.json())
       .then(response => {

--- a/catalogue/webapp/components/IIIFViewer/ZoomedImage.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ZoomedImage.tsx
@@ -43,11 +43,13 @@ const ErrorMessage = () => (
   </div>
 );
 
-type Props = OptionalToUndefined<{
+type ZoomedImageProps = OptionalToUndefined<{
   iiifImageLocation?: DigitalLocation;
 }>;
 
-const ZoomedImage: FunctionComponent<Props> = ({ iiifImageLocation }) => {
+const ZoomedImage: FunctionComponent<ZoomedImageProps> = ({
+  iiifImageLocation,
+}) => {
   const { transformedManifest, query, setShowZoomed } =
     useContext(ItemViewerContext);
   const currentCanvas =

--- a/catalogue/webapp/components/IIIFViewer/index.tsx
+++ b/catalogue/webapp/components/IIIFViewer/index.tsx
@@ -1,0 +1,13 @@
+import IIIFViewer from './IIIFViewer';
+
+// canvas and manifest params use 1-based indexing, but are used to access items in 0 indexed arrays,
+// so we need to convert it in various places
+export function queryParamToArrayIndex(canvas: number): number {
+  return canvas - 1;
+}
+
+export function arrayIndexToQueryParam(canvasIndex: number): number {
+  return canvasIndex + 1;
+}
+
+export default IIIFViewer;

--- a/catalogue/webapp/pages/works/[workId]/images.tsx
+++ b/catalogue/webapp/pages/works/[workId]/images.tsx
@@ -19,6 +19,7 @@ import {
   setTzitzitParams,
 } from '@weco/common/views/components/ApiToolbar';
 import { setCacheControl } from '@weco/common/utils/setCacheControl';
+import { getDigitalLocationOfType } from 'utils/works';
 
 function createTzitzitImageLink(
   work: Work,
@@ -45,7 +46,8 @@ const ImagePage: FunctionComponent<Props> = ({
   catalogueApiUrl,
 }) => {
   const title = work.title || '';
-  const iiifImageLocation = image.locations[0];
+  const iiifImageLocation =
+    image.locations[0] || getDigitalLocationOfType(work, 'iiif-image');
 
   const apiLink = {
     id: 'json',

--- a/catalogue/webapp/pages/works/[workId]/images.tsx
+++ b/catalogue/webapp/pages/works/[workId]/images.tsx
@@ -48,6 +48,10 @@ const ImagePage: FunctionComponent<Props> = ({
   const title = work.title || '';
   const iiifImageLocation =
     image.locations[0] || getDigitalLocationOfType(work, 'iiif-image');
+  const iiifPresentationLocation = getDigitalLocationOfType(
+    work,
+    'iiif-presentation'
+  );
 
   const apiLink = {
     id: 'json',
@@ -72,7 +76,11 @@ const ImagePage: FunctionComponent<Props> = ({
       hideTopContent={true}
     >
       {iiifImageLocation ? (
-        <IIIFViewer work={work} iiifImageLocation={iiifImageLocation} />
+        <IIIFViewer
+          work={work}
+          iiifImageLocation={iiifImageLocation}
+          iiifPresentationLocation={iiifPresentationLocation}
+        />
       ) : (
         <Layout12>
           <Space v={{ size: 'l', properties: ['margin-bottom'] }}>

--- a/catalogue/webapp/pages/works/[workId]/images.tsx
+++ b/catalogue/webapp/pages/works/[workId]/images.tsx
@@ -6,7 +6,7 @@ import CataloguePageLayout from '@weco/catalogue/components/CataloguePageLayout/
 import Layout12 from '@weco/common/views/components/Layout12/Layout12';
 import BetaMessage from '@weco/common/views/components/BetaMessage/BetaMessage';
 import Space from '@weco/common/views/components/styled/Space';
-import IIIFViewer from '@weco/catalogue/components/IIIFViewer/IIIFViewer';
+import IIIFViewer from '@weco/catalogue/components/IIIFViewer';
 import { serialiseProps } from '@weco/common/utils/json';
 import { getWork } from '@weco/catalogue/services/wellcome/catalogue/works';
 import { getImage } from '@weco/catalogue/services/wellcome/catalogue/images';

--- a/catalogue/webapp/pages/works/[workId]/items.tsx
+++ b/catalogue/webapp/pages/works/[workId]/items.tsx
@@ -93,6 +93,7 @@ type Props = {
   canvas: number;
   canvasOcr?: string;
   iiifImageLocation?: DigitalLocation;
+  iiifPresentationLocation?: DigitalLocation;
   pageview: Pageview;
 };
 
@@ -101,6 +102,7 @@ const ItemPage: NextPage<Props> = ({
   work,
   canvasOcr,
   iiifImageLocation,
+  iiifPresentationLocation,
   canvas,
 }) => {
   const transformedManifest =
@@ -326,6 +328,7 @@ const ItemPage: NextPage<Props> = ({
             transformedManifest={transformedManifest}
             canvasOcr={canvasOcr}
             iiifImageLocation={iiifImageLocation}
+            iiifPresentationLocation={iiifPresentationLocation}
             handleImageError={() => {
               // If the image fails to load, we check to see if it's because the cookie is missing/no longer valid
               reloadAuthIframe(document, iframeId);
@@ -427,11 +430,13 @@ export const getServerSideProps: GetServerSideProps<
 
     return {
       props: serialiseProps({
-        compressedTransformedManifest: toCompressedTransformedManifest(displayManifest),
+        compressedTransformedManifest:
+          toCompressedTransformedManifest(displayManifest),
         canvasOcr,
         work,
         canvas,
         iiifImageLocation,
+        iiifPresentationLocation,
         pageview,
         serverData,
       }),
@@ -446,6 +451,7 @@ export const getServerSideProps: GetServerSideProps<
         canvas,
         canvases: [],
         iiifImageLocation,
+        iiifPresentationLocation,
         pageview,
         serverData,
       }),

--- a/catalogue/webapp/pages/works/[workId]/items.tsx
+++ b/catalogue/webapp/pages/works/[workId]/items.tsx
@@ -12,7 +12,7 @@ import CataloguePageLayout from '@weco/catalogue/components/CataloguePageLayout/
 import Layout12 from '@weco/common/views/components/Layout12/Layout12';
 import IIIFViewer, {
   queryParamToArrayIndex,
-} from '@weco/catalogue/components/IIIFViewer/IIIFViewer';
+} from '@weco/catalogue/components/IIIFViewer';
 import VideoPlayer from '@weco/catalogue/components/VideoPlayer/VideoPlayer';
 import BetaMessage from '@weco/common/views/components/BetaMessage/BetaMessage';
 import styled from 'styled-components';


### PR DESCRIPTION
This is a small piece spun out of #10004, complicated enough to justify its own review, part of https://github.com/wellcomecollection/wellcomecollection.org/issues/8339

Our component architecture looks something like this:

```mermaid
graph LR
    I[items.tsx page] --> V[IIIFViewer component]
    V --> S[ViewerSidebar component]
    V --> T[ViewerTopBar component]
    V --> B[ViewerBottomBar component]
```

Right now we're getting the Work object at the top level, extracting some of the IIIF location information from the Work, then passing both the work and the IIIF location down into the components… which get the IIIF information from the Work again.

This is inefficient, and liable to cause confusion – it would be better to extract the specific bits of location information we need right at the top level, then just pass those locations down.

This unblocks the way to cutting the size of the remaining Work information.

## OptionalToUndefined

This is a utility type we've had for a while, and I've started using it in this PR. It changes a type like:

```typescript
// 'iiifImageLocation' is optional
type Props = {
  iiifImageLocation?: DigitalLocation
}
```

to 

```typescript
// 'iiifImageLocation' is required
type Props = {
  iiifImageLocation: DigitalLocation | undefined
}
```

Now the type system will yell at you if you omit a property.

This is because it's the behaviour we want for these fairly specific components, and not doing this let a bug slip through in #10004 – I'd added a new prop that I wasn't passing anywhere, and the type system let it through because it was an optional new prop.