### PR TITLE
When IIIF manifest 404s, log don't throw

### DIFF
--- a/content/webapp/services/iiif/fetch/manifest.ts
+++ b/content/webapp/services/iiif/fetch/manifest.ts
@@ -18,7 +18,7 @@ async function getIIIFManifest(url: string): Promise<Manifest | undefined> {
       if (bnumber) {
         const dashboardUrl = `https://iiif.wellcomecollection.org/dash/Manifestation/${bnumber}`;
 
-        throw new Error(
+        console.error(
           `Tried to retrieve IIIF Manifest at ${url}, but it's 404-ing. To fix, try running the "Rebuild IIIF" task in the iiif-builder dashboard. ${dashboardUrl}`
         );
       }


### PR DESCRIPTION
## What does this change?

This change logs an error when no IIIF manifest is found rather than throwing as this breaks works pages in the whole when we could still display useful information.

In general we should try to degrade gracefully and avoid extraneous requests failing whole page loads.

## How to test

- [ ] Run locally, visit a works page with a 404ing IIIF manifest: http://localhost:3000/works/k8eqduzc

## How can we measure success?

Reduced noise in our alerts channel, more graceful failure on works pages

## Have we considered potential risks?

This change returns the behaviour to a previous known state, hopefully mitigating any risk.
