### PR TITLE
EG GuideStop image, audio transcript, and video subtitles fields

### DIFF
--- a/common/prismicio-types.d.ts
+++ b/common/prismicio-types.d.ts
@@ -6405,10 +6405,10 @@ export interface GuideStopSliceDefaultPrimary {
   bsl_video: prismic.EmbedField;
 
   /**
-   * Transcript field in *GuideStop → Primary*
+   * Audio transcript field in *GuideStop → Primary*
    *
    * - **Field Type**: Rich Text
-   * - **Placeholder**: *None*
+   * - **Placeholder**: Transcript of the audio file
    * - **API ID Path**: guide_stop.primary.transcript
    * - **Documentation**: https://prismic.io/docs/field#rich-text-title
    */
@@ -6423,6 +6423,16 @@ export interface GuideStopSliceDefaultPrimary {
    * - **Documentation**: https://prismic.io/docs/field#image
    */
   image: prismic.ImageField<'32:15' | '16:9' | 'square'>;
+
+  /**
+   * Video subtitles field in *GuideStop → Primary*
+   *
+   * - **Field Type**: Rich Text
+   * - **Placeholder**: Transcript of the BSL video
+   * - **API ID Path**: guide_stop.primary.subtitles
+   * - **Documentation**: https://prismic.io/docs/field#rich-text-title
+   */
+  subtitles: prismic.RichTextField;
 }
 
 /**

--- a/common/prismicio-types.d.ts
+++ b/common/prismicio-types.d.ts
@@ -6395,16 +6395,6 @@ export interface GuideStopSliceDefaultPrimary {
   audio_with_description: prismic.LinkToMediaField;
 
   /**
-   * BSL video (Youtube) field in *GuideStop → Primary*
-   *
-   * - **Field Type**: Embed
-   * - **Placeholder**: *None*
-   * - **API ID Path**: guide_stop.primary.bsl_video
-   * - **Documentation**: https://prismic.io/docs/field#embed
-   */
-  bsl_video: prismic.EmbedField;
-
-  /**
    * Audio transcript field in *GuideStop → Primary*
    *
    * - **Field Type**: Rich Text
@@ -6415,14 +6405,14 @@ export interface GuideStopSliceDefaultPrimary {
   transcript: prismic.RichTextField;
 
   /**
-   * Image field in *GuideStop → Primary*
+   * BSL video (Youtube) field in *GuideStop → Primary*
    *
-   * - **Field Type**: Image
+   * - **Field Type**: Embed
    * - **Placeholder**: *None*
-   * - **API ID Path**: guide_stop.primary.image
-   * - **Documentation**: https://prismic.io/docs/field#image
+   * - **API ID Path**: guide_stop.primary.bsl_video
+   * - **Documentation**: https://prismic.io/docs/field#embed
    */
-  image: prismic.ImageField<'32:15' | '16:9' | 'square'>;
+  bsl_video: prismic.EmbedField;
 
   /**
    * Video subtitles field in *GuideStop → Primary*
@@ -6433,6 +6423,16 @@ export interface GuideStopSliceDefaultPrimary {
    * - **Documentation**: https://prismic.io/docs/field#rich-text-title
    */
   subtitles: prismic.RichTextField;
+
+  /**
+   * Image field in *GuideStop → Primary*
+   *
+   * - **Field Type**: Image
+   * - **Placeholder**: *None*
+   * - **API ID Path**: guide_stop.primary.image
+   * - **Documentation**: https://prismic.io/docs/field#image
+   */
+  image: prismic.ImageField<'32:15' | '16:9' | 'square'>;
 }
 
 /**

--- a/common/prismicio-types.d.ts
+++ b/common/prismicio-types.d.ts
@@ -6413,6 +6413,16 @@ export interface GuideStopSliceDefaultPrimary {
    * - **Documentation**: https://prismic.io/docs/field#rich-text-title
    */
   transcript: prismic.RichTextField;
