### PR TITLE
Remove the UTC implementation from isSameDay

### DIFF
--- a/common/services/prismic/opening-times.ts
+++ b/common/services/prismic/opening-times.ts
@@ -56,7 +56,7 @@ export function getOverrideDatesForAllVenues(venues: Venue[]): OverrideDate[] {
     .sort((a, b) => Number(a.overrideDate) - Number(b.overrideDate))
     .reduce((result: OverrideDate[], thisOverride: OverrideDate) => {
       const isAlreadyInResult = result.some(t =>
-        isSameDay(t.overrideDate, thisOverride.overrideDate, 'London')
+        isSameDay(t.overrideDate, thisOverride.overrideDate)
       );
 
       if (!isAlreadyInResult) {
@@ -259,10 +259,10 @@ export function createExceptionalOpeningHoursDays(
     const days = sortedDates
       .map(date => {
         const matchingVenueGroup = groupedExceptionalDays.find(group =>
-          group.find(day => isSameDay(day.overrideDate, date, 'London'))
+          group.find(day => isSameDay(day.overrideDate, date))
         );
         const matchingDay = matchingVenueGroup?.find(day =>
-          isSameDay(day.overrideDate, date, 'London')
+          isSameDay(day.overrideDate, date)
         );
         const backfillDay = exceptionalFromRegular(venue, date, type);
         return matchingDay || backfillDay;
@@ -293,7 +293,7 @@ export function groupConsecutiveExceptionalDays<T extends HasOverrideDate>(
 
       if (
         lastDayOfGroup &&
-        isSameDay(addDays(date.overrideDate, -1), lastDayOfGroup, 'London')
+        isSameDay(addDays(date.overrideDate, -1), lastDayOfGroup)
       ) {
         group.push(date);
       } else {
@@ -335,7 +335,7 @@ export function getTodaysVenueHours(
   const todaysDate = today();
   const todayString = formatDayName(todaysDate);
   const exceptionalOpeningHours = venue.openingHours.exceptional.find(i =>
-    isSameDay(todaysDate, i.overrideDate, 'London')
+    isSameDay(todaysDate, i.overrideDate)
   );
   const regularOpeningHours = venue.openingHours.regular.find(
     i => i.dayOfWeek === todayString

--- a/common/utils/dates.test.ts
+++ b/common/utils/dates.test.ts
@@ -29,7 +29,7 @@ it('identifies dates in the future', () => {
 describe('isSameDay', () => {
   it('says a day is the same as itself', () => {
     const day = new Date(2001, 1, 1, 1, 1, 1);
-    const result = isSameDay(day, day, 'UTC');
+    const result = isSameDay(day, day, 'London');
 
     expect(result).toEqual(true);
   });
@@ -61,11 +61,6 @@ describe('isSameDay', () => {
       expect(result).toEqual(true);
     });
 
-    it('says midnight {x} BST in London is not on the same day as midday {x} BST using a comparison mode of "UTC"', () => {
-      const result = isSameDay(september19Midnight, september19Midday, 'UTC');
-      expect(result).toEqual(false);
-    });
-
     it('says 23:30 {x} BST in London is not on the same day as 00:30 {x+1} BST using a comparison mode of "London"', () => {
       const result = isSameDay(
         september18TwentyThreeThirty,
@@ -74,35 +69,6 @@ describe('isSameDay', () => {
       );
       expect(result).toEqual(false);
     });
-
-    it('says 23:30 {x} BST in London is on the same day as 00:30 {x+1} BST using a comparison mode of "UTC"', () => {
-      const result = isSameDay(
-        september18TwentyThreeThirty,
-        september19MidnightThirty,
-        'UTC'
-      );
-      expect(result).toEqual(true);
-    });
-  });
-
-  each([
-    // same day of the week as returned by Date.getDay()
-    [new Date(2001, 2, 3, 1, 1, 1), new Date(2001, 2, 10, 1, 1, 1)],
-
-    // same year/month, different day
-    [new Date(2001, 2, 3, 1, 1, 1), new Date(2001, 2, 10, 1, 1, 1)],
-
-    // same year/day, different month
-    [new Date(2001, 2, 3, 1, 1, 1), new Date(2001, 10, 3, 1, 1, 1)],
-
-    // same month/day, different year
-    [new Date(2001, 2, 3, 1, 1, 1), new Date(2022, 2, 3, 1, 1, 1)],
-
-    // completely different days
-    [new Date(2001, 2, 3, 1, 1, 1), new Date(2022, 5, 7, 19, 11, 13)],
-  ]).test('identifies %s and %s as different', (a, b) => {
-    const result = isSameDay(a, b, 'UTC');
-    expect(result).toEqual(false);
   });
 
   each([
@@ -236,7 +202,7 @@ describe('startOfWeek and endOfWeek', () => {
   ])(
     'the week containing $day starts on $expectedStart',
     ({ day, expectedStart }) => {
-      expect(isSameDay(startOfWeek(day), expectedStart, 'UTC')).toBeTruthy();
+      expect(isSameDay(startOfWeek(day), expectedStart, 'London')).toBeTruthy();
     }
   );
 
@@ -247,7 +213,7 @@ describe('startOfWeek and endOfWeek', () => {
   ])(
     'the week containing $day ends on $expectedEnd',
     ({ day, expectedEnd }) => {
-      expect(isSameDay(endOfWeek(day), expectedEnd, 'UTC')).toBeTruthy();
+      expect(isSameDay(endOfWeek(day), expectedEnd, 'London')).toBeTruthy();
     }
   );
 });

--- a/common/utils/dates.test.ts
+++ b/common/utils/dates.test.ts
@@ -8,7 +8,6 @@ import {
   isPast,
   isSameDay,
   isSameDayOrBefore,
-  isSameMonth,
   minDate,
   maxDate,
   startOfWeek,
@@ -135,47 +134,6 @@ describe('isSameDayOrBefore', () => {
 
     expect(isSameDayOrBefore(date1, date2)).toEqual(true);
     expect(isSameDayOrBefore(date2, date1)).toEqual(false);
-  });
-});
-
-describe('isSameMonth', () => {
-  it('says a day is the same as itself', () => {
-    const day = new Date(2001, 1, 1, 1, 1, 1);
-    const result = isSameMonth(day, day);
-
-    expect(result).toEqual(true);
-  });
-
-  it('says two times on the same day are the same', () => {
-    const result = isSameMonth(
-      new Date(2001, 1, 1, 1, 1, 1),
-      new Date(2001, 1, 1, 13, 24, 37)
-    );
-
-    expect(result).toEqual(true);
-  });
-
-  it('says two days in the same month are the same', () => {
-    const result = isSameMonth(
-      new Date(2001, 1, 1, 1, 1, 1),
-      new Date(2001, 1, 13, 4, 21, 53)
-    );
-
-    expect(result).toEqual(true);
-  });
-
-  each([
-    // same year/day, different month
-    [new Date(2001, 2, 1, 1, 1, 1), new Date(2001, 3, 1, 1, 1, 1)],
-
-    // same month of year, different year
-    [new Date(2001, 2, 1, 1, 1, 1), new Date(2005, 2, 1, 1, 1, 1)],
-
-    // completely different months
-    [new Date(2001, 2, 3, 1, 1, 1), new Date(2022, 5, 7, 19, 11, 13)],
-  ]).test('identifies %s and %s as different', (a, b) => {
-    const result = isSameMonth(a, b);
-    expect(result).toEqual(false);
   });
 });
 

--- a/common/utils/dates.test.ts
+++ b/common/utils/dates.test.ts
@@ -29,46 +29,39 @@ it('identifies dates in the future', () => {
 describe('isSameDay', () => {
   it('says a day is the same as itself', () => {
     const day = new Date(2001, 1, 1, 1, 1, 1);
-    const result = isSameDay(day, day, 'London');
+    const result = isSameDay(day, day);
 
     expect(result).toEqual(true);
   });
 
-  describe('ComparisonMode', () => {
-    const september19Midnight = new Date(
-      // = Sep 18 2022 23:00:00 UTC
-      'Mon Sep 19 2022 00:00:00 GMT+0100 (British Summer Time)'
-    );
-    const september18TwentyThreeThirty = new Date(
-      // = Sep 18 2022 22:30:00 UTC
-      'Sun Sep 18 2022 23:30:00 GMT+0100 (British Summer Time)'
-    );
-    const september19MidnightThirty = new Date(
-      // = Sep 18 2022 23:30:00 UTC
-      'Mon Sep 19 2022 00:30:00 GMT+0100 (British Summer Time)'
-    );
-    const september19Midday = new Date(
-      // = Sep 19 2022 11:00:00 UTC
-      'Mon Sep 19 2022 12:00:00 GMT+0100 (British Summer Time)'
-    );
+  const september19Midnight = new Date(
+    // = Sep 18 2022 23:00:00 UTC
+    'Mon Sep 19 2022 00:00:00 GMT+0100 (British Summer Time)'
+  );
+  const september18TwentyThreeThirty = new Date(
+    // = Sep 18 2022 22:30:00 UTC
+    'Sun Sep 18 2022 23:30:00 GMT+0100 (British Summer Time)'
+  );
+  const september19MidnightThirty = new Date(
+    // = Sep 18 2022 23:30:00 UTC
+    'Mon Sep 19 2022 00:30:00 GMT+0100 (British Summer Time)'
+  );
+  const september19Midday = new Date(
+    // = Sep 19 2022 11:00:00 UTC
+    'Mon Sep 19 2022 12:00:00 GMT+0100 (British Summer Time)'
+  );
 
-    it('says midnight {x} BST in London is on the same day as midday {x} BST using a comparison mode of "London"', () => {
-      const result = isSameDay(
-        september19Midnight,
-        september19Midday,
-        'London'
-      );
-      expect(result).toEqual(true);
-    });
+  it('says midnight {x} BST is on the same day as midday {x} BST', () => {
+    const result = isSameDay(september19Midnight, september19Midday);
+    expect(result).toEqual(true);
+  });
 
-    it('says 23:30 {x} BST in London is not on the same day as 00:30 {x+1} BST using a comparison mode of "London"', () => {
-      const result = isSameDay(
-        september18TwentyThreeThirty,
-        september19MidnightThirty,
-        'London'
-      );
-      expect(result).toEqual(false);
-    });
+  it('says 23:30 {x} BST is not on the same day as 00:30 {x+1} BST', () => {
+    const result = isSameDay(
+      september18TwentyThreeThirty,
+      september19MidnightThirty
+    );
+    expect(result).toEqual(false);
   });
 
   each([
@@ -87,7 +80,7 @@ describe('isSameDay', () => {
     // completely different days
     [new Date(2001, 2, 3, 1, 1, 1), new Date(2022, 5, 7, 19, 11, 13)],
   ]).test('identifies %s and %s as different (London time)', (a, b) => {
-    const result = isSameDay(a, b, 'London');
+    const result = isSameDay(a, b);
     expect(result).toEqual(false);
   });
 });
@@ -202,7 +195,7 @@ describe('startOfWeek and endOfWeek', () => {
   ])(
     'the week containing $day starts on $expectedStart',
     ({ day, expectedStart }) => {
-      expect(isSameDay(startOfWeek(day), expectedStart, 'London')).toBeTruthy();
+      expect(isSameDay(startOfWeek(day), expectedStart)).toBeTruthy();
     }
   );
 
@@ -213,7 +206,7 @@ describe('startOfWeek and endOfWeek', () => {
   ])(
     'the week containing $day ends on $expectedEnd',
     ({ day, expectedEnd }) => {
-      expect(isSameDay(endOfWeek(day), expectedEnd, 'London')).toBeTruthy();
+      expect(isSameDay(endOfWeek(day), expectedEnd)).toBeTruthy();
     }
   );
 });
@@ -247,8 +240,8 @@ describe('getNextWeekendDateRange', () => {
   ])('the next weekend after $day is $weekend', ({ day, weekend }) => {
     const range = getNextWeekendDateRange(day);
 
-    expect(isSameDay(range.start, weekend.start, 'London')).toBeTruthy();
-    expect(isSameDay(range.end, weekend.end, 'London')).toBeTruthy();
+    expect(isSameDay(range.start, weekend.start)).toBeTruthy();
+    expect(isSameDay(range.end, weekend.end)).toBeTruthy();
   });
 });
 

--- a/common/utils/dates.ts
+++ b/common/utils/dates.ts
@@ -41,31 +41,15 @@ export function isSameMonth(date1: Date, date2: Date): boolean {
   );
 }
 
-type ComparisonMode = 'UTC' | 'London';
-
 /** Returns true if `date1` is on the same day as `date2`, false otherwise.
  *
- * Note: this function supports UTC or London comparisons.  We suspect we always
- * want London comparisons -- uses of this function should be examined and tested
- * to decide the correct behaviour, and updated as necessary.
+ * This compares the dates in London, not UTC.  See the tests for examples
+ * of edge cases where there are different UTC days but this function still
+ * returns true.
  *
- * If we get to a point where every comparison uses London, we should delete the
- * mode argument and document that requirement explicitly.
- *
- * TODO: This should really be London-only.  See https://github.com/wellcomecollection/wellcomecollection.org/issues/9874
  */
-export function isSameDay(
-  date1: Date,
-  date2: Date,
-  mode: ComparisonMode
-): boolean {
-  if (mode === 'UTC') {
-    return (
-      isSameMonth(date1, date2) && date1.getUTCDate() === date2.getUTCDate()
-    );
-  } else {
-    return formatDayDate(date1) === formatDayDate(date2);
-  }
+export function isSameDay(date1: Date, date2: Date): boolean {
+  return formatDayDate(date1) === formatDayDate(date2);
 }
 
 /** Returns true if `date1` is on the same day or before `date2`,
@@ -85,7 +69,7 @@ export function isSameDay(
  *
  */
 export function isSameDayOrBefore(date1: Date, date2: Date): boolean {
-  return isSameDay(date1, date2, 'London') || date1 <= date2;
+  return isSameDay(date1, date2) || date1 <= date2;
 }
 
 type LondonTZ = 'GMT' | 'BST';

--- a/common/utils/dates.ts
+++ b/common/utils/dates.ts
@@ -34,13 +34,6 @@ export function isFuture(date: Date): boolean {
   return date > today();
 }
 
-export function isSameMonth(date1: Date, date2: Date): boolean {
-  return (
-    date1.getUTCFullYear() === date2.getUTCFullYear() &&
-    date1.getUTCMonth() === date2.getUTCMonth()
-  );
-}
-
 /** Returns true if `date1` is on the same day as `date2`, false otherwise.
  *
  * This compares the dates in London, not UTC.  See the tests for examples

--- a/common/views/components/DateRange/DateRange.tsx
+++ b/common/views/components/DateRange/DateRange.tsx
@@ -32,7 +32,7 @@ type Props = {
  *
  */
 const DateRange: FunctionComponent<Props> = ({ start, end, splitTime }) => {
-  return isSameDay(start, end, 'London') ? (
+  return isSameDay(start, end) ? (
     <>
       <HTMLDayDate date={start} />
       {!splitTime && ', '}

--- a/content/webapp/components/StatusIndicator/StatusIndicator.tsx
+++ b/content/webapp/components/StatusIndicator/StatusIndicator.tsx
@@ -26,8 +26,8 @@ export function formatDateRangeWithMessage({
 }): { text: string; color: PaletteColor } {
   const closesInThisWeek = isSameDayOrBefore(end, addDays(today(), 6));
 
-  const opensToday = isSameDay(start, today(), 'London');
-  const closesToday = isSameDay(end, today(), 'London');
+  const opensToday = isSameDay(start, today());
+  const closesToday = isSameDay(end, today());
 
   if (!opensToday && isFuture(start)) {
     return { text: 'Coming soon', color: 'neutral.500' };

--- a/content/webapp/services/prismic/transformers/events.ts
+++ b/content/webapp/services/prismic/transformers/events.ts
@@ -457,8 +457,7 @@ export function transformEventBasicTimes(
   const everyDayHasSomething = daysInScheduleRange.every(d =>
     scheduleTimes.some(
       s =>
-        isSameDay(d, s.range.startDateTime, 'London') ||
-        isSameDay(d, s.range.endDateTime, 'London')
+        isSameDay(d, s.range.startDateTime) || isSameDay(d, s.range.endDateTime)
     )
   );
 

--- a/content/webapp/utils/dates.ts
+++ b/content/webapp/utils/dates.ts
@@ -20,11 +20,7 @@ export function isLibraryOpen(
     return false;
   }
 
-  if (
-    exceptionalClosedDates.find(exception =>
-      isSameDay(date, exception, 'London')
-    )
-  ) {
+  if (exceptionalClosedDates.find(exception => isSameDay(date, exception))) {
     return false;
   }
 
@@ -193,7 +189,7 @@ export function isRequestableDate(params: {
 }): boolean {
   const { date, startDate, endDate, excludedDates, excludedDays } = params;
   const isExceptionalClosedDay = excludedDates.some(excluded =>
-    isSameDay(excluded, date, 'London')
+    isSameDay(excluded, date)
   );
   const isRegularClosedDay = excludedDays.includes(formatDayName(date));
   return (


### PR DESCRIPTION
Now that the codebase is exclusively using London-based date comparisons for `isSameDay`, we can remove the UTC implementation of `isSameDay`. This also allows us to remove `isSameMonth`, which was only used in that function.

Closes #9874 (finally!)