### PR TITLE
Use London comparisons in groupConsecutiveExceptionalDays, not UTC

### DIFF
--- a/common/services/prismic/opening-times.ts
+++ b/common/services/prismic/opening-times.ts
@@ -272,6 +272,16 @@ export function createExceptionalOpeningHoursDays(
   });
 }
 
+/** Given a single list of exceptional dates, split them into a list of lists,
+ * where each list is a consecutive run of dates.
+ *
+ * e.g. input  = [Jan 1, Jan 2, Jan 3, Feb 4, Mar 5, Mar 6]
+ *
+ *      output = [[Jan 1, Jan 2, Jan 3],
+ *                [Feb 4],
+ *                [Mar 5, Mar 6]]
+ *
+ */
 export function groupConsecutiveExceptionalDays<T extends HasOverrideDate>(
   dates: T[]
 ): T[][] {

--- a/common/services/prismic/opening-times.ts
+++ b/common/services/prismic/opening-times.ts
@@ -293,7 +293,7 @@ export function groupConsecutiveExceptionalDays<T extends HasOverrideDate>(
 
       if (
         lastDayOfGroup &&
-        isSameDay(addDays(date.overrideDate, -1), lastDayOfGroup, 'UTC')
+        isSameDay(addDays(date.overrideDate, -1), lastDayOfGroup, 'London')
       ) {
         group.push(date);
       } else {


### PR DESCRIPTION
Penultimate change for https://github.com/wellcomecollection/wellcomecollection.org/issues/9874

As in https://github.com/wellcomecollection/wellcomecollection.org/commit/a5eac3dc6a6c55acbc6f8980beaff32a190ad88c, I think we could actually replace this with the stronger assertion:

```javascript
addDays(date.overrideDate, -1) === lastDayOfGroup
```

because any time these days are consecutive, they'll have been entered as part of the same batch and I'd expect them to have the same time of day.  As such, within this function I'm pretty sure UTC and London will always behave in the same way.

(And all the tests pass unmodified.)