### PR TITLE
Tiny tidy of TODOs and READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ You can run both apps together with the following command:
 
 ### Running CI steps locally
 
-In order to reproduce a build step locally you can run the same `docker-compose` command that [Buildkite](https://buildkite.com/wellcomecollection/experience) runs.
+In order to reproduce a build step locally you can run the same `docker compose` command that [Buildkite](https://buildkite.com/wellcomecollection/experience) runs.
 
 See an example for `edge_lambdas` below. This example presumes you have an AWS credentials file set up to allow you to assume the CI role.
 
@@ -165,11 +165,11 @@ services:
 
 You will need to add a `command`, `volumes` and `environment` block to specify the required command and mount your AWS credentials in the running container.
 
-You can then run `docker-compose` commands as would occur in the CI environment.
+You can then run `docker compose` commands as would occur in the CI environment.
 
 ```shell script
-docker-compose edge_lambdas build
-docker-compose edge_lambdas run
+docker compose edge_lambdas build
+docker compose edge_lambdas run
 ```
 
 ## Linting

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.3'
 services:
   common:
     image: common_webapp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+version: '3.3'
 services:
   common:
     image: common_webapp

--- a/identity/README.md
+++ b/identity/README.md
@@ -30,6 +30,6 @@ volumes:
 Then run:
 
 ```console
-$ docker-compose build identity
-$ docker-compose run -p 3003:3003 identity yarn start:dev
+$ docker compose build identity
+$ docker compose run -p 3003:3003 identity yarn start:dev
 ```

--- a/pa11y/Dockerfile
+++ b/pa11y/Dockerfile
@@ -2,6 +2,9 @@ FROM public.ecr.aws/docker/library/node:20-bookworm-slim
 
 VOLUME /dist
 
+
+# Set of system libraries required for running Node.js applications and tools
+# like Puppeteer or Chromium (used for headless browser testing).
 RUN apt-get update && apt-get install -yq --no-install-recommends \
   libasound2 libatk-bridge2.0-0 libatk1.0-0 libatspi2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
   libdrm2 libexpat1 libgbm1 libgcc1 libglib2.0-0 libnspr4 libnss3 libpango-1.0-0 libpangocairo-1.0-0  \

--- a/pa11y/webapp/write-report.js
+++ b/pa11y/webapp/write-report.js
@@ -73,6 +73,11 @@ const promises = urls.map(url =>
       // https://github.com/wellcomecollection/wellcomecollection.org/issues/11269
       'WCAG2AA.Principle2.Guideline2_4.2_4_1.H64.1',
     ],
+    log: {
+      debug: console.log,
+      error: console.error,
+      info: console.info,
+    },
   })
 );
 
@@ -99,7 +104,6 @@ Promise.all(promises)
         console.error(`!!! ${chalk.redBright('Fix these before merging')}`);
         console.log(...resultsLog);
 
-        // TODO do we want it to stop people from merging also when it's of type "warning" or "notice"?
         const hasErrors = results.find(result =>
           result.issues.find(issue => issue.type === 'error')
         );


### PR DESCRIPTION
## What does this change?

Spent a couple hours trying to debug why our pa11y dashboard task fails so often (e.g. https://buildkite.com/wellcomecollection/wc-dot-org-deployment/builds/3966#_), but I think it's out of my knowledge level and not worth me spending more time on for now. I did find out it errors because the `write-report` script fails (seems to be puppeteer/chrome browser related) and therefore the report isn't written, which means the `.dist/report.json` folder/file doesn't, indeed, exist.

I did end up tidying up a few bits. 
- command line `docker-compose` should now be `docker compose`.
- Added comments to explain the pa11y Dockerfile more
- Added logging to the pa11y report for further understanding/exploration.