### PR TITLE
Acknowledge Cookie banner state from Modal to avoid locking issues

### DIFF
--- a/common/services/app/civic-uk.ts
+++ b/common/services/app/civic-uk.ts
@@ -2,6 +2,9 @@ import { getCookies } from 'cookies-next';
 import { GetServerSidePropsContext } from 'next';
 import { ConsentStatusProps } from '@weco/common/server-data/types';
 
+export const ACTIVE_COOKIE_BANNER_ID = 'ccc-overlay';
+export const COOKIE_BANNER_PARENT_ID = 'ccc';
+
 type CivicUKCookie = {
   optionalCookies?: {
     analytics: 'accepted' | 'revoked';

--- a/common/views/components/AppContext/AppContext.tsx
+++ b/common/views/components/AppContext/AppContext.tsx
@@ -17,6 +17,7 @@ type AppContextProps = {
   audioPlaybackRate: number;
   setAudioPlaybackRate: (rate: number) => void;
   hasAcknowledgedCookieBanner: boolean;
+  setHasAcknowledgedCookieBanner: (isAcknowledged: boolean) => void;
 };
 
 const appContextDefaults = {
@@ -26,6 +27,7 @@ const appContextDefaults = {
   audioPlaybackRate: 1,
   setAudioPlaybackRate: () => null,
   hasAcknowledgedCookieBanner: false,
+  setHasAcknowledgedCookieBanner: () => null,
 };
 
 export const AppContext = createContext<AppContextProps>(appContextDefaults);
@@ -85,35 +87,6 @@ export const AppContextProvider: FunctionComponent<PropsWithChildren> = ({
     setIsFullSupportBrowser('IntersectionObserver' in window);
   }, []);
 
-  useEffect(() => {
-    // If CookieControl has not been set yet;
-    if (!hasAcknowledgedCookieBanner) {
-      // If the CivicUK script failed to load for any reason, we should consider it acknowledged by default.
-      // We need this for our tests and Cardigan as well.
-      setHasAcknowledgedCookieBanner(true);
-
-      // If banner or popup is actively displaying on load;
-      if (
-        document.getElementById('ccc') &&
-        document.getElementById('ccc-overlay')
-      ) {
-        // Only once has it gone from the DOM can we consider the cookie banner acknowledged
-        const callback = mutationList => {
-          for (const mutation of mutationList) {
-            if (mutation.type === 'childList') {
-              setHasAcknowledgedCookieBanner(
-                document.getElementById('ccc')?.childElementCount === 0
-              );
-            }
-          }
-        };
-        const observer = new MutationObserver(callback);
-        observer.observe(document.body, { childList: true, subtree: true });
-        return () => observer.disconnect();
-      }
-    }
-  }, []);
-
   return (
     <AppContext.Provider
       value={{
@@ -123,6 +96,7 @@ export const AppContextProvider: FunctionComponent<PropsWithChildren> = ({
         audioPlaybackRate,
         setAudioPlaybackRate,
         hasAcknowledgedCookieBanner,
+        setHasAcknowledgedCookieBanner,
       }}
     >
       {children}

--- a/common/views/components/AppContext/AppContext.tsx
+++ b/common/views/components/AppContext/AppContext.tsx
@@ -57,7 +57,7 @@ export const AppContextProvider: FunctionComponent<PropsWithChildren> = ({
     appContextDefaults.audioPlaybackRate
   );
   const [hasAcknowledgedCookieBanner, setHasAcknowledgedCookieBanner] =
-    useState(Boolean(getCookies().CookieControl));
+    useState(Boolean(getCookies().CookieControl) || false);
 
   useEffect(() => {
     setIsEnhanced(true);
@@ -107,7 +107,10 @@ export const AppContextProvider: FunctionComponent<PropsWithChildren> = ({
       const observer = new MutationObserver(callback);
       observer.observe(document.body, { childList: true, subtree: true });
       return () => observer.disconnect();
-    } else if (!document.getElementById('ccc')) {
+    } else if (
+      !document.getElementById('ccc') &&
+      !hasAcknowledgedCookieBanner
+    ) {
       // If the CivicUK script failed to load for any reason, we should consider it acknowledged by default.
       // We need this for our tests and Cardigan as well.
       setHasAcknowledgedCookieBanner(true);

--- a/common/views/components/AppContext/AppContext.tsx
+++ b/common/views/components/AppContext/AppContext.tsx
@@ -58,7 +58,7 @@ export const AppContextProvider: FunctionComponent<PropsWithChildren> = ({
   );
   const [hasAcknowledgedCookieBanner, setHasAcknowledgedCookieBanner] =
     useState(Boolean(getCookies().CookieControl));
-  console.log('getcookies', getCookies().CookieControl);
+
   useEffect(() => {
     setIsEnhanced(true);
   }, []);
@@ -86,9 +86,13 @@ export const AppContextProvider: FunctionComponent<PropsWithChildren> = ({
   }, []);
 
   useEffect(() => {
-    // Cookie has not been set yet;
+    // If CookieControl has not been set yet;
     if (!hasAcknowledgedCookieBanner) {
-      // Banner or popup is actively displaying.
+      // If the CivicUK script failed to load for any reason, we should consider it acknowledged by default.
+      // We need this for our tests and Cardigan as well.
+      setHasAcknowledgedCookieBanner(true);
+
+      // If banner or popup is actively displaying on load;
       if (
         document.getElementById('ccc') &&
         document.getElementById('ccc-overlay')
@@ -106,11 +110,6 @@ export const AppContextProvider: FunctionComponent<PropsWithChildren> = ({
         const observer = new MutationObserver(callback);
         observer.observe(document.body, { childList: true, subtree: true });
         return () => observer.disconnect();
-      } else if (document && !document.getElementById('ccc')) {
-        // If the CivicUK script failed to load for any reason, we should consider it acknowledged by default.
-        // We need this for our tests and Cardigan as well.
-        console.log('no banner');
-        setHasAcknowledgedCookieBanner(true);
       }
     }
   }, []);

--- a/common/views/components/AppContext/AppContext.tsx
+++ b/common/views/components/AppContext/AppContext.tsx
@@ -106,7 +106,7 @@ export const AppContextProvider: FunctionComponent<PropsWithChildren> = ({
         const observer = new MutationObserver(callback);
         observer.observe(document.body, { childList: true, subtree: true });
         return () => observer.disconnect();
-      } else if (!document.getElementById('ccc')) {
+      } else if (document && !document.getElementById('ccc')) {
         // If the CivicUK script failed to load for any reason, we should consider it acknowledged by default.
         // We need this for our tests and Cardigan as well.
         console.log('no banner');

--- a/common/views/components/AppContext/AppContext.tsx
+++ b/common/views/components/AppContext/AppContext.tsx
@@ -57,8 +57,8 @@ export const AppContextProvider: FunctionComponent<PropsWithChildren> = ({
     appContextDefaults.audioPlaybackRate
   );
   const [hasAcknowledgedCookieBanner, setHasAcknowledgedCookieBanner] =
-    useState(Boolean(getCookies().CookieControl) || false);
-
+    useState(Boolean(getCookies().CookieControl));
+  console.log('getcookies', getCookies().CookieControl);
   useEffect(() => {
     setIsEnhanced(true);
   }, []);
@@ -86,34 +86,32 @@ export const AppContextProvider: FunctionComponent<PropsWithChildren> = ({
   }, []);
 
   useEffect(() => {
-    if (
-      // Cookie has already been set;
-      !hasAcknowledgedCookieBanner &&
-      // CivicUK script has loaded;
-      document.getElementById('ccc') &&
+    // Cookie has not been set yet;
+    if (!hasAcknowledgedCookieBanner) {
       // Banner or popup is actively displaying.
-      document.getElementById('ccc-overlay')
-    ) {
-      // Only once has it gone from the DOM can we consider the cookie banner acknowledged
-      const callback = mutationList => {
-        for (const mutation of mutationList) {
-          if (mutation.type === 'childList') {
-            setHasAcknowledgedCookieBanner(
-              document.getElementById('ccc')?.childElementCount === 0
-            );
+      if (
+        document.getElementById('ccc') &&
+        document.getElementById('ccc-overlay')
+      ) {
+        // Only once has it gone from the DOM can we consider the cookie banner acknowledged
+        const callback = mutationList => {
+          for (const mutation of mutationList) {
+            if (mutation.type === 'childList') {
+              setHasAcknowledgedCookieBanner(
+                document.getElementById('ccc')?.childElementCount === 0
+              );
+            }
           }
-        }
-      };
-      const observer = new MutationObserver(callback);
-      observer.observe(document.body, { childList: true, subtree: true });
-      return () => observer.disconnect();
-    } else if (
-      !document.getElementById('ccc') &&
-      !hasAcknowledgedCookieBanner
-    ) {
-      // If the CivicUK script failed to load for any reason, we should consider it acknowledged by default.
-      // We need this for our tests and Cardigan as well.
-      setHasAcknowledgedCookieBanner(true);
+        };
+        const observer = new MutationObserver(callback);
+        observer.observe(document.body, { childList: true, subtree: true });
+        return () => observer.disconnect();
+      } else if (!document.getElementById('ccc')) {
+        // If the CivicUK script failed to load for any reason, we should consider it acknowledged by default.
+        // We need this for our tests and Cardigan as well.
+        console.log('no banner');
+        setHasAcknowledgedCookieBanner(true);
+      }
     }
   }, []);
 

--- a/common/views/components/AppContext/AppContext.tsx
+++ b/common/views/components/AppContext/AppContext.tsx
@@ -87,6 +87,33 @@ export const AppContextProvider: FunctionComponent<PropsWithChildren> = ({
     setIsFullSupportBrowser('IntersectionObserver' in window);
   }, []);
 
+  useEffect(() => {
+    // If CookieControl has not been set yet;
+    if (!hasAcknowledgedCookieBanner) {
+      // If banner or popup is actively displaying
+      if (document.getElementById('ccc-overlay')) {
+        // Only once has the overlay gone from the DOM can we consider the cookie banner acknowledged
+        // The parent element (#ccc) is always in the DOM, but if it has no children then it's inactive.
+        const callback = mutationList => {
+          for (const mutation of mutationList) {
+            if (mutation.type === 'childList') {
+              setHasAcknowledgedCookieBanner(
+                document.getElementById('ccc')?.childElementCount === 0
+              );
+            }
+          }
+        };
+        const observer = new MutationObserver(callback);
+        observer.observe(document.body, { childList: true, subtree: true });
+        return () => observer.disconnect();
+      } else if (!document.getElementById('ccc')) {
+        // If the CivicUK script failed to load for any reason, we should consider it acknowledged by default.
+        // We need this for our tests and Cardigan as well.
+        setHasAcknowledgedCookieBanner(true);
+      }
+    }
+  }, [hasAcknowledgedCookieBanner]);
+
   return (
     <AppContext.Provider
       value={{

--- a/common/views/components/AppContext/AppContext.tsx
+++ b/common/views/components/AppContext/AppContext.tsx
@@ -9,6 +9,10 @@ import {
 import { getCookies } from 'cookies-next';
 import theme from '@weco/common/views/themes/default';
 import { Size } from '@weco/common/views/themes/config';
+import {
+  ACTIVE_COOKIE_BANNER_ID,
+  COOKIE_BANNER_PARENT_ID,
+} from '@weco/common/services/app/civic-uk';
 
 type AppContextProps = {
   isEnhanced: boolean;
@@ -91,14 +95,15 @@ export const AppContextProvider: FunctionComponent<PropsWithChildren> = ({
     // If CookieControl has not been set yet;
     if (!hasAcknowledgedCookieBanner) {
       // If banner or popup is actively displaying
-      if (document.getElementById('ccc-overlay')) {
+      if (document.getElementById(ACTIVE_COOKIE_BANNER_ID)) {
         // Only once has the overlay gone from the DOM can we consider the cookie banner acknowledged
-        // The parent element (#ccc) is always in the DOM, but if it has no children then it's inactive.
+        // The parent element is always in the DOM, but if it has no children then it's inactive.
         const callback = mutationList => {
           for (const mutation of mutationList) {
             if (mutation.type === 'childList') {
               setHasAcknowledgedCookieBanner(
-                document.getElementById('ccc')?.childElementCount === 0
+                document.getElementById(COOKIE_BANNER_PARENT_ID)
+                  ?.childElementCount === 0
               );
             }
           }
@@ -106,7 +111,7 @@ export const AppContextProvider: FunctionComponent<PropsWithChildren> = ({
         const observer = new MutationObserver(callback);
         observer.observe(document.body, { childList: true, subtree: true });
         return () => observer.disconnect();
-      } else if (!document.getElementById('ccc')) {
+      } else if (!document.getElementById(COOKIE_BANNER_PARENT_ID)) {
         // If the CivicUK script failed to load for any reason, we should consider it acknowledged by default.
         // We need this for our tests and Cardigan as well.
         setHasAcknowledgedCookieBanner(true);

--- a/common/views/components/CivicUK/index.tsx
+++ b/common/views/components/CivicUK/index.tsx
@@ -93,23 +93,15 @@ const CivicUK = ({ apiKey }: { apiKey: string }) => {
     useContext(AppContext);
 
   useEffect(() => {
-    console.log('Civic UK loads');
     // If CookieControl has not been set yet;
     if (!hasAcknowledgedCookieBanner) {
-      // If banner or popup is actively displaying on load;
-      if (
-        document.getElementById('ccc') &&
-        document.getElementById('ccc-overlay')
-      ) {
-        console.log('open banner is detected');
+      // If banner or popup is actively displaying
+      if (document.getElementById('ccc-overlay')) {
         // Only once has the overlay gone from the DOM can we consider the cookie banner acknowledged
+        // The parent element (#ccc) is always in the DOM, but if it has no children then it's inactive.
         const callback = mutationList => {
           for (const mutation of mutationList) {
             if (mutation.type === 'childList') {
-              console.log(
-                'mutation happening, setting it to',
-                document.getElementById('ccc')?.childElementCount === 0
-              );
               setHasAcknowledgedCookieBanner(
                 document.getElementById('ccc')?.childElementCount === 0
               );
@@ -123,7 +115,6 @@ const CivicUK = ({ apiKey }: { apiKey: string }) => {
         // If the CivicUK script failed to load for any reason, we should consider it acknowledged by default.
         // We need this for our tests and Cardigan as well.
         setHasAcknowledgedCookieBanner(true);
-        console.log('set ACB to true because there is no script loading');
       }
     }
   }, [hasAcknowledgedCookieBanner]);

--- a/common/views/components/CivicUK/index.tsx
+++ b/common/views/components/CivicUK/index.tsx
@@ -126,7 +126,7 @@ const CivicUK = ({ apiKey }: { apiKey: string }) => {
         console.log('set ACB to true because there is no script loading');
       }
     }
-  }, []);
+  }, [hasAcknowledgedCookieBanner]);
 
   return (
     <>

--- a/common/views/components/CivicUK/index.tsx
+++ b/common/views/components/CivicUK/index.tsx
@@ -86,16 +86,15 @@ const necessaryCookies = () => {
 
 const analyticsCookies = ['_gid', '_gat', '_ga*', 'ajs_anonymous_id'];
 
-const CivicUK = ({ apiKey }: { apiKey: string }) => {
-  return (
-    <>
-      <script
-        src="https://cc.cdn.civiccomputing.com/9/cookieControl-9.x.min.js"
-        type="text/javascript"
-      ></script>
-      <script
-        dangerouslySetInnerHTML={{
-          __html: `CookieControl.load({
+const CivicUK = ({ apiKey }: { apiKey: string }) => (
+  <>
+    <script
+      src="https://cc.cdn.civiccomputing.com/9/cookieControl-9.x.min.js"
+      type="text/javascript"
+    ></script>
+    <script
+      dangerouslySetInnerHTML={{
+        __html: `CookieControl.load({
             product: 'COMMUNITY',
             apiKey: '${apiKey}',
             product: 'pro',
@@ -170,10 +169,9 @@ const CivicUK = ({ apiKey }: { apiKey: string }) => {
             branding: ${JSON.stringify(branding)},
             text: ${JSON.stringify(text)}
           });`,
-        }}
-      />
-    </>
-  );
-};
+      }}
+    />
+  </>
+);
 
 export default CivicUK;

--- a/common/views/components/CivicUK/index.tsx
+++ b/common/views/components/CivicUK/index.tsx
@@ -97,21 +97,28 @@ const CivicUK = (props: Props) => {
     useContext(AppContext);
 
   useEffect(() => {
+    console.log('Civic UK loads');
     // If CookieControl has not been set yet;
     if (!hasAcknowledgedCookieBanner) {
       // If the CivicUK script failed to load for any reason, we should consider it acknowledged by default.
       // We need this for our tests and Cardigan as well.
       setHasAcknowledgedCookieBanner(true);
+      console.log('set ACB to true by default');
 
       // If banner or popup is actively displaying on load;
       if (
         document.getElementById('ccc') &&
         document.getElementById('ccc-overlay')
       ) {
+        console.log('open banner is detected');
         // Only once has the overlay gone from the DOM can we consider the cookie banner acknowledged
         const callback = mutationList => {
           for (const mutation of mutationList) {
             if (mutation.type === 'childList') {
+              console.log(
+                'mutation happening, setting it to',
+                document.getElementById('ccc')?.childElementCount === 0
+              );
               setHasAcknowledgedCookieBanner(
                 document.getElementById('ccc')?.childElementCount === 0
               );

--- a/common/views/components/CivicUK/index.tsx
+++ b/common/views/components/CivicUK/index.tsx
@@ -1,8 +1,6 @@
 import cookies from '@weco/common/data/cookies';
 import theme from '@weco/common/views/themes/default';
 import { font } from '@weco/common/utils/classnames';
-import { useContext, useEffect } from 'react';
-import { AppContext } from '../AppContext/AppContext';
 
 const headingStyles =
   'style="font-weight: 500; font-family: Inter, sans-serif;"';
@@ -89,36 +87,6 @@ const necessaryCookies = () => {
 const analyticsCookies = ['_gid', '_gat', '_ga*', 'ajs_anonymous_id'];
 
 const CivicUK = ({ apiKey }: { apiKey: string }) => {
-  const { hasAcknowledgedCookieBanner, setHasAcknowledgedCookieBanner } =
-    useContext(AppContext);
-
-  useEffect(() => {
-    // If CookieControl has not been set yet;
-    if (!hasAcknowledgedCookieBanner) {
-      // If banner or popup is actively displaying
-      if (document.getElementById('ccc-overlay')) {
-        // Only once has the overlay gone from the DOM can we consider the cookie banner acknowledged
-        // The parent element (#ccc) is always in the DOM, but if it has no children then it's inactive.
-        const callback = mutationList => {
-          for (const mutation of mutationList) {
-            if (mutation.type === 'childList') {
-              setHasAcknowledgedCookieBanner(
-                document.getElementById('ccc')?.childElementCount === 0
-              );
-            }
-          }
-        };
-        const observer = new MutationObserver(callback);
-        observer.observe(document.body, { childList: true, subtree: true });
-        return () => observer.disconnect();
-      } else if (!document.getElementById('ccc')) {
-        // If the CivicUK script failed to load for any reason, we should consider it acknowledged by default.
-        // We need this for our tests and Cardigan as well.
-        setHasAcknowledgedCookieBanner(true);
-      }
-    }
-  }, [hasAcknowledgedCookieBanner]);
-
   return (
     <>
       <script

--- a/common/views/components/CivicUK/index.tsx
+++ b/common/views/components/CivicUK/index.tsx
@@ -88,11 +88,7 @@ const necessaryCookies = () => {
 
 const analyticsCookies = ['_gid', '_gat', '_ga*', 'ajs_anonymous_id'];
 
-type Props = {
-  apiKey: string;
-};
-
-const CivicUK = (props: Props) => {
+const CivicUK = ({ apiKey }: { apiKey: string }) => {
   const { hasAcknowledgedCookieBanner, setHasAcknowledgedCookieBanner } =
     useContext(AppContext);
 
@@ -100,11 +96,6 @@ const CivicUK = (props: Props) => {
     console.log('Civic UK loads');
     // If CookieControl has not been set yet;
     if (!hasAcknowledgedCookieBanner) {
-      // If the CivicUK script failed to load for any reason, we should consider it acknowledged by default.
-      // We need this for our tests and Cardigan as well.
-      setHasAcknowledgedCookieBanner(true);
-      console.log('set ACB to true by default');
-
       // If banner or popup is actively displaying on load;
       if (
         document.getElementById('ccc') &&
@@ -128,6 +119,11 @@ const CivicUK = (props: Props) => {
         const observer = new MutationObserver(callback);
         observer.observe(document.body, { childList: true, subtree: true });
         return () => observer.disconnect();
+      } else if (!document.getElementById('ccc')) {
+        // If the CivicUK script failed to load for any reason, we should consider it acknowledged by default.
+        // We need this for our tests and Cardigan as well.
+        setHasAcknowledgedCookieBanner(true);
+        console.log('set ACB to true because there is no script loading');
       }
     }
   }, []);
@@ -142,7 +138,7 @@ const CivicUK = (props: Props) => {
         dangerouslySetInnerHTML={{
           __html: `CookieControl.load({
             product: 'COMMUNITY',
-            apiKey: '${props.apiKey}',
+            apiKey: '${apiKey}',
             product: 'pro',
             initialState: 'notify',
             consentCookieExpiry: 182,

--- a/common/views/components/Modal/Modal.tsx
+++ b/common/views/components/Modal/Modal.tsx
@@ -6,7 +6,6 @@ import {
   MutableRefObject,
   PropsWithChildren,
   useContext,
-  useState,
 } from 'react';
 import styled from 'styled-components';
 import Space from '@weco/common/views/components/styled/Space';
@@ -203,7 +202,6 @@ const Modal: FunctionComponent<Props> = ({
   const initialLoad = useRef(true);
   const nodeRef = useRef(null);
   const { hasAcknowledgedCookieBanner } = useContext(AppContext);
-  const [shouldLock, setShouldLock] = useState(false);
 
   useEffect(() => {
     if (isActive) {
@@ -231,13 +229,9 @@ const Modal: FunctionComponent<Props> = ({
     if (document && document.documentElement) {
       if (isActive && hasAcknowledgedCookieBanner) {
         document.documentElement.classList.add('is-scroll-locked');
-        setShouldLock(true);
       } else {
         document.documentElement.classList.remove('is-scroll-locked');
-        setShouldLock(false);
       }
-    } else {
-      setShouldLock(false);
     }
 
     return () => {
@@ -246,14 +240,16 @@ const Modal: FunctionComponent<Props> = ({
   }, [isActive, hasAcknowledgedCookieBanner]);
 
   return (
-    <FocusTrap active={shouldLock} focusTrapOptions={{ preventScroll: true }}>
+    <FocusTrap
+      active={isActive && hasAcknowledgedCookieBanner}
+      focusTrapOptions={{ preventScroll: true }}
+    >
       <div>
         {isActive && showOverlay && (
           <Overlay
             onClick={() => {
               if (!removeCloseButton) {
                 setIsActive(false);
-                setShouldLock(false);
               }
             }}
           />
@@ -278,7 +274,6 @@ const Modal: FunctionComponent<Props> = ({
                 ref={closeButtonRef}
                 onClick={() => {
                   setIsActive(false);
-                  setShouldLock(false);
                 }}
               >
                 <span className="visually-hidden">Close modal window</span>

--- a/common/views/components/Modal/Modal.tsx
+++ b/common/views/components/Modal/Modal.tsx
@@ -202,7 +202,7 @@ const Modal: FunctionComponent<Props> = ({
   const initialLoad = useRef(true);
   const nodeRef = useRef(null);
   const { hasAcknowledgedCookieBanner } = useContext(AppContext);
-
+  console.log('modal', { hasAcknowledgedCookieBanner });
   useEffect(() => {
     if (isActive) {
       closeButtonRef?.current?.focus();
@@ -229,13 +229,16 @@ const Modal: FunctionComponent<Props> = ({
     if (document && document.documentElement) {
       console.log({ isActive, hasAcknowledgedCookieBanner });
       if (isActive && hasAcknowledgedCookieBanner) {
+        console.log('scroll lock');
         document.documentElement.classList.add('is-scroll-locked');
       } else {
+        console.log('scroll unlock');
         document.documentElement.classList.remove('is-scroll-locked');
       }
     }
 
     return () => {
+      console.log('scroll unlock');
       document.documentElement.classList.remove('is-scroll-locked');
     };
   }, [isActive, hasAcknowledgedCookieBanner]);

--- a/common/views/components/Modal/Modal.tsx
+++ b/common/views/components/Modal/Modal.tsx
@@ -14,6 +14,7 @@ import { CSSTransition } from 'react-transition-group';
 import { cross } from '@weco/common/icons';
 import FocusTrap from 'focus-trap-react';
 import { AppContext } from '../AppContext/AppContext';
+import { ACTIVE_COOKIE_BANNER_ID } from '@weco/common/services/app/civic-uk';
 
 type BaseModalProps = {
   $width?: string | null;
@@ -209,7 +210,7 @@ const Modal: FunctionComponent<Props> = ({
       // There can be a sort of race condition between modals and the cookie banner,
       // so we need to check here too if it is active.
       // The overlay element is visible if the banner or the popup is actively showing.
-      if (document.getElementById('ccc-overlay')) {
+      if (document.getElementById(ACTIVE_COOKIE_BANNER_ID)) {
         setHasAcknowledgedCookieBanner(false);
       } else {
         closeButtonRef?.current?.focus();

--- a/common/views/components/Modal/Modal.tsx
+++ b/common/views/components/Modal/Modal.tsx
@@ -227,6 +227,7 @@ const Modal: FunctionComponent<Props> = ({
 
   useEffect(() => {
     if (document && document.documentElement) {
+      console.log({ isActive, hasAcknowledgedCookieBanner });
       if (isActive && hasAcknowledgedCookieBanner) {
         document.documentElement.classList.add('is-scroll-locked');
       } else {

--- a/common/views/components/Modal/Modal.tsx
+++ b/common/views/components/Modal/Modal.tsx
@@ -206,8 +206,10 @@ const Modal: FunctionComponent<Props> = ({
 
   useEffect(() => {
     if (isActive) {
+      // There can be a sort of race condition between modals and the cookie banner,
+      // so we need to check here too if it is active.
+      // The overlay element is visible if the banner or the popup is actively showing.
       if (document.getElementById('ccc-overlay')) {
-        console.log('modal check of ACB sets it to false');
         setHasAcknowledgedCookieBanner(false);
       } else {
         closeButtonRef?.current?.focus();
@@ -233,18 +235,14 @@ const Modal: FunctionComponent<Props> = ({
 
   useEffect(() => {
     if (document && document.documentElement) {
-      console.log({ isActive, hasAcknowledgedCookieBanner });
       if (isActive && hasAcknowledgedCookieBanner) {
-        console.log('scroll lock');
         document.documentElement.classList.add('is-scroll-locked');
       } else {
-        console.log('scroll unlock');
         document.documentElement.classList.remove('is-scroll-locked');
       }
     }
 
     return () => {
-      console.log('scroll unlock');
       document.documentElement.classList.remove('is-scroll-locked');
     };
   }, [isActive, hasAcknowledgedCookieBanner]);

--- a/common/views/components/Modal/Modal.tsx
+++ b/common/views/components/Modal/Modal.tsx
@@ -201,11 +201,17 @@ const Modal: FunctionComponent<Props> = ({
   const ModalWindow = determineModal(modalStyle);
   const initialLoad = useRef(true);
   const nodeRef = useRef(null);
-  const { hasAcknowledgedCookieBanner } = useContext(AppContext);
-  console.log('modal', { hasAcknowledgedCookieBanner });
+  const { hasAcknowledgedCookieBanner, setHasAcknowledgedCookieBanner } =
+    useContext(AppContext);
+
   useEffect(() => {
     if (isActive) {
-      closeButtonRef?.current?.focus();
+      if (document.getElementById('ccc-overlay')) {
+        console.log('modal check of ACB sets it to false');
+        setHasAcknowledgedCookieBanner(false);
+      } else {
+        closeButtonRef?.current?.focus();
+      }
     } else if (!initialLoad.current) {
       openButtonRef && openButtonRef.current && openButtonRef.current.focus();
     }

--- a/common/views/components/Modal/Modal.tsx
+++ b/common/views/components/Modal/Modal.tsx
@@ -6,6 +6,7 @@ import {
   MutableRefObject,
   PropsWithChildren,
   useContext,
+  useState,
 } from 'react';
 import styled from 'styled-components';
 import Space from '@weco/common/views/components/styled/Space';
@@ -202,6 +203,7 @@ const Modal: FunctionComponent<Props> = ({
   const initialLoad = useRef(true);
   const nodeRef = useRef(null);
   const { hasAcknowledgedCookieBanner } = useContext(AppContext);
+  const [shouldLock, setShouldLock] = useState(false);
 
   useEffect(() => {
     if (isActive) {
@@ -229,17 +231,19 @@ const Modal: FunctionComponent<Props> = ({
     if (document && document.documentElement) {
       if (isActive && hasAcknowledgedCookieBanner) {
         document.documentElement.classList.add('is-scroll-locked');
+        setShouldLock(true);
       } else {
         document.documentElement.classList.remove('is-scroll-locked');
+        setShouldLock(false);
       }
+    } else {
+      setShouldLock(false);
     }
 
     return () => {
       document.documentElement.classList.remove('is-scroll-locked');
     };
   }, [isActive, hasAcknowledgedCookieBanner]);
-
-  const shouldLock = isActive && hasAcknowledgedCookieBanner;
 
   return (
     <FocusTrap active={shouldLock} focusTrapOptions={{ preventScroll: true }}>
@@ -249,6 +253,7 @@ const Modal: FunctionComponent<Props> = ({
             onClick={() => {
               if (!removeCloseButton) {
                 setIsActive(false);
+                setShouldLock(false);
               }
             }}
           />
@@ -273,6 +278,7 @@ const Modal: FunctionComponent<Props> = ({
                 ref={closeButtonRef}
                 onClick={() => {
                   setIsActive(false);
+                  setShouldLock(false);
                 }}
               >
                 <span className="visually-hidden">Close modal window</span>

--- a/playwright/test/work.test.ts
+++ b/playwright/test/work.test.ts
@@ -43,7 +43,7 @@ test.describe(`Scenario 1: a user wants to see relevant information about where 
 
     await expect(whereToFindIt).toBeVisible();
 
-    await expect(loginLink.or(unavailableBanner)).not.toBeVisible(); // TODO: Revert before merge. Fail test in order to have access to e2e environment
+    await expect(loginLink.or(unavailableBanner)).toBeVisible();
   });
 
   test(`works with only a physical location don't display an 'Available online' section`, async ({

--- a/playwright/test/work.test.ts
+++ b/playwright/test/work.test.ts
@@ -43,7 +43,7 @@ test.describe(`Scenario 1: a user wants to see relevant information about where 
 
     await expect(whereToFindIt).toBeVisible();
 
-    await expect(loginLink.or(unavailableBanner)).toBeVisible();
+    await expect(loginLink.or(unavailableBanner)).not.toBeVisible(); // TODO: Revert before merge. Fail test in order to have access to e2e environment
   });
 
   test(`works with only a physical location don't display an 'Available online' section`, async ({


### PR DESCRIPTION
## Who is this for?
#10915 

## What is it doing for them?
On live environments it seems that the modal/cookie banner need more time to detect interactions with the other, and so we need to be able to control `hasAcknowledgedCookieBanner` from the Modal. The modal checks if the overlay is active (which means either the banner or the popup is there) and that turns off the focus lock.

I've aimed to test as much as possible on the e2e environment and it seems to work nicely, but as we had to revert the last "fix" (which was wonky I admit), if this can be tested locally as well I reckon all the better!

I'll squash and merge for this as I made a lot of noisy useless commits for the sake of debugging.