### PR TITLE
Move RSS app into content app

### DIFF
--- a/content/webapp/app.ts
+++ b/content/webapp/app.ts
@@ -13,6 +13,9 @@ import {
 import linkResolver from '@weco/common/services/prismic/link-resolver';
 import { createClient as createPrismicClient } from '@weco/common/services/prismic/fetch';
 import * as prismic from '@prismicio/client';
+import RSS from 'rss';
+
+import { asText } from './services/prismic/transformers';
 
 const dev = process.env.NODE_ENV !== 'production';
 const nextApp = next({ dev });
@@ -46,11 +49,115 @@ const appPromise = nextApp
     koaApp.use(apmErrorMiddleware);
     koaApp.use(withCachedValues);
 
+    const storyGraphQuery = `{
+      articles {
+        ...articlesFields
+        format {
+          ...formatFields
+        }
+        contributors {
+          ...contributorsFields
+          role {
+            ...roleFields
+          }
+          contributor {
+            ... on people {
+              ...peopleFields
+            }
+            ... on organisations {
+              ...organisationsFields
+            }
+          }
+        }
+      }
+    
+      webcomics {
+        ...webcomicsFields
+        series {
+          series {
+            ...seriesFields
+          }
+        }
+        contributors {
+          ...contributorsFields
+          role {
+            ...roleFields
+          }
+          contributor {
+            ... on people {
+              ...peopleFields
+            }
+          }
+        }
+      }
+    }`;
+
     // Add a naive healthcheck endpoint for the load balancer
     router.get('/management/healthcheck', async ctx => {
       ctx.body = {
         status: 'ok',
       };
+    });
+
+    // Add a naive healthcheck endpoint for the load balancer
+    router.get('/rss', async ctx => {
+      const client = createPrismicClient();
+
+      const stories = await client.get({
+        graphQuery: storyGraphQuery,
+        orderings: [
+          { field: 'my.articles.publishDate' },
+          { field: 'my.webcomics.publishDate' },
+          { field: 'document.first_publication_date', direction: 'desc' },
+        ],
+        filters: [
+          prismic.filter.any('document.type', ['articles', 'webcomics']),
+        ],
+        pageSize: 100,
+      });
+
+      const rssFeed = new RSS({
+        title: 'Wellcome Collection stories',
+        description:
+          'Our words and pictures explore the connections between science, medicine, life and art. Dive into a story no matter where in the world you are.',
+        feed_url: 'https://rss.wellcomecollection.org/stories',
+        site_url: 'https://wellcomecollection.org/stories',
+        image_url:
+          'https://i.wellcomecollection.org/assets/icons/android-chrome-512x512.png',
+        language: 'en',
+        categories: ['Science', 'Medicine', 'Art'],
+        pubDate: stories.results[0].first_publication_date,
+      });
+
+      stories.results.forEach(story => {
+        const { data } = story;
+        const description =
+          data.promo && data.promo.length > 0
+            ? data.promo
+                .filter(slice => slice.primary.image)
+                .map(({ primary: { caption } }) => {
+                  return asText(caption);
+                })
+                .find(Boolean)
+            : '';
+
+        const contributors = data.contributors
+          .filter(({ contributor }) => contributor.isBroken === false)
+          .map(({ contributor }) => {
+            return contributor.data.name;
+          });
+
+        rssFeed.item({
+          title: asText(data.title),
+          description,
+          url: `https://wellcomecollection.org/articles/${story.id}`,
+          author: contributors.join(', '),
+          date: story.first_publication_date,
+        });
+      });
+
+      ctx.type = 'application/xml';
+      ctx.body = rssFeed.xml();
     });
 
     router.get('/preview', async ctx => {

--- a/content/webapp/package.json
+++ b/content/webapp/package.json
@@ -29,6 +29,7 @@
     "react-photo-album": "^2.0.0",
     "react-window": "^1.8.8",
     "reading-time": "^1.5.0",
+    "rss": "^1.2.2",
     "search-query-parser": "^1.3.0",
     "styled-components": "^6.1.0",
     "ts-node": "^10.9.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16043,6 +16043,18 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.51.0.tgz#d9ff62451859b18342d960850dc3cfb77e63fb0c"
   integrity sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==
 
+mime-db@~1.25.0:
+  version "1.25.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.25.0.tgz#c18dbd7c73a5dbf6f44a024dc0d165a1e7b1c392"
+  integrity sha512-5k547tI4Cy+Lddr/hdjNbBEWBwSl8EBc5aSdKvedav8DReADgWJzcYiktaRIw3GtGC1jjwldXtTzvqJZmtvC7w==
+
+mime-types@2.1.13:
+  version "2.1.13"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.13.tgz#e07aaa9c6c6b9a7ca3012c69003ad25a39e92a88"
+  integrity sha512-ryBDp1Z/6X90UvjUK3RksH0IBPM137T7cmg4OgD5wQBojlAiUwuok0QeELkim/72EtcYuNlmbkrcGuxj3Kl0YQ==
+  dependencies:
+    mime-db "~1.25.0"
+
 mime-types@^2.1.12, mime-types@^2.1.18, mime-types@^2.1.27, mime-types@^2.1.30, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
@@ -18828,6 +18840,14 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
+rss@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/rss/-/rss-1.2.2.tgz#50a1698876138133a74f9a05d2bdc8db8d27a921"
+  integrity sha512-xUhRTgslHeCBeHAqaWSbOYTydN2f0tAzNXvzh3stjz7QDhQMzdgHf3pfgNIngeytQflrFPfy6axHilTETr6gDg==
+  dependencies:
+    mime-types "2.1.13"
+    xml "1.0.1"
+
 rsvp@^4.8.4:
   version "4.8.5"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
@@ -21580,6 +21600,11 @@ xml-name-validator@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-4.0.0.tgz#79a006e2e63149a8600f15430f0a4725d1524835"
   integrity sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==
+
+xml@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
+  integrity sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==
 
 xmlchars@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
## What does this change?

This change moves the RSS app previously served by Vercel into the content app.

**TODO**

This will be served through a new cloudfront distro for rss.wellcomecollection.org, routing to /rss on the content app.

## How to test

- [ ] Run the content app locally and visit http://localhost:3000/rss, is the content the same as https://rss.wellcomecollection.org/stories?

## How can we measure success?

We can remove the RSS app running in Vercel with no interruption of service.

## Have we considered potential risks?

TBD
