### PR TITLE
Change Layout to ContainerLayout, create streamlined Layout component

### DIFF
--- a/cardigan/stories/components/PageHeader/PageHeader.stories.tsx
+++ b/cardigan/stories/components/PageHeader/PageHeader.stories.tsx
@@ -10,7 +10,10 @@ import { EmbedSlice as RawEmbedSlice } from '@weco/common/prismicio-types';
 import { headerBackgroundLs } from '@weco/common/utils/backgrounds';
 import { font } from '@weco/common/utils/classnames';
 import HeaderBackground from '@weco/common/views/components/HeaderBackground/HeaderBackground';
-import Layout, { gridSize8 } from '@weco/common/views/components/Layout';
+import {
+  ContaineredLayout,
+  gridSize8,
+} from '@weco/common/views/components/Layout';
 import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
 import PageHeaderReadme from '@weco/common/views/components/PageHeader/README.md';
 import ShortFilmPageHeaderReadme from '@weco/common/views/components/PageHeader/ShortFilm_README.md';
@@ -269,13 +272,13 @@ book.args = {
   breadcrumbs: { items: [{ text: 'Books', url: '#' }] },
   FeaturedMedia: (
     <Space $v={{ size: 'xl', properties: ['margin-top', 'padding-top'] }}>
-      <Layout gridSizes={gridSize8()}>
+      <ContaineredLayout gridSizes={gridSize8()}>
         <BookImage
           image={image(bookImageUrl, 1659, 1800)}
           sizes={{ xlarge: 1 / 3, large: 1 / 3, medium: 1 / 3, small: 1 }}
           quality="low"
         />
-      </Layout>
+      </ContaineredLayout>
     </Space>
   ),
 };

--- a/common/data/errors.tsx
+++ b/common/data/errors.tsx
@@ -1,6 +1,9 @@
 import { FunctionComponent } from 'react';
 
-import Layout, { gridSize8 } from '@weco/common/views/components/Layout';
+import {
+  ContaineredLayout,
+  gridSize8,
+} from '@weco/common/views/components/Layout';
 import Space from '@weco/common/views/components/styled/Space';
 
 import { prismicPageIds } from './hardcoded-ids';
