### PR TITLE
Space ps in TextAndImageOrIcons with margin-top

### DIFF
--- a/content/webapp/components/TextAndImageOrIcons/TextAndImageOrIcons.tsx
+++ b/content/webapp/components/TextAndImageOrIcons/TextAndImageOrIcons.tsx
@@ -62,7 +62,7 @@ const ImageOrIcons = styled(Space).attrs({
   }
 `;
 
-const Text = styled.div`
+const Text = styled.div.attrs({ className: 'spaced-text' })`
   flex-basis: 100%;
 
   ${props => props.theme.media('medium')`


### PR DESCRIPTION
## Who is this for?
People looking at Visual Stories

## What is it doing for them?
Spacing text using the same system we use elsewhere, which prevents excess space appearing at the bottom of the component

__before__
<img width="468" alt="image" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/1394592/239d83c2-27b6-4b16-8768-ad6a85ae1d4f">


__after__
<img width="471" alt="image" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/1394592/843191af-d485-4079-aef8-5657c333f148">
