### PR TITLE
Modal: Set `shouldLock` in state

### DIFF
--- a/common/views/components/Modal/Modal.tsx
+++ b/common/views/components/Modal/Modal.tsx
@@ -6,6 +6,7 @@ import {
   MutableRefObject,
   PropsWithChildren,
   useContext,
+  useState,
 } from 'react';
 import styled from 'styled-components';
 import Space from '@weco/common/views/components/styled/Space';
@@ -202,6 +203,7 @@ const Modal: FunctionComponent<Props> = ({
   const initialLoad = useRef(true);
   const nodeRef = useRef(null);
   const { hasAcknowledgedCookieBanner } = useContext(AppContext);
+  const [shouldLock, setShouldLock] = useState(false);
 
   useEffect(() => {
     if (isActive) {
@@ -228,8 +230,10 @@ const Modal: FunctionComponent<Props> = ({
   useEffect(() => {
     if (document && document.documentElement) {
       if (isActive && hasAcknowledgedCookieBanner) {
+        setShouldLock(true);
         document.documentElement.classList.add('is-scroll-locked');
       } else {
+        setShouldLock(false);
         document.documentElement.classList.remove('is-scroll-locked');
       }
     }
@@ -238,8 +242,6 @@ const Modal: FunctionComponent<Props> = ({
       document.documentElement.classList.remove('is-scroll-locked');
     };
   }, [isActive, hasAcknowledgedCookieBanner]);
-
-  const shouldLock = isActive && hasAcknowledgedCookieBanner;
 
   return (
     <FocusTrap active={shouldLock} focusTrapOptions={{ preventScroll: true }}>

--- a/common/views/components/Modal/Modal.tsx
+++ b/common/views/components/Modal/Modal.tsx
@@ -233,9 +233,9 @@ const Modal: FunctionComponent<Props> = ({
         setShouldLock(true);
         document.documentElement.classList.add('is-scroll-locked');
       } else {
-        setShouldLock(false);
         document.documentElement.classList.remove('is-scroll-locked');
       }
+      setShouldLock(false);
     }
 
     return () => {
@@ -251,6 +251,7 @@ const Modal: FunctionComponent<Props> = ({
             onClick={() => {
               if (!removeCloseButton) {
                 setIsActive(false);
+                setShouldLock(false);
               }
             }}
           />
@@ -275,6 +276,7 @@ const Modal: FunctionComponent<Props> = ({
                 ref={closeButtonRef}
                 onClick={() => {
                   setIsActive(false);
+                  setShouldLock(false);
                 }}
               >
                 <span className="visually-hidden">Close modal window</span>

--- a/playwright/test/events.test.ts
+++ b/playwright/test/events.test.ts
@@ -16,7 +16,7 @@ test('single event pages include the scheduled events', async ({
   });
   // Heart n Soul Radio occured twice, once in November, once in December
   const eventNameLocator = page
-    .getByRole('heading', { name: 'Powerful Portraits' })
+    .getByRole('headings', { name: 'Powerful Portraits' })
     .first();
   await expect(pastEventsLocator).toBeVisible();
   await expect(dateLocator).toBeVisible();

--- a/playwright/test/events.test.ts
+++ b/playwright/test/events.test.ts
@@ -16,7 +16,7 @@ test('single event pages include the scheduled events', async ({
   });
   // Heart n Soul Radio occured twice, once in November, once in December
   const eventNameLocator = page
-    .getByRole('headings', { name: 'Powerful Portraits' })
+    .getByRole('heading', { name: 'Powerful Portraits' })
     .first();
   await expect(pastEventsLocator).toBeVisible();
   await expect(dateLocator).toBeVisible();


### PR DESCRIPTION
## Who is this for?
Follow-up for #10920 (ticket #10915)

## What is it doing for them?
I realised that some sort of race condition was causing the bug to still be there when there was a hard refresh/on first load. This wasn't happening in local which is why it wasn't caught there and why it's harder to test.
I put the `shouldLock` in the state instead, and made sure it got updated properly in all the different scenarios
I broke an e2e test on purpose so the environment would stay up longer (fixed now) and tested it there, and it seemed to work perfectly fine, so I'm hoping it's a good representation of other live environments.