### PR TITLE
Allow nvda users to pan image with keyboard

### DIFF
--- a/content/webapp/components/IIIFViewer/ZoomedImage.tsx
+++ b/content/webapp/components/IIIFViewer/ZoomedImage.tsx
@@ -66,6 +66,7 @@ const ZoomedImage: FunctionComponent<ZoomedImageProps> = ({
   const firstControl = useRef<HTMLButtonElement>(null);
   const lastControl = useRef<HTMLButtonElement>(null);
   const zoomedImage = useRef<HTMLDivElement>(null);
+
   function setupViewer(imageInfoSrc: string, viewerId: string) {
     fetch(imageInfoSrc)
       .then(response => response.json())
@@ -93,6 +94,14 @@ const ZoomedImage: FunctionComponent<ZoomedImageProps> = ({
         });
         osdViewer.addOnceHandler('tile-loaded', () => {
           doZoomIn(osdViewer);
+        });
+        osdViewer.addHandler('tile-loaded', () => {
+          // Prevent NVDA arrow key events escaping the viewer (https://stackoverflow.com/a/41523306)
+          osdViewer.container.setAttribute('role', 'toolbar');
+          osdViewer.container.setAttribute(
+            'aria-description',
+            'use arrow keys to pan the image'
+          );
         });
         setViewer(osdViewer);
       })


### PR DESCRIPTION
For #10299 

## Who is this for?
NVDA screen-reader users

## What is it doing for them?
Allowing them to pan the image using arrow keys as is possible for other keyboard users

I don't know if the `aria-description` is either

1. overkill (sighted users don't get this information)
2. not enough (we should _also_ give sighted users this information)

