### PR TITLE
Amend `sliceAnalysis` script to account for guides' model

### DIFF
--- a/prismic-model/sliceAnalysis.ts
+++ b/prismic-model/sliceAnalysis.ts
@@ -144,7 +144,7 @@ async function main() {
     );
   console.info('');
 
-  // console.info(contentTypeMatches);
+  console.info(contentTypeMatches);
   console.info(
     `found ${
       slicesMatches ? slicesMatches + ' ' + type : totalSlices + ' slices'

--- a/prismic-model/sliceAnalysis.ts
+++ b/prismic-model/sliceAnalysis.ts
@@ -65,20 +65,25 @@ async function main() {
   const snapshotDir = await downloadPrismicSnapshot();
 
   for (const result of getPrismicDocuments(snapshotDir)) {
-    if (result.data.body) {
-      for (const slice of result.data.body) {
+    const hasSlices = !!result.data.body || !!result.data.slices;
+
+    if (hasSlices) {
+      // Not all slices are within the body (Exhibition guides' were built straight in)
+      const slices = result.data.body || result.data.slices;
+
+      for (const slice of slices) {
         const currentValue = sliceCounter.get(slice.slice_type) || 0;
         sliceCounter.set(slice.slice_type, currentValue + 1);
       }
 
       const isWithType: boolean = type
-        ? result.data.body.some(slice => slice.slice_type === type)
+        ? slices.some(slice => slice.slice_type === type)
         : true;
 
       if (isWithType) {
         // Find how often the slice is used within the content type
         let nodeSliceCount = 0;
-        result.data.body
+        slices
           .map(slice => {
             if (slice.slice_type === type) {
               slicesMatches++;
@@ -139,7 +144,7 @@ async function main() {
     );
   console.info('');
 
-  console.info(contentTypeMatches);
+  // console.info(contentTypeMatches);
   console.info(
     `found ${
       slicesMatches ? slicesMatches + ' ' + type : totalSlices + ' slices'


### PR DESCRIPTION
## What does this change?

Realised the script didn't account for when slices were not within something called "Body". Guides' model is a bit different and they weren't getting caught; is that something we'd be happy to amend so it matches the rest? (@gestchild @davidpmccormick )

Before
<img width="338" alt="Screenshot 2025-01-28 at 13 24 45" src="https://github.com/user-attachments/assets/8b2a3b84-d137-4e1c-9a3b-f40b0769f192" />


After
<img width="347" alt="Screenshot 2025-01-28 at 13 21 13" src="https://github.com/user-attachments/assets/be9db038-4583-4415-a72e-9eaf94be4776" />


## How to test

Run it locally

## How can we measure success?

Data is valid again

## Have we considered potential risks?
N/A but should we make sure models are aligned?