### PR TITLE
Pick some low-hanging fruit to reduce the size of our Next.js props

### DIFF
--- a/content/webapp/components/IIIFViewer/IIIFViewer.tsx
+++ b/content/webapp/components/IIIFViewer/IIIFViewer.tsx
@@ -6,13 +6,13 @@ import {
   useContext,
 } from 'react';
 import styled from 'styled-components';
-import { Manifest } from '@iiif/presentation-3';
 import { DigitalLocation } from '@weco/common/model/catalogue';
 import { WorkBasic } from '@weco/content/services/wellcome/catalogue/types';
 import ViewerSidebar from './ViewerSidebar';
 import MainViewer from './MainViewer';
 import ViewerTopBar from './ViewerTopBar';
 import ItemViewerContext, {
+  ParentManifest,
   RotatedImage,
 } from '../ItemViewerContext/ItemViewerContext';
 import { useRouter } from 'next/router';
@@ -39,7 +39,7 @@ type IIIFViewerProps = {
   handleImageError?: () => void;
   searchResults: SearchResults | null;
   setSearchResults: (v) => void;
-  parentManifest?: Manifest;
+  parentManifest?: ParentManifest;
 };
 
 const LoadingComponent = () => (

--- a/content/webapp/components/IIIFViewer/IIIFViewer.tsx
+++ b/content/webapp/components/IIIFViewer/IIIFViewer.tsx
@@ -7,7 +7,10 @@ import {
 } from 'react';
 import styled from 'styled-components';
 import { DigitalLocation } from '@weco/common/model/catalogue';
-import { WorkBasic } from '@weco/content/services/wellcome/catalogue/types';
+import {
+  Work,
+  WorkBasic,
+} from '@weco/content/services/wellcome/catalogue/types';
 import ViewerSidebar from './ViewerSidebar';
 import MainViewer from './MainViewer';
 import ViewerTopBar from './ViewerTopBar';
@@ -31,7 +34,7 @@ import { NoScriptImage } from '@weco/content/components/IIIFViewer/NoScriptImage
 import { queryParamToArrayIndex, DelayVisibility } from '.';
 
 type IIIFViewerProps = {
-  work: WorkBasic;
+  work: WorkBasic & Pick<Work, 'description'>;
   iiifImageLocation?: DigitalLocation;
   iiifPresentationLocation?: DigitalLocation;
   transformedManifest?: TransformedManifest;

--- a/content/webapp/components/IIIFViewer/MultipleManifestList.tsx
+++ b/content/webapp/components/IIIFViewer/MultipleManifestList.tsx
@@ -3,10 +3,7 @@ import NextLink from 'next/link';
 import { toLink as itemLink } from '../ItemLink';
 import ItemViewerContext from '../ItemViewerContext/ItemViewerContext';
 import { volumesNavigationLabel } from '@weco/common/text/aria-labels';
-import {
-  getMultiVolumeLabel,
-  getCollectionManifests,
-} from '@weco/content/utils/iiif/v3';
+import { getMultiVolumeLabel } from '@weco/content/utils/iiif/v3';
 import { queryParamToArrayIndex } from '.';
 import {
   List,
@@ -16,9 +13,7 @@ import {
 const MultipleManifestList: FunctionComponent = () => {
   const { parentManifest, work, query, setIsMobileSidebarActive } =
     useContext(ItemViewerContext);
-  const manifests = parentManifest
-    ? getCollectionManifests(parentManifest)
-    : [];
+  const manifests = parentManifest?.canvases || [];
 
   return (
     <nav>

--- a/content/webapp/components/IIIFViewer/MultipleManifestList.tsx
+++ b/content/webapp/components/IIIFViewer/MultipleManifestList.tsx
@@ -53,7 +53,7 @@ const MultipleManifestList: FunctionComponent = () => {
                   setIsMobileSidebarActive(false);
                 }}
               >
-                {(manifest?.label &&
+                {(manifest.label &&
                   getMultiVolumeLabel(manifest.label, work?.title || '')) ||
                   'Unknown'}
               </a>

--- a/content/webapp/components/IIIFViewer/ViewerSidebar.tsx
+++ b/content/webapp/components/IIIFViewer/ViewerSidebar.tsx
@@ -21,10 +21,7 @@ import IIIFSearchWithin from '../IIIFSearchWithin/IIIFSearchWithin';
 import WorkTitle from '../WorkTitle/WorkTitle';
 import { toHtmlId } from '@weco/common/utils/string';
 import { arrow, chevron } from '@weco/common/icons';
-import {
-  getMultiVolumeLabel,
-  getCollectionManifests,
-} from '@weco/content/utils/iiif/v3';
+import { getMultiVolumeLabel } from '@weco/content/utils/iiif/v3';
 import { OptionalToUndefined } from '@weco/common/utils/utility-types';
 
 const Inner = styled(Space).attrs({
@@ -137,14 +134,16 @@ const ViewerSidebar: FunctionComponent<ViewerSidebarProps> = ({
   const { work, transformedManifest, parentManifest } =
     useContext(ItemViewerContext);
 
-  const matchingManifest = parentManifest && getCollectionManifests(parentManifest).find(canvas => {
-    return !transformedManifest
-      ? false
-      : canvas.id === transformedManifest.id;
-  });
+  const matchingManifest =
+    parentManifest &&
+    parentManifest.canvases.find(canvas => {
+      return !transformedManifest
+        ? false
+        : canvas.id === transformedManifest.id;
+    });
 
   const manifestLabel =
-  matchingManifest?.label &&
+    matchingManifest?.label &&
     getMultiVolumeLabel(matchingManifest.label, work?.title || '');
 
   const { iiifCredit, structures, searchService } = { ...transformedManifest };
@@ -246,9 +245,15 @@ const ViewerSidebar: FunctionComponent<ViewerSidebarProps> = ({
             <ViewerStructures />
           </AccordionItem>
         )}
+        {/* 
+          Note: this check for `behavior === 'multi-part'` is repeated in items.tsx to
+          avoid sending unnecessary data about parent manifests that we're not going
+          to render.  If you change the display condition here, you'll likely want to
+          update it there also.
+        */}
         {parentManifest &&
           parentManifest.behavior?.[0] === 'multi-part' &&
-          parentManifest.items && (
+          parentManifest.canvases && (
             <AccordionItem title="Volumes">
               <MultipleManifestList />
             </AccordionItem>

--- a/content/webapp/components/ItemViewerContext/ItemViewerContext.tsx
+++ b/content/webapp/components/ItemViewerContext/ItemViewerContext.tsx
@@ -1,7 +1,7 @@
 import { createContext, RefObject } from 'react';
 import { WorkBasic } from '@weco/content/services/wellcome/catalogue/types';
 import { SearchResults } from '@weco/content/services/iiif/types/search/v3';
-import { Manifest } from '@iiif/presentation-3';
+import { Canvas, Manifest } from '@iiif/presentation-3';
 import { TransformedManifest } from '../../types/manifest';
 
 export type RotatedImage = { canvas: number; rotation: number };
@@ -14,12 +14,16 @@ export type Query = {
   shouldScrollToCanvas: boolean;
 };
 
+export type ParentManifest = Pick<Manifest, 'behavior'> & {
+  canvases: Pick<Canvas, 'id' | 'label'>[];
+};
+
 type Props = {
   // DATA props:
   query: Query;
   work: WorkBasic;
   transformedManifest: TransformedManifest | undefined;
-  parentManifest: Manifest | undefined;
+  parentManifest: ParentManifest | undefined;
   searchResults: SearchResults | null;
   setSearchResults: (v) => void;
 

--- a/content/webapp/components/ItemViewerContext/ItemViewerContext.tsx
+++ b/content/webapp/components/ItemViewerContext/ItemViewerContext.tsx
@@ -1,5 +1,8 @@
 import { createContext, RefObject } from 'react';
-import { WorkBasic } from '@weco/content/services/wellcome/catalogue/types';
+import {
+  Work,
+  WorkBasic,
+} from '@weco/content/services/wellcome/catalogue/types';
 import { SearchResults } from '@weco/content/services/iiif/types/search/v3';
 import { Canvas, Manifest } from '@iiif/presentation-3';
 import { TransformedManifest } from '../../types/manifest';
@@ -21,7 +24,7 @@ export type ParentManifest = Pick<Manifest, 'behavior'> & {
 type Props = {
   // DATA props:
   query: Query;
-  work: WorkBasic;
+  work: WorkBasic & Pick<Work, 'description'>;
   transformedManifest: TransformedManifest | undefined;
   parentManifest: ParentManifest | undefined;
   searchResults: SearchResults | null;
@@ -71,7 +74,7 @@ const query = {
   shouldScrollToCanvas: true,
 };
 
-const work: WorkBasic = {
+const work: WorkBasic & Pick<Work, 'description'> = {
   id: '',
   title: '',
   description: undefined,

--- a/content/webapp/pages/works/[workId]/download.tsx
+++ b/content/webapp/pages/works/[workId]/download.tsx
@@ -63,7 +63,10 @@ const Credit: FunctionComponent<CreditProps> = ({
 };
 
 type Props = {
-  transformedManifest?: TransformedManifest;
+  transformedManifest?: Pick<
+    TransformedManifest,
+    'title' | 'downloadEnabled' | 'downloadOptions' | 'iiifCredit'
+  >;
   work: Work;
 };
 
@@ -89,10 +92,10 @@ const DownloadPage: NextPage<Props> = ({ transformedManifest, work }) => {
 
   const iiifImageDownloadOptions = iiifImageLocationUrl
     ? getDownloadOptionsFromImageUrl({
-      url: iiifImageLocationUrl,
-      width: undefined,
-      height: undefined,
-    })
+        url: iiifImageLocationUrl,
+        width: undefined,
+        height: undefined,
+      })
     : [];
 
   const allDownloadOptions = [
@@ -208,7 +211,12 @@ export const getServerSideProps: GetServerSideProps<
     props: serialiseProps({
       serverData,
       workId,
-      transformedManifest,
+      transformedManifest: transformedManifest && {
+        title: transformedManifest.title,
+        downloadEnabled: transformedManifest.downloadEnabled,
+        downloadOptions: transformedManifest.downloadOptions,
+        iiifCredit: transformedManifest.iiifCredit,
+      },
       work,
     }),
   };

--- a/content/webapp/pages/works/[workId]/items.tsx
+++ b/content/webapp/pages/works/[workId]/items.tsx
@@ -490,7 +490,6 @@ export const getServerSideProps: GetServerSideProps<
         compressedTransformedManifest:
           toCompressedTransformedManifest(displayManifest),
         canvasOcr,
-        work: toWorkBasic(work),
         canvas,
         iiifImageLocation,
         iiifPresentationLocation,
@@ -498,6 +497,14 @@ export const getServerSideProps: GetServerSideProps<
         pageview,
         serverData,
         serverSearchResults,
+        // Note: the `description` field on works can be large, which is why we omit it
+        // from the standard WorkBasic model.  We include it here because we use it for
+        // alt text in the IIIFViewer component, but we don't want it in other places
+        // where we use WorkBasic.
+        work: {
+          ...toWorkBasic(work),
+          description: work.description,
+        },
         // Note: the parentManifest data can be enormous; for /works/cf4mdjzg/items it's
         // over 12MB in size (!).
         //

--- a/content/webapp/services/wellcome/catalogue/types/work.ts
+++ b/content/webapp/services/wellcome/catalogue/types/work.ts
@@ -12,7 +12,6 @@ import { OptionalToUndefined } from '@weco/common/utils/utility-types';
 export type WorkBasic = OptionalToUndefined<{
   id: string;
   title: string;
-  description?: string;
   languageId?: string;
   thumbnail?: DigitalLocation;
   referenceNumber?: string;
@@ -23,7 +22,7 @@ export type WorkBasic = OptionalToUndefined<{
 }>;
 
 export function toWorkBasic(work: Work): WorkBasic {
-  const { id, title, description, thumbnail, referenceNumber } = work;
+  const { id, title, thumbnail, referenceNumber } = work;
 
   // We only send a lang if it's unambiguous -- better to send
   // no language than the wrong one.
@@ -35,7 +34,6 @@ export function toWorkBasic(work: Work): WorkBasic {
   return {
     id,
     title,
-    description,
     thumbnail,
     referenceNumber,
     languageId,

--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -506,7 +506,7 @@ export function groupStructures(
   ).groupedArray;
 }
 
-export function getCollectionManifests(manifest: Manifest) {
+export function getCollectionManifests(manifest: Manifest): Canvas[] {
   const firstLevelManifests =
     manifest.items?.filter(c => c.type === 'Manifest') || [];
   const collections =


### PR DESCRIPTION
I'm seeing a lot of warnings in the catalogue app logs about "page data is too large". I suspect this may be related to the weekend's outages; even if it isn't, this is a useful optimisation and will make the site load faster.

There are three changes here:

1. **Only send the subset of manifest fields we use on the download page.** Previously we were sending the entire IIIF manifest, but we only use four fields – in particular we don't need the list of individual images/canvases, which can be very large. Now we only send the fields we're using on that page.

    Using `/works/rbtxk55p/download` as an example:

    * Before = 307.34 kB
    * After  =  15.43 kB

    That's a ~95% saving in the size of the Next.js props.

2. **Don't send the list of parent manifests if we aren't going to render them.** Currently we send a complete list of parent manifests to the page, but we don't always render the multiple manifests list – it looks like e.g. some IIIF items can be in a collection, but we don't actually render it if the collection is too vague. Now we skip sending grhe list of parent manifests if we know we're not going to render it.

    Using `/works/cf4mdjzg/items` as an example:

    * Before = 12251.99 kB (that's not a typo, it's ~12 MB)
    * After  =    14.05 kB

    That's a ~99.9% saving in the size of the Next.js props.

3. **Don't include the description in WorkBasic by default.** These descriptions can be extremely long, and they're bloating the size of search result pages. The only reason they're on WorkBasic is because they're used for alt text in IIIFViewer, so let's change things up so we don't send description unless it's needed.

    Using `/search/works?query=copy%20url` as an example:

    * Before = 389.93 kB
    * After  =  18.35 kB

    That's a ~95% saving in the size of the Next.js props.
