### PR TITLE
Tweak icon alignment on Exhibition Guide cards

### DIFF
--- a/content/webapp/components/ExhibitionGuideLinks/TypeOption.tsx
+++ b/content/webapp/components/ExhibitionGuideLinks/TypeOption.tsx
@@ -53,6 +53,12 @@ const TypeLink = styled.a<{
   }
 `;
 
+const TypeIconsWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+`;
+
 function cookieHandler(key: string, data: string) {
   // We set the cookie to expire in 8 hours (the maximum length of
   // time the galleries are open in a day)
@@ -107,11 +113,11 @@ const TypeOption: FunctionComponent<Props> = ({
         >
           <h2 className={font('wb', 3)}>{title}</h2>
 
-          <RelevantGuideIcons types={[type]} />
+          <TypeIconsWrapper>
+            <RelevantGuideIcons types={[type]} />
 
-          <div style={{ position: 'absolute', bottom: '10px', right: '15px' }}>
             <Icon icon={arrow} sizeOverride="height: 32px; width: 32px;" />
-          </div>
+          </TypeIconsWrapper>
         </Space>
       </TypeLink>
     </TypeItem>

--- a/content/webapp/components/ExhibitionGuideLinksPromo/ExhibitionGuideLinksPromo.tsx
+++ b/content/webapp/components/ExhibitionGuideLinksPromo/ExhibitionGuideLinksPromo.tsx
@@ -21,14 +21,6 @@ const ExhibitionTitleLink = styled.a`
   text-decoration: none;
 `;
 
-const TypeListItem = ({ url, text }) => {
-  return (
-    <Type>
-      <a href={url}>{text}</a>
-    </Type>
-  );
-};
-
 type Props = {
   exhibitionGuide: ExhibitionGuideBasic;
 };
@@ -88,10 +80,7 @@ const ExhibitionGuideLinksPromo: FunctionComponent<Props> = ({
         )}
 
         <Space
-          $v={{
-            size: 'm',
-            properties: ['margin-top', 'margin-bottom'],
-          }}
+          $v={{ size: 'm', properties: ['margin-top', 'margin-bottom'] }}
           as="h3"
           className={font('wb', 3)}
         >
@@ -101,7 +90,9 @@ const ExhibitionGuideLinksPromo: FunctionComponent<Props> = ({
       <Space $v={{ size: 's', properties: ['margin-top'] }}>
         <PlainList className={font('intr', 5)}>
           {links.map((link, i) => (
-            <TypeListItem key={i} url={link.url} text={link.text} />
+            <Type key={i}>
+              <a href={link.url}>{link.text}</a>
+            </Type>
           ))}
         </PlainList>
       </Space>

--- a/content/webapp/components/ExhibitionGuideRelevantIcons/index.tsx
+++ b/content/webapp/components/ExhibitionGuideRelevantIcons/index.tsx
@@ -1,3 +1,4 @@
+import styled from 'styled-components';
 import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper/ConditionalWrapper';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import {
@@ -8,6 +9,12 @@ import {
 import Space from '@weco/common/views/components/styled/Space';
 import { ExhibitionGuideType } from '@weco/content/types/exhibition-guides';
 
+// Gets rid of unwanted vertical spacing
+const IconsWrapper = styled.div`
+  line-height: 1;
+  font-size: 0;
+`;
+
 const RelevantGuideIcons = ({ types }: { types: ExhibitionGuideType[] }) => {
   // The captions icon will be on every Guide moving forward
   // We're ordering icons alphabetically
@@ -16,7 +23,7 @@ const RelevantGuideIcons = ({ types }: { types: ExhibitionGuideType[] }) => {
   ];
 
   return (
-    <>
+    <IconsWrapper>
       {sortedTypes.map((type, i) => {
         const getIcon = () => {
           switch (type) {
@@ -48,7 +55,7 @@ const RelevantGuideIcons = ({ types }: { types: ExhibitionGuideType[] }) => {
           </ConditionalWrapper>
         ) : undefined;
       })}
-    </>
+    </IconsWrapper>
   );
 };
 


### PR DESCRIPTION
## What does this change?

Changes made based on [Kasia's comment](https://github.com/wellcomecollection/wellcomecollection.org/issues/11033#issuecomment-2262921790) in #11033 to better align BSL/AD/TEXT icons with arrow.

Before
<img width="1033" alt="Screenshot 2024-08-01 at 15 31 54" src="https://github.com/user-attachments/assets/3f19293d-09ea-4530-9c30-4023c83cfebd">

After
<img width="1061" alt="Screenshot 2024-08-01 at 15 31 31" src="https://github.com/user-attachments/assets/b4fcc4f7-855d-409c-b12a-67b67d25beba">



## How to test

Compare with [designs](https://www.figma.com/design/YY8hrWmKYhLm8ZQeYaKiLm/Exhibition-guides?node-id=1333-2854&t=sM1uvCzEWBLfeSBl-0)
## How can we measure success?

N/A


## Have we considered potential risks?

N/A

