### PR TITLE
Improve the readability of the opening-times tests

### DIFF
--- a/common/model/opening-hours.ts
+++ b/common/model/opening-hours.ts
@@ -8,6 +8,10 @@ export type OverrideType =
   | 'Late Spectacular'
   | 'other';
 
+export type HasOverrideDate = {
+  overrideDate: Date;
+};
+
 export type OverrideDate = {
   overrideDate: Date;
   overrideType: OverrideType;

--- a/common/services/prismic/opening-times.ts
+++ b/common/services/prismic/opening-times.ts
@@ -6,6 +6,7 @@ import {
   Venue,
   OpeningHoursDay,
   ExceptionalOpeningHoursDay,
+  HasOverrideDate,
 } from '../../model/opening-hours';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
 import {
@@ -180,9 +181,9 @@ export function completeDateRangeForExceptionalPeriods(
  * Each group will have at most 14 days between the first day and the last day.
  *
  */
-export function groupExceptionalVenueDays(
-  exceptionalDays: ExceptionalOpeningHoursDay[]
-): ExceptionalOpeningHoursDay[][] {
+export function groupExceptionalVenueDays<T extends HasOverrideDate>(
+  exceptionalDays: T[]
+): T[][] {
   return exceptionalDays.length > 0
     ? exceptionalDays
         .sort((a, b) => countDaysBetween(a.overrideDate, b.overrideDate))
@@ -203,7 +204,7 @@ export function groupExceptionalVenueDays(
             }
             return acc;
           },
-          [[]] as ExceptionalOpeningHoursDay[][]
+          [[]] as T[][]
         )
     : [];
 }
@@ -271,9 +272,9 @@ export function createExceptionalOpeningHoursDays(
   });
 }
 
-export function groupConsecutiveExceptionalDays(
-  dates: ExceptionalOpeningHoursGroup
-): ExceptionalOpeningHoursGroup[] {
+export function groupConsecutiveExceptionalDays<T extends HasOverrideDate>(
+  dates: T[]
+): T[][] {
   return dates
     .sort((a, b) => (a.overrideDate > b.overrideDate ? 1 : -1))
     .reduce((acc, date) => {
@@ -290,7 +291,7 @@ export function groupConsecutiveExceptionalDays(
       }
 
       return acc;
-    }, [] as ExceptionalOpeningHoursGroup[]);
+    }, [] as T[][]);
 }
 
 /** Returns a list of all exceptional periods that we want to display.
@@ -299,9 +300,9 @@ export function groupConsecutiveExceptionalDays(
  * the site on an exceptional day, it highlights the exceptional hours.  We filter
  * this list so we’re not displaying dates very far in the future.
  */
-export function getUpcomingExceptionalOpeningHours(
-  openingHoursGroups: ExceptionalOpeningHoursGroup[]
-): ExceptionalOpeningHoursGroup[] {
+export function getUpcomingExceptionalOpeningHours<T extends HasOverrideDate>(
+  openingHoursGroups: T[][]
+): T[][] {
   return openingHoursGroups.filter(period =>
     period.some(
       d =>


### PR DESCRIPTION
This is a straight-up readability improvement: we have a bunch of values in these tests which feature a lot of repetition and boilerplate.

This patch tries to make the tests more readable in two ways:

*   Ditch some of the boilerplate, so there's less repetition. There are lots of places where the boilerplate isn't interesting to what we're testing, so we can remove it.

*   Using named variables to make it more obvious when the same value appears in multiple places.  This should make it easier to see what the test is doing also -- you can read a list of variable names rather than JavaScript objects.

I've been staring at these tests as part of https://github.com/wellcomecollection/wellcomecollection.org/issues/9874, and got confused in several places – these readability improvements should help with that.