### PR TITLE
Increase space below content (to clear fixed footer)

### DIFF
--- a/content/webapp/pages/guides/exhibitions/[id]/[type]/[stop]/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/[type]/[stop]/index.tsx
@@ -364,7 +364,9 @@ const ExhibitionGuidePage: FunctionComponent<Props> = props => {
           </StickyPlayer>
           {/* Make sure we can scroll content into view if it's behind the fixed position footer (paddingBottom: 100px) */}
 
-          <Space $v={{ size: 'xl', properties: ['padding-bottom'] }}>
+          <Space
+            $v={{ size: 'xl', properties: ['padding-bottom', 'margin-bottom'] }}
+          >
             <Space $v={{ size: 'l', properties: ['padding-top'] }}>
               <CollapsibleContent
                 controlText={controlText}


### PR DESCRIPTION
## What does this change?

This increases the space below the CollapsibleContent on an exhibition guide stop page, so that there is some room between the content and the fixed footer.

__before__
<img width="904" alt="image" src="https://github.com/user-attachments/assets/609fa4c0-696b-413f-af46-b91ca1727e39">


__after__
<img width="909" alt="image" src="https://github.com/user-attachments/assets/ec09731b-13f0-49a0-81a0-0c1a5ec3996a">


## How to test
Visit e.g. `/guides/exhibitions/ZrHvtxEAACYAWmfc/audio-without-descriptions/2`, click 'Read full transcript', scroll to the bottom of the page and check there's space between the bottom of the content and the fixed footer.

## How can we measure success?
n/a

## Have we considered potential risks?
n/a