### PR TITLE
Error page footer opening times adjustment

### DIFF
--- a/common/views/components/Footer/index.tsx
+++ b/common/views/components/Footer/index.tsx
@@ -174,11 +174,21 @@ const Footer: FunctionComponent<Props> = ({ venues }: Props) => {
           </FindUsContainer>
 
           <OpeningTimesContainer>
-            <h4 className={font('intb', 5)}>Today&rsquo;s opening times</h4>
-            <OpeningTimes venues={venues} />
-            <Space as="p" v={{ size: 'm', properties: ['margin-top'] }}>
-              <a href="/opening-times">Opening times</a>
-            </Space>
+            {Array.isArray(venues) && venues.length > 0 ? (
+              <>
+                <h4 className={font('intb', 5)}>Today&rsquo;s opening times</h4>
+                <OpeningTimes venues={venues} />
+                <Space as="p" v={{ size: 'm', properties: ['margin-top'] }}>
+                  <a href="/opening-times">Opening times</a>
+                </Space>
+              </>
+            ) : (
+              <>
+                <Space as="p" v={{ size: 'm', properties: ['margin-bottom'] }}>
+                  <a href="/opening-times">Opening times</a>
+                </Space>
+              </>
+            )}
           </OpeningTimesContainer>
 
           <InternalNavigationContainer>

--- a/common/views/components/Footer/index.tsx
+++ b/common/views/components/Footer/index.tsx
@@ -183,11 +183,10 @@ const Footer: FunctionComponent<Props> = ({ venues }: Props) => {
                 </Space>
               </>
             ) : (
-              <>
-                <Space as="p" v={{ size: 'm', properties: ['margin-bottom'] }}>
-                  <a href="/opening-times">Opening times</a>
-                </Space>
-              </>
+              // Error pages do not receive serverData so should only display openingtimes link
+              <Space as="p" v={{ size: 'm', properties: ['margin-bottom'] }}>
+                <a href="/opening-times">Opening times</a>
+              </Space>
             )}
           </OpeningTimesContainer>
 


### PR DESCRIPTION
## Who is this for?
For #8327 
Users encountering a status page

## What is it doing for them?
Cleans the footer to only show the opening times link when user visits an error page - was agreed it was not the best solution to render serverData on error pages to show venue opening times in full.

Currently shows:
![Screenshot 2023-09-25 at 14 05 45](https://github.com/wellcomecollection/wellcomecollection.org/assets/81175151/d36e1c7c-586e-4ac9-b20a-fd1040419e43)

Proposed:
![Screenshot 2023-09-21 at 11 09 56](https://github.com/wellcomecollection/wellcomecollection.org/assets/81175151/ec18dab1-a373-43b3-9c99-ee81ded5bcf8)
