### PR TITLE
WIP: Newsletter signups: Redesign and Marketing permission checkbox

### DIFF
--- a/common/views/components/CheckboxRadio/CheckboxRadio.tsx
+++ b/common/views/components/CheckboxRadio/CheckboxRadio.tsx
@@ -11,20 +11,20 @@ import { check, indicator } from '@weco/common/icons';
 
 const CheckboxRadioLabel = styled.label`
   display: inline-flex;
-  align-items: center;
+  align-items: flex-start;
   cursor: pointer;
 `;
 
-const CheckboxRadioBoxSpan = styled.span<{ type: string }>``;
-const CheckboxRadioBox = styled(CheckboxRadioBoxSpan)`
+const CheckboxRadioBox = styled.span<{ type: string }>`
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  cursor: pointer;
 
   position: relative;
   width: 1.3em;
   height: 1.3em;
-  border: 2px solid ${props => props.theme.color('warmNeutral.400')};
+  border: 1px solid ${props => props.theme.color('black')};
   border-radius: ${props => (props.type === 'radio' ? '50%' : '0')};
 
   .icon {
@@ -43,17 +43,16 @@ const CheckboxRadioInput = styled.input.attrs(props => ({
   z-index: 1;
   width: 1em;
   height: 1em;
+  cursor: pointer;
 
   &:checked ~ ${CheckboxRadioBox} {
-    border-color: ${props => props.theme.color('black')};
-
     .icon {
       opacity: 1;
     }
   }
 
   &:hover ~ ${CheckboxRadioBox} {
-    border-color: ${props => props.theme.color('black')};
+    border-width: 2px;
   }
 
   &:focus-visible ~ ${CheckboxRadioBox}, &:focus ~ ${CheckboxRadioBox} {
@@ -98,7 +97,7 @@ const CheckboxRadio: FunctionComponent<CheckboxRadioProps> = ({
           <Icon icon={type === 'checkbox' ? check : indicator} />
         </CheckboxRadioBox>
       </CheckBoxWrapper>
-      <Space as="span" h={{ size: 'xs', properties: ['margin-left'] }}>
+      <Space as="span" h={{ size: 's', properties: ['margin-left'] }}>
         {text}
       </Space>
     </CheckboxRadioLabel>

--- a/common/views/components/NewsletterPromo/NewsletterPromo.tsx
+++ b/common/views/components/NewsletterPromo/NewsletterPromo.tsx
@@ -9,33 +9,9 @@ import useValidation from '@weco/common/hooks/useValidation';
 import ButtonSolid from '../ButtonSolid/ButtonSolid';
 import { newsletterAddressBook } from '@weco/common/data/dotdigital';
 import { Container } from '@weco/common/views/components/styled/Container';
-
-const FormElementWrapper = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  width: 100%;
-  gap: 10px;
-
-  > * {
-    width: 100%;
-  }
-
-  ${props => props.theme.media('medium')`
-    flex-wrap: nowrap;
-    align-items: stretch;
-
-    > * {
-      width: auto;
-    }
-  `}
-`;
-
-const ButtonWrap = styled.div`
-  button {
-    height: 100%;
-    width: 100%;
-  }
-`;
+import CheckboxRadio from '../CheckboxRadio/CheckboxRadio';
+import theme from '@weco/common/views/themes/default';
+import Layout8 from '../Layout8/Layout8';
 
 const NewsletterForm = styled.form.attrs({
   name: 'newsletter-signup',
@@ -43,69 +19,38 @@ const NewsletterForm = styled.form.attrs({
   action: 'https://r1-t.trackedlink.net/signup.ashx',
   method: 'post',
 })`
-  display: flex;
-  flex-wrap: wrap;
-  flex: 1;
-  align-items: flex-start;
   position: relative;
-
-  label {
-    flex: 1;
-  }
 
   ${props => props.theme.makeSpacePropertyValues('m', ['margin-bottom'])}
 
   ${props => props.theme.media('medium')`
-    flex-wrap: nowrap;
     min-width: 300px;
   `}
 `;
 
-const YellowBox = styled(Space).attrs({
-  h: { size: 'xl', properties: ['padding-left', 'padding-right'] },
-  v: { size: 'l', properties: ['padding-top', 'padding-bottom'] },
-  'aria-live': 'polite',
-})`
-  border: 12px solid ${props => props.theme.color('yellow')};
-
-  p {
-    max-width: 600px;
-  }
-`;
-
-const BoxInner = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  align-items: center;
-
-  ${props => props.theme.media('xlarge')`
-    flex-wrap: nowrap;
-  `}
-`;
-
-const CopyWrap = styled(Space).attrs({
-  h: { size: 'm', properties: ['padding-right'] },
-  v: { size: 'm', properties: ['margin-bottom'] },
-})`
-  flex-basis: 100%;
-
-  ${props => props.theme.media('medium')`
-    flex-basis: auto;
-  `}
-`;
+const PrivacyNotice = () => (
+  <p className={font('intr', 6)}>
+    By clicking subscribe, you agree to receive this newsletter. You can
+    unsubscribe any time. For information about how we handle your data,{' '}
+    <a
+      href="https://wellcome.org/who-we-are/privacy-and-terms"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      please read our privacy notice
+    </a>
+    .
+  </p>
+);
 
 const NewsletterPromo: FunctionComponent = () => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSuccess, setIsSuccess] = useState(false);
   const [isSubmitError, setIsSubmitError] = useState(false);
+  const [hasCheckedMarketing, setHasCheckedMarketing] = useState(false);
   const [value, setValue] = useState('');
   const { isEnhanced } = useContext(AppContext);
   const emailValidation = useValidation();
-
-  const headingText = 'Stay in the know';
-  const bodyText =
-    'Sign up to our newsletter to find out what’s on, read our latest stories and get involved.';
 
   async function handleSubmit(event) {
     event.preventDefault();
@@ -152,109 +97,99 @@ const NewsletterPromo: FunctionComponent = () => {
   }
 
   return (
-    <div className="is-hidden-print">
+    <Space
+      className="is-hidden-print"
+      style={{ backgroundColor: theme.color('lightYellow') }}
+      v={{ size: 'xl', properties: ['padding-top', 'padding-bottom'] }}
+    >
       <Container>
-        <div style={{ display: 'flex', justifyContent: 'center' }}>
-          <div>
-            <YellowBox>
-              <BoxInner>
-                <CopyWrap>
-                  <h2
-                    className={font('wb', 3)}
-                    style={{ marginBottom: !isSuccess ? 0 : undefined }}
-                  >
-                    {isSuccess ? 'Thank you for signing up!' : headingText}
-                  </h2>
-                  {!isSuccess && (
-                    <p
-                      className={font('intr', 5)}
-                      style={{ marginBottom: 0, maxWidth: '500px' }}
-                    >
-                      {bodyText}
-                    </p>
-                  )}
-                  {isSuccess && (
-                    <div className={`${font('intr', 5)} spaced-text`}>
-                      <p>
-                        If this is the first time you have subscribed to one of
-                        our newsletters, you will receive an email asking you to
-                        confirm your subscription.
-                      </p>
-                      <p>
-                        To find out more about our Access events, and activities
-                        for Young People and Schools, see our{' '}
-                        <a href="/newsletter">full list of newsletters</a>.
-                      </p>
-                    </div>
-                  )}
-                </CopyWrap>
-                {!isSuccess && (
-                  <>
-                    <NewsletterForm
-                      onSubmit={handleSubmit}
-                      noValidate={isEnhanced}
-                    >
-                      <input
-                        type="hidden"
-                        name="addressBookId"
-                        value={newsletterAddressBook.id}
-                      />
-                      <FormElementWrapper>
-                        <TextInput
-                          required={true}
-                          id="newsletter-input"
-                          type="email"
-                          name="email"
-                          label="Your email address"
-                          errorMessage={
-                            isSubmitError
-                              ? 'There was a problem. Please try again.'
-                              : 'Enter a valid email address.'
-                          }
-                          value={value}
-                          setValue={setValue}
-                          {...emailValidation}
-                        />
-                        <ButtonWrap>
-                          <ButtonSolid
-                            dataGtmTrigger="newsletter_promo_subscribe"
-                            text={isSubmitting ? 'Sending…' : 'Subscribe'}
-                            disabled={isSubmitting}
-                          />
-                        </ButtonWrap>
-                      </FormElementWrapper>
-                    </NewsletterForm>
-                  </>
-                )}
-              </BoxInner>
-              {!isSuccess && (
-                <p className={font('intr', 6)} style={{ marginBottom: 0 }}>
+        <Layout8>
+          <h2 className={font('wb', 3)} style={{ textAlign: 'center' }}>
+            {isSuccess ? 'Thank you for signing up!' : 'Stay in the know'}
+          </h2>
+          {!isSuccess && (
+            <>
+              <p className={font('intr', 5)} style={{ marginBottom: '1rem' }}>
+                Sign up to our newsletter to find out what’s on, read our latest
+                stories and get involved.
+              </p>
+
+              <NewsletterForm onSubmit={handleSubmit} noValidate={isEnhanced}>
+                <input
+                  type="hidden"
+                  name="addressBookId"
+                  value={newsletterAddressBook.id}
+                />
+                <TextInput
+                  required={true}
+                  id="newsletter-input"
+                  type="email"
+                  name="email"
+                  label="Your email address"
+                  errorMessage={
+                    isSubmitError
+                      ? 'There was a problem. Please try again.'
+                      : 'Enter a valid email address.'
+                  }
+                  value={value}
+                  setValue={setValue}
+                  {...emailValidation}
+                />
+
+                <p
+                  className={font('intr', 6)}
+                  style={{ marginBottom: 0, marginTop: '1rem' }}
+                >
                   <a href="/newsletter">All our newsletters</a>
                 </p>
-              )}
-            </YellowBox>
-            <Space
-              v={{ size: 'l', properties: ['margin-top'] }}
-              style={{ flexBasis: '100%' }}
-            >
-              <p className={font('intr', 6)} style={{ maxWidth: '800px' }}>
-                By clicking subscribe, you agree to receive this newsletter. You
-                can unsubscribe any time. For information about how we handle
-                your data,{' '}
-                <a
-                  href="https://wellcome.org/who-we-are/privacy-and-terms"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  please read our privacy notice
-                </a>
-                .
+
+                <Space v={{ size: 'l', properties: ['margin-top'] }}>
+                  <CheckboxRadio
+                    id="marketingPermissions"
+                    type="checkbox"
+                    checked={hasCheckedMarketing}
+                    onChange={() => {
+                      setHasCheckedMarketing(currentValue => !currentValue);
+                    }}
+                    text={
+                      <p className={font('intr', 6)}>
+                        Tick this box if you’re happy to receive other emails
+                        about Wellcome Collection, upcoming events and
+                        exhibitions and/or other relevant opportunities.
+                      </p>
+                    }
+                  />
+                </Space>
+
+                <PrivacyNotice />
+
+                <ButtonSolid
+                  dataGtmTrigger="newsletter_promo_subscribe"
+                  text={isSubmitting ? 'Sending…' : 'Subscribe'}
+                  disabled={isSubmitting}
+                />
+              </NewsletterForm>
+            </>
+          )}
+
+          {isSuccess && (
+            <div className={`${font('intr', 5)} spaced-text`}>
+              <p>
+                If this is the first time you have subscribed to one of our
+                newsletters, you will receive an email asking you to confirm
+                your subscription.
               </p>
-            </Space>
-          </div>
-        </div>
+              <p>
+                To find out more about our Access events, and activities for
+                Young People and Schools, see our{' '}
+                <a href="/newsletter">full list of newsletters</a>.
+              </p>
+              <PrivacyNotice />
+            </div>
+          )}
+        </Layout8>
       </Container>
-    </div>
+    </Space>
   );
 };
 

--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -10,7 +10,6 @@ import CookieNotice from '../CookieNotice/CookieNotice';
 import NewsletterPromo from '../NewsletterPromo/NewsletterPromo';
 import Footer from '../Footer';
 import PopupDialog from '../PopupDialog/PopupDialog';
-import Space from '../styled/Space';
 import {
   museumLd,
   libraryLd,
@@ -300,7 +299,6 @@ const PageLayoutComponent: FunctionComponent<Props> = ({
           <ApiToolbar links={apiToolbarLinks.filter(isNotUndefined)} />
         )}
         <CookieNotice source={url.pathname || ''} />
-
         {skipToContentLinks.map(({ anchorId, label }) => (
           <a
             className="visually-hidden visually-hidden-focusable"
@@ -310,13 +308,10 @@ const PageLayoutComponent: FunctionComponent<Props> = ({
             {label}
           </a>
         ))}
-
         <a className="visually-hidden visually-hidden-focusable" href="#main">
           Skip to main content
         </a>
-
         <Header siteSection={siteSection} {...headerProps} />
-
         {globalAlert.data.isShown === 'show' &&
           (!globalAlert.data.routeRegex ||
             urlString.match(new RegExp(globalAlert.data.routeRegex))) && (
@@ -341,16 +336,9 @@ const PageLayoutComponent: FunctionComponent<Props> = ({
         >
           {children}
         </div>
-        {!hideNewsletterPromo && (
-          <Space
-            v={{
-              size: 'xl',
-              properties: ['padding-top', 'padding-bottom'],
-            }}
-          >
-            <NewsletterPromo />
-          </Space>
-        )}
+
+        {!hideNewsletterPromo && <NewsletterPromo />}
+
         {/* The no javascript version of the burger menu relies on the footer being present on the page,
         as we then use an anchor link to take people to the navigation links in the footer.
         We only completely remove the footer if you've got JS. */}


### PR DESCRIPTION
## Who is this for?
Marketing, design

## What is it doing for them?
Relates to #10071 and #10070
The first one's purpose is to add a marketing permission checkbox, the latter is to redesign the NewsletterPromo.
This also meant restyling our checkbox/radio buttons slightly.
New checkboxes are thinner and have a black border, wider on hover and the `cursor: pointer` activates on hover as well.

## Before
### Newsletter Promo
<img width="1206" alt="Screenshot 2023-08-11 at 09 41 21" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/8f1f4cd5-119d-4fe5-b934-c6733ee9dd7c">

### Checkboxes
https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/fde6fe9f-5087-4e41-af42-c265706a6bd6


## After
### Newsletter Promo
<img width="1219" alt="Screenshot 2023-08-11 at 09 41 35" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/9f7be0f4-916d-439d-9025-6d0561c6c6f0">

### Checkboxes
https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/2af1bb54-3120-4a1a-b27d-a9505aad7e78

