### PR TITLE
Fix errors in Table component and tidy

### DIFF
--- a/cardigan/.storybook/preview.js
+++ b/cardigan/.storybook/preview.js
@@ -1,6 +1,6 @@
 import { default as React } from 'react';
 import { RouterContext } from 'next/dist/shared/lib/router-context';
-import { DocsContainer } from '@storybook/addon-docs/blocks';
+import { DocsContainer } from '@storybook/addon-docs';
 import theme from '@weco/common/views/themes/default';
 import { ContextDecorator } from '@weco/cardigan/config/decorators';
 import wellcomeTheme from './wellcome-theme';

--- a/cardigan/stories/components/ArchiveTree/ArchiveTree.stories.mdx
+++ b/cardigan/stories/components/ArchiveTree/ArchiveTree.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Canvas, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/addon-docs';
 import * as stories from './ArchiveTree.stories.tsx';
 import ArchiveTree from '@weco/content/components/ArchiveTree';
 
@@ -6,7 +6,6 @@ import ArchiveTree from '@weco/content/components/ArchiveTree';
 
 # ArchiveTree
 
-{' '}
 <Story story={stories.basic} />
 
 <ArgsTable />

--- a/cardigan/stories/components/AudioPlayer/AudioPlayer.stories.mdx
+++ b/cardigan/stories/components/AudioPlayer/AudioPlayer.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import AudioPlayer from '@weco/content/components/AudioPlayer/AudioPlayer';
 import Readme from '@weco/content/components/AudioPlayer/README.md';
 import * as stories from './AudioPlayer.stories.tsx';

--- a/cardigan/stories/components/BackToResults/BackToResults.stories.mdx
+++ b/cardigan/stories/components/BackToResults/BackToResults.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import BackToResults from '@weco/content/components/BackToResults/BackToResults';
 import Readme from '@weco/content/components/BackToResults/README.md';
 import * as stories from './BackToResults.stories.tsx';
@@ -9,7 +9,6 @@ import * as stories from './BackToResults.stories.tsx';
 
 <Readme />
 
-{' '}
 <Story story={stories.basic} />
 
 <ArgsTable />

--- a/cardigan/stories/components/BetaMessage/BetaMessage.stories.mdx
+++ b/cardigan/stories/components/BetaMessage/BetaMessage.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import BetaMessage from '@weco/content/components/BetaMessage/BetaMessage';
 import * as stories from './BetaMessage.stories.tsx';
 

--- a/cardigan/stories/components/Body/Body.stories.mdx
+++ b/cardigan/stories/components/Body/Body.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import Body from '@weco/content/components/Body/Body';
 import * as stories from './Body.stories.tsx';
 

--- a/cardigan/stories/components/BookPromo/BookPromo.stories.mdx
+++ b/cardigan/stories/components/BookPromo/BookPromo.stories.mdx
@@ -1,5 +1,5 @@
 import BookPromo from '@weco/content/components/BookPromo/BookPromo';
-import { Meta, Canvas, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/addon-docs';
 import * as stories from './BookPromo.stories.tsx';
 
 <Meta title={`Components/BookPromo`} component={BookPromo} />

--- a/cardigan/stories/components/Breadcrumb/Breadcrumb.stories.mdx
+++ b/cardigan/stories/components/Breadcrumb/Breadcrumb.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import Breadcrumb from '@weco/common/views/components/Breadcrumb/Breadcrumb';
 import * as stories from './Breadcrumb.stories.tsx';
 

--- a/cardigan/stories/components/Buttons/Buttons.stories.mdx
+++ b/cardigan/stories/components/Buttons/Buttons.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story } from '@storybook/addon-docs/blocks';
+import { Meta, Story } from '@storybook/addon-docs';
 import * as stories from './Buttons.stories.tsx';
 
 <Meta title={`Components/Buttons: Basics`} />

--- a/cardigan/stories/components/ButtonsAlternates/ButtonsAlternates.stories.mdx
+++ b/cardigan/stories/components/ButtonsAlternates/ButtonsAlternates.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story } from '@storybook/addon-docs/blocks';
+import { Meta, Story } from '@storybook/addon-docs';
 import ControlReadme from '@weco/common/views/components/Control/README.md';
 import * as stories from './ButtonsAlternates.stories.tsx'
 

--- a/cardigan/stories/components/CaptionedImage/CaptionedImage.stories.mdx
+++ b/cardigan/stories/components/CaptionedImage/CaptionedImage.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import CaptionedImage from '@weco/content/components/CaptionedImage/CaptionedImage';
 import * as stories from './CaptionedImage.stories.tsx';
 

--- a/cardigan/stories/components/Cards/Cards.stories.mdx
+++ b/cardigan/stories/components/Cards/Cards.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story } from '@storybook/addon-docs/blocks';
+import { Meta, Story } from '@storybook/addon-docs';
 import FeaturedCardReadme from '@weco/content/components/FeaturedCard/README.md';
 import * as stories from './Cards.stories.tsx';
 

--- a/cardigan/stories/components/CheckboxRadio/CheckboxRadio.stories.mdx
+++ b/cardigan/stories/components/CheckboxRadio/CheckboxRadio.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import CheckboxRadio from '@weco/common/views/components/CheckboxRadio/CheckboxRadio';
 import * as stories from './CheckboxRadio.stories.tsx';
 

--- a/cardigan/stories/components/CollapsibleContent/CollapsibleContent.stories.mdx
+++ b/cardigan/stories/components/CollapsibleContent/CollapsibleContent.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import CollapsibleContent from '@weco/common/views/components/CollapsibleContent';
 import * as stories from './CollapsibleContent.stories.tsx';
 

--- a/cardigan/stories/components/Contact/Contact.stories.mdx
+++ b/cardigan/stories/components/Contact/Contact.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import Contact from '@weco/content/components/Contact/Contact';
 import Readme from '@weco/content/components/Contact/README.md';
 import * as stories from './Contact.stories.tsx';

--- a/cardigan/stories/components/Contributors/Contributors.stories.mdx
+++ b/cardigan/stories/components/Contributors/Contributors.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import Contributors from '@weco/content/components/Contributors/Contributors';
 import Readme from '@weco/content/components/Contributors/README.md';
 import * as stories from './Contributors.stories.tsx';

--- a/cardigan/stories/components/CopyButtons/CopyButtons.stories.mdx
+++ b/cardigan/stories/components/CopyButtons/CopyButtons.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import Readme from '@weco/content/components/CopyButtons/README.md';
 import * as stories from './CopyButtons.stories.tsx';
 

