### PR TITLE
Remove a dead TODO comment in the Prismic model code

### DIFF
--- a/prismic-model/src/parts/gif-video-slice.ts
+++ b/prismic-model/src/parts/gif-video-slice.ts
@@ -14,7 +14,6 @@ export default function () {
         placeholder:
           'title|author|sourceName|sourceLink|license|copyrightHolder|copyrightLink',
       }),
-      // TODO: Media link
       video: mediaLink('Video', { placeholder: 'Video' }),
       playbackRate: select('Playback rate', {
         options: [


### PR DESCRIPTION
This is a comment I wrote when I was partway through writing the helper functions for the Prismic model definitions, reminding me to create a helper for `mediaLink()`.  I did that, so this comment can be removed.