### PR TITLE
set itemsState to ‘stale’ when work items change

### DIFF
--- a/content/webapp/components/PhysicalItems/PhysicalItems.tsx
+++ b/content/webapp/components/PhysicalItems/PhysicalItems.tsx
@@ -83,6 +83,8 @@ const PhysicalItems: FunctionComponent<Props> = ({
     offsiteRequesting
   );
 
+  // This ensures we update an items availability
+  // if the user navigates between items using the archive tree
   useEffect(() => {
     setItemsState('stale');
   }, [workItems]);

--- a/content/webapp/components/PhysicalItems/PhysicalItems.tsx
+++ b/content/webapp/components/PhysicalItems/PhysicalItems.tsx
@@ -23,6 +23,15 @@ type Props = {
   items: PhysicalItem[];
 };
 
+/**
+ * We need to know two things for an item: if it is requestable and if it is available (e.g. someone could have them on hold). The ItemsState type refers to their availability status.
+ *
+ * Non-requestable items are never available. Therefore, their availability status is considered to be "up-to-date"; it'll never change.
+ *
+ * Requestable items may or may not be available, so we have to confirm their availability status every time. Therefore, their availability status is considered "stale"; meaning it needs to be renewed/refetched.
+ * @stale Requestable items
+ * @up-to-date Non-requestable items
+ */
 type ItemsState = 'stale' | 'up-to-date';
 
 const getItemsState = (

--- a/content/webapp/components/PhysicalItems/PhysicalItems.tsx
+++ b/content/webapp/components/PhysicalItems/PhysicalItems.tsx
@@ -83,6 +83,10 @@ const PhysicalItems: FunctionComponent<Props> = ({
     offsiteRequesting
   );
 
+  useEffect(() => {
+    setItemsState('stale');
+  }, [workItems]);
+
   useAbortSignalEffect(
     signal => {
       const fetchUserHolds = async () => {

--- a/content/webapp/components/PhysicalItems/PhysicalItems.tsx
+++ b/content/webapp/components/PhysicalItems/PhysicalItems.tsx
@@ -86,7 +86,7 @@ const PhysicalItems: FunctionComponent<Props> = ({
   // This ensures we update an items availability
   // if the user navigates between items using the archive tree
   useEffect(() => {
-    setItemsState('stale');
+    setItemsState(getItemsState(workItems, offsiteRequesting || false));
   }, [workItems]);
 
   useAbortSignalEffect(


### PR DESCRIPTION
## What does this change?
This fixes a bug [discussed on slack](https://wellcome.slack.com/archives/C8X9YKM5X/p1719928655349099), where the items availability doesn't update when the tree navigation is used to move between items

## How to test
- Run the site locally using `yarn run-concurrently`
- Log in
- Visit http://localhost:3000/works/pxr3mfzx
- notice that under where to find it the item is listed as 'Temporarily unavailable' (N.B. this is true 4/7/2024)
- click on the next item in the archive tree '[Diary 1941]'
- notice the where to find it now has a request button
- click the request button and see available dates are present


