### PR TITLE
Text change to Exhibition page title

### DIFF
--- a/content/webapp/components/Exhibition/Exhibition.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.tsx
@@ -596,7 +596,7 @@ const Exhibition: FunctionComponent<Props> = ({
               <SearchResults
                 id="events-list"
                 items={[...exhibitionOfs, ...pages]}
-                title={`In this ${exhibitionFormat.toLowerCase()}`}
+                title={`${exhibitionFormat} events`}
               />
             </Space>
           )}
@@ -755,7 +755,7 @@ const Exhibition: FunctionComponent<Props> = ({
               <SearchResults
                 id="events-list"
                 items={[...exhibitionOfs, ...pages]}
-                title={`In this ${exhibitionFormat.toLowerCase()}`}
+                title={`${exhibitionFormat} events`}
               />
             </Space>
           )}


### PR DESCRIPTION
## What does this change?

Change section title from 'In this exhibition/installation' to 'Exhibition/Installation events'

## How to test

View an [exhibition page](http://localhost:3000/exhibitions/hard-graft-work-health-and-rights)

See the title displayed correctly

## How can we measure success?


## Have we considered potential risks?

n/a
