### PR TITLE
Allow queries to fetch delisted visual stories

### DIFF
--- a/content/webapp/pages/events/[eventId]/visual-stories.tsx
+++ b/content/webapp/pages/events/[eventId]/visual-stories.tsx
@@ -20,6 +20,7 @@ export const getServerSideProps = async context => {
         context.query.eventId
       ),
     ],
+    hasDelistFilter: false,
   });
 
   if (!visualStoriesQuery || visualStoriesQuery.results.length === 0) {

--- a/content/webapp/pages/exhibitions/[exhibitionId]/visual-stories.tsx
+++ b/content/webapp/pages/exhibitions/[exhibitionId]/visual-stories.tsx
@@ -20,6 +20,7 @@ export const getServerSideProps = async context => {
         context.query.exhibitionId
       ),
     ],
+    hasDelistFilter: false,
   });
 
   if (!visualStoriesQuery || visualStoriesQuery.results.length === 0) {

--- a/content/webapp/services/prismic/fetch/index.ts
+++ b/content/webapp/services/prismic/fetch/index.ts
@@ -98,26 +98,31 @@ export function fetcher<Document extends prismic.PrismicDocument>(
      */
     getByType: async (
       { client }: GetServerSidePropsPrismicClient,
-      params: GetByTypeParams = {}
+      params: GetByTypeParams = {},
+      hasDelistFilter = true
     ): Promise<prismic.Query<Document>> => {
-      const filters = isString(params.filters)
+      const paramsFilters = isString(params.filters)
         ? [params.filters]
         : Array.isArray(params.filters)
         ? params.filters
         : [];
 
+      const filters = [
+        ...paramsFilters,
+        hasDelistFilter ? delistFilter : '',
+      ].filter(f => f);
+
       const response = isString(contentType)
         ? await client.getByType<Document>(contentType, {
             ...params,
             fetchLinks,
-            filters: [...filters, delistFilter],
+            filters,
           })
         : await client.get<Document>({
             ...params,
             fetchLinks,
             filters: [
               ...filters,
-              delistFilter,
               prismic.filter.any('document.type', contentType),
             ],
           });

--- a/content/webapp/services/prismic/fetch/visual-stories.ts
+++ b/content/webapp/services/prismic/fetch/visual-stories.ts
@@ -16,16 +16,21 @@ const visualStoriesFetcher = fetcher<VisualStoryDocument>(
 );
 type GetVisualStoriesProps = {
   filters?: string[];
+  hasDelistFilter?: boolean;
 };
 
 export const fetchVisualStories = (
   client: GetServerSidePropsPrismicClient,
-  { filters = [] }: GetVisualStoriesProps = {}
+  { filters = [], hasDelistFilter = true }: GetVisualStoriesProps = {}
 ): Promise<prismic.Query<VisualStoryDocument>> => {
-  return visualStoriesFetcher.getByType(client, {
-    filters,
-    page: 1,
-  });
+  return visualStoriesFetcher.getByType(
+    client,
+    {
+      filters,
+      page: 1,
+    },
+    hasDelistFilter
+  );
 };
 
 export const fetchVisualStory = visualStoriesFetcher.getById;


### PR DESCRIPTION
## Who is this for?
Visual stories
Relates to #10344

## What is it doing for them?
Visual stories on `/exhibitions/[exhibitionId]/visual-stories` and their event equivalent would display a 404 if they were delisted. The same issue would happen with Prismic previews. We needed to allow the serverSide query for this to fetch delisted VS as well so they display.

This does affect the generic `getByType` (from `content/webapp/services/prismic/fetch/index.ts`), but as it's defaulted to `true`, it shouldn't bother anything unless we strongly dislike having specific code on what is meant to be generic.