### PR TITLE
Remove exhibition/event access info from footer

### DIFF
--- a/common/views/components/FindUs/FindUs.tsx
+++ b/common/views/components/FindUs/FindUs.tsx
@@ -40,7 +40,7 @@ const FindUs: FunctionComponent<Props> = ({ hideAccessibility }) => (
         {wellcomeCollectionAddress.postalCode}
       </PlainLink>
     </Space>
-    <p>
+    <Space as="p" $v={{ size: 'm', properties: ['margin-bottom'] }}>
       <PlainLink
         href={`tel:${wellcomeCollectionGallery.telephone.replace(/\s/g, '')}`}
         aria-label={createScreenreaderLabel(
@@ -53,7 +53,7 @@ const FindUs: FunctionComponent<Props> = ({ hideAccessibility }) => (
       <a href="mailto:info@wellcomecollection.org">
         info@wellcomecollection.org
       </a>
-    </p>
+    </Space>
     <PlainList>
       <Space as="li" $v={{ size: 's', properties: ['padding-bottom'] }}>
         <a href={`/visit-us/${prismicPageIds.gettingHere}`}>Getting here</a>
@@ -63,7 +63,7 @@ const FindUs: FunctionComponent<Props> = ({ hideAccessibility }) => (
           as="li"
           $v={{ size: 's', properties: ['padding-top', 'padding-bottom'] }}
         >
-          <a href={`/visit-us/${prismicPageIds.access}`}>Accessibility</a>
+          <a href={`/visit-us/${prismicPageIds.access}`}>Access information</a>
         </Space>
       )}
     </PlainList>

--- a/common/views/components/Footer/Footer.A11y.tsx
+++ b/common/views/components/Footer/Footer.A11y.tsx
@@ -1,13 +1,7 @@
 import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
-import {
-  accessibleSquare,
-  audioDescribedSquare,
-  bslSquare,
-  closedCaptioningSquare,
-  inductionLoopSquare,
-} from '@weco/common/icons';
+import { accessibleSquare, inductionLoopSquare } from '@weco/common/icons';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import PlainList from '@weco/common/views/components/styled/PlainList';
 import Space from '@weco/common/views/components/styled/Space';
@@ -60,35 +54,6 @@ const FooterA11y: FunctionComponent = () => {
             <Icon icon={inductionLoopSquare} />
           </IconWrap>
           <span>Hearing loops</span>
-        </Li>
-      </PlainList>
-      <Space $v={{ size: 'm', properties: ['margin-top'] }}>
-        <Space
-          style={{ font: 'unset' }}
-          $v={{ size: 's', properties: ['margin-bottom'] }}
-          as="h4"
-        >
-          Our exhibitions and events include:
-        </Space>
-      </Space>
-      <PlainList>
-        <Li>
-          <IconWrap>
-            <Icon icon={bslSquare} />
-          </IconWrap>
-          <span>British Sign Language</span>
-        </Li>
-        <Li>
-          <IconWrap>
-            <Icon icon={audioDescribedSquare} />
-          </IconWrap>
-          <span>Audio description</span>
-        </Li>
-        <Li>
-          <IconWrap>
-            <Icon icon={closedCaptioningSquare} />
-          </IconWrap>
-          <span>Captions</span>
         </Li>
       </PlainList>
       <Space as="p" $v={{ size: 'm', properties: ['margin-top'] }}>

--- a/common/views/components/Footer/Footer.A11y.tsx
+++ b/common/views/components/Footer/Footer.A11y.tsx
@@ -54,8 +54,12 @@ const FooterA11y: FunctionComponent = () => {
           <span>Hearing loops</span>
         </Li>
       </PlainList>
-      <Space as="p" $v={{ size: 'm', properties: ['margin-top'] }}>
-        <a href="/visit-us/accessibility">Accessibility</a>
+      <Space
+        as="p"
+        $v={{ size: 'm', properties: ['margin-top'] }}
+        style={{ marginBottom: 0 }}
+      >
+        <a href="/visit-us/accessibility">Access information</a>
       </Space>
     </div>
   );

--- a/common/views/components/Footer/Footer.A11y.tsx
+++ b/common/views/components/Footer/Footer.A11y.tsx
@@ -26,8 +26,6 @@ const IconWrap = styled(Space).attrs({
   border-radius: 6px;
 
   .icon {
-    width: 32px;
-    height: 32px;
     color: ${props => props.theme.color('white')};
   }
 `;

--- a/common/views/components/Footer/Footer.Social.tsx
+++ b/common/views/components/Footer/Footer.Social.tsx
@@ -27,15 +27,6 @@ const Cell = styled(Space).attrs({
     color: ${props => props.theme.color('neutral.200')};
     background-color: ${props => props.theme.color('black')};
   }
-
-  ${props =>
-    props.$exhibitionAccessContent &&
-    props.theme.mediaBetween(
-      'small',
-      'large'
-    )(`
-    margin-right: 0;
-  `)}
 `;
 
 const Link = styled(Space).attrs({

--- a/common/views/components/Footer/FooterWithA11y.tsx
+++ b/common/views/components/Footer/FooterWithA11y.tsx
@@ -42,12 +42,13 @@ const FooterNavigationContainer = styled(Space).attrs({
 
   ${props => props.theme.media('medium')`
     grid-template-columns: repeat(2, 1fr);
+    grid-gap: 3rem;
+
   `}
 
   ${props => props.theme.media('xlarge')`
     grid-template-columns: repeat(4, 1fr);
     grid-gap: 2rem;
-
   `}
 `;
 
@@ -204,8 +205,9 @@ const Footer: FunctionComponent<Props> = ({ venues }: Props) => {
               as="p"
               $v={{
                 size: 'm',
-                properties: [hasVenuesInfo ? 'margin-top' : 'margin-bottom'],
+                properties: hasVenuesInfo ? ['margin-top'] : [],
               }}
+              style={{ marginBottom: 0 }}
             >
               <a href={`/visit-us/${prismicPageIds.openingTimes}`}>
                 Opening times

--- a/common/views/components/Footer/FooterWithA11y.tsx
+++ b/common/views/components/Footer/FooterWithA11y.tsx
@@ -63,9 +63,7 @@ const PoliciesAndSocials = styled(Space).attrs({
       'medium',
       'large'
     )(`
-    display: grid;
-    grid-gap: 4rem;
-    grid-template-columns: 1fr 1fr;
+    display: block;
   `)}
 `;
 
@@ -107,7 +105,9 @@ const FullWidthDivider = styled(Space).attrs({
   $v: { size: 'm', properties: ['margin-bottom'] },
 })``;
 
-const PoliciesContainer = styled(Space)`
+const PoliciesContainer = styled(Space).attrs({
+  $v: { size: 'm', properties: ['margin-bottom', 'margin-bottom'] },
+})`
   flex: 1 1 50%;
 
   ${props => props.theme.media('medium')`
@@ -116,16 +116,12 @@ const PoliciesContainer = styled(Space)`
     flex-wrap: wrap;
     flex: 1 1 30%;
   `}
-
-  ${props => props.theme.media('large')`
-    margin-top: 1rem;
-    `}
 `;
 
 const SocialsContainer = styled(Space)`
   display: flex;
   flex-wrap: wrap;
-  justify-content: space-between;
+  justify-content: flex-start;
   align-items: center;
   align-self: flex-start;
   flex: 1 1 100%;
@@ -134,18 +130,17 @@ const SocialsContainer = styled(Space)`
   ${props => props.theme.media('medium')`
     flex: 0 1 auto;
     margin: 0;
-    `}
+  `}
 
   ${props => props.theme.media('large')`
     flex: 0 1 100%;
-    justify-content: flex-end;
-    margin-top: 1rem;
-    `}
+  `}
 
   ${props => props.theme.media('xlarge')`
     flex: 0 1 auto;
+    justify-content: flex-end;
     justify-content: space-between;
-    `}
+  `}
 `;
 /** ********************** */
 // END OF FOOTER BODY STYLES

--- a/common/views/components/Footer/FooterWithA11y.tsx
+++ b/common/views/components/Footer/FooterWithA11y.tsx
@@ -30,21 +30,18 @@ const Wrapper = styled(Space).attrs({
   color: ${props => props.theme.color('white')};
 `;
 
-const FooterBasicSection = styled(Space).attrs({
-  $v: { size: 'l', properties: ['padding-bottom'] },
-})``;
-
 /** ************************ */
 // START OF FOOTER BODY STYLES
 /** ************************ */
 
-const FooterNavigationContainer = styled(FooterBasicSection)`
+const FooterNavigationContainer = styled(Space).attrs({
+  $v: { size: 'l', properties: ['margin-bottom'] },
+})`
   display: grid;
   grid-gap: 2rem;
 
   ${props => props.theme.media('medium')`
     grid-template-columns: repeat(2, 1fr);
-    grid-gap: 4rem;
   `}
 
   ${props => props.theme.media('xlarge')`
@@ -54,7 +51,9 @@ const FooterNavigationContainer = styled(FooterBasicSection)`
   `}
 `;
 
-const PoliciesAndSocials = styled(FooterBasicSection)`
+const PoliciesAndSocials = styled(Space).attrs({
+  $v: { size: 'l', properties: ['margin-bottom'] },
+})`
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
@@ -70,9 +69,7 @@ const PoliciesAndSocials = styled(FooterBasicSection)`
   `)}
 `;
 
-const FindUsContainer = styled(Space).attrs({
-  $v: { size: 'l', properties: ['padding-bottom'] },
-})`
+const FindUsContainer = styled.div`
   flex: 1 1 100%;
 
   ${props => props.theme.media('medium')`
@@ -85,7 +82,7 @@ const FindUsContainer = styled(Space).attrs({
     `}
 `;
 
-const OpeningTimesContainer = styled(FooterBasicSection)`
+const OpeningTimesContainer = styled.div`
   flex: 1 1 100%;
 
   ${props => props.theme.media('medium')`
@@ -98,7 +95,7 @@ const OpeningTimesContainer = styled(FooterBasicSection)`
   `}
 `;
 
-const InternalNavigationContainer = styled(FooterBasicSection)`
+const InternalNavigationContainer = styled.div`
   flex: 1 1 50%;
 
   ${props => props.theme.media('medium')`
@@ -107,10 +104,8 @@ const InternalNavigationContainer = styled(FooterBasicSection)`
 `;
 
 const FullWidthDivider = styled(Space).attrs({
-  className: 'is-hidden-s is-hidden-m',
-})`
-  flex: 1 1 100%;
-`;
+  $v: { size: 'm', properties: ['margin-bottom'] },
+})``;
 
 const PoliciesContainer = styled(Space)`
   flex: 1 1 50%;
@@ -192,9 +187,9 @@ const Footer: FunctionComponent<Props> = ({ venues }: Props) => {
   return (
     <Wrapper ref={footer}>
       <Container>
-        <FooterBasicSection as="h3">
+        <h3>
           <FooterWellcomeLogo />
-        </FooterBasicSection>
+        </h3>
 
         <FooterNavigationContainer>
           <FindUsContainer>
@@ -233,11 +228,11 @@ const Footer: FunctionComponent<Props> = ({ venues }: Props) => {
           </InternalNavigationContainer>
         </FooterNavigationContainer>
 
-        <PoliciesAndSocials>
-          <FullWidthDivider>
-            <Divider lineColor="neutral.700" />
-          </FullWidthDivider>
+        <FullWidthDivider>
+          <Divider lineColor="neutral.700" />
+        </FullWidthDivider>
 
+        <PoliciesAndSocials>
           <PoliciesContainer>
             <FooterNav
               isInline


### PR DESCRIPTION
## What does this change?
Removes exhibition/event access info from the footer because there wasn't a way to display it succinctly enough.

<img width="1176" alt="image" src="https://github.com/user-attachments/assets/73168b96-0a54-40b1-9cd1-a045b3f6dd39" />


## How to test
Footer looks like the screenshot and [designs](https://www.figma.com/design/juZQR2wi2BsYG8TDH6R4uk/Wellcome-Collection-%E2%80%93-Styles-and-Component-Library?node-id=3535-8488&m=dev)

## How can we measure success?
n/a

## Have we considered potential risks?
n/a