### PR TITLE
Use bslLiveInterpretationSquare icon for event bsl interpretation types

### DIFF
--- a/common/data/hardcoded-ids.ts
+++ b/common/data/hardcoded-ids.ts
@@ -91,7 +91,7 @@ export const interpretationTypeIconMap = [
   {
     name: 'britishSignLanguageOnline',
     prismicId: 'X2smLBMAACMA-99Z',
-    iconName: undefined, // use 'bslSquare'?,
+    iconName: 'britishSignLanguageOnline',
   },
   {
     name: 'speechToText',
@@ -111,8 +111,8 @@ export const interpretationTypeIconMap = [
   {
     name: 'britishSignLanguage',
     prismicId: 'XkFGqxEAACIAIhNH',
-    iconName: undefined,
-  }, // use 'bslSquare'?
+    iconName: 'britishSignLanguage',
+  },
   {
     name: 'wheelchairAccessible',
     prismicId: 'YkRhDBAAACAAvSvl',

--- a/content/webapp/pages/events/[eventId]/index.tsx
+++ b/content/webapp/pages/events/[eventId]/index.tsx
@@ -30,7 +30,6 @@ import { headerBackgroundLs } from '@weco/common/utils/backgrounds';
 import { font } from '@weco/common/utils/classnames';
 import { isPast } from '@weco/common/utils/dates';
 import { formatDayDate, formatTime } from '@weco/common/utils/format-date';
-import { camelize } from '@weco/common/utils/grammar';
 import { serialiseProps } from '@weco/common/utils/json';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';


### PR DESCRIPTION
## What does this change?

<img width="611" alt="image" src="https://github.com/user-attachments/assets/8f5109b6-a7d4-495b-bb1d-539aa9511afc" />

Sets an `iconName` for the two bsl interpretation types, which then both map onto the `bslLiveInterpretationSquare` (signing hands) icon. As per decision previously outlined [here](https://github.com/wellcomecollection/wellcomecollection.org/issues/11516#issuecomment-2650486701)

## How to test
Visit `/events/access-to-work` and check the icon appears next to the British Sign Language heading in the yellow box

## How can we measure success?
Consistent iconography

## Have we considered potential risks?
n/a