### PR TITLE
Show volumes of nested collections

### DIFF
--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -563,11 +563,25 @@ export function getFileSize(canvas: TransformedCanvas): string | undefined {
   return fileSizeMeta ? getLabelString(fileSizeMeta.value) : undefined;
 }
 
+type CollectionItemsWithItems = CollectionItems & {
+  items: CollectionItemsWithItems[];
+};
 export function getCollectionManifests(
-  manifest: Manifest | Collection
+  manifest:
+    | Manifest
+    | Collection
+    | (CollectionItems & { items: CollectionItemsWithItems[] })
 ): CollectionItems[] {
-  if (isCollection(manifest)) {
-    return manifest.items?.filter(c => c.type === 'Manifest');
+  if (manifest.type === 'Collection') {
+    return manifest.items
+      .map(item => {
+        if (item.type === 'Manifest') {
+          return item;
+        } else {
+          return getCollectionManifests(item);
+        }
+      })
+      .flat(Infinity);
   } else {
     return [];
   }


### PR DESCRIPTION
As [reported in Slack](https://wellcome.slack.com/archives/C8X9YKM5X/p1709720458072779) 

"In some cases, we have items that are both copies and volumes" and these were displaying a blank screen on the items page.

[We ran into this before](https://github.com/wellcomecollection/wellcomecollection.org/issues/9901) and [fixed it](https://github.com/wellcomecollection/wellcomecollection.org/pull/9934), but looks like I broke it again with the recent refactoring.

This fixes it again