### PR TITLE
Remove test string from url

### DIFF
--- a/content/webapp/components/IIIFViewer/IIIFViewerImage.tsx
+++ b/content/webapp/components/IIIFViewer/IIIFViewerImage.tsx
@@ -5,7 +5,7 @@ import { convertRequestUriToInfoUri } from '@weco/content/utils/convert-iiif-uri
 async function getImageMax(url: string): Promise<number> {
   try {
     const infoUrl = convertRequestUriToInfoUri(url);
-    const resp = await fetch(infoUrl + 'll');
+    const resp = await fetch(infoUrl);
     const info = await resp.json();
     // N.B property is called maxWidth, but it is actually the max allowed for the longest side, see https://wellcome.slack.com/archives/CBT40CMKQ/p1702897884100559
     const max = info.profile?.find(item => item.maxWidth)?.maxWidth || 1000;


### PR DESCRIPTION
## What does this change?

Removes string used for tests as per [confirmation here](https://wellcome.slack.com/archives/CBT40CMKQ/p1720583824239179?thread_ts=1720452922.330679&cid=CBT40CMKQ) (related to #10999)

## How to test

Run locally and use item viewer, for example on `works/nny5wq9u/items`

## How can we measure success?

Do they show up, is the console error free?

## Have we considered potential risks?

We are sure this was not meant to be there, so risk free. 