### PR TITLE
Wrap Manifest fetch in try/catch to get more details on error

### DIFF
--- a/content/webapp/services/iiif/fetch/manifest.ts
+++ b/content/webapp/services/iiif/fetch/manifest.ts
@@ -29,7 +29,10 @@ async function getIIIFManifest(url: string): Promise<Manifest | undefined> {
     const manifest = await resp.json();
     return manifest;
   } catch (e) {
-    console.error(`Something went wrong fetching ${url}`);
+    console.error(
+      `Something went wrong fetching ${url}` +
+        `${e.message ? `: ${e.message}` : ''}`
+    );
     throw e;
   }
 }

--- a/content/webapp/services/iiif/fetch/manifest.ts
+++ b/content/webapp/services/iiif/fetch/manifest.ts
@@ -1,32 +1,37 @@
 import { Manifest } from '@iiif/presentation-3';
 
 async function getIIIFManifest(url: string): Promise<Manifest | undefined> {
-  const resp = await fetch(url);
+  try {
+    const resp = await fetch(url);
 
-  if (resp.status === 404) {
-    const bnumber = url.match(/b[0-9]{7}[0-9x]/)?.[0];
+    if (resp.status === 404) {
+      const bnumber = url.match(/b[0-9]{7}[0-9x]/)?.[0];
 
-    // We have to add this condition because of a known issue with BD works and Archivemetica
-    // We don't want the error to be sent if it's part of the known issue.
-    // https://github.com/wellcomecollection/wellcomecollection.org/issues/10907
-    // TODO: Check in once in a while to see if it's been fixed. There is not ticket to link to currently for that piece of work.
+      // We have to add this condition because of a known issue with BD works and Archivemetica
+      // We don't want the error to be sent if it's part of the known issue.
+      // https://github.com/wellcomecollection/wellcomecollection.org/issues/10907
+      // TODO: Check in once in a while to see if it's been fixed. There is not ticket to link to currently for that piece of work.
 
-    // TEMP FIX: If location doesn't contain a B number, we assume that it is a Born Digital work.
-    // This works for now but won't in the future as more BD works come in
-    // TODO: Change how it's done once https://github.com/wellcomecollection/catalogue-pipeline/issues/2659 is through.
-    if (bnumber) {
-      const dashboardUrl = `https://iiif.wellcomecollection.org/dash/Manifestation/${bnumber}`;
+      // TEMP FIX: If location doesn't contain a B number, we assume that it is a Born Digital work.
+      // This works for now but won't in the future as more BD works come in
+      // TODO: Change how it's done once https://github.com/wellcomecollection/catalogue-pipeline/issues/2659 is through.
+      if (bnumber) {
+        const dashboardUrl = `https://iiif.wellcomecollection.org/dash/Manifestation/${bnumber}`;
 
-      throw new Error(
-        `Tried to retrieve IIIF Manifest at ${url}, but it's 404-ing. To fix, try running the "Rebuild IIIF" task in the iiif-builder dashboard. ${dashboardUrl}`
-      );
+        throw new Error(
+          `Tried to retrieve IIIF Manifest at ${url}, but it's 404-ing. To fix, try running the "Rebuild IIIF" task in the iiif-builder dashboard. ${dashboardUrl}`
+        );
+      }
+
+      return undefined;
     }
 
-    return undefined;
+    const manifest = await resp.json();
+    return manifest;
+  } catch (e) {
+    console.error(`Something went wrong fetching ${url}`);
+    throw e;
   }
-
-  const manifest = await resp.json();
-  return manifest;
 }
 
 export async function fetchIIIFPresentationManifest(


### PR DESCRIPTION
## What does this change?

Wrap the `fetch` in a try/catch. We're getting [a lot of errors in the #platform-alerts channel](https://wellcome.slack.com/archives/CQ720BG02/p1722324584987659) that seem related to this, so thinking this might give us more information.

## How to test

Are the tests passing?

## How can we measure success?

We get more information and can get to the bottom of what is causing the errors

## Have we considered potential risks?
No harm in adding this.