### PR TITLE
Remove old code owner rules

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,2 @@
 # These are default codeowners, later rules take precedence
 *	@wellcomecollection/js-ts-reviewers
-
-# To ensure only properly audited changes are run in CI, we require reviews
-# from @wellcomecollection/buildkite-admin when updating pipeline config
-
-/CODEOWNERS	@wellcomecollection/buildkite-admin
-/.buildkite/    @wellcomecollection/buildkite-admin


### PR DESCRIPTION
## Who is this for?
Maintenance

## What is it doing for them?
`buildkite-admins` is not a team anymore, so I removed the lines that did nothing. If we want it back, we can re-add it once we've recreated the team if it feels useful.