### PR TITLE
Show item page link for digital locations of type iiif-image

### DIFF
--- a/content/webapp/utils/works.ts
+++ b/content/webapp/utils/works.ts
@@ -382,6 +382,7 @@ export function showItemLink({
   // This means we rely on there only being one type of thing in a manifest, otherwise non video/sound items will be hidden from the user.
   // This is usually the case, except for manifests with 'Born digital' items.
   // But since we display links to all files when there are 'Born digital' items present, then this should not matter.
+
   const hasVideo = hasItemType(canvases, 'Video');
   const hasSound =
     hasItemType(canvases, 'Sound') || hasItemType(canvases, 'Audio');
@@ -394,7 +395,7 @@ export function showItemLink({
   ) {
     return false;
   } else if (
-    hasIIIFManifest &&
+    (hasIIIFManifest || digitalLocation?.locationType.id === 'iiif-image') &&
     digitalLocation &&
     !hasVideo &&
     !hasSound &&


### PR DESCRIPTION
## What does this change?

See https://wellcome.slack.com/archives/CUA669WHH/p1746536018629519

https://wellcomecollection.org/works/jcqn75bf should show a link to the item page.

It doesn't because one of the conditionals for showing the item link was whether the work had a iiif manifest. In this case it doesn't, but it does have a digital location of iiif-image and we should also show the link for this condition too.

## How to test

Visit [/works/jcqn75bf](localhost:3000/works/jcqn75bf) and see that there is an item page link

## How can we measure success?

Users can view more things on the item page

## Have we considered potential risks?

None really 

