### PR TITLE
Apply new version (lambdas) for redirects changes to apply

### DIFF
--- a/cache/locals.tf
+++ b/cache/locals.tf
@@ -3,8 +3,8 @@ data "aws_secretsmanager_secret_version" "slack_webhook" {
 }
 
 locals {
-  edge_lambda_request_version  = 133
-  edge_lambda_response_version = 131
+  edge_lambda_request_version  = 134
+  edge_lambda_response_version = 132
 
   wellcome_cdn_cert_arn = "arn:aws:acm:us-east-1:130871440101:certificate/bb840c52-56bb-4bf8-86f8-59e7deaf9c98"
 


### PR DESCRIPTION
## What does this change?

Will apply the redirect changes to prod https://github.com/wellcomecollection/wellcomecollection.org/pull/11293/files

## How to test

- Go see in the Lambda app that I'm applying the correct new versions
- Once merged all the way to prod we can check that those redirects have stopped working as they have in staging.

## How can we measure success?

Less useless redirects ✨ 

## Have we considered potential risks?
None, those pages have been archived a year ago.