### PR TITLE
lambda on node20 and account for aws-sdk v3

### DIFF
--- a/cache/send_slack_alert_for_5xx_errors.js
+++ b/cache/send_slack_alert_for_5xx_errors.js
@@ -19,7 +19,7 @@
  *
  */
 
-const AWS = require('aws-sdk');
+const { S3Client, GetObjectCommand } = require('@aws-sdk/client-s3');
 const events = require('events');
 const https = require('https');
 const readline = require('readline');
@@ -43,12 +43,11 @@ const zlib = require('zlib');
  *
  */
 async function findCloudFrontHitsFromLog(bucket, key) {
-  const s3 = new AWS.S3();
+  const s3Client = new S3Client({ region: 'us-east-1' });
 
-  const input = s3
-    .getObject({ Bucket: bucket, Key: key })
-    .createReadStream()
-    .pipe(zlib.createGunzip());
+  const input = (
+    await s3Client.send(new GetObjectCommand({ Bucket: bucket, Key: key }))
+  ).Body.pipe(zlib.createGunzip());
 
   const lineReader = readline.createInterface({ input });
 

--- a/cache/send_slack_alert_for_5xx_errors.tf
+++ b/cache/send_slack_alert_for_5xx_errors.tf
@@ -3,7 +3,7 @@ module "slack_alerts_for_5xx" {
 
   source_file = "${path.module}/send_slack_alert_for_5xx_errors.js"
   handler     = "send_slack_alert_for_5xx_errors.handler"
-  runtime     = "nodejs16.x"
+  runtime     = "nodejs20.x"
 
   description = "Send alerts to Slack when there are 5xx alerts in the CloudFront logs"
   name        = "send_slack_alert_for_5xx_errors"


### PR DESCRIPTION
## What does this change?

https://github.com/wellcomecollection/platform/issues/5965
Upgrade lambda to node20 and changes related to aws-sdk  v2 -> v3
Terraform not applied (will deploy to changes) 

```
Terraform will perform the following actions:

  # module.slack_alerts_for_5xx.aws_lambda_function.lambda_function will be updated in-place
  ~ resource "aws_lambda_function" "lambda_function" {
        id                             = "send_slack_alert_for_5xx_errors"
      ~ last_modified                  = "2024-07-30T12:59:53.000+0000" -> (known after apply)
      ~ runtime                        = "nodejs16.x" -> "nodejs20.x"
      ~ source_code_hash               = "3/BZ0yK45j7KVGKl7pVCWFpNyltVRR8mioUnTuwGKrU=" -> "cliy9H2EDnl+U99BlvLOjV66rP94tyH6o0S4QECog7I="
        tags                           = {}
        # (25 unchanged attributes hidden)

        # (5 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

## How to test

The changes were tested by calling `findCloudFrontHitsFromLog` in isolation
The rest of the code is unchanged vanilla js

## How can we measure success?

5xx errors get posted to Slack
The lambda's cloudwatch logs show no error

## Have we considered potential risks?

We may miss cloudfront errors. If upgrade fails we can revert the code and runtime (node18 still available for lambdas), and reassess 

