### PR TITLE
Fix e2e: use image ID for search

### DIFF
--- a/playwright/test/search-images.test.ts
+++ b/playwright/test/search-images.test.ts
@@ -89,7 +89,7 @@ test.describe('Image search', () => {
 
   test.describe('the expanded image modal', () => {
     test('images without contributors still show a title', async ({ page }) => {
-      await gotoSearchResultPage({ url: imagesUrl, query: 'm2u74c63' }, page);
+      await gotoSearchResultPage({ url: imagesUrl, query: 'kd9h6gr3' }, page);
 
       await clickActionClickSearchResultItem(1, page);
       await expectItemIsVisible(


### PR DESCRIPTION
This makes the e2e test decoupled from the query, as the search will only ever return one thing (rather than all the images belonging to the work)