### PR TITLE
add a toggle for auth v2

### DIFF
--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -99,7 +99,15 @@ const toggles = {
       title: 'Exhibition Guides redesign/restructure work',
       initialValue: false,
       description:
-        'With this actived, you will be able to see the new (and work in progress) versions of exhibition guides',
+        'With this activated, you will be able to see the new (and work in progress) versions of exhibition guides',
+      type: 'experimental',
+    },
+    {
+      id: 'authV2',
+      title: 'IIIF Auth V2',
+      initialValue: false,
+      description:
+        'Will make use of the V2 auth services in the IIIF Presentation manifest, if they are available',
       type: 'experimental',
     },
   ] as const,


### PR DESCRIPTION
## What does this change?
Relates to https://github.com/wellcomecollection/platform/issues/5747
Adds a toggle for using IIIF auth v2 services.

Our iiif manifests contain both auth V1 and auth V2 services.

This will help with the work around viewing restricted items and moving over to auth V2 services more generally.

## How to test
Can't really, but once deployed the toggle will show at https://dash.wellcomecollection.org/toggles/ in the temporary section.

