### PR TITLE
Allow clicking of dev link from terminal

### DIFF
--- a/content/webapp/server.ts
+++ b/content/webapp/server.ts
@@ -8,7 +8,7 @@ const serverPromise = appPromise.then(app => {
   const server = app.listen(port, () => {
     const inDev = process.env.NODE_ENV === 'development';
     const devMessage =
-      '(NODE_ENV === development, also try https://www-dev.wellcomecollection.org)';
+      '(NODE_ENV === development, also try https://www-dev.wellcomecollection.org )';
 
     console.log(`> ready on localhost:${port} ${inDev ? devMessage : ''}`);
   });


### PR DESCRIPTION
I'm lazy and I like to click links in the terminal, but my terminal interpreted the close parenthesis as part of the url so it wouldn't work

## What does this change?

Adds a space before the closing parenthesis

## How to test
`yarn content` then [option/cmd]-click the resulting link to `https://www-dev.wellcomecollection.org` in the terminal

## How can we measure success?
n/a

## Have we considered potential risks?
n/a