### PR TITLE
Check for slice_type 'editorialImage' not (transformed) 'picture'

### DIFF
--- a/content/webapp/types/body.ts
+++ b/content/webapp/types/body.ts
@@ -35,7 +35,7 @@ export function isVideoEmbed(slice: prismic.Slice): slice is RawEmbedSlice {
 export function isEditorialImage(
   slice: prismic.Slice
 ): slice is RawEditorialImageSlice {
-  return slice.slice_type === 'picture';
+  return slice.slice_type === 'editorialImage';
 }
 
 export type ContentListItems =


### PR DESCRIPTION
For #11052 

## What does this change?

We check for the type of the first thing in the SliceZone, and if it's an `editorialImage` we want to pull it out and display it as `featuredMedia` before anything else on the page. Previously, we transformed the data we got from Prismic, and gave editorial images a type of `picture`, but now we deal directly with the untransformed data, and the type we get from Prismic is `editorialImage`, so we need to test for that instead.

__After__
<img width="1229" alt="Screenshot 2024-11-13 at 11 57 32" src="https://github.com/user-attachments/assets/c3958933-e713-4bdc-8942-48f6f2ac7a76">

## How to test
Go to `/visit-us/Wuw19yIAAK1Z3Smk` locally and confirm the image appears before the `OnThisPageAnchors`

## How can we measure success?
Pages appear as they were designed

## Have we considered potential risks?
Can't think of any