### PR TITLE
Add 'featuredText' to page model (instead of text with a label)

### DIFF
--- a/common/customtypes/pages/index.json
+++ b/common/customtypes/pages/index.json
@@ -42,6 +42,15 @@
           "placeholder": ""
         }
       },
+      "featuredText": {
+        "type": "StructuredText",
+        "config": {
+          "label": "Featured text",
+          "placeholder": "Introductory/important text to appear near the top of the page",
+          "allowTargetBlank": false,
+          "multi": "paragraph,strong,em,hyperlink"
+        }
+      },
       "body": {
         "type": "Slices",
         "fieldset": "Slice Zone",

--- a/common/customtypes/pages/index.json
+++ b/common/customtypes/pages/index.json
@@ -42,10 +42,10 @@
           "placeholder": ""
         }
       },
-      "featuredText": {
+      "introText": {
         "type": "StructuredText",
         "config": {
-          "label": "Featured text",
+          "label": "Intro text",
           "placeholder": "Introductory/important text to appear near the top of the page",
           "allowTargetBlank": false,
           "multi": "paragraph,strong,em,hyperlink"

--- a/common/prismicio-types.d.ts
+++ b/common/prismicio-types.d.ts
@@ -3850,6 +3850,17 @@ interface PagesDocumentData {
   showOnThisPage: prismic.BooleanField;
 
   /**
+   * Featured text field in *Page*
+   *
+   * - **Field Type**: Rich Text
+   * - **Placeholder**: Introductory/important text to appear near the top of the page
+   * - **API ID Path**: pages.featuredText
+   * - **Tab**: Page
+   * - **Documentation**: https://prismic.io/docs/field#rich-text-title
+   */
+  featuredText: prismic.RichTextField;
+
+  /**
    * Slice Zone field in *Page*
    *
    * - **Field Type**: Slice Zone
@@ -7201,6 +7212,17 @@ declare module '@prismicio/client' {
       repositoryNameOrEndpoint: string,
       options?: prismic.ClientConfig
     ): prismic.Client<AllDocumentTypes>;
+  }
+
+  interface CreateWriteClient {
+    (
+      repositoryNameOrEndpoint: string,
+      options: prismic.WriteClientConfig
+    ): prismic.WriteClient<AllDocumentTypes>;
+  }
+
+  interface CreateMigration {
+    (): prismic.Migration<AllDocumentTypes>;
   }
 
   namespace Content {

--- a/common/prismicio-types.d.ts
+++ b/common/prismicio-types.d.ts
@@ -3850,15 +3850,15 @@ interface PagesDocumentData {
   showOnThisPage: prismic.BooleanField;
 
   /**
-   * Featured text field in *Page*
+   * Intro text field in *Page*
    *
    * - **Field Type**: Rich Text
    * - **Placeholder**: Introductory/important text to appear near the top of the page
-   * - **API ID Path**: pages.featuredText
+   * - **API ID Path**: pages.introText
    * - **Tab**: Page
    * - **Documentation**: https://prismic.io/docs/field#rich-text-title
    */
-  featuredText: prismic.RichTextField;
+  introText: prismic.RichTextField;
 
   /**
    * Slice Zone field in *Page*

--- a/content/webapp/components/Body/Body.tsx
+++ b/content/webapp/components/Body/Body.tsx
@@ -84,7 +84,7 @@ export const LayoutWidth: FunctionComponent<LayoutWidthProps> = ({
 
 export type Props = {
   untransformedBody: prismic.Slice[];
-  featuredText?: prismic.RichTextField;
+  introText?: prismic.RichTextField;
   onThisPage?: Link[];
   showOnThisPage?: boolean;
   isDropCapped?: boolean;
@@ -147,7 +147,7 @@ export const defaultContext: SliceZoneContext = {
 
 const Body: FunctionComponent<Props> = ({
   untransformedBody,
-  featuredText,
+  introText,
   onThisPage,
   showOnThisPage,
   isDropCapped,
@@ -303,7 +303,7 @@ const Body: FunctionComponent<Props> = ({
       className={`content-type-${contentType}`}
       $splitBackground={isShortFilm}
     >
-      {featuredText && (
+      {introText && (
         <ContaineredLayout gridSizes={gridSize8(!sectionLevelPage)}>
           <div className="body-text spaced-text">
             <Space
@@ -313,7 +313,7 @@ const Body: FunctionComponent<Props> = ({
               }}
             >
               <FeaturedText
-                html={featuredText}
+                html={introText}
                 htmlSerializer={defaultSerializer}
               />
             </Space>

--- a/content/webapp/components/Body/Body.tsx
+++ b/content/webapp/components/Body/Body.tsx
@@ -84,6 +84,7 @@ export const LayoutWidth: FunctionComponent<LayoutWidthProps> = ({
 
 export type Props = {
   untransformedBody: prismic.Slice[];
+  featuredText?: prismic.RichTextField;
   onThisPage?: Link[];
   showOnThisPage?: boolean;
   isDropCapped?: boolean;
@@ -146,6 +147,7 @@ export const defaultContext: SliceZoneContext = {
 
 const Body: FunctionComponent<Props> = ({
   untransformedBody,
+  featuredText,
   onThisPage,
   showOnThisPage,
   isDropCapped,
@@ -157,25 +159,9 @@ const Body: FunctionComponent<Props> = ({
   comicPreviousNext,
   contentType,
 }: Props) => {
-  const isFirstFeaturedTextSliceFromUntransformedBody = (slice, i) =>
-    i === 0 && slice.slice_type === 'text' && slice.slice_label === 'featured';
-
-  const featuredTextFromUntransformedBody = untransformedBody.find(
-    isFirstFeaturedTextSliceFromUntransformedBody
-  ) as prismic.Slice<'text', { text: prismic.RichTextField }>;
-
-  const filteredUntransformedBody = untransformedBody
-    .filter(
-      (slice, i) => !isFirstFeaturedTextSliceFromUntransformedBody(slice, i)
-    )
-    .filter(
-      slice =>
-        !(
-          slice.slice_type === 'editorialImage' &&
-          slice.slice_label === 'featured'
-        )
-    )
-    .filter(slice => slice.slice_type !== 'standfirst');
+  const filteredUntransformedBody = untransformedBody.filter(
+    slice => slice.slice_type !== 'standfirst'
+  );
 
   const firstTextSliceIndex = filteredUntransformedBody
     .map(slice => slice.slice_type)
@@ -317,7 +303,7 @@ const Body: FunctionComponent<Props> = ({
       className={`content-type-${contentType}`}
       $splitBackground={isShortFilm}
     >
-      {featuredTextFromUntransformedBody && (
+      {featuredText && (
         <ContaineredLayout gridSizes={gridSize8(!sectionLevelPage)}>
           <div className="body-text spaced-text">
             <Space
@@ -327,7 +313,7 @@ const Body: FunctionComponent<Props> = ({
               }}
             >
               <FeaturedText
-                html={featuredTextFromUntransformedBody.primary.text}
+                html={featuredText}
                 htmlSerializer={defaultSerializer}
               />
             </Space>

--- a/content/webapp/pages/pages/[pageId].tsx
+++ b/content/webapp/pages/pages/[pageId].tsx
@@ -388,6 +388,7 @@ export const Page: FunctionComponent<Props> = ({
           <Body
             untransformedBody={untransformedBody}
             pageId={page.id}
+            featuredText={page.featuredText}
             onThisPage={page.onThisPage}
             showOnThisPage={page.showOnThisPage}
             isLanding={isLanding}

--- a/content/webapp/pages/pages/[pageId].tsx
+++ b/content/webapp/pages/pages/[pageId].tsx
@@ -388,7 +388,7 @@ export const Page: FunctionComponent<Props> = ({
           <Body
             untransformedBody={untransformedBody}
             pageId={page.id}
-            featuredText={page.featuredText}
+            introText={page.introText}
             onThisPage={page.onThisPage}
             showOnThisPage={page.showOnThisPage}
             isLanding={isLanding}

--- a/content/webapp/services/prismic/transformers/pages.test.ts
+++ b/content/webapp/services/prismic/transformers/pages.test.ts
@@ -27,6 +27,7 @@ const exampleTextSlice = {
 export const pageWithoutBody: RawPagesDocument = {
   ...emptyDocumentWithUid<RawPagesDocument>({
     title: [],
+    introText: exampleTextSlice.primary.text,
     datePublished: null,
     showOnThisPage: false,
     metadataDescription: exampleTextSlice.primary.text,

--- a/content/webapp/services/prismic/transformers/pages.ts
+++ b/content/webapp/services/prismic/transformers/pages.ts
@@ -55,7 +55,7 @@ export function transformPage(document: RawPagesDocument): Page {
       })
     : [];
 
-  const featuredText = data?.featuredText;
+  const introText = data?.introText;
   const siteSections = headerLinks.map(link => link.siteSection);
   const siteSection = document.tags.find(tag =>
     siteSections.includes(tag as SiteSection)
@@ -98,7 +98,7 @@ export function transformPage(document: RawPagesDocument): Page {
     uid: document.uid,
     format: transformFormat(document),
     ...genericFields,
-    featuredText,
+    introText,
     metadataDescription,
     seasons,
     contributors,

--- a/content/webapp/services/prismic/transformers/pages.ts
+++ b/content/webapp/services/prismic/transformers/pages.ts
@@ -55,6 +55,7 @@ export function transformPage(document: RawPagesDocument): Page {
       })
     : [];
 
+  const featuredText = data?.featuredText;
   const siteSections = headerLinks.map(link => link.siteSection);
   const siteSection = document.tags.find(tag =>
     siteSections.includes(tag as SiteSection)
@@ -97,6 +98,7 @@ export function transformPage(document: RawPagesDocument): Page {
     uid: document.uid,
     format: transformFormat(document),
     ...genericFields,
+    featuredText,
     metadataDescription,
     seasons,
     contributors,

--- a/content/webapp/types/pages.ts
+++ b/content/webapp/types/pages.ts
@@ -15,7 +15,7 @@ export type ParentPage = Page & {
 
 export type Page = GenericContentFields & {
   type: 'pages';
-  featuredText?: prismic.RichTextField;
+  introText?: prismic.RichTextField;
   uid: string;
   format: Format | undefined;
   seasons: Season[];

--- a/content/webapp/types/pages.ts
+++ b/content/webapp/types/pages.ts
@@ -1,3 +1,5 @@
+import type * as prismic from '@prismicio/client';
+
 import { SiteSection } from '@weco/common/model/site-section';
 
 import { Contributor } from './contributors';
@@ -13,6 +15,7 @@ export type ParentPage = Page & {
 
 export type Page = GenericContentFields & {
   type: 'pages';
+  featuredText?: prismic.RichTextField;
   uid: string;
   format: Format | undefined;
   seasons: Season[];


### PR DESCRIPTION
For #11050

## What does this change?

The 'featured text' part of a page used to be handled by a `slice_label` of `featured`, but `slice_label`s aren't a thing anymore. This means that the pieces of text that were supposed to have been taken out of the slices and added at the start of the `Body` are currently appearing _after_ the rest of the body content.

Since there can only be _one_ piece of `featuredText` per page, it makes sense for it to be a field on the page model, rather than a piece of text in the slices, so this PR adds a `RichTextField` for 'Featured text'

## How to test

Using the Prismic stage API, go to `/get-involved` and confirm the para of text ("Get involved with what’s happening…") appears before the cards, rather than after them.

## How can we measure success?

Pages render as they are supposed to

## Have we considered potential risks?

Can't think of any (although content will need updating to use the new field where this issue is currently in prod)