### PR TITLE
Add shouldFetchChildren prop to NestedList/ListItem

### DIFF
--- a/content/webapp/components/ArchiveTree/ArchiveTree.ListItem.tsx
+++ b/content/webapp/components/ArchiveTree/ArchiveTree.ListItem.tsx
@@ -105,6 +105,7 @@ type ListItemProps = ListProps & {
   setSize: number;
   posInSet: number;
   index: number;
+  shouldFetchChildren: boolean;
 };
 
 function getTabIndex({
@@ -140,6 +141,7 @@ const ListItem: FunctionComponent<ListItemProps> = ({
   firstItemTabbable,
   showFirstLevelGuideline,
   ItemRenderer,
+  shouldFetchChildren,
 }: ListItemProps) => {
   const { isEnhanced } = useContext(AppContext);
   const isEndNode = item.work.totalParts === 0;
@@ -166,7 +168,7 @@ const ListItem: FunctionComponent<ListItemProps> = ({
     (level > 1 || showFirstLevelGuideline);
 
   function toggleBranch() {
-    if (item.children === undefined) {
+    if (item.children === undefined && shouldFetchChildren) {
       expandTree({
         item,
         setArchiveTree,
@@ -333,6 +335,7 @@ const ListItem: FunctionComponent<ListItemProps> = ({
           firstItemTabbable={firstItemTabbable}
           showFirstLevelGuideline={showFirstLevelGuideline}
           ItemRenderer={ItemRenderer}
+          shouldFetchChildren={shouldFetchChildren}
         />
       )}
     </TreeItem>

--- a/content/webapp/components/ArchiveTree/ArchiveTree.NestedList.tsx
+++ b/content/webapp/components/ArchiveTree/ArchiveTree.NestedList.tsx
@@ -6,6 +6,7 @@ import { ListProps, UiTree } from './ArchiveTree.helpers';
 
 type NestedListProps = Omit<ListProps, 'item'> & {
   archiveTree: UiTree;
+  shouldFetchChildren: boolean;
 };
 
 const NestedList: FunctionComponent<NestedListProps> = ({
@@ -20,6 +21,7 @@ const NestedList: FunctionComponent<NestedListProps> = ({
   firstItemTabbable,
   showFirstLevelGuideline,
   ItemRenderer,
+  shouldFetchChildren,
 }: NestedListProps) => {
   const { isEnhanced } = useContext(AppContext);
   return (
@@ -51,6 +53,7 @@ const NestedList: FunctionComponent<NestedListProps> = ({
                 firstItemTabbable={firstItemTabbable}
                 showFirstLevelGuideline={showFirstLevelGuideline}
                 ItemRenderer={ItemRenderer}
+                shouldFetchChildren={shouldFetchChildren}
               />
             )
           );

--- a/content/webapp/components/ArchiveTree/index.tsx
+++ b/content/webapp/components/ArchiveTree/index.tsx
@@ -269,6 +269,7 @@ const ArchiveTree: FunctionComponent<{ work: Work }> = ({
                 firstItemTabbable={false}
                 showFirstLevelGuideline={false}
                 ItemRenderer={WorkItem}
+                shouldFetchChildren={true}
               />
             </Tree>
           </Modal>
@@ -295,6 +296,7 @@ const ArchiveTree: FunctionComponent<{ work: Work }> = ({
                 firstItemTabbable={false}
                 showFirstLevelGuideline={false}
                 ItemRenderer={WorkItem}
+                shouldFetchChildren={true}
               />
             </Tree>
           </Space>

--- a/content/webapp/components/WorkDetails/WorkDetails.AvailableOnline.tsx
+++ b/content/webapp/components/WorkDetails/WorkDetails.AvailableOnline.tsx
@@ -279,6 +279,7 @@ const WorkDetailsAvailableOnline = ({
                         firstItemTabbable={true}
                         showFirstLevelGuideline={true}
                         ItemRenderer={DownloadItemRenderer}
+                        shouldFetchChildren={false}
                       />
                     </Tree>
                   </TreeContainer>


### PR DESCRIPTION
For #11065

## What does this change?

Allows a consumer of `NestedList` (and by extension, `ArchiveList.TreeItem`) to decide whether clicks on the TreeItems should trigger a fetching of child items. It does this by adding a required boolean `shouldFetchChildren` prop.

I found I _could_ have tested for `ItemRenderer.name === 'DownloadItemRender'`, without the need for an additional prop with our current setup, but this felt a bit brittle and less clear as to what the intention was.

## How to test

1. Turn on the showBornDigital toggle
2. Open the 'objects' tree on http://localhost:3000/works/htzhunbw
3. Click on one of the revealed rows (not the 'download' link)
4. Check there aren't any XHR requests being made/erroring in the console

## How can we measure success?

We stop making unnecessary network requests

## Have we considered potential risks?

We have to remember to make the `shouldFetchChildren` prop to true to get the current behaviour (but the prop is required so don't think this shouldn't be a problem)

