### PR TITLE
determine if a manifest contains born digital

### DIFF
--- a/content/webapp/__mocks__/iiif-manifest-v3.ts
+++ b/content/webapp/__mocks__/iiif-manifest-v3.ts
@@ -11318,3 +11318,328 @@ export const manifestWithClickThroughService = {
     },
   ],
 };
+
+export const manifestAllBornDigital = {
+  items: [
+    {
+      id: 'https://iiif-test.wellcomecollection.org/presentation/ARTCOO/B/10/canvases/ARTCOO_B_10---1_English_Ver.pdf',
+      type: 'Canvas',
+      label: {
+        none: ['1_English_Ver.pdf'],
+      },
+      width: 5000,
+      height: 5000,
+      thumbnail: [
+        {
+          id: 'https://iiif-test.wellcomecollection.org/extensions/born-digital/placeholder-thumb/fmt/17/application/pdf',
+          type: 'Image',
+          width: 500,
+          height: 500,
+          format: 'image/png',
+        },
+      ],
+      metadata: [
+        {
+          label: {
+            en: ['File format'],
+          },
+          value: {
+            none: ['Acrobat PDF 1.3 - Portable Document Format'],
+          },
+        },
+        {
+          label: {
+            en: ['File size'],
+          },
+          value: {
+            none: ['1.9 MB'],
+          },
+        },
+        {
+          label: {
+            en: ['Pronom key'],
+          },
+          value: {
+            none: ['fmt/17'],
+          },
+        },
+        {
+          label: {
+            en: ['Full path'],
+          },
+          value: {
+            none: ['1_English_Ver.pdf'],
+          },
+        },
+      ],
+      rendering: [
+        {
+          id: 'https://iiif-test.wellcomecollection.org/file/ARTCOO_B_10---1_English_Ver.pdf',
+          type: 'Text',
+          label: {
+            none: ['1_English_Ver.pdf'],
+          },
+          format: 'application/pdf',
+          behavior: ['original'],
+        },
+      ],
+      behavior: ['placeholder'],
+      navDate: '2022-03-25T00:00:00.0000000',
+      items: [
+        {
+          id: 'https://iiif-test.wellcomecollection.org/presentation/ARTCOO/B/10/canvases/ARTCOO_B_10---1_English_Ver.pdf/painting',
+          type: 'AnnotationPage',
+          items: [
+            {
+              id: 'https://iiif-test.wellcomecollection.org/presentation/ARTCOO/B/10/canvases/ARTCOO_B_10---1_English_Ver.pdf/painting/anno',
+              type: 'Annotation',
+              motivation: 'painting',
+              body: {
+                id: 'https://iiif-test.wellcomecollection.org/extensions/born-digital/placeholder-canvas/fmt/17/application/pdf',
+                type: 'Image',
+                width: 5000,
+                height: 5000,
+                format: 'image/png',
+              },
+              target:
+                'https://iiif-test.wellcomecollection.org/presentation/ARTCOO/B/10/canvases/ARTCOO_B_10---1_English_Ver.pdf',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      id: 'https://iiif-test.wellcomecollection.org/presentation/ARTCOO/B/10/canvases/ARTCOO_B_10---2_Japanese_Ver.pdf',
+      type: 'Canvas',
+      label: {
+        none: ['2_Japanese_Ver.pdf'],
+      },
+      width: 5000,
+      height: 5000,
+      thumbnail: [
+        {
+          id: 'https://iiif-test.wellcomecollection.org/extensions/born-digital/placeholder-thumb/fmt/17/application/pdf',
+          type: 'Image',
+          width: 500,
+          height: 500,
+          format: 'image/png',
+        },
+      ],
+      metadata: [
+        {
+          label: {
+            en: ['File format'],
+          },
+          value: {
+            none: ['Acrobat PDF 1.3 - Portable Document Format'],
+          },
+        },
+        {
+          label: {
+            en: ['File size'],
+          },
+          value: {
+            none: ['1.9 MB'],
+          },
+        },
+        {
+          label: {
+            en: ['Pronom key'],
+          },
+          value: {
+            none: ['fmt/17'],
+          },
+        },
+        {
+          label: {
+            en: ['Full path'],
+          },
+          value: {
+            none: ['2_Japanese_Ver.pdf'],
+          },
+        },
+      ],
+      rendering: [
+        {
+          id: 'https://iiif-test.wellcomecollection.org/file/ARTCOO_B_10---2_Japanese_Ver.pdf',
+          type: 'Text',
+          label: {
+            none: ['2_Japanese_Ver.pdf'],
+          },
+          format: 'application/pdf',
+          behavior: ['original'],
+        },
+      ],
+      behavior: ['placeholder'],
+      navDate: '2022-03-25T00:00:00.0000000',
+      items: [
+        {
+          id: 'https://iiif-test.wellcomecollection.org/presentation/ARTCOO/B/10/canvases/ARTCOO_B_10---2_Japanese_Ver.pdf/painting',
+          type: 'AnnotationPage',
+          items: [
+            {
+              id: 'https://iiif-test.wellcomecollection.org/presentation/ARTCOO/B/10/canvases/ARTCOO_B_10---2_Japanese_Ver.pdf/painting/anno',
+              type: 'Annotation',
+              motivation: 'painting',
+              body: {
+                id: 'https://iiif-test.wellcomecollection.org/extensions/born-digital/placeholder-canvas/fmt/17/application/pdf',
+                type: 'Image',
+                width: 5000,
+                height: 5000,
+                format: 'image/png',
+              },
+              target:
+                'https://iiif-test.wellcomecollection.org/presentation/ARTCOO/B/10/canvases/ARTCOO_B_10---2_Japanese_Ver.pdf',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+export const manifestMixedBornDigital = {
+  items: [
+    {
+      id: 'https://iiif-stage.wellcomecollection.org/presentation/SAWFO/J/4/canvases/SAWFO_J_4---Disc_2---WFOT_ms.pps',
+      type: 'Canvas',
+      label: {
+        none: ['WFOT_ms.pps'],
+      },
+      width: 1000,
+      height: 800,
+      thumbnail: [
+        {
+          id: 'https://iiif-stage.wellcomecollection.org/extensions/born-digital/placeholder-thumb/fmt/126/application/vnd.ms-powerpoint',
+          type: 'Image',
+          width: 101,
+          height: 151,
+          format: 'image/png',
+        },
+      ],
+      metadata: [
+        {
+          label: {
+            en: ['File format'],
+          },
+          value: {
+            none: ['Microsoft Powerpoint'],
+          },
+        },
+        {
+          label: {
+            en: ['File size'],
+          },
+          value: {
+            none: ['1.6 MB'],
+          },
+        },
+        {
+          label: {
+            en: ['Pronom key'],
+          },
+          value: {
+            none: ['fmt/126'],
+          },
+        },
+        {
+          label: {
+            en: ['Full path'],
+          },
+          value: {
+            none: ['Disc_2/WFOT_ms.pps'],
+          },
+        },
+      ],
+      rendering: [
+        {
+          id: 'https://iiif-stage.wellcomecollection.org/file/SAWFO_J_4---Disc_2---WFOT_ms.pps',
+          type: 'Text',
+          label: {
+            none: ['WFOT_ms.pps'],
+          },
+          format: 'application/vnd.ms-powerpoint',
+          behavior: ['original'],
+        },
+      ],
+      behavior: ['placeholder'],
+      navDate: '2023-04-12T09:34:48.0000000+00:00',
+      items: [
+        {
+          id: 'https://iiif-stage.wellcomecollection.org/presentation/SAWFO/J/4/canvases/SAWFO_J_4---Disc_2---WFOT_ms.pps/painting',
+          type: 'AnnotationPage',
+          items: [
+            {
+              id: 'https://iiif-stage.wellcomecollection.org/presentation/SAWFO/J/4/canvases/SAWFO_J_4---Disc_2---WFOT_ms.pps/painting/anno',
+              type: 'Annotation',
+              motivation: 'painting',
+              body: {
+                id: 'https://iiif-stage.wellcomecollection.org/extensions/born-digital/placeholder-canvas/fmt/126/application/vnd.ms-powerpoint',
+                type: 'Image',
+                width: 1000,
+                height: 800,
+                format: 'image/png',
+              },
+              target:
+                'https://iiif-stage.wellcomecollection.org/presentation/SAWFO/J/4/canvases/SAWFO_J_4---Disc_2---WFOT_ms.pps',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      id: 'https://iiif-stage.wellcomecollection.org/presentation/SAWFO/J/4/canvases/SAWFO_J_4---Disc_2---slide13.wav',
+      type: 'Canvas',
+      label: {
+        none: ['slide13.wav'],
+      },
+      duration: 52.519,
+      metadata: [
+        {
+          label: {
+            en: ['Full path'],
+          },
+          value: {
+            none: ['Disc_2/slide13.wav'],
+          },
+        },
+      ],
+      rendering: [
+        {
+          duration: 52.519,
+          id: 'https://iiif-stage.wellcomecollection.org/av/SAWFO_J_4---Disc_2---slide13.wav/full/max/default.mp3',
+          type: 'Sound',
+          label: {
+            en: ['Audio file, 52.519 s'],
+          },
+          format: 'audio/mp3',
+        },
+      ],
+      navDate: '2023-04-12T09:34:41.0000000+00:00',
+      items: [
+        {
+          id: 'https://iiif-stage.wellcomecollection.org/presentation/SAWFO/J/4/canvases/SAWFO_J_4---Disc_2---slide13.wav/painting',
+          type: 'AnnotationPage',
+          items: [
+            {
+              id: 'https://iiif-stage.wellcomecollection.org/presentation/SAWFO/J/4/canvases/SAWFO_J_4---Disc_2---slide13.wav/painting/anno',
+              type: 'Annotation',
+              motivation: 'painting',
+              body: {
+                duration: 52.519,
+                id: 'https://iiif-stage.wellcomecollection.org/av/SAWFO_J_4---Disc_2---slide13.wav/full/max/default.mp3',
+                type: 'Sound',
+                label: {
+                  en: ['Audio file, 52.519 s'],
+                },
+                format: 'audio/mp3',
+              },
+              target:
+                'https://iiif-stage.wellcomecollection.org/presentation/SAWFO/J/4/canvases/SAWFO_J_4---Disc_2---slide13.wav',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};

--- a/content/webapp/components/Work/Work.tsx
+++ b/content/webapp/components/Work/Work.tsx
@@ -30,6 +30,7 @@ import useTransformedManifest from '@weco/content/hooks/useTransformedManifest';
 import { Audio, Video } from '@weco/content/services/iiif/types/manifest/v3';
 import { ApiToolbarLink } from '@weco/common/views/components/ApiToolbar';
 import { Container } from '@weco/common/views/components/styled/Container';
+import { useToggles } from '@weco/common/server-data/Context';
 
 const ArchiveDetailsContainer = styled.div`
   display: block;
@@ -111,6 +112,7 @@ type Props = {
 
 const Work: FunctionComponent<Props> = ({ work, apiUrl }) => {
   const transformedIIIFManifest = useTransformedManifest(work);
+  const { bornDigitalMessage } = useToggles();
 
   const isArchive = !!(
     work.parts.length ||
@@ -129,7 +131,9 @@ const Work: FunctionComponent<Props> = ({ work, apiUrl }) => {
     iiifPresentationLocation || iiifImageLocation;
   const digitalLocationInfo =
     digitalLocation && getDigitalLocationInfo(digitalLocation);
-  const { video, audio } = { ...transformedIIIFManifest };
+  const { video, audio, collectionManifestsCount, bornDigitalStatus } = {
+    ...transformedIIIFManifest,
+  };
   const shouldShowItemLink = showItemLink({
     digitalLocation,
     accessCondition: digitalLocationInfo?.accessCondition,
@@ -153,8 +157,6 @@ const Work: FunctionComponent<Props> = ({ work, apiUrl }) => {
         crops: {},
       }
     : undefined;
-
-  const { collectionManifestsCount } = { ...transformedIIIFManifest };
 
   return (
     <IsArchiveContext.Provider value={isArchive}>
@@ -187,6 +189,34 @@ const Work: FunctionComponent<Props> = ({ work, apiUrl }) => {
             </Space>
           </Grid>
         </Container>
+
+        {!bornDigitalMessage && ( // TODO take off ! before commiting
+          <Container>
+            <Grid>
+              <Space
+                className={grid({ s: 12 })}
+                $v={{ size: 'l', properties: ['padding-top'] }}
+              >
+                <div
+                  style={{
+                    marginBottom: '10px',
+                    background: '#A1EEED',
+                    width: '100%',
+                    padding: '8px 16px 5px',
+                  }}
+                >
+                  <strong>{`The iif-manifest for this work ${
+                    bornDigitalStatus !== 'noBornDigital'
+                      ? 'has'
+                      : 'does not have'
+                  } born digital content`}</strong>
+                  <br />
+                  {`status: ${bornDigitalStatus}`}
+                </div>
+              </Space>
+            </Grid>
+          </Container>
+        )}
 
         {isArchive ? (
           <>

--- a/content/webapp/components/Work/Work.tsx
+++ b/content/webapp/components/Work/Work.tsx
@@ -205,7 +205,7 @@ const Work: FunctionComponent<Props> = ({ work, apiUrl }) => {
                     padding: '8px 16px 5px',
                   }}
                 >
-                  <strong>{`The iif-manifest for this work ${
+                  <strong>{`The iiif-manifest for this work ${
                     bornDigitalStatus !== 'noBornDigital'
                       ? 'has'
                       : 'does not have'

--- a/content/webapp/components/Work/Work.tsx
+++ b/content/webapp/components/Work/Work.tsx
@@ -190,7 +190,7 @@ const Work: FunctionComponent<Props> = ({ work, apiUrl }) => {
           </Grid>
         </Container>
 
-        {!bornDigitalMessage && ( // TODO take off ! before commiting
+        {bornDigitalMessage && (
           <Container>
             <Grid>
               <Space

--- a/content/webapp/services/iiif/transformers/manifest.ts
+++ b/content/webapp/services/iiif/transformers/manifest.ts
@@ -21,6 +21,7 @@ import {
   getCollectionManifests,
   checkModalRequired,
   checkIsTotallyRestricted,
+  getBornDigitalStatus,
 } from '@weco/content/utils/iiif/v3';
 
 export function transformManifest(manifestV3: Manifest): TransformedManifest {
@@ -58,7 +59,10 @@ export function transformManifest(manifestV3: Manifest): TransformedManifest {
   const structures = manifestV3.structures || [];
   const isCollectionManifest = manifestV3.type === 'Collection';
   const downloadEnabled = hasPdfDownload(manifestV3);
+  const bornDigitalStatus = getBornDigitalStatus(manifestV3);
+
   return {
+    bornDigitalStatus,
     id,
     firstCollectionManifestLocation,
     audio,

--- a/content/webapp/test/utils/iiif.test.ts
+++ b/content/webapp/test/utils/iiif.test.ts
@@ -303,7 +303,7 @@ describe('getIIIFPresentationCredit', () => {
   });
 });
 
-describe.only('Determines if a iiif-manifest includes born digital items', () => {
+describe('Determines if a iiif-manifest includes born digital items', () => {
   it('returns a status of "noBornDigital" for manifests with no born digital items', () => {
     const bornDigitalStatus = getBornDigitalStatus(manifest as Manifest);
     expect(bornDigitalStatus).toEqual('noBornDigital');

--- a/content/webapp/test/utils/iiif.test.ts
+++ b/content/webapp/test/utils/iiif.test.ts
@@ -8,6 +8,7 @@ import {
   getTransformedCanvases,
   getMultiVolumeLabel,
   groupStructures,
+  getBornDigitalStatus,
 } from '../../utils/iiif/v3';
 import {
   manifest,
@@ -17,6 +18,8 @@ import {
   physicalDescriptionMetadataItem,
   manifestWithVideo,
   clickThroughService,
+  manifestAllBornDigital,
+  manifestMixedBornDigital,
 } from '@weco/content/__mocks__/iiif-manifest-v3';
 
 import b16641097 from '@weco/content/test/fixtures/iiif/manifests/b16641097';
@@ -297,5 +300,24 @@ describe('getIIIFPresentationCredit', () => {
       manifestWithTranscript as Manifest
     );
     expect(credit).toEqual('Wellcome Collection');
+  });
+});
+
+describe.only('Determines if a iiif-manifest includes born digital items', () => {
+  it('returns a status of "noBornDigital" for manifests with no born digital items', () => {
+    const bornDigitalStatus = getBornDigitalStatus(manifest as Manifest);
+    expect(bornDigitalStatus).toEqual('noBornDigital');
+  });
+  it('returns a status of "mixedBornDigital" for manifests with a mix of born digital and non born digital items', () => {
+    const bornDigitalStatus = getBornDigitalStatus(
+      manifestMixedBornDigital as unknown as Manifest
+    );
+    expect(bornDigitalStatus).toEqual('mixedBornDigital');
+  });
+  it('returns a status of "allBornDigital" for manifests with only born digital items', () => {
+    const bornDigitalStatus = getBornDigitalStatus(
+      manifestAllBornDigital as unknown as Manifest
+    );
+    expect(bornDigitalStatus).toEqual('allBornDigital');
   });
 });

--- a/content/webapp/types/manifest.ts
+++ b/content/webapp/types/manifest.ts
@@ -43,10 +43,8 @@ export type BornDigitalStatus =
   | 'mixedBornDigital';
 
 export type TransformedManifest = {
-  // Currently from iiifManifest V2:
   downloadEnabled?: boolean;
   firstCollectionManifestLocation?: string;
-  // Currently from iiif manifest v3:
   title: string;
   id: string;
   audio: Audio | undefined;

--- a/content/webapp/types/manifest.ts
+++ b/content/webapp/types/manifest.ts
@@ -45,6 +45,7 @@ export type BornDigitalStatus =
 export type TransformedManifest = {
   downloadEnabled?: boolean;
   firstCollectionManifestLocation?: string;
+  bornDigitalStatus: BornDigitalStatus;
   title: string;
   id: string;
   audio: Audio | undefined;

--- a/content/webapp/types/manifest.ts
+++ b/content/webapp/types/manifest.ts
@@ -37,6 +37,11 @@ export type AuthClickThroughServiceWithPossibleServiceArray = Omit<
   service: AuthAccessTokenService | AuthAccessTokenService[];
 };
 
+export type BornDigitalStatus =
+  | 'allBornDigital'
+  | 'noBornDigital'
+  | 'mixedBornDigital';
+
 export type TransformedManifest = {
   // Currently from iiifManifest V2:
   downloadEnabled?: boolean;

--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -1,5 +1,12 @@
 import { Audio, Video } from '@weco/content/services/iiif/types/manifest/v3';
 import {
+  BornDigitalStatus,
+  DownloadOption,
+  TransformedCanvas,
+  AuthClickThroughServiceWithPossibleServiceArray,
+  SpecificationBehaviors,
+} from '@weco/content/types/manifest';
+import {
   AnnotationPage,
   AnnotationBody,
   ChoiceBody,
@@ -16,11 +23,6 @@ import {
   Range,
 } from '@iiif/presentation-3';
 import { isNotUndefined, isString } from '@weco/common/utils/type-guards';
-import {
-  DownloadOption,
-  TransformedCanvas,
-  AuthClickThroughServiceWithPossibleServiceArray,
-} from '@weco/content/types/manifest';
 import { getThumbnailImage } from './canvas';
 
 // The label we want to use to distinguish between parts of a multi-volume work
@@ -531,4 +533,37 @@ export function getCollectionManifests(manifest: Manifest): Canvas[] {
     })
     .flat();
   return [...firstLevelManifests, ...collectionManifests] as Canvas[];
+}
+
+type CustomSpecificationBehaviors = SpecificationBehaviors & 'placeholder';
+// Whether something is born digital or not is determined at the canvas level within a iiifManifest
+// It is therefore possible to have a iiifManifest that contains:
+// - only born digital items
+// - no born digital items
+// - a mix of the two.
+// We need to know which we have to determine the required UI.
+export function getBornDigitalStatus(manifest: Manifest): BornDigitalStatus {
+  const hasBornDigital =
+    manifest?.items.some(
+      canvas =>
+        canvas?.behavior?.includes(
+          'placeholder' as CustomSpecificationBehaviors
+        )
+    ) || false;
+  const hasNonBornDigital =
+    manifest?.items.some(
+      canvas =>
+        !canvas?.behavior?.includes(
+          'placeholder' as CustomSpecificationBehaviors
+        )
+    ) || false;
+  if (hasBornDigital && !hasNonBornDigital) {
+    return 'allBornDigital';
+  } else if (!hasBornDigital) {
+    return 'noBornDigital';
+  } else if (hasBornDigital && hasNonBornDigital) {
+    return 'mixedBornDigital';
+  } else {
+    return 'noBornDigital';
+  }
 }

--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -4,7 +4,6 @@ import {
   DownloadOption,
   TransformedCanvas,
   AuthClickThroughServiceWithPossibleServiceArray,
-  SpecificationBehaviors,
 } from '@weco/content/types/manifest';
 import {
   AnnotationPage,
@@ -21,6 +20,7 @@ import {
   AuthExternalService,
   AuthAccessTokenService,
   Range,
+  SpecificationBehaviors,
 } from '@iiif/presentation-3';
 import { isNotUndefined, isString } from '@weco/common/utils/type-guards';
 import { getThumbnailImage } from './canvas';
@@ -535,7 +535,7 @@ export function getCollectionManifests(manifest: Manifest): Canvas[] {
   return [...firstLevelManifests, ...collectionManifests] as Canvas[];
 }
 
-type CustomSpecificationBehaviors = SpecificationBehaviors & 'placeholder';
+type CustomSpecificationBehaviors = SpecificationBehaviors | 'placeholder';
 // Whether something is born digital or not is determined at the canvas level within a iiifManifest
 // It is therefore possible to have a iiifManifest that contains:
 // - only born digital items
@@ -543,20 +543,20 @@ type CustomSpecificationBehaviors = SpecificationBehaviors & 'placeholder';
 // - a mix of the two.
 // We need to know which we have to determine the required UI.
 export function getBornDigitalStatus(manifest: Manifest): BornDigitalStatus {
-  const hasBornDigital =
-    manifest?.items.some(
-      canvas =>
-        canvas?.behavior?.includes(
-          'placeholder' as CustomSpecificationBehaviors
-        )
-    ) || false;
-  const hasNonBornDigital =
-    manifest?.items.some(
-      canvas =>
-        !canvas?.behavior?.includes(
-          'placeholder' as CustomSpecificationBehaviors
-        )
-    ) || false;
+  const hasBornDigital = manifest?.items.some(canvas => {
+    const behavior = canvas?.behavior as
+      | CustomSpecificationBehaviors[]
+      | undefined;
+    return behavior?.includes('placeholder') || false;
+  });
+
+  const hasNonBornDigital = manifest?.items.some(canvas => {
+    const behavior = canvas?.behavior as
+      | CustomSpecificationBehaviors[]
+      | undefined;
+    return !behavior?.includes('placeholder') || false;
+  });
+
   if (hasBornDigital && !hasNonBornDigital) {
     return 'allBornDigital';
   } else if (!hasBornDigital) {

--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -559,8 +559,6 @@ export function getBornDigitalStatus(manifest: Manifest): BornDigitalStatus {
 
   if (hasBornDigital && !hasNonBornDigital) {
     return 'allBornDigital';
-  } else if (!hasBornDigital) {
-    return 'noBornDigital';
   } else if (hasBornDigital && hasNonBornDigital) {
     return 'mixedBornDigital';
   } else {

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -68,6 +68,14 @@ const toggles = {
         'Adds an Events section to the Search hub and a new Events tab for more specific searches',
       type: 'experimental',
     },
+    {
+      id: 'bornDigitalMessage',
+      title: 'Displays whether a work has born digital items or not',
+      initialValue: false,
+      description:
+        'Adds some text to the top of a work page stating whether there are born digital items in the iiif-manifest',
+      type: 'experimental',
+    },
   ] as const,
   tests: [] as ABTest[],
 };


### PR DESCRIPTION
Relates to [#10493](https://github.com/wellcomecollection/wellcomecollection.org/issues/10493)

This adds a property of bornDigitalStatus to a transformedManifest, which we can use to make decisions about the UI.

For now, I'm just displaying the status at the top of the work page (behind a toggle).

![Screenshot 2024-01-04 at 14 14 17](https://github.com/wellcomecollection/wellcomecollection.org/assets/6051896/8e0e397a-df6f-4582-8df7-76ab676cd409)
