### PR TITLE
Remove event toggles and related TODOs

### DIFF
--- a/common/data/microcopy.tsx
+++ b/common/data/microcopy.tsx
@@ -154,8 +154,7 @@ export const pastExhibitionsStrapline =
 // search in the global nav and on the categories in wc.org/search
 // TODO review this copy https://github.com/wellcomecollection/wellcomecollection.org/issues/10777
 export const searchLabelText = {
-  overview: 'Search our stories, images and catalogue',
-  overviewToggle: 'Search our stories, images, catalogue and events',
+  overview: 'Search our stories, images, catalogue and events',
   stories: 'Search for stories',
   images: 'Search for images',
   works: 'Search the catalogue',

--- a/common/views/components/Header/Header.tsx
+++ b/common/views/components/Header/Header.tsx
@@ -34,7 +34,6 @@ import MobileSignIn from './MobileSignIn';
 import HeaderSearch from './HeaderSearch';
 import { searchLabelText } from '@weco/common/data/microcopy';
 import { SiteSection } from '../PageLayout/PageLayout';
-import { useToggles } from '@weco/common/server-data/Context';
 
 const NoJSIconWrapper = styled.div`
   padding: 5px 8px 0;
@@ -104,7 +103,6 @@ const Header: FunctionComponent<Props> = ({
   const [searchDropdownIsActive, setSearchDropdownIsActive] = useState(false);
   const searchButtonRef = useRef<HTMLButtonElement>(null);
   const { isEnhanced } = useContext(AppContext);
-  const { eventsSearch } = useToggles();
 
   useEffect(() => {
     if (document && document.documentElement) {
@@ -187,9 +185,7 @@ const Header: FunctionComponent<Props> = ({
                               icon={searchDropdownIsActive ? cross : search}
                             />
                             <span className="visually-hidden">
-                              {eventsSearch
-                                ? searchLabelText.overviewToggle
-                                : searchLabelText.overview}
+                              {searchLabelText.overview}
                             </span>
                           </NoJSIconWrapper>
                         </NextLink>

--- a/common/views/components/SearchForm/SearchForm.tsx
+++ b/common/views/components/SearchForm/SearchForm.tsx
@@ -13,7 +13,6 @@ import {
 } from 'react';
 import SearchContext from '@weco/common/views/components/SearchContext/SearchContext';
 import { searchLabelText } from '@weco/common/data/microcopy';
-import { useToggles } from '@weco/common/server-data/Context';
 
 type SearchCategory = 'overview' | 'works';
 
@@ -42,7 +41,6 @@ const SearchForm = ({
   const router = useRouter();
   const routerQuery = getQueryPropertyValue(router?.query?.query);
   const { link: searchLink } = useContext(SearchContext);
-  const { eventsSearch } = useToggles();
   const initialValue =
     routerQuery || searchLink.as.query?.query?.toString() || '';
   const [inputValue, setInputValue] = useState(initialValue);
@@ -75,11 +73,7 @@ const SearchForm = ({
         form={`search-form-${searchCategory}`}
         placeholder={
           searchLabelText[
-            searchCategory !== 'overview'
-              ? searchCategory
-              : eventsSearch
-              ? 'overviewToggle'
-              : 'overview'
+            searchCategory !== 'overview' ? searchCategory : 'overview'
           ]
         }
         inputRef={inputRef}

--- a/content/webapp/components/SearchPageLayout/SearchNavigation.tsx
+++ b/content/webapp/components/SearchPageLayout/SearchNavigation.tsx
@@ -16,8 +16,6 @@ import {
 } from '@weco/common/utils/search';
 import { capitalize } from '@weco/common/utils/grammar';
 import { searchLabelText } from '@weco/common/data/microcopy';
-import { useToggles } from '@weco/common/server-data/Context';
-import { NavigateSelectableTextLink } from 'components/Tabs/Tabs.Navigate';
 
 const SearchBarContainer = styled(Space)`
   ${props => props.theme.media('medium', 'max-width')`
@@ -45,7 +43,6 @@ const SearchNavigation: FunctionComponent<SearchNavigationProps> = ({
   currentQueryValue: queryValue,
 }) => {
   const router = useRouter();
-  const { eventsSearch } = useToggles();
 
   // Variable naming note:
   //
@@ -125,8 +122,6 @@ const SearchNavigation: FunctionComponent<SearchNavigationProps> = ({
               searchLabelText[
                 currentSearchCategory !== 'overview'
                   ? currentSearchCategory
-                  : eventsSearch
-                  ? 'overviewToggle'
                   : 'overview'
               ]
             }
@@ -139,37 +134,33 @@ const SearchNavigation: FunctionComponent<SearchNavigationProps> = ({
         tabBehaviour="navigate"
         hideBorder={currentSearchCategory === 'overview'}
         label="Search Categories"
-        items={
-          [
-            {
-              id: 'overview',
-              url: getURL('/search'),
-              text: 'All',
-            },
-            {
-              id: 'stories',
-              url: getURL('/search/stories'),
-              text: 'Stories',
-            },
-            {
-              id: 'images',
-              url: getURL('/search/images'),
-              text: 'Images',
-            },
-            {
-              id: 'works',
-              url: getURL('/search/works'),
-              text: 'Catalogue',
-            },
-            eventsSearch
-              ? {
-                  id: 'events',
-                  url: getURL('/search/events'),
-                  text: 'Events',
-                }
-              : {},
-          ].filter(i => i.id) as NavigateSelectableTextLink[] // TODO remove filter when removing eventsSearch toggle
-        }
+        items={[
+          {
+            id: 'overview',
+            url: getURL('/search'),
+            text: 'All',
+          },
+          {
+            id: 'stories',
+            url: getURL('/search/stories'),
+            text: 'Stories',
+          },
+          {
+            id: 'images',
+            url: getURL('/search/images'),
+            text: 'Images',
+          },
+          {
+            id: 'works',
+            url: getURL('/search/works'),
+            text: 'Catalogue',
+          },
+          {
+            id: 'events',
+            url: getURL('/search/events'),
+            text: 'Events',
+          },
+        ]}
         currentSection={currentSearchCategory}
       />
     </>

--- a/content/webapp/pages/search/events.tsx
+++ b/content/webapp/pages/search/events.tsx
@@ -199,11 +199,6 @@ export const getServerSideProps: GetServerSideProps<
   setCacheControl(context.res, cacheTTL.search);
   const serverData = await getServerData(context);
 
-  const { eventsSearch } = serverData?.toggles;
-
-  if (!eventsSearch.value) {
-    return { notFound: true };
-  }
   const query = context.query;
   const params = fromQuery(query);
 

--- a/playwright/test/helpers/contexts.ts
+++ b/playwright/test/helpers/contexts.ts
@@ -186,17 +186,9 @@ const newSearch = async (
     | 'stories'
     | 'events'
     | 'images'
-    | 'works' = 'overview',
-  behindToggle = false
+    | 'works' = 'overview'
 ): Promise<void> => {
-  if (behindToggle) {
-    await context.addCookies([
-      ...requiredCookies,
-      createCookie('toggle_eventsSearch'),
-    ]);
-  } else {
-    await context.addCookies([...requiredCookies]);
-  }
+  await context.addCookies([...requiredCookies]);
 
   const searchUrl = `search${
     searchType === 'overview' ? `` : `/${searchType}`

--- a/playwright/test/search.test.ts
+++ b/playwright/test/search.test.ts
@@ -75,7 +75,7 @@ test('(6) | Boolean filters are disabled when there are no results that match th
   context,
   page,
 }) => {
-  await newSearch(context, page, 'events', true);
+  await newSearch(context, page, 'events');
   await selectAndWaitForFilter('Event types', 'W-BjXhEAAASpa8Kb', page); // Shopping
   await expect(
     page.getByLabel('Catch-up events only', { exact: false })

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -69,14 +69,6 @@ const toggles = {
       type: 'permanent',
     },
     {
-      id: 'eventsSearch',
-      title: 'Add Events to Search pages',
-      initialValue: false,
-      description:
-        'Adds an Events section to the Search hub and a new Events tab for more specific searches',
-      type: 'experimental',
-    },
-    {
       id: 'showBornDigital',
       title: 'Display born digital files',
       initialValue: false,


### PR DESCRIPTION
## Who is this for?
Maintenance and related to #10816 

## What is it doing for them?
- Removes toggle from toggles list (changes to be deployed to dash once it's merged to `main`)
- Removes references to the toggle from within the codebase
- Simplifies test as cookie doesn't need to be added to function.