### PR TITLE
Accessibility tabbing

### DIFF
--- a/common/utils/get-focusable-elements.ts
+++ b/common/utils/get-focusable-elements.ts
@@ -1,4 +1,9 @@
 // https://gomakethings.com/how-to-get-the-first-and-last-focusable-elements-in-the-dom/
+// The keepNegativeTabIndex paramater is for the downloads Dropdown button in the viewer
+// When a canvas changes in the viewer, some of the download links update to point to the current canvas
+// But the whole item link does not need to
+// As a result it already has a tabIndex=-1 when the dropdown is collapsed and gets excluded by getFocusableElements the next time it runs
+// We therefore pass in the keepNegativeTabIndex value set to true to prevent this from happening
 function getFocusableElements<E extends Element = Element>(
   el: HTMLElement,
   keepNegativeTabIndex?: boolean

--- a/common/utils/get-focusable-elements.ts
+++ b/common/utils/get-focusable-elements.ts
@@ -1,12 +1,12 @@
 // https://gomakethings.com/how-to-get-the-first-and-last-focusable-elements-in-the-dom/
 function getFocusableElements<E extends Element = Element>(
-  el: HTMLElement
+  el: HTMLElement,
+  keepNegativeTabIndex?: boolean
 ): E[] {
-  return [
-    ...el.querySelectorAll<E>(
-      'button:not([disabled]), [href]:not([tabindex="-1"]), input, select, textarea, [tabindex]:not([tabindex="-1"]), [role=slider]'
-    ),
-  ];
+  const selectors = keepNegativeTabIndex
+    ? 'button:not([disabled]), input, select, textarea, [role=slider]'
+    : 'button:not([disabled]), [href]:not([tabindex="-1"]), input, select, textarea, [tabindex]:not([tabindex="-1"]), [role=slider]';
+  return [...el.querySelectorAll<E>(selectors)];
 }
 
 export default getFocusableElements;

--- a/common/utils/get-focusable-elements.ts
+++ b/common/utils/get-focusable-elements.ts
@@ -4,7 +4,7 @@ function getFocusableElements<E extends Element = Element>(
   keepNegativeTabIndex?: boolean
 ): E[] {
   const selectors = keepNegativeTabIndex
-    ? 'button:not([disabled]), input, select, textarea, [role=slider]'
+    ? 'button:not([disabled]), [href], input, select, textarea, [tabindex], [role=slider]'
     : 'button:not([disabled]), [href]:not([tabindex="-1"]), input, select, textarea, [tabindex]:not([tabindex="-1"]), [role=slider]';
   return [...el.querySelectorAll<E>(selectors)];
 }

--- a/common/views/components/DropdownButton/DropdownButton.tsx
+++ b/common/views/components/DropdownButton/DropdownButton.tsx
@@ -148,7 +148,7 @@ const DropdownButton: FunctionComponent<PropsWithChildren<Props>> = ({
   useEffect(() => {
     dropdownRef &&
       dropdownRef.current &&
-      setFocusables(getFocusableElements(dropdownRef.current));
+      setFocusables(getFocusableElements(dropdownRef.current, true));
   }, [children]);
 
   useEffect(() => {

--- a/common/views/components/DropdownButton/DropdownButton.tsx
+++ b/common/views/components/DropdownButton/DropdownButton.tsx
@@ -157,7 +157,7 @@ const DropdownButton: FunctionComponent<PropsWithChildren<Props>> = ({
     } else {
       focusables.forEach(focusable => focusable.setAttribute('tabIndex', '-1'));
     }
-  }, [isActive]);
+  }, [isActive, focusables]);
 
   const buttonProps = {
     isActive,

--- a/common/views/components/DropdownButton/DropdownButton.tsx
+++ b/common/views/components/DropdownButton/DropdownButton.tsx
@@ -157,7 +157,7 @@ const DropdownButton: FunctionComponent<PropsWithChildren<Props>> = ({
     } else {
       focusables.forEach(focusable => focusable.setAttribute('tabIndex', '-1'));
     }
-  }, [isActive, children, focusables]);
+  }, [isActive]);
 
   const buttonProps = {
     isActive,


### PR DESCRIPTION
Relates to #10235 and #10236

This fixes the issue where keyboard users couldn't tab into the links inside a dropdown menu, e.g. login, downloads

Only changing the tabIndex of focusable elements when the 'isActive' state changes fixed the inconsistent behaviour we were seeing.

However, this uncovered an issue for Download links in the viewer, whereby the whole item link could not be reached by keyboard, while the others could.

<img width="758" alt="Screenshot 2023-10-10 at 14 35 07" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/6051896/bca421ac-c839-4a61-a9fe-5023824f97ea">

This is because when the viewed canvas changes the first 2 links are updated, while the 'whole item' link isn't. When the getFocusableElements function runs after this has happened it misses out the 'whole item' link because it has a tabIndex=-1.

I think generally the getFocusableElements should behave that way, just not in this case, so I updated the function to include an optional parameter so it can include things with a tabIndex=-1
