### PR TITLE
Prismic linter: Add missing title to linting for guides

### DIFF
--- a/prismic-model/lintPrismicData.ts
+++ b/prismic-model/lintPrismicData.ts
@@ -170,7 +170,7 @@ function detectIncorrectAudioVideoDuration(doc: any): string[] {
     )
     .map(
       e =>
-        `The audio_duration for should be in the format xx:xx but it is ${e.primary.audio_duration}`
+        `The audio_duration for "${e.primary.title[0].text}" should be in the format xx:xx but it is ${e.primary.audio_duration}`
     );
   const videoErrors = guideStopSlices
     .filter(
@@ -180,7 +180,7 @@ function detectIncorrectAudioVideoDuration(doc: any): string[] {
     )
     .map(
       e =>
-        `The video_duration for should be in the format xx:xx but it is ${e.primary.video_duration}`
+        `The video_duration for "${e.primary.title[0].text}" should be in the format xx:xx but it is ${e.primary.video_duration}`
     );
 
   return [...audioErrors, ...videoErrors];


### PR DESCRIPTION
## What does this change?

A Prismic linting flag came up this morning and I noticed a missing part of the error message

<img width="687" alt="Screenshot 2024-11-01 at 09 41 47" src="https://github.com/user-attachments/assets/4fc8baa7-c5e3-4040-b895-1b3acc4ef6d2">

So I went in and added the slice title, you can see here as I mocked the script

<img width="957" alt="Screenshot 2024-11-01 at 09 53 59" src="https://github.com/user-attachments/assets/1c61fa0f-cbc9-407f-aec1-f8218446ebce">

## How to test

You could run `lintPrismicData` locally and mock failing content, but this is pretty low risk and impact and doesn't warrant the effort that much?

## How can we measure success?

Clarity over which video/audio duration to amend.

## Have we considered potential risks?
N/A