### PR TITLE
Use options instead of context so slice-simulator works

### DIFF
--- a/common/views/slices/Text/index.tsx
+++ b/common/views/slices/Text/index.tsx
@@ -21,7 +21,7 @@ const Text: FunctionComponent<TextProps> = ({ slice, context, index }) => {
   const options = { ...defaultContext, ...context };
   return (
     <SpacingComponent $sliceType={slice.slice_type}>
-      <LayoutWidth width={context.minWidth}>
+      <LayoutWidth width={options.minWidth}>
         <div
           className={classNames({
             'body-text spaced-text': true,


### PR DESCRIPTION
## Who is this for?
Content editors

## What is it doing for them?
Allowing text slices to show up in the real-time view