### PR TITLE
Add textAndIcons to (non-article) body

### DIFF
--- a/prismic-model/src/parts/body.ts
+++ b/prismic-model/src/parts/body.ts
@@ -10,6 +10,7 @@ import embed from './embed';
 import mediaObject from './media-object';
 import heading from './heading';
 import booleanDeprecated from './boolean-deprecated';
+import { textAndIconsSlice } from './textAndIcons';
 
 // I've left slice here as we shouldn't really use it.
 type SliceProps = {
@@ -182,20 +183,7 @@ export default {
           ...mediaObject,
         },
       }),
-      textAndIcons: slice('Text and icons', {
-        description: 'Side-by-side',
-        nonRepeat: {
-          text: multiLineText('Text', { extraTextOptions: ['heading3'] }),
-        },
-        repeat: {
-          icon: {
-            type: 'Image',
-            config: {
-              label: 'Icon (will display at 100px wide)',
-            },
-          },
-        },
-      }),
+      textAndIcons: textAndIconsSlice(),
       audioPlayer: slice('Audio Player', {
         nonRepeat: {
           title,

--- a/prismic-model/src/parts/body.ts
+++ b/prismic-model/src/parts/body.ts
@@ -182,6 +182,20 @@ export default {
           ...mediaObject,
         },
       }),
+      textAndIcons: slice('Text and icons', {
+        description: 'Side-by-side',
+        nonRepeat: {
+          text: multiLineText('Text', { extraTextOptions: ['heading3'] }),
+        },
+        repeat: {
+          icon: {
+            type: 'Image',
+            config: {
+              label: 'Icon (will display at 100px wide)',
+            },
+          },
+        },
+      }),
       audioPlayer: slice('Audio Player', {
         nonRepeat: {
           title,

--- a/prismic-model/src/parts/textAndIcons.ts
+++ b/prismic-model/src/parts/textAndIcons.ts
@@ -1,0 +1,19 @@
+import { multiLineText } from './text';
+import { slice } from './body';
+
+export const textAndIconsSlice = () => {
+  return slice('Text and icons', {
+    description: 'Side-by-side',
+    nonRepeat: {
+      text: multiLineText('Text', { extraTextOptions: ['heading3'] }),
+    },
+    repeat: {
+      icon: {
+        type: 'Image',
+        config: {
+          label: 'Icon (will display at 100px wide)',
+        },
+      },
+    },
+  });
+};

--- a/prismic-model/src/parts/visual-story-body.ts
+++ b/prismic-model/src/parts/visual-story-body.ts
@@ -2,6 +2,7 @@ import body, { slice } from './body';
 import boolean from './boolean';
 import { documentLink } from './link';
 import { multiLineText, singleLineText } from './text';
+import { textAndIconsSlice } from './textAndIcons';
 
 export default {
   fieldset: 'Slice zone',
@@ -68,20 +69,7 @@ export default {
           isZoomable: boolean('Allow image to be zoomed to fill viewport?'),
         },
       }),
-      textAndIcons: slice('Text and icons', {
-        description: 'Side-by-side',
-        nonRepeat: {
-          text: multiLineText('Text', { extraTextOptions: ['heading3'] }),
-        },
-        repeat: {
-          icon: {
-            type: 'Image',
-            config: {
-              label: 'Icon (will display at 100px wide)',
-            },
-          },
-        },
-      }),
+      textAndIcons: textAndIconsSlice(),
     },
   },
 };


### PR DESCRIPTION
Part of [#9849](https://github.com/wellcomecollection/wellcomecollection.org/issues/9849)

- [x] Add TextAndIcons to Page content type
