### PR TITLE
Don't compress the storybook Prismic images

### DIFF
--- a/cardigan/stories/content.ts
+++ b/cardigan/stories/content.ts
@@ -67,7 +67,7 @@ export const bannerCardItem: Season = {
       'Our new season explores the intertwined connections between the individual, societal and global health.',
     image: {
       contentUrl:
-        'https://images.prismic.io/wellcomecollection%2F92a873e4-b774-4c46-b9b3-75fda00a0ace_b0011048_artistic+interpretation+of+alzheimers_florence+winterflood.jpg?auto=compress,format&rect=0,0,1600,900&w=3200&h=1800',
+        'https://images.prismic.io/wellcomecollection%2F92a873e4-b774-4c46-b9b3-75fda00a0ace_b0011048_artistic+interpretation+of+alzheimers_florence+winterflood.jpg?auto=format&rect=0,0,1600,900&w=3200&h=1800',
       width: 3200,
       height: 1800,
       alt: 'An artwork featuring a large painted human hand, surrounded by fragments of maps.',
@@ -85,7 +85,7 @@ export const bannerCardItem: Season = {
   },
   image: {
     contentUrl:
-      'https://images.prismic.io/wellcomecollection%2F92a873e4-b774-4c46-b9b3-75fda00a0ace_b0011048_artistic+interpretation+of+alzheimers_florence+winterflood.jpg?auto=compress,format',
+      'https://images.prismic.io/wellcomecollection%2F92a873e4-b774-4c46-b9b3-75fda00a0ace_b0011048_artistic+interpretation+of+alzheimers_florence+winterflood.jpg?auto=format',
     width: 1600,
     height: 900,
     alt: 'An artwork featuring a large painted human hand, surrounded by fragments of maps.',
@@ -101,19 +101,19 @@ export const bannerCardItem: Season = {
     simpleCrops: {
       '32:15': {
         contentUrl:
-          'https://images.prismic.io/wellcomecollection%2F92a873e4-b774-4c46-b9b3-75fda00a0ace_b0011048_artistic+interpretation+of+alzheimers_florence+winterflood.jpg?auto=compress,format&rect=0,75,1600,750&w=3200&h=1500',
+          'https://images.prismic.io/wellcomecollection%2F92a873e4-b774-4c46-b9b3-75fda00a0ace_b0011048_artistic+interpretation+of+alzheimers_florence+winterflood.jpg?auto=format&rect=0,75,1600,750&w=3200&h=1500',
         width: 3200,
         height: 1500,
       },
       '16:9': {
         contentUrl:
-          'https://images.prismic.io/wellcomecollection%2F92a873e4-b774-4c46-b9b3-75fda00a0ace_b0011048_artistic+interpretation+of+alzheimers_florence+winterflood.jpg?auto=compress,format&rect=0,0,1600,900&w=3200&h=1800',
+          'https://images.prismic.io/wellcomecollection%2F92a873e4-b774-4c46-b9b3-75fda00a0ace_b0011048_artistic+interpretation+of+alzheimers_florence+winterflood.jpg?auto=format&rect=0,0,1600,900&w=3200&h=1800',
         width: 3200,
         height: 1800,
       },
       square: {
         contentUrl:
-          'https://images.prismic.io/wellcomecollection%2F92a873e4-b774-4c46-b9b3-75fda00a0ace_b0011048_artistic+interpretation+of+alzheimers_florence+winterflood.jpg?auto=compress,format&rect=350,0,900,900&w=3200&h=3200',
+          'https://images.prismic.io/wellcomecollection%2F92a873e4-b774-4c46-b9b3-75fda00a0ace_b0011048_artistic+interpretation+of+alzheimers_florence+winterflood.jpg?auto=format&rect=350,0,900,900&w=3200&h=3200',
         width: 3200,
         height: 3200,
       },
@@ -122,7 +122,7 @@ export const bannerCardItem: Season = {
 };
 
 export const image = (
-  contentUrl = 'https://images.prismic.io/wellcomecollection/5b28b809814fc6d1d716b0082725b24e0a0ad6a9_ep_000012_089.jpg?auto=compress,format',
+  contentUrl = 'https://images.prismic.io/wellcomecollection/5b28b809814fc6d1d716b0082725b24e0a0ad6a9_ep_000012_089.jpg?auto=format',
   width = 640,
   height = 360
 ) => {
@@ -143,7 +143,7 @@ export const image = (
 };
 
 export const squareImage = (
-  contentUrl = 'https://images.prismic.io/wellcomecollection/e0d9c99ab840cbb76e1981ed453c57f4b5d02a65_reading-room-clock.jpg?auto=compress,format',
+  contentUrl = 'https://images.prismic.io/wellcomecollection/e0d9c99ab840cbb76e1981ed453c57f4b5d02a65_reading-room-clock.jpg?auto=format',
   width = 300,
   height = 300
 ) => {
@@ -166,7 +166,7 @@ export const squareImage = (
 export const pictureImages = [
   {
     contentUrl:
-      'https://images.prismic.io/wellcomecollection/fb5b20a53897d484fde6afc612fb9563e987fd5f_tf_180516_2060224.jpg?auto=compress,format',
+      'https://images.prismic.io/wellcomecollection/fb5b20a53897d484fde6afc612fb9563e987fd5f_tf_180516_2060224.jpg?auto=format',
     width: 3200,
     height: 1500,
     alt: 'Photograph of a man and a woman looking at an exhibit in the Teeth exhibition at Wellcome Collection.',
@@ -183,7 +183,7 @@ export const pictureImages = [
   },
   {
     contentUrl:
-      'https://images.prismic.io/wellcomecollection/3ab79986b581a18eabd68602d0f27e989535e0dc_tf_180516_2060224.jpg?auto=compress,format',
+      'https://images.prismic.io/wellcomecollection/3ab79986b581a18eabd68602d0f27e989535e0dc_tf_180516_2060224.jpg?auto=format',
     width: 3200,
     height: 3200,
     alt: 'Photograph of a man and a woman looking at an exhibit in the Teeth exhibition at Wellcome Collection.',
@@ -372,7 +372,7 @@ export const event: Event = {
   hasEarlyRegistration: false,
   image: {
     contentUrl:
-      'https://images.prismic.io/wellcomecollection/a4e2a07674bb171ba0b7d7dc7dcf09f1694e13ff_sdp_20181009_0007.jpg?auto=compress,format',
+      'https://images.prismic.io/wellcomecollection/a4e2a07674bb171ba0b7d7dc7dcf09f1694e13ff_sdp_20181009_0007.jpg?auto=format',
     width: 4000,
     height: 2250,
     alt: 'Photograph showing a woman giving a talk in the Viewing Room at Wellcome Collection. She is stood at the front of the room looking at a wall mounted television screen. In the foreground are the backs of the heads of the audience.',
@@ -388,19 +388,19 @@ export const event: Event = {
     simpleCrops: {
       square: {
         contentUrl:
-          'https://images.prismic.io/wellcomecollection/318dba668b46078bd957578fa5fc3b2f9b86c5a0_sdp_20181009_0007.jpg?auto=compress,format',
+          'https://images.prismic.io/wellcomecollection/318dba668b46078bd957578fa5fc3b2f9b86c5a0_sdp_20181009_0007.jpg?auto=format',
         width: 3200,
         height: 3200,
       },
       '32:15': {
         contentUrl:
-          'https://images.prismic.io/wellcomecollection/7b01a0b1273b96cfeb8a5c37e812bd83fe96f537_sdp_20181009_0007.jpg?auto=compress,format',
+          'https://images.prismic.io/wellcomecollection/7b01a0b1273b96cfeb8a5c37e812bd83fe96f537_sdp_20181009_0007.jpg?auto=format',
         width: 3200,
         height: 1500,
       },
       '16:9': {
         contentUrl:
-          'https://images.prismic.io/wellcomecollection/1689f6e5ead8d3a228d802256213e0998b15b7a2_sdp_20181009_0007.jpg?auto=compress,format',
+          'https://images.prismic.io/wellcomecollection/1689f6e5ead8d3a228d802256213e0998b15b7a2_sdp_20181009_0007.jpg?auto=format',
         width: 3200,
         height: 1800,
       },
@@ -449,7 +449,7 @@ export const event: Event = {
       'Come and hear Dr Emma Spary discuss her research on the often- overlooked role of priests in the history of pharmacy.',
     image: {
       contentUrl:
-        'https://images.prismic.io/wellcomecollection/1689f6e5ead8d3a228d802256213e0998b15b7a2_sdp_20181009_0007.jpg?auto=compress,format',
+        'https://images.prismic.io/wellcomecollection/1689f6e5ead8d3a228d802256213e0998b15b7a2_sdp_20181009_0007.jpg?auto=format',
       width: 3200,
       height: 1800,
       alt: 'Photograph showing a woman giving a talk in the Viewing Room at Wellcome Collection. She is stood at the front of the room looking at a wall mounted television screen. In the foreground are the backs of the heads of the audience.',
@@ -578,7 +578,7 @@ export const article: Article = {
         name: 'Weewaaz',
         image: {
           contentUrl:
-            'https://images.prismic.io/wellcomecollection/8689f8f1-b106-46bb-84d7-97e5bce33ed3_weewaaz.png?auto=compress,format&rect=0,0,538,538&w=3200&h=3200',
+            'https://images.prismic.io/wellcomecollection/8689f8f1-b106-46bb-84d7-97e5bce33ed3_weewaaz.png?auto=format&rect=0,0,538,538&w=3200&h=3200',
           width: 3200,
           height: 3200,
           alt: 'Weewaaz',
@@ -615,7 +615,7 @@ export const article: Article = {
           {
             image: {
               contentUrl:
-                'https://images.prismic.io/wellcomecollection/3628f5ec-3218-4757-a76d-a7b58dd89b6c_darkcloud.png?auto=compress,format',
+                'https://images.prismic.io/wellcomecollection/3628f5ec-3218-4757-a76d-a7b58dd89b6c_darkcloud.png?auto=format',
               width: 6000,
               height: 6000,
               alt: 'A cartoon figure has a dark cloud wrapped around them. Both have a solemn look on their face.The accompanying text reads ‘There’s a dark cloud following me’. ',
@@ -625,19 +625,19 @@ export const article: Article = {
               simpleCrops: {
                 '32:15': {
                   contentUrl:
-                    'https://images.prismic.io/wellcomecollection/3628f5ec-3218-4757-a76d-a7b58dd89b6c_darkcloud.png?auto=compress,format&rect=0,1594,6000,2813&w=3200&h=1500',
+                    'https://images.prismic.io/wellcomecollection/3628f5ec-3218-4757-a76d-a7b58dd89b6c_darkcloud.png?auto=format&rect=0,1594,6000,2813&w=3200&h=1500',
                   width: 3200,
                   height: 1500,
                 },
                 '16:9': {
                   contentUrl:
-                    'https://images.prismic.io/wellcomecollection/3628f5ec-3218-4757-a76d-a7b58dd89b6c_darkcloud.png?auto=compress,format&rect=0,1313,6000,3375&w=3200&h=1800',
+                    'https://images.prismic.io/wellcomecollection/3628f5ec-3218-4757-a76d-a7b58dd89b6c_darkcloud.png?auto=format&rect=0,1313,6000,3375&w=3200&h=1800',
                   width: 3200,
                   height: 1800,
                 },
                 square: {
                   contentUrl:
-                    'https://images.prismic.io/wellcomecollection/3628f5ec-3218-4757-a76d-a7b58dd89b6c_darkcloud.png?auto=compress,format&rect=0,0,6000,6000&w=3200&h=3200',
+                    'https://images.prismic.io/wellcomecollection/3628f5ec-3218-4757-a76d-a7b58dd89b6c_darkcloud.png?auto=format&rect=0,0,6000,6000&w=3200&h=3200',
                   width: 3200,
                   height: 3200,
                 },
@@ -654,7 +654,7 @@ export const article: Article = {
     caption: 'Do you have any dark clouds following you?',
     image: {
       contentUrl:
-        'https://images.prismic.io/wellcomecollection/0b1e482a-fc92-4345-afd2-01bce69424fc_darkcloud_promo.png?auto=compress,format&rect=0,0,1600,900&w=3200&h=1800',
+        'https://images.prismic.io/wellcomecollection/0b1e482a-fc92-4345-afd2-01bce69424fc_darkcloud_promo.png?auto=format&rect=0,0,1600,900&w=3200&h=1800',
       width: 3200,
       height: 1800,
       alt: 'A cartoon figure has a dark cloud wrapped around them. Both have a solemn look on their face.',
@@ -666,7 +666,7 @@ export const article: Article = {
   },
   image: {
     contentUrl:
-      'https://images.prismic.io/wellcomecollection/0b1e482a-fc92-4345-afd2-01bce69424fc_darkcloud_promo.png?auto=compress,format',
+      'https://images.prismic.io/wellcomecollection/0b1e482a-fc92-4345-afd2-01bce69424fc_darkcloud_promo.png?auto=format',
     width: 1600,
     height: 900,
     alt: 'A cartoon figure has a dark cloud wrapped around them. Both have a solemn look on their face.',
@@ -676,19 +676,19 @@ export const article: Article = {
     simpleCrops: {
       '32:15': {
         contentUrl:
-          'https://images.prismic.io/wellcomecollection/0b1e482a-fc92-4345-afd2-01bce69424fc_darkcloud_promo.png?auto=compress,format&rect=0,75,1600,750&w=3200&h=1500',
+          'https://images.prismic.io/wellcomecollection/0b1e482a-fc92-4345-afd2-01bce69424fc_darkcloud_promo.png?auto=format&rect=0,75,1600,750&w=3200&h=1500',
         width: 3200,
         height: 1500,
       },
       '16:9': {
         contentUrl:
-          'https://images.prismic.io/wellcomecollection/0b1e482a-fc92-4345-afd2-01bce69424fc_darkcloud_promo.png?auto=compress,format&rect=0,0,1600,900&w=3200&h=1800',
+          'https://images.prismic.io/wellcomecollection/0b1e482a-fc92-4345-afd2-01bce69424fc_darkcloud_promo.png?auto=format&rect=0,0,1600,900&w=3200&h=1800',
         width: 3200,
         height: 1800,
       },
       square: {
         contentUrl:
-          'https://images.prismic.io/wellcomecollection/0b1e482a-fc92-4345-afd2-01bce69424fc_darkcloud_promo.png?auto=compress,format&rect=350,0,900,900&w=3200&h=3200',
+          'https://images.prismic.io/wellcomecollection/0b1e482a-fc92-4345-afd2-01bce69424fc_darkcloud_promo.png?auto=format&rect=350,0,900,900&w=3200&h=3200',
         width: 3200,
         height: 3200,
       },
@@ -722,7 +722,7 @@ export const article: Article = {
             name: 'Weewaaz',
             image: {
               contentUrl:
-                'https://images.prismic.io/wellcomecollection/8689f8f1-b106-46bb-84d7-97e5bce33ed3_weewaaz.png?auto=compress,format&rect=0,0,538,538&w=3200&h=3200',
+                'https://images.prismic.io/wellcomecollection/8689f8f1-b106-46bb-84d7-97e5bce33ed3_weewaaz.png?auto=format&rect=0,0,538,538&w=3200&h=3200',
               width: 3200,
               height: 3200,
               alt: 'Weewaaz',
@@ -753,7 +753,7 @@ export const article: Article = {
         caption: '',
         image: {
           contentUrl:
-            'https://images.prismic.io/wellcomecollection/2e78d491-8a35-45fd-8e57-497f50e6273d_promo_main.png?auto=compress,format&rect=0,0,1600,900&w=3200&h=1800',
+            'https://images.prismic.io/wellcomecollection/2e78d491-8a35-45fd-8e57-497f50e6273d_promo_main.png?auto=format&rect=0,0,1600,900&w=3200&h=1800',
           width: 3200,
           height: 1800,
           alt: 'Person holding a large red love heart, smiling.',
@@ -765,7 +765,7 @@ export const article: Article = {
       },
       image: {
         contentUrl:
-          'https://images.prismic.io/wellcomecollection/2e78d491-8a35-45fd-8e57-497f50e6273d_promo_main.png?auto=compress,format',
+          'https://images.prismic.io/wellcomecollection/2e78d491-8a35-45fd-8e57-497f50e6273d_promo_main.png?auto=format',
         width: 1600,
         height: 900,
         alt: 'Person holding a large red love heart, smiling.',
@@ -775,19 +775,19 @@ export const article: Article = {
         simpleCrops: {
           '32:15': {
             contentUrl:
-              'https://images.prismic.io/wellcomecollection/2e78d491-8a35-45fd-8e57-497f50e6273d_promo_main.png?auto=compress,format&rect=0,75,1600,750&w=3200&h=1500',
+              'https://images.prismic.io/wellcomecollection/2e78d491-8a35-45fd-8e57-497f50e6273d_promo_main.png?auto=format&rect=0,75,1600,750&w=3200&h=1500',
             width: 3200,
             height: 1500,
           },
           '16:9': {
             contentUrl:
-              'https://images.prismic.io/wellcomecollection/2e78d491-8a35-45fd-8e57-497f50e6273d_promo_main.png?auto=compress,format&rect=0,0,1600,900&w=3200&h=1800',
+              'https://images.prismic.io/wellcomecollection/2e78d491-8a35-45fd-8e57-497f50e6273d_promo_main.png?auto=format&rect=0,0,1600,900&w=3200&h=1800',
             width: 3200,
             height: 1800,
           },
           square: {
             contentUrl:
-              'https://images.prismic.io/wellcomecollection/2e78d491-8a35-45fd-8e57-497f50e6273d_promo_main.png?auto=compress,format&rect=350,0,900,900&w=3200&h=3200',
+              'https://images.prismic.io/wellcomecollection/2e78d491-8a35-45fd-8e57-497f50e6273d_promo_main.png?auto=format&rect=350,0,900,900&w=3200&h=3200',
             width: 3200,
             height: 3200,
           },


### PR DESCRIPTION
[We wondered if the `compress` attribute is non-deterministic](https://github.com/wellcomecollection/wellcomecollection.org/issues/10692#issuecomment-1997170460) generating slightly different images each time which in turn causes Chromatic to flag a diff.

Removing the compress attribute from the images we're using as mocks in Storybook to see if this helps.