### PR TITLE
Track new pages with HotJar

### DIFF
--- a/content/webapp/pages/collections.tsx
+++ b/content/webapp/pages/collections.tsx
@@ -4,6 +4,7 @@ import { FunctionComponent } from 'react';
 import { prismicPageIds } from '@weco/common/data/hardcoded-ids';
 import { AppErrorProps } from '@weco/common/services/app';
 import CollectionsStaticContent from '@weco/content/components/Body/CollectionsStaticContent';
+import useHotjar from '@weco/content/hooks/useHotjar';
 import { setCacheControl } from '@weco/content/utils/setCacheControl';
 
 import * as page from './pages/[pageId]';
@@ -20,6 +21,8 @@ export const getServerSideProps: GetServerSideProps<
 
 const CollectionsPage: FunctionComponent<page.Props> = (props: page.Props) => {
   const staticContent = <CollectionsStaticContent />;
+  useHotjar(true);
+
   return <page.Page {...props} staticContent={staticContent} />;
 };
 

--- a/content/webapp/pages/concepts/[conceptId].tsx
+++ b/content/webapp/pages/concepts/[conceptId].tsx
@@ -24,6 +24,7 @@ import { toLink as toImagesLink } from '@weco/content/components/SearchPagesLink
 import { toLink as toWorksLink } from '@weco/content/components/SearchPagesLink/Works';
 import Tabs from '@weco/content/components/Tabs';
 import WorksSearchResults from '@weco/content/components/WorksSearchResults/WorksSearchResults';
+import useHotjar from '@weco/content/hooks/useHotjar';
 import { emptyResultList } from '@weco/content/services/wellcome';
 import { looksLikeCanonicalId } from '@weco/content/services/wellcome/catalogue';
 import { getConcept } from '@weco/content/services/wellcome/catalogue/concepts';
