### PR TITLE
Add transcript field to Exhibition Text

### DIFF
--- a/common/prismicio-types.d.ts
+++ b/common/prismicio-types.d.ts
@@ -6582,6 +6582,16 @@ export interface GuideTextItemSliceDefaultPrimary {
    * - **Documentation**: https://prismic.io/docs/field#rich-text-title
    */
   additional_notes: prismic.RichTextField;
+
+  /**
+   * Transcript field in *GuideTextItem → Default → Primary*
+   *
+   * - **Field Type**: Rich Text
+   * - **Placeholder**: *None*
+   * - **API ID Path**: guide_text_item.default.primary.transcript
+   * - **Documentation**: https://prismic.io/docs/field#rich-text-title
+   */
+  transcript: prismic.RichTextField;
 }
 
 /**

--- a/common/views/slices/GuideTextItem/index.tsx
+++ b/common/views/slices/GuideTextItem/index.tsx
@@ -12,16 +12,14 @@ const GuideTextItem: FunctionComponent<GuideTextItemProps> = ({
   slice,
   index,
 }) => {
-  const transformedSlice = transformGuideTextItemSlice(slice);
+  const { additional_notes: additionalNotes, ...transformedSlice } =
+    transformGuideTextItemSlice(slice);
 
   return (
     <TextItem
       key={index}
-      number={transformedSlice.number}
-      title={transformedSlice.title}
-      tombstone={transformedSlice.tombstone}
-      caption={transformedSlice.caption}
-      additionalNotes={transformedSlice.additional_notes}
+      {...transformedSlice}
+      additionalNotes={additionalNotes}
     />
   );
 };

--- a/common/views/slices/GuideTextItem/mocks.json
+++ b/common/views/slices/GuideTextItem/mocks.json
@@ -51,6 +51,17 @@
 						}
 					}
 				]
+			},
+			"transcript": {
+				"__TYPE__": "StructuredTextContent",
+				"value": [
+					{
+						"type": "paragraph",
+						"content": {
+							"text": "Id qui eiusmod eu et elit pariatur qui. Cillum nulla aliquip ea ad et. Duis consequat sit consectetur est adipisicing esse est sint officia est aliquip culpa."
+						}
+					}
+				]
 			}
 		},
 		"items": [

--- a/common/views/slices/GuideTextItem/model.json
+++ b/common/views/slices/GuideTextItem/model.json
@@ -54,6 +54,15 @@
             "allowTargetBlank": false,
             "multi": "paragraph,strong,em,hyperlink"
           }
+        },
+        "transcript": {
+          "type": "StructuredText",
+          "config": {
+            "label": "Transcript",
+            "placeholder": "",
+            "allowTargetBlank": true,
+            "multi": "paragraph,heading1,heading2,heading3,heading4,heading5,strong,em"
+          }
         }
       },
       "items": {}

--- a/content/webapp/components/GuideTextItem/GuideTextItem.tsx
+++ b/content/webapp/components/GuideTextItem/GuideTextItem.tsx
@@ -2,6 +2,8 @@ import * as prismic from '@prismicio/client';
 import { FunctionComponent } from 'react';
 
 import { font } from '@weco/common/utils/classnames';
+import { camelize } from '@weco/common/utils/grammar';
+import CollapsibleContent from '@weco/common/views/components/CollapsibleContent';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock';
 import { Container } from '@weco/common/views/components/styled/Container';
 import Space from '@weco/common/views/components/styled/Space';
@@ -18,7 +20,8 @@ const GuideTextItem: FunctionComponent<{
   tombstone?: prismic.RichTextField;
   caption?: prismic.RichTextField;
   additionalNotes?: prismic.RichTextField;
-}> = ({ number, title, tombstone, caption, additionalNotes }) => {
+  transcript?: prismic.RichTextField;
+}> = ({ number, title, tombstone, caption, additionalNotes, transcript }) => {
   return (
     <Space
       id={number ? `stop-${number}` : undefined}
@@ -42,6 +45,17 @@ const GuideTextItem: FunctionComponent<{
               <Caption>
                 <PrismicHtmlBlock html={caption} />
               </Caption>
+            )}
+
+            {transcript && (
+              <Space $v={{ size: 'xl', properties: ['margin-top'] }}>
+                <CollapsibleContent
+                  id={number ? `${number}` : camelize(title)}
+                  controlText={{ defaultText: 'Read transcript' }}
+                >
+                  <PrismicHtmlBlock html={transcript} />
+                </CollapsibleContent>
+              </Space>
             )}
           </Wrapper>
         )}

--- a/content/webapp/services/prismic/transformers/exhibition-texts.ts
+++ b/content/webapp/services/prismic/transformers/exhibition-texts.ts
@@ -93,6 +93,7 @@ type GuideTextItem = {
   caption: prismic.RichTextField | undefined;
   tombstone: prismic.RichTextField | undefined;
   additional_notes: prismic.RichTextField | undefined;
+  transcript: prismic.RichTextField | undefined;
 };
 
 export function transformGuideTextItemSlice(
@@ -109,6 +110,9 @@ export function transformGuideTextItemSlice(
       : undefined,
     additional_notes: slice.primary.additional_notes
       ? asRichText(slice.primary.additional_notes)
+      : undefined,
+    transcript: slice.primary.transcript
+      ? asRichText(slice.primary.transcript)
       : undefined,
   };
 }


### PR DESCRIPTION
## What does this change?

#11522
Adds a transcript field to "Guide text item" slice.
Displays it on the FE inside a CollapsibleContent component.
<img width="500" alt="Screenshot 2025-01-28 at 15 31 39" src="https://github.com/user-attachments/assets/524ae707-8b6d-4d2d-8806-78028669901a" />
<img width="500" alt="Screenshot 2025-01-28 at 15 31 43" src="https://github.com/user-attachments/assets/cbce8f9e-bb97-485c-8044-f2d29ecaeb9f" />



## How to test
I added one in Kola Nut (first instance of guide text) on staging, so you could run staging locally and see it there.

## How can we measure success?

A feature we lost is back ✨ 

## Have we considered potential risks?
N/A?
