### PR TITLE
Fix content examples in cardigan

### DIFF
--- a/cardigan/stories/content.ts
+++ b/cardigan/stories/content.ts
@@ -1,8 +1,8 @@
 import { LicenseType } from '@weco/common/model/license';
 import { Article } from '@weco/content/types/articles';
-import { Card } from '@weco/content/types/card';
 import { Event } from '@weco/content/types/events';
 import { faker } from '@faker-js/faker';
+import { Season } from '@weco/content/types/seasons';
 
 export function randomNumber(min: number, max: number): number {
   return Math.floor(Math.random() * max) + min;
@@ -53,7 +53,11 @@ export const interpretations = [
 
 export const url = faker.internet.url();
 
-export const bannerCardItem: Card = {
+export const bannerCardItem: Season = {
+  type: 'seasons',
+  id: 'bannerCardItem',
+  body: [],
+  labels: [],
   title: 'What does it mean to be human, now?',
   start: new Date('2021-01-05T00:00:00.000Z'),
   end: new Date('2021-01-26T00:00:00.000Z'),
@@ -75,7 +79,6 @@ export const bannerCardItem: Card = {
         copyrightHolder: undefined,
         copyrightLink: undefined,
       },
-      crops: {},
     },
     link: null,
   },
@@ -301,13 +304,11 @@ export const captionedImage = () => ({
 export const singleLineOfText = () => faker.random.words(7);
 
 export const text = () =>
-  Array(2)
-    .fill()
-    .map(() => ({
-      type: 'paragraph',
-      text: `${faker.random.words(30)}`,
-      spans: [],
-    }));
+  Array(2).fill({
+    type: 'paragraph',
+    text: `${faker.random.words(30)}`,
+    spans: [],
+  });
 
 export const smallText = () => [
   {
@@ -322,31 +323,19 @@ export const videoEmbed = {
 };
 
 export const event: Event = {
+  type: 'events',
+  id: 'x123',
   title: 'Event title',
-  contributorsTitle: '',
-  contributors: [],
+  audiences: [],
+  availableOnline: true,
   body: [],
-  promo: {
-    caption:
-      'Come and hear Dr Emma Spary discuss her research on the often- overlooked role of priests in the history of pharmacy.',
-    image: {
-      contentUrl:
-        'https://images.prismic.io/wellcomecollection/1689f6e5ead8d3a228d802256213e0998b15b7a2_sdp_20181009_0007.jpg?auto=compress,format',
-      width: 3200,
-      height: 1800,
-      alt: 'Photograph showing a woman giving a talk in the Viewing Room at Wellcome Collection. She is stood at the front of the room looking at a wall mounted television screen. In the foreground are the backs of the heads of the audience.',
-      tasl: {
-        title: 'Exploring Research event',
-        author: 'Steven Pocock',
-        sourceName: 'Wellcome Collection',
-        sourceLink: null,
-        license: 'CC-BY-NC' as LicenseType,
-        copyrightHolder: null,
-        copyrightLink: null,
-      },
-    },
-    link: null,
-  },
+  bookingInformation: null,
+  bookingType: 'First come, first served',
+  contributors: [],
+  cost: null,
+  eventbriteId: '',
+  format: { id: 'WlYVBiQAACcAWcu9', title: 'Seminar', description: null },
+  hasEarlyRegistration: false,
   image: {
     contentUrl:
       'https://images.prismic.io/wellcomecollection/a4e2a07674bb171ba0b7d7dc7dcf09f1694e13ff_sdp_20181009_0007.jpg?auto=compress,format',
@@ -383,63 +372,31 @@ export const event: Event = {
       },
     },
   },
-  squareImage: {
-    contentUrl:
-      'https://images.prismic.io/wellcomecollection/318dba668b46078bd957578fa5fc3b2f9b86c5a0_sdp_20181009_0007.jpg?auto=compress,format',
-    width: 3200,
-    height: 3200,
-    alt: 'Photograph showing a woman giving a talk in the Viewing Room at Wellcome Collection. She is stood at the front of the room looking at a wall mounted television screen. In the foreground are the backs of the heads of the audience.',
-    tasl: {
-      title: 'Exploring Research event',
-      author: 'Steven Pocock',
-      sourceName: 'Wellcome Collection',
-      sourceLink: null,
-      license: 'CC-BY-NC' as LicenseType,
-      copyrightHolder: null,
-      copyrightLink: null,
+  interpretations: [],
+  isCompletelySoldOut: false,
+  isPast: false,
+  isRelaxedPerformance: false,
+  isOnline: true,
+  labels: [],
+  locations: [
+    {
+      id: 'WoLtUioAACkANrUM',
+      title: 'Viewing Room',
+      body: [],
+      labels: [],
+      level: 2,
+      capacity: 20,
+      information: [
+        {
+          type: 'paragraph',
+          text: 'We’ll be in the Viewing Room. It’s next to the Library entrance on level 2, which you can reach by taking the lift or the stairs.',
+          spans: [],
+        },
+      ],
     },
-    crops: {},
-  },
-  widescreenImage: {
-    contentUrl:
-      'https://images.prismic.io/wellcomecollection/1689f6e5ead8d3a228d802256213e0998b15b7a2_sdp_20181009_0007.jpg?auto=compress,format',
-    width: 3200,
-    height: 1800,
-    alt: 'Photograph showing a woman giving a talk in the Viewing Room at Wellcome Collection. She is stood at the front of the room looking at a wall mounted television screen. In the foreground are the backs of the heads of the audience.',
-    tasl: {
-      title: 'Exploring Research event',
-      author: 'Steven Pocock',
-      sourceName: 'Wellcome Collection',
-      sourceLink: null,
-      license: 'CC-BY-NC' as LicenseType,
-      copyrightHolder: null,
-      copyrightLink: null,
-    },
-    crops: {},
-  },
-  primaryLabels: [{ text: 'Seminar' }],
-  secondaryLabels: [],
-  place: {
-    id: 'WoLtUioAACkANrUM',
-    title: 'Viewing Room',
-    contributors: [],
-    body: [],
-    labels: [],
-    level: 2,
-    capacity: 20,
-    information: [
-      {
-        type: 'paragraph',
-        text: 'We’ll be in the Viewing Room. It’s next to the Library entrance on level 2, which you can reach by taking the lift or the stairs.',
-        spans: [],
-      },
-    ],
-  },
-  audiences: [],
-  bookingInformation: null,
-  bookingType: 'First come, first served',
-  cost: null,
-  format: { id: 'WlYVBiQAACcAWcu9', title: 'Seminar', description: null },
+  ],
+  onlineHasEarlyRegistration: false,
+  onlinePolicies: [],
   policies: [
     {
       id: 'W3RLAikAACcAF2oO',
@@ -453,11 +410,28 @@ export const event: Event = {
       ],
     },
   ],
-  isDropIn: false,
-  series: [],
-  schedule: [],
-  eventbriteId: '',
-  isCompletelySoldOut: false,
+  primaryLabels: [{ text: 'Seminar' }],
+  promo: {
+    caption:
+      'Come and hear Dr Emma Spary discuss her research on the often- overlooked role of priests in the history of pharmacy.',
+    image: {
+      contentUrl:
+        'https://images.prismic.io/wellcomecollection/1689f6e5ead8d3a228d802256213e0998b15b7a2_sdp_20181009_0007.jpg?auto=compress,format',
+      width: 3200,
+      height: 1800,
+      alt: 'Photograph showing a woman giving a talk in the Viewing Room at Wellcome Collection. She is stood at the front of the room looking at a wall mounted television screen. In the foreground are the backs of the heads of the audience.',
+      tasl: {
+        title: 'Exploring Research event',
+        author: 'Steven Pocock',
+        sourceName: 'Wellcome Collection',
+        sourceLink: null,
+        license: 'CC-BY-NC' as LicenseType,
+        copyrightHolder: null,
+        copyrightLink: null,
+      },
+    },
+    link: null,
+  },
   ticketSalesStart: null,
   times: [
     {
@@ -468,21 +442,14 @@ export const event: Event = {
       isFullyBooked: { inVenue: false, online: false },
     },
   ],
-  displayStart: new Date('2018-10-23T17:00:00.000Z'),
-  displayEnd: new Date('2018-10-23T18:30:00.000Z'),
-  dateRange: {
-    firstDate: new Date('2018-10-23T17:00:00.000Z'),
-    lastDate: new Date('2018-10-23T18:30:00.000Z'),
-    repeats: 1,
-  },
-  isPast: false,
-  isRelaxedPerformance: false,
-  isOnline: true,
-  availableOnline: true,
+  seasons: [],
+  schedule: [],
+  secondaryLabels: [],
+  series: [],
 };
 
 export const imageGallery = () => {
-  const items = Array(4).fill().map(captionedImage);
+  const items = Array(4).fill(captionedImage());
   return {
     id: '123',
     title: singleLineOfText(),
@@ -565,7 +532,6 @@ export const article: Article = {
   type: 'articles',
   id: 'YLoCLhAAACEAfyuO',
   title: 'A dark cloud',
-  contributorsTitle: '',
   contributors: [
     {
       role: {
@@ -610,6 +576,8 @@ export const article: Article = {
       weight: 'standalone',
       value: {
         title: '',
+        isStandalone: false,
+        isFrames: false,
         items: [
           {
             image: {
@@ -642,6 +610,7 @@ export const article: Article = {
                 },
               },
             },
+            hasRoundedCorners: false,
             caption: [],
           },
         ],


### PR DESCRIPTION
## Who is this for?
Maintenance

## What is it doing for them?
There were a few type/linting errors in our example content used in cardigan, I decided to go in and fix them.
It fixes BannerCard (which had missing content) and adds location information to Event Cards.