### PR TITLE
Adds a simple healthcheck endpoint to the content app

### DIFF
--- a/content/webapp/app.ts
+++ b/content/webapp/app.ts
@@ -46,6 +46,13 @@ const appPromise = nextApp
     koaApp.use(apmErrorMiddleware);
     koaApp.use(withCachedValues);
 
+    // Add a naive healthcheck endpoint for the load balancer
+    router.get('/management/healthcheck', async ctx => {
+      ctx.body = {
+        status: 'ok',
+      };
+    });
+
     router.get('/preview', async ctx => {
       // Kill any cookie we had set, as it think it is causing issues.
       ctx.cookies.set(prismic.cookie.preview);


### PR DESCRIPTION
## What does this change?

This change is part of https://github.com/wellcomecollection/wellcomecollection.org/issues/10545 and adds a healthcheck endpoint to the content app so we can really check the health of the app before it is deployed. At present the healthcheck terminates at the nginx container so during deployment (and normal running) we don't check if the app has properly started.

See https://github.com/wellcomecollection/platform-infrastructure/blob/main/images/dockerfiles/nginx/frontend.nginx.conf#L24

> [!NOTE]
> This will require a further change to remove the nginx config that fields the healthcheck request there.  

## How to test?

- [ ] Deploy this change and check there is no change to functionality.

## How can we measure success?

No downtime during deployments resulting in a better experience for visitors to the site, and fewer errors that we cannot effectively respond to in the alerts channel. Deployments that really check if the app is running avoiding situations where we deploy a broken service.