### PR TITLE
We only need to send a WorkBasic on download pages

### DIFF
--- a/content/webapp/pages/works/[workId]/download.tsx
+++ b/content/webapp/pages/works/[workId]/download.tsx
@@ -214,7 +214,6 @@ export const getServerSideProps: GetServerSideProps<
   return {
     props: serialiseProps({
       serverData,
-      workId,
       transformedManifest: transformedManifest && {
         title: transformedManifest.title,
         downloadEnabled: transformedManifest.downloadEnabled,

--- a/content/webapp/pages/works/[workId]/download.tsx
+++ b/content/webapp/pages/works/[workId]/download.tsx
@@ -1,5 +1,9 @@
 import { FunctionComponent } from 'react';
-import { Work } from '@weco/content/services/wellcome/catalogue/types';
+import {
+  Work,
+  WorkBasic,
+  toWorkBasic,
+} from '@weco/content/services/wellcome/catalogue/types';
 import { font } from '@weco/common/utils/classnames';
 import {
   getDownloadOptionsFromImageUrl,
@@ -67,7 +71,7 @@ type Props = {
     TransformedManifest,
     'title' | 'downloadEnabled' | 'downloadOptions' | 'iiifCredit'
   >;
-  work: Work;
+  work: WorkBasic & Pick<Work, 'items'>;
 };
 
 const DownloadPage: NextPage<Props> = ({ transformedManifest, work }) => {
@@ -217,7 +221,10 @@ export const getServerSideProps: GetServerSideProps<
         downloadOptions: transformedManifest.downloadOptions,
         iiifCredit: transformedManifest.iiifCredit,
       },
-      work,
+      work: {
+        ...toWorkBasic(work),
+        items: work.items,
+      },
     }),
   };
 };

--- a/content/webapp/utils/works.ts
+++ b/content/webapp/utils/works.ts
@@ -121,7 +121,7 @@ export function getItemsByLocationType(
 }
 
 export function getDigitalLocationOfType(
-  work: Work,
+  work: Pick<Work, 'items'>,
   locationType: string
 ): DigitalLocation | undefined {
   const [location] = (work.items ?? [])


### PR DESCRIPTION
This is another easy win for page weight and trims the size of download pages with a lot of works in the archive tree.

Taking `/works/huyu25aj/download` as an extreme example:

* Before = 473.53 kB
* After  =   9.73 kB

That's a ~98% reduction in the size of the Next.js props.
