### PR TITLE
Align headings: Create second theme to test behind toggle

### DIFF
--- a/catalogue/webapp/components/ArchiveTree/index.tsx
+++ b/catalogue/webapp/components/ArchiveTree/index.tsx
@@ -5,7 +5,6 @@ import {
   useRef,
   FunctionComponent,
 } from 'react';
-import { font } from '@weco/common/utils/classnames';
 import { getWorkClientSide } from '@weco/catalogue/services/wellcome/catalogue/works';
 import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
 import Space from '@weco/common/views/components/styled/Space';
@@ -276,7 +275,7 @@ const ArchiveTree: FunctionComponent<{ work: Work }> = ({
           <Space
             v={{ size: 'l', properties: ['padding-top', 'padding-bottom'] }}
           >
-            <h2 className={font('wb', 4)}>Collection contents</h2>
+            <h2 className="h3">Collection contents</h2>
             <Tree isEnhanced={isEnhanced}>
               {isEnhanced && (
                 <TreeInstructions>{instructions}</TreeInstructions>

--- a/catalogue/webapp/components/StoriesGrid/index.tsx
+++ b/catalogue/webapp/components/StoriesGrid/index.tsx
@@ -14,20 +14,22 @@ import { Article } from '@weco/catalogue/services/wellcome/content/types/api';
 import linkResolver from '@weco/common/services/prismic/link-resolver';
 import { transformImage } from '@weco/common/services/prismic/transformers/images';
 
-const StoriesContainer = styled.div.attrs<{ isDetailed?: boolean }>(props => ({
+type IsDetailedProps = {
+  isDetailed?: boolean;
+};
+
+const StoriesContainer = styled.div.attrs<IsDetailedProps>(props => ({
   className: props.isDetailed
     ? ''
     : 'grid grid--scroll grid--theme-4 card-theme card-theme--transparent',
-}))<{ isDetailed?: boolean }>``;
+}))<IsDetailedProps>``;
 
-const StoryWrapper = styled(Space).attrs<{
-  isDetailed?: boolean;
-}>(props => ({
+const StoryWrapper = styled(Space).attrs<IsDetailedProps>(props => ({
   v: props.isDetailed
     ? { size: 'xl', properties: ['padding-bottom'] }
     : undefined,
   className: props.isDetailed ? 'grid' : grid({ s: 6, m: 6, l: 3, xl: 3 }),
-}))<{ isDetailed?: boolean }>`
+}))<IsDetailedProps>`
   text-decoration: none;
 
   &:last-child {
@@ -41,16 +43,16 @@ const StoryWrapper = styled(Space).attrs<{
   }
 `;
 
-const ImageWrapper = styled.div.attrs<{ isDetailed?: boolean }>(props => ({
+const ImageWrapper = styled.div.attrs<IsDetailedProps>(props => ({
   className: props.isDetailed ? grid({ s: 12, m: 6, l: 4, xl: 4 }) : '',
-}))<{ isDetailed?: boolean }>`
+}))<IsDetailedProps>`
   position: relative;
   margin-bottom: ${props => props.theme.spacingUnit * 2}px;
 `;
 
-const Details = styled.div.attrs<{ isDetailed?: boolean }>(props => ({
+const Details = styled.div.attrs<IsDetailedProps>(props => ({
   className: props.isDetailed ? grid({ s: 12, m: 6, l: 8, xl: 8 }) : '',
-}))<{ isDetailed?: boolean }>``;
+}))<IsDetailedProps>``;
 
 const DesktopLabel = styled(Space).attrs({
   v: { size: 's', properties: ['margin-bottom'] },
@@ -147,7 +149,7 @@ const StoriesGrid: FunctionComponent<Props> = ({
                 <LabelsList labels={[{ text: article.format.label }]} />
               </DesktopLabel>
 
-              <h3 className={font('wb', 4)}>{article.title}</h3>
+              <h3 className="h3">{article.title}</h3>
 
               {isDetailed &&
                 (article.publicationDate || !!article.contributors.length) && (

--- a/catalogue/webapp/components/WorkDetailsSection/WorkDetailsSection.tsx
+++ b/catalogue/webapp/components/WorkDetailsSection/WorkDetailsSection.tsx
@@ -1,5 +1,4 @@
 import SpacingSection from '@weco/common/views/components/styled/SpacingSection';
-import { font } from '@weco/common/utils/classnames';
 import { FunctionComponent, PropsWithChildren, useContext } from 'react';
 import styled from 'styled-components';
 import Space from '@weco/common/views/components/styled/Space';
@@ -9,9 +8,10 @@ type Props = PropsWithChildren<{
   headingText?: string;
 }>;
 
+type SectionWithDividerProps = { isArchive: boolean };
 const SectionWithDivider = styled(Space).attrs({
   v: { size: 'l', properties: ['padding-top'] },
-})<{ isArchive: boolean }>`
+})<SectionWithDividerProps>`
   ${props =>
     props.isArchive &&
     `
@@ -33,7 +33,7 @@ const WorkDetailsSection: FunctionComponent<Props> = ({
   return (
     <SectionWithDivider isArchive={isArchive}>
       <SpacingSection>
-        {headingText && <h2 className={font('wb', 4)}>{headingText}</h2>}
+        {headingText && <h2 className="h3">{headingText}</h2>}
 
         {children}
       </SpacingSection>

--- a/common/views/components/SectionHeader/SectionHeader.tsx
+++ b/common/views/components/SectionHeader/SectionHeader.tsx
@@ -1,7 +1,6 @@
 import { FunctionComponent } from 'react';
-import { font } from '../../../utils/classnames';
-import Space from '../styled/Space';
 import styled from 'styled-components';
+import Space from '../styled/Space';
 import Layout12 from '../Layout12/Layout12';
 
 const YellowBox = styled.div`
@@ -38,10 +37,10 @@ type Props = {
 
 const SectionHeader: FunctionComponent<Props> = ({ title }) => {
   return (
-    <div className={font('wb', 2)}>
+    <div>
       <Layout12>
         <YellowBox />
-        <TitleWrapper as="h2">
+        <TitleWrapper as="h2" className="h1">
           <Title>{title}</Title>
         </TitleWrapper>
       </Layout12>

--- a/common/views/components/SegmentedControl/SegmentedControl.tsx
+++ b/common/views/components/SegmentedControl/SegmentedControl.tsx
@@ -31,7 +31,7 @@ const DrawerItem = styled(Space).attrs({
     properties: ['padding-top', 'padding-bottom'],
   },
   as: 'li',
-  className: font('wb', 4),
+  className: 'h3',
 })<DrawerItemProps>`
   border-bottom: 1px solid ${props => props.theme.color('neutral.300')};
 
@@ -124,7 +124,7 @@ const Drawer = styled.div`
 const MobileControlsContainer = styled(Space).attrs({
   v: { size: 'm', properties: ['padding-top', 'padding-bottom'] },
   h: { size: 'm', properties: ['padding-left', 'padding-right'] },
-  className: font('wb', 4),
+  className: 'h3',
 })`
   display: flex;
   color: ${props => props.theme.color('white')};

--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -1,31 +1,36 @@
+import { NextPage } from 'next';
 import { AppProps } from 'next/app';
 import React, { useEffect, FunctionComponent, ReactElement } from 'react';
+import ReactGA from 'react-ga';
 import { ThemeProvider } from 'styled-components';
-import theme, { GlobalStyle } from '../../views/themes/default';
-import OutboundLinkTracker from '../../views/components/OutboundLinkTracker/OutboundLinkTracker';
-import LoadingIndicator from '../../views/components/LoadingIndicator/LoadingIndicator';
+
+import theme, { GlobalStyle } from '@weco/common/views/themes/default';
+import { GlobalStyle as AlignedHeadingsGlobalStyle } from '@weco/common/views/themes/defaultV2';
+import OutboundLinkTracker from '@weco/common/views/components/OutboundLinkTracker/OutboundLinkTracker';
+import LoadingIndicator from '@weco/common/views/components/LoadingIndicator/LoadingIndicator';
 import { AppContextProvider } from '../components/AppContext/AppContext';
 import ErrorPage from '../components/ErrorPage/ErrorPage';
-import { Pageview, trackPageview } from '../../services/conversion/track';
-import useIsFontsLoaded from '../../hooks/useIsFontsLoaded';
+import {
+  Pageview,
+  trackPageview,
+} from '@weco/common/services/conversion/track';
+import useIsFontsLoaded from '@weco/common/hooks/useIsFontsLoaded';
 import {
   isServerData,
   defaultServerData,
   ServerData,
-} from '../../server-data/types';
-import { ServerDataContext } from '../../server-data/Context';
+} from '@weco/common/server-data/types';
+import { ServerDataContext } from '@weco/common/server-data/Context';
 import UserProvider from '../components/UserProvider/UserProvider';
 import { ApmContextProvider } from '../components/ApmContext/ApmContext';
-import { AppErrorProps } from '../../services/app';
-import usePrismicPreview from '../../services/app/usePrismicPreview';
-import useMaintainPageHeight from '../../services/app/useMaintainPageHeight';
+import { AppErrorProps } from '@weco/common/services/app';
+import usePrismicPreview from '@weco/common/services/app/usePrismicPreview';
+import useMaintainPageHeight from '@weco/common/services/app/useMaintainPageHeight';
 import {
   GaDimensions,
   useGoogleAnalyticsUA,
-} from '../../services/app/google-analytics';
-import { useOnPageLoad } from '../../services/app/useOnPageLoad';
-import ReactGA from 'react-ga';
-import { NextPage } from 'next';
+} from '@weco/common/services/app/google-analytics';
+import { useOnPageLoad } from '@weco/common/services/app/useOnPageLoad';
 import { deserialiseProps } from '@weco/common/utils/json';
 
 // Error pages can't send anything via the data fetching methods as
@@ -115,6 +120,8 @@ const WecoApp: FunctionComponent<WecoAppProps> = ({
 
   const getLayout = Component.getLayout || (page => <>{page}</>);
 
+  const isFontsLoaded = useIsFontsLoaded();
+
   return (
     <>
       <ApmContextProvider>
@@ -122,10 +129,17 @@ const WecoApp: FunctionComponent<WecoAppProps> = ({
           <UserProvider>
             <AppContextProvider>
               <ThemeProvider theme={theme}>
-                <GlobalStyle
-                  toggles={serverData.toggles}
-                  isFontsLoaded={useIsFontsLoaded()}
-                />
+                {serverData.toggles.headingSizes ? (
+                  <AlignedHeadingsGlobalStyle
+                    toggles={serverData.toggles}
+                    isFontsLoaded={isFontsLoaded}
+                  />
+                ) : (
+                  <GlobalStyle
+                    toggles={serverData.toggles}
+                    isFontsLoaded={isFontsLoaded}
+                  />
+                )}
                 <OutboundLinkTracker>
                   <LoadingIndicator />
                   {!pageProps.err &&

--- a/common/views/themes/defaultV2.ts
+++ b/common/views/themes/defaultV2.ts
@@ -1,0 +1,143 @@
+// Exists for #10022 toggle test
+import { css, createGlobalStyle } from 'styled-components';
+import { SpaceOverrides } from '../components/styled/Space';
+import {
+  typography,
+  makeFontSizeClasses,
+  makeFontSizeOverrideClasses,
+} from './typographyV2';
+import { utilityClasses } from './utility-classes';
+import { normalize } from './base/normalize';
+import { wellcomeNormalize } from './base/wellcome-normalize';
+import { layout } from './base/layout';
+import { row } from './base/row';
+import { inlineFonts } from './base/inline-fonts';
+import { fonts } from './base/fonts';
+import { themeValues, spacingUnits, Size } from './config';
+import { grid } from './grid';
+
+type SpaceSize = 'xs' | 's' | 'm' | 'l' | 'xl';
+type SpaceProperty =
+  | 'margin-bottom'
+  | 'margin-top'
+  | 'padding-bottom'
+  | 'padding-top'
+  | 'top'
+  | 'bottom'
+  | 'margin-left'
+  | 'margin-right'
+  | 'padding-left'
+  | 'padding-right'
+  | 'left'
+  | 'right';
+
+const breakpointNames = ['small', 'medium', 'large'];
+
+function makeSpacePropertyValues(
+  size: SpaceSize,
+  properties: SpaceProperty[],
+  negative?: boolean,
+  overrides?: SpaceOverrides
+): string {
+  return breakpointNames
+    .map(bp => {
+      return `@media (min-width: ${themeValues.sizes[bp]}px) {
+      ${properties
+        .map(
+          p =>
+            `${p}: ${negative ? '-' : ''}${
+              overrides && overrides[bp]
+                ? spacingUnits[overrides[bp]]
+                : themeValues.spaceAtBreakpoints[bp][size]
+            }px;`
+        )
+        .join('')}
+    }`;
+    })
+    .join('');
+}
+
+const theme = {
+  ...themeValues,
+  makeSpacePropertyValues,
+};
+
+type Classes = typeof classes;
+const classes = {
+  displayNone: 'display-none',
+  displayBlock: 'display-block',
+};
+type SizedClasses = {
+  small: Classes;
+  medium: Classes;
+  large: Classes;
+  xlarge: Classes;
+};
+
+const sizesClasses = Object.keys(themeValues.sizes).reduce((acc, size) => {
+  const o = Object.entries(classes).reduce((acc, [key, val]) => {
+    return {
+      ...acc,
+      [key]: `${size}-${val}`,
+    };
+  }, {});
+
+  return {
+    ...acc,
+    [size]: o,
+  };
+}, {});
+
+// We know these types to be true but typescript and `.keys` and `.reduce` doesn't play all that nice
+// TODO: Remove type coercion
+// see: https://fettblog.eu/typescript-better-object-keys/
+const cls = {
+  ...classes,
+  ...sizesClasses,
+} as any as Classes & SizedClasses;
+
+export type GlobalStyleProps = {
+  toggles?: { [key: string]: boolean | undefined };
+  isFontsLoaded?: boolean;
+};
+
+const GlobalStyle = createGlobalStyle<GlobalStyleProps>`
+  ${css`
+    .${cls.displayBlock} {
+      display: block;
+    }
+    .${cls.displayNone} {
+      display: none;
+    }
+  `}
+  ${css`
+    ${Object.keys(themeValues.sizes).map(
+      size => css`
+        .${cls[size as Size].displayNone} {
+          ${props => props.theme.media(size as Size)`
+          display: none;
+        `}
+        }
+        .${cls[size as Size].displayBlock} {
+          ${props => props.theme.media(size as Size)`
+          display: block;
+        `}
+        }
+      `
+    )}
+  `}
+  ${utilityClasses}
+  ${normalize}
+  ${wellcomeNormalize}
+  ${layout}
+  ${row}
+  ${inlineFonts}
+  ${fonts}
+  ${makeFontSizeClasses()}
+  ${makeFontSizeOverrideClasses()}
+  ${typography}
+  ${grid}
+`;
+
+export default theme;
+export { GlobalStyle, cls };

--- a/common/views/themes/typographyV2.ts
+++ b/common/views/themes/typographyV2.ts
@@ -1,0 +1,390 @@
+// Exists for #10022 toggle test
+import { themeValues } from './config';
+import { css } from 'styled-components';
+import { GlobalStyleProps } from './default';
+
+const breakpointNames = ['small', 'medium', 'large'];
+const oneRem = 16;
+
+const fontSizeUnits = {
+  '1': 14 / oneRem, // 0.875rem
+  '2': 15 / oneRem, // 0.9375rem
+  '3': 15.9 / oneRem, // 0.99375rem
+  '4': 18 / oneRem, // 1.125rem
+  '5': 18.8 / oneRem, // 1.175rem
+  '6': 21.6 / oneRem, // 1.35rem
+  '7': 24 / oneRem, // 1.5rem
+  '8': 28 / oneRem, // 1.75rem
+  '9': 32 / oneRem, // 2rem
+  '10': 40 / oneRem, // 2.5rem
+  '11': 50 / oneRem, // 3.125rem
+};
+
+export const fontSizesAtBreakpoints = {
+  small: {
+    0: fontSizeUnits[9],
+    1: fontSizeUnits[8],
+    2: fontSizeUnits[7],
+    3: fontSizeUnits[5],
+    4: fontSizeUnits[3],
+    5: fontSizeUnits[2],
+    6: fontSizeUnits[1],
+  },
+  medium: {
+    0: fontSizeUnits[10],
+    1: fontSizeUnits[9],
+    2: fontSizeUnits[7],
+    3: fontSizeUnits[6],
+    4: fontSizeUnits[4],
+    5: fontSizeUnits[2],
+    6: fontSizeUnits[1],
+  },
+  large: {
+    0: fontSizeUnits[11],
+    1: fontSizeUnits[10],
+    2: fontSizeUnits[8],
+    3: fontSizeUnits[6],
+    4: fontSizeUnits[5],
+    5: fontSizeUnits[3],
+    6: fontSizeUnits[1],
+  },
+};
+
+const fontFamilies = {
+  intr: {
+    base: `Inter, sans-serif;`,
+    full: `Inter, sans-serif;`,
+  },
+  intb: {
+    base: `Inter, sans-serif;`,
+    full: `Inter, sans-serif;`,
+  },
+  wb: {
+    base: `'Wellcome Bold Web Subset', 'Arial Black', sans-serif;`,
+    full: `'Wellcome Bold Web', 'Wellcome Bold Web Subset', 'Arial Black', sans-serif;`,
+  },
+  lr: {
+    base: `'Courier New', Courier, Monospace;`,
+    full: `'Lettera Regular Web', 'Courier New', Courier, Monospace;`,
+  },
+};
+
+const fontSizeMixin = size => {
+  return breakpointNames
+    .map(name => {
+      return `@media (min-width: ${themeValues.sizes[name]}px) {
+      font-size: ${fontSizesAtBreakpoints[name][size]}rem;
+    }`;
+    })
+    .join(' ');
+};
+
+type FontFamily = keyof typeof fontFamilies;
+
+export const fontFamilyMixin = (
+  family: FontFamily,
+  isFull: boolean
+): string => {
+  return `font-family: ${fontFamilies[family][isFull ? 'full' : 'base']}`;
+};
+
+export const typography = css<GlobalStyleProps>`
+  .font-intb {
+    font-weight: bold;
+  }
+
+  .font-intr {
+    font-weight: normal;
+  }
+
+  ${props => `
+    .font-intb {
+      ${fontFamilyMixin('intb', !!props.isFontsLoaded)};
+    }
+
+    .font-intr {
+      ${fontFamilyMixin('intr', !!props.isFontsLoaded)};
+    }
+
+    .font-wb {
+      ${fontFamilyMixin('wb', !!props.isFontsLoaded)};
+    }
+
+    .font-lr {
+      ${fontFamilyMixin('lr', !!props.isFontsLoaded)};
+    }
+  `}
+
+  html {
+    font-size: 100%;
+  }
+
+  body {
+    ${fontFamilyMixin('intr', true)}
+    ${fontSizeMixin(4)}
+    line-height: 1.5;
+    color: ${themeValues.color('black')};
+    font-variant-ligatures: no-common-ligatures;
+    -webkit-font-smoothing: antialiased;
+    -moz-font-smoothing: antialiased;
+    -o-font-smoothing: antialiased;
+  }
+
+  .h0 {
+    ${fontFamilyMixin('wb', true)}
+    ${fontSizeMixin(1)}
+  }
+
+  .h1 {
+    ${fontFamilyMixin('wb', true)}
+    ${fontSizeMixin(2)}
+  }
+
+  .h2 {
+    ${fontFamilyMixin('wb', true)}
+    ${fontSizeMixin(3)}
+  }
+
+  .h3 {
+    ${fontFamilyMixin('wb', true)}
+    ${fontSizeMixin(4)}
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-size: 1em;
+    margin: 0 0 0.6em;
+  }
+
+  a {
+    color: inherit;
+    text-decoration: underline;
+
+    &:hover {
+      text-decoration: none;
+    }
+
+    &:focus-visible,
+    &:focus {
+      box-shadow: ${props => props.theme.focusBoxShadow};
+      outline: 0;
+    }
+
+    :focus:not(:focus-visible) {
+      box-shadow: none;
+    }
+  }
+
+  p {
+    margin-top: 0;
+    margin-bottom: 1.6em;
+
+    &:empty {
+      display: none;
+    }
+  }
+
+  hr {
+    margin: 0;
+  }
+
+  .more-link {
+    color: ${themeValues.color('accent.green')};
+    text-decoration: none;
+
+    &:hover,
+    &:focus {
+      text-decoration: underline;
+    }
+  }
+
+  .spaced-text {
+    p,
+    ul,
+    h2,
+    h3 {
+      margin-bottom: 0;
+    }
+
+    * + * {
+      margin-top: ${themeValues.spacedTextTopMargin};
+    }
+
+    li + li {
+      margin-top: 0.3em;
+    }
+
+    h2 + p,
+    h2 + ul {
+      margin-top: 1.2em;
+    }
+
+    h3 + p,
+    h3 + ul {
+      margin-top: 0.3em;
+    }
+  }
+
+  .body-text {
+    line-height: 1.6;
+    letter-spacing: 0.0044em;
+
+    h1 {
+      ${fontFamilyMixin('wb', true)}
+      ${fontSizeMixin(2)}
+    }
+
+    h2 {
+      ${fontFamilyMixin('wb', true)}
+      ${fontSizeMixin(3)}
+    }
+
+    h3 {
+      ${fontFamilyMixin('intb', true)}
+      ${fontSizeMixin(4)}
+    }
+
+    *::selection {
+      background: ${themeValues.color('accent.turquoise')}4d;
+    }
+
+    /* stylelint-disable no-descending-specificity */
+    ul {
+      list-style: none;
+      padding: 0;
+
+      li {
+        padding-left: 12px;
+
+        &::before {
+          content: '';
+          width: 0.35em;
+          height: 0.35em;
+          display: inline-block;
+          vertical-align: middle;
+          border-radius: 0.1em;
+          background: currentColor;
+          margin-right: 6px;
+          margin-left: -12px;
+        }
+      }
+    }
+    /* stylelint-enable no-descending-specificity */
+
+    a:link:not(.link-reset),
+    a:visited:not(.link-reset) {
+      text-decoration: underline;
+      text-underline-offset: 0.1em;
+      transition: color ${themeValues.transitionProperties};
+
+      &:hover {
+        color: ${themeValues.color('accent.green')};
+        text-decoration-color: transparent;
+      }
+    }
+
+    strong,
+    b {
+      ${fontFamilyMixin('intb', true)};
+    }
+  }
+
+  .drop-cap {
+    ${fontFamilyMixin('wb', true)}
+    font-size: 3em;
+    color: ${themeValues.color('black')};
+    float: left;
+    line-height: 1em;
+    padding-right: 0.1em;
+    position: relative;
+    top: 0.05em;
+  }
+
+  /* stylelint-disable no-descending-specificity */
+  .quote {
+    border-left: 12px solid ${themeValues.color('warmNeutral.400')};
+    padding-left: 0.9em;
+
+    p {
+      &:first-child {
+        margin-top: 0;
+      }
+
+      &:last-child {
+        margin-bottom: 0;
+      }
+    }
+  }
+  /* stylelint-enable no-descending-specificity */
+
+  .quote--pull {
+    border-color: transparent;
+    position: relative;
+
+    &::before {
+      ${fontFamilyMixin('wb', true)}
+      position: absolute;
+      content: '“';
+      color: ${themeValues.color('accent.blue')};
+      left: -14px;
+      top: 0.12em;
+      font-size: 2em;
+      line-height: 1;
+    }
+  }
+
+  .quote__cite {
+    font-style: normal;
+  }
+`;
+
+export function makeFontSizeClasses(): string {
+  return breakpointNames
+    .map(bp => {
+      return `@media (min-width: ${themeValues.sizes[bp]}px) {
+      ${Object.entries(fontSizesAtBreakpoints[bp])
+        .map(([key, value]) => {
+          return `.font-size-${key} {font-size: ${value}rem}`;
+        })
+        .join(' ')}
+    }`;
+    })
+    .join(' ');
+}
+
+function overridesAtBreakpoint(bp: string) {
+  return Object.entries(fontSizeUnits)
+    .map(([key, value]) => {
+      return `.font-size-override-${bp}-${key} {font-size: ${value}rem}`;
+    })
+    .join(' ');
+}
+
+export function makeFontSizeOverrideClasses(): string {
+  return breakpointNames
+    .map(bp => {
+      const minMax =
+        bp === 'small'
+          ? ['small', 'medium']
+          : bp === 'medium'
+          ? ['medium', 'large']
+          : ['large'];
+
+      if (minMax.length === 2) {
+        return `@media (min-width: ${
+          themeValues.sizes[minMax[0]]
+        }px) and (max-width: ${themeValues.sizes[minMax[1]]}px) {
+        ${overridesAtBreakpoint(bp)}
+      }`;
+      } else {
+        return `@media (min-width: ${themeValues.sizes[minMax[0]]}px) {
+        ${overridesAtBreakpoint(bp)}
+      }`;
+      }
+    })
+    .join(' ');
+}

--- a/common/views/themes/typographyV2.ts
+++ b/common/views/themes/typographyV2.ts
@@ -1,4 +1,3 @@
-// Exists for #10022 toggle test
 import { themeValues } from './config';
 import { css } from 'styled-components';
 import { GlobalStyleProps } from './default';
@@ -235,17 +234,17 @@ export const typography = css<GlobalStyleProps>`
 
     h1 {
       ${fontFamilyMixin('wb', true)}
-      ${fontSizeMixin(2)}
+      ${fontSizeMixin(1)}
     }
 
     h2 {
       ${fontFamilyMixin('wb', true)}
-      ${fontSizeMixin(3)}
+      ${fontSizeMixin(2)}
     }
 
     h3 {
       ${fontFamilyMixin('intb', true)}
-      ${fontSizeMixin(4)}
+      ${fontSizeMixin(3)}
     }
 
     *::selection {

--- a/content/webapp/components/BannerCard/BannerCard.tsx
+++ b/content/webapp/components/BannerCard/BannerCard.tsx
@@ -148,7 +148,7 @@ const BannerCard: FunctionComponent<Props> = ({
         <Space
           v={{ size: 'm', properties: ['margin-top', 'margin-bottom'] }}
           as="h2"
-          className={font('wb', 2)}
+          className="h1"
         >
           {title}
         </Space>

--- a/content/webapp/components/BookPromo/BookPromo.tsx
+++ b/content/webapp/components/BookPromo/BookPromo.tsx
@@ -34,7 +34,7 @@ const LinkSpace = styled(Space).attrs<LinkSpaceAttrs>(props => ({
 `;
 
 const Title = styled.h3.attrs({
-  className: font('wb', 4),
+  className: 'h3',
 })`
   margin: 0;
 `;

--- a/content/webapp/components/Card/Card.tsx
+++ b/content/webapp/components/Card/Card.tsx
@@ -160,7 +160,7 @@ const Description = styled.p.attrs({
 export const CardTitle = styled(Space).attrs({
   v: { size: 's', properties: ['margin-bottom'] },
   as: 'h3',
-  className: font('wb', 3),
+  className: 'h2',
 })`
   transition: color 400ms ease;
 `;

--- a/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.Stop.tsx
+++ b/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.Stop.tsx
@@ -25,7 +25,7 @@ const StandaloneTitle = styled(Space).attrs({
     properties: ['padding-top', 'padding-bottom'],
   },
   h: { size: 'm', properties: ['padding-left', 'padding-right'] },
-  className: `${font('wb', 2)}`,
+  className: 'h1',
 })`
   display: inline-block;
   position: relative;
@@ -39,13 +39,13 @@ type LevelProps = { level: number };
 
 const ContextTitle = styled(Space).attrs<LevelProps>(props => ({
   as: `h${props.level}`,
-  className: font('wb', 3),
+  className: 'h2',
   v: { size: 'm', properties: ['margin-bottom'] },
 }))<LevelProps>``;
 
 const TranscriptTitle = styled(Space).attrs<LevelProps>(props => ({
   as: `h${props.level}`,
-  className: font('wb', 4),
+  className: 'h3',
   v: { size: 'm', properties: ['margin-bottom'] },
 }))<LevelProps>``;
 
@@ -63,7 +63,7 @@ const ContextContainer = styled(Space).attrs<ContextContainerProps>(props => ({
 
 const TombstoneTitle = styled(Space).attrs<LevelProps>(props => ({
   as: `h${props.level}`,
-  className: font('wb', 3),
+  className: 'h2',
   v: { size: 's', properties: ['margin-bottom'] },
 }))<LevelProps>``;
 

--- a/content/webapp/components/ExhibitionGuideLinksPromo/ExhibitionGuideLinksPromo.tsx
+++ b/content/webapp/components/ExhibitionGuideLinksPromo/ExhibitionGuideLinksPromo.tsx
@@ -93,7 +93,7 @@ const ExhibitionGuideLinksPromo: FunctionComponent<Props> = ({
             properties: ['margin-top', 'margin-bottom'],
           }}
           as="h3"
-          className={font('wb', 3)}
+          className="h2"
         >
           {exhibitionGuide.title}
         </Space>

--- a/content/webapp/components/FacilityPromo/FacilityPromo.tsx
+++ b/content/webapp/components/FacilityPromo/FacilityPromo.tsx
@@ -65,7 +65,7 @@ const FacilityPromo: FunctionComponent<FacilityPromoType> = ({
 
         <CardBody>
           <div>
-            <h3 className={font('wb', 4)}>{title}</h3>
+            <h3 className="h3">{title}</h3>
             <Description>{description}</Description>
 
             {metaText && (

--- a/content/webapp/components/FeaturedCard/FeaturedCard.tsx
+++ b/content/webapp/components/FeaturedCard/FeaturedCard.tsx
@@ -113,7 +113,7 @@ const FeaturedCardArticleBody: FunctionComponent<
           backgroundColor={seriesColor}
         />
       )}
-      <h2 className={font('wb', 2)}>{article.title}</h2>
+      <h2 className="h1">{article.title}</h2>
       {article.promo?.caption && (
         <p className={font('intr', 5)}>{article.promo?.caption}</p>
       )}
@@ -157,7 +157,7 @@ const FeaturedCardExhibitionBody = ({
 }: FeaturedCardExhibitionBodyProps) => {
   return (
     <div data-test-id="featured-exhibition">
-      <h2 className={font('wb', 2)}>{exhibition.title}</h2>
+      <h2 className="h1">{exhibition.title}</h2>
       {!exhibition.statusOverride && exhibition.start && exhibition.end && (
         <DateWrapper as="p">
           <DateRange start={exhibition.start} end={exhibition.end} />

--- a/content/webapp/components/MediaObject/MediaObject.tsx
+++ b/content/webapp/components/MediaObject/MediaObject.tsx
@@ -6,7 +6,7 @@ import MediaObjectBase, {
 import { getCrop, ImageType } from '@weco/common/model/image';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
 import styled from 'styled-components';
-import { grid, font } from '@weco/common/utils/classnames';
+import { grid } from '@weco/common/utils/classnames';
 import * as prismic from '@prismicio/client';
 import { gridSize12 } from '@weco/common/views/components/Layout12/Layout12';
 
@@ -33,7 +33,7 @@ const TextWrapper = styled.div.attrs<HasImageProps>(props => ({
 }))<HasImageProps>``;
 
 const TitleWrapper = styled.div.attrs({
-  className: font('wb', 4),
+  className: 'h3',
 })``;
 
 export const MediaObject: FunctionComponent<Props> = ({

--- a/content/webapp/components/MediaObjectBase/MediaObjectBase.test.tsx
+++ b/content/webapp/components/MediaObjectBase/MediaObjectBase.test.tsx
@@ -8,7 +8,7 @@ import {
 import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImage';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
 import styled from 'styled-components';
-import { grid, font } from '@weco/common/utils/classnames';
+import { grid } from '@weco/common/utils/classnames';
 import * as prismic from '@prismicio/client';
 
 const getBaseTitleClass = number => {
@@ -46,7 +46,7 @@ const TextWrapper = styled.div.attrs<HasImageProps>(props => {
 })<HasImageProps>``;
 
 const TitleWrapper = styled.div.attrs({
-  className: font('wb', 4),
+  className: 'h3',
 })``;
 
 const extraClass = 'my_extra_extra_class';

--- a/content/webapp/components/MediaObjectBase/MediaObjectBase.tsx
+++ b/content/webapp/components/MediaObjectBase/MediaObjectBase.tsx
@@ -45,7 +45,7 @@ const BaseImageWrapper = styled.div.attrs({
 })``;
 
 const BaseTitleWrapper = styled.h3.attrs({
-  className: font('wb', 3),
+  className: 'h2',
 })`
   margin: 0;
 `;

--- a/content/webapp/components/SeasonsHeader/index.tsx
+++ b/content/webapp/components/SeasonsHeader/index.tsx
@@ -64,7 +64,7 @@ const SeasonsHeader: FunctionComponent<Props> = ({ season }) => {
                     <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
                       <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
                         <h1
-                          className={font('wb', 1)}
+                          className="h0"
                           style={{ display: 'inline-block', marginBottom: 0 }}
                         >
                           {title}

--- a/content/webapp/pages/guides/exhibitions/[id]/[type].tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/[type].tsx
@@ -42,12 +42,13 @@ const ButtonWrapper = styled(Space).attrs({
   display: inline-block;
 `;
 
+type HeaderProps = { backgroundColor: PaletteColor };
 const Header = styled(Space).attrs({
   v: {
     size: 'xl',
     properties: ['padding-top', 'padding-bottom', 'margin-bottom'],
   },
-})<{ backgroundColor: PaletteColor }>`
+})<HeaderProps>`
   background: ${props => props.theme.color(props.backgroundColor)};
 `;
 

--- a/content/webapp/pages/guides/exhibitions/[id]/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/index.tsx
@@ -122,10 +122,7 @@ const ExhibitionGuidePage: FunctionComponent<Props> = ({
     >
       <Layout10 isCentered={false}>
         <SpacingSection>
-          <Space
-            v={{ size: 'l', properties: ['margin-top'] }}
-            className={font('wb', 1)}
-          >
+          <Space v={{ size: 'l', properties: ['margin-top'] }}>
             <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
               <h1
                 className={font('wb', 0)}

--- a/content/webapp/pages/index.tsx
+++ b/content/webapp/pages/index.tsx
@@ -1,6 +1,5 @@
 import { FunctionComponent } from 'react';
 import styled from 'styled-components';
-import { font } from '@weco/common/utils/classnames';
 import SectionHeader from '@weco/common/views/components/SectionHeader/SectionHeader';
 import SpacingSection from '@weco/common/views/components/styled/SpacingSection';
 import SpacingComponent from '@weco/common/views/components/styled/SpacingComponent';
@@ -194,12 +193,9 @@ const Homepage: FunctionComponent<Props> = ({
       >
         <Layout10 isCentered={false}>
           <SpacingSection>
-            <Space
-              v={{ size: 'l', properties: ['margin-top'] }}
-              className={font('wb', 1)}
-            >
+            <Space v={{ size: 'l', properties: ['margin-top'] }}>
               <Space v={{ size: 'm', properties: ['margin-bottom'] }}>
-                <h1>{homepageHeading}</h1>
+                <h1 className="h0">{homepageHeading}</h1>
               </Space>
             </Space>
             {standfirst && (

--- a/content/webapp/pages/whats-on/index.tsx
+++ b/content/webapp/pages/whats-on/index.tsx
@@ -138,7 +138,7 @@ export function getRangeForPeriod(period: Period): { start: Date; end?: Date } {
 //         properties: ['margin-bottom'],
 //       }}
 //       as="p"
-//       className={font('wb', 2)}
+//       className="h1"
 //     >
 //       Our exhibitions are closed today, but our <a href={cafePromo.url}>café</a>{' '}
 //       and <a href={shopPromo.url}>shop</a> are open for your visit.

--- a/identity/webapp/src/frontend/components/Layout.style.ts
+++ b/identity/webapp/src/frontend/components/Layout.style.ts
@@ -45,7 +45,7 @@ export const SectionHeading = styled(Space).attrs<SectionHeadingProps>(
       size: 'm',
       properties: props.addBottomPadding ? ['padding-bottom'] : [],
     },
-    className: font('wb', 3),
+    className: 'h2',
   })
 )<SectionHeadingProps>`
   font-weight: bold;

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -71,6 +71,14 @@ const toggles = {
         'Displays an audio player with text-to-speech audio on selected articles',
       type: 'experimental',
     },
+    {
+      id: 'headingSizes',
+      title: 'Align headings',
+      initialValue: false,
+      description:
+        'Try to align body-text headings with general content ones (#10022)',
+      type: 'experimental',
+    },
   ] as const,
   tests: [] as ABTest[],
 };


### PR DESCRIPTION
## Who is this for?
Aligned styles

## What is it doing for them?
Relates to #10022

> we realised that headings (in this case, all `<h2>`) were being styled differently. [See an example page](https://wellcomecollection.org/exhibitions/Y8VNbhEAAPJM-oki).
Prismic slices can allow editors to create h1, h2 and h3 elements. These are more often than not wrapped in a parent `.body-text` class in the React component we use to render out those slices. (Worth noting that `.body-text` is also elsewhere, so other headings may be impacted). [You may see their declared styles here](https://github.com/wellcomecollection/wellcomecollection.org/blob/main/common/views/themes/typography.ts#L231).
Then, on the same pages you can also find hard-coded headings that are assigned a class (from .h0 to .h6), [which you may find here](https://github.com/wellcomecollection/wellcomecollection.org/blob/main/common/views/themes/typography.ts#L132).
Notice how equivalents pass a different number in the fontSizeMixin() function, meaning that
`<h2 class="h2">Title</h2>`
and
`<div class="body-text"><h2>Title</h2></div>`
display at different sizes.

This PR moves the sizes up one time on `.body-text` children heading behind a toggle ("Align headings") to allow us to confirm this is something we'd want to do officially.

It looks better in the exhibition page, but I think it doesn't look as good to have smaller h2s in Stories. I think we might have to go with a third solution not listed in #10022 and review other headings, maybe bump `<h2 class="h2">` to `<h2 class="h1">`. I'll share this in the FE meetup and with Dom as well.