### PR TITLE
fetch the article series body

### DIFF
--- a/content/webapp/services/prismic/fetch/articles.ts
+++ b/content/webapp/services/prismic/fetch/articles.ts
@@ -89,6 +89,7 @@ const graphQuery = `{
             }
           }
         }
+        body
       }
     }
   }


### PR DESCRIPTION
When [we tidied up some of the graphql queries](https://github.com/wellcomecollection/wellcomecollection.org/pull/10153) we stopped fetching the articles series body. Turns out we needed it, so this puts it back.

Before:
<img width="1174" alt="Screenshot 2023-09-19 at 16 04 48" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/6051896/4464f736-7dc2-48f4-88d1-edda279b85b8">

After: 
<img width="1170" alt="Screenshot 2023-09-19 at 16 04 28" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/6051896/5e1c6901-e64f-4b06-a185-4472f3f7e3b9">
