### PR TITLE
added a Library Data Link Explorer link in the API toolbar

### DIFF
--- a/common/views/components/ApiToolbar/index.tsx
+++ b/common/views/components/ApiToolbar/index.tsx
@@ -165,15 +165,6 @@ const ApiToolbar: FunctionComponent<Props> = ({ links = [] }) => {
           </>
         )}
       </div>
-      <a
-        href="https://main.d33vyuqnhij7au.amplifyapp.com/"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        <button type="button" style={{ padding: '10px' }}>
-          <>🏷️</>
-        </button>
-      </a>
       <button
         type="button"
         onClick={() => {

--- a/common/views/components/ApiToolbar/index.tsx
+++ b/common/views/components/ApiToolbar/index.tsx
@@ -165,6 +165,15 @@ const ApiToolbar: FunctionComponent<Props> = ({ links = [] }) => {
           </>
         )}
       </div>
+      <a
+        href="https://main.d33vyuqnhij7au.amplifyapp.com/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <button type="button" style={{ padding: '10px' }}>
+          <>🏷️</>
+        </button>
+      </a>
       <button
         type="button"
         onClick={() => {

--- a/content/webapp/pages/works/[workId]/images.tsx
+++ b/content/webapp/pages/works/[workId]/images.tsx
@@ -176,6 +176,12 @@ export const getServerSideProps: GetServerSideProps<
           link: catalogueApiUrl!,
         },
         createTzitzitImageLink(work, image),
+        {
+          id: 'library-data-link-explorer',
+          label: 'Library Data Link Explorer',
+          ariaLabel: 'open matcher graph via the Library Data Link Explorer',
+          link: `https://main.d33vyuqnhij7au.amplifyapp.com/?workId=${work.id}`,
+        },
       ].filter(isNotUndefined),
       pageview: {
         name: 'image',

--- a/content/webapp/utils/works.ts
+++ b/content/webapp/utils/works.ts
@@ -437,6 +437,12 @@ export function createApiToolbarWorkLinks(
       label: id.identifierType.label,
       value: id.value,
     })),
+    {
+      id: 'library-data-link-explorer',
+      label: 'Library Data Link Explorer',
+      ariaLabel: 'open matcher graph via the Library Data Link Explorer',
+      link: `https://main.d33vyuqnhij7au.amplifyapp.com/?workId=${work.id}`,
+    },
   ].filter(Boolean) as ApiToolbarLink[];
 
   return links;


### PR DESCRIPTION
## What does this change?

Adds a subtle link to the new Library Data Link Explorer onto the API toolbar. Avoids colleagues from saving the temporary Amplify link as a bookmark. 
![Screenshot 2025-01-06 at 12 01 50](https://github.com/user-attachments/assets/a64d45e1-8625-4246-ae3d-6930a11de1f7)

![Screenshot 2025-01-06 at 12 02 29](https://github.com/user-attachments/assets/78596343-31c9-460e-8874-9e8b386e8354)

## How to test

Ensure you have the toolbar enabled on your local. Click the link, it should open in a new tab (to allow colleagues to go back and forth to the catalogue with ease, rather than refreshing their search). 

The application opened should work as normal. 

## How can we measure success?

Is the 🏷️ link too subtle? Does it match the style of the toolbar to avoid clutter? 

## Have we considered potential risks?

Prevents overuse of the application, keeps the toolbar tidy, even when in mini mode. 

