### PR TITLE
We can use a London comparison here, not UTC

### DIFF
--- a/content/webapp/services/prismic/transformers/events.ts
+++ b/content/webapp/services/prismic/transformers/events.ts
@@ -457,8 +457,8 @@ export function transformEventBasicTimes(
   const everyDayHasSomething = daysInScheduleRange.every(d =>
     scheduleTimes.some(
       s =>
-        isSameDay(d, s.range.startDateTime, 'UTC') ||
-        isSameDay(d, s.range.endDateTime, 'UTC')
+        isSameDay(d, s.range.startDateTime, 'London') ||
+        isSameDay(d, s.range.endDateTime, 'London')
     )
   );
 


### PR DESCRIPTION
This loop runs to produce the event times which are shown on event cards (in particular those associated with an EventBasic).  It only kicks in for events that have a `schedule`, which means multi-part events.

There are two cases we see here:

1.  An event running over one or more days that has multiple scheduled items, e.g. a weekend festival with talks at Sat 2pm, Sat 4pm and Sun 2pm.  In this case we'd show something like 'Sat–Sun' on the event card.

2.  An event which repeats on multiple, distinct dates, e.g. the relaxed openings for an exhibition that occur on 1 Jan, 2 Feb, 3 Mar. In this case we'd show something like '1 Jan … see 2 more dates' on the event card.

This line is checking whether we're in case 1 or 2 -- that is, whether the schedule for this event covers sub-events happening on consecutive days, or whether they're more spread out.

Because the sub-events in a schedule always occur during the opening hours, I'm pretty sure the start/end date times will always be on the same day, whether it's UTC or London, and so this is a safe change.

This is one of the changes we need to finish https://github.com/wellcomecollection/wellcomecollection.org/issues/9874