### PR TITLE
(3) Suggestion for basic page fetch

### DIFF
--- a/content/webapp/pages/pages/[pageId].tsx
+++ b/content/webapp/pages/pages/[pageId].tsx
@@ -43,6 +43,7 @@ import SectionHeader from '@weco/content/components/SectionHeader/SectionHeader'
 import { PageFormatIds } from '@weco/content/data/content-format-ids';
 import { createClient } from '@weco/content/services/prismic/fetch';
 import {
+  fetchBasicPage,
   fetchChildren,
   fetchPage,
   fetchSiblings,
@@ -118,7 +119,7 @@ export const getServerSideProps: GetServerSideProps<
   // As our former URL structure for all pages was /pages/, if a user ends up on an old URL
   // We want to redirect them to where the page now is.
   if (context.resolvedUrl.indexOf('/pages/') === 0) {
-    const basicDocument = await fetchPage(client, pageId);
+    const basicDocument = await fetchBasicPage(client, pageId);
 
     if (isNotUndefined(basicDocument)) {
       const basicDocSiteSection = basicDocument.tags.find(t =>

--- a/content/webapp/services/prismic/fetch/index.ts
+++ b/content/webapp/services/prismic/fetch/index.ts
@@ -157,7 +157,8 @@ export function fetcher<Document extends prismic.PrismicDocument>(
       uid: string,
       // 'orphan' is only ever used in this context,
       // so I'm keeping it separate from SiteSection which is used in other contexts.
-      siteSection?: SiteSection | 'orphan'
+      siteSection?: SiteSection | 'orphan',
+      params?: { graphQuery?: string }
     ): Promise<Document | undefined> => {
       try {
         const primaryContentType = toMaybeString(contentType);
@@ -167,17 +168,21 @@ export function fetcher<Document extends prismic.PrismicDocument>(
         const response = await client.getByUID<Document>(
           primaryContentType,
           uid,
-          {
-            fetchLinks,
-            filters: siteSection
-              ? [
-                  prismic.filter.any(
-                    'document.tags',
-                    siteSection === 'orphan' ? [] : [siteSection]
-                  ),
-                ]
-              : [],
-          }
+          params?.graphQuery
+            ? {
+                graphQuery: params?.graphQuery,
+              }
+            : {
+                fetchLinks,
+                filters: siteSection
+                  ? [
+                      prismic.filter.any(
+                        'document.tags',
+                        siteSection === 'orphan' ? [] : [siteSection]
+                      ),
+                    ]
+                  : [],
+              }
         );
 
         return response;

--- a/content/webapp/services/prismic/fetch/pages.ts
+++ b/content/webapp/services/prismic/fetch/pages.ts
@@ -73,18 +73,17 @@ export const fetchPage = async (
   return pageDocument;
 };
 
-// TODO?
 export const fetchBasicPage = async (
   client: GetServerSidePropsPrismicClient,
-  id: string,
-  // 'orphan' is only ever used in this context,
-  // so I'm keeping it separate from SiteSection which is used in other contexts.
-  siteSection?: SiteSection | 'orphan'
+  id: string
 ): Promise<RawPagesDocument | undefined> => {
-  // #11240 once redirects are in place we should only fetch by uid
-  const pageDocument =
-    (await pagesFetcher.getByUid(client, id, siteSection)) ||
-    (await pagesFetcher.getById(client, id));
+  const pageDocument = await pagesFetcher.getByUid(client, id, undefined, {
+    graphQuery: `{
+        pages {
+          uid
+        }
+      }`.replace(/\n(\s+)/g, '\n'),
+  });
 
   return pageDocument;
 };


### PR DESCRIPTION
## What does this change?
#11072 

The current solution for `/pages/` redirections involves fetching the document before redirecting the user, which means having to fetch the same document twice. We thought we could add a `getBasicDocument` fetch which only returns what is needed to do that (in our case, `id`, `uid` and `tags`). `id` and `tags` are default fields and always get returned, so my graphql request only asks for `uid`. 

The only think I don't like is that it complexifies `getByUid` so I'd love your thoughts.

## How to test
Run locally, does it work well?

## How can we measure success?

Smaller, lighter queries

## Have we considered potential risks?
N/A