### PR TITLE
GraphQuery tidy ups/minimalising

### DIFF
--- a/content/webapp/pages/events/[eventId].tsx
+++ b/content/webapp/pages/events/[eventId].tsx
@@ -7,7 +7,6 @@ import ButtonSolid from '@weco/common/views/components/ButtonSolid/ButtonSolid';
 import ButtonSolidLink from '@weco/common/views/components/ButtonSolidLink/ButtonSolidLink';
 import EventbriteButtons from '@weco/content/components/EventbriteButtons/EventbriteButtons';
 import Message from '@weco/common/views/components/Message/Message';
-import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
 import InfoBox from '@weco/content/components/InfoBox/InfoBox';
 import { font } from '@weco/common/utils/classnames';
 import { camelize } from '@weco/common/utils/grammar';

--- a/content/webapp/services/prismic/fetch/articles.ts
+++ b/content/webapp/services/prismic/fetch/articles.ts
@@ -33,37 +33,12 @@ const articlesFetcher = fetcher<ArticlePrismicDocument>(
 
 export const fetchArticle = articlesFetcher.getById;
 
-export const graphQuery = `{
+const graphQuery = `{
   webcomics {
-    ...webcomicsFields
+    title
     format {
-      ...formatFields
-    }
-    body {
-      ...on editorialImageGallery {
-        non-repeat {
-          title
-        }
-        repeat {
-          image
-          caption
-        }
-      }
-    }
-    series {
-      series {
-        ...seriesFields
-      }
-    }
-    contributors {
-      ...contributorsFields
-      role {
-        ...roleFields
-      }
-      contributor {
-        ... on people {
-          ...peopleFields
-        }
+      ... on article-formats {
+        title
       }
     }
     promo {
@@ -74,50 +49,9 @@ export const graphQuery = `{
         }
       }
     }
-  }
-  articles {
-    ...articlesFields
-    body {
-      ...on standfirst {
-        non-repeat {
-          text
-        }
-      }
-    }
-    contributors {
-      ...contributorsFields
-      role {
-        ...roleFields
-      }
-      contributor {
-        ... on people {
-          ...peopleFields
-        }
-        ... on organisations {
-          ...organisationsFields
-        }
-      }
-    }
     series {
       series {
-        ...seriesFields
-        schedule {
-          ...scheduleFields
-        }
-        contributors {
-          ...contributorsFields
-          role {
-            ...roleFields
-          }
-          contributor {
-            ... on people {
-              ...peopleFields
-            }
-            ... on organisations {
-              ...organisationsFields
-            }
-          }
-        }
+        title
         promo {
           ... on editorialImage {
             non-repeat {
@@ -128,6 +62,14 @@ export const graphQuery = `{
         }
       }
     }
+  }
+  articles {
+    title
+    format {
+      ... on article-formats {
+        title
+      }
+    }
     promo {
       ... on editorialImage {
         non-repeat {
@@ -136,16 +78,14 @@ export const graphQuery = `{
         }
       }
     }
-    seasons {
-      season {
-        ... on seasons {
-          title
-          promo {
-            ... on editorialImage {
-              non-repeat {
-                caption
-                image
-              }
+    series {
+      series {
+        title
+        promo {
+          ... on editorialImage {
+            non-repeat {
+              caption
+              image
             }
           }
         }

--- a/content/webapp/services/prismic/fetch/articles.ts
+++ b/content/webapp/services/prismic/fetch/articles.ts
@@ -77,78 +77,10 @@ export const graphQuery = `{
   }
   articles {
     ...articlesFields
-    format {
-      ...formatFields
-    }
     body {
-      ...on text {
-        non-repeat {
-          text
-        }
-      }
-      ...on editorialImage {
-        non-repeat {
-          image
-          caption
-        }
-      }
-      ...on editorialImageGallery {
-        non-repeat {
-          title
-        }
-        repeat {
-          image
-          caption
-        }
-      }
-      ...on gifVideo {
-        non-repeat {
-          caption
-          tasl
-          video
-          playbackRate
-          autoPlay
-          loop
-          mute
-          showControls
-        }
-      }
-      ...on iframe {
-        non-repeat {
-          iframeSrc
-          previewImage
-        }
-      }
       ...on standfirst {
         non-repeat {
           text
-        }
-      }
-      ...on quoteV2 {
-        non-repeat {
-          text
-          citation
-        }
-      }
-      ...on embed {
-        non-repeat {
-          embed
-          caption
-        }
-      }
-      ...on discussion {
-        non-repeat {
-          title
-          text
-        }
-      }
-      ...on tagList {
-        non-repeat {
-          title
-        }
-        repeat {
-          link
-          linkText
         }
       }
     }

--- a/content/webapp/services/prismic/fetch/events.ts
+++ b/content/webapp/services/prismic/fetch/events.ts
@@ -66,66 +66,44 @@ type FetchEventsQueryParams = {
 const startField = 'my.events.times.startDateTime';
 const endField = 'my.events.times.endDateTime';
 
-export const graphQuery = `{
+const graphQuery = `{
   events {
-    ...eventsFields
+    title
+    isOnline
+    availableOnline
+    isRelaxedPerformance
     format {
-      ...formatFields
-    }
-    series {
-      series {
-        ...seriesFields
-        contributors {
-          ...contributorsFields
-          role {
-            ...roleFields
-          }
-          contributor {
-            ... on people {
-              ...peopleFields
-            }
-            ... on organisations {
-              ...organisationsFields
-            }
-          }
-        }
-        promo {
-          ... on editorialImage {
-            non-repeat {
-              caption
-              image
-            }
-          }
-        }
+      ... on event-formats {
+        title
       }
     }
     interpretations {
       interpretationType {
-        ...interpretationTypeFields
+        title
       }
     }
-    policies {
-      policy {
-        ...policyFields
-      }
+    times {
+      startDateTime
+      endDateTime
     }
     audiences {
       audience {
-        ...audienceFields
+        title
       }
     }
-    contributors {
-      ...contributorsFields
-      role {
-        ...roleFields
+    schedule {
+      event {
+        title
+        times {
+          startDateTime
+          endDateTime
+        }
       }
-      contributor {
-        ... on people {
-          ...peopleFields
-        }
-        ... on organisations {
-          ...organisationsFields
-        }
+      isNotLinked
+    }
+    locations {
+      location {
+        title
       }
     }
     promo {
@@ -136,8 +114,21 @@ export const graphQuery = `{
         }
       }
     }
+    series {
+      series {
+        title
+        promo {
+          ... on editorialImage {
+            non-repeat {
+              caption
+              image
+            }
+          }
+        }
+      }
+    }
   }
-}`;
+}`.replace(/\n(\s+)/g, '\n');
 
 export const fetchEvents = (
   client: GetServerSidePropsPrismicClient,

--- a/content/webapp/services/prismic/fetch/stories-landing.ts
+++ b/content/webapp/services/prismic/fetch/stories-landing.ts
@@ -8,7 +8,7 @@ const graphQuery = `{
     storiesDescription
     stories {
       story {
-        ...on articles {
+        ... on articles {
           title
           format {
             ... on article-formats {

--- a/content/webapp/services/prismic/fetch/stories-landing.ts
+++ b/content/webapp/services/prismic/fetch/stories-landing.ts
@@ -9,18 +9,25 @@ const graphQuery = `{
     stories {
       story {
         ...on articles {
-          ...articlesFields
+          title
           format {
-            ...formatFields
+            ... on article-formats {
+              title
+            }
+          }
+          promo {
+            ... on editorialImage {
+              non-repeat {
+                caption
+                image
+              }
+            }
           }
           series {
             series {
-              ...seriesFields
+              title
             }
           }
-        }
-        ...on series {
-          ...seriesFields
         }
       }
     }
@@ -28,11 +35,20 @@ const graphQuery = `{
     booksDescription
     books {
       book {
-        ...bookFields
+        title
+        subtitle
+        promo {
+          ... on editorialImage {
+            non-repeat {
+              caption
+              image
+            }
+          }
+        }
       }
     }
   }
-}`;
+}`.replace(/\n(\s+)/g, '\n');
 
 export const fetchStoriesLanding = ({
   client,

--- a/prismic-model/src/articles.ts
+++ b/prismic-model/src/articles.ts
@@ -1,7 +1,7 @@
 import title from './parts/title';
 import promo from './parts/promo';
 import list from './parts/list';
-import link, { documentLink } from './parts/link';
+import { documentLink } from './parts/link';
 import number from './parts/number';
 import articleBody from './parts/article-body';
 import contributorsWithTitle from './parts/contributorsWithTitle';


### PR DESCRIPTION
## Who is this for?
Maintenance, devs

## What is it doing for them?
Relates to #10148 
I went through `fetchArticles`, `fetchEvents`, and `fetchStoriesLanding`'s graphQueries and aimed to minimise what was being fetched. I went through everywhere it was used and it seems to be all good, looking the same as prod does.

Of course I could've missed something, so code review/local testing is useful here. I think split view is probably the more useful way to look at code changes.

I'm not sure why so much was being fetched, maybe it used to be used in the event's individual pages? Having all the slices mentioned if what could cause the site to break down if process wasn't followed, but they didn't actually seem to be _used_ anywhere.

I used [Prismic's documentation](https://prismic.io/docs/graphquery-rest-api#fields-in-a-group) as well as our own Custom Types builder.