### PR TITLE
Upgrade cookies-next

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -32,7 +32,7 @@
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^29.5.0",
     "babel-plugin-styled-components": "^2.1.4",
-    "cookies-next": "^4.0.0",
+    "cookies-next": "^4.1.1",
     "elastic-apm-node": "^3.21.1",
     "focus-trap-react": "^10.1.1",
     "fontfaceobserver": "^2.0.13",

--- a/common/utils/cookie-consent.ts
+++ b/common/utils/cookie-consent.ts
@@ -15,7 +15,7 @@ const currentCookieConsent =
 // defaulting to true for them
 export const getConsentCookie = (type: string): boolean => {
   const isCookiesWorkToggleOn = Boolean(getCookie('toggle_cookiesWork'));
-  console.log('client side', { isCookiesWorkToggleOn, currentCookieConsent });
+
   return isCookiesWorkToggleOn && currentCookieConsent
     ? currentCookieConsent[type]
     : true;
@@ -29,13 +29,12 @@ export const getConsentCookieServerSide = (
   type: string
 ): boolean => {
   const isCookiesWorkToggleOn = cookies.toggle_cookiesWork;
-  console.log({ isCookiesWorkToggleOn });
 
   const parsedCookie =
     isCookiesWorkToggleOn && cookies.cookieConsent !== undefined
       ? JSON.parse(cookies.cookieConsent)
       : { necessary: true, analytics: true };
-  console.log({ parsedCookie });
+
   return !!parsedCookie[type];
 };
 

--- a/common/views/pages/_document.tsx
+++ b/common/views/pages/_document.tsx
@@ -59,10 +59,7 @@ class WecoDoc extends Document<DocumentInitialPropsWithTogglesAndGa> {
         });
 
       const initialProps = await Document.getInitialProps(ctx);
-      console.log({
-        getCookies: getCookies({ res: ctx.res, req: ctx.req }),
-        req: ctx.req,
-      });
+
       const hasAnalyticsConsent = getConsentCookieServerSide(
         getCookies({ res: ctx.res, req: ctx.req }),
         'analytics'
@@ -86,7 +83,6 @@ class WecoDoc extends Document<DocumentInitialPropsWithTogglesAndGa> {
   }
 
   render(): ReactElement<DocumentInitialProps> {
-    console.log({ hasAnalyticsConsent: this.props.hasAnalyticsConsent });
     return (
       <Html lang="en">
         <Head>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6021,10 +6021,15 @@
   resolved "https://registry.yarnpkg.com/@types/content-disposition/-/content-disposition-0.5.4.tgz#de48cf01c79c9f1560bcfd8ae43217ab028657f8"
   integrity sha512-0mPF08jn9zYI0n0Q/Pnz7C4kThdSt+6LD4amsrYDDpgBfrVWa3TcCOxKX1zkGgYniGagRv8heN2cbh+CAn+uuQ==
 
-"@types/cookie@^0.4.0", "@types/cookie@^0.4.1":
+"@types/cookie@^0.4.0":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.1.tgz#bfd02c1f2224567676c1545199f87c3a861d878d"
   integrity sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==
+
+"@types/cookie@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.6.0.tgz#eac397f28bf1d6ae0ae081363eca2f425bedf0d5"
+  integrity sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==
 
 "@types/cookiejar@*":
   version "2.1.2"
@@ -9647,19 +9652,24 @@ cookie@^0.5.0:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
   integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
 
+cookie@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.6.0.tgz#2798b04b071b0ecbff0dbb62a505a8efa4e19051"
+  integrity sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==
+
 cookiejar@^2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.4.tgz#ee669c1fea2cf42dc31585469d193fef0d65771b"
   integrity sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==
 
-cookies-next@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/cookies-next/-/cookies-next-4.0.0.tgz#36d5c0d5899cf729a2580fd065071bdfa13783ca"
-  integrity sha512-3TyzeltFCGgdOlVOVTPClSq+YV9ZCdOyA3aHRZv9f5aSgg7EyI4NSvXFOCgzT/xIxeHR4Rz8/z5Tdo9oPqaVpA==
+cookies-next@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/cookies-next/-/cookies-next-4.1.1.tgz#54498efe867bb5c1a47b5a99a7ea8563601c2413"
+  integrity sha512-20QaN0iQSz87Os0BhNg9M71eM++gylT3N5szTlhq2rK6QvXn1FYGPB4eAgU4qFTunbQKhD35zfQ95ZWgzUy3Cg==
   dependencies:
-    "@types/cookie" "^0.4.1"
+    "@types/cookie" "^0.6.0"
     "@types/node" "^16.10.2"
-    cookie "^0.4.0"
+    cookie "^0.6.0"
 
 cookies@~0.8.0:
   version "0.8.0"


### PR DESCRIPTION
## Who is this for?
Allow `getCookies()` server side.

## What is it doing for them?
Fix `getCookies()` returning `undefined` server-side. No idea why it works locally but breaks in staging but this issue does seem to explain the issue we've been having: https://github.com/andreizanik/cookies-next/issues/57
