### PR TITLE
Make gaDimensions available in the dataLayer

### DIFF
--- a/common/services/conversion/track.ts
+++ b/common/services/conversion/track.ts
@@ -155,6 +155,12 @@ function track(conversion: Conversion) {
     });
   }
 
+  const dimensions = conversion.properties?.dimensions;
+
+  if (dimensions) {
+    window.dataLayer?.push({ dimensions });
+  }
+
   window.analytics.track(eventGroup, {
     session,
     properties: { ...properties, toggles },

--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -116,7 +116,10 @@ const WecoApp: FunctionComponent<WecoAppProps> = ({
     if (pageProps.pageview) {
       trackPageview({
         name: pageProps.pageview.name,
-        properties: pageProps.pageview.properties,
+        properties: {
+          ...pageProps.pageview.properties,
+          dimensions: pageProps.gaDimensions,
+        },
         eventGroup: pageProps.pageview.eventGroup,
       });
     }


### PR DESCRIPTION
## Who is this for?
Data analysts

## What is it doing for them?
Adding custom dimension information into the dataLayer

This was information that we had access to before we moved to GA4. Seems like we no longer sent it anywhere after the switch over.

This was specifically for getting the `partOf` information (e.g. when an article is part of a series). The change also required a change in how we query that information in GTM.

@taceybadgerbrook when this goes in you should be able to see an array of ids indicating which (if any) series an article is part of