### PR TITLE
Skip flaky tests temporarily

### DIFF
--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -175,7 +175,8 @@ test('(11) | The multi-volume label should be appropriate', async ({
   expect(await page.getByText('Copy 3').count());
 });
 
-test('(12) | The structured parts should be browseable', async ({
+// TODO remove skip as part of https://github.com/wellcomecollection/wellcomecollection.org/issues/10644
+test.skip('(12) | The structured parts should be browseable', async ({
   page,
   context,
 }) => {
@@ -192,7 +193,11 @@ test('(12) | The structured parts should be browseable', async ({
   }
 });
 
-test('(13) | The main viewer can be scrolled', async ({ page, context }) => {
+// TODO remove skip as part of https://github.com/wellcomecollection/wellcomecollection.org/issues/10644
+test.skip('(13) | The main viewer can be scrolled', async ({
+  page,
+  context,
+}) => {
   await itemWithSearchAndStructures(context, page);
   const mainScrollArea = page.getByTestId('main-viewer').locator('> div');
   await expect(mainScrollArea).toBeVisible();
@@ -218,7 +223,8 @@ test('(14) | The item should be searchable', async ({ page, context }) => {
   await page.getByRole('button', { name: 'search within' }).click();
 });
 
-test('(15) | The location of the search results should be displayed', async ({
+// TODO remove skip as part of https://github.com/wellcomecollection/wellcomecollection.org/issues/10644
+test.skip('(15) | The location of the search results should be displayed', async ({
   page,
   context,
 }) => {


### PR DESCRIPTION
## Who is this for?
Flaky e2es

## What is it doing for them?
Flaky tests take away from the usefulness of e2es; these tend to fail and require a retry and therefore fails aren't taken very seriously and it's extra work to retry them all the time. We're aiming to fix these in #10644 but in the meantime, [as discussed with Gareth](https://wellcome.slack.com/archives/CQ720BG02/p1708956594196199), we want to skip these and have only meaningful fails (although ideally no fail).