### PR TITLE
Cookie policy lists update, third-parties config tweaked

### DIFF
--- a/common/data/cookies.ts
+++ b/common/data/cookies.ts
@@ -8,6 +8,8 @@
  *    3. To make it easier for anyone to update the Cookie policy tables
  */
 
+// **** IF MODIFYING ANY OF THESE *****
+// Remember to modify `cookiesTableCopy below as well`.
 const cookies = {
   // This is the cookie used in the exhibition guides to remember what
   // sort of guide a user prefers.  e.g. if somebody picks a BSL guide,
@@ -41,8 +43,8 @@ const cookies = {
 
 export const cookiesTableCopy = {
   '[necessary_cookies_table]': [
+    ['Cookie name', 'Purpose', 'Duration'],
     [
-      `CivicUK`,
       `CookieControl`,
       `This stores your cookie consent preferences`,
       `182 days`,
@@ -53,238 +55,98 @@ export const cookiesTableCopy = {
       `Persistant`,
     ],
     [
-      `Auth0`,
       `auth0+A4`,
       `Used to implement the session layer for single sign on`,
       `Session`,
     ],
     [
-      `Auth0`,
       `auth0_compat`,
       `Fallback for single sign-on on browsers that don't support the sameSite=None attribute`,
       `Session`,
     ],
+    [`did`, `Device identification for bot attack protection`, `Session`],
     [
-      `Auth0`,
-      `did`,
-      `Device identification for bot attack protection`,
-      `Session`,
-    ],
-    [
-      `Auth0`,
       `did_compat`,
       `Fallback for anomaly detection on browsers that don't support the sameSite=None attribute.`,
       `Session`,
     ],
     [
-      `Auth0`,
       `wecoIdentitySession`,
       `Indicates that successful authentication occurred with the identity provider`,
       `7 days`,
     ],
     [
-      `Wellcome`,
       `WC_userPreferenceGuideType`,
       `Used on exhibition guide pages to remember which type of digital exhibition guide the user prefers`,
       `8 hours`,
     ],
     [
-      `Wellcome`,
       `WC_PopupDialog`,
       `Remembers that the user has cloesd the popup dialogso it is not displayed again`,
       `Session`,
     ],
     [
-      `Wellcome`,
       `WC_globalAlert`,
       `Remembers that the user has closed the global alert banner so it is not displayed again`,
       `Session`,
     ],
     [
-      `Wellcome`,
       `WC_siteIssueBanner`,
       `Remembers that the user has closed the banner about website issues so it is not displayed again`,
       `4 hours`,
     ],
     [
-      `Wellcome`,
       `WC_wellcomeImagesRedirect`,
-      `Used to indicate if the user has closed the banner you see when you've been redirected from Wellcome Images`,
+      `Used to indicate if the user has closed the banner you see when<br />you've been redirected from Wellcome Images`,
       `2036-12-31T23:59:59Z`,
     ],
     [
-      `Wellcome`,
       `WC_apiToolbarMini`,
       `Used to indicate if the user is using the "mini" version of the API toolbar`,
       `Session`,
     ],
     [
-      `Wellcome`,
       `toggle_*`,
-      `Set by Wellcome to switch on/off website features that are under development, or only intended for a subset of users e.g. Wellcome staff or people taking part in usability research`,
+      `Set by Wellcome to switch on/off website features that are under development, or only intended for<br />a subset of users e.g. Wellcome staff or people taking part in usability research`,
       `1 year`,
     ],
-    [
-      `Cloudflare`,
-      `__cf_bm`,
-      `Used to read and filter requests from bots`,
-      `30 mins`,
-    ],
-    [`Prismic`, `Prismic-auth`, `Allows requests to Prismic API`, `Session`],
-    [`Google`, `Ar_debug`, `Used by Google Ad Services to debug ads`, `1 year`],
-    [
-      `YouTube`,
-      `VISITOR_PRIVACY_METADATA`,
-      `Stores the user's cookie consent state for the current domain`,
-      `180 days`,
-    ],
+    [`__cf_bm`, `Used to read and filter requests from bots`, `30 mins`],
+    [`Prismic-auth`, `Allows requests to Prismic API`, `Session`],
+    [`Ar_debug`, `Used by Google Ad Services to debug ads`, `1 year`],
   ],
   '[analytics_cookies_table]': [
+    ['Provider', 'Purpose'],
     [
-      `Google Analytics`,
-      `_ga`,
-      `Used by Google Analytics to register a unique ID that distinguishes visitors and generate statistical data on how each visitor uses the website`,
-      `2 years`,
+      'Google Analytics',
+      'With your permission, we use Google Analytics to to collect data about how you use the website. This information helps us to improve the website.<br />Google Analytics stores information about what pages you visit, how long you are on the site, how you got here and what you click., <br /><a href="https://support.google.com/analytics/answer/6004245" target="_blank" rel="noopener noreferrer">Visit Google to see a full list of cookies and their uses</a>.',
+    ],
+
+    [
+      'Twilio Segment',
+      'With your permission, we use Segment to collect data about how you use the website. This information helps us to improve the website, such as improving our website search.<br /><a href="https://www.twilio.com/en-us/legal/privacy" target="_blank" rel="noopener noreferrer">Visit Segment’s privacy statement</a>.',
     ],
     [
-      `Google Analytics`,
-      `_ga_<container-id>`,
-      `Used by Google Analytics to persist session state`,
-      `2 years`,
+      'Hotjar',
+      `With your permission, we use HotJar to help us understand how you are using the website. We use the data to inform changes we make to improve your experience.<br />Hotjar Analytics cookies store data about whether you have participated in a Hotjar survey, the way in which you interact with a page and what you click on while you are visiting the site.<br /><a href="https://help.hotjar.com/hc/en-us/articles/6952777582999-Cookies-Set-by-the-Hotjar-Tracking-Code" target="_blank" rel="noopener noreferrer">Visit HotJar's website to see a full list of cookies and their uses</a>.`,
     ],
     [
-      `Google Analytics`,
-      `_gid`,
-      `Used by Google Analytics, these help us count how many people visit wellcomecollection.org by tracking if you’ve visited before`,
-      `1 day`,
-    ],
-    [
-      `Google Analytics`,
-      `_gat`,
-      `Used to monitor number of Google Analytics server requests when using Google Tag Manager`,
-      `1 min`,
-    ],
-    [
-      `Google Analytics`,
-      `_dc_gtm_`,
-      `Used to monitor number of Google Analytics server requests`,
-      `1 min`,
-    ],
-    [
-      `Google Analytics`,
-      `AMP_TOKEN`,
-      `Contains a token code that is used to read out a Client ID from the AMP Client ID Service. By matching this ID with that of Google Analytics, users can be matched when switching between AMP content and non-AMP content`,
-      `1 year`,
-    ],
-    [
-      `Google Analytics`,
-      `_gat_`,
-      `Used to set and get tracking data`,
-      `1 hour`,
-    ],
-    [
-      `Google Analytics`,
-      `_utma`,
-      `ID used to identify users and Sessions`,
-      `2 years`,
-    ],
-    [
-      `Google Analytics`,
-      `_utmt`,
-      `Used to monitor number of Google Analytics server requests`,
-      `10 mins`,
-    ],
-    [
-      `Google Analytics`,
-      `_utmb`,
-      `Used to distinguish new sessions and visits. This cookie is set when the GA.js javascript library is loaded and there is no existing __utmb cookie. The cookie is updated every time data is sent to the Google Analytics server.`,
-      `30 mins`,
-    ],
-    [
-      `Google Analytics`,
-      `_utmz`,
-      `Contains information about the traffic source or campaign that directed user to the website. The cookie is set when the GA.js javascript is loaded and updated when data is sent to the Google Anaytics server`,
-      `182 days`,
-    ],
-    [
-      `Segment`,
-      `ajs_anonymous_id`,
-      `These cookies identify user sessions with an anonymous ID generated by Analytics.js`,
-      `1 year`,
-    ],
-    [
-      `Segment`,
-      `ajs_group_id`,
-      `A group ID that can be specified by making a group call with Analytics.js`,
-      `1 year`,
-    ],
-    [
-      `Segment`,
-      `ajs_user_id`,
-      `A user ID that can be specified by making an identify call with Analytics.js`,
-      `1 year`,
-    ],
-    [
-      `HotJar`,
-      `_hjSessionUser_#`,
-      `Collects statistics on the visitor's visits to the website, such as the number of visits, average time spent on the website and what pages have been read.`,
-      `1 Year`,
-    ],
-    [
-      `HotJar`,
-      `_hjSession_#`,
-      `Collects statistics on the visitor's visits to the website, such as the number of visits, average time spent on the website and what pages have been read.`,
-      `30 minutes`,
-    ],
-    [
-      `HotJar`,
-      `hjViewportId`,
-      `Saves the user's screen size in order to adjust the size of images on the website.`,
-      `Session`,
-    ],
-    [
-      `HotJar`,
-      `hjActiveViewportIds`,
-      `Contains an ID string on the current session. This contains non-personal information on what subpages the visitor enters – this information is used to optimize the visitor's experience.`,
-      `Session`,
-    ],
-    [
-      `Google`,
-      `td`,
-      `Registers statistical data on users' behaviour on the website. Used for internal analytics by the website operator.`,
-      `Session`,
-    ],
-    [
-      `YouTube`,
-      `PREF`,
-      `Used to store information such as a user's preferred page configuration and playback preferences like autoplay, shuffle content, and player size.`,
-      `243 days`,
-    ],
-    [
-      `YouTube`,
-      `VISITOR_INFO1_LIVE`,
-      `Tries to estimate the users' bandwidth on pages with integrated YouTube videos`,
-      `180 days`,
+      'YouTube',
+      `We embed videos on our websites from our official YouTube channel using YouTube's privacy-enhanced mode.<br />YouTube will not store personally-identifiable Cookie information for playbacks of embedded videos using the privacy-enhanced mode.<br /><a href="https://www.youtube.com/intl/ALL_uk/howyoutubeworks/our-commitments/protecting-user-data" target="_blank" rel="noopener noreferrer">Read about how YouTube maintains user privacy</a>.`,
     ],
   ],
   '[marketing_cookies_table]': [
+    ['Provider', 'Purpose'],
     [
-      `YouTube`,
-      `YSC`,
-      `Stores and tracks views on embedded YouTube videos`,
-      `Session`,
+      'GoogleAds',
+      `We use tracking technologies to enhance the measurement, optimisation, and targeting of our advertising campaigns on Google.<br /><a href="https://business.safety.google/adscookies/" target="_blank" rel="noopener noreferrer">See the full list of cookies on Google's website</a>.`,
     ],
     [
-      `Google`,
-      `_gac_`,
-      `Contains information related to marketing campaigns of the user. These are shared with Google AdWords / Google Ads when the Google Ads and Google Analytics accounts are linked together.`,
-      `90 days`,
+      'Meta',
+      `We use tracking technologies to enhance the measurement, optimisation, and targeting of our advertising campaigns on Meta (includes Facebook and Instagram).<br /><a href="https://www.facebook.com/privacy/policies/cookies?annotations[0]=explanation%2F1_common_cookies_and_uses" target="_blank" rel="noopener noreferrer">See the full list of cookies on Meta's website</a>.`,
     ],
     [
-      `Segment`,
-      `__tld__`,
-      `Used to track visitors on multiple websites, in order to present relevant advertisement based on the visitor's preferences`,
-      `Session`,
+      'TikTok',
+      `We use tracking technologies to enhance the measurement, optimisation, and targeting of our advertising campaigns on TikTok.<br /><a href="https://ads.tiktok.com/help/article/using-cookies-with-tiktok-pixel?lang=en" target="_blank" rel="noopener noreferrer">Information about the TikTok pixel and list of cookies</a>.`,
     ],
   ],
 };

--- a/common/data/cookies.ts
+++ b/common/data/cookies.ts
@@ -9,7 +9,7 @@
  */
 
 // **** IF MODIFYING ANY OF THESE *****
-// Remember to modify `cookiesTableCopy below as well`.
+// Remember to modify cookiesTableCopy below as well.
 const cookies = {
   // This is the cookie used in the exhibition guides to remember what
   // sort of guide a user prefers.  e.g. if somebody picks a BSL guide,

--- a/common/views/components/CivicUK/index.tsx
+++ b/common/views/components/CivicUK/index.tsx
@@ -137,18 +137,18 @@ const CivicUK = (props: Props) => (
                 },
                 thirdPartyCookies: [
                   {
-                    name: 'Youtube',
-                    optOutLink: 'https://www.youtube.com/intl/ALL_uk/howyoutubeworks/user-settings/privacy/',
+                    name: 'Google Analytics', optOutLink: 'https://support.google.com/analytics/answer/6004245'
                   },
                   {
-                    name: 'Segment', optOutLink: '/'
+                    name: 'Twilio Segment', optOutLink: 'https://www.twilio.com/en-us/legal/privacy'
                   },
                   {
-                    name: 'Google', optOutLink: '/'
+                    name: 'Hotjar', optOutLink: 'https://help.hotjar.com/hc/en-us/articles/360002735873-How-to-Stop-Hotjar-From-Collecting-your-Data'
                   },
                   {
-                    name: 'HotJar', optOutLink: '/'
-                  }
+                    name: 'YouTube',
+                    optOutLink: 'https://myaccount.google.com/yourdata/youtube?hl=en&pli=1',
+                  },
                 ],
               },
               {
@@ -166,15 +166,15 @@ const CivicUK = (props: Props) => (
                 },
                 thirdPartyCookies: [
                   {
-                    name: 'Youtube',
-                    optOutLink: 'https://www.youtube.com/intl/ALL_uk/howyoutubeworks/user-settings/privacy/',
+                    name: 'GoogleAds', optOutLink: 'https://policies.google.com/technologies/ads?hl=en-US'
                   },
                   {
-                    name: 'Segment', optOutLink: '/'
+                    name: 'Meta',
+                    optOutLink: 'https://www.facebook.com/privacy/policies/cookies',
                   },
                   {
-                    name: 'Google', optOutLink: '/'
-                  }
+                    name: 'TikTok', optOutLink: 'https://www.tiktok.com/privacy/ads-and-your-data/en-GB'
+                  },
                 ],
               },
             ],   

