### PR TITLE
Filters tidy, test fix and commenting out interpretation filter

### DIFF
--- a/content/webapp/components/ModalMoreFilters/index.tsx
+++ b/content/webapp/components/ModalMoreFilters/index.tsx
@@ -9,7 +9,7 @@ import {
   Filter,
   CheckboxFilter as CheckboxFilterType,
   filterLabel,
-} from '@weco/content/services/wellcome/catalogue/filters';
+} from '@weco/content/services/wellcome/common/filters';
 import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
 import CheckboxRadio from '@weco/common/views/components/CheckboxRadio/CheckboxRadio';
 import PlainList from '@weco/common/views/components/styled/PlainList';

--- a/content/webapp/components/SearchFilters/ResetActiveFilters.tsx
+++ b/content/webapp/components/SearchFilters/ResetActiveFilters.tsx
@@ -14,7 +14,7 @@ import {
   ColorFilter,
   DateRangeFilter,
   Filter,
-} from '@weco/content/services/wellcome/catalogue/filters';
+} from '@weco/content/services/wellcome/common/filters';
 import { getColorDisplayName } from '@weco/content/components/PaletteColorPicker';
 
 type ResetActiveFilters = {

--- a/content/webapp/components/SearchFilters/SearchFilters.DateRangeFilter.tsx
+++ b/content/webapp/components/SearchFilters/SearchFilters.DateRangeFilter.tsx
@@ -1,6 +1,6 @@
 import { useControlledState } from '@weco/content/utils/useControlledState';
 import NumberInput from '@weco/content/components/NumberInput/NumberInput';
-import { DateRangeFilter as DateRangeFilterType } from '@weco/content/services/wellcome/catalogue/filters';
+import { DateRangeFilter as DateRangeFilterType } from '@weco/content/services/wellcome/common/filters';
 import Space from '@weco/common/views/components/styled/Space';
 
 export const dateRegex = /^\d{4}$|^$/;

--- a/content/webapp/components/SearchFilters/SearchFilters.Desktop.CheckboxFilter.tsx
+++ b/content/webapp/components/SearchFilters/SearchFilters.Desktop.CheckboxFilter.tsx
@@ -1,8 +1,7 @@
 import {
   CheckboxFilter as CheckboxFilterType,
   filterLabel,
-} from '@weco/content/services/wellcome/catalogue/filters';
-
+} from '@weco/content/services/wellcome/common/filters';
 import PlainList from '@weco/common/views/components/styled/PlainList';
 import CheckboxRadio from '@weco/common/views/components/CheckboxRadio/CheckboxRadio';
 import Button from '@weco/common/views/components/Buttons';

--- a/content/webapp/components/SearchFilters/SearchFilters.Desktop.DynamicFilters.tsx
+++ b/content/webapp/components/SearchFilters/SearchFilters.Desktop.DynamicFilters.tsx
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router';
 
 import Button, { ButtonTypes } from '@weco/common/views/components/Buttons';
 import { themeValues } from '@weco/common/views/themes/config';
-import { Filter } from '@weco/content/services/wellcome/catalogue/filters';
+import { Filter } from '@weco/content/services/wellcome/common/filters';
 import Space from '@weco/common/views/components/styled/Space';
 import { filter } from '@weco/common/icons';
 

--- a/content/webapp/components/SearchFilters/SearchFilters.Mobile.tsx
+++ b/content/webapp/components/SearchFilters/SearchFilters.Mobile.tsx
@@ -17,7 +17,7 @@ import { SearchFiltersSharedProps } from '.';
 import {
   CheckboxFilter as CheckboxFilterType,
   filterLabel,
-} from '@weco/content/services/wellcome/catalogue/filters';
+} from '@weco/content/services/wellcome/common/filters';
 import Button, {
   StyledButton,
   ButtonTypes,

--- a/content/webapp/components/SearchFilters/index.tsx
+++ b/content/webapp/components/SearchFilters/index.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent, ReactElement, useContext, useState } from 'react';
 import { ParsedUrlQuery } from 'querystring';
 
 import { LinkProps } from '@weco/common/model/link-props';
-import { Filter } from '@weco/content/services/wellcome/catalogue/filters';
+import { Filter } from '@weco/content/services/wellcome/common/filters';
 import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
 import useIsomorphicLayoutEffect from '@weco/common/hooks/useIsomorphicLayoutEffect';
 

