### PR TITLE
Fix Vimeo embed for unlisted videos

### DIFF
--- a/common/views/components/VideoEmbed/VideoEmbed.tsx
+++ b/common/views/components/VideoEmbed/VideoEmbed.tsx
@@ -127,7 +127,7 @@ const VideoEmbed: FunctionComponent<Props> = ({
           ) : (
             <VideoTrigger
               onClick={() => setIsActive(true)}
-              $hasFullSizePoster={hasFullSizePoster}
+              $hasFullSizePoster={hasFullSizePoster || isVimeo}
             >
               <span className="visually-hidden">Play video</span>
               {isYouTube && <YouTubePlay />}

--- a/content/webapp/components/BslLeafletVideo/index.tsx
+++ b/content/webapp/components/BslLeafletVideo/index.tsx
@@ -78,7 +78,6 @@ const BslLeafletVideo: FunctionComponent<Props> = ({
               embedUrl={video.embedUrl}
               videoProvider={video.videoProvider}
               videoThumbnail={video.videoThumbnail}
-              hasFullSizePoster={true}
             />
             <NewWindowVideo href={video.embedUrl}>
               Open video in a new window

--- a/content/webapp/services/prismic/transformers/embeds.ts
+++ b/content/webapp/services/prismic/transformers/embeds.ts
@@ -24,11 +24,11 @@ export function transformVideoEmbed(
 }
 
 export function getVimeoEmbedUrl(embed: prismic.EmbedField): string {
-  const embedUrl = embed.html?.match(/src="([-a-zA-Z0-9://.?=_]+)?/)![1] || '';
-
+  const urlString = embed.html?.match(/src="([-a-zA-Z0-9://.?=_]+)?/)![1] || '';
+  const embedUrl = new URL(urlString);
+  const hasSearchparams = new URLSearchParams(embedUrl.search).size > 0;
   // The embed URL might already have a query ('?') and if it does we append an '&' instead
-  const hasQueryParams = embedUrl.includes('?');
-  return `${embedUrl}${hasQueryParams ? '&' : '?'}rel=0`;
+  return `${embedUrl}${hasSearchparams ? '&' : '?'}rel=0`;
 }
 
 export function getSoundCloudEmbedUrl(embed: prismic.EmbedField): string {

--- a/content/webapp/services/prismic/transformers/embeds.ts
+++ b/content/webapp/services/prismic/transformers/embeds.ts
@@ -24,9 +24,11 @@ export function transformVideoEmbed(
 }
 
 export function getVimeoEmbedUrl(embed: prismic.EmbedField): string {
-  const embedUrl = embed.html?.match(/src="([-a-zA-Z0-9://.?=_]+)?/)![1];
+  const embedUrl = embed.html?.match(/src="([-a-zA-Z0-9://.?=_]+)?/)![1] || '';
 
-  return `${embedUrl}?rel=0`;
+  // The embed URL might already have a query ('?') and if it does we append an '&' instead
+  const hasQueryParams = embedUrl.includes('?');
+  return `${embedUrl}${hasQueryParams ? '&' : '?'}rel=0`;
 }
 
 export function getSoundCloudEmbedUrl(embed: prismic.EmbedField): string {

--- a/content/webapp/services/prismic/transformers/embeds.ts
+++ b/content/webapp/services/prismic/transformers/embeds.ts
@@ -26,9 +26,10 @@ export function transformVideoEmbed(
 export function getVimeoEmbedUrl(embed: prismic.EmbedField): string {
   const urlString = embed.html?.match(/src="([-a-zA-Z0-9://.?=_]+)?/)![1] || '';
   const embedUrl = new URL(urlString);
-  const hasSearchparams = new URLSearchParams(embedUrl.search).size > 0;
-  // The embed URL might already have a query ('?') and if it does we append an '&' instead
-  return `${embedUrl}${hasSearchparams ? '&' : '?'}rel=0`;
+  // There might already be a query so we set 'rel=0' using URL.searchParams
+  // to avoid having to determine if it needs to be preceeded by a ? or an &
+  embedUrl.searchParams.set('rel', '0');
+  return embedUrl.toString();
 }
 
 export function getSoundCloudEmbedUrl(embed: prismic.EmbedField): string {


### PR DESCRIPTION
For #11452 

## What does this change?
Checks for the presence of a `?` in the `embedUrl` that is extracted by a regex. If it's there, it means there's already a query string, so future parameters (we want to add `rel=0`) should be added with an `&` instead.

<img width="556" alt="image" src="https://github.com/user-attachments/assets/5a87edde-8276-4ebe-bf67-6cf28722ea79" />

## How to test
I've added the vimeo embed referenced in the issue above to [this article](http://localhost:3000/stories/rag-mags-and-monthly-issues--five-period-zines-to-stop-you-seeing-red) in prismic stage, so update the `getRepositoryUrl` to fetch from `wellcomecollection-stage` and check that it works

## How can we measure success?
People can view embedded unlisted videos from vimeo

## Have we considered potential risks?
Can't think of any, but might be worth investigating if a similar fix needs to be implemented for YouTube/other embeds as well