### PR TITLE
Remove an unnecessary conditional in VenueClosedPeriods

### DIFF
--- a/content/webapp/components/VenueClosedPeriods/VenueClosedPeriods.tsx
+++ b/content/webapp/components/VenueClosedPeriods/VenueClosedPeriods.tsx
@@ -39,7 +39,7 @@ const VenueClosedPeriods: FunctionComponent<Props> = ({ venue }) => {
           return (
             closedGroup.length > 0 && (
               <li key={i}>
-                {firstDate && <HTMLDayDate date={firstDate} />}
+                <HTMLDayDate date={firstDate} />
                 {lastDate && (
                   <>
                     &ndash;


### PR DESCRIPTION
The `firstDate` value is always defined, so this condition will always be true -- we can skip conditioning and just render the `HTMLDayDate` immediately.

This is a tiny thing I spotted while looking at https://github.com/wellcomecollection/wellcomecollection.org/issues/9874 – I'm not changing the VenueClosedPeriods component directly, but it calls a bunch of opening-times functions that I'm looking at, and I spotted this.