### PR TITLE
optional chaining in case query is not defined/null

### DIFF
--- a/cache/send_slack_alert_for_5xx_errors.js
+++ b/cache/send_slack_alert_for_5xx_errors.js
@@ -357,7 +357,8 @@ function isInterestingError(hit) {
   // avoid dropping errors from legitimate queries.
   if (
     hit.status === 503 &&
-    (hit.query.split('%C3').length > 80 || hit.query.split('%25C2').length > 80)
+    (hit.query?.split('%C3').length > 80 ||
+      hit.query?.split('%25C2').length > 80)
   ) {
     return false;
   }


### PR DESCRIPTION
## What does this change?

We've seen [errors](https://wellcome.slack.com/archives/CQ720BG02/p1720597318517099) with this code, which should be fixed by this addition of optional chaining in case `query` is `null`

## How can we measure success?

`send_slack_alert_for_5xx_errors` stop erroring 

## Have we considered potential risks?

Yes

terraform plan output
```
Terraform will perform the following actions:

  # module.slack_alerts_for_5xx.aws_lambda_function.lambda_function will be updated in-place
  ~ resource "aws_lambda_function" "lambda_function" {
        id                             = "send_slack_alert_for_5xx_errors"
      ~ last_modified                  = "2023-11-07T16:48:07.000+0000" -> (known after apply)
      ~ source_code_hash               = "Kk8nGDlMCyoPjl/O+gF+5ZWlC+daOijuIUoooE+egs8=" -> "K2lUcAtnTSHqH5gLPlSjrzaOfESI34TxSxxzZNm+yC0="
        tags                           = {}
        # (26 unchanged attributes hidden)

        # (5 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

