### PR TITLE
Tweak get consent state function to work both CS and SS

### DIFF
--- a/common/server-data/index.ts
+++ b/common/server-data/index.ts
@@ -16,12 +16,11 @@
 import path from 'path';
 import { promises as fs } from 'fs';
 import { GetServerSidePropsContext } from 'next';
-import { getCookies } from 'cookies-next';
 import togglesHandler, { getTogglesFromContext } from './toggles';
 import prismicHandler from './prismic';
 import { simplifyServerData } from '../services/prismic/transformers/server-data';
 import { SimplifiedServerData } from './types';
-import { getConsentCookieServerSide } from '@weco/common/utils/cookie-consent';
+import { getAnalyticsConsentState } from '@weco/common/utils/cookie-consent';
 
 export type Handler<DefaultData, FetchedData> = {
   defaultValue: DefaultData;
@@ -134,10 +133,7 @@ export const getServerData = async (
     toggles[enableToggle].value = true;
   }
 
-  const hasAnalyticsConsent = getConsentCookieServerSide(
-    getCookies({ res: context.res, req: context.req }),
-    'analytics'
-  );
+  const hasAnalyticsConsent = getAnalyticsConsentState(context);
 
   const serverData = { toggles, prismic, hasAnalyticsConsent };
 

--- a/common/services/conversion/track.ts
+++ b/common/services/conversion/track.ts
@@ -4,7 +4,7 @@ import { ParsedUrlQuery } from 'querystring';
 import { v4 as uuidv4 } from 'uuid';
 import cookies from '@weco/common/data/cookies';
 import { PageviewName } from '@weco/common/data/segment-values';
-import { getConsentCookie } from '@weco/common/utils/cookie-consent';
+import { getAnalyticsConsentState } from '@weco/common/utils/cookie-consent';
 
 declare global {
   interface Window {
@@ -128,7 +128,7 @@ function trackSegmentEvent({
 }
 
 function track(conversion: Conversion) {
-  const hasAnalyticsConsent = getConsentCookie('analytics');
+  const hasAnalyticsConsent = getAnalyticsConsentState();
   if (!hasAnalyticsConsent) return;
 
   const debug = Boolean(getCookie(cookies.analyticsDebug));

--- a/common/views/components/Footer/Footer.Nav.tsx
+++ b/common/views/components/Footer/Footer.Nav.tsx
@@ -6,7 +6,7 @@ import { NavLink, links } from '@weco/common/views/components/Header/Header';
 import { prismicPageIds } from '@weco/common/data/hardcoded-ids';
 import Buttons from '../Buttons';
 import {
-  getConsentCookie,
+  getAnalyticsConsentState,
   toggleCookieConsent,
 } from '@weco/common/utils/cookie-consent';
 import { useToggles } from '@weco/common/server-data/Context';
@@ -98,7 +98,7 @@ const FooterNav = ({
   const [consentCookieValue, setConsentCookieValue] = useState<boolean>();
 
   useEffect(() => {
-    setConsentCookieValue(getConsentCookie('analytics'));
+    setConsentCookieValue(getAnalyticsConsentState());
   }, []);
 
   const itemsList =

--- a/content/webapp/hooks/useHotjar.ts
+++ b/content/webapp/hooks/useHotjar.ts
@@ -5,7 +5,7 @@
 // We should probably move out the pieces that are troublesome, and check the rest
 
 import { useEffect, useState } from 'react';
-import { getConsentCookie } from '@weco/common/utils/cookie-consent';
+import { getAnalyticsConsentState } from '@weco/common/utils/cookie-consent';
 
 declare global {
   interface Window {
@@ -45,8 +45,8 @@ const heatMapTrigger = (triggerName: string): void => {
 };
 
 const useHotjar = (shouldRender: boolean, triggerName?: string) => {
-  const hasAnalyticsConsent = getConsentCookie('analytics');
   const [rendered, setRendered] = useState(false);
+  const hasAnalyticsConsent = getAnalyticsConsentState();
 
   useEffect(() => {
     if (!hasAnalyticsConsent) return;


### PR DESCRIPTION
## Who is this for?
Simplified functions in cookie work

## What is it doing for them?
Move to using the same function to get the consent state on both client and server. 
Named it `getAnalyticsConsentState` as we're thinking it'll be the only one we need for a while.