### PR TITLE
Add cookies link behind toggle and fix table alignment

### DIFF
--- a/common/views/components/Footer/Footer.Nav.tsx
+++ b/common/views/components/Footer/Footer.Nav.tsx
@@ -32,7 +32,7 @@ const NavList = styled.ul<{ $isInline?: boolean }>`
       `)}
 
       li {
-        margin-right: 2rem;
+        margin-right: 1.1rem;
 
         &:last-child {
           margin-right: 0;
@@ -76,6 +76,29 @@ const PoliciesNavigation: NavLink[] = [
     title: 'Privacy and terms',
   },
   {
+    href: 'https://wellcome.org/who-we-are/modern-slavery-statement',
+    title: 'Modern slavery statement',
+  },
+];
+
+// This is for the cookiesWork toggle, once it's for everyone, then officialise this new list.
+const PoliciesNavigationWithCookieWork: NavLink[] = [
+  { href: 'https://wellcome.org/jobs', title: 'Jobs' },
+  { href: '/press', title: 'Media office' },
+  {
+    href: 'https://developers.wellcomecollection.org',
+    title: 'Developers',
+  },
+  {
+    href: 'https://wellcome.org/who-we-are/privacy-and-terms',
+    title: 'Privacy and terms',
+  },
+
+  {
+    href: '/cookie-policy',
+    title: 'Cookie policy',
+  },
+  {
     href: '/',
     title: 'Manage cookies',
   },
@@ -96,8 +119,12 @@ const FooterNav = ({
 }): ReactElement => {
   const { cookiesWork } = useToggles();
 
+  // This is for the cookiesWork toggle, once it's for everyone, then officialise this new list.
+  const tempPolicyList = cookiesWork
+    ? PoliciesNavigationWithCookieWork
+    : PoliciesNavigation;
   const itemsList =
-    type === 'PoliciesNavigation' ? PoliciesNavigation : InternalNavigation;
+    type === 'PoliciesNavigation' ? tempPolicyList : InternalNavigation;
 
   return (
     <nav aria-label={ariaLabel}>
@@ -107,7 +134,7 @@ const FooterNav = ({
           const isBurgerMenuLink = type === 'InternalNavigation' && i === 0;
           const isManageCookies = link.title === 'Manage cookies';
 
-          return cookiesWork && isManageCookies ? (
+          return isManageCookies ? (
             <li key={link.title}>
               <Link
                 href={link.href}

--- a/content/webapp/components/Table/Tables.styles.tsx
+++ b/content/webapp/components/Table/Tables.styles.tsx
@@ -13,10 +13,14 @@ export const ScrollButtonWrap = styled.div<{
   z-index: 2;
   top: 50%;
   cursor: pointer;
-  margin: 0;
   pointer-events: ${props => (props.$isActive ? 'all' : 'none')};
   opacity: ${props => (props.$isActive ? 1 : 0.2)};
   transition: opacity ${props => props.theme.transitionProperties};
+
+  /* This hack is needed to override the spacing caused by being placed within a div with .spaced-text. */
+  .spaced-text & {
+    margin: 0;
+  }
 
   ${props =>
     props.$isLeft &&


### PR DESCRIPTION
## Who is this for?
#10803 and #10706 

## What is it doing for them?
- Fixes alignment of table arrows (when within `.spaced-text`, its styles need to be overwritten more specifically)
- Adds "Cookie policy" link in footer (behind toggle only). This meant I had to change the styles a little bit, which I just did by removing some margin between links. That style will apply immediately, toggle or not. It still looks a bit strange at a very small range of window size, but nothing too bad.
  **Before**
  <img width="655" alt="Screenshot 2024-04-18 at 17 57 08" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/35d56844-4462-471c-9115-b8cc92ad7ba4">
  **After**
  <img width="729" alt="Screenshot 2024-04-18 at 17 57 00" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/0b9bb0f4-1347-468d-8b28-ea097f6de890">
  **Still happens a little bit between 960px and 995px.**
  <img width="463" alt="Screenshot 2024-04-18 at 17 57 30" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/6c92c671-ad25-4efa-bd51-0840deb77763">
