### PR TITLE
Concepts query by ID only

### DIFF
--- a/content/webapp/pages/concepts/[conceptId].tsx
+++ b/content/webapp/pages/concepts/[conceptId].tsx
@@ -480,7 +480,7 @@ export const getServerSideProps: GetServerSideProps<
         }),
       byLabel: (sectionName: string) =>
         getWorks({
-          params: queryParams(sectionName, conceptResponse),
+          params: allRecordsLinkParams(sectionName, conceptResponse),
           toggles: serverData.toggles,
           pageSize: 5,
         }),
@@ -494,7 +494,7 @@ export const getServerSideProps: GetServerSideProps<
         }),
       byLabel: (sectionName: string) =>
         getImages({
-          params: queryParams(sectionName, conceptResponse),
+          params: allRecordsLinkParams(sectionName, conceptResponse),
           toggles: serverData.toggles,
           pageSize: 5,
         }),

--- a/content/webapp/pages/concepts/[conceptId].tsx
+++ b/content/webapp/pages/concepts/[conceptId].tsx
@@ -43,8 +43,7 @@ import {
   allRecordsLinkParams,
   conceptTypeDisplayName,
   getDisplayIdentifierType,
-  queryParamsById,
-  queryParams as queryParamsByLabel,
+  queryParams,
 } from '@weco/content/utils/concepts';
 import { cacheTTL, setCacheControl } from '@weco/content/utils/setCacheControl';
 
