### PR TITLE
Display cookie banner on cookie policy page

### DIFF
--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -8,7 +8,6 @@ import React, {
 } from 'react';
 import { ThemeProvider } from 'styled-components';
 
-import { prismicPageIds } from '@weco/common/data/hardcoded-ids';
 import useIsFontsLoaded from '@weco/common/hooks/useIsFontsLoaded';
 import { ServerDataContext } from '@weco/common/server-data/Context';
 import {
@@ -171,9 +170,6 @@ const WecoApp: FunctionComponent<WecoAppProps> = ({
   const getLayout = Component.getLayout || (page => <>{page}</>);
 
   const isCookieBannerException = () => {
-    // Banner should not load on cookie policy page to allow user to interact with the page content.
-    if (pageProps['page']?.uid === prismicPageIds.cookiePolicy) return true; // eslint-disable-line dot-notation
-
     // Banner shouldn't appear in Prismic's Slice Simulator (or Page Builder)
     if (router.route === '/slice-simulator') return true;
 


### PR DESCRIPTION
## What does this change?

Context for this counter-intuitive change can be found in the ticket comments: https://github.com/wellcomecollection/wellcomecollection.org/issues/11374

Originally trialled as https://github.com/wellcomecollection/wellcomecollection.org/pull/11644, we had to revert as it was behaving differently in live environments.

This change displays it on all pages.

## How to test

Remove cookies, go to cookie page locally; can you manage cookie preferences from there from the link in the footer?

## How can we measure success?

Cookie preferences can be managed from every page on the site.

## Have we considered potential risks?
Bit strange to have the banner show up on the cookie policy page, but there are ways around it so this was the choice.
