### PR TITLE
Tracking page path

### DIFF
--- a/common/services/conversion/track.ts
+++ b/common/services/conversion/track.ts
@@ -27,6 +27,7 @@ type EventGroup = 'conversion' | 'similarity';
 interface Conversion {
   type: ConversionType;
   source?: string;
+  sourcePath?: string;
   page: Page;
   properties: {
     [key: string]: unknown;
@@ -88,12 +89,13 @@ function trackPageview({
 }: EventProps): void {
   // Source is passed in the querystring in the app, but not the client.
   // e.g. /common/views/component/WorkLink/WorkLink.tsx
-  const { source, ...query } = Router.query;
+  const { source, sourcePath, ...query } = Router.query;
   pageName = name;
 
   const conversion: Conversion = {
     type: 'pageview',
     source: source?.toString() || 'unknown',
+    sourcePath: sourcePath?.toString() || 'unknown',
     eventGroup,
     page: {
       path: Router.asPath,

--- a/content/webapp/components/ConceptLink/index.tsx
+++ b/content/webapp/components/ConceptLink/index.tsx
@@ -6,13 +6,18 @@ import { ConceptLinkSource } from '@weco/common/data/segment-values';
 
 type ConceptLinkProps = { conceptId: string };
 
-function toLink(props: ConceptLinkProps, source: ConceptLinkSource): LinkProps {
+function toLink(
+  props: ConceptLinkProps,
+  source: ConceptLinkSource,
+  sourcePath?: string
+): LinkProps {
   return {
     href: {
       pathname: '/concepts/[conceptId]',
       query: {
         conceptId: props.conceptId,
         source,
+        sourcePath,
       },
     },
     as: {

--- a/content/webapp/components/ExpandedImage/ExpandedImage.tsx
+++ b/content/webapp/components/ExpandedImage/ExpandedImage.tsx
@@ -24,6 +24,7 @@ import LL from '@weco/common/views/components/styled/LL';
 import { toLink as itemLink } from '../ItemLink';
 import { toLink as imageLink } from '../ImageLink';
 import { trackSegmentEvent } from '@weco/common/services/conversion/track';
+import { usePathname } from 'next/navigation';
 
 type Props = {
   image: ImageType | undefined;
@@ -140,6 +141,8 @@ const ExpandedImage: FunctionComponent<Props> = ({
   const [currentImageId, setCurrentImageId] = useState<string | undefined>();
 
   const workId = image?.source.id;
+
+  const pathname = usePathname();
 
   useEffect(() => {
     // We want this fired only if there is a workId (not on initial load),
@@ -264,7 +267,8 @@ const ExpandedImage: FunctionComponent<Props> = ({
             id: image.id,
             resultPosition,
           },
-          trackingSource
+          trackingSource,
+          pathname
         )
       : detailedWork &&
         workId &&
@@ -272,6 +276,7 @@ const ExpandedImage: FunctionComponent<Props> = ({
           workId,
           props: { resultPosition, ...(canvasDeeplink || {}) },
           source: trackingSource,
+          sourcePath: pathname,
         });
 
   if (!detailedWork) {

--- a/content/webapp/components/ImageLink/index.tsx
+++ b/content/webapp/components/ImageLink/index.tsx
@@ -36,7 +36,8 @@ const toQuery: (props: ImageProps) => ParsedUrlQuery = props => {
 
 function toLink(
   partialProps: Partial<ImageProps>,
-  source: ImageLinkSource
+  source: ImageLinkSource,
+  sourcePath?: string
 ): LinkProps {
   const props: ImageProps = {
     ...emptyImageProps,
@@ -51,6 +52,7 @@ function toLink(
         workId: props.workId,
         ...query,
         source,
+        sourcePath,
       },
     },
     as: {
@@ -62,15 +64,19 @@ function toLink(
   };
 }
 
-type Props = LinkFrom<ImageProps> & { source: ImageLinkSource };
+type Props = LinkFrom<ImageProps> & {
+  source: ImageLinkSource;
+  sourcePath?: string;
+};
 
 const ImageLink: FunctionComponent<Props> = ({
   children,
   source,
+  sourcePath,
   ...props
 }: Props) => {
   return (
-    <NextLink {...toLink(props, source)} legacyBehavior>
+    <NextLink {...toLink(props, source, sourcePath)} legacyBehavior>
       {children}
     </NextLink>
   );

--- a/content/webapp/components/ItemLink/index.tsx
+++ b/content/webapp/components/ItemLink/index.tsx
@@ -43,9 +43,10 @@ type ToLinkProps = {
   workId: string;
   props: Partial<ItemProps>;
   source: ItemLinkSource;
+  sourcePath?: string;
 };
 
-function toLink({ workId, props, source }: ToLinkProps): LinkProps {
+function toLink({ workId, props, source, sourcePath }: ToLinkProps): LinkProps {
   const itemProps: ItemProps = {
     ...emptyItemProps,
     ...props,
@@ -55,7 +56,7 @@ function toLink({ workId, props, source }: ToLinkProps): LinkProps {
   return {
     href: {
       pathname: '/works/[workId]/items',
-      query: { ...urlQuery, source },
+      query: { ...urlQuery, source, sourcePath },
     },
     as: {
       pathname: `/works/${workId}/items`,

--- a/content/webapp/components/SearchPagesLink/Works.tsx
+++ b/content/webapp/components/SearchPagesLink/Works.tsx
@@ -63,7 +63,8 @@ const toQuery: (props: WorksProps) => ParsedUrlQuery = props => {
 
 function toLink(
   partialProps: Partial<WorksProps>,
-  source: WorksLinkSource
+  source: WorksLinkSource,
+  sourcePath?: string
 ): LinkProps {
   const pathname = '/search/works';
   const props: WorksProps = {
@@ -75,7 +76,7 @@ function toLink(
   return {
     href: {
       pathname,
-      query: { ...query, source },
+      query: { ...query, source, sourcePath },
     },
     as: {
       pathname,

--- a/content/webapp/components/WorkDetails/index.tsx
+++ b/content/webapp/components/WorkDetails/index.tsx
@@ -33,6 +33,7 @@ import { formatDuration } from '@weco/common/utils/format-date';
 import { CopyUrl } from '@weco/content/components/CopyButtons';
 import WorkDetailsAvailableOnline from './WorkDetails.AvailableOnline';
 import IsArchiveContext from '@weco/content/components/IsArchiveContext/IsArchiveContext';
+import { usePathname } from 'next/navigation';
 
 type Props = {
   work: Work;
@@ -52,7 +53,7 @@ const WorkDetails: FunctionComponent<Props> = ({
     downloadOptions: manifestDownloadOptions,
     audio,
   } = { ...transformedIIIFManifest };
-
+  const pathname = usePathname();
   const iiifImageLocation = getDigitalLocationOfType(work, 'iiif-image');
   const iiifPresentationLocation = getDigitalLocationOfType(
     work,
@@ -280,7 +281,8 @@ const WorkDetails: FunctionComponent<Props> = ({
                     textParts,
                     linkAttributes: conceptLink(
                       { conceptId: contributor.agent.id },
-                      'work_details/contributors'
+                      'work_details/contributors',
+                      pathname
                     ),
                   }
                 : {
@@ -289,7 +291,8 @@ const WorkDetails: FunctionComponent<Props> = ({
                       {
                         'contributors.agent.label': [contributor.agent.label],
                       },
-                      'work_details/contributors'
+                      'work_details/contributors',
+                      pathname
                     ),
                   };
             })}

--- a/content/webapp/components/WorkLink/index.tsx
+++ b/content/webapp/components/WorkLink/index.tsx
@@ -1,6 +1,7 @@
 import NextLink, { LinkProps } from 'next/link';
 import { FunctionComponent, PropsWithChildren } from 'react';
 import { WorkLinkSource } from '@weco/common/data/segment-values';
+import { usePathname } from 'next/navigation';
 
 // We remove `href` and `as` because we contruct those ourselves
 // in the component.
@@ -18,6 +19,7 @@ const WorkLink: FunctionComponent<Props> = ({
   children,
   ...linkProps
 }) => {
+  const pathname = usePathname();
   return (
     <NextLink
       href={{
@@ -25,6 +27,7 @@ const WorkLink: FunctionComponent<Props> = ({
         query: {
           workId: id,
           source,
+          sourcePath: pathname,
           resultPosition,
         },
       }}


### PR DESCRIPTION
For #10642 

Adds a sourcePath property to page view events so it is possible to see where the user came from, e.g.

![sourcePath](https://github.com/wellcomecollection/wellcomecollection.org/assets/6051896/c41dda1b-dc2d-4079-87ad-5b8988417673)

@taceybadgerbrook I know you suggested appending the path to the current source, but this felt cleaner and I think gives you what you need.