### PR TITLE
Tabs colour change

### DIFF
--- a/content/webapp/components/Tabs/Tabs.styles.tsx
+++ b/content/webapp/components/Tabs/Tabs.styles.tsx
@@ -103,10 +103,7 @@ export const NavItemInner = styled(Space).attrs<{ $selected: boolean }>(
   position: relative;
   z-index: 1;
   cursor: pointer;
-  color: ${props =>
-    props.theme.color(
-      props.$isWhite ? 'white' : props.$selected ? 'black' : 'neutral.600'
-    )};
+  color: ${props => props.theme.color(props.$isWhite ? 'white' : 'black')};
   transition: all ${props => props.theme.transitionProperties};
 
   &::after {
@@ -124,7 +121,7 @@ export const NavItemInner = styled(Space).attrs<{ $selected: boolean }>(
     &::after {
       width: 100%;
       background-color: ${props =>
-        props.theme.color(props.$selected ? 'yellow' : 'neutral.300')};
+        props.theme.color(props.$selected ? 'yellow' : 'lightYellow')};
 
       /* Prevent iOS double-tap link issue
        https://css-tricks.com/annoying-mobile-double-tap-link-issue/ */


### PR DESCRIPTION
## What does this change?
Based on chats with Dana.

Just changes the colour of the underline on hover on inactive tabs from grey to pale yellow, and the font colour is back to black for inactive/active tabs.

[See in Cardigan.](https://62f13cdbd0ff140768a8d87b-nvvrjrmryt.chromatic.com/?path=/story/components-tabs--basic)

![image](https://github.com/user-attachments/assets/f6f18927-af4d-46aa-94a0-430088c90c9d)
![image](https://github.com/user-attachments/assets/d871d1ab-413a-4d1a-bffd-20e65fceb654)


