### PR TITLE
Fix arrow in table and access resources spacing

### DIFF
--- a/content/webapp/components/Table/Tables.styles.tsx
+++ b/content/webapp/components/Table/Tables.styles.tsx
@@ -13,6 +13,7 @@ export const ScrollButtonWrap = styled.div<{
   z-index: 2;
   top: 50%;
   cursor: pointer;
+  margin: 0;
   pointer-events: ${props => (props.$isActive ? 'all' : 'none')};
   opacity: ${props => (props.$isActive ? 1 : 0.2)};
   transition: opacity ${props => props.theme.transitionProperties};

--- a/content/webapp/components/styled/AccessResources.ts
+++ b/content/webapp/components/styled/AccessResources.ts
@@ -23,7 +23,7 @@ export const ResourcesItem = styled.li`
 
 export const ResourceLink = styled(Space).attrs<{ href: string }>({
   as: 'a',
-  $h: { size: 's', properties: ['padding-left', 'padding-right'] },
+  $h: { size: 's', properties: ['padding-left'] },
   $v: { size: 'm', properties: ['padding-top', 'padding-bottom'] },
 })<{ $borderColor: PaletteColor; $underlineText?: boolean }>`
   display: block;
@@ -32,6 +32,9 @@ export const ResourceLink = styled(Space).attrs<{ href: string }>({
   text-decoration: ${props => (props.$underlineText ? 'underline' : 'none')};
   border: 1px solid ${props => props.theme.color('warmNeutral.400')};
   border-left: 10px solid ${props => props.theme.color(props.$borderColor)};
+
+  /* Accounts for the size of the arrow icon */
+  padding-right: 34px;
 
   &:hover {
     background: ${props => props.theme.color('neutral.400')};


### PR DESCRIPTION
## Who is this for?
#10770 and #10803

## What is it doing for them?
- Table arrows were misaligned because it was within `spaced-text` and a margin-top was applied to the second arrow.
  <img width="400" alt="Screenshot 2024-04-18 at 12 35 25" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/28bcb9e6-4e50-45d2-8e50-183196aebb55">
  <img width="400" alt="Screenshot 2024-04-18 at 12 35 59" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/fcaf66a2-6dee-4afb-8271-f1bc4cfd6d24">
- Felt like too small a change for a PR so worked on #10770 as well; changed the padding-right to match the size of the arrow icon so the copy would never go over/under. [Screen recording here](https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/740ff062-fb9e-4f1b-a3ad-d5baf3310322). 
