### PR TITLE
remove fetch-links related to exhibition resources

### DIFF
--- a/content/webapp/services/prismic/fetch-links.ts
+++ b/content/webapp/services/prismic/fetch-links.ts
@@ -20,9 +20,4 @@ export const eventAccessOptionsFields = [
   'event-access-options.description',
   'event-access-options.description',
 ];
-export const exhibitionResourcesFields = [
-  'exhibition-resources.title',
-  'exhibition-resources.description',
-  'exhibition-resources.icon',
-];
 export const labelsFields = ['labels.title', 'labels.description'];

--- a/content/webapp/services/prismic/fetch/exhibitions.ts
+++ b/content/webapp/services/prismic/fetch/exhibitions.ts
@@ -13,7 +13,6 @@ import * as prismic from '@prismicio/client';
 import { PagePrismicDocument } from '../types/pages';
 import {
   eventAccessOptionsFields,
-  exhibitionResourcesFields,
 } from '../fetch-links';
 import { Period } from '@weco/common/types/periods';
 import { getExhibitionPeriodFilters } from '../types/filters';
@@ -46,7 +45,6 @@ const fetchLinks = [
   ...exhibitionsFetchLinks,
   ...contributorFetchLinks,
   ...placesFetchLinks,
-  ...exhibitionResourcesFields,
   ...eventSeriesFetchLinks,
   ...articlesFetchLinks,
   ...eventsFetchLinks,


### PR DESCRIPTION
Relates to #10041 

#10121 stopped us rendering the resource fields on an exhibition.

This PR stops removes the fetch-links related to those fields, before we remove them from Prismic.
