### PR TITLE
Replace resources from model

### DIFF
--- a/prismic-model/src/exhibitions.ts
+++ b/prismic-model/src/exhibitions.ts
@@ -2,9 +2,9 @@ import title from './parts/title';
 import promo from './parts/promo';
 import timestamp from './parts/timestamp';
 import place from './parts/place';
-import { documentLink } from './parts/link';
+import { documentLink, mediaLink } from './parts/link';
 import list from './parts/list';
-import { singleLineText } from './parts/text';
+import { singleLineText, multiLineText } from './parts/text';
 import contributorsWithTitle from './parts/contributorsWithTitle';
 import body from './parts/body';
 import booleanDeprecated from './parts/boolean-deprecated';
@@ -45,12 +45,11 @@ const exhibitions: CustomType = {
         item: documentLink('Article', { linkedType: 'articles' }),
       }),
     },
-    Resources: {
-      resources: list('Resources', {
-        resource: documentLink('Resource', {
-          linkedType: 'exhibition-resources',
-        }),
+    'Access content': {
+      pdfs: list('Exhibition pdfs', {
+        pdf: mediaLink('Pdf'),
       }),
+      accompanyingText: multiLineText('Accompanying text and links'),
     },
     Contributors: contributorsWithTitle(),
     Promo: {

--- a/prismic-model/src/visual-stories.ts
+++ b/prismic-model/src/visual-stories.ts
@@ -3,6 +3,7 @@ import promo from './parts/promo';
 import visualStoryBody from './parts/visual-story-body';
 import timestamp from './parts/timestamp';
 import boolean from './parts/boolean';
+import { documentLink } from './parts/link';
 import { CustomType } from './types/CustomType';
 
 const visualStories: CustomType = {
@@ -13,6 +14,9 @@ const visualStories: CustomType = {
   json: {
     Main: {
       title,
+      'related-exhibition': documentLink('Related Exhibition', {
+        linkedType: 'exhibitions',
+      }),
       datePublished: timestamp('Date published'),
       showOnThisPage: boolean(
         "Show 'On this page' anchor links. This will only appear if there are more than 2 H2s in the body",


### PR DESCRIPTION
Relates to #10041

This replaces the fields in the Resources tab for an exhibition with the fields we need to render the access content as per the new designs: https://github.com/wellcomecollection/wellcomecollection.org/issues/9978

MUST DEPLOY #10160 FIRST
