### PR TITLE
Scroll the page to the top after a client-side update

### DIFF
--- a/content/webapp/pages/guides/exhibitions/[id]/[type]/[stop]/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/[type]/[stop]/index.tsx
@@ -194,6 +194,7 @@ const ExhibitionGuidePage: FunctionComponent<Props> = props => {
     const newStop = allStops.find(s => s.number === Number(router.query.stop));
     if (newStop) {
       setCurrentStop(newStop);
+      window.scrollTo(0, 0);
     }
   }, [router.query.stop]);
 


### PR DESCRIPTION
## What does this change?
If you opened the transcript on a guide stop page and scrolled to the bottom, then clicked next/previous, you would still be at that window scroll position because the routing is being done client side. This resets the scroll position to the top of the page after a client-side route change

## How to test
- Make your browser window small enough that the transcripts need to scroll a good deal
- Visit [test stop 1](http://localhost:3000/guides/exhibitions/ZrHvtxEAACYAWmfc/audio-without-descriptions/1)
- Click the 'Next' link bottom right
- Verify that you are scrolled to the top of the new page

## How can we measure success?
n/a

## Have we considered potential risks?
n/a
