### PR TITLE
Remove manifest when a work doesn't have one

### DIFF
--- a/content/webapp/hooks/useTransformedManifest.ts
+++ b/content/webapp/hooks/useTransformedManifest.ts
@@ -36,7 +36,10 @@ const useTransformedManifest = (
           work,
           'iiif-presentation'
         );
-        if (!iiifPresentationLocation) return;
+        if (!iiifPresentationLocation) {
+          setTransformedManifest(undefined);
+          return;
+        }
         manifestPromises.set(
           work.id,
           fetchIIIFPresentationManifest(iiifPresentationLocation.url)


### PR DESCRIPTION
Fixes #10765

When we switch between works we go and fetch the iiif manifest it points to and replace the previous one held in state.

However, if we switch to a work that doesn't have a manifest then we don't do anything and the previous one persists, leading to this bug.

We now remove the manifest from the state if the work doesn't point to one.
