### PR TITLE
Fix keyboard control of archive tree

### DIFF
--- a/content/webapp/components/ArchiveTree/ArchiveTree.ListItem.tsx
+++ b/content/webapp/components/ArchiveTree/ArchiveTree.ListItem.tsx
@@ -316,6 +316,7 @@ const ListItem: FunctionComponent<ListItemProps> = ({
         <ItemRenderer
           currentWorkId={currentWorkId}
           item={item}
+          isSelected={isSelected}
           isEnhanced={isEnhanced}
           level={level}
           showFirstLevelGuideline={showFirstLevelGuideline}


### PR DESCRIPTION
## What does this change?

Users should be able to tab to the link within a selected item of the archive tree. This isn't currently the case and this PR fixes it

## How to test

Visit http://localhost:3000/works/g7zn5j4n, tab to the archive tree - use the arrow keys to move to items within the tree. You should be able to tab to the link within the selected item.

## How can we measure success?

The archive tree links are accessible via keyboard controls

## Have we considered potential risks?

I don't think there are any. It's broken at the moment

