### PR TITLE
Polly experiment

### DIFF
--- a/content/webapp/components/ContentPage/ContentPage.tsx
+++ b/content/webapp/components/ContentPage/ContentPage.tsx
@@ -1,9 +1,9 @@
 import styled from 'styled-components';
 import { Children, createContext, ReactNode, ReactElement } from 'react';
 import { sectionLevelPages } from '@weco/common/data/hardcoded-ids';
-import { Season } from '../../types/seasons';
+import { Season } from '@weco/content/types/seasons';
 import { ElementFromComponent } from '@weco/common/utils/utility-types';
-import { MultiContent } from '../../types/multi-content';
+import { MultiContent } from '@weco/content/types/multi-content';
 import Layout8 from '@weco/common/views/components/Layout8/Layout8';
 import Layout12 from '@weco/common/views/components/Layout12/Layout12';
 import PageHeader, {
@@ -15,11 +15,22 @@ import Space from '@weco/common/views/components/styled/Space';
 import BannerCard from '../BannerCard/BannerCard';
 import Contributors from '../Contributors/Contributors';
 import Outro from '../Outro/Outro';
-import { Contributor } from '../../types/contributors';
+import { Contributor } from '@weco/content/types/contributors';
+import AudioPlayer from '@weco/common/views/components/AudioPlayer/AudioPlayer';
+import { useToggles } from '@weco/common/server-data/Context';
 
 export const PageBackgroundContext = createContext<'warmNeutral.300' | 'white'>(
   'white'
 );
+
+// TODO delete once we get rid of the Polly Experiment
+const pollyRecordings = [
+  {
+    articleId: 'W9m2QxcAAF8AFvE5',
+    audioUrl:
+      'https://wellcomecollection-polly.s3.eu-west-1.amazonaws.com/42235d89-05f4-40f5-899d-4e61a7a4b15a.mp3',
+  },
+];
 
 type Props = {
   id: string;
@@ -65,6 +76,8 @@ const ContentPage = ({
   contributorTitle,
   hideContributors,
 }: Props): ReactElement => {
+  const toggles = useToggles();
+
   // We don't want to add a spacing unit if there's nothing to render
   // in the body (we don't render the 'standfirst' here anymore).
   function shouldRenderBody() {
@@ -77,6 +90,10 @@ const ContentPage = ({
       return false;
     if (Body.props.body.length > 0) return true;
   }
+
+  const hasPollyRecording = pollyRecordings.find(
+    ({ articleId }) => articleId === id
+  );
 
   return (
     <PageBackgroundContext.Provider
@@ -92,7 +109,24 @@ const ContentPage = ({
           </Space>
         )}
         <Wrapper isCreamy={isCreamy}>
-          {shouldRenderBody() && <SpacingSection>{Body}</SpacingSection>}
+          {shouldRenderBody() && (
+            <SpacingSection>
+              {/* TODO: Remove after Polly Experiment */}
+              {toggles.polly && hasPollyRecording && (
+                <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
+                  <Layout8>
+                    <AudioPlayer
+                      title="Text to speech"
+                      audioFile={hasPollyRecording.audioUrl}
+                    />
+                  </Layout8>
+                </Space>
+              )}
+              {/*  */}
+
+              {Body}
+            </SpacingSection>
+          )}
 
           {children && (
             <SpacingSection>

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -63,6 +63,14 @@ const toggles = {
       description: 'Allows access to visual stories pages.',
       type: 'experimental',
     },
+    {
+      id: 'polly',
+      title: 'Text-to-speech Amazon Polly',
+      initialValue: false,
+      description:
+        'Displays an audio player with text-to-speech audio on selected articles',
+      type: 'experimental',
+    },
   ] as const,
   tests: [] as ABTest[],
 };


### PR DESCRIPTION
## Who is this for?
Polly experiment

## What is it doing for them?
Displays an audio player on specified articles (currently only on [A brief history of tattoos](https://wellcomecollection.org/articles/W9m2QxcAAF8AFvE5)). See #10031 for more information.
The toggle has already been deployed.

Since it's behind a toggle I see no harm in merging right away and allowing the team to see the current status. It would allow the team to hear what it sounds like, see what we'd like to tweak, before I go ahead and create 9 more. Also allows a design opinion, and possibly tracking tests.

<img width="820" alt="Screenshot 2023-07-14 at 16 11 49" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/0ce963b4-36f9-4885-b5e6-4adac065522a">
