### PR TITLE
Add border under tabs component

### DIFF
--- a/content/webapp/components/SearchPageLayout/SearchNavigation.tsx
+++ b/content/webapp/components/SearchPageLayout/SearchNavigation.tsx
@@ -3,6 +3,7 @@ import { FunctionComponent, useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { searchLabelText } from '@weco/common/data/microcopy';
+import { useToggles } from '@weco/common/server-data/Context';
 import convertUrlToString from '@weco/common/utils/convert-url-to-string';
 import { formDataAsUrlQuery } from '@weco/common/utils/forms';
 import { capitalize } from '@weco/common/utils/grammar';
@@ -20,6 +21,11 @@ const SearchBarContainer = styled(Space)`
   ${props => props.theme.media('medium', 'max-width')`
     margin-bottom:0;
   `}
+`;
+
+const TabsBorder = styled.div<{ $visible?: boolean }>`
+  border-bottom: ${props =>
+    props.$visible ? `1px solid ${props.theme.color('neutral.300')}` : 'none'};
 `;
 
 type SearchNavigationProps = {
@@ -41,6 +47,7 @@ const SearchNavigation: FunctionComponent<SearchNavigationProps> = ({
   currentSearchCategory,
   currentQueryValue: queryValue,
 }) => {
+  const { allSearch } = useToggles();
   const router = useRouter();
 
   // Variable naming note:
@@ -129,39 +136,41 @@ const SearchNavigation: FunctionComponent<SearchNavigationProps> = ({
           />
         </SearchBarContainer>
       </form>
-      <Tabs
-        tabBehaviour="navigate"
-        hideBorder={currentSearchCategory === 'overview'}
-        label="Search Categories"
-        items={[
-          {
-            id: 'overview',
-            url: getURL('/search'),
-            text: 'All',
-          },
-          {
-            id: 'stories',
-            url: getURL('/search/stories'),
-            text: 'Stories',
-          },
-          {
-            id: 'images',
-            url: getURL('/search/images'),
-            text: 'Images',
-          },
-          {
-            id: 'works',
-            url: getURL('/search/works'),
-            text: 'Catalogue',
-          },
-          {
-            id: 'events',
-            url: getURL('/search/events'),
-            text: 'Events',
-          },
-        ]}
-        currentSection={currentSearchCategory}
-      />
+      <TabsBorder $visible={allSearch}>
+        <Tabs
+          tabBehaviour="navigate"
+          hideBorder={allSearch || currentSearchCategory === 'overview'}
+          label="Search Categories"
+          items={[
+            {
+              id: 'overview',
+              url: getURL('/search'),
+              text: 'All',
+            },
+            {
+              id: 'stories',
+              url: getURL('/search/stories'),
+              text: 'Stories',
+            },
+            {
+              id: 'images',
+              url: getURL('/search/images'),
+              text: 'Images',
+            },
+            {
+              id: 'works',
+              url: getURL('/search/works'),
+              text: 'Catalogue',
+            },
+            {
+              id: 'events',
+              url: getURL('/search/events'),
+              text: 'Events',
+            },
+          ]}
+          currentSection={currentSearchCategory}
+        />
+      </TabsBorder>
     </>
   );
 };


### PR DESCRIPTION
For #11575

## What does this change?

<img width="1289" alt="image" src="https://github.com/user-attachments/assets/4e087a2a-9e8e-49f7-8c19-3fcd4ccdf23b" />


Adds a full-width border below the tabs if the `allSearch` toggle is turned on. The `Tabs` component does have a `hideBorder` prop which if `false` puts a border under the tabs, but since we want the border to span the whole width of the page it made more sense to hide the border on the tabs themselves and add it to a wrapping element.

## How to test
- With the `allSearch` toggle on: [Search for something](http://localhost:3000/search?query=something). Click on the search tabs and verify the border is there for each.
- With the `allSearch` toggle off: check that 1. the All tab doesn't have a border, and 2. the other tabs only display the border the width of the Tabs component itself.

## How can we measure success?
n/a

## Have we considered potential risks?
n/a

