### PR TITLE
Stop lint task failing when error found

### DIFF
--- a/prismic-model/lintPrismicData.ts
+++ b/prismic-model/lintPrismicData.ts
@@ -241,7 +241,6 @@ async function run() {
     console.log(
       chalk.red(`🚨 ${totalErrors} error${totalErrors > 1 ? 's' : ''} detected`)
     );
-    process.exit(1);
   }
 }
 


### PR DESCRIPTION
## Who is this for?
Devs
Relates to #10304 

## What is it doing for them?
As it's not our responsibility to fix prismic linting, it shouldn't show as failed - it makes our PRs look like they're not passing.
[See Slack Convo](https://wellcome.slack.com/archives/C3N7J05TK/p1699979055854609?thread_ts=1699978697.464199&cid=C3N7J05TK)


I think that's what was needed?