### PR TITLE
Add title to play and mute buttons

### DIFF
--- a/content/webapp/components/AudioPlayer/AudioPlayer.Volume.tsx
+++ b/content/webapp/components/AudioPlayer/AudioPlayer.Volume.tsx
@@ -33,9 +33,10 @@ const MuteUnmuteButton = styled.button.attrs<MuteUnmuteButtonProps>(
 type VolumeProps = {
   audioPlayer: HTMLAudioElement;
   id: string;
+  title: string;
 };
 
-const Volume: FunctionComponent<VolumeProps> = ({ audioPlayer, id }) => {
+const Volume: FunctionComponent<VolumeProps> = ({ audioPlayer, id, title }) => {
   const [volume, setVolume] = useState(audioPlayer.volume);
   const [isMuted, setIsMuted] = useState(audioPlayer.muted);
   const [showVolume, setShowVolume] = useState(false);
@@ -86,7 +87,7 @@ const Volume: FunctionComponent<VolumeProps> = ({ audioPlayer, id }) => {
     <VolumeWrapper>
       <MuteUnmuteButton onClick={onVolumeButtonClick}>
         <span className="visually-hidden">
-          {isMuted ? 'Unmute player' : 'Mute player'}
+          {`${title} ${isMuted ? 'Unmute player' : 'Mute player'}`}
         </span>
         <Icon
           iconColor="neutral.600"

--- a/content/webapp/components/AudioPlayer/AudioPlayer.tsx
+++ b/content/webapp/components/AudioPlayer/AudioPlayer.tsx
@@ -181,7 +181,7 @@ export const AudioPlayer: FunctionComponent<AudioPlayerProps> = ({
           <PlayPauseButton onClick={onTogglePlay} isPlaying={isPlaying}>
             <PlayPauseInner>
               <span className="visually-hidden">
-                {isPlaying ? 'Pause' : 'Play'}
+                {`${title} ${isPlaying ? 'Pause' : 'Play'}`}
               </span>
               <Icon iconColor="accent.green" icon={isPlaying ? pause : play} />
             </PlayPauseInner>
@@ -197,7 +197,11 @@ export const AudioPlayer: FunctionComponent<AudioPlayerProps> = ({
             />
           </div>
           {audioPlayerRef.current && (
-            <Volume audioPlayer={audioPlayerRef.current} id={id} />
+            <Volume
+              audioPlayer={audioPlayerRef.current}
+              id={id}
+              title={title}
+            />
           )}
           <SecondRow>
             <div style={{ display: 'flex', justifyContent: 'space-between' }}>


### PR DESCRIPTION
part of #10231

Adds the title of the track to the audio play pause buttons.

Some screen reader users may list the buttons on the page as a means of navigation and this makes them distinguishable from each other.

Voiceover before:
![PXL_20231011_150344223](https://github.com/wellcomecollection/wellcomecollection.org/assets/6051896/0c1eae1f-1de6-4fee-9a38-9fc360400c0c)

Voiceover after:
![PXL_20231011_150118147](https://github.com/wellcomecollection/wellcomecollection.org/assets/6051896/00454d6e-53ba-4267-aae9-517012c597d7)
