### PR TITLE
Remove doubled up microcopy

### DIFF
--- a/content/webapp/components/ExpandedImage/ExpandedImage.tsx
+++ b/content/webapp/components/ExpandedImage/ExpandedImage.tsx
@@ -12,7 +12,6 @@ import {
   Work,
 } from '@weco/content/services/wellcome/catalogue/types';
 import { getWorkClientSide } from '@weco/content/services/wellcome/catalogue/works';
-import { expandedViewImageButton } from '@weco/content/text/aria-labels';
 import { fetchIIIFPresentationManifest } from '@weco/content/services/iiif/fetch/manifest';
 import { transformManifest } from '@weco/content/services/iiif/transformers/manifest';
 
@@ -347,7 +346,7 @@ const ExpandedImage: FunctionComponent<Props> = ({
                   text="View image"
                   icon={eye}
                   link={expandedImageLink}
-                  ariaLabel={expandedViewImageButton}
+                  ariaLabel="View expanded image"
                 />
               </ViewImageButtonWrapper>
             </Space>

--- a/content/webapp/components/IIIFSearchWithin/IIIFSearchWithin.tsx
+++ b/content/webapp/components/IIIFSearchWithin/IIIFSearchWithin.tsx
@@ -24,6 +24,7 @@ import { SearchResults } from '@weco/content/services/iiif/types/search/v3';
 import { TransformedCanvas } from '@weco/content/types/manifest';
 import { thumbnailsPageSize } from '@weco/content/components/IIIFViewer/Paginators';
 import { pluralize } from '@weco/common/utils/grammar';
+import { searchWithinLabel } from '@weco/content/text/aria-labels';
 
 const Highlight = styled.span`
   background: ${props => props.theme.color('accent.purple')};
@@ -203,7 +204,7 @@ const IIIFSearchWithin: FunctionComponent = () => {
         <SearchInputWrapper>
           <TextInput
             id="searchWithin"
-            label="Search within this item"
+            label={searchWithinLabel}
             name="query"
             value={value}
             setValue={setValue}

--- a/content/webapp/text/aria-labels.ts
+++ b/content/webapp/text/aria-labels.ts
@@ -1,9 +1,5 @@
-export const expandedViewImageButton = 'View expanded image';
 export const searchFilterCheckBox = (label: string): string => {
   return `Radio checkbox ${label}`;
 };
-export const searchFormInputCatalogue = 'Search the catalogue';
-export const searchFormInputImage = 'Search for Images';
-export const searchFilterCloseButton = 'Close Filter';
-export const volumesNavigationLabel = 'Volumes navigation';
 export const searchWithinLabel = 'Search within this item';
+export const volumesNavigationLabel = 'Volumes navigation';

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -33,12 +33,13 @@ import {
 } from './selectors/item';
 import { baseUrl } from './helpers/urls';
 import { makeDefaultToggleCookies } from './helpers/utils';
+import {
+  searchWithinLabel,
+  volumesNavigationLabel,
+} from '@weco/content/text/aria-labels';
 import safeWaitForNavigation from './helpers/safeWaitForNavigation';
 
 const domain = new URL(baseUrl).host;
-
-const volumesNavigationLabel = 'Volumes navigation';
-const searchWithinLabel = 'Search within this item';
 
 const searchWithin = async (query: string, page: Page) => {
   await page.fill(`text=${searchWithinLabel}`, query);

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -33,13 +33,12 @@ import {
 } from './selectors/item';
 import { baseUrl } from './helpers/urls';
 import { makeDefaultToggleCookies } from './helpers/utils';
-import {
-  searchWithinLabel,
-  volumesNavigationLabel,
-} from '@weco/content/text/aria-labels';
 import safeWaitForNavigation from './helpers/safeWaitForNavigation';
 
 const domain = new URL(baseUrl).host;
+
+const volumesNavigationLabel = 'Volumes navigation';
+const searchWithinLabel = 'Search within this item';
 
 const searchWithin = async (query: string, page: Page) => {
   await page.fill(`text=${searchWithinLabel}`, query);


### PR DESCRIPTION
## Who is this for?
Maintenance

## What is it doing for them?
Half of this was an opinion, so open to reverting some changes.
If I understood/remember correctly, `aria-labels` files are used to make it easier for anyone to edit copy on the website, but a lot of it isn't used anymore. I just wonder if anyone but devs actually update that copy and if there is still value in having it in a separate file?
- Remove the copy that wasn't used anywhere
- Kept the ones that are used more than once across the site.
- If they were only used once I moved it directly in the component but as that goes against the original goal I'd be up for putting them back. Maybe we move it all to `microcopy`?