### PR TITLE
Convert another use of isSameDay to use London comparisons, not UTC

### DIFF
--- a/common/services/prismic/opening-times.ts
+++ b/common/services/prismic/opening-times.ts
@@ -56,7 +56,7 @@ export function getOverrideDatesForAllVenues(venues: Venue[]): OverrideDate[] {
     .sort((a, b) => Number(a.overrideDate) - Number(b.overrideDate))
     .reduce((result: OverrideDate[], thisOverride: OverrideDate) => {
       const isAlreadyInResult = result.some(t =>
-        isSameDay(t.overrideDate, thisOverride.overrideDate, 'UTC')
+        isSameDay(t.overrideDate, thisOverride.overrideDate, 'London')
       );
 
       if (!isAlreadyInResult) {


### PR DESCRIPTION
In this function, we're building up a list of all the dates when we have exceptional opening hours, e.g. if we had two venues

    library.exceptionalOpeningHours = [3 Jan, 2 Jan, 1 Jan]
    gallery.exceptionalOpeningHours = [3 Jan, 4 Jan, 5 Feb]

then this would return

    [1 Jan, 2 Jan, 3 Jan, 4 Jan, 5 Feb]

I expect these dates to be consistent for each batch that's entered (e.g. if somebody enters five dates, they'll have the same UTC offset), so we're comparing like-for-like in this function.

This means that if somebody enters the same override date in library and gallery, I expect it would be an _identical_ date, not merely a different time on the same day.

In practice this means we could actually replace this with the even stronger check (ignoring any weirdness around comparing dates in JS):

```javascript
const isAlreadyInResult = result.some(t =>
  t.overrideDate === thisOverride.overrideDate
);
```

and we'd get the same results.

We only care about them being the same day, but for this check I don't think the London/UTC distinction will make any difference and so we can switch to the default of London-based comparisons.

Continuing to chip away at https://github.com/wellcomecollection/wellcomecollection.org/issues/9874