### PR TITLE
Use new workType to identify BD works

### DIFF
--- a/content/webapp/components/ExpandedImage/ExpandedImage.tsx
+++ b/content/webapp/components/ExpandedImage/ExpandedImage.tsx
@@ -204,8 +204,9 @@ const ExpandedImage: FunctionComponent<Props> = ({
       imageUrl: string
     ) => {
       const imageLocationBase = imageUrl.replace('/info.json', '');
-      const iiifManifest =
-        await fetchIIIFPresentationManifest(manifestLocation);
+      const iiifManifest = await fetchIIIFPresentationManifest({
+        location: manifestLocation,
+      });
       const transformedManifest =
         iiifManifest && transformManifest(iiifManifest);
       const { firstCollectionManifestLocation, canvases } = {

--- a/content/webapp/pages/works/[workId]/download.tsx
+++ b/content/webapp/pages/works/[workId]/download.tsx
@@ -210,7 +210,7 @@ export const getServerSideProps: GetServerSideProps<
   const manifestLocation = getDigitalLocationOfType(work, 'iiif-presentation');
   const iiifManifest =
     manifestLocation &&
-    (await fetchIIIFPresentationManifest(manifestLocation.url));
+    (await fetchIIIFPresentationManifest({ location: manifestLocation.url }));
   const transformedManifest = iiifManifest && transformManifest(iiifManifest);
 
   return {

--- a/content/webapp/pages/works/[workId]/index.tsx
+++ b/content/webapp/pages/works/[workId]/index.tsx
@@ -257,9 +257,13 @@ export const getServerSideProps: GetServerSideProps<
     work,
     'iiif-presentation'
   );
+
   const iiifManifest =
     iiifPresentationLocation &&
-    (await fetchIIIFPresentationManifest(iiifPresentationLocation.url));
+    (await fetchIIIFPresentationManifest({
+      location: iiifPresentationLocation.url,
+      workType: work.workType?.label,
+    }));
 
   const transformedManifest = iiifManifest && transformManifest(iiifManifest);
 

--- a/content/webapp/pages/works/[workId]/index.tsx
+++ b/content/webapp/pages/works/[workId]/index.tsx
@@ -262,7 +262,7 @@ export const getServerSideProps: GetServerSideProps<
     iiifPresentationLocation &&
     (await fetchIIIFPresentationManifest({
       location: iiifPresentationLocation.url,
-      workType: work.workType?.label,
+      workTypeId: work.workType?.id,
     }));
 
   const transformedManifest = iiifManifest && transformManifest(iiifManifest);

--- a/content/webapp/pages/works/[workId]/items.tsx
+++ b/content/webapp/pages/works/[workId]/items.tsx
@@ -401,7 +401,9 @@ export const getServerSideProps: GetServerSideProps<
   );
   const iiifManifest =
     iiifPresentationLocation &&
-    (await fetchIIIFPresentationManifest(iiifPresentationLocation.url));
+    (await fetchIIIFPresentationManifest({
+      location: iiifPresentationLocation.url,
+    }));
 
   const transformedManifest = iiifManifest && transformManifest(iiifManifest);
 
@@ -417,9 +419,9 @@ export const getServerSideProps: GetServerSideProps<
     if (isCollectionManifest) {
       const selectedCollectionManifestLocation = manifests?.[manifestIndex]?.id;
       const selectedCollectionManifest = selectedCollectionManifestLocation
-        ? await fetchIIIFPresentationManifest(
-            selectedCollectionManifestLocation
-          )
+        ? await fetchIIIFPresentationManifest({
+            location: selectedCollectionManifestLocation,
+          })
         : undefined;
       const firstChildTransformedManifest =
         selectedCollectionManifest &&

--- a/content/webapp/services/iiif/fetch/manifest.ts
+++ b/content/webapp/services/iiif/fetch/manifest.ts
@@ -1,21 +1,23 @@
 import { Manifest } from '@iiif/presentation-3';
 
-async function getIIIFManifest(url: string): Promise<Manifest | undefined> {
+async function getIIIFManifest(
+  url: string,
+  workType?: string
+): Promise<Manifest | undefined> {
   try {
     const resp = await fetch(url);
 
     if (resp.status === 404) {
       const bnumber = url.match(/b[0-9]{7}[0-9x]/)?.[0];
 
-      // We have to add this condition because of a known issue with BD works and Archivemetica
+      // We have to add this condition because of a known issue with BD works and Archivematica
       // We don't want the error to be sent if it's part of the known issue.
       // https://github.com/wellcomecollection/wellcomecollection.org/issues/10907
       // TODO: Check in once in a while to see if it's been fixed. There is not ticket to link to currently for that piece of work.
 
-      // TEMP FIX: If location doesn't contain a B number, we assume that it is a Born Digital work.
-      // This works for now but won't in the future as more BD works come in
-      // TODO: Change how it's done once https://github.com/wellcomecollection/catalogue-pipeline/issues/2659 is through.
-      if (bnumber) {
+      // This label identifies Born Digital works
+      // https://github.com/wellcomecollection/catalogue-pipeline/issues/2659
+      if (workType !== 'Archives - Digital') {
         const dashboardUrl = `https://iiif.wellcomecollection.org/dash/Manifestation/${bnumber}`;
 
         console.error(
@@ -37,14 +39,18 @@ async function getIIIFManifest(url: string): Promise<Manifest | undefined> {
   }
 }
 
-export async function fetchIIIFPresentationManifest(
-  location: string
-): Promise<Manifest | undefined> {
+export async function fetchIIIFPresentationManifest({
+  location,
+  workType,
+}: {
+  location: string;
+  workType?: string;
+}): Promise<Manifest | undefined> {
   // TODO once we're using v3 everywhere,
   // we'll want the catalogue API to return v3, then we can stop doing the following
   const v3Location = location.replace('/v2/', '/v3/');
 
-  const iiifManifest = await getIIIFManifest(v3Location);
+  const iiifManifest = await getIIIFManifest(v3Location, workType);
 
   return iiifManifest;
 }

--- a/content/webapp/services/iiif/fetch/manifest.ts
+++ b/content/webapp/services/iiif/fetch/manifest.ts
@@ -2,7 +2,7 @@ import { Manifest } from '@iiif/presentation-3';
 
 async function getIIIFManifest(
   url: string,
-  workType?: string
+  workTypeId?: string
 ): Promise<Manifest | undefined> {
   try {
     const resp = await fetch(url);
@@ -15,9 +15,9 @@ async function getIIIFManifest(
       // https://github.com/wellcomecollection/wellcomecollection.org/issues/10907
       // TODO: Check in once in a while to see if it's been fixed. There is not ticket to link to currently for that piece of work.
 
-      // This label identifies Born Digital works
+      // This workType ID identifies Born Digital works ("Archives - Digital")
       // https://github.com/wellcomecollection/catalogue-pipeline/issues/2659
-      if (workType !== 'Archives - Digital') {
+      if (workTypeId !== 'hdig') {
         const dashboardUrl = `https://iiif.wellcomecollection.org/dash/Manifestation/${bnumber}`;
 
         console.error(
@@ -41,16 +41,16 @@ async function getIIIFManifest(
 
 export async function fetchIIIFPresentationManifest({
   location,
-  workType,
+  workTypeId,
 }: {
   location: string;
-  workType?: string;
+  workTypeId?: string;
 }): Promise<Manifest | undefined> {
   // TODO once we're using v3 everywhere,
   // we'll want the catalogue API to return v3, then we can stop doing the following
   const v3Location = location.replace('/v2/', '/v3/');
 
-  const iiifManifest = await getIIIFManifest(v3Location, workType);
+  const iiifManifest = await getIIIFManifest(v3Location, workTypeId);
 
   return iiifManifest;
 }


### PR DESCRIPTION
## What does this change?

Relates to [#11128](https://github.com/wellcomecollection/wellcomecollection.org/issues/11128), see ticket for details.

## How to test

Difficult to test without a known "broken" work (should have a manifest but doesn't), but we mostly want to make sure the condition makes sense still and nothing of this shows on the alerts channel if it's a BD work

## How can we measure success?

Less hacky good 👍 
Alerts channel not spammed.

## Have we considered potential risks?
Worst case we get the alerts and tweak the condition.