### PR TITLE
Fix AudioPlayer bug

### DIFF
--- a/content/webapp/components/AudioPlayer/AudioPlayer.tsx
+++ b/content/webapp/components/AudioPlayer/AudioPlayer.tsx
@@ -98,6 +98,12 @@ export const AudioPlayer: FunctionComponent<AudioPlayerProps> = ({
   const id = `${idPrefix || ''}${dasherize(title.slice(0, 15))}`;
 
   useEffect(() => {
+    // If we change the player dynamically, we need to reset the play/pause
+    // button to the appropriate state
+    setIsPlaying(false);
+  }, [audioFile]);
+
+  useEffect(() => {
     if (!audioPlayerRef.current) return;
     if (!progressBarRef.current) return;
 


### PR DESCRIPTION
## What does this change?
If you have an audio file playing and change the stop using the prev/next buttons, the play/pause button doesn't currently reset itself because it's a client-side routing event and we don't re-instantiate the AudioPlayer component. This leaves the UI in a broken state.

## How to test
- Go to a [stop page](http://localhost:3000/guides/exhibitions/ZrHvtxEAACYAWmfc/audio-without-descriptions/2)
- Play the audio
- Click Previous or Next and see the stopped audio shows a play button rather than a pause button

## How can we measure success?
n/a

## Have we considered potential risks?
Is this something that would benefit from a test? 