### PR TITLE
Tests for ArchiveTree.ListItem with born digital items

### DIFF
--- a/playwright/test/helpers/contexts.ts
+++ b/playwright/test/helpers/contexts.ts
@@ -181,6 +181,21 @@ const workWithDigitalLocationAndLocationNote = async (
   await gotoWithoutCache(`${baseUrl}/works/a235xn8e`, page);
 };
 
+const workWithBornDigitalDownloads = async (
+  context: BrowserContext,
+  page: Page
+): Promise<void> => {
+  await context.addCookies(
+    requiredCookies.concat(
+      createCookie({
+        name: 'toggle_showBornDigital',
+        value: 'true',
+      })
+    )
+  );
+  await gotoWithoutCache(`${baseUrl}/works/htzhunbw`, page);
+};
+
 const newSearch = async (
   context: BrowserContext,
   page: Page,
@@ -276,6 +291,7 @@ export {
   workWithPhysicalLocationOnly,
   workWithDigitalLocationOnly,
   workWithDigitalLocationAndLocationNote,
+  workWithBornDigitalDownloads,
   itemWithOnlyOpenAccess,
   itemWithOnlyRestrictedAccess,
   itemWithRestrictedAndOpenAccess,

--- a/playwright/test/helpers/contexts.ts
+++ b/playwright/test/helpers/contexts.ts
@@ -188,7 +188,7 @@ const workWithBornDigitalDownloads = async (
   await context.addCookies(
     requiredCookies.concat(
       createCookie({
-        name: 'toggle_showBornDigital',
+        name: 'toggle_showBornDigital', // TODO: remove this when born digital work isn't behind a toggle anymore
         value: 'true',
       })
     )

--- a/playwright/test/work.test.ts
+++ b/playwright/test/work.test.ts
@@ -91,7 +91,7 @@ test.describe(`Scenario 1: a user wants to see relevant information about where 
   });
 });
 
-test.describe(`Scenario 2: A user downloading 'born digital' items`, () => {
+test.describe(`Scenario 2: A user viewing/downloading 'born digital' items`, () => {
   test(`ArchiveTree.ListItems stays open when inner item is clicked`, async ({
     page,
     context,

--- a/playwright/test/work.test.ts
+++ b/playwright/test/work.test.ts
@@ -3,6 +3,7 @@ import {
   workWithPhysicalLocationOnly,
   workWithDigitalLocationOnly,
   workWithDigitalLocationAndLocationNote,
+  isMobile,
   workWithBornDigitalDownloads,
 } from './helpers/contexts';
 import { Page } from 'playwright';
@@ -118,29 +119,32 @@ test.describe(`Scenario 2: A user viewing/downloading 'born digital' items`, () 
     page,
     context,
   }) => {
-    await workWithBornDigitalDownloads(context, page);
+    if (!isMobile(page)) {
+      await workWithBornDigitalDownloads(context, page);
 
-    await page
-      .getByRole('treeitem', {
-        name: 'objects',
-      })
-      .click();
+      await page
+        .getByRole('treeitem', {
+          name: 'objects',
+        })
+        .click();
 
-    await page
-      .getByRole('link', {
-        name: 'Download',
-      })
-      .first()
-      .click();
-    const dataLayer = await page.evaluate(() => window.dataLayer);
-    const clickEvent = dataLayer.find(
-      (item: { [x: string]: string }) =>
-        item?.['gtm.elementText'] === 'Download'
-    );
-    const gtmTriggers = clickEvent?.['gtm.triggers'].split(',');
-    const DOWNLOAD_TABLE_LINK_TRIGGER = '31009043_218'; // ID that is discoverable through GTM preview
-    expect(gtmTriggers).toEqual(
-      expect.arrayContaining([DOWNLOAD_TABLE_LINK_TRIGGER])
-    );
+      await page
+        .getByRole('link', {
+          name: 'Download',
+        })
+        .first()
+        .click();
+
+      const dataLayer = await page.evaluate(() => window.dataLayer);
+      const clickEvent = dataLayer.find(
+        (item: { [x: string]: string }) =>
+          item?.['gtm.elementText'] === 'Download'
+      );
+      const gtmTriggers = clickEvent?.['gtm.triggers'].split(',');
+      const DOWNLOAD_TABLE_LINK_TRIGGER = '31009043_218'; // ID that is discoverable through GTM preview
+      expect(gtmTriggers).toEqual(
+        expect.arrayContaining([DOWNLOAD_TABLE_LINK_TRIGGER])
+      );
+    }
   });
 });

--- a/playwright/test/work.test.ts
+++ b/playwright/test/work.test.ts
@@ -3,6 +3,7 @@ import {
   workWithPhysicalLocationOnly,
   workWithDigitalLocationOnly,
   workWithDigitalLocationAndLocationNote,
+  workWithBornDigitalDownloads,
 } from './helpers/contexts';
 import { Page } from 'playwright';
 
@@ -81,5 +82,29 @@ test.describe(`Scenario 1: a user wants to see relevant information about where 
     await workWithDigitalLocationAndLocationNote(context, page);
     const { whereToFindIt } = await getAllStates(page);
     await expect(whereToFindIt).toBeVisible();
+  });
+
+  test(`Download ArchiveTree.ListItems stays open when inner item is clicked`, async ({
+    page,
+    context,
+  }) => {
+    await workWithBornDigitalDownloads(context, page);
+    const innerTreeItem = page.getByRole('treeitem', {
+      name: 'A_Camels.psd vnd.adobe.photoshop 6.1 MB Download',
+    });
+
+    await expect(innerTreeItem).not.toBeVisible();
+
+    await page
+      .getByRole('treeitem', {
+        name: 'objects',
+      })
+      .click();
+
+    await expect(innerTreeItem).toBeVisible();
+
+    innerTreeItem.click();
+
+    await expect(innerTreeItem).toBeVisible();
   });
 });


### PR DESCRIPTION
## What does this change?

Adds two tests

1. To check that clicking on inner tree items doesn't close the tree
2. To check that the relevant GTM trigger (`download_table_link`) fires when a link is clicked

## How to test

`cd playwright && yarn test work.test.ts`