### PR TITLE
Remove dead dashboard links

### DIFF
--- a/dash/webapp/pages/index.tsx
+++ b/dash/webapp/pages/index.tsx
@@ -74,29 +74,6 @@ const IndexPage: FunctionComponent = () => {
                 Stacks, our blog
               </a>
             </li>
-            <li>
-              <a href="https://updown.io/2cep" rel="uptime">
-                Uptime: Homepage
-              </a>
-            </li>
-            <li>
-              <a href="https://updown.io/bhef" rel="uptime">
-                Uptime: Works
-              </a>
-            </li>
-            <li>
-              <a
-                href="https://wellcomecollection.org/works/progress"
-                rel="progress"
-              >
-                Catalogue search progress notes
-              </a>
-            </li>
-            <li>
-              <a href="https://docs.google.com/spreadsheets/d/1wArVKfs9UCSy4LAJWsjY51Hjj-6MK5I42biRhM4kHmg/edit?pli=1#gid=0">
-                Digital Engagement Indicators
-              </a>
-            </li>
           </ul>
 
           {prismicLintResults && (


### PR DESCRIPTION
## Who is this for?
Maintenance, we went for removing all of them and finding alternatives only if someone raises it, but they've been dead a while.

## What is it doing for them?
Makes it less frustrating than being offered links that go nowhere.

