### PR TITLE
Change Item viewer licence/credit section

### DIFF
--- a/common/utils/string.ts
+++ b/common/utils/string.ts
@@ -5,3 +5,7 @@ export function toHtmlId(s: string): string {
 export function removeIdiomaticTextTags(s: string): string {
   return s.replace(/<\/?[iI]>/gm, '');
 }
+
+export function removeTrailingFullStop(s: string): string {
+  return s.replace(/\.$/g, '');
+}

--- a/content/webapp/components/IIIFSearchWithin/IIIFSearchWithin.tsx
+++ b/content/webapp/components/IIIFSearchWithin/IIIFSearchWithin.tsx
@@ -117,8 +117,9 @@ const Hit: FunctionComponent<HitProps> = ({
   return (
     <>
       <HitData v={{ size: 's', properties: ['margin-bottom'] }}>
-        {`Found on image ${matchingCanvasParam}${totalCanvases ? ` / ${totalCanvases}` : ''
-          }`}
+        {`Found on image ${matchingCanvasParam}${
+          totalCanvases ? ` / ${totalCanvases}` : ''
+        }`}
         {label}
       </HitData>
       <span role="presentation">…{hit.before}</span>
@@ -166,7 +167,7 @@ const IIIFSearchWithin: FunctionComponent = () => {
         ).json();
         setIsLoading(false);
         setSearchResults && setSearchResults(results);
-      } catch (error) { }
+      } catch (error) {}
     } else {
       setSearchResults && setSearchResults(results);
     }

--- a/content/webapp/components/IIIFViewer/ViewerSidebar.tsx
+++ b/content/webapp/components/IIIFViewer/ViewerSidebar.tsx
@@ -146,7 +146,7 @@ const ViewerSidebar: FunctionComponent<ViewerSidebarProps> = ({
     matchingManifest?.label &&
     getMultiVolumeLabel(matchingManifest.label, work?.title || '');
 
-  const { iiifCredit, structures, searchService } = { ...transformedManifest };
+  const { structures, searchService } = { ...transformedManifest };
 
   const digitalLocation: DigitalLocation | undefined =
     iiifPresentationLocation || iiifImageLocation;
@@ -155,7 +155,9 @@ const ViewerSidebar: FunctionComponent<ViewerSidebarProps> = ({
     digitalLocation?.license &&
     getCatalogueLicenseData(digitalLocation.license);
 
-  const credit = (digitalLocation && digitalLocation.credit) || iiifCredit;
+  const locationOfWork = work.notes.find(
+    note => note.noteType.id === 'location-of-original'
+  );
 
   return (
     <>
@@ -227,14 +229,19 @@ const ViewerSidebar: FunctionComponent<ViewerSidebarProps> = ({
               </p>
             )}
             <p>
-              <strong>Credit:</strong> {work.title.replace(/\.$/g, '')}.
+              <strong>Credit:</strong> {work.title.replace(/\.$/g, '')}.{' '}
+              {digitalLocation?.credit && <>{digitalLocation?.credit}. </>}
+              Source:{' '}
+              <WorkLink id={work.id} source="viewer_credit">
+                Wellcome Collection
+              </WorkLink>
+              .
             </p>
-            {credit && (
+
+            {locationOfWork && (
               <p>
-                <WorkLink id={work.id} source="viewer_credit">
-                  <a>{credit}</a>
-                </WorkLink>
-                .
+                <strong>Provider: </strong>
+                {locationOfWork.contents}
               </p>
             )}
           </div>

--- a/content/webapp/components/IIIFViewer/ViewerSidebar.tsx
+++ b/content/webapp/components/IIIFViewer/ViewerSidebar.tsx
@@ -19,7 +19,7 @@ import ItemViewerContext from '../ItemViewerContext/ItemViewerContext';
 import MultipleManifestList from './MultipleManifestList';
 import IIIFSearchWithin from '../IIIFSearchWithin/IIIFSearchWithin';
 import WorkTitle from '../WorkTitle/WorkTitle';
-import { toHtmlId } from '@weco/common/utils/string';
+import { removeTrailingFullStop, toHtmlId } from '@weco/common/utils/string';
 import { arrow, chevron } from '@weco/common/icons';
 import { getMultiVolumeLabel } from '@weco/content/utils/iiif/v3';
 import { OptionalToUndefined } from '@weco/common/utils/utility-types';
@@ -229,7 +229,7 @@ const ViewerSidebar: FunctionComponent<ViewerSidebarProps> = ({
               </p>
             )}
             <p>
-              <strong>Credit:</strong> {work.title.replace(/\.$/g, '')}.{' '}
+              <strong>Credit:</strong> {removeTrailingFullStop(work.title)}.{' '}
               {digitalLocation?.credit && <>{digitalLocation?.credit}. </>}
               Source:{' '}
               <WorkLink id={work.id} source="viewer_credit">

--- a/content/webapp/components/IIIFViewer/ViewerSidebar.tsx
+++ b/content/webapp/components/IIIFViewer/ViewerSidebar.tsx
@@ -94,7 +94,7 @@ const AccordionItem = ({ title, children, testId }: AccordionItemProps) => {
   }, []);
 
   return (
-    <Item data-test-id={testId}>
+    <Item data-testid={testId}>
       <AccordionInner onClick={() => setIsActive(!isActive)}>
         <AccordionButton
           aria-expanded={isActive ? 'true' : 'false'}
@@ -214,7 +214,7 @@ const ViewerSidebar: FunctionComponent<ViewerSidebarProps> = ({
         </Space>
       </Inner>
       <Inner>
-        <AccordionItem title="Licence and credit" testId="license-and-credit">
+        <AccordionItem title="Licence and re-use" testId="licence-and-reuse">
           <div className={font('intr', 6)}>
             {license && license.label && (
               <p>

--- a/content/webapp/components/ItemViewerContext/ItemViewerContext.tsx
+++ b/content/webapp/components/ItemViewerContext/ItemViewerContext.tsx
@@ -85,6 +85,7 @@ const work: WorkBasic & Pick<Work, 'description'> = {
   archiveLabels: undefined,
   cardLabels: [],
   primaryContributorLabel: undefined,
+  notes: [],
 };
 
 const ItemViewerContext = createContext<Props>({

--- a/content/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/content/webapp/components/WorkDetails/WorkDetails.tsx
@@ -49,6 +49,7 @@ import {
 import { themeValues } from '@weco/common/views/themes/config';
 import { formatDuration } from '@weco/common/utils/format-date';
 import { CopyContent, CopyUrl } from '@weco/content/components/CopyButtons';
+import { removeTrailingFullStop } from '@weco/common/utils/string';
 
 type Props = {
   work: Work;
@@ -477,7 +478,9 @@ const WorkDetails: FunctionComponent<Props> = ({
                             </p>
                             <CopyContent
                               CTA="Copy credit information"
-                              content={`${work.title.replace(/\.$/g, '')}. ${
+                              content={`${removeTrailingFullStop(
+                                work.title
+                              )}. ${
                                 digitalLocation?.credit
                                   ? `${digitalLocation.credit}. `
                                   : ''
@@ -489,7 +492,7 @@ const WorkDetails: FunctionComponent<Props> = ({
                               displayedContent={
                                 <p>
                                   {/* Regex removes trailing full-stops.  */}
-                                  {work.title.replace(/\.$/g, '')}.{' '}
+                                  {removeTrailingFullStop(work.title)}.{' '}
                                   {digitalLocation?.credit && (
                                     <>{digitalLocation?.credit}. </>
                                   )}

--- a/content/webapp/pages/works/[workId]/download.tsx
+++ b/content/webapp/pages/works/[workId]/download.tsx
@@ -30,6 +30,7 @@ import { looksLikeCanonicalId } from '@weco/content/services/wellcome/catalogue'
 import { fetchIIIFPresentationManifest } from '@weco/content/services/iiif/fetch/manifest';
 import { transformManifest } from '@weco/content/services/iiif/transformers/manifest';
 import { setCacheControl } from '@weco/common/utils/setCacheControl';
+import { removeTrailingFullStop } from '@weco/common/utils/string';
 
 type CreditProps = {
   workId: string;
@@ -44,7 +45,7 @@ const Credit: FunctionComponent<CreditProps> = ({
   credit,
   license,
 }) => {
-  const titleCredit = title.replace(/\.$/g, '');
+  const titleCredit = removeTrailingFullStop(title);
 
   const linkCredit = credit && (
     <>

--- a/content/webapp/pages/works/[workId]/items.tsx
+++ b/content/webapp/pages/works/[workId]/items.tsx
@@ -392,7 +392,7 @@ export const getServerSideProps: GetServerSideProps<
   const work = await getWork({
     id: context.query.workId,
     toggles: serverData.toggles,
-    include: ['items', 'languages', 'contributors', 'production'],
+    include: ['items', 'languages', 'contributors', 'production', 'notes'],
   });
 
   if (work.type === 'Error') {

--- a/content/webapp/services/wellcome/catalogue/types/index.ts
+++ b/content/webapp/services/wellcome/catalogue/types/index.ts
@@ -185,7 +185,7 @@ type Language = {
   type: 'Language';
 };
 
-type Note = {
+export type Note = {
   contents: string[];
   noteType: NoteType;
   type: 'Note';

--- a/content/webapp/services/wellcome/catalogue/types/work.ts
+++ b/content/webapp/services/wellcome/catalogue/types/work.ts
@@ -8,6 +8,7 @@ import { Work } from '.';
 import { Label } from '@weco/common/model/labels';
 import { DigitalLocation } from '@weco/common/model/catalogue';
 import { OptionalToUndefined } from '@weco/common/utils/utility-types';
+import { Note } from '@weco/content/services/wellcome/catalogue/types';
 
 export type WorkBasic = OptionalToUndefined<{
   id: string;
@@ -19,10 +20,11 @@ export type WorkBasic = OptionalToUndefined<{
   archiveLabels?: ArchiveLabels;
   cardLabels: Label[];
   primaryContributorLabel?: string;
+  notes: Note[];
 }>;
 
 export function toWorkBasic(work: Work): WorkBasic {
-  const { id, title, thumbnail, referenceNumber } = work;
+  const { id, title, thumbnail, referenceNumber, notes } = work;
 
   // We only send a lang if it's unambiguous -- better to send
   // no language than the wrong one.
@@ -43,5 +45,6 @@ export function toWorkBasic(work: Work): WorkBasic {
     primaryContributorLabel: work.contributors.find(
       contributor => contributor.primary
     )?.agent.label,
+    notes,
   };
 }

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -184,7 +184,7 @@ test.describe('Scenario 4: A user wants to know how they can make use of an item
     if (isMobile(page)) {
       await page.click('text="Show info"');
     }
-    await page.click('text="Licence and credit"');
+    await page.getByTestId('licence-and-reuse').click();
     await page.waitForSelector(`css=body >> text="Licence:"`);
     await page.waitForSelector(`css=body >> text="Credit:"`);
   });


### PR DESCRIPTION
## Who is this for?
Credit/licence work
Relates to #10226 

## What is it doing for them?
- Adds provider
- Changes format of "Credit" to align with Work page's
- Tweaks test (test-id wasn't used anymore but was still declared)
- Changes label to "Licence and re-use" to align with Work page
- Also to Alex's suggestion in another PR, I've made a `removeTrailingFullStop` util as the same regex was used four times.

A few examples:

<img width="438" alt="Screenshot 2023-09-29 at 12 36 18" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/38b1316a-09cb-46ec-a5dd-e43b0fca149a">
<img width="413" alt="Screenshot 2023-09-29 at 12 37 23" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/06c167fe-bc34-4160-b78d-03a636bef851">
<img width="685" alt="Screenshot 2023-09-29 at 12 51 05" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/04d9260a-73c0-4036-bc1b-15529090cdcc">
