### PR TITLE
text change

### DIFF
--- a/content/webapp/components/IIIFViewer/ViewerSidebar.tsx
+++ b/content/webapp/components/IIIFViewer/ViewerSidebar.tsx
@@ -217,7 +217,7 @@ const ViewerSidebar: FunctionComponent<ViewerSidebarProps> = ({
             </RestrictedMessageTitle>
 
             <p style={{ marginBottom: manifestNeedsRegeneration ? '1rem' : 0 }}>
-              This item is hidden from the public.
+              Only staff with the right permissions can view this item online.
             </p>
 
             {manifestNeedsRegeneration && (

--- a/content/webapp/components/WorkDetails/WorkDetails.AvailableOnline.tsx
+++ b/content/webapp/components/WorkDetails/WorkDetails.AvailableOnline.tsx
@@ -196,8 +196,7 @@ const ItemPageLink = ({
               </RestrictedMessageTitle>
 
               <p style={{ marginBottom: '1rem' }}>
-                This item is hidden from the public and can only be viewed by
-                staff.
+                Only staff with the right permissions can view this item online.
               </p>
 
               {manifestNeedsRegeneration && (


### PR DESCRIPTION
## What does this change?

For #11301: updates the text

## How to test

View a [works](http://localhost:3000/works/jjdp9v65) and [items](http://localhost:3000/works/jjdp9v65/items) page for a restricted work while logged in with a user with a role of 'StaffWithRestricted'

See the following text:
<img width="740" alt="Screenshot 2024-10-23 at 11 50 14" src="https://github.com/user-attachments/assets/fc70ca17-e899-4f7d-8826-7b1e2e71d8ca">

<img width="325" alt="Screenshot 2024-10-23 at 11 50 03" src="https://github.com/user-attachments/assets/d2c00124-d634-4c85-a39b-a70ed4c9112f">

## How can we measure success?

The message displays

## Have we considered potential risks?

None really 

