### PR TITLE
Add "all" api endpoint and create alternative page

### DIFF
--- a/content/webapp/services/wellcome/catalogue/types/aggregations.ts
+++ b/content/webapp/services/wellcome/catalogue/types/aggregations.ts
@@ -21,4 +21,4 @@ export type ImageAggregations = {
   type: 'Aggregations';
 };
 
-export type ConceptAggregations = null;
+export type ConceptAggregations = undefined;

--- a/content/webapp/services/wellcome/catalogue/types/index.ts
+++ b/content/webapp/services/wellcome/catalogue/types/index.ts
@@ -238,7 +238,7 @@ type CatalogueAggregations<Result extends ResultType> = Result extends Work
     ? ImageAggregations
     : Result extends Concept
       ? ConceptAggregations
-      : null;
+      : undefined;
 
 export type CatalogueResultsList<Result extends ResultType> =
   WellcomeResultList<Result, CatalogueAggregations<Result>>;

--- a/content/webapp/services/wellcome/content/all.ts
+++ b/content/webapp/services/wellcome/content/all.ts
@@ -1,0 +1,19 @@
+import { QueryProps, WellcomeApiError } from '@weco/content/services/wellcome';
+import {
+  Addressable,
+  ContentApiProps,
+  ContentResultsList,
+} from '@weco/content/services/wellcome/content/types/api';
+
+import { contentListQuery } from '.';
+
+export async function getAddressables(
+  props: QueryProps<ContentApiProps>
+): Promise<ContentResultsList<Addressable> | WellcomeApiError> {
+  const getAddressablesResult = await contentListQuery<
+    ContentApiProps,
+    Addressable
+  >('all', props);
+
+  return getAddressablesResult;
+}

--- a/content/webapp/services/wellcome/content/articles.ts
+++ b/content/webapp/services/wellcome/content/articles.ts
@@ -4,13 +4,13 @@ import {
   ContentResultsList,
 } from '@weco/content/services/wellcome/content/types/api';
 
