### PR TITLE
Only show available online section when there is something to display in it

### DIFF
--- a/content/webapp/components/WorkDetails/index.tsx
+++ b/content/webapp/components/WorkDetails/index.tsx
@@ -154,7 +154,8 @@ const WorkDetails: FunctionComponent<Props> = ({
   const hasVideo = hasItemType(canvases, 'Video');
   const hasSound =
     hasItemType(canvases, 'Sound') || hasItemType(canvases, 'Audio');
-  const hasBornDigital = bornDigitalStatus !== 'noBornDigital';
+  const hasBornDigital =
+    bornDigitalStatus && bornDigitalStatus !== 'noBornDigital';
 
   const showAvailableOnlineSection =
     (digitalLocation && shouldShowItemLink) ||


### PR DESCRIPTION
We were sometimes mistakenly showing the 'Available online section' when there  was nothing to display inside it.

See: https://wellcome.slack.com/archives/C3TQSF63C/p1715759922441179

This stops that
