### PR TITLE
Loading state in search and better API toolbar links

### DIFF
--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -261,9 +261,9 @@ const CatalogueResults = styled(Space).attrs({
   `}
 
   ${props =>
-    props.theme.media('large')(
-      `grid-column: ${props.$fullWidth ? '1 / 13' : '9 / 13'};`
-    )}
+    props.theme.media('large')(`
+      grid-column: ${props.$fullWidth ? '1' : '9'}/13;
+    `)}
 `;
 
 const LoaderContainer = styled.div<{ $fullWidth: boolean }>`
@@ -275,7 +275,7 @@ const LoaderContainer = styled.div<{ $fullWidth: boolean }>`
 
   ${props =>
     props.theme.media('large')(
-      `grid-column: ${props => (props.$fullWidth ? 6 : 10)};`
+      `grid-column: ${props.$fullWidth ? '6' : '10'};`
     )}
 `;
 
@@ -335,9 +335,6 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
   const [isLoadingImages, setIsLoadingImages] = useState(true);
   const [isLoadingWorks, setIsLoadingWorks] = useState(true);
   const [isCatalogueLoading, setIsCatalogueLoading] = useState(true);
-  const [contentResultsLength, setContentResultsLength] = useState(
-    contentResults?.totalResults
-  );
 
   const totalWorksResults = clientSideWorkTypes?.totalResults || 0;
   const totalImagesResults = clientSideImages?.totalResults || 0;
@@ -349,9 +346,7 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
   const pathname = usePathname();
 
   useMemo(() => {
-    if (contentResultsLength !== contentResults?.totalResults)
-      setIsCatalogueLoading(true);
-    setContentResultsLength(contentResults?.totalResults);
+    setIsCatalogueLoading(true);
   }, [contentResults?.totalResults]);
 
   async function fetchWorks() {
@@ -426,8 +421,6 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
     });
 
     setIsCatalogueLoading(true);
-    setClientSideWorkTypes(undefined);
-    setClientSideImages(undefined);
 
     fetchWorks();
     fetchImages();
@@ -529,7 +522,7 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
                     </h3>
                   </Space>
 
-                  {clientSideWorkTypes?.totalResults && (
+                  {!!clientSideWorkTypes?.totalResults && (
                     <CatalogueResultsSection>
                       <CatalogueSectionTitle>
                         Catalogue results
@@ -595,7 +588,7 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
                     </Space>
                   )}
 
-                  {clientSideImages?.totalResults && (
+                  {!!clientSideImages?.totalResults && (
                     <>
                       <CatalogueSectionTitle
                         $h={{
@@ -650,7 +643,7 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
                   </Space>
                 ))}
 
-                {contentResults?.totalPages && (
+                {!!contentResults?.totalPages && (
                   <Pagination
                     totalPages={contentResults.totalPages}
                     ariaLabel="Content search results pagination"

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -161,10 +161,6 @@ const CatalogueResultsInner = styled(Space).attrs({
 })`
   position: relative;
   background-color: ${props => props.theme.color('warmNeutral.300')};
-  min-height: 90px;
-  ${props => props.theme.media('large')`
-      min-height: 400px;
-  `}
 `;
 
 const CatalogueResultsSection = styled(Space).attrs({

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -495,12 +495,12 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
                 <>
                   {formatNumber(totalResults)} result
                   {totalResults === 1 ? '' : 's'}
-                  {queryString ? (
+                  {queryString && (
                     <>
                       {' '}
                       for <span className={font('intb', 5)}>{queryString}</span>
                     </>
-                  ) : null}
+                  )}
                 </>
               )}
             </p>
@@ -529,7 +529,7 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
                     </h3>
                   </Space>
 
-                  {clientSideWorkTypes?.totalResults ? (
+                  {clientSideWorkTypes?.totalResults && (
                     <CatalogueResultsSection>
                       <CatalogueSectionTitle>
                         Catalogue results
@@ -577,7 +577,7 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
                         </AllLink>
                       </NextLink>
                     </CatalogueResultsSection>
-                  ) : null}
+                  )}
 
                   {totalWorksResults > 0 && totalImagesResults > 0 && (
                     <Space
@@ -595,7 +595,7 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
                     </Space>
                   )}
 
-                  {clientSideImages?.totalResults ? (
+                  {clientSideImages?.totalResults && (
                     <>
                       <CatalogueSectionTitle
                         $h={{
@@ -634,7 +634,7 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
                         </NextLink>
                       </CatalogueResultsSection>
                     </>
-                  ) : null}
+                  )}
                 </CatalogueResultsInner>
               </CatalogueResults>
             )}
@@ -650,13 +650,13 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
                   </Space>
                 ))}
 
-                {contentResults?.totalPages ? (
+                {contentResults?.totalPages && (
                   <Pagination
                     totalPages={contentResults.totalPages}
                     ariaLabel="Content search results pagination"
                     isHiddenMobile={false}
                   />
-                ) : null}
+                )}
               </ContentResults>
             )}
           </GridContainer>


### PR DESCRIPTION
## What does this change?

#11610 

Did a few things here, so I'm sorry it looks like more than it is.

- I moved the client-side fetch functions and everything they needed to the `NewSearchPage` component, so it'd all be centralised. I did this to better contain what it needed, but also because I wanted to control state from them.
- I improved how the API toolbar links were created; they are buggy at the moment, and will often only add just the image or just the work link, because they overwrote each other. This ensures they should both be there and updated.
- I removed the works-only and images-only loaders, in favour of a generic one, that way it only displays content once we have it all, which makes it smoother IMO.
- This fixes the "no results" displaying in between a search result with content results and a search result without it.

Before

https://github.com/user-attachments/assets/d49e4dcd-6e84-4c54-9c7d-d0a7b17a26a3

After

https://github.com/user-attachments/assets/f35199ff-1bc3-4a9a-9009-8e1c94faae9b

In a second commit I've removed the min-height of the block (which was probably for the previous load state), so it actually looks like this now:
<img width="500" alt="Screenshot 2025-02-25 at 09 51 17" src="https://github.com/user-attachments/assets/1009b365-5c1a-4df3-9e58-743d250ad07b" />


<img width="500" alt="Screenshot 2025-02-25 at 09 51 03" src="https://github.com/user-attachments/assets/26852916-24b0-41ec-ad44-5ad6ea2bf929" />




## How to test

Run locally and test with mid throttle. Big fan of "Florence Nightingale Greece" for no content results, although it also has no images results, go crazy!

 
## How can we measure success?

Smoother experience for all, and API toolbar links working better and being more useful

## Have we considered potential risks?
N/A
