### PR TITLE
Add Bot Control to WAF rules

### DIFF
--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -156,7 +156,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
     priority = 4
 
     override_action {
-      count {}
+      none {}
     }
 
     statement {
@@ -179,7 +179,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
     priority = 5
 
     override_action {
-      count {}
+      none {}
     }
 
     statement {
@@ -202,7 +202,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
     priority = 6
 
     override_action {
-      count {}
+      none {}
     }
 
     statement {

--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -37,9 +37,42 @@ locals {
 
   ip_allowlist = setunion(var.waf_ip_allowlist, local.qualys_scanner_ips)
 
-  // See https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-bot.html
-  // and comment below for the bot control rule
-  bot_control_rule_allowlist = ["CategorySeo"]
+  // This is the complete list of Bot Control rules from
+  // https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-bot.html
+  //
+  // For ease of maintenance, we have the complete list here and comment out those rules which are
+  // we wish to be enabled or that we wish to remain enabled.
+  // Everything that is not commented out in this list will be disabled by setting its action to count.
+  //
+  // Config and rationale currently reflect's @jamieparkinson's understanding 3/1/2024
+  //
+  // TL;DR comment out a rule if you want to enable it
+  bot_control_rule_no_block_list = [
+    "CategoryAdvertising",       // No substantial traffic
+    "CategoryArchiver",          // Traffic is always desirable
+    "CategoryContentFetcher",    // Traffic is always desirable
+    "CategoryEmailClient",       // Traffic is always desirable
+    "CategoryHttpLibrary",       // High-risk for breaking scripts and other application services
+    "CategoryLinkChecker",       // No substantial traffic
+    "CategoryMiscellaneous",     // No substantial traffic
+    "CategoryMonitoring",        // Traffic is always desirable
+    "CategoryScrapingFramework", // No substantial traffic
+    "CategorySearchEngine",      // Traffic is always desirable
+    "CategorySecurity",          // Traffic is always desirable
+    // "CategorySeo",            // Unverified SEO bots are the source of the _vast_ majority of our bot traffic
+    "CategorySocialMedia",       // Traffic is always desirable
+    "CategoryAI",                // No substantial traffic
+    "SignalAutomatedBrowser",    // No substantial traffic
+    "SignalKnownBotDataCenter",  // Known bot data centres include "good" bots such as Updown
+    "SignalNonBrowserUserAgent", // High risk for breaking scripts and other application services
+    // These are for targeted Bot Control, which we don't use
+    // "TGT_VolumetricIpTokenAbsent",
+    // "TGT_VolumetricSession",
+    // "TGT_SignalAutomatedBrowser",
+    // "TGT_SignalBrowserInconsistency",
+    // "TGT_TokenReuseIp",
+    // "TGT_ML_CoordinatedActivityMedium and TGT_ML_CoordinatedActivityHigh"
+  ]
 }
 
 resource "aws_wafv2_web_acl" "wc_org" {
@@ -228,14 +261,15 @@ resource "aws_wafv2_web_acl" "wc_org" {
     priority = 7
 
     // Because the Bot Control rules are quite aggressive, they block some useful bots
-    // such as Updown. While we could add overrides for these, we don't want to have to
+    // such as Updown. While we could add overrides for specific bots, we don"t want to have to
     // keep coming back here as we use different monitoring services, scripts, etc.
-    // Instead, we're starting by defaulting to disabling rule actions and we only enable them
-    // for a specified allowlist of rules.
+    //
+    // Instead, we"re starting by disabling most of the more high-risk rules and retaining only the
+    // ones like CategorySeo which we know cover the majority of our known-bad bot traffic.
     // Rules can be found here:
     // https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-bot.html
     override_action {
-      count {}
+      none {}
     }
 
     statement {
@@ -250,7 +284,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
         }
 
         dynamic "rule_action_override" {
-          for_each = local.bot_control_rule_allowlist
+          for_each = local.bot_control_rule_no_block_list
           content {
             name = rule_action_override.value
             action_to_use {

--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -219,6 +219,34 @@ resource "aws_wafv2_web_acl" "wc_org" {
     }
   }
 
+  rule {
+    name     = "bot-control-rule-group"
+    priority = 7
+
+    override_action {
+      count {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesBotControlRuleSet"
+        vendor_name = "AWS"
+
+        managed_rule_group_configs {
+          aws_managed_rules_bot_control_rule_set {
+            inspection_level = "COMMON"
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      sampled_requests_enabled   = true
+      metric_name                = "weco-cloudfront-acl-bot-control-${var.namespace}"
+    }
+  }
+
   visibility_config {
     cloudwatch_metrics_enabled = true
     sampled_requests_enabled   = true


### PR DESCRIPTION
## Who is this for?
People who like the website to keep working without using a huge number of tasks

## What is it doing for them?
Hopefully blocking bot requests, which make up the vast majority of the recent increase in traffic
See https://docs.aws.amazon.com/waf/latest/developerguide/waf-bot-control.html