### PR TITLE
use-new-stale-PR-workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,6 @@
 # Automatically mark any pull requests that have been inactive for 30 days as "Stale"
 # then close them 3 days later if there is still no activity.
-# 
-# Shamelessly copied from https://github.com/guardian/.github/blob/main/workflow-templates/stale.yml
+#
 name: "Stale PR Handler"
 
 on:
@@ -15,24 +14,4 @@ permissions:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/stale@v9
-        id: stale
-        # Read about options here: https://github.com/actions/stale#all-options
-        with:
-          # never automatically mark issues as stale
-          days-before-issue-stale: -1
-
-          # Wait 30 days before marking a PR as stale
-          days-before-stale: 30
-          stale-pr-message: >
-            This PR is stale because it has been open 30 days with no activity.
-            Unless a comment is added or the “stale” label removed, this will be closed in 3 days
-
-          # Wait 3 days after a PR has been marked as stale before closing
-          days-before-close: 3
-          close-pr-message: This PR was closed because it has been stalled for 3 days with no activity.
-
-          # Ignore PR's raised by Dependabot
-          exempt-pr-labels: "dependencies"
+    uses: wellcomecollection/.github/.github/workflows/stale.yml@main


### PR DESCRIPTION
## What does this change?

Call the reusable workflow https://github.com/wellcomecollection/.github/blob/main/.github/workflows/stale.yml, avoids duplication in multiple projects

## How to test

Change the cron expression to something more frequent and wait for the workflow to run
Runs only on `main`

## How can we measure success?

Stale PRs are checked every morning Mon-Thu
Workflow is easier to maintain, changes applied only in one place

## Have we considered potential risks?

Negligible 