### PR TITLE
Fix test: adds another exhibition to the expected result

### DIFF
--- a/content/webapp/services/prismic/fetch/exhibitions.test.ts
+++ b/content/webapp/services/prismic/fetch/exhibitions.test.ts
@@ -50,6 +50,7 @@ describe('fetchExhibitions', () => {
         { id: 'Yzv9ChEAABfUrkVp', title: 'The Healing Pavilion' },
         { id: 'ZAW0PxQAACcG-pX8', title: 'Genetic Automata' },
         { id: 'ZJ1zCxAAACMAczPA', title: 'The Cult of Beauty' },
+        { id: 'ZZP8BxAAALeD00jo', title: 'Jason and the Adventure of 254' },
       ]);
 
       mockToday({ as: new Date('2023-04-24T12:00:00Z') });
@@ -70,6 +71,7 @@ describe('fetchExhibitions', () => {
         { id: 'Y8VNbhEAAPJM-oki', title: 'Milk' },
         { id: 'ZAW0PxQAACcG-pX8', title: 'Genetic Automata' },
         { id: 'ZJ1zCxAAACMAczPA', title: 'The Cult of Beauty' },
+        { id: 'ZZP8BxAAALeD00jo', title: 'Jason and the Adventure of 254' },
       ]);
     },
     timeout

--- a/content/webapp/services/prismic/fetch/exhibitions.test.ts
+++ b/content/webapp/services/prismic/fetch/exhibitions.test.ts
@@ -11,6 +11,7 @@ const client: GetServerSidePropsPrismicClient = {
 
 const timeout = 15 * 1000;
 
+// TODO this test will fail when a new Exhibition is published, we should see if we can stop that from happening.
 describe('fetchExhibitions', () => {
   // Implementation note: this test queries Prismic directly.
   //


### PR DESCRIPTION
The test was failing because a new exhibition has been published.

It should be in the results but the test wasn't expecting it. I've added it as a quick fix, but this will happen the next time a new Exhibition is published so we may want to think about improving the test somehow.