--- a/cardigan/stories/components/DateRange/DateRange.stories.mdx
+++ b/cardigan/stories/components/DateRange/DateRange.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import DateRange from '@weco/content/components/DateRange/DateRange';
 import * as stories from './DateRange.stories.tsx';
 

--- a/cardigan/stories/components/Divider/Divider.stories.mdx
+++ b/cardigan/stories/components/Divider/Divider.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import Divider from '@weco/common/views/components/Divider/Divider';
 import Readme from '@weco/common/views/components/Divider/README.md';
 import * as stories from './Divider.stories.tsx';

--- a/cardigan/stories/components/DownloadLink/DownloadLink.stories.mdx
+++ b/cardigan/stories/components/DownloadLink/DownloadLink.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import DownloadLink from '@weco/content/components/DownloadLink/DownloadLink';
 import * as stories from './DownloadLink.stories.tsx';
 

--- a/cardigan/stories/components/EventDateRange/EventDateRange.stories.mdx
+++ b/cardigan/stories/components/EventDateRange/EventDateRange.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import EventDateRange from '@weco/content/components/EventDateRange';
 import Readme from '@weco/content/components/EventDateRange/README.md';
 import * as stories from './EventDateRange.stories.tsx';

--- a/cardigan/stories/components/EventDatesLink/EventDatesLink.stories.mdx
+++ b/cardigan/stories/components/EventDatesLink/EventDatesLink.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import EventDatesLink from '@weco/content/components/EventDatesLink/EventDatesLink';
 import Readme from '@weco/content/components/EventDatesLink/README.md';
 import * as stories from './EventDatesLink.stories.tsx';

--- a/cardigan/stories/components/EventSchedule/EventSchedule.stories.mdx
+++ b/cardigan/stories/components/EventSchedule/EventSchedule.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import EventSchedule from '@weco/content/components/EventSchedule/EventSchedule';
 import Readme from '@weco/content/components/EventSchedule/README.md';
 import * as stories from './EventSchedule.stories.tsx';

--- a/cardigan/stories/components/ExhibitionCaptions/ExhibitionCaptions.stories.mdx
+++ b/cardigan/stories/components/ExhibitionCaptions/ExhibitionCaptions.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import ExhibitionCaptions from '@weco/content/components/ExhibitionCaptions/ExhibitionCaptions';
 import Readme from '@weco/content/components/ExhibitionCaptions/README.md';
 import * as stories from './ExhibitionCaptions.stories.tsx';

--- a/cardigan/stories/components/FeaturedText/FeaturedText.stories.mdx
+++ b/cardigan/stories/components/FeaturedText/FeaturedText.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import FeaturedText from '@weco/content/components/FeaturedText/FeaturedText';
 import Readme from '@weco/content/components/FeaturedText/README.md';
 import * as stories from './FeaturedText.stories.tsx';

--- a/cardigan/stories/components/Footer/Footer.stories.mdx
+++ b/cardigan/stories/components/Footer/Footer.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import Footer from '@weco/common/views/components/Footer';
 import Readme from '@weco/common/views/components/Footer/README.md';
 import * as stories from './Footer.stories.tsx';
@@ -8,8 +8,6 @@ import * as stories from './Footer.stories.tsx';
 # Footer
 
 <Readme />
-
-{' '}
 
 <Story story={stories.basic} inline={false} />
 

--- a/cardigan/stories/components/Header/Header.stories.mdx
+++ b/cardigan/stories/components/Header/Header.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import Header from '@weco/common/views/components/Header/Header';
 import * as stories from './Header.stories.tsx';
 

--- a/cardigan/stories/components/ImageGallery/ImageGallery.stories.mdx
+++ b/cardigan/stories/components/ImageGallery/ImageGallery.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import ImageGallery from '@weco/content/components/ImageGallery';
 import Readme from '@weco/content/components/ImageGallery/README.md';
 import * as stories from './ImageGallery.stories.tsx';

--- a/cardigan/stories/components/ImagePlaceholder/ImagePlaceholder.stories.mdx
+++ b/cardigan/stories/components/ImagePlaceholder/ImagePlaceholder.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import ImagePlaceholder from '@weco/content/components/ImagePlaceholder/ImagePlaceholder';
 import Readme from '@weco/content/components/ImagePlaceholder/README.md';
 import * as stories from './ImagePlaceholder.stories.tsx';

--- a/cardigan/stories/components/InfoBanners/InfoBanners.stories.mdx
+++ b/cardigan/stories/components/InfoBanners/InfoBanners.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import { InfoBanner } from '@weco/common/views/components/InfoBanners';
 import * as stories from './InfoBanners.stories.tsx';
 

--- a/cardigan/stories/components/InfoBlock/InfoBlock.stories.mdx
+++ b/cardigan/stories/components/InfoBlock/InfoBlock.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import InfoBlock from '@weco/content/components/InfoBlock/InfoBlock';
 import Readme from '@weco/content/components/InfoBlock/README.md';
 import * as stories from './InfoBlock.stories.tsx';
@@ -9,7 +9,6 @@ import * as stories from './InfoBlock.stories.tsx';
 
 <Readme />
 
-{' '}
 <Story story={stories.basic} />
 
 <ArgsTable />

--- a/cardigan/stories/components/InfoBox/InfoBox.stories.mdx
+++ b/cardigan/stories/components/InfoBox/InfoBox.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import InfoBox from '@weco/content/components/InfoBox/InfoBox';
 import Readme from '@weco/content/components/InfoBox/README.md';
 import * as stories from './InfoBox.stories.tsx';

--- a/cardigan/stories/components/Label/Label.stories.mdx
+++ b/cardigan/stories/components/Label/Label.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import Label from '@weco/common/views/components/Label/Label';
 import * as stories from './Label.stories.tsx';
 

--- a/cardigan/stories/components/LabelsList/LabelsList.stories.mdx
+++ b/cardigan/stories/components/LabelsList/LabelsList.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
 import * as stories from './LabelsList.stories.tsx';
 

--- a/cardigan/stories/components/LinkLabels/LinkLabels.stories.mdx
+++ b/cardigan/stories/components/LinkLabels/LinkLabels.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import LinkLabels from '@weco/content/components/LinkLabels/LinkLabels';
 import Readme from '@weco/content/components/LinkLabels/README.md';
 import * as stories from './LinkLabels.stories.tsx';
