### PR TITLE
Increase playrate button space and align right

### DIFF
--- a/content/webapp/components/AudioPlayerNew/AudioPlayer.PlayRate.tsx
+++ b/content/webapp/components/AudioPlayerNew/AudioPlayer.PlayRate.tsx
@@ -5,7 +5,6 @@ import styled from 'styled-components';
 
 import { font } from '@weco/common/utils/classnames';
 import { AppContext } from '@weco/common/views/components/AppContext';
-import Space from '@weco/common/views/components/styled/Space';
 
 const TogglePlayRateButton = styled.button.attrs({
   className: font('intr', 6),
@@ -27,15 +26,17 @@ const TogglePlayRateButton = styled.button.attrs({
   }
 `;
 
-const PlayRateButton = styled(Space).attrs<{ $isActive: boolean }>(props => ({
+const PlayRateButton = styled.div.attrs<{ $isActive: boolean }>(props => ({
   as: 'button',
-  $v: { size: 'm', properties: ['padding-top', 'padding-bottom'] },
   className: font(props.$isActive ? 'intsb' : 'intr', 6),
 }))<{
   $isDark: boolean;
   $isActive?: boolean;
 }>`
+  padding: ${props => props.theme.spacingUnits['4']}px;
+  line-height: 1.5;
   display: flex;
+  justify-content: right;
   width: 100%;
   color: ${props =>
     props.$isActive
@@ -49,10 +50,8 @@ const PlayRateButton = styled(Space).attrs<{ $isActive: boolean }>(props => ({
   }
 `;
 
-const PlayRateList = styled(Space).attrs({
-  $v: { size: 's', properties: ['padding-top', 'padding-bottom'] },
-  $h: { size: 'm', properties: ['padding-left', 'padding-right'] },
-})<{ $isActive: boolean; $isDark: boolean }>`
+const PlayRateList = styled.div<{ $isActive: boolean; $isDark: boolean }>`
+  padding: ${props => props.theme.spacingUnits['5']}px;
   list-style: none;
   display: ${props => (props.$isActive ? 'block' : 'none')};
   background-color: ${props =>


### PR DESCRIPTION
## What does this change?

Increases the amount of spacing around the playrate buttons for better ease of use on small screens

<img width="192" alt="image" src="https://github.com/user-attachments/assets/8da59678-69e1-4b20-9bcc-7f1dedc9cb10" />


## How to test

Visit a [guide stop](http://localhost:3000/guides/exhibitions/hard-graft/audio-without-descriptions/1) (or Cardigan) and verify the playrate list matches [the design spacing](https://www.figma.com/design/YY8hrWmKYhLm8ZQeYaKiLm/Exhibition-guides?node-id=2688-4623&m=dev)

## How can we measure success?
Better UX

## Have we considered potential risks?
n/a