### PR TITLE
Add uid fields to custom types

### DIFF
--- a/common/customtypes/articles/index.json
+++ b/common/customtypes/articles/index.json
@@ -22,6 +22,13 @@
           "customtypes": ["article-formats"]
         }
       },
+      "uid": {
+        "type": "UID",
+        "config": {
+          "label": "uid",
+          "placeholder": ""
+        }
+      },
       "body": {
         "type": "Slices",
         "fieldset": "Slice Zone",

--- a/common/customtypes/books/index.json
+++ b/common/customtypes/books/index.json
@@ -81,6 +81,13 @@
           "label": "Date published"
         }
       },
+      "uid": {
+        "type": "UID",
+        "config": {
+          "label": "uid",
+          "placeholder": ""
+        }
+      },
       "body": {
         "type": "Slices",
         "fieldset": "Slice Zone",

--- a/common/customtypes/event-series/index.json
+++ b/common/customtypes/event-series/index.json
@@ -3,6 +3,7 @@
   "label": "Event series",
   "repeatable": true,
   "status": true,
+  "format": "custom",
   "json": {
     "Event series": {
       "title": {
@@ -19,6 +20,13 @@
           "label": "Background texture",
           "select": "document",
           "customtypes": ["background-textures"]
+        }
+      },
+      "uid": {
+        "type": "UID",
+        "config": {
+          "label": "uid",
+          "placeholder": ""
         }
       },
       "body": {
@@ -130,8 +138,8 @@
     "Promo": {
       "promo": {
         "type": "Slices",
+        "fieldset": "Slice Zone",
         "config": {
-          "label": "Promo",
           "choices": {
             "editorialImage": {
               "type": "Slice",
@@ -191,6 +199,5 @@
         }
       }
     }
-  },
-  "format": "custom"
+  }
 }

--- a/common/customtypes/events/index.json
+++ b/common/customtypes/events/index.json
@@ -3,6 +3,7 @@
   "label": "Event",
   "repeatable": true,
   "status": true,
+  "format": "custom",
   "json": {
     "Event": {
       "title": {
@@ -83,6 +84,13 @@
               }
             }
           }
+        }
+      },
+      "uid": {
+        "type": "UID",
+        "config": {
+          "label": "uid",
+          "placeholder": ""
         }
       },
       "body": {
@@ -419,8 +427,8 @@
     "Promo": {
       "promo": {
         "type": "Slices",
+        "fieldset": "Slice Zone",
         "config": {
-          "label": "Promo",
           "choices": {
             "editorialImage": {
               "type": "Slice",
@@ -538,6 +546,5 @@
         }
       }
     }
-  },
-  "format": "custom"
+  }
 }

--- a/common/customtypes/exhibition-guides/index.json
+++ b/common/customtypes/exhibition-guides/index.json
@@ -3,6 +3,7 @@
   "label": "Exhibition guide",
   "repeatable": true,
   "status": false,
+  "format": "custom",
   "json": {
     "Guide": {
       "title": {
@@ -27,6 +28,13 @@
           "multi": "paragraph,hyperlink,strong,em",
           "label": "Introductory text",
           "placeholder": "This will fallback to the related exhibition's promo text if not filled in"
+        }
+      },
+      "uid": {
+        "type": "UID",
+        "config": {
+          "label": "uid",
+          "placeholder": ""
         }
       }
     },
@@ -137,6 +145,5 @@
         }
       }
     }
-  },
-  "format": "custom"
+  }
 }

--- a/common/customtypes/exhibition-highlight-tours/index.json
+++ b/common/customtypes/exhibition-highlight-tours/index.json
@@ -31,6 +31,13 @@
           "multi": "paragraph,strong,em,hyperlink"
         }
       },
+      "uid": {
+        "type": "UID",
+        "config": {
+          "label": "uid",
+          "placeholder": ""
+        }
+      },
       "slices": {
         "type": "Slices",
         "fieldset": "Slice Zone",

--- a/common/customtypes/exhibition-texts/index.json
+++ b/common/customtypes/exhibition-texts/index.json
@@ -32,6 +32,13 @@
           "multi": "paragraph,strong,em,hyperlink"
         }
       },
