### PR TITLE
5. Get Check URL to use uid-based URLs for its checks

### DIFF
--- a/.buildkite/urls/expected_200_urls.txt
+++ b/.buildkite/urls/expected_200_urls.txt
@@ -36,49 +36,47 @@
 /works/d2mach47
 
 # https://wellcome.slack.com/archives/C8X9YKM5X/p1638456535135800
-/articles/W9m2QxcAAF8AFvE5
+/articles/a-brief-history-of-tattoos
 
 # https://wellcome.slack.com/archives/C8X9YKM5X/p1638800127140100
-/event-series/WlYT_SQAACcAWccj
-/articles/WpmW_yUAAKUUF6mV
+/event-series/saturday-studio
+/articles/race--religion-and-the-black-madonna
 
 # https://github.com/wellcomecollection/wellcomecollection.org/issues/7438
-/exhibitions/XOVfTREAAOJmx-Uw
+/exhibitions/heart-n-soul-s-wall-of-change
 
 # This is an article with a webcomics link in the "Try these next" section
-/articles/XLSV-BEAALNzvQVz
+/articles/how-your-hairdresser-could-save-your-life
 
 # This is an article with an event link in the "Try these next" section
-/articles/W_LXOxcAACwAxC5_
+/articles/the-unearthly-children-of-science-fiction-s-cold-war
 
 # This is an example of every content type in Prismic (as of November 2022)
-/articles/YbNRQBEAACMAZfvG
-/books/YRpf9xEAADVQ33g6
-/event-series/XLWcIBEAAGC6wYZr
-/events/YUMsAxAAACUASyMn
-/exhibitions/YLjGYhAAACMAed2Z
-/guides/YL9OAxIAAB8AHsyv
-/pages/YLnuVRAAACMAftOt
-/projects/YEIYwhAAACIANd6T
-/seasons/YEY3ZBAAACEASBjA
-/series/X8YMWBIAACUAhwAx
-/visual-stories/ZU4FRhIAACYAUvi8
+# This is an article which is the 'webcomics' type underneath
+/articles/the-mountain
+/books/harlots--whores---hackabouts
+/event-series/smoke-and-mirrors-live-performances
+/events/racial-difference-in-the-anglophone-caribbean
+/exhibitions/tranquillity
+/guides/archives-at-wellcome-collection
+/pages/the-history-and-context-of-our-collections
+/projects/regarding-forests-touring-exhibition
+/seasons/on-happiness
+/series/the-disabled-lockdown-experience
+/visual-stories/genetic-automata-visual-story
 
 # We should test the root exhibition guide page
 /guides/exhibitions
 
 # We should test one example of each exhibition guide format
-/guides/exhibitions/YzwsAREAAHylrxau/audio-without-descriptions
-/guides/exhibitions/YzwsAREAAHylrxau/captions-and-transcripts
-/guides/exhibitions/YzwsAREAAHylrxau/bsl
-
-# This is an article which is the 'webcomics' type underneath
-/articles/YbNRQBEAACMAZfvG
+/guides/exhibitions/in-plain-sight/audio-without-descriptions
+/guides/exhibitions/in-plain-sight/captions-and-transcripts
+/guides/exhibitions/in-plain-sight/bsl
 
 # This is the RawMinds page, which has an ID very similar to the
 # Schools page, but it shouldn't be redirected.  See the router in
 # the content app, where we enable case-sensitive routing.
-/pages/Wuw2MSIAACtd3Sts
+/pages/youth-projects
 
 # This page won't serve anything especially useful, but we want to
 # make sure it won't throw a 500 error

--- a/.buildkite/urls/expected_404_urls.txt
+++ b/.buildkite/urls/expected_404_urls.txt
@@ -26,3 +26,6 @@
 
 # Requesting a page beyond the end of an article series 
 /series/W-XBJxEAAKmng1TG?page=500
+
+# Uses a UID based URL
+/series/inside-our-books?page=500


### PR DESCRIPTION
## What does this change?
Relates to #11073 

Changed the [Check URL tests](https://buildkite.com/wellcomecollection/wc-dot-org-end-to-end-tests/builds/4855#0191c797-ce1b-4e22-9c1f-6a1f639e7be5) to look at URLs based on UIDs instead of ID

<img width="526" alt="Screenshot 2024-09-06 at 14 15 33" src="https://github.com/user-attachments/assets/c8520b79-ba69-4dac-ad3c-fb33d855c906">

## Question for reviewers:
- Do we want to keep some ID-based URLs in there?
- Do we want to test more things?


## How to test

Unsure, if it passes on this PR it should be fine, maybe just have a look at if anything else could be done!

## How can we measure success?

We don't encounter surprise content types that don't support UIDs

## Have we considered potential risks?

Things don't get flagged when they should because we only test by UID