### PR TITLE
Add list-item as an option for TextAnd slices

### DIFF
--- a/prismic-model/src/parts/bodies/visual-story-body.ts
+++ b/prismic-model/src/parts/bodies/visual-story-body.ts
@@ -47,7 +47,9 @@ export default {
       textAndImage: slice('Text and image', {
         description: 'Side-by-side',
         nonRepeat: {
-          text: multiLineText('Text', { extraTextOptions: ['heading3'] }),
+          text: multiLineText('Text', {
+            extraTextOptions: ['heading3', 'list-item'],
+          }),
           image: {
             type: 'Image',
             config: {

--- a/prismic-model/src/parts/text-and-icons.ts
+++ b/prismic-model/src/parts/text-and-icons.ts
@@ -5,7 +5,9 @@ export const textAndIconsSlice = () => {
   return slice('Text and icons', {
     description: 'Side-by-side',
     nonRepeat: {
-      text: multiLineText('Text', { extraTextOptions: ['heading3'] }),
+      text: multiLineText('Text', {
+        extraTextOptions: ['heading3', 'list-item'],
+      }),
     },
     repeat: {
       icon: {


### PR DESCRIPTION
## Who is this for?
Relates to #10750, see [Slack convo ](https://wellcome.slack.com/archives/CUA669WHH/p1710853645244199)

## What is it doing for them?
Adds list-items to the WYSIWYG in Text and Icons and Text and Image