### PR TITLE
Refactor `search-works` test file

### DIFF
--- a/common/views/components/CookieNotice/CookieNotice.tsx
+++ b/common/views/components/CookieNotice/CookieNotice.tsx
@@ -73,7 +73,7 @@ const CookieNotice: FunctionComponent<Props> = () => {
   }, []);
 
   return shouldRender ? (
-    <CookieNoticeStyle data-test-id="cookie-notice">
+    <CookieNoticeStyle>
       <Layout12>
         <CookieNoticeWrapper>
           <CookieMessage>

--- a/common/views/components/StackingTable/StackingTable.tsx
+++ b/common/views/components/StackingTable/StackingTable.tsx
@@ -39,13 +39,9 @@ const StyledTable = styled.table.attrs({
   }
 `;
 
-type TrProps = {
-  plain?: boolean;
-};
-
 const StyledTr = styled(Space).attrs({
   as: 'tr',
-})<TrProps>`
+})`
   border-bottom: 1px solid ${props => props.theme.color('warmNeutral.400')};
 
   &:last-of-type {
@@ -153,7 +149,7 @@ const StackingTable: FunctionComponent<Props> = ({
       </thead>
       <tbody>
         {bodyRows.map((row, index) => (
-          <StyledTr plain={plain} key={index}>
+          <StyledTr key={index}>
             {row.map((data, index) => {
               return (
                 <StyledTd

--- a/content/webapp/components/FeaturedCard/FeaturedCard.tsx
+++ b/content/webapp/components/FeaturedCard/FeaturedCard.tsx
@@ -152,7 +152,7 @@ const FeaturedCardExhibitionBody = ({
   exhibition,
 }: FeaturedCardExhibitionBodyProps) => {
   return (
-    <div data-test-id="featured-exhibition">
+    <div>
       <h3 className={font('wb', 2)}>{exhibition.title}</h3>
       {!exhibition.statusOverride && exhibition.start && exhibition.end && (
         <DateWrapper as="p">

--- a/content/webapp/components/LibraryMembersBar/LibraryMembersBar.tsx
+++ b/content/webapp/components/LibraryMembersBar/LibraryMembersBar.tsx
@@ -86,7 +86,7 @@ const LibraryMembersBar: FunctionComponent = () => {
         >
           Library members:
         </Space>
-        <span data-test-id="requestingDisabled" className={font('intr', 5)}>
+        <span data-test-id="requesting-disabled" className={font('intr', 5)}>
           {requestingDisabled}
         </span>
       </StyledComponent>

--- a/content/webapp/components/Map/Map.tsx
+++ b/content/webapp/components/Map/Map.tsx
@@ -80,7 +80,7 @@ const Map: FunctionComponent<Props> = ({
     };
   }, []);
 
-  return <MapContainer data-test-id="map-container" ref={mapContainer} />;
+  return <MapContainer ref={mapContainer} />;
 };
 
 export default Map;

--- a/content/webapp/components/WorksSearchResults/WorksSearchResults.tsx
+++ b/content/webapp/components/WorksSearchResults/WorksSearchResults.tsx
@@ -33,9 +33,9 @@ const SearchResultListItem = styled.li`
 
 const WorksSearchResults: FunctionComponent<Props> = ({ works }) => {
   return (
-    <SearchResultUnorderedList data-test-id="works-search-results-container">
+    <SearchResultUnorderedList>
       {works.map((result, i) => (
-        <SearchResultListItem data-test-id="work-search-result" key={result.id}>
+        <SearchResultListItem data-testId="work-search-result" key={result.id}>
           <WorksSearchResult work={result} resultPosition={i} />
         </SearchResultListItem>
       ))}

--- a/content/webapp/components/WorksSearchResults/WorksSearchResults.tsx
+++ b/content/webapp/components/WorksSearchResults/WorksSearchResults.tsx
@@ -35,7 +35,7 @@ const WorksSearchResults: FunctionComponent<Props> = ({ works }) => {
   return (
     <SearchResultUnorderedList>
       {works.map((result, i) => (
-        <SearchResultListItem data-testId="work-search-result" key={result.id}>
+        <SearchResultListItem data-testid="work-search-result" key={result.id}>
           <WorksSearchResult work={result} resultPosition={i} />
         </SearchResultListItem>
       ))}

--- a/content/webapp/pages/whats-on/index.tsx
+++ b/content/webapp/pages/whats-on/index.tsx
@@ -468,9 +468,7 @@ const WhatsOnPage: FunctionComponent<Props> = props => {
                         </Layout12>
                       ) : (
                         <Layout12>
-                          <p data-test-id="no-exhibitions">
-                            There are no current exhibitions
-                          </p>
+                          <p>There are no current exhibitions</p>
                         </Layout12>
                       )}
                     </Space>

--- a/identity/webapp/copy.tsx
+++ b/identity/webapp/copy.tsx
@@ -26,7 +26,7 @@ export const ValidatedSuccessText: FunctionComponent<
     <SectionHeading as="h1">Email verified</SectionHeading>
     <p>Thank you for verifying your email address.</p>
     {isNewSignUp && (
-      <div data-test-id="new-sign-up">
+      <div data-testid="new-sign-up">
         <p>
           You can now request up to 15 items from our closed stores in the
           library.

--- a/identity/webapp/src/frontend/jest-setup.ts
+++ b/identity/webapp/src/frontend/jest-setup.ts
@@ -1,12 +1,9 @@
 import '@testing-library/jest-dom';
 import 'whatwg-fetch'; // This is polyfilled by Next.js in the actual application
-import { configure } from '@testing-library/react';
 import { server } from './mocks/server';
 import { TextEncoder, TextDecoder } from 'util';
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder;
-
-configure({ testIdAttribute: 'data-test-id' });
 
 // Establish API mocking before all tests.
 beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));

--- a/playwright/test/actions/search.ts
+++ b/playwright/test/actions/search.ts
@@ -1,15 +1,7 @@
 import { imagesResultsListItem, searchImagesForm } from '../selectors/images';
-import {
-  formatFilterDropDown,
-  formatFilterDropDownButton,
-  formatFilterMobileButton,
-  mobileModal,
-  mobileModalCloseButton,
-  worksSearchImagesInputField,
-} from '../selectors/search';
+import { worksSearchImagesInputField } from '../selectors/search';
 import { fillInputAction } from './common';
 import { Page } from 'playwright';
-import { isMobile } from '../contexts';
 
 // Fill actions
 export const fillActionSearchInput = async (
@@ -18,43 +10,6 @@ export const fillActionSearchInput = async (
 ): Promise<void> => {
   const selector = `${searchImagesForm} ${worksSearchImagesInputField}`;
   await fillInputAction(selector, value, page);
-};
-
-// Press actions
-export const pressActionEnterSearchInput = async (
-  page: Page
-): Promise<void> => {
-  const selector = `${searchImagesForm} ${worksSearchImagesInputField}`;
-  await page.press(selector, 'Enter');
-};
-
-// Click actions
-export const clickActionFormatDropDown = async (page: Page): Promise<void> => {
-  await page.click(formatFilterDropDownButton);
-};
-
-export const clickActionFormatRadioCheckbox = async (
-  filterName: string,
-  page: Page
-): Promise<void> => {
-  const selector = `${
-    isMobile(page) ? mobileModal : formatFilterDropDown
-  } label[aria-label="Radio checkbox ${filterName}"]`;
-  await page.click(selector);
-};
-
-export const clickActionModalFilterButton = async (
-  page: Page
-): Promise<void> => {
-  const selector = `${searchImagesForm} ${formatFilterMobileButton}`;
-  await page.click(selector);
-};
-
-export const clickActionCloseModalFilterButton = async (
-  page: Page
-): Promise<void> => {
-  const selector = `${searchImagesForm} ${mobileModalCloseButton}`;
-  await page.click(selector);
 };
 
 export const clickActionClickSearchResultItem = async (

--- a/playwright/test/helpers/search.ts
+++ b/playwright/test/helpers/search.ts
@@ -5,12 +5,15 @@ import { formatFilterMobileButton } from '../selectors/search';
 
 export const worksSearchForm = '#search-searchbar';
 
-export const searchFor = async (query: string, page: Page): Promise<void> => {
+export const searchQueryAndSubmit = async (
+  query: string,
+  page: Page
+): Promise<void> => {
   await page.fill(worksSearchForm, query);
   await page.press(worksSearchForm, 'Enter');
 };
 
-export const openDropdown = async (id: string, page: Page) => {
+export const openFilterDropdown = async (id: string, page: Page) => {
   if (isMobile(page)) {
     await page.click(formatFilterMobileButton);
   } else {
@@ -18,12 +21,12 @@ export const openDropdown = async (id: string, page: Page) => {
   }
 };
 
-export const selectFilter = async (
+export const selectFilterAndWaitForApplied = async (
   filterId: string,
   checkboxId: string,
   page: Page
 ) => {
-  await openDropdown(filterId, page);
+  await openFilterDropdown(filterId, page);
 
   const checkbox = page.locator(
     `input[form="search-page-form"][name="${filterId}"][value="${checkboxId}"]`
@@ -38,15 +41,25 @@ export const selectFilter = async (
   }
 };
 
-export const navigateToNextPage = async (page: Page) => {
+export const navigateToNextPageAndConfirmNavigation = async (page: Page) => {
+  const currentPage = await page
+    .getByTestId('pagination')
+    .locator('input[name="page"]')
+    .inputValue();
   const nextButton = page
     .locator('[data-testid="pagination"]')
     .getByRole('link', { name: 'Next' });
 
   await nextButton.click();
+  await expect(
+    page.getByTestId('pagination').locator('input[name="page"]')
+  ).toHaveValue(String(Number(currentPage) + 1));
 };
 
-export const navigateToResult = async (n = 1, page: Page) => {
+export const navigateToResultAndConfirmTitleMatches = async (
+  n = 1,
+  page: Page
+) => {
   const result = `main ul li:nth-of-type(${n}) a`;
   const searchResultTitle = await page.textContent(`${result} h3`);
   await page.click(result);

--- a/playwright/test/helpers/search.ts
+++ b/playwright/test/helpers/search.ts
@@ -1,61 +1,13 @@
 import { Page } from 'playwright';
-import { URL, URLSearchParams } from 'url';
 import { expect } from '@playwright/test';
 import { isMobile } from '../contexts';
-import safeWaitForNavigation from './safeWaitForNavigation';
 import { formatFilterMobileButton } from '../selectors/search';
 
 export const worksSearchForm = '#search-searchbar';
 
-const removeCachebustParameter = (url: string) => {
-  const urlObj = new URL(url);
-  urlObj.searchParams.delete('cachebust');
-  return urlObj.href;
-};
-
 export const searchFor = async (query: string, page: Page): Promise<void> => {
   await page.fill(worksSearchForm, query);
-  await Promise.all([
-    page.press(worksSearchForm, 'Enter'),
-    page.waitForURL(`${removeCachebustParameter(page.url())}?query=${query}`),
-  ]);
-};
-
-export const expectSearchParam = (
-  expectedKey: string,
-  expectedVal: string | undefined,
-  page: Page
-) => {
-  const params = new URLSearchParams(page.url());
-  console.log({ params });
-  if (expectedVal) {
-    const foundMatchingParam = Array.from(params).find(([key, val], i) => {
-      if (i === 0) {
-        // The first key returns the whole URL.
-        // This is fine if it has "cachebust" which we ignored,
-        // but if the first value is a valid filter, it never matches.
-        return (
-          key.slice(key.indexOf('?') + 1) === expectedKey && val === expectedVal
-        );
-      } else {
-        return key === expectedKey && val === expectedVal;
-      }
-    });
-
-    if (!foundMatchingParam) {
-      console.info('No matching params for', page.url(), {
-        expectedKey,
-        expectedVal,
-      });
-    }
-    expect(foundMatchingParam).toBeTruthy();
-  } else {
-    const noMatchProps = !Array.from(params).find(
-      ([key]) => key === expectedKey
-    );
-
-    expect(noMatchProps).toBeTruthy();
-  }
+  await page.press(worksSearchForm, 'Enter');
 };
 
 export const openDropdown = async (id: string, page: Page) => {
@@ -77,14 +29,9 @@ export const selectFilter = async (
     `input[form="search-page-form"][name="${filterId}"][value="${checkboxId}"]`
   );
 
-  // Click checkbox
-  // Wait for Checkbox to be checked, this happens once the page has loaded
-  await Promise.all([
-    checkbox.click(),
-    page.waitForURL(url => url.search.indexOf(filterId) > 0, {
-      waitUntil: 'domcontentloaded',
-    }),
-  ]);
+  await checkbox.click();
+
+  await expect(checkbox).toBeChecked();
 
   if (isMobile(page)) {
     await page.click(`"Show results"`);
@@ -92,43 +39,19 @@ export const selectFilter = async (
 };
 
 export const navigateToNextPage = async (page: Page) => {
-  // data-testid is only set on Pagination components that aren't hidden on mobile
-  // in `common/views/components/Pagination/Pagination.tsx`
   const nextButton = page
     .locator('[data-testid="pagination"]')
     .getByRole('link', { name: 'Next' });
 
-  const currentPage = Number(new URL(page.url()).searchParams.get('page') || 1);
-
-  await Promise.all([
-    nextButton.click(),
-    page.waitForURL(
-      url => url.search.indexOf(`page=${currentPage + 1}`) > 0
-      //  {
-      //   waitUntil: 'domcontentloaded',
-      // }
-    ),
-  ]);
+  await nextButton.click();
 };
 
 export const navigateToResult = async (n = 1, page: Page) => {
   const result = `main ul li:nth-of-type(${n}) a`;
-  await page.waitForTimeout(1000);
   const searchResultTitle = await page.textContent(`${result} h3`);
+  await page.click(result);
 
-  // For reasons I don't really understand, the safeWaitForNavigation will timeout…
-  // but only in the mobile tests.
-  //
-  // Since that helper is only a test convenience and isn't testing the behaviour of
-  // the site, I haven't investigated further -- this seems to make the tests happy.
-  if (isMobile(page)) {
-    await page.click(result);
-    await safeWaitForNavigation(page);
-  } else {
-    await Promise.all([safeWaitForNavigation(page), page.click(result)]);
-  }
-
-  await page.waitForTimeout(1000);
-  const title = await page.textContent('h1');
-  expect(title).toBe(searchResultTitle);
+  const title = await page.locator('h1');
+  await expect(title).toHaveId('work-info');
+  await expect(title).toContainText(String(searchResultTitle)); // searchResultTitle could also be null but I expect it would fail accordingly
 };

--- a/playwright/test/helpers/search.ts
+++ b/playwright/test/helpers/search.ts
@@ -1,0 +1,134 @@
+import { Page } from 'playwright';
+import { URL, URLSearchParams } from 'url';
+import { expect } from '@playwright/test';
+import { isMobile } from '../contexts';
+import safeWaitForNavigation from './safeWaitForNavigation';
+import { formatFilterMobileButton } from '../selectors/search';
+
+export const worksSearchForm = '#search-searchbar';
+
+const removeCachebustParameter = (url: string) => {
+  const urlObj = new URL(url);
+  urlObj.searchParams.delete('cachebust');
+  return urlObj.href;
+};
+
+export const searchFor = async (query: string, page: Page): Promise<void> => {
+  await page.fill(worksSearchForm, query);
+  await Promise.all([
+    page.press(worksSearchForm, 'Enter'),
+    page.waitForURL(`${removeCachebustParameter(page.url())}?query=${query}`),
+  ]);
+};
+
+export const expectSearchParam = (
+  expectedKey: string,
+  expectedVal: string | undefined,
+  page: Page
+) => {
+  const params = new URLSearchParams(page.url());
+  console.log({ params });
+  if (expectedVal) {
+    const foundMatchingParam = Array.from(params).find(([key, val], i) => {
+      if (i === 0) {
+        // The first key returns the whole URL.
+        // This is fine if it has "cachebust" which we ignored,
+        // but if the first value is a valid filter, it never matches.
+        return (
+          key.slice(key.indexOf('?') + 1) === expectedKey && val === expectedVal
+        );
+      } else {
+        return key === expectedKey && val === expectedVal;
+      }
+    });
+
+    if (!foundMatchingParam) {
+      console.info('No matching params for', page.url(), {
+        expectedKey,
+        expectedVal,
+      });
+    }
+    expect(foundMatchingParam).toBeTruthy();
+  } else {
+    const noMatchProps = !Array.from(params).find(
+      ([key]) => key === expectedKey
+    );
+
+    expect(noMatchProps).toBeTruthy();
+  }
+};
+
+export const openDropdown = async (id: string, page: Page) => {
+  if (isMobile(page)) {
+    await page.click(formatFilterMobileButton);
+  } else {
+    await page.click(`button[aria-controls="${id}"]`);
+  }
+};
+
+export const selectFilter = async (
+  filterId: string,
+  checkboxId: string,
+  page: Page
+) => {
+  await openDropdown(filterId, page);
+
+  const checkbox = page.locator(
+    `input[form="search-page-form"][name="${filterId}"][value="${checkboxId}"]`
+  );
+
+  // Click checkbox
+  // Wait for Checkbox to be checked, this happens once the page has loaded
+  await Promise.all([
+    checkbox.click(),
+    page.waitForURL(url => url.search.indexOf(filterId) > 0, {
+      waitUntil: 'domcontentloaded',
+    }),
+  ]);
+
+  if (isMobile(page)) {
+    await page.click(`"Show results"`);
+  }
+};
+
+export const navigateToNextPage = async (page: Page) => {
+  // data-testid is only set on Pagination components that aren't hidden on mobile
+  // in `common/views/components/Pagination/Pagination.tsx`
+  const nextButton = page
+    .locator('[data-testid="pagination"]')
+    .getByRole('link', { name: 'Next' });
+
+  const currentPage = Number(new URL(page.url()).searchParams.get('page') || 1);
+
+  await Promise.all([
+    nextButton.click(),
+    page.waitForURL(
+      url => url.search.indexOf(`page=${currentPage + 1}`) > 0
+      //  {
+      //   waitUntil: 'domcontentloaded',
+      // }
+    ),
+  ]);
+};
+
+export const navigateToResult = async (n = 1, page: Page) => {
+  const result = `main ul li:nth-of-type(${n}) a`;
+  await page.waitForTimeout(1000);
+  const searchResultTitle = await page.textContent(`${result} h3`);
+
+  // For reasons I don't really understand, the safeWaitForNavigation will timeout…
+  // but only in the mobile tests.
+  //
+  // Since that helper is only a test convenience and isn't testing the behaviour of
+  // the site, I haven't investigated further -- this seems to make the tests happy.
+  if (isMobile(page)) {
+    await page.click(result);
+    await safeWaitForNavigation(page);
+  } else {
+    await Promise.all([safeWaitForNavigation(page), page.click(result)]);
+  }
+
+  await page.waitForTimeout(1000);
+  const title = await page.textContent('h1');
+  expect(title).toBe(searchResultTitle);
+};

--- a/playwright/test/helpers/search.ts
+++ b/playwright/test/helpers/search.ts
@@ -67,9 +67,11 @@ export const navigateToResultAndConfirmTitleMatches = async (
 };
 
 // TODO
-// This could probably be better - should we have a different way of spotting if a filter is applied
-// For mobile? Otherwise they are hidden in the modal.
-// Plus "books" could be found multiple times without being the one you want.
+// This could probably be better - We should have a different way of spotting if a filter is applied
+// Especially for mobile where they are hidden in the modal.
+// This isn't solid for multiple reasons such as the fact that "books" could be found multiple times without being the one you want.
+//
+// As we are considering a redesign of filters, this should be considered as part of it
 export const testIfFilterIsApplied = async (label: string, page: Page) => {
   await expect(page.getByRole('status')).toHaveText(
     new RegExp(`.*${label}.*`, 'i')

--- a/playwright/test/helpers/search.ts
+++ b/playwright/test/helpers/search.ts
@@ -68,3 +68,13 @@ export const navigateToResultAndConfirmTitleMatches = async (
   await expect(title).toHaveId('work-info');
   await expect(title).toContainText(String(searchResultTitle)); // searchResultTitle could also be null but I expect it would fail accordingly
 };
+
+// TODO
+// This could probably be better - should we have a different way of spotting if a filter is applied
+// For mobile? Otherwise they are hidden in the modal.
+// Plus "books" could be found multiple times without being the one you want.
+export const testIfFilterIsApplied = async (label: string, page: Page) => {
+  await expect(page.getByRole('status')).toHaveText(
+    new RegExp(`.*${label}.*`, 'i')
+  );
+};

--- a/playwright/test/search-form.test.ts
+++ b/playwright/test/search-form.test.ts
@@ -1,13 +1,13 @@
 import { test, expect } from '@playwright/test';
 import { newWorksSearch } from './contexts';
-import { searchFor, worksSearchForm } from './helpers/search';
+import { searchQueryAndSubmit, worksSearchForm } from './helpers/search';
 
 test('stays focussed on the query input when submitted', async ({
   context,
   page,
 }) => {
   await newWorksSearch(context, page);
-  await searchFor('worms', page);
+  await searchQueryAndSubmit('worms', page);
   await expect(page.locator(worksSearchForm)).toBeFocused();
 });
 

--- a/playwright/test/search-form.test.ts
+++ b/playwright/test/search-form.test.ts
@@ -1,6 +1,8 @@
 import { test, expect } from '@playwright/test';
 import { newWorksSearch } from './contexts';
-import { searchQueryAndSubmit, worksSearchForm } from './helpers/search';
+import { searchQueryAndSubmit } from './helpers/search';
+
+const worksSearchForm = '#search-searchbar';
 
 test('stays focussed on the query input when submitted', async ({
   context,

--- a/playwright/test/search-form.test.ts
+++ b/playwright/test/search-form.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { newWorksSearch } from './contexts';
-import { searchFor, worksSearchForm } from './search-works.test';
+import { searchFor, worksSearchForm } from './helpers/search';
 
 test('stays focussed on the query input when submitted', async ({
   context,

--- a/playwright/test/search-works.test.ts
+++ b/playwright/test/search-works.test.ts
@@ -11,6 +11,7 @@ import {
   openFilterDropdown,
   searchQueryAndSubmit,
   selectFilterAndWaitForApplied,
+  testIfFilterIsApplied,
 } from './helpers/search';
 
 test.describe.configure({ mode: 'parallel' });
@@ -30,8 +31,6 @@ test('(1.2) | The user is looking for an archive; they can get back to their ori
   page,
   context,
 }) => {
-  // Open the search page, search for a term, apply a filter, navigate away from
-  // the first page.
   await newWorksSearch(context, page);
   await searchQueryAndSubmit('Persian', page);
   await selectFilterAndWaitForApplied('workType', 'h', page); // Formats > Archives and manuscripts
@@ -41,41 +40,28 @@ test('(1.2) | The user is looking for an archive; they can get back to their ori
   // https://www-stage.wellcomecollection.org/search/works?query=Persian&workType=h&page=2
   const originalSearchUrl = new URL(page.url());
 
-  // Now go to the third result on the page, and look for "Back to search results".
   await navigateToResultAndConfirmTitleMatches(3, page);
 
-  const backToSearchResults = page.locator(
-    'a:has-text("Back to search results")'
-  );
+  const backToSearchResults = page.getByRole('link', {
+    name: 'Back to search results',
+  });
   await expect(backToSearchResults).toBeVisible();
+  await backToSearchResults.click();
 
-  // Note: we expect the URLs on the "Back to search results" link to be relative,
-  // but the URL class only takes absolute URLs.
-  //
-  // Check this is a relative URL, then construct an absolute URL we can compare.
-  const backToSearchResultsUrlString = (await backToSearchResults?.getAttribute(
-    'href'
-  )) as string;
-  expect(backToSearchResultsUrlString.startsWith('/')).toBe(true);
+  await page.waitForURL(url => {
+    // Now compare the URLs.  Note that the query parameters may be in a different order,
+    // but they're still equivalent for our purposes, e.g.
+    //
+    //      /search/works?query=Persian&workType=h&page=2 and
+    //      /search/works?query=Persian&page=2&workType=h
+    //
+    // are both totally fine.  Sorting them first makes them easier to compare.
 
-  const backToSearchResultsUrl = new URL(
-    `${process.env.PLAYWRIGHT_BASE_URL}${backToSearchResultsUrlString}`
-  );
-  // Now compare the URLs.  Note that the query parameters may be in a different order,
-  // but they're still equivalent for our purposes, e.g.
-  //
-  //      /search/works?query=Persian&workType=h&page=2 and
-  //      /search/works?query=Persian&page=2&workType=h
-  //
-  // are both totally fine.  Sorting them first makes them easier to compare.
-  expect(originalSearchUrl.pathname).toEqual(backToSearchResultsUrl.pathname);
-
-  originalSearchUrl.searchParams.sort();
-  backToSearchResultsUrl.searchParams.sort();
-
-  expect(originalSearchUrl.searchParams).toEqual(
-    backToSearchResultsUrl.searchParams
-  );
+    expect(originalSearchUrl.searchParams.sort()).toEqual(
+      url.searchParams.sort()
+    );
+    return true; // Won't get here if the expect above fails
+  });
 });
 
 test('(2) | The user is searching for a work on open shelves; it should be browsable from the search results', async ({
@@ -87,8 +73,7 @@ test('(2) | The user is searching for a work on open shelves; it should be brows
   await selectFilterAndWaitForApplied('availabilities', 'open-shelves', page); // Locations > Open shelves
   await navigateToNextPageAndConfirmNavigation(page);
 
-  const searchParams = new URLSearchParams(new URL(page.url()).search);
-  expect(searchParams.get('availabilities')).toEqual('open-shelves');
+  await testIfFilterIsApplied('Open shelves', page);
 
   await navigateToResultAndConfirmTitleMatches(6, page);
 });
@@ -102,8 +87,7 @@ test('(3) | The user is searching for a work that is available online; it should
   await selectFilterAndWaitForApplied('availabilities', 'online', page); // Locations > Online
   await navigateToNextPageAndConfirmNavigation(page);
 
-  const searchParams = new URLSearchParams(new URL(page.url()).search);
-  expect(searchParams.get('availabilities')).toEqual('online');
+  await testIfFilterIsApplied('Online', page);
 
   await navigateToResultAndConfirmTitleMatches(8, page);
 });
@@ -114,11 +98,10 @@ test('(4) | The user is searching for a work from Wellcome Images; it should be 
 }) => {
   await newWorksSearch(context, page);
   await searchQueryAndSubmit('skeleton', page);
-  await selectFilterAndWaitForApplied('workType', 'q', page); // Formats > Digital images
+  await selectFilterAndWaitForApplied('workType', 'q', page); // Formats > Digital Images
   await navigateToNextPageAndConfirmNavigation(page);
 
-  const searchParams = new URLSearchParams(new URL(page.url()).search);
-  expect(searchParams.get('workType')).toEqual('q');
+  await testIfFilterIsApplied('Digital Images', page);
 
   await navigateToResultAndConfirmTitleMatches(1, page);
 });
@@ -132,8 +115,7 @@ test('(5) | The user is searching for a work in closed stores; it should be brow
   await selectFilterAndWaitForApplied('availabilities', 'closed-stores', page); // Locations > Closed stores
   await navigateToNextPageAndConfirmNavigation(page);
 
-  const searchParams = new URLSearchParams(new URL(page.url()).search);
-  expect(searchParams.get('availabilities')).toEqual('closed-stores');
+  await testIfFilterIsApplied('Closed stores', page);
 
   await navigateToResultAndConfirmTitleMatches(6, page);
 });
@@ -146,27 +128,20 @@ test('(6) | The user is searching for works from a particular year; it should be
   await searchQueryAndSubmit('brain', page);
   await openFilterDropdown('production.dates', page);
 
-  const datesFrom = page.locator(
-    'input[form="search-page-form"][name="production.dates.from"]'
-  );
-  await datesFrom.fill('1939');
+  await page
+    .locator('input[form="search-page-form"][name="production.dates.from"]')
+    .fill('1939');
 
-  const datesTo = page.locator(
-    'input[form="search-page-form"][name="production.dates.to"]'
-  );
-  await datesTo.fill('2001');
+  await page
+    .locator('input[form="search-page-form"][name="production.dates.to"]')
+    .fill('2001');
 
   if (isMobile(page)) {
     await page.click(`"Show results"`);
-    await expect(page.getByRole('button', { name: 'Filters 1' })).toBeVisible();
-  } else {
-    await expect(
-      page.getByRole('link', { name: 'remove From 1939' })
-    ).toBeVisible();
-    await expect(
-      page.getByRole('link', { name: 'remove To 2001' })
-    ).toBeVisible();
   }
+
+  await testIfFilterIsApplied('From 1939', page);
+  await testIfFilterIsApplied('To 2001', page);
 
   // This is a check that we have actually loaded some results from
   // the API, and the API hasn't just errored out.
@@ -180,17 +155,14 @@ test('(7) | The user is sorting by production dates in search; sort updates URL 
   await newWorksSearch(context, page);
 
   const select = page.locator('select[name="sortOrder"]');
-  await select.selectOption({ index: 2 });
 
-  await expect(page).toHaveURL(/sortOrder=desc/);
-  await expect(page).toHaveURL(/sort=production\.dates/);
+  await select.selectOption({ index: 2 });
+  await expect(select).toHaveValue('production.dates.desc');
 
   await navigateToNextPageAndConfirmNavigation(page);
 
   await select.selectOption({ index: 1 });
-
-  await expect(page).toHaveURL(/sortOrder=asc/);
-  await expect(page).toHaveURL(/sort=production\.dates/);
+  await expect(select).toHaveValue('production.dates.asc');
   await expect(
     page.getByTestId('pagination').locator('input[name="page"]')
   ).toHaveValue('1');
@@ -207,10 +179,10 @@ test('(8) | The user is coming from a prefiltered series search; they should be 
     'search-page-form'
   );
 
-  await expect(page).toHaveURL(/partOf\.title=Medical\+Heritage\+LIbrary/);
+  await testIfFilterIsApplied('Medical Heritage LIbrary', page);
 
   await selectFilterAndWaitForApplied('workType', 'a', page); // Formats > Books
 
-  await expect(page).toHaveURL(/partOf\.title=Medical\+Heritage\+LIbrary/);
-  await expect(page).toHaveURL(/workType=a/);
+  await testIfFilterIsApplied('Medical Heritage LIbrary', page);
+  await testIfFilterIsApplied('Books', page);
 });

--- a/playwright/test/search-works.test.ts
+++ b/playwright/test/search-works.test.ts
@@ -220,6 +220,7 @@ test('(6) | The user is searching for works from a particular year; it should be
 
   if (isMobile(page)) {
     await page.click(`"Show results"`);
+    await expect(page.getByRole('button', { name: 'Filters 1' })).toBeVisible();
   } else {
     await expect(
       page.getByRole('link', { name: 'remove From 1939' })

--- a/playwright/test/search-works.test.ts
+++ b/playwright/test/search-works.test.ts
@@ -1,5 +1,4 @@
-import { Page } from 'playwright';
-import { URL, URLSearchParams } from 'url';
+import { URL } from 'url';
 import { test, expect } from '@playwright/test';
 import {
   isMobile,
@@ -7,330 +6,231 @@ import {
   workWithDigitalLocationAndLocationNote,
 } from './contexts';
 import safeWaitForNavigation from './helpers/safeWaitForNavigation';
-import { formatFilterMobileButton } from './selectors/search';
+import {
+  expectSearchParam,
+  navigateToNextPage,
+  navigateToResult,
+  openDropdown,
+  searchFor,
+  selectFilter,
+} from './helpers/search';
 
-export const worksSearchForm = '#search-searchbar';
-export const searchFor = async (query: string, page: Page): Promise<void> => {
-  console.info('searchFor', query);
-  await page.fill(worksSearchForm, query);
+test.describe.configure({ mode: 'parallel' });
+
+test('(1.1) | The user is looking for an archive; it should be browsable from the search results', async ({
+  page,
+  context,
+}) => {
+  await newWorksSearch(context, page);
+  await searchFor('Persian', page);
+  await selectFilter('workType', 'h', page); // Formats > Archives and manuscripts
+  await navigateToNextPage(page);
+
+  expectSearchParam('workType', 'h', page);
+
+  await navigateToResult(3, page);
+});
+
+test('(1.2) | The user is looking for an archive; they can get back to their original search results', async ({
+  page,
+  context,
+}) => {
+  // Open the search page, search for a term, apply a filter, navigate away from
+  // the first page.
+  await newWorksSearch(context, page);
+  await searchFor('Persian', page);
+  await selectFilter('workType', 'h', page); // Formats > Archives and manuscripts
+  await navigateToNextPage(page);
+
+  // Save the URL of the current search page, which will be something like
+  // https://www-stage.wellcomecollection.org/search/works?query=Persian&workType=h&page=2
+  const originalSearchUrl = new URL(page.url());
+
+  // Now go to the third result on the page, and look for "Back to search results".
+  await navigateToResult(3, page);
+
+  const backToSearchResults = await page.$(
+    'a:has-text("Back to search results")'
+  );
+  expect(backToSearchResults).toBeTruthy();
+
+  // Note: we expect the URLs on the "Back to search results" link to be relative,
+  // but the URL class only takes absolute URLs.
+  //
+  // Check this is a relative URL, then construct an absolute URL we can compare.
+  const backToSearchResultsUrlString = (await backToSearchResults?.getAttribute(
+    'href'
+  )) as string;
+  expect(backToSearchResultsUrlString.startsWith('/')).toBe(true);
+
+  const backToSearchResultsUrl = new URL(
+    `${process.env.PLAYWRIGHT_BASE_URL}${backToSearchResultsUrlString}`
+  );
+  // Now compare the URLs.  Note that the query parameters may be in a different order,
+  // but they're still equivalent for our purposes, e.g.
+  //
+  //      /search/works?query=Persian&workType=h&page=2 and
+  //      /search/works?query=Persian&page=2&workType=h
+  //
+  // are both totally fine.  Sorting them first makes them easier to compare.
+  expect(originalSearchUrl.pathname).toEqual(backToSearchResultsUrl.pathname);
+
+  originalSearchUrl.searchParams.sort();
+  backToSearchResultsUrl.searchParams.sort();
+
+  expect(originalSearchUrl.searchParams).toEqual(
+    backToSearchResultsUrl.searchParams
+  );
+});
+
+test('(2) | The user is searching for a work on open shelves; it should be browsable from the search results', async ({
+  page,
+  context,
+}) => {
+  await newWorksSearch(context, page);
+  await searchFor('eyes', page);
+  await selectFilter('availabilities', 'open-shelves', page); // Locations > Open shelves
+  await navigateToNextPage(page);
+
+  expectSearchParam('availabilities', 'open-shelves', page);
+
+  await navigateToResult(6, page);
+});
+
+test('(3) | The user is searching for a work that is available online; it should be browsable from the search results', async ({
+  page,
+  context,
+}) => {
+  await newWorksSearch(context, page);
+  await searchFor('skin', page);
+  await selectFilter('availabilities', 'online', page); // Locations > Online
+  await navigateToNextPage(page);
+
+  expectSearchParam('availabilities', 'online', page);
+
+  await navigateToResult(8, page);
+});
+
+test('(4) | The user is searching for a work from Wellcome Images; it should be browsable from the search results', async ({
+  page,
+  context,
+}) => {
+  await newWorksSearch(context, page);
+  await searchFor('skeleton', page);
+  await selectFilter('workType', 'q', page); // Formats > Digital images
+  await navigateToNextPage(page);
+
+  expectSearchParam('workType', 'q', page);
+
+  await navigateToResult(1, page);
+});
+
+test('(5) | The user is searching for a work in closed stores; it should be browsable from the search results', async ({
+  page,
+  context,
+}) => {
+  await newWorksSearch(context, page);
+  await searchFor('brain', page);
+  await selectFilter('availabilities', 'closed-stores', page); // Locations > Closed stores
+  await navigateToNextPage(page);
+
+  expectSearchParam('availabilities', 'closed-stores', page);
+
+  await navigateToResult(6, page);
+});
+
+test('(6) | The user is searching for works from a particular year; it should be browsable from the search results', async ({
+  page,
+  context,
+}) => {
+  await newWorksSearch(context, page);
+  await searchFor('brain', page);
+  await openDropdown('production.dates', page);
+
+  // Note: if you put both `page.locator(…).fill(…)` commands in a
+  // single Promise.all(), they can interfere in such a way that only
+  // one of them ends up in the final URL. :-/
+
   await Promise.all([
-    page.press(worksSearchForm, 'Enter'),
     safeWaitForNavigation(page),
+    page
+      .locator('input[form="search-page-form"][name="production.dates.from"]')
+      .fill('1939'),
   ]);
-};
 
-const expectSearchParam = (
-  expectedKey: string,
-  expectedVal: string | undefined,
-  page: Page
-) => {
-  console.info('expectSearchParam', { expectedKey, expectedVal });
-  const params = new URLSearchParams(page.url());
-
-  if (expectedVal) {
-    const foundMatchingParam = Array.from(params).find(([key, val], i) => {
-      if (i === 0) {
-        // The first key returns the whole URL.
-        // This is fine if it has "cachebust" which we ignored,
-        // but if the first value is a valid filter, it never matches.
-        return (
-          key.slice(key.indexOf('?') + 1) === expectedKey && val === expectedVal
-        );
-      } else {
-        return key === expectedKey && val === expectedVal;
-      }
-    });
-
-    if (!foundMatchingParam) {
-      console.log(page.url());
-    }
-
-    expect(foundMatchingParam).toBeTruthy();
-  } else {
-    const noMatchProps = !Array.from(params).find(
-      ([key]) => key === expectedKey
-    );
-
-    expect(noMatchProps).toBeTruthy();
-  }
-};
-
-const openDropdown = async (label: string, page: Page) => {
-  console.info('openDropdown', label);
-  if (isMobile(page)) {
-    await page.click(formatFilterMobileButton);
-  } else {
-    await page.click(`button :text("${label}")`);
-  }
-};
-
-const selectCheckbox = async (label: string, page: Page) => {
-  console.info('selectCheckbox', label);
   await Promise.all([
     safeWaitForNavigation(page),
-    page.click(`label :text("${label}")`),
+    page
+      .locator('input[form="search-page-form"][name="production.dates.to"]')
+      .fill('2001'),
   ]);
-  await page.waitForTimeout(1000);
 
   if (isMobile(page)) {
     await page.click(`"Show results"`);
   }
-};
 
-const navigateToNextPage = async (page: Page) => {
-  // data-testid is only set on Pagination components that aren't hidden on mobile
-  // in `common/views/components/Pagination/Pagination.tsx`
-  await page.waitForTimeout(2000);
+  expectSearchParam('production.dates.from', '1939', page);
+  expectSearchParam('production.dates.to', '2001', page);
+
+  // This is a check that we have actually loaded some results from
+  // the API, and the API hasn't just errored out.
+  await navigateToResult(6, page);
+});
+
+test.only('(7) | The user is sorting by production dates in search; sort updates URL query and goes back to the first page', async ({
+  context,
+  page,
+}) => {
+  await newWorksSearch(context, page);
+
+  const select = page.locator('select[name="sortOrder"]');
+  await select.waitFor();
 
   await Promise.all([
-    safeWaitForNavigation(page),
-    page.click('[data-testid="pagination"] a'),
+    select.selectOption({ index: 2 }),
+    page.waitForURL(
+      url =>
+        url.search.indexOf('sortOrder=desc') > 0 &&
+        url.search.indexOf('sort=production.dates') > 0
+    ),
   ]);
-};
 
-const navigateToResult = async (n = 1, page: Page) => {
-  const result = `main ul li:nth-of-type(${n}) a`;
-  await page.waitForTimeout(1000);
-  const searchResultTitle = await page.textContent(`${result} h3`);
+  await navigateToNextPage(page);
 
-  // For reasons I don't really understand, the safeWaitForNavigation will timeout…
-  // but only in the mobile tests.
-  //
-  // Since that helper is only a test convenience and isn't testing the behaviour of
-  // the site, I haven't investigated further -- this seems to make the tests happy.
-  if (isMobile(page)) {
-    await page.click(result);
-    await safeWaitForNavigation(page);
-  } else {
-    await Promise.all([safeWaitForNavigation(page), page.click(result)]);
-  }
+  expectSearchParam('sortOrder', 'desc', page);
+  expectSearchParam('sort', 'production.dates', page);
+  expectSearchParam('page', '2', page);
 
-  await page.waitForTimeout(1000);
-  const title = await page.textContent('h1');
-  expect(title).toBe(searchResultTitle);
-};
-
-test.describe.configure({ mode: 'parallel' });
-
-test.describe('Scenario 1: The person is looking for an archive', () => {
-  test('the work should be browsable to from the search results', async ({
-    page,
-    context,
-  }) => {
-    await newWorksSearch(context, page);
-    await searchFor('Persian', page);
-    await openDropdown('Formats', page);
-    await selectCheckbox('Archives and manuscripts', page);
-    await navigateToNextPage(page);
-
-    expectSearchParam('workType', 'h', page);
-
-    await navigateToResult(3, page);
-  });
-
-  test('and the user can get back to their original search results', async ({
-    page,
-    context,
-  }) => {
-    // Open the search page, search for a term, apply a filter, navigate away from
-    // the first page.
-    await newWorksSearch(context, page);
-    await searchFor('Persian', page);
-    await openDropdown('Formats', page);
-    await selectCheckbox('Archives and manuscripts', page);
-    await navigateToNextPage(page);
-
-    // Save the URL of the current search page, which will be something like
-    // https://www-stage.wellcomecollection.org/search/works?query=Persian&workType=h&page=2
-    const originalSearchUrl = new URL(page.url());
-
-    // Now go to the third result on the page, and look for "Back to search results".
-    await navigateToResult(3, page);
-
-    const backToSearchResults = await page.$(
-      'a:has-text("Back to search results")'
-    );
-    expect(backToSearchResults).toBeTruthy();
-
-    // Note: we expect the URLs on the "Back to search results" link to be relative,
-    // but the URL class only takes absolute URLs.
-    //
-    // Check this is a relative URL, then construct an absolute URL we can compare.
-    const backToSearchResultsUrlString =
-      (await backToSearchResults?.getAttribute('href')) as string;
-    expect(backToSearchResultsUrlString.startsWith('/')).toBe(true);
-
-    const backToSearchResultsUrl = new URL(
-      `${process.env.PLAYWRIGHT_BASE_URL}${backToSearchResultsUrlString}`
-    );
-
-    // Now compare the URLs.  Note that the query parameters may be in a different order,
-    // but they're still equivalent for our purposes, e.g.
-    //
-    //      /search/works?query=Persian&workType=h&page=2 and
-    //      /search/works?query=Persian&page=2&workType=h
-    //
-    // are both totally fine.  Sorting them first makes them easier to compare.
-    expect(originalSearchUrl.pathname).toEqual(backToSearchResultsUrl.pathname);
-
-    originalSearchUrl.searchParams.sort();
-    backToSearchResultsUrl.searchParams.sort();
-
-    expect(originalSearchUrl.searchParams).toEqual(
-      backToSearchResultsUrl.searchParams
-    );
-  });
+  await Promise.all([
+    select.selectOption({ index: 1 }),
+    page.waitForURL(
+      url => {
+        return (
+          url.search.indexOf('sortOrder=asc') > 0 &&
+          url.search.indexOf('sort=production.dates') > 0 &&
+          url.search.indexOf('page') === -1
+        );
+      },
+      {
+        waitUntil: 'domcontentloaded',
+      }
+    ),
+  ]);
 });
 
-test.describe('Scenario 2: The person is searching for a work on open shelves', () => {
-  test('the work should be browsable to from the search results', async ({
-    page,
-    context,
-  }) => {
-    await newWorksSearch(context, page);
-    await searchFor('eyes', page);
-    await openDropdown('Locations', page);
-    await selectCheckbox('Open shelves', page);
-    await navigateToNextPage(page);
+test('(8) | The user is coming from a prefiltered series search; they should be able to add more filters', async ({
+  context,
+  page,
+}) => {
+  await workWithDigitalLocationAndLocationNote(context, page);
 
-    expectSearchParam('availabilities', 'open-shelves', page);
+  await page.click('a >> text="Medical Heritage LIbrary"'); // Medical Heritage LIbrary
+  await safeWaitForNavigation(page);
 
-    await navigateToResult(6, page);
-  });
-});
+  expectSearchParam('partOf.title', 'Medical Heritage LIbrary', page);
 
-test.describe('Scenario 3: The person is searching for a work that is available online', () => {
-  test('the work should be browsable to from the search results', async ({
-    page,
-    context,
-  }) => {
-    await newWorksSearch(context, page);
-    await searchFor('skin', page);
-    await openDropdown('Locations', page);
-    await selectCheckbox('Online', page);
-    await navigateToNextPage(page);
+  await selectFilter('workType', 'a', page); // Formats > Books
 
-    expectSearchParam('availabilities', 'online', page);
-
-    await navigateToResult(8, page);
-  });
-});
-
-test.describe('Scenario 4: The person is searching for a work from Wellcome Images', () => {
-  test('the work should be browsable to from the search results', async ({
-    page,
-    context,
-  }) => {
-    await newWorksSearch(context, page);
-    await searchFor('skeleton', page);
-    await openDropdown('Formats', page);
-    await selectCheckbox('Digital images', page);
-    await navigateToNextPage(page);
-
-    expectSearchParam('workType', 'q', page);
-
-    await navigateToResult(1, page);
-  });
-});
-
-test.describe('Scenario 5: The person is searching for a work in closed stores', () => {
-  test('the work should be browsable to from the search results', async ({
-    page,
-    context,
-  }) => {
-    await newWorksSearch(context, page);
-    await searchFor('brain', page);
-    await openDropdown('Locations', page);
-    await selectCheckbox('Closed stores', page);
-    await navigateToNextPage(page);
-
-    expectSearchParam('availabilities', 'closed-stores', page);
-
-    await navigateToResult(6, page);
-  });
-});
-
-test.describe('Scenario 6: The reader is searching for works from a particular year', () => {
-  test('the work should be browsable to from the search results', async ({
-    page,
-    context,
-  }) => {
-    await newWorksSearch(context, page);
-    await searchFor('brain', page);
-    await openDropdown('Dates', page);
-
-    // Note: if you put both `page.locator(…).fill(…)` commands in a
-    // single Promise.all(), they can interfere in such a way that only
-    // one of them ends up in the final URL. :-/
-
-    await Promise.all([
-      page
-        .locator('input[form="search-page-form"][name="production.dates.from"]')
-        .fill('1939'),
-      safeWaitForNavigation(page),
-    ]);
-
-    await Promise.all([
-      page
-        .locator('input[form="search-page-form"][name="production.dates.to"]')
-        .fill('2001'),
-      safeWaitForNavigation(page),
-    ]);
-
-    if (isMobile(page)) {
-      await page.click(`"Show results"`);
-    }
-
-    expectSearchParam('production.dates.from', '1939', page);
-    expectSearchParam('production.dates.to', '2001', page);
-
-    // This is a check that we have actually loaded some results from
-    // the API, and the API hasn't just errored out.
-    await navigateToResult(6, page);
-  });
-});
-
-test.describe('Scenario 7: The user is sorting by production dates in search', () => {
-  test('Sort updates URL query and goes back to the first page', async ({
-    context,
-    page,
-  }) => {
-    await newWorksSearch(context, page);
-
-    const select = page.locator('select[name="sortOrder"]');
-    await select.selectOption({ index: 2 });
-
-    await safeWaitForNavigation(page);
-    await navigateToNextPage(page);
-
-    expectSearchParam('sortOrder', 'desc', page);
-    expectSearchParam('sort', 'production.dates', page);
-    expectSearchParam('page', '2', page);
-
-    await select.selectOption({ index: 1 });
-    await safeWaitForNavigation(page);
-
-    expectSearchParam('sortOrder', 'asc', page);
-    expectSearchParam('page', undefined, page);
-  });
-});
-
-test.describe('Scenario 8: The user is coming from a prefiltered series search', () => {
-  test('The user should be able to add more filters', async ({
-    context,
-    page,
-  }) => {
-    await workWithDigitalLocationAndLocationNote(context, page);
-
-    await page.click('a >> text="Medical Heritage LIbrary"'); // Medical Heritage LIbrary
-    await safeWaitForNavigation(page);
-
-    expectSearchParam('partOf.title', 'Medical Heritage LIbrary', page);
-
-    await openDropdown('Formats', page);
-    await selectCheckbox('Books', page);
-
-    expectSearchParam('partOf.title', 'Medical Heritage LIbrary', page);
-    expectSearchParam('workType', 'a', page);
-  });
+  expectSearchParam('partOf.title', 'Medical Heritage LIbrary', page);
+  expectSearchParam('workType', 'a', page);
 });

--- a/playwright/test/search-works.test.ts
+++ b/playwright/test/search-works.test.ts
@@ -6,14 +6,12 @@ import {
   workWithDigitalLocationAndLocationNote,
 } from './contexts';
 import {
-  navigateToNextPage,
-  navigateToResult,
-  openDropdown,
-  searchFor,
-  selectFilter,
-  worksSearchForm,
+  navigateToNextPageAndConfirmNavigation,
+  navigateToResultAndConfirmTitleMatches,
+  openFilterDropdown,
+  searchQueryAndSubmit,
+  selectFilterAndWaitForApplied,
 } from './helpers/search';
-import { formatFilterMobileButton } from './selectors/search';
 
 test.describe.configure({ mode: 'parallel' });
 
@@ -22,50 +20,10 @@ test('(1.1) | The user is looking for an archive; it should be browsable from th
   context,
 }) => {
   await newWorksSearch(context, page);
-
-  // searchFor
-  await page.fill(worksSearchForm, 'Persian');
-  await page.press(worksSearchForm, 'Enter');
-
-  // selectFilter
-  if (isMobile(page)) {
-    await page.click(formatFilterMobileButton);
-  } else {
-    await page.click('button[aria-controls="workType"]');
-  }
-
-  const filterCheckbox = page.locator(
-    'input[form="search-page-form"][type="checkbox"][name="workType"][value="h"]'
-  ); // Formats > Archives and manuscripts
-
-  await filterCheckbox.click();
-  await expect(filterCheckbox).toBeChecked();
-
-  if (isMobile(page)) {
-    await page.click(`"Show results"`);
-  }
-
-  // navigateToNextPage
-  const nextButton = page
-    .locator('[data-testid="pagination"]')
-    .getByRole('link', { name: 'Next' });
-
-  await nextButton.click();
-
-  // confirm navigateToNextPage
-  await expect(page).toHaveURL(/workType=h/);
-  await expect(
-    page.getByTestId('pagination').locator('input[name="page"]')
-  ).toHaveValue('2');
-
-  // navigateToResult
-  const result = `main ul li:nth-of-type(3) a`;
-  const searchResultTitle = await page.textContent(`${result} h3`);
-  await page.click(result);
-
-  const title = await page.locator('h1');
-  await expect(title).toHaveId('work-info');
-  await expect(title).toContainText(String(searchResultTitle));
+  await searchQueryAndSubmit('Persian', page);
+  await selectFilterAndWaitForApplied('workType', 'h', page); // Formats > Archives and manuscripts
+  await navigateToNextPageAndConfirmNavigation(page);
+  await navigateToResultAndConfirmTitleMatches(3, page);
 });
 
 test('(1.2) | The user is looking for an archive; they can get back to their original search results', async ({
@@ -75,20 +33,16 @@ test('(1.2) | The user is looking for an archive; they can get back to their ori
   // Open the search page, search for a term, apply a filter, navigate away from
   // the first page.
   await newWorksSearch(context, page);
-  await searchFor('Persian', page);
-  await selectFilter('workType', 'h', page); // Formats > Archives and manuscripts
-  await navigateToNextPage(page);
-
-  await expect(
-    page.getByTestId('pagination').locator('input[name="page"]')
-  ).toHaveValue('2');
+  await searchQueryAndSubmit('Persian', page);
+  await selectFilterAndWaitForApplied('workType', 'h', page); // Formats > Archives and manuscripts
+  await navigateToNextPageAndConfirmNavigation(page);
 
   // Save the URL of the current search page, which will be something like
   // https://www-stage.wellcomecollection.org/search/works?query=Persian&workType=h&page=2
   const originalSearchUrl = new URL(page.url());
 
   // Now go to the third result on the page, and look for "Back to search results".
-  await navigateToResult(3, page);
+  await navigateToResultAndConfirmTitleMatches(3, page);
 
   const backToSearchResults = page.locator(
     'a:has-text("Back to search results")'
@@ -129,18 +83,14 @@ test('(2) | The user is searching for a work on open shelves; it should be brows
   context,
 }) => {
   await newWorksSearch(context, page);
-  await searchFor('eyes', page);
-  await selectFilter('availabilities', 'open-shelves', page); // Locations > Open shelves
-  await navigateToNextPage(page);
-
-  await expect(
-    page.getByTestId('pagination').locator('input[name="page"]')
-  ).toHaveValue('2');
+  await searchQueryAndSubmit('eyes', page);
+  await selectFilterAndWaitForApplied('availabilities', 'open-shelves', page); // Locations > Open shelves
+  await navigateToNextPageAndConfirmNavigation(page);
 
   const searchParams = new URLSearchParams(new URL(page.url()).search);
   expect(searchParams.get('availabilities')).toEqual('open-shelves');
 
-  await navigateToResult(6, page);
+  await navigateToResultAndConfirmTitleMatches(6, page);
 });
 
 test('(3) | The user is searching for a work that is available online; it should be browsable from the search results', async ({
@@ -148,18 +98,14 @@ test('(3) | The user is searching for a work that is available online; it should
   context,
 }) => {
   await newWorksSearch(context, page);
-  await searchFor('skin', page);
-  await selectFilter('availabilities', 'online', page); // Locations > Online
-  await navigateToNextPage(page);
-
-  await expect(
-    page.getByTestId('pagination').locator('input[name="page"]')
-  ).toHaveValue('2');
+  await searchQueryAndSubmit('skin', page);
+  await selectFilterAndWaitForApplied('availabilities', 'online', page); // Locations > Online
+  await navigateToNextPageAndConfirmNavigation(page);
 
   const searchParams = new URLSearchParams(new URL(page.url()).search);
   expect(searchParams.get('availabilities')).toEqual('online');
 
-  await navigateToResult(8, page);
+  await navigateToResultAndConfirmTitleMatches(8, page);
 });
 
 test('(4) | The user is searching for a work from Wellcome Images; it should be browsable from the search results', async ({
@@ -167,18 +113,14 @@ test('(4) | The user is searching for a work from Wellcome Images; it should be 
   context,
 }) => {
   await newWorksSearch(context, page);
-  await searchFor('skeleton', page);
-  await selectFilter('workType', 'q', page); // Formats > Digital images
-  await navigateToNextPage(page);
-
-  await expect(
-    page.getByTestId('pagination').locator('input[name="page"]')
-  ).toHaveValue('2');
+  await searchQueryAndSubmit('skeleton', page);
+  await selectFilterAndWaitForApplied('workType', 'q', page); // Formats > Digital images
+  await navigateToNextPageAndConfirmNavigation(page);
 
   const searchParams = new URLSearchParams(new URL(page.url()).search);
   expect(searchParams.get('workType')).toEqual('q');
 
-  await navigateToResult(1, page);
+  await navigateToResultAndConfirmTitleMatches(1, page);
 });
 
 test('(5) | The user is searching for a work in closed stores; it should be browsable from the search results', async ({
@@ -186,18 +128,14 @@ test('(5) | The user is searching for a work in closed stores; it should be brow
   context,
 }) => {
   await newWorksSearch(context, page);
-  await searchFor('brain', page);
-  await selectFilter('availabilities', 'closed-stores', page); // Locations > Closed stores
-  await navigateToNextPage(page);
-
-  await expect(
-    page.getByTestId('pagination').locator('input[name="page"]')
-  ).toHaveValue('2');
+  await searchQueryAndSubmit('brain', page);
+  await selectFilterAndWaitForApplied('availabilities', 'closed-stores', page); // Locations > Closed stores
+  await navigateToNextPageAndConfirmNavigation(page);
 
   const searchParams = new URLSearchParams(new URL(page.url()).search);
   expect(searchParams.get('availabilities')).toEqual('closed-stores');
 
-  await navigateToResult(6, page);
+  await navigateToResultAndConfirmTitleMatches(6, page);
 });
 
 test('(6) | The user is searching for works from a particular year; it should be browsable from the search results', async ({
@@ -205,8 +143,8 @@ test('(6) | The user is searching for works from a particular year; it should be
   context,
 }) => {
   await newWorksSearch(context, page);
-  await searchFor('brain', page);
-  await openDropdown('production.dates', page);
+  await searchQueryAndSubmit('brain', page);
+  await openFilterDropdown('production.dates', page);
 
   const datesFrom = page.locator(
     'input[form="search-page-form"][name="production.dates.from"]'
@@ -232,7 +170,7 @@ test('(6) | The user is searching for works from a particular year; it should be
 
   // This is a check that we have actually loaded some results from
   // the API, and the API hasn't just errored out.
-  await navigateToResult(6, page);
+  await navigateToResultAndConfirmTitleMatches(6, page);
 });
 
 test('(7) | The user is sorting by production dates in search; sort updates URL query and goes back to the first page', async ({
@@ -247,11 +185,7 @@ test('(7) | The user is sorting by production dates in search; sort updates URL 
   await expect(page).toHaveURL(/sortOrder=desc/);
   await expect(page).toHaveURL(/sort=production\.dates/);
 
-  await navigateToNextPage(page);
-
-  await expect(
-    page.getByTestId('pagination').locator('input[name="page"]')
-  ).toHaveValue('2');
+  await navigateToNextPageAndConfirmNavigation(page);
 
   await select.selectOption({ index: 1 });
 
@@ -275,7 +209,7 @@ test('(8) | The user is coming from a prefiltered series search; they should be 
 
   await expect(page).toHaveURL(/partOf\.title=Medical\+Heritage\+LIbrary/);
 
-  await selectFilter('workType', 'a', page); // Formats > Books
+  await selectFilterAndWaitForApplied('workType', 'a', page); // Formats > Books
 
   await expect(page).toHaveURL(/partOf\.title=Medical\+Heritage\+LIbrary/);
   await expect(page).toHaveURL(/workType=a/);

--- a/playwright/test/search-works.test.ts
+++ b/playwright/test/search-works.test.ts
@@ -16,7 +16,7 @@ import {
 
 test.describe.configure({ mode: 'parallel' });
 
-test('(1.1) | The user is looking for an archive; it should be browsable from the search results', async ({
+test('(1) | The user is looking for an archive; it should be browsable from the search results', async ({
   page,
   context,
 }) => {
@@ -27,17 +27,17 @@ test('(1.1) | The user is looking for an archive; it should be browsable from th
   await navigateToResultAndConfirmTitleMatches(3, page);
 });
 
-test('(1.2) | The user is looking for an archive; they can get back to their original search results', async ({
+test('(2) | The user is looking for a video; they can get back to their original search results', async ({
   page,
   context,
 }) => {
   await newWorksSearch(context, page);
-  await searchQueryAndSubmit('Persian', page);
-  await selectFilterAndWaitForApplied('workType', 'h', page); // Formats > Archives and manuscripts
+  await searchQueryAndSubmit('Britain', page);
+  await selectFilterAndWaitForApplied('workType', 'g', page); // Formats > Video
   await navigateToNextPageAndConfirmNavigation(page);
 
   // Save the URL of the current search page, which will be something like
-  // https://www-stage.wellcomecollection.org/search/works?query=Persian&workType=h&page=2
+  // https://www-stage.wellcomecollection.org/search/works?query=Britain&workType=g&page=2
   const originalSearchUrl = new URL(page.url());
 
   await navigateToResultAndConfirmTitleMatches(3, page);
@@ -52,8 +52,8 @@ test('(1.2) | The user is looking for an archive; they can get back to their ori
     // Now compare the URLs.  Note that the query parameters may be in a different order,
     // but they're still equivalent for our purposes, e.g.
     //
-    //      /search/works?query=Persian&workType=h&page=2 and
-    //      /search/works?query=Persian&page=2&workType=h
+    //      /search/works?query=Britain&workType=g&page=2 and
+    //      /search/works?query=Britain&page=2&workType=g
     //
     // are both totally fine.  Sorting them first makes them easier to compare.
 
@@ -64,63 +64,9 @@ test('(1.2) | The user is looking for an archive; they can get back to their ori
   });
 });
 
-test('(2) | The user is searching for a work on open shelves; it should be browsable from the search results', async ({
-  page,
-  context,
-}) => {
-  await newWorksSearch(context, page);
-  await searchQueryAndSubmit('eyes', page);
-  await selectFilterAndWaitForApplied('availabilities', 'open-shelves', page); // Locations > Open shelves
-  await navigateToNextPageAndConfirmNavigation(page);
-
-  await testIfFilterIsApplied('Open shelves', page);
-
-  await navigateToResultAndConfirmTitleMatches(6, page);
-});
-
-test('(3) | The user is searching for a work that is available online; it should be browsable from the search results', async ({
-  page,
-  context,
-}) => {
-  await newWorksSearch(context, page);
-  await searchQueryAndSubmit('skin', page);
-  await selectFilterAndWaitForApplied('availabilities', 'online', page); // Locations > Online
-  await navigateToNextPageAndConfirmNavigation(page);
-
-  await testIfFilterIsApplied('Online', page);
-
-  await navigateToResultAndConfirmTitleMatches(8, page);
-});
-
-test('(4) | The user is searching for a work from Wellcome Images; it should be browsable from the search results', async ({
-  page,
-  context,
-}) => {
-  await newWorksSearch(context, page);
-  await searchQueryAndSubmit('skeleton', page);
-  await selectFilterAndWaitForApplied('workType', 'q', page); // Formats > Digital Images
-  await navigateToNextPageAndConfirmNavigation(page);
-
-  await testIfFilterIsApplied('Digital Images', page);
-
-  await navigateToResultAndConfirmTitleMatches(1, page);
-});
-
-test('(5) | The user is searching for a work in closed stores; it should be browsable from the search results', async ({
-  page,
-  context,
-}) => {
-  await newWorksSearch(context, page);
-  await searchQueryAndSubmit('brain', page);
-  await selectFilterAndWaitForApplied('availabilities', 'closed-stores', page); // Locations > Closed stores
-  await navigateToNextPageAndConfirmNavigation(page);
-
-  await testIfFilterIsApplied('Closed stores', page);
-
-  await navigateToResultAndConfirmTitleMatches(6, page);
-});
-
-test('(6) | The user is searching for works from a particular year; it should be browsable from the search results', async ({
+// This is a check that we have actually loaded some results from
+// the API, and the API hasn't just errored out.
+test('(3) | The user is searching for a work from a particular year; there is a list of results', async ({
   page,
   context,
 }) => {
@@ -143,12 +89,10 @@ test('(6) | The user is searching for works from a particular year; it should be
   await testIfFilterIsApplied('From 1939', page);
   await testIfFilterIsApplied('To 2001', page);
 
-  // This is a check that we have actually loaded some results from
-  // the API, and the API hasn't just errored out.
-  await navigateToResultAndConfirmTitleMatches(6, page);
+  await expect(page.getByTestId('work-search-result')).toHaveCount(25);
 });
 
-test('(7) | The user is sorting by production dates in search; sort updates URL query and goes back to the first page', async ({
+test('(4) | The user is sorting by production dates in search; sort updates URL query and goes back to the first page', async ({
   context,
   page,
 }) => {
@@ -168,7 +112,7 @@ test('(7) | The user is sorting by production dates in search; sort updates URL 
   ).toHaveValue('1');
 });
 
-test('(8) | The user is coming from a prefiltered series search; they should be able to add more filters', async ({
+test('(5) | The user is coming from a prefiltered series search; they should be able to add more filters', async ({
   context,
   page,
 }) => {

--- a/playwright/test/search-works.test.ts
+++ b/playwright/test/search-works.test.ts
@@ -10,7 +10,7 @@ import {
   navigateToResultAndConfirmTitleMatches,
   openFilterDropdown,
   searchQueryAndSubmit,
-  selectFilterAndWaitForApplied,
+  selectAndWaitForFilter,
   testIfFilterIsApplied,
 } from './helpers/search';
 
@@ -22,7 +22,7 @@ test('(1) | The user is looking for an archive; it should be browsable from the 
 }) => {
   await newWorksSearch(context, page);
   await searchQueryAndSubmit('Persian', page);
-  await selectFilterAndWaitForApplied('workType', 'h', page); // Formats > Archives and manuscripts
+  await selectAndWaitForFilter('Formats', 'h', page); // Archives and manuscripts
   await navigateToNextPageAndConfirmNavigation(page);
   await navigateToResultAndConfirmTitleMatches(3, page);
 });
@@ -33,7 +33,7 @@ test('(2) | The user is looking for a video; they can get back to their original
 }) => {
   await newWorksSearch(context, page);
   await searchQueryAndSubmit('Britain', page);
-  await selectFilterAndWaitForApplied('workType', 'g', page); // Formats > Video
+  await selectAndWaitForFilter('Formats', 'g', page); // Video
   await navigateToNextPageAndConfirmNavigation(page);
 
   // Save the URL of the current search page, which will be something like
@@ -72,18 +72,16 @@ test('(3) | The user is searching for a work from a particular year; there is a 
 }) => {
   await newWorksSearch(context, page);
   await searchQueryAndSubmit('brain', page);
-  await openFilterDropdown('production.dates', page);
+  await openFilterDropdown('Dates', page);
 
   await page
-    .locator('input[form="search-page-form"][name="production.dates.from"]')
+    .getByRole('spinbutton', { name: 'From', exact: true })
     .fill('1939');
 
-  await page
-    .locator('input[form="search-page-form"][name="production.dates.to"]')
-    .fill('2001');
+  await page.getByRole('spinbutton', { name: 'to', exact: true }).fill('2001');
 
   if (isMobile(page)) {
-    await page.click(`"Show results"`);
+    await page.getByRole('button', { name: 'Show results' }).click();
   }
 
   await testIfFilterIsApplied('From 1939', page);
@@ -125,7 +123,7 @@ test('(5) | The user is coming from a prefiltered series search; they should be 
 
   await testIfFilterIsApplied('Medical Heritage LIbrary', page);
 
-  await selectFilterAndWaitForApplied('workType', 'a', page); // Formats > Books
+  await selectAndWaitForFilter('Formats', 'a', page); // Books
 
   await testIfFilterIsApplied('Medical Heritage LIbrary', page);
   await testIfFilterIsApplied('Books', page);

--- a/playwright/test/search-works.test.ts
+++ b/playwright/test/search-works.test.ts
@@ -133,6 +133,10 @@ test('(2) | The user is searching for a work on open shelves; it should be brows
   await selectFilter('availabilities', 'open-shelves', page); // Locations > Open shelves
   await navigateToNextPage(page);
 
+  await expect(
+    page.getByTestId('pagination').locator('input[name="page"]')
+  ).toHaveValue('2');
+
   const searchParams = new URLSearchParams(new URL(page.url()).search);
   expect(searchParams.get('availabilities')).toEqual('open-shelves');
 
@@ -147,6 +151,10 @@ test('(3) | The user is searching for a work that is available online; it should
   await searchFor('skin', page);
   await selectFilter('availabilities', 'online', page); // Locations > Online
   await navigateToNextPage(page);
+
+  await expect(
+    page.getByTestId('pagination').locator('input[name="page"]')
+  ).toHaveValue('2');
 
   const searchParams = new URLSearchParams(new URL(page.url()).search);
   expect(searchParams.get('availabilities')).toEqual('online');
@@ -163,6 +171,10 @@ test('(4) | The user is searching for a work from Wellcome Images; it should be 
   await selectFilter('workType', 'q', page); // Formats > Digital images
   await navigateToNextPage(page);
 
+  await expect(
+    page.getByTestId('pagination').locator('input[name="page"]')
+  ).toHaveValue('2');
+
   const searchParams = new URLSearchParams(new URL(page.url()).search);
   expect(searchParams.get('workType')).toEqual('q');
 
@@ -177,6 +189,10 @@ test('(5) | The user is searching for a work in closed stores; it should be brow
   await searchFor('brain', page);
   await selectFilter('availabilities', 'closed-stores', page); // Locations > Closed stores
   await navigateToNextPage(page);
+
+  await expect(
+    page.getByTestId('pagination').locator('input[name="page"]')
+  ).toHaveValue('2');
 
   const searchParams = new URLSearchParams(new URL(page.url()).search);
   expect(searchParams.get('availabilities')).toEqual('closed-stores');

--- a/playwright/test/selectors/search.ts
+++ b/playwright/test/selectors/search.ts
@@ -1,23 +1,15 @@
 import { searchFormInputImage } from '../text/aria-labels';
 
 // input
-
 export const worksSearchImagesInputField = `input[aria-label="${searchFormInputImage}"]`;
 
 // modal
-
 export const mobileModal = '#mobile-filters-modal';
 export const mobileModalCloseButton = `${mobileModal} [data-testid="close-modal-button"]`;
 export const formatFilterDropDownContainer = 'div[id="workType"]';
 export const formatFilterMobileButton =
   'button[aria-controls="mobile-filters-modal"]';
 
-// dropdown
-
-export const formatFilterDropDown = '#workType';
-export const formatFilterDropDownButton = 'button[aria-controls="workType"]';
-
 // result list
-
 export const searchResultsContainer =
   '[data-test-id="image-search-results-container"]';

--- a/playwright/test/work.test.ts
+++ b/playwright/test/work.test.ts
@@ -9,7 +9,9 @@ import { Page } from 'playwright';
 const getWhereToFindItAndEncoreLink = async (page: Page) => {
   const whereToFindIt = await page.$('h2:has-text("Where to find it")');
   const encoreLink = await page.$('a:has-text("Request item")');
-  const unavailableBanner = await page.$("[data-test-id='requestingDisabled']");
+  const unavailableBanner = await page.$(
+    "[data-test-id='requesting-disabled']"
+  );
 
   return {
     whereToFindIt,


### PR DESCRIPTION
## Who is this for?
Devs & e2es
Relates to #10409 

## What is it doing for them?
After having had a lot of issues with the e2es being flaky or outright not passing because of race conditions, we've decided to go over them and rewrite them.

The goal of this PR will focus on `search-works` test. So far, the tests in it are taking 3-7 seconds less to run(!).

### My notes so far:
- [Playwright's auto-retrying assertions](https://playwright.dev/docs/test-assertions#auto-retrying-assertions) should be used as much as possible instead of `waitForTimeout`, `waitForSelector` or `waitForNavigation`, which we currently use a lot but are [deprecated or discouraged](https://playwright.dev/docs/api/class-frame#frame-wait-for-timeout). They would be the key to fix race condition issues.
- When testing sorting, filtering or pagination, we can't depend on the URL change nor the value of the input. As some of the content updates before navigation occurs, or as the state of some inputs doesn't update their value right away, the safest route seems to be to expect content on the page to have loaded.
	- **Pagination**: Check the `input[name="page"]` value for the page number
	- **Filters**: Still needs work. Currently looks at if they're listed in the hidden `span role="status"` but I don't love it for the reasons listed in the comments. How should we make it available to the tests both on desktop and mobile?
	- **Sorting**: Look at the value of the Select.
- The selectors we're using should be based on [this recommendation list](https://testing-library.com/docs/queries/about/#priority).

### Next steps:
- Rewrite all tests one by one and only use what Playwright offers without patching it
- This might mean fixing things in the codebase that aren't working as they should, or maybe they need identifiers to be used in tests.
- Clean up all `actions` and `selectors` (like `playwright/test/actions/search.ts`), as a lot of them aren't used anymore.
- Once we make `works-search` work perfectly,  according to all of the above, then it will become a blueprint and we can split the rewrite between us, so do have a look, let us know what you think and get acquainted! 

### Other bits I've done so far in this PR:
- I've renamed the tests and flattened them out, removed the `console.info()` that were left in... with the new naming structure reckon it'll be easy to see what's left to do as we slowly go through them.
- Moved the helpers to another file, rewrote them completely and renamed them so they're extremely clear in the test file itself.
- Removed the unused `data-test-id` that were being passed in in various places in the codebase. Tbf we should also align it so they ideally use `data-testId` and the native [locateByTestId](https://playwright.dev/docs/locators#locate-by-test-id) function, but that's for another time