### PR TITLE
Force ordering on events search behind events listing toggle

### DIFF
--- a/content/webapp/pages/search/events.tsx
+++ b/content/webapp/pages/search/events.tsx
@@ -206,6 +206,7 @@ export const getServerSideProps: GetServerSideProps<
   setCacheControl(context.res, cacheTTL.search);
   const serverData = await getServerData(context);
   const dateFilter = !!serverData.toggles.dateFilter.value;
+  const filterEventsListing = !!serverData.toggles.filterEventsListing.value;
 
   const query = context.query;
   const params = fromQuery(query);
@@ -253,8 +254,16 @@ export const getServerSideProps: GetServerSideProps<
   const eventResponseList = await getEvents({
     params: {
       ...paramsQuery,
-      sort: getQueryPropertyValue(query.sort),
-      sortOrder: getQueryPropertyValue(query.sortOrder),
+      sort: filterEventsListing
+        ? validTimespan === 'past' || validTimespan === 'future'
+          ? 'times.startDateTime'
+          : 'relevance'
+        : getQueryPropertyValue(query.sort),
+      sortOrder: filterEventsListing
+        ? validTimespan === 'past'
+          ? 'desc'
+          : 'asc'
+        : getQueryPropertyValue(query.sortOrder),
       ...(pageNumber && { page: Number(pageNumber) }),
       aggregations: [
         'format',


### PR DESCRIPTION
## What does this change?

https://github.com/wellcomecollection/content-api/issues/241#issuecomment-2827694150

Forgot this use case, so this should sort out the ordering behind the Events listing changes toggle (which spread to Search because of how we figured out sorting behind it).

## How to test

Shouldn't break anything without the toggle on
Ordering should make sense with the toggle on

## How can we measure success?

Sorting makes sense across all events listings

## Have we considered potential risks?
N/A