+
+  /**
+   * Image field in *GuideStop → Primary*
+   *
+   * - **Field Type**: Image
+   * - **Placeholder**: *None*
+   * - **API ID Path**: guide_stop.primary.image
+   * - **Documentation**: https://prismic.io/docs/field#image
+   */
+  image: prismic.ImageField<'32:15' | '16:9' | 'square'>;
 }
 
 /**

--- a/common/views/slices/GuideStop/model.json
+++ b/common/views/slices/GuideStop/model.json
@@ -46,8 +46,8 @@
         "transcript": {
           "type": "StructuredText",
           "config": {
-            "label": "Transcript",
-            "placeholder": "",
+            "label": "Audio transcript",
+            "placeholder": "Transcript of the audio file",
             "allowTargetBlank": true,
             "multi": "paragraph,strong,em,hyperlink"
           }
@@ -73,6 +73,15 @@
                 "height": 3200
               }
             ]
+          }
+        },
+        "subtitles": {
+          "type": "StructuredText",
+          "config": {
+            "label": "Video subtitles",
+            "placeholder": "Transcript of the BSL video",
+            "allowTargetBlank": true,
+            "multi": "paragraph,strong,em,hyperlink"
           }
         }
       },

--- a/common/views/slices/GuideStop/model.json
+++ b/common/views/slices/GuideStop/model.json
@@ -51,6 +51,29 @@
             "allowTargetBlank": true,
             "multi": "paragraph,strong,em,hyperlink"
           }
+        },
+        "image": {
+          "type": "Image",
+          "config": {
+            "label": "Image",
+            "thumbnails": [
+              {
+                "name": "32:15",
+                "width": 3200,
+                "height": 1500
+              },
+              {
+                "name": "16:9",
+                "width": 3200,
+                "height": 1800
+              },
+              {
+                "name": "square",
+                "width": 3200,
+                "height": 3200
+              }
+            ]
+          }
         }
       },
       "items": {}

--- a/common/views/slices/GuideStop/model.json
+++ b/common/views/slices/GuideStop/model.json
@@ -36,6 +36,15 @@
             "select": "media"
           }
         },
+        "transcript": {
+          "type": "StructuredText",
+          "config": {
+            "label": "Audio transcript",
+            "placeholder": "Transcript of the audio file",
+            "allowTargetBlank": true,
+            "multi": "paragraph,strong,em,hyperlink"
+          }
+        },
         "bsl_video": {
           "type": "Embed",
           "config": {
@@ -43,11 +52,11 @@
             "placeholder": ""
           }
         },
-        "transcript": {
+        "subtitles": {
           "type": "StructuredText",
           "config": {
-            "label": "Audio transcript",
-            "placeholder": "Transcript of the audio file",
+            "label": "Video subtitles",
+            "placeholder": "Transcript of the BSL video",
             "allowTargetBlank": true,
             "multi": "paragraph,strong,em,hyperlink"
           }
@@ -73,15 +82,6 @@
                 "height": 3200
               }
             ]
-          }
-        },
-        "subtitles": {
-          "type": "StructuredText",
-          "config": {
-            "label": "Video subtitles",
-            "placeholder": "Transcript of the BSL video",
-            "allowTargetBlank": true,
-            "multi": "paragraph,strong,em,hyperlink"
           }
         }
       },


### PR DESCRIPTION
## What does this change?

- Adds an image field to the GuideStop slice (for #11042)
- Adds a Video subtitles field to the GuideStop slice (part of #11038)
- Changes existing 'transcript' label to 'Audio transcript' (api ID remains as `transcript`)

<img width="794" alt="Screenshot 2024-08-01 at 16 03 00" src="https://github.com/user-attachments/assets/e590d77e-e31f-45ef-9f91-35bed6d4345e">


## How to test

We don't have any published Exhibition highlight tour documents yet so don't think there's anything to test

## How can we measure success?

Let's us create frontend EG journeys

## Have we considered potential risks?

Naming of fields could have been confusing – hopefully the labels/placeholders and orderings of them provide enough clarity for use
