### PR TITLE
User role

### DIFF
--- a/common/model/user.ts
+++ b/common/model/user.ts
@@ -4,6 +4,7 @@ export type UserInfo = {
   email: string;
   emailValidated: boolean;
   barcode: string;
+  role: string;
   userId: string;
 };
 
@@ -19,6 +20,7 @@ export type Auth0UserProfile = {
   family_name: string;
   nickname: string;
   'https://wellcomecollection.org/patron_barcode': string;
+  'https://wellcomecollection.org/patron_role': string;
 };
 
 // Auth0 subject claims (aka user IDs) are prefixed with `auth0|`, plus
@@ -39,7 +41,8 @@ export const isFullAuth0Profile = (data: any): data is Auth0UserProfile =>
   data.family_name &&
   data.email &&
   data.sub &&
-  data['https://wellcomecollection.org/patron_barcode'];
+  data['https://wellcomecollection.org/patron_barcode'] &&
+  data['https://wellcomecollection.org/patron_role'];
 
 export const auth0UserProfileToUserInfo = (
   auth0Profile?: Auth0UserProfile
@@ -50,5 +53,6 @@ export const auth0UserProfileToUserInfo = (
     email: auth0Profile.email,
     emailValidated: !!auth0Profile.email_verified,
     barcode: auth0Profile['https://wellcomecollection.org/patron_barcode'],
+    role: auth0Profile['https://wellcomecollection.org/patron_role'],
     userId: auth0IdToPublic(auth0Profile.sub),
   };

--- a/common/test/fixtures/identity/user.ts
+++ b/common/test/fixtures/identity/user.ts
@@ -8,10 +8,12 @@ export const mockUser: UserInfo = {
   email: 'bruciebaby@wayneenterprises.com',
   emailValidated: true,
   barcode: '1234567',
+  role: 'Staff',
 };
 
 export const mockAuth0Profile: Auth0UserProfile = {
   'https://wellcomecollection.org/patron_barcode': mockUser.barcode,
+  'https://wellcomecollection.org/patron_role': mockUser.role,
   email: mockUser.email,
   email_verified: mockUser.emailValidated,
   family_name: mockUser.lastName,

--- a/content/webapp/components/WorkDetails/index.tsx
+++ b/content/webapp/components/WorkDetails/index.tsx
@@ -8,6 +8,7 @@ import { formatDuration } from '@weco/common/utils/format-date';
 import Button from '@weco/common/views/components/Buttons';
 import Layout, { gridSize10 } from '@weco/common/views/components/Layout';
 import Space from '@weco/common/views/components/styled/Space';
+import { useUser } from '@weco/common/views/components/UserProvider/UserProvider';
 import { themeValues } from '@weco/common/views/themes/config';
 import { toLink as conceptLink } from '@weco/content/components/ConceptLink';
 import { CopyUrl } from '@weco/content/components/CopyButtons';
@@ -59,6 +60,7 @@ const WorkDetails: FunctionComponent<Props> = ({
   digitalLocationInfo,
   transformedManifest,
 }: Props) => {
+  const { user } = useUser();
   const { showBornDigital } = useToggles();
   const isArchive = useContext(IsArchiveContext);
   const transformedIIIFImage = useTransformedIIIFImage(toWorkBasic(work));
@@ -153,11 +155,16 @@ const WorkDetails: FunctionComponent<Props> = ({
   const hasBornDigital =
     bornDigitalStatus && bornDigitalStatus !== 'noBornDigital';
 
+  const treatAsRestricted =
+    digitalLocationInfo?.accessCondition === 'restricted' &&
+    user?.role !== 'StaffWithRestricted';
+
   const showAvailableOnlineSection =
-    (digitalLocation && shouldShowItemLink) ||
-    hasVideo ||
-    hasSound ||
-    (hasBornDigital && showBornDigital);
+    ((digitalLocation && shouldShowItemLink) ||
+      hasVideo ||
+      hasSound ||
+      (hasBornDigital && showBornDigital)) &&
+    !treatAsRestricted;
 
   const renderContent = () => (
     <>

--- a/content/webapp/pages/works/[workId]/index.tsx
+++ b/content/webapp/pages/works/[workId]/index.tsx
@@ -12,6 +12,7 @@ import Divider from '@weco/common/views/components/Divider/Divider';
 import SearchForm from '@weco/common/views/components/SearchForm/SearchForm';
 import { Container } from '@weco/common/views/components/styled/Container';
 import Space from '@weco/common/views/components/styled/Space';
+import { useUser } from '@weco/common/views/components/UserProvider/UserProvider';
 import ArchiveBreadcrumb from '@weco/content/components/ArchiveBreadcrumb/ArchiveBreadcrumb';
 import ArchiveTree from '@weco/content/components/ArchiveTree';
 import BackToResults from '@weco/content/components/BackToResults/BackToResults';
@@ -69,6 +70,8 @@ export const WorkPage: NextPage<Props> = ({
   apiUrl,
   transformedManifest,
 }) => {
+  const { user } = useUser();
+  const role = user?.role;
   const isArchive = !!(
     work.parts.length ||
     (work.partOf.length > 0 && work.partOf[0].totalParts)
@@ -93,6 +96,7 @@ export const WorkPage: NextPage<Props> = ({
   const allOriginalPdfs = isAllOriginalPdfs(canvases || []);
 
   const shouldShowItemLink = showItemLink({
+    role,
     allOriginalPdfs,
     hasIIIFManifest: !!transformedManifest,
     digitalLocation,

--- a/content/webapp/utils/works.ts
+++ b/content/webapp/utils/works.ts
@@ -359,6 +359,7 @@ export function getFirstAccessCondition(
 }
 
 export function showItemLink({
+  role,
   allOriginalPdfs,
   hasIIIFManifest,
   digitalLocation,
@@ -366,6 +367,7 @@ export function showItemLink({
   canvases,
   bornDigitalStatus,
 }: {
+  role?: string;
   allOriginalPdfs: boolean;
   hasIIIFManifest: boolean;
   digitalLocation?: DigitalLocation;
@@ -383,7 +385,10 @@ export function showItemLink({
   const hasSound =
     hasItemType(canvases, 'Sound') || hasItemType(canvases, 'Audio');
 
-  if (accessCondition === 'closed' || accessCondition === 'restricted') {
+  if (
+    accessCondition === 'closed' ||
+    (accessCondition === 'restricted' && role !== 'StaffWithRestricted')
+  ) {
     return false;
   } else if (
     hasIIIFManifest &&

--- a/identity/webapp/src/utility/auth0.ts
+++ b/identity/webapp/src/utility/auth0.ts
@@ -50,7 +50,12 @@ const utilityScopes = [
 // https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
 // you can actually only ask for quite general *scopes*:
 // https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims
-const profileScopes = ['profile', 'email', 'weco:patron_barcode'];
+const profileScopes = [
+  'profile',
+  'email',
+  'weco:patron_barcode',
+  'weco:patron_role',
+];
 
 const identityAuthorizationParams = {
   audience: config.remoteApi.host,

--- a/playwright/test/helpers/contexts.ts
+++ b/playwright/test/helpers/contexts.ts
@@ -188,6 +188,14 @@ const workWithDigitalLocationOnly = async (
   await gotoWithoutCache(`${baseUrl}/works/j9kukb78`, page);
 };
 
+const workWithDigitalLocationAndRestricted = async (
+  context: BrowserContext,
+  page: Page
+): Promise<void> => {
+  await context.addCookies(requiredCookies);
+  await gotoWithoutCache(`${baseUrl}/works/jjdp9v65`, page);
+};
+
 const workWithDigitalLocationAndLocationNote = async (
   context: BrowserContext,
   page: Page
@@ -315,6 +323,7 @@ export {
   itemWithReferenceNumber,
   workWithPhysicalLocationOnly,
   workWithDigitalLocationOnly,
+  workWithDigitalLocationAndRestricted,
   workWithDigitalLocationAndLocationNote,
   workWithBornDigitalDownloads,
   itemWithOnlyOpenAccess,

--- a/playwright/test/work.test.ts
+++ b/playwright/test/work.test.ts
@@ -5,6 +5,7 @@ import {
   isMobile,
   workWithBornDigitalDownloads,
   workWithDigitalLocationAndLocationNote,
+  workWithDigitalLocationAndRestricted,
   workWithDigitalLocationOnly,
   workWithPhysicalLocationOnly,
 } from './helpers/contexts';
@@ -71,6 +72,15 @@ test.describe(`Scenario 1: a user wants to see relevant information about where 
     await workWithDigitalLocationAndLocationNote(context, page);
     const availableOnline = await getAvailableOnline(page);
     await expect(availableOnline).toBeVisible();
+  });
+
+  test(`works with a digital location don't display an 'Available online' section if the work is restricted and the user doesn't have a role of 'StaffWithRestricted'`, async ({
+    page,
+    context,
+  }) => {
+    await workWithDigitalLocationAndRestricted(context, page);
+    const availableOnline = await getAvailableOnline(page);
+    await expect(availableOnline).toHaveCount(0);
   });
 
   test(`works with only a digital location don't display a 'Where to find it' section`, async ({


### PR DESCRIPTION
## What does this change?

For [#5762](https://github.com/wellcomecollection/platform/issues/5762)

- adds the users role to UserInfo 
- passes the users role to the showItemLink function, which determines whether we should display a link to the item page
- if the user has a role of 'StaffWithRestricted' the link will show, if not, or the user is logged out, then the link will not show

Also for #11014

- adds another conditional around the Available Online section, so it won't show if the item is restricted and the user doesn't have the 'StaffWithRestricted' role.

## How to test
- run the site with `yarn run-concurrently`
- Visit a works page which has a [restricted item](http://localhost:3000/works/jjdp9v65) while **logged out** and see that no link to the item page is displayed
- Visit a works page which has a [restricted item](http://localhost:3000/works/jjdp9v65) while **logged in** with a user that **doesn't** have a role of 'StaffWithRestricted' and see that no link to the item page is displayed
- Visit a works page which has a [restricted item](http://localhost:3000/works/jjdp9v65) while **logged in** with a user that **does** have a role of 'StaffWithRestricted' and see that a link to the item page is displayed (you will have to watch me do this)

## How can we measure success?

Staff with a role of 'StaffWithRestricted' are presented with a link to the item page for restricted items, everyone else is not.

## Have we considered potential risks?

What will happen if the user follows the link to the item page (before we've done the rest of the auth work)?

- If the item page would have displayed the viewer, then it will display a modal telling the user that the item is restricted
- If the item page would have displayed an audio/video player, it still will but pressing play won't work as the audio/video file won't load.
- Ashley said that all PDFs are open, so nothing will change for these.
- For Born digital things that contain audio or video (http://localhost:3000/works/h3qjfr87) the link still won't show because of the presence of those files types. (One of the reasons why displaying everything in the viewer will make life easier).
- For Born digital items that don't contain audio and video, the link will show but the item page will be blank.

These behaviours might be annoying, but as this will be temporary and since hardly anyone has the correct role, I don't think this is a problem.

