### PR TITLE
Viewer structures

### DIFF
--- a/content/webapp/components/IIIFViewer/ViewerStructures.tsx
+++ b/content/webapp/components/IIIFViewer/ViewerStructures.tsx
@@ -63,7 +63,7 @@ type Props = {
 
 // If a range doesn't have any nested ranges then we display the range label
 // with a link to the first canvas in the range's items.
-// If the range does have nested ranges then we just display it's label
+// If the range does have nested ranges then we just display its label
 const Structures: FunctionComponent<Props> = ({
   ranges,
   canvases,

--- a/content/webapp/components/IIIFViewer/ViewerStructures.tsx
+++ b/content/webapp/components/IIIFViewer/ViewerStructures.tsx
@@ -61,6 +61,9 @@ type Props = {
   work: WorkBasic & Pick<Work, 'description'>;
 };
 
+// If a range doesn't have any nested ranges then we display the range label
+// with a link to the first canvas in the range's items.
+// If the range does have nested ranges then we just display it's label
 const Structures: FunctionComponent<Props> = ({
   ranges,
   canvases,

--- a/content/webapp/components/IIIFViewer/ViewerStructures.tsx
+++ b/content/webapp/components/IIIFViewer/ViewerStructures.tsx
@@ -52,11 +52,11 @@ const ViewerStructures: FunctionComponent = () => {
   return groupedStructures.length > 0 ? (
     <List>
       {groupedStructures.map((structure, i) => {
-        const maybeFirstCanvasInRange = structure?.items?.[0];
-        const firstCanvasInRange =
-          typeof maybeFirstCanvasInRange !== 'string'
-            ? maybeFirstCanvasInRange
-            : undefined;
+        const isCanvas = (rangeItem: RangeItems): rangeItem is Canvas => {
+          return typeof rangeItem === 'object' && rangeItem.type === 'Canvas';
+        };
+        const canvases = range?.items?.filter(isCanvas) || [];
+        const firstCanvasInRange = canvases[0];
         const canvasIndex =
           canvases?.findIndex(canvas => canvas.id === firstCanvasInRange?.id) ||
           0;

--- a/content/webapp/components/IIIFViewer/ViewerStructures.tsx
+++ b/content/webapp/components/IIIFViewer/ViewerStructures.tsx
@@ -76,9 +76,9 @@ const Structures: FunctionComponent<Props> = ({
         const isCanvas = (rangeItem: RangeItems): rangeItem is Canvas => {
           return typeof rangeItem === 'object' && rangeItem.type === 'Canvas';
         };
-        const canvases =
+        const rangeCanvases =
           range?.items?.filter(isCanvas).map(transformCanvas) || [];
-        const firstCanvasInRange = canvases[0];
+        const firstCanvasInRange = rangeCanvases[0];
         const canvasIndex =
           canvases?.findIndex(canvas => canvas.id === firstCanvasInRange?.id) ||
           0;

--- a/content/webapp/components/IIIFViewer/ViewerStructures.tsx
+++ b/content/webapp/components/IIIFViewer/ViewerStructures.tsx
@@ -1,17 +1,27 @@
 import { useContext, FunctionComponent } from 'react';
-import ItemViewerContext from '../ItemViewerContext/ItemViewerContext';
+import ItemViewerContext, {
+  Query,
+} from '../ItemViewerContext/ItemViewerContext';
 import { font } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 import styled from 'styled-components';
 import {
   getEnFromInternationalString,
-  groupStructures,
+  groupRanges,
+  transformCanvas,
 } from '@weco/content/utils/iiif/v3';
 import PlainList from '@weco/common/views/components/styled/PlainList';
 import { toLink as itemLink } from '@weco/content/components/ItemLink';
 import NextLink from 'next/link';
 import { arrayIndexToQueryParam } from '.';
 import { thumbnailsPageSize } from '@weco/content/components/IIIFViewer/Paginators';
+import {
+  Work,
+  WorkBasic,
+} from '@weco/content/services/wellcome/catalogue/types';
+import { TransformedCanvas } from '@weco/content/types/manifest';
+import { Range, RangeItems, Canvas } from '@iiif/presentation-3';
+import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper/ConditionalWrapper';
 
 export const List = styled(PlainList)`
   border-left: 1px solid ${props => props.theme.color('neutral.600')};
@@ -42,57 +52,115 @@ export const Item = styled(Space).attrs({
     `}
 `;
 
-const ViewerStructures: FunctionComponent = () => {
-  const { transformedManifest, setIsMobileSidebarActive, query, work } =
-    useContext(ItemViewerContext);
-  const { canvas } = query;
-  const { structures, canvases } = { ...transformedManifest };
-  const groupedStructures = groupStructures(canvases || [], structures || []);
+type Props = {
+  ranges: Range[];
+  canvases: TransformedCanvas[] | undefined;
+  currentCanvasIndex: number;
+  setIsMobileSidebarActive: (v: boolean) => void;
+  query: Query;
+  work: WorkBasic & Pick<Work, 'description'>;
+};
 
-  return groupedStructures.length > 0 ? (
+const Structures: FunctionComponent<Props> = ({
+  ranges,
+  canvases,
+  currentCanvasIndex,
+  setIsMobileSidebarActive,
+  work,
+  query,
+}) => {
+  const groupedRanges = groupRanges(canvases || [], ranges);
+  return groupedRanges.length > 0 ? (
     <List>
-      {groupedStructures.map((structure, i) => {
+      {groupedRanges.map((range, i) => {
         const isCanvas = (rangeItem: RangeItems): rangeItem is Canvas => {
           return typeof rangeItem === 'object' && rangeItem.type === 'Canvas';
         };
-        const canvases = range?.items?.filter(isCanvas) || [];
+        const canvases =
+          range?.items?.filter(isCanvas).map(transformCanvas) || [];
         const firstCanvasInRange = canvases[0];
         const canvasIndex =
           canvases?.findIndex(canvas => canvas.id === firstCanvasInRange?.id) ||
           0;
-
+        const isRange = (rangeItem: RangeItems): rangeItem is Range => {
+          return typeof rangeItem === 'object' && rangeItem.type === 'Range';
+        };
+        const nestedRanges = range?.items?.filter(isRange) || [];
         return (
           <Item
             key={i}
-            $isActive={canvas === arrayIndexToQueryParam(canvasIndex)}
+            $isActive={
+              currentCanvasIndex === arrayIndexToQueryParam(canvasIndex)
+            }
           >
-            <NextLink
-              replace={true}
-              {...itemLink({
-                workId: work.id,
-                props: {
-                  manifest: query.manifest,
-                  query: query.query,
-                  canvas: arrayIndexToQueryParam(canvasIndex),
-                  page: Math.ceil(
-                    arrayIndexToQueryParam(canvasIndex) / thumbnailsPageSize
-                  ),
-                },
-                source: 'contents_nav',
-              })}
-              data-gtm-trigger="contents_nav"
-              aria-current={canvas === arrayIndexToQueryParam(canvasIndex)}
-              onClick={() => {
-                setIsMobileSidebarActive(false);
-              }}
+            <ConditionalWrapper
+              condition={Boolean(nestedRanges.length === 0)}
+              wrapper={children => (
+                <NextLink
+                  replace={true}
+                  {...itemLink({
+                    workId: work.id,
+                    props: {
+                      manifest: query.manifest,
+                      query: query.query,
+                      canvas: arrayIndexToQueryParam(canvasIndex),
+                      page: Math.ceil(
+                        arrayIndexToQueryParam(canvasIndex) / thumbnailsPageSize
+                      ),
+                    },
+                    source: 'contents_nav',
+                  })}
+                  data-gtm-trigger="contents_nav"
+                  aria-current={
+                    currentCanvasIndex === arrayIndexToQueryParam(canvasIndex)
+                  }
+                  onClick={() => {
+                    setIsMobileSidebarActive(false);
+                  }}
+                >
+                  {children}
+                </NextLink>
+              )}
             >
-              {getEnFromInternationalString(structure.label)}
-            </NextLink>
+              {getEnFromInternationalString(range.label)}
+            </ConditionalWrapper>
+            {nestedRanges.map((range, i) => {
+              return (
+                <Structures
+                  key={i}
+                  ranges={[range]}
+                  canvases={canvases}
+                  currentCanvasIndex={currentCanvasIndex}
+                  setIsMobileSidebarActive={setIsMobileSidebarActive}
+                  work={work}
+                  query={query}
+                />
+              );
+            })}
           </Item>
         );
       })}
     </List>
   ) : null;
+};
+
+// Used to display the structures property of a iiif-manifest: https://iiif.io/api/presentation
+const ViewerStructures: FunctionComponent = () => {
+  const { transformedManifest, setIsMobileSidebarActive, query, work } =
+    useContext(ItemViewerContext);
+  const { canvas } = query;
+  const { structures: ranges, canvases } = { ...transformedManifest };
+
+  return (
+    <Structures
+      ranges={ranges || []}
+      canvases={canvases}
+      currentCanvasIndex={canvas}
+      setIsMobileSidebarActive={setIsMobileSidebarActive}
+      work={work}
+      query={query}
+    />
+  );
 };
 
 export default ViewerStructures;

--- a/content/webapp/test/utils/iiif.test.ts
+++ b/content/webapp/test/utils/iiif.test.ts
@@ -7,8 +7,8 @@ import {
   getVideo,
   getTransformedCanvases,
   getMultiVolumeLabel,
-  groupStructures,
   getBornDigitalStatus,
+  groupRanges,
 } from '../../utils/iiif/v3';
 import {
   manifest,
@@ -164,9 +164,9 @@ const correctResult = [
   },
 ];
 
-describe('Group repetitive iiif structures', () => {
-  it('groups iiifStructures with consecutive canvases and the same label', () => {
-    const groupedStructures = groupStructures(
+describe('Group repetitive iiif ranges', () => {
+  it('groups iiif ranges with consecutive canvases and the same label', () => {
+    const groupedStructures = groupRanges(
       canvases,
       structures as unknown as Range[]
     );

--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -474,7 +474,7 @@ export function transformCanvas(canvas: Canvas): TransformedCanvas {
 // This means we would display repetitive links to the essentially the same thing.
 // This function groups ranges that have the same label and consecutive pages into a single structure,
 // So we can display one link to the first item in the range.
-export function groupStructures(
+export function groupRanges(
   items: TransformedCanvas[],
   ranges: Range[]
 ): Range[] {

--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -469,16 +469,21 @@ function transformCanvas(canvas: Canvas): TransformedCanvas {
   };
 }
 
+// When lots of the works were digitised, ranges with multiple items, such as a table of contents,
+// were created individually rather than as a single range with multiple items.
+// This means we would display repetitive links to the essentially the same thing.
+// This function groups ranges that have the same label and consecutive pages into a single structure,
+// So we can display one link to the first item in the range.
 export function groupStructures(
   items: TransformedCanvas[],
-  structures: Range[]
+  ranges: Range[]
 ): Range[] {
-  return structures.reduce(
-    (acc, structure) => {
-      if (!structure.items) return acc;
+  return ranges.reduce(
+    (acc, range) => {
+      if (!range.items) return acc;
 
-      const [lastCanvasInRange] = structure.items.slice(-1);
-      const [firstCanvasInRange] = structure.items;
+      const [lastCanvasInRange] = range.items.slice(-1);
+      const [firstCanvasInRange] = range.items;
       const firstCanvasIndex = items.findIndex(
         canvas =>
           !isString(firstCanvasInRange) && canvas.id === firstCanvasInRange.id
@@ -486,7 +491,7 @@ export function groupStructures(
 
       if (
         getEnFromInternationalString(acc.previousLabel) ===
-          getEnFromInternationalString(structure.label) &&
+          getEnFromInternationalString(range.label) &&
         acc.previousLastCanvasIndex &&
         firstCanvasIndex === acc.previousLastCanvasIndex + 1
       ) {
@@ -496,10 +501,10 @@ export function groupStructures(
         acc.groupedArray[acc.groupedArray.length - 1].items!.push(
           lastCanvasInRange
         );
-      } else if (structure.items.length > 0) {
-        acc.groupedArray.push(structure);
+      } else if (range.items.length > 0) {
+        acc.groupedArray.push(range);
       }
-      acc.previousLabel = structure.label;
+      acc.previousLabel = range.label;
       acc.previousLastCanvasIndex = items.findIndex(
         canvas =>
           !isString(lastCanvasInRange) && canvas.id === lastCanvasInRange.id

--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -449,7 +449,7 @@ export function checkIsTotallyRestricted(
   return Boolean(restrictedAuthService && !isAnyImageOpen);
 }
 
-function transformCanvas(canvas: Canvas): TransformedCanvas {
+export function transformCanvas(canvas: Canvas): TransformedCanvas {
   const imageService = getImageService(canvas);
   const imageServiceId = getImageServiceId(imageService);
   const hasRestrictedImage = isImageRestricted(canvas);


### PR DESCRIPTION
Relates to #10494

Specifically addressing: "for a Manifest that represents an object comprising multiple files, arranged in a directory structure, a navigable representation of that structure will be displayed."

While playing with some of the iiif-manifests with born digital material I noticed that we only present this structure one level deep. I don't _think_ it's been an issue with the current content on the site (a book index tends to only be one level deep). But it may have been.

Example from a manifest with born digital items:

Before:
![Screenshot 2024-01-05 at 15 24 44](https://github.com/wellcomecollection/wellcomecollection.org/assets/6051896/a70887ee-7427-4a21-bdd4-82c26d113b3a)

After:

<img width="331" alt="Screenshot 2023-12-14 at 12 11 15" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/6051896/eeac663e-2f01-4b41-8f27-a8d19eda6ddd">
