### PR TITLE
replaces visuallySimilar with withSimilarFeatures to match API

### DIFF
--- a/content/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.tsx
+++ b/content/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.tsx
@@ -66,10 +66,10 @@ const VisuallySimilarImagesFromApi: FunctionComponent<Props> = ({
       const { image: fullImage } = await getImage({
         id: originalId,
         toggles,
-        include: ['visuallySimilar'],
+        include: ['withSimilarFeatures'],
       });
       if (fullImage.type === 'Image') {
-        setSimilarImages(fullImage.visuallySimilar || []);
+        setSimilarImages(fullImage.withSimilarFeatures || []);
         setRequestState('success');
       } else {
         setRequestState('failed');

--- a/content/webapp/services/wellcome/catalogue/images.ts
+++ b/content/webapp/services/wellcome/catalogue/images.ts
@@ -17,8 +17,6 @@ import {
 import { toIsoDateString } from '@weco/content/services/wellcome/catalogue/index';
 
 type ImageInclude =
-  | 'visuallySimilar'
-  | 'withSimilarColors'
   | 'withSimilarFeatures'
   | 'source.contributors'
   | 'source.languages'

--- a/content/webapp/services/wellcome/catalogue/types/index.ts
+++ b/content/webapp/services/wellcome/catalogue/types/index.ts
@@ -219,7 +219,7 @@ export type Image = {
     contributors?: Contributor[];
     type: string;
   };
-  visuallySimilar?: Image[];
+  withSimilarFeatures?: Image[];
   aspectRatio?: number;
 };
 

--- a/content/webapp/services/wellcome/content/types/index.ts
+++ b/content/webapp/services/wellcome/content/types/index.ts
@@ -22,6 +22,6 @@ export type Image = {
     contributors?: Contributor[];
     type: string;
   };
-  visuallySimilar?: Image[];
+  withSimilarFeatures?: Image[];
   aspectRatio?: number;
 };


### PR DESCRIPTION
## Who is this for?
Fixing failing e2e tests because of a change in catalogue API

## What is it doing for them?
The catalogue API returns `withSimilarFeatures` images. `visuallySimilar` query params is not supported anymore