### PR TITLE
Exhibition Guides: Main landing page

### DIFF
--- a/common/views/components/PageHeader/PageHeader.tsx
+++ b/common/views/components/PageHeader/PageHeader.tsx
@@ -145,8 +145,12 @@ const PageHeader: FunctionComponent<Props> = ({
 
   const hasMedia = FeaturedMedia || HeroPicture;
   const amendedLabels = isFree ? addFreeLabel(labels) : labels;
+
+  // As <Breadcrumb> will automatically add "Home" as the first breadcrumb unless "noHomeLink" is true
+  // This checks whether or not there are actually any items.
   const hasBreadcrumbItems =
-    breadcrumbs.items.length > 0 && !breadcrumbs.noHomeLink;
+    breadcrumbs.items.length > 0 ||
+    !(breadcrumbs.items.length === 0 && breadcrumbs.noHomeLink);
 
   return (
     <>

--- a/common/views/components/PageHeader/PageHeader.tsx
+++ b/common/views/components/PageHeader/PageHeader.tsx
@@ -145,6 +145,8 @@ const PageHeader: FunctionComponent<Props> = ({
 
   const hasMedia = FeaturedMedia || HeroPicture;
   const amendedLabels = isFree ? addFreeLabel(labels) : labels;
+  const hasBreadcrumbItems =
+    breadcrumbs.items.length > 0 && !breadcrumbs.noHomeLink;
 
   return (
     <>
@@ -164,7 +166,7 @@ const PageHeader: FunctionComponent<Props> = ({
                   : ['margin-bottom', 'padding-bottom'],
             }}
           >
-            {!sectionLevelPage && (
+            {!sectionLevelPage && hasBreadcrumbItems && (
               // We need to keep some space below the breadcrumbs to prevent
               // 'highlighted' headings from being partially concealed
               <Space
@@ -178,7 +180,7 @@ const PageHeader: FunctionComponent<Props> = ({
               </Space>
             )}
             <ConditionalWrapper
-              condition={sectionLevelPage ?? false}
+              condition={sectionLevelPage || !hasBreadcrumbItems}
               wrapper={children => (
                 <Space $v={{ size: 'l', properties: ['margin-top'] }}>
                   {children}

--- a/content/webapp/components/ExhibitionGuideLinks/ExhibitionGuideLinks.tsx
+++ b/content/webapp/components/ExhibitionGuideLinks/ExhibitionGuideLinks.tsx
@@ -1,4 +1,3 @@
-import { setCookie } from 'cookies-next';
 import { FunctionComponent } from 'react';
 import {
   britishSignLanguage,
@@ -6,7 +5,6 @@ import {
   speechToText,
 } from '@weco/common/icons';
 import TypeOption, { TypeList } from './TypeOption';
-import cookies from '@weco/common/data/cookies';
 import { useToggles } from '@weco/common/server-data/Context';
 import SectionHeader from '@weco/content/components/SectionHeader/SectionHeader';
 import Space from '@weco/common/views/components/styled/Space';
@@ -19,17 +17,6 @@ type Props = {
     audioWithoutDescriptions: boolean;
   };
 };
-
-function cookieHandler(key: string, data: string) {
-  // We set the cookie to expire in 8 hours (the maximum length of
-  // time the galleries are open in a day)
-  const options = {
-    maxAge: 8 * 60 * 60,
-    path: '/',
-    secure: true,
-  };
-  setCookie(key, data, options);
-}
 
 export const ExhibitionGuideLinks: FunctionComponent<Props> = ({
   pathname,
@@ -60,13 +47,7 @@ export const ExhibitionGuideLinks: FunctionComponent<Props> = ({
                     text="Find out more about the exhibition with short audio tracks."
                     backgroundColor="accent.lightSalmon"
                     icon={audioDescribed}
-                    hasTranscripts
-                    onClick={() => {
-                      cookieHandler(
-                        cookies.exhibitionGuideType,
-                        'audio-without-descriptions'
-                      );
-                    }}
+                    type="audio-without-descriptions"
                   />
                 )}
                 {availableTypes.BSLVideo && (
@@ -76,10 +57,7 @@ export const ExhibitionGuideLinks: FunctionComponent<Props> = ({
                     text="Commentary about the exhibition in British Sign Language videos."
                     backgroundColor="accent.lightBlue"
                     icon={britishSignLanguage}
-                    hasTranscripts
-                    onClick={() => {
-                      cookieHandler(cookies.exhibitionGuideType, 'bsl');
-                    }}
+                    type="bsl"
                   />
                 )}
               </TypeList>
@@ -99,12 +77,7 @@ export const ExhibitionGuideLinks: FunctionComponent<Props> = ({
                   text="All the wall and label texts from the gallery, plus audio transcripts – great for those without headphones."
                   backgroundColor="accent.lightGreen"
                   icon={speechToText}
-                  onClick={() => {
-                    cookieHandler(
-                      cookies.exhibitionGuideType,
-                      'captions-and-transcripts'
-                    );
-                  }}
+                  type="captions-and-transcripts"
                 />
               </TypeList>
             </Space>
@@ -119,12 +92,7 @@ export const ExhibitionGuideLinks: FunctionComponent<Props> = ({
               text="Find out more about the exhibition with short audio tracks."
               backgroundColor="accent.lightSalmon"
               icon={audioDescribed}
-              onClick={() => {
-                cookieHandler(
-                  cookies.exhibitionGuideType,
-                  'audio-without-descriptions'
-                );
-              }}
+              type="audio-without-descriptions"
             />
           )}
           {availableTypes.captionsOrTranscripts && (
@@ -134,12 +102,7 @@ export const ExhibitionGuideLinks: FunctionComponent<Props> = ({
               text="All the wall and label texts from the gallery, plus audio transcripts – great for those without headphones."
               backgroundColor="accent.lightGreen"
               icon={speechToText}
-              onClick={() => {
-                cookieHandler(
-                  cookies.exhibitionGuideType,
-                  'captions-and-transcripts'
-                );
-              }}
+              type="captions-and-transcripts"
             />
           )}
           {availableTypes.BSLVideo && (
@@ -149,9 +112,7 @@ export const ExhibitionGuideLinks: FunctionComponent<Props> = ({
               text="Commentary about the exhibition in British Sign Language videos."
               backgroundColor="accent.lightBlue"
               icon={britishSignLanguage}
-              onClick={() => {
-                cookieHandler(cookies.exhibitionGuideType, 'bsl');
-              }}
+              type="bsl"
             />
           )}
         </TypeList>
@@ -195,13 +156,7 @@ export const ExhibitionResourceLinks: FunctionComponent<ResourceProps> = ({
                     text="Find out more about the exhibition with short audio tracks."
                     backgroundColor="accent.lightSalmon"
                     icon={audioDescribed}
-                    hasTranscripts
-                    onClick={() => {
-                      cookieHandler(
-                        cookies.exhibitionGuideType,
-                        'audio-without-descriptions'
-                      );
-                    }}
+                    type="audio-without-descriptions"
                   />
                 )}
                 {videoPathname && (
@@ -211,10 +166,7 @@ export const ExhibitionResourceLinks: FunctionComponent<ResourceProps> = ({
                     text="Commentary about the exhibition in British Sign Language videos."
                     backgroundColor="accent.lightBlue"
                     icon={britishSignLanguage}
-                    hasTranscripts
-                    onClick={() => {
-                      cookieHandler(cookies.exhibitionGuideType, 'bsl');
-                    }}
+                    type="bsl"
                   />
                 )}
               </TypeList>
@@ -233,12 +185,7 @@ export const ExhibitionResourceLinks: FunctionComponent<ResourceProps> = ({
                   text="All the wall and label texts from the gallery, plus audio transcripts – great for those without headphones."
                   backgroundColor="accent.lightGreen"
                   icon={speechToText}
-                  onClick={() => {
-                    cookieHandler(
-                      cookies.exhibitionGuideType,
-                      'captions-and-transcripts'
-                    );
-                  }}
+                  type="captions-and-transcripts"
                 />
               </TypeList>
             </>
@@ -253,12 +200,7 @@ export const ExhibitionResourceLinks: FunctionComponent<ResourceProps> = ({
               text="Find out more about the exhibition with short audio tracks."
               backgroundColor="accent.lightSalmon"
               icon={audioDescribed}
-              onClick={() => {
-                cookieHandler(
-                  cookies.exhibitionGuideType,
-                  'audio-without-descriptions'
-                );
-              }}
+              type="audio-without-descriptions"
             />
           )}
           {textPathname && (
@@ -268,12 +210,7 @@ export const ExhibitionResourceLinks: FunctionComponent<ResourceProps> = ({
               text="All the wall and label texts from the gallery, plus audio transcripts – great for those without headphones."
               backgroundColor="accent.lightGreen"
               icon={speechToText}
-              onClick={() => {
-                cookieHandler(
-                  cookies.exhibitionGuideType,
-                  'captions-and-transcripts'
-                );
-              }}
+              type="captions-and-transcripts"
             />
           )}
           {videoPathname && (
@@ -283,9 +220,7 @@ export const ExhibitionResourceLinks: FunctionComponent<ResourceProps> = ({
               text="Commentary about the exhibition in British Sign Language videos."
               backgroundColor="accent.lightBlue"
               icon={britishSignLanguage}
-              onClick={() => {
-                cookieHandler(cookies.exhibitionGuideType, 'bsl');
-              }}
+              type="bsl"
             />
           )}
         </TypeList>

--- a/content/webapp/components/ExhibitionGuideLinks/TypeOption.tsx
+++ b/content/webapp/components/ExhibitionGuideLinks/TypeOption.tsx
@@ -1,13 +1,17 @@
-import { FunctionComponent, SyntheticEvent } from 'react';
+import { setCookie } from 'cookies-next';
+import { FunctionComponent } from 'react';
+import styled from 'styled-components';
+import cookies from '@weco/common/data/cookies';
 import { IconSvg } from '@weco/common/icons/types';
 import { font } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
-import styled from 'styled-components';
 import { PaletteColor } from '@weco/common/views/themes/config';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import { plainListStyles } from '@weco/common/views/components/styled/PlainList';
 import { useToggles } from '@weco/common/server-data/Context';
-import { arrow, speechToText } from '@weco/common/icons';
+import { arrow } from '@weco/common/icons';
+import { RelevantIcons } from '@weco/content/pages/guides/exhibitions/[id]/[type]';
+import { ExhibitionGuideType } from '@weco/content/types/exhibition-guides';
 
 export const TypeList = styled(Space).attrs({
   $v: { size: 'l', properties: ['row-gap'] },
@@ -49,6 +53,18 @@ const TypeLink = styled.a<{
   }
 `;
 
+function cookieHandler(key: string, data: string) {
+  // We set the cookie to expire in 8 hours (the maximum length of
+  // time the galleries are open in a day)
+  const options = {
+    maxAge: 8 * 60 * 60,
+    path: '/',
+    secure: true,
+  };
+  setCookie(key, data, options);
+}
+
+// TODO Review how this can be streamlined when we move to the new EG models
 type Props = {
   url: string;
   title: string;
@@ -59,10 +75,8 @@ type Props = {
     | 'accent.lightGreen'
     | 'accent.lightPurple'
     | 'accent.lightBlue';
-
+  type: ExhibitionGuideType;
   icon?: IconSvg;
-  hasTranscripts?: boolean;
-  onClick?: (event: SyntheticEvent<HTMLAnchorElement>) => void;
 };
 
 const TypeOption: FunctionComponent<Props> = ({
@@ -71,10 +85,13 @@ const TypeOption: FunctionComponent<Props> = ({
   text,
   backgroundColor,
   icon,
-  hasTranscripts,
-  onClick,
+  type,
 }) => {
   const { egWork } = useToggles();
+
+  const onClick = () => {
+    cookieHandler(cookies.exhibitionGuideType, type as string);
+  };
 
   return egWork ? (
     <TypeItem $egWork={egWork}>
@@ -89,20 +106,9 @@ const TypeOption: FunctionComponent<Props> = ({
           $h={{ size: 'm', properties: ['padding-left', 'padding-right'] }}
         >
           <h2 className={font('wb', 3)}>{title}</h2>
-          {icon && (
-            <Icon icon={icon} sizeOverride="height: 32px; width: 32px;" />
-          )}
-          {hasTranscripts && (
-            <Space
-              $h={{ size: 's', properties: ['margin-left'] }}
-              style={{ display: 'inline' }}
-            >
-              <Icon
-                icon={speechToText}
-                sizeOverride="height: 32px; width: 32px;"
-              />
-            </Space>
-          )}
+
+          <RelevantIcons types={[type]} />
+
           <div style={{ position: 'absolute', bottom: '10px', right: '15px' }}>
             <Icon icon={arrow} sizeOverride="height: 32px; width: 32px;" />
           </div>

--- a/content/webapp/components/ExhibitionGuideLinks/TypeOption.tsx
+++ b/content/webapp/components/ExhibitionGuideLinks/TypeOption.tsx
@@ -10,7 +10,7 @@ import Icon from '@weco/common/views/components/Icon/Icon';
 import { plainListStyles } from '@weco/common/views/components/styled/PlainList';
 import { useToggles } from '@weco/common/server-data/Context';
 import { arrow } from '@weco/common/icons';
-import { RelevantIcons } from '@weco/content/pages/guides/exhibitions/[id]/[type]';
+import RelevantGuideIcons from '@weco/content/components/ExhibitionGuideRelevantIcons';
 import { ExhibitionGuideType } from '@weco/content/types/exhibition-guides';
 
 export const TypeList = styled(Space).attrs({
@@ -107,7 +107,7 @@ const TypeOption: FunctionComponent<Props> = ({
         >
           <h2 className={font('wb', 3)}>{title}</h2>
 
-          <RelevantIcons types={[type]} />
+          <RelevantGuideIcons types={[type]} />
 
           <div style={{ position: 'absolute', bottom: '10px', right: '15px' }}>
             <Icon icon={arrow} sizeOverride="height: 32px; width: 32px;" />

--- a/content/webapp/components/ExhibitionGuidePromo/ExhibitionGuidePromo.tsx
+++ b/content/webapp/components/ExhibitionGuidePromo/ExhibitionGuidePromo.tsx
@@ -1,17 +1,36 @@
 import { FunctionComponent } from 'react';
 import { font } from '@weco/common/utils/classnames';
-import { ExhibitionGuideBasic } from '@weco/content/types/exhibition-guides';
+import {
+  ExhibitionGuideBasic,
+  ExhibitionGuideType,
+} from '@weco/content/types/exhibition-guides';
 import Space from '@weco/common/views/components/styled/Space';
 import { CardOuter, CardBody, CardImageWrapper, CardTitle } from '../Card/Card';
 import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImage';
+import { useToggles } from '@weco/common/server-data/Context';
+import { RelevantIcons } from '@weco/content/pages/guides/exhibitions/[id]/[type]';
 
 type Props = {
   exhibitionGuide: ExhibitionGuideBasic;
 };
 
+const getAvailableTypes = availableTypes => {
+  const availableTypesArray: ExhibitionGuideType[] = [];
+
+  if (availableTypes.audioWithoutDescriptions)
+    availableTypesArray.push('audio-without-descriptions');
+  if (availableTypes.BSLVideo) availableTypesArray.push('bsl');
+  if (availableTypes.captionsOrTranscripts)
+    availableTypesArray.push('captions-and-transcripts');
+
+  return availableTypesArray;
+};
+
 const ExhibitionGuidePromo: FunctionComponent<Props> = ({
   exhibitionGuide,
 }) => {
+  const { egWork } = useToggles();
+
   return (
     <CardOuter
       data-component="ExhibitionGuidePromo"
@@ -49,6 +68,13 @@ const ExhibitionGuidePromo: FunctionComponent<Props> = ({
               <p className={font('intr', 5)} style={{ marginBottom: 0 }}>
                 {exhibitionGuide.promo.caption}
               </p>
+            </Space>
+          )}
+          {egWork && (
+            <Space $v={{ size: 'm', properties: ['margin-top'] }}>
+              <RelevantIcons
+                types={getAvailableTypes(exhibitionGuide.availableTypes)}
+              />
             </Space>
           )}
         </div>

--- a/content/webapp/components/ExhibitionGuidePromo/ExhibitionGuidePromo.tsx
+++ b/content/webapp/components/ExhibitionGuidePromo/ExhibitionGuidePromo.tsx
@@ -8,7 +8,7 @@ import Space from '@weco/common/views/components/styled/Space';
 import { CardOuter, CardBody, CardImageWrapper, CardTitle } from '../Card/Card';
 import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImage';
 import { useToggles } from '@weco/common/server-data/Context';
-import { RelevantIcons } from '@weco/content/pages/guides/exhibitions/[id]/[type]';
+import RelevantGuideIcons from '@weco/content/components/ExhibitionGuideRelevantIcons';
 
 type Props = {
   exhibitionGuide: ExhibitionGuideBasic;
@@ -72,7 +72,7 @@ const ExhibitionGuidePromo: FunctionComponent<Props> = ({
           )}
           {egWork && (
             <Space $v={{ size: 'm', properties: ['margin-top'] }}>
-              <RelevantIcons
+              <RelevantGuideIcons
                 types={getAvailableTypes(exhibitionGuide.availableTypes)}
               />
             </Space>

--- a/content/webapp/components/ExhibitionGuideRelevantIcons/index.tsx
+++ b/content/webapp/components/ExhibitionGuideRelevantIcons/index.tsx
@@ -1,0 +1,55 @@
+import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper/ConditionalWrapper';
+import Icon from '@weco/common/views/components/Icon/Icon';
+import {
+  audioDescribed,
+  britishSignLanguage,
+  speechToText,
+} from '@weco/common/icons';
+import Space from '@weco/common/views/components/styled/Space';
+import { ExhibitionGuideType } from '@weco/content/types/exhibition-guides';
+
+const RelevantGuideIcons = ({ types }: { types: ExhibitionGuideType[] }) => {
+  // The captions icon will be on every Guide moving forward
+  // We're ordering icons alphabetically
+  const sortedTypes = [
+    ...new Set([...types, 'captions-and-transcripts'].sort()),
+  ];
+
+  return (
+    <>
+      {sortedTypes.map((type, i) => {
+        const getIcon = () => {
+          switch (type) {
+            case 'bsl':
+              return britishSignLanguage;
+            case 'audio-without-descriptions':
+              return audioDescribed;
+            case 'captions-and-transcripts':
+              return speechToText;
+          }
+        };
+
+        const icon = getIcon();
+
+        return icon ? (
+          <ConditionalWrapper
+            key={type}
+            condition={i > 0}
+            wrapper={children => (
+              <Space
+                $h={{ size: 's', properties: ['margin-left'] }}
+                style={{ display: 'inline' }}
+              >
+                {children}
+              </Space>
+            )}
+          >
+            <Icon icon={icon} sizeOverride="height: 32px; width: 32px;" />
+          </ConditionalWrapper>
+        ) : undefined;
+      })}
+    </>
+  );
+};
+
+export default RelevantGuideIcons;

--- a/content/webapp/pages/guides/exhibitions/[id]/[type].tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/[type].tsx
@@ -50,12 +50,7 @@ import { components } from '@weco/common/views/slices';
 import { Container } from '@weco/common/views/components/styled/Container';
 import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
 import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper/ConditionalWrapper';
-import Icon from '@weco/common/views/components/Icon/Icon';
-import {
-  audioDescribed,
-  britishSignLanguage,
-  speechToText,
-} from '@weco/common/icons';
+import RelevantGuideIcons from '@weco/content/components/ExhibitionGuideRelevantIcons';
 
 const ButtonWrapper = styled(Space).attrs({
   $v: { size: 's', properties: ['margin-bottom'] },
@@ -103,50 +98,6 @@ function getTypeTitle(type: ExhibitionGuideType, egWork?: boolean): string {
       return 'Captions and transcripts';
   }
 }
-
-export const RelevantIcons = ({ types }: { types: ExhibitionGuideType[] }) => {
-  // The captions icon will be on every Guide moving forward
-  // We're ordering icons alphabetically
-  const sortedTypes = [
-    ...new Set([...types, 'captions-and-transcripts'].sort()),
-  ];
-
-  return (
-    <>
-      {sortedTypes.map((type, i) => {
-        const getIcon = () => {
-          switch (type) {
-            case 'bsl':
-              return britishSignLanguage;
-            case 'audio-without-descriptions':
-              return audioDescribed;
-            case 'captions-and-transcripts':
-              return speechToText;
-          }
-        };
-
-        const icon = getIcon();
-
-        return icon ? (
-          <ConditionalWrapper
-            key={type}
-            condition={i > 0}
-            wrapper={children => (
-              <Space
-                $h={{ size: 's', properties: ['margin-left'] }}
-                style={{ display: 'inline' }}
-              >
-                {children}
-              </Space>
-            )}
-          >
-            <Icon icon={icon} sizeOverride="height: 32px; width: 32px;" />
-          </ConditionalWrapper>
-        ) : undefined;
-      })}
-    </>
-  );
-};
 
 type Props = {
   exhibitionGuide: ExhibitionGuide | ExhibitionText | ExhibitionHighlightTour;
@@ -406,7 +357,7 @@ const ExhibitionGuidePage: FunctionComponent<Props> = props => {
           )}
 
           {egWork ? (
-            <RelevantIcons types={[type]} />
+            <RelevantGuideIcons types={[type]} />
           ) : (
             <>
               <ButtonWrapper>

--- a/content/webapp/pages/guides/exhibitions/[id]/[type].tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/[type].tsx
@@ -104,30 +104,46 @@ function getTypeTitle(type: ExhibitionGuideType, egWork?: boolean): string {
   }
 }
 
-const RelevantIcons = ({ type }: { type: ExhibitionGuideType }) => {
-  const hasMultiple = ['audio-without-descriptions', 'bsl'].includes(type);
+export const RelevantIcons = ({ types }: { types: ExhibitionGuideType[] }) => {
+  // The captions icon will be on every Guide moving forward
+  // We're ordering icons alphabetically
+  const sortedTypes = [
+    ...new Set([...types, 'captions-and-transcripts'].sort()),
+  ];
 
   return (
     <>
-      {hasMultiple && (
-        <Icon
-          icon={type === 'bsl' ? britishSignLanguage : audioDescribed}
-          sizeOverride="height: 32px; width: 32px;"
-        />
-      )}
-      <ConditionalWrapper
-        condition={hasMultiple}
-        wrapper={children => (
-          <Space
-            $h={{ size: 's', properties: ['margin-left'] }}
-            style={{ display: 'inline' }}
+      {sortedTypes.map((type, i) => {
+        const getIcon = () => {
+          switch (type) {
+            case 'bsl':
+              return britishSignLanguage;
+            case 'audio-without-descriptions':
+              return audioDescribed;
+            case 'captions-and-transcripts':
+              return speechToText;
+          }
+        };
+
+        const icon = getIcon();
+
+        return icon ? (
+          <ConditionalWrapper
+            key={type}
+            condition={i > 0}
+            wrapper={children => (
+              <Space
+                $h={{ size: 's', properties: ['margin-left'] }}
+                style={{ display: 'inline' }}
+              >
+                {children}
+              </Space>
+            )}
           >
-            {children}
-          </Space>
-        )}
-      >
-        <Icon icon={speechToText} sizeOverride="height: 32px; width: 32px;" />
-      </ConditionalWrapper>
+            <Icon icon={icon} sizeOverride="height: 32px; width: 32px;" />
+          </ConditionalWrapper>
+        ) : undefined;
+      })}
     </>
   );
 };
@@ -390,7 +406,7 @@ const ExhibitionGuidePage: FunctionComponent<Props> = props => {
           )}
 
           {egWork ? (
-            <RelevantIcons type={type} />
+            <RelevantIcons types={[type]} />
           ) : (
             <>
               <ButtonWrapper>

--- a/content/webapp/pages/guides/exhibitions/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/index.tsx
@@ -1,3 +1,5 @@
+import { FunctionComponent } from 'react';
+import { GetServerSideProps } from 'next';
 import { ExhibitionGuideBasic } from '@weco/content/types/exhibition-guides';
 import type { PaginatedResults } from '@weco/common/services/prismic/types';
 import { transformQuery } from '@weco/content/services/prismic/transformers/paginated-results';
@@ -15,8 +17,6 @@ import {
 } from '@weco/content/services/prismic/transformers/exhibition-texts';
 import { transformExhibitionHighlightTours } from '@weco/content/services/prismic/transformers/exhibition-highlight-tours';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
-import { FunctionComponent } from 'react';
-import { GetServerSideProps } from 'next';
 import { appError, AppErrorProps } from '@weco/common/services/app';
 import { serialiseProps } from '@weco/common/utils/json';
 import { getServerData } from '@weco/common/server-data';
@@ -28,6 +28,7 @@ import SpacingSection from '@weco/common/views/components/styled/SpacingSection'
 import LayoutPaginatedResults from '@weco/content/components/LayoutPaginatedResults/LayoutPaginatedResults';
 import { exhibitionGuidesLinks } from '@weco/common/views/components/Header/Header';
 import { setCacheControl } from '@weco/content/utils/setCacheControl';
+import { useToggles } from '@weco/common/server-data/Context';
 
 type Props = {
   exhibitionGuides: PaginatedResults<ExhibitionGuideBasic>;
@@ -172,11 +173,13 @@ export const getServerSideProps: GetServerSideProps<
 
 const ExhibitionGuidesPage: FunctionComponent<Props> = props => {
   const { exhibitionGuides } = props;
+  const { egWork } = useToggles();
+
   const image = exhibitionGuides.results[0]?.image;
 
   return (
     <PageLayout
-      title="Exhibition Guides"
+      title={egWork ? 'Digital Guides' : 'Exhibition Guides'}
       description={pageDescriptions.exhibitionGuides}
       url={{ pathname: '/guides/exhibitions' }}
       jsonLd={{ '@type': 'WebPage' }}
@@ -191,8 +194,9 @@ const ExhibitionGuidesPage: FunctionComponent<Props> = props => {
     >
       <SpacingSection>
         <LayoutPaginatedResults
-          title="Exhibition guides"
+          title={egWork ? 'Digital Guides' : 'Exhibition Guides'}
           paginatedResults={exhibitionGuides}
+          breadcrumbs={{ items: [], noHomeLink: egWork }}
         />
       </SpacingSection>
     </PageLayout>


### PR DESCRIPTION
## What does this change?

Relates to #11033 

I aimed to make separate commits that made sense, so you could review them one by one.

- Adjust `PageHeader` so that where there are no breadcrumbs (no items and no home link), there is still spacing above the title
- New component `RelevantGuideIcons` to render out the right icons in the landing page, the exhibition specific guide page and the guide pages themselves
- Style Landing page as per mockups, behind toggle
- Moved some things from `<TypeOption>` declaration to `TypeOption.tsx` itself (like the `onClick` function).

## How to test

Run locally, test with toggle and without to ensure the current versions stayed the same. 
Ensure cookie is being set.

## How can we measure success?

N/A - WIP

## Have we considered potential risks?

N/A

