### PR TITLE
Remove toggle check on redirection for Digital Guides

### DIFF
--- a/content/webapp/utils/digital-guides.ts
+++ b/content/webapp/utils/digital-guides.ts
@@ -74,9 +74,8 @@ export const getGuidesRedirections = (
 ) => {
   const { req, res, resolvedUrl } = context;
   const { id: guideId, stopNumber, stopId, type, usingQRCode } = context.query;
-  const hasEgWorkCookie = getCookie('toggle_egWork', { req, res }) === 'true';
 
-  if (!usingQRCode) return;
+  if (toMaybeString(usingQRCode) !== 'true') return;
 
   const userPreferenceGuideType = getCookie(cookies.exhibitionGuideType, {
     req,
@@ -115,8 +114,7 @@ export const getGuidesRedirections = (
   const hasValidStopNumber =
     typeof stopNumber === 'string' && !!Number(stopNumber);
 
-  // TODO remove hasEgWorkCookie check once toggle is removed
-  if (hasEgWorkCookie && hasValidUserPreference && hasValidStopNumber) {
+  if (hasValidUserPreference && hasValidStopNumber) {
     return {
       redirect: {
         permanent: false,


### PR DESCRIPTION
## What does this change?

Now that the `egWork` toggle is set to true publicly, we're happy to remove the check.
The value isn't returned properly when checked in the code since remote toggle values (publicly set ones) are not being fetched yet, only on the client. We _should_ add something to fetch them SS, but because we need this to work today, as agreed with Lauren we're happy to remove this bit in the code to fix it.
Legacy EG should still be supported, so it shouldn't cause any issues.

## How to test

- new type: `guides/exhibitions/ZsdFlRIAACIAqKGB?usingQRCode=true&stopNumber=2&utm_source=Gallery1&utm_medium=QRCode&utm_id=HardGraftGuides&utm_content=Stop2`
- legacy type: `guides/exhibitions/Zdcs4BEAACMA6abC/audio-without-descriptions?utm_campaign=JasonWilsherMillsGuide&utm_medium=QRCode&utm_source=Gallery2&utm_content=Stop07&usingQRCode=true&stopId=mum-as-a-mermaid-10#mum-as-a-mermaid-10`

## Success

Redirects work for both DG types without toggles being needed


## Risk

Breaks current redirects, but well tested it should be fine
