### PR TITLE
Fix broken /opening-times redirection

### DIFF
--- a/cache/edge_lambdas/src/redirects.ts
+++ b/cache/edge_lambdas/src/redirects.ts
@@ -83,7 +83,7 @@ export const literalRedirects: Record<string, string> = {
   '/installations/WyuWLioAACkACeYv': '/exhibitions/the-pharmacy-of-colour',
   '/MakingNature': '/exhibitions/making-nature',
   '/medieval-bodies': '/books/medieval-bodies',
-  '/opening-times': '/pages/opening-time',
+  '/opening-times': '/pages/opening-times',
   '/packed-lunch': '/event-series/packed-lunch',
   '/press': '/pages/press',
   '/press/‘forensics-anatomy-crime’-opens-wellcome-collection':

--- a/cache/locals.tf
+++ b/cache/locals.tf
@@ -3,8 +3,8 @@ data "aws_secretsmanager_secret_version" "slack_webhook" {
 }
 
 locals {
-  edge_lambda_request_version  = 136
-  edge_lambda_response_version = 134
+  edge_lambda_request_version  = 137
+  edge_lambda_response_version = 135
 
   wellcome_cdn_cert_arn = "arn:aws:acm:us-east-1:130871440101:certificate/bb840c52-56bb-4bf8-86f8-59e7deaf9c98"
 


### PR DESCRIPTION
## What does this change?

> [!Note]
> This change has been applied!

This pull request includes a few small changes to correct a typo in a redirect URL and update version numbers for edge lambda requests and responses.

Follows:
- https://github.com/wellcomecollection/wellcomecollection.org/pull/11308
- https://github.com/wellcomecollection/wellcomecollection.org/pull/11311

Changes to redirect URLs:

* [`cache/edge_lambdas/src/redirects.ts`](diffhunk://#diff-e6fb2203ddad8ffdd26f180815ff76fae4d709a2a769c18a61039917a71f5d10L86-R86): Corrected the URL for the `/opening-times` redirect to `/pages/opening-times`.

Updates to version numbers:

* [`cache/locals.tf`](diffhunk://#diff-c1ecd0afc8282ce31d400736b1fb4e73d832eafa42261b35630fe3687636369dL6-R7): Updated `edge_lambda_request_version` to 137 and `edge_lambda_response_version` to 135.

We follow the deployment instructions in https://github.com/wellcomecollection/wellcomecollection.org/tree/main/cache/edge_lambdas to deploy and apply terraform changes as required to roll this out.

## How to test

Check that we are redirected to the correct URL and that it returns a 200, not a 404.

Stage:
```
curl -Ls -o /dev/null -w "%{http_code} %{url_effective}" https://www-stage.wellcomecollection.org/opening-times
200 https://www-stage.wellcomecollection.org/pages/opening-times%  
```

Production:
```
curl -Ls -o /dev/null -w "%{http_code} %{url_effective}" https://wellcomecollection.org/opening-times 
200 https://wellcomecollection.org/pages/opening-times%  
```

## How can we measure success?

Users can find when we're open!

## Have we considered potential risks?

This change should be confined to a single URL and can be easily rolled back in production by reversing the lambda version change.
