### PR TITLE
Show loading indicator when query changes

### DIFF
--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -606,6 +606,8 @@ export const SearchPage: NextPageWithLayout<Props> = ({
     };
     setLink(link);
     if (allSearch) {
+      setClientSideWorkTypes(undefined);
+      setClientSideImages(undefined);
       fetchWorks();
       fetchImages();
     }


### PR DESCRIPTION
## What does this change?

When a query changes on the all search page, the catalogue results update with a slight delay compared to the content results (because the catalogue results are requested client side).

This PR clears the catalogue results when a new query is made, so that the loading icon appears before the new results arrive.

See [conversation in Slack](https://wellcome.slack.com/archives/CUA669WHH/p1738923916074529)

## How to test

- Run the site with the allSearch toggle enabled.
- Search for something
- Search for something else and see the loading icon appear in the catalogue section before the new results arrive.

## How can we measure success?

The page doesn't ever display results for different searches across the content and catalogue sections.

## Have we considered potential risks?

None really

