### PR TITLE
Apply v138 v136 lambda

### DIFF
--- a/cache/locals.tf
+++ b/cache/locals.tf
@@ -3,8 +3,8 @@ data "aws_secretsmanager_secret_version" "slack_webhook" {
 }
 
 locals {
-  edge_lambda_request_version  = 137
-  edge_lambda_response_version = 135
+  edge_lambda_request_version  = 138
+  edge_lambda_response_version = 136
 
   wellcome_cdn_cert_arn = "arn:aws:acm:us-east-1:130871440101:certificate/bb840c52-56bb-4bf8-86f8-59e7deaf9c98"
 


### PR DESCRIPTION
## What does this change?

Applies changes from https://github.com/wellcomecollection/wellcomecollection.org/pull/11248/files

## How to test

Will apply terraform once merged.

## How can we measure success?

Redirects work and we have the new URL structure for pages!

## Have we considered potential risks?

This will affect browsing for the time it takes for the lambda to apply, so buggy behaviour should be ignored for about 10 mins. I will clear the cache in Cloudfront, but we'll have to keep an eye out. I will also let people know in Slack.