### PR TITLE
Add spacing between icon and text for full screen

### DIFF
--- a/content/webapp/components/IIIFViewer/ImageViewerControls.tsx
+++ b/content/webapp/components/IIIFViewer/ImageViewerControls.tsx
@@ -32,18 +32,6 @@ const ImageViewerControlsEl = styled.div<{ $showControls?: boolean }>`
   .icon {
     margin: 0;
   }
-
-  .btn__text {
-    border: 0;
-    clip: rect(0 0 0 0);
-    height: 1px;
-    margin: -1px;
-    overflow: hidden;
-    padding: 0;
-    position: absolute;
-    width: 1px;
-    white-space: nowrap;
-  }
 `;
 
 function updateRotatedImages({

--- a/content/webapp/components/IIIFViewer/ViewerBottomBar.tsx
+++ b/content/webapp/components/IIIFViewer/ViewerBottomBar.tsx
@@ -114,7 +114,7 @@ const ViewerBottomBar: FunctionComponent = () => {
                 }}
               >
                 <Icon icon={maximise} />
-                <span className="btn__text">Full screen</span>
+                <span style={{ marginLeft: '7px' }}>Full screen</span>
               </ViewerButton>
             </Space>
           </div>

--- a/content/webapp/components/IIIFViewer/ViewerTopBar.tsx
+++ b/content/webapp/components/IIIFViewer/ViewerTopBar.tsx
@@ -81,15 +81,6 @@ export const ViewerButton = styled.button.attrs({
     outline: none;
     transition: all ${props.theme.transitionProperties};
 
-    .btn__text {
-      position: absolute;
-      right: 100%;
-
-      ${props.theme.media('large')`
-        position: static;
-      `}
-    }
-
     &:not([disabled]):hover {
       border: 2px solid ${props.theme.color('white')};
     }
@@ -461,12 +452,14 @@ const ViewerTopBar: FunctionComponent<ViewerTopBarProps> = ({
                   document['webkitFullscreenElement'] ? (
                     <>
                       <Icon icon={minimise} />
-                      Exit full screen
+                      <span style={{ marginLeft: '7px' }}>
+                        Exit full screen
+                      </span>
                     </>
                   ) : (
                     <>
                       <Icon icon={maximise} />
-                      <span className="btn__text">Full screen</span>
+                      <span style={{ marginLeft: '7px' }}>Full screen</span>
                     </>
                   )}
                 </ViewerButton>


### PR DESCRIPTION
## What does this change?

I think the `.btn__text` class was a leftover from a different configuration of the viewer and wasn't actually working, so I removed. Do flag if I'm wrong!

I needed to add some spacing between the icon and the text following https://github.com/wellcomecollection/wellcomecollection.org/pull/11860 because it's a bit tight

<img width="144" alt="Screenshot 2025-05-01 at 14 05 04" src="https://github.com/user-attachments/assets/7b531943-7b26-4891-969e-7527d499ab29" />\

<img width="173" alt="Screenshot 2025-05-01 at 14 05 09" src="https://github.com/user-attachments/assets/04ac30cc-70c6-47d4-998a-12441cd8d745" />

---

Now looks like: 

<img width="300" alt="Screenshot 2025-05-01 at 13 59 04" src="https://github.com/user-attachments/assets/8576562c-f33a-48da-bb92-dcc7df5c770f" />
<img width="452" alt="Screenshot 2025-05-01 at 13 59 17" src="https://github.com/user-attachments/assets/2b66ffcc-326b-4d76-ad5d-2f1ae029f857" />
<img width="172" alt="Screenshot 2025-05-01 at 13 59 00" src="https://github.com/user-attachments/assets/7cb5b4f4-ef20-4ff7-b4fa-8f9c125aeb22" />


## How to test

Check out item viewer locally

## How can we measure success?

Less unused code / looks better?

## Have we considered potential risks?
N/A