### PR TITLE
Ensure all dynamic pages have same error handling

### DIFF
--- a/content/webapp/pages/articles/[articleId].tsx
+++ b/content/webapp/pages/articles/[articleId].tsx
@@ -40,6 +40,7 @@ import styled from 'styled-components';
 import { Pageview } from '@weco/common/services/conversion/track';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 import { setCacheControl } from '@weco/content/utils/setCacheControl';
+import { isNotUndefined } from '@weco/common/utils/type-guards';
 
 const ContentTypeWrapper = styled.div`
   display: flex;
@@ -64,15 +65,16 @@ export const getServerSideProps: GetServerSideProps<
 > = async context => {
   setCacheControl(context.res);
   const { articleId } = context.query;
+
   if (!looksLikePrismicId(articleId)) {
     return { notFound: true };
   }
 
   const client = createClient(context);
   const articleDocument = await fetchArticle(client, articleId);
-  const serverData = await getServerData(context);
 
-  if (articleDocument) {
+  if (isNotUndefined(articleDocument)) {
+    const serverData = await getServerData(context);
     const article = transformArticle(articleDocument);
     const jsonLd = articleLd(article);
     return {
@@ -91,9 +93,9 @@ export const getServerSideProps: GetServerSideProps<
         },
       }),
     };
-  } else {
-    return { notFound: true };
   }
+
+  return { notFound: true };
 };
 
 type ArticleSeriesList = {

--- a/content/webapp/pages/books/[bookId].tsx
+++ b/content/webapp/pages/books/[bookId].tsx
@@ -23,6 +23,7 @@ import Layout8 from '@weco/common/views/components/Layout8/Layout8';
 import { Pageview } from '@weco/common/services/conversion/track';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 import { setCacheControl } from '@weco/content/utils/setCacheControl';
+import { isNotUndefined } from '@weco/common/utils/type-guards';
 
 const MetadataWrapper = styled.div`
   border-top: 1px solid ${props => props.theme.color('neutral.300')};
