### PR TITLE
Order filters with booleans at the end

### DIFF
--- a/content/webapp/components/SearchFilters/SearchFilters.Desktop.tsx
+++ b/content/webapp/components/SearchFilters/SearchFilters.Desktop.tsx
@@ -95,19 +95,20 @@ const SearchFiltersDesktop: FunctionComponent<SearchFiltersSharedProps> = ({
           />
         </FilterDropdownsContainer>
 
-        {booleanFilters?.map(f => (
-          <Space
-            key={f.id}
-            $v={{ size: 'm', properties: ['margin-bottom'] }}
-            style={{ height: '32px', display: 'flex', alignItems: 'center' }}
-          >
-            <BooleanFilter
-              {...(!showMoreFiltersModal && { form: searchFormId })}
-              f={f as BooleanFilterType}
-              changeHandler={changeHandler}
-            />
-          </Space>
-        ))}
+        {isEnhanced &&
+          booleanFilters?.map(f => (
+            <Space
+              key={f.id}
+              $v={{ size: 'm', properties: ['margin-bottom'] }}
+              style={{ height: '32px', display: 'flex', alignItems: 'center' }}
+            >
+              <BooleanFilter
+                {...(!showMoreFiltersModal && { form: searchFormId })}
+                f={f as BooleanFilterType}
+                changeHandler={changeHandler}
+              />
+            </Space>
+          ))}
       </Wrapper>
 
       {activeFiltersCount > 0 && (

--- a/content/webapp/components/SearchFilters/index.tsx
+++ b/content/webapp/components/SearchFilters/index.tsx
@@ -3,8 +3,12 @@ import { FunctionComponent, ReactElement, useContext, useState } from 'react';
 
 import useIsomorphicLayoutEffect from '@weco/common/hooks/useIsomorphicLayoutEffect';
 import { LinkProps } from '@weco/common/model/link-props';
+import { partition } from '@weco/common/utils/arrays';
 import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
-import { Filter } from '@weco/content/services/wellcome/common/filters';
+import {
+  BooleanFilter as BooleanFilterType,
+  Filter,
+} from '@weco/content/services/wellcome/common/filters';
 
 import DateRangeFilter from './SearchFilters.DateRangeFilter';
 import SearchFiltersDesktop from './SearchFilters.Desktop';
@@ -57,11 +61,18 @@ const SearchFilters: FunctionComponent<Props> = ({
       return acc + val;
     }, 0);
 
+  // We need the filters to show in a specific order
+  const [booleanFilters, otherFilters] = partition(
+    filters,
+    (f: BooleanFilterType) => f.type === 'boolean'
+  );
+  const orderedFilters = [...otherFilters, ...booleanFilters];
+
   const sharedProps: SearchFiltersSharedProps = {
     query,
     searchFormId,
     changeHandler,
-    filters,
+    filters: orderedFilters,
     linkResolver,
     activeFiltersCount,
     hasNoResults,


### PR DESCRIPTION
## What does this change?

#11636 
Just a thing I noticed that bugged me... 

The Catch-up only filter is special in that it is a checkbox and we display it differently to the others. So I found it strange that in the "more filters" modals, it would show in the middle. I've reordered the filters in this PR.

I also noticed, while doing so, that this filter would show twice without JS, so I fixed that too.


Before

<img width="400" alt="Screenshot 2025-02-19 at 16 33 53" src="https://github.com/user-attachments/assets/5a29c25a-4163-42d3-a81b-56a9bc1a3751" />

<img width="500" alt="Screenshot 2025-02-20 at 15 43 39" src="https://github.com/user-attachments/assets/0148cfbf-b343-4c3c-b97a-5866e94f76f5" />



After
<img width="400" alt="Screenshot 2025-02-20 at 15 41 23" src="https://github.com/user-attachments/assets/ad0b5f68-80b3-4fe2-9758-35e4a9da51c4" />

<img width="500" alt="Screenshot 2025-02-20 at 15 43 25" src="https://github.com/user-attachments/assets/950903dc-2d03-4c56-9e9f-b046a18ee7d1" />


## How to test

Run locally, should all behave as normal.

## How can we measure success?

Makes more sense?

## Have we considered potential risks?
N/A