### PR TITLE
Quick refactor of SearchNoResults

### DIFF
--- a/catalogue/webapp/components/SearchNoResults/SearchNoResults.tsx
+++ b/catalogue/webapp/components/SearchNoResults/SearchNoResults.tsx
@@ -1,47 +1,38 @@
+import { FunctionComponent } from 'react';
+import styled from 'styled-components';
 import Space from '@weco/common/views/components/styled/Space';
 import { font, grid } from '@weco/common/utils/classnames';
-import styled from 'styled-components';
-import { FunctionComponent } from 'react';
-import { PaletteColor } from '@weco/common/views/themes/config';
 
 type Props = {
   query?: string;
   hasFilters?: boolean;
-  textColor?: PaletteColor;
 };
 
 const QuerySpan = styled.span.attrs({
   className: font('intb', 2),
 })``;
 
-const Copy = styled.p.attrs({ className: font('intr', 2) })<{
-  textColor?: PaletteColor;
-}>`
-  ${props =>
-    props.textColor && `color: ${props.theme.color(props.textColor)};`};
-`;
-
 const SearchNoResults: FunctionComponent<Props> = ({
   query,
   hasFilters,
-  textColor,
 }: Props) => {
   return (
     <Space v={{ size: 'xl', properties: ['padding-top', 'padding-bottom'] }}>
       <div className="grid">
         <div className={grid({ s: 12, m: 10, l: 10, xl: 10 })}>
-          <Copy data-test-id="search-no-results" textColor={textColor}>
+          <p data-test-id="search-no-results" className={font('intr', 2)}>
             We couldn&rsquo;t find anything that matched{' '}
             {query ? <QuerySpan>{query}</QuerySpan> : 'your search'}
             {hasFilters ? ' with the filters you have selected.' : '.'}
-          </Copy>
-          <Copy>
+          </p>
+          <p className={font('intr', 3)} style={{ maxWidth: '800px' }}>
             Please adjust your search terms and try again. If you think this
             search should show some results, please email{' '}
             <a href="mailto:digital@wellcomecollection.org">
               digital@wellcomecollection.org
             </a>
-          </Copy>
+            .
+          </p>
         </div>
       </div>
     </Space>


### PR DESCRIPTION
## Who is this for?
Anyone/design

## What is it doing for them?
- More content has been added so it felt like we could make some text smaller now.
- Removed `textColor` as it was not currently used, I can't remember if image search used to have it on a black background? 

<img width="1272" alt="Screenshot 2023-08-01 at 15 50 14" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/e0113281-83df-4128-a9c8-aab90ff522c2">

<img width="1267" alt="Screenshot 2023-08-01 at 15 50 42" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/5858e75b-f147-4020-adb0-57dd4f5b5d72">

