### PR TITLE
Upgrade `faker` to v9

### DIFF
--- a/cardigan/package.json
+++ b/cardigan/package.json
@@ -8,7 +8,7 @@
     "chromatic": "chromatic --only-changed"
   },
   "dependencies": {
-    "@faker-js/faker": "^8.4.1",
+    "@faker-js/faker": "^9.1.0",
     "@storybook/addon-a11y": "^8.3.5",
     "@storybook/addon-backgrounds": "^8.3.5",
     "@storybook/addon-controls": "^8.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2906,10 +2906,10 @@
   dependencies:
     heap ">= 0.2.0"
 
-"@faker-js/faker@^8.4.1":
-  version "8.4.1"
-  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-8.4.1.tgz#5d5e8aee8fce48f5e189bf730ebd1f758f491451"
-  integrity sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==
+"@faker-js/faker@^9.1.0":
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-9.1.0.tgz#5d7957df87e2fb0eee5dcfd311ba83b34ec8eead"
+  integrity sha512-GJvX9iM9PBtKScJVlXQ0tWpihK3i0pha/XAhzQa1hPK/ILLa1Wq3I63Ij7lRtqTwmdTxRCyrUhLC5Sly9SLbug==
 
 "@formatjs/intl-localematcher@^0.5.2":
   version "0.5.4"


### PR DESCRIPTION
## What does this change?

Upgrade `faker` to latest version. Migration guide didn't indicate anything we had to change (we use it quite minimally and weren't using deprecated functions).

## How to test

Is Cardigan flagging any changes? If not, we're good.

(Update: It did flag changes but just because it's using different random things, which tends to happen when we update the package. They are still working perfectly: https://www.chromatic.com/build?appId=62f13cdbd0ff140768a8d87b&number=6803)

## How can we measure success?

Package upgrade yay

## Have we considered potential risks?
N/A