### PR TITLE
Apply scrubber thumb hover styles when timeline is hovered too

### DIFF
--- a/content/webapp/components/AudioPlayerNew/AudioPlayer.Scrubber.tsx
+++ b/content/webapp/components/AudioPlayerNew/AudioPlayer.Scrubber.tsx
@@ -88,10 +88,11 @@ const PercentComplete = styled.div<{
   }
 
   @media (hover: hover) {
-    &:hover
-      ${RangeSlider}::-webkit-slider-thumb,
-      &:hover
-      ${RangeSlider}::-moz-range-thumb {
+    &:hover ${RangeSlider}::-webkit-slider-thumb {
+      ${backgroundTransform};
+    }
+
+    &:hover ${RangeSlider}::-moz-range-thumb {
       ${backgroundTransform};
     }
   }

--- a/content/webapp/components/AudioPlayerNew/AudioPlayer.Scrubber.tsx
+++ b/content/webapp/components/AudioPlayerNew/AudioPlayer.Scrubber.tsx
@@ -9,6 +9,31 @@ const backgroundTransform = css<{ $isDark: boolean }>`
   transform: scale(1.5);
 `;
 
+const thumbStyles = css`
+  background: ${props => props.theme.color('yellow')};
+  appearance: none;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  border: 0;
+
+  transition:
+    background 0.2s ease-out,
+    transform 0.2s ease-out;
+
+  @media (hover: hover) {
+    &:hover {
+      ${backgroundTransform};
+    }
+  }
+
+  @media (hover: none) {
+    &:active {
+      ${backgroundTransform};
+    }
+  }
+`;
+
 const RangeSlider = styled.input.attrs({
   type: 'range',
   step: 'any',
@@ -20,53 +45,11 @@ const RangeSlider = styled.input.attrs({
   background: transparent;
 
   &::-webkit-slider-thumb {
-    background: ${props => props.theme.color('yellow')};
-    appearance: none;
-    width: 1rem;
-    height: 1rem;
-    border-radius: 50%;
-    border: 0;
-
-    transition:
-      background 0.2s ease-out,
-      transform 0.2s ease-out;
-
-    @media (hover: hover) {
-      &:hover {
-        ${backgroundTransform};
-      }
-    }
-
-    @media (hover: none) {
-      &:active {
-        ${backgroundTransform};
-      }
-    }
+    ${thumbStyles};
   }
 
   &::-moz-range-thumb {
-    background: ${props => props.theme.color('yellow')};
-    appearance: none;
-    width: 1rem;
-    height: 1rem;
-    border-radius: 50%;
-    border: 0;
-
-    transition:
-      background 0.2s ease-out,
-      transform 0.2s ease-out;
-
-    @media (hover: hover) {
-      &:hover {
-        ${backgroundTransform};
-      }
-    }
-
-    @media (hover: none) {
-      &:active {
-        ${backgroundTransform};
-      }
-    }
+    ${thumbStyles};
   }
 `;
 
@@ -102,6 +85,15 @@ const PercentComplete = styled.div<{
     border-radius: 4px;
     transform: translateY(-50%);
     max-width: 100%;
+  }
+
+  @media (hover: hover) {
+    &:hover
+      ${RangeSlider}::-webkit-slider-thumb,
+      &:hover
+      ${RangeSlider}::-moz-range-thumb {
+      ${backgroundTransform};
+    }
   }
 `;
 


### PR DESCRIPTION
## What does this change?
Adds hover behaviour to the timeline that scales up the thumb (previously this only happened if you hovered the thumb itself).


https://github.com/user-attachments/assets/3b8861bd-d885-4f8c-9e09-000e66bcc65b


## How to test

Visit a [guide stop](http://localhost:3000/guides/exhibitions/hard-graft/audio-without-descriptions/2) (or Cardigan) and hover the timeline

## How can we measure success?
Better UX

## Have we considered potential risks?
n/a