### PR TITLE
Hide error border when input becomes valid

### DIFF
--- a/common/views/components/TextInput/TextInput.tsx
+++ b/common/views/components/TextInput/TextInput.tsx
@@ -20,20 +20,18 @@ export const TextInputWrap = styled.div.attrs<TextInputWrapProps>(props => ({
 }))<TextInputWrapProps>`
   display: flex;
   position: relative;
-  border: 2px solid
-    ${props => props.theme.color(props.$darkBg ? 'white' : 'neutral.600')};
+  border: ${props =>
+    props.$hasErrorBorder
+      ? `3px solid ${props.theme.color('validation.red')}`
+      : `2px solid ${props.theme.color(
+          props.$darkBg ? 'white' : 'neutral.600'
+        )}`};
 
   &:focus-within {
     box-shadow: ${props => props.theme.focusBoxShadow};
   }
 
   overflow: hidden;
-
-  ${props =>
-    props.$hasErrorBorder &&
-    `
-    box-shadow: 0 0 0 1px ${props.theme.color('validation.red')};
-  `}
 `;
 
 type TextInputLabelProps = {
@@ -93,15 +91,6 @@ export const TextInputInput = styled.input.attrs<{ $type?: string }>(props => ({
   &::-ms-clear {
     display: none;
   }
-
-  ${props =>
-    props.$hasErrorBorder &&
-    `
-      &,
-      &:focus {
-        border: 3px solid ${props.theme.color('validation.red')};
-      }
-    `}
 `;
 
 const TextInputCheckmark = styled.span.attrs<{


### PR DESCRIPTION
## Who is this for?
Users

## What is it doing for them?
Removing the red 'error' border around an e.g. email input once the text in the field is valid

To see the current problem, go to the homepage, type e.g. 'a' in the newsletter promo at the bottom of the page. Tab/click away from the field and see an error message about address format. Click back into the field and make it e.g. 'a@b' – the error message correctly disappears, but the red error border remains.

(spotted when working on #10234)