### PR TITLE
Include email address format example in error message

### DIFF
--- a/cardigan/stories/components/TextInput/TextInput.stories.tsx
+++ b/cardigan/stories/components/TextInput/TextInput.stories.tsx
@@ -15,7 +15,8 @@ const Template = () => {
         type: 'email',
         name: 'email',
         label: 'Your email address',
-        errorMessage: 'Enter a valid email address.',
+        errorMessage:
+          'Enter an email address in the correct format, like name@example.com',
         value,
         setValue,
         ...useValidation(),

--- a/common/views/components/NewsletterPromo/NewsletterPromo.tsx
+++ b/common/views/components/NewsletterPromo/NewsletterPromo.tsx
@@ -130,7 +130,7 @@ const NewsletterPromo: FunctionComponent = () => {
                   errorMessage={
                     isSubmitError
                       ? 'There was a problem. Please try again.'
-                      : 'Enter a valid email address.'
+                      : 'Enter an email address in the correct format, like name@example.com'
                   }
                   value={value}
                   setValue={setValue}

--- a/content/webapp/components/NewsletterSignup/NewsletterSignup.tsx
+++ b/content/webapp/components/NewsletterSignup/NewsletterSignup.tsx
@@ -153,7 +153,7 @@ const NewsletterSignup: FunctionComponent<Props> = ({
               big={true}
               value={emailValue}
               setValue={setEmailValue}
-              errorMessage="Enter a valid email address."
+              errorMessage="Enter an email address in the correct format, like name@example.com"
               {...emailValidation}
             />
           </Space>

--- a/identity/webapp/src/frontend/MyAccount/ChangeEmail.test.tsx
+++ b/identity/webapp/src/frontend/MyAccount/ChangeEmail.test.tsx
@@ -157,7 +157,7 @@ describe('ChangeEmail', () => {
       });
 
       expect(await screen.findByRole('alert')).toHaveTextContent(
-        /enter a valid email address/i
+        /Enter an email address in the correct format, like name@example.com/i
       );
     });
 
@@ -179,7 +179,7 @@ describe('ChangeEmail', () => {
       });
 
       expect(await screen.findByRole('alert')).toHaveTextContent(
-        /enter a valid email address/i
+        /Enter an email address in the correct format, like name@example.com/i
       );
     });
 

--- a/identity/webapp/src/frontend/MyAccount/ChangeEmail.tsx
+++ b/identity/webapp/src/frontend/MyAccount/ChangeEmail.tsx
@@ -108,7 +108,8 @@ export const ChangeEmail: React.FunctionComponent<
               required: 'Enter an email address',
               pattern: {
                 value: validEmailPattern,
-                message: 'Enter a valid email address',
+                message:
+                  'Enter an email address in the correct format, like name@example.com',
               },
               validate: {
                 hasChanged: newValue => {


### PR DESCRIPTION
## Who is this for?
Users

## What is it doing for them?
Giving an example email address format if the address entered isn't valid

Wording taken direct from [gov.uk design system guidelines](https://design-system.service.gov.uk/patterns/email-addresses/#error-messages) as that was a source referenced with regards to this by the accessibility consultant