### PR TITLE
ItemViewer; Change height of item based on type

### DIFF
--- a/content/webapp/components/IIIFViewer/MainViewer.tsx
+++ b/content/webapp/components/IIIFViewer/MainViewer.tsx
@@ -414,6 +414,7 @@ const MainViewer: FunctionComponent = () => {
   const mainViewerRef = useRef<FixedSizeList>(null);
   const [newScrollOffset, setNewScrollOffset] = useState(0);
   const [firstRender, setFirstRender] = useState(true);
+  const [hasImagesOnly, setHasImagesOnly] = useState(false);
   const firstRenderRef = useRef(firstRender);
   firstRenderRef.current = firstRender;
   const scrollVelocity = useScrollVelocity(newScrollOffset);
@@ -454,7 +455,7 @@ const MainViewer: FunctionComponent = () => {
     }
   }
 
-  // Scroll to the correct canvas  when the canvas changes.
+  // Scroll to the correct canvas when the canvas changes.
   // But we don't want this to happen if the canvas changes as a result of the viewer being scrolled,
   // so ItemLink href prop can include a shouldScrollToCanvas query param on the href object to prevent this.
   useEffect(() => {
@@ -467,6 +468,12 @@ const MainViewer: FunctionComponent = () => {
       });
     }
   }, [canvas]);
+
+  useEffect(() => {
+    // Keeping this very simple for now - I think it'll just apply to audio, video and of course mixed works containing either of them.
+    // I would like to also have it return false for PDFs, but they currently do have a thumbnail image.
+    setHasImagesOnly(!canvases?.find(canvas => !canvas.thumbnailImage?.url));
+  }, []);
 
   return (
     <div data-testid="main-viewer">
@@ -486,7 +493,9 @@ const MainViewer: FunctionComponent = () => {
           accessToken,
           placeholderId,
         }}
-        itemSize={mainAreaWidth}
+        // We want images to render bigger than their height for readability
+        // But other things should be centered and therefore based on the height.
+        itemSize={hasImagesOnly ? mainAreaWidth : mainAreaHeight}
         onItemsRendered={debounceHandleOnItemsRendered.current}
         onScroll={handleOnScroll}
         ref={mainViewerRef}


### PR DESCRIPTION
## What does this change?

#11521 
I just changed what we passed to `itemSize`, using the viewerHeight instead of its width. We believe the width is used because it makes images much more readable; but we can use the height for audio/video to align them centrally.

I left comments in the code for more info.

## How to test

Try various types and see they still look good
- Multi audio http://localhost:3000/works/dmpcsthv/items
- Book http://localhost:3000/works/a2239muq/items
- PDF http://localhost:3000/works/pmv8cncs/items
- Mixed born digital http://localhost:3000/works/dn9jwck6/items

## How can we measure success?

Audio looks better!

## Have we considered potential risks?
N/A?