### PR TITLE
Fix Page preview link

### DIFF
--- a/common/model/site-section.ts
+++ b/common/model/site-section.ts
@@ -1,0 +1,15 @@
+const siteSectionList = [
+  'visit-us',
+  'whats-on',
+  'stories',
+  'collections',
+  'get-involved',
+  'about-us',
+  'exhibition-guides',
+] as const;
+export type SiteSection = (typeof siteSectionList)[number];
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const isSiteSection = (section: any): section is SiteSection => {
+  return siteSectionList.includes(section);
+};

--- a/common/services/prismic/link-resolver.ts
+++ b/common/services/prismic/link-resolver.ts
@@ -1,21 +1,22 @@
-import { SiteSection } from '@weco/common/views/components/PageLayout/PageLayout';
+import { isSiteSection, SiteSection } from '@weco/common/model/site-section';
 
 import { isContentType } from './content-types';
 
 type Props = {
   uid?: string;
   type: string;
+  siteSection?: SiteSection;
 };
 type DataProps = {
   uid?: string;
   type: string;
+  tags: string[];
   data: {
     relatedDocument?: {
       uid: string;
       type: string;
     };
   };
-  siteSection: SiteSection;
 };
 
 function linkResolver(doc: Props | DataProps): string {
@@ -28,6 +29,7 @@ function linkResolver(doc: Props | DataProps): string {
   if (type === 'articles') return `/stories/${uid}`;
   if (type === 'webcomics') return `/stories/${uid}`;
   if (type === 'webcomic-series') return `/series/${uid}`;
+
   if (
     type === 'exhibition-guides' ||
     type === 'exhibition-texts' ||
@@ -52,6 +54,10 @@ function linkResolver(doc: Props | DataProps): string {
   if (type === 'pages') {
     if ('siteSection' in doc) {
       return `${doc.siteSection}/${uid}`;
+    } else if ('tags' in doc) {
+      // Needed for Prismic previews
+      const docSiteSection = doc.tags.find(t => isSiteSection(t));
+      return `${docSiteSection ? '/' + docSiteSection : ''}/${uid}`;
     }
     return `/${uid}`;
   }

--- a/common/services/prismic/link-resolver.ts
+++ b/common/services/prismic/link-resolver.ts
@@ -57,6 +57,10 @@ function linkResolver(doc: Props | DataProps): string {
     } else if ('tags' in doc) {
       // Needed for Prismic previews
       const docSiteSection = doc.tags.find(t => isSiteSection(t));
+
+      const isLandingPage = docSiteSection === uid;
+      if (isLandingPage) return `/${uid}`;
+
       return `${docSiteSection ? '/' + docSiteSection : ''}/${uid}`;
     }
     return `/${uid}`;

--- a/common/views/components/Header/Header.tsx
+++ b/common/views/components/Header/Header.tsx
@@ -13,10 +13,10 @@ import { prismicPageIds } from '@weco/common/data/hardcoded-ids';
 import { searchLabelText } from '@weco/common/data/microcopy';
 import { cross, search } from '@weco/common/icons';
 import WellcomeCollectionBlack from '@weco/common/icons/wellcome_collection_black';
+import { SiteSection } from '@weco/common/model/site-section';
 import { font } from '@weco/common/utils/classnames';
 import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
 import Icon from '@weco/common/views/components/Icon/Icon';
-import { SiteSection } from '@weco/common/views/components/PageLayout/PageLayout';
 
 import DesktopSignIn from './DesktopSignIn';
 import {

--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -8,6 +8,7 @@ import { defaultPageTitle } from '@weco/common/data/microcopy';
 import { wellcomeCollectionGallery } from '@weco/common/data/organization';
 import { getCrop, ImageType } from '@weco/common/model/image';
 import { Url } from '@weco/common/model/link-props';
+import { SiteSection } from '@weco/common/model/site-section';
 import { usePrismicData, useToggles } from '@weco/common/server-data/Context';
 import { getVenueById } from '@weco/common/services/prismic/opening-times';
 import { transformCollectionVenues } from '@weco/common/services/prismic/transformers/collection-venues';
@@ -35,22 +36,6 @@ import {
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 import NewsletterPromo from '@weco/common/views/components/NewsletterPromo/NewsletterPromo';
 import PopupDialog from '@weco/common/views/components/PopupDialog/PopupDialog';
-
-const siteSectionList = [
-  'visit-us',
-  'whats-on',
-  'stories',
-  'collections',
-  'get-involved',
-  'about-us',
-  'exhibition-guides',
-] as const;
-export type SiteSection = (typeof siteSectionList)[number];
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const isSiteSection = (section: any): section is SiteSection => {
-  return siteSectionList.includes(section);
-};
 
 type HeaderProps = {
   customNavLinks: NavLink[];

--- a/content/webapp/components/SearchPageLayout/SearchPageLayout.tsx
+++ b/content/webapp/components/SearchPageLayout/SearchPageLayout.tsx
@@ -9,9 +9,9 @@ import {
 } from 'react';
 
 import { pageDescriptions } from '@weco/common/data/microcopy';
+import { SiteSection } from '@weco/common/model/site-section';
 import { getQueryPropertyValue } from '@weco/common/utils/search';
 import { ApiToolbarLink } from '@weco/common/views/components/ApiToolbar';
-import { SiteSection } from '@weco/common/views/components/PageLayout/PageLayout';
 import { Container } from '@weco/common/views/components/styled/Container';
 import CataloguePageLayout from '@weco/content/components/CataloguePageLayout/CataloguePageLayout';
 

--- a/content/webapp/pages/guides/[guideId].tsx
+++ b/content/webapp/pages/guides/[guideId].tsx
@@ -1,6 +1,7 @@
 import { GetServerSideProps } from 'next';
 import { FunctionComponent } from 'react';
 
+import { SiteSection } from '@weco/common/model/site-section';
 import { getServerData } from '@weco/common/server-data';
 import { AppErrorProps } from '@weco/common/services/app';
 import { looksLikePrismicId } from '@weco/common/services/prismic';
@@ -14,9 +15,7 @@ import { HTMLDate } from '@weco/common/views/components/HTMLDateAndTime';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 import { makeLabels } from '@weco/common/views/components/LabelsList/LabelsList';
 import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
-import PageLayout, {
-  SiteSection,
-} from '@weco/common/views/components/PageLayout/PageLayout';
+import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import VideoEmbed from '@weco/common/views/components/VideoEmbed/VideoEmbed';
 import Body from '@weco/content/components/Body/Body';
 import ContentPage from '@weco/content/components/ContentPage/ContentPage';

--- a/content/webapp/pages/pages/[pageId].tsx
+++ b/content/webapp/pages/pages/[pageId].tsx
@@ -6,6 +6,7 @@ import {
   sectionLevelPages,
 } from '@weco/common/data/hardcoded-ids';
 import { getCrop } from '@weco/common/model/image';
+import { isSiteSection, SiteSection } from '@weco/common/model/site-section';
 import { EditorialImageSlice as RawEditorialImageSlice } from '@weco/common/prismicio-types';
 import { getServerData } from '@weco/common/server-data';
 import { AppErrorProps } from '@weco/common/services/app';
@@ -27,10 +28,7 @@ import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 import { makeLabels } from '@weco/common/views/components/LabelsList/LabelsList';
 import { gridSize12 } from '@weco/common/views/components/Layout';
 import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
-import PageLayout, {
-  isSiteSection,
-  SiteSection,
-} from '@weco/common/views/components/PageLayout/PageLayout';
+import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import PrismicImage from '@weco/common/views/components/PrismicImage/PrismicImage';
 import SpacingComponent from '@weco/common/views/components/styled/SpacingComponent';
 import SpacingSection from '@weco/common/views/components/styled/SpacingSection';

--- a/content/webapp/services/prismic/fetch/index.ts
+++ b/content/webapp/services/prismic/fetch/index.ts
@@ -2,6 +2,7 @@ import * as prismic from '@prismicio/client';
 import { GetServerSidePropsContext, NextApiRequest } from 'next';
 import fetch from 'node-fetch';
 
+import { SiteSection } from '@weco/common/model/site-section';
 import {
   ContentType,
   isContentType,
@@ -11,7 +12,6 @@ import { PaginatedResults } from '@weco/common/services/prismic/types';
 import { deserialiseDates as deserialiseJsonDates } from '@weco/common/utils/json';
 import { toMaybeString } from '@weco/common/utils/routes';
 import { isString } from '@weco/common/utils/type-guards';
-import { SiteSection } from '@weco/common/views/components/PageLayout/PageLayout';
 
 export type GetServerSidePropsPrismicClient = {
   type: 'GetServerSidePropsPrismicClient';

--- a/content/webapp/services/prismic/fetch/pages.ts
+++ b/content/webapp/services/prismic/fetch/pages.ts
@@ -1,7 +1,7 @@
 import * as prismic from '@prismicio/client';
 
+import { SiteSection } from '@weco/common/model/site-section';
 import { PagesDocument as RawPagesDocument } from '@weco/common/prismicio-types';
-import { SiteSection } from '@weco/common/views/components/PageLayout/PageLayout';
 import { labelsFields } from '@weco/content/services/prismic/fetch-links';
 import {
   articleFormatsFetchLinks,

--- a/content/webapp/services/prismic/transformers/guides.ts
+++ b/content/webapp/services/prismic/transformers/guides.ts
@@ -1,10 +1,10 @@
+import { SiteSection } from '@weco/common/model/site-section';
 import {
   GuideFormatsDocument as RawGuideFormatsDocument,
   GuidesDocument as RawGuidesDocument,
 } from '@weco/common/prismicio-types';
 import { transformTimestamp } from '@weco/common/services/prismic/transformers';
 import { links as headerLinks } from '@weco/common/views/components/Header/Header';
-import { SiteSection } from '@weco/common/views/components/PageLayout/PageLayout';
 import { Format } from '@weco/content/types/format';
 import { Guide } from '@weco/content/types/guides';
 

--- a/content/webapp/services/prismic/transformers/pages.ts
+++ b/content/webapp/services/prismic/transformers/pages.ts
@@ -1,5 +1,6 @@
 import flattenDeep from 'lodash.flattendeep';
 
+import { SiteSection } from '@weco/common/model/site-section';
 import {
   PagesDocument as RawPagesDocument,
   PagesDocumentData as RawPagesDocumentData,
@@ -9,7 +10,6 @@ import { transformTimestamp } from '@weco/common/services/prismic/transformers';
 import { dasherize } from '@weco/common/utils/grammar';
 import { isNotUndefined, isUndefined } from '@weco/common/utils/type-guards';
 import { links as headerLinks } from '@weco/common/views/components/Header/Header';
-import { SiteSection } from '@weco/common/views/components/PageLayout/PageLayout';
 import { Link } from '@weco/content/types/link';
 import { Page } from '@weco/content/types/pages';
 

--- a/content/webapp/services/prismic/transformers/projects.ts
+++ b/content/webapp/services/prismic/transformers/projects.ts
@@ -1,9 +1,9 @@
+import { SiteSection } from '@weco/common/model/site-section';
 import {
   ProjectsDocument as RawProjectsDocument,
   SeasonsDocument as RawSeasonsDocument,
 } from '@weco/common/prismicio-types';
 import { links as headerLinks } from '@weco/common/views/components/Header/Header';
-import { SiteSection } from '@weco/common/views/components/PageLayout/PageLayout';
 import { Project } from '@weco/content/types/projects';
 
 import {

--- a/content/webapp/services/prismic/transformers/visual-stories.ts
+++ b/content/webapp/services/prismic/transformers/visual-stories.ts
@@ -1,10 +1,10 @@
 import * as prismic from '@prismicio/client';
 
+import { SiteSection } from '@weco/common/model/site-section';
 import { VisualStoriesDocument as RawVisualStoriesDocument } from '@weco/common/prismicio-types';
 import { transformTimestamp } from '@weco/common/services/prismic/transformers';
 import { isFilledLinkToDocumentWithData } from '@weco/common/services/prismic/types';
 import { links as headerLinks } from '@weco/common/views/components/Header/Header';
-import { SiteSection } from '@weco/common/views/components/PageLayout/PageLayout';
 import { VisualStory } from '@weco/content/types/visual-stories';
 
 import { asText, transformGenericFields } from '.';

--- a/content/webapp/types/card.ts
+++ b/content/webapp/types/card.ts
@@ -1,6 +1,6 @@
 import { getCrop, ImageType } from '@weco/common/model/image';
+import { SiteSection } from '@weco/common/model/site-section';
 import linkResolver from '@weco/common/services/prismic/link-resolver';
-import { SiteSection } from '@weco/common/views/components/PageLayout/PageLayout';
 import { ArticleBasic } from '@weco/content/types/articles';
 import { Book } from '@weco/content/types/books';
 import { EventSeries } from '@weco/content/types/event-series';
@@ -62,7 +62,6 @@ export function convertItemToCardProps(
           id: item.id,
           uid: item.uid,
           type: item.type,
-          siteSection: 'siteSection' in item ? item.siteSection : undefined,
           data: { relatedDocument: item.relatedDocument },
         }
       : {

--- a/content/webapp/types/card.ts
+++ b/content/webapp/types/card.ts
@@ -62,6 +62,7 @@ export function convertItemToCardProps(
           id: item.id,
           uid: item.uid,
           type: item.type,
+          tags: 'tags' in item ? item.tags : [],
           data: { relatedDocument: item.relatedDocument },
         }
       : {

--- a/content/webapp/types/guides.ts
+++ b/content/webapp/types/guides.ts
@@ -1,4 +1,4 @@
-import { SiteSection } from '@weco/common/views/components/PageLayout/PageLayout';
+import { SiteSection } from '@weco/common/model/site-section';
 
 import { Format } from './format';
 import { GenericContentFields } from './generic-content-fields';

--- a/content/webapp/types/pages.ts
+++ b/content/webapp/types/pages.ts
@@ -1,4 +1,4 @@
-import { SiteSection } from '@weco/common/views/components/PageLayout/PageLayout';
+import { SiteSection } from '@weco/common/model/site-section';
 
 import { Contributor } from './contributors';
 import { Format } from './format';

--- a/content/webapp/types/projects.ts
+++ b/content/webapp/types/projects.ts
@@ -1,4 +1,4 @@
-import { SiteSection } from '@weco/common/views/components/PageLayout/PageLayout';
+import { SiteSection } from '@weco/common/model/site-section';
 
 import { Contributor } from './contributors';
 import { Format } from './format';

--- a/content/webapp/types/visual-stories.ts
+++ b/content/webapp/types/visual-stories.ts
@@ -1,5 +1,5 @@
 import { ImageType } from '@weco/common/model/image';
-import { SiteSection } from '@weco/common/views/components/PageLayout/PageLayout';
+import { SiteSection } from '@weco/common/model/site-section';
 import { ImagePromo } from '@weco/content/types/image-promo';
 
 import { GenericContentFields } from './generic-content-fields';


### PR DESCRIPTION
## What does this change?
#11346 
Moves `siteSection` types and type guard into `model` folder.
Amend `linkResolver` to account for untransformed data (which was causing the link to be wrong).

I don't fully grasp why I couldn't import `isSiteSection` from `PageLayout` (build was breaking). I know it had to do with the code not being able to compile properly. I moved it into `model` as anyway it seems to be where we keep types.

## How to test

Run locally and preview a Prismic `Page` locally, see if the URL makes sense and you can actually preview it.

## How can we measure success?

No more broken previewing of Pages!

## Have we considered potential risks?
N/A