+      "uid": {
+        "type": "UID",
+        "config": {
+          "label": "uid",
+          "placeholder": ""
+        }
+      },
       "slices": {
         "type": "Slices",
         "fieldset": "Slice Zone",

--- a/common/customtypes/exhibitions/index.json
+++ b/common/customtypes/exhibitions/index.json
@@ -3,6 +3,7 @@
   "label": "Exhibition",
   "repeatable": true,
   "status": true,
+  "format": "custom",
   "json": {
     "Exhibition": {
       "format": {
@@ -27,6 +28,48 @@
           "single": "paragraph,heading1",
           "label": "Short title",
           "placeholder": "Replaces title in breadcrumbs. Useful if title is very long, should otherwise be left empty."
+        }
+      },
+      "start": {
+        "type": "Timestamp",
+        "config": {
+          "label": "Start date"
+        }
+      },
+      "end": {
+        "type": "Timestamp",
+        "config": {
+          "label": "End date"
+        }
+      },
+      "isPermanent": {
+        "type": "Select",
+        "config": {
+          "label": "Is permanent?",
+          "options": ["yes"]
+        }
+      },
+      "statusOverride": {
+        "type": "StructuredText",
+        "config": {
+          "single": "paragraph,hyperlink,strong,em",
+          "label": "Status override"
+        }
+      },
+      "place": {
+        "type": "Link",
+        "fieldset": "Place",
+        "config": {
+          "select": "document",
+          "customtypes": ["places"],
+          "label": "Where is it?"
+        }
+      },
+      "uid": {
+        "type": "UID",
+        "config": {
+          "label": "uid",
+          "placeholder": ""
         }
       },
       "body": {
@@ -92,41 +135,6 @@
               "type": "SharedSlice"
             }
           }
-        }
-      },
-      "start": {
-        "type": "Timestamp",
-        "config": {
-          "label": "Start date"
-        }
-      },
-      "end": {
-        "type": "Timestamp",
-        "config": {
-          "label": "End date"
-        }
-      },
-      "isPermanent": {
-        "type": "Select",
-        "config": {
-          "label": "Is permanent?",
-          "options": ["yes"]
-        }
-      },
-      "statusOverride": {
-        "type": "StructuredText",
-        "config": {
-          "single": "paragraph,hyperlink,strong,em",
-          "label": "Status override"
-        }
-      },
-      "place": {
-        "type": "Link",
-        "fieldset": "Place",
-        "config": {
-          "select": "document",
-          "customtypes": ["places"],
-          "label": "Where is it?"
         }
       }
     },
@@ -257,8 +265,8 @@
     "Promo": {
       "promo": {
         "type": "Slices",
+        "fieldset": "Slice Zone",
         "config": {
-          "label": "Promo",
           "choices": {
             "editorialImage": {
               "type": "Slice",
@@ -360,6 +368,5 @@
         }
       }
     }
-  },
-  "format": "custom"
+  }
 }

--- a/common/customtypes/guides/index.json
+++ b/common/customtypes/guides/index.json
@@ -3,6 +3,7 @@
   "label": "Guide",
   "repeatable": true,
   "status": true,
+  "format": "custom",
   "json": {
     "Guide": {
       "title": {
@@ -32,6 +33,13 @@
         "config": {
           "default_value": false,
           "label": "Show 'On this page' anchor links. This will only appear if there are more than 2 H2s in the body"
+        }
+      },
+      "uid": {
+        "type": "UID",
+        "config": {
+          "label": "uid",
+          "placeholder": ""
         }
       },
       "body": {
@@ -103,8 +111,8 @@
     "Promo": {
       "promo": {
         "type": "Slices",
+        "fieldset": "Slice Zone",
         "config": {
-          "label": "Promo",
           "choices": {
             "editorialImage": {
               "type": "Slice",
@@ -164,6 +172,5 @@
         }
       }
     }
-  },
-  "format": "custom"
+  }
 }

--- a/common/customtypes/pages/index.json
+++ b/common/customtypes/pages/index.json
@@ -35,6 +35,13 @@
           "label": "Show 'On this page' anchor links. This will only appear if there are more than 2 H2s in the body"
         }
       },
