### PR TITLE
Remove bytespider WAF rule

### DIFF
--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -302,41 +302,6 @@ resource "aws_wafv2_web_acl" "wc_org" {
     }
   }
 
-
-  // Block ByteSpider, a prolific bot causing problems with load
-  // on our services that has resulted in outages.
-  rule {
-    name     = "bytespider-useragent"
-
-    priority = 8
-
-    action {
-      block {}
-    }
-
-    statement {
-      byte_match_statement {
-        field_to_match {
-          single_header {
-            name = "user-agent"
-          }
-        }
-
-        positional_constraint = "CONTAINS"
-        search_string          = "Bytespider"
-        text_transformation {
-          priority = 0
-          type     = "NONE"
-        }
-      }
-    }
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      sampled_requests_enabled   = true
-      metric_name                = "weco-cloudfront-acl-bytespider-useragent-${var.namespace}"
-    }
-  }
-
   visibility_config {
     cloudwatch_metrics_enabled = true
     sampled_requests_enabled   = true


### PR DESCRIPTION
## Who is this for?

Folk who want simpler configuration.

## What is it doing for them?

This change removes the bytespider specific rule, as this traffic has been mitigated by https://github.com/wellcomecollection/wellcomecollection.org/pull/10631. This rule does not appear to be matching any traffic (it's probably covered by other rules).

TLDR: This check was not impactful, this bot traffic was skipping the CDN and going straight to the ALB.