### PR TITLE
Just turn up logic

### DIFF
--- a/common/data/hardcoded-ids.ts
+++ b/common/data/hardcoded-ids.ts
@@ -51,6 +51,7 @@ export const prismicPageIds = {
 
 export const eventPolicyIds = {
   schoolBooking: 'W4Vx5h4AACIAehqz',
+  dropIn: 'W3RJeikAACIAF2Mw',
 };
 
 export const getNameFromCollectionVenue = id => {

--- a/content/webapp/components/EventSchedule/EventSchedule.tsx
+++ b/content/webapp/components/EventSchedule/EventSchedule.tsx
@@ -12,8 +12,7 @@ import { font } from '@weco/common/utils/classnames';
 const EventScheduleList: FunctionComponent<{
   groupedEvents: EventsGroup<EventType>[];
   isNotLinkedIds: string[];
-  parentEvent: EventType;
-}> = ({ groupedEvents, isNotLinkedIds, parentEvent }) => (
+}> = ({ groupedEvents, isNotLinkedIds }) => (
   <>
     {groupedEvents.map(
       eventsGroup =>
@@ -31,7 +30,6 @@ const EventScheduleList: FunctionComponent<{
             {eventsGroup.events.map(event => (
               <EventScheduleItem
                 key={event.id}
-                parentEvent={parentEvent}
                 event={event}
                 isNotLinked={isNotLinkedIds.indexOf(event.id) > -1}
               />
@@ -43,7 +41,6 @@ const EventScheduleList: FunctionComponent<{
 );
 
 type Props = {
-  parentEvent: EventType;
   schedule: EventScheduleType;
 };
 
@@ -51,7 +48,7 @@ type Props = {
 // "Festival of Minds and Bodies" (XagmOxAAACIAo0v8), which is
 // a multi-day event with repeated schedule items.  Some of the items
 // span multiple days.
-const EventSchedule: FunctionComponent<Props> = ({ parentEvent, schedule }) => {
+const EventSchedule: FunctionComponent<Props> = ({ schedule }) => {
   const events = schedule.map(({ event }) => event);
   const groupedEvents = groupEventsByDay(events);
   const isNotLinkedIds = schedule
@@ -78,7 +75,6 @@ const EventSchedule: FunctionComponent<Props> = ({ parentEvent, schedule }) => {
           <EventScheduleList
             groupedEvents={futureEvents}
             isNotLinkedIds={isNotLinkedIds}
-            parentEvent={parentEvent}
           />
         </>
       )}
@@ -88,7 +84,6 @@ const EventSchedule: FunctionComponent<Props> = ({ parentEvent, schedule }) => {
           <EventScheduleList
             groupedEvents={pastEvents}
             isNotLinkedIds={isNotLinkedIds}
-            parentEvent={parentEvent}
           />
         </>
       )}

--- a/content/webapp/components/EventSchedule/EventScheduleItem.tsx
+++ b/content/webapp/components/EventSchedule/EventScheduleItem.tsx
@@ -97,7 +97,7 @@ const eventLocations = (locations: Place[], isHybridEvent: boolean) => {
   );
 };
 
-// We have a message block on scheduled events which either displays
+// We have a message block on scheduled events which can display either
 // 'Just turn up' or 'Arrive early to register'
 // N.B. If the criteria to display both messages is satisfied, we only show 'Arrive early to register' (see below)
 // We don't show either message if the following criteria aren't satisfied:

--- a/content/webapp/components/EventSchedule/EventScheduleItem.tsx
+++ b/content/webapp/components/EventSchedule/EventScheduleItem.tsx
@@ -122,11 +122,7 @@ function shouldShowJustTurnUpMessage(event: Event): boolean {
   const hasDropInPolicy = event.policies.some(
     p => p.id === eventPolicyIds.dropIn
   );
-  if (hasDropInPolicy) {
-    return true;
-  } else {
-    return false;
-  }
+  return hasDropInPolicy;
 }
 
 const HintText: FunctionComponent<{ event: Event }> = ({ event }) => {

--- a/content/webapp/components/EventSchedule/EventScheduleItem.tsx
+++ b/content/webapp/components/EventSchedule/EventScheduleItem.tsx
@@ -12,6 +12,7 @@ import { isEventPast } from '../../services/prismic/events';
 import { isPast } from '@weco/common/utils/dates';
 import { HTMLTime } from '@weco/common/views/components/HTMLDateAndTime';
 import { Place } from '@weco/content/types/places';
+import { eventPolicyIds } from '@weco/common/data/hardcoded-ids';
 
 type Props = {
   event: Event;

--- a/content/webapp/components/EventSchedule/EventScheduleItem.tsx
+++ b/content/webapp/components/EventSchedule/EventScheduleItem.tsx
@@ -99,30 +99,58 @@ const eventLocations = (locations: Place[], isHybridEvent: boolean) => {
 
 // We have a message block on scheduled events which either displays
 // 'Just turn up' or 'Arrive early to register'
-// We only show this message if:
-// - the event isn't past AND
-// - it doesn't require booking (either through Eventbrite or by contacting the booking enquiry team) AND
-// - it doesn't have it's own event schedule AND
-// - the parent event isn't Ticketed
-function shouldShowMessage({
-  event,
-  parentEvent,
-}: {
-  event: Event;
-  parentEvent: Event;
-}): boolean {
+// N.B. If the criteria to display both messages is satisfied, we only show 'Arrive early to register' (see below)
+// We don't show either message if the following criteria aren't satisfied:
+function shouldShowMessage(event: Event): boolean {
   return (
     !isEventPast(event) &&
     !event.eventbriteId &&
     !event.bookingEnquiryTeam &&
-    !(event.schedule && event.schedule.length > 1) &&
-    parentEvent.bookingType !== 'Ticketed'
+    !(event.schedule && event.schedule.length > 1)
   );
 }
+// We should show the 'Arrive early to register' message if:
+// - event.hasEarlyRegistration is true AND
+// - the event isn't past AND
+// - it doesn't require booking (either through Eventbrite or by contacting the booking enquiry team) AND
+// - it doesn't have it's own event schedule
+function shouldShowEarlyRegistrationMessage(event: Event): boolean {
+  return event.hasEarlyRegistration;
+}
+
+// We should show the 'Just turn up' message if 'drop in at any time' policy is added to the event AND
+function shouldShowJustTurnUpMessage(event: Event): boolean {
+  const hasDropInPolicy = event.policies.some(
+    p => p.id === eventPolicyIds.dropIn
+  );
+  if (hasDropInPolicy) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+const HintText: FunctionComponent<{ event: Event }> = ({ event }) => {
+  const showMessage = shouldShowMessage(event);
+  const hasEarlyRegistration = shouldShowEarlyRegistrationMessage(event);
+  const hasDropInPolicy = shouldShowJustTurnUpMessage(event);
+  if (showMessage && (hasEarlyRegistration || hasDropInPolicy)) {
+    return (
+      <Space $v={{ size: 'm', properties: ['margin-top'] }}>
+        <Message
+          text={`${
+            hasEarlyRegistration ? 'Arrive early to register' : 'Just turn up'
+          }`}
+        />
+      </Space>
+    );
+  } else {
+    return null;
+  }
+};
 
 const EventScheduleItem: FunctionComponent<Props> = ({
   event,
-  parentEvent,
   isNotLinked,
 }) => {
   const waitForTicketSales =
@@ -217,17 +245,8 @@ const EventScheduleItem: FunctionComponent<Props> = ({
                   <EventBookingButton event={event} />
                 </Space>
               )}
-            {shouldShowMessage({ event, parentEvent }) && (
-              <Space $v={{ size: 'm', properties: ['margin-top'] }}>
-                <Message
-                  text={`${
-                    event.hasEarlyRegistration
-                      ? 'Arrive early to register'
-                      : 'Just turn up'
-                  }`}
-                />
-              </Space>
-            )}
+
+            <HintText event={event} />
 
             {event.secondaryLabels.length > 0 && (
               <Space $v={{ size: 'm', properties: ['margin-top'] }}>

--- a/content/webapp/components/EventSchedule/EventScheduleItem.tsx
+++ b/content/webapp/components/EventSchedule/EventScheduleItem.tsx
@@ -16,7 +16,6 @@ import { eventPolicyIds } from '@weco/common/data/hardcoded-ids';
 
 type Props = {
   event: Event;
-  parentEvent: Event;
   isNotLinked: boolean;
 };
 
@@ -97,7 +96,7 @@ const eventLocations = (locations: Place[], isHybridEvent: boolean) => {
   );
 };
 
-// We have a message block on scheduled events which can display either
+// We have a message block on scheduled events which either displays
 // 'Just turn up' or 'Arrive early to register'
 // N.B. If the criteria to display both messages is satisfied, we only show 'Arrive early to register' (see below)
 // We don't show either message if the following criteria aren't satisfied:

--- a/content/webapp/pages/events/[eventId]/index.tsx
+++ b/content/webapp/pages/events/[eventId]/index.tsx
@@ -273,7 +273,7 @@ const EventPage: NextPage<EventProps> = ({
           <EventDateList event={event} />
         </DateWrapper>
         {event.schedule && event.schedule.length > 0 && (
-          <EventSchedule parentEvent={event} schedule={event.schedule} />
+          <EventSchedule schedule={event.schedule} />
         )}
         {event.ticketSalesStart &&
           showTicketSalesStart(event.ticketSalesStart) && (

--- a/content/webapp/services/prismic/transformers/events.ts
+++ b/content/webapp/services/prismic/transformers/events.ts
@@ -320,7 +320,7 @@ export function transformEvent(
     policies: Array.isArray(data.policies)
       ? transformEventPolicyLabels(data.policies, 'policy')
       : [],
-    hasEarlyRegistration: Boolean(data.hasEarlyRegistration),
+    hasEarlyRegistration: Boolean(data.hasEarlyRegistration === 'yes'),
     series,
     seasons,
     contributors,

--- a/content/webapp/services/prismic/transformers/events.ts
+++ b/content/webapp/services/prismic/transformers/events.ts
@@ -320,7 +320,7 @@ export function transformEvent(
     policies: Array.isArray(data.policies)
       ? transformEventPolicyLabels(data.policies, 'policy')
       : [],
-    hasEarlyRegistration: Boolean(data.hasEarlyRegistration === 'yes'),
+    hasEarlyRegistration: data.hasEarlyRegistration === 'yes',
     series,
     seasons,
     contributors,


### PR DESCRIPTION
## What does this change?

This changes the logic which determines whether the 'just show up' message is displayed on an EventScheduleItem

The [change was requested by Grace](https://wellcome.slack.com/archives/C8X9YKM5X/p1725962331127929?thread_ts=1717509512.966409&cid=C8X9YKM5X)

The 'just turn up' message will now only show if the 'drop in at any time' policy is added to the event.

There was already logic in place to prevent the message from showing under certain circumstances and I have left this in place. We will only show the message if  
- the event isn't past AND
it doesn't require booking (either through Eventbrite or by contacting the booking enquiry team) AND
- it doesn't have it's own event schedule

Also, if the event has early registration, then we will show 'Arrive early to register' rather than 'Just turn up'

## How to test

- run the site locally with the prismicStage toggle enabled and visit: http://localhost:3000/events/ZQgdkREAAAbr6cRR
- 'just turn up' will display under the first item in the schedule, because it has the 'drop in' policy added to it.
- remove the policy from the Lights Up on Beauty 23 Nov event and 'just turn up' will disappear.
- if you run the site on main, i.e. without the changes in this PR, the 'just turn up' message will display regardless of whether the policy is added to the event.
- when running the site back on this branch and setting the early registration to true on the Lights Up on Beauty 23 Nov event, 'Arrive early to register' will display instead of 'Just turn up' even when the 'drop in' policy is added.

## How can we measure success?

'Just turn up' doesn't appear on events in a schedule when we don't want it to:

localhost:3000/events/Zs39phAAACAAPHHO

vs

https://preview.wellcomecollection.org/events/Zs39phAAACAAPHHO


## Have we considered potential risks?

I've altered the logic for displaying the message in unintended ways. I've tested various scenarios

