### PR TITLE
Add (flex) gap properties as option for Space component

### DIFF
--- a/common/views/components/LabelsList/LabelsList.tsx
+++ b/common/views/components/LabelsList/LabelsList.tsx
@@ -7,26 +7,16 @@ import styled from 'styled-components';
 const List = styled(Space).attrs({
   v: {
     size: 'xs',
-    properties: ['margin-bottom'],
-    negative: true,
+    properties: ['row-gap'],
   },
-  h: { size: 'm', properties: ['padding-right'] },
+  h: { size: 'xs', properties: ['column-gap'] },
 })`
   display: flex;
   padding: 0;
-  margin-left: 0;
-  margin-top: 0;
+  margin: 0;
   flex-wrap: wrap;
   list-style: none;
 `;
-
-const ListItem = styled(Space).attrs({
-  v: {
-    size: 'xs',
-    properties: ['margin-bottom'],
-  },
-  h: { size: 'xs', properties: ['margin-right'] },
-})``;
 
 export type Props = {
   labels: LabelType[];
@@ -37,13 +27,15 @@ const LabelsList: FunctionComponent<Props> = ({
   labels,
   defaultLabelColor = 'yellow',
 }: Props) => (
-  <List as="ul">
-    {labels.filter(Boolean).map((label, i) => (
-      <ListItem as="li" key={`${label.text}-${i}`}>
-        <Label label={label} defaultLabelColor={defaultLabelColor} />
-      </ListItem>
-    ))}
-  </List>
+  <Space h={{ size: 'm', properties: ['padding-right'] }}>
+    <List as="ul">
+      {labels.filter(Boolean).map((label, i) => (
+        <li key={`${label.text}-${i}`}>
+          <Label label={label} defaultLabelColor={defaultLabelColor} />
+        </li>
+      ))}
+    </List>
+  </Space>
 );
 
 export default LabelsList;

--- a/common/views/components/styled/Space.tsx
+++ b/common/views/components/styled/Space.tsx
@@ -19,7 +19,8 @@ export type VerticalSpaceProperty =
   | 'padding-top'
   | 'padding-bottom'
   | 'top'
-  | 'bottom';
+  | 'bottom'
+  | 'row-gap';
 
 export type HorizontalSpaceProperty =
   | 'margin-left'
@@ -27,7 +28,8 @@ export type HorizontalSpaceProperty =
   | 'padding-left'
   | 'padding-right'
   | 'left'
-  | 'right';
+  | 'right'
+  | 'column-gap';
 
 type SpacingUnitsIndex = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
 export type SpaceOverrides = {

--- a/common/views/themes/default.ts
+++ b/common/views/themes/default.ts
@@ -28,7 +28,9 @@ type SpaceProperty =
   | 'padding-left'
   | 'padding-right'
   | 'left'
-  | 'right';
+  | 'right'
+  | 'row-gap'
+  | 'column-gap';
 
 const breakpointNames = ['small', 'medium', 'large'];
 


### PR DESCRIPTION
## Who is this for?
Devs who want to author space as a [`gap`](https://developer.mozilla.org/en-US/docs/Web/CSS/gap) to avoid having to apply negative space on parent elements.

## What is it doing for them?
Adding `column-gap` and `row-gap` as allowable `h` and `v` properties in the `Space` component (so that we can keep our responsive spacing hierarchy with these new properties).
