### PR TITLE
Add new toggle for consent work

### DIFF
--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -84,6 +84,14 @@ const toggles = {
         'If there are born digital items in the iiif-manifest, then links to all the files in the manifest are shown on the works page.',
       type: 'experimental',
     },
+    {
+      id: 'cookiesWork',
+      title: 'Various consent/cookies work allowances',
+      initialValue: false,
+      description:
+        'This will allow various pieces of work around consent, tracking and cookies to happen; e.g. testing in production.',
+      type: 'experimental',
+    },
   ] as const,
   tests: [] as ABTest[],
 };


### PR DESCRIPTION
## Who is this for?
Devs and Cookies epic

## What is it doing for them?
It would be good to do this work under a toggle; it'll allow us to actually test in prod that our removal of tracking really work, for example.

I added it as part of another PR (#10639) which adds a button in the footer which toggles consent for analytics.