### PR TITLE
Prismic visual story

### DIFF
--- a/cardigan/stories/components/PageHeader/PageHeader.stories.tsx
+++ b/cardigan/stories/components/PageHeader/PageHeader.stories.tsx
@@ -257,7 +257,7 @@ shortFilm.args = {
   ),
   Body: (
     <Body
-      isShortFilm={true}
+      contentType="short-film"
       body={[
         {
           type: 'videoEmbed',

--- a/common/services/prismic/content-types.ts
+++ b/common/services/prismic/content-types.ts
@@ -14,6 +14,7 @@ const contentTypes = [
   'guide-formats',
   'exhibition-guides',
   'stories-landing',
+  'visual-stories',
 ] as const;
 
 export type ContentType = (typeof contentTypes)[number];

--- a/common/views/themes/typography.ts
+++ b/common/views/themes/typography.ts
@@ -248,7 +248,7 @@ export const typography = css<GlobalStyleProps>`
       border-top: 1px solid black;
     }
 
-    .content-type-visual-story &.first-text-slice h2 {
+    .content-type-visual-story &.first-text-slice h2:first-of-type {
       border-top: 0;
       padding-top: 0;
     }

--- a/common/views/themes/typography.ts
+++ b/common/views/themes/typography.ts
@@ -242,10 +242,11 @@ export const typography = css<GlobalStyleProps>`
       ${fontSizeMixin(2)}
     }
 
+    /* Visual stories have their own h2 styling that involves more space and a border above */
     .content-type-visual-story & h2 {
       padding-top: 2em;
       margin-top: 1.5em;
-      border-top: 1px solid black;
+      border-top: 1px solid ${props => props.theme.color('black')};
     }
 
     .content-type-visual-story &.first-text-slice h2:first-of-type {

--- a/common/views/themes/typography.ts
+++ b/common/views/themes/typography.ts
@@ -242,6 +242,17 @@ export const typography = css<GlobalStyleProps>`
       ${fontSizeMixin(2)}
     }
 
+    .content-type-visual-story & h2 {
+      padding-top: 2em;
+      margin-top: 1.5em;
+      border-top: 1px solid black;
+    }
+
+    .content-type-visual-story &.first-text-slice h2 {
+      border-top: 0;
+      padding-top: 0;
+    }
+
     h3 {
       ${fontFamilyMixin('intb', true)}
       ${fontSizeMixin(3)}

--- a/content/webapp/components/Body/Body.tsx
+++ b/content/webapp/components/Body/Body.tsx
@@ -56,6 +56,7 @@ import SoundCloudEmbed from '../SoundCloudEmbed/SoundCloudEmbed';
 import * as prismic from '@prismicio/client';
 import { Props as ComicPreviousNextProps } from '../ComicPreviousNext/ComicPreviousNext';
 import { PaletteColor } from '@weco/common/views/themes/config';
+import TextAndImageOrIcons from '../TextAndImageOrIcons/TextAndImageOrIcons';
 
 const BodyWrapper = styled.div<{ splitBackground: boolean }>`
   ${props =>
@@ -377,6 +378,22 @@ const Body: FunctionComponent<Props> = ({
                         ))}
                     </div>
                   </LayoutWidth>
+                </SpacingComponent>
+              )}
+
+              {slice.type === 'textAndImage' && (
+                <SpacingComponent sliceType={slice.type}>
+                  <Layout10>
+                    <TextAndImageOrIcons item={slice.value} />
+                  </Layout10>
+                </SpacingComponent>
+              )}
+
+              {slice.type === 'textAndIcons' && (
+                <SpacingComponent sliceType={slice.type}>
+                  <Layout10>
+                    <TextAndImageOrIcons item={slice.value} />
+                  </Layout10>
                 </SpacingComponent>
               )}
 

--- a/content/webapp/components/Body/Body.tsx
+++ b/content/webapp/components/Body/Body.tsx
@@ -383,17 +383,17 @@ const Body: FunctionComponent<Props> = ({
 
               {slice.type === 'textAndImage' && (
                 <SpacingComponent sliceType={slice.type}>
-                  <Layout10>
+                  <Layout8>
                     <TextAndImageOrIcons item={slice.value} />
-                  </Layout10>
+                  </Layout8>
                 </SpacingComponent>
               )}
 
               {slice.type === 'textAndIcons' && (
                 <SpacingComponent sliceType={slice.type}>
-                  <Layout10>
+                  <Layout8>
                     <TextAndImageOrIcons item={slice.value} />
-                  </Layout10>
+                  </Layout8>
                 </SpacingComponent>
               )}
 

--- a/content/webapp/components/Body/Body.tsx
+++ b/content/webapp/components/Body/Body.tsx
@@ -353,7 +353,12 @@ const Body: FunctionComponent<Props> = ({
               {slice.type === 'text' && (
                 <SpacingComponent sliceType={slice.type}>
                   <LayoutWidth width={minWidth}>
-                    <div className="body-text spaced-text">
+                    <div
+                      className={classNames({
+                        'body-text spaced-text': true,
+                        'first-text-slice': firstTextSliceIndex === i,
+                      })}
+                    >
                       {slice.weight !== 'featured' &&
                         (firstTextSliceIndex === i && isDropCapped ? (
                           <>

--- a/content/webapp/components/Body/Body.tsx
+++ b/content/webapp/components/Body/Body.tsx
@@ -105,7 +105,7 @@ type Props = {
   sectionLevelPage?: boolean;
   staticContent?: ReactElement | null;
   comicPreviousNext?: ComicPreviousNextProps;
-  isShortFilm?: boolean;
+  contentType?: 'short-film' | 'visual-story';
 };
 
 type SectionTheme = {
@@ -144,7 +144,7 @@ const Body: FunctionComponent<Props> = ({
   sectionLevelPage = false,
   staticContent = null,
   comicPreviousNext,
-  isShortFilm = false,
+  contentType,
 }: Props) => {
   const filteredBody = body
     .filter(slice => !(slice.type === 'picture' && slice.weight === 'featured'))
@@ -301,9 +301,14 @@ const Body: FunctionComponent<Props> = ({
       return null;
     }
   };
+  const isShortFilm = contentType === 'short-film';
+  const isVisualStory = contentType === 'visual-story';
 
   return (
-    <BodyWrapper splitBackground={isShortFilm}>
+    <BodyWrapper
+      splitBackground={isShortFilm}
+      className={`content-type-${contentType}`}
+    >
       {filteredBody.length < 1 && (
         <AdditionalContent
           index={0}
@@ -401,9 +406,9 @@ const Body: FunctionComponent<Props> = ({
               that width isn't an adequate means to illustrate a difference */}
               {slice.type === 'picture' && slice.weight === 'default' && (
                 <SpacingComponent sliceType={slice.type}>
-                  <Layout10>
+                  <LayoutWidth width={isVisualStory ? 8 : 10}>
                     <CaptionedImage {...slice.value} />
-                  </Layout10>
+                  </LayoutWidth>
                 </SpacingComponent>
               )}
               {slice.type === 'picture' && slice.weight === 'standalone' && (

--- a/content/webapp/components/ContentPage/ContentPage.tsx
+++ b/content/webapp/components/ContentPage/ContentPage.tsx
@@ -127,7 +127,6 @@ const ContentPage = ({
               {Body}
             </SpacingSection>
           )}
-
           {children && (
             <SpacingSection>
               {Children.map(children, child => (
@@ -141,7 +140,6 @@ const ContentPage = ({
               ))}
             </SpacingSection>
           )}
-
           {!hideContributors && contributors && contributors.length > 0 && (
             <SpacingSection>
               <Layout8>

--- a/content/webapp/components/HTMLSerializers/HTMLSerializers.tsx
+++ b/content/webapp/components/HTMLSerializers/HTMLSerializers.tsx
@@ -108,6 +108,12 @@ export const defaultSerializer: JSXFunctionSerializer = (
       const hashLink = isInPage && isInPage[1];
 
       const fileExtension = linkUrl.match(/\.[0-9a-z]+$/i);
+
+      const showForwardArrowUrls = ['eventbrite.com'];
+      const showForwardArrow = showForwardArrowUrls.some(link =>
+        linkUrl.match(link)
+      );
+
       const documentType =
         fileExtension && fileExtension[0].substring(1).toUpperCase();
 
@@ -139,6 +145,7 @@ export const defaultSerializer: JSXFunctionSerializer = (
         return (
           <a key={key} target={target} href={linkUrl}>
             {children}
+            {showForwardArrow && '→'}
           </a>
         );
       }

--- a/content/webapp/components/HTMLSerializers/HTMLSerializers.tsx
+++ b/content/webapp/components/HTMLSerializers/HTMLSerializers.tsx
@@ -109,11 +109,6 @@ export const defaultSerializer: JSXFunctionSerializer = (
 
       const fileExtension = linkUrl.match(/\.[0-9a-z]+$/i);
 
-      const showForwardArrowUrls = ['eventbrite.com'];
-      const showForwardArrow = showForwardArrowUrls.some(link =>
-        linkUrl.match(link)
-      );
-
       const documentType =
         fileExtension && fileExtension[0].substring(1).toUpperCase();
 
@@ -145,7 +140,6 @@ export const defaultSerializer: JSXFunctionSerializer = (
         return (
           <a key={key} target={target} href={linkUrl}>
             {children}
-            {showForwardArrow && '→'}
           </a>
         );
       }

--- a/content/webapp/components/TextAndImageOrIcons/TextAndImageOrIcons.tsx
+++ b/content/webapp/components/TextAndImageOrIcons/TextAndImageOrIcons.tsx
@@ -93,7 +93,6 @@ const TextAndImageOrIcons: FunctionComponent<Props> = ({ item }) => {
               })}
             </ImageOrIcons>
           )}
-
           {item.type === 'image' && item.image && (
             <ImageOrIcons isPortrait={item.image.width < item.image.height}>
               <CaptionedImage
@@ -104,7 +103,6 @@ const TextAndImageOrIcons: FunctionComponent<Props> = ({ item }) => {
               />
             </ImageOrIcons>
           )}
-
           <Text>
             <PrismicHtmlBlock html={item.text} />
           </Text>

--- a/content/webapp/components/TextAndImageOrIcons/TextAndImageOrIcons.tsx
+++ b/content/webapp/components/TextAndImageOrIcons/TextAndImageOrIcons.tsx
@@ -5,6 +5,7 @@ import CaptionedImage from '../CaptionedImage/CaptionedImage';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
 import * as prismic from '@prismicio/client';
 import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImage';
+import { defaultSerializer } from '../HTMLSerializers/HTMLSerializers';
 
 const MediaAndTextWrap = styled.div`
   display: flex;
@@ -109,7 +110,10 @@ const TextAndImageOrIcons: FunctionComponent<Props> = ({ item }) => {
             </ImageOrIcons>
           )}
           <Text>
-            <PrismicHtmlBlock html={item.text} />
+            <PrismicHtmlBlock
+              html={item.text}
+              htmlSerializer={defaultSerializer}
+            />
           </Text>
         </MediaAndTextWrap>
       </DividingLine>

--- a/content/webapp/components/TextAndImageOrIcons/TextAndImageOrIcons.tsx
+++ b/content/webapp/components/TextAndImageOrIcons/TextAndImageOrIcons.tsx
@@ -64,15 +64,21 @@ const Text = styled.div`
   `}
 `;
 
-type Item = {
+export type TextAndImageItem = {
   text: prismic.RichTextField;
-} & (
-  | { type: 'icons'; icons: ImageType[] }
-  | { type: 'image'; image: ImageType; isZoomable: boolean }
-);
+  type: 'image';
+  image: ImageType;
+  isZoomable: boolean;
+};
+
+export type TextAndIconsItem = {
+  text: prismic.RichTextField;
+  type: 'icons';
+  icons: ImageType[];
+};
 
 export type Props = {
-  item: Item;
+  item: TextAndImageItem | TextAndIconsItem;
 };
 
 const TextAndImageOrIcons: FunctionComponent<Props> = ({ item }) => {

--- a/content/webapp/components/TextAndImageOrIcons/TextAndImageOrIcons.tsx
+++ b/content/webapp/components/TextAndImageOrIcons/TextAndImageOrIcons.tsx
@@ -1,6 +1,5 @@
 import { FunctionComponent } from 'react';
 import styled from 'styled-components';
-import Space from '@weco/common/views/components/styled/Space';
 import { ImageType } from '@weco/common/model/image';
 import CaptionedImage from '../CaptionedImage/CaptionedImage';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
@@ -20,9 +19,7 @@ const MediaAndTextWrap = styled.div`
   `}
 `;
 
-const DividingLine = styled(Space).attrs({
-  v: { size: 'l', properties: ['margin-top', 'padding-top'] },
-})`
+const DividingLine = styled.div`
   border-top: 1px solid ${props => props.theme.color('neutral.400')};
 
   &:first-child {
@@ -34,6 +31,8 @@ const DividingLine = styled(Space).attrs({
   .slice-type-text-and-image + .slice-type-text-and-image &,
   .slice-type-text-and-icons + .slice-type-text-and-icons & {
     border-top: 1px solid ${props => props.theme.color('neutral.400')};
+    ${props =>
+      props.theme.makeSpacePropertyValues('l', ['margin-top', 'padding-top'])};
   }
 `;
 

--- a/content/webapp/components/TextAndImageOrIcons/TextAndImageOrIcons.tsx
+++ b/content/webapp/components/TextAndImageOrIcons/TextAndImageOrIcons.tsx
@@ -72,7 +72,7 @@ type Item = {
   | { type: 'image'; image: ImageType; isZoomable: boolean }
 );
 
-type Props = {
+export type Props = {
   item: Item;
 };
 

--- a/content/webapp/components/VisualStories/VisualStories.v1.tsx
+++ b/content/webapp/components/VisualStories/VisualStories.v1.tsx
@@ -1,4 +1,3 @@
-import { useState, useEffect } from 'react';
 import { TwoUp, NoSpacedText, PrototypeH2 } from './VisualStories.styles';
 import Layout from '@weco/common/views/components/Layout/Layout';
 import Layout8 from '@weco/common/views/components/Layout8/Layout8';
@@ -9,17 +8,8 @@ import SpacingSection from '@weco/common/views/components/styled/SpacingSection'
 import { anchorLinks } from './VisualStories.data';
 import Contact from '@weco/common/views/components/Contact/Contact';
 import { font } from '@weco/common/utils/classnames';
-import * as prismic from '@prismicio/client';
-import Body from '@weco/content/components/Body/Body';
-import { transformBody } from 'services/prismic/transformers/body';
+
 export const V1Prototype = () => {
-  const client = prismic.createClient('wellcomecollection');
-  const [visualStory, setVisualStory] = useState();
-  useEffect(() => {
-    client.getAllByType('visual-stories').then(vs => {
-      setVisualStory(transformBody(vs[0].data.body));
-    });
-  }, []);
   return (
     <>
       <Layout12>
@@ -31,12 +21,9 @@ export const V1Prototype = () => {
           to help you know what to expect upon arrival if you have autism and/or
           sensory sensitivities.
         </p>
-        {/* <p className={font('intr', 6)}>Updated DD Month 2023</p> */}
+        <p className={font('intr', 6)}>Updated DD Month 2023</p>
       </Layout>
-
-      <Body pageId="test" body={visualStory} showOnThisPage={true} />
-
-      {/* <Layout8>
+      <Layout8>
         <SpacingSection>
           <OnThisPageAnchors links={anchorLinks} />
         </SpacingSection>
@@ -309,7 +296,7 @@ export const V1Prototype = () => {
             </p>
           </SpacingComponent>
         </div>
-      </Layout8> */}
+      </Layout8>
     </>
   );
 };

--- a/content/webapp/components/VisualStories/VisualStories.v1.tsx
+++ b/content/webapp/components/VisualStories/VisualStories.v1.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import { TwoUp, NoSpacedText, PrototypeH2 } from './VisualStories.styles';
 import Layout from '@weco/common/views/components/Layout/Layout';
 import Layout8 from '@weco/common/views/components/Layout8/Layout8';
@@ -8,8 +9,17 @@ import SpacingSection from '@weco/common/views/components/styled/SpacingSection'
 import { anchorLinks } from './VisualStories.data';
 import Contact from '@weco/common/views/components/Contact/Contact';
 import { font } from '@weco/common/utils/classnames';
-
+import * as prismic from '@prismicio/client';
+import Body from '@weco/content/components/Body/Body';
+import { transformBody } from 'services/prismic/transformers/body';
 export const V1Prototype = () => {
+  const client = prismic.createClient('wellcomecollection');
+  const [visualStory, setVisualStory] = useState();
+  useEffect(() => {
+    client.getAllByType('visual-stories').then(vs => {
+      setVisualStory(transformBody(vs[0].data.body));
+    });
+  }, []);
   return (
     <>
       <Layout12>
@@ -21,9 +31,12 @@ export const V1Prototype = () => {
           to help you know what to expect upon arrival if you have autism and/or
           sensory sensitivities.
         </p>
-        <p className={font('intr', 6)}>Updated DD Month 2023</p>
+        {/* <p className={font('intr', 6)}>Updated DD Month 2023</p> */}
       </Layout>
-      <Layout8>
+
+      <Body pageId="test" body={visualStory} showOnThisPage={true} />
+
+      {/* <Layout8>
         <SpacingSection>
           <OnThisPageAnchors links={anchorLinks} />
         </SpacingSection>
@@ -296,7 +309,7 @@ export const V1Prototype = () => {
             </p>
           </SpacingComponent>
         </div>
-      </Layout8>
+      </Layout8> */}
     </>
   );
 };

--- a/content/webapp/pages/articles/[articleId].tsx
+++ b/content/webapp/pages/articles/[articleId].tsx
@@ -344,7 +344,7 @@ const ArticlePage: FunctionComponent<Props> = ({ article, jsonLd }) => {
             isDropCapped={true}
             pageId={article.id}
             minWidth={isPodcast ? 10 : 8}
-            isShortFilm={isShortFilmFormat}
+            contentType={isShortFilmFormat ? 'short-film' : undefined}
           />
         }
         RelatedContent={Siblings}

--- a/content/webapp/pages/visual-stories/[visualStoryId].tsx
+++ b/content/webapp/pages/visual-stories/[visualStoryId].tsx
@@ -78,6 +78,7 @@ const VisualStory: FunctionComponent<Props> = ({ visualStory }) => {
             pageId={visualStory.id}
             onThisPage={visualStory.onThisPage}
             showOnThisPage={visualStory.showOnThisPage}
+            contentType="visual-story"
           />
         }
         contributors={visualStory.contributors}

--- a/content/webapp/pages/visual-stories/[visualStoryId].tsx
+++ b/content/webapp/pages/visual-stories/[visualStoryId].tsx
@@ -11,11 +11,14 @@ import ContentPage from '@weco/content/components/ContentPage/ContentPage';
 import { VisualStory } from '@weco/content/types/visual-stories';
 import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
 import PageHeaderStandfirst from '@weco/content/components/PageHeaderStandfirst/PageHeaderStandfirst';
+import { visualStoryLd } from '@weco/content/services/prismic/transformers/json-ld';
+import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 
 import Body from '@weco/content/components/Body/Body';
 
 type Props = {
   visualStory: VisualStory;
+  jsonLd: JsonLdObj;
 };
 
 export const getServerSideProps = async context => {
@@ -35,10 +38,13 @@ export const getServerSideProps = async context => {
   const visualStoryDocument = await fetchVisualStory(client, visualStoryId);
   if (visualStoryDocument) {
     const visualStory = transformVisualStory(visualStoryDocument);
+    const jsonLd = visualStoryLd(visualStory);
+
     return {
       props: serialiseProps({
         visualStory,
         serverData,
+        jsonLd,
       }),
     };
   } else {
@@ -46,7 +52,7 @@ export const getServerSideProps = async context => {
   }
 };
 
-const VisualStory: FunctionComponent<Props> = ({ visualStory }) => {
+const VisualStory: FunctionComponent<Props> = ({ visualStory, jsonLd }) => {
   const ContentTypeInfo = visualStory.standfirst && (
     <PageHeaderStandfirst html={visualStory.standfirst} />
   );
@@ -65,7 +71,7 @@ const VisualStory: FunctionComponent<Props> = ({ visualStory }) => {
       title={visualStory.title}
       description="TODO" // TODO
       url={{ pathname: '/visual-stories' }}
-      jsonLd={[]}
+      jsonLd={jsonLd}
       openGraphType="website"
       hideNewsletterPromo={true}
     >

--- a/content/webapp/pages/visual-stories/[visualStoryId].tsx
+++ b/content/webapp/pages/visual-stories/[visualStoryId].tsx
@@ -1,0 +1,89 @@
+import { FunctionComponent } from 'react';
+import { getServerData } from '@weco/common/server-data';
+import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
+import { createClient } from '@weco/content/services/prismic/fetch';
+import { fetchVisualStory } from '@weco/content/services/prismic/fetch/visual-stories';
+import { looksLikePrismicId } from '@weco/common/services/prismic';
+import { serialiseProps } from '@weco/common/utils/json';
+import { setCacheControl } from '@weco/common/utils/setCacheControl';
+import { transformVisualStory } from '@weco/content/services/prismic/transformers/visual-stories';
+import ContentPage from '@weco/content/components/ContentPage/ContentPage';
+import { VisualStory } from '@weco/content/types/visual-stories';
+import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
+import PageHeaderStandfirst from '@weco/content/components/PageHeaderStandfirst/PageHeaderStandfirst';
+
+import Body from '@weco/content/components/Body/Body';
+
+type Props = {
+  visualStory: VisualStory;
+};
+
+export const getServerSideProps = async context => {
+  setCacheControl(context.res);
+  const client = createClient(context);
+  const { visualStoryId } = context.query;
+  const serverData = await getServerData(context);
+
+  if (!serverData?.toggles?.visualStories) {
+    return { notFound: true };
+  }
+
+  if (!looksLikePrismicId(visualStoryId)) {
+    return { notFound: true };
+  }
+
+  const visualStoryDocument = await fetchVisualStory(client, visualStoryId);
+  console.log(visualStoryDocument);
+  if (visualStoryDocument) {
+    const visualStory = transformVisualStory(visualStoryDocument);
+    return {
+      props: serialiseProps({
+        visualStory,
+        serverData,
+      }),
+    };
+  } else {
+    return { notFound: true };
+  }
+};
+
+const VisualStory: FunctionComponent<Props> = ({ visualStory }) => {
+  const ContentTypeInfo = visualStory.standfirst && (
+    <PageHeaderStandfirst html={visualStory.standfirst} />
+  );
+  const Header = (
+    <PageHeader
+      breadcrumbs={{ items: [] }}
+      labels={{ labels: [] }}
+      title={visualStory.title}
+      isContentTypeInfoBeforeMedia={true}
+      ContentTypeInfo={ContentTypeInfo}
+    />
+  );
+
+  return (
+    <PageLayout
+      title="Visual stories"
+      description="TODO" // TODO
+      url={{ pathname: '/visual-stories' }}
+      jsonLd={[]}
+      openGraphType="website"
+      hideNewsletterPromo={true}
+    >
+      <ContentPage
+        id={visualStory.id}
+        Header={Header}
+        Body={
+          <Body
+            body={visualStory.body}
+            pageId={visualStory.id}
+            onThisPage={visualStory.onThisPage}
+            showOnThisPage={visualStory.showOnThisPage}
+          />
+        }
+      />
+    </PageLayout>
+  );
+};
+
+export default VisualStory;

--- a/content/webapp/pages/visual-stories/[visualStoryId].tsx
+++ b/content/webapp/pages/visual-stories/[visualStoryId].tsx
@@ -62,7 +62,7 @@ const VisualStory: FunctionComponent<Props> = ({ visualStory }) => {
 
   return (
     <PageLayout
-      title="Visual stories"
+      title={visualStory.title}
       description="TODO" // TODO
       url={{ pathname: '/visual-stories' }}
       jsonLd={[]}
@@ -81,7 +81,6 @@ const VisualStory: FunctionComponent<Props> = ({ visualStory }) => {
             contentType="visual-story"
           />
         }
-        contributors={visualStory.contributors}
       />
     </PageLayout>
   );

--- a/content/webapp/pages/visual-stories/[visualStoryId].tsx
+++ b/content/webapp/pages/visual-stories/[visualStoryId].tsx
@@ -13,12 +13,14 @@ import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
 import PageHeaderStandfirst from '@weco/content/components/PageHeaderStandfirst/PageHeaderStandfirst';
 import { visualStoryLd } from '@weco/content/services/prismic/transformers/json-ld';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
+import { Pageview } from '@weco/common/services/conversion/track';
 
 import Body from '@weco/content/components/Body/Body';
 
 type Props = {
   visualStory: VisualStory;
   jsonLd: JsonLdObj;
+  pageview: Pageview;
 };
 
 export const getServerSideProps = async context => {
@@ -45,6 +47,10 @@ export const getServerSideProps = async context => {
         visualStory,
         serverData,
         jsonLd,
+        pageview: {
+          name: 'visual-story',
+          properties: {},
+        },
       }),
     };
   } else {

--- a/content/webapp/pages/visual-stories/[visualStoryId].tsx
+++ b/content/webapp/pages/visual-stories/[visualStoryId].tsx
@@ -75,7 +75,7 @@ const VisualStory: FunctionComponent<Props> = ({ visualStory, jsonLd }) => {
   return (
     <PageLayout
       title={visualStory.title}
-      description="TODO" // TODO: will there be promos/cards for visual stories?
+      description={visualStory.promo?.caption || ''}
       url={{ pathname: `/visual-stories/${visualStory.id}` }}
       jsonLd={jsonLd}
       openGraphType="website"

--- a/content/webapp/pages/visual-stories/[visualStoryId].tsx
+++ b/content/webapp/pages/visual-stories/[visualStoryId].tsx
@@ -75,8 +75,8 @@ const VisualStory: FunctionComponent<Props> = ({ visualStory, jsonLd }) => {
   return (
     <PageLayout
       title={visualStory.title}
-      description="TODO" // TODO
-      url={{ pathname: '/visual-stories' }}
+      description="TODO" // TODO: will there be promos/cards for visual stories?
+      url={{ pathname: `/visual-stories/${visualStory.id}` }}
       jsonLd={jsonLd}
       openGraphType="website"
       hideNewsletterPromo={true}

--- a/content/webapp/pages/visual-stories/[visualStoryId].tsx
+++ b/content/webapp/pages/visual-stories/[visualStoryId].tsx
@@ -33,7 +33,6 @@ export const getServerSideProps = async context => {
   }
 
   const visualStoryDocument = await fetchVisualStory(client, visualStoryId);
-  console.log(visualStoryDocument);
   if (visualStoryDocument) {
     const visualStory = transformVisualStory(visualStoryDocument);
     return {
@@ -81,6 +80,7 @@ const VisualStory: FunctionComponent<Props> = ({ visualStory }) => {
             showOnThisPage={visualStory.showOnThisPage}
           />
         }
+        contributors={visualStory.contributors}
       />
     </PageLayout>
   );

--- a/content/webapp/services/prismic/fetch/visual-stories.ts
+++ b/content/webapp/services/prismic/fetch/visual-stories.ts
@@ -1,0 +1,26 @@
+import * as prismic from '@prismicio/client';
+import { fetcher, GetServerSidePropsPrismicClient, GetByTypeParams } from '.';
+import { commonPrismicFieldsFetchLinks } from '../types';
+import { VisualStoriesDocument } from '../types/visual-stories';
+
+const fetchLinks = [...commonPrismicFieldsFetchLinks];
+
+const visualStoriesFetcher = fetcher<VisualStoriesDocument>(
+  'visual-stories',
+  fetchLinks
+);
+
+export const fetchVisualStory = visualStoriesFetcher.getById;
+
+export const fetchVisualStories = (
+  client: GetServerSidePropsPrismicClient,
+  params: GetByTypeParams
+): Promise<prismic.Query<VisualStoriesDocument>> => {
+  return visualStoriesFetcher.getByType(client, {
+    ...params,
+    orderings: [
+      { field: 'my.visual-stories.datePublished', direction: 'desc' },
+      { field: 'document.first_publication_date', direction: 'desc' },
+    ],
+  });
+};

--- a/content/webapp/services/prismic/fetch/visual-stories.ts
+++ b/content/webapp/services/prismic/fetch/visual-stories.ts
@@ -1,10 +1,14 @@
 import * as prismic from '@prismicio/client';
 import { fetcher, GetServerSidePropsPrismicClient, GetByTypeParams } from '.';
-import { commonPrismicFieldsFetchLinks } from '../types';
+import { commonPrismicFieldsFetchLinks, contributorFetchLinks } from '../types';
 import { VisualStoriesDocument } from '../types/visual-stories';
 import { teamsFetchLinks } from '../types/teams';
 
-const fetchLinks = [...commonPrismicFieldsFetchLinks, ...teamsFetchLinks];
+const fetchLinks = [
+  ...commonPrismicFieldsFetchLinks,
+  ...teamsFetchLinks,
+  ...contributorFetchLinks,
+];
 
 const visualStoriesFetcher = fetcher<VisualStoriesDocument>(
   'visual-stories',

--- a/content/webapp/services/prismic/fetch/visual-stories.ts
+++ b/content/webapp/services/prismic/fetch/visual-stories.ts
@@ -1,7 +1,7 @@
 import * as prismic from '@prismicio/client';
 import { fetcher, GetServerSidePropsPrismicClient, GetByTypeParams } from '.';
 import { commonPrismicFieldsFetchLinks, contributorFetchLinks } from '../types';
-import { VisualStoriesDocument } from '../types/visual-stories';
+import { VisualStoryDocument } from '../types/visual-stories';
 import { teamsFetchLinks } from '../types/teams';
 
 const fetchLinks = [
@@ -10,7 +10,7 @@ const fetchLinks = [
   ...contributorFetchLinks,
 ];
 
-const visualStoriesFetcher = fetcher<VisualStoriesDocument>(
+const visualStoriesFetcher = fetcher<VisualStoryDocument>(
   'visual-stories',
   fetchLinks
 );
@@ -20,7 +20,7 @@ export const fetchVisualStory = visualStoriesFetcher.getById;
 export const fetchVisualStories = (
   client: GetServerSidePropsPrismicClient,
   params: GetByTypeParams
-): Promise<prismic.Query<VisualStoriesDocument>> => {
+): Promise<prismic.Query<VisualStoryDocument>> => {
   return visualStoriesFetcher.getByType(client, {
     ...params,
     orderings: [

--- a/content/webapp/services/prismic/fetch/visual-stories.ts
+++ b/content/webapp/services/prismic/fetch/visual-stories.ts
@@ -2,8 +2,9 @@ import * as prismic from '@prismicio/client';
 import { fetcher, GetServerSidePropsPrismicClient, GetByTypeParams } from '.';
 import { commonPrismicFieldsFetchLinks } from '../types';
 import { VisualStoriesDocument } from '../types/visual-stories';
+import { teamsFetchLinks } from '../types/teams';
 
-const fetchLinks = [...commonPrismicFieldsFetchLinks];
+const fetchLinks = [...commonPrismicFieldsFetchLinks, ...teamsFetchLinks];
 
 const visualStoriesFetcher = fetcher<VisualStoriesDocument>(
   'visual-stories',

--- a/content/webapp/services/prismic/transformers/body.ts
+++ b/content/webapp/services/prismic/transformers/body.ts
@@ -84,6 +84,29 @@ function transformTextSlice(slice: TextSlice): BodySlice {
   };
 }
 
+function transformTextAndImage(slice: any): BodySlice {
+  return {
+    type: 'textAndImage',
+    value: {
+      type: 'image',
+      text: slice.primary.text,
+      image: transformImage(slice.primary.image),
+      isZoomable: slice.primary.isZoomable,
+    },
+  };
+}
+
+function transformTextAndIcons(slice: any): BodySlice {
+  return {
+    type: 'textAndIcons',
+    value: {
+      type: 'icons',
+      text: slice.primary.text,
+      icons: slice.items.map(({ icon }) => transformImage(icon)),
+    },
+  };
+}
+
 function transformMapSlice(slice: MapSlice): BodySlice {
   return {
     type: 'map',
@@ -429,6 +452,10 @@ export function transformBody(body: Body): BodySlice[] {
   return body
     .map(slice => {
       switch (slice.slice_type) {
+        case 'textAndImage':
+          return transformTextAndImage(slice);
+        case 'textAndIcons':
+          return transformTextAndIcons(slice);
         case 'standfirst':
           return transformStandfirstSlice(slice);
 

--- a/content/webapp/services/prismic/transformers/body.ts
+++ b/content/webapp/services/prismic/transformers/body.ts
@@ -21,6 +21,8 @@ import {
   Discussion as DiscussionSlice,
   AudioPlayer as AudioPlayerSlice,
   Body,
+  TextAndImageSlice,
+  TextAndIconsSlice,
 } from '../types/body';
 import { Props as ContactProps } from '@weco/common/views/components/Contact/Contact';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
@@ -84,25 +86,27 @@ function transformTextSlice(slice: TextSlice): BodySlice {
   };
 }
 
-function transformTextAndImage(slice: any): BodySlice {
+function transformTextAndImage(slice: TextAndImageSlice): BodySlice {
   return {
     type: 'textAndImage',
     value: {
       type: 'image',
       text: slice.primary.text,
-      image: transformImage(slice.primary.image),
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      image: transformImage(slice.primary.image)!,
       isZoomable: slice.primary.isZoomable,
     },
   };
 }
 
-function transformTextAndIcons(slice: any): BodySlice {
+function transformTextAndIcons(slice: TextAndIconsSlice): BodySlice {
   return {
     type: 'textAndIcons',
     value: {
       type: 'icons',
       text: slice.primary.text,
-      icons: slice.items.map(({ icon }) => transformImage(icon)),
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      icons: slice.items.map(({ icon }) => transformImage(icon)!),
     },
   };
 }

--- a/content/webapp/services/prismic/transformers/json-ld.ts
+++ b/content/webapp/services/prismic/transformers/json-ld.ts
@@ -1,4 +1,5 @@
 import { Event } from '../../../types/events';
+import { VisualStory } from '../../../types/visual-stories';
 import {
   wellcomeCollectionAddress,
   wellcomeCollectionGallery,
@@ -132,6 +133,21 @@ export function articleSeriesLd(series: Series): JsonLdObj {
       url: `https://wellcomecollection.org/series/${series.id}`,
     },
     { type: 'Series' }
+  );
+}
+
+export function visualStoryLd(visualStory: VisualStory): JsonLdObj {
+  return objToJsonLd(
+    {
+      dateCreated: visualStory.datePublished,
+      datePublished: visualStory.datePublished,
+      headline: visualStory.title,
+      publisher: orgLd(wellcomeCollectionGallery),
+      url: `https://wellcomecollection.org/visual-stories/${visualStory.id}`,
+    },
+    {
+      type: 'WebPage',
+    }
   );
 }
 

--- a/content/webapp/services/prismic/transformers/json-ld.ts
+++ b/content/webapp/services/prismic/transformers/json-ld.ts
@@ -142,6 +142,7 @@ export function visualStoryLd(visualStory: VisualStory): JsonLdObj {
       dateCreated: visualStory.datePublished,
       datePublished: visualStory.datePublished,
       headline: visualStory.title,
+      image: visualStory.promo?.image?.contentUrl,
       publisher: orgLd(wellcomeCollectionGallery),
       url: `https://wellcomecollection.org/visual-stories/${visualStory.id}`,
     },

--- a/content/webapp/services/prismic/transformers/visual-stories.ts
+++ b/content/webapp/services/prismic/transformers/visual-stories.ts
@@ -1,0 +1,31 @@
+import { VisualStory } from '@weco/content/types/visual-stories';
+import { VisualStoriesDocument } from '../types/visual-stories';
+import { transformGenericFields } from '.';
+import { links as headerLinks } from '@weco/common/views/components/Header/Header';
+import { transformOnThisPage } from './pages';
+import { transformTimestamp } from '@weco/common/services/prismic/transformers';
+import { SiteSection } from '@weco/common/views/components/PageLayout/PageLayout';
+
+export function transformVisualStory(
+  document: VisualStoriesDocument
+): VisualStory {
+  const { data } = document;
+  const genericFields = transformGenericFields(document);
+  const siteSections = headerLinks.map(link => link.siteSection);
+  const siteSection = document.tags.find(tag =>
+    siteSections.includes(tag as SiteSection)
+  ) as SiteSection;
+
+  const promo = genericFields.promo;
+  return {
+    type: 'visual-stories',
+    ...genericFields,
+    onThisPage: data.body ? transformOnThisPage(data.body) : [],
+    showOnThisPage: data.showOnThisPage || false,
+    promo: promo && promo.image ? promo : undefined,
+    datePublished: data.datePublished
+      ? transformTimestamp(data.datePublished)
+      : undefined,
+    siteSection,
+  };
+}

--- a/content/webapp/services/prismic/transformers/visual-stories.ts
+++ b/content/webapp/services/prismic/transformers/visual-stories.ts
@@ -4,6 +4,7 @@ import { transformGenericFields } from '.';
 import { links as headerLinks } from '@weco/common/views/components/Header/Header';
 import { transformOnThisPage } from './pages';
 import { transformTimestamp } from '@weco/common/services/prismic/transformers';
+import { transformContributors } from './contributors';
 import { SiteSection } from '@weco/common/views/components/PageLayout/PageLayout';
 
 export function transformVisualStory(
@@ -15,11 +16,12 @@ export function transformVisualStory(
   const siteSection = document.tags.find(tag =>
     siteSections.includes(tag as SiteSection)
   ) as SiteSection;
-
+  const contributors = transformContributors(document);
   const promo = genericFields.promo;
   return {
     type: 'visual-stories',
     ...genericFields,
+    contributors,
     onThisPage: data.body ? transformOnThisPage(data.body) : [],
     showOnThisPage: data.showOnThisPage || false,
     promo: promo && promo.image ? promo : undefined,

--- a/content/webapp/services/prismic/transformers/visual-stories.ts
+++ b/content/webapp/services/prismic/transformers/visual-stories.ts
@@ -1,5 +1,5 @@
 import { VisualStory } from '@weco/content/types/visual-stories';
-import { VisualStoriesDocument } from '../types/visual-stories';
+import { VisualStoryDocument } from '../types/visual-stories';
 import { transformGenericFields } from '.';
 import { links as headerLinks } from '@weco/common/views/components/Header/Header';
 import { transformOnThisPage } from './pages';
@@ -8,7 +8,7 @@ import { transformContributors } from './contributors';
 import { SiteSection } from '@weco/common/views/components/PageLayout/PageLayout';
 
 export function transformVisualStory(
-  document: VisualStoriesDocument
+  document: VisualStoryDocument
 ): VisualStory {
   const { data } = document;
   const genericFields = transformGenericFields(document);

--- a/content/webapp/services/prismic/types/body.ts
+++ b/content/webapp/services/prismic/types/body.ts
@@ -6,6 +6,21 @@ import { TeamPrismicDocument } from './teams';
 
 export type TextSlice = prismic.Slice<'text', { text: prismic.RichTextField }>;
 
+export type TextAndImageSlice = prismic.Slice<
+  'textAndImage',
+  {
+    text: prismic.RichTextField;
+    image: prismic.ImageField;
+    isZoomable: prismic.BooleanField;
+  }
+>;
+
+export type TextAndIconsSlice = prismic.Slice<
+  'textAndIcons',
+  { text: prismic.RichTextField },
+  { icon: prismic.ImageField }
+>;
+
 export type EditorialImageSlice = prismic.Slice<
   'editorialImage',
   { image: Image; caption: prismic.RichTextField }

--- a/content/webapp/services/prismic/types/visual-stories.ts
+++ b/content/webapp/services/prismic/types/visual-stories.ts
@@ -1,10 +1,11 @@
 import * as prismic from '@prismicio/client';
-import { CommonPrismicFields } from '.';
+import { CommonPrismicFields, WithContributors } from '.';
 
 export type VisualStoriesDocument = prismic.PrismicDocument<
   {
     datePublished: prismic.TimestampField;
     showOnThisPage: boolean;
-  } & CommonPrismicFields,
+  } & CommonPrismicFields &
+    WithContributors,
   'visual-stories'
 >;

--- a/content/webapp/services/prismic/types/visual-stories.ts
+++ b/content/webapp/services/prismic/types/visual-stories.ts
@@ -1,0 +1,10 @@
+import * as prismic from '@prismicio/client';
+import { CommonPrismicFields } from '.';
+
+export type VisualStoriesDocument = prismic.PrismicDocument<
+  {
+    datePublished: prismic.TimestampField;
+    showOnThisPage: boolean;
+  } & CommonPrismicFields,
+  'visual-stories'
+>;

--- a/content/webapp/services/prismic/types/visual-stories.ts
+++ b/content/webapp/services/prismic/types/visual-stories.ts
@@ -1,7 +1,7 @@
 import * as prismic from '@prismicio/client';
 import { CommonPrismicFields, WithContributors } from '.';
 
-export type VisualStoriesDocument = prismic.PrismicDocument<
+export type VisualStoryDocument = prismic.PrismicDocument<
   {
     datePublished: prismic.TimestampField;
     showOnThisPage: boolean;

--- a/content/webapp/types/body.ts
+++ b/content/webapp/types/body.ts
@@ -12,7 +12,10 @@ import { Props as MapProps } from '../components/Map/Map';
 import { Props as DiscussionProps } from '../components/Discussion/Discussion';
 import { Props as EmbedProps } from '@weco/common/views/components/VideoEmbed/VideoEmbed';
 import { Props as MediaObjectListProps } from '../components/MediaObjectList/MediaObjectList';
-import { Props as TextAndImageOrIconsProps } from '../components/TextAndImageOrIcons/TextAndImageOrIcons';
+import {
+  TextAndIconsItem,
+  TextAndImageItem,
+} from '../components/TextAndImageOrIcons/TextAndImageOrIcons';
 import { AudioPlayerProps } from '@weco/common/views/components/AudioPlayer/AudioPlayer';
 import * as prismic from '@prismicio/client';
 import { CaptionedImage } from '@weco/common/model/captioned-image';
@@ -81,8 +84,8 @@ export function isStandfirst(
 
 export type BodySlice =
   | Slice<'standfirst', prismic.RichTextField>
-  | Slice<'textAndImage', TextAndImageOrIconsProps>
-  | Slice<'textAndIcons', TextAndImageOrIconsProps>
+  | Slice<'textAndImage', TextAndImageItem>
+  | Slice<'textAndIcons', TextAndIconsItem>
   | Slice<'text', prismic.RichTextField>
   | Slice<'map', MapProps>
   | Slice<'mediaObjectList', MediaObjectListProps>

--- a/content/webapp/types/body.ts
+++ b/content/webapp/types/body.ts
@@ -12,6 +12,7 @@ import { Props as MapProps } from '../components/Map/Map';
 import { Props as DiscussionProps } from '../components/Discussion/Discussion';
 import { Props as EmbedProps } from '@weco/common/views/components/VideoEmbed/VideoEmbed';
 import { Props as MediaObjectListProps } from '../components/MediaObjectList/MediaObjectList';
+import { Props as TextAndImageOrIconsProps } from '../components/TextAndImageOrIcons/TextAndImageOrIcons';
 import { AudioPlayerProps } from '@weco/common/views/components/AudioPlayer/AudioPlayer';
 import * as prismic from '@prismicio/client';
 import { CaptionedImage } from '@weco/common/model/captioned-image';
@@ -80,6 +81,8 @@ export function isStandfirst(
 
 export type BodySlice =
   | Slice<'standfirst', prismic.RichTextField>
+  | Slice<'textAndImage', TextAndImageOrIconsProps>
+  | Slice<'textAndIcons', TextAndImageOrIconsProps>
   | Slice<'text', prismic.RichTextField>
   | Slice<'map', MapProps>
   | Slice<'mediaObjectList', MediaObjectListProps>

--- a/content/webapp/types/visual-stories.ts
+++ b/content/webapp/types/visual-stories.ts
@@ -1,10 +1,12 @@
 import { GenericContentFields } from './generic-content-fields';
 import { Link } from './link';
+import { Contributor } from './contributors';
 import { SiteSection } from '@weco/common/views/components/PageLayout/PageLayout';
 
 export type VisualStory = GenericContentFields & {
   type: 'visual-stories';
   onThisPage: Link[];
+  contributors: Contributor[];
   datePublished?: Date;
   siteSection?: SiteSection;
   showOnThisPage: boolean;

--- a/content/webapp/types/visual-stories.ts
+++ b/content/webapp/types/visual-stories.ts
@@ -1,0 +1,11 @@
+import { GenericContentFields } from './generic-content-fields';
+import { Link } from './link';
+import { SiteSection } from '@weco/common/views/components/PageLayout/PageLayout';
+
+export type VisualStory = GenericContentFields & {
+  type: 'visual-stories';
+  onThisPage: Link[];
+  datePublished?: Date;
+  siteSection?: SiteSection;
+  showOnThisPage: boolean;
+};


### PR DESCRIPTION
Wiring a `[visualStoryId]` page up to Prismic.

__TODO:__
- [x] Add a description (will Visual Stories have promos? If so it can come from there probably?)
- [x] Image for social graph gards (again, ordinarily these would come from promos I think)

Relates to #9974 