### PR TITLE
Remove resources from exhibitions

### DIFF
--- a/content/webapp/components/Exhibition/Exhibition.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.tsx
@@ -124,15 +124,6 @@ const resourceIcons: { [key: string]: IconSvg } = {
   family,
 };
 
-function getResourcesItems(exhibition: ExhibitionType): ExhibitionItem[] {
-  return exhibition.resources.map(resource => {
-    return {
-      description: resource.description,
-      icon: resource.icon ? resourceIcons[resource.icon] : undefined,
-    };
-  });
-}
-
 function getBslAdItems(exhibition: ExhibitionType): ExhibitionItem[] {
   return [exhibition.bslInfo, exhibition.audioDescriptionInfo]
     .filter(Boolean)
@@ -176,7 +167,6 @@ export function getInfoItems(exhibition: ExhibitionType): ExhibitionItem[] {
     getadmissionObject(),
     getTodaysHoursObject(),
     getPlaceObject(exhibition),
-    ...getResourcesItems(exhibition),
     ...getAccessibilityItems(),
     ...getBslAdItems(exhibition),
   ].filter(isNotUndefined);

--- a/content/webapp/services/prismic/transformers/exhibitions.ts
+++ b/content/webapp/services/prismic/transformers/exhibitions.ts
@@ -35,33 +35,6 @@ import * as prismic from '@prismicio/client';
 import { noAltTextBecausePromo } from './images';
 import { transformTimestamp } from '@weco/common/services/prismic/transformers';
 
-// TODO: Use better types than Record<string, any>.
-//
-// This was lifted directly from a JavaScript implementation when we converted the
-// codebase to TypeScript (previously it was `Object`), but I can't find any exhibition
-// pages where we actually define/use any resources (or at least not any picked up by
-// the previous implementation), so I couldn't test it.
-function transformResourceTypeList(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  fragment: Record<string, any>[],
-  labelKey: string
-): Resource[] {
-  return fragment
-    .map(label => label[labelKey])
-    .filter(label => label && label.isBroken === false)
-    .map(label => transformResourceType(label.data));
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function transformResourceType(fragment: Record<string, any>): Resource {
-  return {
-    id: fragment.id,
-    title: asText(fragment.title),
-    description: fragment.description,
-    icon: fragment.icon,
-  };
-}
-
 function transformExhibitionFormat(
   format: ExhibitionFormatPrismicDocument
 ): ExhibitionFormat {
@@ -136,9 +109,6 @@ export function transformExhibition(
     place,
     exhibits,
     contributors,
-    resources: Array.isArray(data.resources)
-      ? transformResourceTypeList(data.resources, 'resource')
-      : [],
     relatedIds,
     seasons,
   };

--- a/content/webapp/types/exhibitions.ts
+++ b/content/webapp/types/exhibitions.ts
@@ -49,7 +49,6 @@ export type Exhibition = GenericContentFields & {
   audioDescriptionInfo?: prismic.RichTextField;
   place?: Place;
   exhibits: Exhibit[];
-  resources: Resource[];
   relatedIds: string[];
   seasons: Season[];
   contributors: Contributor[];


### PR DESCRIPTION
Relates to #10041

This is a bit of tidy up, before adding new fields for rendering the resource links we now want.

It stops us rendering anything that is added to the current field under the resource tab:

<img width="1026" alt="Screenshot 2023-08-09 at 16 26 01" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/6051896/40d98982-ee12-4912-8a33-c16a2e7bdf54">

This is not being used anywhere. I'll remove this field in another PR.
