### PR TITLE
Events search metadata and title

### DIFF
--- a/common/data/microcopy.tsx
+++ b/common/data/microcopy.tsx
@@ -43,6 +43,7 @@ export const pageDescriptions = {
       'Search for images about health and human experience. Our collections include paintings, photogrpahs, engravings, etchings, illustrations and more.',
     works:
       'Search our collections about health and human experience. Our collections include books, manuscripts, visual materials, journals and unpublished archives.',
+    events: '',
   },
 };
 

--- a/common/data/microcopy.tsx
+++ b/common/data/microcopy.tsx
@@ -40,7 +40,7 @@ export const pageDescriptions = {
     stories:
       'Search for stories about health and human experience. Our words and pictures make connections, provoke new thinking and share lived experiences.',
     images:
-      'Search for images about health and human experience. Our collections include paintings, photogrpahs, engravings, etchings, illustrations and more.',
+      'Search for images about health and human experience. Our collections include paintings, photographs, engravings, etchings, illustrations and more.',
     works:
       'Search our collections about health and human experience. Our collections include books, manuscripts, visual materials, journals and unpublished archives.',
     events: '',

--- a/common/data/microcopy.tsx
+++ b/common/data/microcopy.tsx
@@ -43,7 +43,8 @@ export const pageDescriptions = {
       'Search for images about health and human experience. Our collections include paintings, photographs, engravings, etchings, illustrations and more.',
     works:
       'Search our collections about health and human experience. Our collections include books, manuscripts, visual materials, journals and unpublished archives.',
-    events: '',
+    events:
+      'Search for past and current events to discover our range of free tours, talks, workshops and more.',
   },
 };
 

--- a/content/webapp/components/SearchPageLayout/SearchPageLayout.tsx
+++ b/content/webapp/components/SearchPageLayout/SearchPageLayout.tsx
@@ -113,6 +113,17 @@ const SearchLayout: FunctionComponent<SearchLayoutProps> = ({
           },
         });
         break;
+      case 'events':
+        setPageLayoutMetadata({
+          ...basePageMetadata,
+          description: pageDescriptions.search.events,
+          title: `${queryStringTitle}Events search`,
+          url: {
+            ...basePageMetadata.url,
+            pathname: '/search/events',
+          },
+        });
+        break;
 
       default:
         break;


### PR DESCRIPTION
## Who is this for?
Good metadata and useful titles.

## What is it doing for them?
Just realised we skipped this part when adding this new page - Added a title and a [metadescription](https://wellcome.slack.com/archives/C3N7J05TK/p1712831942778189).
