### PR TITLE
Fix analysis scripts (prismic-model)

### DIFF
--- a/prismic-model/.gitignore
+++ b/prismic-model/.gitignore
@@ -1,3 +1,4 @@
 snapshot.*
 node_modules
 contentReport.json
+sliceReport.json

--- a/prismic-model/README.md
+++ b/prismic-model/README.md
@@ -98,12 +98,17 @@ The body of a Prismic document is made of "slices" (e.g. quote, paragraph, image
 
 We have a tool that shows you examples of where a slice is used.
 This is useful if you want to know if a slice can be safely deleted from the model, or to find an example for testing.
+You can run:
 
-For example:
+`yarn sliceAnalysis`
 
-```console
-$ ts-node sliceAnalysis --type embed
-```
+You might want to add flags for more information, though, such as:
+
+`--label [slice format label name]` will print out more information about a specific format label.
+`--type [slice type name]` will print out more information about a specific type. There might be a lot of them and it can't print them all, so...
+`--report` will create a `sliceReport.json` file with the full list.
+`--printUrl` will also try to give you relevant URLs based on the type and ID.
+
 
 See the file comment on [sliceAnalysis.ts](./sliceAnalysis.ts)
 

--- a/prismic-model/sliceAnalysis.ts
+++ b/prismic-model/sliceAnalysis.ts
@@ -25,8 +25,9 @@
  * see: https://prismic.io/docs/core-concepts/slices
  */
 import yargs from 'yargs';
-import body from './src/parts/body';
-import articleBody from './src/parts/article-body';
+import body from './src/parts/bodies/body';
+import articleBody from './src/parts/bodies/article-body';
+import visualStoryBody from './src/parts/bodies/visual-story-body';
 import {
   downloadPrismicSnapshot,
   getPrismicDocuments,
@@ -42,7 +43,8 @@ const { label, type } = yargs(process.argv.slice(2))
 
 async function main() {
   const sliceNames = Object.keys(articleBody.config.choices).concat(
-    Object.keys(body.config.choices)
+    Object.keys(body.config.choices),
+    Object.keys(visualStoryBody.config.choices)
   );
 
   const sliceCounter = new Map(sliceNames.map(sliceName => [sliceName, 0]));

--- a/prismic-model/sliceAnalysis.ts
+++ b/prismic-model/sliceAnalysis.ts
@@ -30,12 +30,18 @@ import {
   downloadPrismicSnapshot,
   getPrismicDocuments,
 } from './downloadSnapshot';
+import fs from 'fs';
+import { success } from './console';
 
-const { label, type } = yargs(process.argv.slice(2))
-  .usage('Usage: $0 --label [string] --type [string]')
+const { label, type, printUrl, report } = yargs(process.argv.slice(2))
+  .usage(
+    'Usage: $0 --label [string] --type [string] --printUrl [boolean] --report [boolean]'
+  )
   .options({
     label: { type: 'string' },
     type: { type: 'string' },
+    report: { type: 'boolean' },
+    printUrl: { type: 'boolean' },
   })
   .parseSync();
 
@@ -73,9 +79,22 @@ async function main() {
           type: result.type,
           format: result.data.format?.slug,
           title: result.data.title[0].text,
+          ...(printUrl && {
+            url: `http://wellcomecollection.org/${result.type}/${result.id}`,
+          }),
         });
       }
     }
+  }
+
+  if (report) {
+    await fs.writeFile('./sliceReport.json', JSON.stringify(matches), err => {
+      if (err) console.log(err);
+      else {
+        success('File written successfully');
+      }
+    });
+    success('Reporting done!');
   }
 
   const slicesArray = Array.from(sliceCounter.entries());

--- a/prismic-model/sliceAnalysis.ts
+++ b/prismic-model/sliceAnalysis.ts
@@ -25,9 +25,7 @@
  * see: https://prismic.io/docs/core-concepts/slices
  */
 import yargs from 'yargs';
