### PR TITLE
Add test for visual story redirects

### DIFF
--- a/playwright/test/contexts.ts
+++ b/playwright/test/contexts.ts
@@ -226,6 +226,24 @@ export const event = async (
   await gotoWithoutCache(`${baseUrl}/events/${id}`, page);
 };
 
+export const visualStory = async (
+  id: string,
+  context: BrowserContext,
+  page: Page
+): Promise<void> => {
+  const VSCookie = [
+    ...requiredCookies,
+    {
+      name: 'toggle_visualStories',
+      value: 'true',
+      path: '/',
+      domain: new URL(baseUrl).host,
+    },
+  ]; // TODO remove when the toggle is removed https://github.com/wellcomecollection/wellcomecollection.org/issues/10320
+  await context.addCookies(VSCookie);
+  await gotoWithoutCache(`${baseUrl}/visual-stories/${id}`, page);
+};
+
 const isMobile = (page: Page): boolean =>
   (page.viewportSize()?.width ?? 0) <= devices['iPhone 11'].viewport.width;
 

--- a/playwright/test/visual-stories.test.ts
+++ b/playwright/test/visual-stories.test.ts
@@ -1,0 +1,30 @@
+import { test as base, expect } from '@playwright/test';
+import { visualStory } from './contexts';
+import { baseUrl } from './helpers/urls';
+import { makeDefaultToggleCookies } from './helpers/utils';
+
+const domain = new URL(baseUrl).host;
+
+const test = base.extend({
+  context: async ({ context }, use) => {
+    const defaultToggleCookies = await makeDefaultToggleCookies(domain);
+    await context.addCookies([
+      { name: 'WC_cookiesAccepted', value: 'true', domain, path: '/' },
+      ...defaultToggleCookies,
+    ]);
+    await use(context);
+  },
+});
+
+test.describe('visual-stories', () => {
+  test('if it has a related document, it redirects to the relevant URL', async ({
+    page,
+    context,
+  }) => {
+    await visualStory('ZLe87hAAACIAwzqH', context, page);
+
+    expect(page.url()).toBe(
+      `${baseUrl}/exhibitions/Wt4AACAAAFCxRfQM/visual-stories`
+    );
+  });
+});


### PR DESCRIPTION
## Who is this for?
Devs

## What is it doing for them?
Ensures the redirects work fine. We don't have much to go on at this point, it's using test Prismic documents, so would be nice to change eventually but reckon we want this tested as we're building.