### PR TITLE
Don’t show access content on being human exhibition

### DIFF
--- a/content/webapp/components/Exhibition/Exhibition.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.tsx
@@ -548,7 +548,7 @@ const Exhibition: FunctionComponent<Props> = ({
       // We hide contributors as we show them further up the page
       hideContributors={true}
     >
-      {exhibitionAccessContent ? (
+      {exhibitionAccessContent && exhibition.uid !== 'being-human' ? (
         <>
           {exhibition.end && !isPast(exhibition.end) && (
             <InfoBox


### PR DESCRIPTION
## What does this change?

For [#11732](https://github.com/wellcomecollection/wellcomecollection.org/issues/11732)

Removes Access Resources section from the Being Human exhibition page

## How to test

- Enable the exhibitionAccessContent toggle
- Visit the [Being Human](http://localhost:3000/exhibitions/being-human) exhibition page and see that there there is no Access Resource section
- Visit another[ exhibition page](http://localhost:3000/exhibitions/hard-graft-work-health-and-rights) and see that there is an Access Resources section


## How can we measure success?

n/a

## Have we considered potential risks?

n/a

