### PR TITLE
Remove the x-frame-options header from the slice-simulator route

### DIFF
--- a/content/webapp/app.ts
+++ b/content/webapp/app.ts
@@ -53,6 +53,12 @@ const appPromise = nextApp
       };
     });
 
+    router.get('/slice-simulator', async (ctx, next) => {
+      ctx.remove('x-frame-options');
+
+      await next();
+    });
+
     router.get('/preview', async ctx => {
       // Kill any cookie we had set, as it think it is causing issues.
       ctx.cookies.set(prismic.cookie.preview);


### PR DESCRIPTION
## Who is this for?
Content editors

## What is it doing for them?
Allowing them to see real-time previews of slices in the Prismic Page Builder

