### PR TITLE
Upgrade react-photo-album and change code to support v3

### DIFF
--- a/content/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
+++ b/content/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
@@ -5,10 +5,12 @@ import {
   useMemo,
   useState,
 } from 'react';
-import PhotoAlbum, {
-  RenderPhotoProps,
-  RenderRowContainer,
+import {
+  RenderImageProps,
+  RenderPhotoContext,
+  RowsPhotoAlbum,
 } from 'react-photo-album';
+import 'react-photo-album/rows.css';
 import styled from 'styled-components';
 
 import { ServerDataContext } from '@weco/common/server-data/Context';
@@ -151,24 +153,25 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
     [images]
   );
 
-  const renderRowContainer: RenderRowContainer = ({ children }) => {
-    return <AlbumRow>{children}</AlbumRow>;
-  };
-
-  const imageRenderer: FunctionComponent<RenderPhotoProps<GalleryImageProps>> =
+  const imageRenderer =
     // these are values and props that are passed in by the PhotoAlbum component
-    ({ photo, layout }) => {
+    (
+      props: RenderImageProps,
+      context: RenderPhotoContext<GalleryImageProps>
+    ) => {
+      const { photo, width, height } = context;
       const rgbColor = hexToRgb(photo.averageColor || '');
+
       return (
-        <li style={{ padding: 12 }}>
+        <li>
           <ImageFrame>
             <ImageCard
               id={photo.id}
               workId={photo.source.id}
               image={{
                 contentUrl: photo.src,
-                width: layout.width,
-                height: layout.height,
+                width,
+                height,
                 alt: photo.source.title,
               }}
               onClick={event => {
@@ -187,15 +190,17 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
         </li>
       );
     };
+
   return (
     <>
       {isFullSupportBrowser && !isSmallGallery && (
         <GalleryContainer data-testid="image-search-results-container">
-          <PhotoAlbum
+          <RowsPhotoAlbum
             photos={imagesWithDimensions}
-            renderPhoto={imageRenderer}
-            renderRowContainer={renderRowContainer}
-            layout="rows"
+            render={{
+              track: ({ children }) => <AlbumRow>{children}</AlbumRow>,
+              image: imageRenderer,
+            }}
             spacing={0}
             padding={12}
             targetRowHeight={200}

--- a/content/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
+++ b/content/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
@@ -207,6 +207,7 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
           />
         </GalleryContainer>
       )}
+
       {(!isFullSupportBrowser || isSmallGallery) && (
         <div data-testid="image-search-results-container">
           <ImageCardList>

--- a/content/webapp/package.json
+++ b/content/webapp/package.json
@@ -26,7 +26,7 @@
     "openseadragon": "^4.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-photo-album": "^2.0.0",
+    "react-photo-album": "^3.0.2",
     "react-window": "^1.8.8",
     "reading-time": "^1.5.0",
     "rss": "^1.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13122,10 +13122,10 @@ react-is@^18.0.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
   integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
-react-photo-album@^2.0.0:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/react-photo-album/-/react-photo-album-2.4.1.tgz#9754b22501a157c3c1774260bd3da8a38d88cf4b"
-  integrity sha512-dzqP5QbYAugA0uZTl3qsVldckzDXYDkDOvA8CpACl51hSEfhJmCfwhbnI4WBHnETQHv48nnNQ1jhrulst8njLA==
+react-photo-album@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/react-photo-album/-/react-photo-album-3.0.2.tgz#994644afe651cc8516ea15bfc2f054563568ba45"
+  integrity sha512-w3+8i6aj9l1jRfcubgVbAlBGSdtiXcqWdcwZcH4/Bavc+v7X7h+S3TkQ723pvDABjhaaxS168g9ECEBP6xnKrQ==
 
 react-popper@^2.3.0:
   version "2.3.0"
@@ -14115,7 +14115,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -14201,7 +14210,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -15386,7 +15402,16 @@ wordwrap@>=0.0.2:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
## What does this change?

As per https://github.com/wellcomecollection/wellcomecollection.org/pull/11294

Moving to v3 broke a few things https://github.com/igordanchenko/react-photo-album/releases/tag/v3.0.0 so I aimed to figure out how to not change anything UI facing whilst going with what is now offered by the library.

## How to test

- Run locally
- go to http://localhost:3000/search/images and http://localhost:3000/concepts/fmydsuw2, do they look the same as in prod? On all screen sizes?
- Try to resize, does it looks good? 

## How can we measure success?

Up to date packages and seemingly lighter version of it.

## Have we considered potential risks?
If well tested, low risk