### PR TITLE
Disconnect the resize observer in a useEffect

### DIFF
--- a/content/webapp/pages/guides/exhibitions/[id]/[type]/[stop]/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/[type]/[stop]/index.tsx
@@ -188,6 +188,25 @@ const ExhibitionGuidePage: FunctionComponent<Props> = props => {
   const router = useRouter();
   const [stopNumber, setStopNumber] = useState(stopNumberServerSide);
   const [currentStop, setCurrentStop] = useState(currentStopServerSide);
+  const [headerEl, setHeaderEl] = useState<HTMLElement>();
+
+  const headerRef = useCallback((node: HTMLElement) => {
+    if (node) setHeaderEl(node);
+  }, []);
+
+  useEffect(() => {
+    if (!headerEl) return;
+
+    const resizeObserver = new ResizeObserver(([entry]) => {
+      document.documentElement.style.setProperty(
+        '--stop-header-height',
+        `${entry.contentRect.height}px`
+      );
+    });
+    resizeObserver.observe(headerEl);
+
+    return () => resizeObserver.disconnect();
+  }, [headerEl]);
 
   useEffect(() => {
     setStopNumber(Number(router.query.stop));
@@ -196,21 +215,6 @@ const ExhibitionGuidePage: FunctionComponent<Props> = props => {
       setCurrentStop(newStop);
     }
   }, [router.query.stop]);
-
-  const headerRef = useCallback((node: HTMLElement) => {
-    if (node) {
-      // We measure the height of the Header element with a ResizeObserver and
-      // update the sticky top position of the StickyPlayer element any time it
-      // changes
-      const resizeObserver = new ResizeObserver(([entry]) => {
-        document.documentElement.style.setProperty(
-          '--stop-header-height',
-          `${entry.contentRect.height}px`
-        );
-      });
-      resizeObserver.observe(node);
-    }
-  }, []);
 
   const guideTypeUrl = `/guides/exhibitions/${exhibitionGuideId}/${type}`;
   const pathname = `${guideTypeUrl}/${stopNumber}`;

--- a/content/webapp/pages/guides/exhibitions/[id]/[type]/[stop]/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/[type]/[stop]/index.tsx
@@ -196,7 +196,9 @@ const ExhibitionGuidePage: FunctionComponent<Props> = props => {
 
   useEffect(() => {
     if (!headerEl) return;
-
+    // We measure the height of the Header element with a ResizeObserver and
+    // update the sticky top position of the StickyPlayer element any time it
+    // changes
     const resizeObserver = new ResizeObserver(([entry]) => {
       document.documentElement.style.setProperty(
         '--stop-header-height',


### PR DESCRIPTION
## What does this change?

Uses `useEffect` in conjunction with `useCallback` so that the `ResizeObserver` can be disconnected when it is no longer needed.

## How to test
Check the audio player still sticks beneath the header the correct point when scrolling the page

## How can we measure success?
We prevent potential memory leaks (although not sure how to measure this)

## Have we considered potential risks?
Can't think of any