### PR TITLE
Revert "Trial Prismic's next preview tool, part II"

### DIFF
--- a/common/koa-middleware/withCachedValues.ts
+++ b/common/koa-middleware/withCachedValues.ts
@@ -1,7 +1,11 @@
+import compose from 'koa-compose';
+import { withPrismicPreviewStatus } from './withPrismicPreviewStatus';
 import { IncomingMessage, ServerResponse } from 'http';
 import Router from 'koa-router';
 import { NextServer } from 'next/dist/server/next';
 import { parse, UrlWithParsedQuery } from 'url'; // eslint-disable-line n/no-deprecated-api
+
+export const withCachedValues = compose([withPrismicPreviewStatus]);
 
 export async function route(
   path: string,

--- a/common/koa-middleware/withPrismicPreviewStatus.ts
+++ b/common/koa-middleware/withPrismicPreviewStatus.ts
@@ -1,0 +1,27 @@
+import Koa from 'koa';
+
+export function withPrismicPreviewStatus(
+  ctx: Koa.DefaultContext,
+  next: Koa.Next
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+): Promise<any> {
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+
+  // for previews on localhost we use /preview to determine whether the 'isPreview' cookie should be set
+  // this kinda works for live too, but not for shared preview links, as they never hit /preview
+  // we therefore look for the subdomain .preview to determine if it's a preview
+  const previewCookieName = 'isPreview';
+  const isPreviewDomain = Boolean(ctx.request.host.startsWith('preview.'));
+  const previewCookieMatch = ctx.headers.cookie
+    ? ctx.headers.cookie.match(`(^|;) ?${previewCookieName}=([^;]*)(;|$)`)
+    : undefined;
+
+  const previewCookie = previewCookieMatch ? previewCookieMatch[2] : undefined;
+
+  if (isPreviewDomain && !previewCookie) {
+    ctx.cookies.set('isPreview', 'true', {
+      httpOnly: false,
+    });
+  }
+  return next();
+}

--- a/common/views/components/CivicUK/index.tsx
+++ b/common/views/components/CivicUK/index.tsx
@@ -41,7 +41,7 @@ const necessaryCookies = () => {
   const wcCookies = Object.values(cookies).map(c => c);
 
   // Allows Prismic previews
-  const prismicPreview = ['io.prismic.preview'];
+  const prismicPreview = ['io.prismic.preview', 'isPreview'];
 
   // See @weco/toggles/webapp/toggles for details on each
   const featureFlags = ['toggle_*'];

--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -2,7 +2,6 @@ import { NextPage } from 'next';
 import { AppProps } from 'next/app';
 import React, { useEffect, FunctionComponent, ReactElement } from 'react';
 import { ThemeProvider } from 'styled-components';
-import { PrismicPreview } from '@prismicio/next';
 import theme, { GlobalStyle } from '@weco/common/views/themes/default';
 import LoadingIndicator from '@weco/common/views/components/LoadingIndicator/LoadingIndicator';
 import { AppContextProvider } from '@weco/common/views/components/AppContext/AppContext';
@@ -21,6 +20,7 @@ import { ServerDataContext } from '@weco/common/server-data/Context';
 import UserProvider from '@weco/common/views/components/UserProvider/UserProvider';
 import { ApmContextProvider } from '@weco/common/views/components/ApmContext/ApmContext';
 import { AppErrorProps } from '@weco/common/services/app';
+import usePrismicPreview from '@weco/common/services/app/usePrismicPreview';
 import useMaintainPageHeight from '@weco/common/services/app/useMaintainPageHeight';
 import { GaDimensions } from '@weco/common/services/app/google-analytics';
 import { deserialiseProps } from '@weco/common/utils/json';
@@ -126,6 +126,8 @@ const WecoApp: FunctionComponent<WecoAppProps> = ({
   // or when requested client-side through next/link or next/router
   // i.e. everything that we consider to be a page view
 
+  usePrismicPreview(() => Boolean(document.cookie.match('isPreview=true')));
+
   const getLayout = Component.getLayout || (page => <>{page}</>);
 
   return (
@@ -155,8 +157,6 @@ const WecoApp: FunctionComponent<WecoAppProps> = ({
                       title={pageProps.err.message}
                     />
                   )}
-
-                  <PrismicPreview repositoryName="wellcomecollection" />
                 </ThemeProvider>
               </SearchContextProvider>
             </AppContextProvider>

--- a/content/webapp/app.ts
+++ b/content/webapp/app.ts
@@ -6,7 +6,10 @@ import Router from 'koa-router';
 import next from 'next';
 import { apmErrorMiddleware } from '@weco/common/services/apm/errorMiddleware';
 import { init as initServerData } from '@weco/common/server-data';
-import { handleAllRoute } from '@weco/common/koa-middleware/withCachedValues';
+import {
+  withCachedValues,
+  handleAllRoute,
+} from '@weco/common/koa-middleware/withCachedValues';
 import linkResolver from '@weco/common/services/prismic/link-resolver';
 import { createClient as createPrismicClient } from '@weco/common/services/prismic/fetch';
 import * as prismic from '@prismicio/client';
@@ -41,6 +44,7 @@ const appPromise = nextApp
     });
 
     koaApp.use(apmErrorMiddleware);
+    koaApp.use(withCachedValues);
 
     // Add a naive healthcheck endpoint for the load balancer
     router.get('/management/healthcheck', async ctx => {
@@ -66,6 +70,10 @@ const appPromise = nextApp
       const url = await client.resolvePreviewURL({
         linkResolver: retypedLinkResolver,
         defaultURL: '/',
+      });
+
+      ctx.cookies.set('isPreview', 'true', {
+        httpOnly: false,
       });
 
       ctx.redirect(url);


### PR DESCRIPTION
Reverts wellcomecollection/wellcomecollection.org#10740 - apologies for the amount of reverts, but we've now tested Prismic's Next Preview toolbar in _production_, and it _does_ work, but... what also happens is that the script loads for _all users_ (in order to get the shareable link to work), which causes performance issues, loads jQuery for all and flags an a11y miss in pa11y (no title on the iframe element). [Having read through an issue that was raised 5 years ago,](https://github.com/prismicio/prismic-toolbar/issues/43) it's been a thing for a long time and it doesn't look like it'll be fixed any time soon, so we've decided to revert back to our previous solution.
[Slack chat here for decision making](https://wellcome.slack.com/archives/CUA669WHH/p1712828009443009) and [here for how we detected the issue](https://wellcome.slack.com/archives/C3TQSF63C/p1712823034496939) (pa11y!).
