### PR TITLE
Change searchbar label based on toggle

### DIFF
--- a/common/data/microcopy.tsx
+++ b/common/data/microcopy.tsx
@@ -150,8 +150,10 @@ export const pastExhibitionsStrapline =
 
 // This is the label used in the search box, both for the
 // search in the global nav and on the categories in wc.org/search
+// TODO review this copy https://github.com/wellcomecollection/wellcomecollection.org/issues/10777
 export const searchLabelText = {
-  overview: 'Search our stories, images and catalogue', // TODO edit once we add events officially
+  overview: 'Search our stories, images and catalogue',
+  overviewToggle: 'Search our stories, images, catalogue and events',
   stories: 'Search for stories',
   images: 'Search for images',
   works: 'Search the catalogue',

--- a/common/views/components/Header/Header.tsx
+++ b/common/views/components/Header/Header.tsx
@@ -34,6 +34,7 @@ import MobileSignIn from './MobileSignIn';
 import HeaderSearch from './HeaderSearch';
 import { searchLabelText } from '@weco/common/data/microcopy';
 import { SiteSection } from '../PageLayout/PageLayout';
+import { useToggles } from '@weco/common/server-data/Context';
 
 const NoJSIconWrapper = styled.div`
   padding: 5px 8px 0;
@@ -103,6 +104,7 @@ const Header: FunctionComponent<Props> = ({
   const [searchDropdownIsActive, setSearchDropdownIsActive] = useState(false);
   const searchButtonRef = useRef<HTMLButtonElement>(null);
   const { isEnhanced } = useContext(AppContext);
+  const { eventsSearch } = useToggles();
 
   useEffect(() => {
     if (document && document.documentElement) {
@@ -185,7 +187,9 @@ const Header: FunctionComponent<Props> = ({
                               icon={searchDropdownIsActive ? cross : search}
                             />
                             <span className="visually-hidden">
-                              {searchLabelText.overview}
+                              {eventsSearch
+                                ? searchLabelText.overviewToggle
+                                : searchLabelText.overview}
                             </span>
                           </NoJSIconWrapper>
                         </NextLink>

--- a/common/views/components/SearchForm/SearchForm.tsx
+++ b/common/views/components/SearchForm/SearchForm.tsx
@@ -13,6 +13,7 @@ import {
 } from 'react';
 import SearchContext from '@weco/common/views/components/SearchContext/SearchContext';
 import { searchLabelText } from '@weco/common/data/microcopy';
+import { useToggles } from '@weco/common/server-data/Context';
 
 type SearchCategory = 'overview' | 'works';
 
@@ -41,6 +42,7 @@ const SearchForm = ({
   const router = useRouter();
   const routerQuery = getQueryPropertyValue(router?.query?.query);
   const { link: searchLink } = useContext(SearchContext);
+  const { eventsSearch } = useToggles();
   const initialValue =
     routerQuery || searchLink.as.query?.query?.toString() || '';
   const [inputValue, setInputValue] = useState(initialValue);
@@ -71,7 +73,15 @@ const SearchForm = ({
         inputValue={inputValue}
         setInputValue={setInputValue}
         form={`search-form-${searchCategory}`}
-        placeholder={searchLabelText[searchCategory]}
+        placeholder={
+          searchLabelText[
+            searchCategory !== 'overview'
+              ? searchCategory
+              : eventsSearch
+              ? 'overviewToggle'
+              : 'overview'
+          ]
+        }
         inputRef={inputRef}
         location={location}
       />

--- a/content/webapp/components/SearchPageLayout/SearchNavigation.tsx
+++ b/content/webapp/components/SearchPageLayout/SearchNavigation.tsx
@@ -121,7 +121,15 @@ const SearchNavigation: FunctionComponent<SearchNavigationProps> = ({
           <SearchBar
             inputValue={inputValue}
             setInputValue={setInputValue}
-            placeholder={searchLabelText[currentSearchCategory]}
+            placeholder={
+              searchLabelText[
+                currentSearchCategory !== 'overview'
+                  ? currentSearchCategory
+                  : eventsSearch
+                  ? 'overviewToggle'
+                  : 'overview'
+              ]
+            }
             form={SEARCH_PAGES_FORM_ID}
             location="search"
           />


### PR DESCRIPTION
## Who is this for?
Events in search work #10779 

## What is it doing for them?
Changes the copy if toggle is ON to indicate events are now searchable.
We need to amend the copy when we can though, [I've created a ticket here](https://github.com/wellcomecollection/wellcomecollection.org/pull/10771) to do that, when Lauren is back we can do that change quickly.