### PR TITLE
Video in viewer

### DIFF
--- a/content/webapp/components/DownloadLink/index.tsx
+++ b/content/webapp/components/DownloadLink/index.tsx
@@ -7,46 +7,57 @@ import { font } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 import Space from '@weco/common/views/components/styled/Space';
 
-const DownloadLinkStyle = styled.a.attrs({
-  className: font('intb', 5),
-})`
+const DownloadLinkStyle = styled.a.attrs<{ $theme: 'dark' | undefined }>(
+  props => ({
+    className: props.$theme === 'dark' ? font('intr', 5) : font('intb', 5),
+  })
+)<{ $theme: 'dark' | undefined }>`
   display: inline-block;
   white-space: nowrap;
-  background: ${props => props.theme.color('white')};
-  color: ${props => props.theme.color('accent.green')};
-
-  text-decoration: underline;
-  text-underline-offset: 0.1em;
+  background: ${props =>
+    props.$theme === 'dark' ? 'none' : props.theme.color('white')};
+  color: ${props =>
+    props.$theme === 'dark'
+      ? props.theme.color('white')
+      : props.theme.color('accent.green')};
   transition: color ${props => props.theme.transitionProperties};
 
   &:hover {
-    color: ${props => props.theme.color('accent.green')};
+    color: ${props =>
+      props.$theme
+        ? props.theme.color('white')
+        : props.theme.color('accent.green')};
     text-decoration-color: transparent;
   }
 `;
 
-const DownloadLinkUnStyled = styled.a`
+const DownloadLinkUnStyled = styled.a<{ $theme?: 'dark' }>`
   position: relative;
 `;
 
