### PR TITLE
Revert "Trial Prismic's next preview tool"

### DIFF
--- a/common/koa-middleware/withCachedValues.ts
+++ b/common/koa-middleware/withCachedValues.ts
@@ -1,7 +1,11 @@
+import compose from 'koa-compose';
+import { withPrismicPreviewStatus } from './withPrismicPreviewStatus';
 import { IncomingMessage, ServerResponse } from 'http';
 import Router from 'koa-router';
 import { NextServer } from 'next/dist/server/next';
 import { parse, UrlWithParsedQuery } from 'url'; // eslint-disable-line n/no-deprecated-api
+
+export const withCachedValues = compose([withPrismicPreviewStatus]);
 
 export async function route(
   path: string,

--- a/common/koa-middleware/withPrismicPreviewStatus.ts
+++ b/common/koa-middleware/withPrismicPreviewStatus.ts
@@ -1,0 +1,27 @@
+import Koa from 'koa';
+
+export function withPrismicPreviewStatus(
+  ctx: Koa.DefaultContext,
+  next: Koa.Next
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+): Promise<any> {
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+
+  // for previews on localhost we use /preview to determine whether the 'isPreview' cookie should be set
+  // this kinda works for live too, but not for shared preview links, as they never hit /preview
+  // we therefore look for the subdomain .preview to determine if it's a preview
+  const previewCookieName = 'isPreview';
+  const isPreviewDomain = Boolean(ctx.request.host.startsWith('preview.'));
+  const previewCookieMatch = ctx.headers.cookie
+    ? ctx.headers.cookie.match(`(^|;) ?${previewCookieName}=([^;]*)(;|$)`)
+    : undefined;
+
+  const previewCookie = previewCookieMatch ? previewCookieMatch[2] : undefined;
+
+  if (isPreviewDomain && !previewCookie) {
+    ctx.cookies.set('isPreview', 'true', {
+      httpOnly: false,
+    });
+  }
+  return next();
+}

--- a/common/package.json
+++ b/common/package.json
@@ -17,7 +17,6 @@
     "@next/bundle-analyzer": "^13.2.3",
     "@popperjs/core": "^2.11.7",
     "@prismicio/client": "^7.3.1",
-    "@prismicio/next": "^1.5.0",
     "@prismicio/react": "^2.7.3",
     "@segment/snippet": "^4.10.0",
     "@testing-library/dom": "^9.0.0",

--- a/common/views/components/CivicUK/index.tsx
+++ b/common/views/components/CivicUK/index.tsx
@@ -41,7 +41,7 @@ const necessaryCookies = () => {
   const wcCookies = Object.values(cookies).map(c => c);
 
   // Allows Prismic previews
-  const prismicPreview = ['io.prismic.preview'];
+  const prismicPreview = ['io.prismic.preview', 'isPreview'];
 
   // See @weco/toggles/webapp/toggles for details on each
   const featureFlags = ['toggle_*'];

--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -2,7 +2,6 @@ import { NextPage } from 'next';
 import { AppProps } from 'next/app';
 import React, { useEffect, FunctionComponent, ReactElement } from 'react';
 import { ThemeProvider } from 'styled-components';
-import { PrismicPreview } from '@prismicio/next';
 import theme, { GlobalStyle } from '@weco/common/views/themes/default';
 import LoadingIndicator from '@weco/common/views/components/LoadingIndicator/LoadingIndicator';
 import { AppContextProvider } from '@weco/common/views/components/AppContext/AppContext';
@@ -21,6 +20,7 @@ import { ServerDataContext } from '@weco/common/server-data/Context';
 import UserProvider from '@weco/common/views/components/UserProvider/UserProvider';
 import { ApmContextProvider } from '@weco/common/views/components/ApmContext/ApmContext';
 import { AppErrorProps } from '@weco/common/services/app';
+import usePrismicPreview from '@weco/common/services/app/usePrismicPreview';
 import useMaintainPageHeight from '@weco/common/services/app/useMaintainPageHeight';
 import { GaDimensions } from '@weco/common/services/app/google-analytics';
 import { deserialiseProps } from '@weco/common/utils/json';
@@ -126,6 +126,8 @@ const WecoApp: FunctionComponent<WecoAppProps> = ({
   // or when requested client-side through next/link or next/router
   // i.e. everything that we consider to be a page view
 
+  usePrismicPreview(() => Boolean(document.cookie.match('isPreview=true')));
+
   const getLayout = Component.getLayout || (page => <>{page}</>);
 
   return (
@@ -155,8 +157,6 @@ const WecoApp: FunctionComponent<WecoAppProps> = ({
                       title={pageProps.err.message}
                     />
                   )}
-
-                  <PrismicPreview repositoryName="wellcomecollection" />
                 </ThemeProvider>
               </SearchContextProvider>
             </AppContextProvider>

--- a/content/webapp/app.ts
+++ b/content/webapp/app.ts
@@ -6,7 +6,10 @@ import Router from 'koa-router';
 import next from 'next';
 import { apmErrorMiddleware } from '@weco/common/services/apm/errorMiddleware';
 import { init as initServerData } from '@weco/common/server-data';
-import { handleAllRoute } from '@weco/common/koa-middleware/withCachedValues';
+import {
+  withCachedValues,
+  handleAllRoute,
+} from '@weco/common/koa-middleware/withCachedValues';
 import linkResolver from '@weco/common/services/prismic/link-resolver';
 import { createClient as createPrismicClient } from '@weco/common/services/prismic/fetch';
 import * as prismic from '@prismicio/client';
@@ -41,6 +44,7 @@ const appPromise = nextApp
     });
 
     koaApp.use(apmErrorMiddleware);
+    koaApp.use(withCachedValues);
 
     // Add a naive healthcheck endpoint for the load balancer
     router.get('/management/healthcheck', async ctx => {
@@ -66,6 +70,10 @@ const appPromise = nextApp
       const url = await client.resolvePreviewURL({
         linkResolver: retypedLinkResolver,
         defaultURL: '/',
+      });
+
+      ctx.cookies.set('isPreview', 'true', {
+        httpOnly: false,
       });
 
       ctx.redirect(url);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4351,13 +4351,6 @@
   resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-7.6.0.tgz#9ea331766084288634a9247fcd8b84f16ff4ba07"
   integrity sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==
 
-"@formatjs/intl-localematcher@^0.5.2":
-  version "0.5.4"
-  resolved "https://registry.yarnpkg.com/@formatjs/intl-localematcher/-/intl-localematcher-0.5.4.tgz#caa71f2e40d93e37d58be35cfffe57865f2b366f"
-  integrity sha512-zTwEpWOzZ2CiKcB93BLngUX59hQkuZjT2+SAQEscSm52peDW/getsawMcWF1rGRpMCX6D7nSJA3CzJ8gn13N/g==
-  dependencies:
-    tslib "^2.4.0"
-
 "@gar/promisify@^1.0.1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.2.tgz#30aa825f11d438671d585bd44e7fd564535fc210"
@@ -4970,15 +4963,6 @@
   integrity sha512-9MKR/atr4dIQz8rZsQ4Fe7588qSQF2CYXutYW8O9bJOqlrjvAcC8b1Yvu7AIOksXlxE/aAWPtriQ2JZMiTFjNw==
   dependencies:
     imgix-url-builder "^0.0.4"
-
-"@prismicio/next@^1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@prismicio/next/-/next-1.5.0.tgz#a11d8dfbc715b35981f89e7c97d2f788ed2d80ec"
-  integrity sha512-WbAbBwvUUfrgCJCX8a1SKjGrbnpzLtbo9MnTn0aDRc2yZ4BhK1PRN4Q24Bqx0wmJybQkzM6PcBKiDkZBps1gxA==
-  dependencies:
-    "@formatjs/intl-localematcher" "^0.5.2"
-    imgix-url-builder "^0.0.4"
-    negotiator "^0.6.3"
 
 "@prismicio/react@^2.7.3":
   version "2.7.3"
@@ -15574,11 +15558,6 @@ negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
   integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
-
-negotiator@^0.6.3:
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
-  integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
 neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1, neo-async@^2.6.2:
   version "2.6.2"


### PR DESCRIPTION
Reverts wellcomecollection/wellcomecollection.org#10721

Doesn't seem to be working in staging; I think we need to keep allowing `isPreview`? More testing required.