### PR TITLE
Add marketingPermissions to Newsletter Promo API

### DIFF
--- a/common/views/components/NewsletterPromo/NewsletterPromo.tsx
+++ b/common/views/components/NewsletterPromo/NewsletterPromo.tsx
@@ -70,6 +70,7 @@ const NewsletterPromo: FunctionComponent = () => {
     const data = {
       addressBookId: formEls.find(el => el.name === 'addressBookId').value,
       emailAddress: formEls.find(el => el.name === 'email').value,
+      marketingPermissions: hasCheckedMarketing,
     };
 
     const response = await fetch('/api/newsletter-signup', {


### PR DESCRIPTION
## Who is this for?
Marketing

## What is it doing for them?
Relates to #10071 
I wasn't able to test this form locally and thought #10126 would do it but had failed to notice how differently the forms worked (Promo vs SignUp). Again, I wasn't able to test locally (if anyone knows how please let me know!), but I followed [what the API documentation said](https://developer.dotdigital.com/reference/add-contact-to-address-book).