### PR TITLE
Add gtm hooks

### DIFF
--- a/content/webapp/components/Accordion/Accordion.tsx
+++ b/content/webapp/components/Accordion/Accordion.tsx
@@ -7,6 +7,7 @@ import Icon from '@weco/common/views/components/Icon/Icon';
 import Space from '@weco/common/views/components/styled/Space';
 
 type AccordionItem = {
+  gtmHook?: string;
   summary: string;
   content: ReactElement;
 };
@@ -129,7 +130,7 @@ const Accordion: FunctionComponent<Props> = ({
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         <Details key={item.summary} name={closeOthersOnOpen ? id : undefined}>
-          <Summary>
+          <Summary data-gtm-trigger={item.gtmHook}>
             <SummaryInner>
               {item.summary}{' '}
               <span style={{ display: 'flex' }}>

--- a/content/webapp/components/BslLeafletVideo/index.tsx
+++ b/content/webapp/components/BslLeafletVideo/index.tsx
@@ -93,6 +93,7 @@ const BslLeafletVideo: FunctionComponent<Props> = ({
             <BslLeafletButton
               aria-controls="bsl-leaflet-video-modal"
               onClick={() => setIsModalActive(true)}
+              data-gtm-trigger="watch_in_sign_language"
             >
               <Icon
                 icon={bslSquare}

--- a/content/webapp/components/Exhibition/Exhibition.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.tsx
@@ -301,6 +301,7 @@ const Exhibition: FunctionComponent<Props> = ({
   // We then filter out content that isn't relevant, i.e. if there isn't a highlight tour attached to the exhibition
   const possibleExhibitionAccessContent = [
     {
+      gtmHook: 'digital_highlights_tour',
       summary: 'Digital highlights tour',
       content: (
         <ul>
@@ -327,6 +328,7 @@ const Exhibition: FunctionComponent<Props> = ({
       ),
     },
     {
+      gtmHook: 'bsl_transcripts_and_induction_loops',
       summary: 'BSL, transcripts and induction loops',
       content: (
         <ul>
@@ -368,6 +370,7 @@ const Exhibition: FunctionComponent<Props> = ({
       ),
     },
     {
+      gtmHook: 'audio_description_and_visual_access',
       summary: 'Audio description and visual access',
       content: (
         <ul>
@@ -393,6 +396,7 @@ const Exhibition: FunctionComponent<Props> = ({
       ),
     },
     {
+      gtmHook: 'wheelchair_and_physical_access',
       summary: 'Wheelchair and physical access',
       content: (
         <ul>
@@ -405,6 +409,7 @@ const Exhibition: FunctionComponent<Props> = ({
       ),
     },
     {
+      gtmHook: 'sensory_access',
       summary: 'Sensory access',
       content: (
         <ul>


### PR DESCRIPTION
## What does this change?

Relates to [#11733](https://github.com/wellcomecollection/wellcomecollection.org/issues/11733)

## How to test

-Enable the exhibitionAccessContent toggle
- View [an exhibition page](http://localhost:3000/exhibitions/zines-forever-diy-publishing-and-disability-justice) and use dev tools to confirm the presence of data-gtm-trigger attributes on the summary elements of the accordion and the link for the BSL video

## How can we measure success?

We are able to set up tracking in GTM relating to the use of the accordion and the BSL video link

## Have we considered potential risks?

none really

