### PR TITLE
Filter stories by contributor

### DIFF
--- a/catalogue/webapp/services/wellcome/catalogue/filters.ts
+++ b/catalogue/webapp/services/wellcome/catalogue/filters.ts
@@ -491,6 +491,27 @@ const storiesFormatFilter = ({
   }),
 });
 
+const storiesContributorFilter = ({
+  stories,
+  props,
+}: StoriesFilterProps): CheckboxFilter<keyof StoriesProps> => ({
+  type: 'checkbox',
+  id: 'contributors.contributor',
+  label: 'Contributors',
+  options: filterOptionsWithNonAggregates({
+    options: stories?.aggregations?.['contributors.contributor'].buckets.map(
+      bucket => ({
+        id: bucket.data.id,
+        value: bucket.data.id,
+        count: bucket.count,
+        label: bucket.data.label,
+        selected: props['contributors.contributor'].includes(bucket.data.id),
+      })
+    ),
+    selectedValues: props['contributors.contributor'],
+  }),
+});
+
 const imagesFilters: (props: ImagesFilterProps) => Filter[] = props =>
   [
     colorFilter,
@@ -518,6 +539,6 @@ const worksFilters: (
 const storiesFilters: (
   props: StoriesFilterProps
 ) => Filter<keyof StoriesProps>[] = props =>
-  [storiesFormatFilter].map(f => f(props));
+  [storiesFormatFilter, storiesContributorFilter].map(f => f(props));
 
 export { worksFilters, imagesFilters, storiesFilters };


### PR DESCRIPTION
## Who is this for?
Stories searchers

Via #10028 part of wider initiative for [stories search #5681](https://github.com/wellcomecollection/platform/issues/5681)

## What is it doing for them?
Adds UI to enable users to filter stories by contributor. The highest 20 contributors to the individual search range are displayed in the dropdown. Screenshots below. 

---

![Screenshot 2023-07-14 at 17 27 40](https://github.com/wellcomecollection/wellcomecollection.org/assets/81175151/0d623b25-15d8-43e8-8999-f2c01be6f62f)


![Screenshot 2023-07-14 at 17 26 10](https://github.com/wellcomecollection/wellcomecollection.org/assets/81175151/8ce8871d-fa77-4c8e-975f-1309c8c7c65c)


![Screenshot 2023-07-14 at 17 26 30](https://github.com/wellcomecollection/wellcomecollection.org/assets/81175151/0110521a-ab2b-44ab-a234-a4142757ceb7)


![Screenshot 2023-07-14 at 17 26 58](https://github.com/wellcomecollection/wellcomecollection.org/assets/81175151/60757e49-261a-4672-88cd-ecc51e672950)

