### PR TITLE
e2e test in search-images to check the Date filter

### DIFF
--- a/playwright/test/search-images.test.ts
+++ b/playwright/test/search-images.test.ts
@@ -1,10 +1,12 @@
 import { expect, test } from '@playwright/test';
 
-import { newSearch } from './helpers/contexts';
+import { isMobile, newSearch } from './helpers/contexts';
 import {
   clickImageSearchResultItem,
+  openFilterDropdown,
   searchQuerySubmitAndWait,
   selectAndWaitForColourFilter,
+  testIfFilterIsApplied,
 } from './helpers/search';
 
 const ItemViewerURLRegex = /\/works\/[a-zA-Z0-9]+\/images[?]id=/;
@@ -61,4 +63,30 @@ test('(3) | Image Modal | images with contributors show both title and contribut
     imageModal.getByRole('heading', { name: 'Dr. Darwin.' })
   ).toBeVisible();
   await expect(imageModal).toContainText('Fortey, W. S. (William Samuel)');
+});
+
+test('(4) | Search for images between dates; there is a list of results', async ({
+  page,
+  context,
+}) => {
+  await newSearch(context, page, 'images');
+  await searchQuerySubmitAndWait('instruments', page);
+  await openFilterDropdown('Dates', page);
+
+  await page
+    .getByRole('spinbutton', { name: 'From', exact: true })
+    .fill('1812');
+
+  await page.getByRole('spinbutton', { name: 'to', exact: true }).fill('1870');
+
+  if (isMobile(page)) {
+    await page.getByRole('button', { name: 'Show results' }).click();
+  }
+
+  await testIfFilterIsApplied('From 1812', page);
+  await testIfFilterIsApplied('To 1870', page);
+
+  await expect(
+    page.locator('[data-testid="image-search-results-container"] li')
+  ).toHaveCount(30);
 });


### PR DESCRIPTION
## What does this change?

This adds a fourth(!) test in `search-images.test` to check the Dates filter is applied and returning results. It follows similar logic to the Dates filter check in `search-works.test`, but /images uses `source.production.dates.to/from` to utilise its Date filter. 

> [!NOTE]
> This test was built to meet some requirements in my portfolio as part of my work in Date filtering for `/images`, and so has no related issue par Date filtering work (inc. #9952)

It may not be necessary, so happy to discuss and close if so! 

### Some thoughts to improve if we keep it

Would it be useful to consider more specific checks, especially related to removal of the filter which caused some bugs last year? 

- Checking the filter can be removed and displays correct results (only up to YEAR or only from YEAR) when only one year is applied against results?
- Should the filter check the results more specifically rather than returning the assumed number of results? (particular image from YEAR can be returned after the above)

## How to test

Follow local e2e instructions in `/playwright/README.md`. 

```
PLAYWRIGHT_BASE_URL=http://localhost:3000 yarn test search-images.test.ts
```                                                                                           
Consider using `test.only('(4) ...` without running entire image-search suite.

## How can we measure success?

Asking is this test necessary? 
Does the test pass?
Does the test accurately cover functionality (and previous bugs) of Dates filter?

## Have we considered potential risks?

May not be necessary and could be adding bulk to e2es. 

