### PR TITLE
Comment out the pa11y task until they upgrade to v8

### DIFF
--- a/.buildkite/pipeline.deployment.yml
+++ b/.buildkite/pipeline.deployment.yml
@@ -47,20 +47,22 @@ steps:
     soft_fail:
       - exit_status: 1
 
-  - label: "Update pa11y dashboard"
-    if: build.env("BUILDKITE_GITHUB_DEPLOYMENT_ENVIRONMENT") == "prod"
-    plugins:
-      - wellcomecollection/aws-assume-role#v0.2.2:
-          role: "arn:aws:iam::130871440101:role/experience-ci"
-      - ecr#v2.1.1:
-          login: true
-      - docker-compose#v3.5.0:
-          run: pa11y
-          command: [ "yarn", "deploy" ]
-          env:
-            - AWS_ACCESS_KEY_ID
-            - AWS_SECRET_ACCESS_KEY
-            - AWS_SESSION_TOKEN
+  # TODO aim to uncomment once pa11y upgrades to v8 because of
+  # https://github.com/pa11y/pa11y/issues/688
+  # - label: "Update pa11y dashboard"
+  #   if: build.env("BUILDKITE_GITHUB_DEPLOYMENT_ENVIRONMENT") == "prod"
+  #   plugins:
+  #     - wellcomecollection/aws-assume-role#v0.2.2:
+  #         role: "arn:aws:iam::130871440101:role/experience-ci"
+  #     - ecr#v2.1.1:
+  #         login: true
+  #     - docker-compose#v3.5.0:
+  #         run: pa11y
+  #         command: [ "yarn", "deploy" ]
+  #         env:
+  #           - AWS_ACCESS_KEY_ID
+  #           - AWS_SECRET_ACCESS_KEY
+  #           - AWS_SESSION_TOKEN
 
   - wait
 


### PR DESCRIPTION
## Who is this for?
Us wanting green checkboxes on Buildkite

## What is it doing for them?
https://github.com/pa11y/pa11y/issues/688 <-- they're having dependencies issues, seems to work locally-run but fails in Docker. They're saying it'll be fixed in the next version so we'll keep an eye on it and try it again, although it might be nice to find an alternative to pa11y since they've been troublesome since we left version 5 (which tested against an older version of WCAG).