### PR TITLE
Add CookieControl to list of allowed cookies

### DIFF
--- a/cache/modules/cloudfront_policies/locals.tf
+++ b/cache/modules/cloudfront_policies/locals.tf
@@ -1,6 +1,6 @@
 locals {
   toggles_cookies        = ["toggles", "toggle_*"]
-  userpreference_cookies = ["WC_*"]
+  userpreference_cookies = ["WC_*", "CookieControl"]
   ga_cookies             = ["_ga"]
 
   one_minute = 60


### PR DESCRIPTION
## Who is this for?
Cookie work, this is Civic UK's consent cookie

## What is it doing for them?
That list is the cookies we allow through in our cache policy and we needed his one for good functioning of cookie consent.

Already applied