### PR TITLE
Video, audio, PDF thumbnails

### DIFF
--- a/content/webapp/components/IIIFViewer/GridViewer.tsx
+++ b/content/webapp/components/IIIFViewer/GridViewer.tsx
@@ -51,6 +51,7 @@ type CellProps = {
     searchResults: SearchResults;
     query: Query;
     workId: string;
+    placeholderId?: string;
   };
 };
 
@@ -64,6 +65,7 @@ const Cell = memo(({ columnIndex, rowIndex, style, data }: CellProps) => {
     searchResults,
     query,
     workId,
+    placeholderId,
   } = data;
   const canvasIndex = rowIndex * columnCount + columnIndex;
   const currentCanvas = canvases[canvasIndex];
@@ -105,6 +107,7 @@ const Cell = memo(({ columnIndex, rowIndex, style, data }: CellProps) => {
             >
               <IIIFCanvasThumbnail
                 canvas={currentCanvas}
+                placeholderId={placeholderId}
                 thumbNumber={arrayIndexToQueryParam(canvasIndex)}
                 highlightImage={hasSearchResults}
               />
@@ -195,6 +198,7 @@ const GridViewer: FunctionComponent = () => {
           mainAreaWidth,
           query,
           workId: work.id,
+          placeholderId: transformedManifest?.placeholderId,
         }}
         onScroll={({ scrollTop }) => setNewScrollOffset(scrollTop)}
         ref={grid}

--- a/content/webapp/components/IIIFViewer/IIIFCanvasThumbnail.tsx
+++ b/content/webapp/components/IIIFViewer/IIIFCanvasThumbnail.tsx
@@ -11,7 +11,11 @@ import Space from '@weco/common/views/components/styled/Space';
 import { useUser } from '@weco/common/views/components/UserProvider';
 import { IIIFItemProps } from '@weco/content/components/IIIFItem';
 import { TransformedCanvas } from '@weco/content/types/manifest';
-import { isChoiceBody, isPDFCanvas } from '@weco/content/utils/iiif/v3';
+import {
+  isAudioCanvas,
+  isChoiceBody,
+  isPDFCanvas,
+} from '@weco/content/utils/iiif/v3';
 
 import IIIFViewerImage from './IIIFViewerImage';
 import Padlock from './Padlock';
@@ -108,10 +112,7 @@ const IIIFCanvasThumbnail: FunctionComponent<IIIFCanvasThumbnailProps> = ({
 
   const hasIconPlaceholder =
     !thumbnailSrc &&
-    (itemType === 'Sound' ||
-      itemType === 'Audio' ||
-      itemType === 'Video' ||
-      isPDFCanvas(canvas));
+    (itemType === 'Sound' || isAudioCanvas(canvas) || isPDFCanvas(canvas));
 
   return (
     <IIIFViewerThumb>

--- a/content/webapp/components/IIIFViewer/IIIFCanvasThumbnail.tsx
+++ b/content/webapp/components/IIIFViewer/IIIFCanvasThumbnail.tsx
@@ -1,12 +1,17 @@
+import { IIIFExternalWebResource } from '@iiif/presentation-3';
 import { FunctionComponent, useState } from 'react';
 import styled from 'styled-components';
 
+import { audio, file, video } from '@weco/common/icons';
 import { font } from '@weco/common/utils/classnames';
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
+import Icon from '@weco/common/views/components/Icon';
 import LL from '@weco/common/views/components/styled/LL';
 import Space from '@weco/common/views/components/styled/Space';
 import { useUser } from '@weco/common/views/components/UserProvider';
+import { IIIFItemProps } from '@weco/content/components/IIIFItem';
 import { TransformedCanvas } from '@weco/content/types/manifest';
+import { isChoiceBody, isPDFCanvas } from '@weco/content/utils/iiif/v3';
 
 import IIIFViewerImage from './IIIFViewerImage';
 import Padlock from './Padlock';
@@ -64,16 +69,25 @@ const IIIFViewerThumbNumber = styled.span.attrs({
   }
 `;
 
+const IconWrapper = styled.span`
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
 type IIIFCanvasThumbnailProps = {
   canvas: TransformedCanvas;
   thumbNumber: number;
   highlightImage?: boolean;
+  placeholderId?: string;
 };
 
 const IIIFCanvasThumbnail: FunctionComponent<IIIFCanvasThumbnailProps> = ({
   canvas,
   thumbNumber,
   highlightImage,
+  placeholderId,
 }: IIIFCanvasThumbnailProps) => {
   const [thumbnailLoaded, setThumbnailLoaded] = useState(false);
   const { userIsStaffWithRestricted } = useUser();
@@ -82,50 +96,88 @@ const IIIFCanvasThumbnail: FunctionComponent<IIIFCanvasThumbnailProps> = ({
     ? iiifImageTemplate(canvas.imageServiceId)
     : undefined;
 
+  const thumbnailSrc =
+    canvas?.thumbnailImage?.url ||
+    (urlTemplate && urlTemplate({ size: '200,' })) ||
+    placeholderId;
+
+  const itemType = isChoiceBody(canvas?.painting?.[0])
+    ? (canvas.painting[0].items[0] as IIIFExternalWebResource | IIIFItemProps)
+        ?.type
+    : canvas.painting?.[0]?.type;
+
+  const hasIconPlaceholder =
+    !thumbnailSrc &&
+    (itemType === 'Sound' ||
+      itemType === 'Audio' ||
+      itemType === 'Video' ||
+      isPDFCanvas(canvas));
+
   return (
     <IIIFViewerThumb>
       <IIIFViewerThumbInner>
         <ImageContainer>
-          {!thumbnailLoaded && !isRestricted && (
-            <LL $small={true} $lighten={true} />
-          )}
-          {isRestricted && !userIsStaffWithRestricted ? (
+          {isRestricted && !userIsStaffWithRestricted && (
             <>
               <Padlock />
               <span className="visually-hidden">
                 Thumbnail image is not available
               </span>
             </>
-          ) : (
-            <IIIFViewerImage
-              highlightImage={highlightImage}
-              width={canvas?.thumbnailImage?.width || 30}
-              src={
-                canvas?.thumbnailImage?.url ||
-                (urlTemplate && urlTemplate({ size: '200,' }))
-              }
-              srcSet=""
-              sizes={`${canvas?.thumbnailImage?.width || 30}px`}
-              alt=""
-              loadHandler={() => {
-                setThumbnailLoaded(true);
-              }}
-            />
+          )}
+
+          {!isRestricted && (
+            <>
+              {thumbnailSrc ? (
+                <>
+                  {!thumbnailLoaded && <LL $small={true} $lighten={true} />}
+
+                  <IIIFViewerImage
+                    highlightImage={highlightImage}
+                    width={canvas?.thumbnailImage?.width || 30}
+                    src={thumbnailSrc}
+                    srcSet=""
+                    sizes={`${canvas?.thumbnailImage?.width || 30}px`}
+                    alt=""
+                    loadHandler={() => {
+                      setThumbnailLoaded(true);
+                    }}
+                  />
+                </>
+              ) : (
+                <>
+                  {hasIconPlaceholder && (
+                    <IconWrapper>
+                      <Icon
+                        icon={
+                          itemType === 'Sound'
+                            ? audio
+                            : itemType === 'Video'
+                              ? video
+                              : file
+                        }
+                        iconColor="white"
+                        sizeOverride="width: 53px; height: 53px;"
+                      />
+                    </IconWrapper>
+                  )}
+                </>
+              )}
+            </>
           )}
         </ImageContainer>
+
         <div>
-          <>
-            <Space $v={{ size: 's', properties: ['margin-bottom'] }}>
-              <IIIFViewerThumbNumber>
-                {canvas.label?.trim() !== '-' && 'page'} {canvas.label}
-              </IIIFViewerThumbNumber>
-            </Space>
-            <div>
-              <IIIFViewerThumbNumber>
-                <span style={{ fontSize: '11px' }}>{`${thumbNumber}`}</span>
-              </IIIFViewerThumbNumber>
-            </div>
-          </>
+          <Space $v={{ size: 's', properties: ['margin-bottom'] }}>
+            <IIIFViewerThumbNumber>
+              {canvas.label?.trim() !== '-' && 'page'} {canvas.label}
+            </IIIFViewerThumbNumber>
+          </Space>
+          <div>
+            <IIIFViewerThumbNumber>
+              <span style={{ fontSize: '11px' }}>{`${thumbNumber}`}</span>
+            </IIIFViewerThumbNumber>
+          </div>
         </div>
       </IIIFViewerThumbInner>
     </IIIFViewerThumb>

--- a/content/webapp/components/IIIFViewer/ViewerTopBar.tsx
+++ b/content/webapp/components/IIIFViewer/ViewerTopBar.tsx
@@ -29,6 +29,7 @@ import {
   getDownloadOptionsFromCanvasRenderingAndSupplementing,
   getDownloadOptionsFromManifestRendering,
   getImageServiceFromItem,
+  isAudioCanvas,
   isChoiceBody,
 } from '@weco/content/utils/iiif/v3';
 import { getDownloadOptionsFromImageUrl } from '@weco/content/utils/works';
@@ -283,16 +284,13 @@ const ViewerTopBar: FunctionComponent<ViewerTopBarProps> = ({
   const videoAudioDownloadOptions = () => {
     if (!currentCanvas?.painting) return [];
 
-    const isAudio = (item: IIIFItemProps) =>
-      item.type === 'Sound' || item.type === 'Audio';
-
     const formatItemInfo = item => ({
       format: item.format || '',
       id: item.id || '',
       label:
         item.type === 'Video'
           ? 'This video'
-          : isAudio(item)
+          : isAudioCanvas(item)
             ? 'This audio'
             : '',
     });
@@ -308,7 +306,7 @@ const ViewerTopBar: FunctionComponent<ViewerTopBarProps> = ({
 
             if (
               externalResourceItem.type !== 'Video' &&
-              !isAudio(externalResourceItem)
+              !isAudioCanvas(externalResourceItem)
             )
               return undefined;
 
@@ -317,7 +315,7 @@ const ViewerTopBar: FunctionComponent<ViewerTopBarProps> = ({
         });
     } else {
       currentCanvas.painting.forEach(item => {
-        if (item.type !== 'Video' && !isAudio(item)) return undefined;
+        if (item.type !== 'Video' && !isAudioCanvas(item)) return undefined;
 
         finalOptions.push(formatItemInfo(item));
       });

--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -685,6 +685,12 @@ export function isPDFCanvas(canvas?: TransformedCanvas): boolean {
   return hasOriginalPdf([canvas]) || (hasPDFSupplement && !hasPaintings);
 }
 
+export function isAudioCanvas(
+  canvas: TransformedCanvas | IIIFItemProps
+): boolean {
+  return canvas.type === 'Sound' || canvas.type === 'Audio';
+}
+
 export function isCollection(
   manifest: Manifest | Collection
 ): manifest is Collection {


### PR DESCRIPTION
> [!NOTE]
> Would recommend reviewing while hiding whitespace changes

## What does this change?

#11690


IF an Audio/Video/PDF file does not have either a thumbnail image or a `placeholderId`, (which is a poster image, I believe mostly for videos?), then it displays the relevant icon.

This is quite rare, most files have a (bad) thumbnail image, so most of the time that'll be what's shown: 
<img width="400" alt="Screenshot 2025-04-29 at 12 10 30" src="https://github.com/user-attachments/assets/d1f14d40-6a85-40b3-99bb-c1e06f9b71c9" />
<img width="400" alt="Screenshot 2025-04-29 at 17 04 27" src="https://github.com/user-attachments/assets/515eb108-afde-4dcf-b8c6-91b3c395d3a8" />
and sometimes the field is not empty and yet the image does not work and therefore loads forever (ex: https://www-dev.wellcomecollection.org/works/sx4p4b75/items): 
<img width="400" alt="Screenshot 2025-04-29 at 17 05 15" src="https://github.com/user-attachments/assets/385a9879-f143-4f31-a032-05c48e81edd2" />

But should it happen that those fields are empty, then the relevant icon should be shown. I only found one example: https://wellcomecollection.org/works/dn9jwck6/items

A change from prod is that we didn't pass `placeholderId` before, so it was the loading thumbnail for everything that did not have a thumbnail image (see https://wellcomecollection.org/works/k9k5vv2q/items), so at least that's a nicer view?

I added a `isPDFCanvas` helper function based on what @gestchild told me we consider PDF canvases! Maybe it could be used elsewhere in the codebase?


## How to test

Run locally; I made the grid view be available for every work since most videos only have one canvas, so I could view it that way. But like I said above, I couldn't find a video without a pre-existing thumbnail, but you can at least make sure it doesn't break anything/looks better than it currently does in prod:
PDF: https://www-dev.wellcomecollection.org/works/zu2q4k2w/items
Video: https://www-dev.wellcomecollection.org/works/sx4p4b75/items
Audio: https://www-dev.wellcomecollection.org/works/k9k5vv2q/items
Mixed media: https://wellcomecollection.org/works/dn9jwck6/items

## How can we measure success?

Less loading states in grid view?

## Have we considered potential risks?
 N/A