### PR TITLE
Protect the load-balancer from bots

### DIFF
--- a/cache/cloudfront_e2e.tf
+++ b/cache/cloudfront_e2e.tf
@@ -47,4 +47,6 @@ module "e2e_wc_org_cloudfront_distribution" {
   request_policies  = module.cloudfront_policies.request_policies
   response_policies = module.cloudfront_policies.response_policies
   waf_ip_allowlist  = local.waf_ip_allowlist
+
+  header_shared_secret = local.current_shared_secret
 }

--- a/cache/cloudfront_prod.tf
+++ b/cache/cloudfront_prod.tf
@@ -28,6 +28,8 @@ module "prod_wc_org_cloudfront_distribution" {
   request_policies  = module.cloudfront_policies.request_policies
   response_policies = module.cloudfront_policies.response_policies
   waf_ip_allowlist  = local.waf_ip_allowlist
+
+  header_shared_secret = local.current_shared_secret
 }
 
 data "aws_lambda_function" "versioned_edge_lambda_request" {

--- a/cache/cloudfront_stage.tf
+++ b/cache/cloudfront_stage.tf
@@ -25,4 +25,6 @@ module "stage_wc_org_cloudfront_distribution" {
   request_policies  = module.cloudfront_policies.request_policies
   response_policies = module.cloudfront_policies.response_policies
   waf_ip_allowlist  = local.waf_ip_allowlist
+
+  header_shared_secret = local.current_shared_secret
 }

--- a/cache/modules/wc_org_cloudfront/distribution.tf
+++ b/cache/modules/wc_org_cloudfront/distribution.tf
@@ -17,6 +17,13 @@ resource "aws_cloudfront_distribution" "wc_org" {
       https_port             = "443"
       origin_ssl_protocols   = ["TLSv1.2"]
     }
+
+    # // We need to send the backend token to the load balancer so that it can
+    # // authenticate requests to the backend.
+    custom_header {
+      name  = "x-weco-cloudfront-shared-secret"
+      value = var.header_shared_secret
+    }
   }
 
   // The S3 bucket containing some static assets

--- a/cache/modules/wc_org_cloudfront/variables.tf
+++ b/cache/modules/wc_org_cloudfront/variables.tf
@@ -47,3 +47,7 @@ variable "waf_ip_allowlist" {
   type    = set(string)
   default = []
 }
+
+variable "header_shared_secret" {
+  type = string
+}

--- a/cache/secrets.tf
+++ b/cache/secrets.tf
@@ -1,0 +1,45 @@
+# This secret is used to authenticate requests from CloudFront at
+# the load balancer in all environments. It is used to ensure that 
+# only requests from CloudFront are allowed to access the load balancers.
+resource "aws_secretsmanager_secret" "header_shared_secret_020124" {
+  name = "shared/cloudfront_custom_header/020124"
+  description = "Shared secret for authenticating requests from CloudFront"
+}
+
+data "aws_secretsmanager_secret_version" "header_shared_secret_020124" {
+  secret_id = aws_secretsmanager_secret.header_shared_secret_020124.id
+}
+
+# resource "aws_secretsmanager_secret" "header_shared_secret_DDMMYY" {
+#   name = "shared/cloudfront_custom_header/DDMMYY"
+#   description = "Shared secret for authenticating requests from CloudFront"
+# }
+
+# data "aws_secretsmanager_secret_version" "header_shared_secret_DDMMYY" {
+#   secret_id = aws_secretsmanager_secret.header_shared_secret_DDMMYY.id
+# }
+
+
+locals {
+  current_shared_secret = data.aws_secretsmanager_secret_version.header_shared_secret_020124.secret_string
+}
+
+# **Secret rotation process**
+#
+# If you need to perform a rotation of the secret, follow this process:
+# - Create a new secret above and add it to the list of outputs below. 
+#   `terraform apply` in the cache stack will update will create the new secret
+# - Update the listener rule configs in all apps (content & identity) to accept the new secret.
+#   `terraform apply` in the content and identity stacks will update the listener rules (recommended to do targetted apply per env).
+# - Update the CloudFront distros for all envs by setting current_shared_secret above to the new secret
+#   `terraform apply` in the cache stack will update the CloudFront distros (recommended to do targetted apply per env)
+
+output "cloudfront_header_shared_secrets" {
+  # This is a relatively insecure way to share the secret as we're storing it in tf state, 
+  # but it's not high risk, the important thing is that it's not in the codebase.
+  value = [
+    data.aws_secretsmanager_secret_version.header_shared_secret_020124.secret_string,
+    # data.aws_secretsmanager_secret_version.header_shared_secret_DDMMYY.secret_string
+  ] 
+  sensitive = true
+}

--- a/content/terraform/data.tf
+++ b/content/terraform/data.tf
@@ -9,3 +9,15 @@ data "terraform_remote_state" "experience_shared" {
     region = "eu-west-1"
   }
 }
