### PR TITLE
rename type to bring it in line with others

### DIFF
--- a/common/server-data/prismic.ts
+++ b/common/server-data/prismic.ts
@@ -9,7 +9,7 @@ import * as prismic from '@prismicio/client';
 import { InferDataInterface } from '../services/prismic/types';
 import { createClient as createPrismicClient } from '@weco/common/services/prismic/fetch';
 
-export type CollectionVenuePrismicDocumentLite = {
+export type RawCollectionVenueDocumentLite = {
   id: string;
 } & {
   data: Omit<
@@ -19,7 +19,7 @@ export type CollectionVenuePrismicDocumentLite = {
 };
 
 export type ResultsLite = {
-  results: CollectionVenuePrismicDocumentLite[];
+  results: RawCollectionVenueDocumentLite[];
 };
 
 export const defaultValue = {

--- a/common/services/prismic/transformers/collection-venues.ts
+++ b/common/services/prismic/transformers/collection-venues.ts
@@ -1,6 +1,6 @@
 import {
   ResultsLite,
-  CollectionVenuePrismicDocumentLite,
+  RawCollectionVenueDocumentLite,
 } from '../../../server-data/prismic';
 import { DayOfWeek, formatTime } from '@weco/common/utils/format-date';
 import { Venue, OpeningHoursDay } from '@weco/common/model/opening-hours';
@@ -13,7 +13,7 @@ import { CollectionVenueDocument as RawCollectionVenueDocument } from '@weco/com
 
 export function createRegularDay(
   day: DayOfWeek,
-  venue: RawCollectionVenueDocument | CollectionVenuePrismicDocumentLite
+  venue: RawCollectionVenueDocument | RawCollectionVenueDocumentLite
 ): OpeningHoursDay {
   const { data } = venue;
   const lowercaseDay = day.toLowerCase();
@@ -40,7 +40,7 @@ export function createRegularDay(
 }
 
 export function transformCollectionVenue(
-  venue: RawCollectionVenueDocument | CollectionVenuePrismicDocumentLite
+  venue: RawCollectionVenueDocument | RawCollectionVenueDocumentLite
 ): Venue {
   const data = venue.data;
   const exceptionalOpeningHours = data.modifiedDayOpeningTimes


### PR DESCRIPTION
Relates to https://github.com/wellcomecollection/wellcomecollection.org/pull/10930

A part of that PR we prefaced Prismic types with 'Raw' to help distinguish them from transformed types.

This does the same to a similar type