-const Format = styled(Space).attrs({
-  className: font('intb', 5),
+const Format = styled(Space).attrs<{ $theme?: 'dark' }>(props => ({
+  className: props.$theme === 'dark' ? font('intr', 5) : font('intb', 5),
   $h: { size: 'm', properties: ['margin-left'] },
-})`
-  color: ${props => props.theme.color('neutral.600')};
+}))<{ $theme?: 'dark' }>`
+  color: ${props =>
+    props.$theme === 'dark'
+      ? props.theme.color('white')
+      : props.theme.color('neutral.600')};
 `;
 
-const TextToDisplay = styled.span`
+const TextToDisplay = styled.span<{ $theme?: 'dark' }>`
   margin: 0;
+  text-decoration: ${props => (props.$theme === 'dark' ? 'underline' : 'none')};
+  text-underline-offset: 0.1em;
 `;
 
 /**
  * TODO: figure out why Icon isn't able to be wrapped by styled...
  */
-const IconWrapper = styled.span<{ $forceInline: boolean }>`
-  div {
-    ${({ $forceInline }) => $forceInline && 'top: 5px;'}
-  }
+const IconWrapper = styled(Space).attrs<{
+  $forceInline: boolean;
+}>({ $h: { size: 's', properties: ['margin-right'] } })`
+  display: inline-flex;
 `;
 
 type DisplayText =
@@ -66,6 +77,7 @@ type Props = {
   width?: 'full' | number;
   mimeType: string;
   trackingTags?: string[];
+  theme?: 'dark';
 } & DisplayText;
 const DownloadLink: FunctionComponent<Props> = ({
   isTabbable = true,
@@ -76,11 +88,13 @@ const DownloadLink: FunctionComponent<Props> = ({
   mimeType,
   trackingTags = [],
   children,
+  theme,
 }: Props) => {
   const Wrapper = linkText ? DownloadLinkStyle : DownloadLinkUnStyled;
-
+  const iconColor = theme === 'dark' ? 'yellow' : 'accent.green';
   return (
     <Wrapper
+      $theme={theme}
       tabIndex={isTabbable ? undefined : -1}
       target="_blank"
       rel="noopener noreferrer"
@@ -100,10 +114,14 @@ const DownloadLink: FunctionComponent<Props> = ({
         }
       >
         <IconWrapper $forceInline={!!children}>
-          <Icon icon={download} matchText={!!children} />
+          <Icon icon={download} matchText={false} iconColor={iconColor} />
         </IconWrapper>
-        <TextToDisplay>{linkText || children}</TextToDisplay>
-        {format && <Format as="span">({format})</Format>}
+        <TextToDisplay $theme={theme}>{linkText || children}</TextToDisplay>
+        {format && (
+          <Format as="span" $theme={theme}>
+            ({format})
+          </Format>
+        )}
       </span>
     </Wrapper>
   );

--- a/content/webapp/components/DownloadLink/index.tsx
+++ b/content/webapp/components/DownloadLink/index.tsx
@@ -114,7 +114,7 @@ const DownloadLink: FunctionComponent<Props> = ({
         }
       >
         <IconWrapper $forceInline={!!children}>
-          <Icon icon={download} matchText={false} iconColor={iconColor} />
+          <Icon icon={download} matchText={!!children} iconColor={iconColor} />
         </IconWrapper>
         <TextToDisplay $theme={theme}>{linkText || children}</TextToDisplay>
         {format && (

--- a/content/webapp/components/DownloadLink/index.tsx
+++ b/content/webapp/components/DownloadLink/index.tsx
@@ -7,47 +7,44 @@ import { font } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 import Space from '@weco/common/views/components/styled/Space';
 
-const DownloadLinkStyle = styled.a.attrs<{ $theme: 'dark' | undefined }>(
-  props => ({
-    className: props.$theme === 'dark' ? font('intr', 5) : font('intb', 5),
-  })
-)<{ $theme: 'dark' | undefined }>`
+const DownloadLinkStyle = styled.a.attrs<{ $isDark?: boolean }>(props => ({
+  className: props.$isDark ? font('intr', 5) : font('intb', 5),
+}))<{ $isDark?: boolean }>`
   display: inline-block;
   white-space: nowrap;
-  background: ${props =>
-    props.$theme === 'dark' ? 'none' : props.theme.color('white')};
+  background: ${props => (props.$isDark ? 'none' : props.theme.color('white'))};
   color: ${props =>
-    props.$theme === 'dark'
+    props.$isDark
       ? props.theme.color('white')
       : props.theme.color('accent.green')};
   transition: color ${props => props.theme.transitionProperties};
 
   &:hover {
     color: ${props =>
-      props.$theme
+      props.$isDark
         ? props.theme.color('white')
         : props.theme.color('accent.green')};
     text-decoration-color: transparent;
   }
 `;
 
-const DownloadLinkUnStyled = styled.a<{ $theme?: 'dark' }>`
+const DownloadLinkUnStyled = styled.a<{ $isDark?: boolean }>`
   position: relative;
 `;
 
-const Format = styled(Space).attrs<{ $theme?: 'dark' }>(props => ({
-  className: props.$theme === 'dark' ? font('intr', 5) : font('intb', 5),
+const Format = styled(Space).attrs<{ $isDark?: boolean }>(props => ({
+  className: props.$isDark ? font('intr', 5) : font('intb', 5),
   $h: { size: 'm', properties: ['margin-left'] },
-}))<{ $theme?: 'dark' }>`
+}))<{ $isDark?: boolean }>`
   color: ${props =>
-    props.$theme === 'dark'
+    props.$isDark
       ? props.theme.color('white')
       : props.theme.color('neutral.600')};
 `;
 
-const TextToDisplay = styled.span<{ $theme?: 'dark' }>`
+const TextToDisplay = styled.span<{ $isDark?: boolean }>`
   margin: 0;
