### PR TITLE
Add a link to our status page from the 5xx error

### DIFF
--- a/common/data/errors.tsx
+++ b/common/data/errors.tsx
@@ -28,6 +28,11 @@ export const DefaultErrorText: FunctionComponent = () => (
           and tell us what happened
         </li>
         <li>Refresh the page (sometimes it’s a temporary issue)</li>
+        <li>
+          Have a look at{' '}
+          <a href="https://status.wellcomecollection.org/">our status page</a>{' '}
+          for any updates
+        </li>
         <li>Try again a bit later</li>
       </ul>
     </Space>


### PR DESCRIPTION
## Who is this for?

This change is for users who see errors during a prolonged period where we may want to provide more context.

<img width="1728" alt="Screenshot 2024-01-25 at 14 49 20" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/953792/a40facf2-a757-4191-8262-f3a1f0cf8e62">

The added link is to [our status page](https://status.wellcomecollection.org/).

## What is it doing for them?

This change adds an item to the checklist of things a user can do if they are getting a 5xx error, in order to provide more information about when a problem may be resolved to users.