### PR TITLE
Update WAF rules to block bots with matching user-agents

### DIFF
--- a/cache/cloudfront_rss.tf
+++ b/cache/cloudfront_rss.tf
@@ -9,7 +9,7 @@ resource "aws_cloudfront_distribution" "rss_wc_org" {
   enabled          = true
   retain_on_delete = false
   is_ipv6_enabled  = true
-  aliases          = [
+  aliases = [
     "rss.wellcomecollection.org",
   ]
 
@@ -60,7 +60,7 @@ resource "aws_cloudfront_distribution" "rss_wc_org" {
     response_headers_policy_id = module.cloudfront_policies.response_policies["weco-security"]
 
     function_association {
-      event_type = "viewer-request"
+      event_type   = "viewer-request"
       function_arn = aws_cloudfront_function.rss_stories_url_rewrite.arn
     }
   }

--- a/cache/modules/wc_org_cloudfront/distribution.tf
+++ b/cache/modules/wc_org_cloudfront/distribution.tf
@@ -249,8 +249,8 @@ resource "aws_cloudfront_distribution" "wc_org" {
     cached_methods         = local.stateless_methods
     viewer_protocol_policy = "redirect-to-https"
 
-    cache_policy_id            = var.cache_policies["weco-apps"]
-    origin_request_policy_id   = var.request_policies["host-query-and-toggles"]
+    cache_policy_id          = var.cache_policies["weco-apps"]
+    origin_request_policy_id = var.request_policies["host-query-and-toggles"]
 
     // We can't apply the security headers policy to Slice Machine routes, as
     // it breaks the Slice Machine preview.

--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -302,6 +302,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
       managed_rule_group_statement {
         name        = "AWSManagedRulesBotControlRuleSet"
         vendor_name = "AWS"
+        version     = "Version_3.1"
 
         managed_rule_group_configs {
           aws_managed_rules_bot_control_rule_set {
@@ -384,6 +385,68 @@ resource "aws_wafv2_web_acl" "wc_org" {
     visibility_config {
       cloudwatch_metrics_enabled = true
       metric_name                = "geo-rate-limit-${var.namespace}"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "bot-user-agent-manual"
+    priority = 11
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        aggregate_key_type    = "CONSTANT"
+        evaluation_window_sec = 60
+        limit                 = 300
+
+        scope_down_statement {
+          or_statement {
+            statement {
+              byte_match_statement {
+                positional_constraint = "CONTAINS"
+                search_string         = "PetalBot"
+
+                field_to_match {
+                  single_header {
+                    name = "user-agent"
+                  }
+                }
+
+                text_transformation {
+                  priority = 0
+                  type     = "NONE"
+                }
+              }
+            }
+            statement {
+              byte_match_statement {
+                positional_constraint = "CONTAINS"
+                search_string         = "ClaudeBot"
+
+                field_to_match {
+                  single_header {
+                    name = "user-agent"
+                  }
+                }
+
+                text_transformation {
+                  priority = 0
+                  type     = "NONE"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "bot-user-agent-manual"
       sampled_requests_enabled   = true
     }
   }

--- a/cache/terraform.tf
+++ b/cache/terraform.tf
@@ -5,7 +5,9 @@ terraform {
     dynamodb_table = "terraform-locktable"
     region         = "eu-west-1"
     bucket         = "wellcomecollection-infra"
-    role_arn       = "arn:aws:iam::130871440101:role/experience-developer"
+    assume_role = {
+      role_arn = "arn:aws:iam::130871440101:role/experience-developer"
+    }
   }
 }
 
@@ -48,7 +50,10 @@ data "terraform_remote_state" "experience" {
   backend = "s3"
 
   config = {
-    role_arn = "arn:aws:iam::130871440101:role/experience-read_only"
+    assume_role = {
+      role_arn = "arn:aws:iam::130871440101:role/experience-read_only"
+    }
+
     bucket   = "wellcomecollection-experience-infra"
     key      = "terraform/experience.tfstate"
     region   = "eu-west-1"
@@ -62,7 +67,9 @@ data "terraform_remote_state" "assets" {
     bucket   = "wellcomecollection-infra"
     key      = "build-state/client.tfstate"
     region   = "eu-west-1"
-    role_arn = "arn:aws:iam::130871440101:role/experience-read_only"
+    assume_role = {
+      role_arn = "arn:aws:iam::130871440101:role/experience-read_only"
+    }
   }
 }
 
@@ -73,7 +80,9 @@ data "terraform_remote_state" "platform_account" {
     bucket   = "wellcomecollection-platform-infra"
     key      = "terraform/aws-account-infrastructure/platform.tfstate"
     region   = "eu-west-1"
-    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    assume_role = {
+      role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    }
   }
 }
 


### PR DESCRIPTION
## What does this change?

For https://github.com/wellcomecollection/platform/issues/5884

This change adds a WAF rule that rate limits requests from clients that contain either "PetalBot" or "ClaudeBot" in their user-agent strings. We've seen this block enough traffic to be useful and reduce errors from bot load.

## How to test

- [ ] Apply this change, watch the WAF dashboard to see if bot requests are being blocked.

## How can we measure success?

Less outages, happier users.

## Have we considered potential risks?

This could block potential requests from users who are taking advantage of LLMs to query the site, we mitigate this risk by applying a rate limit rather than a blanket block.
