### PR TITLE
Upgrade github action's node-versions

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -22,6 +22,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      # https://github.com/actions/setup-node?tab=readme-ov-file#usage
+      # The node-version input is optional. If not supplied, the node version from PATH will be used.
+      # However, it is recommended to always specify Node.js version and don't rely on the system one.
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
-      # TODO: Remove this line when we can safely upgrade all our packages
-      # to versions that support Node 16.
-      # See https://github.com/wellcomecollection/wellcomecollection.org/pull/9324
+      # https://github.com/actions/setup-node?tab=readme-ov-file#usage
+      # The node-version input is optional. If not supplied, the node version from PATH will be used.
+      # However, it is recommended to always specify Node.js version and don't rely on the system one.
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -26,7 +26,7 @@ jobs:
       # See https://github.com/wellcomecollection/wellcomecollection.org/pull/9324
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
       - uses: preactjs/compressed-size-action@v2
         with:
           build-script: "build-webapps"

--- a/.github/workflows/tsc.yml
+++ b/.github/workflows/tsc.yml
@@ -8,7 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: install node v16
+    - name: install Node
+      # https://github.com/actions/setup-node?tab=readme-ov-file#usage
+      # The node-version input is optional. If not supplied, the node version from PATH will be used.
+      # However, it is recommended to always specify Node.js version and don't rely on the system one.
       uses: actions/setup-node@v4
       with:
         node-version: 20

--- a/.github/workflows/tsc.yml
+++ b/.github/workflows/tsc.yml
@@ -11,7 +11,7 @@ jobs:
     - name: install node v16
       uses: actions/setup-node@v4
       with:
-        node-version: 16
+        node-version: 20
     - name: yarn install
       run: yarn install
     - name: yarn tsc


### PR DESCRIPTION
Relates to #10846 

## What does this change?

Addresses older TODO; we chose to always specify the `node-version` as per documentation's recommendation.
Upgraded it to use node 20 as per our recent upgrades. 
[It's been flagged as a step in future Node upgrades](https://app.gitbook.com/o/-LumfFcEMKx4gYXKAZTQ/s/DPDDj27NI2F2kPukWrC1/language-tool-specific-notes/nodejs-updates) as well.

## How to test

Did the actions run ok in here? (Yes)

## How can we measure success?

The actions ran ok in here.

## Have we considered potential risks?

N/A
