### PR TITLE
Add URL parameter 

### DIFF
--- a/dash/webapp/pages/toggles.tsx
+++ b/dash/webapp/pages/toggles.tsx
@@ -50,15 +50,18 @@ const TextBox = styled.p`
   margin: 0;
 `;
 
-const MessageBox = styled(TextBox)<{ $isError?: boolean; $isEnable?: boolean }>`
+const MessageBox = styled(TextBox)<{
+  $isError?: boolean;
+  $isEnabled?: boolean;
+}>`
   margin-bottom: 1em;
   color: ${props => {
     if (props.$isError) return 'darkred';
-    return props.$isEnable ? 'darkgreen' : 'darkblue';
+    return props.$isEnabled ? 'darkgreen' : 'darkblue';
   }};
   background-color: ${props => {
     if (props.$isError) return 'lightcoral';
-    return props.$isEnable ? 'lightgreen' : 'lightblue';
+    return props.$isEnabled ? 'lightgreen' : 'lightblue';
   }};
   font-weight: bold;
 `;
@@ -198,11 +201,11 @@ type AbTest = {
 
 const IndexPage: FunctionComponent = () => {
   const router = useRouter();
-  const { enableToggle, disableToggle } = router.query;
+  const { enableToggle, disableToggle, resetToggles } = router.query;
   const [message, setMessage] = useState<{
     text: string;
     isError?: boolean;
-    isEnable?: boolean;
+    isEnabled?: boolean;
   } | null>(null);
   const [toggleStates, setToggleStates] = useState<ToggleStates>({});
   const [toggles, setToggles] = useState<Toggle[]>([]);
@@ -241,7 +244,7 @@ const IndexPage: FunctionComponent = () => {
           setMessage({
             text: `✅ Toggle "${toggleId}" has been successfully enabled!`,
             isError: false,
-            isEnable: true,
+            isEnabled: true,
           });
         } else {
           deleteCookieCustom(toggleId);
@@ -252,7 +255,7 @@ const IndexPage: FunctionComponent = () => {
           setMessage({
             text: `🔵 Toggle "${toggleId}" has been successfully disabled!`,
             isError: false,
-            isEnable: false,
+            isEnabled: false,
           });
         }
       } else {
@@ -265,14 +268,6 @@ const IndexPage: FunctionComponent = () => {
     [toggles]
   );
 
-  useEffect(() => {
-    if (enableToggle) {
-      handleToggle(enableToggle as string, 'enable');
-    } else if (disableToggle) {
-      handleToggle(disableToggle as string, 'disable');
-    }
-  }, [enableToggle, disableToggle, handleToggle]);
-
   const reset = useCallback(
     () =>
       setToggleStates(
@@ -284,6 +279,20 @@ const IndexPage: FunctionComponent = () => {
       ),
     [toggles]
   );
+
+  useEffect(() => {
+    if (resetToggles !== undefined) {
+      reset();
+      setMessage({
+        text: '🔄 All toggles have been reset to their default values.',
+        isError: false,
+      });
+    } else if (enableToggle) {
+      handleToggle(enableToggle as string, 'enable');
+    } else if (disableToggle) {
+      handleToggle(disableToggle as string, 'disable');
+    }
+  }, [enableToggle, disableToggle, resetToggles, handleToggle, reset]);
 
   const generalToggleIds = ['apiToolbar'];
   const generalToggles = toggles.filter(t => generalToggleIds.includes(t.id));
@@ -305,7 +314,10 @@ const IndexPage: FunctionComponent = () => {
           }}
         >
           {message && (
-            <MessageBox $isError={message.isError} $isEnable={message.isEnable}>
+            <MessageBox
+              $isError={message.isError}
+              $isEnabled={message.isEnabled}
+            >
               {message.text}
             </MessageBox>
           )}

--- a/dash/webapp/yarn.lock
+++ b/dash/webapp/yarn.lock
@@ -692,10 +692,10 @@ tslib@2.6.2, tslib@^2.4.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
-typescript@^5.5.3:
-  version "5.5.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.3.tgz#e1b0a3c394190838a0b168e771b0ad56a0af0faa"
-  integrity sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==
+typescript@^5.8.3:
+  version "5.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.3.tgz#92f8a3e5e3cf497356f4178c34cd65a7f5e8440e"
+  integrity sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==
 
 update-browserslist-db@^1.0.13:
   version "1.0.13"


### PR DESCRIPTION
> [!Note]
> This change has been deployed.

## What does this change?

This change allows the addition of URL parameters to dashboard requests that will enable or disable toggles. This allows links to be passed around that will turn on or off features for users, rather than requiring them to find the necessary toggle in the list.

For example:

**Enable** the new theme pages: `https://dash.wellcomecollection.org/toggles/?enableToggle=newThemePages` 
<img width="873" alt="Screenshot 2025-05-02 at 10 58 41" src="https://github.com/user-attachments/assets/219b3371-c607-4407-938b-920f3c91b016" />

**Disable** the new theme pages: `https://dash.wellcomecollection.org/toggles/?disableToggle=newThemePages` 
<img width="873" alt="Screenshot 2025-05-02 at 10 58 56" src="https://github.com/user-attachments/assets/866184f8-025f-4e5d-878a-9d4419e4d25f" />

**Error** with invalid toggle: `https://dash.wellcomecollection.org/toggles/?disableToggle=notThemePages` 
<img width="873" alt="Screenshot 2025-05-02 at 10 59 03" src="https://github.com/user-attachments/assets/8eca43d0-5604-4d7d-8c1a-a7bd05c2af81" />

**Reset** all toggles: `https://dash.wellcomecollection.org/toggles/?resetToggles`
<img width="873" alt="Screenshot 2025-05-02 at 11 21 13" src="https://github.com/user-attachments/assets/374a2521-8cd6-409c-8106-cd69d8a87e7b" />

## How to test

- [ ] Run this locally, does it behave as expected?
- [ ] Deploy this, does it behave as expected?

## How can we measure success?

Easier to show users new features.

## Have we considered potential risks?

Risks should be minimal as this does not impact the user facing site.
