### PR TITLE
Filter out the right things

### DIFF
--- a/content/webapp/components/Exhibition/index.tsx
+++ b/content/webapp/components/Exhibition/index.tsx
@@ -209,10 +209,7 @@ function getAccessibilityItems(): ExhibitionItem[] {
 
   return accessibilityItems.filter(item => {
     if (item.description[0] && 'text' in item.description[0]) {
-      return (
-        item.description[0]?.text !== a11y.bsl &&
-        item.description[0]?.text !== a11y.accessResources
-      );
+      return item.description[0]?.text !== a11y.largePrintGuides;
     } else {
       return true;
     }


### PR DESCRIPTION
## What does this change?

When [I removed the toggle code for exhibitionAccessContent](https://github.com/wellcomecollection/wellcomecollection.org/pull/11820/files#diff-e3fe2a365deb2dc15410a0a763f6730d2363fb193e891401c18682705a5adee5L211-L230), I kept the wrong half of the conditional for what was to go in the yellow box.

This fixes it

<img width="903" alt="image" src="https://github.com/user-attachments/assets/c02a3902-6cd2-4ec6-87ab-c47a6560dfaa" />


## How to test

Visit [1880 THAT](http://localhost:3000/exhibitions/1880-that) and check the point about large print guides is gone and "British Sign Language videos are available" and "Access resources include a visual story, large print guides and audio description" are there (per screenshot above).

## How can we measure success?
n/a

## Have we considered potential risks?
n/a