### PR TITLE
Exhibition model; Add information for shortTitle and remove bsl/audio desc

### DIFF
--- a/content/webapp/components/Exhibition/Exhibition.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.tsx
@@ -21,8 +21,6 @@ import {
   a11Y,
   a11YVisual,
   IconSvg,
-  britishSignLanguage,
-  audioDescribed,
   download,
   arrow,
 } from '@weco/common/icons';
@@ -145,18 +143,6 @@ function getPlaceObject(
   );
 }
 
-function getBslAdItems(exhibition: ExhibitionType): ExhibitionItem[] {
-  return [exhibition.bslInfo, exhibition.audioDescriptionInfo]
-    .filter(Boolean)
-    .map(item => {
-      return {
-        description: item,
-        icon:
-          item === exhibition.bslInfo ? britishSignLanguage : audioDescribed,
-      };
-    });
-}
-
 function getAccessibilityItems(): ExhibitionItem[] {
   return [
     {
@@ -189,7 +175,6 @@ export function getInfoItems(exhibition: ExhibitionType): ExhibitionItem[] {
     getTodaysHoursObject(),
     getPlaceObject(exhibition),
     ...getAccessibilityItems(),
-    ...getBslAdItems(exhibition),
   ].filter(isNotUndefined);
 }
 

--- a/content/webapp/services/prismic/transformers/exhibitions.test.ts
+++ b/content/webapp/services/prismic/transformers/exhibitions.test.ts
@@ -38,8 +38,6 @@ const doc = {
     end: '2022-10-15T23:00:00+0000',
     isPermanent: null,
     statusOverride: [],
-    bslInfo: [],
-    audioDescriptionInfo: [],
     place: {
       id: 'WoLtlioAACoANrY_',
       type: 'places',

--- a/content/webapp/services/prismic/transformers/exhibitions.ts
+++ b/content/webapp/services/prismic/transformers/exhibitions.ts
@@ -97,8 +97,6 @@ export function transformExhibition(
   const start = transformTimestamp(data.start)!;
   const end = data.end ? transformTimestamp(data.end) : undefined;
   const statusOverride = asText(data.statusOverride);
-  const bslInfo = asRichText(data.bslInfo);
-  const audioDescriptionInfo = asRichText(data.audioDescriptionInfo);
 
   const seasons = transformSingleLevelGroup(data.seasons, 'season').map(
     season => transformSeason(season as SeasonPrismicDocument)
@@ -128,8 +126,6 @@ export function transformExhibition(
     end,
     isPermanent: data.isPermanent === 'yes',
     statusOverride,
-    bslInfo,
-    audioDescriptionInfo,
     place,
     exhibits,
     contributors,

--- a/content/webapp/services/prismic/types/exhibitions.ts
+++ b/content/webapp/services/prismic/types/exhibitions.ts
@@ -32,8 +32,6 @@ export type ExhibitionPrismicDocument = prismic.PrismicDocument<
     end: prismic.TimestampField;
     isPermanent: prismic.SelectField<'yes'>;
     statusOverride: prismic.RichTextField;
-    bslInfo: prismic.RichTextField;
-    audioDescriptionInfo: prismic.RichTextField;
     place: prismic.ContentRelationshipField<'place'>;
     exhibits: prismic.GroupField<{
       item: prismic.ContentRelationshipField<

--- a/content/webapp/types/exhibitions.ts
+++ b/content/webapp/types/exhibitions.ts
@@ -45,8 +45,6 @@ export type Exhibition = GenericContentFields & {
   end?: Date;
   isPermanent: boolean;
   statusOverride?: string;
-  bslInfo?: prismic.RichTextField;
-  audioDescriptionInfo?: prismic.RichTextField;
   place?: Place;
   exhibits: Exhibit[];
   relatedIds: string[];

--- a/prismic-model/src/exhibitions.ts
+++ b/prismic-model/src/exhibitions.ts
@@ -21,15 +21,17 @@ const exhibitions: CustomType = {
       format: documentLink('Format', { linkedType: 'exhibition-formats' }),
       title,
       shortTitle: singleLineText('Short title', {
-        overrideTextOptions: ['heading1'],
+        overrideTextOptions: ['paragraph'],
+        placeholder:
+          'Replaces title in breadcrumbs. Useful if title is very long, should otherwise be left empty.',
       }),
       body,
       start: timestamp('Start date'),
       end: timestamp('End date'),
       isPermanent: booleanDeprecated('Is permanent?'),
       statusOverride: singleLineText('Status override'),
-      bslInfo: singleLineText('BSL information'),
-      audioDescriptionInfo: singleLineText('Audio description information'),
+      bslInfo: singleLineText('BSL information'), // TODO remove
+      audioDescriptionInfo: singleLineText('Audio description information'), // TODO remove
       place,
     },
     'In this exhibition': {


### PR DESCRIPTION
## Who is this for?
Editorial and maintenance

## What is it doing for them?
- Short title is only used for breadcrumbs, taking precedence over the title if its filled. This was [for longer named exhibitions](https://github.com/wellcomecollection/wellcomecollection.org/issues/1716). I believe it's a bit unclear to Editorial and they tend to fill it in with just the same name. I wanted to make that clearer so they'd know in the future. I also changed it to a paragraph because I had to put the helper text in the placeholder sadly, and as an h1 it was way too big. I don't think it needed to be an h1 anyway as it's just used in breadcrumbs. I think it's from when [an A/B test was done to use the shortTitle on cards](https://github.com/wellcomecollection/wellcomecollection.org/issues/4418), which was then rolled back.
Current usage:
![image](https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/a81e5877-7ca5-4b1d-b344-535d18ea681c)
Future look:
<img width="672" alt="Screenshot 2024-01-11 at 10 41 17" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/f6b5efa5-59a7-4967-aff1-ba8a6d5954ca">

- First step to remove `bslInfo` and `audioDescriptionInfo` from the model. These fields are never used (ran the `contentAnalysis` script and couldn't find any instance of it. I confirmed with Editorial that this kind of information lives within the guides and the related events anyway. So removing for maintenance for us, and clarity for Editorial. I'll have another PR to remove them from the actual model later, following our guidelines.