### PR TITLE
remove offsiteRequesting toggle

### DIFF
--- a/content/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
+++ b/content/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
@@ -81,7 +81,7 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
   isLast,
 }) => {
   const { state: userState } = useUser();
-  const { disableRequesting, offsiteRequesting } = useToggles();
+  const { disableRequesting } = useToggles();
   const isArchive = useContext(IsArchiveContext);
   const requestButtonRef = useRef<HTMLButtonElement | null>(null);
   const [requestModalIsActive, setRequestModalIsActive] = useState(false);
@@ -136,8 +136,7 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
   // Work out whether to show status, access and request button
   const showAccessStatus = !!accessStatus;
   const showAccessMethod = !isOpenShelves;
-  const isRequestable =
-    itemIsRequestable(item, offsiteRequesting) && !wasJustRequested(item);
+  const isRequestable = itemIsRequestable(item) && !wasJustRequested(item);
 
   const showButton =
     isRequestable && userState === 'signedin' && !disableRequesting;

--- a/content/webapp/components/PhysicalItems/PhysicalItems.tsx
+++ b/content/webapp/components/PhysicalItems/PhysicalItems.tsx
@@ -16,7 +16,6 @@ import {
   itemIsTemporarilyUnavailable,
 } from '../../utils/requesting';
 import { getWorkItemsClientSide } from '@weco/content/services/wellcome/catalogue/works';
-import { useToggles } from '@weco/common/server-data/Context';
 
 type Props = {
   work: Work;
@@ -34,19 +33,15 @@ type Props = {
  */
 type ItemsState = 'stale' | 'up-to-date';
 
-const getItemsState = (
-  items: PhysicalItem[],
-  offsiteRequesting: boolean
-): ItemsState => {
+const getItemsState = (items: PhysicalItem[]): ItemsState => {
   return items.some(itemIsTemporarilyUnavailable) ||
-    items.some(item => itemIsRequestable(item, offsiteRequesting))
+    items.some(item => itemIsRequestable(item))
     ? 'stale'
     : 'up-to-date';
 };
 
 const useItemsState = (
-  items: PhysicalItem[],
-  offsiteRequesting = false
+  items: PhysicalItem[]
 ): [ItemsState, (s: ItemsState) => void] => {
   /* https://github.com/wellcomecollection/wellcomecollection.org/issues/7120#issuecomment-938035546
    *
@@ -69,11 +64,11 @@ const useItemsState = (
    * In all other cases the items API would be a no-op.
    */
   const [itemsState, setItemsState] = useState<ItemsState>(
-    getItemsState(items, offsiteRequesting)
+    getItemsState(items)
   );
 
   useEffect(() => {
-    setItemsState(getItemsState(items, offsiteRequesting));
+    setItemsState(getItemsState(items));
   }, [items]);
 
   return [itemsState, setItemsState];
@@ -83,14 +78,10 @@ const PhysicalItems: FunctionComponent<Props> = ({
   work,
   items: workItems,
 }: Props) => {
-  const { offsiteRequesting } = useToggles();
   const { state: userState } = useUser();
   const [userHolds, setUserHolds] = useState<Set<string>>();
   const [physicalItems, setPhysicalItems] = useState(workItems);
-  const [itemsState, setItemsState] = useItemsState(
-    workItems,
-    offsiteRequesting
-  );
+  const [itemsState, setItemsState] = useItemsState(workItems);
 
   useEffect(() => {
     setPhysicalItems(workItems);

--- a/content/webapp/components/WorkDetails/WorkDetails.WhereToFind.tsx
+++ b/content/webapp/components/WorkDetails/WorkDetails.WhereToFind.tsx
@@ -12,7 +12,6 @@ import {
   PhysicalItem,
   Work,
 } from '@weco/content/services/wellcome/catalogue/types';
-import { useToggles } from '@weco/common/server-data/Context';
 
 type Props = {
   work: Work;
@@ -21,13 +20,10 @@ type Props = {
 };
 
 const WhereToFindIt = ({ work, physicalItems, locationOfWork }: Props) => {
-  const { offsiteRequesting } = useToggles();
   return (
     <WorkDetailsSection headingText="Where to find it">
       {physicalItems.some(
-        item =>
-          itemIsRequestable(item, offsiteRequesting) ||
-          itemIsTemporarilyUnavailable(item)
+        item => itemIsRequestable(item) || itemIsTemporarilyUnavailable(item)
       ) && (
         <Space $v={{ size: 'm', properties: ['margin-bottom'] }}>
           <LibraryMembersBar />

--- a/content/webapp/utils/requesting.ts
+++ b/content/webapp/utils/requesting.ts
@@ -1,7 +1,6 @@
 import { PhysicalItem } from '@weco/content/services/wellcome/catalogue/types';
 import { PhysicalLocation } from '@weco/common/model/catalogue';
 import { getFirstAccessCondition, getFirstPhysicalLocation } from './works';
-import { today, addDays } from '@weco/common/utils/dates';
 
 const requestableStatusIds = ['open', 'open-with-advisory', 'restricted'];
 const requestableMethodIds = ['online-request'];
@@ -19,26 +18,11 @@ const locationIsRequestable = (location: PhysicalLocation): boolean => {
   );
 };
 
-export const itemIsRequestable = (
-  item: PhysicalItem,
-  offsiteRequesting = false
-): boolean => {
+export const itemIsRequestable = (item: PhysicalItem): boolean => {
   // ok because there is only one physical location in reality
   const physicalLocation = getFirstPhysicalLocation(item);
 
-  if (offsiteRequesting) {
-    return !!physicalLocation && locationIsRequestable(physicalLocation);
-  } else {
-    return (
-      !!physicalLocation &&
-      locationIsRequestable(physicalLocation) &&
-      // when the toggle is OFF we don't want items with a long lead time to be requestable
-      !(
-        item.availableDates &&
-        new Date(item.availableDates[0].from) > addDays(today(), 9)
-      )
-    );
-  }
+  return !!physicalLocation && locationIsRequestable(physicalLocation);
 };
 
 export const itemIsTemporarilyUnavailable = (item: PhysicalItem): boolean => {

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -87,14 +87,6 @@ const toggles = {
       type: 'experimental',
     },
     {
-      id: 'offsiteRequesting',
-      title: 'Request items from offsite locations',
-      initialValue: false,
-      description:
-        'This enables online requesting of items that are held at the offsite Deepstore location',
-      type: 'experimental',
-    },
-    {
       id: 'egWork',
       title: 'Exhibition Guides redesign/restructure work',
       initialValue: false,


### PR DESCRIPTION
The toggle has been set to public status: on and will stay like that until the sierra/Calm records update is effected.
This PR will then be merged, leaving it as draft in the meantime

## What does this change?

Removes the `offsiteRequesting` toggle 
Not yet deployed 

## How to test

Once deployed, the toggle should not appear here https://dash.wellcomecollection.org/toggles/

These items should have the "Request item" button on their works page
`SA/CAS/C/10/4` https://wellcomecollection.org/works/fbst3nnc
`SA/CAS/C/4/2` https://wellcomecollection.org/works/hhb8q9ga

## How can we measure success?

Deepstore items can be requested by anyone
Calm/Sierra update still pending so the above 2 are the only ones available at the moment

## Have we considered potential risks?

This has been tested end to end.
We have the option of temporarily disabling requesting if something goes wrong when the Calm/Sierra update is effected.
LE&E staff can alert us of anything that doesn't look right when they print request tickets
