### PR TITLE
Add a Prismic linting UID check

### DIFF
--- a/prismic-model/lintPrismicData.ts
+++ b/prismic-model/lintPrismicData.ts
@@ -9,6 +9,7 @@
  */
 
 import chalk from 'chalk';
+import fs from 'fs';
 import { error } from './console';
 import {
   downloadPrismicSnapshot,
@@ -173,6 +174,41 @@ function detectIncompleteContributorSameAs(doc: any): string[] {
   return [];
 }
 
+// Some Content Type documents should now always have a UID, but some have seemed to escape us
+// so we're adding this as a safeguarding since we'll depend on them for URLs.
+// We have to then get all the types that have that field, which we wanted to be a dynamic fetch
+// so it didn't need a manual add every time.
+const getContentTypesWithUid = () => {
+  const files = fs.readdirSync('../common/customtypes/');
+
+  return files
+    .map(f => {
+      const file = fs.readFileSync(
+        `../common/customtypes/${f}/index.json`,
+        'utf8'
+      );
+
+      let label;
+      if (file) {
+        const fileObject = JSON.parse(file);
+        const firstChildJsonSection = Object.values(fileObject.json)?.[0] as
+          | { uid?: string }
+          | undefined;
+
+        if (firstChildJsonSection && 'uid' in firstChildJsonSection)
+          label = fileObject.id;
+      }
+      return label;
+    })
+    .filter(f => f);
+};
+const contentTypesWithUid = getContentTypesWithUid();
+function detectMissingUidDocuments(doc: any): string[] {
+  return contentTypesWithUid.includes(doc.type) && !doc.uid
+    ? [`Document ${doc.id} (${doc.type}) is missing a UID, please go add one.`]
+    : [];
+}
+
 async function run() {
   const snapshotFile = await downloadPrismicSnapshot();
 
@@ -187,6 +223,7 @@ async function run() {
       ...detectNonHttpContributorLinks(doc),
       ...detectNonPromoImageStories(doc),
       ...detectIncompleteContributorSameAs(doc),
+      ...detectMissingUidDocuments(doc),
     ];
 
     totalErrors += errors.length;


### PR DESCRIPTION
## What does this change?

Added a test that checks 1. which content types have a UID and 2. if one of their document is missing one.
I think the logic makes sense but it's possibly a bit iffy as it assumes the UID field is always in the first tab of the editor?

## How to test

Run script locally.

<img width="704" alt="Screenshot 2024-09-12 at 13 53 20" src="https://github.com/user-attachments/assets/45d0fc3b-4cf5-43ee-b076-4ef07cbd66d1">


## How can we measure success?

N/A

## Have we considered potential risks?

N/A