### PR TITLE
Reset scrubber to zero after audioFile change on iOS

### DIFF
--- a/content/webapp/components/AudioPlayerNew/index.tsx
+++ b/content/webapp/components/AudioPlayerNew/index.tsx
@@ -171,10 +171,16 @@ export const AudioPlayer: FunctionComponent<AudioPlayerProps> = ({
   const progressBarRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
+    if (!progressBarRef.current) return;
     // If we change the player dynamically, we need to reset the play/pause
     // button to the appropriate state
     setIsPlaying(false);
-  }, [audioFile]);
+    // iOS needs a manual update to currentTime and the progressBarRef
+    // to reset the time and the range slider thumb correctly
+    // after an audioFile change
+    setCurrentTime(0);
+    progressBarRef.current.value = `0`;
+  }, [audioFile, progressBarRef.current]);
 
   useEffect(() => {
     if (!audioPlayerRef.current) return;

--- a/content/webapp/components/AudioPlayerNew/index.tsx
+++ b/content/webapp/components/AudioPlayerNew/index.tsx
@@ -179,10 +179,12 @@ export const AudioPlayer: FunctionComponent<AudioPlayerProps> = ({
     // to reset the time and the range slider thumb correctly
     // after an audioFile change
     setCurrentTime(0);
+    setStartTime(0);
     progressBarRef.current.value = `0`;
   }, [audioFile, progressBarRef.current]);
 
   useEffect(() => {
+    console.log('2');
     if (!audioPlayerRef.current) return;
     if (!progressBarRef.current) return;
 
@@ -249,6 +251,7 @@ export const AudioPlayer: FunctionComponent<AudioPlayerProps> = ({
   };
 
   const onScrubberChange = () => {
+    console.log('oi o i');
     if (!audioPlayerRef.current) return;
     if (!progressBarRef.current) return;
 

--- a/content/webapp/components/AudioPlayerNew/index.tsx
+++ b/content/webapp/components/AudioPlayerNew/index.tsx
@@ -184,7 +184,6 @@ export const AudioPlayer: FunctionComponent<AudioPlayerProps> = ({
   }, [audioFile, progressBarRef.current]);
 
   useEffect(() => {
-    console.log('2');
     if (!audioPlayerRef.current) return;
     if (!progressBarRef.current) return;
 
@@ -251,7 +250,6 @@ export const AudioPlayer: FunctionComponent<AudioPlayerProps> = ({
   };
 
   const onScrubberChange = () => {
-    console.log('oi o i');
     if (!audioPlayerRef.current) return;
     if (!progressBarRef.current) return;
 


### PR DESCRIPTION
## What does this change?
Fixes a bug on iOS where the time and now playing scrubber wouldn't reset after an audioFile change (i.e. if you client-side route to a different page without reinstantiating the AudioPlayer)

## How to test
Visit a [guide stop](http://localhost:3000/guides/exhibitions/hard-graft/audio-without-descriptions/11) using the iOS simulator, move the now playing timeline into the middle of the slider, click prev or next, check that the scrubber is reset to the start and the time is 00:00

## How can we measure success?
Less bugs

## Have we considered potential risks?
Still behind a toggle so minimal