### PR TITLE
Civic UK: Change config to match new licence

### DIFF
--- a/common/views/components/CivicUK/index.tsx
+++ b/common/views/components/CivicUK/index.tsx
@@ -96,9 +96,8 @@ const CivicUK = ({ apiKey }: { apiKey: string }) => (
     <script
       dangerouslySetInnerHTML={{
         __html: `CookieControl.load({
-            product: 'COMMUNITY',
+            product: 'PRO_MULTISITE',
             apiKey: '${apiKey}',
-            product: 'pro',
             initialState: 'notify',
             consentCookieExpiry: 182,
             layout: 'popup',


### PR DESCRIPTION
## What does this change?

[#11726](https://github.com/wellcomecollection/wellcomecollection.org/issues/11726)

Look at description there for process; because they key gets passed in at build time, if we change it in AWS as we deploy this change, it should ensure that nothing gets broken along the way. The old prod build will still be using the old config and secret value up until we rebuild it with everything it needs to work with the new one.

## How to test

Run this branch locally. In your `.env` files (content and identity), change the value for `NEXT_PUBLIC_CIVICUK_API_KEY` to match the new licence (available in Civic UK - let me know if you need access).
Ensure you don't have a `CookieControl` cookie set, or delete it. On load, the banner should show up both in the content app and the identity side.

## How can we measure success?

It works :)

## Have we considered potential risks?

I've tested changing the secret already (and then reverted). It did not break production.
