### PR TITLE
Fix new AudioPlayer styling in cardigan (and make transcript obey theme)

### DIFF
--- a/cardigan/stories/components/AudioPlayerNew/AudioPlayerNew.stories.tsx
+++ b/cardigan/stories/components/AudioPlayerNew/AudioPlayerNew.stories.tsx
@@ -33,5 +33,11 @@ type Story = StoryObj<typeof AudioPlayer>;
 
 export const Basic: Story = {
   name: 'AudioPlayerNew',
-  render: args => <AudioPlayer {...args} />,
+  render: args => (
+    <div
+      style={{ padding: '20px', background: args.isDark ? '#111' : 'white' }}
+    >
+      <AudioPlayer {...args} />
+    </div>
+  ),
 };

--- a/common/views/components/CollapsibleContent/index.tsx
+++ b/common/views/components/CollapsibleContent/index.tsx
@@ -27,6 +27,7 @@ const IconContainer = styled.div<{ $darkTheme?: boolean }>`
 const Control = styled.button.attrs({
   className: font('intb', 5),
 })`
+  color: inherit;
   display: flex;
   align-items: center;
 

--- a/content/webapp/components/AudioPlayerNew/AudioPlayer.tsx
+++ b/content/webapp/components/AudioPlayerNew/AudioPlayer.tsx
@@ -358,6 +358,7 @@ export const AudioPlayer: FunctionComponent<AudioPlayerProps> = ({
       {!!(transcript?.length && transcript.length > 0) && (
         <Space $v={{ size: 'm', properties: ['margin-top'] }}>
           <CollapsibleContent
+            darkTheme={isDark}
             id={`audioPlayerTranscript-${audioFile}`}
             controlText={{
               contentShowingText: 'Hide the transcript',


### PR DESCRIPTION
## What does this change?
Makes the AudioPlayer look nicer in Cardigan by adding some padding. Also we make any transcript added to the AudioPlayer obey the light/dark theme (and update cardigan background accordingly).

I'd also noticed that a transcript in a CollapsibleContent that was part of the light version would appear blue on iOS because of [the previously discovered issue](https://github.com/wellcomecollection/wellcomecollection.org/issues/11747) and fixed that at the same time.

## How to test

Look at the [component in Cardigan](http://localhost:9001/?path=/story/components-audioplayernew--basic&args=isDark:!false&globals=backgrounds.value:transparent) and change the `isDark` prop. Check the component has some padding and the transcript toggle changes with the light/dark version change

## How can we measure success?
n/a

## Have we considered potential risks?
n/a