### PR TITLE
Prevent horizontal scrollbar appearing

### DIFF
--- a/content/webapp/components/ImageGallery/ImageGallery.styles.tsx
+++ b/content/webapp/components/ImageGallery/ImageGallery.styles.tsx
@@ -123,9 +123,8 @@ export const Gallery = styled.div<GalleryProps>`
   `}
 
   .close {
-    position: sticky;
-    top: 18px;
     transform: translateX(calc((100vw - 100%) / 2));
+    position: relative;
     z-index: 3;
     pointer-events: all;
   }
@@ -196,7 +195,7 @@ export const ControlContainer = styled(Space).attrs<ControlContainerProps>(
       'is-hidden': !props.$isActive,
     }),
     $v: { size: 'm', properties: ['padding-bottom'] },
-    $h: { size: 'm', properties: ['padding-right'] },
+    $h: { size: 'l', properties: ['margin-right'] },
   })
 )<ControlContainerProps>`
   display: flex;


### PR DESCRIPTION
For #11150 

## What does this change?
The close cross in the image gallery has `padding-right` which, on smaller screens, could lead to a horizontal scrollbar appearing when the galleries were opened. Replacing the `padding-right` with a larger `margin-right` prevents this from happening.

Unrelated to the horizontal scrollbar, I spotted that we'd originally intended this close button to be `position: sticky`, but since we added `overflow: auto` to the `ContentPage__Wrapper` more than two years ago, this wouldn't have worked. I don't think anyone noticed or cared, so I haven't tried to fix it in this PR and have removed the sticky classes instead.

## How to test
Go to http://localhost:3000/exhibitions/ZZP8BxAAALeD00jo, open the image gallery, scroll to the bottom of the page and check that a horizontal scrollbar doesn't appear above the footer at any browser width

## How can we measure success?
Site looks less broken

## Have we considered potential risks?
n/a