### PR TITLE
Cookies: `getConsentStatus` function more generic, add condition to YT script

### DIFF
--- a/common/server-data/index.ts
+++ b/common/server-data/index.ts
@@ -20,7 +20,7 @@ import togglesHandler, { getTogglesFromContext } from './toggles';
 import prismicHandler from './prismic';
 import { simplifyServerData } from '../services/prismic/transformers/server-data';
 import { SimplifiedServerData } from './types';
-import { getAnalyticsConsentState } from '@weco/common/services/app/civic-uk';
+import { getConsentState } from '@weco/common/services/app/civic-uk';
 
 export type Handler<DefaultData, FetchedData> = {
   defaultValue: DefaultData;
@@ -133,7 +133,7 @@ export const getServerData = async (
     toggles[enableToggle].value = true;
   }
 
-  const hasAnalyticsConsent = getAnalyticsConsentState(context);
+  const hasAnalyticsConsent = getConsentState('analytics', context);
 
   const serverData = { toggles, prismic, hasAnalyticsConsent };
 

--- a/common/services/app/civic-uk.ts
+++ b/common/services/app/civic-uk.ts
@@ -4,10 +4,18 @@ import { GetServerSidePropsContext } from 'next';
 type CivicUKCookie = {
   optionalCookies?: {
     analytics: 'accepted' | 'revoked';
+    marketing: 'accepted' | 'revoked';
   };
 };
 
-export const getAnalyticsConsentState = (
+/**
+ * Gets the current status of a specific consent category, passing the context in if server-side.
+ *
+ * @param {'analytics' | 'marketing'} type - Name of the category
+ * @param {GetServerSidePropsContext | undefined} context - Server-side context
+ */
+export const getConsentState = (
+  type: 'analytics' | 'marketing',
   context?: GetServerSidePropsContext
 ): boolean => {
   const cookies = getCookies(context);
@@ -24,7 +32,7 @@ export const getAnalyticsConsentState = (
         decodeURIComponent(consentCookie)
       );
 
-      return civicUKCookie.optionalCookies?.analytics === 'accepted';
+      return civicUKCookie.optionalCookies?.[type] === 'accepted';
     } else {
       // If the feature flag is ON but consent has yet to be defined
       return false;

--- a/common/services/conversion/track.ts
+++ b/common/services/conversion/track.ts
@@ -4,7 +4,7 @@ import { ParsedUrlQuery } from 'querystring';
 import { v4 as uuidv4 } from 'uuid';
 import cookies from '@weco/common/data/cookies';
 import { PageviewName } from '@weco/common/data/segment-values';
-import { getAnalyticsConsentState } from '@weco/common/services/app/civic-uk';
+import { getConsentState } from '@weco/common/services/app/civic-uk';
 
 declare global {
   interface Window {
@@ -130,7 +130,7 @@ function trackSegmentEvent({
 }
 
 function track(conversion: Conversion) {
-  const hasAnalyticsConsent = getAnalyticsConsentState();
+  const hasAnalyticsConsent = getConsentState('analytics');
   // if we don't have consent or the analytics object isn't available, don't track
   if (!hasAnalyticsConsent || !window.analytics) return;
 

--- a/common/views/components/CivicUK/index.tsx
+++ b/common/views/components/CivicUK/index.tsx
@@ -84,7 +84,16 @@ const necessaryCookies = () => {
   ];
 };
 
-const analyticsCookies = ['_gid', '_gat', '_ga*', 'ajs_anonymous_id'];
+const analyticsCookies = [
+  '_gid',
+  '_gat',
+  '_ga*',
+  'ajs_anonymous_id',
+  'PREF',
+  'VISITOR_INFO1_LIVE',
+  'VISITOR_PRIVACY_METADATA',
+  'YSC',
+];
 
 type Props = {
   apiKey: string;

--- a/common/views/components/CivicUK/index.tsx
+++ b/common/views/components/CivicUK/index.tsx
@@ -84,16 +84,7 @@ const necessaryCookies = () => {
   ];
 };
 
-const analyticsCookies = [
-  '_gid',
-  '_gat',
-  '_ga*',
-  'ajs_anonymous_id',
-  'PREF',
-  'VISITOR_INFO1_LIVE',
-  'VISITOR_PRIVACY_METADATA',
-  'YSC',
-];
+const analyticsCookies = ['_gid', '_gat', '_ga*', 'ajs_anonymous_id'];
 
 type Props = {
   apiKey: string;

--- a/common/views/components/VideoEmbed/VideoEmbed.tsx
+++ b/common/views/components/VideoEmbed/VideoEmbed.tsx
@@ -6,6 +6,7 @@ import Caption from '../Caption/Caption';
 import { IframeContainer } from '../Iframe/Iframe';
 import CollapsibleContent from '@weco/common/views/components/CollapsibleContent';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
+import { getConsentState } from '@weco/common/services/app/civic-uk';
 
 export type Props = {
   embedUrl: string;
@@ -59,26 +60,29 @@ const VideoEmbed: FunctionComponent<Props> = ({
 }: Props) => {
   const [isActive, setIsActive] = useState(false);
   const id = embedUrl.match(/embed\/(.*)\?/)?.[1];
+  const hasAnalyticsConsent = getConsentState('analytics');
 
   useEffect(() => {
-    // GA4 automatically tracks youtube engagment, but requires the iframe api
-    // script to have been loaded on the page. Since we're lazyloading youtube
-    // videos, we have to add the script ourselves (and check that we haven't
-    // done so already). The following is a version of 'option 3' from this article:
-    // https://www.analyticsmania.com/post/youtube-tracking-google-tag-manager-solved/
-    const scriptId = 'youtube-iframe-api';
-    const youtubeIframeApi = document.getElementById(scriptId);
+    if (hasAnalyticsConsent) {
+      // GA4 automatically tracks youtube engagment, but requires the iframe api
+      // script to have been loaded on the page. Since we're lazyloading youtube
+      // videos, we have to add the script ourselves (and check that we haven't
+      // done so already). The following is a version of 'option 3' from this article:
+      // https://www.analyticsmania.com/post/youtube-tracking-google-tag-manager-solved/
+      const scriptId = 'youtube-iframe-api';
+      const youtubeIframeApi = document.getElementById(scriptId);
 
-    if (youtubeIframeApi) return;
+      if (youtubeIframeApi) return;
 
-    const s = document.createElement('script');
-    s.id = scriptId;
-    s.type = 'text/javascript';
-    s.async = true;
-    s.src = '//www.youtube.com/iframe_api';
+      const s = document.createElement('script');
+      s.id = scriptId;
+      s.type = 'text/javascript';
+      s.async = true;
+      s.src = '//www.youtube.com/iframe_api';
 
-    const firstScript = document.getElementsByTagName('script')[0];
-    firstScript.parentNode?.insertBefore(s, firstScript);
+      const firstScript = document.getElementsByTagName('script')[0];
+      firstScript.parentNode?.insertBefore(s, firstScript);
+    }
   }, []);
 
   return (
@@ -92,7 +96,7 @@ const VideoEmbed: FunctionComponent<Props> = ({
               allowFullScreen={true}
               allow="autoplay; picture-in-picture"
               src={`${embedUrl}&enablejsapi=1&autoplay=1`}
-              frameBorder="0"
+              style={{ border: 0 }}
             />
           ) : (
             <VideoTrigger

--- a/content/webapp/hooks/useHotjar.ts
+++ b/content/webapp/hooks/useHotjar.ts
@@ -5,7 +5,7 @@
 // We should probably move out the pieces that are troublesome, and check the rest
 
 import { useEffect, useState } from 'react';
-import { getAnalyticsConsentState } from '@weco/common/services/app/civic-uk';
+import { getConsentState } from '@weco/common/services/app/civic-uk';
 
 declare global {
   interface Window {
@@ -46,7 +46,7 @@ const heatMapTrigger = (triggerName: string): void => {
 
 const useHotjar = (shouldRender: boolean, triggerName?: string) => {
   const [rendered, setRendered] = useState(false);
-  const hasAnalyticsConsent = getAnalyticsConsentState();
+  const hasAnalyticsConsent = getConsentState('analytics');
 
   useEffect(() => {
     if (!hasAnalyticsConsent) return;

--- a/content/webapp/pages/cookie-policy.tsx
+++ b/content/webapp/pages/cookie-policy.tsx
@@ -49,15 +49,14 @@ const CookiePolicy: FunctionComponent<page.Props> = (props: page.Props) => {
     .filter(isNotUndefined);
 
   return (
-    // TODO do we want this to come from Prismic as well or do we just want to return the body from getServerSideProps?
     <PageLayout
-      title="Cookie policy"
-      description="This policy contains information on cookies used on the Wellcome Collection website and how to manage your cookie preferences."
+      title={props.page.title}
+      description={props.page.metadataDescription || ''}
       hideNewsletterPromo={true}
       url={{ pathname: '/cookie-policy' }}
       jsonLd={{ '@type': 'WebPage' }}
       openGraphType="website"
-      siteSection="about-us"
+      siteSection={props.page.siteSection}
     >
       <PageHeader
         breadcrumbs={{ items: [] }}
@@ -67,7 +66,6 @@ const CookiePolicy: FunctionComponent<page.Props> = (props: page.Props) => {
       />
       <Space $v={{ size: 'xl', properties: ['margin-top'] }}>
         <Space $v={{ size: 'xl', properties: ['padding-bottom'] }}>
-          {/* TODO Do we care about transformedBody? */}
           {props.page.untransformedBody.map((slice, index) => {
             return tablesPosition.includes(index) ? (
               <CookieTable

--- a/content/webapp/pages/cookie-policy.tsx
+++ b/content/webapp/pages/cookie-policy.tsx
@@ -60,7 +60,7 @@ const CookiePolicy: FunctionComponent<page.Props> = (props: page.Props) => {
     >
       <PageHeader
         breadcrumbs={{ items: [] }}
-        title="Cookie policy"
+        title={props.page.title}
         backgroundTexture={landingHeaderBackgroundLs}
         highlightHeading={true}
       />


### PR DESCRIPTION
## Who is this for?
Cookies work #10888 

## What is it doing for them?
- Makes `getConsent` function more generic
- Adds a `hasAnalyticsConsent` condition to loading the Youtube script needed for GA4
- `frameBorder` on iframe is deprecated, so replacing it with style as recommended.
- **Unrelated cheeky add**: Forgot TODOs in Cookie Policy page from #10890 so addressed them here. Mostly just made the metadata come from Prismic. 