### PR TITLE
Use :active styles for touch devices

### DIFF
--- a/content/webapp/components/AudioPlayerNew/AudioPlayer.Scrubber.tsx
+++ b/content/webapp/components/AudioPlayerNew/AudioPlayer.Scrubber.tsx
@@ -3,7 +3,7 @@ import styled, { css } from 'styled-components';
 
 import { formatPlayerTime } from './AudioPlayer.formatters';
 
-const backgroundTransformHoverActive = css<{ $isDark: boolean }>`
+const backgroundTransform = css<{ $isDark: boolean }>`
   background: ${props =>
     props.$isDark ? props.theme.color('white') : props.theme.color('black')};
   transform: scale(1.5);
@@ -33,13 +33,13 @@ const RangeSlider = styled.input.attrs({
 
     @media (hover: hover) {
       &:hover {
-        ${backgroundTransformHoverActive};
+        ${backgroundTransform};
       }
     }
 
     @media (hover: none) {
       &:active {
-        ${backgroundTransformHoverActive};
+        ${backgroundTransform};
       }
     }
   }
@@ -56,15 +56,15 @@ const RangeSlider = styled.input.attrs({
       background 0.2s ease-out,
       transform 0.2s ease-out;
 
-    @media (pointer: fine) {
+    @media (hover: hover) {
       &:hover {
-        ${backgroundTransformHoverActive};
+        ${backgroundTransform};
       }
     }
 
-    @media (pointer: coarse) {
+    @media (hover: none) {
       &:active {
-        ${backgroundTransformHoverActive};
+        ${backgroundTransform};
       }
     }
   }

--- a/content/webapp/components/AudioPlayerNew/AudioPlayer.tsx
+++ b/content/webapp/components/AudioPlayerNew/AudioPlayer.tsx
@@ -56,7 +56,7 @@ const SkipPlayWrapper = styled.div`
   justify-content: center;
 `;
 
-const colorTransformHoverActive = css<{ $isDark: boolean }>`
+const colorTransform = css<{ $isDark: boolean }>`
   color: ${props =>
     props.$isDark ? props.theme.color('white') : props.theme.color('black')};
   transform: scale(1.1);
@@ -72,13 +72,13 @@ const SkipButton = styled.button<{ $isDark: boolean }>`
 
   @media (hover: hover) {
     &:hover {
-      ${colorTransformHoverActive};
+      ${colorTransform};
     }
   }
 
   @media (hover: none) {
     &:active {
-      ${colorTransformHoverActive};
+      ${colorTransform};
     }
   }
 `;


### PR DESCRIPTION
This prevents the style from persisting when touch is released (which is what happens with :hover)

## What does this change?
We want the hover styles from desktop to apply on mobile _only_ when the user is touching the screen. This applies `:hover` styles when ~`pointer: fine`~ `hover: hover` (i.e. mouse) and `:active` styles when ~`pointer: coarse`~ `hover: none` (i.e. finger)

## How to test
Run in Simulator and check the scrubber, play/pause, and skip buttons styles don't persist when you let go

## How can we measure success?
Nicer UI/UX

## Have we considered potential risks?
n/a