### PR TITLE
Add override publishDate field in series

### DIFF
--- a/common/customtypes/series/index.json
+++ b/common/customtypes/series/index.json
@@ -253,6 +253,15 @@
           }
         }
       }
+    },
+    "Overrides": {
+      "publishDate": {
+        "type": "Timestamp",
+        "config": {
+          "label": "Override published date",
+          "placeholder": ""
+        }
+      }
     }
   }
 }

--- a/common/prismicio-types.d.ts
+++ b/common/prismicio-types.d.ts
@@ -4939,7 +4939,16 @@ interface SeriesDocumentData {
    * - **Tab**: Content relationships
    * - **Documentation**: https://prismic.io/docs/field#group
    */;
-  seasons: prismic.GroupField<Simplify<SeriesDocumentDataSeasonsItem>>;
+  seasons: prismic.GroupField<Simplify<SeriesDocumentDataSeasonsItem>> /**
+   * Override published date field in *Story series*
+   *
+   * - **Field Type**: Timestamp
+   * - **Placeholder**: *None*
+   * - **API ID Path**: series.publishDate
+   * - **Tab**: Overrides
+   * - **Documentation**: https://prismic.io/docs/field#timestamp
+   */;
+  publishDate: prismic.TimestampField;
 }
 
 /**


### PR DESCRIPTION
## What does this change?

For #11488 prep; we'll want this field to exist specifically for Body Squabbles when we move it from a webcomic series to a series. 

## How to test

It should match what we have in "articles". The label is different as Prismic no longer allows for more than 35 characters.

## How can we measure success?

Able to migrate content seamlessly.

## Have we considered potential risks?
N/A not much danger in adding a field