### PR TITLE
Series preview

### DIFF
--- a/.buildkite/urls/expected_404_urls.txt
+++ b/.buildkite/urls/expected_404_urls.txt
@@ -23,3 +23,6 @@
 
 # Guide formats that don't exist
 /guides?format=%not-a-prismic-id%
+
+# Requesting a page beyond the end of an article series 
+/series/inside-our-books?page=500

--- a/.buildkite/urls/expected_404_urls.txt
+++ b/.buildkite/urls/expected_404_urls.txt
@@ -23,6 +23,3 @@
 
 # Guide formats that don't exist
 /guides?format=%not-a-prismic-id%
-
-# Requesting a page beyond the end of an article series 
-/series/inside-our-books?page=500

--- a/content/webapp/pages/series/[seriesId].tsx
+++ b/content/webapp/pages/series/[seriesId].tsx
@@ -123,6 +123,14 @@ export const getServerSideProps: GetServerSideProps<
 
   const articles = transformQuery(articlesQuery, transformArticle);
 
+  // We've seen people trying to request a high-numbered page for a series,
+  // presumably by guessing at URLs, e.g. /series/W-XBJxEAAKmng1TG?page=500.
+  // If the requested page is higher than the number of available pages,
+  // we 404.
+  if (page > articlesQuery.total_pages) {
+    return { notFound: true };
+  }
+
   const scheduledItems = getScheduledItems({
     articles: articles.results,
     series,

--- a/content/webapp/pages/series/[seriesId].tsx
+++ b/content/webapp/pages/series/[seriesId].tsx
@@ -125,9 +125,8 @@ export const getServerSideProps: GetServerSideProps<
 
   // We've seen people trying to request a high-numbered page for a series,
   // presumably by guessing at URLs, e.g. /series/W-XBJxEAAKmng1TG?page=500.
-  // If the requested page is higher than the number of available pages,
-  // we 404.
-  if (page > articlesQuery.total_pages) {
+  // If the requested page is higher than the number of available pages we 404 (except on the first page)
+  if (page > 1 && page > articlesQuery.total_pages) {
     return { notFound: true };
   }
 

--- a/content/webapp/pages/series/[seriesId].tsx
+++ b/content/webapp/pages/series/[seriesId].tsx
@@ -121,35 +121,6 @@ export const getServerSideProps: GetServerSideProps<
     fetchLinks: seasonsFetchLinks,
   });
 
-  // This can occasionally occur if somebody in the Editorial team is
-  // trying to preview a series that doesn't have any entries yet.
-  //
-  // It should never happen for live content so we don't support it;
-  // the log is to make it easier to debug if somebody tries it.
-  if (articlesQuery.total_results_size === 0) {
-    console.warn(`Series ${seriesId} doesn't contain any articles`);
-    return { notFound: true };
-  }
-
-  // We've seen people trying to request a high-numbered page for a series,
-  // presumably by guessing at URLs, e.g. /series/W-XBJxEAAKmng1TG?page=500.
-  //
-  // We need a non-empty list of articles to get any metadata about the series,
-  // so if this page doesn't have any articles, let's 404 here.
-  //
-  // Note: this is a debug rather than a warn because it's more likely to be
-  // somebody guessing about our URL scheme than somebody in Editorial looking
-  // at a yet-to-be-published series.
-  //
-  // Note: we may be able to remove this once we refactor transformArticleSeries,
-  // see https://github.com/wellcomecollection/wellcomecollection.org/issues/8516
-  if (articlesQuery.results_size === 0) {
-    console.debug(
-      `Series ${seriesId} doesn't have any articles on page ${page}`
-    );
-    return { notFound: true };
-  }
-
   const articles = transformQuery(articlesQuery, transformArticle);
 
   const scheduledItems = getScheduledItems({

--- a/content/webapp/pages/series/[seriesId].tsx
+++ b/content/webapp/pages/series/[seriesId].tsx
@@ -87,6 +87,7 @@ export const getServerSideProps: GetServerSideProps<
   const client = createClient(context);
 
   // GOTCHA: This is for a series where we have the `webcomics` type.
+  // i.e.  the body squabbles series.
   // This will have to remain like this until we figure out how to migrate them.
   // We create new webcomics as an article with comic format, and add
   // an article-series to them.
@@ -110,7 +111,7 @@ export const getServerSideProps: GetServerSideProps<
     ? 'my.webcomics.series.series'
     : 'my.articles.series.series';
 
-  // We need the actual ID to fetch related documents
+  // We need the actual ID, not the uid, to fetch related documents
   const seriesId = seriesDocument.id;
 
   const articlesQuery = await fetchArticles(client, {

--- a/content/webapp/pages/series/[seriesId].tsx
+++ b/content/webapp/pages/series/[seriesId].tsx
@@ -82,9 +82,7 @@ export const getServerSideProps: GetServerSideProps<
   // This will have to remain like this until we figure out how to migrate them.
   // We create new webcomics as an article with comic format, and add
   // an article-series to them.
-  const isWebcomics =
-    seriesQueryId === bodySquabblesSeriesId ||
-    seriesQueryId === 'body-squabbles';
+  const isWebcomics = seriesQueryId === bodySquabblesSeriesId;
 
   const seriesDocument = await fetchSeriesById(
     client,

--- a/content/webapp/pages/series/[seriesId].tsx
+++ b/content/webapp/pages/series/[seriesId].tsx
@@ -4,6 +4,10 @@ import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
 import { bodySquabblesSeries as bodySquabblesSeriesId } from '@weco/common/data/hardcoded-ids';
+import {
+  SeriesDocument,
+  WebcomicSeriesDocument,
+} from '@weco/common/prismicio-types';
 import { getServerData } from '@weco/common/server-data';
 import { appError, AppErrorProps } from '@weco/common/services/app';
 import { GaDimensions } from '@weco/common/services/app/analytics-scripts';
@@ -36,6 +40,10 @@ import {
   transformArticleToArticleBasic,
 } from '@weco/content/services/prismic/transformers/articles';
 import { transformQuery } from '@weco/content/services/prismic/transformers/paginated-results';
+import {
+  transformSeries,
+  transformWebcomicSeries,
+} from '@weco/content/services/prismic/transformers/series';
 import { seasonsFetchLinks } from '@weco/content/services/prismic/types';
 import { ArticleScheduleItem } from '@weco/content/types/article-schedule-items';
 import { ArticleBasic } from '@weco/content/types/articles';
@@ -93,6 +101,10 @@ export const getServerSideProps: GetServerSideProps<
   if (!seriesDocument) {
     return { notFound: true };
   }
+
+  const series = isWebcomics
+    ? transformWebcomicSeries(seriesDocument as WebcomicSeriesDocument)
+    : transformSeries(seriesDocument as SeriesDocument);
 
   const seriesField = isWebcomics
     ? 'my.webcomics.series.series'

--- a/content/webapp/pages/series/[seriesId].tsx
+++ b/content/webapp/pages/series/[seriesId].tsx
@@ -152,14 +152,6 @@ export const getServerSideProps: GetServerSideProps<
 
   const articles = transformQuery(articlesQuery, transformArticle);
 
-  // We know that `articles` is non-empty, and because we queried for articles in
-  // this series, we know these articles have a series defined.
-  const series = articles.results[0].series.find(
-    series =>
-      series.id ===
-      (seriesId === 'body-squabbles' ? bodySquabblesSeriesId : seriesId)
-  )!;
-
   const scheduledItems = getScheduledItems({
     articles: articles.results,
     series,

--- a/content/webapp/services/prismic/transformers/index.ts
+++ b/content/webapp/services/prismic/transformers/index.ts
@@ -5,6 +5,7 @@ import {
   ArticlesDocumentData as RawArticlesDocumentData,
   StandfirstSlice as RawStandfirstSlice,
   WebcomicsDocumentData as RawWebcomicsDocumentData,
+  WebcomicSeriesDocument as RawWebcomicSeriesDocument,
 } from '@weco/common/prismicio-types';
 import { transformImage } from '@weco/common/services/prismic/transformers/images';
 import { isFilledLinkToDocumentWithData } from '@weco/common/services/prismic/types';
@@ -124,14 +125,14 @@ export function transformLabelType(
   return {};
 }
 
-const isGenericDocWithPromo = (
-  doc: GenericDoc | RelatedGenericDoc
+export const isGenericDocWithPromo = (
+  doc: GenericDoc | RelatedGenericDoc | RawWebcomicSeriesDocument
 ): doc is GenericDocWithPromo => {
   return Boolean(doc.data && 'promo' in doc.data);
 };
 
-const isGenericDocWithMetaDescription = (
-  doc: GenericDoc | RelatedGenericDoc
+export const isGenericDocWithMetaDescription = (
+  doc: GenericDoc | RelatedGenericDoc | RawWebcomicSeriesDocument
 ): doc is GenericDocWithMetaDescription => {
   return Boolean(doc.data && 'metaDescription' in doc.data);
 };

--- a/content/webapp/services/prismic/transformers/series.ts
+++ b/content/webapp/services/prismic/transformers/series.ts
@@ -30,7 +30,6 @@ export function transformWebcomicSeries(
   doc: RawWebcomicSeriesDocument
 ): Series {
   const { data } = doc;
-  console.log({ doc });
   const promo = isGenericDocWithPromo(doc)
     ? transformImagePromo(data.promo)
     : undefined;

--- a/content/webapp/services/prismic/transformers/series.ts
+++ b/content/webapp/services/prismic/transformers/series.ts
@@ -1,19 +1,75 @@
 import * as prismic from '@prismicio/client';
 
+import { ImageType } from '@weco/common/model/image';
 import {
   SeasonsDocument as RawSeasonsDocument,
   SeriesDocument as RawSeriesDocument,
   StandfirstSlice as RawStandfirstSlice,
+  WebcomicSeriesDocument as RawWebcomicSeriesDocument,
 } from '@weco/common/prismicio-types';
 import { transformTimestamp } from '@weco/common/services/prismic/transformers';
+import { transformImage } from '@weco/common/services/prismic/transformers/images';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
 import { ArticleScheduleItem } from '@weco/content/types/article-schedule-items';
 import { Series, SeriesBasic } from '@weco/content/types/series';
 import { getSeriesColor } from '@weco/content/utils/colors';
 
-import { asTitle, transformGenericFields, transformSingleLevelGroup } from '.';
+import {
+  asText,
+  asTitle,
+  isGenericDocWithMetaDescription,
+  isGenericDocWithPromo,
+  transformGenericFields,
+  transformSingleLevelGroup,
+} from '.';
 import { transformContributors } from './contributors';
+import { transformImagePromo } from './images';
 import { transformSeason } from './seasons';
+
+export function transformWebcomicSeries(
+  doc: RawWebcomicSeriesDocument
+): Series {
+  const { data } = doc;
+  console.log({ doc });
+  const promo = isGenericDocWithPromo(doc)
+    ? transformImagePromo(data.promo)
+    : undefined;
+
+  const primaryPromo =
+    isGenericDocWithPromo(doc) && data.promo.length > 0
+      ? data.promo
+          .filter((slice: prismic.Slice) => slice.primary.image)
+          .find(_ => _)
+      : undefined;
+
+  const image: ImageType | undefined = primaryPromo
+    ? transformImage(primaryPromo.primary.image)
+    : undefined;
+
+  const metadataDescription = isGenericDocWithMetaDescription(doc)
+    ? asText(data.metadataDescription)
+    : undefined;
+
+  const contributors = transformContributors(doc);
+
+  return {
+    type: 'series',
+    id: doc.id,
+    uid: doc.uid,
+    title: data?.title ? asTitle(data.title) : '',
+    promo,
+    image,
+    metadataDescription,
+    contributors,
+    // We don't have data for the following on RawWebcomicSeriesDocument
+    // but adding them in here so we can return the Series type
+    labels: [],
+    schedule: [],
+    seasons: [],
+    items: [],
+    untransformedBody: [],
+  };
+}
 
 export function transformSeries(document: RawSeriesDocument): Series {
   const { data } = document;


### PR DESCRIPTION
## What does this change?

At the moment it is not possible to preview a series page if none of the articles attached to it are published. This fixes that.

#### Background

The reason for the current state is that we never used to fetch the series itself. In order to reduce the number of requests we made, we would fetch the articles linked to the series id, and get the series data from the linked series document on the first article we got back. Therefore, if we have articles (because they are unpublished) we have no data about the series.

However, when we moved to using uids in the url, we began fetching the series directly. Therefore, there is no reason to 404 if there are no articles returned.

## How to test

- Visit wellcomecollection.org/series/the-joy-of-being-disabled, see that it 404s because no articles attached to it are published
- Visit http://localhost:3000/series/the-joy-of-being-disabled and see that the page displays
- http://localhost:3000//series/body-squabbles to make sure it still works (this is our only webcomic series and I had to make some changes for it to still work correctly)

## How can we measure success?

Editors are able to preview series, even when there are no published articles attached to it.

## Have we considered potential risks?

Breaking webcomics series, but have tested for this.

