### PR TITLE
Only show audio player in audio guide

### DIFF
--- a/content/webapp/pages/guides/exhibitions/[id]/[type]/[stop]/index.tsx
+++ b/content/webapp/pages/guides/exhibitions/[id]/[type]/[stop]/index.tsx
@@ -375,21 +375,20 @@ const ExhibitionGuidePage: FunctionComponent<Props> = props => {
             )}
           </ContaineredLayout>
         </div>
-        {currentStop.audio && audioPlayer && (
-          <AudioPlayerNewWrapper>
-            <Container>
-              <AudioPlayerNew audioFile={currentStop.audio} isDark={true} />
-            </Container>
-          </AudioPlayerNewWrapper>
-        )}
+
+        {type === 'audio-without-descriptions' &&
+          currentStop.audio &&
+          audioPlayer && (
+            <AudioPlayerNewWrapper>
+              <Container>
+                <AudioPlayerNew audioFile={currentStop.audio} isDark={true} />
+              </Container>
+            </AudioPlayerNewWrapper>
+          )}
+
         <PrevNext>
           <Container>
-            <div
-              style={{
-                display: 'flex',
-                justifyContent: 'space-between',
-              }}
-            >
+            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
               <div>
                 {stopNumber > 1 && (
                   <NextLink


### PR DESCRIPTION
[Fixes bug where audio player also displays in BSL guides](https://wellcome.slack.com/archives/CUA669WHH/p1746528403116589)