### PR TITLE
Add mutation observer to check if cookie banner has been acknowledged

### DIFF
--- a/cardigan/.storybook/preview.js
+++ b/cardigan/.storybook/preview.js
@@ -6,11 +6,13 @@ import { ContextDecorator } from '@weco/cardigan/config/decorators';
 import wellcomeTheme from './wellcome-theme';
 import { grid } from '@weco/common/utils/classnames';
 import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper/ConditionalWrapper';
+import { AppContextProvider } from '@weco/common/views/components/AppContext/AppContext';
 
 export const decorators = [
   (Story, context) => {
     return (
       <ContextDecorator>
+        <AppContextProvider>
         <ConditionalWrapper
           condition={context?.parameters?.gridSizes}
           wrapper={children => (
@@ -19,6 +21,7 @@ export const decorators = [
         >
           <Story {...context} />
         </ConditionalWrapper>
+        </AppContextProvider>
       </ContextDecorator>
     );
   },

--- a/common/views/components/AppContext/AppContext.tsx
+++ b/common/views/components/AppContext/AppContext.tsx
@@ -86,11 +86,12 @@ export const AppContextProvider: FunctionComponent<PropsWithChildren> = ({
   }, []);
 
   useEffect(() => {
-    // Checks if the cookie banner is active: the CookieControl cookie has never been set AND
-    // We check if it's displaying - in its banner or modal form - by looking for #ccc-overlay
-    // Because if that is in the DOM, it means it's actively displaying.
     if (
+      // Cookie has already been set
       !hasAcknowledgedCookieBanner &&
+      // CivicUK script has loaded
+      document.getElementById('ccc') &&
+      // Banner or popup is actively displaying
       document.getElementById('ccc-overlay')
     ) {
       // Only once has it gone from the DOM can we consider the cookie banner acknowledged

--- a/common/views/components/AppContext/AppContext.tsx
+++ b/common/views/components/AppContext/AppContext.tsx
@@ -6,6 +6,7 @@ import {
   FunctionComponent,
   PropsWithChildren,
 } from 'react';
+import { getCookies } from 'cookies-next';
 import theme from '@weco/common/views/themes/default';
 import { Size } from '@weco/common/views/themes/config';
 
@@ -15,6 +16,7 @@ type AppContextProps = {
   windowSize: Size;
   audioPlaybackRate: number;
   setAudioPlaybackRate: (rate: number) => void;
+  hasAcknowledgedCookieBanner: boolean;
 };
 
 const appContextDefaults = {
@@ -23,6 +25,7 @@ const appContextDefaults = {
   windowSize: 'small' as Size,
   audioPlaybackRate: 1,
   setAudioPlaybackRate: () => null,
+  hasAcknowledgedCookieBanner: false,
 };
 
 export const AppContext = createContext<AppContextProps>(appContextDefaults);
@@ -53,6 +56,8 @@ export const AppContextProvider: FunctionComponent<PropsWithChildren> = ({
   const [audioPlaybackRate, setAudioPlaybackRate] = useState(
     appContextDefaults.audioPlaybackRate
   );
+  const [hasAcknowledgedCookieBanner, setHasAcknowledgedCookieBanner] =
+    useState(Boolean(getCookies().CookieControl));
 
   useEffect(() => {
     setIsEnhanced(true);
@@ -80,6 +85,30 @@ export const AppContextProvider: FunctionComponent<PropsWithChildren> = ({
     setIsFullSupportBrowser('IntersectionObserver' in window);
   }, []);
 
+  useEffect(() => {
+    // Checks if the cookie banner is active: the CookieControl cookie has never been set AND
+    // We check if it's displaying - in its banner or modal form - by looking for #ccc-overlay
+    // Because if that is in the DOM, it means it's actively displaying.
+    if (
+      !hasAcknowledgedCookieBanner &&
+      document.getElementById('ccc-overlay')
+    ) {
+      // Only once has it gone from the DOM can we consider the cookie banner acknowledged
+      const callback = mutationList => {
+        for (const mutation of mutationList) {
+          if (mutation.type === 'childList') {
+            setHasAcknowledgedCookieBanner(
+              document.getElementById('ccc')?.childElementCount === 0
+            );
+          }
+        }
+      };
+      const observer = new MutationObserver(callback);
+      observer.observe(document.body, { childList: true, subtree: true });
+      return () => observer.disconnect();
+    }
+  });
+
   return (
     <AppContext.Provider
       value={{
@@ -88,6 +117,7 @@ export const AppContextProvider: FunctionComponent<PropsWithChildren> = ({
         windowSize,
         audioPlaybackRate,
         setAudioPlaybackRate,
+        hasAcknowledgedCookieBanner,
       }}
     >
       {children}

--- a/common/views/components/AppContext/AppContext.tsx
+++ b/common/views/components/AppContext/AppContext.tsx
@@ -107,8 +107,12 @@ export const AppContextProvider: FunctionComponent<PropsWithChildren> = ({
       const observer = new MutationObserver(callback);
       observer.observe(document.body, { childList: true, subtree: true });
       return () => observer.disconnect();
+    } else if (!document.getElementById('ccc')) {
+      // If the CivicUK script failed to load for any reason, we should consider it acknowledged by default.
+      // We need this for our tests and Cardigan as well.
+      setHasAcknowledgedCookieBanner(true);
     }
-  });
+  }, []);
 
   return (
     <AppContext.Provider

--- a/common/views/components/Modal/Modal.test.tsx
+++ b/common/views/components/Modal/Modal.test.tsx
@@ -4,6 +4,8 @@ import { render, screen } from '@testing-library/react';
 import { ThemeProvider } from 'styled-components';
 import theme from '@weco/common/views/themes/default';
 import userEvent from '@testing-library/user-event';
+import { act } from 'react-dom/test-utils';
+import { AppContextProvider } from '../AppContext/AppContext';
 
 const renderComponent = () => {
   const ModalExample = () => {
@@ -12,19 +14,21 @@ const renderComponent = () => {
 
     return (
       <ThemeProvider theme={theme}>
-        <div>
-          <button ref={openButtonRef} onClick={() => setIsActive(true)}>
-            Open modal window
-          </button>
-          <Modal
-            id="modal-example"
-            isActive={isActive}
-            setIsActive={setIsActive}
-            openButtonRef={openButtonRef}
-          >
-            <p>This is a modal window.</p>
-          </Modal>
-        </div>
+        <AppContextProvider>
+          <div>
+            <button ref={openButtonRef} onClick={() => setIsActive(true)}>
+              Open modal window
+            </button>
+            <Modal
+              id="modal-example"
+              isActive={isActive}
+              setIsActive={setIsActive}
+              openButtonRef={openButtonRef}
+            >
+              <p>This is a modal window.</p>
+            </Modal>
+          </div>
+        </AppContextProvider>
       </ThemeProvider>
     );
   };
@@ -41,7 +45,9 @@ describe('Modal', () => {
   it('should focus the close button when opened', async () => {
     renderComponent();
     const openButton = screen.getByText(/^Open modal window$/i);
-    await userEvent.click(openButton);
+    await act(async () => {
+      await userEvent.click(openButton);
+    });
     const closeButton = screen.getByTestId('close-modal-button');
     await expect(document.activeElement).toEqual(closeButton);
   });
@@ -49,9 +55,13 @@ describe('Modal', () => {
   it('should focus the open button when closed', async () => {
     renderComponent();
     const openButton = screen.getByText(/^Open modal window$/i);
-    await userEvent.click(openButton);
+    await act(async () => {
+      await userEvent.click(openButton);
+    });
     const closeButton = screen.getByTestId('close-modal-button');
-    await userEvent.click(closeButton);
+    await act(async () => {
+      await userEvent.click(closeButton);
+    });
     await expect(document.activeElement).toEqual(openButton);
   });
 });

--- a/common/views/components/Modal/Modal.tsx
+++ b/common/views/components/Modal/Modal.tsx
@@ -204,13 +204,13 @@ const Modal: FunctionComponent<Props> = ({
   const { hasAcknowledgedCookieBanner } = useContext(AppContext);
 
   useEffect(() => {
-    if (isActive && hasAcknowledgedCookieBanner) {
+    if (isActive) {
       closeButtonRef?.current?.focus();
     } else if (!initialLoad.current) {
       openButtonRef && openButtonRef.current && openButtonRef.current.focus();
     }
     initialLoad.current = false;
-  }, [isActive, hasAcknowledgedCookieBanner]);
+  }, [isActive]);
 
   useEffect(() => {
     function closeOnEscape(event: KeyboardEvent) {

--- a/common/views/components/Modal/Modal.tsx
+++ b/common/views/components/Modal/Modal.tsx
@@ -5,6 +5,7 @@ import {
   RefObject,
   MutableRefObject,
   PropsWithChildren,
+  useContext,
 } from 'react';
 import styled from 'styled-components';
 import Space from '@weco/common/views/components/styled/Space';
@@ -12,6 +13,7 @@ import Icon from '@weco/common/views/components/Icon/Icon';
 import { CSSTransition } from 'react-transition-group';
 import { cross } from '@weco/common/icons';
 import FocusTrap from 'focus-trap-react';
+import { AppContext } from '../AppContext/AppContext';
 
 type BaseModalProps = {
   $width?: string | null;
@@ -199,15 +201,16 @@ const Modal: FunctionComponent<Props> = ({
   const ModalWindow = determineModal(modalStyle);
   const initialLoad = useRef(true);
   const nodeRef = useRef(null);
+  const { hasAcknowledgedCookieBanner } = useContext(AppContext);
 
   useEffect(() => {
-    if (isActive) {
+    if (isActive && hasAcknowledgedCookieBanner) {
       closeButtonRef?.current?.focus();
     } else if (!initialLoad.current) {
       openButtonRef && openButtonRef.current && openButtonRef.current.focus();
     }
     initialLoad.current = false;
-  }, [isActive]);
+  }, [isActive, hasAcknowledgedCookieBanner]);
 
   useEffect(() => {
     function closeOnEscape(event: KeyboardEvent) {
@@ -224,7 +227,7 @@ const Modal: FunctionComponent<Props> = ({
 
   useEffect(() => {
     if (document && document.documentElement) {
-      if (isActive) {
+      if (isActive && hasAcknowledgedCookieBanner) {
         document.documentElement.classList.add('is-scroll-locked');
       } else {
         document.documentElement.classList.remove('is-scroll-locked');
@@ -234,10 +237,12 @@ const Modal: FunctionComponent<Props> = ({
     return () => {
       document.documentElement.classList.remove('is-scroll-locked');
     };
-  }, [isActive]);
+  }, [isActive, hasAcknowledgedCookieBanner]);
+
+  const shouldLock = isActive && hasAcknowledgedCookieBanner;
 
   return (
-    <FocusTrap active={isActive} focusTrapOptions={{ preventScroll: true }}>
+    <FocusTrap active={shouldLock} focusTrapOptions={{ preventScroll: true }}>
       <div>
         {isActive && showOverlay && (
           <Overlay


### PR DESCRIPTION
## Who is this for?
#10915 

## What is it doing for them?
  
This PR adds a value in the context that checks if the cookie banner has been acknowledged. I put it at that level as I thought it could be useful elsewhere, but if we think it's overkill I can move it.

In that regard, I've added the context to Storybook and to the concerned tests.

### What's going on?
> When the cookie banner shows on a page with a `Modal` (such as [this work](https://wellcomecollection.org/works/nny5wq9u/items)), the latter is stopping the former from being interacted with as it is locked in with `FocusTrap` (for a11y reasons).
>
> We need to deactivate `FocusTrap` if the cookie banner has yet to be acknowledged and interacted with, then re-activate it to stick by good a11y practices.

The banner can be considered acknowledged in three different ways:
- The user clicks "Accept All": the `CookieControl` cookie is set, and the banner is removed from the DOM.
- The user clicks "Essential only": the `CookieControl` cookie is set, and the banner is removed from the DOM.
- The user clicks "Manage cookies": the CookieControl cookie is set, the banner is removed from the DOM and the Preference centre popup is added to the DOM. The user then interacts (or not) with the contents of the Preference centre popup, then clicks "Save and close". The popup is removed from the DOM.

Because the cookie is not automatically set at the same time as everything is removed from the DOM, we can't count on detecting the cookie to re-activate the `FocusTrap`.
We also can't use CivicUK's callbacks to re-activate `FocusTrap` as it offers one for `onAccept` and `onRevoke`, but not for when a user dismisses the cookie preferences by clicking "Manage cookies" and then simply "Save and close". 

So we have to find out when the banner and popup are fully removed from the DOM, and we can do that by detecting when the `#ccc` Element (`ccc` being the ID of the parent container) has zero children left - because yes, the parent stays in the DOM, but is an empty div. I'm thinking it's so the Preference centre popup knows where to inject itself should it be called up again. Only then can we then activate the `FocusTrap`.
We use `ccc-overlay` to check if the banner is up as it is a sibling of both the popup and the banner should one of them be active.

This was a bit of a maze so happy to jump on a call to run through it.