### PR TITLE
All past event series

### DIFF
--- a/content/webapp/pages/event-series/[eventSeriesId].tsx
+++ b/content/webapp/pages/event-series/[eventSeriesId].tsx
@@ -53,8 +53,7 @@ function getPastEvents(
         ...b.times.map(bTime => bTime.range.startDateTime.valueOf())
       );
       return bStartTime - aStartTime;
-    })
-    .slice(0, 3);
+    });
 }
 
 export const getServerSideProps: GetServerSideProps<

--- a/content/webapp/utils/event-series.test.ts
+++ b/content/webapp/utils/event-series.test.ts
@@ -1,5 +1,5 @@
 import { HasTimes } from '@weco/content/types/events';
-import { getUpcomingEvents, isUpcoming } from './event-series';
+import { isUpcoming } from './event-series';
 import * as dateUtils from '@weco/common/utils/dates';
 
 function createEvent({
@@ -75,58 +75,5 @@ describe('isUpcoming', () => {
     });
 
     expect(isUpcoming(event)).toBeTruthy();
-  });
-});
-
-describe('getUpcomingEvents', () => {
-  it('picks out events that start after today', () => {
-    const events = [
-      { id: '2100', startDateTime: new Date(2100, 1, 1, 0, 0, 0) },
-      { id: '2001', startDateTime: new Date(2001, 1, 1, 0, 0, 0) },
-      { id: '2200', startDateTime: new Date(2200, 1, 1, 0, 0, 0) },
-    ].map(({ id, startDateTime }) => ({
-      id,
-      ...createEvent({ startDateTime, endDateTime: startDateTime }),
-    }));
-
-    const upcomingEvents = getUpcomingEvents(events);
-
-    expect(upcomingEvents.map(ev => ev.id)).toEqual(['2100', '2200']);
-  });
-
-  it('sorts upcoming events by their start date', () => {
-    const january = new Date(2100, 1, 1, 0, 0, 0);
-    const february = new Date(2100, 2, 1, 0, 0, 0);
-    const march = new Date(2100, 3, 1, 0, 0, 0);
-    const april = new Date(2100, 4, 1, 0, 0, 0);
-
-    const events = [
-      { id: 'jan', startDateTime: january },
-      { id: 'mar', startDateTime: march },
-      { id: 'feb', startDateTime: february },
-    ].map(({ id, startDateTime }) => ({
-      id,
-      ...createEvent({ startDateTime, endDateTime: april }),
-    }));
-
-    const upcomingEvents = getUpcomingEvents(events);
-
-    expect(upcomingEvents.map(ev => ev.id)).toEqual(['jan', 'feb', 'mar']);
-  });
-
-  it('includes an event as upcoming if a multi-day event hasn’t finished yet', () => {
-    const pastDate = new Date(2001, 3, 25, 16, 30, 0);
-    const futureDate = new Date(2100, 3, 25, 17, 30);
-
-    const events = [
-      {
-        id: 'my-long-running-event',
-        ...createEvent({ startDateTime: pastDate, endDateTime: futureDate }),
-      },
-    ];
-
-    const upcomingEvents = getUpcomingEvents(events);
-
-    expect(upcomingEvents.map(ev => ev.id)).toEqual(['my-long-running-event']);
   });
 });

--- a/content/webapp/utils/event-series.ts
+++ b/content/webapp/utils/event-series.ts
@@ -4,19 +4,3 @@ import { HasTimes } from '@weco/content/types/events';
 export function isUpcoming<T extends HasTimes>(event: T): boolean {
   return event.times.some(t => isFuture(t.range.endDateTime));
 }
-
-// Returns all the upcoming events from a given list.
-//
-// This is used to populate the "Coming up" list on event series pages.
-//
-export function getUpcomingEvents<T extends HasTimes>(events: T[]): T[] {
-  return events.filter(isUpcoming).sort((a, b) => {
-    const aStartTime = Math.min(
-      ...a.times.map(aTime => aTime.range.startDateTime.valueOf())
-    );
-    const bStartTime = Math.min(
-      ...b.times.map(bTime => bTime.range.startDateTime.valueOf())
-    );
-    return aStartTime - bStartTime;
-  });
-}


### PR DESCRIPTION
For #10131 

## Who is this for?
People who want to be able to see all past event-series events

## What is it doing for them?
Paginating them by 20

An event-series with more than 20 past events is 'Exploring research': `/event-series/W5Zj_CYAACQALK5B`

Previously, we were getting event-series events and then working out which were past and which were upcoming using our own logic. Now, we're querying Prismic using date filters (so the logic that was being tested is no longer in use, so I got rid of it). This does mean there's an extra query (promisified) to Prismic for these pages.

<img width="915" alt="image" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/1394592/85e21e7c-bb05-46d3-8a02-ad7e7c2018d5">
