### PR TITLE
Audio player not rendering for certain works

### DIFF
--- a/content/webapp/components/IIIFItem/IIIFItem.tsx
+++ b/content/webapp/components/IIIFItem/IIIFItem.tsx
@@ -89,9 +89,8 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
           exclude={exclude}
         />
       );
-    case item.type === 'Sound' &&
-      !exclude.includes('Sound') &&
-      Boolean(item.id):
+    case (item.type === 'Sound' && !exclude.includes('Sound')) ||
+      (item.type === 'Audio' && !exclude.includes('Audio') && Boolean(item.id)):
       return (
         <AudioPlayer
           audioFile={item.id || ''}

--- a/content/webapp/components/IIIFItem/IIIFItem.tsx
+++ b/content/webapp/components/IIIFItem/IIIFItem.tsx
@@ -55,10 +55,15 @@ const Choice: FunctionComponent<
 
 type ItemProps = {
   canvas: TransformedCanvas;
-  item: ContentResource | CustomContentResource | ChoiceBody;
+  item:
+    | (Omit<ContentResource, 'type'> & {
+        type: ContentResource['type'] | 'Audio';
+      })
+    | CustomContentResource
+    | ChoiceBody;
   placeholderId: string | undefined;
   i: number;
-  exclude: (ContentResource['type'] | ChoiceBody['type'])[]; // allows us to exclude certain types from being rendered
+  exclude: (ContentResource['type'] | 'Audio' | ChoiceBody['type'])[]; // allows us to exclude certain types from being rendered
 };
 
 // This component will be useful for the IIIFViewer if we want to make that render video, audio, pdfs and Born Digital files in addition to images.

--- a/content/webapp/components/IIIFItem/IIIFItem.tsx
+++ b/content/webapp/components/IIIFItem/IIIFItem.tsx
@@ -55,6 +55,8 @@ const Choice: FunctionComponent<
 
 type ItemProps = {
   canvas: TransformedCanvas;
+  // Some of our ContentResources can have a type of 'Audio':
+  // https://iiif.wellcomecollection.org/presentation/v3/b17276342
   item:
     | (Omit<ContentResource, 'type'> & {
         type: ContentResource['type'] | 'Audio';
@@ -90,7 +92,8 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
         />
       );
     case ((item.type === 'Sound' && !exclude.includes('Sound')) ||
-      (item.type === 'Audio' && !exclude.includes('Audio'))) && Boolean(item.id):
+      (item.type === 'Audio' && !exclude.includes('Audio'))) &&
+      Boolean(item.id):
       return (
         <AudioPlayer
           audioFile={item.id || ''}

--- a/content/webapp/components/IIIFItem/IIIFItem.tsx
+++ b/content/webapp/components/IIIFItem/IIIFItem.tsx
@@ -89,8 +89,8 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
           exclude={exclude}
         />
       );
-    case (item.type === 'Sound' && !exclude.includes('Sound')) ||
-      (item.type === 'Audio' && !exclude.includes('Audio') && Boolean(item.id)):
+    case ((item.type === 'Sound' && !exclude.includes('Sound')) ||
+      (item.type === 'Audio' && !exclude.includes('Audio'))) && Boolean(item.id):
       return (
         <AudioPlayer
           audioFile={item.id || ''}

--- a/content/webapp/components/VideoPlayer/VideoPlayer.tsx
+++ b/content/webapp/components/VideoPlayer/VideoPlayer.tsx
@@ -4,7 +4,13 @@ import { ChoiceBody, ContentResource } from '@iiif/presentation-3';
 import { CustomContentResource } from '@weco/content/types/manifest';
 
 type Props = {
-  video: (ContentResource | CustomContentResource | ChoiceBody) & {
+  video: (
+    | (Omit<ContentResource, 'type'> & {
+        type: ContentResource['type'] | 'Audio';
+      })
+    | CustomContentResource
+    | ChoiceBody
+  ) & {
     format?: string;
   };
   placeholderId: string | undefined;

--- a/content/webapp/components/Work/Work.tsx
+++ b/content/webapp/components/Work/Work.tsx
@@ -64,7 +64,8 @@ function showItemLink({
   // This is usually the case, except for manifests with 'Born digital' items.
   // When we have born digital items, we show links to all the items on the work page instead of the players/view button, so it shouldn't matter.
   const hasVideo = hasItemType(canvases, 'Video');
-  const hasSound = hasItemType(canvases, 'Sound');
+  const hasSound =
+    hasItemType(canvases, 'Sound') || hasItemType(canvases, 'Audio');
   if (accessCondition === 'closed' || accessCondition === 'restricted') {
     return false;
   } else if (digitalLocation && !hasVideo && !hasSound) {

--- a/content/webapp/components/WorkDetails/index.tsx
+++ b/content/webapp/components/WorkDetails/index.tsx
@@ -150,7 +150,8 @@ const WorkDetails: FunctionComponent<Props> = ({
 
   const holdings = getHoldings(work);
   const hasVideo = hasItemType(canvases, 'Video');
-  const hasSound = hasItemType(canvases, 'Sound');
+  const hasSound =
+    hasItemType(canvases, 'Sound') || hasItemType(canvases, 'Audio');
 
   const showAvailableOnlineSection =
     (digitalLocation && shouldShowItemLink) || hasVideo || hasSound;


### PR DESCRIPTION
We render the audio player on the works page if we have a ContentResource of type 'Sound' in the IIIF Manifest.

It turns out [some of our IIIF manifests have ContentResources with a type of 'Audio'](https://iiif.wellcomecollection.org/presentation/v3/b17276342) (although this isn't supposed to be a valid value)

I've amended the type to make 'Audio' a possible value and now look for this too, when determining if we should display the AudioPlayer

[See conversation on Slack](https://wellcome.slack.com/archives/C8X9YKM5X/p1714637016038419)
