### PR TITLE
Apply new lambda versions for redirects

### DIFF
--- a/cache/locals.tf
+++ b/cache/locals.tf
@@ -3,8 +3,8 @@ data "aws_secretsmanager_secret_version" "slack_webhook" {
 }
 
 locals {
-  edge_lambda_request_version  = 134
-  edge_lambda_response_version = 132
+  edge_lambda_request_version  = 136
+  edge_lambda_response_version = 134
 
   wellcome_cdn_cert_arn = "arn:aws:acm:us-east-1:130871440101:certificate/bb840c52-56bb-4bf8-86f8-59e7deaf9c98"
 


### PR DESCRIPTION
## What does this change?

Applies changes from https://github.com/wellcomecollection/wellcomecollection.org/pull/11308 and https://github.com/wellcomecollection/wellcomecollection.org/pull/11298 to production after they seem to work nicely in staging. 

Relates to #11300 

## How to test

Can't really test until deployed and applied, but you could confirm these are the latest versions.

## How can we measure success?

N/A

## Have we considered potential risks?
N/A