### PR TITLE
Transform exhibition

### DIFF
--- a/common/data/microcopy.tsx
+++ b/common/data/microcopy.tsx
@@ -149,3 +149,7 @@ export const searchPlaceholderText = {
   images: 'Search for images',
   works: 'Search the catalogue',
 };
+
+export const visualStoryLinkText = 'Explore information to help you plan and prepare for your visit';
+
+export const exhibitionGuideLinkText = 'Explore Audio description, British Sign Language and captions and transcripts';

--- a/common/services/prismic/link-resolver.ts
+++ b/common/services/prismic/link-resolver.ts
@@ -6,6 +6,7 @@ function linkResolver(doc: { id: string; type: string }): string {
   if (type === 'webcomics') return `/articles/${id}`;
   if (type === 'webcomic-series') return `/series/${id}`;
   if (type === 'exhibition-guides') return `/guides/exhibitions/${id}`;
+  if (type === 'visual-stories') return `/visual-stories/${id}`; // TODO will need redoing when we determine the final url structure for these
 
   if (isContentType(type)) {
     return `/${type}/${id}`;

--- a/content/webapp/components/Exhibition/Exhibition.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.tsx
@@ -42,7 +42,6 @@ import { EventBasic } from '../../types/events';
 import * as prismic from '@prismicio/client';
 import styled from 'styled-components';
 import { createScreenreaderLabel } from '@weco/common/utils/telephone-numbers';
-// TODO move to own component?
 import PlainList from '@weco/common/views/components/styled/PlainList';
 import { PaletteColor } from '@weco/common/views/themes/config';
 import Icon from '@weco/common/views/components/Icon/Icon';

--- a/content/webapp/components/Exhibition/Exhibition.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.tsx
@@ -5,6 +5,8 @@ import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
 import { getFeaturedMedia, getHeroPicture } from '../../utils/page-header';
 import DateRange from '@weco/common/views/components/DateRange/DateRange';
 import HTMLDate from '@weco/common/views/components/HTMLDate/HTMLDate';
+import { defaultSerializer } from '@weco/content/components/HTMLSerializers/HTMLSerializers';
+import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
 import StatusIndicator from '../../components/StatusIndicator/StatusIndicator';
 import InfoBox from '../InfoBox/InfoBox';
 import { font } from '@weco/common/utils/classnames';
@@ -35,12 +37,78 @@ import {
   Exhibition as ExhibitionType,
   ExhibitionAbout,
 } from '../../types/exhibitions';
-
+import { Link } from '../../types/link';
 import { EventBasic } from '../../types/events';
 import * as prismic from '@prismicio/client';
 import styled from 'styled-components';
-
 import { createScreenreaderLabel } from '@weco/common/utils/telephone-numbers';
+// TODO move to own component?
+import PlainList from '@weco/common/views/components/styled/PlainList';
+import { PaletteColor } from '@weco/common/views/themes/config';
+import Icon from '@weco/common/views/components/Icon/Icon';
+import { download } from '@weco/common/icons';
+import { arrow } from '@weco/common/icons';
+
+const ResourcesList = styled(PlainList)`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 15px;
+  ${props => props.theme.media('medium')`
+    gap: 30px;
+  `}
+`;
+const ResourcesItem = styled.li`
+  flex: 0 0 100%;
+  position: relative;
+  min-height: 103px;
+  ${props => props.theme.media('medium')`
+        flex-basis: calc(50% - 15px);
+      `}
+`;
+const ResourceLink = styled(Space).attrs(props => ({
+  as: 'a',
+  h: { size: 's', properties: ['padding-left', 'padding-right'] },
+  v: { size: 'm', properties: ['padding-top', 'padding-bottom'] }
+  }))<{ borderColor: PaletteColor, href: string, underlineText?: boolean }>`
+  display: block;
+  height: 100%;
+  width: 100%;
+  text-decoration: ${props => props.underlineText ? 'underline' : 'none'};
+  border: 1px solid ${props => props.theme.color('warmNeutral.400')};
+  border-left: 10px solid ${props => props.theme.color(props.borderColor)};
+
+  &:hover,
+  &:focus {
+    background: ${props => props.theme.color('neutral.400')};
+  }
+
+  h3 {
+    margin-bottom: 0;
+  }
+
+  span {
+    display: block;
+    max-width: 260px;
+  }
+`;
+
+const ResourceLinkIconWrapper = styled.span`
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+`;
+
+function getBorderColor({ type, i }: {type?: string, i: number}): PaletteColor {
+  if (type === 'visual-story') {
+    return 'accent.turquoise'
+  } else if (type === 'exhibition-guide') {
+    return 'accent.salmon'
+  } else if (i % 2 === 0) {
+    return 'accent.blue'
+  } else {
+    return 'accent.purple'
+  }
+}
 
 type ExhibitionItem = LabelField & {
   icon?: IconSvg;
@@ -181,9 +249,10 @@ export const AccessibilityServices = styled.p.attrs({
 type Props = {
   exhibition: ExhibitionType;
   pages: PageType[];
+  accessResourceLinks: (Link & {type: string})[];
 };
 
-const Exhibition: FunctionComponent<Props> = ({ exhibition, pages }) => {
+const Exhibition: FunctionComponent<Props> = ({ exhibition, pages, accessResourceLinks }) => {
   type ExhibitionOf = (ExhibitionType | EventBasic)[];
 
   const [exhibitionOfs, setExhibitionOfs] = useState<ExhibitionOf>([]);
@@ -228,6 +297,8 @@ const Exhibition: FunctionComponent<Props> = ({ exhibition, pages }) => {
     ? getFeaturedMedia(exhibition)
     : undefined;
 
+  const hasResources = Boolean(exhibition.accessResourcesText || exhibition.accessResourcesPdfs.length > 0 || accessResourceLinks.length > 0);
+
   const Header = (
     <PageHeader
       breadcrumbs={breadcrumbs}
@@ -263,6 +334,48 @@ const Exhibition: FunctionComponent<Props> = ({ exhibition, pages }) => {
       // We hide contributors as we show them further up the page
       hideContributors={true}
     >
+      {hasResources && (
+        <>
+          <h2 className={font('wb', 3)}>Exhibition access content</h2>
+          {(accessResourceLinks.length > 0 || exhibition.accessResourcesPdfs.length > 0) &&
+            <Space v={{ size: 'l', properties: ['padding-bottom'] }}>
+              <ResourcesList>
+                {accessResourceLinks.map((link, i) => {
+                  const borderColor = getBorderColor({type: link.type, i})
+                  return (<ResourcesItem>
+                    <ResourceLink borderColor={borderColor} key={i} href={link.url}>
+                      {link.type === 'exhibition-guide' && <h3 className={font('intb', 4)}>Digital exhibition guide</h3>}
+                      {link.type === 'visual-story' && <h3 className={font('intb', 4)}>Visual story</h3>}
+                      <span className={font('intr', 6)}>{link.text}</span>
+                      <ResourceLinkIconWrapper>
+                        <Icon icon={arrow} />
+                      </ResourceLinkIconWrapper>
+                    </ResourceLink>
+                  </ResourcesItem>)
+                })}
+                {exhibition.accessResourcesPdfs.map((pdf, i) => {
+                  const borderColor = getBorderColor({type: undefined, i})
+                  return (<ResourcesItem>
+                    <ResourceLink borderColor={borderColor} key={i} href={pdf.url} underlineText={true}>
+                      <span className={font('intr', 5)}>
+                        {`${pdf.text} PDF`} {`(${pdf.size}kb)`}
+                        </span>
+                        <ResourceLinkIconWrapper>
+                        <Icon icon={download} />
+                      </ResourceLinkIconWrapper>
+                    </ResourceLink>
+                  </ResourcesItem>)
+                })}
+              </ResourcesList>
+            </Space>
+          }
+          {/* TODO improve styling of download links - defaultSerializer */}
+          {exhibition.accessResourcesText &&
+            <PrismicHtmlBlock html={exhibition.accessResourcesText} htmlSerializer={defaultSerializer} />
+          }
+        </>
+      )}
+
       {exhibition.contributors.length > 0 && (
         <Contributors contributors={exhibition.contributors} />
       )}

--- a/content/webapp/services/prismic/fetch/exhibitions.ts
+++ b/content/webapp/services/prismic/fetch/exhibitions.ts
@@ -9,8 +9,11 @@ import {
   ExhibitionRelatedContentPrismicDocument,
 } from '../types/exhibitions';
 import { fetchPages } from './pages';
+import { fetchVisualStories } from './visual-stories';
+import { fetchExhibitionGuides } from '@weco/content/services/prismic/fetch/exhibition-guides';
 import * as prismic from '@prismicio/client';
 import { PagePrismicDocument } from '../types/pages';
+import { VisualStoryDocument } from '../types/visual-stories';
 import {
   eventAccessOptionsFields,
 } from '../fetch-links';
@@ -20,6 +23,7 @@ import {
   Exhibition,
   ExhibitionRelatedContent,
 } from '../../../types/exhibitions';
+import { ExhibitionGuidePrismicDocument } from '../types/exhibition-guides';
 import {
   articleFormatsFetchLinks,
   contributorFetchLinks,
@@ -59,6 +63,8 @@ const exhibitionsFetcher = fetcher<ExhibitionPrismicDocument>(
 export type FetchExhibitionResult = {
   exhibition?: ExhibitionPrismicDocument;
   pages: prismic.Query<PagePrismicDocument>;
+  visualStories: prismic.Query<VisualStoryDocument>;
+  exhibitionGuides: prismic.Query<ExhibitionGuidePrismicDocument>;
 };
 
 export async function fetchExhibition(
@@ -70,14 +76,25 @@ export async function fetchExhibition(
     filters: [prismic.filter.at('my.pages.parents.parent', id)],
   });
 
-  const [exhibition, pages] = await Promise.all([
+  const visualStoriesQueryPromise = fetchVisualStories(client, {
+    filters: [prismic.filter.at('my.visual-stories.related-exhibition', id)],
+  });
+  const exhibitionGuidesQueryPromise = fetchExhibitionGuides(client, {
+    filters: [prismic.filter.at('my.exhibition-guides.related-exhibition', id)],
+  });
+
+  const [exhibition, pages, visualStories, exhibitionGuides] = await Promise.all([
     exhibitionPromise,
     pageQueryPromise,
+    visualStoriesQueryPromise,
+    exhibitionGuidesQueryPromise
   ]);
 
   return {
     exhibition,
     pages,
+    visualStories,
+    exhibitionGuides,
   };
 }
 

--- a/content/webapp/services/prismic/fetch/visual-stories.ts
+++ b/content/webapp/services/prismic/fetch/visual-stories.ts
@@ -13,19 +13,8 @@ const fetchLinks = [
 const visualStoriesFetcher = fetcher<VisualStoryDocument>(
   'visual-stories',
   fetchLinks
-);
+  );
 
 export const fetchVisualStory = visualStoriesFetcher.getById;
+export const fetchVisualStories = visualStoriesFetcher.getByType;
 
-export const fetchVisualStories = (
-  client: GetServerSidePropsPrismicClient,
-  params: GetByTypeParams
-): Promise<prismic.Query<VisualStoryDocument>> => {
-  return visualStoriesFetcher.getByType(client, {
-    ...params,
-    orderings: [
-      { field: 'my.visual-stories.datePublished', direction: 'desc' },
-      { field: 'document.first_publication_date', direction: 'desc' },
-    ],
-  });
-};

--- a/content/webapp/services/prismic/transformers/exhibitions.test.ts
+++ b/content/webapp/services/prismic/transformers/exhibitions.test.ts
@@ -65,7 +65,7 @@ const doc = {
     exhibits: [],
     events: [],
     articles: [],
-    resources: [],
+    accessResourcesPdfs: [],
     contributors: [],
     contributorsTitle: [],
     promo: [

--- a/content/webapp/services/prismic/transformers/exhibitions.ts
+++ b/content/webapp/services/prismic/transformers/exhibitions.ts
@@ -65,12 +65,16 @@ export function transformExhibition(
     Boolean
   );
   const accessResourcesPdfs = data.accessResourcesPdfs.map(i => {
+    const text = asText(i.linkText) || '';
+    const url = transformLink(i.documentLink) || '';
+    const size = Math.round(parseInt(i.documentLink.size) / 1000) || 0;
     return ({
-      text: asText(i.linkText),
-      url: transformLink(i.documentLink),
-      size: Math.round(parseInt(i.documentLink.size) / 1000)
+      text,
+      url,
+      size,
     })
-  });
+  })
+
   const accessResourcesText = asRichText(data.accessResourcesText);
 
   // TODO: Work out how to get this to type check without the 'as any'.

--- a/content/webapp/services/prismic/transformers/exhibitions.ts
+++ b/content/webapp/services/prismic/transformers/exhibitions.ts
@@ -17,6 +17,9 @@ import {
 import { transformQuery } from './paginated-results';
 import { transformMultiContent } from './multi-content';
 import {
+  transformLink,
+} from '@weco/common/services/prismic/transformers';
+import {
   asHtml,
   asRichText,
   asText,
@@ -25,7 +28,6 @@ import {
 } from '.';
 import { transformSeason } from './seasons';
 import { transformPlace } from './places';
-import { Resource } from '../../../types/resource';
 import { SeasonPrismicDocument } from '../types/seasons';
 import {
   transformContributors,
@@ -62,6 +64,14 @@ export function transformExhibition(
   const relatedIds = [...exhibitIds, ...eventIds, ...articleIds].filter(
     Boolean
   );
+  const accessResourcesPdfs = data.accessResourcesPdfs.map(i => {
+    return ({
+      text: asText(i.linkText),
+      url: transformLink(i.documentLink),
+      size: Math.round(parseInt(i.documentLink.size) / 1000)
+    })
+  });
+  const accessResourcesText = asRichText(data.accessResourcesText);
 
   // TODO: Work out how to get this to type check without the 'as any'.
   const format = isFilledLinkToDocumentWithData(data.format)
@@ -111,6 +121,8 @@ export function transformExhibition(
     contributors,
     relatedIds,
     seasons,
+    accessResourcesPdfs,
+    accessResourcesText,
   };
 
   const labels = exhibition.isPermanent

--- a/content/webapp/services/prismic/types/exhibitions.ts
+++ b/content/webapp/services/prismic/types/exhibitions.ts
@@ -54,9 +54,11 @@ export type ExhibitionPrismicDocument = prismic.PrismicDocument<
     articles: prismic.GroupField<{
       item: prismic.ContentRelationshipField<'articles'>;
     }>;
-    resources: prismic.GroupField<{
-      item: prismic.ContentRelationshipField<'resources'>;
+    accessResourcesPdfs: prismic.GroupField<{
+      linkText: prismic.RichTextField;
+      documentLink: prismic.LinkToMediaField;
     }>;
+    accessResourcesText: prismic.RichTextField;
   } & WithContributors &
     WithExhibitionParents &
     WithSeasons &

--- a/content/webapp/types/exhibitions.ts
+++ b/content/webapp/types/exhibitions.ts
@@ -5,7 +5,7 @@ import { Contributor, ContributorBasic } from './contributors';
 import { EventBasic } from './events';
 import { Place } from './places';
 import { GenericContentFields } from './generic-content-fields';
-import { Resource } from './resource';
+import { Link } from '@weco/content/types/link';
 import { Season } from './seasons';
 import { ImagePromo } from './image-promo';
 import { ImageType } from '@weco/common/model/image';
@@ -52,6 +52,8 @@ export type Exhibition = GenericContentFields & {
   relatedIds: string[];
   seasons: Season[];
   contributors: Contributor[];
+  accessResourcesPdfs: (Link & { size: string })[];
+  accessResourcesText?: prismic.RichTextField;
 };
 
 export type Exhibit = {

--- a/content/webapp/types/exhibitions.ts
+++ b/content/webapp/types/exhibitions.ts
@@ -52,7 +52,7 @@ export type Exhibition = GenericContentFields & {
   relatedIds: string[];
   seasons: Season[];
   contributors: Contributor[];
-  accessResourcesPdfs: (Link & { size: string })[];
+  accessResourcesPdfs: (Link & { size: number })[];
   accessResourcesText?: prismic.RichTextField;
 };
 


### PR DESCRIPTION
For #10041 

Uses new Prismic fields to render access resources on exhibition pages:

<img width="995" alt="Screenshot 2023-09-12 at 17 25 00" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/6051896/002ea519-de93-4a8c-8f24-e6f8c3e01e1e">

N.B I'm going to look at the alignment of the download icon in another PR as it's an existing problem that happens elsewhere too.
