### PR TITLE
Add steps for e2e tests (if necessary) step not to run on main

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -145,6 +145,7 @@
         value: "maybe-later"
       
 - label: "Add steps for e2e tests (if necessary)"
+  if: build.branch != "main"
   depends_on: "ask-user-if-should-run-e2es"
   command: |
     if [[ "$$(buildkite-agent meta-data get should-run-e2es)" == "yes" ]]; then


### PR DESCRIPTION
## What does this change?

Following https://github.com/wellcomecollection/wellcomecollection.org/pull/11183 it was noticed that the `"Add steps for e2e tests (if necessary)"` was still run on `main` even though it doesn't do anything (we run e2e tests in the deployment pipeline for `main`)
See: https://wellcome.slack.com/archives/CUA669WHH/p1726676801756259

## How to test

When merging something to `main` check the [wc.org: build + test](https://buildkite.com/wellcomecollection/wc-dot-org-build-plus-test) pipeline. It should not have a "Add steps for e2e tests (if necessary)" step.

## How can we measure success?

Less noise in the pipeline. 

## Have we considered potential risks?

This step currently fails gracefully and doesn't do anything. 

