### PR TITLE
Display restricted to staff

### DIFF
--- a/content/webapp/components/IIIFClickthrough/IIIFClickthrough.tsx
+++ b/content/webapp/components/IIIFClickthrough/IIIFClickthrough.tsx
@@ -1,9 +1,4 @@
-import {
-  FunctionComponent,
-  PropsWithChildren,
-  useEffect,
-  useState,
-} from 'react';
+import { FunctionComponent, PropsWithChildren } from 'react';
 import styled from 'styled-components';
 
 import { font } from '@weco/common/utils/classnames';
@@ -26,22 +21,19 @@ function reloadAuthIframe(document: Document, id: string) {
 type Props = PropsWithChildren<{
   clickThroughService?: TransformedAuthService;
   tokenService: string;
+  origin?: string;
 }>;
 
 const IIIFClickthrough: FunctionComponent<Props> = ({
   clickThroughService,
   tokenService,
+  origin,
   children,
 }) => {
-  const [origin, setOrigin] = useState<string | undefined>();
   const showClickthroughMessage = useShowClickthrough(
     clickThroughService,
     tokenService
   );
-
-  useEffect(() => {
-    setOrigin(window.origin);
-  }, []);
 
   return clickThroughService && tokenService ? (
     <>

--- a/content/webapp/components/IIIFClickthrough/IIIFClickthrough.tsx
+++ b/content/webapp/components/IIIFClickthrough/IIIFClickthrough.tsx
@@ -26,7 +26,7 @@ function reloadAuthIframe(document: Document, id: string) {
 
 type Props = PropsWithChildren<{
   clickThroughService: TransformedAuthService | undefined;
-  tokenService: TransformedAuthService | undefined;
+  tokenService: string;
 }>;
 
 const IIIFClickthrough: FunctionComponent<Props> = ({
@@ -49,7 +49,7 @@ const IIIFClickthrough: FunctionComponent<Props> = ({
         <IframeAuthMessage
           id={iframeId}
           title="IIIF Authentication iframe for cross-domain messaging"
-          src={`${tokenService.id}?messageId=1&origin=${origin}`}
+          src={tokenService}
         />
       )}
       {showClickthroughMessage ? (

--- a/content/webapp/components/IIIFClickthrough/IIIFClickthrough.tsx
+++ b/content/webapp/components/IIIFClickthrough/IIIFClickthrough.tsx
@@ -1,4 +1,9 @@
-import { FunctionComponent, PropsWithChildren } from 'react';
+import {
+  FunctionComponent,
+  PropsWithChildren,
+  useEffect,
+  useState,
+} from 'react';
 import styled from 'styled-components';
 
 import { font } from '@weco/common/utils/classnames';
@@ -6,7 +11,6 @@ import Button from '@weco/common/views/components/Buttons';
 import Space from '@weco/common/views/components/styled/Space';
 import useShowClickthrough from '@weco/content/hooks/useShowClickthrough';
 import { TransformedAuthService } from '@weco/content/utils/iiif/v3';
-
 const IframeAuthMessage = styled.iframe`
   display: none;
 `;
@@ -20,7 +24,7 @@ function reloadAuthIframe(document: Document, id: string) {
 }
 
 type Props = PropsWithChildren<{
-  clickThroughService: TransformedAuthService | undefined;
+  clickThroughService?: TransformedAuthService;
   tokenService: string;
 }>;
 
@@ -29,10 +33,15 @@ const IIIFClickthrough: FunctionComponent<Props> = ({
   tokenService,
   children,
 }) => {
+  const [origin, setOrigin] = useState<string | undefined>();
   const showClickthroughMessage = useShowClickthrough(
     clickThroughService,
     tokenService
   );
+
+  useEffect(() => {
+    setOrigin(window.origin);
+  }, []);
 
   return clickThroughService && tokenService ? (
     <>

--- a/content/webapp/components/IIIFClickthrough/IIIFClickthrough.tsx
+++ b/content/webapp/components/IIIFClickthrough/IIIFClickthrough.tsx
@@ -1,9 +1,4 @@
-import {
-  FunctionComponent,
-  PropsWithChildren,
-  useEffect,
-  useState,
-} from 'react';
+import { FunctionComponent, PropsWithChildren } from 'react';
 import styled from 'styled-components';
 
 import { font } from '@weco/common/utils/classnames';
@@ -34,14 +29,10 @@ const IIIFClickthrough: FunctionComponent<Props> = ({
   tokenService,
   children,
 }) => {
-  const [origin, setOrigin] = useState<string>();
   const showClickthroughMessage = useShowClickthrough(
     clickThroughService,
     tokenService
   );
-  useEffect(() => {
-    setOrigin(`${window.location.protocol}//${window.location.hostname}`);
-  }, []);
 
   return clickThroughService && tokenService ? (
     <>

--- a/content/webapp/components/IIIFViewer/MainViewer.tsx
+++ b/content/webapp/components/IIIFViewer/MainViewer.tsx
@@ -213,15 +213,14 @@ const ItemRenderer = memo(({ style, index, data }: ItemRendererProps) => {
   const { scrollVelocity, canvases, externalAccessService, accessToken } = data;
   const [mainLoaded, setMainLoaded] = useState(false);
   const currentCanvas = canvases[index];
-  const mainImageService = { '@id': currentCanvas.imageServiceId };
-  const urlTemplateMain = mainImageService['@id']
-    ? iiifImageTemplate(mainImageService['@id'])
   const { user } = useUser();
   const role = user?.role;
+  const urlTemplateMain = currentCanvas.imageServiceId
+    ? iiifImageTemplate(currentCanvas.imageServiceId)
     : undefined;
   const infoUrl =
-    mainImageService['@id'] &&
-    convertRequestUriToInfoUri(mainImageService['@id']);
+    currentCanvas.imageServiceId &&
+    convertRequestUriToInfoUri(currentCanvas.imageServiceId);
   const imageType = scrollVelocity >= 1 ? 'none' : 'main';
   const isRestricted = currentCanvas.hasRestrictedImage;
   const { searchResults, rotatedImages } = useContext(ItemViewerContext);

--- a/content/webapp/components/IIIFViewer/MainViewer.tsx
+++ b/content/webapp/components/IIIFViewer/MainViewer.tsx
@@ -15,6 +15,7 @@ import { useToggles } from '@weco/common/server-data/Context';
 import { font } from '@weco/common/utils/classnames';
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
 import LL from '@weco/common/views/components/styled/LL';
+import { useUser } from '@weco/common/views/components/UserProvider/UserProvider';
 import ItemViewerContext, {
   RotatedImage,
 } from '@weco/content/components/ItemViewerContext/ItemViewerContext';
@@ -217,6 +218,8 @@ const ItemRenderer = memo(({ style, index, data }: ItemRendererProps) => {
   const mainImageService = { '@id': currentCanvas.imageServiceId };
   const urlTemplateMain = mainImageService['@id']
     ? iiifImageTemplate(mainImageService['@id'])
+  const { user } = useUser();
+  const role = user?.role;
     : undefined;
   const infoUrl =
     mainImageService['@id'] &&
@@ -276,7 +279,13 @@ const ItemRenderer = memo(({ style, index, data }: ItemRendererProps) => {
         <div style={{ display: 'flex', justifyContent: 'center' }}>
           <LL $lighten={true} />
         </div>
-      ) : isRestricted ? (
+      ) : isRestricted &&
+        (role !== 'StaffWithRestricted' ||
+          (role === 'StaffWithRestricted' && !accessToken)) ? (
+        // We always want to show the restricted message to users without a role of 'StaffWithRestricted'
+        // If the user has the correct role then officially we should check the probe service repsonse before trying to load the image
+        // However, we've opted to just try and load the image if the accessToken is available rather than making an additional call
+        // In our case the probe service doesn't offer any information other than whether the image would load, so we may as well try that directly.
         <MessageContainer>
           <h2 className={font('intb', 4)}>{externalAccessService?.label}</h2>
           <p

--- a/content/webapp/components/IIIFViewer/MainViewer.tsx
+++ b/content/webapp/components/IIIFViewer/MainViewer.tsx
@@ -11,7 +11,6 @@ import {
 import { areEqual, FixedSizeList } from 'react-window';
 import styled from 'styled-components';
 
-import { useToggles } from '@weco/common/server-data/Context';
 import { font } from '@weco/common/utils/classnames';
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
 import LL from '@weco/common/views/components/styled/LL';
@@ -30,7 +29,6 @@ import { TransformedAuthService } from '@weco/content/utils/iiif/v3';
 
 import { queryParamToArrayIndex } from '.';
 import ImageViewer from './ImageViewer';
-
 type OverlayPositionData = {
   canvasNumber: number;
   overlayTop: number;
@@ -392,7 +390,6 @@ const MainViewer: FunctionComponent = () => {
     errorHandler,
     accessToken,
   } = useContext(ItemViewerContext);
-  const { authV2 } = useToggles();
   const { shouldScrollToCanvas, canvas } = query;
   const mainViewerRef = useRef<FixedSizeList>(null);
   const [newScrollOffset, setNewScrollOffset] = useState(0);
@@ -408,10 +405,9 @@ const MainViewer: FunctionComponent = () => {
     ...transformedManifest,
   };
 
-  // If authV2 toggle is true we try to use the iiif auth V2 services and fallback to V1, in case the manifest doesn't contain V2. Otherwise we just use the V1 services
-  const externalAccessService = authV2
-    ? auth?.v2.externalAccessService || auth?.v1.externalAccessService
-    : auth?.v1.externalAccessService;
+  // Only the V2 external service works for providing access so we always attempt to use that first
+  const externalAccessService =
+    auth?.v2.externalAccessService || auth?.v1.externalAccessService;
 
   // We hide the zoom and rotation controls while the user is scrolling
   function handleOnScroll({ scrollOffset }) {

--- a/content/webapp/components/IIIFViewer/MainViewer.tsx
+++ b/content/webapp/components/IIIFViewer/MainViewer.tsx
@@ -358,7 +358,7 @@ function scrollViewer({
       currentCanvas?.height && currentCanvas?.width
         ? currentCanvas.height / currentCanvas.width
         : 1;
-    const renderedHeight = mainAreaWidth * ratio * 0.8; // TODO: 0.8 = 80% max-width image in container. Variable.
+    const renderedHeight = mainAreaWidth * ratio * 0.8; // 0.8 = 80% max-width image in container. Variable.
     const heightOfPreviousItems =
       queryParamToArrayIndex(canvas) * (viewer?.props.itemSize || 0);
     const distanceToScroll =

--- a/content/webapp/components/IIIFViewer/MainViewer.tsx
+++ b/content/webapp/components/IIIFViewer/MainViewer.tsx
@@ -280,7 +280,8 @@ const ItemRenderer = memo(({ style, index, data }: ItemRendererProps) => {
         (role !== 'StaffWithRestricted' ||
           (role === 'StaffWithRestricted' && !accessToken)) ? (
         // We always want to show the restricted message to users without a role of 'StaffWithRestricted'
-        // If the user has the correct role then officially we should check the probe service repsonse before trying to load the image
+        // If the user has the correct role then officially we should check the probe service repsonse before trying to load the image.
+        // https://iiif.io/api/auth/2.0/#probe-service
         // However, we've opted to just try and load the image if the accessToken is available rather than making an additional call
         // In our case the probe service doesn't offer any information other than whether the image would load, so we may as well try that directly.
         <MessageContainer>

--- a/content/webapp/components/IIIFViewer/MainViewer.tsx
+++ b/content/webapp/components/IIIFViewer/MainViewer.tsx
@@ -283,7 +283,6 @@ const ItemRenderer = memo(({ style, index, data }: ItemRendererProps) => {
         // However, we've opted to just try and load the image if the accessToken is available rather than making an additional call
         // In our case the probe service doesn't offer any information other than whether the image would load, so we may as well try that directly.
         <MessageContainer>
-          Access token: {accessToken}
           <h2 className={font('intb', 4)}>{externalAccessService?.label}</h2>
           <p
             className={font('intr', 5)}

--- a/content/webapp/components/IIIFViewer/MainViewer.tsx
+++ b/content/webapp/components/IIIFViewer/MainViewer.tsx
@@ -276,15 +276,14 @@ const ItemRenderer = memo(({ style, index, data }: ItemRendererProps) => {
         <div style={{ display: 'flex', justifyContent: 'center' }}>
           <LL $lighten={true} />
         </div>
-      ) : isRestricted &&
-        (role !== 'StaffWithRestricted' ||
-          (role === 'StaffWithRestricted' && !accessToken)) ? (
+      ) : isRestricted && role !== 'StaffWithRestricted' ? (
         // We always want to show the restricted message to users without a role of 'StaffWithRestricted'
         // If the user has the correct role then officially we should check the probe service repsonse before trying to load the image.
         // https://iiif.io/api/auth/2.0/#probe-service
         // However, we've opted to just try and load the image if the accessToken is available rather than making an additional call
         // In our case the probe service doesn't offer any information other than whether the image would load, so we may as well try that directly.
         <MessageContainer>
+          Access token: {accessToken}
           <h2 className={font('intb', 4)}>{externalAccessService?.label}</h2>
           <p
             className={font('intr', 5)}

--- a/content/webapp/components/IIIFViewer/MainViewer.tsx
+++ b/content/webapp/components/IIIFViewer/MainViewer.tsx
@@ -211,7 +211,7 @@ function getPositionData({
   return highlightsPositioningData || [];
 }
 const ItemRenderer = memo(({ style, index, data }: ItemRendererProps) => {
-  const { scrollVelocity, canvases, externalAccessService } = data;
+  const { scrollVelocity, canvases, externalAccessService, accessToken } = data;
   const [mainLoaded, setMainLoaded] = useState(false);
   const currentCanvas = canvases[index];
   const mainImageService = { '@id': currentCanvas.imageServiceId };

--- a/content/webapp/components/ItemViewerContext/ItemViewerContext.tsx
+++ b/content/webapp/components/ItemViewerContext/ItemViewerContext.tsx
@@ -30,6 +30,7 @@ type Props = {
   parentManifest: ParentManifest | undefined;
   searchResults: SearchResults | null;
   setSearchResults: (v) => void;
+  accessToken: string | undefined;
 
   // UI props:
   viewerRef: RefObject<HTMLDivElement> | undefined;
@@ -52,7 +53,6 @@ type Props = {
   setRotatedImages: (v: RotatedImage[]) => void;
   isResizing: boolean;
   errorHandler?: () => void;
-  accessToken?: string;
 };
 
 export const results = {
@@ -98,6 +98,7 @@ const ItemViewerContext = createContext<Props>({
   parentManifest: undefined,
   searchResults: results,
   setSearchResults: () => undefined,
+  accessToken: undefined,
 
   // UI props:
   viewerRef: undefined,

--- a/content/webapp/components/WorkDetails/WorkDetails.AvailableOnline.tsx
+++ b/content/webapp/components/WorkDetails/WorkDetails.AvailableOnline.tsx
@@ -282,8 +282,8 @@ const WorkDetailsAvailableOnline = ({
   } = { ...transformedManifest };
   const tokenService = getTokenService({ auth, authV2 });
   const activeAccessService = authV2
-    ? auth?.v2.activeAccessService || auth?.v1.activeAccessService
-    : auth?.v1.activeAccessService; // TODO should this include externalAccessSerice too?
+    ? auth?.v2.activeAccessService
+    : auth?.v1.activeAccessService;
 
   const isBornDigital =
     bornDigitalStatus === 'mixedBornDigital' ||

--- a/content/webapp/components/WorkDetails/WorkDetails.AvailableOnline.tsx
+++ b/content/webapp/components/WorkDetails/WorkDetails.AvailableOnline.tsx
@@ -282,6 +282,7 @@ const WorkDetailsAvailableOnline = ({
     placeholderId,
     rendering,
   } = { ...transformedManifest };
+  const [origin, setOrigin] = useState<string | undefined>();
 
   const tokenService = getIframeTokenSrc({
     role,
@@ -315,6 +316,10 @@ const WorkDetailsAvailableOnline = ({
   }, [archiveTree, tabbableId]);
   const { isEnhanced } = useContext(AppContext);
 
+  useEffect(() => {
+    setOrigin(window.origin);
+  }, []);
+
   return (
     <WorkDetailsSection
       headingText={`Available ${isBornDigital ? 'to download' : 'online'}`}
@@ -325,6 +330,7 @@ const WorkDetailsAvailableOnline = ({
           <IIIFClickthrough
             clickThroughService={activeAccessService}
             tokenService={tokenService || ''}
+            origin={origin}
           >
             {children}
           </IIIFClickthrough>

--- a/content/webapp/components/WorkDetails/WorkDetails.AvailableOnline.tsx
+++ b/content/webapp/components/WorkDetails/WorkDetails.AvailableOnline.tsx
@@ -35,7 +35,6 @@ import DownloadLink from '@weco/content/components/DownloadLink/DownloadLink';
 import IIIFClickthrough from '@weco/content/components/IIIFClickthrough/IIIFClickthrough';
 import IIIFItemList from '@weco/content/components/IIIFItemList/IIIFItemList';
 import { DownloadTable } from '@weco/content/components/WorkDetails/WorkDetails.DownloadItem';
-import { getTokenService } from '@weco/content/pages/works/[workId]/items'; // TODO move function to utils?
 import { Note, Work } from '@weco/content/services/wellcome/catalogue/types';
 import {
   DownloadOption,
@@ -43,6 +42,7 @@ import {
 } from '@weco/content/types/manifest';
 import {
   getFormatString,
+  getIframeTokenSrc,
   getLabelString,
   isAllOriginalPdfs,
 } from '@weco/content/utils/iiif/v3';
@@ -280,7 +280,15 @@ const WorkDetailsAvailableOnline = ({
     placeholderId,
     rendering,
   } = { ...transformedManifest };
-  const tokenService = getTokenService({ auth, authV2 });
+
+  const tokenService = getIframeTokenSrc({
+    authServices,
+    role,
+    workId,
+    origin,
+    auth,
+    authV2,
+  });
   const activeAccessService = authV2
     ? auth?.v2.activeAccessService
     : auth?.v1.activeAccessService;

--- a/content/webapp/components/WorkDetails/WorkDetails.AvailableOnline.tsx
+++ b/content/webapp/components/WorkDetails/WorkDetails.AvailableOnline.tsx
@@ -269,6 +269,8 @@ const WorkDetailsAvailableOnline = ({
   locationOfWork,
   transformedManifest,
 }: Props) => {
+  const { user } = useUser();
+  const role = user?.role;
   const { authV2 } = useToggles();
   const {
     collectionManifestsCount,
@@ -282,9 +284,8 @@ const WorkDetailsAvailableOnline = ({
   } = { ...transformedManifest };
 
   const tokenService = getIframeTokenSrc({
-    authServices,
     role,
-    workId,
+    workId: work.id,
     origin,
     auth,
     authV2,
@@ -320,16 +321,14 @@ const WorkDetailsAvailableOnline = ({
     >
       <ConditionalWrapper
         condition={Boolean(tokenService && !shouldShowItemLink)}
-        wrapper={children =>
-          itemUrl && (
-            <IIIFClickthrough
-              clickThroughService={activeAccessService}
-              tokenService={tokenService}
-            >
-              {children}
-            </IIIFClickthrough>
-          )
-        }
+        wrapper={children => (
+          <IIIFClickthrough
+            clickThroughService={activeAccessService}
+            tokenService={tokenService || ''}
+          >
+            {children}
+          </IIIFClickthrough>
+        )}
       >
         {isBornDigital && !allOriginalPdfs && (
           <>

--- a/content/webapp/hooks/useShowClickthrough.ts
+++ b/content/webapp/hooks/useShowClickthrough.ts
@@ -4,14 +4,14 @@ import { TransformedAuthService } from '@weco/content/utils/iiif/v3';
 
 const useShowClickthrough = (
   clickThroughService: TransformedAuthService | undefined,
-  tokenService: TransformedAuthService | undefined
+  tokenService: string | undefined
 ): boolean => {
   const [showClickthrough, setShowClickthrough] = useState(false);
 
   useEffect(() => {
     function receiveMessage(event: MessageEvent) {
       const data = event.data;
-      const serviceOrigin = tokenService && new URL(tokenService.id);
+      const serviceOrigin = tokenService && new URL(tokenService);
       if (
         serviceOrigin &&
         `${serviceOrigin.protocol}//${serviceOrigin.hostname}` === event.origin

--- a/content/webapp/pages/works/[workId]/items.tsx
+++ b/content/webapp/pages/works/[workId]/items.tsx
@@ -164,6 +164,10 @@ const ItemPage: NextPage<Props> = ({
   const shouldUseAuthMessageIframe =
     ((authV2 && auth?.v2.tokenService) || (!authV2 && auth?.v1.tokenService)) &&
     origin;
+  const tryAndGetRestrictedAuthCookie =
+    role === 'StaffWithRestricted' &&
+    authServices?.external?.id ===
+      'https://iiif.wellcomecollection.org/auth/v2/access/restrictedlogin';
   // showViewer is true by default, so the noScriptViewer is available without javascript
   // if javascript is available we set it to false and then determine whether the clickthrough modal is required
   // before setting it to true
@@ -180,6 +184,18 @@ const ItemPage: NextPage<Props> = ({
   useEffect(() => {
     setOrigin(`${window.origin}`);
   }, []);
+
+  useEffect(() => {
+    if (tryAndGetRestrictedAuthCookie) {
+      const authServiceWindow = window.open(
+        `${authServices?.external?.id || ''}?origin=${window.origin}`
+      );
+      authServiceWindow &&
+        authServiceWindow.addEventListener('unload', function () {
+          reloadAuthIframe(document, iframeId);
+        });
+    }
+  }, [tryAndGetRestrictedAuthCookie]);
 
   useEffect(() => {
     function receiveMessage(event: MessageEvent) {

--- a/content/webapp/pages/works/[workId]/items.tsx
+++ b/content/webapp/pages/works/[workId]/items.tsx
@@ -91,7 +91,6 @@ function createTzitzitWorkLink(work: Work): ApiToolbarLink | undefined {
   });
 }
 
-
 function getIsTotallyRestricted({
   auth,
   authV2,
@@ -99,9 +98,7 @@ function getIsTotallyRestricted({
   auth: Auth | undefined;
   authV2: boolean | undefined;
 }) {
-  return authV2
-    ? auth?.v2.isTotallyRestricted || auth?.v1.isTotallyRestricted
-    : auth?.v1.isTotallyRestricted;
+  return authV2 ? auth?.v2.isTotallyRestricted : auth?.v1.isTotallyRestricted;
 }
 
 type Props = {

--- a/content/webapp/pages/works/[workId]/items.tsx
+++ b/content/webapp/pages/works/[workId]/items.tsx
@@ -57,6 +57,7 @@ import {
   checkModalRequired,
   getAuthServices,
   getCollectionManifests,
+  getIframeTokenSrc,
   hasItemType,
   hasOriginalPdf,
 } from '@weco/content/utils/iiif/v3';
@@ -90,25 +91,6 @@ function createTzitzitWorkLink(work: Work): ApiToolbarLink | undefined {
   });
 }
 
-// We are currently using V1 iiif auth services from the manitest
-// If the authV2 toggle is set to true we try to use V2 services if they're available
-function getIframeAuthSrc({ workId, origin, auth, authV2 }) {
-  // TODO typing
-  if (authV2 && auth.v2.externalAccessService && auth.v2.tokenService) {
-    return `${auth.v2.tokenService.id}?messageId=${workId}&origin=${origin}`;
-  } else if (auth.v1.tokenService) {
-    return `${auth.v1.tokenService.id}?messageId=${workId}&origin=${origin}`;
-  } else {
-    return undefined;
-  }
-}
-
-export function getTokenService({ auth, authV2 }) {
-  const service = authV2
-    ? auth?.v2.tokenService || auth?.v1.tokenService
-    : auth?.v1.tokenService;
-  return service;
-}
 
 function getIsTotallyRestricted({
   auth,

--- a/content/webapp/pages/works/[workId]/items.tsx
+++ b/content/webapp/pages/works/[workId]/items.tsx
@@ -160,7 +160,7 @@ const ItemPage: NextPage<Props> = ({
 
   const hasImage = hasItemType(canvases, 'Image');
   const hasPdf = hasOriginalPdf(canvases);
-
+  const isTotallyRestricted = getIsTotallyRestricted({ auth, authV2 });
   const shouldUseAuthMessageIframe =
     ((authV2 && auth?.v2.tokenService) || (!authV2 && auth?.v1.tokenService)) &&
     origin;

--- a/content/webapp/pages/works/[workId]/items.tsx
+++ b/content/webapp/pages/works/[workId]/items.tsx
@@ -200,17 +200,24 @@ const ItemPage: NextPage<Props> = ({
   useEffect(() => {
     function receiveMessage(event: MessageEvent) {
       const data = event.data;
-      const tokenService = getTokenService({ auth, authV2 });
-      const service = tokenService && new URL(tokenService.id);
-      const isTotallyRestricted = getIsTotallyRestricted({ auth, authV2 });
+      const tokenService = getIframeTokenSrc({
+        role,
+        workId: work.id,
+        origin: window.origin,
+        auth,
+        authV2,
+      });
+      const service = (tokenService && new URL(tokenService)) as
+        | URL
+        | undefined;
+
       // We check this is the event we are interested in
       // N.B. locally react dev tools will create a lot of events
-
-      if (service.origin === event.origin) {
+      if (service?.origin === event.origin) {
         if (Object.prototype.hasOwnProperty.call(data, 'accessToken')) {
+          setAccessToken(data.accessToken);
           setShowModal(Boolean(isTotallyRestricted));
           setShowViewer(!isTotallyRestricted);
-          setAccessToken(data.accessToken);
         } else {
           setShowModal(true);
           setShowViewer(false);

--- a/content/webapp/pages/works/[workId]/items.tsx
+++ b/content/webapp/pages/works/[workId]/items.tsx
@@ -161,6 +161,9 @@ const ItemPage: NextPage<Props> = ({
   const hasImage = hasItemType(canvases, 'Image');
   const hasPdf = hasOriginalPdf(canvases);
 
+  const shouldUseAuthMessageIframe =
+    ((authV2 && auth?.v2.tokenService) || (!authV2 && auth?.v1.tokenService)) &&
+    origin;
   // showViewer is true by default, so the noScriptViewer is available without javascript
   // if javascript is available we set it to false and then determine whether the clickthrough modal is required
   // before setting it to true
@@ -220,7 +223,7 @@ const ItemPage: NextPage<Props> = ({
       hideFooter={true}
       hideTopContent={true}
     >
-      {(auth?.v1.tokenService || auth?.v2.tokenService) && origin && (
+      {shouldUseAuthMessageIframe && (
         <IframeAuthMessage
           id={iframeId}
           title="Authentication"

--- a/content/webapp/pages/works/[workId]/items.tsx
+++ b/content/webapp/pages/works/[workId]/items.tsx
@@ -227,7 +227,8 @@ const ItemPage: NextPage<Props> = ({
         <IframeAuthMessage
           id={iframeId}
           title="Authentication"
-          src={getIframeAuthSrc({
+          src={getIframeTokenSrc({
+            role,
             workId: work.id,
             origin,
             auth,

--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -339,7 +339,8 @@ export function getTokenService(
       )
     : clickThroughService?.service;
 }
-type AuthServices = {
+
+export type AuthServices = {
   active?: TransformedAuthService;
   external?: TransformedAuthService;
 };

--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -224,7 +224,7 @@ function getImageAuthCookieService(
       : undefined;
 }
 
-function getImageAuthProbeService(
+export function getImageAuthProbeService(
   service: BodyService2 | undefined
 ): AuthProbeService2 | undefined {
   return Array.isArray(service)

--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -340,7 +340,7 @@ export function getTokenService(
     : clickThroughService?.service;
 }
 
-export type AuthServices = {
+type AuthServices = {
   active?: TransformedAuthService;
   external?: TransformedAuthService;
 };
@@ -364,6 +364,36 @@ export function getAuthServices({
       external:
         auth?.v2.externalAccessService || auth?.v1.externalAccessService,
     };
+  }
+}
+
+export function getIframeTokenSrc({
+  authServices,
+  role,
+  workId,
+  origin,
+  auth,
+  authV2,
+}: {
+  authServices: AuthServices;
+  role?: string;
+  workId: string;
+  origin: string;
+  auth: Auth | undefined;
+  authV2: boolean | undefined;
+}): string | undefined {
+  // We want the token source to be from the same auth version as the authService
+  // We use v2 if we have a v2 external service and the user has a role of 'StaffWithRestricted'
+  // OR if the authV2 toggle is true
+  const useV2TokenService =
+    (authServices.external?.id ===
+      'https://iiif.wellcomecollection.org/auth/v2/access/restrictedlogin' &&
+      role === 'StaffWithRestricted') ||
+    authV2;
+  if (useV2TokenService && auth?.v2.tokenService) {
+    return `${auth.v2.tokenService.id}?messageId=${workId}&origin=${origin}`;
+  } else if (auth?.v1.tokenService) {
+    return `${auth.v1.tokenService.id}?messageId=${workId}&origin=${origin}`;
   }
 }
 

--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -376,7 +376,7 @@ export function getIframeTokenSrc({
 }: {
   role?: string;
   workId: string;
-  origin: string;
+  origin?: string;
   auth: Auth | undefined;
   authV2: boolean | undefined;
 }): string | undefined {

--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -368,14 +368,12 @@ export function getAuthServices({
 }
 
 export function getIframeTokenSrc({
-  authServices,
   role,
   workId,
   origin,
   auth,
   authV2,
 }: {
-  authServices: AuthServices;
   role?: string;
   workId: string;
   origin: string;
@@ -385,8 +383,9 @@ export function getIframeTokenSrc({
   // We want the token source to be from the same auth version as the authService
   // We use v2 if we have a v2 external service and the user has a role of 'StaffWithRestricted'
   // OR if the authV2 toggle is true
+  const authServices = getAuthServices({ auth, authV2 });
   const useV2TokenService =
-    (authServices.external?.id ===
+    (authServices?.external?.id ===
       'https://iiif.wellcomecollection.org/auth/v2/access/restrictedlogin' &&
       role === 'StaffWithRestricted') ||
     authV2;


### PR DESCRIPTION
## What does this change?

Makes restricted items viewable on the item page for users with a role of 'StaffWithRestricted'. For [#5761](https://github.com/wellcomecollection/platform/issues/5761)

_N.B. It does not deal with born digital things, which we list on the works page. - this needs further consideration._

### Things to be aware of:

The [IIIF Authorization Flow API 2.0 docs](https://iiif.io/api/auth/2.0) describe [three interaction patterns ](https://iiif.io/api/auth/2.0/#33-interaction-patterns) external, kiosk and active. Kiosk is not relevant to us. Active is what we currently use for the clickthrough, but could be used to offer a login. External is the profile used for restricted items.

We use external for restricted items because we don't want to present most users with a login when they either don't have an account, or if they do, their account doesn't give them access to restricted items anyway. This is also the preferred behaviour if the iiif manifest were to be loaded into a third party viewer.

Ordinarily, with the external access service:

- ["The user is expected to have already acquired the authorizing aspect, and no access service will be used."](https://iiif.io/api/auth/2.0/#profile)
  and
- ["There is no access service. Any URI specified in the id property must be ignored."](https://iiif.io/api/auth/2.0/#external-interaction-pattern)
- ["The client must immediately use the related access token service, as described below."](https://iiif.io/api/auth/2.0/#external-interaction-pattern)

However, in our case there is an access service provided by the id of the external service and we need to use it because logging in via Auth0 is a separate system and doesn't provide the authorizing aspect we need.

#### How we handle restricted items using the external service

- A user visits the items page to view the contents of a iiif presentation manifest that contains restricted items.
- If the user is logged in and has a role of 'StaffWithRestricted' we use javascript to open a new window pointing to the id specified in the external service.
- The first time this happens, the new page prompts the user to login again and provides them with the necessary authorizing cookie, before closing the window automatically (on localhost you also need to click a button because the site and services are running on different domains)
- Subsequent views of the items page open and close the window automatically without user interaction as long as the login is still valid.
- Once that is done, things work the same way as clickthroughs. We use the token service (with the authorizing cookie) to get an accessToken.

The [IIIF Authorization Flow API 2.0 docs](https://iiif.io/api/auth/2.0) then states we should use query the [Probe service](https://wellcomecollection.org/works/xnwrtt3c/images?id=tbtvxxmm) with the access token to understand whether the user has access to the access-controlled resource for which the probe service is declared. Orignally I did this, but the probe service doesn't return anything other than a 200 status in our case, so it felt a bit redundant. Instead, I simply use the presence of the accessToken as the condition for trying to load the images.

#### Other things worth knowing
We can have v2 and v1 versions of the auth services in a manifest, but we don't always have v2. Furthermore, only the access service provided by the id of the v2 exteranl service works, the v1 version 404s.

We therefore always try to use the v2 service and fallback to the v1 service. We need to fallback because the presence of this service is what we use to determine whether to show the restricted message to users.

This means that if a user is logged in with a role of 'StaffWithRestricted' and visits an items page with restricted things but only v1 auth services in the manifest, the images won't load. There is [a ticket to address this with modified messaging](https://github.com/wellcomecollection/wellcomecollection.org/issues/11304). **Caveat** if the user has already visited an item with v2 external services and authorized, then they will be able to see the images.

The[ iiif docs state](https://iiif.io/api/auth/2.0/#33-interaction-patterns) that, "If more than one access service is available, the client should interact with them in the order external, kiosk, active."  However, in our case we only want users with a role of "StaffWithRestricted" to use the external access service and only if the external access service is available as v2.

Because the external access service only works with v2 services, we fallback to the v1 active service (if we have a mix)
This means that, for items with a mix of external and active services, users with roles of "StaffWithRestricted" will still be able to see things that require a user interaction.

## How to test

1. **Without logging in or logging in with a user that has a role !== 'StaffWithRestricted'** visit the following pages:

The behaviour should be the same as the live site.

- Restricted audio: http://localhost:3000/works/esd6gs3s/items - should be presented with a player that won't play
- Restricted video: http://localhost:3000/works/zsgh5y3z/items - should be presented with a player that won't play
- Restricted book: http://localhost:3000/works/jjdp9v65/items - should be presented with a modal notifying you the item is restricted.

N.B. users should never end up in the above situations as we don't link to the items page from the work page under these circumstances.

- Mix of restricted and clickthrough: http://localhost:3000/works/nvnknvs7/items - should be presented with a modal containing a content advisory warning. Click 'View the content' should make the first image viewable, but the second image should present a message telling you that it is restricted.

2. Log in with a user that has a role === 'StaffWithRestricted' and visit the following pages:

N.B. on local a new window should open either with a login form or a submit button. Once the form is submitted or the button clicked the window should close.

- Restricted audio: http://localhost:3000/works/esd6gs3s/items - should be presented with a player that will play
- Restricted video: http://localhost:3000/works/zsgh5y3z/items - should be presented with a player that will play
- Restricted book: http://localhost:3000/works/jjdp9v65/items - should be able to see the all the images and have a notice in the sidebar telling you the item is restricted.
- Mix of restricted and clickthrough: http://localhost:3000/works/nvnknvs7/items - should be able to see the all the images. There is **no** notice in the sidebar telling you the item is restricted. The notification needs to be on a per image basis. Work to be done here: https://github.com/wellcomecollection/wellcomecollection.org/issues/11278

N.B. Restricted PDFs should behave as audio/video do. However, according to Ashley all PDFs that are ingested are open, so we can't test them.

## How can we measure success?

Staff with the correct permissions can view restricted material.

## Have we considered potential risks?

Risks should be negligible as the only changes in behaviour should be for the limited number of people who have the role of 'StaffWithRestricted'. As long as e2e tests are passing and the above testing works, we should be good.
