### PR TITLE
Trigger Slack bot when errors are found in Prismic linting Github action run

### DIFF
--- a/.github/workflows/prismic-linting.yml
+++ b/.github/workflows/prismic-linting.yml
@@ -1,5 +1,8 @@
 name: Prismic Linting
 on:
+  push:
+    branches:
+      - 'prismic-linting-slack'
   workflow_dispatch:
   schedule:
     - cron: '0 4 * * MON-FRI'

--- a/.github/workflows/prismic-linting.yml
+++ b/.github/workflows/prismic-linting.yml
@@ -27,26 +27,28 @@ jobs:
       - name: Get webhook
         uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
+          aws-region: eu-west-1
+          role-to-assume: ${{ secrets.EXPERIENCE_GHA_ROLE_ARN }}
           secret-ids: |
             SLACK_WEBHOOK_GA_PRISMIC_LINTING_URL, prismic-model/slack/linting
       - name: Run Prismic linting
         run: docker compose run prismic_model yarn lintPrismicData slackWebhookUrl=SLACK_WEBHOOK_GA_PRISMIC_LINTING_URL
-  on-failure:
-    runs-on: ubuntu-latest
-    if: ${{ always() && (needs.prismic_linting.result == 'failure' || needs.prismic_linting.result == 'timed_out') }}
-    needs:
-      - prismic_linting
-    steps:
-    - name: Send GitHub Action trigger data to Slack workflow
-      id: slack
-      uses: slackapi/slack-github-action@v1.27.0
-      with:
-        # This data can be any valid JSON from a previous step in the GitHub Action
-        payload: |
-          {
-            "action_name": "Prismic linting action",
-            "status": "${{ needs.prismic_linting.result }}",
-            "link": "https://github.com/wellcomecollection/wellcomecollection.org/actions/workflows/prismic-linting.yml"
-          }
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_GA_ACTION_URL }}
+  # on-failure:
+  #   runs-on: ubuntu-latest
+  #   if: ${{ always() && (needs.prismic_linting.result == 'failure' || needs.prismic_linting.result == 'timed_out') }}
+  #   needs:
+  #     - prismic_linting
+  #   steps:
+  #   - name: Send GitHub Action trigger data to Slack workflow
+  #     id: slack
+  #     uses: slackapi/slack-github-action@v1.27.0
+  #     with:
+  #       # This data can be any valid JSON from a previous step in the GitHub Action
+  #       payload: |
+  #         {
+  #           "action_name": "Prismic linting action",
+  #           "status": "${{ needs.prismic_linting.result }}",
+  #           "link": "https://github.com/wellcomecollection/wellcomecollection.org/actions/workflows/prismic-linting.yml"
+  #         }
+  #     env:
+  #       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_GA_ACTION_URL }}

--- a/.github/workflows/prismic-linting.yml
+++ b/.github/workflows/prismic-linting.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           registry-type: public
       - name: Run Prismic linting
-        run: docker compose run prismic_model yarn lintPrismicData
+        run: docker compose run prismic_model yarn lintPrismicData --isGitHubAction
   on-failure:
     runs-on: ubuntu-latest
     if: ${{ always() && (needs.prismic_linting.result == 'failure' || needs.prismic_linting.result == 'timed_out') }}

--- a/.github/workflows/prismic-linting.yml
+++ b/.github/workflows/prismic-linting.yml
@@ -21,8 +21,13 @@ jobs:
           AWS_REGION: us-east-1
         with:
           registry-type: public
+      - name: Get webhook
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            SLACK_WEBHOOK_GA_PRISMIC_LINTING_URL, prismic-model/slack/linting
       - name: Run Prismic linting
-        run: docker compose run prismic_model yarn lintPrismicData --isGitHubAction
+        run: docker compose run prismic_model yarn lintPrismicData slackWebhookUrl=SLACK_WEBHOOK_GA_PRISMIC_LINTING_URL
   on-failure:
     runs-on: ubuntu-latest
     if: ${{ always() && (needs.prismic_linting.result == 'failure' || needs.prismic_linting.result == 'timed_out') }}

--- a/.github/workflows/prismic-linting.yml
+++ b/.github/workflows/prismic-linting.yml
@@ -1,8 +1,5 @@
 name: Prismic Linting
 on:
-  push:
-    branches:
-      - 'prismic-linting-slack'
   workflow_dispatch:
   schedule:
     - cron: '0 4 * * MON-FRI'
@@ -26,22 +23,22 @@ jobs:
           registry-type: public
       - name: Run Prismic linting
         run: docker compose run prismic_model yarn lintPrismicData slackWebhookUrl=${{ secrets.SLACK_WEBHOOK_GA_PRISMIC_LINTING_EDITORIAL_FLAG_URL }}
