### PR TITLE
Re-add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,42 +13,25 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"] # Ignore all patch updates for version updates only
     groups:
-      all:
+      version-update: # Group updates by type
         patterns: ["*"]
+    applies-to:
+      - version-updates
   - package-ecosystem: "npm"
-    directory: "/content/webapp"
+    directory: "/"
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
     groups:
-      all:
+      security-update:
         patterns: ["*"]
-  - package-ecosystem: "npm"
-    directory: "/identity/webapp"
-    schedule:
-      interval: "weekly"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
-    groups:
-      all:
-        patterns: ["*"]
-  - package-ecosystem: "npm"
-    directory: "/common"
-    schedule:
-      interval: "weekly"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
-    groups:
-      all:
-        patterns: ["*"]
+    applies-to:
+      - security-updates
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'weekly'
     groups:
-      all:
+      version-update: # Group updates by type
         patterns: ["*"]
+    applies-to:
+      - version-updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,25 +13,12 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"] # Ignore all patch updates for version updates only
     groups:
-      version-update: # Group updates by type
+      all:
         patterns: ["*"]
-    applies-to:
-      - version-updates
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    groups:
-      security-update:
-        patterns: ["*"]
-    applies-to:
-      - security-updates
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'weekly'
     groups:
-      version-update: # Group updates by type
+      all: 
         patterns: ["*"]
-    applies-to:
-      - version-updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,54 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly" # Check for updates every month
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"] # Ignore all patch updates for version updates only
+    groups:
+      all:
+        patterns: ["*"]
+  - package-ecosystem: "npm"
+    directory: "/content/webapp"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+    groups:
+      all:
+        patterns: ["*"]
+  - package-ecosystem: "npm"
+    directory: "/identity/webapp"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+    groups:
+      all:
+        patterns: ["*"]
+  - package-ecosystem: "npm"
+    directory: "/common"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+    groups:
+      all:
+        patterns: ["*"]
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    groups:
+      all:
+        patterns: ["*"]


### PR DESCRIPTION
## Who is this for?

This change is for developers who want to keep their application up to date and pay attention to necessary security updates.

## What is it doing for them?

This change re-adds Dependabot configuration, but introduces [grouping](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) so that like updates are grouped together in single PR to make them easier to deal with.