### PR TITLE
Point updown to new general channel

### DIFF
--- a/updown/types.ts
+++ b/updown/types.ts
@@ -4,7 +4,7 @@ export type Check = {
   url: string;
   name: string;
   emailAlerts?: boolean;
-  slackAlerts?: ('platform-channel' | 'alerts-channel')[];
+  slackAlerts?: ('digital-general' | 'alerts-channel')[];
   apdexThreshold?: ApdexThreshold;
 };
 

--- a/updown/updown-checks.ts
+++ b/updown/updown-checks.ts
@@ -6,7 +6,7 @@ export default [
     url: 'https://content.wellcomecollection.org/',
     name: 'Homepage',
     emailAlerts: true,
-    slackAlerts: ['platform-channel', 'alerts-channel'],
+    slackAlerts: ['digital-general', 'alerts-channel'],
   },
   {
     url: 'https://content.wellcomecollection.org/stories',
@@ -60,7 +60,7 @@ export default [
     url: 'https://content.wellcomecollection.org/search/works?query=botany',
     name: 'Works search',
     emailAlerts: true,
-    slackAlerts: ['platform-channel', 'alerts-channel'],
+    slackAlerts: ['digital-general', 'alerts-channel'],
     apdexThreshold: 1.0, // We expect this to be a slower page
   },
   {
@@ -94,7 +94,7 @@ export default [
     url: 'https://api.wellcomecollection.org/catalogue/v2/images?query=medicine',
     name: 'Images API: Search',
     emailAlerts: true,
-    slackAlerts: ['platform-channel', 'alerts-channel'],
+    slackAlerts: ['digital-general', 'alerts-channel'],
   },
   {
     url: 'https://api.wellcomecollection.org/catalogue/v2/images/sws5gyfw',
@@ -105,7 +105,7 @@ export default [
     url: 'https://api.wellcomecollection.org/catalogue/v2/works?query=botany',
     name: 'Works API: Search',
     emailAlerts: true,
-    slackAlerts: ['platform-channel', 'alerts-channel'],
+    slackAlerts: ['digital-general', 'alerts-channel'],
   },
   {
     url: 'https://api.wellcomecollection.org/catalogue/v2/works/tp3rer3n',

--- a/updown/updown.ts
+++ b/updown/updown.ts
@@ -36,7 +36,7 @@ export const getAlertRecipients = async (
     );
   const email = recipients.data.find(r => r.type === 'email')?.id;
   const platformChannel = recipients.data.find(
-    r => r.type === 'slack' && r.name.endsWith('#digital-platform')
+    r => r.type === 'slack' && r.name.endsWith('digital-general')
   )?.id;
   const alertsChannel = recipients.data.find(
     r => r.type === 'slack' && r.name.endsWith('platform-alerts')
@@ -53,7 +53,7 @@ export const getAlertRecipients = async (
       recipients.add(email);
     }
     if (
-      desiredCheck.slackAlerts?.includes('platform-channel') &&
+      desiredCheck.slackAlerts?.includes('digital-general') &&
       platformChannel
     ) {
       recipients.add(platformChannel);


### PR DESCRIPTION
## What does this change?

We changed the names of Slack channels a while back, but our Updown integration was still considering "digital-platform" to be what is now "digital-general". To ensure the alerts are posted in the correct channel, we've made these changes.

I've already done the bit on the Updown dashboard itself that should ensure the integration works well.

## How to test

Unsure tbh, we'll see if we get alerts at some point?

## How can we measure success?

Warned in the correct channel should anything be going haywire.

## Have we considered potential risks?

N/A