### PR TITLE
Add cookies to table, manage consent, add third-party cookies

### DIFF
--- a/common/data/cookies.ts
+++ b/common/data/cookies.ts
@@ -1,9 +1,11 @@
-/** This file exists for two reasons:
+/** This file exists for three reasons:
  *
  *    1. To ensure that we use cookie names consistently, rather than
  *       passing around magic strings.
  *
  *    2. To make it easier to assess the set of custom cookies we're setting.
+ *
+ *    3. To make it easier for anyone to update the Cookie policy tables
  */
 
 const cookies = {
@@ -35,6 +37,256 @@ const cookies = {
 
   // Causes Segment session info to be logged to the dev console.
   analyticsDebug: 'WC_analyticsDebug',
+};
+
+export const cookiesTableCopy = {
+  strictlyNecessaryCookies: [
+    [
+      `CivicUK`,
+      `CookieControl`,
+      `This stores your cookie consent preferences`,
+      `182 days`,
+    ],
+    [
+      `SessionID`,
+      `Preserves the visitor's session state across page requests`,
+      `Persistant`,
+    ],
+    [
+      `Auth0`,
+      `auth0+A4`,
+      `Used to implement the session layer for single sign on`,
+      `Session`,
+    ],
+    [
+      `Auth0`,
+      `auth0_compart`,
+      `Fallback for single sign-on on browsers that don't support the sameSite=None attribute`,
+      `Session`,
+    ],
+    [
+      `Auth0`,
+      `did`,
+      `Device identification for bot attack protection`,
+      `Session`,
+    ],
+    [
+      `Auth0`,
+      `did_compat`,
+      `Fallback for anomaly detection on browsers that don't support the sameSite=None attribute.`,
+      `Session`,
+    ],
+    [
+      `Auth0`,
+      `wecoIdentitySession`,
+      `Indicates that successful authentication occurred with the identity provider`,
+      `7 days`,
+    ],
+    [
+      `Wellcome`,
+      `WC_userPreferenceGuideType`,
+      `Used on exhibition guide pages to remember which type of digital exhibition guide the user prefers`,
+      `8 hours`,
+    ],
+    [
+      `Wellcome`,
+      `WC_PopupDialog`,
+      `Remembers that the user has cloesd the popup dialogso it is not displayed again`,
+      `Session`,
+    ],
+    [
+      `Wellcome`,
+      `WC_globalAlert`,
+      `Remembers that the user has closed the global alert banner so it is not displayed again`,
+      `Session`,
+    ],
+    [
+      `Wellcome`,
+      `WC_siteIssueBanner`,
+      `Remembers that the user has closed the banner about website issues so it is not displayed again`,
+      `4 hours`,
+    ],
+    [
+      `Wellcome`,
+      `WC_wellcomeImagesRedirect`,
+      `Used to indicate if the user has closed the banner you see when you've been redirected from Wellcome Images`,
+      `2036-12-31T23:59:59Z`,
+    ],
+    [
+      `Wellcome`,
+      `WC_apiToolbarMini`,
+      `Used to indicate if the user is using the "mini" version of the API toolbar`,
+      `Session`,
+    ],
+    [
+      `Wellcome`,
+      `toggle_*`,
+      `Set by Wellcome to switch on/off website features that are under development, or only intended for a subset of users e.g. Wellcome staff or people taking part in usability research`,
+      `1 year`,
+    ],
+    [
+      `Cloudflare`,
+      `__cf_bm`,
+      `Used to read and filter requests from bots`,
+      `30 mins`,
+    ],
+    [`Prismic`, `Prismic-auth`, `Allows requests to Prismic API`, `Session`],
+    [`Google`, `Ar_debug`, `Used by Google Ad Services to debug ads`, `1 year`],
+    [
+      `YouTube`,
+      `VISITOR_PRIVACY_METADATA`,
+      `Stores the user's cookie consent state for the current domain`,
+      `180 days`,
+    ],
+  ],
+  analyticsCookies: [
+    [
+      `Google Analytics`,
+      `_ga`,
+      `Used by Google Analytics to register a unique ID that distinguishes visitors and generate statistical data on how each visitor uses the website`,
+      `2 years`,
+    ],
+    [
+      `Google Analytics`,
+      `_ga_<container-id>`,
+      `Used by Google Analytics to persist session state`,
+      `2 years`,
+    ],
+    [
+      `Google Analytics`,
+      `_gid`,
+      `Used by Google Analytics, these help us count how many people visit wellcomecollection.org by tracking if you’ve visited before`,
+      `1 day`,
+    ],
+    [
+      `Google Analytics`,
+      `_gat`,
+      `Used to monitor number of Google Analytics server requests when using Google Tag Manager`,
+      `1 min`,
+    ],
+    [
+      `Google Analytics`,
+      `_dc_gtm_`,
+      `Used to monitor number of Google Analytics server requests`,
+      `1 min`,
+    ],
+    [
+      `Google Analytics`,
+      `AMP_TOKEN`,
+      `Contains a token code that is used to read out a Client ID from the AMP Client ID Service. By matching this ID with that of Google Analytics, users can be matched when switching between AMP content and non-AMP content`,
+      `1 year`,
+    ],
+    [
+      `Google Analytics`,
+      `_gat_`,
+      `Used to set and get tracking data`,
+      `1 hour`,
+    ],
+    [
+      `Google Analytics`,
+      `_utma`,
+      `ID used to identify users and Sessions`,
+      `2 years`,
+    ],
+    [
+      `Google Analytics`,
+      `_utmt`,
+      `Used to monitor number of Google Analytics server requests`,
+      `10 mins`,
+    ],
+    [
+      `Google Analytics`,
+      `_utmb`,
+      `Used to distinguish new sessions and visits. This cookie is set when the GA.js javascript library is loaded and there is no existing __utmb cookie. The cookie is updated every time data is sent to the Google Analytics server.`,
+      `30 mins`,
+    ],
+    [
+      `Google Analytics`,
+      `_utmz`,
+      `Contains information about the traffic source or campaign that directed user to the website. The cookie is set when the GA.js javascript is loaded and updated when data is sent to the Google Anaytics server`,
+      `182 days`,
+    ],
+    [
+      `Segment`,
+      `ajs_anonymous_id`,
+      `These cookies identify user sessions with an anonymous ID generated by Analytics.js`,
+      `1 year`,
+    ],
+    [
+      `Segment`,
+      `ajs_group_id`,
+      `A group ID that can be specified by making a group call with Analytics.js`,
+      `1 year`,
+    ],
+    [
+      `Segment`,
+      `ajs_user_id`,
+      `A user ID that can be specified by making an identify call with Analytics.js`,
+      `1 year`,
+    ],
+    [
+      `HotJar`,
+      `_hjSessionUser_#`,
+      `Collects statistics on the visitor's visits to the website, such as the number of visits, average time spent on the website and what pages have been read.`,
+      `1 Year`,
+    ],
+    [
+      `HotJar`,
+      `_hjSession_#`,
+      `Collects statistics on the visitor's visits to the website, such as the number of visits, average time spent on the website and what pages have been read.`,
+      `30 minutes`,
+    ],
+    [
+      `HotJar`,
+      `hjViewportId`,
+      `Saves the user's screen size in order to adjust the size of images on the website.`,
+      `Session`,
+    ],
+    [
+      `HotJar`,
+      `hjActiveViewportIds`,
+      `Contains an ID string on the current session. This contains non-personal information on what subpages the visitor enters – this information is used to optimize the visitor's experience.`,
+      `Session`,
+    ],
+    [
+      `Google`,
+      `td`,
+      `Registers statistical data on users' behaviour on the website. Used for internal analytics by the website operator.`,
+      `Session`,
+    ],
+    [
+      `YouTube`,
+      `PREF`,
+      `Used to store information such as a user's preferred page configuration and playback preferences like autoplay, shuffle content, and player size.`,
+      `243 days`,
+    ],
+    [
+      `YouTube`,
+      `VISITOR_INFO1_LIVE`,
+      `Tries to estimate the users' bandwidth on pages with integrated YouTube videos`,
+      `180 days`,
+    ],
+  ],
+  marketingCookies: [
+    [
+      `YouTube`,
+      `YSC`,
+      `Stores and tracks views on embedded YouTube videos`,
+      `Session`,
+    ],
+    [
+      `Google`,
+      `_gac_`,
+      `Contains information related to marketing campaigns of the user. These are shared with Google AdWords / Google Ads when the Google Ads and Google Analytics accounts are linked together.`,
+      `90 days`,
+    ],
+    [
+      `Segment`,
+      `__tld__`,
+      `Used to track visitors on multiple websites, in order to present relevant advertisement based on the visitor's preferences`,
+      `Session`,
+    ],
+  ],
 };
 
 export default cookies;

--- a/common/views/components/CivicUK/index.tsx
+++ b/common/views/components/CivicUK/index.tsx
@@ -63,11 +63,11 @@ const necessaryCookies = () => {
   // View @weco/common/data/cookies for details on each
   const wcCookies = Object.values(cookies).map(c => c);
 
-  // Allows Prismic previews
-  const prismicPreview = ['io.prismic.preview', 'isPreview'];
-
   // See @weco/toggles/webapp/toggles for details on each
   const featureFlags = ['toggle_*'];
+
+  // Allows Prismic previews
+  const prismicPreview = ['io.prismic.preview', 'isPreview'];
 
   // Digirati auth related
   const digiratiCookies = ['dlcs-*'];
@@ -106,26 +106,55 @@ const CivicUK = (props: Props) => (
                 label: '<h2 ${headingStyles}>Measure website use</h2>',
                 description:
                   '<ul><li>We use these cookies to recognise you, to count your visits to the website, and to see how you move around it.</li><li>They help us to provide you with a good experience while you browse, for example by helping to make sure you can find what you need.</li><li>They also allows us to improve the way the website works.</li></ul>',
-                cookies: [
-                  '_ga',
-                  '_ga*',
-                  '_gid',
-                  '_gat',
-                  '__utma',
-                  '__utmt',
-                  '__utmb',
-                  '__utmc',
-                  '__utmz',
-                  '__utmv',
-                ],
                 onAccept: function () {
-                  const event = new CustomEvent('analyticsConsentChanged', { detail: { consent: 'granted' }});
+                  const event = new CustomEvent('analyticsConsentChanged', { detail: { analyticsConsent: 'granted' }});
                   window.dispatchEvent(event);
                 },
                 onRevoke: function () {
-                  const event = new CustomEvent('analyticsConsentChanged', { detail: { consent: 'denied' } });
+                  const event = new CustomEvent('analyticsConsentChanged', { detail: { analyticsConsent: 'denied' } });
                   window.dispatchEvent(event);
                 },
+                thirdPartyCookies: [
+                  {
+                    name: 'Youtube',
+                    optOutLink: 'https://www.youtube.com/intl/ALL_uk/howyoutubeworks/user-settings/privacy/',
+                  },
+                  {
+                    name: 'Segment', optOutLink: '/'
+                  },
+                  {
+                    name: 'Google', optOutLink: '/'
+                  },
+                  {
+                    name: 'HotJar', optOutLink: '/'
+                  }
+                ],
+              },
+              {
+                name: 'marketing',
+                label: '<h2 ${headingStyles}>Cookies for communications and marketing</h2>',
+                description:
+                  'We will use these to measure how you are interacting with our marketing and advertising materials, and the effectiveness of our campaigns.',
+                onAccept: function () {
+                  const event = new CustomEvent('analyticsConsentChanged', { detail: { marketingConsent: 'granted' }});
+                  window.dispatchEvent(event);
+                },
+                onRevoke: function () {
+                  const event = new CustomEvent('analyticsConsentChanged', { detail: { marketingConsent: 'denied' } });
+                  window.dispatchEvent(event);
+                },
+                thirdPartyCookies: [
+                  {
+                    name: 'Youtube',
+                    optOutLink: 'https://www.youtube.com/intl/ALL_uk/howyoutubeworks/user-settings/privacy/',
+                  },
+                  {
+                    name: 'Segment', optOutLink: '/'
+                  },
+                  {
+                    name: 'Google', optOutLink: '/'
+                  }
+                ],
               },
             ],   
             statement: ${JSON.stringify(statement)},

--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -87,12 +87,23 @@ const WecoApp: FunctionComponent<WecoAppProps> = ({
 
   useMaintainPageHeight();
 
+  type ConsentType = 'granted' | 'denied';
   const onAnalyticsConsentChanged = (
-    event: CustomEvent<{ consent: 'granted' | 'denied' }>
+    event: CustomEvent<{
+      analyticsConsent?: ConsentType;
+      marketingConsent?: ConsentType;
+    }>
   ) => {
     // Update datalayer config with consent value
     gtag('consent', 'update', {
-      analytics_storage: event.detail.consent,
+      ...(event.detail.analyticsConsent && {
+        analytics_storage: event.detail.analyticsConsent,
+      }),
+      ...(event.detail.marketingConsent && {
+        ad_storage: event.detail.marketingConsent,
+        ad_personalization: event.detail.marketingConsent,
+        ad_user_data: event.detail.marketingConsent,
+      }),
     });
   };
 

--- a/content/webapp/pages/cookie-policy.tsx
+++ b/content/webapp/pages/cookie-policy.tsx
@@ -9,34 +9,12 @@ import Layout, { gridSize8 } from '@weco/common/views/components/Layout';
 import { setCacheControl } from '@weco/content/utils/setCacheControl';
 import Table from '@weco/content/components/Table';
 import { policyUpdatedDate } from '@weco/common/views/components/CivicUK';
+import { cookiesTableCopy } from '@weco/common/data/cookies';
 
-const CookieTable = () => {
+const CookieTable = ({ rows }: { rows: string[][] }) => {
   return (
     <Table
-      rows={[
-        [
-          'Cookie name',
-          'Provider',
-          'Purpose',
-          'Type (1st/3rd Party)',
-          'Duration',
-        ],
-        [
-          'lorem ipsum',
-          'dolor sit amet',
-          'lorem ipsum dolor sit amet lorem ipsum dolor sit amet',
-          '1st',
-          '90 days',
-        ],
-        [
-          'lorem ipsum',
-          'dolor sit amet',
-          'lorem ipsum dolor sit amet lorem ipsum dolor sit amet',
-          '1st',
-          '90 days',
-        ],
-        ['', '', '', '', ''],
-      ]}
+      rows={[['Provider', 'Cookie name', 'Purpose', 'Duration'], ...rows]}
       withBorder={true}
     ></Table>
   );
@@ -201,7 +179,7 @@ const CookiePolicy: FunctionComponent = () => {
                 remembering your privacy settings, or information that you enter
                 into an online form.
               </p>
-              <CookieTable />
+              <CookieTable rows={cookiesTableCopy.strictlyNecessaryCookies} />
 
               <h4>Cookies that measure website use</h4>
               <p>
@@ -212,7 +190,7 @@ const CookiePolicy: FunctionComponent = () => {
                 us improve the website. We use the following analytics cookies
                 on our websites:
               </p>
-              <CookieTable />
+              <CookieTable rows={cookiesTableCopy.analyticsCookies} />
 
               <h4>Cookies that help with our communications and marketing</h4>
               <p>
@@ -231,7 +209,7 @@ const CookiePolicy: FunctionComponent = () => {
                 enable us to reach a diverse and wide ranging audience.
               </p>
               <p>We use the following marketing cookies on our websites:</p>
-              <CookieTable />
+              <CookieTable rows={cookiesTableCopy.marketingCookies} />
 
               <h3>Controlling all cookies</h3>
               <p>


### PR DESCRIPTION
## Who is this for?
Cookie work, #10868, #10717, for Lauren to visualise some things we talked about as well.

## What is it doing for them?
- Adds a Marketing cookie category in our Civic UK preference centre.
- Removes list of cookies from `analytics` as I think they belong in the `third party cookie` section instead. None of them are our own AFAIK.
- Deals with marketing consent for Gtag.
- Add content to the tables listing the cookies we use.

This is still a WIP but we want to get it in front of Lauren for further decision making.