### PR TITLE
Update concept ID in end to end test #5804

### DIFF
--- a/playwright/test/concept.test.ts
+++ b/playwright/test/concept.test.ts
@@ -34,7 +34,7 @@ const test = base.extend<{
     // Chosen because there are works both about and by this person,
     // and his label is punctuated in such a way that would break the page if
     // it is not escaped properly in the API calls.
-    await concept('d46ea7yk', context, page);
+    await concept('qe5c6x6f', context, page);
     const thackrahPage = new ConceptPage(page, 'person');
     await use(thackrahPage);
   },


### PR DESCRIPTION
## What does this change?

Change one of the end-to-end tests to use a different concept ID. The old concept ID is no longer in use (i.e. it's no longer referenced from any Works) and has been completely removed in a recent concepts pipeline reindex.

## How to test

There is no need to test this change outside of our automated testing process. 

## How can we measure success?

End-to-end tests no longer fail with the new concepts index. 

## Have we considered potential risks?

There should be no risks associated with this change.
