### PR TITLE
add items as dependency for setItemsState

### DIFF
--- a/content/webapp/components/PhysicalItems/PhysicalItems.tsx
+++ b/content/webapp/components/PhysicalItems/PhysicalItems.tsx
@@ -74,7 +74,7 @@ const useItemsState = (
 
   useEffect(() => {
     setItemsState(getItemsState(items, offsiteRequesting));
-  }, []);
+  }, [items]);
 
   return [itemsState, setItemsState];
 };
@@ -92,10 +92,8 @@ const PhysicalItems: FunctionComponent<Props> = ({
     offsiteRequesting
   );
 
-  // This ensures we update an items availability
-  // if the user navigates between items using the archive tree
   useEffect(() => {
-    setItemsState(getItemsState(workItems, offsiteRequesting || false));
+    setPhysicalItems(workItems);
   }, [workItems]);
 
   useAbortSignalEffect(


### PR DESCRIPTION
## What does this change?

Following [this](https://github.com/wellcomecollection/wellcomecollection.org/pull/10987) fix, there was still a case where the items' status and method didn't refresh correctly when navigating an archive tree
This adds 'items' in the dependency array so that the itemsState is change whenever the items change (as happens when  navigating an archive tree)

## How to test

Running this branch locally: 

https://wellcomecollection.org/works/pxr3mfzx is on hold
Navigate to Diary 1943: it should be requestable online
Back to Diary 1940: it should be on hold

https://wellcomecollection.org/works/vksj5snf
1st item on the next level (PP/AMI/D/1) is not requestable 
Navigate to PP/AMI/D/10: is requestable
Back to PP/AMI/D/1: not requestable

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? -->

