### PR TITLE
Paginator fixes

### DIFF
--- a/content/webapp/components/Pagination/Pagination.test.tsx
+++ b/content/webapp/components/Pagination/Pagination.test.tsx
@@ -7,7 +7,7 @@ import Pagination from './Pagination';
 const useRouter = jest.spyOn(require('next/router'), 'useRouter');
 
 describe('Pagination', () => {
-  it('omits the "Previous" button if we’re on page 1', () => {
+  it('omits the "Previous" link if we’re on page 1', () => {
     useRouter.mockImplementationOnce(() => ({ query: {} }));
 
     const { container } = renderWithTheme(
@@ -16,7 +16,7 @@ describe('Pagination', () => {
     expect(container.innerHTML.includes('Previous')).toBe(false);
   });
 
-  it('include the "Previous" button if we’re after page 1', async () => {
+  it('include the "Previous" link if we’re after page 1', async () => {
     useRouter.mockImplementationOnce(() => ({ query: { page: '5' } }));
 
     const { container, getByRole } = renderWithTheme(
@@ -24,11 +24,11 @@ describe('Pagination', () => {
     );
     expect(container.innerHTML.includes('Previous')).toBe(true);
     await expect(
-      getByRole('button', { name: 'Previous (page 4)' })
+      getByRole('link', { name: 'Previous (page 4)' })
     ).toHaveAttribute('href', '?page=4');
   });
 
-  it('omits the "Next" button if we’re on the last page', () => {
+  it('omits the "Next" link if we’re on the last page', () => {
     useRouter.mockImplementationOnce(() => ({ query: { page: '10' } }));
 
     const { container } = renderWithTheme(
@@ -44,9 +44,10 @@ describe('Pagination', () => {
       <Pagination totalPages={10} ariaLabel="Results pagination" />
     );
     expect(container.innerHTML.includes('Next')).toBe(true);
-    await expect(
-      getByRole('button', { name: 'Next (page 6)' })
-    ).toHaveAttribute('href', '?page=6');
+    await expect(getByRole('link', { name: 'Next (page 6)' })).toHaveAttribute(
+      'href',
+      '?page=6'
+    );
   });
 
   it('includes the pathname and query parameters when linking to the next/previous pages', async () => {
@@ -59,14 +60,12 @@ describe('Pagination', () => {
       <Pagination totalPages={10} ariaLabel="Results pagination" />
     );
     await expect(
-      getByRole('button', { name: 'Previous (page 4)' })
+      getByRole('link', { name: 'Previous (page 4)' })
     ).toHaveAttribute(
       'href',
       '/search/works?page=4&locations=available-online'
     );
-    await expect(
-      getByRole('button', { name: 'Next (page 6)' })
-    ).toHaveAttribute(
+    await expect(getByRole('link', { name: 'Next (page 6)' })).toHaveAttribute(
       'href',
       '/search/works?page=6&locations=available-online'
     );

--- a/content/webapp/components/Pagination/Pagination.tsx
+++ b/content/webapp/components/Pagination/Pagination.tsx
@@ -14,7 +14,6 @@ export type Props = {
   ariaLabel: string;
   hasDarkBg?: boolean;
   isHiddenMobile?: boolean;
-  isLoading?: boolean;
 };
 
 const Container = styled.nav.attrs({
@@ -33,7 +32,7 @@ const Container = styled.nav.attrs({
   `)}
 `;
 
-const ChevronWrapper = styled.button<{ prev?: boolean; hasDarkBg?: boolean }>`
+const ChevronWrapper = styled.a<{ prev?: boolean; hasDarkBg?: boolean }>`
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -94,7 +93,6 @@ export const Pagination: FunctionComponent<Props> = ({
   ariaLabel,
   hasDarkBg,
   isHiddenMobile,
-  isLoading,
 }) => {
   const router = useRouter();
   const { query, pathname } = router;
@@ -137,7 +135,7 @@ export const Pagination: FunctionComponent<Props> = ({
           href={{ pathname, query: { ...query, page: currentPage - 1 } }}
           legacyBehavior
         >
-          <ChevronWrapper hasDarkBg={hasDarkBg} prev disabled={isLoading}>
+          <ChevronWrapper hasDarkBg={hasDarkBg} prev>
             <Icon icon={chevron} />
             <span className="visually-hidden">
               {`Previous (page ${currentPage - 1})`}
@@ -175,7 +173,7 @@ export const Pagination: FunctionComponent<Props> = ({
           href={{ pathname, query: { ...query, page: currentPage + 1 } }}
           legacyBehavior
         >
-          <ChevronWrapper hasDarkBg={hasDarkBg} disabled={isLoading}>
+          <ChevronWrapper hasDarkBg={hasDarkBg}>
             <Icon icon={chevron} />
             <span className="visually-hidden">
               {`Next (page ${currentPage + 1})`}

--- a/content/webapp/components/Pagination/Pagination.tsx
+++ b/content/webapp/components/Pagination/Pagination.tsx
@@ -152,6 +152,9 @@ export const Pagination: FunctionComponent<Props> = ({
             onFocus={() => setIsFocused(true)}
             onBlur={() => setIsFocused(false)}
             form={isFocused ? 'search-page-form' : ''}
+            // We only use the formId if the input is focused
+            // as we can have more than one paginator on the same page
+            // and don't want to submit the same input with different values
             aria-label={`Jump to page ${currentPage} of ${formatNumber(
               totalPages
             )}`}

--- a/content/webapp/components/Pagination/Pagination.tsx
+++ b/content/webapp/components/Pagination/Pagination.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
 import { chevron } from '@weco/common/icons';
 import Icon from '@weco/common/views/components/Icon/Icon';
+import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper/ConditionalWrapper';
 import { font } from '@weco/common/utils/classnames';
 import { formatNumber } from '@weco/common/utils/grammar';
 
@@ -14,6 +15,7 @@ export type Props = {
   ariaLabel: string;
   hasDarkBg?: boolean;
   isHiddenMobile?: boolean;
+  formId?: string;
 };
 
 const Container = styled.nav.attrs({
@@ -93,6 +95,7 @@ export const Pagination: FunctionComponent<Props> = ({
   ariaLabel,
   hasDarkBg,
   isHiddenMobile,
+  formId,
 }) => {
   const router = useRouter();
   const { query, pathname } = router;
@@ -143,18 +146,20 @@ export const Pagination: FunctionComponent<Props> = ({
           </ChevronWrapper>
         </Link>
       )}
-
       {isEnhanced ? (
-        <>
+        <ConditionalWrapper
+          condition={!formId}
+          wrapper={children => <form>{children}</form>}
+        >
           <span aria-hidden>Showing page</span>
           <PageSelectorInput
             name="page"
             onFocus={() => setIsFocused(true)}
             onBlur={() => setIsFocused(false)}
-            form={isFocused ? 'search-page-form' : ''}
             // We only use the formId if the input is focused
             // as we can have more than one paginator on the same page
             // and don't want to submit the same input with different values
+            form={isFocused ? formId : ''}
             aria-label={`Jump to page ${currentPage} of ${formatNumber(
               totalPages
             )}`}
@@ -163,13 +168,12 @@ export const Pagination: FunctionComponent<Props> = ({
             darkBg={hasDarkBg}
           />
           <span aria-hidden>/ {formatNumber(totalPages)}</span>
-        </>
+        </ConditionalWrapper>
       ) : (
         <span>
           Page <strong>{currentPage}</strong> of {formatNumber(totalPages)}
         </span>
       )}
-
       {showNext && (
         <Link
           passHref

--- a/content/webapp/pages/search/images.tsx
+++ b/content/webapp/pages/search/images.tsx
@@ -217,6 +217,7 @@ const ImagesSearchPage: NextPageWithLayout<Props> = ({
                       ariaLabel="Image search pagination"
                       hasDarkBg
                       isHiddenMobile
+                      formId={'search-page-form'}
                     />
                   </SortPaginationWrapper>
                 </PaginationWrapper>
@@ -230,6 +231,7 @@ const ImagesSearchPage: NextPageWithLayout<Props> = ({
                     totalPages={images.totalPages}
                     ariaLabel="Image search pagination"
                     hasDarkBg
+                    formId={'search-page-form'}
                   />
                 </PaginationWrapper>
               </>

--- a/content/webapp/pages/search/stories.tsx
+++ b/content/webapp/pages/search/stories.tsx
@@ -177,6 +177,7 @@ export const SearchPage: NextPageWithLayout<Props> = ({
                     totalPages={storyResponseList.totalPages}
                     ariaLabel="Stories search pagination"
                     isHiddenMobile
+                    formId={'search-page-form'}
                   />
                 </SortPaginationWrapper>
               </PaginationWrapper>
@@ -198,6 +199,7 @@ export const SearchPage: NextPageWithLayout<Props> = ({
                 <Pagination
                   totalPages={storyResponseList.totalPages}
                   ariaLabel="Stories search pagination"
+                  formId={'search-page-form'}
                 />
               </PaginationWrapper>
             </Container>

--- a/content/webapp/pages/search/works.tsx
+++ b/content/webapp/pages/search/works.tsx
@@ -208,6 +208,7 @@ export const CatalogueSearchPage: NextPageWithLayout<Props> = ({
                     totalPages={works.totalPages}
                     ariaLabel="Catalogue search pagination"
                     isHiddenMobile
+                    formId={'search-page-form'}
                   />
                 </SortPaginationWrapper>
               </PaginationWrapper>
@@ -220,6 +221,7 @@ export const CatalogueSearchPage: NextPageWithLayout<Props> = ({
                 <Pagination
                   totalPages={works.totalPages}
                   ariaLabel="Catalogue search pagination"
+                  formId={'search-page-form'}
                 />
               </PaginationWrapper>
             </>

--- a/content/webapp/pages/series/[seriesId].tsx
+++ b/content/webapp/pages/series/[seriesId].tsx
@@ -246,6 +246,7 @@ const ArticleSeriesPage: FunctionComponent<Props> = props => {
             <Pagination
               totalPages={articles.totalPages}
               ariaLabel="Series pagination"
+              formId={'search-page-form'}
             />
           </PaginationWrapper>
         )}

--- a/playwright/test/search-works.test.ts
+++ b/playwright/test/search-works.test.ts
@@ -84,7 +84,7 @@ const navigateToNextPage = async (page: Page) => {
 
   await Promise.all([
     safeWaitForNavigation(page),
-    page.click('[data-testid="pagination"] button'),
+    page.click('[data-testid="pagination"] a'),
   ]);
 };
 


### PR DESCRIPTION
Relates to:

#10209: I've changed the previous next links from buttons to links, as that's what they are and it means that they work without javascript. Also, removed the disabled prop, as it's no longer applicable, and the isLoading prop as it wasn't being passed in anywhere and is no longer required.

#10307: I've added an optional formId prop to the Paginator. If supplied the page input will work as it did before, to submit the relevant form. If not supplied then the input gets wrapped in it's own form tag, so it will submit to the current url.
