### PR TITLE
Ensure filters are unique by label

### DIFF
--- a/content/webapp/services/wellcome/catalogue/filters.test.ts
+++ b/content/webapp/services/wellcome/catalogue/filters.test.ts
@@ -69,4 +69,41 @@ describe('filter options', () => {
 
     expect(filter.options.length).toBe(7);
   });
+
+  it('filters duplicate labels from the aggregation buckets', () =>  {
+    const aggregations =  {aggregations: {
+      'subjects.label': {
+      buckets: [
+        {
+          data: {
+            label: 'University of Glasgow. Library.',
+            type: 'Subject',
+          },
+          count: 100,
+          type: 'AggregationBucket',
+        },
+        {
+          data: {
+            label: 'Public Health.',
+            type: 'Subject',
+          },
+          count: 65705,
+          type: 'AggregationBucket',
+        },
+        {
+          data: {
+            label: 'University of Glasgow. Library.',
+            type: 'Subject',
+          },
+          count: 5,
+          type: 'AggregationBucket',
+        }]}}};
+
+    const filter = worksFilters({
+      works: worksAggregations,
+      props: {},
+    }).find(f => f.id === 'subjects.label') as CheckboxFilter;
+
+    expect(filter.options.length).toBe(2);
+  })
 });

--- a/content/webapp/services/wellcome/catalogue/filters.test.ts
+++ b/content/webapp/services/wellcome/catalogue/filters.test.ts
@@ -98,7 +98,7 @@ describe('filter options', () => {
         }];
 
     var aggregationsWithDuplicates = structuredClone(worksAggregations)
