### PR TITLE
Change default value for shared VSCode config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,10 +3,10 @@
   "editor.tabSize": 2,
   "files.encoding": "utf8",
   "editor.codeActionsOnSave": {
-    "editor.insertSpaces": true,
-    "source.fixAll.eslint": true,
-    "source.fixAll.stylelint": true,
-    "files.trimTrailingWhitespace": true,
+    "editor.insertSpaces": "explicit",
+    "source.fixAll.eslint": "explicit",
+    "source.fixAll.stylelint": "explicit",
+    "files.trimTrailingWhitespace": "explicit"
   },
   "stylelint.validate": ["typescriptreact"],
 }


### PR DESCRIPTION
## Who is this for?
Maintenance/devs

## What is it doing for them?
[The default value for this config](https://code.visualstudio.com/Docs/languages/javascript) has changed. `"explicit"` is the same as `true` , and it updates automatically every time I update the software, so might as well change it for real in the repo. I know it happens to Agnès too, do flag if this goes against what you've got but it should be this moving forward.

From the docs:
> As of today, the following enums are supported:
explicit (default): Triggers Code Actions when explicitly saved. **Same as true.**
[...]
