### PR TITLE
Remove old label code

### DIFF
--- a/cardigan/stories/components/VenueHours/VenueHours.stories.tsx
+++ b/cardigan/stories/components/VenueHours/VenueHours.stories.tsx
@@ -6,7 +6,7 @@ import { ReadmeDecorator } from '@weco/cardigan/config/decorators';
 const Template = () => (
   <ReadmeDecorator
     WrappedComponent={VenueHours}
-    args={{ venue: galleriesVenue, weight: 'featured' }}
+    args={{ venue: galleriesVenue }}
     Readme={Readme}
   />
 );

--- a/common/test/fixtures/components/galleries-venue.ts
+++ b/common/test/fixtures/components/galleries-venue.ts
@@ -136,4 +136,5 @@ export const galleriesVenue: Venue = {
   },
   url: 'https://wellcomecollection.org/whats-on',
   linkText: 'See what’s on',
+  isFeatured: true,
 };

--- a/common/views/slices/CollectionVenue/index.tsx
+++ b/common/views/slices/CollectionVenue/index.tsx
@@ -31,7 +31,6 @@ const CollectionVenue = ({
         ) : (
           <Layout
             gridSizes={
-              transformedSlice.weight === 'featured' || // TODO: remove after Slice Machine migration
               transformedSlice.value.content.isFeatured
                 ? {
                     s: 12,
@@ -52,10 +51,7 @@ const CollectionVenue = ({
                   }
             }
           >
-            <VenueHours
-              venue={transformedSlice.value.content}
-              weight={transformedSlice.weight || 'default'}
-            />
+            <VenueHours venue={transformedSlice.value.content} />
           </Layout>
         )}
       </SpacingComponent>

--- a/content/webapp/components/VenueHours/VenueHours.tsx
+++ b/content/webapp/components/VenueHours/VenueHours.tsx
@@ -23,7 +23,6 @@ import {
   OpeningHoursDay,
   Venue,
 } from '@weco/common/model/opening-hours';
-import { Weight } from '../../types/body';
 import PlainList from '@weco/common/views/components/styled/PlainList';
 
 const VenueHoursImage = styled(Space)`
@@ -151,10 +150,9 @@ export const UnusualOpeningHours: FunctionComponent<
 
 type Props = {
   venue: Venue;
-  weight: Weight;
 };
 
-const VenueHours: FunctionComponent<Props> = ({ venue, weight }) => {
+const VenueHours: FunctionComponent<Props> = ({ venue }) => {
   const { collectionVenues } = usePrismicData();
   const venues = transformCollectionVenues(collectionVenues);
   const allOverrideDates = getOverrideDatesForAllVenues(venues);
@@ -169,7 +167,7 @@ const VenueHours: FunctionComponent<Props> = ({ venue, weight }) => {
   const upcomingExceptionalOpeningHours =
     exceptionalOpeningHours &&
     getUpcomingExceptionalOpeningHours(exceptionalOpeningHours);
-  const isFeatured = weight === 'featured' || venue.isFeatured; // TODO: remove weight check after migration
+  const isFeatured = venue.isFeatured;
   return (
     <>
       {isFeatured && (

--- a/content/webapp/services/prismic/transformers/body.ts
+++ b/content/webapp/services/prismic/transformers/body.ts
@@ -39,7 +39,7 @@ import {
   transformTaslFromString,
 } from '@weco/common/services/prismic/transformers';
 import * as prismic from '@prismicio/client';
-import { ContentListProps, Slice, Weight } from '@weco/content/types/body';
+import { ContentListProps, Slice } from '@weco/content/types/body';
 import { transformCollectionVenue } from '@weco/common/services/prismic/transformers/collection-venues';
 import { transformPage } from './pages';
 import { transformGuide } from './guides';
@@ -73,27 +73,11 @@ import { Props as TitledTextListProps } from '@weco/content/components/TitledTex
 import { Props as AsyncSearchResultsProps } from '@weco/content/components/SearchResults/AsyncSearchResults';
 import { Venue } from '@weco/common/model/opening-hours';
 
-export function getWeight(weight: string | null): Weight {
-  switch (weight) {
-    case 'featured':
-      return weight;
-    case 'standalone':
-      return weight;
-    case 'supporting':
-      return weight;
-    case 'frames':
-      return weight;
-    default:
-      return 'default';
-  }
-}
-
 export function transformStandfirstSlice(
   slice: RawStandfirstSlice
 ): Slice<'standfirst', prismic.RichTextField> {
   return {
     type: 'standfirst',
-    weight: getWeight(slice.slice_label),
     value: slice.primary.text,
   };
 }
@@ -166,7 +150,6 @@ export function transformEditorialImageSlice(
   slice: RawEditorialImageSlice
 ): Slice<'picture', CaptionedImageProps> {
   return {
-    weight: getWeight(slice.slice_label),
     type: 'picture',
     value: transformCaptionedImage(slice.primary),
   };
@@ -181,10 +164,8 @@ export function transformEditorialImageGallerySlice(
     value: {
       title: asText(slice.primary.title),
       items: slice.items.map(item => transformCaptionedImage(item)),
-      isStandalone:
-        isStandalone || getWeight(slice.slice_label) === 'standalone', // TODO: remove the getWeight() part when migration's complete
-      isFrames:
-        slice.primary.isFrames || getWeight(slice.slice_label) === 'frames',
+      isStandalone: isStandalone || false,
+      isFrames: slice.primary.isFrames,
     },
   };
 }
@@ -198,7 +179,6 @@ export function transformGifVideoSlice(
   return isFilledLinkToMediaField(slice.primary.video)
     ? {
         type: 'gifVideo',
-        weight: getWeight(slice.slice_label),
         value: {
           caption: asRichText(slice.primary.caption),
           videoUrl: slice.primary.video.url,
@@ -266,7 +246,6 @@ export function transformIframeSlice(
 ): Slice<'iframe', IframeProps> {
   return {
     type: 'iframe',
-    weight: getWeight(slice.slice_label),
     value: {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       src: slice.primary.iframeSrc!,
@@ -281,14 +260,10 @@ export function transformQuoteSlice(
 ): Slice<'quote', QuoteProps> {
   return {
     type: 'quote',
-    weight: getWeight(slice.slice_label),
     value: {
       text: slice.primary.text,
       citation: slice.primary.citation,
-      isPullOrReview:
-        slice.primary.isPullOrReview ||
-        slice.slice_label === 'pull' ||
-        slice.slice_label === 'review', // TODO: tidy after migration
+      isPullOrReview: slice.primary.isPullOrReview,
     },
   };
 }
@@ -329,7 +304,6 @@ export function transformSearchResultsSlice(
 ): Slice<'searchResults', AsyncSearchResultsProps> {
   return {
     type: 'searchResults',
-    weight: getWeight(slice.slice_label),
     value: {
       title: asText(slice.primary.title),
       query: slice.primary.query || '',
@@ -345,7 +319,6 @@ export function transformCollectionVenueSlice(
   return isFilledLinkToDocumentWithData(slice.primary.content)
     ? {
         type: 'collectionVenue',
-        weight: getWeight(slice.slice_label),
         value: {
           content: {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -369,7 +342,6 @@ export function transformEmbedSlice(
   if (embed.provider_name === 'Vimeo') {
     return {
       type: 'videoEmbed',
-      weight: getWeight(slice.slice_label),
       value: {
         embedUrl: getVimeoEmbedUrl(embed),
         caption: slice.primary.caption,
@@ -381,7 +353,6 @@ export function transformEmbedSlice(
   if (embed.provider_name === 'SoundCloud') {
     return {
       type: 'soundcloudEmbed',
-      weight: getWeight(slice.slice_label),
       value: {
         embedUrl: getSoundCloudEmbedUrl(embed),
         caption: slice.primary.caption,
@@ -393,7 +364,6 @@ export function transformEmbedSlice(
   if (embed.provider_name === 'YouTube') {
     return {
       type: 'videoEmbed',
-      weight: getWeight(slice.slice_label),
       value: {
         embedUrl: getYouTubeEmbedUrl(embed),
         caption: slice.primary.caption,
@@ -412,7 +382,6 @@ export function transformContentListSlice(
 
   return {
     type: 'contentList',
-    weight: getWeight(slice.slice_label),
     value: {
       title: asText(slice.primary.title),
       // TODO: The old code would look up a `hasFeatured` field on `slice.primary`,

--- a/content/webapp/types/body.ts
+++ b/content/webapp/types/body.ts
@@ -17,16 +17,8 @@ import { Card } from './card';
 
 import * as prismic from '@prismicio/client';
 
-export type Weight =
-  | 'default'
-  | 'featured'
-  | 'standalone'
-  | 'supporting'
-  | 'frames';
-
 export type Slice<TypeName extends string, Value> = {
   type: TypeName;
-  weight?: Weight;
   value: Value;
 };
 


### PR DESCRIPTION
Following the slice machine/migration work we no longer have labels on slices. This removes the redundant code
