### PR TITLE
Focus trap dropdown

### DIFF
--- a/common/views/components/DropdownButton/DropdownButton.tsx
+++ b/common/views/components/DropdownButton/DropdownButton.tsx
@@ -19,6 +19,7 @@ import { BorderlessButton } from '../BorderlessClickable/BorderlessClickable';
 import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
 import { chevron, IconSvg } from '@weco/common/icons';
 import { themeValues } from '@weco/common/views/themes/config';
+import FocusTrap from 'focus-trap-react';
 
 const DropdownWrapper = styled.div`
   display: inline-flex;
@@ -172,59 +173,75 @@ const DropdownButton: FunctionComponent<PropsWithChildren<Props>> = ({
     isPill,
     disabled: hasNoOptions,
   };
+  // TODO still able to tab to dates inputs - is that the current behaviour on live?
+  // TODO getting stuck on dates?
+  // TODO try no js
 
   return (
-    <DropdownWrapper ref={dropdownWrapperRef}>
-      {buttonType === 'inline' && (
-        <ButtonSolid
-          {...buttonProps}
-          size="small"
-          hoverUnderline={true}
-          colors={
-            isOnDark
-              ? themeValues.buttonColors.whiteTransparentWhite
-              : themeValues.buttonColors.marbleWhiteCharcoal
-          }
-        />
-      )}
-      {buttonType === 'outlined' && (
-        <ButtonSolid
-          {...buttonProps}
-          colors={
-            isOnDark
-              ? themeValues.buttonColors.whiteTransparentWhite
-              : themeValues.buttonColors.greenTransparentGreen
-          }
-        />
-      )}
-      {buttonType === 'borderless' && (
-        <BorderlessButton
-          aria-controls={id}
-          aria-expanded={isActive}
-          isActive={isActive}
-          clickHandler={() => setIsActive(!isActive)}
-          icon={chevron}
-          iconLeft={iconLeft}
-          type="button"
-          text={label}
-          aria-label={ariaLabel}
-        />
-      )}
-      {isEnhanced && (
-        <Popper
-          id={id}
-          ref={popperRef}
-          style={styles.popper}
-          {...(isEnhanced ? attributes.popper : {})}
-          isVisible={isPopperVisible}
-        >
-          <CSSTransition
-            in={isActive}
-            classNames="fade"
-            timeout={350}
-            onEnter={() => setIsPopperVisible(true)}
-            onExited={() => setIsPopperVisible(false)}
+    <FocusTrap active={isActive} focusTrapOptions={{ preventScroll: false }}>
+      <DropdownWrapper ref={dropdownWrapperRef}>
+        {buttonType === 'inline' && (
+          <ButtonSolid
+            {...buttonProps}
+            size="small"
+            hoverUnderline={true}
+            colors={
+              isOnDark
+                ? themeValues.buttonColors.whiteTransparentWhite
+                : themeValues.buttonColors.marbleWhiteCharcoal
+            }
+          />
+        )}
+        {buttonType === 'outlined' && (
+          <ButtonSolid
+            {...buttonProps}
+            colors={
+              isOnDark
+                ? themeValues.buttonColors.whiteTransparentWhite
+                : themeValues.buttonColors.greenTransparentGreen
+            }
+          />
+        )}
+        {buttonType === 'borderless' && (
+          <BorderlessButton
+            aria-controls={id}
+            aria-expanded={isActive}
+            isActive={isActive}
+            clickHandler={() => setIsActive(!isActive)}
+            icon={chevron}
+            iconLeft={iconLeft}
+            type="button"
+            text={label}
+            aria-label={ariaLabel}
+          />
+        )}
+        {isEnhanced && (
+          <Popper
+            id={id}
+            ref={popperRef}
+            style={styles.popper}
+            {...(isEnhanced ? attributes.popper : {})}
+            isVisible={isPopperVisible}
           >
+            <CSSTransition
+              in={isActive}
+              classNames="fade"
+              timeout={350}
+              onEnter={() => setIsPopperVisible(true)}
+              onExited={() => setIsPopperVisible(false)}
+            >
+              <Dropdown
+                isActive={isActive}
+                isEnhanced={isEnhanced}
+                ref={dropdownRef}
+              >
+                {children}
+              </Dropdown>
+            </CSSTransition>
+          </Popper>
+        )}
+        <noscript>
+          <Popper id={id} ref={popperRef} isVisible={true}>
             <Dropdown
               isActive={isActive}
               isEnhanced={isEnhanced}
@@ -232,21 +249,10 @@ const DropdownButton: FunctionComponent<PropsWithChildren<Props>> = ({
             >
               {children}
             </Dropdown>
-          </CSSTransition>
-        </Popper>
-      )}
-      <noscript>
-        <Popper id={id} ref={popperRef} isVisible={true}>
-          <Dropdown
-            isActive={isActive}
-            isEnhanced={isEnhanced}
-            ref={dropdownRef}
-          >
-            {children}
-          </Dropdown>
-        </Popper>
-      </noscript>
-    </DropdownWrapper>
+          </Popper>
+        </noscript>
+      </DropdownWrapper>
+    </FocusTrap>
   );
 };
 

--- a/common/views/components/DropdownButton/DropdownButton.tsx
+++ b/common/views/components/DropdownButton/DropdownButton.tsx
@@ -175,7 +175,10 @@ const DropdownButton: FunctionComponent<PropsWithChildren<Props>> = ({
   };
 
   return (
-    <FocusTrap active={isActive} focusTrapOptions={{ preventScroll: false }}>
+    <FocusTrap
+      active={isActive}
+      focusTrapOptions={{ preventScroll: false, clickOutsideDeactivates: true }}
+    >
       <DropdownWrapper ref={dropdownWrapperRef}>
         {buttonType === 'inline' && (
           <ButtonSolid

--- a/common/views/components/DropdownButton/DropdownButton.tsx
+++ b/common/views/components/DropdownButton/DropdownButton.tsx
@@ -173,9 +173,6 @@ const DropdownButton: FunctionComponent<PropsWithChildren<Props>> = ({
     isPill,
     disabled: hasNoOptions,
   };
-  // TODO still able to tab to dates inputs - is that the current behaviour on live?
-  // TODO getting stuck on dates?
-  // TODO try no js
 
   return (
     <FocusTrap active={isActive} focusTrapOptions={{ preventScroll: false }}>


### PR DESCRIPTION
For #10269

Implements the suggestion of having the keyboard focus trapped inside a dropdown menu when it is open

This will be wherever we use the DropdownButton, e.g. Downloads, and not just on the search filters where the issue was identified