### PR TITLE
Use 16:9 crop instead of 32:15 in events listings

### DIFF
--- a/content/webapp/components/EventsSearchResults/index.tsx
+++ b/content/webapp/components/EventsSearchResults/index.tsx
@@ -69,7 +69,7 @@ const EventsSearchResults: FunctionComponent<Props> = ({
     <EventsContainer>
       {events.map(event => {
         const image = transformImage(event.image);
-        const croppedImage = getCrop(image, '32:15');
+        const croppedImage = getCrop(image, '16:9');
 
         const times = transformEventTimes(event.id, event.times);
 


### PR DESCRIPTION
## What does this change?

[Feedback from Steven Pocock in Slack](https://wellcome.slack.com/archives/C8X9YKM5X/p1746696012366219?thread_ts=1746621405.647939&cid=C8X9YKM5X)
There is no reason why not! And it does look better

Before
<img width="1261" alt="Screenshot 2025-05-12 at 15 30 01" src="https://github.com/user-attachments/assets/d51a0934-fa1f-4ccc-bbe5-14df4dff4954" />


After
<img width="1285" alt="Screenshot 2025-05-12 at 15 29 55" src="https://github.com/user-attachments/assets/5ae2c449-1e0f-407c-a11e-a1aaa33d6149" />


## How to test

Check it out locally everywhere we have events listing (search, /events..)

## How can we measure success?

Happy photography

## Have we considered potential risks?
N/A