### PR TITLE
Don't merge: Default exhibition access content toggle to true

### DIFF
--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -112,7 +112,7 @@ const toggles = {
     {
       id: 'exhibitionAccessContent',
       title: 'View access content changes in Exhibitions',
-      initialValue: false,
+      initialValue: true,
       description:
         'Displays the access content changes to the Exhibition pages',
       type: 'experimental',


### PR DESCRIPTION
For #11659

## What does this change?
Turns the default toggle value `true` so that everyone gets the exhibition access content.

## How to test
n/a (this will need to be deployed manually)

## How can we measure success?
Better a11y on exhibition pages

## Have we considered potential risks?
n/a