-import body from './src/parts/bodies/body';
-import articleBody from './src/parts/bodies/article-body';
-import visualStoryBody from './src/parts/bodies/visual-story-body';
+import { body, articleBody, visualStoryBody } from './src/parts/bodies';
 import {
   downloadPrismicSnapshot,
   getPrismicDocuments,

--- a/prismic-model/src/articles.ts
+++ b/prismic-model/src/articles.ts
@@ -3,7 +3,7 @@ import promo from './parts/promo';
 import list from './parts/list';
 import link, { documentLink } from './parts/link';
 import number from './parts/number';
-import articleBody from './parts/article-body';
+import articleBody from './parts/bodies/article-body';
 import contributorsWithTitle from './parts/contributorsWithTitle';
 import { singleLineText } from './parts/text';
 import { CustomType } from './types/CustomType';

--- a/prismic-model/src/articles.ts
+++ b/prismic-model/src/articles.ts
@@ -3,7 +3,7 @@ import promo from './parts/promo';
 import list from './parts/list';
 import link, { documentLink } from './parts/link';
 import number from './parts/number';
-import articleBody from './parts/bodies/article-body';
+import { articleBody } from './parts/bodies';
 import contributorsWithTitle from './parts/contributorsWithTitle';
 import { singleLineText } from './parts/text';
 import { CustomType } from './types/CustomType';

--- a/prismic-model/src/books.ts
+++ b/prismic-model/src/books.ts
@@ -1,6 +1,6 @@
 import title from './parts/title';
 import { multiLineText, singleLineText } from './parts/text';
-import body from './parts/body';
+import body from './parts/bodies/body';
 import { documentLink, webLink } from './parts/link';
 import keyword from './parts/keyword';
 import list from './parts/list';

--- a/prismic-model/src/books.ts
+++ b/prismic-model/src/books.ts
@@ -1,6 +1,6 @@
 import title from './parts/title';
 import { multiLineText, singleLineText } from './parts/text';
-import body from './parts/bodies/body';
+import { body } from './parts/bodies';
 import { documentLink, webLink } from './parts/link';
 import keyword from './parts/keyword';
 import list from './parts/list';

--- a/prismic-model/src/event-series.ts
+++ b/prismic-model/src/event-series.ts
@@ -1,6 +1,6 @@
 import title from './parts/title';
 import promo from './parts/promo';
-import body from './parts/bodies/body';
+import { body } from './parts/bodies';
 import contributorsWithTitle from './parts/contributorsWithTitle';
 import { documentLink } from './parts/link';
 import { singleLineText } from './parts/text';

--- a/prismic-model/src/event-series.ts
+++ b/prismic-model/src/event-series.ts
@@ -1,6 +1,6 @@
 import title from './parts/title';
 import promo from './parts/promo';
-import body from './parts/body';
+import body from './parts/bodies/body';
 import contributorsWithTitle from './parts/contributorsWithTitle';
 import { documentLink } from './parts/link';
 import { singleLineText } from './parts/text';

--- a/prismic-model/src/events.ts
+++ b/prismic-model/src/events.ts
@@ -8,7 +8,7 @@ import embed from './parts/embed';
 import booleanDeprecated from './parts/boolean-deprecated';
 import keyword from './parts/keyword';
 import contributorsWithTitle from './parts/contributorsWithTitle';
-import body from './parts/body';
+import body from './parts/bodies/body';
 import boolean from './parts/boolean';
 import number from './parts/number';
 import { CustomType } from './types/CustomType';

--- a/prismic-model/src/events.ts
+++ b/prismic-model/src/events.ts
@@ -8,7 +8,7 @@ import embed from './parts/embed';
 import booleanDeprecated from './parts/boolean-deprecated';
 import keyword from './parts/keyword';
 import contributorsWithTitle from './parts/contributorsWithTitle';
-import body from './parts/bodies/body';
+import { body } from './parts/bodies';
 import boolean from './parts/boolean';
 import number from './parts/number';
 import { CustomType } from './types/CustomType';

--- a/prismic-model/src/exhibitions.ts
+++ b/prismic-model/src/exhibitions.ts
@@ -6,7 +6,7 @@ import { documentLink } from './parts/link';
 import list from './parts/list';
 import { singleLineText } from './parts/text';
 import contributorsWithTitle from './parts/contributorsWithTitle';
-import body from './parts/body';
+import body from './parts/bodies/body';
 import booleanDeprecated from './parts/boolean-deprecated';
 import number from './parts/number';
 import { CustomType } from './types/CustomType';

--- a/prismic-model/src/exhibitions.ts
+++ b/prismic-model/src/exhibitions.ts
@@ -6,7 +6,7 @@ import { documentLink } from './parts/link';
 import list from './parts/list';
 import { singleLineText } from './parts/text';
 import contributorsWithTitle from './parts/contributorsWithTitle';
-import body from './parts/bodies/body';
+import { body } from './parts/bodies';
 import booleanDeprecated from './parts/boolean-deprecated';
 import number from './parts/number';
 import { CustomType } from './types/CustomType';

--- a/prismic-model/src/guides.ts
+++ b/prismic-model/src/guides.ts
@@ -1,5 +1,5 @@
 import title from './parts/title';
-import body from './parts/bodies/body';
+import { body } from './parts/bodies';
 import promo from './parts/promo';
 import { documentLink } from './parts/link';
 import timestamp from './parts/timestamp';

--- a/prismic-model/src/guides.ts
+++ b/prismic-model/src/guides.ts
@@ -1,5 +1,5 @@
 import title from './parts/title';
-import body from './parts/body';
+import body from './parts/bodies/body';
 import promo from './parts/promo';
 import { documentLink } from './parts/link';
 import timestamp from './parts/timestamp';

--- a/prismic-model/src/pages.ts
+++ b/prismic-model/src/pages.ts
@@ -1,5 +1,5 @@
 import title from './parts/title';
-import body from './parts/body';
+import body from './parts/bodies/body';
 import promo from './parts/promo';
 import { documentLink } from './parts/link';
 import list from './parts/list';

--- a/prismic-model/src/pages.ts
+++ b/prismic-model/src/pages.ts
@@ -1,5 +1,5 @@
 import title from './parts/title';
-import body from './parts/bodies/body';
+import { body } from './parts/bodies';
 import promo from './parts/promo';
 import { documentLink } from './parts/link';
 import list from './parts/list';

--- a/prismic-model/src/parts/bodies/article-body.ts
+++ b/prismic-model/src/parts/bodies/article-body.ts
@@ -1,10 +1,10 @@
 import body, { slice } from './body';
-import heading from './heading';
-import { mediaLink, webLink } from './link';
-import keyword from './keyword';
-import { multiLineText, singleLineText } from './text';
-import gifVideoSlice from './gif-video-slice';
-import title from './title';
+import heading from '../heading';
+import { mediaLink, webLink } from '../link';
+import keyword from '../keyword';
+import { multiLineText, singleLineText } from '../text';
+import gifVideoSlice from '../gif-video-slice';
+import title from '../title';
 
 export default {
   fieldset: 'Body content',

--- a/prismic-model/src/parts/bodies/body.ts
+++ b/prismic-model/src/parts/bodies/body.ts
@@ -1,15 +1,15 @@
-import { multiLineText, singleLineText } from './text';
-import captionedImageSlice from './captioned-image-slice';
-import captionedImageGallerySlice from './captioned-image-gallery-slice';
-import gifVideoSlice from './gif-video-slice';
-import iframeSlice from './iframe-slice';
-import title from './title';
-import link, { documentLink, mediaLink, webLink } from './link';
-import text from './keyword';
-import embed from './embed';
-import heading from './heading';
-import booleanDeprecated from './boolean-deprecated';
-import { textAndIconsSlice } from './textAndIcons';
+import { multiLineText, singleLineText } from '../text';
+import captionedImageSlice from '../captioned-image-slice';
+import captionedImageGallerySlice from '../captioned-image-gallery-slice';
+import gifVideoSlice from '../gif-video-slice';
+import iframeSlice from '../iframe-slice';
+import title from '../title';
+import link, { documentLink, mediaLink, webLink } from '../link';
+import text from '../keyword';
+import embed from '../embed';
+import heading from '../heading';
+import booleanDeprecated from '../boolean-deprecated';
+import { textAndIconsSlice } from '../textAndIcons';
 
 // I've left slice here as we shouldn't really use it.
 type SliceProps = {

--- a/prismic-model/src/parts/bodies/index.ts
+++ b/prismic-model/src/parts/bodies/index.ts
@@ -1,0 +1,7 @@
+// If a new body gets added, don't forget to ensure it's added in sliceAnalysis.ts
+// so all new custom slices are accounted for in the next analysis.
+import articleBody from './article-body';
+import body from './body';
+import visualStoryBody from './visual-story-body';
+
+export { articleBody, body, visualStoryBody };

--- a/prismic-model/src/parts/bodies/visual-story-body.ts
+++ b/prismic-model/src/parts/bodies/visual-story-body.ts
@@ -1,8 +1,8 @@
 import body, { slice } from './body';
-import boolean from './boolean';
-import { documentLink } from './link';
-import { multiLineText, singleLineText } from './text';
-import { textAndIconsSlice } from './textAndIcons';
+import boolean from '../boolean';
+import { documentLink } from '../link';
+import { multiLineText, singleLineText } from '../text';
+import { textAndIconsSlice } from '../textAndIcons';
 
 export default {
   fieldset: 'Slice zone',

--- a/prismic-model/src/parts/textAndIcons.ts
+++ b/prismic-model/src/parts/textAndIcons.ts
@@ -1,5 +1,5 @@
 import { multiLineText } from './text';
-import { slice } from './body';
+import { slice } from './bodies/body';
 
 export const textAndIconsSlice = () => {
   return slice('Text and icons', {

--- a/prismic-model/src/parts/textAndIcons.ts
+++ b/prismic-model/src/parts/textAndIcons.ts
@@ -1,8 +1,8 @@
 import { multiLineText } from './text';
-import { slice } from './bodies/body';
+import { body } from './bodies';
 
 export const textAndIconsSlice = () => {
-  return slice('Text and icons', {
+  return body.slice('Text and icons', {
     description: 'Side-by-side',
     nonRepeat: {
       text: multiLineText('Text', { extraTextOptions: ['heading3'] }),

--- a/prismic-model/src/parts/textAndIcons.ts
+++ b/prismic-model/src/parts/textAndIcons.ts
@@ -1,8 +1,8 @@
 import { multiLineText } from './text';
-import { body } from './bodies';
+import { slice } from './bodies/body';
 
 export const textAndIconsSlice = () => {
-  return body.slice('Text and icons', {
+  return slice('Text and icons', {
     description: 'Side-by-side',
     nonRepeat: {
       text: multiLineText('Text', { extraTextOptions: ['heading3'] }),

--- a/prismic-model/src/places.ts
+++ b/prismic-model/src/places.ts
@@ -1,7 +1,7 @@
 import title from './parts/title';
 import geolocation from './parts/geolocation';
 import number from './parts/number';
-import body from './parts/bodies/body';
+import { body } from './parts/bodies';
 import { multiLineText } from './parts/text';
 import { CustomType } from './types/CustomType';
 

--- a/prismic-model/src/places.ts
+++ b/prismic-model/src/places.ts
@@ -1,7 +1,7 @@
 import title from './parts/title';
 import geolocation from './parts/geolocation';
 import number from './parts/number';
-import body from './parts/body';
+import body from './parts/bodies/body';
 import { multiLineText } from './parts/text';
 import { CustomType } from './types/CustomType';
 

--- a/prismic-model/src/projects.ts
+++ b/prismic-model/src/projects.ts
@@ -1,5 +1,5 @@
 import title from './parts/title';
-import body from './parts/body';
+import body from './parts/bodies/body';
 import promo from './parts/promo';
 import { singleLineText } from './parts/text';
 import contributorsWithTitle from './parts/contributorsWithTitle';

--- a/prismic-model/src/projects.ts
+++ b/prismic-model/src/projects.ts
@@ -1,5 +1,5 @@
 import title from './parts/title';
-import body from './parts/bodies/body';
+import { body } from './parts/bodies';
 import promo from './parts/promo';
 import { singleLineText } from './parts/text';
 import contributorsWithTitle from './parts/contributorsWithTitle';

--- a/prismic-model/src/seasons.ts
+++ b/prismic-model/src/seasons.ts
@@ -1,6 +1,6 @@
 import title from './parts/title';
 import promo from './parts/promo';
-import body from './parts/body';
+import body from './parts/bodies/body';
 import timestamp from './parts/timestamp';
 import { CustomType } from './types/CustomType';
 

--- a/prismic-model/src/seasons.ts
+++ b/prismic-model/src/seasons.ts
@@ -1,6 +1,6 @@
 import title from './parts/title';
 import promo from './parts/promo';
-import body from './parts/bodies/body';
+import { body } from './parts/bodies';
 import timestamp from './parts/timestamp';
 import { CustomType } from './types/CustomType';
 

--- a/prismic-model/src/series.ts
+++ b/prismic-model/src/series.ts
@@ -1,6 +1,6 @@
 import title from './parts/title';
 import promo from './parts/promo';
-import body from './parts/bodies/body';
+import { body } from './parts/bodies';
 import contributorsWithTitle from './parts/contributorsWithTitle';
 import list from './parts/list';
 import select from './parts/select';

--- a/prismic-model/src/series.ts
+++ b/prismic-model/src/series.ts
@@ -1,6 +1,6 @@
 import title from './parts/title';
 import promo from './parts/promo';
-import body from './parts/body';
+import body from './parts/bodies/body';
 import contributorsWithTitle from './parts/contributorsWithTitle';
 import list from './parts/list';
 import select from './parts/select';

--- a/prismic-model/src/visual-stories.ts
+++ b/prismic-model/src/visual-stories.ts
@@ -1,6 +1,6 @@
 import title from './parts/title';
 import promo from './parts/promo';
-import visualStoryBody from './parts/bodies/visual-story-body';
+import { visualStoryBody } from './parts/bodies';
 import timestamp from './parts/timestamp';
 import boolean from './parts/boolean';
 import { CustomType } from './types/CustomType';

--- a/prismic-model/src/visual-stories.ts
+++ b/prismic-model/src/visual-stories.ts
@@ -1,6 +1,6 @@
 import title from './parts/title';
 import promo from './parts/promo';
-import visualStoryBody from './parts/visual-story-body';
+import visualStoryBody from './parts/bodies/visual-story-body';
 import timestamp from './parts/timestamp';
 import boolean from './parts/boolean';
 import { CustomType } from './types/CustomType';

--- a/prismic-model/src/webcomics.ts
+++ b/prismic-model/src/webcomics.ts
@@ -2,7 +2,7 @@ import title from './parts/title';
 import list from './parts/list';
 import { documentLink } from './parts/link';
 import promo from './parts/promo';
-import articleBody from './parts/article-body';
+import articleBody from './parts/bodies/article-body';
 import contributorsWithTitle from './parts/contributorsWithTitle';
 import { singleLineText } from './parts/text';
 import { CustomType } from './types/CustomType';

--- a/prismic-model/src/webcomics.ts
+++ b/prismic-model/src/webcomics.ts
@@ -2,7 +2,7 @@ import title from './parts/title';
 import list from './parts/list';
 import { documentLink } from './parts/link';
 import promo from './parts/promo';
-import articleBody from './parts/bodies/article-body';
+import { articleBody } from './parts/bodies';
 import contributorsWithTitle from './parts/contributorsWithTitle';
 import { singleLineText } from './parts/text';
 import { CustomType } from './types/CustomType';


### PR DESCRIPTION
## Who is this for?
Devs, maintenance

## What is it doing for them?
Relates to #10122

- Gets content types straight from Prismic instead of using the snapshots one - this way it lists them even if there is 0 instances.
- Gets visual stories body slices too. I moved all the "body" files to one folder and added a comment requesting to add it to the analysis script if ever there was a new one. I couldn't find how to get them from Prismic as they are custom, if anyone has a better idea, do let me know as I know this is a bit of a plaster!

I also decided to align `sliceAnalysis` with `contentAnalysis` and add the capacity for a URL being added to the output + a report. I find this really useful when doing audits and thought others might too.