### PR TITLE
Codify WAF changes, increase content app task count to 6

### DIFF
--- a/content/terraform/main.tf
+++ b/content/terraform/main.tf
@@ -6,6 +6,8 @@ module "content-prod" {
   environment = data.terraform_remote_state.experience_shared.outputs.prod
   cloudfront_header_secrets = local.cloudfront_header_secrets
 
+  desired_task_count = 6
+
   container_image = local.prod_app_image
   env_suffix      = "prod"
 

--- a/content/terraform/stack/main.tf
+++ b/content/terraform/stack/main.tf
@@ -11,6 +11,8 @@ module "content-service-17092020" {
   container_image = var.container_image
   container_port  = 3000
 
+  desired_task_count = var.desired_task_count
+
   nginx_container_config = {
     image_name    = "uk.ac.wellcome/nginx_frontend"
     container_tag = "552aa56027698be94cbbf3fb206af4f3f2ba267b"

--- a/content/terraform/stack/variables.tf
+++ b/content/terraform/stack/variables.tf
@@ -35,3 +35,8 @@ variable "cloudfront_header_secrets" {
   type    = list(string)
   default = []
 }
+
+variable "desired_task_count" {
+  type   = number
+  default = 3
+}


### PR DESCRIPTION
## What does this change?

This changes removes the geo-blocks we implemented in the WAF to protect against high traffic, ensures these rules are high priority and increases the number of tasks serving the front-end in order to weather increased load.

> [!Note] 
> These terraform changes have been applied.

## How to test

- [ ] Watch the WAF dashboard for potential changes in traffic and pay attention to updown alerts.

## How can we measure success?

Less errors about outages.

## Have we considered potential risks?

This will increase cost, and may not resolve the problem. We should re-visit this configuration if we see issues.
