### PR TITLE
Add header and footer html elements

### DIFF
--- a/common/views/components/Footer/index.tsx
+++ b/common/views/components/Footer/index.tsx
@@ -22,6 +22,7 @@ type Props = {
 const Wrapper = styled(Space).attrs({
   className: `${font('intr', 5)} is-hidden-print`,
   v: { size: 'xl', properties: ['padding-top'] },
+  as: 'footer',
 })`
   position: relative;
   background-color: ${props => props.theme.color('black')};

--- a/common/views/components/Header/Header.tsx
+++ b/common/views/components/Header/Header.tsx
@@ -124,7 +124,7 @@ const Header: FunctionComponent<Props> = ({
       active={searchDropdownIsActive || burgerMenuIsActive}
       focusTrapOptions={{ preventScroll: true }}
     >
-      <div className="is-hidden-print">
+      <header className="is-hidden-print">
         <Wrapper isBurgerOpen={burgerMenuIsActive}>
           <GridCell>
             <Container>
@@ -226,7 +226,7 @@ const Header: FunctionComponent<Props> = ({
             searchButtonRef={searchButtonRef}
           />
         )}
-      </div>
+      </header>
     </FocusTrap>
   );
 };


### PR DESCRIPTION
## Who is this for?
SEO, a11y, semantics

## What is it doing for them?
Makes the container use the header and footer html elements for all they bring to the table for the reasons above.