### PR TITLE
Display "fully booked" when relevant on events search cards

### DIFF
--- a/content/webapp/components/EventPromo/EventPromo.tsx
+++ b/content/webapp/components/EventPromo/EventPromo.tsx
@@ -147,7 +147,7 @@ const EventPromo: FunctionComponent<Props> = ({
             </>
           )}
 
-          {upcomingDatesFullyBooked(event) && (
+          {upcomingDatesFullyBooked(event.times) && (
             <Space $v={{ size: 'm', properties: ['margin-top'] }}>
               <TextWithDot
                 className={font('intr', 5)}

--- a/content/webapp/components/EventsSearchResults/index.tsx
+++ b/content/webapp/components/EventsSearchResults/index.tsx
@@ -32,6 +32,7 @@ import TextWithDot from '@weco/content/components/TextWithDot';
 import Divider from '@weco/common/views/components/Divider/Divider';
 import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
 import { Label } from '@weco/common/model/labels';
+import { upcomingDatesFullyBooked } from 'services/prismic/events';
 
 type Props = {
   events: EventDocument[];
@@ -159,16 +160,15 @@ const EventsSearchResults: FunctionComponent<Props> = ({ events }: Props) => {
                   </>
                 )}
 
-                {/* TODO isFullyBooked needs to be added to API reponse */}
-                {/* {upcomingDatesFullyBooked(event) && (
-                <Space $v={{ size: 'm', properties: ['margin-top'] }}>
-                  <TextWithDot
-                    className={font('intr', 5)}
-                    dotColor="validation.red"
-                    text="Fully booked"
-                  />
-                </Space>
-              )} */}
+                {upcomingDatesFullyBooked(times) && (
+                  <Space $v={{ size: 'm', properties: ['margin-top'] }}>
+                    <TextWithDot
+                      className={font('intr', 5)}
+                      dotColor="validation.red"
+                      text="Fully booked"
+                    />
+                  </Space>
+                )}
 
                 {!isPast && times.length > 1 && (
                   <p className={font('intb', 6)}>See all dates/times</p>

--- a/content/webapp/pages/events/[eventId]/index.tsx
+++ b/content/webapp/pages/events/[eventId]/index.tsx
@@ -237,7 +237,7 @@ const EventPage: NextPage<EventProps> = ({
             </Space>
           </Space>
           {event.isPast && <EventStatus text="Past" color="neutral.500" />}
-          {upcomingDatesFullyBooked(event) && (
+          {upcomingDatesFullyBooked(event.times) && (
             <EventStatus text="Fully booked" color="validation.red" />
           )}
         </>

--- a/content/webapp/services/prismic/events.test.ts
+++ b/content/webapp/services/prismic/events.test.ts
@@ -81,7 +81,7 @@ describe('upcomingDatesFullyBooked', () => {
         },
       ],
     };
-    const result = upcomingDatesFullyBooked(event);
+    const result = upcomingDatesFullyBooked(event.times);
     expect(result).toEqual(true);
   });
 
@@ -105,7 +105,7 @@ describe('upcomingDatesFullyBooked', () => {
         },
       ],
     };
-    const result = upcomingDatesFullyBooked(event);
+    const result = upcomingDatesFullyBooked(event.times);
     expect(result).toEqual(false);
   });
 
@@ -122,7 +122,7 @@ describe('upcomingDatesFullyBooked', () => {
         },
       ],
     };
-    const result = upcomingDatesFullyBooked(event);
+    const result = upcomingDatesFullyBooked(event.times);
     expect(result).toEqual(false);
   });
 
@@ -139,7 +139,7 @@ describe('upcomingDatesFullyBooked', () => {
         },
       ],
     };
-    const result = upcomingDatesFullyBooked(event);
+    const result = upcomingDatesFullyBooked(event.times);
     expect(result).toEqual(false);
   });
 
@@ -148,7 +148,7 @@ describe('upcomingDatesFullyBooked', () => {
       id: 'event-id',
       times: [],
     };
-    const result = upcomingDatesFullyBooked(event);
+    const result = upcomingDatesFullyBooked(event.times);
     expect(result).toEqual(false);
   });
 });

