### PR TITLE
Add a test that checks if the cookie policy is displaying 3 tables

### DIFF
--- a/playwright/test/pages.test.ts
+++ b/playwright/test/pages.test.ts
@@ -33,7 +33,7 @@ test.describe('Server-side redirection logic works as expected', () => {
 
 // As they are displayed through a hack, we want to make sure they're working
 // https://github.com/wellcomecollection/wellcomecollection.org/pull/10890
-test.only('Cookie policy tables are showing', async ({ context, page }) => {
+test('Cookie policy tables are showing', async ({ context, page }) => {
   await context.addCookies(requiredCookies);
   await gotoWithoutCache(`${baseUrl}/about-us/cookie-policy`, page);
 

--- a/playwright/test/pages.test.ts
+++ b/playwright/test/pages.test.ts
@@ -30,3 +30,12 @@ test.describe('Server-side redirection logic works as expected', () => {
     await expect(page.url()).toEqual(`${baseUrl}/visit-us`);
   });
 });
+
+// As they are displayed through a hack, we want to make sure they're working
+// https://github.com/wellcomecollection/wellcomecollection.org/pull/10890
+test.only('Cookie policy tables are showing', async ({ context, page }) => {
+  await context.addCookies(requiredCookies);
+  await gotoWithoutCache(`${baseUrl}/about-us/cookie-policy`, page);
+
+  await expect(page.getByRole('table')).toHaveCount(3);
+});


### PR DESCRIPTION
## What does this change?

https://github.com/wellcomecollection/wellcomecollection.org/issues/11375

Checks if the three tables are accounted for, see ticket for more information.

## How to test

Are the tests passing in this PR?

## How can we measure success?

No more losing them!

## Have we considered potential risks?
N/A