### PR TITLE
`IsAvailableOnline` event filter; Find true bucket to get count

### DIFF
--- a/content/webapp/services/wellcome/common/filters.ts
+++ b/content/webapp/services/wellcome/common/filters.ts
@@ -630,13 +630,18 @@ const eventsAudienceFilter = ({
 const eventsIsAvailableOnlineFilter = ({
   events,
   props,
-}: EventsFilterProps): BooleanFilter<keyof EventsProps> => ({
-  type: 'boolean',
-  id: 'isAvailableOnline',
-  label: 'Catch-up events only',
-  count: events?.aggregations?.isAvailableOnline?.buckets?.[1]?.count || 0,
-  isSelected: !!props.isAvailableOnline,
-});
+}: EventsFilterProps): BooleanFilter<keyof EventsProps> => {
+  const isAvailableOnlineTrueBucket =
+    events?.aggregations?.isAvailableOnline.buckets.find(b => b.data.value);
+
+  return {
+    type: 'boolean',
+    id: 'isAvailableOnline',
+    label: 'Catch-up events only',
+    count: isAvailableOnlineTrueBucket?.count || 0,
+    isSelected: !!props.isAvailableOnline,
+  };
+};
 
 // TODO re-add when https://github.com/wellcomecollection/content-api/issues/106 is done
 // const eventsInterpretationFilter = ({

--- a/content/webapp/services/wellcome/content/types/api.ts
+++ b/content/webapp/services/wellcome/content/types/api.ts
@@ -1,5 +1,6 @@
 import { ArticleFormatId } from '@weco/content/data/content-format-ids';
 import {
+  BooleanBucketData,
   WellcomeAggregation,
   WellcomeResultList,
 } from '@weco/content/services/wellcome';
@@ -116,7 +117,7 @@ export type ArticleAggregations = BasicAggregations & {
 export type EventAggregations = BasicAggregations & {
   audience: WellcomeAggregation;
   interpretation: WellcomeAggregation;
-  isAvailableOnline: WellcomeAggregation;
+  isAvailableOnline: WellcomeAggregation<BooleanBucketData>;
 };
 
 // Results

--- a/content/webapp/services/wellcome/index.ts
+++ b/content/webapp/services/wellcome/index.ts
@@ -55,9 +55,14 @@ export type UnidentifiedBucketData = {
   type: string;
 };
 
+export type BooleanBucketData = UnidentifiedBucketData & {
+  value: boolean;
+};
+
 export type WellcomeAggregation<
   BucketData extends
     | IdentifiedBucketData
+    | BooleanBucketData
     | UnidentifiedBucketData = IdentifiedBucketData,
 > = {
   buckets: {


### PR DESCRIPTION
## Who is this for?
Good functioning of is available online filter, #10668  (follows #10704)

## What is it doing for them?
We were wrongly assuming which bucket would have the `true` value, which would've never worked unless there were always more `false` than `true` results! So went back to the drawing board with @agnesgaroux to structure the boolean buckets further in the API content, which can be seen in the added `type` here. This way we can find the desired one first and use it for the `count`.

Twinned with https://github.com/wellcomecollection/content-api/pull/117