### PR TITLE
Toggles dashboard: Fix Safari and use library

### DIFF
--- a/dash/webapp/pages/toggles.tsx
+++ b/dash/webapp/pages/toggles.tsx
@@ -394,7 +394,7 @@ const IndexPage: FunctionComponent = () => {
 
           <hr style={{ margin: '3em' }} />
 
-          <h2>Custom settings</h2>
+          <h2>Developer settings</h2>
           <div style={{ marginBottom: '3em' }}>
             <label htmlFor="hasLocalToggles">
               <input

--- a/dash/webapp/pages/toggles.tsx
+++ b/dash/webapp/pages/toggles.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react';
 import Head from 'next/head';
 import styled from 'styled-components';
-import { getCookies } from 'cookies-next';
+import { deleteCookie, getCookies, setCookie } from 'cookies-next';
 import Header from '../components/Header';
 
 const fontFamily = 'Gadget, sans-serif';
@@ -47,6 +47,21 @@ const TextBox = styled.p`
   padding: 6px 12px;
   margin: 0;
 `;
+
+const setCookieCustom = (key, value) => {
+  const nowPlusOneYear = new Date();
+  nowPlusOneYear.setFullYear(nowPlusOneYear.getFullYear() + 1);
+
+  setCookie(`toggle_${key}`, value, {
+    path: '/',
+    expires: nowPlusOneYear,
+    secure: true,
+  });
+};
+
+const deleteCookieCustom = key => {
+  deleteCookie(`toggle_${key}`, { path: '/' });
+};
 
 type ListOfTogglesProps = {
   toggles: Toggle[];
@@ -111,7 +126,7 @@ const ListOfToggles: FunctionComponent<ListOfTogglesProps> = ({
 
             <Button
               onClick={() => {
-                setCookie(toggle.id, 'true');
+                setCookieCustom(toggle.id, 'true');
                 setToggleStates(() => ({
                   ...toggleStates,
                   [toggle.id]: true,
@@ -125,7 +140,7 @@ const ListOfToggles: FunctionComponent<ListOfTogglesProps> = ({
             </Button>
             <Button
               onClick={() => {
-                setCookie(toggle.id, 'false');
+                setCookieCustom(toggle.id, 'false');
                 setToggleStates(() => ({
                   ...toggleStates,
                   [toggle.id]: false,
@@ -144,16 +159,6 @@ const ListOfToggles: FunctionComponent<ListOfTogglesProps> = ({
     {toggles.length === 0 && <p>None for now, check back later…</p>}
   </>
 );
-
-const aYear = 31536000;
-function setCookie(name, value) {
-  const expiration = value
-    ? ` Max-Age=${aYear}`
-    : `Expires=${new Date(0).toString()}`;
-  document.cookie = `toggle_${name}=${
-    value || ''
-  }; Path=/; Domain=wellcomecollection.org; ${expiration}; Secure`;
-}
 
 type Toggle = {
   id: string;
@@ -180,8 +185,7 @@ const IndexPage: FunctionComponent = () => {
   const [toggles, setToggles] = useState<Toggle[]>([]);
   const [abTests, setAbTests] = useState<AbTest[]>([]);
 
-  // We use this over getInitialProps as it's ineffectual when an app is
-  // exported.
+  // We use this over getInitialProps as it's ineffectual when an app is exported.
   useEffect(() => {
     fetch('https://toggles.wellcomecollection.org/toggles.json')
       .then(resp => resp.json())
@@ -205,7 +209,7 @@ const IndexPage: FunctionComponent = () => {
     () =>
       setToggleStates(
         toggles.reduce((state, { id, defaultValue }) => {
-          setCookie(id, null);
+          deleteCookieCustom(id);
           state[id] = defaultValue;
           return state;
         }, {})
@@ -318,7 +322,7 @@ const IndexPage: FunctionComponent = () => {
                   <p>{toggle.description}</p>
                   <Button
                     onClick={() => {
-                      setCookie(toggle.id, 'true');
+                      setCookieCustom(toggle.id, 'true');
                       setToggleStates({
                         ...toggleStates,
                         [toggle.id]: true,
@@ -332,7 +336,7 @@ const IndexPage: FunctionComponent = () => {
                   </Button>
                   <Button
                     onClick={() => {
-                      setCookie(toggle.id, 'false');
+                      setCookieCustom(toggle.id, 'false');
                       setToggleStates({
                         ...toggleStates,
                         [toggle.id]: false,
@@ -347,7 +351,7 @@ const IndexPage: FunctionComponent = () => {
                   <Button
                     $opaque
                     onClick={() => {
-                      setCookie(toggle.id, null);
+                      deleteCookieCustom(toggle.id);
                       setToggleStates({
                         ...toggleStates,
                         [toggle.id]: undefined,


### PR DESCRIPTION
Relates to #11100 

## What does this change?

We realised that the current way of resetting does not actually work in Safari, as it _sets_ them without a value instead of deleting them.
<img width="665" alt="Screenshot 2024-08-12 at 14 44 30" src="https://github.com/user-attachments/assets/36fe87e0-66b3-4832-b3a2-4fd29b6eba3b">
That's fine for our actual use of toggles as they are checking if the value is `true` and `undefined` is falsy, but as we [made changes to the error page](https://github.com/wellcomecollection/wellcomecollection.org/pull/11090) and that checks if a cookie _exists_, they are listed there if set, whatever their value.
![image](https://github.com/user-attachments/assets/7203bfb7-abfa-412a-bc87-2fc9a2ef2751)

One of the fixes would've been to just change that error message and only list a toggle if true, but I feel like it's still useful to have it listed whatever its value, and therefore the fix laid here.

- Use of `cookies-next` for setting and deleting (as we used it to `get` them anyway). Makes it more readable IMO as well
- The issue in Safari seemed to lie within the fact that you have to specify the exact same `path` and `domain` when you delete a cookie as when you set it, so I've added that in the deletion function
- I added a checkbox at the bottom of the page (trying to confuse our non-dev users as little as possible!). This checkbox adds a cookie, allowing you to determine if you'd like to add the cookie to `localhost` as well as `wellcomecollection.org`. I thought it might be a nice idea as we have to do it manually at the moment, and it would be nice to have it all in one place. Open to removing it if we think it's unnecessary/could cause issues. 

<img width="658" alt="Screenshot 2024-08-12 at 15 42 53" src="https://github.com/user-attachments/assets/45b57f3e-424e-442c-a0b6-9714f76645da">


## How to test

`cd dash/webapp`
`yarn dev`
Test on all browsers, both turning toggles ON, OFF and RESETTING them.
The `localhost` cookies should behave as expected
The `wellcomecollection.org` ones are a tad more difficult to test, see risks section.

## How can we measure success?

Reset cookies actually deletes cookies in Safari.
We have less manual work to do when working with toggles locally.

## Have we considered potential risks?
I can't seem to test `wc.org` cookies setting behaviour locally, I don't think we ever could? I think it has to do with having to use `secure: false`, as `localhost` in not on HTTPS. I believe it'll have to be tested when deployed, so I'll warn users it might be wonky and revert if it causes issues.