### PR TITLE
Add ability to limit where popupDialog appears with regex

### DIFF
--- a/cardigan/stories/components/PopupDialog/PopupDialog.stories.tsx
+++ b/cardigan/stories/components/PopupDialog/PopupDialog.stories.tsx
@@ -26,6 +26,7 @@ const meta: Meta<typeof PopupDialog> = {
           },
         ],
         isShown: true,
+        routeRegex: null,
       },
     },
   },

--- a/common/customtypes/popup-dialog/index.json
+++ b/common/customtypes/popup-dialog/index.json
@@ -3,6 +3,7 @@
   "label": "Popup dialog",
   "repeatable": false,
   "status": true,
+  "format": "custom",
   "json": {
     "Popup dialog": {
       "openButtonText": {
@@ -44,8 +45,14 @@
           "default_value": false,
           "label": "Is shown?"
         }
+      },
+      "routeRegex": {
+        "type": "Text",
+        "config": {
+          "label": "Route regex",
+          "placeholder": "Pipe-separated (|) list of page paths here if you only want this on certain pages"
+        }
       }
     }
-  },
-  "format": "custom"
+  }
 }

--- a/common/prismicio-types.d.ts
+++ b/common/prismicio-types.d.ts
@@ -4221,6 +4221,17 @@ interface PopupDialogDocumentData {
    * - **Documentation**: https://prismic.io/docs/field#boolean
    */
   isShown: prismic.BooleanField;
+
+  /**
+   * Route regex field in *Popup dialog*
+   *
+   * - **Field Type**: Text
+   * - **Placeholder**: Pipe-separated (|) list of page paths here if you only want this on certain pages
+   * - **API ID Path**: popup-dialog.routeRegex
+   * - **Tab**: Popup dialog
+   * - **Documentation**: https://prismic.io/docs/field#key-text
+   */
+  routeRegex: prismic.KeyTextField;
 }
 
 /**

--- a/common/server-data/prismic.ts
+++ b/common/server-data/prismic.ts
@@ -40,6 +40,7 @@ export const defaultValue = {
       openButtonText: null,
       text: [] as prismic.RichTextField,
       title: null,
+      routeRegex: null,
     },
   },
   collectionVenues: {

--- a/common/services/prismic/documents.ts
+++ b/common/services/prismic/documents.ts
@@ -101,5 +101,6 @@ export function emptyPopupDialog(): RawPopupDialogDocument {
     openButtonText: null,
     text: [],
     title: null,
+    routeRegex: null,
   }) as RawPopupDialogDocument;
 }

--- a/common/test/fixtures/prismicData/prismic-data.ts
+++ b/common/test/fixtures/prismicData/prismic-data.ts
@@ -32,6 +32,7 @@ const prismicData: SimplifiedPrismicData = {
         url: 'https://interviewer.djsresearch.com/scripts/Dubinterviewer.dll/Frames?Quest=7577',
       },
       isShown: false,
+      routeRegex: null,
     },
   },
   collectionVenues: {

--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -341,7 +341,11 @@ const PageLayoutComponent: FunctionComponent<Props> = ({
               }}
             />
           )}
-        {popupDialog.data.isShown && <PopupDialog document={popupDialog} />}
+        {popupDialog.data.isShown &&
+          (!popupDialog.data.routeRegex ||
+            urlString.match(new RegExp(popupDialog.data.routeRegex))) && (
+            <PopupDialog document={popupDialog} />
+          )}
         <div
           id="main"
           className="main"


### PR DESCRIPTION
## What does this change?
Adds the ability to limit where the `PopupDialog` component will appear, by introducing a text field to the model (using the same logic as pre-exists for the Global Alert)

## How to test
- Locally visit any collections page (i.e. one that starts `/collections`, `/works`, `/search/works`, or `search/images`) and wait five seconds, check the button to launch the dialog appears bottom right of the screen.
- Visit a non-collections page and check the button doesn't appear

## How can we measure success?
We can be more targeted with our user research

## Have we considered potential risks?
Can't think of any