### PR TITLE
Fix typo to ensure permanent exhibitions are always shown

### DIFF
--- a/content/webapp/services/prismic/fetch/exhibitions.ts
+++ b/content/webapp/services/prismic/fetch/exhibitions.ts
@@ -113,7 +113,7 @@ export const fetchExhibitions = (
   { filters = [], order = 'desc', period, page = 1 }: GetExhibitionsProps = {}
 ): Promise<prismic.Query<ExhibitionPrismicDocument>> => {
   const orderings: prismic.Ordering[] = [
-    { field: 'my.exhibitions.isPermament', direction: 'desc' },
+    { field: 'my.exhibitions.isPermanent', direction: 'desc' },
     { field: endField, direction: order },
   ];
 


### PR DESCRIPTION
## Who is this for?
Users? 🤷‍♀️ 

## What is it doing for them?
I mean this was a typo for 2 years and there were no complains, so I hesitated in just removing it. We don't have a lot of permanent exhibitions(?), I think it's just Being Human (current) and Medicine Man (past), so hard to test, but this code should ensure that they are always displayed. 

If the order wasn't specified, considering that we have 63 exhibitions, it might mean it doesn't make it in the first 20 pages and therefore isn't shown in `/exhibitions`. So we put it to the top to start with. 
It's then placed after temporary exhibitions [with this function](https://github.com/wellcomecollection/wellcomecollection.org/blob/main/content/webapp/services/prismic/transformers/exhibitions.ts#L200) so the order makes more sense to the user.