### PR TITLE
explicitly fetch only collection-venues that appears on the website

### DIFF
--- a/common/server-data/prismic.ts
+++ b/common/server-data/prismic.ts
@@ -3,6 +3,7 @@ import {
   PopupDialogPrismicDocument,
   GlobalAlertPrismicDocument,
 } from '../services/prismic/documents';
+import { collectionVenueId } from '@weco/common/data/hardcoded-ids';
 import { Handler } from './';
 import * as prismic from '@prismicio/client';
 import { InferDataInterface } from '../services/prismic/types';
@@ -65,7 +66,14 @@ async function fetchPrismicValues(): Promise<PrismicData> {
   const client = createPrismicClient();
 
   const collectionVenuesResultPromise = client.get({
-    filters: [prismic.filter.any('document.type', ['collection-venue'])],
+    filters: [
+      prismic.filter.in('document.id', [
+        collectionVenueId.galleries.id,
+        collectionVenueId.libraries.id,
+        collectionVenueId.shop.id,
+        collectionVenueId.café.id,
+      ]),
+    ],
   });
   const globalAlertResultPromise = client.getSingle('global-alert');
   const popupDialogResultPromise = client.getSingle('popup-dialog');


### PR DESCRIPTION
## Who is this for?

Someone who wants to add Prismic collection-venues that are not to be displayed on wc.org, eg. DeepStore 

## What is it doing for them?

Instead of fetching all Prismic documents of type `collection-venue` we specifically fetch only the ones that are for public consumption (library, café, shop and galleries)
This is necessary because DeepStore is about to be added as a `collection-venue` in Prismic as part of the offsite requesting work, but we do not want this venue to show up on the website.