### PR TITLE
changed /stories pageSize to 25

### DIFF
--- a/catalogue/webapp/pages/search/stories.tsx
+++ b/catalogue/webapp/pages/search/stories.tsx
@@ -254,7 +254,7 @@ export const getServerSideProps: GetServerSideProps<
       ...(pageNumber && { page: Number(pageNumber) }),
       aggregations: ['format', 'contributors.contributor'],
     },
-    pageSize: 6,
+    pageSize: 25,
     toggles: serverData.toggles,
   });
 


### PR DESCRIPTION
## Who is this for?
For #10048 - allows users to see 25 results on `/stories`

## What is it doing for them?
Increases the results / `pageSize` from 6 to 25, as it is on `/works`

![pageSize-at-25](https://github.com/wellcomecollection/wellcomecollection.org/assets/81175151/112cbbd5-e42a-4667-a3c6-6121bdcbba81)
