### PR TITLE
Smaller exhibition guide type title

### DIFF
--- a/content/webapp/pages/guides/exhibitions/[id]/[type]/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/[type]/index.tsx
@@ -340,7 +340,7 @@ const ExhibitionGuidePage: FunctionComponent<Props> = props => {
 
         <Layout gridSizes={gridSize8(false)}>
           {egWork ? (
-            <h2 className={font('intsb', 3)}>{getTypeTitle(type, egWork)}</h2>
+            <h2 className={font('intsb', 4)}>{getTypeTitle(type, egWork)}</h2>
           ) : (
             <h1 className={font('wb', 1)}>
               {exhibitionGuide.title}{' '}


### PR DESCRIPTION
For #11126 

## What does this change?

Makes the exhibition guide type title slightly smaller in line with the designs

## How to test

I don't think it's required

<img width="500" alt="image" src="https://github.com/user-attachments/assets/91f2ce90-8bdf-41db-8088-8041f67f970f">


## How can we measure success?
n/a

## Have we considered potential risks?
n/a