### PR TITLE
Allow card as a contentList type for events and event-series

### DIFF
--- a/content/webapp/components/SearchResults/SearchResults.tsx
+++ b/content/webapp/components/SearchResults/SearchResults.tsx
@@ -43,193 +43,218 @@ const SearchResults: FunctionComponent<Props> = ({
       <Space v={{ size: 'l', properties: ['margin-bottom'] }}>{summary}</Space>
     )}
 
-    {items.map(
-      (item, index) =>
-        item.type !== 'card' && (
-          <Result
-            key={item.id}
-            data-testid={index === 0 ? 'search-result' : undefined}
-          >
-            {item.type === 'pages' && (
-              <CompactCard
-                url={`/pages/${item.id}`}
-                title={item.title || ''}
-                primaryLabels={[]}
-                secondaryLabels={[]}
-                description={item.promo?.caption || item.metadataDescription}
-                urlOverride={item.promo && item.promo.link}
-                Image={
-                  getCrop(item.image, 'square') && (
-                    <PrismicImage
-                      image={{
-                        // We intentionally omit the alt text on promos, so screen reader
-                        // users don't have to listen to the alt text before hearing the
-                        // title of the item in the list.
-                        //
-                        // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
-                        ...getCrop(item.image, 'square')!,
-                        alt: '',
-                      }}
-                      sizes={{
-                        xlarge: 1 / 6,
-                        large: 1 / 6,
-                        medium: 1 / 5,
-                        small: 1 / 4,
-                      }}
-                      quality="low"
-                    />
-                  )
-                }
-                xOfY={{ x: index + 1, y: items.length }}
-              />
-            )}
-            {item.type === 'event-series' && (
-              <CompactCard
-                url={`/event-series/${item.id}`}
-                title={item.title}
-                primaryLabels={item.labels}
-                secondaryLabels={[]}
-                description={item.promo && item.promo.caption}
-                urlOverride={item.promo && item.promo.link}
-                Image={
-                  getCrop(item.image, 'square') && (
-                    <PrismicImage
-                      image={{
-                        // We intentionally omit the alt text on promos, so screen reader
-                        // users don't have to listen to the alt text before hearing the
-                        // title of the item in the list.
-                        //
-                        // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
-                        ...getCrop(item.image, 'square')!,
-                        alt: '',
-                      }}
-                      sizes={{
-                        xlarge: 1 / 6,
-                        large: 1 / 6,
-                        medium: 1 / 5,
-                        small: 1 / 4,
-                      }}
-                      quality="low"
-                    />
-                  )
-                }
-                xOfY={{ x: index + 1, y: items.length }}
-              />
-            )}
-            {item.type === 'books' && (
-              <CompactCard
-                url={`/books/${item.id}`}
-                title={item.title}
-                primaryLabels={item.labels}
-                secondaryLabels={[]}
-                description={item.promo && item.promo.caption}
-                urlOverride={item.promo && item.promo.link}
-                Image={
-                  getCrop(item.cover, 'square') && (
-                    <PrismicImage
-                      image={{
-                        // We intentionally omit the alt text on promos, so screen reader
-                        // users don't have to listen to the alt text before hearing the
-                        // title of the item in the list.
-                        //
-                        // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
-                        ...getCrop(item.cover, 'square')!,
-                        alt: '',
-                      }}
-                      sizes={{
-                        xlarge: 1 / 6,
-                        large: 1 / 6,
-                        medium: 1 / 5,
-                        small: 1 / 4,
-                      }}
-                      quality="low"
-                    />
-                  )
-                }
-                xOfY={{ x: index + 1, y: items.length }}
-              />
-            )}
-            {item.type === 'articles' && (
-              <ArticleCard
-                article={item}
-                showPosition={showPosition}
-                xOfY={{ x: index + 1, y: items.length }}
-              />
-            )}
-            {item.type === 'series' && (
-              <CompactCard
-                url={`/series/${item.id}`}
-                title={item.title || ''}
-                primaryLabels={item.labels}
-                secondaryLabels={[]}
-                description={item.promo && item.promo.caption}
-                urlOverride={item.promo && item.promo.link}
-                Image={
-                  getCrop(item.image, 'square') && (
-                    <PrismicImage
-                      image={{
-                        // We intentionally omit the alt text on promos, so screen reader
-                        // users don't have to listen to the alt text before hearing the
-                        // title of the item in the list.
-                        //
-                        // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
-                        ...getCrop(item.image, 'square')!,
-                        alt: '',
-                      }}
-                      sizes={{
-                        xlarge: 1 / 6,
-                        large: 1 / 6,
-                        medium: 1 / 5,
-                        small: 1 / 4,
-                      }}
-                      quality="low"
-                    />
-                  )
-                }
-                xOfY={{ x: index + 1, y: items.length }}
-              />
-            )}
-            {item.type === 'events' && (
-              <EventCard
-                event={item}
-                xOfY={{ x: index + 1, y: items.length }}
-              />
-            )}
-            {item.type === 'exhibitions' && (
-              <CompactCard
-                url={`/exhibitions/${item.id}`}
-                title={item.title}
-                primaryLabels={item.labels}
-                secondaryLabels={[]}
-                description={item.promo?.caption}
-                Image={
-                  getCrop(item.image, 'square') && (
-                    <PrismicImage
-                      image={{
-                        // We intentionally omit the alt text on promos, so screen reader
-                        // users don't have to listen to the alt text before hearing the
-                        // title of the item in the list.
-                        //
-                        // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
-                        ...getCrop(item.image, 'square')!,
-                        alt: '',
-                      }}
-                      sizes={{
-                        xlarge: 1 / 6,
-                        large: 1 / 6,
-                        medium: 1 / 5,
-                        small: 1 / 4,
-                      }}
-                      quality="low"
-                    />
-                  )
-                }
-                xOfY={{ x: index + 1, y: items.length }}
-              />
-            )}
-          </Result>
-        )
-    )}
+    {items.map((item, index) => (
+      <Result
+        key={item.id}
+        data-testid={index === 0 ? 'search-result' : undefined}
+      >
+        {item.type === 'card' && (
+          <CompactCard
+            url={item.link}
+            title={item.title || ''}
+            primaryLabels={[]}
+            secondaryLabels={[]}
+            description={item.description || ''}
+            Image={
+              getCrop(item.image, 'square') && (
+                <PrismicImage
+                  image={{
+                    // We intentionally omit the alt text on promos, so screen reader
+                    // users don't have to listen to the alt text before hearing the
+                    // title of the item in the list.
+                    //
+                    // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
+                    ...getCrop(item.image, 'square')!,
+                    alt: '',
+                  }}
+                  sizes={{
+                    xlarge: 1 / 6,
+                    large: 1 / 6,
+                    medium: 1 / 5,
+                    small: 1 / 4,
+                  }}
+                  quality="low"
+                />
+              )
+            }
+          />
+        )}
+        {item.type === 'pages' && (
+          <CompactCard
+            url={`/pages/${item.id}`}
+            title={item.title || ''}
+            primaryLabels={[]}
+            secondaryLabels={[]}
+            description={item.promo?.caption || item.metadataDescription}
+            urlOverride={item.promo && item.promo.link}
+            Image={
+              getCrop(item.image, 'square') && (
+                <PrismicImage
+                  image={{
+                    // We intentionally omit the alt text on promos, so screen reader
+                    // users don't have to listen to the alt text before hearing the
+                    // title of the item in the list.
+                    //
+                    // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
+                    ...getCrop(item.image, 'square')!,
+                    alt: '',
+                  }}
+                  sizes={{
+                    xlarge: 1 / 6,
+                    large: 1 / 6,
+                    medium: 1 / 5,
+                    small: 1 / 4,
+                  }}
+                  quality="low"
+                />
+              )
+            }
+            xOfY={{ x: index + 1, y: items.length }}
+          />
+        )}
+        {item.type === 'event-series' && (
+          <CompactCard
+            url={`/event-series/${item.id}`}
+            title={item.title}
+            primaryLabels={item.labels}
+            secondaryLabels={[]}
+            description={item.promo && item.promo.caption}
+            urlOverride={item.promo && item.promo.link}
+            Image={
+              getCrop(item.image, 'square') && (
+                <PrismicImage
+                  image={{
+                    // We intentionally omit the alt text on promos, so screen reader
+                    // users don't have to listen to the alt text before hearing the
+                    // title of the item in the list.
+                    //
+                    // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
+                    ...getCrop(item.image, 'square')!,
+                    alt: '',
+                  }}
+                  sizes={{
+                    xlarge: 1 / 6,
+                    large: 1 / 6,
+                    medium: 1 / 5,
+                    small: 1 / 4,
+                  }}
+                  quality="low"
+                />
+              )
+            }
+            xOfY={{ x: index + 1, y: items.length }}
+          />
+        )}
+        {item.type === 'books' && (
+          <CompactCard
+            url={`/books/${item.id}`}
+            title={item.title}
+            primaryLabels={item.labels}
+            secondaryLabels={[]}
+            description={item.promo && item.promo.caption}
+            urlOverride={item.promo && item.promo.link}
+            Image={
+              getCrop(item.cover, 'square') && (
+                <PrismicImage
+                  image={{
+                    // We intentionally omit the alt text on promos, so screen reader
+                    // users don't have to listen to the alt text before hearing the
+                    // title of the item in the list.
+                    //
+                    // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
+                    ...getCrop(item.cover, 'square')!,
+                    alt: '',
+                  }}
+                  sizes={{
+                    xlarge: 1 / 6,
+                    large: 1 / 6,
+                    medium: 1 / 5,
+                    small: 1 / 4,
+                  }}
+                  quality="low"
+                />
+              )
+            }
+            xOfY={{ x: index + 1, y: items.length }}
+          />
+        )}
+        {item.type === 'articles' && (
+          <ArticleCard
+            article={item}
+            showPosition={showPosition}
+            xOfY={{ x: index + 1, y: items.length }}
+          />
+        )}
+        {item.type === 'series' && (
+          <CompactCard
+            url={`/series/${item.id}`}
+            title={item.title || ''}
+            primaryLabels={item.labels}
+            secondaryLabels={[]}
+            description={item.promo && item.promo.caption}
+            urlOverride={item.promo && item.promo.link}
+            Image={
+              getCrop(item.image, 'square') && (
+                <PrismicImage
+                  image={{
+                    // We intentionally omit the alt text on promos, so screen reader
+                    // users don't have to listen to the alt text before hearing the
+                    // title of the item in the list.
+                    //
+                    // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
+                    ...getCrop(item.image, 'square')!,
+                    alt: '',
+                  }}
+                  sizes={{
+                    xlarge: 1 / 6,
+                    large: 1 / 6,
+                    medium: 1 / 5,
+                    small: 1 / 4,
+                  }}
+                  quality="low"
+                />
+              )
+            }
+            xOfY={{ x: index + 1, y: items.length }}
+          />
+        )}
+        {item.type === 'events' && (
+          <EventCard event={item} xOfY={{ x: index + 1, y: items.length }} />
+        )}
+        {item.type === 'exhibitions' && (
+          <CompactCard
+            url={`/exhibitions/${item.id}`}
+            title={item.title}
+            primaryLabels={item.labels}
+            secondaryLabels={[]}
+            description={item.promo?.caption}
+            Image={
+              getCrop(item.image, 'square') && (
+                <PrismicImage
+                  image={{
+                    // We intentionally omit the alt text on promos, so screen reader
+                    // users don't have to listen to the alt text before hearing the
+                    // title of the item in the list.
+                    //
+                    // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
+                    ...getCrop(item.image, 'square')!,
+                    alt: '',
+                  }}
+                  sizes={{
+                    xlarge: 1 / 6,
+                    large: 1 / 6,
+                    medium: 1 / 5,
+                    small: 1 / 4,
+                  }}
+                  quality="low"
+                />
+              )
+            }
+            xOfY={{ x: index + 1, y: items.length }}
+          />
+        )}
+      </Result>
+    ))}
   </Fragment>
 );
 

