### PR TITLE
Webcomics on stories landing

### DIFF
--- a/content/webapp/services/prismic/fetch/stories-landing.ts
+++ b/content/webapp/services/prismic/fetch/stories-landing.ts
@@ -8,6 +8,17 @@ const graphQuery = `{
     storiesDescription
     stories {
       story {
+        ... on series {
+          title
+          promo {
+            ... on editorialImage {
+              non-repeat {
+                caption
+                image
+              }
+            }
+          }
+        }
         ... on webcomics {
           title
           format {

--- a/content/webapp/services/prismic/fetch/stories-landing.ts
+++ b/content/webapp/services/prismic/fetch/stories-landing.ts
@@ -8,6 +8,27 @@ const graphQuery = `{
     storiesDescription
     stories {
       story {
+        ... on webcomics {
+          title
+          format {
+            ... on article-formats {
+              title
+            }
+          }
+          promo {
+            ... on editorialImage {
+              non-repeat {
+                caption
+                image
+              }
+            }
+          }
+          series {
+            series {
+              title
+            }
+          }
+        }
         ... on articles {
           title
           format {

--- a/content/webapp/services/prismic/transformers/stories-landing.ts
+++ b/content/webapp/services/prismic/transformers/stories-landing.ts
@@ -14,7 +14,7 @@ import { isFilledLinkToDocumentWithData } from '@weco/common/services/prismic/ty
 import { asRichText, asText } from '.';
 
 function transformStoryOrSeries(storyOrSeries) {
-  if (storyOrSeries.type === 'articles') {
+  if (storyOrSeries.type === 'articles' || storyOrSeries.type === 'webcomics') {
     return transformArticleToArticleBasic(transformArticle(storyOrSeries));
   } else {
     return transformSeriesToSeriesBasic(transformSeries(storyOrSeries));


### PR DESCRIPTION
Relates to #10867

- Makes sure we fetch the data for webcomics (and series) if they are added to the content list of the stories landing page
- Makes sure we render the card for a webcomic correctly
