### PR TITLE
Don't close the dialog if the thing you've clicked on is the open dia…

### DIFF
--- a/common/views/components/PopupDialog/PopupDialog.tsx
+++ b/common/views/components/PopupDialog/PopupDialog.tsx
@@ -221,10 +221,13 @@ const PopupDialog: FunctionComponent<Props> = ({ document }: Props) => {
 
   function handleBodyClick(event: MouseEvent) {
     const dialog = dialogWindowRef && dialogWindowRef.current;
+    const openDialog = openDialogRef && openDialogRef.current;
+
+    if (openDialog === event.target) return;
 
     if (
       dialog &&
-      !isActiveRef.current &&
+      isActiveRef.current &&
       !dialog.contains(event.target as HTMLDivElement)
     ) {
       setIsActive(false);


### PR DESCRIPTION
…log button :facepalm:

## Who is this for?
People who want the PopupDialog to work

## What is it doing for them?
Not immediately closing it as a result of clicking the open button. And still letting you use other focusable elements on the page https://wellcome.slack.com/archives/C01FBFSDLUA/p1691055708522749