### PR TITLE
Add data-gtm-trigger for born digital items

### DIFF
--- a/content/webapp/components/WorkDetails/WorkDetails.DownloadItem.tsx
+++ b/content/webapp/components/WorkDetails/WorkDetails.DownloadItem.tsx
@@ -129,7 +129,9 @@ const DownloadItem: FunctionComponent<{
               )}
             </td>
             <td width="100">
-              <a href={displayItem.id}>Download</a>
+              <a data-gtm-trigger="download_table_link" href={displayItem.id}>
+                Download
+              </a>
             </td>
           </tr>
         </tbody>


### PR DESCRIPTION
For #11012 

## What does this change?

Adding a `data-gtm-trigger` attribute to links in the `DownloadTable` component that houses the born digital items that are available to download.

There will be an accompanying piece of work to complete within GTM to use thes data-attributes as triggers (in keeping with how we've done long-lived GTM tracking before) to fire tags.

## How to test

I don't think it's possible to test locally because the triggers are behind a toggle which doesn't work in conjunction with GTM preview. 

## How can we measure success?

Events are being sent through to GA4

## Have we considered potential risks?

can't think of any