### PR TITLE
Add data-gtm-trigger for tracking image zoom in GTM

### DIFF
--- a/content/webapp/components/ZoomedPrismicImage/ZoomedPrismicImage.tsx
+++ b/content/webapp/components/ZoomedPrismicImage/ZoomedPrismicImage.tsx
@@ -14,7 +14,9 @@ import Image from 'next/image';
 import { createPrismicLoader } from '@weco/common/views/components/PrismicImage/PrismicImage';
 import { trackGaEvent } from '@weco/common/utils/ga';
 
-const ZoomButton = styled.button`
+const ZoomButton = styled.button.attrs({
+  'data-gtm-trigger': 'zoom_prismic_image_button',
+})`
   position: absolute;
   top: 10px;
   right: 10px;


### PR DESCRIPTION
☝️ 

Noticed we don't currently have a way to track usage of the image zoom button in tag manager. Now that we're going to be adding zoomable images to visual stories, it will be good to get a handle on whether this is functionality people are using.


- [ ] set up trigger/event in GTM