### PR TITLE
remove ga_cookies from cloudfront policies

### DIFF
--- a/cache/modules/cloudfront_policies/cache_policies.tf
+++ b/cache/modules/cloudfront_policies/cache_policies.tf
@@ -55,7 +55,6 @@ resource "aws_cloudfront_cache_policy" "weco_apps" {
             concat(
               local.toggles_cookies,
               local.userpreference_cookies,
-              local.ga_cookies,
             )
           )
         )
@@ -98,7 +97,6 @@ resource "aws_cloudfront_cache_policy" "weco_apps_all_params" {
             concat(
               local.toggles_cookies,
               local.userpreference_cookies,
-              local.ga_cookies,
             )
           )
         )

--- a/cache/modules/cloudfront_policies/locals.tf
+++ b/cache/modules/cloudfront_policies/locals.tf
@@ -1,7 +1,6 @@
 locals {
   toggles_cookies        = ["toggles", "toggle_*"]
   userpreference_cookies = ["WC_*", "CookieControl"] // CookieControl is Civic UK (our Consent Management Platform)'s cookie that stores user preferences
-  ga_cookies             = ["_ga"]
 
   one_minute = 60
   one_hour   = 60 * local.one_minute

--- a/cache/modules/cloudfront_policies/request_policies.tf
+++ b/cache/modules/cloudfront_policies/request_policies.tf
@@ -14,7 +14,6 @@ resource "aws_cloudfront_origin_request_policy" "host_query_and_toggles" {
         concat(
           local.toggles_cookies,
           local.userpreference_cookies,
-          local.ga_cookies,
         )
       )
     }


### PR DESCRIPTION
## What does this change?

⬆️ 

For #11391 

Stops varying the cache on ga cookies

## How to test

Can't think of a straightforward way.

## How can we measure success?

Hopefully see an improvement in apdex scores

## Have we considered potential risks?

n/a

