### PR TITLE
Suggestion to hide cookie banner within iframes

### DIFF
--- a/common/services/conversion/track.ts
+++ b/common/services/conversion/track.ts
@@ -17,7 +17,6 @@ declare global {
 
     CookieControl: {
       open: () => void;
-      hide: () => void;
     };
   }
 }

--- a/common/services/conversion/track.ts
+++ b/common/services/conversion/track.ts
@@ -17,6 +17,7 @@ declare global {
 
     CookieControl: {
       open: () => void;
+      hide: () => void;
     };
   }
 }

--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -1,6 +1,6 @@
 import { NextPage } from 'next';
 import { AppProps } from 'next/app';
-import { useEffect, FunctionComponent, ReactElement, useState } from 'react';
+import { useEffect, FunctionComponent, ReactElement } from 'react';
 import { ThemeProvider } from 'styled-components';
 import theme, { GlobalStyle } from '@weco/common/views/themes/default';
 import LoadingIndicator from '@weco/common/views/components/LoadingIndicator/LoadingIndicator';
@@ -71,9 +71,6 @@ const WecoApp: FunctionComponent<WecoAppProps> = ({
   // e.g. for error pages
   const isServerDataSet = isServerData(pageProps.serverData);
 
-  // Expected origin for cookie banner to display
-  const [isExpectedOrigin, setIsExpectedOrigin] = useState(true);
-
   // We allow error pages through as they don't need, and can't set
   // serverData as they don't have data fetching methods.exi
   if (
@@ -114,8 +111,6 @@ const WecoApp: FunctionComponent<WecoAppProps> = ({
   useEffect(() => {
     document.documentElement.classList.add('enhanced');
 
-    setIsExpectedOrigin(window.location === window.parent.location);
-
     window.addEventListener(
       'analyticsConsentChanged',
       onAnalyticsConsentChanged
@@ -128,13 +123,6 @@ const WecoApp: FunctionComponent<WecoAppProps> = ({
       );
     };
   }, []);
-
-  useEffect(() => {
-    if (!isExpectedOrigin) {
-      // This needs triggering as it displays it by default
-      window.CookieControl.hide();
-    }
-  }, [isExpectedOrigin]);
 
   useEffect(() => {
     if (pageProps.pageview) {
@@ -161,8 +149,8 @@ const WecoApp: FunctionComponent<WecoAppProps> = ({
     // Banner should not load on cookie policy page to allow user to interact with the page content.
     if (pageProps['page']?.id === prismicPageIds.cookiePolicy) return true; // eslint-disable-line dot-notation
 
-    // Banner should not load when document is an iframe, which can happen with Slice simulator/page builder
-    if (!isExpectedOrigin) return true;
+    // Banner shouldn't appear in Prismic's Slice Simulator (or Page Builder)
+    if (router.route === '/slice-simulator') return true;
 
     return false;
   };


### PR DESCRIPTION
## What does this change?
Does an extra check on whether or not to display the cookie banner. As per #10962 , the banner has been displaying in the page builder previews and the slice simulator, as it's actually an iframe of the website. 

I went for [what was suggested here](https://www.geeksforgeeks.org/how-to-check-a-webpage-is-loaded-inside-an-iframe-or-into-the-browser-window-using-javascript/) to figure out whether or not the document is rendered within an iframe. Had to do it through `useEffect` to access `window`, so there's a slight delay in hiding it in `iframe` as we wanted it to display by default.

## How to test

Run locally, both the website (it should display the banner) and the slice simulator (it shouldn't)

## How can we measure success?

We don't see the banner in the page builder previews and they're made useful again!

## Have we considered potential risks?

Banner stops displaying when we need it too, which is bad, so thorough testing both locally and staging should take place.

