### PR TITLE
Sticky image gallery close button

### DIFF
--- a/content/webapp/components/ContentPage/ContentPage.tsx
+++ b/content/webapp/components/ContentPage/ContentPage.tsx
@@ -39,7 +39,10 @@ type Props = {
 };
 
 const Wrapper = styled.div<{ $isCreamy: boolean }>`
-  overflow: auto;
+  /* This (display: flow-root) prevents unwanted margin collapsing which would
+  otherwise cause white spaces at the bottom of the story pages */
+  display: flow-root;
+
   ${props =>
     props.$isCreamy &&
     `background-color: ${props.theme.color('warmNeutral.300')}`};

--- a/content/webapp/components/ImageGallery/ImageGallery.styles.tsx
+++ b/content/webapp/components/ImageGallery/ImageGallery.styles.tsx
@@ -124,7 +124,8 @@ export const Gallery = styled.div<GalleryProps>`
 
   .close {
     transform: translateX(calc((100vw - 100%) / 2));
-    position: relative;
+    position: sticky;
+    top: 18px;
     z-index: 3;
     pointer-events: all;
   }


### PR DESCRIPTION
![sticky](https://github.com/user-attachments/assets/86a2f1ca-22b0-4c3a-95f6-ac81af3b1234)

## What does this change?
Makes the close button stick to the top of the image gallery when the user scrolls, as it was originally designed. This behaviour stopped working c. 2 years ago when we added a `overflow: auto;` property to the `ContentPage__Wrapper` (a measure put in place to prevent margin collapsing causing white spaces at the bottom of the articles pages) and we apparently never noticed that this broke the stickiness of the button.

There's now a [well-supported `display: flow-root` property](https://caniuse.com/?search=flow-root) which was seemingly created to reduce the need for hacks (like `overflow: auto`). Some information about it on [CSS Tricks here](https://css-tricks.com/display-flow-root/). And it doesn't stop sticky elements from sticking.

## How to test
Visit a [page with an image gallery](http://localhost:3000/exhibitions/ZZP8BxAAALeD00jo), open the gallery and scroll, check the button sticks for the duration of the gallery.

Visit a story page and check that no extra whitespace is being added erroneously.

## How can we measure success?
Pages appear as designed.

## Have we considered potential risks?
display: flow-root introduces different visual regressions

