### PR TITLE
Add `koa*` packages to dependabot ignore list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,10 @@ updates:
       - dependency-name: '@slicemachine'
       # Needs more work, has its own ticket. Remove this once it's done.
       - dependency-name: 'eslint*'
+      # Needs untangling, has its own ticket. Remove this once it's done.
+      - dependency-name: '@types/koa*'
+      - dependency-name: 'koa*'
+      - dependency-name: '@koa*'
     groups:
       all:
         patterns: ['*']


### PR DESCRIPTION
## What does this change?

The `koa*` packages are a proper puzzle, see "package upgrade" ticket for more info: https://github.com/wellcomecollection/wellcomecollection.org/issues/11366

## How to test

N/A

## How can we measure success?

The grouped updates PR Dependabot creates only has easy upgrades in it until we've figured out the more complex ones.

## Have we considered potential risks?
N/A