### PR TITLE
removes a broken url from checks + sets credentials in script

### DIFF
--- a/updown/checks.ts
+++ b/updown/checks.ts
@@ -21,12 +21,6 @@ if (!AWS.config.region) {
   });
 }
 
-// this may or may not be needed depending on the way your aws profiles are set up
-// const credentials = new AWS.SharedIniFileCredentials({
-//   profile: 'platform-developer',
-// });
-// AWS.config.credentials = credentials;
-
 const error = (message: string) => {
   console.error(chalk.redBright(message));
   process.exit(1);

--- a/updown/checks.ts
+++ b/updown/checks.ts
@@ -12,7 +12,7 @@ const { proceed } = yargs(process.argv)
     description: 'Run with verbose logging',
     default: false,
   })
-  .parse();
+  .parseSync();
 
 // set region if not set (as not set by the SDK by default)
 if (!AWS.config.region) {
@@ -20,6 +20,12 @@ if (!AWS.config.region) {
     region: 'eu-west-1',
   });
 }
+
+// this may or may not be needed depending on the way your aws profiles are set up
+// const credentials = new AWS.SharedIniFileCredentials({
+//   profile: 'platform-developer',
+// });
+// AWS.config.credentials = credentials;
 
 const error = (message: string) => {
   console.error(chalk.redBright(message));

--- a/updown/expected-checks.ts
+++ b/updown/expected-checks.ts
@@ -64,10 +64,6 @@ const worksChecks = [
     url: '/search/images?query=skeletons',
     alias: 'Experience: Works: Images search',
   },
-  {
-    url: '/search/works/pbxd2mgd/images?id=q6h754ua',
-    alias: 'Experience: Works: Image',
-  },
 ].flatMap(withOriginPrefix('works'));
 
 const apiChecks = [


### PR DESCRIPTION
## Who is this for?
Updown

## What is it doing for them?
A non-existent url was added to the updown checks, triggering alerts when it 404'd 
This is removing it
Already applied to updown through `yarn checks` 