### PR TITLE
Fix missing background colour in image search gallery

### DIFF
--- a/content/webapp/components/IIIFImage/IIIFImage.tsx
+++ b/content/webapp/components/IIIFImage/IIIFImage.tsx
@@ -12,13 +12,12 @@ import {
   BreakpointSizes,
 } from '@weco/common/views/components/PrismicImage/PrismicImage';
 
-// Not typed as PaletteColor as we want the averageColor of each image
 const StyledImage = styled(Image)`
-  background-color: transparent;
   color: ${props => props.theme.color('neutral.700')};
 `;
 
 const StyledImageContainer = styled.div<{
+  // Not typed as PaletteColor as we want the averageColor of each image
   $background: string;
 }>`
   height: 100%;

--- a/content/webapp/components/IIIFImage/IIIFImage.tsx
+++ b/content/webapp/components/IIIFImage/IIIFImage.tsx
@@ -13,8 +13,8 @@ import {
 } from '@weco/common/views/components/PrismicImage/PrismicImage';
 
 // Not typed as PaletteColor as we want the averageColor of each image
-const StyledImage = styled(Image)<{ $background: string }>`
-  background-color: ${props => props.$background};
+const StyledImage = styled(Image)`
+  background-color: transparent;
   color: ${props => props.theme.color('neutral.700')};
 `;
 
@@ -26,7 +26,7 @@ const StyledImageContainer = styled.div<{
   align-items: center;
   justify-content: center;
 
-  &::after {
+  &::before {
     content: '';
     position: absolute;
     top: 0;
@@ -35,7 +35,6 @@ const StyledImageContainer = styled.div<{
     height: 100%;
     background-color: ${props => props.$background};
     filter: saturate(50%);
-    z-index: -1;
   }
 `;
 
@@ -98,7 +97,6 @@ const IIIFImage: FunctionComponent<Props> = ({
         width={image.width}
         height={image.height}
         priority={priority}
-        $background="transparent"
         sizes={sizesString}
       />
     </StyledImageContainer>


### PR DESCRIPTION
## Who is this for?
Us because we liked it

## What is it doing for them?
Brings it back! I'm not sure exactly what happened that it broke but there was an issue with the layers, the z-index being -1 was hiding the "background". It was always that index, so 🤷‍♀️ but made it a pseudo before instead of a pseudo after and removed the `z-index`. 
Also removed the BackgroundImage `background` as it wasn't used and was set to `transparent` for all.