### PR TITLE
Featured card stories

### DIFF
--- a/build-speedtracker.sh
+++ b/build-speedtracker.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-set -o errexit
-
-curl https://api.speedtracker.org/v1/test/wellcometrust/speedtracker/main/article?key=$SPEEDTRACKER_KEY
-curl https://api.speedtracker.org/v1/test/wellcometrust/speedtracker/main/exhibition?key=$SPEEDTRACKER_KEY
-curl https://api.speedtracker.org/v1/test/wellcometrust/speedtracker/main/stories?key=$SPEEDTRACKER_KEY
-curl https://api.speedtracker.org/v1/test/wellcometrust/speedtracker/main/work?key=$SPEEDTRACKER_KEY
-curl https://api.speedtracker.org/v1/test/wellcometrust/speedtracker/main/works?key=$SPEEDTRACKER_KEY

--- a/content/webapp/pages/api/exhibitions/exhibition.ts
+++ b/content/webapp/pages/api/exhibitions/exhibition.ts
@@ -1,0 +1,33 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import {
+  isJson,
+  serialiseDates as serialiseJsonDates,
+} from '@weco/common/utils/json';
+import { isString } from '@weco/common/utils/type-guards';
+import { createClient } from '@weco/content/services/prismic/fetch';
+import { exhibitionsFetcher } from '@weco/content/services/prismic/fetch/exhibitions';
+
+export default async (
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> => {
+  const { params } = req.query;
+
+  // Reject anybody trying to send nonsense to the API
+  if (!isString(params) || !isJson(params)) {
+    return res.status(404).json({ notFound: true });
+  }
+
+  const parsedParams = JSON.parse(params);
+
+  const client = createClient({ req });
+
+  const exhibitionDocument =
+    (await exhibitionsFetcher.getByUid(client, parsedParams.id)) ||
+    (await exhibitionsFetcher.getById(client, parsedParams.id));
+
+  if (exhibitionDocument) {
+    return res.status(200).json(serialiseJsonDates(exhibitionDocument));
+  }
+};

--- a/content/webapp/services/prismic/fetch/exhibitions.ts
+++ b/content/webapp/services/prismic/fetch/exhibitions.ts
@@ -55,7 +55,7 @@ const fetchLinks = [
   ...seasonsFetchLinks,
 ] as string[];
 
-const exhibitionsFetcher = fetcher<RawExhibitionsDocument>(
+export const exhibitionsFetcher = fetcher<RawExhibitionsDocument>(
   'exhibitions',
   fetchLinks
 );

--- a/content/webapp/services/prismic/transformers/articles.ts
+++ b/content/webapp/services/prismic/transformers/articles.ts
@@ -115,6 +115,7 @@ export function transformArticle(
     prismic.isFilled.contentRelationship(data.exploreMoreDocument)
       ? {
           id: data.exploreMoreDocument.id,
+          uid: data.exploreMoreDocument.uid,
           type: data.exploreMoreDocument.type,
         }
       : undefined;
@@ -126,7 +127,6 @@ export function transformArticle(
     labels: labels.length > 0 ? labels : [{ text: 'Story' }],
     format,
     series,
-    exploreMoreDocument,
     contributors,
     readingTime: showReadingTime(format, labels)
       ? calculateReadingTime(genericFields.untransformedBody)
@@ -137,5 +137,6 @@ export function transformArticle(
           transformSeason(season as RawSeasonsDocument)
         )
       : [],
+    exploreMoreDocument,
   };
 }

--- a/content/webapp/services/prismic/transformers/articles.ts
+++ b/content/webapp/services/prismic/transformers/articles.ts
@@ -1,3 +1,5 @@
+import * as prismic from '@prismicio/client';
+
 import { Label } from '@weco/common/model/labels';
 import {
   ArticlesDocument as RawArticlesDocument,
@@ -107,6 +109,16 @@ export function transformArticle(
 
   const contributors = transformContributors(document);
 
+  // The content will be fetched content side later on
+  const exploreMoreDocument =
+    'exploreMoreDocument' in data &&
+    prismic.isFilled.contentRelationship(data.exploreMoreDocument)
+      ? {
+          id: data.exploreMoreDocument.id,
+          type: data.exploreMoreDocument.type,
+        }
+      : undefined;
+
   return {
     ...genericFields,
     type: 'articles',
@@ -114,6 +126,7 @@ export function transformArticle(
     labels: labels.length > 0 ? labels : [{ text: 'Story' }],
     format,
     series,
+    exploreMoreDocument,
     contributors,
     readingTime: showReadingTime(format, labels)
       ? calculateReadingTime(genericFields.untransformedBody)

--- a/content/webapp/services/prismic/transformers/articles.ts
+++ b/content/webapp/services/prismic/transformers/articles.ts
@@ -109,7 +109,7 @@ export function transformArticle(
 
   const contributors = transformContributors(document);
 
-  // The content will be fetched content side later on
+  // The content will be fetched client side later on
   const exploreMoreDocument =
     'exploreMoreDocument' in data &&
     prismic.isFilled.contentRelationship(data.exploreMoreDocument)

--- a/content/webapp/services/wellcome/content/article.ts
+++ b/content/webapp/services/wellcome/content/article.ts
@@ -1,0 +1,20 @@
+import { WellcomeApiError } from '@weco/content/services/wellcome';
+import { Toggles } from '@weco/toggles';
+
+import { contentDocumentQuery } from '.';
+import { Article } from './types/api';
+
+export async function getArticle({
+  id,
+  toggles,
+}: {
+  id: string;
+  toggles: Toggles;
+}): Promise<Article | WellcomeApiError> {
+  const getArticleResult = await contentDocumentQuery<Article>(
+    `articles/${id}`,
+    { toggles }
+  );
+
+  return getArticleResult;
+}

--- a/content/webapp/services/wellcome/content/index.ts
+++ b/content/webapp/services/wellcome/content/index.ts
@@ -5,6 +5,7 @@ import {
   WellcomeApiError,
   wellcomeApiQuery,
 } from '@weco/content/services/wellcome';
+import { Toggles } from '@weco/toggles';
 
 import { ContentResultsList, ResultType } from './types/api';
 
@@ -32,4 +33,15 @@ export async function contentQuery<Params, Result extends ResultType>(
   return wellcomeApiQuery(url) as unknown as
     | ContentResultsList<Result>
     | WellcomeApiError;
+}
+
+export async function contentDocumentQuery<Result extends ResultType>(
+  endpoint: string,
+  { toggles }: { toggles: Toggles }
+): Promise<Result | WellcomeApiError> {
+  const apiOptions = globalApiOptions(toggles);
+
+  const url = `${rootUris[apiOptions.env]}/v0/${endpoint}`;
+
+  return wellcomeApiQuery(url) as unknown as Result | WellcomeApiError;
 }

--- a/content/webapp/types/articles.ts
+++ b/content/webapp/types/articles.ts
@@ -32,6 +32,7 @@ export type Article = GenericContentFields & {
   format?: Format<ArticleFormatId>;
   readingTime?: string;
   datePublished: Date;
+  exploreMoreDocument?: { id: string; type: 'articles' | 'exhibitions' };
   series: Series[];
   seasons: Season[];
   color?: ColorSelection;

--- a/content/webapp/types/articles.ts
+++ b/content/webapp/types/articles.ts
@@ -32,11 +32,15 @@ export type Article = GenericContentFields & {
   format?: Format<ArticleFormatId>;
   readingTime?: string;
   datePublished: Date;
-  exploreMoreDocument?: { id: string; type: 'articles' | 'exhibitions' };
   series: Series[];
   seasons: Season[];
   color?: ColorSelection;
   contributors: Contributor[];
+  exploreMoreDocument?: {
+    id: string;
+    uid?: string;
+    type: 'articles' | 'exhibitions';
+  };
 };
 
 /** Given an article in a serial, return its part number.


### PR DESCRIPTION
## What does this change?

#11439 #11429 #11428 

- [Deletes an unused script](https://wellcome.slack.com/archives/C3TQSF63C/p1734087650881209?thread_ts=1734087512.439279&cid=C3TQSF63C) (unrelated to ticket work)
- Adds API endpoint to fetch single exhibition (from Prismic API) or single article (Content API) client-side
- Adds `exploreMoreDocument` field to Articles' type and transformer, returning only the required information for a client-side fetch of the document. This had to be done because we couldn't get the required shape only from the content relationship field ([see Slack conversation here](https://wellcome.slack.com/archives/CUA669WHH/p1734452938489909)), and we didn't want to load even more things Server side.
- Add the code to render the Featured Card on articles pages should the field have a value in. The only notable logic is if the related content is an exhibition that is in the past, the block won't get displayed at all. I use the `FeaturedCard` component to render them, passing either `type="article"` or `type="exhibition"`, which renders the relevant card. I've had a chat with Kasia and we'll look at maybe adding the description to the Exhibition Card, and tweaking the font-size and spacing a bit on it, but as part of a different ticket/PR.  

I'm not in love with how I fetch the content (through the useEffect), so will take any suggestions on this. 

## How to test

- Run locally and set it to point to Prismic staging.
- See [Stuck tampon on Prismic](https://wellcomecollection-stage.prismic.io/builder/pages/ZdSMbREAACQA3j30?s=unclassified&section=Content+relationships), in the Content Relationship tab. The first input field is the "Explore more document", which can link to an article or an exhibition. I'd recommend testing how it displays for
  - an article
  - an exhibition that is current or upcoming
  - a past exhibition (should not display the block at all)

## How can we measure success?

More onwards journeys!

## Have we considered potential risks?

None that I can think of? No need to be put under a toggle as the field has to have a value to display anything and the editors aren't yet aware of its existence.