### PR TITLE
Remove polyfill.io

### DIFF
--- a/common/views/components/PageLayout/PageLayout.tsx
+++ b/common/views/components/PageLayout/PageLayout.tsx
@@ -109,23 +109,6 @@ const PageLayoutComponent: FunctionComponent<Props> = ({
     ...openingHoursLd(libraryOpeningHours),
   };
 
-  const polyfillVersion = '3.103.0';
-  const polyfillFeatures = [
-    'default',
-    'AbortController',
-    'Array.prototype.find',
-    'Array.prototype.flat',
-    'Array.prototype.flatMap',
-    'Array.prototype.includes',
-    'Intl.DateTimeFormat',
-    'Object.entries',
-    'Object.fromEntries',
-    'Object.values',
-    'WeakMap',
-    'URL',
-    'URLSearchParams',
-  ];
-
   const globalInfoBar = useContext(GlobalInfoBarContext);
   const { extraApiToolbarLinks } = useContext(SearchContext);
   const { isEnhanced } = useContext(AppContext);
@@ -282,12 +265,6 @@ const PageLayoutComponent: FunctionComponent<Props> = ({
           When we put <Script> tags in the <Head>, they didn't appear in the rendered page.
 
       */}
-
-      <Script
-        src={`https://polyfill-fastly.io/v3/polyfill.js?version=${polyfillVersion}&features=${polyfillFeatures.join(
-          ','
-        )}`}
-      />
 
       <Script
         src="https://i.wellcomecollection.org/assets/libs/picturefill.min.js"


### PR DESCRIPTION
## What does this change?
Removes the polyfill.io script that we used to add missing browser features to older browsers.

[About one year ago](https://github.com/wellcomecollection/wellcomecollection.org/issues/10697#issuecomment-1997024141), less than 0.01% of our site visitors were using Internet Explorer, and this is the only browser with features that we are polyfilling. We no longer have it on our [browser support list](https://app.gitbook.com/o/-LumfFcEMKx4gYXKAZTQ/s/DPDDj27NI2F2kPukWrC1/readme/front-end/front-end-principles#browser-device-support) in any form (full or basic) so it makes sense to remove it.

## How to test
Test on Browserstack against our supported browsers. I've been unable to find a way to test Opera Mini – every suggestion (and link) on [this SO post](https://stackoverflow.com/questions/2594450/how-to-debug-on-opera-mini) is no longer applicable

## How can we measure success?
We have less (third-party) code to maintain.

## Have we considered potential risks?
A feature that was being polyfilled was required by something on our support list that I haven't been able to test (e.g. Opera Mini).