### PR TITLE
Change URL in dashboard for prismic document editing

### DIFF
--- a/dash/README.md
+++ b/dash/README.md
@@ -4,6 +4,6 @@ Dashboard at <https://dash.wellcomecollection.org>.
 
 ## Deployments
 1. Make sure you have packages installed (`yarn install`) and that `yarn build` has been run recently.
-2. You will need to be logged into AWS with the correct role (`experience-developer`).
+2. You will need to be logged into AWS with the correct role (`AWS_PROFILE=experience-developer`).
 3. `yarn build` will have created an output folder (`out`). This is what will get deployed to S3.
 4. Run `yarn deploy`.

--- a/dash/webapp/pages/prismic-linting.tsx
+++ b/dash/webapp/pages/prismic-linting.tsx
@@ -64,7 +64,7 @@ const Index: FunctionComponent = () => {
               {resultsList.errors.map(e => (
                 <>
                   <a
-                    href={`https://wellcomecollection.prismic.io/documents~b=working&c=published&l=en-gb/${e.id}`}
+                    href={`https://wellcomecollection.prismic.io/builder/pages/${e.id}`}
                   >
                     <h3>
                       {e.title && e.title.length > 0 ? (


### PR DESCRIPTION
## What does this change?

A follow up to https://github.com/wellcomecollection/wellcomecollection.org/pull/11167, I hadn't realised it wasn't reusing the same URL...

## How to test

Deploy dash from local, but I've done it now so unless there's been a redeployment since you should be able to see the change. https://dash.wellcomecollection.org/prismic-linting

## How can we measure success?

Actually useful for editors!

## Have we considered potential risks?
N/A