### PR TITLE
Suggested Dependabot config

### DIFF
--- a/.github/.dependabot
+++ b/.github/.dependabot
@@ -1,0 +1,35 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly" # Check for updates every month
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"] # Ignore all patch updates for version updates only
+  - package-ecosystem: "npm"
+    directory: "/content/webapp"
+    schedule:
+      interval: "monthly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+  - package-ecosystem: "npm"
+    directory: "/identity/webapp"
+    schedule:
+      interval: "monthly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+  - package-ecosystem: "npm"
+    directory: "/common"
+    schedule:
+      interval: "monthly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
## Who is this for?
Devs and maintenance

## What is it doing for them?
- Sets Dependabot to run monthly (instead of the weekly we had earlier this year) 
- If I got it right, this should also ignore patch versions as to not overwhelm us with PRs - if you'd rather we also get them feel free to shout!