### PR TITLE
Make anything previously toggled by allSearch the default

### DIFF
--- a/common/data/microcopy.tsx
+++ b/common/data/microcopy.tsx
@@ -165,8 +165,7 @@ export const pastExhibitionsStrapline =
 // This is the label used in the search box, both for the
 // search in the global nav and on the categories in wc.org/search
 export const searchLabelText = {
-  overviewAllSearch: 'Search for anything',
-  overview: 'Search our stories, images, catalogue and events',
+  overview: 'Search for anything',
   stories: 'Search for stories',
   images: 'Search for images',
   works: 'Search the catalogue',

--- a/common/views/components/Header/Header.tsx
+++ b/common/views/components/Header/Header.tsx
@@ -14,7 +14,6 @@ import { searchLabelText } from '@weco/common/data/microcopy';
 import { cross, search } from '@weco/common/icons';
 import WellcomeCollectionBlack from '@weco/common/icons/wellcome_collection_black';
 import { SiteSection } from '@weco/common/model/site-section';
-import { useToggles } from '@weco/common/server-data/Context';
 import { font } from '@weco/common/utils/classnames';
 import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
 import Icon from '@weco/common/views/components/Icon/Icon';
@@ -106,7 +105,6 @@ const Header: FunctionComponent<Props> = ({
   const [searchDropdownIsActive, setSearchDropdownIsActive] = useState(false);
   const searchButtonRef = useRef<HTMLButtonElement>(null);
   const { isEnhanced } = useContext(AppContext);
-  const { allSearch } = useToggles();
 
   useEffect(() => {
     if (document && document.documentElement) {
@@ -189,9 +187,7 @@ const Header: FunctionComponent<Props> = ({
                               icon={searchDropdownIsActive ? cross : search}
                             />
                             <span className="visually-hidden">
-                              {allSearch
-                                ? searchLabelText.overviewAllSearch
-                                : searchLabelText.overview}
+                              {searchLabelText.overview}
                             </span>
                           </NoJSIconWrapper>
                         </NextLink>

--- a/common/views/components/SearchForm/SearchForm.tsx
+++ b/common/views/components/SearchForm/SearchForm.tsx
@@ -72,11 +72,7 @@ const SearchForm = ({
         inputValue={inputValue}
         setInputValue={setInputValue}
         form={`search-form-${searchCategory}`}
-        placeholder={
-          searchLabelText[
-            searchCategory !== 'overview' ? searchCategory : 'overview'
-          ]
-        }
+        placeholder={searchLabelText[searchCategory]}
         inputRef={inputRef}
         location={location}
       />

--- a/common/views/components/SearchForm/SearchForm.tsx
+++ b/common/views/components/SearchForm/SearchForm.tsx
@@ -8,7 +8,6 @@ import {
 } from 'react';
 
 import { searchLabelText } from '@weco/common/data/microcopy';
-import { useToggles } from '@weco/common/server-data/Context';
 import { formDataAsUrlQuery } from '@weco/common/utils/forms';
 import { getQueryPropertyValue, linkResolver } from '@weco/common/utils/search';
 import SearchBar, {
@@ -43,7 +42,6 @@ const SearchForm = ({
   const router = useRouter();
   const routerQuery = getQueryPropertyValue(router?.query?.query);
   const { link: searchLink } = useContext(SearchContext);
-  const { allSearch } = useToggles();
   const initialValue =
     routerQuery || searchLink.as.query?.query?.toString() || '';
   const [inputValue, setInputValue] = useState(initialValue);
@@ -76,11 +74,7 @@ const SearchForm = ({
         form={`search-form-${searchCategory}`}
         placeholder={
           searchLabelText[
-            searchCategory !== 'overview'
-              ? searchCategory
-              : allSearch
-                ? 'overviewAllSearch'
-                : 'overview'
+            searchCategory !== 'overview' ? searchCategory : 'overview'
           ]
         }
         inputRef={inputRef}

--- a/content/webapp/components/SearchPageLayout/SearchNavigation.tsx
+++ b/content/webapp/components/SearchPageLayout/SearchNavigation.tsx
@@ -3,7 +3,6 @@ import { FunctionComponent, useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { searchLabelText } from '@weco/common/data/microcopy';
-import { useToggles } from '@weco/common/server-data/Context';
 import convertUrlToString from '@weco/common/utils/convert-url-to-string';
 import { formDataAsUrlQuery } from '@weco/common/utils/forms';
 import { capitalize } from '@weco/common/utils/grammar';
@@ -47,7 +46,6 @@ const SearchNavigation: FunctionComponent<SearchNavigationProps> = ({
   currentSearchCategory,
   currentQueryValue: queryValue,
 }) => {
-  const { allSearch } = useToggles();
   const router = useRouter();
 
   // Variable naming note:
@@ -103,7 +101,7 @@ const SearchNavigation: FunctionComponent<SearchNavigationProps> = ({
     return router.push(link.href, link.as);
   };
 
-  const allSearchItems = [
+  const tabItems = [
     {
       id: 'overview',
       url: getURL('/search'),
@@ -156,9 +154,7 @@ const SearchNavigation: FunctionComponent<SearchNavigationProps> = ({
               searchLabelText[
                 currentSearchCategory !== 'overview'
                   ? currentSearchCategory
-                  : allSearch
-                    ? 'overviewAllSearch'
-                    : 'overview'
+                  : 'overview'
               ]
             }
             form={SEARCH_PAGES_FORM_ID}
@@ -166,42 +162,12 @@ const SearchNavigation: FunctionComponent<SearchNavigationProps> = ({
           />
         </SearchBarContainer>
       </form>
-      <TabsBorder $visible={allSearch}>
+      <TabsBorder $visible={true}>
         <Tabs
           tabBehaviour="navigate"
-          hideBorder={allSearch || currentSearchCategory === 'overview'}
+          hideBorder={true}
           label="Search Categories"
-          items={
-            allSearch
-              ? allSearchItems
-              : [
-                  {
-                    id: 'overview',
-                    url: getURL('/search'),
-                    text: 'All',
-                  },
-                  {
-                    id: 'stories',
-                    url: getURL('/search/stories'),
-                    text: 'Stories',
-                  },
-                  {
-                    id: 'images',
-                    url: getURL('/search/images'),
-                    text: 'Images',
-                  },
-                  {
-                    id: 'works',
-                    url: getURL('/search/works'),
-                    text: 'Catalogue',
-                  },
-                  {
-                    id: 'events',
-                    url: getURL('/search/events'),
-                    text: 'Events',
-                  },
-                ]
-          }
+          items={tabItems}
           currentSection={currentSearchCategory}
         />
       </TabsBorder>

--- a/content/webapp/components/SearchPageLayout/SearchNavigation.tsx
+++ b/content/webapp/components/SearchPageLayout/SearchNavigation.tsx
@@ -150,13 +150,7 @@ const SearchNavigation: FunctionComponent<SearchNavigationProps> = ({
           <SearchBar
             inputValue={inputValue}
             setInputValue={setInputValue}
-            placeholder={
-              searchLabelText[
-                currentSearchCategory !== 'overview'
-                  ? currentSearchCategory
-                  : 'overview'
-              ]
-            }
+            placeholder={searchLabelText[currentSearchCategory]}
             form={SEARCH_PAGES_FORM_ID}
             location="search"
           />

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -622,9 +622,7 @@ export const getServerSideProps: GetServerSideProps<
 
     // All/Addressables
     const contentResults = await getAddressables({
-      params: {
-        ...query,
-      },
+      params: query,
       pageSize: 20,
       toggles: serverData.toggles,
     });

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -21,11 +21,7 @@ import {
   FromCodecMap,
   stringCodec,
 } from '@weco/common/utils/routes';
-import {
-  getQueryPropertyValue,
-  getQueryResults,
-  ReturnedResults,
-} from '@weco/common/utils/search';
+import { getQueryResults } from '@weco/common/utils/search';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
 import Divider from '@weco/common/views/components/Divider/Divider';
 import Icon from '@weco/common/views/components/Icon/Icon';
@@ -34,18 +30,13 @@ import { Container } from '@weco/common/views/components/styled/Container';
 import LL from '@weco/common/views/components/styled/LL';
 import Space from '@weco/common/views/components/styled/Space';
 import { NextPageWithLayout } from '@weco/common/views/pages/_app';
-import theme from '@weco/common/views/themes/default';
 import ContentSearchResult from '@weco/content/components/ContentSearchResult/ContentSearchResult';
-import EventsSearchResults from '@weco/content/components/EventsSearchResults';
 import ImageEndpointSearchResults from '@weco/content/components/ImageEndpointSearchResults/ImageEndpointSearchResults';
-import MoreLink from '@weco/content/components/MoreLink/MoreLink';
 import Pagination from '@weco/content/components/Pagination/Pagination';
 import SearchNoResults from '@weco/content/components/SearchNoResults/SearchNoResults';
 import { getSearchLayout } from '@weco/content/components/SearchPageLayout/SearchPageLayout';
 import { toLink as imagesLink } from '@weco/content/components/SearchPagesLink/Images';
 import { toLink as worksLink } from '@weco/content/components/SearchPagesLink/Works';
-import StoriesGrid from '@weco/content/components/StoriesGrid';
-import WorksSearchResults from '@weco/content/components/WorksSearchResults/WorksSearchResults';
 import useHotjar from '@weco/content/hooks/useHotjar';
 import {
   WellcomeAggregation,
@@ -55,19 +46,13 @@ import { getImages } from '@weco/content/services/wellcome/catalogue/images';
 import {
   CatalogueResultsList,
   Image,
-  toWorkBasic,
   Work,
-  WorkBasic,
 } from '@weco/content/services/wellcome/catalogue/types';
 import { getWorks } from '@weco/content/services/wellcome/catalogue/works';
 import { getAddressables } from '@weco/content/services/wellcome/content/all';
-import { getArticles } from '@weco/content/services/wellcome/content/articles';
-import { getEvents } from '@weco/content/services/wellcome/content/events';
 import {
   Addressable,
-  Article,
   ContentResultsList,
-  EventDocument,
 } from '@weco/content/services/wellcome/content/types/api';
 import { Query } from '@weco/content/types/search';
 import { cacheTTL, setCacheControl } from '@weco/content/utils/setCacheControl';
@@ -122,10 +107,6 @@ const fromQuery: (params: ParsedUrlQuery) => CodecMapProps = params => {
 };
 
 type Props = {
-  works?: ReturnedResults<WorkBasic>;
-  images?: ReturnedResults<Image>;
-  stories?: ReturnedResults<Article>;
-  events?: ReturnedResults<EventDocument>;
   contentResults?: ContentResultsList<Addressable>;
   query: Query;
   pageview: Pageview;
@@ -141,19 +122,6 @@ type ImageResults = {
 type CatalogueResults = {
   works?: WorkTypes;
   images?: ImageResults;
-};
-
-type NewProps = {
-  query: Query;
-  queryString?: string;
-  contentResults?: ContentResultsList<Addressable>;
-  contentQueryFailed?: boolean;
-};
-
-type SeeMoreButtonProps = {
-  text: string;
-  pathname: string;
-  totalResults: number;
 };
 
 const CatalogueResultsInner = styled(Space).attrs({
@@ -187,27 +155,6 @@ const BasicSection = styled(Space).attrs({
   as: 'section',
   $v: { size: 'xl', properties: ['padding-top', 'padding-bottom'] },
 })``;
-
-const StoriesSection = styled(BasicSection)`
-  background-color: ${props => props.theme.color('neutral.200')};
-`;
-
-const ImagesSection = styled(BasicSection)`
-  background-color: ${props => props.theme.color('black')};
-  color: ${props => props.theme.color('white')};
-`;
-
-const EventsSection = styled(BasicSection).attrs({
-  $v: { size: 'xl', properties: ['padding-bottom'] },
-})``;
-
-const SectionTitle = ({ sectionName }: { sectionName: string }) => {
-  return (
-    <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
-      <h3 className={font('intb', 2)}>{sectionName}</h3>
-    </Space>
-  );
-};
 
 const CatalogueSectionTitle = styled(Space).attrs<{
   $isSmallGallery?: boolean;
@@ -279,46 +226,14 @@ const LoaderContainer = styled.div<{ $fullWidth: boolean }>`
     )}
 `;
 
-const StoryPromoContainer = styled(Container)`
-  ${props =>
-    props.theme.mediaBetween(
-      'small',
-      'medium'
-    )(`
-  max-width: none;
-  width: auto;
-  overflow: auto;
-  padding: 0;
-
-  &::-webkit-scrollbar {
-    height: 18px;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    border-radius: 0;
-    border-style: solid;
-    border-width: 0 ${props.theme.containerPadding.small}px 12px;
-    background: ${props.theme.color('neutral.400')};
-  }
-`)}
-
-  -webkit-overflow-scrolling: touch;
-
-  &::-webkit-scrollbar {
-    background: ${props => props.theme.color('neutral.200')};
-  }
-
-  &::-webkit-scrollbar-thumb {
-    border-color: ${props => props.theme.color('neutral.200')};
-  }
-`;
-
-const NewSearchPage: NextPageWithLayout<NewProps> = ({
-  query,
-  queryString,
+export const SearchPage: NextPageWithLayout<Props> = ({
   contentResults,
   contentQueryFailed,
+  query,
 }) => {
+  useHotjar(true);
+
+  const { query: queryString } = query;
   const { extraApiToolbarLinks, setExtraApiToolbarLinks } =
     useContext(SearchContext);
   const { apiToolbar } = useToggles();
@@ -659,144 +574,6 @@ const NewSearchPage: NextPageWithLayout<NewProps> = ({
   );
 };
 
-export const SearchPage: NextPageWithLayout<Props> = ({
-  contentResults,
-  contentQueryFailed,
-  works,
-  images,
-  stories,
-  events,
-  query,
-}) => {
-  useHotjar(true);
-  const { query: queryString } = query;
-  const { allSearch } = useToggles();
-
-  if (allSearch) {
-    return (
-      <NewSearchPage
-        query={query}
-        queryString={queryString}
-        contentResults={contentResults}
-        contentQueryFailed={contentQueryFailed}
-      />
-    );
-  }
-
-  const SeeMoreButton = ({
-    text,
-    pathname,
-    totalResults,
-  }: SeeMoreButtonProps) => (
-    <MoreLink
-      name={`${text} (${formatNumber(totalResults, {
-        isCompact: true,
-      })})`}
-      url={{
-        href: {
-          pathname,
-          query: { ...(queryString && { query: queryString }) },
-        },
-      }}
-      colors={theme.buttonColors.yellowYellowBlack}
-    />
-  );
-
-  return (
-    <main>
-      {!stories && !images && !works ? (
-        <Container>
-          <SearchNoResults query={queryString} />
-        </Container>
-      ) : (
-        <>
-          {stories && (
-            <StoriesSection>
-              <Container>
-                <SectionTitle sectionName="Stories" />
-              </Container>
-              <StoryPromoContainer>
-                <StoriesGrid
-                  articles={stories.pageResults}
-                  dynamicImageSizes={{
-                    xlarge: 1 / 5,
-                    large: 1 / 5,
-                    medium: 1 / 2,
-                    small: 1 / 2,
-                  }}
-                />
-              </StoryPromoContainer>
-              <Container>
-                <Space $v={{ size: 'l', properties: ['padding-top'] }}>
-                  <SeeMoreButton
-                    text="All stories"
-                    pathname="/search/stories"
-                    totalResults={stories.totalResults}
-                  />
-                </Space>
-              </Container>
-            </StoriesSection>
-          )}
-
-          {images && (
-            <ImagesSection>
-              <Container>
-                <SectionTitle sectionName="Images" />
-
-                <ImageEndpointSearchResults images={images.pageResults} />
-
-                <Space $v={{ size: 'l', properties: ['padding-top'] }}>
-                  <SeeMoreButton
-                    text="All images"
-                    pathname="/search/images"
-                    totalResults={images.totalResults}
-                  />
-                </Space>
-              </Container>
-            </ImagesSection>
-          )}
-
-          {works && (
-            <BasicSection>
-              <Container>
-                <SectionTitle sectionName="Catalogue" />
-
-                <WorksSearchResults works={works.pageResults} />
-
-                <Space $v={{ size: 'l', properties: ['padding-top'] }}>
-                  <SeeMoreButton
-                    text="All works"
-                    pathname="/search/works"
-                    totalResults={works.totalResults}
-                  />
-                </Space>
-              </Container>
-            </BasicSection>
-          )}
-
-          {events && (
-            <EventsSection>
-              <Container>
-                <SectionTitle sectionName="Events" />
-
-                <EventsSearchResults events={events.pageResults} />
-
-                <Space $v={{ size: 'l', properties: ['padding-top'] }}>
-                  <SeeMoreButton
-                    text="All events"
-                    pathname="/search/events"
-                    totalResults={events.totalResults}
-                  />
-                </Space>
-              </Container>
-            </EventsSection>
-          )}
-        </>
-      )}
-    </main>
-  );
-};
-
 SearchPage.getLayout = getSearchLayout;
 
 export const getServerSideProps: GetServerSideProps<
@@ -805,7 +582,6 @@ export const getServerSideProps: GetServerSideProps<
   setCacheControl(context.res, cacheTTL.search);
   const serverData = await getServerData(context);
   const query = context.query;
-  const params = fromQuery(query);
 
   const pageview: Pageview = {
     name: 'search',
@@ -842,137 +618,39 @@ export const getServerSideProps: GetServerSideProps<
   }
 
   try {
-    let contentResults:
-        | ContentResultsList<Addressable>
-        | WellcomeApiError
-        | undefined,
-      stories: ReturnedResults<Article> | undefined,
-      events: ReturnedResults<EventDocument> | undefined,
-      works: ReturnedResults<Work> | undefined,
-      images: ReturnedResults<Image> | undefined;
     let contentQueryFailed = false;
-    if (serverData.toggles.allSearch.value) {
-      // All/Addressables
-      contentResults = await getAddressables({
-        params: {
-          ...query,
-        },
-        pageSize: 20,
-        toggles: serverData.toggles,
-      });
 
-      if (contentResults.type === 'Error') {
-        contentQueryFailed = true;
-        console.error(contentResults.label + ': Error fetching addressables');
-      }
-    } else {
-      // Stories
-      // We want the default order to be "descending publication date" with the Content API
-      const storiesResults = await getArticles({
-        params: {
-          ...query,
-          sort: getQueryPropertyValue(query.sort),
-          sortOrder: getQueryPropertyValue(query.sortOrder),
-        },
-        pageSize: 4,
-        toggles: serverData.toggles,
-      });
+    // All/Addressables
+    const contentResults = await getAddressables({
+      params: {
+        ...query,
+      },
+      pageSize: 20,
+      toggles: serverData.toggles,
+    });
 
-      if (storiesResults.type === 'Error') contentQueryFailed = true;
-
-      stories = getQueryResults({
-        categoryName: 'stories',
-        queryResults: storiesResults as
-          | ContentResultsList<Article>
-          | WellcomeApiError,
-      });
-
-      // Events
-      const eventsResults = await getEvents({
-        params: {
-          ...query,
-          sort: getQueryPropertyValue(query.sort),
-          sortOrder: getQueryPropertyValue(query.sortOrder),
-        },
-        pageSize: 3,
-        toggles: serverData.toggles,
-      });
-
-      if (eventsResults.type === 'Error') contentQueryFailed = true;
-
-      events = getQueryResults({
-        categoryName: 'events',
-        queryResults: eventsResults as
-          | ContentResultsList<EventDocument>
-          | WellcomeApiError,
-      });
-
-      // Works
-      const worksResults = await getWorks({
-        params,
-        pageSize: 5,
-        toggles: serverData.toggles,
-      });
-      works = getQueryResults({
-        categoryName: 'works',
-        queryResults: worksResults,
-      });
-
-      // Images
-      const imagesResults = await getImages({
-        params,
-        pageSize: 10,
-        toggles: serverData.toggles,
-      });
-      images = getQueryResults({
-        categoryName: 'images',
-        queryResults: imagesResults,
-      });
-
-      // If all three queries fail, return an error page
-      if (
-        imagesResults.type === 'Error' &&
-        worksResults.type === 'Error' &&
-        contentQueryFailed
-      ) {
-        // Use the error from the works API as it is the most mature of the 3
-        return appError(
-          context,
-          worksResults.httpStatus,
-          worksResults.description || worksResults.label
-        );
-      }
+    if (contentResults.type === 'Error') {
+      contentQueryFailed = true;
+      console.error(contentResults.label + ': Error fetching addressables');
     }
 
-    const apiToolbarLinks = serverData.toggles.allSearch.value
-      ? [
-          contentResults && contentResults.type !== 'Error'
-            ? {
-                id: 'content-api',
-                label: 'Content API query',
-                link: contentResults._requestUrl,
-              }
-            : undefined,
-        ].filter(isNotUndefined)
-      : [];
+    const apiToolbarLinks = [
+      contentResults && contentResults.type !== 'Error'
+        ? {
+            id: 'content-api',
+            label: 'Content API query',
+            link: contentResults._requestUrl,
+          }
+        : undefined,
+    ].filter(isNotUndefined);
 
     return {
       props: serialiseProps({
         ...defaultProps,
-        ...(stories && stories.pageResults?.length && { stories }),
-        ...(images?.pageResults.length && { images }),
-        ...(events?.pageResults.length && { events }),
         ...(contentResults?.type !== 'Error' && {
           contentResults,
         }),
         contentQueryFailed,
-        works:
-          works && works.pageResults.length
-            ? {
-                ...works,
-                pageResults: works.pageResults.map(toWorkBasic),
-              }
-            : undefined,
         apiToolbarLinks,
       }),
     };

--- a/playwright/test/helpers/contexts.ts
+++ b/playwright/test/helpers/contexts.ts
@@ -83,10 +83,6 @@ const stageApiToggleCookie = createCookie({
   name: 'toggle_stagingApi',
   value: 'true',
 });
-const allSearchCookie = createCookie({
-  name: 'toggle_allSearch',
-  value: 'true',
-});
 
 export const requiredCookies = useStageApis
   ? [acceptCookieCookie, stageApiToggleCookie]
@@ -224,7 +220,7 @@ const search = async (
     | 'images'
     | 'works' = 'overview'
 ): Promise<void> => {
-  await context.addCookies([...requiredCookies, allSearchCookie]);
+  await context.addCookies(requiredCookies);
 
   const searchUrl = `search${
     searchType === 'overview' ? `` : `/${searchType}`

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -95,13 +95,6 @@ const toggles = {
       type: 'experimental',
     },
     {
-      id: 'allSearch',
-      title: 'Modified All search page',
-      initialValue: false,
-      description: 'Displays a new version of the "all" search (/search)',
-      type: 'experimental',
-    },
-    {
       id: 'extendedViewer',
       title: 'Allow viewer to render video, audio and pdfs',
       initialValue: false,


### PR DESCRIPTION
For [#233](https://github.com/wellcomecollection/content-api/issues/233)

## What does this change?
Removes all references to `allSearch` and makes the previously toggled behaviour the default (and removing the old code)

Note: github has hidden the diff for search/index.tsx but it definitely needs reviewing

## How to test
Search for something and check that the new search works

## How can we measure success?
Less code to maintain

## Have we considered potential risks?
Can't think of any

