### PR TITLE
Allow webcomics type to be added to stories landing

### DIFF
--- a/common/customtypes/stories-landing/index.json
+++ b/common/customtypes/stories-landing/index.json
@@ -3,6 +3,7 @@
   "label": "Stories landing",
   "repeatable": false,
   "status": true,
+  "format": "custom",
   "json": {
     "Main": {
       "introText": {
@@ -40,7 +41,7 @@
               "config": {
                 "label": "story/series",
                 "select": "document",
-                "customtypes": ["articles", "series"]
+                "customtypes": ["articles", "series", "webcomics"]
               }
             }
           }
@@ -80,6 +81,5 @@
         }
       }
     }
-  },
-  "format": "custom"
+  }
 }

--- a/common/prismicio-types.d.ts
+++ b/common/prismicio-types.d.ts
@@ -4943,7 +4943,7 @@ export interface StoriesLandingDocumentDataStoriesItem {
    * - **API ID Path**: stories-landing.stories[].story
    * - **Documentation**: https://prismic.io/docs/field#link-content-relationship
    */
-  story: prismic.ContentRelationshipField<'articles' | 'series'>;
+  story: prismic.ContentRelationshipField<'articles' | 'series' | 'webcomics'>;
 }
 
 /**


### PR DESCRIPTION
Relates to #10867 

Allows the deprecated webcomics type to be added to the content list on the stories landing page.

It seems [Helen managed to do this somehow without this](https://wellcome.slack.com/archives/C8X9YKM5X/p1715676681291539). I've no idea how, but this seems like a sensible addition.
