### PR TITLE
Add bslLeafletVideo embed field to exhibition model

### DIFF
--- a/common/customtypes/exhibitions/index.json
+++ b/common/customtypes/exhibitions/index.json
@@ -72,6 +72,13 @@
           "placeholder": ""
         }
       },
+      "bslLeafletVideo": {
+        "type": "Embed",
+        "config": {
+          "label": "BSL leaflet video",
+          "placeholder": ""
+        }
+      },
       "body": {
         "type": "Slices",
         "fieldset": "Slice Zone",

--- a/common/prismicio-types.d.ts
+++ b/common/prismicio-types.d.ts
@@ -3034,6 +3034,17 @@ interface ExhibitionsDocumentData {
   place: prismic.ContentRelationshipField<'places'>;
 
   /**
+   * BSL leaflet video field in *Exhibition*
+   *
+   * - **Field Type**: Embed
+   * - **Placeholder**: *None*
+   * - **API ID Path**: exhibitions.bslLeafletVideo
+   * - **Tab**: Exhibition
+   * - **Documentation**: https://prismic.io/docs/field#embed
+   */
+  bslLeafletVideo: prismic.EmbedField;
+
+  /**
    * Slice Zone field in *Exhibition*
    *
    * - **Field Type**: Slice Zone


### PR DESCRIPTION
## What does this change?
Adds an `embed` field to the exhibition model to contain BSL leaflet video.

## How to test
This has been pushed to Prismic stage so you can see the field in Prismic on e.g. the [Hard Graft exhibition](https://wellcomecollection-stage.prismic.io/builder/pages/ZpE1ghAAACQAgRSg?s=unclassified)

## How can we measure success?
Editors can add BSL content

## Have we considered potential risks?
n/a