### PR TITLE
/stories "Format" button renamed "Formats" for consistency

### DIFF
--- a/catalogue/webapp/services/wellcome/catalogue/filters.ts
+++ b/catalogue/webapp/services/wellcome/catalogue/filters.ts
@@ -478,7 +478,7 @@ const storiesFormatFilter = ({
 }: StoriesFilterProps): CheckboxFilter<keyof StoriesProps> => ({
   type: 'checkbox',
   id: 'format',
-  label: 'Format',
+  label: 'Formats',
   options: filterOptionsWithNonAggregates({
     options: stories?.aggregations?.format?.buckets.map(bucket => ({
       id: bucket.data.id,


### PR DESCRIPTION
## Who is this for?
`/search/stories` Format button - incorrectly named 'Format'

![Screenshot 2023-07-17 at 16 43 29](https://github.com/wellcomecollection/wellcomecollection.org/assets/81175151/65e19cb7-1857-43ce-a3a8-16583ce13dee)



## What is it doing for them?
Has been corrected to 'Formats' for consistency across search

![Screenshot 2023-07-17 at 16 43 41](https://github.com/wellcomecollection/wellcomecollection.org/assets/81175151/97312b1f-d393-4363-8b07-3272bb417a3c)
