### PR TITLE
Add new Boolean Filter for "Is Available Online"

### DIFF
--- a/common/utils/arrays.ts
+++ b/common/utils/arrays.ts
@@ -1,0 +1,14 @@
+// Thanks to https://gist.github.com/zachlysobey/71ac85046d0d533287ed85e1caa64660 !
+export function partition<T>(
+  array: T[],
+  predicate: (val: T) => boolean
+): [T[], T[]] {
+  const partitioned: [T[], T[]] = [[], []];
+
+  array.forEach((val: T) => {
+    const partitionIndex: 0 | 1 = predicate(val) ? 0 : 1;
+    partitioned[partitionIndex].push(val);
+  });
+
+  return partitioned;
+}

--- a/common/views/components/CheckboxRadio/CheckboxRadio.tsx
+++ b/common/views/components/CheckboxRadio/CheckboxRadio.tsx
@@ -9,20 +9,21 @@ import Space from '@weco/common/views/components/styled/Space';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import { check, indicator } from '@weco/common/icons';
 
-const CheckboxRadioLabel = styled.label`
+const CheckboxRadioLabel = styled.label<{ $isDisabled?: boolean }>`
   display: inline-flex;
-  align-items: flex-start;
-  cursor: pointer;
+  align-items: center;
+  cursor: ${props => (props.$isDisabled ? ' not-allowed' : 'pointer')};
 `;
 
 const CheckboxRadioBox = styled.span<{
   $type: string;
   $hasErrorBorder?: boolean;
+  $isDisabled?: boolean;
 }>`
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  cursor: pointer;
+  cursor: ${props => (props.$isDisabled ? ' not-allowed' : 'pointer')};
 
   position: relative;
   width: 1.3em;
