### PR TITLE
Search form ID; one source of truth

### DIFF
--- a/common/utils/search.ts
+++ b/common/utils/search.ts
@@ -22,6 +22,8 @@ export type ReturnedResults<T> = {
   totalResults: number;
 };
 
+export const SEARCH_PAGES_FORM_ID = 'search-page-form';
+
 /**
  * Takes query result and checks for errors to log before returning required data.
  * @param {string} categoryName - e.g. works

--- a/content/webapp/components/SearchPageLayout/SearchNavigation.tsx
+++ b/content/webapp/components/SearchPageLayout/SearchNavigation.tsx
@@ -13,10 +13,10 @@ import {
   getUrlQueryFromSortValue,
   getQueryPropertyValue,
   linkResolver,
+  SEARCH_PAGES_FORM_ID,
 } from '@weco/common/utils/search';
 import { capitalize } from '@weco/common/utils/grammar';
 import { searchPlaceholderText } from '@weco/common/data/microcopy';
-import { SEARCH_FORM_ID } from '@weco/content/pages/search';
 
 const SearchBarContainer = styled(Space)`
   ${props => props.theme.media('medium', 'max-width')`
@@ -102,7 +102,7 @@ const SearchNavigation: FunctionComponent<SearchNavigationProps> = ({
     <>
       <form
         role="search"
-        id={SEARCH_FORM_ID}
+        id={SEARCH_PAGES_FORM_ID}
         onSubmit={event => {
           event.preventDefault();
 
@@ -126,7 +126,7 @@ const SearchNavigation: FunctionComponent<SearchNavigationProps> = ({
             inputValue={inputValue}
             setInputValue={setInputValue}
             placeholder={searchPlaceholderText[currentSearchCategory]}
-            form={SEARCH_FORM_ID}
+            form={SEARCH_PAGES_FORM_ID}
             location="search"
           />
         </SearchBarContainer>

--- a/content/webapp/components/SearchPageLayout/SearchNavigation.tsx
+++ b/content/webapp/components/SearchPageLayout/SearchNavigation.tsx
@@ -16,6 +16,7 @@ import {
 } from '@weco/common/utils/search';
 import { capitalize } from '@weco/common/utils/grammar';
 import { searchPlaceholderText } from '@weco/common/data/microcopy';
+import { SEARCH_FORM_ID } from '@weco/content/pages/search';
 
 const SearchBarContainer = styled(Space)`
   ${props => props.theme.media('medium', 'max-width')`
@@ -101,7 +102,7 @@ const SearchNavigation: FunctionComponent<SearchNavigationProps> = ({
     <>
       <form
         role="search"
-        id="search-page-form"
+        id={SEARCH_FORM_ID}
         onSubmit={event => {
           event.preventDefault();
 
@@ -125,7 +126,7 @@ const SearchNavigation: FunctionComponent<SearchNavigationProps> = ({
             inputValue={inputValue}
             setInputValue={setInputValue}
             placeholder={searchPlaceholderText[currentSearchCategory]}
-            form="search-page-form"
+            form={SEARCH_FORM_ID}
             location="search"
           />
         </SearchBarContainer>

--- a/content/webapp/pages/search/images.tsx
+++ b/content/webapp/pages/search/images.tsx
@@ -26,7 +26,7 @@ import { getServerData } from '@weco/common/server-data';
 import { getSearchLayout } from '@weco/content/components/SearchPageLayout/SearchPageLayout';
 import { imagesFilters } from '@weco/content/services/wellcome/catalogue/filters';
 import { emptyResultList } from '@weco/content/services/wellcome';
-import { linkResolver } from '@weco/common/utils/search';
+import { linkResolver, SEARCH_PAGES_FORM_ID } from '@weco/common/utils/search';
 import { getActiveFiltersLabel, hasFilters } from '@weco/content/utils/search';
 import { pluralize } from '@weco/common/utils/grammar';
 import { setCacheControl } from '@weco/content/utils/setCacheControl';
@@ -38,7 +38,6 @@ import {
 import { NextPageWithLayout } from '@weco/common/views/pages/_app';
 import { Query } from '@weco/content/types/search';
 import { ApiToolbarLink } from '@weco/common/views/components/ApiToolbar';
-import { SEARCH_FORM_ID } from '.';
 
 type Props = {
   images: CatalogueResultsList<Image>;
@@ -144,9 +143,9 @@ const ImagesSearchPage: NextPageWithLayout<Props> = ({
               linkResolver={params =>
                 linkResolver({ params, pathname: '/search/images' })
               }
-              searchFormId={SEARCH_FORM_ID}
+              searchFormId={SEARCH_PAGES_FORM_ID}
               changeHandler={() => {
-                const form = document.getElementById(SEARCH_FORM_ID);
+                const form = document.getElementById(SEARCH_PAGES_FORM_ID);
                 form &&
                   form.dispatchEvent(
                     new window.Event('submit', {
@@ -185,7 +184,7 @@ const ImagesSearchPage: NextPageWithLayout<Props> = ({
 
                   <SortPaginationWrapper>
                     <Sort
-                      formId={SEARCH_FORM_ID}
+                      formId={SEARCH_PAGES_FORM_ID}
                       options={sortOptions}
                       jsLessOptions={{
                         sort: [
@@ -211,7 +210,7 @@ const ImagesSearchPage: NextPageWithLayout<Props> = ({
                     />
 
                     <Pagination
-                      formId={SEARCH_FORM_ID}
+                      formId={SEARCH_PAGES_FORM_ID}
                       totalPages={images.totalPages}
                       ariaLabel="Image search pagination"
                       hasDarkBg
@@ -226,7 +225,7 @@ const ImagesSearchPage: NextPageWithLayout<Props> = ({
 
                 <PaginationWrapper verticalSpacing="l" alignRight>
                   <Pagination
-                    formId={SEARCH_FORM_ID}
+                    formId={SEARCH_PAGES_FORM_ID}
                     totalPages={images.totalPages}
                     ariaLabel="Image search pagination"
                     hasDarkBg

--- a/content/webapp/pages/search/images.tsx
+++ b/content/webapp/pages/search/images.tsx
@@ -12,7 +12,6 @@ import SearchFilters from '@weco/content/components/SearchFilters';
 import PaginationWrapper from '@weco/common/views/components/styled/PaginationWrapper';
 import Sort from '@weco/content/components/Sort/Sort';
 import { Container } from '@weco/common/views/components/styled/Container';
-
 import convertUrlToString from '@weco/common/utils/convert-url-to-string';
 import { getImages } from '@weco/content/services/wellcome/catalogue/images';
 import { serialiseProps } from '@weco/common/utils/json';
@@ -32,8 +31,6 @@ import { getActiveFiltersLabel, hasFilters } from '@weco/content/utils/search';
 import { pluralize } from '@weco/common/utils/grammar';
 import { setCacheControl } from '@weco/content/utils/setCacheControl';
 import { looksLikeSpam } from '@weco/content/utils/spam-detector';
-
-// Types
 import {
   CatalogueResultsList,
   Image,
@@ -41,6 +38,7 @@ import {
 import { NextPageWithLayout } from '@weco/common/views/pages/_app';
 import { Query } from '@weco/content/types/search';
 import { ApiToolbarLink } from '@weco/common/views/components/ApiToolbar';
+import { SEARCH_FORM_ID } from '.';
 
 type Props = {
   images: CatalogueResultsList<Image>;
@@ -146,9 +144,9 @@ const ImagesSearchPage: NextPageWithLayout<Props> = ({
               linkResolver={params =>
                 linkResolver({ params, pathname: '/search/images' })
               }
-              searchFormId="search-page-form"
+              searchFormId={SEARCH_FORM_ID}
               changeHandler={() => {
-                const form = document.getElementById('search-page-form');
+                const form = document.getElementById(SEARCH_FORM_ID);
                 form &&
                   form.dispatchEvent(
                     new window.Event('submit', {
@@ -187,7 +185,7 @@ const ImagesSearchPage: NextPageWithLayout<Props> = ({
 
                   <SortPaginationWrapper>
                     <Sort
-                      formId="search-page-form"
+                      formId={SEARCH_FORM_ID}
                       options={sortOptions}
                       jsLessOptions={{
                         sort: [
@@ -213,11 +211,11 @@ const ImagesSearchPage: NextPageWithLayout<Props> = ({
                     />
 
                     <Pagination
+                      formId={SEARCH_FORM_ID}
                       totalPages={images.totalPages}
                       ariaLabel="Image search pagination"
                       hasDarkBg
                       isHiddenMobile
-                      formId={'search-page-form'}
                     />
                   </SortPaginationWrapper>
                 </PaginationWrapper>
@@ -228,10 +226,10 @@ const ImagesSearchPage: NextPageWithLayout<Props> = ({
 
                 <PaginationWrapper verticalSpacing="l" alignRight>
                   <Pagination
+                    formId={SEARCH_FORM_ID}
                     totalPages={images.totalPages}
                     ariaLabel="Image search pagination"
                     hasDarkBg
-                    formId={'search-page-form'}
                   />
                 </PaginationWrapper>
               </>

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -128,8 +128,6 @@ const StoryPromoContainer = styled(Container)`
   }
 `;
 
-export const SEARCH_FORM_ID = 'search-page-form';
-
 export const SearchPage: NextPageWithLayout<Props> = ({
   works,
   images,

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -128,6 +128,8 @@ const StoryPromoContainer = styled(Container)`
   }
 `;
 
+export const SEARCH_FORM_ID = 'search-page-form';
+
 export const SearchPage: NextPageWithLayout<Props> = ({
   works,
   images,

--- a/content/webapp/pages/search/stories.tsx
+++ b/content/webapp/pages/search/stories.tsx
@@ -1,7 +1,6 @@
 import { GetServerSideProps } from 'next';
 import styled from 'styled-components';
 
-// Components
 import { getSearchLayout } from '@weco/content/components/SearchPageLayout/SearchPageLayout';
 import Pagination from '@weco/content/components/Pagination/Pagination';
 import SearchNoResults from '@weco/content/components/SearchNoResults/SearchNoResults';
@@ -11,8 +10,6 @@ import StoriesGrid from '@weco/content/components/StoriesGrid';
 import Space from '@weco/common/views/components/styled/Space';
 import SearchFilters from '@weco/content/components/SearchFilters';
 import { Container } from '@weco/common/views/components/styled/Container';
-
-// Utils & Helpers
 import { NextPageWithLayout } from '@weco/common/views/pages/_app';
 import { serialiseProps } from '@weco/common/utils/json';
 import { appError, AppErrorProps } from '@weco/common/services/app';
@@ -24,8 +21,6 @@ import { getActiveFiltersLabel, hasFilters } from '@weco/content/utils/search';
 import { getArticles } from '@weco/content/services/wellcome/content/articles';
 import { cacheTTL, setCacheControl } from '@weco/content/utils/setCacheControl';
 import { looksLikeSpam } from '@weco/content/utils/spam-detector';
-
-// Types
 import { Query } from '@weco/content/types/search';
 import {
   Article,
@@ -35,6 +30,7 @@ import { emptyResultList } from '@weco/content/services/wellcome';
 import { ApiToolbarLink } from '@weco/common/views/components/ApiToolbar';
 import { fromQuery, StoriesProps } from '@weco/content/components/StoriesLink';
 import { storiesFilters } from '@weco/content/services/wellcome/catalogue/filters';
+import { SEARCH_FORM_ID } from '.';
 
 type Props = {
   storyResponseList: ContentResultsList<Article>;
@@ -108,9 +104,9 @@ export const SearchPage: NextPageWithLayout<Props> = ({
                 linkResolver={params =>
                   linkResolver({ params, pathname: '/search/stories' })
                 }
-                searchFormId="search-page-form"
+                searchFormId={SEARCH_FORM_ID}
                 changeHandler={() => {
-                  const form = document.getElementById('search-page-form');
+                  const form = document.getElementById(SEARCH_FORM_ID);
                   form &&
                     form.dispatchEvent(
                       new window.Event('submit', {
@@ -150,7 +146,7 @@ export const SearchPage: NextPageWithLayout<Props> = ({
 
                 <SortPaginationWrapper>
                   <Sort
-                    formId="search-page-form"
+                    formId={SEARCH_FORM_ID}
                     options={sortOptions}
                     jsLessOptions={{
                       sort: [
@@ -174,10 +170,10 @@ export const SearchPage: NextPageWithLayout<Props> = ({
                     }}
                   />
                   <Pagination
+                    formId={SEARCH_FORM_ID}
                     totalPages={storyResponseList.totalPages}
                     ariaLabel="Stories search pagination"
                     isHiddenMobile
-                    formId={'search-page-form'}
                   />
                 </SortPaginationWrapper>
               </PaginationWrapper>
@@ -197,9 +193,9 @@ export const SearchPage: NextPageWithLayout<Props> = ({
 
               <PaginationWrapper verticalSpacing="l" alignRight>
                 <Pagination
+                  formId={SEARCH_FORM_ID}
                   totalPages={storyResponseList.totalPages}
                   ariaLabel="Stories search pagination"
-                  formId={'search-page-form'}
                 />
               </PaginationWrapper>
             </Container>

--- a/content/webapp/pages/search/stories.tsx
+++ b/content/webapp/pages/search/stories.tsx
@@ -16,7 +16,11 @@ import { appError, AppErrorProps } from '@weco/common/services/app';
 import { getServerData } from '@weco/common/server-data';
 import { Pageview } from '@weco/common/services/conversion/track';
 import { pluralize } from '@weco/common/utils/grammar';
-import { getQueryPropertyValue, linkResolver } from '@weco/common/utils/search';
+import {
+  getQueryPropertyValue,
+  linkResolver,
+  SEARCH_PAGES_FORM_ID,
+} from '@weco/common/utils/search';
 import { getActiveFiltersLabel, hasFilters } from '@weco/content/utils/search';
 import { getArticles } from '@weco/content/services/wellcome/content/articles';
 import { cacheTTL, setCacheControl } from '@weco/content/utils/setCacheControl';
@@ -30,7 +34,6 @@ import { emptyResultList } from '@weco/content/services/wellcome';
 import { ApiToolbarLink } from '@weco/common/views/components/ApiToolbar';
 import { fromQuery, StoriesProps } from '@weco/content/components/StoriesLink';
 import { storiesFilters } from '@weco/content/services/wellcome/catalogue/filters';
-import { SEARCH_FORM_ID } from '.';
 
 type Props = {
   storyResponseList: ContentResultsList<Article>;
@@ -104,9 +107,9 @@ export const SearchPage: NextPageWithLayout<Props> = ({
                 linkResolver={params =>
                   linkResolver({ params, pathname: '/search/stories' })
                 }
-                searchFormId={SEARCH_FORM_ID}
+                searchFormId={SEARCH_PAGES_FORM_ID}
                 changeHandler={() => {
-                  const form = document.getElementById(SEARCH_FORM_ID);
+                  const form = document.getElementById(SEARCH_PAGES_FORM_ID);
                   form &&
                     form.dispatchEvent(
                       new window.Event('submit', {
@@ -146,7 +149,7 @@ export const SearchPage: NextPageWithLayout<Props> = ({
 
                 <SortPaginationWrapper>
                   <Sort
-                    formId={SEARCH_FORM_ID}
+                    formId={SEARCH_PAGES_FORM_ID}
                     options={sortOptions}
                     jsLessOptions={{
                       sort: [
@@ -170,7 +173,7 @@ export const SearchPage: NextPageWithLayout<Props> = ({
                     }}
                   />
                   <Pagination
-                    formId={SEARCH_FORM_ID}
+                    formId={SEARCH_PAGES_FORM_ID}
                     totalPages={storyResponseList.totalPages}
                     ariaLabel="Stories search pagination"
                     isHiddenMobile
@@ -193,7 +196,7 @@ export const SearchPage: NextPageWithLayout<Props> = ({
 
               <PaginationWrapper verticalSpacing="l" alignRight>
                 <Pagination
-                  formId={SEARCH_FORM_ID}
+                  formId={SEARCH_PAGES_FORM_ID}
                   totalPages={storyResponseList.totalPages}
                   ariaLabel="Stories search pagination"
                 />

--- a/content/webapp/pages/search/works.tsx
+++ b/content/webapp/pages/search/works.tsx
@@ -3,7 +3,6 @@ import { GetServerSideProps } from 'next';
 import Head from 'next/head';
 import styled from 'styled-components';
 
-// Components
 import Space from '@weco/common/views/components/styled/Space';
 import SearchContext from '@weco/common/views/components/SearchContext/SearchContext';
 import SearchNoResults from '@weco/content/components/SearchNoResults/SearchNoResults';
@@ -21,8 +20,6 @@ import {
   WorksProps as WorksRouteProps,
 } from '@weco/content/components/WorksLink';
 import { Container } from '@weco/common/views/components/styled/Container';
-
-// Utils & Helpers
 import { serialiseProps } from '@weco/common/utils/json';
 import { getServerData } from '@weco/common/server-data';
 import { NextPageWithLayout } from '@weco/common/views/pages/_app';
@@ -40,8 +37,6 @@ import { AppErrorProps, appError } from '@weco/common/services/app';
 import { pluralize } from '@weco/common/utils/grammar';
 import { cacheTTL, setCacheControl } from '@weco/content/utils/setCacheControl';
 import { looksLikeSpam } from '@weco/content/utils/spam-detector';
-
-// Types
 import {
   toWorkBasic,
   WorkAggregations,
@@ -49,6 +44,7 @@ import {
 } from '@weco/content/services/wellcome/catalogue/types';
 import { Query } from '@weco/content/types/search';
 import { ApiToolbarLink } from '@weco/common/views/components/ApiToolbar';
+import { SEARCH_FORM_ID } from '.';
 
 type Props = {
   works: WellcomeResultList<WorkBasic, WorkAggregations>;
@@ -63,6 +59,7 @@ const SortPaginationWrapper = styled.div`
   align-items: center;
   flex-wrap: wrap;
 `;
+
 export const CatalogueSearchPage: NextPageWithLayout<Props> = ({
   works,
   worksRouteProps,
@@ -130,9 +127,9 @@ export const CatalogueSearchPage: NextPageWithLayout<Props> = ({
                   linkResolver={params =>
                     linkResolver({ params, pathname: '/search/works' })
                   }
-                  searchFormId="search-page-form"
+                  searchFormId={SEARCH_FORM_ID}
                   changeHandler={() => {
-                    const form = document.getElementById('search-page-form');
+                    const form = document.getElementById(SEARCH_FORM_ID);
                     form &&
                       form.dispatchEvent(
                         new window.Event('submit', {
@@ -172,7 +169,7 @@ export const CatalogueSearchPage: NextPageWithLayout<Props> = ({
 
                 <SortPaginationWrapper>
                   <Sort
-                    formId="search-page-form"
+                    formId={SEARCH_FORM_ID}
                     options={[
                       // Default value to be left empty so it's not added to the URL query
                       { value: '', text: 'Relevance' },
@@ -205,10 +202,10 @@ export const CatalogueSearchPage: NextPageWithLayout<Props> = ({
                   />
 
                   <Pagination
+                    formId={SEARCH_FORM_ID}
                     totalPages={works.totalPages}
                     ariaLabel="Catalogue search pagination"
                     isHiddenMobile
-                    formId={'search-page-form'}
                   />
                 </SortPaginationWrapper>
               </PaginationWrapper>
@@ -219,9 +216,9 @@ export const CatalogueSearchPage: NextPageWithLayout<Props> = ({
 
               <PaginationWrapper verticalSpacing="l" alignRight>
                 <Pagination
+                  formId={SEARCH_FORM_ID}
                   totalPages={works.totalPages}
                   ariaLabel="Catalogue search pagination"
-                  formId={'search-page-form'}
                 />
               </PaginationWrapper>
             </>

--- a/content/webapp/pages/search/works.tsx
+++ b/content/webapp/pages/search/works.tsx
@@ -31,7 +31,7 @@ import {
   WellcomeResultList,
 } from '@weco/content/services/wellcome';
 import convertUrlToString from '@weco/common/utils/convert-url-to-string';
-import { linkResolver } from '@weco/common/utils/search';
+import { linkResolver, SEARCH_PAGES_FORM_ID } from '@weco/common/utils/search';
 import { getActiveFiltersLabel, hasFilters } from '@weco/content/utils/search';
 import { AppErrorProps, appError } from '@weco/common/services/app';
 import { pluralize } from '@weco/common/utils/grammar';
@@ -44,7 +44,6 @@ import {
 } from '@weco/content/services/wellcome/catalogue/types';
 import { Query } from '@weco/content/types/search';
 import { ApiToolbarLink } from '@weco/common/views/components/ApiToolbar';
-import { SEARCH_FORM_ID } from '.';
 
 type Props = {
   works: WellcomeResultList<WorkBasic, WorkAggregations>;
@@ -127,9 +126,9 @@ export const CatalogueSearchPage: NextPageWithLayout<Props> = ({
                   linkResolver={params =>
                     linkResolver({ params, pathname: '/search/works' })
                   }
-                  searchFormId={SEARCH_FORM_ID}
+                  searchFormId={SEARCH_PAGES_FORM_ID}
                   changeHandler={() => {
-                    const form = document.getElementById(SEARCH_FORM_ID);
+                    const form = document.getElementById(SEARCH_PAGES_FORM_ID);
                     form &&
                       form.dispatchEvent(
                         new window.Event('submit', {
@@ -169,7 +168,7 @@ export const CatalogueSearchPage: NextPageWithLayout<Props> = ({
 
                 <SortPaginationWrapper>
                   <Sort
-                    formId={SEARCH_FORM_ID}
+                    formId={SEARCH_PAGES_FORM_ID}
                     options={[
                       // Default value to be left empty so it's not added to the URL query
                       { value: '', text: 'Relevance' },
@@ -202,7 +201,7 @@ export const CatalogueSearchPage: NextPageWithLayout<Props> = ({
                   />
 
                   <Pagination
-                    formId={SEARCH_FORM_ID}
+                    formId={SEARCH_PAGES_FORM_ID}
                     totalPages={works.totalPages}
                     ariaLabel="Catalogue search pagination"
                     isHiddenMobile
@@ -216,7 +215,7 @@ export const CatalogueSearchPage: NextPageWithLayout<Props> = ({
 
               <PaginationWrapper verticalSpacing="l" alignRight>
                 <Pagination
-                  formId={SEARCH_FORM_ID}
+                  formId={SEARCH_PAGES_FORM_ID}
                   totalPages={works.totalPages}
                   ariaLabel="Catalogue search pagination"
                 />

--- a/content/webapp/pages/series/[seriesId].tsx
+++ b/content/webapp/pages/series/[seriesId].tsx
@@ -246,7 +246,6 @@ const ArticleSeriesPage: FunctionComponent<Props> = props => {
             <Pagination
               totalPages={articles.totalPages}
               ariaLabel="Series pagination"
-              formId={'search-page-form'}
             />
           </PaginationWrapper>
         )}


### PR DESCRIPTION
## Who is this for?
Maintenance

## What is it doing for them?
I just noticed repetition in the form ID in search while I had to fix merge conflicts, turns out we declare it a few times in the same file, and it's the same ID in about 5 files, so I thought we could declare it only once and safeguard against future typos in tests etc.? 
And `[series]` doesn't need a search id so I removed it from there and it works really well with the new fix 🙌 