--- a/content/webapp/services/prismic/events.ts
+++ b/content/webapp/services/prismic/events.ts
@@ -9,7 +9,7 @@ import {
   minDate,
   startOfDay,
 } from '@weco/common/utils/dates';
-import { HasTimes } from '../../types/events';
+import { EventTime, HasTimes } from '../../types/events';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
 
 function getNextDateInFuture(event: HasTimes): Date | undefined {
@@ -203,10 +203,10 @@ export function isEventPast({ times }: HasTimes): boolean {
   return times.every(({ range }) => isPast(range.endDateTime));
 }
 
-export function upcomingDatesFullyBooked(event: HasTimes): boolean {
+export function upcomingDatesFullyBooked(times: EventTime[]): boolean {
   const upcoming =
-    event.times.length > 0
-      ? event.times.filter(({ range }) => !isPast(range.endDateTime))
+    times.length > 0
+      ? times.filter(({ range }) => !isPast(range.endDateTime))
       : [];
   if (upcoming.length > 0) {
     return upcoming.every(

--- a/content/webapp/services/prismic/transformers/events.ts
+++ b/content/webapp/services/prismic/transformers/events.ts
@@ -165,8 +165,9 @@ export function transformEventTimes(
               range: range as DateTimeRange,
               isFullyBooked:
                 // isFullyBooked in the Content API is an object containing inVenue and online
-                // Therefore this accounts either Content API or Prismic provenance.
-                typeof isFullyBooked === 'object'
+                // Therefore this accounts either Content API ("yes"|null) or Prismic provenance.
+                // "null" being an object we need to guard against that too.
+                isFullyBooked !== null && typeof isFullyBooked === 'object'
                   ? { ...isFullyBooked }
                   : {
                       inVenue: isFullyBooked,

--- a/content/webapp/services/prismic/transformers/events.ts
+++ b/content/webapp/services/prismic/transformers/events.ts
@@ -139,7 +139,7 @@ function transformThirdPartyBooking(
 
 export function transformEventTimes(
   id: string,
-  times: prismic.GroupField<EventTimePrismicDocument> | ContentApiTimeField[] // TODO review this, should we want the missing fields?
+  times: prismic.GroupField<EventTimePrismicDocument> | ContentApiTimeField[]
 ): EventTime[] {
   return times
     .map(
@@ -163,10 +163,15 @@ export function transformEventTimes(
           isNotUndefined(range.endDateTime)
           ? {
               range: range as DateTimeRange,
-              isFullyBooked: {
-                inVenue: isFullyBooked,
-                online: onlineIsFullyBooked,
-              },
+              isFullyBooked:
+                // isFullyBooked in the Content API is an object containing inVenue and online
+                // Therefore this accounts either Content API or Prismic provenance.
+                typeof isFullyBooked === 'object'
+                  ? { ...isFullyBooked }
+                  : {
+                      inVenue: isFullyBooked,
+                      online: onlineIsFullyBooked,
+                    },
             }
           : undefined;
       }

--- a/content/webapp/services/wellcome/content/types/api.ts
+++ b/content/webapp/services/wellcome/content/types/api.ts
@@ -8,6 +8,10 @@ import { Image } from '@weco/content/services/prismic/types';
 export type ContentApiTimeField = {
   startDateTime?: Date;
   endDateTime?: Date;
+  isFullyBooked: {
+    inVenue: boolean;
+    online: boolean;
+  };
 };
 
 export type ContentApiProps = {


### PR DESCRIPTION
## Who is this for?
Relates to #10587 

## What is it doing for them?
- `upcomingDatesFullyBooked` only needs the event times really, so simplified that
- Made it so an event would be marked as fully booked if necessary on the events search cards
- Modified `transformEventTimes` to allow for the different `isFullyBooked` format from Content API and Prismic API

Worth noting for testing purposes that as Content reindexes happen every 15minutes, it may take 15 minutes for content changes to display on the UI. It's always been the case (incl with articles), but I hadn't really needed a quick refresh as when testing with Fully Booked status, so FYI! 

[If needed, a Test event can be found here in Prismic](https://wellcomecollection.prismic.io/documents~b=working&c=published&l=en-gb/ZbKOnBIAACQAlnWs/?section=Event), or search for "Hybrid event" on the UI.