### PR TITLE
Update WAF rules, block suspicious agents, increase rate limits

### DIFF
--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -330,23 +330,64 @@ resource "aws_wafv2_web_acl" "wc_org" {
   }
 
   rule {
-    name     = "google-other-block"
+    name     = "geo-block-LATAM"
     priority = 9
 
     action {
-      block {}
+      block {
+      }
     }
 
     statement {
-      label_match_statement {
-        key   = "awswaf:managed:aws:bot-control:bot:name:google_other"
-        scope = "LABEL"
+      and_statement {
+        statement {
+          geo_match_statement {
+            country_codes = [
+              "BR",
+              "AR",
+            ]
+          }
+        }
+        statement {
+          byte_match_statement {
+            positional_constraint = "CONTAINS"
+            search_string         = "Windows"
+
+            field_to_match {
+              single_header {
+                name = "user-agent"
+              }
+            }
+
+            text_transformation {
+              priority = 0
+              type     = "NONE"
+            }
+          }
+        }
+        statement {
+          byte_match_statement {
+            positional_constraint = "CONTAINS"
+            search_string         = "Trident"
+
+            field_to_match {
+              single_header {
+                name = "user-agent"
+              }
+            }
+
+            text_transformation {
+              priority = 0
+              type     = "NONE"
+            }
+          }
+        }
       }
     }
 
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                = "weco-cloudfront-acl-google-other-block-${var.namespace}"
+      metric_name                = "geo-block-latam-${var.namespace}"
       sampled_requests_enabled   = true
     }
   }
@@ -406,7 +447,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
       rate_based_statement {
         aggregate_key_type    = "CONSTANT"
         evaluation_window_sec = 60
-        limit                 = 500
+        limit                 = 200
 
         scope_down_statement {
           geo_match_statement {
@@ -464,6 +505,40 @@ resource "aws_wafv2_web_acl" "wc_org" {
               byte_match_statement {
                 positional_constraint = "CONTAINS"
                 search_string         = "ClaudeBot"
+
+                field_to_match {
+                  single_header {
+                    name = "user-agent"
+                  }
+                }
+
+                text_transformation {
+                  priority = 0
+                  type     = "NONE"
+                }
+              }
+            }
+            statement {
+              byte_match_statement {
+                positional_constraint = "CONTAINS"
+                search_string         = "GPTBot"
+
+                field_to_match {
+                  single_header {
+                    name = "user-agent"
+                  }
+                }
+
+                text_transformation {
+                  priority = 0
+                  type     = "NONE"
+                }
+              }
+            }
+            statement {
+              byte_match_statement {
+                positional_constraint = "CONTAINS"
+                search_string         = "GoogleOther"
 
                 field_to_match {
                   single_header {

--- a/cache/terraform.tf
+++ b/cache/terraform.tf
@@ -54,9 +54,9 @@ data "terraform_remote_state" "experience" {
       role_arn = "arn:aws:iam::130871440101:role/experience-read_only"
     }
 
-    bucket   = "wellcomecollection-experience-infra"
-    key      = "terraform/experience.tfstate"
-    region   = "eu-west-1"
+    bucket = "wellcomecollection-experience-infra"
+    key    = "terraform/experience.tfstate"
+    region = "eu-west-1"
   }
 }
 
@@ -64,9 +64,9 @@ data "terraform_remote_state" "assets" {
   backend = "s3"
 
   config = {
-    bucket   = "wellcomecollection-infra"
-    key      = "build-state/client.tfstate"
-    region   = "eu-west-1"
+    bucket = "wellcomecollection-infra"
+    key    = "build-state/client.tfstate"
+    region = "eu-west-1"
     assume_role = {
       role_arn = "arn:aws:iam::130871440101:role/experience-read_only"
     }
@@ -77,9 +77,9 @@ data "terraform_remote_state" "platform_account" {
   backend = "s3"
 
   config = {
-    bucket   = "wellcomecollection-platform-infra"
-    key      = "terraform/aws-account-infrastructure/platform.tfstate"
-    region   = "eu-west-1"
+    bucket = "wellcomecollection-platform-infra"
+    key    = "terraform/aws-account-infrastructure/platform.tfstate"
+    region = "eu-west-1"
     assume_role = {
       role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
     }


### PR DESCRIPTION
## What does this change?

Part of https://github.com/wellcomecollection/platform/issues/5919

This change further updates our WAF rules to:

- Further tighten the LATAM rate limit rule to 200 requests per minute following increased traffic from this region
- Consolidation of "GoogleOther" blocking role with manual user agent rate limit to simplify rules
- Block on LATAM requests that match a suspicious pattern we've seen in logs (outdate IE user-agent appearing in large request spikes.

## How to test

- [ ] Apply these rules in the stage environment, are the expected rules applied?
- [ ] Run these rules manually for a while to ensure they have no detrimental effect?

## How can we measure success?

Better identification of "bad" traffic, less downtime.

## Have we considered potential risks?

These rule changes do impact who can access the site and apply a rate limit. Care has been taken to ensure this impacts bot users only where possible and to minimise the impact otherwise.
