### PR TITLE
Remove unused fields from model

### DIFF
--- a/prismic-model/src/exhibitions.ts
+++ b/prismic-model/src/exhibitions.ts
@@ -30,8 +30,6 @@ const exhibitions: CustomType = {
       end: timestamp('End date'),
       isPermanent: booleanDeprecated('Is permanent?'),
       statusOverride: singleLineText('Status override'),
-      bslInfo: singleLineText('BSL information'), // TODO remove
-      audioDescriptionInfo: singleLineText('Audio description information'), // TODO remove
       place,
     },
     'In this exhibition': {


### PR DESCRIPTION
## Who is this for?
Prismic maintenance

## What is it doing for them?
- Will remove those unused fields from the model.
I'll run the changes once its parent PR is in prod and this one gets merged in `main`.