### PR TITLE
Refactor of Test(2) and Test(3)

### DIFF
--- a/common/views/components/Modal/Modal.tsx
+++ b/common/views/components/Modal/Modal.tsx
@@ -24,6 +24,7 @@ type Props = PropsWithChildren<{
   width?: string | null;
   maxWidth?: string;
   id: string;
+  dataTestId?: string;
   openButtonRef?: MutableRefObject<HTMLElement | null>;
   removeCloseButton?: boolean;
   showOverlay?: boolean;
@@ -188,6 +189,7 @@ const Modal: FunctionComponent<Props> = ({
   width = null,
   maxWidth,
   id,
+  dataTestId,
   openButtonRef,
   removeCloseButton = false,
   showOverlay = true,
@@ -254,6 +256,7 @@ const Modal: FunctionComponent<Props> = ({
         >
           <ModalWindow
             id={id}
+            data-testid={dataTestId}
             hidden={!isActive}
             ref={nodeRef}
             $width={width}

--- a/content/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
+++ b/content/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
@@ -238,6 +238,7 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
       )}
       <Modal
         id="expanded-image-dialog"
+        dataTestId="image-modal"
         isActive={isActive}
         setIsActive={setIsActive}
         maxWidth="1020px"

--- a/playwright/test/search-images.test.ts
+++ b/playwright/test/search-images.test.ts
@@ -1,6 +1,5 @@
-import { Page, test, expect } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 import { newSearch } from './helpers/contexts';
-import { expectItemIsVisible } from './asserts/common';
 import {
   clickImageSearchResultItem,
   searchQuerySubmitAndWait,
@@ -8,16 +7,6 @@ import {
 } from './helpers/search';
 
 const ItemViewerURLRegex = /\/works\/[a-zA-Z0-9]+\/images[?]id=/;
-
-const clickActionClickSearchResultItem = async (
-  nthChild: number,
-  page: Page
-): Promise<void> => {
-  await page
-    .getByTestId('image-search-results-container')
-    .locator(`ul:first-child > li:nth-child(${nthChild}) a`)
-    .click();
-};
 
 test('(1) | Search by term, filter by colour, check results, view image details, view expanded image', async ({
   page,
@@ -51,7 +40,7 @@ test('(2) | Image Modal | images without contributors still show a title', async
   await newSearch(context, page, 'images');
   await searchQuerySubmitAndWait('kd9h6gr3', page);
 
-  await clickActionClickSearchResultItem(1, page);
+  await clickImageSearchResultItem(1, page);
   await expect(page.getByText('Fish. Watercolour drawing.')).toBeVisible();
 });
 
@@ -61,9 +50,9 @@ test('(3) | Image Modal | images with contributors show both title and contribut
 }) => {
   await newSearch(context, page, 'images');
   await searchQuerySubmitAndWait('fcmwqd5u', page);
-  await clickActionClickSearchResultItem(1, page);
+  await clickImageSearchResultItem(1, page);
   await expect(
     page.getByRole('heading', { name: 'Dr. Darwin.' })
   ).toBeVisible();
-  await expect(page.getByText('Fortey, W. S. (William Samuel)')).toBeVisible();
+  // await expect(page.getByText('Fortey, W. S. (William Samuel)')).toBeVisible();
 });

--- a/playwright/test/search-images.test.ts
+++ b/playwright/test/search-images.test.ts
@@ -83,10 +83,8 @@ test('(3) | Image Modal | images with contributors show both title and contribut
   await newSearch(context, page, 'images');
   await searchQuerySubmitAndWait('fcmwqd5u', page);
   await clickActionClickSearchResultItem(1, page);
-  await expectItemIsVisible('h2 >> text="Dr. Darwin."', page);
-
-  await expectItemIsVisible(
-    'span >> text="Fortey, W. S. (William Samuel)"',
-    page
-  );
+  await expect(
+    page.getByRole('heading', { name: 'Dr. Darwin.' })
+  ).toBeVisible();
+  await expect(page.getByText('Fortey, W. S. (William Samuel)')).toBeVisible();
 });

--- a/playwright/test/search-images.test.ts
+++ b/playwright/test/search-images.test.ts
@@ -8,6 +8,8 @@ import {
 
 const ItemViewerURLRegex = /\/works\/[a-zA-Z0-9]+\/images[?]id=/;
 
+test.describe.configure({ mode: 'parallel' });
+
 test('(1) | Search by term, filter by colour, check results, view image details, view expanded image', async ({
   page,
   context,
@@ -39,9 +41,11 @@ test('(2) | Image Modal | images without contributors still show a title', async
 }) => {
   await newSearch(context, page, 'images');
   await searchQuerySubmitAndWait('kd9h6gr3', page);
-
   await clickImageSearchResultItem(1, page);
-  await expect(page.getByText('Fish. Watercolour drawing.')).toBeVisible();
+
+  await expect(
+    page.getByTestId('image-modal').getByText('Fish. Watercolour drawing.')
+  ).toBeVisible();
 });
 
 test('(3) | Image Modal | images with contributors show both title and contributor', async ({
@@ -51,8 +55,10 @@ test('(3) | Image Modal | images with contributors show both title and contribut
   await newSearch(context, page, 'images');
   await searchQuerySubmitAndWait('fcmwqd5u', page);
   await clickImageSearchResultItem(1, page);
+
+  const imageModal = await page.getByTestId('image-modal');
   await expect(
-    page.getByRole('heading', { name: 'Dr. Darwin.' })
+    imageModal.getByRole('heading', { name: 'Dr. Darwin.' })
   ).toBeVisible();
-  // await expect(page.getByText('Fortey, W. S. (William Samuel)')).toBeVisible();
+  await expect(imageModal).toContainText('Fortey, W. S. (William Samuel)');
 });

--- a/playwright/test/search-images.test.ts
+++ b/playwright/test/search-images.test.ts
@@ -73,7 +73,7 @@ test('(2) | Image Modal | images without contributors still show a title', async
   await searchQuerySubmitAndWait('kd9h6gr3', page);
 
   await clickActionClickSearchResultItem(1, page);
-  await expectItemIsVisible('h2 >> text="Fish. Watercolour drawing."', page);
+  await expect(page.getByText('Fish. Watercolour drawing.')).toBeVisible();
 });
 
 test('(3) | Image Modal | images with contributors show both title and contributor', async ({


### PR DESCRIPTION
## Who is this for?
Those of us working on e2es.

## What is it doing for them?
Refactors Tests 2 and 3 - looking specifically at how the Image Modal renders image data. 

- uses the new `clickImageSearchResultItem` function
- hones directly into the `Modal` to test displaying of contributor and title info
- instructs the `search-images` tests to run in parallel to speed up testing