### PR TITLE
Lambdas `137`->`139` (resp) and `139`->`141` (req)

### DIFF
--- a/cache/locals.tf
+++ b/cache/locals.tf
@@ -3,8 +3,8 @@ data "aws_secretsmanager_secret_version" "slack_webhook" {
 }
 
 locals {
-  edge_lambda_request_version  = 139
-  edge_lambda_response_version = 137
+  edge_lambda_request_version  = 140
+  edge_lambda_response_version = 138
 
   wellcome_cdn_cert_arn = "arn:aws:acm:us-east-1:130871440101:certificate/bb840c52-56bb-4bf8-86f8-59e7deaf9c98"
 

--- a/cache/locals.tf
+++ b/cache/locals.tf
@@ -3,8 +3,8 @@ data "aws_secretsmanager_secret_version" "slack_webhook" {
 }
 
 locals {
-  edge_lambda_request_version  = 140
-  edge_lambda_response_version = 138
+  edge_lambda_request_version  = 141
+  edge_lambda_response_version = 139
 
   wellcome_cdn_cert_arn = "arn:aws:acm:us-east-1:130871440101:certificate/bb840c52-56bb-4bf8-86f8-59e7deaf9c98"
 


### PR DESCRIPTION
## What does this change?

Applies these changes 
[Fix code scanning alert no. 2: Incomplete URL substring sanitization](https://github.com/wellcomecollection/wellcomecollection.org/pull/11337)
[Redirect healing pavilion guides](https://github.com/wellcomecollection/wellcomecollection.org/pull/11365)

## How to test

N/A

## How can we measure success?

Up to date

## Have we considered potential risks?
Has been tested in staging and looks good, so I'd say low.
