### PR TITLE
GitHub action slack

### DIFF
--- a/.github/workflows/prismic-linting.yml
+++ b/.github/workflows/prismic-linting.yml
@@ -44,6 +44,7 @@ jobs:
           {
             "action_name": "Prismic linting action",
             "message": "Action has ${{ needs.prismic_linting.result }}"
+            "link": "https://github.com/wellcomecollection/wellcomecollection.org/actions/workflows/prismic-linting.yml"
           }
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/prismic-linting.yml
+++ b/.github/workflows/prismic-linting.yml
@@ -3,10 +3,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 4 * * MON-FRI'
-  # Remove before merge
-  push:
-    branches:
-      - github-action-slack
 
 permissions:
   id-token: write
@@ -15,20 +11,18 @@ jobs:
   prismic_linting:
     runs-on: ubuntu-latest
     steps:
-      - name: failing step
-        run: exit 1
-      # - uses: actions/checkout@v4
-      # - uses: aws-actions/configure-aws-credentials@v4
-      #   with:
-      #     aws-region: eu-west-1
-      #     role-to-assume: ${{ secrets.EXPERIENCE_GHA_ROLE_ARN }}
-      # - uses: aws-actions/amazon-ecr-login@v2
-      #   env:
-      #     AWS_REGION: us-east-1
-      #   with:
-      #     registry-type: public
-      # - name: Run Prismic linting
-      #   run: docker compose run prismic_model yarn lintPrismicData
+      - uses: actions/checkout@v4
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: eu-west-1
+          role-to-assume: ${{ secrets.EXPERIENCE_GHA_ROLE_ARN }}
+      - uses: aws-actions/amazon-ecr-login@v2
+        env:
+          AWS_REGION: us-east-1
+        with:
+          registry-type: public
+      - name: Run Prismic linting
+        run: docker compose run prismic_model yarn lintPrismicData
   on-failure:
     runs-on: ubuntu-latest
     if: ${{ always() && (needs.prismic_linting.result == 'failure' || needs.prismic_linting.result == 'timed_out') }}

--- a/.github/workflows/prismic-linting.yml
+++ b/.github/workflows/prismic-linting.yml
@@ -43,7 +43,7 @@ jobs:
         payload: |
           {
             "action_name": "Prismic linting action",
-            "message": "Action has ${{ needs.prismic_linting.result }}",
+            "status": ${{ needs.prismic_linting.result }},
             "link": "https://github.com/wellcomecollection/wellcomecollection.org/actions/workflows/prismic-linting.yml"
           }
       env:

--- a/.github/workflows/prismic-linting.yml
+++ b/.github/workflows/prismic-linting.yml
@@ -38,5 +38,12 @@ jobs:
     - name: Send GitHub Action trigger data to Slack workflow
       id: slack
       uses: slackapi/slack-github-action@v1.26.0
+      with:
+        # This data can be any valid JSON from a previous step in the GitHub Action
+        payload: |
+          {
+            "action_name": "Prismic linting action",
+            "message": "Action has ${{ needs.prismic_linting.result }}"
+          }
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/prismic-linting.yml
+++ b/.github/workflows/prismic-linting.yml
@@ -43,7 +43,7 @@ jobs:
         payload: |
           {
             "action_name": "Prismic linting action",
-            "status": "${{ needs.prismic_linting.result }}"",
+            "status": "${{ needs.prismic_linting.result }}",
             "link": "https://github.com/wellcomecollection/wellcomecollection.org/actions/workflows/prismic-linting.yml"
           }
       env:

--- a/.github/workflows/prismic-linting.yml
+++ b/.github/workflows/prismic-linting.yml
@@ -43,7 +43,7 @@ jobs:
         payload: |
           {
             "action_name": "Prismic linting action",
-            "message": "Action has ${{ needs.prismic_linting.result }}"
+            "message": "Action has ${{ needs.prismic_linting.result }}",
             "link": "https://github.com/wellcomecollection/wellcomecollection.org/actions/workflows/prismic-linting.yml"
           }
       env:

--- a/.github/workflows/prismic-linting.yml
+++ b/.github/workflows/prismic-linting.yml
@@ -3,6 +3,10 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 4 * * MON-FRI'
+  # Remove before merge
+  push:
+    branches:
+      - github-action-slack
 
 permissions:
   id-token: write
