### PR TITLE
Restricted thumbnails

### DIFF
--- a/content/webapp/components/IIIFViewer/IIIFCanvasThumbnail.tsx
+++ b/content/webapp/components/IIIFViewer/IIIFCanvasThumbnail.tsx
@@ -2,6 +2,7 @@ import { FunctionComponent, useState } from 'react';
 import styled from 'styled-components';
 
 import { font } from '@weco/common/utils/classnames';
+import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
 import LL from '@weco/common/views/components/styled/LL';
 import Space from '@weco/common/views/components/styled/Space';
 import { useUser } from '@weco/common/views/components/UserProvider/UserProvider';
@@ -78,6 +79,9 @@ const IIIFCanvasThumbnail: FunctionComponent<IIIFCanvasThumbnailProps> = ({
   const { user } = useUser();
   const role = user?.role;
   const isRestricted = canvas.hasRestrictedImage;
+  const urlTemplate = canvas.imageServiceId
+    ? iiifImageTemplate(canvas.imageServiceId)
+    : undefined;
 
   return (
     <IIIFViewerThumb>
@@ -97,7 +101,10 @@ const IIIFCanvasThumbnail: FunctionComponent<IIIFCanvasThumbnailProps> = ({
             <IIIFViewerImage
               highlightImage={highlightImage}
               width={canvas?.thumbnailImage?.width || 30}
-              src={canvas?.thumbnailImage?.url}
+              src={
+                canvas?.thumbnailImage?.url ||
+                (urlTemplate && urlTemplate({ size: '200,' }))
+              }
               srcSet=""
               sizes={`${canvas?.thumbnailImage?.width || 30}px`}
               alt=""

--- a/content/webapp/components/IIIFViewer/IIIFCanvasThumbnail.tsx
+++ b/content/webapp/components/IIIFViewer/IIIFCanvasThumbnail.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { font } from '@weco/common/utils/classnames';
 import LL from '@weco/common/views/components/styled/LL';
 import Space from '@weco/common/views/components/styled/Space';
+import { useUser } from '@weco/common/views/components/UserProvider/UserProvider';
 import { TransformedCanvas } from '@weco/content/types/manifest';
 
 import IIIFViewerImage from './IIIFViewerImage';
@@ -74,6 +75,8 @@ const IIIFCanvasThumbnail: FunctionComponent<IIIFCanvasThumbnailProps> = ({
   highlightImage,
 }: IIIFCanvasThumbnailProps) => {
   const [thumbnailLoaded, setThumbnailLoaded] = useState(false);
+  const { user } = useUser();
+  const role = user?.role;
   const isRestricted = canvas.hasRestrictedImage;
 
   return (
@@ -83,7 +86,7 @@ const IIIFCanvasThumbnail: FunctionComponent<IIIFCanvasThumbnailProps> = ({
           {!thumbnailLoaded && !isRestricted && (
             <LL $small={true} $lighten={true} />
           )}
-          {isRestricted ? (
+          {isRestricted && role !== 'StaffWithRestricted' ? (
             <>
               <Padlock />
               <span className="visually-hidden">

--- a/content/webapp/components/IIIFViewer/MainViewer.tsx
+++ b/content/webapp/components/IIIFViewer/MainViewer.tsx
@@ -210,7 +210,7 @@ function getPositionData({
   return highlightsPositioningData || [];
 }
 const ItemRenderer = memo(({ style, index, data }: ItemRendererProps) => {
-  const { scrollVelocity, canvases, externalAccessService, accessToken } = data;
+  const { scrollVelocity, canvases, externalAccessService } = data;
   const [mainLoaded, setMainLoaded] = useState(false);
   const currentCanvas = canvases[index];
   const { user } = useUser();


### PR DESCRIPTION
## What does this change?

Users with a role of 'StaffWithRestricted' were still seeing a padlock icon instead of the thumbnails:

![Screenshot 2024-11-01 at 14 11 01](https://github.com/user-attachments/assets/6e1418dd-7e07-4548-8d85-414b27c31d9f)

This displays a thumbnail image to them instead.

- uses the role in the conditional that determines whether to show the padlock or the thumbnail image
- falls back to the image service to provide a thumbnail image if there is no thumbnail service

## How to test

- login in a user that has the role of 'StaffWithRestricted'
- visit a page with restricted items localhost:3000/works/k2jjvqk2/items
- click on the thumbnails control and see thumbnail images

## How can we measure success?

users with a role of 'StaffWithRestricted' can see thumbnail images for restricted items

## Have we considered potential risks?

Limited. It only affects a small number of users and currently doesn't work

