### PR TITLE
Adds a simple healthcheck endpoint to the identity app

### DIFF
--- a/identity/webapp/src/app.ts
+++ b/identity/webapp/src/app.ts
@@ -81,6 +81,14 @@ export async function createApp(): Promise<Koa> {
   );
 
   const router = new Router();
+
+  // Add a naive healthcheck endpoint for the load balancer
+  router.get('/management/healthcheck', async ctx => {
+    ctx.body = {
+      status: 'ok',
+    };
+  });
+
   router.all('(.*)', async ctx => {
     await nextHandler(ctx.req, ctx.res);
     ctx.respond = false;


### PR DESCRIPTION
## What does this change?

This change is part of https://github.com/wellcomecollection/wellcomecollection.org/issues/10545 and adds a healthcheck endpoint to the content app so we can really check the health of the app before it is deployed. At present the healthcheck terminates at the nginx container so during deployment (and normal running) we don't check if the app has properly started.

Same change for the content app: https://github.com/wellcomecollection/wellcomecollection.org/pull/10612

See https://github.com/wellcomecollection/platform-infrastructure/blob/main/images/dockerfiles/nginx/frontend.nginx.conf#L24

> [!NOTE]
> This will require a further change to remove the nginx config that fields the healthcheck request there.  

## How to test?

- [ ] Run locally, ensure the healthcheck is available and the app runs as expected.
- [ ] Deploy this change and check there is no change to functionality.

## How can we measure success?

No downtime during deployments resulting in a better experience for visitors to the site, and fewer errors that we cannot effectively respond to in the alerts channel. Deployments that really check if the app is running avoiding situations where we deploy a broken service.