### PR TITLE
Use Content API behind toggle on events listing page

### DIFF
--- a/content/webapp/pages/events/index.tsx
+++ b/content/webapp/pages/events/index.tsx
@@ -3,13 +3,14 @@ import { FunctionComponent } from 'react';
 
 import { pageDescriptions } from '@weco/common/data/microcopy';
 import { getServerData } from '@weco/common/server-data';
-import { useToggles } from '@weco/common/server-data/Context';
 import { appError, AppErrorProps } from '@weco/common/services/app';
+import { transformImage } from '@weco/common/services/prismic/transformers/images';
 import { PaginatedResults } from '@weco/common/services/prismic/types';
 import { Period } from '@weco/common/types/periods';
 import { headerBackgroundLs } from '@weco/common/utils/backgrounds';
 import { pluralize } from '@weco/common/utils/grammar';
 import { serialiseProps } from '@weco/common/utils/json';
+import { getQueryPropertyValue } from '@weco/common/utils/search';
 import Divider from '@weco/common/views/components/Divider/Divider';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd/JsonLd';
 import {
@@ -23,6 +24,7 @@ import PaginationWrapper from '@weco/common/views/components/styled/PaginationWr
 import Space from '@weco/common/views/components/styled/Space';
 import SpacingSection from '@weco/common/views/components/styled/SpacingSection';
 import CardGrid from '@weco/content/components/CardGrid/CardGrid';
+import EventsSearchResults from '@weco/content/components/EventsSearchResults';
 import MoreLink from '@weco/content/components/MoreLink/MoreLink';
 import Pagination from '@weco/content/components/Pagination/Pagination';
 import Tabs from '@weco/content/components/Tabs';
@@ -33,8 +35,16 @@ import {
   transformEvent,
   transformEventBasic,
 } from '@weco/content/services/prismic/transformers/events';
-import { eventLd } from '@weco/content/services/prismic/transformers/json-ld';
+import {
+  eventLd,
+  eventLdContentApi,
+} from '@weco/content/services/prismic/transformers/json-ld';
 import { transformQuery } from '@weco/content/services/prismic/transformers/paginated-results';
+import { getEvents } from '@weco/content/services/wellcome/content/events';
+import {
+  ContentResultsList,
+  EventDocument,
+} from '@weco/content/services/wellcome/content/types/api';
 import { EventBasic } from '@weco/content/types/events';
 import { getPage } from '@weco/content/utils/query-params';
 import { cacheTTL, setCacheControl } from '@weco/content/utils/setCacheControl';
@@ -46,8 +56,15 @@ export type Props = {
   jsonLd: JsonLdObj[];
 };
 
+type NewProps = {
+  title: string;
+  contentApiEvents: ContentResultsList<EventDocument>;
+  period: 'future' | 'past';
+  jsonLd: JsonLdObj[];
+};
+
 export const getServerSideProps: GetServerSideProps<
-  Props | AppErrorProps
+  (NewProps | Props) | AppErrorProps
 > = async context => {
   setCacheControl(context.res, cacheTTL.events);
   const page = getPage(context.query);
@@ -57,106 +74,144 @@ export const getServerSideProps: GetServerSideProps<
   }
 
   const serverData = await getServerData(context);
+  const isUsingContentAPI = !!serverData.toggles.filterEventsListing.value;
 
-  const {
-    period = 'current-and-coming-up',
-    isOnline,
-    availableOnline,
-  } = context.query;
+  if (isUsingContentAPI) {
+    const { period = 'future', availableOnline, page } = context.query;
 
-  const client = createClient(context);
+    if (availableOnline) {
+      // TODO redirect https://github.com/wellcomecollection/wellcomecollection.org/issues/11775
+    }
 
-  const eventsQueryPromise = await fetchEvents(client, {
-    page,
-    period: period as 'current-and-coming-up' | 'past' | undefined,
-    pageSize: 100,
-    isOnline: isOnline === 'true',
-    availableOnline: availableOnline === 'true',
-  });
+    const pageNumber = getQueryPropertyValue(page);
+    const paramsQuery = { timespan: getQueryPropertyValue(period) || '' };
 
-  const events = transformQuery(eventsQueryPromise, transformEvent);
-  const basicEvents = transformQuery(eventsQueryPromise, transformEventBasic);
+    const eventResponseList = await getEvents({
+      params: {
+        ...paramsQuery,
+        sort: getQueryPropertyValue(context.query.sort),
+        sortOrder: getQueryPropertyValue(context.query.sortOrder),
+        ...(pageNumber && { page: Number(pageNumber) }),
+      },
+      pageSize: 9,
+      toggles: serverData.toggles,
+    });
 
-  if (events) {
-    const title = (period === 'past' ? 'Past e' : 'E') + 'vents';
-    const jsonLd = events.results.flatMap(eventLd);
-    return {
-      props: serialiseProps({
-        events: {
-          ...events,
-          results: basicEvents.results,
-        },
-        title,
-        period: period as Period,
-        jsonLd,
-        serverData,
-      }),
-    };
-  } else {
+    if (eventResponseList?.type === 'Error') {
+      return appError(
+        context,
+        eventResponseList.httpStatus,
+        'Content API error'
+      );
+    }
+
+    if (eventResponseList) {
+      const title = (period === 'past' ? 'Past e' : 'E') + 'vents';
+      const jsonLd = eventResponseList.results.flatMap(eventLdContentApi);
+
+      return {
+        props: serialiseProps({
+          contentApiEvents: eventResponseList,
+          title,
+          period: period as 'future' | 'past',
+          jsonLd,
+          serverData,
+        }),
+      };
+    }
+
     return { notFound: true };
+  } else {
+    const {
+      period = 'current-and-coming-up',
+      isOnline,
+      availableOnline,
+    } = context.query;
+
+    const client = createClient(context);
+
+    const eventsQueryPromise = await fetchEvents(client, {
+      page,
+      period: period as 'current-and-coming-up' | 'past' | undefined,
+      pageSize: 100,
+      isOnline: isOnline === 'true', // TODO confirm we don't need to redirect this? Seems unused
+      availableOnline: availableOnline === 'true',
+    });
+
+    const events = transformQuery(eventsQueryPromise, transformEvent);
+    const basicEvents = transformQuery(eventsQueryPromise, transformEventBasic);
+
+    if (events) {
+      const title = (period === 'past' ? 'Past e' : 'E') + 'vents';
+      const jsonLd = events.results.flatMap(eventLd);
+      return {
+        props: serialiseProps({
+          events: {
+            ...events,
+            results: basicEvents.results,
+          },
+          title,
+          period: period as Period,
+          jsonLd,
+          serverData,
+        }),
+      };
+    } else {
+      return { notFound: true };
+    }
   }
 };
 
-const EventsPage: FunctionComponent<Props> = props => {
-  const { events, title, period, jsonLd } = props;
-  const { filterEventsListing } = useToggles();
-  const convertedPaginatedResults = {
-    ...events,
-    results:
-      period !== 'past'
-        ? orderEventsByNextAvailableDate(events.results)
-        : events.results,
-  };
-  const firstEvent = events.results[0];
+const EventsPage: FunctionComponent<Props | NewProps> = props => {
+  const { title, period, jsonLd } = props;
 
-  return (
-    <PageLayout
-      title={title}
-      description={pageDescriptions.events}
-      url={{ pathname: `/events${period ? `/${period}` : ''}` }}
-      jsonLd={jsonLd}
-      openGraphType="website"
-      siteSection="whats-on"
-      image={firstEvent?.promo?.image}
-    >
-      <SpacingSection>
-        <PageHeader
-          breadcrumbs={{ items: [] }}
-          labels={undefined}
-          title={title}
-          ContentTypeInfo={
-            pageDescriptions.events && (
-              <PrismicHtmlBlock
-                html={[
-                  {
-                    type: 'paragraph',
-                    text: pageDescriptions.events,
-                    spans: [],
-                  },
-                ]}
-              />
-            )
-          }
-          backgroundTexture={
-            filterEventsListing ? undefined : headerBackgroundLs
-          }
-          highlightHeading={!filterEventsListing}
-          isContentTypeInfoBeforeMedia={filterEventsListing}
-          isSlim={filterEventsListing}
-        />
+  if ('contentApiEvents' in props) {
+    const { contentApiEvents: events } = props;
+    const firstEvent = events.results[0];
 
-        {filterEventsListing && (
+    return (
+      <PageLayout
+        title={title}
+        description={pageDescriptions.events}
+        url={{ pathname: `/events${period ? `/${period}` : ''}` }}
+        jsonLd={jsonLd}
+        openGraphType="website"
+        siteSection="whats-on"
+        image={firstEvent && transformImage(firstEvent.image)}
+      >
+        <SpacingSection>
+          <PageHeader
+            breadcrumbs={{ items: [] }}
+            labels={undefined}
+            title={title}
+            ContentTypeInfo={
+              pageDescriptions.events && (
+                <PrismicHtmlBlock
+                  html={[
+                    {
+                      type: 'paragraph',
+                      text: pageDescriptions.events,
+                      spans: [],
+                    },
+                  ]}
+                />
+              )
+            }
+            isContentTypeInfoBeforeMedia={true}
+            isSlim={true}
+          />
+
           <ContaineredLayout gridSizes={gridSize12()}>
             <Tabs
               hasNewLook
               tabBehaviour="navigate"
               currentSection={
-                period === 'current-and-coming-up' ? 'upcoming' : 'past'
+                period === 'future' || !period ? 'future' : 'past'
               }
               label="Time-based event filter"
               items={[
                 {
-                  id: 'upcoming',
+                  id: 'future',
                   url: `/events`,
                   text: 'Upcoming events',
                 },
@@ -168,73 +223,125 @@ const EventsPage: FunctionComponent<Props> = props => {
               ]}
             />
           </ContaineredLayout>
-        )}
 
-        {(filterEventsListing || convertedPaginatedResults.totalPages > 1) && (
           <ContaineredLayout gridSizes={gridSize12()}>
             <PaginationWrapper $verticalSpacing="l">
-              <span>
-                {pluralize(convertedPaginatedResults.totalResults, 'result')}
-              </span>
+              <span>{pluralize(events.totalResults, 'result')}</span>
+            </PaginationWrapper>
 
-              {!filterEventsListing && (
+            <EventsSearchResults events={events.results} />
+          </ContaineredLayout>
+
+          <ContaineredLayout gridSizes={gridSize12()}>
+            <PaginationWrapper $verticalSpacing="l" $alignRight>
+              <Pagination
+                totalPages={events.totalPages}
+                ariaLabel="Results pagination"
+              />
+            </PaginationWrapper>
+          </ContaineredLayout>
+        </SpacingSection>
+      </PageLayout>
+    );
+  } else {
+    const { events } = props;
+
+    const convertedPaginatedResults = {
+      ...events,
+      results:
+        period !== 'past'
+          ? orderEventsByNextAvailableDate(events.results)
+          : events.results,
+    };
+    const firstEvent = events.results[0];
+
+    return (
+      <PageLayout
+        title={title}
+        description={pageDescriptions.events}
+        url={{ pathname: `/events${period ? `/${period}` : ''}` }}
+        jsonLd={jsonLd}
+        openGraphType="website"
+        siteSection="whats-on"
+        image={firstEvent?.promo?.image}
+      >
+        <SpacingSection>
+          <PageHeader
+            breadcrumbs={{ items: [] }}
+            labels={undefined}
+            title={title}
+            ContentTypeInfo={
+              pageDescriptions.events && (
+                <PrismicHtmlBlock
+                  html={[
+                    {
+                      type: 'paragraph',
+                      text: pageDescriptions.events,
+                      spans: [],
+                    },
+                  ]}
+                />
+              )
+            }
+            backgroundTexture={headerBackgroundLs}
+            highlightHeading={true}
+          />
+
+          {convertedPaginatedResults.totalPages > 1 && (
+            <ContaineredLayout gridSizes={gridSize12()}>
+              <PaginationWrapper $verticalSpacing="l">
+                <span>
+                  {pluralize(convertedPaginatedResults.totalResults, 'result')}
+                </span>
+
                 <Pagination
                   totalPages={convertedPaginatedResults.totalPages}
                   ariaLabel="Results pagination"
                   isHiddenMobile
                 />
-              )}
-            </PaginationWrapper>
+              </PaginationWrapper>
 
-            {!filterEventsListing && (
               <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
                 <Divider />
               </Space>
-            )}
-          </ContaineredLayout>
-        )}
-
-        <Space
-          {...(!filterEventsListing && {
-            $v: {
-              size: 'l',
-              properties: ['margin-top'],
-            },
-          })}
-        >
-          {convertedPaginatedResults.results.length > 0 ? (
-            <CardGrid
-              items={convertedPaginatedResults.results}
-              itemsPerRow={3}
-            />
-          ) : (
-            <ContaineredLayout gridSizes={gridSize12()}>
-              <p>There are no results.</p>
             </ContaineredLayout>
           )}
-        </Space>
 
-        {(filterEventsListing || convertedPaginatedResults.totalPages > 1) && (
-          <ContaineredLayout gridSizes={gridSize12()}>
-            <PaginationWrapper $verticalSpacing="l" $alignRight>
-              <Pagination
-                totalPages={convertedPaginatedResults.totalPages}
-                ariaLabel="Results pagination"
+          <Space $v={{ size: 'l', properties: ['margin-top'] }}>
+            {convertedPaginatedResults.results.length > 0 ? (
+              <CardGrid
+                items={convertedPaginatedResults.results}
+                itemsPerRow={3}
               />
-            </PaginationWrapper>
-          </ContaineredLayout>
-        )}
+            ) : (
+              <ContaineredLayout gridSizes={gridSize12()}>
+                <p>There are no results.</p>
+              </ContaineredLayout>
+            )}
+          </Space>
 
-        {!filterEventsListing && period === 'current-and-coming-up' && (
-          <ContaineredLayout gridSizes={gridSize12()}>
-            <Space $v={{ size: 'm', properties: ['margin-top'] }}>
-              <MoreLink url="/events/past" name="View past events" />
-            </Space>
-          </ContaineredLayout>
-        )}
-      </SpacingSection>
-    </PageLayout>
-  );
+          {convertedPaginatedResults.totalPages > 1 && (
+            <ContaineredLayout gridSizes={gridSize12()}>
+              <PaginationWrapper $verticalSpacing="l" $alignRight>
+                <Pagination
+                  totalPages={convertedPaginatedResults.totalPages}
+                  ariaLabel="Results pagination"
+                />
+              </PaginationWrapper>
+            </ContaineredLayout>
+          )}
+
+          {period === 'current-and-coming-up' && (
+            <ContaineredLayout gridSizes={gridSize12()}>
+              <Space $v={{ size: 'm', properties: ['margin-top'] }}>
+                <MoreLink url="/events/past" name="View past events" />
+              </Space>
+            </ContaineredLayout>
+          )}
+        </SpacingSection>
+      </PageLayout>
+    );
+  }
 };
 
 export default EventsPage;

--- a/content/webapp/pages/events/index.tsx
+++ b/content/webapp/pages/events/index.tsx
@@ -80,7 +80,12 @@ export const getServerSideProps: GetServerSideProps<
     const { period = 'future', availableOnline, page } = context.query;
 
     if (availableOnline) {
-      // TODO redirect https://github.com/wellcomecollection/wellcomecollection.org/issues/11775
+      return {
+        redirect: {
+          permanent: false,
+          destination: '/events/past?isAvailableOnline=true',
+        },
+      };
     }
 
     const pageNumber = getQueryPropertyValue(page);
@@ -134,7 +139,7 @@ export const getServerSideProps: GetServerSideProps<
       page,
       period: period as 'current-and-coming-up' | 'past' | undefined,
       pageSize: 100,
-      isOnline: isOnline === 'true', // TODO confirm we don't need to redirect this? Seems unused
+      isOnline: isOnline === 'true',
       availableOnline: availableOnline === 'true',
     });
 
@@ -144,6 +149,7 @@ export const getServerSideProps: GetServerSideProps<
     if (events) {
       const title = (period === 'past' ? 'Past e' : 'E') + 'vents';
       const jsonLd = events.results.flatMap(eventLd);
+
       return {
         props: serialiseProps({
           events: {

--- a/content/webapp/pages/search/events.tsx
+++ b/content/webapp/pages/search/events.tsx
@@ -242,10 +242,8 @@ export const getServerSideProps: GetServerSideProps<
     };
   }
 
-  // Sending page=1 to Prismic skips the two first results, which seems to have to do with the cursor work
-  // This is a workaround that ensures we only send the page if relevant
   const { page, ...restOfQuery } = query;
-  const pageNumber = page !== '1' && getQueryPropertyValue(page);
+  const pageNumber = getQueryPropertyValue(page);
   const paramsQuery = { ...restOfQuery, timespan: validTimespan };
 
   const eventResponseList = await getEvents({

--- a/content/webapp/services/prismic/transformers/json-ld.ts
+++ b/content/webapp/services/prismic/transformers/json-ld.ts
@@ -165,12 +165,9 @@ export function eventLdContentApi(event: EventContentApi): JsonLdObj[] {
           },
           startDate: event.times.map(time => time.startDateTime),
           endDate: event.times.map(time => time.endDateTime),
-          // description: event.promo?.caption, // TODO, add to event result?
           image: promoImage
             ? getImageUrlAtSize(promoImage, { w: 600 })
             : undefined,
-          // isAccessibleForFree: !event.cost, // TODO?
-          // performers: contributorLd(event.contributors), //TODO?
         },
         { type: 'Event' }
       );


### PR DESCRIPTION
## What does this change?

#11780

- Move use of toggle to `getServerSideProps`, then depending on what is returned, display something different
- Created a new json-ld helper function; `eventLdContentApi`. See comment I left to see what's been removed from it.
- Added a redirect from `/events/past?availableOnline=true` to `/events/past?isAvailableOnline=true`, which doesn't yet work but will once we do https://github.com/wellcomecollection/wellcomecollection.org/issues/11472. It was meant to be done as part of https://github.com/wellcomecollection/wellcomecollection.org/issues/11775 but it felt silly to just leave a comment there.

## How to test

Run locally; 
- Does it look the same as in prod without the toggle? 
- Do both upcoming and past still return what they should?
- Does the pagination work?

## How can we measure success?

We can move ahead with adding filters behind toggle

## Have we considered potential risks?
Breaks something with no toggle 