### PR TITLE
Image search: Display error description if provided

### DIFF
--- a/content/webapp/pages/search/images.tsx
+++ b/content/webapp/pages/search/images.tsx
@@ -315,7 +315,11 @@ export const getServerSideProps: GetServerSideProps<
   });
 
   if (images.type === 'Error') {
-    return appError(context, images.httpStatus, 'Images API error');
+    return appError(
+      context,
+      images.httpStatus,
+      images.description || images.label || 'Images API error'
+    );
   }
 
   return {


### PR DESCRIPTION
## Who is this for?
#10836 

## What is it doing for them?
It had been done [in the past](https://github.com/wellcomecollection/wellcomecollection.org/pull/9237), looked quickly to see where/why it got lost, seems to be when the new image search was created or possibly before (so at least two years back). Anyway, re-adding it so it's clearer for our users that get to page 334 :)