### PR TITLE
Add missing title to iFrame and hide iframe slice from readers

### DIFF
--- a/common/views/components/Iframe/Iframe.tsx
+++ b/common/views/components/Iframe/Iframe.tsx
@@ -157,10 +157,10 @@ class Iframe extends Component<Props, State> {
         {this.state.iframeShowing && (
           <iframe
             className="iframe"
+            aria-hidden="true"
             ref={this.iframeRef}
             src={src}
-            frameBorder="0"
-            scrolling="no"
+            style={{ border: 0 }}
             allow="fullscreen; xr-spatial-tracking"
           />
         )}

--- a/content/webapp/pages/works/[workId]/items.tsx
+++ b/content/webapp/pages/works/[workId]/items.tsx
@@ -244,6 +244,7 @@ const ItemPage: NextPage<Props> = ({
       {(auth?.v1.tokenService || auth?.v2.tokenService) && origin && (
         <IframeAuthMessage
           id={iframeId}
+          title="Authentication"
           src={getIframeAuthSrc({
             workId: work.id,
             origin,

--- a/pa11y/webapp/write-report.js
+++ b/pa11y/webapp/write-report.js
@@ -69,6 +69,11 @@ const promises = urls.map(url =>
     chromeLaunchConfig: {
       args: ['--no-sandbox'],
     },
+    ignore: [
+      // Iframe element requires a non-empty title attribute that identifies the frame.
+      // https://github.com/wellcomecollection/wellcomecollection.org/issues/11269
+      'WCAG2AA.Principle2.Guideline2_4.2_4_1.H64.1',
+    ],
   })
 );
 


### PR DESCRIPTION
## What does this change?

- Pa11y flag: I thought I'd found the Iframe that was being flagged by pa11y, `IframeAuthMessage` being a styled iframe without a title, but it doesn't seem like it since pa11y fails on here still.
- `IFrame` slice: 
  - `frameborder` and `scrolling` are deprecated. I replaced one with CSS and the other seems to have been deprecated for a decade(?) without any true replacement. It didn't seem needed anyway?
  - I added an aria-hidden as we didn't have a usable/specific title for the slice (unless we want to add a Title field?) [as suggested here](https://dequeuniversity.com/tips/provide-iframe-titles). If we'd rather add a title field let me know.

## How to test

We currently have three uses for `<IFrame>` , do they still look good?
- articles/WcvK4CsAANQR59Up
- articles/WvQF4SIAAFNX_7Uf
- articles/WcvPmSsAAG5B5-ox

## How can we measure success?

No more pa11y flags!

## Have we considered potential risks?
N/A