### PR TITLE
Stop deploying dash on merges to main

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -56,18 +56,6 @@
         env:
           - NEXT_PUBLIC_CIVICUK_API_KEY
 
-- label: ':docker: build dash'
-  branches: 'main'
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: 'arn:aws:iam::130871440101:role/experience-ci'
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        build:
-          - dash
-        image-repository: 130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/buildkite
-
 - label: 'diff prismic model'
   branches: 'main'
   plugins:
@@ -179,21 +167,6 @@
         push:
           - identity:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/identity_webapp:ref.${BUILDKITE_COMMIT}
           - identity:130871440101.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/identity_webapp:latest
-
-- label: 'deploy dash'
-  branches: 'main'
-  plugins:
-    - wellcomecollection/aws-assume-role#v0.2.2:
-        role: 'arn:aws:iam::130871440101:role/experience-ci'
-    - ecr#v2.1.1:
-        login: true
-    - docker-compose#v3.5.0:
-        run: dash
-        command: ['yarn', 'deploy']
-        env:
-          - AWS_ACCESS_KEY_ID
-          - AWS_SECRET_ACCESS_KEY
-          - AWS_SESSION_TOKEN
 
 - label: 'deploy edge_lambdas'
   branches: 'main'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,10 +19,6 @@ services:
       dockerfile: identity/Dockerfile
       args:
         - NEXT_PUBLIC_CIVICUK_API_KEY
-  dash:
-    build:
-      context: .
-      dockerfile: dash/Dockerfile
   edge_lambdas:
     build:
       context: .


### PR DESCRIPTION
## What does this change?

Stops `dash` from deploying on _every merge_. It's just about the dash's UI, not its reports. It pushes a new folder in S3 every time (`_next/static/[random folder name]`) and although they are small, it seems unnecessary and a bit much.
<img width="497" alt="Screenshot 2025-02-05 at 09 31 04" src="https://github.com/user-attachments/assets/9d33c480-9d2f-4b5d-9121-2c7342ca2be3" />

[We'd discussed this in Slack already](https://wellcome.slack.com/archives/CUA669WHH/p1727700670906309), and the main "con" was that dependencies should be deployed more often than we now would (only deploying dash manually when it has changes), but my feel is that 1) it's a tool we use, so it breaking only affects us and not that much 2) Dependabot now flags when upgrades are required so it wouldn't get ignored.
But very happy to hear more cons/ideas!

Also; did I miss anything?

## How to test

We'll see when we merge?
Did I miss anything else that should've been removed?

## How can we measure success?

Less unnecessary things, less steps on merges to main.

## Have we considered potential risks?
See description.