@@ -87,13 +88,14 @@ export const getServerSideProps: GetServerSideProps<
 > = async context => {
   setCacheControl(context.res);
   const { bookId } = context.query;
+
   if (!looksLikePrismicId(bookId)) {
     return { notFound: true };
   }
   const client = createClient(context);
   const bookDocument = await fetchBook(client, bookId);
 
-  if (bookDocument) {
+  if (isNotUndefined(bookDocument)) {
     const serverData = await getServerData(context);
     const book = transformBook(bookDocument);
 

--- a/content/webapp/pages/concepts/[conceptId].tsx
+++ b/content/webapp/pages/concepts/[conceptId].tsx
@@ -433,12 +433,13 @@ export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
   setCacheControl(context.res, cacheTTL.search);
-  const serverData = await getServerData(context);
   const { conceptId } = context.query;
 
   if (!looksLikeCanonicalId(conceptId)) {
     return { notFound: true };
   }
+
+  const serverData = await getServerData(context);
 
   const conceptResponse = await getConcept({
     id: conceptId,

--- a/content/webapp/pages/event-series/[eventSeriesId].tsx
+++ b/content/webapp/pages/event-series/[eventSeriesId].tsx
@@ -48,15 +48,14 @@ export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
   setCacheControl(context.res);
-  const serverData = await getServerData(context);
   const { eventSeriesId } = context.query;
 
   if (!looksLikePrismicId(eventSeriesId)) {
     return { notFound: true };
   }
 
+  const serverData = await getServerData(context);
   const client = createClient(context);
-
   const page = getPage(context.query);
 
   if (typeof page !== 'number') {
@@ -115,9 +114,9 @@ export const getServerSideProps: GetServerSideProps<
         page,
       }),
     };
-  } else {
-    return { notFound: true };
   }
+
+  return { notFound: true };
 };
 
 const EventSeriesPage: FunctionComponent<Props> = ({

--- a/content/webapp/pages/exhibitions/[exhibitionId]/index.tsx
+++ b/content/webapp/pages/exhibitions/[exhibitionId]/index.tsx
@@ -26,6 +26,7 @@ import {
   visualStoryLinkText,
   exhibitionGuideLinkText,
 } from '@weco/common/data/microcopy';
+import { isNotUndefined } from '@weco/common/utils/type-guards';
 
 type ExhibitionProps = {
   exhibition: ExhibitionType;
@@ -75,7 +76,6 @@ export const getServerSideProps: GetServerSideProps<
   ExhibitionProps | AppErrorProps
 > = async context => {
   setCacheControl(context.res, cacheTTL.events);
-  const serverData = await getServerData(context);
   const { exhibitionId } = context.query;
 
   if (!looksLikePrismicId(exhibitionId)) {
@@ -86,7 +86,8 @@ export const getServerSideProps: GetServerSideProps<
   const { exhibition, pages, visualStories, exhibitionGuides } =
     await fetchExhibition(client, exhibitionId);
 
-  if (exhibition) {
+  if (isNotUndefined(exhibition)) {
+    const serverData = await getServerData(context);
     const exhibitionDoc = transformExhibition(exhibition);
     const relatedPages = transformQuery(pages, transformPage);
     const visualStoriesLinks = visualStories.results.map(visualStory => {
@@ -126,9 +127,9 @@ export const getServerSideProps: GetServerSideProps<
         },
       }),
     };
-  } else {
-    return { notFound: true };
   }
+
+  return { notFound: true };
 };
 
 export default ExhibitionPage;

--- a/content/webapp/pages/guides/exhibitions/[id]/[type].tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/[type].tsx
@@ -35,6 +35,7 @@ import useHotjar from '@weco/content/hooks/useHotjar';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 import { setCacheControl } from '@weco/content/utils/setCacheControl';
 import { font } from '@weco/common/utils/classnames';
+import { isNotUndefined } from '@weco/common/utils/type-guards';
 
 const ButtonWrapper = styled(Space).attrs({
   $v: { size: 's', properties: ['margin-bottom'] },
@@ -77,13 +78,12 @@ export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
   setCacheControl(context.res);
-  const serverData = await getServerData(context);
   const { id, type, usingQRCode, userPreferenceSet, stopId } = context.query;
-  const { res, req } = context;
 
   if (!looksLikePrismicId(id) || !isValidType(type)) {
     return { notFound: true };
   }
+  const { res, req } = context;
 
   const client = createClient(context);
   const exhibitionGuideQuery = await fetchExhibitionGuide(client, id);
@@ -142,7 +142,8 @@ export const getServerSideProps: GetServerSideProps<
     };
   }
 
-  if (exhibitionGuideQuery) {
+  if (isNotUndefined(exhibitionGuideQuery)) {
+    const serverData = await getServerData(context);
     const exhibitionGuide = transformExhibitionGuide(exhibitionGuideQuery);
     const filteredExhibitionGuide = filterExhibitionGuideComponents(
       exhibitionGuide,
@@ -161,9 +162,9 @@ export const getServerSideProps: GetServerSideProps<
         stopId: stopId as string | undefined,
       }),
     };
-  } else {
-    return { notFound: true };
   }
+
+  return { notFound: true };
 };
 
 const ExhibitionGuidePage: FunctionComponent<Props> = props => {

--- a/content/webapp/pages/pages/[pageId].tsx
+++ b/content/webapp/pages/pages/[pageId].tsx
@@ -119,14 +119,13 @@ export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
   setCacheControl(context.res);
-  const serverData = await getServerData(context);
   const { pageId } = context.query;
-
-  const client = createClient(context);
 
   if (!looksLikePrismicId(pageId)) {
     return { notFound: true };
   }
+
+  const client = createClient(context);
 
   const vanityUrl = isVanityUrl(pageId, context.resolvedUrl)
     ? context.resolvedUrl
@@ -135,7 +134,8 @@ export const getServerSideProps: GetServerSideProps<
   const pageLookup = await fetchPage(client, pageId);
   const page = pageLookup && transformPage(pageLookup);
 
-  if (page) {
+  if (isNotUndefined(page)) {
+    const serverData = await getServerData(context);
     const siblings: SiblingsGroup<PageType>[] = (
       await fetchSiblings(client, page)
     ).map(group => {
@@ -180,9 +180,9 @@ export const getServerSideProps: GetServerSideProps<
         },
       }),
     };
-  } else {
-    return { notFound: true };
   }
+
+  return { notFound: true };
 };
 
 export const Page: FunctionComponent<Props> = ({

--- a/content/webapp/pages/seasons/[seasonId].tsx
+++ b/content/webapp/pages/seasons/[seasonId].tsx
@@ -48,6 +48,7 @@ import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 import * as prismic from '@prismicio/client';
 import { setCacheControl } from '@weco/content/utils/setCacheControl';
+import { isNotUndefined } from '@weco/common/utils/type-guards';
 
 type Props = {
   season: Season;
@@ -116,6 +117,7 @@ export const getServerSideProps: GetServerSideProps<
 > = async context => {
   setCacheControl(context.res);
   const { seasonId } = context.query;
+
   if (!looksLikePrismicId(seasonId)) {
     return { notFound: true };
   }
@@ -182,9 +184,10 @@ export const getServerSideProps: GetServerSideProps<
   const series = transformQuery(seriesQuery, transformSeries);
   const season = seasonDoc && transformSeason(seasonDoc);
 
-  if (season) {
-    const jsonLd = contentLd(season);
+  if (isNotUndefined(season)) {
     const serverData = await getServerData(context);
+    const jsonLd = contentLd(season);
+
     return {
       props: serialiseProps({
         season,
@@ -199,9 +202,9 @@ export const getServerSideProps: GetServerSideProps<
         serverData,
       }),
     };
-  } else {
-    return { notFound: true };
   }
+
+  return { notFound: true };
 };
 
 export default SeasonPage;

--- a/content/webapp/pages/series/[seriesId].tsx
+++ b/content/webapp/pages/series/[seriesId].tsx
@@ -61,14 +61,13 @@ export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
 > = async context => {
   setCacheControl(context.res);
-  const serverData = await getServerData(context);
-
   const { seriesId } = context.query;
 
   if (!looksLikePrismicId(seriesId)) {
     return { notFound: true };
   }
 
+  const serverData = await getServerData(context);
   const page = getPage(context.query);
 
   if (typeof page !== 'number') {

--- a/content/webapp/pages/visual-stories/[visualStoryId].tsx
+++ b/content/webapp/pages/visual-stories/[visualStoryId].tsx
@@ -18,6 +18,7 @@ import Body from '@weco/content/components/Body/Body';
 import { VisualStoryDocument } from '@weco/content/services/prismic/types/visual-stories';
 import { SimplifiedServerData } from '@weco/common/server-data/types';
 import { capitalize } from '@weco/common/utils/grammar';
+import { isNotUndefined } from '@weco/common/utils/type-guards';
 
 type Props = {
   visualStory: VisualStory;
@@ -54,17 +55,21 @@ export const returnVisualStoryProps = ({
 
 export const getServerSideProps = async context => {
   setCacheControl(context.res);
-  const client = createClient(context);
   const { visualStoryId } = context.query;
-  const serverData = await getServerData(context);
 
   if (!looksLikePrismicId(visualStoryId)) {
     return { notFound: true };
   }
 
+  const client = createClient(context);
   const visualStoryDocument = await fetchVisualStory(client, visualStoryId);
 
-  return returnVisualStoryProps({ visualStoryDocument, serverData });
+  if (isNotUndefined(visualStoryDocument)) {
+    const serverData = await getServerData(context);
+    return returnVisualStoryProps({ visualStoryDocument, serverData });
+  }
+
+  return { notFound: true };
 };
 
 const VisualStory: FunctionComponent<Props> = ({ visualStory, jsonLd }) => {


### PR DESCRIPTION
## Who is this for?
Users/Maintenance

## What is it doing for them?
We got a lot of [errors in the alerts channel](https://wellcome.slack.com/archives/CQ720BG02/p1700412843533299) regarding an non-existing event that also had characters in its URL that broke a query. I realised that our `[eventId]` page was lacking the `looksLikePrismicId` check that other pages had that would fail the page before it tried to do things with the Id. 

Then I decided to check our other pages and tried to structure `getServerSideProps` the same so we're a bit more aligned and we had less chances of forgetting some checks in the future.

Basically the changes are;
- Moving some steps to  _after_ we've checked the `id` was valid (instead of automatically doing them every time)
- Using `isNotUndefined` to make sure the document exists
- Returning 404 at the end if it does not

Prob want to use the [no-whitespace version](https://github.com/wellcomecollection/wellcomecollection.org/pull/10444/files?diff=split&w=1) to check changes