### PR TITLE
Don't announce 'hide/show' in favour or 'collapsed/expanded'

### DIFF
--- a/content/webapp/components/Accordion/Accordion.tsx
+++ b/content/webapp/components/Accordion/Accordion.tsx
@@ -133,6 +133,7 @@ const Accordion: FunctionComponent<Props> = ({
             <SummaryInner>
               {item.summary}{' '}
               <span style={{ display: 'flex' }}>
+                {/* Changing the pseudo text from 'show' to 'hide' based on the presence of the `open` attribute prevents some screenreaders from announcing the change of state from 'collapsed' to 'expanded'. Hiding this text with `aria-hidden` fixes the issue. */}
                 <ShowHide aria-hidden="true"></ShowHide>
                 <Icon icon={chevron} />
               </span>

--- a/content/webapp/components/Accordion/Accordion.tsx
+++ b/content/webapp/components/Accordion/Accordion.tsx
@@ -133,7 +133,7 @@ const Accordion: FunctionComponent<Props> = ({
             <SummaryInner>
               {item.summary}{' '}
               <span style={{ display: 'flex' }}>
-                <ShowHide></ShowHide>
+                <ShowHide aria-hidden="true"></ShowHide>
                 <Icon icon={chevron} />
               </span>
             </SummaryInner>


### PR DESCRIPTION
## What does this change?

Ensures screenreaders correctly announce whether the accordion drawer is 'expanded' or 'collapsed'.

## How to test

View the component in Cardigan, launch VoiceOver, tab to an item, check it announces 'collapsed', press enter/space to open the item, check it announces 'expanded'.

## How can we measure success?
Screenreader users get a consistent experience.


## Have we considered potential risks?
We're not screenreader users ourselves, so in the next accessibility audit this would be a good component to single out for testing.