+
+data "terraform_remote_state" "cache" {
+  backend = "s3"
+
+  config = {
+    role_arn = "arn:aws:iam::130871440101:role/experience-read_only"
+
+    bucket = "wellcomecollection-infra"
+    key    = "build-state/cache.tfstate"
+    region = "eu-west-1"
+  }
+}

--- a/content/terraform/locals.tf
+++ b/content/terraform/locals.tf
@@ -21,8 +21,9 @@ locals {
     }
   )
 
-
   e2e_app_image   = "${data.terraform_remote_state.experience_shared.outputs.buildkite_ecr_uri}:content-env.e2e"
   stage_app_image = "${data.terraform_remote_state.experience_shared.outputs.content_webapp_ecr_uri}:env.stage"
   prod_app_image  = "${data.terraform_remote_state.experience_shared.outputs.content_webapp_ecr_uri}:env.prod"
+
+  cloudfront_header_secrets = data.terraform_remote_state.cache.outputs.cloudfront_header_shared_secrets
 }

--- a/content/terraform/main.tf
+++ b/content/terraform/main.tf
@@ -4,6 +4,7 @@ module "content-prod" {
   source = "./stack"
 
   environment = data.terraform_remote_state.experience_shared.outputs.prod
+  cloudfront_header_secrets = local.cloudfront_header_secrets
 
   container_image = local.prod_app_image
   env_suffix      = "prod"
@@ -17,6 +18,7 @@ module "content-stage" {
   source = "./stack"
 
   environment = data.terraform_remote_state.experience_shared.outputs.stage
+  cloudfront_header_secrets = local.cloudfront_header_secrets
 
   container_image = local.stage_app_image
   env_suffix      = "stage"
@@ -37,6 +39,7 @@ module "content-e2e" {
   source = "./stack"
 
   environment = data.terraform_remote_state.experience_shared.outputs.e2e
+  cloudfront_header_secrets = local.cloudfront_header_secrets
 
   container_image = local.e2e_app_image
   env_suffix      = "e2e"

--- a/content/terraform/stack/main.tf
+++ b/content/terraform/stack/main.tf
@@ -61,6 +61,8 @@ module "path_listener" {
   alb_listener_http_arn  = var.environment["listener_http_arn"]
   target_group_arn       = local.target_group_arn
 
+  cloudfront_header_secrets = var.cloudfront_header_secrets
+
   path_patterns = ["/*"]
   priority      = "49998"
 }
@@ -73,6 +75,8 @@ module "subdomain_listener" {
   alb_listener_https_arn = var.environment["listener_https_arn"]
   alb_listener_http_arn  = var.environment["listener_http_arn"]
   target_group_arn       = local.target_group_arn
+
+  cloudfront_header_secrets = var.cloudfront_header_secrets
 
   host_headers = ["${var.subdomain}.wellcomecollection.org"]
   priority     = "49999"

--- a/content/terraform/stack/variables.tf
+++ b/content/terraform/stack/variables.tf
@@ -30,3 +30,8 @@ variable "turn_off_outside_office_hours" {
   type    = bool
   default = false
 }
+
+variable "cloudfront_header_secrets" {
+  type    = list(string)
+  default = []
+}

--- a/identity/terraform/data.tf
+++ b/identity/terraform/data.tf
@@ -9,3 +9,16 @@ data "terraform_remote_state" "experience_shared" {
     region = "eu-west-1"
   }
 }
+
+data "terraform_remote_state" "cache" {
+  backend = "s3"
+
+  config = {
+    role_arn = "arn:aws:iam::130871440101:role/experience-read_only"
+
+    bucket = "wellcomecollection-infra"
+    key    = "build-state/cache.tfstate"
+    region = "eu-west-1"
+  }
+}
+

--- a/identity/terraform/locals.tf
+++ b/identity/terraform/locals.tf
@@ -21,6 +21,8 @@ locals {
       AUTH0_ACTION_SECRET = "identity/${env_name}/redirect_action_secret"
     }
   } }
+
+  cloudfront_header_secrets = data.terraform_remote_state.cache.outputs.cloudfront_header_shared_secrets
 }
 
 resource "aws_secretsmanager_secret" "session_keys" {

--- a/identity/terraform/main.tf
+++ b/identity/terraform/main.tf
@@ -7,6 +7,7 @@ module "identity-prod" {
   env_suffix      = "prod"
 
   environment = data.terraform_remote_state.experience_shared.outputs.prod
+  cloudfront_header_secrets = local.cloudfront_header_secrets
 
   env_vars = merge(
     local.service_env["prod"]["env_vars"],
@@ -26,6 +27,7 @@ module "identity-stage" {
   env_suffix      = "stage"
 
   environment = data.terraform_remote_state.experience_shared.outputs.stage
+  cloudfront_header_secrets = local.cloudfront_header_secrets
 
   env_vars = merge(
     local.service_env["stage"]["env_vars"],
@@ -53,6 +55,7 @@ module "identity-e2e" {
   env_suffix      = "e2e"
 
   environment = data.terraform_remote_state.experience_shared.outputs.e2e
+  cloudfront_header_secrets = local.cloudfront_header_secrets
 
   env_vars = merge(
     local.service_env["stage"]["env_vars"],

--- a/identity/terraform/stack/main.tf
+++ b/identity/terraform/stack/main.tf
@@ -56,6 +56,8 @@ module "path_listener" {
   alb_listener_http_arn  = var.environment["listener_http_arn"]
   target_group_arn       = local.target_group_arn
 
+  cloudfront_header_secrets = var.cloudfront_header_secrets
+
   path_patterns = ["/account*"]
   priority      = "49994"
 }
@@ -68,6 +70,8 @@ module "subdomain_listener" {
   alb_listener_https_arn = var.environment["listener_https_arn"]
   alb_listener_http_arn  = var.environment["listener_http_arn"]
   target_group_arn       = local.target_group_arn
+
+  cloudfront_header_secrets = var.cloudfront_header_secrets
 
   priority     = "301"
   host_headers = ["${var.subdomain}.wellcomecollection.org"]
@@ -105,6 +109,8 @@ module "identity_data_listener" {
   alb_listener_https_arn = var.environment["listener_https_arn"]
   alb_listener_http_arn  = var.environment["listener_http_arn"]
   target_group_arn       = local.target_group_arn
+
+  cloudfront_header_secrets = var.cloudfront_header_secrets
 
   path_patterns = each.value
   priority      = local.min_priority + each.key

--- a/identity/terraform/stack/variables.tf
+++ b/identity/terraform/stack/variables.tf
@@ -34,3 +34,8 @@ variable "turn_off_outside_office_hours" {
   type    = bool
   default = false
 }
+
+variable "cloudfront_header_secrets" {
+  type    = list(string)
+  default = []
+}

--- a/infrastructure/modules/alb_listener_rule/main.tf
+++ b/infrastructure/modules/alb_listener_rule/main.tf
@@ -22,6 +22,20 @@ resource "aws_alb_listener_rule" "https" {
       }
     }
   }
+
+  condition {
+    // Add a check for any of the values of the secret headers
+    // This is used to allow the loadbalancer to check for secret 
+    // headers from CloudFront. We accept multiple headers to allow
+    // for secret rotation to take place safely.
+    dynamic "http_header" {
+      for_each = length(var.cloudfront_header_secrets) > 0 ? [""] : []
+      content {
+        http_header_name = "x-weco-cloudfront-shared-secret"
+        values           = var.cloudfront_header_secrets
+      }
+    }
+  }
 }
 
 resource "aws_alb_listener_rule" "http" {
@@ -47,6 +61,20 @@ resource "aws_alb_listener_rule" "http" {
       for_each = length(var.host_headers) > 0 ? [""] : []
       content {
         values = var.host_headers
+      }
+    }
+  }
+
+  condition {
+    // Add a check for any of the values of the secret headers
+    // This is used to allow the loadbalancer to check for secret 
+    // headers from CloudFront. We accept multiple headers to allow
+    // for secret rotation to take place safely.
+    dynamic "http_header" {
+      for_each = length(var.cloudfront_header_secrets) > 0 ? [""] : []
+      content {
+        http_header_name = "x-weco-cloudfront-shared-secret"
+        values           = var.cloudfront_header_secrets
       }
     }
   }

--- a/infrastructure/modules/alb_listener_rule/variables.tf
+++ b/infrastructure/modules/alb_listener_rule/variables.tf
@@ -15,3 +15,8 @@ variable "host_headers" {
   type    = list(string)
   default = []
 }
+
+variable "cloudfront_header_secrets" {
+  type    = list(string)
+  default = []
+}


### PR DESCRIPTION
## What is this change?

We've recently had issues with requests which appear to come from a client with the "bytespider" user-agent causing load issues and outages for the site. 

Following https://github.com/wellcomecollection/wellcomecollection.org/pull/10619, we discovered that requests from this user-agent seem to be circumventing the CDN and being made at the load-balancer directly. This change protects the load-balancer from requests that do not come through the CDN by following [this AWS recommendation](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/restrict-access-to-load-balancer.html) to have a shared secret between CloudFormation & the ALB that is required to be set in a particular header for requests to succeed.

This change implements the AWS recommendation in terraform.

The implementation allows for secret rotation by allowing multiple header values to be passed to listener rules so that in the event the shared secret is changed we can do so without downtime.

> [!WARNING]
> When this change is rolled out it's important that CloudFront changes are made first to prevent requests being refused at the load balancer before the expected custom is added.

## How to test?

This change has been deployed to the stage environment using targeted `terraform apply`, and subsequent attempts to reach the load balancer directly made to ensure that requests that do not come via the CDN fail. 

## What risks are there?

Changes in the critical path to fulfil requests to the website are always risky - this should be tested in stage (and in e2e by running the tests there).
