### PR TITLE
[HOLD] Replace count with block for core & sql managed rules to WAF

### DIFF
--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -156,7 +156,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
     priority = 4
 
     override_action {
-      count {}
+      none {}
     }
 
     statement {
@@ -179,7 +179,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
     priority = 5
 
     override_action {
-      count {}
+      none {}
     }
 
     statement {
@@ -202,7 +202,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
     priority = 6
 
     override_action {
-      count {}
+      none {}
     }
 
     statement {


### PR DESCRIPTION
## Who is this for?

Part of https://github.com/wellcomecollection/wellcomecollection.org/issues/10511

Following https://github.com/wellcomecollection/wellcomecollection.org/pull/10510

Here's the graph of requests being noticed by the WAF from late last week when the new rules were added:

<img width="1273" alt="Screenshot 2023-12-18 at 09 20 03" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/953792/e889577f-bf14-4502-ab7c-946428cc9ac1">

[Link (experience account)](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#metricsV2?graph=~(metrics~(~(~(id~'id0~label~'1*20-*20BadBots_Header*20awswaf*3amanaged*3aaws*3acore-rule-set~expression~'SUM*28SEARCH*28*27*7bAWS*2fWAFV2*2cLabelName*2cLabelNamespace*2cWebACL*7d*20LabelName*3d*22BadBots_Header*22*20*20LabelNamespace*3d*22awswaf*3amanaged*3aaws*3acore-rule-set*22*20MetricName*3d*28*22BlockedRequests*22*20OR*20*22AllowedRequests*22*20OR*20*22CaptchaRequests*22*20OR*20*22ChallengeRequests*22*29*20WebACL*3d*22weco-cloudfront-acl-prod*22*20*3aaws.AccountId*20*3d*20*22LOCAL*22*20NOT*20*22ALL*22*27*2c*20*27Sum*27*2c*2060*29*29~period~60~visible~true))~(~(id~'id1~label~'2*20-*20AWSManagedReconnaissanceList*20awswaf*3amanaged*3aaws*3aamazon-ip-list~expression~'SUM*28SEARCH*28*27*7bAWS*2fWAFV2*2cLabelName*2cLabelNamespace*2cWebACL*7d*20LabelName*3d*22AWSManagedReconnaissanceList*22*20*20LabelNamespace*3d*22awswaf*3amanaged*3aaws*3aamazon-ip-list*22*20MetricName*3d*28*22BlockedRequests*22*20OR*20*22AllowedRequests*22*20OR*20*22CaptchaRequests*22*20OR*20*22ChallengeRequests*22*29*20WebACL*3d*22weco-cloudfront-acl-prod*22*20*3aaws.AccountId*20*3d*20*22LOCAL*22*20NOT*20*22ALL*22*27*2c*20*27Sum*27*2c*2060*29*29~period~60~visible~true))~(~(id~'id2~label~'3*20-*20NoUserAgent_Header*20awswaf*3amanaged*3aaws*3acore-rule-set~expression~'SUM*28SEARCH*28*27*7bAWS*2fWAFV2*2cLabelName*2cLabelNamespace*2cWebACL*7d*20LabelName*3d*22NoUserAgent_Header*22*20*20LabelNamespace*3d*22awswaf*3amanaged*3aaws*3acore-rule-set*22*20MetricName*3d*28*22BlockedRequests*22*20OR*20*22AllowedRequests*22*20OR*20*22CaptchaRequests*22*20OR*20*22ChallengeRequests*22*29*20WebACL*3d*22weco-cloudfront-acl-prod*22*20*3aaws.AccountId*20*3d*20*22LOCAL*22*20NOT*20*22ALL*22*27*2c*20*27Sum*27*2c*2060*29*29~period~60~visible~true))~(~(id~'id3~label~'4*20-*20AWSManagedIPReputationList*20awswaf*3amanaged*3aaws*3aamazon-ip-list~expression~'SUM*28SEARCH*28*27*7bAWS*2fWAFV2*2cLabelName*2cLabelNamespace*2cWebACL*7d*20LabelName*3d*22AWSManagedIPReputationList*22*20*20LabelNamespace*3d*22awswaf*3amanaged*3aaws*3aamazon-ip-list*22*20MetricName*3d*28*22BlockedRequests*22*20OR*20*22AllowedRequests*22*20OR*20*22CaptchaRequests*22*20OR*20*22ChallengeRequests*22*29*20WebACL*3d*22weco-cloudfront-acl-prod*22*20*3aaws.AccountId*20*3d*20*22LOCAL*22*20NOT*20*22ALL*22*27*2c*20*27Sum*27*2c*2060*29*29~period~60~visible~true))~(~(id~'id4~label~'5*20-*20SizeRestrictions_QueryString*20awswaf*3amanaged*3aaws*3acore-rule-set~expression~'SUM*28SEARCH*28*27*7bAWS*2fWAFV2*2cLabelName*2cLabelNamespace*2cWebACL*7d*20LabelName*3d*22SizeRestrictions_QueryString*22*20*20LabelNamespace*3d*22awswaf*3amanaged*3aaws*3acore-rule-set*22*20MetricName*3d*28*22BlockedRequests*22*20OR*20*22AllowedRequests*22*20OR*20*22CaptchaRequests*22*20OR*20*22ChallengeRequests*22*29*20WebACL*3d*22weco-cloudfront-acl-prod*22*20*3aaws.AccountId*20*3d*20*22LOCAL*22*20NOT*20*22ALL*22*27*2c*20*27Sum*27*2c*2060*29*29~period~60~visible~true))~(~(id~'id5~label~'6*20-*20RestrictedExtensions_QueryArguments*20awswaf*3amanaged*3aaws*3acore-rule-set~expression~'SUM*28SEARCH*28*27*7bAWS*2fWAFV2*2cLabelName*2cLabelNamespace*2cWebACL*7d*20LabelName*3d*22RestrictedExtensions_QueryArguments*22*20*20LabelNamespace*3d*22awswaf*3amanaged*3aaws*3acore-rule-set*22*20MetricName*3d*28*22BlockedRequests*22*20OR*20*22AllowedRequests*22*20OR*20*22CaptchaRequests*22*20OR*20*22ChallengeRequests*22*29*20WebACL*3d*22weco-cloudfront-acl-prod*22*20*3aaws.AccountId*20*3d*20*22LOCAL*22*20NOT*20*22ALL*22*27*2c*20*27Sum*27*2c*2060*29*29~period~60~visible~true))~(~(id~'id6~label~'7*20-*20AWSManagedIPDDoSList*20awswaf*3amanaged*3aaws*3aamazon-ip-list~expression~'SUM*28SEARCH*28*27*7bAWS*2fWAFV2*2cLabelName*2cLabelNamespace*2cWebACL*7d*20LabelName*3d*22AWSManagedIPDDoSList*22*20*20LabelNamespace*3d*22awswaf*3amanaged*3aaws*3aamazon-ip-list*22*20MetricName*3d*28*22BlockedRequests*22*20OR*20*22AllowedRequests*22*20OR*20*22CaptchaRequests*22*20OR*20*22ChallengeRequests*22*29*20WebACL*3d*22weco-cloudfront-acl-prod*22*20*3aaws.AccountId*20*3d*20*22LOCAL*22*20NOT*20*22ALL*22*27*2c*20*27Sum*27*2c*2060*29*29~period~60~visible~true))~(~(id~'id7~label~'8*20-*20SQLi_QueryArguments*20awswaf*3amanaged*3aaws*3asql-database~expression~'SUM*28SEARCH*28*27*7bAWS*2fWAFV2*2cLabelName*2cLabelNamespace*2cWebACL*7d*20LabelName*3d*22SQLi_QueryArguments*22*20*20LabelNamespace*3d*22awswaf*3amanaged*3aaws*3asql-database*22*20MetricName*3d*28*22BlockedRequests*22*20OR*20*22AllowedRequests*22*20OR*20*22CaptchaRequests*22*20OR*20*22ChallengeRequests*22*29*20WebACL*3d*22weco-cloudfront-acl-prod*22*20*3aaws.AccountId*20*3d*20*22LOCAL*22*20NOT*20*22ALL*22*27*2c*20*27Sum*27*2c*2060*29*29~period~60~visible~true))~(~(id~'id8~label~'9*20-*20GenericRFI_Body*20awswaf*3amanaged*3aaws*3acore-rule-set~expression~'SUM*28SEARCH*28*27*7bAWS*2fWAFV2*2cLabelName*2cLabelNamespace*2cWebACL*7d*20LabelName*3d*22GenericRFI_Body*22*20*20LabelNamespace*3d*22awswaf*3amanaged*3aaws*3acore-rule-set*22*20MetricName*3d*28*22BlockedRequests*22*20OR*20*22AllowedRequests*22*20OR*20*22CaptchaRequests*22*20OR*20*22ChallengeRequests*22*29*20WebACL*3d*22weco-cloudfront-acl-prod*22*20*3aaws.AccountId*20*3d*20*22LOCAL*22*20NOT*20*22ALL*22*27*2c*20*27Sum*27*2c*2060*29*29~period~60~visible~true))~(~(id~'id9~label~'10*20-*20ExploitablePaths_URIPath_RC_COUNT*20awswaf*3amanaged*3aaws*3aknown-bad-inputs~expression~'SUM*28SEARCH*28*27*7bAWS*2fWAFV2*2cLabelName*2cLabelNamespace*2cWebACL*7d*20LabelName*3d*22ExploitablePaths_URIPath_RC_COUNT*22*20*20LabelNamespace*3d*22awswaf*3amanaged*3aaws*3aknown-bad-inputs*22*20MetricName*3d*28*22BlockedRequests*22*20OR*20*22AllowedRequests*22*20OR*20*22CaptchaRequests*22*20OR*20*22ChallengeRequests*22*29*20WebACL*3d*22weco-cloudfront-acl-prod*22*20*3aaws.AccountId*20*3d*20*22LOCAL*22*20NOT*20*22ALL*22*27*2c*20*27Sum*27*2c*2060*29*29~period~60~visible~true)))~view~'timeSeries~stacked~false~liveData~false~title~'Top*2010*20managed*20rule*20labels~start~'2023-12-14T06*3a15*3a00.000Z~end~'2023-12-18T09*3a15*3a16.000Z~setPeriodToTimeRange~true~region~'us-east-1))

The rules matched seem overwhelmingly to be UserAgent_BadBots_HEADER from the [Core rule set](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs).

I don't foresee an issue with enabling blocking against these rulesets. The description for this rule is:

```
Inspects for common User-Agent header values that indicate that the request is a bad bot. Example patterns include nessus, and nmap. For bot management, see also AWS WAF Bot Control rule group.
```

[nessus](https://en.wikipedia.org/wiki/Nessus_(software)) and [nmap](https://en.wikipedia.org/wiki/Nmap) are vulnerability scanning tools.

## What is it doing for them?

This change is enabling request blocking after monitoring the requests which match the new rules blocked. The intention is to stop more requests falling through the service itself and reduce the quantity of alarms that we receive that don't need attention.

## How to test?

- [ ] Deploy to production, ensure that the WAF rules have been updated as expected. Be vigilant for errors caused by blocking potentially valid requests.

> [!WARNING] 
> We are holding deployment until after the festive break. Problems are unlikely but not worth the risk!