### PR TITLE
More tidy of mock data

### DIFF
--- a/cardigan/stories/components/MediaObject/MediaObject.stories.tsx
+++ b/cardigan/stories/components/MediaObject/MediaObject.stories.tsx
@@ -1,8 +1,8 @@
 import { MediaObject } from '@weco/content/components/MediaObject/MediaObject';
 import { mockData } from '@weco/common/test/fixtures/components/media-object';
-import { mockImage } from '@weco/common/test/fixtures/components/compact-card';
 import Readme from '@weco/content/components/MediaObject/README.md';
 import { ReadmeDecorator } from '@weco/cardigan/config/decorators';
+import { imageWithCrops } from '@weco/cardigan/stories/data/images';
 
 const Template = args => (
   <ReadmeDecorator WrappedComponent={MediaObject} args={args} Readme={Readme} />
@@ -11,6 +11,6 @@ export const basic = Template.bind({});
 basic.args = {
   title: mockData.title,
   text: mockData.text,
-  image: mockImage,
+  image: imageWithCrops,
 };
 basic.storyName = 'MediaObject';

--- a/cardigan/stories/components/TextAndImageOrIcons/TextAndImageOrIcons.stories.tsx
+++ b/cardigan/stories/components/TextAndImageOrIcons/TextAndImageOrIcons.stories.tsx
@@ -1,9 +1,9 @@
 import TextAndImageOrIcons from '@weco/content/components/TextAndImageOrIcons';
 import Readme from '@weco/content/components/TextAndImageOrIcons/README.md';
 import { ReadmeDecorator } from '@weco/cardigan/config/decorators';
-import { mockImage } from '@weco/common/test/fixtures/components/compact-card';
 import { smallText } from '@weco/cardigan/stories/data/text';
 import { mockIcons } from '@weco/common/test/fixtures/components/text-and-icons';
+import { image as genericImage } from '@weco/cardigan/stories/data/images';
 
 const Template = args => (
   <ReadmeDecorator
@@ -27,7 +27,7 @@ export const image = Template.bind({});
 image.args = {
   item: {
     type: 'image',
-    image: mockImage,
+    image: genericImage(),
     isZoomable: true,
     text: smallText(),
   },

--- a/cardigan/stories/data/images.ts
+++ b/cardigan/stories/data/images.ts
@@ -80,3 +80,36 @@ export const imageGallery = (): ImageGalleryProps & { id: number } => {
     isFrames: false,
   };
 };
+
+export const imageWithCrops = {
+  contentUrl: florenceWinterfloodImageUrl('1600x900'),
+  width: 1600,
+  height: 900,
+  alt: 'An artwork featuring a large painted human hand, surrounded by fragments of maps.',
+  tasl: {
+    title: "Alzheimer's disease",
+    author: 'Florence Winterflood',
+    sourceName: 'Wellcome Collection',
+    sourceLink: 'CC-BY-NC',
+    license: undefined,
+    copyrightHolder: undefined,
+    copyrightLink: undefined,
+  },
+  simpleCrops: {
+    '32:15': {
+      contentUrl: florenceWinterfloodImageUrl('3200x1500'),
+      width: 3200,
+      height: 1500,
+    },
+    '16:9': {
+      contentUrl: florenceWinterfloodImageUrl('3200x1800'),
+      width: 3200,
+      height: 1800,
+    },
+    square: {
+      contentUrl: florenceWinterfloodImageUrl('3200x3200'),
+      width: 3200,
+      height: 3200,
+    },
+  },
+};

--- a/common/test/fixtures/components/media-object.ts
+++ b/common/test/fixtures/components/media-object.ts
@@ -8,8 +8,8 @@ export const mockData = {
       text: 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.',
       spans: [
         {
-          start: 48,
-          end: 54,
+          start: 53,
+          end: 64,
           type: 'hyperlink',
           data: {
             link_type: 'Web',


### PR DESCRIPTION
## Who is this for?
Maintenance #10289 

## What is it doing for them?
Let's move mock data over here or somewhere similar and organise it so it can be used both by tests and by cardigan. https://github.com/wellcomecollection/wellcomecollection.org/tree/main/common/test/fixtures/components