### PR TITLE
Use box-decoration-break

### DIFF
--- a/common/views/components/PageHeader/HighlightedHeading.tsx
+++ b/common/views/components/PageHeader/HighlightedHeading.tsx
@@ -5,14 +5,11 @@ import { font } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 
 const Heading = styled(Space)`
-  display: block;
   background-color: ${props => props.theme.color('white')};
-
-  @supports (-webkit-box-decoration-break: clone) {
-    display: inline;
-    line-height: calc(1.1em + 12px);
-    -webkit-box-decoration-break: clone;
-  }
+  display: inline;
+  line-height: calc(1.1em + 12px);
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
 `;
 
 type Props = {


### PR DESCRIPTION
For #11400 

## What does this change?

Adds the (now standard) `box-decoration-break` property to target Chrome, Edge, and Firefox where previously we only had the (`--webkit`) vendor-prefixed version which worked for Safari and Chrome.

## How to test

visit `/about-us` in Firefox and see the white background only covers the words.

The purpose of `box-decoration-break: clone` is to pad the second and subsequent lines of text with the white background.

__without__
<img width="1172" alt="Screenshot 2025-01-14 at 15 08 06" src="https://github.com/user-attachments/assets/5a11b12a-47c4-4dc0-9605-ce606cb7b557" />

__with__
<img width="1173" alt="image" src="https://github.com/user-attachments/assets/8e7d9e49-969b-44be-a432-f02b755476ab" />


## How can we measure success?
Site looks similar in more browsers

## Have we considered potential risks?
n/a