### PR TITLE
Add hove state to playrate toggle

### DIFF
--- a/content/webapp/components/AudioPlayerNew/AudioPlayer.PlayRate.tsx
+++ b/content/webapp/components/AudioPlayerNew/AudioPlayer.PlayRate.tsx
@@ -11,12 +11,19 @@ const TogglePlayRateButton = styled.button.attrs({
   className: font('intr', 6),
 })<{ $isDark: boolean }>`
   color: ${props =>
-    props.$isDark ? props.theme.color('yellow') : props.theme.color('black')};
+    props.$isDark ? props.theme.color('white') : props.theme.color('black')};
   padding: 0;
 
   span {
+    color: ${props => props.theme.color('yellow')};
     display: flex;
     justify-content: end;
+    transition: color 0.2s ease-in-out;
+  }
+
+  &:hover span {
+    color: ${props =>
+      props.$isDark ? props.theme.color('white') : props.theme.color('black')};
   }
 `;
 


### PR DESCRIPTION
## What does this change?

Adds a hover state to the play rate toggle button that I missed in the spec.

## How to test

Check it looks like this

![hoverplayrate](https://github.com/user-attachments/assets/e027d2c4-efc1-471d-8090-27900c6ff464)

## How can we measure success?
Looks like designs

## Have we considered potential risks?
n/a