### PR TITLE
group ranges when transforming the manifest rather than in the component

### DIFF
--- a/content/webapp/components/IIIFViewer/ViewerStructures.tsx
+++ b/content/webapp/components/IIIFViewer/ViewerStructures.tsx
@@ -7,7 +7,6 @@ import Space from '@weco/common/views/components/styled/Space';
 import styled from 'styled-components';
 import {
   getEnFromInternationalString,
-  groupRanges,
   transformCanvas,
 } from '@weco/content/utils/iiif/v3';
 import PlainList from '@weco/common/views/components/styled/PlainList';
@@ -72,10 +71,9 @@ const Structures: FunctionComponent<Props> = ({
   work,
   query,
 }) => {
-  const groupedRanges = groupRanges(canvases || [], ranges);
-  return groupedRanges.length > 0 ? (
+  return ranges.length > 0 ? (
     <List>
-      {groupedRanges.map((range, i) => {
+      {ranges.map((range, i) => {
         const isCanvas = (rangeItem: RangeItems): rangeItem is Canvas => {
           return typeof rangeItem === 'object' && rangeItem.type === 'Canvas';
         };

--- a/content/webapp/services/iiif/transformers/manifest.ts
+++ b/content/webapp/services/iiif/transformers/manifest.ts
@@ -22,6 +22,7 @@ import {
   checkModalRequired,
   checkIsTotallyRestricted,
   getBornDigitalStatus,
+  groupRanges,
 } from '@weco/content/utils/iiif/v3';
 
 export function transformManifest(manifestV3: Manifest): TransformedManifest {
@@ -56,7 +57,10 @@ export function transformManifest(manifestV3: Manifest): TransformedManifest {
     isAnyImageOpen,
   });
   const searchService = getSearchService(manifestV3);
-  const structures = manifestV3.structures || [];
+  const structures = groupRanges(
+    transformedCanvases || [],
+    manifestV3.structures || []
+  );
   const isCollectionManifest = manifestV3.type === 'Collection';
   const downloadEnabled = hasPdfDownload(manifestV3);
   const bornDigitalStatus = getBornDigitalStatus(manifestV3);


### PR DESCRIPTION
I noticed while working on #10553, that some of the links in the viewer contents panel were being rendered twice. This fixes that.

Before:

![Screenshot 2024-01-07 at 22 22 22](https://github.com/wellcomecollection/wellcomecollection.org/assets/6051896/3f0adbda-65a2-4a36-9f8e-9c22655b3acb)

After:
![Screenshot 2024-01-07 at 22 21 59](https://github.com/wellcomecollection/wellcomecollection.org/assets/6051896/a7f9d771-e3e9-409e-88f7-b9a249f0c2f6)

We now group the ranges when transforming the manifest, rather than in the component.
