### PR TITLE
Automatically size images based on their aspect ratios

### DIFF
--- a/common/views/slices/EditorialImage/index.tsx
+++ b/common/views/slices/EditorialImage/index.tsx
@@ -9,7 +9,6 @@ import {
 } from '@weco/content/components/Body/Body';
 import CaptionedImage from '@weco/content/components/CaptionedImage/CaptionedImage';
 import { transformEditorialImageSlice } from '@weco/content/services/prismic/transformers/body';
-import Layout, { gridSize12 } from '@weco/common/views/components/Layout';
 
 export type EditorialImageSliceProps = SliceComponentProps<
   SliceType,
@@ -23,27 +22,39 @@ const EditorialImageSlice: FunctionComponent<EditorialImageSliceProps> = ({
   const transformedSlice = transformEditorialImageSlice(slice);
 
   const options = { ...defaultContext, ...context };
-  // TODO: use one layout for all image weights if/when it's established
-  // that width isn't an adequate means to illustrate a difference
+  const width = transformedSlice.value.image.width;
+  const height = transformedSlice.value.image.height;
+  const widthDividedByHeight = width / height;
+
+  const aspectRatio = () => {
+    switch (true) {
+      case widthDividedByHeight >= 0.9 && widthDividedByHeight <= 1.1:
+        return 'square';
+      case widthDividedByHeight > 1.1:
+        return 'landscape';
+      case widthDividedByHeight < 0.9:
+        return 'portrait';
+    }
+  };
+
+  // Our images are constrained by viewport height so that they will always fit
+  // on the screen, but we want to make them feel proportionally similar
+  // regardless of their aspect ratio. To do this we can set the _maximum_
+  // number of columns that they're allowed to fill in width (but with no
+  // guarantees that they will get to that width because of the height
+  // constraint)
+  const maxColumns =
+    options.isVisualStory || aspectRatio() === 'portrait'
+      ? 8
+      : aspectRatio() === 'square'
+      ? 10
+      : 12; // landscape
+
   return (
     <SpacingComponent $sliceType={transformedSlice.type}>
-      {transformedSlice.weight === 'default' && (
-        <LayoutWidth width={options.isVisualStory ? 8 : 10}>
-          <CaptionedImage {...transformedSlice.value} />
-        </LayoutWidth>
-      )}
-
-      {transformedSlice.weight === 'standalone' && (
-        <Layout gridSizes={gridSize12()}>
-          <CaptionedImage {...transformedSlice.value} />
-        </Layout>
-      )}
-
-      {transformedSlice.weight === 'supporting' && (
-        <LayoutWidth width={options.minWidth}>
-          <CaptionedImage {...transformedSlice.value} />
-        </LayoutWidth>
-      )}
+      <LayoutWidth width={maxColumns}>
+        <CaptionedImage {...transformedSlice.value} />
+      </LayoutWidth>
     </SpacingComponent>
   );
 };


### PR DESCRIPTION
For #10865 

## Who is this for?
Everyone

## What is it doing for them?
Making images take varying amounts of horizontal space based on their aspect ratios

Landscape images can take up a maximum of 12 columns
Square images can take up a maximum of 10 columns
Portrait images can take up a maximum of 8 columns

Note: images will continue to be constrained by their height to ensure that they always fit within the viewport, so they may not get to their maximum possible width depending on the user's browser.