### PR TITLE
Amend filters id so there are no doubles

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -35,7 +35,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-popper": "^2.3.0",
-    "react-transition-group": "^4.3.0",
+    "react-transition-group": "^4.4.5",
     "styled-components": "^6.1.0",
     "timezone-mock": "^1.3.6",
     "url-template": "^2.0.8",

--- a/content/webapp/services/wellcome/common/filters.test.ts
+++ b/content/webapp/services/wellcome/common/filters.test.ts
@@ -35,11 +35,11 @@ describe('filter options', () => {
     ).toEqual(['map', 'niu']);
 
     expect(
-      workTypeFilter.options.find(option => option.id === 'c')
+      workTypeFilter.options.find(option => option.id === 'format-c')
     ).toBeTruthy();
 
     expect(
-      workTypeFilter.options.find(option => option.id === 'u')
+      workTypeFilter.options.find(option => option.id === 'format-u')
     ).toBeFalsy();
   });
 

--- a/content/webapp/services/wellcome/common/filters.ts
+++ b/content/webapp/services/wellcome/common/filters.ts
@@ -239,7 +239,7 @@ const workTypeFilter = ({
   label: 'Formats',
   options: filterOptionsWithNonAggregates({
     options: works?.aggregations?.workType.buckets.map(bucket => ({
-      id: bucket.data.id,
+      id: `format-${bucket.data.id}`,
       value: bucket.data.id,
       count: bucket.count,
       label: bucket.data.label,
@@ -258,7 +258,7 @@ const subjectsFilter = ({
   label: 'Subjects',
   options: filterOptionsWithNonAggregates({
     options: works?.aggregations?.['subjects.label']?.buckets.map(bucket => ({
-      id: toHtmlId(bucket.data.label),
+      id: toHtmlId(`subject-${bucket.data.label}`),
       value: quoteVal(bucket.data.label),
       count: bucket.count,
       label: bucket.data.label,
@@ -280,7 +280,7 @@ const genresFilter = ({
   label: 'Types/Techniques',
   options: filterOptionsWithNonAggregates({
     options: works?.aggregations?.['genres.label']?.buckets.map(bucket => ({
-      id: toHtmlId(bucket.data.label),
+      id: toHtmlId(`type-${bucket.data.label}`),
       value: quoteVal(bucket.data.label),
       count: bucket.count,
       label: bucket.data.label,
@@ -296,30 +296,26 @@ const genresFilter = ({
 const contributorsAgentFilter = ({
   works,
   props,
-}: WorksFilterProps): CheckboxFilter<keyof WorksProps> => {
-  return {
-    type: 'checkbox',
-    id: 'contributors.agent.label',
-    label: 'Contributors',
-    options: filterOptionsWithNonAggregates({
-      options: works?.aggregations?.['contributors.agent.label']?.buckets.map(
-        bucket => ({
-          id: toHtmlId(bucket.data.label),
-          value: quoteVal(bucket.data.label),
-          count: bucket.count,
-          label: bucket.data.label,
-          selected: props['contributors.agent.label'].includes(
-            bucket.data.label
-          ),
-        })
-      ),
-      selectedValues: props['contributors.agent.label'].map(label => ({
-        value: quoteVal(label),
-        label,
-      })),
-    }),
-  };
-};
+}: WorksFilterProps): CheckboxFilter<keyof WorksProps> => ({
+  type: 'checkbox',
+  id: 'contributors.agent.label',
+  label: 'Contributors',
+  options: filterOptionsWithNonAggregates({
+    options: works?.aggregations?.['contributors.agent.label']?.buckets.map(
+      bucket => ({
+        id: toHtmlId(`contributor-${bucket.data.label}`),
+        value: quoteVal(bucket.data.label),
+        count: bucket.count,
+        label: bucket.data.label,
+        selected: props['contributors.agent.label'].includes(bucket.data.label),
+      })
+    ),
+    selectedValues: props['contributors.agent.label'].map(label => ({
+      value: quoteVal(label),
+      label,
+    })),
+  }),
+});
 
 const languagesFilter = ({
   works,
@@ -330,7 +326,7 @@ const languagesFilter = ({
   label: 'Languages',
   options: filterOptionsWithNonAggregates({
     options: works?.aggregations?.languages?.buckets.map(bucket => ({
-      id: bucket.data.id,
+      id: `lang-${bucket.data.id}`,
       value: bucket.data.id,
       count: bucket.count,
       label: bucket.data.label,
@@ -384,7 +380,7 @@ const availabilitiesFilter = ({
   label: 'Locations',
   options: filterOptionsWithNonAggregates({
     options: works?.aggregations?.availabilities?.buckets.map(bucket => ({
-      id: bucket.data.id,
+      id: `loc-${bucket.data.id}`,
       value: bucket.data.id,
       count: bucket.count,
       label: bucket.data.label,
@@ -448,7 +444,7 @@ const licensesFilter = ({
   label: 'Licences', // UK spelling for UI
   options: filterOptionsWithNonAggregates({
     options: images.aggregations?.license?.buckets.map(bucket => ({
-      id: bucket.data.id,
+      id: `licence-${bucket.data.id}`,
       value: bucket.data.id,
       count: bucket.count,
       label: licenseLabels[bucket.data.id] || bucket.data.label,
@@ -485,7 +481,7 @@ const sourceGenresFilter = ({
   options: filterOptionsWithNonAggregates({
     options: images?.aggregations?.['source.genres.label']?.buckets.map(
       bucket => ({
-        id: toHtmlId(bucket.data.label),
+        id: toHtmlId(`type-${bucket.data.label}`),
         value: quoteVal(bucket.data.label),
         count: bucket.count,
         label: bucket.data.label,
@@ -509,7 +505,7 @@ const sourceSubjectsFilter = ({
   options: filterOptionsWithNonAggregates({
     options: images?.aggregations?.['source.subjects.label']?.buckets.map(
       bucket => ({
-        id: toHtmlId(bucket.data.label),
+        id: toHtmlId(`subject-${bucket.data.label}`),
         value: quoteVal(bucket.data.label),
         count: bucket.count,
         label: bucket.data.label,
@@ -534,7 +530,7 @@ const sourceContributorAgentsFilter = ({
     options: images?.aggregations?.[
       'source.contributors.agent.label'
     ]?.buckets.map(bucket => ({
-      id: toHtmlId(bucket.data.label),
+      id: toHtmlId(`contributor-${bucket.data.label}`),
       value: quoteVal(bucket.data.label),
       count: bucket.count,
       label: bucket.data.label,
@@ -558,7 +554,7 @@ const storiesFormatFilter = ({
   label: 'Formats',
   options: filterOptionsWithNonAggregates({
     options: stories?.aggregations?.format?.buckets.map(bucket => ({
-      id: bucket.data.id,
+      id: `format-${bucket.data.id}`,
       value: bucket.data.id,
       count: bucket.count,
       label: bucket.data.label,
@@ -578,7 +574,7 @@ const storiesContributorFilter = ({
   options: filterOptionsWithNonAggregates({
     options: stories?.aggregations?.['contributors.contributor'].buckets.map(
       bucket => ({
-        id: bucket.data.id,
+        id: `contributor-${bucket.data.id}`,
         value: bucket.data.id,
         count: bucket.count,
         label: bucket.data.label,
@@ -598,7 +594,7 @@ const eventsFormatFilter = ({
   label: 'Event types',
   options: filterOptionsWithNonAggregates({
     options: events?.aggregations?.format?.buckets.map(bucket => ({
-      id: bucket.data.id,
+      id: `format-${bucket.data.id}`,
       value: bucket.data.id,
       count: bucket.count,
       label: bucket.data.label,
@@ -617,7 +613,7 @@ const eventsAudienceFilter = ({
   label: 'Audiences',
   options: filterOptionsWithNonAggregates({
     options: events?.aggregations?.audience?.buckets.map(bucket => ({
-      id: bucket.data.id,
+      id: `audience-${bucket.data.id}`,
       value: bucket.data.id,
       count: bucket.count,
       label: bucket.data.label,
@@ -636,7 +632,7 @@ const eventsLocationFilter = ({
   label: 'Locations',
   options: filterOptionsWithNonAggregates({
     options: events?.aggregations?.location?.buckets.map(bucket => ({
-      id: bucket.data.id,
+      id: `loc-${bucket.data.id}`,
       value: bucket.data.id,
       count: bucket.count,
       label: bucket.data.label,
@@ -674,7 +670,7 @@ const eventsIsAvailableOnlineFilter = ({
 //     options: filterOptionsWithNonAggregates({
 //       options: events?.aggregations?.interpretation?.buckets.map(bucket => {
 //         return {
-//           id: bucket.data.id,
+//           id: `a11y-${bucket.data.id}`,
 //           value: bucket.data.id,
 //           count: bucket.count,
 //           label: bucket.data.label,

--- a/yarn.lock
+++ b/yarn.lock
@@ -17372,10 +17372,10 @@ react-sizeme@^3.0.1:
     shallowequal "^1.1.0"
     throttle-debounce "^3.0.1"
 
-react-transition-group@^4.3.0:
-  version "4.4.2"
-  resolved "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.2.tgz"
-  integrity sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==
+react-transition-group@^4.4.5:
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.5.tgz#e53d4e3f3344da8521489fbef8f2581d42becdd1"
+  integrity sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==
   dependencies:
     "@babel/runtime" "^7.5.5"
     dom-helpers "^5.0.1"


### PR DESCRIPTION
## What does this change?

#10952 

The filters `id` being often based on the `label`, they found themselves duplicated at times.
An example is the Subject `"Leonardo, da Vinci, 1452-1519"` and the Contributor `"Leonardo, da Vinci, 1452-1519"`. Since they are exactly the same, both checkboxes had exactly the same `id`. It would always then select the first checkbox it could find with that `id`, even though it wasn't the one that was selected.
So I added a prefix based on the category for all filters so we can avoid it happening in other scenarios.

## How to test

Run locally and do searches! You can use Leonardo as an example, or Darwin.

## How can we measure success?

Searches work better

## Have we considered potential risks?

Searches are broken, but through testing and automated testing working, it seems unlikely.
