### PR TITLE
If `getByUid` can't return a basic document, try `getById`

### DIFF
--- a/content/webapp/services/prismic/fetch/index.ts
+++ b/content/webapp/services/prismic/fetch/index.ts
@@ -94,7 +94,8 @@ export function fetcher<Document extends prismic.PrismicDocument>(
   return {
     getById: async (
       { client }: GetServerSidePropsPrismicClient,
-      id: string
+      id: string,
+      params?: { graphQuery?: string }
     ): Promise<Document | undefined> => {
       try {
         // This means that Prismic will only return the document with the given ID if
@@ -105,10 +106,17 @@ export function fetcher<Document extends prismic.PrismicDocument>(
           ? [prismic.filter.at('document.type', contentType)]
           : [prismic.filter.any('document.type', contentType)];
 
-        return await client.getByID<Document>(id, {
-          fetchLinks,
-          filters,
-        });
+        return await client.getByID<Document>(
+          id,
+          params?.graphQuery
+            ? {
+                graphQuery: params?.graphQuery,
+              }
+            : {
+                fetchLinks,
+                filters,
+              }
+        );
       } catch {}
     },
 

--- a/content/webapp/services/prismic/fetch/pages.ts
+++ b/content/webapp/services/prismic/fetch/pages.ts
@@ -77,13 +77,20 @@ export const fetchBasicPage = async (
   client: GetServerSidePropsPrismicClient,
   id: string
 ): Promise<RawPagesDocument | undefined> => {
-  const pageDocument = await pagesFetcher.getByUid(client, id, undefined, {
-    graphQuery: `{
+  // This allows for the most basic document to be returned, with an empty data object.
+  const graphQuery = `{
         pages {
           uid
         }
-      }`.replace(/\n(\s+)/g, '\n'),
-  });
+      }`.replace(/\n(\s+)/g, '\n');
+
+  const pageDocument =
+    (await pagesFetcher.getByUid(client, id, undefined, {
+      graphQuery,
+    })) ||
+    (await pagesFetcher.getById(client, id, {
+      graphQuery,
+    }));
 
   return pageDocument;
 };


### PR DESCRIPTION
## What does this change?

If `getByUid` (for `getBasicDocument`) returns undefined, try `getById` with the same `graphQuery`. 

This causes pages like `pages/YDaP2BMAACUAT7DS` to not redirect to `[siteSection]/[uid]` and therefore renders them as 404, breaking many bookmarked pages.

## How to test

Run locally
Can you access the database page through http://localhost:3000/pages/YDaP2BMAACUAT7DS ?
Can you still render other pages by ID without any issues caused by the changes to `getById`? (e.g. http://localhost:3000/stories/XuNqyRIAACIArun9)

Any other scenario you can think of

## How can we measure success?

Fixes many many broken bookmarked pages or pages that are linked to from their ID based URL.

## Have we considered potential risks?
Breaks something else?