### PR TITLE
Align SectionHeader with content below

### DIFF
--- a/content/webapp/components/Body/Body.tsx
+++ b/content/webapp/components/Body/Body.tsx
@@ -268,7 +268,7 @@ const Body: FunctionComponent<Props> = ({
                 <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
                   <SectionHeader
                     title={section.value.title}
-                    gridSize={gridSize12()}
+                    gridSize={sectionLevelPage ? gridSize12() : gridSize8()}
                   />
                 </Space>
               )}


### PR DESCRIPTION
In doing changes for #11050 and #11052 I noticed this long-standing UI weirdness.

## What does this change?

Alignment of the `SectionHeader` and the cards below has (apparently) been offset for a long time on the `/get-involved/young-people` page, and it looks bad.

This PR lines up the heading and the content. Doesn't look amazing, but definitely looks better.

__Before__
<img width="988" alt="image" src="https://github.com/user-attachments/assets/5f248e90-4f6a-49f3-9b5b-8884ed3530de">

__After__
<img width="974" alt="image" src="https://github.com/user-attachments/assets/c281a2fa-e0e8-4c72-a0b2-b1e1c49fa454">


## How to test

Visit `/get-involved/young-people` and see if it looks less bad than in prod.

## How can we measure success?
People don't think our pages look broken

## Have we considered potential risks?
n/a