@@ -11,17 +11,14 @@ import * as stories from './LinkLabels.stories.tsx';
 
 <Description>A set of LinkLabels can appear on their own:</Description>
 
-{' '}
 <Story story={stories.basic} />
 
 <Description>They can also appear with a heading:</Description>
 
-{' '}
 <Story story={stories.withHeading} />
 
 <Description>and with an icon:</Description>
 
-{' '}
 <Story story={stories.withIcon} />
 
 <ArgsTable />

--- a/cardigan/stories/components/Map/Map.stories.mdx
+++ b/cardigan/stories/components/Map/Map.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import Map from '@weco/content/components/Map/Map';
 import * as stories from './Map.stories.tsx';
 

--- a/cardigan/stories/components/MediaObject/MediaObject.stories.mdx
+++ b/cardigan/stories/components/MediaObject/MediaObject.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import { MediaObject } from '@weco/content/components/MediaObject/MediaObject';
 import Readme from '@weco/content/components/MediaObject/README.md';
 import * as stories from './MediaObject.stories.tsx';

--- a/cardigan/stories/components/Message/Message.stories.mdx
+++ b/cardigan/stories/components/Message/Message.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import Message from '@weco/content/components/Message/Message';
 import Readme from '@weco/content/components/Message/README.md';
 import * as stories from './Message.stories.tsx';
@@ -9,7 +9,6 @@ import * as stories from './Message.stories.tsx';
 
 <Readme />
 
-{' '}
 <Story story={stories.basic} />
 
 <ArgsTable />

--- a/cardigan/stories/components/Modal/Modal.stories.mdx
+++ b/cardigan/stories/components/Modal/Modal.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import Modal from '@weco/common/views/components/Modal/Modal';
 import * as stories from './Modal.stories.tsx';
 

--- a/cardigan/stories/components/MoreLink/MoreLink.stories.mdx
+++ b/cardigan/stories/components/MoreLink/MoreLink.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import MoreLink from '@weco/content/components/MoreLink/MoreLink';
 import Readme from '@weco/content/components/MoreLink/README.md';
 import * as stories from './MoreLink.stories.tsx';
@@ -9,7 +9,6 @@ import * as stories from './MoreLink.stories.tsx';
 
 <Readme />
 
-{' '}
 <Story story={stories.basic} />
 
 <ArgsTable />

--- a/cardigan/stories/components/NewsletterPromo/NewsletterPromo.stories.mdx
+++ b/cardigan/stories/components/NewsletterPromo/NewsletterPromo.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import NewsletterPromo from '@weco/common/views/components/NewsletterPromo/NewsletterPromo';
 import * as stories from './NewsletterPromo.stories.tsx';
 

--- a/cardigan/stories/components/NewsletterSignup/NewsletterSignup.stories.mdx
+++ b/cardigan/stories/components/NewsletterSignup/NewsletterSignup.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import NewsletterSignup from '@weco/content/components/NewsletterSignup/NewsletterSignup';
 import * as stories from './NewsletterSignup.stories.tsx';
 

--- a/cardigan/stories/components/OnThisPageAnchors/OnThisPageAnchors.stories.mdx
+++ b/cardigan/stories/components/OnThisPageAnchors/OnThisPageAnchors.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import OnThisPageAnchors from '@weco/content/components/OnThisPageAnchors/OnThisPageAnchors';
 import Readme from '@weco/content/components/OnThisPageAnchors/README.md';
 import * as stories from './OnThisPageAnchors.stories.tsx';

--- a/cardigan/stories/components/PageHeader/PageHeader.stories.mdx
+++ b/cardigan/stories/components/PageHeader/PageHeader.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
 import Readme from '@weco/common/views/components/PageHeader/README.md';
 import * as stories from './PageHeader.stories.tsx';

--- a/cardigan/stories/components/Pagination/Pagination.stories.mdx
+++ b/cardigan/stories/components/Pagination/Pagination.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import Pagination from '@weco/content/components/Pagination/Pagination';
 import * as stories from './Pagination.stories.tsx';
 
@@ -11,7 +11,6 @@ import * as stories from './Pagination.stories.tsx';
   next buttons:
 </Description>
 
-{' '}
 <Story story={stories.middleOfPagination} />
 
 <Description>
@@ -19,7 +18,6 @@ import * as stories from './Pagination.stories.tsx';
   next/previous button as appropriate, for example:
 </Description>
 
-{' '}
 <Story story={stories.startOfPagination} />
 
 <ArgsTable />

--- a/cardigan/stories/components/Placeholder/Placeholder.stories.mdx
+++ b/cardigan/stories/components/Placeholder/Placeholder.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import Placeholder from '@weco/content/components/Placeholder/Placeholder';
 import Readme from '@weco/content/components/Placeholder/README.md';
 import * as stories from './Placeholder.stories.tsx';
@@ -9,7 +9,6 @@ import * as stories from './Placeholder.stories.tsx';
 
 <Readme />
 
-{' '}
 <Story story={stories.basic} />
 
 <ArgsTable />

--- a/cardigan/stories/components/PopupDialog/PopupDialog.stories.mdx
+++ b/cardigan/stories/components/PopupDialog/PopupDialog.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import PopupDialog from '@weco/common/views/components/PopupDialog/PopupDialog';
 import Readme from '@weco/common/views/components/PopupDialog/README.md';
 import * as stories from './PopupDialog.stories.tsx';
@@ -8,8 +8,6 @@ import * as stories from './PopupDialog.stories.tsx';
 # PopupDialog
 
 <Readme />
-
-{' '}
 
 <Story story={stories.basic} />
 

--- a/cardigan/stories/components/Quote/Quote.stories.mdx
+++ b/cardigan/stories/components/Quote/Quote.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import Quote from '@weco/content/components/Quote/Quote';
 import Readme from '@weco/content/components/Quote/README.md';
 import * as stories from './Quote.stories.tsx';

--- a/cardigan/stories/components/SeasonsHeader/SeasonsHeader.stories.mdx
+++ b/cardigan/stories/components/SeasonsHeader/SeasonsHeader.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import SeasonsHeader from '@weco/content/components/SeasonsHeader';
 import * as stories from './SeasonsHeader.stories.tsx';
 

--- a/cardigan/stories/components/SectionHeader/SectionHeader.stories.mdx
+++ b/cardigan/stories/components/SectionHeader/SectionHeader.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import SectionHeader from '@weco/content/components/SectionHeader/SectionHeader';
 import Readme from '@weco/content/components/SectionHeader/README.md';
 import * as stories from './SectionHeader.stories.tsx';
