### PR TITLE
Update Pa11y Dockerfile packages

### DIFF
--- a/pa11y/Dockerfile
+++ b/pa11y/Dockerfile
@@ -2,6 +2,10 @@ FROM public.ecr.aws/docker/library/node:16-slim
 
 VOLUME /dist
 
+# Consider removing this when upgrading to the next version of Pa11y
+# Pa11y 6 runs a very old version of puppeteer
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
+
 RUN apt-get update && apt-get install -yq --no-install-recommends \
   libasound2 libatk-bridge2.0-0 libatk1.0-0 libatspi2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
   libdrm2 libexpat1 libgbm1 libgcc1 libglib2.0-0 libnspr4 libnss3 libpango-1.0-0 libpangocairo-1.0-0  \


### PR DESCRIPTION
## Who is this for?
Devs/functioning of the scripts

## What is it doing for them?
As I [upgraded pa11y recently](https://github.com/wellcomecollection/wellcomecollection.org/pull/10468), it seems that the list in the Dockerfile needed updating as well as it otherwise errors.

[See Slack conversation](https://wellcome.slack.com/archives/C3TQSF63C/p1701691910806299?thread_ts=1701690258.360359&cid=C3TQSF63C)

I updated the list based on what is in [the Debian list here](https://source.chromium.org/chromium/chromium/src/+/main:chrome/installer/linux/debian/dist_package_versions.json).
