### PR TITLE
always use V2 version of iiif auth services for the external service

### DIFF
--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -351,16 +351,17 @@ export function getAuthServices({
   auth?: Auth;
   authV2?: boolean;
 }): AuthServices | undefined {
-  if (auth && authV2) {
+  if (authV2) {
     return {
-      active: auth.v2.activeAccessService,
-      external: auth.v2.externalAccessService,
+      active: auth?.v2.activeAccessService,
+      external: auth?.v2.externalAccessService,
     };
-  } else if (auth) {
+  } else {
     return {
-      active: auth.v1.activeAccessService,
+      active: auth?.v1.activeAccessService,
       // Only the v2 external service works (v1 responds with a 404), we therefore try returning the v2 service, so we can use it if it is available. We still need to fallback to the v1 service as the presence of the service helps us determine whether to show the viewer or not.
-      external: auth.v2.externalAccessService || auth.v1.externalAccessService,
+      external:
+        auth?.v2.externalAccessService || auth?.v1.externalAccessService,
     };
   }
 }

--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -378,7 +378,6 @@ export function checkModalRequired(params: checkModalParams): boolean {
   if (authServices?.active) {
     return true;
   } else if (authServices?.external) {
-    // TODO if we've got a v1 service then display a message to say the manifest needs regenerating
     if (isAnyImageOpen || role === 'StaffWithRestricted') {
       return false;
     } else {

--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -354,12 +354,13 @@ export function getAuthServices({
   if (auth && authV2) {
     return {
       active: auth.v2.activeAccessService,
-      external: auth.v2.externalAccessService, // Only the v2 external service works (v1 responds with a 404), so we only try returning the v2 service
+      external: auth.v2.externalAccessService,
     };
   } else if (auth) {
     return {
       active: auth.v1.activeAccessService,
-      external: auth.v2.externalAccessService, // Only the v2 external service works (v1 responds with a 404), so we try returning the v2 service regardless of the toggle value, so we can use it if it is available
+      // Only the v2 external service works (v1 responds with a 404), we therefore try returning the v2 service, so we can use it if it is available. We still need to fallback to the v1 service as the presence of the service helps us determine whether to show the viewer or not.
+      external: auth.v2.externalAccessService || auth.v1.externalAccessService,
     };
   }
 }
@@ -377,6 +378,7 @@ export function checkModalRequired(params: checkModalParams): boolean {
   if (authServices?.active) {
     return true;
   } else if (authServices?.external) {
+    // TODO if we've got a v1 service then display a message to say the manifest needs regenerating
     if (isAnyImageOpen || role === 'StaffWithRestricted') {
       return false;
     } else {
@@ -510,8 +512,7 @@ export function groupRanges(
       );
 
       if (
-        getDisplayLabel(acc.previousLabel) ===
-          getDisplayLabel(range.label) &&
+        getDisplayLabel(acc.previousLabel) === getDisplayLabel(range.label) &&
         acc.previousLastCanvasIndex &&
         firstCanvasIndex === acc.previousLastCanvasIndex + 1
       ) {


### PR DESCRIPTION
## What does this change?

Moves the getAuthService function so it can be shared and updates it to:
- return both the external and active services rather than just one. (We could get away with that until now, but we are going to have to use both now in order to make restricted things available to staff https://github.com/wellcomecollection/platform/issues/5761)
- ~only~ prefer to return v2 external services, as these are the only ones that work (v1 external service ids return a 404). We still need to fallback to the v1 service as the presence of the service helps us determine whether to show the viewer or not.

## How to test

No behaviour should change.

## How can we measure success?

Gets us closer to making restricted items available

## Have we considered potential risks?

No behaviour should change, so as long as e2e tests pass we should be good.

