### PR TITLE
Revert space hack in #9643

### DIFF
--- a/content/webapp/components/WorkDetails/WorkDetails.Text.tsx
+++ b/content/webapp/components/WorkDetails/WorkDetails.Text.tsx
@@ -15,11 +15,6 @@ const LimitWidth = styled.div.attrs({
    * into an arrow, which can be an issue e.g. for year ranges <1800->
    **/
   font-variant-ligatures: no-contextual;
-
-  /* This ensures any newlines in the API data are rendered on the page,
-   * e.g. lettering with newlines on https://wellcomecollection.org/works/cphumehx
-   **/
-  white-space: break-spaces;
 `;
 
 type TextProps = BaseProps & {


### PR DESCRIPTION
## Who is this for?
Everyone

## What is it doing for them?
#9643 included [a line](https://github.com/wellcomecollection/wellcomecollection.org/blob/8e0782cb62fae98923e3b51c3e4af8b0b49204ed/catalogue/webapp/components/WorkDetailsText/WorkDetailsText.tsx#L22) to make any newlines from the API be honoured on the front end, but when there are also e.g. `<p>` tags in the API response, this introduces extra space as well. After discussion we agreed that we're better off going back and introducing html (e.g. `<p>`s) in the data in places where we expect there to be spaces on the front end, rather than trying to solve it with css.

__before__
<img width="672" alt="Screenshot 2023-10-18 at 15 34 28" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/1394592/041e2905-77fb-45f3-a21f-d9f8c9330111">

__after__
<img width="670" alt="Screenshot 2023-10-18 at 15 34 38" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/1394592/bddbf2cd-0728-4e0a-a8d9-d0a651fab5bf">
