### PR TITLE
Prismic Linting: Move from `docker-compose` (v1) to `docker compose` (v2) 

### DIFF
--- a/.github/workflows/prismic-linting.yml
+++ b/.github/workflows/prismic-linting.yml
@@ -3,6 +3,10 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 4 * * MON-FRI'
+  # Remove before merge
+  push:
+    branches:
+      - docker-compose-ci
 
 permissions:
   id-token: write
@@ -22,4 +26,4 @@ jobs:
         with:
           registry-type: public
       - name: Run Prismic linting
-        run: docker-compose run prismic_model yarn lintPrismicData
+        run: docker compose run prismic_model yarn lintPrismicData

--- a/.github/workflows/prismic-linting.yml
+++ b/.github/workflows/prismic-linting.yml
@@ -3,10 +3,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 4 * * MON-FRI'
-  # Remove before merge
-  push:
-    branches:
-      - docker-compose-ci
 
 permissions:
   id-token: write

--- a/README.md
+++ b/README.md
@@ -123,11 +123,11 @@ services:
 
 You will need to add a `command`, `volumes` and `environment` block to specify the required command and mount your AWS credentials in the running container.
 
-You can then run `docker compose` commands as would occur in the CI environment.
+You can then run `docker-compose` commands as would occur in the CI environment.
 
 ```shell script
-docker compose edge_lambdas build
-docker compose edge_lambdas run
+docker-compose edge_lambdas build
+docker-compose edge_lambdas run
 ```
 
 ## Linting

--- a/README.md
+++ b/README.md
@@ -123,11 +123,11 @@ services:
 
 You will need to add a `command`, `volumes` and `environment` block to specify the required command and mount your AWS credentials in the running container.
 
-You can then run `docker-compose` commands as would occur in the CI environment.
+You can then run `docker compose` commands as would occur in the CI environment.
 
 ```shell script
-docker-compose edge_lambdas build
-docker-compose edge_lambdas run
+docker compose edge_lambdas build
+docker compose edge_lambdas run
 ```
 
 ## Linting


### PR DESCRIPTION
## What does this change?

Prismic linting action [was repeatedly failing](https://github.com/wellcomecollection/wellcomecollection.org/actions/runs/10242411617) and [I reached out on Slack](https://wellcome.slack.com/archives/C3TQSF63C/p1722849702140089) to figure out why. @StepanBrychta sent this thread our way and explained the fix:

https://github.com/orgs/community/discussions/116610#discussioncomment-10239694

> [...] the latest Ubuntu release (ubuntu-latest) in [Ubuntu 22.04 (20240730) Image Update](https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20240730.2) removed Docker Compose v1 support as announced in [GitHub's blog post](https://github.blog/changelog/2024-04-10-github-hosted-runner-images-deprecation-notice-docker-compose-v1/). The relevant issue is here: https://github.com/actions/runner-images/issues/9557
To fix this, you will need to [migrate to Docker Compose v2](https://docs.docker.com/compose/migrate/). As previously mentioned this means changing from `docker-compose` to `docker compose`.

I then tested the action [straight from the PR](https://github.com/wellcomecollection/wellcomecollection.org/pull/11088/commits/95b69e33801290e8f79222a985b1320936d19536#diff-1a8ca66e7639b1b598421b89252088e2f12e65ce092400dde398dbb2cb8d161aR6) and [it succeeded](https://github.com/wellcomecollection/wellcomecollection.org/actions/runs/10246474692). 

I wondered if any READMEs needed updating but I think they're all still valid as is, do correct me if not.

## How to test

Follow the links above to see tests

## How can we measure success?

Prismic linting doesn't fail tomorrow morning

## Have we considered potential risks?
Worst case it fails again but it's already failing so 🤷‍♀️ 

