### PR TITLE
Allow events in content lists for books

### DIFF
--- a/content/webapp/components/SearchResults/AsyncSearchResults.tsx
+++ b/content/webapp/components/SearchResults/AsyncSearchResults.tsx
@@ -18,6 +18,9 @@ class AsyncSearchResults extends Component<Props, State> {
   };
 
   async componentDidMount(): Promise<void> {
+    // Something happens here that reorders results and I'm not sure that's
+    // always useful (see content lists). I dug for a while but am thinking one
+    // day we'd use the content API.
     const multiContentQuery = await fetchMultiContentClientSide(
       this.props.query
     );

--- a/content/webapp/services/prismic/fetch/books.ts
+++ b/content/webapp/services/prismic/fetch/books.ts
@@ -2,8 +2,13 @@ import * as prismic from '@prismicio/client';
 import { fetcher, GetServerSidePropsPrismicClient, GetByTypeParams } from '.';
 import { commonPrismicFieldsFetchLinks, contributorFetchLinks } from '../types';
 import { BookPrismicDocument } from '../types/books';
+import { eventsFetchLinks } from '../types/events';
 
-const fetchLinks = [...commonPrismicFieldsFetchLinks, ...contributorFetchLinks];
+const fetchLinks = [
+  ...commonPrismicFieldsFetchLinks,
+  ...contributorFetchLinks,
+  ...eventsFetchLinks,
+];
 
 const booksFetcher = fetcher<BookPrismicDocument>('books', fetchLinks);
 

--- a/content/webapp/services/prismic/transformers/body.ts
+++ b/content/webapp/services/prismic/transformers/body.ts
@@ -397,6 +397,7 @@ function transformContentListSlice(slice: ContentListSlice): BodySlice {
       // TODO: The old code would look up a `hasFeatured` field on `slice.primary`,
       // but that doesn't exist in our Prismic model.
       // hasFeatured: slice.primary.hasFeatured,
+      // TODO should other types be added? For example, books are allowed in Content Lists
       items: contents
         .map(content => {
           switch (content.type) {


### PR DESCRIPTION
## Who is this for?
Everyone

## What is it doing for them?
[After talking with Alex on Slack](https://wellcome.slack.com/archives/CUA669WHH/p1689858851451629), I tried a different approach that fixes it.
I fell into a deep rabbit hole though, there's a lot of (seemingly) complex things happening around this component. Not all types are allowed, it gets reordered _somewhere_, there are probably more instances like this one to fix... But I thought I'd start with this ticket only and see what happens with the Content API.

Relates to #10051, closes #10052 as it's a better solution.