### PR TITLE
Remove aggregations and visual stories toggle and references to

### DIFF
--- a/content/webapp/pages/events/[eventId]/visual-stories.tsx
+++ b/content/webapp/pages/events/[eventId]/visual-stories.tsx
@@ -12,9 +12,6 @@ export const getServerSideProps = async context => {
   setCacheControl(context.res);
   const client = createClient(context);
   const serverData = await getServerData(context);
-  if (!serverData?.toggles?.visualStories?.value) {
-    return { notFound: true };
-  }
 
   const visualStoriesQuery = await fetchVisualStories(client, {
     filters: [

--- a/content/webapp/pages/exhibitions/[exhibitionId]/visual-stories.tsx
+++ b/content/webapp/pages/exhibitions/[exhibitionId]/visual-stories.tsx
@@ -12,9 +12,6 @@ export const getServerSideProps = async context => {
   setCacheControl(context.res);
   const client = createClient(context);
   const serverData = await getServerData(context);
-  if (!serverData?.toggles?.visualStories?.value) {
-    return { notFound: true };
-  }
 
   const visualStoriesQuery = await fetchVisualStories(client, {
     filters: [

--- a/content/webapp/pages/search/works.tsx
+++ b/content/webapp/pages/search/works.tsx
@@ -49,7 +49,6 @@ import {
 } from '@weco/content/services/wellcome/catalogue/types';
 import { Query } from '@weco/content/types/search';
 import { ApiToolbarLink } from '@weco/common/views/components/ApiToolbar';
-import { isNotUndefined } from '@weco/common/utils/type-guards';
 
 type Props = {
   works: WellcomeResultList<WorkBasic, WorkAggregations>;
@@ -274,25 +273,13 @@ export const getServerSideProps: GetServerSideProps<
 
   const aggregations = serverData.toggles.aggregationsInSearch?.value
     ? [
-        serverData.toggles.aggregationsInSearchWorkType?.value
-          ? 'workType'
-          : undefined,
-        serverData.toggles.aggregationsInSearchAvailabilities?.value
-          ? 'availabilities'
-          : undefined,
-        serverData.toggles.aggregationsInSearchGenres?.value
-          ? 'genres.label'
-          : undefined,
-        serverData.toggles.aggregationsInSearchLanguages?.value
-          ? 'languages'
-          : undefined,
-        serverData.toggles.aggregationsInSearchSubjects?.value
-          ? 'subjects.label'
-          : undefined,
-        serverData.toggles.aggregationsInSearchContributors?.value
-          ? 'contributors.agent.label'
-          : undefined,
-      ].filter(isNotUndefined)
+        'workType',
+        'availabilities',
+        'genres.label',
+        'languages',
+        'subjects.label',
+        'contributors.agent.label',
+      ]
     : [];
 
   const worksApiProps = {

--- a/content/webapp/pages/visual-stories/[visualStoryId].tsx
+++ b/content/webapp/pages/visual-stories/[visualStoryId].tsx
@@ -58,10 +58,6 @@ export const getServerSideProps = async context => {
   const { visualStoryId } = context.query;
   const serverData = await getServerData(context);
 
-  if (!serverData?.toggles?.visualStories?.value) {
-    return { notFound: true };
-  }
-
   if (!looksLikePrismicId(visualStoryId)) {
     return { notFound: true };
   }

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -61,66 +61,11 @@ const toggles = {
       type: 'permanent',
     },
     {
-      id: 'aggregationsInSearchGenres',
-      title: 'Aggregations in search (genres)',
-      initialValue: false,
-      description:
-        'Whether to enable aggregations in search. Aggregations are an expensive part of the query, and they can be temporarily disabled if the API is having performance issues.',
-      type: 'experimental',
-    },
-    {
-      id: 'aggregationsInSearchAvailabilities',
-      title: 'Aggregations in search (availabilities)',
-      initialValue: false,
-      description:
-        'Whether to enable aggregations in search. Aggregations are an expensive part of the query, and they can be temporarily disabled if the API is having performance issues.',
-      type: 'experimental',
-    },
-    {
-      id: 'aggregationsInSearchWorkType',
-      title: 'Aggregations in search (workType)',
-      initialValue: false,
-      description:
-        'Whether to enable aggregations in search. Aggregations are an expensive part of the query, and they can be temporarily disabled if the API is having performance issues.',
-      type: 'experimental',
-    },
-    {
-      id: 'aggregationsInSearchSubjects',
-      title: 'Aggregations in search (subjects)',
-      initialValue: false,
-      description:
-        'Whether to enable aggregations in search. Aggregations are an expensive part of the query, and they can be temporarily disabled if the API is having performance issues.',
-      type: 'experimental',
-    },
-    {
-      id: 'aggregationsInSearchContributors',
-      title: 'Aggregations in search (contributors)',
-      initialValue: false,
-      description:
-        'Whether to enable aggregations in search. Aggregations are an expensive part of the query, and they can be temporarily disabled if the API is having performance issues.',
-      type: 'experimental',
-    },
-    {
-      id: 'aggregationsInSearchLanguages',
-      title: 'Aggregations in search (languages)',
-      initialValue: false,
-      description:
-        'Whether to enable aggregations in search. Aggregations are an expensive part of the query, and they can be temporarily disabled if the API is having performance issues.',
-      type: 'experimental',
-    },
-    {
       id: 'worksTabbedNav',
       title: 'Works page: Tabbed navigation',
       initialValue: false,
       description:
         'Adds tabbed navigation to the works page, for switching between work, item and related content',
-      type: 'experimental',
-    },
-    {
-      id: 'visualStories',
-      title: 'Visual Stories Prototype',
-      initialValue: false,
-      description: 'Allows access to visual stories pages.',
       type: 'experimental',
     },
   ] as const,


### PR DESCRIPTION
## Who is this for?
Maintenance, visual stories
Relates to both #10316 and #10320

## What is it doing for them?
- Cleans up aggregation specific toggles as all seems well now. Filters can still be turned off with the permanent aggregation toggle, just not to an individual level.
- Removes visual story toggle, we're happy enough with it.
- Remove references to those toggles.