### PR TITLE
Dependabot; Ignore chromatic, storybook and next upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,26 +5,29 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: 'npm' # See documentation for possible values
+    directory: '/' # Location of package manifests
     schedule:
-      interval: "weekly" # Check for updates every month
+      interval: 'weekly' # Check for updates every month
     ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"] # Ignore all patch updates for version updates only
+      - dependency-name: '*'
+        update-types: ['version-update:semver-patch'] # Ignore all patch updates for version updates only
       # We are looking at updating Storybook, so don't tell us about it. Remove this once we've upgraded.
       - dependency-name: '@storybook*'
       - dependency-name: 'chromatic*'
       # Bigger piece, has a ticket to upgrade. Remove this once it's done.
       - dependency-name: 'next'
       - dependency-name: '@next*'
+      # Needs to be done carefully, has its own ticket. Remove this once it's done.
+      - dependency-name: 'slice-machine-ui'
+      - dependency-name: '@slicemachine'
     groups:
       all:
-        patterns: ["*"]
+        patterns: ['*']
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'weekly'
     groups:
-      all: 
-        patterns: ["*"]
+      all:
+        patterns: ['*']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,12 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"] # Ignore all patch updates for version updates only
+      # We are looking at updating Storybook, so don't tell us about it. Remove this once we've upgraded.
+      - dependency-name: '@storybook*'
+      - dependency-name: 'chromatic*'
+      # Bigger piece, has a ticket to upgrade. Remove this once it's done.
+      - dependency-name: 'next'
+      - dependency-name: '@next*'
     groups:
       all:
         patterns: ["*"]


### PR DESCRIPTION
## What does this change?

The grouped updates currently contain some really big pieces ([see here](https://github.com/wellcomecollection/wellcomecollection.org/pull/11227)) that we intend on doing, but carefully and one at a time, so I'm ignoring them so the Dependabot upgrade PRs are relevant again.

## How to test

Once merged I'll relaunch the action manually.

## How can we measure success?

Dependabot PRs can be considered merge-able.

## Have we considered potential risks?
N/A