### PR TITLE
Stop landing pages from rendering at the dynamic route

### DIFF
--- a/content/webapp/pages/pages/[pageId].tsx
+++ b/content/webapp/pages/pages/[pageId].tsx
@@ -110,7 +110,11 @@ export const getServerSideProps: GetServerSideProps<
   const { pageId } = context.query;
   const siteSection = toMaybeString(context.params?.siteSection);
 
-  if (!looksLikePrismicId(pageId)) {
+  const isLandingPageRenderingAsSubPage =
+    pageId === siteSection &&
+    context.resolvedUrl === `/${siteSection}/${pageId}`;
+
+  if (!looksLikePrismicId(pageId) || isLandingPageRenderingAsSubPage) {
     return { notFound: true };
   }
 


### PR DESCRIPTION
## What does this change?

Currently in prod, we render all pages tagged with the correct section at `/[section]/[uid]`, which means that the landing page (e.g. 'visit-us'), which is tagged with the 'visit-us' section, also renders there: https://wellcomecollection.org/visit-us/visit-us

We never link to that URL, but I'm thinking we also don't want to allow it, so this covers that.

## How to test

Run locally and try all landing, like http://localhost:3000/visit-us/visit-us (or get-involved, or about-us)
Make sure it doesn't break anything that _should_ work though.

## How can we measure success?

Just less confusion and clearer rules for Page paths.

## Have we considered potential risks?
N/A if we test right and tests pass.