### PR TITLE
commenting out test until Prismic fixes the underlying issue

### DIFF
--- a/playwright/test/article.test.ts
+++ b/playwright/test/article.test.ts
@@ -66,19 +66,20 @@ test('(4) | No related story is shown for an article in a serial with only one s
   ).toHaveCount(0);
 });
 
+// 2024-08-02 - commenting out this test until Prismic permanently fixes the issue
 // See https://github.com/wellcomecollection/wellcomecollection.org/issues/7641
-test('(5) | Articles use the 32:15 crop for their social media preview', async ({
-  page,
-  context,
-}) => {
-  await article('Yd8L-hAAAIAWFxqa', context, page);
+// test('(5) | Articles use the 32:15 crop for their social media preview', async ({
+//   page,
+//   context,
+// }) => {
+//   await article('Yd8L-hAAAIAWFxqa', context, page);
 
-  const metaTag = await page.locator('meta[name="twitter:image"]');
+//   const metaTag = await page.locator('meta[name="twitter:image"]');
 
-  await expect(metaTag).toHaveAttribute(
-    'content',
+//   await expect(metaTag).toHaveAttribute(
+//     'content',
     // TODO amend expected result once image issue is fixed
     // https://github.com/wellcomecollection/wellcomecollection.org/issues/10853
-    'https://images.prismic.io/wellcomecollection/2a42de1c-7954-4ece-be5f-775079c4bc54_Lauren+seated+outside.jpg?auto=format%2Ccompress&rect=&w=800&h='
-  );
-});
+    // 'https://images.prismic.io/wellcomecollection/2a42de1c-7954-4ece-be5f-775079c4bc54_Lauren+seated+outside.jpg?auto=format%2Ccompress&rect=&w=800&h='
+  // );
+// });


### PR DESCRIPTION
## What does this change?

There is a known Prismic issue with crops that they're in the process of fixing
https://github.com/wellcomecollection/wellcomecollection.org/issues/10853
In the meantime, the `expected` is not reliable enough and makes this test flaky
See https://wellcome.slack.com/archives/CUA669WHH/p1722527788912479

## How to test

Run the tests, they pass and this one is skipped

## How can we measure success?

Catalogue-api can be deployed (it runs the e2e tests)

## Have we considered potential risks?

Experience team are aware of the issue and keeping in touch with Prismic
A ticket has been created as a reminder to reinstate the test when Prismic has fixed 
https://github.com/orgs/wellcomecollection/projects/18/views/1#

