### PR TITLE
Req items: revert some changes from prior PR

### DIFF
--- a/content/webapp/components/PhysicalItems/index.tsx
+++ b/content/webapp/components/PhysicalItems/index.tsx
@@ -41,6 +41,40 @@ const getItemsState = (items: PhysicalItem[]): ItemsState => {
     : 'up-to-date';
 };
 
+const useItemsState = (
+  items: PhysicalItem[]
+): [ItemsState, (s: ItemsState) => void] => {
+  /* https://github.com/wellcomecollection/wellcomecollection.org/issues/7120#issuecomment-938035546
+   *
+   * What if we don’t call the items API? There are two possible error cases:
+   *
+   * (1) We don’t show a “request item” button when an item is ready to request.
+   *     This could occur if an item was on hold, has been returned to the stores,
+   *     and we haven’t had the update through the catalogue pipeline yet.
+   * (2) We show a “request item” button when an item isn’t available to request.
+   *     Run the same scenario in reverse: somebody has put the item on hold,
+   *     but we haven’t realised yet in the catalogue API.
+   *
+   * Error (2) is worse than error (1).
+   *
+   * To avoid them:
+   *
+   * Query the items API if the status is “temporarily unavailable”
+   * Query the items API if you want to display a button based on the catalogue API data
+   *
+   * In all other cases the items API would be a no-op.
+   */
+  const [itemsState, setItemsState] = useState<ItemsState>(
+    getItemsState(items)
+  );
+
+  useEffect(() => {
+    setItemsState(getItemsState(items));
+  }, [items]);
+
+  return [itemsState, setItemsState];
+};
+
 const PhysicalItems: FunctionComponent<Props> = ({
   work,
   items: workItems,
@@ -48,14 +82,11 @@ const PhysicalItems: FunctionComponent<Props> = ({
   const { state: userState } = useUser();
   const [userHolds, setUserHolds] = useState<Set<string>>();
   const [physicalItems, setPhysicalItems] = useState(workItems);
-
-  // https://github.com/wellcomecollection/wellcomecollection.org/issues/7120#issuecomment-938035546
-  const [itemsState, setItemsState] = useState(getItemsState(workItems));
+  const [itemsState, setItemsState] = useItemsState(workItems);
 
   useEffect(() => {
-    setItemsState(getItemsState(workItems));
     setPhysicalItems(workItems);
-  }, [work]);
+  }, [workItems]);
 
   useAbortSignalEffect(
     signal => {

--- a/content/webapp/components/WorkDetails/index.tsx
+++ b/content/webapp/components/WorkDetails/index.tsx
@@ -1,5 +1,5 @@
 import { usePathname } from 'next/navigation';
-import { FunctionComponent, useContext, useMemo } from 'react';
+import { FunctionComponent, useContext } from 'react';
 
 import { DigitalLocation } from '@weco/common/model/catalogue';
 import { font } from '@weco/common/utils/classnames';
@@ -120,10 +120,7 @@ const WorkDetails: FunctionComponent<Props> = ({
 
   const seriesPartOfs = work.partOf.filter(p => !p.id);
 
-  const physicalItems = useMemo(
-    () => getItemsWithPhysicalLocation(work.items ?? []),
-    [work.items]
-  );
+  const physicalItems = getItemsWithPhysicalLocation(work.items ?? []);
 
   const locationOfWork = work.notes.find(
     note => note.noteType.id === 'location-of-original'


### PR DESCRIPTION
## What does this change?

Reverts some changes from https://github.com/wellcomecollection/wellcomecollection.org/pull/11841/files
I left the changes to the `showButton` conditions as it made sense for me to keep it, but I haven't dug deep. [Mostly removing because of all the alerts we've been getting in Slack since the PR and I don't have the headspace to fully fix.](https://wellcome.slack.com/archives/C02ANCYL90E/p1746536494213419)

## How to test

Does requesting items still work nicely?

## How can we measure success?

No more alerts in the Slack channel

## Have we considered potential risks?
Breaks something else
