### PR TITLE
Associate prod WAF with preview Cloudfront distro

### DIFF
--- a/cache/modules/wc_org_cloudfront/outputs.tf
+++ b/cache/modules/wc_org_cloudfront/outputs.tf
@@ -5,3 +5,7 @@ output "domain_name" {
 output "distribution_id" {
   value = aws_cloudfront_distribution.wc_org.id
 }
+
+output "waf_web_acl_arn" {
+  value = aws_wafv2_web_acl.wc_org.arn
+}

--- a/cache/outputs.tf
+++ b/cache/outputs.tf
@@ -5,3 +5,7 @@ output "wc_org_cf_distro_id" {
 output "stage_wc_org_cf_distro_id" {
   value = module.stage_wc_org_cloudfront_distribution.distribution_id
 }
+
+output "prod_waf_web_acl_arn" {
+  value = module.prod_wc_org_cloudfront_distribution.waf_web_acl_arn
+}

--- a/preview/terraform/cloudfront.tf
+++ b/preview/terraform/cloudfront.tf
@@ -1,5 +1,10 @@
-# This is a cache that essentially does nothing, but gives us a shield against our origin ALB
+# This is a cache that gives us a shield against our origin ALB:
+# - Allows us to use a custom header to authenticate requests to the backend.
+# - Uses the prod WAF web ACL to protect the distribution.
+
 resource "aws_cloudfront_distribution" "preview" {
+  web_acl_id = local.prod_waf_web_acl_arn
+
   origin {
     domain_name = local.prod_alb_dns
     origin_id   = local.prod_cf_origin_id

--- a/preview/terraform/locals.tf
+++ b/preview/terraform/locals.tf
@@ -1,6 +1,7 @@
 locals {
-  prod_alb_dns      = data.terraform_remote_state.experience.outputs.prod["alb_dns_name"]
-  prod_cf_origin_id = data.terraform_remote_state.cache.outputs.wc_org_cf_distro_id
+  prod_alb_dns         = data.terraform_remote_state.experience.outputs.prod["alb_dns_name"]
+  prod_cf_origin_id    = data.terraform_remote_state.cache.outputs.wc_org_cf_distro_id
+  prod_waf_web_acl_arn = data.terraform_remote_state.cache.outputs.prod_waf_web_acl_arn
 
   wellcome_cdn_cert_arn = "arn:aws:acm:us-east-1:130871440101:certificate/bb840c52-56bb-4bf8-86f8-59e7deaf9c98"
 


### PR DESCRIPTION
## Who is this for?

This change is for people who want less bot traffic.

See: https://github.com/wellcomecollection/platform-infrastructure/issues/423

We can see the "bytespider" traffic drop off as we apply this change.

<img width="1728" alt="Screenshot 2024-03-05 at 16 58 09" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/953792/ad3e343b-5703-44bf-8bd4-ac93d991b6e0">

## What is it doing for them?

Here we extend the prod WAF for wellcomecollection.org to cover preview.wellcomecollection.org that is fronting the same ECS service.

> [!NOTE]
> This change is applied.
