### PR TITLE
Add a `looksLikeSpam` property on pageviews considered as such

### DIFF
--- a/catalogue/webapp/pages/search/images.tsx
+++ b/catalogue/webapp/pages/search/images.tsx
@@ -263,7 +263,9 @@ export const getServerSideProps: GetServerSideProps<
         ...defaultProps,
         pageview: {
           name: 'images',
-          properties: {},
+          properties: {
+            looksLikeSpam: 'true',
+          },
         },
         images: emptyResultList(),
         apiToolbarLinks: [],

--- a/catalogue/webapp/pages/search/index.tsx
+++ b/catalogue/webapp/pages/search/index.tsx
@@ -282,7 +282,17 @@ export const getServerSideProps: GetServerSideProps<
   // The status code will also allow us to filter out spam-like requests from our analytics.
   if (looksLikeSpam(query.query)) {
     context.res.statusCode = 400;
-    return { props: serialiseProps(defaultProps) };
+    return {
+      props: serialiseProps({
+        ...defaultProps,
+        pageview: {
+          name: 'search',
+          properties: {
+            looksLikeSpam: 'true',
+          },
+        },
+      }),
+    };
   }
 
   try {

--- a/catalogue/webapp/pages/search/stories.tsx
+++ b/catalogue/webapp/pages/search/stories.tsx
@@ -229,7 +229,7 @@ export const getServerSideProps: GetServerSideProps<
   if (looksLikeSpam(query.query)) {
     context.res.statusCode = 400;
     return {
-      props: {
+      props: serialiseProps({
         ...defaultProps,
         storyResponseList: emptyResultList(),
         pageview: {
@@ -239,7 +239,7 @@ export const getServerSideProps: GetServerSideProps<
           },
         },
         apiToolbarLinks: [],
-      },
+      }),
     };
   }
 

--- a/catalogue/webapp/pages/search/stories.tsx
+++ b/catalogue/webapp/pages/search/stories.tsx
@@ -234,7 +234,9 @@ export const getServerSideProps: GetServerSideProps<
         storyResponseList: emptyResultList(),
         pageview: {
           name: 'stories',
-          properties: {},
+          properties: {
+            looksLikeSpam: 'true',
+          },
         },
         apiToolbarLinks: [],
       },

--- a/catalogue/webapp/pages/search/works.tsx
+++ b/catalogue/webapp/pages/search/works.tsx
@@ -251,7 +251,9 @@ export const getServerSideProps: GetServerSideProps<
         works: emptyResultList(),
         pageview: {
           name: 'works',
-          properties: {},
+          properties: {
+            looksLikeSpam: 'true',
+          },
         },
         apiToolbarLinks: [],
       },

--- a/catalogue/webapp/pages/search/works.tsx
+++ b/catalogue/webapp/pages/search/works.tsx
@@ -246,7 +246,7 @@ export const getServerSideProps: GetServerSideProps<
   if (looksLikeSpam(query.query)) {
     context.res.statusCode = 400;
     return {
-      props: {
+      props: serialiseProps({
         ...defaultProps,
         works: emptyResultList(),
         pageview: {
@@ -256,7 +256,7 @@ export const getServerSideProps: GetServerSideProps<
           },
         },
         apiToolbarLinks: [],
-      },
+      }),
     };
   }
 


### PR DESCRIPTION
## Who is this for?
Analysts

## What is it doing for them?
Adds a `looksLikeSpam="true"` property to pageviews that are considered to be spam.

Relates to #10091 