### PR TITLE
Events results; Change grid fill property

### DIFF
--- a/content/webapp/components/EventsSearchResults/index.tsx
+++ b/content/webapp/components/EventsSearchResults/index.tsx
@@ -40,7 +40,7 @@ type Props = {
 const EventsContainer = styled.div`
   display: grid;
   gap: 30px;
-  grid-template-columns: repeat(auto-fit, minmax(290px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(290px, 1fr));
 `;
 
 const DateInfo = styled.p.attrs({


### PR DESCRIPTION
## Who is this for?
Nice looking-ness
Related to #10611 

## What is it doing for them?
Biggest change you'll see today. Just ensures that if there is only 1-2 events in the results they don't take up 100% of the space when available ([learning about `auto-fill` vs `auto-fit`](https://css-tricks.com/auto-sizing-columns-css-grid-auto-fill-vs-auto-fit/#aa-fill-or-fit-whats-the-difference)).

before
<img width="400" alt="Screenshot 2024-01-26 at 10 32 24" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/69ec2ea5-10f5-4261-a05f-b25900dc5960">


after
<img width="400" alt="Screenshot 2024-01-26 at 10 32 00" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/bdafa4c5-2588-4aff-8bd8-04f693de52e5">
