### PR TITLE
Add data-gtm-trigger for popular_story

### DIFF
--- a/common/views/components/RecommendedStories/index.tsx
+++ b/common/views/components/RecommendedStories/index.tsx
@@ -210,7 +210,10 @@ const RecommendedStories = () => {
           <StoriesContainer>
             {stories.map(story => {
               return (
-                <StoryWrapper key={story.title}>
+                <StoryWrapper
+                  key={story.title}
+                  data-gtm-trigger="popular_story"
+                >
                   <StoryLink href={story.path}>
                     <Story>
                       <img src={story.imageUrl} alt={story.title} />


### PR DESCRIPTION
## What does this change?
The classes that styled-components generates doesn't give us anything sensible to hook onto for a tagmanager trigger. We've used a data-attribute for this in the past – `data-gtm-trigger={x}`, so reusing that principle here.

## How to test
View a story with the recommended stories toggle turned on and verify the `data-gtm-trigger="popular_story"` attribute is added to the containing `li` elements for each recommended story card

## How can we measure success?
We can use tagmanager to measure events

## Have we considered potential risks?
n/a