### PR TITLE
Re-add Typescript as a devDependency for upddown

### DIFF
--- a/updown/package.json
+++ b/updown/package.json
@@ -8,7 +8,8 @@
   "devDependencies": {
     "@tsconfig/node20": "^20.1.4",
     "@types/node": "^20.10.4",
-    "ts-node": "^10.9.1"
+    "ts-node": "^10.9.1",
+    "typescript": "^5.5.3"
   },
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "^3.468.0",


### PR DESCRIPTION
## What does this change?

Putting back a dependency that I erroneously believed to have been shared at the root

