### PR TITLE
Remove noscript GTM script

### DIFF
--- a/common/services/app/google-analytics.tsx
+++ b/common/services/app/google-analytics.tsx
@@ -71,14 +71,3 @@ export const GoogleTagManager: FunctionComponent = () => (
     }}
   />
 );
-
-export const GoogleTagManagerNoScript: FunctionComponent = () => (
-  <noscript>
-    <iframe
-      src="https://www.googletagmanager.com/ns.html?id=GTM-53DFWQD"
-      height="0"
-      width="0"
-      style={{ display: 'none', visibility: 'hidden' }}
-    ></iframe>
-  </noscript>
-);

--- a/common/views/pages/_document.tsx
+++ b/common/views/pages/_document.tsx
@@ -13,7 +13,6 @@ import { Toggles } from '@weco/toggles';
 import {
   Ga4DataLayer,
   GoogleTagManager,
-  GoogleTagManagerNoScript,
   GaDimensions,
 } from '@weco/common/services/app/google-analytics';
 import CivicUK from '@weco/common/services/app/civic-uk/scripts';
@@ -98,7 +97,6 @@ class WecoDoc extends Document<DocumentInitialPropsWithTogglesAndGa> {
           )}
         </Head>
         <body>
-          {this.props.hasAnalyticsConsent && <GoogleTagManagerNoScript />}
           <div id="top">
             <Main />
           </div>


### PR DESCRIPTION
## Who is this for?
Cookie work and consent-non-given users

## What is it doing for them?
As discussed in standup, I'm removing this as without JS we can't know if we have consent or not from our users and therefore shouldn't be adding this script in?

After reading [this article](https://www.analyticsmania.com/post/google-tag-manager-noscript/), it also seems it's a pretty limited version of the regular script. They recommend using it if
> - You plan to track visitors who have disabled JavaScript on their browsers.
> - Or you wish to [verify the ownership of the website in the Google Search Console](https://support.google.com/webmasters/answer/35179?hl=en) by choosing the “Verify with Google Tag Manager” option.
> - Or you don’t plan to do the aforementioned activities right now, but maybe it will become a priority in the future.

I don't think it applied to us, therefore am putting this forward.