### PR TITLE
Add more necessary cookies

### DIFF
--- a/common/views/components/CivicUK/index.tsx
+++ b/common/views/components/CivicUK/index.tsx
@@ -1,3 +1,5 @@
+import cookies from '@weco/common/data/cookies';
+
 const branding = {
   removeIcon: true,
   removeAbout: true,
@@ -32,6 +34,18 @@ const statement = {
   updated: '25/05/2018',
 };
 
+const necessaryCookies = () => {
+  const wcCookies = Object.values(cookies).map(c => c);
+
+  return [
+    ...wcCookies,
+    'toggle_*',
+    // Allows Prismic previews
+    'io.prismic.preview',
+    'isPreview',
+  ];
+};
+
 const CivicUK = () => (
   <>
     <script
@@ -50,7 +64,7 @@ const CivicUK = () => (
             closeStyle: 'button',
             settingsStyle: 'button',
             notifyDismissButton: false,
-            necessaryCookies: ['toggle_*'],
+            necessaryCookies: ${JSON.stringify(necessaryCookies())},
             optionalCookies: [
               {
                 name: 'analytics',

--- a/common/views/components/CivicUK/index.tsx
+++ b/common/views/components/CivicUK/index.tsx
@@ -34,16 +34,19 @@ const statement = {
   updated: '25/05/2018',
 };
 
+// Define all necessary cookies here and document their usage a little.
+// Don't put comments in the return array as it gets stringified later.
 const necessaryCookies = () => {
+  // View @weco/common/data/cookies for details on each
   const wcCookies = Object.values(cookies).map(c => c);
 
-  return [
-    ...wcCookies,
-    'toggle_*',
-    // Allows Prismic previews
-    'io.prismic.preview',
-    'isPreview',
-  ];
+  // Allows Prismic previews
+  const prismicPreview = ['io.prismic.preview', 'isPreview'];
+
+  // See @weco/toggles/webapp/toggles for details on each
+  const featureFlags = ['toggle_*'];
+
+  return [...wcCookies, ...prismicPreview, ...featureFlags];
 };
 
 const CivicUK = () => (


### PR DESCRIPTION
## Who is this for?
People who want more cookies, part of #10717

## What is it doing for them?
Allows all the cookies we have in https://github.com/wellcomecollection/wellcomecollection.org/blob/main/common/data/cookies.ts, we need them allowed in general and I need `WC_analyticsDebug` to test Segment sends everything well/doesn't in live environments.

Adding `isPreview` for us and Editorial, although I don't think it's the full answer to the current preview issues as cookie toggle would need to be on for those affected and it wouldn't be the external stakeholders' case.