### PR TITLE
Update robots.txt to block common bots

### DIFF
--- a/assets/robots.txt
+++ b/assets/robots.txt
@@ -1,2 +1,50 @@
 User-agent: *
 Allow: /
+
+User-agent: magpie-crawler
+Disallow: /
+
+User-Agent: omgili
+Disallow: /
+
+User-Agent: omgilibot
+Disallow: /
+
+User-agent: ClaudeBot
+Disallow: /
+
+User-agent: Claude-Web
+Disallow: /
+
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: cohere-ai
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: PetalBot
+Disallow: /
+
+User-agent: Scrapy
+Disallow: /
+
+User-agent: GPTBot
+Disallow: /
+
+User-agent: ChatGPT-User
+Disallow: /
+
+User-Agent: PerplexityBot
+Disallow: /
+
+User-agent: OAI-SearchBot
+Disallow: /
+
+User-agent: YandexAdditional
+Disallow: /
+
+User-agent: YandexAdditionalBot
+Disallow: /


### PR DESCRIPTION
## What does this change?

Part of https://github.com/wellcomecollection/platform/issues/5919

This change updates our `robots.txt` to discourage some common bots from crawling out content, some of which we've seen significant traffic from.

This list is cribbed from https://www.bbc.co.uk/robots.txt, and modified to be a lighter touch not wanting to disrupt our SEO.

Some useful context about order of precedence: https://developers.google.com/search/docs/crawling-indexing/robots/robots_txt#order-of-precedence-for-rules

## How to test

- [ ] Deploy this change, do we see a drop off in traffic from the named bots

## How can we measure success?

Less traffic from bots.

## Have we considered potential risks?

This changes how crawlers involved in search index our site, we have removed reference to any Google based bots in order to mitigate any risk of damaging our Google search rankings.
