### PR TITLE
Show viewer for staff

### DIFF
--- a/content/webapp/components/IIIFViewer/IIIFViewer.tsx
+++ b/content/webapp/components/IIIFViewer/IIIFViewer.tsx
@@ -129,14 +129,7 @@ const Sidebar = styled.div<{
 const Topbar = styled.div`
   background: ${props => props.theme.color('neutral.700')};
   grid-area: top-edge / left-edge / desktop-topbar-end / right-edge;
-
-  /* TODO: this is to let downloads sit above sidebar on desktop but not have the topbar above the sidebar on mobile.
-   If we move the downloads, this can be simplified */
-  z-index: 4;
-
-  ${props => props.theme.media('medium')`
-    z-index: 5;
-  `}
+  z-index: 5;
 `;
 
 const Main = styled.div<{

--- a/content/webapp/components/IIIFViewer/IIIFViewer.tsx
+++ b/content/webapp/components/IIIFViewer/IIIFViewer.tsx
@@ -45,6 +45,7 @@ type IIIFViewerProps = {
   searchResults: SearchResults | null;
   setSearchResults: (v) => void;
   parentManifest?: ParentManifest;
+  accessToken?: string;
 };
 
 const LoadingComponent = () => (
@@ -207,6 +208,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
   searchResults,
   setSearchResults,
   parentManifest,
+  accessToken,
 }: IIIFViewerProps) => {
   const router = useRouter();
   const {
@@ -311,6 +313,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
         setRotatedImages,
         isResizing,
         errorHandler: handleImageError,
+        accessToken,
       }}
     >
       <Grid ref={viewerRef} $isFullSupportBrowser={isFullSupportBrowser}>

--- a/content/webapp/components/IIIFViewer/MainViewer.tsx
+++ b/content/webapp/components/IIIFViewer/MainViewer.tsx
@@ -84,6 +84,7 @@ type ItemRendererProps = {
     rotatedImages: RotatedImage[];
     errorHandler?: () => void;
     externalAccessService: TransformedAuthService | undefined;
+    accessToken?: string;
   };
 };
 
