### PR TITLE
Toggles for GA

### DIFF
--- a/common/server-data/Context.tsx
+++ b/common/server-data/Context.tsx
@@ -18,7 +18,10 @@ export const ServerDataContext =
  * Over:
  * `const { toggles: { toggleName } } = useContext(ServerDataContext)`
  */
-export const useToggles = (): Record<ToggleId | TestId, boolean | undefined> => {
+
+type ClientToggleValues = Record<ToggleId | TestId, boolean | undefined>;
+
+export const useToggles = (): ClientToggleValues => {
   const data = useContext(ServerDataContext);
   const toggles = Object.keys(data.toggles).reduce((acc, key) => {
     acc[key] = data.toggles[key].value;

--- a/common/server-data/Context.tsx
+++ b/common/server-data/Context.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext } from 'react';
 import { defaultServerData, SimplifiedServerData } from './types';
 import { SimplifiedPrismicData } from './prismic';
-import { Toggles } from '@weco/toggles';
+import { ToggleId, TestId } from '@weco/toggles';
 
 /**
  * `AppData` is data that we retrieve from ServerData (data cached on the filesystem)
@@ -18,9 +18,13 @@ export const ServerDataContext =
  * Over:
  * `const { toggles: { toggleName } } = useContext(ServerDataContext)`
  */
-export const useToggles = (): Toggles => {
+export const useToggles = (): Record<ToggleId | TestId, boolean | undefined> => {
   const data = useContext(ServerDataContext);
-  return data.toggles;
+  const toggles = Object.keys(data.toggles).reduce((acc, key) => {
+    acc[key] = data.toggles[key].value;
+  return acc;
+}, {});
+  return toggles;
 };
 
 export const usePrismicData = (): SimplifiedPrismicData => {

--- a/common/server-data/Context.tsx
+++ b/common/server-data/Context.tsx
@@ -25,8 +25,8 @@ export const useToggles = (): ClientToggleValues => {
   const data = useContext(ServerDataContext);
   const toggles = Object.keys(data.toggles).reduce((acc, key) => {
     acc[key] = data.toggles[key].value;
-  return acc;
-}, {});
+    return acc;
+  }, {});
   return toggles;
 };
 

--- a/common/server-data/index.ts
+++ b/common/server-data/index.ts
@@ -123,13 +123,11 @@ export const getServerData = async (
 
   const toggles = getTogglesFromContext(togglesResp, context);
 
-  const isEnableToggleValid = Object.keys(toggles).some(
-    id => id === enableToggle
-  );
+  const isEnableToggleValid = Object.keys(toggles).some(id => id === enableToggle);
 
   if (enableToggle && isEnableToggleValid) {
     context.res.setHeader('Set-Cookie', `toggle_${enableToggle}=true; Path=/`);
-    toggles[enableToggle] = true;
+    toggles[enableToggle].value = true;
   }
 
   const serverData = { toggles, prismic };

--- a/common/server-data/toggles.ts
+++ b/common/server-data/toggles.ts
@@ -40,9 +40,12 @@ export function getTogglesFromContext(
     (acc, toggle) => ({
       ...acc,
       [toggle.id]:
-        allCookies[`toggle_${toggle.id}`] === 'true'
+      {
+        value: allCookies[`toggle_${toggle.id}`] === 'true'
           ? true
           : toggle.defaultValue,
+        type: toggle.type,
+      }
     }),
     {} as Toggles
   );
@@ -60,10 +63,13 @@ export function getTogglesFromContext(
     }
     return {
       ...acc,
-      [test.id]: testToggleValue(test.id),
+      [test.id]: {
+        value: testToggleValue(test.id),
+        type: 'test'
+      }
     };
   }, {} as Toggles);
-  return { ...toggles, ...tests };
+  return { ...toggles, ...tests } as Toggles;
 }
 
 export default togglesHandler;

--- a/common/services/app/google-analytics.tsx
+++ b/common/services/app/google-analytics.tsx
@@ -24,7 +24,8 @@ type Props = {
 
 // We send toggles as an event parameter to GA4 so we can determine the condition in which a particular event took place.
 // GA4 now limits event parameter values to 100 characters: https://support.google.com/analytics/answer/9267744?hl=en
-// So instead of sending the whole toggles JSON blob we send a concatenated string of only the toggle names (preceeded with a ! if the toggle is false). We also remove toggles we know we don't care about, i.e. those that aren't part of a test
+// So instead of sending the whole toggles JSON blob, we only look at the "test" typed toggles and send a concatenated string made of the toggles' name
+// , preceeded with a! if its value is false.
 function createToggleString(toggles: Toggles | undefined): string | null {
   const testToggles = toggles ? Object.keys(toggles).reduce((acc, key) => {
     if (toggles?.[key].type === 'test') {

--- a/common/services/app/google-analytics.tsx
+++ b/common/services/app/google-analytics.tsx
@@ -27,15 +27,17 @@ type Props = {
 // So instead of sending the whole toggles JSON blob, we only look at the "test" typed toggles and send a concatenated string made of the toggles' name
 // , preceeded with a! if its value is false.
 function createToggleString(toggles: Toggles | undefined): string | null {
-  const testToggles = toggles ? Object.keys(toggles).reduce((acc, key) => {
-    if (toggles?.[key].type === 'test') {
-        acc[key] = toggles?.[key].value;
-    }
-    return acc;
-  }, {}) : null;
+  const testToggles = toggles
+    ? Object.keys(toggles).reduce((acc, key) => {
+        if (toggles?.[key].type === 'test') {
+          acc[key] = toggles?.[key].value;
+        }
+        return acc;
+      }, {})
+    : null;
   return testToggles
     ? Object.keys(testToggles)
-      .map(toggle => {
+        .map(toggle => {
           switch (testToggles[toggle]) {
             case true:
               return toggle;
@@ -50,8 +52,7 @@ function createToggleString(toggles: Toggles | undefined): string | null {
 }
 
 export const Ga4DataLayer: FunctionComponent<Props> = ({ data }) => {
-
-  const toggleString = createToggleString(data.toggles)
+  const toggleString = createToggleString(data.toggles);
 
   return toggleString ? (
     <script

--- a/common/views/themes/default.ts
+++ b/common/views/themes/default.ts
@@ -14,6 +14,7 @@ import { inlineFonts } from './base/inline-fonts';
 import { fonts } from './base/fonts';
 import { themeValues, spacingUnits, Size } from './config';
 import { grid } from './grid';
+import { Toggles } from '@weco/toggles';
 
 type SpaceSize = 'xs' | 's' | 'm' | 'l' | 'xl';
 type SpaceProperty =
@@ -98,7 +99,7 @@ const cls = {
 } as any as Classes & SizedClasses;
 
 export type GlobalStyleProps = {
-  toggles?: { [key: string]: boolean | undefined };
+  toggles?: Toggles;
   isFontsLoaded?: boolean;
 };
 

--- a/content/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
+++ b/content/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
@@ -79,7 +79,7 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
   const { isFullSupportBrowser } = useContext(AppContext);
   const [expandedImage, setExpandedImage] = useState<Image | undefined>();
   const [isActive, setIsActive] = useState(false);
-  const {toggles} = useContext(ServerDataContext);
+  const { toggles } = useContext(ServerDataContext);
 
   const imageMap = useMemo<Record<string, Image>>(
     () => images.reduce((a, image) => ({ ...a, [image.id]: image }), {}),

--- a/content/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
+++ b/content/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
@@ -79,7 +79,7 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
   const { isFullSupportBrowser } = useContext(AppContext);
   const [expandedImage, setExpandedImage] = useState<Image | undefined>();
   const [isActive, setIsActive] = useState(false);
-  const data = useContext(ServerDataContext);
+  const {toggles} = useContext(ServerDataContext);
 
   const imageMap = useMemo<Record<string, Image>>(
     () => images.reduce((a, image) => ({ ...a, [image.id]: image }), {}),
@@ -105,7 +105,7 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
         setIsActive(true);
       } else {
         // if it's not, fetch the image and then update
-        const { image } = await getImage({ id: hash, toggles: data.toggles });
+        const { image } = await getImage({ id: hash, toggles });
         if (image.type === 'Image') {
           imageMap[image.id] = image;
           setExpandedImage(image);

--- a/content/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
+++ b/content/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
@@ -21,7 +21,7 @@ import Modal from '@weco/common/views/components/Modal/Modal';
 import PlainList from '@weco/common/views/components/styled/PlainList';
 import Space from '@weco/common/views/components/styled/Space';
 import { getImage } from '@weco/content/services/wellcome/catalogue/images';
-import { useToggles } from '@weco/common/server-data/Context';
+import { ServerDataContext } from '@weco/common/server-data/Context';
 
 type Props = {
   images: Image[];
@@ -79,7 +79,7 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
   const { isFullSupportBrowser } = useContext(AppContext);
   const [expandedImage, setExpandedImage] = useState<Image | undefined>();
   const [isActive, setIsActive] = useState(false);
-  const toggles = useToggles();
+  const data = useContext(ServerDataContext);
 
   const imageMap = useMemo<Record<string, Image>>(
     () => images.reduce((a, image) => ({ ...a, [image.id]: image }), {}),
@@ -105,7 +105,7 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
         setIsActive(true);
       } else {
         // if it's not, fetch the image and then update
-        const { image } = await getImage({ id: hash, toggles });
+        const { image } = await getImage({ id: hash, toggles: data.toggles });
         if (image.type === 'Image') {
           imageMap[image.id] = image;
           setExpandedImage(image);

--- a/content/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.tsx
+++ b/content/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.tsx
@@ -58,7 +58,7 @@ const VisuallySimilarImagesFromApi: FunctionComponent<Props> = ({
 }: Props) => {
   const [similarImages, setSimilarImages] = useState<ImageType[]>([]);
   const [requestState, setRequestState] = useState<State>('initial');
-  const {toggles} = useContext(ServerDataContext);
+  const { toggles } = useContext(ServerDataContext);
 
   useEffect(() => {
     setRequestState('loading');

--- a/content/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.tsx
+++ b/content/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.tsx
@@ -58,14 +58,14 @@ const VisuallySimilarImagesFromApi: FunctionComponent<Props> = ({
 }: Props) => {
   const [similarImages, setSimilarImages] = useState<ImageType[]>([]);
   const [requestState, setRequestState] = useState<State>('initial');
-  const data = useContext(ServerDataContext);
+  const {toggles} = useContext(ServerDataContext);
 
   useEffect(() => {
     setRequestState('loading');
     const fetchVisuallySimilarImages = async () => {
       const { image: fullImage } = await getImage({
         id: originalId,
-        toggles: data.toggles,
+        toggles,
         include: ['withSimilarFeatures'],
       });
       if (fullImage.type === 'Image') {

--- a/content/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.tsx
+++ b/content/webapp/components/VisuallySimilarImagesFromApi/VisuallySimilarImagesFromApi.tsx
@@ -1,11 +1,11 @@
-import { FunctionComponent, useEffect, useState } from 'react';
+import { FunctionComponent, useEffect, useState, useContext } from 'react';
 import styled from 'styled-components';
 
 import { font } from '@weco/common/utils/classnames';
 import { Image as ImageType } from '@weco/content/services/wellcome/catalogue/types';
 import { getImage } from '@weco/content/services/wellcome/catalogue/images';
 import Space from '@weco/common/views/components/styled/Space';
-import { useToggles } from '@weco/common/server-data/Context';
+import { ServerDataContext } from '@weco/common/server-data/Context';
 import IIIFImage from '@weco/content/components/IIIFImage/IIIFImage';
 import LL from '@weco/common/views/components/styled/LL';
 import { trackSegmentEvent } from '@weco/common/services/conversion/track';
@@ -58,14 +58,14 @@ const VisuallySimilarImagesFromApi: FunctionComponent<Props> = ({
 }: Props) => {
   const [similarImages, setSimilarImages] = useState<ImageType[]>([]);
   const [requestState, setRequestState] = useState<State>('initial');
-  const toggles = useToggles();
+  const data = useContext(ServerDataContext);
 
   useEffect(() => {
     setRequestState('loading');
     const fetchVisuallySimilarImages = async () => {
       const { image: fullImage } = await getImage({
         id: originalId,
-        toggles,
+        toggles: data.toggles,
         include: ['withSimilarFeatures'],
       });
       if (fullImage.type === 'Image') {

--- a/content/webapp/pages/search/works.tsx
+++ b/content/webapp/pages/search/works.tsx
@@ -261,14 +261,14 @@ export const getServerSideProps: GetServerSideProps<
     };
   }
 
-  const aggregations = serverData.toggles.aggregationsInSearch
+  const aggregations = serverData.toggles.aggregationsInSearch?.value
     ? [
-      serverData.toggles.aggregationsInSearchWorkType ? 'workType' : undefined,
-      serverData.toggles.aggregationsInSearchAvailabilities ? 'availabilities' : undefined,
-      serverData.toggles.aggregationsInSearchGenres ? 'genres.label' : undefined,
-      serverData.toggles.aggregationsInSearchLanguages ? 'languages' : undefined,
-      serverData.toggles.aggregationsInSearchSubjects ? 'subjects.label' : undefined,
-      serverData.toggles.aggregationsInSearchContributors ? 'contributors.agent.label' : undefined,
+      serverData.toggles.aggregationsInSearchWorkType?.value ? 'workType' : undefined,
+      serverData.toggles.aggregationsInSearchAvailabilities?.value ? 'availabilities' : undefined,
+      serverData.toggles.aggregationsInSearchGenres?.value ? 'genres.label' : undefined,
+      serverData.toggles.aggregationsInSearchLanguages?.value ? 'languages' : undefined,
+      serverData.toggles.aggregationsInSearchSubjects?.value ? 'subjects.label' : undefined,
+      serverData.toggles.aggregationsInSearchContributors?.value ? 'contributors.agent.label' : undefined,
     ].filter(isNotUndefined)
     : [];
 

--- a/content/webapp/pages/search/works.tsx
+++ b/content/webapp/pages/search/works.tsx
@@ -263,13 +263,25 @@ export const getServerSideProps: GetServerSideProps<
 
   const aggregations = serverData.toggles.aggregationsInSearch?.value
     ? [
-      serverData.toggles.aggregationsInSearchWorkType?.value ? 'workType' : undefined,
-      serverData.toggles.aggregationsInSearchAvailabilities?.value ? 'availabilities' : undefined,
-      serverData.toggles.aggregationsInSearchGenres?.value ? 'genres.label' : undefined,
-      serverData.toggles.aggregationsInSearchLanguages?.value ? 'languages' : undefined,
-      serverData.toggles.aggregationsInSearchSubjects?.value ? 'subjects.label' : undefined,
-      serverData.toggles.aggregationsInSearchContributors?.value ? 'contributors.agent.label' : undefined,
-    ].filter(isNotUndefined)
+        serverData.toggles.aggregationsInSearchWorkType?.value
+          ? 'workType'
+          : undefined,
+        serverData.toggles.aggregationsInSearchAvailabilities?.value
+          ? 'availabilities'
+          : undefined,
+        serverData.toggles.aggregationsInSearchGenres?.value
+          ? 'genres.label'
+          : undefined,
+        serverData.toggles.aggregationsInSearchLanguages?.value
+          ? 'languages'
+          : undefined,
+        serverData.toggles.aggregationsInSearchSubjects?.value
+          ? 'subjects.label'
+          : undefined,
+        serverData.toggles.aggregationsInSearchContributors?.value
+          ? 'contributors.agent.label'
+          : undefined,
+      ].filter(isNotUndefined)
     : [];
 
   const worksApiProps = {

--- a/content/webapp/pages/visual-stories/[visualStoryId].tsx
+++ b/content/webapp/pages/visual-stories/[visualStoryId].tsx
@@ -29,7 +29,7 @@ export const getServerSideProps = async context => {
   const { visualStoryId } = context.query;
   const serverData = await getServerData(context);
 
-  if (!serverData?.toggles?.visualStories) {
+  if (!serverData?.toggles?.visualStories?.value) {
     return { notFound: true };
   }
 

--- a/content/webapp/pages/visual-stories/index.tsx
+++ b/content/webapp/pages/visual-stories/index.tsx
@@ -6,8 +6,7 @@ import { font } from '@weco/common/utils/classnames';
 
 export const getServerSideProps = async context => {
   const serverData = await getServerData(context);
-
-  if (!serverData?.toggles?.visualStories) {
+  if (!serverData?.toggles?.visualStories?.value) {
     return { notFound: true };
   }
 

--- a/content/webapp/pages/visual-stories/v1.tsx
+++ b/content/webapp/pages/visual-stories/v1.tsx
@@ -6,7 +6,7 @@ import { V1Prototype } from '@weco/content/components/VisualStories';
 export const getServerSideProps = async context => {
   const serverData = await getServerData(context);
 
-  if (!serverData?.toggles?.visualStories) {
+  if (!serverData?.toggles?.visualStories?.value) {
     return { notFound: true };
   }
 

--- a/content/webapp/pages/visual-stories/v2.tsx
+++ b/content/webapp/pages/visual-stories/v2.tsx
@@ -5,8 +5,7 @@ import { V2Prototype } from '@weco/content/components/VisualStories';
 
 export const getServerSideProps = async context => {
   const serverData = await getServerData(context);
-
-  if (!serverData?.toggles?.visualStories) {
+  if (!serverData?.toggles?.visualStories?.value) {
     return { notFound: true };
   }
 

--- a/content/webapp/services/wellcome/catalogue/images.ts
+++ b/content/webapp/services/wellcome/catalogue/images.ts
@@ -1,6 +1,6 @@
 import { CatalogueImagesApiProps, CatalogueResultsList, Image } from './types';
 import { rootUris, notFound, looksLikeCanonicalId, catalogueQuery } from '.';
-import { Toggles } from '@weco/toggles';
+import { ToggleId, TestId } from '@weco/toggles';
 import { propsToQuery } from '@weco/common/utils/routes';
 import {
   emptyImagesProps,
@@ -24,7 +24,7 @@ type ImageInclude =
 
 type GetImageProps = {
   id: string;
-  toggles: Toggles;
+  toggles: Record<ToggleId | TestId, boolean | undefined>;
   include?: ImageInclude[];
 };
 

--- a/content/webapp/services/wellcome/catalogue/images.ts
+++ b/content/webapp/services/wellcome/catalogue/images.ts
@@ -1,6 +1,6 @@
 import { CatalogueImagesApiProps, CatalogueResultsList, Image } from './types';
 import { rootUris, notFound, looksLikeCanonicalId, catalogueQuery } from '.';
-import { ToggleId, TestId } from '@weco/toggles';
+import { Toggles, ToggleId, TestId } from '@weco/toggles';
 import { propsToQuery } from '@weco/common/utils/routes';
 import {
   emptyImagesProps,
@@ -24,7 +24,7 @@ type ImageInclude =
 
 type GetImageProps = {
   id: string;
-  toggles: Record<ToggleId | TestId, boolean | undefined>;
+  toggles: Toggles;
   include?: ImageInclude[];
 };
 

--- a/content/webapp/services/wellcome/catalogue/images.ts
+++ b/content/webapp/services/wellcome/catalogue/images.ts
@@ -1,6 +1,6 @@
 import { CatalogueImagesApiProps, CatalogueResultsList, Image } from './types';
 import { rootUris, notFound, looksLikeCanonicalId, catalogueQuery } from '.';
-import { Toggles, ToggleId, TestId } from '@weco/toggles';
+import { Toggles } from '@weco/toggles';
 import { propsToQuery } from '@weco/common/utils/routes';
 import {
   emptyImagesProps,

--- a/content/webapp/services/wellcome/index.ts
+++ b/content/webapp/services/wellcome/index.ts
@@ -8,7 +8,7 @@ export type GlobalApiOptions = {
 };
 
 export const globalApiOptions = (toggles?: Toggles): GlobalApiOptions => ({
-  env: toggles?.stagingApi ? 'stage' : 'prod',
+  env: toggles?.stagingApi?.value ? 'stage' : 'prod',
 });
 
 // Used as a helper to return a typesafe empty results list

--- a/toggles/webapp/index.ts
+++ b/toggles/webapp/index.ts
@@ -1,10 +1,10 @@
-import toggleConfig, { ABTest, PublishedToggle } from './toggles';
+import toggleConfig, { ABTest, PublishedToggle, ToggleTypes } from './toggles';
 
 const toggleIds = toggleConfig.toggles.map(toggle => toggle.id);
 const testIds = toggleConfig.tests.map(test => test.id);
 
-type ToggleId = (typeof toggleIds)[number];
-type TestId = (typeof testIds)[number];
+export type ToggleId = (typeof toggleIds)[number];
+export type TestId = (typeof testIds)[number];
 
 // As togglesConfig is what is served at https://toggles.wellcomecollection.org/toggles.json
 // This allows methods fetching that URL to type the data fetched
@@ -12,4 +12,5 @@ export type TogglesResp = { toggles: PublishedToggle[]; tests: ABTest[] };
 
 // Don't be tempted to make the keys on this optional - keeping them
 // as required means we catch dead code left over from removed toggles
-export type Toggles = Record<ToggleId | TestId, boolean | undefined>;
+export type Toggles = Record<ToggleId | TestId, { value: boolean | undefined, type: ToggleTypes} >
+

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -1,10 +1,12 @@
 import { CloudFrontRequest } from 'aws-lambda';
 
+export type ToggleTypes = 'permanent' | 'experimental' | 'test';
+
 type ToggleBase = {
   id: string;
   title: string;
   description: string;
-  type: 'permanent' | 'experimental';
+  type: ToggleTypes;
 };
 
 export type ToggleDefinition = ToggleBase & {
@@ -20,6 +22,7 @@ export type ABTest = {
   title: string;
   range: [number, number];
   when: (request: CloudFrontRequest) => boolean;
+  type: 'test';
 };
 
 const toggles = {


### PR DESCRIPTION
Fixes #10188

This changes the toggle data we have on the ServerDataContext to include a type as well as a value (type already existed as part of the toggle.json, but they weren't included in the ServerDataContext before as we had no need of it).

We now use the type to ensure we only send toggles of type 'test' to GA.

The useToggles hook has been updated so it continues to return the value of the toggle. If using toggles server side though, we now need to use the .value property of the toggle.

NB. I think this change will also help with this ticket #10204