### PR TITLE
Add hotjar to collections sub pages

### DIFF
--- a/content/webapp/pages/collections/[uid].tsx
+++ b/content/webapp/pages/collections/[uid].tsx
@@ -2,6 +2,7 @@ import { GetServerSideProps } from 'next';
 import { FunctionComponent } from 'react';
 
 import { AppErrorProps } from '@weco/common/services/app';
+import useHotjar from '@weco/content/hooks/useHotjar';
 import * as page from '@weco/content/pages/pages/[pageId]';
 
 export const getServerSideProps: GetServerSideProps<
@@ -16,7 +17,7 @@ export const getServerSideProps: GetServerSideProps<
 };
 
 const CollectionsPage: FunctionComponent<page.Props> = (props: page.Props) => {
+  useHotjar(true);
   return <page.Page {...props} />;
 };
-
 export default CollectionsPage;


### PR DESCRIPTION
## What does this change?

For [#11440](https://github.com/wellcomecollection/wellcomecollection.org/issues/11440)

looks like 
/concepts*
/works*
and collections landing page already load hotjar.

This adds the hotjar script to the collections sub pages

## How to test

Visit a collections sub page, e.g. http://localhost:3000/collections/what-s-in-the-collections
Look for the hotjar scrip in the Elements tab of Dev tools

## How can we measure success?

The hotjar script is present

## Have we considered potential risks?

none really, we load this script on pages already

