### PR TITLE
Linting from `yarn lint`

### DIFF
--- a/cache/send_slack_alert_for_5xx_errors.js
+++ b/cache/send_slack_alert_for_5xx_errors.js
@@ -50,21 +50,19 @@ async function findCloudFrontHitsFromLog(bucket, key) {
     .createReadStream()
     .pipe(zlib.createGunzip());
 
-  const lineReader = readline.createInterface({ input: input });
+  const lineReader = readline.createInterface({ input });
 
   let fields = [];
-  let result = [];
+  const result = [];
 
   lineReader.on('line', line => {
-    // Skip the first header line.
-    if (line.startsWith('#Version')) {
-    }
     // The second line tells us what the fields are.
-    else if (line.startsWith('#Fields')) {
+    if (line.startsWith('#Fields')) {
       fields = line.replace('#Fields:', '').trim().split(' ');
     }
     // All subsequent lines are values.
-    else {
+    // but skip the first header line.
+    else if (!line.startsWith('#Version')) {
       const values = line.trim().split('\t');
       const hit = Object.assign(...fields.map((k, i) => ({ [k]: values[i] })));
 
@@ -73,7 +71,7 @@ async function findCloudFrontHitsFromLog(bucket, key) {
         host: hit['x-host-header'],
         path: decodeURIComponent(hit['cs-uri-stem']),
         ipAddress: hit['c-ip'],
-        date: new Date(`${hit['date']}T${hit['time']}Z`),
+        date: new Date(`${hit.date}T${hit.time}Z`),
 
         // The CloudFront log records this as a string, but it's more convenient
         // downstream if we can treat it as a number.
@@ -81,7 +79,10 @@ async function findCloudFrontHitsFromLog(bucket, key) {
 
         // Note: if the request contained an empty query string, CloudFront
         // will log this as '-'
-        query: hit['cs-uri-query'] !== '-' ? decodeURIComponent(hit['cs-uri-query']) : null,
+        query:
+          hit['cs-uri-query'] !== '-'
+            ? decodeURIComponent(hit['cs-uri-query'])
+            : null,
       });
 
       result.push(hit);
@@ -217,13 +218,13 @@ function createDisplayUrl(protocol, host, path, query) {
   if (path.startsWith('/account') && query !== null) {
     const originalParams = new URLSearchParams(query);
 
-    const redactedParams = Array.from(originalParams.entries()).map(function (
-      param
-    ) {
-      const key = param[0];
-      const value = param[1];
-      return [key, `[${value.slice(0, 3)}... REDACTED]`];
-    });
+    const redactedParams = Array.from(originalParams.entries()).map(
+      function (param) {
+        const key = param[0];
+        const value = param[1];
+        return [key, `[${value.slice(0, 3)}... REDACTED]`];
+      }
+    );
     const redactedQuery = new URLSearchParams(redactedParams).toString();
 
     return `${protocol}://${host}${path}?${redactedQuery}`

--- a/common/data/microcopy.tsx
+++ b/common/data/microcopy.tsx
@@ -150,6 +150,8 @@ export const searchPlaceholderText = {
   works: 'Search the catalogue',
 };
 
-export const visualStoryLinkText = 'Explore information to help you plan and prepare for your visit';
+export const visualStoryLinkText =
+  'Explore information to help you plan and prepare for your visit';
 
-export const exhibitionGuideLinkText = 'Explore Audio description, British Sign Language and captions and transcripts';
+export const exhibitionGuideLinkText =
+  'Explore Audio description, British Sign Language and captions and transcripts';

--- a/common/server-data/index.ts
+++ b/common/server-data/index.ts
@@ -123,7 +123,9 @@ export const getServerData = async (
 
   const toggles = getTogglesFromContext(togglesResp, context);
 
-  const isEnableToggleValid = Object.keys(toggles).some(id => id === enableToggle);
+  const isEnableToggleValid = Object.keys(toggles).some(
+    id => id === enableToggle
+  );
 
   if (enableToggle && isEnableToggleValid) {
     context.res.setHeader('Set-Cookie', `toggle_${enableToggle}=true; Path=/`);

--- a/common/server-data/toggles.ts
+++ b/common/server-data/toggles.ts
@@ -39,13 +39,13 @@ export function getTogglesFromContext(
   const toggles = [...togglesResp.toggles].reduce(
     (acc, toggle) => ({
       ...acc,
-      [toggle.id]:
-      {
-        value: allCookies[`toggle_${toggle.id}`] === 'true'
-          ? true
-          : toggle.defaultValue,
+      [toggle.id]: {
+        value:
+          allCookies[`toggle_${toggle.id}`] === 'true'
+            ? true
+            : toggle.defaultValue,
         type: toggle.type,
-      }
+      },
     }),
     {} as Toggles
   );
@@ -65,8 +65,8 @@ export function getTogglesFromContext(
       ...acc,
       [test.id]: {
         value: testToggleValue(test.id),
-        type: 'test'
-      }
+        type: 'test',
+      },
     };
   }, {} as Toggles);
   return { ...toggles, ...tests } as Toggles;

--- a/content/webapp/pages/concepts/[conceptId].tsx
+++ b/content/webapp/pages/concepts/[conceptId].tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { useState, JSX, FunctionComponent } from 'react';
 import { GetServerSideProps, NextPage } from 'next';
-import Link, { LinkProps } from 'next/link';
+import { LinkProps } from 'next/link';
 
 // Helpers/Utils
 import { appError, AppErrorProps } from '@weco/common/services/app';

--- a/content/webapp/services/prismic/transformers/exhibitions.ts
+++ b/content/webapp/services/prismic/transformers/exhibitions.ts
@@ -18,6 +18,7 @@ import { transformQuery } from './paginated-results';
 import { transformMultiContent } from './multi-content';
 import {
   transformLink,
+  transformTimestamp,
 } from '@weco/common/services/prismic/transformers';
 import {
   asHtml,
@@ -35,7 +36,6 @@ import {
 } from './contributors';
 import * as prismic from '@prismicio/client';
 import { noAltTextBecausePromo } from './images';
-import { transformTimestamp } from '@weco/common/services/prismic/transformers';
 
 function transformExhibitionFormat(
   format: ExhibitionFormatPrismicDocument
@@ -68,12 +68,12 @@ export function transformExhibition(
     const text = asText(i.linkText) || '';
     const url = transformLink(i.documentLink) || '';
     const size = Math.round(parseInt(i.documentLink.size) / 1000) || 0;
-    return ({
+    return {
       text,
       url,
       size,
-    })
-  })
+    };
+  });
 
   const accessResourcesText = asRichText(data.accessResourcesText);
 

--- a/content/webapp/services/wellcome/catalogue/fixtures/images-aggregations.ts
+++ b/content/webapp/services/wellcome/catalogue/fixtures/images-aggregations.ts
@@ -44,7 +44,8 @@ const aggregations: CatalogueResultsList<Image> = {
         {
           data: {
             id: 'cc-by-nc-nd',
-            label: 'Attribution-NonCommercial-NoDerivatives 4.0 International (CC BY-NC-ND 4.0)',
+            label:
+              'Attribution-NonCommercial-NoDerivatives 4.0 International (CC BY-NC-ND 4.0)',
             type: 'License',
           },
           count: 0,
@@ -73,7 +74,7 @@ const aggregations: CatalogueResultsList<Image> = {
     },
     type: 'Aggregations',
   },
-  _requestUrl: ''
+  _requestUrl: '',
 };
 
 export default aggregations;

--- a/content/webapp/utils/spam-detector.test.ts
+++ b/content/webapp/utils/spam-detector.test.ts
@@ -15,7 +15,7 @@ describe('requests that probably aren’t spam', () => {
 describe('requests that probably are spam', () => {
   test.each([
     {
-      query: '⏩ casino jackpot win win win ⏪'
+      query: '⏩ casino jackpot win win win ⏪',
     },
     {
       query:
@@ -23,7 +23,7 @@ describe('requests that probably are spam', () => {
     },
     {
       query:
-        '华体会官网登录入口手机-【copy url：spam123.abc】-金狮贵宾会官网登录中心-【copy url：spam123.abc】-8su'
+        '华体会官网登录入口手机-【copy url：spam123.abc】-金狮贵宾会官网登录中心-【copy url：spam123.abc】-8su',
     },
     {
       query:

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "e2e-stage": "yarn test:playwright && yarn test:playwright:mobile",
     "run-concurrently": "./scripts/run-concurrently.sh",
     "run-concurrently:clean": "./scripts/run-concurrently.sh -c",
-    "lint": "eslint \"**/*.{ts,tsx}\"",
+    "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "lint:css": "stylelint \"**/*.{js,ts,tsx}\""
   },
   "repository": {

--- a/toggles/webapp/deploy.ts
+++ b/toggles/webapp/deploy.ts
@@ -64,8 +64,8 @@ export async function deploy(client: S3Client): Promise<void> {
   // GA4 now limits event parameter values to 100 characters: https://support.google.com/analytics/answer/9267744?hl=en
   // So instead of sending the whole toggles JSON blob we send a concatenated string of only the toggle names (preceeded with a ! if the toggle is false).
   const potentialToggleString = togglesAndTests.tests
-  .map(toggle => `!${toggle.id}`) // replicating the condition of all toggles being false gives the longest possible string.
-  .join(',');
+    .map(toggle => `!${toggle.id}`) // replicating the condition of all toggles being false gives the longest possible string.
+    .join(',');
 
   // We throw an error here if this string could exceed 100 characters, i.e. if all test toggle values were false.
   // This is a bit of a hack due to GA limiting the amount of characters we can send.

--- a/toggles/webapp/index.ts
+++ b/toggles/webapp/index.ts
@@ -12,5 +12,7 @@ export type TogglesResp = { toggles: PublishedToggle[]; tests: ABTest[] };
 
 // Don't be tempted to make the keys on this optional - keeping them
 // as required means we catch dead code left over from removed toggles
-export type Toggles = Record<ToggleId | TestId, { value: boolean | undefined, type: ToggleTypes} >
-
+export type Toggles = Record<
+  ToggleId | TestId,
+  { value: boolean | undefined; type: ToggleTypes }
+>;


### PR DESCRIPTION
## Who is this for?
Linting issues/maintenance

## What is it doing for them?
As we've recently found out we might have various linting setups that are misaligned, I thought running `yarn lint` and seeing which ones the project flagged might be a good starting point. 
- Unused import (only one)
- Indentation
- Missing `,` in lists
- Unnecessary `()` wrappers
- Unexpected lack of shorthand property passing

`cache/send_slack_alert_for_5xx_errors.js` had a few more but I just added `js` to the list of things to be linted so that'll be why. It also had a warning about empty block on line 60, so changed the conditionals, pls have a look to make sure it still makes sense.

These should be flagged when aiming to commit changes, so let's figure out what we need to do! All the warnings that are left have to do with non-null assertions and the use of `any` in types. We also need to discuss what to do with those (57!) in the hopes of making linting more readable and therefore useful.