### PR TITLE
Use updated container image for nginx in content & identity

### DIFF
--- a/content/terraform/.terraform.lock.hcl
+++ b/content/terraform/.terraform.lock.hcl
@@ -2,8 +2,23 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "5.5.0"
+  version = "5.34.0"
   hashes = [
-    "h1:gpLbjbtFk1XnHBO5+/CXVeQ2U0V45wZlS0GjEpbwwkw=",
+    "h1:1Y1JgV1z99QqAK06+atyfNqreZxyGZKbm4mZO4VhhT8=",
+    "zh:01bb20ae12b8c66f0cacec4f417a5d6741f018009f3a66077008e67cce127aa4",
+    "zh:3b0c9bdbbf846beef2c9573fc27898ceb71b69cf9d2f4b1dd2d0c2b539eab114",
+    "zh:5226ecb9c21c2f6fbf1d662ac82459ffcd4ad058a9ea9c6200750a21a80ca009",
+    "zh:6021b905d9b3cd3d7892eb04d405c6fa20112718de1d6ef7b9f1db0b0c97721a",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9e61b8e0ccf923979cd2dc1f1140dbcb02f92248578e10c1996f560b6306317c",
+    "zh:ad6bf62cdcf531f2f92f6416822918b7ba2af298e4a0065c6baf44991fda982d",
+    "zh:b698b041ef38837753bbe5265dddbc70b76e8b8b34c5c10876e6aab0eb5eaf63",
+    "zh:bb799843c534f6a3f072a99d93a3b53ff97c58a96742be15518adf8127706784",
+    "zh:cebee0d942c37cd3b21e9050457cceb26d0a6ea886b855dab64bb67d78f863d1",
+    "zh:e061fdd1cb99e7c81fb4485b41ae000c6792d38f73f9f50aed0d3d5c2ce6dcfb",
+    "zh:eeb4943f82734946362696928336357cd1d36164907ae5905da0316a67e275e1",
+    "zh:ef09b6ad475efa9300327a30cbbe4373d817261c8e41e5b7391750b16ef4547d",
+    "zh:f01aab3881cd90b3f56da7c2a75f83da37fd03cc615fc5600a44056a7e0f9af7",
+    "zh:fcd0f724ebc4b56a499eb6c0fc602de609af18a0d578befa2f7a8df155c55550",
   ]
 }

