### PR TITLE
Catalogue results on search for all

### DIFF
--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -404,7 +404,9 @@ export const getServerSideProps: GetServerSideProps<
         | WellcomeApiError
         | undefined,
       stories,
-      events;
+      events,
+      works,
+      images;
     let contentQueryFailed = false;
     if (serverData.toggles.allSearch.value) {
       // All/Addressables
@@ -461,42 +463,42 @@ export const getServerSideProps: GetServerSideProps<
           | ContentResultsList<EventDocument>
           | WellcomeApiError,
       });
-    }
 
-    // Works
-    const worksResults = await getWorks({
-      params,
-      pageSize: 5,
-      toggles: serverData.toggles,
-    });
-    const works = getQueryResults({
-      categoryName: 'works',
-      queryResults: worksResults,
-    });
+      // Works
+      const worksResults = await getWorks({
+        params,
+        pageSize: 5,
+        toggles: serverData.toggles,
+      });
+      works = getQueryResults({
+        categoryName: 'works',
+        queryResults: worksResults,
+      });
 
-    // Images
-    const imagesResults = await getImages({
-      params,
-      pageSize: 10,
-      toggles: serverData.toggles,
-    });
-    const images = getQueryResults({
-      categoryName: 'images',
-      queryResults: imagesResults,
-    });
+      // Images
+      const imagesResults = await getImages({
+        params,
+        pageSize: 10,
+        toggles: serverData.toggles,
+      });
+      images = getQueryResults({
+        categoryName: 'images',
+        queryResults: imagesResults,
+      });
 
-    // If all three queries fail, return an error page
-    if (
-      imagesResults.type === 'Error' &&
-      worksResults.type === 'Error' &&
-      contentQueryFailed
-    ) {
-      // Use the error from the works API as it is the most mature of the 3
-      return appError(
-        context,
-        worksResults.httpStatus,
-        worksResults.description || worksResults.label
-      );
+      // If all three queries fail, return an error page
+      if (
+        imagesResults.type === 'Error' &&
+        worksResults.type === 'Error' &&
+        contentQueryFailed
+      ) {
+        // Use the error from the works API as it is the most mature of the 3
+        return appError(
+          context,
+          worksResults.httpStatus,
+          worksResults.description || worksResults.label
+        );
+      }
     }
 
     return {

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -221,6 +221,9 @@ export const SearchPage: NextPageWithLayout<Props> = ({
   const [clientSideWorks, setClientSideWorks] = useState<
     ReturnedResults<Work> | undefined
   >(undefined);
+  const [clientSideImages, setClientSideImages] = useState<
+    ReturnedResults<Image> | undefined
+  >(undefined);
   const params = fromQuery(query);
   const data = useContext(ServerDataContext);
 
@@ -255,9 +258,26 @@ export const SearchPage: NextPageWithLayout<Props> = ({
       return undefined;
     }
   }
+  async function fetchImages() {
+    try {
+      const imagesResults = await getImages({
+        params,
+        pageSize: 1,
+        toggles: data.toggles,
+      });
+      images = getQueryResults({
+        categoryName: 'images',
+        queryResults: imagesResults,
+      });
+      setClientSideImages(images);
+    } catch (e) {
+      return undefined;
+    }
+  }
   useEffect(() => {
     if (allSearch) {
       fetchWorks();
+      fetchImages();
     }
   }, []);
 
@@ -266,7 +286,7 @@ export const SearchPage: NextPageWithLayout<Props> = ({
       <NewSearchPage
         queryString={queryString}
         contentResults={contentResults}
-        catalogueResults={{ works: clientSideWorks, images }}
+        catalogueResults={{ works: clientSideWorks, images: clientSideImages }}
       />
     );
   }

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -180,18 +180,22 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
             </Container>
           </BasicSection>
 
-          <div>
+          {(catalogueResults.images || catalogueResults.works) && (
             <div>
-              <SectionTitle sectionName="Images" />
-              <p>{catalogueResults.images?.totalResults || 0} results</p>
+              {catalogueResults.images && (
+                <div>
+                  <SectionTitle sectionName="Images" />
+                  <p>{catalogueResults.images?.totalResults || 0} results</p>
+                </div>
+              )}
+              {catalogueResults.works && (
+                <div>
+                  <SectionTitle sectionName="Catalogue" />
+                  <p>{catalogueResults.works?.totalResults || 0} results</p>
+                </div>
+              )}
             </div>
-
-            <div>
-              <SectionTitle sectionName="Catalogue" />
-
-              <p>{catalogueResults.works?.totalResults || 0} results</p>
-            </div>
-          </div>
+          )}
         </Container>
       )}
     </main>


### PR DESCRIPTION
## What does this change?

For #11459

[In the RFC for suggestions on how to handle loading](https://github.com/wellcomecollection/docs/tree/main/rfcs/062-content-api-all-search#catalogue-search), we decided to load the works and image results client-side on the 'all' search page.

This does that part of the work. If the toggle is enabled then we don't fetch these in getServerSideProps and instead fetch them client-side.

## How to test
The page doesn't appear any differently, but if you turn javascript off then the works and images won't appear, as they are only fetched client-side.

## How can we measure success?

We don't have to wait for the works and images results to be fetched server side as they are not critical to the page.

## Have we considered potential risks?

It's behind a toggle so none really

