### PR TITLE
Upgrade edge lambdas to node 20

### DIFF
--- a/cache/edge_lambdas.tf
+++ b/cache/edge_lambdas.tf
@@ -30,7 +30,7 @@ data "aws_s3_object" "edge_lambda_origin" {
 resource "aws_lambda_function" "edge_lambda_request" {
   function_name     = "cf_edge_lambda_request"
   role              = aws_iam_role.edge_lambda_role.arn
-  runtime           = "nodejs16.x"
+  runtime           = "nodejs20.x"
   handler           = "origin.request"
   s3_bucket         = "weco-lambdas"
   s3_key            = "edge_lambda_origin.zip"
@@ -41,7 +41,7 @@ resource "aws_lambda_function" "edge_lambda_request" {
 resource "aws_lambda_function" "edge_lambda_response" {
   function_name     = "cf_edge_lambda_response"
   role              = aws_iam_role.edge_lambda_role.arn
-  runtime           = "nodejs12.x"
+  runtime           = "nodejs20.x"
   handler           = "origin.response"
   s3_bucket         = "weco-lambdas"
   s3_key            = "edge_lambda_origin.zip"

--- a/cache/edge_lambdas/Dockerfile
+++ b/cache/edge_lambdas/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/node:16-slim
+FROM public.ecr.aws/docker/library/node:20-bookworm-slim
 
 RUN apt-get update && apt-get install -yq --no-install-recommends git zip
 

--- a/cache/locals.tf
+++ b/cache/locals.tf
@@ -3,8 +3,8 @@ data "aws_secretsmanager_secret_version" "slack_webhook" {
 }
 
 locals {
-  edge_lambda_request_version  = 124
-  edge_lambda_response_version = 124
+  edge_lambda_request_version  = 131
+  edge_lambda_response_version = 129
 
   wellcome_cdn_cert_arn = "arn:aws:acm:us-east-1:130871440101:certificate/bb840c52-56bb-4bf8-86f8-59e7deaf9c98"
 


### PR DESCRIPTION
## What does this change?

This change upgrades the runtime for our edge lambdas to Node version 20 (LTS), in order to remain on a supported version of the node runtime. For the edge-lambdas this is especially important as the response lambda is using node 12 which is out of support in AWS and cannot be modified without upgrading the runtime.

See: https://aws.amazon.com/blogs/developer/announcing-the-end-of-support-for-node-js-12-x-in-the-aws-sdk-for-javascript-v3/

### Context

Currently the request edge lambda is using node 16, and the response edge lambda using node 12 despite being the same code and both being tested with a node 16 based Dockerfile. This change aligns the tests and runtimes to node 20.

Edge lambdas require using [versioned lambdas and specifying the lambda version explicitly](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-at-edge-function-restrictions.html#lambda-at-edge-restrictions-version) which helps us as the runtime version is part of the lambda version so we can safely step the lambda version a cloudfront distribution is forward and back from node 12 to node 20 without worrying about losing access to the node 12 version.

The current setup requires that the prod version of our lambdas is specified explicitly while our stage & e2e versions step forward automatically, this will allow us to apply the change in this PR safely and then a later PR upgrade the prod version after testing in stage.

Part-of: https://github.com/wellcomecollection/wellcomecollection.org/issues/10929

### `terraform plan`

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # aws_lambda_function.edge_lambda_request will be updated in-place
  ~ resource "aws_lambda_function" "edge_lambda_request" {
        id                             = "cf_edge_lambda_request"
      ~ qualified_arn                  = "arn:aws:lambda:us-east-1:130871440101:function:cf_edge_lambda_request:130" -> (known after apply)
      ~ qualified_invoke_arn           = "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:130871440101:function:cf_edge_lambda_request:130/invocations" -> (known after apply)
      ~ runtime                        = "nodejs16.x" -> "nodejs20.x"
        tags                           = {}
      ~ version                        = "130" -> (known after apply)
        # (20 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }

  # aws_lambda_function.edge_lambda_response will be updated in-place
  ~ resource "aws_lambda_function" "edge_lambda_response" {
        id                             = "cf_edge_lambda_response"
      ~ qualified_arn                  = "arn:aws:lambda:us-east-1:130871440101:function:cf_edge_lambda_response:128" -> (known after apply)
      ~ qualified_invoke_arn           = "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:130871440101:function:cf_edge_lambda_response:128/invocations" -> (known after apply)
      ~ runtime                        = "nodejs12.x" -> "nodejs20.x"
        tags                           = {}
      ~ version                        = "128" -> (known after apply)
        # (20 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }

  # module.e2e_wc_org_cloudfront_distribution.aws_cloudfront_distribution.wc_org will be updated in-place
  ~ resource "aws_cloudfront_distribution" "wc_org" {
        id                             = "E24KUWI00L6FA3"
        tags                           = {}
        # (20 unchanged attributes hidden)

      ~ default_cache_behavior {
            # (14 unchanged attributes hidden)

          - lambda_function_association {
              - event_type   = "origin-request" -> null
              - include_body = false -> null
              - lambda_arn   = "arn:aws:lambda:us-east-1:130871440101:function:cf_edge_lambda_request:130" -> null
            }
          - lambda_function_association {
              - event_type   = "origin-response" -> null
              - include_body = false -> null
              - lambda_arn   = "arn:aws:lambda:us-east-1:130871440101:function:cf_edge_lambda_response:128" -> null
            }
          + lambda_function_association {
              + event_type   = "origin-request"
              + include_body = false
              + lambda_arn   = (known after apply)
            }
          + lambda_function_association {
              + event_type   = "origin-response"
              + include_body = false
              + lambda_arn   = (known after apply)
            }
        }

      ~ ordered_cache_behavior {
            # (15 unchanged attributes hidden)

          - lambda_function_association {
              - event_type   = "origin-request" -> null
              - include_body = false -> null
              - lambda_arn   = "arn:aws:lambda:us-east-1:130871440101:function:cf_edge_lambda_request:130" -> null
            }
          - lambda_function_association {
              - event_type   = "origin-response" -> null
              - include_body = false -> null
              - lambda_arn   = "arn:aws:lambda:us-east-1:130871440101:function:cf_edge_lambda_response:128" -> null
            }
          + lambda_function_association {
              + event_type   = "origin-request"
              + include_body = false
              + lambda_arn   = (known after apply)
            }
          + lambda_function_association {
              + event_type   = "origin-response"
              + include_body = false
              + lambda_arn   = (known after apply)
            }
        }
      ~ ordered_cache_behavior {
            # (15 unchanged attributes hidden)

          - lambda_function_association {
              - event_type   = "origin-request" -> null
              - include_body = false -> null
              - lambda_arn   = "arn:aws:lambda:us-east-1:130871440101:function:cf_edge_lambda_request:130" -> null
            }
          - lambda_function_association {
              - event_type   = "origin-response" -> null
              - include_body = false -> null
              - lambda_arn   = "arn:aws:lambda:us-east-1:130871440101:function:cf_edge_lambda_response:128" -> null
            }
          + lambda_function_association {
              + event_type   = "origin-request"
              + include_body = false
              + lambda_arn   = (known after apply)
            }
          + lambda_function_association {
              + event_type   = "origin-response"
              + include_body = false
              + lambda_arn   = (known after apply)
            }
        }
      ~ ordered_cache_behavior {
            # (15 unchanged attributes hidden)

          - lambda_function_association {
              - event_type   = "origin-request" -> null
              - include_body = false -> null
              - lambda_arn   = "arn:aws:lambda:us-east-1:130871440101:function:cf_edge_lambda_request:130" -> null
            }
          - lambda_function_association {
              - event_type   = "origin-response" -> null
              - include_body = false -> null
              - lambda_arn   = "arn:aws:lambda:us-east-1:130871440101:function:cf_edge_lambda_response:128" -> null
            }
          + lambda_function_association {
              + event_type   = "origin-request"
              + include_body = false
              + lambda_arn   = (known after apply)
            }
          + lambda_function_association {
              + event_type   = "origin-response"
              + include_body = false
              + lambda_arn   = (known after apply)
            }
        }
      ~ ordered_cache_behavior {
            # (15 unchanged attributes hidden)

          - lambda_function_association {
              - event_type   = "origin-request" -> null
              - include_body = false -> null
              - lambda_arn   = "arn:aws:lambda:us-east-1:130871440101:function:cf_edge_lambda_request:130" -> null
            }
          - lambda_function_association {
              - event_type   = "origin-response" -> null
              - include_body = false -> null
              - lambda_arn   = "arn:aws:lambda:us-east-1:130871440101:function:cf_edge_lambda_response:128" -> null
            }
          + lambda_function_association {
              + event_type   = "origin-request"
              + include_body = false
              + lambda_arn   = (known after apply)
            }
          + lambda_function_association {
              + event_type   = "origin-response"
              + include_body = false
              + lambda_arn   = (known after apply)
            }
        }
      ~ ordered_cache_behavior {
            # (15 unchanged attributes hidden)

          - lambda_function_association {
              - event_type   = "origin-request" -> null
              - include_body = false -> null
              - lambda_arn   = "arn:aws:lambda:us-east-1:130871440101:function:cf_edge_lambda_request:130" -> null
            }
          - lambda_function_association {
              - event_type   = "origin-response" -> null
              - include_body = false -> null
              - lambda_arn   = "arn:aws:lambda:us-east-1:130871440101:function:cf_edge_lambda_response:128" -> null
            }
          + lambda_function_association {
              + event_type   = "origin-request"
              + include_body = false
              + lambda_arn   = (known after apply)
            }
          + lambda_function_association {
              + event_type   = "origin-response"
              + include_body = false
              + lambda_arn   = (known after apply)
            }
        }
      ~ ordered_cache_behavior {
            # (14 unchanged attributes hidden)

          - lambda_function_association {
              - event_type   = "origin-request" -> null
              - include_body = false -> null
              - lambda_arn   = "arn:aws:lambda:us-east-1:130871440101:function:cf_edge_lambda_request:130" -> null
            }
          - lambda_function_association {
              - event_type   = "origin-response" -> null
              - include_body = false -> null
              - lambda_arn   = "arn:aws:lambda:us-east-1:130871440101:function:cf_edge_lambda_response:128" -> null
            }
          + lambda_function_association {
              + event_type   = "origin-request"
              + include_body = false
              + lambda_arn   = (known after apply)
            }
          + lambda_function_association {
              + event_type   = "origin-response"
              + include_body = false
              + lambda_arn   = (known after apply)
            }
        }

        # (12 unchanged blocks hidden)
    }

  # module.stage_wc_org_cloudfront_distribution.aws_cloudfront_distribution.wc_org will be updated in-place
  ~ resource "aws_cloudfront_distribution" "wc_org" {
        id                             = "E16CX29L3OSCJA"
        tags                           = {}
        # (20 unchanged attributes hidden)

      ~ default_cache_behavior {
            # (14 unchanged attributes hidden)

          - lambda_function_association {
              - event_type   = "origin-request" -> null
              - include_body = false -> null
              - lambda_arn   = "arn:aws:lambda:us-east-1:130871440101:function:cf_edge_lambda_request:130" -> null
            }
          - lambda_function_association {
              - event_type   = "origin-response" -> null
              - include_body = false -> null
              - lambda_arn   = "arn:aws:lambda:us-east-1:130871440101:function:cf_edge_lambda_response:128" -> null
            }
          + lambda_function_association {
              + event_type   = "origin-request"
              + include_body = false
              + lambda_arn   = (known after apply)
            }
          + lambda_function_association {
              + event_type   = "origin-response"
              + include_body = false
              + lambda_arn   = (known after apply)
            }
        }

      ~ ordered_cache_behavior {
            # (15 unchanged attributes hidden)

          - lambda_function_association {
              - event_type   = "origin-request" -> null
              - include_body = false -> null
              - lambda_arn   = "arn:aws:lambda:us-east-1:130871440101:function:cf_edge_lambda_request:130" -> null
            }
          - lambda_function_association {
              - event_type   = "origin-response" -> null
              - include_body = false -> null
              - lambda_arn   = "arn:aws:lambda:us-east-1:130871440101:function:cf_edge_lambda_response:128" -> null
            }
          + lambda_function_association {
              + event_type   = "origin-request"
              + include_body = false
              + lambda_arn   = (known after apply)
            }
          + lambda_function_association {
              + event_type   = "origin-response"
              + include_body = false
              + lambda_arn   = (known after apply)
            }
        }
      ~ ordered_cache_behavior {
            # (15 unchanged attributes hidden)

          - lambda_function_association {
              - event_type   = "origin-request" -> null
              - include_body = false -> null
              - lambda_arn   = "arn:aws:lambda:us-east-1:130871440101:function:cf_edge_lambda_request:130" -> null
            }
          - lambda_function_association {
              - event_type   = "origin-response" -> null
              - include_body = false -> null
              - lambda_arn   = "arn:aws:lambda:us-east-1:130871440101:function:cf_edge_lambda_response:128" -> null
            }
          + lambda_function_association {
              + event_type   = "origin-request"
              + include_body = false
              + lambda_arn   = (known after apply)
            }
          + lambda_function_association {
              + event_type   = "origin-response"
              + include_body = false
              + lambda_arn   = (known after apply)
            }
        }
      ~ ordered_cache_behavior {
            # (15 unchanged attributes hidden)

          - lambda_function_association {
              - event_type   = "origin-request" -> null
              - include_body = false -> null
              - lambda_arn   = "arn:aws:lambda:us-east-1:130871440101:function:cf_edge_lambda_request:130" -> null
            }
          - lambda_function_association {
              - event_type   = "origin-response" -> null
              - include_body = false -> null
              - lambda_arn   = "arn:aws:lambda:us-east-1:130871440101:function:cf_edge_lambda_response:128" -> null
            }
          + lambda_function_association {
              + event_type   = "origin-request"
              + include_body = false
              + lambda_arn   = (known after apply)
            }
          + lambda_function_association {
              + event_type   = "origin-response"
              + include_body = false
              + lambda_arn   = (known after apply)
            }
        }
      ~ ordered_cache_behavior {
            # (15 unchanged attributes hidden)

          - lambda_function_association {
              - event_type   = "origin-request" -> null
              - include_body = false -> null
              - lambda_arn   = "arn:aws:lambda:us-east-1:130871440101:function:cf_edge_lambda_request:130" -> null
            }
          - lambda_function_association {
              - event_type   = "origin-response" -> null
              - include_body = false -> null
              - lambda_arn   = "arn:aws:lambda:us-east-1:130871440101:function:cf_edge_lambda_response:128" -> null
            }
          + lambda_function_association {
              + event_type   = "origin-request"
              + include_body = false
              + lambda_arn   = (known after apply)
            }
          + lambda_function_association {
              + event_type   = "origin-response"
              + include_body = false
              + lambda_arn   = (known after apply)
            }
        }
      ~ ordered_cache_behavior {
            # (15 unchanged attributes hidden)

          - lambda_function_association {
              - event_type   = "origin-request" -> null
              - include_body = false -> null
              - lambda_arn   = "arn:aws:lambda:us-east-1:130871440101:function:cf_edge_lambda_request:130" -> null
            }
          - lambda_function_association {
              - event_type   = "origin-response" -> null
              - include_body = false -> null
              - lambda_arn   = "arn:aws:lambda:us-east-1:130871440101:function:cf_edge_lambda_response:128" -> null
            }
          + lambda_function_association {
              + event_type   = "origin-request"
              + include_body = false
              + lambda_arn   = (known after apply)
            }
          + lambda_function_association {
              + event_type   = "origin-response"
              + include_body = false
              + lambda_arn   = (known after apply)
            }
        }
      ~ ordered_cache_behavior {
            # (14 unchanged attributes hidden)

          - lambda_function_association {
              - event_type   = "origin-request" -> null
              - include_body = false -> null
              - lambda_arn   = "arn:aws:lambda:us-east-1:130871440101:function:cf_edge_lambda_request:130" -> null
            }
          - lambda_function_association {
              - event_type   = "origin-response" -> null
              - include_body = false -> null
              - lambda_arn   = "arn:aws:lambda:us-east-1:130871440101:function:cf_edge_lambda_response:128" -> null
            }
          + lambda_function_association {
              + event_type   = "origin-request"
              + include_body = false
              + lambda_arn   = (known after apply)
            }
          + lambda_function_association {
              + event_type   = "origin-response"
              + include_body = false
              + lambda_arn   = (known after apply)
            }
        }

        # (12 unchanged blocks hidden)
    }

Plan: 0 to add, 4 to change, 0 to destroy.

Changes to Outputs:
  ~ latest_edge_lambda_origin_request_version  = "130" -> (known after apply)
  ~ latest_edge_lambda_origin_response_version = "128" -> (known after apply)
```

## How to test

- [ ] Apply this change, run tests against the e2e environment - does it pass?

## How can we measure success?

We are no longer using an out of support version of Node.

## Have we considered potential risks?

Although you can no longer create new lambdas with node 12 in AWS, the versioned nature of the edge lambdas mean we should be able to safely roll back if we find issues in production that are missed by tests in the e2e environment.
