### PR TITLE
Revert "Modal: Set `shouldLock` in state"

### DIFF
--- a/common/views/components/AppContext/AppContext.tsx
+++ b/common/views/components/AppContext/AppContext.tsx
@@ -87,11 +87,11 @@ export const AppContextProvider: FunctionComponent<PropsWithChildren> = ({
 
   useEffect(() => {
     if (
-      // Cookie has already been set
+      // Cookie has already been set;
       !hasAcknowledgedCookieBanner &&
-      // CivicUK script has loaded
+      // CivicUK script has loaded;
       document.getElementById('ccc') &&
-      // Banner or popup is actively displaying
+      // Banner or popup is actively displaying.
       document.getElementById('ccc-overlay')
     ) {
       // Only once has it gone from the DOM can we consider the cookie banner acknowledged

--- a/common/views/components/Modal/Modal.tsx
+++ b/common/views/components/Modal/Modal.tsx
@@ -6,7 +6,6 @@ import {
   MutableRefObject,
   PropsWithChildren,
   useContext,
-  useState,
 } from 'react';
 import styled from 'styled-components';
 import Space from '@weco/common/views/components/styled/Space';
@@ -203,7 +202,6 @@ const Modal: FunctionComponent<Props> = ({
   const initialLoad = useRef(true);
   const nodeRef = useRef(null);
   const { hasAcknowledgedCookieBanner } = useContext(AppContext);
-  const [shouldLock, setShouldLock] = useState(false);
 
   useEffect(() => {
     if (isActive) {
@@ -230,18 +228,18 @@ const Modal: FunctionComponent<Props> = ({
   useEffect(() => {
     if (document && document.documentElement) {
       if (isActive && hasAcknowledgedCookieBanner) {
-        setShouldLock(true);
         document.documentElement.classList.add('is-scroll-locked');
       } else {
         document.documentElement.classList.remove('is-scroll-locked');
       }
-      setShouldLock(false);
     }
 
     return () => {
       document.documentElement.classList.remove('is-scroll-locked');
     };
   }, [isActive, hasAcknowledgedCookieBanner]);
+
+  const shouldLock = isActive && hasAcknowledgedCookieBanner;
 
   return (
     <FocusTrap active={shouldLock} focusTrapOptions={{ preventScroll: true }}>
@@ -251,7 +249,6 @@ const Modal: FunctionComponent<Props> = ({
             onClick={() => {
               if (!removeCloseButton) {
                 setIsActive(false);
-                setShouldLock(false);
               }
             }}
           />
@@ -276,7 +273,6 @@ const Modal: FunctionComponent<Props> = ({
                 ref={closeButtonRef}
                 onClick={() => {
                   setIsActive(false);
-                  setShouldLock(false);
                 }}
               >
                 <span className="visually-hidden">Close modal window</span>


### PR DESCRIPTION
Reverts wellcomecollection/wellcomecollection.org#10921

Might want to revert; the focus isn't put back on the Modal after the cookie banner is dismissed anymore, which is really bad for keyboard nav users and screen readers. The cookie banner is always available for interaction, though.

This was an attempted fix for a problem that only happened on first load and hard-refresh (#10920 fixed it for normal refresh), so I feel like it might be preferable to revert.