--- a/common/views/components/CivicUK/index.tsx
+++ b/common/views/components/CivicUK/index.tsx
@@ -128,7 +128,7 @@ const CivicUK = (props: Props) => (
                 },
                 thirdPartyCookies: [
                   {
-                    name: 'Google Analytics', optOutLink: 'https://support.google.com/analytics/answer/6004245'
+                    name: 'Google Analytics', optOutLink: 'http://tools.google.com/dlpage/gaoptout'
                   },
                   {
                     name: 'Twilio Segment', optOutLink: 'https://www.twilio.com/en-us/legal/privacy'

--- a/common/views/components/VideoEmbed/VideoEmbed.tsx
+++ b/common/views/components/VideoEmbed/VideoEmbed.tsx
@@ -61,10 +61,11 @@ const VideoEmbed: FunctionComponent<Props> = ({
   const [isActive, setIsActive] = useState(false);
   const id = embedUrl.match(/embed\/(.*)\?/)?.[1];
   const hasAnalyticsConsent = getConsentState('analytics');
+  const isYouTube = embedUrl.indexOf('youtube') >= 0;
 
   useEffect(() => {
-    if (hasAnalyticsConsent) {
-      // GA4 automatically tracks youtube engagment, but requires the iframe api
+    if (isYouTube && hasAnalyticsConsent) {
+      // GA4 automatically tracks YouTube engagement, but requires the iframe api
       // script to have been loaded on the page. Since we're lazyloading youtube
       // videos, we have to add the script ourselves (and check that we haven't
       // done so already). The following is a version of 'option 3' from this article:

--- a/content/webapp/components/Table/Tables.styles.tsx
+++ b/content/webapp/components/Table/Tables.styles.tsx
@@ -85,9 +85,11 @@ export const TableWrap = styled.div`
   background-attachment: local, local, scroll, scroll;
 `;
 
-export const TableTable = styled.table.attrs({
-  className: font('intr', 5),
-})`
+export const TableTable = styled.table.attrs<{ $hasSmallerCopy?: boolean }>(
+  props => ({
+    className: font('intr', props.$hasSmallerCopy ? 6 : 5),
+  })
+)`
   width: 100%;
   border-collapse: collapse;
 `;

--- a/content/webapp/components/Table/index.tsx
+++ b/content/webapp/components/Table/index.tsx
@@ -32,6 +32,7 @@ export type Props = {
   vAlign?: 'top' | 'middle' | 'bottom';
   plain?: boolean;
   withBorder?: boolean;
+  hasSmallerCopy?: boolean;
 };
 
 type TableRowProps = {
@@ -86,6 +87,7 @@ const Table: FunctionComponent<Props> = ({
   vAlign = 'top',
   plain = false,
   withBorder = true,
+  hasSmallerCopy = false,
 }: Props): ReactElement<Props> => {
   const leftButtonRef = useRef<HTMLDivElement>(null);
   const rightButtonRef = useRef<HTMLDivElement>(null);
@@ -206,7 +208,11 @@ const Table: FunctionComponent<Props> = ({
         </ScrollButtons>
 
         <TableWrap ref={tableWrapRef}>
-          <TableTable id="table" ref={tableRef}>
+          <TableTable
+            id="table"
+            ref={tableRef}
+            $hasSmallerCopy={hasSmallerCopy}
+          >
             {caption && <TableCaption>{caption}</TableCaption>}
 
             {headerRow && (

--- a/content/webapp/pages/cookie-policy.tsx
+++ b/content/webapp/pages/cookie-policy.tsx
@@ -22,7 +22,7 @@ const CookieTable = ({ rows }: { rows: string[][] }) => {
   return (
     <SpacingComponent>
       <Layout gridSizes={gridSize8()}>
-        <Table rows={rows} withBorder={true}></Table>
+        <Table rows={rows} withBorder={true} hasSmallerCopy></Table>
       </Layout>
     </SpacingComponent>
   );

--- a/content/webapp/pages/cookie-policy.tsx
+++ b/content/webapp/pages/cookie-policy.tsx
@@ -22,10 +22,7 @@ const CookieTable = ({ rows }: { rows: string[][] }) => {
   return (
     <SpacingComponent>
       <Layout gridSizes={gridSize8()}>
-        <Table
-          rows={[['Provider', 'Cookie name', 'Purpose', 'Duration'], ...rows]}
-          withBorder={true}
-        ></Table>
+        <Table rows={rows} withBorder={true}></Table>
       </Layout>
     </SpacingComponent>
   );


### PR DESCRIPTION
## Who is this for?
Cookies work #10895 and #10717

## What is it doing for them?
- Simplify tables on Cookie Policy page. Headers moved to same place as content as they differ.
- Adds information to 3rd parties sections in CivicUK Config. Most opt-out links [still need to be verified](https://wellcome.slack.com/archives/CUA669WHH/p1716547320671559).
- Allows new prop on `Table` so text is smaller/kind of more readable.
- Add condition to Youtube script that ensures it only loads on Youtube videos. We do not use, but we do allow Vimeo, so have to consider them.