### PR TITLE
Remove conceptsById toggle

### DIFF
--- a/content/webapp/pages/concepts/[conceptId].tsx
+++ b/content/webapp/pages/concepts/[conceptId].tsx
@@ -373,8 +373,7 @@ export const ConceptPage: NextPage<Props> = ({
   apiToolbarLinks,
 }) => {
   useHotjar(true);
-  const { conceptsById, newThemePages } = useToggles();
-  const linkParams = conceptsById ? queryParams : allRecordsLinkParams;
+  const { newThemePages } = useToggles();
 
   const pathname = usePathname();
   const worksTabs = tabOrder
@@ -389,7 +388,7 @@ export const ConceptPage: NextPage<Props> = ({
         tabLabelText: data.label,
         totalResults: data.totalResults.works,
         link: toWorksLink(
-          linkParams(tabId, conceptResponse),
+          allRecordsLinkParams(tabId, conceptResponse),
           linkSources[tabId]
         ),
       });
@@ -411,7 +410,7 @@ export const ConceptPage: NextPage<Props> = ({
         tabLabelText: sectionsData[relationship].label,
         totalResults: sectionsData[relationship].totalResults.images,
         link: toImagesLink(
-          linkParams(tabId, conceptResponse),
+          allRecordsLinkParams(tabId, conceptResponse),
           `${linkSources[tabId]}_${pathname}` as ImagesLinkSource
         ),
       });
@@ -638,8 +637,6 @@ export const getServerSideProps: GetServerSideProps<
     );
   }
 
-  const conceptsById = serverData.toggles?.conceptsById?.value;
-
   const getConceptDocs = {
     works: {
       byId: (sectionName: string) =>
@@ -819,16 +816,7 @@ export const getServerSideProps: GetServerSideProps<
     };
   };
 
-  const totalResults = conceptsById
-    ? {
-        worksAbout: worksAbout?.totalResults,
-        worksBy: worksBy?.totalResults,
-        worksIn: worksIn?.totalResults,
-        imagesAbout: imagesAbout?.totalResults,
-        imagesBy: imagesBy?.totalResults,
-        imagesIn: imagesIn?.totalResults,
-      }
-    : getLabelTotals();
+  const totalResults = getLabelTotals();
 
   const apiToolbarLinks = createApiToolbarLinks(conceptResponse);
 

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -87,14 +87,6 @@ const toggles = {
       type: 'experimental',
     },
     {
-      id: 'conceptsById',
-      title: 'Concepts Improvements',
-      initialValue: false,
-      description:
-        'Use the new concept ID filters & aggregations in the search API to query for works & images by ID rather than label.',
-      type: 'experimental',
-    },
-    {
       id: 'extendedViewer',
       title: 'Allow viewer to render video, audio and pdfs',
       initialValue: false,


### PR DESCRIPTION
## What does this change?

For https://github.com/wellcomecollection/platform/issues/6007

Deletes a now unused toggle.

## How to test

- [x] Run the tests, do they pass?
- [x] Run locally, does it behave as expected?

## How can we measure success?

Removal of unused toggles/code to keep things understandable.

## Have we considered potential risks?

The risks should be minimal as this toggle is now unused.
