### PR TITLE
View transitions

### DIFF
--- a/common/views/components/LoadingIndicator/LoadingIndicator.tsx
+++ b/common/views/components/LoadingIndicator/LoadingIndicator.tsx
@@ -41,6 +41,7 @@ const LoadingIndicator: FunctionComponent = () => {
 
   function handleRouteChangeComplete() {
     NProgress.done();
+    window.postMessage('routechangecomplete');
   }
   useEffect(() => {
     Router.events.on('routeChangeStart', handleRouteChangeStart);

--- a/common/views/components/LoadingIndicator/LoadingIndicator.tsx
+++ b/common/views/components/LoadingIndicator/LoadingIndicator.tsx
@@ -41,8 +41,8 @@ const LoadingIndicator: FunctionComponent = () => {
 
   function handleRouteChangeComplete() {
     NProgress.done();
-    window.postMessage('routechangecomplete');
   }
+
   useEffect(() => {
     Router.events.on('routeChangeStart', handleRouteChangeStart);
     Router.events.on('routeChangeComplete', handleRouteChangeComplete);

--- a/common/views/components/LoadingIndicator/LoadingIndicator.tsx
+++ b/common/views/components/LoadingIndicator/LoadingIndicator.tsx
@@ -42,7 +42,6 @@ const LoadingIndicator: FunctionComponent = () => {
   function handleRouteChangeComplete() {
     NProgress.done();
   }
-
   useEffect(() => {
     Router.events.on('routeChangeStart', handleRouteChangeStart);
     Router.events.on('routeChangeComplete', handleRouteChangeComplete);

--- a/common/views/components/TransitionLink/index.tsx
+++ b/common/views/components/TransitionLink/index.tsx
@@ -1,0 +1,34 @@
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { SyntheticEvent } from 'react';
+declare global {
+  interface Document {
+    startViewTransition: (cb: () => void) => void;
+  }
+}
+const TransitionLink = ({ href, children, ...props }) => {
+  const router = useRouter();
+
+  const handleClick = (event: SyntheticEvent) => {
+    event.preventDefault();
+
+    document.startViewTransition(() => {
+      return new Promise(resolve => {
+        router.push(href);
+
+        window.addEventListener('message', event => {
+          if (event.data !== 'routechangecomplete') return;
+          resolve('route changed');
+        });
+      });
+    });
+  };
+
+  return (
+    <Link href={href} onClick={handleClick} {...props}>
+      {children}
+    </Link>
+  );
+};
+
+export default TransitionLink;

--- a/common/views/components/TransitionLink/index.tsx
+++ b/common/views/components/TransitionLink/index.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import { useRouter } from 'next/router';
 import { SyntheticEvent } from 'react';
 
 import { useToggles } from '@weco/common/server-data/Context';

--- a/common/views/components/TransitionLink/index.tsx
+++ b/common/views/components/TransitionLink/index.tsx
@@ -2,36 +2,25 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { SyntheticEvent } from 'react';
 
-import { useToggles } from '@weco/common/server-data/Context';
-
 declare global {
   interface Document {
     startViewTransition: (cb: () => void) => void;
   }
 }
+
 const TransitionLink = ({ href, children, ...props }) => {
   const router = useRouter();
-  const { viewTransitions } = useToggles();
 
   const handleClick = (event: SyntheticEvent) => {
     event.preventDefault();
 
-    if (!document.startViewTransition || !viewTransitions) {
+    if (!document.startViewTransition) {
       router.push(href);
 
       return;
     }
 
-    document.startViewTransition(() => {
-      return new Promise(resolve => {
-        router.push(href);
-
-        window.addEventListener('message', event => {
-          if (event.data !== 'routechangecomplete') return;
-          resolve('route changed');
-        });
-      });
-    });
+    document.startViewTransition(() => router.push(href));
   };
 
   return (

--- a/common/views/components/TransitionLink/index.tsx
+++ b/common/views/components/TransitionLink/index.tsx
@@ -1,6 +1,9 @@
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { SyntheticEvent } from 'react';
+
+import { useToggles } from '@weco/common/server-data/Context';
+
 declare global {
   interface Document {
     startViewTransition: (cb: () => void) => void;
@@ -8,9 +11,16 @@ declare global {
 }
 const TransitionLink = ({ href, children, ...props }) => {
   const router = useRouter();
+  const { viewTransitions } = useToggles();
 
   const handleClick = (event: SyntheticEvent) => {
     event.preventDefault();
+
+    if (!document.startViewTransition || !viewTransitions) {
+      router.push(href);
+
+      return;
+    }
 
     document.startViewTransition(() => {
       return new Promise(resolve => {

--- a/common/views/components/TransitionLink/index.tsx
+++ b/common/views/components/TransitionLink/index.tsx
@@ -1,6 +1,6 @@
-import Link from 'next/link';
+import Link, { LinkProps } from 'next/link';
 import { useRouter } from 'next/router';
-import { SyntheticEvent } from 'react';
+import { FunctionComponent, ReactNode, SyntheticEvent } from 'react';
 
 declare global {
   interface Document {
@@ -8,7 +8,12 @@ declare global {
   }
 }
 
-const TransitionLink = ({ href, children, ...props }) => {
+type Props = LinkProps & { children: ReactNode };
+const TransitionLink: FunctionComponent<Props> = ({
+  href,
+  children,
+  ...props
+}) => {
   const router = useRouter();
 
   const handleClick = (event: SyntheticEvent) => {

--- a/common/views/components/TransitionLink/index.tsx
+++ b/common/views/components/TransitionLink/index.tsx
@@ -2,24 +2,31 @@ import Link, { LinkProps } from 'next/link';
 import { useRouter } from 'next/router';
 import { FunctionComponent, ReactNode, SyntheticEvent } from 'react';
 
+import { useToggles } from '@weco/common/server-data/Context';
+
 declare global {
   interface Document {
     startViewTransition: (cb: () => void) => void;
   }
 }
 
-type Props = LinkProps & { children: ReactNode };
+type Props = LinkProps & {
+  children: ReactNode;
+  style?: Record<string, string>;
+  onFocus?: () => void;
+};
 const TransitionLink: FunctionComponent<Props> = ({
   href,
   children,
   ...props
 }) => {
+  const { viewTransitions } = useToggles();
   const router = useRouter();
 
   const handleClick = (event: SyntheticEvent) => {
     event.preventDefault();
 
-    if (!document.startViewTransition) {
+    if (!document.startViewTransition || !viewTransitions) {
       router.push(href);
 
       return;

--- a/common/views/themes/base/transitions.ts
+++ b/common/views/themes/base/transitions.ts
@@ -1,8 +1,4 @@
 export const transitions = `
-  @view-transition {
-    navigation: auto;
-  }
-
   @keyframes out {
     from {
       transform: translateX(0%)

--- a/common/views/themes/base/transitions.ts
+++ b/common/views/themes/base/transitions.ts
@@ -1,0 +1,39 @@
+export const transitions = `
+  @view-transition {
+    navigation: auto;
+  }
+
+  @keyframes out {
+    from {
+      transform: translateX(0%)
+    }
+
+    to {
+      transform: translateX(100%)
+    }
+  }
+
+  @keyframes in {
+    from {
+      transform: translateX(-100%)
+    }
+
+    to {
+      transform: translateX(0%)
+    }
+  }
+
+  ::view-transition-old(player-previous) {
+    animation: 200ms out ease-in;
+  }
+  ::view-transition-new(player-previous) {
+    animation: 200ms in ease-in;
+  }
+
+  ::view-transition-old(player-next) {
+    animation: 200ms out ease-in reverse;
+  }
+  ::view-transition-new(player-next) {
+    animation: 200ms in ease-in reverse;
+  }
+`;

--- a/common/views/themes/base/transitions.ts
+++ b/common/views/themes/base/transitions.ts
@@ -36,4 +36,10 @@ export const transitions = `
   ::view-transition-new(player-next) {
     animation: 200ms in ease-in reverse;
   }
+
+  @media (prefers-reduced-motion: reduce) {
+	  * {
+      view-transition-name: none !important;
+    }
+  }
 `;

--- a/common/views/themes/default.ts
+++ b/common/views/themes/default.ts
@@ -8,6 +8,7 @@ import { inlineFonts } from './base/inline-fonts';
 import { layout } from './base/layout';
 import { normalize } from './base/normalize';
 import { row } from './base/row';
+import { transitions } from './base/transitions';
 import { wellcomeNormalize } from './base/wellcome-normalize';
 import { Size, spacingUnits, themeValues } from './config';
 import { grid } from './grid';
@@ -135,6 +136,7 @@ const GlobalStyle = createGlobalStyle<GlobalStyleProps>`
   ${utilityClasses}
   ${normalize}
   ${wellcomeNormalize}
+  ${transitions}
   ${layout}
   ${row}
   ${inlineFonts}

--- a/content/webapp/components/Card/Card.tsx
+++ b/content/webapp/components/Card/Card.tsx
@@ -1,5 +1,5 @@
 import { FunctionComponent } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { getCrop } from '@weco/common/model/image';
 import { Label as LabelType } from '@weco/common/model/labels';
@@ -19,11 +19,7 @@ type Props = {
   item: CardType;
 };
 
-export const CardOuter = styled(TransitionLink).attrs<{
-  'data-gtm-trigger'?: 'card_link';
-}>({
-  'data-gtm-trigger': 'card_link',
-})`
+const sharedCardOuter = css`
   height: 100%;
   display: block; /* IE */
 
@@ -77,6 +73,22 @@ export const CardOuter = styled(TransitionLink).attrs<{
       }
     }
   }
+`;
+
+export const CardOuter = styled.a.attrs<{
+  'data-gtm-trigger'?: 'card_link';
+}>({
+  'data-gtm-trigger': 'card_link',
+})`
+  ${sharedCardOuter};
+`;
+
+export const CardOuterTransition = styled(TransitionLink).attrs<{
+  'data-gtm-trigger'?: 'card_link';
+}>({
+  'data-gtm-trigger': 'card_link',
+})`
+  ${sharedCardOuter};
 `;
 
 export const CardPostBody = styled(Space).attrs({

--- a/content/webapp/components/Card/Card.tsx
+++ b/content/webapp/components/Card/Card.tsx
@@ -7,6 +7,7 @@ import { font } from '@weco/common/utils/classnames';
 import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
 import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImage';
 import Space from '@weco/common/views/components/styled/Space';
+import TransitionLink from '@weco/common/views/components/TransitionLink';
 import PartNumberIndicator from '@weco/content/components/PartNumberIndicator/PartNumberIndicator';
 import { Card as CardType } from '@weco/content/types/card';
 
@@ -18,7 +19,9 @@ type Props = {
   item: CardType;
 };
 
-export const CardOuter = styled.a.attrs<{ 'data-gtm-trigger'?: 'card_link' }>({
+export const CardOuter = styled(TransitionLink).attrs<{
+  'data-gtm-trigger'?: 'card_link';
+}>({
   'data-gtm-trigger': 'card_link',
 })`
   height: 100%;

--- a/content/webapp/components/GuideStopCard/index.tsx
+++ b/content/webapp/components/GuideStopCard/index.tsx
@@ -52,7 +52,6 @@ const GuideStopCard: FunctionComponent<Props> = ({
 }) => {
   const { viewTransitions } = useToggles();
 
-  // TODO: constrain type
   const CardOuterComponent: ElementType = viewTransitions
     ? CardOuterTransition
     : CardOuter;

--- a/content/webapp/components/GuideStopCard/index.tsx
+++ b/content/webapp/components/GuideStopCard/index.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 
 import { duration as durationIcon, map } from '@weco/common/icons';
 import { getCrop, ImageType } from '@weco/common/model/image';
+import { useToggles } from '@weco/common/server-data/Context';
 import { font, grid } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImage';
@@ -11,6 +12,7 @@ import { threeUpGridSizesMap } from '@weco/content/components/Body/GridFactory';
 import {
   CardBody,
   CardImageWrapper,
+  CardOuter,
   CardOuterTransition,
   CardTitle,
 } from '@weco/content/components/Card/Card';
@@ -48,13 +50,22 @@ const GuideStopCard: FunctionComponent<Props> = ({
   type,
   image,
 }) => {
+  const { viewTransitions } = useToggles();
+
+  const CardOuterComponent:
+    | typeof CardOuterTransition
+    | (typeof CardOuter & { href: string }) = viewTransitions
+    ? CardOuterTransition
+    : CardOuter;
+
   const croppedImage = getCrop(image, '16:9');
+
   return (
     <Space
       $v={{ size: 'l', properties: ['margin-bottom'] }}
       className={grid(threeUpGridSizesMap.default[0])}
     >
-      <CardOuterTransition
+      <CardOuterComponent
         href={link}
         style={{ minHeight: '0', viewTransitionName: `player-${number}` }}
         id={`${number}`}
@@ -116,7 +127,7 @@ const GuideStopCard: FunctionComponent<Props> = ({
             </AlignIconFirstLineCenter>
           )}
         </CardBody>
-      </CardOuterTransition>
+      </CardOuterComponent>
     </Space>
   );
 };

--- a/content/webapp/components/GuideStopCard/index.tsx
+++ b/content/webapp/components/GuideStopCard/index.tsx
@@ -11,7 +11,7 @@ import { threeUpGridSizesMap } from '@weco/content/components/Body/GridFactory';
 import {
   CardBody,
   CardImageWrapper,
-  CardOuter,
+  CardOuterTransition,
   CardTitle,
 } from '@weco/content/components/Card/Card';
 import ImagePlaceholder, {
@@ -54,7 +54,7 @@ const GuideStopCard: FunctionComponent<Props> = ({
       $v={{ size: 'l', properties: ['margin-bottom'] }}
       className={grid(threeUpGridSizesMap.default[0])}
     >
-      <CardOuter
+      <CardOuterTransition
         href={link}
         style={{ minHeight: '0', viewTransitionName: `player-${number}` }}
         id={`${number}`}
@@ -116,7 +116,7 @@ const GuideStopCard: FunctionComponent<Props> = ({
             </AlignIconFirstLineCenter>
           )}
         </CardBody>
-      </CardOuter>
+      </CardOuterTransition>
     </Space>
   );
 };

--- a/content/webapp/components/GuideStopCard/index.tsx
+++ b/content/webapp/components/GuideStopCard/index.tsx
@@ -54,7 +54,11 @@ const GuideStopCard: FunctionComponent<Props> = ({
       $v={{ size: 'l', properties: ['margin-bottom'] }}
       className={grid(threeUpGridSizesMap.default[0])}
     >
-      <CardOuter href={link} style={{ minHeight: '0' }} id={`${number}`}>
+      <CardOuter
+        href={link}
+        style={{ minHeight: '0', viewTransitionName: `player-${number}` }}
+        id={`${number}`}
+      >
         <CardImageWrapper>
           {croppedImage ? (
             <PrismicImage
@@ -71,7 +75,12 @@ const GuideStopCard: FunctionComponent<Props> = ({
               quality="low"
             />
           ) : (
-            <div style={{ aspectRatio: '16/9', overflow: 'hidden' }}>
+            <div
+              style={{
+                aspectRatio: '16/9',
+                overflow: 'hidden',
+              }}
+            >
               <ImagePlaceholder
                 backgroundColor={placeholderBackgroundColor(number || 1)}
               />

--- a/content/webapp/components/GuideStopCard/index.tsx
+++ b/content/webapp/components/GuideStopCard/index.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent } from 'react';
+import { ElementType, FunctionComponent } from 'react';
 import styled from 'styled-components';
 
 import { duration as durationIcon, map } from '@weco/common/icons';
@@ -52,9 +52,8 @@ const GuideStopCard: FunctionComponent<Props> = ({
 }) => {
   const { viewTransitions } = useToggles();
 
-  const CardOuterComponent:
-    | typeof CardOuterTransition
-    | (typeof CardOuter & { href: string }) = viewTransitions
+  // TODO: constrain type
+  const CardOuterComponent: ElementType = viewTransitions
     ? CardOuterTransition
     : CardOuter;
 

--- a/content/webapp/pages/guides/exhibitions/[id]/[type]/[stop]/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/[type]/[stop]/index.tsx
@@ -284,7 +284,6 @@ const ExhibitionGuidePage: FunctionComponent<Props> = props => {
                 <TransitionLink
                   href={`${guideTypeUrl}#${currentStop.number}`}
                   onMouseEnter={() => {
-                    console.log('ooof');
                     setViewTransitionName(`player-${currentStop.number}`);
                   }}
                 >

--- a/content/webapp/pages/guides/exhibitions/[id]/[type]/[stop]/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/[type]/[stop]/index.tsx
@@ -385,7 +385,7 @@ const ExhibitionGuidePage: FunctionComponent<Props> = props => {
             )}
           </Layout>
         </div>
-        {/* PrevNext needs a view-transition-name even though it isn't transitioning: https://www.nicchan.me/blog/view-transitions-and-stacking-context/#the-workaround */}
+        {/* Header needs a view-transition-name even though it isn't transitioning: https://www.nicchan.me/blog/view-transitions-and-stacking-context/#the-workaround */}
         <PrevNext style={{ viewTransitionName: 'prevnext' }}>
           <Container>
             <div

--- a/content/webapp/pages/guides/exhibitions/[id]/[type]/[stop]/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/[type]/[stop]/index.tsx
@@ -290,7 +290,8 @@ const ExhibitionGuidePage: FunctionComponent<Props> = props => {
       apiToolbarLinks={[createPrismicLink(exhibitionGuideId)]}
     >
       <Page>
-        <Header ref={headerRef}>
+        {/* Header needs a view-transition-name even though it isn't transitioning: https://www.nicchan.me/blog/view-transitions-and-stacking-context/#the-workaround */}
+        <Header ref={headerRef} style={{ viewTransitionName: 'header' }}>
           <Container>
             <HeaderInner>
               <div>
@@ -384,7 +385,7 @@ const ExhibitionGuidePage: FunctionComponent<Props> = props => {
             )}
           </Layout>
         </div>
-        {/* Even though we're not transitioning the footer, we need to give it a view-transition-name to make sure it is taken into consideration by the browser when it's computing the transition: https://www.nicchan.me/blog/view-transitions-and-stacking-context/#the-workaround */}
+        {/* PrevNext needs a view-transition-name even though it isn't transitioning: https://www.nicchan.me/blog/view-transitions-and-stacking-context/#the-workaround */}
         <PrevNext style={{ viewTransitionName: 'prevnext' }}>
           <Container>
             <div

--- a/content/webapp/pages/guides/exhibitions/[id]/[type]/[stop]/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/[type]/[stop]/index.tsx
@@ -1,7 +1,7 @@
 import { GetServerSideProps } from 'next';
 import { useRouter } from 'next/router';
 import { FunctionComponent, useCallback, useEffect, useState } from 'react';
-import styled, { CSSProperties } from 'styled-components';
+import styled from 'styled-components';
 
 import { pageDescriptions } from '@weco/common/data/microcopy';
 import { arrow, cross } from '@weco/common/icons';
@@ -297,11 +297,7 @@ const ExhibitionGuidePage: FunctionComponent<Props> = props => {
             </HeaderInner>
           </Container>
         </Header>
-        <div
-          style={
-            { 'view-transition-name': viewTransitionName } as CSSProperties
-          }
-        >
+        <div style={{ viewTransitionName }}>
           <FlushContainer>
             <div className="grid">
               <div className={grid(gridSize8())}>

--- a/content/webapp/pages/guides/exhibitions/[id]/[type]/[stop]/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/[type]/[stop]/index.tsx
@@ -283,9 +283,12 @@ const ExhibitionGuidePage: FunctionComponent<Props> = props => {
               <span>
                 <TransitionLink
                   href={`${guideTypeUrl}#${currentStop.number}`}
-                  onMouseEnter={() => {
-                    setViewTransitionName(`player-${currentStop.number}`);
-                  }}
+                  onFocus={() =>
+                    setViewTransitionName(`player-${currentStop.number}`)
+                  }
+                  onMouseEnter={() =>
+                    setViewTransitionName(`player-${currentStop.number}`)
+                  }
                 >
                   <Icon icon={cross} />
                   <span className="visually-hidden">Back to list of stops</span>
@@ -383,6 +386,7 @@ const ExhibitionGuidePage: FunctionComponent<Props> = props => {
                     }}
                     href={`${guideTypeUrl}/${stopNumber - 1}`}
                     shallow={true}
+                    onFocus={() => setViewTransitionName('player-previous')}
                     onMouseEnter={() =>
                       setViewTransitionName('player-previous')
                     }
@@ -416,6 +420,7 @@ const ExhibitionGuidePage: FunctionComponent<Props> = props => {
                     }}
                     href={`${guideTypeUrl}/${stopNumber + 1}`}
                     shallow={true}
+                    onFocus={() => setViewTransitionName('player-next')}
                     onMouseEnter={() => setViewTransitionName('player-next')}
                   >
                     <Space

--- a/content/webapp/pages/guides/exhibitions/[id]/[type]/[stop]/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/[type]/[stop]/index.tsx
@@ -385,7 +385,7 @@ const ExhibitionGuidePage: FunctionComponent<Props> = props => {
             )}
           </Layout>
         </div>
-        {/* Header needs a view-transition-name even though it isn't transitioning: https://www.nicchan.me/blog/view-transitions-and-stacking-context/#the-workaround */}
+        {/* PrevNext needs a view-transition-name even though it isn't transitioning: https://www.nicchan.me/blog/view-transitions-and-stacking-context/#the-workaround */}
         <PrevNext style={{ viewTransitionName: 'prevnext' }}>
           <Container>
             <div

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -79,6 +79,14 @@ const toggles = {
       type: 'permanent',
     },
     {
+      id: 'viewTransitions',
+      title: 'Use view-transitions API',
+      initialValue: false,
+      description:
+        'Use animated transitions between page routes where possible',
+      type: 'experimental',
+    },
+    {
       id: 'showBornDigital',
       title: 'Display born digital files',
       initialValue: false,


### PR DESCRIPTION
## What does this change?
Adds a `TransitionLink` component that is a wrapper around the `next/link` component that allows for the platform–native [View Transitions](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API) to run if they're available.

https://github.com/user-attachments/assets/7d9cb7c5-f618-40fa-a762-0c3bd13f9a9e

## How to test
Set `toggle_viewTransitions` to true locally and visit e.g. a [stops audio index](http://localhost:3000/guides/exhibitions/ZsdFlRIAACIAqKGB/audio-without-descriptions) – check zoom transitions work from cards to players, and slide transitions work with the previous/next buttons from individual stops.

## How can we measure success?
Possibly requires user testing

## Have we considered potential risks?
If the animation is inconsistent or janky, the experience could feel broken. ~This updates all `CardOuter` components which will then by default crossfade to their linked page. Not sure if this is desirable so maybe we need to make it conditional (or another component)~ <– made a separate component