-import { contentQuery } from '.';
+import { contentListQuery } from '.';
 import { Article } from './types/api';
 
 export async function getArticles(
   props: QueryProps<ContentApiProps>
 ): Promise<ContentResultsList<Article> | WellcomeApiError> {
-  const getArticlesResult = await contentQuery<ContentApiProps, Article>(
+  const getArticlesResult = await contentListQuery<ContentApiProps, Article>(
     'articles',
     props
   );

--- a/content/webapp/services/wellcome/content/events.ts
+++ b/content/webapp/services/wellcome/content/events.ts
@@ -4,15 +4,15 @@ import {
   ContentResultsList,
 } from '@weco/content/services/wellcome/content/types/api';
 
-import { contentQuery } from '.';
+import { contentListQuery } from '.';
 import { EventDocument } from './types/api';
 
 export async function getEvents(
   props: QueryProps<ContentApiProps>
 ): Promise<ContentResultsList<EventDocument> | WellcomeApiError> {
-  const getEventsResult = await contentQuery<ContentApiProps, EventDocument>(
-    'events',
-    props
-  );
+  const getEventsResult = await contentListQuery<
+    ContentApiProps,
+    EventDocument
+  >('events', props);
   return getEventsResult;
 }

--- a/content/webapp/services/wellcome/content/index.ts
+++ b/content/webapp/services/wellcome/content/index.ts
@@ -14,7 +14,7 @@ const rootUris = {
   stage: 'https://api-stage.wellcomecollection.org/content',
 };
 
-export async function contentQuery<Params, Result extends ResultType>(
+export async function contentListQuery<Params, Result extends ResultType>(
   endpoint: string,
   { params, toggles, pageSize }: QueryProps<Params>
 ): Promise<ContentResultsList<Result> | WellcomeApiError> {

--- a/content/webapp/services/wellcome/content/types/api.ts
+++ b/content/webapp/services/wellcome/content/types/api.ts
@@ -168,9 +168,5 @@ export type ResultType = Article | EventDocument | Addressable;
 
 export type ContentResultsList<Result extends ResultType> = WellcomeResultList<
   Result,
-  Result extends Article
-    ? ArticleAggregations
-    : Result extends Event
-      ? EventAggregations
-      : null
+  (Result extends Article ? ArticleAggregations : EventAggregations) | undefined
 >;

--- a/content/webapp/services/wellcome/content/types/api.ts
+++ b/content/webapp/services/wellcome/content/types/api.ts
@@ -140,10 +140,37 @@ export type EventAggregations = BasicAggregations & {
   isAvailableOnline: WellcomeAggregation<BooleanBucketData>;
 };
 
+type AddressableType =
+  | 'Article'
+  | 'Book'
+  | 'Event'
+  | 'Project'
+  | 'Season'
+  | 'Exhibition'
+  | 'Exhibition highlight tour'
+  | 'Exhibition text'
+  | 'Page'
+  | 'Visual story';
+
+export type Addressable = {
+  type: AddressableType;
+  id: string;
+  uid: string | null;
+  title: string;
+  description?: string;
+  format?: string;
+  contributors?: string;
+  times?: { start: Date; end: Date };
+};
+
 // Results
-export type ResultType = Article | EventDocument;
+export type ResultType = Article | EventDocument | Addressable;
 
 export type ContentResultsList<Result extends ResultType> = WellcomeResultList<
   Result,
-  Result extends Article ? ArticleAggregations : EventAggregations
+  Result extends Article
+    ? ArticleAggregations
+    : Result extends Event
+      ? EventAggregations
+      : null
 >;

--- a/content/webapp/services/wellcome/index.ts
+++ b/content/webapp/services/wellcome/index.ts
@@ -15,7 +15,7 @@ export const globalApiOptions = (toggles?: Toggles): GlobalApiOptions => ({
 // Used as a helper to return a typesafe empty results list
 export const emptyResultList = <
   Result,
-  Aggregations extends { type: 'Aggregations' } | null,
+  Aggregations extends { type: 'Aggregations' } | undefined,
 >(): WellcomeResultList<Result, Aggregations> => ({
   type: 'ResultList',
   totalResults: 0,
@@ -29,7 +29,7 @@ export const emptyResultList = <
 
 export type WellcomeResultList<
   Result,
-  Aggregations extends { type: 'Aggregations' } | null,
+  Aggregations extends { type: 'Aggregations' } | undefined,
 > = {
   type: 'ResultList';
   totalResults: number;


### PR DESCRIPTION
## What does this change?
#11487 

I've aimed to make the commits clear and separate if you'd like to follow along on there instead.

- Adds an "all" endpoint
- Because this is the first endpoint without filters/aggregations, I had to change some types. I think `aggregations`'s type was `null` because the Catalogue API uses `null`? But we use `undefined`? Anyway, TS was unhappy, and this seems to do the job, but I'd love to discuss if we think this could cause problems.
- I've created a very basic/awful-looking results page under the toggle. I've merged "works and images" in one as the "catalogue query". I've ensured that "events/stories" queries weren't being done if the toggle was active, and that the "all" query wouldn't happen if no toggle was detected, to save on the amount of queries.
<img width="1212" alt="Screenshot 2025-01-10 at 12 14 45" src="https://github.com/user-attachments/assets/a7db7663-c48a-4089-a127-b709bc4217c1" />
<img width="1213" alt="Screenshot 2025-01-10 at 12 14 50" src="https://github.com/user-attachments/assets/e518c402-44ce-4d61-8ce6-5e5bbb2ad777" />

## How to test

Run locally with and without toggle, please ensure that the current behaviour isn't broken in a way that I haven't found yet! This might also affect /concept pages, so a look there too would be useful.

Keyword queries should work on "all" queries.

## How can we measure success?

We're ready to unblock the FE integration tickets

## Have we considered potential risks?
Current behaviour is affected; but we'll QA that.