### PR TITLE
Fix alignment of TypeOption cards

### DIFF
--- a/content/webapp/components/ExhibitionGuideLinks/TypeOption.tsx
+++ b/content/webapp/components/ExhibitionGuideLinks/TypeOption.tsx
@@ -53,6 +53,16 @@ const TypeLink = styled.a<{
   }
 `;
 
+const Wrapper = styled(Space).attrs({
+  $v: { size: 'm', properties: ['padding-top', 'padding-bottom'] },
+  $h: { size: 'm', properties: ['padding-left', 'padding-right'] },
+})`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+`;
+
 const TypeIconsWrapper = styled.div`
   display: flex;
   justify-content: space-between;
@@ -107,10 +117,7 @@ const TypeOption: FunctionComponent<Props> = ({
         $egWork
         onClick={onClick}
       >
-        <Space
-          $v={{ size: 'm', properties: ['padding-top', 'padding-bottom'] }}
-          $h={{ size: 'm', properties: ['padding-left', 'padding-right'] }}
-        >
+        <Wrapper>
           <h2 className={font('wb', 3)}>{title}</h2>
 
           <TypeIconsWrapper>
@@ -118,7 +125,7 @@ const TypeOption: FunctionComponent<Props> = ({
 
             <Icon icon={arrow} sizeOverride="height: 32px; width: 32px;" />
           </TypeIconsWrapper>
-        </Space>
+        </Wrapper>
       </TypeLink>
     </TypeItem>
   ) : (


### PR DESCRIPTION
## What does this change?

As part of #11033, I merged #11083 without realising that on bigger desktop screens, the alignment was off: 

**Before**
<img width="1099" alt="Screenshot 2024-08-05 at 09 55 26" src="https://github.com/user-attachments/assets/7680fc50-655c-48eb-ba67-4a938002b142">

**After**
<img width="1107" alt="Screenshot 2024-08-05 at 09 55 20" src="https://github.com/user-attachments/assets/c94c6231-77ac-44ba-90f5-2bb0468f7454">

I'm aware I might be taking a hammer to the fix, my brain still tends to think in `flex`, so do let me know if there's a nicer way to do this.

## How to test

Run locally

## How can we measure success?

Kasia's happy!

## Have we considered potential risks?
N/A