### PR TITLE
Don’t show audio/video player or item link when showing the DownloadList

### DIFF
--- a/content/webapp/components/WorkDetails/WorkDetails.AvailableOnline.tsx
+++ b/content/webapp/components/WorkDetails/WorkDetails.AvailableOnline.tsx
@@ -80,114 +80,113 @@ const WorkDetailsAvailableOnline = ({
             />
           )}
 
-        {!showBornDigital ||
-          (showBornDigital && bornDigitalStatus === 'noBornDigital' && (
-            <>
-              {video && (
-                <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
-                  <VideoPlayer
-                    video={video}
-                    // Note: because we can't prevent people from downloading videos if
-                    // they're available online, any videos where we want to prevent
-                    // download are restricted in Sierra.
-                    //
-                    // This means that any videos which can be viewed can also be downloaded.
-                    //
-                    // See discussion in https://wellcome.slack.com/archives/C8X9YKM5X/p1641833044030400
-                    showDownloadOptions={true}
-                  />
-                </Space>
-              )}
-              {audio?.sounds && audio.sounds.length > 0 && (
-                <AudioList
-                  items={audio?.sounds || []}
-                  thumbnail={audio?.thumbnail}
-                  transcript={audio?.transcript}
-                  workTitle={work.title}
+        {(!showBornDigital ||
+          (showBornDigital && bornDigitalStatus === 'noBornDigital')) && (
+          <>
+            {video && (
+              <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
+                <VideoPlayer
+                  video={video}
+                  // Note: because we can't prevent people from downloading videos if
+                  // they're available online, any videos where we want to prevent
+                  // download are restricted in Sierra.
+                  //
+                  // This means that any videos which can be viewed can also be downloaded.
+                  //
+                  // See discussion in https://wellcome.slack.com/archives/C8X9YKM5X/p1641833044030400
+                  showDownloadOptions={true}
                 />
-              )}
-              {shouldShowItemLink && (
-                <>
-                  {work.thumbnail && (
-                    <Space $v={{ size: 's', properties: ['margin-bottom'] }}>
-                      <ConditionalWrapper
-                        condition={Boolean(itemUrl)}
-                        wrapper={children =>
-                          itemUrl && (
-                            <NextLink
-                              style={{
-                                display: 'inline-block',
-                              }}
-                              href={itemUrl.href}
-                              as={itemUrl.as}
-                            >
-                              {children}
-                            </NextLink>
-                          )
-                        }
-                      >
-                        <img
-                          style={{
-                            width: 'auto',
-                            height: 'auto',
-                            display: 'block',
-                          }}
-                          alt={`view ${work.title}`}
-                          src={work.thumbnail.url}
-                        />
-                      </ConditionalWrapper>
-                    </Space>
-                  )}
-                  <div style={{ display: 'flex' }}>
-                    {itemUrl && (
-                      <Space
-                        as="span"
-                        $h={{ size: 'm', properties: ['margin-right'] }}
-                      >
-                        <Button
-                          variant="ButtonSolidLink"
-                          icon={eye}
-                          text="View"
-                          link={{ ...itemUrl }}
-                        />
-                      </Space>
-                    )}
-                    {showDownloadOptions && (
-                      <Download
-                        ariaControlsId="itemDownloads"
-                        downloadOptions={downloadOptions}
+              </Space>
+            )}
+            {audio?.sounds && audio.sounds.length > 0 && (
+              <AudioList
+                items={audio?.sounds || []}
+                thumbnail={audio?.thumbnail}
+                transcript={audio?.transcript}
+                workTitle={work.title}
+              />
+            )}
+            {shouldShowItemLink && (
+              <>
+                {work.thumbnail && (
+                  <Space $v={{ size: 's', properties: ['margin-bottom'] }}>
+                    <ConditionalWrapper
+                      condition={Boolean(itemUrl)}
+                      wrapper={children =>
+                        itemUrl && (
+                          <NextLink
+                            style={{
+                              display: 'inline-block',
+                            }}
+                            href={itemUrl.href}
+                            as={itemUrl.as}
+                          >
+                            {children}
+                          </NextLink>
+                        )
+                      }
+                    >
+                      <img
+                        style={{
+                          width: 'auto',
+                          height: 'auto',
+                          display: 'block',
+                        }}
+                        alt={`view ${work.title}`}
+                        src={work.thumbnail.url}
                       />
-                    )}
-                  </div>
-                  {(Boolean(
-                    collectionManifestsCount && collectionManifestsCount > 0
-                  ) ||
-                    Boolean(canvasCount && canvasCount > 0)) && (
-                    <Space $v={{ size: 'm', properties: ['margin-top'] }}>
-                      <p
-                        className={`${font('lr', 6)}`}
-                        style={{ marginBottom: 0 }}
-                      >
-                        Contains:{' '}
-                        {collectionManifestsCount &&
-                        collectionManifestsCount > 0
-                          ? `${collectionManifestsCount} ${
-                              collectionManifestsCount === 1
-                                ? 'volume'
-                                : 'volumes'
-                            }`
-                          : canvasCount && canvasCount > 0
-                          ? `${canvasCount} ${
-                              canvasCount === 1 ? 'image' : 'images'
-                            }`
-                          : ''}
-                      </p>
+                    </ConditionalWrapper>
+                  </Space>
+                )}
+                <div style={{ display: 'flex' }}>
+                  {itemUrl && (
+                    <Space
+                      as="span"
+                      $h={{ size: 'm', properties: ['margin-right'] }}
+                    >
+                      <Button
+                        variant="ButtonSolidLink"
+                        icon={eye}
+                        text="View"
+                        link={{ ...itemUrl }}
+                      />
                     </Space>
                   )}
-                </>
-              )}
-            </>
-          ))}
+                  {showDownloadOptions && (
+                    <Download
+                      ariaControlsId="itemDownloads"
+                      downloadOptions={downloadOptions}
+                    />
+                  )}
+                </div>
+                {(Boolean(
+                  collectionManifestsCount && collectionManifestsCount > 0
+                ) ||
+                  Boolean(canvasCount && canvasCount > 0)) && (
+                  <Space $v={{ size: 'm', properties: ['margin-top'] }}>
+                    <p
+                      className={`${font('lr', 6)}`}
+                      style={{ marginBottom: 0 }}
+                    >
+                      Contains:{' '}
+                      {collectionManifestsCount && collectionManifestsCount > 0
+                        ? `${collectionManifestsCount} ${
+                            collectionManifestsCount === 1
+                              ? 'volume'
+                              : 'volumes'
+                          }`
+                        : canvasCount && canvasCount > 0
+                        ? `${canvasCount} ${
+                            canvasCount === 1 ? 'image' : 'images'
+                          }`
+                        : ''}
+                    </p>
+                  </Space>
+                )}
+              </>
+            )}
+          </>
+        )}
       </ConditionalWrapper>
 
       {digitalLocationInfo?.license && (

--- a/content/webapp/components/WorkDetails/WorkDetails.AvailableOnline.tsx
+++ b/content/webapp/components/WorkDetails/WorkDetails.AvailableOnline.tsx
@@ -70,8 +70,7 @@ const WorkDetailsAvailableOnline = ({
       >
         {showBornDigital &&
           (bornDigitalStatus === 'mixedBornDigital' ||
-            bornDigitalStatus === 'allBornDigital') &&
-          structures && (
+            bornDigitalStatus === 'allBornDigital') && (
             <DownloadList
               structures={
                 structures && structures.length > 0
@@ -81,101 +80,114 @@ const WorkDetailsAvailableOnline = ({
             />
           )}
 
-        {video && (
-          <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
-            <VideoPlayer
-              video={video}
-              // Note: because we can't prevent people from downloading videos if
-              // they're available online, any videos where we want to prevent
-              // download are restricted in Sierra.
-              //
-              // This means that any videos which can be viewed can also be downloaded.
-              //
-              // See discussion in https://wellcome.slack.com/archives/C8X9YKM5X/p1641833044030400
-              showDownloadOptions={true}
-            />
-          </Space>
-        )}
-        {audio?.sounds && audio.sounds.length > 0 && (
-          <AudioList
-            items={audio?.sounds || []}
-            thumbnail={audio?.thumbnail}
-            transcript={audio?.transcript}
-            workTitle={work.title}
-          />
-        )}
-        {shouldShowItemLink && (
-          <>
-            {work.thumbnail && (
-              <Space $v={{ size: 's', properties: ['margin-bottom'] }}>
-                <ConditionalWrapper
-                  condition={Boolean(itemUrl)}
-                  wrapper={children =>
-                    itemUrl && (
-                      <NextLink
-                        style={{
-                          display: 'inline-block',
-                        }}
-                        href={itemUrl.href}
-                        as={itemUrl.as}
-                      >
-                        {children}
-                      </NextLink>
-                    )
-                  }
-                >
-                  <img
-                    style={{
-                      width: 'auto',
-                      height: 'auto',
-                      display: 'block',
-                    }}
-                    alt={`view ${work.title}`}
-                    src={work.thumbnail.url}
-                  />
-                </ConditionalWrapper>
-              </Space>
-            )}
-            <div style={{ display: 'flex' }}>
-              {itemUrl && (
-                <Space
-                  as="span"
-                  $h={{ size: 'm', properties: ['margin-right'] }}
-                >
-                  <Button
-                    variant="ButtonSolidLink"
-                    icon={eye}
-                    text="View"
-                    link={{ ...itemUrl }}
+        {!showBornDigital ||
+          (showBornDigital && bornDigitalStatus === 'noBornDigital' && (
+            <>
+              {video && (
+                <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
+                  <VideoPlayer
+                    video={video}
+                    // Note: because we can't prevent people from downloading videos if
+                    // they're available online, any videos where we want to prevent
+                    // download are restricted in Sierra.
+                    //
+                    // This means that any videos which can be viewed can also be downloaded.
+                    //
+                    // See discussion in https://wellcome.slack.com/archives/C8X9YKM5X/p1641833044030400
+                    showDownloadOptions={true}
                   />
                 </Space>
               )}
-              {showDownloadOptions && (
-                <Download
-                  ariaControlsId="itemDownloads"
-                  downloadOptions={downloadOptions}
+              {audio?.sounds && audio.sounds.length > 0 && (
+                <AudioList
+                  items={audio?.sounds || []}
+                  thumbnail={audio?.thumbnail}
+                  transcript={audio?.transcript}
+                  workTitle={work.title}
                 />
               )}
-            </div>
-            {(Boolean(
-              collectionManifestsCount && collectionManifestsCount > 0
-            ) ||
-              Boolean(canvasCount && canvasCount > 0)) && (
-              <Space $v={{ size: 'm', properties: ['margin-top'] }}>
-                <p className={`${font('lr', 6)}`} style={{ marginBottom: 0 }}>
-                  Contains:{' '}
-                  {collectionManifestsCount && collectionManifestsCount > 0
-                    ? `${collectionManifestsCount} ${
-                        collectionManifestsCount === 1 ? 'volume' : 'volumes'
-                      }`
-                    : canvasCount && canvasCount > 0
-                    ? `${canvasCount} ${canvasCount === 1 ? 'image' : 'images'}`
-                    : ''}
-                </p>
-              </Space>
-            )}
-          </>
-        )}
+              {shouldShowItemLink && (
+                <>
+                  {work.thumbnail && (
+                    <Space $v={{ size: 's', properties: ['margin-bottom'] }}>
+                      <ConditionalWrapper
+                        condition={Boolean(itemUrl)}
+                        wrapper={children =>
+                          itemUrl && (
+                            <NextLink
+                              style={{
+                                display: 'inline-block',
+                              }}
+                              href={itemUrl.href}
+                              as={itemUrl.as}
+                            >
+                              {children}
+                            </NextLink>
+                          )
+                        }
+                      >
+                        <img
+                          style={{
+                            width: 'auto',
+                            height: 'auto',
+                            display: 'block',
+                          }}
+                          alt={`view ${work.title}`}
+                          src={work.thumbnail.url}
+                        />
+                      </ConditionalWrapper>
+                    </Space>
+                  )}
+                  <div style={{ display: 'flex' }}>
+                    {itemUrl && (
+                      <Space
+                        as="span"
+                        $h={{ size: 'm', properties: ['margin-right'] }}
+                      >
+                        <Button
+                          variant="ButtonSolidLink"
+                          icon={eye}
+                          text="View"
+                          link={{ ...itemUrl }}
+                        />
+                      </Space>
+                    )}
+                    {showDownloadOptions && (
+                      <Download
+                        ariaControlsId="itemDownloads"
+                        downloadOptions={downloadOptions}
+                      />
+                    )}
+                  </div>
+                  {(Boolean(
+                    collectionManifestsCount && collectionManifestsCount > 0
+                  ) ||
+                    Boolean(canvasCount && canvasCount > 0)) && (
+                    <Space $v={{ size: 'm', properties: ['margin-top'] }}>
+                      <p
+                        className={`${font('lr', 6)}`}
+                        style={{ marginBottom: 0 }}
+                      >
+                        Contains:{' '}
+                        {collectionManifestsCount &&
+                        collectionManifestsCount > 0
+                          ? `${collectionManifestsCount} ${
+                              collectionManifestsCount === 1
+                                ? 'volume'
+                                : 'volumes'
+                            }`
+                          : canvasCount && canvasCount > 0
+                          ? `${canvasCount} ${
+                              canvasCount === 1 ? 'image' : 'images'
+                            }`
+                          : ''}
+                      </p>
+                    </Space>
+                  )}
+                </>
+              )}
+            </>
+          ))}
       </ConditionalWrapper>
 
       {digitalLocationInfo?.license && (


### PR DESCRIPTION
For #10584

Stops audio players, video players or view item links appearing on the work page when we are showing the DownloadList.