### PR TITLE
Add core & sql managed rules to WAF

### DIFF
--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -155,8 +155,8 @@ resource "aws_wafv2_web_acl" "wc_org" {
     name     = "core-rule-group"
     priority = 4
 
-    action {
-      block {}
+    override_action {
+      none {}
     }
 
     statement {
@@ -178,8 +178,8 @@ resource "aws_wafv2_web_acl" "wc_org" {
     name     = "sql-rule-group"
     priority = 5
 
-    action {
-      block {}
+    override_action {
+      none {}
     }
 
     statement {

--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -150,6 +150,52 @@ resource "aws_wafv2_web_acl" "wc_org" {
     }
   }
 
+  // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs
+  rule {
+    name     = "core-rule-group"
+    priority = 4
+
+    action {
+      block {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      sampled_requests_enabled   = true
+      metric_name                = "weco-cloudfront-acl-core-${var.namespace}"
+    }
+  }
+
+  // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-use-case.html#aws-managed-rule-groups-use-case-sql-db
+  rule {
+    name     = "sql-rule-group"
+    priority = 5
+
+    action {
+      block {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesSQLiRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      sampled_requests_enabled   = true
+      metric_name                = "weco-cloudfront-acl-sql-${var.namespace}"
+    }
+  }
+
   visibility_config {
     cloudwatch_metrics_enabled = true
     sampled_requests_enabled   = true

--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -156,7 +156,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
     priority = 4
 
     override_action {
-      none {}
+      count {}
     }
 
     statement {
@@ -175,11 +175,11 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-use-case.html#aws-managed-rule-groups-use-case-sql-db
   rule {
-    name     = "sql-rule-group"
+    name     = "sqli-rule-group"
     priority = 5
 
     override_action {
-      none {}
+      count {}
     }
 
     statement {
@@ -192,7 +192,30 @@ resource "aws_wafv2_web_acl" "wc_org" {
     visibility_config {
       cloudwatch_metrics_enabled = true
       sampled_requests_enabled   = true
-      metric_name                = "weco-cloudfront-acl-sql-${var.namespace}"
+      metric_name                = "weco-cloudfront-acl-sqli-${var.namespace}"
+    }
+  }
+
+  // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs
+  rule {
+    name     = "known-bad-inputs-rule-group"
+    priority = 6
+
+    override_action {
+      count {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      sampled_requests_enabled   = true
+      metric_name                = "weco-cloudfront-acl-known-bad-inputs-${var.namespace}"
     }
   }
 


### PR DESCRIPTION
## Who is this for?

This change is intended to block a wider array of malicious requests to wellcomecollection.org in order to reduce unnecessary alarms and increase protection to the underlaying services.

## What is it doing for them?

We add `AWSManagedRulesSQLiRuleSet`, `AWSManagedRulesCommonRuleSet` and `AWSManagedRulesKnownBadInputsRuleSet`, to block requests that match recognised OWASP vulnerabilities and include potential (useless) SQL injection attacks that we've seen in alerts.

## `terraform plan`

Targeting the prod stack:

`terraform plan -target module.prod_wc_org_cloudfront_distribution`

Output:
```
  # module.prod_wc_org_cloudfront_distribution.aws_wafv2_web_acl.wc_org will be updated in-place
  ~ resource "aws_wafv2_web_acl" "wc_org" {
        id          = "316ddf50-ea9e-4555-826d-e0a4d1380ead"
        name        = "weco-cloudfront-acl-prod"
        tags        = {}
        # (6 unchanged attributes hidden)

      - rule {
          - name     = "managed-ip-blocking" -> null
          - priority = 1 -> null

          - override_action {
              - none {}
            }

          - statement {
              - managed_rule_group_statement {
                  - name        = "AWSManagedRulesAmazonIpReputationList" -> null
                  - vendor_name = "AWS" -> null
                }
            }

          - visibility_config {
              - cloudwatch_metrics_enabled = true -> null
              - metric_name                = "weco-cloudfront-acl-ip-block-prod" -> null
              - sampled_requests_enabled   = true -> null
            }
        }
      + rule {
          + name     = "core-rule-group"
          + priority = 4

          + override_action {
              + count {}
            }

          + statement {
              + managed_rule_group_statement {
                  + name        = "AWSManagedRulesCommonRuleSet"
                  + vendor_name = "AWS"
                }
            }

          + visibility_config {
              + cloudwatch_metrics_enabled = true
              + metric_name                = "weco-cloudfront-acl-core-prod"
              + sampled_requests_enabled   = true
            }
        }
      + rule {
          + name     = "known-bad-inputs-rule-group"
          + priority = 6

          + override_action {
              + count {}
            }

          + statement {
              + managed_rule_group_statement {
                  + name        = "AWSManagedRulesKnownBadInputsRuleSet"
                  + vendor_name = "AWS"
                }
            }

          + visibility_config {
              + cloudwatch_metrics_enabled = true
              + metric_name                = "weco-cloudfront-acl-known-bad-inputs-prod"
              + sampled_requests_enabled   = true
            }
        }
      + rule {
          + name     = "managed-ip-blocking"
          + priority = 1

          + override_action {
              + none {}
            }

          + statement {
              + managed_rule_group_statement {
                  + name        = "AWSManagedRulesAmazonIpReputationList"
                  + vendor_name = "AWS"
                }
            }

          + visibility_config {
              + cloudwatch_metrics_enabled = true
              + metric_name                = "weco-cloudfront-acl-ip-block-prod"
              + sampled_requests_enabled   = true
            }
        }
      + rule {
          + name     = "sqli-rule-group"
          + priority = 5

          + override_action {
              + count {}
            }

          + statement {
              + managed_rule_group_statement {
                  + name        = "AWSManagedRulesSQLiRuleSet"
                  + vendor_name = "AWS"
                }
            }

          + visibility_config {
              + cloudwatch_metrics_enabled = true
              + metric_name                = "weco-cloudfront-acl-sqli-prod"
              + sampled_requests_enabled   = true
            }
        }

        # (5 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

## How do we test this?

- [x] Deploy this change to the e2e stack, run the e2e tests to catch any obvious problems
- [ ] Deploy this change with the action set to count 
        In order that we can deploy to production and identify potential impact with real traffic before switching to block.

> [!NOTE]
> The `AWSManagedRulesCommonRuleSet` has the potential to match valid requests as it does things like match large request bodies and long urls. Unlikely to be an issue but it's something we can test for so we should probably do that.