### PR TITLE
Don't suppress storybook vulnerabilities now we've upgraded

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,7 @@ updates:
     ignore:
       - dependency-name: '*'
         update-types: ['version-update:semver-patch'] # Ignore all patch updates for version updates only
-      # We are looking at updating Storybook, so don't tell us about it. Remove this once we've upgraded.
-      - dependency-name: '@storybook*'
+      # We are looking at updating Chromatic, so don't tell us about it. Remove this once we've upgraded.
       - dependency-name: 'chromatic*'
       # Bigger piece, has a ticket to upgrade. Remove this once it's done.
       - dependency-name: 'next'


### PR DESCRIPTION
## What does this change?

We've [upgraded Storybook](#11279) to version 8 and we're ready for Dependabot to complain if there are things we need to address to do with Storybook.

## How to test

n/a

## How can we measure success?

We are told about problems and can fix them

## Have we considered potential risks?

Can't think of any