### PR TITLE
Render image in exhibition contentList compact cards

### DIFF
--- a/content/webapp/components/SearchResults/SearchResults.tsx
+++ b/content/webapp/components/SearchResults/SearchResults.tsx
@@ -203,7 +203,7 @@ const SearchResults: FunctionComponent<Props> = ({
                 secondaryLabels={[]}
                 description={item.promo?.caption}
                 Image={
-                  getCrop(item.promo?.image, 'square') && (
+                  getCrop(item.image, 'square') && (
                     <PrismicImage
                       image={{
                         // We intentionally omit the alt text on promos, so screen reader
@@ -211,7 +211,7 @@ const SearchResults: FunctionComponent<Props> = ({
                         // title of the item in the list.
                         //
                         // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
-                        ...getCrop(item.promo?.image, 'square')!,
+                        ...getCrop(item.image, 'square')!,
                         alt: '',
                       }}
                       sizes={{

--- a/content/webapp/types/exhibitions.ts
+++ b/content/webapp/types/exhibitions.ts
@@ -8,6 +8,7 @@ import { GenericContentFields } from './generic-content-fields';
 import { Resource } from './resource';
 import { Season } from './seasons';
 import { ImagePromo } from './image-promo';
+import { ImageType } from '@weco/common/model/image';
 import { Label } from '@weco/common/model/labels';
 import * as prismic from '@prismicio/client';
 
@@ -25,6 +26,7 @@ export type ExhibitionBasic = {
   id: string;
   title: string;
   promo?: ImagePromo;
+  image?: ImageType;
   format?: ExhibitionFormat;
   start: Date;
   end?: Date;


### PR DESCRIPTION
Part of #9849

Making sure an image associated with an exhibition in a content list slice will render.

__Before__
<img width="902" alt="image" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/1394592/67a1e1a0-1b09-4592-a640-b89635e781ed">


__After__
<img width="1027" alt="image" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/1394592/c93f7498-bbee-4f8c-b925-830ff12f0821">
