### PR TITLE
WIP: Add Events to Content API helpers and Search pages

### DIFF
--- a/common/data/segment-values.ts
+++ b/common/data/segment-values.ts
@@ -20,6 +20,7 @@ import { Prefix } from '@weco/common/utils/utility-types';
 export type PageviewName =
   | 'concept'
   | 'event'
+  | 'events'
   | 'exhibition'
   | 'image'
   | 'images'
@@ -86,3 +87,4 @@ export type WorksLinkSource =
   | 'unknown';
 
 export type StoriesLinkSource = 'unknown';
+export type EventsLinkSource = 'unknown'; // TODO?

--- a/common/services/prismic/transformers/images.ts
+++ b/common/services/prismic/transformers/images.ts
@@ -2,20 +2,23 @@ import * as prismic from '@prismicio/client';
 import { ImageType } from '@weco/common/model/image';
 import { isUndefined } from '@weco/common/utils/type-guards';
 import { transformTaslFromString } from '.';
+import { ContentApiImage } from '@weco/content/services/wellcome/content/types';
+
+type PossibleImageTypes =
+  | prismic.EmptyImageFieldImage
+  | prismic.FilledImageFieldImage
+  | ContentApiImage;
 
 // when images have crops, event if the image isn't attached, we get e.g.
 // { '32:15': {}, '16:9': {}, square: {} }
 function isImageLink(
-  maybeImage: prismic.EmptyImageFieldImage | prismic.FilledImageFieldImage
-): maybeImage is prismic.FilledImageFieldImage {
+  maybeImage: PossibleImageTypes
+): maybeImage is prismic.FilledImageFieldImage | ContentApiImage {
   return Boolean(maybeImage && maybeImage.dimensions);
 }
 
 export function transformImage(
-  maybeImage:
-    | prismic.EmptyImageFieldImage
-    | prismic.FilledImageFieldImage
-    | undefined
+  maybeImage?: PossibleImageTypes
 ): ImageType | undefined {
   return maybeImage && isImageLink(maybeImage)
     ? transformFilledImage(maybeImage)
@@ -30,7 +33,9 @@ function startsWith(s: string, prefix: string): boolean {
 }
 
 // We don't export this, as we probably always want to check ^ first
-function transformFilledImage(image: prismic.FilledImageFieldImage): ImageType {
+function transformFilledImage(
+  image: prismic.FilledImageFieldImage | ContentApiImage
+): ImageType {
   const tasl = transformTaslFromString(image.copyright);
   const crops = Object.keys(image)
     .filter(key => prismicImageProps.indexOf(key) === -1)

--- a/content/webapp/components/EventsLink/index.tsx
+++ b/content/webapp/components/EventsLink/index.tsx
@@ -1,0 +1,70 @@
+// TODO couldn't this be made more general for this and Stories?
+
+import { ParsedUrlQuery } from 'querystring';
+import NextLink from 'next/link';
+import { LinkProps } from '@weco/common/model/link-props';
+import { FunctionComponent } from 'react';
+import {
+  LinkFrom,
+  stringCodec,
+  numberCodec,
+  csvCodec,
+  FromCodecMap,
+  encodeQuery,
+  decodeQuery,
+} from '@weco/common/utils/routes';
+import { EventsLinkSource } from '@weco/common/data/segment-values';
+export type EventsProps = FromCodecMap<typeof codecMap>;
+const emptyEventsProps: EventsProps = {
+  query: '',
+  page: 1,
+  format: [],
+  'contributors.contributor': [],
+};
+const codecMap = {
+  query: stringCodec,
+  page: numberCodec,
+  format: csvCodec,
+  'contributors.contributor': csvCodec,
+};
+const fromQuery: (params: ParsedUrlQuery) => EventsProps = params => {
+  return decodeQuery<EventsProps>(params, codecMap);
+};
+const toQuery: (props: EventsProps) => ParsedUrlQuery = props => {
+  return encodeQuery<EventsProps>(props, codecMap);
+};
+function toLink(
+  partialProps: Partial<EventsProps>,
+  source: EventsLinkSource
+): LinkProps {
+  const pathname = '/search/events';
+  const props: EventsProps = {
+    ...emptyEventsProps,
+    ...partialProps,
+  };
+  const query = toQuery(props);
+  return {
+    href: {
+      pathname,
+      query: { ...query, source },
+    },
+    as: {
+      pathname,
+      query,
+    },
+  };
+}
+type Props = LinkFrom<EventsProps> & { source: EventsLinkSource };
+const EventsLink: FunctionComponent<Props> = ({
+  children,
+  source,
+  ...props
+}: Props) => {
+  return (
+    <NextLink {...toLink(props, source)} legacyBehavior>
+      {children}
+    </NextLink>
+  );
+};
+export default EventsLink;
+export { toLink, toQuery, fromQuery, emptyEventsProps };

--- a/content/webapp/components/EventsSearchResults/EventsSearchResults.styles.tsx
+++ b/content/webapp/components/EventsSearchResults/EventsSearchResults.styles.tsx
@@ -1,0 +1,69 @@
+import { grid } from '@weco/common/utils/classnames';
+import Space from '@weco/common/views/components/styled/Space';
+import styled from 'styled-components';
+
+export const EventsContainer = styled.div.attrs<{ $isDetailed?: boolean }>(
+  props => ({
+    className: props.$isDetailed
+      ? ''
+      : 'grid grid--scroll grid--theme-4 card-theme card-theme--transparent',
+  })
+)``;
+
+export const EventWrapper = styled(Space).attrs<{
+  $isDetailed?: boolean;
+}>(props => ({
+  $v: props.$isDetailed
+    ? { size: 'xl', properties: ['padding-bottom'] }
+    : undefined,
+  className: props.$isDetailed ? 'grid' : grid({ s: 6, m: 6, l: 3, xl: 3 }),
+}))`
+  text-decoration: none;
+
+  &:last-child {
+    padding-bottom: 0;
+  }
+
+  &:hover {
+    h3 {
+      text-decoration: underline;
+    }
+  }
+`;
+
+export const ImageWrapper = styled.div.attrs<{ $isDetailed?: boolean }>(
+  props => ({
+    className: props.$isDetailed ? grid({ s: 12, m: 6, l: 4, xl: 4 }) : '',
+  })
+)`
+  position: relative;
+  margin-bottom: ${props => props.theme.spacingUnit * 2}px;
+`;
+
+export const Details = styled.div.attrs<{ $isDetailed?: boolean }>(props => ({
+  className: props.$isDetailed ? grid({ s: 12, m: 6, l: 8, xl: 8 }) : '',
+}))<{ $isDetailed?: boolean }>``;
+
+export const DesktopLabel = styled(Space).attrs({
+  $v: { size: 's', properties: ['margin-bottom'] },
+})`
+  ${props => props.theme.media('medium', 'max-width')`
+      display: none;
+    `}
+`;
+
+export const MobileLabel = styled.div<{ $isDetailed?: boolean }>`
+  position: absolute;
+  bottom: 0;
+
+  ${props =>
+    props.$isDetailed
+      ? `
+        left: 18px;
+
+        ${props.theme.media('medium')`
+          display: none;
+        `}
+    `
+      : ``}
+`;

--- a/content/webapp/components/EventsSearchResults/index.tsx
+++ b/content/webapp/components/EventsSearchResults/index.tsx
@@ -1,0 +1,106 @@
+import { FunctionComponent } from 'react';
+import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
+import { font } from '@weco/common/utils/classnames';
+import PrismicImage, {
+  BreakpointSizes,
+} from '@weco/common/views/components/PrismicImage/PrismicImage';
+import { getCrop } from '@weco/common/model/image';
+import { EventDocument } from '@weco/content/services/wellcome/content/types/api';
+
+import linkResolver from '@weco/common/services/prismic/link-resolver';
+import { transformImage } from '@weco/common/services/prismic/transformers/images';
+import {
+  DesktopLabel,
+  Details,
+  EventWrapper,
+  EventsContainer,
+  ImageWrapper,
+  MobileLabel,
+} from './EventsSearchResults.styles';
+
+type Props = {
+  events: EventDocument[];
+  dynamicImageSizes?: BreakpointSizes;
+  isDetailed?: boolean;
+};
+
+const EventsSearchResults: FunctionComponent<Props> = ({
+  events,
+  dynamicImageSizes,
+  isDetailed,
+}: Props) => {
+  return (
+    <EventsContainer $isDetailed={isDetailed}>
+      {events.map(event => {
+        const image = transformImage(event.image);
+        const croppedImage = getCrop(image, isDetailed ? '16:9' : '32:15');
+
+        return (
+          <EventWrapper
+            key={event.id}
+            as="a"
+            href={linkResolver({ id: event.id, type: 'events' })}
+            $isDetailed={isDetailed}
+          >
+            {croppedImage && (
+              <ImageWrapper $isDetailed={isDetailed}>
+                <PrismicImage
+                  image={{
+                    // We intentionally omit the alt text on promos, so screen reader
+                    // users don't have to listen to the alt text before hearing the
+                    // title of the item in the list.
+                    //
+                    // See https://github.com/wellcomecollection/wellcomecollection.org/issues/6007
+                    ...croppedImage,
+                    alt: '',
+                  }}
+                  sizes={dynamicImageSizes}
+                  quality="low"
+                />
+                <MobileLabel $isDetailed={isDetailed}>
+                  <LabelsList labels={[{ text: event.format.label }]} />
+                </MobileLabel>
+              </ImageWrapper>
+            )}
+            <Details $isDetailed={isDetailed}>
+              {isDetailed && (
+                <DesktopLabel>
+                  <LabelsList labels={[{ text: event.format.label }]} />
+                </DesktopLabel>
+              )}
+
+              <h3 className={font('wb', 4)}>{event.title}</h3>
+
+              {/* {isDetailed &&
+                (event.publicationDate || !!event.contributors.length) && (
+                  <EventInformation>
+                    {event.publicationDate && (
+                      <EventInformationItem className="searchable-selector">
+                        <HTMLDate date={new Date(event.publicationDate)} />
+                      </EventInformationItem>
+                    )}
+                    {!!event.contributors.length && (
+                      <>
+                        <EventInformationItemSeparator>
+                          {' | '}
+                        </EventInformationItemSeparator>
+                        <EventInformationItem>
+                          {event.contributors.map(contributor => (
+                            <span key={contributor.contributor?.id}>
+                              {contributor.contributor?.label}
+                            </span>
+                          ))}
+                        </EventInformationItem>
+                      </>
+                    )}
+                  </EventInformation>
+                )} */}
+            </Details>
+          </EventWrapper>
+        );
+      })}
+    </EventsContainer>
+  );
+};
+
+export default EventsSearchResults;

--- a/content/webapp/components/SearchPageLayout/SearchNavigation.tsx
+++ b/content/webapp/components/SearchPageLayout/SearchNavigation.tsx
@@ -149,6 +149,11 @@ const SearchNavigation: FunctionComponent<SearchNavigationProps> = ({
             url: getURL('/search/works'),
             text: 'Catalogue',
           },
+          {
+            id: 'events',
+            url: getURL('/search/events'),
+            text: 'Events',
+          },
         ]}
         currentSection={currentSearchCategory}
       />

--- a/content/webapp/pages/search/events.tsx
+++ b/content/webapp/pages/search/events.tsx
@@ -6,9 +6,7 @@ import Pagination from '@weco/content/components/Pagination/Pagination';
 import SearchNoResults from '@weco/content/components/SearchNoResults/SearchNoResults';
 import Sort from '@weco/content/components/Sort/Sort';
 import PaginationWrapper from '@weco/common/views/components/styled/PaginationWrapper';
-import StoriesGrid from '@weco/content/components/StoriesGrid';
 import Space from '@weco/common/views/components/styled/Space';
-import SearchFilters from '@weco/content/components/SearchFilters';
 import { Container } from '@weco/common/views/components/styled/Container';
 import { NextPageWithLayout } from '@weco/common/views/pages/_app';
 import { serialiseProps } from '@weco/common/utils/json';
@@ -18,29 +16,27 @@ import { Pageview } from '@weco/common/services/conversion/track';
 import { pluralize } from '@weco/common/utils/grammar';
 import {
   getQueryPropertyValue,
-  linkResolver,
   SEARCH_PAGES_FORM_ID,
 } from '@weco/common/utils/search';
-import { getActiveFiltersLabel, hasFilters } from '@weco/content/utils/search';
-import { getArticles } from '@weco/content/services/wellcome/content/articles';
 import { cacheTTL, setCacheControl } from '@weco/content/utils/setCacheControl';
 import { looksLikeSpam } from '@weco/content/utils/spam-detector';
 import { Query } from '@weco/content/types/search';
 import {
-  Article,
   ContentResultsList,
+  EventDocument,
 } from '@weco/content/services/wellcome/content/types/api';
 import { emptyResultList } from '@weco/content/services/wellcome';
 import { ApiToolbarLink } from '@weco/common/views/components/ApiToolbar';
-import { fromQuery, StoriesProps } from '@weco/content/components/StoriesLink';
-import { storiesFilters } from '@weco/content/services/wellcome/catalogue/filters';
+import { fromQuery, EventsProps } from '@weco/content/components/EventsLink';
+import { getEvents } from 'services/wellcome/content/events';
+import EventsSearchResults from 'components/EventsSearchResults';
 
 type Props = {
-  storyResponseList: ContentResultsList<Article>;
+  eventResponseList: ContentResultsList<EventDocument>;
   query: Query;
   pageview: Pageview;
   apiToolbarLinks: ApiToolbarLink[];
-  storiesRouteProps: StoriesProps;
+  eventsRouteProps: EventsProps;
 };
 
 const Wrapper = styled(Space)`
@@ -58,25 +54,13 @@ const SortPaginationWrapper = styled.div`
   `}
 `;
 
-export const StoriesSearchPage: NextPageWithLayout<Props> = ({
-  storyResponseList,
+export const EventsSearchPage: NextPageWithLayout<Props> = ({
+  eventResponseList,
   query,
-  storiesRouteProps,
 }) => {
   const { query: queryString } = query;
 
-  const filters = storiesFilters({
-    stories: storyResponseList,
-    props: storiesRouteProps,
-  });
-
-  const hasNoResults = storyResponseList.totalResults === 0;
-  const hasActiveFilters = hasFilters({
-    filters: filters.map(f => f.id),
-    queryParams: Object.keys(query),
-  });
-
-  const activeFiltersLabels = getActiveFiltersLabel({ filters });
+  const hasNoResults = eventResponseList.totalResults === 0;
 
   const sortOptions = [
     // Default value to be left empty as to not be reflected in URL query
@@ -96,55 +80,17 @@ export const StoriesSearchPage: NextPageWithLayout<Props> = ({
 
   return (
     <Space $v={{ size: 'l', properties: ['padding-bottom'] }}>
-      {(!hasNoResults || (hasNoResults && hasActiveFilters)) && (
-        <>
-          <Container>
-            <Space
-              $v={{ size: 'l', properties: ['padding-top', 'padding-bottom'] }}
-            >
-              <SearchFilters
-                query={queryString}
-                linkResolver={params =>
-                  linkResolver({ params, pathname: '/search/stories' })
-                }
-                searchFormId={SEARCH_PAGES_FORM_ID}
-                changeHandler={() => {
-                  const form = document.getElementById(SEARCH_PAGES_FORM_ID);
-                  form &&
-                    form.dispatchEvent(
-                      new window.Event('submit', {
-                        cancelable: true,
-                        bubbles: true,
-                      })
-                    );
-                }}
-                filters={filters}
-                hasNoResults={hasNoResults}
-              />
-            </Space>
-          </Container>
-        </>
-      )}
-      {storyResponseList && (
+      {eventResponseList && (
         <Wrapper>
           {hasNoResults ? (
             <Container>
-              <SearchNoResults
-                query={queryString}
-                hasFilters={hasActiveFilters}
-              />
+              <SearchNoResults query={queryString} />
             </Container>
           ) : (
             <Container>
               <PaginationWrapper $verticalSpacing="l">
                 <span role="status">
-                  {pluralize(storyResponseList.totalResults, 'result')}
-                  {activeFiltersLabels.length > 0 && (
-                    <span className="visually-hidden">
-                      {' '}
-                      filtered with: {activeFiltersLabels.join(', ')}
-                    </span>
-                  )}
+                  {pluralize(eventResponseList.totalResults, 'result')}
                 </span>
 
                 <SortPaginationWrapper>
@@ -174,22 +120,21 @@ export const StoriesSearchPage: NextPageWithLayout<Props> = ({
                   />
                   <Pagination
                     formId={SEARCH_PAGES_FORM_ID}
-                    totalPages={storyResponseList.totalPages}
-                    ariaLabel="Stories search pagination"
+                    totalPages={eventResponseList.totalPages}
+                    ariaLabel="Events search pagination"
                     isHiddenMobile
                   />
                 </SortPaginationWrapper>
               </PaginationWrapper>
 
               <main>
-                <StoriesGrid
-                  isDetailed
-                  articles={storyResponseList.results}
+                <EventsSearchResults
+                  events={eventResponseList.results}
                   dynamicImageSizes={{
                     xlarge: 1 / 5,
                     large: 1 / 5,
-                    medium: 1 / 5,
-                    small: 1,
+                    medium: 1 / 2,
+                    small: 1 / 2,
                   }}
                 />
               </main>
@@ -197,8 +142,8 @@ export const StoriesSearchPage: NextPageWithLayout<Props> = ({
               <PaginationWrapper $verticalSpacing="l" $alignRight>
                 <Pagination
                   formId={SEARCH_PAGES_FORM_ID}
-                  totalPages={storyResponseList.totalPages}
-                  ariaLabel="Stories search pagination"
+                  totalPages={eventResponseList.totalPages}
+                  ariaLabel="Events search pagination"
                 />
               </PaginationWrapper>
             </Container>
@@ -209,7 +154,7 @@ export const StoriesSearchPage: NextPageWithLayout<Props> = ({
   );
 };
 
-StoriesSearchPage.getLayout = getSearchLayout;
+EventsSearchPage.getLayout = getSearchLayout;
 
 export const getServerSideProps: GetServerSideProps<
   Props | AppErrorProps
@@ -219,7 +164,7 @@ export const getServerSideProps: GetServerSideProps<
   const query = context.query;
   const params = fromQuery(query);
   const defaultProps = serialiseProps({
-    storiesRouteProps: params,
+    eventsRouteProps: params,
     serverData,
     query,
   });
@@ -237,9 +182,9 @@ export const getServerSideProps: GetServerSideProps<
     return {
       props: serialiseProps({
         ...defaultProps,
-        storyResponseList: emptyResultList(),
+        eventResponseList: emptyResultList(),
         pageview: {
-          name: 'stories',
+          name: 'events',
           properties: {
             looksLikeSpam: 'true',
           },
@@ -254,41 +199,40 @@ export const getServerSideProps: GetServerSideProps<
   const { page, ...restOfQuery } = query;
   const pageNumber = page !== '1' && getQueryPropertyValue(page);
 
-  const storyResponseList = await getArticles({
+  const eventResponseList = await getEvents({
     params: {
       ...restOfQuery,
-      sort: getQueryPropertyValue(query.sort),
-      sortOrder: getQueryPropertyValue(query.sortOrder),
+      // sort: getQueryPropertyValue(query.sort),
+      // sortOrder: getQueryPropertyValue(query.sortOrder),
       ...(pageNumber && { page: Number(pageNumber) }),
-      aggregations: ['format', 'contributors.contributor'],
     },
     pageSize: 25,
     toggles: serverData.toggles,
   });
 
-  if (storyResponseList?.type === 'Error') {
-    return appError(context, storyResponseList.httpStatus, 'Content API error');
+  if (eventResponseList?.type === 'Error') {
+    return appError(context, eventResponseList.httpStatus, 'Content API error');
   }
 
   return {
     props: serialiseProps({
       ...defaultProps,
-      storyResponseList,
+      eventResponseList,
       pageview: {
-        name: 'stories',
+        name: 'events',
         properties: {
-          totalResults: storyResponseList?.totalResults ?? 0,
+          totalResults: eventResponseList?.totalResults ?? 0,
         },
       },
       apiToolbarLinks: [
         {
           id: 'content-api',
           label: 'Content API query',
-          link: storyResponseList._requestUrl,
+          link: eventResponseList._requestUrl,
         },
       ],
     }),
   };
 };
 
-export default StoriesSearchPage;
+export default EventsSearchPage;

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -8,6 +8,7 @@ import SearchNoResults from '@weco/content/components/SearchNoResults/SearchNoRe
 import StoriesGrid from '@weco/content/components/StoriesGrid';
 import ImageEndpointSearchResults from '@weco/content/components/ImageEndpointSearchResults/ImageEndpointSearchResults';
 import WorksSearchResults from '@weco/content/components/WorksSearchResults/WorksSearchResults';
+import EventsSearchResults from '@weco/content/components/EventsSearchResults';
 import MoreLink from '@weco/content/components/MoreLink/MoreLink';
 import { Container } from '@weco/common/views/components/styled/Container';
 import { getSearchLayout } from '@weco/content/components/SearchPageLayout/SearchPageLayout';
@@ -38,9 +39,11 @@ import {
 import theme from '@weco/common/views/themes/default';
 import { formatNumber } from '@weco/common/utils/grammar';
 import { getArticles } from '@weco/content/services/wellcome/content/articles';
+import { getEvents } from '@weco/content/services/wellcome/content/events';
 import {
   Article,
   ContentResultsList,
+  EventDocument,
 } from '@weco/content/services/wellcome/content/types/api';
 import { WellcomeApiError } from '@weco/content/services/wellcome';
 import { cacheTTL, setCacheControl } from '@weco/content/utils/setCacheControl';
@@ -59,6 +62,7 @@ type Props = {
   works?: ReturnedResults<WorkBasic>;
   images?: ReturnedResults<Image>;
   stories?: ReturnedResults<Article>;
+  events?: ReturnedResults<EventDocument>;
   query: Query;
   pageview: Pageview;
 };
@@ -69,22 +73,23 @@ type SeeMoreButtonProps = {
   totalResults: number;
 };
 
-const StoriesSection = styled(Space).attrs({
+const BasicSection = styled(Space).attrs({
+  as: 'section',
   $v: { size: 'xl', properties: ['padding-top', 'padding-bottom'] },
-})`
+})``;
+
+const StoriesSection = styled(BasicSection)`
   background-color: ${props => props.theme.color('neutral.200')};
 `;
 
-const ImagesSection = styled(Space).attrs({
-  $v: { size: 'xl', properties: ['padding-top', 'padding-bottom'] },
-})`
+const ImagesSection = styled(BasicSection)`
   background-color: ${props => props.theme.color('black')};
   color: ${props => props.theme.color('white')};
 `;
 
-const WorksSection = styled(Space).attrs({
-  $v: { size: 'xl', properties: ['padding-top', 'padding-bottom'] },
-})``;
+const EventsSection = styled(BasicSection)`
+  background-color: ${props => props.theme.color('neutral.200')};
+`;
 
 const SectionTitle = ({ sectionName }: { sectionName: string }) => {
   return (
@@ -132,6 +137,7 @@ export const SearchPage: NextPageWithLayout<Props> = ({
   works,
   images,
   stories,
+  events,
   query,
 }) => {
   const { query: queryString } = query;
@@ -181,7 +187,7 @@ export const SearchPage: NextPageWithLayout<Props> = ({
         ) : (
           <>
             {stories && (
-              <StoriesSection as="section">
+              <StoriesSection>
                 <Container>
                   <SectionTitle sectionName="Stories" />
                 </Container>
@@ -227,7 +233,7 @@ export const SearchPage: NextPageWithLayout<Props> = ({
             )}
 
             {works && (
-              <WorksSection>
+              <BasicSection>
                 <Container>
                   <SectionTitle sectionName="Catalogue" />
 
@@ -241,7 +247,33 @@ export const SearchPage: NextPageWithLayout<Props> = ({
                     />
                   </Space>
                 </Container>
-              </WorksSection>
+              </BasicSection>
+            )}
+
+            {events && (
+              <EventsSection>
+                <Container>
+                  <SectionTitle sectionName="Events" />
+
+                  <EventsSearchResults
+                    events={events.pageResults}
+                    dynamicImageSizes={{
+                      xlarge: 1 / 5,
+                      large: 1 / 5,
+                      medium: 1 / 2,
+                      small: 1 / 2,
+                    }}
+                  />
+
+                  <Space $v={{ size: 'l', properties: ['padding-top'] }}>
+                    <SeeMoreButton
+                      text="All events"
+                      pathname="/search/events"
+                      totalResults={200} // TODO
+                    />
+                  </Space>
+                </Container>
+              </EventsSection>
             )}
           </>
         )}
@@ -295,8 +327,26 @@ export const getServerSideProps: GetServerSideProps<
   }
 
   try {
+    // Events
+    const eventsResults = await getEvents({
+      params: {
+        ...query,
+        sort: getQueryPropertyValue(query.sort),
+        sortOrder: getQueryPropertyValue(query.sortOrder),
+      },
+      pageSize: 4,
+      toggles: serverData.toggles,
+    });
+
+    const events = getQueryResults({
+      categoryName: 'events',
+      queryResults: eventsResults as
+        | ContentResultsList<EventDocument>
+        | WellcomeApiError,
+    });
+
     // Stories
-    // We want the default order to be "descending publication date" with the Prismic API
+    // We want the default order to be "descending publication date" with the Content API
 
     const storiesResults = await getArticles({
       params: {
@@ -341,7 +391,8 @@ export const getServerSideProps: GetServerSideProps<
     if (
       imagesResults.type === 'Error' &&
       worksResults.type === 'Error' &&
-      storiesResults.type === 'Error'
+      storiesResults.type === 'Error' &&
+      eventsResults.type === 'Error'
     ) {
       // Use the error from the works API as it is the most mature of the 3
       return appError(
@@ -356,6 +407,7 @@ export const getServerSideProps: GetServerSideProps<
         ...defaultProps,
         ...(stories && stories.pageResults?.length && { stories }),
         ...(images?.pageResults.length && { images }),
+        ...(events?.pageResults.length && { events }),
         works:
           works && works.pageResults.length
             ? {

--- a/content/webapp/services/prismic/types/images.mocks.ts
+++ b/content/webapp/services/prismic/types/images.mocks.ts
@@ -1,10 +1,28 @@
+// TODO review ID and EDIT fields.
+// These are new properties that are expected but not yet being returned?
+// https://github.com/prismicio/prismic-client/pull/326
+// Can't find them in documentation yet
 export const imageWithCrops = {
+  id: 'abc',
+  edit: {
+    x: 0,
+    y: 0,
+    zoom: 0,
+    background: '',
+  },
   dimensions: { width: 4000, height: 3232 },
   alt: 'Photograph of an exhibition gallery wall, square on. The wall is a light pink colour and contains a central panel which is set forward from the way, upon which a large colourful old painting is hung. The painting depicts a family portrait with a mother figure a father figure and a young child. At the base of the wall, under the painting is a low white barrier to prevent visitors from getting too close. In front of the painting, standing with their backs to the camera are 3 young people looking at the painting. One stands alone on the left hand side and the other 2 stand together on the right. Either side of the main painting, further small pen and ink artworks can be seen, framed in brown wooden frames.',
   copyright:
     'Joy exhibition | Painting: © Joy Labinjo. Gallery Photo: Steven Pocock | | | CC-BY-NC | |',
   url: 'https://images.prismic.io/wellcomecollection/ce3d3529-53f5-401d-a011-0d444bae99cd_EP_001514_055.jpg?auto=compress,format',
   '32:15': {
+    id: 'bcd',
+    edit: {
+      x: 0,
+      y: 0,
+      zoom: 0,
+      background: '',
+    },
     dimensions: { width: 3200, height: 1500 },
     alt: 'Photograph of an exhibition gallery wall, square on. The wall is a light pink colour and contains a central panel which is set forward from the way, upon which a large colourful old painting is hung. The painting depicts a family portrait with a mother figure a father figure and a young child. At the base of the wall, under the painting is a low white barrier to prevent visitors from getting too close. In front of the painting, standing with their backs to the camera are 3 young people looking at the painting. One stands alone on the left hand side and the other 2 stand together on the right. Either side of the main painting, further small pen and ink artworks can be seen, framed in brown wooden frames.',
     copyright:
@@ -12,6 +30,13 @@ export const imageWithCrops = {
     url: 'https://images.prismic.io/wellcomecollection/ce3d3529-53f5-401d-a011-0d444bae99cd_EP_001514_055.jpg?auto=compress,format&rect=0,487,4000,1875&w=3200&h=1500',
   },
   '16:9': {
+    id: 'cde',
+    edit: {
+      x: 0,
+      y: 0,
+      zoom: 0,
+      background: '',
+    },
     dimensions: { width: 3200, height: 1800 },
     alt: 'Photograph of an exhibition gallery wall, square on. The wall is a light pink colour and contains a central panel which is set forward from the way, upon which a large colourful old painting is hung. The painting depicts a family portrait with a mother figure a father figure and a young child. At the base of the wall, under the painting is a low white barrier to prevent visitors from getting too close. In front of the painting, standing with their backs to the camera are 3 young people looking at the painting. One stands alone on the left hand side and the other 2 stand together on the right. Either side of the main painting, further small pen and ink artworks can be seen, framed in brown wooden frames.',
     copyright:
@@ -19,6 +44,13 @@ export const imageWithCrops = {
     url: 'https://images.prismic.io/wellcomecollection/ce3d3529-53f5-401d-a011-0d444bae99cd_EP_001514_055.jpg?auto=compress,format&rect=0,394,4000,2250&w=3200&h=1800',
   },
   square: {
+    id: 'def',
+    edit: {
+      x: 0,
+      y: 0,
+      zoom: 0,
+      background: '',
+    },
     dimensions: { width: 3200, height: 3200 },
     alt: 'Photograph of an exhibition gallery wall, square on. The wall is a light pink colour and contains a central panel which is set forward from the way, upon which a large colourful old painting is hung. The painting depicts a family portrait with a mother figure a father figure and a young child. At the base of the wall, under the painting is a low white barrier to prevent visitors from getting too close. In front of the painting, standing with their backs to the camera are 3 young people looking at the painting. One stands alone on the left hand side and the other 2 stand together on the right. Either side of the main painting, further small pen and ink artworks can be seen, framed in brown wooden frames.',
     copyright:
@@ -28,6 +60,13 @@ export const imageWithCrops = {
 };
 
 export const imageWithoutCrops = {
+  id: 'edg',
+  edit: {
+    x: 0,
+    y: 0,
+    zoom: 0,
+    background: '',
+  },
   dimensions: { width: 4000, height: 3232 },
   alt: 'Photograph of an exhibition gallery wall, square on. The wall is a light pink colour and contains a central panel which is set forward from the way, upon which a large colourful old painting is hung. The painting depicts a family portrait with a mother figure a father figure and a young child. At the base of the wall, under the painting is a low white barrier to prevent visitors from getting too close. In front of the painting, standing with their backs to the camera are 3 young people looking at the painting. One stands alone on the left hand side and the other 2 stand together on the right. Either side of the main painting, further small pen and ink artworks can be seen, framed in brown wooden frames.',
   copyright:

--- a/content/webapp/services/wellcome/content/articles.ts
+++ b/content/webapp/services/wellcome/content/articles.ts
@@ -9,7 +9,10 @@ import { QueryProps, WellcomeApiError } from '..';
 export async function getArticles(
   props: QueryProps<ContentApiProps>
 ): Promise<ContentResultsList<Article> | WellcomeApiError> {
-  const getArticlesResult = await contentQuery('articles', props);
+  const getArticlesResult = await contentQuery<ContentApiProps, Article>(
+    'articles',
+    props
+  );
 
   return getArticlesResult;
 }

--- a/content/webapp/services/wellcome/content/events.ts
+++ b/content/webapp/services/wellcome/content/events.ts
@@ -1,0 +1,170 @@
+import { EventDocument } from './types/api';
+import {
+  ContentApiProps,
+  ContentResultsList,
+} from '@weco/content/services/wellcome/content/types/api';
+// import { contentQuery } from '.';
+import { QueryProps, WellcomeApiError } from '..';
+
+export async function getEvents(
+  props: QueryProps<ContentApiProps>
+): Promise<ContentResultsList<EventDocument> | WellcomeApiError> {
+  // const getEventsResult = await contentQuery<ContentApiProps, EventDocument>(
+  //   'events',
+  //   props
+  // );
+  // return getEventsResult;
+  console.log({ props });
+  return {
+    type: 'ResultList',
+    totalResults: 200,
+    totalPages: 10,
+    results: [
+      {
+        type: 'Event',
+        format: {
+          id: 'W5fV5iYAACQAMxHb',
+          label: 'Festival',
+          type: 'EventFormat',
+        },
+        id: 'ZFt0WhQAAHnPEH7P',
+        image: {
+          '16:9': {
+            alt: 'Photograph of a farmer getting ready to harvest his organic crop of native Ragi in Kariyappanadoddi, India. Behind him are hills and a small single storey building. Interwoven into the scene is a graphic element made up of thin red drawn circular lines, which create a larger organic pattern behind the farmer.',
+            copyright:
+              'Farmer Basavaraj in Kariyappanadoddi inspects his ragi crop before harvesting near Bannerghatta, India | | | | | Quicksand |',
+            dimensions: {
+              height: 1800,
+              width: 3200,
+            },
+            url: 'https://images.prismic.io/wellcomecollection/0793d963-8807-4525-a3d7-e77fa4435baa_LBE+Key+Image+04.jpg?auto=compress,format&rect=0,0,4000,2250&w=3200&h=1800',
+          },
+          '32:15': {
+            alt: 'Photograph of a farmer getting ready to harvest his organic crop of native Ragi in Kariyappanadoddi, India. Behind him are hills and a small single storey building. Interwoven into the scene is a graphic element made up of thin red drawn circular lines, which create a larger organic pattern behind the farmer.',
+            copyright:
+              'Farmer Basavaraj in Kariyappanadoddi inspects his ragi crop before harvesting near Bannerghatta, India | | | | | Quicksand |',
+            dimensions: {
+              height: 1500,
+              width: 3200,
+            },
+            url: 'https://images.prismic.io/wellcomecollection/0793d963-8807-4525-a3d7-e77fa4435baa_LBE+Key+Image+04.jpg?auto=compress,format&rect=0,232,4000,1875&w=3200&h=1500',
+          },
+          alt: 'Photograph of a farmer getting ready to harvest his organic crop of native Ragi in Kariyappanadoddi, India. Behind him are hills and a small single storey building. Interwoven into the scene is a graphic element made up of thin red drawn circular lines, which create a larger organic pattern behind the farmer.',
+          copyright:
+            'Farmer Basavaraj in Kariyappanadoddi inspects his ragi crop before harvesting near Bannerghatta, India | | | | | Quicksand |',
+          dimensions: {
+            height: 2250,
+            width: 4000,
+          },
+          square: {
+            alt: 'Photograph of a farmer getting ready to harvest his organic crop of native Ragi in Kariyappanadoddi, India. Behind him are hills and a small single storey building. Interwoven into the scene is a graphic element made up of thin red drawn circular lines, which create a larger organic pattern behind the farmer.',
+            copyright:
+              'Farmer Basavaraj in Kariyappanadoddi inspects his ragi crop before harvesting near Bannerghatta, India | | | | | Quicksand |',
+            dimensions: {
+              height: 3200,
+              width: 3200,
+            },
+            url: 'https://images.prismic.io/wellcomecollection/0793d963-8807-4525-a3d7-e77fa4435baa_LBE+Key+Image+04.jpg?auto=compress,format&rect=1202,0,2250,2250&w=3200&h=3200',
+          },
+          type: 'PrismicImage',
+          url: 'https://images.prismic.io/wellcomecollection/0793d963-8807-4525-a3d7-e77fa4435baa_LBE+Key+Image+04.jpg?auto=compress,format',
+        },
+        interpretations: [],
+        locations: [
+          {
+            id: 'XEnJIhUAAArdgVsW',
+            label: 'Throughout our building',
+            type: 'EventLocation',
+          },
+          {
+            id: 'ef04c8e3-26be-4fbc-9bef-f52589ebc56c',
+            label: 'Online',
+            type: 'EventLocation',
+          },
+        ],
+        times: [
+          {
+            endDateTime: new Date(),
+            startDateTime: new Date(),
+          },
+        ],
+        title: 'Land Body Ecologies Festival Day Two',
+      },
+      {
+        type: 'Event',
+        format: {
+          id: 'WmYRpCQAACUAn-Ap',
+          label: 'Gallery tour',
+          type: 'EventFormat',
+        },
+        id: 'ZJLZoRAAACIARz42',
+        image: {
+          '16:9': {
+            alt: "Photograph of an art installation in gallery space. It's a dark space with black glossy floors and walls. A large parachute suspended from the ceiling which is lit with vibrant pink and orange light. Two visitors are looking at the instillation.",
+            copyright:
+              'From the Collection: For What It’s Worth, 2023. Jess Dobkin |  Gallery photo: Steven Pocock | | | CC-BY-NC | |',
+            dimensions: {
+              height: 1800,
+              width: 3200,
+            },
+            url: 'https://images.prismic.io/wellcomecollection/3e1ef5ca-cf7f-40e5-b1dc-0730a5e11225_EP_002225_007-full.jpg?auto=compress,format&rect=0,0,4000,2250&w=3200&h=1800',
+          },
+          '32:15': {
+            alt: "Photograph of an art installation in gallery space. It's a dark space with black glossy floors and walls. A large parachute suspended from the ceiling which is lit with vibrant pink and orange light. Two visitors are looking at the instillation.",
+            copyright:
+              'From the Collection: For What It’s Worth, 2023. Jess Dobkin |  Gallery photo: Steven Pocock | | | CC-BY-NC | |',
+            dimensions: {
+              height: 1500,
+              width: 3200,
+            },
+            url: 'https://images.prismic.io/wellcomecollection/3e1ef5ca-cf7f-40e5-b1dc-0730a5e11225_EP_002225_007-full.jpg?auto=compress,format&rect=0,188,4000,1875&w=3200&h=1500',
+          },
+          alt: "Photograph of an art installation in gallery space. It's a dark space with black glossy floors and walls. A large parachute suspended from the ceiling which is lit with vibrant pink and orange light. Two visitors are looking at the instillation.",
+          copyright:
+            'From the Collection: For What It’s Worth, 2023. Jess Dobkin |  Gallery photo: Steven Pocock | | | CC-BY-NC | |',
+          dimensions: {
+            height: 2250,
+            width: 4000,
+          },
+          square: {
+            alt: "Photograph of an art installation in gallery space. It's a dark space with black glossy floors and walls. A large parachute suspended from the ceiling which is lit with vibrant pink and orange light. Two visitors are looking at the instillation.",
+            copyright:
+              'From the Collection: For What It’s Worth, 2023. Jess Dobkin |  Gallery photo: Steven Pocock | | | CC-BY-NC | |',
+            dimensions: {
+              height: 3200,
+              width: 3200,
+            },
+            url: 'https://images.prismic.io/wellcomecollection/3e1ef5ca-cf7f-40e5-b1dc-0730a5e11225_EP_002225_007-full.jpg?auto=compress,format&rect=1361,0,2250,2250&w=3200&h=3200',
+          },
+          type: 'PrismicImage',
+          url: 'https://images.prismic.io/wellcomecollection/3e1ef5ca-cf7f-40e5-b1dc-0730a5e11225_EP_002225_007-full.jpg?auto=compress,format',
+        },
+        interpretations: [
+          {
+            id: 'XkFGqxEAACIAIhNH',
+            label: 'British Sign Language',
+            type: 'EventInterpretation',
+          },
+        ],
+        locations: [
+          {
+            id: 'W22bICkAACgA-hVJ',
+            label: 'Information Point',
+            type: 'EventLocation',
+          },
+        ],
+        times: [
+          {
+            endDateTime: new Date(),
+            startDateTime: new Date(),
+          },
+        ],
+        title: 'Perspective Tour With Jess Dobkin',
+      },
+    ],
+    pageSize: 6,
+    prevPage: null,
+    nextPage: null,
+    _requestUrl: '',
+  };
+}

--- a/content/webapp/services/wellcome/content/types/api.ts
+++ b/content/webapp/services/wellcome/content/types/api.ts
@@ -1,6 +1,7 @@
 import { ArticleFormatId } from '@weco/content/data/content-format-ids';
 import * as prismic from '@prismicio/client';
 import { WellcomeAggregation, WellcomeResultList } from '../../index';
+import { ContentApiImage } from '.';
 
 export type ContentApiProps = {
   query?: string;
@@ -10,6 +11,7 @@ export type ContentApiProps = {
   aggregations?: string[];
 };
 
+// Articles
 export type ArticleFormat = {
   type: 'ArticleFormat';
   id: ArticleFormatId;
@@ -17,14 +19,44 @@ export type ArticleFormat = {
 };
 
 export type Article = {
+  type: 'Article';
   id: string;
   title: string;
   publicationDate: string;
   contributors: Contributor[];
   format: ArticleFormat;
-  image?: prismic.EmptyImageFieldImage | prismic.FilledImageFieldImage;
+  image?: prismic.EmptyImageFieldImage | prismic.FilledImageFieldImage; // TODO change to ContentApiImage
   caption?: string;
-  type: 'Article';
+};
+
+// Event Documents
+export type EventDocumentFormat = {
+  type: 'EventFormat';
+  id: string;
+  label: string;
+};
+
+export type EventDocumentLocation = {
+  type: 'EventLocation';
+  id: string;
+  label?: string;
+};
+
+export type EventDocumentInterpretation = {
+  type: 'EventInterpretation';
+  id: string;
+  label?: string;
+};
+
+export type EventDocument = {
+  type: 'Event';
+  id: string;
+  title: string;
+  image?: ContentApiImage;
+  times: { startDateTime?: Date; endDateTime?: Date }[];
+  format: EventDocumentFormat;
+  locations: EventDocumentLocation[];
+  interpretations: EventDocumentInterpretation[];
 };
 
 // Contributors (e.g. author, photographer)
@@ -43,13 +75,16 @@ type Contributor = {
   };
 };
 
-export type ArticleAggregations = {
+type BasicAggregations = {
   format: WellcomeAggregation;
-  'contributors.contributor': WellcomeAggregation;
   type: 'Aggregations';
 };
 
-export type ResultType = Article;
+export type ArticleAggregations = BasicAggregations & {
+  'contributors.contributor': WellcomeAggregation;
+};
+
+export type ResultType = Article | EventDocument;
 
 export type ContentResultsList<Result extends ResultType> = WellcomeResultList<
   Result,

--- a/content/webapp/services/wellcome/content/types/index.ts
+++ b/content/webapp/services/wellcome/content/types/index.ts
@@ -1,4 +1,4 @@
-import { DigitalLocation, Contributor } from '@weco/common/model/catalogue';
+import { ImageDimensions } from '@weco/common/model/image';
 import { ArticleAggregations } from './api';
 
 export type { ArticleAggregations };
@@ -12,16 +12,20 @@ export type ContentApiError = {
   type: 'Error';
 };
 
-export type Image = {
-  type: 'Image';
-  id: string;
-  locations: DigitalLocation[];
-  source: {
-    id: string;
-    title: string;
-    contributors?: Contributor[];
-    type: string;
-  };
-  withSimilarFeatures?: Image[];
-  aspectRatio?: number;
+export type ContentApiCroppedImage = {
+  alt: string;
+  copyright: string;
+  url: string;
+  dimensions: ImageDimensions;
+};
+
+export type ContentApiImage = {
+  type: 'PrismicImage';
+  alt: string;
+  copyright: string;
+  url: string;
+  dimensions: ImageDimensions;
+  square: ContentApiCroppedImage;
+  '32:15': ContentApiCroppedImage;
+  '16:9': ContentApiCroppedImage;
 };

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -68,6 +68,14 @@ const toggles = {
         'Adds tabbed navigation to the works page, for switching between work, item and related content',
       type: 'experimental',
     },
+    {
+      id: 'eventsSearch',
+      title: 'Add Events to Search pages',
+      initialValue: false,
+      description:
+        'Adds an Events section to the Search hub and a new Events tab for more specific searches',
+      type: 'experimental',
+    },
   ] as const,
   tests: [] as ABTest[],
 };


### PR DESCRIPTION
## Who is this for?
Events in Search

## What is it doing for them?
- Adds a toggle
- Adds Events tab and page to search, as well as an Events section in the overview
- Make services more flexible and less Article-centric


Very much a WIP.