### PR TITLE
Add test when Catalogue API 500s and remove "old" test

### DIFF
--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -519,7 +519,7 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
                 </CatalogueResultsInner>
               </CatalogueResults>
             )}
-            <ContentResults>
+            <ContentResults data-testid="search-content-results">
               {contentResults?.results?.map(result => (
                 <Space
                   key={`${result.id}${result.highlightTourType || ''}`}

--- a/playwright/test/all-search.test.ts
+++ b/playwright/test/all-search.test.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 import { isMobile, newAllSearch } from './helpers/contexts';
 import {
@@ -7,7 +7,9 @@ import {
 } from './helpers/search';
 import { baseUrl, ItemViewerURLRegex, slowExpect } from './helpers/utils';
 
-test('The user can find addressable site content', async ({
+test.describe.configure({ mode: 'parallel' });
+
+test('(1) | The user can find addressable site content', async ({
   page,
   context,
 }) => {
@@ -18,14 +20,14 @@ test('The user can find addressable site content', async ({
   await slowExpect(page).toHaveURL(`${baseUrl}/visit-us/opening-times`);
 });
 
-test('The user can find catalogue works', async ({ page, context }) => {
+test('(2) | The user can find catalogue works', async ({ page, context }) => {
   await newAllSearch(context, page);
   await searchQuerySubmitAndWait('test', page);
   await page.getByRole('link', { name: 'All catalogue results' }).click();
   await slowExpect(page).toHaveURL(`${baseUrl}/search/works?query=test`);
 });
 
-test('The user can find images', async ({ page, context }) => {
+test('(3) | The user can find images', async ({ page, context }) => {
   if (isMobile(page)) return; // hidden on smaller screens
 
   await newAllSearch(context, page);
@@ -46,7 +48,7 @@ test('The user can find images', async ({ page, context }) => {
   await slowExpect(page).toHaveURL(RegExp(ItemViewerURLRegex));
 });
 
-test('The user can find work types', async ({ page, context }) => {
+test('(4) | The user can find work types', async ({ page, context }) => {
   if (isMobile(page)) return; // hidden on smaller screens
   await newAllSearch(context, page);
   await searchQuerySubmitAndWait('test', page);
@@ -56,14 +58,14 @@ test('The user can find work types', async ({ page, context }) => {
   );
 });
 
-test('The user can find catalogue images', async ({ page, context }) => {
+test('(5) | The user can find catalogue images', async ({ page, context }) => {
   await newAllSearch(context, page);
   await searchQuerySubmitAndWait('test', page);
   await page.getByRole('link', { name: 'All image results' }).click();
   await slowExpect(page).toHaveURL(`${baseUrl}/search/images?query=test`);
 });
 
-test('The user gets a message if search yields no results', async ({
+test('(6) | The user gets a message if search yields no results', async ({
   page,
   context,
 }) => {
@@ -75,9 +77,39 @@ test('The user gets a message if search yields no results', async ({
   );
 });
 
-test('The user can paginate through results', async ({ page, context }) => {
+test('(7) | The user can paginate through results', async ({
+  page,
+  context,
+}) => {
   await newAllSearch(context, page);
   await searchQuerySubmitAndWait('test', page);
   await page.getByRole('link', { name: 'Next (page 2)' }).click();
   await slowExpect(page).toHaveURL(`${baseUrl}/search?query=test&page=2`);
+});
+
+test('(8) | The user sees content results even if the Catalogue API is down', async ({
+  page,
+  context,
+}) => {
+  // Block the api calls before navigating
+  await page.route('*/**/catalogue/v2/works*', async route => {
+    await route.fulfill({ status: 500 });
+  });
+  await page.route('*/**/catalogue/v2/images*', async route => {
+    await route.fulfill({ status: 500 });
+  });
+
+  await newAllSearch(context, page);
+
+  const allCatalogueResultsLink = await page.getByRole('link', {
+    name: 'All catalogue results',
+  });
+  const allImageResultsLink = await page.getByRole('link', {
+    name: 'All image results',
+  });
+
+  await expect(allCatalogueResultsLink).not.toBeVisible();
+  await expect(allImageResultsLink).not.toBeVisible();
+
+  await expect(page.getByTestId('search-content-results')).toBeVisible();
 });

--- a/playwright/test/helpers/contexts.ts
+++ b/playwright/test/helpers/contexts.ts
@@ -214,7 +214,7 @@ const workWithBornDigitalDownloads = async (
   await gotoWithoutCache(`${baseUrl}/works/htzhunbw`, page);
 };
 
-const newSearch = async (
+const search = async (
   context: BrowserContext,
   page: Page,
   searchType:
@@ -327,7 +327,7 @@ export {
   itemWithSearchAndStructuresAndQuery,
   mediaOffice,
   multiVolumeItem,
-  newSearch,
+  search,
   visualStory,
   whatsOn,
   workWithBornDigitalDownloads,

--- a/playwright/test/helpers/contexts.ts
+++ b/playwright/test/helpers/contexts.ts
@@ -224,20 +224,12 @@ const newSearch = async (
     | 'images'
     | 'works' = 'overview'
 ): Promise<void> => {
-  await context.addCookies([...requiredCookies]);
+  await context.addCookies([...requiredCookies, allSearchCookie]);
 
   const searchUrl = `search${
     searchType === 'overview' ? `` : `/${searchType}`
   }`;
   await gotoWithoutCache(`${baseUrl}/${searchUrl}`, page);
-};
-
-const newAllSearch = async (
-  context: BrowserContext,
-  page: Page
-): Promise<void> => {
-  await context.addCookies([...requiredCookies, allSearchCookie]);
-  await gotoWithoutCache(`${baseUrl}/search`, page);
 };
 
 const article = async (
@@ -335,7 +327,6 @@ export {
   itemWithSearchAndStructuresAndQuery,
   mediaOffice,
   multiVolumeItem,
-  newAllSearch,
   newSearch,
   visualStory,
   whatsOn,

--- a/playwright/test/search-all.test.ts
+++ b/playwright/test/search-all.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-import { isMobile, newSearch } from './helpers/contexts';
+import { isMobile, search } from './helpers/contexts';
 import {
   clickImageSearchResultItem,
   searchQuerySubmitAndWait,
@@ -13,7 +13,7 @@ test('(1) | The user can find addressable site content', async ({
   page,
   context,
 }) => {
-  await newSearch(context, page);
+  await search(context, page);
   await searchQuerySubmitAndWait('opening times', page);
   // In page link (not the one in the footer) goes to the opening times page
   await page.getByRole('link', { name: 'Opening times Find out' }).click();
@@ -21,7 +21,7 @@ test('(1) | The user can find addressable site content', async ({
 });
 
 test('(2) | The user can find catalogue works', async ({ page, context }) => {
-  await newSearch(context, page);
+  await search(context, page);
   await searchQuerySubmitAndWait('test', page);
   await page.getByRole('link', { name: 'All catalogue results' }).click();
   await slowExpect(page).toHaveURL(`${baseUrl}/search/works?query=test`);
@@ -30,7 +30,7 @@ test('(2) | The user can find catalogue works', async ({ page, context }) => {
 test('(3) | The user can find images', async ({ page, context }) => {
   if (isMobile(page)) return; // hidden on smaller screens
 
-  await newSearch(context, page);
+  await search(context, page);
   await searchQuerySubmitAndWait('test', page);
   await slowExpect(
     page.getByTestId('image-search-results-container')
@@ -50,7 +50,7 @@ test('(3) | The user can find images', async ({ page, context }) => {
 
 test('(4) | The user can find work types', async ({ page, context }) => {
   if (isMobile(page)) return; // hidden on smaller screens
-  await newSearch(context, page);
+  await search(context, page);
   await searchQuerySubmitAndWait('test', page);
   await page.getByRole('link', { name: /^Books \(/ }).click();
   await slowExpect(page).toHaveURL(
@@ -59,7 +59,7 @@ test('(4) | The user can find work types', async ({ page, context }) => {
 });
 
 test('(5) | The user can find catalogue images', async ({ page, context }) => {
-  await newSearch(context, page);
+  await search(context, page);
   await searchQuerySubmitAndWait('test', page);
   await page.getByRole('link', { name: 'All image results' }).click();
   await slowExpect(page).toHaveURL(`${baseUrl}/search/images?query=test`);
@@ -69,7 +69,7 @@ test('(6) | The user gets a message if search yields no results', async ({
   page,
   context,
 }) => {
-  await newSearch(context, page);
+  await search(context, page);
   await searchQuerySubmitAndWait('bananana', page);
   const noResultsMessage = page.getByTestId('search-no-results');
   await slowExpect(noResultsMessage).toContainText(
@@ -81,7 +81,7 @@ test('(7) | The user can paginate through results', async ({
   page,
   context,
 }) => {
-  await newSearch(context, page);
+  await search(context, page);
   await searchQuerySubmitAndWait('test', page);
   await page.getByRole('link', { name: 'Next (page 2)' }).click();
   await slowExpect(page).toHaveURL(`${baseUrl}/search?query=test&page=2`);
@@ -99,7 +99,7 @@ test('(8) | The user sees content results even if the Catalogue API is down', as
     await route.fulfill({ status: 500 });
   });
 
-  await newSearch(context, page);
+  await search(context, page);
 
   const allCatalogueResultsLink = await page.getByRole('link', {
     name: 'All catalogue results',

--- a/playwright/test/search-all.test.ts
+++ b/playwright/test/search-all.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-import { isMobile, newAllSearch } from './helpers/contexts';
+import { isMobile, newSearch } from './helpers/contexts';
 import {
   clickImageSearchResultItem,
   searchQuerySubmitAndWait,
@@ -13,7 +13,7 @@ test('(1) | The user can find addressable site content', async ({
   page,
   context,
 }) => {
-  await newAllSearch(context, page);
+  await newSearch(context, page);
   await searchQuerySubmitAndWait('opening times', page);
   // In page link (not the one in the footer) goes to the opening times page
   await page.getByRole('link', { name: 'Opening times Find out' }).click();
@@ -21,7 +21,7 @@ test('(1) | The user can find addressable site content', async ({
 });
 
 test('(2) | The user can find catalogue works', async ({ page, context }) => {
-  await newAllSearch(context, page);
+  await newSearch(context, page);
   await searchQuerySubmitAndWait('test', page);
   await page.getByRole('link', { name: 'All catalogue results' }).click();
   await slowExpect(page).toHaveURL(`${baseUrl}/search/works?query=test`);
@@ -30,7 +30,7 @@ test('(2) | The user can find catalogue works', async ({ page, context }) => {
 test('(3) | The user can find images', async ({ page, context }) => {
   if (isMobile(page)) return; // hidden on smaller screens
 
-  await newAllSearch(context, page);
+  await newSearch(context, page);
   await searchQuerySubmitAndWait('test', page);
   await slowExpect(
     page.getByTestId('image-search-results-container')
@@ -50,7 +50,7 @@ test('(3) | The user can find images', async ({ page, context }) => {
 
 test('(4) | The user can find work types', async ({ page, context }) => {
   if (isMobile(page)) return; // hidden on smaller screens
-  await newAllSearch(context, page);
+  await newSearch(context, page);
   await searchQuerySubmitAndWait('test', page);
   await page.getByRole('link', { name: /^Books \(/ }).click();
   await slowExpect(page).toHaveURL(
@@ -59,7 +59,7 @@ test('(4) | The user can find work types', async ({ page, context }) => {
 });
 
 test('(5) | The user can find catalogue images', async ({ page, context }) => {
-  await newAllSearch(context, page);
+  await newSearch(context, page);
   await searchQuerySubmitAndWait('test', page);
   await page.getByRole('link', { name: 'All image results' }).click();
   await slowExpect(page).toHaveURL(`${baseUrl}/search/images?query=test`);
@@ -69,7 +69,7 @@ test('(6) | The user gets a message if search yields no results', async ({
   page,
   context,
 }) => {
-  await newAllSearch(context, page);
+  await newSearch(context, page);
   await searchQuerySubmitAndWait('bananana', page);
   const noResultsMessage = page.getByTestId('search-no-results');
   await slowExpect(noResultsMessage).toContainText(
@@ -81,7 +81,7 @@ test('(7) | The user can paginate through results', async ({
   page,
   context,
 }) => {
-  await newAllSearch(context, page);
+  await newSearch(context, page);
   await searchQuerySubmitAndWait('test', page);
   await page.getByRole('link', { name: 'Next (page 2)' }).click();
   await slowExpect(page).toHaveURL(`${baseUrl}/search?query=test&page=2`);
@@ -99,7 +99,7 @@ test('(8) | The user sees content results even if the Catalogue API is down', as
     await route.fulfill({ status: 500 });
   });
 
-  await newAllSearch(context, page);
+  await newSearch(context, page);
 
   const allCatalogueResultsLink = await page.getByRole('link', {
     name: 'All catalogue results',

--- a/playwright/test/search-images.test.ts
+++ b/playwright/test/search-images.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-import { isMobile, newSearch } from './helpers/contexts';
+import { isMobile, search } from './helpers/contexts';
 import {
   clickImageSearchResultItem,
   openFilterDropdown,
@@ -16,7 +16,7 @@ test('(1) | Search by term, filter by colour, check results, view image details,
   page,
   context,
 }) => {
-  await newSearch(context, page, 'images');
+  await search(context, page, 'images');
   await searchQuerySubmitAndWait('art of science', page);
 
   await selectAndWaitForColourFilter(page);
@@ -40,7 +40,7 @@ test('(2) | Image Modal | images without contributors still show a title', async
   page,
   context,
 }) => {
-  await newSearch(context, page, 'images');
+  await search(context, page, 'images');
   await searchQuerySubmitAndWait('kd9h6gr3', page);
   await clickImageSearchResultItem(1, page);
 
@@ -53,7 +53,7 @@ test('(3) | Image Modal | images with contributors show both title and contribut
   page,
   context,
 }) => {
-  await newSearch(context, page, 'images');
+  await search(context, page, 'images');
   await searchQuerySubmitAndWait('fcmwqd5u', page);
   await clickImageSearchResultItem(1, page);
 
@@ -68,7 +68,7 @@ test('(4) | Search for images between dates; there is a list of results', async 
   page,
   context,
 }) => {
-  await newSearch(context, page, 'images');
+  await search(context, page, 'images');
   await searchQuerySubmitAndWait('instruments', page);
   await openFilterDropdown('Dates', page);
 

--- a/playwright/test/search-stories.test.ts
+++ b/playwright/test/search-stories.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-import { newSearch } from './helpers/contexts';
+import { search } from './helpers/contexts';
 import {
   locateAndConfirmContributorInfoMatchesStory,
   navigateToNextPageAndConfirmNavigation,
@@ -16,7 +16,7 @@ test('(1) | The user can search for instances of a topic and filter their result
   page,
   context,
 }) => {
-  await newSearch(context, page, 'stories');
+  await search(context, page, 'stories');
   await searchQuerySubmitAndWait('milk', page);
 
   await selectAndWaitForFilter('Formats', 'W7TfJRAAAJ1D0eLK', page); // Articles
@@ -31,7 +31,7 @@ test(`(2) | The user can see the correct contributor's name below the story titl
   page,
   context,
 }) => {
-  await newSearch(context, page, 'stories');
+  await search(context, page, 'stories');
   // Article ID search
   await searchQuerySubmitAndWait('XLRmEBEAABp4vDEG', page);
 
@@ -46,7 +46,7 @@ test(`(3) | The user can paginate through their search results`, async ({
   page,
   context,
 }) => {
-  await newSearch(context, page, 'stories');
+  await search(context, page, 'stories');
   await searchQuerySubmitAndWait('body', page);
 
   await navigateToNextPageAndConfirmNavigation(page);
@@ -61,7 +61,7 @@ test(`(4) | The user can sort their story search results by oldest and most rece
   page,
   context,
 }) => {
-  await newSearch(context, page, 'stories');
+  await search(context, page, 'stories');
   await searchQuerySubmitAndWait('cats', page);
 
   const select = page.locator('select[name="sortOrder"]');
@@ -82,7 +82,7 @@ test(`(5) | Stories with an overridden date should display and reflect the chron
   page,
   context,
 }) => {
-  await newSearch(context, page, 'stories');
+  await search(context, page, 'stories');
   await searchQuerySubmitAndWait(`ken's ten`, page);
 
   const select = page.locator('select[name="sortOrder"]');

--- a/playwright/test/search-works.test.ts
+++ b/playwright/test/search-works.test.ts
@@ -3,7 +3,7 @@ import { URL } from 'url';
 
 import {
   isMobile,
-  newSearch,
+  search,
   workWithDigitalLocationAndLocationNote,
 } from './helpers/contexts';
 import {
@@ -22,7 +22,7 @@ test('(1) | The user is looking for an archive; it should be browsable from the 
   page,
   context,
 }) => {
-  await newSearch(context, page, 'works');
+  await search(context, page, 'works');
   await searchQuerySubmitAndWait('Persian', page);
   await selectAndWaitForFilter('Formats', 'h', page); // Archives and manuscripts
   await navigateToNextPageAndConfirmNavigation(page);
@@ -33,7 +33,7 @@ test('(2) | The user is looking for a video; they can get back to their original
   page,
   context,
 }) => {
-  await newSearch(context, page, 'works');
+  await search(context, page, 'works');
   await searchQuerySubmitAndWait('Britain', page);
   await selectAndWaitForFilter('Formats', 'g', page); // Video
   await navigateToNextPageAndConfirmNavigation(page);
@@ -72,7 +72,7 @@ test('(3) | The user is searching for a work from a particular year; there is a 
   page,
   context,
 }) => {
-  await newSearch(context, page, 'works');
+  await search(context, page, 'works');
   await searchQuerySubmitAndWait('brain', page);
   await openFilterDropdown('Dates', page);
 
@@ -96,7 +96,7 @@ test('(4) | The user is sorting by production dates in search; sort updates URL 
   context,
   page,
 }) => {
-  await newSearch(context, page, 'works');
+  await search(context, page, 'works');
 
   const select = page.locator('select[name="sortOrder"]');
 
@@ -136,7 +136,7 @@ test('(6) | Two options in two different filters have the same label/value; they
   context,
   page,
 }) => {
-  await newSearch(context, page, 'works');
+  await search(context, page, 'works');
   await searchQuerySubmitAndWait('Leonardo da Vinci', page);
 
   await openFilterDropdown('Contributors', page);

--- a/playwright/test/search.test.ts
+++ b/playwright/test/search.test.ts
@@ -2,7 +2,7 @@
 
 import { expect, test } from '@playwright/test';
 
-import { newSearch } from './helpers/contexts';
+import { search } from './helpers/contexts';
 import {
   searchQuerySubmitAndWait,
   selectAndWaitForColourFilter,
@@ -17,7 +17,7 @@ test('(1) | The users changes tabs; the query (but not the filters) should be ma
   page,
   context,
 }) => {
-  await newSearch(context, page, 'images');
+  await search(context, page, 'images');
   await searchQuerySubmitAndWait('art of science', page);
   await selectAndWaitForColourFilter(page);
   await expect(
@@ -34,7 +34,7 @@ test("(3) | The user does a search with filters that doesn't have results; they 
   context,
 }) => {
   const queryString = 'gsdhg;djs';
-  await newSearch(context, page, 'images');
+  await search(context, page, 'images');
   await selectAndWaitForFilter('Licences', 'pdm', page); // Public Domain Mark
   await testIfFilterIsApplied('Public Domain Mark', page);
   await searchQuerySubmitAndWait(queryString, page);
@@ -48,7 +48,7 @@ test('(4) | The search input stays focussed when submitted', async ({
   context,
   page,
 }) => {
-  await newSearch(context, page, 'works');
+  await search(context, page, 'works');
   await searchQuerySubmitAndWait('worms', page);
   await expect(page.getByRole('searchbox')).toBeFocused();
 });
@@ -57,7 +57,7 @@ test('(5) | The search input does not have focus on initial load', async ({
   context,
   page,
 }) => {
-  await newSearch(context, page, 'works');
+  await search(context, page, 'works');
   await expect(page.getByRole('searchbox')).not.toBeFocused();
 });
 
@@ -65,7 +65,7 @@ test('(6) | Boolean filters are disabled when there are no results that match th
   context,
   page,
 }) => {
-  await newSearch(context, page, 'events');
+  await search(context, page, 'events');
   await selectAndWaitForFilter('Event types', 'W-BjXhEAAASpa8Kb', page); // Shopping
   await expect(
     page.getByLabel('Catch-up events only', { exact: false })

--- a/playwright/test/search.test.ts
+++ b/playwright/test/search.test.ts
@@ -1,3 +1,5 @@
+// For overall behaviour / behaviour on category change
+
 import { expect, test } from '@playwright/test';
 
 import { newSearch } from './helpers/contexts';
@@ -24,18 +26,6 @@ test('(1) | The users changes tabs; the query (but not the filters) should be ma
   await page.getByRole('link', { name: 'Catalogue' }).click();
   await slowExpect(page).toHaveURL(
     `${baseUrl}/search/works?query=art%20of%20science`
-  );
-});
-
-test('(2) | The user clicks on "All Stories" on the Overview page; they should be taken to the stories search page', async ({
-  page,
-  context,
-}) => {
-  await newSearch(context, page);
-  await searchQuerySubmitAndWait('art of science', page);
-  await page.getByRole('link', { name: 'All stories' }).click();
-  await slowExpect(page).toHaveURL(
-    `${baseUrl}/search/stories?query=art+of+science`
   );
 });
 


### PR DESCRIPTION
## What does this change?

#11498 

- [Adds a test to check if Content results are still available should Catalogue results not come through](https://github.com/wellcomecollection/wellcomecollection.org/pull/11641/files#diff-4ab95d6441ce1e971bae2f0e0cd9b33a126074b522ce07b22a2bced4acb0bcb2R90-R115)
- I couldn't figure out how to do the other way around easily, as it's a server-side request. It seems to require [new libraries that are experimental](https://github.com/vercel/next.js/blob/canary/packages/next/src/experimental/testmode/playwright/README.md) and weren't very easy to make work. I think we can try to rely on our Check URLs tests for big errors coming through, they cover this page already and expect 200s.
- I removed `newAllSearch` context and moved the new tests to use the existing context which now has the required cookie. Since we'll be moving to new search probably next week, I thought we should make sure nothing would break when we turn the toggle on: 
  - One test failed as it was testing old behaviour and that test has been removed.
- Renamed `newSearch` context to be `search` since the "new search" was released about two years ago 😄 
- Test files have been renamed for grouping and clarifying that the `search.test.ts` one is for general search behaviour (previously contained specific "all" test)

## How to test

Reading it, does it make sense? It is useful?

## How can we measure success?

e2es won't fail once we make the new search toggle public and the new coverage will already be in place

## Have we considered potential risks?
N/A?
