### PR TITLE
removed outro from prismic-model

### DIFF
--- a/prismic-model/src/articles.ts
+++ b/prismic-model/src/articles.ts
@@ -19,20 +19,6 @@ const articles: CustomType = {
       format: documentLink('Format', { linkedType: 'article-formats' }),
       body: articleBody,
     },
-    Outro: {
-      outroResearchItem: link('Outro: Research item'),
-      outroResearchLinkText: singleLineText('Outro: Research link text', {
-        overrideTextOptions: ['paragraph'],
-      }),
-      outroReadItem: link('Outro: Read item'),
-      outroReadLinkText: singleLineText('Outro: Read link text', {
-        overrideTextOptions: ['paragraph'],
-      }),
-      outroVisitItem: link('Outro: Visit item'),
-      outroVisitLinkText: singleLineText('Outro: Visit link text', {
-        overrideTextOptions: ['paragraph'],
-      }),
-    },
     Contributors: contributorsWithTitle(),
     Promo: {
       promo,


### PR DESCRIPTION
## Who is this for?
Editorial team - articles and stories

Part of #10037 

## What is it doing for them?
Removes the outro from articles where present. Stops older articles containing out of date / broken links. Removes outro from the prismic-model