### PR TITLE
Conditionally add tablist/tab roles if there's JS

### DIFF
--- a/content/webapp/components/Tabs/Tabs.Switch.tsx
+++ b/content/webapp/components/Tabs/Tabs.Switch.tsx
@@ -121,7 +121,11 @@ const TabsSwitch: FunctionComponent<Props> = ({
   };
 
   return (
-    <TabsContainer role="tablist" ref={tabListRef} aria-label={label}>
+    <TabsContainer
+      role={isEnhanced ? 'tablist' : undefined}
+      ref={tabListRef}
+      aria-label={label}
+    >
       {items.map(item => {
         const isSelected = isEnhanced && selectedTab === item.id;
         return (
@@ -146,7 +150,7 @@ const TabsSwitch: FunctionComponent<Props> = ({
             onKeyDown={handleKeyDown}
           >
             <TabButton
-              role="tab"
+              role={isEnhanced ? 'tab' : undefined}
               id={`tab-${item.id}`}
               tabIndex={item.id === selectedTab ? 0 : -1}
               aria-controls={`tabpanel-${item.id}`}


### PR DESCRIPTION
For #10437

## What does this change?
Checks if you have JS and adds the `tablist` and `tab` roles to the Tabs.Switch component if you do.

## How to test
Visit `/whats-on` locally with and without JS. Inspect the Months and check for the presence/absence of the above attributes.

## How can we measure success?
The site is accessible in more circumstances


## Have we considered potential risks?
Can't think of any

