### PR TITLE
Expand the range of characters we consider 'unusual' for spam purposes

### DIFF
--- a/content/webapp/utils/spam-detector.test.ts
+++ b/content/webapp/utils/spam-detector.test.ts
@@ -4,6 +4,8 @@ describe('requests that probably aren’t spam', () => {
   test.each([
     { query: undefined },
     { query: 'history of play' },
+    // This is an example of real Chinese text in our catalogue
+    // See https://wellcomecollection.org/works/grgcnqwf
     { query: '生殖健康问题 Reproductive health matters' },
   ])(`$query`, ({ query }) => {
     expect(looksLikeSpam(query)).toBeFalsy();
@@ -15,6 +17,10 @@ describe('requests that probably are spam', () => {
     {
       query:
         '不用认真来找我们免费玩赌场游戏sketchy.xyz我们拥有所有最好的骗局和垃圾邮件我们非常值得信赖您可以完全关闭病毒检查程序',
+    },
+    {
+      query:
+        '\xE6\xBE\xB3\xE9\x97\xA8\xE8\xB6\xB3\xE7\x90\x83\xE5\x80\x8D\xE7\x8E\x87>>\xE5\xAE\x98\xE7\xBD\x9112345.com<<\xE6\xBE\xB3\xE9\x97\xA8\xE8\xB6\xB3\xE7\x90\x83\xE5\x8D\x9A\xE5\xBD\xA9\xE5\xAE\x98\xE6\x96\xB9\xE7\xBD\x91-\xE6\xBE\xB3\xE9\x97\xA8',
     },
   ])(`$query`, ({ query }) => {
     expect(looksLikeSpam(query)).toBeTruthy();

--- a/content/webapp/utils/spam-detector.ts
+++ b/content/webapp/utils/spam-detector.ts
@@ -60,10 +60,20 @@ const isUnusualCharacter = (c: string): boolean => {
     //
     // e.g. "我们" gets encoded as "æä»¬"
     //
-    code === 0xc2 || // Â
-    code === 0xc3 || // Ã
-    code === 0xe4 || // ä
-    code === 0xe5 || // å
+    // The choices here are loosely based on
+    // https://utf8-chartable.de/unicode-utf8-table.pl?start=28480&names=-&utf8=string-literal
+    // https://utf8-chartable.de/unicode-utf8-table.pl?start=38144&utf8=0x
+    //
+    code === 0xc2 ||
+    code === 0xc3 ||
+    (code >= 0xe4 && code <= 0xe9) ||
+    code === 0x80 ||
+    code === 0xb3 ||
+    code === 0xb6 ||
+    code === 0xbd ||
+    code === 0xbe ||
+    code === 0xbf ||
+    (code >= 0x94 && code <= 0x97) ||
     // This is based on the ranges for Han (Chinese) ideographs; see
     // this answer on Stack Overflow: https://stackoverflow.com/a/1366113/1558022
     //
@@ -89,6 +99,8 @@ const isUnusualCharacter = (c: string): boolean => {
 export const looksLikeSpam = (
   queryValue: string | string[] | undefined
 ): boolean => {
+  console.log(queryValue);
+
   if (isUndefined(queryValue)) {
     return false;
   }

--- a/content/webapp/utils/spam-detector.ts
+++ b/content/webapp/utils/spam-detector.ts
@@ -136,9 +136,6 @@ export const looksLikeSpam = (
   //    - Count the number of unusual characters in the query.
   //    - If it's higher than the threshold, mark the request as spam.
   //
-  // The threshold is significantly lower for users that self-identify as bots
-  // in their User-Agent header.
-  //
   // Implementation note: this check is somewhat expensive, so we skip running it
   // if the query is too short to exceed the threshold.
   const maxUnusualCharsAllowed = 25;


### PR DESCRIPTION
Honestly this is a total guess, but I saw some ultra-long queries that are evading our current spam filter and thought maybe making it more aggressive might be helpful as a way to reduce load on the API.