### PR TITLE
Change microcopy for overview to 'Search for anything'

### DIFF
--- a/common/data/microcopy.tsx
+++ b/common/data/microcopy.tsx
@@ -162,7 +162,8 @@ export const pastExhibitionsStrapline =
 // This is the label used in the search box, both for the
 // search in the global nav and on the categories in wc.org/search
 export const searchLabelText = {
-  overview: 'Search for anything',
+  overviewAllSearch: 'Search for anything',
+  overview: 'Search our stories, images, catalogue and events',
   stories: 'Search for stories',
   images: 'Search for images',
   works: 'Search the catalogue',

--- a/common/data/microcopy.tsx
+++ b/common/data/microcopy.tsx
@@ -162,7 +162,7 @@ export const pastExhibitionsStrapline =
 // This is the label used in the search box, both for the
 // search in the global nav and on the categories in wc.org/search
 export const searchLabelText = {
-  overview: 'Search our stories, images, catalogue and events',
+  overview: 'Search for anything',
   stories: 'Search for stories',
   images: 'Search for images',
   works: 'Search the catalogue',

--- a/common/views/components/Header/Header.tsx
+++ b/common/views/components/Header/Header.tsx
@@ -14,6 +14,7 @@ import { searchLabelText } from '@weco/common/data/microcopy';
 import { cross, search } from '@weco/common/icons';
 import WellcomeCollectionBlack from '@weco/common/icons/wellcome_collection_black';
 import { SiteSection } from '@weco/common/model/site-section';
+import { useToggles } from '@weco/common/server-data/Context';
 import { font } from '@weco/common/utils/classnames';
 import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
 import Icon from '@weco/common/views/components/Icon/Icon';
@@ -105,6 +106,7 @@ const Header: FunctionComponent<Props> = ({
   const [searchDropdownIsActive, setSearchDropdownIsActive] = useState(false);
   const searchButtonRef = useRef<HTMLButtonElement>(null);
   const { isEnhanced } = useContext(AppContext);
+  const { allSearch } = useToggles();
 
   useEffect(() => {
     if (document && document.documentElement) {
@@ -187,7 +189,9 @@ const Header: FunctionComponent<Props> = ({
                               icon={searchDropdownIsActive ? cross : search}
                             />
                             <span className="visually-hidden">
-                              {searchLabelText.overview}
+                              {allSearch
+                                ? searchLabelText.overviewAllSearch
+                                : searchLabelText.overview}
                             </span>
                           </NoJSIconWrapper>
                         </NextLink>

--- a/common/views/components/SearchForm/SearchForm.tsx
+++ b/common/views/components/SearchForm/SearchForm.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react';
 
 import { searchLabelText } from '@weco/common/data/microcopy';
+import { useToggles } from '@weco/common/server-data/Context';
 import { formDataAsUrlQuery } from '@weco/common/utils/forms';
 import { getQueryPropertyValue, linkResolver } from '@weco/common/utils/search';
 import SearchBar, {
@@ -42,6 +43,7 @@ const SearchForm = ({
   const router = useRouter();
   const routerQuery = getQueryPropertyValue(router?.query?.query);
   const { link: searchLink } = useContext(SearchContext);
+  const { allSearch } = useToggles();
   const initialValue =
     routerQuery || searchLink.as.query?.query?.toString() || '';
   const [inputValue, setInputValue] = useState(initialValue);
@@ -74,7 +76,11 @@ const SearchForm = ({
         form={`search-form-${searchCategory}`}
         placeholder={
           searchLabelText[
-            searchCategory !== 'overview' ? searchCategory : 'overview'
+            searchCategory !== 'overview'
+              ? searchCategory
+              : allSearch
+                ? 'overviewAllSearch'
+                : 'overview'
           ]
         }
         inputRef={inputRef}

--- a/content/webapp/components/SearchPageLayout/SearchNavigation.tsx
+++ b/content/webapp/components/SearchPageLayout/SearchNavigation.tsx
@@ -3,6 +3,7 @@ import { FunctionComponent, useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { searchLabelText } from '@weco/common/data/microcopy';
+import { useToggles } from '@weco/common/server-data/Context';
 import convertUrlToString from '@weco/common/utils/convert-url-to-string';
 import { formDataAsUrlQuery } from '@weco/common/utils/forms';
 import { capitalize } from '@weco/common/utils/grammar';
@@ -41,6 +42,7 @@ const SearchNavigation: FunctionComponent<SearchNavigationProps> = ({
   currentSearchCategory,
   currentQueryValue: queryValue,
 }) => {
+  const { allSearch } = useToggles();
   const router = useRouter();
 
   // Variable naming note:
@@ -121,7 +123,9 @@ const SearchNavigation: FunctionComponent<SearchNavigationProps> = ({
               searchLabelText[
                 currentSearchCategory !== 'overview'
                   ? currentSearchCategory
-                  : 'overview'
+                  : allSearch
+                    ? 'overviewAllSearch'
+                    : 'overview'
               ]
             }
             form={SEARCH_PAGES_FORM_ID}


### PR DESCRIPTION
For #11546 

## What does this change?
Changes the 'Search our stories, images, catalogue and events' label above the search bar on the `/search` (All search) page, to 'Search for anything'

## How to test
[Search for anything](http://localhost:3000/search?query=anything)

## How can we measure success?
Labels are simpler and more consistent

## Have we considered potential risks?
n/a
