### PR TITLE
Centralise scripts and add Custom HTML tags from GTM

### DIFF
--- a/common/services/app/analytics-scripts/core-web-vitals.tsx
+++ b/common/services/app/analytics-scripts/core-web-vitals.tsx
@@ -1,0 +1,67 @@
+const CoreWebVitalsScript = () => (
+  <>
+    <script
+      id="web-vitals-ga4"
+      dangerouslySetInnerHTML={{
+        __html: `/*
+          * Send Core Web Vitals to the DataLayer 
+          * v3.0
+          */
+          function sendToDataLayer(metric) {
+
+            var rating = metric.rating;
+            var attribution = metric.attribution;
+
+            var debugTarget = attribution ? attribution.largestShiftTarget||attribution.element||attribution.eventTarget||'' : '(not set)';
+
+            var webVitalsMeasurement =  {
+              name: metric.name,
+              id: metric.id, 
+              value: metric.value,
+              delta: metric.delta,
+              rating: rating,
+              valueRounded: Math.round(metric.name === 'CLS' ? metric.value * 1000 : metric.value),
+              deltaRounded: Math.round(metric.name === 'CLS' ? metric.delta * 1000 : metric.delta),
+              event_time: attribution ? attribution.largestShiftTime||(attribution.lcpEntry&&attribution.lcpEntry.startTime)||attribution.eventTime||'': ''
+            };
+
+            dataLayer.push({
+                event: 'coreWebVitals', 
+                webVitalsMeasurement: webVitalsMeasurement
+            });
+          }`,
+      }}
+    />
+    <script
+      id="web-vitals-cdn"
+      dangerouslySetInnerHTML={{
+        __html: `/*
+          * Using the web-vitals script from a CDN
+          * 
+          * https://github.com/GoogleChrome/web-vitals#from-a-cdn
+          * 
+          * Modified to call the sendToDataLayer function on events
+          * 
+          */
+          
+          (function() {
+            var script = document.createElement('script');
+            script.src = 'https://unpkg.com/web-vitals@3.0.0/dist/web-vitals.attribution.iife.js';
+            script.onload = function() {
+              // When loading "web-vitals" using a classic script, all the public
+              // methods can be found on the "webVitals" global namespace.
+              webVitals.onCLS(sendToDataLayer);
+              webVitals.onFID(sendToDataLayer);
+              webVitals.onLCP(sendToDataLayer);
+              webVitals.onFCP(sendToDataLayer);
+              webVitals.onTTFB(sendToDataLayer);
+              webVitals.onINP(sendToDataLayer);
+            }
+            document.head.appendChild(script);
+          }());`,
+      }}
+    />
+  </>
+);
+
+export default CoreWebVitalsScript;

