### PR TITLE
Switch focal for jammy in playwright test image

### DIFF
--- a/playwright/Dockerfile
+++ b/playwright/Dockerfile
@@ -1,13 +1,4 @@
-FROM mcr.microsoft.com/playwright:v1.40.1-focal
-
-# There is currently an issue when running WebKit (mobile) on certain Linux Docker images
-# which causes tests to fail incorrectly:
-# https://github.com/microsoft/playwright/issues/13060
-# To fix this, ideally we would be on Ubuntu jammy (22.04 LTS rather than focal, 20.04 LTS)
-# but currently the Docker version used in Buildkite agents causes a segfault
-# when Node starts https://github.com/nodejs/node/issues/43064, so instead we upgrade
-# packages manually (within focal).
-RUN apt update && apt upgrade -y
+FROM mcr.microsoft.com/playwright:v1.40.1
 
 ADD ./playwright /usr/src/app/webapp/playwright
 WORKDIR /usr/src/app/webapp/playwright


### PR DESCRIPTION
## What does this change?

This change updates the base os for the playwright image to use whatever is the default base rather than focal. The Buildkite stack has been updated, so hopefully now this will run without error.

At time of writing the base image is jammy:

```console
root@1b3df8063781:/# cat /etc/os-release
PRETTY_NAME="Ubuntu 22.04.3 LTS"
NAME="Ubuntu"
VERSION_ID="22.04"
VERSION="22.04.3 LTS (Jammy Jellyfish)"
VERSION_CODENAME=jammy
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=jammy
```

There is an added benefit of moving away from focal which has reached [end of long term support (LTS) for security updates](https://ubuntu.com/about/release-cycle).

> [!NOTE]
> Should follow: [rk/bump-to-pw-1.4](https://github.com/wellcomecollection/wellcomecollection.org/tree/rk/bump-to-pw-1.4)

## How to test?

- [ ] Run the e2e tests, do they pass?

## How can we measure success?

Less extra config to get this working, and we're using more secure images.