### PR TITLE
Prismic images: Remove grey background

### DIFF
--- a/common/utils/backgrounds.ts
+++ b/common/utils/backgrounds.ts
@@ -1,5 +1,7 @@
 export const transparentGif =
   'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+export const whiteBackgroundHalfOpacity =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8Xw8AAoMBgDTD2qgAAAAASUVORK5CYII=';
 export const repeatingLs =
   'https://images.prismic.io/wellcomecollection%2F805ad61b-fba6-4dc1-b2d3-55dbcda0c9f1_ls_svg.svg';
 export const repeatingLsBlack =

--- a/common/views/components/PrismicImage/PrismicImage.tsx
+++ b/common/views/components/PrismicImage/PrismicImage.tsx
@@ -1,12 +1,15 @@
 import { FunctionComponent } from 'react';
 import Image, { ImageLoaderProps } from 'next/image';
 import styled from 'styled-components';
-import { Breakpoint, sizes as breakpointSizes } from '../../themes/config';
+import {
+  Breakpoint,
+  sizes as breakpointSizes,
+} from '@weco/common/views/themes/config';
 import { ImageType } from '@weco/common/model/image';
+import { whiteBackgroundHalfOpacity } from '@weco/common/utils/backgrounds';
 
 const StyledImage = styled(Image)<{ $desaturate: boolean }>`
   color: ${props => props.theme.color('white')};
-  background-color: ${props => props.theme.color('neutral.700')};
   filter: ${props => (props.$desaturate ? 'saturate(0%)' : undefined)};
   width: 100%;
   height: auto;
@@ -120,7 +123,8 @@ const PrismicImage: FunctionComponent<Props> = ({
       $desaturate={desaturate}
       loader={createPrismicLoader(maxLoaderWidth, quality)}
       sizes={imgSizes || sizesString}
-      style={{}}
+      placeholder="blur"
+      blurDataURL={whiteBackgroundHalfOpacity}
     />
   );
 };


### PR DESCRIPTION
## Who is this for?
Users/images/transparent pngs

## What is it doing for them?
We currently had a grey background on all `PrismicImage`s, I believe this acts as a placeholder while the image loads. This means that transparent images have a background, but I guess we didn't really use them at the time so didn't notice. We now do in the `TextAndIcons` components.

I've replaced it with `placeholder="blur"` and a base64 image that is just white with 50% opacity. We can revisit this ( @j-jaworski, we can have a call and decide on something together if this is a bit meh), but in the meantime it allows for transparency as the placeholder is only while the image loads.

Before

https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/99c012cd-668b-42da-896b-94f65fbb29a3


After


https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/20bf4f8b-8b26-4f80-8446-3c9646b25669