@@ -210,7 +211,7 @@ function getPositionData({
   return highlightsPositioningData || [];
 }
 const ItemRenderer = memo(({ style, index, data }: ItemRendererProps) => {
-  const { scrollVelocity, canvases, externalAccessService } = data;
+  const { scrollVelocity, canvases, externalAccessService, accessToken } = data;
   const [mainLoaded, setMainLoaded] = useState(false);
   const currentCanvas = canvases[index];
   const mainImageService = { '@id': currentCanvas.imageServiceId };
@@ -380,6 +381,7 @@ const MainViewer: FunctionComponent = () => {
     rotatedImages,
     setShowControls,
     errorHandler,
+    accessToken,
   } = useContext(ItemViewerContext);
   const { authV2 } = useToggles();
   const { shouldScrollToCanvas, canvas } = query;
@@ -454,6 +456,7 @@ const MainViewer: FunctionComponent = () => {
           errorHandler,
           externalAccessService,
           canvas,
+          accessToken,
         }}
         itemSize={mainAreaWidth}
         onItemsRendered={debounceHandleOnItemsRendered.current}

--- a/content/webapp/components/IIIFViewer/ViewerStructures.tsx
+++ b/content/webapp/components/IIIFViewer/ViewerStructures.tsx
@@ -18,7 +18,7 @@ import {
 } from '@weco/content/services/wellcome/catalogue/types';
 import { TransformedCanvas } from '@weco/content/types/manifest';
 import {
-  getEnFromInternationalString,
+  getDisplayLabel,
   isCanvas,
   isRange,
 } from '@weco/content/utils/iiif/v3';
@@ -121,7 +121,7 @@ const Structures: FunctionComponent<Props> = ({
                 </NextLink>
               )}
             >
-              {getEnFromInternationalString(range.label)}
+              {getDisplayLabel(range.label)}
             </ConditionalWrapper>
             {nestedRanges.map((range, i) => {
               return (

--- a/content/webapp/components/ItemViewerContext/ItemViewerContext.tsx
+++ b/content/webapp/components/ItemViewerContext/ItemViewerContext.tsx
@@ -52,6 +52,7 @@ type Props = {
   setRotatedImages: (v: RotatedImage[]) => void;
   isResizing: boolean;
   errorHandler?: () => void;
+  accessToken?: string;
 };
 
 export const results = {

--- a/content/webapp/pages/works/[workId]/items.tsx
+++ b/content/webapp/pages/works/[workId]/items.tsx
@@ -173,6 +173,7 @@ const ItemPage: NextPage<Props> = ({
   };
 
   const needsModal = checkModalRequired({
+    role,
     auth,
     isAnyImageOpen,
     authV2,
@@ -230,7 +231,7 @@ const ItemPage: NextPage<Props> = ({
       setShowModal(false);
       setShowViewer(true);
     }
-  }, []);
+  }, [needsModal]);
 
   return (
     <CataloguePageLayout

--- a/content/webapp/pages/works/[workId]/items.tsx
+++ b/content/webapp/pages/works/[workId]/items.tsx
@@ -22,6 +22,7 @@ import Button from '@weco/common/views/components/Buttons';
 import Layout, { gridSize12 } from '@weco/common/views/components/Layout';
 import Modal from '@weco/common/views/components/Modal/Modal';
 import Space from '@weco/common/views/components/styled/Space';
+import { useUser } from '@weco/common/views/components/UserProvider/UserProvider';
 import CataloguePageLayout from '@weco/content/components/CataloguePageLayout/CataloguePageLayout';
 import IIIFItemList from '@weco/content/components/IIIFItemList/IIIFItemList';
 import IIIFViewer, {
@@ -156,6 +157,8 @@ const ItemPage: NextPage<Props> = ({
   serverSearchResults,
   parentManifest,
 }) => {
+  const { user } = useUser();
+  const role = user?.role;
   const { authV2 } = useToggles();
   const transformedManifest =
     compressedTransformedManifest &&

--- a/content/webapp/pages/works/[workId]/items.tsx
+++ b/content/webapp/pages/works/[workId]/items.tsx
@@ -174,7 +174,7 @@ const ItemPage: NextPage<Props> = ({
     isAnyImageOpen,
     authV2,
   });
-
+  const [accessToken, setAccessToken] = useState();
   const [searchResults, setSearchResults] = useState(serverSearchResults);
   const authService = getAuthService({ auth, authV2 });
   const currentCanvas = canvases?.[queryParamToArrayIndex(canvas)];
@@ -213,6 +213,7 @@ const ItemPage: NextPage<Props> = ({
         if (Object.prototype.hasOwnProperty.call(data, 'accessToken')) {
           setShowModal(Boolean(isTotallyRestricted));
           setShowViewer(!isTotallyRestricted);
+          setAccessToken(data.accessToken);
         } else {
           setShowModal(true);
           setShowViewer(false);
@@ -337,6 +338,7 @@ const ItemPage: NextPage<Props> = ({
             searchResults={searchResults}
             setSearchResults={setSearchResults}
             parentManifest={parentManifest}
+            accessToken={accessToken}
           />
         )}
     </CataloguePageLayout>

--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -46,19 +46,17 @@ export function getMultiVolumeLabel(
   internationalString: InternationalString,
   itemTitle: string
 ): string | undefined {
-  const stringAtIndex1 = getEnFromInternationalString(internationalString, {
+  const stringAtIndex1 = getDisplayLabel(internationalString, {
     index: 1,
   });
-  const stringAtIndex0 = getEnFromInternationalString(internationalString, {
+  const stringAtIndex0 = getDisplayLabel(internationalString, {
     index: 0,
   });
 
   return stringAtIndex1 === itemTitle ? stringAtIndex0 : stringAtIndex1;
 }
 
-// TODO: rename this to something like getDisplayLabel since the key of interest
-// can be either 'en' or 'none'
-export function getEnFromInternationalString(
+export function getDisplayLabel(
   internationalString: InternationalString,
   indexProps?: { index: number }
 ): string | undefined {
@@ -74,7 +72,7 @@ export function transformLabel(
 ): string | undefined {
   if (typeof label === 'string' || label === undefined) return label;
 
-  return getEnFromInternationalString(label);
+  return getDisplayLabel(label);
 }
 
 // It appears that iiif-manifests for born digital items can exist without the items property
@@ -132,7 +130,7 @@ export function getTitle(
   if (!label) return '';
   if (typeof label === 'string') return label;
 
-  return getEnFromInternationalString(label) || '';
+  return getDisplayLabel(label) || '';
 }
 
 export function getTransformedCanvases(
@@ -254,7 +252,7 @@ export function getIIIFMetadata(
   label: string
 ): MetadataItem | undefined {
   return (manifest.metadata || []).find(
-    data => getEnFromInternationalString(data.label) === label
+    data => getDisplayLabel(data.label) === label
   );
 }
 
@@ -263,7 +261,7 @@ export function getIIIFPresentationCredit(
 ): string | undefined {
   const attribution = getIIIFMetadata(manifest, 'Attribution and usage');
   const maybeValueWithBrTags =
-    attribution?.value && getEnFromInternationalString(attribution.value);
+    attribution?.value && getDisplayLabel(attribution.value);
 
   return maybeValueWithBrTags?.split('<br />')[0];
 }
@@ -489,8 +487,8 @@ export function groupRanges(
       );
 
       if (
-        getEnFromInternationalString(acc.previousLabel) ===
-          getEnFromInternationalString(range.label) &&
+        getDisplayLabel(acc.previousLabel) ===
+          getDisplayLabel(range.label) &&
         acc.previousLastCanvasIndex &&
         firstCanvasIndex === acc.previousLastCanvasIndex + 1
       ) {

--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -341,13 +341,14 @@ export function getTokenService(
 }
 
 type checkModalParams = {
+  role?: string;
   auth?: Auth;
   isAnyImageOpen?: boolean;
   authV2?: boolean;
 };
 
 export function checkModalRequired(params: checkModalParams): boolean {
-  const { auth, isAnyImageOpen, authV2 } = params;
+  const { role, auth, isAnyImageOpen, authV2 } = params;
   // If authV2 is true, We try to use the iiif auth V2 services and fallback to V1 in case the manifest doesn't contain V2
   const externalAccessService = authV2
     ? auth?.v2.externalAccessService || auth?.v1.externalAccessService
@@ -358,7 +359,11 @@ export function checkModalRequired(params: checkModalParams): boolean {
   if (activeAccessService) {
     return true;
   } else if (externalAccessService) {
-    return !isAnyImageOpen;
+    if (isAnyImageOpen || role === 'StaffWithRestricted') {
+      return false;
+    } else {
+      return true;
+    }
   } else {
     return false;
   }

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -91,7 +91,7 @@ const toggles = {
       title: 'IIIF Auth V2',
       initialValue: false,
       description:
-        'Will make use of the V2 auth services in the IIIF Presentation manifest, if they are available',
+        'Will make use of the V2 auth services in the IIIF Presentation manifest, if they are available. N.B. some V2 services contain invalid data, so it is not safe to turn this on for everyone until all manifests have been regenerated.',
       type: 'experimental',
     },
   ] as const,


### PR DESCRIPTION
For #11234

## What does this change?

At the moment if a iiif manifest contains only restricted items then the viewer will not display on the item page and a modal will show telling the user that the items are restricted.

<img width="1403" alt="Screenshot 2024-10-09 at 15 05 58" src="https://github.com/user-attachments/assets/68732c2e-7730-42e3-b79c-b6c6018c98a9">

This will stay the same for most users, but if the user is logged in and has a role of 'StaffWithRestricted' the viewer will display instead.

<img width="1401" alt="Screenshot 2024-10-09 at 15 09 50" src="https://github.com/user-attachments/assets/7fcbf305-469b-40b0-ae14-d34f1fd066a3">

The items themselves will still show as restricted, but this is another step towards making them available.

- Also, adds the accessToken to the ItemViewerContext and makes it available to the ItemRenderer (has no real effect yet, but will be important for [#5761](https://github.com/wellcomecollection/platform/issues/5761))
- Also, tidies up some TODOs that were in the files I was working with.

## How to test

Run the site locally using `yarn run-concurrently` 

Visit http://localhost:3000/works/jjdp9v65/items while logged out

Visits http://localhost:3000/works/jjdp9v65/items while logged in with a user that has a role of 'StaffWithRestricted' (or fake the role locally)

## How can we measure success?

Users with a role of 'StaffWithRestricted' will be presented with the viewer when visiting the item page for restricted items.

## Have we considered potential risks?

This should only change the behaviour for users with a role of 'StaffWithRestricted' so the impact is minimal.

