### PR TITLE
All image sizing

### DIFF
--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -312,14 +312,6 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
 
   const pathname = usePathname();
 
-  const imagesWithDimensions =
-    catalogueResults.images?.results.map(image => ({
-      ...image,
-      src: image.locations[0].url,
-      width: (image.aspectRatio || 1) * 100,
-      height: 100,
-    })) || [];
-
   useEffect(() => {
     if (apiToolbar) {
       if (
@@ -465,20 +457,29 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
                     <>
                       <CatalogueSectionTitle sectionName="Image results" />
                       <CatalogueLinks>
-                        {catalogueResults.images.results.map(image => (
-                          <ImageCard
-                            key={image.id}
-                            id={image.id}
-                            workId={image.source.id}
-                            image={{
-                              contentUrl: image.src,
-                              width: image.width * 0.8,
-                              height: image.height * 0.8,
-                              alt: image.source.title,
-                            }}
-                            layout="raw"
-                          />
-                        ))}
+                        {catalogueResults.images.results.map(image => {
+                          const isPortrait = image.height > image.width;
+                          const width = isPortrait
+                            ? image.width * 1.2
+                            : image.width * 0.8;
+                          const height = isPortrait
+                            ? image.height * 1.2
+                            : image.height * 0.8;
+                          return (
+                            <ImageCard
+                              key={image.id}
+                              id={image.id}
+                              workId={image.source.id}
+                              image={{
+                                contentUrl: image.src,
+                                width,
+                                height,
+                                alt: image.source.title,
+                              }}
+                              layout="raw"
+                            />
+                          );
+                        })}
                       </CatalogueLinks>
                       <NextLink
                         {...imagesLink(

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -459,12 +459,9 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
                       <CatalogueLinks>
                         {catalogueResults.images.results.map(image => {
                           const isPortrait = image.height > image.width;
-                          const width = isPortrait
-                            ? image.width * 1.2
-                            : image.width * 0.8;
-                          const height = isPortrait
-                            ? image.height * 1.2
-                            : image.height * 0.8;
+                          const width = image.width * (isPortrait ? 1.2 : 0.8);
+                          const height =
+                            image.height * (isPortrait ? 1.2 : 0.8);
                           return (
                             <ImageCard
                               key={image.id}

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -312,6 +312,14 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
 
   const pathname = usePathname();
 
+  const imagesWithDimensions =
+    catalogueResults.images?.results.map(image => ({
+      ...image,
+      src: image.locations[0].url,
+      width: (image.aspectRatio || 1) * 100,
+      height: 100,
+    })) || [];
+
   useEffect(() => {
     if (apiToolbar) {
       if (


### PR DESCRIPTION
For #11590 

## What does this change?
Changes the size of the all search image thumbnails based on their aspect ratios. If they're portrait they're made slightly wider, if they're landscape they're made slightly narrower (this was how _all_ images were being treated up till this change). I think this seems to let them take up roughly equivalent amounts of space. One possible down-side is if there's a mixture of landscape and portrait images they are centre-aligned rather than sharing the same baseline – we could change this if we think that would be preferable, either aligning them to a baseline, or giving them all an e.g. black background.

I tried implementing a [react-photo-album](https://react-photo-album.com/) solution (such as is in use for the image search), but I think that all of the available patterns looked worse than this.

## How to test
- Do a [search that gets landscape images](http://localhost:3000/search?query=square+photograph)
- Do a [search that gets portrait images](http://localhost:3000/search?query=mental+health)
- Do a [search that gets both](http://localhost:3000/search?query=eggs)

## How can we measure success?
Images fill more of the available space and are more useful at a glance.

## Have we considered potential risks?
n/a