### PR TITLE
All search tweaks

### DIFF
--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -391,7 +391,7 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
                         </>
                       ) : (
                         <p className={font('intr', 6)}>
-                          We couldn't find any catalogue results
+                          {`We couldn't find any catalogue results`}
                         </p>
                       )}
                     </>
@@ -421,8 +421,8 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
                                 workId={image.source.id}
                                 image={{
                                   contentUrl: image.src,
-                                  width: image.width * 1.57,
-                                  height: image.height * 1.57,
+                                  width: image.width * 0.8,
+                                  height: image.height * 0.8,
                                   alt: image.source.title,
                                 }}
                                 layout="raw"
@@ -451,7 +451,7 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
                         </>
                       ) : (
                         <p className={font('intr', 6)}>
-                          We couldn't find any image results
+                          {`We couldn't find any image results`}
                         </p>
                       )}
                     </>
@@ -528,7 +528,7 @@ export const SearchPage: NextPageWithLayout<Props> = ({
     try {
       const imagesResults = await getImages({
         params,
-        pageSize: 5,
+        pageSize: 7,
         toggles: data.toggles,
       });
       images = getQueryResults({

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -2,7 +2,7 @@ import { GetServerSideProps } from 'next';
 import NextLink from 'next/link';
 import { usePathname } from 'next/navigation';
 import { ParsedUrlQuery } from 'querystring';
-import { useContext, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { arrow } from '@weco/common/icons';
@@ -46,7 +46,6 @@ import { toLink as worksLink } from '@weco/content/components/SearchPagesLink/Wo
 import StoriesGrid from '@weco/content/components/StoriesGrid';
 import WorksSearchResults from '@weco/content/components/WorksSearchResults/WorksSearchResults';
 import useHotjar from '@weco/content/hooks/useHotjar';
-import useSkipInitialEffect from '@weco/content/hooks/useSkipInitialEffect';
 import {
   WellcomeAggregation,
   WellcomeApiError,
@@ -551,7 +550,7 @@ export const SearchPage: NextPageWithLayout<Props> = ({
     }
   }
 
-  useSkipInitialEffect(() => {
+  useEffect(() => {
     const pathname = '/search';
     const link = {
       href: {

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -30,6 +30,7 @@ import Divider from '@weco/common/views/components/Divider/Divider';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import SearchContext from '@weco/common/views/components/SearchContext/SearchContext';
 import { Container } from '@weco/common/views/components/styled/Container';
+import LL from '@weco/common/views/components/styled/LL';
 import Space from '@weco/common/views/components/styled/Space';
 import { NextPageWithLayout } from '@weco/common/views/pages/_app';
 import theme from '@weco/common/views/themes/default';
@@ -156,7 +157,12 @@ const CatalogueResultsInner = styled(Space).attrs({
   $h: { size: 'm', properties: ['padding-left', 'padding-right'] },
   $v: { size: 'm', properties: ['padding-top', 'padding-bottom'] },
 })`
+  position: relative;
   background-color: ${props => props.theme.color('warmNeutral.300')};
+  min-height: 90px;
+  ${props => props.theme.media('large')`
+      min-height: 400px;
+  `}
 `;
 
 const CatalogueLinks = styled(Space).attrs({
@@ -331,133 +337,126 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
           </Container>
           <GridContainer>
             <CatalogueResults>
-              {(!!(
-                catalogueResults.images?.totalResults &&
-                catalogueResults.images?.totalResults > 0
-              ) ||
-                !!(
-                  catalogueResults.works?.totalResults &&
-                  catalogueResults.works?.totalResults > 0
-                )) && (
-                <CatalogueResultsInner>
-                  {catalogueResults.works && (
-                    <>
-                      <CatalogueSectionTitle sectionName="Catalogue results" />
-                      {catalogueResults.works?.totalResults &&
-                      catalogueResults.works?.totalResults > 0 ? (
-                        <>
-                          <CatalogueLinks>
-                            {catalogueResults.works.workTypeBuckets
-                              ?.slice(0, 6)
-                              .map((bucket, i) => (
-                                <NextLink
-                                  key={i}
-                                  {...worksLink(
-                                    {
-                                      query: queryString,
-                                      workType: [bucket.data.id],
-                                    },
-                                    `works_workType_${pathname}`
-                                  )}
-                                  passHref
-                                  legacyBehavior
-                                >
-                                  <WorksLink>
-                                    {bucket.data.label} ({bucket.count})
-                                  </WorksLink>
-                                </NextLink>
-                              ))}
-                          </CatalogueLinks>
-
-                          <NextLink
-                            {...worksLink(
-                              {
-                                query: queryString,
-                              },
-                              `works_all_${pathname}`
-                            )}
-                            passHref
-                            legacyBehavior
-                          >
-                            <AllLink>
-                              {`All catalogue results (${catalogueResults.works?.totalResults})`}
-                              <Icon
-                                icon={arrow}
-                                iconColor="black"
-                                rotate={360}
-                              />
-                            </AllLink>
-                          </NextLink>
-                        </>
-                      ) : (
-                        <p className={font('intr', 6)}>
-                          {`We couldn't find any catalogue results`}
-                        </p>
-                      )}
-                    </>
-                  )}
-                  {catalogueResults.works && catalogueResults.images && (
-                    <Space
-                      className="is-hidden-s is-hidden-m"
-                      $v={{
-                        size: 'l',
-                        properties: ['margin-top', 'margin-bottom'],
-                      }}
-                    >
-                      <Divider lineColor="neutral.400" />
-                    </Space>
-                  )}
-                  {catalogueResults.images && (
-                    <>
-                      <CatalogueSectionTitle sectionName="Image results" />
-                      {catalogueResults.images?.totalResults &&
-                      catalogueResults.images?.totalResults > 0 ? (
-                        <>
-                          <CatalogueLinks>
-                            {catalogueResults.images.results.map(image => (
-                              <ImageCard
-                                key={image.id}
-                                id={image.id}
-                                workId={image.source.id}
-                                image={{
-                                  contentUrl: image.src,
-                                  width: image.width * 0.8,
-                                  height: image.height * 0.8,
-                                  alt: image.source.title,
-                                }}
-                                layout="raw"
-                              />
+              <CatalogueResultsInner>
+                {!catalogueResults.works && !catalogueResults.images && (
+                  <>
+                    <span className="is-hidden-l is-hidden-xl">
+                      <LL $small />
+                    </span>
+                    <span className="is-hidden-s is-hidden-m">
+                      <LL />
+                    </span>
+                  </>
+                )}
+                {catalogueResults.works && (
+                  <>
+                    <CatalogueSectionTitle sectionName="Catalogue results" />
+                    {catalogueResults.works?.totalResults &&
+                    catalogueResults.works?.totalResults > 0 ? (
+                      <>
+                        <CatalogueLinks>
+                          {catalogueResults.works.workTypeBuckets
+                            ?.slice(0, 6)
+                            .map((bucket, i) => (
+                              <NextLink
+                                key={i}
+                                {...worksLink(
+                                  {
+                                    query: queryString,
+                                    workType: [bucket.data.id],
+                                  },
+                                  `works_workType_${pathname}`
+                                )}
+                                passHref
+                                legacyBehavior
+                              >
+                                <WorksLink>
+                                  {bucket.data.label} ({bucket.count})
+                                </WorksLink>
+                              </NextLink>
                             ))}
-                          </CatalogueLinks>
-                          <NextLink
-                            {...imagesLink(
-                              {
-                                query: queryString,
-                              },
-                              `images_all_${pathname}`
-                            )}
-                            passHref
-                            legacyBehavior
-                          >
-                            <AllLink>
-                              {`All image results (${catalogueResults.images?.totalResults})`}
-                              <Icon
-                                icon={arrow}
-                                iconColor="black"
-                                rotate={360}
-                              />
-                            </AllLink>
-                          </NextLink>
-                        </>
-                      ) : (
-                        <p className={font('intr', 6)}>
-                          {`We couldn't find any image results`}
-                        </p>
-                      )}
-                    </>
-                  )}
-                </CatalogueResultsInner>
-              )}
+                        </CatalogueLinks>
+
+                        <NextLink
+                          {...worksLink(
+                            {
+                              query: queryString,
+                            },
+                            `works_all_${pathname}`
+                          )}
+                          passHref
+                          legacyBehavior
+                        >
+                          <AllLink>
+                            {`All catalogue results (${catalogueResults.works?.totalResults})`}
+                            <Icon icon={arrow} iconColor="black" rotate={360} />
+                          </AllLink>
+                        </NextLink>
+                      </>
+                    ) : (
+                      <p className={font('intr', 6)}>
+                        {`We couldn't find any catalogue results`}
+                      </p>
+                    )}
+                  </>
+                )}
+                {catalogueResults.works && catalogueResults.images && (
+                  <Space
+                    className="is-hidden-s is-hidden-m"
+                    $v={{
+                      size: 'l',
+                      properties: ['margin-top', 'margin-bottom'],
+                    }}
+                  >
+                    <Divider lineColor="neutral.400" />
+                  </Space>
+                )}
+                {catalogueResults.images && (
+                  <>
+                    <CatalogueSectionTitle sectionName="Image results" />
+                    {catalogueResults.images?.totalResults &&
+                    catalogueResults.images?.totalResults > 0 ? (
+                      <>
+                        <CatalogueLinks>
+                          {catalogueResults.images.results.map(image => (
+                            <ImageCard
+                              key={image.id}
+                              id={image.id}
+                              workId={image.source.id}
+                              image={{
+                                contentUrl: image.src,
+                                width: image.width * 0.8,
+                                height: image.height * 0.8,
+                                alt: image.source.title,
+                              }}
+                              layout="raw"
+                            />
+                          ))}
+                        </CatalogueLinks>
+                        <NextLink
+                          {...imagesLink(
+                            {
+                              query: queryString,
+                            },
+                            `images_all_${pathname}`
+                          )}
+                          passHref
+                          legacyBehavior
+                        >
+                          <AllLink>
+                            {`All image results (${catalogueResults.images?.totalResults})`}
+                            <Icon icon={arrow} iconColor="black" rotate={360} />
+                          </AllLink>
+                        </NextLink>
+                      </>
+                    ) : (
+                      <p className={font('intr', 6)}>
+                        {`We couldn't find any image results`}
+                      </p>
+                    )}
+                  </>
+                )}
+              </CatalogueResultsInner>
             </CatalogueResults>
             <ContentResults>
               {contentResults?.results?.map(result => (

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -347,8 +347,9 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
                       catalogueResults.works?.totalResults > 0 ? (
                         <>
                           <CatalogueLinks>
-                            {catalogueResults.works.workTypeBuckets?.map(
-                              (bucket, i) => (
+                            {catalogueResults.works.workTypeBuckets
+                              ?.slice(0, 6)
+                              .map((bucket, i) => (
                                 <NextLink
                                   key={i}
                                   {...worksLink(
@@ -365,8 +366,7 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
                                     {bucket.data.label} ({bucket.count})
                                   </WorksLink>
                                 </NextLink>
-                              )
-                            )}
+                              ))}
                           </CatalogueLinks>
 
                           <NextLink


### PR DESCRIPTION
## What does this change?

Makes some tweaks following a conversation with Dana

- always show the catalogue results box with a loading icon until the results arrive:
### large screen
<img width="1317" alt="Screenshot 2025-02-04 at 14 28 51" src="https://github.com/user-attachments/assets/c82c62d7-0f88-4131-b221-6dc82e893da6" />

### small screen
<img width="571" alt="Screenshot 2025-02-04 at 14 28 06" src="https://github.com/user-attachments/assets/7156ad67-affe-4622-942b-4005f9a37c01" />


- limit the works links to first 6
- rather than loading another javascript library just to align the images, they are now smaller and we'll evaluate how this works first.
- replaced useSkipInitialEffect with useEffect as there were instances when the results weren't appearing

## How to test

Vist http://localhost:3000/search with the allSearch toggle enabled

## How can we measure success?

We're happy with how the results look/behave

## Have we considered potential risks?

Still behind a toggle for evaluation, so none really
