### PR TITLE
Add secure attribute to our cookies

### DIFF
--- a/common/views/components/ApiToolbar/index.tsx
+++ b/common/views/components/ApiToolbar/index.tsx
@@ -178,7 +178,10 @@ const ApiToolbar: FunctionComponent<Props> = ({ links = [] }) => {
         type="button"
         onClick={() => {
           setMini(!mini);
-          setCookie(cookies.apiToolbarMini, !mini, { path: '/' });
+          setCookie(cookies.apiToolbarMini, !mini, {
+            path: '/',
+            secure: true,
+          });
         }}
         style={{ padding: '10px' }}
       >

--- a/common/views/components/CookieNotice/CookieNotice.tsx
+++ b/common/views/components/CookieNotice/CookieNotice.tsx
@@ -63,6 +63,7 @@ const CookieNotice: FunctionComponent<Props> = () => {
     setCookie(cookies.cookiesAccepted, 'true', {
       path: '/',
       expires: addDays(today(), 30),
+      secure: true,
     });
 
     setShouldRender(false);

--- a/common/views/components/InfoBanners/InfoBanner.tsx
+++ b/common/views/components/InfoBanners/InfoBanner.tsx
@@ -43,6 +43,7 @@ const InfoBanner: FunctionComponent<Props> = ({
       expires: isSingleSessionCookie
         ? undefined
         : new Date('2036-12-31T23:59:59Z'),
+      secure: true,
     });
 
     setIsVisible(false);

--- a/common/views/components/InfoBanners/WebsiteIssuesBanner.tsx
+++ b/common/views/components/InfoBanners/WebsiteIssuesBanner.tsx
@@ -35,6 +35,7 @@ const WebsiteIssuesBanner: FunctionComponent<Props> = ({
     setCookie(cookieName, 'true', {
       path: '/',
       expires: nowPlusFour,
+      secure: true,
     });
 
     setIsVisible(false);

--- a/common/views/components/PopupDialog/PopupDialog.tsx
+++ b/common/views/components/PopupDialog/PopupDialog.tsx
@@ -178,6 +178,7 @@ const PopupDialog: FunctionComponent<Props> = ({ document }: Props) => {
     setCookie(cookies.popupDialog, 'true', {
       path: '/',
       expires: undefined,
+      secure: true,
     });
 
     setShouldRender(false);

--- a/content/webapp/components/ExhibitionGuideLinks/ExhibitionGuideLinks.tsx
+++ b/content/webapp/components/ExhibitionGuideLinks/ExhibitionGuideLinks.tsx
@@ -36,7 +36,11 @@ type Props = {
 function cookieHandler(key: string, data: string) {
   // We set the cookie to expire in 8 hours (the maximum length of
   // time the galleries are open in a day)
-  const options = { maxAge: 8 * 60 * 60, path: '/' };
+  const options = {
+    maxAge: 8 * 60 * 60,
+    path: '/',
+    secure: true,
+  };
   setCookie(key, data, options);
 }
 

--- a/dash/webapp/pages/toggles.tsx
+++ b/dash/webapp/pages/toggles.tsx
@@ -135,7 +135,7 @@ function setCookie(name, value) {
     : `Expires=${new Date(0).toString()}`;
   document.cookie = `toggle_${name}=${
     value || ''
-  }; Path=/; Domain=wellcomecollection.org; ${expiration}`;
+  }; Path=/; Domain=wellcomecollection.org; ${expiration}; Secure`;
 }
 
 type Toggle = {


### PR DESCRIPTION
## Who is this for?
Security [#9774](https://github.com/wellcomecollection/wellcomecollection.org/issues/9774)

## What is it doing for them?
Adds `Secure` attribute to our cookies (`WC_` and `toggles_`). [More about the Secure attribute](https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/06-Session_Management_Testing/02-Testing_for_Cookies_Attributes#secure-attribute).