### PR TITLE
Born digital on works

### DIFF
--- a/content/webapp/components/IIIFViewer/ViewerStructures.tsx
+++ b/content/webapp/components/IIIFViewer/ViewerStructures.tsx
@@ -8,6 +8,8 @@ import styled from 'styled-components';
 import {
   getEnFromInternationalString,
   transformCanvas,
+  isRange,
+  isCanvas,
 } from '@weco/content/utils/iiif/v3';
 import PlainList from '@weco/common/views/components/styled/PlainList';
 import { toLink as itemLink } from '@weco/content/components/ItemLink';
@@ -19,7 +21,7 @@ import {
   WorkBasic,
 } from '@weco/content/services/wellcome/catalogue/types';
 import { TransformedCanvas } from '@weco/content/types/manifest';
-import { Range, RangeItems, Canvas } from '@iiif/presentation-3';
+import { Range } from '@iiif/presentation-3';
 import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper/ConditionalWrapper';
 
 export const List = styled(PlainList)`
@@ -74,18 +76,12 @@ const Structures: FunctionComponent<Props> = ({
   return ranges.length > 0 ? (
     <List>
       {ranges.map((range, i) => {
-        const isCanvas = (rangeItem: RangeItems): rangeItem is Canvas => {
-          return typeof rangeItem === 'object' && rangeItem.type === 'Canvas';
-        };
         const rangeCanvases =
           range?.items?.filter(isCanvas).map(transformCanvas) || [];
         const firstCanvasInRange = rangeCanvases[0];
         const canvasIndex =
           canvases?.findIndex(canvas => canvas.id === firstCanvasInRange?.id) ||
           0;
-        const isRange = (rangeItem: RangeItems): rangeItem is Range => {
-          return typeof rangeItem === 'object' && rangeItem.type === 'Range';
-        };
         const nestedRanges = range?.items?.filter(isRange) || [];
         return (
           <Item

--- a/content/webapp/components/IIIFViewer/ViewerStructures.tsx
+++ b/content/webapp/components/IIIFViewer/ViewerStructures.tsx
@@ -7,9 +7,8 @@ import Space from '@weco/common/views/components/styled/Space';
 import styled from 'styled-components';
 import {
   getEnFromInternationalString,
-  transformCanvas,
-  isRange,
-  isCanvas,
+  isTransformedRange,
+  isTransformedCanvas,
 } from '@weco/content/utils/iiif/v3';
 import PlainList from '@weco/common/views/components/styled/PlainList';
 import { toLink as itemLink } from '@weco/content/components/ItemLink';
@@ -20,8 +19,10 @@ import {
   Work,
   WorkBasic,
 } from '@weco/content/services/wellcome/catalogue/types';
-import { TransformedCanvas } from '@weco/content/types/manifest';
-import { Range } from '@iiif/presentation-3';
+import {
+  TransformedCanvas,
+  TransformedRange,
+} from '@weco/content/types/manifest';
 import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper/ConditionalWrapper';
 
 export const List = styled(PlainList)`
