### PR TITLE
Tweak docs for running locally

### DIFF
--- a/scripts/configure-local-apis.sh
+++ b/scripts/configure-local-apis.sh
@@ -46,4 +46,4 @@ configure_nginx
 # echo sparkles then "All done! in green
 
 echo -e "\n${GREEN} ✨ All done!${NC}"
-echo -e "\n${YELLOW}Please restart nginx: \"sudo bash -c 'nginx -s stop && nginx'\"${NC}"
+echo -e "\n${YELLOW}Please restart nginx: \"sudo bash -c '(nginx -s stop || true) && nginx'\"${NC}"


### PR DESCRIPTION
## What does this change?

Update docs in run local APIs script to use a command that is happy if you haven't started nginx yet:

`(nginx -s stop || true) && nginx`

## How to test

Can you run it without error?

## How can we measure success?

Less confused developers.

## Have we considered potential risks?

This is a docs change only, risks should be minimal.
