### PR TITLE
Remove `mkdirp-promise` package and replace its use

### DIFF
--- a/pa11y/webapp/package.json
+++ b/pa11y/webapp/package.json
@@ -7,7 +7,6 @@
   },
   "dependencies": {
     "aws-sdk": "^2.1655.0",
-    "mkdirp-promise": "^5.0.1",
     "pa11y": "8.0.0",
     "puppeteer": "22.12.1"
   }

--- a/pa11y/webapp/write-report.js
+++ b/pa11y/webapp/write-report.js
@@ -1,5 +1,4 @@
 const fs = require('fs');
-const mkdirp = require('mkdirp-promise');
 const pa11y = require('pa11y');
 const { promisify } = require('util');
 const writeFile = promisify(fs.writeFile);
@@ -63,7 +62,7 @@ const promises = urls.map(url =>
 
 Promise.all(promises)
   .then(async results => {
-    await mkdirp('./.dist');
+    await fs.promises.mkdir('./.dist', { recursive: true });
     await writeFile('./.dist/report.json', JSON.stringify({ results }));
     console.info('Reporting done!');
   })

--- a/pa11y/webapp/yarn.lock
+++ b/pa11y/webapp/yarn.lock
@@ -788,29 +788,10 @@ lru-cache@^7.14.1:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.18.3.tgz#f793896e0fd0e954a59dfdd82f0773808df6aa89"
   integrity sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==
 
-minimist@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
-  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
-
 mitt@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/mitt/-/mitt-3.0.1.tgz#ea36cf0cc30403601ae074c8f77b7092cdab36d1"
   integrity sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==
-
-mkdirp-promise@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/mkdirp-promise/-/mkdirp-promise-5.0.1.tgz#e9b8f68e552c68a9c1713b84883f7a1dd039b8a1"
-  integrity sha1-6bj2jlUsaKnBcTuEiD96HdA5uKE=
-  dependencies:
-    mkdirp "*"
-
-mkdirp@*:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
-  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
-  dependencies:
-    minimist "0.0.8"
 
 ms@2.1.2:
   version "2.1.2"


### PR DESCRIPTION
## What does this change?

One of our critical flags ([here](https://github.com/wellcomecollection/wellcomecollection.org/security/dependabot/85)) has to do with one of this package's dependencies. Here's [the repo](https://github.com/ahmadnassri/mkdirp-promise?tab=readme-ov-file). They've made it pretty clear we shouldn't be using it (hasn't been touched in 7 years, is archived and unmaintained), but they did say how to replace it, which was a simple use of `fs.mkdir` instead :)

I followed [the docs](https://nodejs.org/api/fs.html#fs_fspromises_mkdir_path_options) here.

I ran `write-report` locally and it worked well.

## How to test

Run it locally too

## How can we measure success?

Pa11y still runs successfully

## Have we considered potential risks?

Pa11y fails, and we fix it.

