### PR TITLE
Digital guides exhibition index page copy amendments

### DIFF
--- a/content/webapp/components/ExhibitionGuideLinks/ExhibitionGuideLinks.tsx
+++ b/content/webapp/components/ExhibitionGuideLinks/ExhibitionGuideLinks.tsx
@@ -150,14 +150,14 @@ export const ExhibitionResourceLinks: FunctionComponent<ResourceProps> = ({
               </Space>
               <p>
                 Find out more about the exhibition with our highlights tour,
-                available in short audio clips with transcripts or as British
-                Sign Language videos.
+                available in short audio clips with audio description and
+                transcripts, or as British Sign Language videos.
               </p>
               <TypeList>
                 {audioPathname && (
                   <TypeOption
                     url={`/${audioPathname}${stopNumber ? `/${stopNumber}` : ''}`}
-                    title="Audio descriptive tour with transcripts"
+                    title="Listen to audio"
                     text="Find out more about the exhibition with short audio tracks."
                     backgroundColor="accent.lightSalmon"
                     icon={audioDescribed}
@@ -167,7 +167,7 @@ export const ExhibitionResourceLinks: FunctionComponent<ResourceProps> = ({
                 {videoPathname && (
                   <TypeOption
                     url={`/${videoPathname}${stopNumber ? `/${stopNumber}` : ''}`}
-                    title="British Sign Language tour with transcripts"
+                    title="Watch British Sign Language videos"
                     text="Commentary about the exhibition in British Sign Language videos."
                     backgroundColor="accent.lightBlue"
                     icon={britishSignLanguage}

--- a/content/webapp/pages/guides/exhibitions/[id]/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/index.tsx
@@ -342,7 +342,7 @@ const ExhibitionGuidePage: FunctionComponent<Props> = ({
     >
       {egWork && (
         <PageHeader
-          title={`${pageTitle} digital guide`}
+          title={`${pageTitle} digital guides`}
           breadcrumbs={{
             items: [
               {


### PR DESCRIPTION
## What does this change?

Relates to #11174 

![Screenshot 2024-09-12 at 14 49 36](https://github.com/user-attachments/assets/703d8876-e23a-45bf-a311-da362e1e31b0)

[Slack chat for Lauren's review](https://wellcome.slack.com/archives/CUA669WHH/p1726148985668539)

## How to test

Run locally
Confirm it doesn't affect legacy exhibition guide copy or copy without toggle on.

## How can we measure success?

N/A

## Have we considered potential risks?
N/A