### PR TITLE
Change schedule and upgrade checkout

### DIFF
--- a/.github/workflows/prismic-linting.yml
+++ b/.github/workflows/prismic-linting.yml
@@ -2,7 +2,7 @@ name: Prismic Linting
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 8 * * *'
+    - cron: '0 4 * * MON-FRI'
 
 permissions:
   id-token: write
@@ -11,7 +11,7 @@ jobs:
   prismic_linting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: eu-west-1


### PR DESCRIPTION
#10843 

## What does this change?
- Have it run earlier in the morning so it's ready before we start our day (it's 8 UTC and so runs at 9, let's have it be early and ready to go in case it's the first thing we look at)
- Only run on week days
- Upgrade checkout to v4 as per Dependabot recommendation (so closes #10975)

## How to test / How can we measure success?

I think mostly just testable once deployed and having seen that [the action runs every morning](https://github.com/wellcomecollection/wellcomecollection.org/actions/workflows/prismic-linting.yml).

## Have we considered potential risks?

Biggest risk is it won't run properly, which isn't that big of an issue and we can address it then.
