### PR TITLE
Add data-gtm-trigger to OnThisPageAnchors links

### DIFF
--- a/content/webapp/components/OnThisPageAnchors/OnThisPageAnchors.tsx
+++ b/content/webapp/components/OnThisPageAnchors/OnThisPageAnchors.tsx
@@ -29,7 +29,9 @@ const OnThisPageAnchors: FunctionComponent<Props> = ({ links }) => {
       <PlainList>
         {links.map((link: Link) => (
           <li key={link.url}>
-            <Anchor href={link.url}>{link.text}</Anchor>
+            <Anchor data-gtm-trigger="link_click_page_position" href={link.url}>
+              {link.text}
+            </Anchor>
           </li>
         ))}
       </PlainList>


### PR DESCRIPTION
## Who is this for?
@taceybadgerbrook 

## What is it doing for them?
Allowing them to use the `matches CSS selector` rule in GTM to reliably detect clicks on the `OnThisPageAnchors` links