### PR TITLE
Events list header/ Tabs tweaks

### DIFF
--- a/cardigan/stories/components/Tabs/Tabs.stories.tsx
+++ b/cardigan/stories/components/Tabs/Tabs.stories.tsx
@@ -55,7 +55,6 @@ const meta: Meta<typeof Tabs> = {
     tabBehaviour: 'switch',
     isWhite: false,
     hideBorder: false,
-    hasNewLook: false,
     items: [
       {
         id: 'all',

--- a/content/webapp/components/Tabs/Tabs.Navigate.tsx
+++ b/content/webapp/components/Tabs/Tabs.Navigate.tsx
@@ -20,7 +20,6 @@ export type Props = {
   items: NavigateSelectableTextLink[];
   currentSection: string;
   isWhite?: boolean;
-  hasNewLook?: boolean;
 };
 
 const TabsNavigate: FunctionComponent<Props> = ({
@@ -29,19 +28,13 @@ const TabsNavigate: FunctionComponent<Props> = ({
   items,
   currentSection,
   isWhite,
-  hasNewLook,
 }: Props) => {
   return (
     <TabsContainer aria-label={label}>
       {items.map(item => {
         const isSelected = currentSection === item.id;
         return (
-          <Tab
-            key={item.id}
-            $selected={isSelected}
-            $hideBorder={hideBorder}
-            $hasNewLook={hasNewLook}
-          >
+          <Tab key={item.id} $selected={isSelected} $hideBorder={hideBorder}>
             <Link
               scroll={false}
               passHref
@@ -52,7 +45,6 @@ const TabsNavigate: FunctionComponent<Props> = ({
                 $selected={isSelected}
                 aria-current={isSelected ? 'page' : 'false'}
                 $isWhite={isWhite}
-                $hasNewLook={hasNewLook}
                 onClick={e => {
                   if (!isSelected) {
                     (e.target as HTMLDivElement).scrollIntoView({

--- a/content/webapp/components/Tabs/Tabs.Switch.tsx
+++ b/content/webapp/components/Tabs/Tabs.Switch.tsx
@@ -55,7 +55,6 @@ export type Props = {
   setSelectedTab: Dispatch<SetStateAction<string>>;
   isWhite?: boolean;
   trackWithSegment?: boolean;
-  hasNewLook?: boolean;
 };
 
 const TabsSwitch: FunctionComponent<Props> = ({
@@ -65,7 +64,6 @@ const TabsSwitch: FunctionComponent<Props> = ({
   selectedTab,
   setSelectedTab,
   isWhite,
-  hasNewLook,
   trackWithSegment = false,
 }: Props) => {
   const { isEnhanced } = useContext(AppContext);
@@ -136,7 +134,6 @@ const TabsSwitch: FunctionComponent<Props> = ({
             $selected={isSelected}
             $isWhite={isWhite}
             $hideBorder={hideBorder}
-            $hasNewLook={hasNewLook}
             onClick={e => {
               if (!(item.id === selectedTab)) {
                 (e.target as HTMLButtonElement).scrollIntoView({
@@ -155,16 +152,11 @@ const TabsSwitch: FunctionComponent<Props> = ({
             <TabButton
               role={isEnhanced ? 'tab' : undefined}
               id={`tab-${item.id}`}
-              $hasNewLook={hasNewLook}
               tabIndex={item.id === selectedTab ? 0 : -1}
               aria-controls={`tabpanel-${item.id}`}
               aria-selected={item.id === selectedTab}
             >
-              <NavItemInner
-                $selected={isSelected}
-                $isWhite={isWhite}
-                $hasNewLook={hasNewLook}
-              >
+              <NavItemInner $selected={isSelected} $isWhite={isWhite}>
                 <ConditionalWrapper
                   condition={Boolean(item.url && !isEnhanced)}
                   wrapper={children => <a href={item.url}>{children}</a>}

--- a/content/webapp/components/Tabs/Tabs.styles.tsx
+++ b/content/webapp/components/Tabs/Tabs.styles.tsx
@@ -46,18 +46,17 @@ type NavItemProps = {
   $selected: boolean;
   $isWhite?: boolean;
   $hideBorder?: boolean;
-  $hasNewLook?: boolean;
 };
 
-export const Tab = styled.div.attrs({
-  className: font('intsb', 5),
-})<NavItemProps>`
+export const Tab = styled.div.attrs<{ $selected?: boolean }>(props => ({
+  className: font(props.$selected ? 'intsb' : 'intm', 5),
+}))<NavItemProps>`
   padding: 0;
   margin: 0;
   flex-shrink: 0;
   border-bottom: ${props =>
     props.$selected
-      ? `3px solid ${props.theme.color(props.$hasNewLook ? 'accent.green' : 'yellow')}`
+      ? `3px solid ${props.theme.color('yellow')}`
       : `1px solid ${props.theme.color(
           props.$hideBorder
             ? 'transparent'
@@ -73,28 +72,18 @@ export const Tab = styled.div.attrs({
     &:focus-visible {
       display: block;
       box-shadow:
-        0 0 0 3px
-          ${props =>
-            props.theme.color(
-              props.$hasNewLook ? 'accent.green' : 'focus.yellow'
-            )}
-          inset,
+        0 0 0 3px ${props => props.theme.color('focus.yellow')} inset,
         0 0 0 6px ${props => props.theme.color('black')} inset;
       outline: 0;
     }
   }
 `;
 
-export const TabButton = styled.div<{ $hasNewLook?: boolean }>`
+export const TabButton = styled.div`
   /* For Tab.Tab */
   &:focus-visible {
     box-shadow:
-      0 0 0 3px
-        ${props =>
-          props.theme.color(
-            props.$hasNewLook ? 'accent.green' : 'focus.yellow'
-          )}
-        inset,
+      0 0 0 3px ${props => props.theme.color('focus.yellow')} inset,
       0 0 0 6px ${props => props.theme.color('black')} inset;
     outline: 0;
   }
@@ -109,20 +98,14 @@ export const NavItemInner = styled(Space).attrs<{ $selected: boolean }>(
       $v: { size: 'm', properties: ['padding-top', 'padding-bottom'] },
     };
   }
-)<{ $isWhite?: boolean; $hasNewLook?: boolean }>`
+)<{ $isWhite?: boolean }>`
   display: block;
   position: relative;
   z-index: 1;
   cursor: pointer;
   color: ${props =>
     props.theme.color(
-      props.$isWhite
-        ? 'white'
-        : props.$hasNewLook
-          ? props.$selected
-            ? 'black'
-            : 'neutral.600'
-          : 'black'
+      props.$isWhite ? 'white' : props.$selected ? 'black' : 'neutral.600'
     )};
   transition: all ${props => props.theme.transitionProperties};
 
@@ -141,13 +124,7 @@ export const NavItemInner = styled(Space).attrs<{ $selected: boolean }>(
     &::after {
       width: 100%;
       background-color: ${props =>
-        props.theme.color(
-          props.$selected
-            ? props.$hasNewLook
-              ? 'accent.green'
-              : 'yellow'
-            : 'neutral.300'
-        )};
+        props.theme.color(props.$selected ? 'yellow' : 'neutral.300')};
 
       /* Prevent iOS double-tap link issue
        https://css-tricks.com/annoying-mobile-double-tap-link-issue/ */

--- a/content/webapp/pages/events/index.tsx
+++ b/content/webapp/pages/events/index.tsx
@@ -204,7 +204,6 @@ const EventsPage: FunctionComponent<Props | NewProps> = props => {
 
           <ContaineredLayout gridSizes={gridSize12()}>
             <Tabs
-              hasNewLook
               tabBehaviour="navigate"
               currentSection={
                 period === 'future' || !period ? 'future' : 'past'

--- a/content/webapp/pages/events/index.tsx
+++ b/content/webapp/pages/events/index.tsx
@@ -25,6 +25,7 @@ import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock/Pri
 import PaginationWrapper from '@weco/common/views/components/styled/PaginationWrapper';
 import Space from '@weco/common/views/components/styled/Space';
 import SpacingSection from '@weco/common/views/components/styled/SpacingSection';
+import { themeValues } from '@weco/common/views/themes/config';
 import CardGrid from '@weco/content/components/CardGrid/CardGrid';
 import EventsSearchResults from '@weco/content/components/EventsSearchResults';
 import MoreLink from '@weco/content/components/MoreLink/MoreLink';
@@ -203,25 +204,32 @@ const EventsPage: FunctionComponent<Props | NewProps> = props => {
           )}
 
           <ContaineredLayout gridSizes={gridSize12()}>
-            <Tabs
-              tabBehaviour="navigate"
-              currentSection={
-                period === 'future' || !period ? 'future' : 'past'
-              }
-              label="Time-based event filter"
-              items={[
-                {
-                  id: 'future',
-                  url: `/events`,
-                  text: 'Upcoming events',
-                },
-                {
-                  id: 'past',
-                  url: `/events/past`,
-                  text: 'Past events',
-                },
-              ]}
-            />
+            <div
+              style={{
+                borderBottom: `1px solid ${themeValues.color('neutral.300')}`,
+              }}
+            >
+              <Tabs
+                tabBehaviour="navigate"
+                currentSection={
+                  period === 'future' || !period ? 'future' : 'past'
+                }
+                label="Time-based event filter"
+                items={[
+                  {
+                    id: 'future',
+                    url: `/events`,
+                    text: 'Upcoming events',
+                  },
+                  {
+                    id: 'past',
+                    url: `/events/past`,
+                    text: 'Past events',
+                  },
+                ]}
+                hideBorder
+              />
+            </div>
           </ContaineredLayout>
 
           <ContaineredLayout gridSizes={gridSize12()}>


### PR DESCRIPTION
## What does this change?

[Dana left comments in Figma](https://www.figma.com/design/Ab9RUk62Ah5MqTnPecwOdl/All-events-landing-page?node-id=4459-4145&m=dev), this addresses those.

#11799 

We also landed on applying new styles across all Tabs: unselected tab is paler (except when white) and uses a thinner font weight. We didn't want to apply the colour change that we can see in the mockups (where the underline is green) as we still use `yellow` as our main accent colour.

<img width="495" alt="Screenshot 2025-04-09 at 12 28 43" src="https://github.com/user-attachments/assets/986fe055-93bd-45b3-a906-365db89bc852" />

So `hasNewLook` is gone (yay) and it's just what it is now, toggle or not!

I've applied a full width border underneath the tabs in the Events listing.


## How to test

Run locally, with and without toggle

## How can we measure success?

It looks good

## Have we considered potential risks?
N/A