### PR TITLE
Readd missing prop from Th in stacking table

### DIFF
--- a/common/views/components/StackingTable/StackingTable.tsx
+++ b/common/views/components/StackingTable/StackingTable.tsx
@@ -52,6 +52,7 @@ const StyledTr = styled(Space).attrs({
 type ThProps = {
   $plain?: boolean;
   $maxWidth?: number;
+  width?: number;
 };
 
 const StyledTh = styled(Space).attrs<ThProps>(props => ({
@@ -141,7 +142,12 @@ const StackingTable: FunctionComponent<Props> = ({
       <thead>
         <tr>
           {headerRow.map((data, index) => (
-            <StyledTh key={index} $maxWidth={maxWidth}>
+            <StyledTh
+              key={index}
+              width={columnWidths[index]}
+              $plain={plain}
+              $maxWidth={maxWidth}
+            >
               {data}
             </StyledTh>
           ))}


### PR DESCRIPTION
## Who is this for?
Design/styling
Relates to #10460 

## What is it doing for them?
Re-styles the StackingTable in the request item section to how it used to be. I removed a prop I shouldn't have when [migrating to styled components 6](https://github.com/wellcomecollection/wellcomecollection.org/pull/10352/files#), so it just needed to be passed in again. `width` was also removed but re-added. 

Current bug
![image](https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/3b3d447c-6153-4f43-940f-91bdcd8bce1b)


Old version and back to
<img width="777" alt="Screenshot 2023-12-01 at 12 36 49" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/28025253-6a1c-441b-9a91-bddd7fd2a532">
