### PR TITLE
Account for interpretations being absent

### DIFF
--- a/content/webapp/services/prismic/transformers/events.ts
+++ b/content/webapp/services/prismic/transformers/events.ts
@@ -190,7 +190,7 @@ export function transformEvent(
     scheduleQuery && scheduleQuery.results
       ? scheduleQuery.results.map(doc => transformEvent(doc))
       : [];
-  const interpretations: Interpretation[] = data.interpretations
+  const interpretations: Interpretation[] = (data.interpretations || [])
     .map(interpretation =>
       prismic.isFilled.link(interpretation.interpretationType)
         ? {


### PR DESCRIPTION
This fixes an error we're seeing on the Schools page where events listed are expected to have an `interpretations` array, but don't.

I'm not happy that this is the final fix because it doesn't explain how this was working before (is there now interpretation data that is missing?)

But it stops the page 500ing.