### PR TITLE
Add explore more document link on stories

### DIFF
--- a/common/customtypes/articles/index.json
+++ b/common/customtypes/articles/index.json
@@ -176,6 +176,14 @@
       }
     },
     "Content relationships": {
+      "exploreMoreDocument": {
+        "type": "Link",
+        "config": {
+          "label": "\"Explore more\" document",
+          "select": "document",
+          "customtypes": ["articles", "exhibitions"]
+        }
+      },
       "series": {
         "type": "Group",
         "fieldset": "Series",

--- a/common/prismicio-types.d.ts
+++ b/common/prismicio-types.d.ts
@@ -283,6 +283,19 @@ interface ArticlesDocumentData {
    * - **Documentation**: https://prismic.io/docs/field#rich-text-title
    */;
   metadataDescription: prismic.RichTextField /**
+   * "Explore more" document field in *Story*
+   *
+   * - **Field Type**: Content Relationship
+   * - **Placeholder**: *None*
+   * - **API ID Path**: articles.exploreMoreDocument
+   * - **Tab**: Content relationships
+   * - **Documentation**: https://prismic.io/docs/field#link-content-relationship
+   */;
+  exploreMoreDocument: prismic.ContentRelationshipField<
+    'articles' | 'exhibitions'
+  >;
+
+  /**
    * Series field in *Story*
    *
    * - **Field Type**: Group
@@ -290,7 +303,7 @@ interface ArticlesDocumentData {
    * - **API ID Path**: articles.series[]
    * - **Tab**: Content relationships
    * - **Documentation**: https://prismic.io/docs/field#group
-   */;
+   */
   series: prismic.GroupField<Simplify<ArticlesDocumentDataSeriesItem>>;
 
   /**

--- a/playwright/test/mocks/one-schedule-item.ts
+++ b/playwright/test/mocks/one-schedule-item.ts
@@ -343,6 +343,7 @@ export const oneScheduleItem: prismic.Query<RawArticlesDocument> = {
             },
           },
         ],
+        exploreMoreDocument: { link_type: 'Document' },
         seasons: [
           {
             season: {


### PR DESCRIPTION
## What does this change?

#11439 
Adds a document link for stories and exhibitions in the story content type.
I've already pushed it to Prismic staging.
I've following the casing from other such fields for its ID.

## How to test

Check out prismic staging?

## How can we measure success?

Able to move forward with the rest of the #11439 work

## Have we considered potential risks?
N/A