### PR TITLE
Use common tsconfig in dash project

### DIFF
--- a/dash/Dockerfile
+++ b/dash/Dockerfile
@@ -4,7 +4,8 @@ WORKDIR /usr/src/app/webapp
 
 RUN apt-get update && apt-get install -y awscli 
 
-ADD ./webapp /usr/src/app/webapp
+COPY dash/webapp /usr/src/app/webapp
+COPY config /usr/src/config
 
 # `less` isn't installed on the image and so we're disabling it as per
 # https://docs.aws.amazon.com/cli/latest/userguide/cli-usage-pagination.html#cli-usage-pagination-clientside 

--- a/dash/webapp/tsconfig.json
+++ b/dash/webapp/tsconfig.json
@@ -1,25 +1,11 @@
 {
-  "compilerOptions": {    
-    "allowJs": false,
-    "composite": false, // Not part of the workspace
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "incremental": true,
-    "isolatedModules": true,
-    "jsx": "preserve",
+  "extends": "../../config/tsconfig-base",
+  "compilerOptions": {
+    "composite": false,
     "lib": ["dom", "dom.iterable", "esnext"],  // Dom ones needed in this subrepo for Docker build
     "module": "esnext",
-    "moduleResolution": "node", // Forced by NextJs on build
-    "noEmit": true,
-    "noFallthroughCasesInSwitch": true,
-    "resolveJsonModule": true,
-    "skipLibCheck": true,
-    "strict": false,
-    "strictNullChecks": true,
-    "target": "es6",
+    "moduleResolution": "node" // Forced by NextJs on build
   },
-  "exclude": ["/**/node_modules"],
-  "include": ["/**/*.ts", "/**/*.tsx"],
   "ts-node": {
     "preferTsExts": true
   }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,8 @@ services:
         - NEXT_PUBLIC_CIVICUK_API_KEY
   dash:
     build:
-      context: ./dash
+      context: .
+      dockerfile: dash/Dockerfile
   edge_lambdas:
     build:
       context: .


### PR DESCRIPTION
## What does this change?

This change updates the dash project to use a shared tsconfig in order to have consistent less surprising configuration between our projects and to avoid drift.

## How to test

- Run `docker-compose build dash` from the root of this project, does it build successfully?

## How can we measure success?

Developers spend less time understanding the structure and rules of projects in this repository.

## Have we considered potential risks?

This change should not impact anything in public view.
