### PR TITLE
No content results

### DIFF
--- a/content/webapp/components/SearchPageLayout/SearchNavigation.tsx
+++ b/content/webapp/components/SearchPageLayout/SearchNavigation.tsx
@@ -131,7 +131,6 @@ const SearchNavigation: FunctionComponent<SearchNavigationProps> = ({
       </form>
       <Tabs
         tabBehaviour="navigate"
-        hideBorder={currentSearchCategory === 'overview'}
         label="Search Categories"
         items={[
           {

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -228,37 +228,33 @@ const CatalogueSectionTitle = ({ sectionName }: { sectionName: string }) => {
 
 const GridContainer = styled(Container)`
   display: grid;
-  grid-template-columns: [l-start] 9fr [l-end r-start] 3fr [r-end];
-
-  ${props => props.theme.media('large')`
-    grid-template-columns: [l-start] 6fr [l-end] 2fr [r-start] 4fr [r-end];
-  `}
+  grid-template-columns: repeat(12, 1fr);
 `;
 
 const ContentResults = styled.div`
-  grid-column: l-start / r-end;
+  grid-column: 1 / 13;
 
   ${props => props.theme.media('medium')`
-    grid-column: l-start / l-end;
+    grid-column: 1 / 10;
   `}
 
   ${props => props.theme.media('large')`
     grid-row: 1;
-    grid-column: l-start / l-end;
+    grid-column: 1 / 8;
   `}
 `;
 
 const CatalogueResults = styled(Space).attrs({
   $v: { size: 'xl', properties: ['margin-bottom'] },
 })`
-  grid-column: l-start / r-end;
+  grid-column: 1 / 13;
 
   ${props => props.theme.media('medium')`
-    grid-column: l-start / l-end;
+    grid-column: 1 / 10;
   `}
 
   ${props => props.theme.media('large')`
-    grid-column: r-start / r-end;
+    grid-column: 9 / 13;
   `}
 `;
 

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -246,16 +246,17 @@ const ContentResults = styled.div`
 
 const CatalogueResults = styled(Space).attrs({
   $v: { size: 'xl', properties: ['margin-bottom'] },
-})`
+})<{ $fullWidth: boolean }>`
   grid-column: 1 / 13;
 
   ${props => props.theme.media('medium')`
     grid-column: 1 / 10;
   `}
 
-  ${props => props.theme.media('large')`
-    grid-column: 9 / 13;
-  `}
+  ${props =>
+    props.theme.media('large')(
+      `grid-column: ${props.$fullWidth ? '1 / 13' : '9 / 13'};`
+    )}
 `;
 
 const StoryPromoContainer = styled(Container)`
@@ -373,7 +374,7 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
             </p>
           </Container>
           <GridContainer>
-            <CatalogueResults>
+            <CatalogueResults $fullWidth={!contentResults?.totalResults}>
               <CatalogueResultsInner>
                 {!catalogueResults.works && !catalogueResults.images && (
                   <>


### PR DESCRIPTION
For #11463

<img width="1334" alt="image" src="https://github.com/user-attachments/assets/3535d846-75e3-4bdc-8482-c2ce1253139b" />


## What does this change?
Allows the catalogue results to span the full width of the page if there aren't any content results.

## How to test
- Search for 'muybrige' (sic) – catalogue results are full width
- Search for 'muybridge' – there is a content result so catalogue results go in a sidebar

## Not in this PR
I've not touched the 'x results for __thing__' here because we weren't yet doing what was in the original designs.

@dana-saur we only display up to 6 aggregation buckets (buttons) and 7 images in this area, and I think we expect the circumstances in which you get lots of catalogue results and no content results to be fairly rare, so my preference would be to allow the images and buttons to wrap onto a second line if there were enough for that to happen rather than write extra logic to force them to stay on one line – what do you think?

## How can we measure success?
Better use of available space

## Have we considered potential risks?
n/a