### PR TITLE
Add a custom message for 410 Gone

### DIFF
--- a/common/data/errors.tsx
+++ b/common/data/errors.tsx
@@ -78,3 +78,22 @@ export const NotFoundErrorText: FunctionComponent = () => (
     </Space>
   </Layout8>
 );
+
+export const GoneErrorText: FunctionComponent = () => (
+  <Layout8>
+    <Space
+      className="body-text"
+      $v={{ size: 'l', properties: ['margin-top', 'margin-bottom'] }}
+    >
+      <p>This work has been deleted from our public catalogue.</p>
+      <p>
+        If that doesn&apos;t seem right or isn&apos;t what you expected, email
+        us at{' '}
+        <a href="mailto:digital@wellcomecollection.org">
+          digital@wellcomecollection.org
+        </a>
+        .
+      </p>
+    </Space>
+  </Layout8>
+);

--- a/common/views/components/ErrorPage/ErrorPage.tsx
+++ b/common/views/components/ErrorPage/ErrorPage.tsx
@@ -1,20 +1,16 @@
 import { Fragment, FunctionComponent, useState, useEffect } from 'react';
-
-// Helpers/Utils
-import { isNotUndefined } from '@weco/common/utils/type-guards';
 import { getCookies } from 'cookies-next';
 import styled from 'styled-components';
 
-// Hard-coded values
+import { isNotUndefined } from '@weco/common/utils/type-guards';
 import {
   DefaultErrorText,
+  GoneErrorText,
   NotFoundErrorText,
   errorMessages,
 } from '@weco/common/data/errors';
 import { headerBackgroundLs } from '@weco/common/utils/backgrounds';
 import { underConstruction } from '@weco/common/icons';
-
-// Components
 import Icon from '@weco/common/views/components/Icon/Icon';
 import Layout8 from '@weco/common/views/components/Layout8/Layout8';
 import PageHeader, { headerSpaceSize } from '../PageHeader/PageHeader';
@@ -93,6 +89,17 @@ const TogglesMessage: FunctionComponent = () => {
   ) : null;
 };
 
+const getErrorMessage = (statusCode: number) => {
+  switch (statusCode) {
+    case 404:
+      return <NotFoundErrorText />;
+    case 410:
+      return <GoneErrorText />;
+    default:
+      return <DefaultErrorText />;
+  }
+};
+
 type Props = {
   statusCode?: number;
   title?: string;
@@ -107,8 +114,8 @@ const ErrorPage: FunctionComponent<Props> = ({ statusCode = 500, title }) => {
 
   return (
     <PageLayout
-      title={`${statusCode}`}
-      description={`${statusCode}`}
+      title={String(statusCode)}
+      description={String(statusCode)}
       url={{ pathname: '/' }}
       jsonLd={{ '@type': 'WebPage' }}
       openGraphType="website"
@@ -124,7 +131,7 @@ const ErrorPage: FunctionComponent<Props> = ({ statusCode = 500, title }) => {
         />
         <SpacingSection>
           <SpacingComponent>
-            {statusCode === 404 ? <NotFoundErrorText /> : <DefaultErrorText />}
+            {getErrorMessage(statusCode)}
             <TogglesMessage />
           </SpacingComponent>
         </SpacingSection>


### PR DESCRIPTION
## Who is this for?
Users
Relates to #10385 

## What is it doing for them?
Displays a custom message if the error is 410 Gone to avoid confusion.
Example URL: https://wellcomecollection.org/works/vxx96d62

<img width="1207" alt="Screenshot 2023-10-27 at 17 12 17" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/35eea89b-fa8a-4ff6-bc7e-b965b7cf11c2">
