### PR TITLE
Configure test file differently to help with timeouts

### DIFF
--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -55,7 +55,7 @@ const test = base.extend({
 });
 
 // We've repeatedly had tests in this test file (not always the same one) fail once on a timeout, only to always pass on a retry.
-// I'll allow this file to retry twice, see if it helps and makes our alerts more relevant.
+// I'll allow this file to retry once, see if it helps and makes our alerts more relevant.
 // I'm also allowing them to run in parallel, hoping it'll help with timeouts as its considered a slow test file.
 test.describe.configure({ mode: 'parallel', retries: 1 });
 

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -57,7 +57,7 @@ const test = base.extend({
 // We've repeatedly had tests in this test file (not always the same one) fail once on a timeout, only to always pass on a retry.
 // I'll allow this file to retry twice, see if it helps and makes our alerts more relevant.
 // I'm also allowing them to run in parallel, hoping it'll help with timeouts as its considered a slow test file.
-test.describe.configure({ mode: 'parallel', retries: 2 });
+test.describe.configure({ mode: 'parallel', retries: 1 });
 
 test.describe('Scenario 1: A user wants a large-scale view of an item', () => {
   test('the images are scalable', async ({ page, context }) => {

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -54,6 +54,11 @@ const test = base.extend({
   },
 });
 
+// We've repeatedly had tests in this test file (not always the same one) fail once on a timeout, only to always pass on a retry.
+// I'll allow this file to retry twice, see if it helps and makes our alerts more relevant.
+// I'm also allowing them to run in parallel, hoping it'll help with timeouts as its considered a slow test file.
+test.describe.configure({ mode: 'parallel', retries: 2 });
+
 test.describe('Scenario 1: A user wants a large-scale view of an item', () => {
   test('the images are scalable', async ({ page, context }) => {
     await multiVolumeItem(context, page);


### PR DESCRIPTION
## Who is this for?
E2es

## What is it doing for them?
Hopefully allowing the tests in the file to run in parallel, with multiple workers, (default is to run in order _within a file_, with 1 worker) and allowing one retry, we should stop having flaky results. [See Slack conversation](https://wellcome.slack.com/archives/CQ720BG02/p1695980030258699).

I've started to try with splitting it into 4 files but (1) I don't like to looks of it 😄 and (2) they were still being considered slow when trialling it locally. 