### PR TITLE
Exhibition page display logic

### DIFF
--- a/content/webapp/components/Exhibition/Exhibition.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.tsx
@@ -295,6 +295,8 @@ const Exhibition: FunctionComponent<Props> = ({
       highlightTourType: 'audio',
     });
 
+  // This contains all the possible content for the access section accordion
+  // We then filter out content that isn't relevant, i.e. if there isn't a highlight tour attached to the exhibition
   const possibleExhibitionAccessContent = [
     {
       summary: 'Digital highlights tour',
@@ -452,14 +454,12 @@ const Exhibition: FunctionComponent<Props> = ({
   ];
 
   const accordionContent = possibleExhibitionAccessContent.filter(section => {
-    if (
-      !hasExhibitionHighlightTours &&
-      section.summary === 'Digital highlights tour'
-    ) {
-      return false;
-    } else {
-      return true;
-    }
+    // If there is no digital highlights tour attached to the exhibition, we want to remove
+    // the section about the digital highlights tour
+    return !(
+      section.summary === 'Digital highlights tour' &&
+      !hasExhibitionHighlightTours
+    );
   });
 
   useEffect(() => {

--- a/content/webapp/components/Exhibition/Exhibition.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.tsx
@@ -274,20 +274,26 @@ const Exhibition: FunctionComponent<Props> = ({
     link => link.type === 'visual-story'
   );
 
+  const hasExhibtionTexts = exhibitionTexts.length > 0;
   const hasExhibitionHighlightTours = exhibitionHighlightTours.length > 0;
 
   // Theoretically, there could be multiple ExhibitionTexts and ExhibitionHighlightTours
   // attached to an exhibition, but in reality there is only one, so we just take the first
   // and create links to them.
-  const exhibitionTextLink = linkResolver(exhibitionTexts[0]);
-  const bslTourLink = linkResolver({
-    ...exhibitionHighlightTours[0],
-    highlightTourType: 'bsl',
-  });
-  const audioTourLink = linkResolver({
-    ...exhibitionHighlightTours[0],
-    highlightTourType: 'audio',
-  });
+  const exhibitionTextLink =
+    hasExhibtionTexts && linkResolver(exhibitionTexts[0]);
+  const bslTourLink =
+    hasExhibitionHighlightTours &&
+    linkResolver({
+      ...exhibitionHighlightTours[0],
+      highlightTourType: 'bsl',
+    });
+  const audioTourLink =
+    hasExhibitionHighlightTours &&
+    linkResolver({
+      ...exhibitionHighlightTours[0],
+      highlightTourType: 'audio',
+    });
 
   const possibleExhibitionAccessContent = [
     {
@@ -301,14 +307,18 @@ const Exhibition: FunctionComponent<Props> = ({
             via handheld devices with tactile buttons, or on an iPad which you
             can borrow
           </li>
-          <li>
-            <NextLink href={bslTourLink}>Watch BSL video tour</NextLink>
-          </li>
-          <li>
-            <NextLink href={audioTourLink}>
-              Listen to audio tour with audio description
-            </NextLink>
-          </li>
+          {bslTourLink && (
+            <li>
+              <NextLink href={bslTourLink}>Watch BSL video tour</NextLink>
+            </li>
+          )}
+          {audioTourLink && (
+            <li>
+              <NextLink href={audioTourLink}>
+                Listen to audio tour with audio description
+              </NextLink>
+            </li>
+          )}
         </ul>
       ),
     },
@@ -321,24 +331,29 @@ const Exhibition: FunctionComponent<Props> = ({
             Live BSL tours are available. See our exhibition events above for
             more information or contact us in advance to request a tour
           </li>
-          <li>
-            <NextLink href={bslTourLink}>
-              Watch BSL videos of the digital highlights tour on your own device
-            </NextLink>
-          </li>
-          <li>
-            <span id="transcript-link-text">
-              Transcripts of all audiovisual content are available
-            </span>{' '}
-            in the gallery and
-            <NextLink
-              id="transcript-link"
-              aria-labelledby="transcript-link-text transcript-link"
-              href={exhibitionTextLink}
-            >
-              online
-            </NextLink>
-          </li>
+          {bslTourLink && (
+            <li>
+              <NextLink href={bslTourLink}>
+                Watch BSL videos of the digital highlights tour on your own
+                device
+              </NextLink>
+            </li>
+          )}
+          {exhibitionTextLink && (
+            <li>
+              <span id="transcript-link-text">
+                Transcripts of all audiovisual content are available
+              </span>{' '}
+              in the gallery and
+              <NextLink
+                id="transcript-link"
+                aria-labelledby="transcript-link-text transcript-link"
+                href={exhibitionTextLink}
+              >
+                online
+              </NextLink>
+            </li>
+          )}
           <li>All videos are subtitled</li>
           <li>
             There are fixed induction loops in the building and portable
@@ -351,16 +366,20 @@ const Exhibition: FunctionComponent<Props> = ({
       summary: 'Audio description and visual access',
       content: (
         <ul>
-          <li>
-            <NextLink href={audioTourLink}>
-              The digital highlights tour is available with audio description
-            </NextLink>
-          </li>
-          <li>
-            <NextLink href={exhibitionTextLink}>
-              Access all the text from the exhibition on your own device
-            </NextLink>
-          </li>
+          {audioTourLink && (
+            <li>
+              <NextLink href={audioTourLink}>
+                The digital highlights tour is available with audio description
+              </NextLink>
+            </li>
+          )}
+          {exhibitionTextLink && (
+            <li>
+              <NextLink href={exhibitionTextLink}>
+                Access all the text from the exhibition on your own device
+              </NextLink>
+            </li>
+          )}
           <li>
             A large-print guide and magnifiers are available in the gallery
           </li>

--- a/content/webapp/components/Exhibition/Exhibition.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.tsx
@@ -339,21 +339,25 @@ const Exhibition: FunctionComponent<Props> = ({
               </NextLink>
             </li>
           )}
-          {exhibitionTextLink && (
-            <li>
-              <span id="transcript-link-text">
-                Transcripts of all audiovisual content are available
-              </span>{' '}
-              in the gallery and{' '}
-              <NextLink
-                id="transcript-link"
-                aria-labelledby="transcript-link-text transcript-link"
-                href={exhibitionTextLink}
-              >
-                online
-              </NextLink>
-            </li>
-          )}
+
+          <li>
+            <span id="transcript-link-text">
+              Transcripts of all audiovisual content are available
+            </span>{' '}
+            in the gallery
+            {exhibitionTextLink && (
+              <>
+                {` and `}
+                <NextLink
+                  id="transcript-link"
+                  aria-labelledby="transcript-link-text transcript-link"
+                  href={exhibitionTextLink}
+                >
+                  online
+                </NextLink>
+              </>
+            )}
+          </li>
 
           <li>All videos are subtitled</li>
           <li>

--- a/content/webapp/components/Exhibition/Exhibition.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.tsx
@@ -590,59 +590,57 @@ const Exhibition: FunctionComponent<Props> = ({
             </Space>
           )}
 
-          {exhibitionAccessContent && (
-            <>
-              <div className="grid">
-                <div className={grid({ s: 12 })}>
-                  <Space
-                    as="h2"
-                    className={font('wb', 3)}
-                    $v={{
-                      size: 'l',
-                      properties: ['margin-top', 'margin-bottom'],
-                    }}
-                  >
-                    Access resources
-                  </Space>
-                </div>
-              </div>
-              {visualStoryLink && (
-                <>
-                  <h3 className={font('intb', 4)}>Plan your visit</h3>
-                  <NextLink href={visualStoryLink.url}>
-                    Exhibition visual story
-                  </NextLink>{' '}
-                  <Space as="p" $v={{ size: 'm', properties: ['margin-top'] }}>
-                    This visual story provides images and information to help
-                    you plan and prepare for your visit to the exhibition.
-                  </Space>
-                </>
-              )}
-              <h3 className={font('intb', 4)}>{`When you're here`}</h3>
-              <p>
-                Resources designed to support your visit are available online
-                and in the gallery.
-              </p>
-              <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
-                <Accordion id="access-resources" items={accordionContent} />
-              </Space>
+          <div className="grid">
+            <div className={grid({ s: 12 })}>
               <Space
-                as="h3"
-                className={font('intb', 4)}
-                $v={{ size: 'l', properties: ['margin-bottom'] }}
-              >
-                Access information and queries
-              </Space>
-              <Contact
-                link={{
-                  text: 'Visit our accessibility page ',
-                  url: '/visit-us/accessibility',
+                as="h2"
+                className={font('wb', 3)}
+                $v={{
+                  size: 'l',
+                  properties: ['margin-top', 'margin-bottom'],
                 }}
-                phone="020 7611 2222"
-                email="access@wellcomecollection.org"
-              />
+              >
+                Access resources
+              </Space>
+            </div>
+          </div>
+
+          {visualStoryLink && (
+            <>
+              <h3 className={font('intb', 4)}>Plan your visit</h3>
+              <NextLink href={visualStoryLink.url}>
+                Exhibition visual story
+              </NextLink>{' '}
+              <Space as="p" $v={{ size: 'm', properties: ['margin-top'] }}>
+                This visual story provides images and information to help you
+                plan and prepare for your visit to the exhibition.
+              </Space>
             </>
           )}
+
+          <h3 className={font('intb', 4)}>{`When you're here`}</h3>
+          <p>
+            Resources designed to support your visit are available online and in
+            the gallery.
+          </p>
+          <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
+            <Accordion id="access-resources" items={accordionContent} />
+          </Space>
+          <Space
+            as="h3"
+            className={font('intb', 4)}
+            $v={{ size: 'l', properties: ['margin-bottom'] }}
+          >
+            Access information and queries
+          </Space>
+          <Contact
+            link={{
+              text: 'Visit our accessibility page ',
+              url: '/visit-us/accessibility',
+            }}
+            phone="020 7611 2222"
+            email="access@wellcomecollection.org"
+          />
 
           {exhibitionAbouts.length > 0 && (
             <Space

--- a/content/webapp/components/Exhibition/Exhibition.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.tsx
@@ -777,60 +777,6 @@ const Exhibition: FunctionComponent<Props> = ({
             </Space>
           )}
 
-          {exhibitionAccessContent && (
-            <>
-              <div className="grid">
-                <div className={grid({ s: 12 })}>
-                  <Space
-                    as="h2"
-                    className={font('wb', 3)}
-                    $v={{
-                      size: 'l',
-                      properties: ['margin-top', 'margin-bottom'],
-                    }}
-                  >
-                    Access resources
-                  </Space>
-                </div>
-              </div>
-              {visualStoryLink && (
-                <>
-                  <h3 className={font('intb', 4)}>Plan your visit</h3>
-                  <NextLink href={visualStoryLink.url}>
-                    Exhibition visual story
-                  </NextLink>{' '}
-                  <Space as="p" $v={{ size: 'm', properties: ['margin-top'] }}>
-                    This visual story provides images and information to help
-                    you plan and prepare for your visit to the exhibition.
-                  </Space>
-                </>
-              )}
-              <h3 className={font('intb', 4)}>{`When you're here`}</h3>
-              <p>
-                Resources designed to support your visit are available online
-                and in the gallery.
-              </p>
-              <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
-                <Accordion id="access-resources" items={accordionContent} />
-              </Space>
-              <Space
-                as="h3"
-                className={font('intb', 4)}
-                $v={{ size: 'l', properties: ['margin-bottom'] }}
-              >
-                Access information and queries
-              </Space>
-              <Contact
-                link={{
-                  text: 'Visit our accessibility page ',
-                  url: '/visit-us/accessibility',
-                }}
-                phone="020 7611 2222"
-                email="access@wellcomecollection.org"
-              />
-            </>
-          )}
-
           {exhibitionAbouts.length > 0 && (
             <SearchResults items={exhibitionAbouts} title="Related stories" />
           )}

--- a/content/webapp/components/Exhibition/Exhibition.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.tsx
@@ -289,7 +289,7 @@ const Exhibition: FunctionComponent<Props> = ({
     highlightTourType: 'audio',
   });
 
-  const possibleAccordionContent = [
+  const possibleExhibitionAccessContent = [
     {
       summary: 'Digital highlights tour',
       content: (
@@ -409,7 +409,7 @@ const Exhibition: FunctionComponent<Props> = ({
     },
   ];
 
-  const accordionContent = possibleAccordionContent.filter(section => {
+  const accordionContent = possibleExhibitionAccessContent.filter(section => {
     if (
       !hasExhibitionHighlightTours &&
       section.summary === 'Digital highlights tour'

--- a/content/webapp/components/Exhibition/Exhibition.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.tsx
@@ -368,7 +368,6 @@ const Exhibition: FunctionComponent<Props> = ({
           <li>
             There are brighter and more even lighting conditions across the
             gallery during our Lights Up sessions.{' '}
-            {/* TODO double check links */}
             <NextLink href="/events">
               For more information, find our exhibition events above.
             </NextLink>
@@ -399,8 +398,6 @@ const Exhibition: FunctionComponent<Props> = ({
           Please speak to a member of staff in the building Weekday mornings and
           Thursday evenings are usually the quietest times to visit Additional
           support is available during our Relaxed Openings.{' '}
-          {/* TODO is this wording correct */}
-          {/* should it link to filtered search? */}
           <NextLink href="/events">
             For more information, find our exhibition events above.
           </NextLink>

--- a/content/webapp/components/Exhibition/Exhibition.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.tsx
@@ -590,57 +590,61 @@ const Exhibition: FunctionComponent<Props> = ({
             </Space>
           )}
 
-          <div className="grid">
-            <div className={grid({ s: 12 })}>
-              <Space
-                as="h2"
-                className={font('wb', 3)}
-                $v={{
-                  size: 'l',
-                  properties: ['margin-top', 'margin-bottom'],
-                }}
-              >
-                Access resources
-              </Space>
-            </div>
-          </div>
-
-          {visualStoryLink && (
+          {exhibition.end && !isPast(exhibition.end) && (
             <>
-              <h3 className={font('intb', 4)}>Plan your visit</h3>
-              <NextLink href={visualStoryLink.url}>
-                Exhibition visual story
-              </NextLink>{' '}
-              <Space as="p" $v={{ size: 'm', properties: ['margin-top'] }}>
-                This visual story provides images and information to help you
-                plan and prepare for your visit to the exhibition.
+              <div className="grid">
+                <div className={grid({ s: 12 })}>
+                  <Space
+                    as="h2"
+                    className={font('wb', 3)}
+                    $v={{
+                      size: 'l',
+                      properties: ['margin-top', 'margin-bottom'],
+                    }}
+                  >
+                    Access resources
+                  </Space>
+                </div>
+              </div>
+
+              {visualStoryLink && (
+                <>
+                  <h3 className={font('intb', 4)}>Plan your visit</h3>
+                  <NextLink href={visualStoryLink.url}>
+                    Exhibition visual story
+                  </NextLink>{' '}
+                  <Space as="p" $v={{ size: 'm', properties: ['margin-top'] }}>
+                    This visual story provides images and information to help
+                    you plan and prepare for your visit to the exhibition.
+                  </Space>
+                </>
+              )}
+
+              <h3 className={font('intb', 4)}>{`When you're here`}</h3>
+              <p>
+                Resources designed to support your visit are available online
+                and in the gallery.
+              </p>
+              <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
+                <Accordion id="access-resources" items={accordionContent} />
               </Space>
+              <Space
+                as="h3"
+                className={font('intb', 4)}
+                $v={{ size: 'l', properties: ['margin-bottom'] }}
+              >
+                Access information and queries
+              </Space>
+              <Contact
+                link={{
+                  text: 'Visit our accessibility page ',
+                  url: '/visit-us/accessibility',
+                }}
+                phone="020 7611 2222"
+                email="access@wellcomecollection.org"
+              />
             </>
           )}
-
-          <h3 className={font('intb', 4)}>{`When you're here`}</h3>
-          <p>
-            Resources designed to support your visit are available online and in
-            the gallery.
-          </p>
-          <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
-            <Accordion id="access-resources" items={accordionContent} />
-          </Space>
-          <Space
-            as="h3"
-            className={font('intb', 4)}
-            $v={{ size: 'l', properties: ['margin-bottom'] }}
-          >
-            Access information and queries
-          </Space>
-          <Contact
-            link={{
-              text: 'Visit our accessibility page ',
-              url: '/visit-us/accessibility',
-            }}
-            phone="020 7611 2222"
-            email="access@wellcomecollection.org"
-          />
 
           {exhibitionAbouts.length > 0 && (
             <Space

--- a/content/webapp/components/Exhibition/Exhibition.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.tsx
@@ -426,7 +426,7 @@ const Exhibition: FunctionComponent<Props> = ({
                 and
               </>
             ) : (
-              'A visual story with a sensory map is available online'
+              'A visual story with a sensory map is available '
             )}{' '}
             in the building at the start of the exhibition
           </li>

--- a/content/webapp/components/Exhibition/Exhibition.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.tsx
@@ -274,14 +274,14 @@ const Exhibition: FunctionComponent<Props> = ({
     link => link.type === 'visual-story'
   );
 
-  const hasExhibtionTexts = exhibitionTexts.length > 0;
+  const hasExhibitionTexts = exhibitionTexts.length > 0;
   const hasExhibitionHighlightTours = exhibitionHighlightTours.length > 0;
 
   // Theoretically, there could be multiple ExhibitionTexts and ExhibitionHighlightTours
   // attached to an exhibition, but in reality there is only one, so we just take the first
   // and create links to them.
   const exhibitionTextLink =
-    hasExhibtionTexts && linkResolver(exhibitionTexts[0]);
+    hasExhibitionTexts && linkResolver(exhibitionTexts[0]);
   const bslTourLink =
     hasExhibitionHighlightTours &&
     linkResolver({

--- a/content/webapp/components/Exhibition/Exhibition.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.tsx
@@ -274,6 +274,8 @@ const Exhibition: FunctionComponent<Props> = ({
     link => link.type === 'visual-story'
   );
 
+  const hasExhibitionHighlightTours = exhibitionHighlightTours.length > 0;
+
   // Theoretically, there could be multiple ExhibitionTexts and ExhibitionHighlightTours
   // attached to an exhibition, but in reality there is only one, so we just take the first
   // and create links to them.
@@ -287,7 +289,7 @@ const Exhibition: FunctionComponent<Props> = ({
     highlightTourType: 'audio',
   });
 
-  const accordionContent = [
+  const possibleAccordionContent = [
     {
       summary: 'Digital highlights tour',
       content: (
@@ -406,6 +408,18 @@ const Exhibition: FunctionComponent<Props> = ({
       ),
     },
   ];
+
+  const accordionContent = possibleAccordionContent.filter(section => {
+    if (
+      !hasExhibitionHighlightTours &&
+      section.summary === 'Digital highlights tour'
+    ) {
+      return false;
+    } else {
+      return true;
+    }
+  });
+
   useEffect(() => {
     const ids = exhibition.relatedIds;
 

--- a/content/webapp/components/Exhibition/Exhibition.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.tsx
@@ -388,9 +388,11 @@ const Exhibition: FunctionComponent<Props> = ({
           <li>
             There are brighter and more even lighting conditions across the
             gallery during our Lights Up sessions.{' '}
-            <NextLink href="#events-list">
-              See our exhibition events for more information and availability
-            </NextLink>
+            {exhibitionOfs.length > 0 && (
+              <NextLink href="#events-list">
+                See our exhibition events for more information and availability
+              </NextLink>
+            )}
           </li>
         </ul>
       ),
@@ -434,9 +436,11 @@ const Exhibition: FunctionComponent<Props> = ({
           </li>
           <li>
             Additional support is available during our Relaxed Openings.{' '}
-            <NextLink href="#events-list">
-              See our exhibition events for more information and availability
-            </NextLink>
+            {exhibitionOfs.length > 0 && (
+              <NextLink href="#events-list">
+                See our exhibition events for more information and availability
+              </NextLink>
+            )}
           </li>
         </ul>
       ),


### PR DESCRIPTION
## What does this change?

For #11495 

Wraps content in logic so that the links and text that are displayed reflect what is available.

## How to test

- Visit [an exhibition page](http://localhost:3000/exhibitions/hard-graft-work-health-and-rights#events-list) with the exhibitionAccessContent toggle enabled
- Use Prismic stage to add/remove visual stories/exhibition texts and exhibition highlight tours from the exhibition
- OR (fake the conditions in the code)
- The displayed text should match what is available - the [logic is described in the comments of this document](https://wellcomecloud-my.sharepoint.com/:w:/r/personal/l_baily_wellcome_ac_uk/Documents/Exhibition%20access%20copy%5B31%5D.docx?d=w83af6d26e2594c6bbcb8c01ebc646ff3&csf=1&web=1&e=FWiunK)

## How can we measure success?

## Have we considered potential risks?

As long as the page appears the same without the toggle enabled there is little risk

