### PR TITLE
add toggle for availabilitySlots from itemsAPI

### DIFF
--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -100,6 +100,14 @@ const toggles = {
         'This will render content using Prismic Slice Machine slices instead of legacy slices',
       type: 'experimental',
     },
+    {
+      id: 'offsiteRequesting',
+      title: 'Get item availability slots from itemsAPI',
+      initialValue: false,
+      description:
+        "This will get the item's availability from itemsAPI when online-requesting an item",
+      type: 'experimental',
+    },
   ] as const,
   tests: [] as ABTest[],
 };


### PR DESCRIPTION
## Who is this for?
Devs working on using the items' availability slots from the itemsAPI instead of calculating them in the browser

## What is it doing for them?
Enabling dev work and testing while keeping the website working as usual 

NOT DEPLOYED 
Edit: deployed 2024-04-26