### PR TITLE
Adds toggle for concepts by ID work

### DIFF
--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -94,6 +94,14 @@ const toggles = {
         'Will make use of the V2 auth services in the IIIF Presentation manifest, if they are available. N.B. some V2 services contain invalid data, so it is not safe to turn this on for everyone until all manifests have been regenerated.',
       type: 'experimental',
     },
+    {
+      id: 'conceptsById',
+      title: 'Concept Pages by ID',
+      initialValue: false,
+      description:
+        'Use the new concept ID filters & aggregatiuons in the search API to query for works & images by ID rather than label.',
+      type: 'experimental',
+    },
   ] as const,
   tests: [] as ABTest[],
 };


### PR DESCRIPTION
## What does this change?

Part of https://github.com/wellcomecollection/platform/issues/5654

Follows https://github.com/wellcomecollection/catalogue-api/pull/830

This change adds a toggle to be used in front-end work to use an implementation of concepts pages and search filters that use concept IDs rather than labels.

## How to test

- [x] `yarn deploy`, does the toggle appear?

<img width="624" alt="Screenshot 2024-11-19 at 13 16 35" src="https://github.com/user-attachments/assets/a9cab009-8466-4cdf-abdd-7cdb50a8289c">

## How can we measure success?

Gracefully working on updating concept pages without changing what the public sees.

## Have we considered potential risks?

This change only adds the toggle (which is off by default), so risk should be minimal.
