### PR TITLE
Add gtm trigger for visually similar images

### DIFF
--- a/content/webapp/components/VisuallySimilarImagesFromApi/index.tsx
+++ b/content/webapp/components/VisuallySimilarImagesFromApi/index.tsx
@@ -94,6 +94,7 @@ const VisuallySimilarImagesFromApi: FunctionComponent<Props> = ({
       <Wrapper>
         {similarImages.map(related => (
           <a
+            data-gtm-trigger="visually-similar-image"
             key={related.id}
             onClick={() => {
               onClickImage(related);

--- a/content/webapp/components/VisuallySimilarImagesFromApi/index.tsx
+++ b/content/webapp/components/VisuallySimilarImagesFromApi/index.tsx
@@ -94,7 +94,7 @@ const VisuallySimilarImagesFromApi: FunctionComponent<Props> = ({
       <Wrapper>
         {similarImages.map(related => (
           <a
-            data-gtm-trigger="visually-similar-image"
+            data-gtm-trigger="visually_similar_image"
             key={related.id}
             onClick={() => {
               onClickImage(related);


### PR DESCRIPTION
For #11618 

## What does this change?
Adds a data-attribute to the visually similar images so that we can track clicks on them through gtm (currently we do this with Segment, which we're moving away from)

## How to test
Open an image search result and inspect the visually similar images beneath – do they contain a `data-gtm-trigger="visually_similar_image"` attribute?

## How can we measure success?
with gtm

## Have we considered potential risks?
n/a