+      "uid": {
+        "type": "UID",
+        "config": {
+          "label": "uid",
+          "placeholder": ""
+        }
+      },
       "body": {
         "type": "Slices",
         "fieldset": "Slice Zone",

--- a/common/customtypes/projects/index.json
+++ b/common/customtypes/projects/index.json
@@ -3,6 +3,7 @@
   "label": "Project",
   "repeatable": true,
   "status": true,
+  "format": "custom",
   "json": {
     "Project": {
       "title": {
@@ -31,6 +32,13 @@
         "type": "Timestamp",
         "config": {
           "label": "End date"
+        }
+      },
+      "uid": {
+        "type": "UID",
+        "config": {
+          "label": "uid",
+          "placeholder": ""
         }
       },
       "body": {
@@ -142,8 +150,8 @@
     "Promo": {
       "promo": {
         "type": "Slices",
+        "fieldset": "Slice Zone",
         "config": {
-          "label": "Promo",
           "choices": {
             "editorialImage": {
               "type": "Slice",
@@ -222,6 +230,5 @@
         }
       }
     }
-  },
-  "format": "custom"
+  }
 }

--- a/common/customtypes/seasons/index.json
+++ b/common/customtypes/seasons/index.json
@@ -3,6 +3,7 @@
   "label": "Season",
   "repeatable": true,
   "status": true,
+  "format": "custom",
   "json": {
     "Season": {
       "title": {
@@ -23,6 +24,13 @@
         "type": "Timestamp",
         "config": {
           "label": "End date"
+        }
+      },
+      "uid": {
+        "type": "UID",
+        "config": {
+          "label": "uid",
+          "placeholder": ""
         }
       },
       "body": {
@@ -94,8 +102,8 @@
     "Promo": {
       "promo": {
         "type": "Slices",
+        "fieldset": "Slice Zone",
         "config": {
-          "label": "Promo",
           "choices": {
             "editorialImage": {
               "type": "Slice",
@@ -146,6 +154,5 @@
         }
       }
     }
-  },
-  "format": "custom"
+  }
 }

--- a/common/customtypes/series/index.json
+++ b/common/customtypes/series/index.json
@@ -3,6 +3,7 @@
   "label": "Story series",
   "repeatable": true,
   "status": true,
+  "format": "custom",
   "json": {
     "Story series": {
       "title": {
@@ -31,6 +32,13 @@
             "accent.salmon",
             "accent.blue"
           ]
+        }
+      },
+      "uid": {
+        "type": "UID",
+        "config": {
+          "label": "uid",
+          "placeholder": ""
         }
       },
       "body": {
@@ -166,8 +174,8 @@
     "Promo": {
       "promo": {
         "type": "Slices",
+        "fieldset": "Slice Zone",
         "config": {
-          "label": "Promo",
           "choices": {
             "editorialImage": {
               "type": "Slice",
@@ -246,6 +254,5 @@
         }
       }
     }
-  },
-  "format": "custom"
+  }
 }

--- a/common/customtypes/visual-stories/index.json
+++ b/common/customtypes/visual-stories/index.json
@@ -35,6 +35,13 @@
           "label": "Show 'On this page' anchor links. This will only appear if there are more than 2 H2s in the body"
         }
       },
+      "uid": {
+        "type": "UID",
+        "config": {
+          "label": "uid",
+          "placeholder": ""
+        }
+      },
       "body": {
         "type": "Slices",
         "fieldset": "Slice Zone",

--- a/common/customtypes/webcomic-series/index.json
+++ b/common/customtypes/webcomic-series/index.json
@@ -3,6 +3,7 @@
   "label": "[Deprecated] Webcomic series",
   "repeatable": true,
   "status": false,
+  "format": "custom",
   "json": {
     "[Deprecated] Webcomic series": {
       "title": {
@@ -18,6 +19,13 @@
         "config": {
           "multi": "paragraph,hyperlink,strong,em",
           "label": "Description"
+        }
+      },
+      "uid": {
+        "type": "UID",
+        "config": {
+          "label": "uid",
+          "placeholder": ""
         }
       }
     },
@@ -64,8 +72,8 @@
     "Promo": {
       "promo": {
         "type": "Slices",
+        "fieldset": "Slice Zone",
         "config": {
-          "label": "Promo",
           "choices": {
             "editorialImage": {
               "type": "Slice",
@@ -125,6 +133,5 @@
         }
       }
     }
-  },
-  "format": "custom"
+  }
 }

--- a/common/customtypes/webcomics/index.json
+++ b/common/customtypes/webcomics/index.json
@@ -28,6 +28,13 @@
           "label": "Webcomic"
         }
       },
+      "uid": {
+        "type": "UID",
+        "config": {
+          "label": "uid",
+          "placeholder": ""
+        }
+      },
       "body": {
         "type": "Slices",
         "fieldset": "Slice Zone",

--- a/common/prismicio-types.d.ts
+++ b/common/prismicio-types.d.ts
@@ -335,7 +335,7 @@ interface ArticlesDocumentData {
  * @typeParam Lang - Language API ID of the document.
  */
 export type ArticlesDocument<Lang extends string = string> =
-  prismic.PrismicDocumentWithoutUID<
+  prismic.PrismicDocumentWithUID<
     Simplify<ArticlesDocumentData>,
     'articles',
     Lang
@@ -777,7 +777,7 @@ interface BooksDocumentData {
  * @typeParam Lang - Language API ID of the document.
  */
 export type BooksDocument<Lang extends string = string> =
-  prismic.PrismicDocumentWithoutUID<Simplify<BooksDocumentData>, 'books', Lang>;
+  prismic.PrismicDocumentWithUID<Simplify<BooksDocumentData>, 'books', Lang>;
 
 /**
  * Content for Card documents
@@ -1435,11 +1435,11 @@ export interface EventSeriesDocumentDataContributorsItem {
 }
 
 /**
- * Primary content in *Event series → Promo → Editorial image → Primary*
+ * Primary content in *Event series → Slice Zone → Editorial image → Primary*
  */
 export interface EventSeriesDocumentDataPromoEditorialImageSlicePrimary {
   /**
-   * Promo text field in *Event series → Promo → Editorial image → Primary*
+   * Promo text field in *Event series → Slice Zone → Editorial image → Primary*
    *
    * - **Field Type**: Rich Text
    * - **Placeholder**: *None*
@@ -1449,7 +1449,7 @@ export interface EventSeriesDocumentDataPromoEditorialImageSlicePrimary {
   caption: prismic.RichTextField;
 
   /**
-   * Promo image field in *Event series → Promo → Editorial image → Primary*
+   * Promo image field in *Event series → Slice Zone → Editorial image → Primary*
    *
    * - **Field Type**: Image
    * - **Placeholder**: *None*
@@ -1459,7 +1459,7 @@ export interface EventSeriesDocumentDataPromoEditorialImageSlicePrimary {
   image: prismic.ImageField<'32:15' | '16:9' | 'square'>;
 
   /**
-   * Link override field in *Event series → Promo → Editorial image → Primary*
+   * Link override field in *Event series → Slice Zone → Editorial image → Primary*
    *
    * - **Field Type**: Text
    * - **Placeholder**: *None*
@@ -1470,7 +1470,7 @@ export interface EventSeriesDocumentDataPromoEditorialImageSlicePrimary {
 }
 
 /**
- * Slice for *Event series → Promo*
+ * Slice for *Event series → Slice Zone*
  */
 export type EventSeriesDocumentDataPromoEditorialImageSlice = prismic.Slice<
   'editorialImage',
@@ -1539,7 +1539,7 @@ interface EventSeriesDocumentData {
    * - **Documentation**: https://prismic.io/docs/field#rich-text-title
    */
   contributorsTitle: prismic.TitleField /**
-   * Promo field in *Event series*
+   * Slice Zone field in *Event series*
    *
    * - **Field Type**: Slice Zone
    * - **Placeholder**: *None*
@@ -1569,7 +1569,7 @@ interface EventSeriesDocumentData {
  * @typeParam Lang - Language API ID of the document.
  */
 export type EventSeriesDocument<Lang extends string = string> =
-  prismic.PrismicDocumentWithoutUID<
+  prismic.PrismicDocumentWithUID<
     Simplify<EventSeriesDocumentData>,
     'event-series',
     Lang
@@ -1797,11 +1797,11 @@ export interface EventsDocumentDataContributorsItem {
 }
 
 /**
- * Primary content in *Event → Promo → Editorial image → Primary*
+ * Primary content in *Event → Slice Zone → Editorial image → Primary*
  */
 export interface EventsDocumentDataPromoEditorialImageSlicePrimary {
   /**
-   * Promo text field in *Event → Promo → Editorial image → Primary*
+   * Promo text field in *Event → Slice Zone → Editorial image → Primary*
    *
    * - **Field Type**: Rich Text
    * - **Placeholder**: *None*
@@ -1811,7 +1811,7 @@ export interface EventsDocumentDataPromoEditorialImageSlicePrimary {
   caption: prismic.RichTextField;
 
   /**
-   * Promo image field in *Event → Promo → Editorial image → Primary*
+   * Promo image field in *Event → Slice Zone → Editorial image → Primary*
    *
    * - **Field Type**: Image
    * - **Placeholder**: *None*
@@ -1821,7 +1821,7 @@ export interface EventsDocumentDataPromoEditorialImageSlicePrimary {
   image: prismic.ImageField<'32:15' | '16:9' | 'square'>;
 
   /**
-   * Link override field in *Event → Promo → Editorial image → Primary*
+   * Link override field in *Event → Slice Zone → Editorial image → Primary*
    *
    * - **Field Type**: Text
    * - **Placeholder**: *None*
@@ -1832,7 +1832,7 @@ export interface EventsDocumentDataPromoEditorialImageSlicePrimary {
 }
 
 /**
- * Slice for *Event → Promo*
+ * Slice for *Event → Slice Zone*
  */
 export type EventsDocumentDataPromoEditorialImageSlice = prismic.Slice<
   'editorialImage',
@@ -2239,7 +2239,7 @@ interface EventsDocumentData {
    * - **Documentation**: https://prismic.io/docs/field#rich-text-title
    */
   contributorsTitle: prismic.TitleField /**
-   * Promo field in *Event*
+   * Slice Zone field in *Event*
    *
    * - **Field Type**: Slice Zone
    * - **Placeholder**: *None*
@@ -2300,11 +2300,7 @@ interface EventsDocumentData {
  * @typeParam Lang - Language API ID of the document.
  */
 export type EventsDocument<Lang extends string = string> =
-  prismic.PrismicDocumentWithoutUID<
-    Simplify<EventsDocumentData>,
-    'events',
-    Lang
-  >;
+  prismic.PrismicDocumentWithUID<Simplify<EventsDocumentData>, 'events', Lang>;
 
 /**
  * Content for Exhibition format documents
@@ -2523,7 +2519,7 @@ interface ExhibitionGuidesDocumentData {
  * @typeParam Lang - Language API ID of the document.
  */
 export type ExhibitionGuidesDocument<Lang extends string = string> =
-  prismic.PrismicDocumentWithoutUID<
+  prismic.PrismicDocumentWithUID<
     Simplify<ExhibitionGuidesDocumentData>,
     'exhibition-guides',
     Lang
@@ -2590,7 +2586,7 @@ interface ExhibitionHighlightToursDocumentData {
  * @typeParam Lang - Language API ID of the document.
  */
 export type ExhibitionHighlightToursDocument<Lang extends string = string> =
-  prismic.PrismicDocumentWithoutUID<
+  prismic.PrismicDocumentWithUID<
     Simplify<ExhibitionHighlightToursDocumentData>,
     'exhibition-highlight-tours',
     Lang
@@ -2713,7 +2709,7 @@ interface ExhibitionTextsDocumentData {
  * @typeParam Lang - Language API ID of the document.
  */
 export type ExhibitionTextsDocument<Lang extends string = string> =
-  prismic.PrismicDocumentWithoutUID<
+  prismic.PrismicDocumentWithUID<
     Simplify<ExhibitionTextsDocumentData>,
     'exhibition-texts',
     Lang
@@ -2846,11 +2842,11 @@ export interface ExhibitionsDocumentDataContributorsItem {
 }
 
 /**
- * Primary content in *Exhibition → Promo → Editorial image → Primary*
+ * Primary content in *Exhibition → Slice Zone → Editorial image → Primary*
  */
 export interface ExhibitionsDocumentDataPromoEditorialImageSlicePrimary {
   /**
-   * Promo text field in *Exhibition → Promo → Editorial image → Primary*
+   * Promo text field in *Exhibition → Slice Zone → Editorial image → Primary*
    *
    * - **Field Type**: Rich Text
    * - **Placeholder**: *None*
@@ -2860,7 +2856,7 @@ export interface ExhibitionsDocumentDataPromoEditorialImageSlicePrimary {
   caption: prismic.RichTextField;
 
   /**
-   * Promo image field in *Exhibition → Promo → Editorial image → Primary*
+   * Promo image field in *Exhibition → Slice Zone → Editorial image → Primary*
    *
    * - **Field Type**: Image
    * - **Placeholder**: *None*
@@ -2870,7 +2866,7 @@ export interface ExhibitionsDocumentDataPromoEditorialImageSlicePrimary {
   image: prismic.ImageField<'32:15' | '16:9' | 'square'>;
 
   /**
-   * Link override field in *Exhibition → Promo → Editorial image → Primary*
+   * Link override field in *Exhibition → Slice Zone → Editorial image → Primary*
    *
    * - **Field Type**: Text
    * - **Placeholder**: *None*
@@ -2881,7 +2877,7 @@ export interface ExhibitionsDocumentDataPromoEditorialImageSlicePrimary {
 }
 
 /**
- * Slice for *Exhibition → Promo*
+ * Slice for *Exhibition → Slice Zone*
  */
 export type ExhibitionsDocumentDataPromoEditorialImageSlice = prismic.Slice<
   'editorialImage',
@@ -2970,17 +2966,6 @@ interface ExhibitionsDocumentData {
   shortTitle: prismic.RichTextField;
 
   /**
-   * Slice Zone field in *Exhibition*
-   *
-   * - **Field Type**: Slice Zone
-   * - **Placeholder**: *None*
-   * - **API ID Path**: exhibitions.body[]
-   * - **Tab**: Exhibition
-   * - **Documentation**: https://prismic.io/docs/field#slices
-   */
-  body: prismic.SliceZone<ExhibitionsDocumentDataBodySlice>;
-
-  /**
    * Start date field in *Exhibition*
    *
    * - **Field Type**: Timestamp
@@ -3033,7 +3018,18 @@ interface ExhibitionsDocumentData {
    * - **Tab**: Exhibition
    * - **Documentation**: https://prismic.io/docs/field#link-content-relationship
    */
-  place: prismic.ContentRelationshipField<'places'> /**
+  place: prismic.ContentRelationshipField<'places'>;
+
+  /**
+   * Slice Zone field in *Exhibition*
+   *
+   * - **Field Type**: Slice Zone
+   * - **Placeholder**: *None*
+   * - **API ID Path**: exhibitions.body[]
+   * - **Tab**: Exhibition
+   * - **Documentation**: https://prismic.io/docs/field#slices
+   */
+  body: prismic.SliceZone<ExhibitionsDocumentDataBodySlice> /**
    * Exhibits field in *Exhibition*
    *
    * - **Field Type**: Group
@@ -3109,7 +3105,7 @@ interface ExhibitionsDocumentData {
    * - **Documentation**: https://prismic.io/docs/field#rich-text-title
    */
   contributorsTitle: prismic.TitleField /**
-   * Promo field in *Exhibition*
+   * Slice Zone field in *Exhibition*
    *
    * - **Field Type**: Slice Zone
    * - **Placeholder**: *None*
@@ -3159,7 +3155,7 @@ interface ExhibitionsDocumentData {
  * @typeParam Lang - Language API ID of the document.
  */
 export type ExhibitionsDocument<Lang extends string = string> =
-  prismic.PrismicDocumentWithoutUID<
+  prismic.PrismicDocumentWithUID<
     Simplify<ExhibitionsDocumentData>,
     'exhibitions',
     Lang
@@ -3285,11 +3281,11 @@ type GuidesDocumentDataBodySlice =
   | AudioPlayerSlice;
 
 /**
- * Primary content in *Guide → Promo → Editorial image → Primary*
+ * Primary content in *Guide → Slice Zone → Editorial image → Primary*
  */
 export interface GuidesDocumentDataPromoEditorialImageSlicePrimary {
   /**
-   * Promo text field in *Guide → Promo → Editorial image → Primary*
+   * Promo text field in *Guide → Slice Zone → Editorial image → Primary*
    *
    * - **Field Type**: Rich Text
    * - **Placeholder**: *None*
@@ -3299,7 +3295,7 @@ export interface GuidesDocumentDataPromoEditorialImageSlicePrimary {
   caption: prismic.RichTextField;
 
   /**
-   * Promo image field in *Guide → Promo → Editorial image → Primary*
+   * Promo image field in *Guide → Slice Zone → Editorial image → Primary*
    *
    * - **Field Type**: Image
    * - **Placeholder**: *None*
@@ -3309,7 +3305,7 @@ export interface GuidesDocumentDataPromoEditorialImageSlicePrimary {
   image: prismic.ImageField<'32:15' | '16:9' | 'square'>;
 
   /**
-   * Link override field in *Guide → Promo → Editorial image → Primary*
+   * Link override field in *Guide → Slice Zone → Editorial image → Primary*
    *
    * - **Field Type**: Text
    * - **Placeholder**: *None*
@@ -3320,7 +3316,7 @@ export interface GuidesDocumentDataPromoEditorialImageSlicePrimary {
 }
 
 /**
- * Slice for *Guide → Promo*
+ * Slice for *Guide → Slice Zone*
  */
 export type GuidesDocumentDataPromoEditorialImageSlice = prismic.Slice<
   'editorialImage',
@@ -3389,7 +3385,7 @@ interface GuidesDocumentData {
    * - **Documentation**: https://prismic.io/docs/field#slices
    */
   body: prismic.SliceZone<GuidesDocumentDataBodySlice> /**
-   * Promo field in *Guide*
+   * Slice Zone field in *Guide*
    *
    * - **Field Type**: Slice Zone
    * - **Placeholder**: *None*
@@ -3419,11 +3415,7 @@ interface GuidesDocumentData {
  * @typeParam Lang - Language API ID of the document.
  */
 export type GuidesDocument<Lang extends string = string> =
-  prismic.PrismicDocumentWithoutUID<
-    Simplify<GuidesDocumentData>,
-    'guides',
-    Lang
-  >;
+  prismic.PrismicDocumentWithUID<Simplify<GuidesDocumentData>, 'guides', Lang>;
 
 /**
  * Content for Interpretation type documents
@@ -3937,7 +3929,7 @@ interface PagesDocumentData {
  * @typeParam Lang - Language API ID of the document.
  */
 export type PagesDocument<Lang extends string = string> =
-  prismic.PrismicDocumentWithoutUID<Simplify<PagesDocumentData>, 'pages', Lang>;
+  prismic.PrismicDocumentWithUID<Simplify<PagesDocumentData>, 'pages', Lang>;
 
 /**
  * Item in *Person → Same as*
@@ -4336,11 +4328,11 @@ export interface ProjectsDocumentDataContributorsItem {
 }
 
 /**
- * Primary content in *Project → Promo → Editorial image → Primary*
+ * Primary content in *Project → Slice Zone → Editorial image → Primary*
  */
 export interface ProjectsDocumentDataPromoEditorialImageSlicePrimary {
   /**
-   * Promo text field in *Project → Promo → Editorial image → Primary*
+   * Promo text field in *Project → Slice Zone → Editorial image → Primary*
    *
    * - **Field Type**: Rich Text
    * - **Placeholder**: *None*
@@ -4350,7 +4342,7 @@ export interface ProjectsDocumentDataPromoEditorialImageSlicePrimary {
   caption: prismic.RichTextField;
 
   /**
-   * Promo image field in *Project → Promo → Editorial image → Primary*
+   * Promo image field in *Project → Slice Zone → Editorial image → Primary*
    *
    * - **Field Type**: Image
    * - **Placeholder**: *None*
@@ -4360,7 +4352,7 @@ export interface ProjectsDocumentDataPromoEditorialImageSlicePrimary {
   image: prismic.ImageField<'32:15' | '16:9' | 'square'>;
 
   /**
-   * Link override field in *Project → Promo → Editorial image → Primary*
+   * Link override field in *Project → Slice Zone → Editorial image → Primary*
    *
    * - **Field Type**: Text
    * - **Placeholder**: *None*
@@ -4371,7 +4363,7 @@ export interface ProjectsDocumentDataPromoEditorialImageSlicePrimary {
 }
 
 /**
- * Slice for *Project → Promo*
+ * Slice for *Project → Slice Zone*
  */
 export type ProjectsDocumentDataPromoEditorialImageSlice = prismic.Slice<
   'editorialImage',
@@ -4477,7 +4469,7 @@ interface ProjectsDocumentData {
    * - **Documentation**: https://prismic.io/docs/field#rich-text-title
    */
   contributorsTitle: prismic.TitleField /**
-   * Promo field in *Project*
+   * Slice Zone field in *Project*
    *
    * - **Field Type**: Slice Zone
    * - **Placeholder**: *None*
@@ -4516,7 +4508,7 @@ interface ProjectsDocumentData {
  * @typeParam Lang - Language API ID of the document.
  */
 export type ProjectsDocument<Lang extends string = string> =
-  prismic.PrismicDocumentWithoutUID<
+  prismic.PrismicDocumentWithUID<
     Simplify<ProjectsDocumentData>,
     'projects',
     Lang
@@ -4544,11 +4536,11 @@ type SeasonsDocumentDataBodySlice =
   | AudioPlayerSlice;
 
 /**
- * Primary content in *Season → Promo → Editorial image → Primary*
+ * Primary content in *Season → Slice Zone → Editorial image → Primary*
  */
 export interface SeasonsDocumentDataPromoEditorialImageSlicePrimary {
   /**
-   * Promo text field in *Season → Promo → Editorial image → Primary*
+   * Promo text field in *Season → Slice Zone → Editorial image → Primary*
    *
    * - **Field Type**: Rich Text
    * - **Placeholder**: *None*
@@ -4558,7 +4550,7 @@ export interface SeasonsDocumentDataPromoEditorialImageSlicePrimary {
   caption: prismic.RichTextField;
 
   /**
-   * Promo image field in *Season → Promo → Editorial image → Primary*
+   * Promo image field in *Season → Slice Zone → Editorial image → Primary*
    *
    * - **Field Type**: Image
    * - **Placeholder**: *None*
@@ -4568,7 +4560,7 @@ export interface SeasonsDocumentDataPromoEditorialImageSlicePrimary {
   image: prismic.ImageField<'32:15' | '16:9' | 'square'>;
 
   /**
-   * Link override field in *Season → Promo → Editorial image → Primary*
+   * Link override field in *Season → Slice Zone → Editorial image → Primary*
    *
    * - **Field Type**: Text
    * - **Placeholder**: *None*
@@ -4579,7 +4571,7 @@ export interface SeasonsDocumentDataPromoEditorialImageSlicePrimary {
 }
 
 /**
- * Slice for *Season → Promo*
+ * Slice for *Season → Slice Zone*
  */
 export type SeasonsDocumentDataPromoEditorialImageSlice = prismic.Slice<
   'editorialImage',
@@ -4637,7 +4629,7 @@ interface SeasonsDocumentData {
    * - **Documentation**: https://prismic.io/docs/field#slices
    */
   body: prismic.SliceZone<SeasonsDocumentDataBodySlice> /**
-   * Promo field in *Season*
+   * Slice Zone field in *Season*
    *
    * - **Field Type**: Slice Zone
    * - **Placeholder**: *None*
@@ -4658,7 +4650,7 @@ interface SeasonsDocumentData {
  * @typeParam Lang - Language API ID of the document.
  */
 export type SeasonsDocument<Lang extends string = string> =
-  prismic.PrismicDocumentWithoutUID<
+  prismic.PrismicDocumentWithUID<
     Simplify<SeasonsDocumentData>,
     'seasons',
     Lang
@@ -4746,11 +4738,11 @@ export interface SeriesDocumentDataContributorsItem {
 }
 
 /**
- * Primary content in *Story series → Promo → Editorial image → Primary*
+ * Primary content in *Story series → Slice Zone → Editorial image → Primary*
  */
 export interface SeriesDocumentDataPromoEditorialImageSlicePrimary {
   /**
-   * Promo text field in *Story series → Promo → Editorial image → Primary*
+   * Promo text field in *Story series → Slice Zone → Editorial image → Primary*
    *
    * - **Field Type**: Rich Text
    * - **Placeholder**: *None*
@@ -4760,7 +4752,7 @@ export interface SeriesDocumentDataPromoEditorialImageSlicePrimary {
   caption: prismic.RichTextField;
 
   /**
-   * Promo image field in *Story series → Promo → Editorial image → Primary*
+   * Promo image field in *Story series → Slice Zone → Editorial image → Primary*
    *
    * - **Field Type**: Image
    * - **Placeholder**: *None*
@@ -4770,7 +4762,7 @@ export interface SeriesDocumentDataPromoEditorialImageSlicePrimary {
   image: prismic.ImageField<'32:15' | '16:9' | 'square'>;
 
   /**
-   * Link override field in *Story series → Promo → Editorial image → Primary*
+   * Link override field in *Story series → Slice Zone → Editorial image → Primary*
    *
    * - **Field Type**: Text
    * - **Placeholder**: *None*
@@ -4781,7 +4773,7 @@ export interface SeriesDocumentDataPromoEditorialImageSlicePrimary {
 }
 
 /**
- * Slice for *Story series → Promo*
+ * Slice for *Story series → Slice Zone*
  */
 export type SeriesDocumentDataPromoEditorialImageSlice = prismic.Slice<
   'editorialImage',
@@ -4886,7 +4878,7 @@ interface SeriesDocumentData {
    * - **Documentation**: https://prismic.io/docs/field#rich-text-title
    */
   contributorsTitle: prismic.TitleField /**
-   * Promo field in *Story series*
+   * Slice Zone field in *Story series*
    *
    * - **Field Type**: Slice Zone
    * - **Placeholder**: *None*
@@ -4925,11 +4917,7 @@ interface SeriesDocumentData {
  * @typeParam Lang - Language API ID of the document.
  */
 export type SeriesDocument<Lang extends string = string> =
-  prismic.PrismicDocumentWithoutUID<
-    Simplify<SeriesDocumentData>,
-    'series',
-    Lang
-  >;
+  prismic.PrismicDocumentWithUID<Simplify<SeriesDocumentData>, 'series', Lang>;
 
 /**
  * Item in *Stories landing → stories*
@@ -5266,7 +5254,7 @@ interface VisualStoriesDocumentData {
  * @typeParam Lang - Language API ID of the document.
  */
 export type VisualStoriesDocument<Lang extends string = string> =
-  prismic.PrismicDocumentWithoutUID<
+  prismic.PrismicDocumentWithUID<
     Simplify<VisualStoriesDocumentData>,
     'visual-stories',
     Lang
@@ -5308,11 +5296,11 @@ export interface WebcomicSeriesDocumentDataContributorsItem {
 }
 
 /**
- * Primary content in *[Deprecated] Webcomic series → Promo → Editorial image → Primary*
+ * Primary content in *[Deprecated] Webcomic series → Slice Zone → Editorial image → Primary*
  */
 export interface WebcomicSeriesDocumentDataPromoEditorialImageSlicePrimary {
   /**
-   * Promo text field in *[Deprecated] Webcomic series → Promo → Editorial image → Primary*
+   * Promo text field in *[Deprecated] Webcomic series → Slice Zone → Editorial image → Primary*
    *
    * - **Field Type**: Rich Text
    * - **Placeholder**: *None*
@@ -5322,7 +5310,7 @@ export interface WebcomicSeriesDocumentDataPromoEditorialImageSlicePrimary {
   caption: prismic.RichTextField;
 
   /**
-   * Promo image field in *[Deprecated] Webcomic series → Promo → Editorial image → Primary*
+   * Promo image field in *[Deprecated] Webcomic series → Slice Zone → Editorial image → Primary*
    *
    * - **Field Type**: Image
    * - **Placeholder**: *None*
@@ -5332,7 +5320,7 @@ export interface WebcomicSeriesDocumentDataPromoEditorialImageSlicePrimary {
   image: prismic.ImageField<'32:15' | '16:9' | 'square'>;
 
   /**
-   * Link override field in *[Deprecated] Webcomic series → Promo → Editorial image → Primary*
+   * Link override field in *[Deprecated] Webcomic series → Slice Zone → Editorial image → Primary*
    *
    * - **Field Type**: Text
    * - **Placeholder**: *None*
@@ -5343,7 +5331,7 @@ export interface WebcomicSeriesDocumentDataPromoEditorialImageSlicePrimary {
 }
 
 /**
- * Slice for *[Deprecated] Webcomic series → Promo*
+ * Slice for *[Deprecated] Webcomic series → Slice Zone*
  */
 export type WebcomicSeriesDocumentDataPromoEditorialImageSlice = prismic.Slice<
   'editorialImage',
@@ -5401,7 +5389,7 @@ interface WebcomicSeriesDocumentData {
    * - **Documentation**: https://prismic.io/docs/field#rich-text-title
    */
   contributorsTitle: prismic.TitleField /**
-   * Promo field in *[Deprecated] Webcomic series*
+   * Slice Zone field in *[Deprecated] Webcomic series*
    *
    * - **Field Type**: Slice Zone
    * - **Placeholder**: *None*
@@ -5431,7 +5419,7 @@ interface WebcomicSeriesDocumentData {
  * @typeParam Lang - Language API ID of the document.
  */
 export type WebcomicSeriesDocument<Lang extends string = string> =
-  prismic.PrismicDocumentWithoutUID<
+  prismic.PrismicDocumentWithUID<
     Simplify<WebcomicSeriesDocumentData>,
     'webcomic-series',
     Lang
@@ -5664,7 +5652,7 @@ interface WebcomicsDocumentData {
  * @typeParam Lang - Language API ID of the document.
  */
 export type WebcomicsDocument<Lang extends string = string> =
-  prismic.PrismicDocumentWithoutUID<
+  prismic.PrismicDocumentWithUID<
     Simplify<WebcomicsDocumentData>,
     'webcomics',
     Lang

--- a/common/services/prismic/documents.ts
+++ b/common/services/prismic/documents.ts
@@ -41,12 +41,32 @@ export function emptyPrismicQuery<
   };
 }
 
-export function emptyDocument<T extends prismic.PrismicDocumentWithoutUID>(
-  data: T['data']
-): prismic.PrismicDocumentWithoutUID<T['data']> {
+export function emptyDocumentWithoutUid<
+  T extends prismic.PrismicDocumentWithoutUID,
+>(data: T['data']): prismic.PrismicDocumentWithoutUID<T['data']> {
   return {
-    id: '',
     uid: null,
+    id: '',
+    url: null,
+    type: '',
+    href: '',
+    tags: [],
+    first_publication_date: '2020-06-29T15:13:27+0000',
+    last_publication_date: '2020-06-29T15:13:27+0000',
+    slugs: [],
+    linked_documents: [],
+    lang: 'en-gb',
+    alternate_languages: [],
+    data,
+  };
+}
+
+export function emptyDocumentWithUid<T extends prismic.PrismicDocumentWithUID>(
+  data: T['data']
+): prismic.PrismicDocumentWithUID<T['data']> {
+  return {
+    uid: '',
+    id: '',
     url: null,
     type: '',
     href: '',
@@ -64,7 +84,7 @@ export function emptyDocument<T extends prismic.PrismicDocumentWithoutUID>(
 export function emptyGlobalAlert(
   overrides: Partial<RawGlobalAlertDocument['data']> = {}
 ): RawGlobalAlertDocument {
-  return emptyDocument<RawGlobalAlertDocument>({
+  return emptyDocumentWithoutUid<RawGlobalAlertDocument>({
     isShown: 'hide',
     routeRegex: null,
     text: [],
@@ -73,7 +93,7 @@ export function emptyGlobalAlert(
 }
 
 export function emptyPopupDialog(): RawPopupDialogDocument {
-  return emptyDocument<RawPopupDialogDocument>({
+  return emptyDocumentWithoutUid<RawPopupDialogDocument>({
     isShown: false,
     link: { link_type: 'Web' },
     linkText: null,

--- a/content/webapp/services/prismic/transformers/pages.test.ts
+++ b/content/webapp/services/prismic/transformers/pages.test.ts
@@ -1,4 +1,4 @@
-import { emptyDocument } from '@weco/common/services/prismic/documents';
+import { emptyDocumentWithUid } from '@weco/common/services/prismic/documents';
 import { transformPage } from './pages';
 import {
   PagesDocument as RawPagesDocument,
@@ -24,7 +24,7 @@ const exampleTextSlice = {
 } as RawTextSlice;
 
 export const pageWithoutBody: RawPagesDocument = {
-  ...emptyDocument<RawPagesDocument>({
+  ...emptyDocumentWithUid<RawPagesDocument>({
     title: [],
     datePublished: null,
     showOnThisPage: false,


### PR DESCRIPTION
## What does this change?
For #11023

It adds a uid field to the content types we will want to query by uid

## How to test

These have been applied to the stage environment so are visible there. (Once this approved I will notify the content team and apply then to the prod environment).

- Login to Prismic
- Switch to the stage environment
- Visit any of the relevant content types and see the uid field is present

## How can we measure success?

We are able to add values to uid fields in Prismic.

## Have we considered potential risks?

Have tested in the stage environment first to determine how the uid field behaves:

Before saving a document the uid field will auto populate with text from the first rich text field to be edited, but will be overidden with whatever is in the title field when that is edited.
After saving a document the uid field will only change if it is edited directly.
