### PR TITLE
Move `dnt` param for Vimeo to VideoEmbed

### DIFF
--- a/common/data/cookies.ts
+++ b/common/data/cookies.ts
@@ -130,6 +130,10 @@ export const cookiesTableCopy = {
       'YouTube',
       `We embed videos on our websites from our official YouTube channel using YouTube's privacy-enhanced mode.<br />YouTube will not store personally-identifiable Cookie information for playbacks of embedded videos using the privacy-enhanced mode.<br /><a href="https://www.youtube.com/intl/ALL_uk/howyoutubeworks/our-commitments/protecting-user-data" target="_blank" rel="noopener noreferrer">Read about how YouTube maintains user privacy</a>.`,
     ],
+    [
+      'Vimeo',
+      `We embed videos on our websites from our official Vimeo channel. With permission we collect data on how you interact with these videos.<br />This information helps us improve the digital content we create. <a href="https://help.vimeo.com/hc/en-us/articles/26080940921361-Vimeo-Player-Cookies" target="_blank" rel="noopener noreferrer">Visit Vimeo to see a full list of cookies and their uses</a>.`,
+    ],
   ],
   '[marketing_cookies_table]': [
     ['Provider', 'Purpose'],

--- a/common/views/components/CivicUK/index.tsx
+++ b/common/views/components/CivicUK/index.tsx
@@ -137,6 +137,10 @@ const CivicUK = ({ apiKey }: { apiKey: string }) => (
                     name: 'YouTube',
                     optOutLink: 'https://myaccount.google.com/yourdata/youtube?hl=en&pli=1',
                   },
+                  {
+                    name: 'Vimeo',
+                    optOutLink: 'https://vimeo.com/cookie_policy'
+                  },
                 ],
               },
               {

--- a/common/views/components/VideoEmbed/VideoEmbed.tsx
+++ b/common/views/components/VideoEmbed/VideoEmbed.tsx
@@ -96,7 +96,7 @@ const VideoEmbed: FunctionComponent<Props> = ({
   const videoSrc = isYouTube
     ? `${embedUrl}&enablejsapi=1&autoplay=1`
     : isVimeo
-      ? `${embedUrl}&autoplay=1`
+      ? `${embedUrl}&autoplay=1${!hasAnalyticsConsent ? '&dnt=1' : ''}`
       : undefined;
 
   const thumbnailSrc = isYouTube

--- a/content/webapp/services/prismic/transformers/embeds.ts
+++ b/content/webapp/services/prismic/transformers/embeds.ts
@@ -3,7 +3,7 @@ import * as prismic from '@prismicio/client';
 export function getVimeoEmbedUrl(embed: prismic.EmbedField): string {
   const embedUrl = embed.html?.match(/src="([-a-zA-Z0-9://.?=_]+)?/)![1];
 
-  return `${embedUrl}?rel=0&dnt=1`;
+  return `${embedUrl}?rel=0`;
 }
 
 export function getSoundCloudEmbedUrl(embed: prismic.EmbedField): string {


### PR DESCRIPTION
## What does this change?

#11408 

The `dnt` param (`1` is `true`, `0` is `false`) stands for Do Not Track. We never tracked by default, but now we want to should the user consent.
I moved it to the `VideoEmbed` component which is the only component used to render Vimeos. I did wonder if it should be passed/not in the `getVimeoUrl` helper, but I didn't want to get the consent everywhere that was used in order to pass it in. This feels much more streamlined.

## How to test

- [This is the list of Vimeo cookies](https://help.vimeo.com/hc/en-us/articles/26080940921361-Vimeo-Player-Cookies). Below the table, they list which cookies are necessary.
- Run locally, allow only necesary cookies. 
- The tracking starts on Play, so find a Vimeo (Hard Graft and Jason' BSL videos) and play it. 
- Ensure only necessary cookies are added.
- Change cookie preferences to allow Analytics. 
- Replay the video, check that tracking cookies are added.

As with the other cookies, should consent be revoked, we display a message saying we couldn't fully revoke consent (aka we don't manually delete cookies), so check the Manage Cookies popup and see that it's part of the list now when consent is revoked.

Also check that the copy is in the cookie policy page and matches what's been provided in the ticket.

## How can we measure success?

Tracking on Vimeo!

## Have we considered potential risks?
N/A