### PR TITLE
Item viewer all the things

### DIFF
--- a/content/webapp/components/IIIFItem/IIIFItem.tsx
+++ b/content/webapp/components/IIIFItem/IIIFItem.tsx
@@ -107,6 +107,8 @@ const IIIFImage: FunctionComponent<{
 
 // Some of our ContentResources can have a type of 'Audio':
 // https://iiif.wellcomecollection.org/presentation/v3/b17276342
+// However, the IIIF Presentation API spec only has a type of 'Sound'
+// so we add 'Audio' to the type here.
 export type IIIFItemProps =
   | (Omit<ContentResource, 'type'> & {
       type: ContentResource['type'] | 'Audio';

--- a/content/webapp/components/IIIFItem/IIIFItem.tsx
+++ b/content/webapp/components/IIIFItem/IIIFItem.tsx
@@ -147,8 +147,8 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
     case item.type === 'Image' && !exclude.includes('Image'):
       return <p>Image goes here</p>; // This will be needed if this Item component is to be used to render an Image in the IIIFViewer
     default: // There are other types we don't do anything with at present, e.g. Dataset
-      if (exclude.length === 0) {
-        // If we have exclusions, we don't want to fall back to the BetaMessage
+      if (!exclude.includes(item.type)) {
+        // If the item hasn't been purposefully excluded then we should show a message
         return (
           <ContaineredLayout gridSizes={gridSize12()}>
             <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>

--- a/content/webapp/components/IIIFItem/IIIFItem.tsx
+++ b/content/webapp/components/IIIFItem/IIIFItem.tsx
@@ -3,10 +3,11 @@ import {
   ContentResource,
   InternationalString,
 } from '@iiif/presentation-3';
-import { FunctionComponent } from 'react';
+import { FunctionComponent, useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { unavailableContentMessage } from '@weco/common/data/microcopy';
+import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
 import {
   ContaineredLayout,
   gridSize12,
@@ -14,20 +15,27 @@ import {
 import Space from '@weco/common/views/components/styled/Space';
 import AudioPlayer from '@weco/content/components/AudioPlayer/AudioPlayer';
 import BetaMessage from '@weco/content/components/BetaMessage/BetaMessage';
+import ImageViewer from '@weco/content/components/IIIFViewer/ImageViewer';
 import VideoPlayer from '@weco/content/components/VideoPlayer/VideoPlayer';
 import VideoTranscript from '@weco/content/components/VideoTranscript/VideoTranscript';
+import { fetchCanvasOcr } from '@weco/content/services/iiif/fetch/canvasOcr';
+import { transformCanvasOcr } from '@weco/content/services/iiif/transformers/canvasOcr';
+import { missingAltTextMessage } from '@weco/content/services/wellcome/catalogue/works';
 import {
   CustomContentResource,
   TransformedCanvas,
 } from '@weco/content/types/manifest';
-import { getLabelString } from '@weco/content/utils/iiif/v3';
+import { convertRequestUriToInfoUri } from '@weco/content/utils/iiif/convert-iiif-uri';
+import {
+  getImageServiceFromItem,
+  getLabelString,
+} from '@weco/content/utils/iiif/v3';
 
 const IframePdfViewer = styled(Space)`
   width: 90vw;
   height: 90vh;
   display: block;
   border: 0;
-  margin-top: 98px;
   margin-left: auto;
   margin-right: auto;
 `;
@@ -57,19 +65,62 @@ const Choice: FunctionComponent<
   return null;
 };
 
+const IIIFImage: FunctionComponent<{
+  index: number;
+  item: ItemProps['item'];
+  canvas: TransformedCanvas;
+  setImageRect?: (v: DOMRect) => void;
+  setImageContainerRect?: (v: DOMRect) => void;
+}> = ({ index, item, canvas, setImageRect, setImageContainerRect }) => {
+  const [ocrText, setOcrText] = useState(missingAltTextMessage);
+  const imageService = getImageServiceFromItem(item);
+  const imageUrl = imageService?.['@id'] || '';
+  const infoUrl = convertRequestUriToInfoUri(imageUrl);
+  const urlTemplate = imageUrl ? iiifImageTemplate(imageUrl) : undefined;
+  useEffect(() => {
+    const fetchOcr = async () => {
+      const ocrText = await fetchCanvasOcr(canvas);
+      const ocrString = transformCanvasOcr(ocrText);
+      setOcrText(ocrString || missingAltTextMessage);
+    };
+    fetchOcr();
+  }, []);
+
+  if (urlTemplate) {
+    return (
+      <ImageViewer
+        infoUrl={infoUrl}
+        id={imageUrl}
+        width={canvas.width || 0}
+        height={canvas.height || 0}
+        index={index}
+        alt={ocrText}
+        urlTemplate={urlTemplate}
+        setImageRect={setImageRect}
+        setImageContainerRect={setImageContainerRect}
+      />
+    );
+  } else {
+    return <img src={item.id} alt={ocrText} />;
+  }
+};
+
+// Some of our ContentResources can have a type of 'Audio':
+// https://iiif.wellcomecollection.org/presentation/v3/b17276342
+export type IIIFItemProps =
+  | (Omit<ContentResource, 'type'> & {
+      type: ContentResource['type'] | 'Audio';
+    })
+  | CustomContentResource
+  | ChoiceBody;
 type ItemProps = {
   canvas: TransformedCanvas;
-  // Some of our ContentResources can have a type of 'Audio':
-  // https://iiif.wellcomecollection.org/presentation/v3/b17276342
-  item:
-    | (Omit<ContentResource, 'type'> & {
-        type: ContentResource['type'] | 'Audio';
-      })
-    | CustomContentResource
-    | ChoiceBody;
+  item: IIIFItemProps;
   placeholderId: string | undefined;
   i: number;
-  exclude: (ContentResource['type'] | 'Audio' | ChoiceBody['type'])[]; // allows us to exclude certain types from being rendered
+  exclude: (ContentResource['type'] | 'Audio' | ChoiceBody['type'])[]; // Allows us to prevent specific types being rendered
+  setImageRect?: (v: DOMRect) => void;
+  setImageContainerRect?: (v: DOMRect) => void;
 };
 
 // This component will be useful for the IIIFViewer if we want to make that render video, audio, pdfs and Born Digital files in addition to images.
@@ -81,6 +132,8 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
   placeholderId,
   i,
   exclude,
+  setImageRect,
+  setImageContainerRect,
 }) => {
   switch (true) {
     case item.type === 'Choice' && !exclude.includes('Choice'):
@@ -93,6 +146,8 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
           i={i}
           RenderItem={IIIFItem}
           exclude={exclude}
+          setImageRect={setImageRect}
+          setImageContainerRect={setImageContainerRect}
         />
       );
     case ((item.type === 'Sound' && !exclude.includes('Sound')) ||
@@ -106,14 +161,14 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
       );
     case item.type === 'Video' && !exclude.includes('Video'):
       return (
-        <>
+        <div className="video">
           <VideoPlayer
-            video={item}
             placeholderId={placeholderId}
+            video={item}
             showDownloadOptions={true}
           />
           <VideoTranscript supplementing={canvas.supplementing} />
-        </>
+        </div>
       );
     case item.type === 'Text' && !exclude.includes('Text'):
       if ('label' in item) {
@@ -122,30 +177,24 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
           : '';
         return (
           <IframePdfViewer
-            $v={{
-              size: 'l',
-              properties: ['margin-bottom'],
-            }}
             as="iframe"
             title={`PDF: ${itemLabel}`}
             src={item.id}
           />
         );
       } else {
-        return (
-          <IframePdfViewer
-            $v={{
-              size: 'l',
-              properties: ['margin-bottom'],
-            }}
-            as="iframe"
-            title="PDF"
-            src={item.id}
-          />
-        );
+        return <IframePdfViewer as="iframe" title="PDF" src={item.id} />;
       }
     case item.type === 'Image' && !exclude.includes('Image'):
-      return <p>Image goes here</p>; // This will be needed if this Item component is to be used to render an Image in the IIIFViewer
+      return (
+        <IIIFImage
+          index={i}
+          item={item}
+          canvas={canvas}
+          setImageRect={setImageRect}
+          setImageContainerRect={setImageContainerRect}
+        />
+      );
     default: // There are other types we don't do anything with at present, e.g. Dataset
       if (!exclude.includes(item.type)) {
         // If the item hasn't been purposefully excluded then we should show a message

--- a/content/webapp/components/IIIFViewer/IIIFViewer.tsx
+++ b/content/webapp/components/IIIFViewer/IIIFViewer.tsx
@@ -349,8 +349,6 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
                 index={0}
                 alt={work?.description || work?.title || ''}
                 urlTemplate={urlTemplate}
-                setImageRect={() => undefined}
-                setImageContainerRect={() => undefined}
               />
             )}
 

--- a/content/webapp/components/IIIFViewer/IIIFViewer.tsx
+++ b/content/webapp/components/IIIFViewer/IIIFViewer.tsx
@@ -10,6 +10,7 @@ import {
 import styled from 'styled-components';
 
 import { DigitalLocation } from '@weco/common/model/catalogue';
+import { useToggles } from '@weco/common/server-data/Context';
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
 import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
 import LL from '@weco/common/views/components/styled/LL';
@@ -218,6 +219,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
     shouldScrollToCanvas = true,
     query = '',
   } = fromQuery(router.query);
+  const { extendedViewer } = useToggles();
   const [gridVisible, setGridVisible] = useState(false);
   const { isFullSupportBrowser } = useContext(AppContext);
   const viewerRef = useRef<HTMLDivElement>(null);
@@ -357,9 +359,9 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
             )}
 
             {/* If we hide the MainViewer when resizing the browser, it will then rerender with the correct canvas displayed */}
-            {hasImageService && !isResizing && isFullSupportBrowser && (
-              <MainViewer />
-            )}
+            {(hasImageService || extendedViewer) &&
+              !isResizing &&
+              isFullSupportBrowser && <MainViewer />}
           </DelayVisibility>
         </Main>
         {showZoomed && isFullSupportBrowser && (

--- a/content/webapp/components/IIIFViewer/IIIFViewerImage.tsx
+++ b/content/webapp/components/IIIFViewer/IIIFViewerImage.tsx
@@ -2,6 +2,7 @@ import { forwardRef, useState } from 'react';
 import styled from 'styled-components';
 
 import { convertIiifImageUri } from '@weco/common/utils/convert-image-uri';
+import LL from '@weco/common/views/components/styled/LL';
 import { convertRequestUriToInfoUri } from '@weco/content/utils/iiif/convert-iiif-uri';
 async function getImageMax(url: string): Promise<number> {
   try {
@@ -61,50 +62,57 @@ const IIIFViewerImage = (
   ref
 ) => {
   const [tryLoadingSmallerImg, setTryLoadingSmallerImg] = useState(true);
+  const [hasLoaded, setHasLoaded] = useState(false);
   return (
-    <Image
-      data-testid={index !== undefined ? `image-${index}` : null}
-      ref={ref}
-      tabIndex={tabIndex}
-      lang={lang}
-      width={width}
-      height={height}
-      className="image"
-      $zoomOnClick={zoomOnClick}
-      $highlightImage={highlightImage}
-      onLoad={loadHandler}
-      onClick={clickHandler}
-      onKeyDown={({ key, keyCode }) => {
-        if (key === 'Enter' || keyCode === 13) {
-          clickHandler && clickHandler();
-        }
-      }}
-      onError={async ({ currentTarget }) => {
-        // Hack/workaround
-        // If the image fails to load it may be because of a size limit,
-        // see: https://wellcome.slack.com/archives/CBT40CMKQ/p1691050149722109,
-        // so first off we try a smaller image
-        if (tryLoadingSmallerImg) {
-          setTryLoadingSmallerImg(false); // prevent looping if image fails to load again
-          // we need to know the max size of the longest side first
-          const imageMax = await getImageMax(currentTarget.src);
-          const isPortrait = Boolean(height && height > width);
-          const newSrc = isPortrait
-            ? convertIiifImageUri(currentTarget.src, imageMax, true)
-            : convertIiifImageUri(currentTarget.src, imageMax);
-          currentTarget.src = newSrc;
-          currentTarget.removeAttribute('srcset');
-          currentTarget.removeAttribute('sizes');
-        } else {
-          // If the image still fails to load, we check to see if it's because the authorisation cookie is missing/no longer valid
-          errorHandler && errorHandler();
-        }
-      }}
-      src={src}
-      srcSet={srcSet}
-      sizes={sizes}
-      alt={alt}
-    />
+    <>
+      {!hasLoaded && <LL $lighten={true} />}
+      <Image
+        data-testid={index !== undefined ? `image-${index}` : null}
+        ref={ref}
+        tabIndex={tabIndex}
+        lang={lang}
+        width={width}
+        height={height}
+        className="image"
+        $zoomOnClick={zoomOnClick}
+        $highlightImage={highlightImage}
+        onLoad={() => {
+          loadHandler && loadHandler();
+          setHasLoaded(true);
+        }}
+        onClick={clickHandler}
+        onKeyDown={({ key, keyCode }) => {
+          if (key === 'Enter' || keyCode === 13) {
+            clickHandler && clickHandler();
+          }
+        }}
+        onError={async ({ currentTarget }) => {
+          // Hack/workaround
+          // If the image fails to load it may be because of a size limit,
+          // see: https://wellcome.slack.com/archives/CBT40CMKQ/p1691050149722109,
+          // so first off we try a smaller image
+          if (tryLoadingSmallerImg) {
+            setTryLoadingSmallerImg(false); // prevent looping if image fails to load again
+            // we need to know the max size of the longest side first
+            const imageMax = await getImageMax(currentTarget.src);
+            const isPortrait = Boolean(height && height > width);
+            const newSrc = isPortrait
+              ? convertIiifImageUri(currentTarget.src, imageMax, true)
+              : convertIiifImageUri(currentTarget.src, imageMax);
+            currentTarget.src = newSrc;
+            currentTarget.removeAttribute('srcset');
+            currentTarget.removeAttribute('sizes');
+          } else {
+            // If the image still fails to load, we check to see if it's because the authorisation cookie is missing/no longer valid
+            errorHandler && errorHandler();
+          }
+        }}
+        src={src}
+        srcSet={srcSet}
+        sizes={sizes}
+        alt={alt}
+      />
+    </>
   );
 };
 

--- a/content/webapp/components/IIIFViewer/ImageViewer.tsx
+++ b/content/webapp/components/IIIFViewer/ImageViewer.tsx
@@ -103,10 +103,10 @@ const ImageViewer: FunctionComponent<ImageViewerProps> = ({
     const imageContainerRect =
       imageWrapperRef?.current?.getBoundingClientRect();
     if (imageRect) {
-      setImageRect(imageRect);
+      setImageRect && setImageRect(imageRect);
     }
     if (imageContainerRect) {
-      setImageContainerRect(imageContainerRect);
+      setImageContainerRect && setImageContainerRect(imageContainerRect);
     }
   }
 

--- a/content/webapp/components/IIIFViewer/ImageViewer.tsx
+++ b/content/webapp/components/IIIFViewer/ImageViewer.tsx
@@ -73,11 +73,11 @@ const ImageViewer: FunctionComponent<ImageViewerProps> = ({
     rotatedImages,
     transformedManifest,
   } = useContext(ItemViewerContext);
-  const imageViewer = useRef<HTMLDivElement>(null);
+  const imageWrapperRef = useRef<HTMLDivElement>(null);
   const imageRef = useRef<HTMLDivElement>(null);
   const isOnScreen = useOnScreen({
     root: mainAreaRef?.current || undefined,
-    ref: imageViewer || undefined,
+    ref: imageWrapperRef || undefined,
     threshold: [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9],
   });
   const [imageSrc, setImageSrc] = useState(urlTemplate({ size: '640,' }));
@@ -100,7 +100,8 @@ const ImageViewer: FunctionComponent<ImageViewerProps> = ({
 
   function updateImagePosition() {
     const imageRect = imageRef?.current?.getBoundingClientRect();
-    const imageContainerRect = imageViewer?.current?.getBoundingClientRect();
+    const imageContainerRect =
+      imageWrapperRef?.current?.getBoundingClientRect();
     if (imageRect) {
       setImageRect(imageRect);
     }
@@ -163,7 +164,7 @@ const ImageViewer: FunctionComponent<ImageViewerProps> = ({
   }, []);
 
   return (
-    <ImageWrapper onLoad={loadHandler} ref={imageViewer}>
+    <ImageWrapper onLoad={loadHandler} ref={imageWrapperRef}>
       <IIIFViewerImage
         index={index}
         ref={imageRef}

--- a/content/webapp/components/IIIFViewer/ImageViewer.tsx
+++ b/content/webapp/components/IIIFViewer/ImageViewer.tsx
@@ -49,8 +49,8 @@ type ImageViewerProps = {
   urlTemplate: (v: IIIFUriProps) => string;
   loadHandler?: () => void;
   index: number;
-  setImageRect: (v: DOMRect) => void;
-  setImageContainerRect: (v: DOMRect) => void;
+  setImageRect?: (v: DOMRect) => void;
+  setImageContainerRect?: (v: DOMRect) => void;
 };
 
 const ImageViewer: FunctionComponent<ImageViewerProps> = ({

--- a/content/webapp/components/IIIFViewer/MainViewer.tsx
+++ b/content/webapp/components/IIIFViewer/MainViewer.tsx
@@ -84,6 +84,8 @@ type ItemRendererProps = {
     errorHandler?: () => void;
     externalAccessService: TransformedAuthService | undefined;
     accessToken?: string;
+    restrictedService: AuthExternalService | undefined;
+    placeholderId: string | undefined;
   };
 };
 
@@ -398,7 +400,7 @@ const MainViewer: FunctionComponent = () => {
     debounce(handleOnItemsRendered, 500)
   );
   const timer = useRef<ReturnType<typeof setTimeout> | undefined>();
-  const { canvases, auth } = {
+  const { canvases, auth, placeholderId } = {
     ...transformedManifest,
   };
 
@@ -425,7 +427,6 @@ const MainViewer: FunctionComponent = () => {
       const viewer = mainViewerRef?.current;
       scrollViewer({ currentCanvas, canvas, viewer, mainAreaWidth });
       setFirstRender(false);
-      setShowControls(true);
     }
   }
 
@@ -459,6 +460,7 @@ const MainViewer: FunctionComponent = () => {
           externalAccessService,
           canvas,
           accessToken,
+          placeholderId,
         }}
         itemSize={mainAreaWidth}
         onItemsRendered={debounceHandleOnItemsRendered.current}

--- a/content/webapp/components/IIIFViewer/MainViewer.tsx
+++ b/content/webapp/components/IIIFViewer/MainViewer.tsx
@@ -19,10 +19,7 @@ import ItemViewerContext, {
   RotatedImage,
 } from '@weco/content/components/ItemViewerContext/ItemViewerContext';
 import useScrollVelocity from '@weco/content/hooks/useScrollVelocity';
-import { fetchCanvasOcr } from '@weco/content/services/iiif/fetch/canvasOcr';
-import { transformCanvasOcr } from '@weco/content/services/iiif/transformers/canvasOcr';
 import { SearchResults } from '@weco/content/services/iiif/types/search/v3';
-import { missingAltTextMessage } from '@weco/content/services/wellcome/catalogue/works';
 import { TransformedCanvas } from '@weco/content/types/manifest';
 import { convertRequestUriToInfoUri } from '@weco/content/utils/iiif/convert-iiif-uri';
 import { TransformedAuthService } from '@weco/content/utils/iiif/v3';
@@ -229,20 +226,10 @@ const ItemRenderer = memo(({ style, index, data }: ItemRendererProps) => {
   const [imageContainerRect, setImageContainerRect] = useState<
     DOMRect | undefined
   >();
-  const [ocrText, setOcrText] = useState(missingAltTextMessage);
 
   const [overlayPositionData, setOverlayPositionData] = useState<
     OverlayPositionData[]
   >([]);
-
-  useEffect(() => {
-    const fetchOcr = async () => {
-      const ocrText = await fetchCanvasOcr(canvases[index]);
-      const ocrString = transformCanvasOcr(ocrText);
-      setOcrText(ocrString || missingAltTextMessage);
-    };
-    fetchOcr();
-  }, []);
 
   useEffect(() => {
     // The search hit dimensions and coordinates are given relative to the full size image.

--- a/content/webapp/components/IIIFViewer/MainViewer.tsx
+++ b/content/webapp/components/IIIFViewer/MainViewer.tsx
@@ -26,6 +26,48 @@ import { TransformedAuthService } from '@weco/content/utils/iiif/v3';
 
 import { queryParamToArrayIndex } from '.';
 import ImageViewer from './ImageViewer';
+
+// Temporary styling for viewer to display audio, video and pdfs
+// will be tidied up in future work
+const ItemWrapper = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+
+  right: 0;
+  padding: 0;
+
+  figure,
+  .video {
+    margin: auto;
+    position: relative;
+    top: 50%;
+    transform: translateY(-50%);
+    display: block;
+    width: auto;
+    height: auto;
+    max-width: 80%;
+    max-height: 95%;
+  }
+
+  iframe {
+    width: 100%;
+    height: 100%;
+    border: 0;
+  }
+
+  .video {
+    video {
+      width: 100%;
+    }
+  }
+
+  img {
+    overflow: scroll; /* for alt text, which can be long */
+  }
+`;
+
 type OverlayPositionData = {
   canvasNumber: number;
   overlayTop: number;

--- a/content/webapp/components/IIIFViewer/MainViewer.tsx
+++ b/content/webapp/components/IIIFViewer/MainViewer.tsx
@@ -37,6 +37,7 @@ const ItemWrapper = styled.div`
   right: 0;
   padding: 0;
 
+  img,
   figure,
   .video {
     margin: auto;
@@ -274,7 +275,6 @@ const ItemRenderer = memo(({ style, index, data }: ItemRendererProps) => {
     // This needs to be recalculated whenever the image changes size or orientation.
     const searchHitsPositioningData =
       imageContainerRect &&
-
       imageRect &&
       getPositionData({
         imageContainerRect,

--- a/content/webapp/components/IIIFViewer/MainViewer.tsx
+++ b/content/webapp/components/IIIFViewer/MainViewer.tsx
@@ -167,7 +167,7 @@ function getPositionData({
   canvases: TransformedCanvas[];
   rotatedImages: RotatedImage[];
 }): OverlayPositionData[] {
-  const highlightsPositioningData = searchResults?.resources.map(resource => {
+  const searchHitsPositioningData = searchResults?.resources.map(resource => {
     // on: "https://wellcomelibrary.org/iiif/b30330002/canvas/c55#xywh=2301,662,157,47"
     // OR
     // on: https://iiif.wellcomecollection.org/presentation/b29338062/canvases/b29338062_0031.jp2#xywh=148,2277,259,59"
@@ -207,7 +207,7 @@ function getPositionData({
       rotation: matchingRotation?.rotation || 0,
     };
   });
-  return highlightsPositioningData || [];
+  return searchHitsPositioningData || [];
 }
 const ItemRenderer = memo(({ style, index, data }: ItemRendererProps) => {
   const { scrollVelocity, canvases, externalAccessService } = data;
@@ -244,12 +244,12 @@ const ItemRenderer = memo(({ style, index, data }: ItemRendererProps) => {
 
   useEffect(() => {
     // The search hit dimensions and coordinates are given relative to the full size image.
-    // The highlights are positioned relative to the image container.
-    // Therefore, in order to display the highlights correctly over the search hits,
+    // The highlight overlays are positioned relative to the image container.
+    // Therefore, in order to display the highlight overlays correctly over the search hits,
     // we need to get the position of the image relative to the container and the display scale of the image relative to the full size.
-    // We then need to calculate the position of the highlight factoring in the orientation of the image.
+    // We then need to calculate the position of the highlight overlays factoring in the orientation of the image.
     // This needs to be recalculated whenever the image changes size or orientation.
-    const highlightsPositioningData =
+    const searchHitsPositioningData =
       imageContainerRect &&
       imageRect &&
       getPositionData({
@@ -260,9 +260,9 @@ const ItemRenderer = memo(({ style, index, data }: ItemRendererProps) => {
         canvases,
         rotatedImages,
       });
-    if (highlightsPositioningData) {
+    if (searchHitsPositioningData) {
       setOverlayPositionData(
-        highlightsPositioningData.filter(item => {
+        searchHitsPositioningData.filter(item => {
           return item.canvasNumber === index;
         })
       );

--- a/content/webapp/components/IIIFViewer/MainViewer.tsx
+++ b/content/webapp/components/IIIFViewer/MainViewer.tsx
@@ -419,7 +419,7 @@ const MainViewer: FunctionComponent = () => {
     }, 500);
   }
 
-  // We display the canvas indicated by the canvas when the page first loads
+  // We display the canvas indicated by the canvas (index) when the page first loads
   function handleOnItemsRendered() {
     let currentCanvas: TransformedCanvas | undefined;
     if (firstRenderRef.current) {

--- a/content/webapp/components/IIIFViewer/MainViewer.tsx
+++ b/content/webapp/components/IIIFViewer/MainViewer.tsx
@@ -121,10 +121,10 @@ type ItemRendererProps = {
     canvases: TransformedCanvas[];
     rotatedImages: RotatedImage[];
     errorHandler?: () => void;
-    externalAccessService: TransformedAuthService | undefined;
+    externalAccessService?: TransformedAuthService;
     accessToken?: string;
-    restrictedService: AuthExternalService | undefined;
-    placeholderId: string | undefined;
+    restrictedService?: AuthExternalService;
+    placeholderId?: string;
   };
 };
 

--- a/content/webapp/components/VideoPlayer/VideoPlayer.tsx
+++ b/content/webapp/components/VideoPlayer/VideoPlayer.tsx
@@ -35,11 +35,6 @@ const VideoPlayer: FunctionComponent<Props> = ({
       controls
       preload="none"
       poster={placeholderId}
-      style={{
-        maxWidth: '100%',
-        maxHeight: '260px',
-        display: 'inline-block',
-      }}
     >
       <source src={video.id} type={video.format} />
       {`Sorry, your browser doesn't support embedded video.`}

--- a/content/webapp/pages/works/[workId]/items.tsx
+++ b/content/webapp/pages/works/[workId]/items.tsx
@@ -128,7 +128,7 @@ const ItemPage: NextPage<Props> = ({
 }) => {
   useHotjar(true);
   const { userIsStaffWithRestricted } = useUser();
-  const { authV2 } = useToggles();
+  const { authV2, extendedViewer } = useToggles();
   const transformedManifest =
     compressedTransformedManifest &&
     fromCompressedManifest(compressedTransformedManifest);
@@ -266,10 +266,9 @@ const ItemPage: NextPage<Props> = ({
       will have a hasImage value of true.
       However, we don't show the viewer for these items,
       so we check for the presence of a pdf in the original property of the canvas.
-      If it has one we show the IIIFItemList
+      If it has one we show the IIIFItemList, unless we are using the extended viewer.
       */}
-
-      {(!hasImage || hasPdf) && showViewer && (
+      {(!hasImage || hasPdf) && showViewer && !extendedViewer && (
         <ContaineredLayout gridSizes={gridSize12()}>
           <Space
             className="body-text"
@@ -331,7 +330,9 @@ const ItemPage: NextPage<Props> = ({
       </Modal>
 
       {showViewer &&
-        ((mainImageService && currentCanvas) || iiifImageLocation) && (
+        ((mainImageService && currentCanvas) ||
+          iiifImageLocation ||
+          extendedViewer) && (
           <IIIFViewer
             work={work}
             transformedManifest={transformedManifest}

--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -652,7 +652,7 @@ export function getOriginalFiles(
   return downloadData || [];
 }
 
-// If we have a files size, it is found in the metadata array of the canvas
+// If we have a file size, it is found in the metadata array of the canvas
 export function getFileSize(canvas: TransformedCanvas): string | undefined {
   const fileSizeMeta = canvas.metadata.find(
     metadata => getLabelString(metadata.label) === 'File size'

--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -23,6 +23,7 @@ import {
 } from '@iiif/presentation-3';
 
 import { isString } from '@weco/common/utils/type-guards';
+import { IIIFItemProps } from '@weco/content/components/IIIFItem/IIIFItem';
 import {
   Auth,
   AuthClickThroughServiceWithPossibleServiceArray,
@@ -170,9 +171,7 @@ function getCanvasTextServiceId(canvas: Canvas): string | undefined {
   return textAnnotation?.id;
 }
 
-export const isChoiceBody = (
-  item: ContentResource | ChoiceBody
-): item is ChoiceBody => {
+export const isChoiceBody = (item: IIIFItemProps): item is ChoiceBody => {
   return typeof item !== 'string' && 'type' in item && item.type === 'Choice';
 };
 

--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -180,7 +180,7 @@ type AnnotationPageBody = {
   service: BodyService;
 };
 
-function getImageService(canvas: Canvas): BodyService | undefined {
+function getImageServiceFromCanvas(canvas: Canvas): BodyService | undefined {
   const items = canvas?.items;
   const AnnotationPages = items?.[0].items;
   const AnnotationBodies = AnnotationPages?.map(
@@ -298,7 +298,7 @@ const restrictedAuthServiceUrls = [
 // We want to move to using v2, but can't guarantee all manifests will include them (they need to be recently generated to have the v2 services).
 // Therefore we check for both. When all manifests have V2 we can remove the V1 code.
 function isImageRestricted(canvas: Canvas): boolean {
-  const imageService = getImageService(canvas);
+  const imageService = getImageServiceFromCanvas(canvas);
   const imageAuthCookieService = getImageAuthCookieService(imageService); // V1 service
   const v2Services = imageService?.service as BodyService2;
   const imageAuthProbeService = getImageAuthProbeService(v2Services || []); // V2 service
@@ -473,7 +473,7 @@ export function getDisplayData(
     .filter(Boolean) as (ChoiceBody | ContentResource)[];
 }
 export function transformCanvas(canvas: Canvas): TransformedCanvas {
-  const imageService = getImageService(canvas);
+  const imageService = getImageServiceFromCanvas(canvas);
   const imageServiceId = getImageServiceId(imageService);
   const hasRestrictedImage = isImageRestricted(canvas);
   const label = getCanvasLabel(canvas);

--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -13,6 +13,7 @@ import {
   Collection,
   CollectionItems,
   ContentResource,
+  ImageService,
   InternationalString,
   Manifest,
   MetadataItem,
@@ -179,6 +180,16 @@ export const isChoiceBody = (item: IIIFItemProps): item is ChoiceBody => {
 type AnnotationPageBody = {
   service: BodyService;
 };
+
+export function getImageServiceFromItem(
+  item: IIIFItemProps
+): ImageService | undefined {
+  if ('service' in item) {
+    return item.service?.find(
+      s => s['@type'] === 'ImageService2'
+    ) as ImageService;
+  }
+}
 
 function getImageServiceFromCanvas(canvas: Canvas): BodyService | undefined {
   const items = canvas?.items;


### PR DESCRIPTION
## What does this change?

Makes it possible for the /items page to display video, audio and pdfs in the viewer, as well as images.

This work is currently behind a toggle (toggle_extendedViewer), as there are some issues with displaying these new things that need ironing out.

## How to test

Run with the toggle turned off and the following should behave exactly as they do on production:

Digitised book: [localhost:3000/works/jm4kaz67/items](localhost:3000/works/jm4kaz67/items)
please check image alt text, search (search highlighting), rotation and zoom controls, downloads (downloads selected image)
Pdf ingested pre born digital: [localhost:3000/works/yycbn2r4/items](localhost:3000/works/yycbn2r4/items)
Digitised video: [localhost:3000/works/sx4p4b75/items](localhost:3000/works/sx4p4b75/items)
Digitised audio: [localhost:3000/works/tp9njewm/items](localhost:3000/works/tp9njewm/items)
Born digital images: [localhost:3000/works/bek57gd8/items](localhost:3000/works/bek57gd8/items)
Born digital mixed: [localhost:3000/works/dn9jwck6/items](localhost:3000/works/dn9jwck6/items)
Born digital pdf: [localhost:3000/works/pmv8cncs/items](localhost:3000/works/pmv8cncs/items)

Run with the toggle turned on:
Digitised books should behave the same way
Audio, video and pdf should now show in viewer
Born digital should now show in the viewer with place holder images for files we can't display

## How can we measure success?

Nothing changes without the toggle turned on, but we can work on improving the viewer for the new file types

## Have we considered potential risks?

The viewer breaks in some way, without the toggle turned on.

