### PR TITLE
Ignore eslint packages for now

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,8 @@ updates:
       # Needs to be done carefully, has its own ticket. Remove this once it's done.
       - dependency-name: 'slice-machine-ui'
       - dependency-name: '@slicemachine'
+      # Needs more work, has its own ticket. Remove this once it's done.
+      - dependency-name: 'eslint*'
     groups:
       all:
         patterns: ['*']


### PR DESCRIPTION
## What does this change?

We have a [ticket](https://github.com/wellcomecollection/wellcomecollection.org/issues/11232) to upgrade eslint so we don't want it flagged in the meantime.

## How to test

N/A

## How can we measure success?

Less noise

## Have we considered potential risks?
N/A