### PR TITLE
Show new audio viewer if toggle is on for audioPlayer and extendedViewer

### DIFF
--- a/common/views/slices/AudioPlayer/index.tsx
+++ b/common/views/slices/AudioPlayer/index.tsx
@@ -4,10 +4,7 @@ import { FunctionComponent } from 'react';
 import { AudioPlayerSlice as RawAudioPlayerSlice } from '@weco/common/prismicio-types';
 import SpacingComponent from '@weco/common/views/components/styled/SpacingComponent';
 import AudioPlayer from '@weco/content/components/AudioPlayer';
-import {
-  LayoutWidth,
-  SliceZoneContext,
-} from '@weco/content/components/Body';
+import { LayoutWidth, SliceZoneContext } from '@weco/content/components/Body';
 import { transformAudioPlayerSlice } from '@weco/content/services/prismic/transformers/body';
 
 export type AudioPlayerProps = SliceComponentProps<

--- a/content/webapp/components/IIIFItem/index.tsx
+++ b/content/webapp/components/IIIFItem/index.tsx
@@ -276,7 +276,7 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
 
     case ((item.type === 'Sound' && !exclude.includes('Sound')) ||
       (item.type === 'Audio' && !exclude.includes('Audio'))) &&
-      Boolean(item.id):
+      !!item.id:
       return (
         <Wrapper
           shouldShowItem={shouldShowItem}
@@ -288,18 +288,14 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
           {audioPlayer && extendedViewer ? (
             <AudioPlayerNew
               isDark
-              audioFile={item.id || ''}
-              title={
-                (canvas.label !== '-' && canvas.label) ||
-                `${titleOverride || ''}`
-              }
+              audioFile={item.id}
+              title={(canvas.label !== '-' && canvas.label) || titleOverride}
             />
           ) : (
             <AudioPlayer
-              audioFile={item.id || ''}
+              audioFile={item.id}
               title={
-                (canvas.label !== '-' && canvas.label) ||
-                `${titleOverride || ''}`
+                (canvas.label !== '-' && canvas.label) || titleOverride || ''
               }
             />
           )}

--- a/content/webapp/components/IIIFItem/index.tsx
+++ b/content/webapp/components/IIIFItem/index.tsx
@@ -11,6 +11,7 @@ import {
   unavailableContentMessage,
 } from '@weco/common/data/microcopy';
 import { information } from '@weco/common/icons';
+import { useToggles } from '@weco/common/server-data/Context';
 import { font } from '@weco/common/utils/classnames';
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
 import Icon from '@weco/common/views/components/Icon';
@@ -21,6 +22,7 @@ import {
 import Space from '@weco/common/views/components/styled/Space';
 import { useUser } from '@weco/common/views/components/UserProvider';
 import AudioPlayer from '@weco/content/components/AudioPlayer';
+import AudioPlayerNew from '@weco/content/components/AudioPlayerNew';
 import BetaMessage from '@weco/content/components/BetaMessage';
 import ImageViewer from '@weco/content/components/IIIFViewer/ImageViewer';
 import VideoPlayer from '@weco/content/components/VideoPlayer';
@@ -245,6 +247,8 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
   const { userIsStaffWithRestricted } = useUser();
   const isRestricted = isItemRestricted(item);
   const shouldShowItem = isItemRestricted(item) && !userIsStaffWithRestricted;
+  const { audioPlayer, extendedViewer } = useToggles();
+
   // N.B. Restricted images are handled differently from restricted audio/video and text.
   // The isItemRestricted function doesn't account for restricted images.
   // Instead there is a hasRestrictedImage property on the TransformedCanvas which is used by
@@ -269,6 +273,7 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
           setImageContainerRect={setImageContainerRect}
         />
       );
+
     case ((item.type === 'Sound' && !exclude.includes('Sound')) ||
       (item.type === 'Audio' && !exclude.includes('Audio'))) &&
       Boolean(item.id):
@@ -280,14 +285,27 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
           canvas={canvas}
           isRestricted={isRestricted}
         >
-          <AudioPlayer
-            audioFile={item.id || ''}
-            title={
-              (canvas.label !== '-' && canvas.label) || `${titleOverride || ''}`
-            }
-          />
+          {audioPlayer && extendedViewer ? (
+            <AudioPlayerNew
+              isDark
+              audioFile={item.id || ''}
+              title={
+                (canvas.label !== '-' && canvas.label) ||
+                `${titleOverride || ''}`
+              }
+            />
+          ) : (
+            <AudioPlayer
+              audioFile={item.id || ''}
+              title={
+                (canvas.label !== '-' && canvas.label) ||
+                `${titleOverride || ''}`
+              }
+            />
+          )}
         </Wrapper>
       );
+
     case item.type === 'Video' && !exclude.includes('Video'):
       return (
         <Wrapper
@@ -307,6 +325,7 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
           </>
         </Wrapper>
       );
+
     case item.type === 'Text' && !exclude.includes('Text'):
       if ('label' in item) {
         const itemLabel = item.label
@@ -340,6 +359,7 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
           </Wrapper>
         );
       }
+
     case item.type === 'Image' && !exclude.includes('Image'):
       return (
         <IIIFImage
@@ -350,6 +370,7 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
           setImageContainerRect={setImageContainerRect}
         />
       );
+
     default: // There are other types we don't do anything with at present, e.g. Dataset
       if (!exclude.includes(item.type)) {
         // If the item hasn't been purposefully excluded then we should show a message


### PR DESCRIPTION
## What does this change?

https://github.com/wellcomecollection/wellcomecollection.org/issues/11520

Only show the new viewer if `audioPlayer` is on (in case we turn the public status OFF) as well as `extendedViewer`.
I tested behaviour (playing and then switching canvas to make sure it didn't keep playing, changing the speed and making sure it keeps it as a preference) and it all works really well (props @davidpmccormick)

## How to test

Here's a work with multiple players: https://www-dev.wellcomecollection.org/works/k9k5vv2q/items
Test it with and without the `extendedViewer` toggle, the new player should only display behind it - mostly because we haven't developed for light mode yet, but also because we should think of a solution for a page without multiple players and making sure they don't all play at the same time (was this discussed?).

## How can we measure success?

Nicer looking and functioning player in viewer.

## Have we considered potential risks?
N/A