### PR TITLE
stop unicode characters printing to page

### DIFF
--- a/content/webapp/components/Tags/Tags.tsx
+++ b/content/webapp/components/Tags/Tags.tsx
@@ -26,6 +26,8 @@ type PartWithSeparatorProps = {
   $isLast: boolean;
 };
 
+const nbsp = '\\00a0';
+
 const PartWithSeparator = styled.span.attrs({
   className: font('intr', 5),
 })<PartWithSeparatorProps>`
@@ -33,7 +35,7 @@ const PartWithSeparator = styled.span.attrs({
     display: ${props => (props.$isLast ? 'none' : 'inline')};
 
     /* non-breaking space (\u00A0) keeps characters that would otherwise break (e.g. hyphens) stuck to the preceding text */
-    content: '\u00A0${props => props.$separator}\u00A0';
+    content: '${nbsp}${props => props.$separator}${nbsp}';
   }
 `;
 


### PR DESCRIPTION
## What does this change?

[As reported on Slack](https://wellcome.slack.com/archives/C8X9YKM5X/p1731342560650259) the unicode encoding we used for on breaking spaces in Tags was being displayed, rather than just the space itself.

![image](https://github.com/user-attachments/assets/ece0070b-9f43-4d6f-84c3-97506e3bb838)


This fixes that

## How to test

Visit localhost:3000/works/tgzf7p3n and see that this doesn't happen

## How can we measure success?

the tags display as expected

## Have we considered potential risks?

Low