--- a/content/webapp/services/prismic/fetch/event-series.ts
+++ b/content/webapp/services/prismic/fetch/event-series.ts
@@ -1,8 +1,13 @@
 import { fetcher } from '.';
 import { commonPrismicFieldsFetchLinks, contributorFetchLinks } from '../types';
 import { EventSeriesPrismicDocument } from '../types/event-series';
+import { cardFetchLinks } from '../types/card';
 
-const fetchLinks = [...commonPrismicFieldsFetchLinks, ...contributorFetchLinks];
+const fetchLinks = [
+  ...commonPrismicFieldsFetchLinks,
+  ...contributorFetchLinks,
+  ...cardFetchLinks,
+];
 
 const eventSeriesFetcher = fetcher<EventSeriesPrismicDocument>(
   'event-series',

--- a/content/webapp/services/prismic/fetch/events.ts
+++ b/content/webapp/services/prismic/fetch/events.ts
@@ -18,6 +18,7 @@ import {
   exhibitionsFetchLinks,
   seasonsFetchLinks,
 } from '../types';
+import { cardFetchLinks } from '../types/card';
 import { placesFetchLinks } from '../types/places';
 import { backgroundTexturesFetchLink } from '../types/background-textures';
 
@@ -35,6 +36,7 @@ const fetchLinks = [
   ...backgroundTexturesFetchLink,
   ...seasonsFetchLinks,
   ...eventsFetchLinks,
+  ...cardFetchLinks,
 ];
 
 const eventsFetcher = fetcher<EventPrismicDocument>('events', fetchLinks);

--- a/content/webapp/services/prismic/transformers/card.ts
+++ b/content/webapp/services/prismic/transformers/card.ts
@@ -3,14 +3,13 @@ import { transformImage } from '@weco/common/services/prismic/transformers/image
 import { Card } from '../../../types/card';
 import { asText, asTitle, transformFormat } from '.';
 import { transformLink } from '@weco/common/services/prismic/transformers';
-import { isFilledLinkToDocument } from '@weco/common/services/prismic/types';
 
 export function transformCard(document: CardPrismicDocument): Card {
   const { title, description, image, link } = document.data;
 
   return {
     type: 'card',
-    id: isFilledLinkToDocument(link) ? link.id : undefined,
+    id: document.id,
     title: asTitle(title),
     format: transformFormat(document),
     description: asText(description),

--- a/content/webapp/services/prismic/transformers/multi-content.ts
+++ b/content/webapp/services/prismic/transformers/multi-content.ts
@@ -11,6 +11,7 @@ import { transformEventBasic } from './events';
 import { transformExhibition } from './exhibitions';
 import { transformPage } from './pages';
 import { MultiContent } from '../../../types/multi-content';
+import { transformCard } from './card';
 
 // TODO:
 // * free text search
@@ -75,5 +76,7 @@ export const transformMultiContent = (
       return transformExhibition(document);
     case 'series':
       return transformSeries(document);
+    case 'card':
+      return transformCard(document);
   }
 };

--- a/content/webapp/services/prismic/types/multi-content.ts
+++ b/content/webapp/services/prismic/types/multi-content.ts
@@ -5,6 +5,7 @@ import { EventPrismicDocument } from '../types/events';
 import { ArticlePrismicDocument } from '../types/articles';
 import { ExhibitionPrismicDocument } from '../types/exhibitions';
 import { SeriesPrismicDocument } from '../types/series';
+import { CardPrismicDocument } from '../types/card';
 
 export type StructuredSearchQuery = {
   types: string[];
@@ -26,4 +27,5 @@ export type MultiContentPrismicDocument =
   | EventPrismicDocument
   | ArticlePrismicDocument
   | ExhibitionPrismicDocument
-  | SeriesPrismicDocument;
+  | SeriesPrismicDocument
+  | CardPrismicDocument;

--- a/content/webapp/types/multi-content.ts
+++ b/content/webapp/types/multi-content.ts
@@ -10,6 +10,7 @@ import { Weblink } from './weblinks';
 import { Project } from './projects';
 import { Season } from './seasons';
 import { ExhibitionGuide, ExhibitionGuideBasic } from './exhibition-guides';
+import { Card } from './card';
 
 export type MultiContent =
   | Page
@@ -25,4 +26,5 @@ export type MultiContent =
   | Project
   | Season
   | ExhibitionGuide
-  | ExhibitionGuideBasic;
+  | ExhibitionGuideBasic
+  | Card;


### PR DESCRIPTION
☝️ 

part of #9849 

Context: we noticed the content team were trying to make things that looked like Compact Cards by using the (now defunct) Media Object List in Prismic. I thought they should already have been able to do this by using a `Card` type and linking to it from within a `content list` in the `body` slice. But we were only getting `cardFetchLinks` inside `pages` and not `events` or `event-series`.

__Before__
<img width="666" alt="image" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/1394592/a81ac131-8e58-4415-882b-9f26d6dc87ad">


__After__
<img width="668" alt="image" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/1394592/803328a1-69f2-4795-aabd-d76ad3e92a3e">
