### PR TITLE
Use safer polyfill

### DIFF
--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -265,7 +265,7 @@ const PageLayoutComponent: FunctionComponent<Props> = ({
       */}
 
       <Script
-        src={`https://cdn.polyfill.io/v3/polyfill.js?version=${polyfillVersion}&features=${polyfillFeatures.join(
+        src={`https://polyfill-fastly.io/v3/polyfill.js?version=${polyfillVersion}&features=${polyfillFeatures.join(
           ','
         )}`}
       />


### PR DESCRIPTION
polyfill.io has recently changed ownership. [Fastly have a branch for trustworthy and reliable access](https://community.fastly.com/t/new-options-for-polyfill-io-users/2540) so we can use that.

We should also work out which, if any, of the things we're currently polyfilling we still require based on our current browser support list (opened #10697).