### PR TITLE
Remove related exhibition field in visual stories prismic model

### DIFF
--- a/prismic-model/src/visual-stories.ts
+++ b/prismic-model/src/visual-stories.ts
@@ -14,9 +14,6 @@ const visualStories: CustomType = {
   json: {
     Main: {
       title,
-      'related-exhibition': documentLink('Related Exhibition', {
-        linkedType: 'exhibitions',
-      }),
       'related-document': documentLink(
         'Related Document (e.g. Exhibition or Event)',
         {


### PR DESCRIPTION
## Who is this for?
Maintenance/changes
Related to #10308 

## What is it doing for them?
Now we've [added the new field and changed the references to it](https://github.com/wellcomecollection/wellcomecollection.org/pull/10319/files), we can remove the old one from the prismic model.