-  # on-failure:
-  #   runs-on: ubuntu-latest
-  #   if: ${{ always() && (needs.prismic_linting.result == 'failure' || needs.prismic_linting.result == 'timed_out') }}
-  #   needs:
-  #     - prismic_linting
-  #   steps:
-  #   - name: Send GitHub Action trigger data to Slack workflow
-  #     id: slack
-  #     uses: slackapi/slack-github-action@v1.27.0
-  #     with:
-  #       # This data can be any valid JSON from a previous step in the GitHub Action
-  #       payload: |
-  #         {
-  #           "action_name": "Prismic linting action",
-  #           "status": "${{ needs.prismic_linting.result }}",
-  #           "link": "https://github.com/wellcomecollection/wellcomecollection.org/actions/workflows/prismic-linting.yml"
-  #         }
-  #     env:
-  #       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_GA_ACTION_URL }}
+  on-failure:
+    runs-on: ubuntu-latest
+    if: ${{ always() && (needs.prismic_linting.result == 'failure' || needs.prismic_linting.result == 'timed_out') }}
+    needs:
+      - prismic_linting
+    steps:
+    - name: Send GitHub Action trigger data to Slack workflow
+      id: slack
+      uses: slackapi/slack-github-action@v1.27.0
+      with:
+        # This data can be any valid JSON from a previous step in the GitHub Action
+        payload: |
+          {
+            "action_name": "Prismic linting action",
+            "status": "${{ needs.prismic_linting.result }}",
+            "link": "https://github.com/wellcomecollection/wellcomecollection.org/actions/workflows/prismic-linting.yml"
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_GA_ACTION_URL }}

--- a/.github/workflows/prismic-linting.yml
+++ b/.github/workflows/prismic-linting.yml
@@ -24,15 +24,8 @@ jobs:
           AWS_REGION: us-east-1
         with:
           registry-type: public
-      - name: Get webhook
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
-        with:
-          aws-region: eu-west-1
-          role-to-assume: ${{ secrets.EXPERIENCE_GHA_ROLE_ARN }}
-          secret-ids: |
-            SLACK_WEBHOOK_GA_PRISMIC_LINTING_URL, prismic-model/slack/linting
       - name: Run Prismic linting
-        run: docker compose run prismic_model yarn lintPrismicData slackWebhookUrl=SLACK_WEBHOOK_GA_PRISMIC_LINTING_URL
+        run: docker compose run prismic_model yarn lintPrismicData slackWebhookUrl=${{ secrets.SLACK_WEBHOOK_GA_PRISMIC_LINTING_EDITORIAL_FLAG_URL }}
   # on-failure:
   #   runs-on: ubuntu-latest
   #   if: ${{ always() && (needs.prismic_linting.result == 'failure' || needs.prismic_linting.result == 'timed_out') }}

--- a/prismic-model/lintPrismicData.ts
+++ b/prismic-model/lintPrismicData.ts
@@ -17,6 +17,7 @@ import chalk from 'chalk';
 import fs from 'fs';
 import yargs from 'yargs';
 
+import { pluralize } from '@weco/common/utils/grammar';
 import { getCreds, setEnvsFromSecrets } from '@weco/ts-aws';
 
 import { error } from './console';
