### PR TITLE
CollapsibleContent; use margin instead of transform for indent

### DIFF
--- a/common/views/components/CollapsibleContent/index.tsx
+++ b/common/views/components/CollapsibleContent/index.tsx
@@ -52,7 +52,7 @@ const Content = styled(Space).attrs({
   display: ${props => (props.$hidden ? 'none' : 'block')};
 
   /* 20px to match the width of the .icon above */
-  transform: translateX(20px);
+  margin-left: 20px;
 `;
 
 type Props = PropsWithChildren<{


### PR DESCRIPTION
## What does this change?

Relates to #11037 

[See visual change request in comment here](https://github.com/wellcomecollection/wellcomecollection.org/issues/11037#issuecomment-2340276294).

Before
<img width="328" alt="Screenshot 2024-09-10 at 11 41 23" src="https://github.com/user-attachments/assets/513bc089-69cc-4ead-9a42-2fb49ab38258">


<img width="500" alt="Screenshot 2024-09-10 at 11 44 20" src="https://github.com/user-attachments/assets/e07bf10f-e230-43ff-9c72-98876b48a246">


After
<img width="344" alt="Screenshot 2024-09-10 at 11 41 14" src="https://github.com/user-attachments/assets/cc4a79aa-3695-4503-907d-b98d7e65dab8">

<img width="500" alt="Screenshot 2024-09-10 at 11 44 28" src="https://github.com/user-attachments/assets/163d3d29-cb51-4193-ac3c-81446f81f2d1">


## How to test

Run locally with staging content activated and go to http://localhost:3000/guides/exhibitions/ZthrZRIAACQALvCC/audio-without-descriptions/1

## How can we measure success?

Looks good.

## Have we considered potential risks?
N/A
