### PR TITLE
Remove reload on consent change and leave a TODO for the future

### DIFF
--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -83,7 +83,8 @@ const WecoApp: FunctionComponent<WecoAppProps> = ({
 
   const serverData = isServerDataSet ? pageProps.serverData : defaultServerData;
 
-  const reloadConsentStatus = () => window.location.reload();
+  const onAnalyticsConsentChange = () =>
+    console.log('Decide on what to do here and how to handle');
 
   useMaintainPageHeight();
   useEffect(() => {
@@ -91,9 +92,12 @@ const WecoApp: FunctionComponent<WecoAppProps> = ({
   }, []);
 
   useEffect(() => {
-    window.addEventListener('analyticsConsentChange', reloadConsentStatus);
+    window.addEventListener('analyticsConsentChange', onAnalyticsConsentChange);
     return () => {
-      window.removeEventListener('analyticsConsentChange', reloadConsentStatus);
+      window.removeEventListener(
+        'analyticsConsentChange',
+        onAnalyticsConsentChange
+      );
     };
   }, []);
 


### PR DESCRIPTION
## Who is this for?
People wanting to play behind the cookie work toggle

## What is it doing for them?
The reload causes an infinite loop in staging, and as it's not something we really want to happen and it still needs discussing, am removing it.