### PR TITLE
High contrast focus

### DIFF
--- a/common/views/components/ButtonSolid/ButtonSolid.tsx
+++ b/common/views/components/ButtonSolid/ButtonSolid.tsx
@@ -41,7 +41,7 @@ export const BaseButton = styled.button.attrs<BaseButtonProps>(props => ({
   &:focus-visible,
   &:focus {
     box-shadow: ${props => props.theme.focusBoxShadow};
-    outline: 0;
+    outline: ${props => props.theme.highContrastOutlineFix};
   }
 
   :focus:not(:focus-visible) {
@@ -188,7 +188,7 @@ export const SolidButton = styled(BaseButton).attrs<SolidButtonProps>(
         }
 
         &:focus {
-          outline: 0;
+          outline: ${props => props.theme.highContrastOutlineFix};
         }
       `
       : `

--- a/common/views/components/CheckboxRadio/CheckboxRadio.tsx
+++ b/common/views/components/CheckboxRadio/CheckboxRadio.tsx
@@ -57,7 +57,7 @@ const CheckboxRadioInput = styled.input.attrs(props => ({
 
   &:focus-visible ~ ${CheckboxRadioBox}, &:focus ~ ${CheckboxRadioBox} {
     box-shadow: ${props => props.theme.focusBoxShadow};
-    outline: 0;
+    outline: ${props => props.theme.highContrastOutlineFix};
   }
 
   &:focus ~ ${CheckboxRadioBox}:not(:focus-visible ~ ${CheckboxRadioBox}) {

--- a/common/views/components/PopupDialog/PopupDialog.tsx
+++ b/common/views/components/PopupDialog/PopupDialog.tsx
@@ -64,7 +64,7 @@ const PopupDialogOpen = styled(Space).attrs<PopupDialogOpenProps>(props => ({
 
   &:hover,
   &:focus {
-    outline: 0;
+    outline: ${props => props.theme.highContrastOutlineFix};
     border: 0;
     color: ${props => props.theme.color('white')};
     background: ${props => props.theme.color('accent.purple')};
@@ -127,7 +127,7 @@ const PopupDialogClose = styled.button`
   &:focus-visible,
   &:focus {
     box-shadow: ${props => props.theme.focusBoxShadow};
-    outline: 0;
+    outline: ${props => props.theme.highContrastOutlineFix};
   }
 
   :focus:not(:focus-visible) {
@@ -159,7 +159,7 @@ const PopupDialogCTA = styled(Space).attrs({
 
   &:hover,
   &:focus {
-    outline: 0;
+    outline: ${props => props.theme.highContrastOutlineFix};
     color: ${props => props.theme.color('accent.purple')};
     border-color: ${props => props.theme.color('accent.purple')};
     background: ${props => props.theme.color('white')};

--- a/common/views/components/TextInput/TextInput.tsx
+++ b/common/views/components/TextInput/TextInput.tsx
@@ -96,7 +96,7 @@ export const TextInputInput = styled.input.attrs(props => ({
   width: 100%;
 
   &:focus {
-    outline: 0;
+    outline: ${props => props.theme.highContrastOutlineFix};
     border-color: ${props => props.theme.color('accent.turquoise')};
   }
 

--- a/common/views/themes/config.ts
+++ b/common/views/themes/config.ts
@@ -245,6 +245,7 @@ export const themeValues = {
   },
   basicBoxShadow: `0 2px 8px 0 rgba(0, 0, 0, 0.4)`,
   focusBoxShadow: '0 0 0 3px rgba(43, 136, 143, 1)',
+  highContrastOutlineFix: `3px solid transparent`,
   keyframes: {
     hoverBounce: keyframes`
       0% {

--- a/common/views/themes/config.ts
+++ b/common/views/themes/config.ts
@@ -245,6 +245,8 @@ export const themeValues = {
   },
   basicBoxShadow: `0 2px 8px 0 rgba(0, 0, 0, 0.4)`,
   focusBoxShadow: '0 0 0 3px rgba(43, 136, 143, 1)',
+  // Problem: https://github.com/wellcomecollection/wellcomecollection.org/issues/10237
+  // Solution: https://benmyers.dev/blog/whcm-outlines/
   highContrastOutlineFix: `3px solid transparent`,
   keyframes: {
     hoverBounce: keyframes`

--- a/common/views/themes/typography.ts
+++ b/common/views/themes/typography.ts
@@ -150,7 +150,7 @@ export const typography = css<GlobalStyleProps>`
     &:focus-visible,
     &:focus {
       box-shadow: ${props => props.theme.focusBoxShadow};
-      outline: 3px solid transparent;
+      outline: ${props => props.theme.highContrastOutlineFix};
     }
 
     :focus:not(:focus-visible) {

--- a/common/views/themes/typography.ts
+++ b/common/views/themes/typography.ts
@@ -150,7 +150,7 @@ export const typography = css<GlobalStyleProps>`
     &:focus-visible,
     &:focus {
       box-shadow: ${props => props.theme.focusBoxShadow};
-      outline: 0;
+      outline: 3px solid transparent;
     }
 
     :focus:not(:focus-visible) {

--- a/content/webapp/components/IIIFViewer/ViewerSidebar.tsx
+++ b/content/webapp/components/IIIFViewer/ViewerSidebar.tsx
@@ -49,7 +49,7 @@ const AccordionInner = styled(Space).attrs({
 
     &:active,
     &:focus {
-      outline: 0;
+      outline: ${props => props.theme.highContrastOutlineFix};
       box-shadow: ${props => props.theme.focusBoxShadow};
     }
 

--- a/content/webapp/components/SearchTabs/SearchTabs.BaseTabs.tsx
+++ b/content/webapp/components/SearchTabs/SearchTabs.BaseTabs.tsx
@@ -38,7 +38,7 @@ const Tab = styled.button.attrs((props: TabProps) => ({
     box-shadow: ${props => props.theme.focusBoxShadow};
     position: relative;
     z-index: 1;
-    outline: 0;
+    outline: ${props => props.theme.highContrastOutlineFix};
   }
 
   padding: 0;

--- a/content/webapp/components/SelectContainer/SelectContainer.tsx
+++ b/content/webapp/components/SelectContainer/SelectContainer.tsx
@@ -30,7 +30,7 @@ const StyledSelect = styled.div.attrs({
     font-weight: inherit;
     appearance: none;
     padding: 8px 42px 8px 16px;
-    border: ${props => `1px solid 
+    border: ${props => `1px solid
         ${props.theme.color(props.darkBg ? 'neutral.300' : 'neutral.600')}`};
     border-radius: ${props =>
       props.isPill ? 20 : props.theme.borderRadiusUnit}px;
@@ -61,7 +61,7 @@ const StyledSelect = styled.div.attrs({
     &:focus-visible,
     &:focus {
       box-shadow: ${props => props.theme.focusBoxShadow};
-      outline: 0;
+      outline: ${props => props.theme.highContrastOutlineFix};
     }
 
     :focus:not(:focus-visible) {


### PR DESCRIPTION
For #10237 

## Who is this for?
Windows high-contrast users

## What is it doing for them?
Ensuring that keyboard focus remains visible when high-contrast mode is turned on

Screen recording of keyboard focus in high-contrast mode:
https://github.com/wellcomecollection/wellcomecollection.org/assets/1394592/7de3bb50-2f9c-4bda-bd90-31e3457f16a8

There are some inconsistencies in how we're handling keyboard focus at present, and some redundancy in the code as a result, but @j-jaworski has been looking at updating/rationalising keyboard focus states across everything and I think we should tidy everything up when we do that piece of work.