### PR TITLE
removed "For..." audience section from bottom of page layout

### DIFF
--- a/content/webapp/pages/events/[eventId].tsx
+++ b/content/webapp/pages/events/[eventId].tsx
@@ -437,14 +437,6 @@ const EventPage: NextPage<EventProps> = ({ event, jsonLd }) => {
             titlePrefix="About your"
           />
         )}
-        {event.audiences.map(audience =>
-          audience.description ? (
-            <div className="body-text" key={audience.title}>
-              <h2>For {audience.title}</h2>
-              <PrismicHtmlBlock html={audience.description} />
-            </div>
-          ) : null
-        )}
       </ContentPage>
     </PageLayout>
   );


### PR DESCRIPTION
## Who is this for?
Requested via #10040 

Clarified on [Slack](https://wellcome.slack.com/archives/C3N7J05TK/p1691496054206989). 

## What is it doing for them?
Removes the "For..." audience age guidance that derives from a description line related to an Audience label in Prismic. The line only exists on 16+, 18+, and 14-19 labelled events. Removing this retains the label but will no longer display at the bottom of the page layout. 

Age guidance is already made clear in the content body of the event. 


Current state
![Screenshot 2023-08-09 at 11 42 49](https://github.com/wellcomecollection/wellcomecollection.org/assets/81175151/8017fb4c-562f-4162-8a57-c4d4cbad73e8)

New state
![Screenshot 2023-08-09 at 11 43 06](https://github.com/wellcomecollection/wellcomecollection.org/assets/81175151/77a3b222-e53f-4809-8340-193f48c15cb8)
