### PR TITLE
Clarify usage of TitleTopper by renaming it and removing TODO

### DIFF
--- a/common/views/components/PageHeader/PageHeader.tsx
+++ b/common/views/components/PageHeader/PageHeader.tsx
@@ -109,13 +109,8 @@ type Props = {
   backgroundTexture?: string;
   highlightHeading?: boolean;
   isContentTypeInfoBeforeMedia?: boolean;
+  SerialPartNumber?: ReactNode;
   sectionLevelPage?: boolean;
-  // TODO: Don't overload this, it's just for putting things in till
-  // we find a pattern
-  // EDIT: The comment above is 5 years old, we believe the change is simple
-  // and created a ticket to address it
-  // https://github.com/wellcomecollection/wellcomecollection.org/issues/10288
-  TitleTopper?: ReactNode;
 };
 
 const sectionLevelPageGridLayout = { s: 12, m: 12, l: 10, xl: 10 };
@@ -134,7 +129,7 @@ const PageHeader: FunctionComponent<Props> = ({
   heroImageBgColor = 'white',
   backgroundTexture,
   highlightHeading,
-  TitleTopper,
+  SerialPartNumber,
   sectionLevelPage,
 }) => {
   const Heading =
@@ -188,7 +183,7 @@ const PageHeader: FunctionComponent<Props> = ({
                 </Space>
               )}
             >
-              {TitleTopper}
+              {SerialPartNumber}
               {Heading}
             </ConditionalWrapper>
 

--- a/content/webapp/pages/articles/[articleId].tsx
+++ b/content/webapp/pages/articles/[articleId].tsx
@@ -218,12 +218,11 @@ const ArticlePage: FunctionComponent<Props> = ({ article, jsonLd }) => {
   const isPodcast = article.format?.id === ArticleFormatIds.Podcast;
 
   // Check if the article is in a serial, and where
+  // If so, create relevant PartNumberIndicator
   const serial = article.series.find(series => series.schedule.length > 0);
   const partNumber = getPartNumberInSeries(article);
 
-  // We can abstract this out as a component if we see it elsewhere.
-  // Not too confident it's going to be used like this for long.
-  const TitleTopper = serial && partNumber && (
+  const SerialPartNumber = serial && partNumber && (
     <PartNumberIndicator
       number={partNumber}
       backgroundColor={serial.color}
@@ -295,7 +294,7 @@ const ArticlePage: FunctionComponent<Props> = ({ article, jsonLd }) => {
           : maybeHeroPicture
       }
       heroImageBgColor={isImageGallery ? 'white' : 'warmNeutral.300'}
-      TitleTopper={TitleTopper}
+      SerialPartNumber={SerialPartNumber}
       isContentTypeInfoBeforeMedia={true}
     />
   );


### PR DESCRIPTION
## Who is this for?
Maintenance
Relates to #10288 

## What is it doing for them?
See ticket for more info but tl;dr the TODO is 5 years old and that prop is only used once for a specific purpose so we opted to make that clear.
