### PR TITLE
Use uid instead of id to check if we're on a 'sectionLevelPage'

### DIFF
--- a/content/webapp/pages/pages/[pageId].tsx
+++ b/content/webapp/pages/pages/[pageId].tsx
@@ -257,7 +257,7 @@ export const Page: FunctionComponent<Props> = ({
     <VideoEmbed {...transformFeaturedVideo.value} />
   ) : undefined;
 
-  const sectionLevelPage = sectionLevelPages.includes(page.id);
+  const sectionLevelPage = sectionLevelPages.includes(page.uid);
 
   function getBreadcrumbText(siteSection: string): string {
     return isLanding


### PR DESCRIPTION
## What does this change?
In trying to fix #11050 I went to the [wayback machine](https://web.archive.org/web/20230701001859/https://wellcomecollection.org/pages/YDaZmxMAACIAT9u8) when I saw the featured text would look strange. I spotted that we used to treat 'Visit us', 'Collections', and 'Get involved' as `sectionLevelPages` and changed the appearance of their header accordingly. The test for this used `id`s which are no longer correct – changing it to `uid` gets us back to where we were.

__Before__
<img width="1452" alt="image" src="https://github.com/user-attachments/assets/d5c078f9-7385-4438-a138-ff29d8161da1">

__After__
<img width="1448" alt="image" src="https://github.com/user-attachments/assets/de1ef48c-5495-4cca-ac1a-ff0cc55194b7">

Without this change, if/when #11050 is fixed, the `featuredText` position will look wrong

## How to test

visit `/get-involved`, `/collections`, and `/visit-us` and confirm the header appears as it used to.

## How can we measure success?
Pages appear as originally designed

## Have we considered potential risks?
Can't think of any