### PR TITLE
Send consent through serverData

### DIFF
--- a/common/server-data/index.ts
+++ b/common/server-data/index.ts
@@ -16,10 +16,12 @@
 import path from 'path';
 import { promises as fs } from 'fs';
 import { GetServerSidePropsContext } from 'next';
+import { getCookies } from 'cookies-next';
 import togglesHandler, { getTogglesFromContext } from './toggles';
 import prismicHandler from './prismic';
 import { simplifyServerData } from '../services/prismic/transformers/server-data';
 import { SimplifiedServerData } from './types';
+import { getConsentCookieServerSide } from '@weco/common/utils/cookie-consent';
 
 export type Handler<DefaultData, FetchedData> = {
   defaultValue: DefaultData;
@@ -132,7 +134,14 @@ export const getServerData = async (
     toggles[enableToggle].value = true;
   }
 
-  const serverData = { toggles, prismic };
+  const hasAnalyticsConsent = getConsentCookieServerSide(
+    getCookies({ res: context.res, req: context.req }),
+    'analytics'
+  );
+
+  console.log('getCookies', getCookies({ res: context.res, req: context.req }));
+
+  const serverData = { toggles, prismic, hasAnalyticsConsent };
 
   return simplifyServerData(serverData);
 };

--- a/common/server-data/types.ts
+++ b/common/server-data/types.ts
@@ -13,16 +13,19 @@ import {
 export type ServerData = {
   toggles: Toggles;
   prismic: PrismicData;
+  hasAnalyticsConsent: boolean;
 };
 
 export type SimplifiedServerData = {
   toggles: Toggles;
   prismic: SimplifiedPrismicData;
+  hasAnalyticsConsent: boolean;
 };
 
 export const defaultServerData: SimplifiedServerData = {
   toggles: {},
   prismic: prismicDefaultValue,
+  hasAnalyticsConsent: false,
 };
 
 /**

--- a/common/views/pages/_document.tsx
+++ b/common/views/pages/_document.tsx
@@ -16,8 +16,6 @@ import {
   GoogleTagManagerNoScript,
   GaDimensions,
 } from '../../services/app/google-analytics';
-import { getCookies } from 'cookies-next';
-import { getConsentCookieServerSide } from '@weco/common/utils/cookie-consent';
 
 const {
   ANALYTICS_WRITE_KEY = '78Czn5jNSaMSVrBq2J9K4yJjWxh6fyRI',
@@ -60,16 +58,11 @@ class WecoDoc extends Document<DocumentInitialPropsWithTogglesAndGa> {
 
       const initialProps = await Document.getInitialProps(ctx);
 
-      const hasAnalyticsConsent = getConsentCookieServerSide(
-        getCookies({ res: ctx.res, req: ctx.req }),
-        'analytics'
-      );
-
       return {
         ...initialProps,
         toggles: pageProps.serverData?.toggles,
         gaDimensions: pageProps.gaDimensions,
-        hasAnalyticsConsent,
+        hasAnalyticsConsent: pageProps.serverData?.hasAnalyticsConsent,
         styles: (
           <>
             {initialProps.styles}


### PR DESCRIPTION
## Who is this for?
Server side cookie fetching

## What is it doing for them?
Since `_document` has access to toggles through `pageProps` (as each page sends it through `serverData`), and `toggles` are cookies, I thought I'd do the same for our _consent_ cookies.

To be honest I'm not super sure why the current method doesn't work as, again, it works locally and it's once in staging that it fails, so we'll have to test it there. Because toggles work fine in staging, I'm hoping this works there too.  Maybe it's because it prefers `getServerData` as a server action to `getInitialProps` which also runs client side (although `_document` only runs server side)? 

I'm leaving a `console.log` in; if it doesn't work at least I can see if it's at the `getCookies` stage and if it might just be the library having issues...