### PR TITLE
Import correct `ContaineredLayout` for `CollectionVenue`

### DIFF
--- a/common/views/slices/CollectionVenue/index.tsx
+++ b/common/views/slices/CollectionVenue/index.tsx
@@ -2,7 +2,7 @@ import { SliceComponentProps } from '@prismicio/react';
 import { FunctionComponent } from 'react';
 
 import { CollectionVenueSlice as RawCollectionVenueSlice } from '@weco/common/prismicio-types';
-import ContaineredLayout from '@weco/common/views/components/Layout';
+import { ContaineredLayout } from '@weco/common/views/components/Layout';
 import SpacingComponent from '@weco/common/views/components/styled/SpacingComponent';
 import {
   LayoutWidth,


### PR DESCRIPTION
## What does this change?

[When we created `ContaineredLayout` and amended the imports to reference the correct one](https://github.com/wellcomecollection/wellcomecollection.org/pull/11267) (`ContaineredLayout` vs the default `Layout`), we didn't do it properly in this file. So it was rendering with `Layout` as it's the default.

[Related Slack convo](https://wellcome.slack.com/archives/CUA669WHH/p1729852658133759)

## How to test

http://localhost:3000/visit-us/opening-times
http://localhost:3000/visit-us/the-library

## How can we measure success?

Looking gooood.

## Have we considered potential risks?
N/A