### PR TITLE
Add iiif V2 auth services to TransformedManifest

### DIFF
--- a/content/webapp/services/iiif/transformers/manifest.ts
+++ b/content/webapp/services/iiif/transformers/manifest.ts
@@ -19,6 +19,10 @@ import {
   getDisplayData,
   isCollection,
   getStructures,
+  getAuthAccessServices,
+  getExternalAuthAccessService,
+  getActiveAuthAccessService,
+  getV2TokenService,
 } from '@weco/content/utils/iiif/v3';
 
 export function transformManifest(
@@ -34,11 +38,28 @@ export function transformManifest(
   const transformedCanvases = getTransformedCanvases(manifestV3);
   const canvasCount = transformedCanvases.length;
   const isAnyImageOpen = checkIsAnyImageOpen(transformedCanvases);
+  // Our manifests reference both the v1 and v2 Auth services.
+  // This is to make it easier to switch from the current Auth implementation to the new one.
+  // The following are taken from the v1 services:
   const restrictedService = getRestrictedLoginService(manifestV3);
   const clickThroughService = getClickThroughService(manifestV3);
   const tokenService = getTokenService(
     clickThroughService || restrictedService
   );
+  // The following are taken from the v2 services:
+  const authAccessServices = getAuthAccessServices(manifestV3);
+  const externalAccessService =
+    getExternalAuthAccessService(authAccessServices); // equivalent of restrictedService
+  const activeAccessService = getActiveAuthAccessService(authAccessServices); // equivalent of clickThroughService
+  const v2TokenService = getV2TokenService(
+    externalAccessService || externalAccessService
+  ); // equivalent of tokenService
+  // We should default to using the v2 services (TODO work in progress).
+  // However, we need to fallback to v1 services if v2 services aren't available.
+  // This is because not all manifests have the v2 services present yet.
+  // see https://wellcome.slack.com/archives/CBT40CMKQ/p1721912291057799 where a manifest needed to be regenerated to start including the v2 services.
+  // TODO We need to see if we can regenerate all manifests on mass.
+
   const firstCollectionManifestLocation =
     getFirstCollectionManifestLocation(manifestV3);
   const isTotallyRestricted = checkIsTotallyRestricted(
@@ -107,5 +128,8 @@ export function transformManifest(
     needsModal,
     placeholderId: firstPlaceholderId,
     rendering,
+    externalAccessService,
+    activeAccessService,
+    v2TokenService,
   };
 }

--- a/content/webapp/types/manifest.ts
+++ b/content/webapp/types/manifest.ts
@@ -12,7 +12,10 @@ import {
   ResourceType,
   Manifest,
   MetadataItem,
+  AuthAccessService2_External as AuthAccessService2External,
+  AuthAccessTokenService2,
 } from '@iiif/presentation-3';
+import { AuthAccessService2WithInteractiveProfile } from '@weco/content/utils/iiif/v3';
 
 export type ThumbnailImage = { url: string; width: number };
 
@@ -88,6 +91,9 @@ export type TransformedManifest = {
   tokenService: AuthAccessTokenService | undefined;
   placeholderId: string | undefined;
   rendering: ContentResource[];
+  externalAccessService: AuthAccessService2External | undefined;
+  activeAccessService: AuthAccessService2WithInteractiveProfile | undefined;
+  v2TokenService: AuthAccessTokenService2 | undefined;
 };
 
 export type CustomSpecificationBehaviors =

--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -688,7 +688,6 @@ export function getActiveAuthAccessService(
 export function getV2TokenService(
   accessService: AuthAccessService2 | undefined
 ): AuthAccessTokenService2 | undefined {
-  if (!accessService) return;
   const authServiceArray = Array.isArray(accessService?.service)
     ? accessService?.service
     : [accessService?.service];

--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -23,6 +23,9 @@ import {
   RangeItems,
   TechnicalProperties,
   CollectionItems,
+  AuthAccessService2,
+  AuthAccessService2_External as AuthAccessService2External,
+  AuthAccessTokenService2,
 } from '@iiif/presentation-3';
 import { isString } from '@weco/common/utils/type-guards';
 import { getThumbnailImage, getOriginal } from './canvas';
@@ -210,8 +213,8 @@ function getImageAuthCookieService(
   return Array.isArray(imageService?.service)
     ? imageService?.service?.find(s => s['@type'] === 'AuthCookieService1')
     : imageService?.service?.['@type'] === 'AuthCookieService1'
-      ? imageService?.service
-      : undefined;
+    ? imageService?.service
+    : undefined;
 }
 
 // We don't know at the top-level of a manifest whether any of the canvases contain images that are open access.
@@ -547,8 +550,8 @@ export function getOriginalFiles(
     canvas.original.length > 0
       ? canvas.original
       : canvas.painting.length > 0
-        ? canvas.painting
-        : canvas.supplementing;
+      ? canvas.painting
+      : canvas.supplementing;
   return downloadData || [];
 }
 
@@ -645,4 +648,49 @@ export function isAllOriginalPdfs(canvases: TransformedCanvas[]): boolean {
   return canvases?.every(canvas =>
     canvas.original.find(original => original.format === 'application/pdf')
   );
+}
+
+// https://iiif.io/api/auth/2.0/#access-service-description
+export function getAuthAccessServices(manifest): AuthAccessService2[] {
+  const services = manifest.services || [];
+  return services.filter(s => s.type === 'AuthAccessService2');
+}
+
+// https://iiif.io/api/auth/2.0/#external-interaction-pattern
+export function getExternalAuthAccessService(
+  services: AuthAccessService2[]
+): AuthAccessService2External | undefined {
+  return services.find(s => s.profile === 'external');
+}
+
+// Docs (https://iiif.io/api/auth/2.0/#profile) say the profile value should be active, but before the Auth 2 spec was finalised the value was interactive and we have still have manifests with this value. N.B. the values will update if the manifest is regenerated.
+export type AuthAccessService2WithInteractiveProfile = Omit<
+  AuthAccessService2,
+  'profile'
+> & {
+  profile: AuthAccessService2['profile'] | 'interactive';
+};
+
+// https://iiif.io/api/auth/2.0/#active-interaction-pattern
+export function getActiveAuthAccessService(
+  services: AuthAccessService2WithInteractiveProfile[]
+): AuthAccessService2WithInteractiveProfile | undefined {
+  return services.find(
+    s => s.profile === 'active' || s.profile === 'interactive'
+  );
+}
+
+// https://iiif.io/api/auth/2.0/#access-token-service-description
+// not sure if the service can be an object or an array,
+// but we do this check for v1 token services, so putting it in to be safe
+export function getV2TokenService(
+  accessService: AuthAccessService2 | undefined
+): AuthAccessTokenService2 | undefined {
+  if (!accessService) return;
+  const authServiceArray = Array.isArray(accessService?.service)
+    ? accessService?.service
+    : [accessService?.service];
+  return authServiceArray.find(s => s?.type === 'AuthAccessTokenService2') as
+    | AuthAccessTokenService2
+    | undefined;
 }

--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -660,7 +660,9 @@ export function getAuthAccessServices(manifest): AuthAccessService2[] {
 export function getExternalAuthAccessService(
   services: AuthAccessService2[]
 ): AuthAccessService2External | undefined {
-  return services.find(s => s.profile === 'external');
+  return services.find(s => s.profile === 'external') as
+    | AuthAccessService2External
+    | undefined;
 }
 
 // Docs (https://iiif.io/api/auth/2.0/#profile) say the profile value should be active, but before the Auth 2 spec was finalised the value was interactive and we have still have manifests with this value. N.B. the values will update if the manifest is regenerated.
@@ -677,7 +679,7 @@ export function getActiveAuthAccessService(
 ): AuthAccessService2WithInteractiveProfile | undefined {
   return services.find(
     s => s.profile === 'active' || s.profile === 'interactive'
-  );
+  ) as AuthAccessService2WithInteractiveProfile | undefined;
 }
 
 // https://iiif.io/api/auth/2.0/#access-token-service-description


### PR DESCRIPTION
## What does this change?

For #11096.

Adds iiif V2 auth services to TransformedManifest

Our manifests reference both the v1 and v2 Auth services.
We currently use the v1 services. This is the first step in making use of the v2 services.

## How to test

Not really easy to test as nothing on the front end should change yet.

## How can we measure success?

This is part of the work that will make restricted items available to staff with the correct permissions, but needs further work to make this possible.

## Have we considered potential risks?

This shouldn't impact the site.

