### PR TITLE
Upgrade `dotenv` in `identity` and ignore a few packages in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,7 @@ updates:
       # Needs more work, they have their own ticket. Remove them from this list once tickets are Done.
       - dependency-name: 'eslint*'
       - dependency-name: '@babel/*'
+      - dependency-name: 'husky'
     groups:
       all:
         patterns: ['*']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,9 @@ updates:
     ignore:
       - dependency-name: '*'
         update-types: ['version-update:semver-patch'] # Ignore all patch updates for version updates only
-      # Needs more work, has its own ticket. Remove this once it's done.
+      # Needs more work, they have their own ticket. Remove them from this list once tickets are Done.
       - dependency-name: 'eslint*'
+      - dependency-name: '@babel/*'
     groups:
       all:
         patterns: ['*']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,13 @@ updates:
     ignore:
       - dependency-name: '*'
         update-types: ['version-update:semver-patch'] # Ignore all patch updates for version updates only
+      # Shouldn't get flagged as we will undertake these in a conscious manner when planned in
+      - dependency-name: 'next'
+      - dependency-name: 'react'
+      - dependency-name: 'typescript'
+      - dependency-name: '@typescript*'
+      # Dependent on higher versions of the list above, remove from here once the upgrade it depends on has been done.
+      - dependency-name: 'cookies-next'
       # Needs more work, they have their own ticket. Remove them from this list once tickets are Done.
       - dependency-name: 'eslint*'
       - dependency-name: '@babel/*'

--- a/identity/webapp/config.js
+++ b/identity/webapp/config.js
@@ -1,11 +1,10 @@
-const { config: dotEnvConfig } = require('dotenv');
+require('dotenv').config();
 
 const port = Number(process.env.PORT) || 3000;
 
 // Defaults (ie "build") need to be set here so that there's something available
 // at build time - it never gets used
 const getConfig = () => {
-  dotEnvConfig();
   return {
     // Random values used for encrypting cookies used for the session. Can be comma separated list.
     sessionKeys: process.env.SESSION_KEYS

--- a/identity/webapp/package.json
+++ b/identity/webapp/package.json
@@ -27,7 +27,7 @@
     "@koa/router": "^13.1.0",
     "@weco/common": "1.0.0",
     "axios": "^0.28.0",
-    "dotenv": "^8.2.0",
+    "dotenv": "^16.4.7",
     "jsonwebtoken": "^9.0.0",
     "koa": "^2.13.0",
     "koa-json": "^2.0.2",

--- a/prismic-model/package.json
+++ b/prismic-model/package.json
@@ -21,7 +21,7 @@
     "@weco/common": "1.0.0",
     "@weco/ts-aws": "^1.0.1",
     "chalk": "^4.1.2",
-    "dotenv": "^16.4.5",
+    "dotenv": "^16.4.7",
     "json-diff": "^1.0.6",
     "tqdm": "^2.0.3",
     "ts-node": "^10.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6755,15 +6755,10 @@ dotenv@16.3.1:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.3.1.tgz#369034de7d7e5b120972693352a3bf112172cc3e"
   integrity sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==
 
-dotenv@^16.4.5:
-  version "16.4.5"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.5.tgz#cdd3b3b604cb327e286b4762e13502f717cb099f"
-  integrity sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==
-
-dotenv@^8.2.0:
-  version "8.6.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
-  integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==
+dotenv@^16.4.7:
+  version "16.4.7"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.7.tgz#0e20c5b82950140aa99be360a8a5f52335f53c26"
+  integrity sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==
 
 dreamopt@~0.8.0:
   version "0.8.0"


### PR DESCRIPTION
## What does this change?

[Had a look at packages to upgrade](https://github.com/wellcomecollection/wellcomecollection.org/pull/11529) and noticed we were way behind on dotenv, so went for that. It seemed a simple enough change, [not a lot of breaking changes](https://github.com/motdotla/dotenv/blob/master/CHANGELOG.md) and just simplified the code [as per their instructions](https://github.com/motdotla/dotenv). Ran identity locally and all seems good.

I also added an ignore for Babel packages while I was at it because I'm creating [a separate ticket](https://github.com/wellcomecollection/wellcomecollection.org/issues/11530) for it, and Husky already has one indicated it wasn't straightforward.

## How to test

Run identity locally, it should still work as normal.

## How can we measure success?

Up to date ✨ 

## Have we considered potential risks?
If it runs well, we'll check again in staging.