### PR TITLE
Adds the shared header to the preview cloudfront distro

### DIFF
--- a/cache/secrets.tf
+++ b/cache/secrets.tf
@@ -33,6 +33,9 @@ locals {
 #   `terraform apply` in the content and identity stacks will update the listener rules (recommended to do targetted apply per env).
 # - Update the CloudFront distros for all envs by setting current_shared_secret above to the new secret
 #   `terraform apply` in the cache stack will update the CloudFront distros (recommended to do targetted apply per env)
+# - Update the preview cloudfront distro by terraforming in the preview stack
+#   `terraform apply` in the preview stack will update the preview CloudFront distro
+# - Once all apps and CloudFront distros are updated, it's safe to delete the old secret in terraform
 
 output "cloudfront_header_shared_secrets" {
   # This is a relatively insecure way to share the secret as we're storing it in tf state, 
@@ -41,5 +44,10 @@ output "cloudfront_header_shared_secrets" {
     data.aws_secretsmanager_secret_version.header_shared_secret_020124.secret_string,
     # data.aws_secretsmanager_secret_version.header_shared_secret_DDMMYY.secret_string
   ] 
+  sensitive = true
+}
+
+output "current_shared_secret" {
+  value = local.current_shared_secret
   sensitive = true
 }

--- a/preview/terraform/.terraform.lock.hcl
+++ b/preview/terraform/.terraform.lock.hcl
@@ -4,6 +4,7 @@
 provider "registry.terraform.io/hashicorp/aws" {
   version = "4.33.0"
   hashes = [
+    "h1:0S9ZXYg6K0CTOJUTQnoH94YrKuOYyJYEcc+hN5qGafA=",
     "h1:rLRYOeKvU17Tky5dleZwTPRoWtbdFTG/jOF/fTP2otY=",
     "zh:421b24e21d7fac4d65d97438d2c0a4effe71d3a1bd15820d6fde2879e49fe817",
     "zh:4378a84ca8e2a6990f47abc24367b801e884be928671b37ad7b8e7b656f73e48",

--- a/preview/terraform/cloudfront.tf
+++ b/preview/terraform/cloudfront.tf
@@ -10,6 +10,13 @@ resource "aws_cloudfront_distribution" "preview" {
       https_port             = "443"
       origin_ssl_protocols   = ["TLSv1.2"]
     }
+
+    # We need to send the backend token to the load balancer so that it can
+    # authenticate requests to the backend.
+    custom_header {
+      name  = "x-weco-cloudfront-shared-secret"
+      value = local.current_shared_secret
+    }
   }
 
   enabled         = true

--- a/preview/terraform/locals.tf
+++ b/preview/terraform/locals.tf
@@ -3,4 +3,7 @@ locals {
   prod_cf_origin_id = data.terraform_remote_state.cache.outputs.wc_org_cf_distro_id
 
   wellcome_cdn_cert_arn = "arn:aws:acm:us-east-1:130871440101:certificate/bb840c52-56bb-4bf8-86f8-59e7deaf9c98"
+
+  // Use the current shared secret from the cache state
+  current_shared_secret = data.terraform_remote_state.cache.outputs.current_shared_secret
 }


### PR DESCRIPTION
## What is this change?

Follows https://github.com/wellcomecollection/wellcomecollection.org/pull/10626 and adds the shared secret to the preview cloudfront distro. 

Missing this caused https://preview.wellcomecollection.org/ to stop working. The secret header was added manually in the console in the preview cloudfront distribution for expediency. This change brings that manual change into terraform state.

As such the terraform plan is a no-op:

<img width="899" alt="Screenshot 2024-02-05 at 16 59 12" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/953792/43852296-3854-44ee-a134-34a98aea36cd">

This change extends the instructions for rotating the secret by adding an extra step to pay attention to the cache stack state update and start sending the new secret.


