### PR TITLE
4. UID: Split `guides` and `projects` from `pages`

### DIFF
--- a/common/views/components/Breadcrumb/Breadcrumb.tsx
+++ b/common/views/components/Breadcrumb/Breadcrumb.tsx
@@ -3,6 +3,22 @@ import { font, classNames } from '@weco/common/utils/classnames';
 import { breadcrumbsLd } from '@weco/common/utils/json-ld';
 import Space from '@weco/common/views/components/styled/Space';
 import { BreadcrumbItems } from '@weco/common/model/breadcrumbs';
+import { links } from '@weco/common/views/components/Header/Header';
+
+export function getBreadcrumbItems(siteSection: string): BreadcrumbItems {
+  return {
+    items: siteSection
+      ? [
+          {
+            text:
+              links.find(link => link.siteSection === siteSection)?.title ||
+              siteSection,
+            url: siteSection ? `/${siteSection}` : '',
+          },
+        ]
+      : [],
+  };
+}
 
 const Breadcrumb: FunctionComponent<BreadcrumbItems> = ({
   items,

--- a/common/views/components/Breadcrumb/Breadcrumb.tsx
+++ b/common/views/components/Breadcrumb/Breadcrumb.tsx
@@ -5,7 +5,8 @@ import Space from '@weco/common/views/components/styled/Space';
 import { BreadcrumbItems } from '@weco/common/model/breadcrumbs';
 import { links } from '@weco/common/views/components/Header/Header';
 
-export function getBreadcrumbItems(siteSection: string): BreadcrumbItems {
+export function getBreadcrumbItems(siteSection?: string): BreadcrumbItems {
+  if (!siteSection) return { items: [] };
   return {
     items: siteSection
       ? [

--- a/common/views/components/LabelsList/LabelsList.tsx
+++ b/common/views/components/LabelsList/LabelsList.tsx
@@ -20,6 +20,12 @@ export type Props = {
   defaultLabelColor?: LabelColor;
 };
 
+export function makeLabels(title?: string): Props | undefined {
+  if (!title) return;
+
+  return { labels: [{ text: title }] };
+}
+
 const LabelsList: FunctionComponent<Props> = ({
   labels,
   defaultLabelColor = 'yellow',

--- a/content/webapp/pages/guides/[guideId].tsx
+++ b/content/webapp/pages/guides/[guideId].tsx
@@ -131,7 +131,7 @@ export const Guide: FunctionComponent<Props> = ({
   // If we have a vanity URL, we prefer that for the link rel="canonical"
   // in the page <head>; it means the canonical URL will match the links
   // we put elsewhere on the website, e.g. in the header.
-  const pathname = vanityUrl || `/guides/${guide.id}`;
+  const pathname = vanityUrl || `/guides/${guide.uid}`;
 
   return (
     <PageLayout

--- a/content/webapp/pages/guides/[guideId].tsx
+++ b/content/webapp/pages/guides/[guideId].tsx
@@ -1,0 +1,168 @@
+import { GetServerSideProps } from 'next';
+import { FunctionComponent, ReactElement } from 'react';
+import PageLayout, {
+  SiteSection,
+} from '@weco/common/views/components/PageLayout/PageLayout';
+import { HTMLDate } from '@weco/common/views/components/HTMLDateAndTime';
+import HeaderBackground from '@weco/common/views/components/HeaderBackground/HeaderBackground';
+import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
+import VideoEmbed from '@weco/common/views/components/VideoEmbed/VideoEmbed';
+import { headerBackgroundLs } from '@weco/common/utils/backgrounds';
+import { AppErrorProps } from '@weco/common/services/app';
+import { serialiseProps } from '@weco/common/utils/json';
+import { getServerData } from '@weco/common/server-data';
+import Body from '@weco/content/components/Body/Body';
+import ContentPage from '@weco/content/components/ContentPage/ContentPage';
+import { contentLd } from '@weco/content/services/prismic/transformers/json-ld';
+import { createClient } from '@weco/content/services/prismic/fetch';
+import { isEditorialImage, isVideoEmbed } from '@weco/content/types/body';
+import { isNotUndefined } from '@weco/common/utils/type-guards';
+import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
+import { looksLikePrismicId } from '@weco/common/services/prismic';
+import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
+import { setCacheControl } from '@weco/content/utils/setCacheControl';
+import { transformEmbedSlice } from '@weco/content/services/prismic/transformers/body';
+import { transformGuide } from '@weco/content/services/prismic/transformers/guides';
+import { isVanityUrl } from '@weco/content/utils/urls';
+import { makeLabels } from '@weco/common/views/components/LabelsList/LabelsList';
+import { Guide as GuideType } from '@weco/content/types/guides';
+import { fetchGuide } from '@weco/content/services/prismic/fetch/guides';
+import { getFeaturedPictureWithTasl } from '../pages/[pageId]';
+import { getBreadcrumbItems } from '@weco/common/views/components/Breadcrumb/Breadcrumb';
+
+export type Props = {
+  guide: GuideType;
+  staticContent: ReactElement | null;
+  vanityUrl?: string;
+  jsonLd: JsonLdObj;
+};
+
+export const getServerSideProps: GetServerSideProps<
+  Props | AppErrorProps
+> = async context => {
+  setCacheControl(context.res);
+  const { guideId } = context.query;
+
+  if (!looksLikePrismicId(guideId)) {
+    return { notFound: true };
+  }
+
+  const client = createClient(context);
+
+  const vanityUrl = isVanityUrl(guideId, context.resolvedUrl)
+    ? context.resolvedUrl
+    : undefined;
+
+  const pageDocument = await fetchGuide(client, guideId);
+
+  const guide = transformGuide(pageDocument);
+
+  if (isNotUndefined(guide)) {
+    const serverData = await getServerData(context);
+
+    const jsonLd = contentLd(guide);
+
+    return {
+      props: serialiseProps({
+        guide,
+        staticContent: null,
+        jsonLd,
+        serverData,
+        vanityUrl,
+      }),
+    };
+  }
+
+  return { notFound: true };
+};
+
+export const Guide: FunctionComponent<Props> = ({
+  guide,
+  staticContent,
+  vanityUrl,
+  jsonLd,
+}) => {
+  const DateInfo = guide.datePublished && (
+    <HTMLDate date={guide.datePublished} />
+  );
+
+  const featuredPicture =
+    guide.untransformedBody.length > 1 &&
+    isEditorialImage(guide.untransformedBody[0])
+      ? guide.untransformedBody[0]
+      : undefined;
+
+  const featuredVideo =
+    guide.untransformedBody.length > 1 &&
+    isVideoEmbed(guide.untransformedBody[0])
+      ? guide.untransformedBody[0]
+      : undefined;
+
+  const transformFeaturedVideo =
+    featuredVideo && transformEmbedSlice(featuredVideo);
+
+  const hasFeaturedMedia =
+    isNotUndefined(featuredPicture) || isNotUndefined(featuredVideo);
+
+  const untransformedBody = hasFeaturedMedia
+    ? guide.untransformedBody.slice(1, guide.untransformedBody.length)
+    : guide.untransformedBody;
+
+  const featuredMedia = featuredPicture ? (
+    getFeaturedPictureWithTasl(featuredPicture)
+  ) : transformFeaturedVideo ? (
+    <VideoEmbed {...transformFeaturedVideo.value} />
+  ) : undefined;
+
+  const displayBackground = featuredMedia ? (
+    <HeaderBackground backgroundTexture={headerBackgroundLs} />
+  ) : undefined;
+
+  const Header = (
+    <PageHeader
+      breadcrumbs={getBreadcrumbItems(guide.siteSection)}
+      labels={makeLabels(guide.format?.title)}
+      title={guide.title}
+      FeaturedMedia={featuredMedia}
+      Background={displayBackground}
+      ContentTypeInfo={DateInfo}
+      backgroundTexture={!featuredMedia ? headerBackgroundLs : undefined}
+      highlightHeading={true}
+      isContentTypeInfoBeforeMedia={false}
+    />
+  );
+
+  // If we have a vanity URL, we prefer that for the link rel="canonical"
+  // in the page <head>; it means the canonical URL will match the links
+  // we put elsewhere on the website, e.g. in the header.
+  const pathname = vanityUrl || `/guides/${guide.id}`;
+
+  return (
+    <PageLayout
+      title={guide.title}
+      description={guide.metadataDescription || guide.promo?.caption || ''}
+      url={{ pathname }}
+      jsonLd={jsonLd}
+      openGraphType="website"
+      siteSection={guide?.siteSection as SiteSection}
+      image={guide.image}
+      apiToolbarLinks={[createPrismicLink(guide.id)]}
+    >
+      <ContentPage
+        id={guide.id}
+        Header={Header}
+        Body={
+          <Body
+            untransformedBody={untransformedBody}
+            pageId={guide.id}
+            onThisPage={guide.onThisPage}
+            showOnThisPage={guide.showOnThisPage}
+            staticContent={staticContent}
+          />
+        }
+      />
+    </PageLayout>
+  );
+};
+
+export default Guide;

--- a/content/webapp/pages/guides/[guideId].tsx
+++ b/content/webapp/pages/guides/[guideId].tsx
@@ -1,5 +1,5 @@
 import { GetServerSideProps } from 'next';
-import { FunctionComponent, ReactElement } from 'react';
+import { FunctionComponent } from 'react';
 import PageLayout, {
   SiteSection,
 } from '@weco/common/views/components/PageLayout/PageLayout';
@@ -23,16 +23,15 @@ import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 import { setCacheControl } from '@weco/content/utils/setCacheControl';
 import { transformEmbedSlice } from '@weco/content/services/prismic/transformers/body';
 import { transformGuide } from '@weco/content/services/prismic/transformers/guides';
-import { isVanityUrl } from '@weco/content/utils/urls';
 import { makeLabels } from '@weco/common/views/components/LabelsList/LabelsList';
 import { Guide as GuideType } from '@weco/content/types/guides';
 import { fetchGuide } from '@weco/content/services/prismic/fetch/guides';
 import { getFeaturedPictureWithTasl } from '../pages/[pageId]';
 import { getBreadcrumbItems } from '@weco/common/views/components/Breadcrumb/Breadcrumb';
+import { isVanityUrl } from '@weco/content/utils/urls';
 
 export type Props = {
   guide: GuideType;
-  staticContent: ReactElement | null;
   vanityUrl?: string;
   jsonLd: JsonLdObj;
 };
@@ -64,7 +63,6 @@ export const getServerSideProps: GetServerSideProps<
     return {
       props: serialiseProps({
         guide,
-        staticContent: null,
         jsonLd,
         serverData,
         vanityUrl,
@@ -77,7 +75,6 @@ export const getServerSideProps: GetServerSideProps<
 
 export const Guide: FunctionComponent<Props> = ({
   guide,
-  staticContent,
   vanityUrl,
   jsonLd,
 }) => {
@@ -156,7 +153,6 @@ export const Guide: FunctionComponent<Props> = ({
             pageId={guide.id}
             onThisPage={guide.onThisPage}
             showOnThisPage={guide.showOnThisPage}
-            staticContent={staticContent}
           />
         }
       />

--- a/content/webapp/pages/guides/[guideId].tsx
+++ b/content/webapp/pages/guides/[guideId].tsx
@@ -53,11 +53,10 @@ export const getServerSideProps: GetServerSideProps<
     ? context.resolvedUrl
     : undefined;
 
-  const pageDocument = await fetchGuide(client, guideId);
+  const guideDocument = await fetchGuide(client, guideId);
 
-  const guide = transformGuide(pageDocument);
-
-  if (isNotUndefined(guide)) {
+  if (isNotUndefined(guideDocument)) {
+    const guide = transformGuide(guideDocument);
     const serverData = await getServerData(context);
 
     const jsonLd = contentLd(guide);

--- a/content/webapp/pages/guides/[pageId].tsx
+++ b/content/webapp/pages/guides/[pageId].tsx
@@ -1,3 +1,0 @@
-import page, { getServerSideProps } from '../pages/[pageId]';
-export { getServerSideProps };
-export default page;

--- a/content/webapp/pages/index.tsx
+++ b/content/webapp/pages/index.tsx
@@ -97,7 +97,7 @@ export const getServerSideProps: GetServerSideProps<
   const eventsQueryPromise = fetchEvents(client, {
     period: 'current-and-coming-up',
   });
-  const pagePromise = fetchPage(client, homepageId, 'pages');
+  const pagePromise = fetchPage(client, homepageId);
   const exhibitionsQueryPromise = fetchExhibitions(client, {
     period: 'next-seven-days',
     order: 'asc',

--- a/content/webapp/pages/pages/[pageId].tsx
+++ b/content/webapp/pages/pages/[pageId].tsx
@@ -1,7 +1,4 @@
-import {
-  PagesDocument as RawPagesDocument,
-  EditorialImageSlice as RawEditorialImageSlice,
-} from '@weco/common/prismicio-types';
+import { EditorialImageSlice as RawEditorialImageSlice } from '@weco/common/prismicio-types';
 import { FunctionComponent, ReactElement } from 'react';
 import PageLayout, {
   SiteSection,
@@ -120,9 +117,8 @@ export const getServerSideProps: GetServerSideProps<
 
   const pageDocument = await fetchPage(client, pageId);
 
-  const page = transformPage(pageDocument as unknown as RawPagesDocument);
-
-  if (isNotUndefined(page)) {
+  if (isNotUndefined(pageDocument)) {
+    const page = transformPage(pageDocument);
     const serverData = await getServerData(context);
     const siblings: SiblingsGroup<PageType>[] = (
       await fetchSiblings(client, page)

--- a/content/webapp/pages/pages/[pageId].tsx
+++ b/content/webapp/pages/pages/[pageId].tsx
@@ -28,7 +28,6 @@ import SpacingComponent from '@weco/common/views/components/styled/SpacingCompon
 import SectionHeader from '@weco/content/components/SectionHeader/SectionHeader';
 import { PageFormatIds } from '@weco/content/data/content-format-ids';
 import { links } from '@weco/common/views/components/Header/Header';
-import { Props as LabelsListProps } from '@weco/common/views/components/LabelsList/LabelsList';
 import { AppErrorProps } from '@weco/common/services/app';
 import { GaDimensions } from '@weco/common/services/app/analytics-scripts';
 import { GetServerSideProps } from 'next';
@@ -60,6 +59,7 @@ import {
 import { gridSize12 } from '@weco/common/views/components/Layout';
 import { transformGuide } from '@weco/content/services/prismic/transformers/guides';
 import { isVanityUrl } from '@weco/content/utils/urls';
+import { makeLabels } from '@weco/common/views/components/LabelsList/LabelsList';
 
 export type Props = {
   page: PageType;
@@ -216,12 +216,6 @@ export const Page: FunctionComponent<Props> = ({
   vanityUrl,
   jsonLd,
 }) => {
-  function makeLabels(title?: string): LabelsListProps | undefined {
-    if (!title) return;
-
-    return { labels: [{ text: title }] };
-  }
-
   const DateInfo = page.datePublished && <HTMLDate date={page.datePublished} />;
   const isLanding = page.format && page.format.id === PageFormatIds.Landing;
   const labels =

--- a/content/webapp/pages/projects/[pageId].tsx
+++ b/content/webapp/pages/projects/[pageId].tsx
@@ -1,3 +1,0 @@
-import page, { getServerSideProps } from '../pages/[pageId]';
-export { getServerSideProps };
-export default page;

--- a/content/webapp/pages/projects/[projectId].tsx
+++ b/content/webapp/pages/projects/[projectId].tsx
@@ -126,7 +126,7 @@ export const Project: FunctionComponent<ProjectProps> = ({
   // If we have a vanity URL, we prefer that for the link rel="canonical"
   // in the page <head>; it means the canonical URL will match the links
   // we put elsewhere on the website, e.g. in the header.
-  const pathname = vanityUrl || `/projects/${project.id}`;
+  const pathname = vanityUrl || `/projects/${project.uid}`;
 
   return (
     <PageLayout

--- a/content/webapp/pages/projects/[projectId].tsx
+++ b/content/webapp/pages/projects/[projectId].tsx
@@ -20,12 +20,12 @@ import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
 import VideoEmbed from '@weco/common/views/components/VideoEmbed/VideoEmbed';
 import { transformEmbedSlice } from '@weco/content/services/prismic/transformers/body';
 import { isEditorialImage, isVideoEmbed } from '@weco/content/types/body';
-import { sectionLevelPages } from '@weco/common/data/hardcoded-ids';
 import { headerBackgroundLs } from '@weco/common/utils/backgrounds';
 import Body from '@weco/content/components/Body/Body';
 import { fetchProject } from '@weco/content/services/prismic/fetch/projects';
 import { isVanityUrl } from '@weco/content/utils/urls';
 import { makeLabels } from '@weco/common/views/components/LabelsList/LabelsList';
+import { getBreadcrumbItems } from '@weco/common/views/components/Breadcrumb/Breadcrumb';
 
 type ProjectProps = {
   project: ProjectType;
@@ -111,20 +111,15 @@ export const Project: FunctionComponent<ProjectProps> = ({
     <VideoEmbed {...transformFeaturedVideo.value} />
   ) : undefined;
 
-  const sectionLevelPage = sectionLevelPages.includes(project.id);
-
   const Header = (
     <PageHeader
-      breadcrumbs={{ items: [] }}
+      breadcrumbs={getBreadcrumbItems(project.siteSection)}
       labels={makeLabels(project.format?.title)}
       title={project.title}
       FeaturedMedia={featuredMedia}
-      backgroundTexture={
-        !featuredMedia && !sectionLevelPage ? headerBackgroundLs : undefined
-      }
+      backgroundTexture={!featuredMedia ? headerBackgroundLs : undefined}
       highlightHeading={true}
       isContentTypeInfoBeforeMedia={false}
-      sectionLevelPage={sectionLevelPage}
     />
   );
 
@@ -150,7 +145,6 @@ export const Project: FunctionComponent<ProjectProps> = ({
           <Body
             untransformedBody={untransformedBody}
             pageId={project.id}
-            sectionLevelPage={sectionLevelPage}
             staticContent={staticContent}
           />
         }

--- a/content/webapp/pages/projects/[projectId].tsx
+++ b/content/webapp/pages/projects/[projectId].tsx
@@ -21,11 +21,11 @@ import VideoEmbed from '@weco/common/views/components/VideoEmbed/VideoEmbed';
 import { transformEmbedSlice } from '@weco/content/services/prismic/transformers/body';
 import { isEditorialImage, isVideoEmbed } from '@weco/content/types/body';
 import { sectionLevelPages } from '@weco/common/data/hardcoded-ids';
-import { Props as LabelsListProps } from '@weco/common/views/components/LabelsList/LabelsList';
 import { headerBackgroundLs } from '@weco/common/utils/backgrounds';
 import Body from '@weco/content/components/Body/Body';
 import { fetchProject } from '@weco/content/services/prismic/fetch/projects';
 import { isVanityUrl } from '@weco/content/utils/urls';
+import { makeLabels } from '@weco/common/views/components/LabelsList/LabelsList';
 
 type ProjectProps = {
   project: ProjectType;
@@ -83,16 +83,6 @@ export const Project: FunctionComponent<ProjectProps> = ({
   vanityUrl,
   jsonLd,
 }) => {
-  function makeLabels(title?: string): LabelsListProps | undefined {
-    if (!title) return;
-
-    return { labels: [{ text: title }] };
-  }
-
-  const labels = !project.format?.title
-    ? makeLabels(project.format?.title)
-    : undefined;
-
   const featuredPicture =
     project.untransformedBody.length > 1 &&
     isEditorialImage(project.untransformedBody[0])
@@ -126,7 +116,7 @@ export const Project: FunctionComponent<ProjectProps> = ({
   const Header = (
     <PageHeader
       breadcrumbs={{ items: [] }}
-      labels={labels}
+      labels={makeLabels(project.format?.title)}
       title={project.title}
       FeaturedMedia={featuredMedia}
       backgroundTexture={

--- a/content/webapp/pages/projects/[projectId].tsx
+++ b/content/webapp/pages/projects/[projectId].tsx
@@ -1,0 +1,174 @@
+import { GetServerSideProps } from 'next';
+import { FunctionComponent, ReactElement } from 'react';
+import { getFeaturedPictureWithTasl } from '../pages/[pageId]';
+import { AppErrorProps } from '@weco/common/services/app';
+import { setCacheControl } from '@weco/content/utils/setCacheControl';
+import { looksLikePrismicId } from '@weco/common/services/prismic';
+import { createClient } from '@weco/content/services/prismic/fetch';
+import { transformProject } from '@weco/content/services/prismic/transformers/projects';
+import { isNotUndefined } from '@weco/common/utils/type-guards';
+import { getServerData } from '@weco/common/server-data';
+import { contentLd } from '@weco/content/services/prismic/transformers/json-ld';
+import { serialiseProps } from '@weco/common/utils/json';
+import { Project as ProjectType } from '@weco/content/types/projects';
+import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
+import { GaDimensions } from '@weco/common/services/app/analytics-scripts';
+import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
+import ContentPage from '@weco/content/components/ContentPage/ContentPage';
+import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
+import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
+import VideoEmbed from '@weco/common/views/components/VideoEmbed/VideoEmbed';
+import { transformEmbedSlice } from '@weco/content/services/prismic/transformers/body';
+import { isEditorialImage, isVideoEmbed } from '@weco/content/types/body';
+import { sectionLevelPages } from '@weco/common/data/hardcoded-ids';
+import { Props as LabelsListProps } from '@weco/common/views/components/LabelsList/LabelsList';
+import { headerBackgroundLs } from '@weco/common/utils/backgrounds';
+import Body from '@weco/content/components/Body/Body';
+import { fetchProject } from '@weco/content/services/prismic/fetch/projects';
+import { isVanityUrl } from '@weco/content/utils/urls';
+
+type ProjectProps = {
+  project: ProjectType;
+  staticContent: ReactElement | null;
+  vanityUrl?: string | undefined;
+  jsonLd: JsonLdObj;
+  gaDimensions: GaDimensions;
+};
+
+export const getServerSideProps: GetServerSideProps<
+  ProjectProps | AppErrorProps
+> = async context => {
+  setCacheControl(context.res);
+  const { projectId } = context.query;
+
+  if (!looksLikePrismicId(projectId)) {
+    return { notFound: true };
+  }
+
+  const client = createClient(context);
+
+  const vanityUrl = isVanityUrl(projectId, context.resolvedUrl)
+    ? context.resolvedUrl
+    : undefined;
+
+  const projectDocument = await fetchProject(client, projectId);
+
+  const project = transformProject(projectDocument);
+
+  if (isNotUndefined(project)) {
+    const serverData = await getServerData(context);
+
+    const jsonLd = contentLd(project);
+
+    return {
+      props: serialiseProps({
+        project,
+        staticContent: null,
+        jsonLd,
+        serverData,
+        vanityUrl,
+        gaDimensions: {
+          partOf: project.seasons?.map(season => season.id),
+        },
+      }),
+    };
+  }
+
+  return { notFound: true };
+};
+
+export const Project: FunctionComponent<ProjectProps> = ({
+  project,
+  staticContent,
+  vanityUrl,
+  jsonLd,
+}) => {
+  function makeLabels(title?: string): LabelsListProps | undefined {
+    if (!title) return;
+
+    return { labels: [{ text: title }] };
+  }
+
+  const labels = !project.format?.title
+    ? makeLabels(project.format?.title)
+    : undefined;
+
+  const featuredPicture =
+    project.untransformedBody.length > 1 &&
+    isEditorialImage(project.untransformedBody[0])
+      ? project.untransformedBody[0]
+      : undefined;
+
+  const featuredVideo =
+    project.untransformedBody.length > 1 &&
+    isVideoEmbed(project.untransformedBody[0])
+      ? project.untransformedBody[0]
+      : undefined;
+
+  const transformFeaturedVideo =
+    featuredVideo && transformEmbedSlice(featuredVideo);
+
+  const hasFeaturedMedia =
+    isNotUndefined(featuredPicture) || isNotUndefined(featuredVideo);
+
+  const untransformedBody = hasFeaturedMedia
+    ? project.untransformedBody.slice(1, project.untransformedBody.length)
+    : project.untransformedBody;
+
+  const featuredMedia = featuredPicture ? (
+    getFeaturedPictureWithTasl(featuredPicture)
+  ) : transformFeaturedVideo ? (
+    <VideoEmbed {...transformFeaturedVideo.value} />
+  ) : undefined;
+
+  const sectionLevelPage = sectionLevelPages.includes(project.id);
+
+  const Header = (
+    <PageHeader
+      breadcrumbs={{ items: [] }}
+      labels={labels}
+      title={project.title}
+      FeaturedMedia={featuredMedia}
+      backgroundTexture={
+        !featuredMedia && !sectionLevelPage ? headerBackgroundLs : undefined
+      }
+      highlightHeading={true}
+      isContentTypeInfoBeforeMedia={false}
+      sectionLevelPage={sectionLevelPage}
+    />
+  );
+
+  // If we have a vanity URL, we prefer that for the link rel="canonical"
+  // in the page <head>; it means the canonical URL will match the links
+  // we put elsewhere on the website, e.g. in the header.
+  const pathname = vanityUrl || `/projects/${project.id}`;
+
+  return (
+    <PageLayout
+      title={project.title}
+      description={project.metadataDescription || project.promo?.caption || ''}
+      url={{ pathname }}
+      jsonLd={jsonLd}
+      openGraphType="website"
+      image={project.image}
+      apiToolbarLinks={[createPrismicLink(project.id)]}
+    >
+      <ContentPage
+        id={project.id}
+        Header={Header}
+        Body={
+          <Body
+            untransformedBody={untransformedBody}
+            pageId={project.id}
+            sectionLevelPage={sectionLevelPage}
+            staticContent={staticContent}
+          />
+        }
+        seasons={project.seasons}
+        contributors={project.contributors}
+      />
+    </PageLayout>
+  );
+};
+
+export default Project;

--- a/content/webapp/pages/projects/[projectId].tsx
+++ b/content/webapp/pages/projects/[projectId].tsx
@@ -23,9 +23,9 @@ import { isEditorialImage, isVideoEmbed } from '@weco/content/types/body';
 import { headerBackgroundLs } from '@weco/common/utils/backgrounds';
 import Body from '@weco/content/components/Body/Body';
 import { fetchProject } from '@weco/content/services/prismic/fetch/projects';
-import { isVanityUrl } from '@weco/content/utils/urls';
 import { makeLabels } from '@weco/common/views/components/LabelsList/LabelsList';
 import { getBreadcrumbItems } from '@weco/common/views/components/Breadcrumb/Breadcrumb';
+import { isVanityUrl } from '@weco/content/utils/urls';
 
 type ProjectProps = {
   project: ProjectType;
@@ -53,9 +53,9 @@ export const getServerSideProps: GetServerSideProps<
 
   const projectDocument = await fetchProject(client, projectId);
 
-  const project = transformProject(projectDocument);
+  if (isNotUndefined(projectDocument)) {
+    const project = transformProject(projectDocument);
 
-  if (isNotUndefined(project)) {
     const serverData = await getServerData(context);
 
     const jsonLd = contentLd(project);

--- a/content/webapp/pages/whats-on/index.tsx
+++ b/content/webapp/pages/whats-on/index.tsx
@@ -319,7 +319,7 @@ export const getServerSideProps: GetServerSideProps<
     period = 'current-and-coming-up';
   }
 
-  const whatsOnPagePromise = fetchPage(client, prismicPageIds.whatsOn, 'pages');
+  const whatsOnPagePromise = fetchPage(client, prismicPageIds.whatsOn);
 
   const exhibitionsQueryPromise = fetchExhibitions(client, {
     period,

--- a/content/webapp/services/prismic/fetch/guides.ts
+++ b/content/webapp/services/prismic/fetch/guides.ts
@@ -1,12 +1,16 @@
 import { fetcher, GetByTypeParams, GetServerSidePropsPrismicClient } from '.';
 import * as prismic from '@prismicio/client';
-import { pagesFetchLinks } from '@weco/content/services/prismic/types';
+import {
+  guideFetchLinks,
+  guideFormatsFetchLinks,
+  pagesFetchLinks,
+} from '@weco/content/services/prismic/types';
 import {
   GuidesDocument as RawGuidesDocument,
   GuideFormatsDocument as RawGuideFormatsDocument,
 } from '@weco/common/prismicio-types';
 
-const fetchLinks = [];
+const fetchLinks = [...guideFormatsFetchLinks, ...guideFetchLinks];
 
 const guidesFetcher = fetcher<RawGuidesDocument>('guides', fetchLinks);
 const guideFormatsFetcher = fetcher<RawGuideFormatsDocument>(
@@ -31,6 +35,17 @@ export const fetchGuides = (
     fetchLinks: pagesFetchLinks,
     ...opts,
   });
+};
+export const fetchGuide = async (
+  client: GetServerSidePropsPrismicClient,
+  id: string
+): Promise<RawGuidesDocument | undefined> => {
+  // TODO once redirects are in place we should only fetch by uid
+  const guideDocument =
+    (await guidesFetcher.getById(client, id)) ||
+    (await guidesFetcher.getByUid(client, id));
+
+  return guideDocument;
 };
 
 export const fetchGuideFormats = guideFormatsFetcher.getByType;

--- a/content/webapp/services/prismic/fetch/guides.ts
+++ b/content/webapp/services/prismic/fetch/guides.ts
@@ -1,6 +1,7 @@
 import { fetcher, GetByTypeParams, GetServerSidePropsPrismicClient } from '.';
 import * as prismic from '@prismicio/client';
 import {
+  commonPrismicFieldsFetchLinks,
   guideFetchLinks,
   guideFormatsFetchLinks,
   pagesFetchLinks,
@@ -10,7 +11,11 @@ import {
   GuideFormatsDocument as RawGuideFormatsDocument,
 } from '@weco/common/prismicio-types';
 
-const fetchLinks = [...guideFormatsFetchLinks, ...guideFetchLinks];
+const fetchLinks = [
+  ...commonPrismicFieldsFetchLinks,
+  ...guideFormatsFetchLinks,
+  ...guideFetchLinks,
+];
 
 const guidesFetcher = fetcher<RawGuidesDocument>('guides', fetchLinks);
 const guideFormatsFetcher = fetcher<RawGuideFormatsDocument>(

--- a/content/webapp/services/prismic/fetch/pages.ts
+++ b/content/webapp/services/prismic/fetch/pages.ts
@@ -19,6 +19,7 @@ import {
   seasonsFetchLinks,
   seriesFetchLinks,
   teamsFetchLinks,
+  commonPrismicFieldsFetchLinks,
 } from '@weco/content/services/prismic/types';
 import { PagesDocument as RawPagesDocument } from '@weco/common/prismicio-types';
 import { labelsFields } from '@weco/content/services/prismic/fetch-links';
@@ -26,6 +27,7 @@ import { Page } from '@weco/content/types/pages';
 import { SiblingsGroup } from '@weco/content/types/siblings-group';
 
 export const fetchLinks = [
+  ...commonPrismicFieldsFetchLinks,
   ...pagesFetchLinks,
   ...seriesFetchLinks,
   ...eventSeriesFetchLinks,

--- a/content/webapp/services/prismic/fetch/pages.ts
+++ b/content/webapp/services/prismic/fetch/pages.ts
@@ -20,10 +20,7 @@ import {
   seriesFetchLinks,
   teamsFetchLinks,
 } from '@weco/content/services/prismic/types';
-import {
-  GuidesDocument as RawGuidesDocument,
-  PagesDocument as RawPagesDocument,
-} from '@weco/common/prismicio-types';
+import { PagesDocument as RawPagesDocument } from '@weco/common/prismicio-types';
 import { labelsFields } from '@weco/content/services/prismic/fetch-links';
 import { Page } from '@weco/content/types/pages';
 import { SiblingsGroup } from '@weco/content/types/siblings-group';
@@ -50,38 +47,20 @@ export const fetchLinks = [
   ...guideFetchLinks,
 ];
 
-export type ValidPagesContentTypes = 'pages' | 'guides' | 'projects';
-/* eslint-disable @typescript-eslint/no-explicit-any */
-export function isValidPagesContentType(
-  type: any
-): type is ValidPagesContentTypes {
-  /* eslint-enable @typescript-eslint/no-explicit-any */
-  return typeof type && ['pages', 'guides', 'projects'].includes(type);
-}
-
 /** Although these are three different document types in Prismic, they all get
  * rendered (and fetched) by the same component.
  */
-const pagesFetcher = fetcher<RawPagesDocument>(
-  ['pages', 'guides', 'projects'],
-  fetchLinks
-);
-
-type PagesContentTypes = RawPagesDocument | RawGuidesDocument;
+const pagesFetcher = fetcher<RawPagesDocument>(['pages'], fetchLinks);
 
 export const fetchPages = pagesFetcher.getByType;
 export const fetchPage = async (
   client: GetServerSidePropsPrismicClient,
-  id: string,
-  contentType: ValidPagesContentTypes
-): Promise<PagesContentTypes | undefined> => {
+  id: string
+): Promise<RawPagesDocument | undefined> => {
   // TODO once redirects are in place we should only fetch by uid
   const pageDocument =
     (await pagesFetcher.getById(client, id)) ||
-    (await fetcher<PagesContentTypes>(contentType, fetchLinks).getByUid(
-      client,
-      id
-    ));
+    (await pagesFetcher.getByUid(client, id));
 
   return pageDocument;
 };

--- a/content/webapp/services/prismic/fetch/pages.ts
+++ b/content/webapp/services/prismic/fetch/pages.ts
@@ -23,7 +23,6 @@ import {
 import {
   GuidesDocument as RawGuidesDocument,
   PagesDocument as RawPagesDocument,
-  ProjectsDocument as RawProjectsDocument,
 } from '@weco/common/prismicio-types';
 import { labelsFields } from '@weco/content/services/prismic/fetch-links';
 import { Page } from '@weco/content/types/pages';
@@ -68,10 +67,7 @@ const pagesFetcher = fetcher<RawPagesDocument>(
   fetchLinks
 );
 
-type PagesContentTypes =
-  | RawPagesDocument
-  | RawProjectsDocument
-  | RawGuidesDocument;
+type PagesContentTypes = RawPagesDocument | RawGuidesDocument;
 
 export const fetchPages = pagesFetcher.getByType;
 export const fetchPage = async (

--- a/content/webapp/services/prismic/fetch/projects.ts
+++ b/content/webapp/services/prismic/fetch/projects.ts
@@ -4,12 +4,14 @@ import {
   contributorFetchLinks,
   projectFormatsFetchLinks,
   seasonsFetchLinks,
-} from '../types';
+} from '@weco/content/services/prismic/types';
+import { labelsFields } from '@weco/content/services/prismic/fetch-links';
 
 export const fetchLinks = [
   ...contributorFetchLinks,
   ...projectFormatsFetchLinks,
   ...seasonsFetchLinks,
+  ...labelsFields,
 ];
 
 const projectsFetcher = fetcher<RawProjectsDocument>('projects', fetchLinks);

--- a/content/webapp/services/prismic/fetch/projects.ts
+++ b/content/webapp/services/prismic/fetch/projects.ts
@@ -1,12 +1,14 @@
 import { GetServerSidePropsPrismicClient, fetcher } from '.';
 import { ProjectsDocument as RawProjectsDocument } from '@weco/common/prismicio-types';
 import {
+  commonPrismicFieldsFetchLinks,
   contributorFetchLinks,
   projectFormatsFetchLinks,
   seasonsFetchLinks,
 } from '@weco/content/services/prismic/types';
 
 export const fetchLinks = [
+  ...commonPrismicFieldsFetchLinks,
   ...contributorFetchLinks,
   ...projectFormatsFetchLinks,
   ...seasonsFetchLinks,

--- a/content/webapp/services/prismic/fetch/projects.ts
+++ b/content/webapp/services/prismic/fetch/projects.ts
@@ -5,13 +5,11 @@ import {
   projectFormatsFetchLinks,
   seasonsFetchLinks,
 } from '@weco/content/services/prismic/types';
-import { labelsFields } from '@weco/content/services/prismic/fetch-links';
 
 export const fetchLinks = [
   ...contributorFetchLinks,
   ...projectFormatsFetchLinks,
   ...seasonsFetchLinks,
-  ...labelsFields,
 ];
 
 const projectsFetcher = fetcher<RawProjectsDocument>('projects', fetchLinks);

--- a/content/webapp/services/prismic/fetch/projects.ts
+++ b/content/webapp/services/prismic/fetch/projects.ts
@@ -1,8 +1,28 @@
-import { fetcher } from '.';
+import { GetServerSidePropsPrismicClient, fetcher } from '.';
 import { ProjectsDocument as RawProjectsDocument } from '@weco/common/prismicio-types';
-import { projectFormatsFetchLinks as fetchLinks } from '../types';
+import {
+  contributorFetchLinks,
+  projectFormatsFetchLinks,
+  seasonsFetchLinks,
+} from '../types';
+
+export const fetchLinks = [
+  ...contributorFetchLinks,
+  ...projectFormatsFetchLinks,
+  ...seasonsFetchLinks,
+];
 
 const projectsFetcher = fetcher<RawProjectsDocument>('projects', fetchLinks);
 
-export const fetchProject = projectsFetcher.getById;
 export const fetchProjects = projectsFetcher.getByType;
+export const fetchProject = async (
+  client: GetServerSidePropsPrismicClient,
+  id: string
+): Promise<RawProjectsDocument | undefined> => {
+  // TODO once redirects are in place we should only fetch by uid
+  const projectDocument =
+    (await projectsFetcher.getById(client, id)) ||
+    (await projectsFetcher.getByUid(client, id));
+
+  return projectDocument;
+};

--- a/content/webapp/services/prismic/transformers/index.ts
+++ b/content/webapp/services/prismic/transformers/index.ts
@@ -9,6 +9,7 @@ import {
   GenericDocWithPromo,
   GenericDocWithMetaDescription,
   RelatedGenericDoc,
+  WithProjectFormat,
 } from '@weco/content/services/prismic/types';
 import { isFilledLinkToDocumentWithData } from '@weco/common/services/prismic/types';
 import {
@@ -31,7 +32,8 @@ export function transformFormat(document: {
     | WithCardFormat
     | WithEventFormat
     | WithGuideFormat
-    | WithPageFormat;
+    | WithPageFormat
+    | WithProjectFormat;
 }): Format | undefined {
   const { format } = document.data;
 

--- a/content/webapp/services/prismic/transformers/json-ld.ts
+++ b/content/webapp/services/prismic/transformers/json-ld.ts
@@ -20,6 +20,8 @@ import {
 } from '@weco/content/types/exhibition-guides';
 import linkResolver from '@weco/common/services/prismic/link-resolver';
 import { Series } from '@weco/content/types/series';
+import { Guide } from '@weco/content/types/guides';
+import { Project } from '@weco/content/types/projects';
 
 // Guide from schema.org
 // https://schema.org/Thing
@@ -213,8 +215,11 @@ function orgLd(org: Organization) {
   );
 }
 
-export function contentLd(content: Page | Season): JsonLdObj {
-  const contributors = content.type === 'seasons' ? [] : content.contributors;
+export function contentLd(content: Page | Guide | Project | Season): JsonLdObj {
+  const contributors =
+    content.type === 'seasons' || content.type === 'guides'
+      ? []
+      : content.contributors;
 
   const author: Contributor = contributors?.find(
     ({ role }) => role && role.title === 'Author'
@@ -240,8 +245,10 @@ export function contentLd(content: Page | Season): JsonLdObj {
             )
           : undefined,
       image: promoImage ? getImageUrlAtSize(promoImage, { w: 600 }) : undefined,
-      datePublished: content.datePublished,
-      dateModified: content.datePublished,
+      datePublished:
+        content.type !== 'projects' ? content.datePublished : undefined,
+      dateModified:
+        content.type !== 'projects' ? content.datePublished : undefined,
       publisher: orgLd(wellcomeCollectionGallery),
       mainEntityOfPage: `https://wellcomecollection.org${url}`,
     },

--- a/content/webapp/services/prismic/transformers/projects.ts
+++ b/content/webapp/services/prismic/transformers/projects.ts
@@ -1,4 +1,4 @@
-import { Project } from '../../../types/projects';
+import { Project } from '@weco/content/types/projects';
 import {
   transformFormat,
   transformGenericFields,
@@ -9,6 +9,9 @@ import {
   SeasonsDocument as RawSeasonsDocument,
   ProjectsDocument as RawProjectsDocument,
 } from '@weco/common/prismicio-types';
+import { SiteSection } from '@weco/common/views/components/PageLayout/PageLayout';
+import { links as headerLinks } from '@weco/common/views/components/Header/Header';
+import { transformContributors } from './contributors';
 
 export function transformProject(document: RawProjectsDocument): Project {
   const { data } = document;
@@ -19,12 +22,24 @@ export function transformProject(document: RawProjectsDocument): Project {
     }
   );
 
+  // TODO (tagging): This is just for now, we will be implementing a proper site tagging
+  // strategy for this later
+  const siteSections = headerLinks.map(link => link.siteSection);
+  const siteSection = document.tags.find(tag =>
+    siteSections.includes(tag as SiteSection)
+  ) as SiteSection;
+
   const promo = genericFields.promo;
+
+  const contributors = transformContributors(document);
+
   return {
     type: 'projects',
     ...genericFields,
     format: transformFormat(document),
     seasons,
     promo: promo && promo.image ? promo : undefined,
+    contributors,
+    siteSection,
   };
 }

--- a/content/webapp/services/prismic/types/index.ts
+++ b/content/webapp/services/prismic/types/index.ts
@@ -517,6 +517,14 @@ export type WithPageFormat = {
   >;
 };
 
+export type WithProjectFormat = {
+  format: prismic.ContentRelationshipField<
+    'project-formats',
+    'en-gb',
+    InferDataInterface<RawProjectFormatsDocument>
+  >;
+};
+
 export type WithEventFormat = {
   format: prismic.ContentRelationshipField<
     'event-formats',

--- a/content/webapp/types/projects.ts
+++ b/content/webapp/types/projects.ts
@@ -1,3 +1,5 @@
+import { SiteSection } from '@weco/common/views/components/PageLayout/PageLayout';
+import { Contributor } from './contributors';
 import { Format } from './format';
 import { GenericContentFields } from './generic-content-fields';
 import { Season } from './seasons';
@@ -6,4 +8,6 @@ export type Project = GenericContentFields & {
   type: 'projects';
   format: Format | undefined;
   seasons: Season[];
+  contributors: Contributor[];
+  siteSection?: SiteSection;
 };

--- a/content/webapp/types/projects.ts
+++ b/content/webapp/types/projects.ts
@@ -6,7 +6,7 @@ import { Season } from './seasons';
 
 export type Project = GenericContentFields & {
   type: 'projects';
-  format: Format | undefined;
+  format?: Format;
   seasons: Season[];
   contributors: Contributor[];
   siteSection?: SiteSection;

--- a/content/webapp/utils/urls.ts
+++ b/content/webapp/utils/urls.ts
@@ -1,0 +1,22 @@
+/** Is this URL a vanity URL?
+ *
+ * e.g. /visit-us instead of /pages/X8ZTSBIAACQAiDzY
+ *
+ * It's moderately fiddly to get all the defined vanity URLs out of the
+ * app controller, so we use a heuristic instead.
+ */
+export function isVanityUrl(pageId: string, url: string): boolean {
+  // Does this URL contain a page ID?  We look for the page ID rather
+  // than a specific prefix, because this template is used for multiple
+  // types of Prismic content.
+  //
+  // e.g. /pages/X8ZTSBIAACQAiDzY, /projects/X_SRxhEAACQAPbwS
+  const containsPageId = url.includes(pageId);
+
+  // This should match a single alphanumeric slug directly after the /
+  //
+  // e.g. /visit-us, /collections
+  const looksLikeVanityUrl = url.match(/\/[a-z-]+/) !== null;
+
+  return !containsPageId && looksLikeVanityUrl;
+}


### PR DESCRIPTION
## What does this change?
Relates to #11147
As part of the work in #11124, I realised Pages, Projects and Guide were using everything from `[pageId]`, including the `pageTransformer`, although guides and projects do not have the same shape, and `fetchPage`.

To simplify `fetchByUid`, which expects to know exactly which content type is being looked for, I've fully split them up, giving them their own fetches.

I've also moved some repeated helper files into various files, but out of `pageId`.


## How to test

Run locally

**Project**
`YNx66hAAACYAG0x8`
`joy-is-a-protest`
URL prefix: `/projects/`

**Page**
`Zmq95BEAACMAGTxS`
`hard-graft--work--health-and-rights`
URL prefix: `/pages/`

**Guide**
`YL9OAxIAAB8AHsyv`
`archives-at-wellcome-collection`
URL prefix: `/guides/`

## How can we measure success?

It's more readable and clearer what is being fetched where, easier to debug these content types.


## Have we considered potential risks?
Some fields aren't being fetched properly and don't display anymore, which we can address if/when it gets flagged.
