### PR TITLE
Don't include `works: {}` in the props if there are no search results

### DIFF
--- a/catalogue/webapp/pages/search/index.tsx
+++ b/catalogue/webapp/pages/search/index.tsx
@@ -95,7 +95,7 @@ const SectionTitle = ({ sectionName }: { sectionName: string }) => {
 };
 
 const StoryPromoContainer = styled(Container)`
-${props =>
+  ${props =>
     props.theme.mediaBetween(
       'small',
       'medium'
@@ -342,12 +342,13 @@ export const getServerSideProps: GetServerSideProps<
         ...defaultProps,
         ...(stories && stories.pageResults?.length && { stories }),
         ...(images?.pageResults.length && { images }),
-        works: works
-          ? {
-            ...works,
-            pageResults: works.pageResults.map(toWorkBasic),
-          }
-          : {},
+        works:
+          works && works.pageResults.length
+            ? {
+                ...works,
+                pageResults: works.pageResults.map(toWorkBasic),
+              }
+            : undefined,
       }),
     };
   } catch (error) {


### PR DESCRIPTION
This is causing a bug on the search page where it sees the variable as defined, so it assumes there are results and renders an empty list of work results.