### PR TITLE
Allow ImageGallery close button to gain focus

### DIFF
--- a/content/webapp/components/ImageGallery/ImageGallery.styles.tsx
+++ b/content/webapp/components/ImageGallery/ImageGallery.styles.tsx
@@ -178,21 +178,28 @@ export const WobblyEdgeWrapper = styled.div`
 `;
 
 type ButtonContainerProps = { $isHidden: boolean };
-export const ButtonContainer = styled.div<ButtonContainerProps>`
-  display: ${props => (props.$isHidden ? 'none' : 'block')};
+export const ButtonContainer = styled.div.attrs<ButtonContainerProps>(
+  props => ({
+    'aria-hidden': props.$isHidden,
+  })
+)<ButtonContainerProps>`
   position: absolute;
   bottom: 24px;
   left: 50%;
   transform: translateX(-50%) translateY(50%);
   z-index: 2;
+  opacity: ${props => (props.$isHidden ? 0 : 1)};
 `;
 
 type ControlContainerProps = { $isActive: boolean };
-export const ControlContainer = styled(Space).attrs({
-  className: 'close',
-  $v: { size: 'm', properties: ['padding-bottom'] },
-  $h: { size: 'l', properties: ['margin-right'] },
-})<ControlContainerProps>`
+export const ControlContainer = styled(Space).attrs<{ $isActive: boolean }>(
+  props => ({
+    'aria-hidden': !props.$isActive,
+    className: 'close',
+    $v: { size: 'm', properties: ['padding-bottom'] },
+    $h: { size: 'l', properties: ['margin-right'] },
+  })
+)<ControlContainerProps>`
   opacity: ${props => (props.$isActive ? 1 : 0)};
   display: flex;
   justify-content: flex-end;

--- a/content/webapp/components/ImageGallery/ImageGallery.styles.tsx
+++ b/content/webapp/components/ImageGallery/ImageGallery.styles.tsx
@@ -192,7 +192,7 @@ export const ButtonContainer = styled.div.attrs<ButtonContainerProps>(
 `;
 
 type ControlContainerProps = { $isActive: boolean };
-export const ControlContainer = styled(Space).attrs<{ $isActive: boolean }>(
+export const ControlContainer = styled(Space).attrs<ControlContainerProps>(
   props => ({
     'aria-hidden': !props.$isActive,
     className: 'close',

--- a/content/webapp/components/ImageGallery/ImageGallery.styles.tsx
+++ b/content/webapp/components/ImageGallery/ImageGallery.styles.tsx
@@ -1,6 +1,5 @@
 import styled from 'styled-components';
 
-import { classNames } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 
 export const FrameGridWrap = styled(Space).attrs({
@@ -189,16 +188,12 @@ export const ButtonContainer = styled.div<ButtonContainerProps>`
 `;
 
 type ControlContainerProps = { $isActive: boolean };
-export const ControlContainer = styled(Space).attrs<ControlContainerProps>(
-  props => ({
-    className: classNames({
-      close: true,
-      'is-hidden': !props.$isActive,
-    }),
-    $v: { size: 'm', properties: ['padding-bottom'] },
-    $h: { size: 'l', properties: ['margin-right'] },
-  })
-)<ControlContainerProps>`
+export const ControlContainer = styled(Space).attrs({
+  className: 'close',
+  $v: { size: 'm', properties: ['padding-bottom'] },
+  $h: { size: 'l', properties: ['margin-right'] },
+})<ControlContainerProps>`
+  opacity: ${props => (props.$isActive ? 1 : 0)};
   display: flex;
   justify-content: flex-end;
 `;

--- a/content/webapp/components/ImageGallery/index.tsx
+++ b/content/webapp/components/ImageGallery/index.tsx
@@ -105,6 +105,7 @@ const ImageGallery: FunctionComponent<{ id: string } & Props> = ({
   function handleCloseClicked() {
     if (openButtonRef.current) {
       openButtonRef.current.tabIndex = 0;
+      openButtonRef.current.focus();
       setIsActive(false);
 
       if (headingRef.current) {


### PR DESCRIPTION
For #11580 

## What does this change?
Gives focus to the image gallery close button when the gallery is opened

## How to test
Open an image gallery then press return – the gallery should close. If you open the gallery using the keyboard the close button should also have visible focus.

## How can we measure success?
Nicer user experience (back to how it was originally implemented).

## Have we considered potential risks?
n/a