### PR TITLE
No js multi volume

### DIFF
--- a/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
@@ -213,6 +213,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
   handleImageError,
   searchResults,
   setSearchResults,
+  parentManifest,
 }: IIIFViewerProps) => {
   const router = useRouter();
   const {
@@ -223,7 +224,6 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
     query = '',
   } = fromQuery(router.query);
   const [gridVisible, setGridVisible] = useState(false);
-  const [parentManifest, setParentManifest] = useState<Manifest | undefined>();
   const { isFullSupportBrowser } = useContext(AppContext);
   const viewerRef = useRef<HTMLDivElement>(null);
   const mainAreaRef = useRef<HTMLDivElement>(null);
@@ -244,7 +244,6 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
   const imageUrl = urlTemplate && urlTemplate({ size: '800,' });
   const hasIiifImage = imageUrl && iiifImageLocation;
   const hasImageService = Boolean(mainImageService['@id'] && currentCanvas);
-  const { parentManifestUrl } = { ...transformedManifest };
   const [showControls, setShowControls] = useState(
     Boolean(hasIiifImage && !hasImageService)
   );
@@ -280,18 +279,6 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
   useEffect(() => {
     handleResize();
   }, [isDesktopSidebarActive]);
-
-  useEffect(() => {
-    const fetchParentManifest = async () => {
-      const parentManifest =
-        transformedManifest?.parentManifestUrl &&
-        (await fetchJson(parentManifestUrl as string));
-
-      parentManifest && setParentManifest(parentManifest);
-    };
-
-    fetchParentManifest();
-  }, []);
 
   return (
     <ItemViewerContext.Provider

--- a/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
+++ b/catalogue/webapp/components/IIIFViewer/IIIFViewer.tsx
@@ -24,7 +24,6 @@ import ImageViewer from './ImageViewer';
 import ImageViewerControls from './ImageViewerControls';
 import ViewerBottomBar from './ViewerBottomBar';
 import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
-import { fetchJson } from '@weco/common/utils/http';
 import { TransformedManifest } from '@weco/catalogue/types/manifest';
 import { fromQuery } from '@weco/catalogue/components/ItemLink';
 import { SearchResults } from '@weco/catalogue/services/iiif/types/search/v3';
@@ -40,6 +39,7 @@ type IIIFViewerProps = {
   handleImageError?: () => void;
   searchResults: SearchResults | null;
   setSearchResults: (v) => void;
+  parentManifest?: Manifest;
 };
 
 const LoadingComponent = () => (

--- a/catalogue/webapp/components/IIIFViewer/MultipleManifestList.tsx
+++ b/catalogue/webapp/components/IIIFViewer/MultipleManifestList.tsx
@@ -13,12 +13,13 @@ import {
   Item,
 } from '@weco/catalogue/components/IIIFViewer/ViewerStructures';
 
-const MultipleManifestListPrototype: FunctionComponent = () => {
+const MultipleManifestList: FunctionComponent = () => {
   const { parentManifest, work, query, setIsMobileSidebarActive } =
     useContext(ItemViewerContext);
   const manifests = parentManifest
     ? getCollectionManifests(parentManifest)
     : [];
+
   return (
     <nav>
       <List aria-label={volumesNavigationLabel}>
@@ -64,4 +65,4 @@ const MultipleManifestListPrototype: FunctionComponent = () => {
   );
 };
 
-export default MultipleManifestListPrototype;
+export default MultipleManifestList;

--- a/catalogue/webapp/components/IIIFViewer/Paginators.tsx
+++ b/catalogue/webapp/components/IIIFViewer/Paginators.tsx
@@ -95,6 +95,7 @@ export const CanvasPaginator = () => {
     props: {
       canvas: query.canvas,
       page: query.page,
+      manifest: query.manifest,
       query: query.query,
     },
     source: 'viewer/paginator',
@@ -170,6 +171,7 @@ export const ThumbnailsPaginator = () => {
     props: {
       canvas: query.canvas,
       page: query.page,
+      manifest: query.manifest,
       query: query.query,
     },
     source: 'viewer/paginator',

--- a/catalogue/webapp/components/IIIFViewer/Thumbnails.tsx
+++ b/catalogue/webapp/components/IIIFViewer/Thumbnails.tsx
@@ -53,6 +53,7 @@ export const Thumbnails = () => {
                 props: {
                   canvas: canvasParam,
                   page: query.page,
+                  manifest: query.manifest,
                   query: query.query,
                 },
                 source: 'viewer/paginator',

--- a/catalogue/webapp/components/IIIFViewer/ViewerSidebar.tsx
+++ b/catalogue/webapp/components/IIIFViewer/ViewerSidebar.tsx
@@ -136,9 +136,17 @@ const ViewerSidebar: FunctionComponent<ViewerSidebarProps> = ({
 }) => {
   const { work, transformedManifest, parentManifest } =
     useContext(ItemViewerContext);
-  const [currentManifestLabel, setCurrentManifestLabel] = useState<
-    string | undefined
-  >();
+
+  const matchingManifest = parentManifest && getCollectionManifests(parentManifest).find(canvas => {
+    return !transformedManifest
+      ? false
+      : canvas.id === transformedManifest.id;
+  });
+
+  const manifestLabel =
+  matchingManifest?.label &&
+    getMultiVolumeLabel(matchingManifest.label, work?.title || '');
+
   const { iiifCredit, structures, searchService } = { ...transformedManifest };
 
   const digitalLocation: DigitalLocation | undefined =
@@ -150,28 +158,12 @@ const ViewerSidebar: FunctionComponent<ViewerSidebarProps> = ({
 
   const credit = (digitalLocation && digitalLocation.credit) || iiifCredit;
 
-  useEffect(() => {
-    const manifests = parentManifest
-      ? getCollectionManifests(parentManifest)
-      : [];
-    const matchingManifest = manifests.find(canvas => {
-      return !transformedManifest
-        ? false
-        : canvas.id === transformedManifest.id;
-    });
-
-    const manifestLabel =
-      matchingManifest?.label &&
-      getMultiVolumeLabel(matchingManifest.label, work?.title || '');
-    manifestLabel && setCurrentManifestLabel(manifestLabel);
-  }, [transformedManifest, parentManifest]);
-
   return (
     <>
       <Inner className={font('intb', 5)}>
-        {currentManifestLabel && (
+        {manifestLabel && (
           <span data-test-id="current-manifest" className={font('intr', 5)}>
-            {currentManifestLabel}
+            {manifestLabel}
           </span>
         )}
         <h1>

--- a/catalogue/webapp/pages/works/[workId]/items.tsx
+++ b/catalogue/webapp/pages/works/[workId]/items.tsx
@@ -105,7 +105,7 @@ type Props = {
   apiToolbarLinks: ApiToolbarLink[];
   pageview: Pageview;
   serverSearchResults: SearchResults | null;
-  parentManifest: Manifest | undefined;
+  parentManifest?: Manifest;
 };
 
 const ItemPage: NextPage<Props> = ({

--- a/catalogue/webapp/pages/works/[workId]/items.tsx
+++ b/catalogue/webapp/pages/works/[workId]/items.tsx
@@ -9,6 +9,7 @@ import {
   WorkBasic,
   toWorkBasic,
 } from '@weco/catalogue/services/wellcome/catalogue/types';
+import { Manifest } from '@iiif/presentation-3';
 import { getDigitalLocationOfType } from '@weco/catalogue/utils/works';
 import { removeIdiomaticTextTags } from '@weco/common/utils/string';
 import { getWork } from '@weco/catalogue/services/wellcome/catalogue/works';
@@ -56,6 +57,7 @@ import {
   toCompressedTransformedManifest,
 } from '@weco/catalogue/types/compressed-manifest';
 import { SearchResults } from '@weco/catalogue/services/iiif/types/search/v3';
+import { fetchJson } from '@weco/common/utils/http';
 
 const IframeAuthMessage = styled.iframe`
   display: none;
@@ -103,6 +105,7 @@ type Props = {
   apiToolbarLinks: ApiToolbarLink[];
   pageview: Pageview;
   serverSearchResults: SearchResults | null;
+  parentManifest: Manifest | undefined;
 };
 
 const ItemPage: NextPage<Props> = ({
@@ -114,6 +117,7 @@ const ItemPage: NextPage<Props> = ({
   apiToolbarLinks,
   canvas,
   serverSearchResults,
+  parentManifest,
 }) => {
   const transformedManifest =
     compressedTransformedManifest &&
@@ -350,10 +354,20 @@ const ItemPage: NextPage<Props> = ({
             }}
             searchResults={searchResults}
             setSearchResults={setSearchResults}
+            parentManifest={parentManifest}
           />
         )}
     </CataloguePageLayout>
   );
+};
+
+async function getParentManifest(parentManifestUrl) {
+  try {
+    return parentManifestUrl &&
+        (await fetchJson(parentManifestUrl as string));
+    } catch (error) {
+      return undefined;
+    }
 };
 
 export const getServerSideProps: GetServerSideProps<
@@ -442,7 +456,10 @@ export const getServerSideProps: GetServerSideProps<
       queryParamToArrayIndex(manifest)
     );
 
-    const { canvases } = displayManifest;
+    const { canvases, parentManifestUrl } = displayManifest;
+
+    const parentManifest = await getParentManifest(parentManifestUrl);
+
     const currentCanvas = canvases[queryParamToArrayIndex(canvas)];
     const canvasOcrText = await fetchCanvasOcr(currentCanvas);
     const canvasOcr = transformCanvasOcr(canvasOcrText);
@@ -478,6 +495,7 @@ export const getServerSideProps: GetServerSideProps<
         pageview,
         serverData,
         serverSearchResults,
+        parentManifest,
       }),
     };
   }


### PR DESCRIPTION
For #9966

If a volume has a parent manifest we now fetch it server side so the non javascript version of the item page can display links to the other volumes and the label of the current volume:

![multi](https://github.com/wellcomecollection/wellcomecollection.org/assets/6051896/e0d3abdd-1f72-44c4-a00f-cd94cd5b479f)
