### PR TITLE
Style Civic UK banner and Manage Cookies button

### DIFF
--- a/common/views/components/CivicUK/index.tsx
+++ b/common/views/components/CivicUK/index.tsx
@@ -23,8 +23,9 @@ const branding = {
   acceptText: theme.color('black'),
   acceptBackground: theme.color('yellow'),
   rejectText: theme.color('black'),
-  toggleColor: theme.color('black'),
+  toggleColor: '#0055cc',
   toggleBackground: theme.color('neutral.300'),
+  toggleText: theme.color('black'),
 };
 
 const text = {

--- a/common/views/components/CivicUK/index.tsx
+++ b/common/views/components/CivicUK/index.tsx
@@ -10,8 +10,6 @@ const notifyTitleStyles = `
   style="display: block; margin: ${theme.spacingUnits['4']}px 0;"
 `;
 
-// Notes for designing chat
-// Toggle can't change border color, has to be same as background-color
 const branding = {
   removeIcon: true,
   removeAbout: true,

--- a/common/views/components/CivicUK/index.tsx
+++ b/common/views/components/CivicUK/index.tsx
@@ -2,15 +2,22 @@ import cookies from '@weco/common/data/cookies';
 import theme from '@weco/common/views/themes/default';
 import { font } from '@weco/common/utils/classnames';
 
+const headingStyles =
+  'style="font-weight: 500; font-family: Inter, sans-serif;"';
+
+const notifyTitleStyles = `
+  class="${font('intm', 3)}"
+  style="display: block; margin: ${theme.spacingUnits['4']}px 0;"
+`;
+
 // Notes for designing chat
-// font-size-headers won't be responsive, but it's the only way otherwise it gets overwritten
-// Only one background color can be set for accept button (same in notify and popup)
 // Toggle can't change border color, has to be same as background-color
 const branding = {
   removeIcon: true,
   removeAbout: true,
   fontFamily: 'Inter, sans-serif',
-  fontSizeHeaders: '20px',
+  fontSize: '0.9375rem',
+  fontSizeHeaders: '1.175rem',
   fontColor: theme.color('black'),
   backgroundColor: theme.color('warmNeutral.200'),
   acceptText: theme.color('black'),
@@ -20,16 +27,14 @@ const branding = {
   toggleBackground: theme.color('neutral.300'),
 };
 
-// Notes for designing chat
-// Notify title font-size is being overwritten
 const text = {
-  title: `<h1 class="${font('intb', 2)}">Manage cookies</h1>`,
+  title: `<h1 class="${font('intm', 2)}">Manage cookies</h1>`,
   intro:
     "We use cookies to make our website work. To help us make our marketing and website better, we'd like your consent to use cookies on behalf of third parties too.",
-  necessaryTitle: 'Essential cookies',
+  necessaryTitle: `<h2 ${headingStyles}>Essential cookies</h2>`,
   necessaryDescription:
     'These cookies are necessary for our website to function and therefore always need to be on.',
-  notifyTitle: 'Our website uses cookies',
+  notifyTitle: `<span ${notifyTitleStyles}>Our website uses cookies</span>`,
   notifyDescription:
     "We use cookies to make our website work. To help us make our marketing and website better, we'd like your consent to use cookies on behalf of third parties too.",
   closeLabel: 'Save and close',
@@ -43,11 +48,12 @@ const text = {
 // Should your privacy policy change after a user gives consent,
 // Cookie Control will invalidate prior records of consent and seek the user's preferences using the latest information available.
 // https://www.civicuk.com/cookie-control/documentation/cookies
+// TODO change URL and Updated as part of https://github.com/wellcomecollection/wellcomecollection.org/issues/10706
 const statement = {
   description: 'You can read more about how we use cookies in our',
   name: 'Privacy policy',
-  url: 'https://wellcome.org/who-we-are/privacy-and-terms', // TODO https://github.com/wellcomecollection/wellcomecollection.org/issues/10706
-  updated: '25/05/2018', // TODO as part of https://github.com/wellcomecollection/wellcomecollection.org/issues/10706
+  url: 'https://wellcome.org/who-we-are/privacy-and-terms',
+  updated: '25/05/2018',
 };
 
 // Define all necessary cookies here and document their usage a little.
@@ -95,7 +101,7 @@ const CivicUK = (props: Props) => (
             optionalCookies: [
               {
                 name: 'analytics',
-                label: 'Measure website use',
+                label: '<h2 ${headingStyles}>Measure website use</h2>',
                 description:
                   '<ul><li>We use these cookies to recognise you, to count your visits to the website, and to see how you move around it.</li><li>They help us to provide you with a good experience while you browse, for example by helping to make sure you can find what you need.</li><li>They also allows us to improve the way the website works.</li></ul>',
                 cookies: [

--- a/common/views/components/CivicUK/index.tsx
+++ b/common/views/components/CivicUK/index.tsx
@@ -37,7 +37,7 @@ const text = {
   notifyTitle: `<span ${notifyTitleStyles}>Our website uses cookies</span>`,
   notifyDescription:
     "We use cookies to make our website work. To help us make our marketing and website better, we'd like your consent to use cookies on behalf of third parties too.",
-  closeLabel: 'Save and close',
+  closeLabel: '<span style="font-weight: normal;">Save and close</span>',
   settings: 'Manage cookies',
   accept: 'Accept all',
   acceptSettings: 'Accept all',

--- a/common/views/components/CivicUK/index.tsx
+++ b/common/views/components/CivicUK/index.tsx
@@ -1,14 +1,31 @@
 import cookies from '@weco/common/data/cookies';
+import theme from '@weco/common/views/themes/default';
+import { font } from '@weco/common/utils/classnames';
 
+// Notes for designing chat
+// font-size-headers won't be responsive, but it's the only way otherwise it gets overwritten
+// Only one background color can be set for accept button (same in notify and popup)
+// Toggle can't change border color, has to be same as background-color
 const branding = {
   removeIcon: true,
   removeAbout: true,
   fontFamily: 'Inter, sans-serif',
+  fontSizeHeaders: '20px',
+  fontColor: theme.color('black'),
+  backgroundColor: theme.color('warmNeutral.200'),
+  acceptText: theme.color('black'),
+  acceptBackground: theme.color('yellow'),
+  rejectText: theme.color('black'),
+  toggleColor: theme.color('black'),
+  toggleBackground: theme.color('neutral.300'),
 };
 
+// Notes for designing chat
+// Notify title font-size is being overwritten
 const text = {
-  title: 'Manage cookies',
-  intro: '',
+  title: `<h1 class="${font('intb', 2)}">Manage cookies</h1>`,
+  intro:
+    "We use cookies to make our website work. To help us make our marketing and website better, we'd like your consent to use cookies on behalf of third parties too.",
   necessaryTitle: 'Essential cookies',
   necessaryDescription:
     'These cookies are necessary for our website to function and therefore always need to be on.',
@@ -27,11 +44,10 @@ const text = {
 // Cookie Control will invalidate prior records of consent and seek the user's preferences using the latest information available.
 // https://www.civicuk.com/cookie-control/documentation/cookies
 const statement = {
-  description:
-    "We use cookies to make our website work. To help us make our marketing and website better, we'd like your consent to use cookies on behalf of third parties too.",
-  name: 'Find out more in our privacy policy',
-  url: 'https://wellcome.org/who-we-are/privacy-and-terms',
-  updated: '25/05/2018',
+  description: 'You can read more about how we use cookies in our',
+  name: 'Privacy policy',
+  url: 'https://wellcome.org/who-we-are/privacy-and-terms', // TODO https://github.com/wellcomecollection/wellcomecollection.org/issues/10706
+  updated: '25/05/2018', // TODO as part of https://github.com/wellcomecollection/wellcomecollection.org/issues/10706
 };
 
 // Define all necessary cookies here and document their usage a little.
@@ -46,7 +62,10 @@ const necessaryCookies = () => {
   // See @weco/toggles/webapp/toggles for details on each
   const featureFlags = ['toggle_*'];
 
-  return [...wcCookies, ...prismicPreview, ...featureFlags];
+  // Digirati auth related
+  const digiratiCookies = ['dlcs-*'];
+
+  return [...wcCookies, ...prismicPreview, ...featureFlags, ...digiratiCookies];
 };
 
 type Props = {
@@ -67,6 +86,7 @@ const CivicUK = (props: Props) => (
             product: 'pro',
             initialState: 'notify',
             layout: 'popup',
+            theme: 'light',
             setInnerHTML: true,
             closeStyle: 'button',
             settingsStyle: 'button',

--- a/common/views/components/Footer/Footer.Nav.tsx
+++ b/common/views/components/Footer/Footer.Nav.tsx
@@ -105,26 +105,27 @@ const FooterNav = ({
         {itemsList.map((link, i) => {
           // ID for Javascript-less users who tried to click on the Burger menu and will get redirected here
           const isBurgerMenuLink = type === 'InternalNavigation' && i === 0;
+          const isManageCookies = link.title === 'Manage cookies';
 
-          return (
+          return cookiesWork && isManageCookies ? (
             <li key={link.title}>
-              {cookiesWork &&
-              type === 'PoliciesNavigation' &&
-              link.title === 'Manage cookies' ? (
-                <Link
-                  href={link.href}
-                  onClick={e => {
-                    e.preventDefault();
-                    window.CookieControl.open();
-                  }}
-                  style={{ display: 'block' }}
-                >
-                  {/* TODO remove trigger in GTM as well once we move everything over */}
-                  <NavLinkElement data-gtm-trigger="consent_test_btn">
-                    {link.title}
-                  </NavLinkElement>
-                </Link>
-              ) : (
+              <Link
+                href={link.href}
+                onClick={e => {
+                  e.preventDefault();
+                  window.CookieControl.open();
+                }}
+                style={{ display: 'block' }}
+              >
+                {/* TODO remove trigger in GTM as well once we move everything over */}
+                <NavLinkElement data-gtm-trigger="consent_test_btn">
+                  {link.title}
+                </NavLinkElement>
+              </Link>
+            </li>
+          ) : (
+            !isManageCookies && (
+              <li key={link.title}>
                 <NavLinkElement
                   as="a"
                   href={link.href}
@@ -133,8 +134,8 @@ const FooterNav = ({
                 >
                   {link.title}
                 </NavLinkElement>
-              )}
-            </li>
+              </li>
+            )
           );
         })}
       </NavList>

--- a/common/views/components/Footer/Footer.Nav.tsx
+++ b/common/views/components/Footer/Footer.Nav.tsx
@@ -1,10 +1,10 @@
 import { ReactElement } from 'react';
 import styled from 'styled-components';
+import Link from 'next/link';
 import { font } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 import { NavLink, links } from '@weco/common/views/components/Header/Header';
 import { prismicPageIds } from '@weco/common/data/hardcoded-ids';
-import Buttons from '../Buttons';
 import { useToggles } from '@weco/common/server-data/Context';
 
 const NavList = styled.ul<{ $isInline?: boolean }>`
@@ -76,6 +76,10 @@ const PoliciesNavigation: NavLink[] = [
     title: 'Privacy and terms',
   },
   {
+    href: '/',
+    title: 'Manage cookies',
+  },
+  {
     href: 'https://wellcome.org/who-we-are/modern-slavery-statement',
     title: 'Modern slavery statement',
   },
@@ -104,30 +108,35 @@ const FooterNav = ({
 
           return (
             <li key={link.title}>
-              <NavLinkElement
-                as="a"
-                href={link.href}
-                data-gtm-trigger="footer_nav_link"
-                {...(isBurgerMenuLink && { id: 'footer-nav-1' })}
-              >
-                {link.title}
-              </NavLinkElement>
+              {cookiesWork &&
+              type === 'PoliciesNavigation' &&
+              link.title === 'Manage cookies' ? (
+                <Link
+                  href={link.href}
+                  onClick={e => {
+                    e.preventDefault();
+                    window.CookieControl.open();
+                  }}
+                  style={{ display: 'block' }}
+                >
+                  {/* TODO remove trigger in GTM as well once we move everything over */}
+                  <NavLinkElement data-gtm-trigger="consent_test_btn">
+                    {link.title}
+                  </NavLinkElement>
+                </Link>
+              ) : (
+                <NavLinkElement
+                  as="a"
+                  href={link.href}
+                  data-gtm-trigger="footer_nav_link"
+                  {...(isBurgerMenuLink && { id: 'footer-nav-1' })}
+                >
+                  {link.title}
+                </NavLinkElement>
+              )}
             </li>
           );
         })}
-        {/* TODO style this/change the preference centre link to something else, this is a very temporary idea/solution */}
-        {cookiesWork && type === 'InternalNavigation' && (
-          <li>
-            <Buttons
-              variant="ButtonSolid"
-              dataGtmTrigger="consent_test_btn"
-              text="Cookie preference centre"
-              clickHandler={() => {
-                window.CookieControl.open();
-              }}
-            />
-          </li>
-        )}
       </NavList>
     </nav>
   );

--- a/content/webapp/pages/guides/exhibitions/[id]/[type].tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/[type].tsx
@@ -206,7 +206,6 @@ const ExhibitionGuidePage: FunctionComponent<Props> = props => {
         isMinimalHeader: true,
       }}
       hideNewsletterPromo={true}
-      hideFooter={true}
       apiToolbarLinks={[createPrismicLink(exhibitionGuide.id)]}
       skipToContentLinks={skipToContentLinks}
     >

--- a/content/webapp/pages/guides/exhibitions/[id]/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/index.tsx
@@ -120,7 +120,6 @@ const ExhibitionGuidePage: FunctionComponent<Props> = ({
       }}
       apiToolbarLinks={[createPrismicLink(exhibitionGuide.id)]}
       hideNewsletterPromo={true}
-      hideFooter={true}
     >
       <Layout gridSizes={gridSize10(false)}>
         <SpacingSection>

--- a/content/webapp/pages/guides/exhibitions/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/index.tsx
@@ -82,7 +82,6 @@ const ExhibitionGuidesPage: FunctionComponent<Props> = props => {
         isMinimalHeader: true,
       }}
       hideNewsletterPromo={true}
-      hideFooter={true}
     >
       <SpacingSection>
         <LayoutPaginatedResults

--- a/identity/webapp/src/frontend/components/PageWrapper.tsx
+++ b/identity/webapp/src/frontend/components/PageWrapper.tsx
@@ -1,10 +1,14 @@
-import { FunctionComponent, PropsWithChildren } from 'react';
+import { FunctionComponent, PropsWithChildren, useContext } from 'react';
 import Head from 'next/head';
 import styled from 'styled-components';
 import Header from '@weco/common/views/components/Header/Header';
 import { GlobalStyle } from '@weco/common/views/themes/default';
 import useIsFontsLoaded from '@weco/common/hooks/useIsFontsLoaded';
 import Favicons from '@weco/common/views/components/Favicons/Favicons';
+import Footer from '@weco/common/views/components/Footer';
+import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
+import { usePrismicData } from '@weco/common/server-data/Context';
+import { transformCollectionVenues } from '@weco/common/services/prismic/transformers/collection-venues';
 
 const Main = styled.div`
   ${props =>
@@ -22,6 +26,10 @@ export const PageWrapper: FunctionComponent<PropsWithChildren<Props>> = ({
   title,
   children,
 }) => {
+  const { isEnhanced } = useContext(AppContext);
+  const { collectionVenues } = usePrismicData();
+  const venues = transformCollectionVenues(collectionVenues);
+
   return (
     <>
       <Head>
@@ -31,6 +39,7 @@ export const PageWrapper: FunctionComponent<PropsWithChildren<Props>> = ({
       <GlobalStyle isFontsLoaded={useIsFontsLoaded()} />
       <Header siteSection="collections" />
       <Main>{children}</Main>
+      {isEnhanced && <Footer venues={venues} />}
     </>
   );
 };


### PR DESCRIPTION
## Who is this for?
Relates to #10597, #10707 and #10714
[Designs](https://www.figma.com/proto/5bZXZ08XyU8IOgyjd9ZsGe/Cookies-update?page-id=2%3A27&type=design&node-id=2312-2634&viewport=-9008%2C-1515%2C0.5&t=OF2Vu1merfAKJ8Hc-1&scaling=min-zoom&starting-point-node-id=2312%3A2634)

## What is it doing for them?
- Adds properties to Civic UK config to try and match our designs as much as possible
- Moves Manage Cookies button to its official place in the footer
- Adds footer to Exhibition Guide pages and Identity pages; this ensures the user can control their cookie preferences from a wider array of pages. We are leaving item viewer pages footerless, though.

All of it should still be behind the toggle (except the footer being re-added, that's done for everyone)

<img width="1073" alt="Screenshot 2024-04-11 at 14 11 18" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/869cc52a-286e-48d4-8918-8f4da9955907">
<img width="740" alt="Screenshot 2024-04-11 at 14 11 23" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/7b1c0dc4-5a51-4caa-98c2-5aa50a5e1d55">
<img width="770" alt="Screenshot 2024-04-11 at 14 11 27" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/1e72624c-c849-4d4c-ad3b-b6b18ef11cdc">



