### PR TITLE
Update the url correctly when the image modal closes

### DIFF
--- a/content/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
+++ b/content/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
@@ -135,7 +135,7 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
     if (isActive && expandedImage !== undefined) {
       setImageIdInURL(expandedImage?.id || '');
     } else {
-      // clear the url of the fragments and includeing the # symbol
+      // clear the URL of the fragments, including the # symbol
       removeImageIdFromURL();
     }
   }, [isActive, expandedImage]);

--- a/content/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
+++ b/content/webapp/components/ImageEndpointSearchResults/ImageEndpointSearchResults.tsx
@@ -91,6 +91,14 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
     window.location.hash = id;
   };
 
+  const removeImageIdFromURL = () => {
+    history.pushState(
+      '',
+      document.title,
+      window.location.pathname + window.location.search
+    );
+  };
+
   useEffect(() => {
     const onHashChanged = async () => {
       // to trim the '#' symbol
@@ -127,8 +135,8 @@ const ImageEndpointSearchResults: FunctionComponent<Props> = ({
     if (isActive && expandedImage !== undefined) {
       setImageIdInURL(expandedImage?.id || '');
     } else {
-      // clear the url of the fragments and also removes the # symbol
-      setImageIdInURL('');
+      // clear the url of the fragments and includeing the # symbol
+      removeImageIdFromURL();
     }
   }, [isActive, expandedImage]);
 


### PR DESCRIPTION
## What does this change?

For [#11631](https://github.com/wellcomecollection/wellcomecollection.org/issues/11631)

Uses the history API to make sure we remove the # from the url when the expanded image modal closes

## How to test
- Visit the following pages where we use the expanded image modal and note the url:
[Search page](https://wellcomecollection.org/search) - with both the allSearch toggle enabled and disabled
[Image search page](https://wellcomecollection.org/search/images?query=darwin)
[Concept page](https://wellcomecollection.org/concepts/fppbxh8b)
- Click on an image result and see that the url has a hash appended to it
- Close the modal or navigate back using the browsers back button
- The url should return to its original state

## How can we measure success?

We no longer have urls with a hash appended to them

## Have we considered potential risks?

Is there a risk to analytics results? @mankeetn