@@ -54,7 +55,7 @@ export const Item = styled(Space).attrs({
 `;
 
 type Props = {
-  ranges: Range[];
+  ranges: TransformedRange[];
   canvases: TransformedCanvas[] | undefined;
   currentCanvasIndex: number;
   setIsMobileSidebarActive: (v: boolean) => void;
@@ -76,13 +77,12 @@ const Structures: FunctionComponent<Props> = ({
   return ranges.length > 0 ? (
     <List>
       {ranges.map((range, i) => {
-        const rangeCanvases =
-          range?.items?.filter(isCanvas).map(transformCanvas) || [];
+        const rangeCanvases = range?.items?.filter(isTransformedCanvas) || [];
         const firstCanvasInRange = rangeCanvases[0];
         const canvasIndex =
           canvases?.findIndex(canvas => canvas.id === firstCanvasInRange?.id) ||
           0;
-        const nestedRanges = range?.items?.filter(isRange) || [];
+        const nestedRanges = range?.items?.filter(isTransformedRange) || [];
         return (
           <Item
             key={i}

--- a/content/webapp/components/Work/Work.tsx
+++ b/content/webapp/components/Work/Work.tsx
@@ -30,7 +30,6 @@ import useTransformedManifest from '@weco/content/hooks/useTransformedManifest';
 import { Audio, Video } from '@weco/content/services/iiif/types/manifest/v3';
 import { ApiToolbarLink } from '@weco/common/views/components/ApiToolbar';
 import { Container } from '@weco/common/views/components/styled/Container';
-import { useToggles } from '@weco/common/server-data/Context';
 
 const ArchiveDetailsContainer = styled.div`
   display: block;
@@ -112,7 +111,6 @@ type Props = {
 
 const Work: FunctionComponent<Props> = ({ work, apiUrl }) => {
   const transformedIIIFManifest = useTransformedManifest(work);
-  const { bornDigitalMessage } = useToggles();
 
   const isArchive = !!(
     work.parts.length ||
@@ -131,7 +129,7 @@ const Work: FunctionComponent<Props> = ({ work, apiUrl }) => {
     iiifPresentationLocation || iiifImageLocation;
   const digitalLocationInfo =
     digitalLocation && getDigitalLocationInfo(digitalLocation);
-  const { video, audio, collectionManifestsCount, bornDigitalStatus } = {
+  const { video, audio, collectionManifestsCount } = {
     ...transformedIIIFManifest,
   };
   const shouldShowItemLink = showItemLink({
@@ -189,34 +187,6 @@ const Work: FunctionComponent<Props> = ({ work, apiUrl }) => {
             </Space>
           </Grid>
         </Container>
-
-        {bornDigitalMessage && bornDigitalStatus && (
-          <Container>
-            <Grid>
-              <Space
-                className={grid({ s: 12 })}
-                $v={{ size: 'l', properties: ['padding-top'] }}
-              >
-                <div
-                  style={{
-                    marginBottom: '10px',
-                    background: '#A1EEED',
-                    width: '100%',
-                    padding: '8px 16px 5px',
-                  }}
-                >
-                  <strong>{`The iiif-manifest for this work ${
-                    bornDigitalStatus !== 'noBornDigital'
-                      ? 'has'
-                      : 'does not have'
-                  } born digital content`}</strong>
-                  <br />
-                  {`status: ${bornDigitalStatus}`}
-                </div>
-              </Space>
-            </Grid>
-          </Container>
-        )}
 
         {isArchive ? (
           <>

--- a/content/webapp/services/iiif/transformers/manifest.ts
+++ b/content/webapp/services/iiif/transformers/manifest.ts
@@ -23,6 +23,7 @@ import {
   checkIsTotallyRestricted,
   getBornDigitalStatus,
   groupRanges,
+  augmentStructuresCanvasData,
 } from '@weco/content/utils/iiif/v3';
 
 export function transformManifest(manifestV3: Manifest): TransformedManifest {
@@ -57,9 +58,9 @@ export function transformManifest(manifestV3: Manifest): TransformedManifest {
     isAnyImageOpen,
   });
   const searchService = getSearchService(manifestV3);
-  const structures = groupRanges(
-    transformedCanvases || [],
-    manifestV3.structures || []
+  const structures = augmentStructuresCanvasData(
+    groupRanges(transformedCanvases || [], manifestV3.structures || []),
+    transformedCanvases
   );
   const isCollectionManifest = manifestV3.type === 'Collection';
   const downloadEnabled = hasPdfDownload(manifestV3);

--- a/content/webapp/types/compressed-manifest.ts
+++ b/content/webapp/types/compressed-manifest.ts
@@ -8,9 +8,11 @@ import {
   TransformedManifest,
   BornDigitalData,
 } from './manifest';
+import { ResourceType } from '@iiif/presentation-3';
 
 type CompressedTransformedCanvases = {
   id: CommonParts;
+  type: NonNullable<ResourceType>[];
   width: (number | undefined)[];
   height: (number | undefined)[];
   imageServiceId: CommonParts;
@@ -37,6 +39,7 @@ export function toCompressedTransformedManifest(
   return {
     compressedCanvases: {
       id: toCommonParts(canvases.map(c => c.id)),
+      type: canvases.map(c => c.type),
       width: canvases.map(c => c.width),
       height: canvases.map(c => c.height),
       imageServiceId: toCommonParts(canvases.map(c => c.imageServiceId)),
@@ -69,6 +72,7 @@ export function fromCompressedManifest(
   );
 
   const {
+    type,
     width,
     height,
     restrictedImageIds,
@@ -81,6 +85,7 @@ export function fromCompressedManifest(
   for (let index = 0; index < id.length; index++) {
     const canvas: TransformedCanvas = {
       id: id[index],
+      type: type[index],
       width: width[index],
       height: height[index],
       imageServiceId: imageServiceId[index],

--- a/content/webapp/types/compressed-manifest.ts
+++ b/content/webapp/types/compressed-manifest.ts
@@ -3,7 +3,11 @@ import {
   fromCommonParts,
   CommonParts,
 } from '@weco/content/utils/compressed-array';
-import { TransformedCanvas, TransformedManifest } from './manifest';
+import {
+  TransformedCanvas,
+  TransformedManifest,
+  BornDigitalData,
+} from './manifest';
 
 type CompressedTransformedCanvases = {
   id: CommonParts;
@@ -15,6 +19,7 @@ type CompressedTransformedCanvases = {
   textServiceId: CommonParts;
   thumbnailImageUrl: CommonParts;
   thumbnailImageWidth: (number | undefined)[];
+  bornDigitalData: (BornDigitalData | undefined)[];
 };
 
 export type CompressedTransformedManifest = Omit<
@@ -44,6 +49,7 @@ export function toCompressedTransformedManifest(
         canvases.map(c => c.thumbnailImage?.url)
       ),
       thumbnailImageWidth: canvases.map(c => c.thumbnailImage?.width),
+      bornDigitalData: canvases.map(c => c.bornDigitalData),
     },
     ...otherFields,
   };
@@ -62,8 +68,13 @@ export function fromCompressedManifest(
     compressedCanvases.thumbnailImageUrl
   );
 
-  const { width, height, restrictedImageIds, thumbnailImageWidth } =
-    compressedCanvases;
+  const {
+    width,
+    height,
+    restrictedImageIds,
+    thumbnailImageWidth,
+    bornDigitalData,
+  } = compressedCanvases;
 
   const uncompressedCanvases: TransformedCanvas[] = [];
 
@@ -85,6 +96,7 @@ export function fromCompressedManifest(
               /* eslint-enable @typescript-eslint/no-non-null-assertion */
             }
           : undefined,
+      bornDigitalData: bornDigitalData[index],
     };
 
     uncompressedCanvases.push(canvas);

--- a/content/webapp/types/manifest.ts
+++ b/content/webapp/types/manifest.ts
@@ -6,6 +6,8 @@ import {
   AuthAccessTokenService,
   Canvas,
   InternationalString,
+  SpecificationBehaviors,
+  ContentResource,
 } from '@iiif/presentation-3';
 import { Audio, Video } from '@weco/content/services/iiif/types/manifest/v3';
 
@@ -82,4 +84,14 @@ export type TransformedManifest = {
     | AuthClickThroughServiceWithPossibleServiceArray
     | undefined;
   tokenService: AuthAccessTokenService | undefined;
+};
+
+export type CustomSpecificationBehaviors =
+  | SpecificationBehaviors
+  | 'placeholder';
+
+export type CustomContentResource = ContentResource & {
+  behavior: 'original' | undefined;
+  label: InternationalString | null | undefined;
+  format: string | undefined;
 };

--- a/content/webapp/types/manifest.ts
+++ b/content/webapp/types/manifest.ts
@@ -5,6 +5,7 @@ import {
   AuthClickThroughService,
   AuthAccessTokenService,
   Canvas,
+  InternationalString,
 } from '@iiif/presentation-3';
 import { Audio, Video } from '@weco/content/services/iiif/types/manifest/v3';
 
@@ -12,7 +13,7 @@ export type ThumbnailImage = { url: string; width: number };
 
 export type BornDigitalData = {
   originalFile: string | undefined;
-  label: string | undefined;
+  label: InternationalString | null | undefined;
   format?: string;
 };
 
@@ -49,6 +50,10 @@ export type BornDigitalStatus =
   | 'noBornDigital'
   | 'mixedBornDigital';
 
+export type TransformedRange = Omit<Range, 'items'> & {
+  items: (TransformedRange | TransformedCanvas)[];
+};
+
 export type TransformedManifest = {
   downloadEnabled?: boolean;
   firstCollectionManifestLocation?: string;
@@ -71,7 +76,7 @@ export type TransformedManifest = {
   needsModal: boolean;
   restrictedService: AuthExternalService | undefined;
   searchService: Service | undefined;
-  structures: Range[];
+  structures: TransformedRange[];
   manifests: Canvas[];
   clickThroughService:
     | AuthClickThroughServiceWithPossibleServiceArray

--- a/content/webapp/types/manifest.ts
+++ b/content/webapp/types/manifest.ts
@@ -10,6 +10,12 @@ import { Audio, Video } from '@weco/content/services/iiif/types/manifest/v3';
 
 export type ThumbnailImage = { url: string; width: number };
 
+export type BornDigitalData = {
+  originalFile: string | undefined;
+  label: string | undefined;
+  format?: string;
+};
+
 export type TransformedCanvas = {
   id: string;
   width: number | undefined;

--- a/content/webapp/types/manifest.ts
+++ b/content/webapp/types/manifest.ts
@@ -8,6 +8,7 @@ import {
   InternationalString,
   SpecificationBehaviors,
   ContentResource,
+  ResourceType,
 } from '@iiif/presentation-3';
 import { Audio, Video } from '@weco/content/services/iiif/types/manifest/v3';
 
@@ -21,6 +22,7 @@ export type BornDigitalData = {
 
 export type TransformedCanvas = {
   id: string;
+  type: NonNullable<ResourceType>;
   width: number | undefined;
   height: number | undefined;
   imageServiceId: string | undefined;

--- a/content/webapp/types/manifest.ts
+++ b/content/webapp/types/manifest.ts
@@ -25,6 +25,7 @@ export type TransformedCanvas = {
   label: string | undefined;
   textServiceId: string | undefined;
   thumbnailImage: ThumbnailImage | undefined;
+  bornDigitalData: BornDigitalData | undefined;
 };
 
 export type DownloadOption = {

--- a/content/webapp/utils/iiif/v3/canvas.ts
+++ b/content/webapp/utils/iiif/v3/canvas.ts
@@ -1,6 +1,11 @@
-import { Canvas, SpecificationBehaviors } from '@iiif/presentation-3';
+import { Canvas } from '@iiif/presentation-3';
+import {
+  CustomSpecificationBehaviors,
+  CustomContentResource,
+  ThumbnailImage,
+  BornDigitalData,
+} from '@weco/content/types/manifest';
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
-import { ThumbnailImage, BornDigitalData } from '@weco/content/types/manifest';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
 
 // Temporary type until iiif3 types are correct
@@ -58,10 +63,9 @@ export function getThumbnailImage(canvas: Canvas): ThumbnailImage | undefined {
   }
 }
 
-// TODO don't duplicate types with util/index;
-type CustomSpecificationBehaviors = SpecificationBehaviors | 'placeholder';
-
-// TODO comments explaining what is going on
+// If the canvas has a behavior which includes 'placeholder'
+// we know it is Born digital: https://github.com/wellcomecollection/docs/blob/main/rfcs/046-born-digital-iiif/README.md
+// The data we need to display a link to the file is found in the rendering property of the canvas.
 export function getBornDigitalData(
   canvas: Canvas
 ): BornDigitalData | undefined {
@@ -69,14 +73,15 @@ export function getBornDigitalData(
     | CustomSpecificationBehaviors[]
     | undefined;
   const isBornDigital = behavior?.includes('placeholder') || false;
-  const originalRendering = canvas.rendering?.find(item => {
-    return item?.behavior?.includes('original'); // TODO fix type
+  const rendering = canvas.rendering as CustomContentResource[];
+  const originalRendering = rendering?.find(item => {
+    return item?.behavior?.includes('original');
   });
   if (isBornDigital && originalRendering) {
     return {
       originalFile: originalRendering?.id,
-      label: originalRendering.label, // TODO fix type
-      format: originalRendering.format, // TODO fix type
+      label: originalRendering.label,
+      format: originalRendering.format,
     };
   }
 }

--- a/content/webapp/utils/iiif/v3/canvas.ts
+++ b/content/webapp/utils/iiif/v3/canvas.ts
@@ -1,6 +1,6 @@
-import { Canvas } from '@iiif/presentation-3';
+import { Canvas, SpecificationBehaviors } from '@iiif/presentation-3';
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
-import { ThumbnailImage } from '@weco/content/types/manifest';
+import { ThumbnailImage, BornDigitalData } from '@weco/content/types/manifest';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
 
 // Temporary type until iiif3 types are correct
@@ -54,6 +54,29 @@ export function getThumbnailImage(canvas: Canvas): ThumbnailImage | undefined {
     return {
       width: thumbnail.width,
       url: thumbnail.id,
+    };
+  }
+}
+
+// TODO don't duplicate types with util/index;
+type CustomSpecificationBehaviors = SpecificationBehaviors | 'placeholder';
+
+// TODO comments explaining what is going on
+export function getBornDigitalData(
+  canvas: Canvas
+): BornDigitalData | undefined {
+  const behavior = canvas?.behavior as
+    | CustomSpecificationBehaviors[]
+    | undefined;
+  const isBornDigital = behavior?.includes('placeholder') || false;
+  const originalRendering = canvas.rendering?.find(item => {
+    return item?.behavior?.includes('original'); // TODO fix type
+  });
+  if (isBornDigital && originalRendering) {
+    return {
+      originalFile: originalRendering?.id,
+      label: originalRendering.label, // TODO fix type
+      format: originalRendering.format, // TODO fix type
     };
   }
 }

--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -450,13 +450,14 @@ export function checkIsTotallyRestricted(
 }
 
 export function transformCanvas(canvas: Canvas): TransformedCanvas {
-  const imageService = getImageService(canvas);
+  const imageService = getImageService(canvas); // TODO possibly redo how this is done
   const imageServiceId = getImageServiceId(imageService);
   const hasRestrictedImage = isImageRestricted(canvas);
   const label = getCanvasLabel(canvas);
   const textServiceId = getCanvasTextServiceId(canvas);
   const thumbnailImage = getThumbnailImage(canvas);
   const { id, width, height } = canvas;
+  const bornDigitalData = getBornDigitalData(canvas);
   return {
     id,
     width,
@@ -466,6 +467,7 @@ export function transformCanvas(canvas: Canvas): TransformedCanvas {
     label,
     textServiceId,
     thumbnailImage,
+    bornDigitalData,
   };
 }
 

--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -5,6 +5,7 @@ import {
   TransformedCanvas,
   AuthClickThroughServiceWithPossibleServiceArray,
   TransformedRange,
+  CustomSpecificationBehaviors,
 } from '@weco/content/types/manifest';
 import {
   AnnotationPage,
@@ -21,7 +22,6 @@ import {
   AuthExternalService,
   AuthAccessTokenService,
   Range,
-  SpecificationBehaviors,
   RangeItems,
 } from '@iiif/presentation-3';
 import { isNotUndefined, isString } from '@weco/common/utils/type-guards';
@@ -599,7 +599,6 @@ export function getCollectionManifests(manifest: Manifest): Canvas[] {
   return [...firstLevelManifests, ...collectionManifests] as Canvas[];
 }
 
-type CustomSpecificationBehaviors = SpecificationBehaviors | 'placeholder';
 // Whether something is born digital or not is determined at the canvas level within a iiifManifest
 // It is therefore possible to have a iiifManifest that contains:
 // - only born digital items

--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -458,10 +458,11 @@ export function transformCanvas(canvas: Canvas): TransformedCanvas {
   const label = getCanvasLabel(canvas);
   const textServiceId = getCanvasTextServiceId(canvas);
   const thumbnailImage = getThumbnailImage(canvas);
-  const { id, width, height } = canvas;
+  const { id, type, width, height } = canvas;
   const bornDigitalData = getBornDigitalData(canvas);
   return {
     id,
+    type,
     width,
     height,
     imageServiceId,
@@ -527,18 +528,18 @@ export function groupRanges(
   ).groupedArray;
 }
 
-export const isTransformedCanvas = (
-  rangeItem: RangeItems // TODO this is the wrong type
-): rangeItem is TransformedCanvas => {
-  return typeof rangeItem === 'object' && rangeItem.type === 'Canvas';
-};
-
 export const isCanvas = (rangeItem: RangeItems): rangeItem is Canvas => {
   return typeof rangeItem === 'object' && rangeItem.type === 'Canvas';
 };
 
 export const isRange = (rangeItem: RangeItems): rangeItem is Range => {
   return typeof rangeItem === 'object' && rangeItem.type === 'Range';
+};
+
+export const isTransformedCanvas = (
+  rangeItem: TransformedRange | TransformedCanvas
+): rangeItem is TransformedCanvas => {
+  return typeof rangeItem === 'object' && rangeItem.type === 'Canvas';
 };
 
 export const isTransformedRange = (

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -69,11 +69,11 @@ const toggles = {
       type: 'experimental',
     },
     {
-      id: 'bornDigitalMessage',
-      title: 'Displays whether a work has born digital items or not',
+      id: 'showBornDigital',
+      title: 'Display born digital files',
       initialValue: false,
       description:
-        'Adds some text to the top of a work page stating whether there are born digital items in the iiif-manifest',
+        'If there are born digital items in the iiif-manifest, then links to all the files in the manifest are shown on the works page.',
       type: 'experimental',
     },
   ] as const,


### PR DESCRIPTION
Relates to #10568

This PR:

- renames the bornDigitalMessage toggle to showBornDigital
- removes the born digital status message 
- uses the toggle to display the file structure with links to download born digital files on the works page (N.B. there is still work to do to get the non born digital file links to work)

<img width="1048" alt="Screenshot 2024-01-16 at 16 30 24" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/6051896/d7ebb2eb-20d5-4673-8b3f-df00531d9b4a">

- Born digital file url, format and label are added to the TransformedCanvas
- Born digital file url, format and label are added to the canvases in the TransformedRange

There are a few TODOs, which I'll pick up in subsequent PRs
