### PR TITLE
Move .editorconfig settings into .vscode dir

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,0 @@
-root = true
-
-[*]
-indent_style = space
-indent_size = 2
-charset = utf-8
-trim_trailing_whitespace = true
-insert_final_newline = true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,12 @@
 {
   // We add this to avoid having linting commits in CI
+  "editor.tabSize": 2,
+  "files.encoding": "utf8",
   "editor.codeActionsOnSave": {
+    "editor.insertSpaces": true,
     "source.fixAll.eslint": true,
-    "source.fixAll.stylelint": true
+    "source.fixAll.stylelint": true,
+    "files.trimTrailingWhitespace": true,
   },
   "stylelint.validate": ["typescriptreact"],
 }


### PR DESCRIPTION
## Who is this for?
Devs

## What is it doing for them?
Only having one place to manage editor configuration settings