### PR TITLE
Lambda redirects

### DIFF
--- a/cache/edge_lambdas/src/redirector.test.ts
+++ b/cache/edge_lambdas/src/redirector.test.ts
@@ -45,6 +45,45 @@ test('It returns 301 responses for URLs with defined redirects', () => {
   });
 });
 
+test('It returns 301 responses for articles URLs with defined redirects', () => {
+  // Should have been redirected
+  const redirectedResponse = getRedirect(
+    request({ uri: '/articles/X61xYhMAACAAX_z1' })
+  );
+
+  expect(redirectedResponse?.status).toEqual('301');
+  expect(redirectedResponse?.headers.location[0]).toEqual({
+    key: 'Location',
+    value: `https://wellcomecollection.org/stories/to-err-is-human`,
+  });
+});
+
+test('It returns 301 responses for previously redirected URLs with defined redirects', () => {
+  // Should have been redirected
+  const redirectedResponse = getRedirect(
+    request({ uri: '/articles/to-err-is-human' })
+  );
+
+  expect(redirectedResponse?.status).toEqual('301');
+  expect(redirectedResponse?.headers.location[0]).toEqual({
+    key: 'Location',
+    value: `https://wellcomecollection.org/stories/to-err-is-human`,
+  });
+});
+
+test('It returns 301 for articles URLs without defined redirects', () => {
+  // Should have been redirected
+  const redirectedResponse = getRedirect(
+    request({ uri: '/articles/anything' })
+  );
+
+  expect(redirectedResponse?.status).toEqual('301');
+  expect(redirectedResponse?.headers.location[0]).toEqual({
+    key: 'Location',
+    value: `https://wellcomecollection.org/stories/anything`,
+  });
+});
+
 test('It returns nothing for URLs without defined redirects', () => {
   const nonRedirectedResponse = getRedirect(request({ uri: '/visit-us/' }));
   expect(nonRedirectedResponse).toBeUndefined();

--- a/cache/edge_lambdas/src/redirector.ts
+++ b/cache/edge_lambdas/src/redirector.ts
@@ -80,6 +80,13 @@ export const getRedirect = (
         ? 'www-e2e.wellcomecollection.org'
         : 'wellcomecollection.org';
 
+  if (
+    uriSansSlash.startsWith('/articles') &&
+    literalRedirects[uriSansSlash] === undefined
+  ) {
+    return redirect301(host, uriSansSlash.replace(/^\/articles/, '/stories'));
+  }
+
   if (literalRedirects[uriSansSlash]) {
     return redirect301(host, literalRedirects[uriSansSlash]);
   }

--- a/cache/edge_lambdas/src/redirects.ts
+++ b/cache/edge_lambdas/src/redirects.ts
@@ -23,22 +23,22 @@ export const literalRedirects: Record<string, string> = {
   '/access': '/pages/accessibility',
   '/alice-anderson':
     '/exhibitions/alice-anderson--memory-movement-memory-objects',
-  '/articles/aids-posters-0': '/articles/aids-posters',
-  '/articles/hysteria': '/articles/what-is-hysteria', // "hysteria" already taken by ZN-ELxEAACMABO5a in former UID.
   '/articles': '/search/stories',
   '/stories/comic': '/search/stories?format=W7d_ghAAALWY3Ujc',
+  '/articles/aids-posters-0': '/stories/aids-posters',
+  '/articles/hysteria': '/stories/what-is-hysteria', // "hysteria" already taken by ZN-ELxEAACMABO5a in former UID.
   '/articles/lustmord':
-    '/articles/lustmord-and-the-three-perspectives-of-murder',
+    '/stories/lustmord-and-the-three-perspectives-of-murder',
   // Webcomic -> Story of type Comic.
-  '/articles/X5rs7RIAAB4Avr_r': '/articles/what-distinguishes-the-human-',
-  '/articles/X61xYhMAACAAX_z1': '/articles/to-err-is-human',
-  '/articles/X6P6_xMAACEANfQB': '/articles/stuff-humans-like',
-  '/articles/X7bJORMAACEAiRPo': '/articles/humans-are-social-animals',
-  '/articles/X8Ay3hIAACMAbSL2': '/articles/stuff-humans-don-t-like',
-  '/articles/X_dsXREAACMASftU': '/articles/january-diet',
+  '/articles/X5rs7RIAAB4Avr_r': '/stories/what-distinguishes-the-human-',
+  '/articles/X61xYhMAACAAX_z1': '/stories/to-err-is-human',
+  '/articles/X6P6_xMAACEANfQB': '/stories/stuff-humans-like',
+  '/articles/X7bJORMAACEAiRPo': '/stories/humans-are-social-animals',
+  '/articles/X8Ay3hIAACMAbSL2': '/stories/stuff-humans-don-t-like',
+  '/articles/X_dsXREAACMASftU': '/stories/january-diet',
   //
   '/articles/xksu0xiaadlrl4-h':
-    '/articles/enduring-taboos-and-the-future-of-skin-bleaching',
+    '/stories/enduring-taboos-and-the-future-of-skin-bleaching',
   '/ayurvedic-man':
     '/exhibitions/ayurvedic-man--encounters-with-indian-medicine',
   '/bedlam': '/exhibitions/bedlam--the-asylum-and-beyond',

--- a/cache/edge_lambdas/src/redirects.ts
+++ b/cache/edge_lambdas/src/redirects.ts
@@ -25,6 +25,8 @@ export const literalRedirects: Record<string, string> = {
     '/exhibitions/alice-anderson--memory-movement-memory-objects',
   '/articles/aids-posters-0': '/articles/aids-posters',
   '/articles/hysteria': '/articles/what-is-hysteria', // "hysteria" already taken by ZN-ELxEAACMABO5a in former UID.
+  '/articles': '/search/stories',
+  '/stories/comic': '/search/stories?format=W7d_ghAAALWY3Ujc',
   '/articles/lustmord':
     '/articles/lustmord-and-the-three-perspectives-of-murder',
   // Webcomic -> Story of type Comic.


### PR DESCRIPTION
## What does this change?

For #11343

As described in the ticket, it adds the articles redirects to the edge lambda. Once these are deployed and working we can then remove the redirects from the next.config.

## How to test

I've added some tests to the redirector.test.ts, to cover the various scenarios for articles.

Can run with `yarn test src/redirector.test.ts` in the edge_lambdas folder

## How can we measure success?

Can't really until we remove the next redirects and they continue to work

## Have we considered potential risks?

None for this, if it doesn't work at this point we still have the redirects in the next app