-    aggregationsWithDuplicates.aggregations.['subjects.label'].buckets = subjectsWithDuplicates
+    aggregationsWithDuplicates.aggregations['subjects.label'].buckets = subjectsWithDuplicates
     const filter = worksFilters({
       works: aggregationsWithDuplicates,
       props: {},

--- a/content/webapp/services/wellcome/catalogue/filters.test.ts
+++ b/content/webapp/services/wellcome/catalogue/filters.test.ts
@@ -70,40 +70,50 @@ describe('filter options', () => {
     expect(filter.options.length).toBe(7);
   });
 
-  it('filters duplicate labels from the aggregation buckets', () =>  {
-    const subjectsWithDuplicates = [
-        {
-          data: {
-            label: 'University of Glasgow. Library.',
-            type: 'Subject',
-          },
-          count: 100,
-          type: 'AggregationBucket',
+  it('filters duplicate labels from the aggregation buckets', () => {
+    const aggregationsWithDuplicates = {
+      aggregations: {
+        workType: { buckets: [] },
+        availabilities: { buckets: [] },
+        'subjects.label': {
+          buckets: [
+            {
+              data: {
+                label: 'University of Glasgow. Library.',
+                type: 'Subject',
+              },
+              count: 100,
+              type: 'AggregationBucket',
+            },
+            {
+              data: {
+                label: 'Public Health.',
+                type: 'Subject',
+              },
+              count: 65705,
+              type: 'AggregationBucket',
+            },
+            {
+              data: {
+                label: 'University of Glasgow. Library.',
+                type: 'Subject',
+              },
+              count: 5,
+              type: 'AggregationBucket',
+            },
+          ],
         },
-        {
-          data: {
-            label: 'Public Health.',
-            type: 'Subject',
-          },
-          count: 65705,
-          type: 'AggregationBucket',
-        },
-        {
-          data: {
-            label: 'University of Glasgow. Library.',
-            type: 'Subject',
-          },
-          count: 5,
-          type: 'AggregationBucket',
-        }];
+      },
+    };
 
-    var aggregationsWithDuplicates = structuredClone(worksAggregations)
-    aggregationsWithDuplicates.aggregations['subjects.label'].buckets = subjectsWithDuplicates
     const filter = worksFilters({
       works: aggregationsWithDuplicates,
-      props: {},
+      props: fromWorksQuery({
+        'subjects.label': 'something else',
+      }),
     }).find(f => f.id === 'subjects.label') as CheckboxFilter;
 
-    expect(filter.options.length).toBe(2);
-  })
+    expect(filter.options.length).toBe(3);
+    expect(filter.options).toBe('banana');
+  });
 });

--- a/content/webapp/services/wellcome/catalogue/filters.test.ts
+++ b/content/webapp/services/wellcome/catalogue/filters.test.ts
@@ -71,9 +71,7 @@ describe('filter options', () => {
   });
 
   it('filters duplicate labels from the aggregation buckets', () =>  {
-    const aggregations =  {aggregations: {
-      'subjects.label': {
-      buckets: [
+    const subjectsWithDuplicates = [
         {
           data: {
             label: 'University of Glasgow. Library.',
@@ -97,10 +95,12 @@ describe('filter options', () => {
           },
           count: 5,
           type: 'AggregationBucket',
-        }]}}};
+        }];
 
+    var aggregationsWithDuplicates = structuredClone(worksAggregations)
+    aggregationsWithDuplicates.aggregations.['subjects.label'].buckets = subjectsWithDuplicates
     const filter = worksFilters({
-      works: worksAggregations,
+      works: aggregationsWithDuplicates,
       props: {},
     }).find(f => f.id === 'subjects.label') as CheckboxFilter;
 

--- a/content/webapp/services/wellcome/catalogue/filters.test.ts
+++ b/content/webapp/services/wellcome/catalogue/filters.test.ts
@@ -43,18 +43,153 @@ describe('filter options', () => {
     ).toBeFalsy();
   });
 
-  it('includes option to from query that is not in the API aggregation', () => {
+  it('sorts options by count descending then label ascending', () => {
     const filter = worksFilters({
-      works: worksAggregations,
-      props: fromWorksQuery({
-        // An aggregation we know isn't in the fixture response
-        'contributors.agent.label': '"Non existent"',
-      }),
-    }).find(f => f.id === 'contributors.agent.label') as CheckboxFilter;
+      works: worksAggregationsWith('subjects.label', [
+        {
+          data: {
+            label: 'Astronauts',
+            type: 'Subject',
+          },
+          count: 666,
+          type: 'AggregationBucket',
+        },
+        {
+          data: {
+            label: 'Zouaves',
+            type: 'Subject',
+          },
+          count: 999,
+          type: 'AggregationBucket',
+        },
+        {
+          data: {
+            label: 'Zeppelins',
+            type: 'Subject',
+          },
+          count: 100,
+          type: 'AggregationBucket',
+        },
+        {
+          data: {
+            label: 'Aardvarks',
+            type: 'Subject',
+          },
+          count: 100,
+          type: 'AggregationBucket',
+        },
+      ]),
+      props: fromWorksQuery({}),
+    }).find(f => f.id === 'subjects.label') as CheckboxFilter;
 
-    expect(
-      filter.options.find(option => option.label === 'Non existent')
-    ).toBeTruthy();
+    expect(filter.options.map(option => option.count)).toEqual([
+      999, 666, 100, 100,
+    ]);
+
+    expect(filter.options.map(option => option.label)).toEqual([
+      'Zouaves',
+      'Astronauts',
+      'Aardvarks',
+      'Zeppelins',
+    ]);
+  });
+
+  describe('when options in the query are not present in the API aggregation', () => {
+    it('includes the selected option from the query', () => {
+      const filter = worksFilters({
+        works: worksAggregationsWith('contributors.agent.label', []),
+        props: fromWorksQuery({
+          // An aggregation we know isn't in the fixture response
+          'contributors.agent.label': '"Non existent"',
+        }),
+      }).find(f => f.id === 'contributors.agent.label') as CheckboxFilter;
+
+      expect(filter.options[0].label).toEqual('Non existent');
+
+      expect(filter.options[0].selected).toBeTruthy();
+    });
+
+    it('does not present a bogus count for the requested option', () => {
+      const filter = worksFilters({
+        works: worksAggregationsWith('contributors.agent.label', []),
+        props: fromWorksQuery({
+          // An aggregation we know isn't in the fixture response
+          'contributors.agent.label': '"Non existent"',
+        }),
+      }).find(f => f.id === 'contributors.agent.label') as CheckboxFilter;
+
+      expect(filter.options[0].count).toBeUndefined();
+    });
+
+    it('places the requested options above the aggregation options, sorted alphabetically', () => {
+      const filter = worksFilters({
+        works: worksAggregationsWith('subjects.label', [
+          {
+            data: {
+              label: 'Aardvarks',
+              type: 'Subject',
+            },
+            count: 100,
+            type: 'AggregationBucket',
+          },
+        ]),
+        props: fromWorksQuery({
+          'subjects.label': '"Zeppelins", "Bananas"',
+        }),
+      }).find(f => f.id === 'subjects.label') as CheckboxFilter;
+
+      expect(filter.options.map(option => option.label)).toEqual([
+        'Bananas',
+        'Zeppelins',
+        'Aardvarks',
+      ]);
+    });
+  });
+
+  describe('duplicate buckets', () => {
+    const aggregationsWithDuplicates = worksAggregationsWith('subjects.label', [
+      {
+        data: {
+          label: 'University of Glasgow. Library.',
+          type: 'Subject',
+        },
+        count: 100,
+        type: 'AggregationBucket',
+      },
+      {
+        data: {
+          label: 'Public Health.',
+          type: 'Subject',
+        },
+        count: 65705,
+        type: 'AggregationBucket',
+      },
+      {
+        data: {
+          label: 'University of Glasgow. Library.',
+          type: 'Subject',
+        },
+        count: 5,
+        type: 'AggregationBucket',
+      },
+    ]);
+
+    const filter = worksFilters({
+      works: aggregationsWithDuplicates,
+      props: fromWorksQuery({}),
+    }).find(f => f.id === 'subjects.label') as CheckboxFilter;
+
+    it('filters duplicate labels from the aggregation buckets', () => {
+      expect(filter.options.length).toBe(2);
+    });
+
+    it('sums the counts from homonymous buckets', () => {
+      expect(
+        filter.options.find(
+          option => option.label === 'University of Glasgow. Library.'
+        )?.count
+      ).toBe(105);
+    });
   });
 
   it('includes empty buckets on images license filter', () => {
@@ -70,50 +205,13 @@ describe('filter options', () => {
     expect(filter.options.length).toBe(7);
   });
 
-  it('filters duplicate labels from the aggregation buckets', () => {
-    const aggregationsWithDuplicates = {
+  function worksAggregationsWith(aggregationName, bucketList) {
+    return {
       aggregations: {
         workType: { buckets: [] },
         availabilities: { buckets: [] },
-        'subjects.label': {
-          buckets: [
-            {
-              data: {
-                label: 'University of Glasgow. Library.',
-                type: 'Subject',
-              },
-              count: 100,
-              type: 'AggregationBucket',
-            },
-            {
-              data: {
-                label: 'Public Health.',
-                type: 'Subject',
-              },
-              count: 65705,
-              type: 'AggregationBucket',
-            },
-            {
-              data: {
-                label: 'University of Glasgow. Library.',
-                type: 'Subject',
-              },
-              count: 5,
-              type: 'AggregationBucket',
-            },
-          ],
-        },
+        [aggregationName]: { buckets: bucketList },
       },
     };
-
-    const filter = worksFilters({
-      works: aggregationsWithDuplicates,
-      props: fromWorksQuery({
-        'subjects.label': 'something else',
-      }),
-    }).find(f => f.id === 'subjects.label') as CheckboxFilter;
-
-    expect(filter.options.length).toBe(3);
-    expect(filter.options).toBe('banana');
-  });
+  }
 });

--- a/content/webapp/services/wellcome/catalogue/filters.test.ts
+++ b/content/webapp/services/wellcome/catalogue/filters.test.ts
@@ -94,6 +94,55 @@ describe('filter options', () => {
     ]);
   });
 
+  it('presents options with zero matching records at the top of the list', () => {
+    const filter = worksFilters({
+      works: worksAggregationsWith('subjects.label', [
+        {
+          data: {
+            label: 'Astronauts',
+            type: 'Subject',
+          },
+          count: 3,
+          type: 'AggregationBucket',
+        },
+        {
+          data: {
+            label: 'Zouaves',
+            type: 'Subject',
+          },
+          count: 0,
+          type: 'AggregationBucket',
+        },
+        {
+          data: {
+            label: 'Zeppelins',
+            type: 'Subject',
+          },
+          count: 1,
+          type: 'AggregationBucket',
+        },
+        {
+          data: {
+            label: 'Aardvarks',
+            type: 'Subject',
+          },
+          count: 2,
+          type: 'AggregationBucket',
+        },
+      ]),
+      props: fromWorksQuery({ 'subjects.label': 'Zouaves' }),
+    }).find(f => f.id === 'subjects.label') as CheckboxFilter;
+
+    expect(filter.options.map(option => option.count)).toEqual([0, 3, 2, 1]);
+
+    expect(filter.options.map(option => option.label)).toEqual([
+      'Zouaves',
+      'Astronauts',
+      'Aardvarks',
+      'Zeppelins',
+    ]);
+  });
+
   describe('when options in the query are not present in the API aggregation', () => {
     it('includes the selected option from the query', () => {
       const filter = worksFilters({
@@ -142,6 +191,56 @@ describe('filter options', () => {
         'Bananas',
         'Zeppelins',
         'Aardvarks',
+      ]);
+    });
+
+    it('treats the absence of a count the same as a zero count', () => {
+      const filter = worksFilters({
+        works: worksAggregationsWith('subjects.label', [
+          {
+            data: {
+              label: 'Aardvarks',
+              type: 'Subject',
+            },
+            count: 0,
+            type: 'AggregationBucket',
+          },
+          {
+            data: {
+              label: 'XYZZY',
+              type: 'Subject',
+            },
+            count: 0,
+            type: 'AggregationBucket',
+          },
+          {
+            data: {
+              label: 'Plugh!',
+              type: 'Subject',
+            },
+            count: 999,
+            type: 'AggregationBucket',
+          },
+        ]),
+        props: fromWorksQuery({
+          'subjects.label': '"Zeppelins", "Bananas", "Aardvarks", "XYZZY"',
+        }),
+      }).find(f => f.id === 'subjects.label') as CheckboxFilter;
+
+      expect(filter.options.map(option => option.count)).toEqual([
+        0,
+        undefined,
+        0,
+        undefined,
+        999,
+      ]);
+
+      expect(filter.options.map(option => option.label)).toEqual([
+        'Aardvarks',
+        'Bananas',
+        'XYZZY',
+        'Zeppelins',
+        'Plugh!',
       ]);
     });
   });

--- a/content/webapp/services/wellcome/catalogue/filters.ts
+++ b/content/webapp/services/wellcome/catalogue/filters.ts
@@ -103,8 +103,8 @@ function filterOptionsWithNonAggregates({
   );
 
   return allOptions
-    .sort(optionOrder)
-    .filter(option => showEmptyBuckets || option.count || option.selected);
+    .filter(option => showEmptyBuckets || option.count || option.selected)
+    .sort(optionOrder);
 }
 /**
  * Sorting definition for FilterOptions.
@@ -120,10 +120,7 @@ function filterOptionsWithNonAggregates({
  */
 function optionOrder(lhs: FilterOption, rhs: FilterOption): number {
   const countDiff = (rhs.count || Infinity) - (lhs.count || Infinity);
-  const diff =
-    countDiff === 0 || (!lhs.count && !rhs.count)
-      ? lhs.label.localeCompare(rhs.label)
-      : countDiff;
+  const diff = countDiff || lhs.label.localeCompare(rhs.label);
   return diff;
 }
 

--- a/content/webapp/services/wellcome/catalogue/filters.ts
+++ b/content/webapp/services/wellcome/catalogue/filters.ts
@@ -102,10 +102,16 @@ function filterOptionsWithNonAggregates({
       label,
       selected: true,
     }));
-
-  return nonAggregateOptions
-    .concat(options)
+  
+  return distinctByLabel(nonAggregateOptions
+    .concat(options))
     .filter(option => showEmptyBuckets || option.count || option.selected);
+}
+
+function distinctByLabel(options: FilterOption[]): FilterOption[] {
+  return options.filter(
+    (thisInstance, i, arr) => arr.findIndex(firstInstance => firstInstance.label == thisInstance.label) === i
+  )
 }
 
 /** Creates the label for a filter in the GUI.

--- a/content/webapp/services/wellcome/catalogue/filters.ts
+++ b/content/webapp/services/wellcome/catalogue/filters.ts
@@ -112,47 +112,17 @@ function filterOptionsWithNonAggregates({
       }
   );
 
-  allOptions.sort((lhs, rhs) => {
-    const countDiff = (rhs.count || -1) - (lhs.count || -1);
-    const diff =
-      countDiff === 0 ? lhs.label.localeCompare(rhs.label) : countDiff;
-    return diff;
-  });
-
-  return allOptions.filter(
-    option => showEmptyBuckets || option.count || option.selected
-  );
-
-  // const nonAggregateOptions: FilterOption[] = selectedValues
-  //   .map(value =>
-  //     isString(value)
-  //       ? {
-  //           id: value,
-  //           label: value,
-  //         }
-  //       : value
-  //   )
-  //   .filter(({ value }) => !aggregationValues.includes(value))
-  //   .map(({ label, value }) => ({
-  //     id: toHtmlId(value),
-  //     value,
-  //     label,
-  //     selected: true,
-  //   }));
-
-  // return distinctByLabel(nonAggregateOptions.concat(options)).filter(
-  //   option => showEmptyBuckets || option.count || option.selected
-  // );
+  return allOptions
+    .sort((lhs, rhs) => {
+      const countDiff = (rhs.count || Infinity) - (lhs.count || Infinity);
+      const diff =
+        countDiff === 0 || (!lhs.count && !rhs.count)
+          ? lhs.label.localeCompare(rhs.label)
+          : countDiff;
+      return diff;
+    })
+    .filter(option => showEmptyBuckets || option.count || option.selected);
 }
-
-// function distinctByLabel(options: FilterOption[]): FilterOption[] {
-//   return options.filter(
-//     (thisInstance, i, arr) =>
-//       arr.findIndex(
-//         firstInstance => firstInstance.label == thisInstance.label
-//       ) === i
-//   );
-// }
 
 /** Creates the label for a filter in the GUI.
  *


### PR DESCRIPTION
## Who is this for?

Me

## What is it doing for them?

https://github.com/wellcomecollection/wellcomecollection.org/issues/10350

This fixes one of the problems caused by the fact that Aggregations use unique ids, but filters use labels, exemplified here: https://wellcomecollection.org/search/works?query=glasgow&contributors.agent.label=%22University+of+Glasgow.+Library%22

Because multiple entries with the same label exist in the dropdown, it gets selected twice.  It might also fix other problems mentioned [here](https://wellcome.slack.com/archives/C3TQSF63C/p1698424449041649)

Until now, the ordering of filter options has come directly from the API, this is no longer sufficient, given the merging of counts that happens here.  It also led to [a slightly odd sorting behaviour WRT absent selected options](https://wellcome.slack.com/archives/C3TQSF63C/p1698923989854749?thread_ts=1698923914.976269&cid=C3TQSF63C), which is now fixed