### PR TITLE
Add missing fully booked fields in event graphquery

### DIFF
--- a/content/webapp/__mocks__/events.ts
+++ b/content/webapp/__mocks__/events.ts
@@ -85,3 +85,15 @@ export const eventWithOneLocationOnline: Event = {
   locations: [location],
   isOnline: true,
 };
+export const eventFullyBooked: Event = {
+  ...baseEvent,
+  times: [
+    {
+      range: {
+        startDateTime: new Date('2035-08-20T14:00:00+0000'),
+        endDateTime: new Date('2035-08-24T14:00:00+0000'),
+      },
+      isFullyBooked: { inVenue: true, online: true },
+    },
+  ],
+};

--- a/content/webapp/components/EventPromo/EventPromo.test.tsx
+++ b/content/webapp/components/EventPromo/EventPromo.test.tsx
@@ -11,6 +11,7 @@ import {
   eventOnline,
   eventWithOneLocationOnline,
   eventWithMultipleLocations,
+  eventFullyBooked,
 } from '../../__mocks__/events';
 
 jest
@@ -46,6 +47,11 @@ describe('EventPromo', () => {
   it('Shows when an event is a physical/online hybrid', () => {
     renderComponent(eventWithOneLocationOnline);
     expect(screen.getByText('Online | In our building'));
+  });
+
+  it('Shows when an event if fully booked', () => {
+    renderComponent(eventFullyBooked);
+    expect(screen.getByText('Fully booked'));
   });
 });
 

--- a/content/webapp/services/prismic/fetch/events.ts
+++ b/content/webapp/services/prismic/fetch/events.ts
@@ -108,6 +108,8 @@ const graphQuery = `{
     times {
       startDateTime
       endDateTime
+      isFullyBooked
+      onlineIsFullyBooked
     }
     audiences {
       audience {


### PR DESCRIPTION
## Who is this for?
Good functioning of FE!
Relates to #10596 

## What is it doing for them?
Adds missing fields from graphquery, this is stopping "Fully booked" from displaying on the cards when relevant. Probably due to the graphquery cleanup I did months ago, so thanks to @agnesgaroux for finding that bug!

![image](https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/aa40c551-2226-48e6-94d8-224cc0f2e31f)
