### PR TITLE
Remove `deployBundleAnalysis` script, add README section on how to run locally

### DIFF
--- a/common/README.md
+++ b/common/README.md
@@ -6,3 +6,12 @@ Of particular interest:
 
 * The `data` directory holds most the hard-coded data for the site (e.g. microcopy, error messages, contact information). We keep it in one place so it can be easily reviewed and updated across the site.
 * The `customtypes` and `views/slices` directories contain the Prismic model data which is created locally using (SliceMachine)[https://prismic.io/slice-machine]. When creating new custom types, slices, or fields, refer to the (API ID name casing docs in Gitbook)[https://app.gitbook.com/o/-LumfFcEMKx4gYXKAZTQ/s/451yLOIRTl5YiAJ88yIL/api-id-name-casing]
+
+
+## Bundle analysis
+Previously stored in S3 and displayed on dash.wellcomecollection.org, you can still run it locally.
+It currently only is set-up for `content/`, as it's using the `next/next.config.js`. Other repos could be made to use it.
+Example of how to use:
+1. `cd content/webapp`
+2. `BUNDLE_ANALYZE=true yarn build`
+3. It'll render new files, you're probably interested in the one at: `/content/webapp/.dist/content.client.test.html`.

--- a/content/webapp/package.json
+++ b/content/webapp/package.json
@@ -7,8 +7,7 @@
     "dev": "NODE_ENV=development nodemon --watch server.ts --watch app.ts --exec ts-node --project tsconfig.server.json server",
     "start": "NODE_ENV=production ts-node-transpile-only --project tsconfig.server.json server",
     "test": "NODE_ENV=test jest --no-cache",
-    "test:watch": "yarn test -- --watchAll",
-    "deployBundleAnalysis": "aws s3 sync .dist s3://dash.wellcomecollection.org/bundles --only-show-errors --acl public-read"
+    "test:watch": "yarn test -- --watchAll"
   },
   "dependencies": {
     "@iiif/presentation-3": "^2.1.3",

--- a/identity/webapp/package.json
+++ b/identity/webapp/package.json
@@ -18,8 +18,7 @@
     "storybook": "start-storybook -p 4009",
     "build-storybook": "build-storybook",
     "test": "jest",
-    "lint:next": "next lint",
-    "deployBundleAnalysis": "aws s3 sync .dist s3://dash.wellcomecollection.org/bundles --only-show-errors --acl public-read"
+    "lint:next": "next lint"
   },
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.2.0",


### PR DESCRIPTION
## What does this change?

Just found a pretty weighty folder in the dash s3 bucket, and turns out [it's not something we use anymore](https://wellcome.slack.com/archives/CUA669WHH/p1738146586058779). 
<img width="1663" alt="bundles size" src="https://github.com/user-attachments/assets/f4c1079d-1286-4b72-b8ae-c633a87e1cc0" />

I'm removing the command lines which hadn't been used since 2023 anyway, and adding a section in the common README for instructions if anyone is interested in running it locally.

The folder on s3 has been deleted manually, now only at 161mb.

## How to test

Try to run the script locally, see if the README is satisfying

## How can we measure success?

Tidier 🤷‍♀️ ✨ 

## Have we considered potential risks?
N/A not been used in ages.