### PR TITLE
EG: Small visual changes from initial chat with Kasia

### DIFF
--- a/common/views/components/PageHeader/PageHeader.tsx
+++ b/common/views/components/PageHeader/PageHeader.tsx
@@ -157,7 +157,7 @@ const PageHeader: FunctionComponent<Props> = ({
         >
           <Wrapper
             $v={{
-              size: isSlim ? 'm' : 'l',
+              size: isSlim ? 'xs' : 'l',
               properties:
                 isContentTypeInfoBeforeMedia || hasMedia || sectionLevelPage
                   ? ['margin-bottom']

--- a/content/webapp/components/ExhibitionGuidePromo/ExhibitionGuidePromo.tsx
+++ b/content/webapp/components/ExhibitionGuidePromo/ExhibitionGuidePromo.tsx
@@ -71,7 +71,13 @@ const ExhibitionGuidePromo: FunctionComponent<Props> = ({
             </Space>
           )}
           {egWork && (
-            <Space $v={{ size: 'm', properties: ['margin-top'] }}>
+            <Space
+              $v={{
+                size: 'l',
+                properties: ['margin-top'],
+                overrides: { small: 4, medium: 4, large: 5 },
+              }}
+            >
               <RelevantGuideIcons
                 types={getAvailableTypes(exhibitionGuide.availableTypes)}
               />

--- a/content/webapp/pages/guides/exhibitions/[id]/[type].tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/[type].tsx
@@ -100,7 +100,7 @@ function getTypeTitle(type: ExhibitionGuideType, egWork?: boolean): string {
     case 'audio-without-descriptions':
       return egWork ? 'Audio highlight tour with transcripts' : 'Audio';
     case 'captions-and-transcripts':
-      return 'Captions and transcripts';
+      return egWork ? 'Exhibition text' : 'Captions and transcripts';
   }
 }
 

--- a/content/webapp/pages/guides/exhibitions/[id]/[type].tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/[type].tsx
@@ -373,7 +373,7 @@ const ExhibitionGuidePage: FunctionComponent<Props> = props => {
 
         <Layout gridSizes={gridSize8(false)}>
           {egWork ? (
-            <h2 className={font('wb', 3)}>{getTypeTitle(type, egWork)}</h2>
+            <h2 className={font('intsb', 3)}>{getTypeTitle(type, egWork)}</h2>
           ) : (
             <h1 className={font('wb', 1)}>
               {exhibitionGuide.title}{' '}


### PR DESCRIPTION
## What does this change?

Minor style tweaks after initial chat:
- Make spacing smaller between title and subheading
- Change "captions and transcripts" subheading to "Exhibition text" behind toggle. The URL probably still needs to be updated, but as discussed with @LaurenFBaily it'll wait.
- Change subheading font as per #11081
- Adjusted spacing between text and icons on cards - done live on a share screen with Kasia.

## How to test

Run locally and admire.

## How can we measure success?

N/A

## Have we considered potential risks?
N/A