--- a/content/terraform/stack/main.tf
+++ b/content/terraform/stack/main.tf
@@ -13,7 +13,7 @@ module "content-service-17092020" {
 
   nginx_container_config = {
     image_name    = "uk.ac.wellcome/nginx_frontend"
-    container_tag = "ec2c0e28e9b3e6805c408389cffade3021bf55ad"
+    container_tag = "b809c6ef4363ff0cbac8da7ff5e80d865cfcd008"
   }
 
   cpu    = var.env_suffix == "prod" ? 2048 : 512

--- a/content/terraform/stack/main.tf
+++ b/content/terraform/stack/main.tf
@@ -11,6 +11,11 @@ module "content-service-17092020" {
   container_image = var.container_image
   container_port  = 3000
 
+  nginx_container_config = {
+    image_name    = "uk.ac.wellcome/nginx_frontend"
+    container_tag = "ec2c0e28e9b3e6805c408389cffade3021bf55ad"
+  }
+
   cpu    = var.env_suffix == "prod" ? 2048 : 512
   memory = var.env_suffix == "prod" ? 4096 : 1024
 

--- a/identity/terraform/.terraform.lock.hcl
+++ b/identity/terraform/.terraform.lock.hcl
@@ -2,15 +2,42 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "5.5.0"
+  version = "5.35.0"
   hashes = [
-    "h1:gpLbjbtFk1XnHBO5+/CXVeQ2U0V45wZlS0GjEpbwwkw=",
+    "h1:MKNFmhsOIirK7Qzr6TWkVaBcVGN81lCU0BPiaPOeQ8s=",
+    "zh:3a2a6f40db82d30ea8c5e3e251ca5e16b08e520570336e7e342be823df67e945",
+    "zh:420a23b69b412438a15b8b2e2c9aac2cf2e4976f990f117e4bf8f630692d3949",
+    "zh:4d8b887f6a71b38cff77ad14af9279528433e279eed702d96b81ea48e16e779c",
+    "zh:4edd41f8e1c7d29931608a7b01a7ae3d89d6f95ef5502cf8200f228a27917c40",
+    "zh:6337544e2ded5cf37b55a70aa6ce81c07fd444a2644ff3c5aad1d34680051bdc",
+    "zh:668faa3faaf2e0758bf319ea40d2304340f4a2dc2cd24460ddfa6ab66f71b802",
+    "zh:79ddc6d7c90e59fdf4a51e6ea822ba9495b1873d6a9d70daf2eeaf6fc4eb6ff3",
+    "zh:885822027faf1aa57787f980ead7c26e7d0e55b4040d926b65709b764f804513",
+    "zh:8c50a8f397b871388ff2e048f5eb280af107faa2e8926694f1ffd9f32a7a7cdf",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a2f5d2553df5573a060641f18ee7585587047c25ba73fd80617f59b5893d22b4",
+    "zh:c43833ae2a152213ee92eb5be7653f9493779eddbe0ce403ea49b5f1d87fd766",
+    "zh:dab01527a3a55b4f0f958af6f46313d775e27f9ad9d10bedbbfea4a35a06dc5f",
+    "zh:ed49c65620ec42718d681a7fc00c166c295ff2795db6cede2c690b83f9fb3e65",
+    "zh:f0a358c0ae1087c466d0fbcc3b4da886f33f881a145c3836ec43149878b86a1a",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/random" {
-  version = "3.5.1"
+  version = "3.6.0"
   hashes = [
-    "h1:sZ7MTSD4FLekNN2wSNFGpM+5slfvpm5A/NLVZiB7CO0=",
+    "h1:I8MBeauYA8J8yheLJ8oSMWqB0kovn16dF/wKZ1QTdkk=",
+    "zh:03360ed3ecd31e8c5dac9c95fe0858be50f3e9a0d0c654b5e504109c2159287d",
+    "zh:1c67ac51254ba2a2bb53a25e8ae7e4d076103483f55f39b426ec55e47d1fe211",
+    "zh:24a17bba7f6d679538ff51b3a2f378cedadede97af8a1db7dad4fd8d6d50f829",
+    "zh:30ffb297ffd1633175d6545d37c2217e2cef9545a6e03946e514c59c0859b77d",
+    "zh:454ce4b3dbc73e6775f2f6605d45cee6e16c3872a2e66a2c97993d6e5cbd7055",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:91df0a9fab329aff2ff4cf26797592eb7a3a90b4a0c04d64ce186654e0cc6e17",
+    "zh:aa57384b85622a9f7bfb5d4512ca88e61f22a9cea9f30febaa4c98c68ff0dc21",
+    "zh:c4a3e329ba786ffb6f2b694e1fd41d413a7010f3a53c20b432325a94fa71e839",
+    "zh:e2699bc9116447f96c53d55f2a00570f982e6f9935038c3810603572693712d0",
+    "zh:e747c0fd5d7684e5bfad8aa0ca441903f15ae7a98a737ff6aca24ba223207e2c",
+    "zh:f1ca75f417ce490368f047b63ec09fd003711ae48487fba90b4aba2ccf71920e",
   ]
 }

--- a/identity/terraform/stack/main.tf
+++ b/identity/terraform/stack/main.tf
@@ -33,7 +33,7 @@ module "identity-service-18012021" {
   # into the shared logging cluster.
   nginx_container_config = {
     image_name    = "uk.ac.wellcome/nginx_frontend_identity"
-    container_tag = "39d58d9252e68c954e85323f3ac07eb3c0f580e8"
+    container_tag = "ec2c0e28e9b3e6805c408389cffade3021bf55ad"
   }
 
   vpc_id  = local.vpc_id

--- a/identity/terraform/stack/main.tf
+++ b/identity/terraform/stack/main.tf
@@ -33,7 +33,7 @@ module "identity-service-18012021" {
   # into the shared logging cluster.
   nginx_container_config = {
     image_name    = "uk.ac.wellcome/nginx_frontend_identity"
-    container_tag = "ec2c0e28e9b3e6805c408389cffade3021bf55ad"
+    container_tag = "b809c6ef4363ff0cbac8da7ff5e80d865cfcd008"
   }
 
   vpc_id  = local.vpc_id

--- a/infrastructure/modules/service/main.tf
+++ b/infrastructure/modules/service/main.tf
@@ -34,7 +34,7 @@ module "log_router_container_secrets_permissions" {
 }
 
 module "nginx_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/nginx/frontend?ref=v3.15.3"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/nginx/frontend?ref=rk/remove-default-nginx-frontend-tag"
 
   forward_port      = var.container_port
   log_configuration = module.log_router_container.container_log_configuration

--- a/infrastructure/modules/service/main.tf
+++ b/infrastructure/modules/service/main.tf
@@ -23,18 +23,18 @@ resource "aws_lb_target_group" "http" {
 }
 
 module "log_router_container" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v3.15.3"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v4.0.0"
   namespace = var.namespace
 }
 
 module "log_router_container_secrets_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.15.3"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v4.0.0"
   secrets   = module.log_router_container.shared_secrets_logging
   role_name = module.task_definition.task_execution_role_name
 }
 
 module "nginx_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/nginx/frontend?ref=remove-default-nginx-frontend-tag"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/nginx/frontend?ref=v4.0.0"
 
   forward_port      = var.container_port
   log_configuration = module.log_router_container.container_log_configuration
@@ -44,7 +44,7 @@ module "nginx_container" {
 }
 
 module "app_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.15.3"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v4.0.0"
   name   = "app"
 
   image = var.container_image
@@ -56,13 +56,13 @@ module "app_container" {
 }
 
 module "app_container_secrets_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.15.3"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v4.0.0"
   secrets   = var.secret_env_vars
   role_name = module.task_definition.task_execution_role_name
 }
 
 module "task_definition" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v3.15.3"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v4.0.0"
 
   cpu    = var.cpu
   memory = var.memory
@@ -77,7 +77,7 @@ module "task_definition" {
 }
 
 module "service" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/service?ref=v3.15.3"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/service?ref=v4.0.0"
 
   cluster_arn  = var.cluster_arn
   service_name = var.namespace

--- a/infrastructure/modules/service/main.tf
+++ b/infrastructure/modules/service/main.tf
@@ -34,7 +34,7 @@ module "log_router_container_secrets_permissions" {
 }
 
 module "nginx_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/nginx/frontend?ref=rk/remove-default-nginx-frontend-tag"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/nginx/frontend?ref=remove-default-nginx-frontend-tag"
 
   forward_port      = var.container_port
   log_configuration = module.log_router_container.container_log_configuration

--- a/infrastructure/modules/service/variables.tf
+++ b/infrastructure/modules/service/variables.tf
@@ -21,12 +21,6 @@ variable "nginx_container_config" {
     image_name    = string
     container_tag = string
   })
-
-  // This has an increased max request body size, and increased proxy buffer sizes
-  default = {
-    image_name    = "uk.ac.wellcome/nginx_frontend"
-    container_tag = "9b95057b716a60f9891f77111b0bd524b85839aa"
-  }
 }
 
 variable "security_group_ids" {


### PR DESCRIPTION
## Who is this for?

This change uses the updated nginx container images from https://github.com/wellcomecollection/platform-infrastructure/pull/413, in order to allow the healthcheck endpoints added in:

- https://github.com/wellcomecollection/wellcomecollection.org/pull/10617
- https://github.com/wellcomecollection/wellcomecollection.org/pull/10612

To serve traffic and really confirm if the application container has started.

Tested in stage: https://wellcome.slack.com/archives/C3TQSF63C/p1706545489494719

## What is it doing for them?

See https://github.com/wellcomecollection/wellcomecollection.org/issues/10545 for the motivation for this change.
