### PR TITLE
Access resources tweaks

### DIFF
--- a/common/data/microcopy.tsx
+++ b/common/data/microcopy.tsx
@@ -210,4 +210,4 @@ export const restrictedItemMessage = (
 );
 
 export const accessibilityProvisionText =
-  'Our building has step-free access. All exhibitions offer BSL, Audio Description, and Hearing Loop support.';
+  'Our building has step-free access. Exhibitions include audio description, British Sign Language and captions.';

--- a/common/views/components/AccessibilityProvision/AccessibilityProvision.tsx
+++ b/common/views/components/AccessibilityProvision/AccessibilityProvision.tsx
@@ -6,7 +6,7 @@ import {
   accessibleSquare,
   audioDescribedSquare,
   bslSquare,
-  inductionLoopSquare,
+  closedCaptioningSquare,
 } from '@weco/common/icons';
 import { useToggles } from '@weco/common/server-data/Context';
 import { font } from '@weco/common/utils/classnames';
@@ -57,7 +57,7 @@ const AccessibilityProvision: FunctionComponent<Props> = ({
         <Icon icon={accessibleSquare} />
         <Icon icon={bslSquare} />
         <Icon icon={audioDescribedSquare} />
-        <Icon icon={inductionLoopSquare} />
+        <Icon icon={closedCaptioningSquare} />
       </IconsContainer>
       <Text
         className={!showText ? `visually-hidden` : font('intr', 5)}


### PR DESCRIPTION
## What does this change?

 For [#11720](https://github.com/wellcomecollection/wellcomecollection.org/issues/11720)

Makes the changes described in the issue

## How to test

- Enable the exhibitionAccessContent toggle
- view the [homepage](http://localhost:3000), [what's on page](http://localhost:3000/whats-on) and an [exhibition page](http://localhost:3000/exhibitions/hard-graft-work-health-and-rights) and check the copy and the icons are correct

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
n/a

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? -->
n/a