@@ -274,7 +273,7 @@ export const ConceptPage: NextPage<Props> = ({
 }) => {
   useHotjar(true);
   const { conceptsById } = useToggles();
-  const linkParams = conceptsById ? queryParamsById : allRecordsLinkParams;
+  const linkParams = conceptsById ? queryParams : allRecordsLinkParams;
 
   const pathname = usePathname();
   const worksTabs = tabOrder
@@ -475,13 +474,13 @@ export const getServerSideProps: GetServerSideProps<
     works: {
       byId: (sectionName: string) =>
         getWorks({
-          params: queryParamsById(sectionName, conceptResponse),
+          params: queryParams(sectionName, conceptResponse),
           toggles: serverData.toggles,
           pageSize: 5,
         }),
       byLabel: (sectionName: string) =>
         getWorks({
-          params: queryParamsByLabel(sectionName, conceptResponse),
+          params: queryParams(sectionName, conceptResponse),
           toggles: serverData.toggles,
           pageSize: 5,
         }),
@@ -489,13 +488,13 @@ export const getServerSideProps: GetServerSideProps<
     images: {
       byId: (sectionName: string) =>
         getImages({
-          params: queryParamsById(sectionName, conceptResponse),
+          params: queryParams(sectionName, conceptResponse),
           toggles: serverData.toggles,
           pageSize: 5,
         }),
       byLabel: (sectionName: string) =>
         getImages({
-          params: queryParamsByLabel(sectionName, conceptResponse),
+          params: queryParams(sectionName, conceptResponse),
           toggles: serverData.toggles,
           pageSize: 5,
         }),

--- a/content/webapp/utils/concepts.ts
+++ b/content/webapp/utils/concepts.ts
@@ -22,70 +22,41 @@ export const conceptTypeDisplayName = (conceptResponse: ConceptType) => {
     : conceptResponse.type;
 };
 
-const commonKeys = {
+// In order to preserve the existing behaviour of search page filters,
+// the All (Works|Images) links lead to a search for the label corresponding to
+// the genre.
+const linkKeys = {
   worksAbout: { filter: 'subjects.label', fields: ['label'] },
   worksBy: { filter: 'contributors.agent.label', fields: ['label'] },
   imagesAbout: { filter: 'source.subjects.label', fields: ['label'] },
   imagesBy: { filter: 'source.contributors.agent.label', fields: ['label'] },
-};
-
-// Definition of the fields used to populate each section
-// of the page, and to define the link to the "all" searches.
-// Currently, only genres use the id to filter
-// the corresponding works.  As we make the identifiers available
-// for the other queries, they can be changed here.
-// In keeping with our API faceting principles, only the filters that
-// do not operate on the id have the full path to the attribute.
-const queryOnlyKeys = {
-  worksIn: { filter: 'genres.concepts', fields: ['id', 'sameAs'] },
-  imagesIn: { filter: 'source.genres.concepts', fields: ['id', 'sameAs'] },
-};
-
-// In order to preserve the existing behaviour of search page filters,
-// the All (Works|Images) links lead to a search for the label corresponding to
-// the genre.
-// Currently, this matches the label of the genre, rather than individual concept
-// so in some edge situations may not be "correct".  However most genres are
-// not compound, and amongst those that are, many documents also have the main
-// genre of the compound as a separate genre on its own
-const linkOnlyKeys = {
   worksIn: { filter: 'genres.label', fields: ['label'] },
   imagesIn: { filter: 'source.genres.label', fields: ['label'] },
 };
 
-const queryKeys = {
-  ...commonKeys,
-  ...queryOnlyKeys,
-};
-
-const linkKeys = {
-  ...commonKeys,
-  ...linkOnlyKeys,
-};
-
 const keysById = {
   worksAbout: {
-    filter: 'subjects.concepts',
+    filter: 'subjects',
     fields: ['id', 'sameAs'],
   },
   worksBy: {
-    filter: 'contributors.concepts',
+    filter: 'contributors.agent',
     fields: ['id', 'sameAs'],
   },
   imagesAbout: {
-    filter: 'source.subjects.concepts',
+    filter: 'source.subjects',
     fields: ['id', 'sameAs'],
   },
   imagesBy: {
-    filter: 'source.contributors.concepts',
+    filter: 'source.contributors.agent',
     fields: ['id', 'sameAs'],
   },
   worksIn: {
-    filter: 'genres.concepts',
+    filter: 'genres',
     fields: ['id', 'sameAs'],
   },
   imagesIn: {
-    filter: 'source.genres.concepts',
+    filter: 'source.genres',
     fields: ['id', 'sameAs'],
   },
 };
@@ -98,19 +69,6 @@ const gatherValues = (conceptResponse: ConceptType, fields: string[]) => {
 };
 
 export const queryParams = (
-  sectionName: string,
-  conceptResponse: ConceptType
-) => {
-  const queryDefinition = queryKeys[sectionName];
-  return {
-    [queryDefinition.filter]: gatherValues(
-      conceptResponse,
-      queryDefinition.fields
-    ),
-  };
-};
-
-export const queryParamsById = (
   sectionName: string,
   conceptResponse: ConceptType
 ) => {

--- a/content/webapp/utils/concepts.ts
+++ b/content/webapp/utils/concepts.ts
@@ -36,27 +36,27 @@ const linkKeys = {
 
 const keysById = {
   worksAbout: {
-    filter: 'subjects',
+    filters: ['subjects', 'subjects.concepts'],
     fields: ['id', 'sameAs'],
   },
   worksBy: {
-    filter: 'contributors.agent',
+    filters: ['contributors.agent', 'contributors.concepts'],
     fields: ['id', 'sameAs'],
   },
   imagesAbout: {
-    filter: 'source.subjects',
+    filters: ['source.subjects', 'source.subjects.concepts'],
     fields: ['id', 'sameAs'],
   },
   imagesBy: {
-    filter: 'source.contributors.agent',
+    filters: ['source.contributors.agent', 'source.contributors.concepts'],
     fields: ['id', 'sameAs'],
   },
   worksIn: {
-    filter: 'genres',
+    filters: ['genres', 'genres.concepts'],
     fields: ['id', 'sameAs'],
   },
   imagesIn: {
-    filter: 'source.genres',
+    filters: ['source.genres', 'source.genres.concepts'],
     fields: ['id', 'sameAs'],
   },
 };
@@ -72,13 +72,13 @@ export const queryParams = (
   sectionName: string,
   conceptResponse: ConceptType
 ) => {
+  const queryParams = {};
   const queryDefinition = keysById[sectionName];
-  return {
-    [queryDefinition.filter]: gatherValues(
-      conceptResponse,
-      queryDefinition.fields
-    ),
-  };
+  queryDefinition.filters.forEach(filter => {
+    queryParams[filter] = gatherValues(conceptResponse, queryDefinition.fields);
+  });
+
+  return queryParams;
 };
 
 export const allRecordsLinkParams = (


### PR DESCRIPTION
## What does this change?

Query for contributor and subject concepts by ID only on concept pages introduced in https://github.com/wellcomecollection/catalogue-api/pull/832, this change attempts to accommodate the API change at the moment that impacts concept pages.

## How to test

- [x] Run this locally against the prod API, does it behave the same way as the production release? 
- [x] Run this locally against the stage API (or against a local copy of catalogue-api main), does it behave the same way as the production release?
- [x] E2E tests pass: https://buildkite.com/wellcomecollection/wc-dot-org-end-to-end-tests/builds/5328#01946ff5-e895-40c3-84e5-717d03200282

## How can we measure success?

We are able to push the catalogue-api change in main to prod without any unexpected behavior in the frontend.

>[!Note]
> This change needs to go out **before promoting stage to prod**!

## Have we considered potential risks?

This is slightly risky is it relies on edge-case behaviour of the catalogue api to discard unexpected params, we should be protected by e2e tests and other steps in the build pipeline.
