### PR TITLE
Modify sliceAnalysis script to be more useful

### DIFF
--- a/prismic-model/README.md
+++ b/prismic-model/README.md
@@ -104,10 +104,8 @@ You can run:
 
 You might want to add flags for more information, though, such as:
 
-`--label [slice format label name]` will print out more information about a specific format label.
 `--type [slice type name]` will print out more information about a specific type. There might be a lot of them and it can't print them all, so...
 `--report` will create a `sliceReport.json` file with the full list.
-`--printUrl` will also try to give you relevant URLs based on the type and ID.
 
 
 See the file comment on [sliceAnalysis.ts](./sliceAnalysis.ts)

--- a/prismic-model/sliceAnalysis.ts
+++ b/prismic-model/sliceAnalysis.ts
@@ -33,15 +33,11 @@ import {
 import fs from 'fs';
 import { success } from './console';
 
-const { label, type, printUrl, report } = yargs(process.argv.slice(2))
-  .usage(
-    'Usage: $0 --label [string] --type [string] --printUrl [boolean] --report [boolean]'
-  )
+const { type, report } = yargs(process.argv.slice(2))
+  .usage('Usage: $0  --type [string] --report [boolean]')
   .options({
-    label: { type: 'string' },
     type: { type: 'string' },
     report: { type: 'boolean' },
-    printUrl: { type: 'boolean' },
   })
   .parseSync();
 
@@ -74,11 +70,7 @@ async function main() {
         ? result.data.body.some(slice => slice.slice_type === type)
         : true;
 
-      const isWithLabel: boolean = label
-        ? result.data.body.some(slice => slice.slice_label === label)
-        : true;
-
-      if (isWithType && isWithLabel) {
+      if (isWithType) {
         // Find how often the slice is used within the content type
         let nodeSliceCount = 0;
         result.data.body
@@ -101,9 +93,7 @@ async function main() {
           ...(type && {
             sliceCount: nodeSliceCount,
           }),
-          ...(printUrl && {
-            url: `http://wellcomecollection.org/${result.type}/${result.id}`,
-          }),
+          url: `http://wellcomecollection.org/${result.type}/${result.id}`,
         });
       }
     }


### PR DESCRIPTION
## Who is this for?
Devs who want to know more about our slice usage

## What is it doing for them?
- Modify the count to be X slices in X content types [list of content types it's used in]
- Adds a slice count in each object so we know how often the slice is used within the content type node
- Always print URL as it's super useful for seeing _how_ we use them
- Remove search by label as it's too generic (would return everything that uses "Standalone", regardless of slice type. Plus we're deleting labels soon.
- Edits README file to reflect those changes.

Specific slice search
`yarn sliceAnalysis --type=editorialImage`
<img width="769" alt="Screenshot 2024-04-23 at 11 43 19" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/aad32882-2e5a-46b0-b6de-3885986fdc33">

Generic search
`yarn sliceAnalysis`
<img width="1187" alt="Screenshot 2024-04-23 at 11 43 55" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/7a34a8bf-434b-4c77-a84a-9089ca4d80ea">

I've not touched this, but the overall count still precedes any listings;
<img width="304" alt="Screenshot 2024-04-23 at 11 46 53" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/110461050/929f570b-56dc-4c2f-b815-213d3227a7f3">

