### PR TITLE
Item available dates

### DIFF
--- a/content/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
+++ b/content/webapp/components/PhysicalItemDetails/PhysicalItemDetails.tsx
@@ -138,11 +138,14 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
   const showAccessStatus = !!accessStatus;
   const showAccessMethod = !isOpenShelves;
   const isRequestable = itemIsRequestable(item) && !wasJustRequested(item);
-
-  const showButton =
-    isRequestable && userState === 'signedin' && !disableRequesting;
-
   const userNotLoaded = userState === 'loading' || userState === 'initial';
+
+  const isLoading = accessDataIsStale || (isRequestable && userNotLoaded);
+  const showButton =
+    isRequestable &&
+    userState === 'signedin' &&
+    !disableRequesting &&
+    !isLoading;
 
   const title = item.title || '';
   const itemNote = item.note || '';
@@ -164,7 +167,6 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
       </>,
     ];
 
-    const isLoading = accessDataIsStale || (isRequestable && userNotLoaded);
     if (showAccessStatus) {
       dataRow.push(
         <Placeholder isLoading={isLoading} nRows={2} maxWidth="75%">

--- a/content/webapp/components/PhysicalItems/PhysicalItems.tsx
+++ b/content/webapp/components/PhysicalItems/PhysicalItems.tsx
@@ -55,7 +55,7 @@ const PhysicalItems: FunctionComponent<Props> = ({
   useEffect(() => {
     setItemsState(getItemsState(workItems));
     setPhysicalItems(workItems);
-  }, [workItems]);
+  }, [work]);
 
   useAbortSignalEffect(
     signal => {

--- a/content/webapp/components/PhysicalItems/PhysicalItems.tsx
+++ b/content/webapp/components/PhysicalItems/PhysicalItems.tsx
@@ -41,40 +41,6 @@ const getItemsState = (items: PhysicalItem[]): ItemsState => {
     : 'up-to-date';
 };
 
-const useItemsState = (
-  items: PhysicalItem[]
-): [ItemsState, (s: ItemsState) => void] => {
-  /* https://github.com/wellcomecollection/wellcomecollection.org/issues/7120#issuecomment-938035546
-   *
-   * What if we don’t call the items API? There are two possible error cases:
-   *
-   * (1) We don’t show a “request item” button when an item is ready to request.
-   *     This could occur if an item was on hold, has been returned to the stores,
-   *     and we haven’t had the update through the catalogue pipeline yet.
-   * (2) We show a “request item” button when an item isn’t available to request.
-   *     Run the same scenario in reverse: somebody has put the item on hold,
-   *     but we haven’t realised yet in the catalogue API.
-   *
-   * Error (2) is worse than error (1).
-   *
-   * To avoid them:
-   *
-   * Query the items API if the status is “temporarily unavailable”
-   * Query the items API if you want to display a button based on the catalogue API data
-   *
-   * In all other cases the items API would be a no-op.
-   */
-  const [itemsState, setItemsState] = useState<ItemsState>(
-    getItemsState(items)
-  );
-
-  useEffect(() => {
-    setItemsState(getItemsState(items));
-  }, [items]);
-
-  return [itemsState, setItemsState];
-};
-
 const PhysicalItems: FunctionComponent<Props> = ({
   work,
   items: workItems,
@@ -82,9 +48,12 @@ const PhysicalItems: FunctionComponent<Props> = ({
   const { state: userState } = useUser();
   const [userHolds, setUserHolds] = useState<Set<string>>();
   const [physicalItems, setPhysicalItems] = useState(workItems);
-  const [itemsState, setItemsState] = useItemsState(workItems);
+
+  // https://github.com/wellcomecollection/wellcomecollection.org/issues/7120#issuecomment-938035546
+  const [itemsState, setItemsState] = useState(getItemsState(workItems));
 
   useEffect(() => {
+    setItemsState(getItemsState(workItems));
     setPhysicalItems(workItems);
   }, [workItems]);
 

--- a/content/webapp/components/WorkDetails/index.tsx
+++ b/content/webapp/components/WorkDetails/index.tsx
@@ -1,5 +1,5 @@
 import { usePathname } from 'next/navigation';
-import { FunctionComponent, useContext } from 'react';
+import { FunctionComponent, useContext, useMemo } from 'react';
 
 import { DigitalLocation } from '@weco/common/model/catalogue';
 import { font } from '@weco/common/utils/classnames';
@@ -120,7 +120,10 @@ const WorkDetails: FunctionComponent<Props> = ({
 
   const seriesPartOfs = work.partOf.filter(p => !p.id);
 
-  const physicalItems = getItemsWithPhysicalLocation(work.items ?? []);
+  const physicalItems = useMemo(
+    () => getItemsWithPhysicalLocation(work.items ?? []),
+    [work.items]
+  );
 
   const locationOfWork = work.notes.find(
     note => note.noteType.id === 'location-of-original'


### PR DESCRIPTION
For [#5879](https://github.com/wellcomecollection/platform/issues/5879)

## What does this change?

- Prevents the request button from being visible we know you can click it
- Simplifies the `useItemsState` hook into two lines
- Memoises the `physicalItems` which reduces re-rendering locally (I'm not sure if it would necessarily make things better in prod but can't hurt?)

I'm not clear on what is different about the way I've re-implemented `useItemsState` (with a `useState` and `useEffect` not wrapped in a function), but it seems to improve the situation (and I find it easier to reason about)

## How to test

- Visit a requestable work (http://localhost:3000/works/spq4snpy) and refresh lots of times – check that the requesting button consistently appears
- Visit an archive with requestable items (http://localhost:3000/works/pxr3mfzx) and click to another item in the archive – does the requesting section re-render (it should)?


## How can we measure success?
More people able to request things

## Have we considered potential risks?
Still not clear how/why react re-renders sometimes and not at others