### PR TITLE
Remove John the Baptist as a concept testing option

### DIFF
--- a/playwright/test/concept.test.ts
+++ b/playwright/test/concept.test.ts
@@ -43,10 +43,6 @@ const conceptIds = {
   // the search properly.
   'Thackrah, Charles Turner, 1795-1833': 'd46ea7yk',
 
-  // Chosen because there are no associated images if you don't quote
-  // the search properly.
-  'John, the Baptist, Saint': 'qd86ycny',
-
   // Chosen because there are works both about and by this person
   'Nightingale, Florence, 1820-1910': 'gk2eca5r',
 
@@ -128,7 +124,11 @@ test.describe('concepts @conceptPage', () => {
   }) => {
     // I've deliberately picked a complicated ID with commas here, to make sure
     // we're quoting the query we send to the images API.
-    await concept(conceptIds['John, the Baptist, Saint'], context, page);
+    await concept(
+      conceptIds['Nightingale, Florence, 1820-1910'],
+      context,
+      page
+    );
     await page.waitForSelector('h2 >> text="Images"');
   });
 


### PR DESCRIPTION
## Who is this for?
E2Es

## What is it doing for them?
Follow-up to #10146 
This test didn't fail in its branch and only did in staging when the previous PR was merged. 
[See Slack conversation](https://wellcome.slack.com/archives/C02ANCYL90E/p1692262571556779), @paul-butcher says:
> [John, the Baptist, Saint](https://wellcomecollection.org/concepts/ywavfdsc) has no trailing ., but the corresponding subject in [mdwrgvd4](https://wellcomecollection.org/works/mdwrgvd4) does.  I believe this is a consequence of us standardising the  title of the Concept using the [authoritative source](https://id.loc.gov/authorities/names/n78095804.html), but not having done so yet in Works. The link is derived from the identifier, but the page content is still populated using full term matches on the label.

In the meantime, as this only tested if some concept pages _had images_, I replaced it with Florence Nightingale, which still has, and removed the JTB one completely (wasn't used anywhere else).