@@ -23,3 +27,14 @@ jobs:
           registry-type: public
       - name: Run Prismic linting
         run: docker compose run prismic_model yarn lintPrismicData
+  on-failure:
+    runs-on: ubuntu-latest
+    if: ${{ always() && (needs.prismic_linting.result == 'failure' || needs.prismic_linting.result == 'timed_out') }}
+    needs:
+      - prismic_linting
+    steps:
+    - name: Send GitHub Action trigger data to Slack workflow
+      id: slack
+      uses: slackapi/slack-github-action@v1.26.0
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/prismic-linting.yml
+++ b/.github/workflows/prismic-linting.yml
@@ -43,7 +43,7 @@ jobs:
         payload: |
           {
             "action_name": "Prismic linting action",
-            "status": ${{ needs.prismic_linting.result }},
+            "status": "${{ needs.prismic_linting.result }}"",
             "link": "https://github.com/wellcomecollection/wellcomecollection.org/actions/workflows/prismic-linting.yml"
           }
       env:

--- a/.github/workflows/prismic-linting.yml
+++ b/.github/workflows/prismic-linting.yml
@@ -47,4 +47,4 @@ jobs:
             "link": "https://github.com/wellcomecollection/wellcomecollection.org/actions/workflows/prismic-linting.yml"
           }
       env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_GA_ACTION_URL }}

--- a/.github/workflows/prismic-linting.yml
+++ b/.github/workflows/prismic-linting.yml
@@ -15,18 +15,20 @@ jobs:
   prismic_linting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: eu-west-1
-          role-to-assume: ${{ secrets.EXPERIENCE_GHA_ROLE_ARN }}
-      - uses: aws-actions/amazon-ecr-login@v2
-        env:
-          AWS_REGION: us-east-1
-        with:
-          registry-type: public
-      - name: Run Prismic linting
-        run: docker compose run prismic_model yarn lintPrismicData
+      - name: failing step
+        run: exit 1
+      # - uses: actions/checkout@v4
+      # - uses: aws-actions/configure-aws-credentials@v4
+      #   with:
+      #     aws-region: eu-west-1
+      #     role-to-assume: ${{ secrets.EXPERIENCE_GHA_ROLE_ARN }}
+      # - uses: aws-actions/amazon-ecr-login@v2
+      #   env:
+      #     AWS_REGION: us-east-1
+      #   with:
+      #     registry-type: public
+      # - name: Run Prismic linting
+      #   run: docker compose run prismic_model yarn lintPrismicData
   on-failure:
     runs-on: ubuntu-latest
     if: ${{ always() && (needs.prismic_linting.result == 'failure' || needs.prismic_linting.result == 'timed_out') }}


### PR DESCRIPTION
## What does this change?

As only the author of the action gets alerted when it fails, we wanted to add it as a Slack alert as well.

I've done it using a mix of https://github.com/slackapi/slack-github-action (thanks @davidpmccormick !) and https://tomjones.dev/blog/send-github-action-workflow-failure-notifications-to-slack/ for understanding how to fire it under certain conditions.

Adds an `on-failure` step to `prismic-linting.yml` that only fires when the task status is `failure` or `timed_out`.
It works in tandem with the `GitHub actions workflow` automation in Slack to send a message to #wc-platform-alerts when fired, with relevant information.

<img width="668" alt="Screenshot 2024-08-07 at 16 33 30" src="https://github.com/user-attachments/assets/f1fd9f3e-6b22-4d77-acb6-d523fcd82fb6">


## How to test

Create a new branch and re-add these lines https://github.com/wellcomecollection/wellcomecollection.org/pull/11093/commits/16e5d38eccd32d81faf08f64d46797c5a6f39a4e to the action, changing the name of the branch to yours on line 9. It should fail the task and fire the event.

## How can we measure success?

Everyone gets alerted when the action fails and not just the author of the action.

## Have we considered potential risks?

None that I can think of for the codebase, it's quite contained.
But for rollover, I couldn't assign a team to manage the Slack automation and had to add individuals. So it's a new thing to remember to update when people leave and join.
<img width="1003" alt="Screenshot 2024-08-07 at 16 35 44" src="https://github.com/user-attachments/assets/9f8b724a-e422-4d3d-b5a6-023f7b0491b0">
