### PR TITLE
Use status indicator text for exhibitions in content search results

### DIFF
--- a/content/webapp/components/ContentSearchResult/ContentSearchResult.tsx
+++ b/content/webapp/components/ContentSearchResult/ContentSearchResult.tsx
@@ -7,6 +7,7 @@ import { font } from '@weco/common/utils/classnames';
 import { HTMLDate } from '@weco/common/views/components/HTMLDateAndTime';
 import Space from '@weco/common/views/components/styled/Space';
 import DateRange from '@weco/content/components/DateRange/DateRange';
+import { formatDateRangeWithMessage } from '@weco/content/components/StatusIndicator/StatusIndicator';
 
 type Props = {
   uid: string | null;
@@ -74,20 +75,41 @@ const ContentSearchResult: FunctionComponent<Props> = ({
       {type !== 'Page' && <Type>{type === 'Article' ? 'Story' : type}</Type>}
       <Title>{title}</Title>
       {description ? <Description>{description}</Description> : null}
-      {dates?.end ? (
+      {type === 'Exhibition' && dates?.start && dates?.end && (
         <DatesContributors>
-          <DateRange start={new Date(dates.start)} end={new Date(dates.end)} />
+          {
+            formatDateRangeWithMessage({
+              start: new Date(dates.start),
+              end: new Date(dates.end),
+            }).text
+          }
         </DatesContributors>
-      ) : dates?.start ? (
-        <DatesContributors>
-          <HTMLDate date={new Date(dates.start)} />
-        </DatesContributors>
-      ) : null}
-      {times ? (
-        <DatesContributors>
-          <DateRange start={new Date(times.start)} end={new Date(times.end)} />
-        </DatesContributors>
-      ) : null}
+      )}
+
+      {type !== 'Exhibition' && (
+        <>
+          {dates?.end ? (
+            <DatesContributors>
+              <DateRange
+                start={new Date(dates.start)}
+                end={new Date(dates.end)}
+              />
+            </DatesContributors>
+          ) : dates?.start ? (
+            <DatesContributors>
+              <HTMLDate date={new Date(dates.start)} />
+            </DatesContributors>
+          ) : null}
+          {times ? (
+            <DatesContributors>
+              <DateRange
+                start={new Date(times.start)}
+                end={new Date(times.end)}
+              />
+            </DatesContributors>
+          ) : null}
+        </>
+      )}
       {contributors ? (
         <DatesContributors>{contributors}</DatesContributors>
       ) : null}


### PR DESCRIPTION
## What does this change?
Removes the precise dates from exhibitions in search results and replaces it with the text from the `StatusIndicator` component using the same logic (one of 'Now on', 'Past', 'Final weeks', and 'Coming soon').

__Before__
<img width="723" alt="image" src="https://github.com/user-attachments/assets/4b64d925-a7fb-4590-ade2-6e31a233251c" />


__After__
<img width="772" alt="image" src="https://github.com/user-attachments/assets/e9bed71b-d4bc-4af7-b5f9-02990ba85d20" />


It was confusing to see the end dates (or no end dates) for 'Permanent exhibitions'.

## How to test
- Search for 'Being human' – check it's 'Now on'
- Search for 'Medicine man' – check it's 'Past'
- Search for 'Zines forever' – check it's 'Coming soon'

## How can we measure success?
People aren't confused about whether an exhibition is on or not

## Have we considered potential risks?
There's less granular information in the search result (but the link to the result itself gives you all the information, so probably not a real risk)
