### PR TITLE
Refactor api-toolbar tests

### DIFF
--- a/playwright/test/api-toolbar.test.ts
+++ b/playwright/test/api-toolbar.test.ts
@@ -14,39 +14,41 @@ const test = base.extend({
   },
 });
 
-test.describe('tzitzit links', () => {
-  test('does not create a tzitzit link for images in copyright', async ({
-    page,
-  }) => {
-    await gotoWithoutCache(`${baseUrl}/works/fedcvz22/items`, page);
+test('(1) | Does not create a tzitzit link for images in copyright', async ({
+  page,
+}) => {
+  await gotoWithoutCache(`${baseUrl}/works/fedcvz22/items`, page);
 
-    await page.waitForSelector(
-      'li >> text="This image is labelled as in copyright. Check before using."'
-    );
-  });
+  await expect(
+    page.getByText(
+      'This image is labelled as in copyright. Check before using.',
+      { exact: true }
+    )
+  ).toBeVisible();
+});
 
-  test('creates a tzitzit link for item pages', async ({ page }) => {
-    await gotoWithoutCache(`${baseUrl}/works/ccg335hm/items`, page);
+test('(2) | Creates a tzitzit link for item pages', async ({ page }) => {
+  await gotoWithoutCache(`${baseUrl}/works/ccg335hm/items`, page);
 
-    const anchor = await page.waitForSelector('a >> text="tzitzit"');
-    const url = await anchor.getAttribute('href');
+  const anchor = await page.getByRole('link', { name: 'tzitzit' });
+  await expect(anchor).toBeVisible();
 
-    expect(url).toBe(
-      'https://s3-eu-west-1.amazonaws.com/tzitzit.wellcomecollection.org/index.html?title=Fish+schizophrene.&sourceName=Wellcome+Collection&sourceLink=https%3A%2F%2Fwellcomecollection.org%2Fworks%2Fccg335hm%2Fitems&author=Charnley%2C+Bryan%2C+1949-1991'
-    );
-  });
+  const url = await anchor.getAttribute('href');
 
-  test('creates a tzitzit link for image pages', async ({ page }) => {
-    await gotoWithoutCache(
-      `${baseUrl}/works/ccg335hm/images?id=srfsqn7t`,
-      page
-    );
+  expect(url).toBe(
+    'https://s3-eu-west-1.amazonaws.com/tzitzit.wellcomecollection.org/index.html?title=Fish+schizophrene.&sourceName=Wellcome+Collection&sourceLink=https%3A%2F%2Fwellcomecollection.org%2Fworks%2Fccg335hm%2Fitems&author=Charnley%2C+Bryan%2C+1949-1991'
+  );
+});
 
-    const anchor = await page.waitForSelector('a >> text="tzitzit"');
-    const url = await anchor.getAttribute('href');
+test('(3) | Creates a tzitzit link for image pages', async ({ page }) => {
+  await gotoWithoutCache(`${baseUrl}/works/ccg335hm/images?id=srfsqn7t`, page);
 
-    expect(url).toBe(
-      'https://s3-eu-west-1.amazonaws.com/tzitzit.wellcomecollection.org/index.html?title=Fish+schizophrene.&sourceName=Wellcome+Collection&sourceLink=https%3A%2F%2Fwellcomecollection.org%2Fworks%2Fccg335hm%2Fimages%3Fid%3Dsrfsqn7t&licence=CC-BY-NC&author=Charnley%2C+Bryan%2C+1949-1991'
-    );
-  });
+  const anchor = await page.getByRole('link', { name: 'tzitzit' });
+  await expect(anchor).toBeVisible();
+
+  const url = await anchor.getAttribute('href');
+
+  expect(url).toBe(
+    'https://s3-eu-west-1.amazonaws.com/tzitzit.wellcomecollection.org/index.html?title=Fish+schizophrene.&sourceName=Wellcome+Collection&sourceLink=https%3A%2F%2Fwellcomecollection.org%2Fworks%2Fccg335hm%2Fimages%3Fid%3Dsrfsqn7t&licence=CC-BY-NC&author=Charnley%2C+Bryan%2C+1949-1991'
+  );
 });


### PR DESCRIPTION
## Who is this for?
e2e maintenance
Relates to #10409 
I know we're having chats about what we actually want to test next week but these tests still seemed sensible.

## What is it doing for them?
- Flattens tests
- use `getByText` and `getByRole` selectors which matches our goals
- TIL: Using `expect([locator]).toBeVisible()` as it fails way faster than just waiting for the selector ("By default, the timeout for assertions is set to 5 seconds"). Locally it fails in 7 seconds if the locator is wrong, if we skip this step it still fails as the locator can't be found, but that takes 30 seconds.