### PR TITLE
All search styling

### DIFF
--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -315,22 +315,6 @@ export const SearchPage: NextPageWithLayout<Props> = ({
   >(undefined);
   const params = fromQuery(query);
   const data = useContext(ServerDataContext);
-
-  useEffect(() => {
-    const pathname = '/search';
-    const link = {
-      href: {
-        pathname,
-        query,
-      },
-      as: {
-        pathname,
-        query,
-      },
-    };
-    setLink(link);
-  }, [query]);
-
   async function fetchWorks() {
     try {
       const worksResults = await getWorks({
@@ -375,12 +359,25 @@ export const SearchPage: NextPageWithLayout<Props> = ({
       return undefined;
     }
   }
+
   useEffect(() => {
+    const pathname = '/search';
+    const link = {
+      href: {
+        pathname,
+        query,
+      },
+      as: {
+        pathname,
+        query,
+      },
+    };
+    setLink(link);
     if (allSearch) {
       fetchWorks();
       fetchImages();
     }
-  }, []);
+  }, [query]);
 
   if (allSearch) {
     return (

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -25,6 +25,7 @@ import {
   getQueryResults,
   ReturnedResults,
 } from '@weco/common/utils/search';
+import Divider from '@weco/common/views/components/Divider/Divider';
 import SearchContext from '@weco/common/views/components/SearchContext/SearchContext';
 import { Container } from '@weco/common/views/components/styled/Container';
 import Space from '@weco/common/views/components/styled/Space';
@@ -298,69 +299,93 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
           </Container>
           <GridContainer>
             <CatalogueResults>
-            {catalogueResults.works &&
-              catalogueResults.works.totalResults > 0 && (
-                <div>
-                  <SectionTitle sectionName="Catalogue" />
-                  {catalogueResults.works.workTypeBuckets?.map((bucket, i) => (
-                    <NextLink
-                      key={i}
-                      {...worksLink(
-                        {
-                          query: queryString,
-                          workType: [bucket.data.id],
-                        },
-                        `works_workType_${pathname}`
-                      )}
-                      passHref
-                    >
-                      {bucket.data.label} ({bucket.count})
-                    </NextLink>
-                  ))}
-                  <NextLink
-                    {...worksLink(
-                      {
-                        query: queryString,
-                      },
-                      `works_all_${pathname}`
+              {((catalogueResults.images?.totalResults &&
+                catalogueResults.images?.totalResults > 0) ||
+                (catalogueResults.works?.totalResults &&
+                  catalogueResults.works?.totalResults > 0)) && (
+                <CatalogueResultsInner>
+                  {catalogueResults.works &&
+                    catalogueResults.works.totalResults > 0 && (
+                      <>
+                        <CatalogueSectionTitle sectionName="Catalogue results" />
+                        <CatalogueLinks>
+                          {catalogueResults.works.workTypeBuckets?.map(
+                            (bucket, i) => (
+                              <NextLink
+                                key={i}
+                                {...worksLink(
+                                  {
+                                    query: queryString,
+                                    workType: [bucket.data.id],
+                                  },
+                                  `works_workType_${pathname}`
+                                )}
+                                passHref
+                              >
+                                {bucket.data.label} ({bucket.count})
+                              </NextLink>
+                            )
+                          )}
+                        </CatalogueLinks>
+                        <NextLink
+                          {...worksLink(
+                            {
+                              query: queryString,
+                            },
+                            `works_all_${pathname}`
+                          )}
+                          passHref
+                        >
+                          All Catalogue results{' '}
+                          {catalogueResults.works?.totalResults}
+                        </NextLink>
+                      </>
                     )}
-                    passHref
-                  >
-                    All Catalogue results {catalogueResults.works?.totalResults}
-                  </NextLink>
-                </div>
-              )}
-
-            {catalogueResults.images && (
-              <div>
-                <SectionTitle sectionName="Images" />
-                {catalogueResults.images.results.map(image => (
-                  <ImageCard
-                    key={image.id}
-                    id={image.id}
-                    workId={image.source.id}
-                    image={{
-                      contentUrl: image.src,
-                      width: image.width * 1.57,
-                      height: image.height * 1.57,
-                      alt: image.source.title,
-                    }}
-                    layout="raw"
-                  />
-                ))}
-                <NextLink
-                  {...imagesLink(
-                    {
-                      query: queryString,
-                    },
-                    `images_all_${pathname}`
+                  {catalogueResults.works && catalogueResults.images && (
+                    <Space
+                      className="is-hidden-s"
+                      $v={{
+                        size: 'l',
+                        properties: ['margin-top', 'margin-bottom'],
+                      }}
+                    >
+                      <Divider lineColor="neutral.400" />
+                    </Space>
                   )}
-                  passHref
-                >
-                  All images {catalogueResults.images?.totalResults}
-                </NextLink>
-              </div>
-            )}
+                  {catalogueResults.images && (
+                    <>
+                      <CatalogueSectionTitle sectionName="Image results" />
+                      <CatalogueLinks>
+                        {catalogueResults.images.results.map(image => (
+                          <ImageCard
+                            key={image.id}
+                            id={image.id}
+                            workId={image.source.id}
+                            image={{
+                              contentUrl: image.src,
+                              width: image.width * 1.57,
+                              height: image.height * 1.57,
+                              alt: image.source.title,
+                            }}
+                            layout="raw"
+                          />
+                        ))}
+                      </CatalogueLinks>
+                      <NextLink
+                        {...imagesLink(
+                          {
+                            query: queryString,
+                          },
+                          `images_all_${pathname}`
+                        )}
+                        passHref
+                      >
+                        All images {catalogueResults.images?.totalResults}
+                      </NextLink>
+                    </>
+                  )}
+                </CatalogueResultsInner>
+              )}
             </CatalogueResults>
             <ContentResults>
               {contentResults?.results?.map(result => (

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -364,10 +364,14 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
           </Container>
           <GridContainer>
             <CatalogueResults>
-              {((catalogueResults.images?.totalResults &&
-                catalogueResults.images?.totalResults > 0) ||
-                (catalogueResults.works?.totalResults &&
-                  catalogueResults.works?.totalResults > 0)) && (
+              {(!!(
+                catalogueResults.images?.totalResults &&
+                catalogueResults.images?.totalResults > 0
+              ) ||
+                !!(
+                  catalogueResults.works?.totalResults &&
+                  catalogueResults.works?.totalResults > 0
+                )) && (
                 <CatalogueResultsInner>
                   {catalogueResults.works &&
                     catalogueResults.works.totalResults > 0 && (

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -271,7 +271,9 @@ const ContentResults = styled.div`
   `}
 `;
 
-const CatalogueResults = styled.div`
+const CatalogueResults = styled(Space).attrs({
+  $v: { size: 'xl', properties: ['margin-bottom'] },
+})`
   grid-column: l-start / r-end;
 
   ${props => props.theme.media('medium')`

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -382,7 +382,6 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
             </ContentResults>
           </GridContainer>
         </BasicSection>
->>>>>>> origin/all-search
       )}
     </main>
   );

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -5,6 +5,7 @@ import { ParsedUrlQuery } from 'querystring';
 import { useContext, useState } from 'react';
 import styled from 'styled-components';
 
+import { arrow } from '@weco/common/icons';
 import { getServerData } from '@weco/common/server-data';
 import {
   ServerDataContext,
@@ -26,6 +27,7 @@ import {
   ReturnedResults,
 } from '@weco/common/utils/search';
 import Divider from '@weco/common/views/components/Divider/Divider';
+import Icon from '@weco/common/views/components/Icon/Icon';
 import SearchContext from '@weco/common/views/components/SearchContext/SearchContext';
 import { Container } from '@weco/common/views/components/styled/Container';
 import Space from '@weco/common/views/components/styled/Space';
@@ -70,6 +72,18 @@ import {
 import { Query } from '@weco/content/types/search';
 import { cacheTTL, setCacheControl } from '@weco/content/utils/setCacheControl';
 import { looksLikeSpam } from '@weco/content/utils/spam-detector';
+
+const AllLink = styled.a.attrs({
+  className: font('intsb', 5),
+})`
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+
+  .icon {
+    margin-left: 8px;
+  }
+`;
 
 export type WorkTypes = {
   workTypeBuckets: WellcomeAggregation['buckets'] | undefined;
@@ -182,7 +196,7 @@ const SectionTitle = ({ sectionName }: { sectionName: string }) => {
 const CatalogueSectionTitle = ({ sectionName }: { sectionName: string }) => {
   return (
     <Space $v={{ size: 's', properties: ['margin-bottom'] }}>
-      <h3 className={`${font('intb', 4)} is-hidden-s`}>{sectionName}</h3>
+      <h3 className={`${font('intsb', 4)} is-hidden-s`}>{sectionName}</h3>
     </Space>
   );
 };
@@ -335,9 +349,12 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
                             `works_all_${pathname}`
                           )}
                           passHref
+                          legacyBehavior
                         >
-                          All Catalogue results{' '}
-                          {catalogueResults.works?.totalResults}
+                          <AllLink>
+                            {`All Catalogue results (${catalogueResults.works?.totalResults})`}
+                            <Icon icon={arrow} iconColor="black" rotate={360} />
+                          </AllLink>
                         </NextLink>
                       </>
                     )}
@@ -379,8 +396,12 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
                           `images_all_${pathname}`
                         )}
                         passHref
+                        legacyBehavior
                       >
-                        All images {catalogueResults.images?.totalResults}
+                        <AllLink>
+                          {`All images (${catalogueResults.images?.totalResults})`}
+                          <Icon icon={arrow} iconColor="black" rotate={360} />
+                        </AllLink>
                       </NextLink>
                     </>
                   )}

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -41,6 +41,7 @@ import { toLink as worksLink } from '@weco/content/components/SearchPagesLink/Wo
 import StoriesGrid from '@weco/content/components/StoriesGrid';
 import WorksSearchResults from '@weco/content/components/WorksSearchResults/WorksSearchResults';
 import useHotjar from '@weco/content/hooks/useHotjar';
+import useSkipInitialEffect from '@weco/content/hooks/useSkipInitialEffect';
 import {
   WellcomeAggregation,
   WellcomeApiError,
@@ -360,7 +361,7 @@ export const SearchPage: NextPageWithLayout<Props> = ({
     }
   }
 
-  useEffect(() => {
+  useSkipInitialEffect(() => {
     const pathname = '/search';
     const link = {
       href: {

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -136,6 +136,22 @@ type SeeMoreButtonProps = {
   totalResults: number;
 };
 
+const CatalogueResultsInner = styled(Space).attrs({
+  $h: { size: 'm', properties: ['padding-left', 'padding-right'] },
+  $v: { size: 'm', properties: ['padding-top', 'padding-bottom'] },
+})`
+  background-color: ${props => props.theme.color('warmNeutral.300')};
+`;
+
+const CatalogueLinks = styled(Space).attrs({
+  $v: { size: 'm', properties: ['margin-bottom'] },
+  className: 'is-hidden-s',
+})`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+`;
+
 const BasicSection = styled(Space).attrs({
   as: 'section',
   $v: { size: 'xl', properties: ['padding-top', 'padding-bottom'] },
@@ -158,6 +174,14 @@ const SectionTitle = ({ sectionName }: { sectionName: string }) => {
   return (
     <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
       <h3 className={font('intb', 2)}>{sectionName}</h3>
+    </Space>
+  );
+};
+
+const CatalogueSectionTitle = ({ sectionName }: { sectionName: string }) => {
+  return (
+    <Space $v={{ size: 's', properties: ['margin-bottom'] }}>
+      <h3 className={`${font('intb', 4)} is-hidden-s`}>{sectionName}</h3>
     </Space>
   );
 };

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -73,18 +73,6 @@ import { Query } from '@weco/content/types/search';
 import { cacheTTL, setCacheControl } from '@weco/content/utils/setCacheControl';
 import { looksLikeSpam } from '@weco/content/utils/spam-detector';
 
-const AllLink = styled.a.attrs({
-  className: font('intsb', 5),
-})`
-  display: inline-flex;
-  align-items: center;
-  cursor: pointer;
-
-  .icon {
-    margin-left: 8px;
-  }
-`;
-
 const WorksLink = styled.a.attrs({
   className: font('intr', 6),
 })`
@@ -203,6 +191,54 @@ const SectionTitle = ({ sectionName }: { sectionName: string }) => {
       <h3 className={font('intb', 2)}>{sectionName}</h3>
     </Space>
   );
+};
+
+const StyledAllLink = styled.a.attrs({
+  className: font('intsb', 5),
+})`
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+
+  .icon {
+    margin-left: 8px;
+  }
+`;
+
+const AllLink = ({
+  type,
+  results,
+}: {
+  type: 'works' | 'images';
+  results: CatalogueResults;
+}) => {
+  const data = (function () {
+    switch (type) {
+      case 'works':
+        return {
+          total: results.works?.totalResults,
+          text: `All Catalogue results (${results.works?.totalResults})`,
+          noResults: "We couldn't find any catalogue results",
+        };
+      case 'images':
+        return {
+          total: results.images?.totalResults,
+          text: `All Image results (${results.works?.totalResults})`,
+          noResults: "We couldn't find any image results",
+        };
+    }
+  })();
+
+  if (data.total && data.total > 0) {
+    return (
+      <StyledAllLink>
+        {data.text}
+        <Icon icon={arrow} iconColor="black" rotate={360} />
+      </StyledAllLink>
+    );
+  } else {
+    return <p className={font('intr', 6)}>{data.noResults}</p>;
+  }
 };
 
 const CatalogueSectionTitle = ({ sectionName }: { sectionName: string }) => {

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -135,12 +135,14 @@ type ImageResults = {
   results: (Image & { src: string; width: number; height: number })[];
 };
 
+type CatalogueResults = {
+  works?: WorkTypes;
+  images?: ImageResults;
+};
+
 type NewProps = {
   contentResults?: ContentResultsList<Addressable>;
-  catalogueResults: {
-    works?: WorkTypes;
-    images?: ImageResults;
-  };
+  catalogueResults: CatalogueResults;
   queryString?: string;
   contentQueryFailed?: boolean;
 };

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -411,10 +411,7 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
                           passHref
                           legacyBehavior
                         >
-                          <AllLink>
-                            {`All Catalogue results (${catalogueResults.works?.totalResults})`}
-                            <Icon icon={arrow} iconColor="black" rotate={360} />
-                          </AllLink>
+                          <AllLink type="works" results={catalogueResults} />
                         </NextLink>
                       </>
                     )}
@@ -458,10 +455,7 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
                         passHref
                         legacyBehavior
                       >
-                        <AllLink>
-                          {`All images (${catalogueResults.images?.totalResults})`}
-                          <Icon icon={arrow} iconColor="black" rotate={360} />
-                        </AllLink>
+                        <AllLink type="images" results={catalogueResults} />
                       </NextLink>
                     </>
                   )}

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -85,6 +85,18 @@ const AllLink = styled.a.attrs({
   }
 `;
 
+const WorksLink = styled.a.attrs({
+  className: font('intr', 6),
+})`
+  border: 2px solid;
+  padding: 4px 12px;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
 export type WorkTypes = {
   workTypeBuckets: WellcomeAggregation['buckets'] | undefined;
   totalResults: number;
@@ -335,8 +347,11 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
                                   `works_workType_${pathname}`
                                 )}
                                 passHref
+                                legacyBehavior
                               >
-                                {bucket.data.label} ({bucket.count})
+                                <WorksLink>
+                                  {bucket.data.label} ({bucket.count})
+                                </WorksLink>
                               </NextLink>
                             )
                           )}


### PR DESCRIPTION
## What does this change?

For #11459 

Implements styling for the catalogue and image results ([designs](https://www.figma.com/design/qssPpJy1lOWSFtuACajkZr/Global-search?node-id=4656-13903&m=dev))

Wide screen:
![screencapture-localhost-3000-search-2025-01-30-14_28_51](https://github.com/user-attachments/assets/1a5b4ecb-28af-4934-b6c5-8920e8b590c5)

Narrow screen:
<img width="561" alt="Screenshot 2025-01-30 at 14 43 32" src="https://github.com/user-attachments/assets/ce7fef4d-fc05-4c38-8a46-e571316107ae" />

No results: 
<img width="511" alt="Screenshot 2025-01-30 at 14 23 45" src="https://github.com/user-attachments/assets/5d2ebf1b-8a56-43f2-9341-78875355203a" />

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? -->

I've created a few new components, we may want to move them into there own files/add them to cardigan if we think they will be reused.