### PR TITLE
Align format to the right in Download item list

### DIFF
--- a/content/webapp/components/WorkDetails/WorkDetails.DownloadItem.tsx
+++ b/content/webapp/components/WorkDetails/WorkDetails.DownloadItem.tsx
@@ -116,7 +116,7 @@ const DownloadItem: FunctionComponent<{
               />
               {`${itemLabel || canvas?.label}`}
             </td>
-            <td width="120">{`${
+            <td width="120" style={{ textAlign: 'right' }}>{`${
               format ? `${format.split('/').pop()}` : ''
             }`}</td>
             <td width="60">


### PR DESCRIPTION
## What does this change?

#11020 

See ticket conversation for details.

It's still not perfect because if the column to the left takes up to much room it gets pushed to the left, but it's better in many places.

Still gets pushed a bit
<img width="500" alt="Screenshot 2025-02-20 at 16 35 00" src="https://github.com/user-attachments/assets/d9625d3c-0729-4054-b597-0963f75a6777" />

But generally better
<img width="500" alt="Screenshot 2025-02-20 at 15 58 03" src="https://github.com/user-attachments/assets/63051cfa-53bd-4a5a-bb0e-67c942ebb554" />


## How to test

http://localhost:3000/works/htzhunbw
http://localhost:3000/works/tzdty2uj

## How can we measure success?

Looks a bit less waaavy

## Have we considered potential risks?
N/A