### PR TITLE
Centre the status indicator dot with its text

### DIFF
--- a/content/webapp/components/TextWithDot/Dot.tsx
+++ b/content/webapp/components/TextWithDot/Dot.tsx
@@ -2,14 +2,15 @@ import styled from 'styled-components';
 
 import { PaletteColor } from '@weco/common/views/themes/config';
 
-const Dot = styled.span.attrs({
+const Dot = styled.div.attrs({
   'aria-hidden': true,
 })<{ $dotColor: PaletteColor }>`
-  font-size: 0.7em;
-  color: ${props => props.theme.color(props.$dotColor)};
-
   &::before {
-    content: '⬤';
+    display: block;
+    border: 6px solid;
+    border-radius: 50%;
+    content: '';
+    border-color: ${props => props.theme.color(props.$dotColor)};
   }
 `;
 

--- a/content/webapp/components/TextWithDot/index.tsx
+++ b/content/webapp/components/TextWithDot/index.tsx
@@ -14,10 +14,7 @@ const Wrapper = styled.span`
 const DotWrapper = styled(Space).attrs({
   as: 'span',
   $h: { size: 'xs', properties: ['margin-right'] },
-})`
-  display: flex;
-  align-items: center;
-`;
+})``;
 
 type Props = { dotColor: PaletteColor; text: string; className?: string };
 


### PR DESCRIPTION
## What does this change?

The dots in the status indicator don't quite line up correctly with their accompanying text.

This fixes that.

Before:
![before](https://github.com/user-attachments/assets/862b9c7f-3057-473d-ac90-03b2143f9dae)

After:
<img width="1247" alt="Screenshot 2025-03-19 at 11 41 15" src="https://github.com/user-attachments/assets/b82197e5-25e7-4ef3-a986-fa99461832bd" />

## How to test

Visit [a page with status indicators on it](http://localhost:3000/whats-on) and see that the dot aligns correctly with the text

## How can we measure success?
n/a

## Have we considered potential risks?

none really
