### PR TITLE
Unauthorised images in viewer

### DIFF
--- a/common/utils/convert-image-uri.ts
+++ b/common/utils/convert-image-uri.ts
@@ -100,15 +100,17 @@ function prismicTemplateParts( // gets the params from the original Prismic imag
 
 export function convertIiifImageUri(
   originalUri: string,
-  requiredSize: number | 'full'
+  requiredSize: number | 'full',
+  sizeByHeight?: boolean
 ): string {
   if (determineIfGif(originalUri) || !originalUri.startsWith(iiifImageUri)) {
     return originalUri;
   } else {
     const imageIdentifier = originalUri.split(iiifImageUri)[1].split('/', 2)[0];
 
+    const size = sizeByHeight ? `,${requiredSize}` : `${requiredSize},`;
     const params = {
-      size: requiredSize === 'full' ? 'full' : `${requiredSize},`,
+      size: requiredSize === 'full' ? 'full' : `${size},`,
       format: determineFinalFormat(originalUri),
     };
     return iiifImageTemplate(`${iiifImageUri}${imageIdentifier}`)(params);

--- a/common/utils/convert-image-uri.ts
+++ b/common/utils/convert-image-uri.ts
@@ -110,7 +110,7 @@ export function convertIiifImageUri(
 
     const size = sizeByHeight ? `,${requiredSize}` : `${requiredSize},`;
     const params = {
-      size: requiredSize === 'full' ? 'full' : `${size},`,
+      size: requiredSize === 'full' ? 'full' : `${size}`,
       format: determineFinalFormat(originalUri),
     };
     return iiifImageTemplate(`${iiifImageUri}${imageIdentifier}`)(params);

--- a/content/webapp/components/IIIFViewer/IIIFViewerImage.tsx
+++ b/content/webapp/components/IIIFViewer/IIIFViewerImage.tsx
@@ -74,8 +74,8 @@ const IIIFViewerImage = (
             ? convertIiifImageUri(src, 1000, true)
             : convertIiifImageUri(src, 1000);
           currentTarget.src = newSrc;
-          currentTarget.srcset = '';
-          currentTarget.sizes = '';
+          currentTarget.removeAttribute('srcset');
+          currentTarget.removeAttribute('sizes');
         } else {
           // If the image still fails to load, we check to see if it's because the authorisation cookie is missing/no longer valid
           errorHandler && errorHandler();

--- a/content/webapp/components/IIIFViewer/IIIFViewerImage.tsx
+++ b/content/webapp/components/IIIFViewer/IIIFViewerImage.tsx
@@ -71,8 +71,8 @@ const IIIFViewerImage = (
           setTryLoadingSmallerImg(false); // prevent looping if image fails to load again
           const isPortrait = Boolean(height && height > width);
           const newSrc = isPortrait
-            ? convertIiifImageUri(src, 1000, true)
-            : convertIiifImageUri(src, 1000);
+            ? convertIiifImageUri(currentTarget.src, 1000, true)
+            : convertIiifImageUri(currentTarget.src, 1000);
           currentTarget.src = newSrc;
           currentTarget.removeAttribute('srcset');
           currentTarget.removeAttribute('sizes');

--- a/content/webapp/components/IIIFViewer/IIIFViewerImage.tsx
+++ b/content/webapp/components/IIIFViewer/IIIFViewerImage.tsx
@@ -1,6 +1,19 @@
 import { forwardRef, useState } from 'react';
 import styled from 'styled-components';
 import { convertIiifImageUri } from '@weco/common/utils/convert-image-uri';
+import { convertRequestUriToInfoUri } from '@weco/content/utils/convert-iiif-uri';
+async function getImageMax(url: string): Promise<number> {
+  try {
+    const infoUrl = convertRequestUriToInfoUri(url);
+    const resp = await fetch(infoUrl + 'll');
+    const info = await resp.json();
+    // N.B property is called maxWidth, but it is actually the max allowed for the longest side, see https://wellcome.slack.com/archives/CBT40CMKQ/p1702897884100559
+    const max = info.profile?.find(item => item.maxWidth)?.maxWidth || 1000;
+    return max || 1001;
+  } catch {
+    return 1000;
+  }
+}
 
 const Image = styled.img<{ $highlightImage?: boolean; $zoomOnClick?: boolean }>`
   ${props =>
@@ -62,17 +75,19 @@ const IIIFViewerImage = (
           clickHandler && clickHandler();
         }
       }}
-      onError={({ currentTarget }) => {
+      onError={async ({ currentTarget }) => {
         // Hack/workaround
         // If the image fails to load it may be because of a size limit,
         // see: https://wellcome.slack.com/archives/CBT40CMKQ/p1691050149722109,
         // so first off we try a smaller image
         if (tryLoadingSmallerImg) {
           setTryLoadingSmallerImg(false); // prevent looping if image fails to load again
+          // we need to know the max size of the longest side first
+          const imageMax = await getImageMax(currentTarget.src);
           const isPortrait = Boolean(height && height > width);
           const newSrc = isPortrait
-            ? convertIiifImageUri(currentTarget.src, 1000, true)
-            : convertIiifImageUri(currentTarget.src, 1000);
+            ? convertIiifImageUri(currentTarget.src, imageMax, true)
+            : convertIiifImageUri(currentTarget.src, imageMax);
           currentTarget.src = newSrc;
           currentTarget.removeAttribute('srcset');
           currentTarget.removeAttribute('sizes');

--- a/content/webapp/components/IIIFViewer/IIIFViewerImage.tsx
+++ b/content/webapp/components/IIIFViewer/IIIFViewerImage.tsx
@@ -1,5 +1,6 @@
-import { forwardRef } from 'react';
+import { forwardRef, useState } from 'react';
 import styled from 'styled-components';
+import { convertIiifImageUri } from '@weco/common/utils/convert-image-uri';
 
 const Image = styled.img<{ $highlightImage?: boolean; $zoomOnClick?: boolean }>`
   ${props =>
@@ -43,6 +44,7 @@ const IIIFViewerImage = (
   }: Props,
   ref
 ) => {
+  const [tryLoadingSmallerImg, setTryLoadingSmallerImg] = useState(true);
   return (
     <Image
       ref={ref}
@@ -60,8 +62,24 @@ const IIIFViewerImage = (
           clickHandler && clickHandler();
         }
       }}
-      onError={() => {
-        errorHandler && errorHandler();
+      onError={({ currentTarget }) => {
+        // Hack/workaround
+        // If the image fails to load it may be because of a size limit,
+        // see: https://wellcome.slack.com/archives/CBT40CMKQ/p1691050149722109,
+        // so first off we try a smaller image
+        if (tryLoadingSmallerImg) {
+          setTryLoadingSmallerImg(false); // prevent looping if image fails to load again
+          const isPortrait = Boolean(height > width);
+          const newSrc = isPortrait
+            ? convertIiifImageUri(src, 1000, true)
+            : convertIiifImageUri(src, 1000);
+          currentTarget.src = newSrc;
+          currentTarget.srcset = '';
+          currentTarget.sizes = '';
+        } else {
+          // If the image still fails to load, we check to see if it's because the authorisation cookie is missing/no longer valid
+          errorHandler && errorHandler();
+        }
       }}
       src={src}
       srcSet={srcSet}

--- a/content/webapp/components/IIIFViewer/IIIFViewerImage.tsx
+++ b/content/webapp/components/IIIFViewer/IIIFViewerImage.tsx
@@ -69,7 +69,7 @@ const IIIFViewerImage = (
         // so first off we try a smaller image
         if (tryLoadingSmallerImg) {
           setTryLoadingSmallerImg(false); // prevent looping if image fails to load again
-          const isPortrait = Boolean(height > width);
+          const isPortrait = Boolean(height && height > width);
           const newSrc = isPortrait
             ? convertIiifImageUri(src, 1000, true)
             : convertIiifImageUri(src, 1000);

--- a/content/webapp/components/IIIFViewer/MainViewer.tsx
+++ b/content/webapp/components/IIIFViewer/MainViewer.tsx
@@ -13,7 +13,7 @@ import styled from 'styled-components';
 import LL from '@weco/common/views/components/styled/LL';
 import useScrollVelocity from '@weco/content/hooks/useScrollVelocity';
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
-import { convertIiifUriToInfoUri } from '@weco/content/utils/convert-iiif-uri';
+import { convertRequestUriToInfoUri } from '@weco/content/utils/convert-iiif-uri';
 import { missingAltTextMessage } from '@weco/content/services/wellcome/catalogue/works';
 import { font } from '@weco/common/utils/classnames';
 import { SearchResults } from '@weco/content/services/iiif/types/search/v3';
@@ -215,7 +215,8 @@ const ItemRenderer = memo(({ style, index, data }: ItemRendererProps) => {
     ? iiifImageTemplate(mainImageService['@id'])
     : undefined;
   const infoUrl =
-    mainImageService['@id'] && convertIiifUriToInfoUri(mainImageService['@id']);
+    mainImageService['@id'] &&
+    convertRequestUriToInfoUri(mainImageService['@id']);
   const imageType = scrollVelocity >= 1 ? 'none' : 'main';
   const isRestricted = currentCanvas.hasRestrictedImage;
   const { searchResults, rotatedImages } = useContext(ItemViewerContext);

--- a/content/webapp/components/IIIFViewer/ZoomedImage.tsx
+++ b/content/webapp/components/IIIFViewer/ZoomedImage.tsx
@@ -12,7 +12,7 @@ import Control from '@weco/common/views/components/Buttons/Control/Control';
 import Space from '@weco/common/views/components/styled/Space';
 import ItemViewerContext from '../ItemViewerContext/ItemViewerContext';
 import { cross, minus, plus, rotateRight } from '@weco/common/icons';
-import { convertIiifUriToInfoUri } from '@weco/content/utils/convert-iiif-uri';
+import { convertRequestUriToInfoUri } from '@weco/content/utils/convert-iiif-uri';
 import { queryParamToArrayIndex } from '.';
 import { OptionalToUndefined } from '@weco/common/utils/utility-types';
 
@@ -58,7 +58,7 @@ const ZoomedImage: FunctionComponent<ZoomedImageProps> = ({
   };
   const zoomInfoUrl = iiifImageLocation
     ? iiifImageLocation.url
-    : convertIiifUriToInfoUri(mainImageService['@id']);
+    : convertRequestUriToInfoUri(mainImageService['@id']);
   const [scriptError, setScriptError] = useState(false);
   const [viewer, setViewer] = useState(null);
   const zoomStep = 0.5;

--- a/content/webapp/test/utils/convert-iiif-uri.test.ts
+++ b/content/webapp/test/utils/convert-iiif-uri.test.ts
@@ -1,8 +1,8 @@
-import { convertIiifUriToInfoUri } from '../../utils/convert-iiif-uri';
+import { convertRequestUriToInfoUri } from '../../utils/convert-iiif-uri';
 
-describe('convertIiifUriToInfoUri', () => {
+describe('convertRequestUriToInfoUri', () => {
   it('finds the info.json for a IIIF URI', () => {
-    const result = convertIiifUriToInfoUri(
+    const result = convertRequestUriToInfoUri(
       'https://iiif.wellcomecollection.org/image/b0006.jpg/full/300%2C/0/default.jpg'
     );
     expect(result).toEqual(
@@ -11,7 +11,7 @@ describe('convertIiifUriToInfoUri', () => {
   });
 
   it('finds the info.json for an unrecognised URI', () => {
-    const result = convertIiifUriToInfoUri(
+    const result = convertRequestUriToInfoUri(
       'https://iiif.wellcomecollection.org/image/b0007.jp2'
     );
     expect(result).toEqual(

--- a/content/webapp/utils/convert-iiif-uri.ts
+++ b/content/webapp/utils/convert-iiif-uri.ts
@@ -1,18 +1,17 @@
-export function convertIiifUriToInfoUri(originalUriPath: string): string {
-  // Note: this regex assumes that our image identifiers have a three-letter
-  // file extension.  This won't always be the case, e.g. Miro images have
-  // identifiers like "B0009730".
-  //
-  // Is this going to be an issue?  Would we be better off counting slashes
-  // in the URL?
+// https://iiif.io/api/image/3.0/#21-image-request-uri-syntax
+// Image Request URI Syntax
+// {scheme}://{server}{/prefix}/{identifier}/{region}/{size}/{rotation}/{quality}.{format}
+// Image Information Request URI Syntax
+// {scheme}://{server}{/prefix}/{identifier}/info.json
+export function convertRequestUriToInfoUri(requestUri: string): string {
   const match =
-    originalUriPath &&
-    originalUriPath.match(
-      /^https:\/\/iiif\.wellcomecollection\.org\/image\/(.+?\.[a-z]{3})/
+    requestUri &&
+    requestUri.match(
+      /^https:\/\/iiif\.wellcomecollection\.org\/image\/([^/]+)/
     );
   if (match && match[0]) {
     return `${match[0]}/info.json`;
   } else {
-    return `${originalUriPath}/info.json`;
+    return `${requestUri}/info.json`;
   }
 }


### PR DESCRIPTION
This may be a silly idea, hence the draft PR, but I'd be interested in people's thoughts

## Background

We had an inquiry over the weekend (16th - 17th Dec, 2023) about [a work which is not displaying it's images](https://wellcomecollection.org/works/qvnz25jg/items). The [image url](https://iiif.wellcomecollection.org/image/b18023010_0001.JP2/full/1338%2C/0/default.jpg)s are returning '401 Unauthorized'.

[A slack discussion about this issue](https://wellcome.slack.com/archives/CBT40CMKQ/p1702897123155509) explains that this is because "a bunch of Genetics Books" have some restrictions in place which ultimately means their images have a maxUnauthorised value set to 1000. Because we try and request images that are larger than this, those requests fail as unauthorised.

This is a policy rather than a technical issue and could be fixed by relaxing the rules (dating back to 2012) which restrict the image size.

In lieu of that solution:

## What this PR does

If an image fails to load in the viewer, we try to load an image with it's longest dimension set to 1000px.

Before:
![Screenshot 2023-12-18 at 14 46 28](https://github.com/wellcomecollection/wellcomecollection.org/assets/6051896/48a9f936-9bc7-4087-8a47-730a436b5e45)

After:
![Screenshot 2023-12-18 at 14 46 41](https://github.com/wellcomecollection/wellcomecollection.org/assets/6051896/f5e4b39a-0392-4864-906b-415ffaba1b64)
