### PR TITLE
Add `filterOutExhibitions` to event listing queries

### DIFF
--- a/content/webapp/pages/events/index.tsx
+++ b/content/webapp/pages/events/index.tsx
@@ -104,9 +104,10 @@ export const getServerSideProps: GetServerSideProps<
     const pageNumber = getQueryPropertyValue(page);
     const params = fromQuery(restOfQuery);
     const timespan = 'future';
+    const setParams = { timespan, filterOutExhibitions: 'true' };
 
-    const allPossibleParams = { ...params, timespan };
-    const queriedParams = { ...restOfQuery, timespan };
+    const allPossibleParams = { ...params, ...setParams };
+    const queriedParams = { ...restOfQuery, ...setParams };
 
     const eventResponseList = await getEvents({
       params: {

--- a/content/webapp/pages/events/past.tsx
+++ b/content/webapp/pages/events/past.tsx
@@ -52,9 +52,10 @@ export const getServerSideProps: GetServerSideProps<
     const pageNumber = getQueryPropertyValue(page);
     const params = fromQuery(restOfQuery);
     const timespan = 'past';
+    const setParams = { timespan, filterOutExhibitions: 'true' };
 
-    const allPossibleParams = { ...params, timespan };
-    const queriedParams = { ...restOfQuery, timespan };
+    const allPossibleParams = { ...params, ...setParams };
+    const queriedParams = { ...restOfQuery, ...setParams };
 
     const eventResponseList = await getEvents({
       params: {

--- a/content/webapp/pages/search/events.tsx
+++ b/content/webapp/pages/search/events.tsx
@@ -205,7 +205,8 @@ export const getServerSideProps: GetServerSideProps<
 > = async context => {
   setCacheControl(context.res, cacheTTL.search);
   const serverData = await getServerData(context);
-  const filterEventsListing = !!serverData.toggles.filterEventsListing.value;
+  const filterEventsListing = !!serverData.toggles.filterEventsListing?.value;
+  const exhibitionsInEvents = !!serverData.toggles.exhibitionsInEvents?.value;
 
   const query = context.query;
   const params = fromQuery(query);
@@ -251,8 +252,7 @@ export const getServerSideProps: GetServerSideProps<
   const paramsQuery = {
     ...restOfQuery,
     timespan: validTimespan,
-    // Remove once we are happy to list exhibitions here.
-    filterOutExhibitions: 'true',
+    filterOutExhibitions: exhibitionsInEvents ? undefined : 'true',
   };
 
   const eventResponseList = await getEvents({

--- a/content/webapp/pages/search/events.tsx
+++ b/content/webapp/pages/search/events.tsx
@@ -248,7 +248,12 @@ export const getServerSideProps: GetServerSideProps<
 
   const { page, ...restOfQuery } = query;
   const pageNumber = getQueryPropertyValue(page);
-  const paramsQuery = { ...restOfQuery, timespan: validTimespan };
+  const paramsQuery = {
+    ...restOfQuery,
+    timespan: validTimespan,
+    // Remove once we are happy to list exhibitions here.
+    filterOutExhibitions: 'true',
+  };
 
   const eventResponseList = await getEvents({
     params: {

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -125,6 +125,13 @@ const toggles = {
       description: 'Show updated UI and interactions for the AudioPlayer',
       type: 'experimental',
     },
+    {
+      id: 'exhibitionsInEvents',
+      title: 'Exhibitions in events',
+      initialValue: false,
+      description: 'Adds exhibitions to the events search results',
+      type: 'experimental',
+    },
   ] as const,
   tests: [] as ABTest[],
 };


### PR DESCRIPTION
## What does this change?
#11473

Adding exhibitions is a work in progress but the param is now available, so setting now so it's ready when we switch the pipeline over to the one with exhibitions in events.

I added it everywhere in the end so we could merge the Content API work slowly instead of all at once ([this PR for example](https://github.com/wellcomecollection/content-api/pull/228)). 

> [!NOTE]
> I did not add e2es as per ticket; would we want a test for this? I wasn't sure it was that useful.

## How to test

Consider:
- https://www-dev.wellcomecollection.org/search/events
- https://www-dev.wellcomecollection.org/events
- https://www-dev.wellcomecollection.org/events/past

1. Run locally, no exhibitions should be in any pages above.
2. Run locally with [this branch](https://github.com/wellcomecollection/content-api/pull/228) as Content API locally and no toggles on - no exhibition should show in `/events`, `events/past` or `/search/events`.
3. Activate the `exhibitionsInEvents` toggle - exhibitions should show in `/search/events` and be filterable with the "Exhibitions" format. They should not be in the other pages.

## How can we measure success?

Allows for work to happen slowly in Content API

## Have we considered potential risks?
N/A shouldn't change anything on live for regular users
