### PR TITLE
Born digital iiif-manifest

### DIFF
--- a/common/data/microcopy.tsx
+++ b/common/data/microcopy.tsx
@@ -96,8 +96,8 @@ export const a11y = {
 export const wellcomeImagesRedirectBanner =
   'Coming from Wellcome Images? All freely available images have now been moved to the Wellcome Collection website. Here we’re working to improve data quality, search relevance and tools to help you use these images more easily.';
 
-export const unavailableImageMessage =
-  'We are working to make this image available online.';
+export const unavailableContentMessage =
+  'We are working to make this content available online.';
 
 // Messages used in a user's list of item requests
 // See https://github.com/wellcomecollection/wellcomecollection.org/issues/7660

--- a/content/webapp/components/WorkDetails/WorkDetails.AvailableOnline.tsx
+++ b/content/webapp/components/WorkDetails/WorkDetails.AvailableOnline.tsx
@@ -119,7 +119,6 @@ const WorkDetailsAvailableOnline = ({
                 </ConditionalWrapper>
               </Space>
             )}
-
             <div style={{ display: 'flex' }}>
               {itemUrl && (
                 <Space
@@ -133,7 +132,6 @@ const WorkDetailsAvailableOnline = ({
                   />
                 </Space>
               )}
-
               {showDownloadOptions && (
                 <Download
                   ariaControlsId="itemDownloads"
@@ -141,8 +139,10 @@ const WorkDetailsAvailableOnline = ({
                 />
               )}
             </div>
-            {((collectionManifestsCount && collectionManifestsCount > 0) ||
-              (canvasCount && canvasCount > 0)) && (
+            {(Boolean(
+              collectionManifestsCount && collectionManifestsCount > 0
+            ) ||
+              Boolean(canvasCount && canvasCount > 0)) && (
               <Space $v={{ size: 'm', properties: ['margin-top'] }}>
                 <p className={`${font('lr', 6)}`} style={{ marginBottom: 0 }}>
                   Contains:{' '}

--- a/content/webapp/pages/works/[workId]/images.tsx
+++ b/content/webapp/pages/works/[workId]/images.tsx
@@ -16,7 +16,7 @@ import { serialiseProps } from '@weco/common/utils/json';
 import { getWork } from '@weco/content/services/wellcome/catalogue/works';
 import { getImage } from '@weco/content/services/wellcome/catalogue/images';
 import { getServerData } from '@weco/common/server-data';
-import { unavailableImageMessage } from '@weco/common/data/microcopy';
+import { unavailableContentMessage } from '@weco/common/data/microcopy';
 import { Pageview } from '@weco/common/services/conversion/track';
 import { looksLikeCanonicalId } from '@weco/content/services/wellcome/catalogue';
 import {
@@ -86,7 +86,7 @@ const ImagePage: FunctionComponent<Props> = ({
         <Layout gridSizes={gridSize12()}>
           <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
             <div style={{ marginTop: '98px' }}>
-              <BetaMessage message={unavailableImageMessage} />
+              <BetaMessage message={unavailableContentMessage} />
             </div>
           </Space>
         </Layout>

--- a/content/webapp/pages/works/[workId]/items.tsx
+++ b/content/webapp/pages/works/[workId]/items.tsx
@@ -33,7 +33,7 @@ import WorkLink from '@weco/content/components/WorkLink';
 import { getServerData } from '@weco/common/server-data';
 import AudioList from '@weco/content/components/AudioList/AudioList';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
-import { unavailableImageMessage } from '@weco/common/data/microcopy';
+import { unavailableContentMessage } from '@weco/common/data/microcopy';
 import { looksLikeCanonicalId } from '@weco/content/services/wellcome/catalogue';
 import { fetchIIIFPresentationManifest } from '@weco/content/services/iiif/fetch/manifest';
 import { transformManifest } from '@weco/content/services/iiif/transformers/manifest';
@@ -268,7 +268,7 @@ const ItemPage: NextPage<Props> = ({
           <Layout gridSizes={gridSize12()}>
             <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
               <div style={{ marginTop: '98px' }}>
-                <BetaMessage message={unavailableImageMessage} />
+                <BetaMessage message={unavailableContentMessage} />
               </div>
             </Space>
           </Layout>

--- a/content/webapp/pages/works/[workId]/items.tsx
+++ b/content/webapp/pages/works/[workId]/items.tsx
@@ -259,7 +259,7 @@ const ItemPage: NextPage<Props> = ({
           </Space>
         </Layout>
       )}
-      {/* TODO remove this or update unavailable message to something more appropriate */}
+
       {!(isNotUndefined(audio) && audio?.sounds.length > 0) &&
         !video &&
         !pdf &&


### PR DESCRIPTION
Relates to #10467

It appears that iiif-manifests for born digital items can exist without the items property, e.g. https://iiif.wellcomecollection.org/presentation/collections/archives/SA/SRH/B/41/2

I'm not sure this should be the case, but for now i've made it optional so that works/items pages won't error/break, if we fetch these manifests