### PR TITLE
Allow StatusIndicator to wrap if neeeded

### DIFF
--- a/content/webapp/components/Exhibition/Exhibition.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.tsx
@@ -503,7 +503,7 @@ const Exhibition: FunctionComponent<Props> = ({
             {!exhibition.isPermanent && (
               <Space
                 $v={{ size: 'xs', properties: ['margin-bottom'] }}
-                style={{ display: 'flex' }}
+                style={{ display: 'flex', flexWrap: 'wrap' }}
               >
                 <Space $h={{ size: 'm', properties: ['margin-right'] }}>
                   {DateInfo}


### PR DESCRIPTION
For #11779 

## What does this change?
Allows the StatusIndicator to wrap onto the next line if there isn't enough space for it alongside the date.

<img width="319" alt="image" src="https://github.com/user-attachments/assets/5897a04b-81bb-47dc-b244-d7b3a212361e" />

## How to test
Visit `/exhibitions/zines-forever-diy-publishing-and-disability-justice` and shrink browser window

## How can we measure success?
UI doesn't look broken

## Have we considered potential risks?
n/a