### PR TITLE
Revert a change to stop featured exhibition displaying twice

### DIFF
--- a/content/webapp/services/prismic/transformers/card.ts
+++ b/content/webapp/services/prismic/transformers/card.ts
@@ -1,15 +1,16 @@
 import { CardPrismicDocument } from '../types/card';
 import { transformImage } from '@weco/common/services/prismic/transformers/images';
-import { Card } from '../../../types/card';
+import { Card } from '@weco/content/types/card';
 import { asText, asTitle, transformFormat } from '.';
 import { transformLink } from '@weco/common/services/prismic/transformers';
+import { isFilledLinkToDocument } from '@weco/common/services/prismic/types';
 
 export function transformCard(document: CardPrismicDocument): Card {
   const { title, description, image, link } = document.data;
 
   return {
     type: 'card',
-    id: document.id,
+    id: isFilledLinkToDocument(link) ? link.id : undefined,
     title: asTitle(title),
     format: transformFormat(document),
     description: asText(description),


### PR DESCRIPTION
## Who is this for?
Users
Relates to #10416 

## What is it doing for them?
A few weeks back, [Ben raised](https://wellcome.slack.com/archives/C8X9YKM5X/p1699027709068399) that, on the homepage, exhibitions that were featured were listed again in the content list underneath. As [the comment in code](https://github.com/wellcomecollection/wellcomecollection.org/blob/main/content/webapp/pages/index.tsx#L141) still says this shouldn't be the case, we knew this was not on purpose.

I believe it was introduced in [a higher level PR](https://github.com/wellcomecollection/wellcomecollection.org/pull/10125/files?diff=split&w=1#r1293369060), so I reverted that line back to what it used to be. It was changed because: 
> I can't be sure why this was as it was – I think it was probably a mistake. And it was the reason why id would be undefined here and AsyncSearchResults could end up querying Prismic without any parameters (which then sends back a lot, and potentially breaks the frontend which wasn't expecting it)

As the change happened on the _card_ id and `AsyncSearchResults` looks at the _slice_ id, I believe we're good to revert. It fixes the issue raised by Ben and doesn't affect the original goal of #10125 which was to display cards in content lists.