### PR TITLE
`/events/current-and-coming-up` redirect prod

### DIFF
--- a/cache/locals.tf
+++ b/cache/locals.tf
@@ -3,8 +3,8 @@ data "aws_secretsmanager_secret_version" "slack_webhook" {
 }
 
 locals {
-  edge_lambda_request_version  = 141
-  edge_lambda_response_version = 139
+  edge_lambda_request_version  = 142
+  edge_lambda_response_version = 140
 
   wellcome_cdn_cert_arn = "arn:aws:acm:us-east-1:130871440101:certificate/bb840c52-56bb-4bf8-86f8-59e7deaf9c98"
 


### PR DESCRIPTION
## What does this change?

Will allow for change to be applied to production

Sequel to https://github.com/wellcomecollection/wellcomecollection.org/pull/11878 for https://github.com/wellcomecollection/wellcomecollection.org/issues/11775