### PR TITLE
All search works

### DIFF
--- a/common/data/segment-values.ts
+++ b/common/data/segment-values.ts
@@ -46,6 +46,7 @@ export type ImagesLinkSource =
   | `concept/images_about_${string}`
   | `concept/images_by_${string}`
   | `concept/images_in_${string}`
+  | `images_all_${string}`
   | 'images_search_context'
   | 'work_details/images'
   | 'unknown';
@@ -80,6 +81,8 @@ export type WorksLinkSource =
   | 'concept/works_by'
   | 'concept/works_in'
   | `works_search_context_${string}`
+  | `works_workType_${string}`
+  | `works_all_${string}`
   | `work_details/contributors_${string}`
   | 'work_details/genres'
   | `work_details/subjects_${string}`

--- a/common/utils/search.ts
+++ b/common/utils/search.ts
@@ -1,5 +1,11 @@
 import { ParsedUrlQuery } from 'querystring';
 
+import { WellcomeAggregation } from '@weco/content/services/wellcome';
+import {
+  CatalogueResultsList,
+  Work,
+} from '@weco/content/services/wellcome/catalogue/types';
+
 import { propsToQuery } from './routes';
 
 export type DefaultSortValuesType = {
@@ -43,6 +49,32 @@ export function getQueryResults<T>({
   } else {
     return {
       pageResults: queryResults.results,
+      totalResults: queryResults.totalResults,
+    };
+  }
+}
+
+export type WorkTypes = {
+  workTypeBuckets: WellcomeAggregation['buckets'] | undefined;
+  totalResults: number;
+};
+/**
+ * Takes query result and checks for errors to log before returning required data.
+ * @param {string} categoryName - e.g. works
+ * @param queryResults - Original result from query
+ */
+export function getQueryWorkTypeBuckets({
+  categoryName,
+  queryResults,
+}: {
+  categoryName: string;
+  queryResults: CatalogueResultsList<Work> | ApiError;
+}): WorkTypes | undefined {
+  if (queryResults.type === 'Error') {
+    console.error(queryResults.label + ': Error fetching ' + categoryName);
+  } else {
+    return {
+      workTypeBuckets: queryResults.aggregations?.workType.buckets,
       totalResults: queryResults.totalResults,
     };
   }

--- a/common/utils/search.ts
+++ b/common/utils/search.ts
@@ -1,11 +1,5 @@
 import { ParsedUrlQuery } from 'querystring';
 
-import { WellcomeAggregation } from '@weco/content/services/wellcome';
-import {
-  CatalogueResultsList,
-  Work,
-} from '@weco/content/services/wellcome/catalogue/types';
-
 import { propsToQuery } from './routes';
 
 export type DefaultSortValuesType = {
@@ -49,32 +43,6 @@ export function getQueryResults<T>({
   } else {
     return {
       pageResults: queryResults.results,
-      totalResults: queryResults.totalResults,
-    };
-  }
-}
-
-export type WorkTypes = {
-  workTypeBuckets: WellcomeAggregation['buckets'] | undefined;
-  totalResults: number;
-};
-/**
- * Takes query result and checks for errors to log before returning required data.
- * @param {string} categoryName - e.g. works
- * @param queryResults - Original result from query
- */
-export function getQueryWorkTypeBuckets({
-  categoryName,
-  queryResults,
-}: {
-  categoryName: string;
-  queryResults: CatalogueResultsList<Work> | ApiError;
-}): WorkTypes | undefined {
-  if (queryResults.type === 'Error') {
-    console.error(queryResults.label + ': Error fetching ' + categoryName);
-  } else {
-    return {
-      workTypeBuckets: queryResults.aggregations?.workType.buckets,
       totalResults: queryResults.totalResults,
     };
   }

--- a/content/webapp/components/ImageCard/ImageCard.tsx
+++ b/content/webapp/components/ImageCard/ImageCard.tsx
@@ -13,7 +13,7 @@ type Props = {
   workId: string;
   image: ImageType;
   layout: 'raw' | 'fixed';
-  onClick: (event: SyntheticEvent<HTMLAnchorElement>) => void;
+  onClick?: (event: SyntheticEvent<HTMLAnchorElement>) => void;
   background?: string;
 };
 

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -23,9 +23,7 @@ import {
 import {
   getQueryPropertyValue,
   getQueryResults,
-  getQueryWorkTypeBuckets,
   ReturnedResults,
-  WorkTypes,
 } from '@weco/common/utils/search';
 import SearchContext from '@weco/common/views/components/SearchContext/SearchContext';
 import { Container } from '@weco/common/views/components/styled/Container';
@@ -43,11 +41,16 @@ import { toLink as worksLink } from '@weco/content/components/SearchPagesLink/Wo
 import StoriesGrid from '@weco/content/components/StoriesGrid';
 import WorksSearchResults from '@weco/content/components/WorksSearchResults/WorksSearchResults';
 import useHotjar from '@weco/content/hooks/useHotjar';
-import { WellcomeApiError } from '@weco/content/services/wellcome';
+import {
+  WellcomeAggregation,
+  WellcomeApiError,
+} from '@weco/content/services/wellcome';
 import { getImages } from '@weco/content/services/wellcome/catalogue/images';
 import {
+  CatalogueResultsList,
   Image,
   toWorkBasic,
+  Work,
   WorkBasic,
 } from '@weco/content/services/wellcome/catalogue/types';
 import { getWorks } from '@weco/content/services/wellcome/catalogue/works';
@@ -63,6 +66,32 @@ import {
 import { Query } from '@weco/content/types/search';
 import { cacheTTL, setCacheControl } from '@weco/content/utils/setCacheControl';
 import { looksLikeSpam } from '@weco/content/utils/spam-detector';
+
+export type WorkTypes = {
+  workTypeBuckets: WellcomeAggregation['buckets'] | undefined;
+  totalResults: number;
+};
+/**
+ * Takes query result and checks for errors to log before returning required data.
+ * @param {string} categoryName - e.g. works
+ * @param queryResults - Original result from query
+ */
+export function getQueryWorkTypeBuckets({
+  categoryName,
+  queryResults,
+}: {
+  categoryName: string;
+  queryResults: CatalogueResultsList<Work> | WellcomeApiError;
+}): WorkTypes | undefined {
+  if (queryResults.type === 'Error') {
+    console.error(queryResults.label + ': Error fetching ' + categoryName);
+  } else {
+    return {
+      workTypeBuckets: queryResults.aggregations?.workType.buckets,
+      totalResults: queryResults.totalResults,
+    };
+  }
+}
 
 // Creating this version of fromQuery for the overview page only
 // No filters or pagination required.

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -315,22 +315,6 @@ export const SearchPage: NextPageWithLayout<Props> = ({
   >(undefined);
   const params = fromQuery(query);
   const data = useContext(ServerDataContext);
-
-  useEffect(() => {
-    const pathname = '/search';
-    const link = {
-      href: {
-        pathname,
-        query,
-      },
-      as: {
-        pathname,
-        query,
-      },
-    };
-    setLink(link);
-  }, [query]);
-
   async function fetchWorks() {
     try {
       const worksResults = await getWorks({
@@ -375,12 +359,25 @@ export const SearchPage: NextPageWithLayout<Props> = ({
       return undefined;
     }
   }
+
   useEffect(() => {
+    const pathname = '/search';
+    const link = {
+      href: {
+        pathname,
+        query,
+      },
+      as: {
+        pathname,
+        query,
+      },
+    };
+    setLink(link);
     if (allSearch) {
       fetchWorks();
       fetchImages();
     }
-  }, []);
+  }, [query]);
 
   if (allSearch) {
     return (

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -272,7 +272,16 @@ export const SearchPage: NextPageWithLayout<Props> = ({
         categoryName: 'images',
         queryResults: imagesResults,
       });
-      setClientSideImages(images);
+      setClientSideImages({
+        totalResults: images?.totalResults || 0,
+        results:
+          images?.pageResults.map(image => ({
+            ...image,
+            src: image.locations[0].url,
+            width: (image.aspectRatio || 1) * 100,
+            height: 100,
+          })) || [],
+      });
     } catch (e) {
       return undefined;
     }

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -218,8 +218,8 @@ export const SearchPage: NextPageWithLayout<Props> = ({
   const { query: queryString } = query;
   const { setLink } = useContext(SearchContext);
   const { allSearch } = useToggles();
-  const [clientSideWorks, setClientSideWorks] = useState<
-    ReturnedResults<Work> | undefined
+  const [clientSideWorkTypes, setClientSideWorkTypes] = useState<
+    WorkTypes | undefined
   >(undefined);
   const [clientSideImages, setClientSideImages] = useState<
     ReturnedResults<Image> | undefined
@@ -252,11 +252,11 @@ export const SearchPage: NextPageWithLayout<Props> = ({
         pageSize: 1,
         toggles: data.toggles,
       });
-      const works = getQueryResults({
+      const workTypeBuckets = getQueryWorkTypeBuckets({
         categoryName: 'works',
         queryResults: worksResults,
       });
-      setClientSideWorks(works);
+      setClientSideWorkTypes(workTypeBuckets);
     } catch (e) {
       return undefined;
     }

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -265,7 +265,7 @@ export const SearchPage: NextPageWithLayout<Props> = ({
     try {
       const imagesResults = await getImages({
         params,
-        pageSize: 1,
+        pageSize: 5,
         toggles: data.toggles,
       });
       images = getQueryResults({

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -245,7 +245,10 @@ export const SearchPage: NextPageWithLayout<Props> = ({
   async function fetchWorks() {
     try {
       const worksResults = await getWorks({
-        params,
+        params: {
+          ...params,
+          aggregations: ['workType'],
+        },
         pageSize: 1,
         toggles: data.toggles,
       });

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -2,7 +2,7 @@ import { GetServerSideProps } from 'next';
 import NextLink from 'next/link';
 import { usePathname } from 'next/navigation';
 import { ParsedUrlQuery } from 'querystring';
-import { useContext, useEffect, useState } from 'react';
+import { useContext, useState } from 'react';
 import styled from 'styled-components';
 
 import { getServerData } from '@weco/common/server-data';
@@ -41,6 +41,7 @@ import { toLink as worksLink } from '@weco/content/components/SearchPagesLink/Wo
 import StoriesGrid from '@weco/content/components/StoriesGrid';
 import WorksSearchResults from '@weco/content/components/WorksSearchResults/WorksSearchResults';
 import useHotjar from '@weco/content/hooks/useHotjar';
+import useSkipInitialEffect from '@weco/content/hooks/useSkipInitialEffect';
 import {
   WellcomeAggregation,
   WellcomeApiError,
@@ -360,7 +361,7 @@ export const SearchPage: NextPageWithLayout<Props> = ({
     }
   }
 
-  useEffect(() => {
+  useSkipInitialEffect(() => {
     const pathname = '/search';
     const link = {
       href: {


### PR DESCRIPTION
## What does this change?

For https://github.com/wellcomecollection/wellcomecollection.org/issues/11459

This PR:
- fetches the aggregations for the works and uses them to create the correct links for the catalogue results section
- converts the images results so we can use them with ImageCard and create the necessary links for the image results section

![screencapture-localhost-3000-search-2025-01-28-00_54_33](https://github.com/user-attachments/assets/672eb8d4-a47d-4160-b956-ec9eae653537)

Next comes styling

## How to test

Visit /search with the all allSearch toggle enabled

## How can we measure success?

The data/functionality of the catalogue and images sections of the all search is available

## Have we considered potential risks?

Behind a toggle so they're limited

