### PR TITLE
Refactor search images e2e test first block

### DIFF
--- a/content/webapp/components/PaletteColorPicker/PaletteColorPicker.tsx
+++ b/content/webapp/components/PaletteColorPicker/PaletteColorPicker.tsx
@@ -199,7 +199,6 @@ const PaletteColorPicker: FunctionComponent<PaletteColorPickerProps> = ({
             {palette.map(swatch => (
               <Swatch
                 key={swatch.hexValue}
-                data-testid={`swatch-${swatch.colorName.toLowerCase()}`}
                 $hexColor={swatch.hexValue}
                 ariaPressed={colorState === swatch.hexValue}
                 onClick={() => setColorState(swatch.hexValue)}

--- a/playwright/test/helpers/search.ts
+++ b/playwright/test/helpers/search.ts
@@ -77,6 +77,16 @@ export const navigateToResultAndConfirmTitleMatches = async (
   await slowExpect(title).toContainText(String(searchResultTitle)); // searchResultTitle could also be null but I expect it would fail accordingly
 };
 
+export const clickImageSearchResultItem = async (
+  nthChild: number,
+  page: Page
+): Promise<void> => {
+  await page
+    .getByTestId('image-search-results-container')
+    .locator(`ul:first-child > li:nth-child(${nthChild}) a`)
+    .click();
+};
+
 // TODO
 // This could probably be better - We should have a different way of spotting if a filter is applied
 // Especially for mobile where they are hidden in the modal.

--- a/playwright/test/helpers/search.ts
+++ b/playwright/test/helpers/search.ts
@@ -97,5 +97,7 @@ export const selectAndWaitForColourFilter = async (page: Page) => {
 
   if (isMobile(page)) {
     await page.getByRole('button', { name: 'Show results' }).click();
+  } else {
+    await page.getByRole('button', { name: 'Colours' }).click();
   }
 };

--- a/playwright/test/search-images.test.ts
+++ b/playwright/test/search-images.test.ts
@@ -7,7 +7,7 @@ import {
   selectAndWaitForColourFilter,
 } from './helpers/search';
 
-const regexImageGalleryUrl = /\/works\/[a-zA-Z0-9]+\/images[?]id=/;
+const ItemViewerURLRegex = /\/works\/[a-zA-Z0-9]+\/images[?]id=/;
 
 const clickActionClickSearchResultItem = async (
   nthChild: number,
@@ -19,7 +19,7 @@ const clickActionClickSearchResultItem = async (
     .click();
 };
 
-test('(1) | Search by term, filter by colour, check results, view image details, view expanded image', async ({
+test.only('(1) | Search by term, filter by colour, check results, view image details, view expanded image', async ({
   page,
   context,
 }) => {
@@ -42,7 +42,7 @@ test('(1) | Search by term, filter by colour, check results, view image details,
 
   page.getByRole('link', { name: 'View expanded image' });
   await page.getByLabel('View expanded image').click();
-  await expect(page).toHaveURL(RegExp(regexImageGalleryUrl));
+  await expect(page).toHaveURL(RegExp(ItemViewerURLRegex));
 });
 
 test('(2) | Image Modal | images without contributors still show a title', async ({

--- a/playwright/test/search-images.test.ts
+++ b/playwright/test/search-images.test.ts
@@ -40,8 +40,7 @@ test.only('(1) | Search by term, filter by colour, check results, view image det
     page.getByRole('heading', { name: 'Visually similar images' })
   ).toBeVisible();
 
-  page.getByRole('link', { name: 'View expanded image' });
-  await page.getByLabel('View expanded image').click();
+  await page.getByRole('link', { name: 'View expanded image' }).click();
   await expect(page).toHaveURL(RegExp(ItemViewerURLRegex));
 });
 

--- a/playwright/test/search-images.test.ts
+++ b/playwright/test/search-images.test.ts
@@ -2,6 +2,7 @@ import { Page, test, expect } from '@playwright/test';
 import { newSearch } from './helpers/contexts';
 import { expectItemIsVisible } from './asserts/common';
 import {
+  clickImageSearchResultItem,
   searchQuerySubmitAndWait,
   selectAndWaitForColourFilter,
 } from './helpers/search';
@@ -29,7 +30,7 @@ test('(1) | Search by term, filter by colour, check results, view image details,
   await expect(
     page.getByTestId('image-search-results-container')
   ).toBeVisible();
-  await clickActionClickSearchResultItem(1, page);
+  await clickImageSearchResultItem(1, page);
   await expect(page.getByLabel('View expanded image')).toBeVisible();
 
   // Check we show visually similar images.  This could theoretically fail
@@ -39,6 +40,7 @@ test('(1) | Search by term, filter by colour, check results, view image details,
     page.getByRole('heading', { name: 'Visually similar images' })
   ).toBeVisible();
 
+  page.getByRole('link', { name: 'View expanded image' });
   await page.getByLabel('View expanded image').click();
   await expect(page).toHaveURL(RegExp(regexImageGalleryUrl));
 });

--- a/playwright/test/search-images.test.ts
+++ b/playwright/test/search-images.test.ts
@@ -19,7 +19,7 @@ const clickActionClickSearchResultItem = async (
     .click();
 };
 
-test.only('(1) | Search by term, filter by colour, check results, view image details, view expanded image', async ({
+test('(1) | Search by term, filter by colour, check results, view image details, view expanded image', async ({
   page,
   context,
 }) => {


### PR DESCRIPTION
## Who is this for?
People who like non flaky tests

## What is it doing for them?
- Use `selectAndWaitForColourFilter` because it does what all those lines were doing. Added a step in this function to close the colour filter dropdown on desktop as it was getting in the way of selecting the 1st search result. 
- removed `data-test-id` on the `PaletteColorPicker`, now unused
- not checking that the 1st result item is visible: we click on it later on so it'll fail there if the item is not visible