### PR TITLE
Remove condition that hid Licence and reuse from certain works

### DIFF
--- a/content/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/content/webapp/components/WorkDetails/WorkDetails.tsx
@@ -427,97 +427,80 @@ const WorkDetails: FunctionComponent<Props> = ({
                   />
                 </Space>
               )}
-              {/* TODO remove this hack once we figure out a better way to display copyrights
-              This was a sensitive issue to fix asap 
-              https://github.com/wellcomecollection/wellcomecollection.org/issues/9964 */}
-              {![
-                'wys2bdym',
-                'avqn5jd8',
-                'vsp8ce9z',
-                'a3v24ekj',
-                'ex597wgz',
-                'erqm9zxq',
-                'y2w42fqa',
-                'uzcvr64w',
-                'b5m8zwvd',
-                'bbbwbh85',
-                'y6ntecuu',
-              ].includes(work.id) && (
-                <Space
-                  v={{
-                    size: 'l',
-                    properties: ['margin-top'],
-                  }}
+              <Space
+                v={{
+                  size: 'l',
+                  properties: ['margin-top'],
+                }}
+              >
+                <CollapsibleContent
+                  id="licenseDetail"
+                  controlText={{ defaultText: 'Licence and re-use' }}
                 >
-                  <CollapsibleContent
-                    id="licenseDetail"
-                    controlText={{ defaultText: 'Licence and re-use' }}
-                  >
-                    <>
-                      {digitalLocationInfo.license.humanReadableText && (
-                        <WorkDetailsText
-                          contents={
-                            <>
-                              <p>
-                                <strong>
-                                  {digitalLocationInfo.license.label}
-                                </strong>
-                              </p>
-                              {digitalLocationInfo.license.humanReadableText}
-                            </>
-                          }
-                        />
-                      )}
-
+                  <>
+                    {digitalLocationInfo.license.humanReadableText && (
                       <WorkDetailsText
                         contents={
                           <>
                             <p>
-                              <strong>Credit</strong>
+                              <strong>
+                                {digitalLocationInfo.license.label}
+                              </strong>
                             </p>
-                            <CopyContent
-                              CTA="Copy credit information"
-                              content={`${work.title.replace(/\.$/g, '')}. ${
-                                digitalLocation?.credit
-                                  ? `${digitalLocation.credit}. `
-                                  : ''
-                              }${
-                                digitalLocationInfo.license.label
-                              }. Source: Wellcome Collection. https://wellcomecollection.org/works/${
-                                work.id
-                              }`}
-                              displayedContent={
-                                <p>
-                                  {/* Regex removes trailing full-stops.  */}
-                                  {work.title.replace(/\.$/g, '')}.{' '}
-                                  {digitalLocation?.credit && (
-                                    <>{digitalLocation?.credit}. </>
-                                  )}
-                                  {digitalLocationInfo.license.label}. Source:
-                                  Wellcome Collection.
-                                </p>
-                              }
-                            />
+                            {digitalLocationInfo.license.humanReadableText}
                           </>
                         }
                       />
+                    )}
 
-                      {locationOfWork && (
-                        <WorkDetailsText
-                          contents={
-                            <>
+                    <WorkDetailsText
+                      contents={
+                        <>
+                          <p>
+                            <strong>Credit</strong>
+                          </p>
+                          <CopyContent
+                            CTA="Copy credit information"
+                            content={`${work.title.replace(/\.$/g, '')}. ${
+                              digitalLocation?.credit
+                                ? `${digitalLocation.credit}. `
+                                : ''
+                            }${
+                              digitalLocationInfo.license.label
+                            }. Source: Wellcome Collection. https://wellcomecollection.org/works/${
+                              work.id
+                            }`}
+                            displayedContent={
                               <p>
-                                <strong>Provider</strong>
+                                {/* Regex removes trailing full-stops.  */}
+                                {work.title.replace(/\.$/g, '')}.{' '}
+                                {digitalLocation?.credit && (
+                                  <>{digitalLocation?.credit}. </>
+                                )}
+                                {digitalLocationInfo.license.label}. Source:
+                                Wellcome Collection.
                               </p>
-                              <p>{locationOfWork.contents}</p>
-                            </>
-                          }
-                        />
-                      )}
-                    </>
-                  </CollapsibleContent>
-                </Space>
-              )}
+                            }
+                          />
+                        </>
+                      }
+                    />
+
+                    {locationOfWork && (
+                      <WorkDetailsText
+                        contents={
+                          <>
+                            <p>
+                              <strong>Provider</strong>
+                            </p>
+                            <p>{locationOfWork.contents}</p>
+                          </>
+                        }
+                      />
+                    )}
+                  </>
+                </CollapsibleContent>
+              </Space>
             </>
           )}
         </WorkDetailsSection>

--- a/content/webapp/components/WorkDetails/WorkDetails.tsx
+++ b/content/webapp/components/WorkDetails/WorkDetails.tsx
@@ -448,31 +448,7 @@ const WorkDetails: FunctionComponent<Props> = ({
                                 {digitalLocationInfo.license.label}
                               </strong>
                             </p>
-                            <CopyContent
-                              CTA="Copy credit information"
-                              content={`${removeTrailingFullStop(
-                                work.title
-                              )}. ${
-                                digitalLocation?.credit
-                                  ? `${digitalLocation.credit}. `
-                                  : ''
-                              }${
-                                digitalLocationInfo.license.label
-                              }. Source: Wellcome Collection. https://wellcomecollection.org/works/${
-                                work.id
-                              }`}
-                              displayedContent={
-                                <p>
-                                  {/* Regex removes trailing full-stops.  */}
-                                  {removeTrailingFullStop(work.title)}.{' '}
-                                  {digitalLocation?.credit && (
-                                    <>{digitalLocation?.credit}. </>
-                                  )}
-                                  {digitalLocationInfo.license.label}. Source:
-                                  Wellcome Collection.
-                                </p>
-                              }
-                            />
+                            {digitalLocationInfo.license.humanReadableText}
                           </>
                         }
                       />
@@ -486,7 +462,7 @@ const WorkDetails: FunctionComponent<Props> = ({
                           </p>
                           <CopyContent
                             CTA="Copy credit information"
-                            content={`${work.title.replace(/\.$/g, '')}. ${
+                            content={`${removeTrailingFullStop(work.title)}. ${
                               digitalLocation?.credit
                                 ? `${digitalLocation.credit}. `
                                 : ''
@@ -498,7 +474,7 @@ const WorkDetails: FunctionComponent<Props> = ({
                             displayedContent={
                               <p>
                                 {/* Regex removes trailing full-stops.  */}
-                                {work.title.replace(/\.$/g, '')}.{' '}
+                                {removeTrailingFullStop(work.title)}.{' '}
                                 {digitalLocation?.credit && (
                                   <>{digitalLocation?.credit}. </>
                                 )}


### PR DESCRIPTION
## Who is this for?
Maintenance
Relates to #10253 

## What is it doing for them?
Allows the information to display again after we've worked on making it more relevant.

<img width="861" alt="Screenshot 2023-09-29 at 13 21 53" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/0853b764-511d-483e-a161-820c396421ff">
<img width="861" alt="Screenshot 2023-09-29 at 13 22 52" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/186bda4c-4158-4379-8ea3-7f011e246df4">

