### PR TITLE
Tzitzit; Remove todo and update comment

### DIFF
--- a/common/views/components/ApiToolbar/index.tsx
+++ b/common/views/components/ApiToolbar/index.tsx
@@ -51,12 +51,12 @@ export function setTzitzitParams({
 }): ApiToolbarLink | undefined {
   const licenceId = licence?.id.toUpperCase();
 
-  // We should not be using in copyright images in Stories.
-  // TODO: Double check this is our policy with the Editorial team.
+  // We want to restrict the use of in copyright images in Stories.
+  // The Editorial team might chose to use them but any work on it should be done manually.
   if (licenceId === 'INC')
     return {
       id: 'tzitzit',
-      label: '(no tzitzit, this image is in copyright)',
+      label: 'This image is labelled as in copyright. Check before using.',
     };
 
   const params = new URLSearchParams();

--- a/playwright/test/api-toolbar.test.ts
+++ b/playwright/test/api-toolbar.test.ts
@@ -21,7 +21,7 @@ test.describe('tzitzit links', () => {
     await gotoWithoutCache(`${baseUrl}/works/fedcvz22/items`, page);
 
     await page.waitForSelector(
-      'li >> text="(no tzitzit, this image is in copyright)"'
+      'li >> text="This image is labelled as in copyright. Check before using."'
     );
   });
 


### PR DESCRIPTION
## Who is this for?
Maintenance

## What is it doing for them?
Removes TODO; [I've checked with Editorial ](https://wellcome.slack.com/archives/C3N7J05TK/p1696934242259069)and Alice has confirmed they do use In Copyright images sometimes, but it's something to do carefully. Updating comment and label to reflect this.