### PR TITLE
Add spacing above Exhibition text section

### DIFF
--- a/content/webapp/components/ExhibitionGuideLinks/ExhibitionGuideLinks.tsx
+++ b/content/webapp/components/ExhibitionGuideLinks/ExhibitionGuideLinks.tsx
@@ -8,6 +8,7 @@ import TypeOption, { TypeList } from './TypeOption';
 import { useToggles } from '@weco/common/server-data/Context';
 import SectionHeader from '@weco/content/components/SectionHeader/SectionHeader';
 import Space from '@weco/common/views/components/styled/Space';
+import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper/ConditionalWrapper';
 
 type Props = {
   pathname: string;
@@ -136,11 +137,13 @@ export const ExhibitionResourceLinks: FunctionComponent<ResourceProps> = ({
 }) => {
   const { egWork } = useToggles();
 
+  const hasAudioVideo = !!(audioPathname || videoPathname);
+
   return (
     <>
       {egWork ? (
         <>
-          {(audioPathname || videoPathname) && (
+          {hasAudioVideo && (
             <>
               <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
                 <SectionHeader title="Highlights tour" />
@@ -175,7 +178,14 @@ export const ExhibitionResourceLinks: FunctionComponent<ResourceProps> = ({
             </>
           )}
           {textPathname && (
-            <>
+            <ConditionalWrapper
+              condition={hasAudioVideo}
+              wrapper={children => (
+                <Space $v={{ size: 'xl', properties: ['margin-top'] }}>
+                  {children}
+                </Space>
+              )}
+            >
               <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
                 <SectionHeader title="Exhibition text" />
               </Space>
@@ -190,7 +200,7 @@ export const ExhibitionResourceLinks: FunctionComponent<ResourceProps> = ({
                   type="captions-and-transcripts"
                 />
               </TypeList>
-            </>
+            </ConditionalWrapper>
           )}
         </>
       ) : (


### PR DESCRIPTION
## What does this change?

Adds spacing if "Exhibition text" is the second section in a Guides listing page

**Before**
<img width="836" alt="Screenshot 2024-09-04 at 17 49 44" src="https://github.com/user-attachments/assets/42f6f054-93ae-4189-ac63-cedfbaa02772">


**After**
<img width="873" alt="Screenshot 2024-09-04 at 17 49 34" src="https://github.com/user-attachments/assets/06889464-04d2-44b1-ae35-c8b505b30ded">


## How to test

Run locally with staging content, where I've added the new Jason guides to Kola Nut (to keep the current legacy guides up as well)

## How can we measure success?

N/A

## Have we considered potential risks?
N/A

