### PR TITLE
Add back failing concepts e2e test

### DIFF
--- a/playwright/test/concept.test.ts
+++ b/playwright/test/concept.test.ts
@@ -40,35 +40,34 @@ const test = base.extend<{
   },
 });
 
-// TODO: Temporarily commenting out this test to prevent a deployment deadlock. See: https://wellcome.slack.com/archives/C02ANCYL90E/p1742487720513519?thread_ts=1742485792.254039&cid=C02ANCYL90E
-// test.describe('a Concept representing an Agent with no Images', () => {
-//   test('only has works tabs', async ({ thackrahPage }) => {
-//     // It has two tabs for works
-//     await expect(thackrahPage.worksAboutTab).toBeVisible();
-//     await expect(thackrahPage.worksByTab).toBeVisible();
-//
-//     // and has no images tabs
-//     await expect(thackrahPage.imagesTabGroup).not.toBeAttached();
-//
-//     // The "works by" panel should be visible initially
-//     await expect(thackrahPage.worksByTabPanel).toBeVisible();
-//     // Live data is used in this test, so the actual number is not guaranteed
-//     // to remain stable. Hence asserting that it is not zero.
-//     await expect(
-//       thackrahPage.worksByTabPanel.getByRole('listitem')
-//     ).not.toHaveCount(0);
-//
-//     // The "works about" panel is not expected to be seen ...
-//     await expect(thackrahPage.worksAboutTabPanel).not.toBeVisible();
-//     // Until the "works about" tab is clicked
-//     await thackrahPage.worksAboutTab.click();
-//     // The works about panel is expected to contain a list of works about the concept (spookily enough)
-//     // This list is expected to be populated.
-//     await expect(
-//       thackrahPage.worksAboutTabPanel.getByRole('listitem')
-//     ).not.toHaveCount(0);
-//   });
-// });
+test.describe('a Concept representing an Agent with no Images', () => {
+  test('only has works tabs', async ({ thackrahPage }) => {
+    // It has two tabs for works
+    await expect(thackrahPage.worksAboutTab).toBeVisible();
+    await expect(thackrahPage.worksByTab).toBeVisible();
+
+    // and has no images tabs
+    await expect(thackrahPage.imagesTabGroup).not.toBeAttached();
+
+    // The "works by" panel should be visible initially
+    await expect(thackrahPage.worksByTabPanel).toBeVisible();
+    // Live data is used in this test, so the actual number is not guaranteed
+    // to remain stable. Hence asserting that it is not zero.
+    await expect(
+      thackrahPage.worksByTabPanel.getByRole('listitem')
+    ).not.toHaveCount(0);
+
+    // The "works about" panel is not expected to be seen ...
+    await expect(thackrahPage.worksAboutTabPanel).not.toBeVisible();
+    // Until the "works about" tab is clicked
+    await thackrahPage.worksAboutTab.click();
+    // The works about panel is expected to contain a list of works about the concept (spookily enough)
+    // This list is expected to be populated.
+    await expect(
+      thackrahPage.worksAboutTabPanel.getByRole('listitem')
+    ).not.toHaveCount(0);
+  });
+});
 
 test.describe('a Concept representing an Agent with Works and Images both about and by them', () => {
   test('has both works and image sections, each with about and by tabs', async ({


### PR DESCRIPTION
## What does this change?

Adds back a failing e2e test. We should be able to merge this right after deploying the new concepts API to production. See https://wellcome.slack.com/archives/C02ANCYL90E/p1742485792254039 for more info.

