### PR TITLE
update prismic link to work with new page builder

### DIFF
--- a/common/views/components/ApiToolbar/index.tsx
+++ b/common/views/components/ApiToolbar/index.tsx
@@ -78,7 +78,7 @@ export function createPrismicLink(prismicId: string): ApiToolbarLink {
   return {
     id: 'prismic',
     label: 'Edit in Prismic',
-    link: `https://wellcomecollection.prismic.io/documents~b=working&c=published&l=en-gb/${prismicId}/`,
+    link: `https://wellcomecollection.prismic.io/builder/pages/${prismicId}?s=published`,
   };
 }
 


### PR DESCRIPTION
## What does this change?

This updates the prismic link in the toolbar to work with Prismic's new page builder url structure.

[The link was reported as no longer working](https://wellcome.slack.com/archives/C8X9YKM5X/p1720604172333369)

## How to test

- Have the toolbar toggle turned on
- Visit a Prismic page, e.g. localhost:3000//articles/Zlcu4REAACIArnOu
- click the 'Edit in Prismic' link in the toolbar
- you should be taken to the correct page in Prismic

## How can we measure success?

Content editors are able to use the 'Edit in Prismic' link to reach the relevant page in Prismic

## Have we considered potential risks?

It's currently broken, so none

