### PR TITLE
Corrected message for no results filtered stories search

### DIFF
--- a/content/webapp/pages/search/stories.tsx
+++ b/content/webapp/pages/search/stories.tsx
@@ -130,7 +130,10 @@ export const SearchPage: NextPageWithLayout<Props> = ({
         <Wrapper>
           {storyResponseList.totalResults === 0 ? (
             <Container>
-              <SearchNoResults query={queryString} />
+              <SearchNoResults
+                query={queryString}
+                hasFilters={hasActiveFilters}
+              />
             </Container>
           ) : (
             <Container>


### PR DESCRIPTION
## Who is this for?
Fixes #10286 

## What is it doing for them?
Returns the correct message when filters are selected in stories, but the search returns no results. 

Correct messaging - proposed
![Screenshot 2023-10-11 at 10 57 31](https://github.com/wellcomecollection/wellcomecollection.org/assets/81175151/9adf1b6f-7256-4150-aade-51fff9c1ee52)

Current messaging - as is now
![Screenshot 2023-10-11 at 14 17 28](https://github.com/wellcomecollection/wellcomecollection.org/assets/81175151/01f2648c-a7b1-4280-98a7-5df518341bb9)
