### PR TITLE
Remove unnecessary keys that caused console error

### DIFF
--- a/content/webapp/components/WorkDetails/WorkDetails.Holdings.tsx
+++ b/content/webapp/components/WorkDetails/WorkDetails.Holdings.tsx
@@ -22,6 +22,7 @@ const WorkDetailsHoldings = ({ holdings }: { holdings: Holding[] }) => {
               holding.location && getLocationShelfmark(holding.location);
             const locationLink =
               holding.location && getLocationLink(holding.location);
+
             return (
               <Space
                 key={i}
@@ -32,20 +33,14 @@ const WorkDetailsHoldings = ({ holdings }: { holdings: Holding[] }) => {
                 }
               >
                 {holding.enumeration.length > 0 && (
-                  <Space
-                    key={i}
-                    $v={{ size: 's', properties: ['margin-bottom'] }}
-                  >
+                  <Space $v={{ size: 's', properties: ['margin-bottom'] }}>
                     <ExpandableList
                       listItems={holding.enumeration}
                       initialItems={10}
                     />
                   </Space>
                 )}
-                <Space
-                  key={i}
-                  $v={{ size: 's', properties: ['margin-bottom'] }}
-                >
+                <Space $v={{ size: 's', properties: ['margin-bottom'] }}>
                   {locationLink && (
                     <a className={font('intr', 5)} href={locationLink.url}>
                       {locationLink.linkText}


### PR DESCRIPTION
## What does this change?
Removes duplicate keys that caused a console warning. Keys aren't necessary here (they're not part of a list) and made for duplicate elements when hot reloading.

## How to test

Run locally; no error in console when on a work page that has a holding (like https://wellcomecollection.org/works/ysmqsfhg)

## How can we measure success?

It works!

## Have we considered potential risks?

No risk here that I can think of.

