### PR TITLE
Return the error from the works API if all 3 search requests fail

### DIFF
--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -343,7 +343,12 @@ export const getServerSideProps: GetServerSideProps<
       worksResults.type === 'Error' &&
       storiesResults.type === 'Error'
     ) {
-      return appError(context, 500, 'Search results error');
+      // Use the error from the works API as it is the most mature of the 3
+      return appError(
+        context,
+        worksResults.httpStatus,
+        worksResults.description || worksResults.label
+      );
     }
 
     return {


### PR DESCRIPTION
A bit of a compromise here in turns of returning a meaningful error, but adhering to the general principle that (almost always) we never want to return a 500 "on purpose".