### PR TITLE
Integration field endpoint

### DIFF
--- a/content/webapp/pages/api/prismic/works.ts
+++ b/content/webapp/pages/api/prismic/works.ts
@@ -1,0 +1,59 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+async function fetchWorks(page) {
+  try {
+    const works = await fetch(
+      `https://api.wellcomecollection.org/catalogue/v2/works?pageSize=50&page=${page || 1}`,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    ).then(resp => resp.json());
+    return works;
+  } catch (error) {
+    return undefined;
+  }
+}
+
+// TODO accessToken stuff
+
+const WorksApi = async (
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> => {
+  const { page } = req.query;
+
+  const response = await fetchWorks(page);
+  // We format the response to be compatible with Prismic's integration field
+  // https://prismic.io/docs/integration#custom-api-format
+  const transformedResponse = {
+    results_size: 10000, // This is the most we can get from the catalogue API at present
+    results: response.results.map(result => {
+      const description = `${result.physicalDescription ? `${result.physicalDescription}: ` : ''} ${result.description ? result.description : ''}`;
+      return {
+        id: result.id,
+        title: result.title,
+        description,
+        image_url: result.thumbnail?.url,
+        blob: {
+          id: result.id,
+          title: result.title,
+          physicalDescription: result.physicalDescription,
+          description: result.description,
+        },
+      };
+    }),
+  };
+  res.setHeader('Content-Type', 'application/json');
+  res.setHeader('Access-Control-Allow-Origin', '*');
+
+  if (response.type === 'Error') {
+    res.status(response.httpStatus);
+  } else {
+    res.status(200);
+  }
+  res.json(transformedResponse);
+};
+
+export default WorksApi;

--- a/content/webapp/pages/api/prismic/works.ts
+++ b/content/webapp/pages/api/prismic/works.ts
@@ -3,7 +3,7 @@ import { NextApiRequest, NextApiResponse } from 'next';
 async function fetchWorks(page) {
   try {
     const works = await fetch(
-      `https://api.wellcomecollection.org/catalogue/v2/works?pageSize=50&page=${page || 1}`,
+      `https://api.wellcomecollection.org/catalogue/v2/works?availabilities=online&pageSize=50&page=${page || 1}`,
       {
         headers: {
           'Content-Type': 'application/json',

--- a/content/webapp/pages/api/prismic/works.ts
+++ b/content/webapp/pages/api/prismic/works.ts
@@ -16,8 +16,6 @@ async function fetchWorks(page) {
   }
 }
 
-// TODO accessToken stuff
-
 const WorksApi = async (
   req: NextApiRequest,
   res: NextApiResponse


### PR DESCRIPTION
## What does this change?

Adds an API endpoint to use with [Prismic's integration field](https://prismic.io/docs/integration)

The endpoint sits in front of the Catalogue API and returns the results in a format that is compatible with Prismic's integration field

I want to play with using the integration field as a way for content editors to add items from the collection into stories etc. directly from within Prismic. The first step is to have an endpoint the integration field can crawl, which is what this PR provides.

N.B. I believe Prismic limits the number of items to 100,000 by default (but it is possible to pay for more). The catalogue API will only let us retrieve 10,000 items. This would be a problem if ever wanted to use this for real as the catalogue contains well over a million items.

## How to test

Visit http://localhost:3000/api/prismic/works

## How can we measure success?

We can add an integration field in Prismic that can access the catalogue data

## Have we considered potential risks?

Can anyone think of any?

