### PR TITLE
Align icons to center of first line of text in GuideStopCard

### DIFF
--- a/content/webapp/components/GuideStopCard/index.tsx
+++ b/content/webapp/components/GuideStopCard/index.tsx
@@ -4,6 +4,7 @@ import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImag
 import Icon from '@weco/common/views/components/Icon/Icon';
 import Space from '@weco/common/views/components/styled/Space';
 import { grid } from '@weco/common/utils/classnames';
+import styled from 'styled-components';
 import { threeUpGridSizesMap } from '@weco/content/components/Body/GridFactory';
 import ImagePlaceholder, {
   placeholderBackgroundColor,
@@ -20,6 +21,15 @@ import {
   CardBody,
   CardImageWrapper,
 } from '@weco/content/components/Card/Card';
+
+const AlignIconFirstLineCenter = styled.div`
+  display: flex;
+  align-items: start;
+
+  .icon {
+    height: 1lh;
+  }
+`;
 
 type Props = {
   link?: string;
@@ -77,7 +87,7 @@ const GuideStopCard: FunctionComponent<Props> = ({
         <CardBody style={{ display: 'block' }}>
           <CardTitle>{title}</CardTitle>
           {number && (
-            <div style={{ display: 'flex', alignItems: 'center' }}>
+            <AlignIconFirstLineCenter>
               <Space
                 style={{ display: 'flex' }}
                 $h={{ size: 's', properties: ['margin-right'] }}
@@ -87,9 +97,9 @@ const GuideStopCard: FunctionComponent<Props> = ({
               <span>
                 Stop {number}/{totalStops}
               </span>
-            </div>
+            </AlignIconFirstLineCenter>
           )}
-          <div style={{ display: 'flex', alignItems: 'center' }}>
+          <AlignIconFirstLineCenter>
             <Space
               style={{ display: 'flex' }}
               $h={{ size: 's', properties: ['margin-right'] }}
@@ -105,7 +115,7 @@ const GuideStopCard: FunctionComponent<Props> = ({
                 {type === 'audio' ? 'listen' : 'watch'} time
               </span>
             )}
-          </div>
+          </AlignIconFirstLineCenter>
         </CardBody>
       </CardOuter>
     </Space>


### PR DESCRIPTION
## What does this change?
Exhibition Guide QA revealed that the icons should be center aligned with the first line of text if the text flows onto more than one line. This would also be a problem in the `GuideStopCard`s so I'm fixing pre-emptively

__before__
<img width="237" alt="image" src="https://github.com/user-attachments/assets/5ec9e4e6-fb73-4001-87bd-9d668d1e3ddc">


__after__
<img width="243" alt="image" src="https://github.com/user-attachments/assets/07213bf5-9ba7-4ec1-bd06-e39ff12e2d22">


## How to test
Visit e.g. `guides/exhibitions/ZrHvtxEAACYAWmfc/audio-without-descriptions`, make your browser very narrow to force card icon/text copy onto a second line and check the icon is aligned properly in the center of the first line

## How can we measure success?
n/a

## Have we considered potential risks?
n/a