### PR TITLE
Display access filter in events search

### DIFF
--- a/content/webapp/services/wellcome/common/filters.ts
+++ b/content/webapp/services/wellcome/common/filters.ts
@@ -644,6 +644,29 @@ const eventsLocationFilter = ({
   }),
 });
 
+const eventsInterpretationFilter = ({
+  events,
+  props,
+}: EventsFilterProps): CheckboxFilter<keyof EventsProps> => {
+  return {
+    type: 'checkbox',
+    id: 'interpretation',
+    label: 'Access type',
+    options: filterOptionsWithNonAggregates({
+      options: events?.aggregations?.interpretation?.buckets.map(bucket => {
+        return {
+          id: `access-${bucket.data.id}`,
+          value: bucket.data.id,
+          count: bucket.count,
+          label: bucket.data.label,
+          selected: props.interpretation.includes(bucket.data.id),
+        };
+      }),
+      selectedValues: props.interpretation,
+    }),
+  };
+};
+
 const eventsIsAvailableOnlineFilter = ({
   events,
   props,
@@ -659,30 +682,6 @@ const eventsIsAvailableOnlineFilter = ({
     isSelected: !!props.isAvailableOnline,
   };
 };
-
-// TODO re-add when https://github.com/wellcomecollection/content-api/issues/106 is done
-// const eventsInterpretationFilter = ({
-//   events,
-//   props,
-// }: EventsFilterProps): CheckboxFilter<keyof EventsProps> => {
-//   return {
-//     type: 'checkbox',
-//     id: 'interpretation',
-//     label: 'Accessibility',
-//     options: filterOptionsWithNonAggregates({
-//       options: events?.aggregations?.interpretation?.buckets.map(bucket => {
-//         return {
-//           id: `a11y-${bucket.data.id}`,
-//           value: bucket.data.id,
-//           count: bucket.count,
-//           label: bucket.data.label,
-//           selected: props.interpretation.includes(bucket.data.id),
-//         };
-//       }),
-//       selectedValues: props.interpretation,
-//     }),
-//   };
-// };
 
 const imagesFilters: (props: ImagesFilterProps) => Filter[] = props =>
   [
@@ -721,8 +720,7 @@ const eventsFilters: (
     eventsAudienceFilter,
     eventsLocationFilter,
     eventsIsAvailableOnlineFilter,
-    // TODO re-add when https://github.com/wellcomecollection/content-api/issues/106 is done
-    // eventsInterpretationFilter
+    eventsInterpretationFilter,
   ].map(f => f(props));
 
 export { worksFilters, imagesFilters, storiesFilters, eventsFilters };

--- a/content/webapp/services/wellcome/common/filters.ts
+++ b/content/webapp/services/wellcome/common/filters.ts
@@ -651,7 +651,7 @@ const eventsInterpretationFilter = ({
   return {
     type: 'checkbox',
     id: 'interpretation',
-    label: 'Access type',
+    label: 'Access types',
     options: filterOptionsWithNonAggregates({
       options: events?.aggregations?.interpretation?.buckets.map(bucket => {
         return {


### PR DESCRIPTION
## What does this change?

#11467 

Displays interpretation/access filters in `/search/events`.
The work had already been done content API side when we first released events, as well as all of it in this repo. We'd commented out the lines modified here to hide it because of the duplicates issue that's since been addressed.
So this is quite simple in the end!

There are currently no e2e tests for the events search. Is that something we'd like to put in? All the search tests feel a bit repetitive, so I'm not sure and I'd love opinions on that. @gestchild @davidpmccormick 

## How to test

Run locally, filter out various mixes of filters and see if it behaves as expected.

## How can we measure success?

A new filter to filter with!

## Have we considered potential risks?
Don't think there are any?