### PR TITLE
Accessibility resources text changes

### DIFF
--- a/common/data/microcopy.tsx
+++ b/common/data/microcopy.tsx
@@ -67,7 +67,7 @@ export const a11y = {
   stepFreeAccess: 'Step-free access is available to all floors of the building',
   largePrintGuides:
     'Large-print guides, transcripts and magnifiers are available in the gallery',
-  bsl: 'British Sign Language videos and tours are available',
+  bsl: 'British Sign Language videos are available',
   accessResources:
     'Access resources include a visual story, large print guides and audio description',
 

--- a/content/webapp/components/Exhibition/Exhibition.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.tsx
@@ -330,11 +330,7 @@ const Exhibition: FunctionComponent<Props> = ({
       summary: 'BSL, transcripts and induction loops',
       content: (
         <ul>
-          <li>Audiovisual content is available in BSL in the gallery</li>
-          <li>
-            Live BSL tours are available. See our exhibition events above for
-            more information or contact us in advance to request a tour
-          </li>
+          <li>BSL content is available in the gallery</li>
           {bslTourLink && (
             <li>
               <NextLink href={bslTourLink}>
@@ -393,15 +389,6 @@ const Exhibition: FunctionComponent<Props> = ({
             A large-print guide and magnifiers are available in the gallery
           </li>
           <li>There is a tactile line on the gallery floor</li>
-          <li>
-            There are brighter and more even lighting conditions across the
-            gallery during our Lights Up sessions.{' '}
-            {exhibitionOfs.length > 0 && (
-              <NextLink href="#events-list">
-                See our exhibition events for more information and availability
-              </NextLink>
-            )}
-          </li>
         </ul>
       ),
     },
@@ -441,14 +428,6 @@ const Exhibition: FunctionComponent<Props> = ({
           <li>
             Weekday mornings and Thursday evenings are usually the quietest
             times to visit
-          </li>
-          <li>
-            Additional support is available during our Relaxed Openings.{' '}
-            {exhibitionOfs.length > 0 && (
-              <NextLink href="#events-list">
-                See our exhibition events for more information and availability
-              </NextLink>
-            )}
           </li>
         </ul>
       ),

--- a/content/webapp/components/Exhibition/Exhibition.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.tsx
@@ -546,26 +546,7 @@ const Exhibition: FunctionComponent<Props> = ({
             <InfoBox
               title="Visit us"
               items={getInfoItems(exhibition, exhibitionAccessContent)}
-            >
-              <AccessibilityServices>
-                For more information, please visit our{' '}
-                <a href={`/visit-us/${prismicPageIds.access}`}>Accessibility</a>{' '}
-                page. If you have any queries about accessibility, please email
-                us at{' '}
-                <a href="mailto:access@wellcomecollection.org">
-                  access@wellcomecollection.org
-                </a>{' '}
-                or call{' '}
-                {/*
-                  This is to ensure phone numbers are read in a sensible way by
-                  screen readers.
-                */}
-                <span className="visually-hidden">
-                  {createScreenreaderLabel('020 7611 2222')}
-                </span>
-                <span aria-hidden="true">020&nbsp;7611&nbsp;2222.</span>
-              </AccessibilityServices>
-            </InfoBox>
+            />
           )}
 
           {(exhibitionOfs.length > 0 || pages.length > 0) && (

--- a/content/webapp/components/Exhibition/Exhibition.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.tsx
@@ -623,7 +623,7 @@ const Exhibition: FunctionComponent<Props> = ({
                 className={font('intb', 4)}
                 $v={{ size: 'l', properties: ['margin-bottom'] }}
               >
-                Access information and queries
+                Access information, tours and queries
               </Space>
               <Contact
                 link={{


### PR DESCRIPTION
## What does this change?

For #11694

## How to test

- View [an exhibition page](http://localhost:3000/events/lights-up-on-hard-graft) with the exhibitionAccessContent toggle enabled, make sure the text matches what is described in the above issue.

## How can we measure success?

n/a

## Have we considered potential risks?

None really

