### PR TITLE
Remove fetching and transforming of isRelaxedPerformance

### DIFF
--- a/cardigan/stories/components/EventSchedule/EventSchedule.stories.tsx
+++ b/cardigan/stories/components/EventSchedule/EventSchedule.stories.tsx
@@ -133,7 +133,6 @@ const schedule = [
         },
       ],
       isPast: true,
-      isRelaxedPerformance: false,
       isOnline: null,
       availableOnline: null,
       primaryLabels: [

--- a/cardigan/stories/content.ts
+++ b/cardigan/stories/content.ts
@@ -409,7 +409,6 @@ export const event: Event = {
   interpretations: [],
   isCompletelySoldOut: false,
   isPast: false,
-  isRelaxedPerformance: false,
   isOnline: true,
   labels: [],
   locations: [

--- a/content/webapp/__mocks__/events.ts
+++ b/content/webapp/__mocks__/events.ts
@@ -43,7 +43,6 @@ const baseEvent: Event = {
   thirdPartyBooking: undefined,
   isCompletelySoldOut: false,
   isPast: false,
-  isRelaxedPerformance: false,
   format: {
     id: 'WmYRpCQAACUAn-Ap',
     title: 'Gallery tour',

--- a/content/webapp/pages/events/[eventId]/index.tsx
+++ b/content/webapp/pages/events/[eventId]/index.tsx
@@ -176,9 +176,6 @@ const EventPage: NextPage<EventProps> = ({
   const eventInterpretations = event.interpretations.map(i => ({
     text: i.interpretationType.title,
   }));
-  const relaxedPerformanceLabel = event.isRelaxedPerformance
-    ? [{ text: 'Relaxed' }]
-    : [];
 
   const breadcrumbs = {
     items: [
@@ -207,11 +204,7 @@ const EventPage: NextPage<EventProps> = ({
   };
 
   const labels = {
-    labels: eventFormat.concat(
-      eventAudiences,
-      eventInterpretations,
-      relaxedPerformanceLabel
-    ),
+    labels: eventFormat.concat(eventAudiences, eventInterpretations),
   };
 
   const Header = (

--- a/content/webapp/services/prismic/fetch/events.ts
+++ b/content/webapp/services/prismic/fetch/events.ts
@@ -94,7 +94,6 @@ const graphQuery = `{
     title
     isOnline
     availableOnline
-    isRelaxedPerformance
     format {
       ... on event-formats {
         title

--- a/content/webapp/services/prismic/transformers/events.ts
+++ b/content/webapp/services/prismic/transformers/events.ts
@@ -244,7 +244,6 @@ export function transformEvent(
   const times: EventTime[] = transformEventTimes(document.id, data.times || []);
 
   const lastEndTime = getLastEndTime(times);
-  const isRelaxedPerformance = data.isRelaxedPerformance === 'yes';
   const isOnline = data.isOnline;
   const availableOnline = data.availableOnline;
   const schedule = eventSchedule.map((event, i) => {
@@ -267,20 +266,16 @@ export function transformEvent(
   const interpretationsLabels = interpretations.map(
     i => i.interpretationType.title
   );
-  const relaxedPerformanceLabel = isRelaxedPerformance ? ['Relaxed'] : [];
 
   const labels = [
     formatLabel,
     ...audiencesLabels,
     ...interpretationsLabels,
-    ...relaxedPerformanceLabel,
   ].map(text => ({ text }));
 
-  const primaryLabels = [
-    formatLabel,
-    ...audiencesLabels,
-    ...relaxedPerformanceLabel,
-  ].map(text => ({ text }));
+  const primaryLabels = [formatLabel, ...audiencesLabels].map(text => ({
+    text,
+  }));
 
   const secondaryLabels = [...interpretationsLabels].map(text => ({ text }));
 
@@ -354,7 +349,6 @@ export function transformEvent(
     ticketSalesStart: transformTimestamp(data.ticketSalesStart),
     times,
     isPast: lastEndTime ? isPast(lastEndTime) : true,
-    isRelaxedPerformance,
     isOnline,
     availableOnline,
     labels,

--- a/content/webapp/services/prismic/types/events.ts
+++ b/content/webapp/services/prismic/types/events.ts
@@ -110,7 +110,6 @@ export type EventPrismicDocument = prismic.PrismicDocument<
     isOnline: prismic.BooleanField;
     availableOnline: prismic.BooleanField;
     times: prismic.GroupField<EventTimePrismicDocument>;
-    isRelaxedPerformance: prismic.SelectField<'yes'>;
     interpretations: prismic.GroupField<{
       interpretationType: prismic.ContentRelationshipField<
         'interpretation-types',

--- a/content/webapp/types/events.ts
+++ b/content/webapp/types/events.ts
@@ -119,7 +119,6 @@ export type Event = GenericContentFields & {
   onlineSoldOut?: boolean;
   inVenueSoldOut?: boolean;
   isPast: boolean;
-  isRelaxedPerformance: boolean;
   isOnline: boolean;
   availableOnline: boolean;
   primaryLabels: Label[];


### PR DESCRIPTION
## Who is this for?
Maintenance, Editorial
Relates to #10592 

## What is it doing for them?
- Removes fetching of field in graphQuery as well as where it's transformed and used.
- Does NOT remove it from the Prismic model, this will happen once this is in production, to avoid erroring on live.