### PR TITLE
replaces deleted work id with existing one

### DIFF
--- a/updown/expected-checks.ts
+++ b/updown/expected-checks.ts
@@ -87,7 +87,7 @@ const apiChecks = [
     period: 60 as CheckInterval,
   },
   {
-    url: 'https://api.wellcomecollection.org/catalogue/v2/works/sgmzn6pu',
+    url: 'https://api.wellcomecollection.org/catalogue/v2/works/tp3rer3n',
     alias: 'API: Works: Work',
     period: 60 as CheckInterval,
   },


### PR DESCRIPTION
## What is it doing for them?
Fixes updown check fail when requesting deleted work 
This work was deleted today as part of the Brought to Life images take-down