### PR TITLE
Flex gap

### DIFF
--- a/common/views/components/AudioPlayer/AudioPlayer.PlayRate.tsx
+++ b/common/views/components/AudioPlayer/AudioPlayer.PlayRate.tsx
@@ -3,12 +3,17 @@ import styled from 'styled-components';
 import { AppContext } from '../AppContext/AppContext';
 import { trackGaEvent } from '@weco/common/utils/ga';
 import { font } from '@weco/common/utils/classnames';
+import Space from '../styled/Space';
 
-const PlayRateWrapper = styled.div.attrs({
+const PlayRateWrapper = styled(Space).attrs({
+  h: {
+    size: 'xs',
+    properties: ['column-gap'],
+    overrides: { medium: 1, large: 1 },
+  },
   className: font('intr', 6),
 })`
   display: flex;
-  gap: 5px;
 `;
 
 const PlayRateRadio = styled.input.attrs({

--- a/common/views/components/AudioPlayer/AudioPlayer.Volume.tsx
+++ b/common/views/components/AudioPlayer/AudioPlayer.Volume.tsx
@@ -4,11 +4,17 @@ import { trackGaEvent } from '@weco/common/utils/ga';
 import Icon from '../Icon/Icon';
 import { volumeMuted, volume as volumeIcon } from '@weco/common/icons';
 import { formatVolume } from './AudioPlayer.formatters';
+import Space from '../styled/Space';
 
-const VolumeWrapper = styled.div`
+const VolumeWrapper = styled(Space).attrs({
+  h: {
+    size: 'xs',
+    properties: ['column-gap'],
+    overrides: { medium: 1, large: 1 },
+  },
+})`
   display: flex;
   align-items: center;
-  gap: 5px;
 
   input {
     width: 60px;

--- a/common/views/components/AudioPlayer/AudioPlayer.tsx
+++ b/common/views/components/AudioPlayer/AudioPlayer.tsx
@@ -37,11 +37,17 @@ const PlayPauseInner = styled.div`
   justify-content: center;
 `;
 
-const AudioPlayerGrid = styled.div`
+const AudioPlayerGrid = styled(Space).attrs({
+  h: { size: 's', properties: ['row-gap'], overrides: { medium: 2, large: 2 } },
+  v: {
+    size: 's',
+    properties: ['column-gap'],
+    overrides: { medium: 2, large: 2 },
+  },
+})`
   display: grid;
   grid-template-columns: auto 1fr auto;
   align-items: center;
-  gap: 5px;
 `;
 
 const SecondRow = styled.div`

--- a/common/views/components/styled/PlainList.tsx
+++ b/common/views/components/styled/PlainList.tsx
@@ -1,9 +1,13 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
-const PlainList = styled.ul`
+export const plainListStyles = css`
   list-style: none;
   margin: 0 !important;
   padding: 0;
+`;
+
+const PlainList = styled.ul`
+  ${plainListStyles};
 `;
 
 export default PlainList;

--- a/content/webapp/components/ExhibitionGuideLinks/ExhibitionGuideLinks.tsx
+++ b/content/webapp/components/ExhibitionGuideLinks/ExhibitionGuideLinks.tsx
@@ -8,15 +8,19 @@ import {
 } from '@weco/common/icons';
 import TypeOption from './TypeOption';
 import cookies from '@weco/common/data/cookies';
-import PlainList from '@weco/common/views/components/styled/PlainList';
+import { plainListStyles } from '@weco/common/views/components/styled/PlainList';
+import Space from '@weco/common/views/components/styled/Space';
 
-const TypeList = styled(PlainList)`
-  display: flex;
-  flex-wrap: wrap;
-  gap: 20px;
+const TypeList = styled(Space).attrs({
+  v: { size: 'l', properties: ['row-gap'] },
+  h: { size: 'l', properties: ['column-gap'] },
+})`
+  ${plainListStyles};
+  display: grid;
+
   ${props => props.theme.media('medium')`
-    gap: 50px;
-`}
+    grid-template-columns: 1fr 1fr;
+  `}
 `;
 
 type Props = {

--- a/content/webapp/components/ItemRequestModal/RequestDialog.tsx
+++ b/content/webapp/components/ItemRequestModal/RequestDialog.tsx
@@ -19,10 +19,8 @@ import { themeValues } from '@weco/common/views/themes/config';
 import { dateAsValue, dateFromValue } from './format-date';
 
 const PickUpDate = styled(Space).attrs({
-  v: {
-    size: 'l',
-    properties: ['padding-top', 'padding-bottom'],
-  },
+  v: { size: 'l', properties: ['padding-top', 'padding-bottom'] },
+  h: { size: 'l', properties: ['column-gap'] },
 })`
   border-top: 1px solid ${props => props.theme.color('neutral.300')};
   border-bottom: 1px solid ${props => props.theme.color('neutral.300')};
@@ -30,7 +28,6 @@ const PickUpDate = styled(Space).attrs({
   @media (min-width: 800px) {
     display: flex;
     justify-content: space-between;
-    gap: 20px;
     min-width: min(80vw, 700px);
   }
 `;

--- a/content/webapp/components/TextAndImageOrIcons/TextAndImageOrIcons.tsx
+++ b/content/webapp/components/TextAndImageOrIcons/TextAndImageOrIcons.tsx
@@ -40,11 +40,13 @@ const DividingLine = styled.div`
   }
 `;
 
-const ImageOrIcons = styled.div<{ isIcons?: boolean; isPortrait?: boolean }>`
+const ImageOrIcons = styled(Space).attrs({
+  h: { size: 'm', properties: ['column-gap'] },
+  v: { size: 'm', properties: ['row-gap'] },
+})<{ isIcons?: boolean; isPortrait?: boolean }>`
   position: relative;
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
   justify-content: center;
   flex: 0 0
     ${props => (props.isIcons || props.isPortrait ? 'max(60%, 300px)' : '100%')};

--- a/content/webapp/components/TextAndImageOrIcons/TextAndImageOrIcons.tsx
+++ b/content/webapp/components/TextAndImageOrIcons/TextAndImageOrIcons.tsx
@@ -6,10 +6,13 @@ import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/Pri
 import * as prismic from '@prismicio/client';
 import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImage';
 import { defaultSerializer } from '../HTMLSerializers/HTMLSerializers';
+import Space from '@weco/common/views/components/styled/Space';
 
-const MediaAndTextWrap = styled.div`
+const MediaAndTextWrap = styled(Space).attrs({
+  h: { size: 'l', properties: ['column-gap'] },
+  v: { size: 'l', properties: ['row-gap'] },
+})`
   display: flex;
-  gap: 20px;
   flex-wrap: wrap;
   align-items: flex-start;
   justify-content: center;


### PR DESCRIPTION
## Who is this for?
People who like consistent responsive spacing.

## What is it doing for them?
Using the new(ish) `gap` properties that `Space` now accepts, instead of the hard-coded `gap` values we had in a few places.

Note, I decided not to touch the styles in the identity app, because they don't play by many of the rules in the first place, and are probably due for a complete overhaul at some point.