### PR TITLE
display different message to user if only have v1 external service

### DIFF
--- a/content/webapp/components/IIIFViewer/ViewerSidebar.tsx
+++ b/content/webapp/components/IIIFViewer/ViewerSidebar.tsx
@@ -199,7 +199,7 @@ const ViewerSidebar: FunctionComponent<ViewerSidebarProps> = ({
   const authServices = getAuthServices({ auth, authV2 });
 
   const manifestNeedsRegeneration =
-    authServices?.external.id ===
+    authServices?.external?.id ===
     'https://iiif.wellcomecollection.org/auth/restrictedlogin';
 
   return (

--- a/content/webapp/components/IIIFViewer/ViewerSidebar.tsx
+++ b/content/webapp/components/IIIFViewer/ViewerSidebar.tsx
@@ -10,6 +10,7 @@ import styled from 'styled-components';
 
 import { arrow, chevron, info2 } from '@weco/common/icons';
 import { DigitalLocation } from '@weco/common/model/catalogue';
+import { useToggles } from '@weco/common/server-data/Context';
 import { classNames, font } from '@weco/common/utils/classnames';
 import { getCatalogueLicenseData } from '@weco/common/utils/licenses';
 import { OptionalToUndefined } from '@weco/common/utils/utility-types';
@@ -21,7 +22,10 @@ import ItemViewerContext from '@weco/content/components/ItemViewerContext/ItemVi
 import LinkLabels from '@weco/content/components/LinkLabels/LinkLabels';
 import WorkLink from '@weco/content/components/WorkLink';
 import WorkTitle from '@weco/content/components/WorkTitle/WorkTitle';
-import { getMultiVolumeLabel } from '@weco/content/utils/iiif/v3';
+import {
+  getAuthServices,
+  getMultiVolumeLabel,
+} from '@weco/content/utils/iiif/v3';
 import { removeTrailingFullStop, toHtmlId } from '@weco/content/utils/string';
 import { getDigitalLocationInfo } from '@weco/content/utils/works';
 
@@ -155,6 +159,7 @@ const ViewerSidebar: FunctionComponent<ViewerSidebarProps> = ({
   iiifImageLocation,
   iiifPresentationLocation,
 }) => {
+  const { authV2 } = useToggles();
   const { work, transformedManifest, parentManifest } =
     useContext(ItemViewerContext);
   const { user } = useUser();
@@ -171,7 +176,7 @@ const ViewerSidebar: FunctionComponent<ViewerSidebarProps> = ({
     matchingManifest?.label &&
     getMultiVolumeLabel(matchingManifest.label, work?.title || '');
 
-  const { structures, searchService } = { ...transformedManifest };
+  const { structures, searchService, auth } = { ...transformedManifest };
 
   const digitalLocation: DigitalLocation | undefined =
     iiifPresentationLocation || iiifImageLocation;
@@ -191,7 +196,11 @@ const ViewerSidebar: FunctionComponent<ViewerSidebarProps> = ({
     digitalLocationInfo?.accessCondition === 'restricted' &&
     user?.role === 'StaffWithRestricted';
 
-  const manifestNeedsRegeneration = false;
+  const authServices = getAuthServices({ auth, authV2 });
+
+  const manifestNeedsRegeneration =
+    authServices?.external.id ===
+    'https://iiif.wellcomecollection.org/auth/restrictedlogin';
 
   return (
     <>

--- a/content/webapp/components/WorkDetails/WorkDetails.AvailableOnline.tsx
+++ b/content/webapp/components/WorkDetails/WorkDetails.AvailableOnline.tsx
@@ -150,7 +150,7 @@ const ItemPageLink = ({
     user?.role === 'StaffWithRestricted';
 
   const manifestNeedsRegeneration =
-    authServices?.external.id ===
+    authServices?.external?.id ===
     'https://iiif.wellcomecollection.org/auth/restrictedlogin';
   return (
     <>

--- a/content/webapp/components/WorkDetails/WorkDetails.AvailableOnline.tsx
+++ b/content/webapp/components/WorkDetails/WorkDetails.AvailableOnline.tsx
@@ -41,6 +41,7 @@ import {
   TransformedManifest,
 } from '@weco/content/types/manifest';
 import {
+  getAuthServices,
   getFormatString,
   getIframeTokenSrc,
   getLabelString,
@@ -136,6 +137,7 @@ const ItemPageLink = ({
   collectionManifestsCount,
   canvasCount,
   digitalLocationInfo,
+  authServices,
 }) => {
   const { user } = useUser();
 
@@ -147,8 +149,9 @@ const ItemPageLink = ({
     digitalLocationInfo?.accessCondition === 'restricted' &&
     user?.role === 'StaffWithRestricted';
 
-  const manifestNeedsRegeneration = false;
-
+  const manifestNeedsRegeneration =
+    authServices?.external.id ===
+    'https://iiif.wellcomecollection.org/auth/restrictedlogin';
   return (
     <>
       {work.thumbnail && (
@@ -291,9 +294,8 @@ const WorkDetailsAvailableOnline = ({
     auth,
     authV2,
   });
-  const activeAccessService = authV2
-    ? auth?.v2.activeAccessService
-    : auth?.v1.activeAccessService;
+
+  const authServices = getAuthServices({ auth, authV2 });
 
   const isBornDigital =
     bornDigitalStatus === 'mixedBornDigital' ||
@@ -328,7 +330,7 @@ const WorkDetailsAvailableOnline = ({
         condition={Boolean(tokenService && !shouldShowItemLink)}
         wrapper={children => (
           <IIIFClickthrough
-            clickThroughService={activeAccessService}
+            clickThroughService={authServices?.active}
             tokenService={tokenService || ''}
             origin={origin}
           >
@@ -440,6 +442,7 @@ const WorkDetailsAvailableOnline = ({
                 canvasCount={canvasCount}
                 downloadOptions={downloadOptions}
                 digitalLocationInfo={digitalLocationInfo}
+                authServices={authServices}
               />
             )}
           </>


### PR DESCRIPTION
## What does this change?

For [#11304](https://github.com/wellcomecollection/wellcomecollection.org/issues/11304)

## How to test

Log in with a user that has a role of 'StaffWithRestricted'

Visit http://localhost:3000/works/a24nhdcv and see the following message:

<img width="562" alt="Screenshot 2024-10-22 at 16 22 12" src="https://github.com/user-attachments/assets/386e940d-6b09-4539-8a83-5b6497974f10">

Visit http://localhost:3000/works/a24nhdcv/items and see the following message:

<img width="323" alt="Screenshot 2024-10-22 at 16 28 57" src="https://github.com/user-attachments/assets/8e6cae67-10d6-4292-9d4a-bdeca2025c0e">

## How can we measure success?


## Have we considered potential risks?

Limited as it only affects a limited number of users.

It is possible that if the user has already visited an item with v2 external services and authorized, then they will be able to see the images, but still receive this message. We could try and address this, but felt it was not a great use of time given the limited impact of the issue and the fact it will resolve once all iiif manifests have been regenerated.