### PR TITLE
Concepts filters & toggle clean-up

### DIFF
--- a/content/webapp/utils/concepts.ts
+++ b/content/webapp/utils/concepts.ts
@@ -36,27 +36,27 @@ const linkKeys = {
 
 const keysById = {
   worksAbout: {
-    filters: ['subjects', 'subjects.concepts'],
+    filters: ['subjects'],
     fields: ['id', 'sameAs'],
   },
   worksBy: {
-    filters: ['contributors.agent', 'contributors.concepts'],
+    filters: ['contributors.agent'],
     fields: ['id', 'sameAs'],
   },
   imagesAbout: {
-    filters: ['source.subjects', 'source.subjects.concepts'],
+    filters: ['source.subjects'],
     fields: ['id', 'sameAs'],
   },
   imagesBy: {
-    filters: ['source.contributors.agent', 'source.contributors.concepts'],
+    filters: ['source.contributors.agent'],
     fields: ['id', 'sameAs'],
   },
   worksIn: {
-    filters: ['genres', 'genres.concepts'],
+    filters: ['genres'],
     fields: ['id', 'sameAs'],
   },
   imagesIn: {
-    filters: ['source.genres', 'source.genres.concepts'],
+    filters: ['source.genres'],
     fields: ['id', 'sameAs'],
   },
 };

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -96,10 +96,10 @@ const toggles = {
     },
     {
       id: 'conceptsById',
-      title: 'Concept Pages by ID',
+      title: 'Concepts Improvements',
       initialValue: false,
       description:
-        'Use the new concept ID filters & aggregatiuons in the search API to query for works & images by ID rather than label.',
+        'Use the new concept ID filters & aggregations in the search API to query for works & images by ID rather than label.',
       type: 'experimental',
     },
     {


### PR DESCRIPTION
> [!Note]
> We should merge this on or after 2024-01-20

## What does this change?

Follows: https://github.com/wellcomecollection/wellcomecollection.org/pull/11505

This change implements a couple of small clean-ups to the concepts work.

- Remove the double filter names following the release of: https://github.com/wellcomecollection/platform/issues/5838
- Update the concepts toggle title and description to better match what's being tested

## How to test

- [x] Run the content app locally against prod APIs, do the concept pages behave in the same way they do in prod?
- [x] Deploy the toggle changes manually, do the toggles update?

<img width="637" alt="Screenshot 2025-01-17 at 08 38 56" src="https://github.com/user-attachments/assets/5b3645b3-4b43-4b3a-b46e-3f20bf97880f" />
<img width="915" alt="Screenshot 2025-01-17 at 08 39 15" src="https://github.com/user-attachments/assets/e44277ee-323e-4260-a178-3b3a7c4a0a60" />


## How can we measure success?

Happier developers because unused or incorrect code isn't hanging around to confuse people.

## Have we considered potential risks?

This should not change any user facing content. We are keeping the old pipeline around until Monday, 2024-01-20 in case we need to revert, so a good idea to wait until that's deleted to ensure we don't need to roll this back.
