### PR TITLE
Add note on casing to README

### DIFF
--- a/common/README.md
+++ b/common/README.md
@@ -4,5 +4,5 @@ This contains some code which is shared among the front-end apps.
 
 Of particular interest:
 
-*   The `data` directory holds most the hard-coded data for the site (e.g. microcopy, error messages, contact information).
-    We keep it in one place so it can be easily reviewed and updated across the site.
+* The `data` directory holds most the hard-coded data for the site (e.g. microcopy, error messages, contact information). We keep it in one place so it can be easily reviewed and updated across the site.
+* The `customtypes` and `views/slices` directories contain the Prismic model data which is created locally using (SliceMachine)[https://prismic.io/slice-machine]. When creating new custom types, slices, or fields, refer to the (API ID name casing docs in Gitbook)[https://app.gitbook.com/o/-LumfFcEMKx4gYXKAZTQ/s/451yLOIRTl5YiAJ88yIL/api-id-name-casing]


### PR DESCRIPTION
For #11500 

## What does this change?
Adds a bullet to the README linking to Gitbook

## How to test
Read it?

## How can we measure success?
Developers find the information about casing IDs they've been looking for

## Have we considered potential risks?
n/a
