### PR TITLE
Account for new fields in Prismic filled image type

### DIFF
--- a/common/services/prismic/transformers/images.ts
+++ b/common/services/prismic/transformers/images.ts
@@ -2,19 +2,20 @@ import * as prismic from '@prismicio/client';
 import { ImageType } from '@weco/common/model/image';
 import { isUndefined } from '@weco/common/utils/type-guards';
 import { transformTaslFromString } from '.';
+import { CustomPrismicFilledImage } from '../types';
 
 // when images have crops, event if the image isn't attached, we get e.g.
 // { '32:15': {}, '16:9': {}, square: {} }
 function isImageLink(
-  maybeImage: prismic.EmptyImageFieldImage | prismic.FilledImageFieldImage
-): maybeImage is prismic.FilledImageFieldImage {
+  maybeImage: prismic.EmptyImageFieldImage | CustomPrismicFilledImage
+): maybeImage is CustomPrismicFilledImage {
   return Boolean(maybeImage && maybeImage.dimensions);
 }
 
 export function transformImage(
   maybeImage:
     | prismic.EmptyImageFieldImage
-    | prismic.FilledImageFieldImage
+    | CustomPrismicFilledImage
     | undefined
 ): ImageType | undefined {
   return maybeImage && isImageLink(maybeImage)
@@ -30,7 +31,7 @@ function startsWith(s: string, prefix: string): boolean {
 }
 
 // We don't export this, as we probably always want to check ^ first
-function transformFilledImage(image: prismic.FilledImageFieldImage): ImageType {
+function transformFilledImage(image: CustomPrismicFilledImage): ImageType {
   const tasl = transformTaslFromString(image.copyright);
   const crops = Object.keys(image)
     .filter(key => prismicImageProps.indexOf(key) === -1)

--- a/common/services/prismic/types/index.ts
+++ b/common/services/prismic/types/index.ts
@@ -31,6 +31,13 @@ export type PaginatedResults<T> = {
   totalPages: number;
 };
 
+// https://github.com/prismicio/prismic-client/pull/326
+// These are new properties that are expected but not documented for yet or returned
+export type CustomPrismicFilledImage = Omit<
+  prismic.FilledImageFieldImage,
+  'id' | 'edit'
+>;
+
 // Guards
 export function isFilledLinkToDocument<T, L, D extends DataInterface>(
   field: prismic.ContentRelationshipField<T, L, D> | undefined

--- a/content/webapp/services/prismic/types/index.ts
+++ b/content/webapp/services/prismic/types/index.ts
@@ -10,7 +10,9 @@ import { SeasonPrismicDocument } from './seasons';
 import {
   isFilledLinkToDocumentWithData,
   InferDataInterface,
+  CustomPrismicFilledImage,
 } from '@weco/common/services/prismic/types';
+import { ImageDimensions } from '@weco/common/model/image';
 export type InferCustomType<T> = T extends prismic.PrismicDocument<
   /* eslint-disable @typescript-eslint/no-explicit-any */
   any,
@@ -44,15 +46,10 @@ export type FetchLinks<T extends prismic.PrismicDocument> = {
     : never;
 }[keyof InferDataInterface<T>][];
 
-type Dimension = {
-  width: number;
-  height: number;
-};
-
 // Currently the Prismic types only allow you to specify 1 image
-type ThumbnailedImageField<Thumbnails extends Record<string, Dimension>> =
-  prismic.FilledImageFieldImage & {
-    [Property in keyof Thumbnails]?: prismic.FilledImageFieldImage;
+type ThumbnailedImageField<Thumbnails extends Record<string, ImageDimensions>> =
+  CustomPrismicFilledImage & {
+    [Property in keyof Thumbnails]?: CustomPrismicFilledImage;
   };
 
 export type Image = ThumbnailedImageField<{

--- a/content/webapp/services/wellcome/content/types/api.ts
+++ b/content/webapp/services/wellcome/content/types/api.ts
@@ -1,6 +1,10 @@
 import { ArticleFormatId } from '@weco/content/data/content-format-ids';
 import * as prismic from '@prismicio/client';
-import { WellcomeAggregation, WellcomeResultList } from '../../index';
+import {
+  WellcomeAggregation,
+  WellcomeResultList,
+} from '@weco/content/services/wellcome';
+import { CustomPrismicFilledImage } from '@weco/common/services/prismic/types';
 
 export type ContentApiProps = {
   query?: string;
@@ -22,7 +26,7 @@ export type Article = {
   publicationDate: string;
   contributors: Contributor[];
   format: ArticleFormat;
-  image?: prismic.EmptyImageFieldImage | prismic.FilledImageFieldImage;
+  image?: prismic.EmptyImageFieldImage | CustomPrismicFilledImage;
   caption?: string;
   type: 'Article';
 };


### PR DESCRIPTION
## Who is this for?
Devs, TS

## What is it doing for them?
From `7.3.0`, Prismic's type for FilledImage has two new keys that aren't documented for at all yet.
This breaks our tests and anything using mock data, and we don't want to add random data in those fields as it's unclear what they are for. So we chose to Omit them. I thought about Picking instead but I think for now it's quite readable... Opinions welcomed.
See https://github.com/prismicio/prismic-client/pull/326
[See Slack convo](https://wellcome.slack.com/archives/C02ANCYL90E/p1701096253351109)