--- a/common/services/app/analytics-scripts/google-analytics.tsx
+++ b/common/services/app/analytics-scripts/google-analytics.tsx
@@ -52,6 +52,7 @@ export const Ga4DataLayer: FunctionComponent<Props> = ({
 
   return (
     <script
+      id="google-analytics-data-layer"
       dangerouslySetInnerHTML={{
         __html: `
             window.dataLayer = window.dataLayer || [];
@@ -87,6 +88,7 @@ export const Ga4DataLayer: FunctionComponent<Props> = ({
 
 export const GoogleTagManager: FunctionComponent = () => (
   <script
+    id="google-tag-manager"
     dangerouslySetInnerHTML={{
       __html: `
           (function(w,d,s,l,i){w[l] = w[l] || [];w[l].push({'gtm.start':

--- a/common/services/app/analytics-scripts/index.tsx
+++ b/common/services/app/analytics-scripts/index.tsx
@@ -1,0 +1,17 @@
+import SegmentScript from './segment';
+import CoreWebVitalsScript from './core-web-vitals';
+import PerformanceTimingTrackingScript from './performance-timing-tracking';
+import {
+  Ga4DataLayer,
+  GoogleTagManager,
+  GaDimensions,
+} from './google-analytics';
+
+export {
+  SegmentScript,
+  CoreWebVitalsScript,
+  PerformanceTimingTrackingScript,
+  Ga4DataLayer,
+  GoogleTagManager,
+};
+export type { GaDimensions };

--- a/common/services/app/analytics-scripts/performance-timing-tracking.tsx
+++ b/common/services/app/analytics-scripts/performance-timing-tracking.tsx
@@ -1,0 +1,73 @@
+/* eslint-disable no-useless-escape */
+
+const PerformanceTimingTrackingScript = () => (
+  <script
+    id="performance-timing-tracking"
+    dangerouslySetInnerHTML={{
+      __html: `
+        (function() {
+
+        var siteSpeedSampleRate = 100;
+        var gaCookiename = '_ga';
+        var dataLayerName = 'dataLayer';
+
+        // No need to edit anything after this line
+        var shouldItBeTracked = function(siteSpeedSampleRate) {
+            // If we don't pass a sample rate, default value is 1
+            if (!siteSpeedSampleRate)
+                siteSpeedSampleRate = 1;
+            // Generate a hashId from a String
+            var hashId = function(a) {
+                var b = 1, c;
+                if (a)
+                    for (b = 0,
+                    c = a.length - 1; 0 <= c; c--) {
+                        var d = a.charCodeAt(c);
+                        b = (b << 6 & 268435455) + d + (d << 14);
+                        d = b & 266338304;
+                        b = 0 != d ? b ^ d >> 21 : b
+                    }
+                return b
+            }
+            var clientId = ('; ' + document.cookie).split('; '+gaCookiename+'=').pop().split(';').shift().split(/GA1\.[0-9]\./)[1];
+            if(!clientId) return !1;
+            // If, for any reason the sample speed rate is higher than 100, let's keep it to a 100 max value
+            var b = Math.min(siteSpeedSampleRate, 100);        
+            return hashId(clientId) % 100 >= b ? !1 : !0
+        }
+
+        if (shouldItBeTracked(siteSpeedSampleRate)) {
+            var pt = window.performance || window.webkitPerformance;
+            pt = pt && pt.timing;
+            if (!pt)
+                return;
+            if (pt.navigationStart === 0 || pt.loadEventStart === 0)
+                return;
+            var timingData = {
+                "page_load_time": pt.loadEventStart - pt.navigationStart,
+                "page_download_time": pt.responseEnd - pt.responseStart,
+                "dns_time": pt.domainLookupEnd - pt.domainLookupStart,
+                "redirect_response_time": pt.fetchStart - pt.navigationStart,
+                "server_response_time": pt.responseStart - pt.requestStart,
+                "tcp_connect_time": pt.connectEnd - pt.connectStart,
+                "dom_interactive_time": pt.domInteractive - pt.navigationStart,
+                "content_load_time": pt.domContentLoadedEventStart - pt.navigationStart
+            };
+            // Sanity Checks if any value is negative abort
+            if (Object.values(timingData).filter(function(e) {
+                if (e < 0)
+                    return e;
+            }).length > 0)
+                return;
+            window[dataLayerName] && window[dataLayerName].push({
+                "event": "performance_timing",
+                "timing": timingData
+            })
+        }
+    }
+    )()`,
+    }}
+  />
+);
+
+export default PerformanceTimingTrackingScript;

--- a/common/services/app/analytics-scripts/segment.tsx
+++ b/common/services/app/analytics-scripts/segment.tsx
@@ -1,0 +1,33 @@
+import * as snippet from '@segment/snippet';
+
+// Don't attempt to destructure the process object
+// https://github.com/vercel/next.js/pull/20869/files
+const ANALYTICS_WRITE_KEY =
+  process.env.ANALYTICS_WRITE_KEY || '78Czn5jNSaMSVrBq2J9K4yJjWxh6fyRI';
+const NODE_ENV = process.env.NODE_ENV || 'development';
+
+function renderSegmentSnippet() {
+  const opts = {
+    apiKey: ANALYTICS_WRITE_KEY,
+    page: false,
+  };
+
+  if (NODE_ENV === 'development') {
+    return snippet.max(opts);
+  }
+
+  return snippet.min(opts);
+}
+
+const SegmentScript = () => {
+  return (
+    <script
+      id="segment-script"
+      dangerouslySetInnerHTML={{
+        __html: renderSegmentSnippet(),
+      }}
+    />
+  );
+};
+
+export default SegmentScript;

--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -22,7 +22,7 @@ import { ApmContextProvider } from '@weco/common/views/components/ApmContext/Apm
 import { AppErrorProps } from '@weco/common/services/app';
 import usePrismicPreview from '@weco/common/services/app/usePrismicPreview';
 import useMaintainPageHeight from '@weco/common/services/app/useMaintainPageHeight';
-import { GaDimensions } from '@weco/common/services/app/google-analytics';
+import { GaDimensions } from '@weco/common/services/app/analytics-scripts';
 import { deserialiseProps } from '@weco/common/utils/json';
 import { SearchContextProvider } from '@weco/common/views/components/SearchContext/SearchContext';
 import CivicUK from '@weco/common/views/components/CivicUK';

--- a/common/views/pages/_document.tsx
+++ b/common/views/pages/_document.tsx
@@ -8,34 +8,17 @@ import Document, {
 } from 'next/document';
 import { ReactElement } from 'react';
 import { ServerStyleSheet } from 'styled-components';
-import * as snippet from '@segment/snippet';
 import { Toggles } from '@weco/toggles';
+import { ConsentStatusProps } from '@weco/common/server-data/types';
+import { getErrorPageConsent } from '@weco/common/services/app/civic-uk';
 import {
+  CoreWebVitalsScript,
+  PerformanceTimingTrackingScript,
+  SegmentScript,
   Ga4DataLayer,
   GoogleTagManager,
   GaDimensions,
-} from '@weco/common/services/app/google-analytics';
-import { ConsentStatusProps } from '@weco/common/server-data/types';
-import { getErrorPageConsent } from '@weco/common/services/app/civic-uk';
-
-// Don't attempt to destructure the process object
-// https://github.com/vercel/next.js/pull/20869/files
-const ANALYTICS_WRITE_KEY =
-  process.env.ANALYTICS_WRITE_KEY || '78Czn5jNSaMSVrBq2J9K4yJjWxh6fyRI';
-const NODE_ENV = process.env.NODE_ENV || 'development';
-
-export function renderSegmentSnippet() {
-  const opts = {
-    apiKey: ANALYTICS_WRITE_KEY,
-    page: false,
-  };
-
-  if (NODE_ENV === 'development') {
-    return snippet.max(opts);
-  }
-
-  return snippet.min(opts);
-}
+} from '@weco/common/services/app/analytics-scripts';
 
 type DocumentInitialPropsWithTogglesAndGa = DocumentInitialProps & {
   toggles: Toggles;
@@ -99,11 +82,13 @@ class WecoDoc extends Document<DocumentInitialPropsWithTogglesAndGa> {
             Let's keep an eye on this issue and consider moving it next to the Segment script when it's fixed */}
             <GoogleTagManager />
 
-            {shouldRenderAnalytics && (
-              <script
-                dangerouslySetInnerHTML={{ __html: renderSegmentSnippet() }}
-              />
-            )}
+            {/* https://github.com/wellcomecollection/wellcomecollection.org/issues/10090 */}
+            <PerformanceTimingTrackingScript />
+
+            {/* https://github.com/wellcomecollection/wellcomecollection.org/issues/9286 */}
+            <CoreWebVitalsScript />
+
+            {shouldRenderAnalytics && <SegmentScript />}
           </>
         </Head>
         <body>

--- a/content/webapp/pages/articles/[articleId].tsx
+++ b/content/webapp/pages/articles/[articleId].tsx
@@ -19,7 +19,7 @@ import {
 import { ArticleFormatIds } from '@weco/content/data/content-format-ids';
 import Space from '@weco/common/views/components/styled/Space';
 import { AppErrorProps } from '@weco/common/services/app';
-import { GaDimensions } from '@weco/common/services/app/google-analytics';
+import { GaDimensions } from '@weco/common/services/app/analytics-scripts';
 import { serialiseProps } from '@weco/common/utils/json';
 import { getServerData } from '@weco/common/server-data';
 import SeriesNavigation from '@weco/content/components/SeriesNavigation/SeriesNavigation';

--- a/content/webapp/pages/books/[bookId].tsx
+++ b/content/webapp/pages/books/[bookId].tsx
@@ -9,7 +9,7 @@ import Space from '@weco/common/views/components/styled/Space';
 import BookImage from '@weco/content/components/BookImage/BookImage';
 import styled from 'styled-components';
 import { AppErrorProps } from '@weco/common/services/app';
-import { GaDimensions } from '@weco/common/services/app/google-analytics';
+import { GaDimensions } from '@weco/common/services/app/analytics-scripts';
 import { serialiseProps } from '@weco/common/utils/json';
 import { getServerData } from '@weco/common/server-data';
 import Body from '@weco/content/components/Body/Body';

--- a/content/webapp/pages/events/[eventId]/index.tsx
+++ b/content/webapp/pages/events/[eventId]/index.tsx
@@ -21,7 +21,7 @@ import { upcomingDatesFullyBooked } from '@weco/content/services/prismic/events'
 import EventDatesLink from '@weco/content/components/EventDatesLink/EventDatesLink';
 import Space from '@weco/common/views/components/styled/Space';
 import { LabelField } from '@weco/content/model/label-field';
-import { GaDimensions } from '@weco/common/services/app/google-analytics';
+import { GaDimensions } from '@weco/common/services/app/analytics-scripts';
 import {
   audioDescribed,
   britishSignLanguage,

--- a/content/webapp/pages/exhibitions/[exhibitionId]/index.tsx
+++ b/content/webapp/pages/exhibitions/[exhibitionId]/index.tsx
@@ -5,7 +5,7 @@ import Exhibition from '@weco/content/components/Exhibition/Exhibition';
 import { Exhibition as ExhibitionType } from '@weco/content/types/exhibitions';
 import Installation from '@weco/content/components/Installation/Installation';
 import { AppErrorProps } from '@weco/common/services/app';
-import { GaDimensions } from '@weco/common/services/app/google-analytics';
+import { GaDimensions } from '@weco/common/services/app/analytics-scripts';
 import { serialiseProps } from '@weco/common/utils/json';
 import { getServerData } from '@weco/common/server-data';
 import { createClient } from '@weco/content/services/prismic/fetch';

--- a/content/webapp/pages/pages/[pageId].tsx
+++ b/content/webapp/pages/pages/[pageId].tsx
@@ -26,7 +26,7 @@ import { PageFormatIds } from '@weco/content/data/content-format-ids';
 import { links } from '@weco/common/views/components/Header/Header';
 import { Props as LabelsListProps } from '@weco/common/views/components/LabelsList/LabelsList';
 import { AppErrorProps } from '@weco/common/services/app';
-import { GaDimensions } from '@weco/common/services/app/google-analytics';
+import { GaDimensions } from '@weco/common/services/app/analytics-scripts';
 import { GetServerSideProps } from 'next';
 import { serialiseProps } from '@weco/common/utils/json';
 import { getServerData } from '@weco/common/server-data';
@@ -318,7 +318,6 @@ export const Page: FunctionComponent<Props> = ({
       };
     });
 
-    /* eslint-disable @typescript-eslint/no-non-null-assertion */
     const orderedItems: PageType[] = groupWithOrder
       .filter(s => Boolean(s.order))
       .sort((a, b) => a.order! - b.order!);

--- a/content/webapp/pages/series/[seriesId].tsx
+++ b/content/webapp/pages/series/[seriesId].tsx
@@ -10,7 +10,7 @@ import { getFeaturedMedia } from '@weco/content/utils/page-header';
 import { Series } from '@weco/content/types/series';
 import { ArticleBasic } from '@weco/content/types/articles';
 import { headerBackgroundLs } from '@weco/common/utils/backgrounds';
-import { GaDimensions } from '@weco/common/services/app/google-analytics';
+import { GaDimensions } from '@weco/common/services/app/analytics-scripts';
 import { appError, AppErrorProps } from '@weco/common/services/app';
 import { serialiseProps } from '@weco/common/utils/json';
 import { getServerData } from '@weco/common/server-data';
@@ -125,7 +125,7 @@ export const getServerSideProps: GetServerSideProps<
 
   // We know that `articles` is non-empty, and because we queried for articles in
   // this series, we know these articles have a series defined.
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+
   const series = articles.results[0].series.find(
     series => series.id === seriesId
   )!;


### PR DESCRIPTION
## Who is this for?
#10953 

## What is it doing for them?
- These two specific scripts (Core web vitals and Performance timing tracking) do not need consent to be fired as they don't set any cookies, so they should always be available moving forward (see [Slack convo](https://wellcome.slack.com/archives/CUA669WHH/p1718881372267019))
- Move these two Custom HTML tags from GTM to the codebase, which is where we'll try to have them moving forward ([as per Slack convo](https://wellcome.slack.com/archives/CUA669WHH/p1718358056055009))
- Took the opportunity to centralise our scripts as much as possible.
  - In doing so, I moved the logic needed for the Segment script inside its new script file and out of `_document`. 

More work is needed for Segment but it'll be part of a different ticket: [#10964](https://github.com/wellcomecollection/wellcomecollection.org/issues/10964).