### PR TITLE
Add Hotjar to Jason exhibition page

### DIFF
--- a/content/webapp/pages/exhibitions/[exhibitionId]/index.tsx
+++ b/content/webapp/pages/exhibitions/[exhibitionId]/index.tsx
@@ -22,6 +22,8 @@ import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 import { cacheTTL, setCacheControl } from '@weco/content/utils/setCacheControl';
 import linkResolver from '@weco/common/services/prismic/link-resolver';
 import { Link } from '@weco/content/types/link';
+import useHotjar from '@weco/content/hooks/useHotjar';
+
 import {
   visualStoryLinkText,
   exhibitionGuideLinkText,
@@ -47,30 +49,35 @@ const ExhibitionPage: FunctionComponent<ExhibitionProps> = ({
   pages,
   accessResourceLinks,
   jsonLd,
-}) => (
-  <PageLayout
-    title={exhibition.title}
-    description={
-      exhibition.metadataDescription || exhibition.promo?.caption || ''
-    }
-    url={{ pathname: `/exhibitions/${exhibition.id}` }}
-    jsonLd={jsonLd}
-    openGraphType="website"
-    siteSection="whats-on"
-    image={exhibition.image}
-    apiToolbarLinks={[createPrismicLink(exhibition.id)]}
-  >
-    {exhibition.format && exhibition.format.title === 'Installation' ? (
-      <Installation installation={exhibition} />
-    ) : (
-      <Exhibition
-        exhibition={exhibition}
-        pages={pages}
-        accessResourceLinks={accessResourceLinks}
-      />
-    )}
-  </PageLayout>
-);
+}) => {
+  useHotjar(true);
+  console.log('yo');
+
+  return (
+    <PageLayout
+      title={exhibition.title}
+      description={
+        exhibition.metadataDescription || exhibition.promo?.caption || ''
+      }
+      url={{ pathname: `/exhibitions/${exhibition.id}` }}
+      jsonLd={jsonLd}
+      openGraphType="website"
+      siteSection="whats-on"
+      image={exhibition.image}
+      apiToolbarLinks={[createPrismicLink(exhibition.id)]}
+    >
+      {exhibition.format && exhibition.format.title === 'Installation' ? (
+        <Installation installation={exhibition} />
+      ) : (
+        <Exhibition
+          exhibition={exhibition}
+          pages={pages}
+          accessResourceLinks={accessResourceLinks}
+        />
+      )}
+    </PageLayout>
+  );
+};
 
 export const getServerSideProps: GetServerSideProps<
   ExhibitionProps | AppErrorProps

--- a/content/webapp/pages/exhibitions/[exhibitionId]/index.tsx
+++ b/content/webapp/pages/exhibitions/[exhibitionId]/index.tsx
@@ -50,8 +50,7 @@ const ExhibitionPage: FunctionComponent<ExhibitionProps> = ({
   accessResourceLinks,
   jsonLd,
 }) => {
-  useHotjar(true);
-  console.log('yo');
+  useHotjar(exhibition.id === 'ZZP8BxAAALeD00jo'); // Only on Jason and the Adventure of 254
 
   return (
     <PageLayout


### PR DESCRIPTION
For #11078

## What does this change?

Loads the Hotjar script on the [Jason exhibition page](https://wellcomecollection.org/exhibitions/ZZP8BxAAALeD00jo)

## How to test

- Visit the Jason exhibition page and see the hotjar script being added in the network panel
- Visit a different exhibition and see that the script isn't being added there


## How can we measure success?

We get heatmap data showing up in Hotjar (I've set this up [here](https://insights.hotjar.com/sites/3858/heatmap/view?url=https%3A%2F%2Fwellcomecollection.org%2Fexhibitions%2FZZP8BxAAALeD00jo&match=simple_match&device=desktop&type=click&overlays=top_clicked_elements&filters=%7B%7D&date=%7B%22DAYS_AGO%22%3A%7B%22created%22%3A30%7D%7D))

## Have we considered potential risks?

Can't think of any
