### PR TITLE
Readd sort

### DIFF
--- a/content/webapp/pages/search/events.tsx
+++ b/content/webapp/pages/search/events.tsx
@@ -84,7 +84,7 @@ export const EventsSearchPage: NextPageWithLayout<Props> = ({
                       formId={SEARCH_PAGES_FORM_ID}
                       options={[
                         // Default value to be left empty as to not be reflected in URL query
-                        // is this the best text 'newest to oldest?'
+                        // TODO: 'oldest to newest' and 'newest to oldest' should be changed / option to sort should be better reflected here
                         {
                           value: '',
                           text: 'Relevance',

--- a/content/webapp/pages/search/events.tsx
+++ b/content/webapp/pages/search/events.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { getSearchLayout } from '@weco/content/components/SearchPageLayout/SearchPageLayout';
 import Pagination from '@weco/content/components/Pagination/Pagination';
 import SearchNoResults from '@weco/content/components/SearchNoResults/SearchNoResults';
+import Sort from '@weco/content/components/Sort/Sort';
 import PaginationWrapper from '@weco/common/views/components/styled/PaginationWrapper';
 import Space from '@weco/common/views/components/styled/Space';
 import { Container } from '@weco/common/views/components/styled/Container';
@@ -78,44 +79,46 @@ export const EventsSearchPage: NextPageWithLayout<Props> = ({
                 <SortPaginationWrapper>
                   {/* TODO re-add when sorting works in Content API */}
                   {/* https://github.com/wellcomecollection/wellcomecollection.org/issues/10554 */}
-                  {/* <Sort
-                    formId={SEARCH_PAGES_FORM_ID}
-                    options={[
-                      // Default value to be left empty as to not be reflected in URL query
-                      {
-                        value: '',
-                        text: 'Relevance',
-                      },
-                      {
-                        value: 'publicationDate.asc',
-                        text: 'Oldest to newest',
-                      },
-                      {
-                        value: 'publicationDate.desc',
-                        text: 'Newest to oldest',
-                      },
-                    ]}
-                    jsLessOptions={{
-                      sort: [
+                  {
+                    <Sort
+                      formId={SEARCH_PAGES_FORM_ID}
+                      options={[
+                        // Default value to be left empty as to not be reflected in URL query
                         {
                           value: '',
                           text: 'Relevance',
                         },
                         {
-                          value: 'publicationDate',
-                          text: 'Publication date',
+                          value: 'publicationDate.asc',
+                          text: 'Oldest to newest',
                         },
-                      ],
-                      sortOrder: [
-                        { value: 'asc', text: 'Ascending' },
-                        { value: 'desc', text: 'Descending' },
-                      ],
-                    }}
-                    defaultValues={{
-                      sort: query.sort,
-                      sortOrder: query.sortOrder,
-                    }}
-                  /> */}
+                        {
+                          value: 'publicationDate.desc',
+                          text: 'Newest to oldest',
+                        },
+                      ]}
+                      jsLessOptions={{
+                        sort: [
+                          {
+                            value: '',
+                            text: 'Relevance',
+                          },
+                          {
+                            value: 'publicationDate',
+                            text: 'Publication date',
+                          },
+                        ],
+                        sortOrder: [
+                          { value: 'asc', text: 'Ascending' },
+                          { value: 'desc', text: 'Descending' },
+                        ],
+                      }}
+                      defaultValues={{
+                        sort: query.sort,
+                        sortOrder: query.sortOrder,
+                      }}
+                    />
+                  }
                   <Pagination
                     formId={SEARCH_PAGES_FORM_ID}
                     totalPages={eventResponseList.totalPages}

--- a/content/webapp/pages/search/events.tsx
+++ b/content/webapp/pages/search/events.tsx
@@ -84,16 +84,17 @@ export const EventsSearchPage: NextPageWithLayout<Props> = ({
                       formId={SEARCH_PAGES_FORM_ID}
                       options={[
                         // Default value to be left empty as to not be reflected in URL query
+                        // is this the best text 'newest to oldest?'
                         {
                           value: '',
                           text: 'Relevance',
                         },
                         {
-                          value: 'publicationDate.asc',
+                          value: 'times.startDateTime.asc',
                           text: 'Oldest to newest',
                         },
                         {
-                          value: 'publicationDate.desc',
+                          value: 'times.startDateTime.desc',
                           text: 'Newest to oldest',
                         },
                       ]}
@@ -104,8 +105,8 @@ export const EventsSearchPage: NextPageWithLayout<Props> = ({
                             text: 'Relevance',
                           },
                           {
-                            value: 'publicationDate',
-                            text: 'Publication date',
+                            value: 'times.startDateTime',
+                            text: 'Event date',
                           },
                         ],
                         sortOrder: [


### PR DESCRIPTION
## Who is this for?
For #10554 
- users searching for events
- search events work

## What is it doing for them?
- re-adds the option to sort on the front-end from oldest events to newest events and vice versa. 

## To consider
- wording of 'Oldest to newest' and 'Newest to oldest' should be better reflected. Is in a TODO before we can make a decision as any change will render it inconsistently with /stories, /images, /works
- discussed this with @LFBaily 

![Screenshot 2024-02-14 at 13 19 35](https://github.com/wellcomecollection/wellcomecollection.org/assets/81175151/75dc0ed7-5dc0-46ac-b0e4-188621bdc18c)

![Screenshot 2024-02-14 at 13 19 27](https://github.com/wellcomecollection/wellcomecollection.org/assets/81175151/3b599e54-320e-4df3-a8ee-134b5cec643f)