@@ -9,7 +9,6 @@ import * as stories from './SectionHeader.stories.tsx';
 
 <Readme />
 
-{' '}
 <Story story={stories.basic} />
 
 <ArgsTable />

--- a/cardigan/stories/components/Select/Select.stories.mdx
+++ b/cardigan/stories/components/Select/Select.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import Select from '@weco/content/components/Select';
 import * as stories from './Select.stories.tsx';
 

--- a/cardigan/stories/components/StatusIndicator/StatusIndicator.stories.mdx
+++ b/cardigan/stories/components/StatusIndicator/StatusIndicator.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import StatusIndicator from '@weco/content/components/StatusIndicator/StatusIndicator';
 import Readme from '@weco/content/components/StatusIndicator/README.md';
 import * as stories from './StatusIndicator.stories.tsx';

--- a/cardigan/stories/components/Table/Table.stories.mdx
+++ b/cardigan/stories/components/Table/Table.stories.mdx
@@ -1,19 +1,11 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
-import Table from '@weco/content/components/Table/Table';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
+import Table from '@weco/content/components/Table';
 import * as stories from './Table.stories.tsx';
 
 <Meta title={`Components/Table`} component={Table} />
 
 # Table
 
-## Column headers
-
-{' '}
-<Story story={stories.colHeaders} />
-
-## Row headers
-
-{' '}
-<Story story={stories.rowHeaders} />
+<Story story={stories.table} />
 
 <ArgsTable />

--- a/cardigan/stories/components/Table/Table.stories.tsx
+++ b/cardigan/stories/components/Table/Table.stories.tsx
@@ -1,33 +1,89 @@
-import Table from '@weco/content/components/Table/Table';
+import Table from '@weco/content/components/Table';
 
-const Template = args => <Table {...args} />;
-export const colHeaders = Template.bind({});
-colHeaders.args = {
-  caption: 'Delivery schedule',
-  hasRowHeaders: false,
-  rows: [
-    ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
-    ['09:00', '09:00', '09:00', '09:00', '09:00', '09:00'],
-    ['10:00', '10:00', '10:00', '10:00', '10:00', '10:00'],
-    ['11:00', '11:00', '11:00', '11:00', '11:00', '11:00'],
-    ['12:00', '12:00', '12:00', '12:00', '12:00', '12:00'],
-    ['13:00', '13:00', '13:00', '13:00', '13:00', '13:00'],
-    ['14:00', '14:00', '14:00', '14:00', '14:00', '14:00'],
-  ],
-};
-colHeaders.storyName = 'Column headers';
+const headerInFirstRow = [
+  ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
+  ['09:00', '09:00', '09:00', '09:00', '09:00', '09:00'],
+  ['10:00', '10:00', '10:00', '10:00', '10:00', '10:00'],
+  ['11:00', '11:00', '11:00', '11:00', '11:00', '11:00'],
+  ['12:00', '12:00', '12:00', '12:00', '12:00', '12:00'],
+  ['13:00', '13:00', '13:00', '13:00', '13:00', '13:00'],
+  ['14:00', '14:00', '14:00', '14:00', '14:00', '14:00'],
+];
 
