### PR TITLE
Revert to default Prismic FilledImage type

### DIFF
--- a/common/services/prismic/transformers/images.ts
+++ b/common/services/prismic/transformers/images.ts
@@ -2,20 +2,19 @@ import * as prismic from '@prismicio/client';
 import { ImageType } from '@weco/common/model/image';
 import { isUndefined } from '@weco/common/utils/type-guards';
 import { transformTaslFromString } from '.';
-import { CustomPrismicFilledImage } from '../types';
 
 // when images have crops, event if the image isn't attached, we get e.g.
 // { '32:15': {}, '16:9': {}, square: {} }
 function isImageLink(
-  maybeImage: prismic.EmptyImageFieldImage | CustomPrismicFilledImage
-): maybeImage is CustomPrismicFilledImage {
+  maybeImage: prismic.EmptyImageFieldImage | prismic.FilledImageFieldImage
+): maybeImage is prismic.FilledImageFieldImage {
   return Boolean(maybeImage && maybeImage.dimensions);
 }
 
 export function transformImage(
   maybeImage:
     | prismic.EmptyImageFieldImage
-    | CustomPrismicFilledImage
+    | prismic.FilledImageFieldImage
     | undefined
 ): ImageType | undefined {
   return maybeImage && isImageLink(maybeImage)
@@ -31,7 +30,7 @@ function startsWith(s: string, prefix: string): boolean {
 }
 
 // We don't export this, as we probably always want to check ^ first
-function transformFilledImage(image: CustomPrismicFilledImage): ImageType {
+function transformFilledImage(image: prismic.FilledImageFieldImage): ImageType {
   const tasl = transformTaslFromString(image.copyright);
   const crops = Object.keys(image)
     .filter(key => prismicImageProps.indexOf(key) === -1)

--- a/common/services/prismic/types/index.ts
+++ b/common/services/prismic/types/index.ts
@@ -31,13 +31,6 @@ export type PaginatedResults<T> = {
   totalPages: number;
 };
 
-// https://github.com/prismicio/prismic-client/pull/326
-// These are new properties that are expected but not documented for yet or returned
-export type CustomPrismicFilledImage = Omit<
-  prismic.FilledImageFieldImage,
-  'id' | 'edit'
->;
-
 // Guards
 export function isFilledLinkToDocument<T, L, D extends DataInterface>(
   field: prismic.ContentRelationshipField<T, L, D> | undefined

--- a/content/webapp/services/prismic/types/index.ts
+++ b/content/webapp/services/prismic/types/index.ts
@@ -10,7 +10,6 @@ import { SeasonPrismicDocument } from './seasons';
 import {
   isFilledLinkToDocumentWithData,
   InferDataInterface,
-  CustomPrismicFilledImage,
 } from '@weco/common/services/prismic/types';
 import { ImageDimensions } from '@weco/common/model/image';
 export type InferCustomType<T> = T extends prismic.PrismicDocument<
@@ -48,8 +47,8 @@ export type FetchLinks<T extends prismic.PrismicDocument> = {
 
 // Currently the Prismic types only allow you to specify 1 image
 type ThumbnailedImageField<Thumbnails extends Record<string, ImageDimensions>> =
-  CustomPrismicFilledImage & {
-    [Property in keyof Thumbnails]?: CustomPrismicFilledImage;
+  prismic.FilledImageFieldImage & {
+    [Property in keyof Thumbnails]?: prismic.FilledImageFieldImage;
   };
 
 export type Image = ThumbnailedImageField<{

--- a/content/webapp/services/wellcome/content/events.ts
+++ b/content/webapp/services/wellcome/content/events.ts
@@ -5,7 +5,6 @@ import {
 } from '@weco/content/services/wellcome/content/types/api';
 // import { contentQuery } from '.';
 import { QueryProps, WellcomeApiError } from '..';
-import { CustomPrismicFilledImage } from '@weco/common/services/prismic/types';
 
 export async function getEvents(
   props: QueryProps<ContentApiProps> // eslint-disable-line 
@@ -22,6 +21,7 @@ export async function getEvents(
     results: [
       {
         type: 'Event',
+        title: 'Land Body Ecologies Festival Day Two',
         format: {
           id: 'W5fV5iYAACQAMxHb',
           label: 'Festival',
@@ -38,6 +38,13 @@ export async function getEvents(
             width: 4000,
           },
           url: 'https://images.prismic.io/wellcomecollection/0793d963-8807-4525-a3d7-e77fa4435baa_LBE+Key+Image+04.jpg?auto=compress,format',
+          edit: {
+            background: '#fff',
+            x: 0,
+            y: 0,
+            zoom: 1,
+          },
+          id: 'ZGYrjxQAADxsO9nG',
           '16:9': {
             alt: 'Photograph of a farmer getting ready to harvest his organic crop of native Ragi in Kariyappanadoddi, India. Behind him are hills and a small single storey building. Interwoven into the scene is a graphic element made up of thin red drawn circular lines, which create a larger organic pattern behind the farmer.',
             copyright:
@@ -46,6 +53,13 @@ export async function getEvents(
               height: 1800,
               width: 3200,
             },
+            edit: {
+              background: '#fff',
+              x: 0,
+              y: 0,
+              zoom: 0.8,
+            },
+            id: 'ZGYrjxQAADxsO9nG',
             url: 'https://images.prismic.io/wellcomecollection/0793d963-8807-4525-a3d7-e77fa4435baa_LBE+Key+Image+04.jpg?auto=compress,format&rect=0,0,4000,2250&w=3200&h=1800',
           },
           '32:15': {
@@ -56,6 +70,13 @@ export async function getEvents(
               height: 1500,
               width: 3200,
             },
+            edit: {
+              background: '#fff',
+              x: 0,
+              y: -185,
+              zoom: 0.8,
+            },
+            id: 'ZGYrjxQAADxsO9nG',
             url: 'https://images.prismic.io/wellcomecollection/0793d963-8807-4525-a3d7-e77fa4435baa_LBE+Key+Image+04.jpg?auto=compress,format&rect=0,232,4000,1875&w=3200&h=1500',
           },
           square: {
@@ -66,9 +87,16 @@ export async function getEvents(
               height: 3200,
               width: 3200,
             },
+            edit: {
+              background: '#fff',
+              x: -1709,
+              y: 0,
+              zoom: 1.4222222222222223,
+            },
+            id: 'ZGYrjxQAADxsO9nG',
             url: 'https://images.prismic.io/wellcomecollection/0793d963-8807-4525-a3d7-e77fa4435baa_LBE+Key+Image+04.jpg?auto=compress,format&rect=1202,0,2250,2250&w=3200&h=3200',
           },
-        } as CustomPrismicFilledImage,
+        },
         interpretations: [],
         locations: [
           {
@@ -88,11 +116,11 @@ export async function getEvents(
             startDateTime: new Date('2023-06-23T09:00:00.000Z'),
           },
         ],
-        title: 'Land Body Ecologies Festival Day Two',
         isAvailableOnline: true,
       },
       {
         type: 'Event',
+        title: 'Perspective Tour With Jess Dobkin',
         format: {
           id: 'WmYRpCQAACUAn-Ap',
           label: 'Gallery tour',
@@ -109,6 +137,13 @@ export async function getEvents(
             height: 2250,
             width: 4000,
           },
+          edit: {
+            background: '#fff',
+            x: 0,
+            y: 0,
+            zoom: 1,
+          },
+          id: 'ZKgZeBAAACEAfpCr',
           '16:9': {
             alt: "Photograph of an art installation in gallery space. It's a dark space with black glossy floors and walls. A large parachute suspended from the ceiling which is lit with vibrant pink and orange light. Two visitors are looking at the instillation.",
             copyright:
@@ -117,6 +152,13 @@ export async function getEvents(
               height: 1800,
               width: 3200,
             },
+            edit: {
+              background: '#fff',
+              x: 0,
+              y: 0,
+              zoom: 0.8,
+            },
+            id: 'ZKgZeBAAACEAfpCr',
             url: 'https://images.prismic.io/wellcomecollection/3e1ef5ca-cf7f-40e5-b1dc-0730a5e11225_EP_002225_007-full.jpg?auto=compress,format&rect=0,0,4000,2250&w=3200&h=1800',
           },
           '32:15': {
@@ -127,6 +169,13 @@ export async function getEvents(
               height: 1500,
               width: 3200,
             },
+            edit: {
+              background: '#fff',
+              x: 0,
+              y: -150,
+              zoom: 0.8,
+            },
+            id: 'ZKgZeBAAACEAfpCr',
             url: 'https://images.prismic.io/wellcomecollection/3e1ef5ca-cf7f-40e5-b1dc-0730a5e11225_EP_002225_007-full.jpg?auto=compress,format&rect=0,188,4000,1875&w=3200&h=1500',
           },
           square: {
@@ -137,9 +186,16 @@ export async function getEvents(
               height: 3200,
               width: 3200,
             },
+            edit: {
+              background: '#fff',
+              x: -1935,
+              y: 0,
+              zoom: 1.4222222222222223,
+            },
+            id: 'ZKgZeBAAACEAfpCr',
             url: 'https://images.prismic.io/wellcomecollection/3e1ef5ca-cf7f-40e5-b1dc-0730a5e11225_EP_002225_007-full.jpg?auto=compress,format&rect=1361,0,2250,2250&w=3200&h=3200',
           },
-        } as CustomPrismicFilledImage,
+        },
         interpretations: [
           {
             id: 'XkFGqxEAACIAIhNH',
@@ -160,7 +216,6 @@ export async function getEvents(
             startDateTime: new Date('2023-08-24T16:30:00.000Z'),
           },
         ],
-        title: 'Perspective Tour With Jess Dobkin',
         isAvailableOnline: false,
       },
     ],

--- a/content/webapp/services/wellcome/content/types/api.ts
+++ b/content/webapp/services/wellcome/content/types/api.ts
@@ -1,10 +1,9 @@
 import { ArticleFormatId } from '@weco/content/data/content-format-ids';
-import * as prismic from '@prismicio/client';
 import {
   WellcomeAggregation,
   WellcomeResultList,
 } from '@weco/content/services/wellcome';
-import { CustomPrismicFilledImage } from '@weco/common/services/prismic/types';
+import { Image } from '@weco/content/services/prismic/types';
 
 export type ContentApiTimeField = {
   startDateTime?: Date;
@@ -18,6 +17,8 @@ export type ContentApiProps = {
   sortOrder?: string;
   aggregations?: string[];
 };
+
+type ContentApiImage = Image & { type: 'PrismicImage' };
 
 // Articles
 export type ArticleFormat = {
@@ -33,7 +34,7 @@ export type Article = {
   publicationDate: string;
   contributors: Contributor[];
   format: ArticleFormat;
-  image?: prismic.EmptyImageFieldImage | CustomPrismicFilledImage;
+  image?: ContentApiImage;
   caption?: string;
 };
 
@@ -60,7 +61,7 @@ export type EventDocument = {
   type: 'Event';
   id: string;
   title: string;
-  image?: prismic.EmptyImageFieldImage | CustomPrismicFilledImage;
+  image?: ContentApiImage;
   times: ContentApiTimeField[];
   format: EventDocumentFormat;
   locations: EventDocumentLocation[];


### PR DESCRIPTION
## Who is this for?
Devs, maintenance

## What is it doing for them?
After working on https://github.com/wellcomecollection/content-api/pull/79, we've decided to keep the new fields that Prismic recently added (`edit: object` and `id: string`) and just pass everything in to keep it to the default state instead of picking what we wanted. These fields return data now (were just null a few weeks back, guess they were working on it?), and we're going to have conversations down the line as to what the Content Api should return. In the meantime, I'm making sure our mock data matches what it will return and limiting our manipulation of the data.