@@ -30,6 +31,13 @@ const CheckboxRadioBox = styled.span<{
   border: 1px solid ${props => props.theme.color('black')};
   border-radius: ${props => (props.$type === 'radio' ? '50%' : '0')};
   ${props => (props.$hasErrorBorder ? `border-color: red;` : ``)}
+
+  ${props =>
+    props.$isDisabled
+      ? `background-color: ${props.theme.color('neutral.300')};
+      border-color: ${props.theme.color('neutral.400')};`
+      : ''}
+    
 
   .icon {
     position: absolute;
@@ -41,13 +49,13 @@ const CheckboxRadioBox = styled.span<{
 
 const CheckboxRadioInput = styled.input.attrs<{ $type: string }>(props => ({
   type: props.$type === 'checkbox' ? 'checkbox' : 'radio',
-}))`
+}))<{ disabled?: boolean }>`
   position: absolute;
   opacity: 0;
   z-index: 1;
   width: 1em;
   height: 1em;
-  cursor: pointer;
+  cursor: ${props => (props.disabled ? ' not-allowed' : 'pointer')};
 
   &:checked ~ ${CheckboxRadioBox} {
     .icon {
@@ -56,7 +64,7 @@ const CheckboxRadioInput = styled.input.attrs<{ $type: string }>(props => ({
   }
 
   &:hover ~ ${CheckboxRadioBox} {
-    border-width: 2px;
+    border-width: ${props => (props.disabled ? '1px' : '2px')};
   }
 
   &:focus-visible ~ ${CheckboxRadioBox}, &:focus ~ ${CheckboxRadioBox} {
@@ -71,7 +79,14 @@ const CheckboxRadioInput = styled.input.attrs<{ $type: string }>(props => ({
 
 const CheckBoxWrapper = styled.div`
   position: relative;
-  top: 1px;
+  top: 3px;
+`;
+
+const Label = styled.span<{ $isDisabled?: boolean }>`
+  ${props =>
+    props.$isDisabled
+      ? `color: ${props.theme.color('neutral.600')}`
+      : 'inherit'}
 `;
 
 type CheckboxRadioProps = {
@@ -82,6 +97,7 @@ type CheckboxRadioProps = {
   name?: string;
   onChange: (event: SyntheticEvent<HTMLInputElement>) => void;
   value?: string;
+  disabled?: boolean;
   ariaLabel?: string;
   form?: string;
   hasErrorBorder?: boolean;
@@ -93,18 +109,28 @@ const CheckboxRadio: FunctionComponent<CheckboxRadioProps> = ({
   type,
   ariaLabel,
   hasErrorBorder,
+  disabled,
   ...inputProps
 }: CheckboxRadioProps): ReactElement<CheckboxRadioProps> => {
   return (
-    <CheckboxRadioLabel htmlFor={id}>
+    <CheckboxRadioLabel htmlFor={id} $isDisabled={disabled}>
       <CheckBoxWrapper>
-        <CheckboxRadioInput id={id} $type={type} {...inputProps} />
-        <CheckboxRadioBox $type={type} $hasErrorBorder={hasErrorBorder}>
+        <CheckboxRadioInput
+          id={id}
+          $type={type}
+          disabled={disabled}
+          {...inputProps}
+        />
+        <CheckboxRadioBox
+          $type={type}
+          $hasErrorBorder={hasErrorBorder}
+          $isDisabled={disabled}
+        >
           <Icon icon={type === 'checkbox' ? check : indicator} />
         </CheckboxRadioBox>
       </CheckBoxWrapper>
-      <Space as="span" $h={{ size: 's', properties: ['margin-left'] }}>
-        {text}
+      <Space $h={{ size: 's', properties: ['margin-left'] }}>
+        <Label $isDisabled={disabled}>{text}</Label>
       </Space>
     </CheckboxRadioLabel>
   );

--- a/content/webapp/components/ModalMoreFilters/index.tsx
+++ b/content/webapp/components/ModalMoreFilters/index.tsx
@@ -17,6 +17,7 @@ import { LinkProps } from '@weco/common/model/link-props';
 import { DateRangeFilter } from '../SearchFilters';
 import PaletteColorPicker from '../PaletteColorPicker';
 import { font } from '@weco/common/utils/classnames';
+import { BooleanFilter } from '@weco/content/components/SearchFilters/SearchFilters.Desktop.BooleanFilter';
 
 type ModalMoreFiltersProps = {
   id: string;
@@ -188,6 +189,15 @@ const MoreFilters: FunctionComponent<MoreFiltersProps> = ({
                       name={f.id}
                       color={f.color}
                       onChangeColor={changeHandler}
+                      form={form}
+                    />
+                  )}
+
+                  {/* TODO discuss this one for when count is 0 */}
+                  {f.type === 'boolean' && !(hasNoResults && !f.isSelected) && (
+                    <BooleanFilter
+                      f={f}
+                      changeHandler={changeHandler}
                       form={form}
                     />
                   )}

--- a/content/webapp/components/SearchFilters/ResetActiveFilters.tsx
+++ b/content/webapp/components/SearchFilters/ResetActiveFilters.tsx
@@ -10,6 +10,7 @@ import { cross } from '@weco/common/icons';
 import Space from '@weco/common/views/components/styled/Space';
 import { font } from '@weco/common/utils/classnames';
 import {
+  BooleanFilter,
   CheckboxFilter,
   ColorFilter,
   DateRangeFilter,
@@ -142,6 +143,22 @@ export const ResetActiveFilters: FunctionComponent<ResetActiveFilters> = ({
       </Fragment>
     ) : null;
 
+  const renderBooleanLink = (filter: BooleanFilter) =>
+    filter.isSelected ? (
+      <NextLink
+        key={filter.id}
+        passHref
+        {...linkResolver({
+          ...router.query,
+          page: '1',
+          [filter.id]: undefined,
+          source: `cancel_filter/${filter.id}`,
+        })}
+      >
+        <CancelFilter text={filter.label} />
+      </NextLink>
+    ) : null;
+
   return (
     <Wrapper>
       <div className={font('intb', 5)}>
@@ -159,6 +176,8 @@ export const ResetActiveFilters: FunctionComponent<ResetActiveFilters> = ({
                 return renderDateRangeLinks(f);
               case 'color':
                 return renderColorLink(f);
+              case 'boolean':
+                return renderBooleanLink(f);
               default:
                 return null;
             }

--- a/content/webapp/components/SearchFilters/SearchFilters.Desktop.BooleanFilter.tsx
+++ b/content/webapp/components/SearchFilters/SearchFilters.Desktop.BooleanFilter.tsx
@@ -1,0 +1,33 @@
+import CheckboxRadio from '@weco/common/views/components/CheckboxRadio/CheckboxRadio';
+import {
+  BooleanFilter as BooleanFilterType,
+  filterLabel,
+} from '@weco/content/services/wellcome/common/filters';
+import { searchFilterCheckBox } from '@weco/content/text/aria-labels';
+
+type BooleanFilterProps = {
+  f: BooleanFilterType;
+  changeHandler: () => void;
+  form?: string;
+};
+
+export const BooleanFilter = ({
+  f,
+  changeHandler,
+  form,
+}: BooleanFilterProps) => {
+  return (
+    <CheckboxRadio
+      id={f.id}
+      type="checkbox"
+      text={filterLabel({ label: f.label, count: f.count })}
+      value="true"
+      name={f.id}
+      checked={f.isSelected}
+      onChange={changeHandler}
+      ariaLabel={searchFilterCheckBox(f.label)}
+      form={form}
+      disabled={f.count === 0 && !f.isSelected}
+    />
+  );
+};

--- a/content/webapp/components/SearchFilters/SearchFilters.Desktop.DynamicFilters.tsx
+++ b/content/webapp/components/SearchFilters/SearchFilters.Desktop.DynamicFilters.tsx
@@ -3,13 +3,18 @@ import { useRouter } from 'next/router';
 
 import Button, { ButtonTypes } from '@weco/common/views/components/Buttons';
 import { themeValues } from '@weco/common/views/themes/config';
-import { Filter } from '@weco/content/services/wellcome/common/filters';
+import {
+  BooleanFilter as BooleanFilterType,
+  Filter,
+} from '@weco/content/services/wellcome/common/filters';
 import Space from '@weco/common/views/components/styled/Space';
 import { filter } from '@weco/common/icons';
 
 import CheckboxFilter from './SearchFilters.Desktop.CheckboxFilter';
 import DesktopDateRangeFilter from './SearchFilters.Desktop.DateRangeFilter';
 import DesktopColorFilter from './SearchFilters.Desktop.ColorFilter';
+import { BooleanFilter } from './SearchFilters.Desktop.BooleanFilter';
+import { partition } from '@weco/common/utils/arrays';
 
 const DynamicFilterArray = ({
   showMoreFiltersModal,
@@ -33,6 +38,10 @@ const DynamicFilterArray = ({
       setWrapperWidth(left + width);
     }
   };
+  const [booleanFilters, dropdownFilters] = partition(
+    filters,
+    (f: BooleanFilterType) => f.type === 'boolean'
+  );
 
   const renderDynamicFilter = (f: Filter, i: number) => {
     const isHidden = hasCalculatedFilters
@@ -177,7 +186,8 @@ const DynamicFilterArray = ({
 
   return (
     <>
-      {filters.map(renderDynamicFilter)}
+      {dropdownFilters.map(renderDynamicFilter)}
+
       <Space $h={{ size: 'm', properties: ['margin-right'] }}>
         <Button
           variant="ButtonSolid"
@@ -195,6 +205,15 @@ const DynamicFilterArray = ({
           isPill
         />
       </Space>
+
+      {booleanFilters?.map(f => (
+        <BooleanFilter
+          key={f.id}
+          {...(!showMoreFiltersModal && { form: searchFormId })}
+          f={f}
+          changeHandler={changeHandler}
+        />
+      ))}
     </>
   );
 };

--- a/content/webapp/components/SearchFilters/SearchFilters.Mobile.tsx
+++ b/content/webapp/components/SearchFilters/SearchFilters.Mobile.tsx
@@ -16,6 +16,7 @@ import CheckboxRadio from '@weco/common/views/components/CheckboxRadio/CheckboxR
 import { SearchFiltersSharedProps } from '.';
 import {
   CheckboxFilter as CheckboxFilterType,
+  BooleanFilter as BooleanFilterType,
   filterLabel,
 } from '@weco/content/services/wellcome/common/filters';
 import Button, {
@@ -69,6 +70,7 @@ const ActiveFilters = styled(Space).attrs({
 
 const FiltersBody = styled(Space).attrs({
   $h: { size: 'xl', properties: ['padding-left', 'padding-right'] },
+  $v: { size: 'xl', properties: ['padding-bottom'] },
 })`
   input[type='number'] {
     min-width: calc(24px + 4ch);
@@ -139,6 +141,27 @@ const CheckboxFilter = ({ f, changeHandler, form }: CheckboxFilterProps) => {
         })}
       </PlainList>
     </>
+  );
+};
+
+type BooleanFilterProps = {
+  f: BooleanFilterType;
+  changeHandler: () => void;
+  form?: string;
+};
+const BooleanFilter = ({ f, changeHandler, form }: BooleanFilterProps) => {
+  return (
+    <CheckboxRadio
+      id={`mobile-${f.id}`}
+      type="checkbox"
+      text={filterLabel({ label: f.label, count: f.count })}
+      value="true"
+      name={f.id}
+      checked={f.isSelected}
+      onChange={changeHandler}
+      ariaLabel={searchFilterCheckBox(f.label)}
+      form={form}
+    />
   );
 };
 
@@ -281,6 +304,15 @@ const SearchFiltersMobile: FunctionComponent<SearchFiltersSharedProps> = ({
                       name={f.id}
                       color={f.color}
                       onChangeColor={changeHandler}
+                      form={searchFormId}
+                    />
+                  )}
+
+                  {/* TODO discuss this one for when count is 0 */}
+                  {f.type === 'boolean' && !(hasNoResults && !f.isSelected) && (
+                    <BooleanFilter
+                      f={f}
+                      changeHandler={changeHandler}
                       form={searchFormId}
                     />
                   )}

--- a/content/webapp/components/SearchFilters/index.tsx
+++ b/content/webapp/components/SearchFilters/index.tsx
@@ -47,6 +47,8 @@ const SearchFilters: FunctionComponent<Props> = ({
           return f.options.filter(option => option.selected).length;
         case 'dateRange':
           return f.from.value || f.to.value ? 1 : 0;
+        case 'boolean':
+          return f.isSelected ? 1 : 0;
         default:
           return 0;
       }

--- a/content/webapp/components/SearchPagesLink/Events.tsx
+++ b/content/webapp/components/SearchPagesLink/Events.tsx
@@ -10,6 +10,7 @@ import {
   FromCodecMap,
   encodeQuery,
   decodeQuery,
+  booleanCodec,
 } from '@weco/common/utils/routes';
 import { EventsLinkSource } from '@weco/common/data/segment-values';
 export type EventsProps = FromCodecMap<typeof codecMap>;
@@ -19,6 +20,7 @@ const emptyEventsProps: EventsProps = {
   format: [],
   audience: [],
   interpretation: [],
+  isAvailableOnline: false,
 };
 const codecMap = {
   query: stringCodec,
@@ -26,6 +28,7 @@ const codecMap = {
   format: csvCodec,
   audience: csvCodec,
   interpretation: csvCodec,
+  isAvailableOnline: booleanCodec,
 };
 const fromQuery: (params: ParsedUrlQuery) => EventsProps = params => {
   return decodeQuery<EventsProps>(params, codecMap);

--- a/content/webapp/pages/search/events.tsx
+++ b/content/webapp/pages/search/events.tsx
@@ -35,7 +35,7 @@ import {
 import { getEvents } from '@weco/content/services/wellcome/content/events';
 import EventsSearchResults from '@weco/content/components/EventsSearchResults';
 import SearchFilters from '@weco/content/components/SearchFilters';
-import { hasFilters } from '@weco/content/utils/search';
+import { getActiveFiltersLabel, hasFilters } from '@weco/content/utils/search';
 import { eventsFilters } from '@weco/content/services/wellcome/common/filters';
 
 type Props = {
@@ -74,6 +74,8 @@ export const EventsSearchPage: NextPageWithLayout<Props> = ({
     filters: filters.map(f => f.id),
     queryParams: query,
   });
+
+  const activeFiltersLabels = getActiveFiltersLabel({ filters });
 
   return (
     <Space $v={{ size: 'l', properties: ['padding-bottom'] }}>
@@ -115,6 +117,12 @@ export const EventsSearchPage: NextPageWithLayout<Props> = ({
               <PaginationWrapper $verticalSpacing="l">
                 <span role="status">
                   {pluralize(eventResponseList.totalResults, 'result')}
+                  {activeFiltersLabels.length > 0 && (
+                    <span className="visually-hidden">
+                      {' '}
+                      filtered with: {activeFiltersLabels.join(', ')}
+                    </span>
+                  )}
                 </span>
 
                 <SortPaginationWrapper>
@@ -243,7 +251,12 @@ export const getServerSideProps: GetServerSideProps<
       sort: getQueryPropertyValue(query.sort),
       sortOrder: getQueryPropertyValue(query.sortOrder),
       ...(pageNumber && { page: Number(pageNumber) }),
-      aggregations: ['format', 'audience', 'interpretation'],
+      aggregations: [
+        'format',
+        'audience',
+        'interpretation',
+        'isAvailableOnline',
+      ],
     },
     pageSize: 24,
     toggles: serverData.toggles,

--- a/content/webapp/services/wellcome/common/filters.ts
+++ b/content/webapp/services/wellcome/common/filters.ts
@@ -41,6 +41,15 @@ export type CheckboxFilter<Id extends string = string> = {
   excludeFromMoreFilters?: boolean;
 };
 
+export type BooleanFilter<Id extends string = string> = {
+  type: 'boolean';
+  id: Id;
+  label: string;
+  isSelected: boolean;
+  count?: number;
+  excludeFromMoreFilters?: boolean;
+};
+
 export type ColorFilter = {
   type: 'color';
   id: keyof ImagesProps;
@@ -52,6 +61,7 @@ export type ColorFilter = {
 export type Filter<Id extends string = string> =
   | CheckboxFilter<Id>
   | DateRangeFilter<Id>
+  | BooleanFilter
   | ColorFilter;
 
 type FilterOption = {
@@ -617,6 +627,17 @@ const eventsAudienceFilter = ({
   }),
 });
 
+const eventsIsAvailableOnlineFilter = ({
+  events,
+  props,
+}: EventsFilterProps): BooleanFilter<keyof EventsProps> => ({
+  type: 'boolean',
+  id: 'isAvailableOnline',
+  label: 'Catch-up events only',
+  count: events?.aggregations?.isAvailableOnline?.buckets?.[1]?.count || 0,
+  isSelected: !!props.isAvailableOnline,
+});
+
 // TODO re-add when https://github.com/wellcomecollection/content-api/issues/106 is done
 // const eventsInterpretationFilter = ({
 //   events,
@@ -676,6 +697,7 @@ const eventsFilters: (
   [
     eventsFormatFilter,
     eventsAudienceFilter,
+    eventsIsAvailableOnlineFilter,
     // TODO re-add when https://github.com/wellcomecollection/content-api/issues/106 is done
     // eventsInterpretationFilter
   ].map(f => f(props));

--- a/content/webapp/services/wellcome/content/types/api.ts
+++ b/content/webapp/services/wellcome/content/types/api.ts
@@ -116,6 +116,7 @@ export type ArticleAggregations = BasicAggregations & {
 export type EventAggregations = BasicAggregations & {
   audience: WellcomeAggregation;
   interpretation: WellcomeAggregation;
+  isAvailableOnline: WellcomeAggregation;
 };
 
 // Results

--- a/content/webapp/utils/search.ts
+++ b/content/webapp/utils/search.ts
@@ -38,6 +38,8 @@ export const getActiveFiltersLabel = ({
         return dateRange || undefined;
       } else if (f.type === 'color' && f.color) {
         return getColorDisplayName(f.color) || undefined;
+      } else if (f.type === 'boolean') {
+        return f.isSelected ? f.label : undefined;
       }
       return undefined;
     })


### PR DESCRIPTION
## Who is this for?
General search filters + #10689 

## What is it doing for them?
- Adds a new filter: Boolean Filter. This is for when only "true" is a valid parameter and "false" means "undefined" e.g. in this case, checking "Is available online" means "show me available online events ONLY". If the checkbox is unchecked it returns all events.
- Added a `partition` util, originally only put it in the file itself but I thought it was worth putting in utils.
- Added styles on our checkboxes for when they are disabled.


## Left to discuss
- Not sure it "makes sense" the way things are, to have checkboxes _after_ the "All filters" button. Will aim to have a call with @j-jaworski to go through some of the issues, such as having smaller screens and if it still should show up in the modal, in which case what happens on mobile, etc.
- I'd like to check if we really need to create different `BooleanFilter` elements on mobile and desktop, they're pretty straightforward.