### PR TITLE
Don't display number of stops in new exhibition guide stop page

### DIFF
--- a/content/webapp/pages/guides/exhibitions/[id]/[type]/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/[type]/index.tsx
@@ -386,7 +386,7 @@ const ExhibitionGuidePage: FunctionComponent<Props> = props => {
         <Layout gridSizes={gridSize10(false)}>
           {userPreferenceSet ? (
             <p>
-              {type !== 'captions-and-transcripts' && (
+              {type !== 'captions-and-transcripts' && !egWork && (
                 <>This exhibition has {numberOfStops} stops. </>
               )}
               You selected this type of guide previously, but you can also
@@ -402,7 +402,7 @@ const ExhibitionGuidePage: FunctionComponent<Props> = props => {
             </p>
           ) : (
             <>
-              {type !== 'captions-and-transcripts' && (
+              {type !== 'captions-and-transcripts' && !egWork && (
                 <p>This exhibition has {numberOfStops} stops.</p>
               )}
             </>


### PR DESCRIPTION
## What does this change?

This removes the dynamic stop count on the `[id]/[type]` page since this information will be present in the information at the top of the page.

__before__
<img width="711" alt="image" src="https://github.com/user-attachments/assets/0a653dd8-ab08-4363-9796-1037cf8e4350">

__after__
<img width="690" alt="Screenshot 2024-09-02 at 16 47 34" src="https://github.com/user-attachments/assets/3bcc5865-2fb5-4e31-864f-8b1a62029ca3">

## How to test
check the line of text doesn't appear


## How can we measure success?
n/a

## Have we considered potential risks?
n/a