### PR TITLE
Add dist to eslintignore list

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 /**/node_modules/
 /**/libs/
 /**/_next/
+/**/dist/
 !.storybook/

--- a/content/webapp/services/wellcome/catalogue/images.ts
+++ b/content/webapp/services/wellcome/catalogue/images.ts
@@ -4,18 +4,18 @@ import {
   ImagesProps,
   toQuery,
 } from '@weco/content/components/SearchPagesLink/Images';
-import { toIsoDateString } from '@weco/content/services/wellcome/catalogue/index';
-import { Toggles } from '@weco/toggles';
-
-import { catalogueQuery, looksLikeCanonicalId, notFound, rootUris } from '.';
-import { CatalogueImagesApiProps, CatalogueResultsList, Image } from './types';
 import {
   globalApiOptions,
   QueryProps,
   WellcomeApiError,
   wellcomeApiError,
   wellcomeApiFetch,
-} from '..';
+} from '@weco/content/services/wellcome';
+import { toIsoDateString } from '@weco/content/services/wellcome/catalogue/index';
+import { Toggles } from '@weco/toggles';
+
+import { catalogueQuery, looksLikeCanonicalId, notFound, rootUris } from '.';
+import { CatalogueImagesApiProps, CatalogueResultsList, Image } from './types';
 
 type ImageInclude =
   | 'withSimilarFeatures'

--- a/content/webapp/services/wellcome/catalogue/works.ts
+++ b/content/webapp/services/wellcome/catalogue/works.ts
@@ -4,6 +4,13 @@ import {
   toQuery,
   WorksProps,
 } from '@weco/content/components/SearchPagesLink/Works';
+import {
+  globalApiOptions,
+  QueryProps,
+  WellcomeApiError,
+  wellcomeApiError,
+  wellcomeApiFetch,
+} from '@weco/content/services/wellcome';
 import { toIsoDateString } from '@weco/content/services/wellcome/catalogue/index';
 import { Toggles } from '@weco/toggles';
 
@@ -15,13 +22,6 @@ import {
   ItemsList,
   Work,
 } from './types';
-import {
-  globalApiOptions,
-  QueryProps,
-  WellcomeApiError,
-  wellcomeApiError,
-  wellcomeApiFetch,
-} from '..';
 
 type GetWorkProps = {
   id: string;


### PR DESCRIPTION
## What does this change?
Just noticed that cache/edge_lambdas added a .dist folder when running some of its scripts, which then got picked up by eslint, which we don't want.
Also amended two imports that were flagged as warnings.

## How to test

`yarn lint` at root.

## How can we measure success?

`yarn lint` stays useful

## Have we considered potential risks?
N/A