### PR TITLE
Remove VS cookie in test as toggle was removed.

### DIFF
--- a/playwright/test/contexts.ts
+++ b/playwright/test/contexts.ts
@@ -231,16 +231,7 @@ export const visualStory = async (
   context: BrowserContext,
   page: Page
 ): Promise<void> => {
-  const VSCookie = [
-    ...requiredCookies,
-    {
-      name: 'toggle_visualStories',
-      value: 'true',
-      path: '/',
-      domain: new URL(baseUrl).host,
-    },
-  ]; // TODO remove when the toggle is removed https://github.com/wellcomecollection/wellcomecollection.org/issues/10320
-  await context.addCookies(VSCookie);
+  await context.addCookies(requiredCookies);
   await gotoWithoutCache(`${baseUrl}/visual-stories/${id}`, page);
 };
 


### PR DESCRIPTION
## Who is this for?
Maintenance

## What is it doing for them?
Forgot to do it as part of #10320. The toggle has been removed. This is unused at the moment but will be useful for #10338 