### PR TITLE
Don't destructure the process object

### DIFF
--- a/common/views/pages/_document.tsx
+++ b/common/views/pages/_document.tsx
@@ -16,10 +16,9 @@ import {
   GaDimensions,
 } from '@weco/common/services/app/google-analytics';
 
-const {
-  ANALYTICS_WRITE_KEY = '78Czn5jNSaMSVrBq2J9K4yJjWxh6fyRI',
-  NODE_ENV = 'development',
-} = process.env;
+const ANALYTICS_WRITE_KEY =
+  process.env.ANALYTICS_WRITE_KEY || '78Czn5jNSaMSVrBq2J9K4yJjWxh6fyRI';
+const NODE_ENV = process.env.NODE_ENV || 'development';
 
 export function renderSegmentSnippet() {
   const opts = {
@@ -88,7 +87,7 @@ class WecoDoc extends Document<DocumentInitialPropsWithTogglesAndGa> {
             />
 
             {/* Removing/readding this script on consent changes causes issues with meta tag duplicates
-            https://github.com/wellcomecollection/wellcomecollection.org/pull/10685#discussion_r1516298683 
+            https://github.com/wellcomecollection/wellcomecollection.org/pull/10685#discussion_r1516298683
             Let's keep an eye on this issue and consider moving it next to the Segment script when it's fixed */}
             <GoogleTagManager />
 

--- a/common/views/pages/_document.tsx
+++ b/common/views/pages/_document.tsx
@@ -16,6 +16,8 @@ import {
   GaDimensions,
 } from '@weco/common/services/app/google-analytics';
 
+// Don't attempt to destructure the process object
+// https://github.com/vercel/next.js/pull/20869/files
 const ANALYTICS_WRITE_KEY =
   process.env.ANALYTICS_WRITE_KEY || '78Czn5jNSaMSVrBq2J9K4yJjWxh6fyRI';
 const NODE_ENV = process.env.NODE_ENV || 'development';


### PR DESCRIPTION
Fixes an issue with people not being able to see their holds.

Why this worked up until now is a bit of a mystery, but the [Next docs indicate](https://github.com/vercel/next.js/pull/20869/files) that the `process.env` isn't a regular JS object and, as such, can't be destructured.
