### PR TITLE
Align VS serverside checks and fix preview URLs

### DIFF
--- a/common/services/prismic/link-resolver.ts
+++ b/common/services/prismic/link-resolver.ts
@@ -26,8 +26,7 @@ function linkResolver(doc: Props | DataProps): string {
       const {
         data: { relatedDocument },
       } = doc;
-
-      if (relatedDocument) {
+      if (relatedDocument?.id) {
         return `/${relatedDocument.type}/${relatedDocument.id}/visual-stories`;
       } else {
         return `/visual-stories/${id}`;

--- a/content/webapp/pages/events/[eventId]/visual-stories.tsx
+++ b/content/webapp/pages/events/[eventId]/visual-stories.tsx
@@ -11,7 +11,6 @@ import { setCacheControl } from '@weco/content/utils/setCacheControl';
 export const getServerSideProps = async context => {
   setCacheControl(context.res);
   const client = createClient(context);
-  const serverData = await getServerData(context);
 
   const visualStoriesQuery = await fetchVisualStories(client, {
     filters: [
@@ -31,6 +30,8 @@ export const getServerSideProps = async context => {
   if (!looksLikePrismicId(visualStoriesQuery.results[0].id)) {
     return { notFound: true };
   }
+
+  const serverData = await getServerData(context);
 
   return returnVisualStoryProps({
     visualStoryDocument: visualStoriesQuery.results[0],

--- a/content/webapp/pages/exhibitions/[exhibitionId]/visual-stories.tsx
+++ b/content/webapp/pages/exhibitions/[exhibitionId]/visual-stories.tsx
@@ -11,7 +11,6 @@ import { setCacheControl } from '@weco/content/utils/setCacheControl';
 export const getServerSideProps = async context => {
   setCacheControl(context.res);
   const client = createClient(context);
-  const serverData = await getServerData(context);
 
   const visualStoriesQuery = await fetchVisualStories(client, {
     filters: [
@@ -32,6 +31,7 @@ export const getServerSideProps = async context => {
     return { notFound: true };
   }
 
+  const serverData = await getServerData(context);
   return returnVisualStoryProps({
     visualStoryDocument: visualStoriesQuery.results[0],
     serverData,

--- a/content/webapp/pages/visual-stories/[visualStoryId].tsx
+++ b/content/webapp/pages/visual-stories/[visualStoryId].tsx
@@ -33,7 +33,7 @@ export const returnVisualStoryProps = ({
   visualStoryDocument?: VisualStoryDocument;
   serverData: SimplifiedServerData;
 }) => {
-  if (visualStoryDocument) {
+  if (isNotUndefined(visualStoryDocument)) {
     const visualStory = transformVisualStory(visualStoryDocument);
     const jsonLd = visualStoryLd(visualStory);
 
@@ -48,9 +48,9 @@ export const returnVisualStoryProps = ({
         },
       }),
     };
-  } else {
-    return { notFound: true };
   }
+
+  return { notFound: true };
 };
 
 export const getServerSideProps = async context => {
@@ -61,15 +61,11 @@ export const getServerSideProps = async context => {
     return { notFound: true };
   }
 
+  const serverData = await getServerData(context);
   const client = createClient(context);
   const visualStoryDocument = await fetchVisualStory(client, visualStoryId);
 
-  if (isNotUndefined(visualStoryDocument)) {
-    const serverData = await getServerData(context);
-    return returnVisualStoryProps({ visualStoryDocument, serverData });
-  }
-
-  return { notFound: true };
+  return returnVisualStoryProps({ visualStoryDocument, serverData });
 };
 
 const VisualStory: FunctionComponent<Props> = ({ visualStory, jsonLd }) => {


### PR DESCRIPTION
## Who is this for?
Editorial/Maintenance
Relates to #10408

## What is it doing for them?
The check for link-resolver wasn't good enough. There is always a relatedDocument (` { link_type: 'Document' }`) so the check needs to look at if it has an ID, like we do elsewhere in the codebase.
Also because of the work I did earlier to [align all error handling server side](https://github.com/wellcomecollection/wellcomecollection.org/pull/10444), I noticed I'd missed it there so did that too.