### PR TITLE
Add an e2e for the cookie banner

### DIFF
--- a/playwright/test/homepage.test.ts
+++ b/playwright/test/homepage.test.ts
@@ -15,3 +15,17 @@ test('(1) Website includes the Meta domain verification tag', async ({
     'gl52uu0zshpy3yqv1ohxo3zq39mb0w'
   );
 });
+
+test('(2) | Cookie banner displays on first visit from anywhere, except the cookie policy page.', async ({
+  page,
+}) => {
+  await gotoWithoutCache(baseUrl, page);
+  const cookieBanner = await page.getByLabel('Our website uses cookies');
+  await expect(cookieBanner).toBeAttached();
+
+  await gotoWithoutCache(`${baseUrl}/visit-us`, page);
+  await expect(cookieBanner).toBeAttached();
+
+  await gotoWithoutCache(`${baseUrl}/cookie-policy`, page);
+  await expect(cookieBanner).not.toBeAttached();
+});

--- a/playwright/test/homepage.test.ts
+++ b/playwright/test/homepage.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { baseUrl } from './helpers/utils';
-import { gotoWithoutCache } from './helpers/contexts';
+import { gotoWithoutCache, mediaOffice } from './helpers/contexts';
 
 // See the comment in content/webapp/pages/index.tsx about why this is important
 test('(1) Website includes the Meta domain verification tag', async ({
@@ -27,5 +27,17 @@ test('(2) | Cookie banner displays on first visit from anywhere, except the cook
   await expect(cookieBanner).toBeAttached();
 
   await gotoWithoutCache(`${baseUrl}/cookie-policy`, page);
+  await expect(cookieBanner).not.toBeAttached();
+});
+
+test('(3) | Cookie banner only displays if CookieControl cookie has not already been set', async ({
+  context,
+  page,
+}) => {
+  await gotoWithoutCache(`${baseUrl}/pages/WuxrKCIAAP9h3hmw`, page);
+  const cookieBanner = await page.getByLabel('Our website uses cookies');
+  await expect(cookieBanner).toBeAttached();
+
+  await mediaOffice(context, page);
   await expect(cookieBanner).not.toBeAttached();
 });


### PR DESCRIPTION
## Who is this for?
e2e  #10830 

## What is it doing for them?
- Checks homepage and visit-us have the CivicUK banner, but that Cookie Policy does not.
- Checks banner only displays when `CookieControl` has not been set or has expired.
- If anyone would like anything else checked, lmk! I was thinking maybe check how scripts behave based on consent, but was struggling a bit to find out _how_ to do it. Could take the time after release to dig though, and create a different PR for it if the appetite is there.