### PR TITLE
Make bsl leaflet video button color black on iOS

### DIFF
--- a/content/webapp/components/BslLeafletVideo/index.tsx
+++ b/content/webapp/components/BslLeafletVideo/index.tsx
@@ -20,6 +20,7 @@ const BslLeaftletButtonText = styled(Space).attrs({
 })``;
 
 const BslLeafletButton = styled.button`
+  color: inherit;
   display: flex;
   align-items: center;
 


### PR DESCRIPTION
For #11747 

## What does this change?

<img width="537" alt="image" src="https://github.com/user-attachments/assets/5f173f51-d68f-4898-87ed-d7861d79d25a" />

Changes the BSL leaflet video button to be black on iOS (where buttons are apparently blue by default if otherwise unstyled)

## How to test
Run it in Simulator (or take my word for it that it works)


## How can we measure success?
Consistent style

## Have we considered potential risks?
n/a