### PR TITLE
2. UID: Modify canonical URLs

### DIFF
--- a/content/webapp/pages/articles/[articleId].tsx
+++ b/content/webapp/pages/articles/[articleId].tsx
@@ -329,7 +329,7 @@ const ArticlePage: FunctionComponent<Props> = ({ article, jsonLd }) => {
     <PageLayout
       title={article.title}
       description={article.metadataDescription || article.promo?.caption || ''}
-      url={{ pathname: `/articles/${article.id}` }}
+      url={{ pathname: `/articles/${article.uid}` }}
       jsonLd={jsonLd}
       openGraphType="article"
       siteSection="stories"

--- a/content/webapp/pages/books/[bookId].tsx
+++ b/content/webapp/pages/books/[bookId].tsx
@@ -159,7 +159,7 @@ const BookPage: FunctionComponent<Props> = props => {
     <PageLayout
       title={book.title}
       description={book.metadataDescription || book.promo?.caption || ''}
-      url={{ pathname: `/books/${book.id}` }}
+      url={{ pathname: `/books/${book.uid}` }}
       jsonLd={{ '@type': 'WebPage' }}
       openGraphType="book"
       siteSection="stories"

--- a/content/webapp/pages/event-series/[eventSeriesId].tsx
+++ b/content/webapp/pages/event-series/[eventSeriesId].tsx
@@ -155,7 +155,7 @@ const EventSeriesPage: FunctionComponent<Props> = ({
     <PageLayout
       title={series.title}
       description={series.metadataDescription || series.promo?.caption || ''}
-      url={{ pathname: `/event-series/${series.id}` }}
+      url={{ pathname: `/event-series/${series.uid}` }}
       jsonLd={jsonLd}
       openGraphType="website"
       siteSection="whats-on"

--- a/content/webapp/pages/events/[eventId]/index.tsx
+++ b/content/webapp/pages/events/[eventId]/index.tsx
@@ -253,7 +253,7 @@ const EventPage: NextPage<EventProps> = ({
     <PageLayout
       title={event.title}
       description={event.metadataDescription || event.promo?.caption || ''}
-      url={{ pathname: `/events/${event.id}` }}
+      url={{ pathname: `/events/${event.uid}` }}
       jsonLd={jsonLd}
       openGraphType="website"
       siteSection="whats-on"

--- a/content/webapp/pages/exhibitions/[exhibitionId]/index.tsx
+++ b/content/webapp/pages/exhibitions/[exhibitionId]/index.tsx
@@ -60,7 +60,7 @@ const ExhibitionPage: FunctionComponent<ExhibitionProps> = ({
       description={
         exhibition.metadataDescription || exhibition.promo?.caption || ''
       }
-      url={{ pathname: `/exhibitions/${exhibition.id}` }}
+      url={{ pathname: `/exhibitions/${exhibition.uid}` }}
       jsonLd={jsonLd}
       openGraphType="website"
       siteSection="whats-on"

--- a/content/webapp/pages/guides/exhibitions/[id]/[type]/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/[type]/index.tsx
@@ -222,7 +222,7 @@ const ExhibitionGuidePage: FunctionComponent<Props> = props => {
 
   const { egWork } = useToggles();
   const { exhibitionGuide, jsonLd, type, userPreferenceSet } = props;
-  const pathname = `guides/exhibitions/${exhibitionGuide.id}/${type}`;
+  const pathname = `guides/exhibitions/${exhibitionGuide.uid}/${type}`;
   const typeColor = getTypeColor(type);
   const numberOfStops =
     (isExhibitionGuide(exhibitionGuide) &&

--- a/content/webapp/pages/guides/exhibitions/[id]/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/index.tsx
@@ -314,13 +314,13 @@ const ExhibitionGuidePage: FunctionComponent<Props> = ({
     );
 
   const textPathname = exhibitionText?.id
-    ? `guides/exhibitions/${exhibitionText.uid}/captions-and-transcripts`
+    ? `guides/exhibitions/${exhibitionText.id}/captions-and-transcripts`
     : undefined;
   const audioPathname = hasAudio
-    ? `guides/exhibitions/${exhibitionHighlightTour.uid}/audio-without-descriptions`
+    ? `guides/exhibitions/${exhibitionHighlightTour.id}/audio-without-descriptions`
     : undefined;
   const videoPathname = hasVideo
-    ? `guides/exhibitions/${exhibitionHighlightTour.uid}/bsl`
+    ? `guides/exhibitions/${exhibitionHighlightTour.id}/bsl`
     : undefined;
 
   return (

--- a/content/webapp/pages/guides/exhibitions/[id]/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/index.tsx
@@ -289,7 +289,9 @@ const ExhibitionGuidePage: FunctionComponent<Props> = ({
   stopNumber,
 }) => {
   const { egWork } = useToggles();
-
+  console.log(
+    exhibitionGuide?.id || exhibitionText?.id || exhibitionHighlightTour?.id
+  );
   const pageId =
     exhibitionGuide?.id || exhibitionText?.id || exhibitionHighlightTour?.id;
   const pageTitle =

--- a/content/webapp/pages/guides/exhibitions/[id]/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/index.tsx
@@ -289,11 +289,9 @@ const ExhibitionGuidePage: FunctionComponent<Props> = ({
   stopNumber,
 }) => {
   const { egWork } = useToggles();
-  console.log(
-    exhibitionGuide?.id || exhibitionText?.id || exhibitionHighlightTour?.id
-  );
+
   const pageId =
-    exhibitionGuide?.id || exhibitionText?.id || exhibitionHighlightTour?.id;
+    exhibitionGuide?.uid || exhibitionText?.uid || exhibitionHighlightTour?.uid;
   const pageTitle =
     exhibitionGuide?.title ||
     exhibitionText?.title ||
@@ -316,13 +314,13 @@ const ExhibitionGuidePage: FunctionComponent<Props> = ({
     );
 
   const textPathname = exhibitionText?.id
-    ? `guides/exhibitions/${exhibitionText.id}/captions-and-transcripts`
+    ? `guides/exhibitions/${exhibitionText.uid}/captions-and-transcripts`
     : undefined;
   const audioPathname = hasAudio
-    ? `guides/exhibitions/${exhibitionHighlightTour.id}/audio-without-descriptions`
+    ? `guides/exhibitions/${exhibitionHighlightTour.uid}/audio-without-descriptions`
     : undefined;
   const videoPathname = hasVideo
-    ? `guides/exhibitions/${exhibitionHighlightTour.id}/bsl`
+    ? `guides/exhibitions/${exhibitionHighlightTour.uid}/bsl`
     : undefined;
 
   return (

--- a/content/webapp/pages/guides/exhibitions/[id]/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/index.tsx
@@ -291,12 +291,13 @@ const ExhibitionGuidePage: FunctionComponent<Props> = ({
   const { egWork } = useToggles();
 
   const pageId =
+    exhibitionGuide?.id || exhibitionText?.id || exhibitionHighlightTour?.id;
+  const pageUid =
     exhibitionGuide?.uid || exhibitionText?.uid || exhibitionHighlightTour?.uid;
   const pageTitle =
     exhibitionGuide?.title ||
     exhibitionText?.title ||
     exhibitionHighlightTour?.title;
-  const pathname = `guides/exhibitions/${pageId}`;
 
   const highlightStops = exhibitionHighlightTour?.stops;
   const hasVideo =
@@ -327,7 +328,7 @@ const ExhibitionGuidePage: FunctionComponent<Props> = ({
     <PageLayout
       title={pageTitle || ''}
       description={pageDescriptions.exhibitionGuides}
-      url={{ pathname }}
+      url={{ pathname: `guides/exhibitions/${pageUid}` }}
       jsonLd={jsonLd}
       openGraphType="website"
       siteSection="exhibition-guides"
@@ -383,7 +384,7 @@ const ExhibitionGuidePage: FunctionComponent<Props> = ({
             {exhibitionGuide && (
               <ExhibitionGuideLinks
                 availableTypes={exhibitionGuide.availableTypes}
-                pathname={pathname}
+                pathname={`guides/exhibitions/${pageId}`}
               />
             )}
           </Space>

--- a/content/webapp/pages/pages/[pageId].tsx
+++ b/content/webapp/pages/pages/[pageId].tsx
@@ -399,7 +399,7 @@ export const Page: FunctionComponent<Props> = ({
   // If we have a vanity URL, we prefer that for the link rel="canonical"
   // in the page <head>; it means the canonical URL will match the links
   // we put elsewhere on the website, e.g. in the header.
-  const pathname = vanityUrl || `/pages/${page.id}`;
+  const pathname = vanityUrl || `/pages/${page.uid}`;
 
   return (
     <PageLayout

--- a/content/webapp/pages/seasons/[seasonId].tsx
+++ b/content/webapp/pages/seasons/[seasonId].tsx
@@ -87,7 +87,7 @@ const SeasonPage = ({
     <PageLayout
       title={season.title}
       description={season.metadataDescription || season.promo?.caption || ''}
-      url={{ pathname: `/seasons/${season.id}` }}
+      url={{ pathname: `/seasons/${season.uid}` }}
       jsonLd={jsonLd}
       siteSection="whats-on"
       openGraphType="website"

--- a/content/webapp/pages/series/[seriesId].tsx
+++ b/content/webapp/pages/series/[seriesId].tsx
@@ -219,13 +219,11 @@ const ArticleSeriesPage: FunctionComponent<Props> = props => {
     />
   );
 
-  const paginationRoot = `/series/${series.id}`;
-
   return (
     <PageLayout
       title={series.title}
       description={series.metadataDescription || series.promo?.caption || ''}
-      url={{ pathname: paginationRoot }}
+      url={{ pathname: `/series/${series.uid}` }}
       jsonLd={{ '@type': 'WebPage' }}
       siteSection="stories"
       openGraphType="website"

--- a/content/webapp/pages/visual-stories/[visualStoryId].tsx
+++ b/content/webapp/pages/visual-stories/[visualStoryId].tsx
@@ -230,8 +230,8 @@ const VisualStory: FunctionComponent<Props> = ({
   );
 
   const visualStoryPath = visualStory.relatedDocument?.id
-    ? `/${visualStory.relatedDocument.type}/${visualStory.relatedDocument.id}/visual-stories`
-    : `/visual-stories/${visualStory.id}`;
+    ? `/${visualStory.relatedDocument.type}/${visualStory.relatedDocument.uid}/visual-stories`
+    : `/visual-stories/${visualStory.uid}`;
 
   const onThisPageLinks =
     visualStories.length > 0

--- a/content/webapp/pages/visual-stories/[visualStoryId].tsx
+++ b/content/webapp/pages/visual-stories/[visualStoryId].tsx
@@ -229,8 +229,9 @@ const VisualStory: FunctionComponent<Props> = ({
     />
   );
 
+  // Related document UIDs are optional, so if that's the case, use ID as plan B
   const visualStoryPath = visualStory.relatedDocument?.id
-    ? `/${visualStory.relatedDocument.type}/${visualStory.relatedDocument.uid}/visual-stories`
+    ? `/${visualStory.relatedDocument.type}/${visualStory.relatedDocument.uid || visualStory.relatedDocument.id}/visual-stories`
     : `/visual-stories/${visualStory.uid}`;
 
   const onThisPageLinks =


### PR DESCRIPTION
## What does this change?

Part of #11073 

We want the canonical ref to be referencing the UID, not the ID.

## How to test

- Does it break any API Toolbar links to Prismic? (Should be using ID)
- Did I miss any? [See list](https://github.com/wellcomecollection/wellcomecollection.org/issues/11023)
- Does it work with and without `egWorks` on the guides pages, AND with and without the `Prismic staging` toggle as we need to check both legacy (Jason) and new (Kola Nut) guides are supported.

## How can we measure success?

UID becomes the main URLs, incl on Google results

## Have we considered potential risks?

Something breaks?

