### PR TITLE
Fixing various lines of code that referred to ID instead of UID

### DIFF
--- a/common/services/prismic/index.ts
+++ b/common/services/prismic/index.ts
@@ -1,9 +1,8 @@
-// Returns true if a query parameter is plausibly a Prismic ID, false otherwise.
+// Returns true if a query parameter is plausibly a Prismic UID, false otherwise.
+// It could also be used to check for valid Prismic IDs, even though we don't use those as heavily anymore.
 //
-// There's no way for the front-end to know what strings are valid Prismic IDs
-// (only Prismic itself knows that), but it can reject certain classes of
-// strings that it knows definitely aren't.
-//
+// Any low-ascii characte based string will be considered a valid Prismic UID,
+// but this still helps reject certain classes of strings that it knows definitely aren't.
 // e.g. an empty string definitely isn't a Prismic ID.
 //
 // This is useful for rejecting queries that are obviously malformed, which might

--- a/content/webapp/__mocks__/whats-on.ts
+++ b/content/webapp/__mocks__/whats-on.ts
@@ -92,6 +92,7 @@ export const whatsOn: ({
 }: {
   hasExhibitions: boolean;
 }) => WhatsOnProps = ({ hasExhibitions }) => ({
+  pageId: 'XNFfsxAAANwqbNWD',
   period: 'current-and-coming-up',
   exhibitions: hasExhibitions ? [beingHuman] : [],
   events: [],

--- a/content/webapp/pages/index.tsx
+++ b/content/webapp/pages/index.tsx
@@ -70,6 +70,7 @@ const CreamBox = styled(Space).attrs({
 `;
 
 type Props = {
+  pageId: string;
   exhibitions: ExhibitionBasic[];
   nextSevenDaysEvents: EventBasic[];
   articles: ArticleBasic[];
@@ -150,6 +151,7 @@ export const getServerSideProps: GetServerSideProps<
   if (events && exhibitions && articles && page) {
     return {
       props: serialiseProps({
+        pageId: page.id,
         articles: basicArticles,
         serverData,
         jsonLd,
@@ -177,6 +179,7 @@ const Homepage: FunctionComponent<Props> = ({
   untransformedStandfirst,
   transformedHeaderList,
   transformedContentList,
+  pageId,
 }) => {
   return (
     <>
@@ -212,7 +215,7 @@ const Homepage: FunctionComponent<Props> = ({
         jsonLd={jsonLd}
         openGraphType="website"
         image={pageImage}
-        apiToolbarLinks={[createPrismicLink(homepageId)]}
+        apiToolbarLinks={[createPrismicLink(pageId)]}
       >
         <ContaineredLayout gridSizes={gridSize10(false)}>
           <SpacingSection>

--- a/content/webapp/pages/visual-stories/[visualStoryId].tsx
+++ b/content/webapp/pages/visual-stories/[visualStoryId].tsx
@@ -15,6 +15,7 @@ import { isPast } from '@weco/common/utils/dates';
 import { capitalize } from '@weco/common/utils/grammar';
 import { serialiseProps } from '@weco/common/utils/json';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
+import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 import Divider from '@weco/common/views/components/Divider/Divider';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 import {
@@ -260,6 +261,7 @@ const VisualStory: FunctionComponent<Props> = ({
       openGraphType="website"
       hideNewsletterPromo={true}
       siteSection={visualStory.siteSection}
+      apiToolbarLinks={[createPrismicLink(visualStory.id)]}
     >
       <ContentPage
         id={visualStory.id}

--- a/content/webapp/pages/whats-on/index.tsx
+++ b/content/webapp/pages/whats-on/index.tsx
@@ -106,6 +106,7 @@ const tabItems = [
 ];
 
 export type Props = {
+  pageId: string;
   exhibitions: ExhibitionBasic[];
   events: EventBasic[];
   availableOnlineEvents: EventBasic[];
@@ -379,6 +380,7 @@ export const getServerSideProps: GetServerSideProps<
 
     return {
       props: serialiseProps({
+        pageId: whatsOnPage.id,
         period,
         exhibitions,
         events: basicEvents,
@@ -396,6 +398,7 @@ export const getServerSideProps: GetServerSideProps<
 
 const WhatsOnPage: FunctionComponent<Props> = props => {
   const {
+    pageId,
     period,
     exhibitions,
     events,
@@ -440,7 +443,7 @@ const WhatsOnPage: FunctionComponent<Props> = props => {
       openGraphType="website"
       siteSection="whats-on"
       image={firstExhibition && firstExhibition.promo?.image}
-      apiToolbarLinks={[createPrismicLink(prismicPageIds.whatsOn)]}
+      apiToolbarLinks={[createPrismicLink(pageId)]}
     >
       <>
         <Header

--- a/playwright/test/helpers/contexts.ts
+++ b/playwright/test/helpers/contexts.ts
@@ -236,7 +236,7 @@ const article = async (
   page: Page
 ): Promise<void> => {
   await context.addCookies(requiredCookies);
-  await gotoWithoutCache(`${baseUrl}/articles/${id}`, page);
+  await gotoWithoutCache(`${baseUrl}/stories/${id}`, page);
 };
 
 const articleWithMockSiblings = async (
@@ -251,7 +251,7 @@ const articleWithMockSiblings = async (
       body: JSON.stringify(response),
     })
   );
-  await gotoWithoutCache(`${baseUrl}/articles/${id}`, page);
+  await gotoWithoutCache(`${baseUrl}/stories/${id}`, page);
 };
 
 const concept = async (


### PR DESCRIPTION
## What does this change?

#11292 

We had various checks to make as we got further in the ID->UID and URL structure changes, so this covers them. 

- A few "Edit in Prismic" links (API Toolbar) had to be amended to use the document's ID and not its UID.
  - I'd noted Visual Story pages didn't have that link so I added it in-
- Amended comment for `looksLikePrismicId`. We're happy to consider `Id` as referring to either Prismic ID OR UIDs as they are both identifiers. If we want to change that in the future, we can address it then.
- Amended a few playwright repo-links so they'd follow their new URL structure. Redirects are in place, ensuring these links still work, but good to have their newest version in our code.

## How to test

Run locally, test "Edit in Prismic links'.

## How can we measure success?

Tidier codebase not living in the past ✨ 

## Have we considered potential risks?
N/A