### PR TITLE
Add interpretations to Exhibitions

### DIFF
--- a/common/customtypes/exhibitions/index.json
+++ b/common/customtypes/exhibitions/index.json
@@ -201,7 +201,7 @@
       "interpretations": {
         "type": "Group",
         "config": {
-          "label": "",
+          "label": "Interpretations",
           "repeat": true,
           "fields": {
             "interpretationType": {

--- a/common/customtypes/exhibitions/index.json
+++ b/common/customtypes/exhibitions/index.json
@@ -197,7 +197,42 @@
         }
       }
     },
-    "Access content": {
+    "Access": {
+      "interpretations": {
+        "type": "Group",
+        "config": {
+          "label": "",
+          "repeat": true,
+          "fields": {
+            "interpretationType": {
+              "type": "Link",
+              "config": {
+                "label": "Interpretation",
+                "select": "document",
+                "customtypes": ["interpretation-types"]
+              }
+            },
+            "isPrimary": {
+              "type": "Boolean",
+              "config": {
+                "label": "Primary interpretation",
+                "placeholder_false": "false",
+                "placeholder_true": "true",
+                "default_value": false
+              }
+            },
+            "extraInformation": {
+              "type": "StructuredText",
+              "config": {
+                "label": "Extra information",
+                "placeholder": "",
+                "allowTargetBlank": true,
+                "multi": "paragraph,hyperlink,strong,em"
+              }
+            }
+          }
+        }
+      },
       "accessResourcesPdfs": {
         "type": "Group",
         "fieldset": "Access pdfs",

--- a/common/prismicio-types.d.ts
+++ b/common/prismicio-types.d.ts
@@ -2795,6 +2795,42 @@ export interface ExhibitionsDocumentDataArticlesItem {
 }
 
 /**
+ * Item in *Exhibition → interpretations*
+ */
+export interface ExhibitionsDocumentDataInterpretationsItem {
+  /**
+   * Interpretation field in *Exhibition → interpretations*
+   *
+   * - **Field Type**: Content Relationship
+   * - **Placeholder**: *None*
+   * - **API ID Path**: exhibitions.interpretations[].interpretationType
+   * - **Documentation**: https://prismic.io/docs/field#link-content-relationship
+   */
+  interpretationType: prismic.ContentRelationshipField<'interpretation-types'>;
+
+  /**
+   * Primary interpretation field in *Exhibition → interpretations*
+   *
+   * - **Field Type**: Boolean
+   * - **Placeholder**: *None*
+   * - **Default Value**: false
+   * - **API ID Path**: exhibitions.interpretations[].isPrimary
+   * - **Documentation**: https://prismic.io/docs/field#boolean
+   */
+  isPrimary: prismic.BooleanField;
+
+  /**
+   * Extra information field in *Exhibition → interpretations*
+   *
+   * - **Field Type**: Rich Text
+   * - **Placeholder**: *None*
+   * - **API ID Path**: exhibitions.interpretations[].extraInformation
+   * - **Documentation**: https://prismic.io/docs/field#rich-text-title
+   */
+  extraInformation: prismic.RichTextField;
+}
+
+/**
  * Item in *Exhibition → Access pdfs*
  */
 export interface ExhibitionsDocumentDataAccessResourcesPdfsItem {
@@ -3085,14 +3121,27 @@ interface ExhibitionsDocumentData {
   articles: prismic.GroupField<
     Simplify<ExhibitionsDocumentDataArticlesItem>
   > /**
+   * interpretations field in *Exhibition*
+   *
+   * - **Field Type**: Group
+   * - **Placeholder**: *None*
+   * - **API ID Path**: exhibitions.interpretations[]
+   * - **Tab**: Access
+   * - **Documentation**: https://prismic.io/docs/field#group
+   */;
+  interpretations: prismic.GroupField<
+    Simplify<ExhibitionsDocumentDataInterpretationsItem>
+  >;
+
+  /**
    * Access pdfs field in *Exhibition*
    *
    * - **Field Type**: Group
    * - **Placeholder**: *None*
    * - **API ID Path**: exhibitions.accessResourcesPdfs[]
-   * - **Tab**: Access content
+   * - **Tab**: Access
    * - **Documentation**: https://prismic.io/docs/field#group
-   */;
+   */
   accessResourcesPdfs: prismic.GroupField<
     Simplify<ExhibitionsDocumentDataAccessResourcesPdfsItem>
   >;
@@ -3103,7 +3152,7 @@ interface ExhibitionsDocumentData {
    * - **Field Type**: Rich Text
    * - **Placeholder**: *None*
    * - **API ID Path**: exhibitions.accessResourcesText
-   * - **Tab**: Access content
+   * - **Tab**: Access
    * - **Documentation**: https://prismic.io/docs/field#rich-text-title
    */
   accessResourcesText: prismic.RichTextField /**
@@ -7364,6 +7413,7 @@ declare module '@prismicio/client' {
       ExhibitionsDocumentDataExhibitsItem,
       ExhibitionsDocumentDataEventsItem,
       ExhibitionsDocumentDataArticlesItem,
+      ExhibitionsDocumentDataInterpretationsItem,
       ExhibitionsDocumentDataAccessResourcesPdfsItem,
       ExhibitionsDocumentDataContributorsItem,
       ExhibitionsDocumentDataPromoEditorialImageSlicePrimary,

--- a/common/prismicio-types.d.ts
+++ b/common/prismicio-types.d.ts
@@ -2795,11 +2795,11 @@ export interface ExhibitionsDocumentDataArticlesItem {
 }
 
 /**
- * Item in *Exhibition → interpretations*
+ * Item in *Exhibition → Interpretations*
  */
 export interface ExhibitionsDocumentDataInterpretationsItem {
   /**
-   * Interpretation field in *Exhibition → interpretations*
+   * Interpretation field in *Exhibition → Interpretations*
    *
    * - **Field Type**: Content Relationship
    * - **Placeholder**: *None*
@@ -2809,7 +2809,7 @@ export interface ExhibitionsDocumentDataInterpretationsItem {
   interpretationType: prismic.ContentRelationshipField<'interpretation-types'>;
 
   /**
-   * Primary interpretation field in *Exhibition → interpretations*
+   * Primary interpretation field in *Exhibition → Interpretations*
    *
    * - **Field Type**: Boolean
    * - **Placeholder**: *None*
@@ -2820,7 +2820,7 @@ export interface ExhibitionsDocumentDataInterpretationsItem {
   isPrimary: prismic.BooleanField;
 
   /**
-   * Extra information field in *Exhibition → interpretations*
+   * Extra information field in *Exhibition → Interpretations*
    *
    * - **Field Type**: Rich Text
    * - **Placeholder**: *None*
@@ -3121,7 +3121,7 @@ interface ExhibitionsDocumentData {
   articles: prismic.GroupField<
     Simplify<ExhibitionsDocumentDataArticlesItem>
   > /**
-   * interpretations field in *Exhibition*
+   * Interpretations field in *Exhibition*
    *
    * - **Field Type**: Group
    * - **Placeholder**: *None*


### PR DESCRIPTION
## What does this change?

Prep work for #11473, required for https://github.com/wellcomecollection/content-api/issues/219

- Change "Access content" tab name to "Access", matches Events'
- Adds Interpretations as a repeatable group comprised of a content relationship field, a boolean (in events this is a Select, but it's causing problems (https://github.com/wellcomecollection/wellcomecollection.org/issues/11165) so I thought I'd go with that?

## How to test

Does it match event's closely? Have I missed anything?

## How can we measure success?

Exhibitions can have access types added!

## Have we considered potential risks?
N/A