### PR TITLE
Remove `egWorks` toggle/conditions & legacy QR codes support

### DIFF
--- a/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.Stop.tsx
+++ b/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.Stop.tsx
@@ -15,10 +15,7 @@ import { Container } from '@weco/common/views/components/styled/Container';
 import Space from '@weco/common/views/components/styled/Space';
 import { PaletteColor } from '@weco/common/views/themes/config';
 import ZoomedPrismicImage from '@weco/content/components/ZoomedPrismicImage/ZoomedPrismicImage';
-import {
-  ExhibitionGuideComponent,
-  ExhibitionGuideType,
-} from '@weco/content/types/exhibition-guides';
+import { ExhibitionGuideComponent } from '@weco/content/types/exhibition-guides';
 
 export const StandaloneTitle = styled(Space).attrs({
   as: 'h2',
@@ -30,8 +27,7 @@ export const StandaloneTitle = styled(Space).attrs({
   position: relative;
   margin-bottom: 0;
 
-  background: ${props =>
-    props.theme.color(getTypeColor('captions-and-transcripts'))};
+  background: ${props => props.theme.color('accent.lightGreen')};
 `;
 
 type LevelProps = { $level: number };
@@ -138,18 +134,6 @@ function calculateTombstoneHeadingLevel(titlesUsed: TitlesUsed): number {
     return 3;
   } else {
     return 2;
-  }
-}
-
-export function getTypeColor(type: ExhibitionGuideType): PaletteColor {
-  switch (type) {
-    case 'bsl':
-      return 'accent.lightBlue';
-    case 'audio-without-descriptions':
-      return 'accent.lightSalmon';
-    case 'captions-and-transcripts':
-    default:
-      return 'accent.lightGreen';
   }
 }
 

--- a/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
+++ b/content/webapp/components/ExhibitionCaptions/ExhibitionCaptions.tsx
@@ -3,7 +3,7 @@ import { FunctionComponent } from 'react';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
 import { ExhibitionGuideComponent } from '@weco/content/types/exhibition-guides';
 
-import Stop, { getTypeColor } from './ExhibitionCaptions.Stop';
+import Stop from './ExhibitionCaptions.Stop';
 
 type Props = {
   stops: ExhibitionGuideComponent[];
@@ -51,5 +51,4 @@ const ExhibitionCaptions: FunctionComponent<Props> = ({ stops }) => {
   );
 };
 
-export { getTypeColor };
 export default ExhibitionCaptions;

--- a/content/webapp/components/ExhibitionGuideLinks/ExhibitionGuideLinks.tsx
+++ b/content/webapp/components/ExhibitionGuideLinks/ExhibitionGuideLinks.tsx
@@ -1,11 +1,5 @@
 import { FunctionComponent } from 'react';
 
-import {
-  audioDescribed,
-  britishSignLanguage,
-  speechToText,
-} from '@weco/common/icons';
-import { useToggles } from '@weco/common/server-data/Context';
 import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper/ConditionalWrapper';
 import Space from '@weco/common/views/components/styled/Space';
 import SectionHeader from '@weco/content/components/SectionHeader/SectionHeader';
@@ -25,100 +19,51 @@ export const ExhibitionGuideLinks: FunctionComponent<Props> = ({
   pathname,
   availableTypes,
 }) => {
-  const { egWork } = useToggles();
-
   return (
     <>
-      {egWork ? (
+      {(availableTypes.audioWithoutDescriptions || availableTypes.BSLVideo) && (
         <>
-          {(availableTypes.audioWithoutDescriptions ||
-            availableTypes.BSLVideo) && (
-            <>
-              <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
-                <SectionHeader title="Highlights tour" />
-              </Space>
-              <p>
-                Find out more about the exhibition with our highlights tour,
-                available in short audio clips with transcripts or as British
-                Sign Language videos.
-              </p>
-              <TypeList>
-                {availableTypes.audioWithoutDescriptions && (
-                  <TypeOption
-                    url={`/${pathname}/audio-without-descriptions`}
-                    title="Audio descriptive tour with transcripts"
-                    text="Find out more about the exhibition with short audio tracks."
-                    backgroundColor="accent.lightSalmon"
-                    icon={audioDescribed}
-                    type="audio-without-descriptions"
-                  />
-                )}
-                {availableTypes.BSLVideo && (
-                  <TypeOption
-                    url={`/${pathname}/bsl`}
-                    title="British Sign Language tour with transcripts"
-                    text="Commentary about the exhibition in British Sign Language videos."
-                    backgroundColor="accent.lightBlue"
-                    icon={britishSignLanguage}
-                    type="bsl"
-                  />
-                )}
-              </TypeList>
-            </>
-          )}
-
-          {availableTypes.captionsOrTranscripts && (
-            <Space $v={{ size: 'xl', properties: ['margin-top'] }}>
-              <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
-                <SectionHeader title="Exhibition text" />
-              </Space>
-              <p>All the wall and label text from the exhibition.</p>
-              <TypeList>
-                <TypeOption
-                  url={`/${pathname}/captions-and-transcripts`}
-                  title="Exhibition text"
-                  text="All the wall and label texts from the gallery, plus audio transcripts – great for those without headphones."
-                  backgroundColor="accent.lightGreen"
-                  icon={speechToText}
-                  type="captions-and-transcripts"
-                />
-              </TypeList>
-            </Space>
-          )}
+          <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
+            <SectionHeader title="Highlights tour" />
+          </Space>
+          <p>
+            Find out more about the exhibition with our highlights tour,
+            available in short audio clips with transcripts or as British Sign
+            Language videos.
+          </p>
+          <TypeList>
+            {availableTypes.audioWithoutDescriptions && (
+              <TypeOption
+                url={`/${pathname}/audio-without-descriptions`}
+                title="Audio descriptive tour with transcripts"
+                type="audio-without-descriptions"
+              />
+            )}
+            {availableTypes.BSLVideo && (
+              <TypeOption
+                url={`/${pathname}/bsl`}
+                title="British Sign Language tour with transcripts"
+                type="bsl"
+              />
+            )}
+          </TypeList>
         </>
-      ) : (
-        <TypeList>
-          {availableTypes.audioWithoutDescriptions && (
-            <TypeOption
-              url={`/${pathname}/audio-without-descriptions`}
-              title="Listen to audio"
-              text="Find out more about the exhibition with short audio tracks."
-              backgroundColor="accent.lightSalmon"
-              icon={audioDescribed}
-              type="audio-without-descriptions"
-            />
-          )}
-          {availableTypes.captionsOrTranscripts && (
+      )}
+
+      {availableTypes.captionsOrTranscripts && (
+        <Space $v={{ size: 'xl', properties: ['margin-top'] }}>
+          <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
+            <SectionHeader title="Exhibition text" />
+          </Space>
+          <p>All the wall and label text from the exhibition.</p>
+          <TypeList>
             <TypeOption
               url={`/${pathname}/captions-and-transcripts`}
-              title="Read captions and transcripts"
-              text="All the wall and label texts from the gallery, plus audio transcripts – great for those without headphones."
-              backgroundColor="accent.lightGreen"
-              icon={speechToText}
+              title="Exhibition text"
               type="captions-and-transcripts"
             />
-          )}
-          {availableTypes.BSLVideo && (
-            <TypeOption
-              url={`/${pathname}/bsl`}
-              title="Watch British Sign Language videos"
-              text="Commentary about the exhibition in British Sign Language videos."
-              backgroundColor="accent.lightBlue"
-              icon={britishSignLanguage}
-              type="bsl"
-            />
-          )}
-        </TypeList>
+          </TypeList>
+        </Space>
       )}
     </>
   );
@@ -137,107 +82,59 @@ export const ExhibitionResourceLinks: FunctionComponent<ResourceProps> = ({
   videoPathname,
   stopNumber,
 }) => {
-  const { egWork } = useToggles();
-
   const hasAudioVideo = !!(audioPathname || videoPathname);
 
   return (
     <>
-      {egWork ? (
+      {hasAudioVideo && (
         <>
-          {hasAudioVideo && (
-            <>
-              <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
-                <SectionHeader title="Highlights tour" />
-              </Space>
-              <p>
-                Find out more about the exhibition with our highlights tour,
-                available in short audio clips with audio description and
-                transcripts, or as British Sign Language videos.
-              </p>
-              <TypeList>
-                {audioPathname && (
-                  <TypeOption
-                    url={`/${audioPathname}${stopNumber ? `/${stopNumber}` : ''}`}
-                    title="Listen to audio"
-                    text="Find out more about the exhibition with short audio tracks."
-                    backgroundColor="accent.lightSalmon"
-                    icon={audioDescribed}
-                    type="audio-without-descriptions"
-                  />
-                )}
-                {videoPathname && (
-                  <TypeOption
-                    url={`/${videoPathname}${stopNumber ? `/${stopNumber}` : ''}`}
-                    title="Watch British Sign Language videos"
-                    text="Commentary about the exhibition in British Sign Language videos."
-                    backgroundColor="accent.lightBlue"
-                    icon={britishSignLanguage}
-                    type="bsl"
-                  />
-                )}
-              </TypeList>
-            </>
-          )}
-          {textPathname && (
-            <ConditionalWrapper
-              condition={hasAudioVideo}
-              wrapper={children => (
-                <Space $v={{ size: 'xl', properties: ['margin-top'] }}>
-                  {children}
-                </Space>
-              )}
-            >
-              <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
-                <SectionHeader title="Exhibition text" />
-              </Space>
-              <p>All the wall and label text from the exhibition.</p>
-              <TypeList>
-                <TypeOption
-                  url={`/${textPathname}`}
-                  title="Exhibition text"
-                  text="All the wall and label texts from the gallery, plus audio transcripts – great for those without headphones."
-                  backgroundColor="accent.lightGreen"
-                  icon={speechToText}
-                  type="captions-and-transcripts"
-                />
-              </TypeList>
-            </ConditionalWrapper>
-          )}
+          <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
+            <SectionHeader title="Highlights tour" />
+          </Space>
+          <p>
+            Find out more about the exhibition with our highlights tour,
+            available in short audio clips with audio description and
+            transcripts, or as British Sign Language videos.
+          </p>
+          <TypeList>
+            {audioPathname && (
+              <TypeOption
+                url={`/${audioPathname}${stopNumber ? `/${stopNumber}` : ''}`}
+                title="Listen to audio"
+                type="audio-without-descriptions"
+              />
+            )}
+            {videoPathname && (
+              <TypeOption
+                url={`/${videoPathname}${stopNumber ? `/${stopNumber}` : ''}`}
+                title="Watch British Sign Language videos"
+                type="bsl"
+              />
+            )}
+          </TypeList>
         </>
-      ) : (
-        <TypeList>
-          {audioPathname && (
-            <TypeOption
-              url={`/${audioPathname}`}
-              title="Listen to audio"
-              text="Find out more about the exhibition with short audio tracks."
-              backgroundColor="accent.lightSalmon"
-              icon={audioDescribed}
-              type="audio-without-descriptions"
-            />
+      )}
+      {textPathname && (
+        <ConditionalWrapper
+          condition={hasAudioVideo}
+          wrapper={children => (
+            <Space $v={{ size: 'xl', properties: ['margin-top'] }}>
+              {children}
+            </Space>
           )}
-          {textPathname && (
+        >
+          <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
+            <SectionHeader title="Exhibition text" />
+          </Space>
+          <p>All the wall and label text from the exhibition.</p>
+          <TypeList>
             <TypeOption
               url={`/${textPathname}`}
-              title="Read captions and transcripts"
-              text="All the wall and label texts from the gallery, plus audio transcripts – great for those without headphones."
-              backgroundColor="accent.lightGreen"
-              icon={speechToText}
+              title="Exhibition text"
               type="captions-and-transcripts"
             />
-          )}
-          {videoPathname && (
-            <TypeOption
-              url={`/${videoPathname}`}
-              title="Watch British Sign Language videos"
-              text="Commentary about the exhibition in British Sign Language videos."
-              backgroundColor="accent.lightBlue"
-              icon={britishSignLanguage}
-              type="bsl"
-            />
-          )}
-        </TypeList>
+          </TypeList>
+        </ConditionalWrapper>
       )}
     </>
   );

--- a/content/webapp/components/ExhibitionGuideLinks/TypeOption.tsx
+++ b/content/webapp/components/ExhibitionGuideLinks/TypeOption.tsx
@@ -4,8 +4,6 @@ import styled from 'styled-components';
 
 import cookies from '@weco/common/data/cookies';
 import { arrow } from '@weco/common/icons';
-import { IconSvg } from '@weco/common/icons/types';
-import { useToggles } from '@weco/common/server-data/Context';
 import { font } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import { plainListStyles } from '@weco/common/views/components/styled/PlainList';
@@ -27,31 +25,26 @@ export const TypeList = styled(Space).attrs({
   `}
 `;
 
-const TypeItem = styled.li<{ $egWork?: boolean }>`
+const TypeItem = styled.li`
   flex: 0 0 100%;
   position: relative;
-  ${props => (props.$egWork ? '' : 'min-height: 200px;')}
   ${props => props.theme.media('medium')`
-        flex-basis: calc(50% - 25px);
-      `}
+      flex-basis: calc(50% - 25px);
+    `}
 `;
 
 const TypeLink = styled.a<{
   $backgroundColor: PaletteColor;
-  $egWork?: boolean;
 }>`
   display: block;
   height: 100%;
   width: 100%;
   text-decoration: none;
-  ${props => (props.$egWork ? 'border-radius: 6px;' : '')}
+  border-radius: 6px;
   background: ${props => props.theme.color(props.$backgroundColor)};
 
   &:hover {
-    ${props =>
-      props.$egWork
-        ? 'text-decoration: underline;'
-        : `background: ${props.theme.color('neutral.400')};`}
+    text-decoration: underline;
   }
 `;
 
@@ -62,30 +55,14 @@ const TypeIconsWrapper = styled.div`
 `;
 
 // TODO Review how this can be streamlined when we move to the new EG models
+// https://github.com/wellcomecollection/wellcomecollection.org/issues/11181
 type Props = {
   url: string;
   title: string;
-  text: string;
-  backgroundColor:
-    | 'warmNeutral.300'
-    | 'accent.lightSalmon'
-    | 'accent.lightGreen'
-    | 'accent.lightPurple'
-    | 'accent.lightBlue';
   type: ExhibitionGuideType;
-  icon?: IconSvg;
 };
 
-const TypeOption: FunctionComponent<Props> = ({
-  url,
-  title,
-  text,
-  backgroundColor,
-  icon,
-  type,
-}) => {
-  const { egWork } = useToggles();
-
+const TypeOption: FunctionComponent<Props> = ({ url, title, type }) => {
   const onClick = () => {
     // We set the cookie to expire in 8 hours (the maximum length of
     // time the galleries are open in a day)
@@ -96,14 +73,9 @@ const TypeOption: FunctionComponent<Props> = ({
     });
   };
 
-  return egWork ? (
-    <TypeItem $egWork={egWork}>
-      <TypeLink
-        href={url}
-        $backgroundColor="warmNeutral.300"
-        $egWork
-        onClick={onClick}
-      >
+  return (
+    <TypeItem>
+      <TypeLink href={url} $backgroundColor="warmNeutral.300" onClick={onClick}>
         <CardBody style={{ height: '100%' }}>
           <h2 className={font('wb', 3)}>{title}</h2>
 
@@ -113,21 +85,6 @@ const TypeOption: FunctionComponent<Props> = ({
             <Icon icon={arrow} sizeOverride="height: 32px; width: 32px;" />
           </TypeIconsWrapper>
         </CardBody>
-      </TypeLink>
-    </TypeItem>
-  ) : (
-    <TypeItem>
-      <TypeLink href={url} $backgroundColor={backgroundColor} onClick={onClick}>
-        <Space
-          $v={{ size: 'm', properties: ['padding-top', 'padding-bottom'] }}
-          $h={{ size: 'm', properties: ['padding-left', 'padding-right'] }}
-        >
-          <h2 className={font('wb', 3)}>{title}</h2>
-          <p className={font('intr', 5)}>{text}</p>
-          {icon && (
-            <Icon icon={icon} sizeOverride="height: 32px; width: 32px;" />
-          )}
-        </Space>
       </TypeLink>
     </TypeItem>
   );

--- a/content/webapp/components/ExhibitionGuidePromo/ExhibitionGuidePromo.tsx
+++ b/content/webapp/components/ExhibitionGuidePromo/ExhibitionGuidePromo.tsx
@@ -1,6 +1,5 @@
 import { FunctionComponent } from 'react';
 
-import { useToggles } from '@weco/common/server-data/Context';
 import { font } from '@weco/common/utils/classnames';
 import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImage';
 import Space from '@weco/common/views/components/styled/Space';
@@ -35,8 +34,6 @@ const getAvailableTypes = availableTypes => {
 const ExhibitionGuidePromo: FunctionComponent<Props> = ({
   exhibitionGuide,
 }) => {
-  const { egWork } = useToggles();
-
   return (
     <CardOuter
       data-component="ExhibitionGuidePromo"
@@ -76,19 +73,17 @@ const ExhibitionGuidePromo: FunctionComponent<Props> = ({
               </p>
             </Space>
           )}
-          {egWork && (
-            <Space
-              $v={{
-                size: 'l',
-                properties: ['margin-top'],
-                overrides: { small: 4, medium: 4, large: 5 },
-              }}
-            >
-              <RelevantGuideIcons
-                types={getAvailableTypes(exhibitionGuide.availableTypes)}
-              />
-            </Space>
-          )}
+          <Space
+            $v={{
+              size: 'l',
+              properties: ['margin-top'],
+              overrides: { small: 4, medium: 4, large: 5 },
+            }}
+          >
+            <RelevantGuideIcons
+              types={getAvailableTypes(exhibitionGuide.availableTypes)}
+            />
+          </Space>
         </div>
       </CardBody>
     </CardOuter>

--- a/content/webapp/pages/guides/exhibitions/[id]/[type]/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/[type]/index.tsx
@@ -46,7 +46,6 @@ import {
   ExhibitionText,
   isValidExhibitionGuideType,
 } from '@weco/content/types/exhibition-guides';
-import { getGuidesRedirections } from '@weco/content/utils/digital-guides';
 import { setCacheControl } from '@weco/content/utils/setCacheControl';
 
 const isExhibitionGuide = (
@@ -98,15 +97,6 @@ export const getServerSideProps: GetServerSideProps<
     return { notFound: true };
   }
 
-  // This is needed for the Jason QR codes
-  // TODO remove from this page when it closes or if we change its QR codes
-  // https://github.com/wellcomecollection/wellcomecollection.org/issues/11131
-  // Check if it needs to be redirected because of query params or cookie preferences
-  // Will redirect here if needed
-  const redirect = getGuidesRedirections(context);
-  if (redirect) return redirect;
-
-  // If not needed, then fetch everything required for this page
   const client = createClient(context);
 
   // We don't know exactly which type of document the id is for, so:

--- a/content/webapp/pages/guides/exhibitions/[id]/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/index.tsx
@@ -5,11 +5,9 @@ import { FunctionComponent } from 'react';
 import { pageDescriptions } from '@weco/common/data/microcopy';
 import { GuideStopSlice as RawGuideStopSlice } from '@weco/common/prismicio-types';
 import { getServerData } from '@weco/common/server-data';
-import { useToggles } from '@weco/common/server-data/Context';
 import { AppErrorProps } from '@weco/common/services/app';
 import { looksLikePrismicId } from '@weco/common/services/prismic';
 import { isFilledLinkToMediaField } from '@weco/common/services/prismic/types/';
-import { font } from '@weco/common/utils/classnames';
 import { serialiseProps } from '@weco/common/utils/json';
 import { toMaybeString } from '@weco/common/utils/routes';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
@@ -294,8 +292,6 @@ const ExhibitionGuidePage: FunctionComponent<Props> = ({
   otherExhibitionGuides,
   stopNumber,
 }) => {
-  const { egWork } = useToggles();
-
   const pageId =
     exhibitionGuide?.id || exhibitionText?.id || exhibitionHighlightTour?.id;
   const pageUid =
@@ -348,35 +344,21 @@ const ExhibitionGuidePage: FunctionComponent<Props> = ({
       apiToolbarLinks={[createPrismicLink(pageId || '')]}
       hideNewsletterPromo={true}
     >
-      {egWork && (
-        <PageHeader
-          title={`${pageTitle} digital guides`}
-          breadcrumbs={{
-            items: [
-              {
-                text: 'Digital Guides',
-                url: `/guides/exhibitions`,
-              },
-            ],
-            noHomeLink: true,
-          }}
-          isSlim
-        />
-      )}
+      <PageHeader
+        title={`${pageTitle} digital guides`}
+        breadcrumbs={{
+          items: [
+            {
+              text: 'Digital Guides',
+              url: `/guides/exhibitions`,
+            },
+          ],
+          noHomeLink: true,
+        }}
+        isSlim
+      />
       <Layout gridSizes={gridSize10(false)}>
         <SpacingSection>
-          {!egWork && (
-            <Space
-              $v={{ size: 'l', properties: ['margin-top'] }}
-              className={font('wb', 1)}
-            >
-              <Space $v={{ size: 'm', properties: ['margin-bottom'] }}>
-                <h1 className={font('wb', 0)}>
-                  {`Choose the ${pageTitle} guide for you`}
-                </h1>
-              </Space>
-            </Space>
-          )}
           <Space $v={{ size: 'l', properties: ['margin-top'] }}>
             {/* Links to ExhibitionTexts and ExhibitionHighlightTours */}
             {/* Or, if there is a stopNumber in the URL, link straight to it */}

--- a/content/webapp/pages/guides/exhibitions/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/index.tsx
@@ -3,7 +3,6 @@ import { FunctionComponent } from 'react';
 
 import { pageDescriptions } from '@weco/common/data/microcopy';
 import { getServerData } from '@weco/common/server-data';
-import { useToggles } from '@weco/common/server-data/Context';
 import { appError, AppErrorProps } from '@weco/common/services/app';
 import type { PaginatedResults } from '@weco/common/services/prismic/types';
 import { serialiseProps } from '@weco/common/utils/json';
@@ -174,13 +173,12 @@ export const getServerSideProps: GetServerSideProps<
 
 const ExhibitionGuidesPage: FunctionComponent<Props> = props => {
   const { exhibitionGuides } = props;
-  const { egWork } = useToggles();
 
   const image = exhibitionGuides.results[0]?.image;
 
   return (
     <PageLayout
-      title={egWork ? 'Digital Guides' : 'Exhibition Guides'}
+      title="Digital Guides"
       description={pageDescriptions.exhibitionGuides}
       url={{ pathname: '/guides/exhibitions' }}
       jsonLd={{ '@type': 'WebPage' }}
@@ -195,9 +193,9 @@ const ExhibitionGuidesPage: FunctionComponent<Props> = props => {
     >
       <SpacingSection>
         <LayoutPaginatedResults
-          title={egWork ? 'Digital Guides' : 'Exhibition Guides'}
+          title="Digital Guides"
           paginatedResults={exhibitionGuides}
-          breadcrumbs={{ items: [], noHomeLink: egWork }}
+          breadcrumbs={{ items: [], noHomeLink: true }}
         />
       </SpacingSection>
     </PageLayout>

--- a/content/webapp/types/exhibition-guides.ts
+++ b/content/webapp/types/exhibition-guides.ts
@@ -74,9 +74,6 @@ export type ExhibitionGuide = ExhibitionGuideBasic & {
   components: ExhibitionGuideComponent[];
 };
 
-// TODO remove 'captions-and-transcripts' once we close Jason/migrate it
-// as we no longer set a cookie for that type.
-// https://github.com/wellcomecollection/wellcomecollection.org/issues/11131
 const typeNames = [
   'bsl',
   'audio-without-descriptions',

--- a/content/webapp/utils/digital-guides.test.ts
+++ b/content/webapp/utils/digital-guides.test.ts
@@ -53,26 +53,6 @@ describe('getGuidesRedirections', () => {
 
     expect(result).toBe(undefined);
   });
-
-  it('redirects legacy exhibition guides', () => {
-    // Mock userPreferenceGuideType cookie
-    document.cookie = `WC_userPreferenceGuideType=${userPreferenceGuideType}`;
-
-    const result = getGuidesRedirections({
-      ...contextParams,
-      query: {
-        id: 'ZHXyDBQAAMCZbr6n',
-        type: 'audio-without-descriptions',
-        usingQRCode: 'true',
-        stopId: 'abc',
-      },
-      resolvedUrl: `${baseUrl}/bsl?usingQRCode=true&stopNumber=abc`,
-    });
-
-    expect(result?.redirect?.destination).toBe(
-      `${baseUrl}/bsl?usingQRCode=true&stopNumber=abc`
-    );
-  });
 });
 
 describe('getCleanRedirectURL', () => {

--- a/content/webapp/utils/digital-guides.ts
+++ b/content/webapp/utils/digital-guides.ts
@@ -32,22 +32,10 @@ import { isValidExhibitionGuideType } from '@weco/content/types/exhibition-guide
  *        page they were just looking at. This takes them to `/guides/exhibitions/[id]`
  *        … where we redirect them back to the guide they were just looking at.
  *
- * We only create QR codes that link to the audio guides, not the overview page, so
- * this prevents somebody getting stuck in this sort of redirect loop.
+ * We only created QR codes that linked to the audio guides, not the overview page, so
+ * this prevented somebody getting stuck in this sort of redirect loop.
  *
  */
-
-const legacyGuides = [
-  'Y2omihEAAKLNfLar',
-  'ZHXyDBQAAMCZbr6n',
-  'YvJ4UhAAAPgZztMl',
-  'YvUALRAAACMA2h8V',
-  'Zdcs4BEAACMA6abC',
-  'ZD01LBQAAC4ZiY95',
-  'YzwsAREAAHylrxau',
-  'ZSaiohAAACMAlJbK',
-  'Y2JgxREAACcJWckj',
-];
 
 export const getCleanRedirectURL = (
   resolvedURL: string,
@@ -74,7 +62,7 @@ export const getGuidesRedirections = (
   context: GetServerSidePropsContext<ParsedUrlQuery, PreviewData>
 ) => {
   const { req, res, resolvedUrl } = context;
-  const { id: guideId, stopNumber, stopId, type, usingQRCode } = context.query;
+  const { stopNumber, type, usingQRCode } = context.query;
 
   if (toMaybeString(usingQRCode) !== 'true') return;
 
@@ -88,29 +76,7 @@ export const getGuidesRedirections = (
     userPreferenceGuideType !== type &&
     isValidExhibitionGuideType(userPreferenceGuideType);
 
-  // Supporting Jason exhibition
-  // TODO remove when it closes/we adapt the QR codes
-  // https://github.com/wellcomecollection/wellcomecollection.org/issues/11131
-  if (
-    legacyGuides.includes(toMaybeString(guideId) || '') &&
-    hasValidUserPreference &&
-    type &&
-    typeof stopId === 'string'
-  ) {
-    return {
-      redirect: {
-        permanent: false,
-        // We do a simple replace on the URL so we preserve all other URL information
-        // (e.g. UTM tracking parameters).
-        destination: context.resolvedUrl.replace(
-          `/${type}`,
-          `/${userPreferenceGuideType}`
-        ),
-      },
-    };
-  }
-
-  // New exhibition QR codes URLs should _always_ have the following format:
+  // QR codes URLs should _always_ have the following format:
   // guides/exhibitions/[exhibitionId]?stopNumber=[stopNumber]
   const hasValidStopNumber =
     typeof stopNumber === 'string' && !!Number(stopNumber);

--- a/playwright/test/exhibition-guides.test.ts
+++ b/playwright/test/exhibition-guides.test.ts
@@ -17,27 +17,7 @@ const newJasonGuideRelativeURL = `/guides/exhibitions/${newJasonGuideId}`;
 
 test.describe.configure({ mode: 'parallel' });
 
-// TODO remove this when we stop supporting legacy QRs
-// https://github.com/wellcomecollection/wellcomecollection.org/issues/11131
-test('(1) | Legacy: Still redirects to another format if we have an EG preference and come from a QR code', async ({
-  context,
-  page,
-}) => {
-  // Go to In Plain Sight Audio exhibition guide with the QR code params
-  await digitalGuide(
-    'YzwsAREAAHylrxau/audio-without-descriptions?usingQRCode=true&stopId=witness#witness',
-    context,
-    page,
-    bslCookie
-  );
-
-  // Check we've been redirected to the BSL guide and kept the extra params
-  await expect(page).toHaveURL(
-    /\/bsl[?]usingQRCode=true&stopId=witness#witness/
-  );
-});
-
-test('(2) | New: Redirects to preferred format if user has an EG preference and comes from a QR code', async ({
+test('(1) | Redirects to preferred format if user has an EG preference and comes from a QR code', async ({
   context,
   page,
 }) => {
@@ -53,7 +33,7 @@ test('(2) | New: Redirects to preferred format if user has an EG preference and 
   await expect(page).toHaveURL(/\/bsl\/2[?]usingQRCode=true/);
 });
 
-test('(3) | New: Does not redirect if user does not come from a QR code', async ({
+test('(2) | Does not redirect if user does not come from a QR code', async ({
   context,
   page,
 }) => {
@@ -71,7 +51,7 @@ test('(3) | New: Does not redirect if user does not come from a QR code', async 
   );
 });
 
-test('(4) | New: If first stop, redirects to preferred type landing page instead of [type]/1', async ({
+test('(3) | If first stop, redirects to preferred type landing page instead of [type]/1', async ({
   context,
   page,
 }) => {
@@ -87,7 +67,7 @@ test('(4) | New: If first stop, redirects to preferred type landing page instead
   await expect(page).toHaveURL(/\/guides\/exhibitions\/ZthrZRIAACQALvCC\/bsl/);
 });
 
-test.describe('(5) | New: If no type preference set, links to BSL and Audio on the EG landing page: ', () => {
+test.describe('(4) | If no type preference set, links to BSL and Audio on the EG landing page: ', () => {
   test('go straight to stop page instead of listing page', async ({
     context,
     page,

--- a/playwright/test/exhibition-guides.test.ts
+++ b/playwright/test/exhibition-guides.test.ts
@@ -12,25 +12,14 @@ const bslCookie: CookieProps[] = [
   },
 ];
 
-// TODO remove when we remove the egWork toggle
-const egWorkCookies = [
-  ...bslCookie,
-  {
-    name: 'toggle_egWork',
-    value: 'true',
-    path: '/',
-    domain: new URL(baseUrl).host,
-  },
-];
-
 const newJasonGuideId = 'ZthrZRIAACQALvCC';
 const newJasonGuideRelativeURL = `/guides/exhibitions/${newJasonGuideId}`;
 
 test.describe.configure({ mode: 'parallel' });
 
-// TODO remove when we stop supporting legacy QRs
+// TODO remove this when we stop supporting legacy QRs
 // https://github.com/wellcomecollection/wellcomecollection.org/issues/11131
-test('(1) | Redirects to another format if we have an EG preference and come from a QR code', async ({
+test('(1) | Legacy: Still redirects to another format if we have an EG preference and come from a QR code', async ({
   context,
   page,
 }) => {
@@ -39,7 +28,7 @@ test('(1) | Redirects to another format if we have an EG preference and come fro
     'YzwsAREAAHylrxau/audio-without-descriptions?usingQRCode=true&stopId=witness#witness',
     context,
     page,
-    egWorkCookies
+    bslCookie
   );
 
   // Check we've been redirected to the BSL guide and kept the extra params
@@ -48,28 +37,58 @@ test('(1) | Redirects to another format if we have an EG preference and come fro
   );
 });
 
-test.describe('(2) | with egWork toggle: ', () => {
-  // TODO remove this when we stop supporting legacy QRs
-  // https://github.com/wellcomecollection/wellcomecollection.org/issues/11131
-  test('Legacy: Still redirects to another format if we have an EG preference and come from a QR code', async ({
+test('(2) | New: Redirects to preferred format if user has an EG preference and comes from a QR code', async ({
+  context,
+  page,
+}) => {
+  // Jason with the QR code params and Stop #2
+  await digitalGuide(
+    `${newJasonGuideId}?usingQRCode=true&stopNumber=2`,
     context,
     page,
-  }) => {
-    // Go to In Plain Sight Audio exhibition guide with the QR code params
-    await digitalGuide(
-      'YzwsAREAAHylrxau/audio-without-descriptions?usingQRCode=true&stopId=witness#witness',
-      context,
-      page,
-      egWorkCookies
-    );
+    bslCookie
+  );
 
-    // Check we've been redirected to the BSL guide and kept the extra params
-    await expect(page).toHaveURL(
-      /\/bsl[?]usingQRCode=true&stopId=witness#witness/
-    );
-  });
+  // Check we've been redirected to the BSL guide's second stop, and kept the extra params
+  await expect(page).toHaveURL(/\/bsl\/2[?]usingQRCode=true/);
+});
 
-  test('New: Redirects to preferred format if user has an EG preference and comes from a QR code', async ({
+test('(3) | New: Does not redirect if user does not come from a QR code', async ({
+  context,
+  page,
+}) => {
+  // Jason with the QR code params and Stop #2
+  await digitalGuide(
+    `${newJasonGuideId}?stopNumber=2`,
+    context,
+    page,
+    bslCookie
+  );
+
+  // Nothing happens, URL is the same
+  await expect(page).toHaveURL(
+    /\/guides\/exhibitions\/ZthrZRIAACQALvCC[?]stopNumber=2/
+  );
+});
+
+test('(4) | New: If first stop, redirects to preferred type landing page instead of [type]/1', async ({
+  context,
+  page,
+}) => {
+  // Jason with the QR code params and Stop #1
+  await digitalGuide(
+    `${newJasonGuideId}?usingQRCode=true&stopNumber=1`,
+    context,
+    page,
+    bslCookie
+  );
+
+  // Nothing happens, URL is the same
+  await expect(page).toHaveURL(/\/guides\/exhibitions\/ZthrZRIAACQALvCC\/bsl/);
+});
+
+test.describe('(5) | New: If no type preference set, links to BSL and Audio on the EG landing page: ', () => {
+  test('go straight to stop page instead of listing page', async ({
     context,
     page,
   }) => {
@@ -78,119 +97,53 @@ test.describe('(2) | with egWork toggle: ', () => {
       `${newJasonGuideId}?usingQRCode=true&stopNumber=2`,
       context,
       page,
-      egWorkCookies
+      [
+        {
+          name: 'CookieControl',
+          value: '{}',
+          path: '/',
+          domain: new URL(baseUrl).host,
+        }, // Civic UK banner
+      ]
     );
 
-    // Check we've been redirected to the BSL guide's second stop, and kept the extra params
-    await expect(page).toHaveURL(/\/bsl\/2[?]usingQRCode=true/);
+    await expect(
+      page.getByRole('link', { name: 'Listen to audio' }).first()
+    ).toHaveAttribute(
+      'href',
+      `${newJasonGuideRelativeURL}/audio-without-descriptions/2`
+    );
+
+    await expect(
+      page.getByRole('link', { name: 'Watch British Sign Language' }).first()
+    ).toHaveAttribute('href', `${newJasonGuideRelativeURL}/bsl/2`);
   });
 
-  test('New: Does not redirect if user does not come from a QR code', async ({
-    context,
-    page,
-  }) => {
-    // Jason with the QR code params and Stop #2
-    await digitalGuide(
-      `${newJasonGuideId}?stopNumber=2`,
-      context,
-      page,
-      egWorkCookies
-    );
-
-    // Nothing happens, URL is the same
-    await expect(page).toHaveURL(
-      /\/guides\/exhibitions\/ZthrZRIAACQALvCC[?]stopNumber=2/
-    );
-  });
-
-  test('New: If first stop, redirects to preferred type landing page instead of [type]/1', async ({
-    context,
-    page,
-  }) => {
+  test('unless it is the first stop', async ({ context, page }) => {
     // Jason with the QR code params and Stop #1
     await digitalGuide(
       `${newJasonGuideId}?usingQRCode=true&stopNumber=1`,
       context,
       page,
-      egWorkCookies
+      [
+        {
+          name: 'CookieControl',
+          value: '{}',
+          path: '/',
+          domain: new URL(baseUrl).host,
+        }, // Civic UK banner
+      ]
     );
 
-    // Nothing happens, URL is the same
-    await expect(page).toHaveURL(
-      /\/guides\/exhibitions\/ZthrZRIAACQALvCC\/bsl/
+    await expect(
+      page.getByRole('link', { name: 'Listen to audio' }).first()
+    ).toHaveAttribute(
+      'href',
+      `${newJasonGuideRelativeURL}/audio-without-descriptions`
     );
-  });
 
-  test.describe('New: If no type preference set, links to BSL and Audio on the EG landing page: ', () => {
-    test('go straight to stop page instead of listing page', async ({
-      context,
-      page,
-    }) => {
-      // Jason with the QR code params and Stop #2
-      await digitalGuide(
-        `${newJasonGuideId}?usingQRCode=true&stopNumber=2`,
-        context,
-        page,
-        [
-          {
-            name: 'toggle_egWork',
-            value: 'true',
-            path: '/',
-            domain: new URL(baseUrl).host,
-          },
-          {
-            name: 'CookieControl',
-            value: '{}',
-            path: '/',
-            domain: new URL(baseUrl).host,
-          }, // Civic UK banner
-        ]
-      );
-
-      await expect(
-        page.getByRole('link', { name: 'Listen to audio' }).first()
-      ).toHaveAttribute(
-        'href',
-        `${newJasonGuideRelativeURL}/audio-without-descriptions/2`
-      );
-
-      await expect(
-        page.getByRole('link', { name: 'Watch British Sign Language' }).first()
-      ).toHaveAttribute('href', `${newJasonGuideRelativeURL}/bsl/2`);
-    });
-
-    test('unless it is the first stop', async ({ context, page }) => {
-      // Jason with the QR code params and Stop #1
-      await digitalGuide(
-        `${newJasonGuideId}?usingQRCode=true&stopNumber=1`,
-        context,
-        page,
-        [
-          {
-            name: 'toggle_egWork',
-            value: 'true',
-            path: '/',
-            domain: new URL(baseUrl).host,
-          },
-          {
-            name: 'CookieControl',
-            value: '{}',
-            path: '/',
-            domain: new URL(baseUrl).host,
-          }, // Civic UK banner
-        ]
-      );
-
-      await expect(
-        page.getByRole('link', { name: 'Listen to audio' }).first()
-      ).toHaveAttribute(
-        'href',
-        `${newJasonGuideRelativeURL}/audio-without-descriptions`
-      );
-
-      await expect(
-        page.getByRole('link', { name: 'Watch British Sign Language' }).first()
-      ).toHaveAttribute('href', `${newJasonGuideRelativeURL}/bsl`);
-    });
+    await expect(
+      page.getByRole('link', { name: 'Watch British Sign Language' }).first()
+    ).toHaveAttribute('href', `${newJasonGuideRelativeURL}/bsl`);
   });
 });

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -87,14 +87,6 @@ const toggles = {
       type: 'experimental',
     },
     {
-      id: 'egWork',
-      title: 'Exhibition Guides redesign/restructure work',
-      initialValue: false,
-      description:
-        'With this activated, you will be able to see the new (and work in progress) versions of exhibition guides',
-      type: 'experimental',
-    },
-    {
       id: 'authV2',
       title: 'IIIF Auth V2',
       initialValue: false,


### PR DESCRIPTION
## What does this change?

#11131 tidies the codebase after `egWorks` has successfully been made public, and we stop supporting legacy QR codes. As we've moved Jason over and it was the only one still using them, this should be good to go.

- Removed legacy tests
- Removed `getTypeColor()` helper function as we don't use those colours on DG anymore
- Remove all `egWorks` conditions and the toggle
- Removed redirection logic for legacy guides
- Removed redirection check in `content/webapp/pages/guides/exhibitions/[id]/[type]/index.tsx` as we do not point to that page from QR codes anymore.

> [!NOTE]
> There is still tidying work to do once we've migrated all legacy Exhibition Guide content types. They should be identified and done after https://github.com/wellcomecollection/wellcomecollection.org/issues/11181 is completed.

## How to test

Run locally, do all affected pages still lookgood? Look at a legacy exhibition ([In Plain Sight](http://localhost:3000/guides/exhibitions/YzwsAREAAHylrxau)) and a new one ([Hard Graft](http://localhost:3000/guides/exhibitions/ZsdFlRIAACIAqKGB))

## How can we measure success?

Tidier code, easier to read and make changes to.

## Have we considered potential risks?
QA should cover visual risks, and e2es as well.