### PR TITLE
Remove ECR repository for catalogue app, small docs tweak

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To get a login, ask a friendly experience team member near you.
 ### [Catalogue](https://wellcomecollection.org/works)
 
 - Tools to allow people to browse and dig deeper into our catalogue.
-  [`code`](./catalogue).
+  [`code`](./content).
 
 ### [Cardigan](https://cardigan.wellcomecollection.org)
 
@@ -61,6 +61,7 @@ yarn content
 yarn run-concurrently
 ```
 ### Port
+
 By default webapps will run on port `3000`.
 
 You can specify a port by setting the `PORT` in your `.env.development`.

--- a/infrastructure/experience/.terraform.lock.hcl
+++ b/infrastructure/experience/.terraform.lock.hcl
@@ -2,8 +2,23 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "4.61.0"
+  version = "5.31.0"
   hashes = [
-    "h1:GrboLwI2hok/i8xfq87uS9kUKPqAE8b/1iJTEupRthY=",
+    "h1:ltxyuBWIy9cq0kIKDJH1jeWJy/y7XJLjS4QrsQK4plA=",
+    "zh:0cdb9c2083bf0902442384f7309367791e4640581652dda456f2d6d7abf0de8d",
+    "zh:2fe4884cb9642f48a5889f8dff8f5f511418a18537a9dfa77ada3bcdad391e4e",
+    "zh:36d8bdd72fe61d816d0049c179f495bc6f1e54d8d7b07c45b62e5e1696882a89",
+    "zh:539dd156e3ec608818eb21191697b230117437a58587cbd02ce533202a4dd520",
+    "zh:6a53f4b57ac4eb3479fc0d8b6e301ca3a27efae4c55d9f8bd24071b12a03361c",
+    "zh:6faeb8ff6792ca7af1c025255755ad764667a300291cc10cea0c615479488c87",
+    "zh:7d9423149b323f6d0df5b90c4d9029e5455c670aea2a7eb6fef4684ba7eb2e0b",
+    "zh:8235badd8a5d0993421cacf5ead48fac73d3b5a25c8a68599706a404b1f70730",
+    "zh:860b4f60842b2879c5128b7e386c8b49adeda9287fed12c5cd74861bb659bbcd",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b021fceaf9382c8fe3c6eb608c24d01dce3d11ba7e65bb443d51ca9b90e9b237",
+    "zh:b38b0bfc1c69e714e80cf1c9ea06e687ee86aa9f45694be28eb07adcebbe0489",
+    "zh:c972d155f6c01af9690a72adfb99cfc24ef5ef311ca92ce46b9b13c5c153f572",
+    "zh:e0dd29920ec84fdb6026acff44dcc1fb1a24a0caa093fa04cdbc713d384c651d",
+    "zh:e3127ebd2cb0374cd1808f911e6bffe2f4ac4d84317061381242353f3a7bc27d",
   ]
 }

--- a/infrastructure/experience/ecr.tf
+++ b/infrastructure/experience/ecr.tf
@@ -37,17 +37,9 @@ resource "aws_ecr_lifecycle_policy" "content_webapp" {
   policy     = local.ecr_policy_only_keep_the_last_100_images
 }
 
+# Removing is a 2 step process where we first remove the policy and then the repository
 resource "aws_ecr_repository" "catalogue_webapp" {
   name = "uk.ac.wellcome/catalogue_webapp"
-
-  lifecycle {
-    prevent_destroy = true
-  }
-}
-
-resource "aws_ecr_lifecycle_policy" "catalogue_webapp" {
-  repository = aws_ecr_repository.catalogue_webapp.name
-  policy     = local.ecr_policy_only_keep_the_last_100_images
 }
 
 resource "aws_ecr_repository" "identity_webapp" {

--- a/infrastructure/experience/ecr.tf
+++ b/infrastructure/experience/ecr.tf
@@ -37,11 +37,6 @@ resource "aws_ecr_lifecycle_policy" "content_webapp" {
   policy     = local.ecr_policy_only_keep_the_last_100_images
 }
 
-# Removing is a 2 step process where we first remove the policy and then the repository
-resource "aws_ecr_repository" "catalogue_webapp" {
-  name = "uk.ac.wellcome/catalogue_webapp"
-}
-
 resource "aws_ecr_repository" "identity_webapp" {
   name = "uk.ac.wellcome/identity_webapp"
 

--- a/infrastructure/experience/outputs.tf
+++ b/infrastructure/experience/outputs.tf
@@ -6,10 +6,6 @@ output "content_webapp_ecr_uri" {
   value = aws_ecr_repository.content_webapp.repository_url
 }
 
-output "catalogue_webapp_ecr_uri" {
-  value = aws_ecr_repository.catalogue_webapp.repository_url
-}
-
 output "identity_webapp_ecr_uri" {
   value = aws_ecr_repository.identity_webapp.repository_url
 }


### PR DESCRIPTION
## Who is this for?

Follows https://github.com/wellcomecollection/wellcomecollection.org/pull/10518, we don't need the ECR repository any more.

This infrastructure has been deleted via `terraform apply`.

## What is it doing for them?

This removes redundant infrastructure and reduces cost.