--- a/content/webapp/pages/search/events.tsx
+++ b/content/webapp/pages/search/events.tsx
@@ -36,7 +36,7 @@ import { getEvents } from '@weco/content/services/wellcome/content/events';
 import EventsSearchResults from '@weco/content/components/EventsSearchResults';
 import SearchFilters from '@weco/content/components/SearchFilters';
 import { hasFilters } from '@weco/content/utils/search';
-import { eventsFilters } from '@weco/content/services/wellcome/catalogue/filters';
+import { eventsFilters } from '@weco/content/services/wellcome/common/filters';
 
 type Props = {
   eventResponseList: ContentResultsList<EventDocument>;

--- a/content/webapp/pages/search/images.tsx
+++ b/content/webapp/pages/search/images.tsx
@@ -26,7 +26,7 @@ import {
 } from '@weco/content/components/SearchPagesLink/Images';
 import { getServerData } from '@weco/common/server-data';
 import { getSearchLayout } from '@weco/content/components/SearchPageLayout/SearchPageLayout';
-import { imagesFilters } from '@weco/content/services/wellcome/catalogue/filters';
+import { imagesFilters } from '@weco/content/services/wellcome/common/filters';
 import { emptyResultList } from '@weco/content/services/wellcome';
 import { linkResolver, SEARCH_PAGES_FORM_ID } from '@weco/common/utils/search';
 import { getActiveFiltersLabel, hasFilters } from '@weco/content/utils/search';

--- a/content/webapp/pages/search/stories.tsx
+++ b/content/webapp/pages/search/stories.tsx
@@ -36,7 +36,7 @@ import {
   fromQuery,
   StoriesProps,
 } from '@weco/content/components/SearchPagesLink/Stories';
-import { storiesFilters } from '@weco/content/services/wellcome/catalogue/filters';
+import { storiesFilters } from '@weco/content/services/wellcome/common/filters';
 
 type Props = {
   storyResponseList: ContentResultsList<Article>;

--- a/content/webapp/pages/search/works.tsx
+++ b/content/webapp/pages/search/works.tsx
@@ -23,7 +23,7 @@ import { getServerData } from '@weco/common/server-data';
 import { NextPageWithLayout } from '@weco/common/views/pages/_app';
 import { Pageview } from '@weco/common/services/conversion/track';
 import { getWorks } from '@weco/content/services/wellcome/catalogue/works';
-import { worksFilters } from '@weco/content/services/wellcome/catalogue/filters';
+import { worksFilters } from '@weco/content/services/wellcome/common/filters';
 import {
   emptyResultList,
   WellcomeResultList,

--- a/content/webapp/services/wellcome/common/filters.test.ts
+++ b/content/webapp/services/wellcome/common/filters.test.ts
@@ -1,5 +1,5 @@
-import worksAggregations from './fixtures/works-aggregations';
-import imagesAggregations from './fixtures/images-aggregations';
+import worksAggregations from '../catalogue/fixtures/works-aggregations';
+import imagesAggregations from '../catalogue/fixtures/images-aggregations';
 import { CheckboxFilter, imagesFilters, worksFilters } from './filters';
 import { fromQuery as fromWorksQuery } from '@weco/content/components/SearchPagesLink/Works';
 import {
@@ -52,7 +52,7 @@ describe('filter options', () => {
             type: 'Subject',
           },
           count: 666,
-          type: 'AggregationBucket',
+          type: 'AggregationBucket' as const,
         },
         {
           data: {
@@ -60,7 +60,7 @@ describe('filter options', () => {
             type: 'Subject',
           },
           count: 999,
-          type: 'AggregationBucket',
+          type: 'AggregationBucket' as const,
         },
         {
           data: {
@@ -68,7 +68,7 @@ describe('filter options', () => {
             type: 'Subject',
           },
           count: 100,
-          type: 'AggregationBucket',
+          type: 'AggregationBucket' as const,
         },
         {
           data: {
@@ -76,7 +76,7 @@ describe('filter options', () => {
             type: 'Subject',
           },
           count: 100,
-          type: 'AggregationBucket',
+          type: 'AggregationBucket' as const,
         },
       ]),
       props: fromWorksQuery({}),
@@ -103,7 +103,7 @@ describe('filter options', () => {
             type: 'Subject',
           },
           count: 3,
-          type: 'AggregationBucket',
+          type: 'AggregationBucket' as const,
         },
         {
           data: {
@@ -111,7 +111,7 @@ describe('filter options', () => {
             type: 'Subject',
           },
           count: 0,
-          type: 'AggregationBucket',
+          type: 'AggregationBucket' as const,
         },
         {
           data: {
@@ -119,7 +119,7 @@ describe('filter options', () => {
             type: 'Subject',
           },
           count: 1,
-          type: 'AggregationBucket',
+          type: 'AggregationBucket' as const,
         },
         {
           data: {
@@ -127,7 +127,7 @@ describe('filter options', () => {
             type: 'Subject',
           },
           count: 2,
-          type: 'AggregationBucket',
+          type: 'AggregationBucket' as const,
         },
       ]),
       props: fromWorksQuery({ 'subjects.label': '"Zouaves"' }),
@@ -179,7 +179,7 @@ describe('filter options', () => {
               type: 'Subject',
             },
             count: 100,
-            type: 'AggregationBucket',
+            type: 'AggregationBucket' as const,
           },
         ]),
         props: fromWorksQuery({
@@ -203,7 +203,7 @@ describe('filter options', () => {
               type: 'Subject',
             },
             count: 0,
-            type: 'AggregationBucket',
+            type: 'AggregationBucket' as const,
           },
           {
             data: {
@@ -211,7 +211,7 @@ describe('filter options', () => {
               type: 'Subject',
             },
             count: 0,
-            type: 'AggregationBucket',
+            type: 'AggregationBucket' as const,
           },
           {
             data: {
@@ -219,7 +219,7 @@ describe('filter options', () => {
               type: 'Subject',
             },
             count: 999,
-            type: 'AggregationBucket',
+            type: 'AggregationBucket' as const,
           },
         ]),
         props: fromWorksQuery({
@@ -253,7 +253,7 @@ describe('filter options', () => {
           type: 'Subject',
         },
         count: 100,
-        type: 'AggregationBucket',
+        type: 'AggregationBucket' as const,
       },
       {
         data: {
@@ -261,7 +261,7 @@ describe('filter options', () => {
           type: 'Subject',
         },
         count: 65705,
-        type: 'AggregationBucket',
+        type: 'AggregationBucket' as const,
       },
       {
         data: {
@@ -269,7 +269,7 @@ describe('filter options', () => {
           type: 'Subject',
         },
         count: 5,
-        type: 'AggregationBucket',
+        type: 'AggregationBucket' as const,
       },
     ]);
 
@@ -294,6 +294,7 @@ describe('filter options', () => {
   describe('matching query options to aggregation options', () => {
     const workTypeAggregations = {
       aggregations: {
+        type: 'Aggregations' as const,
         workType: {
           buckets: [
             {
@@ -303,7 +304,7 @@ describe('filter options', () => {
                 type: 'Format',
               },
               count: 113802,
-              type: 'AggregationBucket',
+              type: 'AggregationBucket' as const,
             },
             {
               data: {
@@ -312,7 +313,7 @@ describe('filter options', () => {
                 type: 'Format',
               },
               count: 13402,
-              type: 'AggregationBucket',
+              type: 'AggregationBucket' as const,
             },
             {
               data: {
@@ -321,11 +322,12 @@ describe('filter options', () => {
                 type: 'Format',
               },
               count: 3755,
-              type: 'AggregationBucket',
+              type: 'AggregationBucket' as const,
             },
           ],
+          type: 'Aggregation' as const,
         },
-        availabilities: { buckets: [] },
+        availabilities: { buckets: [], type: 'Aggregation' as const },
         languages: {
           buckets: [
             {
@@ -335,7 +337,7 @@ describe('filter options', () => {
                 type: 'Language',
               },
               count: 33,
-              type: 'AggregationBucket',
+              type: 'AggregationBucket' as const,
             },
             {
               data: {
@@ -344,9 +346,10 @@ describe('filter options', () => {
                 type: 'Language',
               },
               count: 21,
-              type: 'AggregationBucket',
+              type: 'AggregationBucket' as const,
             },
           ],
+          type: 'Aggregation' as const,
         },
       },
     };
@@ -403,9 +406,10 @@ describe('filter options', () => {
   function worksAggregationsWith(aggregationName, bucketList) {
     return {
       aggregations: {
-        workType: { buckets: [] },
-        availabilities: { buckets: [] },
+        workType: { buckets: [], type: 'Aggregation' as const },
+        availabilities: { buckets: [], type: 'Aggregation' as const },
         [aggregationName]: { buckets: bucketList },
+        type: 'Aggregations' as const,
       },
     };
   }

--- a/content/webapp/services/wellcome/common/filters.ts
+++ b/content/webapp/services/wellcome/common/filters.ts
@@ -579,7 +579,6 @@ const storiesContributorFilter = ({
   }),
 });
 
-// TODO move content filters out of catalogue?
 const eventsFormatFilter = ({
   events,
   props,
@@ -618,28 +617,29 @@ const eventsAudienceFilter = ({
   }),
 });
 
-const eventsInterpretationFilter = ({
-  events,
-  props,
-}: EventsFilterProps): CheckboxFilter<keyof EventsProps> => {
-  return {
-    type: 'checkbox',
-    id: 'interpretation',
-    label: 'Accessibility',
-    options: filterOptionsWithNonAggregates({
-      options: events?.aggregations?.interpretation?.buckets.map(bucket => {
-        return {
-          id: bucket.data.id,
-          value: bucket.data.id,
-          count: bucket.count,
-          label: bucket.data.label,
-          selected: props.interpretation.includes(bucket.data.id),
-        };
-      }),
-      selectedValues: props.interpretation,
-    }),
-  };
-};
+// TODO re-add when https://github.com/wellcomecollection/content-api/issues/106 is done
+// const eventsInterpretationFilter = ({
+//   events,
+//   props,
+// }: EventsFilterProps): CheckboxFilter<keyof EventsProps> => {
+//   return {
+//     type: 'checkbox',
+//     id: 'interpretation',
+//     label: 'Accessibility',
+//     options: filterOptionsWithNonAggregates({
+//       options: events?.aggregations?.interpretation?.buckets.map(bucket => {
+//         return {
+//           id: bucket.data.id,
+//           value: bucket.data.id,
+//           count: bucket.count,
+//           label: bucket.data.label,
+//           selected: props.interpretation.includes(bucket.data.id),
+//         };
+//       }),
+//       selectedValues: props.interpretation,
+//     }),
+//   };
+// };
 
 const imagesFilters: (props: ImagesFilterProps) => Filter[] = props =>
   [
@@ -673,8 +673,11 @@ const storiesFilters: (
 const eventsFilters: (
   props: EventsFilterProps
 ) => Filter<keyof EventsProps>[] = props =>
-  [eventsFormatFilter, eventsAudienceFilter, eventsInterpretationFilter].map(
-    f => f(props)
-  );
+  [
+    eventsFormatFilter,
+    eventsAudienceFilter,
+    // TODO re-add when https://github.com/wellcomecollection/content-api/issues/106 is done
+    // eventsInterpretationFilter
+  ].map(f => f(props));
 
 export { worksFilters, imagesFilters, storiesFilters, eventsFilters };

--- a/content/webapp/utils/search.ts
+++ b/content/webapp/utils/search.ts
@@ -1,6 +1,6 @@
 import { isNotUndefined } from '@weco/common/utils/type-guards';
 import { getColorDisplayName } from 'components/PaletteColorPicker';
-import { Filter } from '@weco/content/services/wellcome/catalogue/filters';
+import { Filter } from '@weco/content/services/wellcome/common/filters';
 
 // FILTERS
 /**


### PR DESCRIPTION
## Who is this for?
Maintenance and events work #10689 

## What is it doing for them?
- Moves the filter file (and its test file) to a new `common` folder. It was sitting within the `catalogue` service directory, which didn't feel right for our newer `content` filters, but I thought splitting them wasn't the way to go as we may end up reusing them? Open to chatting though.
- Comments out the interpretation filter for now as per #10689, left a TODO to clarify why and when it could be uncommented.
- The `filters.test.ts` file had had TS errors on it for a while so I fixed them; it was mostly just adding a `type` everywhere.