### PR TITLE
Get rid of the last use of a UTC comparison in isSameDay

### DIFF
--- a/common/services/prismic/opening-times.ts
+++ b/common/services/prismic/opening-times.ts
@@ -259,10 +259,10 @@ export function createExceptionalOpeningHoursDays(
     const days = sortedDates
       .map(date => {
         const matchingVenueGroup = groupedExceptionalDays.find(group =>
-          group.find(day => isSameDay(day.overrideDate, date, 'UTC'))
+          group.find(day => isSameDay(day.overrideDate, date, 'London'))
         );
         const matchingDay = matchingVenueGroup?.find(day =>
-          isSameDay(day.overrideDate, date, 'UTC')
+          isSameDay(day.overrideDate, date, 'London')
         );
         const backfillDay = exceptionalFromRegular(venue, date, type);
         return matchingDay || backfillDay;

--- a/common/services/prismic/opening-times.ts
+++ b/common/services/prismic/opening-times.ts
@@ -248,12 +248,12 @@ type ExceptionalOpeningHoursGroup = ExceptionalOpeningHoursDay[];
  */
 export function createExceptionalOpeningHoursDays(
   venue: Venue,
-  allVenueExceptionalPeriods?: ExceptionalPeriod[]
+  allVenueExceptionalPeriods: ExceptionalPeriod[]
 ): ExceptionalOpeningHoursGroup[] {
   const groupedExceptionalDays = groupExceptionalVenueDays(
     venue.openingHours.exceptional
   );
-  return (allVenueExceptionalPeriods ?? []).map(period => {
+  return allVenueExceptionalPeriods.map(period => {
     const sortedDates = period.dates.sort((a, b) => countDaysBetween(a, b));
     const type = period.type || 'other';
     const days = sortedDates

--- a/common/test/services/prismic/opening-times.test.ts
+++ b/common/test/services/prismic/opening-times.test.ts
@@ -303,7 +303,7 @@ describe('opening-times', () => {
     });
   });
 
-  describe("backfillExceptionalVenueDays: returns the venue's exceptional opening times for each date, and if there is no exceptional opening time for a specific date, then it uses the venue's regular opening times for that day.", () => {
+  describe("createExceptionalOpeningHoursDays: returns the venue's exceptional opening times for each date, and if there is no exceptional opening time for a specific date, then it uses the venue's regular opening times for that day.", () => {
     it('returns an exceptional override date type for each of the dates provided', () => {
       const result = createExceptionalOpeningHoursDays(libraryVenue, [
         {

--- a/content/webapp/components/VenueHours/VenueHours.tsx
+++ b/content/webapp/components/VenueHours/VenueHours.tsx
@@ -161,9 +161,10 @@ const VenueHours: FunctionComponent<Props> = ({ venue, weight }) => {
   const exceptionalPeriods = groupOverrideDates(allOverrideDates);
   const completeExceptionalPeriods =
     completeDateRangeForExceptionalPeriods(exceptionalPeriods);
-  const exceptionalOpeningHours = venue
-    ? createExceptionalOpeningHoursDays(venue, completeExceptionalPeriods)
-    : [];
+  const exceptionalOpeningHours = createExceptionalOpeningHoursDays(
+    venue,
+    completeExceptionalPeriods
+  );
 
   const upcomingExceptionalOpeningHours =
     exceptionalOpeningHours &&


### PR DESCRIPTION
In this part of the code, we've got a complete list of all the days in the exceptional opening period, and we're trying to work out which opening hours to use in that time.

e.g. if we have exceptional hours on Mon/Weds/Fri, then this function is looking at Mon/Tues/Wed/Thurs/Fri:

* Mon = use the exceptional hours
* Tues = use the normal hours
* Wed = use the exceptional hours
* Thurs = use the normal hours
* Fri = use the exceptional hours

What's happening in this code is we're going through the days in this period one-by-one, and looking to find if there are exceptional hours for this day.  As with previous PRs, it should be sufficient to do

```javascript
day.overrideDate === date
```

here because all the dates come from Prismic in the same format.

Using `isSameDay` is a bit safer, but there shouldn't be any difference between UTC/London in practice.


For https://github.com/wellcomecollection/wellcomecollection.org/issues/9874