### PR TITLE
Born digital PDFs to display in viewer

### DIFF
--- a/content/webapp/components/IIIFItemList/IIIFItemList.tsx
+++ b/content/webapp/components/IIIFItemList/IIIFItemList.tsx
@@ -5,6 +5,7 @@ import PlainList from '@weco/common/views/components/styled/PlainList';
 import Space from '@weco/common/views/components/styled/Space';
 import IIIFItem from '@weco/content/components/IIIFItem/IIIFItem';
 import { TransformedCanvas } from '@weco/content/types/manifest';
+import { getDisplayItems } from '@weco/content/utils/iiif/v3/canvas';
 
 type Props = {
   canvases: TransformedCanvas[] | undefined;
@@ -16,28 +17,14 @@ const IIIFItemList: FunctionComponent<Props> = ({
   canvases,
   exclude,
   placeholderId,
-}) => (
-  <PlainList as="ol">
-    {canvases &&
-      canvases.map((canvas, i) => {
-        // Ordinarly we would use the painting array to display an item to the user, see https://iiif.io/api/presentation/3.0/#values-for-motivation
-        // However, if there is a PDF in the 'original' array we want to display that.
-        // If neither of those things are available we fallback to the supplementing array.
-        // This is because pdfs that were added to manifests before the DLCS changes, which took place in May 2023,
-        // will be in the supplementing array.
-        const originalPdfs = canvas.original.filter(o => {
-          if ('format' in o) {
-            return o.format === 'application/pdf';
-          } else {
-            return false;
-          }
-        });
-        const displayItems =
-          originalPdfs.length > 0
-            ? originalPdfs
-            : canvas.painting.length > 0
-              ? canvas.painting
-              : canvas.supplementing;
+}) => {
+  if (!canvases) return null;
+
+  return (
+    <PlainList as="ol">
+      {canvases.map((canvas, i) => {
+        const displayItems = getDisplayItems(canvas);
+
         return displayItems.map(item => {
           return (
             <li key={item.id}>
@@ -54,7 +41,8 @@ const IIIFItemList: FunctionComponent<Props> = ({
           );
         });
       })}
-  </PlainList>
-);
+    </PlainList>
+  );
+};
 
 export default IIIFItemList;

--- a/content/webapp/components/IIIFViewer/MainViewer.tsx
+++ b/content/webapp/components/IIIFViewer/MainViewer.tsx
@@ -295,7 +295,7 @@ const ItemRenderer = memo(({ style, index, data }: ItemRendererProps) => {
   }, [imageRect, imageContainerRect, currentCanvas, searchResults]);
 
   const displayItems = getDisplayItems(currentCanvas);
-  console.log({ displayItems: displayItems.length });
+
   return (
     <div style={style}>
       {scrollVelocity === 3 ? (

--- a/content/webapp/components/IIIFViewer/MainViewer.tsx
+++ b/content/webapp/components/IIIFViewer/MainViewer.tsx
@@ -23,6 +23,7 @@ import useScrollVelocity from '@weco/content/hooks/useScrollVelocity';
 import { SearchResults } from '@weco/content/services/iiif/types/search/v3';
 import { TransformedCanvas } from '@weco/content/types/manifest';
 import { TransformedAuthService } from '@weco/content/utils/iiif/v3';
+import { getDisplayItems } from '@weco/content/utils/iiif/v3/canvas';
 
 import { queryParamToArrayIndex } from '.';
 
@@ -262,10 +263,10 @@ const ItemRenderer = memo(({ style, index, data }: ItemRendererProps) => {
   const [imageContainerRect, setImageContainerRect] = useState<
     DOMRect | undefined
   >();
-
   const [overlayPositionData, setOverlayPositionData] = useState<
     OverlayPositionData[]
   >([]);
+
   useEffect(() => {
     // The search hit dimensions and coordinates are given relative to the full size image.
     // The highlight overlays are positioned relative to the image container.
@@ -293,11 +294,8 @@ const ItemRenderer = memo(({ style, index, data }: ItemRendererProps) => {
     }
   }, [imageRect, imageContainerRect, currentCanvas, searchResults]);
 
-  const displayItems =
-    currentCanvas.painting.length > 0
-      ? currentCanvas.painting
-      : currentCanvas.supplementing; // We fall back to supplementing for some of the pdfs
-
+  const displayItems = getDisplayItems(currentCanvas);
+  console.log({ displayItems: displayItems.length });
   return (
     <div style={style}>
       {scrollVelocity === 3 ? (
@@ -335,43 +333,22 @@ const ItemRenderer = memo(({ style, index, data }: ItemRendererProps) => {
               );
             })}
 
-          {displayItems.map((item, i) => {
-            return (
-              <ItemWrapper key={i}>
-                {currentCanvas.painting.length > 0 &&
-                  currentCanvas.painting.map((item, i) => {
-                    return (
-                      <IIIFItem
-                        key={i}
-                        placeholderId={placeholderId}
-                        item={item}
-                        canvas={currentCanvas}
-                        i={index}
-                        exclude={[]}
-                        setImageRect={setImageRect}
-                        setImageContainerRect={setImageContainerRect}
-                      />
-                    );
-                  })}
-                {/* Pdfs added to manifests before the DLCS changes, that took place in May 2023, are available from the supplementing property */}
-                {currentCanvas.painting.length === 0 &&
-                  currentCanvas.supplementing.map((item, i) => {
-                    return (
-                      <IIIFItem
-                        key={i}
-                        placeholderId={placeholderId}
-                        item={item}
-                        canvas={currentCanvas}
-                        i={index}
-                        exclude={[]}
-                        setImageRect={setImageRect}
-                        setImageContainerRect={setImageContainerRect}
-                      />
-                    );
-                  })}
-              </ItemWrapper>
-            );
-          })}
+          {displayItems.length > 0 &&
+            displayItems.map(item => {
+              return (
+                <ItemWrapper key={item.id}>
+                  <IIIFItem
+                    placeholderId={placeholderId}
+                    item={item}
+                    canvas={currentCanvas}
+                    i={index}
+                    exclude={[]}
+                    setImageRect={setImageRect}
+                    setImageContainerRect={setImageContainerRect}
+                  />
+                </ItemWrapper>
+              );
+            })}
         </>
       )}
     </div>

--- a/content/webapp/utils/iiif/v3/canvas.ts
+++ b/content/webapp/utils/iiif/v3/canvas.ts
@@ -5,6 +5,7 @@ import { isNotUndefined } from '@weco/common/utils/type-guards';
 import {
   CustomContentResource,
   ThumbnailImage,
+  TransformedCanvas,
 } from '@weco/content/types/manifest';
 
 // Temporary type until iiif3 types are correct
@@ -75,3 +76,24 @@ export function getOriginal(
   });
   return original || [];
 }
+
+// Ordinarly we would use the painting array to display an item to the user, see https://iiif.io/api/presentation/3.0/#values-for-motivation
+// However, if there is a PDF in the 'original' array we want to display that.
+// If neither of those things are available we fallback to the supplementing array.
+// This is because pdfs that were added to manifests before the DLCS changes, which took place in May 2023,
+// will be in the supplementing array.
+export const getDisplayItems = (canvas: TransformedCanvas) => {
+  const originalPdfs = canvas.original.filter(o => {
+    if ('format' in o) {
+      return o.format === 'application/pdf';
+    } else {
+      return false;
+    }
+  });
+
+  return originalPdfs.length > 0
+    ? originalPdfs
+    : canvas.painting.length > 0
+      ? canvas.painting
+      : canvas.supplementing;
+};


### PR DESCRIPTION
## What does this change?

#11512 

Use function that already existed that checks if there is a PDF in a canvas, in order to display it for Born Digital items too.
I made that function a separate helper as to not duplicate it and have the context in one place.

I also simplified what gets displayed, but it might be due to a lack of understanding of what COULD display, so please question it/let me know if it doesn't work like that. I couldn't find an example where it broke.

This work isn't done explicitly behind the toggle as it works already without the toggle, now it'll just work for both. 

## How to test

With extended viewer toggle;

- [ ] Born digital PDF: http://localhost:3000/works/pmv8cncs/items
- [ ] Non-BD PDF should still work as is: http://localhost:3000/works/yycbn2r4/items
- [ ] Have a look around other works and see if they render as expected;
  - [ ] http://localhost:3000/works/a2239muq/items
  - [ ] Mixed BD: http://localhost:3000/works/dn9jwck6/items
- [ ] Verify that nothing has changed when the toggle is turned off.


## How can we measure success?

PDFs are viewable no matter their format!

## Have we considered potential risks?
Breaks some works that I'm not aware of.