### PR TITLE
Guides slices: don't display divs if no content

### DIFF
--- a/content/webapp/components/GuideSectionHeading/GuideSectionHeading.tsx
+++ b/content/webapp/components/GuideSectionHeading/GuideSectionHeading.tsx
@@ -18,35 +18,41 @@ const GuideSectionHeading: FunctionComponent<{
   subtitle: string;
   text: prismic.RichTextField | undefined;
 }> = ({ index, number, title, subtitle, text }) => {
+  if (!title && !subtitle && !text) return null;
+
   return (
     <div id={number ? `stop-${number}` : undefined}>
-      <Container>
-        <div style={{ display: 'flex', flexWrap: 'wrap' }}>
-          <Spacer />
-          <Space
-            $h={{ size: 'm', properties: ['margin-left'], negative: true }}
-            $v={{ size: 'l', properties: ['margin-bottom'] }}
-          >
-            <Title>{title}</Title>
-          </Space>
-        </div>
-      </Container>
+      {title && (
+        <Container>
+          <div style={{ display: 'flex', flexWrap: 'wrap' }}>
+            <Spacer />
+            <Space
+              $h={{ size: 'm', properties: ['margin-left'], negative: true }}
+              $v={{ size: 'l', properties: ['margin-bottom'] }}
+            >
+              <Title>{title}</Title>
+            </Space>
+          </div>
+        </Container>
+      )}
 
       <Space as="article" $v={{ size: 'xl', properties: ['margin-bottom'] }}>
-        <Background
-          $backgroundColor={index === 0 ? 'white' : 'warmNeutral.300'}
-          $hasPadding={!(index === 0)}
-        >
-          <Container style={{ display: 'flex', flexWrap: 'wrap' }}>
-            <Spacer />
-            <TextWrapper>
-              {subtitle && subtitle.length > 0 && (
-                <Subtitle $level={3}>{subtitle}</Subtitle>
-              )}
-              {text && <PrismicHtmlBlock html={text} />}
-            </TextWrapper>
-          </Container>
-        </Background>
+        {(text || subtitle) && (
+          <Background
+            $backgroundColor={index === 0 ? 'white' : 'warmNeutral.300'}
+            $hasPadding={!(index === 0)}
+          >
+            <Container style={{ display: 'flex', flexWrap: 'wrap' }}>
+              <Spacer />
+              <TextWrapper>
+                {subtitle && subtitle.length > 0 && (
+                  <Subtitle $level={3}>{subtitle}</Subtitle>
+                )}
+                {text && <PrismicHtmlBlock html={text} />}
+              </TextWrapper>
+            </Container>
+          </Background>
+        )}
       </Space>
     </div>
   );


### PR DESCRIPTION
## What does this change?
Doesn't display empty divs if there is no content, to match the legacy exhibition guide components. I did keep the spacing div to match [current behaviour](https://wellcomecollection.org/guides/exhibitions/Zdcs4BEAACMA6abC/captions-and-transcripts).

**Before**
<img width="600" alt="Screenshot 2024-09-04 at 16 08 01" src="https://github.com/user-attachments/assets/be6d75fd-f75a-462e-beab-2d3cd7c110b5">

and

<img width="600" alt="Screenshot 2024-09-04 at 16 08 10" src="https://github.com/user-attachments/assets/fad9fda2-0988-4c39-8b03-e075c59e028b">


**After**
<img width="600" alt="Screenshot 2024-09-04 at 16 07 55" src="https://github.com/user-attachments/assets/1140ae98-8b77-41b2-9a9b-b5e509e34163">

and

<img width="600" alt="Screenshot 2024-09-04 at 16 10 55" src="https://github.com/user-attachments/assets/9135b92c-6622-40b0-8143-baae181aa19c">


## How to test

Preview [Jason Text draft](https://wellcomecollection.prismic.io/builder/pages/ZthyQxIAACQALx4_?fallback=YiUzRHdvcmtpbmclMjZjJTNEdW5jbGFzc2lmaWVkJTI2bCUzRGVuLWdi&s=unclassified) locally

## How can we measure success?
It looks good

## Have we considered potential risks?
It doesn't look good.