### PR TITLE
Revert change to link-resolver 

### DIFF
--- a/common/services/prismic/link-resolver.ts
+++ b/common/services/prismic/link-resolver.ts
@@ -46,12 +46,10 @@ function linkResolver(doc: Props | DataProps): string {
   if (
     type === 'exhibition-guides' ||
     type === 'exhibition-highlight-tours' ||
-    type === 'exhibition-guides-links'
-  )
+    type === 'exhibition-guides-links' ||
+    type === 'exhibition-texts'
+  ) {
     return `/guides/exhibitions/${uid}`;
-
-  if (type === 'exhibition-texts') {
-    return `/guides/exhibitions/${uid}/captions-and-transcripts`;
   }
 
   if (type === 'visual-stories') {

--- a/common/services/prismic/link-resolver.ts
+++ b/common/services/prismic/link-resolver.ts
@@ -1,10 +1,6 @@
 import { isSiteSection, SiteSection } from '@weco/common/model/site-section';
 
-import {
-  contentApiTypeMap,
-  isContentApiContentType,
-  isContentType,
-} from './content-types';
+import { isContentType } from './content-types';
 
 type Props = {
   uid?: string;
@@ -30,13 +26,7 @@ function linkResolver(doc: Props | DataProps): string {
   // which doesn't necessarily have access to all data
   if (!doc) return '/';
 
-  const { uid } = doc;
-
-  const type = isContentType(doc.type)
-    ? doc.type
-    : isContentApiContentType(doc.type)
-      ? contentApiTypeMap[doc.type]
-      : '';
+  const { uid, type } = doc;
 
   if (!uid) return '/';
   if (type === 'articles') return `/stories/${uid}`;
@@ -45,12 +35,11 @@ function linkResolver(doc: Props | DataProps): string {
 
   if (
     type === 'exhibition-guides' ||
+    type === 'exhibition-texts' ||
     type === 'exhibition-highlight-tours' ||
-    type === 'exhibition-guides-links' ||
-    type === 'exhibition-texts'
-  ) {
+    type === 'exhibition-guides-links'
+  )
     return `/guides/exhibitions/${uid}`;
-  }
 
   if (type === 'visual-stories') {
     if ('data' in doc) {


### PR DESCRIPTION
## What does this change?

[Flagged as a bug by Grace on Slack](https://wellcome.slack.com/archives/C3N7J05TK/p1738237445998549?thread_ts=1738228074.651889&cid=C3N7J05TK)
This I think is due to a change we made for the search links to work as expected.
As that's still behind a toggle, I'm just reverting the change to the link on the exhibition guides page gets back to normal/working. 
We can address the fix for the search component at a later point: [#11549](https://github.com/wellcomecollection/wellcomecollection.org/issues/11549)

UPDATE: To address [other problems that were found](https://github.com/wellcomecollection/wellcomecollection.org/pull/11548#issuecomment-2624321268), all changes to the link resolvers from the [search work](https://github.com/wellcomecollection/wellcomecollection.org/pull/11534/files) have been reverted, we'll address them in the ticket listed above.

## How to test

Access exhibition texts from various points; is it fixed on what users see?
e.g. http://localhost:3000/guides/exhibitions/hard-graft
Do the links at the bottom (from the other exhibition) also work?

## How can we measure success?

Not a broken link anymore

## Have we considered potential risks?
I don't think it'll break anything other than the search results behind the toggle, but good to QA a few different places to make sure.