### PR TITLE
Remove console warning when not relevant

### DIFF
--- a/content/webapp/services/prismic/transformers/body.ts
+++ b/content/webapp/services/prismic/transformers/body.ts
@@ -227,7 +227,10 @@ function transformInfoBlockSlice(slice: InfoBlockSlice): BodySlice {
       title: asTitle(slice.primary.title),
       text: slice.primary.text,
       linkText: slice.primary.linkText,
-      link: transformLink(slice.primary.link),
+      link:
+        'url' in slice.primary.link
+          ? transformLink(slice.primary.link)
+          : undefined,
     },
   };
 }


### PR DESCRIPTION
## Who is this for?
Devs

## What is it doing for them?
I was curious about an warning I kept getting in my console so I investigated:
```
Unable to construct link for {"link_type":"Web"}
```

It comes from [`transformLink`](https://github.com/wellcomecollection/wellcomecollection.org/blob/main/common/services/prismic/transformers/index.ts#L56), which is used in an array of places to transform Prismic `LinkFields`. Seems like [the warning was added for a good reason](https://github.com/wellcomecollection/wellcomecollection.org/pull/8092), but I don't think it's relevant in the case of the `InfoBlock` slice, which is what was causing the warning to display. 

The `InfoBlock` slice allows for a Web link to be added, but it's not at all a requirement. Actually, I believe it's only currently used in ~2 of its 151 instances. Getting the warning every time it can't find a link felt like polluting in that case, so I added a check for that slice only, not wanting to affect other uses of the field without knowing.