### PR TITLE
Audio player qa 2

### DIFF
--- a/common/views/slices/Contact/index.tsx
+++ b/common/views/slices/Contact/index.tsx
@@ -3,10 +3,7 @@ import { FunctionComponent } from 'react';
 
 import { ContactSlice as RawContactSlice } from '@weco/common/prismicio-types';
 import SpacingComponent from '@weco/common/views/components/styled/SpacingComponent';
-import {
-  LayoutWidth,
-  SliceZoneContext,
-} from '@weco/content/components/Body';
+import { LayoutWidth, SliceZoneContext } from '@weco/content/components/Body';
 import Contact from '@weco/content/components/Contact';
 import { transformContactSlice } from '@weco/content/services/prismic/transformers/body';
 

--- a/content/webapp/components/AudioPlayerNew/AudioPlayer.PlayRate.tsx
+++ b/content/webapp/components/AudioPlayerNew/AudioPlayer.PlayRate.tsx
@@ -15,11 +15,11 @@ const TogglePlayRateButton = styled.button.attrs({
   color: ${props =>
     props.$isDark ? props.theme.color('white') : props.theme.color('black')};
   padding: 0;
+  transition: color 0.2s ease-in-out;
 
   span {
     display: flex;
     justify-content: end;
-    transition: color 0.2s ease-in-out;
   }
 
   &:hover {
@@ -28,7 +28,7 @@ const TogglePlayRateButton = styled.button.attrs({
   }
 `;
 
-const PlayRateButton = styled.div.attrs<{ $isActive: boolean }>({
+const PlayRateButton = styled.div.attrs({
   as: 'button',
   className: font('intr', 5),
 })<{

--- a/content/webapp/components/AudioPlayerNew/AudioPlayer.PlayRate.tsx
+++ b/content/webapp/components/AudioPlayerNew/AudioPlayer.PlayRate.tsx
@@ -177,7 +177,6 @@ const PlayRate: FunctionComponent<PlayRateProps> = ({
               return (
                 <PlayRateButton
                   key={speed}
-                  $isActive={audioPlaybackRate === speed}
                   $isDark={isDark}
                   onClick={() => updatePlaybackRate(speed)}
                 >

--- a/content/webapp/components/AudioPlayerNew/AudioPlayer.PlayRate.tsx
+++ b/content/webapp/components/AudioPlayerNew/AudioPlayer.PlayRate.tsx
@@ -181,7 +181,7 @@ const PlayRate: FunctionComponent<PlayRateProps> = ({
                   $isDark={isDark}
                   onClick={() => updatePlaybackRate(speed)}
                 >
-                  <span style={{ display: 'flex', alignItems: 'end' }}>
+                  <span style={{ display: 'flex', alignItems: 'center' }}>
                     {speed}x
                     {audioPlaybackRate === speed && (
                       <Space $h={{ size: 'xl', properties: ['margin-left'] }}>

--- a/content/webapp/components/AudioPlayerNew/AudioPlayer.PlayRate.tsx
+++ b/content/webapp/components/AudioPlayerNew/AudioPlayer.PlayRate.tsx
@@ -14,15 +14,14 @@ const TogglePlayRateButton = styled.button.attrs({
   padding: 0;
 
   span {
-    color: ${props => props.theme.color('yellow')};
     display: flex;
     justify-content: end;
     transition: color 0.2s ease-in-out;
   }
 
-  &:hover span {
+  &:hover {
     color: ${props =>
-      props.$isDark ? props.theme.color('white') : props.theme.color('black')};
+      props.$isDark ? props.theme.color('yellow') : props.theme.color('black')};
   }
 `;
 

--- a/content/webapp/components/AudioPlayerNew/AudioPlayer.PlayRate.tsx
+++ b/content/webapp/components/AudioPlayerNew/AudioPlayer.PlayRate.tsx
@@ -3,8 +3,11 @@ import { FunctionComponent, useContext, useEffect, useState } from 'react';
 import { usePopper } from 'react-popper';
 import styled from 'styled-components';
 
+import { check } from '@weco/common/icons';
 import { font } from '@weco/common/utils/classnames';
 import { AppContext } from '@weco/common/views/components/AppContext';
+import Icon from '@weco/common/views/components/Icon';
+import Space from '@weco/common/views/components/styled/Space';
 
 const TogglePlayRateButton = styled.button.attrs({
   className: font('intr', 6),
@@ -25,24 +28,19 @@ const TogglePlayRateButton = styled.button.attrs({
   }
 `;
 
-const PlayRateButton = styled.div.attrs<{ $isActive: boolean }>(props => ({
+const PlayRateButton = styled.div.attrs<{ $isActive: boolean }>({
   as: 'button',
-  className: font(props.$isActive ? 'intsb' : 'intr', 6),
-}))<{
+  className: font('intr', 5),
+})<{
   $isDark: boolean;
-  $isActive?: boolean;
 }>`
   padding: ${props => props.theme.spacingUnits['4']}px;
   line-height: 1.5;
   display: flex;
-  justify-content: right;
+  justify-content: space-between;
   width: 100%;
   color: ${props =>
-    props.$isActive
-      ? props.theme.color('yellow')
-      : props.$isDark
-        ? props.theme.color('white')
-        : props.theme.color('black')};
+    props.$isDark ? props.theme.color('white') : props.theme.color('black')};
 
   &:hover {
     text-decoration: underline;
@@ -50,7 +48,7 @@ const PlayRateButton = styled.div.attrs<{ $isActive: boolean }>(props => ({
 `;
 
 const PlayRateList = styled.div<{ $isActive: boolean; $isDark: boolean }>`
-  padding: ${props => props.theme.spacingUnits['5']}px;
+  padding: ${props => props.theme.spacingUnits['3']}px 0;
   list-style: none;
   display: ${props => (props.$isActive ? 'block' : 'none')};
   background-color: ${props =>
@@ -58,12 +56,8 @@ const PlayRateList = styled.div<{ $isActive: boolean; $isDark: boolean }>`
       ? props.theme.color('neutral.700')
       : props.theme.color('white')};
   z-index: 2;
-  border-radius: 8px 0 8px 8px;
+  border-radius: 8px;
   box-shadow: ${props => props.theme.basicBoxShadow};
-
-  &[data-popper-placement='top'] {
-    border-radius: 8px 8px 0;
-  }
 
   ul {
     margin: 0;
@@ -187,7 +181,18 @@ const PlayRate: FunctionComponent<PlayRateProps> = ({
                   $isDark={isDark}
                   onClick={() => updatePlaybackRate(speed)}
                 >
-                  {speed}x
+                  <span style={{ display: 'flex', alignItems: 'end' }}>
+                    {speed}x
+                    {audioPlaybackRate === speed && (
+                      <Space $h={{ size: 'xl', properties: ['margin-left'] }}>
+                        <span
+                          style={{ transform: 'scale(1.5)', display: 'flex' }}
+                        >
+                          <Icon icon={check} matchText={true} />
+                        </span>
+                      </Space>
+                    )}
+                  </span>
                 </PlayRateButton>
               );
             })}

--- a/content/webapp/components/AudioPlayerNew/AudioPlayer.Scrubber.tsx
+++ b/content/webapp/components/AudioPlayerNew/AudioPlayer.Scrubber.tsx
@@ -9,8 +9,9 @@ const backgroundTransform = css<{ $isDark: boolean }>`
   transform: scale(1.5);
 `;
 
-const thumbStyles = css`
-  background: ${props => props.theme.color('yellow')};
+const thumbStyles = css<{ $isDark: boolean }>`
+  background: ${props =>
+    props.$isDark ? props.theme.color('yellow') : props.theme.color('black')};
   appearance: none;
   width: 1rem;
   height: 1rem;

--- a/content/webapp/components/AudioPlayerNew/index.tsx
+++ b/content/webapp/components/AudioPlayerNew/index.tsx
@@ -61,14 +61,14 @@ const SkipPlayWrapper = styled.div`
 
 const colorTransform = css<{ $isDark: boolean }>`
   color: ${props =>
-    props.$isDark ? props.theme.color('white') : props.theme.color('black')};
+    props.$isDark ? props.theme.color('yellow') : props.theme.color('black')};
   transform: scale(1.1);
 `;
 
 const SkipButton = styled.button<{ $isDark: boolean }>`
   padding: ${props => props.theme.spacingUnits['5']}px 0 0;
   color: ${props =>
-    props.$isDark ? props.theme.color('yellow') : props.theme.color('black')};
+    props.$isDark ? props.theme.color('white') : props.theme.color('black')};
 
   transition:
     color 0.2s ease-out,
@@ -96,7 +96,7 @@ const PlayerRateWrapper = styled.div`
 
 const colorTransformIconFill = css<{ $isDark: boolean }>`
   color: ${props =>
-    props.$isDark ? props.theme.color('white') : props.theme.color('black')};
+    props.$isDark ? props.theme.color('yellow') : props.theme.color('black')};
   transform: scale(1.1);
 
   .icon__playpause {
@@ -111,12 +111,15 @@ const TitleWrapper = styled.span<{ $isDark: boolean }>`
 `;
 
 const PlayPauseInner = styled.div<{ $isDark: boolean }>`
-  color: ${props => props.theme.color('yellow')};
+  color: ${props =>
+    props.$isDark ? props.theme.color('white') : props.theme.color('black')};
   transition:
     color 0.2s ease-out,
     transform 0.2s ease-out;
 
   .icon__playpause {
+    fill: ${props =>
+      props.$isDark ? props.theme.color('black') : props.theme.color('white')};
     transition: fill 0.2s ease-out;
   }
 

--- a/content/webapp/services/prismic/fetch/guides.ts
+++ b/content/webapp/services/prismic/fetch/guides.ts
@@ -9,6 +9,7 @@ import {
   guideFetchLinks,
   guideFormatsFetchLinks,
   pagesFetchLinks,
+  teamsFetchLinks,
 } from '@weco/content/services/prismic/types';
 
 import { fetcher, GetByTypeParams, GetServerSidePropsPrismicClient } from '.';
@@ -17,6 +18,7 @@ const fetchLinks = [
   ...commonPrismicFieldsFetchLinks,
   ...guideFormatsFetchLinks,
   ...guideFetchLinks,
+  ...teamsFetchLinks,
 ];
 
 const guidesFetcher = fetcher<RawGuidesDocument>('guides', fetchLinks);


### PR DESCRIPTION
Note: [This commit](https://github.com/wellcomecollection/wellcomecollection.org/pull/11887/commits/ca30fb1fc71371261645c112025b5f77582db1c5) to add `teamsFetchLinks` to guide pages was included in this PR accidentally but stayed in because it was fixing a live issue

For #11883 

## What does this change?

<img width="741" alt="image" src="https://github.com/user-attachments/assets/183c23b0-1afb-4f60-a8ee-bd8c8bf1f253" />

<img width="739" alt="image" src="https://github.com/user-attachments/assets/511798c0-162b-4a48-b02a-72d55e795e40" />


## How to test
Open AudioPlayerNew in Cardigan and check light/dark version match [designs](https://www.figma.com/design/YY8hrWmKYhLm8ZQeYaKiLm/Exhibition-guides?node-id=2528-4005&p=f&m=dev) (I didn't add the trust yellow because it felt like overkill for such a small piece of UI)

## How can we measure success?
Consistent UI across light/dark versions

## Have we considered potential risks?
n/a