### PR TITLE
Tweak how identity starts, update playwright docs 

### DIFF
--- a/identity/webapp/package.json
+++ b/identity/webapp/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "scripts": {
     "start": "NODE_ENV=production ts-node-transpile-only -r tsconfig-paths/register src/index.ts",
-    "start:dev": "CREDENTIALS=$(AWS_PROFILE=identity-dev aws secretsmanager get-secret-value --secret-id=identity/stage/local_dev_client/credentials) NODE_ENV=development nodemon --ignore './src/frontend/' src/index.ts",
+    "start:dev": "CREDENTIALS=$(AWS_PROFILE=identity-developer aws secretsmanager get-secret-value --secret-id=identity/stage/local_dev_client/credentials) NODE_ENV=development nodemon --ignore './src/frontend/' src/index.ts",
     "watch:client": "yarn build:frontend --watch",
     "build": "NODE_ENV=production && yarn build:next",
     "build:next": "next build",

--- a/playwright/README.md
+++ b/playwright/README.md
@@ -31,3 +31,9 @@ $ cd playwright
 $ yarn
 $ PLAYWRIGHT_BASE_URL=http://localhost:3000 yarn test
 ```
+
+Some tests require you to run both `content` & `identity` apps at the same time, to do this run from the repository root:
+
+```console
+$ ./scripts/run-concurrently.sh
+```


### PR DESCRIPTION
## Who is this for?

This change is for new people working on this app who might need to run the `playwright` tests.

## What is it doing for them?

We make the AWS profile used in dev mode `identity-developer` rather than `identity-dev` to match the name in the profile [provided in the documentation](https://github.com/wellcomecollection/aws-account-infrastructure/blob/main/accounts/credentials.ini), and update the `README.md` to make it clear you may want to start both apps.

This change contains some commits from https://github.com/wellcomecollection/wellcomecollection.org/pull/10520 as this was discovered in the process of writing that PR, either change can be merged first.

> [!NOTE] 
> The `run-concurrently.sh` script requires you to log into aws every time, without checking if you've already got a valid profile. A further extension may be a check using the `aws sts` CLI whether a valid profile exists and _not_ ask in that case.