### PR TITLE
Rearrange tabs for all search

### DIFF
--- a/content/webapp/components/SearchPageLayout/SearchNavigation.tsx
+++ b/content/webapp/components/SearchPageLayout/SearchNavigation.tsx
@@ -103,6 +103,34 @@ const SearchNavigation: FunctionComponent<SearchNavigationProps> = ({
     return router.push(link.href, link.as);
   };
 
+  const allSearchItems = [
+    {
+      id: 'overview',
+      url: getURL('/search'),
+      text: 'All',
+    },
+    {
+      id: 'works',
+      url: getURL('/search/works'),
+      text: 'Catalogue',
+    },
+    {
+      id: 'images',
+      url: getURL('/search/images'),
+      text: 'Images',
+    },
+    {
+      id: 'events',
+      url: getURL('/search/events'),
+      text: 'Events',
+    },
+    {
+      id: 'stories',
+      url: getURL('/search/stories'),
+      text: 'Stories',
+    },
+  ];
+
   return (
     <>
       <form
@@ -143,33 +171,37 @@ const SearchNavigation: FunctionComponent<SearchNavigationProps> = ({
           tabBehaviour="navigate"
           hideBorder={allSearch || currentSearchCategory === 'overview'}
           label="Search Categories"
-          items={[
-            {
-              id: 'overview',
-              url: getURL('/search'),
-              text: 'All',
-            },
-            {
-              id: 'stories',
-              url: getURL('/search/stories'),
-              text: 'Stories',
-            },
-            {
-              id: 'images',
-              url: getURL('/search/images'),
-              text: 'Images',
-            },
-            {
-              id: 'works',
-              url: getURL('/search/works'),
-              text: 'Catalogue',
-            },
-            {
-              id: 'events',
-              url: getURL('/search/events'),
-              text: 'Events',
-            },
-          ]}
+          items={
+            allSearch
+              ? allSearchItems
+              : [
+                  {
+                    id: 'overview',
+                    url: getURL('/search'),
+                    text: 'All',
+                  },
+                  {
+                    id: 'stories',
+                    url: getURL('/search/stories'),
+                    text: 'Stories',
+                  },
+                  {
+                    id: 'images',
+                    url: getURL('/search/images'),
+                    text: 'Images',
+                  },
+                  {
+                    id: 'works',
+                    url: getURL('/search/works'),
+                    text: 'Catalogue',
+                  },
+                  {
+                    id: 'events',
+                    url: getURL('/search/events'),
+                    text: 'Events',
+                  },
+                ]
+          }
           currentSection={currentSearchCategory}
         />
       </TabsBorder>


### PR DESCRIPTION
For #11591 

<img width="943" alt="image" src="https://github.com/user-attachments/assets/c8bf39c9-fbf1-4224-b91b-d5d21efdf7c1" />

## What does this change?
Rearranges the tabs to All | Catalogue | Images | Events | Stories

(The ticket references 'Events & Exhibtions', but we don't have that yet).

## How to test
Look at the search pages to check they're in the above order

## How can we measure success?
Catalogue researchers can get to what they want quicker/easier

## Have we considered potential risks?
n/a