### PR TITLE
Remove heading classes

### DIFF
--- a/cardigan/stories/components/Cards/Cards.stories.tsx
+++ b/cardigan/stories/components/Cards/Cards.stories.tsx
@@ -16,6 +16,7 @@ import {
 } from '@weco/cardigan/stories/content';
 import Readme from '@weco/content/components/FeaturedCard/README.md';
 import { ReadmeDecorator } from '@weco/cardigan/config/decorators';
+import { font } from '@weco/common/utils/classnames';
 
 const primaryLabelList = [{ text: 'Study day' }, { text: 'Schools' }];
 const secondaryLabelList = [{ text: 'Speech-to-text' }];
@@ -67,10 +68,8 @@ const FeaturedCardTemplate = args => {
       }}
       Readme={Readme}
     >
-      <h2 className="font-wb font-size-2">
-        Remote diagnosis from wee to the Web
-      </h2>
-      <p className="font-intr font-size-5">
+      <h2 className={font('wb', 2)}>Remote diagnosis from wee to the Web</h2>
+      <p className={font('intr', 5)}>
         Medical practice might have moved on from when patients posted flasks of
         their urine for doctors to taste, but telehealth today keeps up the
         tradition of remote diagnosis – to our possible detriment.

--- a/cardigan/stories/components/WobblyBottom/WobblyBottom.stories.tsx
+++ b/cardigan/stories/components/WobblyBottom/WobblyBottom.stories.tsx
@@ -1,6 +1,7 @@
 import WobblyBottom from '@weco/common/views/components/WobblyBottom/WobblyBottom';
 import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImage';
 import { image as contentImage } from '@weco/cardigan/stories/content';
+import { font } from '@weco/common/utils/classnames';
 
 const Template = args => <WobblyBottom {...args} />;
 export const image = Template.bind({});
