### PR TITLE
Idea for changing type hierarchy in cards

### DIFF
--- a/common/views/themes/config.ts
+++ b/common/views/themes/config.ts
@@ -147,7 +147,7 @@ export const sizes = {
 
 export const cardSizes = {
   small: 0,
-  medium: 400,
+  medium: 380,
   large: 550,
 };
 

--- a/common/views/themes/config.ts
+++ b/common/views/themes/config.ts
@@ -145,6 +145,12 @@ export const sizes = {
   headerLarge: 1040,
 };
 
+export const cardSizes = {
+  small: 0,
+  medium: 400,
+  large: 550,
+};
+
 const defaultButtonColors: ButtonColors = {
   border: 'accent.green',
   background: 'accent.green',
@@ -240,6 +246,7 @@ export const themeValues = {
     xlarge: 60,
   },
   sizes,
+  cardSizes,
   gutter: {
     small: 18,
     medium: 24,

--- a/common/views/themes/typography.ts
+++ b/common/views/themes/typography.ts
@@ -350,13 +350,23 @@ export const typography = css<GlobalStyleProps>`
 export function makeFontSizeClasses(): string {
   return breakpointNames
     .map(bp => {
-      return `@media (min-width: ${themeValues.sizes[bp]}px) {
-      ${Object.entries(fontSizesAtBreakpoints[bp])
-        .map(([key, value]) => {
-          return `.font-size-${key} {font-size: ${value}rem}`;
-        })
-        .join(' ')}
-    }`;
+      return `
+        @media (min-width: ${themeValues.sizes[bp]}px) {
+          ${Object.entries(fontSizesAtBreakpoints[bp])
+            .map(([key, value]) => {
+              return `.font-size-${key} {font-size: ${value}rem;}`;
+            })
+            .join(' ')}
+        }
+
+        @container card (min-width: ${themeValues.cardSizes[bp]}px) {
+          ${Object.entries(fontSizesAtBreakpoints[bp])
+            .map(([key, value]) => {
+              return `.font-size-${key} {font-size: ${value}rem !important;}`;
+            })
+            .join(' ')}
+        }
+      `;
     })
     .join(' ');
 }

--- a/content/webapp/components/Card/Card.tsx
+++ b/content/webapp/components/Card/Card.tsx
@@ -20,6 +20,7 @@ type Props = {
 export const CardOuter = styled.a.attrs<{ 'data-gtm-trigger'?: 'card_link' }>({
   'data-gtm-trigger': 'card_link',
 })`
+  container: card / inline-size;
   height: 100%;
   display: block; /* IE */
 


### PR DESCRIPTION
## What does this change?

Out current responsive typography rules make it such that as the viewport gets larger, each piece of type will get larger. However, this doesn't take into account we have components that might end up being wider at smaller viewport widths (e.g. when cards are on a medium screen, there might be two of them side-by-side, each wider than when there are three side-by-side on a larger screen).

Container queries are relatively new but now supported in all modern browsers and allow you to make css decisions based on the size of a containing element rather than the width of the whole viewport.

This PR allows our font classes to behave differently when they are in a `card` context.

## How to test

Visit the homepage and see that the font sizes in cards is larger when the _browser_ is 500px wide (when there is only one card in a column) than when it is 1200px wide 

## How can we measure success?

Cards have more appropriate use of available space – easier to process visually?

## Have we considered potential risks?

It complicates the css and possibly makes it a bit less easy to reason about. This implementation requires `!important` for the `@container` to take precedence over the `@media` query. Looping through all the `@container`s inside each `@media` felt like a lot of duplication to avoid using `!important`. There might be a way to use `:has()` and `:not()` to check if we're in a `card` for the `@media` queries, but I didn't want to get too deep into it.

