### PR TITLE
Chromatic snapshots: Remove delays for image, add delay for Tabs

### DIFF
--- a/cardigan/stories/components/BookPromo/BookPromo.stories.tsx
+++ b/cardigan/stories/components/BookPromo/BookPromo.stories.tsx
@@ -16,5 +16,4 @@ basic.args = {
 basic.storyName = 'BookPromo';
 basic.parameters = {
   gridSizes: { s: 12, m: 6, l: 4, xl: 4 },
-  chromatic: { diffThreshold: 0.2 },
 };

--- a/cardigan/stories/components/Cards/Cards.stories.tsx
+++ b/cardigan/stories/components/Cards/Cards.stories.tsx
@@ -25,9 +25,6 @@ import { singleLineOfText } from '@weco/cardigan/stories/data/text';
 const primaryLabelList = [{ text: 'Study day' }, { text: 'Schools' }];
 const secondaryLabelList = [{ text: 'Speech-to-text' }];
 const imageProps = squareImage();
-const sharedParameters = {
-  chromatic: { diffThreshold: 0.2, delay: 1000 },
-};
 
 const CompactCardTemplate = args => <CompactCard {...args} />;
 
@@ -45,7 +42,6 @@ compactCard.args = {
 };
 compactCard.storyName = 'CompactCard';
 compactCard.parameters = {
-  ...sharedParameters,
   gridSizes: { s: 12, m: 10, l: 8, xl: 8 },
 };
 
@@ -55,7 +51,6 @@ bannerCard.args = {
   item: bannerCardItem,
 };
 bannerCard.storyName = 'BannerCard';
-bannerCard.parameters = sharedParameters;
 
 const FeaturedCardTemplate = args => {
   return (
@@ -88,7 +83,6 @@ featuredCard.args = {
   isReversed: false,
 };
 featuredCard.storyName = 'FeaturedCard';
-featuredCard.parameters = sharedParameters;
 
 const EventPromoTemplate = args => <EventPromo {...args} />;
 export const eventPromo = EventPromoTemplate.bind({});
@@ -97,7 +91,6 @@ eventPromo.args = {
   event,
 };
 eventPromo.parameters = {
-  ...sharedParameters,
   gridSizes: { s: 12, m: 6, l: 4, xl: 4 },
 };
 eventPromo.storyName = 'EventPromo';
@@ -106,7 +99,6 @@ const ExhibitionPromoTemplate = args => <ExhibitionPromo {...args} />;
 export const exhibitionPromo = ExhibitionPromoTemplate.bind({});
 exhibitionPromo.args = { exhibition: exhibitionBasic };
 exhibitionPromo.parameters = {
-  ...sharedParameters,
   gridSizes: { s: 12, m: 6, l: 4, xl: 4 },
 };
 exhibitionPromo.storyName = 'ExhibitionPromo';
@@ -121,9 +113,6 @@ guideStopCard.args = {
   title: 'Exhibition guide stop',
   type: 'audio',
   image: imageWithCrops,
-};
-guideStopCard.parameters = {
-  ...sharedParameters,
 };
 guideStopCard.argTypes = {
   type: {
@@ -153,7 +142,6 @@ storyPromo.args = {
   position: 0,
 };
 storyPromo.parameters = {
-  ...sharedParameters,
   gridSizes: { s: 12, m: 6, l: 4, xl: 4 },
 };
 storyPromo.storyName = 'StoryPromo';

--- a/cardigan/stories/components/ImageGallery/ImageGallery.stories.tsx
+++ b/cardigan/stories/components/ImageGallery/ImageGallery.stories.tsx
@@ -34,6 +34,3 @@ frames.args = {
   ...sharedArgs,
   isFrames: true,
 };
-frames.parameters = {
-  chromatic: { diffThreshold: 0.2, delay: 1000 },
-};

--- a/cardigan/stories/components/SeasonsHeader/SeasonsHeader.stories.tsx
+++ b/cardigan/stories/components/SeasonsHeader/SeasonsHeader.stories.tsx
@@ -55,9 +55,7 @@ export const basic = Template.bind({});
 basic.args = { season };
 basic.parameters = {
   chromatic: {
-    diffThreshold: 0.2,
     viewports: [375, 1200],
-    delay: 500, // The image loads slowly
   },
 };
 basic.storyName = 'SeasonsHeader';

--- a/cardigan/stories/components/Tabs/Tabs.stories.tsx
+++ b/cardigan/stories/components/Tabs/Tabs.stories.tsx
@@ -87,4 +87,8 @@ basic.args = {
   ],
 };
 
+basic.parameters = {
+  chromatic: { delay: 1000 },
+};
+
 basic.storyName = 'Tabs';


### PR DESCRIPTION
## What does this change?

[Tabs has been flagging a lot as different recently](https://wellcome.slack.com/archives/CUA669WHH/p1724054820504579). The theory is that it's because of the Readme Decorator loading, so we'll add a second delay to allow the snapshot more time.

I also took the opportunity to test removing `delay` and `diffThreshold` from the stories with images. [We originally thought it was needed](https://github.com/wellcomecollection/wellcomecollection.org/pull/9680) but then found out it was most likely that the images weren't static, which we've now addressed.

## How to test

See the Chromatic tests below.

## How can we measure success?

Tabs stop being flagged unnecessarily.

## Have we considered potential risks?
None, really.