### PR TITLE
Simplify counts in all search filter links and CTAs

### DIFF
--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -71,6 +71,7 @@ import {
   EventDocument,
 } from '@weco/content/services/wellcome/content/types/api';
 import { Query } from '@weco/content/types/search';
+import { simplifyCount } from '@weco/content/utils/numeric';
 import { cacheTTL, setCacheControl } from '@weco/content/utils/setCacheControl';
 import { looksLikeSpam } from '@weco/content/utils/spam-detector';
 
@@ -418,7 +419,8 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
                               legacyBehavior
                             >
                               <WorksLink>
-                                {bucket.data.label} ({bucket.count})
+                                {bucket.data.label} (
+                                {simplifyCount(bucket.count)})
                               </WorksLink>
                             </NextLink>
                           ))}
@@ -435,7 +437,7 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
                         legacyBehavior
                       >
                         <AllLink>
-                          {`All catalogue results (${catalogueResults.works?.totalResults})`}
+                          {`All catalogue results (${simplifyCount(totalWorksResults)})`}
                           <Icon icon={arrow} iconColor="black" rotate={360} />
                         </AllLink>
                       </NextLink>
@@ -483,7 +485,7 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
                         legacyBehavior
                       >
                         <AllLink>
-                          {`All image results (${catalogueResults.images?.totalResults})`}
+                          {`All image results (${simplifyCount(totalImagesResults)})`}
                           <Icon icon={arrow} iconColor="black" rotate={360} />
                         </AllLink>
                       </NextLink>

--- a/content/webapp/utils/numeric.test.ts
+++ b/content/webapp/utils/numeric.test.ts
@@ -1,4 +1,4 @@
-import { clamp } from './numeric';
+import { clamp, simplifyCount } from './numeric';
 
 describe('clamp', () => {
   test.each([
@@ -18,4 +18,21 @@ describe('clamp', () => {
       expect(clamp(x, min, max)).toStrictEqual(expected);
     }
   );
+});
+
+describe('simplifyCount', () => {
+  test.each([
+    // number is less than 1000
+    { number: 1, expected: 1 },
+    { number: 999, expected: 999 },
+
+    // number is 1000 or more
+    { number: 1000, expected: '1K' },
+    { number: 1001, expected: '1K' }, // Note: not 1.0K
+    { number: 1500, expected: '1.5K' },
+    { number: 2000, expected: '2K' },
+    { number: 9999, expected: '10K' },
+  ])('simplifying $number is $expected', ({ number, expected }) => {
+    expect(simplifyCount(number)).toStrictEqual(expected);
+  });
 });

--- a/content/webapp/utils/numeric.ts
+++ b/content/webapp/utils/numeric.ts
@@ -1,2 +1,6 @@
 export const clamp = (x: number, min = 0, max = 1): number =>
   x > max ? max : x < min ? min : x;
+
+export function simplifyCount(number: number) {
+  return number >= 1000 ? parseFloat((number / 1000).toFixed(1)) + 'K' : number;
+}


### PR DESCRIPTION
For #11592 

## What does this change?
- Simplifies the counts from e.g. "69089" to "69.1K"
- The decimal is omitted if it would have been `.0`
- The number is precise if it's less than 1000

<img width="449" alt="image" src="https://github.com/user-attachments/assets/efbf5891-a2ab-45b3-ab99-ce23cc0a74db" />


## How to test
Search for something that is on the boundary of 1000 results (e.g. [test](http://localhost:3000/search?query=test))

`cd content/webapp/utils && yarn jest numeric.test.ts`

## How can we measure success?
Counts are more intuitive/concise

## Have we considered potential risks?
n/a