### PR TITLE
no slack alert for e2e tests endpoint

### DIFF
--- a/cache/send_slack_alert_for_5xx_errors.js
+++ b/cache/send_slack_alert_for_5xx_errors.js
@@ -385,7 +385,7 @@ function isInterestingError(hit) {
   // tests.  Any errors here are either opportunistic bots we don't care
   // about, or a failure which will be surfaced elsewhere by the end-to-end
   // test results.  We don't need to hear about them in Slack.
-  if (hit.host.includes('.www-e2e.')) {
+  if (hit.host.includes('www-e2e.')) {
     return false;
   }
 


### PR DESCRIPTION
## Who is this for?
Naughty bots

## What is it doing for ~them~ us?
Not alerting on Slack when they hit urls such as this: 
https://www-e2e.wellcomecollection.org/uapjs/jsinvoke/?action=invoke