### PR TITLE
replaces visuallySimilar with withSimilarFeatures to match API

### DIFF
--- a/catalogue/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.tsx
+++ b/catalogue/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.tsx
@@ -66,7 +66,7 @@ const VisuallySimilarImagesFromApi: FunctionComponent<Props> = ({
       const { image: fullImage } = await getImage({
         id: originalId,
         toggles,
-        include: ['visuallySimilar'],
+        include: ['withSimilarFeatures'],
       });
       if (fullImage.type === 'Image') {
         setSimilarImages(fullImage.visuallySimilar || []);

--- a/catalogue/webapp/services/wellcome/catalogue/images.ts
+++ b/catalogue/webapp/services/wellcome/catalogue/images.ts
@@ -17,8 +17,6 @@ import {
 import { toIsoDateString } from '@weco/catalogue/services/wellcome/catalogue/index';
 
 type ImageInclude =
-  | 'visuallySimilar'
-  | 'withSimilarColors'
   | 'withSimilarFeatures'
   | 'source.contributors'
   | 'source.languages'

--- a/catalogue/webapp/services/wellcome/catalogue/types/index.ts
+++ b/catalogue/webapp/services/wellcome/catalogue/types/index.ts
@@ -219,7 +219,7 @@ export type Image = {
     contributors?: Contributor[];
     type: string;
   };
-  visuallySimilar?: Image[];
+  withSimilarFeatures?: Image[];
   aspectRatio?: number;
 };
 

--- a/catalogue/webapp/services/wellcome/content/types/index.ts
+++ b/catalogue/webapp/services/wellcome/content/types/index.ts
@@ -22,6 +22,6 @@ export type Image = {
     contributors?: Contributor[];
     type: string;
   };
-  visuallySimilar?: Image[];
+  withSimilarFeatures?: Image[];
   aspectRatio?: number;
 };


### PR DESCRIPTION
## Who is this for?
Fixing e2e tests because of changes in the catalogue API

## What is it doing for them?
The catalogue API returns `withSimilarFeatures` images. `visuallySimilar` query params is not supported anymore