### PR TITLE
Prevent pixelated image for youtube placeholder

### DIFF
--- a/common/views/slices/Embed/index.tsx
+++ b/common/views/slices/Embed/index.tsx
@@ -23,10 +23,7 @@ const EmbedSlice: FunctionComponent<EmbedProps> = ({ slice, context }) => {
       {transformedSlice.type === 'videoEmbed' && (
         <SpacingComponent $sliceType={transformedSlice.type}>
           <LayoutWidth width={options.isShortFilm ? 12 : options.minWidth}>
-            <VideoEmbed
-              {...transformedSlice.value}
-              hasFullSizePoster={options.isShortFilm}
-            />
+            <VideoEmbed {...transformedSlice.value} hasFullSizePoster={true} />
           </LayoutWidth>
         </SpacingComponent>
       )}


### PR DESCRIPTION
## What does this change?

We had a [report of pixelated images](https://wellcome.slack.com/archives/C8X9YKM5X/p1741947199376929) for youtube embeds. This fixes that

## How to test

- vist http://localhost:3000/stories/ballet-beauty-and-the-joy-of-wheelchair-dance
- see the placeholder image for the youtube embed is not pixelated

## How can we measure success?

Users aren't presented with pixelated images

## Have we considered potential risks?

This is a blanket change for youtube videos in the body of a prismic page. I think that makes sense, but it may be that it causes us to load larger images than necessary under certain circumstances. I'm going to put this in as it is required for a story being published first thing on Monday, but I would like to sense check with @davidpmccormick and @rcantin-w and maybe revisit if necessary.