@@ -257,6 +258,7 @@ export const ConceptPage: NextPage<Props> = ({
   sectionsData,
   apiToolbarLinks,
 }) => {
+  useHotjar(true);
   const pathname = usePathname();
   const worksTabs = tabOrder
     .map(relationship => {

--- a/content/webapp/pages/exhibitions/[exhibitionId]/index.tsx
+++ b/content/webapp/pages/exhibitions/[exhibitionId]/index.tsx
@@ -18,7 +18,6 @@ import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import Exhibition from '@weco/content/components/Exhibition/Exhibition';
 import Installation from '@weco/content/components/Installation/Installation';
-import useHotjar from '@weco/content/hooks/useHotjar';
 import { createClient } from '@weco/content/services/prismic/fetch';
 import { fetchExhibition } from '@weco/content/services/prismic/fetch/exhibitions';
 import { transformExhibition } from '@weco/content/services/prismic/transformers/exhibitions';
@@ -50,8 +49,6 @@ const ExhibitionPage: FunctionComponent<ExhibitionProps> = ({
   accessResourceLinks,
   jsonLd,
 }) => {
-  useHotjar(exhibition.id === 'ZZP8BxAAALeD00jo'); // Only on Jason and the Adventure of 254
-
   return (
     <PageLayout
       title={exhibition.title}

--- a/content/webapp/pages/guides/exhibitions/[id]/[type]/[stop]/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/[type]/[stop]/index.tsx
@@ -33,7 +33,6 @@ import AudioPlayer from '@weco/content/components/AudioPlayer/AudioPlayer';
 import ImagePlaceholder, {
   placeholderBackgroundColor,
 } from '@weco/content/components/ImagePlaceholder/ImagePlaceholder';
-import useHotjar from '@weco/content/hooks/useHotjar';
 import { createClient } from '@weco/content/services/prismic/fetch';
 import { fetchExhibitionHighlightTour } from '@weco/content/services/prismic/fetch/exhibition-highlight-tours';
 import {
@@ -205,8 +204,6 @@ const ExhibitionGuidePage: FunctionComponent<Props> = props => {
     exhibitionGuide,
     allStops,
   } = props;
-  useHotjar(exhibitionGuideId === 'ZthrZRIAACQALvCC'); // Only on Jason and the Adventure of 254
-
   // We use the `shallow` prop with NextLinks to avoid doing an unnecessary
   // `getServerSideProps` using the Previous/Next links, because we already have
   // all the data we need and can work it out client side

--- a/content/webapp/pages/guides/exhibitions/[id]/[type]/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/[type]/index.tsx
@@ -33,7 +33,6 @@ import Space from '@weco/common/views/components/styled/Space';
 import { components } from '@weco/common/views/slices';
 import RelevantGuideIcons from '@weco/content/components/ExhibitionGuideRelevantIcons';
 import ExhibitionGuideStops from '@weco/content/components/ExhibitionGuideStops/ExhibitionGuideStops';
-import useHotjar from '@weco/content/hooks/useHotjar';
 import { createClient } from '@weco/content/services/prismic/fetch';
 import { fetchExhibitionGuide } from '@weco/content/services/prismic/fetch/exhibition-guides';
 import { fetchExhibitionHighlightTour } from '@weco/content/services/prismic/fetch/exhibition-highlight-tours';
@@ -203,8 +202,6 @@ export const getServerSideProps: GetServerSideProps<
 };
 
 const ExhibitionGuidePage: FunctionComponent<Props> = props => {
-  useHotjar(true);
-
   const { exhibitionGuide, jsonLd, type, userPreferenceSet } = props;
   const pathname = `${linkResolver(exhibitionGuide)}/${type}`;
 

--- a/content/webapp/pages/guides/exhibitions/[id]/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/index.tsx
@@ -28,7 +28,6 @@ import {
   ExhibitionResourceLinks,
 } from '@weco/content/components/ExhibitionGuideLinks/ExhibitionGuideLinks';
 import OtherExhibitionGuides from '@weco/content/components/OtherExhibitionGuides/OtherExhibitionGuides';
-import useHotjar from '@weco/content/hooks/useHotjar';
 import { allGuides } from '@weco/content/pages/guides/exhibitions';
 import { createClient } from '@weco/content/services/prismic/fetch';
 import {
@@ -68,7 +67,6 @@ import { setCacheControl } from '@weco/content/utils/setCacheControl';
 // At which point we'll have the exhibition id in the url and can query the types directly, filtering by the exhibition id
 
 type Props = {
-  exhibitionId: string;
   exhibitionGuide?: ExhibitionGuide;
   exhibitionText?: ExhibitionText;
   exhibitionHighlightTour?: ExhibitionHighlightTour;
@@ -175,7 +173,6 @@ export const getServerSideProps: GetServerSideProps<
 
       return {
         props: serialiseProps({
-          exhibitionId: id,
           exhibitionGuide,
           jsonLd,
           serverData,
@@ -287,7 +284,6 @@ export const getServerSideProps: GetServerSideProps<
 };
 
 const ExhibitionGuidePage: FunctionComponent<Props> = ({
-  exhibitionId,
   exhibitionGuide,
   exhibitionText,
   exhibitionHighlightTour,
@@ -303,8 +299,6 @@ const ExhibitionGuidePage: FunctionComponent<Props> = ({
     exhibitionGuide?.title ||
     exhibitionText?.title ||
     exhibitionHighlightTour?.title;
-
-  useHotjar(exhibitionId === 'ZthrZRIAACQALvCC'); // Only on Jason and the Adventure of 254
 
   const highlightStops = exhibitionHighlightTour?.stops;
   const hasVideo =

--- a/content/webapp/pages/search/events.tsx
+++ b/content/webapp/pages/search/events.tsx
@@ -26,6 +26,7 @@ import {
   fromQuery,
 } from '@weco/content/components/SearchPagesLink/Events';
 import Sort from '@weco/content/components/Sort/Sort';
+import useHotjar from '@weco/content/hooks/useHotjar';
 import { emptyResultList } from '@weco/content/services/wellcome';
 import { eventsFilters } from '@weco/content/services/wellcome/common/filters';
 import { getEvents } from '@weco/content/services/wellcome/content/events';
@@ -62,6 +63,7 @@ export const EventsSearchPage: NextPageWithLayout<Props> = ({
   query,
   eventsRouteProps,
 }) => {
+  useHotjar(true);
   const { query: queryString } = query;
 
   const filters = eventsFilters({

--- a/content/webapp/pages/search/images.tsx
+++ b/content/webapp/pages/search/images.tsx
@@ -29,6 +29,7 @@ import {
   toLink,
 } from '@weco/content/components/SearchPagesLink/Images';
 import Sort from '@weco/content/components/Sort/Sort';
+import useHotjar from '@weco/content/hooks/useHotjar';
 import { emptyResultList } from '@weco/content/services/wellcome';
 import { getImages } from '@weco/content/services/wellcome/catalogue/images';
 import {
@@ -80,6 +81,7 @@ const ImagesSearchPage: NextPageWithLayout<Props> = ({
   imagesRouteProps,
   query,
 }) => {
+  useHotjar(true);
   const { query: queryString } = query;
   const { setLink } = useContext(SearchContext);
 

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -31,6 +31,7 @@ import SearchNoResults from '@weco/content/components/SearchNoResults/SearchNoRe
 import { getSearchLayout } from '@weco/content/components/SearchPageLayout/SearchPageLayout';
 import StoriesGrid from '@weco/content/components/StoriesGrid';
 import WorksSearchResults from '@weco/content/components/WorksSearchResults/WorksSearchResults';
+import useHotjar from '@weco/content/hooks/useHotjar';
 import { WellcomeApiError } from '@weco/content/services/wellcome';
 import { getImages } from '@weco/content/services/wellcome/catalogue/images';
 import {
@@ -140,6 +141,7 @@ export const SearchPage: NextPageWithLayout<Props> = ({
   events,
   query,
 }) => {
+  useHotjar(true);
   const { query: queryString } = query;
   const { setLink } = useContext(SearchContext);
 

--- a/content/webapp/pages/search/stories.tsx
+++ b/content/webapp/pages/search/stories.tsx
@@ -26,6 +26,7 @@ import {
 } from '@weco/content/components/SearchPagesLink/Stories';
 import Sort from '@weco/content/components/Sort/Sort';
 import StoriesGrid from '@weco/content/components/StoriesGrid';
+import useHotjar from '@weco/content/hooks/useHotjar';
 import { emptyResultList } from '@weco/content/services/wellcome';
 import { storiesFilters } from '@weco/content/services/wellcome/common/filters';
 import { getArticles } from '@weco/content/services/wellcome/content/articles';
@@ -66,6 +67,7 @@ export const StoriesSearchPage: NextPageWithLayout<Props> = ({
   query,
   storiesRouteProps,
 }) => {
+  useHotjar(true);
   const { query: queryString } = query;
 
   const filters = storiesFilters({

--- a/content/webapp/pages/search/works.tsx
+++ b/content/webapp/pages/search/works.tsx
@@ -28,6 +28,7 @@ import {
 } from '@weco/content/components/SearchPagesLink/Works';
 import Sort from '@weco/content/components/Sort/Sort';
 import WorksSearchResults from '@weco/content/components/WorksSearchResults/WorksSearchResults';
+import useHotjar from '@weco/content/hooks/useHotjar';
 import {
   emptyResultList,
   WellcomeResultList,
@@ -63,6 +64,7 @@ const CatalogueSearchPage: NextPageWithLayout<Props> = ({
   worksRouteProps,
   query,
 }) => {
+  useHotjar(true);
   const { query: queryString } = query;
 
   const { setLink } = useContext(SearchContext);

--- a/content/webapp/pages/works/[workId]/images.tsx
+++ b/content/webapp/pages/works/[workId]/images.tsx
@@ -20,6 +20,7 @@ import Space from '@weco/common/views/components/styled/Space';
 import BetaMessage from '@weco/content/components/BetaMessage/BetaMessage';
 import CataloguePageLayout from '@weco/content/components/CataloguePageLayout/CataloguePageLayout';
 import IIIFViewer from '@weco/content/components/IIIFViewer';
+import useHotjar from '@weco/content/hooks/useHotjar';
 import { looksLikeCanonicalId } from '@weco/content/services/wellcome/catalogue';
 import { getImage } from '@weco/content/services/wellcome/catalogue/images';
 import {
@@ -60,6 +61,7 @@ const ImagePage: FunctionComponent<Props> = ({
   iiifPresentationLocation,
   apiToolbarLinks,
 }) => {
+  useHotjar(true);
   const title = work.title || '';
 
   return (

--- a/content/webapp/pages/works/[workId]/index.tsx
+++ b/content/webapp/pages/works/[workId]/index.tsx
@@ -20,6 +20,7 @@ import CataloguePageLayout from '@weco/content/components/CataloguePageLayout/Ca
 import IsArchiveContext from '@weco/content/components/IsArchiveContext/IsArchiveContext';
 import WorkDetails from '@weco/content/components/WorkDetails';
 import WorkHeader from '@weco/content/components/WorkHeader/WorkHeader';
+import useHotjar from '@weco/content/hooks/useHotjar';
 import { fetchIIIFPresentationManifest } from '@weco/content/services/iiif/fetch/manifest';
 import { transformManifest } from '@weco/content/services/iiif/transformers/manifest';
 import { looksLikeCanonicalId } from '@weco/content/services/wellcome/catalogue';
@@ -70,6 +71,7 @@ export const WorkPage: NextPage<Props> = ({
   apiUrl,
   transformedManifest,
 }) => {
+  useHotjar(true);
   const { user } = useUser();
   const role = user?.role;
   const isArchive = !!(

--- a/content/webapp/pages/works/[workId]/items.tsx
+++ b/content/webapp/pages/works/[workId]/items.tsx
@@ -34,6 +34,7 @@ import IIIFViewer, {
 import { fromQuery } from '@weco/content/components/ItemLink';
 import { ParentManifest } from '@weco/content/components/ItemViewerContext/ItemViewerContext';
 import WorkLink from '@weco/content/components/WorkLink';
+import useHotjar from '@weco/content/hooks/useHotjar';
 import { fetchCanvasOcr } from '@weco/content/services/iiif/fetch/canvasOcr';
 import { fetchIIIFPresentationManifest } from '@weco/content/services/iiif/fetch/manifest';
 import { transformCanvasOcr } from '@weco/content/services/iiif/transformers/canvasOcr';
@@ -146,6 +147,7 @@ const ItemPage: NextPage<Props> = ({
   serverSearchResults,
   parentManifest,
 }) => {
+  useHotjar(true);
   const { user } = useUser();
   const role = user?.role;
   const { authV2 } = useToggles();


### PR DESCRIPTION
## What does this change?

#11306 

- Removes it from all Exhibitions and Digital Guides pages 
- Adds it to
  - `/concepts/[conceptId]`
  - `/collections`
  - `/search`
  - `/search/works`
  - `/search/images`
  - `/search/events`
  - `/search/stories`
  - `/works/[workId]`
  - `/works/[workId]/items`
  - `/works/[workId]/images`

## How to test

Run locally and check if Hotjar scripts are loaded on the above page **only** when you have given analytics permissions.
Check that it doesn't load anymore where it's been removed.

## How can we measure success?

So much success to be gained from this! 

## Have we considered potential risks?
N/A