### PR TITLE
useEffect when item.availableDates becomes defined

### DIFF
--- a/content/webapp/components/ItemRequestModal/RequestDialog.tsx
+++ b/content/webapp/components/ItemRequestModal/RequestDialog.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, FormEvent, useState } from 'react';
+import { FunctionComponent, FormEvent, useState, useEffect } from 'react';
 import { allowedRequests } from '@weco/common/values/requests';
 import { font } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
@@ -82,12 +82,18 @@ const RequestDialog: FunctionComponent<RequestDialogProps> = ({
   setIsActive,
   currentHoldNumber,
 }) => {
-  const firstAvailableDate = item.availableDates
-    ? item.availableDates[0]
-    : undefined;
   const [pickUpDate, setPickUpDate] = useState<string | undefined>(
-    firstAvailableDate && dateAsValue(new Date(firstAvailableDate.from))
+    item.availableDates && dateAsValue(new Date(item.availableDates[0].from))
   );
+
+  // the RequestingDayPicker's state sometimes get set as undefined before the availableDates have been fetched
+  // as a result the user can't confirm the request unless they interact with the RequestingDayPicker in some way to trigger a state update
+  // here we set pickUpDate when item.availableDates becomes defined
+  useEffect(() => {
+    if (!pickUpDate && item.availableDates) {
+      setPickUpDate(dateAsValue(new Date(item.availableDates[0].from)));
+    }
+  }, [item.availableDates]);
 
   function handleConfirmRequest(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();

--- a/content/webapp/components/ItemRequestModal/RequestDialog.tsx
+++ b/content/webapp/components/ItemRequestModal/RequestDialog.tsx
@@ -86,7 +86,7 @@ const RequestDialog: FunctionComponent<RequestDialogProps> = ({
     item.availableDates && dateAsValue(new Date(item.availableDates[0].from))
   );
 
-  // the RequestingDayPicker's state sometimes get set as undefined before the availableDates have been fetched
+  // the pickUpDate's state sometimes get set as undefined before the availableDates have been fetched
   // as a result the user can't confirm the request unless they interact with the RequestingDayPicker in some way to trigger a state update
   // here we set pickUpDate when item.availableDates becomes defined
   useEffect(() => {


### PR DESCRIPTION
## Who is this for?

Users who click the "Request item" button super fast when the work page loads

## What is it doing for them?

It sometimes takes a little bit longer to fetch and set an item's availableDates than it takes to render the "Request item" button. In this case, the `RequestingDayPicker` dropdown would show the date but the form would have its value as undefined. This, in turn, would make the "Confirm request" button unresponsive, since you can't confirm a request without a date.
This PR adds a `UseEffect` to force a `setPickUpDate` state update when the item's availableDates actually become, well.. available :) 