-export const rowHeaders = Template.bind({});
-rowHeaders.args = {
-  caption: 'Delivery schedule',
-  hasRowHeaders: true,
-  rows: [
-    ['Monday', '09:00', '10:00', '11:00', '12:00', '13:00', '14:00'],
-    ['Tuesday', '09:00', '10:00', '11:00', '12:00', '13:00', '14:00'],
-    ['Wednesday', '09:00', '10:00', '11:00', '12:00', '13:00', '14:00'],
-    ['Thursday', '09:00', '10:00', '11:00', '12:00', '13:00', '14:00'],
-    ['Friday', '09:00', '10:00', '11:00', '12:00', '13:00', '14:00'],
-    ['Saturday', '09:00', '10:00', '11:00', '12:00', '13:00', '14:00'],
-  ],
+const headerInFirstColumn = [
+  ['Monday', '09:00', '10:00', '11:00', '12:00', '13:00', '14:00'],
+  ['Tuesday', '09:00', '10:00', '11:00', '12:00', '13:00', '14:00'],
+  ['Wednesday', '09:00', '10:00', '11:00', '12:00', '13:00', '14:00'],
+  ['Thursday', '09:00', '10:00', '11:00', '12:00', '13:00', '14:00'],
+  ['Friday', '09:00', '10:00', '11:00', '12:00', '13:00', '14:00'],
+  ['Saturday', '09:00', '10:00', '11:00', '12:00', '13:00', '14:00'],
+];
+
+const Template = args => {
+  const { headerPosition, hasRowHeaders, addMoreContent, ...props } = args;
+
+  const getRows = content =>
+    addMoreContent
+      ? [
+          ...content,
+          [
+            'veeeeeeeeeeeeeeeeeeeeryyyyyyyyyyy loooooooong ttiiiiiiiittllleeeee',
+            'veeeeeeeeeeeeeeeeeeeeryyyyyyyyyyy loooooooong ttiiiiiiiittllleeeee',
+            'veeeeeeeeeeeeeeeeeeeeryyyyyyyyyyy loooooooong ttiiiiiiiittllleeeee',
+            'veeeeeeeeeeeeeeeeeeeeryyyyyyyyyyy loooooooong ttiiiiiiiittllleeeee',
+            'veeeeeeeeeeeeeeeeeeeeryyyyyyyyyyy loooooooong ttiiiiiiiittllleeeee',
+            'veeeeeeeeeeeeeeeeeeeeryyyyyyyyyyy loooooooong ttiiiiiiiittllleeeee',
+          ],
+        ]
+      : content;
+
+  return (
+    <>
+      <p>
+        Choose &quot;add more content&quot; and resize to see navigable arrows
+      </p>
+      <Table
+        rows={
+          headerPosition === 'row'
+            ? getRows(headerInFirstColumn)
+            : getRows(headerInFirstRow)
+        }
+        hasRowHeaders={headerPosition === 'row'}
+        {...props}
+      />
+    </>
+  );
 };
-rowHeaders.storyName = 'Row headers';
+
+export const table = Template.bind({});
+table.args = {
+  caption: 'Delivery schedule',
+  plain: false,
+  withBorder: false,
+  vAlign: 'middle',
+  headerPosition: 'column',
+  addMoreContent: false,
+};
+table.argTypes = {
+  vAlign: {
+    options: ['top', 'middle', 'bottom'],
+    control: { type: 'radio' },
+  },
+  plain: { control: 'boolean' },
+  withBorder: { control: 'boolean' },
+  headerPosition: {
+    options: ['row', 'column'],
+    control: { type: 'radio' },
+  },
+  rows: {
+    table: {
+      disable: true,
+    },
+  },
+  hasRowHeaders: {
+    table: {
+      disable: true,
+    },
+  },
+  addMoreContent: { control: 'boolean' },
+};

--- a/cardigan/stories/components/Table/Table.stories.tsx
+++ b/cardigan/stories/components/Table/Table.stories.tsx
@@ -40,7 +40,8 @@ const Template = args => {
   return (
     <>
       <p>
-        Choose &quot;add more content&quot; and resize to see navigable arrows
+        On a large desktop, choose &quot;add more content&quot; and resize to
+        see navigable arrows
       </p>
       <Table
         rows={

--- a/cardigan/stories/components/Tabs/Tabs.stories.mdx
+++ b/cardigan/stories/components/Tabs/Tabs.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import Tabs from '@weco/content/components/Tabs';
 import Readme from '@weco/content/components/Tabs/README.md';
 import * as stories from './Tabs.stories.tsx';

--- a/cardigan/stories/components/Tags/Tags.stories.mdx
+++ b/cardigan/stories/components/Tags/Tags.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import Tags from '@weco/content/components/Tags/Tags';
 import Readme from '@weco/content/components/Tags/README.md';
 import * as stories from './Tags.stories.tsx';
@@ -9,7 +9,6 @@ import * as stories from './Tags.stories.tsx';
 
 <Readme />
 
-{' '}
 <Story story={stories.basic} />
 
 <ArgsTable />

--- a/cardigan/stories/components/TagsGroup/TagsGroup.stories.mdx
+++ b/cardigan/stories/components/TagsGroup/TagsGroup.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import TagsGroup from '@weco/content/components/TagsGroup/TagsGroup';
 import Readme from '@weco/content/components/TagsGroup/README.md';
 import * as stories from './TagsGroup.stories.tsx';
@@ -9,7 +9,6 @@ import * as stories from './TagsGroup.stories.tsx';
 
 <Readme />
 
-{' '}
 <Story story={stories.basic} />
 
 <ArgsTable />

--- a/cardigan/stories/components/TextInput/TextInput.stories.mdx
+++ b/cardigan/stories/components/TextInput/TextInput.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import TextInput from '@weco/common/views/components/TextInput';
 import Readme from '@weco/common/views/components/TextInput/README.md';
 import * as stories from './TextInput.stories.tsx';

--- a/cardigan/stories/components/TitledTextList/TitledTextList.stories.mdx
+++ b/cardigan/stories/components/TitledTextList/TitledTextList.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import TitledTextList from '@weco/content/components/TitledTextList/TitledTextList';
 import Readme from '@weco/content/components/TitledTextList/README.md';
 import * as stories from './TitledTextList.stories.tsx';

--- a/cardigan/stories/components/VenueClosedPeriods/VenueClosedPeriods.stories.mdx
+++ b/cardigan/stories/components/VenueClosedPeriods/VenueClosedPeriods.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import VenueClosedPeriods from '@weco/content/components/VenueClosedPeriods/VenueClosedPeriods';
 import * as stories from './VenueClosedPeriods.stories.tsx';
 

--- a/cardigan/stories/components/VenueHours/VenueHours.stories.mdx
+++ b/cardigan/stories/components/VenueHours/VenueHours.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import VenueHours from '@weco/content/components/VenueHours/VenueHours';
 import Readme from '@weco/content/components/VenueHours/README.md';
 import * as stories from './VenueHours.stories.tsx';

--- a/cardigan/stories/components/WobblyEdge/WobblyEdge.stories.mdx
+++ b/cardigan/stories/components/WobblyEdge/WobblyEdge.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import { WobblyBottom } from '@weco/common/views/components/WobblyEdge';
 import * as stories from './WobblyEdge.stories.tsx';
 

--- a/cardigan/stories/global/cardigan/cardigan.stories.mdx
+++ b/cardigan/stories/global/cardigan/cardigan.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta } from '@storybook/addon-docs/blocks';
+import { Meta } from '@storybook/addon-docs';
 
 <Meta title={`Cardigan`} />
 

--- a/cardigan/stories/global/icons/icons.stories.mdx
+++ b/cardigan/stories/global/icons/icons.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Canvas, Story } from '@storybook/addon-docs/blocks';
+import { Meta, Canvas, Story } from '@storybook/addon-docs';
 import { Icons } from './icons.stories.tsx';
 
 <Meta title={`Global/Icons`} />

--- a/cardigan/stories/global/palette/gitbook.palette.stories.mdx
+++ b/cardigan/stories/global/palette/gitbook.palette.stories.mdx
@@ -1,4 +1,4 @@
-import {Meta, Story} from '@storybook/addon-docs/blocks';
+import { Meta, Story } from '@storybook/addon-docs';
 import * as stories from './palette.stories.tsx';
 
 <Meta title={`GitBook/Palette`} />

--- a/cardigan/stories/global/palette/palette.stories.mdx
+++ b/cardigan/stories/global/palette/palette.stories.mdx
@@ -1,5 +1,5 @@
-import {Meta} from '@storybook/addon-docs/blocks';
-import {Palette} from './palette.stories.tsx';
+import { Meta } from '@storybook/addon-docs';
+import { Palette } from './palette.stories.tsx';
 
 <Meta title={`Global/Palette`} />
 

--- a/cardigan/stories/global/palette/palette.stories.tsx
+++ b/cardigan/stories/global/palette/palette.stories.tsx
@@ -3,7 +3,7 @@ import { themeValues } from '@weco/common/views/themes/config';
 import styled from 'styled-components';
 import { font } from '@weco/common/utils/classnames';
 import Divider from '@weco/common/views/components/Divider/Divider';
-import Table from '@weco/content/components/Table/Table';
+import Table from '@weco/content/components/Table';
 import {
   RGB,
   HSL,

--- a/cardigan/stories/global/spacing/gitbook.spacing.stories.mdx
+++ b/cardigan/stories/global/spacing/gitbook.spacing.stories.mdx
@@ -1,4 +1,4 @@
-import {Meta, Story} from '@storybook/addon-docs/blocks';
+import { Meta, Story } from '@storybook/addon-docs';
 import * as stories from './spacing.stories.tsx';
 
 <Meta title={`GitBook/Spacing`} />

--- a/cardigan/stories/global/spacing/spacing.stories.mdx
+++ b/cardigan/stories/global/spacing/spacing.stories.mdx
@@ -1,5 +1,5 @@
-import {Meta} from '@storybook/addon-docs/blocks';
-import {Spacing} from './spacing.stories.tsx';
+import { Meta } from '@storybook/addon-docs';
+import { Spacing } from './spacing.stories.tsx';
 
 <Meta title={`Global/Spacing`} />
 
@@ -12,6 +12,7 @@ It also enables us to make systematic decisions without being reliant on visual 
 ## Section spacing
 
 We define 'Sections' as the top-level elements of the `ContentPage`
+
 - `PageHeader`
 - `Body`
 - `children`

--- a/cardigan/stories/global/spacing/spacing.stories.tsx
+++ b/cardigan/stories/global/spacing/spacing.stories.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent } from 'react';
 import styled from 'styled-components';
-import Table from '@weco/content/components/Table/Table';
+import Table from '@weco/content/components/Table';
 import SpacingSection from '@weco/common/views/components/styled/SpacingSection';
 import SpacingComponent from '@weco/common/views/components/styled/SpacingComponent';
 import { PaletteColor, themeValues } from '@weco/common/views/themes/config';

--- a/cardigan/stories/global/typography/gitbook.typography.stories.mdx
+++ b/cardigan/stories/global/typography/gitbook.typography.stories.mdx
@@ -1,4 +1,4 @@
-import {Meta, Story} from '@storybook/addon-docs/blocks';
+import {Meta, Story} from '@storybook/addon-docs';
 import * as stories from './typography.stories.tsx';
 
 <Meta title={`GitBook/Typography`} />

--- a/cardigan/stories/global/typography/typography.stories.mdx
+++ b/cardigan/stories/global/typography/typography.stories.mdx
@@ -1,4 +1,4 @@
-import {Meta, Canvas, Story} from '@storybook/addon-docs/blocks';
+import { Meta, Canvas, Story } from '@storybook/addon-docs';
 import * as stories from './typography.stories.tsx';
 
 <Meta title={`Global/Typography`} />
@@ -6,21 +6,21 @@ import * as stories from './typography.stories.tsx';
 # Typography
 
 ## Scale at breakpoints
+
 We have seven possible sizes for type, numbered `0` to `6`, with `0` being the largest and `6` the smallest.
 
 Each of these sizes is responsive, being largest at the large breakpoint, becoming smaller at the medium breakpoint and smaller still at the smallest breakpoint.
 
-  <Story story={stories.scale} />
+<Story story={stories.scale} />
 
 ## Font families
 
 We use Wellcome Bold, Inter, and Lettera on the site.
 
-  <Story story={stories.families} />
+<Story story={stories.families} />
 
 ## Misc
 
-  <Story story={stories.misc} />
+<Story story={stories.misc} />
 
 [Edit this Readme on GitHub](https://github.com/wellcometrust/wellcomecollection.org/blob/main/cardigan/stories/global/typography/typography.stories.mdx)
-

--- a/cardigan/stories/global/typography/typography.stories.tsx
+++ b/cardigan/stories/global/typography/typography.stories.tsx
@@ -1,4 +1,4 @@
-import Table from '@weco/content/components/Table/Table';
+import Table from '@weco/content/components/Table';
 import { fontSizesAtBreakpoints } from '@weco/common/views/themes/typography';
 import styled from 'styled-components';
 import { font } from '@weco/common/utils/classnames';

--- a/common/views/components/styled/Space.tsx
+++ b/common/views/components/styled/Space.tsx
@@ -52,7 +52,7 @@ type HorizontalSpaceProps = {
   overrides?: SpaceOverrides;
 };
 
-export type SpaceComponentProps = {
+type SpaceComponentProps = {
   $v?: VerticalSpaceProps;
   $h?: HorizontalSpaceProps;
 };

--- a/content/webapp/components/Table/Tables.styles.tsx
+++ b/content/webapp/components/Table/Tables.styles.tsx
@@ -1,0 +1,148 @@
+import styled from 'styled-components';
+import { font } from '@weco/common/utils/classnames';
+
+export const ControlsWrap = styled.div`
+  position: relative;
+`;
+
+export const ScrollButtonWrap = styled.div<{
+  $isActive?: boolean;
+  $isLeft?: boolean;
+}>`
+  position: absolute;
+  z-index: 2;
+  top: 50%;
+  cursor: pointer;
+  pointer-events: ${props => (props.$isActive ? 'all' : 'none')};
+  opacity: ${props => (props.$isActive ? 1 : 0.2)};
+  transition: opacity ${props => props.theme.transitionProperties};
+
+  ${props =>
+    props.$isLeft &&
+    `
+    left: 0;
+    transform: translateX(-50%) translateY(-50%) scale(0.6);
+  `}
+
+  ${props =>
+    !props.$isLeft &&
+    `
+    right: 0;
+    transform: translateX(50%) translateY(-50%) scale(0.6);
+  `}
+
+  ${props =>
+    props.theme.media('medium')(`
+    transform: ${
+      props.$isLeft
+        ? 'translateX(-50%) translateY(-50%)'
+        : 'translateX(50%) translateY(-50%)'
+    };
+  `)}
+`;
+
+export const ScrollButtons = styled.div<{
+  $isActive?: boolean;
+}>`
+  display: ${props => (props.$isActive ? 'block' : 'none')};
+`;
+
+export const TableWrap = styled.div`
+  position: relative;
+  max-width: 100%;
+  overflow: scroll;
+  background:
+    linear-gradient(to right, white 30%, rgba(255, 255, 255, 0)),
+    linear-gradient(to right, rgba(255, 255, 255, 0), white 70%) 0 100%,
+    radial-gradient(
+      farthest-side at 0% 50%,
+      rgba(0, 0, 0, 0.2),
+      rgba(0, 0, 0, 0)
+    ),
+    radial-gradient(
+        farthest-side at 100% 50%,
+        rgba(0, 0, 0, 0.2),
+        rgba(0, 0, 0, 0)
+      )
+      0 100%;
+  background-repeat: no-repeat;
+  background-color: white;
+  background-size:
+    40px 100%,
+    40px 100%,
+    14px 100%,
+    14px 100%;
+  background-position:
+    0 0,
+    100%,
+    0 0,
+    100%;
+  background-attachment: local, local, scroll, scroll;
+`;
+
+export const TableTable = styled.table.attrs({
+  className: font('intr', 5),
+})`
+  width: 100%;
+  border-collapse: collapse;
+`;
+
+export const TableThead = styled.thead`
+  text-align: left;
+`;
+
+export const TableCaption = styled.caption.attrs({
+  className: 'visually-hidden',
+})``;
+
+export const TableTbody = styled.tbody``;
+
+export const TableTr = styled.tr<{ $withBorder?: boolean }>`
+  ${TableTbody} & {
+    border-bottom: ${props =>
+      props.$withBorder
+        ? `1px dotted ${props.theme.color('neutral.500')}`
+        : 'none'};
+  }
+
+  ${TableTbody}.has-row-headers & {
+    border-top: ${props =>
+      props.$withBorder
+        ? `1px dotted ${props.theme.color('neutral.500')}`
+        : 'none'};
+  }
+`;
+
+export const TableTh = styled.th<{ $plain?: boolean }>`
+  ${props =>
+    props.theme.makeSpacePropertyValues('s', [
+      'padding-bottom',
+      'padding-top',
+      'padding-left',
+      'padding-right',
+    ])}
+
+  font-weight: bold;
+  background: ${props =>
+    props.$plain ? 'transparent' : props.theme.color('warmNeutral.400')};
+  white-space: nowrap;
+
+  ${TableTbody}.has-row-headers & {
+    background: transparent;
+    text-align: left;
+  }
+`;
+
+export const TableTd = styled.td<{ $vAlign?: string }>`
+  ${props =>
+    props.theme.makeSpacePropertyValues('s', [
+      'padding-bottom',
+      'padding-top',
+      'padding-left',
+      'padding-right',
+    ])}
+
+  vertical-align: ${props => props.$vAlign};
+  white-space: nowrap;
+  height: 53px;
+`;

--- a/content/webapp/components/Table/index.tsx
+++ b/content/webapp/components/Table/index.tsx
@@ -1,9 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
-// TODO: To fix when we create a new Storybook - this component could actually be deleted
-// But needs to be replaced in Storybook instances
-// https://github.com/wellcomecollection/wellcomecollection.org/issues/9158
-import styled from 'styled-components';
 import {
   useRef,
   useEffect,
@@ -14,153 +8,22 @@ import {
   ReactElement,
 } from 'react';
 import { font } from '@weco/common/utils/classnames';
-import Space from '@weco/common/views/components/styled/Space';
 import Rotator from '@weco/common/views/components/styled/Rotator';
 import Control from '@weco/common/views/components/Control';
 import { arrow } from '@weco/common/icons';
-
-const ControlsWrap = styled.div`
-  position: relative;
-`;
-
-type ScrollButtonWrapProps = {
-  $isActive?: boolean;
-  $isLeft?: boolean;
-};
-
-const ScrollButtonWrap = styled.div<ScrollButtonWrapProps>`
-  position: absolute;
-  z-index: 2;
-  top: 50%;
-  cursor: pointer;
-  pointer-events: ${props => (props.$isActive ? 'all' : 'none')};
-  opacity: ${props => (props.$isActive ? 1 : 0.2)};
-  transition: opacity ${props => props.theme.transitionProperties};
-
-  ${props =>
-    props.$isLeft &&
-    `
-    left: 0;
-    transform: translateX(-50%) translateY(-50%) scale(0.6);
-  `}
-
-  ${props =>
-    !props.$isLeft &&
-    `
-    right: 0;
-    transform: translateX(50%) translateY(-50%) scale(0.6);
-  `}
-
-  ${props => props.theme.media('medium')`
-    transform: ${
-      props.$isLeft
-        ? 'translateX(-50%) translateY(-50%)'
-        : 'translateX(50%) translateY(-50%)'
-    };
-  `}
-`;
-
-type ScrollButtonsProps = {
-  $isActive?: boolean;
-};
-
-const ScrollButtons = styled.div<ScrollButtonsProps>`
-  display: ${props => (props.$isActive ? 'block' : 'none')};
-`;
-
-const TableWrap = styled.div`
-  position: relative;
-  max-width: 100%;
-  overflow: scroll;
-  background:
-    linear-gradient(to right, white 30%, rgba(255, 255, 255, 0)),
-    linear-gradient(to right, rgba(255, 255, 255, 0), white 70%) 0 100%,
-    radial-gradient(
-      farthest-side at 0% 50%,
-      rgba(0, 0, 0, 0.2),
-      rgba(0, 0, 0, 0)
-    ),
-    radial-gradient(
-        farthest-side at 100% 50%,
-        rgba(0, 0, 0, 0.2),
-        rgba(0, 0, 0, 0)
-      )
-      0 100%;
-  background-repeat: no-repeat;
-  background-color: white;
-  background-size:
-    40px 100%,
-    40px 100%,
-    14px 100%,
-    14px 100%;
-  background-position:
-    0 0,
-    100%,
-    0 0,
-    100%;
-  background-attachment: local, local, scroll, scroll;
-`;
-
-const TableTable = styled.table.attrs({
-  className: font('intr', 5),
-})`
-  width: 100%;
-  border-collapse: collapse;
-`;
-
-const TableThead = styled.thead`
-  text-align: left;
-`;
-
-const TableCaption = styled.caption.attrs({
-  className: 'visually-hidden',
-})``;
-
-const TableTbody = styled.tbody``;
-
-const TableTr = styled.tr<{ $withBorder?: boolean }>`
-  ${TableTbody} & {
-    border-bottom: ${props =>
-      props.$withBorder
-        ? `1px dotted
-      ${props => props.theme.color('neutral.500')}`
-        : 'none'};
-  }
-
-  ${TableTbody}.has-row-headers & {
-    border-top: ${props =>
-      props.$withBorder
-        ? `1px dotted
-      ${props => props.theme.color('neutral.500')}`
-        : 'none'};
-  }
-`;
-
-const TableTh = styled(Space).attrs<{ $plain: boolean }>({
-  as: 'th',
-  $v: { size: 's', properties: ['padding-top', 'padding-bottom'] },
-  $h: { size: 's', properties: ['padding-left', 'padding-right'] },
-})`
-  font-weight: bold;
-  background: ${props =>
-    props.$plain ? 'transparent' : props.theme.color('warmNeutral.400')};
-  white-space: nowrap;
-
-  ${TableTbody}.has-row-headers & {
-    background: transparent;
-    text-align: left;
-  }
-`;
-
-const TableTd = styled(Space).attrs<{ $vAlign?: string }>({
-  as: 'td',
-  $v: { size: 's', properties: ['padding-top', 'padding-bottom'] },
-  $h: { size: 's', properties: ['padding-left', 'padding-right'] },
-})`
-  vertical-align: ${props => props.$vAlign};
-  white-space: nowrap;
-  height: 53px;
-`;
+import {
+  ControlsWrap,
+  ScrollButtonWrap,
+  ScrollButtons,
+  TableCaption,
+  TableTable,
+  TableThead,
+  TableTbody,
+  TableTd,
+  TableTh,
+  TableTr,
+  TableWrap,
+} from './Tables.styles';
 
 export type Props = {
   rows: (string | ReactElement)[][];
@@ -224,8 +87,8 @@ const Table: FunctionComponent<Props> = ({
   plain = false,
   withBorder = true,
 }: Props): ReactElement<Props> => {
-  const leftButtonRef = useRef(null);
-  const rightButtonRef = useRef(null);
+  const leftButtonRef = useRef<HTMLDivElement>(null);
+  const rightButtonRef = useRef<HTMLDivElement>(null);
   const tableRef = useRef<HTMLTableElement>(null);
   const controlsRef = useRef(null);
   const tableWrapRef = useRef<HTMLDivElement>(null);
@@ -240,7 +103,7 @@ const Table: FunctionComponent<Props> = ({
     return {
       tableWidth: tableRef?.current && tableRef.current.offsetWidth,
       tableWrapScrollLeft:
-        tableWrapRef?.current && tableWrapRef.current.scrollLeft,
+        (tableWrapRef?.current && tableWrapRef.current.scrollLeft) || 0,
       tableWrapWidth: tableWrapRef?.current && tableWrapRef.current.offsetWidth,
     };
   }
@@ -257,8 +120,10 @@ const Table: FunctionComponent<Props> = ({
   function updateButtonVisibility() {
     const { tableWidth, tableWrapScrollLeft, tableWrapWidth } = getUiData();
 
-    setIsLeftActive(tableWrapScrollLeft > 0);
-    setIsRightActive(tableWrapScrollLeft < tableWidth - tableWrapWidth);
+    if (tableWidth && tableWrapWidth) {
+      setIsLeftActive(tableWrapScrollLeft > 0);
+      setIsRightActive(tableWrapScrollLeft < tableWidth - tableWrapWidth);
+    }
   }
 
   function scroll(isLeft: boolean) {
@@ -290,11 +155,12 @@ const Table: FunctionComponent<Props> = ({
   useEffect(() => {
     window.addEventListener('resize', checkOverflow);
     window.addEventListener('resize', updateButtonVisibility);
-    tableWrapRef &&
+
+    tableWrapRef?.current &&
       tableWrapRef.current.addEventListener('scroll', updateButtonVisibility);
-    leftButtonRef &&
+    leftButtonRef?.current &&
       leftButtonRef.current.addEventListener('click', scrollLeft);
-    rightButtonRef &&
+    rightButtonRef?.current &&
       rightButtonRef.current.addEventListener('click', scrollRight);
 
     checkOverflow();
@@ -303,14 +169,14 @@ const Table: FunctionComponent<Props> = ({
     return () => {
       window.removeEventListener('resize', checkOverflow);
       window.removeEventListener('resize', updateButtonVisibility);
-      tableWrapRef &&
+      tableWrapRef?.current &&
         tableWrapRef.current.removeEventListener(
           'scroll',
           updateButtonVisibility
         );
-      leftButtonRef &&
+      leftButtonRef?.current &&
         leftButtonRef.current.removeEventListener('click', scrollLeft);
-      rightButtonRef &&
+      rightButtonRef?.current &&
         rightButtonRef.current.removeEventListener('click', scrollRight);
     };
   }, []);
@@ -333,18 +199,21 @@ const Table: FunctionComponent<Props> = ({
               <Control colorScheme="light" icon={arrow} text="" />
             </Rotator>
           </ScrollButtonWrap>
+
           <ScrollButtonWrap $isActive={isRightActive} ref={rightButtonRef}>
             <Control colorScheme="light" icon={arrow} text="" />
           </ScrollButtonWrap>
         </ScrollButtons>
+
         <TableWrap ref={tableWrapRef}>
           <TableTable id="table" ref={tableRef}>
             {caption && <TableCaption>{caption}</TableCaption>}
+
             {headerRow && (
               <TableThead>
                 <TableTr>
                   {headerRow.map((item, index) =>
-                    isValidElement ? (
+                    isValidElement(item) ? (
                       <TableTh key={index} $plain={plain} scope="col">
                         {item}
                       </TableTh>
@@ -360,6 +229,7 @@ const Table: FunctionComponent<Props> = ({
                 </TableTr>
               </TableThead>
             )}
+
             <TableTbody className="has-row-headers">
               {bodyRows.map((row, index) => (
                 <TableRow


### PR DESCRIPTION
## Who is this for?
Maintenance, possible future use of Table

## What is it doing for them?
We had disabled all linting on this older `Table` component thinking we'd delete it soon, as we has deleted the Slice a while back and it was only used in Storybook.

We're now talking about using it for the cookie page (and maybe one day born digital pages? although I doubt we'd use the same one). So I went it and tidied a bit to make it more usable/fix a few bugs.

[I made the Storybook more interactive as well](https://github.com/wellcomecollection/wellcomecollection.org/pull/10798/files#diff-f37bc47b2b6c3b12d128a91df4e15e954cc2bde1b0cf94c422e90367702f130f) ([have a play here](https://62f13cdbd0ff140768a8d87b-iizzhmblhi.chromatic.com/?path=%2Fstory%2Fcomponents-table--table&globals=viewport.width%3A1200)), which is where the bulk of the work happened, as well as in the fixes [in the component itself](https://github.com/wellcomecollection/wellcomecollection.org/pull/10798/files#diff-d37385bbaa5cf7390c18a9601438a00436f497026fe852da687a4b5ffd7e8bb2), which are mostly linting/TS related, although the border wasn't working and now is!

While I ran Storybook I came across a warning that indicated that importing from `'@storybook/addon-docs/blocks'` was deprecated and could just be `'@storybook/addon-docs'` so I did that across, apologies for the amount of changes it creates 😄  