### PR TITLE
Add a toggle for disabling aggregations in search

### DIFF
--- a/content/webapp/pages/search/works.tsx
+++ b/content/webapp/pages/search/works.tsx
@@ -260,14 +260,16 @@ export const getServerSideProps: GetServerSideProps<
     };
   }
 
-  const aggregations = [
-    'workType',
-    'availabilities',
-    'genres.label',
-    'languages',
-    'subjects.label',
-    'contributors.agent.label',
-  ];
+  const aggregations = serverData.toggles.aggregationsInSearch
+    ? [
+      'workType',
+      'availabilities',
+      'genres.label',
+      'languages',
+      'subjects.label',
+      'contributors.agent.label',
+    ]
+    : [];
 
   const worksApiProps = {
     ...params,

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -49,6 +49,13 @@ const toggles = {
       type: 'permanent',
     },
     {
+      id: 'aggregationsInSearch',
+      title: 'Aggregations in search',
+      initialValue: true,
+      description: 'Whether to enable aggregations in search. Aggregations are an expensive part of the query, and they can be temporarily disabled if the API is having performance issues.',
+      type: 'permanent',
+    },
+    {
       id: 'worksTabbedNav',
       title: 'Works page: Tabbed navigation',
       initialValue: false,


### PR DESCRIPTION
It seems like the ongoing site flakiness is caused by expensive queries overloading the Elasticsearch cluster; the hope is that having a way to disable aggregations might alleviate some of the load.