### PR TITLE
Remove visual stories redirections and use canonical link instead

### DIFF
--- a/common/services/prismic/link-resolver.ts
+++ b/common/services/prismic/link-resolver.ts
@@ -1,14 +1,39 @@
 import { isContentType } from './content-types';
 
-function linkResolver(doc: { id: string; type: string }): string {
+type Props = {
+  id: string;
+  type: string;
+};
+type DataProps = {
+  id: string;
+  type: string;
+  data: {
+    'related-document'?: {
+      id: string;
+      type: string;
+    };
+  };
+};
+function linkResolver(doc: Props | DataProps): string {
   const { id, type } = doc;
 
   if (type === 'webcomics') return `/articles/${id}`;
   if (type === 'webcomic-series') return `/series/${id}`;
   if (type === 'exhibition-guides') return `/guides/exhibitions/${id}`;
-  // TODO will need redoing when we determine the final url structure for these
-  // https://github.com/wellcomecollection/wellcomecollection.org/issues/9790
-  if (type === 'visual-stories') return `/visual-stories/${id}`;
+
+  if (type === 'visual-stories') {
+    if ('data' in doc) {
+      const {
+        data: { 'related-document': relatedDocument },
+      } = doc;
+
+      if (relatedDocument) {
+        return `/${relatedDocument.type}/${relatedDocument.id}/visual-stories`;
+      } else {
+        return `/visual-stories/${id}`;
+      }
+    }
+  }
 
   if (isContentType(type)) {
     return `/${type}/${id}`;

--- a/content/webapp/pages/visual-stories/[visualStoryId].tsx
+++ b/content/webapp/pages/visual-stories/[visualStoryId].tsx
@@ -68,22 +68,6 @@ export const getServerSideProps = async context => {
 
   const visualStoryDocument = await fetchVisualStory(client, visualStoryId);
 
-  // We want to check if the VS belongs to an event or an exhibition
-  // If so, it should be redirected immediately
-  if (
-    visualStoryDocument?.data['related-document'] &&
-    'id' in visualStoryDocument.data['related-document']
-  ) {
-    const { type, id } = visualStoryDocument.data['related-document'];
-
-    return {
-      redirect: {
-        permanent: true,
-        destination: `/${type}/${id}/visual-stories`,
-      },
-    };
-  }
-
   return returnVisualStoryProps({ visualStoryDocument, serverData });
 };
 

--- a/content/webapp/pages/visual-stories/[visualStoryId].tsx
+++ b/content/webapp/pages/visual-stories/[visualStoryId].tsx
@@ -102,6 +102,7 @@ const VisualStory: FunctionComponent<Props> = ({ visualStory, jsonLd }) => {
     />
   );
 
+  // Ensures the canonical link points the the desired URL should there be a related Event or Exhibition
   const visualStoryPath = visualStory.relatedDocument?.id
     ? `/${visualStory.relatedDocument.type}/${visualStory.relatedDocument.id}/visual-stories`
     : `/visual-stories/${visualStory.id}`;

--- a/content/webapp/pages/visual-stories/[visualStoryId].tsx
+++ b/content/webapp/pages/visual-stories/[visualStoryId].tsx
@@ -102,11 +102,15 @@ const VisualStory: FunctionComponent<Props> = ({ visualStory, jsonLd }) => {
     />
   );
 
+  const visualStoryPath = visualStory.relatedDocument?.id
+    ? `/${visualStory.relatedDocument.type}/${visualStory.relatedDocument.id}/visual-stories`
+    : `/visual-stories/${visualStory.id}`;
+
   return (
     <PageLayout
       title={visualStory.title}
       description={visualStory.promo?.caption || ''}
-      url={{ pathname: `/visual-stories/${visualStory.id}` }}
+      url={{ pathname: visualStoryPath }}
       jsonLd={jsonLd}
       openGraphType="website"
       hideNewsletterPromo={true}

--- a/content/webapp/services/prismic/transformers/json-ld.ts
+++ b/content/webapp/services/prismic/transformers/json-ld.ts
@@ -140,6 +140,10 @@ export function articleSeriesLd(series: Series): JsonLdObj {
 }
 
 export function visualStoryLd(visualStory: VisualStory): JsonLdObj {
+  const visualStoryPath = visualStory.relatedDocument?.id
+    ? `${visualStory.relatedDocument.type}/${visualStory.relatedDocument.id}/visual-stories`
+    : `visual-stories/${visualStory.id}`;
+
   return objToJsonLd(
     {
       dateCreated: visualStory.datePublished,
@@ -147,7 +151,7 @@ export function visualStoryLd(visualStory: VisualStory): JsonLdObj {
       headline: visualStory.title,
       image: visualStory.promo?.image?.contentUrl,
       publisher: orgLd(wellcomeCollectionGallery),
-      url: `https://wellcomecollection.org/visual-stories/${visualStory.id}`,
+      url: `https://wellcomecollection.org/${visualStoryPath}`,
     },
     {
       type: 'WebPage',

--- a/playwright/test/visual-stories.test.ts
+++ b/playwright/test/visual-stories.test.ts
@@ -1,4 +1,6 @@
-// TODO will be rewritten as part of https://github.com/wellcomecollection/wellcomecollection.org/issues/10323
+// TODO Rewrite as part of https://github.com/wellcomecollection/wellcomecollection.org/issues/10338
+// We found out that using test content for this was not realistic so we need real static content.
+
 // import { test as base, expect } from '@playwright/test';
 // import { visualStory } from './contexts';
 // import { baseUrl } from './helpers/urls';
@@ -15,17 +17,4 @@
 //     ]);
 //     await use(context);
 //   },
-// });
-
-// test.describe('visual-stories', () => {
-//   test('if it has a related document, it redirects to the relevant URL', async ({
-//     page,
-//     context,
-//   }) => {
-//     await visualStory('ZLe87hAAACIAwzqH', context, page);
-
-//     expect(page.url()).toBe(
-//       `${baseUrl}/exhibitions/Wt4AACAAAFCxRfQM/visual-stories`
-//     );
-//   });
 // });


### PR DESCRIPTION
## Who is this for?
Users/Visual stories
Relates to #10323 

## What is it doing for them?
We decided to remove the redirects and just use a canonical link instead. See the ticket for more information about how it should work moving forward and I've committed them separately with (hopefully) useful commit names.

Typescript kind of got me in `common/services/prismic/link-resolver.ts` and if anyone has a cleverer way about it please let me know, I kind of got stuck.

The ticket mentioned changing the test but after [commenting it out here](https://github.com/wellcomecollection/wellcomecollection.org/pull/10331) as we started having [issues](https://wellcome.slack.com/archives/CQ720BG02/p1697624078434609), I'm thinking it's better to wait until we have real content as using test content is a dangerous idea, they change all the time.
I'm suggesting creating a new ticket for it for the backlog and changing the comment in the test file to link to the new ticket. Just deleting the file I think we would forget about it, whilst having a TODO pushes us to do it.