### PR TITLE
Don't show available online label if access condition is restricted

### DIFF
--- a/content/webapp/components/Work/Work.tsx
+++ b/content/webapp/components/Work/Work.tsx
@@ -232,7 +232,9 @@ const Work: FunctionComponent<Props> = ({ work, apiUrl }) => {
               <Grid>
                 <WorkHeader
                   work={toWorkBasic(work)}
-                  collectionManifestsCount={collectionManifestsCount}
+                  collectionManifestsCount={
+                    shouldShowItemLink ? collectionManifestsCount : undefined
+                  }
                 />
               </Grid>
             </Container>
@@ -256,7 +258,9 @@ const Work: FunctionComponent<Props> = ({ work, apiUrl }) => {
               <Grid>
                 <WorkHeader
                   work={toWorkBasic(work)}
-                  collectionManifestsCount={collectionManifestsCount}
+                  collectionManifestsCount={
+                    shouldShowItemLink ? collectionManifestsCount : undefined
+                  }
                 />
               </Grid>
             </Container>


### PR DESCRIPTION
## What does this change?

We have works with restricted access conditions that are reporting that they have volumes available online, which is confusing ([from Slack](https://wellcome.slack.com/archives/C8X9YKM5X/p1719829738540849)).

This PR checks the work's access condition isn't `restricted` or `closed` using logic from the pre-existing `showItemLink` function and hides the label where necessary.

E.g. this url: https://wellcomecollection.org/works/z3mb56ec

__Before__
<img width="358" alt="image" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/1394592/a3dc2462-a1d0-464b-8736-b14c812cf793">

__After__
<img width="359" alt="image" src="https://github.com/wellcomecollection/wellcomecollection.org/assets/1394592/5d0e5d3a-ed77-47ef-9a4e-d94e79ff82fa">