@@ -310,7 +311,7 @@ async function run() {
             method: 'POST',
             headers: { 'Content-Type': 'application/json; charset=UTF-8' },
             body: JSON.stringify({
-              message: `The Prismic linting script has found ${errors.length} thing${errors.length > 1 ? 's' : ''} that require${errors.length > 1 ? '' : 's'} your attention.`,
+              message: `The Prismic linting script has found ${errors.length} ${pluralize(errors.length, 'thing')} that require${errors.length > 1 ? '' : 's'} your attention.`,
             }),
           });
         } catch (e) {

--- a/prismic-model/lintPrismicData.ts
+++ b/prismic-model/lintPrismicData.ts
@@ -18,7 +18,6 @@ import fs from 'fs';
 import yargs from 'yargs';
 
 import { pluralize } from '@weco/common/utils/grammar';
-import { getCreds, setEnvsFromSecrets } from '@weco/ts-aws';
 
 import { error } from './console';
 import {
@@ -33,10 +32,10 @@ type ErrorProps = {
   errors: string[];
 };
 
-const { isGitHubAction } = yargs(process.argv.slice(2))
-  .usage('Usage: $0 --isGitHubAction [boolean]')
+const { slackWebhookUrl } = yargs(process.argv.slice(2))
+  .usage('Usage: $0 --slackWebhookUrl [string]')
   .options({
-    isGitHubAction: { type: 'boolean' },
+    slackWebhookUrl: { type: 'string' },
   })
   .parseSync();
 
@@ -258,15 +257,6 @@ function detectMissingUidDocuments(doc: any): string[] {
 async function run() {
   const snapshotFile = await downloadPrismicSnapshot();
 
-  await setEnvsFromSecrets(
-    {
-      SLACK_WEBHOOK_GA_PRISMIC_LINTING_URL: 'prismic-model/slack/linting',
-    },
-    await getCreds('experience', 'developer')
-  );
-
-  const slackWebhookUrl = process.env.SLACK_WEBHOOK_GA_PRISMIC_LINTING_URL;
-
   let totalErrors = 0;
   const allErrors: ErrorProps[] = [];
 
@@ -302,10 +292,10 @@ async function run() {
         console.log(`- ${msg}`);
       }
       console.log('');
-
+      console.log({ slackWebhookUrl });
       // Send an alert to Editors if anything is found on a GitHub Action run
       // https://github.com/wellcomecollection/wellcomecollection.org/actions/workflows/prismic-linting.yml
-      if (isGitHubAction && slackWebhookUrl) {
+      if (slackWebhookUrl) {
         try {
           await fetch(slackWebhookUrl, {
             method: 'POST',

--- a/prismic-model/lintPrismicData.ts
+++ b/prismic-model/lintPrismicData.ts
@@ -292,7 +292,7 @@ async function run() {
         console.log(`- ${msg}`);
       }
       console.log('');
-      console.log({ slackWebhookUrl });
+
       // Send an alert to Editors if anything is found on a GitHub Action run
       // https://github.com/wellcomecollection/wellcomecollection.org/actions/workflows/prismic-linting.yml
       if (slackWebhookUrl) {

--- a/prismic-model/lintPrismicData.ts
+++ b/prismic-model/lintPrismicData.ts
@@ -15,6 +15,9 @@ import {
 import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import chalk from 'chalk';
 import fs from 'fs';
+import yargs from 'yargs';
+
+import { getCreds, setEnvsFromSecrets } from '@weco/ts-aws';
 
 import { error } from './console';
 import {
@@ -28,6 +31,13 @@ type ErrorProps = {
   title: string;
   errors: string[];
 };
+
+const { isGitHubAction } = yargs(process.argv.slice(2))
+  .usage('Usage: $0 --isGitHubAction [boolean]')
+  .options({
+    isGitHubAction: { type: 'boolean' },
+  })
+  .parseSync();
 
 // Look for eur01 safelinks.  These occur when somebody has copied
 // a URL directly from Outlook and isn't using the original URL.
@@ -145,6 +155,8 @@ function detectNonPromoImageStories(doc: any): string[] {
   return [];
 }
 
+// Digital guides video and audio have a text field to input duration.
+// We'd like the style to always be xx:xx, so we're adding a test to ensure this is respected.
 function detectIncorrectAudioVideoDuration(doc: any): string[] {
   const guideStopSlices =
     doc?.data?.slices?.filter(s => s.slice_type === 'guide_stop') || [];
@@ -232,6 +244,9 @@ const getContentTypesWithUid = () => {
     })
     .filter(f => f);
 };
+
+// No document with the UID field should be saveable without that field filled in.
+// We've had a few instances of it though, maybe they were drafts? So we're adding a test for the future.
 const contentTypesWithUid = getContentTypesWithUid();
 function detectMissingUidDocuments(doc: any): string[] {
   return contentTypesWithUid.includes(doc.type) && !doc.uid
@@ -241,6 +256,15 @@ function detectMissingUidDocuments(doc: any): string[] {
 
 async function run() {
   const snapshotFile = await downloadPrismicSnapshot();
+
+  await setEnvsFromSecrets(
+    {
+      SLACK_WEBHOOK_GA_PRISMIC_LINTING_URL: 'prismic-model/slack/linting',
+    },
+    await getCreds('experience', 'developer')
+  );
+
+  const slackWebhookUrl = process.env.SLACK_WEBHOOK_GA_PRISMIC_LINTING_URL;
 
   let totalErrors = 0;
   const allErrors: ErrorProps[] = [];
@@ -277,6 +301,22 @@ async function run() {
         console.log(`- ${msg}`);
       }
       console.log('');
+
+      // Send an alert to Editors if anything is found on a GitHub Action run
+      // https://github.com/wellcomecollection/wellcomecollection.org/actions/workflows/prismic-linting.yml
+      if (isGitHubAction && slackWebhookUrl) {
+        try {
+          await fetch(slackWebhookUrl, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json; charset=UTF-8' },
+            body: JSON.stringify({
+              message: `The Prismic linting script has found ${errors.length} thing${errors.length > 1 ? 's' : ''} that require${errors.length > 1 ? '' : 's'} your attention.`,
+            }),
+          });
+        } catch (e) {
+          console.log(e);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## What does this change?

Relates to [#11202](https://github.com/wellcomecollection/wellcomecollection.org/issues/11202)

Currently, Natalie writes to #wc-editorial when the [Prismic linting script](https://github.com/wellcomecollection/wellcomecollection.org/actions/workflows/prismic-linting.yml) reports errors on [the dashboard](https://dash.wellcomecollection.org/prismic-linting/).
This aims to give her one less task every morning!

I've added a webhook workflow that posts this little message when an error or more is found:

<img width="629" alt="Screenshot 2024-09-24 at 11 43 47" src="https://github.com/user-attachments/assets/7b6d925f-3613-4974-be3a-4fa05f5fb5e3">


I'll be curious to test it against the action itself, but running it locally it seems to work smoothly. See the #bot-test channel in Slack that I've created for stuff like this for all the versions of the bot 😄 The currently still points to it, I'll change that once we're happy and everything is merged, and will tell Editors about it.

## How to test

I ran it locally with `yarn lintPrismicData --isGitHubAction` and a mock test that I was sure would fail.

## How can we measure success?

Automated job, happy Natalie!

## Have we considered potential risks?

Don't really see any that we couldn't address.
