### PR TITLE
Remove isRelaxedPerformance from event prismic model

### DIFF
--- a/prismic-model/src/events.ts
+++ b/prismic-model/src/events.ts
@@ -61,7 +61,6 @@ const events: CustomType = {
       body,
     },
     Access: {
-      isRelaxedPerformance: booleanDeprecated('Relaxed'),
       interpretations: list('Interpretations', {
         interpretationType: documentLink('Interpretation', {
           linkedType: 'interpretation-types',


### PR DESCRIPTION
## Who is this for?
Maintenance, Editorial
Relates to #10592 

## What is it doing for them?
Removes field from Prismic Model, to be merged and deployed only once the parent branch (#10593 ) is on prod