-  text-decoration: ${props => (props.$theme === 'dark' ? 'underline' : 'none')};
+  text-decoration: ${props => (props.$isDark ? 'underline' : 'none')};
   text-underline-offset: 0.1em;
 `;
 
@@ -77,7 +74,7 @@ type Props = {
   width?: 'full' | number;
   mimeType: string;
   trackingTags?: string[];
-  theme?: 'dark';
+  isDark?: boolean;
 } & DisplayText;
 const DownloadLink: FunctionComponent<Props> = ({
   isTabbable = true,
@@ -88,13 +85,13 @@ const DownloadLink: FunctionComponent<Props> = ({
   mimeType,
   trackingTags = [],
   children,
-  theme,
+  isDark,
 }: Props) => {
   const Wrapper = linkText ? DownloadLinkStyle : DownloadLinkUnStyled;
-  const iconColor = theme === 'dark' ? 'yellow' : 'accent.green';
+  const iconColor = isDark ? 'yellow' : 'accent.green';
   return (
     <Wrapper
-      $theme={theme}
+      $isDark={isDark}
       tabIndex={isTabbable ? undefined : -1}
       target="_blank"
       rel="noopener noreferrer"
@@ -116,9 +113,9 @@ const DownloadLink: FunctionComponent<Props> = ({
         <IconWrapper $forceInline={!!children}>
           <Icon icon={download} matchText={!!children} iconColor={iconColor} />
         </IconWrapper>
-        <TextToDisplay $theme={theme}>{linkText || children}</TextToDisplay>
+        <TextToDisplay $isDark={isDark}>{linkText || children}</TextToDisplay>
         {format && (
-          <Format as="span" $theme={theme}>
+          <Format as="span" $isDark={isDark}>
             ({format})
           </Format>
         )}

--- a/content/webapp/components/IIIFItem/index.tsx
+++ b/content/webapp/components/IIIFItem/index.tsx
@@ -83,7 +83,7 @@ const Choice: FunctionComponent<
   RenderItem,
   exclude,
   i,
-  theme,
+  isDark,
 }) => {
   // We may have multiple items, such as videos of different formats
   // but we only show the first of these currently
@@ -100,7 +100,7 @@ const Choice: FunctionComponent<
             placeholderId={placeholderId}
             titleOverride={titleOverride}
             exclude={exclude}
-            theme={theme}
+            isDark={isDark}
           />
         </>
       );
@@ -168,7 +168,7 @@ type ItemProps = {
   exclude: (ContentResource['type'] | 'Audio' | ChoiceBody['type'])[]; // Allows us to prevent specific types being rendered
   setImageRect?: (v: DOMRect) => void;
   setImageContainerRect?: (v: DOMRect) => void;
-  theme?: 'dark';
+  isDark?: boolean;
 };
 
 const PublicRestrictedMessage: FunctionComponent<{
@@ -246,7 +246,7 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
   exclude,
   setImageRect,
   setImageContainerRect,
-  theme,
+  isDark,
 }) => {
   const { userIsStaffWithRestricted } = useUser();
   const isRestricted = isItemRestricted(item);
@@ -275,7 +275,7 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
           exclude={exclude}
           setImageRect={setImageRect}
           setImageContainerRect={setImageContainerRect}
-          theme={theme}
+          isDark={isDark}
         />
       );
 
@@ -324,7 +324,7 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
             />
             <VideoTranscript
               supplementing={canvas.supplementing}
-              theme={theme}
+              isDark={isDark}
             />
           </>
         </Wrapper>

--- a/content/webapp/components/IIIFItem/index.tsx
+++ b/content/webapp/components/IIIFItem/index.tsx
@@ -83,6 +83,7 @@ const Choice: FunctionComponent<
   RenderItem,
   exclude,
   i,
+  theme,
 }) => {
   // We may have multiple items, such as videos of different formats
   // but we only show the first of these currently
@@ -99,6 +100,7 @@ const Choice: FunctionComponent<
             placeholderId={placeholderId}
             titleOverride={titleOverride}
             exclude={exclude}
+            theme={theme}
           />
         </>
       );
@@ -166,6 +168,7 @@ type ItemProps = {
   exclude: (ContentResource['type'] | 'Audio' | ChoiceBody['type'])[]; // Allows us to prevent specific types being rendered
   setImageRect?: (v: DOMRect) => void;
   setImageContainerRect?: (v: DOMRect) => void;
+  theme?: 'dark';
 };
 
 const PublicRestrictedMessage: FunctionComponent<{
@@ -243,6 +246,7 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
   exclude,
   setImageRect,
   setImageContainerRect,
+  theme,
 }) => {
   const { userIsStaffWithRestricted } = useUser();
   const isRestricted = isItemRestricted(item);
@@ -271,6 +275,7 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
           exclude={exclude}
           setImageRect={setImageRect}
           setImageContainerRect={setImageContainerRect}
+          theme={theme}
         />
       );
 
@@ -317,7 +322,10 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
               video={item}
               showDownloadOptions={true}
             />
-            <VideoTranscript supplementing={canvas.supplementing} />
+            <VideoTranscript
+              supplementing={canvas.supplementing}
+              theme={theme}
+            />
           </>
         </Wrapper>
       );

--- a/content/webapp/components/IIIFViewer/MainViewer.tsx
+++ b/content/webapp/components/IIIFViewer/MainViewer.tsx
@@ -511,7 +511,7 @@ const MainViewer: FunctionComponent = () => {
                       canvas={currentCanvas}
                       titleOverride={`${canvas}/${canvases?.length}`}
                       exclude={[]}
-                      theme="dark"
+                      isDark={true}
                     />
                   </ItemWrapper>
                 ) : null}

--- a/content/webapp/components/IIIFViewer/MainViewer.tsx
+++ b/content/webapp/components/IIIFViewer/MainViewer.tsx
@@ -511,6 +511,7 @@ const MainViewer: FunctionComponent = () => {
                       canvas={currentCanvas}
                       titleOverride={`${canvas}/${canvases?.length}`}
                       exclude={[]}
+                      theme="dark"
                     />
                   </ItemWrapper>
                 ) : null}

--- a/content/webapp/components/IIIFViewer/MainViewer.tsx
+++ b/content/webapp/components/IIIFViewer/MainViewer.tsx
@@ -62,7 +62,7 @@ const ItemWrapper = styled.div`
     width: 100%;
     max-height: calc(
       100vh - ${props => props.theme.navHeight}px - 140px
-    ); /* 130 px allows for the height of the header and the transcript link */
+    ); /* 140px allows for the height of the header and the transcript link */
   }
 `; // minus height of the header
 type OverlayPositionData = {

--- a/content/webapp/components/IIIFViewer/MainViewer.tsx
+++ b/content/webapp/components/IIIFViewer/MainViewer.tsx
@@ -60,10 +60,11 @@ const ItemWrapper = styled.div`
     display: block;
     margin: auto;
     width: 100%;
