### PR TITLE
Digital Guides QR logic pt II: Add e2e tests

### DIFF
--- a/content/webapp/pages/exhibitions/[exhibitionId]/index.tsx
+++ b/content/webapp/pages/exhibitions/[exhibitionId]/index.tsx
@@ -50,6 +50,8 @@ const ExhibitionPage: FunctionComponent<ExhibitionProps> = ({
   accessResourceLinks,
   jsonLd,
 }) => {
+  // Switch over to new Jason exhibition guide ID
+  // https://github.com/wellcomecollection/wellcomecollection.org/issues/11131
   useHotjar(exhibition.id === 'ZZP8BxAAALeD00jo'); // Only on Jason and the Adventure of 254
 
   return (

--- a/content/webapp/pages/guides/exhibitions/[id]/[type]/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/[type]/index.tsx
@@ -121,6 +121,7 @@ export const getServerSideProps: GetServerSideProps<
 
   // This is needed for the Jason QR codes
   // TODO remove from this page when it closes or if we change its QR codes
+  // https://github.com/wellcomecollection/wellcomecollection.org/issues/11131
   // Check if it needs to be redirected because of query params or cookie preferences
   // Will redirect here if needed
   const redirect = getGuidesRedirections(context);

--- a/content/webapp/types/exhibition-guides.ts
+++ b/content/webapp/types/exhibition-guides.ts
@@ -72,6 +72,7 @@ export type ExhibitionGuide = ExhibitionGuideBasic & {
 
 // TODO remove 'captions-and-transcripts' once we close Jason/migrate it
 // as we no longer set a cookie for that type.
+// https://github.com/wellcomecollection/wellcomecollection.org/issues/11131
 const typeNames = [
   'bsl',
   'audio-without-descriptions',

--- a/content/webapp/utils/digital-guides.ts
+++ b/content/webapp/utils/digital-guides.ts
@@ -90,6 +90,7 @@ export const getGuidesRedirections = (
 
   // Supporting Jason exhibition
   // TODO remove when it closes/we adapt the QR codes
+  // https://github.com/wellcomecollection/wellcomecollection.org/issues/11131
   if (
     legacyGuides.includes(toMaybeString(guideId) || '') &&
     hasValidUserPreference &&

--- a/content/webapp/utils/digital-guides.ts
+++ b/content/webapp/utils/digital-guides.ts
@@ -53,6 +53,7 @@ export const getGuidesRedirections = (
 ) => {
   const { req, res, resolvedUrl } = context;
   const { id: guideId, stopNumber, stopId, type, usingQRCode } = context.query;
+  const hasEgWorkCookie = getCookie('toggle_egWork', { req, res }) === 'true';
 
   if (!usingQRCode) return;
 
@@ -94,7 +95,8 @@ export const getGuidesRedirections = (
 
   // The first stop's link is an exception, in that it should link to
   // the [exhibitionId]/[type] page, and not directly on the stop's page.
-  if (hasValidUserPreference && hasValidStopNumber) {
+  // TODO remove hasEgWorkCookie check once toggle is removed
+  if (hasEgWorkCookie && hasValidUserPreference && hasValidStopNumber) {
     // We do a simple replace on the URL so we preserve all other URL information
     // (e.g. UTM tracking parameters).
     return {

--- a/playwright/test/exhibition-guides.test.ts
+++ b/playwright/test/exhibition-guides.test.ts
@@ -25,6 +25,7 @@ const egWorkCookies = [
 test.describe.configure({ mode: 'parallel' });
 
 // TODO remove when we stop supporting legacy QRs
+// https://github.com/wellcomecollection/wellcomecollection.org/issues/11131
 test('(1) | Redirects to another format if we have an EG preference and come from a QR code', async ({
   context,
   page,
@@ -46,6 +47,7 @@ test('(1) | Redirects to another format if we have an EG preference and come fro
 
 test.describe('(2) | with egWork toggle: ', () => {
   // TODO remove this when we stop supporting legacy QRs
+  // https://github.com/wellcomecollection/wellcomecollection.org/issues/11131
   test('Legacy: Still redirects to another format if we have an EG preference and come from a QR code', async ({
     context,
     page,
@@ -119,76 +121,77 @@ test.describe('(2) | with egWork toggle: ', () => {
 
   // TODO uncomment this once we have content for it in production
   // Currently only works with Prismic staging content, but it is a good test to have.
-  // test.describe('New: If no type preference set, ', () => {
-  //   test('links to BSL and Audio now go straight to stop page instead of landing', async ({
-  //     context,
-  //     page,
-  //   }) => {
-  //     await context.addCookies([
-  //       {
-  //         name: 'toggle_egWork',
-  //         value: 'true',
-  //         path: '/',
-  //         domain: new URL(baseUrl).host,
-  //       },
-  //       {
-  //         name: 'CookieControl',
-  //         value: '{}',
-  //         path: '/',
-  //         domain: new URL(baseUrl).host,
-  //       }, // Civic UK banner
-  //     ]);
+  // https://github.com/wellcomecollection/wellcomecollection.org/issues/11131
+  test.describe.skip('New: If no type preference set, ', () => {
+    test('links to BSL and Audio now go straight to stop page instead of landing', async ({
+      context,
+      page,
+    }) => {
+      await context.addCookies([
+        {
+          name: 'toggle_egWork',
+          value: 'true',
+          path: '/',
+          domain: new URL(baseUrl).host,
+        },
+        {
+          name: 'CookieControl',
+          value: '{}',
+          path: '/',
+          domain: new URL(baseUrl).host,
+        }, // Civic UK banner
+      ]);
 
-  //     //  Kola Nuts with the QR code params and Stop #2
-  //     await gotoWithoutCache(
-  //       `${baseUrl}/guides/exhibitions/ZrHvtxEAACYAWmfc?usingQRCode=true&stopNumber=2`,
-  //       page
-  //     );
+      //  Kola Nuts with the QR code params and Stop #2
+      await gotoWithoutCache(
+        `${baseUrl}/guides/exhibitions/ZrHvtxEAACYAWmfc?usingQRCode=true&stopNumber=2`,
+        page
+      );
 
-  //     await expect(
-  //       page.getByRole('link', { name: 'Audio descriptive tour with' })
-  //     ).toHaveAttribute(
-  //       'href',
-  //       '/guides/exhibitions/ZrHvtxEAACYAWmfc/audio-without-descriptions/2'
-  //     );
+      await expect(
+        page.getByRole('link', { name: 'Audio descriptive tour with' })
+      ).toHaveAttribute(
+        'href',
+        '/guides/exhibitions/ZrHvtxEAACYAWmfc/audio-without-descriptions/2'
+      );
 
-  //     await expect(
-  //       page.getByRole('link', { name: 'British Sign Language tour' })
-  //     ).toHaveAttribute('href', '/guides/exhibitions/ZrHvtxEAACYAWmfc/bsl/2');
-  //   });
+      await expect(
+        page.getByRole('link', { name: 'British Sign Language tour' })
+      ).toHaveAttribute('href', '/guides/exhibitions/ZrHvtxEAACYAWmfc/bsl/2');
+    });
 
-  //   test('unless it is the first stop', async ({ context, page }) => {
-  //     await context.addCookies([
-  //       {
-  //         name: 'toggle_egWork',
-  //         value: 'true',
-  //         path: '/',
-  //         domain: new URL(baseUrl).host,
-  //       },
-  //       {
-  //         name: 'CookieControl',
-  //         value: '{}',
-  //         path: '/',
-  //         domain: new URL(baseUrl).host,
-  //       }, // Civic UK banner
-  //     ]);
+    test('unless it is the first stop', async ({ context, page }) => {
+      await context.addCookies([
+        {
+          name: 'toggle_egWork',
+          value: 'true',
+          path: '/',
+          domain: new URL(baseUrl).host,
+        },
+        {
+          name: 'CookieControl',
+          value: '{}',
+          path: '/',
+          domain: new URL(baseUrl).host,
+        }, // Civic UK banner
+      ]);
 
-  //     //  Kola Nuts with the QR code params and Stop #1
-  //     await gotoWithoutCache(
-  //       `${baseUrl}/guides/exhibitions/ZrHvtxEAACYAWmfc?usingQRCode=true&stopNumber=1`,
-  //       page
-  //     );
+      //  Kola Nuts with the QR code params and Stop #1
+      await gotoWithoutCache(
+        `${baseUrl}/guides/exhibitions/ZrHvtxEAACYAWmfc?usingQRCode=true&stopNumber=1`,
+        page
+      );
 
-  //     await expect(
-  //       page.getByRole('link', { name: 'Audio descriptive tour with' })
-  //     ).toHaveAttribute(
-  //       'href',
-  //       '/guides/exhibitions/ZrHvtxEAACYAWmfc/audio-without-descriptions'
-  //     );
+      await expect(
+        page.getByRole('link', { name: 'Audio descriptive tour with' })
+      ).toHaveAttribute(
+        'href',
+        '/guides/exhibitions/ZrHvtxEAACYAWmfc/audio-without-descriptions'
+      );
 
-  //     await expect(
-  //       page.getByRole('link', { name: 'British Sign Language tour' })
-  //     ).toHaveAttribute('href', '/guides/exhibitions/ZrHvtxEAACYAWmfc/bsl');
-  //   });
-  // });
+      await expect(
+        page.getByRole('link', { name: 'British Sign Language tour' })
+      ).toHaveAttribute('href', '/guides/exhibitions/ZrHvtxEAACYAWmfc/bsl');
+    });
+  });
 });

--- a/playwright/test/exhibition-guides.test.ts
+++ b/playwright/test/exhibition-guides.test.ts
@@ -2,19 +2,35 @@ import { test, expect } from '@playwright/test';
 import { baseUrl } from './helpers/utils';
 import { gotoWithoutCache } from './helpers/contexts';
 
-test('Redirects to another format if we have an EG preference and come from a QR code', async ({
+const bslCookie = [
+  {
+    name: 'WC_userPreferenceGuideType',
+    value: 'bsl',
+    path: '/',
+    domain: new URL(baseUrl).host,
+  },
+];
+
+// TODO remove when we remove the egWork toggle
+const egWorkCookies = [
+  ...bslCookie,
+  {
+    name: 'toggle_egWork',
+    value: 'true',
+    path: '/',
+    domain: new URL(baseUrl).host,
+  },
+];
+
+test.describe.configure({ mode: 'parallel' });
+
+// TODO remove when we stop supporting legacy QRs
+test('(1) | Redirects to another format if we have an EG preference and come from a QR code', async ({
   context,
   page,
 }) => {
   // Add cookie for BSL preference
-  await context.addCookies([
-    {
-      name: 'WC_userPreferenceGuideType',
-      value: 'bsl',
-      path: '/',
-      domain: new URL(baseUrl).host,
-    },
-  ]);
+  await context.addCookies(bslCookie);
 
   // Go to In Plain Sight Audio exhibition guide with the QR code params
   await gotoWithoutCache(
@@ -26,4 +42,153 @@ test('Redirects to another format if we have an EG preference and come from a QR
   await expect(page).toHaveURL(
     /\/bsl[?]usingQRCode=true&stopId=witness#witness/
   );
+});
+
+test.describe('(2) | with egWork toggle: ', () => {
+  // TODO remove this when we stop supporting legacy QRs
+  test('Legacy: Still redirects to another format if we have an EG preference and come from a QR code', async ({
+    context,
+    page,
+  }) => {
+    // Add cookie for BSL preference
+    await context.addCookies(egWorkCookies);
+
+    // Go to In Plain Sight Audio exhibition guide with the QR code params
+    await gotoWithoutCache(
+      `${baseUrl}/guides/exhibitions/YzwsAREAAHylrxau/audio-without-descriptions?usingQRCode=true&stopId=witness#witness`,
+      page
+    );
+
+    // Check we've been redirected to the BSL guide and kept the extra params
+    await expect(page).toHaveURL(
+      /\/bsl[?]usingQRCode=true&stopId=witness#witness/
+    );
+  });
+
+  test('New: Redirects to preferred format if user has an EG preference and comes from a QR code', async ({
+    context,
+    page,
+  }) => {
+    await context.addCookies(egWorkCookies);
+
+    // Kola Nuts with the QR code params and Stop #2
+    await gotoWithoutCache(
+      `${baseUrl}/guides/exhibitions/ZrHvtxEAACYAWmfc?usingQRCode=true&stopNumber=2`,
+      page
+    );
+
+    // Check we've been redirected to the BSL guide's second stop, and kept the extra params
+    await expect(page).toHaveURL(/\/bsl\/2[?]usingQRCode=true/);
+  });
+
+  test('New: Does not redirect if user does not come from a QR code', async ({
+    context,
+    page,
+  }) => {
+    await context.addCookies(egWorkCookies);
+
+    //  Kola Nuts with the QR code params and Stop #2
+    await gotoWithoutCache(
+      `${baseUrl}/guides/exhibitions/ZrHvtxEAACYAWmfc?stopNumber=2`,
+      page
+    );
+
+    // Nothing happens, URL is the same
+    await expect(page).toHaveURL(
+      /\/guides\/exhibitions\/ZrHvtxEAACYAWmfc[?]stopNumber=2/
+    );
+  });
+
+  test('New: If first stop, redirects to preferred type landing page instead of [type]/1', async ({
+    context,
+    page,
+  }) => {
+    await context.addCookies(egWorkCookies);
+
+    //  Kola Nuts with the QR code params and Stop #1
+    await gotoWithoutCache(
+      `${baseUrl}/guides/exhibitions/ZrHvtxEAACYAWmfc?usingQRCode=true&stopNumber=1`,
+      page
+    );
+
+    // Nothing happens, URL is the same
+    await expect(page).toHaveURL(
+      /\/guides\/exhibitions\/ZrHvtxEAACYAWmfc\/bsl/
+    );
+  });
+
+  // TODO uncomment this once we have content for it in production
+  // Currently only works with Prismic staging content, but it is a good test to have.
+  // test.describe('New: If no type preference set, ', () => {
+  //   test('links to BSL and Audio now go straight to stop page instead of landing', async ({
+  //     context,
+  //     page,
+  //   }) => {
+  //     await context.addCookies([
+  //       {
+  //         name: 'toggle_egWork',
+  //         value: 'true',
+  //         path: '/',
+  //         domain: new URL(baseUrl).host,
+  //       },
+  //       {
+  //         name: 'CookieControl',
+  //         value: '{}',
+  //         path: '/',
+  //         domain: new URL(baseUrl).host,
+  //       }, // Civic UK banner
+  //     ]);
+
+  //     //  Kola Nuts with the QR code params and Stop #2
+  //     await gotoWithoutCache(
+  //       `${baseUrl}/guides/exhibitions/ZrHvtxEAACYAWmfc?usingQRCode=true&stopNumber=2`,
+  //       page
+  //     );
+
+  //     await expect(
+  //       page.getByRole('link', { name: 'Audio descriptive tour with' })
+  //     ).toHaveAttribute(
+  //       'href',
+  //       '/guides/exhibitions/ZrHvtxEAACYAWmfc/audio-without-descriptions/2'
+  //     );
+
+  //     await expect(
+  //       page.getByRole('link', { name: 'British Sign Language tour' })
+  //     ).toHaveAttribute('href', '/guides/exhibitions/ZrHvtxEAACYAWmfc/bsl/2');
+  //   });
+
+  //   test('unless it is the first stop', async ({ context, page }) => {
+  //     await context.addCookies([
+  //       {
+  //         name: 'toggle_egWork',
+  //         value: 'true',
+  //         path: '/',
+  //         domain: new URL(baseUrl).host,
+  //       },
+  //       {
+  //         name: 'CookieControl',
+  //         value: '{}',
+  //         path: '/',
+  //         domain: new URL(baseUrl).host,
+  //       }, // Civic UK banner
+  //     ]);
+
+  //     //  Kola Nuts with the QR code params and Stop #1
+  //     await gotoWithoutCache(
+  //       `${baseUrl}/guides/exhibitions/ZrHvtxEAACYAWmfc?usingQRCode=true&stopNumber=1`,
+  //       page
+  //     );
+
+  //     await expect(
+  //       page.getByRole('link', { name: 'Audio descriptive tour with' })
+  //     ).toHaveAttribute(
+  //       'href',
+  //       '/guides/exhibitions/ZrHvtxEAACYAWmfc/audio-without-descriptions'
+  //     );
+
+  //     await expect(
+  //       page.getByRole('link', { name: 'British Sign Language tour' })
+  //     ).toHaveAttribute('href', '/guides/exhibitions/ZrHvtxEAACYAWmfc/bsl');
+  //   });
+  // });
 });


### PR DESCRIPTION
Relates to #11039

## What does this change?
After work on #11118, this serves to add loads of tests, aimed to test if we still supported legacy exhibition guides, as well as if the new ones behaved the way we expect them to.

## How to test

- "Exhibition Guides redesign/restructure work" toggle is ON
- Run locally with the [Prismic endpoint](https://github.com/wellcomecollection/wellcomecollection.org/blob/main/common/services/prismic/fetch/index.ts#L32) set to wellcomecollection-stage.
  - Once this is done, you can uncomment the last tests, they need the data that's in staging right now to work. Then run all the tests.

Test with and without the `egWorks` toggle, with and without the Prismic staging, so we can make sure it won't affect current behaviour.

## How can we measure success?

Green tests 👍 

## Have we considered potential risks?
N/A
Although, can you see anything I would've forgotten?