@@ -12,5 +13,5 @@ image.args = {
 export const headline = Template.bind({});
 headline.args = {
   backgroundColor: 'warmNeutral.300',
-  children: <h1 className="h1">Lorem ipsum dolor sit amet</h1>,
+  children: <h1 className={font('wb', 2)}>Lorem ipsum dolor sit amet</h1>,
 };

--- a/cardigan/stories/global/palette/palette.stories.tsx
+++ b/cardigan/stories/global/palette/palette.stories.tsx
@@ -36,7 +36,7 @@ const SectionWrapper = styled.div`
   margin: 1rem 0;
 `;
 
-const SectionTitle = styled.h2.attrs({ className: 'h2' })`
+const SectionTitle = styled.h2.attrs({ className: font('wb', 3) })`
   padding: 2rem 0 0;
 `;
 

--- a/catalogue/webapp/components/ItemRequestModal/ConfirmedDialog.tsx
+++ b/catalogue/webapp/components/ItemRequestModal/ConfirmedDialog.tsx
@@ -2,6 +2,7 @@ import { FunctionComponent } from 'react';
 import { CTAs, CurrentRequests, Header } from './common';
 import { allowedRequests } from '@weco/common/values/requests';
 import ButtonSolidLink from '@weco/common/views/components/ButtonSolidLink/ButtonSolidLink';
+import { font } from '@weco/common/utils/classnames';
 
 type ConfirmedDialogProps = {
   currentHoldNumber?: number;
@@ -13,7 +14,7 @@ const ConfirmedDialog: FunctionComponent<ConfirmedDialogProps> = ({
   return (
     <>
       <Header>
-        <span className="h2">Request confirmed</span>
+        <span className={font('wb', 3)}>Request confirmed</span>
         <CurrentRequests
           allowedHoldRequests={allowedRequests}
           currentHoldRequests={currentHoldNumber}

--- a/catalogue/webapp/components/ItemRequestModal/ErrorDialog.tsx
+++ b/catalogue/webapp/components/ItemRequestModal/ErrorDialog.tsx
@@ -3,6 +3,7 @@ import { defaultRequestErrorMessage } from '@weco/common/data/microcopy';
 import ButtonSolid from '@weco/common/views/components/ButtonSolid/ButtonSolid';
 import { CTAs, Header } from './common';
 import { themeValues } from '@weco/common/views/themes/config';
+import { font } from '@weco/common/utils/classnames';
 
 type ErrorDialogProps = {
   setIsActive: (value: boolean) => void;
@@ -15,7 +16,7 @@ const ErrorDialog: FunctionComponent<ErrorDialogProps> = ({
 }) => (
   <>
     <Header>
-      <span className="h2">Request failed</span>
+      <span className={font('wb', 3)}>Request failed</span>
     </Header>
     <p style={{ marginBottom: 0 }}>
       {errorMessage || defaultRequestErrorMessage}

--- a/catalogue/webapp/components/ItemRequestModal/RequestDialog.tsx
+++ b/catalogue/webapp/components/ItemRequestModal/RequestDialog.tsx
@@ -121,7 +121,7 @@ const RequestDialog: FunctionComponent<RequestDialogProps> = ({
   return (
     <Request onSubmit={handleConfirmRequest}>
       <Header>
-        <span className="h2">Request item</span>
+        <span className={font('wb', 3)}>Request item</span>
         <CurrentRequests
           allowedHoldRequests={allowedRequests}
           currentHoldRequests={currentHoldNumber}

--- a/catalogue/webapp/components/ModalMoreFilters/index.tsx
+++ b/catalogue/webapp/components/ModalMoreFilters/index.tsx
@@ -18,6 +18,7 @@ import PlainList from '@weco/common/views/components/styled/PlainList';
 import { LinkProps } from '@weco/common/model/link-props';
 import { DateRangeFilter } from '../SearchFilters';
 import PaletteColorPicker from '../PaletteColorPicker';
+import { font } from '@weco/common/utils/classnames';
 
 type ModalMoreFiltersProps = {
   id: string;
@@ -166,7 +167,9 @@ const MoreFilters: FunctionComponent<MoreFiltersProps> = ({
           // (https://github.com/wellcomecollection/wellcomecollection.org/issues/9109)
           // as we now sometimes get "Warning: Encountered two children with the same key" console errors
           <FilterSection key={`${f.id}-${i}`}>
-            <h3 className="h3">{f.type === 'color' ? 'Colours' : f.label}</h3>
+            <h3 className={font('wb', 4)}>
+              {f.type === 'color' ? 'Colours' : f.label}
+            </h3>
             <Space as="span" h={{ size: 'm', properties: ['margin-right'] }}>
               <PlainList as="div">
                 <section aria-label={f.label}>
@@ -237,7 +240,7 @@ const ModalMoreFilters: FunctionComponent<ModalMoreFiltersProps> = ({
         modalStyle="filters"
       >
         <FiltersHeader>
-          <h3 className="h3">All filters</h3>
+          <h3 className={font('wb', 4)}>All filters</h3>
         </FiltersHeader>
 
         <ModalInner>

--- a/catalogue/webapp/components/SearchFilters/SearchFilters.Mobile.tsx
+++ b/catalogue/webapp/components/SearchFilters/SearchFilters.Mobile.tsx
@@ -27,6 +27,7 @@ import { filter } from '@weco/common/icons';
 import Modal from '@weco/common/views/components/Modal/Modal';
 import PaletteColorPicker from '@weco/catalogue/components/PaletteColorPicker';
 import DateRangeFilter from './SearchFilters.DateRangeFilter';
+import { font } from '@weco/common/utils/classnames';
 
 const SearchFiltersContainer = styled(Space).attrs({
   v: { size: 'm', properties: ['padding-top', 'padding-bottom'] },
@@ -234,7 +235,7 @@ const SearchFiltersMobile: FunctionComponent<SearchFiltersSharedProps> = ({
       >
         <FiltersScrollable>
           <FiltersHeader>
-            <h2 className="h2">Filters</h2>
+            <h2 className={font('wb', 3)}>Filters</h2>
           </FiltersHeader>
 
           <FiltersBody>
@@ -255,7 +256,7 @@ const SearchFiltersMobile: FunctionComponent<SearchFiltersSharedProps> = ({
                 // (https://github.com/wellcomecollection/wellcomecollection.org/issues/9109)
                 // as we now sometimes get "Warning: Encountered two children with the same key" console errors
                 <FilterSection key={`${f.id}-${i}`}>
-                  <h3 className="h3">
+                  <h3 className={font('wb', 4)}>
                     {f.type === 'color' ? 'Colours' : f.label}
                   </h3>
                   {f.type === 'checkbox' && (

--- a/catalogue/webapp/pages/concepts/[conceptId].tsx
+++ b/catalogue/webapp/pages/concepts/[conceptId].tsx
@@ -365,7 +365,7 @@ export const ConceptPage: NextPage<Props> = ({
       {hasImages && (
         <ConceptImages as="section">
           <Container>
-            <h2 className="h2 sectionTitle">Images</h2>
+            <h2 className={`${font('wb', 3)} sectionTitle`}>Images</h2>
             {hasImagesTabs && (
               <TabNav
                 id="images"
@@ -392,7 +392,7 @@ export const ConceptPage: NextPage<Props> = ({
         <>
           <ConceptWorksHeader hasWorksTabs={hasWorksTabs}>
             <Container>
-              <h2 className="h2">Catalogue</h2>
+              <h2 className={font('wb', 3)}>Catalogue</h2>
 
               {hasWorksTabs && (
                 <TabNav

--- a/common/views/components/ApiToolbar/index.tsx
+++ b/common/views/components/ApiToolbar/index.tsx
@@ -4,6 +4,7 @@ import cookies from '@weco/common/data/cookies';
 import { getCookie, setCookie } from 'cookies-next';
 import useIsomorphicLayoutEffect from '../../../hooks/useIsomorphicLayoutEffect';
 import { Contributor, License } from '../../../model/catalogue';
+import { font } from 'utils/classnames';
 
 export type ApiToolbarLink = {
   id: string;
@@ -142,12 +143,7 @@ const ApiToolbar: FunctionComponent<Props> = ({ links = [] }) => {
       >
         {!mini && (
           <>
-            <span
-              className="h3"
-              style={{
-                marginLeft: '10px',
-              }}
-            >
+            <span className={font('wb', 4)} style={{ marginLeft: '10px' }}>
               API toolbar
             </span>
             <LinkList>

--- a/common/views/components/ApiToolbar/index.tsx
+++ b/common/views/components/ApiToolbar/index.tsx
@@ -1,10 +1,10 @@
 import { FunctionComponent, useState } from 'react';
 import styled from 'styled-components';
-import cookies from '@weco/common/data/cookies';
 import { getCookie, setCookie } from 'cookies-next';
-import useIsomorphicLayoutEffect from '../../../hooks/useIsomorphicLayoutEffect';
-import { Contributor, License } from '../../../model/catalogue';
-import { font } from 'utils/classnames';
+import cookies from '@weco/common/data/cookies';
+import useIsomorphicLayoutEffect from '@weco/common/hooks/useIsomorphicLayoutEffect';
+import { Contributor, License } from '@weco/common/model/catalogue';
+import { font } from '@weco/common/utils/classnames';
 
 export type ApiToolbarLink = {
   id: string;

--- a/common/views/components/InfoBlock/InfoBlock.tsx
+++ b/common/views/components/InfoBlock/InfoBlock.tsx
@@ -1,11 +1,12 @@
+import { FunctionComponent, ReactElement } from 'react';
+import styled from 'styled-components';
 import Space from '@weco/common/views/components/styled/Space';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
 import ButtonSolidLink from '@weco/common/views/components/ButtonSolidLink/ButtonSolidLink';
 import { dasherize } from '@weco/common/utils/grammar';
-import { FunctionComponent, ReactElement } from 'react';
-import styled from 'styled-components';
 import * as prismic from '@prismicio/client';
 import { themeValues } from '@weco/common/views/themes/config';
+import { font } from '@weco/common/utils/classnames';
 
 const Wrapper = styled(Space).attrs({
   h: { size: 'l', properties: ['padding-left', 'padding-right'] },
@@ -28,7 +29,7 @@ const InfoBlock: FunctionComponent<Props> = ({
 }: Props): ReactElement<Props> => {
   return (
     <Wrapper>
-      <h2 id={dasherize(title)} className="h2">
+      <h2 id={dasherize(title)} className={font('wb', 3)}>
         {title}
       </h2>
       <div className="spaced-text body-text">

--- a/common/views/components/NewsletterPromo/NewsletterPromo.tsx
+++ b/common/views/components/NewsletterPromo/NewsletterPromo.tsx
@@ -160,7 +160,7 @@ const NewsletterPromo: FunctionComponent = () => {
               <BoxInner>
                 <CopyWrap>
                   <h2
-                    className="h2"
+                    className={font('wb', 3)}
                     style={{ marginBottom: !isSuccess ? 0 : undefined }}
                   >
                     {isSuccess ? 'Thank you for signing up!' : headingText}

--- a/common/views/components/PageHeader/HighlightedHeading.tsx
+++ b/common/views/components/PageHeader/HighlightedHeading.tsx
@@ -1,6 +1,7 @@
 import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 import Space from '@weco/common/views/components/styled/Space';
+import { font } from '@weco/common/utils/classnames';
 
 const Heading = styled(Space)`
   display: block;
@@ -19,7 +20,7 @@ type Props = {
 
 const HighlightedHeading: FunctionComponent<Props> = ({ text }: Props) => {
   return (
-    <h1 className="h1">
+    <h1 className={font('wb', 2)}>
       <Heading
         v={{
           size: 's',

--- a/common/views/components/Table/Table.tsx
+++ b/common/views/components/Table/Table.tsx
@@ -314,7 +314,7 @@ const Table: FunctionComponent<Props> = ({
   return (
     <>
       {caption && (
-        <h2 className="h2" aria-hidden="true">
+        <h2 className={font('wb', 3)} aria-hidden="true">
           {caption}
         </h2>
       )}

--- a/common/views/themes/typography.ts
+++ b/common/views/themes/typography.ts
@@ -129,26 +129,6 @@ export const typography = css<GlobalStyleProps>`
     -o-font-smoothing: antialiased;
   }
 
-  .h0 {
-    ${fontFamilyMixin('wb', true)}
-    ${fontSizeMixin(1)}
-  }
-
-  .h1 {
-    ${fontFamilyMixin('wb', true)}
-    ${fontSizeMixin(2)}
-  }
-
-  .h2 {
-    ${fontFamilyMixin('wb', true)}
-    ${fontSizeMixin(3)}
-  }
-
-  .h3 {
-    ${fontFamilyMixin('wb', true)}
-    ${fontSizeMixin(4)}
-  }
-
   h1,
   h2,
   h3,

--- a/content/webapp/components/Body/Body.tsx
+++ b/content/webapp/components/Body/Body.tsx
@@ -233,7 +233,7 @@ const Body: FunctionComponent<Props> = ({
                     textColor={sectionTheme.featuredCardText}
                     isReversed={false}
                   >
-                    <h2 className="font-wb font-size-2">{firstItem.title}</h2>
+                    <h2 className={font('wb', 2)}>{firstItem.title}</h2>
                     {isCardType && firstItem.description && (
                       <p className={font('intr', 5)}>{firstItem.description}</p>
                     )}

--- a/content/webapp/components/Contributors/Contributors.tsx
+++ b/content/webapp/components/Contributors/Contributors.tsx
@@ -3,6 +3,7 @@ import { isNotUndefined } from '@weco/common/utils/type-guards';
 import Space from '@weco/common/views/components/styled/Space';
 import Contributor from './Contributor';
 import { Contributor as ContributorType } from '../../types/contributors';
+import { font } from '@weco/common/utils/classnames';
 
 export type Props = {
   titlePrefix?: string;
@@ -71,7 +72,7 @@ const Contributors: FunctionComponent<Props> = ({
 
   return (
     <>
-      <h2 className="h2">
+      <h2 className={font('wb', 3)}>
         {isNotUndefined(titleOverride)
           ? titleOverride
           : getContributorsTitle(roles, titlePrefix)}

--- a/content/webapp/components/Discussion/Discussion.tsx
+++ b/content/webapp/components/Discussion/Discussion.tsx
@@ -5,6 +5,7 @@ import ButtonSolid from '@weco/common/views/components/ButtonSolid/ButtonSolid';
 import styled from 'styled-components';
 import { plus, minus } from '@weco/common/icons';
 import * as prismic from '@prismicio/client';
+import { font } from '@weco/common/utils/classnames';
 
 const ButtonContainer = styled.div`
   position: absolute;
@@ -37,7 +38,7 @@ const Discussion: FunctionComponent<Props> = ({ title, text }: Props) => {
 
   return (
     <>
-      {title && <h2 className="h2">{title}</h2>}
+      {title && <h2 className={font('wb', 3)}>{title}</h2>}
       {textToShow && (
         <div id="discussion-container" aria-live="polite">
           <PrismicHtmlBlock html={textToShow} />

--- a/content/webapp/components/EventSchedule/EventSchedule.tsx
+++ b/content/webapp/components/EventSchedule/EventSchedule.tsx
@@ -7,6 +7,7 @@ import EventScheduleItem from './EventScheduleItem';
 import { EventsGroup, groupEventsByDay } from '../../services/prismic/events';
 import Space from '@weco/common/views/components/styled/Space';
 import { isPast } from '@weco/common/utils/dates';
+import { font } from '@weco/common/utils/classnames';
 
 const EventScheduleList: FunctionComponent<{
   groupedEvents: EventsGroup<EventType>[];
@@ -21,7 +22,7 @@ const EventScheduleList: FunctionComponent<{
               <Space
                 v={{ size: 'm', properties: ['margin-bottom'] }}
                 as="h3"
-                className="h3"
+                className={font('wb', 4)}
               >
                 {eventsGroup.label}
               </Space>
@@ -70,7 +71,7 @@ const EventSchedule: FunctionComponent<Props> = ({ schedule }) => {
     <>
       {futureEvents.length > 0 && (
         <>
-          <h2 className="h2">Events</h2>
+          <h2 className={font('wb', 3)}>Events</h2>
           <EventScheduleList
             groupedEvents={futureEvents}
             isNotLinkedIds={isNotLinkedIds}
@@ -79,7 +80,7 @@ const EventSchedule: FunctionComponent<Props> = ({ schedule }) => {
       )}
       {pastEvents.length > 0 && (
         <>
-          <h2 className="h2">Past events</h2>
+          <h2 className={font('wb', 3)}>Past events</h2>
           <EventScheduleList
             groupedEvents={pastEvents}
             isNotLinkedIds={isNotLinkedIds}

--- a/content/webapp/components/EventSchedule/EventScheduleItem.tsx
+++ b/content/webapp/components/EventSchedule/EventScheduleItem.tsx
@@ -128,7 +128,7 @@ const EventScheduleItem: FunctionComponent<Props> = ({
             <Space
               v={{ size: 's', properties: ['margin-bottom'] }}
               as="h5"
-              className="h2"
+              className={font('wb', 3)}
             >
               {event.title}
             </Space>

--- a/content/webapp/components/ExhibitionGuideLinks/TypeOption.tsx
+++ b/content/webapp/components/ExhibitionGuideLinks/TypeOption.tsx
@@ -55,7 +55,7 @@ const TypeOption: FunctionComponent<Props> = ({
         v={{ size: 'm', properties: ['padding-top', 'padding-bottom'] }}
         h={{ size: 'm', properties: ['padding-left', 'padding-right'] }}
       >
-        <h2 className="h2">{title}</h2>
+        <h2 className={font('wb', 3)}>{title}</h2>
         <p className={font('intr', 5)}>{text}</p>
         {icon && <Icon icon={icon} />}
       </Space>

--- a/content/webapp/components/ImageGallery/ImageGallery.tsx
+++ b/content/webapp/components/ImageGallery/ImageGallery.tsx
@@ -346,7 +346,7 @@ const ImageGallery: FunctionComponent<{ id: number } & Props> = ({
             <Space as="span" h={{ size: 's', properties: ['margin-right'] }}>
               <Icon icon={gallery} />
             </Space>
-            <h2 id={`gallery-${id}`} className="h2" ref={headingRef}>
+            <h2 id={`gallery-${id}`} className={font('wb', 3)} ref={headingRef}>
               {title || 'In pictures'}
             </h2>
           </GalleryTitle>

--- a/content/webapp/components/InfoBox/InfoBox.tsx
+++ b/content/webapp/components/InfoBox/InfoBox.tsx
@@ -33,7 +33,7 @@ const InfoIconWrapper = styled(Space).attrs({
 const InfoBox: FunctionComponent<Props> = ({ title, items, children }) => {
   return (
     <>
-      <h2 className="h2">{title}</h2>
+      <h2 className={font('wb', 3)}>{title}</h2>
       <InfoContainer>
         {items.map(({ title, description, icon }, i) => (
           <div key={i}>

--- a/content/webapp/components/MediaObjectBase/MediaObjectBase.test.tsx
+++ b/content/webapp/components/MediaObjectBase/MediaObjectBase.test.tsx
@@ -12,7 +12,7 @@ import { grid, font } from '@weco/common/utils/classnames';
 import * as prismic from '@prismicio/client';
 
 const getBaseTitleClass = number => {
-  return `font-wb font-size-${number}`;
+  return font('wb', number);
 };
 
 const mockOnClick = jest.fn();

--- a/content/webapp/components/OnThisPageAnchors/OnThisPageAnchors.tsx
+++ b/content/webapp/components/OnThisPageAnchors/OnThisPageAnchors.tsx
@@ -25,7 +25,7 @@ type Props = {
 const OnThisPageAnchors: FunctionComponent<Props> = ({ links }) => {
   return (
     <Root>
-      <h2 className="h3">What’s on this page</h2>
+      <h2 className={font('wb', 4)}>What’s on this page</h2>
       <PlainList>
         {links.map((link: Link) => (
           <li key={link.url}>

--- a/content/webapp/components/OtherExhibitionGuides/OtherExhibitionGuides.tsx
+++ b/content/webapp/components/OtherExhibitionGuides/OtherExhibitionGuides.tsx
@@ -1,9 +1,10 @@
-import Layout8 from '@weco/common/views/components/Layout8/Layout8';
-import Space from '@weco/common/views/components/styled/Space';
-import CardGrid from 'components/CardGrid/CardGrid';
 import { FunctionComponent } from 'react';
 import styled from 'styled-components';
-import { ExhibitionGuideBasic } from 'types/exhibition-guides';
+import { font } from '@weco/common/utils/classnames';
+import Layout8 from '@weco/common/views/components/Layout8/Layout8';
+import Space from '@weco/common/views/components/styled/Space';
+import CardGrid from '@weco/content/components/CardGrid/CardGrid';
+import { ExhibitionGuideBasic } from '@weco/content/types/exhibition-guides';
 
 const PromoContainer = styled.div`
   background: ${props => props.theme.color('warmNeutral.300')};
@@ -20,7 +21,7 @@ const OtherExhibitionGuides: FunctionComponent<Props> = ({
     <Space v={{ size: 'xl', properties: ['padding-top', 'padding-bottom'] }}>
       <Layout8 shift={false}>
         <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
-          <h2 className="h2">Other exhibition guides available</h2>
+          <h2 className={font('wb', 3)}>Other exhibition guides available</h2>
         </Space>
       </Layout8>
       <CardGrid

--- a/content/webapp/components/SearchResults/AsyncSearchResults.tsx
+++ b/content/webapp/components/SearchResults/AsyncSearchResults.tsx
@@ -1,6 +1,6 @@
 import { Component, Fragment, ReactElement } from 'react';
 import SearchResults from './SearchResults';
-import { grid } from '@weco/common/utils/classnames';
+import { font, grid } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 import { fetchMultiContentClientSide } from '../../services/prismic/fetch/multi-content';
 import { MultiContent } from '../../types/multi-content';
@@ -35,7 +35,7 @@ class AsyncSearchResults extends Component<Props, State> {
           <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
             <div className="grid">
               <div className={grid({ s: 12 })}>
-                <h2 className="h2" style={{ marginBottom: 0 }}>
+                <h2 className={font('wb', 3)} style={{ marginBottom: 0 }}>
                   {this.props.title}
                 </h2>
               </div>

--- a/content/webapp/components/SearchResults/SearchResults.tsx
+++ b/content/webapp/components/SearchResults/SearchResults.tsx
@@ -1,7 +1,7 @@
 import { Fragment, FunctionComponent } from 'react';
 import styled from 'styled-components';
 import { MultiContent } from '../../types/multi-content';
-import { grid } from '@weco/common/utils/classnames';
+import { font, grid } from '@weco/common/utils/classnames';
 import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImage';
 import CompactCard from '../CompactCard/CompactCard';
 import EventCard from '../EventCard/EventCard';
@@ -34,7 +34,7 @@ const SearchResults: FunctionComponent<Props> = ({
       >
         <div className="grid">
           <div className={grid({ s: 12 })}>
-            <h2 className="h2">{title}</h2>
+            <h2 className={font('wb', 3)}>{title}</h2>
           </div>
         </div>
       </Space>

--- a/content/webapp/components/SimpleCardGrid/SimpleCardGrid.tsx
+++ b/content/webapp/components/SimpleCardGrid/SimpleCardGrid.tsx
@@ -1,4 +1,4 @@
-import { cssGrid } from '@weco/common/utils/classnames';
+import { cssGrid, font } from '@weco/common/utils/classnames';
 import { Card as CardType } from '../../types/card';
 import Card from '../Card/Card';
 import Layout12 from '@weco/common/views/components/Layout12/Layout12';
@@ -55,9 +55,9 @@ const CardGridFeaturedCard = ({ item }: CardGridFeaturedCardProps) => {
         background="neutral.700"
         textColor="white"
       >
-        {item.title && <h2 className="font-wb font-size-2">{item.title}</h2>}
+        {item.title && <h2 className={font('wb', 2)}>{item.title}</h2>}
         {item.description && (
-          <p className="font-intr font-size-5">{item.description}</p>
+          <p className={font('intr', 5)}>{item.description}</p>
         )}
       </FeaturedCard>
     </Layout12>

--- a/content/webapp/components/VenueHours/VenueHours.tsx
+++ b/content/webapp/components/VenueHours/VenueHours.tsx
@@ -204,7 +204,7 @@ const VenueHours: FunctionComponent<Props> = ({ venue, weight }) => {
         <Space
           as="h2"
           h={{ size: 'm', properties: ['padding-right'] }}
-          className="h2"
+          className={font('wb', 3)}
         >
           {isFeatured ? venue.name : 'Opening hours'}
         </Space>

--- a/content/webapp/components/VisualStories/VisualStories.styles.tsx
+++ b/content/webapp/components/VisualStories/VisualStories.styles.tsx
@@ -1,7 +1,8 @@
 import styled from 'styled-components';
 import Space from '@weco/common/views/components/styled/Space';
+import { font } from '@weco/common/utils/classnames';
 
-export const PrototypeH1 = styled.h1.attrs({ className: 'h0' })``;
+export const PrototypeH1 = styled.h1.attrs({ className: font('wb', 1) })``;
 
 export const TwoUp = styled.div`
   display: grid;
@@ -52,7 +53,7 @@ export const InfoBlock = styled(Space).attrs<{ hasBorder?: boolean }>(
 
 export const PrototypeH2 = styled(Space).attrs<{ isFirst?: boolean }>({
   as: 'h2',
-  classNames: 'h2',
+  classNames: font('wb', 3),
   v: { size: 'l', properties: ['padding-top'] },
 })<{ isFirst?: boolean }>`
   border-top: 1px solid ${props => props.theme.color('neutral.400')};

--- a/content/webapp/components/VisualStories/VisualStories.v1.tsx
+++ b/content/webapp/components/VisualStories/VisualStories.v1.tsx
@@ -13,7 +13,7 @@ export const V1Prototype = () => {
   return (
     <>
       <Layout12>
-        <h1 className="h0">Wellcome Collection visual story</h1>
+        <h1 className={font('wb', 1)}>Wellcome Collection visual story</h1>
       </Layout12>
       <Layout gridSizes={{ s: 12, m: 10, l: 8, xl: 8 }}>
         <p style={{ marginBottom: '1rem' }}>

--- a/content/webapp/pages/event-series/[eventSeriesId].tsx
+++ b/content/webapp/pages/event-series/[eventSeriesId].tsx
@@ -30,6 +30,7 @@ import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 import { getUpcomingEvents } from '@weco/content/utils/event-series';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 import { setCacheControl } from '@weco/common/utils/setCacheControl';
+import { font } from '@weco/common/utils/classnames';
 
 type Props = {
   series: EventSeries;
@@ -159,7 +160,7 @@ const EventSeriesPage: FunctionComponent<Props> = ({
         {upcomingEvents.length > 0 ? (
           <SearchResults items={upcomingEvents} title="Coming up" />
         ) : (
-          <h2 className="h2">No upcoming events</h2>
+          <h2 className={font('wb', 3)}>No upcoming events</h2>
         )}
 
         {pastEvents.length > 0 && (

--- a/content/webapp/pages/guides/exhibitions/[id]/[type].tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/[type].tsx
@@ -34,6 +34,7 @@ import { getTypeColor } from '@weco/content/components/ExhibitionCaptions/Exhibi
 import useHotjar from '@weco/common/hooks/useHotjar';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 import { setCacheControl } from '@weco/common/utils/setCacheControl';
+import { font } from '@weco/common/utils/classnames';
 
 const ButtonWrapper = styled(Space).attrs({
   v: { size: 's', properties: ['margin-bottom'] },
@@ -209,9 +210,9 @@ const ExhibitionGuidePage: FunctionComponent<Props> = props => {
       <Header backgroundColor={typeColor}>
         <Layout8 shift={false}>
           <>
-            <h1 className="h0">
+            <h1 className={font('wb', 1)}>
               {exhibitionGuide.title}{' '}
-              <div className="h1">{getTypeTitle(type)}</div>
+              <div className={font('wb', 2)}>{getTypeTitle(type)}</div>
             </h1>
 
             {exhibitionGuide.introText?.length > 0 ? (

--- a/content/webapp/pages/visual-stories/index.tsx
+++ b/content/webapp/pages/visual-stories/index.tsx
@@ -2,6 +2,7 @@ import { getServerData } from '@weco/common/server-data';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import Space from '@weco/common/views/components/styled/Space';
 import { Container } from '@weco/common/views/components/styled/Container';
+import { font } from '@weco/common/utils/classnames';
 
 export const getServerSideProps = async context => {
   const serverData = await getServerData(context);
@@ -29,7 +30,7 @@ const VisualStory = () => {
     >
       <Space v={{ size: 'xl', properties: ['padding-bottom', 'padding-top'] }}>
         <Container>
-          <h1 className="h1">Visual Stories prototypes</h1>
+          <h1 className={font('wb', 2)}>Visual Stories prototypes</h1>
           <ul>
             <li>
               <a href="/visual-stories/v1">Version 1</a>

--- a/content/webapp/pages/whats-on/index.tsx
+++ b/content/webapp/pages/whats-on/index.tsx
@@ -559,7 +559,7 @@ const WhatsOnPage: FunctionComponent<Props> = props => {
                       justifyContent: 'space-between',
                     }}
                   >
-                    <h2 className="h1">Exhibitions and Events</h2>
+                    <h2 className={font('wb', 2)}>Exhibitions and Events</h2>
                     <span className={font('intb', 4)}>Free admission</span>
                   </div>
                 </Layout12>

--- a/identity/webapp/src/frontend/MyAccount/MyAccount.style.ts
+++ b/identity/webapp/src/frontend/MyAccount/MyAccount.style.ts
@@ -1,5 +1,6 @@
 import styled, { css } from 'styled-components';
 import Space from '@weco/common/views/components/styled/Space';
+import { font } from '@weco/common/utils/classnames';
 
 export const ProgressBar = styled(Space).attrs({
   v: { size: 'm', properties: ['margin-bottom'] },
@@ -59,7 +60,7 @@ export const ItemPickup = styled.span`
 export const ModalTitle = styled(Space).attrs({
   as: 'h2',
   h: { size: 'l', properties: ['margin-bottom'] },
-  className: 'h2',
+  className: font('wb', 3),
 })``;
 
 const colours = {


### PR DESCRIPTION
## Who is this for?
FE devs, maintenance

## What is it doing for them?
Relates to #10022 , following prior tries of  #10077, we went for removing `.h[number]` classes in favour of the `font()` function. We might get back to utility classes, but will be naming them differently/document their usage after a design review. In the meantime, we're trying to stick to a minimum of styling methods.

In this PR I've removed the classes and replaced them where they were used [with their equivalents](https://github.com/wellcomecollection/wellcomecollection.org/pull/10077#issuecomment-1660137415). I've also found a few long forms (`className="font-wb font-size-5`) that I've also replaced with `font()`. 

There are a few standalone `className="font-wb"` and `className="font-size-3"` left in the codebase, but I assumed there was a reason for not using `font()`, having to redeclare the font-family or size could be an issue.

Chromatic flagged no changes.

Closes #10077 