### PR TITLE
Added infoblock slice to article body

### DIFF
--- a/prismic-model/src/parts/article-body.ts
+++ b/prismic-model/src/parts/article-body.ts
@@ -103,6 +103,16 @@ export default {
           },
         },
       },
+      infoBlock: slice('Info block', {
+        nonRepeat: {
+          title: heading('Title', { level: 2 }),
+          text: multiLineText('Text', {
+            extraTextOptions: ['heading3', 'list-item'],
+          }),
+          link: webLink('Button link'),
+          linkText: keyword('Button text'),
+        },
+      }),
       standfirst: {
         type: 'Slice',
         fieldset: 'Standfirst',


### PR DESCRIPTION
## Who is this for?
Editors

## What is it doing for them?
Adds InfoBlock as an available slice for Stories/Articles.

Relates to #10065 