### PR TITLE
Add CloudFront distro to front requests to rss.wellcomecollection.org

### DIFF
--- a/cache/cloudfront_functions/rss-url-rewrite.js
+++ b/cache/cloudfront_functions/rss-url-rewrite.js
@@ -1,0 +1,14 @@
+// eslint-disable-next-line no-unused-vars
+function handler(event) {
+  const request = event.request;
+  const uri = request.uri;
+
+  if (uri === '/stories') {
+    request.uri = '/rss';
+    return request;
+  } else {
+    return {
+      statusCode: 404,
+    };
+  }
+}

--- a/cache/cloudfront_rss.tf
+++ b/cache/cloudfront_rss.tf
@@ -5,7 +5,7 @@
 // 
 // This service has been migrated to CloudFront to allow for stats to be
 // gathered on usage. There is no staging environment for this service.
-resource "aws_cloudfront_distribution" "wc_org" {
+resource "aws_cloudfront_distribution" "rss_wc_org" {
   enabled          = true
   retain_on_delete = false
   is_ipv6_enabled  = true
@@ -14,7 +14,7 @@ resource "aws_cloudfront_distribution" "wc_org" {
   ]
 
   origin {
-    domain_name = data.terraform_remote_state.experience.outputs.e2e["alb_dns_name"]
+    domain_name = data.terraform_remote_state.experience.outputs.prod["alb_dns_name"]
     origin_id   = "origin"
 
     custom_origin_config {
@@ -61,13 +61,13 @@ resource "aws_cloudfront_distribution" "wc_org" {
 
     function_association {
       event_type = "viewer-request"
-      function_arn = aws_cloudfront_function.rss_url_rewrite.arn
+      function_arn = aws_cloudfront_function.rss_stories_url_rewrite.arn
     }
   }
 }
 
-resource "aws_cloudfront_function" "rss_url_rewrite" {
-  name    = "rss-url-rewrite"
+resource "aws_cloudfront_function" "rss_stories_url_rewrite" {
+  name    = "rss-stories-url-rewrite"
   runtime = "cloudfront-js-2.0"
   comment = "Rewrites /stories to /rss for rss.wellcomecollection.org"
   publish = true

--- a/cache/cloudfront_rss.tf
+++ b/cache/cloudfront_rss.tf
@@ -1,0 +1,68 @@
+resource "aws_cloudfront_distribution" "wc_org" {
+  enabled          = true
+  retain_on_delete = false
+  is_ipv6_enabled  = true
+  aliases          = [
+    "rss.wellcomecollection.org",
+  ]
+
+  origin {
+    domain_name = data.terraform_remote_state.experience.outputs.e2e["alb_dns_name"]
+    origin_id   = "origin"
+
+    custom_origin_config {
+      origin_protocol_policy = "https-only"
+      http_port              = "80"
+      https_port             = "443"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+
+    custom_header {
+      name  = "x-weco-cloudfront-shared-secret"
+      value = local.current_shared_secret
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = local.wellcome_cdn_cert_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2018"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  logging_config {
+    include_cookies = false
+    bucket          = "wellcomecollection-experience-cloudfront-logs.s3.amazonaws.com"
+    prefix          = "rss.wellcomecollection.org/"
+  }
+
+  default_cache_behavior {
+    target_origin_id = "origin"
+
+    allowed_methods        = ["HEAD", "GET"]
+    cached_methods         = ["HEAD", "GET"]
+    viewer_protocol_policy = "redirect-to-https"
+
+    cache_policy_id            = module.cloudfront_policies.cache_policies["weco-apps"]
+    origin_request_policy_id   = module.cloudfront_policies.request_policies["host-query-and-toggles"]
+    response_headers_policy_id = module.cloudfront_policies.response_policies["weco-security"]
+
+    function_association {
+      event_type = "viewer-request"
+      function_arn = aws_cloudfront_function.rss_url_rewrite.arn
+    }
+  }
+}
+
+resource "aws_cloudfront_function" "rss_url_rewrite" {
+  name    = "rss-url-rewrite"
+  runtime = "cloudfront-js-2.0"
+  comment = "Rewrites /stories to /rss for rss.wellcomecollection.org"
+  publish = true
+  code    = file("${path.module}/cloudfront_functions/rss-url-rewrite.js")
+}

--- a/cache/cloudfront_rss.tf
+++ b/cache/cloudfront_rss.tf
@@ -1,3 +1,10 @@
+// This file provisions infrastructure for the RSS CloudFront distribution, 
+// it routes requests to the content service at /rss. 
+//
+// https://rss.wellcomecollection.org/stories -> https://wellcomecollection.org/rss
+// 
+// This service has been migrated to CloudFront to allow for stats to be
+// gathered on usage. There is no staging environment for this service.
 resource "aws_cloudfront_distribution" "wc_org" {
   enabled          = true
   retain_on_delete = false

--- a/content/webapp/app.ts
+++ b/content/webapp/app.ts
@@ -54,6 +54,8 @@ const appPromise = nextApp
       };
     });
 
+    // This content is served from rss.wellcomecollection.org/stories
+    // See cache/cloudfront_rss.tf for the CloudFront distribution.
     router.get('/rss', async ctx => {
       ctx.type = 'application/xml';
       ctx.body = await buildStoriesRss(ctx);


### PR DESCRIPTION
## What does this change?

This change adds a CloudFront distribution for `rss.wellcomecollection.org` so that we can continue to serve content from that URL. We are using a [CloudFront Function](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cloudfront-functions.html) to rewrite URLs.

Requests come to https://rss.wellcomecollection.org/stories, the CloudFront distribution described in this PR will direct them to a behaviour which points them at the content app ALB origin, but rewrites requests for /stories to /rss and returns 404s for all other requests to `rss.wellcomecollection.org`.

Follows: https://github.com/wellcomecollection/wellcomecollection.org/pull/10982, which implements the RSS endpoint on the content app.

### `terraform plan`

```console
# aws_cloudfront_distribution.wc_org will be created
  + resource "aws_cloudfront_distribution" "wc_org" {
      + aliases                         = [
          + "rss.wellcomecollection.org",
        ]
      + arn                             = (known after apply)
      + caller_reference                = (known after apply)
      + continuous_deployment_policy_id = (known after apply)
      + domain_name                     = (known after apply)
      + enabled                         = true
      + etag                            = (known after apply)
      + hosted_zone_id                  = (known after apply)
      + http_version                    = "http2"
      + id                              = (known after apply)
      + in_progress_validation_batches  = (known after apply)
      + is_ipv6_enabled                 = true
      + last_modified_time              = (known after apply)
      + price_class                     = "PriceClass_All"
      + retain_on_delete                = false
      + staging                         = false
      + status                          = (known after apply)
      + tags_all                        = {
          + "Department"                = "Digital Platform"
          + "Division"                  = "Culture and Society"
          + "TerraformConfigurationURL" = "https://github.com/wellcomecollection/wellcomecollection.org/tree/main/cache"
          + "Use"                       = "Front-end CloudFront distributions"
        }
      + trusted_key_groups              = (known after apply)
      + trusted_signers                 = (known after apply)
      + wait_for_deployment             = true

      + default_cache_behavior {
          + allowed_methods            = [
              + "GET",
              + "HEAD",
            ]
          + cache_policy_id            = "b2c915f6-c889-4d69-84c1-0986bcf82901"
          + cached_methods             = [
              + "GET",
              + "HEAD",
            ]
          + compress                   = false
          + default_ttl                = (known after apply)
          + max_ttl                    = (known after apply)
          + min_ttl                    = 0
          + origin_request_policy_id   = "7d466a9a-b53c-43ab-babb-6f3e66ca5caf"
          + response_headers_policy_id = "6a3b328f-7d56-48ed-872d-6616b7dc7a71"
          + target_origin_id           = "origin"
          + trusted_key_groups         = (known after apply)
          + trusted_signers            = (known after apply)
          + viewer_protocol_policy     = "redirect-to-https"

          + function_association {
              + event_type   = "viewer-request"
              + function_arn = (known after apply)
            }
        }

      + logging_config {
          + bucket          = "wellcomecollection-experience-cloudfront-logs.s3.amazonaws.com"
          + include_cookies = false
          + prefix          = "rss.wellcomecollection.org/"
        }

      + origin {
          # At least one attribute in this block is (or was) sensitive,
          # so its contents will not be displayed.
        }

      + restrictions {
          + geo_restriction {
              + locations        = (known after apply)
              + restriction_type = "none"
            }
        }

      + viewer_certificate {
          + acm_certificate_arn      = "arn:aws:acm:us-east-1:130871440101:certificate/bb840c52-56bb-4bf8-86f8-59e7deaf9c98"
          + minimum_protocol_version = "TLSv1.2_2018"
          + ssl_support_method       = "sni-only"
        }
    }

  # aws_cloudfront_function.rss_url_rewrite will be created
  + resource "aws_cloudfront_function" "rss_url_rewrite" {
      + arn             = (known after apply)
      + code            = <<-EOT
            // eslint-disable-next-line no-unused-vars
            function handler(event) {
              const request = event.request;
              const uri = request.uri;

              if (uri === '/stories') {
                request.uri = '/visit-us';
                return request;
              } else {
                return {
                  statusCode: 404,
                };
              }
            }
        EOT
      + comment         = "Rewrites /stories to /rss for rss.wellcomecollection.org"
      + etag            = (known after apply)
      + id              = (known after apply)
      + live_stage_etag = (known after apply)
      + name            = "rss-url-rewrite"
      + publish         = true
      + runtime         = "cloudfront-js-2.0"
      + status          = (known after apply)
    }

Plan: 2 to add, 0 to change, 0 to destroy.
```

## How to test

Terraform this change, and manually configure to test with `rss-stage.wellcomecollection.org`. If this succeeds we can update the CNAME record for `rss.wellcomecollection.org`.

## How can we measure success?

No more infrastructure on Vercel.

## Have we considered potential risks?

We could break the existing RSS implementation during deployment, but this is not a high priority feature.
