### PR TITLE
Find true bucket to get count

### DIFF
--- a/content/webapp/services/wellcome/common/filters.ts
+++ b/content/webapp/services/wellcome/common/filters.ts
@@ -631,16 +631,15 @@ const eventsIsAvailableOnlineFilter = ({
   events,
   props,
 }: EventsFilterProps): BooleanFilter<keyof EventsProps> => {
-  const isAvailableOnlineTrueBucket =
-    events?.aggregations?.isAvailableOnline?.buckets.find(
-      b => b.data.isAvailableOnline === true
-    );
-
+  // const isAvailableOnlineTrueBucket =
+  // events?.aggregations?.isAvailableOnline?.buckets.find(
+  //   b => b.data.isAvailableOnline === true
+  // );
   return {
     type: 'boolean',
     id: 'isAvailableOnline',
     label: 'Catch-up events only',
-    count: isAvailableOnlineTrueBucket?.count || 0,
+    count: events?.aggregations?.isAvailableOnline?.buckets?.[1]?.count || 0,
     isSelected: !!props.isAvailableOnline,
   };
 };

--- a/content/webapp/services/wellcome/common/filters.ts
+++ b/content/webapp/services/wellcome/common/filters.ts
@@ -630,13 +630,20 @@ const eventsAudienceFilter = ({
 const eventsIsAvailableOnlineFilter = ({
   events,
   props,
-}: EventsFilterProps): BooleanFilter<keyof EventsProps> => ({
-  type: 'boolean',
-  id: 'isAvailableOnline',
-  label: 'Catch-up events only',
-  count: events?.aggregations?.isAvailableOnline?.buckets?.[1]?.count || 0,
-  isSelected: !!props.isAvailableOnline,
-});
+}: EventsFilterProps): BooleanFilter<keyof EventsProps> => {
+  const isAvailableOnlineTrueBucket =
+    events?.aggregations?.isAvailableOnline?.buckets.find(
+      b => b.data.isAvailableOnline === true
+    );
+
+  return {
+    type: 'boolean',
+    id: 'isAvailableOnline',
+    label: 'Catch-up events only',
+    count: isAvailableOnlineTrueBucket?.count || 0,
+    isSelected: !!props.isAvailableOnline,
+  };
+};
 
 // TODO re-add when https://github.com/wellcomecollection/content-api/issues/106 is done
 // const eventsInterpretationFilter = ({

--- a/content/webapp/services/wellcome/content/types/api.ts
+++ b/content/webapp/services/wellcome/content/types/api.ts
@@ -1,5 +1,7 @@
 import { ArticleFormatId } from '@weco/content/data/content-format-ids';
 import {
+  IdentifiedBucketData,
+  UnidentifiedBucketData,
   WellcomeAggregation,
   WellcomeResultList,
 } from '@weco/content/services/wellcome';
@@ -116,7 +118,11 @@ export type ArticleAggregations = BasicAggregations & {
 export type EventAggregations = BasicAggregations & {
   audience: WellcomeAggregation;
   interpretation: WellcomeAggregation;
-  isAvailableOnline: WellcomeAggregation;
+  isAvailableOnline: WellcomeAggregation<
+    (IdentifiedBucketData | UnidentifiedBucketData) & {
+      isAvailableOnline: boolean;
+    }
+  >;
 };
 
 // Results

--- a/content/webapp/services/wellcome/content/types/api.ts
+++ b/content/webapp/services/wellcome/content/types/api.ts
@@ -1,7 +1,5 @@
 import { ArticleFormatId } from '@weco/content/data/content-format-ids';
 import {
-  IdentifiedBucketData,
-  UnidentifiedBucketData,
   WellcomeAggregation,
   WellcomeResultList,
 } from '@weco/content/services/wellcome';
@@ -118,11 +116,12 @@ export type ArticleAggregations = BasicAggregations & {
 export type EventAggregations = BasicAggregations & {
   audience: WellcomeAggregation;
   interpretation: WellcomeAggregation;
-  isAvailableOnline: WellcomeAggregation<
-    (IdentifiedBucketData | UnidentifiedBucketData) & {
-      isAvailableOnline: boolean;
-    }
-  >;
+  //   isAvailableOnline: WellcomeAggregation<
+  //   (IdentifiedBucketData | UnidentifiedBucketData) & {
+  //     isAvailableOnline: boolean;
+  //   }
+  // >;
+  isAvailableOnline: WellcomeAggregation;
 };
 
 // Results


### PR DESCRIPTION
## Who is this for?
Good filter data, #10668 

## What is it doing for them?
After testing random searches on https://github.com/wellcomecollection/wellcomecollection.org/pull/10704 I realised that I was assuming that the bucket we wanted (`isAvailableOnline: true`) was always the second one, but really when there is no result that has `isAvailableOnline: false`, it becomes the first one, of course (e.g. https://www-stage.wellcomecollection.org/search/events?audience=ZCvS4RQAAB3yVHfk).

So I find the one we want instead and return that count. Had to tweak types a bit so TS would understand what I was doing.