### PR TITLE
Concept pages link to works search by label

### DIFF
--- a/content/webapp/pages/concepts/[conceptId].tsx
+++ b/content/webapp/pages/concepts/[conceptId].tsx
@@ -309,7 +309,7 @@ export const ConceptPage: NextPage<Props> = ({
         tabId,
         resultsGroup: sectionsData[relationship].images,
         tabLabelText: sectionsData[relationship].label,
-        totalResults: sectionsData[relationship].totalResults.works,
+        totalResults: sectionsData[relationship].totalResults.images,
         link: toImagesLink(
           linkParams(tabId, conceptResponse),
           `${linkSources[tabId]}_${pathname}` as ImagesLinkSource

--- a/content/webapp/pages/concepts/[conceptId].tsx
+++ b/content/webapp/pages/concepts/[conceptId].tsx
@@ -157,13 +157,11 @@ const ImagesTabPanel: FunctionComponent<ImagesTabPanelProps> = ({
   results,
   totalResults,
 }) => {
-  const showSeeMore = totalResults !== undefined && totalResults > 0;
-
   return (
     <div role="tabpanel" id={`tabpanel-${id}`} aria-labelledby={`tab-${id}`}>
       <ImageEndpointSearchResults images={results.pageResults} />
       <Space $v={{ size: 'm', properties: ['margin-top'] }}>
-        {showSeeMore && (
+        {!!totalResults && (
           <SeeMoreButton
             text="All images"
             totalResults={totalResults}
@@ -187,14 +185,12 @@ const WorksTabPanel: FunctionComponent<WorksTabPanelProps> = ({
   results,
   totalResults,
 }) => {
-  const showSeeMore = totalResults !== undefined && totalResults > 0;
-
   return (
     <Container>
       <div role="tabpanel" id={`tabpanel-${id}`} aria-labelledby={`tab-${id}`}>
         <WorksSearchResults works={results.pageResults} />
         <Space $v={{ size: 'l', properties: ['padding-top'] }}>
-          {showSeeMore && (
+          {!!totalResults && (
             <SeeMoreButton
               text="All works"
               totalResults={totalResults}

--- a/content/webapp/pages/concepts/[conceptId].tsx
+++ b/content/webapp/pages/concepts/[conceptId].tsx
@@ -149,7 +149,7 @@ type ImagesTabPanelProps = {
   id: string;
   link: LinkProps;
   results: ReturnedResults<ImageType>;
-  totalResults: number;
+  totalResults: number | undefined;
 };
 const ImagesTabPanel: FunctionComponent<ImagesTabPanelProps> = ({
   id,
@@ -161,7 +161,7 @@ const ImagesTabPanel: FunctionComponent<ImagesTabPanelProps> = ({
     <div role="tabpanel" id={`tabpanel-${id}`} aria-labelledby={`tab-${id}`}>
       <ImageEndpointSearchResults images={results.pageResults} />
       <Space $v={{ size: 'm', properties: ['margin-top'] }}>
-        {totalResults > 0 && (
+        {totalResults && (
           <SeeMoreButton
             text="All images"
             totalResults={totalResults}
@@ -177,7 +177,7 @@ type WorksTabPanelProps = {
   id: string;
   link: LinkProps;
   results: ReturnedResults<WorkBasic>;
-  totalResults: number;
+  totalResults: number | undefined;
 };
 const WorksTabPanel: FunctionComponent<WorksTabPanelProps> = ({
   id,
@@ -190,7 +190,7 @@ const WorksTabPanel: FunctionComponent<WorksTabPanelProps> = ({
       <div role="tabpanel" id={`tabpanel-${id}`} aria-labelledby={`tab-${id}`}>
         <WorksSearchResults works={results.pageResults} />
         <Space $v={{ size: 'l', properties: ['padding-top'] }}>
-          {totalResults > 0 && (
+          {totalResults && (
             <SeeMoreButton
               text="All works"
               totalResults={totalResults}
@@ -214,14 +214,14 @@ type PageSectionDefinition<T> = {
     id: string;
     link: LinkProps;
     results: ReturnedResults<T>;
-    totalResults: number;
+    totalResults: number | undefined;
   };
 };
 type PageSectionDefinitionProps<T> = {
   tabId: string;
   resultsGroup: ReturnedResults<T> | undefined;
   tabLabelText: string;
-  totalResults: number;
+  totalResults: number | undefined;
   link: LinkProps;
 };
 
@@ -251,7 +251,7 @@ type SectionData = {
   label: string;
   works: ReturnedResults<WorkBasic> | undefined;
   images: ReturnedResults<ImageType> | undefined;
-  totalResults: { works: number; images: number };
+  totalResults: { works: number | undefined; images: number | undefined };
 };
 
 type SectionsData = {

--- a/content/webapp/pages/concepts/[conceptId].tsx
+++ b/content/webapp/pages/concepts/[conceptId].tsx
@@ -157,11 +157,13 @@ const ImagesTabPanel: FunctionComponent<ImagesTabPanelProps> = ({
   results,
   totalResults,
 }) => {
+  const showSeeMore = totalResults !== undefined && totalResults > 0;
+
   return (
     <div role="tabpanel" id={`tabpanel-${id}`} aria-labelledby={`tab-${id}`}>
       <ImageEndpointSearchResults images={results.pageResults} />
       <Space $v={{ size: 'm', properties: ['margin-top'] }}>
-        {totalResults && (
+        {showSeeMore && (
           <SeeMoreButton
             text="All images"
             totalResults={totalResults}
@@ -185,12 +187,14 @@ const WorksTabPanel: FunctionComponent<WorksTabPanelProps> = ({
   results,
   totalResults,
 }) => {
+  const showSeeMore = totalResults !== undefined && totalResults > 0;
+
   return (
     <Container>
       <div role="tabpanel" id={`tabpanel-${id}`} aria-labelledby={`tab-${id}`}>
         <WorksSearchResults works={results.pageResults} />
         <Space $v={{ size: 'l', properties: ['padding-top'] }}>
-          {totalResults && (
+          {showSeeMore && (
             <SeeMoreButton
               text="All works"
               totalResults={totalResults}

--- a/playwright/test/concept.test.ts
+++ b/playwright/test/concept.test.ts
@@ -5,7 +5,7 @@ import { ConceptPage } from './pages/concept';
 
 const test = base.extend<{
   armyPage: ConceptPage;
-  lithographsPage: ConceptPage;
+  mohPage: ConceptPage;
   songsPage: ConceptPage;
   thackrahPage: ConceptPage;
 }>({
@@ -16,11 +16,11 @@ const test = base.extend<{
     await use(armyPage);
   },
 
-  lithographsPage: async ({ context, page }, use) => {
+  mohPage: async ({ context, page }, use) => {
     // A Genre with both works and images using it, but nothing about it.
-    await concept('fmydsuw2', context, page);
-    const lithographsPage = new ConceptPage(page, 'type/technique');
-    await use(lithographsPage);
+    await concept('rasp7aye', context, page);
+    const mohPage = new ConceptPage(page, 'type/technique');
+    await use(mohPage);
   },
 
   songsPage: async ({ context, page }, use) => {
@@ -165,28 +165,27 @@ test.describe('a Concept representing a Genre with works and images both about a
 
 test.describe('a Concept representing a Genre that is only used as a genre for both works and images', () => {
   test('has both works and image sections showing records in that genre', async ({
-    lithographsPage,
+    mohPage,
   }) => {
     // Both images and works sections exist
-    await expect(lithographsPage.imagesHeader).toBeVisible();
-    await expect(lithographsPage.worksHeader).toBeVisible();
-    // There are no tabs, because there is only one group within each of the two sections
-    await expect(lithographsPage.worksAboutTab).not.toBeVisible();
-    await expect(lithographsPage.worksInTab).not.toBeVisible();
-    await expect(lithographsPage.imagesAboutTab).not.toBeVisible();
-    await expect(lithographsPage.imagesInTab).not.toBeVisible();
+    await expect(mohPage.imagesHeader).toBeVisible();
+    await expect(mohPage.worksHeader).toBeVisible();
 
-    // It has links to filtered searches
-    await expect(lithographsPage.allWorksLink).toHaveAttribute(
+    // There are no tabs, because there is only one group within each of the two sections
+    await expect(mohPage.worksAboutTab).not.toBeVisible();
+    await expect(mohPage.worksInTab).not.toBeVisible();
+    await expect(mohPage.imagesAboutTab).not.toBeVisible();
+    await expect(mohPage.imagesInTab).not.toBeVisible();
+
+    // It has links to filtered searches, (not using encodeURIComponent because the genre includes '+'")
+    await expect(mohPage.allWorksLink).toHaveAttribute(
       'href',
-      `/search/works?genres.label=${encodeURIComponent('"Lithographs"')}`
+      `/search/works?genres.label=%22MOH+reports%22`
     );
 
-    await expect(lithographsPage.allImagesLink).toHaveAttribute(
+    await expect(mohPage.allImagesLink).toHaveAttribute(
       'href',
-      `/search/images?source.genres.label=${encodeURIComponent(
-        '"Lithographs"'
-      )}`
+      `/search/images?source.genres.label=%22MOH+reports%22`
     );
   });
 });


### PR DESCRIPTION
## What does this change?

For https://github.com/wellcomecollection/platform/issues/5834

This change brings concept pages by ID out from behind a toggle, but keeps links back to works search as label based, removing the possibility of a link give the incorrect number of results, or return you to an empty search page.

To enable this the "all _thing_" link is removed when a label based search has no results.

See [this conversation](https://wellcome.slack.com/archives/C07PUCL8TR8/p1732800543188889) for more information, and videos of expected behaviour.

## How to test

- [x] Do the tests pass?
- [ ] Run this locally, ensure the "Concept Pages by ID" is _off_ and visit:
  - http://localhost:3000/concepts/tprv87tq
     Follow "all works" and "all images" links, [compare currently live](https://wellcomecollection.org/concepts/tprv87tq).
     _Expected behaviour:_ There will be more works and images on the concept page, the links to works and images will have correct number and work as expected.
  - http://localhost:3000/works/kdrnqtph
     Follow contributors link for `Aleksievich, Svetlana, 1948-`, [compare currently live](https://wellcomecollection.org/works/kdrnqtph).
     _Expected behaviour:_ You should not hit a dead end, there should be no "all works" or "all images link" on a concept page

With the "Concept Pages by ID" toggle on, "all works" and "all images" links will continue to behave as they do now behind a toggle, i.e. link to works and images search by concept ID filter. This is in anticipation of future work to update the filters.

## How can we measure success?

No dead ends.

## Have we considered potential risks?

Risks should be minimised by being behind a toggle. But this is a change to the current user experience, and needs looking at by product folk first.
