### PR TITLE
Change condition for "throughout our building"

### DIFF
--- a/content/webapp/components/EventPromo/EventPromo.test.tsx
+++ b/content/webapp/components/EventPromo/EventPromo.test.tsx
@@ -61,11 +61,11 @@ describe('getLocationText', () => {
     expect(locationText).toEqual('Reading Room');
   });
 
-  it('returns "In our building" given one physical location which has the name "Throughout the building"', () => {
+  it('returns "In our building" given one physical location which has the name "Throughout our building"', () => {
     const locationText = getLocationText(false, [
       {
         ...location,
-        title: 'Throughout the building',
+        title: 'Throughout our building',
       },
     ]);
     expect(locationText).toEqual('In our building');

--- a/content/webapp/components/EventPromo/EventPromo.tsx
+++ b/content/webapp/components/EventPromo/EventPromo.tsx
@@ -41,11 +41,11 @@ export function getLocationText(
   // * If an event is only in venue, in multiple locations, we display 'In our building'
   // * If an event is only online, we display 'Online'
   // * If an event is online and in venue, we display 'Online | In our building'
-  // * If an event has a single Prismic location, 'Throughout the building', we display 'In our building'
+  // * If an event has a single Prismic location, 'Throughout our building', we display 'In our building'
   //   This is how the editorial team used to do multi-location events before we added proper support
   //   for multiple locations.
   if (!isOnline && isNotUndefined(places) && places.length === 1) {
-    return places[0].title === 'Throughout the building'
+    return places[0].title === 'Throughout our building'
       ? inOurBuilding
       : places[0].title;
   }


### PR DESCRIPTION
## Who is this for?
General tidy

## What is it doing for them?
I was rereading [the rules for location](https://github.com/wellcomecollection/wellcomecollection.org/blob/main/content/webapp/components/EventPromo/EventPromo.tsx#L35) because of https://github.com/wellcomecollection/content-api/issues/103 and noticed that actually, "Throughout our building" would still show up even though the last rule says:
> If an event has a single Prismic location, 'Throughout the building', we display 'In our building'

<img width="398" alt="Screenshot 2024-03-18 at 16 30 48" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/d3b0943d-1597-4123-bac4-49724e2285cd">

I went into Prismic and actually that `Place` ([those places](https://wellcomecollection.prismic.io/documents/working?k=places&s=throughout&l=en-gb)) is now called "Throughout **our** building" and has been for at least two years. It _used to be_ "Throughout **the** building" but we can see in Prismic history that was changed. As the test was just testing `getLocationText` and therefore did not use real data and was passing, so it wasn't caught.

We could add it as real data test so it gets caught if it gets changed in Prismic again? Maybe as an e2e on events search?