@@ -11,7 +14,7 @@ export const errorMessages = {
 };
 
 export const DefaultErrorText: FunctionComponent = () => (
-  <Layout gridSizes={gridSize8()}>
+  <ContaineredLayout gridSizes={gridSize8()}>
     <Space
       className="body-text"
       $v={{ size: 'l', properties: ['margin-top', 'margin-bottom'] }}
@@ -38,11 +41,11 @@ export const DefaultErrorText: FunctionComponent = () => (
         <li>Try again a bit later</li>
       </ul>
     </Space>
-  </Layout>
+  </ContaineredLayout>
 );
 
 export const NotFoundErrorText: FunctionComponent = () => (
-  <Layout gridSizes={gridSize8()}>
+  <ContaineredLayout gridSizes={gridSize8()}>
     <Space
       className="body-text"
       $v={{ size: 'l', properties: ['margin-top', 'margin-bottom'] }}
@@ -83,11 +86,11 @@ export const NotFoundErrorText: FunctionComponent = () => (
         .
       </p>
     </Space>
-  </Layout>
+  </ContaineredLayout>
 );
 
 export const GoneErrorText: FunctionComponent = () => (
-  <Layout gridSizes={gridSize8()}>
+  <ContaineredLayout gridSizes={gridSize8()}>
     <Space
       className="body-text"
       $v={{ size: 'l', properties: ['margin-top', 'margin-bottom'] }}
@@ -102,5 +105,5 @@ export const GoneErrorText: FunctionComponent = () => (
         .
       </p>
     </Space>
-  </Layout>
+  </ContaineredLayout>
 );

--- a/common/views/components/ErrorPage/ErrorPage.tsx
+++ b/common/views/components/ErrorPage/ErrorPage.tsx
@@ -13,7 +13,10 @@ import { headerBackgroundLs } from '@weco/common/utils/backgrounds';
 import { dangerouslyGetEnabledToggles } from '@weco/common/utils/cookies';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
 import Icon from '@weco/common/views/components/Icon/Icon';
-import Layout, { gridSize8 } from '@weco/common/views/components/Layout';
+import {
+  ContaineredLayout,
+  gridSize8,
+} from '@weco/common/views/components/Layout';
 import PageHeader, {
   headerSpaceSize,
 } from '@weco/common/views/components/PageHeader/PageHeader';
@@ -87,7 +90,7 @@ const TogglesMessage: FunctionComponent = () => {
 
   return toggles.length > 0 ? (
     <Space $v={{ size: 'l', properties: ['margin-top'] }}>
-      <Layout gridSizes={gridSize8()}>
+      <ContaineredLayout gridSizes={gridSize8()}>
         <MessageBar>
           <Space $h={{ size: 's', properties: ['margin-right'] }}>
             <Icon icon={underConstruction} />
@@ -108,7 +111,7 @@ const TogglesMessage: FunctionComponent = () => {
             .
           </Space>
         </MessageBar>
-      </Layout>
+      </ContaineredLayout>
     </Space>
   ) : null;
 };
@@ -128,7 +131,7 @@ const SafariPreviewMessage: FunctionComponent = () => {
 
   return showPreviewSafariMessage ? (
     <Space $v={{ size: 'l', properties: ['margin-top'] }}>
-      <Layout gridSizes={gridSize8()}>
+      <ContaineredLayout gridSizes={gridSize8()}>
         <MessageBar>
           <Space $h={{ size: 's', properties: ['margin-right'] }}>
             <Icon icon={underConstruction} />
@@ -138,7 +141,7 @@ const SafariPreviewMessage: FunctionComponent = () => {
             browser, or enable cross-site cookies.
           </Space>
         </MessageBar>
-      </Layout>
+      </ContaineredLayout>
     </Space>
   ) : null;
 };

--- a/common/views/components/Layout/index.tsx
+++ b/common/views/components/Layout/index.tsx
@@ -3,7 +3,7 @@ import { FunctionComponent, PropsWithChildren } from 'react';
 import { grid, SizeMap } from '@weco/common/utils/classnames';
 import { Container } from '@weco/common/views/components/styled/Container';
 
-export const gridSize6 = () => ({
+const gridSize6 = () => ({
   s: 12,
   m: 6,
   shiftM: 1,
@@ -13,7 +13,7 @@ export const gridSize6 = () => ({
   shiftXl: 2,
 });
 
-export const gridSize8 = (shift = true) => ({
+const gridSize8 = (shift = true) => ({
   s: 12,
   m: 10,
   shiftM: shift ? 1 : 0,
@@ -23,7 +23,7 @@ export const gridSize8 = (shift = true) => ({
   shiftXL: shift ? 2 : 0,
 });
 
-export const gridSize10 = (isCentered = true) => ({
+const gridSize10 = (isCentered = true) => ({
   s: 12,
   m: 10,
   shiftM: isCentered ? 1 : 0,
@@ -33,17 +33,28 @@ export const gridSize10 = (isCentered = true) => ({
   shiftXl: isCentered ? 1 : 0,
 });
 
-export const gridSize12 = () => ({ s: 12, m: 12, l: 12, xl: 12 });
+const gridSize12 = () => ({ s: 12, m: 12, l: 12, xl: 12 });
 
 type Props = PropsWithChildren<{
   gridSizes: SizeMap;
 }>;
 
-const Layout: FunctionComponent<Props> = ({ gridSizes, children }) => (
+const ContaineredLayout: FunctionComponent<Props> = ({
+  gridSizes,
+  children,
+}) => (
   <Container>
     <div className="grid">
       <div className={grid(gridSizes)}>{children}</div>
     </div>
   </Container>
 );
+
+const Layout: FunctionComponent<Props> = ({ gridSizes, children }) => (
+  <div className="grid">
+    <div className={grid(gridSizes)}>{children}</div>
+  </div>
+);
+
+export { ContaineredLayout, gridSize12, gridSize10, gridSize8, gridSize6 };
 export default Layout;

--- a/common/views/components/NewsletterPromo/NewsletterPromo.tsx
+++ b/common/views/components/NewsletterPromo/NewsletterPromo.tsx
@@ -7,7 +7,10 @@ import { font } from '@weco/common/utils/classnames';
 import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
 import Button from '@weco/common/views/components/Buttons';
 import CheckboxRadio from '@weco/common/views/components/CheckboxRadio/CheckboxRadio';
-import Layout, { gridSize8 } from '@weco/common/views/components/Layout';
+import {
+  ContaineredLayout,
+  gridSize8,
+} from '@weco/common/views/components/Layout';
 import { Container } from '@weco/common/views/components/styled/Container';
 import Space from '@weco/common/views/components/styled/Space';
 import TextInput from '@weco/common/views/components/TextInput';
@@ -103,7 +106,7 @@ const NewsletterPromo: FunctionComponent = () => {
       $v={{ size: 'xl', properties: ['padding-top', 'padding-bottom'] }}
     >
       <Container>
-        <Layout gridSizes={gridSize8()}>
+        <ContaineredLayout gridSizes={gridSize8()}>
           <h2 className={font('wb', 3)} style={{ textAlign: 'center' }}>
             {isSuccess ? 'Thank you for signing up!' : 'Stay in the know'}
           </h2>
@@ -190,7 +193,7 @@ const NewsletterPromo: FunctionComponent = () => {
               <PrivacyNotice />
             </div>
           )}
-        </Layout>
+        </ContaineredLayout>
       </Container>
     </Space>
   );

--- a/common/views/components/PageHeader/PageHeader.tsx
+++ b/common/views/components/PageHeader/PageHeader.tsx
@@ -11,7 +11,8 @@ import Breadcrumb from '@weco/common/views/components/Breadcrumb/Breadcrumb';
 import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper/ConditionalWrapper';
 import HeaderBackground from '@weco/common/views/components/HeaderBackground/HeaderBackground';
 import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
-import Layout, {
+import {
+  ContaineredLayout,
   gridSize10,
   gridSize12,
 } from '@weco/common/views/components/Layout';
@@ -158,7 +159,7 @@ const PageHeader: FunctionComponent<Props> = ({
     <>
       <Container $backgroundTexture={backgroundTexture}>
         {Background}
-        <Layout
+        <ContaineredLayout
           gridSizes={
             sectionLevelPage ? gridSize12() : sectionLevelPageGridLayout
           }
@@ -209,12 +210,12 @@ const PageHeader: FunctionComponent<Props> = ({
               <LabelsList {...amendedLabels} />
             )}
           </Wrapper>
-        </Layout>
+        </ContaineredLayout>
 
         {FeaturedMedia && (
-          <Layout gridSizes={gridSize10()}>
+          <ContaineredLayout gridSizes={gridSize10()}>
             <div style={{ position: 'relative' }}>{FeaturedMedia}</div>
-          </Layout>
+          </ContaineredLayout>
         )}
 
         {HeroPicture && (
@@ -236,14 +237,14 @@ const PageHeader: FunctionComponent<Props> = ({
         !isSlim && <WobblyEdge backgroundColor="white" />}
 
       {!isContentTypeInfoBeforeMedia && ContentTypeInfo && (
-        <Layout gridSizes={sectionLevelPageGridLayout}>
+        <ContaineredLayout gridSizes={sectionLevelPageGridLayout}>
           <Space
             $v={{ size: 'l', properties: ['margin-top'] }}
             className={font('intb', 4)}
           >
             {ContentTypeInfo}
           </Space>
-        </Layout>
+        </ContaineredLayout>
       )}
     </>
   );

--- a/common/views/slices/CollectionVenue/index.tsx
+++ b/common/views/slices/CollectionVenue/index.tsx
@@ -2,7 +2,7 @@ import { SliceComponentProps } from '@prismicio/react';
 import { FunctionComponent } from 'react';
 
 import { CollectionVenueSlice as RawCollectionVenueSlice } from '@weco/common/prismicio-types';
-import Layout from '@weco/common/views/components/Layout';
+import ContaineredLayout from '@weco/common/views/components/Layout';
 import SpacingComponent from '@weco/common/views/components/styled/SpacingComponent';
 import {
   LayoutWidth,
@@ -33,7 +33,7 @@ const CollectionVenue: FunctionComponent<CollectionVenueProps> = ({
             <VenueClosedPeriods venue={transformedSlice.value.content} />
           </LayoutWidth>
         ) : (
-          <Layout
+          <ContaineredLayout
             gridSizes={
               transformedSlice.value.content.isFeatured
                 ? {
@@ -55,7 +55,7 @@ const CollectionVenue: FunctionComponent<CollectionVenueProps> = ({
             }
           >
             <VenueHours venue={transformedSlice.value.content} />
-          </Layout>
+          </ContaineredLayout>
         )}
       </SpacingComponent>
     );

--- a/common/views/slices/GifVideo/index.tsx
+++ b/common/views/slices/GifVideo/index.tsx
@@ -2,7 +2,10 @@ import { SliceComponentProps } from '@prismicio/react';
 import { FunctionComponent } from 'react';
 
 import { GifVideoSlice as RawGifVideoSlice } from '@weco/common/prismicio-types';
-import Layout, { gridSize10 } from '@weco/common/views/components/Layout';
+import {
+  ContaineredLayout,
+  gridSize10,
+} from '@weco/common/views/components/Layout';
 import SpacingComponent from '@weco/common/views/components/styled/SpacingComponent';
 import GifVideo from '@weco/content/components/GifVideo/GifVideo';
 import { transformGifVideoSlice } from '@weco/content/services/prismic/transformers/body';
@@ -14,9 +17,9 @@ const GifVideoSlice: FunctionComponent<GifVideoProps> = ({ slice }) => {
   if (transformedSlice) {
     return (
       <SpacingComponent $sliceType={transformedSlice.type}>
-        <Layout gridSizes={gridSize10()}>
+        <ContaineredLayout gridSizes={gridSize10()}>
           <GifVideo {...transformedSlice.value} />
-        </Layout>
+        </ContaineredLayout>
       </SpacingComponent>
     );
   } else {

--- a/common/views/slices/Iframe/index.tsx
+++ b/common/views/slices/Iframe/index.tsx
@@ -3,7 +3,10 @@ import { FunctionComponent } from 'react';
 
 import { IframeSlice as RawIframeSlice } from '@weco/common/prismicio-types';
 import Iframe from '@weco/common/views/components/Iframe/Iframe';
-import Layout, { gridSize10 } from '@weco/common/views/components/Layout';
+import {
+  ContaineredLayout,
+  gridSize10,
+} from '@weco/common/views/components/Layout';
 import SpacingComponent from '@weco/common/views/components/styled/SpacingComponent';
 import { transformIframeSlice } from '@weco/content/services/prismic/transformers/body';
 export type IframeProps = SliceComponentProps<RawIframeSlice>;
@@ -12,9 +15,9 @@ const IframeSlice: FunctionComponent<IframeProps> = ({ slice }) => {
   const transformedSlice = transformIframeSlice(slice);
   return (
     <SpacingComponent $sliceType={transformedSlice.type}>
-      <Layout gridSizes={gridSize10()}>
+      <ContaineredLayout gridSizes={gridSize10()}>
         <Iframe {...transformedSlice.value} />
-      </Layout>
+      </ContaineredLayout>
     </SpacingComponent>
   );
 };

--- a/common/views/slices/TextAndIcons/index.tsx
+++ b/common/views/slices/TextAndIcons/index.tsx
@@ -2,7 +2,10 @@ import { SliceComponentProps } from '@prismicio/react';
 import { FunctionComponent } from 'react';
 
 import { TextAndIconsSlice as RawTextAndIconsSlice } from '@weco/common/prismicio-types';
-import Layout, { gridSize8 } from '@weco/common/views/components/Layout';
+import {
+  ContaineredLayout,
+  gridSize8,
+} from '@weco/common/views/components/Layout';
 import SpacingComponent from '@weco/common/views/components/styled/SpacingComponent';
 import TextAndImageOrIcons from '@weco/content/components/TextAndImageOrIcons';
 import { transformTextAndIcons } from '@weco/content/services/prismic/transformers/body';
@@ -14,9 +17,9 @@ const TextAndIconsSlice: FunctionComponent<TextAndIconsProps> = ({ slice }) => {
 
   return (
     <SpacingComponent $sliceType={transformedSlice.type}>
-      <Layout gridSizes={gridSize8()}>
+      <ContaineredLayout gridSizes={gridSize8()}>
         <TextAndImageOrIcons item={transformedSlice.value} />
-      </Layout>
+      </ContaineredLayout>
     </SpacingComponent>
   );
 };

--- a/common/views/slices/TextAndImage/index.tsx
+++ b/common/views/slices/TextAndImage/index.tsx
@@ -2,7 +2,10 @@ import { SliceComponentProps } from '@prismicio/react';
 import { FunctionComponent } from 'react';
 
 import { TextAndImageSlice as RawTextAndImageSlice } from '@weco/common/prismicio-types';
-import Layout, { gridSize8 } from '@weco/common/views/components/Layout';
+import {
+  ContaineredLayout,
+  gridSize8,
+} from '@weco/common/views/components/Layout';
 import SpacingComponent from '@weco/common/views/components/styled/SpacingComponent';
 import TextAndImageOrIcons from '@weco/content/components/TextAndImageOrIcons';
 import { transformTextAndImage } from '@weco/content/services/prismic/transformers/body';
@@ -13,9 +16,9 @@ const TextAndImageSlice: FunctionComponent<TextAndImageProps> = ({ slice }) => {
   const transformedSlice = transformTextAndImage(slice);
   return (
     <SpacingComponent $sliceType={transformedSlice.type}>
-      <Layout gridSizes={gridSize8()}>
+      <ContaineredLayout gridSizes={gridSize8()}>
         <TextAndImageOrIcons item={transformedSlice.value} />
-      </Layout>
+      </ContaineredLayout>
     </SpacingComponent>
   );
 };

--- a/content/webapp/components/Body/Body.tsx
+++ b/content/webapp/components/Body/Body.tsx
@@ -10,7 +10,8 @@ import styled from 'styled-components';
 
 import { ContentListSlice as RawContentListSlice } from '@weco/common/prismicio-types';
 import { classNames, font } from '@weco/common/utils/classnames';
-import Layout, {
+import {
+  ContaineredLayout,
   gridSize10,
   gridSize12,
   gridSize8,
@@ -59,11 +60,23 @@ export const LayoutWidth: FunctionComponent<LayoutWidthProps> = ({
 }): ReactElement | null => {
   switch (true) {
     case width === 12:
-      return <Layout gridSizes={gridSize12()}>{children}</Layout>;
+      return (
+        <ContaineredLayout gridSizes={gridSize12()}>
+          {children}
+        </ContaineredLayout>
+      );
     case width === 10:
-      return <Layout gridSizes={gridSize10()}>{children}</Layout>;
+      return (
+        <ContaineredLayout gridSizes={gridSize10()}>
+          {children}
+        </ContaineredLayout>
+      );
     case width === 8:
-      return <Layout gridSizes={gridSize8()}>{children}</Layout>;
+      return (
+        <ContaineredLayout gridSizes={gridSize8()}>
+          {children}
+        </ContaineredLayout>
+      );
     default:
       return null;
   }
@@ -275,7 +288,9 @@ const Body: FunctionComponent<Props> = ({
               )}
               {featuredItem && (
                 <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
-                  <Layout gridSizes={gridSize12()}>{featuredItem}</Layout>
+                  <ContaineredLayout gridSizes={gridSize12()}>
+                    {featuredItem}
+                  </ContaineredLayout>
                 </Space>
               )}
               {cards.length > 0 && (
@@ -303,7 +318,7 @@ const Body: FunctionComponent<Props> = ({
       $splitBackground={isShortFilm}
     >
       {featuredTextFromUntransformedBody && (
-        <Layout gridSizes={gridSize8(!sectionLevelPage)}>
+        <ContaineredLayout gridSizes={gridSize8(!sectionLevelPage)}>
           <div className="body-text spaced-text">
             <Space
               $v={{
@@ -317,7 +332,7 @@ const Body: FunctionComponent<Props> = ({
               />
             </Space>
           </div>
-        </Layout>
+        </ContaineredLayout>
       )}
 
       {staticContent}

--- a/content/webapp/components/Body/CollectionsStaticContent.tsx
+++ b/content/webapp/components/Body/CollectionsStaticContent.tsx
@@ -1,16 +1,19 @@
 import { FunctionComponent } from 'react';
 
-import Layout, { gridSize12 } from '@weco/common/views/components/Layout';
+import {
+  ContaineredLayout,
+  gridSize12,
+} from '@weco/common/views/components/Layout';
 import SearchForm from '@weco/common/views/components/SearchForm/SearchForm';
 import SpacingSection from '@weco/common/views/components/styled/SpacingSection';
 
 const CollectionsStaticContent: FunctionComponent = () => {
   return (
-    <Layout gridSizes={gridSize12()}>
+    <ContaineredLayout gridSizes={gridSize12()}>
       <SpacingSection>
         <SearchForm searchCategory="works" location="page" />
       </SpacingSection>
-    </Layout>
+    </ContaineredLayout>
   );
 };
 

--- a/content/webapp/components/Body/VisitUsStaticContent.tsx
+++ b/content/webapp/components/Body/VisitUsStaticContent.tsx
@@ -5,7 +5,10 @@ import { usePrismicData } from '@weco/common/server-data/Context';
 import { transformCollectionVenues } from '@weco/common/services/prismic/transformers/collection-venues';
 import { font, grid } from '@weco/common/utils/classnames';
 import FindUs from '@weco/common/views/components/FindUs/FindUs';
-import Layout, { gridSize12 } from '@weco/common/views/components/Layout';
+import {
+  ContaineredLayout,
+  gridSize12,
+} from '@weco/common/views/components/Layout';
 import OpeningTimes from '@weco/common/views/components/OpeningTimes/OpeningTimes';
 import Space from '@weco/common/views/components/styled/Space';
 import SpacingComponent from '@weco/common/views/components/styled/SpacingComponent';
@@ -14,7 +17,7 @@ import SpacingSection from '@weco/common/views/components/styled/SpacingSection'
 const Container: FunctionComponent<PropsWithChildren> = ({ children }) => (
   <SpacingSection>
     <SpacingComponent>
-      <Layout gridSizes={gridSize12()}>{children}</Layout>
+      <ContaineredLayout gridSizes={gridSize12()}>{children}</ContaineredLayout>
     </SpacingComponent>
   </SpacingSection>
 );

--- a/content/webapp/components/CardGrid/CardGrid.tsx
+++ b/content/webapp/components/CardGrid/CardGrid.tsx
@@ -1,7 +1,10 @@
 import { FunctionComponent } from 'react';
 
 import { classNames, cssGrid } from '@weco/common/utils/classnames';
-import Layout, { gridSize12 } from '@weco/common/views/components/Layout';
+import {
+  ContaineredLayout,
+  gridSize12,
+} from '@weco/common/views/components/Layout';
 import CssGridContainer from '@weco/common/views/components/styled/CssGridContainer';
 import Space from '@weco/common/views/components/styled/Space';
 import BookPromo from '@weco/content/components/BookPromo/BookPromo';
@@ -88,7 +91,7 @@ const CardGrid: FunctionComponent<Props> = ({
         </div>
       </CssGridContainer>
       {links && links.length > 0 && (
-        <Layout gridSizes={gridSize12()}>
+        <ContaineredLayout gridSizes={gridSize12()}>
           <Space $v={{ size: 'l', properties: ['margin-top'] }}>
             {links.map(link => (
               <Space
@@ -99,7 +102,7 @@ const CardGrid: FunctionComponent<Props> = ({
               </Space>
             ))}
           </Space>
-        </Layout>
+        </ContaineredLayout>
       )}
     </div>
   );

--- a/content/webapp/components/ContentPage/ContentPage.tsx
+++ b/content/webapp/components/ContentPage/ContentPage.tsx
@@ -3,7 +3,8 @@ import styled from 'styled-components';
 
 import { sectionLevelPages } from '@weco/common/data/hardcoded-ids';
 import { ElementFromComponent } from '@weco/common/utils/utility-types';
-import Layout, {
+import {
+  ContaineredLayout,
   gridSize12,
   gridSize8,
 } from '@weco/common/views/components/Layout';
@@ -90,7 +91,9 @@ const ContentPage = ({
                 <>
                   {child && (
                     <SpacingComponent>
-                      <Layout gridSizes={gridSize8()}>{child}</Layout>
+                      <ContaineredLayout gridSizes={gridSize8()}>
+                        {child}
+                      </ContaineredLayout>
                     </SpacingComponent>
                   )}
                 </>
@@ -99,12 +102,12 @@ const ContentPage = ({
           )}
           {!hideContributors && contributors && contributors.length > 0 && (
             <SpacingSection>
-              <Layout gridSizes={gridSize8()}>
+              <ContaineredLayout gridSizes={gridSize8()}>
                 <Contributors
                   contributors={contributors}
                   titleOverride={contributorTitle}
                 />
-              </Layout>
+              </ContaineredLayout>
             </SpacingSection>
           )}
         </Wrapper>
@@ -120,9 +123,9 @@ const ContentPage = ({
         {seasons.length > 0 &&
           seasons.map(season => (
             <SpacingSection key={season.id}>
-              <Layout gridSizes={gridSize12()}>
+              <ContaineredLayout gridSizes={gridSize12()}>
                 <BannerCard item={season} />
-              </Layout>
+              </ContaineredLayout>
             </SpacingSection>
           ))}
       </Wrapper>

--- a/content/webapp/components/IIIFItem/IIIFItem.tsx
+++ b/content/webapp/components/IIIFItem/IIIFItem.tsx
@@ -7,7 +7,10 @@ import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
 import { unavailableContentMessage } from '@weco/common/data/microcopy';
-import Layout, { gridSize12 } from '@weco/common/views/components/Layout';
+import {
+  ContaineredLayout,
+  gridSize12,
+} from '@weco/common/views/components/Layout';
 import Space from '@weco/common/views/components/styled/Space';
 import AudioPlayer from '@weco/content/components/AudioPlayer/AudioPlayer';
 import BetaMessage from '@weco/content/components/BetaMessage/BetaMessage';
@@ -147,11 +150,11 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
       if (exclude.length === 0) {
         // If we have exclusions, we don't want to fall back to the BetaMessage
         return (
-          <Layout gridSizes={gridSize12()}>
+          <ContaineredLayout gridSizes={gridSize12()}>
             <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
               <BetaMessage message={unavailableContentMessage} />
             </Space>
-          </Layout>
+          </ContaineredLayout>
         );
       } else {
         return null;

--- a/content/webapp/components/ImageGallery/index.tsx
+++ b/content/webapp/components/ImageGallery/index.tsx
@@ -13,7 +13,8 @@ import { font } from '@weco/common/utils/classnames';
 import Button from '@weco/common/views/components/Buttons';
 import Control from '@weco/common/views/components/Control';
 import Icon from '@weco/common/views/components/Icon/Icon';
-import Layout, {
+import {
+  ContaineredLayout,
   gridSize10,
   gridSize12,
   gridSize8,
@@ -134,7 +135,7 @@ const ImageGallery: FunctionComponent<{ id: number } & Props> = ({
   return (
     <>
       {!isStandalone && !isFrames && (
-        <Layout gridSizes={gridSize8()}>
+        <ContaineredLayout gridSizes={gridSize8()}>
           <GalleryTitle>
             <Space as="span" $h={{ size: 's', properties: ['margin-right'] }}>
               <Icon icon={gallery} />
@@ -143,7 +144,7 @@ const ImageGallery: FunctionComponent<{ id: number } & Props> = ({
               {title || 'In pictures'}
             </h2>
           </GalleryTitle>
-        </Layout>
+        </ContaineredLayout>
       )}
       <Gallery
         id={`image-gallery-${id}`}
@@ -160,7 +161,7 @@ const ImageGallery: FunctionComponent<{ id: number } & Props> = ({
             background: `url(${repeatingLsBlack}) no-repeat top center`,
           }}
         />
-        <Layout gridSizes={getGridSize()}>
+        <ContaineredLayout gridSizes={getGridSize()}>
           {comicPreviousNext && <ComicPreviousNext {...comicPreviousNext} />}
           <Space
             $v={
@@ -266,7 +267,7 @@ const ImageGallery: FunctionComponent<{ id: number } & Props> = ({
               </ButtonContainer>
             )}
           </Space>
-        </Layout>
+        </ContaineredLayout>
       </Gallery>
     </>
   );

--- a/content/webapp/components/LayoutPaginatedResults/LayoutPaginatedResults.tsx
+++ b/content/webapp/components/LayoutPaginatedResults/LayoutPaginatedResults.tsx
@@ -5,7 +5,10 @@ import { headerBackgroundLs } from '@weco/common/utils/backgrounds';
 import { pluralize } from '@weco/common/utils/grammar';
 import Breadcrumb from '@weco/common/views/components/Breadcrumb/Breadcrumb';
 import Divider from '@weco/common/views/components/Divider/Divider';
-import Layout, { gridSize12 } from '@weco/common/views/components/Layout';
+import {
+  ContaineredLayout,
+  gridSize12,
+} from '@weco/common/views/components/Layout';
 import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
 import PaginationWrapper from '@weco/common/views/components/styled/PaginationWrapper';
@@ -69,7 +72,7 @@ const LayoutPaginatedResults: FunctionComponent<Props> = ({
     {children}
 
     {paginatedResults.totalPages > 1 && (
-      <Layout gridSizes={gridSize12()}>
+      <ContaineredLayout gridSizes={gridSize12()}>
         <PaginationWrapper $verticalSpacing="l">
           <span>{pluralize(paginatedResults.totalResults, 'result')}</span>
 
@@ -83,28 +86,28 @@ const LayoutPaginatedResults: FunctionComponent<Props> = ({
         <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
           <Divider />
         </Space>
-      </Layout>
+      </ContaineredLayout>
     )}
 
     <Space $v={{ size: 'l', properties: ['margin-top'] }}>
       {paginatedResults.results.length > 0 ? (
         <CardGrid items={paginatedResults.results} itemsPerRow={3} />
       ) : (
-        <Layout gridSizes={gridSize12()}>
+        <ContaineredLayout gridSizes={gridSize12()}>
           <p>There are no results.</p>
-        </Layout>
+        </ContaineredLayout>
       )}
     </Space>
 
     {paginatedResults.totalPages > 1 && (
-      <Layout gridSizes={gridSize12()}>
+      <ContaineredLayout gridSizes={gridSize12()}>
         <PaginationWrapper $verticalSpacing="l" $alignRight>
           <Pagination
             totalPages={paginatedResults.totalPages}
             ariaLabel="Results pagination"
           />
         </PaginationWrapper>
-      </Layout>
+      </ContaineredLayout>
     )}
   </>
 );

--- a/content/webapp/components/OtherExhibitionGuides/OtherExhibitionGuides.tsx
+++ b/content/webapp/components/OtherExhibitionGuides/OtherExhibitionGuides.tsx
@@ -2,7 +2,10 @@ import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
 import { font } from '@weco/common/utils/classnames';
-import Layout, { gridSize8 } from '@weco/common/views/components/Layout';
+import {
+  ContaineredLayout,
+  gridSize8,
+} from '@weco/common/views/components/Layout';
 import Space from '@weco/common/views/components/styled/Space';
 import CardGrid from '@weco/content/components/CardGrid/CardGrid';
 import { ExhibitionGuideBasic } from '@weco/content/types/exhibition-guides';
@@ -20,11 +23,11 @@ const OtherExhibitionGuides: FunctionComponent<Props> = ({
 }) => (
   <PromoContainer>
     <Space $v={{ size: 'xl', properties: ['padding-top', 'padding-bottom'] }}>
-      <Layout gridSizes={gridSize8(false)}>
+      <ContaineredLayout gridSizes={gridSize8(false)}>
         <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
           <h2 className={font('wb', 3)}>Other exhibition guides available</h2>
         </Space>
-      </Layout>
+      </ContaineredLayout>
       <CardGrid
         itemsHaveTransparentBackground={true}
         items={otherExhibitionGuides.map(result => ({

--- a/content/webapp/components/SeasonsHeader/index.tsx
+++ b/content/webapp/components/SeasonsHeader/index.tsx
@@ -4,7 +4,8 @@ import styled from 'styled-components';
 import { getCrop } from '@weco/common/model/image';
 import { font } from '@weco/common/utils/classnames';
 import LabelsList from '@weco/common/views/components/LabelsList/LabelsList';
-import Layout, {
+import {
+  ContaineredLayout,
   gridSize10,
   gridSize12,
 } from '@weco/common/views/components/Layout';
@@ -32,7 +33,7 @@ const SeasonsHeader: FunctionComponent<Props> = ({ season }) => {
   const superWidescreenImage = getCrop(season.image, '32:15');
 
   return (
-    <Layout gridSizes={gridSize12()}>
+    <ContaineredLayout gridSizes={gridSize12()}>
       <HeaderWrapper>
         <WobblyBottom backgroundColor="white">
           {superWidescreenImage && (
@@ -47,7 +48,7 @@ const SeasonsHeader: FunctionComponent<Props> = ({ season }) => {
           <Space
             $v={{ size: 'l', properties: ['padding-top', 'padding-bottom'] }}
           >
-            <Layout gridSizes={gridSize10()}>
+            <ContaineredLayout gridSizes={gridSize10()}>
               <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
                 <TextWrapper>
                   <Space $h={{ size: 'm', properties: ['padding-left'] }}>
@@ -84,11 +85,11 @@ const SeasonsHeader: FunctionComponent<Props> = ({ season }) => {
                   </Space>
                 </TextWrapper>
               </Space>
-            </Layout>
+            </ContaineredLayout>
           </Space>
         </WobblyBottom>
       </HeaderWrapper>
-    </Layout>
+    </ContaineredLayout>
   );
 };
 

--- a/content/webapp/components/SectionHeader/SectionHeader.tsx
+++ b/content/webapp/components/SectionHeader/SectionHeader.tsx
@@ -3,7 +3,10 @@ import styled from 'styled-components';
 
 import { font, SizeMap } from '@weco/common/utils/classnames';
 import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper/ConditionalWrapper';
-import Layout, { gridSize12 } from '@weco/common/views/components/Layout';
+import {
+  ContaineredLayout,
+  gridSize12,
+} from '@weco/common/views/components/Layout';
 import Space from '@weco/common/views/components/styled/Space';
 
 const YellowBox = styled.div`
@@ -45,7 +48,9 @@ const SectionHeader: FunctionComponent<Props> = ({ title, gridSize }) => {
       <ConditionalWrapper
         condition={!!gridSize}
         wrapper={children => (
-          <Layout gridSizes={gridSize || gridSize12()}>{children}</Layout>
+          <ContaineredLayout gridSizes={gridSize || gridSize12()}>
+            {children}
+          </ContaineredLayout>
         )}
       >
         <YellowBox />

--- a/content/webapp/components/SeriesNavigation/SeriesNavigation.tsx
+++ b/content/webapp/components/SeriesNavigation/SeriesNavigation.tsx
@@ -1,6 +1,9 @@
 import { FunctionComponent } from 'react';
 
-import Layout, { gridSize8 } from '@weco/common/views/components/Layout';
+import {
+  ContaineredLayout,
+  gridSize8,
+} from '@weco/common/views/components/Layout';
 import Space from '@weco/common/views/components/styled/Space';
 import SpacingComponent from '@weco/common/views/components/styled/SpacingComponent';
 import MoreLink from '@weco/content/components/MoreLink/MoreLink';
@@ -25,7 +28,7 @@ const SeriesNavigation: FunctionComponent<Props> = ({
     : `Read more from ${series.title}`;
   return items.length > 0 ? (
     <SpacingComponent>
-      <Layout gridSizes={gridSize8()}>
+      <ContaineredLayout gridSizes={gridSize8()}>
         <SearchResults
           key={series.id}
           title={title}
@@ -44,7 +47,7 @@ const SeriesNavigation: FunctionComponent<Props> = ({
             }}
           />
         </Space>
-      </Layout>
+      </ContaineredLayout>
     </SpacingComponent>
   ) : null;
 };

--- a/content/webapp/components/SimpleCardGrid/SimpleCardGrid.tsx
+++ b/content/webapp/components/SimpleCardGrid/SimpleCardGrid.tsx
@@ -2,7 +2,10 @@ import { FunctionComponent } from 'react';
 
 import { getCrop } from '@weco/common/model/image';
 import { cssGrid, font } from '@weco/common/utils/classnames';
-import Layout, { gridSize12 } from '@weco/common/views/components/Layout';
+import {
+  ContaineredLayout,
+  gridSize12,
+} from '@weco/common/views/components/Layout';
 import CssGridContainer from '@weco/common/views/components/styled/CssGridContainer';
 import Space from '@weco/common/views/components/styled/Space';
 import Card from '@weco/content/components/Card/Card';
@@ -22,7 +25,7 @@ const CardGridFeaturedCard = ({ item }: CardGridFeaturedCardProps) => {
   const image = getCrop(item.image, '16:9');
 
   return (
-    <Layout gridSizes={gridSize12()}>
+    <ContaineredLayout gridSizes={gridSize12()}>
       <FeaturedCard
         image={
           image && {
@@ -60,7 +63,7 @@ const CardGridFeaturedCard = ({ item }: CardGridFeaturedCardProps) => {
           <p className={font('intr', 5)}>{item.description}</p>
         )}
       </FeaturedCard>
-    </Layout>
+    </ContaineredLayout>
   );
 };
 

--- a/content/webapp/components/WorkDetails/index.tsx
+++ b/content/webapp/components/WorkDetails/index.tsx
@@ -5,7 +5,10 @@ import { DigitalLocation } from '@weco/common/model/catalogue';
 import { font } from '@weco/common/utils/classnames';
 import { formatDuration } from '@weco/common/utils/format-date';
 import Button from '@weco/common/views/components/Buttons';
-import Layout, { gridSize10 } from '@weco/common/views/components/Layout';
+import {
+  ContaineredLayout,
+  gridSize10,
+} from '@weco/common/views/components/Layout';
 import Space from '@weco/common/views/components/styled/Space';
 import { useUser } from '@weco/common/views/components/UserProvider/UserProvider';
 import { themeValues } from '@weco/common/views/themes/config';
@@ -476,7 +479,9 @@ const WorkDetails: FunctionComponent<Props> = ({
       {renderContent()}
     </Space>
   ) : (
-    <Layout gridSizes={gridSize10()}>{renderContent()}</Layout>
+    <ContaineredLayout gridSizes={gridSize10()}>
+      {renderContent()}
+    </ContaineredLayout>
   );
 };
 

--- a/content/webapp/pages/books/[bookId].tsx
+++ b/content/webapp/pages/books/[bookId].tsx
@@ -14,7 +14,10 @@ import { isNotUndefined } from '@weco/common/utils/type-guards';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 import Button from '@weco/common/views/components/Buttons';
 import { HTMLDate } from '@weco/common/views/components/HTMLDateAndTime';
-import Layout, { gridSize8 } from '@weco/common/views/components/Layout';
+import {
+  ContaineredLayout,
+  gridSize8,
+} from '@weco/common/views/components/Layout';
 import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import Space from '@weco/common/views/components/styled/Space';
@@ -124,13 +127,13 @@ const BookPage: FunctionComponent<Props> = props => {
   const { book } = props;
   const FeaturedMedia = book.cover && (
     <Space $v={{ size: 'xl', properties: ['margin-top', 'padding-top'] }}>
-      <Layout gridSizes={gridSize8()}>
+      <ContaineredLayout gridSizes={gridSize8()}>
         <BookImage
           image={{ ...book.cover }}
           sizes={{ xlarge: 1 / 3, large: 1 / 3, medium: 1 / 3, small: 1 }}
           quality="low"
         />
-      </Layout>
+      </ContaineredLayout>
     </Space>
   );
   const breadcrumbs = {

--- a/content/webapp/pages/cookie-policy.tsx
+++ b/content/webapp/pages/cookie-policy.tsx
@@ -8,7 +8,10 @@ import { AppErrorProps } from '@weco/common/services/app';
 import { landingHeaderBackgroundLs } from '@weco/common/utils/backgrounds';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
 import { policyUpdatedDate } from '@weco/common/views/components/CivicUK';
-import Layout, { gridSize8 } from '@weco/common/views/components/Layout';
+import {
+  ContaineredLayout,
+  gridSize8,
+} from '@weco/common/views/components/Layout';
 import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import Space from '@weco/common/views/components/styled/Space';
@@ -22,9 +25,9 @@ import * as page from './pages/[pageId]';
 const CookieTable = ({ rows }: { rows: string[][] }) => {
   return (
     <SpacingComponent>
-      <Layout gridSizes={gridSize8()}>
+      <ContaineredLayout gridSizes={gridSize8()}>
         <Table rows={rows} withBorder={true} hasSmallerCopy></Table>
-      </Layout>
+      </ContaineredLayout>
     </SpacingComponent>
   );
 };
@@ -76,13 +79,13 @@ const CookiePolicy: FunctionComponent<page.Props> = (props: page.Props) => {
           })}
 
           <SpacingComponent>
-            <Layout gridSizes={gridSize8()}>
+            <ContaineredLayout gridSizes={gridSize8()}>
               <div className="body-text spaced-text">
                 <p>
                   <em>This policy was last updated on {policyUpdatedDate}.</em>
                 </p>
               </div>
-            </Layout>
+            </ContaineredLayout>
           </SpacingComponent>
         </Space>
       </Space>

--- a/content/webapp/pages/events/index.tsx
+++ b/content/webapp/pages/events/index.tsx
@@ -8,7 +8,10 @@ import { PaginatedResults } from '@weco/common/services/prismic/types';
 import { Period } from '@weco/common/types/periods';
 import { serialiseProps } from '@weco/common/utils/json';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
-import Layout, { gridSize12 } from '@weco/common/views/components/Layout';
+import {
+  ContaineredLayout,
+  gridSize12,
+} from '@weco/common/views/components/Layout';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import Space from '@weco/common/views/components/styled/Space';
 import SpacingSection from '@weco/common/views/components/styled/SpacingSection';
@@ -112,11 +115,11 @@ const EventsPage: FunctionComponent<Props> = props => {
           paginatedResults={convertedPaginatedResults}
         />
         {period === 'current-and-coming-up' && (
-          <Layout gridSizes={gridSize12()}>
+          <ContaineredLayout gridSizes={gridSize12()}>
             <Space $v={{ size: 'm', properties: ['margin-top'] }}>
               <MoreLink url="/events/past" name="View past events" />
             </Space>
-          </Layout>
+          </ContaineredLayout>
         )}
       </SpacingSection>
     </PageLayout>

--- a/content/webapp/pages/exhibitions/index.tsx
+++ b/content/webapp/pages/exhibitions/index.tsx
@@ -14,7 +14,10 @@ import { isFuture } from '@weco/common/utils/dates';
 import { serialiseProps } from '@weco/common/utils/json';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
-import Layout, { gridSize12 } from '@weco/common/views/components/Layout';
+import {
+  ContaineredLayout,
+  gridSize12,
+} from '@weco/common/views/components/Layout';
 import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
@@ -154,11 +157,11 @@ const ExhibitionsPage: FunctionComponent<ExhibitionsProps> = props => {
           {!period && (
             <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
               <SectionHeader title="Past Exhibitions" gridSize={gridSize12()} />
-              <Layout gridSizes={gridSize12()}>
+              <ContaineredLayout gridSizes={gridSize12()}>
                 <Space $v={{ size: 'm', properties: ['margin-top'] }}>
                   <p style={{ marginBottom: 0 }}>{pastExhibitionsStrapline}</p>
                 </Space>
-              </Layout>
+              </ContaineredLayout>
             </Space>
           )}
           <SpacingSection>

--- a/content/webapp/pages/guides/exhibitions/[id]/[type]/[stop]/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/[type]/[stop]/index.tsx
@@ -18,7 +18,10 @@ import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 import CollapsibleContent from '@weco/common/views/components/CollapsibleContent';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
-import Layout, { gridSize8 } from '@weco/common/views/components/Layout';
+import {
+  ContaineredLayout,
+  gridSize8,
+} from '@weco/common/views/components/Layout';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
 import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImage';
@@ -351,7 +354,7 @@ const ExhibitionGuidePage: FunctionComponent<Props> = props => {
             </div>
           </FlushContainer>
 
-          <Layout gridSizes={gridSize8()}>
+          <ContaineredLayout gridSizes={gridSize8()}>
             <StickyPlayer $sticky={type !== 'bsl'}>
               {type === 'bsl' ? (
                 <>
@@ -389,7 +392,7 @@ const ExhibitionGuidePage: FunctionComponent<Props> = props => {
                 </Space>
               </Space>
             )}
-          </Layout>
+          </ContaineredLayout>
         </div>
         {/* PrevNext needs a view-transition-name even though it isn't transitioning: https://www.nicchan.me/blog/view-transitions-and-stacking-context/#the-workaround */}
         <PrevNext style={{ viewTransitionName: 'prevnext' }}>

--- a/content/webapp/pages/guides/exhibitions/[id]/[type]/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/[type]/index.tsx
@@ -20,7 +20,8 @@ import { isNotUndefined } from '@weco/common/utils/type-guards';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 import { exhibitionGuidesLinks } from '@weco/common/views/components/Header/Header';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
-import Layout, {
+import {
+  ContaineredLayout,
   gridSize10,
   gridSize8,
 } from '@weco/common/views/components/Layout';
@@ -259,7 +260,7 @@ const ExhibitionGuidePage: FunctionComponent<Props> = props => {
         isSlim
       />
 
-      <Layout gridSizes={gridSize8(false)}>
+      <ContaineredLayout gridSizes={gridSize8(false)}>
         <h2 className={font('intsb', 4)}>{getTypeTitle(type)}</h2>
 
         {exhibitionGuide.introText?.length > 0 ? (
@@ -271,10 +272,10 @@ const ExhibitionGuidePage: FunctionComponent<Props> = props => {
         )}
 
         <RelevantGuideIcons types={[type]} />
-      </Layout>
+      </ContaineredLayout>
 
       <Space $v={{ size: 'l', properties: ['margin-top'] }}>
-        <Layout gridSizes={gridSize10(false)}>
+        <ContaineredLayout gridSizes={gridSize10(false)}>
           {userPreferenceSet && (
             <p>
               You selected this type of guide previously, but you can also
@@ -289,7 +290,7 @@ const ExhibitionGuidePage: FunctionComponent<Props> = props => {
               </a>
             </p>
           )}
-        </Layout>
+        </ContaineredLayout>
       </Space>
 
       {/* For deprecated ExhibitionGuides */}

--- a/content/webapp/pages/guides/exhibitions/[id]/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/index.tsx
@@ -15,7 +15,10 @@ import { isNotUndefined } from '@weco/common/utils/type-guards';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 import { exhibitionGuidesLinks } from '@weco/common/views/components/Header/Header';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
-import Layout, { gridSize10 } from '@weco/common/views/components/Layout';
+import {
+  ContaineredLayout,
+  gridSize10,
+} from '@weco/common/views/components/Layout';
 import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import Space from '@weco/common/views/components/styled/Space';
@@ -357,7 +360,7 @@ const ExhibitionGuidePage: FunctionComponent<Props> = ({
         }}
         isSlim
       />
-      <Layout gridSizes={gridSize10(false)}>
+      <ContaineredLayout gridSizes={gridSize10(false)}>
         <SpacingSection>
           <Space $v={{ size: 'l', properties: ['margin-top'] }}>
             {/* Links to ExhibitionTexts and ExhibitionHighlightTours */}
@@ -379,7 +382,7 @@ const ExhibitionGuidePage: FunctionComponent<Props> = ({
             )}
           </Space>
         </SpacingSection>
-      </Layout>
+      </ContaineredLayout>
       {otherExhibitionGuides?.length > 0 && (
         <OtherExhibitionGuides otherExhibitionGuides={otherExhibitionGuides} />
       )}

--- a/content/webapp/pages/index.tsx
+++ b/content/webapp/pages/index.tsx
@@ -18,7 +18,8 @@ import { serialiseProps } from '@weco/common/utils/json';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
-import Layout, {
+import {
+  ContaineredLayout,
   gridSize10,
   gridSize12,
 } from '@weco/common/views/components/Layout';
@@ -213,7 +214,7 @@ const Homepage: FunctionComponent<Props> = ({
         image={pageImage}
         apiToolbarLinks={[createPrismicLink(homepageId)]}
       >
-        <Layout gridSizes={gridSize10(false)}>
+        <ContaineredLayout gridSizes={gridSize10(false)}>
           <SpacingSection>
             <Space
               $v={{ size: 'l', properties: ['margin-top'] }}
@@ -235,7 +236,7 @@ const Homepage: FunctionComponent<Props> = ({
               </CreamBox>
             )}
           </SpacingSection>
-        </Layout>
+        </ContaineredLayout>
         {transformedHeaderList && (
           <SpacingSection>
             {transformedHeaderList.value.title && (

--- a/content/webapp/pages/newsletter.tsx
+++ b/content/webapp/pages/newsletter.tsx
@@ -6,7 +6,10 @@ import { getServerData } from '@weco/common/server-data';
 import { AppErrorProps } from '@weco/common/services/app';
 import { landingHeaderBackgroundLs } from '@weco/common/utils/backgrounds';
 import { serialiseProps } from '@weco/common/utils/json';
-import Layout, { gridSize8 } from '@weco/common/views/components/Layout';
+import {
+  ContaineredLayout,
+  gridSize8,
+} from '@weco/common/views/components/Layout';
 import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import Space from '@weco/common/views/components/styled/Space';
@@ -59,13 +62,13 @@ const Newsletter: FunctionComponent<Props> = ({ result }) => {
 
       <Space $v={{ size: 'xl', properties: ['margin-top'] }}>
         <Space $v={{ size: 'xl', properties: ['padding-bottom'] }}>
-          <Layout gridSizes={gridSize8()}>
+          <ContaineredLayout gridSizes={gridSize8()}>
             <NewsletterSignup
               isSuccess={result === 'success'}
               isError={result === 'error'}
               isConfirmed={result === 'confirmed'}
             />
-          </Layout>
+          </ContaineredLayout>
         </Space>
       </Space>
     </PageLayout>

--- a/content/webapp/pages/stories/index.tsx
+++ b/content/webapp/pages/stories/index.tsx
@@ -10,7 +10,8 @@ import { AppErrorProps } from '@weco/common/services/app';
 import { serialiseProps } from '@weco/common/utils/json';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
-import Layout, {
+import {
+  ContaineredLayout,
   gridSize12,
   gridSize8,
 } from '@weco/common/views/components/Layout';
@@ -185,7 +186,7 @@ const StoriesPage: FunctionComponent<Props> = ({
         sectionLevelPage={true}
       />
       {introText && (
-        <Layout gridSizes={gridSize8(false)}>
+        <ContaineredLayout gridSizes={gridSize8(false)}>
           <div className="body-text spaced-text">
             <Space $v={{ size: 'xl', properties: ['margin-bottom'] }}>
               <FeaturedText
@@ -194,19 +195,19 @@ const StoriesPage: FunctionComponent<Props> = ({
               />
             </Space>
           </div>
-        </Layout>
+        </ContaineredLayout>
       )}
 
       <SpacingSection>
         <ArticlesContainer className="row--has-wobbly-background">
           <Space $v={{ size: 'xl', properties: ['margin-bottom'] }}>
-            <Layout gridSizes={gridSize12()}>
+            <ContaineredLayout gridSizes={gridSize12()}>
               <FeaturedCardArticle
                 article={firstArticle}
                 background="neutral.700"
                 textColor="white"
               />
-            </Layout>
+            </ContaineredLayout>
           </Space>
           <div className="row__wobbly-background" />
           <StoryPromoContainer>
@@ -238,9 +239,9 @@ const StoriesPage: FunctionComponent<Props> = ({
         )}
         {storiesLanding.storiesDescription && (
           <SpacingComponent>
-            <Layout gridSizes={gridSize12()}>
+            <ContaineredLayout gridSizes={gridSize12()}>
               <PrismicHtmlBlock html={storiesLanding.storiesDescription} />
-            </Layout>
+            </ContaineredLayout>
           </SpacingComponent>
         )}
         <SpacingComponent>
@@ -258,9 +259,9 @@ const StoriesPage: FunctionComponent<Props> = ({
         </SpacingComponent>
 
         <SpacingComponent>
-          <Layout gridSizes={gridSize12()}>
+          <ContaineredLayout gridSizes={gridSize12()}>
             <p>{pageDescriptions.comic}</p>
-          </Layout>
+          </ContaineredLayout>
         </SpacingComponent>
 
         <SpacingComponent>
@@ -284,9 +285,9 @@ const StoriesPage: FunctionComponent<Props> = ({
         )}
         {storiesLanding.booksDescription && (
           <SpacingComponent>
-            <Layout gridSizes={gridSize12()}>
+            <ContaineredLayout gridSizes={gridSize12()}>
               <PrismicHtmlBlock html={storiesLanding.booksDescription} />
-            </Layout>
+            </ContaineredLayout>
           </SpacingComponent>
         )}
         <SpacingComponent>

--- a/content/webapp/pages/visual-stories/[visualStoryId].tsx
+++ b/content/webapp/pages/visual-stories/[visualStoryId].tsx
@@ -17,7 +17,10 @@ import { serialiseProps } from '@weco/common/utils/json';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
 import Divider from '@weco/common/views/components/Divider/Divider';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
-import Layout, { gridSize12 } from '@weco/common/views/components/Layout';
+import {
+  ContaineredLayout,
+  gridSize12,
+} from '@weco/common/views/components/Layout';
 import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import Space from '@weco/common/views/components/styled/Space';
@@ -273,7 +276,7 @@ const VisualStory: FunctionComponent<Props> = ({
       />
       {visualStories.length > 0 && (
         <Space $v={{ size: 'xl', properties: ['margin-top', 'margin-bottom'] }}>
-          <Layout gridSizes={gridSize12()}>
+          <ContaineredLayout gridSizes={gridSize12()}>
             <Divider lineColor="neutral.400" />
             <Space
               $v={{
@@ -285,7 +288,7 @@ const VisualStory: FunctionComponent<Props> = ({
                 More Visual Stories
               </h2>
             </Space>
-          </Layout>
+          </ContaineredLayout>
           <CardGrid items={visualStories} itemsPerRow={3} />
         </Space>
       )}

--- a/content/webapp/pages/whats-on/index.tsx
+++ b/content/webapp/pages/whats-on/index.tsx
@@ -35,7 +35,10 @@ import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 import { HTMLDate } from '@weco/common/views/components/HTMLDateAndTime';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
-import Layout, { gridSize12 } from '@weco/common/views/components/Layout';
+import {
+  ContaineredLayout,
+  gridSize12,
+} from '@weco/common/views/components/Layout';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import { Container } from '@weco/common/views/components/styled/Container';
 import CssGridContainer from '@weco/common/views/components/styled/CssGridContainer';
@@ -442,13 +445,13 @@ const WhatsOnPage: FunctionComponent<Props> = props => {
           todaysOpeningHours={todaysOpeningHours}
           featuredText={featuredText}
         />
-        <Layout gridSizes={gridSize12()}>
+        <ContaineredLayout gridSizes={gridSize12()}>
           <DateRange dateRange={dateRange} period={period} />
 
           {period === 'today' && todaysOpeningHours?.isClosed && (
             <ClosedMessage />
           )}
-        </Layout>
+        </ContaineredLayout>
         <Space $v={{ size: 'm', properties: ['margin-top'] }}>
           {period === 'current-and-coming-up' && (
             <>
@@ -463,17 +466,17 @@ const WhatsOnPage: FunctionComponent<Props> = props => {
                   <SpacingComponent>
                     <Space $v={{ size: 'xl', properties: ['margin-bottom'] }}>
                       {firstExhibition ? (
-                        <Layout gridSizes={gridSize12()}>
+                        <ContaineredLayout gridSizes={gridSize12()}>
                           <FeaturedCardExhibition
                             exhibition={firstExhibition}
                             background="warmNeutral.300"
                             textColor="black"
                           />
-                        </Layout>
+                        </ContaineredLayout>
                       ) : (
-                        <Layout gridSizes={gridSize12()}>
+                        <ContaineredLayout gridSizes={gridSize12()}>
                           <p>There are no current exhibitions</p>
-                        </Layout>
+                        </ContaineredLayout>
                       )}
                     </Space>
                   </SpacingComponent>
@@ -500,9 +503,9 @@ const WhatsOnPage: FunctionComponent<Props> = props => {
                         links={[{ text: 'View all events', url: '/events' }]}
                       />
                     ) : (
-                      <Layout gridSizes={gridSize12()}>
+                      <ContaineredLayout gridSizes={gridSize12()}>
                         <p>There are no upcoming events</p>
-                      </Layout>
+                      </ContaineredLayout>
                     )}
                   </SpacingComponent>
                 </SpacingSection>
@@ -524,9 +527,9 @@ const WhatsOnPage: FunctionComponent<Props> = props => {
                         ]}
                       />
                     ) : (
-                      <Layout gridSizes={gridSize12()}>
+                      <ContaineredLayout gridSizes={gridSize12()}>
                         <p>There are no upcoming catch up events</p>
-                      </Layout>
+                      </ContaineredLayout>
                     )}
                   </SpacingComponent>
                 </SpacingSection>
@@ -542,7 +545,7 @@ const WhatsOnPage: FunctionComponent<Props> = props => {
                     properties: ['padding-top', 'margin-bottom'],
                   }}
                 >
-                  <Layout gridSizes={gridSize12()}>
+                  <ContaineredLayout gridSizes={gridSize12()}>
                     <div
                       style={{
                         display: 'flex',
@@ -553,7 +556,7 @@ const WhatsOnPage: FunctionComponent<Props> = props => {
                       <h2 className={font('wb', 2)}>Exhibitions and Events</h2>
                       <span className={font('intb', 4)}>Free admission</span>
                     </div>
-                  </Layout>
+                  </ContaineredLayout>
                 </Space>
                 <ExhibitionsAndEvents
                   exhibitions={exhibitionsToShow}

--- a/content/webapp/pages/works/[workId]/download.tsx
+++ b/content/webapp/pages/works/[workId]/download.tsx
@@ -10,7 +10,10 @@ import {
   getCatalogueLicenseData,
   LicenseData,
 } from '@weco/common/utils/licenses';
-import Layout, { gridSize8 } from '@weco/common/views/components/Layout';
+import {
+  ContaineredLayout,
+  gridSize8,
+} from '@weco/common/views/components/Layout';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import Space from '@weco/common/views/components/styled/Space';
 import SpacingComponent from '@weco/common/views/components/styled/SpacingComponent';
@@ -126,7 +129,7 @@ const DownloadPage: NextPage<Props> = ({ transformedManifest, work }) => {
       siteSection="collections"
       hideNewsletterPromo={true}
     >
-      <Layout gridSizes={gridSize8()}>
+      <ContaineredLayout gridSizes={gridSize8()}>
         <SpacingSection>
           <SpacingComponent>
             <Space
@@ -174,7 +177,7 @@ const DownloadPage: NextPage<Props> = ({ transformedManifest, work }) => {
             </SpacingComponent>
           )}
         </SpacingSection>
-      </Layout>
+      </ContaineredLayout>
     </PageLayout>
   );
 };

--- a/content/webapp/pages/works/[workId]/images.tsx
+++ b/content/webapp/pages/works/[workId]/images.tsx
@@ -12,7 +12,10 @@ import {
   ApiToolbarLink,
   setTzitzitParams,
 } from '@weco/common/views/components/ApiToolbar';
-import Layout, { gridSize12 } from '@weco/common/views/components/Layout';
+import {
+  ContaineredLayout,
+  gridSize12,
+} from '@weco/common/views/components/Layout';
 import Space from '@weco/common/views/components/styled/Space';
 import BetaMessage from '@weco/content/components/BetaMessage/BetaMessage';
 import CataloguePageLayout from '@weco/content/components/CataloguePageLayout/CataloguePageLayout';
@@ -84,13 +87,13 @@ const ImagePage: FunctionComponent<Props> = ({
           setSearchResults={() => null}
         />
       ) : (
-        <Layout gridSizes={gridSize12()}>
+        <ContaineredLayout gridSizes={gridSize12()}>
           <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
             <div style={{ marginTop: '98px' }}>
               <BetaMessage message={unavailableContentMessage} />
             </div>
           </Space>
-        </Layout>
+        </ContaineredLayout>
       )}
     </CataloguePageLayout>
   );

--- a/content/webapp/pages/works/[workId]/items.tsx
+++ b/content/webapp/pages/works/[workId]/items.tsx
@@ -19,7 +19,10 @@ import {
   setTzitzitParams,
 } from '@weco/common/views/components/ApiToolbar';
 import Button from '@weco/common/views/components/Buttons';
-import Layout, { gridSize12 } from '@weco/common/views/components/Layout';
+import {
+  ContaineredLayout,
+  gridSize12,
+} from '@weco/common/views/components/Layout';
 import Modal from '@weco/common/views/components/Modal/Modal';
 import Space from '@weco/common/views/components/styled/Space';
 import { useUser } from '@weco/common/views/components/UserProvider/UserProvider';
@@ -259,7 +262,7 @@ const ItemPage: NextPage<Props> = ({
       */}
 
       {(!hasImage || hasPdf) && showViewer && (
-        <Layout gridSizes={gridSize12()}>
+        <ContaineredLayout gridSizes={gridSize12()}>
           <Space
             className="body-text"
             $v={{ size: 'xl', properties: ['margin-top', 'margin-bottom'] }}
@@ -270,7 +273,7 @@ const ItemPage: NextPage<Props> = ({
               placeholderId={placeholderId}
             />
           </Space>
-        </Layout>
+        </ContaineredLayout>
       )}
 
       <Modal

--- a/identity/webapp/pages/delete-requested.tsx
+++ b/identity/webapp/pages/delete-requested.tsx
@@ -4,7 +4,10 @@ import { getServerData } from '@weco/common/server-data';
 import { SimplifiedServerData } from '@weco/common/server-data/types';
 import { AppErrorProps } from '@weco/common/services/app';
 import { serialiseProps } from '@weco/common/utils/json';
-import Layout, { gridSize10 } from '@weco/common/views/components/Layout';
+import {
+  ContaineredLayout,
+  gridSize10,
+} from '@weco/common/views/components/Layout';
 import Space from '@weco/common/views/components/styled/Space';
 import { DeleteRequestedText } from '@weco/identity/copy';
 import {
@@ -16,7 +19,7 @@ import { PageWrapper } from '@weco/identity/src/frontend/components/PageWrapper'
 const DeleteRequestedPage: NextPage = () => {
   return (
     <PageWrapper title="Delete request">
-      <Layout gridSizes={gridSize10()}>
+      <ContaineredLayout gridSizes={gridSize10()}>
         <Space $v={{ size: 'xl', properties: ['margin-top'] }}>
           <Container>
             <Wrapper>
@@ -24,7 +27,7 @@ const DeleteRequestedPage: NextPage = () => {
             </Wrapper>
           </Container>
         </Space>
-      </Layout>
+      </ContaineredLayout>
     </PageWrapper>
   );
 };

--- a/identity/webapp/pages/error.tsx
+++ b/identity/webapp/pages/error.tsx
@@ -5,7 +5,10 @@ import { SimplifiedServerData } from '@weco/common/server-data/types';
 import { AppErrorProps } from '@weco/common/services/app';
 import { serialiseProps } from '@weco/common/utils/json';
 import { StyledButton } from '@weco/common/views/components/Buttons';
-import Layout, { gridSize10 } from '@weco/common/views/components/Layout';
+import {
+  ContaineredLayout,
+  gridSize10,
+} from '@weco/common/views/components/Layout';
 import Space from '@weco/common/views/components/styled/Space';
 import { themeValues } from '@weco/common/views/themes/config';
 import CustomError from '@weco/identity/src/frontend/components/CustomError';
@@ -18,7 +21,7 @@ import { PageWrapper } from '@weco/identity/src/frontend/components/PageWrapper'
 const ErrorPage: NextPage<Props> = ({ errorDescription }) => {
   return (
     <PageWrapper title="Error">
-      <Layout gridSizes={gridSize10()}>
+      <ContaineredLayout gridSizes={gridSize10()}>
         <Space $v={{ size: 'xl', properties: ['margin-top'] }}>
           <Container>
             <Wrapper>
@@ -38,7 +41,7 @@ const ErrorPage: NextPage<Props> = ({ errorDescription }) => {
             </Wrapper>
           </Container>
         </Space>
-      </Layout>
+      </ContaineredLayout>
     </PageWrapper>
   );
 };

--- a/identity/webapp/pages/index.tsx
+++ b/identity/webapp/pages/index.tsx
@@ -23,7 +23,8 @@ import { serialiseProps } from '@weco/common/utils/json';
 import { allowedRequests } from '@weco/common/values/requests';
 import { HTMLDate } from '@weco/common/views/components/HTMLDateAndTime';
 import Icon from '@weco/common/views/components/Icon/Icon';
-import Layout, {
+import {
+  ContaineredLayout,
   gridSize10,
   gridSize12,
 } from '@weco/common/views/components/Layout';
@@ -243,18 +244,18 @@ const AccountPage: NextPage<Props> = ({ user: auth0UserClaims }) => {
   return (
     <PageWrapper title="Your library account">
       <Header $v={{ size: 'l', properties: ['margin-bottom'] }}>
-        <Layout gridSizes={gridSize12()}>
+        <ContaineredLayout gridSizes={gridSize12()}>
           <Space
             $v={{ size: 'l', properties: ['padding-top', 'padding-bottom'] }}
           >
             <Title>Library account</Title>
           </Space>
-        </Layout>
+        </ContaineredLayout>
         <div className="is-hidden-s">
           <WobblyEdge backgroundColor="warmNeutral.300" />
         </div>
       </Header>
-      <Layout gridSizes={gridSize10()}>
+      <ContaineredLayout gridSizes={gridSize10()}>
         <>
           {!user?.emailValidated && (
             <AccountStatus type="info">
@@ -449,7 +450,7 @@ const AccountPage: NextPage<Props> = ({ user: auth0UserClaims }) => {
             </Wrapper>
           </Container>
         </>
-      </Layout>
+      </ContaineredLayout>
     </PageWrapper>
   );
 };

--- a/identity/webapp/pages/registration.tsx
+++ b/identity/webapp/pages/registration.tsx
@@ -13,7 +13,8 @@ import { serialiseProps } from '@weco/common/utils/json';
 import { isString } from '@weco/common/utils/type-guards';
 import Button, { ButtonTypes } from '@weco/common/views/components/Buttons';
 import CheckboxRadio from '@weco/common/views/components/CheckboxRadio/CheckboxRadio';
-import Layout, {
+import {
+  ContaineredLayout,
   gridSize10,
   gridSize8,
 } from '@weco/common/views/components/Layout';
@@ -120,11 +121,11 @@ const RegistrationPage: NextPage<Props> = ({
 
   return (
     <PageWrapper title="Registration">
-      <Layout gridSizes={gridSize10()}>
+      <ContaineredLayout gridSizes={gridSize10()}>
         <Space $v={{ size: 'xl', properties: ['margin-top'] }}>
           <Container>
             <Wrapper>
-              <Layout gridSizes={gridSize8()}>
+              <ContaineredLayout gridSizes={gridSize8()}>
                 <Space $v={{ size: 'xl', properties: ['padding-top'] }}>
                   <RegistrationInformation email={email} />
 
@@ -247,11 +248,11 @@ const RegistrationPage: NextPage<Props> = ({
                     </SpacingComponent>
                   </form>
                 </Space>
-              </Layout>
+              </ContaineredLayout>
             </Wrapper>
           </Container>
         </Space>
-      </Layout>
+      </ContaineredLayout>
     </PageWrapper>
   );
 };

--- a/identity/webapp/pages/success.tsx
+++ b/identity/webapp/pages/success.tsx
@@ -4,7 +4,8 @@ import { getServerData } from '@weco/common/server-data';
 import { SimplifiedServerData } from '@weco/common/server-data/types';
 import { AppErrorProps } from '@weco/common/services/app';
 import { serialiseProps } from '@weco/common/utils/json';
-import Layout, {
+import {
+  ContaineredLayout,
   gridSize10,
   gridSize8,
 } from '@weco/common/views/components/Layout';
@@ -42,19 +43,19 @@ const SuccessPage: NextPage<Props> = ({ email }) => {
 
   return (
     <PageWrapper title="Registration">
-      <Layout gridSizes={gridSize10()}>
+      <ContaineredLayout gridSizes={gridSize10()}>
         <Space $v={{ size: 'xl', properties: ['margin-top'] }}>
           <Container>
             <Wrapper>
-              <Layout gridSizes={gridSize8()}>
+              <ContaineredLayout gridSizes={gridSize8()}>
                 <Space $v={{ size: 'xl', properties: ['padding-top'] }}>
                   <ApplicationReceived email={email} />
                 </Space>
-              </Layout>
+              </ContaineredLayout>
             </Wrapper>
           </Container>
         </Space>
-      </Layout>
+      </ContaineredLayout>
     </PageWrapper>
   );
 };

--- a/identity/webapp/pages/validated.tsx
+++ b/identity/webapp/pages/validated.tsx
@@ -5,7 +5,10 @@ import { SimplifiedServerData } from '@weco/common/server-data/types';
 import { AppErrorProps } from '@weco/common/services/app';
 import { serialiseProps } from '@weco/common/utils/json';
 import Button from '@weco/common/views/components/Buttons';
-import Layout, { gridSize10 } from '@weco/common/views/components/Layout';
+import {
+  ContaineredLayout,
+  gridSize10,
+} from '@weco/common/views/components/Layout';
 import Space from '@weco/common/views/components/styled/Space';
 import { useUser } from '@weco/common/views/components/UserProvider/UserProvider';
 import { ValidatedFailedText, ValidatedSuccessText } from '@weco/identity/copy';
@@ -25,7 +28,7 @@ const ValidatedPage: NextPage<Props> = ({ success, message, isNewSignUp }) => {
   // auth0.com/docs/brand-and-customize/email/email-template-descriptions#redirect-to-results-for-verification-email-template
   return (
     <PageWrapper title="Email verified">
-      <Layout gridSizes={gridSize10()}>
+      <ContaineredLayout gridSizes={gridSize10()}>
         <Space $v={{ size: 'xl', properties: ['margin-top'] }}>
           <Container>
             <Wrapper>
@@ -48,7 +51,7 @@ const ValidatedPage: NextPage<Props> = ({ success, message, isNewSignUp }) => {
             </Wrapper>
           </Container>
         </Space>
-      </Layout>
+      </ContaineredLayout>
     </PageWrapper>
   );
 };

--- a/identity/webapp/src/frontend/Registration/AccountCreated.tsx
+++ b/identity/webapp/src/frontend/Registration/AccountCreated.tsx
@@ -2,7 +2,10 @@ import { FunctionComponent } from 'react';
 
 import { info2 } from '@weco/common/icons';
 import Icon from '@weco/common/views/components/Icon/Icon';
-import Layout, { gridSize10 } from '@weco/common/views/components/Layout';
+import {
+  ContaineredLayout,
+  gridSize10,
+} from '@weco/common/views/components/Layout';
 import Space from '@weco/common/views/components/styled/Space';
 import SpacingComponent from '@weco/common/views/components/styled/SpacingComponent';
 import {
@@ -17,7 +20,7 @@ import { SuccessMessage } from './Registration.style';
 export const AccountCreated: FunctionComponent = () => {
   return (
     <PageWrapper title="Account created">
-      <Layout gridSizes={gridSize10()}>
+      <ContaineredLayout gridSizes={gridSize10()}>
         <Space $v={{ size: 'xl', properties: ['margin-top'] }}>
           <Container>
             <Wrapper>
@@ -63,7 +66,7 @@ export const AccountCreated: FunctionComponent = () => {
             </Wrapper>
           </Container>
         </Space>
-      </Layout>
+      </ContaineredLayout>
     </PageWrapper>
   );
 };


### PR DESCRIPTION
## What does this change?
David and I were discussing how to do Layouts, and two things came out of it;

- In the long term; we should audit the various methods we currently use and pick one https://github.com/wellcomecollection/wellcomecollection.org/issues/11268
-  In the short term; `Layout` shouldn't necessarily be wrapped in a `Container` as `Container` has its own padding that is not customisable, so an alternative should be created.

This PR addresses the second point.

`Layout` has renamed to `ContainerisedLayout`, and the new `Layout` default export is one that does not have any parent and is therefore more easily customisable when used. Most of the changes here have to do with the renaming and import.

## How to test

Run locally, do pages still looks ok in their layout? Did Chromatic complain about any changes? (no it didn't)

## How can we measure success?

More intuitive use of Layout.

## Have we considered potential risks?
N/A