### PR TITLE
Move cookie policy page to its siteSection - about us

### DIFF
--- a/content/webapp/pages/about-us/cookie-policy.tsx
+++ b/content/webapp/pages/about-us/cookie-policy.tsx
@@ -18,9 +18,8 @@ import Space from '@weco/common/views/components/styled/Space';
 import SpacingComponent from '@weco/common/views/components/styled/SpacingComponent';
 import { components } from '@weco/common/views/slices';
 import Table from '@weco/content/components/Table';
+import * as page from '@weco/content/pages/pages/[pageId]';
 import { setCacheControl } from '@weco/content/utils/setCacheControl';
-
-import * as page from './pages/[pageId]';
 
 const CookieTable = ({ rows }: { rows: string[][] }) => {
   return (
@@ -54,7 +53,7 @@ const CookiePolicy: FunctionComponent<page.Props> = (props: page.Props) => {
       title={props.page.title}
       description={props.page.metadataDescription || ''}
       hideNewsletterPromo={true}
-      url={{ pathname: '/cookie-policy' }}
+      url={{ pathname: '/about-us/cookie-policy' }}
       jsonLd={{ '@type': 'WebPage' }}
       openGraphType="website"
       siteSection={props.page.siteSection}
@@ -101,6 +100,7 @@ export const getServerSideProps: GetServerSideProps<
   return page.getServerSideProps({
     ...context,
     query: { pageId: prismicPageIds.cookiePolicy },
+    params: { siteSection: 'about-us' },
   });
 };
 


### PR DESCRIPTION
## What does this change?

https://wellcomecollection.org/about-us/cookie-policy currently does not render the cookies tables.

![image](https://github.com/user-attachments/assets/11ecf84a-a1a6-4189-ad04-a8339f833fe0)

This is because it's not actually rendering where it should as, in the codebase, that page was considered an orphan (`/pages/cookie-policy.tsx`). It had to be moved to the correct route to use the "special" file we'd created for it in the codebase, in the meantime is was rendering as a normal page (using the code from `/pages/about-us/[uid].tsx`). It's why the Text slices were exposed as is, instead of being replaced with the cookie tables.


## How to test

Run locally
http://localhost:3000/about-us/cookie-policy with cookie tables
http://localhost:3000/cookie-policy should 404


## How can we measure success?

We're doing the right thing legally and showing people what cookies we're using etc.

## Have we considered potential risks?
N/A