### PR TITLE
All search

### DIFF
--- a/cardigan/stories/components/ContentSearchResult/ContentSearchResult.stories.tsx
+++ b/cardigan/stories/components/ContentSearchResult/ContentSearchResult.stories.tsx
@@ -1,0 +1,36 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import ContentSearchResult from '@weco/content/components/ContentSearchResult/ContentSearchResult';
+
+const meta: Meta<typeof ContentSearchResult> = {
+  title: 'Components/ContentSearchResult',
+  component: ContentSearchResult,
+  args: {
+    uid: 'shortlist-revealed-for-wellcome-book-prize-2018',
+    contributors: 'Joe Bloggs',
+    dates: {
+      start: new Date('2022-03-01T00:00:00Z'),
+      end: new Date('2022-03-08T00:00:00Z'),
+    },
+    times: {
+      start: new Date('2022-03-01T13:15:00Z'),
+      end: new Date('2022-03-01T14:15:00Z'),
+    },
+    description:
+      'The shortlist for the 2018 Wellcome Book Prize is announced, celebrating the best new books that illuminate our encounters with health, medicine and illness.',
+    title: 'Shortlist revealed for Wellcome Book Prize 2018',
+    type: 'Page',
+    tags: ['press'],
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ContentSearchResult>;
+
+const Template = args => <ContentSearchResult {...args} />;
+
+export const Basic: Story = {
+  name: 'ContentSearchResult',
+  render: Template,
+};

--- a/cardigan/stories/components/ContentSearchResult/ContentSearchResult.stories.tsx
+++ b/cardigan/stories/components/ContentSearchResult/ContentSearchResult.stories.tsx
@@ -19,7 +19,7 @@ const meta: Meta<typeof ContentSearchResult> = {
     description:
       'The shortlist for the 2018 Wellcome Book Prize is announced, celebrating the best new books that illuminate our encounters with health, medicine and illness.',
     title: 'Shortlist revealed for Wellcome Book Prize 2018',
-    type: 'Page',
+    type: 'Event',
     tags: ['press'],
   },
 };

--- a/cardigan/stories/components/ContentSearchResult/ContentSearchResult.stories.tsx
+++ b/cardigan/stories/components/ContentSearchResult/ContentSearchResult.stories.tsx
@@ -9,12 +9,12 @@ const meta: Meta<typeof ContentSearchResult> = {
     uid: 'shortlist-revealed-for-wellcome-book-prize-2018',
     contributors: 'Joe Bloggs',
     dates: {
-      start: new Date('2022-03-01T00:00:00Z'),
-      end: new Date('2022-03-08T00:00:00Z'),
+      start: '2022-03-01T00:00:00Z',
+      end: '2022-03-08T00:00:00Z',
     },
     times: {
-      start: new Date('2022-03-01T13:15:00Z'),
-      end: new Date('2022-03-01T14:15:00Z'),
+      start: '2022-03-01T13:15:00Z',
+      end: '2022-03-01T14:15:00Z',
     },
     description:
       'The shortlist for the 2018 Wellcome Book Prize is announced, celebrating the best new books that illuminate our encounters with health, medicine and illness.',

--- a/common/services/prismic/content-types.ts
+++ b/common/services/prismic/content-types.ts
@@ -34,6 +34,7 @@ const contentApiContentTypes = [
   'Season',
 ];
 
+// We want to be able to treat Prismic and Content API content types as the same so we can test against single values in the link resolver
 export const contentApiTypeMap = {
   Book: 'books',
   'Event series': 'event-series',

--- a/common/services/prismic/content-types.ts
+++ b/common/services/prismic/content-types.ts
@@ -34,6 +34,20 @@ const contentApiContentTypes = [
   'Season',
 ];
 
+export const contentApiTypeMap = {
+  Book: 'books',
+  'Event series': 'event-series',
+  Event: 'events',
+  Exhibition: 'exhibitions',
+  'Visual story': 'visual-stories',
+  'Exhibition text': 'exhibition-texts',
+  Page: 'pages',
+  'Exhibition highlight tour': 'exhibition-highlight-tours',
+  Project: 'projects',
+  Article: 'articles',
+  Season: 'seasons',
+};
+
 export type ContentType = (typeof contentTypes)[number];
 export type ContentApiContentType = (typeof contentApiContentTypes)[number];
 /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/common/services/prismic/content-types.ts
+++ b/common/services/prismic/content-types.ts
@@ -20,9 +20,32 @@ const contentTypes = [
   'webcomic-series',
 ] as const;
 
+const contentApiContentTypes = [
+  'Book',
+  'Event series',
+  'Event',
+  'Exhibition',
+  'Visual story',
+  'Exhibition text',
+  'Page',
+  'Exhibition highlight tour',
+  'Project',
+  'Article',
+  'Season',
+];
+
 export type ContentType = (typeof contentTypes)[number];
+export type ContentApiContentType = (typeof contentApiContentTypes)[number];
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export function isContentType(type: any): type is ContentType {
   /* eslint-enable @typescript-eslint/no-explicit-any */
   return typeof type && contentTypes.includes(type);
+}
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export function isContentApiContentType(
+  type: any
+): type is ContentApiContentType {
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+  return typeof type && contentApiContentTypes.includes(type);
 }

--- a/common/services/prismic/link-resolver.ts
+++ b/common/services/prismic/link-resolver.ts
@@ -45,13 +45,16 @@ function linkResolver(doc: Props | DataProps): string {
 
   if (
     type === 'exhibition-guides' ||
-    type === 'exhibition-texts' ||
     type === 'exhibition-highlight-tours' ||
     type === 'exhibition-guides-links' ||
     type === 'Exhibition text' ||
     type === 'Exhibition highlight tour'
   )
     return `/guides/exhibitions/${uid}`;
+
+  if (type === 'exhibition-texts') {
+    return `/guides/exhibitions/${uid}/captions-and-transcripts`;
+  }
 
   if (type === 'visual-stories') {
     if ('data' in doc) {

--- a/common/services/prismic/link-resolver.ts
+++ b/common/services/prismic/link-resolver.ts
@@ -1,6 +1,6 @@
 import { isSiteSection, SiteSection } from '@weco/common/model/site-section';
 
-import { isContentType } from './content-types';
+import { isContentApiContentType, isContentType } from './content-types';
 
 type Props = {
   uid?: string;
@@ -29,7 +29,7 @@ function linkResolver(doc: Props | DataProps): string {
   const { uid, type } = doc;
 
   if (!uid) return '/';
-  if (type === 'articles') return `/stories/${uid}`;
+  if (type === 'articles' || type === 'Article') return `/stories/${uid}`;
   if (type === 'webcomics') return `/stories/${uid}`;
   if (type === 'webcomic-series') return `/series/${uid}`;
 
@@ -37,7 +37,9 @@ function linkResolver(doc: Props | DataProps): string {
     type === 'exhibition-guides' ||
     type === 'exhibition-texts' ||
     type === 'exhibition-highlight-tours' ||
-    type === 'exhibition-guides-links'
+    type === 'exhibition-guides-links' ||
+    type === 'Exhibition text' ||
+    type === 'Exhibition highlight tour'
   )
     return `/guides/exhibitions/${uid}`;
 
@@ -54,7 +56,7 @@ function linkResolver(doc: Props | DataProps): string {
     }
   }
 
-  if (type === 'pages') {
+  if (type === 'pages' || type === 'Page') {
     let siteSection: SiteSection | undefined;
 
     if ('siteSection' in doc) {
@@ -73,6 +75,10 @@ function linkResolver(doc: Props | DataProps): string {
 
   if (isContentType(type)) {
     return `/${type}/${uid}`;
+  }
+
+  if (isContentApiContentType(type)) {
+    return `/${type.toLowerCase().replace(/ /g, '-')}s/${uid}`;
   }
 
   return '/';

--- a/common/services/prismic/link-resolver.ts
+++ b/common/services/prismic/link-resolver.ts
@@ -46,9 +46,7 @@ function linkResolver(doc: Props | DataProps): string {
   if (
     type === 'exhibition-guides' ||
     type === 'exhibition-highlight-tours' ||
-    type === 'exhibition-guides-links' ||
-    type === 'Exhibition text' ||
-    type === 'Exhibition highlight tour'
+    type === 'exhibition-guides-links'
   )
     return `/guides/exhibitions/${uid}`;
 

--- a/common/services/prismic/link-resolver.ts
+++ b/common/services/prismic/link-resolver.ts
@@ -1,6 +1,10 @@
 import { isSiteSection, SiteSection } from '@weco/common/model/site-section';
 
-import { isContentApiContentType, isContentType } from './content-types';
+import {
+  contentApiTypeMap,
+  isContentApiContentType,
+  isContentType,
+} from './content-types';
 
 type Props = {
   uid?: string;
@@ -26,10 +30,16 @@ function linkResolver(doc: Props | DataProps): string {
   // which doesn't necessarily have access to all data
   if (!doc) return '/';
 
-  const { uid, type } = doc;
+  const { uid } = doc;
+
+  const type = isContentType(doc.type)
+    ? doc.type
+    : isContentApiContentType(doc.type)
+      ? contentApiTypeMap[doc.type]
+      : '';
 
   if (!uid) return '/';
-  if (type === 'articles' || type === 'Article') return `/stories/${uid}`;
+  if (type === 'articles') return `/stories/${uid}`;
   if (type === 'webcomics') return `/stories/${uid}`;
   if (type === 'webcomic-series') return `/series/${uid}`;
 
@@ -56,7 +66,7 @@ function linkResolver(doc: Props | DataProps): string {
     }
   }
 
-  if (type === 'pages' || type === 'Page') {
+  if (type === 'pages') {
     let siteSection: SiteSection | undefined;
 
     if ('siteSection' in doc) {
@@ -75,10 +85,6 @@ function linkResolver(doc: Props | DataProps): string {
 
   if (isContentType(type)) {
     return `/${type}/${uid}`;
-  }
-
-  if (isContentApiContentType(type)) {
-    return `/${type.toLowerCase().replace(/ /g, '-')}s/${uid}`;
   }
 
   return '/';

--- a/content/webapp/components/ContentSearchResult/ContentSearchResult.tsx
+++ b/content/webapp/components/ContentSearchResult/ContentSearchResult.tsx
@@ -14,8 +14,8 @@ type Props = {
   description: string;
   highlightTourType?: 'audio' | 'bsl';
   tags?: string[];
-  dates?: { start: Date; end: Date };
-  times?: { start: Date; end: Date };
+  dates?: { start: string; end: string };
+  times?: { start: string; end: string };
   contributors?: string;
 };
 
@@ -70,17 +70,17 @@ const ContentSearchResult: FunctionComponent<Props> = ({
 
   return (
     <Link href={link()}>
-      {type !== 'Page' && <Type>{type}</Type>}
+      {type !== 'Page' && <Type>{type === 'Article' ? 'Story' : type}</Type>}
       <Title>{title}</Title>
       <Description>{description}</Description>
       {dates ? (
         <DatesContributors>
-          <DateRange start={dates.start} end={dates.end} />
+          <DateRange start={new Date(dates.start)} end={new Date(dates.end)} />
         </DatesContributors>
       ) : null}
       {times ? (
         <DatesContributors>
-          <DateRange start={times.start} end={times.end} />
+          <DateRange start={new Date(times.start)} end={new Date(times.end)} />
         </DatesContributors>
       ) : null}
       {contributors ? (

--- a/content/webapp/components/ContentSearchResult/ContentSearchResult.tsx
+++ b/content/webapp/components/ContentSearchResult/ContentSearchResult.tsx
@@ -63,7 +63,6 @@ const ContentSearchResult: FunctionComponent<Props> = ({
   contributors,
 }) => {
   const link = (): string => {
-    console.log(highlightTourType);
     if (highlightTourType) {
       return `/guides/exhibitions/${uid}/${highlightTourType === 'audio' ? 'audio-without-descriptions' : 'bsl'}`;
     } else {

--- a/content/webapp/components/ContentSearchResult/ContentSearchResult.tsx
+++ b/content/webapp/components/ContentSearchResult/ContentSearchResult.tsx
@@ -26,8 +26,8 @@ const Link = styled(NextLink)`
 `;
 
 const Type = styled(Space).attrs({
-  $v: { size: 'm', properties: ['margin-bottom'] },
-  className: font('intr', 5),
+  $v: { size: 's', properties: ['margin-bottom'] },
+  className: font('intr', 6),
 })``;
 
 const Title = styled(Space).attrs({

--- a/content/webapp/components/ContentSearchResult/ContentSearchResult.tsx
+++ b/content/webapp/components/ContentSearchResult/ContentSearchResult.tsx
@@ -4,17 +4,18 @@ import styled from 'styled-components';
 
 import linkResolver from '@weco/common/services/prismic/link-resolver';
 import { font } from '@weco/common/utils/classnames';
+import { HTMLDate } from '@weco/common/views/components/HTMLDateAndTime';
 import Space from '@weco/common/views/components/styled/Space';
 import DateRange from '@weco/content/components/DateRange/DateRange';
 
 type Props = {
-  uid: string;
+  uid?: string;
   type: string;
   title: string;
-  description: string;
+  description?: string;
   highlightTourType?: 'audio' | 'bsl';
   tags?: string[];
-  dates?: { start: string; end: string };
+  dates?: { start: string; end?: string };
   times?: { start: string; end: string };
   contributors?: string;
 };
@@ -72,10 +73,14 @@ const ContentSearchResult: FunctionComponent<Props> = ({
     <Link href={link()}>
       {type !== 'Page' && <Type>{type === 'Article' ? 'Story' : type}</Type>}
       <Title>{title}</Title>
-      <Description>{description}</Description>
-      {dates ? (
+      {description ? <Description>{description}</Description> : null}
+      {dates?.end ? (
         <DatesContributors>
           <DateRange start={new Date(dates.start)} end={new Date(dates.end)} />
+        </DatesContributors>
+      ) : dates?.start ? (
+        <DatesContributors>
+          <HTMLDate date={new Date(dates.start)} />
         </DatesContributors>
       ) : null}
       {times ? (

--- a/content/webapp/components/ContentSearchResult/ContentSearchResult.tsx
+++ b/content/webapp/components/ContentSearchResult/ContentSearchResult.tsx
@@ -9,7 +9,7 @@ import Space from '@weco/common/views/components/styled/Space';
 import DateRange from '@weco/content/components/DateRange/DateRange';
 
 type Props = {
-  uid?: string;
+  uid: string | null;
   type: string;
   title: string;
   description?: string;
@@ -62,6 +62,7 @@ const ContentSearchResult: FunctionComponent<Props> = ({
   contributors,
 }) => {
   const link = (): string => {
+    console.log(highlightTourType);
     if (highlightTourType) {
       return `/guides/exhibitions/${uid}/${highlightTourType === 'audio' ? 'audio-without-descriptions' : 'bsl'}`;
     } else {

--- a/content/webapp/components/ContentSearchResult/ContentSearchResult.tsx
+++ b/content/webapp/components/ContentSearchResult/ContentSearchResult.tsx
@@ -66,7 +66,7 @@ const ContentSearchResult: FunctionComponent<Props> = ({
     if (highlightTourType) {
       return `/guides/exhibitions/${uid}/${highlightTourType === 'audio' ? 'audio-without-descriptions' : 'bsl'}`;
     } else {
-      return linkResolver({ uid, type, tags });
+      return linkResolver({ uid: uid || undefined, type, tags });
     }
   };
 

--- a/content/webapp/components/ContentSearchResult/ContentSearchResult.tsx
+++ b/content/webapp/components/ContentSearchResult/ContentSearchResult.tsx
@@ -23,6 +23,7 @@ type Props = {
 const Link = styled(NextLink)`
   text-decoration: none;
   color: inherit;
+  display: block;
 `;
 
 const Type = styled(Space).attrs({

--- a/content/webapp/components/ContentSearchResult/ContentSearchResult.tsx
+++ b/content/webapp/components/ContentSearchResult/ContentSearchResult.tsx
@@ -1,6 +1,10 @@
+import NextLink from 'next/link';
 import { FunctionComponent } from 'react';
+import styled from 'styled-components';
 
 import linkResolver from '@weco/common/services/prismic/link-resolver';
+import { font } from '@weco/common/utils/classnames';
+import Space from '@weco/common/views/components/styled/Space';
 import DateRange from '@weco/content/components/DateRange/DateRange';
 
 type Props = {
@@ -14,6 +18,36 @@ type Props = {
   times?: { start: Date; end: Date };
   contributors?: string;
 };
+
+const Link = styled(NextLink)`
+  text-decoration: none;
+  color: inherit;
+`;
+
+const Type = styled(Space).attrs({
+  $v: { size: 'm', properties: ['margin-bottom'] },
+  className: font('intr', 5),
+})``;
+
+const Title = styled(Space).attrs({
+  as: 'h2',
+  $v: { size: 's', properties: ['margin-bottom'] },
+})`
+  ${Link}:hover & {
+    text-decoration: underline;
+  }
+`;
+
+const Description = styled(Space).attrs({
+  $v: { size: 'xs', properties: ['margin-bottom'] },
+})``;
+
+const DatesContributors = styled(Space).attrs({
+  $v: { size: 's', properties: ['margin-bottom'] },
+  className: font('intr', 6),
+})`
+  color: ${props => props.theme.color('neutral.600')};
+`;
 
 const ContentSearchResult: FunctionComponent<Props> = ({
   uid,
@@ -35,22 +69,24 @@ const ContentSearchResult: FunctionComponent<Props> = ({
   };
 
   return (
-    <a href={link()}>
-      {type !== 'Page' && <span>{type}</span>}
-      <h2>{title}</h2>
-      <p>{description}</p>
+    <Link href={link()}>
+      {type !== 'Page' && <Type>{type}</Type>}
+      <Title>{title}</Title>
+      <Description>{description}</Description>
       {dates ? (
-        <p>
+        <DatesContributors>
           <DateRange start={dates.start} end={dates.end} />
-        </p>
+        </DatesContributors>
       ) : null}
       {times ? (
-        <p>
+        <DatesContributors>
           <DateRange start={times.start} end={times.end} />
-        </p>
+        </DatesContributors>
       ) : null}
-      {contributors ? <p>{contributors}</p> : null}
-    </a>
+      {contributors ? (
+        <DatesContributors>{contributors}</DatesContributors>
+      ) : null}
+    </Link>
   );
 };
 

--- a/content/webapp/components/ContentSearchResult/ContentSearchResult.tsx
+++ b/content/webapp/components/ContentSearchResult/ContentSearchResult.tsx
@@ -1,0 +1,57 @@
+import { FunctionComponent } from 'react';
+
+import linkResolver from '@weco/common/services/prismic/link-resolver';
+import DateRange from '@weco/content/components/DateRange/DateRange';
+
+type Props = {
+  uid: string;
+  type: string;
+  title: string;
+  description: string;
+  highlightTourType?: 'audio' | 'bsl';
+  tags?: string[];
+  dates?: { start: Date; end: Date };
+  times?: { start: Date; end: Date };
+  contributors?: string;
+};
+
+const ContentSearchResult: FunctionComponent<Props> = ({
+  uid,
+  type,
+  title,
+  description,
+  highlightTourType,
+  tags,
+  dates,
+  times,
+  contributors,
+}) => {
+  const link = (): string => {
+    if (highlightTourType) {
+      return `/guides/exhibitions/${uid}/${highlightTourType === 'audio' ? 'audio-without-descriptions' : 'bsl'}`;
+    } else {
+      return linkResolver({ uid, type, tags });
+    }
+  };
+
+  return (
+    <a href={link()}>
+      {type !== 'Page' && <span>{type}</span>}
+      <h2>{title}</h2>
+      <p>{description}</p>
+      {dates ? (
+        <p>
+          <DateRange start={dates.start} end={dates.end} />
+        </p>
+      ) : null}
+      {times ? (
+        <p>
+          <DateRange start={times.start} end={times.end} />
+        </p>
+      ) : null}
+      {contributors ? <p>{contributors}</p> : null}
+    </a>
+  );
+};
+
+export default ContentSearchResult;

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -181,15 +181,7 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
                 key={result.uid}
                 $v={{ size: 'xl', properties: ['margin-bottom'] }}
               >
-                <ContentSearchResult
-                  uid={result.uid || undefined}
-                  type={result.type}
-                  title={result.title}
-                  description={result.description}
-                  tags={result.tags}
-                  dates={result.dates}
-                  times={result.times}
-                />
+                <ContentSearchResult {...result} />
               </Space>
             ))}
 

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -157,6 +157,10 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
   catalogueResults,
   contentQueryFailed,
 }) => {
+  const totalResults =
+    (contentResults?.totalResults || 0) +
+    (catalogueResults.images?.totalResults || 0) +
+    (catalogueResults.works?.totalResults || 0);
   return (
     <main>
       {!contentResults &&
@@ -182,8 +186,8 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
                 </>
               ) : (
                 <>
-                  {contentResults?.totalResults || 0} result
-                  {contentResults?.totalResults === 1 ? '' : 's'} for{' '}
+                  {totalResults} result
+                  {totalResults === 1 ? '' : 's'} for{' '}
                   <span className={font('intb', 6)}>{queryString}</span>
                 </>
               )}

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -72,6 +72,7 @@ type Props = {
   contentResults?: ContentResultsList<Addressable>;
   query: Query;
   pageview: Pageview;
+  contentQueryFailed: boolean;
 };
 
 type NewProps = {
@@ -81,6 +82,7 @@ type NewProps = {
     images?: ReturnedResults<Image>;
   };
   queryString?: string;
+  contentQueryFailed: boolean;
 };
 
 type SeeMoreButtonProps = {
@@ -153,6 +155,7 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
   queryString,
   contentResults,
   catalogueResults,
+  contentQueryFailed,
 }) => {
   return (
     <main>
@@ -172,9 +175,18 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
         >
           <BasicSection>
             <p className={font('intr', 5)}>
-              {contentResults?.totalResults || 0} result
-              {contentResults?.totalResults === 1 ? '' : 's'} for{' '}
-              <span className={font('intb', 6)}>{queryString}</span>
+              {contentQueryFailed ? (
+                <>
+                  There was a problem fetching some search results. Please try
+                  again. If the problem persists, please contact us.
+                </>
+              ) : (
+                <>
+                  {contentResults?.totalResults || 0} result
+                  {contentResults?.totalResults === 1 ? '' : 's'} for{' '}
+                  <span className={font('intb', 6)}>{queryString}</span>
+                </>
+              )}
             </p>
             {contentResults?.results?.map(result => (
               <Space
@@ -214,6 +226,7 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
 
 export const SearchPage: NextPageWithLayout<Props> = ({
   contentResults,
+  contentQueryFailed,
   works,
   images,
   stories,
@@ -246,6 +259,7 @@ export const SearchPage: NextPageWithLayout<Props> = ({
         queryString={queryString}
         contentResults={contentResults}
         catalogueResults={{ works, images }}
+        contentQueryFailed={contentQueryFailed}
       />
     );
   }
@@ -519,6 +533,7 @@ export const getServerSideProps: GetServerSideProps<
           contentResults?.results.length && {
             contentResults,
           }),
+        contentQueryFailed,
         works:
           works && works.pageResults.length
             ? {

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -29,6 +29,7 @@ import ContentSearchResult from '@weco/content/components/ContentSearchResult/Co
 import EventsSearchResults from '@weco/content/components/EventsSearchResults';
 import ImageEndpointSearchResults from '@weco/content/components/ImageEndpointSearchResults/ImageEndpointSearchResults';
 import MoreLink from '@weco/content/components/MoreLink/MoreLink';
+import Pagination from '@weco/content/components/Pagination/Pagination';
 import SearchNoResults from '@weco/content/components/SearchNoResults/SearchNoResults';
 import { getSearchLayout } from '@weco/content/components/SearchPageLayout/SearchPageLayout';
 import StoriesGrid from '@weco/content/components/StoriesGrid';
@@ -162,33 +163,43 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
           <SearchNoResults query={queryString} />
         </Container>
       ) : (
-        <Container style={{ display: 'flex' }}>
+        <Container
+          style={{
+            display: 'grid',
+            gridTemplateColumns: '3fr 2fr',
+            gap: '160px',
+          }}
+        >
           <BasicSection>
-            <Container>
-              <SectionTitle sectionName="Content results" />
-              <p>{contentResults?.totalResults || 0} results</p>
-              {/* <code>
-                <pre style={{ fontFamily: 'monaco', fontSize: '10px' }}>
-                  {JSON.stringify(contentResults, null, 2)}
-                </pre>
-              </code> */}
-              {contentResults?.results?.map(result => (
-                <Space
-                  key={result.uid}
-                  $v={{ size: 'xl', properties: ['margin-bottom'] }}
-                >
-                  <ContentSearchResult
-                    uid={result.uid || undefined}
-                    type={result.type}
-                    title={result.title}
-                    description={result.description}
-                    tags={result.tags}
-                    dates={result.dates}
-                    times={result.times}
-                  />
-                </Space>
-              ))}
-            </Container>
+            <p className={font('intr', 5)}>
+              {contentResults?.totalResults || 0} result
+              {contentResults?.totalResults === 1 ? '' : 's'} for{' '}
+              <span className={font('intb', 6)}>{queryString}</span>
+            </p>
+            {contentResults?.results?.map(result => (
+              <Space
+                key={result.uid}
+                $v={{ size: 'xl', properties: ['margin-bottom'] }}
+              >
+                <ContentSearchResult
+                  uid={result.uid || undefined}
+                  type={result.type}
+                  title={result.title}
+                  description={result.description}
+                  tags={result.tags}
+                  dates={result.dates}
+                  times={result.times}
+                />
+              </Space>
+            ))}
+
+            {contentResults?.totalPages ? (
+              <Pagination
+                totalPages={contentResults.totalPages}
+                ariaLabel="Content search results pagination"
+                isHiddenMobile
+              />
+            ) : null}
           </BasicSection>
 
           <div>
@@ -419,7 +430,7 @@ export const getServerSideProps: GetServerSideProps<
         params: {
           ...query,
         },
-        pageSize: 4,
+        pageSize: 20,
         toggles: serverData.toggles,
       });
 

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -241,7 +241,7 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
             <ContentResults>
               {contentResults?.results?.map(result => (
                 <Space
-                  key={result.uid}
+                  key={`${result.uid}${result.highlightTourType || ''}`}
                   $v={{ size: 'xl', properties: ['margin-bottom'] }}
                 >
                   <ContentSearchResult {...result} />

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -313,36 +313,37 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
                     </div>
                   )}
 
-                {catalogueResults.images && (
-                  <div>
-                    <SectionTitle sectionName="Images" />
-                    {catalogueResults.images.results.map(image => (
-                      <ImageCard
-                        key={image.id}
-                        id={image.id}
-                        workId={image.source.id}
-                        image={{
-                          contentUrl: image.src,
-                          width: image.width * 1.57,
-                          height: image.height * 1.57,
-                          alt: image.source.title,
-                        }}
-                        layout="raw"
-                      />
-                    ))}
-                    <NextLink
-                      {...imagesLink(
-                        {
-                          query: queryString,
-                        },
-                        `images_all_${pathname}`
-                      )}
-                      passHref
-                    >
-                      All images {catalogueResults.images?.totalResults}
-                    </NextLink>
-                  </div>
-                )}
+                {catalogueResults.images &&
+                  catalogueResults.images.totalResults > 0 && (
+                    <div>
+                      <SectionTitle sectionName="Images" />
+                      {catalogueResults.images.results.map(image => (
+                        <ImageCard
+                          key={image.id}
+                          id={image.id}
+                          workId={image.source.id}
+                          image={{
+                            contentUrl: image.src,
+                            width: image.width * 1.57,
+                            height: image.height * 1.57,
+                            alt: image.source.title,
+                          }}
+                          layout="raw"
+                        />
+                      ))}
+                      <NextLink
+                        {...imagesLink(
+                          {
+                            query: queryString,
+                          },
+                          `images_all_${pathname}`
+                        )}
+                        passHref
+                      >
+                        All images {catalogueResults.images?.totalResults}
+                      </NextLink>
+                    </div>
+                  )}
               </div>
             </CatalogueResults>
             <ContentResults>

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -25,6 +25,7 @@ import { Container } from '@weco/common/views/components/styled/Container';
 import Space from '@weco/common/views/components/styled/Space';
 import { NextPageWithLayout } from '@weco/common/views/pages/_app';
 import theme from '@weco/common/views/themes/default';
+import ContentSearchResult from '@weco/content/components/ContentSearchResult/ContentSearchResult';
 import EventsSearchResults from '@weco/content/components/EventsSearchResults';
 import ImageEndpointSearchResults from '@weco/content/components/ImageEndpointSearchResults/ImageEndpointSearchResults';
 import MoreLink from '@weco/content/components/MoreLink/MoreLink';
@@ -166,17 +167,27 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
             <Container>
               <SectionTitle sectionName="Content results" />
               <p>{contentResults?.totalResults || 0} results</p>
-              <div
-                style={{
-                  fontSize: '12px',
-                  maxWidth: '780px',
-                  overflow: 'scroll',
-                }}
-              >
-                {contentResults && (
-                  <pre>{JSON.stringify(contentResults, null, 2)}</pre>
-                )}
-              </div>
+              {/* <code>
+                <pre style={{ fontFamily: 'monaco', fontSize: '10px' }}>
+                  {JSON.stringify(contentResults, null, 2)}
+                </pre>
+              </code> */}
+              {contentResults?.results?.map(result => (
+                <Space
+                  key={result.uid}
+                  $v={{ size: 'xl', properties: ['margin-bottom'] }}
+                >
+                  <ContentSearchResult
+                    uid={result.uid}
+                    type={result.type}
+                    title={result.title}
+                    description={result.description}
+                    tags={result.tags}
+                    dates={result.dates}
+                    times={result.times}
+                  />
+                </Space>
+              ))}
             </Container>
           </BasicSection>
 

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -68,13 +68,13 @@ type Props = {
   images?: ReturnedResults<Image>;
   stories?: ReturnedResults<Article>;
   events?: ReturnedResults<EventDocument>;
-  contentResults?: ReturnedResults<Addressable>;
+  contentResults?: ContentResultsList<Addressable>;
   query: Query;
   pageview: Pageview;
 };
 
 type NewProps = {
-  contentResults?: ReturnedResults<Addressable>;
+  contentResults?: ContentResultsList<Addressable>;
   catalogueResults: {
     works?: ReturnedResults<WorkBasic>;
     images?: ReturnedResults<Image>;
@@ -178,7 +178,7 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
                   $v={{ size: 'xl', properties: ['margin-bottom'] }}
                 >
                   <ContentSearchResult
-                    uid={result.uid}
+                    uid={result.uid || undefined}
                     type={result.type}
                     title={result.title}
                     description={result.description}

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -117,6 +117,40 @@ const SectionTitle = ({ sectionName }: { sectionName: string }) => {
   );
 };
 
+const GridContainer = styled(Container)`
+  display: grid;
+  grid-template-columns: [l-start] 9fr [l-end r-start] 3fr [r-end];
+
+  ${props => props.theme.media('large')`
+    grid-template-columns: [l-start] 6fr [l-end] 2fr [r-start] 4fr [r-end];
+  `}
+`;
+
+const ContentResults = styled.div`
+  grid-column: l-start / r-end;
+
+  ${props => props.theme.media('medium')`
+    grid-column: l-start / l-end;
+  `}
+
+  ${props => props.theme.media('large')`
+    grid-row: 1;
+    grid-column: l-start / l-end;
+  `}
+`;
+
+const CatalogueResults = styled.div`
+  grid-column: l-start / r-end;
+
+  ${props => props.theme.media('medium')`
+    grid-column: l-start / l-end;
+  `}
+
+  ${props => props.theme.media('large')`
+    grid-column: r-start / r-end;
+  `}
+`;
+
 const StoryPromoContainer = styled(Container)`
   ${props =>
     props.theme.mediaBetween(
@@ -170,14 +204,8 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
           <SearchNoResults query={queryString} />
         </Container>
       ) : (
-        <Container
-          style={{
-            display: 'grid',
-            gridTemplateColumns: '3fr 2fr',
-            gap: '160px',
-          }}
-        >
-          <BasicSection>
+        <BasicSection>
+          <Container>
             <p className={font('intr', 5)}>
               {contentQueryFailed ? (
                 <>
@@ -192,37 +220,39 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
                 </>
               )}
             </p>
-            {contentResults?.results?.map(result => (
-              <Space
-                key={result.uid}
-                $v={{ size: 'xl', properties: ['margin-bottom'] }}
-              >
-                <ContentSearchResult {...result} />
-              </Space>
-            ))}
+          </Container>
+          <GridContainer>
+            <CatalogueResults>
+              <div>
+                <SectionTitle sectionName="Images" />
+                <p>{catalogueResults.images?.totalResults || 0} results</p>
+              </div>
 
-            {contentResults?.totalPages ? (
-              <Pagination
-                totalPages={contentResults.totalPages}
-                ariaLabel="Content search results pagination"
-                isHiddenMobile
-              />
-            ) : null}
-          </BasicSection>
+              <div>
+                <SectionTitle sectionName="Catalogue" />
+                <p>{catalogueResults.works?.totalResults || 0} results</p>
+              </div>
+            </CatalogueResults>
+            <ContentResults>
+              {contentResults?.results?.map(result => (
+                <Space
+                  key={result.uid}
+                  $v={{ size: 'xl', properties: ['margin-bottom'] }}
+                >
+                  <ContentSearchResult {...result} />
+                </Space>
+              ))}
 
-          <div>
-            <div>
-              <SectionTitle sectionName="Images" />
-              <p>{catalogueResults.images?.totalResults || 0} results</p>
-            </div>
-
-            <div>
-              <SectionTitle sectionName="Catalogue" />
-
-              <p>{catalogueResults.works?.totalResults || 0} results</p>
-            </div>
-          </div>
-        </Container>
+              {contentResults?.totalPages ? (
+                <Pagination
+                  totalPages={contentResults.totalPages}
+                  ariaLabel="Content search results pagination"
+                  isHiddenMobile
+                />
+              ) : null}
+            </ContentResults>
+          </GridContainer>
+        </BasicSection>
       )}
     </main>
   );

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -215,8 +215,13 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
               ) : (
                 <>
                   {totalResults} result
-                  {totalResults === 1 ? '' : 's'} for{' '}
-                  <span className={font('intb', 6)}>{queryString}</span>
+                  {totalResults === 1 ? '' : 's'}
+                  {queryString ? (
+                    <>
+                      {' '}
+                      for <span className={font('intb', 5)}>{queryString}</span>
+                    </>
+                  ) : null}
                 </>
               )}
             </p>

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -76,7 +76,7 @@ type Props = {
   contentResults?: ContentResultsList<Addressable>;
   query: Query;
   pageview: Pageview;
-  contentQueryFailed: boolean;
+  contentQueryFailed?: boolean;
 };
 
 type NewProps = {
@@ -86,7 +86,7 @@ type NewProps = {
     images?: ReturnedResults<Image>;
   };
   queryString?: string;
-  contentQueryFailed: boolean;
+  contentQueryFailed?: boolean;
 };
 
 type SeeMoreButtonProps = {

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -244,7 +244,7 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
             <ContentResults>
               {contentResults?.results?.map(result => (
                 <Space
-                  key={`${result.uid}${result.highlightTourType || ''}`}
+                  key={`${result.id}${result.highlightTourType || ''}`}
                   $v={{ size: 'xl', properties: ['margin-bottom'] }}
                 >
                   <ContentSearchResult {...result} />

--- a/content/webapp/services/wellcome/content/types/api.ts
+++ b/content/webapp/services/wellcome/content/types/api.ts
@@ -163,6 +163,7 @@ export type Addressable = {
   times?: { start: string; end: string };
   dates?: { start: string; end?: string };
   tags?: string[];
+  highlightTourType?: 'audio' | 'bsl';
 };
 
 // Results

--- a/content/webapp/services/wellcome/content/types/api.ts
+++ b/content/webapp/services/wellcome/content/types/api.ts
@@ -160,7 +160,9 @@ export type Addressable = {
   description?: string;
   format?: string;
   contributors?: string;
-  times?: { start: Date; end: Date };
+  times?: { start: string; end: string };
+  dates?: { start: string; end?: string };
+  tags?: string[];
 };
 
 // Results


### PR DESCRIPTION
Part of #11460 

<img width="1401" alt="image" src="https://github.com/user-attachments/assets/4e38ee36-b783-46c3-bcea-a62e6135ae18" />


## What does this change?
Adds a `ContentSearchResult` component and uses it behind the `allSearch` toggle on the new search page

## How to test
Turn on the toggle, search for something, check the linkResolver takes you to where it should for each of the possible content types.

I used the existing Pagination component (if/when we update to match the designs, I think that could be a larger piece of work to make that change everywhere we do pagination).

Catalogue results are being dealt with separately. I also backed out of tackling the styling of the search box and adding then number of hits per section as part of this PR. It would require several more requests and maybe needs more discussion before it gets built

## How can we measure success?
We can serve site-search information to users rather than them having to Ask Jeeves

## Have we considered potential risks?
Things link to the wrong place/display incorrectly. It's behind a toggle so this shouldn't be a problem for as long as that's the case if so

