### PR TITLE
Look for event card image in the right place

### DIFF
--- a/content/webapp/components/EventCard/EventCard.tsx
+++ b/content/webapp/components/EventCard/EventCard.tsx
@@ -19,7 +19,7 @@ const EventCard: FunctionComponent<Props> = ({ event, xOfY }) => {
     <EventDateRange event={event} />
   );
 
-  const squareImage = getCrop(event.promo?.image, 'square');
+  const squareImage = getCrop(event.image, 'square');
   const ImageComponent = squareImage && (
     <PrismicImage
       image={{


### PR DESCRIPTION
## Who is this for?
People who like images in compact cards.

## What is it doing for them?
Getting the image from the right place. E.g. [this exhibition page](https://wellcomecollection.org/exhibitions/Y8VNbhEAAPJM-oki)

__Before__
<img width="915" alt="image" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/1394592/74edd4b5-de07-447e-8c30-89b478a5a237">

__After__
<img width="958" alt="image" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/1394592/9f0a3194-40d8-447e-8732-ea1c2bba1fcf">

