### PR TITLE
Remove quotev2 from slice list

### DIFF
--- a/common/views/slices/index.ts
+++ b/common/views/slices/index.ts
@@ -18,7 +18,6 @@ export const components = {
   infoBlock: dynamic(() => import('./InfoBlock')),
   map: dynamic(() => import('./Map')),
   quote: dynamic(() => import('./Quote')),
-  quoteV2: dynamic(() => import('./Quote')),
   searchResults: dynamic(() => import('./SearchResults')),
   standfirst: dynamic(() => import('./Standfirst')),
   tagList: dynamic(() => import('./TagList')),


### PR DESCRIPTION
I feel like this used to error when we removed it, but I couldn't replicate - let's get rid of it fully?

What scenario haven't I tested?