### PR TITLE
handle exhibition-highlight-tours type in linkResolver

### DIFF
--- a/common/services/prismic/link-resolver.ts
+++ b/common/services/prismic/link-resolver.ts
@@ -23,7 +23,8 @@ function linkResolver(doc: Props | DataProps): string {
   if (
     type === 'exhibition-guides' ||
     type === 'exhibition-texts' ||
-    type === 'exhibition-highlight-tours'
+    type === 'exhibition-highlight-tours' ||
+    type === 'exhibition-guides-links'
   )
     return `/guides/exhibitions/${uid}`;
 

--- a/content/webapp/components/ExhibitionGuideLinksPromo/ExhibitionGuideLinksPromo.tsx
+++ b/content/webapp/components/ExhibitionGuideLinksPromo/ExhibitionGuideLinksPromo.tsx
@@ -34,19 +34,19 @@ const ExhibitionGuideLinksPromo: FunctionComponent<Props> = ({
   const links: { url: string; text: string }[] = [];
   if (exhibitionGuide.availableTypes.audioWithoutDescriptions) {
     links.push({
-      url: `${linkResolver(exhibitionGuide)}/audio-without-descriptions`,
+      url: `${linkResolver({ ...exhibitionGuide, uid: exhibitionGuide.exhibitionHighlightTourUid })}/audio-without-descriptions`,
       text: 'Listen to audio',
     });
   }
   if (exhibitionGuide.availableTypes.captionsOrTranscripts) {
     links.push({
-      url: `${linkResolver(exhibitionGuide)}/captions-and-transcripts`,
+      url: `${linkResolver({ ...exhibitionGuide, uid: exhibitionGuide.exhibitionTextUid })}/captions-and-transcripts`,
       text: 'Read captions and transcriptions',
     });
   }
   if (exhibitionGuide.availableTypes.BSLVideo) {
     links.push({
-      url: `${linkResolver(exhibitionGuide)}/bsl`,
+      url: `${linkResolver({ ...exhibitionGuide, uid: exhibitionGuide.exhibitionHighlightTourUid })}/bsl`,
       text: 'Watch British Sign Language videos',
     });
   }

--- a/content/webapp/pages/guides/exhibitions/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/index.tsx
@@ -72,8 +72,8 @@ export function allGuides({
         );
       return {
         ...guide,
-        exhibitionTextId: matchingExhibitionText?.id,
-        exhibitionHighlightTourId: matchingExhibitionHighlightTour?.id,
+        exhibitionTextUid: matchingExhibitionText?.uid,
+        exhibitionHighlightTourUid: matchingExhibitionHighlightTour?.uid,
         availableTypes: {
           BSLVideo:
             matchingExhibitionText?.availableTypes.BSLVideo ||

--- a/content/webapp/types/exhibition-guides.ts
+++ b/content/webapp/types/exhibition-guides.ts
@@ -58,8 +58,8 @@ export type ExhibitionGuideBasic = {
     | 'exhibition-guides-links'
     | 'exhibition-texts'
     | 'exhibition-highlight-tours';
-  exhibitionTextId?: string;
-  exhibitionHighlightTourId?: string;
+  exhibitionTextUid?: string;
+  exhibitionHighlightTourUid?: string;
   image?: ImageType;
   promo?: ImagePromo;
   relatedExhibition?: RelatedExhibition;


### PR DESCRIPTION
## What does this change?

Relates to #11190

Noticed that the links on the bottom of an Exhibition page weren't going to the correct place:

https://wellcomecollection.org/guides/exhibitions/hard-graft-exhibition-text

<img width="519" alt="Screenshot 2024-10-10 at 16 15 37" src="https://github.com/user-attachments/assets/f6cd0be7-e344-4a00-84bd-9407d861ded9">

This fixes that

## How to test

Visit https://wellcomecollection.org/guides/exhibitions/hard-graft-exhibition-text and click the links at the bottom of the page under the 'Other exhibition guides available' heading

## How can we measure success?

You can navigate to the expected destination by following the links

## Have we considered potential risks?

It's currently broken so this is an improvement

