### PR TITLE
Display message for previews on Safari

### DIFF
--- a/common/views/components/ErrorPage/ErrorPage.tsx
+++ b/common/views/components/ErrorPage/ErrorPage.tsx
@@ -20,7 +20,7 @@ import Space from '@weco/common/views/components/styled/Space';
 import { dangerouslyGetEnabledToggles } from '@weco/common/utils/cookies';
 import Layout, { gridSize8 } from '../Layout';
 
-const ToggleMessageBar = styled(Space).attrs({
+const MessageBar = styled(Space).attrs({
   $h: { size: 'm', properties: ['padding-left', 'padding-right'] },
   $v: { size: 's', properties: ['padding-top', 'padding-bottom'] },
 })`
@@ -69,7 +69,7 @@ const TogglesMessage: FunctionComponent = () => {
 
   return toggles.length > 0 ? (
     <Layout gridSizes={gridSize8()}>
-      <ToggleMessageBar>
+      <MessageBar>
         <Space $h={{ size: 's', properties: ['margin-right'] }}>
           <Icon icon={underConstruction} />
         </Space>
@@ -84,8 +84,38 @@ const TogglesMessage: FunctionComponent = () => {
             </Fragment>
           ))}
         </Space>
-      </ToggleMessageBar>
+      </MessageBar>
     </Layout>
+  ) : null;
+};
+
+const SafariPreviewMessage: FunctionComponent = () => {
+  const [showPreviewSafariMessage, setShowPreviewSafariMessage] =
+    useState(false);
+
+  useEffect(() => {
+    const isSafari =
+      !navigator.userAgent.includes('Chrome') &&
+      navigator.userAgent.includes('Safari');
+    const isPreview = window.location.host.includes('preview.');
+
+    setShowPreviewSafariMessage(isSafari && isPreview);
+  }, []);
+
+  return showPreviewSafariMessage ? (
+    <Space $v={{ size: 'l', properties: ['margin-top'] }}>
+      <Layout gridSizes={gridSize8()}>
+        <MessageBar>
+          <Space $h={{ size: 's', properties: ['margin-right'] }}>
+            <Icon icon={underConstruction} />
+          </Space>
+          <Space $h={{ size: 's', properties: ['margin-right'] }}>
+            Prismic previews do not work in Safari. Please use a different
+            browser, or enable cross-site cookies.
+          </Space>
+        </MessageBar>
+      </Layout>
+    </Space>
   ) : null;
 };
 
@@ -131,6 +161,7 @@ const ErrorPage: FunctionComponent<Props> = ({ statusCode = 500, title }) => {
         />
         <SpacingSection>
           <SpacingComponent>
+            <SafariPreviewMessage />
             {getErrorMessage(statusCode)}
             <TogglesMessage />
           </SpacingComponent>


### PR DESCRIPTION
## Who is this for?
Editors and the people they share these links with
See related tickets #7761 and #10481

## What is it doing for them?
The ErrorPage component looks if the host contains `preview.` and the navigator userAgent includes `Safari` (and not `Chrome`, since [Chrome's userAgent can very well contain "Safari"](https://github.com/tamimibrahim17/List-of-user-agents/blob/master/Chrome.txt). If both conditions are met, an error message displays at the top of the Error Message (which is a 404, which I didn't think needed to be hidden).

<img width="1063" alt="Screenshot 2024-01-03 at 10 28 54" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/69dd8a3a-07e0-4162-96fd-67cb59db8c72">

I can't really test it locally as it depends on the host name, but I believe it'll work nicely + code review to double check my thinking!