### PR TITLE
Chromatic plaster; Add more diffThresholds and delays

### DIFF
--- a/cardigan/stories/components/Cards/Cards.stories.tsx
+++ b/cardigan/stories/components/Cards/Cards.stories.tsx
@@ -22,7 +22,7 @@ const primaryLabelList = [{ text: 'Study day' }, { text: 'Schools' }];
 const secondaryLabelList = [{ text: 'Speech-to-text' }];
 const imageProps = squareImage();
 const sharedParameters = {
-  chromatic: { diffThreshold: 0.2 },
+  chromatic: { diffThreshold: 0.2, delay: 1000 },
 };
 
 const CompactCardTemplate = args => <CompactCard {...args} />;

--- a/cardigan/stories/components/PageHeader/PageHeader.stories.tsx
+++ b/cardigan/stories/components/PageHeader/PageHeader.stories.tsx
@@ -268,6 +268,9 @@ shortFilm.args = {
     />
   ),
 };
+shortFilm.parameters = {
+  chromatic: { diffThreshold: 0.2 },
+};
 
 export const event = Template.bind({});
 event.args = {
@@ -329,4 +332,7 @@ book.args = {
       </Layout>
     </Space>
   ),
+};
+book.parameters = {
+  chromatic: { diffThreshold: 0.2 },
 };


### PR DESCRIPTION
## Who is this for?
Our UI tests that keep failing (see #10690)
This PR is mergeable if we'd like to test it out, but mostly serves as a starting point for yet another Chromatic config chat.

## What is it doing for them?
This is not the best fix, it's defo a plaster, but I identified the main failing stories and added `diffThreshold` ([docs](https://www.chromatic.com/docs/threshold/)) which we've done in the past to the main offenders. I've added a [delay](https://www.chromatic.com/docs/delay) to Cards because I wonder if the image needs time to load and has a slight difference because of it? So that one is more of a test and if it works maybe we want it on everything that has an image?

[This tool](https://6262c53f521620003ac2ff49-ukmsdlppcb.chromatic.com/?path=/story/stories-diff-threshold-check--test-yours-out) helps finding what threshold you'd like based on their snapshots, but for the image differences, I have to go up to `0.5` which is way too high and we don't want it there. So I'm wondering if we want to test a different way of getting images? As an example, [this is one of the ones we use](https://images.prismic.io/wellcomecollection/5b28b809814fc6d1d716b0082725b24e0a0ad6a9_ep_000012_089.jpg?auto=compress,format), maybe it doesn't like the `compress` parameter? We've discussed it in the past but I can't fully recall so let's do it again.  

<img width="751" alt="Screenshot 2024-03-08 at 11 23 02" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/4cf7b861-c2ea-4c38-853a-864af8d21277">
<img width="708" alt="Screenshot 2024-03-08 at 11 23 12" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/0d0ceb25-67e9-448e-9ae5-2847f2b82712">

