### PR TITLE
Block bytespider bot by user-agent header

### DIFF
--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -302,6 +302,41 @@ resource "aws_wafv2_web_acl" "wc_org" {
     }
   }
 
+
+  // Block ByteSpider, a prolific bot causing problems with load
+  // on our services that has resulted in outages.
+  rule {
+    name     = "bytespider-useragent"
+
+    priority = 8
+
+    action {
+      block {}
+    }
+
+    statement {
+      byte_match_statement {
+        field_to_match {
+          single_header {
+            name = "user-agent"
+          }
+        }
+
+        positional_constraint = "CONTAINS"
+        search_string          = "Bytespider"
+        text_transformation {
+          priority = 0
+          type     = "NONE"
+        }
+      }
+    }
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      sampled_requests_enabled   = true
+      metric_name                = "weco-cloudfront-acl-bytespider-useragent-${var.namespace}"
+    }
+  }
+
   visibility_config {
     cloudwatch_metrics_enabled = true
     sampled_requests_enabled   = true


### PR DESCRIPTION
## Who is this for?

Users of our site who want to be able to visit it without issue, and developers who don't want to be alerted about bad behaving bots.

https://wellcome.slack.com/archives/CQ720BG02/p1706520543358799

Logs of recent issue: https://logging.wellcomecollection.org/app/r/s/rTkEb

See Sunday 28th of Jan deluge of requests:
<img width="1715" alt="Screenshot 2024-01-29 at 10 55 26" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/953792/5e03777e-4407-4509-9986-e27d1aa325f7">

## What is it doing for them?

We've been seeing problematic traffic from ByteSpider for a while, causing an outage at the start of 2024, and now getting round our WAF rules to cause smaller problems.

This change blocks this bot specifically by matching on user-agent rather than relying on the other WAF rules.

## How to test?

- [x] Targetted apply to stage: `terraform apply -target module.stage_wc_org_cloudfront_distribution`
- [x] Send request with "Bytespider" in user-agent to test WAG reaction.

https://github.com/wellcomecollection/wellcomecollection.org/assets/953792/ddec4ea6-6da3-4b5c-b0b5-c130635022da

