### PR TITLE
Clarify closures on Today in What's on

### DIFF
--- a/content/webapp/__mocks__/whats-on.ts
+++ b/content/webapp/__mocks__/whats-on.ts
@@ -52,6 +52,8 @@ const beingHuman: Exhibition = {
       weight: 'default',
       value: {
         title: 'Exhibition highlights',
+        isStandalone: false,
+        isFrames: true,
         items: [
           {
             hasRoundedCorners: false,
@@ -1160,18 +1162,20 @@ const beingHuman: Exhibition = {
       },
     ],
   },
-  resources: [],
   relatedIds: ['XYt51BAAACIAYa4e', 'XYofFREAACQAp-Vl'],
+  accessResourcesPdfs: [],
   exhibits: [],
   seasons: [],
   contributors: [],
 };
 
-export const whatsOn: (hasExhibition: boolean) => WhatsOnProps = (
-  hasExhibition: boolean
-) => ({
+export const whatsOn: ({
+  hasExhibitions,
+}: {
+  hasExhibitions: boolean;
+}) => WhatsOnProps = ({ hasExhibitions }) => ({
   period: 'current-and-coming-up',
-  exhibitions: hasExhibition ? [beingHuman] : [],
+  exhibitions: hasExhibitions ? [beingHuman] : [],
   events: [],
   availableOnlineEvents: [],
   dateRange: { start: new Date(2020, 11, 5) },

--- a/content/webapp/components/InfoBox/InfoBox.tsx
+++ b/content/webapp/components/InfoBox/InfoBox.tsx
@@ -41,24 +41,25 @@ const InfoBox: FunctionComponent<Props> = ({
     <>
       <h2 className={headingClasses}>{title}</h2>
       <InfoContainer>
-        {items.map(({ title, description, icon }, i) => (
-          <div key={i}>
-            {icon && (title || description) && (
-              <InfoIconWrapper>
-                <Icon icon={icon} />
-              </InfoIconWrapper>
-            )}
-            {title && <h3 className={font('intb', 5)}>{title}</h3>}
-            {description && (
-              <Space
-                $v={{ size: 'm', properties: ['margin-bottom'] }}
-                className={font('intr', 5)}
-              >
-                <PrismicHtmlBlock html={description} />
-              </Space>
-            )}
-          </div>
-        ))}
+        {items.length > 0 &&
+          items.map(({ title, description, icon }, i) => (
+            <div key={i}>
+              {icon && (title || description) && (
+                <InfoIconWrapper>
+                  <Icon icon={icon} />
+                </InfoIconWrapper>
+              )}
+              {title && <h3 className={font('intb', 5)}>{title}</h3>}
+              {description && (
+                <Space
+                  $v={{ size: 'm', properties: ['margin-bottom'] }}
+                  className={font('intr', 5)}
+                >
+                  <PrismicHtmlBlock html={description} />
+                </Space>
+              )}
+            </div>
+          ))}
         {children}
       </InfoContainer>
     </>

--- a/content/webapp/components/InfoBox/InfoBox.tsx
+++ b/content/webapp/components/InfoBox/InfoBox.tsx
@@ -41,25 +41,24 @@ const InfoBox: FunctionComponent<Props> = ({
     <>
       <h2 className={headingClasses}>{title}</h2>
       <InfoContainer>
-        {items.length > 0 &&
-          items.map(({ title, description, icon }, i) => (
-            <div key={i}>
-              {icon && (title || description) && (
-                <InfoIconWrapper>
-                  <Icon icon={icon} />
-                </InfoIconWrapper>
-              )}
-              {title && <h3 className={font('intb', 5)}>{title}</h3>}
-              {description && (
-                <Space
-                  $v={{ size: 'm', properties: ['margin-bottom'] }}
-                  className={font('intr', 5)}
-                >
-                  <PrismicHtmlBlock html={description} />
-                </Space>
-              )}
-            </div>
-          ))}
+        {items.map(({ title, description, icon }, i) => (
+          <div key={i}>
+            {icon && (title || description) && (
+              <InfoIconWrapper>
+                <Icon icon={icon} />
+              </InfoIconWrapper>
+            )}
+            {title && <h3 className={font('intb', 5)}>{title}</h3>}
+            {description && (
+              <Space
+                $v={{ size: 'm', properties: ['margin-bottom'] }}
+                className={font('intr', 5)}
+              >
+                <PrismicHtmlBlock html={description} />
+              </Space>
+            )}
+          </div>
+        ))}
         {children}
       </InfoContainer>
     </>

--- a/content/webapp/components/InfoBox/InfoBox.tsx
+++ b/content/webapp/components/InfoBox/InfoBox.tsx
@@ -14,6 +14,7 @@ type InfoBoxItem = LabelField & {
 type Props = PropsWithChildren<{
   title: string;
   items: InfoBoxItem[];
+  headingClasses?: string;
 }>;
 
 const InfoContainer = styled(Space).attrs({
@@ -23,17 +24,22 @@ const InfoContainer = styled(Space).attrs({
   background-color: ${props => props.theme.color('yellow')};
 `;
 
-const InfoIconWrapper = styled(Space).attrs({
+export const InfoIconWrapper = styled(Space).attrs({
   className: font('intb', 4),
   $h: { size: 's', properties: ['margin-right'] },
 })`
   float: left;
 `;
 
-const InfoBox: FunctionComponent<Props> = ({ title, items, children }) => {
+const InfoBox: FunctionComponent<Props> = ({
+  title,
+  items,
+  headingClasses = font('wb', 3),
+  children,
+}) => {
   return (
     <>
-      <h2 className={font('wb', 3)}>{title}</h2>
+      <h2 className={headingClasses}>{title}</h2>
       <InfoContainer>
         {items.map(({ title, description, icon }, i) => (
           <div key={i}>

--- a/content/webapp/pages/whats-on/index.tsx
+++ b/content/webapp/pages/whats-on/index.tsx
@@ -142,18 +142,19 @@ const ClosedMessage = () => (
       headingClasses={font('wb', 2)}
       items={[]}
     >
+      <InfoIconWrapper>
+        <Icon icon={information} />
+      </InfoIconWrapper>
       <p className={font('intr', 5)}>
-        <InfoIconWrapper>
-          <Icon icon={information} />
-        </InfoIconWrapper>
         Our exhibitions are closed today, but our{' '}
         <a href="/pages/Wvl1wiAAADMJ3zNe">café</a> and{' '}
         <a href="/pages/WwgaIh8AAB8AGhC_">shop</a> are open for your visit.
       </p>
+
+      <InfoIconWrapper>
+        <Icon icon={clock} />
+      </InfoIconWrapper>
       <p className={font('intr', 5)} style={{ marginBottom: 0 }}>
-        <InfoIconWrapper>
-          <Icon icon={clock} />
-        </InfoIconWrapper>
         Galleries open Tuesday–Sunday,{' '}
         <a href="/opening-times">see full opening times</a>.
       </p>

--- a/content/webapp/pages/whats-on/index.tsx
+++ b/content/webapp/pages/whats-on/index.tsx
@@ -15,7 +15,7 @@ import {
   filterEventsForWeekend,
 } from '@weco/content/services/prismic/events';
 import { formatDayName, formatDate } from '@weco/common/utils/format-date';
-import { clock } from '@weco/common/icons';
+import { clock, information } from '@weco/common/icons';
 import {
   getTodaysVenueHours,
   getVenueById,
@@ -81,6 +81,11 @@ import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 import { cacheTTL, setCacheControl } from '@weco/content/utils/setCacheControl';
 import { Container } from '@weco/common/views/components/styled/Container';
 import Tabs from '@weco/content/components/Tabs';
+import InfoBox, {
+  InfoIconWrapper,
+} from '@weco/content/components/InfoBox/InfoBox';
+import MoreLink from '@weco/content/components/MoreLink/MoreLink';
+import theme from '@weco/common/views/themes/default';
 
 const tabItems = [
   {
@@ -127,27 +132,40 @@ export function getRangeForPeriod(period: Period): { start: Date; end?: Date } {
   }
 }
 
-// const ClosedMessage = () => (
-//   <>
-//     <Space
-//       $v={{
-//         size: 'm',
-//         properties: ['margin-bottom'],
-//       }}
-//       as="p"
-//       className={font('wb', 2)}
-//     >
-//       Our exhibitions are closed today, but our <a href={cafePromo.url}>café</a>{' '}
-//       and <a href={shopPromo.url}>shop</a> are open for your visit.
-//     </Space>
-//     <Space
-//       $v={{
-//         size: 'l',
-//         properties: ['margin-top', 'margin-bottom'],
-//       }}
-//     ></Space>
-//   </>
-// );
+const ClosedMessage = () => (
+  <Space
+    $v={{ size: 'l', properties: ['margin-top', 'margin-bottom'] }}
+    style={{ maxWidth: theme.sizes.large }}
+  >
+    <InfoBox
+      title="Exhibitions are closed today"
+      headingClasses={font('wb', 2)}
+      items={[]}
+    >
+      <p className={font('intr', 5)}>
+        <InfoIconWrapper>
+          <Icon icon={information} />
+        </InfoIconWrapper>
+        Our exhibitions are closed today, but our{' '}
+        <a href="/pages/Wvl1wiAAADMJ3zNe">café</a> and{' '}
+        <a href="/pages/WwgaIh8AAB8AGhC_">shop</a> are open for your visit.
+      </p>
+      <p className={font('intr', 5)} style={{ marginBottom: 0 }}>
+        <InfoIconWrapper>
+          <Icon icon={clock} />
+        </InfoIconWrapper>
+        Galleries open Tuesday–Sunday,{' '}
+        <a href="/opening-times">see full opening times</a>.
+      </p>
+    </InfoBox>
+    <Space $v={{ size: 'l', properties: ['margin-top'] }}>
+      <MoreLink url="/exhibitions" name="View all exhibitions" />
+    </Space>
+    <Space $v={{ size: 'm', properties: ['margin-top'] }}>
+      <MoreLink url="/events" name="View all events" />
+    </Space>
+  </Space>
+);
 
 type DateRangeProps = {
   dateRange: { start: Date; end?: Date };
@@ -421,6 +439,10 @@ const WhatsOnPage: FunctionComponent<Props> = props => {
       ? filterEventsForWeekend(events)
       : events;
 
+  // When the galleries are closed, we shouldn't be displaying exhibitions
+  const exhibitionsToShow =
+    period === 'today' && todaysOpeningHours?.isClosed ? [] : exhibitions;
+
   return (
     <PageLayout
       title={pageTitle}
@@ -440,10 +462,10 @@ const WhatsOnPage: FunctionComponent<Props> = props => {
         />
         <Layout gridSizes={gridSize12()}>
           <DateRange dateRange={dateRange} period={period} />
-          {/* TODO put back when building, shop and cafe are open normally */}
-          {/* {period === 'today' && todaysOpeningHours?.isClosed && (
+
+          {period === 'today' && todaysOpeningHours?.isClosed && (
             <ClosedMessage />
-          )} */}
+          )}
         </Layout>
         <Space $v={{ size: 'm', properties: ['margin-top'] }}>
           {period === 'current-and-coming-up' && (
@@ -526,34 +548,38 @@ const WhatsOnPage: FunctionComponent<Props> = props => {
               </Space>
             </>
           )}
-          {period !== 'current-and-coming-up' && (
-            <SpacingSection>
-              <Space
-                $v={{ size: 'm', properties: ['padding-top', 'margin-bottom'] }}
-              >
-                <Layout gridSizes={gridSize12()}>
-                  <div
-                    style={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'space-between',
-                    }}
-                  >
-                    <h2 className={font('wb', 2)}>Exhibitions and Events</h2>
-                    <span className={font('intb', 4)}>Free admission</span>
-                  </div>
-                </Layout>
-              </Space>
-              <ExhibitionsAndEvents
-                exhibitions={exhibitions}
-                events={eventsToShow}
-                links={[
-                  { text: 'View all exhibitions', url: '/exhibitions' },
-                  { text: 'View all events', url: '/events' },
-                ]}
-              />
-            </SpacingSection>
-          )}
+          {period !== 'current-and-coming-up' &&
+            (exhibitionsToShow.length > 0 || eventsToShow.length > 0) && (
+              <SpacingSection>
+                <Space
+                  $v={{
+                    size: 'm',
+                    properties: ['padding-top', 'margin-bottom'],
+                  }}
+                >
+                  <Layout gridSizes={gridSize12()}>
+                    <div
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'space-between',
+                      }}
+                    >
+                      <h2 className={font('wb', 2)}>Exhibitions and Events</h2>
+                      <span className={font('intb', 4)}>Free admission</span>
+                    </div>
+                  </Layout>
+                </Space>
+                <ExhibitionsAndEvents
+                  exhibitions={exhibitionsToShow}
+                  events={eventsToShow}
+                  links={[
+                    { text: 'View all exhibitions', url: '/exhibitions' },
+                    { text: 'View all events', url: '/events' },
+                  ]}
+                />
+              </SpacingSection>
+            )}
         </Space>
 
         <SpacingSection>

--- a/content/webapp/test/pages/whats-on.test.tsx
+++ b/content/webapp/test/pages/whats-on.test.tsx
@@ -18,12 +18,24 @@ jest.mock('next/router', () => require('next-router-mock'));
 
 describe('/whats-on', () => {
   it('renders a featured exhibition when there is one', () => {
-    const { getByText } = renderWithTheme(<WhatsOnPage {...whatsOn(true)} />);
+    const { getByText } = renderWithTheme(
+      <WhatsOnPage
+        {...whatsOn({
+          hasExhibitions: true,
+        })}
+      />
+    );
     expect(getByText('Being Human'));
   });
 
   it('renders no exhibitions when there are none', () => {
-    const { getByText } = renderWithTheme(<WhatsOnPage {...whatsOn(false)} />);
+    const { getByText } = renderWithTheme(
+      <WhatsOnPage
+        {...whatsOn({
+          hasExhibitions: false,
+        })}
+      />
+    );
     expect(getByText('There are no current exhibitions'));
   });
 });


### PR DESCRIPTION
## Who is this for?
Users who are interested in What's on today... on Mondays.
Relates to #10629 

## What is it doing for them?
- Makes it more obvious when the galleries are closed. We used to have a message there that was commented out during the covid closures, so we modernised it a little.
- Also removes exhibitions from being listed out (only in the Today tab and only when the galleries are closed) as that could cause further confusion.

- I also fixed the types in the test that were flagged as incorrect and tweaked the test a bit to be a bit clearer. I wanted to add a test either here or on the e2e about hiding the Events/Exhibitions on Monday, but the Jest ones don't get the Prismic data (which we need for opening hours) and the e2es ones can't mock the date yet ([It's been requested](https://github.com/microsoft/playwright/issues/6347), but nothing so far), unless we use another tool library... I thought I'd leave it for now as it felt like overkill for one test?

Before:

https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/5cfd32da-d95d-4bd1-b052-74338c774778


After:

https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/18f472ec-46bb-4324-bb0f-529b0854f158

