### PR TITLE
Only show controls for things with an image service

### DIFF
--- a/content/webapp/components/IIIFViewer/MainViewer.tsx
+++ b/content/webapp/components/IIIFViewer/MainViewer.tsx
@@ -274,7 +274,6 @@ const ItemRenderer = memo(({ style, index, data }: ItemRendererProps) => {
     // This needs to be recalculated whenever the image changes size or orientation.
     const searchHitsPositioningData =
       imageContainerRect &&
-
       imageRect &&
       getPositionData({
         imageContainerRect,
@@ -459,7 +458,10 @@ const MainViewer: FunctionComponent = () => {
     setNewScrollOffset(scrollOffset);
 
     timer.current = setTimeout(() => {
-      setShowControls(true);
+      const currentCanvas = canvases?.[queryParamToArrayIndex(canvas)];
+      if (currentCanvas?.imageServiceId) {
+        setShowControls(true);
+      }
     }, 500);
   }
 


### PR DESCRIPTION
## What does this change?

For #11513

It only makes sense to show the rotation and zoom controls for items that have an image service. They shouldn't show when display the audio/video players or pdfs.

## How to test

Make sure the extendedViewer toggle is turned on

Visit http://localhost:3000/works/enye955g/items
The controls for rotation and zoom should appear when each canvas is scrolled to

Visit:
http://localhost:3000/works/yycbn2r4/items (pdf)
http://localhost:3000/works/tp9njewm/items (audio)
http://localhost:3000/works/qvgcmea3/items (born digital)
http://localhost:3000/works/fhy2fv5k/items (video)

The controls for rotation and zoom should **not** appear

## How can we measure success?

Redundant controls aren't displayed

## Have we considered potential risks?

The controls don't show when they should.

