### PR TITLE
only show born digital message if appropriate

### DIFF
--- a/content/webapp/components/Work/Work.tsx
+++ b/content/webapp/components/Work/Work.tsx
@@ -190,7 +190,7 @@ const Work: FunctionComponent<Props> = ({ work, apiUrl }) => {
           </Grid>
         </Container>
 
-        {bornDigitalMessage && (
+        {bornDigitalMessage && bornDigitalStatus && (
           <Container>
             <Grid>
               <Space


### PR DESCRIPTION
Follows on from #10549

Some works don't have digital locations and so won't have a born digital status. in which case we don't want to show the message.

E.g.

![Screenshot 2024-01-08 at 15 33 33](https://github.com/wellcomecollection/wellcomecollection.org/assets/6051896/8ef235be-37f4-4b2b-9ec8-538ec152c2d2)
