### PR TITLE
Show any exhibitions and events for the current week on the homepage

### DIFF
--- a/content/webapp/pages/index.tsx
+++ b/content/webapp/pages/index.tsx
@@ -232,7 +232,7 @@ const Homepage: FunctionComponent<Props> = ({
           </SpacingSection>
         )}
 
-        {nextSevenDaysEvents.length + exhibitions.length > 2 && (
+        {nextSevenDaysEvents.length + exhibitions.length > 0 && (
           <SpacingSection>
             <SpacingComponent>
               <SectionHeader title="This week" />


### PR DESCRIPTION
Relates to https://wellcome.slack.com/archives/C8X9YKM5X/p1697534223218419

For some reason we were checking that there were more than 2 events and exhibitions before displaying them, we now show any number.