-    max-height: 90%;
+    max-height: calc(
+      100vh - ${props => props.theme.navHeight}px - 140px
+    ); /* 130 px allows for the height of the header and the transcript link */
   }
-`;
-
+`; // minus height of the header
 type OverlayPositionData = {
   canvasNumber: number;
   overlayTop: number;

--- a/content/webapp/components/VideoTranscript/index.tsx
+++ b/content/webapp/components/VideoTranscript/index.tsx
@@ -12,10 +12,12 @@ import { getFormatString } from '@weco/content/utils/iiif/v3';
 
 type Props = {
   supplementing: (ContentResource | ChoiceBody)[];
+  theme?: 'dark';
 };
 
 const VideoTranscript: FunctionComponent<Props> = ({
   supplementing,
+  theme,
 }: Props) => {
   return (
     <>
@@ -32,6 +34,7 @@ const VideoTranscript: FunctionComponent<Props> = ({
                 format={getFormatString(displayItem.format || '')}
                 mimeType={displayItem.format || ''}
                 trackingTags={['annotation']}
+                theme={theme}
               />
             </Space>
           );

--- a/content/webapp/components/VideoTranscript/index.tsx
+++ b/content/webapp/components/VideoTranscript/index.tsx
@@ -12,12 +12,12 @@ import { getFormatString } from '@weco/content/utils/iiif/v3';
 
 type Props = {
   supplementing: (ContentResource | ChoiceBody)[];
-  theme?: 'dark';
+  isDark?: boolean;
 };
 
 const VideoTranscript: FunctionComponent<Props> = ({
   supplementing,
-  theme,
+  isDark,
 }: Props) => {
   return (
     <>
@@ -34,7 +34,7 @@ const VideoTranscript: FunctionComponent<Props> = ({
                 format={getFormatString(displayItem.format || '')}
                 mimeType={displayItem.format || ''}
                 trackingTags={['annotation']}
-                theme={theme}
+                isDark={isDark}
               />
             </Space>
           );


### PR DESCRIPTION
## What does this change?

For [#11519](https://github.com/wellcomecollection/wellcomecollection.org/issues/11519)

- makes sure the video player is never displayed larger than the screen
- styles the download link on a dark background

<img width="951" alt="Screenshot 2025-05-06 at 16 16 50" src="https://github.com/user-attachments/assets/165486ad-7016-4756-a193-19f1de98fcc7" />

see designs: https://www.figma.com/design/OxxzV0GrHOEofLRb9sm2fP/Audio-and-video-player?node-id=24-4171&m=dev

## How to test

- turn on the extendedViewer toggle
- view [a video item with transcript link](http://localhost:3000/works/sx4p4b75/items)

## How can we measure success?

- can watch videos in the viewer and download transcripts

## Have we considered potential risks?

- behind a toggle, so none really

