### PR TITLE
Don't apply border radius to caption container

### DIFF
--- a/content/webapp/components/CaptionedImage/CaptionedImage.tsx
+++ b/content/webapp/components/CaptionedImage/CaptionedImage.tsx
@@ -43,7 +43,7 @@ const ImageContainerInner = styled.div<ImageContainerInnerProps>`
   ${props =>
     props.hasRoundedCorners &&
     `
-    > div {
+    > div:first-child {
       border-radius:  clamp(10px, 2vw, 26px);
       overflow: hidden;
     }


### PR DESCRIPTION
☝️ 

__before__
<img width="682" alt="Screenshot 2023-08-23 at 14 16 59" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/1394592/689999ec-7350-4c08-8e52-d3c323629add">

__after__
<img width="701" alt="Screenshot 2023-08-23 at 14 16 34" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/1394592/8961449a-07cb-47d4-9c9c-de7e14005973">

From [Slack conversation](https://wellcome.slack.com/archives/C8X9YKM5X/p1692796022655459)