### PR TITLE
Load cookie banner on cookie policy page but hide it

### DIFF
--- a/common/services/conversion/track.ts
+++ b/common/services/conversion/track.ts
@@ -19,6 +19,7 @@ declare global {
     // CivicUK
     CookieControl: {
       open: () => void;
+      hide: () => void;
     };
 
     // Meta pixel

--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -8,7 +8,6 @@ import React, {
 } from 'react';
 import { ThemeProvider } from 'styled-components';
 
-import { prismicPageIds } from '@weco/common/data/hardcoded-ids';
 import useIsFontsLoaded from '@weco/common/hooks/useIsFontsLoaded';
 import { ServerDataContext } from '@weco/common/server-data/Context';
 import {
@@ -171,9 +170,6 @@ const WecoApp: FunctionComponent<WecoAppProps> = ({
   const getLayout = Component.getLayout || (page => <>{page}</>);
 
   const isCookieBannerException = () => {
-    // Banner should not load on cookie policy page to allow user to interact with the page content.
-    if (pageProps['page']?.uid === prismicPageIds.cookiePolicy) return true; // eslint-disable-line dot-notation
-
     // Banner shouldn't appear in Prismic's Slice Simulator (or Page Builder)
     if (router.route === '/slice-simulator') return true;
 

--- a/content/webapp/pages/about-us/cookie-policy.tsx
+++ b/content/webapp/pages/about-us/cookie-policy.tsx
@@ -1,6 +1,6 @@
 import { SliceZone } from '@prismicio/react';
 import { GetServerSideProps } from 'next';
-import { FunctionComponent } from 'react';
+import { FunctionComponent, useEffect } from 'react';
 
 import { cookiesTableCopy } from '@weco/common/data/cookies';
 import { prismicPageIds } from '@weco/common/data/hardcoded-ids';
@@ -47,6 +47,10 @@ const CookiePolicy: FunctionComponent<page.Props> = (props: page.Props) => {
       return undefined;
     })
     .filter(isNotUndefined);
+
+  useEffect(() => {
+    window.CookieControl.hide();
+  }, []);
 
   return (
     <PageLayout


### PR DESCRIPTION
## What does this change?

#11374 

[See comment in ticket](https://github.com/wellcomecollection/wellcomecollection.org/issues/11374#issuecomment-2671972326), I wrote it all there

## How to test

Navigate to Cookie Policy
- Delete all cookies, navigate to website, cookie banner should appear.
- Click "manage cookies"
- Click "cookie policy"
- The banner should not display on cookie policy (the cookie has been set, empty)
- Scroll down and click "Cookie preferences" in the footer
- The modal box should appear.

Land directly on Cookie Policy
- Delete all cookies
- Navigate directly to the Cookie policy page
- The banner will display but hide immediately and you should be able to navigate.
- If you navigate to ANY OTHER PAGE, the banner should show again as you have not yet selected your preferences.

## How can we measure success?

More legit? Users should be able to change their preferences on the cookie policy page.

## Have we considered potential risks?
N/A if behaviour is tested and looks good.