### PR TITLE
Remove deprecated related-document

### DIFF
--- a/prismic-model/src/visual-stories.ts
+++ b/prismic-model/src/visual-stories.ts
@@ -20,13 +20,6 @@ const visualStories: CustomType = {
           linkedTypes: ['exhibitions', 'events'],
         }
       ),
-      // TODO delete in subsequent PR
-      'related-document': documentLink(
-        'Deprecated: Related Document (e.g. Exhibition or Event)',
-        {
-          linkedTypes: ['exhibitions', 'events'],
-        }
-      ),
       datePublished: timestamp('Date published'),
       showOnThisPage: boolean(
         "Show 'On this page' anchor links. This will only appear if there are more than 2 H2s in the body",


### PR DESCRIPTION
## Who is this for?
Maintenance
Relates to #10335

## What is it doing for them?
Cleans it up. Will deploy and merge once the PR changing the references to this field has made its way to prod.