### PR TITLE
Don't fail checking if we need to ask about e2es

### DIFF
--- a/.buildkite/e2e_on_pull_requests/check_if_we_need_to_ask.sh
+++ b/.buildkite/e2e_on_pull_requests/check_if_we_need_to_ask.sh
@@ -13,44 +13,84 @@
 set -o errexit
 set -o nounset
 
-GITHUB_API_TOKEN=$(aws secretsmanager get-secret-value \
-  --secret-id builds/github_wecobot/e2e_pull_request_labels \
-  | jq -r .SecretString)
-
-HAS_SKIP_E2E_LABEL=$(
-  curl -L \
-    -H 'Accept: application/vnd.github+json' \
-    -H "Authorization: Bearer $GITHUB_API_TOKEN" \
-    -H "X-GitHub-Api-Version: 2022-11-28" \
-    "https://api.github.com/repos/wellcomecollection/wellcomecollection.org/issues/$BUILDKITE_PULL_REQUEST/labels" \
-    | jq '. | map(select(.name == "e2es not required")) | length'
-)
-
-if (( HAS_SKIP_E2E_LABEL == 1 ))
+# Buildkite freezes all its environment variables at the point when
+# the build starts -- this means that if it starts building a commit
+# on a branch before there's a pull request created from that branch,
+# then this variable won't point to anything.
+#
+# In this case, we don't bother checking for labels on the PR --
+# we know there won't be any, as it's too soon.
+#
+# Additionally, we don't offer the option to skip e2es forever on
+# this PR -- we don't have enough information to apply the tag to
+# the PR yet.
+if [[ "$BUILDKITE_PULL_REQUEST" != "false" ]]
 then
-  exit 0
+  GITHUB_API_TOKEN=$(aws secretsmanager get-secret-value \
+    --secret-id builds/github_wecobot/e2e_pull_request_labels \
+    | jq -r .SecretString)
+
+  HAS_SKIP_E2E_LABEL=$(
+    curl -L \
+      -H 'Accept: application/vnd.github+json' \
+      -H "Authorization: Bearer $GITHUB_API_TOKEN" \
+      -H "X-GitHub-Api-Version: 2022-11-28" \
+      "https://api.github.com/repos/wellcomecollection/wellcomecollection.org/issues/$BUILDKITE_PULL_REQUEST/labels" \
+      | jq '. | map(select(.name == "e2es not required")) | length'
+  )
+
+  if (( HAS_SKIP_E2E_LABEL == 1 ))
+  then
+    exit 0
+  fi
 fi
 
-buildkite-agent pipeline upload << EOF
-- wait
+if [[ "$BUILDKITE_PULL_REQUEST" != "false" ]]
+then
+  buildkite-agent pipeline upload << EOF
+  - wait
 
-- input: "Do you want to run end-to-end tests on this pull request?"
-  key: "ask-user-if-should-run-e2es"
-  fields:
-    - select: "Run e2es?"
-      key: "should-run-e2es"
-      options:
-        - label: "Yes, run e2e tests now"
-          value: "yes"
-        - label: "Not now, maybe later"
-          value: "maybe-later"
-        - label: "No, not needed for this PR"
-          value: "no"
+  - input: "Do you want to run end-to-end tests on this pull request?"
+    key: "ask-user-if-should-run-e2es"
+    fields:
+      - select: "Run e2es?"
+        key: "should-run-e2es"
+        options:
+          - label: "Yes, run e2e tests now"
+            value: "yes"
+          - label: "Not now, maybe later"
+            value: "maybe-later"
+          - label: "No, not needed for this PR"
+            value: "no"
 
-- label: "Add steps for e2e tests (if necessary)"
-  command: ".buildkite/e2e_on_pull_requests/react_to_user_choice_about_e2e_on_pull_request.sh"
-  depends_on: "ask-user-if-should-run-e2es"
+  - label: "Add steps for e2e tests (if necessary)"
+    command: ".buildkite/e2e_on_pull_requests/react_to_user_choice_about_e2e_on_pull_request.sh"
+    depends_on: "ask-user-if-should-run-e2es"
 
-  agents:
-    queue: nano
+    agents:
+      queue: nano
 EOF
+else
+  buildkite-agent pipeline upload << EOF
+  - wait
+
+  - input: "Do you want to run end-to-end tests on this pull request?"
+    key: "ask-user-if-should-run-e2es"
+    fields:
+      - select: "Run e2es?"
+        key: "should-run-e2es"
+        options:
+          - label: "Yes, run e2e tests now"
+            value: "yes"
+          - label: "Not now, maybe later"
+            value: "maybe-later"
+
+  - label: "Add steps for e2e tests (if necessary)"
+    command: ".buildkite/e2e_on_pull_requests/react_to_user_choice_about_e2e_on_pull_request.sh"
+    depends_on: "ask-user-if-should-run-e2es"
+
+    agents:
+      queue: nano
+EOF
+fi
+


### PR DESCRIPTION
We can see problems with the e2e tests if Buildkite starts the build (locking in all the environment variables) before the user opens a pull request.  This can cause weird errors in the "check if we need to ask e2es" step in Buildkite, which is resolved if you push a new commit.

The particular error you see in Buildkite is:

    jq: error (at <stdin>:4): Cannot index string with string "name"

This error occurs when we call the GitHub API, looking for the "skip e2es" tag on the pull request.  In particular, we're calling the API with the variable `BUILDKITE_PULL_REQUEST=false`, and that's not a valid PR identifier, so the GitHub API returns an error that we fail to parse.

This issue occurs when Buildkite starts a build before the PR is created:

```mermaid
gantt
    dateFormat X
    axisFormat ""

    section Events
    User pushes branch        :des1, 1, 2
    Buildkite starts build    :des2, 2, 3
    BUILDKITE_PULL_REQUEST=false :des3, 2, 3

    User opens pull request   :des1, 3, 4
```

Retrying the step doesn't work, because those environment variables are locked in before the build gets created -- and before the PR exists.

This is what happens when Buildkite starts a build after the PR is created, or if you push a new commit on a branch:

```mermaid
gantt
    dateFormat X
    axisFormat ""

    section Events
    User pushes branch        :des1, 1, 2

    User opens pull request   :des1, 1, 2

    Buildkite starts build    :des2, 2, 3
    BUILDKITE_PULL_REQUEST=123 :des3, 2, 3
```

This patch checks to see if `BUILDKITE_PULL_REQUEST` is undefined, and if so it:

1. Doesn't bother looking for a "skip e2es" tag on the pull request
2. Doesn't offer the option to disable e2es on this PR forever, because it won't know which PR that should apply to