### PR TITLE
Show early registration info inside event schedule

### DIFF
--- a/content/webapp/components/EventSchedule/EventScheduleItem.tsx
+++ b/content/webapp/components/EventSchedule/EventScheduleItem.tsx
@@ -197,7 +197,13 @@ const EventScheduleItem: FunctionComponent<Props> = ({
               !event.bookingEnquiryTeam &&
               !(event.schedule && event.schedule.length > 1) && (
                 <Space $v={{ size: 'm', properties: ['margin-top'] }}>
-                  <Message text="Just turn up" />
+                  <Message
+                    text={`${
+                      event.hasEarlyRegistration
+                        ? 'Arrive early to register'
+                        : 'Just turn up'
+                    }`}
+                  />
                 </Space>
               )}
 


### PR DESCRIPTION
## Who is this for?
People coming to events

## What is it doing for them?
Making sure they have the right information about event availability.

<img width="897" alt="image" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/1394592/994a2cac-ad5a-44a2-906e-562aded312ba">
